### PR TITLE
fix(site/src/pages/AgentsPage): reserve scrollbar gutter in chat skeleton

### DIFF
--- a/site/src/pages/AgentsPage/AgentDetailView.tsx
+++ b/site/src/pages/AgentsPage/AgentDetailView.tsx
@@ -423,14 +423,14 @@ export const AgentDetailLoadingView: FC<AgentDetailLoadingViewProps> = ({
 					isSidebarCollapsed={isSidebarCollapsed}
 					onToggleSidebarCollapsed={onToggleSidebarCollapsed}
 				/>
-				<div className="flex min-h-0 flex-1 flex-col-reverse overflow-hidden">
+				<div className="flex min-h-0 flex-1 flex-col-reverse overflow-y-auto [scrollbar-gutter:stable] [scrollbar-width:thin] [scrollbar-color:hsl(var(--surface-quaternary))_transparent]">
 					<div className="px-4">
 						<div className="mx-auto w-full max-w-3xl py-6">
 							<ChatConversationSkeleton />
 						</div>
 					</div>
 				</div>
-				<div className="shrink-0 px-4">
+				<div className="shrink-0 overflow-y-auto px-4 [scrollbar-gutter:stable] [scrollbar-width:thin]">
 					<AgentChatInput
 						onSend={() => {}}
 						initialValue=""


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

The `AgentDetailLoadingView` skeleton used `overflow-hidden` with no scrollbar gutter, while the loaded `AgentDetailView` reserves gutter space via `scrollbar-gutter:stable`. This caused a layout shift when the chat finished loading and the scrollbar gutter popped in.

This PR matches the skeleton's scroll container and input wrapper to use the same `scrollbar-gutter:stable` styling as the loaded view, so the gutter space is reserved from the start and no shift occurs.

> "I find your lack of scrollbar-gutter... disturbing." -- Darth Vader, probably reviewing this CSS