### PR TITLE
fix(coderd): gate OAuth2 well-known endpoints behind experiment flag

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1044,10 +1044,12 @@ func New(options *Options) *API {
 
 	// OAuth2 metadata endpoint for RFC 8414 discovery
 	r.Route("/.well-known/oauth-authorization-server", func(r chi.Router) {
+		r.Use(httpmw.RequireExperimentWithDevBypass(api.Experiments, codersdk.ExperimentOAuth2))
 		r.Get("/*", api.oauth2AuthorizationServerMetadata())
 	})
 	// OAuth2 protected resource metadata endpoint for RFC 9728 discovery
 	r.Route("/.well-known/oauth-protected-resource", func(r chi.Router) {
+		r.Use(httpmw.RequireExperimentWithDevBypass(api.Experiments, codersdk.ExperimentOAuth2))
 		r.Get("/*", api.oauth2ProtectedResourceMetadata())
 	})
 


### PR DESCRIPTION
## Summary

- Add `RequireExperimentWithDevBypass` middleware to `/.well-known/oauth-authorization-server` and `/.well-known/oauth-protected-resource` routes, matching the existing `/oauth2` routes.
- Clients can now detect OAuth2 support via unauthenticated discovery (404 = not available).

Fixes https://github.com/coder/coder/issues/21608