### PR TITLE
feat(site/pages/AgentsPage): move terminal to sidebar panel

### DIFF
--- a/site/src/pages/AgentsPage/AgentDetail.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.tsx
@@ -15,11 +15,7 @@ import { workspaceById, workspaceByIdKey } from "api/queries/workspaces";
 import type * as TypesGen from "api/typesGenerated";
 import type { ChatMessagePart } from "api/typesGenerated";
 import { useProxy } from "contexts/ProxyContext";
-import {
-	getTerminalHref,
-	getVSCodeHref,
-	openAppInNewWindow,
-} from "modules/apps/apps";
+import { getTerminalHref, getVSCodeHref } from "modules/apps/apps";
 import {
 	type FC,
 	useCallback,
@@ -765,13 +761,6 @@ const AgentDetail: FC = () => {
 		window.open(workspaceRoute, "_blank");
 	};
 
-	const handleOpenTerminal = () => {
-		if (!terminalHref) {
-			return;
-		}
-		openAppInNewWindow(terminalHref);
-	};
-
 	const handleArchiveAgentAction = () => {
 		if (!agentId || isArchived) {
 			return;
@@ -857,7 +846,7 @@ const AgentDetail: FC = () => {
 			sshCommand={sshCommand}
 			handleOpenInEditor={handleOpenInEditor}
 			handleViewWorkspace={handleViewWorkspace}
-			handleOpenTerminal={handleOpenTerminal}
+			terminalHref={terminalHref}
 			handleCommit={handleCommit}
 			onNavigateToChat={(chatId) => navigate(`/agents/${chatId}`)}
 			handleInterrupt={handleInterrupt}

--- a/site/src/pages/AgentsPage/AgentDetail/TopBar.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail/TopBar.stories.tsx
@@ -14,7 +14,6 @@ const defaultProps = {
 		canOpenWorkspace: true,
 		onOpenInEditor: () => {},
 		onViewWorkspace: () => {},
-		onOpenTerminal: () => {},
 		sshCommand: "ssh main.my-workspace.admin.coder",
 	},
 	onArchiveAgent: () => {},

--- a/site/src/pages/AgentsPage/AgentDetail/TopBar.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail/TopBar.tsx
@@ -20,7 +20,6 @@ import {
 	PanelLeftIcon,
 	PanelRightCloseIcon,
 	PanelRightOpenIcon,
-	TerminalIcon,
 	Trash2Icon,
 } from "lucide-react";
 import type { FC } from "react";
@@ -41,7 +40,6 @@ interface WorkspaceActions {
 	canOpenWorkspace: boolean;
 	onOpenInEditor: (editor: "cursor" | "vscode") => void;
 	onViewWorkspace: () => void;
-	onOpenTerminal: () => void;
 	sshCommand: string | undefined;
 }
 
@@ -195,14 +193,6 @@ export const AgentDetailTopBar: FC<AgentDetailTopBarProps> = ({
 							>
 								<ExternalLinkIcon className="h-3.5 w-3.5" />
 								Open in VS Code
-							</DropdownMenuItem>
-							<DropdownMenuItem
-								// You can think of the web terminal as an editor if you squint.
-								disabled={!workspace.canOpenEditors}
-								onSelect={workspace.onOpenTerminal}
-							>
-								<TerminalIcon className="h-3.5 w-3.5" />
-								Open Terminal
 							</DropdownMenuItem>
 							<DropdownMenuItem
 								disabled={!workspace.sshCommand}

--- a/site/src/pages/AgentsPage/AgentDetailView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentDetailView.stories.tsx
@@ -126,7 +126,7 @@ const meta: Meta<typeof AgentDetailView> = {
 		sshCommand: undefined,
 		handleOpenInEditor: fn(),
 		handleViewWorkspace: fn(),
-		handleOpenTerminal: fn(),
+		terminalHref: null,
 		handleCommit: fn(),
 		onNavigateToChat: fn(),
 		handleInterrupt: fn(),

--- a/site/src/pages/AgentsPage/AgentDetailView.tsx
+++ b/site/src/pages/AgentsPage/AgentDetailView.tsx
@@ -2,7 +2,7 @@ import type * as TypesGen from "api/typesGenerated";
 import type { ChatDiffStatus, ChatMessagePart } from "api/typesGenerated";
 import type { ModelSelectorOption } from "components/ai-elements";
 import { Button } from "components/Button/Button";
-import { ArchiveIcon, ArrowDownIcon } from "lucide-react";
+import { ArchiveIcon, ArrowDownIcon, TerminalIcon } from "lucide-react";
 import {
 	type FC,
 	type RefObject,
@@ -29,6 +29,7 @@ import {
 import { GitPanel } from "./GitPanel";
 import { RightPanel } from "./RightPanel";
 import { SidebarTabView } from "./SidebarTabView";
+import { TerminalPanel } from "./TerminalPanel";
 import type { ChatDetailError } from "./usageLimitMessage";
 
 type ChatStoreHandle = ReturnType<typeof useChatStore>["store"];
@@ -111,8 +112,8 @@ interface AgentDetailViewProps {
 	sshCommand: string | undefined;
 	handleOpenInEditor: (editor: "cursor" | "vscode") => void;
 	handleViewWorkspace: () => void;
-	handleOpenTerminal: () => void;
 	handleCommit: (repoRoot: string) => void;
+	terminalHref: string | null;
 
 	// Navigation.
 	onNavigateToChat: (chatId: string) => void;
@@ -176,8 +177,8 @@ export const AgentDetailView: FC<AgentDetailViewProps> = ({
 	sshCommand,
 	handleOpenInEditor,
 	handleViewWorkspace,
-	handleOpenTerminal,
 	handleCommit,
+	terminalHref,
 	onNavigateToChat,
 	handleInterrupt,
 	handleDeleteQueuedMessage,
@@ -238,7 +239,6 @@ export const AgentDetailView: FC<AgentDetailViewProps> = ({
 							canOpenWorkspace,
 							onOpenInEditor: handleOpenInEditor,
 							onViewWorkspace: handleViewWorkspace,
-							onOpenTerminal: handleOpenTerminal,
 							sshCommand,
 						}}
 						onArchiveAgent={handleArchiveAgentAction}
@@ -349,10 +349,20 @@ export const AgentDetailView: FC<AgentDetailViewProps> = ({
 									chatInputRef={editing.chatInputRef}
 								/>
 							),
-						},
-					]}
-					onClose={() => onSetShowSidebarPanel(false)}
-					isExpanded={visualExpanded}
+							},
+							{
+								id: "terminal",
+								label: "Terminal",
+								icon: <TerminalIcon className="!size-3.5" />,
+								content: (
+									<TerminalPanel
+										terminalHref={terminalHref}
+										isExpanded={visualExpanded}
+									/>
+								),
+							},						]}
+						onClose={() => onSetShowSidebarPanel(false)}
+						isExpanded={visualExpanded}
 					onToggleExpanded={() => setIsRightPanelExpanded((prev) => !prev)}
 					isSidebarCollapsed={isSidebarCollapsed}
 					onToggleSidebarCollapsed={onToggleSidebarCollapsed}
@@ -412,7 +422,6 @@ export const AgentDetailLoadingView: FC<AgentDetailLoadingViewProps> = ({
 						canOpenWorkspace: false,
 						onOpenInEditor: () => {},
 						onViewWorkspace: () => {},
-						onOpenTerminal: () => {},
 						sshCommand: undefined,
 					}}
 					onOpenParentChat={() => {}}
@@ -486,7 +495,6 @@ export const AgentDetailNotFoundView: FC<AgentDetailNotFoundViewProps> = ({
 					canOpenWorkspace: false,
 					onOpenInEditor: () => {},
 					onViewWorkspace: () => {},
-					onOpenTerminal: () => {},
 					sshCommand: undefined,
 				}}
 				onOpenParentChat={() => {}}

--- a/site/src/pages/AgentsPage/TerminalPanel.tsx
+++ b/site/src/pages/AgentsPage/TerminalPanel.tsx
@@ -1,0 +1,31 @@
+import { Spinner } from "components/Spinner/Spinner";
+import { TerminalIcon } from "lucide-react";
+import type { FC } from "react";
+
+interface TerminalPanelProps {
+	terminalHref: string | null;
+	isExpanded: boolean;
+}
+
+export const TerminalPanel: FC<TerminalPanelProps> = ({
+	terminalHref,
+	isExpanded: _isExpanded,
+}) => {
+	if (!terminalHref) {
+		return (
+			<div className="flex h-full flex-col items-center justify-center gap-2 text-content-secondary">
+				<Spinner loading className="h-6 w-6" />
+				<span className="text-sm">Waiting for workspace to connect...</span>
+			</div>
+		);
+	}
+
+	return (
+		<iframe
+			src={terminalHref}
+			title="Terminal"
+			className="h-full w-full border-0 bg-black"
+			style={{ display: "block" }}
+		/>
+	);
+};


### PR DESCRIPTION
## Summary

Move the **Open Terminal** action from the top bar dropdown menu into the right sidebar as an embedded **Terminal** tab alongside Git and Desktop.

### Changes

- **New**: `TerminalPanel.tsx` — embeds the workspace terminal as an iframe; shows a spinner placeholder while workspace is connecting
- **AgentDetailView.tsx** — Terminal tab always present in the sidebar tabs array
- **TopBar.tsx** — removed the "Open Terminal" dropdown item and `onOpenTerminal` from `WorkspaceActions`
- **AgentDetail.tsx** — passes `terminalHref` (nullable) to the view instead of the old `handleOpenTerminal` callback
- **Stories** — updated to match interface changes

### Behavior

| State | Terminal tab |
|---|---|
| Workspace connected | Embedded terminal via iframe |
| Workspace not connected | Spinner + "Waiting for workspace to connect..." |

### Before

Top bar dropdown with "Open Terminal":

![before-terminal](https://github.com/user-attachments/assets/before-terminal.png)

### After

Top bar dropdown — "Open Terminal" removed:

![after-topbar](https://github.com/user-attachments/assets/after-topbar.png)

Sidebar with new Terminal tab (showing waiting state in Storybook):

![after-sidebar](https://github.com/user-attachments/assets/after-sidebar.png)
