### PR TITLE
feat: add unsaved changes warning to agent settings pages

### DIFF
--- a/site/src/hooks/useUnsavedChangesWarning.ts
+++ b/site/src/hooks/useUnsavedChangesWarning.ts
@@ -1,0 +1,26 @@
+import { useEffect } from "react";
+import { unstable_usePrompt as usePrompt } from "react-router";
+
+const MESSAGE = "You have unsaved changes. Are you sure you want to leave?";
+
+export const useUnsavedChangesWarning = (isDirty: boolean) => {
+	useEffect(() => {
+		const onBeforeUnload = (e: BeforeUnloadEvent) => {
+			if (isDirty) {
+				e.preventDefault();
+				return MESSAGE;
+			}
+		};
+
+		window.addEventListener("beforeunload", onBeforeUnload);
+
+		return () => {
+			window.removeEventListener("beforeunload", onBeforeUnload);
+		};
+	}, [isDirty]);
+
+	usePrompt({
+		message: MESSAGE,
+		when: isDirty,
+	});
+};

--- a/site/src/pages/AgentsPage/ChatModelAdminPanel/ModelForm.tsx
+++ b/site/src/pages/AgentsPage/ChatModelAdminPanel/ModelForm.tsx
@@ -11,6 +11,7 @@ import {
 } from "components/Select/Select";
 import { Spinner } from "components/Spinner/Spinner";
 import { useFormik } from "formik";
+import { useUnsavedChangesWarning } from "hooks/useUnsavedChangesWarning";
 import {
 	ChevronDownIcon,
 	ChevronLeftIcon,
@@ -183,6 +184,7 @@ export const ModelForm: FC<ModelFormProps> = ({
 			// here to avoid a double view-transition.
 		},
 	});
+	useUnsavedChangesWarning(form.dirty);
 
 	const getFieldHelpers = getFormHelpers(form);
 

--- a/site/src/pages/AgentsPage/ChatModelAdminPanel/ProviderForm.tsx
+++ b/site/src/pages/AgentsPage/ChatModelAdminPanel/ProviderForm.tsx
@@ -8,6 +8,7 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "components/Tooltip/Tooltip";
+import { useUnsavedChangesWarning } from "hooks/useUnsavedChangesWarning";
 import { ChevronLeftIcon, InfoIcon } from "lucide-react";
 import { type FC, type FormEvent, useId, useState } from "react";
 import { formatProviderLabel } from "../modelOptions";
@@ -83,6 +84,8 @@ export const ProviderForm: FC<ProviderFormProps> = ({
 		displayName.trim() !== initialValues.displayName ||
 		effectiveApiKey !== "" ||
 		baseURLValue.trim() !== initialValues.baseURL.trim();
+
+	useUnsavedChangesWarning(isDirty);
 
 	const canSave =
 		!providerConfigsUnavailable &&

--- a/site/src/pages/AgentsPage/MCPServerAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/MCPServerAdminPanel.tsx
@@ -25,6 +25,7 @@ import {
 	TooltipTrigger,
 } from "components/Tooltip/Tooltip";
 import { useFormik } from "formik";
+import { useUnsavedChangesWarning } from "hooks/useUnsavedChangesWarning";
 import {
 	CheckCircleIcon,
 	ChevronLeftIcon,
@@ -338,6 +339,8 @@ const ServerForm: FC<ServerFormProps> = ({
 			await onSave(req, server?.id);
 		},
 	});
+
+	useUnsavedChangesWarning(form.dirty);
 
 	const isDisabled = isSaving || isDeleting;
 	const canSubmit =

--- a/site/src/pages/AgentsPage/SettingsPageContent.tsx
+++ b/site/src/pages/AgentsPage/SettingsPageContent.tsx
@@ -39,6 +39,7 @@ import {
 import dayjs from "dayjs";
 import { useDebouncedValue } from "hooks/debounce";
 import { useClickableTableRow } from "hooks/useClickableTableRow";
+import { useUnsavedChangesWarning } from "hooks/useUnsavedChangesWarning";
 import { ChevronLeftIcon, ShieldIcon } from "lucide-react";
 import { type FC, type FormEvent, useState } from "react";
 import {
@@ -465,6 +466,10 @@ export const SettingsPageContent: FC<SettingsPageContentProps> = ({
 		isSavingDesktopEnabled ||
 		isSavingWorkspaceTTL;
 	const isTTLLoading = workspaceTTLQuery.isLoading;
+
+	useUnsavedChangesWarning(
+		isSystemPromptDirty || isUserPromptDirty || isTTLDirty,
+	);
 
 	const handleSaveSystemPrompt = (event: FormEvent) => {
 		event.preventDefault();


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

## What

Adds an "Are you sure you want to leave?" guard to the agent settings pages when there are unsaved form edits.

## How

Introduces a reusable `useUnsavedChangesWarning(isDirty)` hook that combines:
- `beforeunload` event listener — catches browser back, tab close, and refresh
- `unstable_usePrompt` from react-router — catches in-app navigation (e.g. clicking a different settings tab)

This follows the same pattern already used in `TemplateVersionEditor`.

## Where it is wired in

| Component | Dirty state guarded |
|---|---|
| `SettingsPageContent` | System prompt, user prompt, workspace TTL |
| `ProviderForm` | Display name, API key, base URL |
| `ModelForm` | All Formik-managed model config fields |
| `MCPServerAdminPanel` (ServerForm) | All Formik-managed MCP server config fields |
