### PR TITLE
fix: correct malformed struct tags in organizationroles and scim_test

### DIFF
--- a/cli/organizationroles.go
+++ b/cli/organizationroles.go
@@ -524,7 +524,7 @@ type roleTableRow struct {
 	Name            string `table:"name,default_sort"`
 	DisplayName     string `table:"display name"`
 	OrganizationID  string `table:"organization id"`
-	SitePermissions string ` table:"site permissions"`
+	SitePermissions string `table:"site permissions"`
 	// map[<org_id>] -> Permissions
 	OrganizationPermissions string `table:"organization permissions"`
 	UserPermissions         string `table:"user permissions"`

--- a/enterprise/coderd/scim_test.go
+++ b/enterprise/coderd/scim_test.go
@@ -40,17 +40,17 @@ func makeScimUser(t testing.TB) coderd.SCIMUser {
 	return coderd.SCIMUser{
 		UserName: rstr,
 		Name: struct {
-			GivenName  string "json:\"givenName\""
-			FamilyName string "json:\"familyName\""
+			GivenName  string `json:"givenName"`
+			FamilyName string `json:"familyName"`
 		}{
 			GivenName:  rstr,
 			FamilyName: rstr,
 		},
 		Emails: []struct {
-			Primary bool   "json:\"primary\""
-			Value   string "json:\"value\" format:\"email\""
-			Type    string "json:\"type\""
-			Display string "json:\"display\""
+			Primary bool   `json:"primary"`
+			Value   string `json:"value" format:"email"`
+			Type    string `json:"type"`
+			Display string `json:"display"`
 		}{
 			{Primary: true, Value: fmt.Sprintf("%s@coder.com", rstr)},
 		},


### PR DESCRIPTION
Two real bugs found during tagalign investigation (#23201):

1. Leading space in table tag in `cli/organizationroles.go`
2. Escaped-quote tag syntax in `enterprise/coderd/scim_test.go`

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻