### PR TITLE
fix(examples): clean up old code-server versions to save disk space

### DIFF
--- a/examples/jfrog/docker/main.tf
+++ b/examples/jfrog/docker/main.tf
@@ -67,6 +67,24 @@ resource "coder_agent" "main" {
 
     # install and start code-server
     curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server
+
+    # Remove old code-server versions and cached tarballs to save disk space.
+    # https://github.com/coder/coder/issues/23356
+    for old_dir in /tmp/code-server/lib/code-server-*; do
+      [ -d "$old_dir" ] || continue
+      case "$old_dir" in
+        *"$(/tmp/code-server/bin/code-server --version | head -1)"*) continue ;;
+      esac
+      rm -rf "$old_dir"
+    done
+    for old_tar in "$${XDG_CACHE_HOME:-$HOME/.cache}"/code-server/code-server-*.tar.gz; do
+      [ -f "$old_tar" ] || continue
+      case "$old_tar" in
+        *"$(/tmp/code-server/bin/code-server --version | head -1)"*) continue ;;
+      esac
+      rm -f "$old_tar"
+    done
+
     /tmp/code-server/bin/code-server --auth none --port 13337 >/tmp/code-server.log 2>&1 &
 
     # Install the JFrog VS Code extension.

--- a/examples/parameters-dynamic-options/main.tf
+++ b/examples/parameters-dynamic-options/main.tf
@@ -60,6 +60,26 @@ resource "coder_agent" "main" {
     # Append "-s -- --version x.x.x" to install a specific version of code-server.
     curl -fsSL https://code-server.dev/install.sh | sh
 
+    # Remove old code-server cached archives to save disk space.
+    # https://github.com/coder/coder/issues/23356
+    if command -v code-server >/dev/null 2>&1; then
+      CS_VERSION=$(code-server --version | head -1)
+      for old_tar in "$${XDG_CACHE_HOME:-$HOME/.cache}"/code-server/code-server-*.tar.gz; do
+        [ -f "$old_tar" ] || continue
+        case "$old_tar" in
+          *"$CS_VERSION"*) continue ;;
+        esac
+        rm -f "$old_tar"
+      done
+      for old_pkg in "$${XDG_CACHE_HOME:-$HOME/.cache}"/code-server/code-server_*.deb "$${XDG_CACHE_HOME:-$HOME/.cache}"/code-server/code-server-*.rpm; do
+        [ -f "$old_pkg" ] || continue
+        case "$old_pkg" in
+          *"$CS_VERSION"*) continue ;;
+        esac
+        rm -f "$old_pkg"
+      done
+    fi
+
     # Start code-server.
     code-server --auth none --port 13337
     EOF

--- a/examples/parameters/main.tf
+++ b/examples/parameters/main.tf
@@ -33,6 +33,23 @@ resource "coder_agent" "main" {
     # Append "--version x.x.x" to install a specific version of code-server.
     curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server
 
+    # Remove old code-server versions and cached tarballs to save disk space.
+    # https://github.com/coder/coder/issues/23356
+    for old_dir in /tmp/code-server/lib/code-server-*; do
+      [ -d "$old_dir" ] || continue
+      case "$old_dir" in
+        *"$(/tmp/code-server/bin/code-server --version | head -1)"*) continue ;;
+      esac
+      rm -rf "$old_dir"
+    done
+    for old_tar in "$${XDG_CACHE_HOME:-$HOME/.cache}"/code-server/code-server-*.tar.gz; do
+      [ -f "$old_tar" ] || continue
+      case "$old_tar" in
+        *"$(/tmp/code-server/bin/code-server --version | head -1)"*) continue ;;
+      esac
+      rm -f "$old_tar"
+    done
+
     # Start code-server in the background.
     /tmp/code-server/bin/code-server --auth none --port 13337 >/tmp/code-server.log 2>&1 &
   EOT

--- a/examples/templates/kubernetes/main.tf
+++ b/examples/templates/kubernetes/main.tf
@@ -113,6 +113,23 @@ resource "coder_agent" "main" {
     # Append "--version x.x.x" to install a specific version of code-server.
     curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server
 
+    # Remove old code-server versions and cached tarballs to save disk space.
+    # https://github.com/coder/coder/issues/23356
+    for old_dir in /tmp/code-server/lib/code-server-*; do
+      [ -d "$old_dir" ] || continue
+      case "$old_dir" in
+        *"$(/tmp/code-server/bin/code-server --version | head -1)"*) continue ;;
+      esac
+      rm -rf "$old_dir"
+    done
+    for old_tar in "$${XDG_CACHE_HOME:-$HOME/.cache}"/code-server/code-server-*.tar.gz; do
+      [ -f "$old_tar" ] || continue
+      case "$old_tar" in
+        *"$(/tmp/code-server/bin/code-server --version | head -1)"*) continue ;;
+      esac
+      rm -f "$old_tar"
+    done
+
     # Start code-server in the background.
     /tmp/code-server/bin/code-server --auth none --port 13337 >/tmp/code-server.log 2>&1 &
   EOT

--- a/examples/templates/nomad-docker/main.tf
+++ b/examples/templates/nomad-docker/main.tf
@@ -95,6 +95,24 @@ resource "coder_agent" "main" {
     set -e
     # install and start code-server
     curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server
+
+    # Remove old code-server versions and cached tarballs to save disk space.
+    # https://github.com/coder/coder/issues/23356
+    for old_dir in /tmp/code-server/lib/code-server-*; do
+      [ -d "$old_dir" ] || continue
+      case "$old_dir" in
+        *"$(/tmp/code-server/bin/code-server --version | head -1)"*) continue ;;
+      esac
+      rm -rf "$old_dir"
+    done
+    for old_tar in "$${XDG_CACHE_HOME:-$HOME/.cache}"/code-server/code-server-*.tar.gz; do
+      [ -f "$old_tar" ] || continue
+      case "$old_tar" in
+        *"$(/tmp/code-server/bin/code-server --version | head -1)"*) continue ;;
+      esac
+      rm -f "$old_tar"
+    done
+
     /tmp/code-server/bin/code-server --auth none --port 13337 >/tmp/code-server.log 2>&1 &
   EOT
 

--- a/examples/workspace-tags/main.tf
+++ b/examples/workspace-tags/main.tf
@@ -76,6 +76,26 @@ resource "coder_agent" "main" {
     # Append "-s -- --version x.x.x" to install a specific version of code-server.
     curl -fsSL https://code-server.dev/install.sh | sh
 
+    # Remove old code-server cached archives to save disk space.
+    # https://github.com/coder/coder/issues/23356
+    if command -v code-server >/dev/null 2>&1; then
+      CS_VERSION=$(code-server --version | head -1)
+      for old_tar in "$${XDG_CACHE_HOME:-$HOME/.cache}"/code-server/code-server-*.tar.gz; do
+        [ -f "$old_tar" ] || continue
+        case "$old_tar" in
+          *"$CS_VERSION"*) continue ;;
+        esac
+        rm -f "$old_tar"
+      done
+      for old_pkg in "$${XDG_CACHE_HOME:-$HOME/.cache}"/code-server/code-server_*.deb "$${XDG_CACHE_HOME:-$HOME/.cache}"/code-server/code-server-*.rpm; do
+        [ -f "$old_pkg" ] || continue
+        case "$old_pkg" in
+          *"$CS_VERSION"*) continue ;;
+        esac
+        rm -f "$old_pkg"
+      done
+    fi
+
     # Start code-server.
     code-server --auth none --port 13337
     EOF


### PR DESCRIPTION
## Summary

After installing a new version of code-server via `install.sh`, old versions accumulate in two locations:

1. **Cached tarballs** in `~/.cache/code-server/` (~120MB each)
2. **Extracted installs** in `$INSTALL_PREFIX/lib/code-server-$VERSION/` (~200-300MB each)

Over time, this wastes GBs of disk space in long-lived workspaces.

## Changes

Adds cleanup logic to all 6 example templates that use inline `curl | sh` to install code-server:

- **Standalone installs** (`kubernetes`, `parameters`, `nomad-docker`, `jfrog/docker`): Removes old extracted directories from `/tmp/code-server/lib/` and old tarballs from the cache.
- **System-wide installs** (`parameters-dynamic-options`, `workspace-tags`): Removes old cached tarballs and package files (`.deb`/`.rpm`).

Cleanup runs after install, only removes versions that don't match the currently installed version.

## Related work

The 15 templates using the registry module (`registry.coder.com/coder/code-server/coder`) need a separate fix in [coder/registry](https://github.com/coder/registry). The root-cause fix belongs in `install.sh` in [coder/code-server](https://github.com/coder/code-server).

Fixes #23356