### PR TITLE
refactor: consolidate provisionersdk Tar/Untar and improve security

### DIFF
--- a/provisionersdk/archive.go
+++ b/provisionersdk/archive.go
@@ -72,14 +72,9 @@ func Tar(w io.Writer, logger slog.Logger, directory string, limit int64) error {
 		if err != nil {
 			return err
 		}
-		// Skip symlinks entirely. Neither Untar nor extractArchive
-		// restores symlinks, so including them is pointless and can
-		// be a security concern.
-		// See: https://github.com/coder/coder/issues/16163
+		// Symlinks are skipped because neither Untar nor extractArchive
+		// restore them. See #16163.
 		if fileInfo.Mode()&os.ModeSymlink != 0 {
-			if fileInfo.IsDir() {
-				return filepath.SkipDir
-			}
 			return nil
 		}
 		header, err := tar.FileInfoHeader(fileInfo, "")

--- a/provisionersdk/archive.go
+++ b/provisionersdk/archive.go
@@ -17,6 +17,9 @@ import (
 const (
 	// TemplateArchiveLimit represents the maximum size of a template in bytes.
 	TemplateArchiveLimit = 1 << 20
+
+	// defaultFileMode is used when a tar entry has no mode set.
+	defaultFileMode = 0o600
 )
 
 func dirHasExt(dir string, exts ...string) (bool, error) {
@@ -69,14 +72,17 @@ func Tar(w io.Writer, logger slog.Logger, directory string, limit int64) error {
 		if err != nil {
 			return err
 		}
-		var link string
-		if fileInfo.Mode()&os.ModeSymlink == os.ModeSymlink {
-			link, err = os.Readlink(file)
-			if err != nil {
-				return err
+		// Skip symlinks entirely. Neither Untar nor extractArchive
+		// restores symlinks, so including them is pointless and can
+		// be a security concern.
+		// See: https://github.com/coder/coder/issues/16163
+		if fileInfo.Mode()&os.ModeSymlink != 0 {
+			if fileInfo.IsDir() {
+				return filepath.SkipDir
 			}
+			return nil
 		}
-		header, err := tar.FileInfoHeader(fileInfo, link)
+		header, err := tar.FileInfoHeader(fileInfo, "")
 		if err != nil {
 			return err
 		}
@@ -155,40 +161,57 @@ func Untar(directory string, r io.Reader) error {
 			return nil
 		}
 		if err != nil {
-			return err
+			return xerrors.Errorf("read tar archive: %w", err)
 		}
-		if header.Name == "." || strings.Contains(header.Name, "..") {
+
+		// Use filepath.IsLocal for robust path traversal protection.
+		// This rejects absolute paths, paths containing "..", and
+		// other non-local path constructs.
+		if !filepath.IsLocal(header.Name) {
 			continue
 		}
-		// #nosec
+
+		// Skip symlinks explicitly. Neither Tar nor extractArchive
+		// handles restoring symlinks, and they can be a security
+		// concern (e.g. symlink-following attacks).
+		// See: https://github.com/coder/coder/issues/16163
+		if header.Typeflag == tar.TypeSymlink || header.Typeflag == tar.TypeLink {
+			continue
+		}
+
+		mode := header.FileInfo().Mode()
+		if mode == 0 {
+			mode = defaultFileMode
+		}
+
+		// nolint: gosec // filepath.IsLocal check above prevents traversal.
 		target := filepath.Join(directory, filepath.FromSlash(header.Name))
 		switch header.Typeflag {
 		case tar.TypeDir:
-			if _, err := os.Stat(target); err != nil {
-				if err := os.MkdirAll(target, 0o755); err != nil {
-					return err
-				}
+			if err := os.MkdirAll(target, mode|os.ModeDir); err != nil {
+				return xerrors.Errorf("mkdir %q: %w", target, err)
 			}
 		case tar.TypeReg:
-			// #nosec G115 - Safe conversion as tar header mode fits within uint32
-			err := os.MkdirAll(filepath.Dir(target), os.FileMode(header.Mode)|os.ModeDir|100)
+			err := os.MkdirAll(filepath.Dir(target), 0o755)
 			if err != nil {
-				return err
+				return xerrors.Errorf("mkdir parent of %q: %w", target, err)
 			}
-			// #nosec G115 - Safe conversion as tar header mode fits within uint32
-			file, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR|os.O_TRUNC, os.FileMode(header.Mode))
+			file, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR|os.O_TRUNC, mode)
 			if err != nil {
-				return err
+				return xerrors.Errorf("create file %q: %w", target, err)
 			}
-			// Max file size of 10MB.
-			_, err = io.CopyN(file, tarReader, (1<<20)*10)
+			// Max file size of 10 MiB.
+			_, err = io.CopyN(file, tarReader, 10<<20)
 			if xerrors.Is(err, io.EOF) {
 				err = nil
 			}
 			if err != nil {
-				return err
+				_ = file.Close()
+				return xerrors.Errorf("copy file %q: %w", target, err)
 			}
-			_ = file.Close()
+			if err = file.Close(); err != nil {
+				return xerrors.Errorf("close file %q: %w", target, err)
+			}
 		}
 	}
 }

--- a/provisionersdk/archive.go
+++ b/provisionersdk/archive.go
@@ -175,8 +175,12 @@ func Untar(directory string, r io.Reader) error {
 		}
 
 		mode := header.FileInfo().Mode()
-		if mode == 0 {
-			mode = defaultFileMode
+		if mode.Perm() == 0 {
+			if header.Typeflag == tar.TypeDir {
+				mode = os.ModeDir | 0o755
+			} else {
+				mode = defaultFileMode
+			}
 		}
 
 		// nolint: gosec // filepath.IsLocal check above prevents traversal.

--- a/provisionersdk/archive_test.go
+++ b/provisionersdk/archive_test.go
@@ -370,6 +370,47 @@ func TestUntar(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("ZeroModeDirFallback", func(t *testing.T) {
+		t.Parallel()
+
+		// Create a tar with a directory that has zero mode bits
+		// and a regular file inside it.
+		var buf bytes.Buffer
+		tw := tar.NewWriter(&buf)
+		err := tw.WriteHeader(&tar.Header{
+			Name:     "zerodir/",
+			Mode:     0,
+			Typeflag: tar.TypeDir,
+		})
+		require.NoError(t, err)
+		err = tw.WriteHeader(&tar.Header{
+			Name:     "zerodir/hello.txt",
+			Mode:     0o644,
+			Size:     5,
+			Typeflag: tar.TypeReg,
+		})
+		require.NoError(t, err)
+		_, err = tw.Write([]byte("world"))
+		require.NoError(t, err)
+		require.NoError(t, tw.Close())
+
+		dir := t.TempDir()
+		err = provisionersdk.Untar(dir, &buf)
+		require.NoError(t, err)
+
+		// The directory should have 0o755 permissions.
+		info, err := os.Stat(filepath.Join(dir, "zerodir"))
+		require.NoError(t, err)
+		require.True(t, info.IsDir())
+		require.Equal(t, os.FileMode(0o755), info.Mode().Perm(),
+			"zero-mode directory should get 0o755 fallback permissions")
+
+		// The file inside should be extracted successfully.
+		content, err := os.ReadFile(filepath.Join(dir, "zerodir", "hello.txt"))
+		require.NoError(t, err)
+		require.Equal(t, "world", string(content))
+	})
+
 	t.Run("ZeroModeFallback", func(t *testing.T) {
 		t.Parallel()
 

--- a/provisionersdk/archive_test.go
+++ b/provisionersdk/archive_test.go
@@ -1,6 +1,7 @@
 package provisionersdk_test
 
 import (
+	"archive/tar"
 	"bytes"
 	"io"
 	"os"
@@ -35,6 +36,38 @@ func TestTar(t *testing.T) {
 		err = provisionersdk.Tar(io.Discard, log, dir, 1024*1024)
 		require.NoError(t, err)
 	})
+
+	t.Run("SkipsSymlinks", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+
+		// Create a real .tf file.
+		err := os.WriteFile(filepath.Join(dir, "main.tf"), []byte("# real"), 0o644)
+		require.NoError(t, err)
+
+		// Create a symlink to a file and a dangling symlink.
+		err = os.Symlink(filepath.Join(dir, "main.tf"), filepath.Join(dir, "linked.tf"))
+		require.NoError(t, err)
+		err = os.Symlink("no-target", filepath.Join(dir, "dangling"))
+		require.NoError(t, err)
+
+		var buf bytes.Buffer
+		err = provisionersdk.Tar(&buf, log, dir, 1024*1024)
+		require.NoError(t, err)
+
+		// Read the archive and verify no symlink entries exist.
+		tr := tar.NewReader(&buf)
+		for {
+			hdr, err := tr.Next()
+			if err == io.EOF {
+				break
+			}
+			require.NoError(t, err)
+			require.NotEqual(t, tar.TypeSymlink, hdr.Typeflag,
+				"symlink entry %q should not be in archive", hdr.Name)
+		}
+	})
+
 	t.Run("HeaderBreakLimit", func(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
@@ -248,5 +281,124 @@ func TestUntar(t *testing.T) {
 		content, err := os.ReadFile(filepath.Join(dir2, filepath.Base(file.Name())))
 		require.NoError(t, err)
 		require.Equal(t, "# c", string(content))
+	})
+
+	t.Run("PathTraversal", func(t *testing.T) {
+		t.Parallel()
+
+		// Create a tar archive with a path traversal entry.
+		var buf bytes.Buffer
+		tw := tar.NewWriter(&buf)
+		// Write a file with a "../" prefix to attempt traversal.
+		err := tw.WriteHeader(&tar.Header{
+			Name:     "../etc/passwd",
+			Mode:     0o644,
+			Size:     4,
+			Typeflag: tar.TypeReg,
+		})
+		require.NoError(t, err)
+		_, err = tw.Write([]byte("evil"))
+		require.NoError(t, err)
+		// Also write a valid file to confirm extraction still works.
+		err = tw.WriteHeader(&tar.Header{
+			Name:     "safe.txt",
+			Mode:     0o644,
+			Size:     4,
+			Typeflag: tar.TypeReg,
+		})
+		require.NoError(t, err)
+		_, err = tw.Write([]byte("good"))
+		require.NoError(t, err)
+		require.NoError(t, tw.Close())
+
+		dir := t.TempDir()
+		err = provisionersdk.Untar(dir, &buf)
+		require.NoError(t, err)
+
+		// The traversal file must not exist anywhere.
+		_, err = os.Stat(filepath.Join(dir, "..", "etc", "passwd"))
+		require.ErrorIs(t, err, os.ErrNotExist)
+
+		// The safe file should exist.
+		_, err = os.Stat(filepath.Join(dir, "safe.txt"))
+		require.NoError(t, err)
+	})
+
+	t.Run("SkipsSymlinks", func(t *testing.T) {
+		t.Parallel()
+
+		// Create a tar archive containing a symlink entry.
+		var buf bytes.Buffer
+		tw := tar.NewWriter(&buf)
+		err := tw.WriteHeader(&tar.Header{
+			Name:     "link",
+			Linkname: "/etc/passwd",
+			Typeflag: tar.TypeSymlink,
+		})
+		require.NoError(t, err)
+		// Also add a hard link entry.
+		err = tw.WriteHeader(&tar.Header{
+			Name:     "hardlink",
+			Linkname: "link",
+			Typeflag: tar.TypeLink,
+		})
+		require.NoError(t, err)
+		// Add a regular file so the archive is not empty.
+		err = tw.WriteHeader(&tar.Header{
+			Name:     "real.txt",
+			Mode:     0o644,
+			Size:     5,
+			Typeflag: tar.TypeReg,
+		})
+		require.NoError(t, err)
+		_, err = tw.Write([]byte("hello"))
+		require.NoError(t, err)
+		require.NoError(t, tw.Close())
+
+		dir := t.TempDir()
+		err = provisionersdk.Untar(dir, &buf)
+		require.NoError(t, err)
+
+		// Symlink and hardlink must not exist.
+		_, err = os.Lstat(filepath.Join(dir, "link"))
+		require.ErrorIs(t, err, os.ErrNotExist)
+		_, err = os.Lstat(filepath.Join(dir, "hardlink"))
+		require.ErrorIs(t, err, os.ErrNotExist)
+
+		// Regular file should be extracted.
+		_, err = os.Stat(filepath.Join(dir, "real.txt"))
+		require.NoError(t, err)
+	})
+
+	t.Run("ZeroModeFallback", func(t *testing.T) {
+		t.Parallel()
+
+		// Create a tar with a file that has zero mode bits.
+		var buf bytes.Buffer
+		tw := tar.NewWriter(&buf)
+		err := tw.WriteHeader(&tar.Header{
+			Name:     "nomode.txt",
+			Mode:     0,
+			Size:     3,
+			Typeflag: tar.TypeReg,
+		})
+		require.NoError(t, err)
+		_, err = tw.Write([]byte("abc"))
+		require.NoError(t, err)
+		require.NoError(t, tw.Close())
+
+		dir := t.TempDir()
+		err = provisionersdk.Untar(dir, &buf)
+		require.NoError(t, err)
+
+		// The file should exist and be readable.
+		content, err := os.ReadFile(filepath.Join(dir, "nomode.txt"))
+		require.NoError(t, err)
+		require.Equal(t, "abc", string(content))
+
+		// The file mode should be the fallback (0o600).
+		info, err := os.Stat(filepath.Join(dir, "nomode.txt"))
+		require.NoError(t, err)
+		require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
 	})
 }

--- a/provisionersdk/archive_test.go
+++ b/provisionersdk/archive_test.go
@@ -42,7 +42,7 @@ func TestTar(t *testing.T) {
 		dir := t.TempDir()
 
 		// Create a real .tf file.
-		err := os.WriteFile(filepath.Join(dir, "main.tf"), []byte("# real"), 0o644)
+		err := os.WriteFile(filepath.Join(dir, "main.tf"), []byte("# real"), 0o600)
 		require.NoError(t, err)
 
 		// Create a symlink to a file and a dangling symlink.


### PR DESCRIPTION
## Problem

`provisionersdk.Untar()` and `tfpath.extractArchive()` are two separate tar extraction implementations with divergent behavior:
- `Untar` has weak path traversal checks (`.`/`..` string checks), no symlink handling, no zero-mode fallback, and discards file close errors
- `extractArchive` has robust security (`filepath.IsLocal`), zero-mode fallback, CRC32 checksums, and proper error wrapping

Additionally, `Tar()` writes symlink entries (`TypeSymlink`) that neither extractor can restore — they're silently dropped.

## Solution

**`Untar` improvements:**
- Replace weak `.`/`..` string check with `filepath.IsLocal` for robust path traversal protection
- Add explicit symlink skipping (`TypeSymlink` and `TypeLink`)
- Add zero-mode fallback (0o600) for files with no mode set
- Fix file close error handling (was discarding close errors)
- Use `os.MkdirAll` directly instead of stat-then-create pattern for directories
- Use `xerrors.Errorf` for consistent error wrapping with context

**`Tar` improvements:**
- Skip symlinks entirely instead of writing `TypeSymlink` entries that no extractor restores
- Pass empty string for link name to `tar.FileInfoHeader` since symlinks are skipped

**Tests added:**
- Path traversal: verifies `../etc/passwd` entries are rejected
- Symlink skipping in Untar: verifies `TypeSymlink` and `TypeLink` entries are safely dropped
- Symlink skipping in Tar: verifies symlinks in the source directory are not included in the archive
- Zero-mode fallback: verifies files with mode 0 get created with 0o600

This is Phase 1 of the refactor. Phase 2 (consolidating `extractArchive` callers with `Untar`) can follow once this is validated.

Fixes #16163