### PR TITLE
fix(coderd/chatd): rate-limit stream drop WARN logs to avoid log spam

### DIFF
--- a/coderd/chatd/chatd.go
+++ b/coderd/chatd/chatd.go
@@ -64,6 +64,11 @@ const (
 	// of 5 means recovery runs at 1/5 of the stale-after duration.
 	staleRecoveryIntervalDivisor = 5
 
+	// streamDropWarnInterval controls how often WARN-level logs are
+	// emitted when stream events are dropped. Between intervals the
+	// drop is logged at DEBUG to avoid log spam.
+	streamDropWarnInterval = 10 * time.Second
+
 	// DefaultMaxChatsPerAcquire is the maximum number of chats to
 	// acquire in a single processOnce call. Batching avoids
 	// waiting a full polling interval between acquisitions
@@ -326,6 +331,10 @@ type chatStreamState struct {
 	durableMessages      []codersdk.ChatStreamEvent
 	durableEvictedBefore int64 // highest message ID evicted from durable cache
 	subscribers          map[uuid.UUID]chan codersdk.ChatStreamEvent
+	bufferDropCount      int64
+	bufferLastWarnAt     time.Time
+	subscriberDropCount  int64
+	subscriberLastWarnAt time.Time
 }
 
 // MaxQueueSize is the maximum number of queued user messages per chat.
@@ -1498,8 +1507,20 @@ func (p *Server) publishToStream(chatID uuid.UUID, event codersdk.ChatStreamEven
 			return
 		}
 		if len(state.buffer) >= maxStreamBufferSize {
-			p.logger.Warn(context.Background(), "chat stream buffer full, dropping oldest event",
-				slog.F("chat_id", chatID), slog.F("buffer_size", len(state.buffer)))
+			state.bufferDropCount++
+			fields := []slog.Field{
+				slog.F("chat_id", chatID),
+				slog.F("buffer_size", len(state.buffer)),
+			}
+			now := p.clock.Now()
+			if now.Sub(state.bufferLastWarnAt) >= streamDropWarnInterval {
+				fields = append(fields, slog.F("dropped_count", state.bufferDropCount))
+				p.logger.Warn(context.Background(), "chat stream buffer full, dropping oldest event", fields...)
+				state.bufferDropCount = 0
+				state.bufferLastWarnAt = now
+			} else {
+				p.logger.Debug(context.Background(), "chat stream buffer full, dropping oldest event", fields...)
+			}
 			state.buffer = state.buffer[1:]
 		}
 		state.buffer = append(state.buffer, event)
@@ -1510,13 +1531,31 @@ func (p *Server) publishToStream(chatID uuid.UUID, event codersdk.ChatStreamEven
 	}
 	state.mu.Unlock()
 
+	var subDropped int64
 	for _, ch := range subscribers {
 		select {
 		case ch <- event:
 		default:
-			p.logger.Warn(context.Background(), "dropping chat stream event",
-				slog.F("chat_id", chatID), slog.F("type", event.Type))
+			subDropped++
 		}
+	}
+	if subDropped > 0 {
+		state.mu.Lock()
+		state.subscriberDropCount += subDropped
+		fields := []slog.Field{
+			slog.F("chat_id", chatID),
+			slog.F("type", event.Type),
+		}
+		now := p.clock.Now()
+		if now.Sub(state.subscriberLastWarnAt) >= streamDropWarnInterval {
+			fields = append(fields, slog.F("dropped_count", state.subscriberDropCount))
+			p.logger.Warn(context.Background(), "dropping chat stream event", fields...)
+			state.subscriberDropCount = 0
+			state.subscriberLastWarnAt = now
+		} else {
+			p.logger.Debug(context.Background(), "dropping chat stream event", fields...)
+		}
+		state.mu.Unlock()
 	}
 
 	// Clean up the stream entry if it was created by
@@ -2430,11 +2469,15 @@ func (p *Server) processChat(ctx context.Context, chat database.Chat) {
 	streamState := p.getOrCreateStreamState(chat.ID)
 	streamState.mu.Lock()
 	streamState.buffer = nil
+	streamState.bufferDropCount = 0
+	streamState.bufferLastWarnAt = time.Time{}
 	streamState.buffering = true
 	streamState.mu.Unlock()
 	defer func() {
 		streamState.mu.Lock()
 		streamState.buffer = nil
+		streamState.bufferDropCount = 0
+		streamState.bufferLastWarnAt = time.Time{}
 		streamState.buffering = false
 		p.cleanupStreamIfIdle(chat.ID, streamState)
 		streamState.mu.Unlock()
@@ -2980,6 +3023,8 @@ func (p *Server) runChat(
 			if ss, ok := val.(*chatStreamState); ok {
 				ss.mu.Lock()
 				ss.buffer = nil
+				ss.bufferDropCount = 0
+				ss.bufferLastWarnAt = time.Time{}
 				ss.mu.Unlock()
 			}
 		}
@@ -3190,6 +3235,8 @@ func (p *Server) runChat(
 				if rs, ok := val.(*chatStreamState); ok {
 					rs.mu.Lock()
 					rs.buffer = nil
+					rs.bufferDropCount = 0
+					rs.bufferLastWarnAt = time.Time{}
 					rs.mu.Unlock()
 				}
 			}

--- a/coderd/chatd/chatd.go
+++ b/coderd/chatd/chatd.go
@@ -1568,6 +1568,9 @@ func (p *Server) logRateLimitedDrop(
 	delta int64,
 	msg string, fields []slog.Field,
 ) {
+	if p.clock == nil {
+		p.clock = quartz.NewReal()
+	}
 	*count += delta
 	now := p.clock.Now()
 	if now.Sub(*lastWarn) >= streamDropWarnInterval {

--- a/coderd/chatd/chatd.go
+++ b/coderd/chatd/chatd.go
@@ -340,6 +340,15 @@ type chatStreamState struct {
 	subscriberLastWarnAt time.Time
 }
 
+// resetDropCounters zeroes the rate-limiting state for both buffer
+// and subscriber drop warnings. The caller must hold s.mu.
+func (s *chatStreamState) resetDropCounters() {
+	s.bufferDropCount = 0
+	s.bufferLastWarnAt = time.Time{}
+	s.subscriberDropCount = 0
+	s.subscriberLastWarnAt = time.Time{}
+}
+
 // MaxQueueSize is the maximum number of queued user messages per chat.
 const MaxQueueSize = 20
 
@@ -1510,20 +1519,11 @@ func (p *Server) publishToStream(chatID uuid.UUID, event codersdk.ChatStreamEven
 			return
 		}
 		if len(state.buffer) >= maxStreamBufferSize {
-			state.bufferDropCount++
-			fields := []slog.Field{
-				slog.F("chat_id", chatID),
-				slog.F("buffer_size", len(state.buffer)),
-			}
-			now := p.clock.Now()
-			if now.Sub(state.bufferLastWarnAt) >= streamDropWarnInterval {
-				fields = append(fields, slog.F("dropped_count", state.bufferDropCount))
-				p.logger.Warn(context.Background(), "chat stream buffer full, dropping oldest event", fields...)
-				state.bufferDropCount = 0
-				state.bufferLastWarnAt = now
-			} else {
-				p.logger.Debug(context.Background(), "chat stream buffer full, dropping oldest event", fields...)
-			}
+			p.logRateLimitedDrop(
+				&state.bufferDropCount, &state.bufferLastWarnAt, 1,
+				"chat stream buffer full, dropping oldest event",
+				[]slog.Field{slog.F("chat_id", chatID), slog.F("buffer_size", len(state.buffer))},
+			)
 			state.buffer = state.buffer[1:]
 		}
 		state.buffer = append(state.buffer, event)
@@ -1548,23 +1548,36 @@ func (p *Server) publishToStream(chatID uuid.UUID, event codersdk.ChatStreamEven
 	// gap between the two sections.
 	state.mu.Lock()
 	if subDropped > 0 {
-		state.subscriberDropCount += subDropped
-		fields := []slog.Field{
-			slog.F("chat_id", chatID),
-			slog.F("type", event.Type),
-		}
-		now := p.clock.Now()
-		if now.Sub(state.subscriberLastWarnAt) >= streamDropWarnInterval {
-			fields = append(fields, slog.F("dropped_count", state.subscriberDropCount))
-			p.logger.Warn(context.Background(), "dropping chat stream event", fields...)
-			state.subscriberDropCount = 0
-			state.subscriberLastWarnAt = now
-		} else {
-			p.logger.Debug(context.Background(), "dropping chat stream event", fields...)
-		}
+		p.logRateLimitedDrop(
+			&state.subscriberDropCount, &state.subscriberLastWarnAt, subDropped,
+			"dropping chat stream event",
+			[]slog.Field{slog.F("chat_id", chatID), slog.F("type", event.Type)},
+		)
 	}
 	p.cleanupStreamIfIdle(chatID, state)
 	state.mu.Unlock()
+}
+
+// logRateLimitedDrop emits a rate-limited log for a stream drop event.
+// It logs at WARN (with the accumulated dropped_count) at most once
+// per streamDropWarnInterval, and at DEBUG in between. The delta is
+// added to count before evaluating. The caller must hold the
+// relevant lock protecting count and lastWarn.
+func (p *Server) logRateLimitedDrop(
+	count *int64, lastWarn *time.Time,
+	delta int64,
+	msg string, fields []slog.Field,
+) {
+	*count += delta
+	now := p.clock.Now()
+	if now.Sub(*lastWarn) >= streamDropWarnInterval {
+		fields = append(fields, slog.F("dropped_count", *count))
+		p.logger.Warn(context.Background(), msg, fields...)
+		*count = 0
+		*lastWarn = now
+	} else {
+		p.logger.Debug(context.Background(), msg, fields...)
+	}
 }
 
 // cacheDurableMessage stores a recently persisted message event in the
@@ -2470,19 +2483,13 @@ func (p *Server) processChat(ctx context.Context, chat database.Chat) {
 	streamState := p.getOrCreateStreamState(chat.ID)
 	streamState.mu.Lock()
 	streamState.buffer = nil
-	streamState.bufferDropCount = 0
-	streamState.bufferLastWarnAt = time.Time{}
-	streamState.subscriberDropCount = 0
-	streamState.subscriberLastWarnAt = time.Time{}
+	streamState.resetDropCounters()
 	streamState.buffering = true
 	streamState.mu.Unlock()
 	defer func() {
 		streamState.mu.Lock()
 		streamState.buffer = nil
-		streamState.bufferDropCount = 0
-		streamState.bufferLastWarnAt = time.Time{}
-		streamState.subscriberDropCount = 0
-		streamState.subscriberLastWarnAt = time.Time{}
+		streamState.resetDropCounters()
 		streamState.buffering = false
 		p.cleanupStreamIfIdle(chat.ID, streamState)
 		streamState.mu.Unlock()
@@ -3028,10 +3035,7 @@ func (p *Server) runChat(
 			if ss, ok := val.(*chatStreamState); ok {
 				ss.mu.Lock()
 				ss.buffer = nil
-				ss.bufferDropCount = 0
-				ss.bufferLastWarnAt = time.Time{}
-				ss.subscriberDropCount = 0
-				ss.subscriberLastWarnAt = time.Time{}
+				ss.resetDropCounters()
 				ss.mu.Unlock()
 			}
 		}
@@ -3242,10 +3246,7 @@ func (p *Server) runChat(
 				if rs, ok := val.(*chatStreamState); ok {
 					rs.mu.Lock()
 					rs.buffer = nil
-					rs.bufferDropCount = 0
-					rs.bufferLastWarnAt = time.Time{}
-					rs.subscriberDropCount = 0
-					rs.subscriberLastWarnAt = time.Time{}
+					rs.resetDropCounters()
 					rs.mu.Unlock()
 				}
 			}

--- a/coderd/chatd/chatd.go
+++ b/coderd/chatd/chatd.go
@@ -1519,11 +1519,17 @@ func (p *Server) publishToStream(chatID uuid.UUID, event codersdk.ChatStreamEven
 			return
 		}
 		if len(state.buffer) >= maxStreamBufferSize {
-			p.logRateLimitedDrop(
-				&state.bufferDropCount, &state.bufferLastWarnAt, 1,
-				"chat stream buffer full, dropping oldest event",
-				[]slog.Field{slog.F("chat_id", chatID), slog.F("buffer_size", len(state.buffer))},
-			)
+			state.bufferDropCount++
+			now := p.clock.Now()
+			if now.Sub(state.bufferLastWarnAt) >= streamDropWarnInterval {
+				p.logger.Warn(context.Background(), "chat stream buffer full, dropping oldest event",
+					slog.F("chat_id", chatID),
+					slog.F("buffer_size", len(state.buffer)),
+					slog.F("dropped_count", state.bufferDropCount),
+				)
+				state.bufferDropCount = 0
+				state.bufferLastWarnAt = now
+			}
 			state.buffer = state.buffer[1:]
 		}
 		state.buffer = append(state.buffer, event)
@@ -1548,39 +1554,20 @@ func (p *Server) publishToStream(chatID uuid.UUID, event codersdk.ChatStreamEven
 	// gap between the two sections.
 	state.mu.Lock()
 	if subDropped > 0 {
-		p.logRateLimitedDrop(
-			&state.subscriberDropCount, &state.subscriberLastWarnAt, subDropped,
-			"dropping chat stream event",
-			[]slog.Field{slog.F("chat_id", chatID), slog.F("type", event.Type)},
-		)
+		state.subscriberDropCount += subDropped
+		now := p.clock.Now()
+		if now.Sub(state.subscriberLastWarnAt) >= streamDropWarnInterval {
+			p.logger.Warn(context.Background(), "dropping chat stream event",
+				slog.F("chat_id", chatID),
+				slog.F("type", event.Type),
+				slog.F("dropped_count", state.subscriberDropCount),
+			)
+			state.subscriberDropCount = 0
+			state.subscriberLastWarnAt = now
+		}
 	}
 	p.cleanupStreamIfIdle(chatID, state)
 	state.mu.Unlock()
-}
-
-// logRateLimitedDrop emits a rate-limited log for a stream drop event.
-// It logs at WARN (with the accumulated dropped_count) at most once
-// per streamDropWarnInterval, and at DEBUG in between. The delta is
-// added to count before evaluating. The caller must hold the
-// relevant lock protecting count and lastWarn.
-func (p *Server) logRateLimitedDrop(
-	count *int64, lastWarn *time.Time,
-	delta int64,
-	msg string, fields []slog.Field,
-) {
-	if p.clock == nil {
-		p.clock = quartz.NewReal()
-	}
-	*count += delta
-	now := p.clock.Now()
-	if now.Sub(*lastWarn) >= streamDropWarnInterval {
-		fields = append(fields, slog.F("dropped_count", *count))
-		p.logger.Warn(context.Background(), msg, fields...)
-		*count = 0
-		*lastWarn = now
-	} else {
-		p.logger.Debug(context.Background(), msg, fields...)
-	}
 }
 
 // cacheDurableMessage stores a recently persisted message event in the

--- a/coderd/chatd/chatd.go
+++ b/coderd/chatd/chatd.go
@@ -66,7 +66,10 @@ const (
 
 	// streamDropWarnInterval controls how often WARN-level logs are
 	// emitted when stream events are dropped. Between intervals the
-	// drop is logged at DEBUG to avoid log spam.
+	// drop is logged at DEBUG to avoid log spam. This uses a
+	// timestamp comparison rather than a quartz.Ticker because the
+	// state is per-chat — a ticker per chat would require extra
+	// goroutines and lifecycle management.
 	streamDropWarnInterval = 10 * time.Second
 
 	// DefaultMaxChatsPerAcquire is the maximum number of chats to
@@ -1539,8 +1542,12 @@ func (p *Server) publishToStream(chatID uuid.UUID, event codersdk.ChatStreamEven
 			subDropped++
 		}
 	}
+
+	// Re-acquire the lock once for both subscriber-drop logging and
+	// idle cleanup. Merging these avoids an unnecessary unlock/re-lock
+	// gap between the two sections.
+	state.mu.Lock()
 	if subDropped > 0 {
-		state.mu.Lock()
 		state.subscriberDropCount += subDropped
 		fields := []slog.Field{
 			slog.F("chat_id", chatID),
@@ -1555,13 +1562,7 @@ func (p *Server) publishToStream(chatID uuid.UUID, event codersdk.ChatStreamEven
 		} else {
 			p.logger.Debug(context.Background(), "dropping chat stream event", fields...)
 		}
-		state.mu.Unlock()
 	}
-
-	// Clean up the stream entry if it was created by
-	// getOrCreateStreamState but has no subscribers and is not
-	// actively buffering (e.g. publish with no watchers).
-	state.mu.Lock()
 	p.cleanupStreamIfIdle(chatID, state)
 	state.mu.Unlock()
 }
@@ -2471,6 +2472,8 @@ func (p *Server) processChat(ctx context.Context, chat database.Chat) {
 	streamState.buffer = nil
 	streamState.bufferDropCount = 0
 	streamState.bufferLastWarnAt = time.Time{}
+	streamState.subscriberDropCount = 0
+	streamState.subscriberLastWarnAt = time.Time{}
 	streamState.buffering = true
 	streamState.mu.Unlock()
 	defer func() {
@@ -2478,6 +2481,8 @@ func (p *Server) processChat(ctx context.Context, chat database.Chat) {
 		streamState.buffer = nil
 		streamState.bufferDropCount = 0
 		streamState.bufferLastWarnAt = time.Time{}
+		streamState.subscriberDropCount = 0
+		streamState.subscriberLastWarnAt = time.Time{}
 		streamState.buffering = false
 		p.cleanupStreamIfIdle(chat.ID, streamState)
 		streamState.mu.Unlock()
@@ -3025,6 +3030,8 @@ func (p *Server) runChat(
 				ss.buffer = nil
 				ss.bufferDropCount = 0
 				ss.bufferLastWarnAt = time.Time{}
+				ss.subscriberDropCount = 0
+				ss.subscriberLastWarnAt = time.Time{}
 				ss.mu.Unlock()
 			}
 		}
@@ -3237,6 +3244,8 @@ func (p *Server) runChat(
 					rs.buffer = nil
 					rs.bufferDropCount = 0
 					rs.bufferLastWarnAt = time.Time{}
+					rs.subscriberDropCount = 0
+					rs.subscriberLastWarnAt = time.Time{}
 					rs.mu.Unlock()
 				}
 			}

--- a/coderd/chatd/chatd_internal_test.go
+++ b/coderd/chatd/chatd_internal_test.go
@@ -617,8 +617,7 @@ func TestPublishToStream_BufferClearResetsWarnCadence(t *testing.T) {
 	// Simulate a buffer clear (as processChat does between steps).
 	state.mu.Lock()
 	state.buffer = make([]codersdk.ChatStreamEvent, maxStreamBufferSize)
-	state.bufferDropCount = 0
-	state.bufferLastWarnAt = time.Time{}
+	state.resetDropCounters()
 	state.mu.Unlock()
 
 	// The very next drop should WARN immediately — the reset

--- a/coderd/chatd/chatd_internal_test.go
+++ b/coderd/chatd/chatd_internal_test.go
@@ -471,6 +471,7 @@ func TestPublishToStream_BufferFullRateLimitsWarn(t *testing.T) {
 
 	chatID := uuid.New()
 	// Pre-fill the buffer to capacity with buffering enabled.
+	// make(T, N) sets len=N, so the buffer is immediately full.
 	state := &chatStreamState{
 		buffering:   true,
 		buffer:      make([]codersdk.ChatStreamEvent, maxStreamBufferSize),
@@ -486,7 +487,8 @@ func TestPublishToStream_BufferFullRateLimitsWarn(t *testing.T) {
 	// First publish triggers WARN because lastWarnAt is zero.
 	server.publishToStream(chatID, event)
 
-	// Next 49 publishes should all be DEBUG (within the 10s window).
+	// Next 49 publishes should all be DEBUG (within the warn window).
+	// 50 total - 1 WARN = 49 DEBUG.
 	for i := 0; i < 49; i++ {
 		server.publishToStream(chatID, event)
 	}
@@ -501,24 +503,21 @@ func TestPublishToStream_BufferFullRateLimitsWarn(t *testing.T) {
 	require.Len(t, warnEntries, 1, "expected exactly 1 WARN in first batch")
 	require.Len(t, debugEntries, 49, "expected 49 DEBUG in first batch")
 
-	// Verify the WARN entry has a dropped_count field.
-	hasDroppedCount := false
-	for _, f := range warnEntries[0].Fields {
-		if f.Name == "dropped_count" {
-			hasDroppedCount = true
-			break
-		}
-	}
-	require.True(t, hasDroppedCount, "WARN entry should include dropped_count field")
+	// The first WARN should report dropped_count=1 (only one drop
+	// before the first WARN fires).
+	requireFieldValue(t, warnEntries[0], "dropped_count", int64(1))
 
 	// Advance clock past the warn interval and publish again.
-	mClock.Advance(11 * time.Second)
+	// This triggers a second WARN carrying the 49 accumulated DEBUG
+	// drops plus the current drop = 50.
+	mClock.Advance(streamDropWarnInterval + time.Second)
 	server.publishToStream(chatID, event)
 
 	warnEntries = sink.Entries(func(e slog.SinkEntry) bool {
 		return e.Level == slog.LevelWarn && e.Message == "chat stream buffer full, dropping oldest event"
 	})
 	require.Len(t, warnEntries, 2, "expected 2 total WARNs after clock advance")
+	requireFieldValue(t, warnEntries[1], "dropped_count", int64(50))
 }
 
 func TestPublishToStream_SubscriberFullRateLimitsWarn(t *testing.T) {
@@ -553,7 +552,7 @@ func TestPublishToStream_SubscriberFullRateLimitsWarn(t *testing.T) {
 	// First publish triggers WARN.
 	server.publishToStream(chatID, event)
 
-	// Next 9 should be DEBUG.
+	// Next 9 should be DEBUG. 10 total - 1 WARN = 9 DEBUG.
 	for i := 0; i < 9; i++ {
 		server.publishToStream(chatID, event)
 	}
@@ -567,13 +566,79 @@ func TestPublishToStream_SubscriberFullRateLimitsWarn(t *testing.T) {
 
 	require.Len(t, warnEntries, 1, "expected exactly 1 WARN for subscriber drops")
 	require.Len(t, debugEntries, 9, "expected 9 DEBUG for subscriber drops")
+	requireFieldValue(t, warnEntries[0], "dropped_count", int64(1))
 
-	// Advance clock and publish again — should get another WARN.
-	mClock.Advance(11 * time.Second)
+	// Advance clock and publish again — should get another WARN
+	// with dropped_count = 10 (9 accumulated + 1 current).
+	mClock.Advance(streamDropWarnInterval + time.Second)
 	server.publishToStream(chatID, event)
 
 	warnEntries = sink.Entries(func(e slog.SinkEntry) bool {
 		return e.Level == slog.LevelWarn && e.Message == "dropping chat stream event"
 	})
 	require.Len(t, warnEntries, 2, "expected 2 total WARNs after clock advance")
+	requireFieldValue(t, warnEntries[1], "dropped_count", int64(10))
+}
+
+func TestPublishToStream_BufferClearResetsWarnCadence(t *testing.T) {
+	t.Parallel()
+
+	sink := testutil.NewFakeSink(t)
+	mClock := quartz.NewMock(t)
+
+	server := &Server{
+		logger: sink.Logger(),
+		clock:  mClock,
+	}
+
+	chatID := uuid.New()
+	state := &chatStreamState{
+		buffering:   true,
+		buffer:      make([]codersdk.ChatStreamEvent, maxStreamBufferSize),
+		subscribers: make(map[uuid.UUID]chan codersdk.ChatStreamEvent),
+	}
+	server.chatStreams.Store(chatID, state)
+
+	event := codersdk.ChatStreamEvent{
+		Type:        codersdk.ChatStreamEventTypeMessagePart,
+		MessagePart: &codersdk.ChatStreamMessagePart{},
+	}
+
+	// Trigger a WARN then a few DEBUGs.
+	for i := 0; i < 5; i++ {
+		server.publishToStream(chatID, event)
+	}
+
+	warnFilter := func(e slog.SinkEntry) bool {
+		return e.Level == slog.LevelWarn && e.Message == "chat stream buffer full, dropping oldest event"
+	}
+	require.Len(t, sink.Entries(warnFilter), 1)
+
+	// Simulate a buffer clear (as processChat does between steps).
+	state.mu.Lock()
+	state.buffer = make([]codersdk.ChatStreamEvent, maxStreamBufferSize)
+	state.bufferDropCount = 0
+	state.bufferLastWarnAt = time.Time{}
+	state.mu.Unlock()
+
+	// The very next drop should WARN immediately — the reset
+	// zeroed lastWarnAt so the interval check passes.
+	server.publishToStream(chatID, event)
+
+	warnEntries := sink.Entries(warnFilter)
+	require.Len(t, warnEntries, 2, "expected WARN immediately after counter reset")
+	requireFieldValue(t, warnEntries[1], "dropped_count", int64(1))
+}
+
+// requireFieldValue asserts that a SinkEntry contains a field with
+// the given name and value.
+func requireFieldValue(t *testing.T, entry slog.SinkEntry, name string, expected interface{}) {
+	t.Helper()
+	for _, f := range entry.Fields {
+		if f.Name == name {
+			require.Equal(t, expected, f.Value, "field %q value mismatch", name)
+			return
+		}
+	}
+	t.Fatalf("field %q not found in log entry", name)
 }

--- a/coderd/chatd/chatd_internal_test.go
+++ b/coderd/chatd/chatd_internal_test.go
@@ -461,9 +461,8 @@ func requireNoStreamEvent(t *testing.T, events <-chan codersdk.ChatStreamEvent, 
 // TestPublishToStream_DropWarnRateLimiting walks through a
 // realistic lifecycle: buffer fills up, subscriber channel fills
 // up, counters get reset between steps. It verifies that WARN
-// logs are rate-limited to at most once per streamDropWarnInterval,
-// with DEBUG in between, and that counter resets re-enable an
-// immediate WARN.
+// logs are rate-limited to at most once per streamDropWarnInterval
+// and that counter resets re-enable an immediate WARN.
 func TestPublishToStream_DropWarnRateLimiting(t *testing.T) {
 	t.Parallel()
 
@@ -512,12 +511,12 @@ func TestPublishToStream_DropWarnRateLimiting(t *testing.T) {
 	}
 
 	require.Len(t, sink.Entries(filter(slog.LevelWarn, bufferMsg)), 1)
-	require.Len(t, sink.Entries(filter(slog.LevelDebug, bufferMsg)), 49)
+	require.Empty(t, sink.Entries(filter(slog.LevelDebug, bufferMsg)))
 	requireFieldValue(t, sink.Entries(filter(slog.LevelWarn, bufferMsg))[0], "dropped_count", int64(1))
 
 	// Subscriber also saw 50 drops (one per publish).
 	require.Len(t, sink.Entries(filter(slog.LevelWarn, subMsg)), 1)
-	require.Len(t, sink.Entries(filter(slog.LevelDebug, subMsg)), 49)
+	require.Empty(t, sink.Entries(filter(slog.LevelDebug, subMsg)))
 	requireFieldValue(t, sink.Entries(filter(slog.LevelWarn, subMsg))[0], "dropped_count", int64(1))
 
 	// --- Phase 2: clock advance triggers second WARN with count ---

--- a/coderd/chatd/chatd_internal_test.go
+++ b/coderd/chatd/chatd_internal_test.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/mock/gomock"
 	"golang.org/x/xerrors"
 
+	"cdr.dev/slog/v3"
 	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbmock"
@@ -19,6 +20,8 @@ import (
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
 	"github.com/coder/coder/v2/codersdk/workspacesdk/agentconnmock"
+	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/quartz"
 )
 
 func TestRefreshChatWorkspaceSnapshot_NoReloadWhenWorkspacePresent(t *testing.T) {
@@ -453,4 +456,124 @@ func requireNoStreamEvent(t *testing.T, events <-chan codersdk.ChatStreamEvent, 
 		t.Fatalf("unexpected chat stream event: %+v", event)
 	case <-time.After(wait):
 	}
+}
+
+func TestPublishToStream_BufferFullRateLimitsWarn(t *testing.T) {
+	t.Parallel()
+
+	sink := testutil.NewFakeSink(t)
+	mClock := quartz.NewMock(t)
+
+	server := &Server{
+		logger: sink.Logger(),
+		clock:  mClock,
+	}
+
+	chatID := uuid.New()
+	// Pre-fill the buffer to capacity with buffering enabled.
+	state := &chatStreamState{
+		buffering:   true,
+		buffer:      make([]codersdk.ChatStreamEvent, maxStreamBufferSize),
+		subscribers: make(map[uuid.UUID]chan codersdk.ChatStreamEvent),
+	}
+	server.chatStreams.Store(chatID, state)
+
+	event := codersdk.ChatStreamEvent{
+		Type:        codersdk.ChatStreamEventTypeMessagePart,
+		MessagePart: &codersdk.ChatStreamMessagePart{},
+	}
+
+	// First publish triggers WARN because lastWarnAt is zero.
+	server.publishToStream(chatID, event)
+
+	// Next 49 publishes should all be DEBUG (within the 10s window).
+	for i := 0; i < 49; i++ {
+		server.publishToStream(chatID, event)
+	}
+
+	warnEntries := sink.Entries(func(e slog.SinkEntry) bool {
+		return e.Level == slog.LevelWarn && e.Message == "chat stream buffer full, dropping oldest event"
+	})
+	debugEntries := sink.Entries(func(e slog.SinkEntry) bool {
+		return e.Level == slog.LevelDebug && e.Message == "chat stream buffer full, dropping oldest event"
+	})
+
+	require.Len(t, warnEntries, 1, "expected exactly 1 WARN in first batch")
+	require.Len(t, debugEntries, 49, "expected 49 DEBUG in first batch")
+
+	// Verify the WARN entry has a dropped_count field.
+	hasDroppedCount := false
+	for _, f := range warnEntries[0].Fields {
+		if f.Name == "dropped_count" {
+			hasDroppedCount = true
+			break
+		}
+	}
+	require.True(t, hasDroppedCount, "WARN entry should include dropped_count field")
+
+	// Advance clock past the warn interval and publish again.
+	mClock.Advance(11 * time.Second)
+	server.publishToStream(chatID, event)
+
+	warnEntries = sink.Entries(func(e slog.SinkEntry) bool {
+		return e.Level == slog.LevelWarn && e.Message == "chat stream buffer full, dropping oldest event"
+	})
+	require.Len(t, warnEntries, 2, "expected 2 total WARNs after clock advance")
+}
+
+func TestPublishToStream_SubscriberFullRateLimitsWarn(t *testing.T) {
+	t.Parallel()
+
+	sink := testutil.NewFakeSink(t)
+	mClock := quartz.NewMock(t)
+
+	server := &Server{
+		logger: sink.Logger(),
+		clock:  mClock,
+	}
+
+	chatID := uuid.New()
+	// Create a subscriber channel that's already full.
+	subCh := make(chan codersdk.ChatStreamEvent, 1)
+	subCh <- codersdk.ChatStreamEvent{} // fill it
+
+	state := &chatStreamState{
+		subscribers: map[uuid.UUID]chan codersdk.ChatStreamEvent{
+			uuid.New(): subCh,
+		},
+	}
+	server.chatStreams.Store(chatID, state)
+
+	// Use a non-message_part event so it skips the buffer path
+	// but still hits the subscriber send path.
+	event := codersdk.ChatStreamEvent{
+		Type: codersdk.ChatStreamEventTypeStatus,
+	}
+
+	// First publish triggers WARN.
+	server.publishToStream(chatID, event)
+
+	// Next 9 should be DEBUG.
+	for i := 0; i < 9; i++ {
+		server.publishToStream(chatID, event)
+	}
+
+	warnEntries := sink.Entries(func(e slog.SinkEntry) bool {
+		return e.Level == slog.LevelWarn && e.Message == "dropping chat stream event"
+	})
+	debugEntries := sink.Entries(func(e slog.SinkEntry) bool {
+		return e.Level == slog.LevelDebug && e.Message == "dropping chat stream event"
+	})
+
+	require.Len(t, warnEntries, 1, "expected exactly 1 WARN for subscriber drops")
+	require.Len(t, debugEntries, 9, "expected 9 DEBUG for subscriber drops")
+
+	// Advance clock and publish again — should get another WARN.
+	mClock.Advance(11 * time.Second)
+	server.publishToStream(chatID, event)
+
+	warnEntries = sink.Entries(func(e slog.SinkEntry) bool {
+		return e.Level == slog.LevelWarn && e.Message == "dropping chat stream event"
+	})
+	require.Len(t, warnEntries, 2, "expected 2 total WARNs after clock advance")
 }

--- a/coderd/chatd/chatd_internal_test.go
+++ b/coderd/chatd/chatd_internal_test.go
@@ -458,7 +458,13 @@ func requireNoStreamEvent(t *testing.T, events <-chan codersdk.ChatStreamEvent, 
 	}
 }
 
-func TestPublishToStream_BufferFullRateLimitsWarn(t *testing.T) {
+// TestPublishToStream_DropWarnRateLimiting walks through a
+// realistic lifecycle: buffer fills up, subscriber channel fills
+// up, counters get reset between steps. It verifies that WARN
+// logs are rate-limited to at most once per streamDropWarnInterval,
+// with DEBUG in between, and that counter resets re-enable an
+// immediate WARN.
+func TestPublishToStream_DropWarnRateLimiting(t *testing.T) {
 	t.Parallel()
 
 	sink := testutil.NewFakeSink(t)
@@ -470,163 +476,79 @@ func TestPublishToStream_BufferFullRateLimitsWarn(t *testing.T) {
 	}
 
 	chatID := uuid.New()
-	// Pre-fill the buffer to capacity with buffering enabled.
-	// make(T, N) sets len=N, so the buffer is immediately full.
-	state := &chatStreamState{
-		buffering:   true,
-		buffer:      make([]codersdk.ChatStreamEvent, maxStreamBufferSize),
-		subscribers: make(map[uuid.UUID]chan codersdk.ChatStreamEvent),
-	}
-	server.chatStreams.Store(chatID, state)
-
-	event := codersdk.ChatStreamEvent{
-		Type:        codersdk.ChatStreamEventTypeMessagePart,
-		MessagePart: &codersdk.ChatStreamMessagePart{},
-	}
-
-	// First publish triggers WARN because lastWarnAt is zero.
-	server.publishToStream(chatID, event)
-
-	// Next 49 publishes should all be DEBUG (within the warn window).
-	// 50 total - 1 WARN = 49 DEBUG.
-	for i := 0; i < 49; i++ {
-		server.publishToStream(chatID, event)
-	}
-
-	warnEntries := sink.Entries(func(e slog.SinkEntry) bool {
-		return e.Level == slog.LevelWarn && e.Message == "chat stream buffer full, dropping oldest event"
-	})
-	debugEntries := sink.Entries(func(e slog.SinkEntry) bool {
-		return e.Level == slog.LevelDebug && e.Message == "chat stream buffer full, dropping oldest event"
-	})
-
-	require.Len(t, warnEntries, 1, "expected exactly 1 WARN in first batch")
-	require.Len(t, debugEntries, 49, "expected 49 DEBUG in first batch")
-
-	// The first WARN should report dropped_count=1 (only one drop
-	// before the first WARN fires).
-	requireFieldValue(t, warnEntries[0], "dropped_count", int64(1))
-
-	// Advance clock past the warn interval and publish again.
-	// This triggers a second WARN carrying the 49 accumulated DEBUG
-	// drops plus the current drop = 50.
-	mClock.Advance(streamDropWarnInterval + time.Second)
-	server.publishToStream(chatID, event)
-
-	warnEntries = sink.Entries(func(e slog.SinkEntry) bool {
-		return e.Level == slog.LevelWarn && e.Message == "chat stream buffer full, dropping oldest event"
-	})
-	require.Len(t, warnEntries, 2, "expected 2 total WARNs after clock advance")
-	requireFieldValue(t, warnEntries[1], "dropped_count", int64(50))
-}
-
-func TestPublishToStream_SubscriberFullRateLimitsWarn(t *testing.T) {
-	t.Parallel()
-
-	sink := testutil.NewFakeSink(t)
-	mClock := quartz.NewMock(t)
-
-	server := &Server{
-		logger: sink.Logger(),
-		clock:  mClock,
-	}
-
-	chatID := uuid.New()
-	// Create a subscriber channel that's already full.
 	subCh := make(chan codersdk.ChatStreamEvent, 1)
-	subCh <- codersdk.ChatStreamEvent{} // fill it
+	subCh <- codersdk.ChatStreamEvent{} // pre-fill so sends always drop
 
+	// Set up state that mirrors a running chat: buffer at capacity,
+	// buffering enabled, one saturated subscriber.
 	state := &chatStreamState{
+		buffering: true,
+		buffer:    make([]codersdk.ChatStreamEvent, maxStreamBufferSize),
 		subscribers: map[uuid.UUID]chan codersdk.ChatStreamEvent{
 			uuid.New(): subCh,
 		},
 	}
 	server.chatStreams.Store(chatID, state)
 
-	// Use a non-message_part event so it skips the buffer path
-	// but still hits the subscriber send path.
-	event := codersdk.ChatStreamEvent{
-		Type: codersdk.ChatStreamEventTypeStatus,
+	bufferMsg := "chat stream buffer full, dropping oldest event"
+	subMsg := "dropping chat stream event"
+
+	filter := func(level slog.Level, msg string) func(slog.SinkEntry) bool {
+		return func(e slog.SinkEntry) bool {
+			return e.Level == level && e.Message == msg
+		}
 	}
 
-	// First publish triggers WARN.
-	server.publishToStream(chatID, event)
-
-	// Next 9 should be DEBUG. 10 total - 1 WARN = 9 DEBUG.
-	for i := 0; i < 9; i++ {
-		server.publishToStream(chatID, event)
-	}
-
-	warnEntries := sink.Entries(func(e slog.SinkEntry) bool {
-		return e.Level == slog.LevelWarn && e.Message == "dropping chat stream event"
-	})
-	debugEntries := sink.Entries(func(e slog.SinkEntry) bool {
-		return e.Level == slog.LevelDebug && e.Message == "dropping chat stream event"
-	})
-
-	require.Len(t, warnEntries, 1, "expected exactly 1 WARN for subscriber drops")
-	require.Len(t, debugEntries, 9, "expected 9 DEBUG for subscriber drops")
-	requireFieldValue(t, warnEntries[0], "dropped_count", int64(1))
-
-	// Advance clock and publish again — should get another WARN
-	// with dropped_count = 10 (9 accumulated + 1 current).
-	mClock.Advance(streamDropWarnInterval + time.Second)
-	server.publishToStream(chatID, event)
-
-	warnEntries = sink.Entries(func(e slog.SinkEntry) bool {
-		return e.Level == slog.LevelWarn && e.Message == "dropping chat stream event"
-	})
-	require.Len(t, warnEntries, 2, "expected 2 total WARNs after clock advance")
-	requireFieldValue(t, warnEntries[1], "dropped_count", int64(10))
-}
-
-func TestPublishToStream_BufferClearResetsWarnCadence(t *testing.T) {
-	t.Parallel()
-
-	sink := testutil.NewFakeSink(t)
-	mClock := quartz.NewMock(t)
-
-	server := &Server{
-		logger: sink.Logger(),
-		clock:  mClock,
-	}
-
-	chatID := uuid.New()
-	state := &chatStreamState{
-		buffering:   true,
-		buffer:      make([]codersdk.ChatStreamEvent, maxStreamBufferSize),
-		subscribers: make(map[uuid.UUID]chan codersdk.ChatStreamEvent),
-	}
-	server.chatStreams.Store(chatID, state)
-
-	event := codersdk.ChatStreamEvent{
+	// --- Phase 1: buffer-full rate limiting ---
+	// message_part events hit both the buffer-full and subscriber-full
+	// paths. The first publish triggers a WARN for each; the rest
+	// within the window are DEBUG.
+	partEvent := codersdk.ChatStreamEvent{
 		Type:        codersdk.ChatStreamEventTypeMessagePart,
 		MessagePart: &codersdk.ChatStreamMessagePart{},
 	}
-
-	// Trigger a WARN then a few DEBUGs.
-	for i := 0; i < 5; i++ {
-		server.publishToStream(chatID, event)
+	for i := 0; i < 50; i++ {
+		server.publishToStream(chatID, partEvent)
 	}
 
-	warnFilter := func(e slog.SinkEntry) bool {
-		return e.Level == slog.LevelWarn && e.Message == "chat stream buffer full, dropping oldest event"
-	}
-	require.Len(t, sink.Entries(warnFilter), 1)
+	require.Len(t, sink.Entries(filter(slog.LevelWarn, bufferMsg)), 1)
+	require.Len(t, sink.Entries(filter(slog.LevelDebug, bufferMsg)), 49)
+	requireFieldValue(t, sink.Entries(filter(slog.LevelWarn, bufferMsg))[0], "dropped_count", int64(1))
 
-	// Simulate a buffer clear (as processChat does between steps).
+	// Subscriber also saw 50 drops (one per publish).
+	require.Len(t, sink.Entries(filter(slog.LevelWarn, subMsg)), 1)
+	require.Len(t, sink.Entries(filter(slog.LevelDebug, subMsg)), 49)
+	requireFieldValue(t, sink.Entries(filter(slog.LevelWarn, subMsg))[0], "dropped_count", int64(1))
+
+	// --- Phase 2: clock advance triggers second WARN with count ---
+	mClock.Advance(streamDropWarnInterval + time.Second)
+	server.publishToStream(chatID, partEvent)
+
+	bufWarn := sink.Entries(filter(slog.LevelWarn, bufferMsg))
+	require.Len(t, bufWarn, 2)
+	requireFieldValue(t, bufWarn[1], "dropped_count", int64(50))
+
+	subWarn := sink.Entries(filter(slog.LevelWarn, subMsg))
+	require.Len(t, subWarn, 2)
+	requireFieldValue(t, subWarn[1], "dropped_count", int64(50))
+
+	// --- Phase 3: counter reset (simulates step persist) ---
 	state.mu.Lock()
 	state.buffer = make([]codersdk.ChatStreamEvent, maxStreamBufferSize)
 	state.resetDropCounters()
 	state.mu.Unlock()
 
-	// The very next drop should WARN immediately — the reset
-	// zeroed lastWarnAt so the interval check passes.
-	server.publishToStream(chatID, event)
+	// The very next drop should WARN immediately — the reset zeroed
+	// lastWarnAt so the interval check passes.
+	server.publishToStream(chatID, partEvent)
 
-	warnEntries := sink.Entries(warnFilter)
-	require.Len(t, warnEntries, 2, "expected WARN immediately after counter reset")
-	requireFieldValue(t, warnEntries[1], "dropped_count", int64(1))
+	bufWarn = sink.Entries(filter(slog.LevelWarn, bufferMsg))
+	require.Len(t, bufWarn, 3, "expected WARN immediately after counter reset")
+	requireFieldValue(t, bufWarn[2], "dropped_count", int64(1))
+
+	subWarn = sink.Entries(filter(slog.LevelWarn, subMsg))
+	require.Len(t, subWarn, 3, "expected subscriber WARN immediately after counter reset")
+	requireFieldValue(t, subWarn[2], "dropped_count", int64(1))
 }
 
 // requireFieldValue asserts that a SinkEntry contains a field with


### PR DESCRIPTION
- Rate-limit "chat stream buffer full" and "dropping chat stream event"
  WARN logs to at most once per 10s per chat.
- Intermediate drops not logged; WARN includes `dropped_count`.
- Per-chat tracking on `chatStreamState` using timestamp comparison
  against `quartz.Clock` — no global tickers, no new `Server` fields.
- Subscriber and buffer drop counters reset at all lifecycle boundaries.

> 🤖 This PR was created with the help of Coder Agents, and was reviewed by my human.  🧑‍💻