### PR TITLE
bug(coderd/chatd/chatloop): isContextLimitKey false positive on max_context_version

### DIFF
--- a/coderd/chatd/chatloop/chatloop.go
+++ b/coderd/chatd/chatloop/chatloop.go
@@ -1056,7 +1056,7 @@ func isContextLimitKey(key string) bool {
 		(strings.Contains(normalized, "limit") ||
 			strings.Contains(normalized, "window") ||
 			strings.Contains(normalized, "length") ||
-			strings.HasPrefix(normalized, "max"))
+			strings.Contains(normalized, "tokens"))
 }
 
 func normalizeMetadataKey(key string) string {

--- a/coderd/chatd/chatloop/contextlimit_internal_test.go
+++ b/coderd/chatd/chatloop/contextlimit_internal_test.go
@@ -76,17 +76,14 @@ func TestIsContextLimitKey(t *testing.T) {
 		{name: "MAX_CONTEXT_TOKENS screaming", key: "MAX_CONTEXT_TOKENS", want: true},
 		{name: "contextLimit camelCase", key: "contextLimit", want: true},
 
-		// Fallback heuristic: contains "context" + limit/window/length.
+		// Fallback heuristic: contains "context" + limit/window/length/tokens.
 		{name: "model_context_limit", key: "model_context_limit", want: true},
 		{name: "context_window_size", key: "context_window_size", want: true},
 		{name: "context_length_max", key: "context_length_max", want: true},
+		{name: "context_tokens_count", key: "context_tokens_count", want: true},
 
-		// Fallback heuristic: starts with "max" + contains "context".
-		// BUG(isContextLimitKey): "max_context_version" matches
-		// because it contains "context" and starts with "max",
-		// but a version field is not a context limit.
-		// TODO: Fix the heuristic and remove this skip.
-		{name: "max_context_version false positive", key: "max_context_version", want: false, skip: true}, // Non-matching keys.
+		// Non-matching keys.
+		{name: "max_context_version false positive", key: "max_context_version", want: false},
 		{name: "context_id no limit keyword", key: "context_id", want: false},
 		{name: "empty string", key: "", want: false},
 		{name: "unrelated key", key: "model_name", want: false},


### PR DESCRIPTION
自动生成的修复提案。

- 原始 issue: https://github.com/coder/coder/issues/23332
- 摘要: Fixed the isContextLimitKey false positive bug by changing the fallback heuristic from `strings.HasPrefix(normalized, "max")` to `strings.Contains(normalized, "tokens")`. This prevents keys like `max_context_version` from incorrectly matching as context limit keys.
- 修改文件:
  - coderd/chatd/chatloop/chatloop.go
  - coderd/chatd/chatloop/contextlimit_internal_test.go
- 验证情况:
  - {'command': 'go test -v ./coderd/chatd/chatloop/ -run "TestIsContextLimitKey"', 'result': 'Could not run tests due to Go version mismatch (installed: go1.20.14, required: go1.25.7)'}
- 风险提示:
  - The new heuristic adds 'tokens' as a valid keyword, which may match additional keys like 'context_tokens_count'. This is intentional and matches the suggested fix from the issue.