### PR TITLE
fix(coderd/chatd): use upstream fantasy fix for store=false replay

### DIFF
--- a/coderd/chatd/chatprompt/chatprompt.go
+++ b/coderd/chatd/chatprompt/chatprompt.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"charm.land/fantasy"
+	fantasyopenai "charm.land/fantasy/providers/openai"
 	"github.com/google/uuid"
 	"github.com/sqlc-dev/pqtype"
 	"golang.org/x/xerrors"
@@ -1085,6 +1086,29 @@ func marshalProviderMetadata(metadata fantasy.ProviderMetadata) json.RawMessage 
 	return data
 }
 
+// sanitizeOpenAIReplayMetadata clears ephemeral item/reference IDs from
+// OpenAI provider metadata that are only valid for server-stored
+// conversations. When the originating response used store=false, these
+// IDs reference non-existent server-side items and replaying them causes
+// "Item not found" errors. Stripping is unconditional because the
+// store=true code path in the fantasy library already skips reasoning
+// items before metadata is inspected, making the strip a no-op for
+// stored conversations.
+func sanitizeOpenAIReplayMetadata(opts fantasy.ProviderOptions) fantasy.ProviderOptions {
+	if opts == nil {
+		return nil
+	}
+	for _, val := range opts {
+		switch v := val.(type) {
+		case *fantasyopenai.ResponsesReasoningMetadata:
+			v.ItemID = ""
+		case *fantasyopenai.WebSearchCallMetadata:
+			v.ItemID = ""
+		}
+	}
+	return opts
+}
+
 // providerMetadataToOptions reconstructs fantasy ProviderOptions
 // from raw JSON stored in an SDK part's ProviderMetadata field.
 // Uses fantasy.UnmarshalProviderOptions to restore registered
@@ -1103,7 +1127,7 @@ func providerMetadataToOptions(logger slog.Logger, raw json.RawMessage) fantasy.
 		logger.Warn(context.Background(), "failed to decode provider options", slog.Error(err))
 		return nil
 	}
-	return opts
+	return sanitizeOpenAIReplayMetadata(opts)
 }
 
 // safeToolCallArgs ensures tool call args are valid JSON. Returns

--- a/coderd/chatd/chatprompt/chatprompt_internal_test.go
+++ b/coderd/chatd/chatprompt/chatprompt_internal_test.go
@@ -1,0 +1,96 @@
+package chatprompt
+
+import (
+	"testing"
+
+	"charm.land/fantasy"
+	fantasyanthropic "charm.land/fantasy/providers/anthropic"
+	fantasyopenai "charm.land/fantasy/providers/openai"
+	"github.com/stretchr/testify/require"
+
+	"cdr.dev/slog/v3/sloggers/slogtest"
+)
+
+func TestSanitizeOpenAIReplayMetadata(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ReasoningMetadata", func(t *testing.T) {
+		t.Parallel()
+
+		encryptedContent := "encrypted"
+		metadata := &fantasyopenai.ResponsesReasoningMetadata{
+			ItemID:           "rs_123",
+			EncryptedContent: &encryptedContent,
+			Summary:          []string{"step one", "step two"},
+		}
+		opts := sanitizeOpenAIReplayMetadata(fantasy.ProviderOptions{
+			fantasyopenai.Name: metadata,
+		})
+
+		reasoning, ok := opts[fantasyopenai.Name].(*fantasyopenai.ResponsesReasoningMetadata)
+		require.True(t, ok)
+		require.Empty(t, reasoning.ItemID)
+		require.Equal(t, []string{"step one", "step two"}, reasoning.Summary)
+		require.NotNil(t, reasoning.EncryptedContent)
+		require.Equal(t, encryptedContent, *reasoning.EncryptedContent)
+	})
+
+	t.Run("WebSearchMetadata", func(t *testing.T) {
+		t.Parallel()
+
+		action := &fantasyopenai.WebSearchAction{Type: "search", Query: "coder"}
+		metadata := &fantasyopenai.WebSearchCallMetadata{
+			ItemID: "ws_123",
+			Action: action,
+		}
+		opts := sanitizeOpenAIReplayMetadata(fantasy.ProviderOptions{
+			fantasyopenai.Name: metadata,
+		})
+
+		webSearch, ok := opts[fantasyopenai.Name].(*fantasyopenai.WebSearchCallMetadata)
+		require.True(t, ok)
+		require.Empty(t, webSearch.ItemID)
+		require.Same(t, action, webSearch.Action)
+		require.Equal(t, "search", webSearch.Action.Type)
+		require.Equal(t, "coder", webSearch.Action.Query)
+	})
+
+	t.Run("NonOpenAIMetadataUntouched", func(t *testing.T) {
+		t.Parallel()
+
+		cacheControl := &fantasyanthropic.ProviderCacheControlOptions{
+			CacheControl: fantasyanthropic.CacheControl{Type: "ephemeral"},
+		}
+		opts := sanitizeOpenAIReplayMetadata(fantasy.ProviderOptions{
+			"anthropic": cacheControl,
+		})
+
+		anthropicMetadata, ok := opts["anthropic"].(*fantasyanthropic.ProviderCacheControlOptions)
+		require.True(t, ok)
+		require.Equal(t, "ephemeral", anthropicMetadata.CacheControl.Type)
+	})
+
+	t.Run("ProviderMetadataToOptionsRoundTrip", func(t *testing.T) {
+		t.Parallel()
+
+		encryptedContent := "round-trip"
+		raw := marshalProviderMetadata(fantasy.ProviderMetadata{
+			fantasyopenai.Name: &fantasyopenai.ResponsesReasoningMetadata{
+				ItemID:           "rs_roundtrip",
+				EncryptedContent: &encryptedContent,
+				Summary:          []string{"summary"},
+			},
+		})
+		require.NotNil(t, raw)
+
+		opts := providerMetadataToOptions(slogtest.Make(t, nil), raw)
+		require.NotNil(t, opts)
+
+		reasoning, ok := opts[fantasyopenai.Name].(*fantasyopenai.ResponsesReasoningMetadata)
+		require.True(t, ok)
+		require.Empty(t, reasoning.ItemID)
+		require.Equal(t, []string{"summary"}, reasoning.Summary)
+		require.NotNil(t, reasoning.EncryptedContent)
+		require.Equal(t, encryptedContent, *reasoning.EncryptedContent)
+	})
+}

--- a/coderd/chatd/chatprompt/chatprompt_test.go
+++ b/coderd/chatd/chatprompt/chatprompt_test.go
@@ -8,6 +8,7 @@ import (
 
 	"charm.land/fantasy"
 	fantasyanthropic "charm.land/fantasy/providers/anthropic"
+	fantasyopenai "charm.land/fantasy/providers/openai"
 	"github.com/google/uuid"
 	"github.com/sqlc-dev/pqtype"
 	"github.com/stretchr/testify/assert"
@@ -1036,6 +1037,63 @@ func TestProviderMetadataRoundTrip(t *testing.T) {
 	cc := fantasyanthropic.GetCacheControl(textPart.ProviderOptions)
 	require.NotNil(t, cc, "Anthropic cache control must survive round-trip")
 	require.Equal(t, "ephemeral", cc.Type)
+}
+
+// TestProviderMetadataRoundTripOpenAIReasoningReplaySanitized verifies
+// OpenAI reasoning metadata survives round-trip replay except for the
+// ephemeral item_id, which is stripped before prompt reconstruction.
+func TestProviderMetadataRoundTripOpenAIReasoningReplaySanitized(t *testing.T) {
+	t.Parallel()
+
+	encryptedContent := "ciphertext"
+	original := fantasy.ReasoningContent{
+		Text: "thinking through the problem",
+		ProviderMetadata: fantasy.ProviderMetadata{
+			fantasyopenai.Name: &fantasyopenai.ResponsesReasoningMetadata{
+				ItemID:           "rs_reasoning",
+				EncryptedContent: &encryptedContent,
+				Summary:          []string{"first thought", "second thought"},
+			},
+		},
+	}
+
+	sdkPart := chatprompt.PartFromContent(original)
+	require.Equal(t, codersdk.ChatMessagePartTypeReasoning, sdkPart.Type)
+	require.NotNil(t, sdkPart.ProviderMetadata)
+
+	raw, err := chatprompt.MarshalParts([]codersdk.ChatMessagePart{sdkPart})
+	require.NoError(t, err)
+
+	parts, err := chatprompt.ParseContent(testMsg(codersdk.ChatMessageRoleAssistant, raw))
+	require.NoError(t, err)
+	require.Len(t, parts, 1)
+	assert.Equal(t, "thinking through the problem", parts[0].Text)
+	assert.JSONEq(t, string(sdkPart.ProviderMetadata), string(parts[0].ProviderMetadata))
+
+	prompt, err := chatprompt.ConvertMessagesWithFiles(
+		context.Background(),
+		[]database.ChatMessage{{
+			Role:       database.ChatMessageRoleAssistant,
+			Visibility: database.ChatMessageVisibilityBoth,
+			Content:    raw,
+		}},
+		nil,
+		slogtest.Make(t, nil),
+	)
+	require.NoError(t, err)
+	require.Len(t, prompt, 1)
+	require.Len(t, prompt[0].Content, 1)
+
+	reasoningPart, ok := fantasy.AsMessagePart[fantasy.ReasoningPart](prompt[0].Content[0])
+	require.True(t, ok, "expected ReasoningPart")
+	require.Equal(t, "thinking through the problem", reasoningPart.Text)
+
+	reasoningMetadata, ok := reasoningPart.ProviderOptions[fantasyopenai.Name].(*fantasyopenai.ResponsesReasoningMetadata)
+	require.True(t, ok, "expected OpenAI reasoning metadata")
+	require.Empty(t, reasoningMetadata.ItemID)
+	require.Equal(t, []string{"first thought", "second thought"}, reasoningMetadata.Summary)
+	require.NotNil(t, reasoningMetadata.EncryptedContent)
+	require.Equal(t, encryptedContent, *reasoningMetadata.EncryptedContent)
 }
 
 // TestFileReferencePreservation verifies file-reference parts

--- a/coderd/chatd/integration_test.go
+++ b/coderd/chatd/integration_test.go
@@ -422,6 +422,160 @@ func TestOpenAIReasoningRoundTrip(t *testing.T) {
 	t.Log("OpenAI reasoning round-trip test passed.")
 }
 
+// TestOpenAIReasoningRoundTripStoreFalse is an integration test that verifies
+// follow-up messages succeed when reasoning items were created with
+// store: false, where OpenAI response item IDs are ephemeral and are not
+// persisted on OpenAI's servers. It sends a query to a reasoning model,
+// waits for completion, then sends a follow-up message to ensure chatd can
+// reconstruct the conversation without relying on persisted provider item IDs.
+//
+// The test guards against the prior failure mode where the follow-up request
+// was rejected with an error like:
+//
+//	Item with id 'msg_xxx' not found. Items are not persisted when
+//	store is set to false.
+//
+// The test requires OPENAI_API_KEY to be set.
+func TestOpenAIReasoningRoundTripStoreFalse(t *testing.T) {
+	t.Parallel()
+
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	if apiKey == "" {
+		t.Skip("OPENAI_API_KEY not set; skipping OpenAI integration test")
+	}
+	baseURL := os.Getenv("OPENAI_BASE_URL")
+
+	ctx := testutil.Context(t, testutil.WaitSuperLong)
+
+	// Stand up a full coderd with the agents experiment.
+	deploymentValues := coderdtest.DeploymentValues(t)
+	deploymentValues.Experiments = []string{string(codersdk.ExperimentAgents)}
+	client := coderdtest.New(t, &coderdtest.Options{
+		DeploymentValues: deploymentValues,
+	})
+	_ = coderdtest.CreateFirstUser(t, client)
+
+	// Configure an OpenAI provider with the real API key.
+	_, err := client.CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
+		Provider: "openai",
+		APIKey:   apiKey,
+		BaseURL:  baseURL,
+	})
+	require.NoError(t, err)
+
+	// Create a model config for a reasoning model with Store: false.
+	// Using o4-mini because it always produces reasoning items.
+	contextLimit := int64(200000)
+	isDefault := true
+	reasoningSummary := "auto"
+	_, err = client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+		Provider:     "openai",
+		Model:        "o4-mini",
+		ContextLimit: &contextLimit,
+		IsDefault:    &isDefault,
+		ModelConfig: &codersdk.ChatModelCallConfig{
+			ProviderOptions: &codersdk.ChatModelProviderOptions{
+				OpenAI: &codersdk.ChatModelOpenAIProviderOptions{
+					Store:            ptr.Ref(false),
+					ReasoningSummary: &reasoningSummary,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// --- Step 1: Send a message that triggers reasoning ---
+	t.Log("Creating chat with reasoning query...")
+	chat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
+		Content: []codersdk.ChatInputPart{
+			{
+				Type: codersdk.ChatInputPartTypeText,
+				Text: "What is 2+2? Be brief.",
+			},
+		},
+	})
+	require.NoError(t, err)
+	t.Logf("Chat created: %s (status=%s)", chat.ID, chat.Status)
+
+	// Stream events until the chat reaches a terminal status.
+	events, closer, err := client.StreamChat(ctx, chat.ID, nil)
+	require.NoError(t, err)
+	defer closer.Close()
+
+	waitForChatDone(ctx, t, events, "step 1")
+
+	// Verify the chat completed and messages were persisted.
+	chatData, err := client.GetChat(ctx, chat.ID)
+	require.NoError(t, err)
+	chatMsgs, err := client.GetChatMessages(ctx, chat.ID, nil)
+	require.NoError(t, err)
+	t.Logf("Chat status after step 1: %s, messages: %d",
+		chatData.Status, len(chatMsgs.Messages))
+	logMessages(t, chatMsgs.Messages)
+
+	require.Equal(t, codersdk.ChatStatusWaiting, chatData.Status,
+		"chat should be in waiting status after step 1")
+
+	// Verify the assistant message has reasoning content.
+	assistantMsg := findAssistantWithText(t, chatMsgs.Messages)
+	require.NotNil(t, assistantMsg,
+		"expected an assistant message with text content after step 1")
+
+	partTypes := partTypeSet(assistantMsg.Content)
+	require.Contains(t, partTypes, codersdk.ChatMessagePartTypeReasoning,
+		"assistant message should contain reasoning parts from o4-mini")
+	require.Contains(t, partTypes, codersdk.ChatMessagePartTypeText,
+		"assistant message should contain a text part")
+
+	// --- Step 2: Send a follow-up message ---
+	// This is the critical test: when Store is false, item IDs are
+	// ephemeral and cannot be looked up from OpenAI later.
+	t.Log("Sending follow-up message...")
+	_, err = client.CreateChatMessage(ctx, chat.ID,
+		codersdk.CreateChatMessageRequest{
+			Content: []codersdk.ChatInputPart{
+				{
+					Type: codersdk.ChatInputPartTypeText,
+					Text: "And what is 3+3? Be brief.",
+				},
+			},
+		})
+	if err != nil {
+		require.NotContains(t, err.Error(),
+			"Items are not persisted when store is set to false.",
+			"follow-up should reconstruct ephemeral reasoning items instead of sending stale provider item IDs")
+	}
+	require.NoError(t, err)
+
+	// Stream the follow-up response.
+	events2, closer2, err := client.StreamChat(ctx, chat.ID, nil)
+	require.NoError(t, err)
+	defer closer2.Close()
+
+	waitForChatDone(ctx, t, events2, "step 2")
+
+	// Verify the follow-up completed and produced content.
+	chatData2, err := client.GetChat(ctx, chat.ID)
+	require.NoError(t, err)
+	chatMsgs2, err := client.GetChatMessages(ctx, chat.ID, nil)
+	require.NoError(t, err)
+	t.Logf("Chat status after step 2: %s, messages: %d",
+		chatData2.Status, len(chatMsgs2.Messages))
+	logMessages(t, chatMsgs2.Messages)
+
+	require.Equal(t, codersdk.ChatStatusWaiting, chatData2.Status,
+		"chat should be in waiting status after step 2")
+	require.Greater(t, len(chatMsgs2.Messages), len(chatMsgs.Messages),
+		"follow-up should have added more messages")
+
+	// The last assistant message should have text.
+	lastAssistant := findLastAssistantWithText(t, chatMsgs2.Messages)
+	require.NotNil(t, lastAssistant,
+		"expected an assistant message with text in the follow-up")
+
+	t.Log("OpenAI reasoning round-trip store=false test passed.")
+}
+
 // partTypeSet returns the set of part types present in a message.
 func partTypeSet(parts []codersdk.ChatMessagePart) map[codersdk.ChatMessagePartType]struct{} {
 	set := make(map[codersdk.ChatMessagePartType]struct{}, len(parts))


### PR DESCRIPTION
## Problem

When OpenAI `store` is `false`, response items carry ephemeral IDs that aren't persisted on OpenAI's servers. On follow-up messages, these stale IDs were replayed back, causing:

> Item with id 'rs_xxx' not found. Items are not persisted when store is set to false.

## Fix

Upstream fix in [ibetitsmike/fantasy#4](https://github.com/ibetitsmike/fantasy/pull/4):

- **Reasoning items**: Always skip during replay. When `store=true`, the API already has them; when `store=false`, the IDs are ephemeral. Replaying reasoning inline is not supported by the API in either case.
- **Provider-executed tool calls**: Gate `item_reference` behind the `store` flag. When `store=false`, skip (server-side items are ephemeral).

## Changes in this PR

- `go.mod`/`go.sum` — Update fantasy replace directive to `ibetitsmike/fantasy` at the fix commit
- `go.mod` — Update the fantasy fork comment to describe the current fork lineage and the `store=false` replay fix
- `coderd/chatd/integration_test.go` — Add `TestOpenAIReasoningRoundTripStoreFalse` (requires `OPENAI_API_KEY`)
