### PR TITLE
fix(dogfood/coder): suppress du stderr in docker usage metadata

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -533,7 +533,7 @@ resource "coder_agent" "dev" {
     display_name = "/var/lib/docker Usage"
     key          = "var_lib_docker_usage"
     order        = 3
-    script       = "sudo du -sh /var/lib/docker | awk '{print $1}'"
+    script       = "sudo du -sh /var/lib/docker 2>/dev/null | awk '{print $1}'"
     interval     = 3600 # 1h to avoid thrashing disk
     timeout      = 60   # Longer than this is likely problematic
   }


### PR DESCRIPTION
Docker overlay directories can disappear mid-scan during container operations, causing `du` to emit 'No such file or directory' errors that get mixed into the displayed metadata value. Redirect stderr to `/dev/null`.

> 🤖 This PR was created with the help of Mux, and has been reviewed by a human. 🏂🏻

<img width="473" height="138" alt="image" src="https://github.com/user-attachments/assets/e27c386a-5fe0-4799-9700-0b6db9e93e9c" />
