### PR TITLE
feat: wrap dbtestutil.NewDB with dbauthz by default

### DIFF
--- a/coderd/database/dbtestutil/db.go
+++ b/coderd/database/dbtestutil/db.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -19,7 +20,11 @@ import (
 
 	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/pubsub"
+	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
+	"github.com/coder/coder/v2/coderd/rbac/regosql"
 	"github.com/coder/coder/v2/testutil"
 )
 
@@ -29,6 +34,7 @@ type options struct {
 	returnSQLDB   func(*sql.DB)
 	logger        slog.Logger
 	url           string
+	noAuthz       bool
 }
 
 type Option func(*options)
@@ -62,6 +68,15 @@ func WithURL(u string) Option {
 func withReturnSQLDB(f func(*sql.DB)) Option {
 	return func(o *options) {
 		o.returnSQLDB = f
+	}
+}
+
+// WithNoAuthz skips wrapping the database store with dbauthz. This is
+// an escape hatch for tests that need raw database access without
+// authorization checks.
+func WithNoAuthz() Option {
+	return func(o *options) {
+		o.noAuthz = true
 	}
 }
 
@@ -140,6 +155,13 @@ func NewDB(t testing.TB, opts ...Option) (database.Store, pubsub.Pubsub) {
 	t.Cleanup(func() {
 		_ = ps.Close()
 	})
+
+	if !o.noAuthz {
+		acs := &atomic.Pointer[dbauthz.AccessControlStore]{}
+		var s dbauthz.AccessControlStore = dbauthz.AGPLTemplateAccessControlStore{}
+		acs.Store(&s)
+		db = dbauthz.New(db, &passAuthorizer{}, o.logger, acs)
+	}
 
 	return db, ps
 }
@@ -320,6 +342,32 @@ func normalizeDump(schema []byte) []byte {
 	schema = regexp.MustCompile(`(?im)\n{3,}`).ReplaceAll(schema, []byte("\n\n"))
 
 	return schema
+}
+
+// passAuthorizer is an rbac.Authorizer that always permits access.
+// It is used by default in dbtestutil so that every test database
+// is wrapped with dbauthz, exercising the authorization layer
+// without rejecting any queries.
+type passAuthorizer struct{}
+
+func (passAuthorizer) Authorize(_ context.Context, _ rbac.Subject, _ policy.Action, _ rbac.Object) error {
+	return nil
+}
+
+func (passAuthorizer) Prepare(_ context.Context, _ rbac.Subject, _ policy.Action, _ string) (rbac.PreparedAuthorized, error) {
+	return &passPrepared{}, nil
+}
+
+// passPrepared is an rbac.PreparedAuthorized that always permits
+// access and compiles to a SQL expression that is always true.
+type passPrepared struct{}
+
+func (passPrepared) Authorize(_ context.Context, _ rbac.Object) error {
+	return nil
+}
+
+func (passPrepared) CompileToSQL(_ context.Context, _ regosql.ConvertConfig) (string, error) {
+	return "TRUE", nil
 }
 
 // Deprecated: disable foreign keys was created to aid in migrating off


### PR DESCRIPTION
## Summary

- `dbtestutil.NewDB` now wraps the returned `database.Store` with the `dbauthz` authorization layer by default
- Added `dbtestutil.WithNoAuthz()` option as an escape hatch for tests needing raw access
- Uses a pass-through authorizer (always allows) — tests only need an actor in context, not real RBAC
- Double-wrap guard in `dbauthz.New()` means tests using `coderdtest.New()` are unaffected

## Impact analysis

| Category | Files | Call sites |
|---|---|---|
| Manual `dbauthz.New()` wrap | 14 | ~132 |
| `coderdtest.New()` (auto-wraps) | 29 | ~140 |
| **Raw store (needs migration)** | **94** | **~448** |
| Total | 139 | ~737 |

## Overhead

Measured `TestFirstUser` in `coderd/` (warm cache, 3 runs each):
- **Before**: 0.30–0.42s
- **After**: 0.39–0.42s
- **Delta**: within noise (≤ 20ms, within run-to-run variance)

## What breaks

~448 call sites across 94 files that use the raw store directly. Fix pattern:
- Add `dbauthz.AsSystemRestricted(ctx)` (or appropriate `dbauthz.As*()` context) to direct DB calls
- Or opt out with `dbtestutil.WithNoAuthz()` for tests that legitimately bypass authz

## Next steps

The 94 files need migration. This PR is intentionally scoped to the mechanism only to validate the approach before the larger migration.

> 🤖 This PR was created with the help of Coder Agents, and will be reviewed by my human.  🧑‍💻