### PR TITLE
fix: add keyboard accessibility to TooltipTrigger for non-button elements

### DIFF
--- a/site/src/components/Tooltip/Tooltip.test.tsx
+++ b/site/src/components/Tooltip/Tooltip.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "./Tooltip";
+
+describe("TooltipTrigger", () => {
+	it("injects tabIndex={0} on non-focusable child when asChild is used", () => {
+		render(
+			<TooltipProvider>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<span>hover me</span>
+					</TooltipTrigger>
+					<TooltipContent>Tooltip text</TooltipContent>
+				</Tooltip>
+			</TooltipProvider>,
+		);
+
+		const trigger = screen.getByText("hover me");
+		expect(trigger.tagName).toBe("SPAN");
+		expect(trigger).toHaveAttribute("tabindex", "0");
+	});
+
+	it("respects an explicit tabIndex on the child element", () => {
+		render(
+			<TooltipProvider>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<span tabIndex={-1}>not focusable</span>
+					</TooltipTrigger>
+					<TooltipContent>Tooltip text</TooltipContent>
+				</Tooltip>
+			</TooltipProvider>,
+		);
+
+		const trigger = screen.getByText("not focusable");
+		expect(trigger).toHaveAttribute("tabindex", "-1");
+	});
+
+	it("shows tooltip when non-focusable element receives keyboard focus", async () => {
+		const user = userEvent.setup();
+
+		render(
+			<TooltipProvider>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<span>focus me</span>
+					</TooltipTrigger>
+					<TooltipContent>Keyboard tooltip</TooltipContent>
+				</Tooltip>
+			</TooltipProvider>,
+		);
+
+		const trigger = screen.getByText("focus me");
+		expect(trigger).toHaveAttribute("tabindex", "0");
+
+		await user.tab();
+		expect(trigger).toHaveFocus();
+
+		await waitFor(() => {
+			expect(screen.getByRole("tooltip")).toBeInTheDocument();
+		});
+	});
+});

--- a/site/src/components/Tooltip/Tooltip.tsx
+++ b/site/src/components/Tooltip/Tooltip.tsx
@@ -3,6 +3,7 @@
  * @see {@link https://ui.shadcn.com/docs/components/tooltip}
  */
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import { cloneElement, isValidElement, type ReactElement } from "react";
 import { cn } from "utils/cn";
 
 export const TooltipProvider = TooltipPrimitive.Provider;
@@ -11,7 +12,34 @@ export type TooltipProps = TooltipPrimitive.TooltipProps;
 
 export const Tooltip = TooltipPrimitive.Root;
 
-export const TooltipTrigger = TooltipPrimitive.Trigger;
+// When asChild is used with non-focusable elements (div, span, Pill,
+// Badge, SVG icons), they need tabIndex to be reachable via keyboard.
+// Radix's TooltipTrigger uses Primitive.button internally which is
+// natively focusable, but Slot (used with asChild) doesn't add tabIndex
+// to non-focusable elements. We inject tabIndex={0} unless the child
+// already specifies one.
+export const TooltipTrigger: React.FC<
+	React.ComponentPropsWithRef<typeof TooltipPrimitive.Trigger>
+> = ({ children, asChild, ref, ...props }) => {
+	if (asChild && isValidElement(children)) {
+		const childProps = children.props as Record<string, unknown>;
+		if (childProps.tabIndex === undefined) {
+			return (
+				<TooltipPrimitive.Trigger asChild ref={ref} {...props}>
+					{cloneElement(children as ReactElement<{ tabIndex?: number }>, {
+						tabIndex: 0,
+					})}
+				</TooltipPrimitive.Trigger>
+			);
+		}
+	}
+
+	return (
+		<TooltipPrimitive.Trigger asChild={asChild} ref={ref} {...props}>
+			{children}
+		</TooltipPrimitive.Trigger>
+	);
+};
 
 export const TooltipArrow = TooltipPrimitive.Arrow;
 


### PR DESCRIPTION
When `TooltipTrigger` is used with `asChild` and a non-focusable element (div, span, Pill, Badge, etc.), the element is unreachable via keyboard because Radix's Slot doesn't inject `tabIndex`.

This wraps `TooltipTrigger` to inject `tabIndex={0}` on child elements when:
- `asChild` is true
- The child doesn't already have an explicit `tabIndex`

This is a no-op for native button elements (which already have implicit tabIndex=0).

Fixes #14776