### PR TITLE
fix(site): prevent overscroll in local diff viewer

### DIFF
--- a/site/src/pages/AgentsPage/DiffViewer.stories.tsx
+++ b/site/src/pages/AgentsPage/DiffViewer.stories.tsx
@@ -34,6 +34,30 @@ const sampleDiff = [
 const parsedFiles = parsePatchFiles(sampleDiff).flatMap((p) => p.files);
 const firstFileName = parsedFiles[0]?.name ?? "";
 
+function generateLargeDiff(fileCount: number, linesPerFile: number): string {
+	const files: string[] = [];
+	for (let f = 0; f < fileCount; f++) {
+		const name = `src/module${f}.ts`;
+		const lines = [
+			`diff --git a/${name} b/${name}`,
+			`index ${f}aaa111..${f}bbb222 100644`,
+			`--- a/${name}`,
+			`+++ b/${name}`,
+			`@@ -1,${linesPerFile} +1,${linesPerFile * 2} @@`,
+		];
+		for (let i = 0; i < linesPerFile; i++) {
+			lines.push(` // existing line ${i}`);
+			lines.push(`+// added line ${i}`);
+		}
+		files.push(lines.join("\n"));
+	}
+	return files.join("\n");
+}
+
+const largeParsedFiles = parsePatchFiles(generateLargeDiff(5, 30)).flatMap(
+	(p) => p.files,
+);
+
 const meta: Meta<typeof DiffViewer> = {
 	title: "pages/AgentsPage/DiffViewer",
 	component: DiffViewer,
@@ -46,7 +70,14 @@ const meta: Meta<typeof DiffViewer> = {
 	},
 	decorators: [
 		(Story) => (
-			<div style={{ height: 500, width: 700 }}>
+			<div
+				style={{
+					height: 500,
+					width: 700,
+					display: "flex",
+					flexDirection: "column",
+				}}
+			>
 				<Story />
 			</div>
 		),
@@ -60,6 +91,13 @@ export const Default: Story = {};
 export const SplitView: Story = {
 	args: {
 		diffStyle: "split",
+	},
+};
+
+/** Large diff that requires scrolling. Regression test for overscroll. */
+export const LargeDiff: Story = {
+	args: {
+		parsedFiles: largeParsedFiles,
 	},
 };
 

--- a/site/src/pages/AgentsPage/DiffViewer.tsx
+++ b/site/src/pages/AgentsPage/DiffViewer.tsx
@@ -801,7 +801,7 @@ export const DiffViewer: FC<DiffViewerProps> = ({
 	// ---------------------------------------------------------------
 	if (isLoading) {
 		return (
-			<div className="flex h-full min-w-0 flex-col overflow-hidden">
+			<div className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
 				<div className="space-y-4 p-4">
 					{Array.from({ length: 3 }, (_, i) => (
 						<div key={i} className="space-y-2">
@@ -833,7 +833,7 @@ export const DiffViewer: FC<DiffViewerProps> = ({
 	return (
 		<div
 			ref={containerRef}
-			className="flex h-full min-w-0 flex-col overflow-hidden"
+			className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
 		>
 			{/* Diff contents */}
 			{sortedFiles.length === 0 ? (

--- a/site/src/pages/AgentsPage/GitPanel.stories.tsx
+++ b/site/src/pages/AgentsPage/GitPanel.stories.tsx
@@ -50,6 +50,26 @@ index aaa1111..bbb2222 100644
 +Follow the steps below to get started.
 `;
 
+function generateLargeDiff(fileCount: number, linesPerFile: number): string {
+	const files: string[] = [];
+	for (let f = 0; f < fileCount; f++) {
+		const name = `src/module${f}.ts`;
+		const lines = [
+			`diff --git a/${name} b/${name}`,
+			`index ${f}aaa111..${f}bbb222 100644`,
+			`--- a/${name}`,
+			`+++ b/${name}`,
+			`@@ -1,${linesPerFile} +1,${linesPerFile * 2} @@`,
+		];
+		for (let i = 0; i < linesPerFile; i++) {
+			lines.push(` // existing line ${i}`);
+			lines.push(`+// added line ${i}`);
+		}
+		files.push(lines.join("\n"));
+	}
+	return files.join("\n");
+}
+
 const makeRepo = (
 	overrides: Partial<WorkspaceAgentRepoChanges> = {},
 ): WorkspaceAgentRepoChanges => ({
@@ -105,7 +125,14 @@ const meta: Meta<typeof GitPanel> = {
 	},
 	decorators: [
 		(Story) => (
-			<div style={{ height: 600, width: 480 }}>
+			<div
+				style={{
+					height: 600,
+					width: 480,
+					display: "flex",
+					flexDirection: "column",
+				}}
+			>
 				<Story />
 			</div>
 		),
@@ -226,6 +253,18 @@ export const WorkingChangesOnly: Story = {
 	},
 };
 
+/** Large local diff that requires scrolling. Regression test for overscroll. */
+export const LargeLocalDiff: Story = {
+	args: {
+		repositories: new Map([
+			[
+				"/home/coder/coder",
+				makeRepo({ unified_diff: generateLargeDiff(5, 30) }),
+			],
+		]),
+	},
+};
+
 /** Multiple repos with working changes. */
 export const MultipleRepos: Story = {
 	args: {
@@ -277,7 +316,14 @@ export const InlineCommentInput: Story = {
 	},
 	decorators: [
 		(Story) => (
-			<div style={{ height: 700, width: 600 }}>
+			<div
+				style={{
+					height: 700,
+					width: 600,
+					display: "flex",
+					flexDirection: "column",
+				}}
+			>
 				<Story />
 			</div>
 		),


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

## Problem

The local diff viewer allowed overscrolling past the last change, even after #23305 fixed this for the remote diff viewer.

## Root cause

`DiffViewer`'s root div used `h-full` (`height: 100%`) which resolves to the **full parent height**, ignoring sibling elements. In `LocalRepoContent`, the `RepoHeader` is always rendered above the diff, causing DiffViewer to overflow by the header's height. This made the scroll area viewport taller than the visible space, so `minHeight: viewportHeight` on the last file wrapper added too much padding, producing overscroll.

The remote case usually worked because the PR sub-header is conditionally rendered and often absent.

## Fix

Add `flex-1 min-h-0` to DiffViewer's root so it takes exactly the remaining space after siblings instead of the full parent height. The existing `h-full` is kept as a fallback for non-flex contexts.

Story decorators are updated to use flex containers so `flex-1` takes effect in Storybook.

> Tony Stark built an arc reactor in a cave with a box of scraps. I added two CSS classes to fix an overscroll bug. We are not the same. But here's the PR.