### PR TITLE
fix(site): prevent auto-scroll from fighting user scroll in agent chat

### DIFF
--- a/site/src/hooks/useStickToBottom.test.ts
+++ b/site/src/hooks/useStickToBottom.test.ts
@@ -1,0 +1,129 @@
+import { renderHook, act } from "@testing-library/react";
+import { useStickToBottom } from "./useStickToBottom";
+
+// Minimal mock for a flex-col-reverse scrollable div.
+const createMockScrollContainer = () => {
+	let scrollTop = 0;
+	const listeners = new Map<string, Set<EventListener>>();
+
+	const el = {
+		get scrollTop() {
+			return scrollTop;
+		},
+		set scrollTop(value: number) {
+			scrollTop = value;
+		},
+		scrollTo({ top }: { top: number; behavior?: string }) {
+			scrollTop = top;
+			// Fire scroll event synchronously for testing.
+			for (const handler of listeners.get("scroll") ?? []) {
+				handler(new Event("scroll"));
+			}
+		},
+		addEventListener(type: string, handler: EventListener) {
+			if (!listeners.has(type)) {
+				listeners.set(type, new Set());
+			}
+			listeners.get(type)!.add(handler);
+		},
+		removeEventListener(type: string, handler: EventListener) {
+			listeners.get(type)?.delete(handler);
+		},
+		// Helper to simulate a scroll event at a given scrollTop.
+		simulateScroll(newScrollTop: number) {
+			scrollTop = newScrollTop;
+			for (const handler of listeners.get("scroll") ?? []) {
+				handler(new Event("scroll"));
+			}
+		},
+	} as unknown as HTMLDivElement & { simulateScroll: (v: number) => void };
+
+	return el;
+};
+
+describe("useStickToBottom", () => {
+	it("starts in the stuck state", () => {
+		const { result } = renderHook(() => useStickToBottom());
+		expect(result.current.isStuck).toBe(true);
+	});
+
+	it("unsticks when user scrolls up past threshold", () => {
+		const { result } = renderHook(() => useStickToBottom());
+		const el = createMockScrollContainer();
+
+		// Attach the scroll container via the callback ref.
+		act(() => {
+			result.current.scrollRef(el);
+		});
+
+		// Simulate scrolling up (scrollTop increases in flex-col-reverse).
+		act(() => {
+			el.simulateScroll(10);
+		});
+		// Still within the 48px threshold.
+		expect(result.current.isStuck).toBe(true);
+
+		act(() => {
+			el.simulateScroll(100);
+		});
+		// Past threshold — should unstick.
+		expect(result.current.isStuck).toBe(false);
+	});
+
+	it("re-sticks when user scrolls back to bottom", () => {
+		const { result } = renderHook(() => useStickToBottom());
+		const el = createMockScrollContainer();
+
+		act(() => {
+			result.current.scrollRef(el);
+		});
+
+		// Scroll up past threshold.
+		act(() => {
+			el.simulateScroll(100);
+		});
+		expect(result.current.isStuck).toBe(false);
+
+		// Scroll back to near-bottom.
+		act(() => {
+			el.simulateScroll(10);
+		});
+		expect(result.current.isStuck).toBe(true);
+	});
+
+	it("scrollToBottom scrolls to top=0 in flex-col-reverse", () => {
+		const { result } = renderHook(() => useStickToBottom());
+		const el = createMockScrollContainer();
+
+		act(() => {
+			result.current.scrollRef(el);
+		});
+
+		// Scroll up.
+		act(() => {
+			el.simulateScroll(500);
+		});
+		expect(result.current.isStuck).toBe(false);
+
+		// Use the programmatic scroll-to-bottom.
+		act(() => {
+			result.current.scrollToBottom();
+		});
+		expect(el.scrollTop).toBe(0);
+		// The scroll event from scrollTo should re-stick.
+		expect(result.current.isStuck).toBe(true);
+	});
+
+	it("cleans up scroll listener on unmount", () => {
+		const { result, unmount } = renderHook(() => useStickToBottom());
+		const el = createMockScrollContainer();
+		const removeSpy = vi.spyOn(el, "removeEventListener");
+
+		act(() => {
+			result.current.scrollRef(el);
+		});
+
+		unmount();
+		expect(removeSpy).toHaveBeenCalledWith("scroll", expect.any(Function));
+	});
+});

--- a/site/src/hooks/useStickToBottom.ts
+++ b/site/src/hooks/useStickToBottom.ts
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * Threshold in pixels from the bottom of a flex-col-reverse scroll
+ * container. When scrollTop is within this range the user is
+ * considered "at the bottom" and auto-scroll stays enabled.
+ */
+const STICK_THRESHOLD_PX = 48;
+
+interface UseStickToBottomReturn {
+	/** Whether the view is currently stuck to the bottom. */
+	isStuck: boolean;
+	/** Programmatically scroll to the bottom and re-enable stick. */
+	scrollToBottom: () => void;
+	/**
+	 * Callback ref — pass this as the `ref` prop on the scroll
+	 * container so the hook can observe it even when the element
+	 * mounts after the hook (e.g. loading → loaded transition).
+	 */
+	scrollRef: (node: HTMLDivElement | null) => void;
+}
+
+/**
+ * Chat-style "stick to bottom" scroll behaviour for a
+ * flex-col-reverse container.
+ *
+ * In flex-col-reverse, scrollTop === 0 is the visual bottom.
+ * Scrolling *up* increases scrollTop. So:
+ *   - isStuck  ⟹  scrollTop ≤ threshold
+ *   - unstuck  ⟹  scrollTop > threshold (user scrolled up)
+ *
+ * The scroll container must have `overflow-anchor: none` in CSS
+ * to prevent the browser from fighting the user's scroll position
+ * during streaming content updates.
+ */
+export const useStickToBottom = (): UseStickToBottomReturn => {
+	const [isStuck, setIsStuck] = useState(true);
+	const [scrollEl, setScrollEl] = useState<HTMLDivElement | null>(null);
+
+	// Track the last known scrollTop so we can detect scroll
+	// direction inside the passive scroll listener.
+	const lastScrollTopRef = useRef(0);
+
+	// Avoid re-subscribing to the scroll event on every render.
+	const isStuckRef = useRef(isStuck);
+	isStuckRef.current = isStuck;
+
+	const scrollToBottom = useCallback(() => {
+		if (!scrollEl) return;
+		// Use instant scroll so the UI is consistent — the button
+		// disappears and the viewport jumps together.
+		scrollEl.scrollTo({ top: 0, behavior: "instant" });
+		// Let the scroll handler re-set isStuck on the next event
+		// rather than forcing it synchronously here. This avoids
+		// a flash where the button hides before the viewport moves.
+	}, [scrollEl]);
+
+	useEffect(() => {
+		if (!scrollEl) return;
+		lastScrollTopRef.current = scrollEl.scrollTop;
+
+		const onScroll = () => {
+			const { scrollTop } = scrollEl;
+			const nearBottom = scrollTop <= STICK_THRESHOLD_PX;
+
+			// User scrolled up — detach.
+			if (scrollTop > lastScrollTopRef.current && !nearBottom) {
+				if (isStuckRef.current) {
+					setIsStuck(false);
+				}
+			}
+
+			// User scrolled back to the bottom — re-attach.
+			if (nearBottom && !isStuckRef.current) {
+				setIsStuck(true);
+			}
+
+			lastScrollTopRef.current = scrollTop;
+		};
+
+		scrollEl.addEventListener("scroll", onScroll, { passive: true });
+		return () => {
+			scrollEl.removeEventListener("scroll", onScroll);
+		};
+	}, [scrollEl]);
+
+	return { isStuck, scrollToBottom, scrollRef: setScrollEl };
+};

--- a/site/src/pages/AgentsPage/AgentDetail.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.tsx
@@ -17,6 +17,7 @@ import { workspaceById, workspaceByIdKey } from "api/queries/workspaces";
 import type * as TypesGen from "api/typesGenerated";
 import type { ChatMessagePart } from "api/typesGenerated";
 import { useProxy } from "contexts/ProxyContext";
+import { useStickToBottom } from "hooks/useStickToBottom";
 import {
 	getTerminalHref,
 	getVSCodeHref,
@@ -252,7 +253,7 @@ const AgentDetail: FC = () => {
 		isSidebarCollapsed,
 		onToggleSidebarCollapsed,
 	} = outletContext;
-	const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+	const { isStuck: isScrollStuck, scrollToBottom, scrollRef: scrollContainerRef } = useStickToBottom();
 	const chatInputRef = useRef<ChatMessageInputRef | null>(null);
 	const inputValueRef = useRef("");
 
@@ -601,9 +602,7 @@ const AgentDetail: FC = () => {
 			clearChatErrorReason(agentId);
 			clearStreamError();
 			setPendingEditMessageId(editedMessageID);
-			if (scrollContainerRef.current) {
-				scrollContainerRef.current.scrollTop = 0;
-			}
+			scrollToBottom();
 			store.clearStreamState();
 			try {
 				await editMutation.mutateAsync({
@@ -628,9 +627,7 @@ const AgentDetail: FC = () => {
 		};
 		clearChatErrorReason(agentId);
 		clearStreamError();
-		if (scrollContainerRef.current) {
-			scrollContainerRef.current.scrollTop = 0;
-		}
+		scrollToBottom();
 
 		// No optimistic rendering — the message will appear in the
 		// timeline when the server confirms via the POST response or
@@ -894,6 +891,8 @@ const AgentDetail: FC = () => {
 			}
 			urlTransform={urlTransform}
 			scrollContainerRef={scrollContainerRef}
+			isScrollStuck={isScrollStuck}
+			onScrollToBottom={scrollToBottom}
 			hasMoreMessages={chatMessagesQuery.hasNextPage ?? false}
 			isFetchingMoreMessages={chatMessagesQuery.isFetchingNextPage}
 			onFetchMoreMessages={chatMessagesQuery.fetchNextPage}

--- a/site/src/pages/AgentsPage/AgentDetail/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail/ConversationTimeline.tsx
@@ -637,7 +637,7 @@ const StickyUserMessage: FC<{
 		if (!sentinel) return;
 		// Immediate check so the first paint is correct when the
 		// sentinel is already scrolled out of view.
-		const scroller = sentinel.closest(".overflow-y-auto");
+		const scroller = sentinel.closest("[data-scroll-container]");
 		if (scroller) {
 			const stuck =
 				sentinel.getBoundingClientRect().top <
@@ -662,7 +662,7 @@ const StickyUserMessage: FC<{
 		const sentinel = sentinelRef.current;
 		const container = containerRef.current;
 		if (!sentinel || !container) return;
-		const scroller = sentinel.closest(".overflow-y-auto") as HTMLElement | null;
+		const scroller = sentinel.closest("[data-scroll-container]") as HTMLElement | null;
 		if (!scroller) return;
 
 		const MIN_HEIGHT = 72;
@@ -758,7 +758,7 @@ const StickyUserMessage: FC<{
 					const sentinel = sentinelRef.current;
 					if (!sentinel) return;
 					const scroller = sentinel.closest(
-						".overflow-y-auto",
+						"[data-scroll-container]",
 					) as HTMLElement | null;
 					if (!scroller) return;
 					const offset =

--- a/site/src/pages/AgentsPage/AgentDetailView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentDetailView.stories.tsx
@@ -134,7 +134,9 @@ const meta: Meta<typeof AgentDetailView> = {
 		handleArchiveAgentAction: fn(),
 		handleUnarchiveAgentAction: fn(),
 		handleArchiveAndDeleteWorkspaceAction: fn(),
-		scrollContainerRef: { current: null },
+		scrollContainerRef: () => {},
+		isScrollStuck: true,
+		onScrollToBottom: () => {},
 	},
 };
 

--- a/site/src/pages/AgentsPage/AgentDetailView.tsx
+++ b/site/src/pages/AgentsPage/AgentDetailView.tsx
@@ -1,7 +1,7 @@
 import type * as TypesGen from "api/typesGenerated";
 import type { ChatDiffStatus, ChatMessagePart } from "api/typesGenerated";
 import type { ModelSelectorOption } from "components/ai-elements";
-import { ArchiveIcon } from "lucide-react";
+import { ArchiveIcon, ArrowDownIcon } from "lucide-react";
 import { type FC, type RefObject, useEffect, useRef, useState } from "react";
 import type { UrlTransform } from "streamdown";
 import { cn } from "utils/cn";
@@ -119,8 +119,12 @@ interface AgentDetailViewProps {
 	handleUnarchiveAgentAction: () => void;
 	handleArchiveAndDeleteWorkspaceAction: () => void;
 
-	// Scroll container ref.
-	scrollContainerRef: RefObject<HTMLDivElement | null>;
+	// Scroll container ref (callback ref from useStickToBottom).
+	scrollContainerRef: (node: HTMLDivElement | null) => void;
+
+	// Stick-to-bottom scroll state.
+	isScrollStuck: boolean;
+	onScrollToBottom: () => void;
 
 	// Pagination for loading older messages.
 	hasMoreMessages: boolean;
@@ -178,6 +182,8 @@ export const AgentDetailView: FC<AgentDetailViewProps> = ({
 	handleUnarchiveAgentAction,
 	handleArchiveAndDeleteWorkspaceAction,
 	scrollContainerRef,
+	isScrollStuck,
+	onScrollToBottom,
 	hasMoreMessages,
 	isFetchingMoreMessages,
 	onFetchMoreMessages,
@@ -260,7 +266,8 @@ export const AgentDetailView: FC<AgentDetailViewProps> = ({
 				</div>
 				<div
 					ref={scrollContainerRef}
-					className="flex min-h-0 flex-1 flex-col-reverse overflow-y-auto [scrollbar-gutter:stable] [scrollbar-width:thin] [scrollbar-color:hsl(var(--surface-quaternary))_transparent]"
+					data-scroll-container
+					className="relative flex min-h-0 flex-1 flex-col-reverse overflow-y-auto [overflow-anchor:none] [scrollbar-gutter:stable] [scrollbar-width:thin] [scrollbar-color:hsl(var(--surface-quaternary))_transparent]"
 				>
 					<div className="px-4">
 						<AgentDetailTimeline
@@ -281,11 +288,14 @@ export const AgentDetailView: FC<AgentDetailViewProps> = ({
 					</div>
 					{hasMoreMessages && (
 						<MessagesPaginationSentinel
-							containerRef={scrollContainerRef}
 							isFetching={isFetchingMoreMessages}
 							onLoadMore={onFetchMoreMessages}
 						/>
 					)}
+					<ScrollToBottomButton
+						visible={!isScrollStuck}
+						onClick={onScrollToBottom}
+					/>
 				</div>
 				<div className="shrink-0 overflow-y-auto px-4 [scrollbar-gutter:stable] [scrollbar-width:thin]">
 					<AgentDetailInput
@@ -507,16 +517,19 @@ export const AgentDetailNotFoundView: FC<AgentDetailNotFoundViewProps> = ({
  * container (which is the DOM bottom).
  */
 const MessagesPaginationSentinel: FC<{
-	containerRef: RefObject<HTMLDivElement | null>;
 	isFetching: boolean;
 	onLoadMore: () => void;
-}> = ({ containerRef, isFetching, onLoadMore }) => {
+}> = ({ isFetching, onLoadMore }) => {
 	const sentinelRef = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
 		const sentinel = sentinelRef.current;
-		const container = containerRef.current;
-		if (!sentinel || !container) return;
+		if (!sentinel) return;
+		// Walk up to the nearest scrollable ancestor. This avoids
+		// the need for a RefObject prop now that the scroll container
+		// uses a callback ref from useStickToBottom.
+		const container = sentinel.closest("[data-scroll-container]");
+		if (!container) return;
 
 		const observer = new IntersectionObserver(
 			([entry]) => {
@@ -532,7 +545,46 @@ const MessagesPaginationSentinel: FC<{
 		);
 		observer.observe(sentinel);
 		return () => observer.disconnect();
-	}, [containerRef, isFetching, onLoadMore]);
+	}, [isFetching, onLoadMore]);
 
 	return <div ref={sentinelRef} className="h-px shrink-0" />;
 };
+
+/**
+ * Floating button that appears when the user scrolls away from the
+ * bottom of the chat. Clicking it scrolls back to the newest
+ * messages. Uses a sticky position inside the flex-col-reverse
+ * scroll container so it stays anchored to the visual bottom.
+ */
+const ScrollToBottomButton: FC<{
+	visible: boolean;
+	onClick: () => void;
+}> = ({ visible, onClick }) => (
+	<div
+		className={cn(
+			"sticky bottom-4 z-20 flex justify-center",
+			"transition-opacity duration-200",
+			visible
+				? "opacity-100"
+				: "opacity-0 pointer-events-none",
+		)}
+		aria-hidden={visible ? undefined : true}
+	>
+		<button
+			type="button"
+			onClick={onClick}
+			tabIndex={visible ? 0 : -1}
+			className={cn(
+				"flex items-center gap-1.5",
+				"rounded-full border border-border-default bg-surface-primary",
+				"px-3 py-1.5 text-xs font-medium text-content-secondary",
+				"shadow-md hover:bg-surface-secondary",
+				"transition-colors cursor-pointer",
+			)}
+			aria-label="Scroll to latest messages"
+		>
+			<ArrowDownIcon className="size-3.5" />
+			Jump to bottom
+		</button>
+	</div>
+);


### PR DESCRIPTION
## Problem

When using Coder Agents in PWA, scrolling up while a chat is active constantly gets dragged back down as the agent streams new messages.

## Root Cause

Browser `overflow-anchor: auto` on the `flex-col-reverse` scroll container repositions the viewport when streaming content grows.

## Solution

- New `useStickToBottom` hook: tracks scroll proximity to bottom, detaches when user scrolls up, re-attaches when they return
- `overflow-anchor: none` on the scroll container
- `data-scroll-container` attribute for robust DOM traversal (replaces fragile `.overflow-y-auto` selector)
- Floating "Jump to bottom" button with proper accessibility
- 5 renderHook tests for the new hook