### PR TITLE
test: remove classic params from ephemeral params test

### DIFF
--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -4372,9 +4372,7 @@ func TestWorkspaceWithEphemeralRichParameters(t *testing.T) {
 		}},
 	})
 	coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
-	template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID, func(request *codersdk.CreateTemplateRequest) {
-		request.UseClassicParameterFlow = ptr.Ref(true) // TODO: Remove this when dynamic parameters handles this case
-	})
+	template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
 
 	// Create workspace with default values
 	workspace := coderdtest.CreateWorkspace(t, client, template.ID)

--- a/provisioner/echo/serve.go
+++ b/provisioner/echo/serve.go
@@ -650,6 +650,12 @@ func ParameterTerraform(param *proto.RichParameter) (string, error) {
 			s, _ := proto.ProviderFormType(v.FormType)
 			return string(s)
 		},
+		"hasDefault": func(v *proto.RichParameter) bool {
+			// Emit default when the value is explicitly non-empty,
+			// or when the parameter is ephemeral (ephemeral params
+			// always need a default, even if it's an empty string).
+			return v.DefaultValue != "" || v.Ephemeral
+		},
 	}).Parse(`
 data "coder_parameter" "{{ .Name }}" {
   name         = "{{ .Name }}"
@@ -659,7 +665,7 @@ data "coder_parameter" "{{ .Name }}" {
   mutable      = {{ .Mutable }}
   ephemeral    = {{ .Ephemeral }}
   order 	 = {{ .Order }}
-{{- if .DefaultValue }}
+{{- if hasDefault . }}
   {{- if eq .Type "list(string)" }}
   default      = jsonencode({{ .DefaultValue }})
   {{else if eq .Type "bool"}}


### PR DESCRIPTION
Dynamic parameters supports ephemeral parameters. Updated the test to use dynamic parameters.

Ephemeral params **require** a default value.
Closes https://github.com/coder/coder/issues/19065
