### PR TITLE
fix: diff against upstream instead of HEAD to include unpushed commits

### DIFF
--- a/agent/agentgit/agentgit.go
+++ b/agent/agentgit/agentgit.go
@@ -337,7 +337,8 @@ func findRepoRoot(gitBin string, p string) (string, error) {
 }
 
 // getRepoChanges reads the current state of a git repository using
-// the git CLI. It returns branch, remote origin, and a unified diff.
+// the git CLI. It returns branch, remote origin, and a unified diff
+// that includes both committed-but-not-pushed and uncommitted changes.
 func getRepoChanges(ctx context.Context, logger slog.Logger, gitBin string, repoRoot string) (codersdk.WorkspaceAgentRepoChanges, error) {
 	result := codersdk.WorkspaceAgentRepoChanges{
 		RepoRoot: repoRoot,
@@ -381,9 +382,43 @@ func getRepoChanges(ctx context.Context, logger slog.Logger, gitBin string, repo
 	return result, nil
 }
 
-// computeGitDiff produces a unified diff string for the repository by
-// combining `git diff HEAD` (staged + unstaged changes) with diffs
-// for untracked files.
+// diffBaseRef determines the best reference to diff the working tree
+// against. It tries, in order:
+//  1. @{upstream} — the branch's remote tracking ref
+//  2. origin/HEAD — the remote's default branch
+//  3. HEAD — falls back to showing only uncommitted changes
+func diffBaseRef(ctx context.Context, logger slog.Logger, gitBin string, repoRoot string) string {
+	// Try upstream tracking branch first.
+	upCmd := exec.CommandContext(ctx, gitBin, "-C", repoRoot, "rev-parse", "--verify", "@{upstream}")
+	if out, err := upCmd.Output(); err == nil {
+		if ref := strings.TrimSpace(string(out)); ref != "" {
+			logger.Debug(ctx, "using @{upstream} as diff base",
+				slog.F("root", repoRoot), slog.F("ref", ref))
+			return "@{upstream}"
+		}
+	}
+
+	// Fall back to origin/HEAD (the remote's default branch).
+	ohCmd := exec.CommandContext(ctx, gitBin, "-C", repoRoot, "rev-parse", "--verify", "origin/HEAD")
+	if out, err := ohCmd.Output(); err == nil {
+		if ref := strings.TrimSpace(string(out)); ref != "" {
+			logger.Debug(ctx, "using origin/HEAD as diff base",
+				slog.F("root", repoRoot), slog.F("ref", ref))
+			return "origin/HEAD"
+		}
+	}
+
+	logger.Debug(ctx, "no upstream or origin/HEAD, falling back to HEAD",
+		slog.F("root", repoRoot))
+	return "HEAD"
+}
+
+// computeGitDiff produces a unified diff string for the repository.
+// It diffs the working tree against the best available base ref
+// (upstream tracking branch, origin/HEAD, or HEAD) so that
+// committed-but-not-pushed changes are included alongside any
+// uncommitted modifications. Untracked files are appended as
+// synthetic diffs.
 func computeGitDiff(ctx context.Context, logger slog.Logger, gitBin string, repoRoot string) (string, error) {
 	var diffParts []string
 
@@ -395,12 +430,11 @@ func computeGitDiff(ctx context.Context, logger slog.Logger, gitBin string, repo
 	}
 
 	if hasCommits {
-		// `git diff HEAD` captures both staged and unstaged changes
-		// relative to HEAD in a single unified diff.
-		cmd := exec.CommandContext(ctx, gitBin, "-C", repoRoot, "diff", "HEAD")
+		base := diffBaseRef(ctx, logger, gitBin, repoRoot)
+		cmd := exec.CommandContext(ctx, gitBin, "-C", repoRoot, "diff", base)
 		out, err := cmd.Output()
 		if err != nil {
-			return "", xerrors.Errorf("git diff HEAD: %w", err)
+			return "", xerrors.Errorf("git diff %s: %w", base, err)
 		}
 		if len(out) > 0 {
 			diffParts = append(diffParts, string(out))

--- a/agent/agentgit/agentgit_test.go
+++ b/agent/agentgit/agentgit_test.go
@@ -1422,3 +1422,124 @@ func TestE2E_RepoDeletionEmitsRemoved(t *testing.T) {
 	}
 	require.True(t, foundRemoved, "expected repo %s to be marked as removed", repoDir)
 }
+
+// initTestRepoWithRemote creates a bare "remote" repo, clones it into
+// a working directory with an initial commit, and pushes so that the
+// upstream tracking branch is established. Returns the working repo
+// root.
+func initTestRepoWithRemote(t *testing.T) string {
+	t.Helper()
+
+	// Create the bare remote.
+	bareDir := t.TempDir()
+	gitCmd(t, bareDir, "init", "--bare")
+
+	// Clone into a working directory.
+	workDir := t.TempDir()
+	gitCmd(t, workDir, "clone", bareDir, "repo")
+	repoDir := filepath.Join(workDir, "repo")
+
+	// Resolve symlinks so paths match git's canonical output.
+	resolved, err := filepath.EvalSymlinks(repoDir)
+	if err == nil {
+		repoDir = resolved
+	}
+
+	gitCmd(t, repoDir, "config", "user.name", "Test")
+	gitCmd(t, repoDir, "config", "user.email", "test@test.com")
+
+	// Create an initial commit and push to establish upstream.
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("# Test\n"), 0o600))
+	gitCmd(t, repoDir, "add", "README.md")
+	gitCmd(t, repoDir, "commit", "-m", "initial commit")
+	gitCmd(t, repoDir, "push", "origin", "HEAD")
+
+	// Ensure origin/HEAD is set so diffBaseRef can fall back to it
+	// for branches that have no upstream tracking ref.
+	gitCmd(t, repoDir, "remote", "set-head", "origin", "--auto")
+
+	return repoDir
+}
+
+func TestScanIncludesCommittedNotPushedChanges(t *testing.T) {
+	t.Parallel()
+
+	repoDir := initTestRepoWithRemote(t)
+	logger := slogtest.Make(t, nil)
+
+	// Make a local commit without pushing.
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "feature.go"), []byte("package feature\n"), 0o600))
+	gitCmd(t, repoDir, "add", "feature.go")
+	gitCmd(t, repoDir, "commit", "-m", "add feature")
+
+	// Working tree is now clean, but we're 1 commit ahead of
+	// origin. The scan should still report a non-empty diff.
+	h := agentgit.NewHandler(logger)
+	h.Subscribe([]string{filepath.Join(repoDir, "feature.go")})
+
+	ctx := context.Background()
+	msg := h.Scan(ctx)
+	require.NotNil(t, msg)
+	require.Len(t, msg.Repositories, 1)
+
+	repo := msg.Repositories[0]
+	require.NotEmpty(t, repo.UnifiedDiff, "committed-but-not-pushed changes should appear in unified_diff")
+	require.Contains(t, repo.UnifiedDiff, "feature.go")
+}
+
+func TestScanFallsBackToOriginHeadWithoutUpstream(t *testing.T) {
+	t.Parallel()
+
+	repoDir := initTestRepoWithRemote(t)
+	logger := slogtest.Make(t, nil)
+
+	// Create a new local branch with no upstream tracking.
+	gitCmd(t, repoDir, "checkout", "-b", "local-only-branch")
+
+	// Commit a file on this branch.
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "local.go"), []byte("package local\n"), 0o600))
+	gitCmd(t, repoDir, "add", "local.go")
+	gitCmd(t, repoDir, "commit", "-m", "local only commit")
+
+	// No upstream for this branch, but origin/HEAD exists.
+	// The scan should fall back to diffing against origin/HEAD.
+	h := agentgit.NewHandler(logger)
+	h.Subscribe([]string{filepath.Join(repoDir, "local.go")})
+
+	ctx := context.Background()
+	msg := h.Scan(ctx)
+	require.NotNil(t, msg)
+	require.Len(t, msg.Repositories, 1)
+
+	repo := msg.Repositories[0]
+	require.NotEmpty(t, repo.UnifiedDiff, "changes on a branch with no upstream should diff against origin/HEAD")
+	require.Contains(t, repo.UnifiedDiff, "local.go")
+}
+
+func TestScanIncludesBothCommittedAndUncommittedChanges(t *testing.T) {
+	t.Parallel()
+
+	repoDir := initTestRepoWithRemote(t)
+	logger := slogtest.Make(t, nil)
+
+	// Make a committed change (not pushed).
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "committed.go"), []byte("package committed\n"), 0o600))
+	gitCmd(t, repoDir, "add", "committed.go")
+	gitCmd(t, repoDir, "commit", "-m", "committed change")
+
+	// Make an uncommitted change.
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "uncommitted.go"), []byte("package uncommitted\n"), 0o600))
+
+	h := agentgit.NewHandler(logger)
+	h.Subscribe([]string{filepath.Join(repoDir, "committed.go")})
+
+	ctx := context.Background()
+	msg := h.Scan(ctx)
+	require.NotNil(t, msg)
+	require.Len(t, msg.Repositories, 1)
+
+	repo := msg.Repositories[0]
+	require.NotEmpty(t, repo.UnifiedDiff)
+	require.Contains(t, repo.UnifiedDiff, "committed.go", "committed-not-pushed file should appear")
+	require.Contains(t, repo.UnifiedDiff, "uncommitted.go", "uncommitted file should also appear")
+}

--- a/codersdk/workspaceagents.go
+++ b/codersdk/workspaceagents.go
@@ -737,9 +737,12 @@ type WorkspaceAgentGitServerMessage struct {
 }
 
 // WorkspaceAgentRepoChanges describes the current state of a single
-// git repository's working tree. When Removed is true the repo root
-// directory or its .git subdirectory no longer exists; all other
-// fields (Branch, RemoteOrigin, UnifiedDiff) are empty/zero.
+// git repository. UnifiedDiff includes both committed-but-not-pushed
+// and uncommitted changes relative to the upstream tracking branch
+// (or origin/HEAD, or HEAD as a last resort). When Removed is true
+// the repo root directory or its .git subdirectory no longer exists;
+// all other fields (Branch, RemoteOrigin, UnifiedDiff) are
+// empty/zero.
 type WorkspaceAgentRepoChanges struct {
 	RepoRoot     string `json:"repo_root"`
 	Branch       string `json:"branch"`

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -7836,9 +7836,12 @@ export interface WorkspaceAgentPortShares {
 // From codersdk/workspaceagents.go
 /**
  * WorkspaceAgentRepoChanges describes the current state of a single
- * git repository's working tree. When Removed is true the repo root
- * directory or its .git subdirectory no longer exists; all other
- * fields (Branch, RemoteOrigin, UnifiedDiff) are empty/zero.
+ * git repository. UnifiedDiff includes both committed-but-not-pushed
+ * and uncommitted changes relative to the upstream tracking branch
+ * (or origin/HEAD, or HEAD as a last resort). When Removed is true
+ * the repo root directory or its .git subdirectory no longer exists;
+ * all other fields (Branch, RemoteOrigin, UnifiedDiff) are
+ * empty/zero.
  */
 export interface WorkspaceAgentRepoChanges {
 	readonly repo_root: string;


### PR DESCRIPTION
- Introduce `diffBaseRef()` to resolve the best base ref for diffing: `@{upstream}`, then `origin/HEAD`, then `HEAD`
- `computeGitDiff()` uses the resolved base instead of hardcoded `HEAD`
- Fixes the agents view RHS panel showing no diffs when there are local commits that haven't been pushed
- No frontend changes needed — existing `GitPanel` logic works once `unified_diff` is non-empty

> 🤖 This PR was created with the help of Coder Agents, and will be reviewed by my human.  🧑‍💻