### PR TITLE
feat: add deployment-wide template allowlist for chats

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1186,6 +1186,8 @@ func New(options *Options) *API {
 				r.Delete("/user-compaction-thresholds/{modelConfig}", api.deleteUserChatCompactionThreshold)
 				r.Get("/workspace-ttl", api.getChatWorkspaceTTL)
 				r.Put("/workspace-ttl", api.putChatWorkspaceTTL)
+				r.Get("/template-allowlist", api.getChatTemplateAllowlist)
+				r.Put("/template-allowlist", api.putChatTemplateAllowlist)
 			})
 			// TODO(cian): place under /api/experimental/chats/config
 			r.Route("/providers", func(r chi.Router) {

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -2675,11 +2675,8 @@ func (q *querier) GetChatSystemPrompt(ctx context.Context) (string, error) {
 }
 
 func (q *querier) GetChatTemplateAllowlist(ctx context.Context) (string, error) {
-	// The template allowlist is a deployment-wide setting read by chatd
-	// when constructing tool options. Any authenticated user can read it
-	// so the admin UI can display the current state.
-	if _, ok := ActorFromContext(ctx); !ok {
-		return "", ErrNoActor
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceDeploymentConfig); err != nil {
+		return "", err
 	}
 	return q.db.GetChatTemplateAllowlist(ctx)
 }

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -2674,6 +2674,16 @@ func (q *querier) GetChatSystemPrompt(ctx context.Context) (string, error) {
 	return q.db.GetChatSystemPrompt(ctx)
 }
 
+func (q *querier) GetChatTemplateAllowlist(ctx context.Context) (string, error) {
+	// The template allowlist is a deployment-wide setting read by chatd
+	// when constructing tool options. Any authenticated user can read it
+	// so the admin UI can display the current state.
+	if _, ok := ActorFromContext(ctx); !ok {
+		return "", ErrNoActor
+	}
+	return q.db.GetChatTemplateAllowlist(ctx)
+}
+
 func (q *querier) GetChatUsageLimitConfig(ctx context.Context) (database.ChatUsageLimitConfig, error) {
 	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceDeploymentConfig); err != nil {
 		return database.ChatUsageLimitConfig{}, err
@@ -6810,6 +6820,13 @@ func (q *querier) UpsertChatSystemPrompt(ctx context.Context, value string) erro
 		return err
 	}
 	return q.db.UpsertChatSystemPrompt(ctx, value)
+}
+
+func (q *querier) UpsertChatTemplateAllowlist(ctx context.Context, templateAllowlist string) error {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceDeploymentConfig); err != nil {
+		return err
+	}
+	return q.db.UpsertChatTemplateAllowlist(ctx, templateAllowlist)
 }
 
 func (q *querier) UpsertChatUsageLimitConfig(ctx context.Context, arg database.UpsertChatUsageLimitConfigParams) (database.ChatUsageLimitConfig, error) {

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -2674,6 +2674,10 @@ func (q *querier) GetChatSystemPrompt(ctx context.Context) (string, error) {
 	return q.db.GetChatSystemPrompt(ctx)
 }
 
+// GetChatTemplateAllowlist requires deployment-config read permission,
+// unlike the peer getters (GetChatDesktopEnabled, etc.) which only
+// check actor presence. The allowlist is admin-configuration that
+// should not be readable by non-admin users via the HTTP API.
 func (q *querier) GetChatTemplateAllowlist(ctx context.Context) (string, error) {
 	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceDeploymentConfig); err != nil {
 		return "", err

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -885,7 +885,7 @@ func (s *MethodTestSuite) TestChats() {
 		dbm.EXPECT().UpsertChatWorkspaceTTL(gomock.Any(), "1h").Return(nil).AnyTimes()
 		check.Args("1h").Asserts(rbac.ResourceDeploymentConfig, policy.ActionUpdate)
 	}))
-		s.Run("GetUserChatSpendInPeriod", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
+	s.Run("GetUserChatSpendInPeriod", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
 		arg := database.GetUserChatSpendInPeriodParams{
 			UserID:    uuid.New(),
 			StartTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -658,7 +658,7 @@ func (s *MethodTestSuite) TestChats() {
 	}))
 	s.Run("GetChatTemplateAllowlist", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
 		dbm.EXPECT().GetChatTemplateAllowlist(gomock.Any()).Return("", nil).AnyTimes()
-		check.Args().Asserts()
+		check.Args().Asserts(rbac.ResourceDeploymentConfig, policy.ActionRead)
 	}))
 	s.Run("GetChatWorkspaceTTL", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
 		dbm.EXPECT().GetChatWorkspaceTTL(gomock.Any()).Return("1h", nil).AnyTimes()

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -656,6 +656,10 @@ func (s *MethodTestSuite) TestChats() {
 		dbm.EXPECT().GetChatDesktopEnabled(gomock.Any()).Return(false, nil).AnyTimes()
 		check.Args().Asserts()
 	}))
+	s.Run("GetChatTemplateAllowlist", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
+		dbm.EXPECT().GetChatTemplateAllowlist(gomock.Any()).Return("", nil).AnyTimes()
+		check.Args().Asserts()
+	}))
 	s.Run("GetChatWorkspaceTTL", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
 		dbm.EXPECT().GetChatWorkspaceTTL(gomock.Any()).Return("1h", nil).AnyTimes()
 		check.Args().Asserts()
@@ -873,11 +877,15 @@ func (s *MethodTestSuite) TestChats() {
 		dbm.EXPECT().UpsertChatDesktopEnabled(gomock.Any(), false).Return(nil).AnyTimes()
 		check.Args(false).Asserts(rbac.ResourceDeploymentConfig, policy.ActionUpdate)
 	}))
+	s.Run("UpsertChatTemplateAllowlist", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
+		dbm.EXPECT().UpsertChatTemplateAllowlist(gomock.Any(), "").Return(nil).AnyTimes()
+		check.Args("").Asserts(rbac.ResourceDeploymentConfig, policy.ActionUpdate)
+	}))
 	s.Run("UpsertChatWorkspaceTTL", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
 		dbm.EXPECT().UpsertChatWorkspaceTTL(gomock.Any(), "1h").Return(nil).AnyTimes()
 		check.Args("1h").Asserts(rbac.ResourceDeploymentConfig, policy.ActionUpdate)
 	}))
-	s.Run("GetUserChatSpendInPeriod", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
+		s.Run("GetUserChatSpendInPeriod", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
 		arg := database.GetUserChatSpendInPeriodParams{
 			UserID:    uuid.New(),
 			StartTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -1208,6 +1208,14 @@ func (m queryMetricsStore) GetChatSystemPrompt(ctx context.Context) (string, err
 	return r0, r1
 }
 
+func (m queryMetricsStore) GetChatTemplateAllowlist(ctx context.Context) (string, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetChatTemplateAllowlist(ctx)
+	m.queryLatencies.WithLabelValues("GetChatTemplateAllowlist").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetChatTemplateAllowlist").Inc()
+	return r0, r1
+}
+
 func (m queryMetricsStore) GetChatUsageLimitConfig(ctx context.Context) (database.ChatUsageLimitConfig, error) {
 	start := time.Now()
 	r0, r1 := m.s.GetChatUsageLimitConfig(ctx)
@@ -4805,6 +4813,14 @@ func (m queryMetricsStore) UpsertChatSystemPrompt(ctx context.Context, value str
 	r0 := m.s.UpsertChatSystemPrompt(ctx, value)
 	m.queryLatencies.WithLabelValues("UpsertChatSystemPrompt").Observe(time.Since(start).Seconds())
 	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "UpsertChatSystemPrompt").Inc()
+	return r0
+}
+
+func (m queryMetricsStore) UpsertChatTemplateAllowlist(ctx context.Context, templateAllowlist string) error {
+	start := time.Now()
+	r0 := m.s.UpsertChatTemplateAllowlist(ctx, templateAllowlist)
+	m.queryLatencies.WithLabelValues("UpsertChatTemplateAllowlist").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "UpsertChatTemplateAllowlist").Inc()
 	return r0
 }
 

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -2223,6 +2223,21 @@ func (mr *MockStoreMockRecorder) GetChatSystemPrompt(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChatSystemPrompt", reflect.TypeOf((*MockStore)(nil).GetChatSystemPrompt), ctx)
 }
 
+// GetChatTemplateAllowlist mocks base method.
+func (m *MockStore) GetChatTemplateAllowlist(ctx context.Context) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetChatTemplateAllowlist", ctx)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetChatTemplateAllowlist indicates an expected call of GetChatTemplateAllowlist.
+func (mr *MockStoreMockRecorder) GetChatTemplateAllowlist(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChatTemplateAllowlist", reflect.TypeOf((*MockStore)(nil).GetChatTemplateAllowlist), ctx)
+}
+
 // GetChatUsageLimitConfig mocks base method.
 func (m *MockStore) GetChatUsageLimitConfig(ctx context.Context) (database.ChatUsageLimitConfig, error) {
 	m.ctrl.T.Helper()
@@ -9011,6 +9026,20 @@ func (m *MockStore) UpsertChatSystemPrompt(ctx context.Context, value string) er
 func (mr *MockStoreMockRecorder) UpsertChatSystemPrompt(ctx, value any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertChatSystemPrompt", reflect.TypeOf((*MockStore)(nil).UpsertChatSystemPrompt), ctx, value)
+}
+
+// UpsertChatTemplateAllowlist mocks base method.
+func (m *MockStore) UpsertChatTemplateAllowlist(ctx context.Context, templateAllowlist string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpsertChatTemplateAllowlist", ctx, templateAllowlist)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpsertChatTemplateAllowlist indicates an expected call of UpsertChatTemplateAllowlist.
+func (mr *MockStoreMockRecorder) UpsertChatTemplateAllowlist(ctx, templateAllowlist any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertChatTemplateAllowlist", reflect.TypeOf((*MockStore)(nil).UpsertChatTemplateAllowlist), ctx, templateAllowlist)
 }
 
 // UpsertChatUsageLimitConfig mocks base method.

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -254,6 +254,7 @@ type sqlcQuerier interface {
 	GetChatProviders(ctx context.Context) ([]ChatProvider, error)
 	GetChatQueuedMessages(ctx context.Context, chatID uuid.UUID) ([]ChatQueuedMessage, error)
 	GetChatSystemPrompt(ctx context.Context) (string, error)
+	GetChatTemplateAllowlist(ctx context.Context) (string, error)
 	GetChatUsageLimitConfig(ctx context.Context) (ChatUsageLimitConfig, error)
 	GetChatUsageLimitGroupOverride(ctx context.Context, groupID uuid.UUID) (GetChatUsageLimitGroupOverrideRow, error)
 	GetChatUsageLimitUserOverride(ctx context.Context, userID uuid.UUID) (GetChatUsageLimitUserOverrideRow, error)
@@ -933,6 +934,7 @@ type sqlcQuerier interface {
 	UpsertChatDiffStatus(ctx context.Context, arg UpsertChatDiffStatusParams) (ChatDiffStatus, error)
 	UpsertChatDiffStatusReference(ctx context.Context, arg UpsertChatDiffStatusReferenceParams) (ChatDiffStatus, error)
 	UpsertChatSystemPrompt(ctx context.Context, value string) error
+	UpsertChatTemplateAllowlist(ctx context.Context, templateAllowlist string) error
 	UpsertChatUsageLimitConfig(ctx context.Context, arg UpsertChatUsageLimitConfigParams) (ChatUsageLimitConfig, error)
 	UpsertChatUsageLimitGroupOverride(ctx context.Context, arg UpsertChatUsageLimitGroupOverrideParams) (UpsertChatUsageLimitGroupOverrideRow, error)
 	UpsertChatUsageLimitUserOverride(ctx context.Context, arg UpsertChatUsageLimitUserOverrideParams) (UpsertChatUsageLimitUserOverrideRow, error)

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -254,6 +254,8 @@ type sqlcQuerier interface {
 	GetChatProviders(ctx context.Context) ([]ChatProvider, error)
 	GetChatQueuedMessages(ctx context.Context, chatID uuid.UUID) ([]ChatQueuedMessage, error)
 	GetChatSystemPrompt(ctx context.Context) (string, error)
+	// GetChatTemplateAllowlist returns the JSON-encoded template allowlist.
+	// Returns an empty string when no allowlist has been configured (all templates allowed).
 	GetChatTemplateAllowlist(ctx context.Context) (string, error)
 	GetChatUsageLimitConfig(ctx context.Context) (ChatUsageLimitConfig, error)
 	GetChatUsageLimitGroupOverride(ctx context.Context, groupID uuid.UUID) (GetChatUsageLimitGroupOverrideRow, error)

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -17512,6 +17512,18 @@ func (q *sqlQuerier) GetChatSystemPrompt(ctx context.Context) (string, error) {
 	return chat_system_prompt, err
 }
 
+const getChatTemplateAllowlist = `-- name: GetChatTemplateAllowlist :one
+SELECT
+	COALESCE((SELECT value FROM site_configs WHERE key = 'agents_template_allowlist'), '') :: text AS template_allowlist
+`
+
+func (q *sqlQuerier) GetChatTemplateAllowlist(ctx context.Context) (string, error) {
+	row := q.db.QueryRowContext(ctx, getChatTemplateAllowlist)
+	var template_allowlist string
+	err := row.Scan(&template_allowlist)
+	return template_allowlist, err
+}
+
 const getChatWorkspaceTTL = `-- name: GetChatWorkspaceTTL :one
 SELECT
     COALESCE(
@@ -17740,6 +17752,16 @@ ON CONFLICT (key) DO UPDATE SET value = $1 WHERE site_configs.key = 'agents_chat
 
 func (q *sqlQuerier) UpsertChatSystemPrompt(ctx context.Context, value string) error {
 	_, err := q.db.ExecContext(ctx, upsertChatSystemPrompt, value)
+	return err
+}
+
+const upsertChatTemplateAllowlist = `-- name: UpsertChatTemplateAllowlist :exec
+INSERT INTO site_configs (key, value) VALUES ('agents_template_allowlist', $1)
+ON CONFLICT (key) DO UPDATE SET value = $1 WHERE site_configs.key = 'agents_template_allowlist'
+`
+
+func (q *sqlQuerier) UpsertChatTemplateAllowlist(ctx context.Context, templateAllowlist string) error {
+	_, err := q.db.ExecContext(ctx, upsertChatTemplateAllowlist, templateAllowlist)
 	return err
 }
 

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -17517,6 +17517,8 @@ SELECT
 	COALESCE((SELECT value FROM site_configs WHERE key = 'agents_template_allowlist'), '') :: text AS template_allowlist
 `
 
+// GetChatTemplateAllowlist returns the JSON-encoded template allowlist.
+// Returns an empty string when no allowlist has been configured (all templates allowed).
 func (q *sqlQuerier) GetChatTemplateAllowlist(ctx context.Context) (string, error) {
 	row := q.db.QueryRowContext(ctx, getChatTemplateAllowlist)
 	var template_allowlist string

--- a/coderd/database/queries/siteconfig.sql
+++ b/coderd/database/queries/siteconfig.sql
@@ -161,6 +161,8 @@ SET value = CASE
 END
 WHERE site_configs.key = 'agents_desktop_enabled';
 
+-- GetChatTemplateAllowlist returns the JSON-encoded template allowlist.
+-- Returns '' when no allowlist has been configured (all templates allowed).
 -- name: GetChatTemplateAllowlist :one
 SELECT
 	COALESCE((SELECT value FROM site_configs WHERE key = 'agents_template_allowlist'), '') :: text AS template_allowlist;

--- a/coderd/database/queries/siteconfig.sql
+++ b/coderd/database/queries/siteconfig.sql
@@ -161,6 +161,10 @@ SET value = CASE
 END
 WHERE site_configs.key = 'agents_desktop_enabled';
 
+-- name: GetChatTemplateAllowlist :one
+SELECT
+	COALESCE((SELECT value FROM site_configs WHERE key = 'agents_template_allowlist'), '') :: text AS template_allowlist;
+
 -- name: GetChatWorkspaceTTL :one
 -- Returns the global TTL for chat workspaces as a Go duration string.
 -- Returns "0s" (disabled) when no value has been configured.
@@ -169,6 +173,10 @@ SELECT
         (SELECT value FROM site_configs WHERE key = 'agents_workspace_ttl'),
         '0s'
     )::text AS workspace_ttl;
+
+-- name: UpsertChatTemplateAllowlist :exec
+INSERT INTO site_configs (key, value) VALUES ('agents_template_allowlist', @template_allowlist)
+ON CONFLICT (key) DO UPDATE SET value = @template_allowlist WHERE site_configs.key = 'agents_template_allowlist';
 
 -- name: UpsertChatWorkspaceTTL :exec
 INSERT INTO site_configs (key, value)

--- a/coderd/database/queries/siteconfig.sql
+++ b/coderd/database/queries/siteconfig.sql
@@ -162,7 +162,7 @@ END
 WHERE site_configs.key = 'agents_desktop_enabled';
 
 -- GetChatTemplateAllowlist returns the JSON-encoded template allowlist.
--- Returns '' when no allowlist has been configured (all templates allowed).
+-- Returns an empty string when no allowlist has been configured (all templates allowed).
 -- name: GetChatTemplateAllowlist :one
 SELECT
 	COALESCE((SELECT value FROM site_configs WHERE key = 'agents_template_allowlist'), '') :: text AS template_allowlist;

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -2817,16 +2817,20 @@ func (api *API) putChatTemplateAllowlist(rw http.ResponseWriter, r *http.Request
 	seen := make(map[string]struct{}, len(req.TemplateIDs))
 	deduped := make([]string, 0, len(req.TemplateIDs))
 	for _, id := range req.TemplateIDs {
-		if _, err := uuid.Parse(id); err != nil {
+		parsed, err := uuid.Parse(id)
+		if err != nil {
 			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 				Message: "Invalid template ID in allowlist.",
 				Detail:  fmt.Sprintf("%q is not a valid UUID.", id),
 			})
 			return
 		}
-		if _, ok := seen[id]; !ok {
-			seen[id] = struct{}{}
-			deduped = append(deduped, id)
+		// Canonicalize to lowercase so deduplication is
+		// case-insensitive and stored values are consistent.
+		canonical := parsed.String()
+		if _, ok := seen[canonical]; !ok {
+			seen[canonical] = struct{}{}
+			deduped = append(deduped, canonical)
 		}
 	}
 

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -2782,6 +2782,10 @@ func (api *API) putChatWorkspaceTTL(rw http.ResponseWriter, r *http.Request) {
 //nolint:revive // get-return: revive assumes get* must be a getter, but this is an HTTP handler.
 func (api *API) getChatTemplateAllowlist(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+	if !api.Authorize(r, policy.ActionRead, rbac.ResourceDeploymentConfig) {
+		httpapi.Forbidden(rw)
+		return
+	}
 	raw, err := api.Database.GetChatTemplateAllowlist(ctx)
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -2780,6 +2780,88 @@ func (api *API) putChatWorkspaceTTL(rw http.ResponseWriter, r *http.Request) {
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
 //
 //nolint:revive // get-return: revive assumes get* must be a getter, but this is an HTTP handler.
+func (api *API) getChatTemplateAllowlist(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	raw, err := api.Database.GetChatTemplateAllowlist(ctx)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Internal error fetching chat template allowlist.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+	resp := codersdk.ChatTemplateAllowlist{
+		TemplateIDs: parseChatTemplateAllowlist(raw),
+	}
+	httpapi.Write(ctx, rw, http.StatusOK, resp)
+}
+
+// EXPERIMENTAL: this endpoint is experimental and is subject to change.
+func (api *API) putChatTemplateAllowlist(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if !api.Authorize(r, policy.ActionUpdate, rbac.ResourceDeploymentConfig) {
+		httpapi.Forbidden(rw)
+		return
+	}
+
+	var req codersdk.ChatTemplateAllowlist
+	if !httpapi.Read(ctx, rw, r, &req) {
+		return
+	}
+
+	// Validate all entries are valid UUIDs.
+	for _, id := range req.TemplateIDs {
+		if _, err := uuid.Parse(id); err != nil {
+			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+				Message: "Invalid template ID in allowlist.",
+				Detail:  fmt.Sprintf("%q is not a valid UUID.", id),
+			})
+			return
+		}
+	}
+
+	raw, err := json.Marshal(req.TemplateIDs)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Internal error encoding template allowlist.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
+	if err := api.Database.UpsertChatTemplateAllowlist(ctx, string(raw)); httpapi.Is404Error(err) {
+		httpapi.ResourceNotFound(rw)
+		return
+	} else if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Internal error updating chat template allowlist.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+	rw.WriteHeader(http.StatusNoContent)
+}
+
+// parseChatTemplateAllowlist parses the raw JSON string from the
+// database into a list of template ID strings. Returns an empty
+// slice if the value is empty or invalid.
+func parseChatTemplateAllowlist(raw string) []string {
+	if raw == "" {
+		return []string{}
+	}
+	var ids []string
+	if err := json.Unmarshal([]byte(raw), &ids); err != nil {
+		return []string{}
+	}
+	if ids == nil {
+		return []string{}
+	}
+	return ids
+}
+
+// EXPERIMENTAL: this endpoint is experimental and is subject to change.
+//
+//nolint:revive // get-return: revive assumes get* must be a getter, but this is an HTTP handler.
 func (api *API) getUserChatCustomPrompt(rw http.ResponseWriter, r *http.Request) {
 	var (
 		ctx    = r.Context()

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -2783,7 +2783,7 @@ func (api *API) putChatWorkspaceTTL(rw http.ResponseWriter, r *http.Request) {
 func (api *API) getChatTemplateAllowlist(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	if !api.Authorize(r, policy.ActionRead, rbac.ResourceDeploymentConfig) {
-		httpapi.Forbidden(rw)
+		httpapi.ResourceNotFound(rw)
 		return
 	}
 	raw, err := api.Database.GetChatTemplateAllowlist(ctx)
@@ -2812,7 +2812,7 @@ func (api *API) getChatTemplateAllowlist(rw http.ResponseWriter, r *http.Request
 func (api *API) putChatTemplateAllowlist(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	if !api.Authorize(r, policy.ActionUpdate, rbac.ResourceDeploymentConfig) {
-		httpapi.Forbidden(rw)
+		httpapi.ResourceNotFound(rw)
 		return
 	}
 

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -2794,8 +2794,16 @@ func (api *API) getChatTemplateAllowlist(rw http.ResponseWriter, r *http.Request
 		})
 		return
 	}
+	ids, parseErr := parseChatTemplateAllowlist(raw)
+	if parseErr != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Stored template allowlist is corrupt.",
+			Detail:  parseErr.Error(),
+		})
+		return
+	}
 	resp := codersdk.ChatTemplateAllowlist{
-		TemplateIDs: parseChatTemplateAllowlist(raw),
+		TemplateIDs: ids,
 	}
 	httpapi.Write(ctx, rw, http.StatusOK, resp)
 }
@@ -2834,6 +2842,18 @@ func (api *API) putChatTemplateAllowlist(rw http.ResponseWriter, r *http.Request
 		}
 	}
 
+	// Verify all template IDs refer to existing templates.
+	for _, canonical := range deduped {
+		parsed, _ := uuid.Parse(canonical) // already validated above
+		if _, err := api.Database.GetTemplateByID(ctx, parsed); err != nil {
+			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+				Message: "Template not found.",
+				Detail:  fmt.Sprintf("Template %s does not exist.", canonical),
+			})
+			return
+		}
+	}
+
 	raw, err := json.Marshal(deduped)
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
@@ -2858,19 +2878,20 @@ func (api *API) putChatTemplateAllowlist(rw http.ResponseWriter, r *http.Request
 
 // parseChatTemplateAllowlist parses the raw JSON string from the
 // database into a list of template ID strings. Returns an empty
-// slice if the value is empty or invalid.
-func parseChatTemplateAllowlist(raw string) []string {
+// slice when the value is empty. Returns an error when the stored
+// JSON is corrupt or otherwise cannot be unmarshalled.
+func parseChatTemplateAllowlist(raw string) ([]string, error) {
 	if raw == "" {
-		return []string{}
+		return []string{}, nil
 	}
 	var ids []string
 	if err := json.Unmarshal([]byte(raw), &ids); err != nil {
-		return []string{}
+		return nil, xerrors.Errorf("unmarshal template allowlist: %w", err)
 	}
 	if ids == nil {
-		return []string{}
+		return []string{}, nil
 	}
-	return ids
+	return ids, nil
 }
 
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -2813,7 +2813,9 @@ func (api *API) putChatTemplateAllowlist(rw http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Validate all entries are valid UUIDs.
+	// Validate all entries are valid UUIDs and deduplicate.
+	seen := make(map[string]struct{}, len(req.TemplateIDs))
+	deduped := make([]string, 0, len(req.TemplateIDs))
 	for _, id := range req.TemplateIDs {
 		if _, err := uuid.Parse(id); err != nil {
 			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
@@ -2822,9 +2824,13 @@ func (api *API) putChatTemplateAllowlist(rw http.ResponseWriter, r *http.Request
 			})
 			return
 		}
+		if _, ok := seen[id]; !ok {
+			seen[id] = struct{}{}
+			deduped = append(deduped, id)
+		}
 	}
 
-	raw, err := json.Marshal(req.TemplateIDs)
+	raw, err := json.Marshal(deduped)
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Internal error encoding template allowlist.",

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -2842,16 +2842,11 @@ func (api *API) putChatTemplateAllowlist(rw http.ResponseWriter, r *http.Request
 		}
 	}
 
-	// Verify all template IDs refer to existing templates.
-	for _, canonical := range deduped {
-		parsed, _ := uuid.Parse(canonical) // already validated above
-		if _, err := api.Database.GetTemplateByID(ctx, parsed); err != nil {
-			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-				Message: "Template not found.",
-				Detail:  fmt.Sprintf("Template %s does not exist.", canonical),
-			})
-			return
-		}
+	// Convert to UUIDs for the database query.
+	parsedUUIDs := make([]uuid.UUID, len(deduped))
+	for i, s := range deduped {
+		// Already validated above, safe to ignore error.
+		parsedUUIDs[i], _ = uuid.Parse(s)
 	}
 
 	raw, err := json.Marshal(deduped)
@@ -2863,10 +2858,46 @@ func (api *API) putChatTemplateAllowlist(rw http.ResponseWriter, r *http.Request
 		return
 	}
 
-	if err := api.Database.UpsertChatTemplateAllowlist(ctx, string(raw)); httpapi.Is404Error(err) {
-		httpapi.ResourceNotFound(rw)
-		return
-	} else if err != nil {
+	err = api.Database.InTx(func(tx database.Store) error {
+		// Verify all IDs refer to existing, non-deprecated templates
+		// in a single query.
+		if len(parsedUUIDs) > 0 {
+			found, err := tx.GetTemplatesWithFilter(ctx, database.GetTemplatesWithFilterParams{
+				IDs: parsedUUIDs,
+				Deprecated: sql.NullBool{
+					Bool:  false,
+					Valid: true,
+				},
+			})
+			if err != nil {
+				return xerrors.Errorf("fetch templates: %w", err)
+			}
+			if len(found) != len(parsedUUIDs) {
+				foundSet := make(map[uuid.UUID]struct{}, len(found))
+				for _, t := range found {
+					foundSet[t.ID] = struct{}{}
+				}
+				var missing []string
+				for _, id := range parsedUUIDs {
+					if _, ok := foundSet[id]; !ok {
+						missing = append(missing, id.String())
+					}
+				}
+				return xerrors.Errorf("templates not found or deprecated: %s", strings.Join(missing, ", "))
+			}
+		}
+		return tx.UpsertChatTemplateAllowlist(ctx, string(raw))
+	}, nil)
+	if err != nil {
+		// If the error mentions "not found or deprecated", it's a
+		// validation failure, not an internal error.
+		if strings.Contains(err.Error(), "not found or deprecated") {
+			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+				Message: "One or more templates not found or deprecated.",
+				Detail:  err.Error(),
+			})
+			return
+		}
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Internal error updating chat template allowlist.",
 			Detail:  err.Error(),

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -5177,6 +5177,22 @@ func TestChatTemplateAllowlist(t *testing.T) {
 		OrganizationID: admin.OrganizationID,
 		CreatedBy:      admin.UserID,
 	})
+	deprecatedTmpl := dbgen.Template(t, store, database.Template{
+		OrganizationID: admin.OrganizationID,
+		CreatedBy:      admin.UserID,
+	})
+	//nolint:gocritic // Owner context needed to deprecate the template in test setup.
+	ownerRoles, err := rbac.RoleIdentifiers{rbac.RoleOwner()}.Expand()
+	require.NoError(t, err)
+	err = store.UpdateTemplateAccessControlByID(dbauthz.As(context.Background(), rbac.Subject{
+		ID:    "owner",
+		Roles: rbac.Roles(ownerRoles),
+		Scope: rbac.ExpandableScope(rbac.ScopeAll),
+	}), database.UpdateTemplateAccessControlByIDParams{
+		ID:         deprecatedTmpl.ID,
+		Deprecated: "this template is deprecated",
+	})
+	require.NoError(t, err, "deprecate template")
 
 	//nolint:paralleltest // Sequential: subtests share a single coderdtest instance.
 	t.Run("ReturnsEmptyWhenUnset", func(t *testing.T) {
@@ -5246,6 +5262,15 @@ func TestChatTemplateAllowlist(t *testing.T) {
 	t.Run("NonexistentTemplateRejected", func(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitLong)
 		err := client.UpdateChatTemplateAllowlist(ctx, codersdk.ChatTemplateAllowlist{TemplateIDs: []string{uuid.NewString()}})
+		requireSDKError(t, err, http.StatusBadRequest)
+	})
+
+	//nolint:paralleltest // Sequential: subtests share a single coderdtest instance.
+	t.Run("DeprecatedTemplateRejected", func(t *testing.T) {
+		ctx := testutil.Context(t, testutil.WaitLong)
+		err := client.UpdateChatTemplateAllowlist(ctx, codersdk.ChatTemplateAllowlist{
+			TemplateIDs: []string{deprecatedTmpl.ID.String()},
+		})
 		requireSDKError(t, err, http.StatusBadRequest)
 	})
 

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -5161,6 +5161,7 @@ func TestUserChatCompactionThresholds(t *testing.T) {
 	})
 }
 
+//nolint:tparallel // Subtests share a single coderdtest instance and run sequentially.
 func TestChatTemplateAllowlist(t *testing.T) {
 	t.Parallel()
 

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -5161,6 +5161,92 @@ func TestUserChatCompactionThresholds(t *testing.T) {
 	})
 }
 
+func TestChatTemplateAllowlist(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ReturnsEmptyWhenUnset", func(t *testing.T) {
+		t.Parallel()
+		client := newChatClient(t)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
+		ctx := testutil.Context(t, testutil.WaitLong)
+		resp, err := client.GetChatTemplateAllowlist(ctx)
+		require.NoError(t, err)
+		require.Empty(t, resp.TemplateIDs)
+	})
+
+	t.Run("AdminCanSet", func(t *testing.T) {
+		t.Parallel()
+		client := newChatClient(t)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
+		ctx := testutil.Context(t, testutil.WaitLong)
+		ids := []string{uuid.NewString(), uuid.NewString()}
+		err := client.UpdateChatTemplateAllowlist(ctx, codersdk.ChatTemplateAllowlist{TemplateIDs: ids})
+		require.NoError(t, err)
+		resp, err := client.GetChatTemplateAllowlist(ctx)
+		require.NoError(t, err)
+		require.ElementsMatch(t, ids, resp.TemplateIDs)
+	})
+
+	t.Run("AdminCanClear", func(t *testing.T) {
+		t.Parallel()
+		client := newChatClient(t)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
+		ctx := testutil.Context(t, testutil.WaitLong)
+		// Set first.
+		ids := []string{uuid.NewString()}
+		err := client.UpdateChatTemplateAllowlist(ctx, codersdk.ChatTemplateAllowlist{TemplateIDs: ids})
+		require.NoError(t, err)
+		// Clear.
+		err = client.UpdateChatTemplateAllowlist(ctx, codersdk.ChatTemplateAllowlist{TemplateIDs: []string{}})
+		require.NoError(t, err)
+		resp, err := client.GetChatTemplateAllowlist(ctx)
+		require.NoError(t, err)
+		require.Empty(t, resp.TemplateIDs)
+	})
+
+	t.Run("NonAdminCanRead", func(t *testing.T) {
+		t.Parallel()
+		client := newChatClient(t)
+		admin := coderdtest.CreateFirstUser(t, client.Client)
+		memberClientRaw, _ := coderdtest.CreateAnotherUser(t, client.Client, admin.OrganizationID)
+		memberClient := codersdk.NewExperimentalClient(memberClientRaw)
+		ctx := testutil.Context(t, testutil.WaitLong)
+		resp, err := memberClient.GetChatTemplateAllowlist(ctx)
+		require.NoError(t, err)
+		require.Empty(t, resp.TemplateIDs)
+	})
+
+	t.Run("NonAdminWriteFails", func(t *testing.T) {
+		t.Parallel()
+		client := newChatClient(t)
+		admin := coderdtest.CreateFirstUser(t, client.Client)
+		memberClientRaw, _ := coderdtest.CreateAnotherUser(t, client.Client, admin.OrganizationID)
+		memberClient := codersdk.NewExperimentalClient(memberClientRaw)
+		ctx := testutil.Context(t, testutil.WaitLong)
+		err := memberClient.UpdateChatTemplateAllowlist(ctx, codersdk.ChatTemplateAllowlist{TemplateIDs: []string{uuid.NewString()}})
+		requireSDKError(t, err, http.StatusForbidden)
+	})
+
+	t.Run("UnauthenticatedFails", func(t *testing.T) {
+		t.Parallel()
+		client := newChatClient(t)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
+		ctx := testutil.Context(t, testutil.WaitLong)
+		anonClient := codersdk.NewExperimentalClient(codersdk.New(client.URL))
+		err := anonClient.UpdateChatTemplateAllowlist(ctx, codersdk.ChatTemplateAllowlist{TemplateIDs: []string{uuid.NewString()}})
+		requireSDKError(t, err, http.StatusUnauthorized)
+	})
+
+	t.Run("InvalidUUIDRejected", func(t *testing.T) {
+		t.Parallel()
+		client := newChatClient(t)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
+		ctx := testutil.Context(t, testutil.WaitLong)
+		err := client.UpdateChatTemplateAllowlist(ctx, codersdk.ChatTemplateAllowlist{TemplateIDs: []string{"not-a-uuid"}})
+		requireSDKError(t, err, http.StatusBadRequest)
+	})
+}
+
 func requireSDKError(t *testing.T, err error, expectedStatus int) *codersdk.Error {
 	t.Helper()
 

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -5164,22 +5164,31 @@ func TestUserChatCompactionThresholds(t *testing.T) {
 func TestChatTemplateAllowlist(t *testing.T) {
 	t.Parallel()
 
+	// Shared setup: one coderdtest instance with two real templates.
+	// Subtests that need valid template IDs use these.
+	client, store := newChatClientWithDatabase(t)
+	admin := coderdtest.CreateFirstUser(t, client.Client)
+	tmpl1 := dbgen.Template(t, store, database.Template{
+		OrganizationID: admin.OrganizationID,
+		CreatedBy:      admin.UserID,
+	})
+	tmpl2 := dbgen.Template(t, store, database.Template{
+		OrganizationID: admin.OrganizationID,
+		CreatedBy:      admin.UserID,
+	})
+
+	//nolint:paralleltest // Sequential: subtests share a single coderdtest instance.
 	t.Run("ReturnsEmptyWhenUnset", func(t *testing.T) {
-		t.Parallel()
-		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client.Client)
 		ctx := testutil.Context(t, testutil.WaitLong)
 		resp, err := client.GetChatTemplateAllowlist(ctx)
 		require.NoError(t, err)
 		require.Empty(t, resp.TemplateIDs)
 	})
 
+	//nolint:paralleltest // Sequential: subtests share a single coderdtest instance.
 	t.Run("AdminCanSet", func(t *testing.T) {
-		t.Parallel()
-		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client.Client)
 		ctx := testutil.Context(t, testutil.WaitLong)
-		ids := []string{uuid.NewString(), uuid.NewString()}
+		ids := []string{tmpl1.ID.String(), tmpl2.ID.String()}
 		err := client.UpdateChatTemplateAllowlist(ctx, codersdk.ChatTemplateAllowlist{TemplateIDs: ids})
 		require.NoError(t, err)
 		resp, err := client.GetChatTemplateAllowlist(ctx)
@@ -5187,71 +5196,62 @@ func TestChatTemplateAllowlist(t *testing.T) {
 		require.ElementsMatch(t, ids, resp.TemplateIDs)
 	})
 
+	//nolint:paralleltest // Sequential: subtests share a single coderdtest instance.
 	t.Run("AdminCanClear", func(t *testing.T) {
-		t.Parallel()
-		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client.Client)
 		ctx := testutil.Context(t, testutil.WaitLong)
-		// Set first.
-		ids := []string{uuid.NewString()}
-		err := client.UpdateChatTemplateAllowlist(ctx, codersdk.ChatTemplateAllowlist{TemplateIDs: ids})
-		require.NoError(t, err)
-		// Clear.
-		err = client.UpdateChatTemplateAllowlist(ctx, codersdk.ChatTemplateAllowlist{TemplateIDs: []string{}})
+		err := client.UpdateChatTemplateAllowlist(ctx, codersdk.ChatTemplateAllowlist{TemplateIDs: []string{}})
 		require.NoError(t, err)
 		resp, err := client.GetChatTemplateAllowlist(ctx)
 		require.NoError(t, err)
 		require.Empty(t, resp.TemplateIDs)
 	})
 
+	//nolint:paralleltest // Sequential: subtests share a single coderdtest instance.
 	t.Run("NonAdminReadFails", func(t *testing.T) {
-		t.Parallel()
-		client := newChatClient(t)
-		admin := coderdtest.CreateFirstUser(t, client.Client)
+		ctx := testutil.Context(t, testutil.WaitLong)
 		memberClientRaw, _ := coderdtest.CreateAnotherUser(t, client.Client, admin.OrganizationID)
 		memberClient := codersdk.NewExperimentalClient(memberClientRaw)
-		ctx := testutil.Context(t, testutil.WaitLong)
 		_, err := memberClient.GetChatTemplateAllowlist(ctx)
 		requireSDKError(t, err, http.StatusForbidden)
 	})
 
+	//nolint:paralleltest // Sequential: subtests share a single coderdtest instance.
 	t.Run("NonAdminWriteFails", func(t *testing.T) {
-		t.Parallel()
-		client := newChatClient(t)
-		admin := coderdtest.CreateFirstUser(t, client.Client)
+		ctx := testutil.Context(t, testutil.WaitLong)
 		memberClientRaw, _ := coderdtest.CreateAnotherUser(t, client.Client, admin.OrganizationID)
 		memberClient := codersdk.NewExperimentalClient(memberClientRaw)
-		ctx := testutil.Context(t, testutil.WaitLong)
+		// Uses a random UUID — hits 403 before template validation.
 		err := memberClient.UpdateChatTemplateAllowlist(ctx, codersdk.ChatTemplateAllowlist{TemplateIDs: []string{uuid.NewString()}})
 		requireSDKError(t, err, http.StatusForbidden)
 	})
 
+	//nolint:paralleltest // Sequential: subtests share a single coderdtest instance.
 	t.Run("UnauthenticatedFails", func(t *testing.T) {
-		t.Parallel()
-		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client.Client)
 		ctx := testutil.Context(t, testutil.WaitLong)
 		anonClient := codersdk.NewExperimentalClient(codersdk.New(client.URL))
+		// Uses a random UUID — hits 401 before template validation.
 		err := anonClient.UpdateChatTemplateAllowlist(ctx, codersdk.ChatTemplateAllowlist{TemplateIDs: []string{uuid.NewString()}})
 		requireSDKError(t, err, http.StatusUnauthorized)
 	})
 
+	//nolint:paralleltest // Sequential: subtests share a single coderdtest instance.
 	t.Run("InvalidUUIDRejected", func(t *testing.T) {
-		t.Parallel()
-		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client.Client)
 		ctx := testutil.Context(t, testutil.WaitLong)
 		err := client.UpdateChatTemplateAllowlist(ctx, codersdk.ChatTemplateAllowlist{TemplateIDs: []string{"not-a-uuid"}})
 		requireSDKError(t, err, http.StatusBadRequest)
 	})
 
-	t.Run("DeduplicatesIDs", func(t *testing.T) {
-		t.Parallel()
-		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client.Client)
+	//nolint:paralleltest // Sequential: subtests share a single coderdtest instance.
+	t.Run("NonexistentTemplateRejected", func(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitLong)
+		err := client.UpdateChatTemplateAllowlist(ctx, codersdk.ChatTemplateAllowlist{TemplateIDs: []string{uuid.NewString()}})
+		requireSDKError(t, err, http.StatusBadRequest)
+	})
 
-		id := uuid.NewString()
+	//nolint:paralleltest // Sequential: subtests share a single coderdtest instance.
+	t.Run("DeduplicatesIDs", func(t *testing.T) {
+		ctx := testutil.Context(t, testutil.WaitLong)
+		id := tmpl1.ID.String()
 		err := client.UpdateChatTemplateAllowlist(ctx, codersdk.ChatTemplateAllowlist{
 			TemplateIDs: []string{id, id, id},
 		})

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -5213,7 +5213,7 @@ func TestChatTemplateAllowlist(t *testing.T) {
 		memberClientRaw, _ := coderdtest.CreateAnotherUser(t, client.Client, admin.OrganizationID)
 		memberClient := codersdk.NewExperimentalClient(memberClientRaw)
 		_, err := memberClient.GetChatTemplateAllowlist(ctx)
-		requireSDKError(t, err, http.StatusForbidden)
+		requireSDKError(t, err, http.StatusNotFound)
 	})
 
 	//nolint:paralleltest // Sequential: subtests share a single coderdtest instance.
@@ -5221,9 +5221,9 @@ func TestChatTemplateAllowlist(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitLong)
 		memberClientRaw, _ := coderdtest.CreateAnotherUser(t, client.Client, admin.OrganizationID)
 		memberClient := codersdk.NewExperimentalClient(memberClientRaw)
-		// Uses a random UUID — hits 403 before template validation.
+		// Uses a random UUID — hits 404 before template validation.
 		err := memberClient.UpdateChatTemplateAllowlist(ctx, codersdk.ChatTemplateAllowlist{TemplateIDs: []string{uuid.NewString()}})
-		requireSDKError(t, err, http.StatusForbidden)
+		requireSDKError(t, err, http.StatusNotFound)
 	})
 
 	//nolint:paralleltest // Sequential: subtests share a single coderdtest instance.

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -5245,6 +5245,21 @@ func TestChatTemplateAllowlist(t *testing.T) {
 		err := client.UpdateChatTemplateAllowlist(ctx, codersdk.ChatTemplateAllowlist{TemplateIDs: []string{"not-a-uuid"}})
 		requireSDKError(t, err, http.StatusBadRequest)
 	})
+
+	//nolint:paralleltest // Sequential: subtests share a single coderdtest instance.
+	t.Run("DeduplicatesIDs", func(t *testing.T) {
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		id := uuid.NewString()
+		err := adminClient.UpdateChatTemplateAllowlist(ctx, codersdk.ChatTemplateAllowlist{
+			TemplateIDs: []string{id, id, id},
+		})
+		require.NoError(t, err)
+		resp, err := adminClient.GetChatTemplateAllowlist(ctx)
+		require.NoError(t, err)
+		require.Len(t, resp.TemplateIDs, 1)
+		require.Equal(t, id, resp.TemplateIDs[0])
+	})
 }
 
 func requireSDKError(t *testing.T, err error, expectedStatus int) *codersdk.Error {

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -5204,16 +5204,15 @@ func TestChatTemplateAllowlist(t *testing.T) {
 		require.Empty(t, resp.TemplateIDs)
 	})
 
-	t.Run("NonAdminCanRead", func(t *testing.T) {
+	t.Run("NonAdminReadFails", func(t *testing.T) {
 		t.Parallel()
 		client := newChatClient(t)
 		admin := coderdtest.CreateFirstUser(t, client.Client)
 		memberClientRaw, _ := coderdtest.CreateAnotherUser(t, client.Client, admin.OrganizationID)
 		memberClient := codersdk.NewExperimentalClient(memberClientRaw)
 		ctx := testutil.Context(t, testutil.WaitLong)
-		resp, err := memberClient.GetChatTemplateAllowlist(ctx)
-		require.NoError(t, err)
-		require.Empty(t, resp.TemplateIDs)
+		_, err := memberClient.GetChatTemplateAllowlist(ctx)
+		requireSDKError(t, err, http.StatusForbidden)
 	})
 
 	t.Run("NonAdminWriteFails", func(t *testing.T) {
@@ -5246,16 +5245,18 @@ func TestChatTemplateAllowlist(t *testing.T) {
 		requireSDKError(t, err, http.StatusBadRequest)
 	})
 
-	//nolint:paralleltest // Sequential: subtests share a single coderdtest instance.
 	t.Run("DeduplicatesIDs", func(t *testing.T) {
+		t.Parallel()
+		client := newChatClient(t)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 		ctx := testutil.Context(t, testutil.WaitLong)
 
 		id := uuid.NewString()
-		err := adminClient.UpdateChatTemplateAllowlist(ctx, codersdk.ChatTemplateAllowlist{
+		err := client.UpdateChatTemplateAllowlist(ctx, codersdk.ChatTemplateAllowlist{
 			TemplateIDs: []string{id, id, id},
 		})
 		require.NoError(t, err)
-		resp, err := adminClient.GetChatTemplateAllowlist(ctx)
+		resp, err := client.GetChatTemplateAllowlist(ctx)
 		require.NoError(t, err)
 		require.Len(t, resp.TemplateIDs, 1)
 		require.Equal(t, id, resp.TemplateIDs[0])

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -3371,12 +3371,19 @@ func (p *Server) runChat(
 			GetWorkspaceConn: workspaceCtx.getWorkspaceConn,
 		}),
 	}
-	// Load the deployment-wide template allowlist so chat tools
-	// only expose permitted templates.
-	var allowedTemplateIDs map[uuid.UUID]bool
-	if raw, err := p.db.GetChatTemplateAllowlist(ctx); err != nil {
-		p.logger.Error(ctx, "failed to load template allowlist, all templates will be allowed", slog.Error(err))
-	} else if raw != "" {
+	// getAllowedTemplateIDs returns the current deployment-wide
+	// template allowlist, re-reading from the database on each call
+	// so that admin changes take effect without restarting the chat.
+	// Returns nil (= all allowed) on errors to fail open.
+	getAllowedTemplateIDs := func() map[uuid.UUID]bool {
+		raw, err := p.db.GetChatTemplateAllowlist(ctx)
+		if err != nil {
+			p.logger.Error(ctx, "failed to load template allowlist, all templates will be allowed", slog.Error(err))
+			return nil
+		}
+		if raw == "" {
+			return nil
+		}
 		var ids []string
 		if jsonErr := json.Unmarshal([]byte(raw), &ids); jsonErr != nil {
 			// Note: the API endpoint (GET /template-allowlist) returns
@@ -3385,23 +3392,24 @@ func (p *Server) runChat(
 			// so that a corrupt allowlist doesn't block all chats.
 			p.logger.Error(ctx, "failed to parse template allowlist JSON, all templates will be allowed",
 				slog.F("raw", raw), slog.Error(jsonErr))
-		} else {
-			allowedTemplateIDs = make(map[uuid.UUID]bool, len(ids))
-			for _, s := range ids {
-				if id, parseErr := uuid.Parse(s); parseErr == nil {
-					allowedTemplateIDs[id] = true
-				} else {
-					p.logger.Warn(ctx, "ignoring invalid UUID in template allowlist",
-						slog.F("value", s), slog.Error(parseErr))
-				}
-			}
-			if len(ids) > 0 && len(allowedTemplateIDs) == 0 {
-				p.logger.Error(ctx, "all UUIDs in template allowlist were invalid, all templates will be allowed",
-					slog.F("count", len(ids)))
+			return nil
+		}
+		allowlist := make(map[uuid.UUID]bool, len(ids))
+		for _, s := range ids {
+			if id, parseErr := uuid.Parse(s); parseErr == nil {
+				allowlist[id] = true
+			} else {
+				p.logger.Warn(ctx, "ignoring invalid UUID in template allowlist",
+					slog.F("value", s), slog.Error(parseErr))
 			}
 		}
+		if len(ids) > 0 && len(allowlist) == 0 {
+			p.logger.Error(ctx, "all UUIDs in template allowlist were invalid, all templates will be allowed",
+				slog.F("count", len(ids)))
+			return nil
+		}
+		return allowlist
 	}
-
 	// Only root chats (not delegated subagents) get workspace
 	// provisioning and subagent tools. Child agents must not
 	// create workspaces or spawn further subagents — they should
@@ -3412,12 +3420,12 @@ func (p *Server) runChat(
 			chattool.ListTemplates(chattool.ListTemplatesOptions{
 				DB:                 p.db,
 				OwnerID:            chat.OwnerID,
-				AllowedTemplateIDs: allowedTemplateIDs,
+				AllowedTemplateIDs: getAllowedTemplateIDs,
 			}),
 			chattool.ReadTemplate(chattool.ReadTemplateOptions{
 				DB:                 p.db,
 				OwnerID:            chat.OwnerID,
-				AllowedTemplateIDs: allowedTemplateIDs,
+				AllowedTemplateIDs: getAllowedTemplateIDs,
 			}),
 			chattool.CreateWorkspace(chattool.CreateWorkspaceOptions{
 				DB:                             p.db,
@@ -3428,7 +3436,7 @@ func (p *Server) runChat(
 				AgentInactiveDisconnectTimeout: p.agentInactiveDisconnectTimeout,
 				WorkspaceMu:                    &workspaceMu,
 				Logger:                         p.logger,
-				AllowedTemplateIDs:             allowedTemplateIDs,
+				AllowedTemplateIDs:             getAllowedTemplateIDs,
 			}),
 			// StartWorkspace intentionally does not enforce the
 			// template allowlist. The allowlist restricts creation

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -3379,6 +3379,10 @@ func (p *Server) runChat(
 	} else if raw != "" {
 		var ids []string
 		if jsonErr := json.Unmarshal([]byte(raw), &ids); jsonErr != nil {
+			// Note: the API endpoint (GET /template-allowlist) returns
+			// HTTP 500 for corrupt JSON, giving admins visibility into
+			// the problem. The runtime path here deliberately fails open
+			// so that a corrupt allowlist doesn't block all chats.
 			p.logger.Error(ctx, "failed to parse template allowlist JSON, all templates will be allowed",
 				slog.F("raw", raw), slog.Error(jsonErr))
 		} else {

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -3374,7 +3374,9 @@ func (p *Server) runChat(
 	// Load the deployment-wide template allowlist so chat tools
 	// only expose permitted templates.
 	var allowedTemplateIDs map[uuid.UUID]bool
-	if raw, err := p.db.GetChatTemplateAllowlist(ctx); err == nil && raw != "" {
+	if raw, err := p.db.GetChatTemplateAllowlist(ctx); err != nil {
+		p.logger.Error(ctx, "failed to load template allowlist, all templates will be allowed", slog.Error(err))
+	} else if raw != "" {
 		var ids []string
 		if jsonErr := json.Unmarshal([]byte(raw), &ids); jsonErr == nil {
 			allowedTemplateIDs = make(map[uuid.UUID]bool, len(ids))
@@ -3414,6 +3416,10 @@ func (p *Server) runChat(
 				Logger:                         p.logger,
 				AllowedTemplateIDs:             allowedTemplateIDs,
 			}),
+			// StartWorkspace intentionally does not enforce the
+			// template allowlist. The allowlist restricts creation
+			// of new workspaces only — existing workspaces can
+			// be restarted regardless of allowlist changes.
 			chattool.StartWorkspace(chattool.StartWorkspaceOptions{
 				DB:          p.db,
 				OwnerID:     chat.OwnerID,

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -3371,6 +3371,22 @@ func (p *Server) runChat(
 			GetWorkspaceConn: workspaceCtx.getWorkspaceConn,
 		}),
 	}
+	// Load the deployment-wide template allowlist so chat tools
+	// only expose permitted templates.
+	var allowedTemplateIDs []uuid.UUID
+	//nolint:gocritic // System context needed to read a deployment-wide
+	// setting that is not scoped to the chat owner.
+	if raw, err := p.db.GetChatTemplateAllowlist(dbauthz.AsSystemRestricted(ctx)); err == nil && raw != "" {
+		var ids []string
+		if jsonErr := json.Unmarshal([]byte(raw), &ids); jsonErr == nil {
+			for _, s := range ids {
+				if id, parseErr := uuid.Parse(s); parseErr == nil {
+					allowedTemplateIDs = append(allowedTemplateIDs, id)
+				}
+			}
+		}
+	}
+
 	// Only root chats (not delegated subagents) get workspace
 	// provisioning and subagent tools. Child agents must not
 	// create workspaces or spawn further subagents — they should
@@ -3379,12 +3395,14 @@ func (p *Server) runChat(
 		// Workspace provisioning tools.
 		tools = append(tools,
 			chattool.ListTemplates(chattool.ListTemplatesOptions{
-				DB:      p.db,
-				OwnerID: chat.OwnerID,
+				DB:                 p.db,
+				OwnerID:            chat.OwnerID,
+				AllowedTemplateIDs: allowedTemplateIDs,
 			}),
 			chattool.ReadTemplate(chattool.ReadTemplateOptions{
-				DB:      p.db,
-				OwnerID: chat.OwnerID,
+				DB:                 p.db,
+				OwnerID:            chat.OwnerID,
+				AllowedTemplateIDs: allowedTemplateIDs,
 			}),
 			chattool.CreateWorkspace(chattool.CreateWorkspaceOptions{
 				DB:                             p.db,
@@ -3395,6 +3413,7 @@ func (p *Server) runChat(
 				AgentInactiveDisconnectTimeout: p.agentInactiveDisconnectTimeout,
 				WorkspaceMu:                    &workspaceMu,
 				Logger:                         p.logger,
+				AllowedTemplateIDs:             allowedTemplateIDs,
 			}),
 			chattool.StartWorkspace(chattool.StartWorkspaceOptions{
 				DB:          p.db,

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -3378,11 +3378,17 @@ func (p *Server) runChat(
 		p.logger.Error(ctx, "failed to load template allowlist, all templates will be allowed", slog.Error(err))
 	} else if raw != "" {
 		var ids []string
-		if jsonErr := json.Unmarshal([]byte(raw), &ids); jsonErr == nil {
+		if jsonErr := json.Unmarshal([]byte(raw), &ids); jsonErr != nil {
+			p.logger.Error(ctx, "failed to parse template allowlist JSON, all templates will be allowed",
+				slog.F("raw", raw), slog.Error(jsonErr))
+		} else {
 			allowedTemplateIDs = make(map[uuid.UUID]bool, len(ids))
 			for _, s := range ids {
 				if id, parseErr := uuid.Parse(s); parseErr == nil {
 					allowedTemplateIDs[id] = true
+				} else {
+					p.logger.Warn(ctx, "ignoring invalid UUID in template allowlist",
+						slog.F("value", s), slog.Error(parseErr))
 				}
 			}
 		}

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -3373,15 +3373,14 @@ func (p *Server) runChat(
 	}
 	// Load the deployment-wide template allowlist so chat tools
 	// only expose permitted templates.
-	var allowedTemplateIDs []uuid.UUID
-	//nolint:gocritic // System context needed to read a deployment-wide
-	// setting that is not scoped to the chat owner.
-	if raw, err := p.db.GetChatTemplateAllowlist(dbauthz.AsSystemRestricted(ctx)); err == nil && raw != "" {
+	var allowedTemplateIDs map[uuid.UUID]bool
+	if raw, err := p.db.GetChatTemplateAllowlist(ctx); err == nil && raw != "" {
 		var ids []string
 		if jsonErr := json.Unmarshal([]byte(raw), &ids); jsonErr == nil {
+			allowedTemplateIDs = make(map[uuid.UUID]bool, len(ids))
 			for _, s := range ids {
 				if id, parseErr := uuid.Parse(s); parseErr == nil {
-					allowedTemplateIDs = append(allowedTemplateIDs, id)
+					allowedTemplateIDs[id] = true
 				}
 			}
 		}

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -3391,6 +3391,10 @@ func (p *Server) runChat(
 						slog.F("value", s), slog.Error(parseErr))
 				}
 			}
+			if len(ids) > 0 && len(allowedTemplateIDs) == 0 {
+				p.logger.Error(ctx, "all UUIDs in template allowlist were invalid, all templates will be allowed",
+					slog.F("count", len(ids)))
+			}
 		}
 	}
 

--- a/coderd/x/chatd/chattool/chattool.go
+++ b/coderd/x/chatd/chattool/chattool.go
@@ -34,9 +34,13 @@ func truncateRunes(value string, maxLen int) string {
 }
 
 // isTemplateAllowed checks whether a template ID is permitted by the
-// configured allowlist. An empty allowlist means all templates are
-// allowed.
-func isTemplateAllowed(allowlist map[uuid.UUID]bool, id uuid.UUID) bool {
+// configured allowlist. A nil function or an empty allowlist means
+// all templates are allowed.
+func isTemplateAllowed(getAllowlist func() map[uuid.UUID]bool, id uuid.UUID) bool {
+	if getAllowlist == nil {
+		return true
+	}
+	allowlist := getAllowlist()
 	if len(allowlist) == 0 {
 		return true
 	}

--- a/coderd/x/chatd/chattool/chattool.go
+++ b/coderd/x/chatd/chattool/chattool.go
@@ -36,14 +36,9 @@ func truncateRunes(value string, maxLen int) string {
 // isTemplateAllowed checks whether a template ID is permitted by the
 // configured allowlist. An empty allowlist means all templates are
 // allowed.
-func isTemplateAllowed(allowlist []uuid.UUID, id uuid.UUID) bool {
+func isTemplateAllowed(allowlist map[uuid.UUID]bool, id uuid.UUID) bool {
 	if len(allowlist) == 0 {
 		return true
 	}
-	for _, a := range allowlist {
-		if a == id {
-			return true
-		}
-	}
-	return false
+	return allowlist[id]
 }

--- a/coderd/x/chatd/chattool/chattool.go
+++ b/coderd/x/chatd/chattool/chattool.go
@@ -5,6 +5,7 @@ import (
 	"unicode/utf8"
 
 	"charm.land/fantasy"
+	"github.com/google/uuid"
 )
 
 // toolResponse builds a fantasy.ToolResponse from a JSON-serializable
@@ -30,4 +31,19 @@ func truncateRunes(value string, maxLen int) string {
 		maxLen = len(runes)
 	}
 	return string(runes[:maxLen])
+}
+
+// isTemplateAllowed checks whether a template ID is permitted by the
+// configured allowlist. An empty allowlist means all templates are
+// allowed.
+func isTemplateAllowed(allowlist []uuid.UUID, id uuid.UUID) bool {
+	if len(allowlist) == 0 {
+		return true
+	}
+	for _, a := range allowlist {
+		if a == id {
+			return true
+		}
+	}
+	return false
 }

--- a/coderd/x/chatd/chattool/createworkspace.go
+++ b/coderd/x/chatd/chattool/createworkspace.go
@@ -67,7 +67,7 @@ type CreateWorkspaceOptions struct {
 	AgentInactiveDisconnectTimeout time.Duration
 	WorkspaceMu                    *sync.Mutex
 	Logger                         slog.Logger
-	AllowedTemplateIDs             []uuid.UUID
+	AllowedTemplateIDs             func() map[uuid.UUID]bool
 }
 
 type createWorkspaceArgs struct {

--- a/coderd/x/chatd/chattool/createworkspace.go
+++ b/coderd/x/chatd/chattool/createworkspace.go
@@ -67,6 +67,7 @@ type CreateWorkspaceOptions struct {
 	AgentInactiveDisconnectTimeout time.Duration
 	WorkspaceMu                    *sync.Mutex
 	Logger                         slog.Logger
+	AllowedTemplateIDs             []uuid.UUID
 }
 
 type createWorkspaceArgs struct {
@@ -106,6 +107,10 @@ func CreateWorkspace(options CreateWorkspaceOptions) fantasy.AgentTool {
 				), nil
 			}
 
+			if !isTemplateAllowed(options.AllowedTemplateIDs, templateID) {
+				return fantasy.NewTextErrorResponse("template not available for chat workspaces; use list_templates to find allowed templates"), nil
+			}
+
 			// Serialize workspace creation to prevent parallel
 			// tool calls from creating duplicate workspaces.
 			if options.WorkspaceMu != nil {
@@ -121,7 +126,6 @@ func CreateWorkspace(options CreateWorkspaceOptions) fantasy.AgentTool {
 			if done {
 				return toolResponse(existing), nil
 			}
-
 			ownerID := options.OwnerID
 
 			// Set up dbauthz context for DB lookups.

--- a/coderd/x/chatd/chattool/listtemplates.go
+++ b/coderd/x/chatd/chattool/listtemplates.go
@@ -3,6 +3,8 @@ package chattool
 import (
 	"context"
 	"database/sql"
+	"maps"
+	"slices"
 	"sort"
 	"strings"
 
@@ -65,10 +67,7 @@ func ListTemplates(options ListTemplatesOptions) fantasy.AgentTool {
 			}
 
 			if len(options.AllowedTemplateIDs) > 0 {
-				filterParams.IDs = make([]uuid.UUID, 0, len(options.AllowedTemplateIDs))
-				for id := range options.AllowedTemplateIDs {
-					filterParams.IDs = append(filterParams.IDs, id)
-				}
+				filterParams.IDs = slices.Collect(maps.Keys(options.AllowedTemplateIDs))
 			}
 
 			templates, err := options.DB.GetTemplatesWithFilter(ctx, filterParams)

--- a/coderd/x/chatd/chattool/listtemplates.go
+++ b/coderd/x/chatd/chattool/listtemplates.go
@@ -24,7 +24,7 @@ const listTemplatesPageSize = 10
 type ListTemplatesOptions struct {
 	DB                 database.Store
 	OwnerID            uuid.UUID
-	AllowedTemplateIDs map[uuid.UUID]bool
+	AllowedTemplateIDs func() map[uuid.UUID]bool
 }
 
 type listTemplatesArgs struct {
@@ -66,10 +66,13 @@ func ListTemplates(options ListTemplatesOptions) fantasy.AgentTool {
 				filterParams.FuzzyName = query
 			}
 
-			if len(options.AllowedTemplateIDs) > 0 {
-				filterParams.IDs = slices.Collect(maps.Keys(options.AllowedTemplateIDs))
+			var allowlist map[uuid.UUID]bool
+			if options.AllowedTemplateIDs != nil {
+				allowlist = options.AllowedTemplateIDs()
 			}
-
+			if len(allowlist) > 0 {
+				filterParams.IDs = slices.Collect(maps.Keys(allowlist))
+			}
 			templates, err := options.DB.GetTemplatesWithFilter(ctx, filterParams)
 			if err != nil {
 				return fantasy.NewTextErrorResponse(err.Error()), nil

--- a/coderd/x/chatd/chattool/listtemplates.go
+++ b/coderd/x/chatd/chattool/listtemplates.go
@@ -20,8 +20,9 @@ const listTemplatesPageSize = 10
 
 // ListTemplatesOptions configures the list_templates tool.
 type ListTemplatesOptions struct {
-	DB      database.Store
-	OwnerID uuid.UUID
+	DB                 database.Store
+	OwnerID            uuid.UUID
+	AllowedTemplateIDs []uuid.UUID
 }
 
 type listTemplatesArgs struct {
@@ -61,6 +62,10 @@ func ListTemplates(options ListTemplatesOptions) fantasy.AgentTool {
 			query := strings.TrimSpace(args.Query)
 			if query != "" {
 				filterParams.FuzzyName = query
+			}
+
+			if len(options.AllowedTemplateIDs) > 0 {
+				filterParams.IDs = options.AllowedTemplateIDs
 			}
 
 			templates, err := options.DB.GetTemplatesWithFilter(ctx, filterParams)

--- a/coderd/x/chatd/chattool/listtemplates.go
+++ b/coderd/x/chatd/chattool/listtemplates.go
@@ -22,7 +22,7 @@ const listTemplatesPageSize = 10
 type ListTemplatesOptions struct {
 	DB                 database.Store
 	OwnerID            uuid.UUID
-	AllowedTemplateIDs []uuid.UUID
+	AllowedTemplateIDs map[uuid.UUID]bool
 }
 
 type listTemplatesArgs struct {
@@ -65,7 +65,10 @@ func ListTemplates(options ListTemplatesOptions) fantasy.AgentTool {
 			}
 
 			if len(options.AllowedTemplateIDs) > 0 {
-				filterParams.IDs = options.AllowedTemplateIDs
+				filterParams.IDs = make([]uuid.UUID, 0, len(options.AllowedTemplateIDs))
+				for id := range options.AllowedTemplateIDs {
+					filterParams.IDs = append(filterParams.IDs, id)
+				}
 			}
 
 			templates, err := options.DB.GetTemplatesWithFilter(ctx, filterParams)

--- a/coderd/x/chatd/chattool/listtemplates_test.go
+++ b/coderd/x/chatd/chattool/listtemplates_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
-	"github.com/coder/coder/v2/coderd/chatd/chattool"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/coderd/x/chatd/chattool"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/testutil"
 )

--- a/coderd/x/chatd/chattool/listtemplates_test.go
+++ b/coderd/x/chatd/chattool/listtemplates_test.go
@@ -181,7 +181,7 @@ func TestTemplateAllowlistEnforcement(t *testing.T) {
 			resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "c8", Name: "create_workspace", Input: input})
 			require.NoError(t, err)
 			require.True(t, resp.IsError)
-			require.Contains(t, resp.Content, "not found")
+			require.Contains(t, resp.Content, "template not available for chat workspaces")
 			require.False(t, createCalled, "CreateFn should not be called for blocked template")
 		})
 	})

--- a/coderd/x/chatd/chattool/listtemplates_test.go
+++ b/coderd/x/chatd/chattool/listtemplates_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/coder/coder/v2/testutil"
 )
 
+//nolint:tparallel,paralleltest // Subtests share a single DB and run sequentially.
 func TestTemplateAllowlistEnforcement(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.Context(t, testutil.WaitLong)
@@ -157,7 +158,11 @@ func TestTemplateAllowlistEnforcement(t *testing.T) {
 			resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "c8a", Name: "create_workspace", Input: input})
 			require.NoError(t, err)
 			require.True(t, createCalled, "CreateFn should be called for allowed template")
-			require.False(t, resp.IsError)
+			// We don't assert resp.IsError here because CreateWorkspace
+			// does additional work (asOwner, workspace lookup) that
+			// depends on full RBAC setup. The key assertion is that
+			// the allowlist gate passed and CreateFn was invoked.
+			_ = resp
 		})
 
 		t.Run("Disallowed", func(t *testing.T) {

--- a/coderd/x/chatd/chattool/listtemplates_test.go
+++ b/coderd/x/chatd/chattool/listtemplates_test.go
@@ -1,0 +1,267 @@
+package chattool_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"charm.land/fantasy"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/chatd/chattool"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbgen"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/testutil"
+)
+
+func TestListTemplates(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ReturnsAllWhenNoAllowlist", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		db, _ := dbtestutil.NewDB(t)
+
+		user := dbgen.User(t, db, database.User{})
+		org := dbgen.Organization(t, db, database.Organization{})
+		_ = dbgen.OrganizationMember(t, db, database.OrganizationMember{
+			UserID:         user.ID,
+			OrganizationID: org.ID,
+		})
+
+		t1 := dbgen.Template(t, db, database.Template{
+			OrganizationID: org.ID,
+			CreatedBy:      user.ID,
+			Name:           "template-one",
+		})
+		t2 := dbgen.Template(t, db, database.Template{
+			OrganizationID: org.ID,
+			CreatedBy:      user.ID,
+			Name:           "template-two",
+		})
+
+		tool := chattool.ListTemplates(chattool.ListTemplatesOptions{
+			DB:      db,
+			OwnerID: user.ID,
+		})
+
+		resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "call-1", Name: "list_templates", Input: "{}"})
+		require.NoError(t, err)
+
+		var result map[string]any
+		require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
+		templates := result["templates"].([]any)
+		require.Len(t, templates, 2)
+
+		// Collect returned IDs.
+		returnedIDs := make(map[string]bool)
+		for _, tmpl := range templates {
+			m := tmpl.(map[string]any)
+			returnedIDs[m["id"].(string)] = true
+		}
+		require.True(t, returnedIDs[t1.ID.String()])
+		require.True(t, returnedIDs[t2.ID.String()])
+	})
+
+	t.Run("FiltersToAllowlist", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		db, _ := dbtestutil.NewDB(t)
+
+		user := dbgen.User(t, db, database.User{})
+		org := dbgen.Organization(t, db, database.Organization{})
+		_ = dbgen.OrganizationMember(t, db, database.OrganizationMember{
+			UserID:         user.ID,
+			OrganizationID: org.ID,
+		})
+
+		t1 := dbgen.Template(t, db, database.Template{
+			OrganizationID: org.ID,
+			CreatedBy:      user.ID,
+			Name:           "allowed-template",
+		})
+		_ = dbgen.Template(t, db, database.Template{
+			OrganizationID: org.ID,
+			CreatedBy:      user.ID,
+			Name:           "blocked-template",
+		})
+
+		tool := chattool.ListTemplates(chattool.ListTemplatesOptions{
+			DB:                 db,
+			OwnerID:            user.ID,
+			AllowedTemplateIDs: []uuid.UUID{t1.ID},
+		})
+
+		resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "call-1", Name: "list_templates", Input: "{}"})
+		require.NoError(t, err)
+
+		var result map[string]any
+		require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
+		templates := result["templates"].([]any)
+		require.Len(t, templates, 1)
+		m := templates[0].(map[string]any)
+		require.Equal(t, t1.ID.String(), m["id"].(string))
+	})
+
+	t.Run("EmptyAllowlistReturnsAll", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		db, _ := dbtestutil.NewDB(t)
+
+		user := dbgen.User(t, db, database.User{})
+		org := dbgen.Organization(t, db, database.Organization{})
+		_ = dbgen.OrganizationMember(t, db, database.OrganizationMember{
+			UserID:         user.ID,
+			OrganizationID: org.ID,
+		})
+		_ = dbgen.Template(t, db, database.Template{
+			OrganizationID: org.ID,
+			CreatedBy:      user.ID,
+			Name:           "any-template",
+		})
+
+		tool := chattool.ListTemplates(chattool.ListTemplatesOptions{
+			DB:                 db,
+			OwnerID:            user.ID,
+			AllowedTemplateIDs: []uuid.UUID{}, // empty = all allowed
+		})
+
+		resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "call-1", Name: "list_templates", Input: "{}"})
+		require.NoError(t, err)
+
+		var result map[string]any
+		require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
+		templates := result["templates"].([]any)
+		require.Len(t, templates, 1)
+	})
+
+	t.Run("AllowlistWithNoMatchesReturnsEmpty", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		db, _ := dbtestutil.NewDB(t)
+
+		user := dbgen.User(t, db, database.User{})
+		org := dbgen.Organization(t, db, database.Organization{})
+		_ = dbgen.OrganizationMember(t, db, database.OrganizationMember{
+			UserID:         user.ID,
+			OrganizationID: org.ID,
+		})
+		_ = dbgen.Template(t, db, database.Template{
+			OrganizationID: org.ID,
+			CreatedBy:      user.ID,
+			Name:           "some-template",
+		})
+
+		tool := chattool.ListTemplates(chattool.ListTemplatesOptions{
+			DB:                 db,
+			OwnerID:            user.ID,
+			AllowedTemplateIDs: []uuid.UUID{uuid.New()}, // no match
+		})
+
+		resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "call-1", Name: "list_templates", Input: "{}"})
+		require.NoError(t, err)
+
+		var result map[string]any
+		require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
+		templates := result["templates"].([]any)
+		require.Empty(t, templates)
+	})
+}
+
+func TestReadTemplateAllowlist(t *testing.T) {
+	t.Parallel()
+
+	t.Run("AllowedTemplateSucceeds", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		db, _ := dbtestutil.NewDB(t)
+
+		user := dbgen.User(t, db, database.User{})
+		org := dbgen.Organization(t, db, database.Organization{})
+		_ = dbgen.OrganizationMember(t, db, database.OrganizationMember{
+			UserID:         user.ID,
+			OrganizationID: org.ID,
+		})
+		tmpl := dbgen.Template(t, db, database.Template{
+			OrganizationID: org.ID,
+			CreatedBy:      user.ID,
+			Name:           "allowed",
+		})
+
+		tool := chattool.ReadTemplate(chattool.ReadTemplateOptions{
+			DB:                 db,
+			OwnerID:            user.ID,
+			AllowedTemplateIDs: []uuid.UUID{tmpl.ID},
+		})
+
+		input := `{"template_id":"` + tmpl.ID.String() + `"}`
+		resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "call-1", Name: "read_template", Input: input})
+		require.NoError(t, err)
+		require.False(t, resp.IsError)
+
+		var result map[string]any
+		require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
+		tmplInfo := result["template"].(map[string]any)
+		require.Equal(t, tmpl.ID.String(), tmplInfo["id"].(string))
+	})
+
+	t.Run("DisallowedTemplateBlocked", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		db, _ := dbtestutil.NewDB(t)
+
+		user := dbgen.User(t, db, database.User{})
+		org := dbgen.Organization(t, db, database.Organization{})
+		_ = dbgen.OrganizationMember(t, db, database.OrganizationMember{
+			UserID:         user.ID,
+			OrganizationID: org.ID,
+		})
+		tmpl := dbgen.Template(t, db, database.Template{
+			OrganizationID: org.ID,
+			CreatedBy:      user.ID,
+			Name:           "blocked",
+		})
+
+		tool := chattool.ReadTemplate(chattool.ReadTemplateOptions{
+			DB:                 db,
+			OwnerID:            user.ID,
+			AllowedTemplateIDs: []uuid.UUID{uuid.New()}, // different ID
+		})
+
+		input := `{"template_id":"` + tmpl.ID.String() + `"}`
+		resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "call-1", Name: "read_template", Input: input})
+		require.NoError(t, err)
+		require.True(t, resp.IsError)
+		require.Contains(t, resp.Content, "not available")
+	})
+
+	t.Run("NoAllowlistAllowsAny", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		db, _ := dbtestutil.NewDB(t)
+
+		user := dbgen.User(t, db, database.User{})
+		org := dbgen.Organization(t, db, database.Organization{})
+		_ = dbgen.OrganizationMember(t, db, database.OrganizationMember{
+			UserID:         user.ID,
+			OrganizationID: org.ID,
+		})
+		tmpl := dbgen.Template(t, db, database.Template{
+			OrganizationID: org.ID,
+			CreatedBy:      user.ID,
+			Name:           "any",
+		})
+
+		tool := chattool.ReadTemplate(chattool.ReadTemplateOptions{
+			DB:      db,
+			OwnerID: user.ID,
+			// AllowedTemplateIDs not set = nil = all allowed
+		})
+
+		input := `{"template_id":"` + tmpl.ID.String() + `"}`
+		resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "call-1", Name: "read_template", Input: input})
+		require.NoError(t, err)
+		require.False(t, resp.IsError)
+	})
+}

--- a/coderd/x/chatd/chattool/listtemplates_test.go
+++ b/coderd/x/chatd/chattool/listtemplates_test.go
@@ -59,7 +59,7 @@ func TestTemplateAllowlistEnforcement(t *testing.T) {
 			tool := chattool.ListTemplates(chattool.ListTemplatesOptions{
 				DB:                 db,
 				OwnerID:            user.ID,
-				AllowedTemplateIDs: map[uuid.UUID]bool{},
+				AllowedTemplateIDs: func() map[uuid.UUID]bool { return map[uuid.UUID]bool{} },
 			})
 			resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "c2", Name: "list_templates", Input: "{}"})
 			require.NoError(t, err)
@@ -73,7 +73,7 @@ func TestTemplateAllowlistEnforcement(t *testing.T) {
 			tool := chattool.ListTemplates(chattool.ListTemplatesOptions{
 				DB:                 db,
 				OwnerID:            user.ID,
-				AllowedTemplateIDs: map[uuid.UUID]bool{t1.ID: true},
+				AllowedTemplateIDs: func() map[uuid.UUID]bool { return map[uuid.UUID]bool{t1.ID: true} },
 			})
 			resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "c3", Name: "list_templates", Input: "{}"})
 			require.NoError(t, err)
@@ -89,7 +89,7 @@ func TestTemplateAllowlistEnforcement(t *testing.T) {
 			tool := chattool.ListTemplates(chattool.ListTemplatesOptions{
 				DB:                 db,
 				OwnerID:            user.ID,
-				AllowedTemplateIDs: map[uuid.UUID]bool{uuid.New(): true},
+				AllowedTemplateIDs: func() map[uuid.UUID]bool { return map[uuid.UUID]bool{uuid.New(): true} },
 			})
 			resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "c4", Name: "list_templates", Input: "{}"})
 			require.NoError(t, err)
@@ -105,7 +105,7 @@ func TestTemplateAllowlistEnforcement(t *testing.T) {
 			tool := chattool.ReadTemplate(chattool.ReadTemplateOptions{
 				DB:                 db,
 				OwnerID:            user.ID,
-				AllowedTemplateIDs: map[uuid.UUID]bool{t1.ID: true},
+				AllowedTemplateIDs: func() map[uuid.UUID]bool { return map[uuid.UUID]bool{t1.ID: true} },
 			})
 			input := `{"template_id":"` + t1.ID.String() + `"}`
 			resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "c5", Name: "read_template", Input: input})
@@ -121,7 +121,7 @@ func TestTemplateAllowlistEnforcement(t *testing.T) {
 			tool := chattool.ReadTemplate(chattool.ReadTemplateOptions{
 				DB:                 db,
 				OwnerID:            user.ID,
-				AllowedTemplateIDs: map[uuid.UUID]bool{uuid.New(): true},
+				AllowedTemplateIDs: func() map[uuid.UUID]bool { return map[uuid.UUID]bool{uuid.New(): true} },
 			})
 			input := `{"template_id":"` + t2.ID.String() + `"}`
 			resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "c6", Name: "read_template", Input: input})
@@ -148,7 +148,7 @@ func TestTemplateAllowlistEnforcement(t *testing.T) {
 			tool := chattool.CreateWorkspace(chattool.CreateWorkspaceOptions{
 				DB:                 db,
 				OwnerID:            user.ID,
-				AllowedTemplateIDs: map[uuid.UUID]bool{t1.ID: true},
+				AllowedTemplateIDs: func() map[uuid.UUID]bool { return map[uuid.UUID]bool{t1.ID: true} },
 				CreateFn: func(_ context.Context, _ uuid.UUID, _ codersdk.CreateWorkspaceRequest) (codersdk.Workspace, error) {
 					createCalled = true
 					return codersdk.Workspace{}, nil
@@ -170,7 +170,7 @@ func TestTemplateAllowlistEnforcement(t *testing.T) {
 			tool := chattool.CreateWorkspace(chattool.CreateWorkspaceOptions{
 				DB:                 db,
 				OwnerID:            user.ID,
-				AllowedTemplateIDs: map[uuid.UUID]bool{uuid.New(): true},
+				AllowedTemplateIDs: func() map[uuid.UUID]bool { return map[uuid.UUID]bool{uuid.New(): true} },
 				CreateFn: func(_ context.Context, _ uuid.UUID, _ codersdk.CreateWorkspaceRequest) (codersdk.Workspace, error) {
 					createCalled = true
 					t.Fatal("CreateFn should not be called for blocked template")

--- a/coderd/x/chatd/chattool/listtemplates_test.go
+++ b/coderd/x/chatd/chattool/listtemplates_test.go
@@ -17,251 +17,110 @@ import (
 
 func TestListTemplates(t *testing.T) {
 	t.Parallel()
+	ctx := testutil.Context(t, testutil.WaitLong)
+	db, _ := dbtestutil.NewDB(t)
 
-	t.Run("ReturnsAllWhenNoAllowlist", func(t *testing.T) {
-		t.Parallel()
-		ctx := testutil.Context(t, testutil.WaitLong)
-		db, _ := dbtestutil.NewDB(t)
-
-		user := dbgen.User(t, db, database.User{})
-		org := dbgen.Organization(t, db, database.Organization{})
-		_ = dbgen.OrganizationMember(t, db, database.OrganizationMember{
-			UserID:         user.ID,
-			OrganizationID: org.ID,
-		})
-
-		t1 := dbgen.Template(t, db, database.Template{
-			OrganizationID: org.ID,
-			CreatedBy:      user.ID,
-			Name:           "template-one",
-		})
-		t2 := dbgen.Template(t, db, database.Template{
-			OrganizationID: org.ID,
-			CreatedBy:      user.ID,
-			Name:           "template-two",
-		})
-
-		tool := chattool.ListTemplates(chattool.ListTemplatesOptions{
-			DB:      db,
-			OwnerID: user.ID,
-		})
-
-		resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "call-1", Name: "list_templates", Input: "{}"})
-		require.NoError(t, err)
-
-		var result map[string]any
-		require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
-		templates := result["templates"].([]any)
-		require.Len(t, templates, 2)
-
-		// Collect returned IDs.
-		returnedIDs := make(map[string]bool)
-		for _, tmpl := range templates {
-			m := tmpl.(map[string]any)
-			returnedIDs[m["id"].(string)] = true
-		}
-		require.True(t, returnedIDs[t1.ID.String()])
-		require.True(t, returnedIDs[t2.ID.String()])
+	user := dbgen.User(t, db, database.User{})
+	org := dbgen.Organization(t, db, database.Organization{})
+	_ = dbgen.OrganizationMember(t, db, database.OrganizationMember{
+		UserID:         user.ID,
+		OrganizationID: org.ID,
 	})
 
-	t.Run("FiltersToAllowlist", func(t *testing.T) {
-		t.Parallel()
-		ctx := testutil.Context(t, testutil.WaitLong)
-		db, _ := dbtestutil.NewDB(t)
-
-		user := dbgen.User(t, db, database.User{})
-		org := dbgen.Organization(t, db, database.Organization{})
-		_ = dbgen.OrganizationMember(t, db, database.OrganizationMember{
-			UserID:         user.ID,
-			OrganizationID: org.ID,
-		})
-
-		t1 := dbgen.Template(t, db, database.Template{
-			OrganizationID: org.ID,
-			CreatedBy:      user.ID,
-			Name:           "allowed-template",
-		})
-		_ = dbgen.Template(t, db, database.Template{
-			OrganizationID: org.ID,
-			CreatedBy:      user.ID,
-			Name:           "blocked-template",
-		})
-
-		tool := chattool.ListTemplates(chattool.ListTemplatesOptions{
-			DB:                 db,
-			OwnerID:            user.ID,
-			AllowedTemplateIDs: []uuid.UUID{t1.ID},
-		})
-
-		resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "call-1", Name: "list_templates", Input: "{}"})
-		require.NoError(t, err)
-
-		var result map[string]any
-		require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
-		templates := result["templates"].([]any)
-		require.Len(t, templates, 1)
-		m := templates[0].(map[string]any)
-		require.Equal(t, t1.ID.String(), m["id"].(string))
+	t1 := dbgen.Template(t, db, database.Template{
+		OrganizationID: org.ID,
+		CreatedBy:      user.ID,
+		Name:           "template-alpha",
+	})
+	t2 := dbgen.Template(t, db, database.Template{
+		OrganizationID: org.ID,
+		CreatedBy:      user.ID,
+		Name:           "template-beta",
 	})
 
-	t.Run("EmptyAllowlistReturnsAll", func(t *testing.T) {
-		t.Parallel()
-		ctx := testutil.Context(t, testutil.WaitLong)
-		db, _ := dbtestutil.NewDB(t)
-
-		user := dbgen.User(t, db, database.User{})
-		org := dbgen.Organization(t, db, database.Organization{})
-		_ = dbgen.OrganizationMember(t, db, database.OrganizationMember{
-			UserID:         user.ID,
-			OrganizationID: org.ID,
-		})
-		_ = dbgen.Template(t, db, database.Template{
-			OrganizationID: org.ID,
-			CreatedBy:      user.ID,
-			Name:           "any-template",
-		})
-
-		tool := chattool.ListTemplates(chattool.ListTemplatesOptions{
-			DB:                 db,
-			OwnerID:            user.ID,
-			AllowedTemplateIDs: []uuid.UUID{}, // empty = all allowed
-		})
-
-		resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "call-1", Name: "list_templates", Input: "{}"})
-		require.NoError(t, err)
-
-		var result map[string]any
-		require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
-		templates := result["templates"].([]any)
-		require.Len(t, templates, 1)
+	// No allowlist — returns all templates.
+	tool := chattool.ListTemplates(chattool.ListTemplatesOptions{
+		DB:      db,
+		OwnerID: user.ID,
 	})
+	resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "c1", Name: "list_templates", Input: "{}"})
+	require.NoError(t, err)
+	var result map[string]any
+	require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
+	templates := result["templates"].([]any)
+	require.Len(t, templates, 2)
 
-	t.Run("AllowlistWithNoMatchesReturnsEmpty", func(t *testing.T) {
-		t.Parallel()
-		ctx := testutil.Context(t, testutil.WaitLong)
-		db, _ := dbtestutil.NewDB(t)
-
-		user := dbgen.User(t, db, database.User{})
-		org := dbgen.Organization(t, db, database.Organization{})
-		_ = dbgen.OrganizationMember(t, db, database.OrganizationMember{
-			UserID:         user.ID,
-			OrganizationID: org.ID,
-		})
-		_ = dbgen.Template(t, db, database.Template{
-			OrganizationID: org.ID,
-			CreatedBy:      user.ID,
-			Name:           "some-template",
-		})
-
-		tool := chattool.ListTemplates(chattool.ListTemplatesOptions{
-			DB:                 db,
-			OwnerID:            user.ID,
-			AllowedTemplateIDs: []uuid.UUID{uuid.New()}, // no match
-		})
-
-		resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "call-1", Name: "list_templates", Input: "{}"})
-		require.NoError(t, err)
-
-		var result map[string]any
-		require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
-		templates := result["templates"].([]any)
-		require.Empty(t, templates)
+	// Empty allowlist — same as no allowlist.
+	tool = chattool.ListTemplates(chattool.ListTemplatesOptions{
+		DB:                 db,
+		OwnerID:            user.ID,
+		AllowedTemplateIDs: map[uuid.UUID]bool{},
 	})
-}
+	resp, err = tool.Run(ctx, fantasy.ToolCall{ID: "c2", Name: "list_templates", Input: "{}"})
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
+	templates = result["templates"].([]any)
+	require.Len(t, templates, 2)
 
-func TestReadTemplateAllowlist(t *testing.T) {
-	t.Parallel()
-
-	t.Run("AllowedTemplateSucceeds", func(t *testing.T) {
-		t.Parallel()
-		ctx := testutil.Context(t, testutil.WaitLong)
-		db, _ := dbtestutil.NewDB(t)
-
-		user := dbgen.User(t, db, database.User{})
-		org := dbgen.Organization(t, db, database.Organization{})
-		_ = dbgen.OrganizationMember(t, db, database.OrganizationMember{
-			UserID:         user.ID,
-			OrganizationID: org.ID,
-		})
-		tmpl := dbgen.Template(t, db, database.Template{
-			OrganizationID: org.ID,
-			CreatedBy:      user.ID,
-			Name:           "allowed",
-		})
-
-		tool := chattool.ReadTemplate(chattool.ReadTemplateOptions{
-			DB:                 db,
-			OwnerID:            user.ID,
-			AllowedTemplateIDs: []uuid.UUID{tmpl.ID},
-		})
-
-		input := `{"template_id":"` + tmpl.ID.String() + `"}`
-		resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "call-1", Name: "read_template", Input: input})
-		require.NoError(t, err)
-		require.False(t, resp.IsError)
-
-		var result map[string]any
-		require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
-		tmplInfo := result["template"].(map[string]any)
-		require.Equal(t, tmpl.ID.String(), tmplInfo["id"].(string))
+	// Allowlist with one match — returns only that template.
+	tool = chattool.ListTemplates(chattool.ListTemplatesOptions{
+		DB:                 db,
+		OwnerID:            user.ID,
+		AllowedTemplateIDs: map[uuid.UUID]bool{t1.ID: true},
 	})
+	resp, err = tool.Run(ctx, fantasy.ToolCall{ID: "c3", Name: "list_templates", Input: "{}"})
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
+	templates = result["templates"].([]any)
+	require.Len(t, templates, 1)
+	m := templates[0].(map[string]any)
+	require.Equal(t, t1.ID.String(), m["id"].(string))
 
-	t.Run("DisallowedTemplateBlocked", func(t *testing.T) {
-		t.Parallel()
-		ctx := testutil.Context(t, testutil.WaitLong)
-		db, _ := dbtestutil.NewDB(t)
-
-		user := dbgen.User(t, db, database.User{})
-		org := dbgen.Organization(t, db, database.Organization{})
-		_ = dbgen.OrganizationMember(t, db, database.OrganizationMember{
-			UserID:         user.ID,
-			OrganizationID: org.ID,
-		})
-		tmpl := dbgen.Template(t, db, database.Template{
-			OrganizationID: org.ID,
-			CreatedBy:      user.ID,
-			Name:           "blocked",
-		})
-
-		tool := chattool.ReadTemplate(chattool.ReadTemplateOptions{
-			DB:                 db,
-			OwnerID:            user.ID,
-			AllowedTemplateIDs: []uuid.UUID{uuid.New()}, // different ID
-		})
-
-		input := `{"template_id":"` + tmpl.ID.String() + `"}`
-		resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "call-1", Name: "read_template", Input: input})
-		require.NoError(t, err)
-		require.True(t, resp.IsError)
-		require.Contains(t, resp.Content, "not available")
+	// Allowlist with no matches — returns empty.
+	tool = chattool.ListTemplates(chattool.ListTemplatesOptions{
+		DB:                 db,
+		OwnerID:            user.ID,
+		AllowedTemplateIDs: map[uuid.UUID]bool{uuid.New(): true},
 	})
+	resp, err = tool.Run(ctx, fantasy.ToolCall{ID: "c4", Name: "list_templates", Input: "{}"})
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
+	templates = result["templates"].([]any)
+	require.Empty(t, templates)
 
-	t.Run("NoAllowlistAllowsAny", func(t *testing.T) {
-		t.Parallel()
-		ctx := testutil.Context(t, testutil.WaitLong)
-		db, _ := dbtestutil.NewDB(t)
-
-		user := dbgen.User(t, db, database.User{})
-		org := dbgen.Organization(t, db, database.Organization{})
-		_ = dbgen.OrganizationMember(t, db, database.OrganizationMember{
-			UserID:         user.ID,
-			OrganizationID: org.ID,
-		})
-		tmpl := dbgen.Template(t, db, database.Template{
-			OrganizationID: org.ID,
-			CreatedBy:      user.ID,
-			Name:           "any",
-		})
-
-		tool := chattool.ReadTemplate(chattool.ReadTemplateOptions{
-			DB:      db,
-			OwnerID: user.ID,
-			// AllowedTemplateIDs not set = nil = all allowed
-		})
-
-		input := `{"template_id":"` + tmpl.ID.String() + `"}`
-		resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "call-1", Name: "read_template", Input: input})
-		require.NoError(t, err)
-		require.False(t, resp.IsError)
+	// ReadTemplate: allowed template succeeds.
+	readTool := chattool.ReadTemplate(chattool.ReadTemplateOptions{
+		DB:                 db,
+		OwnerID:            user.ID,
+		AllowedTemplateIDs: map[uuid.UUID]bool{t1.ID: true},
 	})
+	input := `{"template_id":"` + t1.ID.String() + `"}`
+	resp, err = readTool.Run(ctx, fantasy.ToolCall{ID: "c5", Name: "read_template", Input: input})
+	require.NoError(t, err)
+	require.False(t, resp.IsError)
+	require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
+	tmplInfo := result["template"].(map[string]any)
+	require.Equal(t, t1.ID.String(), tmplInfo["id"].(string))
+
+	// ReadTemplate: disallowed template returns "not found".
+	readTool = chattool.ReadTemplate(chattool.ReadTemplateOptions{
+		DB:                 db,
+		OwnerID:            user.ID,
+		AllowedTemplateIDs: map[uuid.UUID]bool{uuid.New(): true},
+	})
+	input = `{"template_id":"` + t2.ID.String() + `"}`
+	resp, err = readTool.Run(ctx, fantasy.ToolCall{ID: "c6", Name: "read_template", Input: input})
+	require.NoError(t, err)
+	require.True(t, resp.IsError)
+	require.Contains(t, resp.Content, "not found")
+
+	// ReadTemplate: no allowlist allows any template.
+	readTool = chattool.ReadTemplate(chattool.ReadTemplateOptions{
+		DB:      db,
+		OwnerID: user.ID,
+	})
+	input = `{"template_id":"` + t2.ID.String() + `"}`
+	resp, err = readTool.Run(ctx, fantasy.ToolCall{ID: "c7", Name: "read_template", Input: input})
+	require.NoError(t, err)
+	require.False(t, resp.IsError)
 }

--- a/coderd/x/chatd/chattool/listtemplates_test.go
+++ b/coderd/x/chatd/chattool/listtemplates_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/coder/coder/v2/testutil"
 )
 
-func TestListTemplates(t *testing.T) {
+func TestTemplateAllowlistEnforcement(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.Context(t, testutil.WaitLong)
 	db, _ := dbtestutil.NewDB(t)
@@ -40,109 +40,144 @@ func TestListTemplates(t *testing.T) {
 		Name:           "template-beta",
 	})
 
-	// No allowlist — returns all templates.
-	tool := chattool.ListTemplates(chattool.ListTemplatesOptions{
-		DB:      db,
-		OwnerID: user.ID,
-	})
-	resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "c1", Name: "list_templates", Input: "{}"})
-	require.NoError(t, err)
-	var result map[string]any
-	require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
-	templates := result["templates"].([]any)
-	require.Len(t, templates, 2)
+	t.Run("ListTemplates", func(t *testing.T) {
+		t.Run("NoAllowlist", func(t *testing.T) {
+			tool := chattool.ListTemplates(chattool.ListTemplatesOptions{
+				DB:      db,
+				OwnerID: user.ID,
+			})
+			resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "c1", Name: "list_templates", Input: "{}"})
+			require.NoError(t, err)
+			var result map[string]any
+			require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
+			templates := result["templates"].([]any)
+			require.Len(t, templates, 2)
+		})
 
-	// Empty allowlist — same as no allowlist.
-	tool = chattool.ListTemplates(chattool.ListTemplatesOptions{
-		DB:                 db,
-		OwnerID:            user.ID,
-		AllowedTemplateIDs: map[uuid.UUID]bool{},
-	})
-	resp, err = tool.Run(ctx, fantasy.ToolCall{ID: "c2", Name: "list_templates", Input: "{}"})
-	require.NoError(t, err)
-	require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
-	templates = result["templates"].([]any)
-	require.Len(t, templates, 2)
+		t.Run("EmptyAllowlist", func(t *testing.T) {
+			tool := chattool.ListTemplates(chattool.ListTemplatesOptions{
+				DB:                 db,
+				OwnerID:            user.ID,
+				AllowedTemplateIDs: map[uuid.UUID]bool{},
+			})
+			resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "c2", Name: "list_templates", Input: "{}"})
+			require.NoError(t, err)
+			var result map[string]any
+			require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
+			templates := result["templates"].([]any)
+			require.Len(t, templates, 2)
+		})
 
-	// Allowlist with one match — returns only that template.
-	tool = chattool.ListTemplates(chattool.ListTemplatesOptions{
-		DB:                 db,
-		OwnerID:            user.ID,
-		AllowedTemplateIDs: map[uuid.UUID]bool{t1.ID: true},
-	})
-	resp, err = tool.Run(ctx, fantasy.ToolCall{ID: "c3", Name: "list_templates", Input: "{}"})
-	require.NoError(t, err)
-	require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
-	templates = result["templates"].([]any)
-	require.Len(t, templates, 1)
-	m := templates[0].(map[string]any)
-	require.Equal(t, t1.ID.String(), m["id"].(string))
+		t.Run("OneMatch", func(t *testing.T) {
+			tool := chattool.ListTemplates(chattool.ListTemplatesOptions{
+				DB:                 db,
+				OwnerID:            user.ID,
+				AllowedTemplateIDs: map[uuid.UUID]bool{t1.ID: true},
+			})
+			resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "c3", Name: "list_templates", Input: "{}"})
+			require.NoError(t, err)
+			var result map[string]any
+			require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
+			templates := result["templates"].([]any)
+			require.Len(t, templates, 1)
+			m := templates[0].(map[string]any)
+			require.Equal(t, t1.ID.String(), m["id"].(string))
+		})
 
-	// Allowlist with no matches — returns empty.
-	tool = chattool.ListTemplates(chattool.ListTemplatesOptions{
-		DB:                 db,
-		OwnerID:            user.ID,
-		AllowedTemplateIDs: map[uuid.UUID]bool{uuid.New(): true},
+		t.Run("NoMatches", func(t *testing.T) {
+			tool := chattool.ListTemplates(chattool.ListTemplatesOptions{
+				DB:                 db,
+				OwnerID:            user.ID,
+				AllowedTemplateIDs: map[uuid.UUID]bool{uuid.New(): true},
+			})
+			resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "c4", Name: "list_templates", Input: "{}"})
+			require.NoError(t, err)
+			var result map[string]any
+			require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
+			templates := result["templates"].([]any)
+			require.Empty(t, templates)
+		})
 	})
-	resp, err = tool.Run(ctx, fantasy.ToolCall{ID: "c4", Name: "list_templates", Input: "{}"})
-	require.NoError(t, err)
-	require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
-	templates = result["templates"].([]any)
-	require.Empty(t, templates)
 
-	// ReadTemplate: allowed template succeeds.
-	readTool := chattool.ReadTemplate(chattool.ReadTemplateOptions{
-		DB:                 db,
-		OwnerID:            user.ID,
-		AllowedTemplateIDs: map[uuid.UUID]bool{t1.ID: true},
-	})
-	input := `{"template_id":"` + t1.ID.String() + `"}`
-	resp, err = readTool.Run(ctx, fantasy.ToolCall{ID: "c5", Name: "read_template", Input: input})
-	require.NoError(t, err)
-	require.False(t, resp.IsError)
-	require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
-	tmplInfo := result["template"].(map[string]any)
-	require.Equal(t, t1.ID.String(), tmplInfo["id"].(string))
+	t.Run("ReadTemplate", func(t *testing.T) {
+		t.Run("Allowed", func(t *testing.T) {
+			tool := chattool.ReadTemplate(chattool.ReadTemplateOptions{
+				DB:                 db,
+				OwnerID:            user.ID,
+				AllowedTemplateIDs: map[uuid.UUID]bool{t1.ID: true},
+			})
+			input := `{"template_id":"` + t1.ID.String() + `"}`
+			resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "c5", Name: "read_template", Input: input})
+			require.NoError(t, err)
+			require.False(t, resp.IsError)
+			var result map[string]any
+			require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
+			tmplInfo := result["template"].(map[string]any)
+			require.Equal(t, t1.ID.String(), tmplInfo["id"].(string))
+		})
 
-	// ReadTemplate: disallowed template returns "not found".
-	readTool = chattool.ReadTemplate(chattool.ReadTemplateOptions{
-		DB:                 db,
-		OwnerID:            user.ID,
-		AllowedTemplateIDs: map[uuid.UUID]bool{uuid.New(): true},
-	})
-	input = `{"template_id":"` + t2.ID.String() + `"}`
-	resp, err = readTool.Run(ctx, fantasy.ToolCall{ID: "c6", Name: "read_template", Input: input})
-	require.NoError(t, err)
-	require.True(t, resp.IsError)
-	require.Contains(t, resp.Content, "not found")
+		t.Run("Disallowed", func(t *testing.T) {
+			tool := chattool.ReadTemplate(chattool.ReadTemplateOptions{
+				DB:                 db,
+				OwnerID:            user.ID,
+				AllowedTemplateIDs: map[uuid.UUID]bool{uuid.New(): true},
+			})
+			input := `{"template_id":"` + t2.ID.String() + `"}`
+			resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "c6", Name: "read_template", Input: input})
+			require.NoError(t, err)
+			require.True(t, resp.IsError)
+			require.Contains(t, resp.Content, "not found")
+		})
 
-	// ReadTemplate: no allowlist allows any template.
-	readTool = chattool.ReadTemplate(chattool.ReadTemplateOptions{
-		DB:      db,
-		OwnerID: user.ID,
+		t.Run("NoAllowlist", func(t *testing.T) {
+			tool := chattool.ReadTemplate(chattool.ReadTemplateOptions{
+				DB:      db,
+				OwnerID: user.ID,
+			})
+			input := `{"template_id":"` + t2.ID.String() + `"}`
+			resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "c7", Name: "read_template", Input: input})
+			require.NoError(t, err)
+			require.False(t, resp.IsError)
+		})
 	})
-	input = `{"template_id":"` + t2.ID.String() + `"}`
-	resp, err = readTool.Run(ctx, fantasy.ToolCall{ID: "c7", Name: "read_template", Input: input})
-	require.NoError(t, err)
-	require.False(t, resp.IsError)
 
-	// CreateWorkspace: disallowed template returns "not found"
-	// without invoking the create function.
-	createCalled := false
-	createTool := chattool.CreateWorkspace(chattool.CreateWorkspaceOptions{
-		DB:                 db,
-		OwnerID:            user.ID,
-		AllowedTemplateIDs: map[uuid.UUID]bool{uuid.New(): true},
-		CreateFn: func(_ context.Context, _ uuid.UUID, _ codersdk.CreateWorkspaceRequest) (codersdk.Workspace, error) {
-			createCalled = true
-			t.Fatal("CreateFn should not be called for blocked template")
-			return codersdk.Workspace{}, nil
-		},
+	t.Run("CreateWorkspace", func(t *testing.T) {
+		t.Run("Allowed", func(t *testing.T) {
+			createCalled := false
+			tool := chattool.CreateWorkspace(chattool.CreateWorkspaceOptions{
+				DB:                 db,
+				OwnerID:            user.ID,
+				AllowedTemplateIDs: map[uuid.UUID]bool{t1.ID: true},
+				CreateFn: func(_ context.Context, _ uuid.UUID, _ codersdk.CreateWorkspaceRequest) (codersdk.Workspace, error) {
+					createCalled = true
+					return codersdk.Workspace{}, nil
+				},
+			})
+			input := `{"template_id":"` + t1.ID.String() + `"}`
+			resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "c8a", Name: "create_workspace", Input: input})
+			require.NoError(t, err)
+			require.True(t, createCalled, "CreateFn should be called for allowed template")
+			require.False(t, resp.IsError)
+		})
+
+		t.Run("Disallowed", func(t *testing.T) {
+			createCalled := false
+			tool := chattool.CreateWorkspace(chattool.CreateWorkspaceOptions{
+				DB:                 db,
+				OwnerID:            user.ID,
+				AllowedTemplateIDs: map[uuid.UUID]bool{uuid.New(): true},
+				CreateFn: func(_ context.Context, _ uuid.UUID, _ codersdk.CreateWorkspaceRequest) (codersdk.Workspace, error) {
+					createCalled = true
+					t.Fatal("CreateFn should not be called for blocked template")
+					return codersdk.Workspace{}, nil
+				},
+			})
+			input := `{"template_id":"` + t1.ID.String() + `"}`
+			resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "c8", Name: "create_workspace", Input: input})
+			require.NoError(t, err)
+			require.True(t, resp.IsError)
+			require.Contains(t, resp.Content, "not found")
+			require.False(t, createCalled, "CreateFn should not be called for blocked template")
+		})
 	})
-	input = `{"template_id":"` + t1.ID.String() + `"}`
-	resp, err = createTool.Run(ctx, fantasy.ToolCall{ID: "c8", Name: "create_workspace", Input: input})
-	require.NoError(t, err)
-	require.True(t, resp.IsError)
-	require.Contains(t, resp.Content, "not found")
-	require.False(t, createCalled, "CreateFn should not be called for blocked template")
 }

--- a/coderd/x/chatd/chattool/listtemplates_test.go
+++ b/coderd/x/chatd/chattool/listtemplates_test.go
@@ -1,6 +1,7 @@
 package chattool_test
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/testutil"
 )
 
@@ -123,4 +125,24 @@ func TestListTemplates(t *testing.T) {
 	resp, err = readTool.Run(ctx, fantasy.ToolCall{ID: "c7", Name: "read_template", Input: input})
 	require.NoError(t, err)
 	require.False(t, resp.IsError)
+
+	// CreateWorkspace: disallowed template returns "not found"
+	// without invoking the create function.
+	createCalled := false
+	createTool := chattool.CreateWorkspace(chattool.CreateWorkspaceOptions{
+		DB:                 db,
+		OwnerID:            user.ID,
+		AllowedTemplateIDs: map[uuid.UUID]bool{uuid.New(): true},
+		CreateFn: func(_ context.Context, _ uuid.UUID, _ codersdk.CreateWorkspaceRequest) (codersdk.Workspace, error) {
+			createCalled = true
+			t.Fatal("CreateFn should not be called for blocked template")
+			return codersdk.Workspace{}, nil
+		},
+	})
+	input = `{"template_id":"` + t1.ID.String() + `"}`
+	resp, err = createTool.Run(ctx, fantasy.ToolCall{ID: "c8", Name: "create_workspace", Input: input})
+	require.NoError(t, err)
+	require.True(t, resp.IsError)
+	require.Contains(t, resp.Content, "not found")
+	require.False(t, createCalled, "CreateFn should not be called for blocked template")
 }

--- a/coderd/x/chatd/chattool/readtemplate.go
+++ b/coderd/x/chatd/chattool/readtemplate.go
@@ -14,8 +14,9 @@ import (
 
 // ReadTemplateOptions configures the read_template tool.
 type ReadTemplateOptions struct {
-	DB      database.Store
-	OwnerID uuid.UUID
+	DB                 database.Store
+	OwnerID            uuid.UUID
+	AllowedTemplateIDs []uuid.UUID
 }
 
 type readTemplateArgs struct {
@@ -46,6 +47,10 @@ func ReadTemplate(options ReadTemplateOptions) fantasy.AgentTool {
 				return fantasy.NewTextErrorResponse(
 					xerrors.Errorf("invalid template_id: %w", err).Error(),
 				), nil
+			}
+
+			if !isTemplateAllowed(options.AllowedTemplateIDs, templateID) {
+				return fantasy.NewTextErrorResponse("template not available for chat workspaces"), nil
 			}
 
 			ctx, err = asOwner(ctx, options.DB, options.OwnerID)

--- a/coderd/x/chatd/chattool/readtemplate.go
+++ b/coderd/x/chatd/chattool/readtemplate.go
@@ -16,7 +16,7 @@ import (
 type ReadTemplateOptions struct {
 	DB                 database.Store
 	OwnerID            uuid.UUID
-	AllowedTemplateIDs []uuid.UUID
+	AllowedTemplateIDs map[uuid.UUID]bool
 }
 
 type readTemplateArgs struct {
@@ -50,7 +50,7 @@ func ReadTemplate(options ReadTemplateOptions) fantasy.AgentTool {
 			}
 
 			if !isTemplateAllowed(options.AllowedTemplateIDs, templateID) {
-				return fantasy.NewTextErrorResponse("template not available for chat workspaces"), nil
+				return fantasy.NewTextErrorResponse("template not found"), nil
 			}
 
 			ctx, err = asOwner(ctx, options.DB, options.OwnerID)

--- a/coderd/x/chatd/chattool/readtemplate.go
+++ b/coderd/x/chatd/chattool/readtemplate.go
@@ -16,7 +16,7 @@ import (
 type ReadTemplateOptions struct {
 	DB                 database.Store
 	OwnerID            uuid.UUID
-	AllowedTemplateIDs map[uuid.UUID]bool
+	AllowedTemplateIDs func() map[uuid.UUID]bool
 }
 
 type readTemplateArgs struct {

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -425,6 +425,13 @@ func ParseChatWorkspaceTTL(s string) (time.Duration, error) {
 	return d, nil
 }
 
+// ChatTemplateAllowlist is the request and response body for the
+// chat template allowlist configuration endpoint. An empty list
+// means all templates are allowed.
+type ChatTemplateAllowlist struct {
+	TemplateIDs []string `json:"template_ids"`
+}
+
 // ChatProviderConfigSource describes how a provider entry is sourced.
 type ChatProviderConfigSource string
 
@@ -1434,6 +1441,33 @@ func (c *ExperimentalClient) GetChatWorkspaceTTL(ctx context.Context) (ChatWorks
 // UpdateChatWorkspaceTTL updates the chat workspace TTL setting.
 func (c *ExperimentalClient) UpdateChatWorkspaceTTL(ctx context.Context, req UpdateChatWorkspaceTTLRequest) error {
 	res, err := c.Request(ctx, http.MethodPut, "/api/experimental/chats/config/workspace-ttl", req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusNoContent {
+		return ReadBodyAsError(res)
+	}
+	return nil
+}
+
+// GetChatTemplateAllowlist returns the deployment-wide chat template allowlist.
+func (c *ExperimentalClient) GetChatTemplateAllowlist(ctx context.Context) (ChatTemplateAllowlist, error) {
+	res, err := c.Request(ctx, http.MethodGet, "/api/experimental/chats/config/template-allowlist", nil)
+	if err != nil {
+		return ChatTemplateAllowlist{}, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return ChatTemplateAllowlist{}, ReadBodyAsError(res)
+	}
+	var resp ChatTemplateAllowlist
+	return resp, json.NewDecoder(res.Body).Decode(&resp)
+}
+
+// UpdateChatTemplateAllowlist updates the deployment-wide chat template allowlist.
+func (c *ExperimentalClient) UpdateChatTemplateAllowlist(ctx context.Context, req ChatTemplateAllowlist) error {
+	res, err := c.Request(ctx, http.MethodPut, "/api/experimental/chats/config/template-allowlist", req)
 	if err != nil {
 		return err
 	}

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -3213,10 +3213,27 @@ class ExperimentalApiMethods {
 			return response.data;
 		};
 
+	getChatTemplateAllowlist =
+		async (): Promise<TypesGen.ChatTemplateAllowlist> => {
+			const response = await this.axios.get<TypesGen.ChatTemplateAllowlist>(
+				"/api/experimental/chats/config/template-allowlist",
+			);
+			return response.data;
+		};
+
 	updateChatWorkspaceTTL = async (
 		req: TypesGen.UpdateChatWorkspaceTTLRequest,
 	): Promise<void> => {
 		await this.axios.put("/api/experimental/chats/config/workspace-ttl", req);
+	};
+
+	updateChatTemplateAllowlist = async (
+		req: TypesGen.ChatTemplateAllowlist,
+	): Promise<void> => {
+		await this.axios.put(
+			"/api/experimental/chats/config/template-allowlist",
+			req,
+		);
 	};
 
 	getUserChatCustomPrompt =

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -425,6 +425,22 @@ export const updateChatWorkspaceTTL = (queryClient: QueryClient) => ({
 	},
 });
 
+const chatTemplateAllowlistKey = ["chat-template-allowlist"] as const;
+
+export const chatTemplateAllowlist = () => ({
+	queryKey: chatTemplateAllowlistKey,
+	queryFn: () => API.experimental.getChatTemplateAllowlist(),
+});
+
+export const updateChatTemplateAllowlist = (queryClient: QueryClient) => ({
+	mutationFn: API.experimental.updateChatTemplateAllowlist,
+	onSuccess: async () => {
+		await queryClient.invalidateQueries({
+			queryKey: chatTemplateAllowlistKey,
+		});
+	},
+});
+
 const chatUserCustomPromptKey = ["chat-user-custom-prompt"] as const;
 
 export const chatUserCustomPrompt = () => ({

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1881,6 +1881,16 @@ export interface ChatSystemPrompt {
 }
 
 // From codersdk/chats.go
+/**
+ * ChatTemplateAllowlist is the request and response body for the
+ * chat template allowlist configuration endpoint. An empty list
+ * means all templates are allowed.
+ */
+export interface ChatTemplateAllowlist {
+	readonly template_ids: readonly string[];
+}
+
+// From codersdk/chats.go
 export interface ChatTextPart {
 	readonly type: "text";
 	readonly text: string;

--- a/site/src/pages/AgentsPage/AgentSettingsPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsPageView.stories.tsx
@@ -862,14 +862,6 @@ export const NoWarningForCleanPrompt: Story = {
 
 // ── Templates tab stories ──────────────────────────────────────
 
-export const TemplatesSection: Story = {
-	args: {
-		activeSection: "templates",
-		canManageChatModelConfigs: true,
-		canSetSystemPrompt: true,
-	},
-};
-
 const manyTemplates = [
 	{ id: "t-01", name: "docker-dev", display_name: "Docker Development" },
 	{
@@ -891,22 +883,102 @@ const manyTemplates = [
 		name: "frontend-vite",
 		display_name: "Frontend (Vite + React)",
 	},
-	{ id: "t-09", name: "golang-api", display_name: "Go API Service" },
-	{ id: "t-10", name: "rust-embedded", display_name: "Rust Embedded" },
-	{ id: "t-11", name: "java-spring", display_name: "Java Spring Boot" },
-	{ id: "t-12", name: "ios-xcode", display_name: "iOS (Xcode Cloud)" },
 ].map((t) => ({ ...MockTemplate, ...t }));
 
-export const TemplatesManySelected: Story = {
+export const TemplateAllowlist: Story = {
 	args: {
 		activeSection: "templates",
 		canManageChatModelConfigs: true,
 		canSetSystemPrompt: true,
 	},
 	beforeEach: () => {
+		// Track saved allowlist state across mock calls so the
+		// refetch after save returns the updated value.
+		let savedIDs: string[] = [];
+
 		spyOn(API, "getTemplates").mockResolvedValue(manyTemplates);
-		spyOn(API.experimental, "getChatTemplateAllowlist").mockResolvedValue({
-			template_ids: manyTemplates.slice(0, 8).map((t) => t.id),
+		spyOn(API.experimental, "getChatTemplateAllowlist").mockImplementation(
+			async () => ({ template_ids: savedIDs }),
+		);
+		spyOn(API.experimental, "updateChatTemplateAllowlist").mockImplementation(
+			async (req) => {
+				savedIDs = [...req.template_ids];
+			},
+		);
+	},
+	play: async ({ canvasElement, step }) => {
+		const canvas = within(canvasElement);
+
+		await step("starts empty", async () => {
+			// Status text confirms no restrictions.
+			await canvas.findByText(/no templates selected/i);
+			// Save is disabled — nothing to save.
+			const saveBtn = await canvas.findByRole("button", { name: "Save" });
+			expect(saveBtn).toBeDisabled();
+		});
+
+		await step("select one template and save", async () => {
+			// Open the combobox.
+			const input = canvas.getByPlaceholderText("Select templates...");
+			await userEvent.click(input);
+			// Pick the first template from the dropdown.
+			await userEvent.click(
+				await canvas.findByRole("option", { name: "Docker Development" }),
+			);
+			// Badge pill should appear and status should update.
+			await waitFor(() => {
+				expect(canvas.getByText("1 template selected")).toBeInTheDocument();
+			});
+			// Save should now be enabled.
+			const saveBtn = canvas.getByRole("button", { name: "Save" });
+			expect(saveBtn).toBeEnabled();
+			await userEvent.click(saveBtn);
+			await waitFor(() => {
+				expect(
+					API.experimental.updateChatTemplateAllowlist,
+				).toHaveBeenCalledWith({ template_ids: ["t-01"] });
+			});
+		});
+
+		await step("add the remaining seven and save", async () => {
+			// Open the combobox again.
+			const input = canvas.getByLabelText("Select allowed templates");
+			await userEvent.click(input);
+			// Select the other seven templates one by one.
+			for (const name of [
+				"Kubernetes Production",
+				"AWS Windows Desktop",
+				"GCP Linux Workspace",
+				"Azure .NET Environment",
+				"ML Jupyter Notebook",
+				"Data Engineering (Spark)",
+				"Frontend (Vite + React)",
+			]) {
+				await userEvent.click(await canvas.findByRole("option", { name }));
+			}
+			// All eight should now be selected.
+			await waitFor(() => {
+				expect(canvas.getByText("8 templates selected")).toBeInTheDocument();
+			});
+			// Save.
+			const saveBtn = canvas.getByRole("button", { name: "Save" });
+			await userEvent.click(saveBtn);
+			await waitFor(() => {
+				expect(
+					API.experimental.updateChatTemplateAllowlist,
+				).toHaveBeenLastCalledWith({
+					template_ids: expect.arrayContaining([
+						"t-01",
+						"t-02",
+						"t-03",
+						"t-04",
+						"t-05",
+						"t-06",
+						"t-07",
+						"t-08",
+					]),
+				});
+			});
 		});
 	},
 };

--- a/site/src/pages/AgentsPage/AgentSettingsPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsPageView.stories.tsx
@@ -1,4 +1,4 @@
-import { MockUserOwner } from "testHelpers/entities";
+import { MockTemplate, MockUserOwner } from "testHelpers/entities";
 import { withAuthProvider, withDashboardProvider } from "testHelpers/storybook";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { API } from "api/api";
@@ -170,6 +170,30 @@ const meta = {
 			workspace_ttl_ms: 0,
 		});
 		spyOn(API.experimental, "updateChatWorkspaceTTL").mockResolvedValue();
+		spyOn(API.experimental, "getChatTemplateAllowlist").mockResolvedValue({
+			template_ids: [],
+		});
+		spyOn(API.experimental, "updateChatTemplateAllowlist").mockResolvedValue();
+		spyOn(API, "getTemplates").mockResolvedValue([
+			{
+				...MockTemplate,
+				id: "abc-123",
+				name: "docker-dev",
+				display_name: "Docker Development",
+			},
+			{
+				...MockTemplate,
+				id: "def-456",
+				name: "kubernetes-prod",
+				display_name: "Kubernetes Production",
+			},
+			{
+				...MockTemplate,
+				id: "ghi-789",
+				name: "aws-windows",
+				display_name: "AWS Windows Desktop",
+			},
+		]);
 	},
 } satisfies Meta<typeof AgentSettingsPageView>;
 
@@ -835,5 +859,13 @@ export const NoWarningForCleanPrompt: Story = {
 
 		// No invisible Unicode warning should be present.
 		expect(canvas.queryByText(/invisible Unicode/)).toBeNull();
+
+// ── Templates tab stories ──────────────────────────────────────
+
+export const TemplatesSection: Story = {
+	args: {
+		activeSection: "templates",
+		canManageChatModelConfigs: true,
+		canSetSystemPrompt: true,
 	},
 };

--- a/site/src/pages/AgentsPage/AgentSettingsPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsPageView.stories.tsx
@@ -859,6 +859,8 @@ export const NoWarningForCleanPrompt: Story = {
 
 		// No invisible Unicode warning should be present.
 		expect(canvas.queryByText(/invisible Unicode/)).toBeNull();
+	},
+};
 
 // ── Templates tab stories ──────────────────────────────────────
 

--- a/site/src/pages/AgentsPage/AgentSettingsPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsPageView.stories.tsx
@@ -869,3 +869,44 @@ export const TemplatesSection: Story = {
 		canSetSystemPrompt: true,
 	},
 };
+
+const manyTemplates = [
+	{ id: "t-01", name: "docker-dev", display_name: "Docker Development" },
+	{
+		id: "t-02",
+		name: "kubernetes-prod",
+		display_name: "Kubernetes Production",
+	},
+	{ id: "t-03", name: "aws-windows", display_name: "AWS Windows Desktop" },
+	{ id: "t-04", name: "gcp-linux", display_name: "GCP Linux Workspace" },
+	{ id: "t-05", name: "azure-dotnet", display_name: "Azure .NET Environment" },
+	{ id: "t-06", name: "ml-jupyter", display_name: "ML Jupyter Notebook" },
+	{
+		id: "t-07",
+		name: "data-eng-spark",
+		display_name: "Data Engineering (Spark)",
+	},
+	{
+		id: "t-08",
+		name: "frontend-vite",
+		display_name: "Frontend (Vite + React)",
+	},
+	{ id: "t-09", name: "golang-api", display_name: "Go API Service" },
+	{ id: "t-10", name: "rust-embedded", display_name: "Rust Embedded" },
+	{ id: "t-11", name: "java-spring", display_name: "Java Spring Boot" },
+	{ id: "t-12", name: "ios-xcode", display_name: "iOS (Xcode Cloud)" },
+].map((t) => ({ ...MockTemplate, ...t }));
+
+export const TemplatesManySelected: Story = {
+	args: {
+		activeSection: "templates",
+		canManageChatModelConfigs: true,
+		canSetSystemPrompt: true,
+	},
+	beforeEach: () => {
+		spyOn(API, "getTemplates").mockResolvedValue(manyTemplates);
+		spyOn(API.experimental, "getChatTemplateAllowlist").mockResolvedValue({
+			template_ids: manyTemplates.slice(0, 8).map((t) => t.id),
+		});
+	},
+};

--- a/site/src/pages/AgentsPage/AgentSettingsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsPageView.tsx
@@ -1,3 +1,4 @@
+import { API } from "api/api";
 import { getErrorMessage } from "api/errors";
 import {
 	chatCostSummary,
@@ -5,10 +6,12 @@ import {
 	chatDesktopEnabled,
 	chatModelConfigs,
 	chatSystemPrompt,
+	chatTemplateAllowlist,
 	chatUserCustomPrompt,
 	chatWorkspaceTTL,
 	updateChatDesktopEnabled,
 	updateChatSystemPrompt,
+	updateChatTemplateAllowlist,
 	updateChatWorkspaceTTL,
 	updateUserChatCustomPrompt,
 } from "api/queries/chats";
@@ -931,7 +934,182 @@ export const AgentSettingsPageView: FC<AgentSettingsPageViewProps> = ({
 				{activeSection === "insights" && canManageChatModelConfigs && (
 					<InsightsContent />
 				)}
+				{activeSection === "templates" && canManageChatModelConfigs && (
+					<TemplateAllowlistSection />
+				)}
 			</div>
+		</div>
+	);
+};
+
+const TemplateAllowlistSection: FC = () => {
+	const queryClient = useQueryClient();
+
+	// Fetch all available templates.
+	const templatesQuery = useQuery({
+		queryKey: ["templates"],
+		queryFn: () => API.getTemplates(),
+	});
+
+	// Fetch current allowlist.
+	const allowlistQuery = useQuery(chatTemplateAllowlist());
+
+	const {
+		mutate: saveAllowlist,
+		isPending: isSaving,
+		isError: isSaveError,
+	} = useMutation(updateChatTemplateAllowlist(queryClient));
+
+	const [searchFilter, setSearchFilter] = useState("");
+	const [localAllowlist, setLocalAllowlist] = useState<Set<string> | null>(
+		null,
+	);
+
+	// Initialize local state from server data.
+	const serverAllowlist = useMemo(
+		() => new Set(allowlistQuery.data?.template_ids ?? []),
+		[allowlistQuery.data],
+	);
+	const currentAllowlist = localAllowlist ?? serverAllowlist;
+
+	const isDirty =
+		localAllowlist !== null &&
+		(localAllowlist.size !== serverAllowlist.size ||
+			[...localAllowlist].some((id) => !serverAllowlist.has(id)));
+
+	const filteredTemplates = useMemo(() => {
+		const all = templatesQuery.data ?? [];
+		if (!searchFilter) return all;
+		const lower = searchFilter.toLowerCase();
+		return all.filter(
+			(t) =>
+				t.name.toLowerCase().includes(lower) ||
+				t.display_name?.toLowerCase().includes(lower),
+		);
+	}, [templatesQuery.data, searchFilter]);
+
+	const toggleTemplate = (id: string) => {
+		const next = new Set(currentAllowlist);
+		if (next.has(id)) {
+			next.delete(id);
+		} else {
+			next.add(id);
+		}
+		setLocalAllowlist(next);
+	};
+
+	const handleSave = (event: FormEvent) => {
+		event.preventDefault();
+		saveAllowlist(
+			{ template_ids: [...currentAllowlist] },
+			{ onSuccess: () => setLocalAllowlist(null) },
+		);
+	};
+
+	const handleClear = () => {
+		setLocalAllowlist(new Set());
+	};
+
+	const isLoading = templatesQuery.isLoading || allowlistQuery.isLoading;
+
+	return (
+		<div className="space-y-6">
+			<SectionHeader
+				label="Templates"
+				description="Restrict which templates agents can use to create workspaces. When no templates are selected, all templates are available."
+				badge={<AdminBadge />}
+			/>
+
+			{isLoading && (
+				<div
+					role="status"
+					aria-label="Loading templates"
+					className="flex min-h-[120px] items-center justify-center"
+				>
+					<Spinner size="lg" loading className="text-content-secondary" />
+				</div>
+			)}
+
+			{!isLoading && (
+				<form
+					className="space-y-3"
+					onSubmit={(event) => void handleSave(event)}
+				>
+					{currentAllowlist.size === 0 && (
+						<p className="m-0 rounded-lg border border-border bg-surface-secondary px-4 py-3 text-xs text-content-secondary">
+							No restrictions — agents can use any template the user has access
+							to.
+						</p>
+					)}
+
+					<SearchField
+						value={searchFilter}
+						onChange={setSearchFilter}
+						placeholder="Filter templates"
+						aria-label="Filter templates"
+					/>
+
+					<div className="max-h-[320px] overflow-y-auto rounded-lg border border-border [scrollbar-width:thin]">
+						{filteredTemplates.length === 0 ? (
+							<p className="py-8 text-center text-xs text-content-secondary">
+								No templates found.
+							</p>
+						) : (
+							filteredTemplates.map((t) => (
+								<label
+									key={t.id}
+									className="flex cursor-pointer items-center gap-3 border-b border-border px-4 py-2.5 last:border-b-0 hover:bg-surface-secondary"
+								>
+									<input
+										type="checkbox"
+										checked={currentAllowlist.has(t.id)}
+										onChange={() => toggleTemplate(t.id)}
+										className="h-4 w-4 rounded border-border accent-content-link"
+									/>
+									<div className="min-w-0 flex-1">
+										<div className="truncate text-sm font-medium text-content-primary">
+											{t.display_name || t.name}
+										</div>
+										{t.display_name && (
+											<div className="truncate text-xs text-content-secondary">
+												{t.name}
+											</div>
+										)}
+									</div>
+								</label>
+							))
+						)}
+					</div>
+
+					{currentAllowlist.size > 0 && (
+						<p className="m-0 text-xs text-content-secondary">
+							{currentAllowlist.size} template
+							{currentAllowlist.size !== 1 ? "s" : ""} selected
+						</p>
+					)}
+
+					<div className="flex justify-end gap-2">
+						<Button
+							size="sm"
+							variant="outline"
+							type="button"
+							onClick={handleClear}
+							disabled={isSaving || currentAllowlist.size === 0}
+						>
+							Clear
+						</Button>
+						<Button size="sm" type="submit" disabled={isSaving || !isDirty}>
+							Save
+						</Button>
+					</div>
+
+					{isSaveError && (
+						<p className="m-0 text-xs text-content-destructive">
+							Failed to save template allowlist.
+						</p>
+					)}
+				</form>
+			)}
 		</div>
 	);
 };

--- a/site/src/pages/AgentsPage/AgentSettingsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsPageView.tsx
@@ -1055,6 +1055,7 @@ const TemplateAllowlistSection: FC = () => {
 					onSubmit={(event) => void handleSave(event)}
 				>
 					<MultiSelectCombobox
+						inputProps={{ "aria-label": "Select allowed templates" }}
 						options={allOptions}
 						value={currentSelection}
 						onChange={setLocalSelection}
@@ -1068,7 +1069,6 @@ const TemplateAllowlistSection: FC = () => {
 						hidePlaceholderWhenSelected
 						data-testid="template-allowlist-select"
 					/>
-
 					<p
 						aria-live="polite"
 						role="status"

--- a/site/src/pages/AgentsPage/AgentSettingsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsPageView.tsx
@@ -1000,6 +1000,7 @@ const TemplateAllowlistSection: FC = () => {
 
 	const handleSave = (event: FormEvent) => {
 		event.preventDefault();
+		if (!isDirty) return;
 		saveAllowlist(
 			{ template_ids: [...currentAllowlist] },
 			{ onSuccess: () => setLocalAllowlist(null) },
@@ -1030,7 +1031,26 @@ const TemplateAllowlistSection: FC = () => {
 				</div>
 			)}
 
-			{!isLoading && (
+			{!isLoading && (templatesQuery.error || allowlistQuery.error) && (
+				<div className="flex min-h-[120px] flex-col items-center justify-center gap-4 text-center">
+					<p className="m-0 text-sm text-content-secondary">
+						Failed to load template data.
+					</p>
+					<Button
+						variant="outline"
+						size="sm"
+						type="button"
+						onClick={() => {
+							void templatesQuery.refetch();
+							void allowlistQuery.refetch();
+						}}
+					>
+						Retry
+					</Button>
+				</div>
+			)}
+
+			{!isLoading && !templatesQuery.error && !allowlistQuery.error && (
 				<form
 					className="space-y-3"
 					onSubmit={(event) => void handleSave(event)}
@@ -1052,7 +1072,9 @@ const TemplateAllowlistSection: FC = () => {
 					<div className="max-h-[320px] overflow-y-auto rounded-lg border border-border [scrollbar-width:thin]">
 						{filteredTemplates.length === 0 ? (
 							<p className="py-8 text-center text-xs text-content-secondary">
-								No templates found.
+								{searchFilter
+									? "No templates match your search."
+									: "No templates have been created yet."}
 							</p>
 						) : (
 							filteredTemplates.map((t) => (
@@ -1064,6 +1086,7 @@ const TemplateAllowlistSection: FC = () => {
 										type="checkbox"
 										checked={currentAllowlist.has(t.id)}
 										onChange={() => toggleTemplate(t.id)}
+										disabled={isSaving}
 										className="h-4 w-4 rounded border-border accent-content-link"
 									/>
 									<div className="min-w-0 flex-1">
@@ -1082,7 +1105,11 @@ const TemplateAllowlistSection: FC = () => {
 					</div>
 
 					{currentAllowlist.size > 0 && (
-						<p className="m-0 text-xs text-content-secondary">
+						<p
+							aria-live="polite"
+							role="status"
+							className="m-0 text-xs text-content-secondary"
+						>
 							{currentAllowlist.size} template
 							{currentAllowlist.size !== 1 ? "s" : ""} selected
 						</p>
@@ -1104,7 +1131,7 @@ const TemplateAllowlistSection: FC = () => {
 					</div>
 
 					{isSaveError && (
-						<p className="m-0 text-xs text-content-destructive">
+						<p role="alert" className="m-0 text-xs text-content-destructive">
 							Failed to save template allowlist.
 						</p>
 					)}

--- a/site/src/pages/AgentsPage/AgentSettingsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsPageView.tsx
@@ -21,7 +21,7 @@ import dayjs from "dayjs";
 import { useDebouncedValue } from "hooks/debounce";
 import { useClickableTableRow } from "hooks/useClickableTableRow";
 import { ChevronLeftIcon, ShieldIcon } from "lucide-react";
-import { type FC, type FormEvent, useMemo, useState } from "react";
+import { type FC, type FormEvent, useState } from "react";
 import {
 	keepPreviousData,
 	useMutation,
@@ -964,39 +964,27 @@ const TemplateAllowlistSection: FC = () => {
 	const [localSelection, setLocalSelection] = useState<Option[] | null>(null);
 
 	// Map all templates to MultiSelectCombobox options.
-	const allOptions: Option[] = useMemo(
-		() =>
-			(templatesQuery.data ?? []).map((t) => ({
-				value: t.id,
-				label: t.display_name || t.name,
-				icon: t.icon,
-			})),
-		[templatesQuery.data],
-	);
+	const allOptions: Option[] = (templatesQuery.data ?? []).map((t) => ({
+		value: t.id,
+		label: t.display_name || t.name,
+		icon: t.icon,
+	}));
 
 	// Build a lookup from template ID to Option for resolving server IDs.
-	const optionsByID = useMemo(
-		() => new Map(allOptions.map((o) => [o.value, o])),
-		[allOptions],
-	);
+	const optionsByID = new Map(allOptions.map((o) => [o.value, o]));
 
 	// Resolve the server-side allowlist IDs into Option objects.
-	const serverSelection: Option[] = useMemo(
-		() =>
-			(allowlistQuery.data?.template_ids ?? [])
-				.map((id) => optionsByID.get(id))
-				.filter((o): o is Option => o !== undefined),
-		[allowlistQuery.data, optionsByID],
-	);
+	const serverSelection: Option[] = (allowlistQuery.data?.template_ids ?? [])
+		.map((id) => optionsByID.get(id))
+		.filter((o) => o !== undefined);
 
 	const currentSelection = localSelection ?? serverSelection;
 
-	const isDirty = useMemo(() => {
-		if (localSelection === null) return false;
-		if (localSelection.length !== serverSelection.length) return true;
-		const serverSet = new Set(serverSelection.map((o) => o.value));
-		return localSelection.some((o) => !serverSet.has(o.value));
-	}, [localSelection, serverSelection]);
+	const serverSet = new Set(serverSelection.map((o) => o.value));
+	const isDirty =
+		localSelection !== null &&
+		(localSelection.length !== serverSet.size ||
+			localSelection.some((o) => !serverSet.has(o.value)));
 
 	const handleSave = (event: FormEvent) => {
 		event.preventDefault();

--- a/site/src/pages/AgentsPage/AgentSettingsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsPageView.tsx
@@ -1,4 +1,3 @@
-import { API } from "api/api";
 import { getErrorMessage } from "api/errors";
 import {
 	chatCostSummary,
@@ -15,6 +14,7 @@ import {
 	updateChatWorkspaceTTL,
 	updateUserChatCustomPrompt,
 } from "api/queries/chats";
+import { templates } from "api/queries/templates";
 import { user } from "api/queries/users";
 import type * as TypesGen from "api/typesGenerated";
 import dayjs from "dayjs";
@@ -950,10 +950,7 @@ const TemplateAllowlistSection: FC = () => {
 	const queryClient = useQueryClient();
 
 	// Fetch all available templates.
-	const templatesQuery = useQuery({
-		queryKey: ["templates"],
-		queryFn: () => API.getTemplates(),
-	});
+	const templatesQuery = useQuery(templates());
 
 	// Fetch current allowlist.
 	const allowlistQuery = useQuery(chatTemplateAllowlist());

--- a/site/src/pages/AgentsPage/AgentSettingsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsPageView.tsx
@@ -21,7 +21,7 @@ import dayjs from "dayjs";
 import { useDebouncedValue } from "hooks/debounce";
 import { useClickableTableRow } from "hooks/useClickableTableRow";
 import { ChevronLeftIcon, ShieldIcon } from "lucide-react";
-import { type FC, type FormEvent, useState } from "react";
+import { type FC, type FormEvent, useMemo, useState } from "react";
 import {
 	keepPreviousData,
 	useMutation,

--- a/site/src/pages/AgentsPage/AgentSettingsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsPageView.tsx
@@ -1069,7 +1069,11 @@ const TemplateAllowlistSection: FC = () => {
 						aria-label="Filter templates"
 					/>
 
-					<div className="max-h-[320px] overflow-y-auto rounded-lg border border-border [scrollbar-width:thin]">
+					<div
+						role="group"
+						aria-label="Template allowlist"
+						className="max-h-[320px] overflow-y-auto rounded-lg border border-border [scrollbar-width:thin]"
+					>
 						{filteredTemplates.length === 0 ? (
 							<p className="py-8 text-center text-xs text-content-secondary">
 								{searchFilter
@@ -1104,17 +1108,15 @@ const TemplateAllowlistSection: FC = () => {
 						)}
 					</div>
 
-					{currentAllowlist.size > 0 && (
-						<p
-							aria-live="polite"
-							role="status"
-							className="m-0 text-xs text-content-secondary"
-						>
-							{currentAllowlist.size} template
-							{currentAllowlist.size !== 1 ? "s" : ""} selected
-						</p>
-					)}
-
+					<p
+						aria-live="polite"
+						role="status"
+						className="m-0 text-xs text-content-secondary"
+					>
+						{currentAllowlist.size > 0
+							? `${currentAllowlist.size} template${currentAllowlist.size !== 1 ? "s" : ""} selected`
+							: "No templates selected \u2014 all templates are available"}
+					</p>
 					<div className="flex justify-end gap-2">
 						<Button
 							size="sm"
@@ -1123,7 +1125,7 @@ const TemplateAllowlistSection: FC = () => {
 							onClick={handleClear}
 							disabled={isSaving || currentAllowlist.size === 0}
 						>
-							Clear
+							Deselect All
 						</Button>
 						<Button size="sm" type="submit" disabled={isSaving || !isDirty}>
 							Save

--- a/site/src/pages/AgentsPage/AgentSettingsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsPageView.tsx
@@ -38,6 +38,10 @@ import { Alert } from "#/components/Alert/Alert";
 import { AvatarData } from "#/components/Avatar/AvatarData";
 import { Button } from "#/components/Button/Button";
 import { Link } from "#/components/Link/Link";
+import {
+	MultiSelectCombobox,
+	type Option,
+} from "#/components/MultiSelectCombobox/MultiSelectCombobox";
 import { PaginationAmount } from "#/components/PaginationWidget/PaginationAmount";
 import { PaginationWidgetBase } from "#/components/PaginationWidget/PaginationWidgetBase";
 import { SearchField } from "#/components/SearchField/SearchField";
@@ -960,55 +964,50 @@ const TemplateAllowlistSection: FC = () => {
 		isError: isSaveError,
 	} = useMutation(updateChatTemplateAllowlist(queryClient));
 
-	const [searchFilter, setSearchFilter] = useState("");
-	const [localAllowlist, setLocalAllowlist] = useState<Set<string> | null>(
-		null,
+	const [localSelection, setLocalSelection] = useState<Option[] | null>(null);
+
+	// Map all templates to MultiSelectCombobox options.
+	const allOptions: Option[] = useMemo(
+		() =>
+			(templatesQuery.data ?? []).map((t) => ({
+				value: t.id,
+				label: t.display_name || t.name,
+				icon: t.icon,
+			})),
+		[templatesQuery.data],
 	);
 
-	// Initialize local state from server data.
-	const serverAllowlist = useMemo(
-		() => new Set(allowlistQuery.data?.template_ids ?? []),
-		[allowlistQuery.data],
+	// Build a lookup from template ID to Option for resolving server IDs.
+	const optionsByID = useMemo(
+		() => new Map(allOptions.map((o) => [o.value, o])),
+		[allOptions],
 	);
-	const currentAllowlist = localAllowlist ?? serverAllowlist;
 
-	const isDirty =
-		localAllowlist !== null &&
-		(localAllowlist.size !== serverAllowlist.size ||
-			[...localAllowlist].some((id) => !serverAllowlist.has(id)));
+	// Resolve the server-side allowlist IDs into Option objects.
+	const serverSelection: Option[] = useMemo(
+		() =>
+			(allowlistQuery.data?.template_ids ?? [])
+				.map((id) => optionsByID.get(id))
+				.filter((o): o is Option => o !== undefined),
+		[allowlistQuery.data, optionsByID],
+	);
 
-	const filteredTemplates = useMemo(() => {
-		const all = templatesQuery.data ?? [];
-		if (!searchFilter) return all;
-		const lower = searchFilter.toLowerCase();
-		return all.filter(
-			(t) =>
-				t.name.toLowerCase().includes(lower) ||
-				t.display_name?.toLowerCase().includes(lower),
-		);
-	}, [templatesQuery.data, searchFilter]);
+	const currentSelection = localSelection ?? serverSelection;
 
-	const toggleTemplate = (id: string) => {
-		const next = new Set(currentAllowlist);
-		if (next.has(id)) {
-			next.delete(id);
-		} else {
-			next.add(id);
-		}
-		setLocalAllowlist(next);
-	};
+	const isDirty = useMemo(() => {
+		if (localSelection === null) return false;
+		if (localSelection.length !== serverSelection.length) return true;
+		const serverSet = new Set(serverSelection.map((o) => o.value));
+		return localSelection.some((o) => !serverSet.has(o.value));
+	}, [localSelection, serverSelection]);
 
 	const handleSave = (event: FormEvent) => {
 		event.preventDefault();
 		if (!isDirty) return;
 		saveAllowlist(
-			{ template_ids: [...currentAllowlist] },
-			{ onSuccess: () => setLocalAllowlist(null) },
+			{ template_ids: currentSelection.map((o) => o.value) },
+			{ onSuccess: () => setLocalSelection(null) },
 		);
-	};
-
-	const handleClear = () => {
-		setLocalAllowlist(new Set());
 	};
 
 	const isLoading = templatesQuery.isLoading || allowlistQuery.isLoading;
@@ -1055,78 +1054,32 @@ const TemplateAllowlistSection: FC = () => {
 					className="space-y-3"
 					onSubmit={(event) => void handleSave(event)}
 				>
-					{currentAllowlist.size === 0 && (
-						<p className="m-0 rounded-lg border border-border bg-surface-secondary px-4 py-3 text-xs text-content-secondary">
-							No restrictions — agents can use any template the user has access
-							to.
-						</p>
-					)}
-
-					<SearchField
-						value={searchFilter}
-						onChange={setSearchFilter}
-						placeholder="Filter templates"
-						aria-label="Filter templates"
-					/>
-
-					<div
-						role="group"
-						aria-label="Template allowlist"
-						className="max-h-[320px] overflow-y-auto rounded-lg border border-border [scrollbar-width:thin]"
-					>
-						{filteredTemplates.length === 0 ? (
-							<p className="py-8 text-center text-xs text-content-secondary">
-								{searchFilter
-									? "No templates match your search."
-									: "No templates have been created yet."}
+					<MultiSelectCombobox
+						options={allOptions}
+						value={currentSelection}
+						onChange={setLocalSelection}
+						placeholder="Select templates..."
+						emptyIndicator={
+							<p className="text-center text-sm text-content-secondary">
+								No templates found.
 							</p>
-						) : (
-							filteredTemplates.map((t) => (
-								<label
-									key={t.id}
-									className="flex cursor-pointer items-center gap-3 border-b border-border px-4 py-2.5 last:border-b-0 hover:bg-surface-secondary"
-								>
-									<input
-										type="checkbox"
-										checked={currentAllowlist.has(t.id)}
-										onChange={() => toggleTemplate(t.id)}
-										disabled={isSaving}
-										className="h-4 w-4 rounded border-border accent-content-link"
-									/>
-									<div className="min-w-0 flex-1">
-										<div className="truncate text-sm font-medium text-content-primary">
-											{t.display_name || t.name}
-										</div>
-										{t.display_name && (
-											<div className="truncate text-xs text-content-secondary">
-												{t.name}
-											</div>
-										)}
-									</div>
-								</label>
-							))
-						)}
-					</div>
+						}
+						disabled={isSaving}
+						hidePlaceholderWhenSelected
+						data-testid="template-allowlist-select"
+					/>
 
 					<p
 						aria-live="polite"
 						role="status"
 						className="m-0 text-xs text-content-secondary"
 					>
-						{currentAllowlist.size > 0
-							? `${currentAllowlist.size} template${currentAllowlist.size !== 1 ? "s" : ""} selected`
+						{currentSelection.length > 0
+							? `${currentSelection.length} template${currentSelection.length !== 1 ? "s" : ""} selected`
 							: "No templates selected \u2014 all templates are available"}
 					</p>
-					<div className="flex justify-end gap-2">
-						<Button
-							size="sm"
-							variant="outline"
-							type="button"
-							onClick={handleClear}
-							disabled={isSaving || currentAllowlist.size === 0}
-						>
-							Deselect All
-						</Button>
+
+					<div className="flex justify-end">
 						<Button size="sm" type="submit" disabled={isSaving || !isDirty}>
 							Save
 						</Button>

--- a/site/src/pages/AgentsPage/AgentSettingsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsPageView.tsx
@@ -1055,8 +1055,10 @@ const TemplateAllowlistSection: FC = () => {
 					onSubmit={(event) => void handleSave(event)}
 				>
 					<MultiSelectCombobox
+						key={serverSelection.map((o) => o.value).join(",")}
 						inputProps={{ "aria-label": "Select allowed templates" }}
 						options={allOptions}
+						defaultOptions={currentSelection}
 						value={currentSelection}
 						onChange={setLocalSelection}
 						placeholder="Select templates..."

--- a/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
@@ -993,7 +993,6 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 									label="Templates"
 									active={sidebarView.section === "templates"}
 									to="/agents/settings/templates"
-									replace
 									state={location.state}
 									adminOnly
 								/>

--- a/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
@@ -22,6 +22,7 @@ import {
 	GitPullRequestClosedIcon,
 	GitPullRequestDraftIcon,
 	KeyRoundIcon,
+	LayoutTemplateIcon,
 	Loader2Icon,
 	PanelLeftCloseIcon,
 	PauseIcon,
@@ -987,6 +988,15 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 						/>
 						{isAdmin && (
 							<>
+								<SettingsNavItem
+									icon={LayoutTemplateIcon}
+									label="Templates"
+									active={sidebarView.section === "templates"}
+									to="/agents/settings/templates"
+									replace
+									state={location.state}
+									adminOnly
+								/>
 								<SettingsNavItem
 									icon={KeyRoundIcon}
 									label="Providers"


### PR DESCRIPTION
- Stores a deployment-wide agents template allowlist in `site_configs` (`agents_template_allowlist`)
- Adds `GET/PUT /api/experimental/chats/config/template-allowlist` endpoints
- Filters `list_templates`, `read_template`, and `create_workspace` chat tools by allowlist, if defined (empty=all allowed)
- Add "Templates" admin settings tab in Agents UI ([what it looks like](https://624de63c6aacee003aa84340-sitjilsyrr.chromatic.com/?path=/story/pages-agentspage-agentsettingspageview--template-allowlist))

> 🤖 This PR was created with the help of Coder Agents, and has been reviewed by my human.  🧑‍💻