### PR TITLE
feat(site): add scroll-to-bottom button to agent chat

### DIFF
--- a/site/src/pages/AgentsPage/AgentDetailView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentDetailView.stories.tsx
@@ -455,6 +455,19 @@ export const ScrollToBottomButton: Story = {
 	args: {
 		store: buildStoreWithMessages(buildLongConversation(40)),
 	},
+	decorators: [
+		(Story) => (
+			<div
+				style={{
+					height: "600px",
+					display: "flex",
+					flexDirection: "column",
+				}}
+			>
+				<Story />
+			</div>
+		),
+	],
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 
@@ -463,21 +476,36 @@ export const ScrollToBottomButton: Story = {
 		expect(button).toHaveClass("opacity-0");
 
 		// Find the scroll container (the flex-col-reverse element).
-		const scrollContainer = button.parentElement?.querySelector(
+		const scrollContainer = canvasElement.querySelector(
 			"[class*='flex-col-reverse']",
 		) as HTMLElement;
 		expect(scrollContainer).toBeTruthy();
 
-		// Scroll up — in flex-col-reverse, negative scrollTop = scrolled up.
-		scrollContainer.scrollTop = -800;
-		scrollContainer.dispatchEvent(new Event("scroll", { bubbles: false }));
+		// Wait for content to render and create overflow.
+		await waitFor(() => {
+			expect(scrollContainer.scrollHeight).toBeGreaterThan(
+				scrollContainer.clientHeight,
+			);
+		});
+
+		// Scroll up. In flex-col-reverse containers, Chrome uses
+		// negative scrollTop values when scrolled away from the
+		// bottom. Try negative first, fall back to positive for
+		// other engines.
+		const maxScroll =
+			scrollContainer.scrollHeight - scrollContainer.clientHeight;
+		scrollContainer.scrollTop = -maxScroll;
+		if (Math.abs(scrollContainer.scrollTop) < 100) {
+			scrollContainer.scrollTop = maxScroll;
+		}
+		scrollContainer.dispatchEvent(new Event("scroll"));
 
 		// Button should become visible.
 		await waitFor(() => {
 			expect(button).toHaveClass("opacity-100");
 		});
 
-		// Click the button.
+		// Click the button to scroll back to the bottom.
 		await userEvent.click(button);
 
 		// Button should fade out once we're back at the bottom.

--- a/site/src/pages/AgentsPage/AgentDetailView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentDetailView.stories.tsx
@@ -5,7 +5,7 @@ import { API } from "api/api";
 import type * as TypesGen from "api/typesGenerated";
 import type { ChatDiffStatus, ChatMessagePart } from "api/typesGenerated";
 import type { ModelSelectorOption } from "components/ai-elements";
-import { fn, spyOn } from "storybook/test";
+import { expect, fn, spyOn, userEvent, waitFor, within } from "storybook/test";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
 import { createChatStore } from "./AgentDetail/ChatContext";
 import {
@@ -427,4 +427,62 @@ export const NotFoundSidebarCollapsed: Story = {
 			onToggleSidebarCollapsed={fn()}
 		/>
 	),
+};
+
+// ---------------------------------------------------------------------------
+// Scroll-to-bottom button stories
+// ---------------------------------------------------------------------------
+
+/** Generate a long conversation so the scroll container overflows. */
+const buildLongConversation = (count: number): TypesGen.ChatMessage[] => {
+	const messages: TypesGen.ChatMessage[] = [];
+	for (let i = 1; i <= count; i++) {
+		const role: TypesGen.ChatMessageRole = i % 2 === 1 ? "user" : "assistant";
+		const text =
+			role === "user"
+				? `Question ${Math.ceil(i / 2)}: Can you explain concept ${Math.ceil(i / 2)} in detail?`
+				: `Sure! Here is a detailed explanation of concept ${Math.floor(i / 2)}. `.repeat(
+						4,
+					);
+		messages.push(buildMessage(i, role, text));
+	}
+	return messages;
+};
+
+/** Scroll-to-bottom button appears after scrolling up in a long
+ *  conversation, and clicking it returns to the bottom. */
+export const ScrollToBottomButton: Story = {
+	args: {
+		store: buildStoreWithMessages(buildLongConversation(40)),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		// The button should be hidden initially (user starts at bottom).
+		const button = canvas.getByRole("button", { name: "Scroll to bottom" });
+		expect(button).toHaveClass("opacity-0");
+
+		// Find the scroll container (the flex-col-reverse element).
+		const scrollContainer = button.parentElement?.querySelector(
+			"[class*='flex-col-reverse']",
+		) as HTMLElement;
+		expect(scrollContainer).toBeTruthy();
+
+		// Scroll up — in flex-col-reverse, negative scrollTop = scrolled up.
+		scrollContainer.scrollTop = -800;
+		scrollContainer.dispatchEvent(new Event("scroll", { bubbles: false }));
+
+		// Button should become visible.
+		await waitFor(() => {
+			expect(button).toHaveClass("opacity-100");
+		});
+
+		// Click the button.
+		await userEvent.click(button);
+
+		// Button should fade out once we're back at the bottom.
+		await waitFor(() => {
+			expect(button).toHaveClass("opacity-0");
+		});
+	},
 };

--- a/site/src/pages/AgentsPage/AgentDetailView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentDetailView.stories.tsx
@@ -471,15 +471,14 @@ export const ScrollToBottomButton: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 
-		// The button should be hidden initially (user starts at bottom).
-		const button = canvas.getByRole("button", { name: "Scroll to bottom" });
-		expect(button).toHaveClass("opacity-0");
+		// The button should be hidden initially — it has aria-hidden="true"
+		// when not shown, so queryByRole correctly returns null.
+		expect(
+			canvas.queryByRole("button", { name: "Scroll to bottom" }),
+		).toBeNull();
 
-		// Find the scroll container (the flex-col-reverse element).
-		const scrollContainer = canvasElement.querySelector(
-			"[class*='flex-col-reverse']",
-		) as HTMLElement;
-		expect(scrollContainer).toBeTruthy();
+		// Find the scroll container via data-testid.
+		const scrollContainer = canvas.getByTestId("scroll-container");
 
 		// Wait for content to render and create overflow.
 		await waitFor(() => {
@@ -500,17 +499,22 @@ export const ScrollToBottomButton: Story = {
 		}
 		scrollContainer.dispatchEvent(new Event("scroll"));
 
-		// Button should become visible.
-		await waitFor(() => {
-			expect(button).toHaveClass("opacity-100");
+		// Button should become visible (enters the accessibility tree).
+		const button = await waitFor(() => {
+			const btn = canvas.getByRole("button", { name: "Scroll to bottom" });
+			expect(btn).toBeVisible();
+			return btn;
 		});
 
 		// Click the button to scroll back to the bottom.
 		await userEvent.click(button);
 
-		// Button should fade out once we're back at the bottom.
+		// Button should be hidden again. The click handler immediately
+		// hides it, so this doesn't depend on smooth scroll completing.
 		await waitFor(() => {
-			expect(button).toHaveClass("opacity-0");
+			expect(
+				canvas.queryByRole("button", { name: "Scroll to bottom" }),
+			).toBeNull();
 		});
 	},
 };

--- a/site/src/pages/AgentsPage/AgentDetailView.tsx
+++ b/site/src/pages/AgentsPage/AgentDetailView.tsx
@@ -581,48 +581,72 @@ const ScrollAnchoredContainer: FC<{
 	// In a flex-col-reverse container, scrollTop = 0 means the user
 	// is at the bottom (most recent content). Scrolling up to see
 	// older messages makes scrollTop negative.
+	//
+	// Throttled to once per animation frame so we avoid calling
+	// setState on every high-frequency scroll event.
 	useEffect(() => {
 		const container = scrollContainerRef.current;
 		if (!container) return;
 
+		let rafId: number | null = null;
+
 		const handleScroll = () => {
-			const isAtBottom = Math.abs(container.scrollTop) < SCROLL_THRESHOLD;
-			setShowScrollToBottom(!isAtBottom);
+			if (rafId !== null) return;
+			rafId = requestAnimationFrame(() => {
+				const isAtBottom = Math.abs(container.scrollTop) < SCROLL_THRESHOLD;
+				setShowScrollToBottom(!isAtBottom);
+				rafId = null;
+			});
 		};
 
 		container.addEventListener("scroll", handleScroll, { passive: true });
-		return () => container.removeEventListener("scroll", handleScroll);
+		return () => {
+			container.removeEventListener("scroll", handleScroll);
+			if (rafId !== null) {
+				cancelAnimationFrame(rafId);
+			}
+		};
 	}, [scrollContainerRef]);
 
 	const handleScrollToBottom = useCallback(() => {
 		const container = scrollContainerRef.current;
 		if (!container) return;
 		container.scrollTo({ top: 0, behavior: "smooth" });
+		// Hide immediately so the button doesn't linger while the
+		// smooth scroll animates.  If the user interrupts the scroll
+		// before it reaches the bottom, the scroll handler will
+		// re-show the button.
+		setShowScrollToBottom(false);
 	}, [scrollContainerRef]);
 
 	return (
 		<div className="relative flex min-h-0 flex-1 flex-col">
 			<div
 				ref={scrollContainerRef}
+				data-testid="scroll-container"
 				className="flex min-h-0 flex-1 flex-col-reverse overflow-y-auto [overflow-anchor:none] [scrollbar-gutter:stable] [scrollbar-width:thin] [scrollbar-color:hsl(var(--surface-quaternary))_transparent]"
 			>
 				{children}
 				{hasMoreMessages && <div ref={sentinelRef} className="h-px shrink-0" />}
 			</div>
-			<Button
-				variant="outline"
-				size="icon"
-				className={cn(
-					"absolute bottom-4 left-1/2 z-10 -translate-x-1/2 rounded-full bg-surface-primary shadow-md transition-all duration-200",
-					showScrollToBottom
-						? "translate-y-0 opacity-100"
-						: "pointer-events-none translate-y-2 opacity-0",
-				)}
-				onClick={handleScrollToBottom}
-				aria-label="Scroll to bottom"
-			>
-				<ArrowDownIcon />
-			</Button>
+			<div className="pointer-events-none absolute inset-x-0 bottom-2 z-10 flex justify-center overflow-y-auto py-2 [scrollbar-gutter:stable] [scrollbar-width:thin]">
+				<Button
+					variant="outline"
+					size="icon"
+					className={cn(
+						"rounded-full bg-surface-primary shadow-md transition-all duration-200",
+						showScrollToBottom
+							? "pointer-events-auto translate-y-0 opacity-100"
+							: "translate-y-2 opacity-0",
+					)}
+					onClick={handleScrollToBottom}
+					aria-label="Scroll to bottom"
+					aria-hidden={!showScrollToBottom || undefined}
+					tabIndex={showScrollToBottom ? undefined : -1}
+				>
+					<ArrowDownIcon />
+				</Button>
+			</div>
 		</div>
 	);
 };

--- a/site/src/pages/AgentsPage/AgentDetailView.tsx
+++ b/site/src/pages/AgentsPage/AgentDetailView.tsx
@@ -512,6 +512,7 @@ export const AgentDetailNotFoundView: FC<AgentDetailNotFoundViewProps> = ({
  * containers.
  */
 const SCROLL_THRESHOLD = 100;
+const SCROLL_DEBOUNCE_MS = 150;
 
 const ScrollAnchoredContainer: FC<{
 	scrollContainerRef: RefObject<HTMLDivElement | null>;
@@ -581,17 +582,36 @@ const ScrollAnchoredContainer: FC<{
 	// In a flex-col-reverse container, scrollTop = 0 means the user
 	// is at the bottom (most recent content). Scrolling up to see
 	// older messages makes scrollTop negative.
+	//
+	// We debounce the check so momentum scrolling and iOS
+	// rubber-band overscroll can settle before we decide whether
+	// to show the button. Without this, the bounce-back from an
+	// iOS overscroll can look like an upward scroll and briefly
+	// flash the button.
 	useEffect(() => {
 		const container = scrollContainerRef.current;
 		if (!container) return;
 
+		let timer: ReturnType<typeof setTimeout> | null = null;
+
 		const handleScroll = () => {
-			const isAtBottom = Math.abs(container.scrollTop) < SCROLL_THRESHOLD;
-			setShowScrollToBottom(!isAtBottom);
+			if (timer !== null) {
+				clearTimeout(timer);
+			}
+			timer = setTimeout(() => {
+				const isAtBottom = Math.abs(container.scrollTop) < SCROLL_THRESHOLD;
+				setShowScrollToBottom(!isAtBottom);
+				timer = null;
+			}, SCROLL_DEBOUNCE_MS);
 		};
 
 		container.addEventListener("scroll", handleScroll, { passive: true });
-		return () => container.removeEventListener("scroll", handleScroll);
+		return () => {
+			container.removeEventListener("scroll", handleScroll);
+			if (timer !== null) {
+				clearTimeout(timer);
+			}
+		};
 	}, [scrollContainerRef]);
 
 	const handleScrollToBottom = useCallback(() => {

--- a/site/src/pages/AgentsPage/AgentDetailView.tsx
+++ b/site/src/pages/AgentsPage/AgentDetailView.tsx
@@ -1,8 +1,16 @@
 import type * as TypesGen from "api/typesGenerated";
 import type { ChatDiffStatus, ChatMessagePart } from "api/typesGenerated";
 import type { ModelSelectorOption } from "components/ai-elements";
-import { ArchiveIcon } from "lucide-react";
-import { type FC, type RefObject, useEffect, useRef, useState } from "react";
+import { Button } from "components/Button/Button";
+import { ArchiveIcon, ArrowDownIcon } from "lucide-react";
+import {
+	type FC,
+	type RefObject,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
 import type { UrlTransform } from "streamdown";
 import { cn } from "utils/cn";
 import { pageTitle } from "utils/page";
@@ -503,6 +511,8 @@ export const AgentDetailNotFoundView: FC<AgentDetailNotFoundViewProps> = ({
  * renders — CSS scroll anchoring is unreliable in flex-col-reverse
  * containers.
  */
+const SCROLL_THRESHOLD = 100;
+
 const ScrollAnchoredContainer: FC<{
 	scrollContainerRef: RefObject<HTMLDivElement | null>;
 	isFetchingMoreMessages: boolean;
@@ -522,6 +532,7 @@ const ScrollAnchoredContainer: FC<{
 	isFetchingRef.current = isFetchingMoreMessages;
 	const onFetchRef = useRef(onFetchMoreMessages);
 	onFetchRef.current = onFetchMoreMessages;
+	const [showScrollToBottom, setShowScrollToBottom] = useState(false);
 
 	// Sentinel observer — triggers loading older messages.
 	// All changing values are read from refs so the observer
@@ -566,14 +577,53 @@ const ScrollAnchoredContainer: FC<{
 		observer.observe(sentinel);
 	}, [isFetchingMoreMessages]);
 
+	// Track scroll position to show/hide the scroll-to-bottom button.
+	// In a flex-col-reverse container, scrollTop = 0 means the user
+	// is at the bottom (most recent content). Scrolling up to see
+	// older messages makes scrollTop negative.
+	useEffect(() => {
+		const container = scrollContainerRef.current;
+		if (!container) return;
+
+		const handleScroll = () => {
+			const isAtBottom = Math.abs(container.scrollTop) < SCROLL_THRESHOLD;
+			setShowScrollToBottom(!isAtBottom);
+		};
+
+		container.addEventListener("scroll", handleScroll, { passive: true });
+		return () => container.removeEventListener("scroll", handleScroll);
+	}, [scrollContainerRef]);
+
+	const handleScrollToBottom = useCallback(() => {
+		const container = scrollContainerRef.current;
+		if (!container) return;
+		container.scrollTo({ top: 0, behavior: "smooth" });
+	}, [scrollContainerRef]);
+
 	return (
-		<div
-			ref={scrollContainerRef}
-			className="flex min-h-0 flex-1 flex-col-reverse overflow-y-auto [scrollbar-gutter:stable] [scrollbar-width:thin] [scrollbar-color:hsl(var(--surface-quaternary))_transparent]"
-			style={{ overflowAnchor: "none" }}
-		>
-			{children}
-			{hasMoreMessages && <div ref={sentinelRef} className="h-px shrink-0" />}
+		<div className="relative flex min-h-0 flex-1 flex-col">
+			<div
+				ref={scrollContainerRef}
+				className="flex min-h-0 flex-1 flex-col-reverse overflow-y-auto [scrollbar-gutter:stable] [scrollbar-width:thin] [scrollbar-color:hsl(var(--surface-quaternary))_transparent]"
+				style={{ overflowAnchor: "none" }}
+			>
+				{children}
+				{hasMoreMessages && <div ref={sentinelRef} className="h-px shrink-0" />}
+			</div>
+			<Button
+				variant="outline"
+				size="icon"
+				className={cn(
+					"absolute bottom-4 left-1/2 z-10 -translate-x-1/2 rounded-full shadow-md transition-all duration-200",
+					showScrollToBottom
+						? "translate-y-0 opacity-100"
+						: "pointer-events-none translate-y-2 opacity-0",
+				)}
+				onClick={handleScrollToBottom}
+				aria-label="Scroll to bottom"
+			>
+				<ArrowDownIcon />
+			</Button>
 		</div>
 	);
 };

--- a/site/src/pages/AgentsPage/AgentDetailView.tsx
+++ b/site/src/pages/AgentsPage/AgentDetailView.tsx
@@ -604,8 +604,7 @@ const ScrollAnchoredContainer: FC<{
 		<div className="relative flex min-h-0 flex-1 flex-col">
 			<div
 				ref={scrollContainerRef}
-				className="flex min-h-0 flex-1 flex-col-reverse overflow-y-auto [scrollbar-gutter:stable] [scrollbar-width:thin] [scrollbar-color:hsl(var(--surface-quaternary))_transparent]"
-				style={{ overflowAnchor: "none" }}
+				className="flex min-h-0 flex-1 flex-col-reverse overflow-y-auto [overflow-anchor:none] [scrollbar-gutter:stable] [scrollbar-width:thin] [scrollbar-color:hsl(var(--surface-quaternary))_transparent]"
 			>
 				{children}
 				{hasMoreMessages && <div ref={sentinelRef} className="h-px shrink-0" />}
@@ -614,7 +613,7 @@ const ScrollAnchoredContainer: FC<{
 				variant="outline"
 				size="icon"
 				className={cn(
-					"absolute bottom-4 left-1/2 z-10 -translate-x-1/2 rounded-full shadow-md transition-all duration-200",
+					"absolute bottom-4 left-1/2 z-10 -translate-x-1/2 rounded-full bg-surface-primary shadow-md transition-all duration-200",
 					showScrollToBottom
 						? "translate-y-0 opacity-100"
 						: "pointer-events-none translate-y-2 opacity-0",

--- a/site/src/pages/AgentsPage/AgentDetailView.tsx
+++ b/site/src/pages/AgentsPage/AgentDetailView.tsx
@@ -512,7 +512,6 @@ export const AgentDetailNotFoundView: FC<AgentDetailNotFoundViewProps> = ({
  * containers.
  */
 const SCROLL_THRESHOLD = 100;
-const SCROLL_DEBOUNCE_MS = 150;
 
 const ScrollAnchoredContainer: FC<{
 	scrollContainerRef: RefObject<HTMLDivElement | null>;
@@ -582,36 +581,17 @@ const ScrollAnchoredContainer: FC<{
 	// In a flex-col-reverse container, scrollTop = 0 means the user
 	// is at the bottom (most recent content). Scrolling up to see
 	// older messages makes scrollTop negative.
-	//
-	// We debounce the check so momentum scrolling and iOS
-	// rubber-band overscroll can settle before we decide whether
-	// to show the button. Without this, the bounce-back from an
-	// iOS overscroll can look like an upward scroll and briefly
-	// flash the button.
 	useEffect(() => {
 		const container = scrollContainerRef.current;
 		if (!container) return;
 
-		let timer: ReturnType<typeof setTimeout> | null = null;
-
 		const handleScroll = () => {
-			if (timer !== null) {
-				clearTimeout(timer);
-			}
-			timer = setTimeout(() => {
-				const isAtBottom = Math.abs(container.scrollTop) < SCROLL_THRESHOLD;
-				setShowScrollToBottom(!isAtBottom);
-				timer = null;
-			}, SCROLL_DEBOUNCE_MS);
+			const isAtBottom = Math.abs(container.scrollTop) < SCROLL_THRESHOLD;
+			setShowScrollToBottom(!isAtBottom);
 		};
 
 		container.addEventListener("scroll", handleScroll, { passive: true });
-		return () => {
-			container.removeEventListener("scroll", handleScroll);
-			if (timer !== null) {
-				clearTimeout(timer);
-			}
-		};
+		return () => container.removeEventListener("scroll", handleScroll);
 	}, [scrollContainerRef]);
 
 	const handleScrollToBottom = useCallback(() => {


### PR DESCRIPTION
🤖 *This PR was authored by Coder Agent on behalf of Danielle Maywood.*

---


When scrolled up in an agent chat conversation, a floating arrow-down button now appears at the bottom-center of the scroll area. Clicking it smoothly scrolls back to the latest messages.

## Changes

- Added scroll position tracking to `ScrollAnchoredContainer` in `AgentDetailView.tsx`
- A circular outline button with an `ArrowDownIcon` fades in when `|scrollTop| > 100px` (indicating the user has scrolled away from the bottom in the `flex-col-reverse` container)
- Button fades out with a subtle slide animation when the user returns to the bottom
- Clicking the button calls `scrollTo({ top: 0, behavior: "smooth" })` — in a `flex-col-reverse` layout, `scrollTop = 0` is the bottom (latest content)
- Uses existing `Button` component (`variant="outline"`, `size="icon"`) and `ArrowDownIcon` from lucide-react for design system consistency

## Testing

All 406 existing AgentsPage tests continue to pass.


https://github.com/user-attachments/assets/15045ee7-ae6a-4e07-ac42-29f633d87c91
