### PR TITLE
fix(site): align workspace combobox styling with model selector

### DIFF
--- a/site/src/components/ai-elements/model-selector.test.tsx
+++ b/site/src/components/ai-elements/model-selector.test.tsx
@@ -10,7 +10,7 @@ const mockModelOptions: readonly ModelSelectorOption[] = [
 	},
 ];
 
-test("does not suppress focus ring styles on the model selector trigger", () => {
+test("suppresses mouse-focus ring but keeps keyboard-focus ring on model selector trigger", () => {
 	render(
 		<ModelSelector
 			options={mockModelOptions}
@@ -21,6 +21,9 @@ test("does not suppress focus ring styles on the model selector trigger", () => 
 
 	const trigger = screen.getByRole("combobox");
 
-	expect(trigger.className).not.toContain("focus:ring-0");
+	// Mouse-focus ring should be suppressed.
+	expect(trigger.className).toContain("focus:ring-0");
+	// Keyboard-focus ring should remain.
+	expect(trigger.className).toContain("focus-visible:ring-2");
 	expect(trigger.className).not.toContain("focus-visible:ring-0");
 });

--- a/site/src/components/ai-elements/model-selector.tsx
+++ b/site/src/components/ai-elements/model-selector.tsx
@@ -91,7 +91,7 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
 		<Select value={value} onValueChange={onValueChange} disabled={isDisabled}>
 			<SelectTrigger
 				className={cn(
-					"h-8 w-auto gap-1.5 border-none bg-transparent px-1 text-xs shadow-none transition-colors hover:bg-transparent hover:text-content-primary [&>svg]:transition-colors [&>svg]:hover:text-content-primary",
+					"h-8 w-auto gap-1.5 border-none bg-transparent px-1 text-xs shadow-none transition-colors hover:bg-transparent hover:text-content-primary focus:ring-0 [&>svg]:transition-colors [&>svg]:hover:text-content-primary",
 					className,
 				)}
 			>

--- a/site/src/pages/AgentsPage/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/AgentCreateForm.tsx
@@ -383,11 +383,17 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 								handleWorkspaceChange(value ?? autoCreateWorkspaceValue)
 							}
 						>
+							{/* pointer-events-auto overrides the pointer-events:none
+								   that Radix Select's DismissableLayer sets on
+								   document.body when the Model Selector is open.
+								   Without it the first click only dismisses the
+								   Select and a second click is needed to open
+								   the Combobox. */}
 							<ComboboxTrigger asChild>
 								<button
 									type="button"
 									disabled={isCreating || workspacesQuery.isLoading}
-									className="group flex h-8 items-center gap-1.5 border-none bg-transparent px-1 text-xs text-content-secondary shadow-none transition-colors hover:bg-transparent hover:text-content-primary cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
+									className="pointer-events-auto group flex h-8 items-center gap-1.5 rounded-md border-none bg-transparent px-1 text-xs text-content-secondary shadow-none ring-offset-background transition-colors hover:bg-transparent hover:text-content-primary focus:outline-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-content-link cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
 								>
 									<MonitorIcon className="h-3.5 w-3.5 shrink-0 text-content-secondary transition-colors group-hover:text-content-primary" />
 									<span>{selectedWorkspaceLabel ?? "Workspace"}</span>
@@ -396,8 +402,8 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 							</ComboboxTrigger>
 							<ComboboxContent
 								side="top"
-								align="center"
-								className="w-72 [&_[cmdk-item]]:text-xs"
+								align="start"
+								className="w-72 bg-surface-primary border-border [&_[cmdk-root]]:bg-surface-primary [&_[cmdk-item]]:text-xs [&_[cmdk-item]>svg:last-child]:ml-auto"
 							>
 								<ComboboxInput placeholder="Search workspaces..." />
 								<ComboboxList>


### PR DESCRIPTION
## Summary

Aligns the visual appearance and interaction behavior of the two dropdowns on the Agent Create Form (Model Selector and Workspace Selector).

## Changes

### Focus ring fix (ModelSelector)
- Added `focus:ring-0` to the `SelectTrigger` so the ring only appears on keyboard navigation (`focus-visible`), not after mouse interactions. The base `SelectTrigger` component has both `focus:ring-2` and `focus-visible:ring-2`; closing the Radix Select returns focus to the trigger, causing a flash on every mouse interaction.

### Workspace combobox trigger styling
- Added `rounded-md`, `focus-visible:ring-2`, `ring-offset-background`, and `focus:outline-none` to match the model selector trigger.

### Single-click opening fix
- Added `pointer-events-auto` to the workspace combobox trigger. Radix Select hardcodes `disableOutsidePointerEvents: true` on its dismiss layer, which sets `pointer-events: none` on `document.body` while open. This caused the combobox trigger to require two clicks (first to dismiss the Select, second to open the combobox). The explicit `pointer-events-auto` overrides the inherited value.

### Dropdown content alignment
- Overrode `ComboboxContent` background (`bg-surface-primary`) and border (`border-border`) at the usage site to match `SelectContent` defaults.
- Changed dropdown `align` from `center` to `start` so the dropdown position stays stable when the selected workspace label changes width.
- Right-aligned the check icon in combobox items via `[&_[cmdk-item]>svg:last-child]:ml-auto` to match `SelectItem` positioning.

### Test update
- Updated `model-selector.test.tsx` to assert the new focus ring behavior.