### PR TITLE
feat: enable React profiling build for dogfood

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1216,8 +1216,10 @@ jobs:
           GCLOUD_ACCESS_TOKEN: ${{ steps.gcloud_auth.outputs.access_token }}
           JSIGN_PATH: /tmp/jsign-6.0.jar
           # Enable React profiling build and discoverable source maps
-          # for the dogfood deployment (dev.coder.com). These images
-          # (coder-preview) are never used for releases.
+          # for the dogfood deployment (dev.coder.com). This also
+          # applies to release/* branch builds, but those still
+          # produce coder-preview images, not release images.
+          # Release images are built by release.yaml (no profiling).
           CODER_REACT_PROFILING: "true"
 
       # Free up disk space before building Docker images. The preceding

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1215,6 +1215,10 @@ jobs:
           EV_CERTIFICATE_PATH: /tmp/ev_cert.pem
           GCLOUD_ACCESS_TOKEN: ${{ steps.gcloud_auth.outputs.access_token }}
           JSIGN_PATH: /tmp/jsign-6.0.jar
+          # Enable React profiling build and discoverable source maps
+          # for the dogfood deployment (dev.coder.com). These images
+          # (coder-preview) are never used for releases.
+          CODER_REACT_PROFILING: "true"
 
       # Free up disk space before building Docker images. The preceding
       # Build step produces ~2 GB of binaries and packages, the Go build

--- a/site/vite.config.mts
+++ b/site/vite.config.mts
@@ -210,6 +210,9 @@ export default defineConfig({
 			// In profiling builds, swap the production react-dom client
 			// bundle for the profiling variant so that <Profiler>
 			// onRender receives actual timing data.
+			// Note: react-dom/profiling is a superset of react-dom/client
+			// (16 vs 3 exports). If a future React major changes this
+			// relationship, the alias may need updating.
 			...(isProfilingBuild
 				? { "react-dom/client": "react-dom/profiling" }
 				: {}),

--- a/site/vite.config.mts
+++ b/site/vite.config.mts
@@ -7,6 +7,14 @@ import type { PluginOption } from "vite";
 import checker from "vite-plugin-checker";
 import { defineConfig } from "vitest/config";
 
+// Enable the React profiling build and discoverable source maps for
+// internal deployments (e.g. dogfood). The profiling build swaps
+// react-dom/client for react-dom/profiling, which keeps production
+// optimizations but leaves the <Profiler> onRender callback and
+// React Performance Tracks instrumentation intact. The overhead is
+// ~13% on the react-dom chunk size.
+const isProfilingBuild = process.env.CODER_REACT_PROFILING === "true";
+
 const plugins: PluginOption[] = [
 	react(),
 	checker({
@@ -32,7 +40,7 @@ export default defineConfig({
 	build: {
 		outDir: path.resolve(__dirname, "./out"),
 		emptyOutDir: false, // We need to keep the /bin folder and GITKEEP files
-		sourcemap: "hidden",
+		sourcemap: isProfilingBuild ? true : "hidden",
 		rollupOptions: {
 			input: {
 				index: path.resolve(__dirname, "./index.html"),
@@ -199,6 +207,12 @@ export default defineConfig({
 	},
 	resolve: {
 		alias: {
+			// In profiling builds, swap the production react-dom client
+			// bundle for the profiling variant so that <Profiler>
+			// onRender receives actual timing data.
+			...(isProfilingBuild
+				? { "react-dom/client": "react-dom/profiling" }
+				: {}),
 			App: path.resolve(__dirname, "./src/App"),
 			api: path.resolve(__dirname, "./src/api"),
 			components: path.resolve(__dirname, "./src/components"),


### PR DESCRIPTION
The coder-preview images (used by dev.coder.com) now build the frontend with `react-dom/profiling` instead of `react-dom/client` and emit discoverable source maps.

## What this changes

When `CODER_REACT_PROFILING=true` is set at build time (added to the ci.yaml `build` job that produces preview images):

1. **Profiling react-dom**: Vite aliases `react-dom/client` to `react-dom/profiling`. This is still a production build (minified, no dev warnings) but with profiling instrumentation left in. The overhead is ~13% on the react-dom chunk size (607KB vs 536KB pre-minification).

2. **Discoverable source maps**: `sourcemap` switches from `"hidden"` to `true`, adding the `//# sourceMappingURL` comment so browsers auto-load source maps. The `.map` files were already generated and embedded in the binary, they just weren't referenced.

## What this enables

- **`<Profiler>` onRender callbacks** work in the dogfood build. A follow-up PR can wrap the agents chat subtree to log slow renders to the console and emit `performance.measure()` entries visible in Safari Timeline.
- **React Performance Tracks** appear in Chrome DevTools Performance panel (Scheduler track by default, Components track for `<Profiler>`-wrapped trees or with React DevTools installed).
- **Readable stack traces** on dev.coder.com without needing to manually add source maps in DevTools.

## What this does NOT affect

- Release builds (`release.yaml`) never set `CODER_REACT_PROFILING`.
- Local dev builds remain unchanged (the env var defaults to unset).
- No behavioral changes to the application.

> 🤖 This PR was created with the help of Coder Agents, and has been reviewed by a human. 🏂🏻