### PR TITLE
fix(Makefile): install playwright browsers before storybook tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1343,6 +1343,7 @@ test-js: site/node_modules/.installed
 
 test-storybook: site/node_modules/.installed
 	cd site/
+	pnpm playwright:install
 	pnpm exec vitest run --project=storybook
 .PHONY: test-storybook
 


### PR DESCRIPTION
The `test-storybook` Makefile target uses `@vitest/browser-playwright` with Chromium, but never installs the browser binaries. `pnpm install` only fetches the npm package; the actual browser must be downloaded separately via `playwright install`. This caused `make pre-push` to fail when Chromium wasn't already cached.

This adds `pnpm playwright:install` to `test-storybook`, mirroring what `test-e2e` already does.

> 🤖 This PR was created with the help of Coder Agents, and reviewed by a human. 🏂🏻