### PR TITLE
feat: replace DeploymentBanner scrollbar with slide navigation

### DIFF
--- a/site/src/modules/dashboard/DeploymentBanner/DeploymentBannerView.tsx
+++ b/site/src/modules/dashboard/DeploymentBanner/DeploymentBannerView.tsx
@@ -19,6 +19,8 @@ import {
 import dayjs from "dayjs";
 import {
 	AppWindowIcon,
+	ChevronLeftIcon,
+	ChevronRightIcon,
 	CircleAlertIcon,
 	CloudDownloadIcon,
 	CloudUploadIcon,
@@ -31,11 +33,14 @@ import prettyBytes from "pretty-bytes";
 import {
 	type FC,
 	type PropsWithChildren,
+	useCallback,
 	useEffect,
 	useMemo,
+	useRef,
 	useState,
 } from "react";
 import { Link as RouterLink } from "react-router";
+import { cn } from "utils/cn";
 import { getDisplayWorkspaceStatus } from "utils/workspace";
 
 interface DeploymentBannerViewProps {
@@ -100,11 +105,80 @@ export const DeploymentBannerView: FC<DeploymentBannerViewProps> = ({
 	const healthErrors = health ? getHealthErrors(health) : [];
 	const displayLatency = stats?.workspaces.connection_latency_ms.P50 || -1;
 
+	// ── Slide navigation state ──────────────────────────────
+	const wrapperRef = useRef<HTMLDivElement>(null);
+	const trackRef = useRef<HTMLDivElement>(null);
+	const [offset, setOffset] = useState(0);
+	const [canSlide, setCanSlide] = useState({ left: false, right: false });
+
+	const recalc = useCallback((nextOffset: number) => {
+		const wrapper = wrapperRef.current;
+		const track = trackRef.current;
+		if (!wrapper || !track) return nextOffset;
+		const max = Math.max(0, track.scrollWidth - wrapper.clientWidth);
+		const clamped = Math.max(0, Math.min(max, nextOffset));
+		setCanSlide({ left: clamped > 0, right: clamped < max - 1 });
+		return clamped;
+	}, []);
+
+	// Snap to the nearest section boundary so we never land mid-label.
+	const snap = useCallback((raw: number) => {
+		const track = trackRef.current;
+		if (!track) return raw;
+		const sections = track.querySelectorAll<HTMLElement>(
+			"[data-banner-section]",
+		);
+		let best = raw;
+		let bestDist = Number.POSITIVE_INFINITY;
+		for (const el of sections) {
+			const boundary = el.offsetLeft;
+			const dist = Math.abs(boundary - raw);
+			if (dist < bestDist) {
+				bestDist = dist;
+				best = boundary;
+			}
+		}
+		return best;
+	}, []);
+
+	const slideTo = useCallback(
+		(px: number) => {
+			const clamped = recalc(px);
+			setOffset(clamped);
+		},
+		[recalc],
+	);
+
+	const slideNext = useCallback(() => {
+		const step = Math.round((wrapperRef.current?.clientWidth ?? 400) * 0.9);
+		slideTo(snap(offset + step));
+	}, [offset, snap, slideTo]);
+
+	const slidePrev = useCallback(() => {
+		const step = Math.round((wrapperRef.current?.clientWidth ?? 400) * 0.9);
+		slideTo(snap(offset - step));
+	}, [offset, snap, slideTo]);
+
+	// Recalculate on mount and resize.
+	useEffect(() => {
+		const onResize = () => slideTo(offset);
+		onResize();
+		window.addEventListener("resize", onResize);
+		return () => window.removeEventListener("resize", onResize);
+	}, [offset, slideTo]);
+
+	// Recalculate whenever stats change (content may reflow).
+	// biome-ignore lint/correctness/useExhaustiveDependencies(stats): content may reflow when stats change
+	// biome-ignore lint/correctness/useExhaustiveDependencies(health): content may reflow when health changes
+	useEffect(() => {
+		slideTo(offset);
+	}, [stats, health, offset, slideTo]);
+
 	return (
 		<div
-			className="sticky bottom-0 z-[1] flex h-9 w-full items-center gap-8
-		 		overflow-x-auto overflow-y-hidden whitespace-nowrap border-0 border-t border-solid border-border
-				bg-surface-primary pr-4 font-mono text-xs leading-none [scrollbar-width:thin]"
+			className="sticky bottom-0 z-[1] flex h-9 w-full items-center
+				whitespace-nowrap border-0 border-t border-solid border-border
+				bg-surface-primary font-mono text-xs leading-none"
 		>
 			<TooltipProvider delayDuration={100}>
 				<Tooltip>
@@ -124,7 +198,7 @@ export const DeploymentBannerView: FC<DeploymentBannerViewProps> = ({
 							</Link>
 						) : (
 							<div
-								className="flex h-full items-center justify-center pl-3"
+								className="flex h-full items-center justify-center px-3"
 								data-testid="deployment-health-trigger"
 							>
 								<RocketIcon className="size-icon-sm" />
@@ -153,201 +227,266 @@ export const DeploymentBannerView: FC<DeploymentBannerViewProps> = ({
 				</Tooltip>
 			</TooltipProvider>
 
-			<div className="flex items-center">
-				<div className="mr-4 text-content-primary">Workspaces</div>
-				<div className="flex gap-2 text-content-secondary">
-					<WorkspaceBuildValue
-						status="pending"
-						count={stats?.workspaces.pending}
-					/>
-					<ValueSeparator />
-					<WorkspaceBuildValue
-						status="starting"
-						count={stats?.workspaces.building}
-					/>
-					<ValueSeparator />
-					<WorkspaceBuildValue
-						status="running"
-						count={stats?.workspaces.running}
-					/>
-					<ValueSeparator />
-					<WorkspaceBuildValue
-						status="stopped"
-						count={stats?.workspaces.stopped}
-					/>
-					<ValueSeparator />
-					<WorkspaceBuildValue
-						status="failed"
-						count={stats?.workspaces.failed}
-					/>
+			{/* ── Sliding track ─────────────────────── */}
+			<div ref={wrapperRef} className="relative flex-1 overflow-hidden h-full">
+				{/* Left edge fade */}
+				<div
+					className={cn(
+						"pointer-events-none absolute inset-y-0 left-0 z-10 w-12 transition-opacity duration-300",
+						"bg-gradient-to-r from-surface-primary to-transparent",
+						canSlide.left ? "opacity-100" : "opacity-0",
+					)}
+				/>
+				{/* Right edge fade */}
+				<div
+					className={cn(
+						"pointer-events-none absolute inset-y-0 right-0 z-10 w-12 transition-opacity duration-300",
+						"bg-gradient-to-l from-surface-primary to-transparent",
+						canSlide.right ? "opacity-100" : "opacity-0",
+					)}
+				/>
+
+				<div
+					ref={trackRef}
+					className="flex h-full items-center gap-8 pr-4 transition-transform duration-[400ms] ease-[cubic-bezier(.4,0,.2,1)]"
+					style={{ transform: `translateX(-${offset}px)` }}
+				>
+					<div className="flex items-center" data-banner-section>
+						<div className="mr-4 text-content-primary">Workspaces</div>
+						<div className="flex gap-2 text-content-secondary">
+							<WorkspaceBuildValue
+								status="pending"
+								count={stats?.workspaces.pending}
+							/>
+							<ValueSeparator />
+							<WorkspaceBuildValue
+								status="starting"
+								count={stats?.workspaces.building}
+							/>
+							<ValueSeparator />
+							<WorkspaceBuildValue
+								status="running"
+								count={stats?.workspaces.running}
+							/>
+							<ValueSeparator />
+							<WorkspaceBuildValue
+								status="stopped"
+								count={stats?.workspaces.stopped}
+							/>
+							<ValueSeparator />
+							<WorkspaceBuildValue
+								status="failed"
+								count={stats?.workspaces.failed}
+							/>
+						</div>
+					</div>
+
+					<div className="flex items-center" data-banner-section>
+						<TooltipProvider delayDuration={100}>
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<div className="mr-4 text-content-primary">Transmission</div>
+								</TooltipTrigger>
+								<TooltipContent>
+									{`Activity in the last ~${aggregatedMinutes} minutes`}
+								</TooltipContent>
+							</Tooltip>
+						</TooltipProvider>
+						<div className="flex gap-2 text-content-secondary">
+							<TooltipProvider delayDuration={100}>
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<div className="flex items-center gap-1">
+											<CloudDownloadIcon className="size-icon-xs" />
+											{stats ? prettyBytes(stats.workspaces.rx_bytes) : "-"}
+										</div>
+									</TooltipTrigger>
+									<TooltipContent>Data sent to workspaces</TooltipContent>
+								</Tooltip>
+							</TooltipProvider>
+							<ValueSeparator />
+							<TooltipProvider delayDuration={100}>
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<div className="flex items-center gap-1">
+											<CloudUploadIcon className="size-icon-xs" />
+											{stats ? prettyBytes(stats.workspaces.tx_bytes) : "-"}
+										</div>
+									</TooltipTrigger>
+									<TooltipContent>Data sent from workspaces</TooltipContent>
+								</Tooltip>
+							</TooltipProvider>
+							<ValueSeparator />
+							<TooltipProvider delayDuration={100}>
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<div className="flex items-center gap-1">
+											<GaugeIcon className="size-icon-xs" />
+											{displayLatency > 0
+												? `${displayLatency?.toFixed(2)} ms`
+												: "-"}
+										</div>
+									</TooltipTrigger>
+									<TooltipContent>
+										{displayLatency < 0
+											? "No recent workspace connections have been made"
+											: "The average latency of user connections to workspaces"}
+									</TooltipContent>
+								</Tooltip>
+							</TooltipProvider>
+						</div>
+					</div>
+
+					<div className="flex items-center" data-banner-section>
+						<div className="mr-4 text-content-primary">Active Connections</div>
+
+						<div className="flex gap-2 text-content-secondary">
+							<TooltipProvider delayDuration={100}>
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<div className="flex items-center gap-1">
+											<VSCodeIcon className="size-icon-xs [&_*]:fill-current" />
+											{typeof stats?.session_count.vscode === "undefined"
+												? "-"
+												: stats?.session_count.vscode}
+										</div>
+									</TooltipTrigger>
+									<TooltipContent>
+										VS Code Editors with the Coder Remote Extension
+									</TooltipContent>
+								</Tooltip>
+							</TooltipProvider>
+							<ValueSeparator />
+							<TooltipProvider delayDuration={100}>
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<div className="flex items-center gap-1">
+											<JetBrainsIcon className="size-icon-xs [&_*]:fill-current" />
+											{typeof stats?.session_count.jetbrains === "undefined"
+												? "-"
+												: stats?.session_count.jetbrains}
+										</div>
+									</TooltipTrigger>
+									<TooltipContent>JetBrains Editors</TooltipContent>
+								</Tooltip>
+							</TooltipProvider>
+							<ValueSeparator />
+							<TooltipProvider delayDuration={100}>
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<div className="flex items-center gap-1">
+											<TerminalIcon className="size-icon-xs" />
+											{typeof stats?.session_count.ssh === "undefined"
+												? "-"
+												: stats?.session_count.ssh}
+										</div>
+									</TooltipTrigger>
+									<TooltipContent>SSH Sessions</TooltipContent>
+								</Tooltip>
+							</TooltipProvider>
+							<ValueSeparator />
+							<TooltipProvider delayDuration={100}>
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<div className="flex items-center gap-1">
+											<AppWindowIcon className="size-icon-xs" />
+											{typeof stats?.session_count.reconnecting_pty ===
+											"undefined"
+												? "-"
+												: stats?.session_count.reconnecting_pty}
+										</div>
+									</TooltipTrigger>
+									<TooltipContent>Web Terminal Sessions</TooltipContent>
+								</Tooltip>
+							</TooltipProvider>
+						</div>
+					</div>
+
+					<div
+						className="ml-auto flex mr-3 items-center gap-8 text-content-primary"
+						data-banner-section
+					>
+						<TooltipProvider delayDuration={100}>
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<div className="flex items-center gap-1">
+										<GitCompareArrowsIcon className="size-icon-xs" />
+										{lastAggregated}
+									</div>
+								</TooltipTrigger>
+								<TooltipContent
+									className="max-w-xs"
+									collisionPadding={{ right: 20 }}
+								>
+									The last time stats were aggregated. Workspaces report
+									statistics periodically, so it may take a bit for these to
+									update!
+								</TooltipContent>
+							</Tooltip>
+						</TooltipProvider>
+
+						<TooltipProvider delayDuration={100}>
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<Button
+										className="font-mono [&_svg]:mr-1"
+										onClick={() => {
+											if (fetchStats) {
+												fetchStats();
+											}
+										}}
+										variant="subtle"
+										size="icon"
+									>
+										<RotateCwIcon />
+										{timeUntilRefresh}s
+									</Button>
+								</TooltipTrigger>
+								<TooltipContent
+									className="max-w-xs"
+									collisionPadding={{ right: 20 }}
+								>
+									A countdown until stats are fetched again. Click to refresh!
+								</TooltipContent>
+							</Tooltip>
+						</TooltipProvider>
+					</div>
 				</div>
 			</div>
 
-			<div className="flex items-center">
-				<TooltipProvider delayDuration={100}>
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<div className="mr-4 text-content-primary">Transmission</div>
-						</TooltipTrigger>
-						<TooltipContent>
-							{`Activity in the last ~${aggregatedMinutes} minutes`}
-						</TooltipContent>
-					</Tooltip>
-				</TooltipProvider>
-				<div className="flex gap-2 text-content-secondary">
-					<TooltipProvider delayDuration={100}>
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<div className="flex items-center gap-1">
-									<CloudDownloadIcon className="size-icon-xs" />
-									{stats ? prettyBytes(stats.workspaces.rx_bytes) : "-"}
-								</div>
-							</TooltipTrigger>
-							<TooltipContent>Data sent to workspaces</TooltipContent>
-						</Tooltip>
-					</TooltipProvider>
-					<ValueSeparator />
-					<TooltipProvider delayDuration={100}>
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<div className="flex items-center gap-1">
-									<CloudUploadIcon className="size-icon-xs" />
-									{stats ? prettyBytes(stats.workspaces.tx_bytes) : "-"}
-								</div>
-							</TooltipTrigger>
-							<TooltipContent>Data sent from workspaces</TooltipContent>
-						</Tooltip>
-					</TooltipProvider>
-					<ValueSeparator />
-					<TooltipProvider delayDuration={100}>
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<div className="flex items-center gap-1">
-									<GaugeIcon className="size-icon-xs" />
-									{displayLatency > 0
-										? `${displayLatency?.toFixed(2)} ms`
-										: "-"}
-								</div>
-							</TooltipTrigger>
-							<TooltipContent>
-								{displayLatency < 0
-									? "No recent workspace connections have been made"
-									: "The average latency of user connections to workspaces"}
-							</TooltipContent>
-						</Tooltip>
-					</TooltipProvider>
+			{/* ── Chevron navigation ────────────────── */}
+			{(canSlide.left || canSlide.right) && (
+				<div className="flex items-center gap-0.5 px-1.5 h-full shrink-0 border-0 border-l border-solid border-border">
+					<button
+						type="button"
+						aria-label="Scroll left"
+						disabled={!canSlide.left}
+						onClick={slidePrev}
+						className={cn(
+							"flex items-center justify-center size-6 rounded border-none bg-transparent cursor-pointer",
+							"text-content-secondary transition-colors duration-150",
+							"hover:bg-surface-tertiary hover:text-content-primary",
+							"disabled:opacity-20 disabled:pointer-events-none",
+						)}
+					>
+						<ChevronLeftIcon className="size-3.5" />
+					</button>
+					<button
+						type="button"
+						aria-label="Scroll right"
+						disabled={!canSlide.right}
+						onClick={slideNext}
+						className={cn(
+							"flex items-center justify-center size-6 rounded border-none bg-transparent cursor-pointer",
+							"text-content-secondary transition-colors duration-150",
+							"hover:bg-surface-tertiary hover:text-content-primary",
+							"disabled:opacity-20 disabled:pointer-events-none",
+						)}
+					>
+						<ChevronRightIcon className="size-3.5" />
+					</button>
 				</div>
-			</div>
-
-			<div className="flex items-center">
-				<div className="mr-4 text-content-primary">Active Connections</div>
-
-				<div className="flex gap-2 text-content-secondary">
-					<TooltipProvider delayDuration={100}>
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<div className="flex items-center gap-1">
-									<VSCodeIcon className="size-icon-xs [&_*]:fill-current" />
-									{typeof stats?.session_count.vscode === "undefined"
-										? "-"
-										: stats?.session_count.vscode}
-								</div>
-							</TooltipTrigger>
-							<TooltipContent>
-								VS Code Editors with the Coder Remote Extension
-							</TooltipContent>
-						</Tooltip>
-					</TooltipProvider>
-					<ValueSeparator />
-					<TooltipProvider delayDuration={100}>
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<div className="flex items-center gap-1">
-									<JetBrainsIcon className="size-icon-xs [&_*]:fill-current" />
-									{typeof stats?.session_count.jetbrains === "undefined"
-										? "-"
-										: stats?.session_count.jetbrains}
-								</div>
-							</TooltipTrigger>
-							<TooltipContent>JetBrains Editors</TooltipContent>
-						</Tooltip>
-					</TooltipProvider>
-					<ValueSeparator />
-					<TooltipProvider delayDuration={100}>
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<div className="flex items-center gap-1">
-									<TerminalIcon className="size-icon-xs" />
-									{typeof stats?.session_count.ssh === "undefined"
-										? "-"
-										: stats?.session_count.ssh}
-								</div>
-							</TooltipTrigger>
-							<TooltipContent>SSH Sessions</TooltipContent>
-						</Tooltip>
-					</TooltipProvider>
-					<ValueSeparator />
-					<TooltipProvider delayDuration={100}>
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<div className="flex items-center gap-1">
-									<AppWindowIcon className="size-icon-xs" />
-									{typeof stats?.session_count.reconnecting_pty === "undefined"
-										? "-"
-										: stats?.session_count.reconnecting_pty}
-								</div>
-							</TooltipTrigger>
-							<TooltipContent>Web Terminal Sessions</TooltipContent>
-						</Tooltip>
-					</TooltipProvider>
-				</div>
-			</div>
-
-			<div className="ml-auto flex mr-3 items-center gap-8 text-content-primary">
-				<TooltipProvider delayDuration={100}>
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<div className="flex items-center gap-1">
-								<GitCompareArrowsIcon className="size-icon-xs" />
-								{lastAggregated}
-							</div>
-						</TooltipTrigger>
-						<TooltipContent
-							className="max-w-xs"
-							collisionPadding={{ right: 20 }}
-						>
-							The last time stats were aggregated. Workspaces report statistics
-							periodically, so it may take a bit for these to update!
-						</TooltipContent>
-					</Tooltip>
-				</TooltipProvider>
-
-				<TooltipProvider delayDuration={100}>
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								className="font-mono [&_svg]:mr-1"
-								onClick={() => {
-									if (fetchStats) {
-										fetchStats();
-									}
-								}}
-								variant="subtle"
-								size="icon"
-							>
-								<RotateCwIcon />
-								{timeUntilRefresh}s
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent
-							className="max-w-xs"
-							collisionPadding={{ right: 20 }}
-						>
-							A countdown until stats are fetched again. Click to refresh!
-						</TooltipContent>
-					</Tooltip>
-				</TooltipProvider>
-			</div>
+			)}
 		</div>
 	);
 };

--- a/site/src/modules/dashboard/DeploymentBanner/DeploymentBannerView.tsx
+++ b/site/src/modules/dashboard/DeploymentBanner/DeploymentBannerView.tsx
@@ -174,8 +174,41 @@ export const DeploymentBannerView: FC<DeploymentBannerViewProps> = ({
 		slideTo(offset);
 	}, [stats, health, offset, slideTo]);
 
+	// When a keyboard user tabs to an element that's been translated
+	// off-screen, auto-slide so the focused element is visible.
+	// This satisfies WCAG 2.4.7 (Focus Visible).
+	useEffect(() => {
+		const wrapper = wrapperRef.current;
+		if (!wrapper) return;
+
+		const onFocusIn = (e: FocusEvent) => {
+			const target = e.target as HTMLElement;
+			const track = trackRef.current;
+			if (!track || !wrapper.contains(target)) return;
+
+			// Position of the focused element relative to the track.
+			const elLeft = target.offsetLeft;
+			const elRight = elLeft + target.offsetWidth;
+			const visibleLeft = offset;
+			const visibleRight = offset + wrapper.clientWidth;
+
+			if (elLeft < visibleLeft) {
+				// Element is clipped on the left — slide back.
+				slideTo(snap(elLeft));
+			} else if (elRight > visibleRight) {
+				// Element is clipped on the right — slide forward.
+				slideTo(snap(elRight - wrapper.clientWidth));
+			}
+		};
+
+		wrapper.addEventListener("focusin", onFocusIn);
+		return () => wrapper.removeEventListener("focusin", onFocusIn);
+	}, [offset, snap, slideTo]);
+
 	return (
 		<div
+			role="region"
+			aria-label="Deployment statistics"
 			className="sticky bottom-0 z-[1] flex h-9 w-full items-center
 				whitespace-nowrap border-0 border-t border-solid border-border
 				bg-surface-primary font-mono text-xs leading-none"
@@ -229,23 +262,24 @@ export const DeploymentBannerView: FC<DeploymentBannerViewProps> = ({
 
 			{/* ── Sliding track ─────────────────────── */}
 			<div ref={wrapperRef} className="relative flex-1 overflow-hidden h-full">
-				{/* Left edge fade */}
+				{/* Left edge fade — decorative */}
 				<div
+					aria-hidden="true"
 					className={cn(
 						"pointer-events-none absolute inset-y-0 left-0 z-10 w-12 transition-opacity duration-300",
 						"bg-gradient-to-r from-surface-primary to-transparent",
 						canSlide.left ? "opacity-100" : "opacity-0",
 					)}
 				/>
-				{/* Right edge fade */}
+				{/* Right edge fade — decorative */}
 				<div
+					aria-hidden="true"
 					className={cn(
 						"pointer-events-none absolute inset-y-0 right-0 z-10 w-12 transition-opacity duration-300",
 						"bg-gradient-to-l from-surface-primary to-transparent",
 						canSlide.right ? "opacity-100" : "opacity-0",
 					)}
 				/>
-
 				<div
 					ref={trackRef}
 					className="flex h-full items-center gap-8 pr-4 transition-transform duration-[400ms] ease-[cubic-bezier(.4,0,.2,1)]"
@@ -456,7 +490,11 @@ export const DeploymentBannerView: FC<DeploymentBannerViewProps> = ({
 
 			{/* ── Chevron navigation ────────────────── */}
 			{(canSlide.left || canSlide.right) && (
-				<div className="flex items-center gap-0.5 px-1.5 h-full shrink-0 border-0 border-l border-solid border-border">
+				<nav
+					aria-label="Scroll deployment banner"
+					className="flex items-center gap-0.5 px-1.5 h-full shrink-0 border-0 border-l border-solid border-border"
+				>
+					{" "}
 					<button
 						type="button"
 						aria-label="Scroll left"
@@ -485,12 +523,11 @@ export const DeploymentBannerView: FC<DeploymentBannerViewProps> = ({
 					>
 						<ChevronRightIcon className="size-3.5" />
 					</button>
-				</div>
+				</nav>
 			)}
 		</div>
 	);
 };
-
 interface WorkspaceBuildValueProps {
 	status: WorkspaceStatus;
 	count?: number;


### PR DESCRIPTION
## Summary

Replace the horizontal scrollbar (`overflow-x-auto`) on the deployment status banner with a chevron-based slide navigation pattern.

## Changes

Single file change: `site/src/modules/dashboard/DeploymentBanner/DeploymentBannerView.tsx`

### What's different

- **No scrollbar** — `overflow-x-auto` replaced with a hidden-overflow track wrapper
- **Chevron buttons** (`‹ ›`) appear on the right when content overflows
- **Edge fade masks** — gradient fades on left/right edges indicate more content in that direction
- **Viewport-aware stepping** — each click slides ~90% of visible width, snapping to nearest section boundary
- **Auto-hide** — chevrons disappear entirely when all content fits the viewport
- **Responsive** — recalculates on resize and when stats/health data changes

### What's preserved

All existing content, layout, tooltips, links, and styling remain identical.

## Demo

Prototype: https://8080--main--sticky-bottom-prototype--tracy--apps.dev.coder.com (requires Coder auth)