### PR TITLE
feat: add Alpine Linux OpenRC service support

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -267,6 +267,9 @@ To run a Coder server:
   $ sudo rc-service coder start
   $ sudo rc-update add coder default
 
+  # View logs
+  $ tail -f /var/log/coder.log
+
   # Or just run the server directly
   $ coder server
 

--- a/install.sh
+++ b/install.sh
@@ -248,6 +248,37 @@ To connect to a Coder deployment:
 EOF
 }
 
+echo_openrc_postinstall() {
+	if [ "${DRY_RUN-}" ]; then
+		echo_dryrun_postinstall
+		return
+	fi
+
+	echoh
+	cath <<EOF
+$1 package has been installed.
+
+To run a Coder server:
+
+  # Edit the configuration!
+  $ sudo vi /etc/coder.d/coder.env
+
+  # Start Coder now and on reboot
+  $ sudo rc-service coder start
+  $ sudo rc-update add coder default
+
+  # Or just run the server directly
+  $ coder server
+
+  Configuring Coder: https://coder.com/docs/admin/setup
+
+To connect to a Coder deployment:
+
+  $ coder login <deployment url>
+
+EOF
+}
+
 echo_dryrun_postinstall() {
 	cath <<EOF
 Dry-run complete.
@@ -645,7 +676,7 @@ install_apk() {
 		"$CACHE_DIR/coder_${VERSION}_${OS}_${ARCH}.apk"
 	sudo_sh_c apk add --allow-untrusted "$CACHE_DIR/coder_${VERSION}_${OS}_${ARCH}.apk"
 
-	echo_systemd_postinstall apk
+	echo_openrc_postinstall apk
 }
 
 install_standalone() {

--- a/scripts/linux-pkg/coder-workspace-proxy.openrc
+++ b/scripts/linux-pkg/coder-workspace-proxy.openrc
@@ -1,0 +1,33 @@
+#!/sbin/openrc-run
+
+name="coder-workspace-proxy"
+description="Coder - external workspace proxy server"
+
+command="/usr/bin/coder"
+command_args="workspace-proxy server"
+command_user="coder:coder"
+command_background=true
+
+pidfile="/run/${RC_SVCNAME}.pid"
+output_log="/var/log/${RC_SVCNAME}.log"
+error_log="/var/log/${RC_SVCNAME}.log"
+
+# Load environment variables from the same file as the systemd service.
+start_pre() {
+    if [ ! -f /etc/coder.d/coder-workspace-proxy.env ]; then
+        eerror "Config file /etc/coder.d/coder-workspace-proxy.env not found"
+        return 1
+    fi
+    # Export all variables from the env file, skipping comments
+    # and blank lines.
+    set -a
+    . /etc/coder.d/coder-workspace-proxy.env
+    set +a
+}
+
+depend() {
+    need net
+    after firewall
+}
+
+retry="SIGINT/30 SIGINT/30 SIGKILL/10"

--- a/scripts/linux-pkg/coder-workspace-proxy.openrc
+++ b/scripts/linux-pkg/coder-workspace-proxy.openrc
@@ -30,4 +30,4 @@ depend() {
     after firewall
 }
 
-retry="SIGINT/30 SIGINT/30 SIGKILL/10"
+retry="SIGINT/30/SIGINT/30/SIGKILL/10"

--- a/scripts/linux-pkg/coder-workspace-proxy.openrc
+++ b/scripts/linux-pkg/coder-workspace-proxy.openrc
@@ -6,9 +6,11 @@ description="Coder - external workspace proxy server"
 command="/usr/bin/coder"
 command_args="workspace-proxy server"
 command_user="coder:coder"
-command_background=true
+supervisor="supervise-daemon"
+respawn_delay=5
+respawn_max=10
+respawn_period=60
 
-pidfile="/run/${RC_SVCNAME}.pid"
 output_log="/var/log/${RC_SVCNAME}.log"
 error_log="/var/log/${RC_SVCNAME}.log"
 
@@ -18,8 +20,8 @@ start_pre() {
         eerror "Config file /etc/coder.d/coder-workspace-proxy.env not found"
         return 1
     fi
-    # Export all variables from the env file, skipping comments
-    # and blank lines.
+    # Source the env file. The shell naturally ignores comments
+    # and blank lines. set -a auto-exports all assignments.
     set -a
     . /etc/coder.d/coder-workspace-proxy.env
     set +a
@@ -30,4 +32,13 @@ depend() {
     after firewall
 }
 
-retry="SIGINT/30/SIGINT/30/SIGKILL/10"
+# NOTE: The systemd unit includes sandboxing (ProtectSystem,
+# PrivateTmp, NoNewPrivileges, etc.) that OpenRC does not
+# natively support. Consider additional hardening if running
+# in a security-sensitive environment.
+
+# Logs are written to /var/log/coder-workspace-proxy.log.
+# Unlike systemd's journald, OpenRC does not rotate logs
+# automatically. Consider configuring logrotate for this file.
+
+retry="SIGINT/90/SIGKILL/10"

--- a/scripts/linux-pkg/coder.openrc
+++ b/scripts/linux-pkg/coder.openrc
@@ -30,4 +30,4 @@ depend() {
     after firewall
 }
 
-retry="SIGINT/30 SIGINT/30 SIGKILL/10"
+retry="SIGINT/30/SIGINT/30/SIGKILL/10"

--- a/scripts/linux-pkg/coder.openrc
+++ b/scripts/linux-pkg/coder.openrc
@@ -1,0 +1,33 @@
+#!/sbin/openrc-run
+
+name="coder"
+description="Coder - Self-hosted developer workspaces on your infra"
+
+command="/usr/bin/coder"
+command_args="server"
+command_user="coder:coder"
+command_background=true
+
+pidfile="/run/${RC_SVCNAME}.pid"
+output_log="/var/log/${RC_SVCNAME}.log"
+error_log="/var/log/${RC_SVCNAME}.log"
+
+# Load environment variables from the same file as the systemd service.
+start_pre() {
+    if [ ! -f /etc/coder.d/coder.env ]; then
+        eerror "Config file /etc/coder.d/coder.env not found"
+        return 1
+    fi
+    # Export all variables from the env file, skipping comments
+    # and blank lines.
+    set -a
+    . /etc/coder.d/coder.env
+    set +a
+}
+
+depend() {
+    need net
+    after firewall
+}
+
+retry="SIGINT/30 SIGINT/30 SIGKILL/10"

--- a/scripts/linux-pkg/coder.openrc
+++ b/scripts/linux-pkg/coder.openrc
@@ -6,9 +6,11 @@ description="Coder - Self-hosted developer workspaces on your infra"
 command="/usr/bin/coder"
 command_args="server"
 command_user="coder:coder"
-command_background=true
+supervisor="supervise-daemon"
+respawn_delay=5
+respawn_max=10
+respawn_period=60
 
-pidfile="/run/${RC_SVCNAME}.pid"
 output_log="/var/log/${RC_SVCNAME}.log"
 error_log="/var/log/${RC_SVCNAME}.log"
 
@@ -18,8 +20,8 @@ start_pre() {
         eerror "Config file /etc/coder.d/coder.env not found"
         return 1
     fi
-    # Export all variables from the env file, skipping comments
-    # and blank lines.
+    # Source the env file. The shell naturally ignores comments
+    # and blank lines. set -a auto-exports all assignments.
     set -a
     . /etc/coder.d/coder.env
     set +a
@@ -30,4 +32,13 @@ depend() {
     after firewall
 }
 
-retry="SIGINT/30/SIGINT/30/SIGKILL/10"
+# NOTE: The systemd unit includes sandboxing (ProtectSystem,
+# PrivateTmp, NoNewPrivileges, etc.) that OpenRC does not
+# natively support. Consider additional hardening if running
+# in a security-sensitive environment.
+
+# Logs are written to /var/log/coder.log. Unlike systemd's
+# journald, OpenRC does not rotate logs automatically.
+# Consider configuring logrotate for this file.
+
+retry="SIGINT/90/SIGKILL/10"

--- a/scripts/linux-pkg/nfpm.yaml
+++ b/scripts/linux-pkg/nfpm.yaml
@@ -25,5 +25,23 @@ contents:
     type: "config|noreplace"
   - src: coder.service
     dst: /usr/lib/systemd/system/coder.service
+    packager: deb
+  - src: coder.service
+    dst: /usr/lib/systemd/system/coder.service
+    packager: rpm
   - src: coder-workspace-proxy.service
     dst: /usr/lib/systemd/system/coder-workspace-proxy.service
+    packager: deb
+  - src: coder-workspace-proxy.service
+    dst: /usr/lib/systemd/system/coder-workspace-proxy.service
+    packager: rpm
+  - src: coder.openrc
+    dst: /etc/init.d/coder
+    file_info:
+      mode: 0755
+    packager: apk
+  - src: coder-workspace-proxy.openrc
+    dst: /etc/init.d/coder-workspace-proxy
+    file_info:
+      mode: 0755
+    packager: apk

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -86,6 +86,8 @@ ln "$input_file" "$temp_dir/coder"
 ln "$(realpath coder.env)" "$temp_dir/"
 ln "$(realpath scripts/linux-pkg/coder-workspace-proxy.service)" "$temp_dir/"
 ln "$(realpath scripts/linux-pkg/coder.service)" "$temp_dir/"
+ln "$(realpath scripts/linux-pkg/coder.openrc)" "$temp_dir/"
+ln "$(realpath scripts/linux-pkg/coder-workspace-proxy.openrc)" "$temp_dir/"
 ln "$(realpath scripts/linux-pkg/nfpm.yaml)" "$temp_dir/"
 ln "$(realpath scripts/linux-pkg/preinstall.sh)" "$temp_dir/"
 


### PR DESCRIPTION
## Problem

Coder only ships systemd service files. On Alpine Linux (which uses OpenRC), the install script incorrectly tells users to run `systemctl`, and no service file is created.

## Solution

- Add OpenRC init scripts for `coder` and `coder-workspace-proxy`
- Include them in apk packages via nfpm
- Fix the install script to show correct OpenRC commands on Alpine

The OpenRC scripts mirror the systemd service behavior:
- Run as `coder:coder` user/group
- Load env vars from `/etc/coder.d/coder.env`
- Depend on network
- Use SIGINT for graceful shutdown (matching `KillSignal=SIGINT`)

Fixes #12294