### PR TITLE
feat(site): add early access badge to agents page sidebar

### DIFF
--- a/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
@@ -17,6 +17,7 @@ import {
 } from "components/DropdownMenu/DropdownMenu";
 import { ExternalImage } from "components/ExternalImage/ExternalImage";
 import { CoderIcon } from "components/Icons/CoderIcon";
+import { FeatureStageBadge } from "components/FeatureStageBadge/FeatureStageBadge";
 import { ScrollArea } from "components/ScrollArea/ScrollArea";
 import { Skeleton } from "components/Skeleton/Skeleton";
 import { Spinner } from "components/Spinner/Spinner";
@@ -704,6 +705,7 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 								<CoderIcon className="h-6 w-6 fill-content-primary" />
 							)}
 						</NavLink>
+						<FeatureStageBadge contentType="early_access" size="sm" />
 						<div className="flex items-center gap-0.5 -mr-1.5">
 							<Button
 								asChild

--- a/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
@@ -16,8 +16,8 @@ import {
 	DropdownMenuTrigger,
 } from "components/DropdownMenu/DropdownMenu";
 import { ExternalImage } from "components/ExternalImage/ExternalImage";
-import { CoderIcon } from "components/Icons/CoderIcon";
 import { FeatureStageBadge } from "components/FeatureStageBadge/FeatureStageBadge";
+import { CoderIcon } from "components/Icons/CoderIcon";
 import { ScrollArea } from "components/ScrollArea/ScrollArea";
 import { Skeleton } from "components/Skeleton/Skeleton";
 import { Spinner } from "components/Spinner/Spinner";
@@ -698,14 +698,16 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 			>
 				<div className="hidden border-b border-border-default px-2 pb-3 pt-1.5 md:block">
 					<div className="mb-2.5 flex items-center justify-between">
-						<NavLink to="/workspaces" className="inline-flex">
-							{logoUrl ? (
-								<ExternalImage className="h-6" src={logoUrl} alt="Logo" />
-							) : (
-								<CoderIcon className="h-6 w-6 fill-content-primary" />
-							)}
-						</NavLink>
-						<FeatureStageBadge contentType="early_access" size="sm" />
+						<div className="flex items-center gap-2">
+							<NavLink to="/workspaces" className="inline-flex">
+								{logoUrl ? (
+									<ExternalImage className="h-6" src={logoUrl} alt="Logo" />
+								) : (
+									<CoderIcon className="h-6 w-6 fill-content-primary" />
+								)}
+							</NavLink>
+							<FeatureStageBadge contentType="early_access" size="sm" />
+						</div>
 						<div className="flex items-center gap-0.5 -mr-1.5">
 							<Button
 								asChild


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

Adds a `FeatureStageBadge` with `early_access` type next to the Coder logo in the agents page sidebar. Uses the existing `FeatureStageBadge` component which renders an orange pill with a tooltip linking to the feature stages docs.