### PR TITLE
feat(site/AgentsPage): linear-style framed content layout

### DIFF
--- a/site/src/pages/AgentsPage/AgentsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageView.tsx
@@ -162,15 +162,18 @@ export const AgentsPageView: FC<AgentsPageViewProps> = ({
 			</div>
 			<div
 				className={cn(
-					"min-h-0 min-w-0 flex-1 flex-col bg-surface-primary",
+					"min-h-0 min-w-0 flex-1 flex-col",
 					isSettingsIndex ? "hidden md:flex" : "flex",
 					!agentId &&
 						!isSettingsDetail &&
 						sidebarView.panel === "chats" &&
 						"order-1 md:order-none flex-none md:flex-1",
+					"md:p-2",
 				)}
 			>
-				<Outlet context={outletContextValue} />
+				<div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-surface-secondary md:rounded-xl">
+					<Outlet context={outletContextValue} />
+				</div>
 			</div>
 		</div>
 	);

--- a/site/src/pages/AgentsPage/components/AgentDetailView.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetailView.tsx
@@ -254,7 +254,7 @@ export const AgentDetailView: FC<AgentDetailViewProps> = ({
 					)}
 					<div
 						aria-hidden
-						className="pointer-events-none absolute inset-x-0 top-full z-10 h-3 sm:h-6 bg-surface-primary"
+						className="pointer-events-none absolute inset-x-0 top-full z-10 h-3 sm:h-6 bg-surface-secondary"
 						style={{
 							maskImage:
 								"linear-gradient(to bottom, black 0%, rgba(0,0,0,0.6) 40%, rgba(0,0,0,0.2) 70%, transparent 100%)",

--- a/site/src/pages/AgentsPage/components/AgentsSkeletons.tsx
+++ b/site/src/pages/AgentsPage/components/AgentsSkeletons.tsx
@@ -33,7 +33,7 @@ function getRightPanelState(): { open: boolean; width: number } {
 export const AgentsPageSkeleton: FC = () => (
 	<div className="flex h-full min-h-0 flex-col overflow-hidden bg-surface-primary md:flex-row">
 		<div className="order-2 md:order-none flex-1 min-h-0 border-t border-border-default md:flex-none md:border-t-0 md:h-full md:w-[320px] md:min-h-0 md:border-b-0">
-			<div className="relative flex h-full w-full min-h-0 border-0 border-r border-solid overflow-hidden">
+			<div className="relative flex h-full w-full min-h-0 overflow-hidden">
 				<div className="absolute inset-0 flex flex-col">
 					<div className="hidden border-b border-border-default px-2 pb-3 pt-1.5 md:block">
 						<div className="mb-2.5 flex items-center justify-between">
@@ -69,7 +69,9 @@ export const AgentsPageSkeleton: FC = () => (
 				</div>
 			</div>
 		</div>
-		<div className="flex min-h-0 min-w-0 flex-1 flex-col bg-surface-primary order-1 md:order-none" />
+		<div className="flex min-h-0 min-w-0 flex-1 flex-col order-1 md:order-none md:p-2">
+			<div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-surface-secondary md:rounded-xl" />
+		</div>
 	</div>
 );
 
@@ -109,7 +111,7 @@ export const ChatConversationSkeleton: FC = () => (
  * a few content lines.
  */
 export const RightPanelSkeleton: FC = () => (
-	<div className="flex h-full min-w-0 flex-col overflow-hidden bg-surface-primary">
+	<div className="flex h-full min-w-0 flex-col overflow-hidden bg-surface-secondary">
 		{/* Skeleton tab bar */}
 		<div className="flex shrink-0 items-center gap-2 border-0 border-b border-solid border-border-default px-3 py-1">
 			<Skeleton className="h-6 w-12 rounded-md" />

--- a/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
@@ -685,7 +685,7 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 	const subNavTitle = "Settings";
 
 	return (
-		<div className="relative flex h-full w-full min-h-0 border-0 border-r border-solid overflow-hidden">
+		<div className="relative flex h-full w-full min-h-0 overflow-hidden">
 			{/* ── Panel 1: Chats ── */}
 			<div
 				className={cn(


### PR DESCRIPTION
## Changes

UI layout exploration for the agents page:

- **Content frame**: The main content area (chat, create form, settings) is wrapped in a `bg-surface-secondary` panel with `rounded-xl` corners.
- **Gap**: Uniform 8px (`p-2`) padding around the frame on desktop, exposing the `bg-surface-primary` page background.
- **Sidebar border removed**: The right border on the sidebar is removed — the frame's rounded edges and gap provide visual separation.
- **Fade overlay + skeletons**: Updated to match the new `surface-secondary` background.

Mobile layout is unchanged (full-bleed, no rounding).