### PR TITLE
test: share coderdtest instances in OAuth2 validation tests

### DIFF
--- a/coderd/oauth2_metadata_validation_test.go
+++ b/coderd/oauth2_metadata_validation_test.go
@@ -18,11 +18,12 @@ import (
 func TestOAuth2ClientMetadataValidation(t *testing.T) {
 	t.Parallel()
 
+	// Single instance shared across all sub-tests. Each registers independent OAuth2 apps with unique client names.
+	client := coderdtest.New(t, nil)
+	_ = coderdtest.CreateFirstUser(t, client)
+
 	t.Run("RedirectURIValidation", func(t *testing.T) {
 		t.Parallel()
-
-		client := coderdtest.New(t, nil)
-		_ = coderdtest.CreateFirstUser(t, client)
 
 		tests := []struct {
 			name          string
@@ -132,9 +133,6 @@ func TestOAuth2ClientMetadataValidation(t *testing.T) {
 	t.Run("ClientURIValidation", func(t *testing.T) {
 		t.Parallel()
 
-		client := coderdtest.New(t, nil)
-		_ = coderdtest.CreateFirstUser(t, client)
-
 		tests := []struct {
 			name        string
 			clientURI   string
@@ -207,9 +205,6 @@ func TestOAuth2ClientMetadataValidation(t *testing.T) {
 	t.Run("LogoURIValidation", func(t *testing.T) {
 		t.Parallel()
 
-		client := coderdtest.New(t, nil)
-		_ = coderdtest.CreateFirstUser(t, client)
-
 		tests := []struct {
 			name        string
 			logoURI     string
@@ -271,9 +266,6 @@ func TestOAuth2ClientMetadataValidation(t *testing.T) {
 
 	t.Run("GrantTypeValidation", func(t *testing.T) {
 		t.Parallel()
-
-		client := coderdtest.New(t, nil)
-		_ = coderdtest.CreateFirstUser(t, client)
 
 		tests := []struct {
 			name        string
@@ -347,9 +339,6 @@ func TestOAuth2ClientMetadataValidation(t *testing.T) {
 	t.Run("ResponseTypeValidation", func(t *testing.T) {
 		t.Parallel()
 
-		client := coderdtest.New(t, nil)
-		_ = coderdtest.CreateFirstUser(t, client)
-
 		tests := []struct {
 			name          string
 			responseTypes []codersdk.OAuth2ProviderResponseType
@@ -406,9 +395,6 @@ func TestOAuth2ClientMetadataValidation(t *testing.T) {
 
 	t.Run("TokenEndpointAuthMethodValidation", func(t *testing.T) {
 		t.Parallel()
-
-		client := coderdtest.New(t, nil)
-		_ = coderdtest.CreateFirstUser(t, client)
 
 		tests := []struct {
 			name        string
@@ -479,6 +465,10 @@ func TestOAuth2ClientMetadataValidation(t *testing.T) {
 func TestOAuth2ClientNameValidation(t *testing.T) {
 	t.Parallel()
 
+	// Single instance shared across all sub-tests. Each registers independent OAuth2 apps.
+	client := coderdtest.New(t, nil)
+	_ = coderdtest.CreateFirstUser(t, client)
+
 	tests := []struct {
 		name        string
 		clientName  string
@@ -530,8 +520,6 @@ func TestOAuth2ClientNameValidation(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			client := coderdtest.New(t, nil)
-			_ = coderdtest.CreateFirstUser(t, client)
 			ctx := testutil.Context(t, testutil.WaitLong)
 
 			req := codersdk.OAuth2ClientRegistrationRequest{
@@ -553,6 +541,10 @@ func TestOAuth2ClientNameValidation(t *testing.T) {
 // TestOAuth2ClientScopeValidation tests scope parameter validation
 func TestOAuth2ClientScopeValidation(t *testing.T) {
 	t.Parallel()
+
+	// Single instance shared across all sub-tests. Each registers independent OAuth2 apps.
+	client := coderdtest.New(t, nil)
+	_ = coderdtest.CreateFirstUser(t, client)
 
 	tests := []struct {
 		name        string
@@ -615,8 +607,6 @@ func TestOAuth2ClientScopeValidation(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			client := coderdtest.New(t, nil)
-			_ = coderdtest.CreateFirstUser(t, client)
 			ctx := testutil.Context(t, testutil.WaitLong)
 
 			req := codersdk.OAuth2ClientRegistrationRequest{
@@ -682,11 +672,13 @@ func TestOAuth2ClientMetadataDefaults(t *testing.T) {
 func TestOAuth2ClientMetadataEdgeCases(t *testing.T) {
 	t.Parallel()
 
+	// Single instance shared across all sub-tests. Each registers independent OAuth2 apps with unique client names.
+	client := coderdtest.New(t, nil)
+	_ = coderdtest.CreateFirstUser(t, client)
+
 	t.Run("ExtremelyLongRedirectURI", func(t *testing.T) {
 		t.Parallel()
 
-		client := coderdtest.New(t, nil)
-		_ = coderdtest.CreateFirstUser(t, client)
 		ctx := testutil.Context(t, testutil.WaitLong)
 
 		// Create a very long but valid HTTPS URI
@@ -709,8 +701,6 @@ func TestOAuth2ClientMetadataEdgeCases(t *testing.T) {
 	t.Run("ManyRedirectURIs", func(t *testing.T) {
 		t.Parallel()
 
-		client := coderdtest.New(t, nil)
-		_ = coderdtest.CreateFirstUser(t, client)
 		ctx := testutil.Context(t, testutil.WaitLong)
 
 		// Test with many redirect URIs
@@ -732,8 +722,6 @@ func TestOAuth2ClientMetadataEdgeCases(t *testing.T) {
 	t.Run("URIWithUnusualPort", func(t *testing.T) {
 		t.Parallel()
 
-		client := coderdtest.New(t, nil)
-		_ = coderdtest.CreateFirstUser(t, client)
 		ctx := testutil.Context(t, testutil.WaitLong)
 
 		req := codersdk.OAuth2ClientRegistrationRequest{
@@ -748,8 +736,6 @@ func TestOAuth2ClientMetadataEdgeCases(t *testing.T) {
 	t.Run("URIWithComplexPath", func(t *testing.T) {
 		t.Parallel()
 
-		client := coderdtest.New(t, nil)
-		_ = coderdtest.CreateFirstUser(t, client)
 		ctx := testutil.Context(t, testutil.WaitLong)
 
 		req := codersdk.OAuth2ClientRegistrationRequest{
@@ -764,8 +750,6 @@ func TestOAuth2ClientMetadataEdgeCases(t *testing.T) {
 	t.Run("URIWithEncodedCharacters", func(t *testing.T) {
 		t.Parallel()
 
-		client := coderdtest.New(t, nil)
-		_ = coderdtest.CreateFirstUser(t, client)
 		ctx := testutil.Context(t, testutil.WaitLong)
 
 		// Test with URL-encoded characters

--- a/coderd/oauth2provider/validation_test.go
+++ b/coderd/oauth2provider/validation_test.go
@@ -18,11 +18,12 @@ import (
 func TestOAuth2ClientMetadataValidation(t *testing.T) {
 	t.Parallel()
 
+	// Single instance shared across all sub-tests. Each registers independent OAuth2 apps with unique client names.
+	client := coderdtest.New(t, nil)
+	_ = coderdtest.CreateFirstUser(t, client)
+
 	t.Run("RedirectURIValidation", func(t *testing.T) {
 		t.Parallel()
-
-		client := coderdtest.New(t, nil)
-		_ = coderdtest.CreateFirstUser(t, client)
 
 		tests := []struct {
 			name          string
@@ -132,9 +133,6 @@ func TestOAuth2ClientMetadataValidation(t *testing.T) {
 	t.Run("ClientURIValidation", func(t *testing.T) {
 		t.Parallel()
 
-		client := coderdtest.New(t, nil)
-		_ = coderdtest.CreateFirstUser(t, client)
-
 		tests := []struct {
 			name        string
 			clientURI   string
@@ -207,9 +205,6 @@ func TestOAuth2ClientMetadataValidation(t *testing.T) {
 	t.Run("LogoURIValidation", func(t *testing.T) {
 		t.Parallel()
 
-		client := coderdtest.New(t, nil)
-		_ = coderdtest.CreateFirstUser(t, client)
-
 		tests := []struct {
 			name        string
 			logoURI     string
@@ -271,9 +266,6 @@ func TestOAuth2ClientMetadataValidation(t *testing.T) {
 
 	t.Run("GrantTypeValidation", func(t *testing.T) {
 		t.Parallel()
-
-		client := coderdtest.New(t, nil)
-		_ = coderdtest.CreateFirstUser(t, client)
 
 		tests := []struct {
 			name        string
@@ -347,9 +339,6 @@ func TestOAuth2ClientMetadataValidation(t *testing.T) {
 	t.Run("ResponseTypeValidation", func(t *testing.T) {
 		t.Parallel()
 
-		client := coderdtest.New(t, nil)
-		_ = coderdtest.CreateFirstUser(t, client)
-
 		tests := []struct {
 			name          string
 			responseTypes []codersdk.OAuth2ProviderResponseType
@@ -406,9 +395,6 @@ func TestOAuth2ClientMetadataValidation(t *testing.T) {
 
 	t.Run("TokenEndpointAuthMethodValidation", func(t *testing.T) {
 		t.Parallel()
-
-		client := coderdtest.New(t, nil)
-		_ = coderdtest.CreateFirstUser(t, client)
 
 		tests := []struct {
 			name        string
@@ -479,6 +465,10 @@ func TestOAuth2ClientMetadataValidation(t *testing.T) {
 func TestOAuth2ClientNameValidation(t *testing.T) {
 	t.Parallel()
 
+	// Single instance shared across all sub-tests. Each registers independent OAuth2 apps.
+	client := coderdtest.New(t, nil)
+	_ = coderdtest.CreateFirstUser(t, client)
+
 	tests := []struct {
 		name        string
 		clientName  string
@@ -530,8 +520,6 @@ func TestOAuth2ClientNameValidation(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			client := coderdtest.New(t, nil)
-			_ = coderdtest.CreateFirstUser(t, client)
 			ctx := testutil.Context(t, testutil.WaitLong)
 
 			req := codersdk.OAuth2ClientRegistrationRequest{
@@ -553,6 +541,10 @@ func TestOAuth2ClientNameValidation(t *testing.T) {
 // TestOAuth2ClientScopeValidation tests scope parameter validation
 func TestOAuth2ClientScopeValidation(t *testing.T) {
 	t.Parallel()
+
+	// Single instance shared across all sub-tests. Each registers independent OAuth2 apps.
+	client := coderdtest.New(t, nil)
+	_ = coderdtest.CreateFirstUser(t, client)
 
 	tests := []struct {
 		name        string
@@ -615,8 +607,6 @@ func TestOAuth2ClientScopeValidation(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			client := coderdtest.New(t, nil)
-			_ = coderdtest.CreateFirstUser(t, client)
 			ctx := testutil.Context(t, testutil.WaitLong)
 
 			req := codersdk.OAuth2ClientRegistrationRequest{
@@ -682,11 +672,13 @@ func TestOAuth2ClientMetadataDefaults(t *testing.T) {
 func TestOAuth2ClientMetadataEdgeCases(t *testing.T) {
 	t.Parallel()
 
+	// Single instance shared across all sub-tests. Each registers independent OAuth2 apps with unique client names.
+	client := coderdtest.New(t, nil)
+	_ = coderdtest.CreateFirstUser(t, client)
+
 	t.Run("ExtremelyLongRedirectURI", func(t *testing.T) {
 		t.Parallel()
 
-		client := coderdtest.New(t, nil)
-		_ = coderdtest.CreateFirstUser(t, client)
 		ctx := testutil.Context(t, testutil.WaitLong)
 
 		// Create a very long but valid HTTPS URI
@@ -709,8 +701,6 @@ func TestOAuth2ClientMetadataEdgeCases(t *testing.T) {
 	t.Run("ManyRedirectURIs", func(t *testing.T) {
 		t.Parallel()
 
-		client := coderdtest.New(t, nil)
-		_ = coderdtest.CreateFirstUser(t, client)
 		ctx := testutil.Context(t, testutil.WaitLong)
 
 		// Test with many redirect URIs
@@ -732,8 +722,6 @@ func TestOAuth2ClientMetadataEdgeCases(t *testing.T) {
 	t.Run("URIWithUnusualPort", func(t *testing.T) {
 		t.Parallel()
 
-		client := coderdtest.New(t, nil)
-		_ = coderdtest.CreateFirstUser(t, client)
 		ctx := testutil.Context(t, testutil.WaitLong)
 
 		req := codersdk.OAuth2ClientRegistrationRequest{
@@ -748,8 +736,6 @@ func TestOAuth2ClientMetadataEdgeCases(t *testing.T) {
 	t.Run("URIWithComplexPath", func(t *testing.T) {
 		t.Parallel()
 
-		client := coderdtest.New(t, nil)
-		_ = coderdtest.CreateFirstUser(t, client)
 		ctx := testutil.Context(t, testutil.WaitLong)
 
 		req := codersdk.OAuth2ClientRegistrationRequest{
@@ -764,8 +750,6 @@ func TestOAuth2ClientMetadataEdgeCases(t *testing.T) {
 	t.Run("URIWithEncodedCharacters", func(t *testing.T) {
 		t.Parallel()
 
-		client := coderdtest.New(t, nil)
-		_ = coderdtest.CreateFirstUser(t, client)
 		ctx := testutil.Context(t, testutil.WaitLong)
 
 		// Test with URL-encoded characters


### PR DESCRIPTION
## Summary

Consolidate 8 test functions (4 per file × 2 mirror files) from per-sub-test `coderdtest.New(t, nil)` to a single shared instance per parent.

- `TestOAuth2ClientMetadataValidation` (6 → 1 per file)
- `TestOAuth2ClientNameValidation` (8 → 1 per file)
- `TestOAuth2ClientScopeValidation` (10 → 1 per file)
- `TestOAuth2ClientMetadataEdgeCases` (5 → 1 per file)

**60 → 10 instances** across both `coderd/` and `coderd/oauth2provider/`.

## Benchmark Results

Avg of 10 runs, `-count=1`, warm cache:

| Metric | Before (60 instances) | After (10 instances) | Change |
|--------|----------------------|---------------------|--------|
| Test execution | 1976ms | 993ms | **-49.7%** |
| Wall clock | 6366ms | 5783ms | **-9.2%** |

## Approach

Same pattern as #23454: hoist `coderdtest.New` + `CreateFirstUser` to parent, sub-tests remain parallel with `t.Parallel()`. Each sub-test registers independent OAuth2 apps with unique client names — no shared state risk.

> 🤖 This PR was created with the help of Coder Agents, and will be reviewed by my human.  🧑‍💻