### PR TITLE
fix(site): prevent rehype-raw from swallowing JSX in chat output

### DIFF
--- a/site/src/components/ai-elements/response.stories.tsx
+++ b/site/src/components/ai-elements/response.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, within } from "storybook/test";
 import { Response } from "./response";
 
 const sampleMarkdown = `
@@ -64,5 +65,41 @@ export const FencedFileBlock: Story = {
 export const MarkdownAndLinksLight: Story = {
 	globals: {
 		theme: "light",
+	},
+};
+
+// Verifies that JSX-like syntax in LLM output is preserved as
+// escaped text rather than being swallowed by the HTML pipeline.
+const jsxProseMarkdown = `
+\`getLineAnnotations\` depends on \`activeCommentBox\` which could shift.
+
+<RemoteDiffPanel
+  commentBox={commentBox}
+  scrollToFile={scrollTarget}
+  onScrollToFileComplete={handleScrollComplete}
+/>
+
+The props that might change on every \`RemoteDiffPanel\` re-render:
+- \`isLoading\` only during refetch
+- \`getLineAnnotations\` only when \`activeCommentBox\` changes
+`;
+
+export const JsxInProse: Story = {
+	args: {
+		children: jsxProseMarkdown,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		// These strings live inside the <RemoteDiffPanel .../> JSX block.
+		// Without the rehype-raw fix they are silently eaten by the
+		// HTML sanitizer and never reach the DOM.
+		// The tag name itself is the token most likely to be consumed
+		// by HTML parsing, so assert it explicitly.
+		const tagName = await canvas.findByText(/<RemoteDiffPanel/);
+		expect(tagName).toBeInTheDocument();
+		const marker = await canvas.findByText(/scrollToFile=\{scrollTarget\}/);
+		expect(marker).toBeInTheDocument();
+		const marker2 = await canvas.findByText(/commentBox=\{commentBox\}/);
+		expect(marker2).toBeInTheDocument();
 	},
 };

--- a/site/src/components/ai-elements/response.tsx
+++ b/site/src/components/ai-elements/response.tsx
@@ -5,13 +5,28 @@ import {
 } from "@pierre/diffs/react";
 import type { ComponentPropsWithRef, ReactNode } from "react";
 import { useMemo } from "react";
-import { type Components, Streamdown, type UrlTransform } from "streamdown";
+import {
+	type Components,
+	defaultRehypePlugins,
+	Streamdown,
+	type UrlTransform,
+} from "streamdown";
 import { cn } from "utils/cn";
 
 interface ResponseProps extends Omit<ComponentPropsWithRef<"div">, "children"> {
 	children: string;
 	urlTransform?: UrlTransform;
 }
+
+// Omit rehype-raw so HTML-like syntax in LLM output is rendered as
+// escaped text instead of being parsed by the HTML5 engine. Without
+// this, JSX fragments such as <ComponentName prop={value} /> are
+// consumed by rehype-raw and then stripped by rehype-sanitize,
+// silently destroying content mid-stream.
+const chatRehypePlugins = [
+	defaultRehypePlugins.sanitize,
+	defaultRehypePlugins.harden,
+];
 
 const fileViewerCSS =
 	"pre, [data-line], [data-diffs-header] { background-color: transparent !important; }";
@@ -241,6 +256,7 @@ export const Response = ({
 				controls={false}
 				components={components}
 				urlTransform={urlTransform}
+				rehypePlugins={chatRehypePlugins}
 			>
 				{children}
 			</Streamdown>


### PR DESCRIPTION
## What

Omit `rehype-raw` from the Streamdown rehype plugin list so HTML-like syntax in LLM output is rendered as escaped text instead of being parsed by the HTML5 engine and stripped by `rehype-sanitize`.

## Why

When the LLM writes JSX fragments like `<ComponentName prop={value} />` outside code fences (common when discussing React components), the markdown pipeline silently destroys the content:

1. `remark-parse` tags JSX-like syntax as `html` AST nodes
2. `rehype-raw` feeds those nodes to parse5 (HTML5 parser)
3. `rehype-sanitize` strips unknown elements like `remotediffpanel`
4. The content disappears from the rendered output

During streaming, `remend`'s `htmlTags` handler also strips trailing incomplete HTML tags, and the SmoothText jitter buffer creates intermediate states where partial JSX is exposed to the pipeline at different cut points.

## Fix

Without `rehype-raw` in the plugin list, Streamdown auto-injects a remark plugin that converts `html` nodes to `text` nodes, preserving them as visible escaped text (`&lt;ComponentName...`). All markdown formatting (bold, italic, links, code blocks, tables, headings) is unaffected since those go through remark/rehype directly.

## Red/green

Test verified red without the fix (JSX content missing from DOM) and green with it.

> 🤖 This PR was created with the help of Coder Agents, and has been reviewed by a human. 🏂🏻