### PR TITLE
fix(site): use HttpResponse constructor for binary mock response

### DIFF
--- a/site/src/testHelpers/handlers.ts
+++ b/site/src/testHelpers/handlers.ts
@@ -343,7 +343,7 @@ export const handlers = [
 			path.resolve(__dirname, "./templateFiles.tar"),
 		);
 
-		return HttpResponse.arrayBuffer(fileBuffer);
+		return new HttpResponse(fileBuffer);
 	}),
 
 	http.get("/api/v2/templateversions/:templateVersionId/parameters", () => {


### PR DESCRIPTION
## Context

`./scripts/develop.sh` was failing to build in my dogfood workspace with:

```
src/testHelpers/handlers.ts(346,35): error TS2345: Argument of type 'NonSharedBuffer'
is not assignable to parameter of type 'ArrayBuffer'.
  Type 'Buffer<ArrayBuffer>' is missing the following properties from type 'ArrayBuffer':
  maxByteLength, resizable, resize, detached, and 2 more.
```

## Alternatives considered

**`fileBuffer.buffer`** — `.buffer` gives you the underlying `ArrayBuffer`, but Node pools small buffers into a shared 8 KB slab. A `Buffer.from("hello")` has `byteOffset: 1472` and `.buffer.byteLength: 8192` — passing `.buffer` to a `Response` sends all 8,192 bytes instead of 5. It happens to work for `readFileSync` (dedicated allocation, offset 0), but breaks silently if someone refactors how the buffer is constructed.

**`fileBuffer.buffer.slice(byteOffset, byteOffset + byteLength)`** — the safe version of the above. Always correct, but unnecessarily complex.

**`new HttpResponse(fileBuffer)`** (chosen) — `HttpResponse` extends `Response`, whose constructor accepts `BodyInit` which includes `Uint8Array`. When you pass a typed array view, `Response` reads only the bytes within that view (respecting `byteOffset`/`byteLength`), so it's safe regardless of pooling. `Buffer` is a `Uint8Array` subclass, so this just works:

```
pooled = Buffer.from("hello")   → byteOffset: 1472, .buffer: 8192 bytes
new Response(pooled.buffer)     → body: 8192 bytes ✗
new Response(pooled)            → body: 5 bytes    ✓
```
