### PR TITLE
fix: guard against undefined text in chat message reasoning parts

### DIFF
--- a/site/src/pages/AgentsPage/AgentDetail/blockUtils.test.ts
+++ b/site/src/pages/AgentsPage/AgentDetail/blockUtils.test.ts
@@ -44,6 +44,15 @@ describe("appendTextBlock", () => {
 		expect(appendTextBlock(blocks, "thinking", "\n\t")).toBe(blocks);
 	});
 
+	it("returns the same blocks when text is undefined", () => {
+		const blocks: RenderBlock[] = [{ type: "response", text: "hello" }];
+		// Go's omitempty drops empty text fields, so the frontend
+		// can receive a part with type "reasoning" but no text.
+		expect(
+			appendTextBlock(blocks, "thinking", undefined as unknown as string),
+		).toBe(blocks);
+	});
+
 	it("appends a new response block to an empty list", () => {
 		const result = appendTextBlock([], "response", "hello");
 		expect(result).toEqual([{ type: "response", text: "hello" }]);

--- a/site/src/pages/AgentsPage/AgentDetail/blockUtils.ts
+++ b/site/src/pages/AgentsPage/AgentDetail/blockUtils.ts
@@ -15,7 +15,7 @@ export const appendTextBlock = (
 	type: "response" | "thinking",
 	text: string,
 ): RenderBlock[] => {
-	if (!text.trim()) {
+	if (!text?.trim()) {
 		return blocks;
 	}
 	const nextBlocks = [...blocks];

--- a/site/src/pages/AgentsPage/AgentDetail/messageParsing.test.ts
+++ b/site/src/pages/AgentsPage/AgentDetail/messageParsing.test.ts
@@ -109,6 +109,18 @@ describe("parseMessageContent", () => {
 		]);
 	});
 
+	it("handles a reasoning part with undefined text (omitempty)", () => {
+		// Go's omitempty drops the text field when it is empty,
+		// so the frontend receives {type: "reasoning"} with no
+		// text property.
+		const part = { type: "reasoning" } as unknown as Parameters<
+			typeof parseMessageContent
+		>[0][number];
+		const result = parseMessageContent([part]);
+		expect(result.reasoning).toBe("");
+		expect(result.blocks).toEqual([]);
+	});
+
 	it("parses a tool_use / tool-call block", () => {
 		const result = parseMessageContent([
 			{

--- a/site/src/pages/AgentsPage/AgentDetail/messageParsing.ts
+++ b/site/src/pages/AgentsPage/AgentDetail/messageParsing.ts
@@ -12,7 +12,7 @@ import type {
 
 /** Concatenate text chunks, skipping whitespace-only values. */
 const appendText = (current: string, next: string): string => {
-	if (!next.trim()) {
+	if (!next?.trim()) {
 		return current;
 	}
 	return `${current}${next}`;


### PR DESCRIPTION
Go serializes `ChatMessagePart` with `omitempty` on the `Text` field.
When a reasoning part has an empty string, the `text` field is omitted
from JSON. The frontend then receives `{type: "reasoning"}` with `text`
as `undefined`, and `appendText` / `appendTextBlock` crash on
`undefined.trim()`.

This happens when the AI provider emits a `reasoning_start` event with
an empty delta, which gets stored as a `ChatMessagePart` with empty
`Text`. On subsequent page loads, parsing the stored message triggers
the crash, making the entire agents chat page unusable.

Fix: guard both `appendText` (`messageParsing.ts`) and
`appendTextBlock` (`blockUtils.ts`) with optional chaining so
`undefined`/`null` text is treated the same as empty string.

Regression tests verify both functions handle `undefined` text without
throwing.