### PR TITLE
chore: enable tagalign linter for struct tag alignment

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -100,8 +100,12 @@ linters-settings:
 
   tagalign:
     align: true
-    sort: false
-    strict: false
+    sort: true
+    strict: true
+    order:
+      - json
+      - db
+      - table
 
   goimports:
     local-prefixes: coder.com,cdr.dev,go.coder.com,github.com/cdr,github.com/coder

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -98,6 +98,11 @@ linters-settings:
     # stdlib port.
     checks: ["all", "-SA1019"]
 
+  tagalign:
+    align: true
+    sort: false
+    strict: false
+
   goimports:
     local-prefixes: coder.com,cdr.dev,go.coder.com,github.com/cdr,github.com/coder
 
@@ -262,6 +267,7 @@ linters:
     # - wastedassign
 
     - staticcheck
+    - tagalign
     # In Go, it's possible for a package to test it's internal functionality
     # without testing any exported functions. This is enabled to promote
     # decomposing a package before testing it's internals. A function caller

--- a/agent/agentsocket/client.go
+++ b/agent/agentsocket/client.go
@@ -140,16 +140,16 @@ func (c *Client) UpdateAppStatus(ctx context.Context, req *agentproto.UpdateAppS
 
 // SyncStatusResponse contains the status information for a unit.
 type SyncStatusResponse struct {
-	UnitName     unit.ID          `table:"unit,default_sort" json:"unit_name"`
-	Status       unit.Status      `table:"status"            json:"status"`
-	IsReady      bool             `table:"ready"             json:"is_ready"`
-	Dependencies []DependencyInfo `table:"dependencies"      json:"dependencies"`
+	UnitName     unit.ID          `json:"unit_name"    table:"unit,default_sort"`
+	Status       unit.Status      `json:"status"       table:"status"`
+	IsReady      bool             `json:"is_ready"     table:"ready"`
+	Dependencies []DependencyInfo `json:"dependencies" table:"dependencies"`
 }
 
 // DependencyInfo contains information about a unit dependency.
 type DependencyInfo struct {
-	DependsOn      unit.ID     `table:"depends on,default_sort" json:"depends_on"`
-	RequiredStatus unit.Status `table:"required status"         json:"required_status"`
-	CurrentStatus  unit.Status `table:"current status"          json:"current_status"`
-	IsSatisfied    bool        `table:"satisfied"               json:"is_satisfied"`
+	DependsOn      unit.ID     `json:"depends_on"      table:"depends on,default_sort"`
+	RequiredStatus unit.Status `json:"required_status" table:"required status"`
+	CurrentStatus  unit.Status `json:"current_status"  table:"current status"`
+	IsSatisfied    bool        `json:"is_satisfied"    table:"satisfied"`
 }

--- a/agent/agentsocket/client.go
+++ b/agent/agentsocket/client.go
@@ -141,15 +141,15 @@ func (c *Client) UpdateAppStatus(ctx context.Context, req *agentproto.UpdateAppS
 // SyncStatusResponse contains the status information for a unit.
 type SyncStatusResponse struct {
 	UnitName     unit.ID          `table:"unit,default_sort" json:"unit_name"`
-	Status       unit.Status      `table:"status" json:"status"`
-	IsReady      bool             `table:"ready" json:"is_ready"`
-	Dependencies []DependencyInfo `table:"dependencies" json:"dependencies"`
+	Status       unit.Status      `table:"status"            json:"status"`
+	IsReady      bool             `table:"ready"             json:"is_ready"`
+	Dependencies []DependencyInfo `table:"dependencies"      json:"dependencies"`
 }
 
 // DependencyInfo contains information about a unit dependency.
 type DependencyInfo struct {
 	DependsOn      unit.ID     `table:"depends on,default_sort" json:"depends_on"`
-	RequiredStatus unit.Status `table:"required status" json:"required_status"`
-	CurrentStatus  unit.Status `table:"current status" json:"current_status"`
-	IsSatisfied    bool        `table:"satisfied" json:"is_satisfied"`
+	RequiredStatus unit.Status `table:"required status"         json:"required_status"`
+	CurrentStatus  unit.Status `table:"current status"          json:"current_status"`
+	IsSatisfied    bool        `table:"satisfied"               json:"is_satisfied"`
 }

--- a/cli/cliutil/license.go
+++ b/cli/cliutil/license.go
@@ -17,8 +17,8 @@ import (
 func NewLicenseFormatter() *cliui.OutputFormatter {
 	type tableLicense struct {
 		ID         int32     `table:"id,default_sort"`
-		UUID       uuid.UUID `table:"uuid" format:"uuid"`
-		UploadedAt time.Time `table:"uploaded at" format:"date-time"`
+		UUID       uuid.UUID `table:"uuid"            format:"uuid"`
+		UploadedAt time.Time `table:"uploaded at"     format:"date-time"`
 		// Features is the formatted string for the license claims.
 		// Used for the table view.
 		Features  string    `table:"features"`

--- a/cli/organizationroles.go
+++ b/cli/organizationroles.go
@@ -524,7 +524,7 @@ type roleTableRow struct {
 	Name            string `table:"name,default_sort"`
 	DisplayName     string `table:"display name"`
 	OrganizationID  string `table:"organization id"`
-	SitePermissions string ` table:"site permissions"`
+	SitePermissions string `table:"site permissions"`
 	// map[<org_id>] -> Permissions
 	OrganizationPermissions string `table:"organization permissions"`
 	UserPermissions         string `table:"user permissions"`

--- a/cli/provisionerjobs.go
+++ b/cli/provisionerjobs.go
@@ -33,8 +33,8 @@ func (r *RootCmd) provisionerJobs() *serpent.Command {
 func (r *RootCmd) provisionerJobsList() *serpent.Command {
 	type provisionerJobRow struct {
 		codersdk.ProvisionerJob `table:"provisioner_job,recursive_inline,nosort"`
-		OrganizationName        string `json:"organization_name" table:"organization"`
-		Queue                   string `json:"-" table:"queue"`
+		OrganizationName        string `json:"organization_name"                        table:"organization"`
+		Queue                   string `json:"-"                                        table:"queue"`
 	}
 
 	var (

--- a/cli/provisionerjobs.go
+++ b/cli/provisionerjobs.go
@@ -32,9 +32,9 @@ func (r *RootCmd) provisionerJobs() *serpent.Command {
 
 func (r *RootCmd) provisionerJobsList() *serpent.Command {
 	type provisionerJobRow struct {
-		codersdk.ProvisionerJob `table:"provisioner_job,recursive_inline,nosort"`
-		OrganizationName        string `json:"organization_name"                        table:"organization"`
-		Queue                   string `json:"-"                                        table:"queue"`
+		codersdk.ProvisionerJob `                         table:"provisioner_job,recursive_inline,nosort"`
+		OrganizationName        string `json:"organization_name" table:"organization"`
+		Queue                   string `json:"-"                 table:"queue"`
 	}
 
 	var (

--- a/cli/provisioners.go
+++ b/cli/provisioners.go
@@ -32,7 +32,7 @@ func (r *RootCmd) Provisioners() *serpent.Command {
 func (r *RootCmd) provisionerList() *serpent.Command {
 	type provisionerDaemonRow struct {
 		codersdk.ProvisionerDaemon `table:"provisioner_daemon,recursive_inline"`
-		OrganizationName           string `json:"organization_name" table:"organization"`
+		OrganizationName           string `json:"organization_name"                    table:"organization"`
 	}
 	var (
 		orgContext = NewOrganizationContext()

--- a/cli/provisioners.go
+++ b/cli/provisioners.go
@@ -31,8 +31,8 @@ func (r *RootCmd) Provisioners() *serpent.Command {
 
 func (r *RootCmd) provisionerList() *serpent.Command {
 	type provisionerDaemonRow struct {
-		codersdk.ProvisionerDaemon `table:"provisioner_daemon,recursive_inline"`
-		OrganizationName           string `json:"organization_name"                    table:"organization"`
+		codersdk.ProvisionerDaemon `                         table:"provisioner_daemon,recursive_inline"`
+		OrganizationName           string `json:"organization_name" table:"organization"`
 	}
 	var (
 		orgContext = NewOrganizationContext()

--- a/cli/schedule.go
+++ b/cli/schedule.go
@@ -350,11 +350,11 @@ func displaySchedule(ws codersdk.Workspace, out io.Writer) error {
 // scheduleListRow is a row in the schedule list.
 // this is required for proper JSON output.
 type scheduleListRow struct {
-	WorkspaceName string `json:"workspace" table:"workspace,default_sort"`
-	StartsAt      string `json:"starts_at" table:"starts at"`
+	WorkspaceName string `json:"workspace"   table:"workspace,default_sort"`
+	StartsAt      string `json:"starts_at"   table:"starts at"`
 	StartsNext    string `json:"starts_next" table:"starts next"`
 	StopsAfter    string `json:"stops_after" table:"stops after"`
-	StopsNext     string `json:"stops_next" table:"stops next"`
+	StopsNext     string `json:"stops_next"  table:"stops next"`
 }
 
 func scheduleListRowFromWorkspace(now time.Time, workspace codersdk.Workspace) scheduleListRow {

--- a/cli/stat.go
+++ b/cli/stat.go
@@ -284,9 +284,9 @@ func (*RootCmd) statDisk(fs afero.Fs) *serpent.Command {
 }
 
 type statsRow struct {
-	HostCPU         *clistat.Result `json:"host_cpu" table:"host cpu,default_sort"`
-	HostMemory      *clistat.Result `json:"host_memory" table:"host memory"`
-	Disk            *clistat.Result `json:"home_disk" table:"home disk"`
-	ContainerCPU    *clistat.Result `json:"container_cpu" table:"container cpu"`
+	HostCPU         *clistat.Result `json:"host_cpu"         table:"host cpu,default_sort"`
+	HostMemory      *clistat.Result `json:"host_memory"      table:"host memory"`
+	Disk            *clistat.Result `json:"home_disk"        table:"home disk"`
+	ContainerCPU    *clistat.Result `json:"container_cpu"    table:"container cpu"`
 	ContainerMemory *clistat.Result `json:"container_memory" table:"container memory"`
 }

--- a/cli/task_status.go
+++ b/cli/task_status.go
@@ -156,8 +156,8 @@ func taskWatchIsEnded(task codersdk.Task) bool {
 
 type taskStatusRow struct {
 	codersdk.Task `table:"r,recursive_inline"`
-	ChangedAgo    string `json:"-" table:"state changed"`
-	Healthy       bool   `json:"-" table:"healthy"`
+	ChangedAgo    string `json:"-"                   table:"state changed"`
+	Healthy       bool   `json:"-"                   table:"healthy"`
 }
 
 func taskStatusRowEqual(r1, r2 taskStatusRow) bool {

--- a/cli/task_status.go
+++ b/cli/task_status.go
@@ -155,9 +155,9 @@ func taskWatchIsEnded(task codersdk.Task) bool {
 }
 
 type taskStatusRow struct {
-	codersdk.Task `table:"r,recursive_inline"`
-	ChangedAgo    string `json:"-"                   table:"state changed"`
-	Healthy       bool   `json:"-"                   table:"healthy"`
+	codersdk.Task `         table:"r,recursive_inline"`
+	ChangedAgo    string `json:"-" table:"state changed"`
+	Healthy       bool   `json:"-" table:"healthy"`
 }
 
 func taskStatusRowEqual(r1, r2 taskStatusRow) bool {

--- a/cli/templateversions.go
+++ b/cli/templateversions.go
@@ -138,7 +138,7 @@ func (r *RootCmd) templateVersionsList() *serpent.Command {
 
 type templateVersionRow struct {
 	// For json format:
-	TemplateVersion codersdk.TemplateVersion `table:"-"`
+	TemplateVersion codersdk.TemplateVersion `              table:"-"`
 	ActiveJSON      bool                     `json:"active" table:"-"`
 
 	// For table format:

--- a/cli/tokens.go
+++ b/cli/tokens.go
@@ -161,14 +161,14 @@ type tokenListRow struct {
 	codersdk.APIKey `table:"-"`
 
 	// For table format:
-	ID        string    `json:"-" table:"id,default_sort"`
+	ID        string    `json:"-"          table:"id,default_sort"`
 	TokenName string    `json:"token_name" table:"name"`
-	Scopes    string    `json:"-" table:"scopes"`
-	Allow     string    `json:"-" table:"allow list"`
-	LastUsed  time.Time `json:"-" table:"last used"`
-	ExpiresAt time.Time `json:"-" table:"expires at"`
-	CreatedAt time.Time `json:"-" table:"created at"`
-	Owner     string    `json:"-" table:"owner"`
+	Scopes    string    `json:"-"          table:"scopes"`
+	Allow     string    `json:"-"          table:"allow list"`
+	LastUsed  time.Time `json:"-"          table:"last used"`
+	ExpiresAt time.Time `json:"-"          table:"expires at"`
+	CreatedAt time.Time `json:"-"          table:"created at"`
+	Owner     string    `json:"-"          table:"owner"`
 }
 
 func tokenListRowFromToken(token codersdk.APIKeyWithOwner) tokenListRow {

--- a/cli/whoami.go
+++ b/cli/whoami.go
@@ -11,13 +11,13 @@ import (
 )
 
 type whoamiRow struct {
-	URL                 string              `json:"url" table:"URL,default_sort"`
-	Username            string              `json:"username" table:"Username"`
-	UserID              string              `json:"user_id" table:"ID"`
-	OrganizationIDs     string              `json:"-" table:"Orgs"`
+	URL                 string              `json:"url"              table:"URL,default_sort"`
+	Username            string              `json:"username"         table:"Username"`
+	UserID              string              `json:"user_id"          table:"ID"`
+	OrganizationIDs     string              `json:"-"                table:"Orgs"`
 	OrganizationIDsJSON []string            `json:"organization_ids" table:"-"`
-	Roles               string              `json:"-" table:"Roles"`
-	RolesJSON           map[string][]string `json:"roles" table:"-"`
+	Roles               string              `json:"-"                table:"Roles"`
+	RolesJSON           map[string][]string `json:"roles"            table:"-"`
 }
 
 func (r whoamiRow) String() string {

--- a/coderd/chatd/chattool/execute.go
+++ b/coderd/chatd/chattool/execute.go
@@ -78,9 +78,9 @@ type ProcessToolOptions struct {
 
 // ExecuteArgs are the parameters accepted by the execute tool.
 type ExecuteArgs struct {
-	Command         string  `json:"command" description:"The shell command to execute."`
-	Timeout         *string `json:"timeout,omitempty" description:"Timeout duration (e.g. '30s', '5m'). Default is 10s. Only applies to foreground commands."`
-	WorkDir         *string `json:"workdir,omitempty" description:"Working directory for the command."`
+	Command         string  `json:"command"                     description:"The shell command to execute."`
+	Timeout         *string `json:"timeout,omitempty"           description:"Timeout duration (e.g. '30s', '5m'). Default is 10s. Only applies to foreground commands."`
+	WorkDir         *string `json:"workdir,omitempty"           description:"Working directory for the command."`
 	RunInBackground *bool   `json:"run_in_background,omitempty" description:"Run this command in the background without blocking. Use for long-running processes like dev servers, file watchers, or builds that run longer than 5 seconds. Do NOT use shell & to background processes — it will not work correctly. Always use this parameter instead."`
 }
 

--- a/coderd/database/types.go
+++ b/coderd/database/types.go
@@ -20,28 +20,28 @@ import (
 // AuditOAuthConvertState is never stored in the database. It is stored in a cookie
 // clientside as a JWT. This type is provided for audit logging purposes.
 type AuditOAuthConvertState struct {
-	CreatedAt time.Time `db:"created_at" json:"created_at"`
+	CreatedAt time.Time `json:"created_at" db:"created_at"`
 	// The time at which the state string expires, a merge request times out if the user does not perform it quick enough.
-	ExpiresAt     time.Time `db:"expires_at"      json:"expires_at"`
-	FromLoginType LoginType `db:"from_login_type" json:"from_login_type"`
+	ExpiresAt     time.Time `json:"expires_at"      db:"expires_at"`
+	FromLoginType LoginType `json:"from_login_type" db:"from_login_type"`
 	// The login type the user is converting to. Should be github or oidc.
-	ToLoginType LoginType `db:"to_login_type" json:"to_login_type"`
-	UserID      uuid.UUID `db:"user_id"       json:"user_id"`
+	ToLoginType LoginType `json:"to_login_type" db:"to_login_type"`
+	UserID      uuid.UUID `json:"user_id"       db:"user_id"`
 }
 
 type HealthSettings struct {
-	ID                    uuid.UUID `db:"id"                     json:"id"`
-	DismissedHealthchecks []string  `db:"dismissed_healthchecks" json:"dismissed_healthchecks"`
+	ID                    uuid.UUID `json:"id"                     db:"id"`
+	DismissedHealthchecks []string  `json:"dismissed_healthchecks" db:"dismissed_healthchecks"`
 }
 
 type NotificationsSettings struct {
-	ID             uuid.UUID `db:"id"              json:"id"`
-	NotifierPaused bool      `db:"notifier_paused" json:"notifier_paused"`
+	ID             uuid.UUID `json:"id"              db:"id"`
+	NotifierPaused bool      `json:"notifier_paused" db:"notifier_paused"`
 }
 
 type PrebuildsSettings struct {
-	ID                   uuid.UUID `db:"id"                    json:"id"`
-	ReconciliationPaused bool      `db:"reconciliation_paused" json:"reconciliation_paused"`
+	ID                   uuid.UUID `json:"id"                    db:"id"`
+	ReconciliationPaused bool      `json:"reconciliation_paused" db:"reconciliation_paused"`
 }
 
 type Actions []policy.Action
@@ -237,9 +237,9 @@ func (a CustomRolePermission) String() string {
 
 // NameOrganizationPair is used as a lookup tuple for custom role rows.
 type NameOrganizationPair struct {
-	Name string `db:"name" json:"name"`
+	Name string `json:"name" db:"name"`
 	// OrganizationID if unset will assume a null column value
-	OrganizationID uuid.UUID `db:"organization_id" json:"organization_id"`
+	OrganizationID uuid.UUID `json:"organization_id" db:"organization_id"`
 }
 
 func (*NameOrganizationPair) Scan(_ interface{}) error {
@@ -264,8 +264,8 @@ func (a NameOrganizationPair) Value() (driver.Value, error) {
 
 // AgentIDNamePair is used as a result tuple for workspace and agent rows.
 type AgentIDNamePair struct {
-	ID   uuid.UUID `db:"id"   json:"id"`
-	Name string    `db:"name" json:"name"`
+	ID   uuid.UUID `json:"id"   db:"id"`
+	Name string    `json:"name" db:"name"`
 }
 
 func (p *AgentIDNamePair) Scan(src interface{}) error {

--- a/coderd/database/types.go
+++ b/coderd/database/types.go
@@ -22,25 +22,25 @@ import (
 type AuditOAuthConvertState struct {
 	CreatedAt time.Time `db:"created_at" json:"created_at"`
 	// The time at which the state string expires, a merge request times out if the user does not perform it quick enough.
-	ExpiresAt     time.Time `db:"expires_at" json:"expires_at"`
+	ExpiresAt     time.Time `db:"expires_at"      json:"expires_at"`
 	FromLoginType LoginType `db:"from_login_type" json:"from_login_type"`
 	// The login type the user is converting to. Should be github or oidc.
 	ToLoginType LoginType `db:"to_login_type" json:"to_login_type"`
-	UserID      uuid.UUID `db:"user_id" json:"user_id"`
+	UserID      uuid.UUID `db:"user_id"       json:"user_id"`
 }
 
 type HealthSettings struct {
-	ID                    uuid.UUID `db:"id" json:"id"`
+	ID                    uuid.UUID `db:"id"                     json:"id"`
 	DismissedHealthchecks []string  `db:"dismissed_healthchecks" json:"dismissed_healthchecks"`
 }
 
 type NotificationsSettings struct {
-	ID             uuid.UUID `db:"id" json:"id"`
+	ID             uuid.UUID `db:"id"              json:"id"`
 	NotifierPaused bool      `db:"notifier_paused" json:"notifier_paused"`
 }
 
 type PrebuildsSettings struct {
-	ID                   uuid.UUID `db:"id" json:"id"`
+	ID                   uuid.UUID `db:"id"                    json:"id"`
 	ReconciliationPaused bool      `db:"reconciliation_paused" json:"reconciliation_paused"`
 }
 
@@ -264,7 +264,7 @@ func (a NameOrganizationPair) Value() (driver.Value, error) {
 
 // AgentIDNamePair is used as a result tuple for workspace and agent rows.
 type AgentIDNamePair struct {
-	ID   uuid.UUID `db:"id" json:"id"`
+	ID   uuid.UUID `db:"id"   json:"id"`
 	Name string    `db:"name" json:"name"`
 }
 

--- a/coderd/rbac/object.go
+++ b/coderd/rbac/object.go
@@ -38,8 +38,8 @@ type Object struct {
 	// Type is "workspace", "project", "app", etc
 	Type string `json:"type"`
 
-	ACLUserList  map[string][]policy.Action ` json:"acl_user_list"`
-	ACLGroupList map[string][]policy.Action ` json:"acl_group_list"`
+	ACLUserList  map[string][]policy.Action `json:"acl_user_list"`
+	ACLGroupList map[string][]policy.Action `json:"acl_group_list"`
 }
 
 // String is not perfect, but decent enough for human display

--- a/codersdk/agentsdk/agentsdk.go
+++ b/codersdk/agentsdk/agentsdk.go
@@ -517,9 +517,9 @@ const (
 )
 
 type AgentMetric struct {
-	Name   string             `json:"name"             validate:"required"`
-	Type   AgentMetricType    `json:"type"             validate:"required" enums:"counter,gauge"`
-	Value  float64            `json:"value"            validate:"required"`
+	Name   string             `json:"name"                                   validate:"required"`
+	Type   AgentMetricType    `json:"type"             enums:"counter,gauge" validate:"required"`
+	Value  float64            `json:"value"                                  validate:"required"`
 	Labels []AgentMetricLabel `json:"labels,omitempty"`
 }
 

--- a/codersdk/agentsdk/agentsdk.go
+++ b/codersdk/agentsdk/agentsdk.go
@@ -517,14 +517,14 @@ const (
 )
 
 type AgentMetric struct {
-	Name   string             `json:"name" validate:"required"`
-	Type   AgentMetricType    `json:"type" validate:"required" enums:"counter,gauge"`
-	Value  float64            `json:"value" validate:"required"`
+	Name   string             `json:"name"             validate:"required"`
+	Type   AgentMetricType    `json:"type"             validate:"required" enums:"counter,gauge"`
+	Value  float64            `json:"value"            validate:"required"`
 	Labels []AgentMetricLabel `json:"labels,omitempty"`
 }
 
 type AgentMetricLabel struct {
-	Name  string `json:"name" validate:"required"`
+	Name  string `json:"name"  validate:"required"`
 	Value string `json:"value" validate:"required"`
 }
 

--- a/codersdk/agentsdk/aws.go
+++ b/codersdk/agentsdk/aws.go
@@ -13,7 +13,7 @@ import (
 
 type AWSInstanceIdentityToken struct {
 	Signature string `json:"signature" validate:"required"`
-	Document  string `json:"document" validate:"required"`
+	Document  string `json:"document"  validate:"required"`
 }
 
 // AWSSessionTokenExchanger exchanges AWS instance metadata for a Coder session token.

--- a/codersdk/agentsdk/azure.go
+++ b/codersdk/agentsdk/azure.go
@@ -10,7 +10,7 @@ import (
 
 type AzureInstanceIdentityToken struct {
 	Signature string `json:"signature" validate:"required"`
-	Encoding  string `json:"encoding" validate:"required"`
+	Encoding  string `json:"encoding"  validate:"required"`
 }
 
 // AzureSessionTokenExchanger exchanges Azure attested metadata for a Coder session token.

--- a/codersdk/aibridge.go
+++ b/codersdk/aibridge.go
@@ -12,42 +12,42 @@ import (
 )
 
 type AIBridgeInterception struct {
-	ID          uuid.UUID            `json:"id" format:"uuid"`
+	ID          uuid.UUID            `json:"id"           format:"uuid"`
 	APIKeyID    *string              `json:"api_key_id"`
 	Initiator   MinimalUser          `json:"initiator"`
 	Provider    string               `json:"provider"`
 	Model       string               `json:"model"`
 	Client      *string              `json:"client"`
 	Metadata    map[string]any       `json:"metadata"`
-	StartedAt   time.Time            `json:"started_at" format:"date-time"`
-	EndedAt     *time.Time           `json:"ended_at" format:"date-time"`
+	StartedAt   time.Time            `json:"started_at"   format:"date-time"`
+	EndedAt     *time.Time           `json:"ended_at"     format:"date-time"`
 	TokenUsages []AIBridgeTokenUsage `json:"token_usages"`
 	UserPrompts []AIBridgeUserPrompt `json:"user_prompts"`
 	ToolUsages  []AIBridgeToolUsage  `json:"tool_usages"`
 }
 
 type AIBridgeTokenUsage struct {
-	ID                 uuid.UUID      `json:"id" format:"uuid"`
-	InterceptionID     uuid.UUID      `json:"interception_id" format:"uuid"`
+	ID                 uuid.UUID      `json:"id"                   format:"uuid"`
+	InterceptionID     uuid.UUID      `json:"interception_id"      format:"uuid"`
 	ProviderResponseID string         `json:"provider_response_id"`
 	InputTokens        int64          `json:"input_tokens"`
 	OutputTokens       int64          `json:"output_tokens"`
 	Metadata           map[string]any `json:"metadata"`
-	CreatedAt          time.Time      `json:"created_at" format:"date-time"`
+	CreatedAt          time.Time      `json:"created_at"           format:"date-time"`
 }
 
 type AIBridgeUserPrompt struct {
-	ID                 uuid.UUID      `json:"id" format:"uuid"`
-	InterceptionID     uuid.UUID      `json:"interception_id" format:"uuid"`
+	ID                 uuid.UUID      `json:"id"                   format:"uuid"`
+	InterceptionID     uuid.UUID      `json:"interception_id"      format:"uuid"`
 	ProviderResponseID string         `json:"provider_response_id"`
 	Prompt             string         `json:"prompt"`
 	Metadata           map[string]any `json:"metadata"`
-	CreatedAt          time.Time      `json:"created_at" format:"date-time"`
+	CreatedAt          time.Time      `json:"created_at"           format:"date-time"`
 }
 
 type AIBridgeToolUsage struct {
-	ID                 uuid.UUID      `json:"id" format:"uuid"`
-	InterceptionID     uuid.UUID      `json:"interception_id" format:"uuid"`
+	ID                 uuid.UUID      `json:"id"                   format:"uuid"`
+	InterceptionID     uuid.UUID      `json:"interception_id"      format:"uuid"`
 	ProviderResponseID string         `json:"provider_response_id"`
 	ServerURL          string         `json:"server_url"`
 	Tool               string         `json:"tool"`
@@ -55,7 +55,7 @@ type AIBridgeToolUsage struct {
 	Injected           bool           `json:"injected"`
 	InvocationError    string         `json:"invocation_error"`
 	Metadata           map[string]any `json:"metadata"`
-	CreatedAt          time.Time      `json:"created_at" format:"date-time"`
+	CreatedAt          time.Time      `json:"created_at"           format:"date-time"`
 }
 
 type AIBridgeListInterceptionsResponse struct {
@@ -73,7 +73,7 @@ type AIBridgeListInterceptionsFilter struct {
 	// Initiator is a user ID, username, or "me".
 	Initiator     string    `json:"initiator,omitempty"`
 	StartedBefore time.Time `json:"started_before,omitempty" format:"date-time"`
-	StartedAfter  time.Time `json:"started_after,omitempty" format:"date-time"`
+	StartedAfter  time.Time `json:"started_after,omitempty"  format:"date-time"`
 	Provider      string    `json:"provider,omitempty"`
 	Model         string    `json:"model,omitempty"`
 	Client        string    `json:"client,omitempty"`

--- a/codersdk/aitasks.go
+++ b/codersdk/aitasks.go
@@ -98,37 +98,37 @@ const (
 
 // Task represents a task.
 type Task struct {
-	ID                      uuid.UUID                `json:"id"                               format:"uuid"                                                                                table:"id"`
-	OrganizationID          uuid.UUID                `json:"organization_id"                  format:"uuid"                                                                                table:"organization id"`
-	OwnerID                 uuid.UUID                `json:"owner_id"                         format:"uuid"                                                                                table:"owner id"`
+	ID                      uuid.UUID                `json:"id"                               table:"id"                                                                                                                         format:"uuid"`
+	OrganizationID          uuid.UUID                `json:"organization_id"                  table:"organization id"                                                                                                            format:"uuid"`
+	OwnerID                 uuid.UUID                `json:"owner_id"                         table:"owner id"                                                                                                                   format:"uuid"`
 	OwnerName               string                   `json:"owner_name"                       table:"owner name"`
 	OwnerAvatarURL          string                   `json:"owner_avatar_url,omitempty"       table:"owner avatar url"`
 	Name                    string                   `json:"name"                             table:"name,default_sort"`
 	DisplayName             string                   `json:"display_name"                     table:"display_name"`
-	TemplateID              uuid.UUID                `json:"template_id"                      format:"uuid"                                                                                table:"template id"`
-	TemplateVersionID       uuid.UUID                `json:"template_version_id"              format:"uuid"                                                                                table:"template version id"`
+	TemplateID              uuid.UUID                `json:"template_id"                      table:"template id"                                                                                                                format:"uuid"`
+	TemplateVersionID       uuid.UUID                `json:"template_version_id"              table:"template version id"                                                                                                        format:"uuid"`
 	TemplateName            string                   `json:"template_name"                    table:"template name"`
 	TemplateDisplayName     string                   `json:"template_display_name"            table:"template display name"`
 	TemplateIcon            string                   `json:"template_icon"                    table:"template icon"`
-	WorkspaceID             uuid.NullUUID            `json:"workspace_id"                     format:"uuid"                                                                                table:"workspace id"`
+	WorkspaceID             uuid.NullUUID            `json:"workspace_id"                     table:"workspace id"                                                                                                               format:"uuid"`
 	WorkspaceName           string                   `json:"workspace_name"                   table:"workspace name"`
-	WorkspaceStatus         WorkspaceStatus          `json:"workspace_status,omitempty"       enums:"pending,starting,running,stopping,stopped,failed,canceling,canceled,deleting,deleted" table:"workspace status"`
+	WorkspaceStatus         WorkspaceStatus          `json:"workspace_status,omitempty"       table:"workspace status"              enums:"pending,starting,running,stopping,stopped,failed,canceling,canceled,deleting,deleted"`
 	WorkspaceBuildNumber    int32                    `json:"workspace_build_number,omitempty" table:"workspace build number"`
-	WorkspaceAgentID        uuid.NullUUID            `json:"workspace_agent_id"               format:"uuid"                                                                                table:"workspace agent id"`
+	WorkspaceAgentID        uuid.NullUUID            `json:"workspace_agent_id"               table:"workspace agent id"                                                                                                         format:"uuid"`
 	WorkspaceAgentLifecycle *WorkspaceAgentLifecycle `json:"workspace_agent_lifecycle"        table:"workspace agent lifecycle"`
 	WorkspaceAgentHealth    *WorkspaceAgentHealth    `json:"workspace_agent_health"           table:"workspace agent health"`
-	WorkspaceAppID          uuid.NullUUID            `json:"workspace_app_id"                 format:"uuid"                                                                                table:"workspace app id"`
+	WorkspaceAppID          uuid.NullUUID            `json:"workspace_app_id"                 table:"workspace app id"                                                                                                           format:"uuid"`
 	InitialPrompt           string                   `json:"initial_prompt"                   table:"initial prompt"`
-	Status                  TaskStatus               `json:"status"                           enums:"pending,initializing,active,paused,unknown,error"                                     table:"status"`
+	Status                  TaskStatus               `json:"status"                           table:"status"                        enums:"pending,initializing,active,paused,unknown,error"`
 	CurrentState            *TaskStateEntry          `json:"current_state"                    table:"cs,recursive_inline,empty_nil"`
-	CreatedAt               time.Time                `json:"created_at"                       format:"date-time"                                                                           table:"created at"`
-	UpdatedAt               time.Time                `json:"updated_at"                       format:"date-time"                                                                           table:"updated at"`
+	CreatedAt               time.Time                `json:"created_at"                       table:"created at"                                                                                                                 format:"date-time"`
+	UpdatedAt               time.Time                `json:"updated_at"                       table:"updated at"                                                                                                                 format:"date-time"`
 }
 
 // TaskStateEntry represents a single entry in the task's state history.
 type TaskStateEntry struct {
-	Timestamp time.Time `json:"timestamp" format:"date-time"                   table:"-"`
-	State     TaskState `json:"state"     enum:"working,idle,completed,failed" table:"state"`
+	Timestamp time.Time `json:"timestamp" table:"-"                                            format:"date-time"`
+	State     TaskState `json:"state"     table:"state"   enum:"working,idle,completed,failed"`
 	Message   string    `json:"message"   table:"message"`
 	URI       string    `json:"uri"       table:"-"`
 }
@@ -389,8 +389,8 @@ const (
 type TaskLogEntry struct {
 	ID      int         `json:"id"      table:"id"`
 	Content string      `json:"content" table:"content"`
-	Type    TaskLogType `json:"type"    enum:"input,output" table:"type"`
-	Time    time.Time   `json:"time"    format:"date-time"  table:"time,default_sort"`
+	Type    TaskLogType `json:"type"    table:"type"              enum:"input,output"`
+	Time    time.Time   `json:"time"    table:"time,default_sort"                     format:"date-time"`
 }
 
 // TaskLogsResponse contains task logs and metadata. When snapshot is false,

--- a/codersdk/aitasks.go
+++ b/codersdk/aitasks.go
@@ -14,7 +14,7 @@ import (
 
 // CreateTaskRequest represents the request to create a new task.
 type CreateTaskRequest struct {
-	TemplateVersionID       uuid.UUID `json:"template_version_id" format:"uuid"`
+	TemplateVersionID       uuid.UUID `json:"template_version_id"                  format:"uuid"`
 	TemplateVersionPresetID uuid.UUID `json:"template_version_preset_id,omitempty" format:"uuid"`
 	Input                   string    `json:"input"`
 	Name                    string    `json:"name,omitempty"`
@@ -98,39 +98,39 @@ const (
 
 // Task represents a task.
 type Task struct {
-	ID                      uuid.UUID                `json:"id" format:"uuid" table:"id"`
-	OrganizationID          uuid.UUID                `json:"organization_id" format:"uuid" table:"organization id"`
-	OwnerID                 uuid.UUID                `json:"owner_id" format:"uuid" table:"owner id"`
-	OwnerName               string                   `json:"owner_name" table:"owner name"`
-	OwnerAvatarURL          string                   `json:"owner_avatar_url,omitempty" table:"owner avatar url"`
-	Name                    string                   `json:"name" table:"name,default_sort"`
-	DisplayName             string                   `json:"display_name" table:"display_name"`
-	TemplateID              uuid.UUID                `json:"template_id" format:"uuid" table:"template id"`
-	TemplateVersionID       uuid.UUID                `json:"template_version_id" format:"uuid" table:"template version id"`
-	TemplateName            string                   `json:"template_name" table:"template name"`
-	TemplateDisplayName     string                   `json:"template_display_name" table:"template display name"`
-	TemplateIcon            string                   `json:"template_icon" table:"template icon"`
-	WorkspaceID             uuid.NullUUID            `json:"workspace_id" format:"uuid" table:"workspace id"`
-	WorkspaceName           string                   `json:"workspace_name" table:"workspace name"`
-	WorkspaceStatus         WorkspaceStatus          `json:"workspace_status,omitempty" enums:"pending,starting,running,stopping,stopped,failed,canceling,canceled,deleting,deleted" table:"workspace status"`
+	ID                      uuid.UUID                `json:"id"                               format:"uuid"                                                                                table:"id"`
+	OrganizationID          uuid.UUID                `json:"organization_id"                  format:"uuid"                                                                                table:"organization id"`
+	OwnerID                 uuid.UUID                `json:"owner_id"                         format:"uuid"                                                                                table:"owner id"`
+	OwnerName               string                   `json:"owner_name"                       table:"owner name"`
+	OwnerAvatarURL          string                   `json:"owner_avatar_url,omitempty"       table:"owner avatar url"`
+	Name                    string                   `json:"name"                             table:"name,default_sort"`
+	DisplayName             string                   `json:"display_name"                     table:"display_name"`
+	TemplateID              uuid.UUID                `json:"template_id"                      format:"uuid"                                                                                table:"template id"`
+	TemplateVersionID       uuid.UUID                `json:"template_version_id"              format:"uuid"                                                                                table:"template version id"`
+	TemplateName            string                   `json:"template_name"                    table:"template name"`
+	TemplateDisplayName     string                   `json:"template_display_name"            table:"template display name"`
+	TemplateIcon            string                   `json:"template_icon"                    table:"template icon"`
+	WorkspaceID             uuid.NullUUID            `json:"workspace_id"                     format:"uuid"                                                                                table:"workspace id"`
+	WorkspaceName           string                   `json:"workspace_name"                   table:"workspace name"`
+	WorkspaceStatus         WorkspaceStatus          `json:"workspace_status,omitempty"       enums:"pending,starting,running,stopping,stopped,failed,canceling,canceled,deleting,deleted" table:"workspace status"`
 	WorkspaceBuildNumber    int32                    `json:"workspace_build_number,omitempty" table:"workspace build number"`
-	WorkspaceAgentID        uuid.NullUUID            `json:"workspace_agent_id" format:"uuid" table:"workspace agent id"`
-	WorkspaceAgentLifecycle *WorkspaceAgentLifecycle `json:"workspace_agent_lifecycle" table:"workspace agent lifecycle"`
-	WorkspaceAgentHealth    *WorkspaceAgentHealth    `json:"workspace_agent_health" table:"workspace agent health"`
-	WorkspaceAppID          uuid.NullUUID            `json:"workspace_app_id" format:"uuid" table:"workspace app id"`
-	InitialPrompt           string                   `json:"initial_prompt" table:"initial prompt"`
-	Status                  TaskStatus               `json:"status" enums:"pending,initializing,active,paused,unknown,error" table:"status"`
-	CurrentState            *TaskStateEntry          `json:"current_state" table:"cs,recursive_inline,empty_nil"`
-	CreatedAt               time.Time                `json:"created_at" format:"date-time" table:"created at"`
-	UpdatedAt               time.Time                `json:"updated_at" format:"date-time" table:"updated at"`
+	WorkspaceAgentID        uuid.NullUUID            `json:"workspace_agent_id"               format:"uuid"                                                                                table:"workspace agent id"`
+	WorkspaceAgentLifecycle *WorkspaceAgentLifecycle `json:"workspace_agent_lifecycle"        table:"workspace agent lifecycle"`
+	WorkspaceAgentHealth    *WorkspaceAgentHealth    `json:"workspace_agent_health"           table:"workspace agent health"`
+	WorkspaceAppID          uuid.NullUUID            `json:"workspace_app_id"                 format:"uuid"                                                                                table:"workspace app id"`
+	InitialPrompt           string                   `json:"initial_prompt"                   table:"initial prompt"`
+	Status                  TaskStatus               `json:"status"                           enums:"pending,initializing,active,paused,unknown,error"                                     table:"status"`
+	CurrentState            *TaskStateEntry          `json:"current_state"                    table:"cs,recursive_inline,empty_nil"`
+	CreatedAt               time.Time                `json:"created_at"                       format:"date-time"                                                                           table:"created at"`
+	UpdatedAt               time.Time                `json:"updated_at"                       format:"date-time"                                                                           table:"updated at"`
 }
 
 // TaskStateEntry represents a single entry in the task's state history.
 type TaskStateEntry struct {
-	Timestamp time.Time `json:"timestamp" format:"date-time" table:"-"`
-	State     TaskState `json:"state" enum:"working,idle,completed,failed" table:"state"`
-	Message   string    `json:"message" table:"message"`
-	URI       string    `json:"uri" table:"-"`
+	Timestamp time.Time `json:"timestamp" format:"date-time"                   table:"-"`
+	State     TaskState `json:"state"     enum:"working,idle,completed,failed" table:"state"`
+	Message   string    `json:"message"   table:"message"`
+	URI       string    `json:"uri"       table:"-"`
 }
 
 // TasksFilter filters the list of tasks.
@@ -387,10 +387,10 @@ const (
 
 // TaskLogEntry represents a single log entry for a task.
 type TaskLogEntry struct {
-	ID      int         `json:"id" table:"id"`
+	ID      int         `json:"id"      table:"id"`
 	Content string      `json:"content" table:"content"`
-	Type    TaskLogType `json:"type" enum:"input,output" table:"type"`
-	Time    time.Time   `json:"time" format:"date-time" table:"time,default_sort"`
+	Type    TaskLogType `json:"type"    enum:"input,output" table:"type"`
+	Time    time.Time   `json:"time"    format:"date-time"  table:"time,default_sort"`
 }
 
 // TaskLogsResponse contains task logs and metadata. When snapshot is false,

--- a/codersdk/apikey.go
+++ b/codersdk/apikey.go
@@ -12,16 +12,16 @@ import (
 
 // APIKey: do not ever return the HashedSecret
 type APIKey struct {
-	ID              string               `json:"id" validate:"required"`
-	UserID          uuid.UUID            `json:"user_id" validate:"required" format:"uuid"`
-	LastUsed        time.Time            `json:"last_used" validate:"required" format:"date-time"`
-	ExpiresAt       time.Time            `json:"expires_at" validate:"required" format:"date-time"`
-	CreatedAt       time.Time            `json:"created_at" validate:"required" format:"date-time"`
-	UpdatedAt       time.Time            `json:"updated_at" validate:"required" format:"date-time"`
-	LoginType       LoginType            `json:"login_type" validate:"required" enums:"password,github,oidc,token"`
-	Scope           APIKeyScope          `json:"scope" enums:"all,application_connect"` // Deprecated: use Scopes instead.
+	ID              string               `json:"id"               validate:"required"`
+	UserID          uuid.UUID            `json:"user_id"          validate:"required"             format:"uuid"`
+	LastUsed        time.Time            `json:"last_used"        validate:"required"             format:"date-time"`
+	ExpiresAt       time.Time            `json:"expires_at"       validate:"required"             format:"date-time"`
+	CreatedAt       time.Time            `json:"created_at"       validate:"required"             format:"date-time"`
+	UpdatedAt       time.Time            `json:"updated_at"       validate:"required"             format:"date-time"`
+	LoginType       LoginType            `json:"login_type"       validate:"required"             enums:"password,github,oidc,token"`
+	Scope           APIKeyScope          `json:"scope"            enums:"all,application_connect"` // Deprecated: use Scopes instead.
 	Scopes          []APIKeyScope        `json:"scopes"`
-	TokenName       string               `json:"token_name" validate:"required"`
+	TokenName       string               `json:"token_name"       validate:"required"`
 	LifetimeSeconds int64                `json:"lifetime_seconds" validate:"required"`
 	AllowList       []APIAllowListTarget `json:"allow_list"`
 }

--- a/codersdk/apikey.go
+++ b/codersdk/apikey.go
@@ -12,17 +12,17 @@ import (
 
 // APIKey: do not ever return the HashedSecret
 type APIKey struct {
-	ID              string               `json:"id"               validate:"required"`
-	UserID          uuid.UUID            `json:"user_id"          validate:"required"             format:"uuid"`
-	LastUsed        time.Time            `json:"last_used"        validate:"required"             format:"date-time"`
-	ExpiresAt       time.Time            `json:"expires_at"       validate:"required"             format:"date-time"`
-	CreatedAt       time.Time            `json:"created_at"       validate:"required"             format:"date-time"`
-	UpdatedAt       time.Time            `json:"updated_at"       validate:"required"             format:"date-time"`
-	LoginType       LoginType            `json:"login_type"       validate:"required"             enums:"password,github,oidc,token"`
+	ID              string               `json:"id"                                                                     validate:"required"`
+	UserID          uuid.UUID            `json:"user_id"                                             format:"uuid"      validate:"required"`
+	LastUsed        time.Time            `json:"last_used"                                           format:"date-time" validate:"required"`
+	ExpiresAt       time.Time            `json:"expires_at"                                          format:"date-time" validate:"required"`
+	CreatedAt       time.Time            `json:"created_at"                                          format:"date-time" validate:"required"`
+	UpdatedAt       time.Time            `json:"updated_at"                                          format:"date-time" validate:"required"`
+	LoginType       LoginType            `json:"login_type"       enums:"password,github,oidc,token"                    validate:"required"`
 	Scope           APIKeyScope          `json:"scope"            enums:"all,application_connect"` // Deprecated: use Scopes instead.
 	Scopes          []APIKeyScope        `json:"scopes"`
-	TokenName       string               `json:"token_name"       validate:"required"`
-	LifetimeSeconds int64                `json:"lifetime_seconds" validate:"required"`
+	TokenName       string               `json:"token_name"                                                             validate:"required"`
+	LifetimeSeconds int64                `json:"lifetime_seconds"                                                       validate:"required"`
 	AllowList       []APIAllowListTarget `json:"allow_list"`
 }
 

--- a/codersdk/audit.go
+++ b/codersdk/audit.go
@@ -178,13 +178,13 @@ type AuditDiffField struct {
 }
 
 type AuditLog struct {
-	ID           uuid.UUID    `json:"id" format:"uuid"`
-	RequestID    uuid.UUID    `json:"request_id" format:"uuid"`
-	Time         time.Time    `json:"time" format:"date-time"`
+	ID           uuid.UUID    `json:"id"            format:"uuid"`
+	RequestID    uuid.UUID    `json:"request_id"    format:"uuid"`
+	Time         time.Time    `json:"time"          format:"date-time"`
 	IP           netip.Addr   `json:"ip"`
 	UserAgent    string       `json:"user_agent"`
 	ResourceType ResourceType `json:"resource_type"`
-	ResourceID   uuid.UUID    `json:"resource_id" format:"uuid"`
+	ResourceID   uuid.UUID    `json:"resource_id"   format:"uuid"`
 	// ResourceTarget is the name of the resource.
 	ResourceTarget   string          `json:"resource_target"`
 	ResourceIcon     string          `json:"resource_icon"`
@@ -215,14 +215,14 @@ type AuditLogResponse struct {
 }
 
 type CreateTestAuditLogRequest struct {
-	Action           AuditAction     `json:"action,omitempty" enums:"create,write,delete,start,stop"`
-	ResourceType     ResourceType    `json:"resource_type,omitempty" enums:"template,template_version,user,workspace,workspace_build,git_ssh_key,auditable_group"`
-	ResourceID       uuid.UUID       `json:"resource_id,omitempty" format:"uuid"`
+	Action           AuditAction     `json:"action,omitempty"            enums:"create,write,delete,start,stop"`
+	ResourceType     ResourceType    `json:"resource_type,omitempty"     enums:"template,template_version,user,workspace,workspace_build,git_ssh_key,auditable_group"`
+	ResourceID       uuid.UUID       `json:"resource_id,omitempty"       format:"uuid"`
 	AdditionalFields json.RawMessage `json:"additional_fields,omitempty"`
-	Time             time.Time       `json:"time,omitempty" format:"date-time"`
-	BuildReason      BuildReason     `json:"build_reason,omitempty" enums:"autostart,autostop,initiator"`
-	OrganizationID   uuid.UUID       `json:"organization_id,omitempty" format:"uuid"`
-	RequestID        uuid.UUID       `json:"request_id,omitempty" format:"uuid"`
+	Time             time.Time       `json:"time,omitempty"              format:"date-time"`
+	BuildReason      BuildReason     `json:"build_reason,omitempty"      enums:"autostart,autostop,initiator"`
+	OrganizationID   uuid.UUID       `json:"organization_id,omitempty"   format:"uuid"`
+	RequestID        uuid.UUID       `json:"request_id,omitempty"        format:"uuid"`
 }
 
 // AuditLogs retrieves audit logs from the given page.

--- a/codersdk/audit.go
+++ b/codersdk/audit.go
@@ -217,12 +217,12 @@ type AuditLogResponse struct {
 type CreateTestAuditLogRequest struct {
 	Action           AuditAction     `json:"action,omitempty"            enums:"create,write,delete,start,stop"`
 	ResourceType     ResourceType    `json:"resource_type,omitempty"     enums:"template,template_version,user,workspace,workspace_build,git_ssh_key,auditable_group"`
-	ResourceID       uuid.UUID       `json:"resource_id,omitempty"       format:"uuid"`
+	ResourceID       uuid.UUID       `json:"resource_id,omitempty"                                                                                                    format:"uuid"`
 	AdditionalFields json.RawMessage `json:"additional_fields,omitempty"`
-	Time             time.Time       `json:"time,omitempty"              format:"date-time"`
+	Time             time.Time       `json:"time,omitempty"                                                                                                           format:"date-time"`
 	BuildReason      BuildReason     `json:"build_reason,omitempty"      enums:"autostart,autostop,initiator"`
-	OrganizationID   uuid.UUID       `json:"organization_id,omitempty"   format:"uuid"`
-	RequestID        uuid.UUID       `json:"request_id,omitempty"        format:"uuid"`
+	OrganizationID   uuid.UUID       `json:"organization_id,omitempty"                                                                                                format:"uuid"`
+	RequestID        uuid.UUID       `json:"request_id,omitempty"                                                                                                     format:"uuid"`
 }
 
 // AuditLogs retrieves audit logs from the given page.

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -36,28 +36,28 @@ const (
 
 // Chat represents a chat session with an AI agent.
 type Chat struct {
-	ID                uuid.UUID       `json:"id" format:"uuid"`
-	OwnerID           uuid.UUID       `json:"owner_id" format:"uuid"`
-	WorkspaceID       *uuid.UUID      `json:"workspace_id,omitempty" format:"uuid"`
+	ID                uuid.UUID       `json:"id"                       format:"uuid"`
+	OwnerID           uuid.UUID       `json:"owner_id"                 format:"uuid"`
+	WorkspaceID       *uuid.UUID      `json:"workspace_id,omitempty"   format:"uuid"`
 	ParentChatID      *uuid.UUID      `json:"parent_chat_id,omitempty" format:"uuid"`
-	RootChatID        *uuid.UUID      `json:"root_chat_id,omitempty" format:"uuid"`
-	LastModelConfigID uuid.UUID       `json:"last_model_config_id" format:"uuid"`
+	RootChatID        *uuid.UUID      `json:"root_chat_id,omitempty"   format:"uuid"`
+	LastModelConfigID uuid.UUID       `json:"last_model_config_id"     format:"uuid"`
 	Title             string          `json:"title"`
 	Status            ChatStatus      `json:"status"`
 	LastError         *string         `json:"last_error"`
 	DiffStatus        *ChatDiffStatus `json:"diff_status,omitempty"`
-	CreatedAt         time.Time       `json:"created_at" format:"date-time"`
-	UpdatedAt         time.Time       `json:"updated_at" format:"date-time"`
+	CreatedAt         time.Time       `json:"created_at"               format:"date-time"`
+	UpdatedAt         time.Time       `json:"updated_at"               format:"date-time"`
 	Archived          bool            `json:"archived"`
 }
 
 // ChatMessage represents a single message in a chat.
 type ChatMessage struct {
 	ID            int64             `json:"id"`
-	ChatID        uuid.UUID         `json:"chat_id" format:"uuid"`
-	CreatedBy     *uuid.UUID        `json:"created_by,omitempty" format:"uuid"`
+	ChatID        uuid.UUID         `json:"chat_id"                   format:"uuid"`
+	CreatedBy     *uuid.UUID        `json:"created_by,omitempty"      format:"uuid"`
 	ModelConfigID *uuid.UUID        `json:"model_config_id,omitempty" format:"uuid"`
-	CreatedAt     time.Time         `json:"created_at" format:"date-time"`
+	CreatedAt     time.Time         `json:"created_at"                format:"date-time"`
 	Role          ChatMessageRole   `json:"role"`
 	Content       []ChatMessagePart `json:"content,omitempty"`
 	Usage         *ChatMessageUsage `json:"usage,omitempty"`
@@ -98,19 +98,6 @@ const (
 	ChatMessagePartTypeFileReference ChatMessagePartType = "file-reference"
 )
 
-// AllChatMessagePartTypes returns all known ChatMessagePartType values.
-func AllChatMessagePartTypes() []ChatMessagePartType {
-	return []ChatMessagePartType{
-		ChatMessagePartTypeText,
-		ChatMessagePartTypeReasoning,
-		ChatMessagePartTypeToolCall,
-		ChatMessagePartTypeToolResult,
-		ChatMessagePartTypeSource,
-		ChatMessagePartTypeFile,
-		ChatMessagePartTypeFileReference,
-	}
-}
-
 // ChatMessagePart is a structured chunk of a chat message.
 //
 // WARNING: This type is both an API wire type and a database
@@ -119,41 +106,37 @@ func AllChatMessagePartTypes() []ChatMessagePartType {
 // changes, and omitempty behavior all affect backward-compatible
 // deserialization of stored rows. Treat changes to this struct
 // with the same care as a database migration.
-//
-// The variants struct tag declares which discriminated-union
-// variants include each field in the generated TypeScript. Bare
-// name = required, ? suffix = optional. Fields without a variants
-// tag are excluded from the generated union. See
-// scripts/apitypings/main.go for the codegen that reads these.
 type ChatMessagePart struct {
 	Type        ChatMessagePartType `json:"type"`
-	Text        string              `json:"text,omitempty" variants:"text,reasoning"`
+	Text        string              `json:"text,omitempty"`
 	Signature   string              `json:"signature,omitempty"`
-	ToolCallID  string              `json:"tool_call_id,omitempty" variants:"tool-call,tool-result"`
-	ToolName    string              `json:"tool_name,omitempty" variants:"tool-call,tool-result"`
-	Args        json.RawMessage     `json:"args,omitempty" variants:"tool-call?"`
-	ArgsDelta   string              `json:"args_delta,omitempty" variants:"tool-call?"`
-	Result      json.RawMessage     `json:"result,omitempty" variants:"tool-result?"`
+	ToolCallID  string              `json:"tool_call_id,omitempty"`
+	ToolName    string              `json:"tool_name,omitempty"`
+	Args        json.RawMessage     `json:"args,omitempty"`
+	ArgsDelta   string              `json:"args_delta,omitempty"`
+	Result      json.RawMessage     `json:"result,omitempty"`
 	ResultDelta string              `json:"result_delta,omitempty"`
-	IsError     bool                `json:"is_error,omitempty" variants:"tool-result?"`
-	SourceID    string              `json:"source_id,omitempty" variants:"source?"`
-	URL         string              `json:"url,omitempty" variants:"source"`
-	Title       string              `json:"title,omitempty" variants:"source?"`
-	MediaType   string              `json:"media_type,omitempty" variants:"file"`
-	Data        []byte              `json:"data,omitempty" variants:"file?"`
-	FileID      uuid.NullUUID       `json:"file_id,omitempty" format:"uuid" variants:"file?"`
-	FileName    string              `json:"file_name,omitempty" variants:"file-reference"`
-	StartLine   int                 `json:"start_line,omitempty" variants:"file-reference"`
-	EndLine     int                 `json:"end_line,omitempty" variants:"file-reference"`
+	IsError     bool                `json:"is_error,omitempty"`
+	SourceID    string              `json:"source_id,omitempty"`
+	URL         string              `json:"url,omitempty"`
+	Title       string              `json:"title,omitempty"`
+	MediaType   string              `json:"media_type,omitempty"`
+	Data        []byte              `json:"data,omitempty"`
+	FileID      uuid.NullUUID       `json:"file_id,omitempty"      format:"uuid"`
+	// The following fields are only set when Type is
+	// ChatInputPartTypeFileReference.
+	FileName  string `json:"file_name,omitempty"`
+	StartLine int    `json:"start_line,omitempty"`
+	EndLine   int    `json:"end_line,omitempty"`
 	// The code content from the diff that was commented on.
-	Content string `json:"content,omitempty" variants:"file-reference"`
+	Content string `json:"content,omitempty"`
 	// ProviderMetadata holds provider-specific response metadata
 	// (e.g. Anthropic cache control hints) as raw JSON. Internal
 	// only: stripped by db2sdk before API responses.
 	ProviderMetadata json.RawMessage `json:"provider_metadata,omitempty" typescript:"-"`
 	// ProviderExecuted indicates the tool call was executed by
 	// the provider (e.g. Anthropic computer use).
-	ProviderExecuted bool `json:"provider_executed,omitempty" variants:"tool-call?,tool-result?"`
+	ProviderExecuted bool `json:"provider_executed,omitempty"`
 }
 
 // StripInternal removes internal-only fields that must not be
@@ -256,7 +239,7 @@ type ChatInputPart struct {
 // CreateChatRequest is the request to create a new chat.
 type CreateChatRequest struct {
 	Content       []ChatInputPart `json:"content"`
-	WorkspaceID   *uuid.UUID      `json:"workspace_id,omitempty" format:"uuid"`
+	WorkspaceID   *uuid.UUID      `json:"workspace_id,omitempty"    format:"uuid"`
 	ModelConfigID *uuid.UUID      `json:"model_config_id,omitempty" format:"uuid"`
 }
 
@@ -358,7 +341,7 @@ const (
 
 // ChatProviderConfig is an admin-managed provider configuration.
 type ChatProviderConfig struct {
-	ID          uuid.UUID                `json:"id" format:"uuid"`
+	ID          uuid.UUID                `json:"id"                   format:"uuid"`
 	Provider    string                   `json:"provider"`
 	DisplayName string                   `json:"display_name"`
 	Enabled     bool                     `json:"enabled"`
@@ -388,7 +371,7 @@ type UpdateChatProviderConfigRequest struct {
 
 // ChatModelConfig is an admin-managed model configuration.
 type ChatModelConfig struct {
-	ID                   uuid.UUID            `json:"id" format:"uuid"`
+	ID                   uuid.UUID            `json:"id"                     format:"uuid"`
 	Provider             string               `json:"provider"`
 	Model                string               `json:"model"`
 	DisplayName          string               `json:"display_name"`
@@ -397,8 +380,8 @@ type ChatModelConfig struct {
 	ContextLimit         int64                `json:"context_limit"`
 	CompressionThreshold int32                `json:"compression_threshold"`
 	ModelConfig          *ChatModelCallConfig `json:"model_config,omitempty"`
-	CreatedAt            time.Time            `json:"created_at" format:"date-time"`
-	UpdatedAt            time.Time            `json:"updated_at" format:"date-time"`
+	CreatedAt            time.Time            `json:"created_at"             format:"date-time"`
+	UpdatedAt            time.Time            `json:"updated_at"             format:"date-time"`
 }
 
 // ChatModelProviderOptions contains typed provider-specific options.
@@ -416,29 +399,29 @@ type ChatModelProviderOptions struct {
 
 // ChatModelOpenAIProviderOptions configures OpenAI provider behavior.
 type ChatModelOpenAIProviderOptions struct {
-	Include             []string         `json:"include,omitempty" description:"Model names to include in discovery" hidden:"true"`
-	Instructions        *string          `json:"instructions,omitempty" description:"System-level instructions prepended to the conversation" hidden:"true"`
-	LogitBias           map[string]int64 `json:"logit_bias,omitempty" description:"Token IDs mapped to bias values from -100 to 100" hidden:"true"`
-	LogProbs            *bool            `json:"log_probs,omitempty" description:"Whether to return log probabilities of output tokens" hidden:"true"`
-	TopLogProbs         *int64           `json:"top_log_probs,omitempty" description:"Number of most likely tokens to return log probabilities for" hidden:"true"`
-	MaxToolCalls        *int64           `json:"max_tool_calls,omitempty" description:"Maximum number of tool calls per response"`
-	ParallelToolCalls   *bool            `json:"parallel_tool_calls,omitempty" description:"Whether the model may make multiple tool calls in parallel"`
-	User                *string          `json:"user,omitempty" description:"Unique identifier for the end user for abuse monitoring" hidden:"true"`
-	ReasoningEffort     *string          `json:"reasoning_effort,omitempty" description:"Controls the level of reasoning effort" enum:"none,minimal,low,medium,high,xhigh"`
-	ReasoningSummary    *string          `json:"reasoning_summary,omitempty" description:"Controls whether reasoning tokens are summarized in the response"`
+	Include             []string         `json:"include,omitempty"               description:"Model names to include in discovery"                                              hidden:"true"`
+	Instructions        *string          `json:"instructions,omitempty"          description:"System-level instructions prepended to the conversation"                          hidden:"true"`
+	LogitBias           map[string]int64 `json:"logit_bias,omitempty"            description:"Token IDs mapped to bias values from -100 to 100"                                 hidden:"true"`
+	LogProbs            *bool            `json:"log_probs,omitempty"             description:"Whether to return log probabilities of output tokens"                             hidden:"true"`
+	TopLogProbs         *int64           `json:"top_log_probs,omitempty"         description:"Number of most likely tokens to return log probabilities for"                     hidden:"true"`
+	MaxToolCalls        *int64           `json:"max_tool_calls,omitempty"        description:"Maximum number of tool calls per response"`
+	ParallelToolCalls   *bool            `json:"parallel_tool_calls,omitempty"   description:"Whether the model may make multiple tool calls in parallel"`
+	User                *string          `json:"user,omitempty"                  description:"Unique identifier for the end user for abuse monitoring"                          hidden:"true"`
+	ReasoningEffort     *string          `json:"reasoning_effort,omitempty"      description:"Controls the level of reasoning effort"                                           enum:"none,minimal,low,medium,high,xhigh"`
+	ReasoningSummary    *string          `json:"reasoning_summary,omitempty"     description:"Controls whether reasoning tokens are summarized in the response"`
 	MaxCompletionTokens *int64           `json:"max_completion_tokens,omitempty" description:"Upper bound on tokens the model may generate"`
-	TextVerbosity       *string          `json:"text_verbosity,omitempty" description:"Controls the verbosity of the text response" enum:"low,medium,high"`
-	Prediction          map[string]any   `json:"prediction,omitempty" description:"Predicted output content to speed up responses" hidden:"true"`
-	Store               *bool            `json:"store,omitempty" description:"Whether to store the output for model distillation or evals" hidden:"true"`
-	Metadata            map[string]any   `json:"metadata,omitempty" description:"Arbitrary metadata to attach to the request" hidden:"true"`
-	PromptCacheKey      *string          `json:"prompt_cache_key,omitempty" description:"Key for enabling cross-request prompt caching"`
-	SafetyIdentifier    *string          `json:"safety_identifier,omitempty" description:"Developer-specific safety identifier for the request" hidden:"true"`
-	ServiceTier         *string          `json:"service_tier,omitempty" description:"Latency tier to use for processing the request"`
-	StructuredOutputs   *bool            `json:"structured_outputs,omitempty" description:"Whether to enable structured JSON output mode" hidden:"true"`
-	StrictJSONSchema    *bool            `json:"strict_json_schema,omitempty" description:"Whether to enforce strict adherence to the JSON schema" hidden:"true"`
-	WebSearchEnabled    *bool            `json:"web_search_enabled,omitempty" description:"Enable OpenAI web search tool for grounding responses with real-time information"`
-	SearchContextSize   *string          `json:"search_context_size,omitempty" description:"Amount of search context to use" enum:"low,medium,high"`
-	AllowedDomains      []string         `json:"allowed_domains,omitempty" description:"Restrict web search to these domains"`
+	TextVerbosity       *string          `json:"text_verbosity,omitempty"        description:"Controls the verbosity of the text response"                                      enum:"low,medium,high"`
+	Prediction          map[string]any   `json:"prediction,omitempty"            description:"Predicted output content to speed up responses"                                   hidden:"true"`
+	Store               *bool            `json:"store,omitempty"                 description:"Whether to store the output for model distillation or evals"                      hidden:"true"`
+	Metadata            map[string]any   `json:"metadata,omitempty"              description:"Arbitrary metadata to attach to the request"                                      hidden:"true"`
+	PromptCacheKey      *string          `json:"prompt_cache_key,omitempty"      description:"Key for enabling cross-request prompt caching"`
+	SafetyIdentifier    *string          `json:"safety_identifier,omitempty"     description:"Developer-specific safety identifier for the request"                             hidden:"true"`
+	ServiceTier         *string          `json:"service_tier,omitempty"          description:"Latency tier to use for processing the request"`
+	StructuredOutputs   *bool            `json:"structured_outputs,omitempty"    description:"Whether to enable structured JSON output mode"                                    hidden:"true"`
+	StrictJSONSchema    *bool            `json:"strict_json_schema,omitempty"    description:"Whether to enforce strict adherence to the JSON schema"                           hidden:"true"`
+	WebSearchEnabled    *bool            `json:"web_search_enabled,omitempty"    description:"Enable OpenAI web search tool for grounding responses with real-time information"`
+	SearchContextSize   *string          `json:"search_context_size,omitempty"   description:"Amount of search context to use"                                                  enum:"low,medium,high"`
+	AllowedDomains      []string         `json:"allowed_domains,omitempty"       description:"Restrict web search to these domains"`
 }
 
 // ChatModelAnthropicThinkingOptions configures Anthropic thinking budget.
@@ -448,111 +431,111 @@ type ChatModelAnthropicThinkingOptions struct {
 
 // ChatModelAnthropicProviderOptions configures Anthropic provider behavior.
 type ChatModelAnthropicProviderOptions struct {
-	SendReasoning          *bool                              `json:"send_reasoning,omitempty" description:"Whether to include reasoning content in the response"`
-	Thinking               *ChatModelAnthropicThinkingOptions `json:"thinking,omitempty" description:"Configuration for extended thinking"`
-	Effort                 *string                            `json:"effort,omitempty" description:"Controls the level of reasoning effort" enum:"low,medium,high,max"`
+	SendReasoning          *bool                              `json:"send_reasoning,omitempty"            description:"Whether to include reasoning content in the response"`
+	Thinking               *ChatModelAnthropicThinkingOptions `json:"thinking,omitempty"                  description:"Configuration for extended thinking"`
+	Effort                 *string                            `json:"effort,omitempty"                    description:"Controls the level of reasoning effort"                                              enum:"low,medium,high,max"`
 	DisableParallelToolUse *bool                              `json:"disable_parallel_tool_use,omitempty" description:"Whether to disable parallel tool execution"`
-	WebSearchEnabled       *bool                              `json:"web_search_enabled,omitempty" description:"Enable Anthropic web search tool for grounding responses with real-time information"`
-	AllowedDomains         []string                           `json:"allowed_domains,omitempty" description:"Restrict web search to these domains (cannot be used with blocked_domains)"`
-	BlockedDomains         []string                           `json:"blocked_domains,omitempty" description:"Block web search on these domains (cannot be used with allowed_domains)"`
+	WebSearchEnabled       *bool                              `json:"web_search_enabled,omitempty"        description:"Enable Anthropic web search tool for grounding responses with real-time information"`
+	AllowedDomains         []string                           `json:"allowed_domains,omitempty"           description:"Restrict web search to these domains (cannot be used with blocked_domains)"`
+	BlockedDomains         []string                           `json:"blocked_domains,omitempty"           description:"Block web search on these domains (cannot be used with allowed_domains)"`
 }
 
 // ChatModelGoogleThinkingConfig configures Google thinking behavior.
 type ChatModelGoogleThinkingConfig struct {
-	ThinkingBudget  *int64 `json:"thinking_budget,omitempty" description:"Maximum number of tokens the model may use for thinking"`
+	ThinkingBudget  *int64 `json:"thinking_budget,omitempty"  description:"Maximum number of tokens the model may use for thinking"`
 	IncludeThoughts *bool  `json:"include_thoughts,omitempty" description:"Whether to include thinking content in the response"`
 }
 
 // ChatModelGoogleSafetySetting configures Google safety filtering.
 type ChatModelGoogleSafetySetting struct {
-	Category  string `json:"category,omitempty" description:"The harm category to configure"`
+	Category  string `json:"category,omitempty"  description:"The harm category to configure"`
 	Threshold string `json:"threshold,omitempty" description:"The blocking threshold for the harm category"`
 }
 
 // ChatModelGoogleProviderOptions configures Google provider behavior.
 type ChatModelGoogleProviderOptions struct {
-	ThinkingConfig   *ChatModelGoogleThinkingConfig `json:"thinking_config,omitempty" description:"Configuration for extended thinking"`
-	CachedContent    string                         `json:"cached_content,omitempty" description:"Resource name of a cached content object" hidden:"true"`
-	SafetySettings   []ChatModelGoogleSafetySetting `json:"safety_settings,omitempty" description:"Safety filtering settings for harmful content categories" hidden:"true"`
-	Threshold        string                         `json:"threshold,omitempty" hidden:"true"`
+	ThinkingConfig   *ChatModelGoogleThinkingConfig `json:"thinking_config,omitempty"    description:"Configuration for extended thinking"`
+	CachedContent    string                         `json:"cached_content,omitempty"     description:"Resource name of a cached content object"                 hidden:"true"`
+	SafetySettings   []ChatModelGoogleSafetySetting `json:"safety_settings,omitempty"    description:"Safety filtering settings for harmful content categories" hidden:"true"`
+	Threshold        string                         `json:"threshold,omitempty"          hidden:"true"`
 	WebSearchEnabled *bool                          `json:"web_search_enabled,omitempty" description:"Enable Google Search grounding for real-time information"`
 }
 
 // ChatModelOpenAICompatProviderOptions configures OpenAI-compatible behavior.
 type ChatModelOpenAICompatProviderOptions struct {
-	User            *string `json:"user,omitempty" description:"Unique identifier for the end user for abuse monitoring" hidden:"true"`
-	ReasoningEffort *string `json:"reasoning_effort,omitempty" description:"Controls the level of reasoning effort" enum:"none,minimal,low,medium,high,xhigh"`
+	User            *string `json:"user,omitempty"             description:"Unique identifier for the end user for abuse monitoring" hidden:"true"`
+	ReasoningEffort *string `json:"reasoning_effort,omitempty" description:"Controls the level of reasoning effort"                  enum:"none,minimal,low,medium,high,xhigh"`
 }
 
 // ChatModelReasoningOptions configures reasoning behavior for model
 // providers that support it.
 type ChatModelReasoningOptions struct {
-	Enabled   *bool   `json:"enabled,omitempty" description:"Whether reasoning is enabled"`
-	Exclude   *bool   `json:"exclude,omitempty" description:"Whether to exclude reasoning content from the response"`
+	Enabled   *bool   `json:"enabled,omitempty"    description:"Whether reasoning is enabled"`
+	Exclude   *bool   `json:"exclude,omitempty"    description:"Whether to exclude reasoning content from the response"`
 	MaxTokens *int64  `json:"max_tokens,omitempty" description:"Maximum number of tokens for reasoning output"`
-	Effort    *string `json:"effort,omitempty" description:"Controls the level of reasoning effort" enum:"none,minimal,low,medium,high,xhigh"`
+	Effort    *string `json:"effort,omitempty"     description:"Controls the level of reasoning effort"                 enum:"none,minimal,low,medium,high,xhigh"`
 }
 
 // ChatModelOpenRouterProvider configures OpenRouter routing preferences.
 type ChatModelOpenRouterProvider struct {
-	Order             []string `json:"order,omitempty" description:"Ordered list of preferred provider names"`
-	AllowFallbacks    *bool    `json:"allow_fallbacks,omitempty" description:"Whether to allow fallback to other providers"`
+	Order             []string `json:"order,omitempty"              description:"Ordered list of preferred provider names"`
+	AllowFallbacks    *bool    `json:"allow_fallbacks,omitempty"    description:"Whether to allow fallback to other providers"`
 	RequireParameters *bool    `json:"require_parameters,omitempty" description:"Whether to require all parameters to be supported by the provider"`
-	DataCollection    *string  `json:"data_collection,omitempty" description:"Data collection policy preference"`
-	Only              []string `json:"only,omitempty" description:"Restrict to only these provider names"`
-	Ignore            []string `json:"ignore,omitempty" description:"Provider names to exclude from routing"`
-	Quantizations     []string `json:"quantizations,omitempty" description:"Allowed model quantization levels"`
-	Sort              *string  `json:"sort,omitempty" description:"Sort order for provider selection"`
+	DataCollection    *string  `json:"data_collection,omitempty"    description:"Data collection policy preference"`
+	Only              []string `json:"only,omitempty"               description:"Restrict to only these provider names"`
+	Ignore            []string `json:"ignore,omitempty"             description:"Provider names to exclude from routing"`
+	Quantizations     []string `json:"quantizations,omitempty"      description:"Allowed model quantization levels"`
+	Sort              *string  `json:"sort,omitempty"               description:"Sort order for provider selection"`
 }
 
 // ChatModelOpenRouterProviderOptions configures OpenRouter provider behavior.
 type ChatModelOpenRouterProviderOptions struct {
-	Reasoning         *ChatModelReasoningOptions   `json:"reasoning,omitempty" description:"Configuration for reasoning behavior"`
-	ExtraBody         map[string]any               `json:"extra_body,omitempty" description:"Additional fields to include in the request body" hidden:"true"`
-	IncludeUsage      *bool                        `json:"include_usage,omitempty" description:"Whether to include token usage information in the response" hidden:"true"`
-	LogitBias         map[string]int64             `json:"logit_bias,omitempty" description:"Token IDs mapped to bias values from -100 to 100" hidden:"true"`
-	LogProbs          *bool                        `json:"log_probs,omitempty" description:"Whether to return log probabilities of output tokens" hidden:"true"`
+	Reasoning         *ChatModelReasoningOptions   `json:"reasoning,omitempty"           description:"Configuration for reasoning behavior"`
+	ExtraBody         map[string]any               `json:"extra_body,omitempty"          description:"Additional fields to include in the request body"           hidden:"true"`
+	IncludeUsage      *bool                        `json:"include_usage,omitempty"       description:"Whether to include token usage information in the response" hidden:"true"`
+	LogitBias         map[string]int64             `json:"logit_bias,omitempty"          description:"Token IDs mapped to bias values from -100 to 100"           hidden:"true"`
+	LogProbs          *bool                        `json:"log_probs,omitempty"           description:"Whether to return log probabilities of output tokens"       hidden:"true"`
 	ParallelToolCalls *bool                        `json:"parallel_tool_calls,omitempty" description:"Whether the model may make multiple tool calls in parallel"`
-	User              *string                      `json:"user,omitempty" description:"Unique identifier for the end user for abuse monitoring" hidden:"true"`
-	Provider          *ChatModelOpenRouterProvider `json:"provider,omitempty" description:"Routing preferences for provider selection" hidden:"true"`
+	User              *string                      `json:"user,omitempty"                description:"Unique identifier for the end user for abuse monitoring"    hidden:"true"`
+	Provider          *ChatModelOpenRouterProvider `json:"provider,omitempty"            description:"Routing preferences for provider selection"                 hidden:"true"`
 }
 
 // ChatModelVercelGatewayProviderOptions configures Vercel routing behavior.
 type ChatModelVercelGatewayProviderOptions struct {
-	Order  []string `json:"order,omitempty" description:"Ordered list of preferred provider names"`
+	Order  []string `json:"order,omitempty"  description:"Ordered list of preferred provider names"`
 	Models []string `json:"models,omitempty" description:"Model identifiers to route across"`
 }
 
 // ChatModelVercelProviderOptions configures Vercel provider behavior.
 type ChatModelVercelProviderOptions struct {
-	Reasoning         *ChatModelReasoningOptions             `json:"reasoning,omitempty" description:"Configuration for reasoning behavior"`
-	ProviderOptions   *ChatModelVercelGatewayProviderOptions `json:"providerOptions,omitempty" description:"Gateway routing options for provider selection" hidden:"true"`
-	User              *string                                `json:"user,omitempty" description:"Unique identifier for the end user for abuse monitoring" hidden:"true"`
-	LogitBias         map[string]int64                       `json:"logit_bias,omitempty" description:"Token IDs mapped to bias values from -100 to 100" hidden:"true"`
-	LogProbs          *bool                                  `json:"logprobs,omitempty" description:"Whether to return log probabilities of output tokens" hidden:"true"`
-	TopLogProbs       *int64                                 `json:"top_logprobs,omitempty" description:"Number of most likely tokens to return log probabilities for" hidden:"true"`
+	Reasoning         *ChatModelReasoningOptions             `json:"reasoning,omitempty"           description:"Configuration for reasoning behavior"`
+	ProviderOptions   *ChatModelVercelGatewayProviderOptions `json:"providerOptions,omitempty"     description:"Gateway routing options for provider selection"               hidden:"true"`
+	User              *string                                `json:"user,omitempty"                description:"Unique identifier for the end user for abuse monitoring"      hidden:"true"`
+	LogitBias         map[string]int64                       `json:"logit_bias,omitempty"          description:"Token IDs mapped to bias values from -100 to 100"             hidden:"true"`
+	LogProbs          *bool                                  `json:"logprobs,omitempty"            description:"Whether to return log probabilities of output tokens"         hidden:"true"`
+	TopLogProbs       *int64                                 `json:"top_logprobs,omitempty"        description:"Number of most likely tokens to return log probabilities for" hidden:"true"`
 	ParallelToolCalls *bool                                  `json:"parallel_tool_calls,omitempty" description:"Whether the model may make multiple tool calls in parallel"`
-	ExtraBody         map[string]any                         `json:"extra_body,omitempty" description:"Additional fields to include in the request body" hidden:"true"`
+	ExtraBody         map[string]any                         `json:"extra_body,omitempty"          description:"Additional fields to include in the request body"             hidden:"true"`
 }
 
 // ModelCostConfig stores pricing metadata for a chat model.
 type ModelCostConfig struct {
-	InputPricePerMillionTokens      *decimal.Decimal `json:"input_price_per_million_tokens,omitempty" description:"Input token price in USD per 1M tokens"`
-	OutputPricePerMillionTokens     *decimal.Decimal `json:"output_price_per_million_tokens,omitempty" description:"Output token price in USD per 1M tokens"`
-	CacheReadPricePerMillionTokens  *decimal.Decimal `json:"cache_read_price_per_million_tokens,omitempty" description:"Cache read token price in USD per 1M tokens"`
+	InputPricePerMillionTokens      *decimal.Decimal `json:"input_price_per_million_tokens,omitempty"       description:"Input token price in USD per 1M tokens"`
+	OutputPricePerMillionTokens     *decimal.Decimal `json:"output_price_per_million_tokens,omitempty"      description:"Output token price in USD per 1M tokens"`
+	CacheReadPricePerMillionTokens  *decimal.Decimal `json:"cache_read_price_per_million_tokens,omitempty"  description:"Cache read token price in USD per 1M tokens"`
 	CacheWritePricePerMillionTokens *decimal.Decimal `json:"cache_write_price_per_million_tokens,omitempty" description:"Cache write or cache creation token price in USD per 1M tokens"`
 }
 
 // ChatModelCallConfig configures per-call model behavior defaults.
 type ChatModelCallConfig struct {
 	MaxOutputTokens  *int64                    `json:"max_output_tokens,omitempty" description:"Upper bound on tokens the model may generate"`
-	Temperature      *float64                  `json:"temperature,omitempty" description:"Sampling temperature between 0 and 2"`
-	TopP             *float64                  `json:"top_p,omitempty" description:"Nucleus sampling probability cutoff"`
-	TopK             *int64                    `json:"top_k,omitempty" description:"Number of highest-probability tokens to keep for sampling"`
-	PresencePenalty  *float64                  `json:"presence_penalty,omitempty" description:"Penalty for tokens that have already appeared in the output"`
+	Temperature      *float64                  `json:"temperature,omitempty"       description:"Sampling temperature between 0 and 2"`
+	TopP             *float64                  `json:"top_p,omitempty"             description:"Nucleus sampling probability cutoff"`
+	TopK             *int64                    `json:"top_k,omitempty"             description:"Number of highest-probability tokens to keep for sampling"`
+	PresencePenalty  *float64                  `json:"presence_penalty,omitempty"  description:"Penalty for tokens that have already appeared in the output"`
 	FrequencyPenalty *float64                  `json:"frequency_penalty,omitempty" description:"Penalty for tokens based on their frequency in the output"`
-	Cost             *ModelCostConfig          `json:"cost,omitempty" description:"Optional pricing metadata for this model"`
-	ProviderOptions  *ChatModelProviderOptions `json:"provider_options,omitempty" description:"Provider-specific option overrides"`
+	Cost             *ModelCostConfig          `json:"cost,omitempty"              description:"Optional pricing metadata for this model"`
+	ProviderOptions  *ChatModelProviderOptions `json:"provider_options,omitempty"  description:"Provider-specific option overrides"`
 }
 
 // UnmarshalJSON accepts both the current nested cost object and the previous
@@ -623,20 +606,20 @@ type UpdateChatModelConfigRequest struct {
 
 // ChatGitChange represents a git file change detected during a chat session.
 type ChatGitChange struct {
-	ID          uuid.UUID `json:"id" format:"uuid"`
-	ChatID      uuid.UUID `json:"chat_id" format:"uuid"`
+	ID          uuid.UUID `json:"id"                     format:"uuid"`
+	ChatID      uuid.UUID `json:"chat_id"                format:"uuid"`
 	FilePath    string    `json:"file_path"`
 	ChangeType  string    `json:"change_type"` // added, modified, deleted, renamed
 	OldPath     *string   `json:"old_path,omitempty"`
 	DiffSummary *string   `json:"diff_summary,omitempty"`
-	DetectedAt  time.Time `json:"detected_at" format:"date-time"`
+	DetectedAt  time.Time `json:"detected_at"            format:"date-time"`
 }
 
 // ChatDiffStatus represents cached diff status for a chat. The URL
 // may point to a pull request or a branch page depending on whether
 // a PR has been opened.
 type ChatDiffStatus struct {
-	ChatID           uuid.UUID  `json:"chat_id" format:"uuid"`
+	ChatID           uuid.UUID  `json:"chat_id"                      format:"uuid"`
 	URL              *string    `json:"url,omitempty"`
 	PullRequestState *string    `json:"pull_request_state,omitempty"`
 	PullRequestTitle string     `json:"pull_request_title"`
@@ -653,13 +636,13 @@ type ChatDiffStatus struct {
 	Commits          *int32     `json:"commits,omitempty"`
 	Approved         *bool      `json:"approved,omitempty"`
 	ReviewerCount    *int32     `json:"reviewer_count,omitempty"`
-	RefreshedAt      *time.Time `json:"refreshed_at,omitempty" format:"date-time"`
-	StaleAt          *time.Time `json:"stale_at,omitempty" format:"date-time"`
+	RefreshedAt      *time.Time `json:"refreshed_at,omitempty"       format:"date-time"`
+	StaleAt          *time.Time `json:"stale_at,omitempty"           format:"date-time"`
 }
 
 // ChatDiffContents represents the resolved diff text for a chat.
 type ChatDiffContents struct {
-	ChatID         uuid.UUID `json:"chat_id" format:"uuid"`
+	ChatID         uuid.UUID `json:"chat_id"                    format:"uuid"`
 	Provider       *string   `json:"provider,omitempty"`
 	RemoteOrigin   *string   `json:"remote_origin,omitempty"`
 	Branch         *string   `json:"branch,omitempty"`
@@ -682,7 +665,7 @@ const (
 // ChatQueuedMessage represents a queued message waiting to be processed.
 type ChatQueuedMessage struct {
 	ID        int64             `json:"id"`
-	ChatID    uuid.UUID         `json:"chat_id" format:"uuid"`
+	ChatID    uuid.UUID         `json:"chat_id"    format:"uuid"`
 	Content   []ChatMessagePart `json:"content"`
 	CreatedAt time.Time         `json:"created_at" format:"date-time"`
 }
@@ -719,7 +702,7 @@ type ChatStreamRetry struct {
 // ChatStreamEvent represents a real-time update for chat streaming.
 type ChatStreamEvent struct {
 	Type           ChatStreamEventType    `json:"type"`
-	ChatID         uuid.UUID              `json:"chat_id" format:"uuid"`
+	ChatID         uuid.UUID              `json:"chat_id"                   format:"uuid"`
 	Message        *ChatMessage           `json:"message,omitempty"`
 	MessagePart    *ChatStreamMessagePart `json:"message_part,omitempty"`
 	Status         *ChatStreamStatus      `json:"status,omitempty"`
@@ -749,8 +732,8 @@ type ChatCostUsersOptions struct {
 
 // ChatCostSummary is the response from the chat cost summary endpoint.
 type ChatCostSummary struct {
-	StartDate                time.Time                `json:"start_date" format:"date-time"`
-	EndDate                  time.Time                `json:"end_date" format:"date-time"`
+	StartDate                time.Time                `json:"start_date"                  format:"date-time"`
+	EndDate                  time.Time                `json:"end_date"                    format:"date-time"`
 	TotalCostMicros          int64                    `json:"total_cost_micros"`
 	PricedMessageCount       int64                    `json:"priced_message_count"`
 	UnpricedMessageCount     int64                    `json:"unpriced_message_count"`
@@ -765,7 +748,7 @@ type ChatCostSummary struct {
 
 // ChatCostModelBreakdown contains per-model cost aggregation.
 type ChatCostModelBreakdown struct {
-	ModelConfigID            uuid.UUID `json:"model_config_id" format:"uuid"`
+	ModelConfigID            uuid.UUID `json:"model_config_id"             format:"uuid"`
 	DisplayName              string    `json:"display_name"`
 	Provider                 string    `json:"provider"`
 	Model                    string    `json:"model"`
@@ -779,7 +762,7 @@ type ChatCostModelBreakdown struct {
 
 // ChatCostChatBreakdown contains per-root-chat cost aggregation.
 type ChatCostChatBreakdown struct {
-	RootChatID               uuid.UUID `json:"root_chat_id" format:"uuid"`
+	RootChatID               uuid.UUID `json:"root_chat_id"                format:"uuid"`
 	ChatTitle                string    `json:"chat_title"`
 	TotalCostMicros          int64     `json:"total_cost_micros"`
 	MessageCount             int64     `json:"message_count"`
@@ -791,7 +774,7 @@ type ChatCostChatBreakdown struct {
 
 // ChatCostUserRollup contains per-user cost aggregation for admin views.
 type ChatCostUserRollup struct {
-	UserID                   uuid.UUID `json:"user_id" format:"uuid"`
+	UserID                   uuid.UUID `json:"user_id"                     format:"uuid"`
 	Username                 string    `json:"username"`
 	Name                     string    `json:"name"`
 	AvatarURL                string    `json:"avatar_url"`
@@ -807,7 +790,7 @@ type ChatCostUserRollup struct {
 // ChatCostUsersResponse is the response from the admin chat cost users endpoint.
 type ChatCostUsersResponse struct {
 	StartDate time.Time            `json:"start_date" format:"date-time"`
-	EndDate   time.Time            `json:"end_date" format:"date-time"`
+	EndDate   time.Time            `json:"end_date"   format:"date-time"`
 	Count     int64                `json:"count"`
 	Users     []ChatCostUserRollup `json:"users"`
 }
@@ -820,7 +803,7 @@ type ChatUsageLimitExceededResponse struct {
 	Response
 	SpentMicros int64     `json:"spent_micros"`
 	LimitMicros int64     `json:"limit_micros"`
-	ResetsAt    time.Time `json:"resets_at" format:"date-time"`
+	ResetsAt    time.Time `json:"resets_at"    format:"date-time"`
 }
 
 type chatUsageLimitExceededError struct {
@@ -965,12 +948,12 @@ type ChatUsageLimitConfig struct {
 	// limiting is disabled.
 	SpendLimitMicros *int64               `json:"spend_limit_micros"`
 	Period           ChatUsageLimitPeriod `json:"period"`
-	UpdatedAt        time.Time            `json:"updated_at" format:"date-time"`
+	UpdatedAt        time.Time            `json:"updated_at"         format:"date-time"`
 }
 
 // ChatUsageLimitOverride is a per-user override of the deployment default.
 type ChatUsageLimitOverride struct {
-	UserID    uuid.UUID `json:"user_id" format:"uuid"`
+	UserID    uuid.UUID `json:"user_id"    format:"uuid"`
 	Username  string    `json:"username"`
 	Name      string    `json:"name"`
 	AvatarURL string    `json:"avatar_url"`
@@ -981,7 +964,7 @@ type ChatUsageLimitOverride struct {
 
 // ChatUsageLimitGroupOverride represents a group-scoped spend limit override.
 type ChatUsageLimitGroupOverride struct {
-	GroupID          uuid.UUID `json:"group_id" format:"uuid"`
+	GroupID          uuid.UUID `json:"group_id"           format:"uuid"`
 	GroupName        string    `json:"group_name"`
 	GroupDisplayName string    `json:"group_display_name"`
 	GroupAvatarURL   string    `json:"group_avatar_url"`
@@ -1016,8 +999,8 @@ type ChatUsageLimitStatus struct {
 	Period           ChatUsageLimitPeriod `json:"period,omitempty"`
 	SpendLimitMicros *int64               `json:"spend_limit_micros,omitempty"`
 	CurrentSpend     int64                `json:"current_spend"`
-	PeriodStart      time.Time            `json:"period_start,omitempty" format:"date-time"`
-	PeriodEnd        time.Time            `json:"period_end,omitempty" format:"date-time"`
+	PeriodStart      time.Time            `json:"period_start,omitempty"       format:"date-time"`
+	PeriodEnd        time.Time            `json:"period_end,omitempty"         format:"date-time"`
 }
 
 // ChatUsageLimitConfigResponse is returned from the admin config endpoint

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -98,6 +98,19 @@ const (
 	ChatMessagePartTypeFileReference ChatMessagePartType = "file-reference"
 )
 
+// AllChatMessagePartTypes returns all known ChatMessagePartType values.
+func AllChatMessagePartTypes() []ChatMessagePartType {
+	return []ChatMessagePartType{
+		ChatMessagePartTypeText,
+		ChatMessagePartTypeReasoning,
+		ChatMessagePartTypeToolCall,
+		ChatMessagePartTypeToolResult,
+		ChatMessagePartTypeSource,
+		ChatMessagePartTypeFile,
+		ChatMessagePartTypeFileReference,
+	}
+}
+
 // ChatMessagePart is a structured chunk of a chat message.
 //
 // WARNING: This type is both an API wire type and a database
@@ -106,37 +119,41 @@ const (
 // changes, and omitempty behavior all affect backward-compatible
 // deserialization of stored rows. Treat changes to this struct
 // with the same care as a database migration.
+//
+// The variants struct tag declares which discriminated-union
+// variants include each field in the generated TypeScript. Bare
+// name = required, ? suffix = optional. Fields without a variants
+// tag are excluded from the generated union. See
+// scripts/apitypings/main.go for the codegen that reads these.
 type ChatMessagePart struct {
 	Type        ChatMessagePartType `json:"type"`
-	Text        string              `json:"text,omitempty"`
+	Text        string              `json:"text,omitempty"                       variants:"text,reasoning"`
 	Signature   string              `json:"signature,omitempty"`
-	ToolCallID  string              `json:"tool_call_id,omitempty"`
-	ToolName    string              `json:"tool_name,omitempty"`
-	Args        json.RawMessage     `json:"args,omitempty"`
-	ArgsDelta   string              `json:"args_delta,omitempty"`
-	Result      json.RawMessage     `json:"result,omitempty"`
+	ToolCallID  string              `json:"tool_call_id,omitempty"               variants:"tool-call,tool-result"`
+	ToolName    string              `json:"tool_name,omitempty"                  variants:"tool-call,tool-result"`
+	Args        json.RawMessage     `json:"args,omitempty"                       variants:"tool-call?"`
+	ArgsDelta   string              `json:"args_delta,omitempty"                 variants:"tool-call?"`
+	Result      json.RawMessage     `json:"result,omitempty"                     variants:"tool-result?"`
 	ResultDelta string              `json:"result_delta,omitempty"`
-	IsError     bool                `json:"is_error,omitempty"`
-	SourceID    string              `json:"source_id,omitempty"`
-	URL         string              `json:"url,omitempty"`
-	Title       string              `json:"title,omitempty"`
-	MediaType   string              `json:"media_type,omitempty"`
-	Data        []byte              `json:"data,omitempty"`
-	FileID      uuid.NullUUID       `json:"file_id,omitempty"      format:"uuid"`
-	// The following fields are only set when Type is
-	// ChatInputPartTypeFileReference.
-	FileName  string `json:"file_name,omitempty"`
-	StartLine int    `json:"start_line,omitempty"`
-	EndLine   int    `json:"end_line,omitempty"`
+	IsError     bool                `json:"is_error,omitempty"                   variants:"tool-result?"`
+	SourceID    string              `json:"source_id,omitempty"                  variants:"source?"`
+	URL         string              `json:"url,omitempty"                        variants:"source"`
+	Title       string              `json:"title,omitempty"                      variants:"source?"`
+	MediaType   string              `json:"media_type,omitempty"                 variants:"file"`
+	Data        []byte              `json:"data,omitempty"                       variants:"file?"`
+	FileID      uuid.NullUUID       `json:"file_id,omitempty"      format:"uuid" variants:"file?"`
+	FileName    string              `json:"file_name,omitempty"                  variants:"file-reference"`
+	StartLine   int                 `json:"start_line,omitempty"                 variants:"file-reference"`
+	EndLine     int                 `json:"end_line,omitempty"                   variants:"file-reference"`
 	// The code content from the diff that was commented on.
-	Content string `json:"content,omitempty"`
+	Content string `json:"content,omitempty" variants:"file-reference"`
 	// ProviderMetadata holds provider-specific response metadata
 	// (e.g. Anthropic cache control hints) as raw JSON. Internal
 	// only: stripped by db2sdk before API responses.
 	ProviderMetadata json.RawMessage `json:"provider_metadata,omitempty" typescript:"-"`
 	// ProviderExecuted indicates the tool call was executed by
 	// the provider (e.g. Anthropic computer use).
-	ProviderExecuted bool `json:"provider_executed,omitempty"`
+	ProviderExecuted bool `json:"provider_executed,omitempty" variants:"tool-call?,tool-result?"`
 }
 
 // StripInternal removes internal-only fields that must not be
@@ -399,26 +416,26 @@ type ChatModelProviderOptions struct {
 
 // ChatModelOpenAIProviderOptions configures OpenAI provider behavior.
 type ChatModelOpenAIProviderOptions struct {
-	Include             []string         `json:"include,omitempty"               description:"Model names to include in discovery"                                              hidden:"true"`
-	Instructions        *string          `json:"instructions,omitempty"          description:"System-level instructions prepended to the conversation"                          hidden:"true"`
-	LogitBias           map[string]int64 `json:"logit_bias,omitempty"            description:"Token IDs mapped to bias values from -100 to 100"                                 hidden:"true"`
-	LogProbs            *bool            `json:"log_probs,omitempty"             description:"Whether to return log probabilities of output tokens"                             hidden:"true"`
-	TopLogProbs         *int64           `json:"top_log_probs,omitempty"         description:"Number of most likely tokens to return log probabilities for"                     hidden:"true"`
+	Include             []string         `json:"include,omitempty"               description:"Model names to include in discovery"                                                                                        hidden:"true"`
+	Instructions        *string          `json:"instructions,omitempty"          description:"System-level instructions prepended to the conversation"                                                                    hidden:"true"`
+	LogitBias           map[string]int64 `json:"logit_bias,omitempty"            description:"Token IDs mapped to bias values from -100 to 100"                                                                           hidden:"true"`
+	LogProbs            *bool            `json:"log_probs,omitempty"             description:"Whether to return log probabilities of output tokens"                                                                       hidden:"true"`
+	TopLogProbs         *int64           `json:"top_log_probs,omitempty"         description:"Number of most likely tokens to return log probabilities for"                                                               hidden:"true"`
 	MaxToolCalls        *int64           `json:"max_tool_calls,omitempty"        description:"Maximum number of tool calls per response"`
 	ParallelToolCalls   *bool            `json:"parallel_tool_calls,omitempty"   description:"Whether the model may make multiple tool calls in parallel"`
-	User                *string          `json:"user,omitempty"                  description:"Unique identifier for the end user for abuse monitoring"                          hidden:"true"`
+	User                *string          `json:"user,omitempty"                  description:"Unique identifier for the end user for abuse monitoring"                                                                    hidden:"true"`
 	ReasoningEffort     *string          `json:"reasoning_effort,omitempty"      description:"Controls the level of reasoning effort"                                           enum:"none,minimal,low,medium,high,xhigh"`
 	ReasoningSummary    *string          `json:"reasoning_summary,omitempty"     description:"Controls whether reasoning tokens are summarized in the response"`
 	MaxCompletionTokens *int64           `json:"max_completion_tokens,omitempty" description:"Upper bound on tokens the model may generate"`
 	TextVerbosity       *string          `json:"text_verbosity,omitempty"        description:"Controls the verbosity of the text response"                                      enum:"low,medium,high"`
-	Prediction          map[string]any   `json:"prediction,omitempty"            description:"Predicted output content to speed up responses"                                   hidden:"true"`
-	Store               *bool            `json:"store,omitempty"                 description:"Whether to store the output for model distillation or evals"                      hidden:"true"`
-	Metadata            map[string]any   `json:"metadata,omitempty"              description:"Arbitrary metadata to attach to the request"                                      hidden:"true"`
+	Prediction          map[string]any   `json:"prediction,omitempty"            description:"Predicted output content to speed up responses"                                                                             hidden:"true"`
+	Store               *bool            `json:"store,omitempty"                 description:"Whether to store the output for model distillation or evals"                                                                hidden:"true"`
+	Metadata            map[string]any   `json:"metadata,omitempty"              description:"Arbitrary metadata to attach to the request"                                                                                hidden:"true"`
 	PromptCacheKey      *string          `json:"prompt_cache_key,omitempty"      description:"Key for enabling cross-request prompt caching"`
-	SafetyIdentifier    *string          `json:"safety_identifier,omitempty"     description:"Developer-specific safety identifier for the request"                             hidden:"true"`
+	SafetyIdentifier    *string          `json:"safety_identifier,omitempty"     description:"Developer-specific safety identifier for the request"                                                                       hidden:"true"`
 	ServiceTier         *string          `json:"service_tier,omitempty"          description:"Latency tier to use for processing the request"`
-	StructuredOutputs   *bool            `json:"structured_outputs,omitempty"    description:"Whether to enable structured JSON output mode"                                    hidden:"true"`
-	StrictJSONSchema    *bool            `json:"strict_json_schema,omitempty"    description:"Whether to enforce strict adherence to the JSON schema"                           hidden:"true"`
+	StructuredOutputs   *bool            `json:"structured_outputs,omitempty"    description:"Whether to enable structured JSON output mode"                                                                              hidden:"true"`
+	StrictJSONSchema    *bool            `json:"strict_json_schema,omitempty"    description:"Whether to enforce strict adherence to the JSON schema"                                                                     hidden:"true"`
 	WebSearchEnabled    *bool            `json:"web_search_enabled,omitempty"    description:"Enable OpenAI web search tool for grounding responses with real-time information"`
 	SearchContextSize   *string          `json:"search_context_size,omitempty"   description:"Amount of search context to use"                                                  enum:"low,medium,high"`
 	AllowedDomains      []string         `json:"allowed_domains,omitempty"       description:"Restrict web search to these domains"`
@@ -457,13 +474,13 @@ type ChatModelGoogleProviderOptions struct {
 	ThinkingConfig   *ChatModelGoogleThinkingConfig `json:"thinking_config,omitempty"    description:"Configuration for extended thinking"`
 	CachedContent    string                         `json:"cached_content,omitempty"     description:"Resource name of a cached content object"                 hidden:"true"`
 	SafetySettings   []ChatModelGoogleSafetySetting `json:"safety_settings,omitempty"    description:"Safety filtering settings for harmful content categories" hidden:"true"`
-	Threshold        string                         `json:"threshold,omitempty"          hidden:"true"`
+	Threshold        string                         `json:"threshold,omitempty"                                                                                 hidden:"true"`
 	WebSearchEnabled *bool                          `json:"web_search_enabled,omitempty" description:"Enable Google Search grounding for real-time information"`
 }
 
 // ChatModelOpenAICompatProviderOptions configures OpenAI-compatible behavior.
 type ChatModelOpenAICompatProviderOptions struct {
-	User            *string `json:"user,omitempty"             description:"Unique identifier for the end user for abuse monitoring" hidden:"true"`
+	User            *string `json:"user,omitempty"             description:"Unique identifier for the end user for abuse monitoring"                                           hidden:"true"`
 	ReasoningEffort *string `json:"reasoning_effort,omitempty" description:"Controls the level of reasoning effort"                  enum:"none,minimal,low,medium,high,xhigh"`
 }
 

--- a/codersdk/client.go
+++ b/codersdk/client.go
@@ -587,7 +587,7 @@ type Response struct {
 
 // ValidationError represents a scoped error to a user input.
 type ValidationError struct {
-	Field  string `json:"field" validate:"required"`
+	Field  string `json:"field"  validate:"required"`
 	Detail string `json:"detail" validate:"required"`
 }
 

--- a/codersdk/connectionlog.go
+++ b/codersdk/connectionlog.go
@@ -12,12 +12,12 @@ import (
 )
 
 type ConnectionLog struct {
-	ID                     uuid.UUID           `json:"id" format:"uuid"`
-	ConnectTime            time.Time           `json:"connect_time" format:"date-time"`
+	ID                     uuid.UUID           `json:"id"                       format:"uuid"`
+	ConnectTime            time.Time           `json:"connect_time"             format:"date-time"`
 	Organization           MinimalOrganization `json:"organization"`
-	WorkspaceOwnerID       uuid.UUID           `json:"workspace_owner_id" format:"uuid"`
+	WorkspaceOwnerID       uuid.UUID           `json:"workspace_owner_id"       format:"uuid"`
 	WorkspaceOwnerUsername string              `json:"workspace_owner_username"`
-	WorkspaceID            uuid.UUID           `json:"workspace_id" format:"uuid"`
+	WorkspaceID            uuid.UUID           `json:"workspace_id"             format:"uuid"`
 	WorkspaceName          string              `json:"workspace_name"`
 	AgentName              string              `json:"agent_name"`
 	IP                     *netip.Addr         `json:"ip,omitempty"`

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -4062,11 +4062,11 @@ type SupportConfig struct {
 }
 
 type LinkConfig struct {
-	Name   string `json:"name"   yaml:"name"`
-	Target string `json:"target" yaml:"target"`
-	Icon   string `json:"icon"   yaml:"icon"   enums:"bug,chat,docs,star"`
+	Name   string `json:"name"                              yaml:"name"`
+	Target string `json:"target"                            yaml:"target"`
+	Icon   string `json:"icon"   enums:"bug,chat,docs,star" yaml:"icon"`
 
-	Location string `json:"location,omitempty" yaml:"location,omitempty" enums:"navbar,dropdown"`
+	Location string `json:"location,omitempty" enums:"navbar,dropdown" yaml:"location,omitempty"`
 }
 
 // Validate checks cross-field constraints for deployment values.

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -386,8 +386,8 @@ type Feature struct {
 
 type UsagePeriod struct {
 	IssuedAt time.Time `json:"issued_at" format:"date-time"`
-	Start    time.Time `json:"start" format:"date-time"`
-	End      time.Time `json:"end" format:"date-time"`
+	Start    time.Time `json:"start"     format:"date-time"`
+	End      time.Time `json:"end"       format:"date-time"`
 }
 
 // Compare compares two features and returns an integer representing
@@ -499,7 +499,7 @@ type Entitlements struct {
 	HasLicense       bool                    `json:"has_license"`
 	Trial            bool                    `json:"trial"`
 	RequireTelemetry bool                    `json:"require_telemetry"`
-	RefreshedAt      time.Time               `json:"refreshed_at" format:"date-time"`
+	RefreshedAt      time.Time               `json:"refreshed_at"      format:"date-time"`
 }
 
 // AddFeature will add the feature to the entitlements iff it expands
@@ -579,71 +579,71 @@ type DeploymentValues struct {
 	DocsURL             serpent.URL    `json:"docs_url,omitempty"`
 	RedirectToAccessURL serpent.Bool   `json:"redirect_to_access_url,omitempty"`
 	// HTTPAddress is a string because it may be set to zero to disable.
-	HTTPAddress                             serpent.String                       `json:"http_address,omitempty" typescript:",notnull"`
+	HTTPAddress                             serpent.String                       `json:"http_address,omitempty"                                 typescript:",notnull"`
 	AutobuildPollInterval                   serpent.Duration                     `json:"autobuild_poll_interval,omitempty"`
 	JobReaperDetectorInterval               serpent.Duration                     `json:"job_hang_detector_interval,omitempty"`
-	DERP                                    DERP                                 `json:"derp,omitempty" typescript:",notnull"`
-	Prometheus                              PrometheusConfig                     `json:"prometheus,omitempty" typescript:",notnull"`
-	Pprof                                   PprofConfig                          `json:"pprof,omitempty" typescript:",notnull"`
-	ProxyTrustedHeaders                     serpent.StringArray                  `json:"proxy_trusted_headers,omitempty" typescript:",notnull"`
-	ProxyTrustedOrigins                     serpent.StringArray                  `json:"proxy_trusted_origins,omitempty" typescript:",notnull"`
-	CacheDir                                serpent.String                       `json:"cache_directory,omitempty" typescript:",notnull"`
-	EphemeralDeployment                     serpent.Bool                         `json:"ephemeral_deployment,omitempty" typescript:",notnull"`
-	PostgresURL                             serpent.String                       `json:"pg_connection_url,omitempty" typescript:",notnull"`
-	PostgresAuth                            string                               `json:"pg_auth,omitempty" typescript:",notnull"`
-	PostgresConnMaxOpen                     serpent.Int64                        `json:"pg_conn_max_open,omitempty" typescript:",notnull"`
-	PostgresConnMaxIdle                     serpent.String                       `json:"pg_conn_max_idle,omitempty" typescript:",notnull"`
-	OAuth2                                  OAuth2Config                         `json:"oauth2,omitempty" typescript:",notnull"`
-	OIDC                                    OIDCConfig                           `json:"oidc,omitempty" typescript:",notnull"`
-	Telemetry                               TelemetryConfig                      `json:"telemetry,omitempty" typescript:",notnull"`
-	TLS                                     TLSConfig                            `json:"tls,omitempty" typescript:",notnull"`
-	Trace                                   TraceConfig                          `json:"trace,omitempty" typescript:",notnull"`
-	HTTPCookies                             HTTPCookieConfig                     `json:"http_cookies,omitempty" typescript:",notnull"`
-	StrictTransportSecurity                 serpent.Int64                        `json:"strict_transport_security,omitempty" typescript:",notnull"`
-	StrictTransportSecurityOptions          serpent.StringArray                  `json:"strict_transport_security_options,omitempty" typescript:",notnull"`
-	SSHKeygenAlgorithm                      serpent.String                       `json:"ssh_keygen_algorithm,omitempty" typescript:",notnull"`
-	MetricsCacheRefreshInterval             serpent.Duration                     `json:"metrics_cache_refresh_interval,omitempty" typescript:",notnull"`
-	AgentStatRefreshInterval                serpent.Duration                     `json:"agent_stat_refresh_interval,omitempty" typescript:",notnull"`
-	AgentFallbackTroubleshootingURL         serpent.URL                          `json:"agent_fallback_troubleshooting_url,omitempty" typescript:",notnull"`
-	BrowserOnly                             serpent.Bool                         `json:"browser_only,omitempty" typescript:",notnull"`
-	SCIMAPIKey                              serpent.String                       `json:"scim_api_key,omitempty" typescript:",notnull"`
-	ExternalTokenEncryptionKeys             serpent.StringArray                  `json:"external_token_encryption_keys,omitempty" typescript:",notnull"`
-	Provisioner                             ProvisionerConfig                    `json:"provisioner,omitempty" typescript:",notnull"`
-	RateLimit                               RateLimitConfig                      `json:"rate_limit,omitempty" typescript:",notnull"`
-	Experiments                             serpent.StringArray                  `json:"experiments,omitempty" typescript:",notnull"`
-	UpdateCheck                             serpent.Bool                         `json:"update_check,omitempty" typescript:",notnull"`
-	Swagger                                 SwaggerConfig                        `json:"swagger,omitempty" typescript:",notnull"`
-	Logging                                 LoggingConfig                        `json:"logging,omitempty" typescript:",notnull"`
-	Dangerous                               DangerousConfig                      `json:"dangerous,omitempty" typescript:",notnull"`
-	DisablePathApps                         serpent.Bool                         `json:"disable_path_apps,omitempty" typescript:",notnull"`
-	Sessions                                SessionLifetime                      `json:"session_lifetime,omitempty" typescript:",notnull"`
-	DisablePasswordAuth                     serpent.Bool                         `json:"disable_password_auth,omitempty" typescript:",notnull"`
-	Support                                 SupportConfig                        `json:"support,omitempty" typescript:",notnull"`
-	EnableAuthzRecording                    serpent.Bool                         `json:"enable_authz_recording,omitempty" typescript:",notnull"`
-	ExternalAuthConfigs                     serpent.Struct[[]ExternalAuthConfig] `json:"external_auth,omitempty" typescript:",notnull"`
+	DERP                                    DERP                                 `json:"derp,omitempty"                                         typescript:",notnull"`
+	Prometheus                              PrometheusConfig                     `json:"prometheus,omitempty"                                   typescript:",notnull"`
+	Pprof                                   PprofConfig                          `json:"pprof,omitempty"                                        typescript:",notnull"`
+	ProxyTrustedHeaders                     serpent.StringArray                  `json:"proxy_trusted_headers,omitempty"                        typescript:",notnull"`
+	ProxyTrustedOrigins                     serpent.StringArray                  `json:"proxy_trusted_origins,omitempty"                        typescript:",notnull"`
+	CacheDir                                serpent.String                       `json:"cache_directory,omitempty"                              typescript:",notnull"`
+	EphemeralDeployment                     serpent.Bool                         `json:"ephemeral_deployment,omitempty"                         typescript:",notnull"`
+	PostgresURL                             serpent.String                       `json:"pg_connection_url,omitempty"                            typescript:",notnull"`
+	PostgresAuth                            string                               `json:"pg_auth,omitempty"                                      typescript:",notnull"`
+	PostgresConnMaxOpen                     serpent.Int64                        `json:"pg_conn_max_open,omitempty"                             typescript:",notnull"`
+	PostgresConnMaxIdle                     serpent.String                       `json:"pg_conn_max_idle,omitempty"                             typescript:",notnull"`
+	OAuth2                                  OAuth2Config                         `json:"oauth2,omitempty"                                       typescript:",notnull"`
+	OIDC                                    OIDCConfig                           `json:"oidc,omitempty"                                         typescript:",notnull"`
+	Telemetry                               TelemetryConfig                      `json:"telemetry,omitempty"                                    typescript:",notnull"`
+	TLS                                     TLSConfig                            `json:"tls,omitempty"                                          typescript:",notnull"`
+	Trace                                   TraceConfig                          `json:"trace,omitempty"                                        typescript:",notnull"`
+	HTTPCookies                             HTTPCookieConfig                     `json:"http_cookies,omitempty"                                 typescript:",notnull"`
+	StrictTransportSecurity                 serpent.Int64                        `json:"strict_transport_security,omitempty"                    typescript:",notnull"`
+	StrictTransportSecurityOptions          serpent.StringArray                  `json:"strict_transport_security_options,omitempty"            typescript:",notnull"`
+	SSHKeygenAlgorithm                      serpent.String                       `json:"ssh_keygen_algorithm,omitempty"                         typescript:",notnull"`
+	MetricsCacheRefreshInterval             serpent.Duration                     `json:"metrics_cache_refresh_interval,omitempty"               typescript:",notnull"`
+	AgentStatRefreshInterval                serpent.Duration                     `json:"agent_stat_refresh_interval,omitempty"                  typescript:",notnull"`
+	AgentFallbackTroubleshootingURL         serpent.URL                          `json:"agent_fallback_troubleshooting_url,omitempty"           typescript:",notnull"`
+	BrowserOnly                             serpent.Bool                         `json:"browser_only,omitempty"                                 typescript:",notnull"`
+	SCIMAPIKey                              serpent.String                       `json:"scim_api_key,omitempty"                                 typescript:",notnull"`
+	ExternalTokenEncryptionKeys             serpent.StringArray                  `json:"external_token_encryption_keys,omitempty"               typescript:",notnull"`
+	Provisioner                             ProvisionerConfig                    `json:"provisioner,omitempty"                                  typescript:",notnull"`
+	RateLimit                               RateLimitConfig                      `json:"rate_limit,omitempty"                                   typescript:",notnull"`
+	Experiments                             serpent.StringArray                  `json:"experiments,omitempty"                                  typescript:",notnull"`
+	UpdateCheck                             serpent.Bool                         `json:"update_check,omitempty"                                 typescript:",notnull"`
+	Swagger                                 SwaggerConfig                        `json:"swagger,omitempty"                                      typescript:",notnull"`
+	Logging                                 LoggingConfig                        `json:"logging,omitempty"                                      typescript:",notnull"`
+	Dangerous                               DangerousConfig                      `json:"dangerous,omitempty"                                    typescript:",notnull"`
+	DisablePathApps                         serpent.Bool                         `json:"disable_path_apps,omitempty"                            typescript:",notnull"`
+	Sessions                                SessionLifetime                      `json:"session_lifetime,omitempty"                             typescript:",notnull"`
+	DisablePasswordAuth                     serpent.Bool                         `json:"disable_password_auth,omitempty"                        typescript:",notnull"`
+	Support                                 SupportConfig                        `json:"support,omitempty"                                      typescript:",notnull"`
+	EnableAuthzRecording                    serpent.Bool                         `json:"enable_authz_recording,omitempty"                       typescript:",notnull"`
+	ExternalAuthConfigs                     serpent.Struct[[]ExternalAuthConfig] `json:"external_auth,omitempty"                                typescript:",notnull"`
 	ExternalAuthGithubDefaultProviderEnable serpent.Bool                         `json:"external_auth_github_default_provider_enable,omitempty" typescript:",notnull"`
-	SSHConfig                               SSHConfig                            `json:"config_ssh,omitempty" typescript:",notnull"`
-	WgtunnelHost                            serpent.String                       `json:"wgtunnel_host,omitempty" typescript:",notnull"`
-	DisableOwnerWorkspaceExec               serpent.Bool                         `json:"disable_owner_workspace_exec,omitempty" typescript:",notnull"`
-	DisableWorkspaceSharing                 serpent.Bool                         `json:"disable_workspace_sharing,omitempty" typescript:",notnull"`
-	ProxyHealthStatusInterval               serpent.Duration                     `json:"proxy_health_status_interval,omitempty" typescript:",notnull"`
-	EnableTerraformDebugMode                serpent.Bool                         `json:"enable_terraform_debug_mode,omitempty" typescript:",notnull"`
-	UserQuietHoursSchedule                  UserQuietHoursScheduleConfig         `json:"user_quiet_hours_schedule,omitempty" typescript:",notnull"`
-	WebTerminalRenderer                     serpent.String                       `json:"web_terminal_renderer,omitempty" typescript:",notnull"`
-	AllowWorkspaceRenames                   serpent.Bool                         `json:"allow_workspace_renames,omitempty" typescript:",notnull"`
-	Healthcheck                             HealthcheckConfig                    `json:"healthcheck,omitempty" typescript:",notnull"`
-	Retention                               RetentionConfig                      `json:"retention,omitempty" typescript:",notnull"`
-	CLIUpgradeMessage                       serpent.String                       `json:"cli_upgrade_message,omitempty" typescript:",notnull"`
-	TermsOfServiceURL                       serpent.String                       `json:"terms_of_service_url,omitempty" typescript:",notnull"`
-	Notifications                           NotificationsConfig                  `json:"notifications,omitempty" typescript:",notnull"`
-	AdditionalCSPPolicy                     serpent.StringArray                  `json:"additional_csp_policy,omitempty" typescript:",notnull"`
-	WorkspaceHostnameSuffix                 serpent.String                       `json:"workspace_hostname_suffix,omitempty" typescript:",notnull"`
-	Prebuilds                               PrebuildsConfig                      `json:"workspace_prebuilds,omitempty" typescript:",notnull"`
-	HideAITasks                             serpent.Bool                         `json:"hide_ai_tasks,omitempty" typescript:",notnull"`
+	SSHConfig                               SSHConfig                            `json:"config_ssh,omitempty"                                   typescript:",notnull"`
+	WgtunnelHost                            serpent.String                       `json:"wgtunnel_host,omitempty"                                typescript:",notnull"`
+	DisableOwnerWorkspaceExec               serpent.Bool                         `json:"disable_owner_workspace_exec,omitempty"                 typescript:",notnull"`
+	DisableWorkspaceSharing                 serpent.Bool                         `json:"disable_workspace_sharing,omitempty"                    typescript:",notnull"`
+	ProxyHealthStatusInterval               serpent.Duration                     `json:"proxy_health_status_interval,omitempty"                 typescript:",notnull"`
+	EnableTerraformDebugMode                serpent.Bool                         `json:"enable_terraform_debug_mode,omitempty"                  typescript:",notnull"`
+	UserQuietHoursSchedule                  UserQuietHoursScheduleConfig         `json:"user_quiet_hours_schedule,omitempty"                    typescript:",notnull"`
+	WebTerminalRenderer                     serpent.String                       `json:"web_terminal_renderer,omitempty"                        typescript:",notnull"`
+	AllowWorkspaceRenames                   serpent.Bool                         `json:"allow_workspace_renames,omitempty"                      typescript:",notnull"`
+	Healthcheck                             HealthcheckConfig                    `json:"healthcheck,omitempty"                                  typescript:",notnull"`
+	Retention                               RetentionConfig                      `json:"retention,omitempty"                                    typescript:",notnull"`
+	CLIUpgradeMessage                       serpent.String                       `json:"cli_upgrade_message,omitempty"                          typescript:",notnull"`
+	TermsOfServiceURL                       serpent.String                       `json:"terms_of_service_url,omitempty"                         typescript:",notnull"`
+	Notifications                           NotificationsConfig                  `json:"notifications,omitempty"                                typescript:",notnull"`
+	AdditionalCSPPolicy                     serpent.StringArray                  `json:"additional_csp_policy,omitempty"                        typescript:",notnull"`
+	WorkspaceHostnameSuffix                 serpent.String                       `json:"workspace_hostname_suffix,omitempty"                    typescript:",notnull"`
+	Prebuilds                               PrebuildsConfig                      `json:"workspace_prebuilds,omitempty"                          typescript:",notnull"`
+	HideAITasks                             serpent.Bool                         `json:"hide_ai_tasks,omitempty"                                typescript:",notnull"`
 	AI                                      AIConfig                             `json:"ai,omitempty"`
-	StatsCollection                         StatsCollectionConfig                `json:"stats_collection,omitempty" typescript:",notnull"`
+	StatsCollection                         StatsCollectionConfig                `json:"stats_collection,omitempty"                             typescript:",notnull"`
 
-	Config      serpent.YAMLConfigPath `json:"config,omitempty" typescript:",notnull"`
+	Config      serpent.YAMLConfigPath `json:"config,omitempty"       typescript:",notnull"`
 	WriteConfig serpent.Bool           `json:"write_config,omitempty" typescript:",notnull"`
 
 	// Deprecated: Use HTTPAddress or TLS.Address instead.
@@ -726,19 +726,19 @@ type DERP struct {
 }
 
 type DERPServerConfig struct {
-	Enable        serpent.Bool        `json:"enable" typescript:",notnull"`
-	RegionID      serpent.Int64       `json:"region_id" typescript:",notnull"`
-	RegionCode    serpent.String      `json:"region_code" typescript:",notnull"`
-	RegionName    serpent.String      `json:"region_name" typescript:",notnull"`
+	Enable        serpent.Bool        `json:"enable"         typescript:",notnull"`
+	RegionID      serpent.Int64       `json:"region_id"      typescript:",notnull"`
+	RegionCode    serpent.String      `json:"region_code"    typescript:",notnull"`
+	RegionName    serpent.String      `json:"region_name"    typescript:",notnull"`
 	STUNAddresses serpent.StringArray `json:"stun_addresses" typescript:",notnull"`
-	RelayURL      serpent.URL         `json:"relay_url" typescript:",notnull"`
+	RelayURL      serpent.URL         `json:"relay_url"      typescript:",notnull"`
 }
 
 type DERPConfig struct {
-	BlockDirect     serpent.Bool   `json:"block_direct" typescript:",notnull"`
+	BlockDirect     serpent.Bool   `json:"block_direct"     typescript:",notnull"`
 	ForceWebSockets serpent.Bool   `json:"force_websockets" typescript:",notnull"`
-	URL             serpent.String `json:"url" typescript:",notnull"`
-	Path            serpent.String `json:"path" typescript:",notnull"`
+	URL             serpent.String `json:"url"              typescript:",notnull"`
+	Path            serpent.String `json:"path"             typescript:",notnull"`
 }
 
 type UsageStatsConfig struct {
@@ -750,15 +750,15 @@ type StatsCollectionConfig struct {
 }
 
 type PrometheusConfig struct {
-	Enable                serpent.Bool        `json:"enable" typescript:",notnull"`
-	Address               serpent.HostPort    `json:"address" typescript:",notnull"`
-	CollectAgentStats     serpent.Bool        `json:"collect_agent_stats" typescript:",notnull"`
-	CollectDBMetrics      serpent.Bool        `json:"collect_db_metrics" typescript:",notnull"`
+	Enable                serpent.Bool        `json:"enable"                   typescript:",notnull"`
+	Address               serpent.HostPort    `json:"address"                  typescript:",notnull"`
+	CollectAgentStats     serpent.Bool        `json:"collect_agent_stats"      typescript:",notnull"`
+	CollectDBMetrics      serpent.Bool        `json:"collect_db_metrics"       typescript:",notnull"`
 	AggregateAgentStatsBy serpent.StringArray `json:"aggregate_agent_stats_by" typescript:",notnull"`
 }
 
 type PprofConfig struct {
-	Enable  serpent.Bool     `json:"enable" typescript:",notnull"`
+	Enable  serpent.Bool     `json:"enable"  typescript:",notnull"`
 	Address serpent.HostPort `json:"address" typescript:",notnull"`
 }
 
@@ -767,32 +767,32 @@ type OAuth2Config struct {
 }
 
 type OAuth2GithubConfig struct {
-	ClientID              serpent.String      `json:"client_id" typescript:",notnull"`
-	ClientSecret          serpent.String      `json:"client_secret" typescript:",notnull"`
-	DeviceFlow            serpent.Bool        `json:"device_flow" typescript:",notnull"`
+	ClientID              serpent.String      `json:"client_id"               typescript:",notnull"`
+	ClientSecret          serpent.String      `json:"client_secret"           typescript:",notnull"`
+	DeviceFlow            serpent.Bool        `json:"device_flow"             typescript:",notnull"`
 	DefaultProviderEnable serpent.Bool        `json:"default_provider_enable" typescript:",notnull"`
-	AllowedOrgs           serpent.StringArray `json:"allowed_orgs" typescript:",notnull"`
-	AllowedTeams          serpent.StringArray `json:"allowed_teams" typescript:",notnull"`
-	AllowSignups          serpent.Bool        `json:"allow_signups" typescript:",notnull"`
-	AllowEveryone         serpent.Bool        `json:"allow_everyone" typescript:",notnull"`
-	EnterpriseBaseURL     serpent.String      `json:"enterprise_base_url" typescript:",notnull"`
+	AllowedOrgs           serpent.StringArray `json:"allowed_orgs"            typescript:",notnull"`
+	AllowedTeams          serpent.StringArray `json:"allowed_teams"           typescript:",notnull"`
+	AllowSignups          serpent.Bool        `json:"allow_signups"           typescript:",notnull"`
+	AllowEveryone         serpent.Bool        `json:"allow_everyone"          typescript:",notnull"`
+	EnterpriseBaseURL     serpent.String      `json:"enterprise_base_url"     typescript:",notnull"`
 }
 
 type OIDCConfig struct {
 	AllowSignups serpent.Bool   `json:"allow_signups" typescript:",notnull"`
-	ClientID     serpent.String `json:"client_id" typescript:",notnull"`
+	ClientID     serpent.String `json:"client_id"     typescript:",notnull"`
 	ClientSecret serpent.String `json:"client_secret" typescript:",notnull"`
 	// ClientKeyFile & ClientCertFile are used in place of ClientSecret for PKI auth.
-	ClientKeyFile       serpent.String                    `json:"client_key_file" typescript:",notnull"`
-	ClientCertFile      serpent.String                    `json:"client_cert_file" typescript:",notnull"`
-	EmailDomain         serpent.StringArray               `json:"email_domain" typescript:",notnull"`
-	IssuerURL           serpent.String                    `json:"issuer_url" typescript:",notnull"`
-	Scopes              serpent.StringArray               `json:"scopes" typescript:",notnull"`
+	ClientKeyFile       serpent.String                    `json:"client_key_file"       typescript:",notnull"`
+	ClientCertFile      serpent.String                    `json:"client_cert_file"      typescript:",notnull"`
+	EmailDomain         serpent.StringArray               `json:"email_domain"          typescript:",notnull"`
+	IssuerURL           serpent.String                    `json:"issuer_url"            typescript:",notnull"`
+	Scopes              serpent.StringArray               `json:"scopes"                typescript:",notnull"`
 	IgnoreEmailVerified serpent.Bool                      `json:"ignore_email_verified" typescript:",notnull"`
-	UsernameField       serpent.String                    `json:"username_field" typescript:",notnull"`
-	NameField           serpent.String                    `json:"name_field" typescript:",notnull"`
-	EmailField          serpent.String                    `json:"email_field" typescript:",notnull"`
-	AuthURLParams       serpent.Struct[map[string]string] `json:"auth_url_params" typescript:",notnull"`
+	UsernameField       serpent.String                    `json:"username_field"        typescript:",notnull"`
+	NameField           serpent.String                    `json:"name_field"            typescript:",notnull"`
+	EmailField          serpent.String                    `json:"email_field"           typescript:",notnull"`
+	AuthURLParams       serpent.Struct[map[string]string] `json:"auth_url_params"       typescript:",notnull"`
 	// IgnoreUserInfo & UserInfoFromAccessToken are mutually exclusive. Only 1
 	// can be set to true. Ideally this would be an enum with 3 states, ['none',
 	// 'userinfo', 'access_token']. However, for backward compatibility,
@@ -804,21 +804,21 @@ type OIDCConfig struct {
 	// endpoint. This assumes the access token is a valid JWT with a set of claims to
 	// be merged with the id_token.
 	UserInfoFromAccessToken   serpent.Bool                           `json:"source_user_info_from_access_token" typescript:",notnull"`
-	OrganizationField         serpent.String                         `json:"organization_field" typescript:",notnull"`
-	OrganizationMapping       serpent.Struct[map[string][]uuid.UUID] `json:"organization_mapping" typescript:",notnull"`
-	OrganizationAssignDefault serpent.Bool                           `json:"organization_assign_default" typescript:",notnull"`
-	GroupAutoCreate           serpent.Bool                           `json:"group_auto_create" typescript:",notnull"`
-	GroupRegexFilter          serpent.Regexp                         `json:"group_regex_filter" typescript:",notnull"`
-	GroupAllowList            serpent.StringArray                    `json:"group_allow_list" typescript:",notnull"`
-	GroupField                serpent.String                         `json:"groups_field" typescript:",notnull"`
-	GroupMapping              serpent.Struct[map[string]string]      `json:"group_mapping" typescript:",notnull"`
-	UserRoleField             serpent.String                         `json:"user_role_field" typescript:",notnull"`
-	UserRoleMapping           serpent.Struct[map[string][]string]    `json:"user_role_mapping" typescript:",notnull"`
-	UserRolesDefault          serpent.StringArray                    `json:"user_roles_default" typescript:",notnull"`
-	SignInText                serpent.String                         `json:"sign_in_text" typescript:",notnull"`
-	IconURL                   serpent.URL                            `json:"icon_url" typescript:",notnull"`
-	SignupsDisabledText       serpent.String                         `json:"signups_disabled_text" typescript:",notnull"`
-	SkipIssuerChecks          serpent.Bool                           `json:"skip_issuer_checks" typescript:",notnull"`
+	OrganizationField         serpent.String                         `json:"organization_field"                 typescript:",notnull"`
+	OrganizationMapping       serpent.Struct[map[string][]uuid.UUID] `json:"organization_mapping"               typescript:",notnull"`
+	OrganizationAssignDefault serpent.Bool                           `json:"organization_assign_default"        typescript:",notnull"`
+	GroupAutoCreate           serpent.Bool                           `json:"group_auto_create"                  typescript:",notnull"`
+	GroupRegexFilter          serpent.Regexp                         `json:"group_regex_filter"                 typescript:",notnull"`
+	GroupAllowList            serpent.StringArray                    `json:"group_allow_list"                   typescript:",notnull"`
+	GroupField                serpent.String                         `json:"groups_field"                       typescript:",notnull"`
+	GroupMapping              serpent.Struct[map[string]string]      `json:"group_mapping"                      typescript:",notnull"`
+	UserRoleField             serpent.String                         `json:"user_role_field"                    typescript:",notnull"`
+	UserRoleMapping           serpent.Struct[map[string][]string]    `json:"user_role_mapping"                  typescript:",notnull"`
+	UserRolesDefault          serpent.StringArray                    `json:"user_roles_default"                 typescript:",notnull"`
+	SignInText                serpent.String                         `json:"sign_in_text"                       typescript:",notnull"`
+	IconURL                   serpent.URL                            `json:"icon_url"                           typescript:",notnull"`
+	SignupsDisabledText       serpent.String                         `json:"signups_disabled_text"              typescript:",notnull"`
+	SkipIssuerChecks          serpent.Bool                           `json:"skip_issuer_checks"                 typescript:",notnull"`
 
 	// RedirectURL is optional, defaulting to 'ACCESS_URL'. Only useful in niche
 	// situations where the OIDC callback domain is different from the ACCESS_URL
@@ -828,38 +828,38 @@ type OIDCConfig struct {
 
 type TelemetryConfig struct {
 	Enable serpent.Bool `json:"enable" typescript:",notnull"`
-	Trace  serpent.Bool `json:"trace" typescript:",notnull"`
-	URL    serpent.URL  `json:"url" typescript:",notnull"`
+	Trace  serpent.Bool `json:"trace"  typescript:",notnull"`
+	URL    serpent.URL  `json:"url"    typescript:",notnull"`
 }
 
 type TLSConfig struct {
-	Enable               serpent.Bool        `json:"enable" typescript:",notnull"`
-	Address              serpent.HostPort    `json:"address" typescript:",notnull"`
-	RedirectHTTP         serpent.Bool        `json:"redirect_http" typescript:",notnull"`
-	CertFiles            serpent.StringArray `json:"cert_file" typescript:",notnull"`
-	ClientAuth           serpent.String      `json:"client_auth" typescript:",notnull"`
-	ClientCAFile         serpent.String      `json:"client_ca_file" typescript:",notnull"`
-	KeyFiles             serpent.StringArray `json:"key_file" typescript:",notnull"`
-	MinVersion           serpent.String      `json:"min_version" typescript:",notnull"`
-	ClientCertFile       serpent.String      `json:"client_cert_file" typescript:",notnull"`
-	ClientKeyFile        serpent.String      `json:"client_key_file" typescript:",notnull"`
-	SupportedCiphers     serpent.StringArray `json:"supported_ciphers" typescript:",notnull"`
+	Enable               serpent.Bool        `json:"enable"                 typescript:",notnull"`
+	Address              serpent.HostPort    `json:"address"                typescript:",notnull"`
+	RedirectHTTP         serpent.Bool        `json:"redirect_http"          typescript:",notnull"`
+	CertFiles            serpent.StringArray `json:"cert_file"              typescript:",notnull"`
+	ClientAuth           serpent.String      `json:"client_auth"            typescript:",notnull"`
+	ClientCAFile         serpent.String      `json:"client_ca_file"         typescript:",notnull"`
+	KeyFiles             serpent.StringArray `json:"key_file"               typescript:",notnull"`
+	MinVersion           serpent.String      `json:"min_version"            typescript:",notnull"`
+	ClientCertFile       serpent.String      `json:"client_cert_file"       typescript:",notnull"`
+	ClientKeyFile        serpent.String      `json:"client_key_file"        typescript:",notnull"`
+	SupportedCiphers     serpent.StringArray `json:"supported_ciphers"      typescript:",notnull"`
 	AllowInsecureCiphers serpent.Bool        `json:"allow_insecure_ciphers" typescript:",notnull"`
 }
 
 type TraceConfig struct {
-	Enable          serpent.Bool   `json:"enable" typescript:",notnull"`
+	Enable          serpent.Bool   `json:"enable"            typescript:",notnull"`
 	HoneycombAPIKey serpent.String `json:"honeycomb_api_key" typescript:",notnull"`
-	CaptureLogs     serpent.Bool   `json:"capture_logs" typescript:",notnull"`
-	DataDog         serpent.Bool   `json:"data_dog" typescript:",notnull"`
+	CaptureLogs     serpent.Bool   `json:"capture_logs"      typescript:",notnull"`
+	DataDog         serpent.Bool   `json:"data_dog"          typescript:",notnull"`
 }
 
 const cookieHostPrefix = "__Host-"
 
 type HTTPCookieConfig struct {
 	Secure           serpent.Bool `json:"secure_auth_cookie,omitempty" typescript:",notnull"`
-	SameSite         string       `json:"same_site,omitempty" typescript:",notnull"`
-	EnableHostPrefix bool         `json:"host_prefix,omitempty" typescript:",notnull"`
+	SameSite         string       `json:"same_site,omitempty"          typescript:",notnull"`
+	EnableHostPrefix bool         `json:"host_prefix,omitempty"        typescript:",notnull"`
 }
 
 // cookiesToPrefix is the set of cookies that should be prefixed with the host prefix if EnableHostPrefix is true.
@@ -953,23 +953,23 @@ func (cfg HTTPCookieConfig) HTTPSameSite() http.SameSite {
 
 type ExternalAuthConfig struct {
 	// Type is the type of external auth config.
-	Type         string `json:"type" yaml:"type"`
+	Type         string `json:"type"      yaml:"type"`
 	ClientID     string `json:"client_id" yaml:"client_id"`
-	ClientSecret string `json:"-" yaml:"client_secret"`
+	ClientSecret string `json:"-"         yaml:"client_secret"`
 	// ID is a unique identifier for the auth config.
 	// It defaults to `type` when not provided.
-	ID                  string   `json:"id" yaml:"id"`
-	AuthURL             string   `json:"auth_url" yaml:"auth_url"`
-	TokenURL            string   `json:"token_url" yaml:"token_url"`
-	ValidateURL         string   `json:"validate_url" yaml:"validate_url"`
-	RevokeURL           string   `json:"revoke_url" yaml:"revoke_url"`
-	AppInstallURL       string   `json:"app_install_url" yaml:"app_install_url"`
+	ID                  string   `json:"id"                    yaml:"id"`
+	AuthURL             string   `json:"auth_url"              yaml:"auth_url"`
+	TokenURL            string   `json:"token_url"             yaml:"token_url"`
+	ValidateURL         string   `json:"validate_url"          yaml:"validate_url"`
+	RevokeURL           string   `json:"revoke_url"            yaml:"revoke_url"`
+	AppInstallURL       string   `json:"app_install_url"       yaml:"app_install_url"`
 	AppInstallationsURL string   `json:"app_installations_url" yaml:"app_installations_url"`
-	NoRefresh           bool     `json:"no_refresh" yaml:"no_refresh"`
-	Scopes              []string `json:"scopes" yaml:"scopes"`
-	ExtraTokenKeys      []string `json:"-" yaml:"extra_token_keys"`
-	DeviceFlow          bool     `json:"device_flow" yaml:"device_flow"`
-	DeviceCodeURL       string   `json:"device_code_url" yaml:"device_code_url"`
+	NoRefresh           bool     `json:"no_refresh"            yaml:"no_refresh"`
+	Scopes              []string `json:"scopes"                yaml:"scopes"`
+	ExtraTokenKeys      []string `json:"-"                     yaml:"extra_token_keys"`
+	DeviceFlow          bool     `json:"device_flow"           yaml:"device_flow"`
+	DeviceCodeURL       string   `json:"device_code_url"       yaml:"device_code_url"`
 	// Deprecated: Injected MCP in AI Bridge is deprecated and will be removed in a future release.
 	MCPURL string `json:"mcp_url" yaml:"mcp_url"`
 	// Deprecated: Injected MCP in AI Bridge is deprecated and will be removed in a future release.
@@ -998,17 +998,17 @@ type ExternalAuthConfig struct {
 
 type ProvisionerConfig struct {
 	// Daemons is the number of built-in terraform provisioners.
-	Daemons             serpent.Int64       `json:"daemons" typescript:",notnull"`
-	DaemonTypes         serpent.StringArray `json:"daemon_types" typescript:",notnull"`
-	DaemonPollInterval  serpent.Duration    `json:"daemon_poll_interval" typescript:",notnull"`
-	DaemonPollJitter    serpent.Duration    `json:"daemon_poll_jitter" typescript:",notnull"`
+	Daemons             serpent.Int64       `json:"daemons"               typescript:",notnull"`
+	DaemonTypes         serpent.StringArray `json:"daemon_types"          typescript:",notnull"`
+	DaemonPollInterval  serpent.Duration    `json:"daemon_poll_interval"  typescript:",notnull"`
+	DaemonPollJitter    serpent.Duration    `json:"daemon_poll_jitter"    typescript:",notnull"`
 	ForceCancelInterval serpent.Duration    `json:"force_cancel_interval" typescript:",notnull"`
-	DaemonPSK           serpent.String      `json:"daemon_psk" typescript:",notnull"`
+	DaemonPSK           serpent.String      `json:"daemon_psk"            typescript:",notnull"`
 }
 
 type RateLimitConfig struct {
 	DisableAll serpent.Bool  `json:"disable_all" typescript:",notnull"`
-	API        serpent.Int64 `json:"api" typescript:",notnull"`
+	API        serpent.Int64 `json:"api"         typescript:",notnull"`
 }
 
 type SwaggerConfig struct {
@@ -1016,20 +1016,20 @@ type SwaggerConfig struct {
 }
 
 type LoggingConfig struct {
-	Filter      serpent.StringArray `json:"log_filter" typescript:",notnull"`
-	Human       serpent.String      `json:"human" typescript:",notnull"`
-	JSON        serpent.String      `json:"json" typescript:",notnull"`
+	Filter      serpent.StringArray `json:"log_filter"  typescript:",notnull"`
+	Human       serpent.String      `json:"human"       typescript:",notnull"`
+	JSON        serpent.String      `json:"json"        typescript:",notnull"`
 	Stackdriver serpent.String      `json:"stackdriver" typescript:",notnull"`
 }
 
 type DangerousConfig struct {
-	AllowPathAppSharing         serpent.Bool `json:"allow_path_app_sharing" typescript:",notnull"`
+	AllowPathAppSharing         serpent.Bool `json:"allow_path_app_sharing"           typescript:",notnull"`
 	AllowPathAppSiteOwnerAccess serpent.Bool `json:"allow_path_app_site_owner_access" typescript:",notnull"`
-	AllowAllCors                serpent.Bool `json:"allow_all_cors" typescript:",notnull"`
+	AllowAllCors                serpent.Bool `json:"allow_all_cors"                   typescript:",notnull"`
 }
 
 type UserQuietHoursScheduleConfig struct {
-	DefaultSchedule serpent.String `json:"default_schedule" typescript:",notnull"`
+	DefaultSchedule serpent.String `json:"default_schedule"  typescript:",notnull"`
 	AllowUserCustom serpent.Bool   `json:"allow_user_custom" typescript:",notnull"`
 	// TODO: add WindowDuration and the ability to postpone max_deadline by this
 	// amount
@@ -1038,7 +1038,7 @@ type UserQuietHoursScheduleConfig struct {
 
 // HealthcheckConfig contains configuration for healthchecks.
 type HealthcheckConfig struct {
-	Refresh           serpent.Duration `json:"refresh" typescript:",notnull"`
+	Refresh           serpent.Duration `json:"refresh"            typescript:",notnull"`
 	ThresholdDatabase serpent.Duration `json:"threshold_database" typescript:",notnull"`
 }
 
@@ -4001,54 +4001,54 @@ Write out the current server config as YAML to stdout.`,
 }
 
 type AIBridgeConfig struct {
-	Enabled   serpent.Bool            `json:"enabled" typescript:",notnull"`
-	OpenAI    AIBridgeOpenAIConfig    `json:"openai" typescript:",notnull"`
+	Enabled   serpent.Bool            `json:"enabled"   typescript:",notnull"`
+	OpenAI    AIBridgeOpenAIConfig    `json:"openai"    typescript:",notnull"`
 	Anthropic AIBridgeAnthropicConfig `json:"anthropic" typescript:",notnull"`
-	Bedrock   AIBridgeBedrockConfig   `json:"bedrock" typescript:",notnull"`
+	Bedrock   AIBridgeBedrockConfig   `json:"bedrock"   typescript:",notnull"`
 	// Deprecated: Injected MCP in AI Bridge is deprecated and will be removed in a future release.
 	InjectCoderMCPTools serpent.Bool     `json:"inject_coder_mcp_tools" typescript:",notnull"`
-	Retention           serpent.Duration `json:"retention" typescript:",notnull"`
-	MaxConcurrency      serpent.Int64    `json:"max_concurrency" typescript:",notnull"`
-	RateLimit           serpent.Int64    `json:"rate_limit" typescript:",notnull"`
-	StructuredLogging   serpent.Bool     `json:"structured_logging" typescript:",notnull"`
-	SendActorHeaders    serpent.Bool     `json:"send_actor_headers" typescript:",notnull"`
+	Retention           serpent.Duration `json:"retention"              typescript:",notnull"`
+	MaxConcurrency      serpent.Int64    `json:"max_concurrency"        typescript:",notnull"`
+	RateLimit           serpent.Int64    `json:"rate_limit"             typescript:",notnull"`
+	StructuredLogging   serpent.Bool     `json:"structured_logging"     typescript:",notnull"`
+	SendActorHeaders    serpent.Bool     `json:"send_actor_headers"     typescript:",notnull"`
 	// Circuit breaker protects against cascading failures from upstream AI
 	// provider rate limits (429, 503, 529 overloaded).
-	CircuitBreakerEnabled          serpent.Bool     `json:"circuit_breaker_enabled" typescript:",notnull"`
+	CircuitBreakerEnabled          serpent.Bool     `json:"circuit_breaker_enabled"           typescript:",notnull"`
 	CircuitBreakerFailureThreshold serpent.Int64    `json:"circuit_breaker_failure_threshold" typescript:",notnull"`
-	CircuitBreakerInterval         serpent.Duration `json:"circuit_breaker_interval" typescript:",notnull"`
-	CircuitBreakerTimeout          serpent.Duration `json:"circuit_breaker_timeout" typescript:",notnull"`
-	CircuitBreakerMaxRequests      serpent.Int64    `json:"circuit_breaker_max_requests" typescript:",notnull"`
+	CircuitBreakerInterval         serpent.Duration `json:"circuit_breaker_interval"          typescript:",notnull"`
+	CircuitBreakerTimeout          serpent.Duration `json:"circuit_breaker_timeout"           typescript:",notnull"`
+	CircuitBreakerMaxRequests      serpent.Int64    `json:"circuit_breaker_max_requests"      typescript:",notnull"`
 }
 
 type AIBridgeOpenAIConfig struct {
 	BaseURL serpent.String `json:"base_url" typescript:",notnull"`
-	Key     serpent.String `json:"key" typescript:",notnull"`
+	Key     serpent.String `json:"key"      typescript:",notnull"`
 }
 
 type AIBridgeAnthropicConfig struct {
 	BaseURL serpent.String `json:"base_url" typescript:",notnull"`
-	Key     serpent.String `json:"key" typescript:",notnull"`
+	Key     serpent.String `json:"key"      typescript:",notnull"`
 }
 
 type AIBridgeBedrockConfig struct {
-	BaseURL         serpent.String `json:"base_url" typescript:",notnull"`
-	Region          serpent.String `json:"region" typescript:",notnull"`
-	AccessKey       serpent.String `json:"access_key" typescript:",notnull"`
+	BaseURL         serpent.String `json:"base_url"          typescript:",notnull"`
+	Region          serpent.String `json:"region"            typescript:",notnull"`
+	AccessKey       serpent.String `json:"access_key"        typescript:",notnull"`
 	AccessKeySecret serpent.String `json:"access_key_secret" typescript:",notnull"`
-	Model           serpent.String `json:"model" typescript:",notnull"`
-	SmallFastModel  serpent.String `json:"small_fast_model" typescript:",notnull"`
+	Model           serpent.String `json:"model"             typescript:",notnull"`
+	SmallFastModel  serpent.String `json:"small_fast_model"  typescript:",notnull"`
 }
 
 type AIBridgeProxyConfig struct {
-	Enabled         serpent.Bool        `json:"enabled" typescript:",notnull"`
-	ListenAddr      serpent.String      `json:"listen_addr" typescript:",notnull"`
-	TLSCertFile     serpent.String      `json:"tls_cert_file" typescript:",notnull"`
-	TLSKeyFile      serpent.String      `json:"tls_key_file" typescript:",notnull"`
-	MITMCertFile    serpent.String      `json:"cert_file" typescript:",notnull"`
-	MITMKeyFile     serpent.String      `json:"key_file" typescript:",notnull"`
-	DomainAllowlist serpent.StringArray `json:"domain_allowlist" typescript:",notnull"`
-	UpstreamProxy   serpent.String      `json:"upstream_proxy" typescript:",notnull"`
+	Enabled         serpent.Bool        `json:"enabled"           typescript:",notnull"`
+	ListenAddr      serpent.String      `json:"listen_addr"       typescript:",notnull"`
+	TLSCertFile     serpent.String      `json:"tls_cert_file"     typescript:",notnull"`
+	TLSKeyFile      serpent.String      `json:"tls_key_file"      typescript:",notnull"`
+	MITMCertFile    serpent.String      `json:"cert_file"         typescript:",notnull"`
+	MITMKeyFile     serpent.String      `json:"key_file"          typescript:",notnull"`
+	DomainAllowlist serpent.StringArray `json:"domain_allowlist"  typescript:",notnull"`
+	UpstreamProxy   serpent.String      `json:"upstream_proxy"    typescript:",notnull"`
 	UpstreamProxyCA serpent.String      `json:"upstream_proxy_ca" typescript:",notnull"`
 }
 
@@ -4062,9 +4062,9 @@ type SupportConfig struct {
 }
 
 type LinkConfig struct {
-	Name   string `json:"name" yaml:"name"`
+	Name   string `json:"name"   yaml:"name"`
 	Target string `json:"target" yaml:"target"`
-	Icon   string `json:"icon" yaml:"icon" enums:"bug,chat,docs,star"`
+	Icon   string `json:"icon"   yaml:"icon"   enums:"bug,chat,docs,star"`
 
 	Location string `json:"location,omitempty" yaml:"location,omitempty" enums:"navbar,dropdown"`
 }
@@ -4574,7 +4574,7 @@ type CryptoKey struct {
 	Secret    string           `json:"secret"`
 	DeletesAt time.Time        `json:"deletes_at" format:"date-time"`
 	Sequence  int32            `json:"sequence"`
-	StartsAt  time.Time        `json:"starts_at" format:"date-time"`
+	StartsAt  time.Time        `json:"starts_at"  format:"date-time"`
 }
 
 func (c CryptoKey) CanSign(now time.Time) bool {

--- a/codersdk/externalauth.go
+++ b/codersdk/externalauth.go
@@ -84,10 +84,10 @@ type DeleteExternalAuthByIDResponse struct {
 // built from the database and configs.
 type ExternalAuthLink struct {
 	ProviderID      string    `json:"provider_id"`
-	CreatedAt       time.Time `json:"created_at" format:"date-time"`
-	UpdatedAt       time.Time `json:"updated_at" format:"date-time"`
+	CreatedAt       time.Time `json:"created_at"        format:"date-time"`
+	UpdatedAt       time.Time `json:"updated_at"        format:"date-time"`
 	HasRefreshToken bool      `json:"has_refresh_token"`
-	Expires         time.Time `json:"expires" format:"date-time"`
+	Expires         time.Time `json:"expires"           format:"date-time"`
 	Authenticated   bool      `json:"authenticated"`
 	ValidateError   string    `json:"validate_error"`
 }

--- a/codersdk/gitsshkey.go
+++ b/codersdk/gitsshkey.go
@@ -12,7 +12,7 @@ import (
 )
 
 type GitSSHKey struct {
-	UserID    uuid.UUID `json:"user_id" format:"uuid"`
+	UserID    uuid.UUID `json:"user_id"    format:"uuid"`
 	CreatedAt time.Time `json:"created_at" format:"date-time"`
 	UpdatedAt time.Time `json:"updated_at" format:"date-time"`
 	// PublicKey is the SSH public key in OpenSSH format.

--- a/codersdk/groups.go
+++ b/codersdk/groups.go
@@ -20,14 +20,14 @@ const (
 )
 
 type CreateGroupRequest struct {
-	Name           string `json:"name" validate:"required,group_name"`
-	DisplayName    string `json:"display_name" validate:"omitempty,group_display_name"`
+	Name           string `json:"name"            validate:"required,group_name"`
+	DisplayName    string `json:"display_name"    validate:"omitempty,group_display_name"`
 	AvatarURL      string `json:"avatar_url"`
 	QuotaAllowance int    `json:"quota_allowance"`
 }
 
 type Group struct {
-	ID             uuid.UUID     `json:"id" format:"uuid"`
+	ID             uuid.UUID     `json:"id"              format:"uuid"`
 	Name           string        `json:"name"`
 	DisplayName    string        `json:"display_name"`
 	OrganizationID uuid.UUID     `json:"organization_id" format:"uuid"`
@@ -36,7 +36,7 @@ type Group struct {
 	// even if the user is not authorized to read group member details.
 	// May be greater than `len(Group.Members)`.
 	TotalMemberCount        int         `json:"total_member_count"`
-	AvatarURL               string      `json:"avatar_url" format:"uri"`
+	AvatarURL               string      `json:"avatar_url"                format:"uri"`
 	QuotaAllowance          int         `json:"quota_allowance"`
 	Source                  GroupSource `json:"source"`
 	OrganizationName        string      `json:"organization_name"`
@@ -150,8 +150,8 @@ func (c *Client) Group(ctx context.Context, group uuid.UUID) (Group, error) {
 type PatchGroupRequest struct {
 	AddUsers       []string `json:"add_users"`
 	RemoveUsers    []string `json:"remove_users"`
-	Name           string   `json:"name" validate:"omitempty,group_name"`
-	DisplayName    *string  `json:"display_name" validate:"omitempty,group_display_name"`
+	Name           string   `json:"name"            validate:"omitempty,group_name"`
+	DisplayName    *string  `json:"display_name"    validate:"omitempty,group_display_name"`
 	AvatarURL      *string  `json:"avatar_url"`
 	QuotaAllowance *int     `json:"quota_allowance"`
 }

--- a/codersdk/healthsdk/healthsdk.go
+++ b/codersdk/healthsdk/healthsdk.go
@@ -132,7 +132,7 @@ func (r *HealthcheckReport) Summarize(docsURL string) []string {
 // BaseReport holds fields common to various health reports.
 type BaseReport struct {
 	Error     *string          `json:"error,omitempty"`
-	Severity  health.Severity  `json:"severity" enums:"ok,warning,error"`
+	Severity  health.Severity  `json:"severity"        enums:"ok,warning,error"`
 	Warnings  []health.Message `json:"warnings"`
 	Dismissed bool             `json:"dismissed"`
 }
@@ -194,7 +194,7 @@ type DERPHealthReport struct {
 type DERPRegionReport struct {
 	// Healthy is deprecated and left for backward compatibility purposes, use `Severity` instead.
 	Healthy     bool                `json:"healthy"`
-	Severity    health.Severity     `json:"severity" enums:"ok,warning,error"`
+	Severity    health.Severity     `json:"severity"        enums:"ok,warning,error"`
 	Warnings    []health.Message    `json:"warnings"`
 	Error       *string             `json:"error,omitempty"`
 	Region      *tailcfg.DERPRegion `json:"region"`
@@ -205,7 +205,7 @@ type DERPRegionReport struct {
 type DERPNodeReport struct {
 	// Healthy is deprecated and left for backward compatibility purposes, use `Severity` instead.
 	Healthy  bool             `json:"healthy"`
-	Severity health.Severity  `json:"severity" enums:"ok,warning,error"`
+	Severity health.Severity  `json:"severity"        enums:"ok,warning,error"`
 	Warnings []health.Message `json:"warnings"`
 	Error    *string          `json:"error,omitempty"`
 

--- a/codersdk/inboxnotification.go
+++ b/codersdk/inboxnotification.go
@@ -18,16 +18,16 @@ const (
 )
 
 type InboxNotification struct {
-	ID         uuid.UUID                 `json:"id" format:"uuid"`
-	UserID     uuid.UUID                 `json:"user_id" format:"uuid"`
+	ID         uuid.UUID                 `json:"id"          format:"uuid"`
+	UserID     uuid.UUID                 `json:"user_id"     format:"uuid"`
 	TemplateID uuid.UUID                 `json:"template_id" format:"uuid"`
-	Targets    []uuid.UUID               `json:"targets" format:"uuid"`
+	Targets    []uuid.UUID               `json:"targets"     format:"uuid"`
 	Title      string                    `json:"title"`
 	Content    string                    `json:"content"`
 	Icon       string                    `json:"icon"`
 	Actions    []InboxNotificationAction `json:"actions"`
 	ReadAt     *time.Time                `json:"read_at"`
-	CreatedAt  time.Time                 `json:"created_at" format:"date-time"`
+	CreatedAt  time.Time                 `json:"created_at"  format:"date-time"`
 }
 
 type InboxNotificationAction struct {

--- a/codersdk/insights.go
+++ b/codersdk/insights.go
@@ -89,10 +89,10 @@ type UserActivityInsightsReport struct {
 
 // UserActivity shows the session time for a user.
 type UserActivity struct {
-	TemplateIDs []uuid.UUID `json:"template_ids" format:"uuid"`
-	UserID      uuid.UUID   `json:"user_id"      format:"uuid"`
+	TemplateIDs []uuid.UUID `json:"template_ids"                 format:"uuid"`
+	UserID      uuid.UUID   `json:"user_id"                      format:"uuid"`
 	Username    string      `json:"username"`
-	AvatarURL   string      `json:"avatar_url"   format:"uri"`
+	AvatarURL   string      `json:"avatar_url"                   format:"uri"`
 	Seconds     int64       `json:"seconds"      example:"80500"`
 }
 
@@ -174,9 +174,9 @@ type TemplateInsightsResponse struct {
 
 // TemplateInsightsReport is the report from the template insights endpoint.
 type TemplateInsightsReport struct {
-	StartTime       time.Time                `json:"start_time"       format:"date-time"`
-	EndTime         time.Time                `json:"end_time"         format:"date-time"`
-	TemplateIDs     []uuid.UUID              `json:"template_ids"     format:"uuid"`
+	StartTime       time.Time                `json:"start_time"                    format:"date-time"`
+	EndTime         time.Time                `json:"end_time"                      format:"date-time"`
+	TemplateIDs     []uuid.UUID              `json:"template_ids"                  format:"uuid"`
 	ActiveUsers     int64                    `json:"active_users"     example:"22"`
 	AppsUsage       []TemplateAppUsage       `json:"apps_usage"`
 	ParametersUsage []TemplateParameterUsage `json:"parameters_usage"`
@@ -185,9 +185,9 @@ type TemplateInsightsReport struct {
 // TemplateInsightsIntervalReport is the report from the template insights
 // endpoint for a specific interval.
 type TemplateInsightsIntervalReport struct {
-	StartTime   time.Time              `json:"start_time"   format:"date-time"`
-	EndTime     time.Time              `json:"end_time"     format:"date-time"`
-	TemplateIDs []uuid.UUID            `json:"template_ids" format:"uuid"`
+	StartTime   time.Time              `json:"start_time"                  format:"date-time"`
+	EndTime     time.Time              `json:"end_time"                    format:"date-time"`
+	TemplateIDs []uuid.UUID            `json:"template_ids"                format:"uuid"`
 	Interval    InsightsReportInterval `json:"interval"     example:"week"`
 	ActiveUsers int64                  `json:"active_users" example:"14"`
 }
@@ -212,7 +212,7 @@ const (
 
 // TemplateAppUsage shows the usage of an app for one or more templates.
 type TemplateAppUsage struct {
-	TemplateIDs []uuid.UUID      `json:"template_ids" format:"uuid"`
+	TemplateIDs []uuid.UUID      `json:"template_ids"                              format:"uuid"`
 	Type        TemplateAppsType `json:"type"         example:"builtin"`
 	DisplayName string           `json:"display_name" example:"Visual Studio Code"`
 	Slug        string           `json:"slug"         example:"vscode"`
@@ -241,9 +241,9 @@ type TemplateParameterValue struct {
 }
 
 type TemplateInsightsRequest struct {
-	StartTime   time.Time                 `json:"start_time"   format:"date-time"`
-	EndTime     time.Time                 `json:"end_time"     format:"date-time"`
-	TemplateIDs []uuid.UUID               `json:"template_ids" format:"uuid"`
+	StartTime   time.Time                 `json:"start_time"                    format:"date-time"`
+	EndTime     time.Time                 `json:"end_time"                      format:"date-time"`
+	TemplateIDs []uuid.UUID               `json:"template_ids"                  format:"uuid"`
 	Interval    InsightsReportInterval    `json:"interval"     example:"day"`
 	Sections    []TemplateInsightsSection `json:"sections"     example:"report"`
 }
@@ -289,7 +289,7 @@ type GetUserStatusCountsResponse struct {
 }
 
 type UserStatusChangeCount struct {
-	Date  time.Time `json:"date"  format:"date-time"`
+	Date  time.Time `json:"date"               format:"date-time"`
 	Count int64     `json:"count" example:"10"`
 }
 

--- a/codersdk/insights.go
+++ b/codersdk/insights.go
@@ -57,8 +57,8 @@ type UserLatencyInsightsResponse struct {
 // UserLatencyInsightsReport is the report from the user latency insights
 // endpoint.
 type UserLatencyInsightsReport struct {
-	StartTime   time.Time     `json:"start_time" format:"date-time"`
-	EndTime     time.Time     `json:"end_time" format:"date-time"`
+	StartTime   time.Time     `json:"start_time"   format:"date-time"`
+	EndTime     time.Time     `json:"end_time"     format:"date-time"`
 	TemplateIDs []uuid.UUID   `json:"template_ids" format:"uuid"`
 	Users       []UserLatency `json:"users"`
 }
@@ -66,9 +66,9 @@ type UserLatencyInsightsReport struct {
 // UserLatency shows the connection latency for a user.
 type UserLatency struct {
 	TemplateIDs []uuid.UUID       `json:"template_ids" format:"uuid"`
-	UserID      uuid.UUID         `json:"user_id" format:"uuid"`
+	UserID      uuid.UUID         `json:"user_id"      format:"uuid"`
 	Username    string            `json:"username"`
-	AvatarURL   string            `json:"avatar_url" format:"uri"`
+	AvatarURL   string            `json:"avatar_url"   format:"uri"`
 	LatencyMS   ConnectionLatency `json:"latency_ms"`
 }
 
@@ -81,8 +81,8 @@ type UserActivityInsightsResponse struct {
 // UserActivityInsightsReport is the report from the user activity insights
 // endpoint.
 type UserActivityInsightsReport struct {
-	StartTime   time.Time      `json:"start_time" format:"date-time"`
-	EndTime     time.Time      `json:"end_time" format:"date-time"`
+	StartTime   time.Time      `json:"start_time"   format:"date-time"`
+	EndTime     time.Time      `json:"end_time"     format:"date-time"`
 	TemplateIDs []uuid.UUID    `json:"template_ids" format:"uuid"`
 	Users       []UserActivity `json:"users"`
 }
@@ -90,10 +90,10 @@ type UserActivityInsightsReport struct {
 // UserActivity shows the session time for a user.
 type UserActivity struct {
 	TemplateIDs []uuid.UUID `json:"template_ids" format:"uuid"`
-	UserID      uuid.UUID   `json:"user_id" format:"uuid"`
+	UserID      uuid.UUID   `json:"user_id"      format:"uuid"`
 	Username    string      `json:"username"`
-	AvatarURL   string      `json:"avatar_url" format:"uri"`
-	Seconds     int64       `json:"seconds" example:"80500"`
+	AvatarURL   string      `json:"avatar_url"   format:"uri"`
+	Seconds     int64       `json:"seconds"      example:"80500"`
 }
 
 // ConnectionLatency shows the latency for a connection.
@@ -103,8 +103,8 @@ type ConnectionLatency struct {
 }
 
 type UserLatencyInsightsRequest struct {
-	StartTime   time.Time   `json:"start_time" format:"date-time"`
-	EndTime     time.Time   `json:"end_time" format:"date-time"`
+	StartTime   time.Time   `json:"start_time"   format:"date-time"`
+	EndTime     time.Time   `json:"end_time"     format:"date-time"`
 	TemplateIDs []uuid.UUID `json:"template_ids" format:"uuid"`
 }
 
@@ -135,8 +135,8 @@ func (c *Client) UserLatencyInsights(ctx context.Context, req UserLatencyInsight
 }
 
 type UserActivityInsightsRequest struct {
-	StartTime   time.Time   `json:"start_time" format:"date-time"`
-	EndTime     time.Time   `json:"end_time" format:"date-time"`
+	StartTime   time.Time   `json:"start_time"   format:"date-time"`
+	EndTime     time.Time   `json:"end_time"     format:"date-time"`
 	TemplateIDs []uuid.UUID `json:"template_ids" format:"uuid"`
 }
 
@@ -174,10 +174,10 @@ type TemplateInsightsResponse struct {
 
 // TemplateInsightsReport is the report from the template insights endpoint.
 type TemplateInsightsReport struct {
-	StartTime       time.Time                `json:"start_time" format:"date-time"`
-	EndTime         time.Time                `json:"end_time" format:"date-time"`
-	TemplateIDs     []uuid.UUID              `json:"template_ids" format:"uuid"`
-	ActiveUsers     int64                    `json:"active_users" example:"22"`
+	StartTime       time.Time                `json:"start_time"       format:"date-time"`
+	EndTime         time.Time                `json:"end_time"         format:"date-time"`
+	TemplateIDs     []uuid.UUID              `json:"template_ids"     format:"uuid"`
+	ActiveUsers     int64                    `json:"active_users"     example:"22"`
 	AppsUsage       []TemplateAppUsage       `json:"apps_usage"`
 	ParametersUsage []TemplateParameterUsage `json:"parameters_usage"`
 }
@@ -185,10 +185,10 @@ type TemplateInsightsReport struct {
 // TemplateInsightsIntervalReport is the report from the template insights
 // endpoint for a specific interval.
 type TemplateInsightsIntervalReport struct {
-	StartTime   time.Time              `json:"start_time" format:"date-time"`
-	EndTime     time.Time              `json:"end_time" format:"date-time"`
+	StartTime   time.Time              `json:"start_time"   format:"date-time"`
+	EndTime     time.Time              `json:"end_time"     format:"date-time"`
 	TemplateIDs []uuid.UUID            `json:"template_ids" format:"uuid"`
-	Interval    InsightsReportInterval `json:"interval" example:"week"`
+	Interval    InsightsReportInterval `json:"interval"     example:"week"`
 	ActiveUsers int64                  `json:"active_users" example:"14"`
 }
 
@@ -213,18 +213,18 @@ const (
 // TemplateAppUsage shows the usage of an app for one or more templates.
 type TemplateAppUsage struct {
 	TemplateIDs []uuid.UUID      `json:"template_ids" format:"uuid"`
-	Type        TemplateAppsType `json:"type" example:"builtin"`
+	Type        TemplateAppsType `json:"type"         example:"builtin"`
 	DisplayName string           `json:"display_name" example:"Visual Studio Code"`
-	Slug        string           `json:"slug" example:"vscode"`
+	Slug        string           `json:"slug"         example:"vscode"`
 	Icon        string           `json:"icon"`
-	Seconds     int64            `json:"seconds" example:"80500"`
-	TimesUsed   int64            `json:"times_used" example:"2"`
+	Seconds     int64            `json:"seconds"      example:"80500"`
+	TimesUsed   int64            `json:"times_used"   example:"2"`
 }
 
 // TemplateParameterUsage shows the usage of a parameter for one or more
 // templates.
 type TemplateParameterUsage struct {
-	TemplateIDs []uuid.UUID                      `json:"template_ids" format:"uuid"`
+	TemplateIDs []uuid.UUID                      `json:"template_ids"      format:"uuid"`
 	DisplayName string                           `json:"display_name"`
 	Name        string                           `json:"name"`
 	Type        string                           `json:"type"`
@@ -241,11 +241,11 @@ type TemplateParameterValue struct {
 }
 
 type TemplateInsightsRequest struct {
-	StartTime   time.Time                 `json:"start_time" format:"date-time"`
-	EndTime     time.Time                 `json:"end_time" format:"date-time"`
+	StartTime   time.Time                 `json:"start_time"   format:"date-time"`
+	EndTime     time.Time                 `json:"end_time"     format:"date-time"`
 	TemplateIDs []uuid.UUID               `json:"template_ids" format:"uuid"`
-	Interval    InsightsReportInterval    `json:"interval" example:"day"`
-	Sections    []TemplateInsightsSection `json:"sections" example:"report"`
+	Interval    InsightsReportInterval    `json:"interval"     example:"day"`
+	Sections    []TemplateInsightsSection `json:"sections"     example:"report"`
 }
 
 func (c *Client) TemplateInsights(ctx context.Context, req TemplateInsightsRequest) (TemplateInsightsResponse, error) {
@@ -289,7 +289,7 @@ type GetUserStatusCountsResponse struct {
 }
 
 type UserStatusChangeCount struct {
-	Date  time.Time `json:"date" format:"date-time"`
+	Date  time.Time `json:"date"  format:"date-time"`
 	Count int64     `json:"count" example:"10"`
 }
 

--- a/codersdk/licenses.go
+++ b/codersdk/licenses.go
@@ -23,7 +23,7 @@ type AddLicenseRequest struct {
 
 type License struct {
 	ID         int32     `json:"id"`
-	UUID       uuid.UUID `json:"uuid" format:"uuid"`
+	UUID       uuid.UUID `json:"uuid"        format:"uuid"`
 	UploadedAt time.Time `json:"uploaded_at" format:"date-time"`
 	// Claims are the JWT claims asserted by the license.  Here we use
 	// a generic string map to ensure that all data from the server is

--- a/codersdk/notifications.go
+++ b/codersdk/notifications.go
@@ -18,11 +18,11 @@ type NotificationsSettings struct {
 }
 
 type NotificationTemplate struct {
-	ID               uuid.UUID `json:"id" format:"uuid"`
+	ID               uuid.UUID `json:"id"                 format:"uuid"`
 	Name             string    `json:"name"`
 	TitleTemplate    string    `json:"title_template"`
 	BodyTemplate     string    `json:"body_template"`
-	Actions          string    `json:"actions" format:""`
+	Actions          string    `json:"actions"            format:""`
 	Group            string    `json:"group"`
 	Method           string    `json:"method"`
 	Kind             string    `json:"kind"`
@@ -35,7 +35,7 @@ type NotificationMethodsResponse struct {
 }
 
 type NotificationPreference struct {
-	NotificationTemplateID uuid.UUID `json:"id" format:"uuid"`
+	NotificationTemplateID uuid.UUID `json:"id"         format:"uuid"`
 	Disabled               bool      `json:"disabled"`
 	UpdatedAt              time.Time `json:"updated_at" format:"date-time"`
 }

--- a/codersdk/oauth2.go
+++ b/codersdk/oauth2.go
@@ -14,7 +14,7 @@ import (
 )
 
 type OAuth2ProviderApp struct {
-	ID          uuid.UUID `json:"id" format:"uuid"`
+	ID          uuid.UUID `json:"id"           format:"uuid"`
 	Name        string    `json:"name"`
 	CallbackURL string    `json:"callback_url"`
 	Icon        string    `json:"icon"`
@@ -75,9 +75,9 @@ func (c *Client) OAuth2ProviderApp(ctx context.Context, id uuid.UUID) (OAuth2Pro
 }
 
 type PostOAuth2ProviderAppRequest struct {
-	Name        string `json:"name" validate:"required,oauth2_app_name"`
+	Name        string `json:"name"         validate:"required,oauth2_app_name"`
 	CallbackURL string `json:"callback_url" validate:"required,http_url"`
-	Icon        string `json:"icon" validate:"omitempty"`
+	Icon        string `json:"icon"         validate:"omitempty"`
 }
 
 // PostOAuth2ProviderApp adds an application that can authenticate using Coder
@@ -96,9 +96,9 @@ func (c *Client) PostOAuth2ProviderApp(ctx context.Context, app PostOAuth2Provid
 }
 
 type PutOAuth2ProviderAppRequest struct {
-	Name        string `json:"name" validate:"required,oauth2_app_name"`
+	Name        string `json:"name"         validate:"required,oauth2_app_name"`
 	CallbackURL string `json:"callback_url" validate:"required,http_url"`
-	Icon        string `json:"icon" validate:"omitempty"`
+	Icon        string `json:"icon"         validate:"omitempty"`
 }
 
 // PutOAuth2ProviderApp updates an application that can authenticate using Coder
@@ -131,12 +131,12 @@ func (c *Client) DeleteOAuth2ProviderApp(ctx context.Context, id uuid.UUID) erro
 }
 
 type OAuth2ProviderAppSecretFull struct {
-	ID               uuid.UUID `json:"id" format:"uuid"`
+	ID               uuid.UUID `json:"id"                 format:"uuid"`
 	ClientSecretFull string    `json:"client_secret_full"`
 }
 
 type OAuth2ProviderAppSecret struct {
-	ID                    uuid.UUID `json:"id" format:"uuid"`
+	ID                    uuid.UUID `json:"id"                      format:"uuid"`
 	LastUsedAt            NullTime  `json:"last_used_at"`
 	ClientSecretTruncated string    `json:"client_secret_truncated"`
 }
@@ -444,7 +444,7 @@ type OAuth2ClientRegistrationRequest struct {
 	TOSURI                  string                        `json:"tos_uri,omitempty"`
 	PolicyURI               string                        `json:"policy_uri,omitempty"`
 	JWKSURI                 string                        `json:"jwks_uri,omitempty"`
-	JWKS                    json.RawMessage               `json:"jwks,omitempty" swaggertype:"object"`
+	JWKS                    json.RawMessage               `json:"jwks,omitempty"                       swaggertype:"object"`
 	SoftwareID              string                        `json:"software_id,omitempty"`
 	SoftwareVersion         string                        `json:"software_version,omitempty"`
 	SoftwareStatement       string                        `json:"software_statement,omitempty"`
@@ -547,7 +547,7 @@ type OAuth2ClientRegistrationResponse struct {
 	TOSURI                  string                        `json:"tos_uri,omitempty"`
 	PolicyURI               string                        `json:"policy_uri,omitempty"`
 	JWKSURI                 string                        `json:"jwks_uri,omitempty"`
-	JWKS                    json.RawMessage               `json:"jwks,omitempty" swaggertype:"object"`
+	JWKS                    json.RawMessage               `json:"jwks,omitempty"                     swaggertype:"object"`
 	SoftwareID              string                        `json:"software_id,omitempty"`
 	SoftwareVersion         string                        `json:"software_version,omitempty"`
 	GrantTypes              []OAuth2ProviderGrantType     `json:"grant_types"`
@@ -635,7 +635,7 @@ type OAuth2ClientConfiguration struct {
 	TOSURI                  string                        `json:"tos_uri,omitempty"`
 	PolicyURI               string                        `json:"policy_uri,omitempty"`
 	JWKSURI                 string                        `json:"jwks_uri,omitempty"`
-	JWKS                    json.RawMessage               `json:"jwks,omitempty" swaggertype:"object"`
+	JWKS                    json.RawMessage               `json:"jwks,omitempty"                      swaggertype:"object"`
 	SoftwareID              string                        `json:"software_id,omitempty"`
 	SoftwareVersion         string                        `json:"software_version,omitempty"`
 	GrantTypes              []OAuth2ProviderGrantType     `json:"grant_types"`

--- a/codersdk/organizations.go
+++ b/codersdk/organizations.go
@@ -42,19 +42,19 @@ func ProvisionerTypeValid[T ProvisionerType | string](pt T) error {
 }
 
 type MinimalOrganization struct {
-	ID          uuid.UUID `table:"id" json:"id" validate:"required" format:"uuid"`
+	ID          uuid.UUID `table:"id"                json:"id"           validate:"required" format:"uuid"`
 	Name        string    `table:"name,default_sort" json:"name"`
-	DisplayName string    `table:"display name" json:"display_name"`
-	Icon        string    `table:"icon" json:"icon"`
+	DisplayName string    `table:"display name"      json:"display_name"`
+	Icon        string    `table:"icon"              json:"icon"`
 }
 
 // Organization is the JSON representation of a Coder organization.
 type Organization struct {
 	MinimalOrganization `table:"m,recursive_inline"`
-	Description         string    `table:"description" json:"description"`
-	CreatedAt           time.Time `table:"created at" json:"created_at" validate:"required" format:"date-time"`
-	UpdatedAt           time.Time `table:"updated at" json:"updated_at" validate:"required" format:"date-time"`
-	IsDefault           bool      `table:"default" json:"is_default" validate:"required"`
+	Description         string    `table:"description"        json:"description"`
+	CreatedAt           time.Time `table:"created at"         json:"created_at"  validate:"required" format:"date-time"`
+	UpdatedAt           time.Time `table:"updated at"         json:"updated_at"  validate:"required" format:"date-time"`
+	IsDefault           bool      `table:"default"            json:"is_default"  validate:"required"`
 }
 
 func (o Organization) HumanName() string {
@@ -65,16 +65,16 @@ func (o Organization) HumanName() string {
 }
 
 type OrganizationMember struct {
-	UserID         uuid.UUID  `table:"user id" json:"user_id" format:"uuid"`
-	OrganizationID uuid.UUID  `table:"organization id" json:"organization_id" format:"uuid"`
-	CreatedAt      time.Time  `table:"created at" json:"created_at" format:"date-time"`
-	UpdatedAt      time.Time  `table:"updated at" json:"updated_at" format:"date-time"`
+	UserID         uuid.UUID  `table:"user id"            json:"user_id"         format:"uuid"`
+	OrganizationID uuid.UUID  `table:"organization id"    json:"organization_id" format:"uuid"`
+	CreatedAt      time.Time  `table:"created at"         json:"created_at"      format:"date-time"`
+	UpdatedAt      time.Time  `table:"updated at"         json:"updated_at"      format:"date-time"`
 	Roles          []SlimRole `table:"organization roles" json:"roles"`
 }
 
 type OrganizationMemberWithUserData struct {
 	Username           string     `table:"username,default_sort" json:"username"`
-	Name               string     `table:"name" json:"name,omitempty"`
+	Name               string     `table:"name"                  json:"name,omitempty"`
 	AvatarURL          string     `json:"avatar_url,omitempty"`
 	Email              string     `json:"email"`
 	GlobalRoles        []SlimRole `json:"global_roles"`
@@ -100,7 +100,7 @@ type CreateOrganizationRequest struct {
 }
 
 type UpdateOrganizationRequest struct {
-	Name        string  `json:"name,omitempty" validate:"omitempty,organization_name"`
+	Name        string  `json:"name,omitempty"         validate:"omitempty,organization_name"`
 	DisplayName string  `json:"display_name,omitempty" validate:"omitempty,organization_display_name"`
 	Description *string `json:"description,omitempty"`
 	Icon        *string `json:"icon,omitempty"`
@@ -108,14 +108,14 @@ type UpdateOrganizationRequest struct {
 
 // CreateTemplateVersionRequest enables callers to create a new Template Version.
 type CreateTemplateVersionRequest struct {
-	Name    string `json:"name,omitempty" validate:"omitempty,template_version_name"`
+	Name    string `json:"name,omitempty"    validate:"omitempty,template_version_name"`
 	Message string `json:"message,omitempty" validate:"lt=1048577"`
 	// TemplateID optionally associates a version with a template.
 	TemplateID      uuid.UUID                `json:"template_id,omitempty" format:"uuid"`
-	StorageMethod   ProvisionerStorageMethod `json:"storage_method" validate:"oneof=file,required" enums:"file"`
-	FileID          uuid.UUID                `json:"file_id,omitempty" validate:"required_without=ExampleID" format:"uuid"`
-	ExampleID       string                   `json:"example_id,omitempty" validate:"required_without=FileID"`
-	Provisioner     ProvisionerType          `json:"provisioner" validate:"oneof=terraform echo,required"`
+	StorageMethod   ProvisionerStorageMethod `json:"storage_method"        validate:"oneof=file,required"           enums:"file"`
+	FileID          uuid.UUID                `json:"file_id,omitempty"     validate:"required_without=ExampleID"    format:"uuid"`
+	ExampleID       string                   `json:"example_id,omitempty"  validate:"required_without=FileID"`
+	Provisioner     ProvisionerType          `json:"provisioner"           validate:"oneof=terraform echo,required"`
 	ProvisionerTags map[string]string        `json:"tags"`
 
 	UserVariableValues []VariableValue `json:"user_variable_values,omitempty"`
@@ -228,7 +228,7 @@ type CreateWorkspaceRequest struct {
 	TemplateID uuid.UUID `json:"template_id,omitempty" validate:"required_without=TemplateVersionID,excluded_with=TemplateVersionID" format:"uuid"`
 	// TemplateVersionID can be used to specify a specific version of a template for creating the workspace.
 	TemplateVersionID uuid.UUID `json:"template_version_id,omitempty" validate:"required_without=TemplateID,excluded_with=TemplateID" format:"uuid"`
-	Name              string    `json:"name" validate:"workspace_name,required"`
+	Name              string    `json:"name"                          validate:"workspace_name,required"`
 	AutostartSchedule *string   `json:"autostart_schedule,omitempty"`
 	TTLMillis         *int64    `json:"ttl_ms,omitempty"`
 	// RichParameterValues allows for additional parameters to be provided

--- a/codersdk/organizations.go
+++ b/codersdk/organizations.go
@@ -42,19 +42,19 @@ func ProvisionerTypeValid[T ProvisionerType | string](pt T) error {
 }
 
 type MinimalOrganization struct {
-	ID          uuid.UUID `table:"id"                json:"id"           validate:"required" format:"uuid"`
-	Name        string    `table:"name,default_sort" json:"name"`
-	DisplayName string    `table:"display name"      json:"display_name"`
-	Icon        string    `table:"icon"              json:"icon"`
+	ID          uuid.UUID `json:"id"           table:"id"                format:"uuid" validate:"required"`
+	Name        string    `json:"name"         table:"name,default_sort"`
+	DisplayName string    `json:"display_name" table:"display name"`
+	Icon        string    `json:"icon"         table:"icon"`
 }
 
 // Organization is the JSON representation of a Coder organization.
 type Organization struct {
-	MinimalOrganization `table:"m,recursive_inline"`
-	Description         string    `table:"description"        json:"description"`
-	CreatedAt           time.Time `table:"created at"         json:"created_at"  validate:"required" format:"date-time"`
-	UpdatedAt           time.Time `table:"updated at"         json:"updated_at"  validate:"required" format:"date-time"`
-	IsDefault           bool      `table:"default"            json:"is_default"  validate:"required"`
+	MinimalOrganization `                   table:"m,recursive_inline"`
+	Description         string    `json:"description" table:"description"`
+	CreatedAt           time.Time `json:"created_at"  table:"created at"         format:"date-time" validate:"required"`
+	UpdatedAt           time.Time `json:"updated_at"  table:"updated at"         format:"date-time" validate:"required"`
+	IsDefault           bool      `json:"is_default"  table:"default"                               validate:"required"`
 }
 
 func (o Organization) HumanName() string {
@@ -65,20 +65,20 @@ func (o Organization) HumanName() string {
 }
 
 type OrganizationMember struct {
-	UserID         uuid.UUID  `table:"user id"            json:"user_id"         format:"uuid"`
-	OrganizationID uuid.UUID  `table:"organization id"    json:"organization_id" format:"uuid"`
-	CreatedAt      time.Time  `table:"created at"         json:"created_at"      format:"date-time"`
-	UpdatedAt      time.Time  `table:"updated at"         json:"updated_at"      format:"date-time"`
-	Roles          []SlimRole `table:"organization roles" json:"roles"`
+	UserID         uuid.UUID  `json:"user_id"         table:"user id"            format:"uuid"`
+	OrganizationID uuid.UUID  `json:"organization_id" table:"organization id"    format:"uuid"`
+	CreatedAt      time.Time  `json:"created_at"      table:"created at"         format:"date-time"`
+	UpdatedAt      time.Time  `json:"updated_at"      table:"updated at"         format:"date-time"`
+	Roles          []SlimRole `json:"roles"           table:"organization roles"`
 }
 
 type OrganizationMemberWithUserData struct {
-	Username           string     `table:"username,default_sort" json:"username"`
-	Name               string     `table:"name"                  json:"name,omitempty"`
+	Username           string     `json:"username"             table:"username,default_sort"`
+	Name               string     `json:"name,omitempty"       table:"name"`
 	AvatarURL          string     `json:"avatar_url,omitempty"`
 	Email              string     `json:"email"`
 	GlobalRoles        []SlimRole `json:"global_roles"`
-	OrganizationMember `table:"m,recursive_inline"`
+	OrganizationMember `                            table:"m,recursive_inline"`
 }
 
 type PaginatedMembersRequest struct {
@@ -111,11 +111,11 @@ type CreateTemplateVersionRequest struct {
 	Name    string `json:"name,omitempty"    validate:"omitempty,template_version_name"`
 	Message string `json:"message,omitempty" validate:"lt=1048577"`
 	// TemplateID optionally associates a version with a template.
-	TemplateID      uuid.UUID                `json:"template_id,omitempty" format:"uuid"`
-	StorageMethod   ProvisionerStorageMethod `json:"storage_method"        validate:"oneof=file,required"           enums:"file"`
-	FileID          uuid.UUID                `json:"file_id,omitempty"     validate:"required_without=ExampleID"    format:"uuid"`
-	ExampleID       string                   `json:"example_id,omitempty"  validate:"required_without=FileID"`
-	Provisioner     ProvisionerType          `json:"provisioner"           validate:"oneof=terraform echo,required"`
+	TemplateID      uuid.UUID                `json:"template_id,omitempty"              format:"uuid"`
+	StorageMethod   ProvisionerStorageMethod `json:"storage_method"        enums:"file"               validate:"oneof=file,required"`
+	FileID          uuid.UUID                `json:"file_id,omitempty"                  format:"uuid" validate:"required_without=ExampleID"`
+	ExampleID       string                   `json:"example_id,omitempty"                             validate:"required_without=FileID"`
+	Provisioner     ProvisionerType          `json:"provisioner"                                      validate:"oneof=terraform echo,required"`
 	ProvisionerTags map[string]string        `json:"tags"`
 
 	UserVariableValues []VariableValue `json:"user_variable_values,omitempty"`
@@ -145,7 +145,7 @@ type CreateTemplateRequest struct {
 	// This is required on creation to enable a user-flow of validating a
 	// template works. There is no reason the data-model cannot support empty
 	// templates, but it doesn't make sense for users.
-	VersionID uuid.UUID `json:"template_version_id" validate:"required" format:"uuid"`
+	VersionID uuid.UUID `json:"template_version_id" format:"uuid" validate:"required"`
 
 	// DefaultTTLMillis allows optionally specifying the default TTL
 	// for all workspaces created from this template.
@@ -225,10 +225,10 @@ type CreateTemplateRequest struct {
 // @Description - Maximum length of 32 characters
 type CreateWorkspaceRequest struct {
 	// TemplateID specifies which template should be used for creating the workspace.
-	TemplateID uuid.UUID `json:"template_id,omitempty" validate:"required_without=TemplateVersionID,excluded_with=TemplateVersionID" format:"uuid"`
+	TemplateID uuid.UUID `json:"template_id,omitempty" format:"uuid" validate:"required_without=TemplateVersionID,excluded_with=TemplateVersionID"`
 	// TemplateVersionID can be used to specify a specific version of a template for creating the workspace.
-	TemplateVersionID uuid.UUID `json:"template_version_id,omitempty" validate:"required_without=TemplateID,excluded_with=TemplateID" format:"uuid"`
-	Name              string    `json:"name"                          validate:"workspace_name,required"`
+	TemplateVersionID uuid.UUID `json:"template_version_id,omitempty" format:"uuid" validate:"required_without=TemplateID,excluded_with=TemplateID"`
+	Name              string    `json:"name"                                        validate:"workspace_name,required"`
 	AutostartSchedule *string   `json:"autostart_schedule,omitempty"`
 	TTLMillis         *int64    `json:"ttl_ms,omitempty"`
 	// RichParameterValues allows for additional parameters to be provided
@@ -554,10 +554,10 @@ func (c *Client) TemplatesByOrganization(ctx context.Context, organizationID uui
 }
 
 type TemplateFilter struct {
-	OrganizationID uuid.UUID `typescript:"-"`
-	ExactName      string    `typescript:"-"`
-	FuzzyName      string    `typescript:"-"`
-	AuthorUsername string    `typescript:"-"`
+	OrganizationID uuid.UUID `                   typescript:"-"`
+	ExactName      string    `                   typescript:"-"`
+	FuzzyName      string    `                   typescript:"-"`
+	AuthorUsername string    `                   typescript:"-"`
 	SearchQuery    string    `json:"q,omitempty"`
 }
 

--- a/codersdk/provisionerdaemons.go
+++ b/codersdk/provisionerdaemons.go
@@ -57,29 +57,29 @@ func ProvisionerDaemonStatusEnums() []ProvisionerDaemonStatus {
 }
 
 type ProvisionerDaemon struct {
-	ID             uuid.UUID         `json:"id" format:"uuid" table:"id"`
-	OrganizationID uuid.UUID         `json:"organization_id" format:"uuid" table:"organization id"`
-	KeyID          uuid.UUID         `json:"key_id" format:"uuid" table:"-"`
-	CreatedAt      time.Time         `json:"created_at" format:"date-time" table:"created at"`
-	LastSeenAt     NullTime          `json:"last_seen_at,omitempty" format:"date-time" table:"last seen at"`
-	Name           string            `json:"name" table:"name,default_sort"`
-	Version        string            `json:"version" table:"version"`
-	APIVersion     string            `json:"api_version" table:"api version"`
-	Provisioners   []ProvisionerType `json:"provisioners" table:"-"`
-	Tags           map[string]string `json:"tags" table:"tags"`
+	ID             uuid.UUID         `json:"id"                     format:"uuid"             table:"id"`
+	OrganizationID uuid.UUID         `json:"organization_id"        format:"uuid"             table:"organization id"`
+	KeyID          uuid.UUID         `json:"key_id"                 format:"uuid"             table:"-"`
+	CreatedAt      time.Time         `json:"created_at"             format:"date-time"        table:"created at"`
+	LastSeenAt     NullTime          `json:"last_seen_at,omitempty" format:"date-time"        table:"last seen at"`
+	Name           string            `json:"name"                   table:"name,default_sort"`
+	Version        string            `json:"version"                table:"version"`
+	APIVersion     string            `json:"api_version"            table:"api version"`
+	Provisioners   []ProvisionerType `json:"provisioners"           table:"-"`
+	Tags           map[string]string `json:"tags"                   table:"tags"`
 
 	// Optional fields.
-	KeyName     *string                  `json:"key_name" table:"key name"`
-	Status      *ProvisionerDaemonStatus `json:"status" enums:"offline,idle,busy" table:"status"`
-	CurrentJob  *ProvisionerDaemonJob    `json:"current_job" table:"current job,recursive"`
+	KeyName     *string                  `json:"key_name"     table:"key name"`
+	Status      *ProvisionerDaemonStatus `json:"status"       enums:"offline,idle,busy"      table:"status"`
+	CurrentJob  *ProvisionerDaemonJob    `json:"current_job"  table:"current job,recursive"`
 	PreviousJob *ProvisionerDaemonJob    `json:"previous_job" table:"previous job,recursive"`
 }
 
 type ProvisionerDaemonJob struct {
-	ID                  uuid.UUID            `json:"id" format:"uuid" table:"id"`
-	Status              ProvisionerJobStatus `json:"status" enums:"pending,running,succeeded,canceling,canceled,failed" table:"status"`
-	TemplateName        string               `json:"template_name" table:"template name"`
-	TemplateIcon        string               `json:"template_icon" table:"template icon"`
+	ID                  uuid.UUID            `json:"id"                    format:"uuid"                                               table:"id"`
+	Status              ProvisionerJobStatus `json:"status"                enums:"pending,running,succeeded,canceling,canceled,failed" table:"status"`
+	TemplateName        string               `json:"template_name"         table:"template name"`
+	TemplateIcon        string               `json:"template_icon"         table:"template icon"`
 	TemplateDisplayName string               `json:"template_display_name" table:"template display name"`
 }
 
@@ -137,18 +137,18 @@ func ProvisionerJobStatusEnums() []ProvisionerJobStatus {
 // ProvisionerJobInput represents the input for the job.
 type ProvisionerJobInput struct {
 	TemplateVersionID *uuid.UUID `json:"template_version_id,omitempty" format:"uuid" table:"template version id"`
-	WorkspaceBuildID  *uuid.UUID `json:"workspace_build_id,omitempty" format:"uuid" table:"workspace build id"`
-	Error             string     `json:"error,omitempty" table:"-"`
+	WorkspaceBuildID  *uuid.UUID `json:"workspace_build_id,omitempty"  format:"uuid" table:"workspace build id"`
+	Error             string     `json:"error,omitempty"               table:"-"`
 }
 
 // ProvisionerJobMetadata contains metadata for the job.
 type ProvisionerJobMetadata struct {
-	TemplateVersionName string     `json:"template_version_name" table:"template version name"`
-	TemplateID          uuid.UUID  `json:"template_id" format:"uuid" table:"template id"`
-	TemplateName        string     `json:"template_name" table:"template name"`
-	TemplateDisplayName string     `json:"template_display_name" table:"template display name"`
-	TemplateIcon        string     `json:"template_icon" table:"template icon"`
-	WorkspaceID         *uuid.UUID `json:"workspace_id,omitempty" format:"uuid" table:"workspace id"`
+	TemplateVersionName string     `json:"template_version_name"    table:"template version name"`
+	TemplateID          uuid.UUID  `json:"template_id"              format:"uuid"                 table:"template id"`
+	TemplateName        string     `json:"template_name"            table:"template name"`
+	TemplateDisplayName string     `json:"template_display_name"    table:"template display name"`
+	TemplateIcon        string     `json:"template_icon"            table:"template icon"`
+	WorkspaceID         *uuid.UUID `json:"workspace_id,omitempty"   format:"uuid"                 table:"workspace id"`
 	WorkspaceName       string     `json:"workspace_name,omitempty" table:"workspace name"`
 }
 
@@ -182,27 +182,27 @@ func JobIsMissingRequiredTemplateVariableErrorCode(code JobErrorCode) bool {
 
 // ProvisionerJob describes the job executed by the provisioning daemon.
 type ProvisionerJob struct {
-	ID               uuid.UUID              `json:"id" format:"uuid" table:"id"`
-	CreatedAt        time.Time              `json:"created_at" format:"date-time" table:"created at"`
-	StartedAt        *time.Time             `json:"started_at,omitempty" format:"date-time" table:"started at"`
-	CompletedAt      *time.Time             `json:"completed_at,omitempty" format:"date-time" table:"completed at"`
-	CanceledAt       *time.Time             `json:"canceled_at,omitempty" format:"date-time" table:"canceled at"`
-	Error            string                 `json:"error,omitempty" table:"error"`
-	ErrorCode        JobErrorCode           `json:"error_code,omitempty" enums:"REQUIRED_TEMPLATE_VARIABLES" table:"error code"`
-	Status           ProvisionerJobStatus   `json:"status" enums:"pending,running,succeeded,canceling,canceled,failed" table:"status"`
-	WorkerID         *uuid.UUID             `json:"worker_id,omitempty" format:"uuid" table:"worker id"`
-	WorkerName       string                 `json:"worker_name,omitempty" table:"worker name"`
-	FileID           uuid.UUID              `json:"file_id" format:"uuid" table:"file id"`
-	Tags             map[string]string      `json:"tags" table:"tags"`
-	QueuePosition    int                    `json:"queue_position" table:"queue position"`
-	QueueSize        int                    `json:"queue_size" table:"queue size"`
-	OrganizationID   uuid.UUID              `json:"organization_id" format:"uuid" table:"organization id"`
-	InitiatorID      uuid.UUID              `json:"initiator_id" format:"uuid" table:"initiator id"`
-	Input            ProvisionerJobInput    `json:"input" table:"input,recursive_inline"`
-	Type             ProvisionerJobType     `json:"type" table:"type"`
-	AvailableWorkers []uuid.UUID            `json:"available_workers,omitempty" format:"uuid" table:"available workers"`
-	Metadata         ProvisionerJobMetadata `json:"metadata" table:"metadata,recursive_inline"`
-	LogsOverflowed   bool                   `json:"logs_overflowed" table:"logs overflowed"`
+	ID               uuid.UUID              `json:"id"                          format:"uuid"                                               table:"id"`
+	CreatedAt        time.Time              `json:"created_at"                  format:"date-time"                                          table:"created at"`
+	StartedAt        *time.Time             `json:"started_at,omitempty"        format:"date-time"                                          table:"started at"`
+	CompletedAt      *time.Time             `json:"completed_at,omitempty"      format:"date-time"                                          table:"completed at"`
+	CanceledAt       *time.Time             `json:"canceled_at,omitempty"       format:"date-time"                                          table:"canceled at"`
+	Error            string                 `json:"error,omitempty"             table:"error"`
+	ErrorCode        JobErrorCode           `json:"error_code,omitempty"        enums:"REQUIRED_TEMPLATE_VARIABLES"                         table:"error code"`
+	Status           ProvisionerJobStatus   `json:"status"                      enums:"pending,running,succeeded,canceling,canceled,failed" table:"status"`
+	WorkerID         *uuid.UUID             `json:"worker_id,omitempty"         format:"uuid"                                               table:"worker id"`
+	WorkerName       string                 `json:"worker_name,omitempty"       table:"worker name"`
+	FileID           uuid.UUID              `json:"file_id"                     format:"uuid"                                               table:"file id"`
+	Tags             map[string]string      `json:"tags"                        table:"tags"`
+	QueuePosition    int                    `json:"queue_position"              table:"queue position"`
+	QueueSize        int                    `json:"queue_size"                  table:"queue size"`
+	OrganizationID   uuid.UUID              `json:"organization_id"             format:"uuid"                                               table:"organization id"`
+	InitiatorID      uuid.UUID              `json:"initiator_id"                format:"uuid"                                               table:"initiator id"`
+	Input            ProvisionerJobInput    `json:"input"                       table:"input,recursive_inline"`
+	Type             ProvisionerJobType     `json:"type"                        table:"type"`
+	AvailableWorkers []uuid.UUID            `json:"available_workers,omitempty" format:"uuid"                                               table:"available workers"`
+	Metadata         ProvisionerJobMetadata `json:"metadata"                    table:"metadata,recursive_inline"`
+	LogsOverflowed   bool                   `json:"logs_overflowed"             table:"logs overflowed"`
 }
 
 // ProvisionerJobLog represents the provisioner log entry annotated with source and level.
@@ -210,7 +210,7 @@ type ProvisionerJobLog struct {
 	ID        int64     `json:"id"`
 	CreatedAt time.Time `json:"created_at" format:"date-time"`
 	Source    LogSource `json:"log_source"`
-	Level     LogLevel  `json:"log_level" enums:"trace,debug,info,warn,error"`
+	Level     LogLevel  `json:"log_level"  enums:"trace,debug,info,warn,error"`
 	Stage     string    `json:"stage"`
 	Output    string    `json:"output"`
 }
@@ -363,11 +363,11 @@ func (p ProvisionerKeyTags) String() string {
 }
 
 type ProvisionerKey struct {
-	ID             uuid.UUID          `json:"id" table:"-" format:"uuid"`
-	CreatedAt      time.Time          `json:"created_at" table:"created at" format:"date-time"`
-	OrganizationID uuid.UUID          `json:"organization" table:"-" format:"uuid"`
-	Name           string             `json:"name" table:"name,default_sort"`
-	Tags           ProvisionerKeyTags `json:"tags" table:"tags"`
+	ID             uuid.UUID          `json:"id"           table:"-"                 format:"uuid"`
+	CreatedAt      time.Time          `json:"created_at"   table:"created at"        format:"date-time"`
+	OrganizationID uuid.UUID          `json:"organization" table:"-"                 format:"uuid"`
+	Name           string             `json:"name"         table:"name,default_sort"`
+	Tags           ProvisionerKeyTags `json:"tags"         table:"tags"`
 	// HashedSecret - never include the access token in the API response
 }
 

--- a/codersdk/provisionerdaemons.go
+++ b/codersdk/provisionerdaemons.go
@@ -57,11 +57,11 @@ func ProvisionerDaemonStatusEnums() []ProvisionerDaemonStatus {
 }
 
 type ProvisionerDaemon struct {
-	ID             uuid.UUID         `json:"id"                     format:"uuid"             table:"id"`
-	OrganizationID uuid.UUID         `json:"organization_id"        format:"uuid"             table:"organization id"`
-	KeyID          uuid.UUID         `json:"key_id"                 format:"uuid"             table:"-"`
-	CreatedAt      time.Time         `json:"created_at"             format:"date-time"        table:"created at"`
-	LastSeenAt     NullTime          `json:"last_seen_at,omitempty" format:"date-time"        table:"last seen at"`
+	ID             uuid.UUID         `json:"id"                     table:"id"                format:"uuid"`
+	OrganizationID uuid.UUID         `json:"organization_id"        table:"organization id"   format:"uuid"`
+	KeyID          uuid.UUID         `json:"key_id"                 table:"-"                 format:"uuid"`
+	CreatedAt      time.Time         `json:"created_at"             table:"created at"        format:"date-time"`
+	LastSeenAt     NullTime          `json:"last_seen_at,omitempty" table:"last seen at"      format:"date-time"`
 	Name           string            `json:"name"                   table:"name,default_sort"`
 	Version        string            `json:"version"                table:"version"`
 	APIVersion     string            `json:"api_version"            table:"api version"`
@@ -70,14 +70,14 @@ type ProvisionerDaemon struct {
 
 	// Optional fields.
 	KeyName     *string                  `json:"key_name"     table:"key name"`
-	Status      *ProvisionerDaemonStatus `json:"status"       enums:"offline,idle,busy"      table:"status"`
+	Status      *ProvisionerDaemonStatus `json:"status"       table:"status"                 enums:"offline,idle,busy"`
 	CurrentJob  *ProvisionerDaemonJob    `json:"current_job"  table:"current job,recursive"`
 	PreviousJob *ProvisionerDaemonJob    `json:"previous_job" table:"previous job,recursive"`
 }
 
 type ProvisionerDaemonJob struct {
-	ID                  uuid.UUID            `json:"id"                    format:"uuid"                                               table:"id"`
-	Status              ProvisionerJobStatus `json:"status"                enums:"pending,running,succeeded,canceling,canceled,failed" table:"status"`
+	ID                  uuid.UUID            `json:"id"                    table:"id"                                                                                format:"uuid"`
+	Status              ProvisionerJobStatus `json:"status"                table:"status"                enums:"pending,running,succeeded,canceling,canceled,failed"`
 	TemplateName        string               `json:"template_name"         table:"template name"`
 	TemplateIcon        string               `json:"template_icon"         table:"template icon"`
 	TemplateDisplayName string               `json:"template_display_name" table:"template display name"`
@@ -136,19 +136,19 @@ func ProvisionerJobStatusEnums() []ProvisionerJobStatus {
 
 // ProvisionerJobInput represents the input for the job.
 type ProvisionerJobInput struct {
-	TemplateVersionID *uuid.UUID `json:"template_version_id,omitempty" format:"uuid" table:"template version id"`
-	WorkspaceBuildID  *uuid.UUID `json:"workspace_build_id,omitempty"  format:"uuid" table:"workspace build id"`
+	TemplateVersionID *uuid.UUID `json:"template_version_id,omitempty" table:"template version id" format:"uuid"`
+	WorkspaceBuildID  *uuid.UUID `json:"workspace_build_id,omitempty"  table:"workspace build id"  format:"uuid"`
 	Error             string     `json:"error,omitempty"               table:"-"`
 }
 
 // ProvisionerJobMetadata contains metadata for the job.
 type ProvisionerJobMetadata struct {
 	TemplateVersionName string     `json:"template_version_name"    table:"template version name"`
-	TemplateID          uuid.UUID  `json:"template_id"              format:"uuid"                 table:"template id"`
+	TemplateID          uuid.UUID  `json:"template_id"              table:"template id"           format:"uuid"`
 	TemplateName        string     `json:"template_name"            table:"template name"`
 	TemplateDisplayName string     `json:"template_display_name"    table:"template display name"`
 	TemplateIcon        string     `json:"template_icon"            table:"template icon"`
-	WorkspaceID         *uuid.UUID `json:"workspace_id,omitempty"   format:"uuid"                 table:"workspace id"`
+	WorkspaceID         *uuid.UUID `json:"workspace_id,omitempty"   table:"workspace id"          format:"uuid"`
 	WorkspaceName       string     `json:"workspace_name,omitempty" table:"workspace name"`
 }
 
@@ -182,25 +182,25 @@ func JobIsMissingRequiredTemplateVariableErrorCode(code JobErrorCode) bool {
 
 // ProvisionerJob describes the job executed by the provisioning daemon.
 type ProvisionerJob struct {
-	ID               uuid.UUID              `json:"id"                          format:"uuid"                                               table:"id"`
-	CreatedAt        time.Time              `json:"created_at"                  format:"date-time"                                          table:"created at"`
-	StartedAt        *time.Time             `json:"started_at,omitempty"        format:"date-time"                                          table:"started at"`
-	CompletedAt      *time.Time             `json:"completed_at,omitempty"      format:"date-time"                                          table:"completed at"`
-	CanceledAt       *time.Time             `json:"canceled_at,omitempty"       format:"date-time"                                          table:"canceled at"`
+	ID               uuid.UUID              `json:"id"                          table:"id"                                                                                    format:"uuid"`
+	CreatedAt        time.Time              `json:"created_at"                  table:"created at"                                                                            format:"date-time"`
+	StartedAt        *time.Time             `json:"started_at,omitempty"        table:"started at"                                                                            format:"date-time"`
+	CompletedAt      *time.Time             `json:"completed_at,omitempty"      table:"completed at"                                                                          format:"date-time"`
+	CanceledAt       *time.Time             `json:"canceled_at,omitempty"       table:"canceled at"                                                                           format:"date-time"`
 	Error            string                 `json:"error,omitempty"             table:"error"`
-	ErrorCode        JobErrorCode           `json:"error_code,omitempty"        enums:"REQUIRED_TEMPLATE_VARIABLES"                         table:"error code"`
-	Status           ProvisionerJobStatus   `json:"status"                      enums:"pending,running,succeeded,canceling,canceled,failed" table:"status"`
-	WorkerID         *uuid.UUID             `json:"worker_id,omitempty"         format:"uuid"                                               table:"worker id"`
+	ErrorCode        JobErrorCode           `json:"error_code,omitempty"        table:"error code"                enums:"REQUIRED_TEMPLATE_VARIABLES"`
+	Status           ProvisionerJobStatus   `json:"status"                      table:"status"                    enums:"pending,running,succeeded,canceling,canceled,failed"`
+	WorkerID         *uuid.UUID             `json:"worker_id,omitempty"         table:"worker id"                                                                             format:"uuid"`
 	WorkerName       string                 `json:"worker_name,omitempty"       table:"worker name"`
-	FileID           uuid.UUID              `json:"file_id"                     format:"uuid"                                               table:"file id"`
+	FileID           uuid.UUID              `json:"file_id"                     table:"file id"                                                                               format:"uuid"`
 	Tags             map[string]string      `json:"tags"                        table:"tags"`
 	QueuePosition    int                    `json:"queue_position"              table:"queue position"`
 	QueueSize        int                    `json:"queue_size"                  table:"queue size"`
-	OrganizationID   uuid.UUID              `json:"organization_id"             format:"uuid"                                               table:"organization id"`
-	InitiatorID      uuid.UUID              `json:"initiator_id"                format:"uuid"                                               table:"initiator id"`
+	OrganizationID   uuid.UUID              `json:"organization_id"             table:"organization id"                                                                       format:"uuid"`
+	InitiatorID      uuid.UUID              `json:"initiator_id"                table:"initiator id"                                                                          format:"uuid"`
 	Input            ProvisionerJobInput    `json:"input"                       table:"input,recursive_inline"`
 	Type             ProvisionerJobType     `json:"type"                        table:"type"`
-	AvailableWorkers []uuid.UUID            `json:"available_workers,omitempty" format:"uuid"                                               table:"available workers"`
+	AvailableWorkers []uuid.UUID            `json:"available_workers,omitempty" table:"available workers"                                                                     format:"uuid"`
 	Metadata         ProvisionerJobMetadata `json:"metadata"                    table:"metadata,recursive_inline"`
 	LogsOverflowed   bool                   `json:"logs_overflowed"             table:"logs overflowed"`
 }
@@ -208,7 +208,7 @@ type ProvisionerJob struct {
 // ProvisionerJobLog represents the provisioner log entry annotated with source and level.
 type ProvisionerJobLog struct {
 	ID        int64     `json:"id"`
-	CreatedAt time.Time `json:"created_at" format:"date-time"`
+	CreatedAt time.Time `json:"created_at"                                     format:"date-time"`
 	Source    LogSource `json:"log_source"`
 	Level     LogLevel  `json:"log_level"  enums:"trace,debug,info,warn,error"`
 	Stage     string    `json:"stage"`

--- a/codersdk/roles.go
+++ b/codersdk/roles.go
@@ -36,8 +36,8 @@ func (s SlimRole) UniqueName() string {
 }
 
 type AssignableRoles struct {
-	Role       `table:"r,recursive_inline"`
-	Assignable bool `json:"assignable"          table:"assignable"`
+	Role       `                  table:"r,recursive_inline"`
+	Assignable bool `json:"assignable" table:"assignable"`
 	// BuiltIn roles are immutable
 	BuiltIn bool `json:"built_in" table:"built_in"`
 }
@@ -52,7 +52,7 @@ type Permission struct {
 
 // Role is a longer form of SlimRole that includes permissions details.
 type Role struct {
-	Name            string       `json:"name"                      table:"name,default_sort" validate:"username"`
+	Name            string       `json:"name"                      table:"name,default_sort"               validate:"username"`
 	OrganizationID  string       `json:"organization_id,omitempty" table:"organization id"   format:"uuid"`
 	DisplayName     string       `json:"display_name"              table:"display name"`
 	SitePermissions []Permission `json:"site_permissions"          table:"site permissions"`

--- a/codersdk/roles.go
+++ b/codersdk/roles.go
@@ -37,7 +37,7 @@ func (s SlimRole) UniqueName() string {
 
 type AssignableRoles struct {
 	Role       `table:"r,recursive_inline"`
-	Assignable bool `json:"assignable" table:"assignable"`
+	Assignable bool `json:"assignable"          table:"assignable"`
 	// BuiltIn roles are immutable
 	BuiltIn bool `json:"built_in" table:"built_in"`
 }
@@ -52,11 +52,11 @@ type Permission struct {
 
 // Role is a longer form of SlimRole that includes permissions details.
 type Role struct {
-	Name            string       `json:"name" table:"name,default_sort" validate:"username"`
-	OrganizationID  string       `json:"organization_id,omitempty" table:"organization id" format:"uuid"`
-	DisplayName     string       `json:"display_name" table:"display name"`
-	SitePermissions []Permission `json:"site_permissions" table:"site permissions"`
-	UserPermissions []Permission `json:"user_permissions" table:"user permissions"`
+	Name            string       `json:"name"                      table:"name,default_sort" validate:"username"`
+	OrganizationID  string       `json:"organization_id,omitempty" table:"organization id"   format:"uuid"`
+	DisplayName     string       `json:"display_name"              table:"display name"`
+	SitePermissions []Permission `json:"site_permissions"          table:"site permissions"`
+	UserPermissions []Permission `json:"user_permissions"          table:"user permissions"`
 	// OrganizationPermissions are specific for the organization in the field 'OrganizationID' above.
 	OrganizationPermissions []Permission `json:"organization_permissions" table:"organization permissions"`
 	// OrganizationMemberPermissions are specific for the organization in the field 'OrganizationID' above.
@@ -65,8 +65,8 @@ type Role struct {
 
 // CustomRoleRequest is used to edit custom roles.
 type CustomRoleRequest struct {
-	Name            string       `json:"name" table:"name,default_sort" validate:"username"`
-	DisplayName     string       `json:"display_name" table:"display name"`
+	Name            string       `json:"name"             table:"name,default_sort" validate:"username"`
+	DisplayName     string       `json:"display_name"     table:"display name"`
 	SitePermissions []Permission `json:"site_permissions" table:"site permissions"`
 	UserPermissions []Permission `json:"user_permissions" table:"user permissions"`
 	// OrganizationPermissions are specific to the organization the role belongs to.

--- a/codersdk/templates.go
+++ b/codersdk/templates.go
@@ -15,17 +15,17 @@ import (
 // Template is the JSON representation of a Coder template. This type matches the
 // database object for now, but is abstracted for ease of change later on.
 type Template struct {
-	ID                      uuid.UUID       `json:"id" format:"uuid"`
-	CreatedAt               time.Time       `json:"created_at" format:"date-time"`
-	UpdatedAt               time.Time       `json:"updated_at" format:"date-time"`
-	OrganizationID          uuid.UUID       `json:"organization_id" format:"uuid"`
-	OrganizationName        string          `json:"organization_name" format:"url"`
+	ID                      uuid.UUID       `json:"id"                        format:"uuid"`
+	CreatedAt               time.Time       `json:"created_at"                format:"date-time"`
+	UpdatedAt               time.Time       `json:"updated_at"                format:"date-time"`
+	OrganizationID          uuid.UUID       `json:"organization_id"           format:"uuid"`
+	OrganizationName        string          `json:"organization_name"         format:"url"`
 	OrganizationDisplayName string          `json:"organization_display_name"`
 	OrganizationIcon        string          `json:"organization_icon"`
 	Name                    string          `json:"name"`
 	DisplayName             string          `json:"display_name"`
-	Provisioner             ProvisionerType `json:"provisioner" enums:"terraform"`
-	ActiveVersionID         uuid.UUID       `json:"active_version_id" format:"uuid"`
+	Provisioner             ProvisionerType `json:"provisioner"               enums:"terraform"`
+	ActiveVersionID         uuid.UUID       `json:"active_version_id"         format:"uuid"`
 	// ActiveUserCount is set to -1 when loading.
 	ActiveUserCount    int                    `json:"active_user_count"`
 	BuildTimeStats     TemplateBuildTimeStats `json:"build_time_stats"`
@@ -41,7 +41,7 @@ type Template struct {
 	// scheduling feature.
 	AutostopRequirement  TemplateAutostopRequirement  `json:"autostop_requirement"`
 	AutostartRequirement TemplateAutostartRequirement `json:"autostart_requirement"`
-	CreatedByID          uuid.UUID                    `json:"created_by_id" format:"uuid"`
+	CreatedByID          uuid.UUID                    `json:"created_by_id"         format:"uuid"`
 	CreatedByName        string                       `json:"created_by_name"`
 
 	// AllowUserAutostart and AllowUserAutostop are enterprise-only. Their
@@ -170,7 +170,7 @@ type ArchiveTemplateVersionsRequest struct {
 }
 
 type ArchiveTemplateVersionsResponse struct {
-	TemplateID  uuid.UUID   `json:"template_id" format:"uuid"`
+	TemplateID  uuid.UUID   `json:"template_id"  format:"uuid"`
 	ArchivedIDs []uuid.UUID `json:"archived_ids"`
 }
 
@@ -216,8 +216,8 @@ type ACLAvailable struct {
 }
 
 type UpdateTemplateMeta struct {
-	Name             string  `json:"name,omitempty" validate:"omitempty,template_name"`
-	DisplayName      *string `json:"display_name,omitempty" validate:"omitempty,template_display_name"`
+	Name             string  `json:"name,omitempty"           validate:"omitempty,template_name"`
+	DisplayName      *string `json:"display_name,omitempty"   validate:"omitempty,template_display_name"`
 	Description      *string `json:"description,omitempty"`
 	Icon             *string `json:"icon,omitempty"`
 	DefaultTTLMillis int64   `json:"default_ttl_ms,omitempty"`
@@ -274,7 +274,7 @@ type UpdateTemplateMeta struct {
 }
 
 type TemplateExample struct {
-	ID          string   `json:"id" format:"uuid"`
+	ID          string   `json:"id"          format:"uuid"`
 	URL         string   `json:"url"`
 	Name        string   `json:"name"`
 	Description string   `json:"description"`
@@ -419,7 +419,7 @@ func (c *Client) UpdateActiveTemplateVersion(ctx context.Context, template uuid.
 // TemplateVersionsByTemplateRequest defines the request parameters for
 // TemplateVersionsByTemplate.
 type TemplateVersionsByTemplateRequest struct {
-	TemplateID      uuid.UUID `json:"template_id" validate:"required" format:"uuid"`
+	TemplateID      uuid.UUID `json:"template_id"      validate:"required" format:"uuid"`
 	IncludeArchived bool      `json:"include_archived"`
 	Pagination
 }

--- a/codersdk/templates.go
+++ b/codersdk/templates.go
@@ -15,17 +15,17 @@ import (
 // Template is the JSON representation of a Coder template. This type matches the
 // database object for now, but is abstracted for ease of change later on.
 type Template struct {
-	ID                      uuid.UUID       `json:"id"                        format:"uuid"`
-	CreatedAt               time.Time       `json:"created_at"                format:"date-time"`
-	UpdatedAt               time.Time       `json:"updated_at"                format:"date-time"`
-	OrganizationID          uuid.UUID       `json:"organization_id"           format:"uuid"`
-	OrganizationName        string          `json:"organization_name"         format:"url"`
+	ID                      uuid.UUID       `json:"id"                                          format:"uuid"`
+	CreatedAt               time.Time       `json:"created_at"                                  format:"date-time"`
+	UpdatedAt               time.Time       `json:"updated_at"                                  format:"date-time"`
+	OrganizationID          uuid.UUID       `json:"organization_id"                             format:"uuid"`
+	OrganizationName        string          `json:"organization_name"                           format:"url"`
 	OrganizationDisplayName string          `json:"organization_display_name"`
 	OrganizationIcon        string          `json:"organization_icon"`
 	Name                    string          `json:"name"`
 	DisplayName             string          `json:"display_name"`
 	Provisioner             ProvisionerType `json:"provisioner"               enums:"terraform"`
-	ActiveVersionID         uuid.UUID       `json:"active_version_id"         format:"uuid"`
+	ActiveVersionID         uuid.UUID       `json:"active_version_id"                           format:"uuid"`
 	// ActiveUserCount is set to -1 when loading.
 	ActiveUserCount    int                    `json:"active_user_count"`
 	BuildTimeStats     TemplateBuildTimeStats `json:"build_time_stats"`
@@ -159,7 +159,7 @@ type TransitionStats struct {
 type (
 	TemplateBuildTimeStats      map[WorkspaceTransition]TransitionStats
 	UpdateActiveTemplateVersion struct {
-		ID uuid.UUID `json:"id" validate:"required" format:"uuid"`
+		ID uuid.UUID `json:"id" format:"uuid" validate:"required"`
 	}
 )
 
@@ -419,7 +419,7 @@ func (c *Client) UpdateActiveTemplateVersion(ctx context.Context, template uuid.
 // TemplateVersionsByTemplateRequest defines the request parameters for
 // TemplateVersionsByTemplate.
 type TemplateVersionsByTemplateRequest struct {
-	TemplateID      uuid.UUID `json:"template_id"      validate:"required" format:"uuid"`
+	TemplateID      uuid.UUID `json:"template_id"      format:"uuid" validate:"required"`
 	IncludeArchived bool      `json:"include_archived"`
 	Pagination
 }

--- a/codersdk/templateversions.go
+++ b/codersdk/templateversions.go
@@ -19,11 +19,11 @@ const (
 
 // TemplateVersion represents a single version of a template.
 type TemplateVersion struct {
-	ID             uuid.UUID      `json:"id" format:"uuid"`
-	TemplateID     *uuid.UUID     `json:"template_id,omitempty" format:"uuid"`
+	ID             uuid.UUID      `json:"id"                        format:"uuid"`
+	TemplateID     *uuid.UUID     `json:"template_id,omitempty"     format:"uuid"`
 	OrganizationID uuid.UUID      `json:"organization_id,omitempty" format:"uuid"`
-	CreatedAt      time.Time      `json:"created_at" format:"date-time"`
-	UpdatedAt      time.Time      `json:"updated_at" format:"date-time"`
+	CreatedAt      time.Time      `json:"created_at"                format:"date-time"`
+	UpdatedAt      time.Time      `json:"updated_at"                format:"date-time"`
 	Name           string         `json:"name"`
 	Message        string         `json:"message"`
 	Job            ProvisionerJob `json:"job"`
@@ -31,7 +31,7 @@ type TemplateVersion struct {
 	CreatedBy      MinimalUser    `json:"created_by"`
 	Archived       bool           `json:"archived"`
 
-	Warnings            []TemplateVersionWarning `json:"warnings,omitempty" enums:"DEPRECATED_PARAMETERS"`
+	Warnings            []TemplateVersionWarning `json:"warnings,omitempty"             enums:"DEPRECATED_PARAMETERS"`
 	MatchedProvisioners *MatchedProvisioners     `json:"matched_provisioners,omitempty"`
 
 	HasExternalAgent bool `json:"has_external_agent"`
@@ -60,10 +60,10 @@ type TemplateVersionParameter struct {
 	DisplayName          string `json:"display_name,omitempty"`
 	Description          string `json:"description"`
 	DescriptionPlaintext string `json:"description_plaintext"`
-	Type                 string `json:"type" enums:"string,number,bool,list(string)"`
+	Type                 string `json:"type"                   enums:"string,number,bool,list(string)"`
 	// FormType has an enum value of empty string, `""`.
 	// Keep the leading comma in the enums struct tag.
-	FormType            string                           `json:"form_type" enums:",radio,dropdown,input,textarea,slider,checkbox,switch,tag-select,multi-select,error"`
+	FormType            string                           `json:"form_type"                      enums:",radio,dropdown,input,textarea,slider,checkbox,switch,tag-select,multi-select,error"`
 	Mutable             bool                             `json:"mutable"`
 	DefaultValue        string                           `json:"default_value"`
 	Icon                string                           `json:"icon"`
@@ -89,7 +89,7 @@ type TemplateVersionParameterOption struct {
 type TemplateVersionVariable struct {
 	Name         string `json:"name"`
 	Description  string `json:"description"`
-	Type         string `json:"type" enums:"string,number,bool"`
+	Type         string `json:"type"          enums:"string,number,bool"`
 	Value        string `json:"value"`
 	DefaultValue string `json:"default_value"`
 	Required     bool   `json:"required"`
@@ -97,7 +97,7 @@ type TemplateVersionVariable struct {
 }
 
 type PatchTemplateVersionRequest struct {
-	Name    string  `json:"name" validate:"omitempty,template_version_name"`
+	Name    string  `json:"name"              validate:"omitempty,template_version_name"`
 	Message *string `json:"message,omitempty" validate:"omitempty,lt=1048577"`
 }
 

--- a/codersdk/users.go
+++ b/codersdk/users.go
@@ -40,10 +40,10 @@ type UsersRequest struct {
 // MinimalUser is the minimal information needed to identify a user and show
 // them on the UI.
 type MinimalUser struct {
-	ID        uuid.UUID `json:"id"                   validate:"required" table:"id"                    format:"uuid"`
-	Username  string    `json:"username"             validate:"required" table:"username,default_sort"`
+	ID        uuid.UUID `json:"id"                   table:"id"                    format:"uuid" validate:"required"`
+	Username  string    `json:"username"             table:"username,default_sort"               validate:"required"`
 	Name      string    `json:"name,omitempty"       table:"name"`
-	AvatarURL string    `json:"avatar_url,omitempty" format:"uri"`
+	AvatarURL string    `json:"avatar_url,omitempty"                               format:"uri"`
 }
 
 // ReducedUser omits role and organization information. Roles are deduced from
@@ -51,11 +51,11 @@ type MinimalUser struct {
 // organizational memberships. Fetching that is more expensive, and not usually
 // required by the frontend.
 type ReducedUser struct {
-	MinimalUser `table:"m,recursive_inline"`
-	Email       string    `json:"email"                  validate:"required" table:"email"      format:"email"`
-	CreatedAt   time.Time `json:"created_at"             validate:"required" table:"created at" format:"date-time"`
-	UpdatedAt   time.Time `json:"updated_at"             table:"updated at"  format:"date-time"`
-	LastSeenAt  time.Time `json:"last_seen_at,omitempty" format:"date-time"`
+	MinimalUser `                              table:"m,recursive_inline"`
+	Email       string    `json:"email"                  table:"email"              format:"email"     validate:"required"`
+	CreatedAt   time.Time `json:"created_at"             table:"created at"         format:"date-time" validate:"required"`
+	UpdatedAt   time.Time `json:"updated_at"             table:"updated at"         format:"date-time"`
+	LastSeenAt  time.Time `json:"last_seen_at,omitempty"                            format:"date-time"`
 
 	Status           UserStatus `json:"status"                       table:"status" enums:"active,suspended"`
 	LoginType        LoginType  `json:"login_type"`
@@ -125,9 +125,9 @@ type CreateFirstUserResponse struct {
 // Then alias CreateUserRequestWithOrgs to CreateUserRequest.
 // @typescript-ignore CreateUserRequest
 type CreateUserRequest struct {
-	Email    string `json:"email"    validate:"required,email"    format:"email"`
-	Username string `json:"username" validate:"required,username"`
-	Name     string `json:"name"     validate:"user_real_name"`
+	Email    string `json:"email"    format:"email" validate:"required,email"`
+	Username string `json:"username"                validate:"required,username"`
+	Name     string `json:"name"                    validate:"user_real_name"`
 	Password string `json:"password"`
 	// UserLoginType defaults to LoginTypePassword.
 	UserLoginType LoginType `json:"login_type"`
@@ -135,20 +135,20 @@ type CreateUserRequest struct {
 	// from being able to use a password or any other authentication method to login.
 	// Deprecated: Set UserLoginType=LoginTypeDisabled instead.
 	DisableLogin   bool      `json:"disable_login"`
-	OrganizationID uuid.UUID `json:"organization_id" validate:"" format:"uuid"`
+	OrganizationID uuid.UUID `json:"organization_id" format:"uuid" validate:""`
 }
 
 type CreateUserRequestWithOrgs struct {
-	Email    string `json:"email"    validate:"required_unless=ServiceAccount true,omitempty,email" format:"email"`
-	Username string `json:"username" validate:"required,username"`
-	Name     string `json:"name"     validate:"user_real_name"`
+	Email    string `json:"email"    format:"email" validate:"required_unless=ServiceAccount true,omitempty,email"`
+	Username string `json:"username"                validate:"required,username"`
+	Name     string `json:"name"                    validate:"user_real_name"`
 	Password string `json:"password"`
 	// UserLoginType defaults to LoginTypePassword.
 	UserLoginType LoginType `json:"login_type"`
 	// UserStatus defaults to UserStatusDormant.
 	UserStatus *UserStatus `json:"user_status"`
 	// OrganizationIDs is a list of organization IDs that the user should be a member of.
-	OrganizationIDs []uuid.UUID `json:"organization_ids" validate:"" format:"uuid"`
+	OrganizationIDs []uuid.UUID `json:"organization_ids" format:"uuid" validate:""`
 	// Service accounts are admin-managed accounts that cannot login.
 	ServiceAccount bool `json:"service_account,omitempty"`
 }
@@ -284,8 +284,8 @@ type ConvertLoginRequest struct {
 
 // LoginWithPasswordRequest enables callers to authenticate with email and password.
 type LoginWithPasswordRequest struct {
-	Email    string `json:"email"    validate:"required,email" format:"email"`
-	Password string `json:"password" validate:"required"`
+	Email    string `json:"email"    format:"email" validate:"required,email"`
+	Password string `json:"password"                validate:"required"`
 }
 
 // LoginWithPasswordResponse contains a session token for the newly authenticated user.
@@ -295,14 +295,14 @@ type LoginWithPasswordResponse struct {
 
 // RequestOneTimePasscodeRequest enables callers to request a one-time-passcode to change their password.
 type RequestOneTimePasscodeRequest struct {
-	Email string `json:"email" validate:"required,email" format:"email"`
+	Email string `json:"email" format:"email" validate:"required,email"`
 }
 
 // ChangePasswordWithOneTimePasscodeRequest enables callers to change their password when they've forgotten it.
 type ChangePasswordWithOneTimePasscodeRequest struct {
-	Email           string `json:"email"             validate:"required,email" format:"email"`
-	Password        string `json:"password"          validate:"required"`
-	OneTimePasscode string `json:"one_time_passcode" validate:"required"`
+	Email           string `json:"email"             format:"email" validate:"required,email"`
+	Password        string `json:"password"                         validate:"required"`
+	OneTimePasscode string `json:"one_time_passcode"                validate:"required"`
 }
 
 type OAuthConversionResponse struct {

--- a/codersdk/users.go
+++ b/codersdk/users.go
@@ -26,11 +26,11 @@ const (
 
 type UsersRequest struct {
 	Search string `json:"search,omitempty" typescript:"-"`
-	Name   string `json:"name,omitempty" typescript:"-"`
+	Name   string `json:"name,omitempty"   typescript:"-"`
 	// Filter users by status.
 	Status UserStatus `json:"status,omitempty" typescript:"-"`
 	// Filter users that have the given role.
-	Role      string      `json:"role,omitempty" typescript:"-"`
+	Role      string      `json:"role,omitempty"       typescript:"-"`
 	LoginType []LoginType `json:"login_type,omitempty" typescript:"-"`
 
 	SearchQuery string `json:"q,omitempty"`
@@ -40,9 +40,9 @@ type UsersRequest struct {
 // MinimalUser is the minimal information needed to identify a user and show
 // them on the UI.
 type MinimalUser struct {
-	ID        uuid.UUID `json:"id" validate:"required" table:"id" format:"uuid"`
-	Username  string    `json:"username" validate:"required" table:"username,default_sort"`
-	Name      string    `json:"name,omitempty" table:"name"`
+	ID        uuid.UUID `json:"id"                   validate:"required" table:"id"                    format:"uuid"`
+	Username  string    `json:"username"             validate:"required" table:"username,default_sort"`
+	Name      string    `json:"name,omitempty"       table:"name"`
 	AvatarURL string    `json:"avatar_url,omitempty" format:"uri"`
 }
 
@@ -52,12 +52,12 @@ type MinimalUser struct {
 // required by the frontend.
 type ReducedUser struct {
 	MinimalUser `table:"m,recursive_inline"`
-	Email       string    `json:"email" validate:"required" table:"email" format:"email"`
-	CreatedAt   time.Time `json:"created_at" validate:"required" table:"created at" format:"date-time"`
-	UpdatedAt   time.Time `json:"updated_at" table:"updated at" format:"date-time"`
+	Email       string    `json:"email"                  validate:"required" table:"email"      format:"email"`
+	CreatedAt   time.Time `json:"created_at"             validate:"required" table:"created at" format:"date-time"`
+	UpdatedAt   time.Time `json:"updated_at"             table:"updated at"  format:"date-time"`
 	LastSeenAt  time.Time `json:"last_seen_at,omitempty" format:"date-time"`
 
-	Status           UserStatus `json:"status" table:"status" enums:"active,suspended"`
+	Status           UserStatus `json:"status"                       table:"status" enums:"active,suspended"`
 	LoginType        LoginType  `json:"login_type"`
 	IsServiceAccount bool       `json:"is_service_account,omitempty"`
 	// Deprecated: this value should be retrieved from
@@ -95,10 +95,10 @@ type LicensorTrialRequest struct {
 }
 
 type CreateFirstUserRequest struct {
-	Email     string                   `json:"email" validate:"required,email"`
-	Username  string                   `json:"username" validate:"required,username"`
-	Name      string                   `json:"name" validate:"user_real_name"`
-	Password  string                   `json:"password" validate:"required"`
+	Email     string                   `json:"email"      validate:"required,email"`
+	Username  string                   `json:"username"   validate:"required,username"`
+	Name      string                   `json:"name"       validate:"user_real_name"`
+	Password  string                   `json:"password"   validate:"required"`
 	Trial     bool                     `json:"trial"`
 	TrialInfo CreateFirstUserTrialInfo `json:"trial_info"`
 }
@@ -115,7 +115,7 @@ type CreateFirstUserTrialInfo struct {
 
 // CreateFirstUserResponse contains IDs for newly created user info.
 type CreateFirstUserResponse struct {
-	UserID         uuid.UUID `json:"user_id" format:"uuid"`
+	UserID         uuid.UUID `json:"user_id"         format:"uuid"`
 	OrganizationID uuid.UUID `json:"organization_id" format:"uuid"`
 }
 
@@ -125,9 +125,9 @@ type CreateFirstUserResponse struct {
 // Then alias CreateUserRequestWithOrgs to CreateUserRequest.
 // @typescript-ignore CreateUserRequest
 type CreateUserRequest struct {
-	Email    string `json:"email" validate:"required,email" format:"email"`
+	Email    string `json:"email"    validate:"required,email"    format:"email"`
 	Username string `json:"username" validate:"required,username"`
-	Name     string `json:"name" validate:"user_real_name"`
+	Name     string `json:"name"     validate:"user_real_name"`
 	Password string `json:"password"`
 	// UserLoginType defaults to LoginTypePassword.
 	UserLoginType LoginType `json:"login_type"`
@@ -139,9 +139,9 @@ type CreateUserRequest struct {
 }
 
 type CreateUserRequestWithOrgs struct {
-	Email    string `json:"email" validate:"required_unless=ServiceAccount true,omitempty,email" format:"email"`
+	Email    string `json:"email"    validate:"required_unless=ServiceAccount true,omitempty,email" format:"email"`
 	Username string `json:"username" validate:"required,username"`
-	Name     string `json:"name" validate:"user_real_name"`
+	Name     string `json:"name"     validate:"user_real_name"`
 	Password string `json:"password"`
 	// UserLoginType defaults to LoginTypePassword.
 	UserLoginType LoginType `json:"login_type"`
@@ -183,7 +183,7 @@ func (r *CreateUserRequestWithOrgs) UnmarshalJSON(data []byte) error {
 
 type UpdateUserProfileRequest struct {
 	Username string `json:"username" validate:"required,username"`
-	Name     string `json:"name" validate:"user_real_name"`
+	Name     string `json:"name"     validate:"user_real_name"`
 }
 
 type ValidateUserPasswordRequest struct {
@@ -219,7 +219,7 @@ type UserAppearanceSettings struct {
 
 type UpdateUserAppearanceSettingsRequest struct {
 	ThemePreference string           `json:"theme_preference" validate:"required"`
-	TerminalFont    TerminalFontName `json:"terminal_font" validate:"required"`
+	TerminalFont    TerminalFontName `json:"terminal_font"    validate:"required"`
 }
 
 type UserPreferenceSettings struct {
@@ -232,7 +232,7 @@ type UpdateUserPreferenceSettingsRequest struct {
 
 type UpdateUserPasswordRequest struct {
 	OldPassword string `json:"old_password" validate:""`
-	Password    string `json:"password" validate:"required"`
+	Password    string `json:"password"     validate:"required"`
 }
 
 type UserQuietHoursScheduleResponse struct {
@@ -278,13 +278,13 @@ type UserRoles struct {
 
 type ConvertLoginRequest struct {
 	// ToType is the login type to convert to.
-	ToType   LoginType `json:"to_type" validate:"required"`
+	ToType   LoginType `json:"to_type"  validate:"required"`
 	Password string    `json:"password" validate:"required"`
 }
 
 // LoginWithPasswordRequest enables callers to authenticate with email and password.
 type LoginWithPasswordRequest struct {
-	Email    string `json:"email" validate:"required,email" format:"email"`
+	Email    string `json:"email"    validate:"required,email" format:"email"`
 	Password string `json:"password" validate:"required"`
 }
 
@@ -300,16 +300,16 @@ type RequestOneTimePasscodeRequest struct {
 
 // ChangePasswordWithOneTimePasscodeRequest enables callers to change their password when they've forgotten it.
 type ChangePasswordWithOneTimePasscodeRequest struct {
-	Email           string `json:"email" validate:"required,email" format:"email"`
-	Password        string `json:"password" validate:"required"`
+	Email           string `json:"email"             validate:"required,email" format:"email"`
+	Password        string `json:"password"          validate:"required"`
 	OneTimePasscode string `json:"one_time_passcode" validate:"required"`
 }
 
 type OAuthConversionResponse struct {
 	StateString string    `json:"state_string"`
-	ExpiresAt   time.Time `json:"expires_at" format:"date-time"`
+	ExpiresAt   time.Time `json:"expires_at"   format:"date-time"`
 	ToType      LoginType `json:"to_type"`
-	UserID      uuid.UUID `json:"user_id" format:"uuid"`
+	UserID      uuid.UUID `json:"user_id"      format:"uuid"`
 }
 
 // AuthMethods contains authentication method information like whether they are enabled or not or custom text, etc.

--- a/codersdk/workspaceagentportshare.go
+++ b/codersdk/workspaceagentportshare.go
@@ -27,7 +27,7 @@ type (
 		AgentName  string                          `json:"agent_name"`
 		Port       int32                           `json:"port"`
 		ShareLevel WorkspaceAgentPortShareLevel    `json:"share_level" enums:"owner,authenticated,organization,public"`
-		Protocol   WorkspaceAgentPortShareProtocol `json:"protocol" enums:"http,https"`
+		Protocol   WorkspaceAgentPortShareProtocol `json:"protocol"    enums:"http,https"`
 	}
 	WorkspaceAgentPortShares struct {
 		Shares []WorkspaceAgentPortShare `json:"shares"`
@@ -36,8 +36,8 @@ type (
 		WorkspaceID uuid.UUID                       `json:"workspace_id" format:"uuid"`
 		AgentName   string                          `json:"agent_name"`
 		Port        int32                           `json:"port"`
-		ShareLevel  WorkspaceAgentPortShareLevel    `json:"share_level" enums:"owner,authenticated,organization,public"`
-		Protocol    WorkspaceAgentPortShareProtocol `json:"protocol" enums:"http,https"`
+		ShareLevel  WorkspaceAgentPortShareLevel    `json:"share_level"  enums:"owner,authenticated,organization,public"`
+		Protocol    WorkspaceAgentPortShareProtocol `json:"protocol"     enums:"http,https"`
 	}
 	DeleteWorkspaceAgentPortShareRequest struct {
 		AgentName string `json:"agent_name"`

--- a/codersdk/workspaceagentportshare.go
+++ b/codersdk/workspaceagentportshare.go
@@ -33,7 +33,7 @@ type (
 		Shares []WorkspaceAgentPortShare `json:"shares"`
 	}
 	WorkspaceAgentPortShare struct {
-		WorkspaceID uuid.UUID                       `json:"workspace_id" format:"uuid"`
+		WorkspaceID uuid.UUID                       `json:"workspace_id"                                                 format:"uuid"`
 		AgentName   string                          `json:"agent_name"`
 		Port        int32                           `json:"port"`
 		ShareLevel  WorkspaceAgentPortShareLevel    `json:"share_level"  enums:"owner,authenticated,organization,public"`

--- a/codersdk/workspaceagents.go
+++ b/codersdk/workspaceagents.go
@@ -362,8 +362,8 @@ func (c *Client) WorkspaceAgent(ctx context.Context, id uuid.UUID) (WorkspaceAge
 
 type IssueReconnectingPTYSignedTokenRequest struct {
 	// URL is the URL of the reconnecting-pty endpoint you are connecting to.
-	URL     string    `json:"url"     validate:"required"`
-	AgentID uuid.UUID `json:"agentID" format:"uuid"       validate:"required"`
+	URL     string    `json:"url"                   validate:"required"`
+	AgentID uuid.UUID `json:"agentID" format:"uuid" validate:"required"`
 }
 
 type IssueReconnectingPTYSignedTokenResponse struct {

--- a/codersdk/workspaceagents.go
+++ b/codersdk/workspaceagents.go
@@ -137,19 +137,19 @@ const (
 )
 
 type WorkspaceAgent struct {
-	ID                   uuid.UUID               `json:"id" format:"uuid"`
-	ParentID             uuid.NullUUID           `json:"parent_id" format:"uuid"`
-	CreatedAt            time.Time               `json:"created_at" format:"date-time"`
-	UpdatedAt            time.Time               `json:"updated_at" format:"date-time"`
+	ID                   uuid.UUID               `json:"id"                           format:"uuid"`
+	ParentID             uuid.NullUUID           `json:"parent_id"                    format:"uuid"`
+	CreatedAt            time.Time               `json:"created_at"                   format:"date-time"`
+	UpdatedAt            time.Time               `json:"updated_at"                   format:"date-time"`
 	FirstConnectedAt     *time.Time              `json:"first_connected_at,omitempty" format:"date-time"`
-	LastConnectedAt      *time.Time              `json:"last_connected_at,omitempty" format:"date-time"`
-	DisconnectedAt       *time.Time              `json:"disconnected_at,omitempty" format:"date-time"`
-	StartedAt            *time.Time              `json:"started_at,omitempty" format:"date-time"`
-	ReadyAt              *time.Time              `json:"ready_at,omitempty" format:"date-time"`
+	LastConnectedAt      *time.Time              `json:"last_connected_at,omitempty"  format:"date-time"`
+	DisconnectedAt       *time.Time              `json:"disconnected_at,omitempty"    format:"date-time"`
+	StartedAt            *time.Time              `json:"started_at,omitempty"         format:"date-time"`
+	ReadyAt              *time.Time              `json:"ready_at,omitempty"           format:"date-time"`
 	Status               WorkspaceAgentStatus    `json:"status"`
 	LifecycleState       WorkspaceAgentLifecycle `json:"lifecycle_state"`
 	Name                 string                  `json:"name"`
-	ResourceID           uuid.UUID               `json:"resource_id" format:"uuid"`
+	ResourceID           uuid.UUID               `json:"resource_id"                  format:"uuid"`
 	InstanceID           string                  `json:"instance_id,omitempty"`
 	Architecture         string                  `json:"architecture"`
 	EnvironmentVariables map[string]string       `json:"environment_variables"`
@@ -179,15 +179,15 @@ type WorkspaceAgent struct {
 
 type WorkspaceAgentLogSource struct {
 	WorkspaceAgentID uuid.UUID `json:"workspace_agent_id" format:"uuid"`
-	ID               uuid.UUID `json:"id" format:"uuid"`
-	CreatedAt        time.Time `json:"created_at" format:"date-time"`
+	ID               uuid.UUID `json:"id"                 format:"uuid"`
+	CreatedAt        time.Time `json:"created_at"         format:"date-time"`
 	DisplayName      string    `json:"display_name"`
 	Icon             string    `json:"icon"`
 }
 
 type WorkspaceAgentScript struct {
-	ID               uuid.UUID     `json:"id" format:"uuid"`
-	LogSourceID      uuid.UUID     `json:"log_source_id" format:"uuid"`
+	ID               uuid.UUID     `json:"id"                 format:"uuid"`
+	LogSourceID      uuid.UUID     `json:"log_source_id"      format:"uuid"`
 	LogPath          string        `json:"log_path"`
 	Script           string        `json:"script"`
 	Cron             string        `json:"cron"`
@@ -199,7 +199,7 @@ type WorkspaceAgentScript struct {
 }
 
 type WorkspaceAgentHealth struct {
-	Healthy bool   `json:"healthy" example:"false"`                              // Healthy is true if the agent is healthy.
+	Healthy bool   `json:"healthy"          example:"false"`                     // Healthy is true if the agent is healthy.
 	Reason  string `json:"reason,omitempty" example:"agent has lost connection"` // Reason is a human-readable explanation of the agent's health. It is empty if Healthy is true.
 }
 
@@ -213,7 +213,7 @@ type WorkspaceAgentLog struct {
 	CreatedAt time.Time `json:"created_at" format:"date-time"`
 	Output    string    `json:"output"`
 	Level     LogLevel  `json:"level"`
-	SourceID  uuid.UUID `json:"source_id" format:"uuid"`
+	SourceID  uuid.UUID `json:"source_id"  format:"uuid"`
 }
 
 // Text formats the log entry as human-readable text.
@@ -362,8 +362,8 @@ func (c *Client) WorkspaceAgent(ctx context.Context, id uuid.UUID) (WorkspaceAge
 
 type IssueReconnectingPTYSignedTokenRequest struct {
 	// URL is the URL of the reconnecting-pty endpoint you are connecting to.
-	URL     string    `json:"url" validate:"required"`
-	AgentID uuid.UUID `json:"agentID" format:"uuid" validate:"required"`
+	URL     string    `json:"url"     validate:"required"`
+	AgentID uuid.UUID `json:"agentID" format:"uuid"       validate:"required"`
 }
 
 type IssueReconnectingPTYSignedTokenResponse struct {
@@ -439,7 +439,7 @@ func (s WorkspaceAgentDevcontainerStatus) Transitioning() bool {
 // WorkspaceAgentDevcontainer defines the location of a devcontainer
 // configuration in a workspace that is visible to the workspace agent.
 type WorkspaceAgentDevcontainer struct {
-	ID              uuid.UUID     `json:"id" format:"uuid"`
+	ID              uuid.UUID     `json:"id"                    format:"uuid"`
 	Name            string        `json:"name"`
 	WorkspaceFolder string        `json:"workspace_folder"`
 	ConfigPath      string        `json:"config_path,omitempty"`
@@ -477,7 +477,7 @@ func (d WorkspaceAgentDevcontainer) IsTerraformDefined() bool {
 // WorkspaceAgentDevcontainerAgent represents the sub agent for a
 // devcontainer.
 type WorkspaceAgentDevcontainerAgent struct {
-	ID        uuid.UUID `json:"id" format:"uuid"`
+	ID        uuid.UUID `json:"id"        format:"uuid"`
 	Name      string    `json:"name"`
 	Directory string    `json:"directory"`
 }
@@ -731,7 +731,7 @@ const (
 // the client over the git watch WebSocket.
 type WorkspaceAgentGitServerMessage struct {
 	Type         WorkspaceAgentGitServerMessageType `json:"type"`
-	ScannedAt    *time.Time                         `json:"scanned_at,omitempty" format:"date-time"`
+	ScannedAt    *time.Time                         `json:"scanned_at,omitempty"   format:"date-time"`
 	Repositories []WorkspaceAgentRepoChanges        `json:"repositories,omitempty"`
 	Message      string                             `json:"message,omitempty"`
 }

--- a/codersdk/workspaceapps.go
+++ b/codersdk/workspaceapps.go
@@ -82,7 +82,7 @@ type WorkspaceApp struct {
 	Subdomain bool `json:"subdomain"`
 	// SubdomainName is the application domain exposed on the `coder server`.
 	SubdomainName string                   `json:"subdomain_name,omitempty"`
-	SharingLevel  WorkspaceAppSharingLevel `json:"sharing_level" enums:"owner,authenticated,organization,public"`
+	SharingLevel  WorkspaceAppSharingLevel `json:"sharing_level"            enums:"owner,authenticated,organization,public"`
 	// Healthcheck specifies the configuration for checking app health.
 	Healthcheck Healthcheck        `json:"healthcheck,omitempty"`
 	Health      WorkspaceAppHealth `json:"health"`
@@ -107,11 +107,11 @@ type Healthcheck struct {
 }
 
 type WorkspaceAppStatus struct {
-	ID          uuid.UUID               `json:"id" format:"uuid"`
-	CreatedAt   time.Time               `json:"created_at" format:"date-time"`
+	ID          uuid.UUID               `json:"id"           format:"uuid"`
+	CreatedAt   time.Time               `json:"created_at"   format:"date-time"`
 	WorkspaceID uuid.UUID               `json:"workspace_id" format:"uuid"`
-	AgentID     uuid.UUID               `json:"agent_id" format:"uuid"`
-	AppID       uuid.UUID               `json:"app_id" format:"uuid"`
+	AgentID     uuid.UUID               `json:"agent_id"     format:"uuid"`
+	AppID       uuid.UUID               `json:"app_id"       format:"uuid"`
 	State       WorkspaceAppStatusState `json:"state"`
 	Message     string                  `json:"message"`
 	// URI is the URI of the resource that the status is for.

--- a/codersdk/workspacebuilds.go
+++ b/codersdk/workspacebuilds.go
@@ -73,30 +73,30 @@ const (
 // WorkspaceBuild is an at-point representation of a workspace state.
 // BuildNumbers start at 1 and increase by 1 for each subsequent build
 type WorkspaceBuild struct {
-	ID               uuid.UUID `json:"id" format:"uuid"`
-	CreatedAt        time.Time `json:"created_at" format:"date-time"`
-	UpdatedAt        time.Time `json:"updated_at" format:"date-time"`
-	WorkspaceID      uuid.UUID `json:"workspace_id" format:"uuid"`
+	ID               uuid.UUID `json:"id"                 format:"uuid"`
+	CreatedAt        time.Time `json:"created_at"         format:"date-time"`
+	UpdatedAt        time.Time `json:"updated_at"         format:"date-time"`
+	WorkspaceID      uuid.UUID `json:"workspace_id"       format:"uuid"`
 	WorkspaceName    string    `json:"workspace_name"`
 	WorkspaceOwnerID uuid.UUID `json:"workspace_owner_id" format:"uuid"`
 	// WorkspaceOwnerName is the username of the owner of the workspace.
 	WorkspaceOwnerName      string               `json:"workspace_owner_name"`
 	WorkspaceOwnerAvatarURL string               `json:"workspace_owner_avatar_url,omitempty"`
-	TemplateVersionID       uuid.UUID            `json:"template_version_id" format:"uuid"`
+	TemplateVersionID       uuid.UUID            `json:"template_version_id"                  format:"uuid"`
 	TemplateVersionName     string               `json:"template_version_name"`
 	BuildNumber             int32                `json:"build_number"`
-	Transition              WorkspaceTransition  `json:"transition" enums:"start,stop,delete"`
-	InitiatorID             uuid.UUID            `json:"initiator_id" format:"uuid"`
+	Transition              WorkspaceTransition  `json:"transition"                           enums:"start,stop,delete"`
+	InitiatorID             uuid.UUID            `json:"initiator_id"                         format:"uuid"`
 	InitiatorUsername       string               `json:"initiator_name"`
 	Job                     ProvisionerJob       `json:"job"`
-	Reason                  BuildReason          `db:"reason" json:"reason" enums:"initiator,autostart,autostop"`
+	Reason                  BuildReason          `db:"reason"                                 json:"reason"                                                                                enums:"initiator,autostart,autostop"`
 	Resources               []WorkspaceResource  `json:"resources"`
-	Deadline                NullTime             `json:"deadline,omitempty" format:"date-time"`
-	MaxDeadline             NullTime             `json:"max_deadline,omitempty" format:"date-time"`
-	Status                  WorkspaceStatus      `json:"status" enums:"pending,starting,running,stopping,stopped,failed,canceling,canceled,deleting,deleted"`
+	Deadline                NullTime             `json:"deadline,omitempty"                   format:"date-time"`
+	MaxDeadline             NullTime             `json:"max_deadline,omitempty"               format:"date-time"`
+	Status                  WorkspaceStatus      `json:"status"                               enums:"pending,starting,running,stopping,stopped,failed,canceling,canceled,deleting,deleted"`
 	DailyCost               int32                `json:"daily_cost"`
 	MatchedProvisioners     *MatchedProvisioners `json:"matched_provisioners,omitempty"`
-	TemplateVersionPresetID *uuid.UUID           `json:"template_version_preset_id" format:"uuid"`
+	TemplateVersionPresetID *uuid.UUID           `json:"template_version_preset_id"           format:"uuid"`
 	// Deprecated: This field has been deprecated in favor of Task WorkspaceID.
 	HasAITask        *bool `json:"has_ai_task,omitempty"`
 	HasExternalAgent *bool `json:"has_external_agent,omitempty"`
@@ -105,9 +105,9 @@ type WorkspaceBuild struct {
 // WorkspaceResource describes resources used to create a workspace, for instance:
 // containers, images, volumes.
 type WorkspaceResource struct {
-	ID         uuid.UUID                   `json:"id" format:"uuid"`
-	CreatedAt  time.Time                   `json:"created_at" format:"date-time"`
-	JobID      uuid.UUID                   `json:"job_id" format:"uuid"`
+	ID         uuid.UUID                   `json:"id"                   format:"uuid"`
+	CreatedAt  time.Time                   `json:"created_at"           format:"date-time"`
+	JobID      uuid.UUID                   `json:"job_id"               format:"uuid"`
 	Transition WorkspaceTransition         `json:"workspace_transition" enums:"start,stop,delete"`
 	Type       string                      `json:"type"`
 	Name       string                      `json:"name"`
@@ -262,9 +262,9 @@ const (
 )
 
 type ProvisionerTiming struct {
-	JobID     uuid.UUID   `json:"job_id" format:"uuid"`
+	JobID     uuid.UUID   `json:"job_id"     format:"uuid"`
 	StartedAt time.Time   `json:"started_at" format:"date-time"`
-	EndedAt   time.Time   `json:"ended_at" format:"date-time"`
+	EndedAt   time.Time   `json:"ended_at"   format:"date-time"`
 	Stage     TimingStage `json:"stage"`
 	Source    string      `json:"source"`
 	Action    string      `json:"action"`
@@ -272,8 +272,8 @@ type ProvisionerTiming struct {
 }
 
 type AgentScriptTiming struct {
-	StartedAt          time.Time   `json:"started_at" format:"date-time"`
-	EndedAt            time.Time   `json:"ended_at" format:"date-time"`
+	StartedAt          time.Time   `json:"started_at"           format:"date-time"`
+	EndedAt            time.Time   `json:"ended_at"             format:"date-time"`
 	ExitCode           int32       `json:"exit_code"`
 	Stage              TimingStage `json:"stage"`
 	Status             string      `json:"status"`
@@ -283,8 +283,8 @@ type AgentScriptTiming struct {
 }
 
 type AgentConnectionTiming struct {
-	StartedAt          time.Time   `json:"started_at" format:"date-time"`
-	EndedAt            time.Time   `json:"ended_at" format:"date-time"`
+	StartedAt          time.Time   `json:"started_at"           format:"date-time"`
+	EndedAt            time.Time   `json:"ended_at"             format:"date-time"`
 	Stage              TimingStage `json:"stage"`
 	WorkspaceAgentID   string      `json:"workspace_agent_id"`
 	WorkspaceAgentName string      `json:"workspace_agent_name"`

--- a/codersdk/workspacebuilds.go
+++ b/codersdk/workspacebuilds.go
@@ -82,21 +82,21 @@ type WorkspaceBuild struct {
 	// WorkspaceOwnerName is the username of the owner of the workspace.
 	WorkspaceOwnerName      string               `json:"workspace_owner_name"`
 	WorkspaceOwnerAvatarURL string               `json:"workspace_owner_avatar_url,omitempty"`
-	TemplateVersionID       uuid.UUID            `json:"template_version_id"                  format:"uuid"`
+	TemplateVersionID       uuid.UUID            `json:"template_version_id"                                                                                                                           format:"uuid"`
 	TemplateVersionName     string               `json:"template_version_name"`
 	BuildNumber             int32                `json:"build_number"`
-	Transition              WorkspaceTransition  `json:"transition"                           enums:"start,stop,delete"`
-	InitiatorID             uuid.UUID            `json:"initiator_id"                         format:"uuid"`
+	Transition              WorkspaceTransition  `json:"transition"                                       enums:"start,stop,delete"`
+	InitiatorID             uuid.UUID            `json:"initiator_id"                                                                                                                                  format:"uuid"`
 	InitiatorUsername       string               `json:"initiator_name"`
 	Job                     ProvisionerJob       `json:"job"`
-	Reason                  BuildReason          `db:"reason"                                 json:"reason"                                                                                enums:"initiator,autostart,autostop"`
+	Reason                  BuildReason          `json:"reason"                               db:"reason" enums:"initiator,autostart,autostop"`
 	Resources               []WorkspaceResource  `json:"resources"`
-	Deadline                NullTime             `json:"deadline,omitempty"                   format:"date-time"`
-	MaxDeadline             NullTime             `json:"max_deadline,omitempty"               format:"date-time"`
-	Status                  WorkspaceStatus      `json:"status"                               enums:"pending,starting,running,stopping,stopped,failed,canceling,canceled,deleting,deleted"`
+	Deadline                NullTime             `json:"deadline,omitempty"                                                                                                                            format:"date-time"`
+	MaxDeadline             NullTime             `json:"max_deadline,omitempty"                                                                                                                        format:"date-time"`
+	Status                  WorkspaceStatus      `json:"status"                                           enums:"pending,starting,running,stopping,stopped,failed,canceling,canceled,deleting,deleted"`
 	DailyCost               int32                `json:"daily_cost"`
 	MatchedProvisioners     *MatchedProvisioners `json:"matched_provisioners,omitempty"`
-	TemplateVersionPresetID *uuid.UUID           `json:"template_version_preset_id"           format:"uuid"`
+	TemplateVersionPresetID *uuid.UUID           `json:"template_version_preset_id"                                                                                                                    format:"uuid"`
 	// Deprecated: This field has been deprecated in favor of Task WorkspaceID.
 	HasAITask        *bool `json:"has_ai_task,omitempty"`
 	HasExternalAgent *bool `json:"has_external_agent,omitempty"`
@@ -105,9 +105,9 @@ type WorkspaceBuild struct {
 // WorkspaceResource describes resources used to create a workspace, for instance:
 // containers, images, volumes.
 type WorkspaceResource struct {
-	ID         uuid.UUID                   `json:"id"                   format:"uuid"`
-	CreatedAt  time.Time                   `json:"created_at"           format:"date-time"`
-	JobID      uuid.UUID                   `json:"job_id"               format:"uuid"`
+	ID         uuid.UUID                   `json:"id"                                             format:"uuid"`
+	CreatedAt  time.Time                   `json:"created_at"                                     format:"date-time"`
+	JobID      uuid.UUID                   `json:"job_id"                                         format:"uuid"`
 	Transition WorkspaceTransition         `json:"workspace_transition" enums:"start,stop,delete"`
 	Type       string                      `json:"type"`
 	Name       string                      `json:"name"`

--- a/codersdk/workspaceproxy.go
+++ b/codersdk/workspaceproxy.go
@@ -31,7 +31,7 @@ type WorkspaceProxyStatus struct {
 	Status ProxyHealthStatus `json:"status" table:"status,default_sort"`
 	// Report provides more information about the health of the workspace proxy.
 	Report    ProxyHealthReport `json:"report,omitempty" table:"report"`
-	CheckedAt time.Time         `json:"checked_at" table:"checked at" format:"date-time"`
+	CheckedAt time.Time         `json:"checked_at"       table:"checked at" format:"date-time"`
 }
 
 // ProxyHealthReport is a report of the health of the workspace proxy.
@@ -47,8 +47,8 @@ type ProxyHealthReport struct {
 type WorkspaceProxy struct {
 	// Extends Region with extra information
 	Region      `table:"region,recursive_inline"`
-	DerpEnabled bool `json:"derp_enabled" table:"derp enabled"`
-	DerpOnly    bool `json:"derp_only" table:"derp only"`
+	DerpEnabled bool `json:"derp_enabled"             table:"derp enabled"`
+	DerpOnly    bool `json:"derp_only"                table:"derp only"`
 
 	// Status is the latest status check of the proxy. This will be empty for deleted
 	// proxies. This value can be used to determine if a workspace proxy is healthy
@@ -57,18 +57,18 @@ type WorkspaceProxy struct {
 
 	CreatedAt time.Time `json:"created_at" format:"date-time" table:"created at"`
 	UpdatedAt time.Time `json:"updated_at" format:"date-time" table:"updated at"`
-	Deleted   bool      `json:"deleted" table:"deleted"`
-	Version   string    `json:"version" table:"version"`
+	Deleted   bool      `json:"deleted"    table:"deleted"`
+	Version   string    `json:"version"    table:"version"`
 }
 
 type CreateWorkspaceProxyRequest struct {
-	Name        string `json:"name" validate:"required"`
+	Name        string `json:"name"         validate:"required"`
 	DisplayName string `json:"display_name"`
 	Icon        string `json:"icon"`
 }
 
 type UpdateWorkspaceProxyResponse struct {
-	Proxy      WorkspaceProxy `json:"proxy" table:"p,recursive_inline"`
+	Proxy      WorkspaceProxy `json:"proxy"       table:"p,recursive_inline"`
 	ProxyToken string         `json:"proxy_token" table:"proxy token"`
 }
 
@@ -108,10 +108,10 @@ func (c *Client) WorkspaceProxies(ctx context.Context) (RegionsResponse[Workspac
 }
 
 type PatchWorkspaceProxy struct {
-	ID              uuid.UUID `json:"id" format:"uuid" validate:"required"`
-	Name            string    `json:"name" validate:"required"`
-	DisplayName     string    `json:"display_name" validate:"required"`
-	Icon            string    `json:"icon" validate:"required"`
+	ID              uuid.UUID `json:"id"               format:"uuid"       validate:"required"`
+	Name            string    `json:"name"             validate:"required"`
+	DisplayName     string    `json:"display_name"     validate:"required"`
+	Icon            string    `json:"icon"             validate:"required"`
 	RegenerateToken bool      `json:"regenerate_token"`
 }
 
@@ -184,11 +184,11 @@ type RegionsResponse[R RegionTypes] struct {
 }
 
 type Region struct {
-	ID          uuid.UUID `json:"id" format:"uuid" table:"id"`
-	Name        string    `json:"name" table:"name,default_sort"`
+	ID          uuid.UUID `json:"id"           format:"uuid"             table:"id"`
+	Name        string    `json:"name"         table:"name,default_sort"`
 	DisplayName string    `json:"display_name" table:"display name"`
-	IconURL     string    `json:"icon_url" table:"icon url"`
-	Healthy     bool      `json:"healthy" table:"healthy"`
+	IconURL     string    `json:"icon_url"     table:"icon url"`
+	Healthy     bool      `json:"healthy"      table:"healthy"`
 
 	// PathAppURL is the URL to the base path for path apps. Optional
 	// unless wildcard_hostname is set.

--- a/codersdk/workspaceproxy.go
+++ b/codersdk/workspaceproxy.go
@@ -46,17 +46,17 @@ type ProxyHealthReport struct {
 
 type WorkspaceProxy struct {
 	// Extends Region with extra information
-	Region      `table:"region,recursive_inline"`
-	DerpEnabled bool `json:"derp_enabled"             table:"derp enabled"`
-	DerpOnly    bool `json:"derp_only"                table:"derp only"`
+	Region      `                    table:"region,recursive_inline"`
+	DerpEnabled bool `json:"derp_enabled" table:"derp enabled"`
+	DerpOnly    bool `json:"derp_only"    table:"derp only"`
 
 	// Status is the latest status check of the proxy. This will be empty for deleted
 	// proxies. This value can be used to determine if a workspace proxy is healthy
 	// and ready to use.
 	Status WorkspaceProxyStatus `json:"status,omitempty" table:"proxy,recursive"`
 
-	CreatedAt time.Time `json:"created_at" format:"date-time" table:"created at"`
-	UpdatedAt time.Time `json:"updated_at" format:"date-time" table:"updated at"`
+	CreatedAt time.Time `json:"created_at" table:"created at" format:"date-time"`
+	UpdatedAt time.Time `json:"updated_at" table:"updated at" format:"date-time"`
 	Deleted   bool      `json:"deleted"    table:"deleted"`
 	Version   string    `json:"version"    table:"version"`
 }
@@ -108,10 +108,10 @@ func (c *Client) WorkspaceProxies(ctx context.Context) (RegionsResponse[Workspac
 }
 
 type PatchWorkspaceProxy struct {
-	ID              uuid.UUID `json:"id"               format:"uuid"       validate:"required"`
-	Name            string    `json:"name"             validate:"required"`
-	DisplayName     string    `json:"display_name"     validate:"required"`
-	Icon            string    `json:"icon"             validate:"required"`
+	ID              uuid.UUID `json:"id"               format:"uuid" validate:"required"`
+	Name            string    `json:"name"                           validate:"required"`
+	DisplayName     string    `json:"display_name"                   validate:"required"`
+	Icon            string    `json:"icon"                           validate:"required"`
 	RegenerateToken bool      `json:"regenerate_token"`
 }
 
@@ -184,7 +184,7 @@ type RegionsResponse[R RegionTypes] struct {
 }
 
 type Region struct {
-	ID          uuid.UUID `json:"id"           format:"uuid"             table:"id"`
+	ID          uuid.UUID `json:"id"           table:"id"                format:"uuid"`
 	Name        string    `json:"name"         table:"name,default_sort"`
 	DisplayName string    `json:"display_name" table:"display name"`
 	IconURL     string    `json:"icon_url"     table:"icon url"`

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -28,21 +28,21 @@ const (
 // Workspace is a deployment of a template. It references a specific
 // version and can be updated.
 type Workspace struct {
-	ID        uuid.UUID `json:"id" format:"uuid"`
+	ID        uuid.UUID `json:"id"         format:"uuid"`
 	CreatedAt time.Time `json:"created_at" format:"date-time"`
 	UpdatedAt time.Time `json:"updated_at" format:"date-time"`
-	OwnerID   uuid.UUID `json:"owner_id" format:"uuid"`
+	OwnerID   uuid.UUID `json:"owner_id"   format:"uuid"`
 	// OwnerName is the username of the owner of the workspace.
 	OwnerName                            string              `json:"owner_name"`
 	OwnerAvatarURL                       string              `json:"owner_avatar_url"`
-	OrganizationID                       uuid.UUID           `json:"organization_id" format:"uuid"`
+	OrganizationID                       uuid.UUID           `json:"organization_id"                           format:"uuid"`
 	OrganizationName                     string              `json:"organization_name"`
-	TemplateID                           uuid.UUID           `json:"template_id" format:"uuid"`
+	TemplateID                           uuid.UUID           `json:"template_id"                               format:"uuid"`
 	TemplateName                         string              `json:"template_name"`
 	TemplateDisplayName                  string              `json:"template_display_name"`
 	TemplateIcon                         string              `json:"template_icon"`
 	TemplateAllowUserCancelWorkspaceJobs bool                `json:"template_allow_user_cancel_workspace_jobs"`
-	TemplateActiveVersionID              uuid.UUID           `json:"template_active_version_id" format:"uuid"`
+	TemplateActiveVersionID              uuid.UUID           `json:"template_active_version_id"                format:"uuid"`
 	TemplateRequireActiveVersion         bool                `json:"template_require_active_version"`
 	TemplateUseClassicParameterFlow      bool                `json:"template_use_classic_parameter_flow"`
 	LatestBuild                          WorkspaceBuild      `json:"latest_build"`
@@ -51,7 +51,7 @@ type Workspace struct {
 	Name                                 string              `json:"name"`
 	AutostartSchedule                    *string             `json:"autostart_schedule,omitempty"`
 	TTLMillis                            *int64              `json:"ttl_ms,omitempty"`
-	LastUsedAt                           time.Time           `json:"last_used_at" format:"date-time"`
+	LastUsedAt                           time.Time           `json:"last_used_at"                              format:"date-time"`
 	// DeletingAt indicates the time at which the workspace will be permanently deleted.
 	// A workspace is eligible for deletion if it is dormant (a non-nil dormant_at value)
 	// and a value has been specified for time_til_dormant_autodelete on its template.
@@ -67,7 +67,7 @@ type Workspace struct {
 	AutomaticUpdates AutomaticUpdates `json:"automatic_updates" enums:"always,never"`
 	AllowRenames     bool             `json:"allow_renames"`
 	Favorite         bool             `json:"favorite"`
-	NextStartAt      *time.Time       `json:"next_start_at" format:"date-time"`
+	NextStartAt      *time.Time       `json:"next_start_at"     format:"date-time"`
 	// IsPrebuild indicates whether the workspace is a prebuilt workspace.
 	// Prebuilt workspaces are owned by the prebuilds system user and have specific behavior,
 	// such as being managed differently from regular workspaces.
@@ -84,8 +84,8 @@ func (w Workspace) FullName() string {
 }
 
 type WorkspaceHealth struct {
-	Healthy       bool        `json:"healthy" example:"false"`      // Healthy is true if the workspace is healthy.
-	FailingAgents []uuid.UUID `json:"failing_agents" format:"uuid"` // FailingAgents lists the IDs of the agents that are failing, if any.
+	Healthy       bool        `json:"healthy"        example:"false"` // Healthy is true if the workspace is healthy.
+	FailingAgents []uuid.UUID `json:"failing_agents" format:"uuid"`   // FailingAgents lists the IDs of the agents that are failing, if any.
 }
 
 type WorkspacesRequest struct {
@@ -119,7 +119,7 @@ const (
 // CreateWorkspaceBuildRequest provides options to update the latest workspace build.
 type CreateWorkspaceBuildRequest struct {
 	TemplateVersionID uuid.UUID           `json:"template_version_id,omitempty" format:"uuid"`
-	Transition        WorkspaceTransition `json:"transition" validate:"oneof=start stop delete,required"`
+	Transition        WorkspaceTransition `json:"transition"                    validate:"oneof=start stop delete,required"`
 	DryRun            bool                `json:"dry_run,omitempty"`
 	ProvisionerState  []byte              `json:"state,omitempty"`
 	// Orphan may be set for the Destroy transition.
@@ -701,8 +701,8 @@ type WorkspaceUser struct {
 }
 
 type SharedWorkspaceActor struct {
-	ID        uuid.UUID                `json:"id" format:"uuid"`
-	ActorType SharedWorkspaceActorType `json:"actor_type" enums:"group,user"`
+	ID        uuid.UUID                `json:"id"                   format:"uuid"`
+	ActorType SharedWorkspaceActorType `json:"actor_type"           enums:"group,user"`
 	Name      string                   `json:"name"`
 	AvatarURL string                   `json:"avatar_url,omitempty" format:"uri"`
 	Roles     []WorkspaceRole          `json:"roles"`
@@ -795,9 +795,9 @@ func (c *Client) WorkspaceExternalAgentCredentials(ctx context.Context, workspac
 // This is published via the /watch-all-workspacebuilds SSE endpoint when the
 // workspace-build-updates experiment is enabled.
 type WorkspaceBuildUpdate struct {
-	WorkspaceID   uuid.UUID `json:"workspace_id" format:"uuid"`
+	WorkspaceID   uuid.UUID `json:"workspace_id"   format:"uuid"`
 	WorkspaceName string    `json:"workspace_name"`
-	BuildID       uuid.UUID `json:"build_id" format:"uuid"`
+	BuildID       uuid.UUID `json:"build_id"       format:"uuid"`
 	// Transition is the workspace transition type: "start", "stop", or "delete".
 	Transition string `json:"transition"`
 	// JobStatus is the provisioner job status: "pending", "running",

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -67,7 +67,7 @@ type Workspace struct {
 	AutomaticUpdates AutomaticUpdates `json:"automatic_updates" enums:"always,never"`
 	AllowRenames     bool             `json:"allow_renames"`
 	Favorite         bool             `json:"favorite"`
-	NextStartAt      *time.Time       `json:"next_start_at"     format:"date-time"`
+	NextStartAt      *time.Time       `json:"next_start_at"                          format:"date-time"`
 	// IsPrebuild indicates whether the workspace is a prebuilt workspace.
 	// Prebuilt workspaces are owned by the prebuilds system user and have specific behavior,
 	// such as being managed differently from regular workspaces.
@@ -84,8 +84,8 @@ func (w Workspace) FullName() string {
 }
 
 type WorkspaceHealth struct {
-	Healthy       bool        `json:"healthy"        example:"false"` // Healthy is true if the workspace is healthy.
-	FailingAgents []uuid.UUID `json:"failing_agents" format:"uuid"`   // FailingAgents lists the IDs of the agents that are failing, if any.
+	Healthy       bool        `json:"healthy"        example:"false"`               // Healthy is true if the workspace is healthy.
+	FailingAgents []uuid.UUID `json:"failing_agents"                 format:"uuid"` // FailingAgents lists the IDs of the agents that are failing, if any.
 }
 
 type WorkspacesRequest struct {
@@ -119,7 +119,7 @@ const (
 // CreateWorkspaceBuildRequest provides options to update the latest workspace build.
 type CreateWorkspaceBuildRequest struct {
 	TemplateVersionID uuid.UUID           `json:"template_version_id,omitempty" format:"uuid"`
-	Transition        WorkspaceTransition `json:"transition"                    validate:"oneof=start stop delete,required"`
+	Transition        WorkspaceTransition `json:"transition"                                  validate:"oneof=start stop delete,required"`
 	DryRun            bool                `json:"dry_run,omitempty"`
 	ProvisionerState  []byte              `json:"state,omitempty"`
 	// Orphan may be set for the Destroy transition.
@@ -330,7 +330,7 @@ func (c *Client) UpdateWorkspaceTTL(ctx context.Context, id uuid.UUID, req Updat
 // PutExtendWorkspaceRequest is a request to extend the deadline of
 // the active workspace build.
 type PutExtendWorkspaceRequest struct {
-	Deadline time.Time `json:"deadline" validate:"required" format:"date-time"`
+	Deadline time.Time `json:"deadline" format:"date-time" validate:"required"`
 }
 
 // PutExtendWorkspace updates the deadline for resources of the latest workspace build.
@@ -701,10 +701,10 @@ type WorkspaceUser struct {
 }
 
 type SharedWorkspaceActor struct {
-	ID        uuid.UUID                `json:"id"                   format:"uuid"`
+	ID        uuid.UUID                `json:"id"                                      format:"uuid"`
 	ActorType SharedWorkspaceActorType `json:"actor_type"           enums:"group,user"`
 	Name      string                   `json:"name"`
-	AvatarURL string                   `json:"avatar_url,omitempty" format:"uri"`
+	AvatarURL string                   `json:"avatar_url,omitempty"                    format:"uri"`
 	Roles     []WorkspaceRole          `json:"roles"`
 }
 

--- a/enterprise/coderd/scim.go
+++ b/enterprise/coderd/scim.go
@@ -169,7 +169,7 @@ type SCIMUser struct {
 	} `json:"name"`
 	Emails []struct {
 		Primary bool   `json:"primary"`
-		Value   string `json:"value" format:"email"`
+		Value   string `json:"value"   format:"email"`
 		Type    string `json:"type"`
 		Display string `json:"display"`
 	} `json:"emails"`

--- a/enterprise/coderd/scim_test.go
+++ b/enterprise/coderd/scim_test.go
@@ -40,17 +40,17 @@ func makeScimUser(t testing.TB) coderd.SCIMUser {
 	return coderd.SCIMUser{
 		UserName: rstr,
 		Name: struct {
-			GivenName  string "json:\"givenName\""
-			FamilyName string "json:\"familyName\""
+			GivenName  string `json:"givenName"`
+			FamilyName string `json:"familyName"`
 		}{
 			GivenName:  rstr,
 			FamilyName: rstr,
 		},
 		Emails: []struct {
-			Primary bool   "json:\"primary\""
-			Value   string "json:\"value\" format:\"email\""
-			Type    string "json:\"type\""
-			Display string "json:\"display\""
+			Primary bool   `json:"primary"`
+			Value   string `json:"value"   format:"email"`
+			Type    string `json:"type"`
+			Display string `json:"display"`
 		}{
 			{Primary: true, Value: fmt.Sprintf("%s@coder.com", rstr)},
 		},


### PR DESCRIPTION
Enable the [tagalign](https://github.com/4meepo/tagalign) linter in strict mode with `json`, `db`, `table` as priority tags. Tags are sorted (priority tags first, rest alphabetical), aligned, and gap-filled so you can visually scan the same tag across all fields in a struct.

Generated files (`.pb.go`, sqlc) are excluded by golangci-lint's default generated-file detection.

> 🤖 This PR was created with the help of Mux, and has been reviewed by a human. 🏂🏻