### PR TITLE
feat: add /ui-messages endpoint with collapsed tool calls

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1219,6 +1219,7 @@ func New(options *Options) *API {
 				r.Get("/", api.getChat)
 				r.Patch("/", api.patchChat)
 				r.Get("/messages", api.getChatMessages)
+				r.Get("/ui-messages", api.getChatUIMessages)
 				r.Post("/messages", api.postChatMessages)
 				r.Patch("/messages/{message}", api.patchChatMessage)
 				r.Route("/stream", func(r chi.Router) {

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -2655,6 +2655,14 @@ func (q *querier) GetChatSystemPrompt(ctx context.Context) (string, error) {
 	return q.db.GetChatSystemPrompt(ctx)
 }
 
+func (q *querier) GetChatUIMessages(ctx context.Context, arg database.GetChatUIMessagesParams) ([]database.GetChatUIMessagesRow, error) {
+	_, err := q.GetChatByID(ctx, arg.ChatID)
+	if err != nil {
+		return nil, err
+	}
+	return q.db.GetChatUIMessages(ctx, arg)
+}
+
 func (q *querier) GetChatUsageLimitConfig(ctx context.Context) (database.ChatUsageLimitConfig, error) {
 	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceDeploymentConfig); err != nil {
 		return database.ChatUsageLimitConfig{}, err

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -1192,6 +1192,14 @@ func (m queryMetricsStore) GetChatSystemPrompt(ctx context.Context) (string, err
 	return r0, r1
 }
 
+func (m queryMetricsStore) GetChatUIMessages(ctx context.Context, arg database.GetChatUIMessagesParams) ([]database.GetChatUIMessagesRow, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetChatUIMessages(ctx, arg)
+	m.queryLatencies.WithLabelValues("GetChatUIMessages").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetChatUIMessages").Inc()
+	return r0, r1
+}
+
 func (m queryMetricsStore) GetChatUsageLimitConfig(ctx context.Context) (database.ChatUsageLimitConfig, error) {
 	start := time.Now()
 	r0, r1 := m.s.GetChatUsageLimitConfig(ctx)

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -2179,6 +2179,21 @@ func (mr *MockStoreMockRecorder) GetChatSystemPrompt(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChatSystemPrompt", reflect.TypeOf((*MockStore)(nil).GetChatSystemPrompt), ctx)
 }
 
+// GetChatUIMessages mocks base method.
+func (m *MockStore) GetChatUIMessages(ctx context.Context, arg database.GetChatUIMessagesParams) ([]database.GetChatUIMessagesRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetChatUIMessages", ctx, arg)
+	ret0, _ := ret[0].([]database.GetChatUIMessagesRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetChatUIMessages indicates an expected call of GetChatUIMessages.
+func (mr *MockStoreMockRecorder) GetChatUIMessages(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChatUIMessages", reflect.TypeOf((*MockStore)(nil).GetChatUIMessages), ctx, arg)
+}
+
 // GetChatUsageLimitConfig mocks base method.
 func (m *MockStore) GetChatUsageLimitConfig(ctx context.Context) (database.ChatUsageLimitConfig, error) {
 	m.ctrl.T.Helper()

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -252,6 +252,11 @@ type sqlcQuerier interface {
 	GetChatProviders(ctx context.Context) ([]ChatProvider, error)
 	GetChatQueuedMessages(ctx context.Context, chatID uuid.UUID) ([]ChatQueuedMessage, error)
 	GetChatSystemPrompt(ctx context.Context) (string, error)
+	// Returns boundary messages (user, first assistant, last pure-text assistant)
+	// for each "turn" in a chat, plus lightweight working-block metadata.
+	// Interior tool-call/tool-result messages are omitted for efficiency.
+	// Pagination is by turn (user message ID) rather than raw message ID.
+	GetChatUIMessages(ctx context.Context, arg GetChatUIMessagesParams) ([]GetChatUIMessagesRow, error)
 	GetChatUsageLimitConfig(ctx context.Context) (ChatUsageLimitConfig, error)
 	GetChatUsageLimitGroupOverride(ctx context.Context, groupID uuid.UUID) (GetChatUsageLimitGroupOverrideRow, error)
 	GetChatUsageLimitUserOverride(ctx context.Context, userID uuid.UUID) (GetChatUsageLimitUserOverrideRow, error)

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -4628,6 +4628,192 @@ func (q *sqlQuerier) GetChatQueuedMessages(ctx context.Context, chatID uuid.UUID
 	return items, nil
 }
 
+const getChatUIMessages = `-- name: GetChatUIMessages :many
+WITH paginated_users AS (
+    SELECT
+        cm.id AS user_msg_id,
+        COALESCE(
+            (SELECT MIN(cm2.id)
+             FROM chat_messages cm2
+             WHERE cm2.chat_id = $1
+               AND cm2.role = 'user'
+               AND cm2.id > cm.id
+               AND cm2.visibility IN ('user', 'both')
+               AND cm2.deleted = false),
+            0
+        ) AS turn_end_id
+    FROM chat_messages cm
+    WHERE cm.chat_id = $1
+      AND cm.role = 'user'
+      AND cm.visibility IN ('user', 'both')
+      AND cm.deleted = false
+      AND CASE WHEN $2::bigint > 0 THEN cm.id < $2 ELSE true END
+    ORDER BY cm.id DESC
+    LIMIT COALESCE(NULLIF($3::int, 0), 20)
+),
+turn_data AS (
+    SELECT
+        pu.user_msg_id,
+        pu.turn_end_id,
+        fa.id AS first_assistant_id,
+        la.id AS last_assistant_id,
+        COALESCE(ws.interior_count, 0)::bigint AS interior_count,
+        EXTRACT(EPOCH FROM ws.work_started_at)::bigint AS work_started_at_epoch,
+        EXTRACT(EPOCH FROM ws.work_ended_at)::bigint AS work_ended_at_epoch
+    FROM paginated_users pu
+    LEFT JOIN LATERAL (
+        SELECT id FROM chat_messages
+        WHERE chat_id = $1 AND role = 'assistant'
+          AND id > pu.user_msg_id
+          AND (pu.turn_end_id = 0 OR id < pu.turn_end_id)
+          AND visibility IN ('user', 'both') AND deleted = false
+        ORDER BY id ASC LIMIT 1
+    ) fa ON TRUE
+    LEFT JOIN LATERAL (
+        SELECT id FROM chat_messages
+        WHERE chat_id = $1 AND role = 'assistant'
+          AND id > pu.user_msg_id
+          AND (pu.turn_end_id = 0 OR id < pu.turn_end_id)
+          AND id != COALESCE(fa.id, 0)
+          AND NOT content @> '[{"type":"tool-call"}]'::jsonb
+          AND visibility IN ('user', 'both') AND deleted = false
+        ORDER BY id DESC LIMIT 1
+    ) la ON TRUE
+    LEFT JOIN LATERAL (
+        SELECT
+            COUNT(*) AS interior_count,
+            MIN(created_at) AS work_started_at,
+            MAX(created_at) AS work_ended_at
+        FROM chat_messages
+        WHERE chat_id = $1
+          AND id > COALESCE(fa.id, pu.user_msg_id)
+          AND id < COALESCE(
+              la.id,
+              CASE WHEN pu.turn_end_id = 0 THEN 9223372036854775807 ELSE pu.turn_end_id END
+          )
+          AND visibility IN ('user', 'both') AND deleted = false
+          AND role != 'user'
+    ) ws ON ws.interior_count > 0
+)
+SELECT
+    cm.id,
+    cm.chat_id,
+    cm.model_config_id,
+    cm.created_at,
+    cm.role,
+    cm.content,
+    cm.visibility,
+    cm.input_tokens,
+    cm.output_tokens,
+    cm.total_tokens,
+    cm.reasoning_tokens,
+    cm.cache_creation_tokens,
+    cm.cache_read_tokens,
+    cm.context_limit,
+    cm.compressed,
+    cm.created_by,
+    cm.content_version,
+    cm.total_cost_micros,
+    cm.runtime_ms,
+    cm.deleted,
+    td.user_msg_id AS turn_user_msg_id,
+    td.interior_count,
+    COALESCE(td.work_started_at_epoch, 0)::bigint AS work_started_at_epoch,
+    COALESCE(td.work_ended_at_epoch, 0)::bigint AS work_ended_at_epoch
+FROM turn_data td
+JOIN chat_messages cm ON (
+    cm.id = td.user_msg_id
+    OR (td.first_assistant_id IS NOT NULL AND cm.id = td.first_assistant_id)
+    OR (td.last_assistant_id IS NOT NULL AND cm.id = td.last_assistant_id)
+)
+ORDER BY td.user_msg_id DESC, cm.id ASC
+`
+
+type GetChatUIMessagesParams struct {
+	ChatID   uuid.UUID `db:"chat_id" json:"chat_id"`
+	BeforeID int64     `db:"before_id" json:"before_id"`
+	LimitVal int32     `db:"limit_val" json:"limit_val"`
+}
+
+type GetChatUIMessagesRow struct {
+	ID                  int64                 `db:"id" json:"id"`
+	ChatID              uuid.UUID             `db:"chat_id" json:"chat_id"`
+	ModelConfigID       uuid.NullUUID         `db:"model_config_id" json:"model_config_id"`
+	CreatedAt           time.Time             `db:"created_at" json:"created_at"`
+	Role                ChatMessageRole       `db:"role" json:"role"`
+	Content             pqtype.NullRawMessage `db:"content" json:"content"`
+	Visibility          ChatMessageVisibility `db:"visibility" json:"visibility"`
+	InputTokens         sql.NullInt64         `db:"input_tokens" json:"input_tokens"`
+	OutputTokens        sql.NullInt64         `db:"output_tokens" json:"output_tokens"`
+	TotalTokens         sql.NullInt64         `db:"total_tokens" json:"total_tokens"`
+	ReasoningTokens     sql.NullInt64         `db:"reasoning_tokens" json:"reasoning_tokens"`
+	CacheCreationTokens sql.NullInt64         `db:"cache_creation_tokens" json:"cache_creation_tokens"`
+	CacheReadTokens     sql.NullInt64         `db:"cache_read_tokens" json:"cache_read_tokens"`
+	ContextLimit        sql.NullInt64         `db:"context_limit" json:"context_limit"`
+	Compressed          bool                  `db:"compressed" json:"compressed"`
+	CreatedBy           uuid.NullUUID         `db:"created_by" json:"created_by"`
+	ContentVersion      int16                 `db:"content_version" json:"content_version"`
+	TotalCostMicros     sql.NullInt64         `db:"total_cost_micros" json:"total_cost_micros"`
+	RuntimeMs           sql.NullInt64         `db:"runtime_ms" json:"runtime_ms"`
+	Deleted             bool                  `db:"deleted" json:"deleted"`
+	TurnUserMsgID       int64                 `db:"turn_user_msg_id" json:"turn_user_msg_id"`
+	InteriorCount       int64                 `db:"interior_count" json:"interior_count"`
+	WorkStartedAtEpoch  int64                 `db:"work_started_at_epoch" json:"work_started_at_epoch"`
+	WorkEndedAtEpoch    int64                 `db:"work_ended_at_epoch" json:"work_ended_at_epoch"`
+}
+
+// Returns boundary messages (user, first assistant, last pure-text assistant)
+// for each "turn" in a chat, plus lightweight working-block metadata.
+// Interior tool-call/tool-result messages are omitted for efficiency.
+// Pagination is by turn (user message ID) rather than raw message ID.
+func (q *sqlQuerier) GetChatUIMessages(ctx context.Context, arg GetChatUIMessagesParams) ([]GetChatUIMessagesRow, error) {
+	rows, err := q.db.QueryContext(ctx, getChatUIMessages, arg.ChatID, arg.BeforeID, arg.LimitVal)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetChatUIMessagesRow
+	for rows.Next() {
+		var i GetChatUIMessagesRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.ChatID,
+			&i.ModelConfigID,
+			&i.CreatedAt,
+			&i.Role,
+			&i.Content,
+			&i.Visibility,
+			&i.InputTokens,
+			&i.OutputTokens,
+			&i.TotalTokens,
+			&i.ReasoningTokens,
+			&i.CacheCreationTokens,
+			&i.CacheReadTokens,
+			&i.ContextLimit,
+			&i.Compressed,
+			&i.CreatedBy,
+			&i.ContentVersion,
+			&i.TotalCostMicros,
+			&i.RuntimeMs,
+			&i.Deleted,
+			&i.TurnUserMsgID,
+			&i.InteriorCount,
+			&i.WorkStartedAtEpoch,
+			&i.WorkEndedAtEpoch,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getChatUsageLimitConfig = `-- name: GetChatUsageLimitConfig :one
 SELECT id, singleton, enabled, default_limit_micros, period, created_at, updated_at FROM chat_usage_limit_config WHERE singleton = TRUE LIMIT 1
 `

--- a/coderd/database/queries/chats.sql
+++ b/coderd/database/queries/chats.sql
@@ -70,6 +70,110 @@ ORDER BY
 LIMIT
     COALESCE(NULLIF(@limit_val::int, 0), 50);
 
+-- name: GetChatUIMessages :many
+-- Returns boundary messages (user, first assistant, last pure-text assistant)
+-- for each "turn" in a chat, plus lightweight working-block metadata.
+-- Interior tool-call/tool-result messages are omitted for efficiency.
+-- Pagination is by turn (user message ID) rather than raw message ID.
+WITH paginated_users AS (
+    SELECT
+        cm.id AS user_msg_id,
+        COALESCE(
+            (SELECT MIN(cm2.id)
+             FROM chat_messages cm2
+             WHERE cm2.chat_id = @chat_id
+               AND cm2.role = 'user'
+               AND cm2.id > cm.id
+               AND cm2.visibility IN ('user', 'both')
+               AND cm2.deleted = false),
+            0
+        ) AS turn_end_id
+    FROM chat_messages cm
+    WHERE cm.chat_id = @chat_id
+      AND cm.role = 'user'
+      AND cm.visibility IN ('user', 'both')
+      AND cm.deleted = false
+      AND CASE WHEN @before_id::bigint > 0 THEN cm.id < @before_id ELSE true END
+    ORDER BY cm.id DESC
+    LIMIT COALESCE(NULLIF(@limit_val::int, 0), 20)
+),
+turn_data AS (
+    SELECT
+        pu.user_msg_id,
+        pu.turn_end_id,
+        fa.id AS first_assistant_id,
+        la.id AS last_assistant_id,
+        COALESCE(ws.interior_count, 0)::bigint AS interior_count,
+        EXTRACT(EPOCH FROM ws.work_started_at)::bigint AS work_started_at_epoch,
+        EXTRACT(EPOCH FROM ws.work_ended_at)::bigint AS work_ended_at_epoch
+    FROM paginated_users pu
+    LEFT JOIN LATERAL (
+        SELECT id FROM chat_messages
+        WHERE chat_id = @chat_id AND role = 'assistant'
+          AND id > pu.user_msg_id
+          AND (pu.turn_end_id = 0 OR id < pu.turn_end_id)
+          AND visibility IN ('user', 'both') AND deleted = false
+        ORDER BY id ASC LIMIT 1
+    ) fa ON TRUE
+    LEFT JOIN LATERAL (
+        SELECT id FROM chat_messages
+        WHERE chat_id = @chat_id AND role = 'assistant'
+          AND id > pu.user_msg_id
+          AND (pu.turn_end_id = 0 OR id < pu.turn_end_id)
+          AND id != COALESCE(fa.id, 0)
+          AND NOT content @> '[{"type":"tool-call"}]'::jsonb
+          AND visibility IN ('user', 'both') AND deleted = false
+        ORDER BY id DESC LIMIT 1
+    ) la ON TRUE
+    LEFT JOIN LATERAL (
+        SELECT
+            COUNT(*) AS interior_count,
+            MIN(created_at) AS work_started_at,
+            MAX(created_at) AS work_ended_at
+        FROM chat_messages
+        WHERE chat_id = @chat_id
+          AND id > COALESCE(fa.id, pu.user_msg_id)
+          AND id < COALESCE(
+              la.id,
+              CASE WHEN pu.turn_end_id = 0 THEN 9223372036854775807 ELSE pu.turn_end_id END
+          )
+          AND visibility IN ('user', 'both') AND deleted = false
+          AND role != 'user'
+    ) ws ON ws.interior_count > 0
+)
+SELECT
+    cm.id,
+    cm.chat_id,
+    cm.model_config_id,
+    cm.created_at,
+    cm.role,
+    cm.content,
+    cm.visibility,
+    cm.input_tokens,
+    cm.output_tokens,
+    cm.total_tokens,
+    cm.reasoning_tokens,
+    cm.cache_creation_tokens,
+    cm.cache_read_tokens,
+    cm.context_limit,
+    cm.compressed,
+    cm.created_by,
+    cm.content_version,
+    cm.total_cost_micros,
+    cm.runtime_ms,
+    cm.deleted,
+    td.user_msg_id AS turn_user_msg_id,
+    td.interior_count,
+    COALESCE(td.work_started_at_epoch, 0)::bigint AS work_started_at_epoch,
+    COALESCE(td.work_ended_at_epoch, 0)::bigint AS work_ended_at_epoch
+FROM turn_data td
+JOIN chat_messages cm ON (
+    cm.id = td.user_msg_id
+    OR (td.first_assistant_id IS NOT NULL AND cm.id = td.first_assistant_id)
+    OR (td.last_assistant_id IS NOT NULL AND cm.id = td.last_assistant_id)
+)
+ORDER BY td.user_msg_id DESC, cm.id ASC;
+
 -- name: GetChatMessagesForPromptByChatID :many
 WITH latest_compressed_summary AS (
     SELECT

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -1143,6 +1143,79 @@ func (api *API) getChatMessages(rw http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// getChatUIMessages returns boundary messages grouped by turn with
+// working-block metadata for collapsed tool-call sections.
+//
+// @Summary Get chat UI messages
+// @ID get-chat-ui-messages
+// @Security CoderSessionToken
+// @Tags Chats
+// @Produce json
+// @Param chat path string true "Chat ID" format(uuid)
+// @Param before query int false "Cursor: user message ID to paginate before"
+// @Param limit query int false "Number of turns to return (max 50, default 20)"
+// @Success 200 {object} codersdk.ChatUIMessagesResponse
+// @Router /experimental/chats/{chat}/ui-messages [get]
+// @x-apidocgen {"skip": true}
+//
+//nolint:revive // get-return: revive assumes get* must be a getter, but this is an HTTP handler.
+func (api *API) getChatUIMessages(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	chat := httpmw.ChatParam(r)
+	chatID := chat.ID
+
+	queryParams := r.URL.Query()
+	parser := httpapi.NewQueryParamParser()
+	beforeID := parser.PositiveInt64(queryParams, 0, "before")
+	limit := parser.PositiveInt32(queryParams, 20, "limit")
+	if len(parser.Errors) > 0 {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message:     "Query parameters have invalid values.",
+			Validations: parser.Errors,
+		})
+		return
+	}
+	if limit < 1 || limit > 50 {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "Invalid limit parameter (1-50).",
+		})
+		return
+	}
+
+	// Fetch limit+1 turns to detect whether more pages exist.
+	rows, err := api.Database.GetChatUIMessages(ctx, database.GetChatUIMessagesParams{
+		ChatID:   chatID,
+		BeforeID: beforeID,
+		LimitVal: limit + 1,
+	})
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Failed to get chat UI messages.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
+	// Group rows into turns and build response.
+	isFirstPage := beforeID == 0
+	resp := buildUIMessagesResponse(rows, int(limit), chat.Status, isFirstPage)
+
+	// Only fetch queued messages on the first page.
+	if beforeID == 0 {
+		queuedMessages, err := api.Database.GetChatQueuedMessages(ctx, chatID)
+		if err != nil {
+			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+				Message: "Failed to get queued messages.",
+				Detail:  err.Error(),
+			})
+			return
+		}
+		resp.QueuedMessages = convertChatQueuedMessages(queuedMessages)
+	}
+
+	httpapi.Write(ctx, rw, http.StatusOK, resp)
+}
+
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
 //
 //nolint:revive // HTTP handler writes to ResponseWriter.
@@ -3267,6 +3340,131 @@ func convertChatMessages(messages []database.ChatMessage) []codersdk.ChatMessage
 		result = append(result, convertChatMessage(m))
 	}
 	return result
+}
+
+// buildUIMessagesResponse groups GetChatUIMessagesRow results into
+// the ChatUIMessagesResponse structure. Each row is a boundary message
+// annotated with its turn's user message ID and working block stats.
+func buildUIMessagesResponse(rows []database.GetChatUIMessagesRow, limit int, chatStatus database.ChatStatus, isFirstPage bool) codersdk.ChatUIMessagesResponse {
+	type turnInfo struct {
+		messages         []codersdk.ChatMessage
+		interiorCount    int64
+		workStartedEpoch int64
+		workEndedEpoch   int64
+	}
+
+	// Group rows by turn (identified by turn_user_msg_id).
+	// Maintain insertion order.
+	turnOrder := []int64{}
+	turns := map[int64]*turnInfo{}
+
+	for _, row := range rows {
+		turnID := row.TurnUserMsgID
+		t, ok := turns[turnID]
+		if !ok {
+			t = &turnInfo{
+				interiorCount:    row.InteriorCount,
+				workStartedEpoch: row.WorkStartedAtEpoch,
+				workEndedEpoch:   row.WorkEndedAtEpoch,
+			}
+			turns[turnID] = t
+			turnOrder = append(turnOrder, turnID)
+		}
+
+		// Convert the row to a ChatMessage using the existing helper.
+		msg := db2sdk.ChatMessage(uiRowToChatMessage(row))
+		t.messages = append(t.messages, msg)
+	}
+
+	// Detect has_more: if we got more turns than the limit, trim.
+	hasMore := len(turnOrder) > limit
+	if hasMore {
+		turnOrder = turnOrder[:limit]
+	}
+
+	// Build flat message list and working blocks.
+	messages := []codersdk.ChatMessage{}
+	workingBlocks := []codersdk.ChatUIWorkingBlock{}
+
+	for _, turnID := range turnOrder {
+		t := turns[turnID]
+		isLatestTurn := isFirstPage && turnID == turnOrder[0]
+		isActive := isLatestTurn && (chatStatus == database.ChatStatusRunning || chatStatus == database.ChatStatusPending)
+
+		for _, msg := range t.messages {
+			messages = append(messages, msg)
+		}
+
+		// Build working block if there are interior messages.
+		if t.interiorCount > 0 {
+			var afterID, beforeID int64
+			if len(t.messages) > 0 {
+				// afterID is the first non-user message (first
+				// assistant), or the user message if there's only
+				// one message.
+				if len(t.messages) >= 2 {
+					afterID = t.messages[1].ID // first assistant
+				} else {
+					afterID = t.messages[0].ID // user message
+				}
+				// beforeID is the last message (final assistant),
+				// or 0 if still active.
+				if len(t.messages) >= 3 {
+					beforeID = t.messages[len(t.messages)-1].ID
+				}
+			}
+
+			startedAt := time.Unix(t.workStartedEpoch, 0)
+			wb := codersdk.ChatUIWorkingBlock{
+				AfterMessageID:  afterID,
+				BeforeMessageID: beforeID,
+				StartedAt:       startedAt,
+				MessageCount:    int(t.interiorCount),
+			}
+
+			if !isActive && t.workEndedEpoch > 0 {
+				endedAt := time.Unix(t.workEndedEpoch, 0)
+				wb.EndedAt = &endedAt
+			}
+
+			workingBlocks = append(workingBlocks, wb)
+		}
+	}
+
+	return codersdk.ChatUIMessagesResponse{
+		Messages:       messages,
+		WorkingBlocks:  workingBlocks,
+		QueuedMessages: []codersdk.ChatQueuedMessage{},
+		HasMore:        hasMore,
+	}
+}
+
+// uiRowToChatMessage converts a GetChatUIMessagesRow to a
+// database.ChatMessage so we can reuse the existing db2sdk.ChatMessage
+// converter.
+func uiRowToChatMessage(row database.GetChatUIMessagesRow) database.ChatMessage {
+	return database.ChatMessage{
+		ID:                  row.ID,
+		ChatID:              row.ChatID,
+		ModelConfigID:       row.ModelConfigID,
+		CreatedAt:           row.CreatedAt,
+		Role:                row.Role,
+		Content:             row.Content,
+		Visibility:          row.Visibility,
+		InputTokens:         row.InputTokens,
+		OutputTokens:        row.OutputTokens,
+		TotalTokens:         row.TotalTokens,
+		ReasoningTokens:     row.ReasoningTokens,
+		CacheCreationTokens: row.CacheCreationTokens,
+		CacheReadTokens:     row.CacheReadTokens,
+		ContextLimit:        row.ContextLimit,
+		Compressed:          row.Compressed,
+		CreatedBy:           row.CreatedBy,
+		ContentVersion:      row.ContentVersion,
+		TotalCostMicros:     row.TotalCostMicros,
+		RuntimeMs:           row.RuntimeMs,
+		Deleted:             row.Deleted,
+	}
 }
 
 func (api *API) listChatProviders(rw http.ResponseWriter, r *http.Request) {

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -4950,6 +4950,665 @@ func TestChatWorkspaceTTL(t *testing.T) {
 	requireSDKError(t, err, http.StatusBadRequest)
 }
 
+func TestGetChatUIMessages(t *testing.T) {
+	t.Parallel()
+
+	// marshalParts is a test helper that encodes SDK chat message parts
+	// into a JSON string suitable for InsertChatMessages content.
+	marshalParts := func(t *testing.T, parts []codersdk.ChatMessagePart) string {
+		t.Helper()
+		encoded, err := chatprompt.MarshalParts(parts)
+		require.NoError(t, err)
+		return string(encoded.RawMessage)
+	}
+
+	// insertMessages is a test helper that batch-inserts messages into a
+	// chat. Each message is described by a role, content parts, and a
+	// created-by UUID (uuid.Nil for assistant/tool, user ID for user).
+	type testMsg struct {
+		role    database.ChatMessageRole
+		parts   []codersdk.ChatMessagePart
+		creator uuid.UUID
+	}
+	insertMessages := func(
+		t *testing.T,
+		ctx context.Context,
+		db database.Store,
+		chatID uuid.UUID,
+		modelConfigID uuid.UUID,
+		msgs []testMsg,
+	) []database.ChatMessage {
+		t.Helper()
+		n := len(msgs)
+		roles := make([]database.ChatMessageRole, n)
+		contents := make([]string, n)
+		creators := make([]uuid.UUID, n)
+		modelIDs := make([]uuid.UUID, n)
+		versions := make([]int16, n)
+		visibilities := make([]database.ChatMessageVisibility, n)
+		inputTokens := make([]int64, n)
+		outputTokens := make([]int64, n)
+		totalTokens := make([]int64, n)
+		reasoningTokens := make([]int64, n)
+		cacheCreationTokens := make([]int64, n)
+		cacheReadTokens := make([]int64, n)
+		contextLimits := make([]int64, n)
+		compressed := make([]bool, n)
+		totalCostMicros := make([]int64, n)
+		runtimeMs := make([]int64, n)
+		for i, m := range msgs {
+			roles[i] = m.role
+			contents[i] = marshalParts(t, m.parts)
+			creators[i] = m.creator
+			modelIDs[i] = modelConfigID
+			versions[i] = chatprompt.CurrentContentVersion
+			visibilities[i] = database.ChatMessageVisibilityBoth
+		}
+		results, err := db.InsertChatMessages(dbauthz.AsSystemRestricted(ctx), database.InsertChatMessagesParams{
+			ChatID:              chatID,
+			CreatedBy:           creators,
+			ModelConfigID:       modelIDs,
+			Role:                roles,
+			Content:             contents,
+			ContentVersion:      versions,
+			Visibility:          visibilities,
+			InputTokens:         inputTokens,
+			OutputTokens:        outputTokens,
+			TotalTokens:         totalTokens,
+			ReasoningTokens:     reasoningTokens,
+			CacheCreationTokens: cacheCreationTokens,
+			CacheReadTokens:     cacheReadTokens,
+			ContextLimit:        contextLimits,
+			Compressed:          compressed,
+			TotalCostMicros:     totalCostMicros,
+			RuntimeMs:           runtimeMs,
+		})
+		require.NoError(t, err)
+		require.Len(t, results, n)
+		return results
+	}
+
+	t.Run("EmptyChat", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client, db := newChatClientWithDatabase(t)
+		user := coderdtest.CreateFirstUser(t, client)
+		modelConfig := createChatModelConfig(t, client)
+
+		chat, err := db.InsertChat(dbauthz.AsSystemRestricted(ctx), database.InsertChatParams{
+			OwnerID:           user.UserID,
+			LastModelConfigID: modelConfig.ID,
+			Title:             "empty-chat",
+		})
+		require.NoError(t, err)
+
+		resp, err := client.GetChatUIMessages(ctx, chat.ID, nil)
+		require.NoError(t, err)
+		require.Empty(t, resp.Messages)
+		require.Empty(t, resp.WorkingBlocks)
+		require.False(t, resp.HasMore)
+	})
+
+	t.Run("SimpleQA", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client, db := newChatClientWithDatabase(t)
+		user := coderdtest.CreateFirstUser(t, client)
+		modelConfig := createChatModelConfig(t, client)
+
+		chat, err := db.InsertChat(dbauthz.AsSystemRestricted(ctx), database.InsertChatParams{
+			OwnerID:           user.UserID,
+			LastModelConfigID: modelConfig.ID,
+			Title:             "simple-qa",
+		})
+		require.NoError(t, err)
+
+		inserted := insertMessages(t, ctx, db, chat.ID, modelConfig.ID, []testMsg{
+			{
+				role:    database.ChatMessageRoleUser,
+				parts:   []codersdk.ChatMessagePart{codersdk.ChatMessageText("Hello")},
+				creator: user.UserID,
+			},
+			{
+				role:    database.ChatMessageRoleAssistant,
+				parts:   []codersdk.ChatMessagePart{codersdk.ChatMessageText("Hi there!")},
+				creator: uuid.Nil,
+			},
+		})
+
+		resp, err := client.GetChatUIMessages(ctx, chat.ID, nil)
+		require.NoError(t, err)
+		require.Len(t, resp.Messages, 2)
+		require.Empty(t, resp.WorkingBlocks)
+		require.False(t, resp.HasMore)
+
+		// First message is the user message, second is assistant.
+		require.Equal(t, codersdk.ChatMessageRoleUser, resp.Messages[0].Role)
+		require.Equal(t, inserted[0].ID, resp.Messages[0].ID)
+		require.Equal(t, codersdk.ChatMessageRoleAssistant, resp.Messages[1].Role)
+		require.Equal(t, inserted[1].ID, resp.Messages[1].ID)
+
+		// Verify content was decoded.
+		require.Len(t, resp.Messages[0].Content, 1)
+		require.Equal(t, codersdk.ChatMessagePartTypeText, resp.Messages[0].Content[0].Type)
+		require.Equal(t, "Hello", resp.Messages[0].Content[0].Text)
+	})
+
+	t.Run("SingleToolCallTurn", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client, db := newChatClientWithDatabase(t)
+		user := coderdtest.CreateFirstUser(t, client)
+		modelConfig := createChatModelConfig(t, client)
+
+		chat, err := db.InsertChat(dbauthz.AsSystemRestricted(ctx), database.InsertChatParams{
+			OwnerID:           user.UserID,
+			LastModelConfigID: modelConfig.ID,
+			Title:             "single-tool-call",
+		})
+		require.NoError(t, err)
+
+		// User → assistant(text + tool-call) → tool(result) →
+		// assistant(final text).
+		inserted := insertMessages(t, ctx, db, chat.ID, modelConfig.ID, []testMsg{
+			{
+				role:    database.ChatMessageRoleUser,
+				parts:   []codersdk.ChatMessagePart{codersdk.ChatMessageText("Read /foo")},
+				creator: user.UserID,
+			},
+			{
+				role: database.ChatMessageRoleAssistant,
+				parts: []codersdk.ChatMessagePart{
+					codersdk.ChatMessageText("Let me check"),
+					codersdk.ChatMessageToolCall("call_1", "read_file", json.RawMessage(`{"path":"/foo"}`)),
+				},
+				creator: uuid.Nil,
+			},
+			{
+				role: database.ChatMessageRoleTool,
+				parts: []codersdk.ChatMessagePart{
+					codersdk.ChatMessageToolResult("call_1", "read_file", json.RawMessage(`"file contents"`), false),
+				},
+				creator: uuid.Nil,
+			},
+			{
+				role:    database.ChatMessageRoleAssistant,
+				parts:   []codersdk.ChatMessagePart{codersdk.ChatMessageText("Done, the file says...")},
+				creator: uuid.Nil,
+			},
+		})
+
+		resp, err := client.GetChatUIMessages(ctx, chat.ID, nil)
+		require.NoError(t, err)
+
+		// Should return 3 boundary messages: user, first assistant,
+		// final assistant. The tool result is interior.
+		require.Len(t, resp.Messages, 3)
+		require.Equal(t, inserted[0].ID, resp.Messages[0].ID) // user
+		require.Equal(t, inserted[1].ID, resp.Messages[1].ID) // first assistant
+		require.Equal(t, inserted[3].ID, resp.Messages[2].ID) // final assistant
+
+		// One working block with interior_count=1 (the tool result).
+		require.Len(t, resp.WorkingBlocks, 1)
+		wb := resp.WorkingBlocks[0]
+		require.Equal(t, 1, wb.MessageCount)
+		require.Equal(t, inserted[1].ID, wb.AfterMessageID)
+		require.Equal(t, inserted[3].ID, wb.BeforeMessageID)
+		require.NotNil(t, wb.EndedAt, "completed turn should have ended_at")
+		require.False(t, resp.HasMore)
+	})
+
+	t.Run("MultipleToolCallSteps", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client, db := newChatClientWithDatabase(t)
+		user := coderdtest.CreateFirstUser(t, client)
+		modelConfig := createChatModelConfig(t, client)
+
+		chat, err := db.InsertChat(dbauthz.AsSystemRestricted(ctx), database.InsertChatParams{
+			OwnerID:           user.UserID,
+			LastModelConfigID: modelConfig.ID,
+			Title:             "multi-tool-call",
+		})
+		require.NoError(t, err)
+
+		// User → assistant(text + tool-call) → tool(result) →
+		// assistant(text + tool-call) → tool(result) →
+		// assistant(final text).
+		inserted := insertMessages(t, ctx, db, chat.ID, modelConfig.ID, []testMsg{
+			{
+				role:    database.ChatMessageRoleUser,
+				parts:   []codersdk.ChatMessagePart{codersdk.ChatMessageText("Read two files")},
+				creator: user.UserID,
+			},
+			{
+				role: database.ChatMessageRoleAssistant,
+				parts: []codersdk.ChatMessagePart{
+					codersdk.ChatMessageText("Reading first file"),
+					codersdk.ChatMessageToolCall("call_1", "read_file", json.RawMessage(`{"path":"/a"}`)),
+				},
+				creator: uuid.Nil,
+			},
+			{
+				role: database.ChatMessageRoleTool,
+				parts: []codersdk.ChatMessagePart{
+					codersdk.ChatMessageToolResult("call_1", "read_file", json.RawMessage(`"content a"`), false),
+				},
+				creator: uuid.Nil,
+			},
+			{
+				role: database.ChatMessageRoleAssistant,
+				parts: []codersdk.ChatMessagePart{
+					codersdk.ChatMessageText("Now the second"),
+					codersdk.ChatMessageToolCall("call_2", "read_file", json.RawMessage(`{"path":"/b"}`)),
+				},
+				creator: uuid.Nil,
+			},
+			{
+				role: database.ChatMessageRoleTool,
+				parts: []codersdk.ChatMessagePart{
+					codersdk.ChatMessageToolResult("call_2", "read_file", json.RawMessage(`"content b"`), false),
+				},
+				creator: uuid.Nil,
+			},
+			{
+				role:    database.ChatMessageRoleAssistant,
+				parts:   []codersdk.ChatMessagePart{codersdk.ChatMessageText("Both files read")},
+				creator: uuid.Nil,
+			},
+		})
+
+		resp, err := client.GetChatUIMessages(ctx, chat.ID, nil)
+		require.NoError(t, err)
+
+		// 3 boundary messages: user, first assistant, final assistant.
+		require.Len(t, resp.Messages, 3)
+		require.Equal(t, inserted[0].ID, resp.Messages[0].ID) // user
+		require.Equal(t, inserted[1].ID, resp.Messages[1].ID) // first assistant
+		require.Equal(t, inserted[5].ID, resp.Messages[2].ID) // final assistant
+
+		// 1 working block with 3 interior messages (tool, assistant,
+		// tool).
+		require.Len(t, resp.WorkingBlocks, 1)
+		wb := resp.WorkingBlocks[0]
+		require.Equal(t, 3, wb.MessageCount)
+		require.Equal(t, inserted[1].ID, wb.AfterMessageID)
+		require.Equal(t, inserted[5].ID, wb.BeforeMessageID)
+		require.NotNil(t, wb.EndedAt)
+		require.False(t, resp.HasMore)
+	})
+
+	t.Run("MultipleTurnsPagination", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client, db := newChatClientWithDatabase(t)
+		user := coderdtest.CreateFirstUser(t, client)
+		modelConfig := createChatModelConfig(t, client)
+
+		chat, err := db.InsertChat(dbauthz.AsSystemRestricted(ctx), database.InsertChatParams{
+			OwnerID:           user.UserID,
+			LastModelConfigID: modelConfig.ID,
+			Title:             "multi-turn-pagination",
+		})
+		require.NoError(t, err)
+
+		// Turn 1: simple Q&A.
+		turn1 := insertMessages(t, ctx, db, chat.ID, modelConfig.ID, []testMsg{
+			{
+				role:    database.ChatMessageRoleUser,
+				parts:   []codersdk.ChatMessagePart{codersdk.ChatMessageText("First question")},
+				creator: user.UserID,
+			},
+			{
+				role:    database.ChatMessageRoleAssistant,
+				parts:   []codersdk.ChatMessagePart{codersdk.ChatMessageText("First answer")},
+				creator: uuid.Nil,
+			},
+		})
+
+		// Turn 2: Q&A with a tool call.
+		turn2 := insertMessages(t, ctx, db, chat.ID, modelConfig.ID, []testMsg{
+			{
+				role:    database.ChatMessageRoleUser,
+				parts:   []codersdk.ChatMessagePart{codersdk.ChatMessageText("Second question")},
+				creator: user.UserID,
+			},
+			{
+				role: database.ChatMessageRoleAssistant,
+				parts: []codersdk.ChatMessagePart{
+					codersdk.ChatMessageText("Checking"),
+					codersdk.ChatMessageToolCall("call_t2", "ls", json.RawMessage(`{}`)),
+				},
+				creator: uuid.Nil,
+			},
+			{
+				role: database.ChatMessageRoleTool,
+				parts: []codersdk.ChatMessagePart{
+					codersdk.ChatMessageToolResult("call_t2", "ls", json.RawMessage(`"files"`), false),
+				},
+				creator: uuid.Nil,
+			},
+			{
+				role:    database.ChatMessageRoleAssistant,
+				parts:   []codersdk.ChatMessagePart{codersdk.ChatMessageText("Here are the files")},
+				creator: uuid.Nil,
+			},
+		})
+
+		// Page 1: limit=1 should return only the latest turn (turn 2)
+		// and indicate more.
+		page1, err := client.GetChatUIMessages(ctx, chat.ID, &codersdk.ChatMessagesPaginationOptions{
+			Limit: 1,
+		})
+		require.NoError(t, err)
+		require.True(t, page1.HasMore)
+
+		// Turn 2 has 3 boundary messages.
+		require.Len(t, page1.Messages, 3)
+		require.Equal(t, turn2[0].ID, page1.Messages[0].ID) // user
+		require.Equal(t, turn2[1].ID, page1.Messages[1].ID) // first assistant
+		require.Equal(t, turn2[3].ID, page1.Messages[2].ID) // final assistant
+		require.Len(t, page1.WorkingBlocks, 1)
+
+		// Page 2: paginate before the turn-2 user message ID to get
+		// turn 1.
+		page2, err := client.GetChatUIMessages(ctx, chat.ID, &codersdk.ChatMessagesPaginationOptions{
+			BeforeID: turn2[0].ID,
+			Limit:    1,
+		})
+		require.NoError(t, err)
+		require.False(t, page2.HasMore)
+
+		// Turn 1 is simple Q&A — 2 messages, no working blocks.
+		require.Len(t, page2.Messages, 2)
+		require.Equal(t, turn1[0].ID, page2.Messages[0].ID)
+		require.Equal(t, turn1[1].ID, page2.Messages[1].ID)
+		require.Empty(t, page2.WorkingBlocks)
+	})
+
+	t.Run("StillWorkingNoFinalText", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client, db := newChatClientWithDatabase(t)
+		user := coderdtest.CreateFirstUser(t, client)
+		modelConfig := createChatModelConfig(t, client)
+
+		// Mark the chat as running so the working block stays active.
+		chat, err := db.InsertChat(dbauthz.AsSystemRestricted(ctx), database.InsertChatParams{
+			OwnerID:           user.UserID,
+			LastModelConfigID: modelConfig.ID,
+			Title:             "still-working",
+		})
+		require.NoError(t, err)
+
+		// User → assistant(text + tool-call) → tool(result) → no
+		// final assistant yet.
+		inserted := insertMessages(t, ctx, db, chat.ID, modelConfig.ID, []testMsg{
+			{
+				role:    database.ChatMessageRoleUser,
+				parts:   []codersdk.ChatMessagePart{codersdk.ChatMessageText("Do something")},
+				creator: user.UserID,
+			},
+			{
+				role: database.ChatMessageRoleAssistant,
+				parts: []codersdk.ChatMessagePart{
+					codersdk.ChatMessageText("On it"),
+					codersdk.ChatMessageToolCall("call_w", "run_cmd", json.RawMessage(`{"cmd":"make"}`)),
+				},
+				creator: uuid.Nil,
+			},
+			{
+				role: database.ChatMessageRoleTool,
+				parts: []codersdk.ChatMessagePart{
+					codersdk.ChatMessageToolResult("call_w", "run_cmd", json.RawMessage(`"ok"`), false),
+				},
+				creator: uuid.Nil,
+			},
+		})
+
+		// Transition the chat to running so the working block stays
+		// open.
+		_, err = db.UpdateChatStatus(dbauthz.AsSystemRestricted(ctx), database.UpdateChatStatusParams{
+			ID:     chat.ID,
+			Status: database.ChatStatusRunning,
+		})
+		require.NoError(t, err)
+
+		resp, err := client.GetChatUIMessages(ctx, chat.ID, nil)
+		require.NoError(t, err)
+
+		// 2 boundary messages: user and first assistant. No final
+		// assistant exists.
+		require.Len(t, resp.Messages, 2)
+		require.Equal(t, inserted[0].ID, resp.Messages[0].ID)
+		require.Equal(t, inserted[1].ID, resp.Messages[1].ID)
+
+		// Working block should exist but without ended_at.
+		require.Len(t, resp.WorkingBlocks, 1)
+		wb := resp.WorkingBlocks[0]
+		require.Equal(t, 1, wb.MessageCount)
+		require.Equal(t, inserted[1].ID, wb.AfterMessageID)
+		require.Equal(t, int64(0), wb.BeforeMessageID, "before_message_id should be 0 when no final assistant")
+		require.Nil(t, wb.EndedAt, "active working block should not have ended_at")
+		require.False(t, resp.HasMore)
+	})
+
+	t.Run("OnlyToolCallNoInitialText", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client, db := newChatClientWithDatabase(t)
+		user := coderdtest.CreateFirstUser(t, client)
+		modelConfig := createChatModelConfig(t, client)
+
+		chat, err := db.InsertChat(dbauthz.AsSystemRestricted(ctx), database.InsertChatParams{
+			OwnerID:           user.UserID,
+			LastModelConfigID: modelConfig.ID,
+			Title:             "only-tool-call",
+		})
+		require.NoError(t, err)
+
+		// User → assistant(only tool-call, no text) → tool(result) →
+		// assistant(final text).
+		inserted := insertMessages(t, ctx, db, chat.ID, modelConfig.ID, []testMsg{
+			{
+				role:    database.ChatMessageRoleUser,
+				parts:   []codersdk.ChatMessagePart{codersdk.ChatMessageText("Do it")},
+				creator: user.UserID,
+			},
+			{
+				role: database.ChatMessageRoleAssistant,
+				parts: []codersdk.ChatMessagePart{
+					codersdk.ChatMessageToolCall("call_n", "write_file", json.RawMessage(`{"path":"/x"}`)),
+				},
+				creator: uuid.Nil,
+			},
+			{
+				role: database.ChatMessageRoleTool,
+				parts: []codersdk.ChatMessagePart{
+					codersdk.ChatMessageToolResult("call_n", "write_file", json.RawMessage(`"done"`), false),
+				},
+				creator: uuid.Nil,
+			},
+			{
+				role:    database.ChatMessageRoleAssistant,
+				parts:   []codersdk.ChatMessagePart{codersdk.ChatMessageText("File written")},
+				creator: uuid.Nil,
+			},
+		})
+
+		resp, err := client.GetChatUIMessages(ctx, chat.ID, nil)
+		require.NoError(t, err)
+
+		// 3 boundary messages: user, first assistant (tool-call
+		// only), final assistant.
+		require.Len(t, resp.Messages, 3)
+		require.Equal(t, inserted[0].ID, resp.Messages[0].ID) // user
+		require.Equal(t, inserted[1].ID, resp.Messages[1].ID) // first assistant (tool-call only)
+		require.Equal(t, inserted[3].ID, resp.Messages[2].ID) // final assistant
+
+		// The first assistant has a tool-call, verify its content.
+		require.Len(t, resp.Messages[1].Content, 1)
+		require.Equal(t, codersdk.ChatMessagePartTypeToolCall, resp.Messages[1].Content[0].Type)
+
+		// Working block covers the tool result.
+		require.Len(t, resp.WorkingBlocks, 1)
+		wb := resp.WorkingBlocks[0]
+		require.Equal(t, 1, wb.MessageCount)
+		require.Equal(t, inserted[1].ID, wb.AfterMessageID)
+		require.Equal(t, inserted[3].ID, wb.BeforeMessageID)
+		require.NotNil(t, wb.EndedAt)
+		require.False(t, resp.HasMore)
+	})
+
+	t.Run("UserOnlyTurnNoAssistant", func(t *testing.T) {
+		t.Parallel()
+
+		client, db := newChatClientWithDatabase(t)
+		ctx := testutil.Context(t, testutil.WaitShort)
+		user := coderdtest.CreateFirstUser(t, client)
+
+		modelConfig := createChatModelConfig(t, client)
+		chat, err := db.InsertChat(dbauthz.AsSystemRestricted(ctx), database.InsertChatParams{
+			OwnerID:           user.UserID,
+			LastModelConfigID: modelConfig.ID,
+			Title:             "user-only",
+		})
+		require.NoError(t, err)
+
+		// Insert only a user message — no assistant response yet.
+		inserted := insertMessages(t, ctx, db, chat.ID, modelConfig.ID, []testMsg{
+			{role: database.ChatMessageRoleUser, parts: []codersdk.ChatMessagePart{
+				{Type: codersdk.ChatMessagePartTypeText, Text: "Hello?"},
+			}, creator: user.UserID},
+		})
+
+		resp, err := client.GetChatUIMessages(ctx, chat.ID, nil)
+		require.NoError(t, err)
+
+		// Should return just the user message, no working blocks.
+		require.Len(t, resp.Messages, 1)
+		require.Equal(t, inserted[0].ID, resp.Messages[0].ID)
+		require.Equal(t, codersdk.ChatMessageRoleUser, resp.Messages[0].Role)
+		require.Empty(t, resp.WorkingBlocks)
+		require.False(t, resp.HasMore)
+	})
+
+	t.Run("SoftDeletedMessagesFiltered", func(t *testing.T) {
+		t.Parallel()
+
+		client, db := newChatClientWithDatabase(t)
+		ctx := testutil.Context(t, testutil.WaitShort)
+		user := coderdtest.CreateFirstUser(t, client)
+
+		modelConfig := createChatModelConfig(t, client)
+		chat, err := db.InsertChat(dbauthz.AsSystemRestricted(ctx), database.InsertChatParams{
+			OwnerID:           user.UserID,
+			LastModelConfigID: modelConfig.ID,
+			Title:             "soft-delete",
+		})
+		require.NoError(t, err)
+
+		// Insert a normal turn: user + assistant.
+		inserted := insertMessages(t, ctx, db, chat.ID, modelConfig.ID, []testMsg{
+			{role: database.ChatMessageRoleUser, parts: []codersdk.ChatMessagePart{
+				{Type: codersdk.ChatMessagePartTypeText, Text: "Hello"},
+			}, creator: user.UserID},
+			{role: database.ChatMessageRoleAssistant, parts: []codersdk.ChatMessagePart{
+				{Type: codersdk.ChatMessagePartTypeText, Text: "Hi there"},
+			}},
+		})
+
+		// Soft-delete the user message.
+		err = db.SoftDeleteChatMessageByID(dbauthz.AsSystemRestricted(ctx), inserted[0].ID)
+		require.NoError(t, err)
+
+		resp, err := client.GetChatUIMessages(ctx, chat.ID, nil)
+		require.NoError(t, err)
+
+		// The deleted user message means no turn boundary, so no
+		// messages should be returned.
+		require.Empty(t, resp.Messages)
+		require.Empty(t, resp.WorkingBlocks)
+	})
+
+	t.Run("HistoricalTurnNotMarkedActive", func(t *testing.T) {
+		t.Parallel()
+
+		client, db := newChatClientWithDatabase(t)
+		ctx := testutil.Context(t, testutil.WaitShort)
+		user := coderdtest.CreateFirstUser(t, client)
+
+		modelConfig := createChatModelConfig(t, client)
+		chat, err := db.InsertChat(dbauthz.AsSystemRestricted(ctx), database.InsertChatParams{
+			OwnerID:           user.UserID,
+			LastModelConfigID: modelConfig.ID,
+			Title:             "historical",
+		})
+		require.NoError(t, err)
+
+		// Turn 1: complete turn with tool calls.
+		turn1 := insertMessages(t, ctx, db, chat.ID, modelConfig.ID, []testMsg{
+			{role: database.ChatMessageRoleUser, parts: []codersdk.ChatMessagePart{
+				{Type: codersdk.ChatMessagePartTypeText, Text: "Turn 1"},
+			}, creator: user.UserID},
+			{role: database.ChatMessageRoleAssistant, parts: []codersdk.ChatMessagePart{
+				{Type: codersdk.ChatMessagePartTypeText, Text: "Checking"},
+				{Type: codersdk.ChatMessagePartTypeToolCall, ToolCallID: "c1", ToolName: "read_file"},
+			}},
+			{role: database.ChatMessageRoleTool, parts: []codersdk.ChatMessagePart{
+				{Type: codersdk.ChatMessagePartTypeToolResult, ToolCallID: "c1", ToolName: "read_file"},
+			}},
+			{role: database.ChatMessageRoleAssistant, parts: []codersdk.ChatMessagePart{
+				{Type: codersdk.ChatMessagePartTypeText, Text: "Done with turn 1"},
+			}},
+		})
+
+		// Turn 2: incomplete turn (still working).
+		turn2 := insertMessages(t, ctx, db, chat.ID, modelConfig.ID, []testMsg{
+			{role: database.ChatMessageRoleUser, parts: []codersdk.ChatMessagePart{
+				{Type: codersdk.ChatMessagePartTypeText, Text: "Turn 2"},
+			}, creator: user.UserID},
+			{role: database.ChatMessageRoleAssistant, parts: []codersdk.ChatMessagePart{
+				{Type: codersdk.ChatMessagePartTypeToolCall, ToolCallID: "c2", ToolName: "execute"},
+			}},
+			{role: database.ChatMessageRoleTool, parts: []codersdk.ChatMessagePart{
+				{Type: codersdk.ChatMessagePartTypeToolResult, ToolCallID: "c2", ToolName: "execute"},
+			}},
+		})
+
+		// Set chat to running.
+		_, err = db.UpdateChatStatus(dbauthz.AsSystemRestricted(ctx), database.UpdateChatStatusParams{
+			ID:     chat.ID,
+			Status: database.ChatStatusRunning,
+		})
+		require.NoError(t, err)
+
+		// Page 2: fetch only turn 1 (the historical turn) by paginating
+		// past turn 2.
+		resp, err := client.GetChatUIMessages(ctx, chat.ID, &codersdk.ChatMessagesPaginationOptions{
+			BeforeID: turn2[0].ID, // cursor is turn 2's user message
+			Limit:    1,
+		})
+		require.NoError(t, err)
+
+		_ = turn1 // used for readability above
+
+		// Turn 1 should have a working block with EndedAt set even
+		// though the chat is running, because this is a historical
+		// turn (not the latest).
+		require.Len(t, resp.WorkingBlocks, 1)
+		wb := resp.WorkingBlocks[0]
+		require.NotNil(t, wb.EndedAt, "historical turn should have EndedAt even when chat is running")
+	})
+}
+
 func requireSDKError(t *testing.T, err error, expectedStatus int) *codersdk.Error {
 	t.Helper()
 

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -308,6 +308,32 @@ type ChatMessagesResponse struct {
 	HasMore        bool                `json:"has_more"`
 }
 
+// ChatUIWorkingBlock describes a range of omitted messages (tool calls,
+// tool results, intermediate assistant messages) that are collapsed into
+// a "Working" indicator in the UI.
+type ChatUIWorkingBlock struct {
+	// AfterMessageID is the last included message before the gap.
+	AfterMessageID int64 `json:"after_message_id"`
+	// BeforeMessageID is the first included message after the gap.
+	// Zero when the turn is still active (no final message yet).
+	BeforeMessageID int64 `json:"before_message_id"`
+	StartedAt time.Time `json:"started_at" format:"date-time"`
+	// EndedAt is nil when the working block is still active.
+	EndedAt *time.Time `json:"ended_at,omitempty" format:"date-time"`
+	MessageCount int `json:"message_count"`
+}
+
+// ChatUIMessagesResponse is returned by the /ui-messages endpoint.
+// It contains only the boundary messages needed for rendering
+// (user messages, initial assistant text, final assistant text)
+// with working-block metadata for the omitted interior.
+type ChatUIMessagesResponse struct {
+	Messages       []ChatMessage        `json:"messages"`
+	WorkingBlocks  []ChatUIWorkingBlock `json:"working_blocks"`
+	QueuedMessages []ChatQueuedMessage  `json:"queued_messages"`
+	HasMore        bool                 `json:"has_more"`
+}
+
 // ChatModelProviderUnavailableReason explains why a provider cannot be used.
 type ChatModelProviderUnavailableReason string
 
@@ -1609,6 +1635,34 @@ func (c *ExperimentalClient) GetChatMessages(ctx context.Context, chatID uuid.UU
 		return ChatMessagesResponse{}, ReadBodyAsError(res)
 	}
 	var resp ChatMessagesResponse
+	return resp, json.NewDecoder(res.Body).Decode(&resp)
+}
+
+// GetChatUIMessages returns boundary messages grouped by turn with
+// working-block metadata for collapsed tool-call sections.
+func (c *Client) GetChatUIMessages(ctx context.Context, chatID uuid.UUID, opts *ChatMessagesPaginationOptions) (ChatUIMessagesResponse, error) {
+	reqOpts := []RequestOption{}
+	if opts != nil {
+		reqOpts = append(reqOpts, func(r *http.Request) {
+			q := r.URL.Query()
+			if opts.BeforeID > 0 {
+				q.Set("before", strconv.FormatInt(opts.BeforeID, 10))
+			}
+			if opts.Limit > 0 {
+				q.Set("limit", strconv.Itoa(opts.Limit))
+			}
+			r.URL.RawQuery = q.Encode()
+		})
+	}
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/experimental/chats/%s/ui-messages", chatID), nil, reqOpts...)
+	if err != nil {
+		return ChatUIMessagesResponse{}, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return ChatUIMessagesResponse{}, ReadBodyAsError(res)
+	}
+	var resp ChatUIMessagesResponse
 	return resp, json.NewDecoder(res.Body).Decode(&resp)
 }
 

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -3070,6 +3070,22 @@ class ExperimentalApiMethods {
 		const response = await this.axios.get<TypesGen.ChatMessagesResponse>(url);
 		return response.data;
 	};
+	getChatUIMessages = async (
+		chatId: string,
+		opts?: { before?: number; limit?: number },
+	): Promise<TypesGen.ChatUIMessagesResponse> => {
+		const params = new URLSearchParams();
+		if (opts?.before) {
+			params.set("before", opts.before.toString());
+		}
+		if (opts?.limit) {
+			params.set("limit", opts.limit.toString());
+		}
+		const query = params.toString();
+		const url = `/api/experimental/chats/${chatId}/ui-messages${query ? `?${query}` : ""}`;
+		const response = await this.axios.get<TypesGen.ChatUIMessagesResponse>(url);
+		return response.data;
+	};
 
 	createChat = async (
 		req: TypesGen.CreateChatRequest,

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -169,6 +169,29 @@ export const chatMessagesForInfiniteScroll = (chatId: string) => ({
 	},
 });
 
+export const chatUIMessagesForInfiniteScroll = (chatId: string) => ({
+	queryKey: ["chatUIMessages", chatId],
+	queryFn: async ({ pageParam }: { pageParam?: number }) => {
+		return API.experimental.getChatUIMessages(chatId, {
+			before: pageParam,
+			limit: 20,
+		});
+	},
+	getNextPageParam: (lastPage: TypesGen.ChatUIMessagesResponse) => {
+		if (!lastPage.has_more) return undefined;
+		// Find the oldest user message ID for cursor.
+		const userMessages = lastPage.messages.filter(
+			(m) => m.role === "user",
+		);
+		if (userMessages.length === 0) return undefined;
+		// Messages are ordered by turn (newest first), so the last user
+		// message in the array is the oldest turn's user message.
+		return userMessages[userMessages.length - 1].id;
+	},
+	initialPageParam: undefined as number | undefined,
+	enabled: !!chatId,
+});
+
 export const archiveChat = (queryClient: QueryClient) => ({
 	mutationFn: (chatId: string) =>
 		API.experimental.updateChat(chatId, { archived: true }),

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1849,6 +1849,44 @@ export interface ChatToolResultPart {
 
 // From codersdk/chats.go
 /**
+ * ChatUIMessagesResponse is returned by the /ui-messages endpoint.
+ * It contains only the boundary messages needed for rendering
+ * (user messages, initial assistant text, final assistant text)
+ * with working-block metadata for the omitted interior.
+ */
+export interface ChatUIMessagesResponse {
+	readonly messages: readonly ChatMessage[];
+	readonly working_blocks: readonly ChatUIWorkingBlock[];
+	readonly queued_messages: readonly ChatQueuedMessage[];
+	readonly has_more: boolean;
+}
+
+// From codersdk/chats.go
+/**
+ * ChatUIWorkingBlock describes a range of omitted messages (tool calls,
+ * tool results, intermediate assistant messages) that are collapsed into
+ * a "Working" indicator in the UI.
+ */
+export interface ChatUIWorkingBlock {
+	/**
+	 * AfterMessageID is the last included message before the gap.
+	 */
+	readonly after_message_id: number;
+	/**
+	 * BeforeMessageID is the first included message after the gap.
+	 * Zero when the turn is still active (no final message yet).
+	 */
+	readonly before_message_id: number;
+	readonly started_at: string;
+	/**
+	 * EndedAt is nil when the working block is still active.
+	 */
+	readonly ended_at?: string;
+	readonly message_count: number;
+}
+
+// From codersdk/chats.go
+/**
  * ChatUsageLimitConfig is the deployment-wide default usage limit config.
  */
 export interface ChatUsageLimitConfig {

--- a/site/src/components/ai-elements/WorkingBlock.tsx
+++ b/site/src/components/ai-elements/WorkingBlock.tsx
@@ -1,0 +1,127 @@
+import { ChevronDownIcon } from "lucide-react";
+import { type FC, type ReactNode, memo, useEffect, useState } from "react";
+import { cn } from "utils/cn";
+import { ConversationItem } from "./conversation";
+import { Message, MessageContent } from "./message";
+import { Shimmer } from "./shimmer";
+
+interface WorkingBlockProps {
+	startedAt: string;
+	endedAt?: string | null;
+	isActive: boolean;
+	defaultExpanded?: boolean;
+	/**
+	 * Called when the user first expands the block. The callback
+	 * should return the React content to display (e.g. fetched
+	 * tool call messages). Subsequent toggles reuse the result.
+	 */
+	onExpand?: () => Promise<ReactNode> | ReactNode;
+	/** Pre-loaded content to render immediately without fetching. */
+	children?: ReactNode;
+}
+
+function formatElapsed(ms: number): string {
+	const totalSeconds = Math.floor(ms / 1000);
+	const minutes = Math.floor(totalSeconds / 60);
+	const seconds = totalSeconds % 60;
+	if (minutes === 0) {
+		return `${seconds}s`;
+	}
+	return `${minutes}m ${seconds}s`;
+}
+
+/**
+ * WorkingBlock renders a clickable "Working... 4m 36s" shimmer
+ * indicator (active) or "Worked for 4m 36s" label (complete)
+ * with a chevron disclosure that expands to reveal tool calls.
+ */
+export const WorkingBlock: FC<WorkingBlockProps> = memo(
+	function WorkingBlock({ startedAt, endedAt, isActive, defaultExpanded, onExpand, children }) {
+		const [expanded, setExpanded] = useState(defaultExpanded ?? false);
+		const [loadedContent, setLoadedContent] = useState<ReactNode>(null);
+		const [loading, setLoading] = useState(false);
+		const [elapsed, setElapsed] = useState(() => {
+			const start = new Date(startedAt).getTime();
+			const end = endedAt ? new Date(endedAt).getTime() : Date.now();
+			return end - start;
+		});
+
+		useEffect(() => {
+			if (!isActive) return;
+			const start = new Date(startedAt).getTime();
+			const interval = setInterval(() => {
+				setElapsed(Date.now() - start);
+			}, 1000);
+			return () => clearInterval(interval);
+		}, [isActive, startedAt]);
+
+		const label = isActive
+			? `Working... ${formatElapsed(elapsed)}`
+			: `Worked for ${formatElapsed(elapsed)}`;
+
+		const handleToggle = async () => {
+			const next = !expanded;
+			setExpanded(next);
+			if (next && !loadedContent && !children && onExpand) {
+				setLoading(true);
+				try {
+					const content = await onExpand();
+					setLoadedContent(content);
+				} finally {
+					setLoading(false);
+				}
+			}
+		};
+
+		const expandedContent = children ?? loadedContent;
+
+		return (
+			<ConversationItem role="assistant">
+				<Message className="w-full">
+					<MessageContent className="whitespace-normal">
+						<div>
+							<button
+								type="button"
+								aria-expanded={expanded}
+								onClick={handleToggle}
+								className={cn(
+									"border-0 bg-transparent p-0 m-0 font-[inherit] text-[inherit] text-left",
+									"flex w-full items-center gap-2 cursor-pointer",
+								)}
+							>
+								{isActive ? (
+									<Shimmer
+										as="span"
+										className="text-[13px] leading-relaxed"
+									>
+										{label}
+									</Shimmer>
+								) : (
+									<span className="text-[13px] leading-relaxed text-content-secondary">
+										{label}
+									</span>
+								)}
+								<ChevronDownIcon
+									className={cn(
+										"h-3 w-3 shrink-0 text-content-secondary transition-transform",
+										expanded ? "rotate-0" : "-rotate-90",
+									)}
+								/>
+							</button>
+							{expanded && loading && (
+								<div className="mt-3 text-xs text-content-secondary">
+									Loading...
+								</div>
+							)}
+							{expanded && expandedContent && (
+								<div className="mt-3 space-y-3">
+									{expandedContent}
+								</div>
+							)}
+						</div>
+					</MessageContent>
+				</Message>
+			</ConversationItem>
+		);
+	},
+);

--- a/site/src/pages/AgentsPage/AgentDetail.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.tsx
@@ -7,6 +7,7 @@ import {
 	chatMessagesForInfiniteScroll,
 	chatModelConfigs,
 	chatModels,
+	chatUIMessagesForInfiniteScroll,
 	createChatMessage,
 	deleteChatQueuedMessage,
 	editChatMessage,
@@ -23,7 +24,7 @@ import {
 	getVSCodeHref,
 	openAppInNewWindow,
 } from "modules/apps/apps";
-import { type FC, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { type FC, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import {
 	useInfiniteQuery,
 	useMutation,
@@ -43,6 +44,7 @@ import {
 	getParentChatID,
 	getWorkspaceAgent,
 } from "./components/AgentDetail/chatHelpers";
+import { getWorkingBlocksEnabled } from "./components/AgentDetail/useWorkingBlocks";
 import { useWorkspaceCreationWatcher } from "./components/AgentDetail/useWorkspaceCreationWatcher";
 import {
 	AgentDetailLoadingView,
@@ -279,8 +281,20 @@ const AgentDetail: FC = () => {
 		...chat(agentId ?? ""),
 		enabled: Boolean(agentId),
 	});
+	const workingBlocksEnabled = useMemo(
+		() => getWorkingBlocksEnabled(),
+		[],
+	);
+	// When collapsed mode is on we fetch from the ui-messages
+	// endpoint; otherwise the standard messages endpoint. Both
+	// share the same page shape except for working_blocks, which
+	// is only accessed through a guarded "in" check.
 	const chatMessagesQuery = useInfiniteQuery({
-		...chatMessagesForInfiniteScroll(agentId ?? ""),
+		...((workingBlocksEnabled
+			? chatUIMessagesForInfiniteScroll(agentId ?? "")
+			: chatMessagesForInfiniteScroll(
+					agentId ?? "",
+				)) as ReturnType<typeof chatUIMessagesForInfiniteScroll>),
 		enabled: Boolean(agentId),
 	});
 	const parentChatID = getParentChatID(chatQuery.data);
@@ -403,6 +417,18 @@ const AgentDetail: FC = () => {
 	// Queued messages are only in the first page (most recent).
 	const chatQueuedMessages = chatMessagesQuery.data?.pages[0]?.queued_messages;
 
+	// Working blocks describe collapsed tool-call ranges to render
+	// as "Working" indicators between boundary messages.
+	const workingBlocks = useMemo(() => {
+		if (!workingBlocksEnabled) return [];
+		const pages = chatMessagesQuery.data?.pages;
+		if (!pages) return [];
+		return pages.flatMap((p) =>
+			"working_blocks" in p
+				? (p as TypesGen.ChatUIMessagesResponse).working_blocks
+				: [],
+		);
+	}, [chatMessagesQuery.data, workingBlocksEnabled]);
 	// Build a synthetic ChatMessagesResponse from the flattened
 	// data for backward compat with useChatStore.
 	const chatMessagesData: TypesGen.ChatMessagesResponse | undefined =
@@ -849,6 +875,8 @@ const AgentDetail: FC = () => {
 			isArchived={isArchived}
 			hasWorkspace={Boolean(workspaceId)}
 			store={store}
+			workingBlocks={workingBlocks}
+			workingBlocksEnabled={workingBlocksEnabled}
 			editing={editing}
 			pendingEditMessageId={pendingEditMessageId}
 			effectiveSelectedModel={effectiveSelectedModel}

--- a/site/src/pages/AgentsPage/AgentSettingsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsPageView.tsx
@@ -57,6 +57,7 @@ import {
 	type DateRangeValue,
 } from "../TemplatePage/TemplateInsightsPage/DateRange";
 import { ChatCostSummaryView } from "./components/ChatCostSummaryView";
+import { getWorkingBlocksEnabled, setWorkingBlocksEnabled } from "./components/AgentDetail/useWorkingBlocks";
 import { ChatModelAdminPanel } from "./components/ChatModelAdminPanel/ChatModelAdminPanel";
 import { InsightsContent } from "./components/InsightsContent";
 import { LimitsTab } from "./components/LimitsTab";
@@ -550,6 +551,9 @@ export const AgentSettingsPageView: FC<AgentSettingsPageViewProps> = ({
 	const isTTLDirty = localTTLMs !== null && localTTLMs !== serverTTLMs;
 	const maxTTLMs = 30 * 24 * 60 * 60_000; // 30 days
 	const isTTLOverMax = ttlMs > maxTTLMs;
+	const [workingBlocksEnabled, setWorkingBlocksEnabledState] = useState(
+		() => getWorkingBlocksEnabled(),
+	);
 	const isDisabled =
 		isSavingSystemPrompt ||
 		isSavingUserPrompt ||
@@ -635,6 +639,28 @@ export const AgentSettingsPageView: FC<AgentSettingsPageViewProps> = ({
 								</p>
 							)}
 						</form>
+
+						{/* ── Working blocks toggle ── */}
+						<hr className="my-5 border-0 border-t border-solid border-border" />
+						<div className="space-y-2">
+							<h3 className="m-0 text-[13px] font-semibold text-content-primary">
+								Working blocks
+							</h3>
+							<div className="flex items-center justify-between gap-4">
+								<p className="!mt-0.5 m-0 flex-1 text-xs text-content-secondary">
+									Show a summary &ldquo;Working&rdquo; indicator instead
+									of individual tool calls during agent turns.
+								</p>
+								<Switch
+									checked={workingBlocksEnabled}
+									onCheckedChange={(checked) => {
+										setWorkingBlocksEnabled(checked);
+										setWorkingBlocksEnabledState(checked);
+									}}
+									aria-label="Working blocks"
+								/>
+							</div>
+						</div>
 
 						{/* ── Admin system prompt (admin only) ── */}
 						{canSetSystemPrompt && (

--- a/site/src/pages/AgentsPage/components/AgentDetail/ChatContext.ts
+++ b/site/src/pages/AgentsPage/components/AgentDetail/ChatContext.ts
@@ -843,6 +843,7 @@ export const useChatStore = (
 							store.setChatStatus(nextStatus);
 							if (nextStatus === "pending" || nextStatus === "waiting") {
 								store.clearStreamState();
+								queryClient.invalidateQueries({ queryKey: ["chatUIMessages", chatID] });
 								store.clearRetryState();
 							}
 							if (nextStatus === "running") {

--- a/site/src/pages/AgentsPage/components/AgentDetail/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetail/ConversationTimeline.stories.tsx
@@ -20,6 +20,7 @@ const defaultArgs: Omit<
 	React.ComponentProps<typeof ConversationTimeline>,
 	"parsedMessages"
 > = {
+	chatId: "story-chat",
 	isEmpty: false,
 	hasStreamOutput: false,
 	streamState: null,

--- a/site/src/pages/AgentsPage/components/AgentDetail/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetail/ConversationTimeline.tsx
@@ -1,3 +1,4 @@
+import { API } from "api/api";
 import type * as TypesGen from "api/typesGenerated";
 import { Alert } from "components/Alert/Alert";
 import {
@@ -9,6 +10,7 @@ import {
 	Tool,
 } from "components/ai-elements";
 import { WebSearchSources } from "components/ai-elements/tool";
+import { WorkingBlock } from "components/ai-elements/WorkingBlock";
 import { Button } from "components/Button/Button";
 import { FileReferenceChip } from "components/ChatMessageInput/FileReferenceNode";
 import { Spinner } from "components/Spinner/Spinner";
@@ -24,6 +26,7 @@ import {
 	memo,
 	type ReactNode,
 	useLayoutEffect,
+	useMemo,
 	useRef,
 	useState,
 } from "react";
@@ -34,6 +37,7 @@ import type { ChatDetailError } from "../../utils/usageLimitMessage";
 import { ImageThumbnail } from "../AgentChatInput";
 import { ImageLightbox } from "../ImageLightbox";
 import { useSmoothStreamingText } from "./SmoothText";
+import { parseMessagesWithMergedTools } from "./messageParsing";
 import type {
 	MergedTool,
 	ParsedMessageContent,
@@ -261,6 +265,8 @@ const ChatMessageItem = memo<{
 	// that fades text out toward the bottom. Used by the sticky
 	// overlay to indicate truncated content.
 	fadeFromBottom?: boolean;
+	hideToolBlocks?: boolean;
+	animateText?: boolean;
 	urlTransform?: UrlTransform;
 }>(
 	({
@@ -271,6 +277,8 @@ const ChatMessageItem = memo<{
 		savingMessageId,
 		isAfterEditingMessage = false,
 		fadeFromBottom = false,
+		hideToolBlocks = false,
+		animateText = false,
 		urlTransform,
 	}) => {
 		const isUser = message.role === "user";
@@ -320,15 +328,20 @@ const ChatMessageItem = memo<{
 			role: isUser ? "user" : "assistant",
 		};
 		const { elements: orderedBlocks, renderedToolIDs } = renderBlockList({
-			blocks: parsed.blocks,
+			blocks: hideToolBlocks
+				? parsed.blocks.filter(
+						(b) => b.type === "response" || b.type === "thinking",
+					)
+				: parsed.blocks,
 			toolByID,
 			keyPrefix: String(message.id),
+			isStreaming: animateText,
 			onImageClick: setPreviewImage,
 			urlTransform,
 		});
-		const remainingTools = parsed.tools.filter(
-			(tool) => !renderedToolIDs.has(tool.id),
-		);
+		const remainingTools = hideToolBlocks
+			? []
+			: parsed.tools.filter((tool) => !renderedToolIDs.has(tool.id));
 
 		return (
 			<div
@@ -837,13 +850,17 @@ const StickyUserMessage: FC<{
 };
 
 interface ConversationTimelineProps {
+	chatId: string;
 	isEmpty: boolean;
 	parsedMessages: readonly ParsedMessageEntry[];
+	workingBlocks?: readonly TypesGen.ChatUIWorkingBlock[];
+	chatStatus?: TypesGen.ChatStatus;
 	hasStreamOutput: boolean;
 	streamState: StreamState | null;
 	streamTools: readonly MergedTool[];
 	subagentTitles: Map<string, string>;
 	subagentStatusOverrides: Map<string, TypesGen.ChatStatus>;
+	streamHasToolCalls?: boolean;
 	retryState?: { attempt: number; error: string } | null;
 	isAwaitingFirstStreamChunk: boolean;
 	detailError?: ChatDetailError | null;
@@ -858,13 +875,17 @@ interface ConversationTimelineProps {
 }
 
 export const ConversationTimeline: FC<ConversationTimelineProps> = ({
+	chatId,
 	isEmpty,
 	parsedMessages,
+	workingBlocks,
+	chatStatus,
 	hasStreamOutput,
 	streamState,
 	streamTools,
 	subagentTitles,
 	subagentStatusOverrides,
+	streamHasToolCalls,
 	retryState,
 	isAwaitingFirstStreamChunk,
 	detailError,
@@ -876,6 +897,115 @@ export const ConversationTimeline: FC<ConversationTimelineProps> = ({
 	const shouldRenderStreamAfterMessages =
 		hasStreamOutput && parsedMessages.length > 0;
 	const isUsageLimitError = detailError?.kind === "usage-limit";
+
+	// Track when the stream first enters the working phase so the
+	// WorkingBlock timer starts from the right moment.
+	const workingStartRef = useRef<string | null>(null);
+	if (streamHasToolCalls && !workingStartRef.current) {
+		workingStartRef.current = new Date().toISOString();
+	}
+	if (!streamHasToolCalls) {
+		workingStartRef.current = null;
+	}
+
+	// Identify the last user message index once, shared by both
+	// workingBlockAfterMessage and the live-stream hiding logic.
+	const lastUserMsgIndex = (() => {
+		for (let i = parsedMessages.length - 1; i >= 0; i--) {
+			if (parsedMessages[i].message.role === "user") return i;
+		}
+		return -1;
+	})();
+
+	// Map working blocks by the message ID they follow.
+	// Includes REST-provided blocks for historical turns and a
+	// synthetic block for the current turn when its messages are
+	// already in the store (from WebSocket durable events) but
+	// the REST data hasn't refreshed yet.
+	const workingBlockAfterMessage = useMemo(() => {
+		const map = new Map<number, TypesGen.ChatUIWorkingBlock>();
+		for (const wb of workingBlocks ?? []) {
+			map.set(wb.after_message_id, wb);
+		}
+
+		// Build a synthetic working block for the current turn when
+		// the store has tool-call messages but REST hasn't caught up.
+		// This avoids a flash of interior messages between stream
+		// clearing and REST refetch.
+		if (parsedMessages.length > 0 && lastUserMsgIndex >= 0) {
+			const turnMsgs = parsedMessages.slice(lastUserMsgIndex + 1);
+			const firstAssistant = turnMsgs[0];
+			const hasTools = turnMsgs.some(
+				({ parsed }) => parsed.toolCalls.length > 0,
+			);
+			// Only add synthetic block if the turn has tools AND
+			// no REST working block covers it yet.
+			if (
+				hasTools &&
+				firstAssistant &&
+				!map.has(firstAssistant.message.id)
+			) {
+				// The final text message is the last assistant in
+				// the turn with no tool calls.
+				const lastPureText = [...turnMsgs]
+					.reverse()
+					.find(
+						({ message, parsed }) =>
+							message.role === "assistant" &&
+							parsed.toolCalls.length === 0 &&
+							parsed.markdown.length > 0,
+					);
+				const interiorCount = turnMsgs.length
+					- 1 // first assistant (boundary)
+					- (lastPureText ? 1 : 0); // final text (boundary)
+
+				map.set(firstAssistant.message.id, {
+					after_message_id: firstAssistant.message.id,
+					before_message_id: lastPureText?.message.id ?? 0,
+					started_at: firstAssistant.message.created_at,
+					ended_at: lastPureText
+						? lastPureText.message.created_at
+						: undefined,
+					message_count: Math.max(interiorCount, 0),
+				});
+			}
+		}
+
+		return map;
+	}, [workingBlocks, parsedMessages, lastUserMsgIndex]);
+
+	// Build a set of message IDs that fall inside a working block's
+	// range and should be hidden from the timeline. Single O(n)
+	// pass — each message checked against the small interval list.
+	const hiddenByWorkingBlock = useMemo(() => {
+		const hidden = new Set<number>();
+		if (workingBlockAfterMessage.size === 0) return hidden;
+		const ranges = [...workingBlockAfterMessage.values()].map((wb) => ({
+			after: wb.after_message_id,
+			before: wb.before_message_id,
+		}));
+		for (const { message } of parsedMessages) {
+			for (const r of ranges) {
+				if (message.id > r.after && (r.before === 0 || message.id < r.before)) {
+					hidden.add(message.id);
+					break;
+				}
+			}
+		}
+		return hidden;
+	}, [workingBlockAfterMessage, parsedMessages]);
+
+	// Build a set of message IDs that are the final text
+	// message after a working block — these animate text in.
+	const animateTextMessageIds = useMemo(() => {
+		const ids = new Set<number>();
+		for (const wb of workingBlockAfterMessage.values()) {
+			if (wb.before_message_id > 0) {
+				ids.add(wb.before_message_id);
+			}
+		}
+		return ids;
+	}, [workingBlockAfterMessage]);
 
 	// Build a set of message IDs that appear after the message
 	// currently being edited so they can be visually faded.
@@ -893,37 +1023,120 @@ export const ConversationTimeline: FC<ConversationTimelineProps> = ({
 		}
 	}
 
+	let seenFirstAssistantInCurrentTurn = false;
+
 	return (
-		<div className="mx-auto w-full max-w-3xl space-y-3 py-6">
+		<div className="mx-auto w-full max-w-3xl py-6">
 			{isEmpty && !hasStreamOutput ? (
 				<div className="py-12 text-center text-content-secondary">
 					<p className="text-sm">Start a conversation with your agent.</p>
 				</div>
 			) : (
 				<div className="flex flex-col gap-3">
-					{parsedMessages.map(({ message, parsed }) =>
-						message.role === "user" ? (
-							<StickyUserMessage
-								key={message.id}
-								message={message}
-								parsed={parsed}
-								onEditUserMessage={onEditUserMessage}
-								editingMessageId={editingMessageId}
-								savingMessageId={savingMessageId}
-								isAfterEditingMessage={afterEditingMessageIds.has(message.id)}
-							/>
-						) : (
-							<ChatMessageItem
-								key={message.id}
-								message={message}
-								parsed={parsed}
-								savingMessageId={savingMessageId}
-								urlTransform={urlTransform}
-								isAfterEditingMessage={afterEditingMessageIds.has(message.id)}
-							/>
-						),
-					)}
-					{shouldRenderStreamAfterMessages && (
+					{parsedMessages.map(({ message, parsed }, idx) => {
+						const isInCurrentTurn = idx > lastUserMsgIndex;
+
+						// During live streaming with tool calls, only the
+						// first assistant in the current turn renders (with
+						// tool blocks hidden). All other non-user messages
+						// are interior — shown inside the live WorkingBlock.
+						let isFirstAssistantInCurrentTurn = false;
+						if (streamHasToolCalls && isInCurrentTurn && message.role !== "user") {
+							if (!seenFirstAssistantInCurrentTurn && message.role === "assistant") {
+								seenFirstAssistantInCurrentTurn = true;
+								isFirstAssistantInCurrentTurn = true;
+							} else {
+								return null;
+							}
+						}
+
+						// Skip messages inside a working block range (REST or synthetic).
+						if (hiddenByWorkingBlock.has(message.id)) {
+							return null;
+						}
+
+						const workingBlock = workingBlockAfterMessage.get(message.id);
+						const shouldHideTools = !!workingBlock || isFirstAssistantInCurrentTurn;
+						const isActive =
+							workingBlock && chatStatus
+								? ["running", "pending"].includes(chatStatus)
+								: false;
+
+						return (
+							<Fragment key={message.id}>
+								{message.role === "user" ? (
+									<StickyUserMessage
+										message={message}
+										parsed={parsed}
+										onEditUserMessage={onEditUserMessage}
+										editingMessageId={editingMessageId}
+										savingMessageId={savingMessageId}
+										isAfterEditingMessage={afterEditingMessageIds.has(message.id)}
+									/>
+								) : (
+									<ChatMessageItem
+										message={message}
+										parsed={parsed}
+										savingMessageId={savingMessageId}
+										urlTransform={urlTransform}
+										isAfterEditingMessage={afterEditingMessageIds.has(message.id)}
+										hideToolBlocks={shouldHideTools}
+										animateText={animateTextMessageIds.has(message.id)}
+									/>
+								)}
+								{workingBlock && !isFirstAssistantInCurrentTurn && (
+									<WorkingBlock
+										startedAt={workingBlock.started_at}
+										endedAt={workingBlock.ended_at}
+										isActive={isActive && !workingBlock.ended_at}
+										onExpand={async () => {
+											// Check if interior messages are already
+											// in the store first.
+											const storeInterior = parsedMessages
+												.filter(({ message: m }) =>
+													hiddenByWorkingBlock.has(m.id)
+													&& m.id > workingBlock.after_message_id
+													&& (workingBlock.before_message_id === 0 || m.id < workingBlock.before_message_id),
+												);
+											if (storeInterior.length > 0) {
+												return storeInterior.map(({ message: m, parsed: p }) => (
+													<ChatMessageItem
+														key={m.id}
+														message={m}
+														parsed={p}
+														urlTransform={urlTransform}
+													/>
+												));
+											}
+											// Fetch from the API for historical turns.
+											const resp = await API.experimental.getChatMessages(chatId, {
+												before_id: workingBlock.before_message_id || undefined,
+												limit: 200,
+											});
+											// Filter to only messages in this working
+											// block's range.
+											const rangeMessages = resp.messages
+												.filter((m) =>
+													m.id > workingBlock.after_message_id
+													&& (workingBlock.before_message_id === 0 || m.id < workingBlock.before_message_id),
+												)
+												.sort((a, b) => a.id - b.id);
+											const parsed = parseMessagesWithMergedTools(rangeMessages);
+											return parsed.map(({ message: m, parsed: p }) => (
+												<ChatMessageItem
+													key={m.id}
+													message={m}
+													parsed={p}
+													urlTransform={urlTransform}
+												/>
+											));
+										}}
+									/>
+								)}
+							</Fragment>
+						);
+					})}
+					{shouldRenderStreamAfterMessages && !streamHasToolCalls && (
 						<StreamingOutput
 							streamState={streamState}
 							streamTools={streamTools}
@@ -934,7 +1147,45 @@ export const ConversationTimeline: FC<ConversationTimelineProps> = ({
 							urlTransform={urlTransform}
 						/>
 					)}
-					{hasStreamOutput && parsedMessages.length === 0 && (
+					{shouldRenderStreamAfterMessages && streamHasToolCalls && (
+						<WorkingBlock
+							startedAt={workingStartRef.current ?? new Date().toISOString()}
+							isActive={true}
+							defaultExpanded={true}
+						>
+							{/* Persisted interior messages from completed steps */}
+							{(() => {
+								// Find the first assistant index so we skip it
+								// (it's rendered above the WorkingBlock).
+								const firstAsstIdx = parsedMessages.findIndex(
+									(e, i) => i > lastUserMsgIndex && e.message.role === "assistant",
+								);
+								return parsedMessages
+									.filter(({ message: m }, idx) =>
+										idx > lastUserMsgIndex
+										&& m.role !== "user"
+										&& idx !== firstAsstIdx,
+									)
+									.map(({ message: m, parsed: p }) => (
+										<ChatMessageItem
+											key={m.id}
+											message={m}
+											parsed={p}
+											urlTransform={urlTransform}
+										/>
+									));
+							})()}
+							{/* Live stream from current step */}
+							<StreamingOutput
+								streamState={streamState}
+								streamTools={streamTools}
+								subagentTitles={subagentTitles}
+								subagentStatusOverrides={subagentStatusOverrides}
+								urlTransform={urlTransform}
+							/>
+						</WorkingBlock>
+					)}
+					{hasStreamOutput && parsedMessages.length === 0 && !streamHasToolCalls && (
 						<StreamingOutput
 							streamState={streamState}
 							streamTools={streamTools}
@@ -943,6 +1194,12 @@ export const ConversationTimeline: FC<ConversationTimelineProps> = ({
 							showInitialPlaceholder={isAwaitingFirstStreamChunk}
 							retryState={retryState}
 							urlTransform={urlTransform}
+						/>
+					)}
+					{hasStreamOutput && parsedMessages.length === 0 && streamHasToolCalls && (
+						<WorkingBlock
+							startedAt={workingStartRef.current ?? new Date().toISOString()}
+							isActive={true}
 						/>
 					)}
 				</div>

--- a/site/src/pages/AgentsPage/components/AgentDetail/useWorkingBlocks.ts
+++ b/site/src/pages/AgentsPage/components/AgentDetail/useWorkingBlocks.ts
@@ -1,0 +1,21 @@
+const STORAGE_KEY = "agents.working-blocks";
+
+export function getWorkingBlocksEnabled(): boolean {
+	try {
+		return localStorage.getItem(STORAGE_KEY) === "true";
+	} catch {
+		return false;
+	}
+}
+
+export function setWorkingBlocksEnabled(enabled: boolean): void {
+	try {
+		if (enabled) {
+			localStorage.setItem(STORAGE_KEY, "true");
+		} else {
+			localStorage.removeItem(STORAGE_KEY);
+		}
+	} catch {
+		// Silently ignore storage errors.
+	}
+}

--- a/site/src/pages/AgentsPage/components/AgentDetailContent.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetailContent.tsx
@@ -1,7 +1,7 @@
 import type * as TypesGen from "api/typesGenerated";
 import type { ModelSelectorOption } from "components/ai-elements";
 import { useDashboard } from "modules/dashboard/useDashboard";
-import { type FC, useEffect } from "react";
+import { type FC, useEffect, useRef } from "react";
 import { toast } from "sonner";
 import type { UrlTransform } from "streamdown";
 import { useFileAttachments } from "../hooks/useFileAttachments";
@@ -41,6 +41,9 @@ const isChatMessage = (
 
 interface AgentDetailTimelineProps {
 	store: ChatStoreHandle;
+	chatId: string;
+	workingBlocks: readonly TypesGen.ChatUIWorkingBlock[];
+	workingBlocksEnabled?: boolean;
 	persistedErrorReason: ChatDetailError | undefined;
 	onEditUserMessage?: (
 		messageId: number,
@@ -57,6 +60,9 @@ interface AgentDetailTimelineProps {
 // via a memo boundary so that streaming ticks don't re-parse history.
 const MessageListProvider: FC<AgentDetailTimelineProps> = ({
 	store,
+	chatId,
+	workingBlocks,
+	workingBlocksEnabled,
 	persistedErrorReason,
 	onEditUserMessage,
 	editingMessageId,
@@ -92,6 +98,9 @@ const MessageListProvider: FC<AgentDetailTimelineProps> = ({
 	return (
 		<StreamingBridge
 			store={store}
+			chatId={chatId}
+			workingBlocks={workingBlocks}
+			workingBlocksEnabled={workingBlocksEnabled}
 			isEmpty={messages.length === 0}
 			parsedMessages={parsedMessages}
 			subagentTitles={subagentTitles}
@@ -112,6 +121,9 @@ const MessageListProvider: FC<AgentDetailTimelineProps> = ({
 // so that streamState changes don't invalidate parsedMessages above.
 const StreamingBridge: FC<{
 	store: ChatStoreHandle;
+	chatId: string;
+	workingBlocks: readonly TypesGen.ChatUIWorkingBlock[];
+	workingBlocksEnabled?: boolean;
 	isEmpty: boolean;
 	parsedMessages: ParsedMessageEntry[];
 	subagentTitles: Map<string, string>;
@@ -130,6 +142,9 @@ const StreamingBridge: FC<{
 	urlTransform?: UrlTransform;
 }> = ({
 	store,
+	chatId,
+	workingBlocks,
+	workingBlocksEnabled,
 	isEmpty,
 	parsedMessages,
 	subagentTitles,
@@ -145,6 +160,26 @@ const StreamingBridge: FC<{
 }) => {
 	const streamState = useChatSelector(store, selectStreamState);
 	const streamTools = buildStreamTools(streamState);
+
+	// Sticky flag: once the stream enters the "working" phase (any
+	// tool call seen), it stays true until the turn ends (status
+	// leaves running/pending). This prevents flicker between LLM
+	// steps when clearStreamState() briefly nulls streamState.
+	const streamHasToolCallsRef = useRef(false);
+	const currentHasTools =
+		workingBlocksEnabled &&
+		streamState !== null &&
+		Object.keys(streamState.toolCalls).length > 0;
+	if (currentHasTools) {
+		streamHasToolCallsRef.current = true;
+	}
+	// Clear the latch when the turn ends.
+	const isRunning = chatStatus === "running" || chatStatus === "pending";
+	if (!isRunning) {
+		streamHasToolCallsRef.current = false;
+	}
+	const streamHasToolCalls = streamHasToolCallsRef.current;
+
 	const isAwaitingFirstStreamChunk =
 		!streamState &&
 		(chatStatus === "running" || chatStatus === "pending") &&
@@ -153,9 +188,13 @@ const StreamingBridge: FC<{
 
 	return (
 		<ConversationTimeline
+			chatId={chatId}
 			isEmpty={isEmpty}
 			parsedMessages={parsedMessages}
+			workingBlocks={workingBlocks}
+			chatStatus={chatStatus ?? undefined}
 			hasStreamOutput={hasStreamOutput}
+			streamHasToolCalls={streamHasToolCalls}
 			streamState={streamState}
 			streamTools={streamTools}
 			subagentTitles={subagentTitles}
@@ -168,9 +207,8 @@ const StreamingBridge: FC<{
 			savingMessageId={savingMessageId}
 			urlTransform={urlTransform}
 		/>
-	);
+		);
 };
-
 export const AgentDetailTimeline: FC<AgentDetailTimelineProps> = (props) => {
 	return <MessageListProvider {...props} />;
 };

--- a/site/src/pages/AgentsPage/components/AgentDetailView.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetailView.tsx
@@ -63,6 +63,12 @@ interface AgentDetailViewProps {
 	// Store handle.
 	store: ChatStoreHandle;
 
+	// Working blocks from the UI messages endpoint.
+	workingBlocks: readonly TypesGen.ChatUIWorkingBlock[];
+
+	// Whether the collapsed tool-call rendering is active.
+	workingBlocksEnabled?: boolean;
+
 	// Editing state.
 	editing: EditingState;
 	pendingEditMessageId: number | null;
@@ -139,6 +145,8 @@ export const AgentDetailView: FC<AgentDetailViewProps> = ({
 	isArchived,
 	hasWorkspace,
 	store,
+	workingBlocks,
+	workingBlocksEnabled,
 	editing,
 	pendingEditMessageId,
 	effectiveSelectedModel,
@@ -259,24 +267,27 @@ export const AgentDetailView: FC<AgentDetailViewProps> = ({
 					hasMoreMessages={hasMoreMessages}
 					onFetchMoreMessages={onFetchMoreMessages}
 				>
-					<div className="px-4">
-						<AgentDetailTimeline
-							store={store}
-							persistedErrorReason={
-								chatErrorReasons[agentId] ??
-								(chatStatus === "error" && chatRecord?.last_error
-									? { kind: "generic" as const, message: chatRecord.last_error }
-									: undefined)
-							}
-							onEditUserMessage={editing.handleEditUserMessage}
-							editingMessageId={editing.editingMessageId}
-							savingMessageId={pendingEditMessageId}
-							urlTransform={urlTransform}
-						/>
-					</div>
-				</ScrollAnchoredContainer>
-				<div className="shrink-0 overflow-y-auto px-4 pb-4 md:pb-0 [scrollbar-gutter:stable] [scrollbar-width:thin]">
-					<AgentDetailInput
+						<div className="px-4">
+							<AgentDetailTimeline
+								store={store}
+								chatId={agentId}
+								workingBlocks={workingBlocks}
+								workingBlocksEnabled={workingBlocksEnabled}
+								persistedErrorReason={
+									chatErrorReasons[agentId] ??
+									(chatStatus === "error" && chatRecord?.last_error
+										? { kind: "generic" as const, message: chatRecord.last_error }
+										: undefined)
+								}
+								onEditUserMessage={editing.handleEditUserMessage}
+								editingMessageId={editing.editingMessageId}
+								savingMessageId={pendingEditMessageId}
+								urlTransform={urlTransform}
+							/>
+						</div>
+					</ScrollAnchoredContainer>
+					<div className="shrink-0 overflow-y-auto px-4 pb-4 md:pb-0 [scrollbar-gutter:stable] [scrollbar-width:thin]">
+						<AgentDetailInput
 						store={store}
 						compressionThreshold={compressionThreshold}
 						onSend={editing.handleSendFromInput}


### PR DESCRIPTION
## Summary

Adds a new `GET /api/experimental/chats/{chat}/ui-messages` endpoint and a collapsed tool-call rendering mode for the agents chat UI.

### What it does

Instead of rendering every individual tool call/result during an agent turn, this shows:

1. **User message**
2. **Initial assistant text/reasoning** (before any tool calls)
3. **"Working... 4m 36s"** shimmer indicator (replaces all tool calls)
4. **Final assistant text** (after all tool work completes)

### Feature flag

Gated behind a localStorage preference (`agents.collapsed-tool-calls`), **default OFF**. Users can toggle it in **Settings > Behavior > "Collapse tool calls"**. When off, existing rendering is completely untouched.

### Backend

- Single SQL query using LATERAL joins — fetches only boundary messages (user, first assistant, last pure-text assistant) per turn, plus lightweight working-block metadata (count, timestamps) without loading interior message content.
- `ChatUIWorkingBlock` and `ChatUIMessagesResponse` SDK types reuse the existing `ChatMessage` type.
- Turn-based pagination (cursor = user message ID).
- 10 test cases covering: empty chats, simple Q&A, single/multi tool call steps, pagination, still-working turns, soft-deleted messages, historical turn active-state.

### Frontend

- `WorkingBlock` component with `<Shimmer>` animation when active, static duration when complete.
- `ConversationTimeline` renders working blocks between boundary messages, hides tool blocks on initial assistant messages, skips interior messages.
- Synthetic working blocks computed client-side from WebSocket durable events so final text appears instantly when the stream ends (no REST round-trip).
- `StreamingOutput` suppressed during working phase, replaced by live `WorkingBlock` timer.
- Expansion of collapsed blocks uses the existing `/messages` endpoint (no new query needed).

### To rip out

Delete `useCollapsedToolCalls.ts`, `WorkingBlock.tsx`, the settings toggle, the conditional in `AgentDetail.tsx`, and the extra props gated by `collapsedToolCalls`. The old rendering path remains the only path.