### PR TITLE
refactor: replace sort.Slice with slices.SortFunc

### DIFF
--- a/agent/agentcontainers/containers_dockercli.go
+++ b/agent/agentcontainers/containers_dockercli.go
@@ -3,13 +3,13 @@ package agentcontainers
 import (
 	"bufio"
 	"bytes"
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
 	"net"
 	"os/user"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -479,8 +479,8 @@ func convertDockerInspect(raw []byte) ([]codersdk.WorkspaceAgentContainer, []str
 			in.Mounts = []dockerInspectMount{}
 		}
 		// Sort the mounts for deterministic output.
-		sort.Slice(in.Mounts, func(i, j int) bool {
-			return in.Mounts[i].Source < in.Mounts[j].Source
+		slices.SortFunc(in.Mounts, func(a, b dockerInspectMount) int {
+			return cmp.Compare(a.Source, b.Source)
 		})
 		for _, k := range in.Mounts {
 			out.Volumes[k.Source] = k.Destination

--- a/agent/agentproc/api.go
+++ b/agent/agentproc/api.go
@@ -1,12 +1,13 @@
 package agentproc
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
-	"sort"
+	"slices"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -129,11 +130,14 @@ func (api *API) handleListProcesses(rw http.ResponseWriter, r *http.Request) {
 
 	// Sort by running state (running first), then by started_at
 	// descending so the most recent processes appear first.
-	sort.Slice(infos, func(i, j int) bool {
-		if infos[i].Running != infos[j].Running {
-			return infos[i].Running
+	slices.SortFunc(infos, func(a, b workspacesdk.ProcessInfo) int {
+		if a.Running != b.Running {
+			if a.Running {
+				return -1
+			}
+			return 1
 		}
-		return infos[i].StartedAt > infos[j].StartedAt
+		return cmp.Compare(b.StartedAt, a.StartedAt)
 	})
 
 	// Cap the response to avoid bloating LLM context.

--- a/cli/cliui/resources.go
+++ b/cli/cliui/resources.go
@@ -1,9 +1,10 @@
 package cliui
 
 import (
+	"cmp"
 	"fmt"
 	"io"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -48,8 +49,8 @@ type WorkspaceResourcesOptions struct {
 // └────────────────────────────────────────────────────────────────────────────┘
 func WorkspaceResources(writer io.Writer, resources []codersdk.WorkspaceResource, options WorkspaceResourcesOptions) error {
 	// Sort resources by type for consistent output.
-	sort.Slice(resources, func(i, j int) bool {
-		return resources[i].Type < resources[j].Type
+	slices.SortFunc(resources, func(a, b codersdk.WorkspaceResource) int {
+		return cmp.Compare(a.Type, b.Type)
 	})
 
 	tableWriter := table.NewWriter()
@@ -88,8 +89,8 @@ func WorkspaceResources(writer io.Writer, resources []codersdk.WorkspaceResource
 		resourceAddress := resource.Type + "." + resource.Name
 
 		// Sort agents by name for consistent output.
-		sort.Slice(resource.Agents, func(i, j int) bool {
-			return resource.Agents[i].Name < resource.Agents[j].Name
+		slices.SortFunc(resource.Agents, func(a, b codersdk.WorkspaceAgent) int {
+			return cmp.Compare(a.Name, b.Name)
 		})
 
 		// Display a line for the resource.

--- a/cli/help.go
+++ b/cli/help.go
@@ -2,12 +2,12 @@ package cli
 
 import (
 	"bufio"
+	"cmp"
 	_ "embed"
 	"fmt"
 	"os"
 	"regexp"
 	"slices"
-	"sort"
 	"strings"
 	"text/tabwriter"
 	"text/template"
@@ -208,8 +208,8 @@ var usageTemplate = func() *template.Template {
 					}
 
 					// Sort options lexicographically.
-					sort.Slice(cmd.Options, func(i, j int) bool {
-						return cmd.Options[i].Name < cmd.Options[j].Name
+					slices.SortFunc(cmd.Options, func(a, b serpent.Option) int {
+						return cmp.Compare(a.Name, b.Name)
 					})
 
 				optionLoop:
@@ -244,9 +244,9 @@ var usageTemplate = func() *template.Template {
 							Options:     serpent.OptionSet{opt},
 						})
 					}
-					sort.Slice(groups, func(i, j int) bool {
+					slices.SortFunc(groups, func(a, b optionGroup) int {
 						// Sort groups lexicographically.
-						return groups[i].Name < groups[j].Name
+						return cmp.Compare(a.Name, b.Name)
 					})
 
 					// Always show enterprise group last.

--- a/cli/schedule_test.go
+++ b/cli/schedule_test.go
@@ -2,10 +2,11 @@ package cli_test
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"database/sql"
 	"encoding/json"
-	"sort"
+	"slices"
 	"testing"
 	"time"
 
@@ -70,10 +71,8 @@ func setupTestSchedule(t *testing.T, sched *cron.Schedule) (ownerClient, memberC
 	require.Len(t, resp.Workspaces, 4)
 	// Ensure same order as in CLI output
 	ws = resp.Workspaces
-	sort.Slice(ws, func(i, j int) bool {
-		a := ws[i].OwnerName + "/" + ws[i].Name
-		b := ws[j].OwnerName + "/" + ws[j].Name
-		return a < b
+	slices.SortFunc(ws, func(a, b codersdk.Workspace) int {
+		return cmp.Compare(a.OwnerName+"/"+a.Name, b.OwnerName+"/"+b.Name)
 	})
 
 	return ownerClient, memberClient, db, ws
@@ -225,10 +224,8 @@ func TestScheduleShow(t *testing.T) {
 		require.NoError(t, json.Unmarshal(buf.Bytes(), &parsed))
 		require.Len(t, parsed, 4)
 		// Ensure same order as in CLI output
-		sort.Slice(parsed, func(i, j int) bool {
-			a := parsed[i]["workspace"]
-			b := parsed[j]["workspace"]
-			return a < b
+		slices.SortFunc(parsed, func(a, b map[string]string) int {
+			return cmp.Compare(a["workspace"], b["workspace"])
 		})
 		// 1st workspace: a-owner-ws1 has both autostart and autostop enabled.
 		assert.Equal(t, ws[0].OwnerName+"/"+ws[0].Name, parsed[0]["workspace"])

--- a/cli/server_createadminuser.go
+++ b/cli/server_createadminuser.go
@@ -3,8 +3,9 @@
 package cli
 
 import (
+	"cmp"
 	"fmt"
-	"sort"
+	"slices"
 
 	"github.com/google/uuid"
 	"golang.org/x/xerrors"
@@ -182,8 +183,8 @@ func (r *RootCmd) newCreateAdminUserCommand() *serpent.Command {
 				}
 
 				// Sort organizations by name so that test output is consistent.
-				sort.Slice(orgs, func(i, j int) bool {
-					return orgs[i].Name < orgs[j].Name
+				slices.SortFunc(orgs, func(a, b database.Organization) int {
+					return cmp.Compare(a.Name, b.Name)
 				})
 
 				_, _ = fmt.Fprintln(inv.Stderr, "Creating user...")

--- a/cli/show.go
+++ b/cli/show.go
@@ -1,8 +1,9 @@
 package cli
 
 import (
+	"cmp"
 	"fmt"
-	"sort"
+	"slices"
 	"sync"
 	"time"
 
@@ -76,8 +77,8 @@ func fetchRuntimeResources(inv *serpent.Invocation, client *codersdk.Client, res
 				if err != nil {
 					cliui.Warnf(inv.Stderr, "Failed to get listening ports for agent %s: %v", agent.Name, err)
 				}
-				sort.Slice(lp.Ports, func(i, j int) bool {
-					return lp.Ports[i].Port < lp.Ports[j].Port
+				slices.SortFunc(lp.Ports, func(a, b codersdk.WorkspaceAgentListeningPort) int {
+					return cmp.Compare(a.Port, b.Port)
 				})
 				mu.Lock()
 				ports[agent.ID] = lp

--- a/cli/templatepull.go
+++ b/cli/templatepull.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 
 	"golang.org/x/xerrors"
 
@@ -74,8 +74,8 @@ func (r *RootCmd) templatePull() *serpent.Command {
 				}
 
 				// Sort the slice from newest to oldest template.
-				sort.SliceStable(versions, func(i, j int) bool {
-					return versions[i].CreatedAt.After(versions[j].CreatedAt)
+				slices.SortStableFunc(versions, func(a, b codersdk.TemplateVersion) int {
+					return b.CreatedAt.Compare(a.CreatedAt)
 				})
 
 				latestVersion = versions[0]

--- a/coderd/autobuild/notify/notifier.go
+++ b/coderd/autobuild/notify/notifier.go
@@ -1,8 +1,9 @@
 package notify
 
 import (
+	"cmp"
 	"context"
-	"sort"
+	"slices"
 	"sync"
 	"time"
 
@@ -55,9 +56,7 @@ func WithTestClock(clk quartz.Clock) Option {
 func New(cond Condition, interval time.Duration, countdown []time.Duration, opts ...Option) *Notifier {
 	// Ensure countdown is sorted in descending order and contains no duplicates.
 	ct := unique(countdown)
-	sort.Slice(ct, func(i, j int) bool {
-		return ct[i] < ct[j]
-	})
+	slices.SortFunc(ct, cmp.Compare)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	n := &Notifier{

--- a/coderd/database/db2sdk/db2sdk.go
+++ b/coderd/database/db2sdk/db2sdk.go
@@ -2,12 +2,12 @@
 package db2sdk
 
 import (
+	"cmp"
 	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net/url"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -592,14 +592,14 @@ func AppSubdomain(dbApp database.WorkspaceApp, agentName, workspaceName, ownerNa
 }
 
 func Apps(dbApps []database.WorkspaceApp, statuses []database.WorkspaceAppStatus, agent database.WorkspaceAgent, ownerName string, workspace database.WorkspaceTable) []codersdk.WorkspaceApp {
-	sort.Slice(dbApps, func(i, j int) bool {
-		if dbApps[i].DisplayOrder != dbApps[j].DisplayOrder {
-			return dbApps[i].DisplayOrder < dbApps[j].DisplayOrder
+	slices.SortFunc(dbApps, func(a, b database.WorkspaceApp) int {
+		if c := cmp.Compare(a.DisplayOrder, b.DisplayOrder); c != 0 {
+			return c
 		}
-		if dbApps[i].DisplayName != dbApps[j].DisplayName {
-			return dbApps[i].DisplayName < dbApps[j].DisplayName
+		if c := cmp.Compare(a.DisplayName, b.DisplayName); c != 0 {
+			return c
 		}
-		return dbApps[i].Slug < dbApps[j].Slug
+		return cmp.Compare(a.Slug, b.Slug)
 	})
 
 	statusesByAppID := map[uuid.UUID][]database.WorkspaceAppStatus{}
@@ -710,8 +710,8 @@ func RecentProvisionerDaemons(now time.Time, staleInterval time.Duration, daemon
 	}
 
 	// Ensure stable order for display and for tests
-	sort.Slice(results, func(i, j int) bool {
-		return results[i].Name < results[j].Name
+	slices.SortFunc(results, func(a, b codersdk.ProvisionerDaemon) int {
+		return cmp.Compare(a.Name, b.Name)
 	})
 
 	return results
@@ -991,19 +991,19 @@ func PreviewParameterValidation(v *previewtypes.ParameterValidation) codersdk.Pr
 
 func AIBridgeInterception(interception database.AIBridgeInterception, initiator database.VisibleUser, tokenUsages []database.AIBridgeTokenUsage, userPrompts []database.AIBridgeUserPrompt, toolUsages []database.AIBridgeToolUsage) codersdk.AIBridgeInterception {
 	sdkTokenUsages := slice.List(tokenUsages, AIBridgeTokenUsage)
-	sort.Slice(sdkTokenUsages, func(i, j int) bool {
+	slices.SortFunc(sdkTokenUsages, func(a, b codersdk.AIBridgeTokenUsage) int {
 		// created_at ASC
-		return sdkTokenUsages[i].CreatedAt.Before(sdkTokenUsages[j].CreatedAt)
+		return a.CreatedAt.Compare(b.CreatedAt)
 	})
 	sdkUserPrompts := slice.List(userPrompts, AIBridgeUserPrompt)
-	sort.Slice(sdkUserPrompts, func(i, j int) bool {
+	slices.SortFunc(sdkUserPrompts, func(a, b codersdk.AIBridgeUserPrompt) int {
 		// created_at ASC
-		return sdkUserPrompts[i].CreatedAt.Before(sdkUserPrompts[j].CreatedAt)
+		return a.CreatedAt.Compare(b.CreatedAt)
 	})
 	sdkToolUsages := slice.List(toolUsages, AIBridgeToolUsage)
-	sort.Slice(sdkToolUsages, func(i, j int) bool {
+	slices.SortFunc(sdkToolUsages, func(a, b codersdk.AIBridgeToolUsage) int {
 		// created_at ASC
-		return sdkToolUsages[i].CreatedAt.Before(sdkToolUsages[j].CreatedAt)
+		return a.CreatedAt.Compare(b.CreatedAt)
 	})
 	intc := codersdk.AIBridgeInterception{
 		ID:           interception.ID,

--- a/coderd/database/migrations/migrate.go
+++ b/coderd/database/migrations/migrate.go
@@ -1,6 +1,7 @@
 package migrations
 
 import (
+	"cmp"
 	"context"
 	"crypto/sha256"
 	"database/sql"
@@ -9,7 +10,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -37,8 +38,8 @@ func calculateMigrationsHash(migrationsFs embed.FS) (string, error) {
 	}
 	sortedFiles := make([]fs.DirEntry, len(files))
 	copy(sortedFiles, files)
-	sort.Slice(sortedFiles, func(i, j int) bool {
-		return sortedFiles[i].Name() < sortedFiles[j].Name()
+	slices.SortFunc(sortedFiles, func(a, b fs.DirEntry) int {
+		return cmp.Compare(a.Name(), b.Name())
 	})
 
 	var builder strings.Builder

--- a/coderd/database/modelmethods.go
+++ b/coderd/database/modelmethods.go
@@ -1,10 +1,10 @@
 package database
 
 import (
+	"cmp"
 	"database/sql"
 	"encoding/hex"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -95,8 +95,8 @@ func (g Group) Auditable(members []GroupMember) AuditableGroup {
 	}
 
 	// consistent ordering
-	sort.Slice(members, func(i, j int) bool {
-		return members[i].UserID.String() < members[j].UserID.String()
+	slices.SortFunc(members, func(a, b GroupMember) int {
+		return cmp.Compare(a.UserID.String(), b.UserID.String())
 	})
 
 	return AuditableGroup{

--- a/coderd/database/pglocks.go
+++ b/coderd/database/pglocks.go
@@ -1,10 +1,11 @@
 package database
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"reflect"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -96,8 +97,8 @@ type PGLocks []PGLock
 
 func (l PGLocks) String() string {
 	// Try to group things together by relation name.
-	sort.Slice(l, func(i, j int) bool {
-		return safeString(l[i].RelationName) < safeString(l[j].RelationName)
+	slices.SortFunc(l, func(a, b PGLock) int {
+		return cmp.Compare(safeString(a.RelationName), safeString(b.RelationName))
 	})
 
 	var out strings.Builder

--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -1,6 +1,7 @@
 package database_test
 
 import (
+	"cmp"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -8,7 +9,6 @@ import (
 	"fmt"
 	"net"
 	"slices"
-	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -1768,8 +1768,8 @@ func TestQueuePosition(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, queued, jobCount)
-	sort.Slice(queued, func(i, j int) bool {
-		return queued[i].QueuePosition < queued[j].QueuePosition
+	slices.SortFunc(queued, func(a, b database.GetProvisionerJobsByIDsWithQueuePositionRow) int {
+		return cmp.Compare(a.QueuePosition, b.QueuePosition)
 	})
 	// Ensure that the queue positions are correct based on insertion ID!
 	for index, job := range queued {
@@ -1799,8 +1799,8 @@ func TestQueuePosition(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, queued, jobCount)
-	sort.Slice(queued, func(i, j int) bool {
-		return queued[i].QueuePosition < queued[j].QueuePosition
+	slices.SortFunc(queued, func(a, b database.GetProvisionerJobsByIDsWithQueuePositionRow) int {
+		return cmp.Compare(a.QueuePosition, b.QueuePosition)
 	})
 	// Ensure that queue positions are updated now that the first job has been acquired!
 	for index, job := range queued {
@@ -1871,8 +1871,8 @@ func TestAcquireProvisionerJob(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, qjs, numJobs)
 		// Ensure the jobs are sorted by queue position.
-		sort.Slice(qjs, func(i, j int) bool {
-			return qjs[i].QueuePosition < qjs[j].QueuePosition
+		slices.SortFunc(qjs, func(a, b database.GetProvisionerJobsByIDsWithQueuePositionRow) int {
+			return cmp.Compare(a.QueuePosition, b.QueuePosition)
 		})
 
 		// Then: the queue positions for the jobs should indicate the order in which
@@ -4693,8 +4693,8 @@ func TestGetProvisionerJobsByIDsWithQueuePosition(t *testing.T) {
 			require.Len(t, actualJobs, len(filteredJobs), "should return all unskipped jobs")
 
 			// Then: the jobs should be returned in the correct order (sorted by createdAt)
-			sort.Slice(filteredJobs, func(i, j int) bool {
-				return filteredJobs[i].CreatedAt.Before(filteredJobs[j].CreatedAt)
+			slices.SortFunc(filteredJobs, func(a, b database.ProvisionerJob) int {
+				return a.CreatedAt.Compare(b.CreatedAt)
 			})
 			for idx, job := range actualJobs {
 				assert.EqualValues(t, filteredJobs[idx], job.ProvisionerJob)
@@ -4836,8 +4836,8 @@ func TestGetProvisionerJobsByIDsWithQueuePosition_MixedStatuses(t *testing.T) {
 	require.Len(t, actualJobs, len(allJobs), "should return all jobs")
 
 	// Then: the jobs should be returned in the correct order (sorted by createdAt)
-	sort.Slice(allJobs, func(i, j int) bool {
-		return allJobs[i].CreatedAt.Before(allJobs[j].CreatedAt)
+	slices.SortFunc(allJobs, func(a, b database.ProvisionerJob) int {
+		return a.CreatedAt.Compare(b.CreatedAt)
 	})
 	for idx, job := range actualJobs {
 		assert.EqualValues(t, allJobs[idx], job.ProvisionerJob)
@@ -4934,8 +4934,8 @@ func TestGetProvisionerJobsByIDsWithQueuePosition_OrderValidation(t *testing.T) 
 	require.Len(t, actualJobs, len(allJobs), "should return all jobs")
 
 	// Then: the jobs should be returned in the correct order (sorted by createdAt)
-	sort.Slice(allJobs, func(i, j int) bool {
-		return allJobs[i].CreatedAt.Before(allJobs[j].CreatedAt)
+	slices.SortFunc(allJobs, func(a, b database.ProvisionerJob) int {
+		return a.CreatedAt.Compare(b.CreatedAt)
 	})
 	for idx, job := range actualJobs {
 		assert.EqualValues(t, allJobs[idx], job.ProvisionerJob)

--- a/coderd/healthcheck/workspaceproxy.go
+++ b/coderd/healthcheck/workspaceproxy.go
@@ -3,7 +3,7 @@ package healthcheck
 import (
 	"context"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/coder/coder/v2/coderd/healthcheck/health"
@@ -71,8 +71,8 @@ func (r *WorkspaceProxyReport) Run(ctx context.Context, opts *WorkspaceProxyRepo
 	}
 
 	// Stable sort based on create timestamp.
-	sort.Slice(r.WorkspaceProxies.Regions, func(i int, j int) bool {
-		return r.WorkspaceProxies.Regions[i].CreatedAt.Before(r.WorkspaceProxies.Regions[j].CreatedAt)
+	slices.SortFunc(r.WorkspaceProxies.Regions, func(a, b codersdk.WorkspaceProxy) int {
+		return a.CreatedAt.Compare(b.CreatedAt)
 	})
 
 	var total, healthy, warning int

--- a/coderd/notifications/reports/generator.go
+++ b/coderd/notifications/reports/generator.go
@@ -1,11 +1,11 @@
 package reports
 
 import (
+	"cmp"
 	"context"
 	"database/sql"
 	"io"
 	"slices"
-	"sort"
 	"time"
 
 	"github.com/google/uuid"
@@ -325,8 +325,8 @@ func findTemplateAdmins(ctx context.Context, db database.Store, stats database.G
 			templateAdmins = append(templateAdmins, usersByIDs[entry.UserID])
 		}
 	}
-	sort.Slice(templateAdmins, func(i, j int) bool {
-		return templateAdmins[i].Username < templateAdmins[j].Username
+	slices.SortFunc(templateAdmins, func(a, b database.GetUsersRow) int {
+		return cmp.Compare(a.Username, b.Username)
 	})
 	return templateAdmins, nil
 }

--- a/coderd/notifications/reports/generator_internal_test.go
+++ b/coderd/notifications/reports/generator_internal_test.go
@@ -1,9 +1,10 @@
 package reports
 
 import (
+	"cmp"
 	"context"
 	"database/sql"
-	"sort"
+	"slices"
 	"testing"
 	"time"
 
@@ -244,11 +245,11 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 		templateAdmins := []uuid.UUID{templateAdmin1.ID, templateAdmin2.ID}
 
 		// Ensure consistent order for tests
-		sort.Slice(templateAdmins, func(i, j int) bool {
-			return templateAdmins[i].String() < templateAdmins[j].String()
+		slices.SortFunc(templateAdmins, func(a, b uuid.UUID) int {
+			return cmp.Compare(a.String(), b.String())
 		})
-		sort.Slice(sent, func(i, j int) bool {
-			return sent[i].UserID.String() < sent[j].UserID.String()
+		slices.SortFunc(sent, func(a, b *notificationstest.FakeNotification) int {
+			return cmp.Compare(a.UserID.String(), b.UserID.String())
 		})
 
 		for i, templateAdmin := range templateAdmins {
@@ -335,11 +336,11 @@ func TestReportFailedWorkspaceBuilds(t *testing.T) {
 		templateAdmins = []uuid.UUID{templateAdmin1.ID, templateAdmin2.ID}
 
 		// Ensure consistent order for tests
-		sort.Slice(templateAdmins, func(i, j int) bool {
-			return templateAdmins[i].String() < templateAdmins[j].String()
+		slices.SortFunc(templateAdmins, func(a, b uuid.UUID) int {
+			return cmp.Compare(a.String(), b.String())
 		})
-		sort.Slice(sent, func(i, j int) bool {
-			return sent[i].UserID.String() < sent[j].UserID.String()
+		slices.SortFunc(sent, func(a, b *notificationstest.FakeNotification) int {
+			return cmp.Compare(a.UserID.String(), b.UserID.String())
 		})
 
 		for i, templateAdmin := range templateAdmins {

--- a/coderd/prometheusmetrics/aggregator_test.go
+++ b/coderd/prometheusmetrics/aggregator_test.go
@@ -1,9 +1,10 @@
 package prometheusmetrics_test
 
 import (
+	"cmp"
 	"context"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -177,14 +178,14 @@ func verifyCollectedMetrics(t *testing.T, expected []*agentproto.Stats_Metric, a
 	}
 
 	// ensure stable iteration order
-	sort.Slice(expected, func(i, j int) bool {
-		return expected[i].Name < expected[j].Name
+	slices.SortFunc(expected, func(a, b *agentproto.Stats_Metric) int {
+		return cmp.Compare(a.Name, b.Name)
 	})
 
-	sort.Slice(actual, func(i, j int) bool {
-		m1 := prometheusMetricToString(t, actual[i])
-		m2 := prometheusMetricToString(t, actual[j])
-		return m1 < m2
+	slices.SortFunc(actual, func(a, b prometheus.Metric) int {
+		m1 := prometheusMetricToString(t, a)
+		m2 := prometheusMetricToString(t, b)
+		return cmp.Compare(m1, m2)
 	})
 
 	for i, e := range expected {
@@ -213,11 +214,11 @@ func verifyCollectedMetrics(t *testing.T, expected []*agentproto.Stats_Metric, a
 
 		dtoLabels := asMetricAgentLabels(d.GetLabel())
 		// dto labels are sorted in alphabetical order.
-		sortFn := func(i, j int) bool {
-			return expectedLabels[i].Name < expectedLabels[j].Name
+		sortFn := func(a, b *agentproto.Stats_Metric_Label) int {
+			return cmp.Compare(a.Name, b.Name)
 		}
-		sort.Slice(expectedLabels, sortFn)
-		sort.Slice(dtoLabels, sortFn)
+		slices.SortFunc(expectedLabels, sortFn)
+		slices.SortFunc(dtoLabels, sortFn)
 		assert.Equal(t, expectedLabels, dtoLabels, d.String())
 	}
 	return true
@@ -234,8 +235,8 @@ func prometheusMetricToString(t *testing.T, m prometheus.Metric) string {
 	err := m.Write(&d)
 	assert.NoError(t, err)
 	dtoLabels := asMetricAgentLabels(d.GetLabel())
-	sort.Slice(dtoLabels, func(i, j int) bool {
-		return dtoLabels[i].Name < dtoLabels[j].Name
+	slices.SortFunc(dtoLabels, func(a, b *agentproto.Stats_Metric_Label) int {
+		return cmp.Compare(a.Name, b.Name)
 	})
 
 	for _, dtoLabel := range dtoLabels {

--- a/coderd/prometheusmetrics/collector_test.go
+++ b/coderd/prometheusmetrics/collector_test.go
@@ -1,8 +1,8 @@
 package prometheusmetrics_test
 
 import (
+	"cmp"
 	"slices"
-	"sort"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -134,8 +134,8 @@ func collectAndSortMetrics(t *testing.T, collector prometheus.Collector, count i
 	}
 
 	// Ensure always the same order of metrics
-	sort.Slice(metrics, func(i, j int) bool {
-		return slices.IsSorted([]string{metrics[i].Label[0].GetValue(), metrics[j].Label[1].GetValue()})
+	slices.SortFunc(metrics, func(a, b *dto.Metric) int {
+		return cmp.Compare(a.Label[0].GetValue(), b.Label[1].GetValue())
 	})
 	return metrics
 }

--- a/coderd/provisionerdserver/provisionerdserver.go
+++ b/coderd/provisionerdserver/provisionerdserver.go
@@ -1,6 +1,7 @@
 package provisionerdserver
 
 import (
+	"cmp"
 	"context"
 	"crypto/sha256"
 	"database/sql"
@@ -12,7 +13,6 @@ import (
 	"net/url"
 	"reflect"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -1464,8 +1464,8 @@ func (s *server) prepareForNotifyWorkspaceManualBuildFailed(ctx context.Context,
 			}
 		}
 	}
-	sort.Slice(templateAdmins, func(i, j int) bool {
-		return templateAdmins[i].Username < templateAdmins[j].Username
+	slices.SortFunc(templateAdmins, func(a, b database.GetUsersRow) int {
+		return cmp.Compare(a.Username, b.Username)
 	})
 
 	template, err := s.Database.GetTemplateByID(ctx, workspace.TemplateID)

--- a/coderd/provisionerdserver/provisionerdserver_test.go
+++ b/coderd/provisionerdserver/provisionerdserver_test.go
@@ -1,13 +1,13 @@
 package provisionerdserver_test
 
 import (
+	"cmp"
 	"context"
 	"database/sql"
 	"encoding/json"
 	"io"
 	"net/url"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -3970,8 +3970,8 @@ func TestInsertWorkspaceResource(t *testing.T) {
 
 					devcontainers, err := db.GetWorkspaceAgentDevcontainersByAgentID(ctx, parentAgent.ID)
 					require.NoError(t, err)
-					sort.Slice(devcontainers, func(i, j int) bool {
-						return devcontainers[i].Name > devcontainers[j].Name
+					slices.SortFunc(devcontainers, func(a, b database.WorkspaceAgentDevcontainer) int {
+						return cmp.Compare(b.Name, a.Name)
 					})
 					require.Len(t, devcontainers, 2)
 					if useProtoIDs {

--- a/coderd/provisionerjobs.go
+++ b/coderd/provisionerjobs.go
@@ -1,13 +1,14 @@
 package coderd
 
 import (
+	"cmp"
 	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
-	"sort"
+	"slices"
 	"strconv"
 
 	"github.com/google/uuid"
@@ -349,8 +350,8 @@ func (api *API) provisionerJobResources(rw http.ResponseWriter, r *http.Request,
 		}
 		apiResources = append(apiResources, convertWorkspaceResource(resource, agents, metadata))
 	}
-	sort.Slice(apiResources, func(i, j int) bool {
-		return apiResources[i].Name < apiResources[j].Name
+	slices.SortFunc(apiResources, func(a, b codersdk.WorkspaceResource) int {
+		return cmp.Compare(a.Name, b.Name)
 	})
 
 	httpapi.Write(ctx, rw, http.StatusOK, apiResources)

--- a/coderd/rbac/allowlist.go
+++ b/coderd/rbac/allowlist.go
@@ -1,8 +1,8 @@
 package rbac
 
 import (
+	"cmp"
 	"slices"
-	"sort"
 	"strings"
 
 	"github.com/google/uuid"
@@ -116,11 +116,11 @@ func NormalizeAllowList(inputs []AllowListElement) ([]AllowListElement, error) {
 		}
 	}
 
-	sort.Slice(out, func(i, j int) bool {
-		if out[i].Type == out[j].Type {
-			return out[i].ID < out[j].ID
+	slices.SortFunc(out, func(a, b AllowListElement) int {
+		if c := cmp.Compare(a.Type, b.Type); c != 0 {
+			return c
 		}
-		return out[i].Type < out[j].Type
+		return cmp.Compare(a.ID, b.ID)
 	})
 	return out, nil
 }

--- a/coderd/rbac/roles.go
+++ b/coderd/rbac/roles.go
@@ -1,9 +1,10 @@
 package rbac
 
 import (
+	"cmp"
 	"encoding/json"
 	"errors"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -925,8 +926,8 @@ func Permissions(perms map[string][]policy.Action) []Permission {
 		}
 	}
 	// Deterministic ordering of permissions
-	sort.Slice(list, func(i, j int) bool {
-		return list[i].ResourceType < list[j].ResourceType
+	slices.SortFunc(list, func(a, b Permission) int {
+		return cmp.Compare(a.ResourceType, b.ResourceType)
 	})
 	return list
 }

--- a/coderd/rbac/scopes_catalog.go
+++ b/coderd/rbac/scopes_catalog.go
@@ -1,8 +1,8 @@
 package rbac
 
 import (
-	"sort"
-	"strings"
+	"cmp"
+	"slices"
 )
 
 // externalLowLevel is the curated set of low-level scope names exposed to users.
@@ -117,6 +117,6 @@ func ExternalScopeNames() []string {
 		names = append(names, string(name))
 	}
 
-	sort.Slice(names, func(i, j int) bool { return strings.Compare(names[i], names[j]) < 0 })
+	slices.SortFunc(names, cmp.Compare)
 	return names
 }

--- a/coderd/telemetry/telemetry_test.go
+++ b/coderd/telemetry/telemetry_test.go
@@ -1,6 +1,7 @@
 package telemetry_test
 
 import (
+	stdcmp "cmp"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -9,7 +10,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"slices"
-	"sort"
 	"testing"
 	"time"
 
@@ -363,12 +363,15 @@ func TestTelemetry(t *testing.T) {
 		}))
 
 		tvs := snapshot.TemplateVersions
-		sort.Slice(tvs, func(i, j int) bool {
+		slices.SortFunc(tvs, func(a, b telemetry.TemplateVersion) int {
 			// Sort by SourceExampleID presence (non-nil comes before nil)
-			if (tvs[i].SourceExampleID != nil) != (tvs[j].SourceExampleID != nil) {
-				return tvs[i].SourceExampleID != nil
+			if (a.SourceExampleID != nil) != (b.SourceExampleID != nil) {
+				if a.SourceExampleID != nil {
+					return -1
+				}
+				return 1
 			}
-			return false
+			return 0
 		})
 		require.Equal(t, tvs[0].SourceExampleID, &sourceExampleID)
 		require.Nil(t, tvs[1].SourceExampleID)
@@ -462,8 +465,8 @@ func TestTelemetry(t *testing.T) {
 		_, snapshot := collectSnapshot(ctx, t, db, nil)
 		require.Len(t, snapshot.WorkspaceModules, 2)
 		modules := snapshot.WorkspaceModules
-		sort.Slice(modules, func(i, j int) bool {
-			return modules[i].Source < modules[j].Source
+		slices.SortFunc(modules, func(a, b telemetry.WorkspaceModule) int {
+			return stdcmp.Compare(a.Source, b.Source)
 		})
 		require.Equal(t, modules[0].Source, "ed662ec0396db67e77119f14afcb9253574cc925b04a51d4374bcb1eae299f5d")
 		require.Equal(t, modules[0].Version, "92521fc3cbd964bdc9f584a991b89fddaa5754ed1cc96d6d42445338669c1305")

--- a/coderd/templates.go
+++ b/coderd/templates.go
@@ -1,12 +1,13 @@
 package coderd
 
 import (
+	"cmp"
 	"context"
 	"database/sql"
 	"errors"
 	"fmt"
 	"net/http"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -1072,8 +1073,8 @@ func (api *API) convertTemplates(templates []database.Template) []codersdk.Templ
 	}
 
 	// Sort templates by ActiveUserCount DESC
-	sort.SliceStable(apiTemplates, func(i, j int) bool {
-		return apiTemplates[i].ActiveUserCount > apiTemplates[j].ActiveUserCount
+	slices.SortStableFunc(apiTemplates, func(a, b codersdk.Template) int {
+		return cmp.Compare(b.ActiveUserCount, a.ActiveUserCount)
 	})
 
 	return apiTemplates

--- a/coderd/util/maps/maps.go
+++ b/coderd/util/maps/maps.go
@@ -1,7 +1,7 @@
 package maps
 
 import (
-	"sort"
+	"slices"
 
 	"golang.org/x/exp/constraints"
 )
@@ -35,6 +35,6 @@ func SortedKeys[K constraints.Ordered, V any](m map[K]V) (keys []K) {
 	for k := range m {
 		keys = append(keys, k)
 	}
-	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+	slices.Sort(keys)
 	return keys
 }

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -2,6 +2,7 @@ package coderd
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -11,7 +12,6 @@ import (
 	"net/http"
 	"net/url"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -1892,11 +1892,11 @@ func (api *API) watchWorkspaceAgentMetadata(
 
 func convertWorkspaceAgentMetadata(db []database.WorkspaceAgentMetadatum) []codersdk.WorkspaceAgentMetadata {
 	// Sort the input database slice by DisplayOrder and then by Key before processing
-	sort.Slice(db, func(i, j int) bool {
-		if db[i].DisplayOrder == db[j].DisplayOrder {
-			return db[i].Key < db[j].Key
+	slices.SortFunc(db, func(a, b database.WorkspaceAgentMetadatum) int {
+		if c := cmp.Compare(a.DisplayOrder, b.DisplayOrder); c != 0 {
+			return c
 		}
-		return db[i].DisplayOrder < db[j].DisplayOrder
+		return cmp.Compare(a.Key, b.Key)
 	})
 
 	// An empty array is easier for clients to handle than a null.
@@ -2877,11 +2877,11 @@ func prependAgentChatContextSentinelIfNeeded(
 }
 
 func sortChatMessagesByCreatedAtAndID(messages []database.ChatMessage) {
-	sort.SliceStable(messages, func(i, j int) bool {
-		if messages[i].CreatedAt.Equal(messages[j].CreatedAt) {
-			return messages[i].ID < messages[j].ID
+	slices.SortStableFunc(messages, func(a, b database.ChatMessage) int {
+		if c := a.CreatedAt.Compare(b.CreatedAt); c != 0 {
+			return c
 		}
-		return messages[i].CreatedAt.Before(messages[j].CreatedAt)
+		return cmp.Compare(a.ID, b.ID)
 	})
 }
 

--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -1,6 +1,7 @@
 package coderd
 
 import (
+	"cmp"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -9,7 +10,6 @@ import (
 	"math"
 	"net/http"
 	"slices"
-	"sort"
 	"strconv"
 	"time"
 
@@ -1243,11 +1243,11 @@ func (api *API) convertWorkspaceBuild(
 	resourceAgentsMinOrder := map[uuid.UUID]int32{} // map[resource.ID]minOrder
 	for _, resource := range resources {
 		agents := agentsByResourceID[resource.ID]
-		sort.Slice(agents, func(i, j int) bool {
-			if agents[i].DisplayOrder != agents[j].DisplayOrder {
-				return agents[i].DisplayOrder < agents[j].DisplayOrder
+		slices.SortFunc(agents, func(a, b database.WorkspaceAgent) int {
+			if c := cmp.Compare(a.DisplayOrder, b.DisplayOrder); c != 0 {
+				return c
 			}
-			return agents[i].Name < agents[j].Name
+			return cmp.Compare(a.Name, b.Name)
 		})
 
 		apiAgents := make([]codersdk.WorkspaceAgent, 0)
@@ -1272,13 +1272,13 @@ func (api *API) convertWorkspaceBuild(
 		metadata := append(make([]database.WorkspaceResourceMetadatum, 0), metadataByResourceID[resource.ID]...)
 		apiResources = append(apiResources, convertWorkspaceResource(resource, apiAgents, metadata))
 	}
-	sort.Slice(apiResources, func(i, j int) bool {
-		orderI := resourceAgentsMinOrder[apiResources[i].ID]
-		orderJ := resourceAgentsMinOrder[apiResources[j].ID]
-		if orderI != orderJ {
-			return orderI < orderJ
+	slices.SortFunc(apiResources, func(a, b codersdk.WorkspaceResource) int {
+		orderA := resourceAgentsMinOrder[a.ID]
+		orderB := resourceAgentsMinOrder[b.ID]
+		if c := cmp.Compare(orderA, orderB); c != 0 {
+			return c
 		}
-		return apiResources[i].Name < apiResources[j].Name
+		return cmp.Compare(a.Name, b.Name)
 	})
 
 	var presetID *uuid.UUID

--- a/coderd/workspacestats/tracker.go
+++ b/coderd/workspacestats/tracker.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"flag"
 	"os"
-	"sort"
+	"slices"
 	"sync"
 	"time"
 
@@ -223,10 +223,10 @@ func (s *uuidSet) UniqueAndClear() []uuid.UUID {
 		l = append(l, k)
 	}
 	// For ease of testing, sort the IDs lexically
-	sort.Slice(l, func(i, j int) bool {
+	slices.SortFunc(l, func(a, b uuid.UUID) int {
 		// For some unfathomable reason, byte arrays are not comparable?
 		// See https://github.com/golang/go/issues/61004
-		return bytes.Compare(l[i][:], l[j][:]) < 0
+		return bytes.Compare(a[:], b[:])
 	})
 	clear(s.m)
 	return l

--- a/coderd/workspacestats/tracker_test.go
+++ b/coderd/workspacestats/tracker_test.go
@@ -2,7 +2,7 @@ package workspacestats_test
 
 import (
 	"bytes"
-	"sort"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -63,8 +63,8 @@ func TestTracker(t *testing.T) {
 	}
 
 	// Sort ids so mDB know what to expect.
-	sort.Slice(ids, func(i, j int) bool {
-		return bytes.Compare(ids[i][:], ids[j][:]) < 0
+	slices.SortFunc(ids, func(a, b uuid.UUID) int {
+		return bytes.Compare(a[:], b[:])
 	})
 
 	now = dbtime.Now()

--- a/coderd/x/chatd/chatprovider/chatprovider.go
+++ b/coderd/x/chatd/chatprovider/chatprovider.go
@@ -1,9 +1,10 @@
 package chatprovider
 
 import (
+	"cmp"
 	"context"
 	"net/http"
-	"sort"
+	"slices"
 	"strings"
 
 	"charm.land/fantasy"
@@ -492,8 +493,8 @@ func newChatModel(provider, modelID, displayName string) codersdk.ChatModel {
 }
 
 func sortChatModels(models []codersdk.ChatModel) {
-	sort.Slice(models, func(i, j int) bool {
-		return models[i].Model < models[j].Model
+	slices.SortFunc(models, func(a, b codersdk.ChatModel) int {
+		return cmp.Compare(a.Model, b.Model)
 	})
 }
 

--- a/coderd/x/chatd/subagent.go
+++ b/coderd/x/chatd/subagent.go
@@ -1,11 +1,12 @@
 package chatd
 
 import (
+	"cmp"
 	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -968,11 +969,11 @@ func latestSubagentAssistantMessage(
 		return "", xerrors.Errorf("get chat messages: %w", err)
 	}
 
-	sort.Slice(messages, func(i, j int) bool {
-		if messages[i].CreatedAt.Equal(messages[j].CreatedAt) {
-			return messages[i].ID < messages[j].ID
+	slices.SortFunc(messages, func(a, b database.ChatMessage) int {
+		if a.CreatedAt.Equal(b.CreatedAt) {
+			return cmp.Compare(a.ID, b.ID)
 		}
-		return messages[i].CreatedAt.Before(messages[j].CreatedAt)
+		return a.CreatedAt.Compare(b.CreatedAt)
 	})
 
 	for i := len(messages) - 1; i >= 0; i-- {

--- a/codersdk/templatevariables.go
+++ b/codersdk/templatevariables.go
@@ -1,11 +1,12 @@
 package codersdk
 
 import (
+	"cmp"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2/hclparse"
@@ -189,8 +190,8 @@ func convertMapIntoVariableValues(m map[string]string) []VariableValue {
 			Value: value,
 		})
 	}
-	sort.Slice(parsed, func(i, j int) bool {
-		return parsed[i].Name < parsed[j].Name
+	slices.SortFunc(parsed, func(a, b VariableValue) int {
+		return cmp.Compare(a.Name, b.Name)
 	})
 	return parsed
 }
@@ -265,8 +266,8 @@ func CombineVariableValues(valuesSets ...[]VariableValue) []VariableValue {
 		result = append(result, VariableValue{Name: name, Value: value})
 	}
 
-	sort.Slice(result, func(i, j int) bool {
-		return result[i].Name < result[j].Name
+	slices.SortFunc(result, func(a, b VariableValue) int {
+		return cmp.Compare(a.Name, b.Name)
 	})
 	return result
 }

--- a/codersdk/toolsdk/toolsdk_test.go
+++ b/codersdk/toolsdk/toolsdk_test.go
@@ -1,6 +1,7 @@
 package toolsdk_test
 
 import (
+	"cmp"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -10,7 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"sort"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -254,11 +255,11 @@ func TestTools(t *testing.T) {
 		require.Len(t, result, len(expected))
 
 		// Sort the results by name to ensure the order is consistent
-		sort.Slice(expected, func(a, b int) bool {
-			return expected[a].Name < expected[b].Name
+		slices.SortFunc(expected, func(a, b codersdk.Template) int {
+			return cmp.Compare(a.Name, b.Name)
 		})
-		sort.Slice(result, func(a, b int) bool {
-			return result[a].Name < result[b].Name
+		slices.SortFunc(result, func(a, b toolsdk.MinimalTemplate) int {
+			return cmp.Compare(a.Name, b.Name)
 		})
 		for i, template := range result {
 			require.Equal(t, expected[i].ID.String(), template.ID)

--- a/enterprise/coderd/groups_test.go
+++ b/enterprise/coderd/groups_test.go
@@ -1,9 +1,10 @@
 package coderd_test
 
 import (
+	"cmp"
 	"context"
 	"net/http"
-	"sort"
+	"slices"
 	"testing"
 	"time"
 
@@ -614,8 +615,8 @@ func normalizeGroupMembers(group *codersdk.Group) {
 		group.Members[i].CreatedAt = time.Time{}
 		group.Members[i].UpdatedAt = time.Time{}
 	}
-	sort.Slice(group.Members, func(i, j int) bool {
-		return group.Members[i].ID.String() < group.Members[j].ID.String()
+	slices.SortFunc(group.Members, func(a, b codersdk.ReducedUser) int {
+		return cmp.Compare(a.ID.String(), b.ID.String())
 	})
 }
 

--- a/enterprise/coderd/license/license.go
+++ b/enterprise/coderd/license/license.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"math"
 	"slices"
-	"sort"
 	"time"
 
 	"github.com/golang-jwt/jwt/v4"
@@ -803,8 +802,8 @@ func (p *licenseValidityPeriod) merged() [][2]time.Time {
 	// Sort the input periods by start time.
 	sorted := make([][2]time.Time, len(p.parts))
 	copy(sorted, p.parts)
-	sort.Slice(sorted, func(i, j int) bool {
-		return sorted[i][0].Before(sorted[j][0])
+	slices.SortFunc(sorted, func(a, b [2]time.Time) int {
+		return a[0].Compare(b[0])
 	})
 
 	out := make([][2]time.Time, 0, len(sorted))

--- a/enterprise/coderd/prebuilds/reconcile_test.go
+++ b/enterprise/coderd/prebuilds/reconcile_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"sort"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -2306,8 +2306,8 @@ func TestExpiredPrebuildsMultipleActions(t *testing.T) {
 			require.NoError(t, err)
 
 			// Sort non-expired workspaces by CreatedAt in ascending order (oldest first)
-			sort.Slice(nonExpiredWorkspaces, func(i, j int) bool {
-				return nonExpiredWorkspaces[i].CreatedAt.Before(nonExpiredWorkspaces[j].CreatedAt)
+			slices.SortFunc(nonExpiredWorkspaces, func(a, b database.WorkspaceTable) int {
+				return a.CreatedAt.Compare(b.CreatedAt)
 			})
 
 			// Verify the status of each non-expired workspace:

--- a/provisioner/terraform/diagnostic.go
+++ b/provisioner/terraform/diagnostic.go
@@ -2,8 +2,9 @@ package terraform
 
 import (
 	"bytes"
+	"cmp"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 
 	tfjson "github.com/hashicorp/terraform-json"
@@ -54,8 +55,8 @@ func appendSourceSnippets(buf *bytes.Buffer, diag *tfjson.Diagnostic) {
 			// "count" and "for_each", or within "for" expressions.
 			values := make([]tfjson.DiagnosticExpressionValue, len(snippet.Values))
 			copy(values, snippet.Values)
-			sort.Slice(values, func(i, j int) bool {
-				return values[i].Traversal < values[j].Traversal
+			slices.SortFunc(values, func(a, b tfjson.DiagnosticExpressionValue) int {
+				return cmp.Compare(a.Traversal, b.Traversal)
 			})
 
 			_, _ = buf.WriteString("    ├────────────────\n")

--- a/provisioner/terraform/provision_test.go
+++ b/provisioner/terraform/provision_test.go
@@ -3,6 +3,7 @@
 package terraform_test
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
@@ -11,7 +12,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -1205,8 +1206,8 @@ func TestProvision(t *testing.T) {
 
 func normalizeResources(resources []*proto.Resource) {
 	for _, resource := range resources {
-		sort.Slice(resource.Agents, func(i, j int) bool {
-			return resource.Agents[i].Name < resource.Agents[j].Name
+		slices.SortFunc(resource.Agents, func(a, b *proto.Agent) int {
+			return cmp.Compare(a.Name, b.Name)
 		})
 
 		for _, agent := range resource.Agents {
@@ -1217,8 +1218,8 @@ func normalizeResources(resources []*proto.Resource) {
 			agent.Auth = &proto.Agent_Token{}
 		}
 	}
-	sort.Slice(resources, func(i, j int) bool {
-		return resources[i].Name < resources[j].Name
+	slices.SortFunc(resources, func(a, b *proto.Resource) int {
+		return cmp.Compare(a.Name, b.Name)
 	})
 }
 

--- a/provisioner/terraform/resources_test.go
+++ b/provisioner/terraform/resources_test.go
@@ -1,6 +1,7 @@
 package terraform_test
 
 import (
+	stdcmp "cmp"
 	"context"
 	"crypto/sha256"
 	"encoding/json"
@@ -8,8 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"sort"
-	"strings"
+	"slices"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -1798,41 +1798,41 @@ func TestExternalAgents(t *testing.T) {
 // sortResource ensures resources appear in a consistent ordering
 // to prevent tests from flaking.
 func sortResources(resources []*proto.Resource) {
-	sort.Slice(resources, func(i, j int) bool {
-		if resources[i].Name != resources[j].Name {
-			return resources[i].Name < resources[j].Name
+	slices.SortFunc(resources, func(a, b *proto.Resource) int {
+		if c := stdcmp.Compare(a.Name, b.Name); c != 0 {
+			return c
 		}
-		return resources[i].Type < resources[j].Type
+		return stdcmp.Compare(a.Type, b.Type)
 	})
 	for _, resource := range resources {
 		for _, agent := range resource.Agents {
-			sort.Slice(agent.Apps, func(i, j int) bool {
-				return agent.Apps[i].Slug < agent.Apps[j].Slug
+			slices.SortFunc(agent.Apps, func(a, b *proto.App) int {
+				return stdcmp.Compare(a.Slug, b.Slug)
 			})
-			sort.Slice(agent.ExtraEnvs, func(i, j int) bool {
-				return agent.ExtraEnvs[i].Name < agent.ExtraEnvs[j].Name
+			slices.SortFunc(agent.ExtraEnvs, func(a, b *proto.Env) int {
+				return stdcmp.Compare(a.Name, b.Name)
 			})
-			sort.Slice(agent.Scripts, func(i, j int) bool {
-				return agent.Scripts[i].DisplayName < agent.Scripts[j].DisplayName
+			slices.SortFunc(agent.Scripts, func(a, b *proto.Script) int {
+				return stdcmp.Compare(a.DisplayName, b.DisplayName)
 			})
-			sort.Slice(agent.Devcontainers, func(i, j int) bool {
-				return agent.Devcontainers[i].Name < agent.Devcontainers[j].Name
+			slices.SortFunc(agent.Devcontainers, func(a, b *proto.Devcontainer) int {
+				return stdcmp.Compare(a.Name, b.Name)
 			})
 			for _, dc := range agent.Devcontainers {
-				sort.Slice(dc.Apps, func(i, j int) bool {
-					return dc.Apps[i].Slug < dc.Apps[j].Slug
+				slices.SortFunc(dc.Apps, func(a, b *proto.App) int {
+					return stdcmp.Compare(a.Slug, b.Slug)
 				})
 			}
 		}
-		sort.Slice(resource.Agents, func(i, j int) bool {
-			return resource.Agents[i].Name < resource.Agents[j].Name
+		slices.SortFunc(resource.Agents, func(a, b *proto.Agent) int {
+			return stdcmp.Compare(a.Name, b.Name)
 		})
 	}
 }
 
 func sortExternalAuthProviders(providers []*proto.ExternalAuthProviderResource) {
-	sort.Slice(providers, func(i, j int) bool {
-		return strings.Compare(providers[i].Id, providers[j].Id) == -1
+	slices.SortFunc(providers, func(a, b *proto.ExternalAuthProviderResource) int {
+		return stdcmp.Compare(a.Id, b.Id)
 	})
 }
 

--- a/provisioner/terraform/tfparse/tfparse.go
+++ b/provisioner/terraform/tfparse/tfparse.go
@@ -3,12 +3,12 @@ package tfparse
 import (
 	"archive/zip"
 	"bytes"
+	"cmp"
 	"context"
 	"encoding/json"
 	"io"
 	"os"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -249,8 +249,8 @@ func (p *Parser) TemplateVariables() ([]*proto.TemplateVariable, error) {
 	for _, v := range p.module.Variables {
 		variables = append(variables, v)
 	}
-	sort.Slice(variables, func(i, j int) bool {
-		return compareSourcePos(variables[i].Pos, variables[j].Pos)
+	slices.SortFunc(variables, func(a, b *tfconfig.Variable) int {
+		return compareSourcePos(a.Pos, b.Pos)
 	})
 
 	var templateVariables []*proto.TemplateVariable
@@ -542,11 +542,11 @@ func convertTerraformVariable(variable *tfconfig.Variable) (*proto.TemplateVaria
 	}, nil
 }
 
-func compareSourcePos(x, y tfconfig.SourcePos) bool {
-	if x.Filename != y.Filename {
-		return x.Filename < y.Filename
+func compareSourcePos(x, y tfconfig.SourcePos) int {
+	if c := cmp.Compare(x.Filename, y.Filename); c != 0 {
+		return c
 	}
-	return x.Line < y.Line
+	return cmp.Compare(x.Line, y.Line)
 }
 
 // CtyValueString converts a cty.Value to a string.

--- a/scaletest/autostart/output.go
+++ b/scaletest/autostart/output.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"sort"
+	"slices"
 	"time"
 
 	"golang.org/x/xerrors"
@@ -56,9 +56,7 @@ func NewRunResults(runs []RunResult) RunResults {
 
 	// Calculate percentiles for end-to-end latency.
 	if len(endToEndLatencies) > 0 {
-		sort.Slice(endToEndLatencies, func(i, j int) bool {
-			return endToEndLatencies[i] < endToEndLatencies[j]
-		})
+		slices.Sort(endToEndLatencies)
 		results.EndToEndLatencyP50 = percentile(endToEndLatencies, 0.50)
 		results.EndToEndLatencyP95 = percentile(endToEndLatencies, 0.95)
 		results.EndToEndLatencyP99 = percentile(endToEndLatencies, 0.99)
@@ -66,9 +64,7 @@ func NewRunResults(runs []RunResult) RunResults {
 
 	// Calculate percentiles for trigger to completion latency.
 	if len(triggerToCompletionLatencies) > 0 {
-		sort.Slice(triggerToCompletionLatencies, func(i, j int) bool {
-			return triggerToCompletionLatencies[i] < triggerToCompletionLatencies[j]
-		})
+		slices.Sort(triggerToCompletionLatencies)
 		results.TriggerToCompletionP50 = percentile(triggerToCompletionLatencies, 0.50)
 		results.TriggerToCompletionP95 = percentile(triggerToCompletionLatencies, 0.95)
 		results.TriggerToCompletionP99 = percentile(triggerToCompletionLatencies, 0.99)

--- a/scaletest/harness/strategies_test.go
+++ b/scaletest/harness/strategies_test.go
@@ -3,7 +3,7 @@ package harness_test
 import (
 	"context"
 	"io"
-	"sort"
+	"slices"
 	"strconv"
 	"sync/atomic"
 	"testing"
@@ -173,8 +173,8 @@ func Test_ShuffleExecutionStrategyWrapper(t *testing.T) {
 
 	sortedTimes := make([]time.Time, len(runs))
 	copy(sortedTimes, unsortedTimes)
-	sort.Slice(sortedTimes, func(i, j int) bool {
-		return sortedTimes[i].Before(sortedTimes[j])
+	slices.SortFunc(sortedTimes, func(a, b time.Time) int {
+		return a.Compare(b)
 	})
 
 	require.NotEqual(t, unsortedTimes, sortedTimes)

--- a/scripts/apidocgen/postprocess/main.go
+++ b/scripts/apidocgen/postprocess/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"cmp"
 	"encoding/json"
 	"flag"
 	"log"
@@ -10,7 +11,6 @@ import (
 	"path"
 	"regexp"
 	"slices"
-	"sort"
 	"strings"
 
 	"golang.org/x/xerrors"
@@ -162,14 +162,14 @@ func writeDocs(sections [][]byte) error {
 
 	// Sort API pages
 	// The "General" section is expected to be always first.
-	sort.Slice(mdFiles, func(i, j int) bool {
-		if mdFiles[i].title == "General" {
-			return true // "General" < ... - sorted
+	slices.SortFunc(mdFiles, func(a, b mdFile) int {
+		if a.title == "General" {
+			return -1 // "General" < ... - sorted
 		}
-		if mdFiles[j].title == "General" {
-			return false // ... < "General" - not sorted
+		if b.title == "General" {
+			return 1 // ... < "General" - not sorted
 		}
-		return slices.IsSorted([]string{mdFiles[i].title, mdFiles[j].title})
+		return cmp.Compare(a.title, b.title)
 	})
 
 	// Update manifest.json

--- a/scripts/clidocgen/main.go
+++ b/scripts/clidocgen/main.go
@@ -1,10 +1,11 @@
 package main
 
 import (
+	"cmp"
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/coder/coder/v2/enterprise/cli"
@@ -179,8 +180,8 @@ func main() {
 			}
 			// Sort children by title because wroteMap iteration is
 			// non-deterministic.
-			sort.Slice(child.Children, func(i, j int) bool {
-				return child.Children[i].Title < child.Children[j].Title
+			slices.SortFunc(child.Children, func(a, b route) int {
+				return cmp.Compare(a.Title, b.Title)
 			})
 		}
 	}

--- a/scripts/metricsdocgen/main.go
+++ b/scripts/metricsdocgen/main.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"bytes"
+	"cmp"
 	"errors"
 	"flag"
 	"io"
 	"log"
 	"os"
-	"sort"
+	"slices"
 	"strings"
 
 	dto "github.com/prometheus/client_model/go"
@@ -123,8 +124,8 @@ func readAndMergeMetrics() ([]*dto.MetricFamily, error) {
 		metrics = append(metrics, m)
 	}
 
-	sort.Slice(metrics, func(i, j int) bool {
-		return *metrics[i].Name < *metrics[j].Name
+	slices.SortFunc(metrics, func(a, b *dto.MetricFamily) int {
+		return cmp.Compare(*a.Name, *b.Name)
 	})
 
 	return metrics, nil

--- a/scripts/metricsdocgen/scanner/scanner.go
+++ b/scripts/metricsdocgen/scanner/scanner.go
@@ -8,6 +8,7 @@
 package main
 
 import (
+	"cmp"
 	"fmt"
 	"go/ast"
 	"go/parser"
@@ -17,7 +18,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 
 	"golang.org/x/term"
@@ -118,8 +119,8 @@ func main() {
 	}
 
 	// Sort metrics by name for consistent output across runs.
-	sort.Slice(metrics, func(i, j int) bool {
-		return metrics[i].Name < metrics[j].Name
+	slices.SortFunc(metrics, func(a, b Metric) int {
+		return cmp.Compare(a.Name, b.Name)
 	})
 
 	writeMetrics(metrics, os.Stdout)

--- a/scripts/releaser/commit.go
+++ b/scripts/releaser/commit.go
@@ -1,8 +1,9 @@
 package main
 
 import (
+	"cmp"
 	"regexp"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -92,13 +93,13 @@ func commitLog(commitRange string) ([]commitEntry, error) {
 
 	// Sort by conventional commit prefix, then by timestamp
 	// (matching the bash script's sort -k3,3 -k1,1n).
-	sort.SliceStable(entries, func(i, j int) bool {
-		pi := commitSortPrefix(entries[i].Title)
-		pj := commitSortPrefix(entries[j].Title)
-		if pi != pj {
-			return pi < pj
+	slices.SortStableFunc(entries, func(a, b commitEntry) int {
+		pa := commitSortPrefix(a.Title)
+		pb := commitSortPrefix(b.Title)
+		if c := cmp.Compare(pa, pb); c != 0 {
+			return c
 		}
-		return entries[i].Timestamp < entries[j].Timestamp
+		return cmp.Compare(a.Timestamp, b.Timestamp)
 	})
 
 	return entries, nil

--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -1,6 +1,7 @@
 package vpn
 
 import (
+	"cmp"
 	"context"
 	"database/sql/driver"
 	"encoding/json"
@@ -10,7 +11,7 @@ import (
 	"net/netip"
 	"net/url"
 	"reflect"
-	"sort"
+	"slices"
 	"strconv"
 	"sync"
 	"time"
@@ -467,8 +468,8 @@ func (u *updater) createPeerUpdateLocked(update tailnet.WorkspaceUpdate) *PeerUp
 		for name := range agent.Hosts {
 			fqdn = append(fqdn, name.WithTrailingDot())
 		}
-		sort.Slice(fqdn, func(i, j int) bool {
-			return len(fqdn[i]) < len(fqdn[j])
+		slices.SortFunc(fqdn, func(a, b string) int {
+			return cmp.Compare(len(a), len(b))
 		})
 		out.DeletedAgents[i] = &Agent{
 			Id:            tailnet.UUIDToByteSlice(agent.ID),
@@ -492,8 +493,8 @@ func (u *updater) convertAgentsLocked(agents []*agentWithPing) []*Agent {
 		for name := range agent.Hosts {
 			fqdn = append(fqdn, name.WithTrailingDot())
 		}
-		sort.Slice(fqdn, func(i, j int) bool {
-			return len(fqdn[i]) < len(fqdn[j])
+		slices.SortFunc(fqdn, func(a, b string) int {
+			return cmp.Compare(len(a), len(b))
 		})
 		var lastPing *LastPing
 		if agent.lastPing != nil {


### PR DESCRIPTION
🤖 Agent on behalf of mafredri

Continues the sort-to-slices migration from #23457. Converts all 85 `sort.Slice` and `sort.SliceStable` call sites to `slices.SortFunc` and `slices.SortStableFunc` with `cmp.Compare` comparators.

Comparator conversions follow these patterns:
- Simple `<` on ordered types uses `cmp.Compare(a.X, b.X)`
- `time.Before`/`After` uses `a.T.Compare(b.T)`
- Multi-field fallback chains use `if c := cmp.Compare(...); c != 0 { return c }`
- Plain ordered-type slices (e.g. `coderd/util/maps`) simplified to `slices.Sort`

> 🤖 This PR was created with the help of Coder Agents, and reviewed by a human. 🏂🏻