### PR TITLE
ci: harden triage-via-chat-api against secret leakage and path injection

### DIFF
--- a/.github/workflows/triage-via-chat-api.yaml
+++ b/.github/workflows/triage-via-chat-api.yaml
@@ -136,8 +136,10 @@ jobs:
             5. When you have finished implementation according to the plan, commit and push your changes, and create a PR using the gh CLI for me to review.
           EOF
           )
-          # Perform variable substitution on the prompt (${ISSUE_URL}).
-          TASK_PROMPT=$(echo "${TASK_PROMPT}" | envsubst)
+          # Perform variable substitution on the prompt — scoped to $ISSUE_URL only.
+          # Using envsubst without arguments would expand every env var in scope
+          # (including CODER_SESSION_TOKEN), so we name the variable explicitly.
+          TASK_PROMPT=$(echo "${TASK_PROMPT}" | envsubst '$ISSUE_URL')
 
           echo "Creating chat with prompt:"
           echo "${TASK_PROMPT}"
@@ -160,6 +162,14 @@ jobs:
           if [[ -z "${CHAT_ID}" || "${CHAT_ID}" == "null" ]]; then
             echo "::error::Failed to create chat — no ID returned"
             echo "Response: ${RESPONSE}"
+            exit 1
+          fi
+
+          # Validate that CHAT_ID is a UUID before using it in URL paths.
+          # This guards against unexpected API responses being interpolated
+          # into subsequent curl calls.
+          if [[ ! "${CHAT_ID}" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
+            echo "::error::CHAT_ID is not a valid UUID: ${CHAT_ID}"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

Security hardening for the `triage-via-chat-api.yaml` workflow introduced in #23154, based on code review findings.

- **Scope `envsubst` to `$ISSUE_URL` only.** The original `envsubst` call without arguments expands *every* environment variable present in the shell at that point — including `CODER_SESSION_TOKEN` and `CODER_URL`. If a future template edit accidentally references `${CODER_SESSION_TOKEN}` in the prompt body, the secret would be silently embedded in the payload sent to the Chat API and recorded in chat history. Naming the variable explicitly (`envsubst '$ISSUE_URL'`) makes the substitution scope explicit and safe.

- **Validate `CHAT_ID` is a UUID before use in URL paths.** `CHAT_ID` is extracted from the Coder API response via `jq -r '.id'` and then interpolated into subsequent `curl` URL paths. Adding a UUID format check before use guards against unexpected or malformed API responses being used in path construction.

## Test plan

- [ ] Trigger the `chat-triage` label on an issue and confirm the workflow runs end-to-end
- [ ] Verify that a non-UUID `CHAT_ID` (simulated by temporarily hardcoding a bad value) causes the step to fail with the expected error
- [ ] Confirm `envsubst '$ISSUE_URL'` correctly substitutes the issue URL and leaves other `${...}` patterns unexpanded

🤖 Generated with [Claude Code](https://claude.com/claude-code)