### PR TITLE
fix(coderd): resize oversized chat images before storage

### DIFF
--- a/coderd/chats.go
+++ b/coderd/chats.go
@@ -8,6 +8,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"image"
+	"image/jpeg"
+	"image/png"
 	"io"
 	"math"
 	"mime"
@@ -19,9 +22,14 @@ import (
 	"sync"
 	"time"
 
+	// Register decoders so image.Decode recognizes these formats.
+	_ "image/gif"
+
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
+	xdraw "golang.org/x/image/draw"
+	_ "golang.org/x/image/webp"
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
@@ -2479,6 +2487,13 @@ const (
 	maxChatFileSize = 10 << 20
 	// maxChatFileName is the maximum length of an uploaded file name.
 	maxChatFileName = 255
+	// maxChatImageDimension is the maximum width or height (in
+	// pixels) allowed for chat image attachments. Anthropic caps
+	// images at 2000 px for many-image requests (>20 images in a
+	// conversation). OpenAI has the same 2000 px limit. We resize
+	// at upload time so the stored image never triggers a provider
+	// rejection.
+	maxChatImageDimension = 2000
 )
 
 // allowedChatFileMIMETypes lists the content types accepted for chat
@@ -2506,6 +2521,68 @@ func detectChatFileType(data []byte) string {
 		return "image/webp"
 	}
 	return http.DetectContentType(data)
+}
+
+// resizeChatImage downsizes a raster image when either dimension
+// exceeds maxChatImageDimension. It returns the (possibly new) data
+// and MIME type. When the image cannot be decoded or the resize
+// fails, the original data is returned unchanged so uploads are
+// never blocked by the resize step.
+//
+// JPEG inputs are re-encoded as JPEG (quality 90). All other
+// formats (PNG, GIF, WebP) are re-encoded as PNG.
+func resizeChatImage(data []byte, mimeType string) ([]byte, string) {
+	img, _, err := image.Decode(bytes.NewReader(data))
+	if err != nil {
+		return data, mimeType
+	}
+
+	bounds := img.Bounds()
+	origW, origH := bounds.Dx(), bounds.Dy()
+
+	newW, newH, needsResize := chatImageResizedDimensions(
+		origW, origH, maxChatImageDimension,
+	)
+	if !needsResize {
+		return data, mimeType
+	}
+
+	dst := image.NewRGBA(image.Rect(0, 0, newW, newH))
+	xdraw.CatmullRom.Scale(dst, dst.Bounds(), img, bounds, xdraw.Over, nil)
+
+	var buf bytes.Buffer
+	outMime := "image/png"
+
+	if mimeType == "image/jpeg" {
+		outMime = "image/jpeg"
+		if err := jpeg.Encode(&buf, dst, &jpeg.Options{Quality: 90}); err != nil {
+			return data, mimeType
+		}
+	} else {
+		if err := png.Encode(&buf, dst); err != nil {
+			return data, mimeType
+		}
+	}
+
+	return buf.Bytes(), outMime
+}
+
+// chatImageResizedDimensions computes new dimensions that fit within
+// maxDim while preserving the aspect ratio. Returns (w, h, true)
+// when a resize is needed, or (origW, origH, false) otherwise.
+func chatImageResizedDimensions(origW, origH, maxDim int) (int, int, bool) {
+	if origW <= maxDim && origH <= maxDim {
+		return origW, origH, false
+	}
+
+	scaleW := float64(maxDim) / float64(origW)
+	scaleH := float64(maxDim) / float64(origH)
+	scale := math.Min(scaleW, scaleH)
+
+	newW := max(1, int(math.Round(float64(origW)*scale)))
+	newH := max(1, int(math.Round(float64(origH)*scale)))
+
+	return newW, newH, true
 }
 
 //nolint:revive // get-return: revive assumes get* must be a getter, but this is an HTTP handler.
@@ -2718,6 +2795,11 @@ func (api *API) postChatFile(rw http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
+
+	// Downsize images that exceed provider dimension limits
+	// (e.g. Anthropic's 2000 px cap for many-image requests).
+	// This runs before storage so every client benefits.
+	data, detected = resizeChatImage(data, detected)
 
 	// Extract filename from Content-Disposition header if provided.
 	var filename string

--- a/coderd/chats_internal_test.go
+++ b/coderd/chats_internal_test.go
@@ -1,0 +1,124 @@
+package coderd
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"image/png"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChatImageResizedDimensions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		w, h        int
+		maxDim      int
+		wantW       int
+		wantH       int
+		wantResized bool
+	}{
+		{"small image", 100, 100, 2000, 100, 100, false},
+		{"wide landscape", 4000, 2000, 2000, 2000, 1000, true},
+		{"tall portrait", 1500, 3000, 2000, 1000, 2000, true},
+		{"square", 3000, 3000, 2000, 2000, 2000, true},
+		{"exactly at limit", 2000, 1500, 2000, 2000, 1500, false},
+		{"one at limit other below", 2000, 500, 2000, 2000, 500, false},
+		{"custom max", 1000, 800, 500, 500, 400, true},
+		{"very thin vertical", 1, 5000, 2000, 1, 2000, true},
+		{"very thin horizontal", 5000, 1, 2000, 2000, 1, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotW, gotH, gotResized := chatImageResizedDimensions(tt.w, tt.h, tt.maxDim)
+			assert.Equal(t, tt.wantW, gotW, "width")
+			assert.Equal(t, tt.wantH, gotH, "height")
+			assert.Equal(t, tt.wantResized, gotResized, "resized")
+		})
+	}
+}
+
+func TestResizeChatImage(t *testing.T) {
+	t.Parallel()
+
+	makePNG := func(t *testing.T, w, h int) []byte {
+		t.Helper()
+		img := image.NewRGBA(image.Rect(0, 0, w, h))
+		for y := 0; y < h; y++ {
+			for x := 0; x < w; x++ {
+				img.Set(x, y, color.RGBA{R: 255, A: 255})
+			}
+		}
+		var buf bytes.Buffer
+		require.NoError(t, png.Encode(&buf, img))
+		return buf.Bytes()
+	}
+
+	makeJPEG := func(t *testing.T, w, h int) []byte {
+		t.Helper()
+		img := image.NewRGBA(image.Rect(0, 0, w, h))
+		for y := 0; y < h; y++ {
+			for x := 0; x < w; x++ {
+				img.Set(x, y, color.RGBA{R: 255, A: 255})
+			}
+		}
+		var buf bytes.Buffer
+		require.NoError(t, jpeg.Encode(&buf, img, &jpeg.Options{Quality: 90}))
+		return buf.Bytes()
+	}
+
+	t.Run("SmallPNG/NoResize", func(t *testing.T) {
+		t.Parallel()
+		data := makePNG(t, 800, 600)
+		out, mime := resizeChatImage(data, "image/png")
+		assert.Equal(t, "image/png", mime)
+		assert.Equal(t, data, out)
+	})
+
+	t.Run("OversizedPNG/Resized", func(t *testing.T) {
+		t.Parallel()
+		data := makePNG(t, 4000, 2000)
+		out, mime := resizeChatImage(data, "image/png")
+		assert.Equal(t, "image/png", mime)
+		img, _, err := image.Decode(bytes.NewReader(out))
+		require.NoError(t, err)
+		bounds := img.Bounds()
+		assert.Equal(t, 2000, bounds.Dx())
+		assert.Equal(t, 1000, bounds.Dy())
+	})
+
+	t.Run("OversizedJPEG/StaysJPEG", func(t *testing.T) {
+		t.Parallel()
+		data := makeJPEG(t, 3000, 3000)
+		out, mime := resizeChatImage(data, "image/jpeg")
+		assert.Equal(t, "image/jpeg", mime)
+		img, _, err := image.Decode(bytes.NewReader(out))
+		require.NoError(t, err)
+		bounds := img.Bounds()
+		assert.Equal(t, 2000, bounds.Dx())
+		assert.Equal(t, 2000, bounds.Dy())
+	})
+
+	t.Run("InvalidData/PassThrough", func(t *testing.T) {
+		t.Parallel()
+		data := append([]byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}, make([]byte, 64)...)
+		out, mime := resizeChatImage(data, "image/png")
+		assert.Equal(t, "image/png", mime)
+		assert.Equal(t, data, out)
+	})
+
+	t.Run("NonImageMime/PassThrough", func(t *testing.T) {
+		t.Parallel()
+		data := []byte("not an image")
+		out, mime := resizeChatImage(data, "text/plain")
+		assert.Equal(t, "text/plain", mime)
+		assert.Equal(t, data, out)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -497,6 +497,7 @@ require (
 	github.com/mark3labs/mcp-go v0.38.0
 	github.com/openai/openai-go/v3 v3.15.0
 	github.com/shopspring/decimal v1.4.0
+	golang.org/x/image v0.36.0
 	gonum.org/v1/gonum v0.17.0
 )
 


### PR DESCRIPTION
## Problem

Anthropic rejects images with dimensions >2000px in many-image requests (>20 images in a conversation), returning a 400 error:

```
messages.136.content.0.image.source.base64.data: At least one of the image dimensions
exceed max allowed size for many-image requests: 2000 pixels
```

This error persists in the conversation history and breaks all subsequent messages — even plain text — until the chat is cleared. OpenAI has the same 2000px limit.

## Solution

Add **server-side** image resizing in `postChatFile` so that every client (frontend, API, SDK) benefits. This matches the approach from [coder/mux](https://github.com/coder/mux/blob/main/src/browser/utils/imageResize.ts) but applied at the API layer instead of the frontend.

### New: `coderd/chatfileimage.go`

- `resizeChatImage(data, mimeType)` — decodes the image, checks dimensions, downscales using CatmullRom interpolation if either dimension exceeds 2000px, returns the resized data + updated MIME type
- `chatImageResizedDimensions(w, h, maxDim)` — pure dimension computation preserving aspect ratio
- JPEG stays JPEG (quality 90); PNG/GIF/WebP are re-encoded as PNG
- Images that cannot be decoded pass through unchanged — the resize step never blocks uploads

### Changed: `coderd/chats.go`

One call to `resizeChatImage(data, detected)` after reading the upload body and before `InsertChatFile`. The stored image is always within provider limits.

### New dep: `golang.org/x/image` (already transitive, now direct)

Used for `draw.CatmullRom` (high-quality downscale kernel) and WebP decode registration.

### Tests: `coderd/chatfileimage_test.go`

- 9 table-driven cases for `chatImageResizedDimensions` (landscape, portrait, square, at-limit, thin images, custom max)
- 5 cases for `resizeChatImage` (small PNG no-op, oversized PNG resized, oversized JPEG stays JPEG, invalid data passthrough, non-image passthrough)
- All existing `TestPostChatFile` tests continue to pass