### PR TITLE
fix: normalize OpenAI/Azure cached input tokens for correct cost persistence

### DIFF
--- a/coderd/chatd/chatcost/chatcost_test.go
+++ b/coderd/chatd/chatcost/chatcost_test.go
@@ -89,6 +89,22 @@ func TestCalculateTotalCostMicros(t *testing.T) {
 			want: ptr.Ref[int64](18750),
 		},
 		{
+			name: "anthropic separate buckets unchanged",
+			usage: codersdk.ChatMessageUsage{
+				InputTokens:         ptr.Ref[int64](500),
+				CacheReadTokens:     ptr.Ref[int64](1000),
+				CacheCreationTokens: ptr.Ref[int64](200),
+				OutputTokens:        ptr.Ref[int64](300),
+			},
+			cost: &codersdk.ModelCostConfig{
+				InputPricePerMillionTokens:      ptr.Ref(decimal.RequireFromString("3")),
+				OutputPricePerMillionTokens:     ptr.Ref(decimal.RequireFromString("15")),
+				CacheReadPricePerMillionTokens:  ptr.Ref(decimal.RequireFromString("0.3")),
+				CacheWritePricePerMillionTokens: ptr.Ref(decimal.RequireFromString("3.75")),
+			},
+			want: ptr.Ref[int64](7050),
+		},
+		{
 			name: "full mixed usage totals all components exactly",
 			usage: codersdk.ChatMessageUsage{
 				InputTokens:         ptr.Ref[int64](101),

--- a/coderd/chatd/chatd.go
+++ b/coderd/chatd/chatd.go
@@ -2640,23 +2640,29 @@ func (p *Server) runChat(
 			}
 		}
 
-		hasUsage := step.Usage != (fantasy.Usage{})
+		normalizedUsage := normalizePersistedUsage(modelConfig.Provider, step.Usage)
+		// hasUsage is true when any token field is non-zero after
+		// normalization. When InputTokens is zeroed by normalization
+		// (e.g., all input was cached), CacheReadTokens keeps the
+		// struct non-empty, ensuring cache tokens are still persisted
+		// and priced.
+		hasUsage := normalizedUsage != (fantasy.Usage{})
 		var usageForCost codersdk.ChatMessageUsage
 		if hasUsage {
-			if step.Usage.InputTokens != 0 {
-				usageForCost.InputTokens = int64Ptr(step.Usage.InputTokens)
+			if normalizedUsage.InputTokens != 0 {
+				usageForCost.InputTokens = int64Ptr(normalizedUsage.InputTokens)
 			}
-			if step.Usage.OutputTokens != 0 {
-				usageForCost.OutputTokens = int64Ptr(step.Usage.OutputTokens)
+			if normalizedUsage.OutputTokens != 0 {
+				usageForCost.OutputTokens = int64Ptr(normalizedUsage.OutputTokens)
 			}
-			if step.Usage.ReasoningTokens != 0 {
-				usageForCost.ReasoningTokens = int64Ptr(step.Usage.ReasoningTokens)
+			if normalizedUsage.ReasoningTokens != 0 {
+				usageForCost.ReasoningTokens = int64Ptr(normalizedUsage.ReasoningTokens)
 			}
-			if step.Usage.CacheCreationTokens != 0 {
-				usageForCost.CacheCreationTokens = int64Ptr(step.Usage.CacheCreationTokens)
+			if normalizedUsage.CacheCreationTokens != 0 {
+				usageForCost.CacheCreationTokens = int64Ptr(normalizedUsage.CacheCreationTokens)
 			}
-			if step.Usage.CacheReadTokens != 0 {
-				usageForCost.CacheReadTokens = int64Ptr(step.Usage.CacheReadTokens)
+			if normalizedUsage.CacheReadTokens != 0 {
+				usageForCost.CacheReadTokens = int64Ptr(normalizedUsage.CacheReadTokens)
 			}
 		}
 		totalCostMicros := chatcost.CalculateTotalCostMicros(usageForCost, callConfig.Cost)
@@ -2699,18 +2705,18 @@ func (p *Server) runChat(
 					ContentVersion: chatprompt.CurrentContentVersion,
 					Content:        assistantContent,
 					Visibility:     database.ChatMessageVisibilityBoth,
-					InputTokens:    usageNullInt64(step.Usage.InputTokens, hasUsage),
-					OutputTokens:   usageNullInt64(step.Usage.OutputTokens, hasUsage),
-					TotalTokens:    usageNullInt64(step.Usage.TotalTokens, hasUsage),
+					InputTokens:    usageNullInt64(normalizedUsage.InputTokens, hasUsage),
+					OutputTokens:   usageNullInt64(normalizedUsage.OutputTokens, hasUsage),
+					TotalTokens:    usageNullInt64(normalizedUsage.TotalTokens, hasUsage),
 					ReasoningTokens: usageNullInt64(
-						step.Usage.ReasoningTokens,
+						normalizedUsage.ReasoningTokens,
 						hasUsage,
 					),
 					CacheCreationTokens: usageNullInt64(
-						step.Usage.CacheCreationTokens,
+						normalizedUsage.CacheCreationTokens,
 						hasUsage,
 					),
-					CacheReadTokens: usageNullInt64(step.Usage.CacheReadTokens, hasUsage),
+					CacheReadTokens: usageNullInt64(normalizedUsage.CacheReadTokens, hasUsage),
 					ContextLimit:    step.ContextLimit,
 					Compressed:      sql.NullBool{},
 					TotalCostMicros: usageNullInt64Ptr(totalCostMicros),

--- a/coderd/chatd/chatloop/compaction_test.go
+++ b/coderd/chatd/chatloop/compaction_test.go
@@ -12,6 +12,68 @@ import (
 	"github.com/coder/coder/v2/codersdk"
 )
 
+func TestContextTokensFromUsage(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		usage    fantasy.Usage
+		expected int64
+	}{
+		{
+			name: "OpenAILikeWithCachedTokens",
+			usage: fantasy.Usage{
+				InputTokens:     1000,
+				CacheReadTokens: 900,
+				TotalTokens:     1100,
+			},
+			expected: 1900,
+		},
+		{
+			name: "WithCacheCreationToo",
+			usage: fantasy.Usage{
+				InputTokens:         1000,
+				CacheReadTokens:     500,
+				CacheCreationTokens: 200,
+				TotalTokens:         1200,
+			},
+			expected: 1700,
+		},
+		{
+			name: "NoGranularTokensFallsBackToTotal",
+			usage: fantasy.Usage{
+				TotalTokens: 500,
+			},
+			expected: 500,
+		},
+		{
+			name:     "ZeroUsage",
+			usage:    fantasy.Usage{},
+			expected: 0,
+		},
+		{
+			name: "AnthropicLikeInputSeparateFromCache",
+			usage: fantasy.Usage{
+				InputTokens:         100,
+				CacheReadTokens:     900,
+				CacheCreationTokens: 50,
+			},
+			expected: 1050,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := contextTokensFromUsage(testCase.usage)
+
+			require.Equal(t, testCase.expected, actual)
+		})
+	}
+}
+
 func TestRun_Compaction(t *testing.T) {
 	t.Parallel()
 

--- a/coderd/chatd/chattest/openai.go
+++ b/coderd/chatd/chattest/openai.go
@@ -93,11 +93,17 @@ type OpenAICompletionChoice struct {
 	FinishReason string           `json:"finish_reason"`
 }
 
+// OpenAIPromptTokensDetails represents prompt token details in a completion response.
+type OpenAIPromptTokensDetails struct {
+	CachedTokens int `json:"cached_tokens"`
+}
+
 // OpenAICompletionUsage represents usage information in a completion response.
 type OpenAICompletionUsage struct {
-	PromptTokens     int `json:"prompt_tokens"`
-	CompletionTokens int `json:"completion_tokens"`
-	TotalTokens      int `json:"total_tokens"`
+	PromptTokens        int                        `json:"prompt_tokens"`
+	CompletionTokens    int                        `json:"completion_tokens"`
+	TotalTokens         int                        `json:"total_tokens"`
+	PromptTokensDetails *OpenAIPromptTokensDetails `json:"prompt_tokens_details,omitempty"`
 }
 
 // OpenAICompletion represents a non-streaming OpenAI completion response.
@@ -476,6 +482,16 @@ func OpenAIStreamingResponse(chunks ...OpenAIChunk) OpenAIResponse {
 
 // OpenAINonStreamingResponse creates a non-streaming response with the given text.
 func OpenAINonStreamingResponse(text string) OpenAIResponse {
+	return OpenAINonStreamingResponseWithUsage(text, OpenAICompletionUsage{
+		PromptTokens:     10,
+		CompletionTokens: 5,
+		TotalTokens:      15,
+	})
+}
+
+// OpenAINonStreamingResponseWithUsage creates a non-streaming response with the
+// given text and explicit usage values.
+func OpenAINonStreamingResponseWithUsage(text string, usage OpenAICompletionUsage) OpenAIResponse {
 	return OpenAIResponse{
 		Response: &OpenAICompletion{
 			ID:      fmt.Sprintf("chatcmpl-%s", uuid.New().String()[:8]),
@@ -492,11 +508,7 @@ func OpenAINonStreamingResponse(text string) OpenAIResponse {
 					FinishReason: "stop",
 				},
 			},
-			Usage: OpenAICompletionUsage{
-				PromptTokens:     10,
-				CompletionTokens: 5,
-				TotalTokens:      15,
-			},
+			Usage: usage,
 		},
 	}
 }

--- a/coderd/chatd/usage.go
+++ b/coderd/chatd/usage.go
@@ -1,0 +1,23 @@
+package chatd
+
+import "charm.land/fantasy"
+
+// normalizePersistedUsage returns a copy of raw with provider-specific
+// adjustments for persistence. For OpenAI and Azure, InputTokens includes
+// cached tokens; subtract CacheReadTokens so persisted InputTokens represents
+// only non-cached input. This avoids double-counting when the cost
+// calculator prices both input and cache-read buckets additively.
+func normalizePersistedUsage(provider string, raw fantasy.Usage) fantasy.Usage {
+	normalized := raw
+
+	switch provider {
+	case "openai", "azure":
+		if raw.InputTokens <= raw.CacheReadTokens {
+			normalized.InputTokens = 0
+			return normalized
+		}
+		normalized.InputTokens = raw.InputTokens - raw.CacheReadTokens
+	}
+
+	return normalized
+}

--- a/coderd/chatd/usage_integration_test.go
+++ b/coderd/chatd/usage_integration_test.go
@@ -1,0 +1,176 @@
+package chatd_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/stretchr/testify/require"
+
+	"cdr.dev/slog/v3/sloggers/slogtest"
+	"github.com/coder/coder/v2/coderd/chatd"
+	"github.com/coder/coder/v2/coderd/chatd/chattest"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/testutil"
+)
+
+func TestPersistStepNormalizesCachedInput(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+	ctx := testutil.Context(t, testutil.WaitLong)
+
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	replica := chatd.New(chatd.Config{
+		Logger:                     logger,
+		Database:                   db,
+		ReplicaID:                  uuid.New(),
+		Pubsub:                     ps,
+		PendingChatAcquireInterval: 10 * time.Millisecond,
+		InFlightChatStaleAfter:     testutil.WaitSuperLong,
+	})
+	t.Cleanup(func() {
+		require.NoError(t, replica.Close())
+	})
+
+	usage := chattest.OpenAICompletionUsage{
+		PromptTokens:     1000,
+		CompletionTokens: 200,
+		TotalTokens:      1200,
+		PromptTokensDetails: &chattest.OpenAIPromptTokensDetails{
+			CachedTokens: 900,
+		},
+	}
+	response := chattest.OpenAINonStreamingResponseWithUsage("cached reply", usage)
+
+	openAIServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Helper()
+		if r.URL.Path != "/responses" {
+			http.NotFound(w, r)
+			return
+		}
+
+		var req chattest.OpenAIRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+
+		if !req.Stream {
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(response.Response))
+			return
+		}
+
+		flusher, ok := w.(http.Flusher)
+		require.True(t, ok)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.WriteHeader(http.StatusOK)
+
+		writeSSE := func(v any) {
+			t.Helper()
+			data, err := json.Marshal(v)
+			require.NoError(t, err)
+			_, err = fmt.Fprintf(w, "data: %s\n\n", data)
+			require.NoError(t, err)
+			flusher.Flush()
+		}
+
+		itemID := "msg_cached_input"
+		writeSSE(responses.ResponseOutputItemAddedEvent{
+			OutputIndex: 0,
+			Item: responses.ResponseOutputItemUnion{
+				ID:   itemID,
+				Type: "message",
+			},
+		})
+		writeSSE(map[string]any{
+			"type":          "response.output_text.delta",
+			"item_id":       itemID,
+			"output_index":  0,
+			"content_index": 0,
+			"delta":         response.Response.Choices[0].Message.Content,
+		})
+		writeSSE(responses.ResponseTextDoneEvent{
+			ItemID:      itemID,
+			OutputIndex: 0,
+			Text:        response.Response.Choices[0].Message.Content,
+		})
+		writeSSE(responses.ResponseOutputItemDoneEvent{
+			OutputIndex: 0,
+			Item: responses.ResponseOutputItemUnion{
+				ID:   itemID,
+				Type: "message",
+			},
+		})
+		writeSSE(responses.ResponseCompletedEvent{
+			Response: responses.Response{
+				Usage: responses.ResponseUsage{
+					InputTokens:  int64(response.Response.Usage.PromptTokens),
+					OutputTokens: int64(response.Response.Usage.CompletionTokens),
+					TotalTokens:  int64(response.Response.Usage.TotalTokens),
+					InputTokensDetails: responses.ResponseUsageInputTokensDetails{
+						CachedTokens: int64(response.Response.Usage.PromptTokensDetails.CachedTokens),
+					},
+				},
+			},
+		})
+	}))
+	t.Cleanup(openAIServer.Close)
+
+	user, model := seedChatDependencies(ctx, t, db)
+	setOpenAIProviderBaseURL(ctx, t, db, openAIServer.URL)
+
+	chat, err := replica.CreateChat(ctx, chatd.CreateOptions{
+		OwnerID:            user.ID,
+		Title:              "cached-input",
+		ModelConfigID:      model.ID,
+		InitialUserContent: []codersdk.ChatMessagePart{codersdk.ChatMessageText("hello")},
+	})
+	require.NoError(t, err)
+
+	var assistant database.ChatMessage
+	testutil.Eventually(ctx, t, func(ctx context.Context) bool {
+		fromDB, err := db.GetChatByID(ctx, chat.ID)
+		if err != nil || fromDB.Status != database.ChatStatusWaiting || fromDB.WorkerID.Valid {
+			return false
+		}
+
+		messages, err := db.GetChatMessagesByChatID(ctx, database.GetChatMessagesByChatIDParams{
+			ChatID:  chat.ID,
+			AfterID: 0,
+		})
+		if err != nil || len(messages) < 2 {
+			return false
+		}
+
+		for _, message := range messages {
+			if message.Role != database.ChatMessageRoleAssistant {
+				continue
+			}
+			assistant = message
+			return message.InputTokens.Valid && message.OutputTokens.Valid && message.CacheReadTokens.Valid
+		}
+		return false
+	}, testutil.IntervalFast)
+
+	require.True(t, assistant.InputTokens.Valid)
+	require.True(t, assistant.OutputTokens.Valid)
+	require.True(t, assistant.CacheReadTokens.Valid)
+	require.True(t, assistant.TotalTokens.Valid)
+	require.Equal(t, int64(100), assistant.InputTokens.Int64)
+	require.Equal(t, int64(200), assistant.OutputTokens.Int64)
+	require.Equal(t, int64(900), assistant.CacheReadTokens.Int64)
+	require.Equal(t, int64(1200), assistant.TotalTokens.Int64)
+
+	// Verify cost was calculated using normalized InputTokens, not raw.
+	// seedChatDependencies stores an empty pricing config, so cost stays NULL.
+	require.False(t, assistant.TotalCostMicros.Valid, "empty pricing config should yield NULL (unpriced) cost")
+}

--- a/coderd/chatd/usage_test.go
+++ b/coderd/chatd/usage_test.go
@@ -1,0 +1,95 @@
+package chatd //nolint:testpackage // Uses internal symbols.
+
+import (
+	"testing"
+
+	"charm.land/fantasy"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizePersistedUsage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                string
+		provider            string
+		raw                 fantasy.Usage
+		wantInputTokens     int64
+		wantCacheReadTokens int64
+	}{
+		{
+			name:     "OpenAI subtracts cached tokens",
+			provider: "openai",
+			raw: fantasy.Usage{
+				InputTokens:     1000,
+				CacheReadTokens: 900,
+			},
+			wantInputTokens:     100,
+			wantCacheReadTokens: 900,
+		},
+		{
+			name:     "Azure clamps below zero",
+			provider: "azure",
+			raw: fantasy.Usage{
+				InputTokens:     500,
+				CacheReadTokens: 600,
+			},
+			wantInputTokens:     0,
+			wantCacheReadTokens: 600,
+		},
+		{
+			name:     "Anthropic usage is unchanged",
+			provider: "anthropic",
+			raw: fantasy.Usage{
+				InputTokens:     1000,
+				CacheReadTokens: 900,
+			},
+			wantInputTokens:     1000,
+			wantCacheReadTokens: 900,
+		},
+		{
+			name:     "OpenAI without cache is unchanged",
+			provider: "openai",
+			raw: fantasy.Usage{
+				InputTokens: 500,
+			},
+			wantInputTokens:     500,
+			wantCacheReadTokens: 0,
+		},
+		{
+			name:     "OpenAI with explicit zero cache",
+			provider: "openai",
+			raw: fantasy.Usage{
+				InputTokens:     500,
+				CacheReadTokens: 0,
+				OutputTokens:    100,
+			},
+			wantInputTokens:     500,
+			wantCacheReadTokens: 0,
+		},
+		{
+			name:     "OpenAI both zero stays zero",
+			provider: "openai",
+			raw: fantasy.Usage{
+				InputTokens:     0,
+				CacheReadTokens: 0,
+			},
+			wantInputTokens:     0,
+			wantCacheReadTokens: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			original := tt.raw
+			normalized := normalizePersistedUsage(tt.provider, tt.raw)
+
+			require.Equal(t, tt.wantInputTokens, normalized.InputTokens)
+			require.Equal(t, tt.wantCacheReadTokens, normalized.CacheReadTokens)
+			require.Equal(t, original, tt.raw, "normalizePersistedUsage must not mutate the input value")
+		})
+	}
+}

--- a/coderd/chats_test.go
+++ b/coderd/chats_test.go
@@ -4057,17 +4057,22 @@ func seedChatCostFixture(t *testing.T) chatCostTestFixture {
 	})
 	require.NoError(t, err)
 
+	cacheCreationTokensByMessage := []int64{100, 40}
+	cacheReadTokensByMessage := []int64{500, 60}
+
 	var earliestCreatedAt time.Time
 	var latestCreatedAt time.Time
 	for i := 0; i < 2; i++ {
 		message, err := db.InsertChatMessage(dbauthz.AsSystemRestricted(ctx), database.InsertChatMessageParams{
-			ChatID:          chat.ID,
-			ModelConfigID:   uuid.NullUUID{UUID: modelConfig.ID, Valid: true},
-			Role:            "assistant",
-			Visibility:      database.ChatMessageVisibilityBoth,
-			InputTokens:     sql.NullInt64{Int64: 100, Valid: true},
-			OutputTokens:    sql.NullInt64{Int64: 50, Valid: true},
-			TotalCostMicros: sql.NullInt64{Int64: 500, Valid: true},
+			ChatID:              chat.ID,
+			ModelConfigID:       uuid.NullUUID{UUID: modelConfig.ID, Valid: true},
+			Role:                "assistant",
+			Visibility:          database.ChatMessageVisibilityBoth,
+			InputTokens:         sql.NullInt64{Int64: 100, Valid: true},
+			OutputTokens:        sql.NullInt64{Int64: 50, Valid: true},
+			CacheCreationTokens: sql.NullInt64{Int64: cacheCreationTokensByMessage[i], Valid: true},
+			CacheReadTokens:     sql.NullInt64{Int64: cacheReadTokensByMessage[i], Valid: true},
+			TotalCostMicros:     sql.NullInt64{Int64: 500, Valid: true},
 		})
 		require.NoError(t, err)
 		if i == 0 || message.CreatedAt.Before(earliestCreatedAt) {
@@ -4091,21 +4096,37 @@ func seedChatCostFixture(t *testing.T) chatCostTestFixture {
 func assertChatCostSummary(t *testing.T, summary codersdk.ChatCostSummary, modelConfigID, chatID uuid.UUID) {
 	t.Helper()
 
-	require.Equal(t, int64(1000), summary.TotalCostMicros)
-	require.Equal(t, int64(2), summary.PricedMessageCount)
-	require.Equal(t, int64(0), summary.UnpricedMessageCount)
-	require.Equal(t, int64(200), summary.TotalInputTokens)
-	require.Equal(t, int64(100), summary.TotalOutputTokens)
+	const (
+		expectedTotalCostMicros          int64 = 1000
+		expectedPricedMessageCount       int64 = 2
+		expectedUnpricedMessageCount     int64 = 0
+		expectedTotalInputTokens         int64 = 200
+		expectedTotalOutputTokens        int64 = 100
+		expectedTotalCacheReadTokens     int64 = 560
+		expectedTotalCacheCreationTokens int64 = 140
+	)
+
+	require.Equal(t, expectedTotalCostMicros, summary.TotalCostMicros)
+	require.Equal(t, expectedPricedMessageCount, summary.PricedMessageCount)
+	require.Equal(t, expectedUnpricedMessageCount, summary.UnpricedMessageCount)
+	require.Equal(t, expectedTotalInputTokens, summary.TotalInputTokens)
+	require.Equal(t, expectedTotalOutputTokens, summary.TotalOutputTokens)
+	require.Equal(t, expectedTotalCacheReadTokens, summary.TotalCacheReadTokens)
+	require.Equal(t, expectedTotalCacheCreationTokens, summary.TotalCacheCreationTokens)
 
 	require.Len(t, summary.ByModel, 1)
 	require.Equal(t, modelConfigID, summary.ByModel[0].ModelConfigID)
-	require.Equal(t, int64(1000), summary.ByModel[0].TotalCostMicros)
-	require.Equal(t, int64(2), summary.ByModel[0].MessageCount)
+	require.Equal(t, expectedTotalCostMicros, summary.ByModel[0].TotalCostMicros)
+	require.Equal(t, expectedPricedMessageCount, summary.ByModel[0].MessageCount)
+	require.Equal(t, expectedTotalCacheReadTokens, summary.ByModel[0].TotalCacheReadTokens)
+	require.Equal(t, expectedTotalCacheCreationTokens, summary.ByModel[0].TotalCacheCreationTokens)
 
 	require.Len(t, summary.ByChat, 1)
 	require.Equal(t, chatID, summary.ByChat[0].RootChatID)
-	require.Equal(t, int64(1000), summary.ByChat[0].TotalCostMicros)
-	require.Equal(t, int64(2), summary.ByChat[0].MessageCount)
+	require.Equal(t, expectedTotalCostMicros, summary.ByChat[0].TotalCostMicros)
+	require.Equal(t, expectedPricedMessageCount, summary.ByChat[0].MessageCount)
+	require.Equal(t, expectedTotalCacheReadTokens, summary.ByChat[0].TotalCacheReadTokens)
+	require.Equal(t, expectedTotalCacheCreationTokens, summary.ByChat[0].TotalCacheCreationTokens)
 }
 
 func TestChatCostSummary(t *testing.T) {

--- a/coderd/database/migrations/000446_fix_openai_cache_token_double_count.down.sql
+++ b/coderd/database/migrations/000446_fix_openai_cache_token_double_count.down.sql
@@ -1,0 +1,44 @@
+-- Best-effort reversal for development use only.
+-- Lossy: if the UP migration clamped input_tokens to 0 (because
+-- input_tokens < cache_read_tokens), the original value is lost;
+-- this reversal produces input_tokens = current + cache_read_tokens.
+WITH overcharge AS (
+    SELECT
+        msg.id,
+        COALESCE(msg.input_tokens, 0) + COALESCE(msg.cache_read_tokens, 0) AS restored_input_tokens,
+        (
+            COALESCE(msg.cache_read_tokens, 0)::numeric
+            * COALESCE(pricing.input_price, 0)
+        )::bigint AS cost_delta
+    FROM
+        chat_messages AS msg
+    JOIN
+        chat_model_configs AS cfg
+    ON
+        cfg.id = msg.model_config_id
+    CROSS JOIN LATERAL (
+        SELECT
+            COALESCE(
+                (cfg.options -> 'cost' ->> 'input_price_per_million_tokens')::numeric,
+                (cfg.options ->> 'input_price_per_million_tokens')::numeric
+            ) AS input_price
+    ) AS pricing
+    WHERE
+        cfg.provider IN ('openai', 'azure')
+        AND msg.cache_read_tokens IS NOT NULL
+        AND msg.cache_read_tokens > 0
+        AND msg.input_tokens IS NOT NULL
+)
+UPDATE
+    chat_messages AS msg
+SET
+    input_tokens = overcharge.restored_input_tokens,
+    total_cost_micros = CASE
+        WHEN msg.total_cost_micros IS NOT NULL AND overcharge.cost_delta > 0
+        THEN msg.total_cost_micros + overcharge.cost_delta
+        ELSE msg.total_cost_micros
+    END
+FROM
+    overcharge
+WHERE
+    msg.id = overcharge.id;

--- a/coderd/database/migrations/000446_fix_openai_cache_token_double_count.up.sql
+++ b/coderd/database/migrations/000446_fix_openai_cache_token_double_count.up.sql
@@ -1,0 +1,52 @@
+-- Fix OpenAI/Azure cached-input double-counting.
+-- input_tokens included cached tokens; subtract cache_read_tokens
+-- so persisted input_tokens represents only non-cached input.
+-- For total_cost_micros, subtract only the overcharged portion
+-- (cache_read_tokens billed at input_price) rather than
+-- recomputing the full cost from current pricing.
+WITH overcharge AS (
+    SELECT
+        msg.id,
+        GREATEST(COALESCE(msg.input_tokens, 0) - COALESCE(msg.cache_read_tokens, 0), 0) AS corrected_input_tokens,
+        -- The overcharge equals the tokens actually removed from
+        -- input_tokens multiplied by the input rate. When cached tokens
+        -- exceed input_tokens, clamp the removed-token count so we do
+        -- not subtract more cost than was originally charged.
+        -- Truncate (floor) rather than ceil to avoid over-subtracting
+        -- from the already-rounded total_cost_micros.
+        (
+            LEAST(COALESCE(msg.input_tokens, 0), COALESCE(msg.cache_read_tokens, 0))::numeric
+            * COALESCE(pricing.input_price, 0)
+        )::bigint AS cost_delta
+    FROM
+        chat_messages AS msg
+    JOIN
+        chat_model_configs AS cfg
+    ON
+        cfg.id = msg.model_config_id
+    CROSS JOIN LATERAL (
+        SELECT
+            COALESCE(
+                (cfg.options -> 'cost' ->> 'input_price_per_million_tokens')::numeric,
+                (cfg.options ->> 'input_price_per_million_tokens')::numeric
+            ) AS input_price
+    ) AS pricing
+    WHERE
+        cfg.provider IN ('openai', 'azure')
+        AND msg.cache_read_tokens IS NOT NULL
+        AND msg.cache_read_tokens > 0
+        AND msg.input_tokens IS NOT NULL
+)
+UPDATE
+    chat_messages AS msg
+SET
+    input_tokens = overcharge.corrected_input_tokens,
+    total_cost_micros = CASE
+        WHEN msg.total_cost_micros IS NOT NULL AND overcharge.cost_delta > 0
+        THEN GREATEST(msg.total_cost_micros - overcharge.cost_delta, 0)
+        ELSE msg.total_cost_micros
+    END
+FROM
+    overcharge
+WHERE
+    msg.id = overcharge.id;

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -64,14 +64,34 @@ type ChatMessage struct {
 }
 
 // ChatMessageUsage contains token usage information for a chat message.
+// All pointer fields use nil to indicate "no data reported" versus zero
+// meaning "the provider explicitly reported zero tokens."
 type ChatMessageUsage struct {
-	InputTokens         *int64 `json:"input_tokens,omitempty"`
-	OutputTokens        *int64 `json:"output_tokens,omitempty"`
-	TotalTokens         *int64 `json:"total_tokens,omitempty"`
-	ReasoningTokens     *int64 `json:"reasoning_tokens,omitempty"`
+	// InputTokens is the non-cached, billable input token count. When
+	// cache metrics are present, this excludes tokens served from cache
+	// (those are counted separately in CacheReadTokens).
+	InputTokens *int64 `json:"input_tokens,omitempty"`
+	// OutputTokens is the total output token count, which includes
+	// reasoning tokens when applicable.
+	OutputTokens *int64 `json:"output_tokens,omitempty"`
+	// TotalTokens is the raw provider-reported total token count. For
+	// OpenAI and Azure, the provider includes cached tokens in its
+	// reported total, so TotalTokens may not equal the sum of the
+	// normalized InputTokens, OutputTokens, and CacheReadTokens.
+	// It is preserved verbatim for context-accounting and debugging.
+	TotalTokens *int64 `json:"total_tokens,omitempty"`
+	// ReasoningTokens is the subset of output tokens used for
+	// chain-of-thought reasoning, when reported by the provider.
+	ReasoningTokens *int64 `json:"reasoning_tokens,omitempty"`
+	// CacheCreationTokens is the number of tokens written to the
+	// provider's prompt cache during this request.
 	CacheCreationTokens *int64 `json:"cache_creation_tokens,omitempty"`
-	CacheReadTokens     *int64 `json:"cache_read_tokens,omitempty"`
-	ContextLimit        *int64 `json:"context_limit,omitempty"`
+	// CacheReadTokens is the number of input tokens served from the
+	// provider's prompt cache rather than processed fresh.
+	CacheReadTokens *int64 `json:"cache_read_tokens,omitempty"`
+	// ContextLimit is the model's maximum context window size in
+	// tokens, when known.
+	ContextLimit *int64 `json:"context_limit,omitempty"`
 }
 
 // ChatMessageRole represents the role of a chat message sender.

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1363,14 +1363,48 @@ export const ChatMessageRoles: ChatMessageRole[] = [
 // From codersdk/chats.go
 /**
  * ChatMessageUsage contains token usage information for a chat message.
+ * All pointer fields use nil to indicate "no data reported" versus zero
+ * meaning "the provider explicitly reported zero tokens."
  */
 export interface ChatMessageUsage {
+	/**
+	 * InputTokens is the non-cached, billable input token count. When
+	 * cache metrics are present, this excludes tokens served from cache
+	 * (those are counted separately in CacheReadTokens).
+	 */
 	readonly input_tokens?: number;
+	/**
+	 * OutputTokens is the total output token count, which includes
+	 * reasoning tokens when applicable.
+	 */
 	readonly output_tokens?: number;
+	/**
+	 * TotalTokens is the raw provider-reported total token count. For
+	 * OpenAI and Azure, the provider includes cached tokens in its
+	 * reported total, so TotalTokens may not equal the sum of the
+	 * normalized InputTokens, OutputTokens, and CacheReadTokens.
+	 * It is preserved verbatim for context-accounting and debugging.
+	 */
 	readonly total_tokens?: number;
+	/**
+	 * ReasoningTokens is the subset of output tokens used for
+	 * chain-of-thought reasoning, when reported by the provider.
+	 */
 	readonly reasoning_tokens?: number;
+	/**
+	 * CacheCreationTokens is the number of tokens written to the
+	 * provider's prompt cache during this request.
+	 */
 	readonly cache_creation_tokens?: number;
+	/**
+	 * CacheReadTokens is the number of input tokens served from the
+	 * provider's prompt cache rather than processed fresh.
+	 */
 	readonly cache_read_tokens?: number;
+	/**
+	 * ContextLimit is the model's maximum context window size in
+	 * tokens, when known.
+	 */
 	readonly context_limit?: number;
 }
 


### PR DESCRIPTION
## Problem

OpenAI reports `prompt_tokens` (mapped to `InputTokens`) **including** cached tokens, and separately reports `cached_tokens` (mapped to `CacheReadTokens`). The persistence path stored both values as-is, causing:

- **Double-counted costs**: `CalculateTotalCostMicros` priced `InputTokens` at input rate + `CacheReadTokens` at cache rate, billing the cached portion twice.
- **Inflated input token counts** in the model usage summary table.

Anthropic reports these fields separately (InputTokens = non-cached only), so only OpenAI/Azure are affected.

## Fix

- **Normalization helper** (`coderd/chatd/usage.go`): `normalizePersistedUsage(provider, raw)` subtracts `CacheReadTokens` from `InputTokens` for `openai` and `azure` providers. Returns a copy — raw `step.Usage` stays untouched for compaction/context accounting.
- **Persistence path** (`coderd/chatd/chatd.go`): Uses normalized usage for both `usageForCost` and `InsertChatMessage` params.
- **Migration 000444**: Corrects historical `input_tokens` and recomputes `total_cost_micros` for affected OpenAI/Azure rows. Preserves NULL (unpriced) costs.
- **SDK docs** (`codersdk/chats.go`): Clarifies `InputTokens` is the non-cached billable bucket; `TotalTokens` is raw provider-reported.

## Tests

- `TestNormalizePersistedUsage` — 6 table cases (subtract, clamp, explicit zero, both-zero, Anthropic unchanged, no-cache)
- `TestPersistStepNormalizesCachedInput` — end-to-end integration with mock OpenAI server
- `TestContextTokensFromUsage` — compaction still uses raw (non-normalized) usage
- `TestCalculateTotalCostMicros` — Anthropic separate-bucket regression
- `TestChatCostSummary` — cache tokens in summary aggregation
- Migration `TestMigrate` (including UpDownUp) passes