### PR TITLE
docs: document smart hook file classification in CONTRIBUTING

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,9 @@
+paths:
+  # The triage workflow uses a quoted heredoc (<<'EOF') with ${VAR}
+  # placeholders that envsubst expands later. Shellcheck's SC2016
+  # warns about unexpanded variables in single-quoted strings, but
+  # the non-expansion is intentional here. Actionlint doesn't honor
+  # inline shellcheck disable directives inside heredocs.
+  .github/workflows/triage-via-chat-api.yaml:
+    ignore:
+      - 'SC2016'

--- a/docs/about/contributing/CONTRIBUTING.md
+++ b/docs/about/contributing/CONTRIBUTING.md
@@ -71,6 +71,8 @@ Use the following `make` commands and scripts in development:
 - `make install` installs binaries to `$GOPATH/bin`
 - `make test`
 - `make pre-commit` runs gen, fmt, lint, typos, and builds a slim binary
+- `make pre-commit-light` runs fmt and lint for shell, terraform, markdown,
+  helm, actions, and typos (skips gen, Go/TS lint+fmt, and binary build)
 - `make pre-push` runs heavier CI checks including tests (allowlisted)
 
 Install the git hooks to run these automatically:
@@ -78,6 +80,12 @@ Install the git hooks to run these automatically:
 ```sh
 git config core.hooksPath scripts/githooks
 ```
+
+The hooks classify staged/changed files and select the appropriate target.
+Commits that only touch docs, shell, terraform, or other lightweight files
+run `make pre-commit-light` instead of the full `make pre-commit`, and
+`pre-push` is skipped entirely. Changes to Go, TypeScript, SQL, proto, or
+the Makefile trigger the full targets as before.
 
 ### Running Coder on development mode
 


### PR DESCRIPTION
The git hooks from #23358 now classify staged files and select either
the full or lightweight make target. The contributing guide didn't
mention `make pre-commit-light` or explain that hooks take a fast
path for docs/shell/terraform-only changes.

Also adds `.github/actionlint.yaml` to suppress a pre-existing
SC2016 false positive in the triage workflow. Shellcheck `disable`
directives inside heredocs aren't honored when actionlint drives
shellcheck (known limitation).

Closes the documentation gap noted in
https://github.com/coder/coder/pull/23358#issuecomment-4098831335.

> 🤖 This PR was created with the help of Coder Agents, and has been reviewed by a human. 🏂🏻