### PR TITLE
fix(site): normalize chat message spacing for visual consistency

### DIFF
--- a/site/src/pages/AgentsPage/AgentDetail/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail/ConversationTimeline.tsx
@@ -338,7 +338,7 @@ const ChatMessageItem = memo<{
 			>
 				<ConversationItem {...conversationItemProps}>
 					{isUser ? (
-						<Message className="my-2 w-full max-w-none">
+						<Message className="w-full max-w-none">
 							<MessageContent
 								className={cn(
 									"group/msg rounded-lg border border-solid border-border-default bg-surface-secondary px-3 py-2 font-sans shadow-sm transition-shadow",
@@ -762,7 +762,7 @@ const StickyUserMessage: FC<{
 			<div
 				ref={containerRef}
 				className={cn(
-					"relative px-3 -mx-3 pt-2 pb-2",
+					"relative px-3 -mx-3 -mt-3",
 					!isTooTall && "sticky z-10",
 					!isReady && "invisible",
 					isStuck && !isTooTall && "pointer-events-none",
@@ -816,14 +816,11 @@ const StickyUserMessage: FC<{
 									"linear-gradient(to bottom, black calc(var(--clip-h, 100%) + 24px), transparent calc(var(--clip-h, 100%) + 48px))",
 							}}
 						/>
-						{/* Content layer: px-3 pt-2 matches the
-						    sticky container's padding so the
-						    overlay aligns with the flow element.
-						    will-change promotes to GPU layer. */}
-						<div
-							className="relative px-3 pt-2 pointer-events-auto"
-							style={{ willChange: "max-height" }}
-						>
+						{/* Content layer: px-3 matches the sticky
+							    container's padding so the overlay aligns
+							    with the flow element. will-change promotes
+							    to GPU layer. */}
+						<div className="relative px-3 pointer-events-auto will-change-[max-height]">
 							<ChatMessageItem
 								message={message}
 								parsed={parsed}


### PR DESCRIPTION
🤖 *This PR was written by Coder Agent on behalf of Danielle Maywood.*

---

## Problem

The chat message list on the agents page had inconsistent vertical gaps between messages. The spacing varied wildly depending on which message types were adjacent:

| Transition | Gap |
|---|---|
| Assistant → Assistant | 12px |
| Assistant → User | **40px** |
| User → Assistant | **28px** |
| User → User | **68px** |

The root cause was three layers of spacing compounding on user messages:
1. The parent flex container's `gap-3` (12px)
2. A zero-height sentinel div (for sticky scroll detection) consuming an extra gap slot (+12px)
3. `pt-2 pb-2` padding on the sticky container (+16px)
4. `my-2` margin on the user `<Message>` wrapper (+16px)

Assistant messages had none of these extras — just the 12px flex gap.

## Fix

- **Remove `my-2`** from the user `<Message>` className — let the parent flex gap handle inter-message spacing uniformly.
- **Replace `pt-2 pb-2` with `-mt-3`** on the sticky container — the negative margin cancels the 12px phantom gap the sentinel div creates. The sentinel must remain a separate flex sibling (outside the sticky container) because the IntersectionObserver, push-up DOM traversal, and clip-height calculation all depend on it being in normal document flow.
- **Remove `pt-2`** from the overlay content layer to match the updated container.

After this change, all inter-message gaps are a uniform **12px**.

## What was NOT changed (and why)

- **The sentinel stays outside the container**: Moving it inside would break the sticky detection (IntersectionObserver), push-up sibling traversal, and Storybook structural tests.
- **Inner content gaps stay different**: User messages use `gap-1.5` (6px) for tightly-coupled inline content inside a bordered bubble. Assistant messages use `space-y-3` (12px) for independent full-width blocks (tool cards, response paragraphs). These serve different purposes.