### PR TITLE
fix: use auto-retrying assertion for bool parameter verification

### DIFF
--- a/site/e2e/helpers.ts
+++ b/site/e2e/helpers.ts
@@ -218,10 +218,14 @@ export const verifyParameters = async (
 								await expect(parameterField).toBeChecked({
 									timeout: 15_000,
 								});
-							} else {
+							} else if (buildParameter.value === "false") {
 								await expect(parameterField).not.toBeChecked({
 									timeout: 15_000,
 								});
+							} else {
+								throw new Error(
+									`Invalid boolean build parameter value: ${buildParameter.value}`,
+								);
 							}
 						}
 						break;

--- a/site/e2e/helpers.ts
+++ b/site/e2e/helpers.ts
@@ -210,9 +210,19 @@ export const verifyParameters = async (
 				switch (richParameter.type) {
 					case "bool":
 						{
+							// Use auto-retrying assertions to avoid capturing
+							// a stale default value before data hydration
+							// completes.
 							const parameterField = parameterLabel.locator("input");
-							const value = await parameterField.isChecked();
-							expect(value.toString()).toEqual(buildParameter.value);
+							if (buildParameter.value === "true") {
+								await expect(parameterField).toBeChecked({
+									timeout: 15_000,
+								});
+							} else {
+								await expect(parameterField).not.toBeChecked({
+									timeout: 15_000,
+								});
+							}
 						}
 						break;
 					case "string":


### PR DESCRIPTION
## Problem

Flaky e2e test `create workspace and overwrite default parameters` — the boolean parameter verification reads `"true"` when it should be `"false"`.

`verifyParameters` in `site/e2e/helpers.ts` used a one-shot `isChecked()` for boolean parameters (line 214), while the `string`/`number` path used Playwright's auto-retrying `toHaveValue()` with a 15-second timeout. When the settings/parameters page hydrates with React Query data, the Switch can briefly render the default value (`true`) before settling on the override (`false`). The one-shot check captures the stale state.

## Fix

Replace the one-shot `isChecked()` + `expect().toEqual()` with Playwright's auto-retrying `toBeChecked()` / `not.toBeChecked()` assertions using a 15-second timeout, matching the pattern already used for string/number parameters.

Fixes coder/internal#1414

Authored by coder agent 🤖 