### PR TITLE
feat: return structured response from edit_files

### DIFF
--- a/agent/agentfiles/files.go
+++ b/agent/agentfiles/files.go
@@ -363,14 +363,18 @@ func (api *API) HandleEditFiles(rw http.ResponseWriter, r *http.Request) {
 
 	var combinedErr error
 	status := http.StatusOK
+	var results []workspacesdk.FileEditResult
 	for _, edit := range req.Files {
-		s, err := api.editFile(r.Context(), edit.Path, edit.Edits)
+		s, result, err := api.editFile(r.Context(), edit.Path, edit.Edits)
 		// Keep the highest response status, so 500 will be preferred over 400, etc.
 		if s > status {
 			status = s
 		}
 		if err != nil {
 			combinedErr = errors.Join(combinedErr, err)
+		}
+		if result != nil {
+			results = append(results, *result)
 		}
 	}
 
@@ -392,22 +396,22 @@ func (api *API) HandleEditFiles(rw http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	httpapi.Write(ctx, rw, http.StatusOK, codersdk.Response{
-		Message: "Successfully edited file(s)",
+	httpapi.Write(ctx, rw, http.StatusOK, workspacesdk.FileEditResponse{
+		Files: results,
 	})
 }
 
-func (api *API) editFile(ctx context.Context, path string, edits []workspacesdk.FileEdit) (int, error) {
+func (api *API) editFile(ctx context.Context, path string, edits []workspacesdk.FileEdit) (int, *workspacesdk.FileEditResult, error) {
 	if path == "" {
-		return http.StatusBadRequest, xerrors.New("\"path\" is required")
+		return http.StatusBadRequest, nil, xerrors.New("\"path\" is required")
 	}
 
 	if !filepath.IsAbs(path) {
-		return http.StatusBadRequest, xerrors.Errorf("file path must be absolute: %q", path)
+		return http.StatusBadRequest, nil, xerrors.Errorf("file path must be absolute: %q", path)
 	}
 
 	if len(edits) == 0 {
-		return http.StatusBadRequest, xerrors.New("must specify at least one edit")
+		return http.StatusBadRequest, nil, xerrors.New("must specify at least one edit")
 	}
 
 	f, err := api.filesystem.Open(path)
@@ -419,35 +423,50 @@ func (api *API) editFile(ctx context.Context, path string, edits []workspacesdk.
 		case errors.Is(err, os.ErrPermission):
 			status = http.StatusForbidden
 		}
-		return status, err
+		return status, nil, err
 	}
 	defer f.Close()
 
 	stat, err := f.Stat()
 	if err != nil {
-		return http.StatusInternalServerError, err
+		return http.StatusInternalServerError, nil, err
 	}
 
 	if stat.IsDir() {
-		return http.StatusBadRequest, xerrors.Errorf("open %s: not a file", path)
+		return http.StatusBadRequest, nil, xerrors.Errorf("open %s: not a file", path)
 	}
 
 	data, err := io.ReadAll(f)
 	if err != nil {
-		return http.StatusInternalServerError, xerrors.Errorf("read %s: %w", path, err)
+		return http.StatusInternalServerError, nil, xerrors.Errorf("read %s: %w", path, err)
 	}
 	content := string(data)
 
+	// Track the "loosest" strategy across all edits so callers can
+	// detect when any edit needed fuzzy matching.
+	var worstStrategy string
 	for _, edit := range edits {
+		var strategy string
 		var err error
-		content, err = fuzzyReplace(content, edit)
+		content, strategy, err = fuzzyReplace(content, edit)
 		if err != nil {
-			return http.StatusBadRequest, xerrors.Errorf("edit %s: %w", path, err)
+			return http.StatusBadRequest, nil, xerrors.Errorf("edit %s: %w", path, err)
+		}
+		if strategyRank(strategy) > strategyRank(worstStrategy) {
+			worstStrategy = strategy
 		}
 	}
 
 	m := stat.Mode()
-	return api.atomicWrite(ctx, path, &m, strings.NewReader(content))
+	s, err := api.atomicWrite(ctx, path, &m, strings.NewReader(content))
+	if err != nil {
+		return s, nil, err
+	}
+	return s, &workspacesdk.FileEditResult{
+		Path:         path,
+		EditsApplied: len(edits),
+		Strategy:     worstStrategy,
+	}, nil
 }
 
 // atomicWrite writes content from r to path via a temp file in the
@@ -510,6 +529,22 @@ func (api *API) atomicWrite(ctx context.Context, path string, mode *os.FileMode,
 	return 0, nil
 }
 
+// strategyRank returns a numeric rank for match strategies so the
+// "loosest" (most fuzzy) strategy can be tracked across multiple
+// edits: exact < fuzzy_trailing_whitespace < fuzzy_indent.
+func strategyRank(s string) int {
+	switch s {
+	case "exact":
+		return 1
+	case "fuzzy_trailing_whitespace":
+		return 2
+	case "fuzzy_indent":
+		return 3
+	default:
+		return 0
+	}
+}
+
 // fuzzyReplace attempts to find `search` inside `content` and replace it
 // with `replace`. It uses a cascading match strategy inspired by
 // openai/codex's apply_patch:
@@ -527,24 +562,24 @@ func (api *API) atomicWrite(ctx context.Context, path string, mode *os.FileMode,
 // When a fuzzy match is found (passes 2 or 3), the replacement is still
 // applied at the byte offsets of the original content so that surrounding
 // text (including indentation of untouched lines) is preserved.
-func fuzzyReplace(content string, edit workspacesdk.FileEdit) (string, error) {
+func fuzzyReplace(content string, edit workspacesdk.FileEdit) (result string, strategy string, err error) {
 	search := edit.Search
 	replace := edit.Replace
 
 	// Pass 1 – exact substring match.
 	if strings.Contains(content, search) {
 		if edit.ReplaceAll {
-			return strings.ReplaceAll(content, search, replace), nil
+			return strings.ReplaceAll(content, search, replace), "exact", nil
 		}
 		count := strings.Count(content, search)
 		if count > 1 {
-			return "", xerrors.Errorf("search string matches %d occurrences "+
+			return "", "", xerrors.Errorf("search string matches %d occurrences "+
 				"(expected exactly 1). Include more surrounding "+
 				"context to make the match unique, or set "+
 				"replace_all to true", count)
 		}
 		// Exactly one match.
-		return strings.Replace(content, search, replace, 1), nil
+		return strings.Replace(content, search, replace, 1), "exact", nil
 	}
 
 	// For line-level fuzzy matching we split both content and search
@@ -570,13 +605,13 @@ func fuzzyReplace(content string, edit workspacesdk.FileEdit) (string, error) {
 	if start, end, ok := seekLines(contentLines, searchLines, trimRight); ok {
 		if !edit.ReplaceAll {
 			if count := countLineMatches(contentLines, searchLines, trimRight); count > 1 {
-				return "", xerrors.Errorf("search string matches %d occurrences "+
+				return "", "", xerrors.Errorf("search string matches %d occurrences "+
 					"(expected exactly 1). Include more surrounding "+
 					"context to make the match unique, or set "+
 					"replace_all to true", count)
 			}
 		}
-		return spliceLines(contentLines, start, end, replace), nil
+		return spliceLines(contentLines, start, end, replace), "fuzzy_trailing_whitespace", nil
 	}
 
 	// Pass 3 – trim all leading and trailing whitespace
@@ -584,16 +619,16 @@ func fuzzyReplace(content string, edit workspacesdk.FileEdit) (string, error) {
 	if start, end, ok := seekLines(contentLines, searchLines, trimAll); ok {
 		if !edit.ReplaceAll {
 			if count := countLineMatches(contentLines, searchLines, trimAll); count > 1 {
-				return "", xerrors.Errorf("search string matches %d occurrences "+
+				return "", "", xerrors.Errorf("search string matches %d occurrences "+
 					"(expected exactly 1). Include more surrounding "+
 					"context to make the match unique, or set "+
 					"replace_all to true", count)
 			}
 		}
-		return spliceLines(contentLines, start, end, replace), nil
+		return spliceLines(contentLines, start, end, replace), "fuzzy_indent", nil
 	}
 
-	return "", xerrors.New("search string not found in file. Verify the search " +
+	return "", "", xerrors.New("search string not found in file. Verify the search " +
 		"string matches the file content exactly, including whitespace " +
 		"and indentation")
 }

--- a/agent/agentfiles/files_test.go
+++ b/agent/agentfiles/files_test.go
@@ -1395,3 +1395,67 @@ func TestReadFileLines(t *testing.T) {
 		})
 	}
 }
+
+func TestEditFiles_ResponseStructure(t *testing.T) {
+	t.Parallel()
+
+	tmpdir := os.TempDir()
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	fs := newTestFs(afero.NewMemMapFs(), func(_, _ string) error { return nil })
+	api := agentfiles.NewAPI(logger, fs, nil)
+
+	exactPath := filepath.Join(tmpdir, "resp-exact")
+	err := afero.WriteFile(fs, exactPath, []byte("hello world"), 0o644)
+	require.NoError(t, err)
+
+	fuzzyPath := filepath.Join(tmpdir, "resp-fuzzy")
+	err = afero.WriteFile(fs, fuzzyPath, []byte("\t\tindented line\n"), 0o644)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+	defer cancel()
+
+	body := workspacesdk.FileEditRequest{
+		Files: []workspacesdk.FileEdits{
+			{
+				Path: exactPath,
+				Edits: []workspacesdk.FileEdit{
+					{Search: "hello", Replace: "goodbye"},
+				},
+			},
+			{
+				// Search with wrong indent to trigger fuzzy pass 3.
+				Path: fuzzyPath,
+				Edits: []workspacesdk.FileEdit{
+					// Search with spaces instead of tabs to force fuzzy
+					// pass 3 (indent-tolerant match).
+					{Search: "    indented line\n", Replace: "\t\tchanged line\n"},
+				},
+			},
+		},
+	}
+	buf := bytes.NewBuffer(nil)
+	enc := json.NewEncoder(buf)
+	enc.SetEscapeHTML(false)
+	err = enc.Encode(body)
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequestWithContext(ctx, http.MethodPost, "/edit-files", buf)
+	api.Routes().ServeHTTP(w, r)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp workspacesdk.FileEditResponse
+	err = json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+
+	require.Len(t, resp.Files, 2)
+
+	require.Equal(t, exactPath, resp.Files[0].Path)
+	require.Equal(t, 1, resp.Files[0].EditsApplied)
+	require.Equal(t, "exact", resp.Files[0].Strategy)
+
+	require.Equal(t, fuzzyPath, resp.Files[1].Path)
+	require.Equal(t, 1, resp.Files[1].EditsApplied)
+	require.Equal(t, "fuzzy_indent", resp.Files[1].Strategy)
+}

--- a/coderd/x/chatd/chattool/editfiles.go
+++ b/coderd/x/chatd/chattool/editfiles.go
@@ -2,6 +2,7 @@ package chattool
 
 import (
 	"context"
+	"encoding/json"
 
 	"charm.land/fantasy"
 
@@ -43,8 +44,13 @@ func executeEditFilesTool(
 		return fantasy.NewTextErrorResponse("files is required"), nil
 	}
 
-	if err := conn.EditFiles(ctx, workspacesdk.FileEditRequest{Files: args.Files}); err != nil {
+	resp, err := conn.EditFiles(ctx, workspacesdk.FileEditRequest{Files: args.Files})
+	if err != nil {
 		return fantasy.NewTextErrorResponse(err.Error()), nil
 	}
-	return toolResponse(map[string]any{"ok": true}), nil
+	data, err := json.Marshal(resp)
+	if err != nil {
+		return fantasy.NewTextErrorResponse("failed to marshal response: " + err.Error()), nil
+	}
+	return fantasy.NewTextResponse(string(data)), nil
 }

--- a/codersdk/toolsdk/toolsdk.go
+++ b/codersdk/toolsdk/toolsdk.go
@@ -1710,7 +1710,7 @@ var WorkspaceEditFile = Tool[WorkspaceEditFileArgs, codersdk.Response]{
 		}
 		defer conn.Close()
 
-		err = conn.EditFiles(ctx, workspacesdk.FileEditRequest{
+		_, err = conn.EditFiles(ctx, workspacesdk.FileEditRequest{
 			Files: []workspacesdk.FileEdits{
 				{
 					Path:  args.Path,
@@ -1792,7 +1792,7 @@ var WorkspaceEditFiles = Tool[WorkspaceEditFilesArgs, codersdk.Response]{
 		}
 		defer conn.Close()
 
-		err = conn.EditFiles(ctx, workspacesdk.FileEditRequest{Files: args.Files})
+		_, err = conn.EditFiles(ctx, workspacesdk.FileEditRequest{Files: args.Files})
 		if err != nil {
 			return codersdk.Response{}, err
 		}

--- a/codersdk/workspacesdk/agentconn.go
+++ b/codersdk/workspacesdk/agentconn.go
@@ -81,7 +81,7 @@ type AgentConn interface {
 	ReadFile(ctx context.Context, path string, offset, limit int64) (io.ReadCloser, string, error)
 	ReadFileLines(ctx context.Context, path string, offset, limit int64, limits ReadFileLinesLimits) (ReadFileLinesResponse, error)
 	WriteFile(ctx context.Context, path string, reader io.Reader) error
-	EditFiles(ctx context.Context, edits FileEditRequest) error
+	EditFiles(ctx context.Context, edits FileEditRequest) (FileEditResponse, error)
 	SSH(ctx context.Context) (*gonet.TCPConn, error)
 	SSHClient(ctx context.Context) (*ssh.Client, error)
 	SSHClientOnPort(ctx context.Context, port uint16) (*ssh.Client, error)
@@ -923,6 +923,25 @@ type FileEditRequest struct {
 	Files []FileEdits `json:"files"`
 }
 
+// FileEditResult describes the outcome of edits applied to a single
+// file.
+type FileEditResult struct {
+	// Path is the absolute file path that was edited.
+	Path string `json:"path"`
+	// EditsApplied is the number of edits successfully applied.
+	EditsApplied int `json:"edits_applied"`
+	// Strategy is the loosest match strategy used across all edits
+	// (exact < fuzzy_trailing_whitespace < fuzzy_indent).
+	Strategy string `json:"strategy,omitempty"`
+}
+
+// FileEditResponse is the response from the edit-files endpoint.
+type FileEditResponse struct {
+	// Files contains per-file results for every successfully edited
+	// file.
+	Files []FileEditResult `json:"files"`
+}
+
 // StartProcess starts a new process on the workspace agent.
 func (c *agentConn) StartProcess(ctx context.Context, req StartProcessRequest) (StartProcessResponse, error) {
 	ctx, span := tracing.StartSpan(ctx)
@@ -995,24 +1014,24 @@ func (c *agentConn) SignalProcess(ctx context.Context, id string, signal string)
 }
 
 // EditFiles performs search and replace edits on one or more files.
-func (c *agentConn) EditFiles(ctx context.Context, edits FileEditRequest) error {
+func (c *agentConn) EditFiles(ctx context.Context, edits FileEditRequest) (FileEditResponse, error) {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
 	res, err := c.apiRequest(ctx, http.MethodPost, "/api/v0/edit-files", edits)
 	if err != nil {
-		return xerrors.Errorf("do request: %w", err)
+		return FileEditResponse{}, xerrors.Errorf("do request: %w", err)
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return codersdk.ReadBodyAsError(res)
+		return FileEditResponse{}, codersdk.ReadBodyAsError(res)
 	}
 
-	var m codersdk.Response
-	if err := json.NewDecoder(res.Body).Decode(&m); err != nil {
-		return xerrors.Errorf("decode response body: %w", err)
+	var resp FileEditResponse
+	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+		return FileEditResponse{}, xerrors.Errorf("decode response body: %w", err)
 	}
-	return nil
+	return resp, nil
 }
 
 // apiRequest makes a request to the workspace agent's HTTP API server.

--- a/codersdk/workspacesdk/agentconnmock/agentconnmock.go
+++ b/codersdk/workspacesdk/agentconnmock/agentconnmock.go
@@ -173,11 +173,12 @@ func (mr *MockAgentConnMockRecorder) DialContext(ctx, network, addr any) *gomock
 }
 
 // EditFiles mocks base method.
-func (m *MockAgentConn) EditFiles(ctx context.Context, edits workspacesdk.FileEditRequest) error {
+func (m *MockAgentConn) EditFiles(ctx context.Context, edits workspacesdk.FileEditRequest) (workspacesdk.FileEditResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EditFiles", ctx, edits)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(workspacesdk.FileEditResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // EditFiles indicates an expected call of EditFiles.


### PR DESCRIPTION
Changes `edit_files` from returning `{ok: true}` to a structured response with per-file details:

```json
{"files": [{"path": "/abs/path", "edits_applied": 2, "strategy": "exact"}]}
```

The `strategy` field indicates which match pass was used: `exact`, `fuzzy_trailing_whitespace`, or `fuzzy_indent`. This makes the fuzzy matching behavior visible to callers instead of silently applying.

**Changes:**
- `fuzzyReplace` returns `(result, strategy, error)`
- `editFile` returns `(status, *FileEditResult, error)`
- `HandleEditFiles` collects results and returns `FileEditResponse`
- New `FileEditResult` and `FileEditResponse` types in workspacesdk
- `AgentConn.EditFiles` returns `(FileEditResponse, error)`
- chattool serializes the structured response
- toolsdk discards the new return value (no behavior change)

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻