### PR TITLE
chore: force deploying to dogfood from main

### DIFF
--- a/scripts/should_deploy.sh
+++ b/scripts/should_deploy.sh
@@ -58,6 +58,10 @@ else
 fi
 log "Deploy branch: $deploy_branch"
 
+# TODO: remove this temporary override
+log "OVERRIDE: forcing main as deploy branch"
+deploy_branch=main
+
 # Finally, check if the current branch is the deploy branch.
 log
 if [[ "$branch_name" != "$deploy_branch" ]]; then


### PR DESCRIPTION
Always deploy from main for now. We want to keep testing commits to main as soon as they're merged, so we're going to disable the release freezing behavior. We will test cut releases on a separate deployment, upgraded manually.