### PR TITLE
fix(site): use ExternalImage for preset icons in task prompt

### DIFF
--- a/site/src/api/queries/templates.ts
+++ b/site/src/api/queries/templates.ts
@@ -304,9 +304,15 @@ export const previousTemplateVersion = (
 	};
 };
 
+export const templateVersionPresetsKey = (versionId: string) => [
+	templateVersionRoot,
+	versionId,
+	"presets",
+];
+
 export const templateVersionPresets = (versionId: string) => {
 	return {
-		queryKey: [templateVersionRoot, versionId, "presets"],
+		queryKey: templateVersionPresetsKey(versionId),
 		queryFn: () => API.getTemplateVersionPresets(versionId),
 	};
 };

--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.stories.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.stories.tsx
@@ -528,9 +528,10 @@ export const IconContrast: Story = {
 		queries: [
 			{
 				key: templateVersionPresetsKey(MockTemplateVersion.id),
-				data: MockPresets.map((preset, i) => ({
+				data: MockPresets.map((preset) => ({
 					...preset,
-					Icon: i === 0 ? "/icon/github.svg" : "/icon/tasks.svg",
+					Icon:
+						preset.ID === "preset-1" ? "/icon/github.svg" : "/icon/tasks.svg",
 				})),
 			},
 		],

--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.stories.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.stories.tsx
@@ -13,6 +13,7 @@ import {
 import { withAuthProvider, withToaster } from "testHelpers/storybook";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { API } from "api/api";
+import { templateVersionPresetsKey } from "api/queries/templates";
 import type { Task } from "api/typesGenerated";
 import { expect, spyOn, userEvent, waitFor, within } from "storybook/test";
 import type TasksPage from "../../../pages/TasksPage/TasksPage";
@@ -495,6 +496,44 @@ export const PresetSelectorFocused: Story = {
 		const canvas = within(canvasElement);
 		const presetSelect = await canvas.findByLabelText(/preset/i);
 		presetSelect.focus();
+	},
+};
+
+// Regression test for https://github.com/coder/coder/issues/22245
+// Dark monochrome icons (like GitHub or Tasks) were invisible on dark
+// backgrounds because icons used a plain <img> instead of
+// ExternalImage, which applies theme-aware CSS filters.
+export const IconContrast: Story = {
+	args: {
+		templates: [
+			{
+				...MockTemplate,
+				id: "github-template",
+				name: "github-template",
+				display_name: "GitHub",
+				icon: "/icon/github.svg",
+				active_version_id: MockTemplateVersion.id,
+			},
+			{
+				...MockTemplate,
+				id: "tasks-template",
+				name: "tasks-template",
+				display_name: "Tasks",
+				icon: "/icon/tasks.svg",
+				active_version_id: MockTemplateVersion.id,
+			},
+		],
+	},
+	parameters: {
+		queries: [
+			{
+				key: templateVersionPresetsKey(MockTemplateVersion.id),
+				data: MockPresets.map((preset, i) => ({
+					...preset,
+					Icon: i === 0 ? "/icon/github.svg" : "/icon/tasks.svg",
+				})),
+			},
+		],
 	},
 };
 

--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.stories.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.stories.tsx
@@ -528,11 +528,16 @@ export const IconContrast: Story = {
 		queries: [
 			{
 				key: templateVersionPresetsKey(MockTemplateVersion.id),
-				data: MockPresets.map((preset) => ({
-					...preset,
-					Icon:
-						preset.ID === "preset-1" ? "/icon/github.svg" : "/icon/tasks.svg",
-				})),
+				data: [
+					{
+						...MockPresets[0],
+						Icon: "/icon/github.svg",
+					},
+					{
+						...MockPresets[1],
+						Icon: "/icon/tasks.svg",
+					},
+				],
 			},
 		],
 	},

--- a/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
+++ b/site/src/modules/tasks/TaskPrompt/TaskPrompt.tsx
@@ -284,7 +284,7 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 											<SelectItem value={template.id} key={template.id}>
 												<div className="flex items-center gap-2">
 													{template.icon && (
-														<img
+														<ExternalImage
 															src={template.icon}
 															alt={template.name}
 															className="size-icon-sm flex-shrink-0"
@@ -343,7 +343,7 @@ const CreateTaskForm: FC<CreateTaskFormProps> = ({ templates, onSuccess }) => {
 												<SelectItem value={preset.ID} key={preset.ID}>
 													<div className="flex items-center gap-2">
 														{preset.Icon && (
-															<img
+															<ExternalImage
 																data-slot="preset-icon"
 																src={preset.Icon}
 																alt={preset.Name}


### PR DESCRIPTION
🤖 *This PR was authored by Coder Agent on behalf of Danielle Maywood.*

---

Fixes #22245

Preset icons in the task prompt selector used a plain `<img>` tag, which bypassed the theme-aware CSS filters provided by `ExternalImage`. Dark monochrome icons (like OpenAI/Codex) were invisible on dark backgrounds because no brightness/contrast filter was applied.
