### PR TITLE
ci: disable go cache for build jobs to prevent disk space exhaustion

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1119,6 +1119,8 @@ jobs:
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
+        with:
+          use-cache: false
 
       - name: Install rcodesign
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -163,6 +163,8 @@ jobs:
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
+        with:
+          use-cache: false
 
       - name: Setup Node
         uses: ./.github/actions/setup-node


### PR DESCRIPTION
- Disable Go build cache restore for `build` job in `ci.yaml` and `release` job in `release.yaml`
- Depot runners have been running out of disk space during `.deb` packaging due to go cacheprog artifacts from previous builds filling the disk
- The post-build cache cleanup step in `ci.yaml` is preserved since the build itself still generates cache artifacts that need clearing before Docker image builds

> 🤖 This PR was created with the help of Coder Agents, and has been reviewed by my human.  🧑‍💻