### PR TITLE
fix(site): reduce unnecessary re-renders and network calls

### DIFF
--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -143,7 +143,6 @@ export const infiniteChats = (opts?: { q?: string; archived?: boolean }) => {
 	} satisfies UseInfiniteQueryOptions<TypesGen.Chat[]>;
 };
 
-
 export const chat = (chatId: string) => ({
 	queryKey: chatKey(chatId),
 	queryFn: () => API.getChat(chatId),

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -143,11 +143,6 @@ export const infiniteChats = (opts?: { q?: string; archived?: boolean }) => {
 	} satisfies UseInfiniteQueryOptions<TypesGen.Chat[]>;
 };
 
-export const chats = () => ({
-	queryKey: chatsKey,
-	queryFn: () => API.getChats(),
-	refetchOnWindowFocus: true as const,
-});
 
 export const chat = (chatId: string) => ({
 	queryKey: chatKey(chatId),

--- a/site/src/pages/AgentsPage/AgentDetail.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.tsx
@@ -3,7 +3,6 @@ import { isApiError } from "api/errors";
 import {
 	chat,
 	chatMessagesForInfiniteScroll,
-	chats,
 	createChatMessage,
 	deleteChatQueuedMessage,
 	editChatMessage,
@@ -294,7 +293,11 @@ const AgentDetail: FC = () => {
 		...chatMessagesForInfiniteScroll(agentId ?? ""),
 		enabled: Boolean(agentId),
 	});
-	const chatsQuery = useQuery(chats());
+	const parentChatID = getParentChatID(chatQuery.data);
+	const parentChatQuery = useQuery({
+		...chat(parentChatID ?? ""),
+		enabled: Boolean(parentChatID),
+	});
 	const workspaceId = chatQuery.data?.workspace_id;
 	const workspaceQuery = useQuery({
 		...workspaceById(workspaceId ?? ""),
@@ -706,10 +709,7 @@ const AgentDetail: FC = () => {
 		</title>
 	);
 
-	const parentChatID = getParentChatID(chatQuery.data);
-	const parentChat = parentChatID
-		? chatsQuery.data?.find((chat) => chat.id === parentChatID)
-		: undefined;
+	const parentChat = parentChatQuery.data;
 	const workspaceRoute = workspace
 		? `/@${workspace.owner_name}/${workspace.name}`
 		: null;

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -390,13 +390,15 @@ const AgentsPage: FC = () => {
 					const chatEvent = sse.data;
 					const updatedChat = chatEvent.chat;
 
-					// Read the previous status from the query cache, which
-					// is synchronously updated by both the per-chat WebSocket
-					// (via updateSidebarChat) and this handler. This avoids
-					// the async-lag of a useEffect-based status map.
-					const prevStatus = queryClient.getQueryData<TypesGen.Chat>(
-						chatKey(updatedChat.id),
-					)?.status; // Only play the chime for top-level chats, not sub-agents.
+					// Read the previous status from the infinite chat list
+					// cache before we write the update below. The per-chat
+					// query cache (chatKey) only exists for chats the user
+					// has opened, so reading from the list cache ensures
+					// prevStatus is available for background agents too.
+					const prevStatus = readInfiniteChatsCache(queryClient)?.find(
+						(c) => c.id === updatedChat.id,
+					)?.status;
+					// Only play the chime for top-level chats, not sub-agents.
 					if (!updatedChat.parent_chat_id) {
 						maybePlayChime(
 							prevStatus,

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -54,6 +54,7 @@ import { useAgentsPWA } from "./useAgentsPWA";
 
 const lastModelConfigIDStorageKey = "agents.last-model-config-id";
 const nilUUID = "00000000-0000-0000-0000-000000000000";
+const EMPTY_MODEL_CONFIGS: TypesGen.ChatModelConfig[] = [];
 
 // Type guard for SSE events from the chat list watch endpoint.
 function isChatListSSEEvent(
@@ -249,7 +250,10 @@ const AgentsPage: FC = () => {
 			return next;
 		});
 	}, []);
-	const chatList = chatsQuery.data?.pages.flat() ?? [];
+	const chatList = useMemo(
+			() => chatsQuery.data?.pages.flat() ?? [],
+			[chatsQuery.data],
+		);
 	const isArchiving =
 		archiveAgentMutation.isPending || archiveAndDeleteMutation.isPending;
 	const archivingChatId =
@@ -390,9 +394,8 @@ const AgentsPage: FC = () => {
 					// is synchronously updated by both the per-chat WebSocket
 					// (via updateSidebarChat) and this handler. This avoids
 					// the async-lag of a useEffect-based status map.
-					const currentChats = readInfiniteChatsCache(queryClient);
-					const prevStatus = currentChats?.find(
-						(c) => c.id === updatedChat.id,
+					const prevStatus = queryClient.getQueryData<TypesGen.Chat>(
+						chatKey(updatedChat.id),
 					)?.status; // Only play the chime for top-level chats, not sub-agents.
 					if (!updatedChat.parent_chat_id) {
 						maybePlayChime(
@@ -522,7 +525,7 @@ const AgentsPage: FC = () => {
 				agentId={agentId}
 				chatList={chatList}
 				catalogModelOptions={catalogModelOptions}
-				modelConfigs={chatModelConfigsQuery.data ?? []}
+				modelConfigs={chatModelConfigsQuery.data ?? EMPTY_MODEL_CONFIGS}
 				logoUrl={appearance.logo_url}
 				handleNewAgent={handleNewAgent}
 				isCreating={createMutation.isPending}

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -251,9 +251,9 @@ const AgentsPage: FC = () => {
 		});
 	}, []);
 	const chatList = useMemo(
-			() => chatsQuery.data?.pages.flat() ?? [],
-			[chatsQuery.data],
-		);
+		() => chatsQuery.data?.pages.flat() ?? [],
+		[chatsQuery.data],
+	);
 	const isArchiving =
 		archiveAgentMutation.isPending || archiveAndDeleteMutation.isPending;
 	const archivingChatId =


### PR DESCRIPTION
> 🤖 Generated by an AI agent on behalf of Danielle Maywood 🤖

## Summary

Two targeted performance fixes for the AgentsPage component tree.

### 1. Remove redundant full chat list fetch from AgentDetail

`AgentDetail` was calling `useQuery(chats())` which fetches the **entire** unpaginated chat list just to `.find()` one parent chat by ID. This query used the `["chats"]` key, which matches `isChatListQuery`, so every `invalidateChatListQueries()` call (archive, unarchive, create, WS reconnect) triggered a full re-fetch of all chats.

Replaced with a targeted `useQuery(chat(parentChatID))` that fetches only the single parent chat when needed. The now-orphaned `chats()` query factory has been removed.

### 2. Memoize `chatList` derivation and stabilize fallback references

`chatsQuery.data?.pages.flat() ?? []` was computed on every render without `useMemo`. `.flat()` always returns a new array reference, and the `?? []` fallback does too. This cascaded through `AgentsPageView` -> `AgentsSidebar`, where it served as a dependency for multiple `useMemo` hooks (chat tree, chatById map, visibleChatIDs), blowing all of them on every render.

Also stabilized the `modelConfigs` empty-array fallback with a module-level constant.

### 3. Fix inaccurate comment on prevStatus cache read

The old comment on the `prevStatus` lookup in the `watchChats` WebSocket handler claimed the value was read from the per-chat query cache, which is "synchronously updated by both the per-chat WebSocket (via `updateSidebarChat`) and this handler." This was inaccurate — `updateSidebarChat` only writes to the infinite list cache, not the per-chat cache. The comment has been corrected to reflect the actual data source.