### PR TITLE
ci: update linear-release-action to version 0.5.0

### DIFF
--- a/.github/workflows/linear-release.yaml
+++ b/.github/workflows/linear-release.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Sync issues
         id: sync
-        uses: linear/linear-release-action@f64cdc603e6eb7a7ef934bc5492ae929f88c8d1a # v0
+        uses: linear/linear-release-action@5cbaabc187ceb63eee9d446e62e68e5c29a03ae8 # v0.5.0
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
           command: sync


### PR DESCRIPTION
bumps the workflow version for Linear issue tracking