### PR TITLE
fix(site): clamp SmoothText dtMs to prevent animation budget inflation

### DIFF
--- a/site/src/pages/AgentsPage/components/AgentDetail/SmoothText.ts
+++ b/site/src/pages/AgentsPage/components/AgentDetail/SmoothText.ts
@@ -170,9 +170,13 @@ export class SmoothTextEngine {
 	 * Advance the presentation clock by a timestep.
 	 */
 	tick(dtMs: number): number {
-		if (dtMs <= 0) {
+		if (dtMs <= 0 || Number.isNaN(dtMs)) {
 			return this.visibleLengthValue;
 		}
+
+		// Clamp to prevent charBudget inflation after long
+		// background periods where RAF was paused by the browser.
+		dtMs = Math.min(100, dtMs);
 
 		if (!this.isStreaming || this.bypassSmoothing) {
 			return this.visibleLengthValue;


### PR DESCRIPTION
After a long requestAnimationFrame pause (e.g. backgrounded tab), the time delta can be very large, causing the character budget to spike and bypass smooth rendering entirely. Clamp to 100ms.

Extracted from #23236.

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻