### PR TITLE
fix(agent): downgrade script completion error log to warn

### DIFF
--- a/agent/agentscripts/agentscripts.go
+++ b/agent/agentscripts/agentscripts.go
@@ -398,11 +398,11 @@ func (r *Runner) run(ctx context.Context, script codersdk.WorkspaceAgentScript, 
 				},
 			})
 			if err != nil {
-				logger.Error(ctx, fmt.Sprintf("reporting script completed: %s", err.Error()))
+				logger.Warn(ctx, "reporting script completed", slog.Error(err))
 			}
 		})
 		if err != nil {
-			logger.Error(ctx, fmt.Sprintf("reporting script completed: track command goroutine: %s", err.Error()))
+			logger.Warn(ctx, "reporting script completed: track command goroutine", slog.Error(err))
 		}
 	}()
 


### PR DESCRIPTION
Downgrades the "reporting script completed" log in `agentscripts` from
ERROR to WARN.

During agent reconnects, the `scriptCompleted` RPC can race with the
connection teardown, producing a "connection closed" error. Since
`slogtest` treats ERROR logs as test failures, this causes
`TestAgent_ReconnectNoLifecycleReemit` to flake on macOS.

A failed timing report is non-fatal — the script itself has already
finished, and the agent will continue operating normally. WARN is the
appropriate severity, consistent with the call site in
`agent.go:createDevcontainer`.

Also switches from `fmt.Sprintf` to structured `slog.Error` fields for
consistency with the rest of the codebase.

Fixes coder/internal#1410