### PR TITLE
fix(site): fix browser back navigation between agents settings pages

### DIFF
--- a/site/src/pages/AgentsPage/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/AgentsSidebar.tsx
@@ -962,7 +962,6 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 							label="Behavior"
 							active={sidebarView.section === "behavior"}
 							to="/agents/settings/behavior"
-							replace
 							state={location.state}
 						/>
 						{isAdmin && (
@@ -972,7 +971,6 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 									label="Providers"
 									active={sidebarView.section === "providers"}
 									to="/agents/settings/providers"
-									replace
 									state={location.state}
 									adminOnly
 								/>
@@ -981,7 +979,6 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 									label="Models"
 									active={sidebarView.section === "models"}
 									to="/agents/settings/models"
-									replace
 									state={location.state}
 									adminOnly
 								/>
@@ -990,7 +987,6 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 									label="Limits"
 									active={sidebarView.section === "limits"}
 									to="/agents/settings/limits"
-									replace
 									state={location.state}
 									adminOnly
 								/>
@@ -999,7 +995,6 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 									label="Usage"
 									active={sidebarView.section === "usage"}
 									to="/agents/settings/usage"
-									replace
 									state={location.state}
 									adminOnly
 								/>
@@ -1008,7 +1003,6 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 									label="Analytics"
 									active={sidebarView.section === "insights"}
 									to="/agents/settings/insights"
-									replace
 									state={location.state}
 									adminOnly
 								/>{" "}


### PR DESCRIPTION
## Bug

Browser back-button navigation doesn't work between agents settings pages.

**Repro:**
1. Start on main agents page (`/agents`)
2. Go to `/agents/settings`
3. Go to `/agents/settings/limits` (or any other settings sub-page)
4. Press back

**Expected:** Return to `/agents/settings`
**Actual:** Skips `/agents/settings` and returns to the previous chat

## Root Cause

All six `SettingsNavItem` links in `AgentsSidebar.tsx` used the `replace` prop. The first tab click replaced the `/agents/settings` history entry, so the browser had nothing to go back to.

## Fix

Remove the `replace` prop. Each tab click now pushes a normal history entry. Back-navigation works as expected.