### PR TITLE
fix: fix data race in TestUserOIDCClaims

### DIFF
--- a/cli/useroidcclaims_test.go
+++ b/cli/useroidcclaims_test.go
@@ -21,18 +21,21 @@ import (
 func TestUserOIDCClaims(t *testing.T) {
 	t.Parallel()
 
-	fake := oidctest.NewFakeIDP(t,
-		oidctest.WithServing(),
-	)
-	cfg := fake.OIDCConfig(t, nil, func(cfg *coderd.OIDCConfig) {
-		cfg.AllowSignups = true
-	})
-	ownerClient := coderdtest.New(t, &coderdtest.Options{
-		OIDCConfig: cfg,
-	})
+	setupOIDCTest := func(t *testing.T) (*oidctest.FakeIDP, *codersdk.Client) {
+		t.Helper()
+		fake := oidctest.NewFakeIDP(t, oidctest.WithServing())
+		cfg := fake.OIDCConfig(t, nil, func(cfg *coderd.OIDCConfig) {
+			cfg.AllowSignups = true
+		})
+		ownerClient := coderdtest.New(t, &coderdtest.Options{
+			OIDCConfig: cfg,
+		})
+		return fake, ownerClient
+	}
 
 	t.Run("OwnClaims", func(t *testing.T) {
 		t.Parallel()
+		fake, ownerClient := setupOIDCTest(t)
 
 		claims := jwt.MapClaims{
 			"email":          "alice@coder.com",
@@ -60,6 +63,7 @@ func TestUserOIDCClaims(t *testing.T) {
 
 	t.Run("Table", func(t *testing.T) {
 		t.Parallel()
+		fake, ownerClient := setupOIDCTest(t)
 
 		claims := jwt.MapClaims{
 			"email":          "bob@coder.com",
@@ -101,6 +105,7 @@ func TestUserOIDCClaims(t *testing.T) {
 	// to request another user's claims by design.
 	t.Run("OnlyOwnClaims", func(t *testing.T) {
 		t.Parallel()
+		fake, ownerClient := setupOIDCTest(t)
 
 		aliceClaims := jwt.MapClaims{
 			"email":          "alice-isolation@coder.com",
@@ -133,6 +138,7 @@ func TestUserOIDCClaims(t *testing.T) {
 
 	t.Run("ClaimsNeverNull", func(t *testing.T) {
 		t.Parallel()
+		fake, ownerClient := setupOIDCTest(t)
 
 		// Use minimal claims — just enough for OIDC login.
 		claims := jwt.MapClaims{


### PR DESCRIPTION
TestUserOIDCClaims previously had subtests that shared a FakeIDP whose login flow mutates a shared oauth2 config. The HTTP handler reads the same config without synchronization. When subtests ran in parallel, the write from one login races with the read from another's in-flight token exchange.

This change seems consistent with how other OIDC test are written, e.g. `TestUserOIDC` subtests have separate servers created with `coderdtest.NewWithDatabase` and separate OIDC providers created with `NewFakeIDP()`. 

https://github.com/coder/internal/issues/1413