### PR TITLE
refactor(site/src/pages/AgentsPage): migrate delete dialog to shadcn components

### DIFF
--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -15,7 +15,19 @@ import {
 } from "api/queries/chats";
 import { workspaceById } from "api/queries/workspaces";
 import type * as TypesGen from "api/typesGenerated";
-import { DeleteDialog } from "components/Dialogs/DeleteDialog/DeleteDialog";
+import { Button } from "components/Button/Button";
+import {
+	Dialog,
+	DialogClose,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "components/Dialog/Dialog";
+import { Input } from "components/Input/Input";
+import { Label } from "components/Label/Label";
+import { Spinner } from "components/Spinner/Spinner";
 import { useAuthenticated } from "hooks";
 import { useDashboard } from "modules/dashboard/useDashboard";
 import { type FC, useEffect, useRef, useState } from "react";
@@ -493,6 +505,8 @@ const AgentsPage: FC = () => {
 
 	const deleteDialogOpen =
 		pendingArchiveAndDelete !== null && Boolean(pendingWorkspaceName);
+	const [deleteConfirmText, setDeleteConfirmText] = useState("");
+	const deleteConfirmed = deleteConfirmText === pendingWorkspaceName;
 
 	return (
 		<>
@@ -526,19 +540,80 @@ const AgentsPage: FC = () => {
 				archivedFilter={archivedFilter}
 				onArchivedFilterChange={setArchivedFilter}
 			/>
-			<DeleteDialog
-				key={pendingWorkspaceName}
-				isOpen={deleteDialogOpen}
-				onConfirm={handleConfirmArchiveAndDelete}
-				onCancel={() => setPendingArchiveAndDelete(null)}
-				entity="workspace"
-				name={pendingWorkspaceName}
-				confirmLoading={archiveAndDeleteMutation.isPending}
-				title="Archive agent & delete workspace"
-				verb="Archiving and deleting"
-				info="This will archive the agent and permanently delete the associated workspace and all its resources."
-			/>
+			<Dialog
+				open={deleteDialogOpen}
+				onOpenChange={(open) => {
+					if (!open) {
+						setPendingArchiveAndDelete(null);
+						setDeleteConfirmText("");
+					}
+				}}
+			>
+				<DialogContent variant="destructive">
+					<DialogHeader>
+						<DialogTitle>Archive agent &amp; delete workspace</DialogTitle>
+						<DialogDescription asChild>
+							<div className="flex flex-col gap-4">
+								<p>Archiving and deleting this workspace is irreversible!</p>
+								<div className="rounded-md border border-solid border-border-destructive bg-surface-destructive px-4 py-2 text-content-primary">
+									This will archive the agent and permanently delete the
+									associated workspace and all its resources.
+								</div>
+								<p>
+									Type{" "}
+									<strong className="text-content-primary">
+										{pendingWorkspaceName}
+									</strong>{" "}
+									below to confirm.
+								</p>
+							</div>
+						</DialogDescription>
+					</DialogHeader>
+					<form
+						onSubmit={(e) => {
+							e.preventDefault();
+							if (deleteConfirmed) {
+								handleConfirmArchiveAndDelete();
+							}
+						}}
+					>
+						<div className="flex flex-col gap-2">
+							<Label htmlFor="delete-confirm-name">
+								Name of the workspace to delete
+							</Label>
+							<Input
+								id="delete-confirm-name"
+								autoFocus
+								autoComplete="off"
+								placeholder={pendingWorkspaceName}
+								value={deleteConfirmText}
+								onChange={(e) => setDeleteConfirmText(e.target.value)}
+								data-testid="delete-dialog-name-confirmation"
+							/>
+						</div>
+					</form>
+					<DialogFooter>
+						<DialogClose asChild>
+							<Button
+								variant="outline"
+								disabled={archiveAndDeleteMutation.isPending}
+							>
+								Cancel
+							</Button>
+						</DialogClose>
+						<Button
+							variant="destructive"
+							disabled={!deleteConfirmed || archiveAndDeleteMutation.isPending}
+							onClick={handleConfirmArchiveAndDelete}
+						>
+							<Spinner loading={archiveAndDeleteMutation.isPending} />
+							Delete
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
 		</>
 	);
 };
+
 export default AgentsPage;

--- a/site/src/pages/AgentsPage/AgentsPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageView.stories.tsx
@@ -9,7 +9,19 @@ import { API } from "api/api";
 import type * as TypesGen from "api/typesGenerated";
 import type { Chat } from "api/typesGenerated";
 import type { ModelSelectorOption } from "components/ai-elements";
-import { DeleteDialog } from "components/Dialogs/DeleteDialog/DeleteDialog";
+import { Button } from "components/Button/Button";
+import {
+	Dialog,
+	DialogClose,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "components/Dialog/Dialog";
+import { Input } from "components/Input/Input";
+import { Label } from "components/Label/Label";
+import { Spinner } from "components/Spinner/Spinner";
 import dayjs from "dayjs";
 import { useState } from "react";
 import {
@@ -375,22 +387,76 @@ export const DeleteConfirmationDialog: Story = {
 		const [isOpen, setIsOpen] = useState(true);
 		const [isLoading, setIsLoading] = useState(false);
 		const onConfirm = fn();
+		const [confirmText, setConfirmText] = useState("");
 		return (
-			<DeleteDialog
-				key="my-workspace"
-				isOpen={isOpen}
-				onConfirm={() => {
-					onConfirm();
-					setIsLoading(true);
+			<Dialog
+				open={isOpen}
+				onOpenChange={(open) => {
+					if (!open) setIsOpen(false);
 				}}
-				onCancel={() => setIsOpen(false)}
-				entity="workspace"
-				name="my-workspace"
-				confirmLoading={isLoading}
-				title="Archive agent & delete workspace"
-				verb="Archiving and deleting"
-				info="This will archive the agent and permanently delete the associated workspace and all its resources."
-			/>
+			>
+				<DialogContent variant="destructive">
+					<DialogHeader>
+						<DialogTitle>Archive agent &amp; delete workspace</DialogTitle>
+						<DialogDescription asChild>
+							<div className="flex flex-col gap-4">
+								<p>Archiving and deleting this workspace is irreversible!</p>
+								<div className="rounded-md border border-solid border-border-destructive bg-surface-destructive px-4 py-2 text-content-primary">
+									This will archive the agent and permanently delete the
+									associated workspace and all its resources.
+								</div>
+								<p>
+									Type{" "}
+									<strong className="text-content-primary">my-workspace</strong>{" "}
+									below to confirm.
+								</p>
+							</div>
+						</DialogDescription>
+					</DialogHeader>
+					<form
+						onSubmit={(e) => {
+							e.preventDefault();
+							if (confirmText === "my-workspace") {
+								onConfirm();
+								setIsLoading(true);
+							}
+						}}
+					>
+						<div className="flex flex-col gap-2">
+							<Label htmlFor="delete-confirm-name">
+								Name of the workspace to delete
+							</Label>
+							<Input
+								id="delete-confirm-name"
+								autoFocus
+								autoComplete="off"
+								placeholder="my-workspace"
+								value={confirmText}
+								onChange={(e) => setConfirmText(e.target.value)}
+								data-testid="delete-dialog-name-confirmation"
+							/>
+						</div>
+					</form>
+					<DialogFooter>
+						<DialogClose asChild>
+							<Button variant="outline" disabled={isLoading}>
+								Cancel
+							</Button>
+						</DialogClose>
+						<Button
+							variant="destructive"
+							disabled={confirmText !== "my-workspace" || isLoading}
+							onClick={() => {
+								onConfirm();
+								setIsLoading(true);
+							}}
+						>
+							<Spinner loading={isLoading} />
+							Delete
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
 		);
 	},
 	play: async () => {


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

## Summary

Replaces the legacy MUI-based `DeleteDialog`/`ConfirmDialog` with the newer shadcn-style Dialog primitives (Radix + Tailwind) for the archive & delete workspace confirmation on the Agents page.

## Changes

- Swap `@emotion/react` + `@mui/material/TextField` for `Dialog`, `Input`, `Label`, `Button`, and `Spinner` from the shadcn component library
- Use `DialogContent variant="destructive"` for the destructive border styling
- Replicate the type-to-confirm behavior with controlled `Input` state
- Update the Storybook story to match the new component structure

## Testing

- TypeScript compiles cleanly (`tsc --noEmit` passes)
- Biome linter/formatter passes
- Storybook `DeleteConfirmationDialog` story play function assertions remain compatible (same button names, label text, and test IDs)