### PR TITLE
docs: clarify agent permission inheritance and default security posture

### DIFF
--- a/docs/ai-coder/agents/architecture.md
+++ b/docs/ai-coder/agents/architecture.md
@@ -140,25 +140,39 @@ They traverse the same Tailnet tunnel used by web terminals and IDE connections.
 ### Platform tools
 
 These tools run entirely within the control plane. They do not require a
-workspace connection.
+workspace connection. Platform and orchestration tools are only available to
+root chats — sub-agents spawned by `spawn_agent` do not have access to them
+and cannot create workspaces or spawn further sub-agents.
 
-| Tool               | What it does                                                      |
-|--------------------|-------------------------------------------------------------------|
-| `list_templates`   | Browses available workspace templates, sorted by popularity.      |
-| `read_template`    | Gets template details and configurable parameters.                |
-| `create_workspace` | Creates a workspace from a template and waits for it to be ready. |
+| Tool               | What it does                                                                           |
+|--------------------|----------------------------------------------------------------------------------------|
+| `list_templates`   | Browses available workspace templates, sorted by popularity.                           |
+| `read_template`    | Gets template details and configurable parameters.                                     |
+| `create_workspace` | Creates a workspace from a template and waits for it to be ready.                      |
+| `start_workspace`  | Starts the chat's workspace if it is currently stopped. Idempotent if already running. |
 
 ### Orchestration tools
 
 These tools manage sub-agents — child chats that work on independent tasks in
 parallel.
 
-| Tool            | What it does                                                 |
-|-----------------|--------------------------------------------------------------|
-| `spawn_agent`   | Delegates a task to a sub-agent with its own context window. |
-| `wait_agent`    | Waits for a sub-agent to finish and collects its result.     |
-| `message_agent` | Sends a follow-up message to a running sub-agent.            |
-| `close_agent`   | Stops a running sub-agent.                                   |
+| Tool                       | What it does                                                                                                             |
+|----------------------------|--------------------------------------------------------------------------------------------------------------------------|
+| `spawn_agent`              | Delegates a task to a sub-agent with its own context window.                                                             |
+| `spawn_computer_use_agent` | Spawns a sub-agent with desktop interaction capabilities (screenshots, mouse, keyboard). Requires an Anthropic provider. |
+| `wait_agent`               | Waits for a sub-agent to finish and collects its result.                                                                 |
+| `message_agent`            | Sends a follow-up message to a running sub-agent.                                                                        |
+| `close_agent`              | Stops a running sub-agent.                                                                                               |
+
+### Provider tools
+
+These tools are executed server-side by the LLM provider, not by the control
+plane or workspace. They are conditionally available based on the model
+configuration set by an administrator.
+
+| Tool         | What it does                                                                                                                                     |
+|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| `web_search` | Searches the internet for up-to-date information. Available when web search is enabled for the configured Anthropic, OpenAI, or Google provider. |
 
 ## What runs where
 

--- a/docs/ai-coder/agents/architecture.md
+++ b/docs/ai-coder/agents/architecture.md
@@ -106,6 +106,11 @@ Tools are how the agent takes action. Each tool call from the LLM translates to
 a concrete operation — either inside a workspace or within the control plane
 itself.
 
+The agent is restricted to the tool set defined in this section. It has no
+direct access to the Coder API beyond what these tools expose and cannot
+execute arbitrary operations against the control plane. If a capability is
+not represented by a tool, the agent cannot perform it.
+
 ### Workspace connection lifecycle
 
 The connection to a workspace is **lazy**. It is not established when a chat
@@ -243,6 +248,22 @@ is tied to the user who submitted the prompt. There is no shared bot account or
 anonymous identity. If a developer submits a prompt that results in a pull
 request, that pull request is attributed to them via the git authentication
 already configured in your Coder deployment.
+
+### Permission boundaries
+
+The agent operates with the exact same permissions as the user who submitted
+the prompt. If a user cannot access a template, workspace, or API endpoint
+through the Coder dashboard or CLI, the agent cannot access it either. There
+is no privilege escalation.
+
+This extends to workspace isolation: the agent can only interact with
+workspaces owned by the user who started the chat. It cannot read files,
+execute commands, or connect to workspaces belonging to other users.
+
+Template visibility follows the same rule. When the agent lists available
+templates, it sees only the templates the user is authorized to access.
+The agent cannot provision a workspace from a template the user does not
+have permission to use.
 
 ## Scaling and resource impact
 

--- a/docs/ai-coder/agents/architecture.md
+++ b/docs/ai-coder/agents/architecture.md
@@ -156,13 +156,12 @@ and cannot create workspaces or spawn further sub-agents.
 These tools manage sub-agents — child chats that work on independent tasks in
 parallel.
 
-| Tool                       | What it does                                                                                                             |
-|----------------------------|--------------------------------------------------------------------------------------------------------------------------|
-| `spawn_agent`              | Delegates a task to a sub-agent with its own context window.                                                             |
-| `spawn_computer_use_agent` | Spawns a sub-agent with desktop interaction capabilities (screenshots, mouse, keyboard). Requires an Anthropic provider. |
-| `wait_agent`               | Waits for a sub-agent to finish and collects its result.                                                                 |
-| `message_agent`            | Sends a follow-up message to a running sub-agent.                                                                        |
-| `close_agent`              | Stops a running sub-agent.                                                                                               |
+| Tool            | What it does                                                 |
+|-----------------|--------------------------------------------------------------|
+| `spawn_agent`   | Delegates a task to a sub-agent with its own context window. |
+| `wait_agent`    | Waits for a sub-agent to finish and collects its result.     |
+| `message_agent` | Sends a follow-up message to a running sub-agent.            |
+| `close_agent`   | Stops a running sub-agent.                                   |
 
 ### Provider tools
 

--- a/docs/ai-coder/agents/index.md
+++ b/docs/ai-coder/agents/index.md
@@ -195,7 +195,7 @@ entirely:
 > By default, agent workspaces have the same network access and permissions
 > as any workspace the user creates manually. If your templates do not
 > restrict outbound network access, the agent has full internet access from
-> the workspace. See [Template Routing](./platform-controls/template-optimization.md)
+> the workspace. See [Template Optimization](./platform-controls/template-optimization.md)
 > for guidance on configuring network boundaries and scoping credentials for
 > agent workloads.
 

--- a/docs/ai-coder/agents/index.md
+++ b/docs/ai-coder/agents/index.md
@@ -83,9 +83,9 @@ This means:
 - **Lower infrastructure cost** — workspaces are only created when the agent
   needs to do real development work.
 
-When a workspace _is_ needed, the agent reads the available templates —
+When a workspace _is_ needed, the agent reads the templates available to that user —
 including their descriptions and parameters — selects the appropriate one, and
-creates a workspace automatically. Users can also manually choose which workspace is used when starting a new chat.
+creates a workspace automatically. Template visibility is scoped to the user's role and permissions, so the agent can only select templates the user is authorized to use. Users can also manually choose which workspace is used when starting a new chat.
 
 Platform teams control template routing by writing clear template descriptions.
 For example, a description like "Use this template for Python backend services
@@ -174,12 +174,30 @@ entirely:
 - **User identity is always attached.** Every action the agent takes — PRs
   opened, code pushed, commands run — is tied to the user who submitted the
   prompt. There is no shared bot identity or anonymous execution.
+- **No privilege escalation.** The agent operates with the exact same
+  permissions as the user who submitted the prompt. If a developer cannot
+  access a template, workspace, or resource through the Coder dashboard,
+  the agent cannot access it either. There is no escalation of privileges
+  and no shared service account.
+- **Workspace isolation is preserved.** The agent can only access workspaces
+  owned by the user who submitted the prompt. There is no cross-user
+  workspace access — an agent running on behalf of one developer cannot
+  read files, execute commands, or interact with another developer's
+  workspaces.
 
 > [!TIP]
 > For highly sensitive environments, create a dedicated set of templates for
 > agent workloads with stricter network policies than your standard developer
 > templates. Because the AI comes from the control plane, these templates don't
 > need any outbound access to LLM providers.
+
+> [!WARNING]
+> By default, agent workspaces have the same network access and permissions
+> as any workspace the user creates manually. If your templates do not
+> restrict outbound network access, the agent has full internet access from
+> the workspace. See [Template Routing](./platform-controls/template-optimization.md)
+> for guidance on configuring network boundaries and scoping credentials for
+> agent workloads.
 
 ## LLM provider support
 

--- a/docs/ai-coder/agents/index.md
+++ b/docs/ai-coder/agents/index.md
@@ -232,22 +232,21 @@ model. Developers select from enabled models when starting a chat.
 The agent has access to a set of workspace tools that it uses to accomplish
 tasks:
 
-| Tool                       | Description                                             |
-|----------------------------|---------------------------------------------------------|
-| `list_templates`           | Browse available workspace templates                    |
-| `read_template`            | Get template details and configurable parameters        |
-| `create_workspace`         | Create a workspace from a template                      |
-| `start_workspace`          | Start a stopped workspace for the current chat          |
-| `read_file`                | Read file contents from the workspace                   |
-| `write_file`               | Write a file to the workspace                           |
-| `edit_files`               | Perform search-and-replace edits across files           |
-| `execute`                  | Run shell commands in the workspace                     |
-| `spawn_agent`              | Delegate a task to a sub-agent running in parallel      |
-| `spawn_computer_use_agent` | Spawn a sub-agent with desktop interaction capabilities |
-| `wait_agent`               | Wait for a sub-agent to complete and collect its result |
-| `message_agent`            | Send a follow-up message to a running sub-agent         |
-| `close_agent`              | Stop a running sub-agent                                |
-| `web_search`               | Search the internet (provider-native, when enabled)     |
+| Tool               | Description                                             |
+|--------------------|---------------------------------------------------------|
+| `list_templates`   | Browse available workspace templates                    |
+| `read_template`    | Get template details and configurable parameters        |
+| `create_workspace` | Create a workspace from a template                      |
+| `start_workspace`  | Start a stopped workspace for the current chat          |
+| `read_file`        | Read file contents from the workspace                   |
+| `write_file`       | Write a file to the workspace                           |
+| `edit_files`       | Perform search-and-replace edits across files           |
+| `execute`          | Run shell commands in the workspace                     |
+| `spawn_agent`      | Delegate a task to a sub-agent running in parallel      |
+| `wait_agent`       | Wait for a sub-agent to complete and collect its result |
+| `message_agent`    | Send a follow-up message to a running sub-agent         |
+| `close_agent`      | Stop a running sub-agent                                |
+| `web_search`       | Search the internet (provider-native, when enabled)     |
 
 These tools connect to the workspace over the same secure connection used for
 web terminals and IDE access. No additional ports or services are required in
@@ -255,7 +254,7 @@ the workspace.
 
 Platform tools (`list_templates`, `read_template`, `create_workspace`,
 `start_workspace`) and orchestration tools (`spawn_agent`,
-`spawn_computer_use_agent`) are only available to root chats. Sub-agents do
+`spawn_agent`) are only available to root chats. Sub-agents do
 not have access to these tools and cannot create workspaces or spawn further
 sub-agents.
 

--- a/docs/ai-coder/agents/index.md
+++ b/docs/ai-coder/agents/index.md
@@ -253,8 +253,8 @@ web terminals and IDE access. No additional ports or services are required in
 the workspace.
 
 Platform tools (`list_templates`, `read_template`, `create_workspace`,
-`start_workspace`) and orchestration tools (`spawn_agent`,
-`spawn_agent`) are only available to root chats. Sub-agents do
+`start_workspace`) and orchestration tools (`spawn_agent`)
+are only available to root chats. Sub-agents do
 not have access to these tools and cannot create workspaces or spawn further
 sub-agents.
 

--- a/docs/ai-coder/agents/index.md
+++ b/docs/ai-coder/agents/index.md
@@ -191,6 +191,8 @@ entirely:
 > templates. Because the AI comes from the control plane, these templates don't
 > need any outbound access to LLM providers.
 
+<!-- break between callouts -->
+
 > [!WARNING]
 > By default, agent workspaces have the same network access and permissions
 > as any workspace the user creates manually. If your templates do not

--- a/docs/ai-coder/agents/index.md
+++ b/docs/ai-coder/agents/index.md
@@ -232,23 +232,32 @@ model. Developers select from enabled models when starting a chat.
 The agent has access to a set of workspace tools that it uses to accomplish
 tasks:
 
-| Tool               | Description                                             |
-|--------------------|---------------------------------------------------------|
-| `list_templates`   | Browse available workspace templates                    |
-| `read_template`    | Get template details and configurable parameters        |
-| `create_workspace` | Create a workspace from a template                      |
-| `read_file`        | Read file contents from the workspace                   |
-| `write_file`       | Write a file to the workspace                           |
-| `edit_files`       | Perform search-and-replace edits across files           |
-| `execute`          | Run shell commands in the workspace                     |
-| `spawn_agent`      | Delegate a task to a sub-agent running in parallel      |
-| `wait_agent`       | Wait for a sub-agent to complete and collect its result |
-| `message_agent`    | Send a follow-up message to a running sub-agent         |
-| `close_agent`      | Stop a running sub-agent                                |
+| Tool                       | Description                                             |
+|----------------------------|---------------------------------------------------------|
+| `list_templates`           | Browse available workspace templates                    |
+| `read_template`            | Get template details and configurable parameters        |
+| `create_workspace`         | Create a workspace from a template                      |
+| `start_workspace`          | Start a stopped workspace for the current chat          |
+| `read_file`                | Read file contents from the workspace                   |
+| `write_file`               | Write a file to the workspace                           |
+| `edit_files`               | Perform search-and-replace edits across files           |
+| `execute`                  | Run shell commands in the workspace                     |
+| `spawn_agent`              | Delegate a task to a sub-agent running in parallel      |
+| `spawn_computer_use_agent` | Spawn a sub-agent with desktop interaction capabilities |
+| `wait_agent`               | Wait for a sub-agent to complete and collect its result |
+| `message_agent`            | Send a follow-up message to a running sub-agent         |
+| `close_agent`              | Stop a running sub-agent                                |
+| `web_search`               | Search the internet (provider-native, when enabled)     |
 
 These tools connect to the workspace over the same secure connection used for
 web terminals and IDE access. No additional ports or services are required in
 the workspace.
+
+Platform tools (`list_templates`, `read_template`, `create_workspace`,
+`start_workspace`) and orchestration tools (`spawn_agent`,
+`spawn_computer_use_agent`) are only available to root chats. Sub-agents do
+not have access to these tools and cannot create workspaces or spawn further
+sub-agents.
 
 ## Comparison to Coder Tasks
 

--- a/docs/ai-coder/agents/platform-controls/template-optimization.md
+++ b/docs/ai-coder/agents/platform-controls/template-optimization.md
@@ -112,6 +112,14 @@ for more detail on the security model.
 
 ## Scope permissions and credentials
 
+> [!WARNING]
+> By default, agent workspaces inherit the same network access and
+> permissions as any workspace the user creates manually. If your templates
+> do not explicitly restrict outbound network access, the agent has full
+> internet access from the workspace. Review the guidance below and in
+> [Configure network boundaries](#configure-network-boundaries) to lock
+> down agent workloads appropriately.
+
 The agent operates with the same identity and permissions as the user who
 submitted the prompt. There is no privilege escalation — if a developer cannot
 access a resource through the Coder dashboard, the agent cannot access it

--- a/docs/ai-coder/agents/platform-controls/template-optimization.md
+++ b/docs/ai-coder/agents/platform-controls/template-optimization.md
@@ -1,4 +1,4 @@
-# Template Routing
+# Template Optimization
 
 Not every chat with Coder Agents requires a workspace. A workspace is only provisioned when the
 agent decides it needs compute — to read files, write code, run commands, or


### PR DESCRIPTION
Addresses five documentation gaps identified from an internal agents briefing Q&A, specifically around what permissions an agent inherits from the user:

1. **No privilege escalation** — Added explicit statement that the agent has the exact same permissions as the user. No escalation, no shared service account.
2. **Cross-user workspace isolation** — Added statement that agents cannot access workspaces belonging to other users.
3. **Default-state warning** — Added WARNING callouts that agent workspaces inherit the user's full network access unless templates explicitly restrict it.
4. **Tool boundary statement** — Added explicit statement that the agent cannot act outside its defined tool set and has no direct access to the Coder API.
5. **Template visibility scoped to user RBAC** — Clarified that template selection respects the user's role and permissions.

Changes across 3 files:
- `docs/ai-coder/agents/index.md`
- `docs/ai-coder/agents/architecture.md`
- `docs/ai-coder/agents/platform-controls/template-optimization.md`

---
PR generated with Coder Agents