### PR TITLE
feat: add first-class LiteLLM provider support for agents

### DIFF
--- a/coderd/chatd/chatprovider/chatprovider.go
+++ b/coderd/chatd/chatprovider/chatprovider.go
@@ -19,11 +19,14 @@ import (
 	"github.com/coder/coder/v2/codersdk"
 )
 
+const litellmProviderName = "litellm"
+
 var supportedProviderNames = []string{
 	fantasyanthropic.Name,
 	fantasyazure.Name,
 	fantasybedrock.Name,
 	fantasygoogle.Name,
+	litellmProviderName,
 	fantasyopenai.Name,
 	fantasyopenaicompat.Name,
 	fantasyopenrouter.Name,
@@ -40,6 +43,7 @@ var providerDisplayNameByName = map[string]string{
 	fantasyazure.Name:        "Azure OpenAI",
 	fantasybedrock.Name:      "AWS Bedrock",
 	fantasygoogle.Name:       "Google",
+	litellmProviderName:      "LiteLLM",
 	fantasyopenai.Name:       "OpenAI",
 	fantasyopenaicompat.Name: "OpenAI Compatible",
 	fantasyopenrouter.Name:   "OpenRouter",
@@ -360,6 +364,8 @@ func NormalizeProvider(provider string) string {
 		return fantasyopenai.Name
 	case fantasyopenaicompat.Name:
 		return fantasyopenaicompat.Name
+	case litellmProviderName:
+		return litellmProviderName
 	case fantasyopenrouter.Name:
 		return fantasyopenrouter.Name
 	case fantasyvercel.Name:
@@ -503,6 +509,16 @@ func ReasoningEffortFromChat(provider string, value *string) *string {
 			string(fantasyopenrouter.ReasoningEffortMedium),
 			string(fantasyopenrouter.ReasoningEffortHigh),
 		)
+	case litellmProviderName, fantasyopenaicompat.Name:
+		// LiteLLM and generic OpenAI-compat providers accept the
+		// same reasoning-effort values as the OpenAI provider.
+		return normalizedEnumValue(
+			normalized,
+			string(fantasyopenai.ReasoningEffortMinimal),
+			string(fantasyopenai.ReasoningEffortLow),
+			string(fantasyopenai.ReasoningEffortMedium),
+			string(fantasyopenai.ReasoningEffortHigh),
+		)
 	case fantasyvercel.Name:
 		return normalizedEnumValue(
 			normalized,
@@ -602,6 +618,7 @@ func MergeMissingProviderOptions(
 		fantasyanthropic.Name,
 		fantasygoogle.Name,
 		fantasyopenaicompat.Name,
+		litellmProviderName,
 		fantasyopenrouter.Name,
 		fantasyvercel.Name,
 	} {
@@ -752,6 +769,24 @@ func MergeMissingProviderOptions(
 			}
 			if dstCompat.ReasoningEffort == nil {
 				dstCompat.ReasoningEffort = defaultCompat.ReasoningEffort
+			}
+
+		case litellmProviderName:
+			if defaults.LiteLLM == nil {
+				continue
+			}
+			if current.LiteLLM == nil {
+				copied := *defaults.LiteLLM
+				current.LiteLLM = &copied
+				continue
+			}
+			dstLiteLLM := current.LiteLLM
+			defaultLiteLLM := defaults.LiteLLM
+			if dstLiteLLM.User == nil {
+				dstLiteLLM.User = defaultLiteLLM.User
+			}
+			if dstLiteLLM.ReasoningEffort == nil {
+				dstLiteLLM.ReasoningEffort = defaultLiteLLM.ReasoningEffort
 			}
 
 		case fantasyopenrouter.Name:
@@ -962,6 +997,16 @@ func ModelFromConfig(
 			options = append(options, fantasyopenaicompat.WithBaseURL(baseURL))
 		}
 		providerClient, err = fantasyopenaicompat.New(options...)
+	case litellmProviderName:
+		options := []fantasyopenaicompat.Option{
+			fantasyopenaicompat.WithName(litellmProviderName),
+			fantasyopenaicompat.WithAPIKey(apiKey),
+			fantasyopenaicompat.WithUserAgent(userAgent),
+		}
+		if baseURL != "" {
+			options = append(options, fantasyopenaicompat.WithBaseURL(baseURL))
+		}
+		providerClient, err = fantasyopenaicompat.New(options...)
 	case fantasyopenrouter.Name:
 		providerClient, err = fantasyopenrouter.New(
 			fantasyopenrouter.WithAPIKey(apiKey),
@@ -1004,6 +1049,8 @@ func missingProviderAPIKeyError(provider string) error {
 		return xerrors.New("OPENAI_API_KEY is not set")
 	case fantasyopenaicompat.Name:
 		return xerrors.New("OPENAI_COMPAT_API_KEY is not set")
+	case litellmProviderName:
+		return xerrors.New("LITELLM_API_KEY is not set")
 	case fantasyopenrouter.Name:
 		return xerrors.New("OPENROUTER_API_KEY is not set")
 	case fantasyvercel.Name:
@@ -1044,6 +1091,13 @@ func ProviderOptionsFromChatModelConfig(
 	if options.OpenAICompat != nil {
 		result[fantasyopenaicompat.Name] = openAICompatProviderOptionsFromChatConfig(
 			options.OpenAICompat,
+		)
+	}
+	if options.LiteLLM != nil {
+		// LiteLLM uses the openaicompat fantasy provider under the
+		// hood, so its options are stored under that provider key.
+		result[fantasyopenaicompat.Name] = liteLLMProviderOptionsFromChatConfig(
+			options.LiteLLM,
 		)
 	}
 	if options.OpenRouter != nil {
@@ -1155,6 +1209,15 @@ func googleProviderOptionsFromChatConfig(
 
 func openAICompatProviderOptionsFromChatConfig(
 	options *codersdk.ChatModelOpenAICompatProviderOptions,
+) *fantasyopenaicompat.ProviderOptions {
+	return &fantasyopenaicompat.ProviderOptions{
+		User:            normalizedStringPointer(options.User),
+		ReasoningEffort: openAIReasoningEffortFromChat(options.ReasoningEffort),
+	}
+}
+
+func liteLLMProviderOptionsFromChatConfig(
+	options *codersdk.ChatModelLiteLLMProviderOptions,
 ) *fantasyopenaicompat.ProviderOptions {
 	return &fantasyopenaicompat.ProviderOptions{
 		User:            normalizedStringPointer(options.User),

--- a/coderd/chatd/chatprovider/chatprovider_test.go
+++ b/coderd/chatd/chatprovider/chatprovider_test.go
@@ -47,6 +47,12 @@ func TestReasoningEffortFromChat(t *testing.T) {
 			want:     stringPtr(string(fantasyvercel.ReasoningEffortXHigh)),
 		},
 		{
+			name:     "LiteLLMEffort",
+			provider: "litellm",
+			input:    stringPtr("high"),
+			want:     stringPtr(string(fantasyopenai.ReasoningEffortHigh)),
+		},
+		{
 			name:     "InvalidEffortReturnsNil",
 			provider: "openai",
 			input:    stringPtr("unknown"),
@@ -135,6 +141,124 @@ func TestMergeMissingProviderOptions_OpenRouterNested(t *testing.T) {
 	require.Equal(t, []string{"foo"}, options.OpenRouter.Provider.Ignore)
 	require.Equal(t, []string{"int8"}, options.OpenRouter.Provider.Quantizations)
 	require.Equal(t, "latency", *options.OpenRouter.Provider.Sort)
+}
+
+func TestNormalizeProvider_LiteLLM(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"Exact", "litellm", "litellm"},
+		{"UpperCase", "LITELLM", "litellm"},
+		{"MixedCase", "LiteLLM", "litellm"},
+		{"Padded", "  litellm  ", "litellm"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, chatprovider.NormalizeProvider(tt.input))
+		})
+	}
+}
+
+func TestSupportedProviders_IncludesLiteLLM(t *testing.T) {
+	t.Parallel()
+
+	providers := chatprovider.SupportedProviders()
+	require.Contains(t, providers, "litellm")
+}
+
+func TestMergeMissingProviderOptions_LiteLLM(t *testing.T) {
+	t.Parallel()
+
+	options := &codersdk.ChatModelProviderOptions{
+		LiteLLM: &codersdk.ChatModelLiteLLMProviderOptions{
+			ReasoningEffort: stringPtr("low"),
+		},
+	}
+	defaults := &codersdk.ChatModelProviderOptions{
+		LiteLLM: &codersdk.ChatModelLiteLLMProviderOptions{
+			User:            stringPtr("default-user"),
+			ReasoningEffort: stringPtr("high"),
+		},
+	}
+
+	chatprovider.MergeMissingProviderOptions(&options, defaults)
+
+	require.NotNil(t, options)
+	require.NotNil(t, options.LiteLLM)
+	// ReasoningEffort was already set, so it should keep the original.
+	require.Equal(t, "low", *options.LiteLLM.ReasoningEffort)
+	// User was nil, so it should be filled from defaults.
+	require.Equal(t, "default-user", *options.LiteLLM.User)
+}
+
+func TestMergeMissingProviderOptions_LiteLLMNilDst(t *testing.T) {
+	t.Parallel()
+
+	options := &codersdk.ChatModelProviderOptions{}
+	defaults := &codersdk.ChatModelProviderOptions{
+		LiteLLM: &codersdk.ChatModelLiteLLMProviderOptions{
+			User:            stringPtr("default-user"),
+			ReasoningEffort: stringPtr("medium"),
+		},
+	}
+
+	chatprovider.MergeMissingProviderOptions(&options, defaults)
+
+	require.NotNil(t, options.LiteLLM)
+	require.Equal(t, "default-user", *options.LiteLLM.User)
+	require.Equal(t, "medium", *options.LiteLLM.ReasoningEffort)
+}
+
+func TestProviderDisplayName_LiteLLM(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "LiteLLM", chatprovider.ProviderDisplayName("litellm"))
+	require.Equal(t, "LiteLLM", chatprovider.ProviderDisplayName("LITELLM"))
+	require.Equal(t, "LiteLLM", chatprovider.ProviderDisplayName(" LiteLLM "))
+}
+
+func TestMergeProviderAPIKeys_LiteLLM(t *testing.T) {
+	t.Parallel()
+
+	fallback := chatprovider.ProviderAPIKeys{
+		ByProvider:        map[string]string{"litellm": "fallback-key"},
+		BaseURLByProvider: map[string]string{"litellm": "http://localhost:4000"},
+	}
+	providers := []chatprovider.ConfiguredProvider{
+		{
+			Provider: "litellm",
+			APIKey:   "configured-key",
+			BaseURL:  "http://litellm.internal:4000",
+		},
+	}
+
+	merged := chatprovider.MergeProviderAPIKeys(fallback, providers)
+
+	// Configured provider key overrides fallback.
+	require.Equal(t, "configured-key", merged.APIKey("litellm"))
+	require.Equal(t, "http://litellm.internal:4000", merged.BaseURL("litellm"))
+}
+
+func TestMergeProviderAPIKeys_LiteLLMFallback(t *testing.T) {
+	t.Parallel()
+
+	fallback := chatprovider.ProviderAPIKeys{
+		ByProvider:        map[string]string{"litellm": "fallback-key"},
+		BaseURLByProvider: map[string]string{"litellm": "http://localhost:4000"},
+	}
+
+	// No configured providers — fallback keys are preserved.
+	merged := chatprovider.MergeProviderAPIKeys(fallback, nil)
+
+	require.Equal(t, "fallback-key", merged.APIKey("litellm"))
+	require.Equal(t, "http://localhost:4000", merged.BaseURL("litellm"))
 }
 
 func stringPtr(value string) *string {

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -419,6 +419,7 @@ type ChatModelProviderOptions struct {
 	Anthropic    *ChatModelAnthropicProviderOptions    `json:"anthropic,omitempty"`
 	Google       *ChatModelGoogleProviderOptions       `json:"google,omitempty"`
 	OpenAICompat *ChatModelOpenAICompatProviderOptions `json:"openaicompat,omitempty"`
+	LiteLLM      *ChatModelLiteLLMProviderOptions      `json:"litellm,omitempty"`
 	OpenRouter   *ChatModelOpenRouterProviderOptions   `json:"openrouter,omitempty"`
 	Vercel       *ChatModelVercelProviderOptions       `json:"vercel,omitempty"`
 }
@@ -489,6 +490,17 @@ type ChatModelGoogleProviderOptions struct {
 
 // ChatModelOpenAICompatProviderOptions configures OpenAI-compatible behavior.
 type ChatModelOpenAICompatProviderOptions struct {
+	User            *string `json:"user,omitempty" description:"Unique identifier for the end user for abuse monitoring" hidden:"true"`
+	ReasoningEffort *string `json:"reasoning_effort,omitempty" description:"Controls the level of reasoning effort" enum:"none,minimal,low,medium,high,xhigh"`
+}
+
+// ChatModelLiteLLMProviderOptions configures LiteLLM proxy provider
+// behavior. LiteLLM (https://github.com/BerriAI/litellm) is an
+// OpenAI-compatible gateway that provides access to 100+ LLM
+// providers through a unified API. Configure with a base URL
+// pointing to your LiteLLM proxy instance and an API key for
+// authentication.
+type ChatModelLiteLLMProviderOptions struct {
 	User            *string `json:"user,omitempty" description:"Unique identifier for the end user for abuse monitoring" hidden:"true"`
 	ReasoningEffort *string `json:"reasoning_effort,omitempty" description:"Controls the level of reasoning effort" enum:"none,minimal,low,medium,high,xhigh"`
 }

--- a/scripts/modeloptionsgen/main.go
+++ b/scripts/modeloptionsgen/main.go
@@ -63,6 +63,7 @@ func main() {
 		{"anthropic", reflect.TypeOf(codersdk.ChatModelAnthropicProviderOptions{})},
 		{"google", reflect.TypeOf(codersdk.ChatModelGoogleProviderOptions{})},
 		{"openaicompat", reflect.TypeOf(codersdk.ChatModelOpenAICompatProviderOptions{})},
+		{"litellm", reflect.TypeOf(codersdk.ChatModelLiteLLMProviderOptions{})},
 		{"openrouter", reflect.TypeOf(codersdk.ChatModelOpenRouterProviderOptions{})},
 		{"vercel", reflect.TypeOf(codersdk.ChatModelVercelProviderOptions{})},
 	}

--- a/site/src/api/chatModelOptionsGenerated.json
+++ b/site/src/api/chatModelOptionsGenerated.json
@@ -199,6 +199,28 @@
 				}
 			]
 		},
+		"litellm": {
+			"fields": [
+				{
+					"json_name": "user",
+					"go_name": "User",
+					"type": "string",
+					"description": "Unique identifier for the end user for abuse monitoring",
+					"required": false,
+					"input_type": "input",
+					"hidden": true
+				},
+				{
+					"json_name": "reasoning_effort",
+					"go_name": "ReasoningEffort",
+					"type": "string",
+					"description": "Controls the level of reasoning effort",
+					"required": false,
+					"enum": ["none", "minimal", "low", "medium", "high", "xhigh"],
+					"input_type": "select"
+				}
+			]
+		},
 		"openai": {
 			"fields": [
 				{

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1502,6 +1502,20 @@ export interface ChatModelGoogleThinkingConfig {
 
 // From codersdk/chats.go
 /**
+ * ChatModelLiteLLMProviderOptions configures LiteLLM proxy provider
+ * behavior. LiteLLM (https://github.com/BerriAI/litellm) is an
+ * OpenAI-compatible gateway that provides access to 100+ LLM
+ * providers through a unified API. Configure with a base URL
+ * pointing to your LiteLLM proxy instance and an API key for
+ * authentication.
+ */
+export interface ChatModelLiteLLMProviderOptions {
+	readonly user?: string;
+	readonly reasoning_effort?: string;
+}
+
+// From codersdk/chats.go
+/**
  * ChatModelOpenAICompatProviderOptions configures OpenAI-compatible behavior.
  */
 export interface ChatModelOpenAICompatProviderOptions {
@@ -1595,6 +1609,7 @@ export interface ChatModelProviderOptions {
 	readonly anthropic?: ChatModelAnthropicProviderOptions;
 	readonly google?: ChatModelGoogleProviderOptions;
 	readonly openaicompat?: ChatModelOpenAICompatProviderOptions;
+	readonly litellm?: ChatModelLiteLLMProviderOptions;
 	readonly openrouter?: ChatModelOpenRouterProviderOptions;
 	readonly vercel?: ChatModelVercelProviderOptions;
 }

--- a/site/src/pages/AgentsPage/ChatModelAdminPanel/ProviderIcon.tsx
+++ b/site/src/pages/AgentsPage/ChatModelAdminPanel/ProviderIcon.tsx
@@ -12,6 +12,7 @@ const providerIconMap: Record<string, string> = {
 	bedrock: "/icon/aws.svg",
 	google: "/icon/google.svg",
 	gemini: "/icon/gemini.svg",
+	litellm: "/icon/litellm.svg",
 };
 
 interface ProviderIconProps {

--- a/site/src/pages/AgentsPage/modelOptions.ts
+++ b/site/src/pages/AgentsPage/modelOptions.ts
@@ -116,6 +116,8 @@ export const formatProviderLabel = (provider: string): string => {
 		case "openai-compatible":
 		case "openai_compatible":
 			return "OpenAI-compatible";
+		case "litellm":
+			return "LiteLLM";
 		case "openrouter":
 			return "OpenRouter";
 		case "vercel":

--- a/site/src/theme/icons.json
+++ b/site/src/theme/icons.json
@@ -85,6 +85,7 @@
 	"kiro.svg",
 	"kotlin.svg",
 	"lakefs.svg",
+	"litellm.svg",
 	"lxc.svg",
 	"matlab.svg",
 	"memory.svg",

--- a/site/static/icon/litellm.svg
+++ b/site/static/icon/litellm.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
-  <rect width="24" height="24" rx="4" fill="#1a73e8"/>
-  <text x="12" y="16.5" font-family="Arial, sans-serif" font-size="10" font-weight="bold" fill="white" text-anchor="middle">LL</text>
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="256" height="256" rx="42" fill="#1a73e8"/>
+  <text x="128" y="160" font-family="Arial, sans-serif" font-size="100" font-weight="bold" fill="white" text-anchor="middle">LL</text>
 </svg>

--- a/site/static/icon/litellm.svg
+++ b/site/static/icon/litellm.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <rect width="24" height="24" rx="4" fill="#1a73e8"/>
+  <text x="12" y="16.5" font-family="Arial, sans-serif" font-size="10" font-weight="bold" fill="white" text-anchor="middle">LL</text>
+</svg>


### PR DESCRIPTION
## Summary

Adds [LiteLLM](https://github.com/BerriAI/litellm) as a first-class provider for the agents feature. LiteLLM is an OpenAI-compatible gateway that provides access to 100+ LLM providers through a unified API. 

LiteLLM is widely adopted in the enterprise and will likely be highly demanded from our initial user base.

### Motivation

Users who self-host LiteLLM as their LLM gateway want a dedicated "LiteLLM" entry in the provider list rather than using the generic "OpenAI Compatible" provider. This gives admins a clear, purpose-built configuration surface with the correct display name, icon, and error messages.

### Implementation

Since LiteLLM exposes a standard OpenAI-compatible API, the implementation reuses the `fantasyopenaicompat` provider from the Fantasy library under the hood. The key architectural decisions:

- **Provider name**: Registered as `"litellm"` (a distinct named provider)
- **Fantasy provider**: Uses `openaicompat.New()` with `WithName("litellm")` to create the underlying client
- **Provider options key**: Options are stored under `fantasyopenaicompat.Name` (`"openai-compat"`) because the Fantasy library's `PrepareCallFunc` looks up options using the package-level `Name` constant, not the dynamic provider name
- **Configuration**: Requires a `base_url` (pointing to the LiteLLM proxy) and `api_key` for authentication, same as any provider

### Changes

| File | Description |
|------|-------------|
| `codersdk/chats.go` | Added `ChatModelLiteLLMProviderOptions` struct with `User` and `ReasoningEffort` fields; added `LiteLLM` field to `ChatModelProviderOptions` |
| `coderd/chatd/chatprovider/chatprovider.go` | Registered litellm in all provider registries: `supportedProviderNames`, `providerDisplayNameByName`, `NormalizeProvider()`, `ModelFromConfig()`, `missingProviderAPIKeyError()`, `ProviderOptionsFromChatModelConfig()`, `MergeMissingProviderOptions()`, `ReasoningEffortFromChat()` |
| `coderd/chatd/chatprovider/chatprovider_test.go` | 8 new test functions covering normalization, supported providers, display name, provider options merge, API key merge, and reasoning effort |
| `scripts/modeloptionsgen/main.go` | Added litellm to provider types for code generation |
| `site/src/pages/AgentsPage/modelOptions.ts` | Added `"litellm"` label formatting |
| `site/src/pages/AgentsPage/ChatModelAdminPanel/ProviderIcon.tsx` | Added litellm icon mapping |
| `site/static/icon/litellm.svg` | New LiteLLM provider icon |

### Testing

- All existing tests pass
- 8 new test functions:
  - `TestNormalizeProvider_LiteLLM` (4 subtests: exact, uppercase, mixed case, padded)
  - `TestSupportedProviders_IncludesLiteLLM`
  - `TestMergeMissingProviderOptions_LiteLLM`
  - `TestMergeMissingProviderOptions_LiteLLMNilDst`
  - `TestProviderDisplayName_LiteLLM`
  - `TestMergeProviderAPIKeys_LiteLLM`
  - `TestMergeProviderAPIKeys_LiteLLMFallback`
  - `TestReasoningEffortFromChat/LiteLLMEffort`