### PR TITLE
fix(site): add chat input skeleton to prevent layout shift on agent detail

### DIFF
--- a/site/src/pages/AgentsPage/components/AgentsSkeletons.tsx
+++ b/site/src/pages/AgentsPage/components/AgentsSkeletons.tsx
@@ -125,6 +125,25 @@ export const RightPanelSkeleton: FC = () => (
 );
 
 /**
+ * Skeleton placeholder for the chat input area. Matches the layout of
+ * the real AgentChatInput so the transition from Suspense fallback to
+ * the loaded component doesn't cause a vertical layout shift.
+ */
+const ChatInputSkeleton: FC = () => (
+	<div className="shrink-0 overflow-y-auto px-4 [scrollbar-gutter:stable] [scrollbar-width:thin]">
+		<div className="mx-auto w-full max-w-3xl pb-0 sm:pb-4">
+			<div className="rounded-2xl border border-border-default/80 bg-surface-secondary/45 p-1 shadow-sm">
+				<div className="min-h-[60px] sm:min-h-24 px-3 py-2" />
+				<div className="flex items-center justify-between gap-2 px-2.5 pb-1.5">
+					<Skeleton className="h-6 w-24 rounded" />
+					<Skeleton className="size-7 rounded-full" />
+				</div>
+			</div>
+		</div>
+	</div>
+);
+
+/**
  * Skeleton shown while the AgentDetail chunk is loading. Mimics a
  * top bar + chat conversation layout so the user sees navigable
  * structure during the brief Suspense fallback.
@@ -154,6 +173,7 @@ export const AgentDetailSkeleton: FC = () => {
 						</div>
 					</div>
 				</div>
+				<ChatInputSkeleton />
 			</div>
 			{rightPanel.open && (
 				<div


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

## Problem

When loading a chat with an agent, the `AgentDetailSkeleton` (the `<Suspense>` fallback while the lazy-loaded `AgentDetail` JS chunk downloads) rendered a top bar skeleton and conversation skeleton but **no chat input area** at the bottom.

Once the chunk loaded, `AgentDetailLoadingView` rendered the same skeleton *plus* the real `AgentChatInput`, causing visible layout shift as the input box appeared and pushed the conversation content upward.

## Fix

Added a `ChatInputSkeleton` component that mirrors the dimensions and structure of the real `AgentChatInput`:
- Same `shrink-0` wrapper with matching padding and scrollbar-gutter
- Same `max-w-3xl` centered container
- Same `rounded-2xl` border/background styling
- Same `min-h-[60px] sm:min-h-24` textarea area height
- Skeleton placeholders for the model selector and send button

This ensures the layout is stable from the very first paint through chunk load and data fetch.