### PR TITLE
fix: return 409 Conflict instead of 502 when task agent is busy

### DIFF
--- a/coderd/aitasks.go
+++ b/coderd/aitasks.go
@@ -773,7 +773,7 @@ func (api *API) taskSend(rw http.ResponseWriter, r *http.Request) {
 		}
 
 		if statusResp.Status != agentapisdk.StatusStable {
-			return httperror.NewResponseError(http.StatusBadGateway, codersdk.Response{
+			return httperror.NewResponseError(http.StatusConflict, codersdk.Response{
 				Message: "Task app is not ready to accept input.",
 				Detail:  fmt.Sprintf("Status: %s", statusResp.Status),
 			})

--- a/coderd/aitasks_test.go
+++ b/coderd/aitasks_test.go
@@ -789,6 +789,11 @@ func TestTasks(t *testing.T) {
 			})
 			require.Error(t, err, "wanted error due to bad status")
 
+			var sdkErr *codersdk.Error
+			require.ErrorAs(t, err, &sdkErr)
+			require.Equal(t, http.StatusConflict, sdkErr.StatusCode())
+			require.Contains(t, sdkErr.Message, "not ready to accept input")
+
 			statusResponse = agentapisdk.StatusStable
 
 			//nolint:tparallel // Not intended to run in parallel.


### PR DESCRIPTION
The `taskSend` handler returns 502 Bad Gateway when the agentapi
reports a non-stable status (e.g. "running"). The server successfully
reached the agent and got a valid response, the agent is just busy
processing a previous prompt. 502 is semantically wrong here.

409 Conflict is the correct status code, consistent with how the same
handler already returns 409 for pending, initializing, and paused
states in `authAndDoWithTaskAppClient`.

Other 502s in the file are unchanged because they represent actual
gateway failures (connection refused, dial errors, agent unreachable).

> 🤖 This PR was created with the help of Coder Agents, and has been reviewed by a human. 🏂🏻