### PR TITLE
feat: expose PromptCacheKey in OpenAI model config form

### DIFF
--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -404,7 +404,7 @@ type ChatModelOpenAIProviderOptions struct {
 	Prediction          map[string]any   `json:"prediction,omitempty" description:"Predicted output content to speed up responses" hidden:"true"`
 	Store               *bool            `json:"store,omitempty" description:"Whether to store the output for model distillation or evals" hidden:"true"`
 	Metadata            map[string]any   `json:"metadata,omitempty" description:"Arbitrary metadata to attach to the request" hidden:"true"`
-	PromptCacheKey      *string          `json:"prompt_cache_key,omitempty" description:"Key for enabling cross-request prompt caching" hidden:"true"`
+	PromptCacheKey      *string          `json:"prompt_cache_key,omitempty" description:"Key for enabling cross-request prompt caching"`
 	SafetyIdentifier    *string          `json:"safety_identifier,omitempty" description:"Developer-specific safety identifier for the request" hidden:"true"`
 	ServiceTier         *string          `json:"service_tier,omitempty" description:"Latency tier to use for processing the request"`
 	StructuredOutputs   *bool            `json:"structured_outputs,omitempty" description:"Whether to enable structured JSON output mode" hidden:"true"`

--- a/site/src/api/chatModelOptionsGenerated.json
+++ b/site/src/api/chatModelOptionsGenerated.json
@@ -338,8 +338,7 @@
 					"type": "string",
 					"description": "Key for enabling cross-request prompt caching",
 					"required": false,
-					"input_type": "input",
-					"hidden": true
+					"input_type": "input"
 				},
 				{
 					"json_name": "safety_identifier",

--- a/site/src/pages/AgentsPage/ChatModelAdminPanel/modelConfigFormLogic.test.ts
+++ b/site/src/pages/AgentsPage/ChatModelAdminPanel/modelConfigFormLogic.test.ts
@@ -243,6 +243,7 @@ describe("extractModelConfigFormState", () => {
 						service_tier: "auto",
 						reasoning_summary: "concise",
 						user: "test-user",
+						prompt_cache_key: "my-cache-key",
 					},
 				},
 			},
@@ -255,6 +256,7 @@ describe("extractModelConfigFormState", () => {
 		expect(openai.serviceTier).toBe("auto");
 		expect(openai.reasoningSummary).toBe("concise");
 		expect(openai.user).toBe("test-user");
+		expect(openai.promptCacheKey).toBe("my-cache-key");
 	});
 
 	it("extracts Anthropic provider options with thinking", () => {
@@ -606,6 +608,7 @@ describe("buildModelConfigFromForm", () => {
 						serviceTier: "auto",
 						reasoningSummary: "concise",
 						user: "user-123",
+						promptCacheKey: "cache-key-1",
 					},
 				}),
 			);
@@ -620,6 +623,7 @@ describe("buildModelConfigFromForm", () => {
 			expect(openai.service_tier).toBe("auto");
 			expect(openai.reasoning_summary).toBe("concise");
 			expect(openai.user).toBe("user-123");
+			expect(openai.prompt_cache_key).toBe("cache-key-1");
 		});
 
 		it("reports error for invalid reasoning effort option", () => {


### PR DESCRIPTION
## Summary

Remove the `hidden` tag from the `PromptCacheKey` field on
`ChatModelOpenAIProviderOptions` so the auto-generated JSON schema
no longer marks it as hidden. This allows the admin model
configuration UI to render a "Prompt Cache Key" text input for
OpenAI models alongside other visible options like Reasoning Effort,
Service Tier, and Web Search.

## Changes

- **`codersdk/chats.go`**: Remove `hidden:"true"` from `PromptCacheKey` struct tag.
- **`site/src/api/chatModelOptionsGenerated.json`**: Regenerated via `make gen` — `hidden: true` removed from the `prompt_cache_key` entry.
- **`modelConfigFormLogic.test.ts`**: Extend existing "all fields set" tests to cover extract and build roundtrip for `promptCacheKey`.

## How it works

The `hidden` Go struct tag propagates through the code generation pipeline:

1. Go struct tag → `scripts/modeloptionsgen` → `chatModelOptionsGenerated.json`
2. The frontend `getVisibleProviderFields()` filters out fields with `hidden: true`
3. Removing the tag makes the field visible in the schema-driven form renderer

No new UI components are needed — the existing `ModelConfigFields` component
automatically renders the field as a text input based on the schema (`type: "string"`, `input_type: "input"`).

The field appears as **"Prompt Cache Key"** with description
"Key for enabling cross-request prompt caching" in the OpenAI provider
section of the admin model configuration form.