### PR TITLE
fix: buffer chat events during tab catch-up to prevent slow replay

### DIFF
--- a/site/src/pages/AgentsPage/AgentDetail/ChatContext.test.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail/ChatContext.test.tsx
@@ -36,6 +36,7 @@ import { QueryClient, QueryClientProvider } from "react-query";
 import type { OneWayMessageEvent } from "utils/OneWayWebSocket";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+	selectCatchUpRenderPending,
 	selectChatStatus,
 	selectOrderedMessageIDs,
 	selectQueuedMessages,
@@ -2553,6 +2554,477 @@ describe("useChatStore", () => {
 			const blocks = result.current.streamState?.blocks ?? [];
 			const textBlock = blocks.find((b) => b.type === "response");
 			expect(textBlock).toBeDefined();
+		});
+	});
+
+	describe("tab visibility catch-up", () => {
+		type CapturedRAF = {
+			id: number;
+			cb: FrameRequestCallback;
+			cancelled: boolean;
+		};
+
+		const emitPart = (socket: MockSocket, chatID: string, text: string) => {
+			socket.emitData({
+				type: "message_part",
+				chat_id: chatID,
+				message_part: {
+					role: "assistant",
+					part: { type: "text", text },
+				},
+			});
+		};
+
+		const emitDurableMessage = (
+			socket: MockSocket,
+			chatID: string,
+			id: number,
+			role: TypesGen.ChatMessageRole,
+			text: string,
+		) => {
+			socket.emitData({
+				type: "message",
+				chat_id: chatID,
+				message: makeMessage(chatID, id, role, text),
+			});
+		};
+
+		const emitStatus = (
+			socket: MockSocket,
+			chatID: string,
+			status: TypesGen.ChatStatus,
+		) => {
+			socket.emitData({
+				type: "status",
+				chat_id: chatID,
+				status: { status },
+			});
+		};
+
+		const setupCatchUpTest = async (options?: {
+			chatID?: string;
+			captureRAF?: boolean;
+		}) => {
+			const chatID = options?.chatID ?? "chat-catchup";
+			vi.useFakeTimers({ shouldAdvanceTime: true });
+
+			const capturedRAFs: CapturedRAF[] = [];
+			if (options?.captureRAF) {
+				let nextRAFId = 1;
+				vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+					const id = nextRAFId++;
+					capturedRAFs.push({ id, cb, cancelled: false });
+					return id;
+				});
+				vi.spyOn(window, "cancelAnimationFrame").mockImplementation((id) => {
+					for (const raf of capturedRAFs) {
+						if (raf.id === id) {
+							raf.cancelled = true;
+						}
+					}
+				});
+			} else {
+				immediateAnimationFrame();
+			}
+
+			const existingMessage = makeMessage(chatID, 1, "user", "hello");
+			const mockSocket = createMockSocket();
+			vi.mocked(watchChat).mockReturnValue(mockSocket as never);
+
+			const queryClient = createTestQueryClient();
+			const wrapper = ({ children }: PropsWithChildren) => (
+				<QueryClientProvider client={queryClient}>
+					{children}
+				</QueryClientProvider>
+			);
+			const setChatErrorReason = vi.fn();
+			const clearChatErrorReason = vi.fn();
+
+			const { result, unmount } = renderHook(
+				() => {
+					const { store } = useChatStore({
+						chatID,
+						chatMessages: [existingMessage],
+						chatRecord: makeChat(chatID),
+						chatMessagesData: {
+							messages: [existingMessage],
+							queued_messages: [],
+							has_more: false,
+						},
+						chatQueuedMessages: [],
+						setChatErrorReason,
+						clearChatErrorReason,
+					});
+					return {
+						store,
+						streamState: useChatSelector(store, selectStreamState),
+						chatStatus: useChatSelector(store, selectChatStatus),
+						catchUpRenderPending: useChatSelector(
+							store,
+							selectCatchUpRenderPending,
+						),
+						orderedMessageIDs: useChatSelector(store, selectOrderedMessageIDs),
+					};
+				},
+				{ wrapper },
+			);
+
+			await waitFor(() => {
+				expect(watchChat).toHaveBeenCalledWith(chatID, 1);
+			});
+
+			let mockHidden = false;
+			vi.spyOn(document, "hidden", "get").mockImplementation(() => mockHidden);
+
+			const setHidden = (hidden: boolean) => {
+				mockHidden = hidden;
+				document.dispatchEvent(new Event("visibilitychange"));
+			};
+
+			const fireDrain = async () => {
+				await act(async () => {
+					vi.advanceTimersByTime(0);
+				});
+			};
+
+			const fireRAF = () => {
+				const last = capturedRAFs[capturedRAFs.length - 1];
+				if (last && !last.cancelled) {
+					act(() => {
+						last.cb(0);
+					});
+				}
+			};
+
+			return {
+				result,
+				mockSocket,
+				setHidden,
+				fireDrain,
+				unmount,
+				chatID,
+				capturedRAFs,
+				fireRAF,
+			};
+		};
+
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		it("batches events received while tab was hidden into a single render", async () => {
+			const { result, mockSocket, setHidden, fireDrain, chatID } =
+				await setupCatchUpTest({ chatID: "chat-catchup-batch" });
+
+			setHidden(true);
+			setHidden(false);
+
+			// Attach a subscriber spy to count notifications.
+			const storeRef = result.current.store;
+			let subscriberCalls = 0;
+			const unsub = storeRef.subscribe(() => {
+				subscriberCalls++;
+			});
+
+			// Emit several message_parts during the catch-up window.
+			// In a real browser, these are buffered WS messages
+			// delivered after the visibilitychange event. During
+			// catch-up, emit() is suppressed by the batch so no
+			// subscriber notifications fire yet.
+			emitPart(mockSocket, chatID, "catch");
+			emitPart(mockSocket, chatID, "-up");
+			emitPart(mockSocket, chatID, " text");
+
+			// Subscriber should NOT have been called yet because
+			// the batch suppresses emit.
+			expect(subscriberCalls).toBe(0);
+
+			await fireDrain();
+
+			// After drain: the batch ended, producing a small
+			// number of notifications: endBatch fires once, then
+			// RAF fires setCatchUpRenderPending(false) which fires
+			// again. Without batch suppression each emitData call
+			// would trigger its own subscriber notification,
+			// pushing the count well above 3.
+			expect(subscriberCalls).toBe(2);
+
+			await waitFor(() => {
+				expect(result.current.streamState?.blocks).toEqual([
+					{ type: "response", text: "catch-up text" },
+				]);
+			});
+
+			unsub();
+		});
+
+		it("sets catchUpRenderPending for exactly one frame after catch-up", async () => {
+			const {
+				result,
+				mockSocket,
+				setHidden,
+				fireDrain,
+				chatID,
+				capturedRAFs,
+				fireRAF,
+			} = await setupCatchUpTest({
+				chatID: "chat-catchup-raf",
+				captureRAF: true,
+			});
+
+			// Transition to running so message_parts are accepted.
+			act(() => {
+				emitStatus(mockSocket, chatID, "running");
+			});
+
+			await waitFor(() => {
+				expect(result.current.chatStatus).toBe("running");
+			});
+
+			setHidden(true);
+			setHidden(false);
+
+			// Emit an event during the catch-up window so
+			// endCatchUp has work to do.
+			emitPart(mockSocket, chatID, "queued");
+
+			await fireDrain();
+
+			// After drain: catchUpRenderPending should be true
+			// because the RAF hasn't fired yet.
+			await waitFor(() => {
+				expect(result.current.catchUpRenderPending).toBe(true);
+			});
+
+			// Fire the captured RAF callback.
+			expect(capturedRAFs.length).toBeGreaterThan(0);
+			fireRAF();
+
+			// Now it should be cleared.
+			await waitFor(() => {
+				expect(result.current.catchUpRenderPending).toBe(false);
+			});
+		});
+
+		it("handles rapid hidden-visible-hidden-visible without freezing", async () => {
+			const { result, mockSocket, setHidden, fireDrain, chatID } =
+				await setupCatchUpTest({ chatID: "chat-rapid-toggle" });
+
+			act(() => {
+				emitStatus(mockSocket, chatID, "running");
+			});
+
+			await waitFor(() => {
+				expect(result.current.chatStatus).toBe("running");
+			});
+
+			// Rapid toggle: hidden -> visible -> hidden -> visible.
+			setHidden(true);
+			setHidden(false);
+			setHidden(true);
+			setHidden(false);
+
+			await fireDrain();
+
+			// Store should still accept events (not frozen in batch
+			// mode). Emit a new message_part and verify it updates.
+			act(() => {
+				emitPart(mockSocket, chatID, "after-toggle");
+			});
+
+			await waitFor(() => {
+				expect(result.current.streamState?.blocks).toEqual([
+					{ type: "response", text: "after-toggle" },
+				]);
+			});
+		});
+
+		it("cleanup during catch-up ends the batch", async () => {
+			const { result, mockSocket, setHidden, unmount, chatID } =
+				await setupCatchUpTest({ chatID: "chat-catchup-cleanup" });
+
+			act(() => {
+				emitStatus(mockSocket, chatID, "running");
+			});
+
+			await waitFor(() => {
+				expect(result.current.chatStatus).toBe("running");
+			});
+
+			setHidden(true);
+			setHidden(false);
+
+			// Grab the store ref before unmount.
+			const storeRef = result.current.store;
+
+			// Unmount while the batch is still open (drain hasn't
+			// fired). Cleanup should discard the batch without
+			// emitting stale mutations.
+			unmount();
+			// The store should not be stuck in batch mode. Verify
+			// by subscribing and checking that a mutation triggers
+			// the subscriber.
+			let subscriberCalled = false;
+			const unsub = storeRef.subscribe(() => {
+				subscriberCalled = true;
+			});
+
+			storeRef.setChatStatus("completed");
+			expect(subscriberCalled).toBe(true);
+
+			unsub();
+		});
+
+		it("catch-up with no queued messages is a no-op", async () => {
+			const { result, mockSocket, setHidden, fireDrain, chatID } =
+				await setupCatchUpTest({ chatID: "chat-catchup-noop" });
+
+			// Snapshot state before the cycle.
+			const stateBefore = {
+				streamState: result.current.streamState,
+				orderedMessageIDs: result.current.orderedMessageIDs,
+				chatStatus: result.current.chatStatus,
+			};
+
+			setHidden(true);
+			setHidden(false);
+
+			await fireDrain();
+
+			// State should be unchanged — the cycle was a no-op.
+			expect(result.current.streamState).toBe(stateBefore.streamState);
+			expect(result.current.orderedMessageIDs).toEqual(
+				stateBefore.orderedMessageIDs,
+			);
+			expect(result.current.chatStatus).toBe(stateBefore.chatStatus);
+
+			// Verify the store still works normally after the
+			// no-op catch-up: the batch opened and closed
+			// correctly, so a subsequent message_part renders.
+			act(() => {
+				emitPart(mockSocket, chatID, "after-noop");
+			});
+
+			await waitFor(() => {
+				expect(result.current.streamState?.blocks).toEqual([
+					{ type: "response", text: "after-noop" },
+				]);
+			});
+		});
+
+		it("resolves pending stream reset across turn boundaries during catch-up", async () => {
+			const { result, mockSocket, setHidden, fireDrain, chatID } =
+				await setupCatchUpTest({
+					chatID: "chat-catchup-turn-boundary",
+				});
+
+			// Transition to running so message_parts are accepted.
+			act(() => {
+				emitStatus(mockSocket, chatID, "running");
+			});
+
+			await waitFor(() => {
+				expect(result.current.chatStatus).toBe("running");
+			});
+
+			setHidden(true);
+			setHidden(false);
+
+			// Turn 1: stream some parts then complete the turn
+			// with a durable message.
+			emitPart(mockSocket, chatID, "turn one text");
+
+			// Durable message completes turn 1. This sets
+			// catchUpPendingReset = true because changed is true.
+			emitDurableMessage(mockSocket, chatID, 2, "assistant", "turn one text");
+
+			// Turn 2: new parts arrive. The pending reset should
+			// clear stream state before applying these.
+			emitPart(mockSocket, chatID, "turn two text");
+
+			await fireDrain();
+
+			// Stream state should contain only turn two text.
+			// Without catchUpPendingReset, turn one text would
+			// be concatenated with turn two text.
+			await waitFor(() => {
+				expect(result.current.streamState?.blocks).toEqual([
+					{ type: "response", text: "turn two text" },
+				]);
+			});
+		});
+
+		it("cancels stale stream reset RAF when tab becomes visible", async () => {
+			const { result, mockSocket, setHidden, fireDrain, chatID, capturedRAFs } =
+				await setupCatchUpTest({
+					chatID: "chat-stale-raf",
+					captureRAF: true,
+				});
+
+			// Transition to running so message_parts are accepted.
+			act(() => {
+				emitStatus(mockSocket, chatID, "running");
+			});
+
+			await waitFor(() => {
+				expect(result.current.chatStatus).toBe("running");
+			});
+
+			// Emit a message_part followed by a durable message
+			// with changed=true. This schedules a stream reset
+			// via scheduleStreamReset (a RAF).
+			act(() => {
+				emitPart(mockSocket, chatID, "old text");
+			});
+
+			await waitFor(() => {
+				expect(result.current.streamState?.blocks).toEqual([
+					{ type: "response", text: "old text" },
+				]);
+			});
+
+			act(() => {
+				emitDurableMessage(mockSocket, chatID, 2, "assistant", "old text");
+			});
+
+			// A RAF for scheduleStreamReset is now pending.
+			// Snapshot the count before the visibility cycle.
+			const rafCountBeforeVisibility = capturedRAFs.length;
+
+			// Go hidden then visible. This enters catch-up and
+			// calls cancelScheduledStreamReset.
+			setHidden(true);
+			setHidden(false);
+
+			emitPart(mockSocket, chatID, "new text");
+
+			await fireDrain();
+
+			// The pending stream reset RAF was cancelled and its
+			// intent transferred to catchUpPendingReset. When the
+			// new message_part arrives, the reset fires first,
+			// clearing "old text" before applying "new text".
+			await waitFor(() => {
+				expect(result.current.streamState?.blocks).toEqual([
+					{ type: "response", text: "new text" },
+				]);
+			});
+
+			// Now fire the stale RAF callbacks that were captured
+			// before the visibility change. Cancelled RAFs are
+			// skipped (simulating browser cancelAnimationFrame).
+			act(() => {
+				for (let i = 0; i < rafCountBeforeVisibility; i++) {
+					if (!capturedRAFs[i].cancelled) {
+						capturedRAFs[i].cb(0);
+					}
+				}
+			});
+
+			// Stream state should still be intact.
+			expect(result.current.streamState?.blocks).toEqual([
+				{ type: "response", text: "new text" },
+			]);
 		});
 	});
 });

--- a/site/src/pages/AgentsPage/AgentDetail/ChatContext.ts
+++ b/site/src/pages/AgentsPage/AgentDetail/ChatContext.ts
@@ -130,6 +130,10 @@ type ChatStoreState = {
 	retryState: { attempt: number; error: string } | null;
 	queuedMessages: readonly TypesGen.ChatQueuedMessage[];
 	subagentStatusOverrides: Map<string, TypesGen.ChatStatus>;
+	// True for exactly one render cycle after a catch-up batch is
+	// applied. Components use this to bypass smooth-text animation
+	// so the entire catch-up state appears instantly.
+	catchUpRenderPending: boolean;
 };
 
 type ChatStore = {
@@ -158,6 +162,10 @@ type ChatStore = {
 		status: TypesGen.ChatStatus,
 	) => void;
 	resetTransientState: () => void;
+	setCatchUpRenderPending: (pending: boolean) => void;
+	beginBatch: () => void;
+	endBatch: () => void;
+	discardBatch: () => void;
 };
 
 const createInitialState = (): ChatStoreState => ({
@@ -169,13 +177,23 @@ const createInitialState = (): ChatStoreState => ({
 	retryState: null,
 	queuedMessages: [],
 	subagentStatusOverrides: new Map(),
+	catchUpRenderPending: false,
 });
 
 export const createChatStore = (): ChatStore => {
 	let state = createInitialState();
 	const listeners = new Set<() => void>();
 
+	// Batch mechanism: while batchDepth > 0, emit() is deferred.
+	// endBatch() fires a single emit when depth returns to 0.
+	let batchDepth = 0;
+	let batchDirty = false;
+
 	const emit = (): void => {
+		if (batchDepth > 0) {
+			batchDirty = true;
+			return;
+		}
 		for (const listener of listeners) {
 			listener();
 		}
@@ -383,7 +401,8 @@ export const createChatStore = (): ChatStore => {
 				state.streamState === null &&
 				state.streamError === null &&
 				state.retryState === null &&
-				state.subagentStatusOverrides.size === 0
+				state.subagentStatusOverrides.size === 0 &&
+				!state.catchUpRenderPending
 			) {
 				return;
 			}
@@ -393,7 +412,36 @@ export const createChatStore = (): ChatStore => {
 				streamError: null,
 				retryState: null,
 				subagentStatusOverrides: new Map(),
+				catchUpRenderPending: false,
 			}));
+		},
+		setCatchUpRenderPending: (pending) => {
+			if (state.catchUpRenderPending === pending) {
+				return;
+			}
+			setState((current) => ({
+				...current,
+				catchUpRenderPending: pending,
+			}));
+		},
+		beginBatch: () => {
+			batchDepth++;
+		},
+		endBatch: () => {
+			batchDepth = Math.max(0, batchDepth - 1);
+			if (batchDepth === 0 && batchDirty) {
+				batchDirty = false;
+				for (const listener of listeners) {
+					listener();
+				}
+			}
+		},
+		// Reset batch state without emitting. Used during
+		// cleanup to discard buffered mutations rather than
+		// publishing stale data from a previous chat.
+		discardBatch: () => {
+			batchDepth = 0;
+			batchDirty = false;
 		},
 	};
 };
@@ -421,6 +469,8 @@ export const selectQueuedMessages = (state: ChatStoreState) =>
 export const selectSubagentStatusOverrides = (state: ChatStoreState) =>
 	state.subagentStatusOverrides;
 export const selectRetryState = (state: ChatStoreState) => state.retryState;
+export const selectCatchUpRenderPending = (state: ChatStoreState) =>
+	state.catchUpRenderPending;
 
 export const useChatStore = (
 	options: UseChatStoreOptions,
@@ -497,6 +547,11 @@ export const useChatStore = (
 			});
 		},
 		[chatID, queryClient],
+	);
+
+	const hasScheduledStreamReset = useCallback(
+		() => streamResetFrameRef.current !== null,
+		[],
 	);
 
 	const cancelScheduledStreamReset = useCallback(() => {
@@ -641,6 +696,96 @@ export const useChatStore = (
 		// outside the utility) can bail out after cleanup.
 		let disposed = false;
 
+		// --- Catch-up state ---
+		// When the tab was hidden and becomes visible, we open a
+		// store batch (beginBatch) that suppresses emit. Each
+		// handleMessage call mutates the store normally but no
+		// React re-renders happen. When the browser's WS message
+		// queue drains (setTimeout(0) fires), we end the batch,
+		// producing a single atomic render.
+		let wasHidden = document.hidden;
+		let catchingUp = false;
+		// Tracks whether a completed durable message needs to
+		// clear stream state before the next message_part. Used
+		// during catch-up instead of the RAF-based
+		// scheduleStreamReset, which can't fire inside a batch.
+		let catchUpPendingReset = false;
+		let drainTimer: ReturnType<typeof setTimeout> | null = null;
+		let catchUpRenderFrameId: number | null = null;
+
+		const cancelDrainTimer = () => {
+			if (drainTimer !== null) {
+				clearTimeout(drainTimer);
+				drainTimer = null;
+			}
+		};
+
+		// Ends the catch-up batch after the browser's WS message
+		// queue has drained. Resolves any trailing stream reset
+		// and emits exactly once via endBatch.
+		const endCatchUp = () => {
+			drainTimer = null;
+			if (!catchingUp || disposed) {
+				return;
+			}
+			// If the tab was re-hidden before the drain fires, keep
+			// the batch open. The next visibility change will retry.
+			if (document.hidden) {
+				return;
+			}
+			catchingUp = false;
+
+			// Resolve any trailing reset from a completed durable
+			// message that had no subsequent parts.
+			if (catchUpPendingReset) {
+				store.clearStreamState();
+				catchUpPendingReset = false;
+			}
+
+			// Signal components to bypass smooth-text animation
+			// for this render. Cleared after the browser paints.
+			store.setCatchUpRenderPending(true);
+			store.endBatch();
+
+			// Clear the bypass flag after the browser paints the
+			// catch-up frame so subsequent live events animate
+			// normally.
+			catchUpRenderFrameId = window.requestAnimationFrame(() => {
+				catchUpRenderFrameId = null;
+				store.setCatchUpRenderPending(false);
+			});
+		};
+
+		const onVisibilityChange = () => {
+			if (document.hidden) {
+				wasHidden = true;
+				return;
+			}
+			if (!wasHidden) {
+				return;
+			}
+			wasHidden = false;
+			// Cancel any pre-existing stream reset RAF that was
+			// paused while the tab was hidden. Without this, the
+			// RAF fires after catch-up and wipes stream state.
+			if (!catchingUp) {
+				catchingUp = true;
+				catchUpPendingReset = false;
+				store.beginBatch();
+			}
+			// Transfer intent from cancelled RAF to catch-up flag.
+			if (hasScheduledStreamReset()) {
+				catchUpPendingReset = true;
+			}
+			cancelScheduledStreamReset();
+			// Schedule an immediate drain in case no WS messages
+			// are queued (e.g. short background, nothing happened).
+			cancelDrainTimer();
+			drainTimer = setTimeout(endCatchUp, 0);
+		};
+
+		document.addEventListener("visibilitychange", onVisibilityChange);
+
 		const handleMessage = (
 			payload: OneWayMessageEvent<TypesGen.ServerSentEvent>,
 		) => {
@@ -660,6 +805,14 @@ export const useChatStore = (
 				return;
 			}
 
+			// During catch-up, reset the drain timer on each
+			// message so that endCatchUp fires only once the
+			// browser's queued WS messages have all been delivered.
+			if (catchingUp) {
+				cancelDrainTimer();
+				drainTimer = setTimeout(endCatchUp, 0);
+			}
+
 			const shouldApplyMessagePart = (): boolean => {
 				const currentStatus = store.getSnapshot().chatStatus;
 				return currentStatus !== "pending" && currentStatus !== "waiting";
@@ -670,21 +823,32 @@ export const useChatStore = (
 				if (pendingMessageParts.length === 0) {
 					return;
 				}
-				cancelScheduledStreamReset();
 				const parts = pendingMessageParts.splice(0, pendingMessageParts.length);
-				const currentChatID = chatID;
-				startTransition(() => {
-					if (activeChatIDRef.current !== currentChatID) {
-						return;
-					}
-					// Re-check status at execution time. A status
-					// event processed between scheduling and running
-					// this callback may have cleared stream state.
-					if (!shouldApplyMessagePart()) {
-						return;
+				if (catchingUp) {
+					// During catch-up: resolve any pending reset from
+					// a completed turn before applying the next turn's
+					// parts, then apply synchronously (no transition).
+					if (catchUpPendingReset) {
+						store.clearStreamState();
+						catchUpPendingReset = false;
 					}
 					store.applyMessageParts(parts);
-				});
+				} else {
+					cancelScheduledStreamReset();
+					const currentChatID = chatID;
+					startTransition(() => {
+						if (activeChatIDRef.current !== currentChatID) {
+							return;
+						}
+						// Re-check status at execution time. A status
+						// event processed between scheduling and running
+						// this callback may have cleared stream state.
+						if (!shouldApplyMessagePart()) {
+							return;
+						}
+						store.applyMessageParts(parts);
+					});
+				}
 			};
 
 			for (const streamEvent of streamEvents) {
@@ -697,7 +861,9 @@ export const useChatStore = (
 					}
 					const part = streamEvent.message_part?.part;
 					if (part) {
-						cancelScheduledStreamReset();
+						if (!catchingUp) {
+							cancelScheduledStreamReset();
+						}
 						pendingMessageParts.push(part);
 					}
 					continue;
@@ -726,7 +892,11 @@ export const useChatStore = (
 							lastMessageIdRef.current = message.id;
 						}
 						if (changed && message.role === "assistant") {
-							scheduleStreamReset();
+							if (catchingUp) {
+								catchUpPendingReset = true;
+							} else {
+								scheduleStreamReset();
+							}
 						}
 						// Do not update updated_at here. The global
 						// chat-list WebSocket delivers the authoritative
@@ -758,6 +928,7 @@ export const useChatStore = (
 						if (nextStatus === "pending" || nextStatus === "waiting") {
 							store.clearStreamState();
 							store.clearRetryState();
+							catchUpPendingReset = false;
 						}
 						if (nextStatus === "running") {
 							store.clearRetryState();
@@ -797,6 +968,7 @@ export const useChatStore = (
 						const retry = streamEvent.retry;
 						if (retry) {
 							store.clearStreamState();
+							catchUpPendingReset = false;
 							store.setRetryState({
 								attempt: retry.attempt,
 								error: retry.error,
@@ -827,6 +999,7 @@ export const useChatStore = (
 				// from a clean slate to avoid duplicating text.
 				store.clearStreamError();
 				store.clearStreamState();
+				catchUpPendingReset = false;
 			},
 			onDisconnect(attempt) {
 				// Show the error only on the first disconnect (not
@@ -848,12 +1021,22 @@ export const useChatStore = (
 			disposed = true;
 			disposeSocket();
 			cancelScheduledStreamReset();
+			cancelDrainTimer();
+			if (catchUpRenderFrameId !== null) {
+				window.cancelAnimationFrame(catchUpRenderFrameId);
+				store.setCatchUpRenderPending(false);
+			}
+			if (catchingUp) {
+				store.discardBatch();
+			}
+			document.removeEventListener("visibilitychange", onVisibilityChange);
 			activeChatIDRef.current = null;
 		};
 	}, [
 		cancelScheduledStreamReset,
 		chatID,
 		clearChatErrorReason,
+		hasScheduledStreamReset,
 		initialDataLoaded,
 		scheduleStreamReset,
 		setChatErrorReason,
@@ -861,7 +1044,6 @@ export const useChatStore = (
 		updateChatQueuedMessages,
 		updateSidebarChat,
 	]);
-
 	return {
 		store,
 		clearStreamError: useCallback(() => {

--- a/site/src/pages/AgentsPage/AgentDetail/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail/ConversationTimeline.tsx
@@ -88,6 +88,7 @@ type RenderBlockListParams = {
 	toolByID: ReadonlyMap<string, MergedTool>;
 	keyPrefix: string;
 	isStreaming?: boolean;
+	bypassSmoothing?: boolean;
 	subagentTitles?: Map<string, string>;
 	subagentStatusOverrides?: Map<string, TypesGen.ChatStatus>;
 	onImageClick?: (src: string) => void;
@@ -100,12 +101,13 @@ type RenderBlockListParams = {
 const SmoothedResponse: FC<{
 	text: string;
 	streamKey: string;
+	bypassSmoothing?: boolean;
 	urlTransform?: UrlTransform;
-}> = ({ text, streamKey, urlTransform }) => {
+}> = ({ text, streamKey, bypassSmoothing = false, urlTransform }) => {
 	const { visibleText } = useSmoothStreamingText({
 		fullText: text,
 		isStreaming: true,
-		bypassSmoothing: false,
+		bypassSmoothing,
 		streamKey,
 	});
 	return <Response urlTransform={urlTransform}>{visibleText}</Response>;
@@ -121,6 +123,7 @@ function renderBlockList({
 	toolByID,
 	keyPrefix,
 	isStreaming = false,
+	bypassSmoothing = false,
 	subagentTitles,
 	subagentStatusOverrides,
 	onImageClick,
@@ -136,6 +139,7 @@ function renderBlockList({
 							key={`${keyPrefix}-response-${index}`}
 							text={block.text}
 							streamKey={keyPrefix}
+							bypassSmoothing={bypassSmoothing}
 							urlTransform={urlTransform}
 						/>
 					) : (
@@ -152,7 +156,7 @@ function renderBlockList({
 							key={`${keyPrefix}-thinking-${index}`}
 							id={`${keyPrefix}-thinking-${index}`}
 							text={block.text}
-							isStreaming={isStreaming}
+							isStreaming={isStreaming && !bypassSmoothing}
 							urlTransform={urlTransform}
 						/>
 					);
@@ -501,6 +505,7 @@ export const StreamingOutput = memo<{
 	showInitialPlaceholder?: boolean;
 	retryState?: { attempt: number; error: string } | null;
 	urlTransform?: UrlTransform;
+	bypassSmoothing?: boolean;
 }>(
 	({
 		streamState,
@@ -510,6 +515,7 @@ export const StreamingOutput = memo<{
 		showInitialPlaceholder = false,
 		retryState,
 		urlTransform,
+		bypassSmoothing,
 	}) => {
 		const conversationItemProps = { role: "assistant" as const };
 		const toolByID = new Map(streamTools.map((tool) => [tool.id, tool]));
@@ -519,6 +525,7 @@ export const StreamingOutput = memo<{
 			toolByID,
 			keyPrefix: "stream",
 			isStreaming: true,
+			bypassSmoothing,
 			subagentTitles,
 			subagentStatusOverrides,
 			urlTransform,
@@ -859,6 +866,7 @@ interface ConversationTimelineProps {
 	editingMessageId?: number | null;
 	savingMessageId?: number | null;
 	urlTransform?: UrlTransform;
+	bypassSmoothing?: boolean;
 }
 
 export const ConversationTimeline: FC<ConversationTimelineProps> = ({
@@ -877,6 +885,7 @@ export const ConversationTimeline: FC<ConversationTimelineProps> = ({
 	editingMessageId,
 	savingMessageId,
 	urlTransform,
+	bypassSmoothing,
 }) => {
 	const shouldRenderStreamAfterMessages =
 		hasStreamOutput && parsedMessages.length > 0;
@@ -938,6 +947,7 @@ export const ConversationTimeline: FC<ConversationTimelineProps> = ({
 							showInitialPlaceholder={isAwaitingFirstStreamChunk}
 							retryState={retryState}
 							urlTransform={urlTransform}
+							bypassSmoothing={bypassSmoothing}
 						/>
 					)}
 					{hasStreamOutput && parsedMessages.length === 0 && (
@@ -949,6 +959,7 @@ export const ConversationTimeline: FC<ConversationTimelineProps> = ({
 							showInitialPlaceholder={isAwaitingFirstStreamChunk}
 							retryState={retryState}
 							urlTransform={urlTransform}
+							bypassSmoothing={bypassSmoothing}
 						/>
 					)}
 				</div>

--- a/site/src/pages/AgentsPage/AgentDetail/SmoothText.test.ts
+++ b/site/src/pages/AgentsPage/AgentDetail/SmoothText.test.ts
@@ -149,4 +149,34 @@ describe("SmoothTextEngine", () => {
 		// approximately the same number of characters.
 		expect(Math.abs(at60Hz - at240Hz)).toBeLessThanOrEqual(2);
 	});
+
+	it("clamps dtMs to prevent charBudget inflation after long background pause", () => {
+		const setupEngine = () => {
+			const engine = new SmoothTextEngine();
+			engine.update(makeText(400), true, false);
+			for (let i = 0; i < 3; i++) {
+				engine.tick(16);
+			}
+			return engine;
+		};
+
+		const engineA = setupEngine();
+		const engineB = setupEngine();
+
+		const baselineA = engineA.visibleLength;
+		const baselineB = engineB.visibleLength;
+		expect(baselineA).toBe(baselineB);
+
+		// Simulate a 5-second RAF pause (browser backgrounded the tab).
+		engineA.tick(5000);
+		const revealedAfterLongPause = engineA.visibleLength - baselineA;
+
+		// Simulate a normal 100ms tick from the same starting state.
+		engineB.tick(100);
+		const revealedAfterNormalTick = engineB.visibleLength - baselineB;
+
+		// The dtMs clamp ensures a long pause does not inflate
+		// charBudget beyond what 100ms would produce.
+		expect(revealedAfterLongPause).toBe(revealedAfterNormalTick);
+	});
 });

--- a/site/src/pages/AgentsPage/AgentDetail/SmoothText.ts
+++ b/site/src/pages/AgentsPage/AgentDetail/SmoothText.ts
@@ -170,9 +170,13 @@ export class SmoothTextEngine {
 	 * Advance the presentation clock by a timestep.
 	 */
 	tick(dtMs: number): number {
-		if (dtMs <= 0) {
+		if (dtMs <= 0 || Number.isNaN(dtMs)) {
 			return this.visibleLengthValue;
 		}
+
+		// Clamp to prevent charBudget inflation after long
+		// background periods where RAF was paused by the browser.
+		dtMs = Math.min(100, dtMs);
 
 		if (!this.isStreaming || this.bypassSmoothing) {
 			return this.visibleLengthValue;

--- a/site/src/pages/AgentsPage/AgentDetail/chatStore.test.ts
+++ b/site/src/pages/AgentsPage/AgentDetail/chatStore.test.ts
@@ -506,3 +506,134 @@ describe("subscribe", () => {
 		expect(countB).toBe(1);
 	});
 });
+
+// ---------------------------------------------------------------------------
+// beginBatch / endBatch / discardBatch
+// ---------------------------------------------------------------------------
+
+describe("beginBatch / endBatch / discardBatch", () => {
+	it("coalesces multiple mutations into a single subscriber notification", () => {
+		const store = createChatStore();
+		let callCount = 0;
+		store.subscribe(() => {
+			callCount += 1;
+		});
+
+		store.beginBatch();
+		store.setChatStatus("running");
+		store.setStreamError("oops");
+		store.setRetryState({ attempt: 1, error: "rate limited" });
+		store.endBatch();
+
+		expect(callCount).toBe(1);
+	});
+
+	it("emits nothing when no mutations occur inside batch", () => {
+		const store = createChatStore();
+		let callCount = 0;
+		store.subscribe(() => {
+			callCount += 1;
+		});
+
+		store.beginBatch();
+		store.endBatch();
+
+		expect(callCount).toBe(0);
+	});
+
+	it("does not suppress emit when not batching", () => {
+		const store = createChatStore();
+		let callCount = 0;
+		store.subscribe(() => {
+			callCount += 1;
+		});
+
+		store.setChatStatus("running");
+		store.setStreamError("oops");
+
+		expect(callCount).toBe(2);
+	});
+
+	it("handles nested beginBatch / endBatch correctly", () => {
+		const store = createChatStore();
+		let callCount = 0;
+		store.subscribe(() => {
+			callCount += 1;
+		});
+
+		store.beginBatch();
+		store.beginBatch();
+		store.setChatStatus("running");
+		store.endBatch(); // inner
+		expect(callCount).toBe(0);
+
+		store.endBatch(); // outer
+		expect(callCount).toBe(1);
+	});
+
+	it("discardBatch resets batch without emitting", () => {
+		const store = createChatStore();
+		let callCount = 0;
+		store.subscribe(() => {
+			callCount += 1;
+		});
+
+		store.beginBatch();
+		store.setChatStatus("running");
+		store.setStreamError("oops");
+		store.discardBatch();
+
+		// No subscriber notification from discardBatch.
+		expect(callCount).toBe(0);
+
+		// Store is no longer in batch mode — subsequent
+		// mutations emit normally.
+		store.setChatStatus("completed");
+		expect(callCount).toBe(1);
+
+		// Mutations from the discarded batch are still in state
+		// (discardBatch only suppresses the emit, it does not
+		// roll back state).
+		expect(store.getSnapshot().chatStatus).toBe("completed");
+		expect(store.getSnapshot().streamError).toBe("oops");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// setCatchUpRenderPending
+// ---------------------------------------------------------------------------
+
+describe("setCatchUpRenderPending", () => {
+	it("sets and clears the flag", () => {
+		const store = createChatStore();
+
+		store.setCatchUpRenderPending(true);
+		expect(store.getSnapshot().catchUpRenderPending).toBe(true);
+
+		store.setCatchUpRenderPending(false);
+		expect(store.getSnapshot().catchUpRenderPending).toBe(false);
+	});
+
+	it("no-ops when setting the same value", () => {
+		const store = createChatStore();
+		let callCount = 0;
+		store.subscribe(() => {
+			callCount += 1;
+		});
+
+		store.setCatchUpRenderPending(true);
+		expect(callCount).toBe(1);
+
+		store.setCatchUpRenderPending(true);
+		expect(callCount).toBe(1);
+	});
+
+	it("resetTransientState clears catchUpRenderPending", () => {
+		const store = createChatStore();
+		store.setCatchUpRenderPending(true);
+
+		store.resetTransientState();
+
+		expect(store.getSnapshot().catchUpRenderPending).toBe(false);
+	});
+});

--- a/site/src/pages/AgentsPage/AgentDetailContent.tsx
+++ b/site/src/pages/AgentsPage/AgentDetailContent.tsx
@@ -10,6 +10,7 @@ import {
 	type UploadState,
 } from "./AgentChatInput";
 import {
+	selectCatchUpRenderPending,
 	selectChatStatus,
 	selectHasStreamState,
 	selectMessagesByID,
@@ -71,6 +72,10 @@ export const AgentDetailTimeline: FC<AgentDetailTimelineProps> = ({
 		selectSubagentStatusOverrides,
 	);
 	const retryState = useChatSelector(store, selectRetryState);
+	const catchUpRenderPending = useChatSelector(
+		store,
+		selectCatchUpRenderPending,
+	);
 
 	const messages = useMemo(
 		() =>
@@ -124,6 +129,7 @@ export const AgentDetailTimeline: FC<AgentDetailTimelineProps> = ({
 			editingMessageId={editingMessageId}
 			savingMessageId={savingMessageId}
 			urlTransform={urlTransform}
+			bypassSmoothing={catchUpRenderPending}
 		/>
 	);
 };


### PR DESCRIPTION
## Problem

When a user backgrounds a tab with an active agents chat and returns later,
queued WebSocket messages replay frame-by-frame. Each message triggers a
synchronous React render via `useSyncExternalStore`, causing a minutes-long
slow scroll through intermediate states.

## Approach

Detect tab hide/show via the Page Visibility API. On visible (after hidden),
open a store batch (`beginBatch`) that suppresses `emit()`. Each WS message
mutates the store normally but no React renders fire. When the browser's
message queue drains (`setTimeout(0)` fires without new messages), end the
batch, producing a single atomic render.

The catch-up path reuses the existing `handleMessage` event loop with
conditional branches: `startTransition` is bypassed (it's a no-op for
`useSyncExternalStore` anyway), and `scheduleStreamReset` is replaced by
a flag-based `catchUpPendingReset` that can't fire inside a batch.

After the catch-up render, `catchUpRenderPending` signals components to
bypass smooth-text animation for one frame. Cleared via RAF after paint.

## Key decisions

**Inline branches vs. separate buffer**: The catch-up path uses
`if (catchingUp)` branches inside `handleMessage` / `flushMessageParts`
rather than duplicating the event switch in a separate drain function.
Less code, single source of truth for event semantics.

**`SmoothedResponse` always renders when streaming**: Instead of swapping
between `<Response>` and `<SmoothedResponse>` based on `bypassSmoothing`
(which causes a remount and 120-char retraction flash), `bypassSmoothing`
is passed through to the engine. Same component, no unmount.

**Always clear stream state on reconnect**: `onOpen` clears stream state
unconditionally, even during catch-up. The server replays all message_part
events, so stale state must go to avoid text duplication.

**Transfer pending stream reset on visibility change**: If a
`scheduleStreamReset` RAF was paused while the tab was hidden, its intent
is transferred to `catchUpPendingReset` before the RAF is cancelled.

## SmoothText fix (independent)

Clamp `dtMs` to 100ms in `tick()`. After a long background pause where
the browser paused RAF, the first frame's delta could be minutes,
inflating `charBudget` to thousands. The per-frame cap meant this budget
drained over ~43 seconds. The clamp is in `tick()` (public API) not
`frame()` so all callers are protected.

## Testing

118 tests (was 103). Catch-up tests use shared helpers
(`setupCatchUpTest`, `setHidden`, `fireDrain`, `emitPart`) to reduce
boilerplate. Each regression test verified red by reverting the
corresponding production fix.

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻
