### PR TITLE
fix(site): handle invalid coder_app URLs gracefully instead of crashing

### DIFF
--- a/site/src/modules/apps/apps.test.ts
+++ b/site/src/modules/apps/apps.test.ts
@@ -112,6 +112,21 @@ describe("getAppHref", () => {
 		expect(href).toBe(externalApp.url);
 	});
 
+	it("returns an empty string when external app has an invalid URL", () => {
+		const externalApp = {
+			...MockWorkspaceApp,
+			external: true,
+			url: "not-a-valid-url",
+		};
+		const href = getAppHref(externalApp, {
+			host: "*.apps-host.tld",
+			path: "/path-base",
+			agent: MockWorkspaceAgent,
+			workspace: MockWorkspace,
+		});
+		expect(href).toBe("");
+	});
+
 	it("returns a path when app doesn't use a subdomain", () => {
 		const app = {
 			...MockWorkspaceApp,

--- a/site/src/modules/apps/apps.ts
+++ b/site/src/modules/apps/apps.ts
@@ -105,7 +105,15 @@ export const getAppHref = (
 	{ path, token, workspace, agent, host }: GetAppHrefParams,
 ): string => {
 	if (isExternalApp(app)) {
-		const appProtocol = new URL(app.url).protocol;
+		let appProtocol: string;
+		try {
+			appProtocol = new URL(app.url).protocol;
+		} catch {
+			// The URL is not parseable (e.g. missing scheme). Return an empty
+			// string so callers can detect this and render an error state
+			// instead of crashing the page.
+			return "";
+		}
 		const isAllowedProtocol =
 			ALLOWED_EXTERNAL_APP_PROTOCOLS.includes(appProtocol);
 

--- a/site/src/modules/resources/AppLink/AppLink.tsx
+++ b/site/src/modules/resources/AppLink/AppLink.tsx
@@ -109,6 +109,18 @@ export const AppLink: FC<AppLinkProps> = ({
 		);
 	}
 
+	if (isExternalApp(app) && !link.href) {
+		canClick = false;
+		icon = (
+			<CircleAlertIcon
+				aria-hidden="true"
+				className="size-icon-sm text-content-warning"
+			/>
+		);
+		primaryTooltip =
+			"This app has an invalid URL. A template admin must fix the app URL.";
+	}
+
 	if (isExternalApp(app) && needsSessionToken(app) && !link.hasToken) {
 		canClick = false;
 	}


### PR DESCRIPTION
Fixes #22349
Fixes #22350

## Problem

`getAppHref()` in `site/src/modules/apps/apps.ts` calls `new URL(app.url)` without any error handling. When a template author provides an invalid URL on an external `coder_app` (e.g. `"my-repo"` with no scheme), JavaScript's `URL` constructor throws a `TypeError`. Since this runs during render via `useAppLink`, the unhandled exception crashes both the Workspace List and Workspace detail pages — not just the broken app button.

## Changes

**`site/src/modules/apps/apps.ts`** — Wrap the `new URL()` call in a try-catch. If the URL is unparseable, return an empty string as a sentinel value instead of letting the exception propagate.

**`site/src/modules/resources/AppLink/AppLink.tsx`** — Detect the empty href for external apps and render a disabled button with a warning icon and tooltip ("This app has an invalid URL. A template admin must fix the app URL."). This follows the same pattern already used for missing subdomain configuration.

**`site/src/modules/apps/apps.test.ts`** — Added a test case verifying `getAppHref()` returns `""` for an external app with an invalid URL.