### PR TITLE
fix: make reasoning part text optional in generated types

### DIFF
--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -127,7 +127,7 @@ func AllChatMessagePartTypes() []ChatMessagePartType {
 // scripts/apitypings/main.go for the codegen that reads these.
 type ChatMessagePart struct {
 	Type        ChatMessagePartType `json:"type"`
-	Text        string              `json:"text,omitempty" variants:"text,reasoning"`
+	Text        string              `json:"text,omitempty" variants:"text,reasoning?"`
 	Signature   string              `json:"signature,omitempty"`
 	ToolCallID  string              `json:"tool_call_id,omitempty" variants:"tool-call?,tool-result?"`
 	ToolName    string              `json:"tool_name,omitempty" variants:"tool-call?,tool-result?"`

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1682,7 +1682,7 @@ export interface ChatQueuedMessage {
 // From codersdk/chats.go
 export interface ChatReasoningPart {
 	readonly type: "reasoning";
-	readonly text: string;
+	readonly text?: string;
 }
 
 // From codersdk/chats.go

--- a/site/src/pages/AgentsPage/AgentDetail/messageParsing.ts
+++ b/site/src/pages/AgentsPage/AgentDetail/messageParsing.ts
@@ -131,8 +131,9 @@ export const parseMessageContent = (
 				break;
 			}
 			case "reasoning": {
-				parsed.reasoning = appendText(parsed.reasoning, part.text);
-				parsed.blocks = appendTextBlock(parsed.blocks, "thinking", part.text);
+				const text = part.text ?? "";
+				parsed.reasoning = appendText(parsed.reasoning, text);
+				parsed.blocks = appendTextBlock(parsed.blocks, "thinking", text);
 				break;
 			}
 			case "tool-call": {


### PR DESCRIPTION
Go serializes `ChatMessagePart.Text` with `omitempty`, so empty
reasoning text (from `reasoning_start` with no delta) is omitted
from JSON. The frontend receives `{type: "reasoning"}` with `text`
as `undefined`, crashing on `.trim()` calls in `appendText` and
`appendTextBlock`.

This changes the `variants` struct tag on `Text` from
`"text,reasoning"` to `"text,reasoning?"`, generating
`ChatReasoningPart` with `text?: string`. The frontend coalesces
with `?? ""`.

Closes #23245.

> 🤖 This PR was created with the help of Coder Agents, and has been reviewed by a human. 🏂🏻