### PR TITLE
fix(site): add expand sidebar button to settings and analytics views

### DIFF
--- a/site/src/pages/AgentsPage/AgentsPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageView.stories.tsx
@@ -302,6 +302,32 @@ export const SidebarCollapsed: Story = {
 	},
 };
 
+export const SettingsSidebarCollapsed: Story = {
+	args: {
+		isSidebarCollapsed: true,
+		isAgentsAdmin: true,
+	},
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: { path: "/agents/settings/behavior" },
+			routing: agentsRouting,
+		}),
+	},
+};
+
+export const AnalyticsSidebarCollapsed: Story = {
+	args: {
+		isSidebarCollapsed: true,
+		isAgentsAdmin: true,
+	},
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: { path: "/agents/analytics" },
+			routing: agentsRouting,
+		}),
+	},
+};
+
 export const WithToolbarEndContent: Story = {
 	args: {
 		isAgentsAdmin: true,

--- a/site/src/pages/AgentsPage/AgentsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageView.tsx
@@ -243,13 +243,43 @@ export const AgentsPageView: FC<AgentsPageViewProps> = ({
 				)}
 			>
 				{sidebarView.panel === "settings" ? (
-					<SettingsPageContent
-						activeSection={sidebarView.section}
-						canManageChatModelConfigs={isAgentsAdmin}
-						canSetSystemPrompt={isAgentsAdmin}
-					/>
+					<>
+						{isSidebarCollapsed && (
+							<div className="flex shrink-0 items-center gap-2 px-4 py-1.5">
+								<Button
+									variant="subtle"
+									size="icon"
+									onClick={onExpandSidebar}
+									aria-label="Expand sidebar"
+									className="hidden h-7 w-7 min-w-0 shrink-0 md:inline-flex"
+								>
+									<PanelLeftIcon />
+								</Button>
+							</div>
+						)}
+						<SettingsPageContent
+							activeSection={sidebarView.section}
+							canManageChatModelConfigs={isAgentsAdmin}
+							canSetSystemPrompt={isAgentsAdmin}
+						/>
+					</>
 				) : sidebarView.panel === "analytics" ? (
-					<AnalyticsPageContent now={analyticsNow} />
+					<>
+						{isSidebarCollapsed && (
+							<div className="flex shrink-0 items-center gap-2 px-4 py-1.5">
+								<Button
+									variant="subtle"
+									size="icon"
+									onClick={onExpandSidebar}
+									aria-label="Expand sidebar"
+									className="hidden h-7 w-7 min-w-0 shrink-0 md:inline-flex"
+								>
+									<PanelLeftIcon />
+								</Button>
+							</div>
+						)}
+						<AnalyticsPageContent now={analyticsNow} />
+					</>
 				) : agentId ? (
 					<Outlet key={agentId} context={outletContextValue} />
 				) : (


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

## Problem

When the sidebar is collapsed on the `/agents/settings/*` or `/agents/analytics` pages, there was no expand button to re-open it. This left the user stuck with a collapsed sidebar and no way to restore it without navigating away.

The sidebar collapse button is available on the analytics page (it uses Panel 1 which shows the collapse button), and the collapsed state persists when navigating between pages. But unlike the main agents page (which has an expand button in its header) and the agent detail view (which has one in `TopBar`), the settings and analytics views had no corresponding expand button.

## Fix

Added the same `PanelLeftIcon` expand button that already exists on other views to both the settings and analytics content areas. The button only renders when:
- `isSidebarCollapsed` is `true`
- The viewport is `md` or larger (matches the sidebar collapse behavior)

Also added `SettingsSidebarCollapsed` and `AnalyticsSidebarCollapsed` Storybook stories to demonstrate the fix.