### PR TITLE
fix(coderd/x/chatd/mcpclient): use dedicated HTTP transport per MCP connection

### DIFF
--- a/coderd/x/chatd/mcpclient/mcpclient.go
+++ b/coderd/x/chatd/mcpclient/mcpclient.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
 	"sync"
@@ -214,17 +215,27 @@ func createTransport(
 	cfg database.MCPServerConfig,
 	headers map[string]string,
 ) (transport.Interface, error) {
+	// Each connection gets its own HTTP client with a dedicated
+	// transport so that httptest.Server.Close() (which calls
+	// CloseIdleConnections on http.DefaultTransport) does not
+	// disrupt unrelated connections during parallel tests.
+	httpClient := &http.Client{
+		Transport: http.DefaultTransport.(*http.Transport).Clone(),
+	}
+
 	switch cfg.Transport {
 	case "sse":
 		return transport.NewSSE(
 			cfg.Url,
 			transport.WithHeaders(headers),
+			transport.WithHTTPClient(httpClient),
 		)
 	case "", "streamable_http":
 		// Default to streamable HTTP, the newer transport.
 		return transport.NewStreamableHTTP(
 			cfg.Url,
 			transport.WithHTTPHeaders(headers),
+			transport.WithHTTPBasicClient(httpClient),
 		)
 	default:
 		return nil, xerrors.Errorf(

--- a/coderd/x/chatd/mcpclient/mcpclient.go
+++ b/coderd/x/chatd/mcpclient/mcpclient.go
@@ -219,8 +219,11 @@ func createTransport(
 	// transport so that httptest.Server.Close() (which calls
 	// CloseIdleConnections on http.DefaultTransport) does not
 	// disrupt unrelated connections during parallel tests.
-	httpClient := &http.Client{
-		Transport: http.DefaultTransport.(*http.Transport).Clone(),
+	var httpClient *http.Client
+	if dt, ok := http.DefaultTransport.(*http.Transport); ok {
+		httpClient = &http.Client{Transport: dt.Clone()}
+	} else {
+		httpClient = &http.Client{}
 	}
 
 	switch cfg.Transport {


### PR DESCRIPTION
## Problem

`TestConnectAll_MultipleServers` flakes with:

```
net/http: HTTP/1.x transport connection broken: http: CloseIdleConnections called
```

Each MCP client connection implicitly uses `http.DefaultTransport`. When `httptest.Server.Close()` runs during parallel test cleanup, it calls `CloseIdleConnections` on `http.DefaultTransport`, breaking in-flight connections from other goroutines or parallel tests sharing that transport.

## Fix

Clone the default transport for each MCP connection via `http.DefaultTransport.(*http.Transport).Clone()`, passed through `WithHTTPBasicClient` (StreamableHTTP) and `WithHTTPClient` (SSE). This scopes idle connection cleanup to a single MCP server so it cannot disrupt unrelated connections.

Fixes coder/internal#1420