### PR TITLE
fix(agent/agentproc): enforce chat ID isolation on output and signal endpoints

### DIFF
--- a/agent/agentproc/api.go
+++ b/agent/agentproc/api.go
@@ -151,6 +151,18 @@ func (api *API) handleProcessOutput(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Enforce chat ID isolation. If the request carries
+	// a chat context, only allow access to processes
+	// belonging to that chat.
+	if chatID, _, ok := agentgit.ExtractChatContext(r); ok {
+		if proc.chatID != "" && proc.chatID != chatID.String() {
+			httpapi.Write(ctx, rw, http.StatusNotFound, codersdk.Response{
+				Message: fmt.Sprintf("Process %q not found.", id),
+			})
+			return
+		}
+	}
+
 	output, truncated := proc.output()
 	info := proc.info()
 
@@ -167,6 +179,17 @@ func (api *API) handleSignalProcess(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	id := chi.URLParam(r, "id")
+
+	// Enforce chat ID isolation.
+	if chatID, _, ok := agentgit.ExtractChatContext(r); ok {
+		proc, procOK := api.manager.get(id)
+		if procOK && proc.chatID != "" && proc.chatID != chatID.String() {
+			httpapi.Write(ctx, rw, http.StatusNotFound, codersdk.Response{
+				Message: fmt.Sprintf("Process %q not found.", id),
+			})
+			return
+		}
+	}
 
 	var req workspacesdk.SignalProcessRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {

--- a/agent/agentproc/api_test.go
+++ b/agent/agentproc/api_test.go
@@ -77,6 +77,22 @@ func getOutput(t *testing.T, handler http.Handler, id string) *httptest.Response
 	return w
 }
 
+// getOutputWithHeaders sends a GET /{id}/output request with
+// custom headers and returns the recorder.
+func getOutputWithHeaders(t *testing.T, handler http.Handler, id string, headers http.Header) *httptest.ResponseRecorder {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+	defer cancel()
+	path := fmt.Sprintf("/%s/output", id)
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, path, nil)
+	for k, v := range headers {
+		req.Header[k] = v
+	}
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	return w
+}
+
 // postSignal sends a POST /{id}/signal request and returns
 // the recorder.
 func postSignal(t *testing.T, handler http.Handler, id string, req workspacesdk.SignalProcessRequest) *httptest.ResponseRecorder {
@@ -738,6 +754,34 @@ func TestProcessOutput(t *testing.T) {
 		err := json.NewDecoder(w.Body).Decode(&resp)
 		require.NoError(t, err)
 		require.Contains(t, resp.Message, "not found")
+	})
+
+	t.Run("ChatIDEnforcement", func(t *testing.T) {
+		t.Parallel()
+
+		handler := newTestAPI(t)
+
+		// Start a process with chat-a.
+		chatA := uuid.New()
+		id := startAndGetID(t, handler, workspacesdk.StartProcessRequest{
+			Command:    "echo secret",
+			Background: true,
+		}, http.Header{
+			workspacesdk.CoderChatIDHeader: {chatA.String()},
+		})
+		waitForExit(t, handler, id)
+
+		// Chat-b should NOT see this process.
+		chatB := uuid.New()
+		w1 := getOutputWithHeaders(t, handler, id, http.Header{
+			workspacesdk.CoderChatIDHeader: {chatB.String()},
+		})
+		require.Equal(t, http.StatusNotFound, w1.Code)
+
+		// Without any chat ID header, should return 200
+		// (backwards compatible).
+		w2 := getOutput(t, handler, id)
+		require.Equal(t, http.StatusOK, w2.Code)
 	})
 }
 


### PR DESCRIPTION
> 🤖 mafredri sent me to lock the doors between chat sessions.

The process output and signal endpoints did not check the `X-Coder-Chat-ID` header, so any chat session could read output from or signal processes started by a different chat. This is a correctness issue, not a security boundary (the agent trusts all callers equally), but it breaks the isolation model that chatd relies on.

Adds chat ID checks to `handleProcessOutput` and `handleSignalProcess`. If the request carries a chat context and the process belongs to a different chat, the endpoint returns 404. Requests without a chat header still work (backwards compatible).

Test: `ChatIDEnforcement` subtest starts a process under chat-a, verifies chat-b gets 404, and verifies a headerless request gets 200.

> 🤖 This PR was created with the help of Coder Agents, and has been reviewed by a human. 🏂🏻