### PR TITLE
test: stabilize AgentsPageView analytics story date

### DIFF
--- a/site/src/pages/AgentsPage/AgentsPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageView.stories.tsx
@@ -5,6 +5,7 @@ import { API } from "api/api";
 import type * as TypesGen from "api/typesGenerated";
 import type { Chat } from "api/typesGenerated";
 import type { ModelSelectorOption } from "components/ai-elements";
+import dayjs from "dayjs";
 import {
 	expect,
 	fn,
@@ -100,6 +101,9 @@ const mockUsageUsers: TypesGen.ChatCostUsersResponse = {
 	],
 };
 
+// Use local noon so the rendered range label stays stable across timezones.
+const fixedAnalyticsNow = dayjs("2026-03-12T12:00:00");
+
 const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
 const todayTimestamp = new Date().toISOString();
 
@@ -166,6 +170,7 @@ const meta: Meta<typeof AgentsPageView> = {
 			onToggleSidebarCollapsed: fn(),
 		},
 		isAgentsAdmin: false,
+		analyticsNow: fixedAnalyticsNow,
 		archivedFilter: "active" as const,
 		onArchivedFilterChange: fn(),
 		isFetchingNextPage: false,

--- a/site/src/pages/AgentsPage/AgentsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageView.tsx
@@ -3,6 +3,7 @@ import type { ModelSelectorOption } from "components/ai-elements";
 import { Button } from "components/Button/Button";
 import { ExternalImage } from "components/ExternalImage/ExternalImage";
 import { CoderIcon } from "components/Icons/CoderIcon";
+import type { Dayjs } from "dayjs";
 import { PanelLeftIcon } from "lucide-react";
 import { type FC, useCallback, useMemo } from "react";
 import { NavLink, Outlet, useLocation, useNavigate } from "react-router";
@@ -62,6 +63,7 @@ interface AgentsPageViewProps {
 	isFetchingNextPage: boolean;
 	archivedFilter: "active" | "archived";
 	onArchivedFilterChange: (filter: "active" | "archived") => void;
+	analyticsNow?: Dayjs;
 }
 
 export const AgentsPageView: FC<AgentsPageViewProps> = ({
@@ -93,6 +95,7 @@ export const AgentsPageView: FC<AgentsPageViewProps> = ({
 	isFetchingNextPage,
 	archivedFilter,
 	onArchivedFilterChange,
+	analyticsNow,
 }) => {
 	const {
 		chatErrorReasons,
@@ -179,7 +182,7 @@ export const AgentsPageView: FC<AgentsPageViewProps> = ({
 						canSetSystemPrompt={isAgentsAdmin}
 					/>
 				) : sidebarView.panel === "analytics" ? (
-					<AnalyticsPageContent />
+					<AnalyticsPageContent now={analyticsNow} />
 				) : agentId ? (
 					<Outlet key={agentId} context={outletContextValue} />
 				) : (


### PR DESCRIPTION
## Summary
The `AgentsPageView: Opens Analytics For Admins` story was flaky because the analytics header renders a rolling 30-day date range in the top-right corner. Since that range was based on the current date, the story output changed every day.

This change makes the story deterministic by:
- adding an optional `analyticsNow` prop to `AgentsPageView`
- passing that value through to `AnalyticsPageContent` when the analytics panel is shown
- setting a fixed local-noon timestamp in the story so the rendered range label stays stable across timezones
