### PR TITLE
feat(dogfood): add Android development template

### DIFF
--- a/dogfood/coder-android/Dockerfile
+++ b/dogfood/coder-android/Dockerfile
@@ -1,0 +1,170 @@
+FROM ubuntu:24.04 AS go
+
+# Install Go and gcc from apt, then build gomobile/gobind for Android
+# Go bindings.
+ARG GOPATH="/tmp/"
+
+RUN apt-get update && \
+	apt-get install --yes golang gcc && \
+	mkdir --parents "$GOPATH" && \
+	go install golang.org/x/mobile/cmd/gomobile@latest && \
+	go install golang.org/x/mobile/cmd/gobind@latest && \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/*
+
+FROM ubuntu:24.04
+
+SHELL ["/bin/bash", "-c"]
+
+# Install packages from apt repositories.
+ARG DEBIAN_FRONTEND="noninteractive"
+
+# Install core system packages needed for Android development.
+RUN apt-get update && \
+	apt-get install --yes \
+	build-essential \
+	ca-certificates \
+	curl \
+	git \
+	gnupg \
+	htop \
+	jq \
+	less \
+	libusb-1.0-0 \
+	openssh-server \
+	screen \
+	sudo \
+	tmux \
+	udev \
+	unzip \
+	usbutils \
+	vim \
+	wget \
+	zip && \
+	# Delete package cache to avoid consuming space in layer.
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/*
+
+# Install JDK 17 for Android builds.
+RUN apt-get update && \
+	apt-get install --yes openjdk-17-jdk && \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+
+# Install Android SDK command-line tools.
+ARG ANDROID_SDK_TOOLS_VERSION=14742923
+ENV ANDROID_HOME=/opt/android-sdk
+ENV ANDROID_SDK_ROOT=/opt/android-sdk
+
+RUN mkdir -p ${ANDROID_HOME}/cmdline-tools && \
+	curl --silent --show-error --location --fail \
+	"https://dl.google.com/android/repository/commandlinetools-linux-${ANDROID_SDK_TOOLS_VERSION}_latest.zip" \
+	-o /tmp/cmdline-tools.zip && \
+	unzip -q /tmp/cmdline-tools.zip -d ${ANDROID_HOME}/cmdline-tools && \
+	mv ${ANDROID_HOME}/cmdline-tools/cmdline-tools ${ANDROID_HOME}/cmdline-tools/latest && \
+	rm /tmp/cmdline-tools.zip
+
+ENV PATH=${PATH}:${ANDROID_HOME}/cmdline-tools/latest/bin:${ANDROID_HOME}/platform-tools
+
+# Accept all Android SDK licenses and install SDK components.
+# platform-tools: adb and fastboot
+# build-tools: aapt, dx, zipalign for building APKs
+# platforms: target API levels for compilation
+# ndk: Native Development Kit for C/C++ code
+# cmake: required by NDK for native builds
+RUN yes | sdkmanager --licenses > /dev/null 2>&1 && \
+	sdkmanager \
+	"platform-tools" \
+	"build-tools;35.0.0" \
+	"platforms;android-35" \
+	"platforms;android-34" \
+	"ndk;27.2.12479018" \
+	"cmake;3.22.1" \
+	"cmdline-tools;latest"
+
+ENV ANDROID_NDK_HOME=${ANDROID_HOME}/ndk/27.2.12479018
+
+# Install Gradle 8.11 for project builds.
+ARG GRADLE_VERSION=8.11
+RUN curl --silent --show-error --location --fail \
+	"https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \
+	-o /tmp/gradle.zip && \
+	unzip -q /tmp/gradle.zip -d /opt && \
+	mv /opt/gradle-${GRADLE_VERSION} /opt/gradle && \
+	rm /tmp/gradle.zip
+
+ENV PATH=${PATH}:/opt/gradle/bin
+
+# Install Go from apt and copy only the gomobile/gobind binaries
+# built in the go stage.
+RUN apt-get update && \
+	apt-get install --yes golang && \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/*
+
+COPY --from=go /tmp/bin /usr/local/bin
+
+ENV GOPATH=/home/coder/go
+ENV PATH=${PATH}:${GOPATH}/bin
+
+# See https://github.com/cli/cli/issues/6175#issuecomment-1235984381 for
+# proof the apt repository is unreliable.
+RUN GH_CLI_VERSION=$(curl -s "https://api.github.com/repos/cli/cli/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') && \
+	curl -L "https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_amd64.deb" -o gh.deb && \
+	dpkg -i gh.deb && \
+	rm gh.deb
+
+# Configure udev rules for common Android device vendors so that
+# USB-connected devices are accessible without root.
+RUN mkdir -p /etc/udev/rules.d && \
+	echo '# Google' > /etc/udev/rules.d/51-android.rules && \
+	echo 'SUBSYSTEM=="usb", ATTR{idVendor}=="18d1", MODE="0666", GROUP="plugdev"' >> /etc/udev/rules.d/51-android.rules && \
+	echo '# Samsung' >> /etc/udev/rules.d/51-android.rules && \
+	echo 'SUBSYSTEM=="usb", ATTR{idVendor}=="04e8", MODE="0666", GROUP="plugdev"' >> /etc/udev/rules.d/51-android.rules && \
+	echo '# HTC' >> /etc/udev/rules.d/51-android.rules && \
+	echo 'SUBSYSTEM=="usb", ATTR{idVendor}=="0bb4", MODE="0666", GROUP="plugdev"' >> /etc/udev/rules.d/51-android.rules && \
+	echo '# Huawei' >> /etc/udev/rules.d/51-android.rules && \
+	echo 'SUBSYSTEM=="usb", ATTR{idVendor}=="12d1", MODE="0666", GROUP="plugdev"' >> /etc/udev/rules.d/51-android.rules && \
+	echo '# LG' >> /etc/udev/rules.d/51-android.rules && \
+	echo 'SUBSYSTEM=="usb", ATTR{idVendor}=="1004", MODE="0666", GROUP="plugdev"' >> /etc/udev/rules.d/51-android.rules && \
+	echo '# Motorola' >> /etc/udev/rules.d/51-android.rules && \
+	echo 'SUBSYSTEM=="usb", ATTR{idVendor}=="22b8", MODE="0666", GROUP="plugdev"' >> /etc/udev/rules.d/51-android.rules && \
+	echo '# OnePlus' >> /etc/udev/rules.d/51-android.rules && \
+	echo 'SUBSYSTEM=="usb", ATTR{idVendor}=="2a70", MODE="0666", GROUP="plugdev"' >> /etc/udev/rules.d/51-android.rules && \
+	echo '# Sony' >> /etc/udev/rules.d/51-android.rules && \
+	echo 'SUBSYSTEM=="usb", ATTR{idVendor}=="0fce", MODE="0666", GROUP="plugdev"' >> /etc/udev/rules.d/51-android.rules && \
+	echo '# Xiaomi' >> /etc/udev/rules.d/51-android.rules && \
+	echo 'SUBSYSTEM=="usb", ATTR{idVendor}=="2717", MODE="0666", GROUP="plugdev"' >> /etc/udev/rules.d/51-android.rules && \
+	chmod a+r /etc/udev/rules.d/51-android.rules
+
+# Add coder user and allow passwordless sudo.
+RUN useradd coder \
+	--create-home \
+	--shell=/bin/bash \
+	--uid=1000 \
+	--user-group && \
+	mkdir -p /etc/sudoers.d && \
+	echo 'coder ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/nopasswd && \
+	chmod 750 /etc/sudoers.d/ && \
+	chmod 640 /etc/sudoers.d/nopasswd
+
+# Configure ADB: write common vendor IDs and enable listening on all
+# interfaces for network ADB connections.
+RUN mkdir -p /home/coder/.android && \
+	printf '0x18d1\n0x04e8\n0x0bb4\n0x12d1\n0x1004\n0x22b8\n0x2a70\n0x0fce\n0x2717\n' \
+	> /home/coder/.android/adb_usb.ini && \
+	echo 'adb_server_port=5037' > /home/coder/.android/adb_env.ini && \
+	chown -R coder:coder /home/coder/.android
+
+# Adjust OpenSSH config.
+RUN echo "PermitUserEnvironment yes" >>/etc/ssh/sshd_config
+
+# Ensure the android-sdk directory is accessible to the coder user.
+RUN chmod -R a+r ${ANDROID_HOME} && \
+	find ${ANDROID_HOME} -type d -exec chmod a+x {} +
+
+USER coder
+
+WORKDIR /home/coder

--- a/dogfood/coder-android/Makefile
+++ b/dogfood/coder-android/Makefile
@@ -1,0 +1,16 @@
+# Makefile for building and pushing the Android dogfood image.
+# See ../coder/Makefile for reference.
+
+REGISTRY := codercom
+IMAGE := oss-dogfood-android
+TAG := latest
+
+.PHONY: build push
+
+build:
+	docker build \
+		--tag $(REGISTRY)/$(IMAGE):$(TAG) \
+		.
+
+push: build
+	docker push $(REGISTRY)/$(IMAGE):$(TAG)

--- a/dogfood/coder-android/README.md
+++ b/dogfood/coder-android/README.md
@@ -1,0 +1,75 @@
+# Android Development Template
+
+This Coder template provides a complete Android development environment for
+building the [coder-mobile-android](https://github.com/coder/coder-mobile-android)
+project.
+
+## What's Included
+
+| Tool            | Version | Purpose                            |
+|-----------------|---------|------------------------------------|
+| JDK             | 17      | Android build toolchain            |
+| Android SDK     | 35      | Target platform APIs               |
+| Android NDK     | r27     | Native C/C++ compilation           |
+| Build Tools     | 35.0.0  | APK packaging (aapt, d8, zipalign) |
+| Gradle          | 8.11    | Build system                       |
+| Go              | apt     | gomobile / native Go code          |
+| gomobile/gobind | latest  | Go-to-Android bindings             |
+| ADB             | latest  | Device communication               |
+| CMake           | 3.22.1  | NDK native builds                  |
+| GitHub CLI      | latest  | Repository management              |
+
+## ADB and Local Device Connections
+
+The workspace is pre-configured with ADB and udev rules for common Android
+device vendors (Google, Samsung, HTC, Huawei, LG, Motorola, OnePlus, Sony,
+Xiaomi).
+
+### Connecting a Device Over the Network
+
+Since workspaces run in Docker containers, USB passthrough is not directly
+available. Use ADB over TCP/IP instead:
+
+1. On your **local machine**, connect the device via USB and run:
+
+   ```sh
+   adb tcpip 5555
+   ```
+
+2. Find the device's IP address:
+
+   ```sh
+   adb shell ip route | awk '{print $9}'
+   ```
+
+3. Inside the **Coder workspace**, connect to the device:
+
+   ```sh
+   adb connect <device-ip>:5555
+   ```
+
+### Port Forwarding with Coder
+
+You can also forward the local ADB port into the workspace using the Coder
+CLI:
+
+```sh
+# On your local machine (where the device is plugged in):
+coder port-forward <workspace-name> --tcp 5037:5037
+```
+
+This forwards the local ADB server port into the workspace so that `adb
+devices` inside the workspace sees your locally connected devices.
+
+## Building coder-mobile-android
+
+```sh
+cd ~/coder-mobile-android
+./gradlew assembleDebug
+```
+
+## Building Go Libraries for Android
+
+```sh
+gomobile bind -target=android -androidapi 28 ./path/to/gopackage
+```

--- a/dogfood/coder-android/main.tf
+++ b/dogfood/coder-android/main.tf
@@ -1,0 +1,338 @@
+terraform {
+  required_providers {
+    coder = {
+      source  = "coder/coder"
+      version = ">= 2.13.0"
+    }
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "~> 3.6"
+    }
+  }
+}
+
+locals {
+  // These are cluster service addresses mapped to Tailscale nodes.
+  // Ask Dean or Kyle for help.
+  docker_host = {
+    ""              = "tcp://rubinsky-pit-cdr-dev.tailscale.svc.cluster.local:2375"
+    "us-pittsburgh" = "tcp://rubinsky-pit-cdr-dev.tailscale.svc.cluster.local:2375"
+    // For legacy reasons, this host is labelled `eu-helsinki` but it's
+    // actually in Germany now.
+    "eu-helsinki" = "tcp://katerose-fsn-cdr-dev.tailscale.svc.cluster.local:2375"
+    "ap-sydney"   = "tcp://wolfgang-syd-cdr-dev.tailscale.svc.cluster.local:2375"
+    "za-cpt"      = "tcp://schonkopf-cpt-cdr-dev.tailscale.svc.cluster.local:2375"
+  }
+
+  container_name = "coder-${data.coder_workspace_owner.me.name}-${lower(data.coder_workspace.me.name)}"
+}
+
+# --- Parameters ---
+
+data "coder_parameter" "region" {
+  type    = "string"
+  name    = "Region"
+  icon    = "/emojis/1f30e.png"
+  default = "us-pittsburgh"
+  option {
+    icon  = "/emojis/1f1fa-1f1f8.png"
+    name  = "Pittsburgh"
+    value = "us-pittsburgh"
+  }
+  option {
+    icon = "/emojis/1f1e9-1f1ea.png"
+    name = "Falkenstein"
+    // For legacy reasons, this host is labelled `eu-helsinki` but it's
+    // actually in Germany now.
+    value = "eu-helsinki"
+  }
+  option {
+    icon  = "/emojis/1f1e6-1f1fa.png"
+    name  = "Sydney"
+    value = "ap-sydney"
+  }
+  option {
+    icon  = "/emojis/1f1ff-1f1e6.png"
+    name  = "Cape Town"
+    value = "za-cpt"
+  }
+}
+
+data "coder_parameter" "repo" {
+  type        = "string"
+  name        = "Android Repository"
+  default     = "https://github.com/coder/coder-mobile-android"
+  description = "The Android project repository to clone into the workspace."
+  mutable     = true
+}
+
+# --- Presets ---
+
+data "coder_workspace_preset" "pittsburgh" {
+  name        = "Pittsburgh"
+  default     = true
+  description = "Android development workspace hosted in United States"
+  icon        = "/emojis/1f1fa-1f1f8.png"
+  parameters = {
+    (data.coder_parameter.region.name) = "us-pittsburgh"
+    (data.coder_parameter.repo.name)   = "https://github.com/coder/coder-mobile-android"
+  }
+  prebuilds {
+    instances = 0
+  }
+}
+
+# --- Providers ---
+
+provider "docker" {
+  host = lookup(local.docker_host, data.coder_parameter.region.value)
+}
+
+provider "coder" {}
+
+# --- Data Sources ---
+
+data "coder_workspace" "me" {}
+data "coder_workspace_owner" "me" {}
+
+data "coder_external_auth" "github" {
+  id = "github"
+}
+
+data "coder_workspace_tags" "tags" {
+  tags = {
+    "cluster" : "dogfood-v2"
+    "env" : "gke"
+  }
+}
+
+# --- Docker Resources ---
+
+resource "docker_volume" "home_volume" {
+  name = "coder-${data.coder_workspace.me.id}-home"
+  # Protect the volume from being deleted due to changes in attributes.
+  lifecycle {
+    ignore_changes = all
+  }
+  # Add labels in Docker to keep track of orphan resources.
+  labels {
+    label = "coder.owner"
+    value = data.coder_workspace_owner.me.name
+  }
+  labels {
+    label = "coder.owner_id"
+    value = data.coder_workspace_owner.me.id
+  }
+  labels {
+    label = "coder.workspace_id"
+    value = data.coder_workspace.me.id
+  }
+  # This field becomes outdated if the workspace is renamed but can
+  # be useful for debugging or cleaning out dangling volumes.
+  labels {
+    label = "coder.workspace_name_at_creation"
+    value = data.coder_workspace.me.name
+  }
+}
+
+data "docker_registry_image" "android" {
+  name = "codercom/oss-dogfood-android:latest"
+}
+
+resource "docker_image" "android" {
+  name = "codercom/oss-dogfood-android:latest@${data.docker_registry_image.android.sha256_digest}"
+  pull_triggers = [
+    data.docker_registry_image.android.sha256_digest,
+    filesha1("Dockerfile"),
+  ]
+  keep_locally = true
+}
+
+resource "docker_container" "workspace" {
+  lifecycle {
+    ignore_changes = [
+      name,
+      hostname,
+      labels,
+      env,
+      entrypoint,
+    ]
+  }
+  count = data.coder_workspace.me.start_count
+  image = docker_image.android.name
+  name  = local.container_name
+  # Hostname makes the shell more user friendly: coder@my-workspace:~$
+  hostname = data.coder_workspace.me.name
+  # Use the docker gateway if the access URL is 127.0.0.1
+  entrypoint = ["sh", "-c", coder_agent.dev.init_script]
+  # 32 GB memory for Android builds and emulator.
+  memory  = 32768
+  runtime = "sysbox-runc"
+  dns     = ["1.1.1.1"]
+
+  env = [
+    "CODER_AGENT_TOKEN=${coder_agent.dev.token}",
+  ]
+  host {
+    host = "host.docker.internal"
+    ip   = "host-gateway"
+  }
+  volumes {
+    container_path = "/home/coder/"
+    volume_name    = docker_volume.home_volume.name
+    read_only      = false
+  }
+  capabilities {
+    add = ["CAP_NET_ADMIN", "CAP_SYS_NICE"]
+  }
+  # Add labels in Docker to keep track of orphan resources.
+  labels {
+    label = "coder.owner"
+    value = data.coder_workspace_owner.me.name
+  }
+  labels {
+    label = "coder.owner_id"
+    value = data.coder_workspace_owner.me.id
+  }
+  labels {
+    label = "coder.workspace_id"
+    value = data.coder_workspace.me.id
+  }
+  labels {
+    label = "coder.workspace_name"
+    value = data.coder_workspace.me.name
+  }
+}
+
+# --- Coder Agent ---
+
+resource "coder_agent" "dev" {
+  arch = "amd64"
+  os   = "linux"
+  dir  = "/home/coder"
+
+  startup_script_behavior = "blocking"
+
+  display_apps {
+    vscode = true
+  }
+
+  env = {
+    GITHUB_TOKEN = data.coder_external_auth.github.access_token
+  }
+
+  metadata {
+    display_name = "CPU Usage"
+    key          = "cpu_usage"
+    order        = 0
+    script       = "coder stat cpu"
+    interval     = 10
+    timeout      = 1
+  }
+
+  metadata {
+    display_name = "RAM Usage"
+    key          = "ram_usage"
+    order        = 1
+    script       = "coder stat mem"
+    interval     = 10
+    timeout      = 1
+  }
+
+  metadata {
+    display_name = "/home Usage"
+    key          = "home_usage"
+    order        = 2
+    script       = "sudo du -sh /home/coder | awk '{print $1}'"
+    interval     = 3600 # 1h to avoid thrashing disk
+    timeout      = 60   # Longer than this is likely problematic
+  }
+
+  startup_script = <<-EOT
+    #!/usr/bin/env bash
+    set -eux -o pipefail
+
+    # Start Docker daemon if the socket is available (sysbox-runc
+    # provides nested Docker support for emulator images, etc.).
+    if command -v dockerd &>/dev/null; then
+      sudo service docker start || true
+    fi
+
+    # Start the ADB server so devices/emulators are discoverable
+    # as soon as the workspace is ready.
+    if command -v adb &>/dev/null; then
+      adb start-server || true
+    fi
+
+    # Print environment info for debugging build issues.
+    echo "=== Android SDK ==="
+    if [ -n "$${ANDROID_HOME:-}" ]; then
+      echo "ANDROID_HOME=$ANDROID_HOME"
+      "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --list_installed 2>/dev/null | head -20 || true
+    else
+      echo "ANDROID_HOME is not set"
+    fi
+
+    echo "=== Go Version ==="
+    go version || echo "Go is not installed"
+  EOT
+}
+
+# --- Metadata ---
+
+resource "coder_metadata" "home_volume" {
+  resource_id = docker_volume.home_volume.id
+  daily_cost  = 1
+}
+
+resource "coder_metadata" "container_info" {
+  count       = data.coder_workspace.me.start_count
+  resource_id = docker_container.workspace[0].id
+  item {
+    key   = "memory"
+    value = docker_container.workspace[0].memory
+  }
+  item {
+    key   = "runtime"
+    value = docker_container.workspace[0].runtime
+  }
+  item {
+    key   = "region"
+    value = data.coder_parameter.region.option[index(data.coder_parameter.region.option.*.value, data.coder_parameter.region.value)].name
+  }
+}
+
+# --- Registry Modules ---
+
+module "git-clone" {
+  count    = data.coder_workspace.me.start_count
+  source   = "dev.registry.coder.com/coder/git-clone/coder"
+  version  = "1.0.27"
+  agent_id = coder_agent.dev.id
+  url      = data.coder_parameter.repo.value
+}
+
+module "git-config" {
+  count    = data.coder_workspace.me.start_count
+  source   = "dev.registry.coder.com/coder/git-config/coder"
+  version  = "1.0.16"
+  agent_id = coder_agent.dev.id
+}
+
+module "dotfiles" {
+  count    = data.coder_workspace.me.start_count
+  source   = "dev.registry.coder.com/coder/dotfiles/coder"
+  version  = "1.4.0"
+  agent_id = coder_agent.dev.id
+}
+
+module "code-server" {
+  count    = data.coder_workspace.me.start_count
+  source   = "dev.registry.coder.com/coder/code-server/coder"
+  version  = "1.2.0"
+  agent_id = coder_agent.dev.id
+}
+
+# TODO: Add an android-studio coder_app when Projector or a web-based
+# Android Studio solution is ready. It would serve on localhost:8080
+# with subdomain = true for in-browser IDE access.

--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -80,7 +80,7 @@ resource "coderd_template" "dogfood" {
   allow_user_auto_start             = true
   allow_user_auto_stop              = true
   allow_user_cancel_workspace_jobs  = false
-  auto_start_permitted_days_of_week = ["friday", "monday", "saturday", "sunday", "thursday", "tuesday", "wednesday"]
+  auto_start_permitted_days_of_week = ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"]
   auto_stop_requirement = {
     days_of_week = ["sunday"]
     weeks        = 1
@@ -127,7 +127,48 @@ resource "coderd_template" "envbuilder_dogfood" {
   allow_user_auto_start             = true
   allow_user_auto_stop              = true
   allow_user_cancel_workspace_jobs  = false
-  auto_start_permitted_days_of_week = ["friday", "monday", "saturday", "sunday", "thursday", "tuesday", "wednesday"]
+  auto_start_permitted_days_of_week = ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"]
+  auto_stop_requirement = {
+    days_of_week = ["sunday"]
+    weeks        = 1
+  }
+  default_ttl_ms                 = 28800000
+  deprecation_message            = null
+  failure_ttl_ms                 = 604800000
+  require_active_version         = true
+  time_til_dormant_autodelete_ms = 7776000000
+  time_til_dormant_ms            = 8640000000
+}
+
+resource "coderd_template" "android_dogfood" {
+  name            = "coder-android"
+  display_name    = "Android Development"
+  description     = "Android development workspace for building coder-mobile-android with Go, NDK, and ADB."
+  icon            = "/emojis/1f4f1.png" # 📱
+  organization_id = data.coderd_organization.default.id
+  versions = [
+    {
+      name      = var.CODER_TEMPLATE_VERSION
+      message   = var.CODER_TEMPLATE_MESSAGE
+      directory = "./coder-android"
+      active    = true
+    }
+  ]
+  acl = {
+    groups = [{
+      id   = data.coderd_organization.default.id
+      role = "use"
+    }]
+    users = [{
+      id   = data.coderd_user.machine.id
+      role = "admin"
+    }]
+  }
+  activity_bump_ms                  = 10800000
+  allow_user_auto_start             = true
+  allow_user_auto_stop              = true
+  allow_user_cancel_workspace_jobs  = false
+  auto_start_permitted_days_of_week = ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"]
   auto_stop_requirement = {
     days_of_week = ["sunday"]
     weeks        = 1


### PR DESCRIPTION
## Summary

Add a new dogfood template for Android development, targeting the
[coder-mobile-android](https://github.com/coder/coder-mobile-android) project.

## What's Included

| Tool | Version | Purpose |
|------|---------|---------|
| JDK | 17 | Android build toolchain |
| Android SDK | 35 | Target platform APIs |
| Android NDK | r27 (27.2.12479018) | Native C/C++ compilation |
| Build Tools | 35.0.0 | APK packaging |
| Gradle | 8.11 | Build system |
| Go | 1.24.4 | gomobile / native Go code |
| gomobile/gobind | latest | Go-to-Android bindings |
| ADB | latest | Device communication |
| CMake | 3.22.1 | NDK native builds |
| GitHub CLI | latest | Repository management |

## Files Added

- `dogfood/coder-android/Dockerfile` - Multi-stage Docker image with all Android dev tools
- `dogfood/coder-android/main.tf` - Terraform template following existing dogfood patterns
- `dogfood/coder-android/Makefile` - Image build/push helpers
- `dogfood/coder-android/README.md` - Usage docs including ADB device connection instructions
- `dogfood/main.tf` - Updated to register the new `coder-android` template

## ADB Device Connectivity

Since workspaces run in Docker, USB passthrough isn't directly available.
The template supports two approaches:

1. **Network ADB** (`adb tcpip 5555` then `adb connect <device-ip>:5555`)
2. **Coder port-forwarding** (`coder port-forward <workspace> --tcp 5037:5037`)

Both are documented in the README.

## Template Design

Follows existing dogfood patterns:
- Docker-based workspace with sysbox-runc runtime
- Persistent home volume
- Registry modules (git-clone, dotfiles, code-server, git-config)
- Multi-region support (Pittsburgh, Falkenstein, Sydney, Cape Town)
- 32GB memory allocation for Android builds
- Workspace presets with 0 prebuild instances (specialized template)