### PR TITLE
feat(site): add Profiler instrumentation for agents chat

### DIFF
--- a/site/src/pages/AgentsPage/components/AgentDetail/useOnRenderProfiler.ts
+++ b/site/src/pages/AgentsPage/components/AgentDetail/useOnRenderProfiler.ts
@@ -8,27 +8,44 @@ const SLOW_RENDER_THRESHOLD_MS = 16;
 // id, to avoid flooding the console during rapid streaming updates.
 const WARN_THROTTLE_MS = 2000;
 
+// Cap the number of performance.measure entries to avoid unbounded
+// memory growth during long streaming sessions. When the cap is
+// reached, only this profiler's entries are cleared by name
+// and counting restarts.
+const MAX_MEASURE_ENTRIES = 500;
+
 /**
  * Returns a stable onRender callback for React's <Profiler> component.
- * When a render exceeds SLOW_RENDER_THRESHOLD_MS, it logs a
- * console.warn with timing details and emits a performance.measure()
- * entry visible in browser devtools (including Safari Timeline).
+ * Every render emits a performance.measure() entry visible in browser
+ * devtools (including Safari Timeline). Renders exceeding
+ * SLOW_RENDER_THRESHOLD_MS additionally log a console.warn with
+ * timing details (throttled per profiler id).
  *
- * The <Profiler> onRender callback is a no-op in standard production
- * builds. It only receives timing data when the app is built with
- * react-dom/profiling (enabled via CODER_REACT_PROFILING=true).
+ * In standard production builds, React does not call the onRender
+ * callback with timing data, so the hook is effectively inert. It
+ * only produces output when built with react-dom/profiling (enabled
+ * via CODER_REACT_PROFILING=true).
  */
 export function useOnRenderProfiler(): ProfilerOnRenderCallback {
-	const lastWarnTime = useRef<Record<string, number>>({});
+	const lastWarnTime = useRef(0);
+	const measureCount = useRef(0);
+	const measureNames = useRef(new Set<string>());
 
 	return useCallback<ProfilerOnRenderCallback>(
 		(id, phase, actualDuration, baseDuration, startTime, commitTime) => {
-			// Emit a performance.measure entry for every render so it
-			// appears in the browser's Performance/Timeline panel
-			// regardless of whether it's "slow". The entry name uses a
-			// React atom symbol to make it easy to filter.
+			// In standard production builds the Profiler callback
+			// receives zero for all timing values. Bail out early to
+			// avoid creating garbage performance entries.
+			if (actualDuration <= 0) {
+				return;
+			}
+
+			// Emit a performance.measure entry for every render so
+			// the Performance/Timeline panel shows the full render
+			// timeline when investigating jank, not just outliers.
+			const measureName = `⚛ ${id} (${phase})`;
 			try {
-				performance.measure(`⚛ ${id} (${phase})`, {
+				performance.measure(measureName, {
 					start: startTime,
 					duration: actualDuration,
 				});
@@ -36,18 +53,29 @@ export function useOnRenderProfiler(): ProfilerOnRenderCallback {
 				// performance.measure can throw if startTime is invalid
 				// (e.g. negative or before time origin). Safe to ignore.
 			}
+			measureNames.current.add(measureName);
+			measureCount.current++;
+			if (measureCount.current >= MAX_MEASURE_ENTRIES) {
+				for (const name of measureNames.current) {
+					performance.clearMeasures(name);
+				}
+				measureNames.current.clear();
+				measureCount.current = 0;
+			}
 
 			if (actualDuration <= SLOW_RENDER_THRESHOLD_MS) {
 				return;
 			}
 
 			const now = performance.now();
-			const last = lastWarnTime.current[id] ?? 0;
-			if (now - last < WARN_THROTTLE_MS) {
+			if (now - lastWarnTime.current < WARN_THROTTLE_MS) {
 				return;
 			}
-			lastWarnTime.current[id] = now;
+			lastWarnTime.current = now;
 
+			// actualDuration covers the render phase only. The commit
+			// offset (commitTime - startTime) includes yield/suspend
+			// time in concurrent React, so it can be larger.
 			console.warn(
 				`[Slow render] %c${id}%c ${phase}: ` +
 					`${actualDuration.toFixed(1)}ms actual, ` +

--- a/site/src/pages/AgentsPage/components/AgentDetail/useOnRenderProfiler.ts
+++ b/site/src/pages/AgentsPage/components/AgentDetail/useOnRenderProfiler.ts
@@ -1,0 +1,62 @@
+import { type ProfilerOnRenderCallback, useCallback, useRef } from "react";
+
+// Threshold in milliseconds. Renders exceeding one frame budget
+// (16.67ms at 60fps) are logged as warnings.
+const SLOW_RENDER_THRESHOLD_MS = 16;
+
+// Minimum interval between consecutive warnings for the same profiler
+// id, to avoid flooding the console during rapid streaming updates.
+const WARN_THROTTLE_MS = 2000;
+
+/**
+ * Returns a stable onRender callback for React's <Profiler> component.
+ * When a render exceeds SLOW_RENDER_THRESHOLD_MS, it logs a
+ * console.warn with timing details and emits a performance.measure()
+ * entry visible in browser devtools (including Safari Timeline).
+ *
+ * The <Profiler> onRender callback is a no-op in standard production
+ * builds. It only receives timing data when the app is built with
+ * react-dom/profiling (enabled via CODER_REACT_PROFILING=true).
+ */
+export function useOnRenderProfiler(): ProfilerOnRenderCallback {
+	const lastWarnTime = useRef<Record<string, number>>({});
+
+	return useCallback<ProfilerOnRenderCallback>(
+		(id, phase, actualDuration, baseDuration, startTime, commitTime) => {
+			// Emit a performance.measure entry for every render so it
+			// appears in the browser's Performance/Timeline panel
+			// regardless of whether it's "slow". The entry name uses a
+			// React atom symbol to make it easy to filter.
+			try {
+				performance.measure(`⚛ ${id} (${phase})`, {
+					start: startTime,
+					duration: actualDuration,
+				});
+			} catch {
+				// performance.measure can throw if startTime is invalid
+				// (e.g. negative or before time origin). Safe to ignore.
+			}
+
+			if (actualDuration <= SLOW_RENDER_THRESHOLD_MS) {
+				return;
+			}
+
+			const now = performance.now();
+			const last = lastWarnTime.current[id] ?? 0;
+			if (now - last < WARN_THROTTLE_MS) {
+				return;
+			}
+			lastWarnTime.current[id] = now;
+
+			console.warn(
+				`[Slow render] %c${id}%c ${phase}: ` +
+					`${actualDuration.toFixed(1)}ms actual, ` +
+					`${baseDuration.toFixed(1)}ms base ` +
+					`(commit ${(commitTime - startTime).toFixed(1)}ms after start)`,
+				"font-weight: bold",
+				"font-weight: normal",
+			);
+		},
+		[],
+	);
+}

--- a/site/src/pages/AgentsPage/components/AgentDetailContent.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetailContent.tsx
@@ -1,7 +1,7 @@
 import type * as TypesGen from "api/typesGenerated";
 import type { ModelSelectorOption } from "components/ai-elements";
 import { useDashboard } from "modules/dashboard/useDashboard";
-import { type FC, useEffect } from "react";
+import { type FC, Profiler, useEffect } from "react";
 import { toast } from "sonner";
 import type { UrlTransform } from "streamdown";
 import { useFileAttachments } from "../hooks/useFileAttachments";
@@ -32,6 +32,7 @@ import {
 } from "./AgentDetail/messageParsing";
 import { buildStreamTools } from "./AgentDetail/streamState";
 import type { ParsedMessageEntry } from "./AgentDetail/types";
+import { useOnRenderProfiler } from "./AgentDetail/useOnRenderProfiler";
 
 type ChatStoreHandle = ReturnType<typeof useChatStore>["store"];
 
@@ -145,6 +146,7 @@ const StreamingBridge: FC<{
 }) => {
 	const streamState = useChatSelector(store, selectStreamState);
 	const streamTools = buildStreamTools(streamState);
+	const onRenderProfiler = useOnRenderProfiler();
 	const isAwaitingFirstStreamChunk =
 		!streamState &&
 		(chatStatus === "running" || chatStatus === "pending") &&
@@ -152,22 +154,24 @@ const StreamingBridge: FC<{
 	const hasStreamOutput = Boolean(streamState) || isAwaitingFirstStreamChunk;
 
 	return (
-		<ConversationTimeline
-			isEmpty={isEmpty}
-			parsedMessages={parsedMessages}
-			hasStreamOutput={hasStreamOutput}
-			streamState={streamState}
-			streamTools={streamTools}
-			subagentTitles={subagentTitles}
-			subagentStatusOverrides={subagentStatusOverrides}
-			retryState={retryState}
-			isAwaitingFirstStreamChunk={isAwaitingFirstStreamChunk}
-			detailError={detailError}
-			onEditUserMessage={onEditUserMessage}
-			editingMessageId={editingMessageId}
-			savingMessageId={savingMessageId}
-			urlTransform={urlTransform}
-		/>
+		<Profiler id="AgentChat" onRender={onRenderProfiler}>
+			<ConversationTimeline
+				isEmpty={isEmpty}
+				parsedMessages={parsedMessages}
+				hasStreamOutput={hasStreamOutput}
+				streamState={streamState}
+				streamTools={streamTools}
+				subagentTitles={subagentTitles}
+				subagentStatusOverrides={subagentStatusOverrides}
+				retryState={retryState}
+				isAwaitingFirstStreamChunk={isAwaitingFirstStreamChunk}
+				detailError={detailError}
+				onEditUserMessage={onEditUserMessage}
+				editingMessageId={editingMessageId}
+				savingMessageId={savingMessageId}
+				urlTransform={urlTransform}
+			/>
+		</Profiler>
 	);
 };
 


### PR DESCRIPTION
Wraps the agents chat timeline in React's `<Profiler>` component to surface render timing in browser devtools.

## What this does

Adds a `useOnRenderProfiler` hook that:

1. **Emits `performance.measure()` entries** for every render of the chat subtree. These appear as `⚛ AgentChat (mount|update)` entries in any browser's Performance/Timeline panel, including Safari.

2. **Logs `console.warn`** when a render exceeds 16ms (one frame budget at 60fps). Warnings are throttled to one per 2 seconds per profiler id to avoid flooding during streaming.

The `<Profiler>` wraps `ConversationTimeline` inside `AgentDetailTimeline`, covering the entire message list and streaming output.

## Dependency

The `<Profiler>` `onRender` callback is a no-op in standard production builds. It only receives actual timing data when built with `react-dom/profiling`, enabled by #23354. Without that PR, this code is inert (no overhead, no output).

With both PRs merged, opening the agents chat on dev.coder.com and recording a Performance trace will show per-render timing for the chat subtree. Slow renders during streaming will also appear in the console.

## Files

- `site/src/pages/AgentsPage/AgentDetail/useOnRenderProfiler.ts` (new): the hook
- `site/src/pages/AgentsPage/AgentDetailContent.tsx`: wraps `ConversationTimeline` in `<Profiler>`

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻