### PR TITLE
fix(site): restore gap between agent chat messages

### DIFF
--- a/site/src/pages/AgentsPage/AgentDetail/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail/ConversationTimeline.tsx
@@ -953,7 +953,7 @@ export const ConversationTimeline: FC<ConversationTimelineProps> = ({
 					<p className="text-sm">Start a conversation with your agent.</p>
 				</div>
 			) : (
-				<div className="flex flex-col">
+				<div className="flex flex-col gap-3">
 					{parsedMessages.map(({ message, parsed }) =>
 						message.role === "user" ? (
 							<StickyUserMessage


### PR DESCRIPTION
## Summary

The refactor in 6fc9f195f ("fix: resolve chat message pagination scroll issues") flattened the section-based message layout into a flat list but accidentally dropped the `gap-3` Tailwind class from the message container. This removed all vertical spacing between chat messages in the agent detail view.

## Fix

Restores `gap-3` on the `flex flex-col` container that holds the message list, matching the spacing that each section previously had.

---

> Written by Coder Agent on behalf of Danielle Maywood.