### PR TITLE
fix(site): correct React Query usage in AgentsPage

### DIFF
--- a/site/src/api/queries/chats.test.ts
+++ b/site/src/api/queries/chats.test.ts
@@ -239,7 +239,6 @@ describe("archiveChat optimistic update", () => {
 		const initialChats = [makeChat(chatId)];
 		seedInfiniteChats(queryClient, initialChats);
 		queryClient.setQueryData(chatKey(chatId), makeChat(chatId));
-		const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
 		const mutation = archiveChat(queryClient);
 		const context = await mutation.onMutate(chatId);
@@ -247,13 +246,12 @@ describe("archiveChat optimistic update", () => {
 		// Verify the optimistic update took effect.
 		expect(readInfiniteChats(queryClient)?.[0].archived).toBe(true);
 
-		// Simulate an error — the onError handler invalidates the
-		// cache so a re-fetch restores the correct state.
+		// Simulate an error — the onError handler restores the
+		// previous cache state synchronously.
 		mutation.onError(new Error("server error"), chatId, context);
 
-		expect(invalidateSpy).toHaveBeenCalledWith(
-			expect.objectContaining({ queryKey: chatsKey }),
-		);
+		// The infinite cache should be restored to the pre-mutation state.
+		expect(readInfiniteChats(queryClient)?.[0].archived).toBe(false);
 	});
 
 	it("rolls back the individual chat cache on error", async () => {
@@ -279,7 +277,6 @@ describe("archiveChat optimistic update", () => {
 		const queryClient = createTestQueryClient();
 		const chatId = "chat-1";
 		seedInfiniteChats(queryClient, [makeChat(chatId, { archived: true })]);
-		const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
 		const mutation = archiveChat(queryClient);
 
@@ -287,11 +284,6 @@ describe("archiveChat optimistic update", () => {
 		expect(() => {
 			mutation.onError(new Error("fail"), chatId, undefined);
 		}).not.toThrow();
-
-		// The handler should still invalidate to trigger a refetch.
-		expect(invalidateSpy).toHaveBeenCalledWith(
-			expect.objectContaining({ queryKey: chatsKey }),
-		);
 	});
 
 	it("handles onMutate when no individual chat cache exists", async () => {
@@ -364,7 +356,6 @@ describe("unarchiveChat optimistic update", () => {
 			chatKey(chatId),
 			makeChat(chatId, { archived: true }),
 		);
-		const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
 		const mutation = unarchiveChat(queryClient);
 		const context = await mutation.onMutate(chatId);
@@ -378,10 +369,8 @@ describe("unarchiveChat optimistic update", () => {
 		// Roll back.
 		mutation.onError(new Error("server error"), chatId, context);
 
-		// The chats list is rolled back via invalidation.
-		expect(invalidateSpy).toHaveBeenCalledWith(
-			expect.objectContaining({ queryKey: chatsKey }),
-		);
+		// The infinite cache is restored synchronously.
+		expect(readInfiniteChats(queryClient)?.[0].archived).toBe(true);
 		// The individual chat cache is restored directly.
 		expect(
 			queryClient.getQueryData<TypesGen.Chat>(chatKey(chatId))?.archived,
@@ -694,16 +683,16 @@ describe("infiniteChats", () => {
 			const lastPage = Array.from({ length: PAGE_LIMIT - 1 }, (_, i) =>
 				makeChat(`chat-${i}`),
 			);
-			expect(getNextPageParam(lastPage, [lastPage])).toBeUndefined();
+			expect(getNextPageParam(lastPage, [lastPage], 0)).toBeUndefined();
 		});
 
-		it("returns pages.length + 1 when lastPage has exactly the limit", () => {
+		it("returns lastPageParam + limit when lastPage has exactly the limit", () => {
 			const { getNextPageParam } = infiniteChats();
 			const lastPage = Array.from({ length: PAGE_LIMIT }, (_, i) =>
 				makeChat(`chat-${i}`),
 			);
 			const pages = [lastPage];
-			expect(getNextPageParam(lastPage, pages)).toBe(pages.length + 1);
+			expect(getNextPageParam(lastPage, pages, 0)).toBe(PAGE_LIMIT);
 		});
 	});
 
@@ -718,38 +707,21 @@ describe("infiniteChats", () => {
 			});
 		});
 
-		it("computes offset 0 for pageParam <= 0", async () => {
-			vi.mocked(API.getChats).mockResolvedValue([]);
-			const { queryFn } = infiniteChats();
-			await queryFn({ pageParam: -1 });
-			expect(API.getChats).toHaveBeenCalledWith({
-				limit: PAGE_LIMIT,
-				offset: 0,
-			});
-		});
-
 		it("computes correct offset for subsequent pages", async () => {
 			vi.mocked(API.getChats).mockResolvedValue([]);
 			const { queryFn } = infiniteChats();
 
-			await queryFn({ pageParam: 2 });
+			await queryFn({ pageParam: PAGE_LIMIT });
 			expect(API.getChats).toHaveBeenCalledWith({
 				limit: PAGE_LIMIT,
 				offset: PAGE_LIMIT,
 			});
 
-			await queryFn({ pageParam: 3 });
+			await queryFn({ pageParam: PAGE_LIMIT * 2 });
 			expect(API.getChats).toHaveBeenCalledWith({
 				limit: PAGE_LIMIT,
 				offset: PAGE_LIMIT * 2,
 			});
-		});
-
-		it("throws when pageParam is not a number", () => {
-			const { queryFn } = infiniteChats();
-			expect(() => queryFn({ pageParam: "bad" })).toThrow(
-				"pageParam must be a number",
-			);
 		});
 	});
 });

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -1,6 +1,6 @@
 import { API } from "api/api";
 import type * as TypesGen from "api/typesGenerated";
-import type { QueryClient, UseInfiniteQueryOptions } from "react-query";
+import type { QueryClient } from "react-query";
 
 export const chatsKey = ["chats"] as const;
 export const chatKey = (chatId: string) => ["chats", chatId] as const;
@@ -146,23 +146,23 @@ export const infiniteChats = (opts?: { q?: string; archived?: boolean }) => {
 		getNextPageParam: (
 			lastPage: TypesGen.Chat[],
 			_allPages: TypesGen.Chat[][],
-			lastPageParam: unknown,
+			lastPageParam: number,
 		) => {
 			if (lastPage.length < limit) {
 				return undefined;
 			}
-			return (lastPageParam as number) + limit;
+			return lastPageParam + limit;
 		},
 		initialPageParam: 0,
-		queryFn: ({ pageParam }: { pageParam: unknown }) => {
+		queryFn: ({ pageParam }: { pageParam: number }) => {
 			return API.getChats({
 				limit,
-				offset: pageParam as number,
+				offset: pageParam,
 				q,
 			});
 		},
 		refetchOnWindowFocus: true as const,
-	} satisfies UseInfiniteQueryOptions<TypesGen.Chat[]>;
+	};
 };
 
 export const chats = () => ({

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -20,7 +20,7 @@ export const updateInfiniteChatsCache = (
 	queryClient.setQueriesData<{
 		pages: TypesGen.Chat[][];
 		pageParams: unknown[];
-	}>({ queryKey: chatsKey, predicate: isChatListQuery }, (prev) => {
+	}>({ queryKey: chatsKey, predicate: isInfiniteChatListQuery }, (prev) => {
 		if (!prev) return prev;
 		if (!prev.pages) return prev;
 		const nextPages = prev.pages.map((page) => updater(page));
@@ -44,7 +44,7 @@ export const prependToInfiniteChatsCache = (
 	queryClient.setQueriesData<{
 		pages: TypesGen.Chat[][];
 		pageParams: unknown[];
-	}>({ queryKey: chatsKey, predicate: isChatListQuery }, (prev) => {
+	}>({ queryKey: chatsKey, predicate: isInfiniteChatListQuery }, (prev) => {
 		if (!prev?.pages) return prev;
 		// Check across ALL pages to avoid duplicates.
 		const exists = prev.pages.some((page) =>
@@ -69,7 +69,7 @@ export const readInfiniteChatsCache = (
 	const queries = queryClient.getQueriesData<{
 		pages: TypesGen.Chat[][];
 		pageParams: unknown[];
-	}>({ queryKey: chatsKey, predicate: isChatListQuery });
+	}>({ queryKey: chatsKey, predicate: isInfiniteChatListQuery });
 	for (const [, data] of queries) {
 		if (data?.pages) {
 			return data.pages.flat();
@@ -79,23 +79,45 @@ export const readInfiniteChatsCache = (
 };
 
 /**
- * Invalidate only the sidebar chat-list queries (flat + infinite)
-/**
- * Predicate that matches only chat-list queries (the sidebar), not
- * per-chat queries (detail, messages, diffs, cost).
+ * Predicate that matches only infinite chat-list queries, excluding
+ * the flat ["chats"] query. Used for direct cache manipulation
+ * (setQueriesData) where the data structure must be { pages,
+ * pageParams }.
  *
- * Sidebar keys look like ["chats"] or ["chats", <object|undefined>].
+ * Infinite keys look like ["chats", <object | undefined>].
  * Per-chat keys look like ["chats", <string-id>, ...].
+ */
+const isInfiniteChatListQuery = (query: {
+	queryKey: readonly unknown[];
+}): boolean => {
+	const key = query.queryKey;
+	// Exclude: ["chats"] (flat list) — its data is Chat[], not
+	// { pages, pageParams }, so cache helpers must not touch it.
+	if (key.length <= 1) return false;
+	// Match: ["chats", <object | undefined>] (infinite query
+	// with optional filter opts like {archived, q}).
+	const segment = key[1];
+	return (
+		segment === undefined || (segment !== null && typeof segment === "object")
+	);
+};
+
+/**
+ * Predicate that matches both flat and infinite chat-list queries
+ * (the sidebar). Used for invalidation where we want to refresh
+ * all list views.
  */
 const isChatListQuery = (query: { queryKey: readonly unknown[] }): boolean => {
 	const key = query.queryKey;
 	// Match: ["chats"] (flat list).
 	if (key.length <= 1) return true;
-	// Match: ["chats", <object | undefined>] (infinite query
-	// with optional filter opts like {archived, q}).
-	const segment = key[1];
-	return segment === undefined || typeof segment === "object";
+	// Delegate to the infinite predicate for longer keys.
+	return isInfiniteChatListQuery(query);
 };
+
+/**
+ * Invalidate only the sidebar chat-list queries (flat + infinite).
+ */
 
 export const invalidateChatListQueries = (queryClient: QueryClient) => {
 	return queryClient.invalidateQueries({
@@ -121,20 +143,21 @@ export const infiniteChats = (opts?: { q?: string; archived?: boolean }) => {
 
 	return {
 		queryKey: [...chatsKey, opts],
-		getNextPageParam: (lastPage: TypesGen.Chat[], pages: TypesGen.Chat[][]) => {
+		getNextPageParam: (
+			lastPage: TypesGen.Chat[],
+			_allPages: TypesGen.Chat[][],
+			lastPageParam: unknown,
+		) => {
 			if (lastPage.length < limit) {
 				return undefined;
 			}
-			return pages.length + 1;
+			return (lastPageParam as number) + limit;
 		},
 		initialPageParam: 0,
 		queryFn: ({ pageParam }: { pageParam: unknown }) => {
-			if (typeof pageParam !== "number") {
-				throw new Error("pageParam must be a number");
-			}
 			return API.getChats({
 				limit,
-				offset: pageParam <= 0 ? 0 : (pageParam - 1) * limit,
+				offset: pageParam as number,
 				q,
 			});
 		},
@@ -179,12 +202,7 @@ export const archiveChat = (queryClient: QueryClient) => ({
 	onMutate: async (chatId: string) => {
 		await queryClient.cancelQueries({
 			queryKey: chatsKey,
-			predicate: (query) => {
-				const key = query.queryKey;
-				if (key.length <= 1) return true;
-				const segment = key[1];
-				return segment === undefined || typeof segment === "object";
-			},
+			predicate: isChatListQuery,
 		});
 		await queryClient.cancelQueries({
 			queryKey: chatKey(chatId),
@@ -193,6 +211,12 @@ export const archiveChat = (queryClient: QueryClient) => ({
 		const previousChat = queryClient.getQueryData<TypesGen.Chat>(
 			chatKey(chatId),
 		);
+		// Snapshot infinite cache before optimistic update so we
+		// can restore it on error without a flash of stale data.
+		const previousInfiniteData = queryClient.getQueriesData<{
+			pages: TypesGen.Chat[][];
+			pageParams: unknown[];
+		}>({ queryKey: chatsKey, predicate: isInfiniteChatListQuery });
 		updateInfiniteChatsCache(queryClient, (chats) =>
 			chats.map((chat) =>
 				chat.id === chatId ? { ...chat, archived: true } : chat,
@@ -204,7 +228,7 @@ export const archiveChat = (queryClient: QueryClient) => ({
 				archived: true,
 			});
 		}
-		return { previousChat };
+		return { previousChat, previousInfiniteData };
 	},
 	onError: (
 		_error: unknown,
@@ -212,11 +236,18 @@ export const archiveChat = (queryClient: QueryClient) => ({
 		context:
 			| {
 					previousChat?: TypesGen.Chat;
+					previousInfiniteData?: [
+						readonly unknown[],
+						{ pages: TypesGen.Chat[][]; pageParams: unknown[] } | undefined,
+					][];
 			  }
 			| undefined,
 	) => {
-		// Rollback: invalidate to re-fetch the correct state.
-		void invalidateChatListQueries(queryClient);
+		// Rollback: restore both caches synchronously. The
+		// onSettled handler will refetch for server consistency.
+		for (const [key, data] of context?.previousInfiniteData ?? []) {
+			queryClient.setQueryData(key, data);
+		}
 		if (context?.previousChat) {
 			queryClient.setQueryData<TypesGen.Chat>(
 				chatKey(chatId),
@@ -238,12 +269,7 @@ export const unarchiveChat = (queryClient: QueryClient) => ({
 	onMutate: async (chatId: string) => {
 		await queryClient.cancelQueries({
 			queryKey: chatsKey,
-			predicate: (query) => {
-				const key = query.queryKey;
-				if (key.length <= 1) return true;
-				const segment = key[1];
-				return segment === undefined || typeof segment === "object";
-			},
+			predicate: isChatListQuery,
 		});
 		await queryClient.cancelQueries({
 			queryKey: chatKey(chatId),
@@ -252,6 +278,12 @@ export const unarchiveChat = (queryClient: QueryClient) => ({
 		const previousChat = queryClient.getQueryData<TypesGen.Chat>(
 			chatKey(chatId),
 		);
+		// Snapshot infinite cache before optimistic update so we
+		// can restore it on error without a flash of stale data.
+		const previousInfiniteData = queryClient.getQueriesData<{
+			pages: TypesGen.Chat[][];
+			pageParams: unknown[];
+		}>({ queryKey: chatsKey, predicate: isInfiniteChatListQuery });
 		updateInfiniteChatsCache(queryClient, (chats) =>
 			chats.map((chat) =>
 				chat.id === chatId ? { ...chat, archived: false } : chat,
@@ -263,7 +295,7 @@ export const unarchiveChat = (queryClient: QueryClient) => ({
 				archived: false,
 			});
 		}
-		return { previousChat };
+		return { previousChat, previousInfiniteData };
 	},
 	onError: (
 		_error: unknown,
@@ -271,11 +303,18 @@ export const unarchiveChat = (queryClient: QueryClient) => ({
 		context:
 			| {
 					previousChat?: TypesGen.Chat;
+					previousInfiniteData?: [
+						readonly unknown[],
+						{ pages: TypesGen.Chat[][]; pageParams: unknown[] } | undefined,
+					][];
 			  }
 			| undefined,
 	) => {
-		// Rollback: invalidate to re-fetch the correct state.
-		void invalidateChatListQueries(queryClient);
+		// Rollback: restore both caches synchronously. The
+		// onSettled handler will refetch for server consistency.
+		for (const [key, data] of context?.previousInfiniteData ?? []) {
+			queryClient.setQueryData(key, data);
+		}
 		if (context?.previousChat) {
 			queryClient.setQueryData<TypesGen.Chat>(
 				chatKey(chatId),
@@ -294,8 +333,8 @@ export const unarchiveChat = (queryClient: QueryClient) => ({
 
 export const createChat = (queryClient: QueryClient) => ({
 	mutationFn: (req: TypesGen.CreateChatRequest) => API.createChat(req),
-	onSuccess: () => {
-		void invalidateChatListQueries(queryClient);
+	onSuccess: async () => {
+		await invalidateChatListQueries(queryClient);
 	},
 });
 
@@ -318,17 +357,17 @@ type EditChatMessageMutationArgs = {
 export const editChatMessage = (queryClient: QueryClient, chatId: string) => ({
 	mutationFn: ({ messageId, req }: EditChatMessageMutationArgs) =>
 		API.editChatMessage(chatId, messageId, req),
-	onSuccess: () => {
+	onSuccess: async () => {
 		// Editing truncates all messages after the edited one on the
 		// server. The WebSocket can insert/update messages but cannot
 		// remove stale ones, so a full messages refetch is required.
 		// Use exact matching to avoid cascading to unrelated queries
 		// (diff-status, diff-contents, cost summaries, etc.).
-		void queryClient.invalidateQueries({
+		await queryClient.invalidateQueries({
 			queryKey: chatKey(chatId),
 			exact: true,
 		});
-		void queryClient.invalidateQueries({
+		await queryClient.invalidateQueries({
 			queryKey: chatMessagesKey(chatId),
 			exact: true,
 		});

--- a/site/src/pages/AgentsPage/AgentDetail.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.tsx
@@ -675,7 +675,7 @@ const AgentDetail: FC = () => {
 		if (!agentId || interruptMutation.isPending) {
 			return;
 		}
-		void interruptMutation.mutateAsync();
+		interruptMutation.mutate();
 	};
 
 	const handleDeleteQueuedMessage = useCallback(

--- a/site/src/pages/AgentsPage/AgentDetail/ChatContext.ts
+++ b/site/src/pages/AgentsPage/AgentDetail/ChatContext.ts
@@ -563,8 +563,19 @@ export const useChatStore = (
 			if (hasStaleEntries) {
 				store.replaceMessages(chatMessages);
 			} else {
+				let anyChanged = false;
 				for (const message of chatMessages) {
-					store.upsertDurableMessage(message);
+					const { changed } = store.upsertDurableMessage(message);
+					if (changed) {
+						anyChanged = true;
+					}
+				}
+				// If a REST refetch delivered a new or updated message
+				// while streaming is still active, clear stream state
+				// to avoid showing the same content in both the durable
+				// message list and the streaming output.
+				if (anyChanged && storeSnap.streamState !== null) {
+					store.clearStreamState();
 				}
 			}
 		}

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -155,16 +155,22 @@ const AgentsPage: FC = () => {
 			await API.deleteWorkspace(workspaceId);
 			return { chatId, workspaceId };
 		},
-		onSuccess: async ({ chatId }) => {
+		onSuccess: ({ chatId }) => {
 			clearChatErrorReason(chatId);
-			await invalidateChatListQueries(queryClient);
-			await queryClient.invalidateQueries({
-				queryKey: chatKey(chatId),
-				exact: true,
-			});
 		},
 		onError: (error) => {
 			toast.error(getErrorMessage(error, "Failed to archive agent."));
+		},
+		onSettled: async (_data, _error, variables) => {
+			// Always invalidate — even on partial failure the chat
+			// may have been archived server-side.
+			if (variables) {
+				await invalidateChatListQueries(queryClient);
+				await queryClient.invalidateQueries({
+					queryKey: chatKey(variables.chatId),
+					exact: true,
+				});
+			}
 		},
 	});
 	const unarchiveChatBase = unarchiveChat(queryClient);
@@ -503,7 +509,11 @@ const AgentsPage: FC = () => {
 			modelCatalogError={chatModelsQuery.error}
 			isAgentsAdmin={isAgentsAdmin}
 			hasNextPage={chatsQuery.hasNextPage}
-			onLoadMore={() => void chatsQuery.fetchNextPage()}
+			onLoadMore={() => {
+				if (!chatsQuery.isFetching) {
+					void chatsQuery.fetchNextPage();
+				}
+			}}
 			isFetchingNextPage={chatsQuery.isFetchingNextPage}
 			archivedFilter={archivedFilter}
 			onArchivedFilterChange={setArchivedFilter}

--- a/site/src/pages/AgentsPage/ChatModelAdminPanel/ChatModelAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/ChatModelAdminPanel/ChatModelAdminPanel.tsx
@@ -327,9 +327,7 @@ export const ChatModelAdminPanel: FC<ChatModelAdminPanelProps> = ({
 								req,
 							})
 						}
-						onDeleteProvider={(id, onSuccess) =>
-							deleteProviderMut.mutate(id, { onSuccess })
-						}
+						onDeleteProvider={(id) => deleteProviderMut.mutate(id)}
 						onSelectedProviderChange={setRequestedProvider}
 					/>
 				) : (
@@ -353,9 +351,7 @@ export const ChatModelAdminPanel: FC<ChatModelAdminPanelProps> = ({
 								req,
 							})
 						}
-						onDeleteModel={(id, onSuccess) =>
-							deleteModelMut.mutate(id, { onSuccess })
-						}
+						onDeleteModel={(id) => deleteModelMut.mutate(id)}
 						onSetDefaultModel={(modelConfigId) =>
 							updateModelMut.mutate({
 								modelConfigId,

--- a/site/src/pages/AgentsPage/ChatModelAdminPanel/ChatModelAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/ChatModelAdminPanel/ChatModelAdminPanel.tsx
@@ -327,7 +327,7 @@ export const ChatModelAdminPanel: FC<ChatModelAdminPanelProps> = ({
 								req,
 							})
 						}
-						onDeleteProvider={(id) => deleteProviderMut.mutate(id)}
+						onDeleteProvider={(id) => deleteProviderMut.mutateAsync(id)}
 						onSelectedProviderChange={setRequestedProvider}
 					/>
 				) : (
@@ -351,7 +351,7 @@ export const ChatModelAdminPanel: FC<ChatModelAdminPanelProps> = ({
 								req,
 							})
 						}
-						onDeleteModel={(id) => deleteModelMut.mutate(id)}
+						onDeleteModel={(id) => deleteModelMut.mutateAsync(id)}
 						onSetDefaultModel={(modelConfigId) =>
 							updateModelMut.mutate({
 								modelConfigId,

--- a/site/src/pages/AgentsPage/ChatModelAdminPanel/ChatModelAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/ChatModelAdminPanel/ChatModelAdminPanel.tsx
@@ -327,7 +327,9 @@ export const ChatModelAdminPanel: FC<ChatModelAdminPanelProps> = ({
 								req,
 							})
 						}
-						onDeleteProvider={(id) => deleteProviderMut.mutateAsync(id)}
+						onDeleteProvider={(id, onSuccess) =>
+							deleteProviderMut.mutate(id, { onSuccess })
+						}
 						onSelectedProviderChange={setRequestedProvider}
 					/>
 				) : (
@@ -351,7 +353,15 @@ export const ChatModelAdminPanel: FC<ChatModelAdminPanelProps> = ({
 								req,
 							})
 						}
-						onDeleteModel={(id) => deleteModelMut.mutateAsync(id)}
+						onDeleteModel={(id, onSuccess) =>
+							deleteModelMut.mutate(id, { onSuccess })
+						}
+						onSetDefaultModel={(modelConfigId) =>
+							updateModelMut.mutate({
+								modelConfigId,
+								req: { is_default: true },
+							})
+						}
 					/>
 				)}
 			</div>

--- a/site/src/pages/AgentsPage/ChatModelAdminPanel/ModelForm.tsx
+++ b/site/src/pages/AgentsPage/ChatModelAdminPanel/ModelForm.tsx
@@ -76,7 +76,7 @@ interface ModelFormProps {
 		req: TypesGen.UpdateChatModelConfigRequest,
 	) => Promise<unknown>;
 	onCancel: () => void;
-	onDeleteModel?: (modelConfigId: string) => Promise<void>;
+	onDeleteModel?: (modelConfigId: string) => void;
 }
 
 export const ModelForm: FC<ModelFormProps> = ({
@@ -528,13 +528,7 @@ export const ModelForm: FC<ModelFormProps> = ({
 									size="lg"
 									type="button"
 									disabled={isDeleting}
-									onClick={async () => {
-										try {
-											await onDeleteModel(editingModel.id);
-										} catch {
-											// Error is surfaced via mutation state in the parent.
-										}
-									}}
+									onClick={() => onDeleteModel(editingModel.id)}
 								>
 									{isDeleting && <Spinner className="h-4 w-4" loading />}
 									Delete model

--- a/site/src/pages/AgentsPage/ChatModelAdminPanel/ModelForm.tsx
+++ b/site/src/pages/AgentsPage/ChatModelAdminPanel/ModelForm.tsx
@@ -528,7 +528,9 @@ export const ModelForm: FC<ModelFormProps> = ({
 									size="lg"
 									type="button"
 									disabled={isDeleting}
-									onClick={() => void onDeleteModel(editingModel.id)}
+									onClick={() =>
+										void onDeleteModel(editingModel.id).catch(() => {})
+									}
 								>
 									{isDeleting && <Spinner className="h-4 w-4" loading />}
 									Delete model

--- a/site/src/pages/AgentsPage/ChatModelAdminPanel/ModelForm.tsx
+++ b/site/src/pages/AgentsPage/ChatModelAdminPanel/ModelForm.tsx
@@ -528,9 +528,13 @@ export const ModelForm: FC<ModelFormProps> = ({
 									size="lg"
 									type="button"
 									disabled={isDeleting}
-									onClick={() =>
-										void onDeleteModel(editingModel.id).catch(() => {})
-									}
+									onClick={async () => {
+										try {
+											await onDeleteModel(editingModel.id);
+										} catch {
+											// Error is surfaced via mutation state in the parent.
+										}
+									}}
 								>
 									{isDeleting && <Spinner className="h-4 w-4" loading />}
 									Delete model

--- a/site/src/pages/AgentsPage/ChatModelAdminPanel/ModelsSection.tsx
+++ b/site/src/pages/AgentsPage/ChatModelAdminPanel/ModelsSection.tsx
@@ -159,9 +159,13 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 		</DropdownMenu>
 	);
 
-	const handleSetDefault = (modelConfig: TypesGen.ChatModelConfig) => {
+	const handleSetDefault = async (modelConfig: TypesGen.ChatModelConfig) => {
 		if (modelConfig.is_default) return;
-		void onUpdateModel(modelConfig.id, { is_default: true }).catch(() => {});
+		try {
+			await onUpdateModel(modelConfig.id, { is_default: true });
+		} catch {
+			// Error is surfaced via mutation state in the parent.
+		}
 	};
 
 	return (

--- a/site/src/pages/AgentsPage/ChatModelAdminPanel/ModelsSection.tsx
+++ b/site/src/pages/AgentsPage/ChatModelAdminPanel/ModelsSection.tsx
@@ -161,7 +161,7 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 
 	const handleSetDefault = (modelConfig: TypesGen.ChatModelConfig) => {
 		if (modelConfig.is_default) return;
-		void onUpdateModel(modelConfig.id, { is_default: true });
+		void onUpdateModel(modelConfig.id, { is_default: true }).catch(() => {});
 	};
 
 	return (

--- a/site/src/pages/AgentsPage/ChatModelAdminPanel/ModelsSection.tsx
+++ b/site/src/pages/AgentsPage/ChatModelAdminPanel/ModelsSection.tsx
@@ -52,7 +52,8 @@ interface ModelsSectionProps {
 		modelConfigId: string,
 		req: TypesGen.UpdateChatModelConfigRequest,
 	) => Promise<unknown>;
-	onDeleteModel: (modelConfigId: string) => Promise<void>;
+	onDeleteModel: (modelConfigId: string, onSuccess?: () => void) => void;
+	onSetDefaultModel: (modelConfigId: string) => void;
 }
 
 export const ModelsSection: FC<ModelsSectionProps> = ({
@@ -71,6 +72,7 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 	onCreateModel,
 	onUpdateModel,
 	onDeleteModel,
+	onSetDefaultModel,
 }) => {
 	const [view, setView] = useState<ModelView>({ mode: "list" });
 
@@ -115,9 +117,8 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 				onCancel={() => setView({ mode: "list" })}
 				onDeleteModel={
 					editingModel
-						? async (id) => {
-								await onDeleteModel(id);
-								setView({ mode: "list" });
+						? (id) => {
+								onDeleteModel(id, () => setView({ mode: "list" }));
 							}
 						: undefined
 				}
@@ -159,13 +160,9 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 		</DropdownMenu>
 	);
 
-	const handleSetDefault = async (modelConfig: TypesGen.ChatModelConfig) => {
+	const handleSetDefault = (modelConfig: TypesGen.ChatModelConfig) => {
 		if (modelConfig.is_default) return;
-		try {
-			await onUpdateModel(modelConfig.id, { is_default: true });
-		} catch {
-			// Error is surfaced via mutation state in the parent.
-		}
+		onSetDefaultModel(modelConfig.id);
 	};
 
 	return (

--- a/site/src/pages/AgentsPage/ChatModelAdminPanel/ModelsSection.tsx
+++ b/site/src/pages/AgentsPage/ChatModelAdminPanel/ModelsSection.tsx
@@ -52,7 +52,7 @@ interface ModelsSectionProps {
 		modelConfigId: string,
 		req: TypesGen.UpdateChatModelConfigRequest,
 	) => Promise<unknown>;
-	onDeleteModel: (modelConfigId: string, onSuccess?: () => void) => void;
+	onDeleteModel: (modelConfigId: string) => void;
 	onSetDefaultModel: (modelConfigId: string) => void;
 }
 
@@ -118,7 +118,8 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 				onDeleteModel={
 					editingModel
 						? (id) => {
-								onDeleteModel(id, () => setView({ mode: "list" }));
+								onDeleteModel(id);
+								setView({ mode: "list" });
 							}
 						: undefined
 				}

--- a/site/src/pages/AgentsPage/ChatModelAdminPanel/ModelsSection.tsx
+++ b/site/src/pages/AgentsPage/ChatModelAdminPanel/ModelsSection.tsx
@@ -52,7 +52,7 @@ interface ModelsSectionProps {
 		modelConfigId: string,
 		req: TypesGen.UpdateChatModelConfigRequest,
 	) => Promise<unknown>;
-	onDeleteModel: (modelConfigId: string) => void;
+	onDeleteModel: (modelConfigId: string) => Promise<unknown>;
 	onSetDefaultModel: (modelConfigId: string) => void;
 }
 
@@ -117,9 +117,14 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 				onCancel={() => setView({ mode: "list" })}
 				onDeleteModel={
 					editingModel
-						? (id) => {
-								onDeleteModel(id);
-								setView({ mode: "list" });
+						? async (id) => {
+								try {
+									await onDeleteModel(id);
+									setView({ mode: "list" });
+								} catch {
+									// Error is surfaced via mutation state
+									// in the parent.
+								}
 							}
 						: undefined
 				}

--- a/site/src/pages/AgentsPage/ChatModelAdminPanel/ProviderForm.tsx
+++ b/site/src/pages/AgentsPage/ChatModelAdminPanel/ProviderForm.tsx
@@ -273,9 +273,13 @@ export const ProviderForm: FC<ProviderFormProps> = ({
 										size="lg"
 										type="button"
 										disabled={isProviderMutationPending}
-										onClick={() =>
-											void onDeleteProvider(providerConfig.id).catch(() => {})
-										}
+										onClick={async () => {
+											try {
+												await onDeleteProvider(providerConfig.id);
+											} catch {
+												// Error is surfaced via mutation state in the parent.
+											}
+										}}
 									>
 										{isProviderMutationPending && (
 											<Spinner className="h-4 w-4" loading />

--- a/site/src/pages/AgentsPage/ChatModelAdminPanel/ProviderForm.tsx
+++ b/site/src/pages/AgentsPage/ChatModelAdminPanel/ProviderForm.tsx
@@ -273,7 +273,9 @@ export const ProviderForm: FC<ProviderFormProps> = ({
 										size="lg"
 										type="button"
 										disabled={isProviderMutationPending}
-										onClick={() => void onDeleteProvider(providerConfig.id)}
+										onClick={() =>
+											void onDeleteProvider(providerConfig.id).catch(() => {})
+										}
 									>
 										{isProviderMutationPending && (
 											<Spinner className="h-4 w-4" loading />

--- a/site/src/pages/AgentsPage/ChatModelAdminPanel/ProviderForm.tsx
+++ b/site/src/pages/AgentsPage/ChatModelAdminPanel/ProviderForm.tsx
@@ -31,7 +31,7 @@ interface ProviderFormProps {
 		providerConfigId: string,
 		req: TypesGen.UpdateChatProviderConfigRequest,
 	) => Promise<unknown>;
-	onDeleteProvider: (providerConfigId: string) => Promise<void>;
+	onDeleteProvider: (providerConfigId: string) => void;
 	onBack: () => void;
 }
 
@@ -273,13 +273,7 @@ export const ProviderForm: FC<ProviderFormProps> = ({
 										size="lg"
 										type="button"
 										disabled={isProviderMutationPending}
-										onClick={async () => {
-											try {
-												await onDeleteProvider(providerConfig.id);
-											} catch {
-												// Error is surfaced via mutation state in the parent.
-											}
-										}}
+										onClick={() => onDeleteProvider(providerConfig.id)}
 									>
 										{isProviderMutationPending && (
 											<Spinner className="h-4 w-4" loading />

--- a/site/src/pages/AgentsPage/ChatModelAdminPanel/ProvidersSection.tsx
+++ b/site/src/pages/AgentsPage/ChatModelAdminPanel/ProvidersSection.tsx
@@ -23,7 +23,7 @@ interface ProvidersSectionProps {
 		providerConfigId: string,
 		req: TypesGen.UpdateChatProviderConfigRequest,
 	) => Promise<unknown>;
-	onDeleteProvider: (providerConfigId: string, onSuccess?: () => void) => void;
+	onDeleteProvider: (providerConfigId: string) => void;
 	onSelectedProviderChange: (provider: string) => void;
 }
 
@@ -61,7 +61,8 @@ export const ProvidersSection: FC<ProvidersSectionProps> = ({
 				onCreateProvider={onCreateProvider}
 				onUpdateProvider={onUpdateProvider}
 				onDeleteProvider={(id) => {
-					onDeleteProvider(id, () => setView({ mode: "list" }));
+					onDeleteProvider(id);
+					setView({ mode: "list" });
 				}}
 				onBack={() => setView({ mode: "list" })}
 			/>

--- a/site/src/pages/AgentsPage/ChatModelAdminPanel/ProvidersSection.tsx
+++ b/site/src/pages/AgentsPage/ChatModelAdminPanel/ProvidersSection.tsx
@@ -23,7 +23,7 @@ interface ProvidersSectionProps {
 		providerConfigId: string,
 		req: TypesGen.UpdateChatProviderConfigRequest,
 	) => Promise<unknown>;
-	onDeleteProvider: (providerConfigId: string) => Promise<void>;
+	onDeleteProvider: (providerConfigId: string, onSuccess?: () => void) => void;
 	onSelectedProviderChange: (provider: string) => void;
 }
 
@@ -60,9 +60,8 @@ export const ProvidersSection: FC<ProvidersSectionProps> = ({
 				isProviderMutationPending={isProviderMutationPending}
 				onCreateProvider={onCreateProvider}
 				onUpdateProvider={onUpdateProvider}
-				onDeleteProvider={async (id) => {
-					await onDeleteProvider(id);
-					setView({ mode: "list" });
+				onDeleteProvider={(id) => {
+					onDeleteProvider(id, () => setView({ mode: "list" }));
 				}}
 				onBack={() => setView({ mode: "list" })}
 			/>

--- a/site/src/pages/AgentsPage/ChatModelAdminPanel/ProvidersSection.tsx
+++ b/site/src/pages/AgentsPage/ChatModelAdminPanel/ProvidersSection.tsx
@@ -23,7 +23,7 @@ interface ProvidersSectionProps {
 		providerConfigId: string,
 		req: TypesGen.UpdateChatProviderConfigRequest,
 	) => Promise<unknown>;
-	onDeleteProvider: (providerConfigId: string) => void;
+	onDeleteProvider: (providerConfigId: string) => Promise<unknown>;
 	onSelectedProviderChange: (provider: string) => void;
 }
 
@@ -60,9 +60,13 @@ export const ProvidersSection: FC<ProvidersSectionProps> = ({
 				isProviderMutationPending={isProviderMutationPending}
 				onCreateProvider={onCreateProvider}
 				onUpdateProvider={onUpdateProvider}
-				onDeleteProvider={(id) => {
-					onDeleteProvider(id);
-					setView({ mode: "list" });
+				onDeleteProvider={async (id) => {
+					try {
+						await onDeleteProvider(id);
+						setView({ mode: "list" });
+					} catch {
+						// Error is surfaced via mutation state in the parent.
+					}
 				}}
 				onBack={() => setView({ mode: "list" })}
 			/>

--- a/site/src/pages/AgentsPage/InsightsContent.tsx
+++ b/site/src/pages/AgentsPage/InsightsContent.tsx
@@ -6,7 +6,7 @@ import { useQuery } from "react-query";
 import { type PRInsightsTimeRange, PRInsightsView } from "./PRInsightsView";
 
 function timeRangeToDates(range: PRInsightsTimeRange) {
-	const end = dayjs();
+	const end = dayjs().startOf("minute");
 	const days = Number.parseInt(range, 10);
 	const start = end.subtract(days, "day");
 	return {

--- a/site/src/pages/AgentsPage/SettingsPageContent.tsx
+++ b/site/src/pages/AgentsPage/SettingsPageContent.tsx
@@ -148,7 +148,7 @@ const UsageContent: FC<UsageContentProps> = ({ now }) => {
 		placeholderData: keepPreviousData,
 	});
 	const summaryQuery = useQuery({
-		...chatCostSummary(selectedUser?.user_id ?? "me", {
+		...chatCostSummary(selectedUser?.user_id ?? "", {
 			start_date: dateRange.startDate,
 			end_date: dateRange.endDate,
 		}),


### PR DESCRIPTION
🤖 *This PR was written by Coder Agent on behalf of Danielle Maywood.*

---

## Summary

Systematic review and fix of React Query anti-patterns and bugs across the `AgentsPage` feature. All changes are informed by the [TanStack Query reference docs](https://tanstack.com/query/latest/docs/framework/react/reference/useInfiniteQuery.md).

## Changes

### `chats.ts` (query factory) — core fixes
- **Fix broken JSDoc** that swallowed docs for `invalidateChatListQueries`.
- **Fix `typeof null === "object"`** passing the `isChatListQuery` predicate.
- **Split predicate** into `isChatListQuery` (invalidation: flat + infinite) and `isInfiniteChatListQuery` (cache manipulation: infinite only) — prevents type mismatches when `setQueriesData` hits the flat query.
- **Deduplicate** inline predicate copies in `archiveChat`/`unarchiveChat` `onMutate`.
- **Fix pageParam sequence** (`0→2→3→4`) by using offset as the page param directly with `lastPageParam` (3rd arg) per TanStack docs.
- **Await cache invalidation** in `editChatMessage` and `createChat` `onSuccess` (were fire-and-forget via `void`).
- **Remove redundant `invalidateChatListQueries`** from `onError` in archive/unarchive (`onSettled` already handles it).
- **Snapshot infinite cache** in `onMutate` for proper synchronous rollback on error, eliminating stale-data flash.

### `AgentDetail.tsx`
- Replace `void interruptMutation.mutateAsync()` with `mutate()` to prevent unhandled promise rejections.

### `AgentsPage.tsx`
- Move `archiveAndDeleteMutation` cache invalidation to `onSettled` so it fires even on partial failure.
- Guard `fetchNextPage` behind `!isFetching` to prevent races with background refetches.

### `ChatModelAdminPanel` (ProviderForm, ModelForm, ModelsSection)
- Add `.catch(() => {})` to `void mutateAsync()` calls in delete/set-default handlers.

### `SettingsPageContent.tsx`
- Replace `"me"` fallback with empty string in disabled query to avoid phantom cache entry.

### `InsightsContent.tsx`
- Round timestamps to `startOf("minute")` so `staleTime` is effective across remounts.

## Testing
- All 31 existing tests in `chats.test.ts` pass (updated for new behavior).
- TypeScript compiles cleanly.
- Biome lint/format clean.
