### PR TITLE
fix(site): polish diff header padding, stat badge borders, and gutter line color

### DIFF
--- a/site/src/components/ai-elements/tool/utils.ts
+++ b/site/src/components/ai-elements/tool/utils.ts
@@ -166,6 +166,7 @@ const SELECTION_OVERRIDE_CSS = [
 	"  --diffs-bg-selection-override: hsl(var(--content-link) / 0.08);",
 	"  --diffs-bg-selection-number-override: hsl(var(--content-link) / 0.13);",
 	"  --diffs-selection-number-fg: hsl(var(--content-link));",
+	"  --diffs-gap-style: 1px solid hsl(var(--border-default));",
 	"}",
 	// Direct rules that override both context and change-line
 	// selection backgrounds so every selected line looks the same.
@@ -239,7 +240,7 @@ const DIFF_HEADER_CSS = [
 	"  font-size: 13px;",
 	"  min-height: 32px !important;",
 	"  padding-block: 0 !important;",
-	"  padding-inline: 12px !important;",
+	"  padding-inline: 10px !important;",
 	"  border-bottom: 1px solid hsl(var(--border-default));",
 	"}",
 
@@ -284,6 +285,9 @@ const DIFF_HEADER_CSS = [
 	"[data-diffs-header] [data-metadata] {",
 	"  flex-direction: row-reverse;",
 	"  gap: 0 !important;",
+	"  border: 1px solid hsl(var(--border-default));",
+	"  border-radius: 3px;",
+	"  overflow: hidden;",
 	"}",
 	"[data-diffs-header] [data-additions-count],",
 	"[data-diffs-header] [data-deletions-count] {",
@@ -292,7 +296,7 @@ const DIFF_HEADER_CSS = [
 	"  font-weight: 500;",
 	"  line-height: 20px;",
 	"  padding-inline: 6px;",
-	"  border-radius: 3px;",
+	"  border-radius: 0;",
 	"}",
 	"[data-diffs-header] [data-additions-count] {",
 	"  color: hsl(var(--git-added-bright)) !important;",
@@ -301,14 +305,6 @@ const DIFF_HEADER_CSS = [
 	"[data-diffs-header] [data-deletions-count] {",
 	"  color: hsl(var(--git-deleted-bright)) !important;",
 	"  background-color: hsl(var(--surface-git-deleted));",
-	"}",
-	// Joined badge: flatten touching inner edges. DOM order is
-	// [deletions][additions]; row-reverse puts additions left.
-	"[data-deletions-count] + [data-additions-count] {",
-	"  border-radius: 3px 0 0 3px;",
-	"}",
-	"[data-deletions-count]:has(+ [data-additions-count]) {",
-	"  border-radius: 0 3px 3px 0;",
 	"}",
 ].join(" ");
 

--- a/site/src/components/ai-elements/tool/utils.ts
+++ b/site/src/components/ai-elements/tool/utils.ts
@@ -295,7 +295,7 @@ const DIFF_HEADER_CSS = [
 	"  font-size: 12px;",
 	"  font-weight: 500;",
 	"  line-height: 20px;",
-	"  padding-inline: 6px;",
+	"  padding-inline: 4px;",
 	"  border-radius: 0;",
 	"}",
 	"[data-diffs-header] [data-additions-count] {",

--- a/site/src/components/ai-elements/tool/utils.ts
+++ b/site/src/components/ai-elements/tool/utils.ts
@@ -284,7 +284,9 @@ const DIFF_HEADER_CSS = [
 	// Stat counts styled as compact pill badges.
 	"[data-diffs-header] [data-metadata] {",
 	"  flex-direction: row-reverse;",
+	"  align-items: stretch;",
 	"  gap: 0 !important;",
+	"  padding: 0;",
 	"  border: 1px solid hsl(var(--border-default));",
 	"  border-radius: 3px;",
 	"  overflow: hidden;",


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

Three small visual tweaks to the diff viewer header CSS in `utils.ts`:

1. **Header padding**: Reduced `padding-inline` from `12px` to `10px` to better match the visual vertical space created by the `min-height: 32px` centering.
2. **Stat badge border**: Added a `1px solid` border to the `[data-metadata]` wrapper so the additions/deletions pills match the bordered style of the `DiffStatBadge` used next to the Commit button. Moved `border-radius` to the wrapper and simplified by removing the per-element joined-badge radius overrides.
3. **Gutter separator color**: Overrode `--diffs-gap-style` so the line between line numbers and code uses `--border-default` instead of the library default (white/`--diffs-bg`).