### PR TITLE
chore: move chat methods to ExperimentalClient

### DIFF
--- a/coderd/chatd/chatd_test.go
+++ b/coderd/chatd/chatd_test.go
@@ -111,6 +111,7 @@ func TestSubagentChatExcludesWorkspaceProvisioningTools(t *testing.T) {
 		IncludeProvisionerDaemon: true,
 	})
 	user := coderdtest.CreateFirstUser(t, client)
+	expClient := codersdk.NewExperimentalClient(client)
 
 	agentToken := uuid.NewString()
 	version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
@@ -161,7 +162,7 @@ func TestSubagentChatExcludesWorkspaceProvisioningTools(t *testing.T) {
 		)
 	})
 
-	_, err := client.CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
+	_, err := expClient.CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
 		Provider: "openai-compat",
 		APIKey:   "test-api-key",
 		BaseURL:  openAIURL,
@@ -170,7 +171,7 @@ func TestSubagentChatExcludesWorkspaceProvisioningTools(t *testing.T) {
 
 	contextLimit := int64(4096)
 	isDefault := true
-	_, err = client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+	_, err = expClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
 		Provider:     "openai-compat",
 		Model:        "gpt-4o-mini",
 		ContextLimit: &contextLimit,
@@ -179,7 +180,7 @@ func TestSubagentChatExcludesWorkspaceProvisioningTools(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a root chat whose first model call will spawn a subagent.
-	chat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
+	chat, err := expClient.CreateChat(ctx, codersdk.CreateChatRequest{
 		Content: []codersdk.ChatInputPart{
 			{
 				Type: codersdk.ChatInputPartTypeText,
@@ -193,7 +194,7 @@ func TestSubagentChatExcludesWorkspaceProvisioningTools(t *testing.T) {
 	// The root chat finishes first, then the chatd server
 	// picks up and runs the child (subagent) chat.
 	require.Eventually(t, func() bool {
-		got, getErr := client.GetChat(ctx, chat.ID)
+		got, getErr := expClient.GetChat(ctx, chat.ID)
 		if getErr != nil {
 			return false
 		}
@@ -1844,6 +1845,7 @@ func TestCreateWorkspaceTool_EndToEnd(t *testing.T) {
 		IncludeProvisionerDaemon: true,
 	})
 	user := coderdtest.CreateFirstUser(t, client)
+	expClient := codersdk.NewExperimentalClient(client)
 
 	agentToken := uuid.NewString()
 	// Add a startup script so the agent spends time in the
@@ -1898,7 +1900,7 @@ func TestCreateWorkspaceTool_EndToEnd(t *testing.T) {
 		)
 	})
 
-	_, err := client.CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
+	_, err := expClient.CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
 		Provider: "openai-compat",
 		APIKey:   "test-api-key",
 		BaseURL:  openAIURL,
@@ -1907,7 +1909,7 @@ func TestCreateWorkspaceTool_EndToEnd(t *testing.T) {
 
 	contextLimit := int64(4096)
 	isDefault := true
-	_, err = client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+	_, err = expClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
 		Provider:     "openai-compat",
 		Model:        "gpt-4o-mini",
 		ContextLimit: &contextLimit,
@@ -1915,7 +1917,7 @@ func TestCreateWorkspaceTool_EndToEnd(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	chat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
+	chat, err := expClient.CreateChat(ctx, codersdk.CreateChatRequest{
 		Content: []codersdk.ChatInputPart{
 			{
 				Type: codersdk.ChatInputPartTypeText,
@@ -1927,7 +1929,7 @@ func TestCreateWorkspaceTool_EndToEnd(t *testing.T) {
 
 	var chatResult codersdk.Chat
 	require.Eventually(t, func() bool {
-		got, getErr := client.GetChat(ctx, chat.ID)
+		got, getErr := expClient.GetChat(ctx, chat.ID)
 		if getErr != nil {
 			return false
 		}
@@ -1949,7 +1951,7 @@ func TestCreateWorkspaceTool_EndToEnd(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, workspaceName, workspace.Name)
 
-	chatMsgs, err := client.GetChatMessages(ctx, chat.ID, nil)
+	chatMsgs, err := expClient.GetChatMessages(ctx, chat.ID, nil)
 	require.NoError(t, err)
 
 	var foundCreateWorkspaceResult bool
@@ -2023,6 +2025,7 @@ func TestStartWorkspaceTool_EndToEnd(t *testing.T) {
 		IncludeProvisionerDaemon: true,
 	})
 	user := coderdtest.CreateFirstUser(t, client)
+	expClient := codersdk.NewExperimentalClient(client)
 
 	version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
 		Parse:          echo.ParseComplete,
@@ -2067,7 +2070,7 @@ func TestStartWorkspaceTool_EndToEnd(t *testing.T) {
 		)
 	})
 
-	_, err := client.CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
+	_, err := expClient.CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
 		Provider: "openai-compat",
 		APIKey:   "test-api-key",
 		BaseURL:  openAIURL,
@@ -2076,7 +2079,7 @@ func TestStartWorkspaceTool_EndToEnd(t *testing.T) {
 
 	contextLimit := int64(4096)
 	isDefault := true
-	_, err = client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+	_, err = expClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
 		Provider:     "openai-compat",
 		Model:        "gpt-4o-mini",
 		ContextLimit: &contextLimit,
@@ -2085,7 +2088,7 @@ func TestStartWorkspaceTool_EndToEnd(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a chat with the stopped workspace pre-associated.
-	chat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
+	chat, err := expClient.CreateChat(ctx, codersdk.CreateChatRequest{
 		Content: []codersdk.ChatInputPart{
 			{
 				Type: codersdk.ChatInputPartTypeText,
@@ -2098,7 +2101,7 @@ func TestStartWorkspaceTool_EndToEnd(t *testing.T) {
 
 	var chatResult codersdk.Chat
 	require.Eventually(t, func() bool {
-		got, getErr := client.GetChat(ctx, chat.ID)
+		got, getErr := expClient.GetChat(ctx, chat.ID)
 		if getErr != nil {
 			return false
 		}
@@ -2120,7 +2123,7 @@ func TestStartWorkspaceTool_EndToEnd(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, codersdk.WorkspaceTransitionStart, updatedWorkspace.LatestBuild.Transition)
 
-	chatMsgs, err := client.GetChatMessages(ctx, chat.ID, nil)
+	chatMsgs, err := expClient.GetChatMessages(ctx, chat.ID, nil)
 	require.NoError(t, err)
 
 	// Verify start_workspace tool result exists in the chat messages.

--- a/coderd/chatd/integration_test.go
+++ b/coderd/chatd/integration_test.go
@@ -42,9 +42,10 @@ func TestAnthropicWebSearchRoundTrip(t *testing.T) {
 		DeploymentValues: deploymentValues,
 	})
 	_ = coderdtest.CreateFirstUser(t, client)
+	expClient := codersdk.NewExperimentalClient(client)
 
 	// Configure an Anthropic provider with the real API key.
-	_, err := client.CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
+	_, err := expClient.CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
 		Provider: "anthropic",
 		APIKey:   apiKey,
 		BaseURL:  baseURL,
@@ -54,7 +55,7 @@ func TestAnthropicWebSearchRoundTrip(t *testing.T) {
 	// Create a model config that enables web_search.
 	contextLimit := int64(200000)
 	isDefault := true
-	_, err = client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+	_, err = expClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
 		Provider:     "anthropic",
 		Model:        "claude-sonnet-4-20250514",
 		ContextLimit: &contextLimit,
@@ -71,7 +72,7 @@ func TestAnthropicWebSearchRoundTrip(t *testing.T) {
 
 	// --- Step 1: Send a message that triggers web_search ---
 	t.Log("Creating chat with web search query...")
-	chat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
+	chat, err := expClient.CreateChat(ctx, codersdk.CreateChatRequest{
 		Content: []codersdk.ChatInputPart{
 			{
 				Type: codersdk.ChatInputPartTypeText,
@@ -83,16 +84,16 @@ func TestAnthropicWebSearchRoundTrip(t *testing.T) {
 	t.Logf("Chat created: %s (status=%s)", chat.ID, chat.Status)
 
 	// Stream events until the chat reaches a terminal status.
-	events, closer, err := client.StreamChat(ctx, chat.ID, nil)
+	events, closer, err := expClient.StreamChat(ctx, chat.ID, nil)
 	require.NoError(t, err)
 	defer closer.Close()
 
 	waitForChatDone(ctx, t, events, "step 1")
 
 	// Verify the chat completed and messages were persisted.
-	chatData, err := client.GetChat(ctx, chat.ID)
+	chatData, err := expClient.GetChat(ctx, chat.ID)
 	require.NoError(t, err)
-	chatMsgs, err := client.GetChatMessages(ctx, chat.ID, nil)
+	chatMsgs, err := expClient.GetChatMessages(ctx, chat.ID, nil)
 	require.NoError(t, err)
 	t.Logf("Chat status after step 1: %s, messages: %d",
 		chatData.Status, len(chatMsgs.Messages))
@@ -133,7 +134,7 @@ func TestAnthropicWebSearchRoundTrip(t *testing.T) {
 	// by Anthropic because server_tool_use has no matching
 	// web_search_tool_result.
 	t.Log("Sending follow-up message...")
-	_, err = client.CreateChatMessage(ctx, chat.ID,
+	_, err = expClient.CreateChatMessage(ctx, chat.ID,
 		codersdk.CreateChatMessageRequest{
 			Content: []codersdk.ChatInputPart{
 				{
@@ -145,16 +146,16 @@ func TestAnthropicWebSearchRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 
 	// Stream the follow-up response.
-	events2, closer2, err := client.StreamChat(ctx, chat.ID, nil)
+	events2, closer2, err := expClient.StreamChat(ctx, chat.ID, nil)
 	require.NoError(t, err)
 	defer closer2.Close()
 
 	waitForChatDone(ctx, t, events2, "step 2")
 
 	// Verify the follow-up completed and produced content.
-	chatData2, err := client.GetChat(ctx, chat.ID)
+	chatData2, err := expClient.GetChat(ctx, chat.ID)
 	require.NoError(t, err)
-	chatMsgs2, err := client.GetChatMessages(ctx, chat.ID, nil)
+	chatMsgs2, err := expClient.GetChatMessages(ctx, chat.ID, nil)
 	require.NoError(t, err)
 	t.Logf("Chat status after step 2: %s, messages: %d",
 		chatData2.Status, len(chatMsgs2.Messages))
@@ -301,9 +302,10 @@ func TestOpenAIReasoningRoundTrip(t *testing.T) {
 		DeploymentValues: deploymentValues,
 	})
 	_ = coderdtest.CreateFirstUser(t, client)
+	expClient := codersdk.NewExperimentalClient(client)
 
 	// Configure an OpenAI provider with the real API key.
-	_, err := client.CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
+	_, err := expClient.CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
 		Provider: "openai",
 		APIKey:   apiKey,
 		BaseURL:  baseURL,
@@ -316,7 +318,7 @@ func TestOpenAIReasoningRoundTrip(t *testing.T) {
 	contextLimit := int64(200000)
 	isDefault := true
 	reasoningSummary := "auto"
-	_, err = client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+	_, err = expClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
 		Provider:     "openai",
 		Model:        "o4-mini",
 		ContextLimit: &contextLimit,
@@ -334,7 +336,7 @@ func TestOpenAIReasoningRoundTrip(t *testing.T) {
 
 	// --- Step 1: Send a message that triggers reasoning ---
 	t.Log("Creating chat with reasoning query...")
-	chat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
+	chat, err := expClient.CreateChat(ctx, codersdk.CreateChatRequest{
 		Content: []codersdk.ChatInputPart{
 			{
 				Type: codersdk.ChatInputPartTypeText,
@@ -346,16 +348,16 @@ func TestOpenAIReasoningRoundTrip(t *testing.T) {
 	t.Logf("Chat created: %s (status=%s)", chat.ID, chat.Status)
 
 	// Stream events until the chat reaches a terminal status.
-	events, closer, err := client.StreamChat(ctx, chat.ID, nil)
+	events, closer, err := expClient.StreamChat(ctx, chat.ID, nil)
 	require.NoError(t, err)
 	defer closer.Close()
 
 	waitForChatDone(ctx, t, events, "step 1")
 
 	// Verify the chat completed and messages were persisted.
-	chatData, err := client.GetChat(ctx, chat.ID)
+	chatData, err := expClient.GetChat(ctx, chat.ID)
 	require.NoError(t, err)
-	chatMsgs, err := client.GetChatMessages(ctx, chat.ID, nil)
+	chatMsgs, err := expClient.GetChatMessages(ctx, chat.ID, nil)
 	require.NoError(t, err)
 	t.Logf("Chat status after step 1: %s, messages: %d",
 		chatData.Status, len(chatMsgs.Messages))
@@ -382,7 +384,7 @@ func TestOpenAIReasoningRoundTrip(t *testing.T) {
 	//   Item 'rs_xxx' of type 'reasoning' was provided without its
 	//   required following item.
 	t.Log("Sending follow-up message...")
-	_, err = client.CreateChatMessage(ctx, chat.ID,
+	_, err = expClient.CreateChatMessage(ctx, chat.ID,
 		codersdk.CreateChatMessageRequest{
 			Content: []codersdk.ChatInputPart{
 				{
@@ -394,16 +396,16 @@ func TestOpenAIReasoningRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 
 	// Stream the follow-up response.
-	events2, closer2, err := client.StreamChat(ctx, chat.ID, nil)
+	events2, closer2, err := expClient.StreamChat(ctx, chat.ID, nil)
 	require.NoError(t, err)
 	defer closer2.Close()
 
 	waitForChatDone(ctx, t, events2, "step 2")
 
 	// Verify the follow-up completed and produced content.
-	chatData2, err := client.GetChat(ctx, chat.ID)
+	chatData2, err := expClient.GetChat(ctx, chat.ID)
 	require.NoError(t, err)
-	chatMsgs2, err := client.GetChatMessages(ctx, chat.ID, nil)
+	chatMsgs2, err := expClient.GetChatMessages(ctx, chat.ID, nil)
 	require.NoError(t, err)
 	t.Logf("Chat status after step 2: %s, messages: %d",
 		chatData2.Status, len(chatMsgs2.Messages))
@@ -454,9 +456,10 @@ func TestOpenAIReasoningRoundTripStoreFalse(t *testing.T) {
 		DeploymentValues: deploymentValues,
 	})
 	_ = coderdtest.CreateFirstUser(t, client)
+	expClient := codersdk.NewExperimentalClient(client)
 
 	// Configure an OpenAI provider with the real API key.
-	_, err := client.CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
+	_, err := expClient.CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
 		Provider: "openai",
 		APIKey:   apiKey,
 		BaseURL:  baseURL,
@@ -468,7 +471,7 @@ func TestOpenAIReasoningRoundTripStoreFalse(t *testing.T) {
 	contextLimit := int64(200000)
 	isDefault := true
 	reasoningSummary := "auto"
-	_, err = client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+	_, err = expClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
 		Provider:     "openai",
 		Model:        "o4-mini",
 		ContextLimit: &contextLimit,
@@ -486,7 +489,7 @@ func TestOpenAIReasoningRoundTripStoreFalse(t *testing.T) {
 
 	// --- Step 1: Send a message that triggers reasoning ---
 	t.Log("Creating chat with reasoning query...")
-	chat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
+	chat, err := expClient.CreateChat(ctx, codersdk.CreateChatRequest{
 		Content: []codersdk.ChatInputPart{
 			{
 				Type: codersdk.ChatInputPartTypeText,
@@ -498,16 +501,16 @@ func TestOpenAIReasoningRoundTripStoreFalse(t *testing.T) {
 	t.Logf("Chat created: %s (status=%s)", chat.ID, chat.Status)
 
 	// Stream events until the chat reaches a terminal status.
-	events, closer, err := client.StreamChat(ctx, chat.ID, nil)
+	events, closer, err := expClient.StreamChat(ctx, chat.ID, nil)
 	require.NoError(t, err)
 	defer closer.Close()
 
 	waitForChatDone(ctx, t, events, "step 1")
 
 	// Verify the chat completed and messages were persisted.
-	chatData, err := client.GetChat(ctx, chat.ID)
+	chatData, err := expClient.GetChat(ctx, chat.ID)
 	require.NoError(t, err)
-	chatMsgs, err := client.GetChatMessages(ctx, chat.ID, nil)
+	chatMsgs, err := expClient.GetChatMessages(ctx, chat.ID, nil)
 	require.NoError(t, err)
 	t.Logf("Chat status after step 1: %s, messages: %d",
 		chatData.Status, len(chatMsgs.Messages))
@@ -531,7 +534,7 @@ func TestOpenAIReasoningRoundTripStoreFalse(t *testing.T) {
 	// This is the critical test: when Store is false, item IDs are
 	// ephemeral and cannot be looked up from OpenAI later.
 	t.Log("Sending follow-up message...")
-	_, err = client.CreateChatMessage(ctx, chat.ID,
+	_, err = expClient.CreateChatMessage(ctx, chat.ID,
 		codersdk.CreateChatMessageRequest{
 			Content: []codersdk.ChatInputPart{
 				{
@@ -548,16 +551,16 @@ func TestOpenAIReasoningRoundTripStoreFalse(t *testing.T) {
 	require.NoError(t, err)
 
 	// Stream the follow-up response.
-	events2, closer2, err := client.StreamChat(ctx, chat.ID, nil)
+	events2, closer2, err := expClient.StreamChat(ctx, chat.ID, nil)
 	require.NoError(t, err)
 	defer closer2.Close()
 
 	waitForChatDone(ctx, t, events2, "step 2")
 
 	// Verify the follow-up completed and produced content.
-	chatData2, err := client.GetChat(ctx, chat.ID)
+	chatData2, err := expClient.GetChat(ctx, chat.ID)
 	require.NoError(t, err)
-	chatMsgs2, err := client.GetChatMessages(ctx, chat.ID, nil)
+	chatMsgs2, err := expClient.GetChatMessages(ctx, chat.ID, nil)
 	require.NoError(t, err)
 	t.Logf("Chat status after step 2: %s, messages: %d",
 		chatData2.Status, len(chatMsgs2.Messages))

--- a/coderd/chats_test.go
+++ b/coderd/chats_test.go
@@ -45,20 +45,22 @@ func chatDeploymentValues(t testing.TB) *codersdk.DeploymentValues {
 	return values
 }
 
-func newChatClient(t testing.TB) *codersdk.Client {
+func newChatClient(t testing.TB) *codersdk.ExperimentalClient {
 	t.Helper()
 
-	return coderdtest.New(t, &coderdtest.Options{
+	client := coderdtest.New(t, &coderdtest.Options{
 		DeploymentValues: chatDeploymentValues(t),
 	})
+	return codersdk.NewExperimentalClient(client)
 }
 
-func newChatClientWithDatabase(t testing.TB) (*codersdk.Client, database.Store) {
+func newChatClientWithDatabase(t testing.TB) (*codersdk.ExperimentalClient, database.Store) {
 	t.Helper()
 
-	return coderdtest.NewWithDatabase(t, &coderdtest.Options{
+	client, db := coderdtest.NewWithDatabase(t, &coderdtest.Options{
 		DeploymentValues: chatDeploymentValues(t),
 	})
+	return codersdk.NewExperimentalClient(client), db
 }
 
 func requireChatUsageLimitExceededError(
@@ -158,7 +160,7 @@ func TestPostChats(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		user := coderdtest.CreateFirstUser(t, client)
+		user := coderdtest.CreateFirstUser(t, client.Client)
 		modelConfig := createChatModelConfig(t, client)
 
 		chat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
@@ -209,7 +211,7 @@ func TestPostChats(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 		_ = createChatModelConfig(t, client)
 
 		chat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
@@ -234,8 +236,9 @@ func TestPostChats(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		adminClient, db := newChatClientWithDatabase(t)
-		firstUser := coderdtest.CreateFirstUser(t, adminClient)
-		memberClient, _ := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID)
+		firstUser := coderdtest.CreateFirstUser(t, adminClient.Client)
+		memberClientRaw, _ := coderdtest.CreateAnotherUser(t, adminClient.Client, firstUser.OrganizationID)
+		memberClient := codersdk.NewExperimentalClient(memberClientRaw)
 
 		workspaceBuild := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
 			OrganizationID: firstUser.OrganizationID,
@@ -264,13 +267,14 @@ func TestPostChats(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		adminClient, db := newChatClientWithDatabase(t)
-		firstUser := coderdtest.CreateFirstUser(t, adminClient)
-		orgAdminClient, _ := coderdtest.CreateAnotherUser(
+		firstUser := coderdtest.CreateFirstUser(t, adminClient.Client)
+		orgAdminClientRaw, _ := coderdtest.CreateAnotherUser(
 			t,
-			adminClient,
+			adminClient.Client,
 			firstUser.OrganizationID,
 			rbac.ScopedRoleOrgAdmin(firstUser.OrganizationID),
 		)
+		orgAdminClient := codersdk.NewExperimentalClient(orgAdminClientRaw)
 
 		workspaceBuild := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
 			OrganizationID: firstUser.OrganizationID,
@@ -299,7 +303,7 @@ func TestPostChats(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 
 		workspaceID := uuid.New()
 		_, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
@@ -324,7 +328,7 @@ func TestPostChats(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client, db := newChatClientWithDatabase(t)
-		user := coderdtest.CreateFirstUser(t, client)
+		user := coderdtest.CreateFirstUser(t, client.Client)
 		modelConfig := createChatModelConfig(t, client)
 
 		workspaceBuild := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
@@ -352,7 +356,7 @@ func TestPostChats(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 
 		_, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
 			Content: []codersdk.ChatInputPart{
@@ -371,7 +375,7 @@ func TestPostChats(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 
 		_, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
 			Content: nil,
@@ -386,7 +390,7 @@ func TestPostChats(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 
 		_, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
 			Content: []codersdk.ChatInputPart{
@@ -406,7 +410,7 @@ func TestPostChats(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 
 		_, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
 			Content: []codersdk.ChatInputPart{
@@ -426,7 +430,7 @@ func TestPostChats(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client, db := newChatClientWithDatabase(t)
-		user := coderdtest.CreateFirstUser(t, client)
+		user := coderdtest.CreateFirstUser(t, client.Client)
 		modelConfig := createChatModelConfig(t, client)
 		wantResetsAt := enableDailyChatUsageLimit(ctx, t, db, 100)
 
@@ -457,7 +461,7 @@ func TestListChats(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client, db := newChatClientWithDatabase(t)
-		firstUser := coderdtest.CreateFirstUser(t, client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 		modelConfig := createChatModelConfig(t, client)
 
 		firstChatA, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
@@ -480,7 +484,8 @@ func TestListChats(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		memberClient, member := coderdtest.CreateAnotherUser(t, client, firstUser.OrganizationID)
+		memberClientRaw, member := coderdtest.CreateAnotherUser(t, client.Client, firstUser.OrganizationID)
+		memberClient := codersdk.NewExperimentalClient(memberClientRaw)
 		memberDBChat, err := db.InsertChat(dbauthz.AsSystemRestricted(ctx), database.InsertChatParams{
 			OwnerID:           member.ID,
 			LastModelConfigID: modelConfig.ID,
@@ -544,19 +549,18 @@ func TestListChats(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 
-		unauthenticatedClient := codersdk.New(client.URL)
+		unauthenticatedClient := codersdk.NewExperimentalClient(codersdk.New(client.URL))
 		_, err := unauthenticatedClient.ListChats(ctx, nil)
 		requireSDKError(t, err, http.StatusUnauthorized)
 	})
-
 	t.Run("Pagination", func(t *testing.T) {
 		t.Parallel()
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client, _ := newChatClientWithDatabase(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 		_ = createChatModelConfig(t, client)
 
 		// Create 5 chats.
@@ -644,7 +648,7 @@ func TestListChatModels(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 		_ = createChatModelConfig(t, client)
 
 		models, err := client.ListChatModels(ctx)
@@ -675,9 +679,9 @@ func TestListChatModels(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 
-		unauthenticatedClient := codersdk.New(client.URL)
+		unauthenticatedClient := codersdk.NewExperimentalClient(codersdk.New(client.URL))
 		_, err := unauthenticatedClient.ListChatModels(ctx)
 		requireSDKError(t, err, http.StatusUnauthorized)
 	})
@@ -691,7 +695,7 @@ func TestWatchChats(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 		_ = createChatModelConfig(t, client)
 
 		conn, err := client.Dial(ctx, "/api/experimental/chats/watch", nil)
@@ -743,11 +747,12 @@ func TestWatchChats(t *testing.T) {
 		t.Parallel()
 
 		ctx := testutil.Context(t, testutil.WaitLong)
-		client, _, api := coderdtest.NewWithAPI(t, &coderdtest.Options{
+		rawClient, _, api := coderdtest.NewWithAPI(t, &coderdtest.Options{
 			DeploymentValues: chatDeploymentValues(t),
 		})
+		client := codersdk.NewExperimentalClient(rawClient)
 		db := api.Database
-		user := coderdtest.CreateFirstUser(t, client)
+		user := coderdtest.CreateFirstUser(t, client.Client)
 		modelConfig := createChatModelConfig(t, client)
 
 		// Insert a chat and a diff status row.
@@ -865,7 +870,7 @@ func TestWatchChats(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 
 		unauthenticatedClient := codersdk.New(client.URL)
 		res, err := unauthenticatedClient.Request(
@@ -888,7 +893,7 @@ func TestListChatProviders(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 		_ = createChatModelConfig(t, client)
 
 		providers, err := client.ListChatProviders(ctx)
@@ -912,8 +917,9 @@ func TestListChatProviders(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		adminClient := newChatClient(t)
-		firstUser := coderdtest.CreateFirstUser(t, adminClient)
-		memberClient, _ := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID)
+		firstUser := coderdtest.CreateFirstUser(t, adminClient.Client)
+		memberClientRaw, _ := coderdtest.CreateAnotherUser(t, adminClient.Client, firstUser.OrganizationID)
+		memberClient := codersdk.NewExperimentalClient(memberClientRaw)
 
 		_, err := memberClient.ListChatProviders(ctx)
 		requireSDKError(t, err, http.StatusForbidden)
@@ -928,7 +934,7 @@ func TestCreateChatProvider(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 
 		provider, err := client.CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
 			Provider:    "openai",
@@ -949,7 +955,7 @@ func TestCreateChatProvider(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 
 		_, err := client.CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
 			Provider: "not-a-provider",
@@ -964,7 +970,7 @@ func TestCreateChatProvider(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 
 		_, err := client.CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
 			Provider: "openai",
@@ -985,8 +991,9 @@ func TestCreateChatProvider(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		adminClient := newChatClient(t)
-		firstUser := coderdtest.CreateFirstUser(t, adminClient)
-		memberClient, _ := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID)
+		firstUser := coderdtest.CreateFirstUser(t, adminClient.Client)
+		memberClientRaw, _ := coderdtest.CreateAnotherUser(t, adminClient.Client, firstUser.OrganizationID)
+		memberClient := codersdk.NewExperimentalClient(memberClientRaw)
 
 		_, err := memberClient.CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
 			Provider: "openai",
@@ -1004,7 +1011,7 @@ func TestUpdateChatProvider(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 
 		provider, err := client.CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
 			Provider: "openai",
@@ -1031,7 +1038,7 @@ func TestUpdateChatProvider(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 
 		_, err := client.UpdateChatProvider(ctx, uuid.New(), codersdk.UpdateChatProviderConfigRequest{
 			DisplayName: "missing",
@@ -1044,7 +1051,7 @@ func TestUpdateChatProvider(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 
 		res, err := client.Request(
 			ctx,
@@ -1065,8 +1072,9 @@ func TestUpdateChatProvider(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		adminClient := newChatClient(t)
-		firstUser := coderdtest.CreateFirstUser(t, adminClient)
-		memberClient, _ := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID)
+		firstUser := coderdtest.CreateFirstUser(t, adminClient.Client)
+		memberClientRaw, _ := coderdtest.CreateAnotherUser(t, adminClient.Client, firstUser.OrganizationID)
+		memberClient := codersdk.NewExperimentalClient(memberClientRaw)
 
 		provider, err := adminClient.CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
 			Provider: "openai",
@@ -1089,7 +1097,7 @@ func TestDeleteChatProvider(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 
 		provider, err := client.CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
 			Provider: "openai",
@@ -1112,7 +1120,7 @@ func TestDeleteChatProvider(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 
 		err := client.DeleteChatProvider(ctx, uuid.New())
 		requireSDKError(t, err, http.StatusNotFound)
@@ -1123,7 +1131,7 @@ func TestDeleteChatProvider(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 
 		res, err := client.Request(
 			ctx,
@@ -1144,8 +1152,9 @@ func TestDeleteChatProvider(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		adminClient := newChatClient(t)
-		firstUser := coderdtest.CreateFirstUser(t, adminClient)
-		memberClient, _ := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID)
+		firstUser := coderdtest.CreateFirstUser(t, adminClient.Client)
+		memberClientRaw, _ := coderdtest.CreateAnotherUser(t, adminClient.Client, firstUser.OrganizationID)
+		memberClient := codersdk.NewExperimentalClient(memberClientRaw)
 
 		provider, err := adminClient.CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
 			Provider: "openai",
@@ -1166,7 +1175,7 @@ func TestListChatModelConfigs(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 		modelConfig := createChatModelConfig(t, client)
 
 		configs, err := client.ListChatModelConfigs(ctx)
@@ -1190,7 +1199,7 @@ func TestListChatModelConfigs(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client, db := newChatClientWithDatabase(t)
-		firstUser := coderdtest.CreateFirstUser(t, client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 
 		_, err := client.CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
 			Provider: "openai",
@@ -1232,9 +1241,10 @@ func TestListChatModelConfigs(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		adminClient := newChatClient(t)
-		firstUser := coderdtest.CreateFirstUser(t, adminClient)
+		firstUser := coderdtest.CreateFirstUser(t, adminClient.Client)
 		modelConfig := createChatModelConfig(t, adminClient)
-		memberClient, _ := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID)
+		memberClientRaw, _ := coderdtest.CreateAnotherUser(t, adminClient.Client, firstUser.OrganizationID)
+		memberClient := codersdk.NewExperimentalClient(memberClientRaw)
 
 		// Non-admin users should see only enabled model configs.
 		configs, err := memberClient.ListChatModelConfigs(ctx)
@@ -1261,7 +1271,7 @@ func TestCreateChatModelConfig(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 
 		_, err := client.CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
 			Provider: "openai",
@@ -1305,7 +1315,7 @@ func TestCreateChatModelConfig(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 
 		_, err := client.CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
 			Provider: "openai",
@@ -1338,7 +1348,7 @@ func TestCreateChatModelConfig(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 
 		_, err := client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
 			Provider: "openai",
@@ -1353,7 +1363,7 @@ func TestCreateChatModelConfig(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 
 		contextLimit := int64(4096)
 		_, err := client.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
@@ -1370,8 +1380,9 @@ func TestCreateChatModelConfig(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		adminClient := newChatClient(t)
-		firstUser := coderdtest.CreateFirstUser(t, adminClient)
-		memberClient, _ := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID)
+		firstUser := coderdtest.CreateFirstUser(t, adminClient.Client)
+		memberClientRaw, _ := coderdtest.CreateAnotherUser(t, adminClient.Client, firstUser.OrganizationID)
+		memberClient := codersdk.NewExperimentalClient(memberClientRaw)
 
 		_, err := adminClient.CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
 			Provider: "openai",
@@ -1397,7 +1408,7 @@ func TestUpdateChatModelConfig(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 		modelConfig := createChatModelConfig(t, client)
 
 		contextLimit := int64(8192)
@@ -1431,7 +1442,7 @@ func TestUpdateChatModelConfig(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 		modelConfig := createChatModelConfig(t, client)
 
 		_, err := client.UpdateChatModelConfig(ctx, modelConfig.ID, codersdk.UpdateChatModelConfigRequest{
@@ -1455,7 +1466,7 @@ func TestUpdateChatModelConfig(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 
 		_, err := client.UpdateChatModelConfig(ctx, uuid.New(), codersdk.UpdateChatModelConfigRequest{
 			DisplayName: "missing",
@@ -1468,7 +1479,7 @@ func TestUpdateChatModelConfig(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 		modelConfig := createChatModelConfig(t, client)
 
 		contextLimit := int64(0)
@@ -1484,7 +1495,7 @@ func TestUpdateChatModelConfig(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 
 		res, err := client.Request(
 			ctx,
@@ -1505,8 +1516,9 @@ func TestUpdateChatModelConfig(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		adminClient := newChatClient(t)
-		firstUser := coderdtest.CreateFirstUser(t, adminClient)
-		memberClient, _ := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID)
+		firstUser := coderdtest.CreateFirstUser(t, adminClient.Client)
+		memberClientRaw, _ := coderdtest.CreateAnotherUser(t, adminClient.Client, firstUser.OrganizationID)
+		memberClient := codersdk.NewExperimentalClient(memberClientRaw)
 
 		modelConfig := createChatModelConfig(t, adminClient)
 		_, err := memberClient.UpdateChatModelConfig(ctx, modelConfig.ID, codersdk.UpdateChatModelConfigRequest{
@@ -1524,7 +1536,7 @@ func TestDeleteChatModelConfig(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 		modelConfig := createChatModelConfig(t, client)
 
 		err := client.DeleteChatModelConfig(ctx, modelConfig.ID)
@@ -1542,7 +1554,7 @@ func TestDeleteChatModelConfig(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 
 		err := client.DeleteChatModelConfig(ctx, uuid.New())
 		requireSDKError(t, err, http.StatusNotFound)
@@ -1553,7 +1565,7 @@ func TestDeleteChatModelConfig(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 
 		res, err := client.Request(
 			ctx,
@@ -1574,8 +1586,9 @@ func TestDeleteChatModelConfig(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		adminClient := newChatClient(t)
-		firstUser := coderdtest.CreateFirstUser(t, adminClient)
-		memberClient, _ := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID)
+		firstUser := coderdtest.CreateFirstUser(t, adminClient.Client)
+		memberClientRaw, _ := coderdtest.CreateAnotherUser(t, adminClient.Client, firstUser.OrganizationID)
+		memberClient := codersdk.NewExperimentalClient(memberClientRaw)
 
 		modelConfig := createChatModelConfig(t, adminClient)
 		err := memberClient.DeleteChatModelConfig(ctx, modelConfig.ID)
@@ -1591,7 +1604,7 @@ func TestGetChat(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		firstUser := coderdtest.CreateFirstUser(t, client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 		modelConfig := createChatModelConfig(t, client)
 
 		createdChat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
@@ -1637,7 +1650,7 @@ func TestGetChat(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		firstUser := coderdtest.CreateFirstUser(t, client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 		_ = createChatModelConfig(t, client)
 
 		createdChat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
@@ -1650,7 +1663,8 @@ func TestGetChat(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		otherClient, _ := coderdtest.CreateAnotherUser(t, client, firstUser.OrganizationID)
+		otherClientRaw, _ := coderdtest.CreateAnotherUser(t, client.Client, firstUser.OrganizationID)
+		otherClient := codersdk.NewExperimentalClient(otherClientRaw)
 		_, err = otherClient.GetChat(ctx, createdChat.ID)
 		requireSDKError(t, err, http.StatusNotFound)
 	})
@@ -1664,7 +1678,7 @@ func TestArchiveChat(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 		_ = createChatModelConfig(t, client)
 
 		chatToArchive, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
@@ -1723,7 +1737,7 @@ func TestArchiveChat(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 
 		err := client.UpdateChat(ctx, uuid.New(), codersdk.UpdateChatRequest{Archived: ptr.Ref(true)})
 		requireSDKError(t, err, http.StatusNotFound)
@@ -1734,7 +1748,7 @@ func TestArchiveChat(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client, db := newChatClientWithDatabase(t)
-		user := coderdtest.CreateFirstUser(t, client)
+		user := coderdtest.CreateFirstUser(t, client.Client)
 		modelConfig := createChatModelConfig(t, client)
 
 		// Create a parent chat via the API.
@@ -1801,7 +1815,7 @@ func TestUnarchiveChat(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 		_ = createChatModelConfig(t, client)
 
 		chat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
@@ -1851,7 +1865,7 @@ func TestUnarchiveChat(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 		_ = createChatModelConfig(t, client)
 
 		chat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
@@ -1873,7 +1887,7 @@ func TestUnarchiveChat(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 
 		err := client.UpdateChat(ctx, uuid.New(), codersdk.UpdateChatRequest{Archived: ptr.Ref(false)})
 		requireSDKError(t, err, http.StatusNotFound)
@@ -1888,7 +1902,7 @@ func TestPostChatMessages(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 		_ = createChatModelConfig(t, client)
 
 		chat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
@@ -1978,7 +1992,7 @@ func TestPostChatMessages(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 		_ = createChatModelConfig(t, client)
 
 		chat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
@@ -2009,7 +2023,7 @@ func TestPostChatMessages(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client, db := newChatClientWithDatabase(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 		modelConfig := createChatModelConfig(t, client)
 
 		chat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
@@ -2037,7 +2051,7 @@ func TestPostChatMessages(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 		_ = createChatModelConfig(t, client)
 
 		_, err := client.CreateChatMessage(ctx, uuid.New(), codersdk.CreateChatMessageRequest{
@@ -2056,7 +2070,7 @@ func TestChatMessageWithFileReferences(t *testing.T) {
 	t.Parallel()
 
 	// createChat is a helper that creates a chat so we can post messages to it.
-	createChatForTest := func(t *testing.T, client *codersdk.Client) codersdk.Chat {
+	createChatForTest := func(t *testing.T, client *codersdk.ExperimentalClient) codersdk.Chat {
 		t.Helper()
 		ctx := testutil.Context(t, testutil.WaitLong)
 		chat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
@@ -2074,7 +2088,7 @@ func TestChatMessageWithFileReferences(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 		_ = createChatModelConfig(t, client)
 		chat := createChatForTest(t, client)
 
@@ -2136,7 +2150,7 @@ func TestChatMessageWithFileReferences(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 		_ = createChatModelConfig(t, client)
 		chat := createChatForTest(t, client)
 
@@ -2189,7 +2203,7 @@ func TestChatMessageWithFileReferences(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 		_ = createChatModelConfig(t, client)
 		chat := createChatForTest(t, client)
 
@@ -2242,7 +2256,7 @@ func TestChatMessageWithFileReferences(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 		_ = createChatModelConfig(t, client)
 		chat := createChatForTest(t, client)
 
@@ -2295,7 +2309,7 @@ func TestChatMessageWithFileReferences(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 		_ = createChatModelConfig(t, client)
 		chat := createChatForTest(t, client)
 
@@ -2408,7 +2422,7 @@ func TestChatMessageWithFileReferences(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 		_ = createChatModelConfig(t, client)
 		chat := createChatForTest(t, client)
 
@@ -2430,7 +2444,7 @@ func TestChatMessageWithFileReferences(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 		_ = createChatModelConfig(t, client)
 
 		// File references should also work in the initial CreateChat call.
@@ -2460,7 +2474,7 @@ func TestChatMessageWithFiles(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		firstUser := coderdtest.CreateFirstUser(t, client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 		_ = createChatModelConfig(t, client)
 
 		// Upload a file.
@@ -2504,7 +2518,7 @@ func TestChatMessageWithFiles(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		firstUser := coderdtest.CreateFirstUser(t, client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 		_ = createChatModelConfig(t, client)
 
 		// Upload a file.
@@ -2564,7 +2578,7 @@ func TestChatMessageWithFiles(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		firstUser := coderdtest.CreateFirstUser(t, client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 		_ = createChatModelConfig(t, client)
 
 		// Upload a file.
@@ -2592,7 +2606,7 @@ func TestChatMessageWithFiles(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 		_ = createChatModelConfig(t, client)
 
 		// Create a chat with text first.
@@ -2629,7 +2643,7 @@ func TestPatchChatMessage(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 		_ = createChatModelConfig(t, client)
 
 		chat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
@@ -2705,7 +2719,7 @@ func TestPatchChatMessage(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		firstUser := coderdtest.CreateFirstUser(t, client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 		_ = createChatModelConfig(t, client)
 
 		// Upload a file.
@@ -2801,7 +2815,7 @@ func TestPatchChatMessage(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client, db := newChatClientWithDatabase(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 		modelConfig := createChatModelConfig(t, client)
 
 		chat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
@@ -2841,7 +2855,7 @@ func TestPatchChatMessage(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 		_ = createChatModelConfig(t, client)
 
 		chat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
@@ -2871,7 +2885,7 @@ func TestPatchChatMessage(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 		_ = createChatModelConfig(t, client)
 
 		chat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
@@ -2914,7 +2928,7 @@ func TestStreamChat(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 		_ = createChatModelConfig(t, client)
 
 		const initialMessage = "stream chat route initial message"
@@ -2966,7 +2980,7 @@ func TestStreamChat(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 
 		unauthenticatedClient := codersdk.New(client.URL)
 		res, err := unauthenticatedClient.Request(
@@ -2989,7 +3003,7 @@ func TestInterruptChat(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client, db := newChatClientWithDatabase(t)
-		user := coderdtest.CreateFirstUser(t, client)
+		user := coderdtest.CreateFirstUser(t, client.Client)
 		modelConfig := createChatModelConfig(t, client)
 
 		chat, err := db.InsertChat(dbauthz.AsSystemRestricted(ctx), database.InsertChatParams{
@@ -3031,7 +3045,7 @@ func TestInterruptChat(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 
 		_, err := client.InterruptChat(ctx, uuid.New())
 		requireSDKError(t, err, http.StatusNotFound)
@@ -3045,7 +3059,7 @@ func TestGetChatDiffStatus(t *testing.T) {
 		t.Parallel()
 
 		ctx := testutil.Context(t, testutil.WaitLong)
-		client, _, api := coderdtest.NewWithAPI(t, &coderdtest.Options{
+		rawClient, _, api := coderdtest.NewWithAPI(t, &coderdtest.Options{
 			DeploymentValues: chatDeploymentValues(t),
 			ExternalAuthConfigs: []*externalauth.Config{
 				{
@@ -3055,9 +3069,10 @@ func TestGetChatDiffStatus(t *testing.T) {
 				},
 			},
 		})
+		client := codersdk.NewExperimentalClient(rawClient)
 		db := api.Database
 
-		user := coderdtest.CreateFirstUser(t, client)
+		user := coderdtest.CreateFirstUser(t, client.Client)
 		modelConfig := createChatModelConfig(t, client)
 
 		noCachedStatusChat, err := db.InsertChat(dbauthz.AsSystemRestricted(ctx), database.InsertChatParams{
@@ -3137,7 +3152,7 @@ func TestGetChatDiffStatus(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		firstUser := coderdtest.CreateFirstUser(t, client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 		_ = createChatModelConfig(t, client)
 
 		createdChat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
@@ -3150,7 +3165,8 @@ func TestGetChatDiffStatus(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		otherClient, _ := coderdtest.CreateAnotherUser(t, client, firstUser.OrganizationID)
+		otherClientRaw, _ := coderdtest.CreateAnotherUser(t, client.Client, firstUser.OrganizationID)
+		otherClient := codersdk.NewExperimentalClient(otherClientRaw)
 		_, err = otherClient.GetChat(ctx, createdChat.ID)
 		requireSDKError(t, err, http.StatusNotFound)
 	})
@@ -3203,7 +3219,7 @@ func TestGetChatDiffStatus(t *testing.T) {
 		const providerID = "test-github"
 		fake := oidctest.NewFakeIDP(t, oidctest.WithServing())
 
-		client, _, api := coderdtest.NewWithAPI(t, &coderdtest.Options{
+		rawClient, _, api := coderdtest.NewWithAPI(t, &coderdtest.Options{
 			DeploymentValues: chatDeploymentValues(t),
 			ExternalAuthConfigs: []*externalauth.Config{
 				fake.ExternalAuthConfig(t, providerID, nil, func(cfg *externalauth.Config) {
@@ -3215,19 +3231,19 @@ func TestGetChatDiffStatus(t *testing.T) {
 				}),
 			},
 		})
+		client := codersdk.NewExperimentalClient(rawClient)
 		db := api.Database
 
 		// Use the TLS mock server's HTTP client (which trusts its
 		// self-signed cert) for git provider API calls.
 		api.HTTPClient = ghAPI.Client()
-
-		user := coderdtest.CreateFirstUser(t, client)
+		user := coderdtest.CreateFirstUser(t, client.Client)
 		modelConfig := createChatModelConfig(t, client)
 
 		// Log in to the external auth provider so the user has an
 		// ExternalAuthLink row in the DB. This is what
 		// resolveChatGitAccessToken reads via GetExternalAuthLink.
-		fake.ExternalLogin(t, client)
+		fake.ExternalLogin(t, client.Client)
 
 		// Insert a chat owned by the user.
 		chat, err := db.InsertChat(dbauthz.AsSystemRestricted(ctx), database.InsertChatParams{
@@ -3290,7 +3306,7 @@ func TestGetChatDiffContents(t *testing.T) {
 		t.Parallel()
 
 		ctx := testutil.Context(t, testutil.WaitLong)
-		client, _, api := coderdtest.NewWithAPI(t, &coderdtest.Options{
+		rawClient, _, api := coderdtest.NewWithAPI(t, &coderdtest.Options{
 			DeploymentValues: chatDeploymentValues(t),
 			ExternalAuthConfigs: []*externalauth.Config{
 				{
@@ -3300,10 +3316,10 @@ func TestGetChatDiffContents(t *testing.T) {
 				},
 			},
 		})
+		client := codersdk.NewExperimentalClient(rawClient)
 		db := api.Database
-		user := coderdtest.CreateFirstUser(t, client)
+		user := coderdtest.CreateFirstUser(t, client.Client)
 		modelConfig := createChatModelConfig(t, client)
-
 		chat, err := db.InsertChat(dbauthz.AsSystemRestricted(ctx), database.InsertChatParams{
 			OwnerID:           user.UserID,
 			LastModelConfigID: modelConfig.ID,
@@ -3341,7 +3357,7 @@ func TestGetChatDiffContents(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 		_ = createChatModelConfig(t, client)
 
 		chat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
@@ -3369,7 +3385,7 @@ func TestGetChatDiffContents(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		firstUser := coderdtest.CreateFirstUser(t, client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 		_ = createChatModelConfig(t, client)
 
 		createdChat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
@@ -3382,7 +3398,8 @@ func TestGetChatDiffContents(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		otherClient, _ := coderdtest.CreateAnotherUser(t, client, firstUser.OrganizationID)
+		otherClientRaw, _ := coderdtest.CreateAnotherUser(t, client.Client, firstUser.OrganizationID)
+		otherClient := codersdk.NewExperimentalClient(otherClientRaw)
 		_, err = otherClient.GetChatDiffContents(ctx, createdChat.ID)
 		requireSDKError(t, err, http.StatusNotFound)
 	})
@@ -3396,7 +3413,7 @@ func TestDeleteChatQueuedMessage(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client, db := newChatClientWithDatabase(t)
-		user := coderdtest.CreateFirstUser(t, client)
+		user := coderdtest.CreateFirstUser(t, client.Client)
 		modelConfig := createChatModelConfig(t, client)
 
 		chat, err := db.InsertChat(dbauthz.AsSystemRestricted(ctx), database.InsertChatParams{
@@ -3447,7 +3464,7 @@ func TestDeleteChatQueuedMessage(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client, db := newChatClientWithDatabase(t)
-		user := coderdtest.CreateFirstUser(t, client)
+		user := coderdtest.CreateFirstUser(t, client.Client)
 		modelConfig := createChatModelConfig(t, client)
 
 		chat, err := db.InsertChat(dbauthz.AsSystemRestricted(ctx), database.InsertChatParams{
@@ -3481,7 +3498,7 @@ func TestPromoteChatQueuedMessage(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client, db := newChatClientWithDatabase(t)
-		user := coderdtest.CreateFirstUser(t, client)
+		user := coderdtest.CreateFirstUser(t, client.Client)
 		modelConfig := createChatModelConfig(t, client)
 
 		chat, err := db.InsertChat(dbauthz.AsSystemRestricted(ctx), database.InsertChatParams{
@@ -3550,7 +3567,7 @@ func TestPromoteChatQueuedMessage(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client, db := newChatClientWithDatabase(t)
-		user := coderdtest.CreateFirstUser(t, client)
+		user := coderdtest.CreateFirstUser(t, client.Client)
 		modelConfig := createChatModelConfig(t, client)
 		enableDailyChatUsageLimit(ctx, t, db, 100)
 
@@ -3625,7 +3642,7 @@ func TestPromoteChatQueuedMessage(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client, db := newChatClientWithDatabase(t)
-		user := coderdtest.CreateFirstUser(t, client)
+		user := coderdtest.CreateFirstUser(t, client.Client)
 		modelConfig := createChatModelConfig(t, client)
 
 		chat, err := db.InsertChat(dbauthz.AsSystemRestricted(ctx), database.InsertChatParams{
@@ -3659,8 +3676,8 @@ func TestChatUsageLimitOverrideRoutes(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client, _ := newChatClientWithDatabase(t)
-		firstUser := coderdtest.CreateFirstUser(t, client)
-		_, member := coderdtest.CreateAnotherUser(t, client, firstUser.OrganizationID)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
+		_, member := coderdtest.CreateAnotherUser(t, client.Client, firstUser.OrganizationID)
 
 		res, err := client.Request(
 			ctx,
@@ -3682,7 +3699,7 @@ func TestChatUsageLimitOverrideRoutes(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 
 		_, err := client.UpsertChatUsageLimitOverride(ctx, uuid.New(), codersdk.UpsertChatUsageLimitOverrideRequest{
 			SpendLimitMicros: 7_000_000,
@@ -3696,7 +3713,7 @@ func TestChatUsageLimitOverrideRoutes(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 
 		err := client.DeleteChatUsageLimitOverride(ctx, uuid.New())
 		sdkErr := requireSDKError(t, err, http.StatusBadRequest)
@@ -3708,8 +3725,8 @@ func TestChatUsageLimitOverrideRoutes(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		firstUser := coderdtest.CreateFirstUser(t, client)
-		_, member := coderdtest.CreateAnotherUser(t, client, firstUser.OrganizationID)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
+		_, member := coderdtest.CreateAnotherUser(t, client.Client, firstUser.OrganizationID)
 
 		err := client.DeleteChatUsageLimitOverride(ctx, member.ID)
 		sdkErr := requireSDKError(t, err, http.StatusBadRequest)
@@ -3721,8 +3738,8 @@ func TestChatUsageLimitOverrideRoutes(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client, _ := newChatClientWithDatabase(t)
-		firstUser := coderdtest.CreateFirstUser(t, client)
-		_, member := coderdtest.CreateAnotherUser(t, client, firstUser.OrganizationID)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
+		_, member := coderdtest.CreateAnotherUser(t, client.Client, firstUser.OrganizationID)
 
 		_, err := client.UpsertChatUsageLimitOverride(ctx, member.ID, codersdk.UpsertChatUsageLimitOverrideRequest{
 			SpendLimitMicros: 5_000_000,
@@ -3750,8 +3767,8 @@ func TestChatUsageLimitOverrideRoutes(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client, db := newChatClientWithDatabase(t)
-		firstUser := coderdtest.CreateFirstUser(t, client)
-		_, member := coderdtest.CreateAnotherUser(t, client, firstUser.OrganizationID)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
+		_, member := coderdtest.CreateAnotherUser(t, client.Client, firstUser.OrganizationID)
 		group := dbgen.Group(t, db, database.Group{OrganizationID: firstUser.OrganizationID})
 		dbgen.GroupMember(t, db, database.GroupMemberTable{GroupID: group.ID, UserID: member.ID})
 		dbgen.GroupMember(t, db, database.GroupMemberTable{GroupID: group.ID, UserID: database.PrebuildsSystemUserID})
@@ -3784,8 +3801,8 @@ func TestChatUsageLimitOverrideRoutes(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client, db := newChatClientWithDatabase(t)
-		firstUser := coderdtest.CreateFirstUser(t, client)
-		_, member := coderdtest.CreateAnotherUser(t, client, firstUser.OrganizationID)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
+		_, member := coderdtest.CreateAnotherUser(t, client.Client, firstUser.OrganizationID)
 		group := dbgen.Group(t, db, database.Group{OrganizationID: firstUser.OrganizationID})
 		dbgen.GroupMember(t, db, database.GroupMemberTable{GroupID: group.ID, UserID: firstUser.UserID})
 		dbgen.GroupMember(t, db, database.GroupMemberTable{GroupID: group.ID, UserID: member.ID})
@@ -3818,7 +3835,7 @@ func TestChatUsageLimitOverrideRoutes(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 
 		_, err := client.UpsertChatUsageLimitGroupOverride(ctx, uuid.New(), codersdk.UpsertChatUsageLimitGroupOverrideRequest{
 			SpendLimitMicros: 7_000_000,
@@ -3832,7 +3849,7 @@ func TestChatUsageLimitOverrideRoutes(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client, db := newChatClientWithDatabase(t)
-		firstUser := coderdtest.CreateFirstUser(t, client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 		group := dbgen.Group(t, db, database.Group{OrganizationID: firstUser.OrganizationID})
 
 		err := client.DeleteChatUsageLimitGroupOverride(ctx, group.ID)
@@ -3848,7 +3865,7 @@ func TestPostChatFile(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		firstUser := coderdtest.CreateFirstUser(t, client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 
 		// Valid PNG header + padding.
 		data := append([]byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}, make([]byte, 64)...)
@@ -3861,7 +3878,7 @@ func TestPostChatFile(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		firstUser := coderdtest.CreateFirstUser(t, client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 
 		data := append([]byte{0xFF, 0xD8, 0xFF, 0xE0}, make([]byte, 64)...)
 		resp, err := client.UploadChatFile(ctx, firstUser.OrganizationID, "image/jpeg", "test.jpg", bytes.NewReader(data))
@@ -3873,7 +3890,7 @@ func TestPostChatFile(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		firstUser := coderdtest.CreateFirstUser(t, client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 
 		// WebP: RIFF + 4-byte size + WEBP + padding.
 		data := append([]byte("RIFF"), make([]byte, 4)...)
@@ -3888,7 +3905,7 @@ func TestPostChatFile(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		firstUser := coderdtest.CreateFirstUser(t, client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 
 		_, err := client.UploadChatFile(ctx, firstUser.OrganizationID, "text/plain", "test.txt", bytes.NewReader([]byte("hello")))
 		requireSDKError(t, err, http.StatusBadRequest)
@@ -3898,7 +3915,7 @@ func TestPostChatFile(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		firstUser := coderdtest.CreateFirstUser(t, client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 
 		_, err := client.UploadChatFile(ctx, firstUser.OrganizationID, "image/svg+xml", "test.svg", bytes.NewReader([]byte("<svg></svg>")))
 		requireSDKError(t, err, http.StatusBadRequest)
@@ -3908,7 +3925,7 @@ func TestPostChatFile(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		firstUser := coderdtest.CreateFirstUser(t, client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 
 		// Header says PNG but body is plain text.
 		_, err := client.UploadChatFile(ctx, firstUser.OrganizationID, "image/png", "test.png", bytes.NewReader([]byte("hello world")))
@@ -3919,7 +3936,7 @@ func TestPostChatFile(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		firstUser := coderdtest.CreateFirstUser(t, client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 
 		// 10 MB + 1 byte, with valid PNG header to pass MIME check.
 		data := make([]byte, 10<<20+1)
@@ -3932,7 +3949,7 @@ func TestPostChatFile(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		coderdtest.CreateFirstUser(t, client)
+		coderdtest.CreateFirstUser(t, client.Client)
 
 		data := append([]byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}, make([]byte, 64)...)
 		res, err := client.Request(ctx, http.MethodPost, "/api/experimental/chats/files", bytes.NewReader(data), func(r *http.Request) {
@@ -3949,7 +3966,7 @@ func TestPostChatFile(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		coderdtest.CreateFirstUser(t, client)
+		coderdtest.CreateFirstUser(t, client.Client)
 
 		data := append([]byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}, make([]byte, 64)...)
 		res, err := client.Request(ctx, http.MethodPost, "/api/experimental/chats/files?organization=not-a-uuid", bytes.NewReader(data), func(r *http.Request) {
@@ -3966,7 +3983,7 @@ func TestPostChatFile(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		coderdtest.CreateFirstUser(t, client)
+		coderdtest.CreateFirstUser(t, client.Client)
 
 		data := append([]byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}, make([]byte, 64)...)
 		_, err := client.UploadChatFile(ctx, uuid.New(), "image/png", "test.png", bytes.NewReader(data))
@@ -3983,9 +4000,9 @@ func TestPostChatFile(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		firstUser := coderdtest.CreateFirstUser(t, client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 
-		unauthed := codersdk.New(client.URL)
+		unauthed := codersdk.NewExperimentalClient(codersdk.New(client.URL))
 		data := append([]byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}, make([]byte, 64)...)
 		_, err := unauthed.UploadChatFile(ctx, firstUser.OrganizationID, "image/png", "test.png", bytes.NewReader(data))
 		requireSDKError(t, err, http.StatusUnauthorized)
@@ -3999,7 +4016,7 @@ func TestGetChatFile(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		firstUser := coderdtest.CreateFirstUser(t, client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 
 		data := append([]byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}, make([]byte, 64)...)
 		uploaded, err := client.UploadChatFile(ctx, firstUser.OrganizationID, "image/png", "test.png", bytes.NewReader(data))
@@ -4015,7 +4032,7 @@ func TestGetChatFile(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		firstUser := coderdtest.CreateFirstUser(t, client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 
 		data := append([]byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}, make([]byte, 64)...)
 		uploaded, err := client.UploadChatFile(ctx, firstUser.OrganizationID, "image/png", "test.png", bytes.NewReader(data))
@@ -4035,7 +4052,7 @@ func TestGetChatFile(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		firstUser := coderdtest.CreateFirstUser(t, client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 
 		longName := strings.Repeat("a", 300) + ".png"
 		data := append([]byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}, make([]byte, 64)...)
@@ -4058,7 +4075,7 @@ func TestGetChatFile(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		firstUser := coderdtest.CreateFirstUser(t, client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 
 		// Upload with a non-ASCII filename using RFC 5987 encoding,
 		// which is what the frontend sends for Unicode filenames.
@@ -4082,7 +4099,7 @@ func TestGetChatFile(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		coderdtest.CreateFirstUser(t, client)
+		coderdtest.CreateFirstUser(t, client.Client)
 
 		_, _, err := client.GetChatFile(ctx, uuid.New())
 		requireSDKError(t, err, http.StatusNotFound)
@@ -4092,7 +4109,7 @@ func TestGetChatFile(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		coderdtest.CreateFirstUser(t, client)
+		coderdtest.CreateFirstUser(t, client.Client)
 
 		res, err := client.Request(ctx, http.MethodGet,
 			"/api/experimental/chats/files/not-a-uuid", nil)
@@ -4106,20 +4123,21 @@ func TestGetChatFile(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		firstUser := coderdtest.CreateFirstUser(t, client)
+		firstUser := coderdtest.CreateFirstUser(t, client.Client)
 
 		data := append([]byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}, make([]byte, 64)...)
 		uploaded, err := client.UploadChatFile(ctx, firstUser.OrganizationID, "image/png", "test.png", bytes.NewReader(data))
 		require.NoError(t, err)
 
-		otherClient, _ := coderdtest.CreateAnotherUser(t, client, firstUser.OrganizationID)
+		otherClientRaw, _ := coderdtest.CreateAnotherUser(t, client.Client, firstUser.OrganizationID)
+		otherClient := codersdk.NewExperimentalClient(otherClientRaw)
 		_, _, err = otherClient.GetChatFile(ctx, uploaded.ID)
 		requireSDKError(t, err, http.StatusNotFound)
 	})
 }
 
 type chatCostTestFixture struct {
-	Client            *codersdk.Client
+	Client            *codersdk.ExperimentalClient
 	DB                database.Store
 	ModelConfigID     uuid.UUID
 	ChatID            uuid.UUID
@@ -4141,7 +4159,7 @@ func seedChatCostFixture(t *testing.T) chatCostTestFixture {
 
 	ctx := testutil.Context(t, testutil.WaitLong)
 	client, db := newChatClientWithDatabase(t)
-	firstUser := coderdtest.CreateFirstUser(t, client)
+	firstUser := coderdtest.CreateFirstUser(t, client.Client)
 	modelConfig := createChatModelConfig(t, client)
 
 	chat, err := db.InsertChat(dbauthz.AsSystemRestricted(ctx), database.InsertChatParams{
@@ -4256,8 +4274,9 @@ func TestChatCostSummary_AdminDrilldown(t *testing.T) {
 
 	seedCtx := testutil.Context(t, testutil.WaitLong)
 	client, db := newChatClientWithDatabase(t)
-	firstUser := coderdtest.CreateFirstUser(t, client)
-	memberClient, member := coderdtest.CreateAnotherUser(t, client, firstUser.OrganizationID)
+	firstUser := coderdtest.CreateFirstUser(t, client.Client)
+	memberClientRaw, member := coderdtest.CreateAnotherUser(t, client.Client, firstUser.OrganizationID)
+	memberClient := codersdk.NewExperimentalClient(memberClientRaw)
 	modelConfig := createChatModelConfig(t, client)
 
 	chat, err := db.InsertChat(dbauthz.AsSystemRestricted(seedCtx), database.InsertChatParams{
@@ -4321,8 +4340,9 @@ func TestChatCostUsers(t *testing.T) {
 
 	seedCtx := testutil.Context(t, testutil.WaitLong)
 	client, db := newChatClientWithDatabase(t)
-	firstUser := coderdtest.CreateFirstUser(t, client)
-	memberClient, member := coderdtest.CreateAnotherUser(t, client, firstUser.OrganizationID)
+	firstUser := coderdtest.CreateFirstUser(t, client.Client)
+	memberClientRaw, member := coderdtest.CreateAnotherUser(t, client.Client, firstUser.OrganizationID)
+	memberClient := codersdk.NewExperimentalClient(memberClientRaw)
 	firstUserRecord, err := db.GetUserByID(dbauthz.AsSystemRestricted(seedCtx), firstUser.UserID)
 	require.NoError(t, err)
 	modelConfig := createChatModelConfig(t, client)
@@ -4434,7 +4454,7 @@ func TestChatCostSummary_DateRange(t *testing.T) {
 
 	seedCtx := testutil.Context(t, testutil.WaitLong)
 	client, db := newChatClientWithDatabase(t)
-	firstUser := coderdtest.CreateFirstUser(t, client)
+	firstUser := coderdtest.CreateFirstUser(t, client.Client)
 	modelConfig := createChatModelConfig(t, client)
 
 	chat, err := db.InsertChat(dbauthz.AsSystemRestricted(seedCtx), database.InsertChatParams{
@@ -4499,7 +4519,7 @@ func TestChatCostSummary_UnpricedMessages(t *testing.T) {
 
 	ctx := testutil.Context(t, testutil.WaitLong)
 	client, db := newChatClientWithDatabase(t)
-	firstUser := coderdtest.CreateFirstUser(t, client)
+	firstUser := coderdtest.CreateFirstUser(t, client.Client)
 	modelConfig := createChatModelConfig(t, client)
 
 	chat, err := db.InsertChat(dbauthz.AsSystemRestricted(ctx), database.InsertChatParams{
@@ -4612,7 +4632,7 @@ func TestWatchChatDesktop(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
 		_ = createChatModelConfig(t, client)
 
 		createdChat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
@@ -4639,7 +4659,7 @@ func TestWatchChatDesktop(t *testing.T) {
 	})
 }
 
-func createChatModelConfig(t *testing.T, client *codersdk.Client) codersdk.ChatModelConfig {
+func createChatModelConfig(t *testing.T, client *codersdk.ExperimentalClient) codersdk.ChatModelConfig {
 	t.Helper()
 
 	ctx := testutil.Context(t, testutil.WaitLong)
@@ -4666,8 +4686,9 @@ func TestChatSystemPrompt(t *testing.T) {
 	t.Parallel()
 
 	adminClient := newChatClient(t)
-	firstUser := coderdtest.CreateFirstUser(t, adminClient)
-	memberClient, _ := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID)
+	firstUser := coderdtest.CreateFirstUser(t, adminClient.Client)
+	memberClientRaw, _ := coderdtest.CreateAnotherUser(t, adminClient.Client, firstUser.OrganizationID)
+	memberClient := codersdk.NewExperimentalClient(memberClientRaw)
 
 	t.Run("ReturnsEmptyWhenUnset", func(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitLong)
@@ -4717,7 +4738,7 @@ func TestChatSystemPrompt(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
 
-		anonClient := codersdk.New(adminClient.URL)
+		anonClient := codersdk.NewExperimentalClient(codersdk.New(adminClient.URL))
 		_, err := anonClient.GetChatSystemPrompt(ctx)
 		var sdkErr *codersdk.Error
 		require.ErrorAs(t, err, &sdkErr)
@@ -4744,7 +4765,7 @@ func TestChatDesktopEnabled(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitLong)
 
 		adminClient := newChatClient(t)
-		coderdtest.CreateFirstUser(t, adminClient)
+		coderdtest.CreateFirstUser(t, adminClient.Client)
 
 		resp, err := adminClient.GetChatDesktopEnabled(ctx)
 		require.NoError(t, err)
@@ -4756,7 +4777,7 @@ func TestChatDesktopEnabled(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitLong)
 
 		adminClient := newChatClient(t)
-		coderdtest.CreateFirstUser(t, adminClient)
+		coderdtest.CreateFirstUser(t, adminClient.Client)
 
 		err := adminClient.UpdateChatDesktopEnabled(ctx, codersdk.UpdateChatDesktopEnabledRequest{
 			EnableDesktop: true,
@@ -4773,7 +4794,7 @@ func TestChatDesktopEnabled(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitLong)
 
 		adminClient := newChatClient(t)
-		coderdtest.CreateFirstUser(t, adminClient)
+		coderdtest.CreateFirstUser(t, adminClient.Client)
 
 		// Set true first, then set false.
 		err := adminClient.UpdateChatDesktopEnabled(ctx, codersdk.UpdateChatDesktopEnabledRequest{
@@ -4796,8 +4817,9 @@ func TestChatDesktopEnabled(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitLong)
 
 		adminClient := newChatClient(t)
-		firstUser := coderdtest.CreateFirstUser(t, adminClient)
-		memberClient, _ := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID)
+		firstUser := coderdtest.CreateFirstUser(t, adminClient.Client)
+		memberClientRaw, _ := coderdtest.CreateAnotherUser(t, adminClient.Client, firstUser.OrganizationID)
+		memberClient := codersdk.NewExperimentalClient(memberClientRaw)
 
 		err := adminClient.UpdateChatDesktopEnabled(ctx, codersdk.UpdateChatDesktopEnabledRequest{
 			EnableDesktop: true,
@@ -4814,8 +4836,9 @@ func TestChatDesktopEnabled(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitLong)
 
 		adminClient := newChatClient(t)
-		firstUser := coderdtest.CreateFirstUser(t, adminClient)
-		memberClient, _ := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID)
+		firstUser := coderdtest.CreateFirstUser(t, adminClient.Client)
+		memberClientRaw, _ := coderdtest.CreateAnotherUser(t, adminClient.Client, firstUser.OrganizationID)
+		memberClient := codersdk.NewExperimentalClient(memberClientRaw)
 
 		err := memberClient.UpdateChatDesktopEnabled(ctx, codersdk.UpdateChatDesktopEnabledRequest{
 			EnableDesktop: true,
@@ -4828,9 +4851,9 @@ func TestChatDesktopEnabled(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitLong)
 
 		adminClient := newChatClient(t)
-		coderdtest.CreateFirstUser(t, adminClient)
+		coderdtest.CreateFirstUser(t, adminClient.Client)
 
-		anonClient := codersdk.New(adminClient.URL)
+		anonClient := codersdk.NewExperimentalClient(codersdk.New(adminClient.URL))
 		_, err := anonClient.GetChatDesktopEnabled(ctx)
 		var sdkErr *codersdk.Error
 		require.ErrorAs(t, err, &sdkErr)
@@ -4843,9 +4866,10 @@ func TestChatWorkspaceTTL(t *testing.T) {
 	ctx := testutil.Context(t, testutil.WaitLong)
 
 	adminClient := newChatClient(t)
-	firstUser := coderdtest.CreateFirstUser(t, adminClient)
-	memberClient, _ := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID)
-	anonClient := codersdk.New(adminClient.URL)
+	firstUser := coderdtest.CreateFirstUser(t, adminClient.Client)
+	memberClientRaw, _ := coderdtest.CreateAnotherUser(t, adminClient.Client, firstUser.OrganizationID)
+	memberClient := codersdk.NewExperimentalClient(memberClientRaw)
+	anonClient := codersdk.NewExperimentalClient(codersdk.New(adminClient.URL))
 
 	// Default value is 0 (disabled) when nothing has been configured.
 	resp, err := adminClient.GetChatWorkspaceTTL(ctx)

--- a/coderd/mcp_test.go
+++ b/coderd/mcp_test.go
@@ -437,14 +437,16 @@ func TestChatWithMCPServerIDs(t *testing.T) {
 	client := newMCPClient(t)
 	_ = coderdtest.CreateFirstUser(t, client)
 
+	expClient := codersdk.NewExperimentalClient(client)
+
 	// Create the chat model config required for creating a chat.
-	_ = createChatModelConfigForMCP(t, client)
+	_ = createChatModelConfigForMCP(t, expClient)
 
 	// Create an enabled MCP server config.
 	mcpConfig := createMCPServerConfig(t, client, "chat-mcp-server", true)
 
 	// Create a chat referencing the MCP server.
-	chat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
+	chat, err := expClient.CreateChat(ctx, codersdk.CreateChatRequest{
 		Content: []codersdk.ChatInputPart{
 			{
 				Type: codersdk.ChatInputPartTypeText,
@@ -458,7 +460,7 @@ func TestChatWithMCPServerIDs(t *testing.T) {
 	require.Contains(t, chat.MCPServerIDs, mcpConfig.ID)
 
 	// Fetch the chat and verify the MCP server IDs persist.
-	fetched, err := client.GetChat(ctx, chat.ID)
+	fetched, err := expClient.GetChat(ctx, chat.ID)
 	require.NoError(t, err)
 	require.Contains(t, fetched.MCPServerIDs, mcpConfig.ID)
 }
@@ -466,7 +468,7 @@ func TestChatWithMCPServerIDs(t *testing.T) {
 // createChatModelConfigForMCP sets up a chat provider and model
 // config so that CreateChat succeeds. This mirrors the helper in
 // chats_test.go but is defined here to avoid coupling.
-func createChatModelConfigForMCP(t testing.TB, client *codersdk.Client) codersdk.ChatModelConfig {
+func createChatModelConfigForMCP(t testing.TB, client *codersdk.ExperimentalClient) codersdk.ChatModelConfig {
 	t.Helper()
 
 	ctx := testutil.Context(t, testutil.WaitLong)

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -1084,7 +1084,7 @@ type ListChatsOptions struct {
 }
 
 // ListChats returns all chats for the authenticated user.
-func (c *Client) ListChats(ctx context.Context, opts *ListChatsOptions) ([]Chat, error) {
+func (c *ExperimentalClient) ListChats(ctx context.Context, opts *ListChatsOptions) ([]Chat, error) {
 	var reqOpts []RequestOption
 	if opts != nil {
 		reqOpts = append(reqOpts, opts.Pagination.asRequestOption())
@@ -1109,7 +1109,7 @@ func (c *Client) ListChats(ctx context.Context, opts *ListChatsOptions) ([]Chat,
 }
 
 // ListChatModels returns the available chat model catalog.
-func (c *Client) ListChatModels(ctx context.Context) (ChatModelsResponse, error) {
+func (c *ExperimentalClient) ListChatModels(ctx context.Context) (ChatModelsResponse, error) {
 	res, err := c.Request(ctx, http.MethodGet, "/api/experimental/chats/models", nil)
 	if err != nil {
 		return ChatModelsResponse{}, err
@@ -1124,7 +1124,7 @@ func (c *Client) ListChatModels(ctx context.Context) (ChatModelsResponse, error)
 }
 
 // ListChatProviders returns admin-managed chat provider configs.
-func (c *Client) ListChatProviders(ctx context.Context) ([]ChatProviderConfig, error) {
+func (c *ExperimentalClient) ListChatProviders(ctx context.Context) ([]ChatProviderConfig, error) {
 	res, err := c.Request(ctx, http.MethodGet, "/api/experimental/chats/providers", nil)
 	if err != nil {
 		return nil, err
@@ -1139,7 +1139,7 @@ func (c *Client) ListChatProviders(ctx context.Context) ([]ChatProviderConfig, e
 }
 
 // CreateChatProvider creates an admin-managed chat provider config.
-func (c *Client) CreateChatProvider(ctx context.Context, req CreateChatProviderConfigRequest) (ChatProviderConfig, error) {
+func (c *ExperimentalClient) CreateChatProvider(ctx context.Context, req CreateChatProviderConfigRequest) (ChatProviderConfig, error) {
 	res, err := c.Request(ctx, http.MethodPost, "/api/experimental/chats/providers", req)
 	if err != nil {
 		return ChatProviderConfig{}, err
@@ -1154,7 +1154,7 @@ func (c *Client) CreateChatProvider(ctx context.Context, req CreateChatProviderC
 }
 
 // UpdateChatProvider updates an admin-managed chat provider config.
-func (c *Client) UpdateChatProvider(ctx context.Context, providerID uuid.UUID, req UpdateChatProviderConfigRequest) (ChatProviderConfig, error) {
+func (c *ExperimentalClient) UpdateChatProvider(ctx context.Context, providerID uuid.UUID, req UpdateChatProviderConfigRequest) (ChatProviderConfig, error) {
 	res, err := c.Request(ctx, http.MethodPatch, fmt.Sprintf("/api/experimental/chats/providers/%s", providerID), req)
 	if err != nil {
 		return ChatProviderConfig{}, err
@@ -1169,7 +1169,7 @@ func (c *Client) UpdateChatProvider(ctx context.Context, providerID uuid.UUID, r
 }
 
 // DeleteChatProvider deletes an admin-managed chat provider config.
-func (c *Client) DeleteChatProvider(ctx context.Context, providerID uuid.UUID) error {
+func (c *ExperimentalClient) DeleteChatProvider(ctx context.Context, providerID uuid.UUID) error {
 	res, err := c.Request(ctx, http.MethodDelete, fmt.Sprintf("/api/experimental/chats/providers/%s", providerID), nil)
 	if err != nil {
 		return err
@@ -1182,7 +1182,7 @@ func (c *Client) DeleteChatProvider(ctx context.Context, providerID uuid.UUID) e
 }
 
 // ListChatModelConfigs returns admin-managed chat model configs.
-func (c *Client) ListChatModelConfigs(ctx context.Context) ([]ChatModelConfig, error) {
+func (c *ExperimentalClient) ListChatModelConfigs(ctx context.Context) ([]ChatModelConfig, error) {
 	res, err := c.Request(ctx, http.MethodGet, "/api/experimental/chats/model-configs", nil)
 	if err != nil {
 		return nil, err
@@ -1197,7 +1197,7 @@ func (c *Client) ListChatModelConfigs(ctx context.Context) ([]ChatModelConfig, e
 }
 
 // CreateChatModelConfig creates an admin-managed chat model config.
-func (c *Client) CreateChatModelConfig(ctx context.Context, req CreateChatModelConfigRequest) (ChatModelConfig, error) {
+func (c *ExperimentalClient) CreateChatModelConfig(ctx context.Context, req CreateChatModelConfigRequest) (ChatModelConfig, error) {
 	res, err := c.Request(ctx, http.MethodPost, "/api/experimental/chats/model-configs", req)
 	if err != nil {
 		return ChatModelConfig{}, err
@@ -1212,7 +1212,7 @@ func (c *Client) CreateChatModelConfig(ctx context.Context, req CreateChatModelC
 }
 
 // UpdateChatModelConfig updates an admin-managed chat model config.
-func (c *Client) UpdateChatModelConfig(ctx context.Context, modelConfigID uuid.UUID, req UpdateChatModelConfigRequest) (ChatModelConfig, error) {
+func (c *ExperimentalClient) UpdateChatModelConfig(ctx context.Context, modelConfigID uuid.UUID, req UpdateChatModelConfigRequest) (ChatModelConfig, error) {
 	res, err := c.Request(ctx, http.MethodPatch, fmt.Sprintf("/api/experimental/chats/model-configs/%s", modelConfigID), req)
 	if err != nil {
 		return ChatModelConfig{}, err
@@ -1227,7 +1227,7 @@ func (c *Client) UpdateChatModelConfig(ctx context.Context, modelConfigID uuid.U
 }
 
 // DeleteChatModelConfig deletes an admin-managed chat model config.
-func (c *Client) DeleteChatModelConfig(ctx context.Context, modelConfigID uuid.UUID) error {
+func (c *ExperimentalClient) DeleteChatModelConfig(ctx context.Context, modelConfigID uuid.UUID) error {
 	res, err := c.Request(ctx, http.MethodDelete, fmt.Sprintf("/api/experimental/chats/model-configs/%s", modelConfigID), nil)
 	if err != nil {
 		return err
@@ -1243,7 +1243,7 @@ func (c *Client) DeleteChatModelConfig(ctx context.Context, modelConfigID uuid.U
 // user. Zero-valued StartDate or EndDate fields are omitted from the
 // request, letting the server apply its own defaults (typically the last
 // 30 days).
-func (c *Client) GetChatCostSummary(ctx context.Context, user string, opts ChatCostSummaryOptions) (ChatCostSummary, error) {
+func (c *ExperimentalClient) GetChatCostSummary(ctx context.Context, user string, opts ChatCostSummaryOptions) (ChatCostSummary, error) {
 	qp := url.Values{}
 	if !opts.StartDate.IsZero() {
 		qp.Set("start_date", opts.StartDate.Format(time.RFC3339))
@@ -1271,7 +1271,7 @@ func (c *Client) GetChatCostSummary(ctx context.Context, user string, opts ChatC
 // (admin only). Zero-valued StartDate or EndDate fields are omitted from
 // the request, letting the server apply its own defaults (typically the
 // last 30 days).
-func (c *Client) GetChatCostUsers(ctx context.Context, opts ChatCostUsersOptions) (ChatCostUsersResponse, error) {
+func (c *ExperimentalClient) GetChatCostUsers(ctx context.Context, opts ChatCostUsersOptions) (ChatCostUsersResponse, error) {
 	qp := url.Values{}
 	if !opts.StartDate.IsZero() {
 		qp.Set("start_date", opts.StartDate.Format(time.RFC3339))
@@ -1305,7 +1305,7 @@ func (c *Client) GetChatCostUsers(ctx context.Context, opts ChatCostUsersOptions
 }
 
 // GetChatSystemPrompt returns the deployment-wide chat system prompt.
-func (c *Client) GetChatSystemPrompt(ctx context.Context) (ChatSystemPrompt, error) {
+func (c *ExperimentalClient) GetChatSystemPrompt(ctx context.Context) (ChatSystemPrompt, error) {
 	res, err := c.Request(ctx, http.MethodGet, "/api/experimental/chats/config/system-prompt", nil)
 	if err != nil {
 		return ChatSystemPrompt{}, err
@@ -1319,7 +1319,7 @@ func (c *Client) GetChatSystemPrompt(ctx context.Context) (ChatSystemPrompt, err
 }
 
 // UpdateChatSystemPrompt updates the deployment-wide chat system prompt.
-func (c *Client) UpdateChatSystemPrompt(ctx context.Context, req ChatSystemPrompt) error {
+func (c *ExperimentalClient) UpdateChatSystemPrompt(ctx context.Context, req ChatSystemPrompt) error {
 	res, err := c.Request(ctx, http.MethodPut, "/api/experimental/chats/config/system-prompt", req)
 	if err != nil {
 		return err
@@ -1332,7 +1332,7 @@ func (c *Client) UpdateChatSystemPrompt(ctx context.Context, req ChatSystemPromp
 }
 
 // GetUserChatCustomPrompt fetches the user's custom chat prompt.
-func (c *Client) GetUserChatCustomPrompt(ctx context.Context) (UserChatCustomPrompt, error) {
+func (c *ExperimentalClient) GetUserChatCustomPrompt(ctx context.Context) (UserChatCustomPrompt, error) {
 	res, err := c.Request(ctx, http.MethodGet, "/api/experimental/chats/config/user-prompt", nil)
 	if err != nil {
 		return UserChatCustomPrompt{}, err
@@ -1346,7 +1346,7 @@ func (c *Client) GetUserChatCustomPrompt(ctx context.Context) (UserChatCustomPro
 }
 
 // GetChatDesktopEnabled returns the deployment-wide desktop setting.
-func (c *Client) GetChatDesktopEnabled(ctx context.Context) (ChatDesktopEnabledResponse, error) {
+func (c *ExperimentalClient) GetChatDesktopEnabled(ctx context.Context) (ChatDesktopEnabledResponse, error) {
 	res, err := c.Request(ctx, http.MethodGet, "/api/experimental/chats/config/desktop-enabled", nil)
 	if err != nil {
 		return ChatDesktopEnabledResponse{}, err
@@ -1360,7 +1360,7 @@ func (c *Client) GetChatDesktopEnabled(ctx context.Context) (ChatDesktopEnabledR
 }
 
 // UpdateChatDesktopEnabled updates the deployment-wide desktop setting.
-func (c *Client) UpdateChatDesktopEnabled(ctx context.Context, req UpdateChatDesktopEnabledRequest) error {
+func (c *ExperimentalClient) UpdateChatDesktopEnabled(ctx context.Context, req UpdateChatDesktopEnabledRequest) error {
 	res, err := c.Request(ctx, http.MethodPut, "/api/experimental/chats/config/desktop-enabled", req)
 	if err != nil {
 		return err
@@ -1373,7 +1373,7 @@ func (c *Client) UpdateChatDesktopEnabled(ctx context.Context, req UpdateChatDes
 }
 
 // GetChatWorkspaceTTL returns the configured chat workspace TTL.
-func (c *Client) GetChatWorkspaceTTL(ctx context.Context) (ChatWorkspaceTTLResponse, error) {
+func (c *ExperimentalClient) GetChatWorkspaceTTL(ctx context.Context) (ChatWorkspaceTTLResponse, error) {
 	res, err := c.Request(ctx, http.MethodGet, "/api/experimental/chats/config/workspace-ttl", nil)
 	if err != nil {
 		return ChatWorkspaceTTLResponse{}, err
@@ -1387,7 +1387,7 @@ func (c *Client) GetChatWorkspaceTTL(ctx context.Context) (ChatWorkspaceTTLRespo
 }
 
 // UpdateChatWorkspaceTTL updates the chat workspace TTL setting.
-func (c *Client) UpdateChatWorkspaceTTL(ctx context.Context, req UpdateChatWorkspaceTTLRequest) error {
+func (c *ExperimentalClient) UpdateChatWorkspaceTTL(ctx context.Context, req UpdateChatWorkspaceTTLRequest) error {
 	res, err := c.Request(ctx, http.MethodPut, "/api/experimental/chats/config/workspace-ttl", req)
 	if err != nil {
 		return err
@@ -1400,7 +1400,7 @@ func (c *Client) UpdateChatWorkspaceTTL(ctx context.Context, req UpdateChatWorks
 }
 
 // UpdateUserChatCustomPrompt updates the user's custom chat prompt.
-func (c *Client) UpdateUserChatCustomPrompt(ctx context.Context, req UserChatCustomPrompt) (UserChatCustomPrompt, error) {
+func (c *ExperimentalClient) UpdateUserChatCustomPrompt(ctx context.Context, req UserChatCustomPrompt) (UserChatCustomPrompt, error) {
 	res, err := c.Request(ctx, http.MethodPut, "/api/experimental/chats/config/user-prompt", req)
 	if err != nil {
 		return UserChatCustomPrompt{}, err
@@ -1414,7 +1414,7 @@ func (c *Client) UpdateUserChatCustomPrompt(ctx context.Context, req UserChatCus
 }
 
 // CreateChat creates a new chat.
-func (c *Client) CreateChat(ctx context.Context, req CreateChatRequest) (Chat, error) {
+func (c *ExperimentalClient) CreateChat(ctx context.Context, req CreateChatRequest) (Chat, error) {
 	res, err := c.Request(ctx, http.MethodPost, "/api/experimental/chats", req)
 	if err != nil {
 		return Chat{}, err
@@ -1441,7 +1441,7 @@ type StreamChatOptions struct {
 // The returned channel includes initial snapshot events first, followed by
 // live updates. Callers must close the returned io.Closer to release the
 // websocket connection when done.
-func (c *Client) StreamChat(ctx context.Context, chatID uuid.UUID, opts *StreamChatOptions) (<-chan ChatStreamEvent, io.Closer, error) {
+func (c *ExperimentalClient) StreamChat(ctx context.Context, chatID uuid.UUID, opts *StreamChatOptions) (<-chan ChatStreamEvent, io.Closer, error) {
 	path := fmt.Sprintf("/api/experimental/chats/%s/stream", chatID)
 	if opts != nil && opts.AfterID != nil {
 		path += fmt.Sprintf("?after_id=%d", *opts.AfterID)
@@ -1564,7 +1564,7 @@ func (c *Client) StreamChat(ctx context.Context, chatID uuid.UUID, opts *StreamC
 }
 
 // GetChat returns a chat by ID.
-func (c *Client) GetChat(ctx context.Context, chatID uuid.UUID) (Chat, error) {
+func (c *ExperimentalClient) GetChat(ctx context.Context, chatID uuid.UUID) (Chat, error) {
 	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/experimental/chats/%s", chatID), nil)
 	if err != nil {
 		return Chat{}, err
@@ -1586,7 +1586,7 @@ type ChatMessagesPaginationOptions struct {
 }
 
 // GetChatMessages returns the messages and queued messages for a chat.
-func (c *Client) GetChatMessages(ctx context.Context, chatID uuid.UUID, opts *ChatMessagesPaginationOptions) (ChatMessagesResponse, error) {
+func (c *ExperimentalClient) GetChatMessages(ctx context.Context, chatID uuid.UUID, opts *ChatMessagesPaginationOptions) (ChatMessagesResponse, error) {
 	reqOpts := []RequestOption{}
 	if opts != nil {
 		reqOpts = append(reqOpts, func(r *http.Request) {
@@ -1613,7 +1613,7 @@ func (c *Client) GetChatMessages(ctx context.Context, chatID uuid.UUID, opts *Ch
 }
 
 // UpdateChat patches a chat resource.
-func (c *Client) UpdateChat(ctx context.Context, chatID uuid.UUID, req UpdateChatRequest) error {
+func (c *ExperimentalClient) UpdateChat(ctx context.Context, chatID uuid.UUID, req UpdateChatRequest) error {
 	res, err := c.Request(ctx, http.MethodPatch, fmt.Sprintf("/api/experimental/chats/%s", chatID), req)
 	if err != nil {
 		return err
@@ -1626,7 +1626,7 @@ func (c *Client) UpdateChat(ctx context.Context, chatID uuid.UUID, req UpdateCha
 }
 
 // CreateChatMessage adds a message to a chat.
-func (c *Client) CreateChatMessage(ctx context.Context, chatID uuid.UUID, req CreateChatMessageRequest) (CreateChatMessageResponse, error) {
+func (c *ExperimentalClient) CreateChatMessage(ctx context.Context, chatID uuid.UUID, req CreateChatMessageRequest) (CreateChatMessageResponse, error) {
 	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/experimental/chats/%s/messages", chatID), req)
 	if err != nil {
 		return CreateChatMessageResponse{}, err
@@ -1640,7 +1640,7 @@ func (c *Client) CreateChatMessage(ctx context.Context, chatID uuid.UUID, req Cr
 }
 
 // EditChatMessage edits an existing user message in a chat and re-runs from there.
-func (c *Client) EditChatMessage(
+func (c *ExperimentalClient) EditChatMessage(
 	ctx context.Context,
 	chatID uuid.UUID,
 	messageID int64,
@@ -1664,7 +1664,7 @@ func (c *Client) EditChatMessage(
 }
 
 // InterruptChat cancels an in-flight chat run and leaves it waiting.
-func (c *Client) InterruptChat(ctx context.Context, chatID uuid.UUID) (Chat, error) {
+func (c *ExperimentalClient) InterruptChat(ctx context.Context, chatID uuid.UUID) (Chat, error) {
 	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/experimental/chats/%s/interrupt", chatID), nil)
 	if err != nil {
 		return Chat{}, err
@@ -1678,7 +1678,7 @@ func (c *Client) InterruptChat(ctx context.Context, chatID uuid.UUID) (Chat, err
 }
 
 // GetChatGitChanges returns git changes for a chat.
-func (c *Client) GetChatGitChanges(ctx context.Context, chatID uuid.UUID) ([]ChatGitChange, error) {
+func (c *ExperimentalClient) GetChatGitChanges(ctx context.Context, chatID uuid.UUID) ([]ChatGitChange, error) {
 	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/experimental/chats/%s/git-changes", chatID), nil)
 	if err != nil {
 		return nil, err
@@ -1692,7 +1692,7 @@ func (c *Client) GetChatGitChanges(ctx context.Context, chatID uuid.UUID) ([]Cha
 }
 
 // GetChatDiffContents returns resolved diff contents for a chat.
-func (c *Client) GetChatDiffContents(ctx context.Context, chatID uuid.UUID) (ChatDiffContents, error) {
+func (c *ExperimentalClient) GetChatDiffContents(ctx context.Context, chatID uuid.UUID) (ChatDiffContents, error) {
 	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/experimental/chats/%s/diff", chatID), nil)
 	if err != nil {
 		return ChatDiffContents{}, err
@@ -1706,7 +1706,7 @@ func (c *Client) GetChatDiffContents(ctx context.Context, chatID uuid.UUID) (Cha
 }
 
 // UploadChatFile uploads a file for use in chat messages.
-func (c *Client) UploadChatFile(ctx context.Context, organizationID uuid.UUID, contentType string, filename string, rd io.Reader) (UploadChatFileResponse, error) {
+func (c *ExperimentalClient) UploadChatFile(ctx context.Context, organizationID uuid.UUID, contentType string, filename string, rd io.Reader) (UploadChatFileResponse, error) {
 	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/experimental/chats/files?organization=%s", organizationID), rd, func(r *http.Request) {
 		r.Header.Set("Content-Type", contentType)
 		if filename != "" {
@@ -1725,7 +1725,7 @@ func (c *Client) UploadChatFile(ctx context.Context, organizationID uuid.UUID, c
 }
 
 // GetChatFile retrieves a previously uploaded chat file by ID.
-func (c *Client) GetChatFile(ctx context.Context, fileID uuid.UUID) ([]byte, string, error) {
+func (c *ExperimentalClient) GetChatFile(ctx context.Context, fileID uuid.UUID) ([]byte, string, error) {
 	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/experimental/chats/files/%s", fileID), nil)
 	if err != nil {
 		return nil, "", err
@@ -1742,7 +1742,7 @@ func (c *Client) GetChatFile(ctx context.Context, fileID uuid.UUID) ([]byte, str
 }
 
 // GetChatUsageLimitConfig returns the deployment-wide chat usage limit config.
-func (c *Client) GetChatUsageLimitConfig(ctx context.Context) (ChatUsageLimitConfigResponse, error) {
+func (c *ExperimentalClient) GetChatUsageLimitConfig(ctx context.Context) (ChatUsageLimitConfigResponse, error) {
 	res, err := c.Request(ctx, http.MethodGet, "/api/experimental/chats/usage-limits", nil)
 	if err != nil {
 		return ChatUsageLimitConfigResponse{}, err
@@ -1756,7 +1756,7 @@ func (c *Client) GetChatUsageLimitConfig(ctx context.Context) (ChatUsageLimitCon
 }
 
 // UpdateChatUsageLimitConfig updates the deployment-wide usage limit config.
-func (c *Client) UpdateChatUsageLimitConfig(ctx context.Context, req ChatUsageLimitConfig) (ChatUsageLimitConfig, error) {
+func (c *ExperimentalClient) UpdateChatUsageLimitConfig(ctx context.Context, req ChatUsageLimitConfig) (ChatUsageLimitConfig, error) {
 	res, err := c.Request(ctx, http.MethodPut, "/api/experimental/chats/usage-limits", req)
 	if err != nil {
 		return ChatUsageLimitConfig{}, err
@@ -1770,7 +1770,7 @@ func (c *Client) UpdateChatUsageLimitConfig(ctx context.Context, req ChatUsageLi
 }
 
 // UpsertChatUsageLimitOverride creates or updates a per-user usage limit override.
-func (c *Client) UpsertChatUsageLimitOverride(ctx context.Context, userID uuid.UUID, req UpsertChatUsageLimitOverrideRequest) (ChatUsageLimitOverride, error) {
+func (c *ExperimentalClient) UpsertChatUsageLimitOverride(ctx context.Context, userID uuid.UUID, req UpsertChatUsageLimitOverrideRequest) (ChatUsageLimitOverride, error) {
 	res, err := c.Request(ctx, http.MethodPut, fmt.Sprintf("/api/experimental/chats/usage-limits/overrides/%s", userID), req)
 	if err != nil {
 		return ChatUsageLimitOverride{}, err
@@ -1784,12 +1784,12 @@ func (c *Client) UpsertChatUsageLimitOverride(ctx context.Context, userID uuid.U
 }
 
 // UpdateChatUserUsageLimitOverride creates or updates a per-user usage limit override.
-func (c *Client) UpdateChatUserUsageLimitOverride(ctx context.Context, userID uuid.UUID, req UpdateChatUsageLimitOverrideRequest) (ChatUsageLimitOverride, error) {
+func (c *ExperimentalClient) UpdateChatUserUsageLimitOverride(ctx context.Context, userID uuid.UUID, req UpdateChatUsageLimitOverrideRequest) (ChatUsageLimitOverride, error) {
 	return c.UpsertChatUsageLimitOverride(ctx, userID, req)
 }
 
 // DeleteChatUsageLimitOverride removes a per-user usage limit override.
-func (c *Client) DeleteChatUsageLimitOverride(ctx context.Context, userID uuid.UUID) error {
+func (c *ExperimentalClient) DeleteChatUsageLimitOverride(ctx context.Context, userID uuid.UUID) error {
 	res, err := c.Request(ctx, http.MethodDelete, fmt.Sprintf("/api/experimental/chats/usage-limits/overrides/%s", userID), nil)
 	if err != nil {
 		return err
@@ -1802,13 +1802,13 @@ func (c *Client) DeleteChatUsageLimitOverride(ctx context.Context, userID uuid.U
 }
 
 // DeleteChatUserUsageLimitOverride removes a per-user usage limit override.
-func (c *Client) DeleteChatUserUsageLimitOverride(ctx context.Context, userID uuid.UUID) error {
+func (c *ExperimentalClient) DeleteChatUserUsageLimitOverride(ctx context.Context, userID uuid.UUID) error {
 	return c.DeleteChatUsageLimitOverride(ctx, userID)
 }
 
 // UpsertChatUsageLimitGroupOverride creates or updates a group-level
 // spend limit override. EXPERIMENTAL: This API is subject to change.
-func (c *Client) UpsertChatUsageLimitGroupOverride(ctx context.Context, groupID uuid.UUID, req UpsertChatUsageLimitGroupOverrideRequest) (ChatUsageLimitGroupOverride, error) {
+func (c *ExperimentalClient) UpsertChatUsageLimitGroupOverride(ctx context.Context, groupID uuid.UUID, req UpsertChatUsageLimitGroupOverrideRequest) (ChatUsageLimitGroupOverride, error) {
 	res, err := c.Request(ctx, http.MethodPut,
 		fmt.Sprintf("/api/experimental/chats/usage-limits/group-overrides/%s", groupID),
 		req,
@@ -1826,7 +1826,7 @@ func (c *Client) UpsertChatUsageLimitGroupOverride(ctx context.Context, groupID 
 
 // DeleteChatUsageLimitGroupOverride removes a group-level spend limit
 // override. EXPERIMENTAL: This API is subject to change.
-func (c *Client) DeleteChatUsageLimitGroupOverride(ctx context.Context, groupID uuid.UUID) error {
+func (c *ExperimentalClient) DeleteChatUsageLimitGroupOverride(ctx context.Context, groupID uuid.UUID) error {
 	res, err := c.Request(ctx, http.MethodDelete,
 		fmt.Sprintf("/api/experimental/chats/usage-limits/group-overrides/%s", groupID),
 		nil,
@@ -1842,7 +1842,7 @@ func (c *Client) DeleteChatUsageLimitGroupOverride(ctx context.Context, groupID 
 }
 
 // GetMyChatUsageLimitStatus returns the current user's chat usage limit status.
-func (c *Client) GetMyChatUsageLimitStatus(ctx context.Context) (ChatUsageLimitStatus, error) {
+func (c *ExperimentalClient) GetMyChatUsageLimitStatus(ctx context.Context) (ChatUsageLimitStatus, error) {
 	res, err := c.Request(ctx, http.MethodGet, "/api/experimental/chats/usage-limits/status", nil)
 	if err != nil {
 		return ChatUsageLimitStatus{}, err

--- a/codersdk/chats_test.go
+++ b/codersdk/chats_test.go
@@ -87,7 +87,7 @@ func TestChatUsageLimitExceededFrom(t *testing.T) {
 		serverURL, err := url.Parse(srv.URL)
 		require.NoError(t, err)
 
-		client := codersdk.New(serverURL)
+		client := codersdk.NewExperimentalClient(codersdk.New(serverURL))
 		_, err = client.CreateChat(context.Background(), codersdk.CreateChatRequest{
 			Content: []codersdk.ChatInputPart{{
 				Type: codersdk.ChatInputPartTypeText,
@@ -121,7 +121,7 @@ func TestChatUsageLimitExceededFrom(t *testing.T) {
 		serverURL, err := url.Parse(srv.URL)
 		require.NoError(t, err)
 
-		client := codersdk.New(serverURL)
+		client := codersdk.NewExperimentalClient(codersdk.New(serverURL))
 		_, err = client.CreateChat(context.Background(), codersdk.CreateChatRequest{
 			Content: []codersdk.ChatInputPart{{
 				Type: codersdk.ChatInputPartTypeText,

--- a/enterprise/coderd/chatd/chatd.go
+++ b/enterprise/coderd/chatd/chatd.go
@@ -445,7 +445,8 @@ func dialRelay(
 		token:     extractSessionToken(requestHeader),
 		replicaID: replicaID,
 	}
-	sourceEvents, sourceStream, err := sdkClient.StreamChat(relayCtx, chatID, &codersdk.StreamChatOptions{
+	expClient := codersdk.NewExperimentalClient(sdkClient)
+	sourceEvents, sourceStream, err := expClient.StreamChat(relayCtx, chatID, &codersdk.StreamChatOptions{
 		AfterID: ptr.Ref(int64(math.MaxInt64)),
 	})
 	if err != nil {

--- a/enterprise/coderd/chats_test.go
+++ b/enterprise/coderd/chats_test.go
@@ -73,7 +73,7 @@ func TestChatStreamRelay(t *testing.T) {
 		})
 
 		//nolint:gocritic // Test uses owner client to configure chat providers.
-		provider, err := firstClient.CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
+		provider, err := codersdk.NewExperimentalClient(firstClient).CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
 			Provider:    "openai",
 			DisplayName: "OpenAI",
 			APIKey:      "test",
@@ -82,7 +82,7 @@ func TestChatStreamRelay(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, codersdk.ChatProviderConfigSourceDatabase, provider.Source)
 
-		model, err := firstClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+		model, err := codersdk.NewExperimentalClient(firstClient).CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
 			Provider:             provider.Provider,
 			Model:                "gpt-4",
 			DisplayName:          "GPT-4",
@@ -92,7 +92,7 @@ func TestChatStreamRelay(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create a chat on the first replica
-		chat, err := firstClient.CreateChat(ctx, codersdk.CreateChatRequest{
+		chat, err := codersdk.NewExperimentalClient(firstClient).CreateChat(ctx, codersdk.CreateChatRequest{
 			Content: []codersdk.ChatInputPart{{
 				Type: codersdk.ChatInputPartTypeText,
 				Text: "Test chat for relay",
@@ -115,15 +115,15 @@ func TestChatStreamRelay(t *testing.T) {
 			return true
 		}, testutil.WaitLong, testutil.IntervalFast)
 
-		var localClient *codersdk.Client
-		var relayClient *codersdk.Client
+		var localClient *codersdk.ExperimentalClient
+		var relayClient *codersdk.ExperimentalClient
 		switch runningChat.WorkerID.UUID {
 		case firstReplicaID:
-			localClient = firstClient
-			relayClient = secondClient
+			localClient = codersdk.NewExperimentalClient(firstClient)
+			relayClient = codersdk.NewExperimentalClient(secondClient)
 		case secondReplicaID:
-			localClient = secondClient
-			relayClient = firstClient
+			localClient = codersdk.NewExperimentalClient(secondClient)
+			relayClient = codersdk.NewExperimentalClient(firstClient)
 		default:
 			require.FailNowf(
 				t,
@@ -263,7 +263,7 @@ func TestChatStreamRelay(t *testing.T) {
 		})
 
 		//nolint:gocritic // Test uses owner client to configure chat providers.
-		provider, err := firstClient.CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
+		provider, err := codersdk.NewExperimentalClient(firstClient).CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
 			Provider:    "openai",
 			DisplayName: "OpenAI",
 			APIKey:      "test",
@@ -271,7 +271,7 @@ func TestChatStreamRelay(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		model, err := firstClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+		model, err := codersdk.NewExperimentalClient(firstClient).CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
 			Provider:             provider.Provider,
 			Model:                "gpt-4",
 			DisplayName:          "GPT-4",
@@ -281,7 +281,7 @@ func TestChatStreamRelay(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create a chat on the first replica.
-		chat, err := firstClient.CreateChat(ctx, codersdk.CreateChatRequest{
+		chat, err := codersdk.NewExperimentalClient(firstClient).CreateChat(ctx, codersdk.CreateChatRequest{
 			Content: []codersdk.ChatInputPart{{
 				Type: codersdk.ChatInputPartTypeText,
 				Text: "Test chat for TLS relay",
@@ -304,15 +304,15 @@ func TestChatStreamRelay(t *testing.T) {
 			return true
 		}, testutil.WaitLong, testutil.IntervalFast)
 
-		var localClient *codersdk.Client
-		var relayClient *codersdk.Client
+		var localClient *codersdk.ExperimentalClient
+		var relayClient *codersdk.ExperimentalClient
 		switch runningChat.WorkerID.UUID {
 		case firstReplicaID:
-			localClient = firstClient
-			relayClient = secondClient
+			localClient = codersdk.NewExperimentalClient(firstClient)
+			relayClient = codersdk.NewExperimentalClient(secondClient)
 		case secondReplicaID:
-			localClient = secondClient
-			relayClient = firstClient
+			localClient = codersdk.NewExperimentalClient(secondClient)
+			relayClient = codersdk.NewExperimentalClient(firstClient)
 		default:
 			require.FailNowf(
 				t,
@@ -434,7 +434,7 @@ func TestChatStreamRelay(t *testing.T) {
 		})
 
 		//nolint:gocritic // Test uses owner client to configure providers.
-		provider, err := firstClient.CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
+		provider, err := codersdk.NewExperimentalClient(firstClient).CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
 			Provider:    "openai",
 			DisplayName: "OpenAI",
 			APIKey:      "test",
@@ -442,7 +442,7 @@ func TestChatStreamRelay(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		model, err := firstClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+		model, err := codersdk.NewExperimentalClient(firstClient).CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
 			Provider:             provider.Provider,
 			Model:                "gpt-4",
 			DisplayName:          "GPT-4",
@@ -451,7 +451,7 @@ func TestChatStreamRelay(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		chat, err := firstClient.CreateChat(ctx, codersdk.CreateChatRequest{
+		chat, err := codersdk.NewExperimentalClient(firstClient).CreateChat(ctx, codersdk.CreateChatRequest{
 			Content: []codersdk.ChatInputPart{{
 				Type: codersdk.ChatInputPartTypeText,
 				Text: "Test cookie-only relay",
@@ -474,15 +474,15 @@ func TestChatStreamRelay(t *testing.T) {
 			return true
 		}, testutil.WaitLong, testutil.IntervalFast)
 
-		var localClient *codersdk.Client
-		var relayClient *codersdk.Client
+		var localClient *codersdk.ExperimentalClient
+		var relayClient *codersdk.ExperimentalClient
 		switch runningChat.WorkerID.UUID {
 		case firstReplicaID:
-			localClient = firstClient
-			relayClient = secondClient
+			localClient = codersdk.NewExperimentalClient(firstClient)
+			relayClient = codersdk.NewExperimentalClient(secondClient)
 		case secondReplicaID:
-			localClient = secondClient
-			relayClient = firstClient
+			localClient = codersdk.NewExperimentalClient(secondClient)
+			relayClient = codersdk.NewExperimentalClient(firstClient)
 		default:
 			require.FailNowf(
 				t,
@@ -606,7 +606,7 @@ func TestChatStreamRelay(t *testing.T) {
 		})
 
 		//nolint:gocritic // Test uses owner client to configure providers.
-		provider, err := firstClient.CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
+		provider, err := codersdk.NewExperimentalClient(firstClient).CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
 			Provider:    "openai",
 			DisplayName: "OpenAI",
 			APIKey:      "test",
@@ -614,7 +614,7 @@ func TestChatStreamRelay(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		model, err := firstClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+		model, err := codersdk.NewExperimentalClient(firstClient).CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
 			Provider:             provider.Provider,
 			Model:                "gpt-4",
 			DisplayName:          "GPT-4",
@@ -623,7 +623,7 @@ func TestChatStreamRelay(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		chat, err := firstClient.CreateChat(ctx, codersdk.CreateChatRequest{
+		chat, err := codersdk.NewExperimentalClient(firstClient).CreateChat(ctx, codersdk.CreateChatRequest{
 			Content: []codersdk.ChatInputPart{{
 				Type: codersdk.ChatInputPartTypeText,
 				Text: "Test host-prefix relay",
@@ -646,15 +646,15 @@ func TestChatStreamRelay(t *testing.T) {
 			return true
 		}, testutil.WaitLong, testutil.IntervalFast)
 
-		var localClient *codersdk.Client
-		var relayClient *codersdk.Client
+		var localClient *codersdk.ExperimentalClient
+		var relayClient *codersdk.ExperimentalClient
 		switch runningChat.WorkerID.UUID {
 		case firstReplicaID:
-			localClient = firstClient
-			relayClient = secondClient
+			localClient = codersdk.NewExperimentalClient(firstClient)
+			relayClient = codersdk.NewExperimentalClient(secondClient)
 		case secondReplicaID:
-			localClient = secondClient
-			relayClient = firstClient
+			localClient = codersdk.NewExperimentalClient(secondClient)
+			relayClient = codersdk.NewExperimentalClient(firstClient)
 		default:
 			require.FailNowf(
 				t,
@@ -753,7 +753,7 @@ func TestChatStreamRelay(t *testing.T) {
 		})
 
 		//nolint:gocritic // Test uses owner client to configure chat providers.
-		provider, err := firstClient.CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
+		provider, err := codersdk.NewExperimentalClient(firstClient).CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
 			Provider:    "openai",
 			DisplayName: "OpenAI",
 			APIKey:      "test",
@@ -761,7 +761,7 @@ func TestChatStreamRelay(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		model, err := firstClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+		model, err := codersdk.NewExperimentalClient(firstClient).CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
 			Provider:             provider.Provider,
 			Model:                "gpt-4",
 			DisplayName:          "GPT-4",
@@ -771,7 +771,7 @@ func TestChatStreamRelay(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create a chat on the first replica.
-		chat, err := firstClient.CreateChat(ctx, codersdk.CreateChatRequest{
+		chat, err := codersdk.NewExperimentalClient(firstClient).CreateChat(ctx, codersdk.CreateChatRequest{
 			Content: []codersdk.ChatInputPart{{
 				Type: codersdk.ChatInputPartTypeText,
 				Text: "Test chat for buffered relay",
@@ -794,15 +794,15 @@ func TestChatStreamRelay(t *testing.T) {
 			return true
 		}, testutil.WaitLong, testutil.IntervalFast)
 
-		var localClient *codersdk.Client
-		var relayClient *codersdk.Client
+		var localClient *codersdk.ExperimentalClient
+		var relayClient *codersdk.ExperimentalClient
 		switch runningChat.WorkerID.UUID {
 		case firstReplicaID:
-			localClient = firstClient
-			relayClient = secondClient
+			localClient = codersdk.NewExperimentalClient(firstClient)
+			relayClient = codersdk.NewExperimentalClient(secondClient)
 		case secondReplicaID:
-			localClient = secondClient
-			relayClient = firstClient
+			localClient = codersdk.NewExperimentalClient(secondClient)
+			relayClient = codersdk.NewExperimentalClient(firstClient)
 		default:
 			require.FailNowf(
 				t,
@@ -950,9 +950,10 @@ func TestChatModelConfigDefault(t *testing.T) {
 	ctx := testutil.Context(t, testutil.WaitLong)
 
 	client, _ := coderdenttest.New(t, nil)
+	expClient := codersdk.NewExperimentalClient(client)
 
 	//nolint:gocritic // Test uses owner client to configure chat providers.
-	provider, err := client.CreateChatProvider(
+	provider, err := expClient.CreateChatProvider(
 		ctx,
 		codersdk.CreateChatProviderConfigRequest{
 			Provider:    "openai",
@@ -968,7 +969,7 @@ func TestChatModelConfigDefault(t *testing.T) {
 	trueValue := true
 	falseValue := false
 
-	firstModel, err := client.CreateChatModelConfig(
+	firstModel, err := expClient.CreateChatModelConfig(
 		ctx,
 		codersdk.CreateChatModelConfigRequest{
 			Provider:             provider.Provider,
@@ -982,7 +983,7 @@ func TestChatModelConfigDefault(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, firstModel.IsDefault)
 
-	secondModel, err := client.CreateChatModelConfig(
+	secondModel, err := expClient.CreateChatModelConfig(
 		ctx,
 		codersdk.CreateChatModelConfigRequest{
 			Provider:             provider.Provider,
@@ -996,14 +997,14 @@ func TestChatModelConfigDefault(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, secondModel.IsDefault)
 
-	modelConfigs, err := client.ListChatModelConfigs(ctx)
+	modelConfigs, err := expClient.ListChatModelConfigs(ctx)
 	require.NoError(t, err)
 	firstStored := findChatModelConfigByID(t, modelConfigs, firstModel.ID)
 	secondStored := findChatModelConfigByID(t, modelConfigs, secondModel.ID)
 	require.False(t, firstStored.IsDefault)
 	require.True(t, secondStored.IsDefault)
 
-	updatedFirst, err := client.UpdateChatModelConfig(
+	updatedFirst, err := expClient.UpdateChatModelConfig(
 		ctx,
 		firstModel.ID,
 		codersdk.UpdateChatModelConfigRequest{
@@ -1013,14 +1014,14 @@ func TestChatModelConfigDefault(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, updatedFirst.IsDefault)
 
-	modelConfigs, err = client.ListChatModelConfigs(ctx)
+	modelConfigs, err = expClient.ListChatModelConfigs(ctx)
 	require.NoError(t, err)
 	firstStored = findChatModelConfigByID(t, modelConfigs, firstModel.ID)
 	secondStored = findChatModelConfigByID(t, modelConfigs, secondModel.ID)
 	require.True(t, firstStored.IsDefault)
 	require.False(t, secondStored.IsDefault)
 
-	updatedFirst, err = client.UpdateChatModelConfig(
+	updatedFirst, err = expClient.UpdateChatModelConfig(
 		ctx,
 		firstModel.ID,
 		codersdk.UpdateChatModelConfigRequest{
@@ -1030,7 +1031,7 @@ func TestChatModelConfigDefault(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, updatedFirst.IsDefault)
 
-	modelConfigs, err = client.ListChatModelConfigs(ctx)
+	modelConfigs, err = expClient.ListChatModelConfigs(ctx)
 	require.NoError(t, err)
 	firstStored = findChatModelConfigByID(t, modelConfigs, firstModel.ID)
 	secondStored = findChatModelConfigByID(t, modelConfigs, secondModel.ID)


### PR DESCRIPTION
- Changes all 41 chat method receivers in `codersdk/chats.go` from `*Client` to `*ExperimentalClient` to ensure that callers are aware that these reference potentially unstable `/api/experimental` endpoints.


> 🤖 This PR was created with the help of Coder Agents, and has been reviewed by my human.  🧑‍💻