### PR TITLE
fix(dogfood): chrome desktop icons with compatibility flags

### DIFF
--- a/dogfood/coder/Dockerfile
+++ b/dogfood/coder/Dockerfile
@@ -214,7 +214,11 @@ RUN sed -i 's|http://archive.ubuntu.com/ubuntu/|http://mirrors.edge.kernel.org/u
 # Install Google Chrome directly from Google. Ubuntu 22.04 ships
 # chromium-browser as a snap-only package, which does not work in
 # Docker containers.
-RUN wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
+# configure-chrome-flags.sh is automatically run after dpkg operations
+# by dogfood/coder/files/etc/apt/apt.conf.d/99-chrome-flags.
+COPY configure-chrome-flags.sh /usr/local/bin/configure-chrome-flags.sh
+RUN chmod a+x /usr/local/bin/configure-chrome-flags.sh && \
+	wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
 	apt-get install --yes ./google-chrome-stable_current_amd64.deb && \
 	rm google-chrome-stable_current_amd64.deb
 

--- a/dogfood/coder/configure-chrome-flags.sh
+++ b/dogfood/coder/configure-chrome-flags.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Adds launch flags to all Google Chrome .desktop files so that Chrome
+# works correctly in headless / GPU-less environments (e.g. Coder
+# workspaces running inside Docker containers).
+#
+# This script is idempotent.
+
+set -euo pipefail
+
+CHROME_FLAGS=(
+	--use-gl=angle
+	--use-angle=swiftshader
+	--disable-dev-shm-usage
+	--no-first-run
+	--no-default-browser-check
+	--disable-background-networking
+	--disable-sync
+	--start-maximized
+)
+
+FLAGS_STR="${CHROME_FLAGS[*]}"
+
+for desktop_file in /usr/share/applications/google-chrome*.desktop /usr/share/applications/com.google.Chrome*.desktop; do
+	[ -f "$desktop_file" ] || continue
+	# Skip if flags are already present.
+	if grep -q -- '--use-gl=angle' "$desktop_file"; then
+		continue
+	fi
+	# Insert flags after the binary path on every Exec= line.
+	sed -i "s|Exec=/usr/bin/google-chrome-stable|Exec=/usr/bin/google-chrome-stable ${FLAGS_STR}|" "$desktop_file"
+done

--- a/dogfood/coder/files/etc/apt/apt.conf.d/99-chrome-flags
+++ b/dogfood/coder/files/etc/apt/apt.conf.d/99-chrome-flags
@@ -1,0 +1,3 @@
+// Re-apply Chrome desktop-file flags after any package operation so
+// that a google-chrome-stable upgrade does not silently drop them.
+DPkg::Post-Invoke { "/usr/local/bin/configure-chrome-flags.sh 2>/dev/null || true"; };


### PR DESCRIPTION
Our dogfood image already included chrome. Since we run dogfood workspaces in Docker, chrome requires some compatibility flags to run properly. If you launch chrome without them, some webpages crash and fail to load.

The newest release of https://github.com/coder/portabledesktop added an icon dock. This PR edits the chrome `.desktop` files so when you open chrome from the dock it runs with the correct flags.

https://github.com/user-attachments/assets/7bf880e1-22a4-4faa-8f7f-394863c6b127

