### PR TITLE
feat: make editor deep link list configurable in agent detail

### DIFF
--- a/site/src/modules/apps/apps.test.ts
+++ b/site/src/modules/apps/apps.test.ts
@@ -46,6 +46,18 @@ describe("getVSCodeHref", () => {
 
 		expect(href).toBe(`cursor://coder.coder-remote/open?${query}`);
 	});
+
+	it("generates href for any custom editor protocol", () => {
+		const href = getVSCodeHref("windsurf", {
+			owner: "owner",
+			workspace: "my-workspace",
+			token: "abc123",
+			agent: "agent",
+		});
+		expect(href).toBe(
+			"windsurf://coder.coder-remote/open?owner=owner&workspace=my-workspace&url=http%3A%2F%2Flocalhost%3A3000&token=abc123&openRecent=true&agent=agent",
+		);
+	});
 });
 
 describe("getAppHref", () => {

--- a/site/src/modules/apps/apps.ts
+++ b/site/src/modules/apps/apps.ts
@@ -28,6 +28,28 @@ const ALLOWED_EXTERNAL_APP_PROTOCOLS = [
 	"antigravity:",
 ];
 
+/**
+ * Describes an editor that can open a Coder workspace via a deep link.
+ * All editors using the `coder.coder-remote` VS Code extension protocol
+ * (i.e. `{protocol}://coder.coder-remote/open?...`) are supported.
+ */
+export type EditorDescriptor = {
+	/** The protocol scheme used for deep links (e.g. "vscode", "cursor"). */
+	protocol: string;
+	/** The human-readable name shown in the UI (e.g. "VS Code", "Cursor"). */
+	displayName: string;
+};
+
+/**
+ * The default set of editors shown in the agent detail dropdown.
+ * Deployments can override this list to add or remove editors
+ * (e.g. adding PyCharm, Windsurf, or other JetBrains IDEs).
+ */
+export const DEFAULT_EDITOR_LIST: readonly EditorDescriptor[] = [
+	{ protocol: "cursor", displayName: "Cursor" },
+	{ protocol: "vscode", displayName: "VS Code" },
+];
+
 type GetVSCodeHrefParams = {
 	owner: string;
 	workspace: string;
@@ -38,7 +60,7 @@ type GetVSCodeHrefParams = {
 };
 
 export const getVSCodeHref = (
-	app: "vscode" | "vscode-insiders" | "cursor",
+	app: string,
 	{ owner, workspace, token, agent, folder, chatId }: GetVSCodeHrefParams,
 ) => {
 	const query = new URLSearchParams({

--- a/site/src/pages/AgentsPage/AgentDetail.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.tsx
@@ -724,14 +724,14 @@ const AgentDetail: FC = () => {
 		mutationFn: () => API.getApiKey(),
 	});
 
-	const handleOpenInEditor = (editor: "cursor" | "vscode") => {
+	const handleOpenInEditor = (editorProtocol: string) => {
 		if (!workspace || !workspaceAgent) {
 			return;
 		}
 
 		generateKeyMutation.mutate(undefined, {
 			onSuccess: ({ key }) => {
-				location.href = getVSCodeHref(editor, {
+				location.href = getVSCodeHref(editorProtocol, {
 					owner: workspace.owner_name,
 					workspace: workspace.name,
 					token: key,
@@ -741,11 +741,7 @@ const AgentDetail: FC = () => {
 				});
 			},
 			onError: () => {
-				toast.error(
-					editor === "cursor"
-						? "Failed to open in Cursor."
-						: "Failed to open in VS Code.",
-				);
+				toast.error("Failed to open in editor.");
 			},
 		});
 	};

--- a/site/src/pages/AgentsPage/AgentDetail/TopBar.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail/TopBar.tsx
@@ -27,6 +27,10 @@ import type { FC } from "react";
 import { useNavigate } from "react-router";
 import { toast } from "sonner";
 import { cn } from "utils/cn";
+import {
+	DEFAULT_EDITOR_LIST,
+	type EditorDescriptor,
+} from "modules/apps/apps";
 import { useEmbedContext } from "../EmbedContext";
 import { PrStateIcon } from "../GitPanel";
 import { parsePullRequestUrl } from "../pullRequest";
@@ -39,7 +43,7 @@ interface SidebarPanelState {
 interface WorkspaceActions {
 	canOpenEditors: boolean;
 	canOpenWorkspace: boolean;
-	onOpenInEditor: (editor: "cursor" | "vscode") => void;
+	onOpenInEditor: (editorProtocol: string) => void;
 	onViewWorkspace: () => void;
 	onOpenTerminal: () => void;
 	sshCommand: string | undefined;
@@ -59,6 +63,8 @@ type AgentDetailTopBarProps = {
 	isSidebarCollapsed: boolean;
 	onToggleSidebarCollapsed: () => void;
 	diffStatusData?: ChatDiffStatus;
+	/** Editors to show in the dropdown. Defaults to `DEFAULT_EDITOR_LIST`. */
+	editorList?: readonly EditorDescriptor[];
 };
 
 export const AgentDetailTopBar: FC<AgentDetailTopBarProps> = ({
@@ -75,6 +81,7 @@ export const AgentDetailTopBar: FC<AgentDetailTopBarProps> = ({
 	isSidebarCollapsed,
 	onToggleSidebarCollapsed,
 	diffStatusData,
+	editorList = DEFAULT_EDITOR_LIST,
 }) => {
 	const navigate = useNavigate();
 	const { isEmbedded } = useEmbedContext();
@@ -178,24 +185,18 @@ export const AgentDetailTopBar: FC<AgentDetailTopBarProps> = ({
 							</Button>
 						</DropdownMenuTrigger>
 						<DropdownMenuContent align="end">
-							<DropdownMenuItem
-								disabled={!workspace.canOpenEditors}
-								onSelect={() => {
-									workspace.onOpenInEditor("cursor");
-								}}
-							>
-								<ExternalLinkIcon className="h-3.5 w-3.5" />
-								Open in Cursor
-							</DropdownMenuItem>
-							<DropdownMenuItem
-								disabled={!workspace.canOpenEditors}
-								onSelect={() => {
-									workspace.onOpenInEditor("vscode");
-								}}
-							>
-								<ExternalLinkIcon className="h-3.5 w-3.5" />
-								Open in VS Code
-							</DropdownMenuItem>
+							{editorList.map((editor) => (
+								<DropdownMenuItem
+									key={editor.protocol}
+									disabled={!workspace.canOpenEditors}
+									onSelect={() => {
+										workspace.onOpenInEditor(editor.protocol);
+									}}
+								>
+									<ExternalLinkIcon className="h-3.5 w-3.5" />
+									Open in {editor.displayName}
+								</DropdownMenuItem>
+							))}
 							<DropdownMenuItem
 								// You can think of the web terminal as an editor if you squint.
 								disabled={!workspace.canOpenEditors}

--- a/site/src/pages/AgentsPage/AgentDetailView.tsx
+++ b/site/src/pages/AgentsPage/AgentDetailView.tsx
@@ -22,6 +22,7 @@ import {
 import { GitPanel } from "./GitPanel";
 import { RightPanel } from "./RightPanel";
 import { SidebarTabView } from "./SidebarTabView";
+import type { EditorDescriptor } from "modules/apps/apps";
 import type { ChatDetailError } from "./usageLimitMessage";
 
 type ChatStoreHandle = ReturnType<typeof useChatStore>["store"];
@@ -102,7 +103,9 @@ interface AgentDetailViewProps {
 	canOpenEditors: boolean;
 	canOpenWorkspace: boolean;
 	sshCommand: string | undefined;
-	handleOpenInEditor: (editor: "cursor" | "vscode") => void;
+	/** Editors to show in the agent detail dropdown. */
+	editorList?: readonly EditorDescriptor[];
+	handleOpenInEditor: (editorProtocol: string) => void;
 	handleViewWorkspace: () => void;
 	handleOpenTerminal: () => void;
 	handleCommit: (repoRoot: string) => void;
@@ -167,6 +170,7 @@ export const AgentDetailView: FC<AgentDetailViewProps> = ({
 	canOpenEditors,
 	canOpenWorkspace,
 	sshCommand,
+	editorList,
 	handleOpenInEditor,
 	handleViewWorkspace,
 	handleOpenTerminal,
@@ -242,6 +246,7 @@ export const AgentDetailView: FC<AgentDetailViewProps> = ({
 						diffStatusData={diffStatusData}
 						isSidebarCollapsed={isSidebarCollapsed}
 						onToggleSidebarCollapsed={onToggleSidebarCollapsed}
+						editorList={editorList}
 					/>
 					{isArchived && (
 						<div className="flex shrink-0 items-center gap-2 border-b border-border-default bg-surface-secondary px-4 py-2 text-xs text-content-secondary">


### PR DESCRIPTION
## Summary

The editor list in the agent detail TopBar dropdown was hardcoded to only Cursor and VS Code. This PR makes it data-driven so deployments can easily configure which editors appear.

## Changes

### New types and constants (`modules/apps/apps.ts`)
- **`EditorDescriptor`** type: describes an editor with `protocol` (e.g. `"cursor"`, `"windsurf"`) and `displayName` (e.g. `"Cursor"`, `"Windsurf"`).
- **`DEFAULT_EDITOR_LIST`**: the default set of editors (Cursor + VS Code), matching current behavior.
- Widened `getVSCodeHref` `app` parameter from `"vscode" | "vscode-insiders" | "cursor"` to `string`, enabling any VS-Code-compatible protocol.

### Configurable TopBar (`AgentDetail/TopBar.tsx`)
- New optional `editorList` prop (defaults to `DEFAULT_EDITOR_LIST`).
- Replaced hardcoded Cursor/VS Code `DropdownMenuItem` elements with a `.map()` over the editor list.

### Prop threading
- `AgentDetailView` accepts and forwards `editorList` to `AgentDetailTopBar`.
- `AgentDetail` updated `handleOpenInEditor` to accept `string` instead of a union literal.

### Tests
- Added test for custom editor protocol (Windsurf) in `apps.test.ts`.

## How to use

To add more editors (e.g. for enterprise), pass a custom list:
```tsx
<AgentDetailTopBar
  editorList={[
    { protocol: "cursor", displayName: "Cursor" },
    { protocol: "vscode", displayName: "VS Code" },
    { protocol: "windsurf", displayName: "Windsurf" },
    { protocol: "positron", displayName: "Positron" },
  ]}
  // ...
/>
```

The default behavior (Cursor + VS Code) is unchanged.