### PR TITLE
docs: update JetBrains client downloader link

### DIFF
--- a/docs/admin/templates/extending-templates/jetbrains-airgapped.md
+++ b/docs/admin/templates/extending-templates/jetbrains-airgapped.md
@@ -16,8 +16,9 @@ If you have a suggestion or encounter an issue, please
 Install the JetBrains Client Downloader binary. Note that the server must be a Linux-based distribution:
 
 ```shell
-wget https://download.jetbrains.com/idea/code-with-me/backend/jetbrains-clients-downloader-linux-x86_64-1867.tar.gz && \
-tar -xzvf jetbrains-clients-downloader-linux-x86_64-1867.tar.gz
+wget -O jetbrains-clients-downloader-linux-x86_64.tar.gz \
+  'https://data.services.jetbrains.com/products/download?code=JCD&platform=linux_x86-64' && \
+tar -xzvf jetbrains-clients-downloader-linux-x86_64.tar.gz
 ```
 
 ## 2. Install backends and clients
@@ -40,7 +41,7 @@ To install both backends and clients, you will need to run two commands.
 
 ```shell
 mkdir ~/backends
-./jetbrains-clients-downloader-linux-x86_64-1867/bin/jetbrains-clients-downloader --products-filter <product-code> --build-filter <build-number> --platforms-filter linux-x64,windows-x64,osx-x64 --download-backends ~/backends
+./jetbrains-clients-downloader-linux-x86_64-*/bin/jetbrains-clients-downloader --products-filter <product-code> --build-filter <build-number> --platforms-filter linux-x64,windows-x64,osx-x64 --download-backends ~/backends
 ```
 
 ### Clients
@@ -49,7 +50,7 @@ This is the same command as above, with the `--download-backends` flag removed.
 
 ```shell
 mkdir ~/clients
-./jetbrains-clients-downloader-linux-x86_64-1867/bin/jetbrains-clients-downloader --products-filter <product-code> --build-filter <build-number> --platforms-filter linux-x64,windows-x64,osx-x64 ~/clients
+./jetbrains-clients-downloader-linux-x86_64-*/bin/jetbrains-clients-downloader --products-filter <product-code> --build-filter <build-number> --platforms-filter linux-x64,windows-x64,osx-x64 ~/clients
 ```
 
 We now have both clients and backends installed.

--- a/docs/admin/templates/extending-templates/jetbrains-preinstall.md
+++ b/docs/admin/templates/extending-templates/jetbrains-preinstall.md
@@ -10,22 +10,23 @@ For a faster first time connection with JetBrains IDEs, pre-install the IDEs bac
 Install the JetBrains Client Downloader binary:
 
 ```shell
-wget https://download.jetbrains.com/idea/code-with-me/backend/jetbrains-clients-downloader-linux-x86_64-1867.tar.gz && \
-tar -xzvf jetbrains-clients-downloader-linux-x86_64-1867.tar.gz
-rm jetbrains-clients-downloader-linux-x86_64-1867.tar.gz
+wget -O jetbrains-clients-downloader-linux-x86_64.tar.gz \
+  'https://data.services.jetbrains.com/products/download?code=JCD&platform=linux_x86-64' && \
+tar -xzvf jetbrains-clients-downloader-linux-x86_64.tar.gz
+rm jetbrains-clients-downloader-linux-x86_64.tar.gz
 ```
 
 ## Install Gateway backend
 
 ```shell
 mkdir ~/JetBrains
-./jetbrains-clients-downloader-linux-x86_64-1867/bin/jetbrains-clients-downloader --products-filter <product-code> --build-filter <build-number> --platforms-filter linux-x64 --download-backends ~/JetBrains
+./jetbrains-clients-downloader-linux-x86_64-*/bin/jetbrains-clients-downloader --products-filter <product-code> --build-filter <build-number> --platforms-filter linux-x64 --download-backends ~/JetBrains
 ```
 
 For example, to install the build `243.26053.27` of IntelliJ IDEA:
 
 ```shell
-./jetbrains-clients-downloader-linux-x86_64-1867/bin/jetbrains-clients-downloader --products-filter IU --build-filter 243.26053.27 --platforms-filter linux-x64 --download-backends ~/JetBrains
+./jetbrains-clients-downloader-linux-x86_64-*/bin/jetbrains-clients-downloader --products-filter IU --build-filter 243.26053.27 --platforms-filter linux-x64 --download-backends ~/JetBrains
 tar -xzvf ~/JetBrains/backends/IU/*.tar.gz -C ~/JetBrains/backends/IU
 rm -rf ~/JetBrains/backends/IU/*.tar.gz
 ```


### PR DESCRIPTION
We removed the public sources for the jetbrains-client-downloader after shutting down the CWM sources (which originally hosted the source link for the client downloader). We also created an alias for the latest artifact of the jetbrains-client-downloader.

## Summary
- switch JetBrains Client Downloader docs to the new data.services.jetbrains.com download endpoint
- save the archive to a stable local filename so the recipe does not depend on the redirected build number
- update follow-up commands to use a wildcarded extracted directory name instead of the old hardcoded -1867 path

## Validation
- pnpm run lint-docs

## Notes
- the repo pre-commit hook in this checkout pulled in unrelated generator work outside these docs files, so this change was validated with the targeted docs lint instead of a clean full pre-commit pass