### PR TITLE
fix(site/src/pages/AgentsPage): stabilize remote diff cache keys

### DIFF
--- a/site/src/pages/AgentsPage/components/DiffViewer/RemoteDiffPanel.tsx
+++ b/site/src/pages/AgentsPage/components/DiffViewer/RemoteDiffPanel.tsx
@@ -97,13 +97,15 @@ export const RemoteDiffPanel: FC<RemoteDiffPanelProps> = ({
 		try {
 			// The @pierre/diffs worker pool only keys cached highlighted
 			// ASTs by `cacheKey`, so the key must change whenever the diff
-			// text changes, including across component remounts. Deriving
-			// the prefix from the diff content avoids stale cache hits that
-			// can pair a new FileDiffMetadata with an old highlighted AST
-			// and trigger DiffHunksRenderer.processDiffResult errors.
+			// query updates. React Query's `dataUpdatedAt` survives panel
+			// remounts, which prevents stale cache hits from pairing a new
+			// FileDiffMetadata with an older highlighted AST.
 			const patches = parsePatchFiles(
 				diffContent,
-				getDiffCacheKeyPrefix(`chat-${chatId}`, diffContent),
+				getDiffCacheKeyPrefix(
+					`chat-${chatId}`,
+					diffContentsQuery.dataUpdatedAt,
+				),
 			);
 			return patches.flatMap((p) => p.files);
 		} catch {

--- a/site/src/pages/AgentsPage/components/DiffViewer/RemoteDiffPanel.tsx
+++ b/site/src/pages/AgentsPage/components/DiffViewer/RemoteDiffPanel.tsx
@@ -19,6 +19,7 @@ import type { ChatMessageInputRef } from "../AgentChatInput";
 import { CommentableDiffViewer } from "../DiffViewer/CommentableDiffViewer";
 import { DiffStatBadge } from "../DiffViewer/DiffStats";
 import type { DiffStyle } from "../DiffViewer/DiffViewer";
+import { getDiffCacheKeyPrefix } from "../DiffViewer/diffCacheKey";
 
 export { InlinePromptInput } from "../DiffViewer/CommentableDiffViewer";
 
@@ -89,33 +90,20 @@ export const RemoteDiffPanel: FC<RemoteDiffPanelProps> = ({
 	});
 
 	const diffContent = diffContentsQuery.data?.diff;
-	const [diffVersion, setDiffVersion] = useState(0);
-	const [prevDiffContent, setPrevDiffContent] = useState<string | undefined>(
-		undefined,
-	);
-	if (diffContent !== prevDiffContent) {
-		setPrevDiffContent(diffContent);
-		setDiffVersion((v) => v + 1);
-	}
-
 	const parsedFiles = (() => {
 		if (!diffContent) {
 			return [] as FileDiffMetadata[];
 		}
 		try {
-			// The cacheKeyPrefix enables the worker pool's LRU cache
-			// so highlighted ASTs are reused across re-renders instead
-			// of being re-computed on every render cycle. We include a
-			// version counter derived from the diff content so that when
-			// the diff changes (e.g. new commits pushed) the old cached
-			// highlight AST is not reused with mismatched line indices,
-			// which would cause DiffHunksRenderer.processDiffResult to
-			// throw. Unlike dataUpdatedAt, this counter only increments
-			// when the actual diff string changes, avoiding unnecessary
-			// recomputation on refetches with identical content.
+			// The @pierre/diffs worker pool only keys cached highlighted
+			// ASTs by `cacheKey`, so the key must change whenever the diff
+			// text changes, including across component remounts. Deriving
+			// the prefix from the diff content avoids stale cache hits that
+			// can pair a new FileDiffMetadata with an old highlighted AST
+			// and trigger DiffHunksRenderer.processDiffResult errors.
 			const patches = parsePatchFiles(
 				diffContent,
-				`chat-${chatId}-v${diffVersion}`,
+				getDiffCacheKeyPrefix(`chat-${chatId}`, diffContent),
 			);
 			return patches.flatMap((p) => p.files);
 		} catch {

--- a/site/src/pages/AgentsPage/components/DiffViewer/diffCacheKey.test.ts
+++ b/site/src/pages/AgentsPage/components/DiffViewer/diffCacheKey.test.ts
@@ -1,28 +1,21 @@
 import { getDiffCacheKeyPrefix } from "./diffCacheKey";
 
 describe("getDiffCacheKeyPrefix", () => {
-	it("returns the same key for the same scope and diff contents", () => {
-		const diff = "diff --git a/a.ts b/a.ts\n--- a/a.ts\n+++ b/a.ts\n";
-
-		expect(getDiffCacheKeyPrefix("chat-123", diff)).toBe(
-			getDiffCacheKeyPrefix("chat-123", diff),
+	it("returns the same key for the same scope and query update time", () => {
+		expect(getDiffCacheKeyPrefix("chat-123", 101)).toBe(
+			getDiffCacheKeyPrefix("chat-123", 101),
 		);
 	});
 
-	it("changes when the diff contents change", () => {
-		const original = "diff --git a/a.ts b/a.ts\n-old\n+new\n";
-		const updated = "diff --git a/a.ts b/a.ts\n-old\n+newer\n";
-
-		expect(getDiffCacheKeyPrefix("chat-123", original)).not.toBe(
-			getDiffCacheKeyPrefix("chat-123", updated),
+	it("changes when the query update time changes", () => {
+		expect(getDiffCacheKeyPrefix("chat-123", 101)).not.toBe(
+			getDiffCacheKeyPrefix("chat-123", 202),
 		);
 	});
 
 	it("changes when the scope changes", () => {
-		const diff = "diff --git a/a.ts b/a.ts\n-old\n+new\n";
-
-		expect(getDiffCacheKeyPrefix("chat-123", diff)).not.toBe(
-			getDiffCacheKeyPrefix("chat-456", diff),
+		expect(getDiffCacheKeyPrefix("chat-123", 101)).not.toBe(
+			getDiffCacheKeyPrefix("chat-456", 101),
 		);
 	});
 });

--- a/site/src/pages/AgentsPage/components/DiffViewer/diffCacheKey.test.ts
+++ b/site/src/pages/AgentsPage/components/DiffViewer/diffCacheKey.test.ts
@@ -1,0 +1,28 @@
+import { getDiffCacheKeyPrefix } from "./diffCacheKey";
+
+describe("getDiffCacheKeyPrefix", () => {
+	it("returns the same key for the same scope and diff contents", () => {
+		const diff = "diff --git a/a.ts b/a.ts\n--- a/a.ts\n+++ b/a.ts\n";
+
+		expect(getDiffCacheKeyPrefix("chat-123", diff)).toBe(
+			getDiffCacheKeyPrefix("chat-123", diff),
+		);
+	});
+
+	it("changes when the diff contents change", () => {
+		const original = "diff --git a/a.ts b/a.ts\n-old\n+new\n";
+		const updated = "diff --git a/a.ts b/a.ts\n-old\n+newer\n";
+
+		expect(getDiffCacheKeyPrefix("chat-123", original)).not.toBe(
+			getDiffCacheKeyPrefix("chat-123", updated),
+		);
+	});
+
+	it("changes when the scope changes", () => {
+		const diff = "diff --git a/a.ts b/a.ts\n-old\n+new\n";
+
+		expect(getDiffCacheKeyPrefix("chat-123", diff)).not.toBe(
+			getDiffCacheKeyPrefix("chat-456", diff),
+		);
+	});
+});

--- a/site/src/pages/AgentsPage/components/DiffViewer/diffCacheKey.ts
+++ b/site/src/pages/AgentsPage/components/DiffViewer/diffCacheKey.ts
@@ -1,0 +1,21 @@
+/**
+ * Build a stable worker-pool cache key for `@pierre/diffs` that changes
+ * whenever the diff contents change, even across component remounts.
+ *
+ * The upstream library only keys its highlighted diff cache by `cacheKey`, so
+ * callers must update that key whenever the diff text changes. We derive the
+ * key from a small deterministic hash of the diff contents instead of using a
+ * component-local counter, which can reset on remount and collide with stale
+ * cached ASTs.
+ */
+export const getDiffCacheKeyPrefix = (
+	prefix: string,
+	diffContent: string,
+): string => {
+	let hash = 0x811c9dc5;
+	for (let i = 0; i < diffContent.length; i++) {
+		hash ^= diffContent.charCodeAt(i);
+		hash = Math.imul(hash, 0x01000193);
+	}
+	return `${prefix}-${diffContent.length}-${(hash >>> 0).toString(36)}`;
+};

--- a/site/src/pages/AgentsPage/components/DiffViewer/diffCacheKey.ts
+++ b/site/src/pages/AgentsPage/components/DiffViewer/diffCacheKey.ts
@@ -1,21 +1,12 @@
 /**
- * Build a stable worker-pool cache key for `@pierre/diffs` that changes
- * whenever the diff contents change, even across component remounts.
+ * Build a stable worker-pool cache key prefix for `@pierre/diffs`.
  *
- * The upstream library only keys its highlighted diff cache by `cacheKey`, so
- * callers must update that key whenever the diff text changes. We derive the
- * key from a small deterministic hash of the diff contents instead of using a
- * component-local counter, which can reset on remount and collide with stale
- * cached ASTs.
+ * We use React Query's `dataUpdatedAt` as the invalidation token instead of a
+ * component-local counter. That timestamp survives component remounts, so a
+ * freshly fetched diff cannot accidentally reuse a highlighted AST cached for
+ * an older diff body.
  */
 export const getDiffCacheKeyPrefix = (
 	prefix: string,
-	diffContent: string,
-): string => {
-	let hash = 0x811c9dc5;
-	for (let i = 0; i < diffContent.length; i++) {
-		hash ^= diffContent.charCodeAt(i);
-		hash = Math.imul(hash, 0x01000193);
-	}
-	return `${prefix}-${diffContent.length}-${(hash >>> 0).toString(36)}`;
-};
+	dataUpdatedAt: number,
+): string => `${prefix}-${dataUpdatedAt}`;


### PR DESCRIPTION
## Summary
- use React Query's `dataUpdatedAt` as the remote diff cache invalidation token instead of a component-local counter
- keep the `@pierre/diffs` cache key stable across remounts without a custom hashing implementation
- preserve targeted coverage for the cache-key helper used by the /agents remote diff viewer

## Testing
- `cd site && pnpm exec biome check src/pages/AgentsPage/components/DiffViewer/RemoteDiffPanel.tsx src/pages/AgentsPage/components/DiffViewer/diffCacheKey.ts src/pages/AgentsPage/components/DiffViewer/diffCacheKey.test.ts`
- `cd site && pnpm exec vitest run src/pages/AgentsPage/components/DiffViewer/diffCacheKey.test.ts --project=unit`
- `cd site && pnpm exec tsc -p .`
