### PR TITLE
fix: balance visual padding on agent chat sidebar items

### DIFF
--- a/site/src/pages/AgentsPage/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.tsx
@@ -412,7 +412,7 @@ const ChatTreeNode = memo<ChatTreeNodeProps>(({ chat, isChildNode }) => {
 			<div
 				data-testid={`agents-tree-node-${chat.id}`}
 				className={cn(
-					"group relative flex min-w-0 items-start gap-1.5 rounded-md px-1 text-content-secondary",
+					"group relative flex min-w-0 items-start gap-1.5 rounded-md pl-1 pr-1.5 text-content-secondary",
 					"transition-none [@media(hover:hover)]:hover:bg-surface-tertiary/50 [@media(hover:hover)]:hover:text-content-primary has-[[data-state=open]]:bg-surface-tertiary",
 					"has-[[aria-current=page]]:bg-surface-quaternary/25 has-[[aria-current=page]]:text-content-primary [@media(hover:hover)]:has-[[aria-current=page]]:hover:bg-surface-quaternary/50",
 					isChildNode &&


### PR DESCRIPTION
🤖 *This PR was created by Coder Agent on behalf of Danielle Maywood.*

## Problem

The agent chat list items in the left sidebar had visually uneven horizontal padding. The left side appeared to have more padding than the right.

## Root Cause

The status icon (`h-3.5 w-3.5` = 14px) is centered inside a larger container (`h-5 w-5` = 20px), creating 3px of internal empty space on each side. Combined with the row's symmetric `px-1` (4px), the left visual padding was **7px** (4 + 3) while the right was only **4px**.

## Fix

Replace symmetric `px-1` with `pl-1 pr-1.5`, increasing the right padding from 4px to 6px to closely match the 7px of visual left padding. The 1px remaining difference is imperceptible.

- **Left visual**: 4px (`pl-1`) + 3px (icon centering) = **7px**
- **Right visual**: 6px (`pr-1.5`) ≈ **7px**

Single-line change, no behavioral differences.