### PR TITLE
fix: rename chat logger from coderd.chats.chat-processor to coderd.chatd.processor

### DIFF
--- a/coderd/chatd/chatd.go
+++ b/coderd/chatd/chatd.go
@@ -1308,7 +1308,7 @@ func New(cfg Config) *Server {
 		closed:                     make(chan struct{}),
 		db:                         cfg.Database,
 		workerID:                   workerID,
-		logger:                     cfg.Logger.Named("chat-processor"),
+		logger:                     cfg.Logger.Named("processor"),
 		subscribeFn:                cfg.SubscribeFn,
 		agentConnFn:                cfg.AgentConn,
 		createWorkspaceFn:          cfg.CreateWorkspace,

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -776,7 +776,7 @@ func New(options *Options) *API {
 	}
 
 	api.chatDaemon = chatd.New(chatd.Config{
-		Logger:             options.Logger.Named("chats"),
+		Logger:             options.Logger.Named("chatd"),
 		Database:           options.Database,
 		ReplicaID:          api.ID,
 		SubscribeFn:        options.ChatSubscribeFn,


### PR DESCRIPTION
- Rename logger `coderd.chats` to `coderd.chatd` in `coderd.go`
- Rename sub-logger `chat-processor` to `processor` in `chatd/chatd.go`

> 🤖 This PR was created with the help of Coder Agents, and will be reviewed by my human.  🧑‍💻