### PR TITLE
fix(coderd/database): fall back to model names in PR insights

### DIFF
--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -10417,6 +10417,49 @@ func TestGetPRInsights(t *testing.T) {
 		assert.Equal(t, int64(0), recent[0].CostMicros)
 	})
 
+	t.Run("BlankDisplayNameFallsBackToModel", func(t *testing.T) {
+		t.Parallel()
+		store, userID, _ := setupChatInfra(t)
+
+		const modelName = "claude-4.1"
+		emptyDisplayModel, err := store.InsertChatModelConfig(context.Background(), database.InsertChatModelConfigParams{
+			Provider:             "anthropic",
+			Model:                modelName,
+			DisplayName:          "",
+			CreatedBy:            uuid.NullUUID{UUID: userID, Valid: true},
+			UpdatedBy:            uuid.NullUUID{UUID: userID, Valid: true},
+			Enabled:              true,
+			IsDefault:            false,
+			ContextLimit:         128000,
+			CompressionThreshold: 80,
+			Options:              json.RawMessage(`{}`),
+		})
+		require.NoError(t, err)
+
+		chat := createChat(t, store, userID, emptyDisplayModel.ID, "chat-empty-display-name")
+		insertCostMessage(t, store, chat.ID, userID, emptyDisplayModel.ID, 1_000_000)
+		linkPR(t, store, chat.ID, "https://github.com/org/repo/pull/72", "merged", "fix: blank display name", 10, 2, 1)
+
+		byModel, err := store.GetPRInsightsPerModel(context.Background(), database.GetPRInsightsPerModelParams{
+			StartDate: startDate,
+			EndDate:   endDate,
+			OwnerID:   noOwner,
+		})
+		require.NoError(t, err)
+		require.Len(t, byModel, 1)
+		assert.Equal(t, modelName, byModel[0].DisplayName)
+
+		recent, err := store.GetPRInsightsRecentPRs(context.Background(), database.GetPRInsightsRecentPRsParams{
+			StartDate: startDate,
+			EndDate:   endDate,
+			OwnerID:   noOwner,
+			LimitVal:  20,
+		})
+		require.NoError(t, err)
+		require.Len(t, recent, 1)
+		assert.Equal(t, modelName, recent[0].ModelDisplayName)
+	})
+
 	t.Run("MergedCostMicros_OnlyCountsMerged", func(t *testing.T) {
 		t.Parallel()
 		store, userID, mcID := setupChatInfra(t)

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -2753,6 +2753,7 @@ deduped AS (
         cds.deletions,
         cmc.id AS model_config_id,
         cmc.display_name,
+        cmc.model,
         cmc.provider
     FROM chat_diff_statuses cds
     JOIN chats c ON c.id = cds.chat_id
@@ -2765,7 +2766,7 @@ deduped AS (
 )
 SELECT
     d.model_config_id,
-    COALESCE(d.display_name, 'Unknown')::text AS display_name,
+    COALESCE(NULLIF(d.display_name, ''), NULLIF(d.model, ''), 'Unknown')::text AS display_name,
     COALESCE(d.provider, 'unknown')::text AS provider,
     COUNT(*)::bigint AS total_prs,
     COUNT(*) FILTER (WHERE d.pull_request_state = 'merged')::bigint AS merged_prs,
@@ -2775,7 +2776,7 @@ SELECT
     COALESCE(SUM(pc.cost_micros) FILTER (WHERE d.pull_request_state = 'merged'), 0)::bigint AS merged_cost_micros
 FROM deduped d
 JOIN pr_costs pc ON pc.pr_key = d.pr_key
-GROUP BY d.model_config_id, d.display_name, d.provider
+GROUP BY d.model_config_id, d.display_name, d.model, d.provider
 ORDER BY total_prs DESC
 `
 
@@ -2886,7 +2887,7 @@ deduped AS (
         cds.author_login,
         cds.author_avatar_url,
         COALESCE(cds.base_branch, '')::text AS base_branch,
-        COALESCE(cmc.display_name, cmc.model, 'Unknown')::text AS model_display_name,
+        COALESCE(NULLIF(cmc.display_name, ''), NULLIF(cmc.model, ''), 'Unknown')::text AS model_display_name,
         c.created_at
     FROM chat_diff_statuses cds
     JOIN chats c ON c.id = cds.chat_id

--- a/coderd/database/queries/chatinsights.sql
+++ b/coderd/database/queries/chatinsights.sql
@@ -147,6 +147,7 @@ deduped AS (
         cds.deletions,
         cmc.id AS model_config_id,
         cmc.display_name,
+        cmc.model,
         cmc.provider
     FROM chat_diff_statuses cds
     JOIN chats c ON c.id = cds.chat_id
@@ -159,7 +160,7 @@ deduped AS (
 )
 SELECT
     d.model_config_id,
-    COALESCE(d.display_name, 'Unknown')::text AS display_name,
+    COALESCE(NULLIF(d.display_name, ''), NULLIF(d.model, ''), 'Unknown')::text AS display_name,
     COALESCE(d.provider, 'unknown')::text AS provider,
     COUNT(*)::bigint AS total_prs,
     COUNT(*) FILTER (WHERE d.pull_request_state = 'merged')::bigint AS merged_prs,
@@ -169,7 +170,7 @@ SELECT
     COALESCE(SUM(pc.cost_micros) FILTER (WHERE d.pull_request_state = 'merged'), 0)::bigint AS merged_cost_micros
 FROM deduped d
 JOIN pr_costs pc ON pc.pr_key = d.pr_key
-GROUP BY d.model_config_id, d.display_name, d.provider
+GROUP BY d.model_config_id, d.display_name, d.model, d.provider
 ORDER BY total_prs DESC;
 
 -- name: GetPRInsightsRecentPRs :many
@@ -227,7 +228,7 @@ deduped AS (
         cds.author_login,
         cds.author_avatar_url,
         COALESCE(cds.base_branch, '')::text AS base_branch,
-        COALESCE(cmc.display_name, cmc.model, 'Unknown')::text AS model_display_name,
+        COALESCE(NULLIF(cmc.display_name, ''), NULLIF(cmc.model, ''), 'Unknown')::text AS model_display_name,
         c.created_at
     FROM chat_diff_statuses cds
     JOIN chats c ON c.id = cds.chat_id


### PR DESCRIPTION
Fallback to the configured model name in PR Insights when a model config has a blank display name.

This updates both the by-model breakdown and recent PR rows, and adds a regression test for blank display names.