### PR TITLE
refactor(site): replace raw <button> elements with Button component

### DIFF
--- a/site/src/pages/AgentsPage/AgentSettingsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsPageView.tsx
@@ -274,15 +274,15 @@ const UsageContent: FC<UsageContentProps> = ({ now }) => {
 		};
 
 		const backButton = (
-			<button
-				type="button"
+			<Button
+				variant="subtle"
+				size="sm"
 				onClick={clearUser}
-				className="mb-4 inline-flex cursor-pointer items-center gap-0.5 bg-transparent border-0 p-0 text-sm text-content-secondary transition-colors hover:text-content-primary"
+				className="mb-4 min-w-0 h-auto gap-0.5 p-0 text-sm"
 			>
-				{" "}
 				<ChevronLeftIcon className="h-4 w-4" />
 				Back
-			</button>
+			</Button>
 		);
 
 		if (selectedUserQuery.isLoading) {

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelForm.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelForm.tsx
@@ -233,14 +233,15 @@ export const ModelForm: FC<ModelFormProps> = ({
 	if (!selectedProviderState || modelConfigsUnavailable) {
 		return (
 			<div>
-				<button
-					type="button"
+				<Button
+					variant="subtle"
+					size="sm"
 					onClick={onCancel}
-					className="mb-4 inline-flex cursor-pointer items-center gap-0.5 bg-transparent border-0 p-0 text-sm text-content-secondary transition-colors hover:text-content-primary"
+					className="mb-4 min-w-0 h-auto gap-0.5 p-0 text-sm"
 				>
 					<ChevronLeftIcon className="h-4 w-4" />
 					Back
-				</button>
+				</Button>{" "}
 				<h2 className="m-0 text-lg font-medium text-content-primary">
 					{isEditing ? "Edit Model" : "Add Model"}
 				</h2>
@@ -254,14 +255,15 @@ export const ModelForm: FC<ModelFormProps> = ({
 	if (!canManageModels && !isEditing) {
 		return (
 			<div>
-				<button
-					type="button"
+				<Button
+					variant="subtle"
+					size="sm"
 					onClick={onCancel}
-					className="mb-4 inline-flex cursor-pointer items-center gap-0.5 bg-transparent border-0 p-0 text-sm text-content-secondary transition-colors hover:text-content-primary"
+					className="mb-4 min-w-0 h-auto gap-0.5 p-0 text-sm"
 				>
 					<ChevronLeftIcon className="h-4 w-4" />
 					Back
-				</button>
+				</Button>
 				<h2 className="m-0 text-lg font-medium text-content-primary">
 					Add Model
 				</h2>
@@ -287,15 +289,15 @@ export const ModelForm: FC<ModelFormProps> = ({
 	return (
 		<div className="flex min-h-full flex-col">
 			{/* Back */}
-			<button
-				type="button"
+			<Button
+				variant="subtle"
+				size="sm"
 				onClick={onCancel}
-				className="mb-4 inline-flex cursor-pointer items-center gap-0.5 bg-transparent border-0 p-0 text-sm text-content-secondary transition-colors hover:text-content-primary"
+				className="mb-4 min-w-0 h-auto gap-0.5 p-0 text-sm"
 			>
 				<ChevronLeftIcon className="h-4 w-4" />
 				Back
-			</button>
-
+			</Button>
 			{/* Header — editable display name */}
 			<div className="flex items-center gap-3">
 				{selectedProviderState && (

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ProviderForm.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ProviderForm.tsx
@@ -169,15 +169,15 @@ export const ProviderForm: FC<ProviderFormProps> = ({
 	return (
 		<div className="flex min-h-full flex-col">
 			{/* Back */}
-			<button
-				type="button"
+			<Button
+				variant="subtle"
+				size="sm"
 				onClick={onBack}
-				className="mb-4 inline-flex cursor-pointer items-center gap-0.5 bg-transparent border-0 p-0 text-sm text-content-secondary transition-colors hover:text-content-primary"
+				className="mb-4 min-w-0 h-auto gap-0.5 p-0 text-sm"
 			>
 				<ChevronLeftIcon className="h-4 w-4" />
 				Back
-			</button>
-
+			</Button>
 			{/* Provider header — editable name */}
 			<div className="flex items-center gap-3">
 				<ProviderIcon provider={provider} className="h-8 w-8" />

--- a/site/src/pages/AgentsPage/components/GitPanel/GitPanel.tsx
+++ b/site/src/pages/AgentsPage/components/GitPanel/GitPanel.tsx
@@ -397,15 +397,17 @@ const RepoHeader: FC<{
 					additions={diffStats.additions}
 					deletions={diffStats.deletions}
 				/>
-				<button
-					type="button"
+				<Button
+					variant="outline"
+					size="sm"
 					onClick={onCommit}
 					disabled={!repo.unified_diff}
-					className="inline-flex cursor-pointer items-center gap-1 rounded-sm border border-solid border-border-default bg-transparent px-2 text-[13px] font-medium leading-5 text-content-secondary no-underline transition-colors hover:bg-surface-secondary hover:text-content-primary disabled:pointer-events-none disabled:opacity-50"
+					className="min-w-0 h-auto rounded-sm text-[13px] leading-5 text-content-secondary hover:text-content-primary disabled:opacity-50"
 				>
+					{" "}
 					<CheckIcon className="size-3" />
 					Commit
-				</button>
+				</Button>{" "}
 			</div>
 		</div>
 	);

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
@@ -349,15 +349,15 @@ const ServerForm: FC<ServerFormProps> = ({
 	return (
 		<div className="flex min-h-full flex-col">
 			{/* Back */}
-			<button
-				type="button"
+			<Button
+				variant="subtle"
+				size="sm"
 				onClick={onBack}
-				className="mb-4 inline-flex cursor-pointer items-center gap-0.5 bg-transparent border-0 p-0 text-sm text-content-secondary transition-colors hover:text-content-primary"
+				className="mb-4 min-w-0 h-auto gap-0.5 p-0 text-sm"
 			>
 				<ChevronLeftIcon className="h-4 w-4" />
 				Back
-			</button>
-
+			</Button>
 			{/* Header with icon + editable name + enabled toggle */}
 			<div className="flex items-center gap-3">
 				<MCPServerIcon


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

Replace 7 raw HTML `<button>` elements across `AgentsPage/` with the shared `Button` component from `components/Button/Button`.

## Changes

- 6 identical "Back" navigation buttons → `<Button variant="subtle" size="sm">`
- 1 "Commit" action button → `<Button variant="outline" size="sm">`

### Files touched

| File | Buttons replaced |
|---|---|
| `ChatModelAdminPanel/ProviderForm.tsx` | 1 (Back) |
| `ChatModelAdminPanel/ModelForm.tsx` | 3 (Back) |
| `MCPServerAdminPanel.tsx` | 1 (Back) |
| `AgentSettingsPageView.tsx` | 1 (Back) |
| `GitPanel/GitPanel.tsx` | 1 (Commit) |

All affected files already imported `Button`. No new dependencies added.