### PR TITLE
bug: Coder agent crashes when script log contains invalid UTF-8

### DIFF
--- a/coderd/agentapi/logs.go
+++ b/coderd/agentapi/logs.go
@@ -2,6 +2,7 @@ package agentapi
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -77,8 +78,12 @@ func (a *LogsAPI) BatchCreateLogs(ctx context.Context, req *agentproto.BatchCrea
 	level := make([]database.LogLevel, 0)
 	outputLength := 0
 	for _, logEntry := range req.Logs {
-		output = append(output, logEntry.Output)
-		outputLength += len(logEntry.Output)
+		// Sanitize the log output: strip null bytes which are technically valid UTF-8
+		// but not supported by PostgreSQL TEXT columns. This is a defense-in-depth
+		// measure; the client-side should also strip null bytes.
+		sanitizedOutput := strings.ReplaceAll(logEntry.Output, "\x00", "")
+		output = append(output, sanitizedOutput)
+		outputLength += len(sanitizedOutput)
 
 		var dbLevel database.LogLevel
 		switch logEntry.Level {

--- a/coderd/agentapi/logs_test.go
+++ b/coderd/agentapi/logs_test.go
@@ -426,4 +426,67 @@ func TestBatchCreateLogs(t *testing.T) {
 		require.True(t, publishWorkspaceUpdateCalled)
 		require.False(t, publishWorkspaceAgentLogsUpdateCalled)
 	})
+
+	t.Run("StripsNullBytes", func(t *testing.T) {
+		t.Parallel()
+
+		dbM := dbmock.NewMockStore(gomock.NewController(t))
+
+		publishWorkspaceUpdateCalled := false
+		publishWorkspaceAgentLogsUpdateCalled := false
+		now := dbtime.Now()
+		api := &agentapi.LogsAPI{
+			AgentFn: func(context.Context) (database.WorkspaceAgent, error) {
+				return agent, nil
+			},
+			Database: dbM,
+			Log:      testutil.Logger(t),
+			PublishWorkspaceUpdateFn: func(ctx context.Context, _ uuid.UUID, kind wspubsub.WorkspaceEventKind) error {
+				publishWorkspaceUpdateCalled = true
+				return nil
+			},
+			PublishWorkspaceAgentLogsUpdateFn: func(ctx context.Context, workspaceAgentID uuid.UUID, msg agentsdk.LogsNotifyMessage) {
+				publishWorkspaceAgentLogsUpdateCalled = true
+			},
+			TimeNowFn: func() time.Time { return now },
+		}
+
+		// Input with null bytes (0x00) that PostgreSQL doesn't support in TEXT columns
+		req := &agentproto.BatchCreateLogsRequest{
+			LogSourceId: logSource.ID[:],
+			Logs: []*agentproto.Log{
+				{
+					CreatedAt: timestamppb.New(now),
+					Level:     agentproto.Log_INFO,
+					Output:    "hello\x00world with\x00null bytes",
+				},
+			},
+		}
+
+		// Expect the null bytes to be stripped in the DB insert
+		expectedParams := database.InsertWorkspaceAgentLogsParams{
+			AgentID:      agent.ID,
+			LogSourceID:  logSource.ID,
+			CreatedAt:    now,
+			Output:       []string{"helloworld withnull bytes"},
+			Level:        []database.LogLevel{database.LogLevelInfo},
+			OutputLength: int32(len("helloworld withnull bytes")),
+		}
+		dbM.EXPECT().InsertWorkspaceAgentLogs(gomock.Any(), expectedParams).Return([]database.WorkspaceAgentLog{
+			{
+				AgentID:     agent.ID,
+				CreatedAt:   now,
+				ID:          1,
+				Output:      "helloworld withnull bytes",
+				Level:       database.LogLevelInfo,
+				LogSourceID: logSource.ID,
+			},
+		}, nil)
+
+		resp, err := api.BatchCreateLogs(context.Background(), req)
+		require.NoError(t, err)
+		require.Equal(t, &agentproto.BatchCreateLogsResponse{}, resp)
+		require.True(t, publishWorkspaceUpdateCalled)
+		require.True(t, publishWorkspaceAgentLogsUpdateCalled)
+	})
 }

--- a/codersdk/agentsdk/convert.go
+++ b/codersdk/agentsdk/convert.go
@@ -374,9 +374,15 @@ func ProtoFromLog(log Log) (*proto.Log, error) {
 	if !ok {
 		return nil, xerrors.Errorf("unknown log level: %s", log.Level)
 	}
+	// Sanitize the log output:
+	// 1. Replace invalid UTF-8 sequences with the replacement character
+	// 2. Strip null bytes (0x00) which are technically valid UTF-8 but not supported
+	//    by PostgreSQL TEXT columns and can cause "invalid byte sequence for encoding UTF8: 0x00"
+	output := strings.ToValidUTF8(log.Output, "❌")
+	output = strings.ReplaceAll(output, "\x00", "")
 	return &proto.Log{
 		CreatedAt: timestamppb.New(log.CreatedAt),
-		Output:    strings.ToValidUTF8(log.Output, "❌"),
+		Output:    output,
 		Level:     proto.Log_Level(lvl),
 	}, nil
 }

--- a/codersdk/agentsdk/logs_internal_test.go
+++ b/codersdk/agentsdk/logs_internal_test.go
@@ -274,6 +274,50 @@ func TestLogSender_InvalidUTF8(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 }
 
+func TestLogSender_NullBytes(t *testing.T) {
+	t.Parallel()
+	testCtx := testutil.Context(t, testutil.WaitShort)
+	ctx, cancel := context.WithCancel(testCtx)
+	logger := testutil.Logger(t)
+	fDest := newFakeLogDest()
+	uut := NewLogSender(logger)
+
+	t0 := dbtime.Now()
+	ls1 := uuid.UUID{0x11}
+
+	uut.Enqueue(ls1,
+		Log{
+			CreatedAt: t0,
+			Output:    "test\x00log with\x00null bytes",
+			Level:     codersdk.LogLevelInfo,
+		},
+		Log{
+			CreatedAt: t0,
+			Output:    "normal log",
+			Level:     codersdk.LogLevelInfo,
+		})
+
+	loopErr := make(chan error, 1)
+	go func() {
+		err := uut.SendLoop(ctx, fDest)
+		loopErr <- err
+	}()
+
+	req := testutil.TryReceive(ctx, t, fDest.reqs)
+	require.NotNil(t, req)
+	require.Len(t, req.Logs, 2, "it should strip null bytes, but still send")
+	// null bytes (0x00) should be stripped since PostgreSQL TEXT columns don't support them
+	require.Equal(t, "testlog withnull bytes", req.Logs[0].GetOutput())
+	require.Equal(t, proto.Log_INFO, req.Logs[0].GetLevel())
+	require.Equal(t, "normal log", req.Logs[1].GetOutput())
+	require.Equal(t, proto.Log_INFO, req.Logs[1].GetLevel())
+	testutil.RequireSend(ctx, t, fDest.resps, &proto.BatchCreateLogsResponse{})
+
+	cancel()
+	err := testutil.TryReceive(testCtx, t, loopErr)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
 func TestLogSender_Batch(t *testing.T) {
 	t.Parallel()
 	testCtx := testutil.Context(t, testutil.WaitShort)


### PR DESCRIPTION
自动生成的修复提案。

- 原始 issue: https://github.com/coder/coder/issues/23292
- 摘要: Fixed null byte (0x00) handling in agent logs that caused PostgreSQL 'invalid byte sequence for encoding UTF8: 0x00' error. Added client-side sanitization in ProtoFromLog and server-side defense-in-depth in BatchCreateLogs.
- 修改文件:
  - codersdk/agentsdk/convert.go
  - codersdk/agentsdk/logs_internal_test.go
  - coderd/agentapi/logs.go
  - coderd/agentapi/logs_test.go
- 验证情况:
  - {'command': "go test ./codersdk/agentsdk/... -run 'TestLogSender_InvalidUTF8|TestLogSender_NullBytes' -v", 'result': 'PASS - Both tests pass'}
  - {'command': 'go test ./codersdk/agentsdk/... -v', 'result': 'PASS - All agentsdk tests pass'}
  - {'command': "go test ./coderd/agentapi/... -run 'TestBatchCreateLogs' -v", 'result': 'PASS - All BatchCreateLogs tests pass including new StripsNullBytes test'}
- 风险提示:
  - The existing TestMemoryResourceMonitor* tests fail due to missing Docker socket in container - unrelated to this fix