### PR TITLE
fix(site): focus chat input after submitting diff comment

### DIFF
--- a/site/src/pages/AgentsPage/components/DiffViewer/CommentableDiffViewer.tsx
+++ b/site/src/pages/AgentsPage/components/DiffViewer/CommentableDiffViewer.tsx
@@ -294,6 +294,7 @@ export const CommentableDiffViewer: FC<CommentableDiffViewerProps> = ({
 		if (text.trim()) {
 			chatInputRef?.current?.insertText(text);
 		}
+		chatInputRef?.current?.focus();
 		setActiveCommentBox(null);
 	};
 


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

When a user adds an inline comment on a diff line in the DiffViewer
and submits it, the file reference chip and text are inserted into
the chat input but focus is not moved. This adds a `chatInputRef.focus()`
call after insertion so the cursor lands in the chat input, letting
the user immediately continue typing or press Enter to send.