### PR TITLE
fix(site): strip SVN-style Index headers from diffs before parsing

### DIFF
--- a/site/src/components/ai-elements/tool/utils.test.ts
+++ b/site/src/components/ai-elements/tool/utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
 	BORDER_BG_STYLE,
 	buildEditDiff,
@@ -22,6 +22,7 @@ import {
 	parseArgs,
 	parseEditFilesArgs,
 	shortDurationMs,
+	stripSvnIndexHeaders,
 	toProviderLabel,
 } from "./utils";
 
@@ -420,6 +421,20 @@ describe("buildWriteFileDiff", () => {
 		// That's 1 empty-string line, which is still a valid line.
 		expect(diff).not.toBeNull();
 	});
+
+	it("does not emit console errors from SVN-style Index headers", () => {
+		const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+		try {
+			const diff = buildWriteFileDiff(
+				"src/components/Example.tsx",
+				"export default function Example() {\n  return <div />;\n}\n",
+			);
+			expect(diff).not.toBeNull();
+			expect(spy).not.toHaveBeenCalled();
+		} finally {
+			spy.mockRestore();
+		}
+	});
 });
 
 describe("getWriteFileDiff", () => {
@@ -520,6 +535,26 @@ describe("buildEditDiff", () => {
 		expect(diff).not.toBeNull();
 	});
 
+	it("does not emit console errors for multi-edit diffs", () => {
+		const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+		try {
+			const diff = buildEditDiff(
+				"/home/coder/coder/site/src/pages/AgentsPage/AgentsSidebar.tsx",
+				[
+					{ search: "const a = 1;", replace: "const a = 2;" },
+					{ search: "const b = 3;", replace: "const b = 4;" },
+				],
+			);
+			expect(diff).not.toBeNull();
+			// Before the fix, @pierre/diffs logged:
+			//   parseLineType: Invalid firstChar: "I"
+			//   processFile: invalid rawLine: Index: ...
+			expect(spy).not.toHaveBeenCalled();
+		} finally {
+			spy.mockRestore();
+		}
+	});
+
 	it("strips leading slash from path", () => {
 		const diff = buildEditDiff("/src/index.ts", [
 			{ search: "old", replace: "new" },
@@ -567,6 +602,68 @@ describe("buildEditDiff", () => {
 		// middle line rather than removing and re-adding everything.
 		const hasContext = hunk.hunkContent.some((c) => c.type === "context");
 		expect(hasContext).toBe(true);
+	});
+});
+
+describe("stripSvnIndexHeaders", () => {
+	it("removes Index: headers from SVN-style patches", () => {
+		const input = [
+			"Index: src/file.ts",
+			"===================================================================",
+			"--- src/file.ts",
+			"+++ src/file.ts",
+			"@@ -1,1 +1,1 @@",
+			"-old",
+			"+new",
+			"",
+		].join("\n");
+		const result = stripSvnIndexHeaders(input);
+		expect(result).not.toContain("Index:");
+		expect(result).not.toContain("===");
+		expect(result).toContain("--- src/file.ts");
+	});
+
+	it("handles multiple Index: headers in concatenated patches", () => {
+		const input = [
+			"Index: a.ts",
+			"===================================================================",
+			"--- a.ts",
+			"+++ a.ts",
+			"@@ -1,1 +1,1 @@",
+			"-old1",
+			"+new1",
+			"Index: b.ts",
+			"===================================================================",
+			"--- b.ts",
+			"+++ b.ts",
+			"@@ -1,1 +1,1 @@",
+			"-old2",
+			"+new2",
+			"",
+		].join("\n");
+		const result = stripSvnIndexHeaders(input);
+		// Both Index headers removed.
+		expect(result.match(/Index:/g)).toBeNull();
+		// Diff content preserved.
+		expect(result).toContain("-old1");
+		expect(result).toContain("+new2");
+	});
+
+	it("is a no-op for git-style diffs", () => {
+		const gitDiff = [
+			"diff --git a/file.ts b/file.ts",
+			"--- a/file.ts",
+			"+++ b/file.ts",
+			"@@ -1,1 +1,1 @@",
+			"-old",
+			"+new",
+			"",
+		].join("\n");
+		expect(stripSvnIndexHeaders(gitDiff)).toBe(gitDiff);
+	});
+
+	it("is a no-op for empty strings", () => {
+		expect(stripSvnIndexHeaders("")).toBe("");
 	});
 });
 

--- a/site/src/components/ai-elements/tool/utils.ts
+++ b/site/src/components/ai-elements/tool/utils.ts
@@ -189,6 +189,15 @@ export function getFileViewerOptionsMinimal(isDark: boolean) {
 	};
 }
 
+/**
+ * Strips SVN-style "Index:" headers that `Diff.createPatch()`
+ * emits but `@pierre/diffs` does not recognize as file
+ * boundaries. Left in place they leak into hunk bodies and
+ * trigger console errors.
+ */
+export const stripSvnIndexHeaders = (patch: string): string =>
+	patch.replace(/^Index: .*\n={3,}\n/gm, "");
+
 export const DIFFS_FONT_STYLE = {
 	"--diffs-font-family": '"Geist Mono Variable", monospace, monospace',
 	"--diffs-header-font-family": '"Geist Variable", system-ui, sans-serif',
@@ -261,7 +270,7 @@ export const buildWriteFileDiff = (
 ): FileDiffMetadata | null => {
 	if (!content) return null;
 	const patch = Diff.createPatch(path, "", content, "", "");
-	const parsed = parsePatchFiles(patch);
+	const parsed = parsePatchFiles(stripSvnIndexHeaders(patch));
 	if (!parsed.length || !parsed[0].files.length) return null;
 	return parsed[0].files[0];
 };
@@ -338,12 +347,10 @@ export const buildEditDiff = (
 		// All edits were skipped (empty search). Produce a
 		// header-only patch so the parser still returns a file
 		// entry with zero hunks.
-		patches.push(
-			`Index: ${diffPath}\n===================================================================\n--- ${diffPath}\n+++ ${diffPath}\n`,
-		);
+		patches.push(`--- ${diffPath}\n+++ ${diffPath}\n`);
 	}
 
-	const parsed = parsePatchFiles(patches.join(""));
+	const parsed = parsePatchFiles(stripSvnIndexHeaders(patches.join("")));
 	if (!parsed.length || !parsed[0].files.length) return null;
 	return parsed[0].files[0];
 };


### PR DESCRIPTION
## Problem

`Diff.createPatch()` from the `diff` npm package emits SVN-style `Index:` / `===` headers that `@pierre/diffs` does not recognize as file boundaries. When multiple edit patches are concatenated in `buildEditDiff()`, those headers leak into hunk bodies and cause `parseLineType` / `processFile` console errors:

```
parseLineType: Invalid firstChar: "I", full line: "Index: home/coder/coder/site/src/pages/AgentsPage/AgentsSidebar.tsx"
processFile: invalid rawLine: Index: home/coder/coder/site/src/pages/AgentsPage/AgentsSidebar.tsx
```

## Root cause

`@pierre/diffs` splits multi-file diffs using `/(?=^diff --git)/gm` (git) or `/(?=^---\s+\S)/gm` (unified). Neither handles `Index:` lines. When patches are joined, the `Index:` line from patch N+1 ends up inside the last hunk body of patch N, where `parseLineType()` rejects it because `"I"` is not a valid diff-line prefix (`+`, `-`, ` `, or `\\`).

## Fix

- Add `stripSvnIndexHeaders()` — a one-line regex that strips `Index: ...\n===...\n` pairs before passing to `parsePatchFiles()`.
- Applied in both `buildWriteFileDiff()` and `buildEditDiff()`.
- Removed the now-unnecessary `Index:` header from the empty-search fallback in `buildEditDiff()`.

## Tests

- `buildEditDiff`: asserts `console.error` is not called for multi-edit diffs (the exact scenario from the bug).
- `buildWriteFileDiff`: same assertion for the write path.
- `stripSvnIndexHeaders`: unit tests for single header, multi-header, git-style passthrough, and empty string.