### PR TITLE
feat: bump workspace last_used_at on chat heartbeat

### DIFF
--- a/coderd/chatd/chatd.go
+++ b/coderd/chatd/chatd.go
@@ -31,6 +31,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/pubsub"
 	coderdpubsub "github.com/coder/coder/v2/coderd/pubsub"
 	"github.com/coder/coder/v2/coderd/webpush"
+	"github.com/coder/coder/v2/coderd/workspacestats"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
 	"github.com/coder/quartz"
@@ -95,6 +96,8 @@ type Server struct {
 	// workspace agent ID so we don't re-dial on every chat turn.
 	instructionCacheMu sync.RWMutex
 	instructionCache   map[uuid.UUID]cachedInstruction
+
+	usageTracker *workspacestats.UsageTracker
 
 	// Configuration
 	pendingChatAcquireInterval time.Duration
@@ -1224,6 +1227,7 @@ type Config struct {
 	Pubsub                     pubsub.Pubsub
 	ProviderAPIKeys            chatprovider.ProviderAPIKeys
 	WebpushDispatcher          webpush.Dispatcher
+	UsageTracker               *workspacestats.UsageTracker
 }
 
 // New creates a new chat processor. The processor polls for pending
@@ -1269,6 +1273,7 @@ func New(cfg Config) *Server {
 		pendingChatAcquireInterval: pendingChatAcquireInterval,
 		maxChatsPerAcquire:         maxChatsPerAcquire,
 		inFlightChatStaleAfter:     inFlightChatStaleAfter,
+		usageTracker:               cfg.UsageTracker,
 	}
 
 	//nolint:gocritic // The chat processor uses a scoped chatd context.
@@ -2200,6 +2205,9 @@ func (p *Server) processChat(ctx context.Context, chat database.Chat) {
 				if rows == 0 {
 					cancel(chatloop.ErrInterrupted)
 					return
+				}
+				if p.usageTracker != nil && chat.WorkspaceID.Valid {
+					p.usageTracker.Add(chat.WorkspaceID.UUID)
 				}
 			}
 		}

--- a/coderd/chatd/chatd.go
+++ b/coderd/chatd/chatd.go
@@ -47,7 +47,9 @@ const (
 
 	homeInstructionLookupTimeout = 5 * time.Second
 	instructionCacheTTL          = 5 * time.Minute
-	chatHeartbeatInterval        = 60 * time.Second
+	// DefaultChatHeartbeatInterval is the default time between chat
+	// heartbeat updates while a chat is being processed.
+	DefaultChatHeartbeatInterval = 30 * time.Second
 	maxChatSteps                 = 1200
 	// maxStreamBufferSize caps the number of events buffered
 	// per chat during a single LLM step. When exceeded the
@@ -98,11 +100,13 @@ type Server struct {
 	instructionCache   map[uuid.UUID]cachedInstruction
 
 	usageTracker *workspacestats.UsageTracker
+	clock        quartz.Clock
 
 	// Configuration
 	pendingChatAcquireInterval time.Duration
 	maxChatsPerAcquire         int32
 	inFlightChatStaleAfter     time.Duration
+	chatHeartbeatInterval      time.Duration
 }
 
 type cachedInstruction struct {
@@ -1221,6 +1225,7 @@ type Config struct {
 	PendingChatAcquireInterval time.Duration
 	MaxChatsPerAcquire         int32
 	InFlightChatStaleAfter     time.Duration
+	ChatHeartbeatInterval      time.Duration
 	AgentConn                  AgentConnFunc
 	CreateWorkspace            chattool.CreateWorkspaceFn
 	StartWorkspace             chattool.StartWorkspaceFn
@@ -1228,6 +1233,7 @@ type Config struct {
 	ProviderAPIKeys            chatprovider.ProviderAPIKeys
 	WebpushDispatcher          webpush.Dispatcher
 	UsageTracker               *workspacestats.UsageTracker
+	Clock                      quartz.Clock
 }
 
 // New creates a new chat processor. The processor polls for pending
@@ -1249,6 +1255,16 @@ func New(cfg Config) *Server {
 	maxChatsPerAcquire := cfg.MaxChatsPerAcquire
 	if maxChatsPerAcquire <= 0 {
 		maxChatsPerAcquire = DefaultMaxChatsPerAcquire
+	}
+
+	chatHeartbeatInterval := cfg.ChatHeartbeatInterval
+	if chatHeartbeatInterval == 0 {
+		chatHeartbeatInterval = DefaultChatHeartbeatInterval
+	}
+
+	clk := cfg.Clock
+	if clk == nil {
+		clk = quartz.NewReal()
 	}
 
 	workerID := cfg.ReplicaID
@@ -1273,7 +1289,9 @@ func New(cfg Config) *Server {
 		pendingChatAcquireInterval: pendingChatAcquireInterval,
 		maxChatsPerAcquire:         maxChatsPerAcquire,
 		inFlightChatStaleAfter:     inFlightChatStaleAfter,
+		chatHeartbeatInterval:      chatHeartbeatInterval,
 		usageTracker:               cfg.UsageTracker,
+		clock:                      clk,
 	}
 
 	//nolint:gocritic // The chat processor uses a scoped chatd context.
@@ -2187,7 +2205,7 @@ func (p *Server) processChat(ctx context.Context, chat database.Chat) {
 	// worker is still alive. The goroutine stops when chatCtx is
 	// canceled (either by completion or interruption).
 	go func() {
-		ticker := time.NewTicker(chatHeartbeatInterval)
+		ticker := p.clock.NewTicker(p.chatHeartbeatInterval, "chatd", "heartbeat")
 		defer ticker.Stop()
 		for {
 			select {

--- a/coderd/chatd/chatd.go
+++ b/coderd/chatd/chatd.go
@@ -2187,6 +2187,35 @@ func (p *Server) tryAutoPromoteQueuedMessage(
 	return &msg, remainingQueuedMessages, true, nil
 }
 
+// trackWorkspaceUsage bumps the workspace's last_used_at via the
+// usage tracker. If wsID is not yet valid, it re-reads the chat
+// from the DB to pick up late associations (e.g. create_workspace
+// linking a workspace mid-conversation). The caller should store
+// the returned value so that subsequent calls skip the DB lookup
+// once a workspace has been found.
+func (p *Server) trackWorkspaceUsage(
+	ctx context.Context,
+	chatID uuid.UUID,
+	wsID uuid.NullUUID,
+	logger slog.Logger,
+) uuid.NullUUID {
+	if p.usageTracker == nil {
+		return wsID
+	}
+	if !wsID.Valid {
+		latest, err := p.db.GetChatByID(ctx, chatID)
+		if err != nil {
+			logger.Warn(ctx, "failed to re-read chat for workspace association", slog.Error(err))
+			return wsID
+		}
+		wsID = latest.WorkspaceID
+	}
+	if wsID.Valid {
+		p.usageTracker.Add(wsID.UUID)
+	}
+	return wsID
+}
+
 func (p *Server) processChat(ctx context.Context, chat database.Chat) {
 	logger := p.logger.With(slog.F("chat_id", chat.ID))
 	logger.Info(ctx, "processing chat request")
@@ -2224,9 +2253,7 @@ func (p *Server) processChat(ctx context.Context, chat database.Chat) {
 					cancel(chatloop.ErrInterrupted)
 					return
 				}
-				if p.usageTracker != nil && chat.WorkspaceID.Valid {
-					p.usageTracker.Add(chat.WorkspaceID.UUID)
-				}
+				chat.WorkspaceID = p.trackWorkspaceUsage(chatCtx, chat.ID, chat.WorkspaceID, logger)
 			}
 		}
 	}()

--- a/coderd/chatd/chatd_test.go
+++ b/coderd/chatd/chatd_test.go
@@ -2042,7 +2042,7 @@ func TestHeartbeatBumpsWorkspaceUsage(t *testing.T) {
 		case <-ctx.Done():
 			return false
 		}
-	}, 200*time.Millisecond,
+	}, testutil.IntervalMedium,
 		"expected usage tracker to flush at least one workspace")
 
 	// Verify the workspace's last_used_at was actually updated.

--- a/coderd/chatd/chatd_test.go
+++ b/coderd/chatd/chatd_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	dbpubsub "github.com/coder/coder/v2/coderd/database/pubsub"
 	"github.com/coder/coder/v2/coderd/util/slice"
+	"github.com/coder/coder/v2/coderd/workspacestats"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
 	"github.com/coder/coder/v2/codersdk/workspacesdk/agentconnmock"
@@ -1952,6 +1953,174 @@ func TestStartWorkspaceTool_EndToEnd(t *testing.T) {
 		}
 	}
 	require.True(t, foundToolResultInSecondCall, "expected second streamed model call to include start_workspace tool output")
+}
+
+func TestHeartbeatBumpsWorkspaceUsage(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	user, model := seedChatDependencies(ctx, t, db)
+	setOpenAIProviderBaseURL(ctx, t, db, chattest.NewOpenAI(t, func(req *chattest.OpenAIRequest) chattest.OpenAIResponse {
+		if !req.Stream {
+			return chattest.OpenAINonStreamingResponse("ok")
+		}
+		// Block until the request context is canceled so the chat
+		// stays in a processing state long enough for heartbeats
+		// to fire.
+		chunks := make(chan chattest.OpenAIChunk)
+		go func() {
+			defer close(chunks)
+			<-req.Context().Done()
+		}()
+		return chattest.OpenAIResponse{StreamingChunks: chunks}
+	}))
+
+	// Create a workspace so we can link it to the chat.
+	org := dbgen.Organization(t, db, database.Organization{})
+	tmpl := dbgen.Template(t, db, database.Template{
+		OrganizationID: org.ID,
+		CreatedBy:      user.ID,
+	})
+	ws := dbgen.Workspace(t, db, database.WorkspaceTable{
+		OwnerID:        user.ID,
+		OrganizationID: org.ID,
+		TemplateID:     tmpl.ID,
+	})
+
+	// Set up a short heartbeat interval and a UsageTracker that
+	// flushes frequently so last_used_at gets updated in the DB.
+	flushTick := make(chan time.Time)
+	flushDone := make(chan int, 1)
+	tracker := workspacestats.NewTracker(db,
+		workspacestats.TrackerWithTickFlush(flushTick, flushDone),
+		workspacestats.TrackerWithLogger(slogtest.Make(t, nil)),
+	)
+	t.Cleanup(func() { tracker.Close() })
+
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	server := chatd.New(chatd.Config{
+		Logger:                     logger,
+		Database:                   db,
+		ReplicaID:                  uuid.New(),
+		Pubsub:                     ps,
+		PendingChatAcquireInterval: 10 * time.Millisecond,
+		InFlightChatStaleAfter:     testutil.WaitLong,
+		ChatHeartbeatInterval:      100 * time.Millisecond,
+		UsageTracker:               tracker,
+	})
+	t.Cleanup(func() {
+		require.NoError(t, server.Close())
+	})
+
+	// Create a chat with the workspace linked upfront so that
+	// processChat sees the workspace_id when it acquires the chat.
+	_, err := server.CreateChat(ctx, chatd.CreateOptions{
+		OwnerID:            user.ID,
+		Title:              "usage-tracking-test",
+		ModelConfigID:      model.ID,
+		WorkspaceID:        uuid.NullUUID{UUID: ws.ID, Valid: true},
+		InitialUserContent: []fantasy.Content{fantasy.TextContent{Text: "hello"}},
+	})
+	require.NoError(t, err)
+
+	// The short heartbeat interval (100ms) means the tracker
+	// will receive workspace IDs quickly. Wait for the chat to
+	// start processing and for at least one heartbeat to fire.
+	testutil.Eventually(ctx, t, func(ctx context.Context) bool {
+		// Trigger a tracker flush and check if any workspaces
+		// were tracked.
+		select {
+		case flushTick <- time.Now():
+		case <-ctx.Done():
+			return false
+		}
+		select {
+		case count := <-flushDone:
+			return count > 0
+		case <-ctx.Done():
+			return false
+		}
+	}, 200*time.Millisecond,
+		"expected usage tracker to flush at least one workspace")
+
+	// Verify the workspace's last_used_at was actually updated.
+	updatedWs, err := db.GetWorkspaceByID(ctx, ws.ID)
+	require.NoError(t, err)
+	require.True(t, updatedWs.LastUsedAt.After(ws.LastUsedAt),
+		"workspace last_used_at should have been bumped")
+}
+
+func TestHeartbeatNoWorkspaceNoBump(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	user, model := seedChatDependencies(ctx, t, db)
+	setOpenAIProviderBaseURL(ctx, t, db, chattest.NewOpenAI(t, func(req *chattest.OpenAIRequest) chattest.OpenAIResponse {
+		if !req.Stream {
+			return chattest.OpenAINonStreamingResponse("ok")
+		}
+		chunks := make(chan chattest.OpenAIChunk)
+		go func() {
+			defer close(chunks)
+			<-req.Context().Done()
+		}()
+		return chattest.OpenAIResponse{StreamingChunks: chunks}
+	}))
+
+	// Set up UsageTracker with manual tick/flush.
+	usageTickCh := make(chan time.Time)
+	flushCh := make(chan int, 1)
+	tracker := workspacestats.NewTracker(db,
+		workspacestats.TrackerWithTickFlush(usageTickCh, flushCh),
+		workspacestats.TrackerWithLogger(slogtest.Make(t, nil)),
+	)
+	t.Cleanup(func() { tracker.Close() })
+
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	server := chatd.New(chatd.Config{
+		Logger:                     logger,
+		Database:                   db,
+		ReplicaID:                  uuid.New(),
+		Pubsub:                     ps,
+		PendingChatAcquireInterval: 10 * time.Millisecond,
+		InFlightChatStaleAfter:     testutil.WaitLong,
+		ChatHeartbeatInterval:      100 * time.Millisecond,
+	})
+	t.Cleanup(func() {
+		require.NoError(t, server.Close())
+	})
+
+	// Create a chat WITHOUT linking a workspace.
+	chat, err := server.CreateChat(ctx, chatd.CreateOptions{
+		OwnerID:            user.ID,
+		Title:              "no-workspace-test",
+		ModelConfigID:      model.ID,
+		InitialUserContent: []fantasy.Content{fantasy.TextContent{Text: "hello"}},
+	})
+	require.NoError(t, err)
+
+	// Wait for the chat to be acquired and at least one heartbeat
+	// to fire.
+	testutil.Eventually(ctx, t, func(ctx context.Context) bool {
+		fromDB, listErr := db.GetChatByID(ctx, chat.ID)
+		if listErr != nil {
+			return false
+		}
+		return fromDB.Status == database.ChatStatusRunning &&
+			fromDB.HeartbeatAt.Valid &&
+			fromDB.HeartbeatAt.Time.After(fromDB.CreatedAt)
+	}, testutil.IntervalFast,
+		"chat should be running with at least one heartbeat")
+
+	// Flush the tracker. Since no workspace was linked, count
+	// should be 0.
+	testutil.RequireSend(ctx, t, usageTickCh, time.Now())
+	count := testutil.RequireReceive(ctx, t, flushCh)
+	require.Equal(t, 0, count, "expected no workspaces to be flushed when chat has no workspace")
 }
 
 func newTestServer(

--- a/coderd/chatd/chatd_test.go
+++ b/coderd/chatd/chatd_test.go
@@ -1977,7 +1977,9 @@ func TestHeartbeatBumpsWorkspaceUsage(t *testing.T) {
 		return chattest.OpenAIResponse{StreamingChunks: chunks}
 	}))
 
-	// Create a workspace so we can link it to the chat.
+	// Create a workspace that will be linked to the chat later,
+	// simulating the normal flow where a chat is created first
+	// and then creates a workspace via create_workspace.
 	org := dbgen.Organization(t, db, database.Organization{})
 	tmpl := dbgen.Template(t, db, database.Template{
 		OrganizationID: org.ID,
@@ -2014,36 +2016,59 @@ func TestHeartbeatBumpsWorkspaceUsage(t *testing.T) {
 		require.NoError(t, server.Close())
 	})
 
-	// Create a chat with the workspace linked upfront so that
-	// processChat sees the workspace_id when it acquires the chat.
-	_, err := server.CreateChat(ctx, chatd.CreateOptions{
+	// Create a chat WITHOUT a workspace, the normal starting state.
+	chat, err := server.CreateChat(ctx, chatd.CreateOptions{
 		OwnerID:            user.ID,
 		Title:              "usage-tracking-test",
 		ModelConfigID:      model.ID,
-		WorkspaceID:        uuid.NullUUID{UUID: ws.ID, Valid: true},
-		InitialUserContent: []fantasy.Content{fantasy.TextContent{Text: "hello"}},
+		InitialUserContent: []codersdk.ChatMessagePart{codersdk.ChatMessageText("hello")},
 	})
 	require.NoError(t, err)
 
-	// The short heartbeat interval (100ms) means the tracker
-	// will receive workspace IDs quickly. Wait for the chat to
-	// start processing and for at least one heartbeat to fire.
+	// Wait for the chat to start processing and at least one
+	// heartbeat to fire.
 	testutil.Eventually(ctx, t, func(ctx context.Context) bool {
-		// Trigger a tracker flush and check if any workspaces
-		// were tracked.
+		fromDB, listErr := db.GetChatByID(ctx, chat.ID)
+		if listErr != nil {
+			return false
+		}
+		return fromDB.Status == database.ChatStatusRunning &&
+			fromDB.HeartbeatAt.Valid &&
+			fromDB.HeartbeatAt.Time.After(fromDB.CreatedAt)
+	}, testutil.IntervalFast,
+		"chat should be running with at least one heartbeat")
+
+	// Flush the tracker and verify nothing was tracked yet
+	// (no workspace linked).
+	testutil.RequireSend(ctx, t, flushTick, time.Now())
+	count := testutil.RequireReceive(ctx, t, flushDone)
+	require.Equal(t, 0, count,
+		"expected no workspaces to be flushed before association")
+
+	// Link the workspace to the chat in the DB, simulating what
+	// the create_workspace tool does mid-conversation.
+	_, err = db.UpdateChatWorkspace(ctx, database.UpdateChatWorkspaceParams{
+		WorkspaceID: uuid.NullUUID{UUID: ws.ID, Valid: true},
+		ID:          chat.ID,
+	})
+	require.NoError(t, err)
+
+	// The heartbeat re-reads the workspace association from the DB
+	// on each tick. Wait for the tracker to pick it up.
+	testutil.Eventually(ctx, t, func(ctx context.Context) bool {
 		select {
 		case flushTick <- time.Now():
 		case <-ctx.Done():
 			return false
 		}
 		select {
-		case count := <-flushDone:
-			return count > 0
+		case c := <-flushDone:
+			return c > 0
 		case <-ctx.Done():
 			return false
 		}
 	}, testutil.IntervalMedium,
-		"expected usage tracker to flush at least one workspace")
+		"expected usage tracker to flush the late-associated workspace")
 
 	// Verify the workspace's last_used_at was actually updated.
 	updatedWs, err := db.GetWorkspaceByID(ctx, ws.ID)
@@ -2099,7 +2124,7 @@ func TestHeartbeatNoWorkspaceNoBump(t *testing.T) {
 		OwnerID:            user.ID,
 		Title:              "no-workspace-test",
 		ModelConfigID:      model.ID,
-		InitialUserContent: []fantasy.Content{fantasy.TextContent{Text: "hello"}},
+		InitialUserContent: []codersdk.ChatMessagePart{codersdk.ChatMessageText("hello")},
 	})
 	require.NoError(t, err)
 

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -776,18 +776,18 @@ func New(options *Options) *API {
 	}
 
 	api.chatDaemon = chatd.New(chatd.Config{
-		Logger:             options.Logger.Named("chats"),
-		Database:           options.Database,
-		ReplicaID:          api.ID,
-		SubscribeFn:        options.ChatSubscribeFn,
-		MaxChatsPerAcquire: int32(maxChatsPerAcquire), //nolint:gosec // maxChatsPerAcquire is clamped to int32 range above.
-		ProviderAPIKeys:    chatProviderAPIKeysFromDeploymentValues(options.DeploymentValues),
-		AgentConn:          api.agentProvider.AgentConn,
-		CreateWorkspace:    api.chatCreateWorkspace,
-		StartWorkspace:     api.chatStartWorkspace,
-		Pubsub:             options.Pubsub,
-		WebpushDispatcher:  options.WebPushDispatcher,
-	})
+			Logger:             options.Logger.Named("chats"),
+			Database:           options.Database,
+			ReplicaID:          api.ID,
+			SubscribeFn:        options.ChatSubscribeFn,
+			MaxChatsPerAcquire: int32(maxChatsPerAcquire), //nolint:gosec // maxChatsPerAcquire is clamped to int32 range above.
+			ProviderAPIKeys:    chatProviderAPIKeysFromDeploymentValues(options.DeploymentValues),
+			AgentConn:          api.agentProvider.AgentConn,
+			CreateWorkspace:    api.chatCreateWorkspace,
+			StartWorkspace:     api.chatStartWorkspace,
+			Pubsub:             options.Pubsub,
+			WebpushDispatcher:  options.WebPushDispatcher,
+			UsageTracker:       options.WorkspaceUsageTracker,	})
 	gitSyncLogger := options.Logger.Named("gitsync")
 	refresher := gitsync.NewRefresher(
 		api.resolveGitProvider,

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -776,18 +776,19 @@ func New(options *Options) *API {
 	}
 
 	api.chatDaemon = chatd.New(chatd.Config{
-			Logger:             options.Logger.Named("chats"),
-			Database:           options.Database,
-			ReplicaID:          api.ID,
-			SubscribeFn:        options.ChatSubscribeFn,
-			MaxChatsPerAcquire: int32(maxChatsPerAcquire), //nolint:gosec // maxChatsPerAcquire is clamped to int32 range above.
-			ProviderAPIKeys:    chatProviderAPIKeysFromDeploymentValues(options.DeploymentValues),
-			AgentConn:          api.agentProvider.AgentConn,
-			CreateWorkspace:    api.chatCreateWorkspace,
-			StartWorkspace:     api.chatStartWorkspace,
-			Pubsub:             options.Pubsub,
-			WebpushDispatcher:  options.WebPushDispatcher,
-			UsageTracker:       options.WorkspaceUsageTracker,	})
+		Logger:             options.Logger.Named("chats"),
+		Database:           options.Database,
+		ReplicaID:          api.ID,
+		SubscribeFn:        options.ChatSubscribeFn,
+		MaxChatsPerAcquire: int32(maxChatsPerAcquire), //nolint:gosec // maxChatsPerAcquire is clamped to int32 range above.
+		ProviderAPIKeys:    chatProviderAPIKeysFromDeploymentValues(options.DeploymentValues),
+		AgentConn:          api.agentProvider.AgentConn,
+		CreateWorkspace:    api.chatCreateWorkspace,
+		StartWorkspace:     api.chatStartWorkspace,
+		Pubsub:             options.Pubsub,
+		WebpushDispatcher:  options.WebPushDispatcher,
+		UsageTracker:       options.WorkspaceUsageTracker,
+	})
 	gitSyncLogger := options.Logger.Named("gitsync")
 	refresher := gitsync.NewRefresher(
 		api.resolveGitProvider,


### PR DESCRIPTION
- coderd: Wires `options.WorkspaceUsageTracker` into the chatd config.
- chatd: Adds `UsageTracker` and calls `UsageTracker.Add(workspaceID)` on each heartbeat tick
- chatd: adds tests to verify `last_used_at` bump behaviour

> 🤖 This PR was created with the help of Coder Agents, and will be reviewed by my human.  🧑‍💻