### PR TITLE
fix(site): retry chat list query after window refocus

### DIFF
--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -139,6 +139,7 @@ export const infiniteChats = (opts?: { q?: string; archived?: boolean }) => {
 			});
 		},
 		refetchOnWindowFocus: true as const,
+		retry: 3,
 	} satisfies UseInfiniteQueryOptions<TypesGen.Chat[]>;
 };
 


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

## Problem

When leaving a laptop idle (closing the lid), the agents page sidebar enters an error state on return.

The `infiniteChats` query overrides `refetchOnWindowFocus: true` so the sidebar refreshes when the user comes back. But it inherits the global `retry: false` default from `App.tsx`. If the refetch fires before the network has fully recovered after sleep, the query immediately errors out and the sidebar shows an `ErrorAlert` with a manual "Retry" button.

## Fix

Add `retry: 3` to the `infiniteChats` query, giving react-query a few attempts with exponential backoff before surfacing an error. This matches the resilience already present in the WebSocket reconnection layer (`createReconnectingWebSocket`).

> Tony Stark built an arc reactor in a cave with a box of scraps. We fixed a sidebar error state with a single retry option. We are not the same. But here's the PR.