### PR TITLE
bug: old code-server archives waste the disk space

### DIFF
--- a/.github/pr-deployments/template/main.tf
+++ b/.github/pr-deployments/template/main.tf
@@ -96,6 +96,10 @@ resource "coder_agent" "main" {
 
     # install and start code-server
     curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server
+
+    # Clean up old code-server archives to save disk space.
+    rm -f ~/.cache/code-server/code-server-*.tar.gz
+
     /tmp/code-server/bin/code-server --auth none --port 13337 >/tmp/code-server.log 2>&1 &
 
   EOT

--- a/docs/admin/templates/extending-templates/web-ides.md
+++ b/docs/admin/templates/extending-templates/web-ides.md
@@ -45,6 +45,9 @@ resource "coder_agent" "main" {
     # add '-s -- --version x.x.x' to install a specific code-server version
     curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server
 
+    # Clean up old code-server archives to save disk space.
+    rm -f ~/.cache/code-server/code-server-*.tar.gz
+
     # start code-server on a specific port
     # authn is off since the user already authn-ed into the coder deployment
     # & is used to run the process in the background

--- a/examples/jfrog/docker/main.tf
+++ b/examples/jfrog/docker/main.tf
@@ -67,6 +67,10 @@ resource "coder_agent" "main" {
 
     # install and start code-server
     curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server
+
+    # Clean up old code-server archives to save disk space.
+    rm -f ~/.cache/code-server/code-server-*.tar.gz
+
     /tmp/code-server/bin/code-server --auth none --port 13337 >/tmp/code-server.log 2>&1 &
 
     # Install the JFrog VS Code extension.

--- a/examples/parameters-dynamic-options/main.tf
+++ b/examples/parameters-dynamic-options/main.tf
@@ -60,6 +60,9 @@ resource "coder_agent" "main" {
     # Append "-s -- --version x.x.x" to install a specific version of code-server.
     curl -fsSL https://code-server.dev/install.sh | sh
 
+    # Clean up old code-server archives to save disk space.
+    rm -f ~/.cache/code-server/code-server-*.tar.gz
+
     # Start code-server.
     code-server --auth none --port 13337
     EOF

--- a/examples/parameters/main.tf
+++ b/examples/parameters/main.tf
@@ -33,6 +33,9 @@ resource "coder_agent" "main" {
     # Append "--version x.x.x" to install a specific version of code-server.
     curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server
 
+    # Clean up old code-server archives to save disk space.
+    rm -f ~/.cache/code-server/code-server-*.tar.gz
+
     # Start code-server in the background.
     /tmp/code-server/bin/code-server --auth none --port 13337 >/tmp/code-server.log 2>&1 &
   EOT

--- a/examples/templates/kubernetes/main.tf
+++ b/examples/templates/kubernetes/main.tf
@@ -113,6 +113,9 @@ resource "coder_agent" "main" {
     # Append "--version x.x.x" to install a specific version of code-server.
     curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server
 
+    # Clean up old code-server archives to save disk space.
+    rm -f ~/.cache/code-server/code-server-*.tar.gz
+
     # Start code-server in the background.
     /tmp/code-server/bin/code-server --auth none --port 13337 >/tmp/code-server.log 2>&1 &
   EOT

--- a/examples/templates/nomad-docker/main.tf
+++ b/examples/templates/nomad-docker/main.tf
@@ -95,6 +95,10 @@ resource "coder_agent" "main" {
     set -e
     # install and start code-server
     curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server
+
+    # Clean up old code-server archives to save disk space.
+    rm -f ~/.cache/code-server/code-server-*.tar.gz
+
     /tmp/code-server/bin/code-server --auth none --port 13337 >/tmp/code-server.log 2>&1 &
   EOT
 

--- a/examples/workspace-tags/main.tf
+++ b/examples/workspace-tags/main.tf
@@ -76,6 +76,9 @@ resource "coder_agent" "main" {
     # Append "-s -- --version x.x.x" to install a specific version of code-server.
     curl -fsSL https://code-server.dev/install.sh | sh
 
+    # Clean up old code-server archives to save disk space.
+    rm -f ~/.cache/code-server/code-server-*.tar.gz
+
     # Start code-server.
     code-server --auth none --port 13337
     EOF


### PR DESCRIPTION
自动生成的修复提案。

- 原始 issue: https://github.com/coder/coder/issues/23356
- 摘要: Added cleanup command 'rm -f ~/.cache/code-server/code-server-*.tar.gz' after code-server installation in 7 template files and updated documentation to remove old code-server archives and save disk space.
- 修改文件:
  - .github/pr-deployments/template/main.tf
  - docs/admin/templates/extending-templates/web-ides.md
  - examples/jfrog/docker/main.tf
  - examples/parameters-dynamic-options/main.tf
  - examples/parameters/main.tf
  - examples/templates/kubernetes/main.tf
  - examples/templates/nomad-docker/main.tf
  - examples/workspace-tags/main.tf
- 验证情况:
  - Changes are syntactically correct shell script additions to Terraform heredocs
  - All 8 files modified with identical cleanup pattern after code-server install
- 风险提示:
  - Templates are examples - existing deployments won't benefit from this fix
  - The code-server registry module (external at registry.coder.com/modules/coder/code-server) was not updated - may need separate issue