### PR TITLE
fix(site/src/pages/AgentsPage): pre-compute selectedLines to avoid busting LazyFileDiff memo

### DIFF
--- a/site/src/pages/AgentsPage/DiffViewer.tsx
+++ b/site/src/pages/AgentsPage/DiffViewer.tsx
@@ -633,6 +633,23 @@ export const DiffViewer: FC<DiffViewerProps> = ({
 		return map;
 	}, [sortedFiles, getLineAnnotations]);
 
+	// Pre-compute per-file selected lines so each LazyFileDiff
+	// receives a stable reference. Without this, calling
+	// getSelectedLines during render returns a new object every
+	// time, which busts the memo comparator and forces an
+	// expensive Shadow DOM + shiki re-highlight.
+	const perFileSelectedLines = useMemo(() => {
+		if (!getSelectedLines) return null;
+		const map = new Map<string, SelectedLineRange>();
+		for (const file of sortedFiles) {
+			const sel = getSelectedLines(file.name);
+			if (sel) {
+				map.set(file.name, sel);
+			}
+		}
+		return map;
+	}, [sortedFiles, getSelectedLines]);
+
 	// ---------------------------------------------------------------
 	// Container width measurement via ResizeObserver so we can decide
 	// whether to show the file tree sidebar without a prop from the
@@ -889,7 +906,9 @@ export const DiffViewer: FC<DiffViewerProps> = ({
 											}
 											lineAnnotations={perFileAnnotations?.get(fileDiff.name)}
 											renderAnnotation={renderAnnotation}
-											selectedLines={getSelectedLines?.(fileDiff.name)}
+											selectedLines={
+												perFileSelectedLines?.get(fileDiff.name) ?? null
+											}
 										/>
 										{isLast && (
 											<div className="flex items-center justify-center py-4 text-xs text-content-secondary">

--- a/site/src/pages/AgentsPage/DiffViewer.tsx
+++ b/site/src/pages/AgentsPage/DiffViewer.tsx
@@ -623,14 +623,14 @@ export const DiffViewer: FC<DiffViewerProps> = ({
 	// Pre-compute per-file line annotations for the same reason.
 	const perFileAnnotations = useMemo(() => {
 		if (!getLineAnnotations) return null;
-		const map = new Map<string, DiffLineAnnotation<string>[]>();
-		for (const file of sortedFiles) {
-			const annotations = getLineAnnotations(file.name);
-			if (annotations.length > 0) {
-				map.set(file.name, annotations);
-			}
-		}
-		return map;
+		return new Map(
+			sortedFiles
+				.map((f) => [f.name, getLineAnnotations(f.name)] as const)
+				.filter(
+					(entry): entry is [string, DiffLineAnnotation<string>[]] =>
+						entry[1].length > 0,
+				),
+		);
 	}, [sortedFiles, getLineAnnotations]);
 
 	// Pre-compute per-file selected lines so each LazyFileDiff
@@ -640,14 +640,13 @@ export const DiffViewer: FC<DiffViewerProps> = ({
 	// expensive Shadow DOM + shiki re-highlight.
 	const perFileSelectedLines = useMemo(() => {
 		if (!getSelectedLines) return null;
-		const map = new Map<string, SelectedLineRange>();
-		for (const file of sortedFiles) {
-			const sel = getSelectedLines(file.name);
-			if (sel) {
-				map.set(file.name, sel);
-			}
-		}
-		return map;
+		return new Map(
+			sortedFiles
+				.map((f) => [f.name, getSelectedLines(f.name)] as const)
+				.filter(
+					(entry): entry is [string, SelectedLineRange] => entry[1] != null,
+				),
+		);
 	}, [sortedFiles, getSelectedLines]);
 
 	// ---------------------------------------------------------------


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

## Problem

`getSelectedLines` was called inline during render in `DiffViewer`, returning a new object on every call. `LazyFileDiff`'s custom memo comparator checks `selectedLines` by reference, so the fresh object forced an expensive Shadow DOM teardown + shiki re-highlight on every parent re-render — even when the selection hadn't actually changed.

This is the only consumer-visible path that could cause significant jank, since each re-highlight involves full syntax tokenization inside a Shadow DOM.

## Fix

Pre-compute per-file selected lines into a stable `Map` via `useMemo`, mirroring the existing `perFileAnnotations` pattern. The map is keyed by file name and only recomputes when `sortedFiles` or `getSelectedLines` changes.