### PR TITLE
feat: add TypeScript and React reference docs for deep-review Modernization Reviewer

### DIFF
--- a/.agents/skills/deep-review/SKILL.md
+++ b/.agents/skills/deep-review/SKILL.md
@@ -111,8 +111,8 @@ Tier 2 file filters:
 
 - **Modernization Reviewer**: one instance per language present in the diff. Filter by extension:
   - Go: `*.go` — reference `.claude/docs/GO.md` before reviewing.
-  - TypeScript: `*.ts` `*.tsx`
-  - React: `*.tsx` `*.jsx`
+  - TypeScript: `*.ts` `*.tsx` — reference `.agents/skills/deep-review/references/typescript.md` before reviewing.
+  - React: `*.tsx` `*.jsx` — reference `.agents/skills/deep-review/references/react.md` before reviewing.
 
   `.tsx` files match both TypeScript and React filters. Spawn both instances when the diff contains `.tsx` changes — TS covers language-level patterns; React covers component and hooks patterns. Before spawning, verify each instance's filter produces a non-empty diff. Skip instances whose filtered diff is empty.
 
@@ -155,9 +155,11 @@ File scope: {filter from step 2}.
 Output file: {REVIEW_DIR}/{role-name}.md
 ```
 
-For the Modernization Reviewer (Go), add after the methodology line:
+For Modernization Reviewer instances, add the language reference after the methodology line:
 
-> Read `.claude/docs/GO.md` as your Go language reference before reviewing.
+- **Go:** `Read .claude/docs/GO.md as your Go language reference before reviewing.`
+- **TypeScript:** `Read .agents/skills/deep-review/references/typescript.md as your TypeScript language reference before reviewing.`
+- **React:** `Read .agents/skills/deep-review/references/react.md as your React language reference before reviewing.`
 
 For re-reviews, append to both Tier 1 and Tier 2 prompts:
 

--- a/.agents/skills/deep-review/SKILL.md
+++ b/.agents/skills/deep-review/SKILL.md
@@ -111,8 +111,8 @@ Tier 2 file filters:
 
 - **Modernization Reviewer**: one instance per language present in the diff. Filter by extension:
   - Go: `*.go` — reference `.claude/docs/GO.md` before reviewing.
-  - TypeScript: `*.ts` `*.tsx` — reference `.agents/skills/deep-review/references/typescript.md` before reviewing.
-  - React: `*.tsx` `*.jsx` — reference `.agents/skills/deep-review/references/react.md` before reviewing.
+  - TypeScript: `*.ts` `*.tsx`: reference `.agents/skills/deep-review/references/typescript.md` before reviewing.
+  - React: `*.tsx` `*.jsx`: reference `.agents/skills/deep-review/references/react.md` before reviewing.
 
   `.tsx` files match both TypeScript and React filters. Spawn both instances when the diff contains `.tsx` changes — TS covers language-level patterns; React covers component and hooks patterns. Before spawning, verify each instance's filter produces a non-empty diff. Skip instances whose filtered diff is empty.
 

--- a/.agents/skills/deep-review/references/react.md
+++ b/.agents/skills/deep-review/references/react.md
@@ -1,0 +1,305 @@
+# Modern React (18–19.2) + Compiler 1.0 — Reference
+
+Reference for writing idiomatic React. Covers what changed, what it replaced, and what to reach for. Includes React Compiler patterns — what the compiler handles automatically, what it changes semantically, and how to verify its behavior empirically. Scope: client-side SPA patterns only. Server Components, `use server`, and `use client` directives are framework-specific and omitted. Check the project's React version and compiler config before reaching for newer APIs.
+
+## How modern React thinks differently
+
+**Concurrent rendering** (18): React can now pause, interrupt, and resume renders. This is the foundation everything else builds on. Most existing code "just works," but components that produce side effects during render (mutations, subscriptions, network calls in the render body) are unsafe and will misbehave. Concurrent features are opt-in — they only activate when you use a concurrent API like `startTransition` or `useDeferredValue`.
+
+**Urgent vs. non-urgent updates** (18): The `startTransition` / `useTransition` API introduces a formal split between updates that must feel immediate (typing, clicking) and updates that can be interrupted (filtering a large list, navigating to a new screen). Non-urgent updates yield to urgent ones mid-render. Use this instead of `setTimeout` or manual debounce when you want the UI to stay responsive during expensive re-renders.
+
+**Actions** (19): Async functions passed to `startTransition` are called "Actions." They automatically manage pending state, error handling, and optimistic updates as a unit. The `useActionState` hook and `<form action={fn}>` prop are built on this. The pattern replaces the hand-rolled `isPending/setIsPending` + `try/catch` + `setError` boilerplate that was previously necessary for every data mutation.
+
+**Automatic batching** (18): State updates are now batched everywhere — inside `setTimeout`, `Promise.then`, native event handlers, etc. Previously batching only happened inside React-managed event handlers. If you genuinely need a synchronous flush, use `flushSync`.
+
+**Automatic memoization** (Compiler 1.0): React Compiler is a build-time Babel plugin that automatically inserts memoization into components and hooks. It replaces manual `useMemo`, `useCallback`, and `React.memo` — including conditional memoization and memoization after early returns, which manual APIs cannot express. The compiler only processes components and hooks, not standalone functions. It understands data flow and mutability through its own HIR (High-level Intermediate Representation), so it can memoize more granularly than a human would. Projects adopt it incrementally — typically via path-based Babel overrides or the `"use memo"` directive. Components that violate the Rules of React are silently skipped (no build error), so the automated lint tools that check compiler compatibility matter.
+
+## Replace these patterns
+
+The left column reflects patterns common before React 18/19. Write the right column instead. The "Since" column tells you the minimum React version required.
+
+| Old pattern                                                       | Modern replacement                                                             | Since |
+| ----------------------------------------------------------------- | ------------------------------------------------------------------------------ | ----- |
+| `ReactDOM.render(<App />, el)`                                    | `createRoot(el).render(<App />)`                                               | 18    |
+| `ReactDOM.hydrate(<App />, el)`                                   | `hydrateRoot(el, <App />)`                                                     | 18    |
+| `ReactDOM.unmountComponentAtNode(el)`                             | `root.unmount()`                                                               | 18    |
+| `ReactDOM.findDOMNode(this)`                                      | DOM ref: `const ref = useRef(); ref.current`                                   | 18    |
+| `<Context.Provider value={v}>`                                    | `<Context value={v}>`                                                          | 19    |
+| `React.forwardRef((props, ref) => ...)`                           | `function Comp({ ref, ...props }) { ... }` (ref as a regular prop)             | 19    |
+| String ref `ref="input"` in class components                      | Callback ref or `createRef()`                                                  | 19    |
+| `Heading.propTypes = { ... }`                                     | TypeScript / ES6 type annotations                                              | 19    |
+| `Component.defaultProps = { ... }` on function components         | ES6 default parameters `({ text = 'Hi' })`                                     | 19    |
+| Legacy Context: `contextTypes` + `getChildContext`                | `React.createContext()` + `contextType`                                        | 19    |
+| `import { act } from 'react-dom/test-utils'`                      | `import { act } from 'react'`                                                  | 19    |
+| `import ShallowRenderer from 'react-test-renderer/shallow'`       | `import ShallowRenderer from 'react-shallow-renderer'`                         | 19    |
+| Manual `isPending` state around async calls                       | `const [isPending, startTransition] = useTransition()`                         | 18    |
+| Manual optimistic state + revert logic                            | `useOptimistic(currentValue)`                                                  | 19    |
+| `useEffect` to subscribe to external stores                       | `useSyncExternalStore(subscribe, getSnapshot)`                                 | 18    |
+| Hand-rolled unique ID (counter, random, index)                    | `useId()` — SSR-safe, hydration-safe                                           | 18    |
+| `useEffect` to inject `<title>` or `<meta>` / `react-helmet`      | Render `<title>`, `<meta>`, `<link>` directly in components; React hoists them | 19    |
+| `ReactDOM.useFormState(action, initial)` (Canary name)            | `useActionState(action, initial)`                                              | 19    |
+| `useReducer<React.Reducer<State, Action>>(reducer)`               | `useReducer(reducer)` — infers from the reducer function                       | 19    |
+| `<div ref={current => (instance = current)} />` (implicit return) | `<div ref={current => { instance = current }} />` (explicit block body)        | 19    |
+| `useRef<T>()` with no argument                                    | `useRef<T>(undefined)` or `useRef<T \| null>(null)` — argument is now required | 19    |
+| `MutableRefObject<T>` type annotation                             | `RefObject<T>` — all refs are mutable now; `MutableRefObject` is deprecated    | 19    |
+| `React.createFactory('button')`                                   | `<button />` JSX                                                               | 19    |
+| `useMemo(() => expr, [deps])` in compiled components              | `const val = expr;` — compiler memoizes automatically                          | C 1.0 |
+| `useCallback(fn, [deps])` in compiled components                  | `const fn = () => { ... };` — compiler memoizes automatically                  | C 1.0 |
+| `React.memo(Component)` in compiled components                    | Plain component — compiler skips re-render when props are unchanged            | C 1.0 |
+| `eslint-plugin-react-compiler` (standalone)                       | `eslint-plugin-react-hooks@latest` (compiler rules merged into recommended)    | C 1.0 |
+| `useRef` + `useLayoutEffect` for stable callbacks                 | `useEffectEvent(fn)` — compiler handles both, but `useEffectEvent` is clearer  | 19.2  |
+
+## New capabilities
+
+These enable things that weren't practical before. Reach for them in the described situations.
+
+| What                                                                 | Since   | When to use it                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| -------------------------------------------------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `useTransition()` / `startTransition()`                              | 18      | Mark a state update as non-urgent so React can interrupt it to handle clicks or keystrokes. The `isPending` boolean lets you show a loading indicator without blocking the UI.                                                                                                                                                                                                                                                                                              |
+| `useDeferredValue(value, initialValue?)`                             | 18 / 19 | Defer re-rendering a slow subtree: pass the deferred value as a prop, wrap the expensive child in `memo`. Unlike debounce, uses no fixed timeout — renders as soon as the browser is idle. The `initialValue` arg (19) avoids a flash on first render.                                                                                                                                                                                                                      |
+| `useId()`                                                            | 18      | Generate a stable, SSR-consistent ID for accessibility attributes (`htmlFor`, `aria-describedby`). Do not use for list keys.                                                                                                                                                                                                                                                                                                                                                |
+| `useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot?)`   | 18      | Subscribe to external (non-React) state stores safely under concurrent rendering. Preferred over `useEffect`-based subscriptions in libraries.                                                                                                                                                                                                                                                                                                                              |
+| `useActionState(action, initialState)`                               | 19      | Manage an async mutation: returns `[state, wrappedAction, isPending]`. Handles pending, result, and error state as a unit. Replaces the manual `isPending` + `try/catch` + `setError` pattern.                                                                                                                                                                                                                                                                              |
+| `useOptimistic(currentValue)`                                        | 19      | Show a speculative value while an async Action is in flight. Returns `[optimisticValue, setOptimistic]`. React automatically reverts to `currentValue` when the transition settles.                                                                                                                                                                                                                                                                                         |
+| `use(promiseOrContext)`                                              | 19      | Read a promise or Context value inside a component or custom hook. Unlike hooks, `use` can be called conditionally (after early returns). Promises must come from a cache — do not create them during render.                                                                                                                                                                                                                                                               |
+| `useFormStatus()` (from `react-dom`)                                 | 19      | Read `{ pending, data, method, action }` of the nearest parent `<form>` Action. Works across component boundaries without prop drilling — useful for submit buttons inside design-system components.                                                                                                                                                                                                                                                                        |
+| `useEffectEvent(fn)`                                                 | 19.2    | Extract a non-reactive callback from an effect. The function sees the latest props/state without being listed in deps, and is never stale. Replaces the `useRef`-and-mutate-in-layout-effect workaround for stable event-like callbacks. The compiler has built-in knowledge of this hook and correctly prunes its return value from effect dependency arrays. Both `useEffectEvent` and the old ref workaround compile cleanly; `useEffectEvent` is preferred for clarity. |
+| `<Activity>`                                                         | 19.2    | Hide part of the UI while preserving its state and DOM. React deprioritizes updates to hidden content. Use via framework APIs for route prerendering or tab preservation — not a direct replacement for CSS `visibility`.                                                                                                                                                                                                                                                   |
+| `captureOwnerStack()`                                                | 19.1    | Dev-only API that returns a string showing which components are responsible for rendering the current component (owner stack, not call stack). Useful for custom error overlays. Returns `null` in production.                                                                                                                                                                                                                                                              |
+| `<form action={fn}>`                                                 | 19      | Pass an async function as a form's `action` prop. React handles submission, pending state, and automatic form reset on success. Works with `useActionState` and `useFormStatus`.                                                                                                                                                                                                                                                                                            |
+| Ref cleanup function                                                 | 19      | Return a cleanup function from a ref callback: `ref={el => { ...; return () => cleanup(); }}`. React calls it on unmount. Replaces the pattern of checking `el === null` in the callback.                                                                                                                                                                                                                                                                                   |
+| `<link rel="stylesheet" precedence="default">`                       | 19      | Declare a stylesheet next to the component that needs it. React deduplicates and inserts it in the correct order before revealing Suspense content.                                                                                                                                                                                                                                                                                                                         |
+| `preinit`, `preload`, `prefetchDNS`, `preconnect` (from `react-dom`) | 19      | Imperatively hint the browser to load resources early. Call from render or event handlers. React deduplicates hints across the component tree.                                                                                                                                                                                                                                                                                                                              |
+| React Compiler (`babel-plugin-react-compiler`)                       | C 1.0   | Build-time automatic memoization for components and hooks. Install, add to Babel/Vite pipeline. Projects typically start with path-based overrides to compile a subset of files.                                                                                                                                                                                                                                                                                            |
+| `"use memo"` directive                                               | C 1.0   | Opt a single function into compilation when using `compilationMode: 'annotation'`. Place at the start of the function body. Module-level `"use memo"` at the top of a file compiles all functions in that file.                                                                                                                                                                                                                                                             |
+| `"use no memo"` directive                                            | C 1.0   | Temporary escape hatch — skip compilation for a specific component or hook that causes a runtime regression. Not a permanent solution. Place at the start of the function body.                                                                                                                                                                                                                                                                                             |
+| Compiler-powered ESLint rules                                        | C 1.0   | Rules for purity, refs, set-state-in-render, immutability, etc. now ship in `eslint-plugin-react-hooks` recommended preset. Surface Rules-of-React violations even without the compiler installed. Note: some projects use Biome instead — check project lint config.                                                                                                                                                                                                       |
+
+## Key APIs
+
+### `useTransition` and `startTransition` (18)
+
+`useTransition` returns `[isPending, startTransition]`. Wrap any state update that is not directly tied to the user's current gesture inside `startTransition`. React will render the old UI while computing the new one, and `isPending` is `true` during that window.
+
+In React 19, `startTransition` can accept an async function (an "Action"). React sets `isPending` to `true` for the entire duration of the async work, not just during the synchronous part.
+
+```tsx
+// 18: synchronous transition
+const [isPending, startTransition] = useTransition();
+startTransition(() => setQuery(input));
+
+// 19: async Action — isPending stays true until the await settles
+startTransition(async () => {
+	const err = await updateName(name);
+	if (err) setError(err);
+});
+```
+
+Use `startTransition` (the module-level export) when you cannot use the hook (outside a component, in a router callback, etc.).
+
+### `useDeferredValue` (18 / 19)
+
+Creates a "lagging" copy of a value. Pass it to a memoized, expensive component so that React can render the stale UI while computing the updated one.
+
+```tsx
+// 19: initialValue shows '' on first render; avoids loading flash
+const deferred = useDeferredValue(searchQuery, "");
+return <Results query={deferred} />; // Results wrapped in memo
+```
+
+`deferred !== searchQuery` while the deferred render is in progress — use this to show a "stale" indicator.
+
+### `useActionState` (19)
+
+Replaces the `useState` + `isPending` + `try/catch` + `setError` boilerplate for any async operation that can be retried or submitted as a form.
+
+```tsx
+const [error, submitAction, isPending] = useActionState(
+	async (prevState, formData) => {
+		const err = await updateName(formData.get("name"));
+		if (err) return err; // returned value becomes next state
+		redirect("/profile");
+		return null;
+	},
+	null, // initialState
+);
+
+// Use submitAction as the form's action prop or call it directly
+<form action={submitAction}>
+	<input name="name" />
+	<button disabled={isPending}>Save</button>
+	{error && <p>{error}</p>}
+</form>;
+```
+
+### `useOptimistic` (19)
+
+Shows a speculative value immediately while an async Action is in progress. React automatically reverts to the server-confirmed value when the Action resolves or rejects.
+
+```tsx
+const [optimisticName, setOptimisticName] = useOptimistic(currentName);
+
+const submit = async (formData) => {
+	const newName = formData.get("name");
+	setOptimisticName(newName); // shows immediately
+	await updateName(newName); // reverts if this throws
+};
+```
+
+### `use()` (19)
+
+Unlike hooks, `use` can appear after conditional statements. Two primary uses:
+
+**Reading a promise** (must be stable — from a cache, not created inline):
+
+```tsx
+function Comments({ commentsPromise }) {
+	const comments = use(commentsPromise); // suspends until resolved
+	return comments.map((c) => <p key={c.id}>{c.text}</p>);
+}
+```
+
+**Reading context after an early return** (hooks cannot appear after `return`):
+
+```tsx
+function Heading({ children }) {
+	if (!children) return null;
+	const theme = use(ThemeContext); // valid here; hooks would not be
+	return <h1 style={{ color: theme.color }}>{children}</h1>;
+}
+```
+
+### `useSyncExternalStore` (18)
+
+The correct way for libraries (and app code) to subscribe to non-React state. Prevents tearing under concurrent rendering.
+
+```tsx
+const value = useSyncExternalStore(
+	store.subscribe, // called when store changes
+	store.getSnapshot, // returns current value (must be stable reference if unchanged)
+	store.getServerSnapshot, // optional: for SSR
+);
+```
+
+## Verifying compiler behavior
+
+The compiler is a black box unless you inspect its output. When reviewing code in compiled paths, run the compiler on the specific code to see what it actually does. Do not guess — verify.
+
+**Run the compiler on a code snippet:**
+
+```sh
+cd site && node -e "
+const {transformSync} = require('@babel/core');
+const code = \`<paste component here>\`;
+const diagnostics = [];
+const result = transformSync(code, {
+  plugins: [
+    ['@babel/plugin-syntax-typescript', {isTSX: true}],
+    ['babel-plugin-react-compiler', {
+      logger: {
+        logEvent(_, event) {
+          if (event.kind === 'CompileError' || event.kind === 'CompileSkip') {
+            diagnostics.push(event.detail?.toString?.()?.substring(0, 200));
+          }
+        },
+      },
+    }],
+  ],
+  filename: 'test.tsx',
+});
+console.log('Compiled:', result.code.includes('_c('));
+if (diagnostics.length) console.log('Diagnostics:', diagnostics);
+console.log(result.code);
+"
+```
+
+**Reading compiled output:**
+
+- `const $ = _c(N)` — allocates N memoization cache slots.
+- `if ($[n] !== dep)` — cache invalidation guard. Re-computes when `dep` changes (referential equality).
+- `if ($[n] === Symbol.for("react.memo_cache_sentinel"))` — one-time initialization. Runs once on first render, cached forever after. This is how the compiler handles expressions with no reactive dependencies.
+- `_temp` functions — pure callbacks the compiler hoisted out of the component body.
+
+**Check all compiled files at once:**
+
+```sh
+cd site && pnpm run lint:compiler
+```
+
+This runs the compiler on every file in the compiled paths and reports CompileError / CompileSkip diagnostics. Zero diagnostics means all functions compiled cleanly.
+
+**What the compiler catches vs. what it does not:**
+
+The compiler emits `CompileError` for mutations of props, state, or hook arguments during render, and for `ref.current` access during render. The project's lint pipeline catches these automatically — do not flag them in review.
+
+The compiler does **not** flag impure function calls during render (`Math.random()`, `Date.now()`, `new Date()`). Instead it silently memoizes them with a sentinel guard, freezing the value after first render. This changes semantics without any diagnostic. Verify suspicious calls by running the compiler and checking for sentinel guards in the output.
+
+## Pitfalls
+
+Things that are easy to get wrong even when you know the modern API exists. Check your output against these.
+
+**Effects run twice in development with StrictMode.** React 18 intentionally mounts → unmounts → remounts every component in dev to surface effects that are not resilient to remounting. This is not a bug. If an effect breaks on the second mount, it is missing a cleanup function. Write `return () => cleanup()` from every effect that sets up a subscription, timer, or external resource.
+
+**Concurrent rendering can call render multiple times.** The render function (component body) may be called more than once before React commits to the DOM. Side effects (mutations, subscriptions, logging) in the render body will run multiple times. Move them into `useEffect` or event handlers.
+
+**Do not create promises during render and pass them to `use()`.** A new promise is created every render, causing an infinite suspend-retry loop. Create the promise outside the component (module level), or use a caching library (SWR, React Query, `cache()` from React) to stabilize it.
+
+**`useOptimistic` reverts automatically — do not fight it.** The optimistic value is a presentation layer only. When the Action settles, React replaces it with the real `currentValue` you passed in. Do not try to sync optimistic state back to your real state; let React handle the revert.
+
+**`flushSync` opts out of automatic batching.** If third-party code or a browser API (e.g. `ResizeObserver`) calls `setState` and you need synchronous DOM flushing, wrap with `flushSync(() => setState(...))`. This is a last resort; prefer letting React batch.
+
+**`forwardRef` still works in React 19 but will be deprecated.** Function components accept `ref` as a plain prop now. New code should use the prop directly. Existing `forwardRef` wrappers continue to work without changes; migrate when convenient.
+
+**`<Activity>` does not unmount.** Content inside a hidden `<Activity>` boundary stays mounted. Effects keep running. Use it for preserving scroll position or form state, not for preventing expensive mounts — use lazy loading for that.
+
+**TypeScript: implicit returns from ref callbacks are now type errors.** In React 19, returning anything other than a cleanup function (or nothing) from a ref callback is rejected by the TypeScript types. The most common case is arrow-function refs that implicitly return the DOM node:
+
+```tsx
+// Error in React 19 types:
+<div ref={el => (instance = el)} />
+
+// Fix — use a block body:
+<div ref={el => { instance = el; }} />
+```
+
+**TypeScript: `useRef` now requires an argument.** `useRef<T>()` with no argument is a type error. Pass `undefined` for mutable refs or `null` for DOM refs you initialize on mount: `useRef<T>(undefined)` / `useRef<HTMLDivElement | null>(null)`.
+
+**`useId` output format changed across versions.** React 18 produced `:r0:`. React 19.1 changed it to `«r0»`. React 19.2 changed it again to `_r0`. Do not parse or depend on the specific format — treat it as an opaque string.
+
+**`useFormStatus` reads the nearest parent `<form>` with a function `action`.** It does not reflect native HTML form submissions — only React Actions. A submit button that is a sibling of `<form>` (rather than a descendant) will not see the form's status.
+
+**Context as a provider (`<Context>`) requires React 19; `<Context.Provider>` still works.** Do not use `<Context>` shorthand in a codebase that needs to support React 18. The two forms can coexist during migration.
+
+**Compiler freezes impure expressions silently.** `Math.random()`, `Date.now()`, `new Date()`, and `window.innerWidth` in a component body all compile without diagnostics. The compiler wraps them in a sentinel guard (`Symbol.for("react.memo_cache_sentinel")`) that runs the expression once and caches the result forever. The value never updates on re-render. Fix: move to a `useState` initializer (`useState(() => Math.random())`), `useEffect`, or event handler.
+
+**Component granularity affects compiler optimization.** When one pattern in a component causes a `CompileError` (e.g., a necessary `ref.current` read during render), the compiler skips the **entire** component. If the rest of the component would benefit from compilation, extract the non-compilable pattern into a small child component. This keeps the parent compiled.
+
+**The compiler only memoizes components and hooks.** Standalone utility functions (even expensive ones called during render) are not compiled. If a utility function is truly expensive, it still needs its own caching strategy outside of React (e.g., a module-level cache, `WeakMap`, etc.).
+
+**Changing memoization can shift `useEffect` firing.** A value that was unstable before compilation may become stable after, causing an effect that depended on it to fire less often. Conversely, future compiler changes may alter memoization granularity. Effects that use memoized values as dependencies should be resilient to these changes — they should be true synchronization effects, not "run this when X changes" hacks.
+
+## Behavioral changes that affect code
+
+- **Automatic batching** (18): State updates in `setTimeout`, `Promise.then`, `addEventListener` callbacks, etc. are now batched into a single re-render. Previously only React synthetic event handlers were batched. Code that relied on unbatched updates (reading DOM synchronously after each `setState`) must use `flushSync`.
+
+- **StrictMode double-invoke** (18): In development, every component is mounted → unmounted → remounted with the previous state. Every effect runs cleanup → setup twice on initial mount. `useMemo` and `useCallback` also double-invoke their functions. Production behavior is unchanged. If a test or component breaks under this, the component had a latent cleanup bug.
+
+- **StrictMode ref double-invoke** (19): In development, ref callbacks are also invoked twice on mount (attach → detach → attach). Return a cleanup function from the ref callback to handle detach correctly.
+
+- **StrictMode memoization reuse** (19): During the second pass of double-rendering, `useMemo` and `useCallback` now reuse the cached result from the first pass instead of calling the function again. Components that are already StrictMode-compatible should not notice a difference.
+
+- **Suspense fallback commits immediately** (19): When a component suspends, React now commits the nearest `<Suspense>` fallback without waiting for sibling trees to finish rendering. After the fallback is shown, React "pre-warms" suspended siblings in the background. This makes fallbacks appear faster but changes the order of rendering work.
+
+- **Error re-throwing removed** (19): Errors that are not caught by an Error Boundary are now reported to `window.reportError` (not re-thrown). Errors caught by an Error Boundary go to `console.error` once. If your production monitoring relied on the re-thrown error, add handlers to `createRoot`: `createRoot(el, { onUncaughtError, onCaughtError })`.
+
+- **Transitions in `popstate` are synchronous** (19): Browser back/forward navigation triggers synchronous transition flushing. This ensures the URL and UI update together atomically during history navigation.
+
+- **`useEffect` from discrete events flushes synchronously** (18): Effects triggered by a click or keydown (discrete events) are now flushed synchronously before the browser paints, consistent with `useLayoutEffect` for those cases.
+
+- **Hydration mismatches treated as errors** (18 / improved in 19): Text content mismatches between server HTML and client render revert to client rendering up to the nearest `<Suspense>` boundary. React 19 logs a single diff instead of multiple warnings, making mismatches much easier to diagnose.
+
+- **New JSX transform required** (19): The automatic JSX runtime introduced in 2020 (`react/jsx-runtime`) is now mandatory. The classic transform (which required `import React from 'react'` in every file) is no longer supported. Most toolchains have already shipped the new transform; check your Babel or TypeScript config if you see warnings.
+
+- **UMD builds removed** (19): React no longer ships UMD bundles. Load via npm and a bundler, or use an ESM CDN (`import React from "https://esm.sh/react@19"`).
+
+- **React Compiler automatic memoization** (Compiler 1.0): Build-time Babel plugin that inserts memoization into components and hooks. Components that follow the Rules of React are automatically memoized; components that violate them are silently skipped (no build error, no runtime change). The compiler can memoize conditionally and after early returns — things impossible with manual `useMemo`/`useCallback`. Works with React 17+ via `react-compiler-runtime`; best with React 19+. Projects adopt incrementally via path-based Babel overrides, `compilationMode: 'annotation'`, or the `"use memo"` / `"use no memo"` directives. Check the project's Vite/Babel config to know which paths are compiled. Compiled components show a "Memo ✨" badge in React DevTools.

--- a/.agents/skills/deep-review/references/typescript.md
+++ b/.agents/skills/deep-review/references/typescript.md
@@ -1,0 +1,199 @@
+# Modern TypeScript (5.0–6.0 RC) — Reference
+
+Reference for writing idiomatic TypeScript. Covers what changed, what it replaced, and what to reach for. Respect the project's minimum TypeScript version: don't emit features from a version newer than what the project targets. Check `package.json` and `tsconfig.json` before writing code.
+
+## How modern TypeScript thinks differently
+
+The 5.x era resolves years of module system ambiguity and cleans house on legacy options. Three themes dominate:
+
+**Module semantics are explicit.** `--verbatimModuleSyntax` (5.0) makes import/export intent visible in source: type imports must carry `type`, value imports stay. Combined with `--module preserve` or `--moduleResolution bundler`, the compiler now accurately models what bundlers and modern runtimes actually do. `import defer` (5.9) extends the model to deferred evaluation.
+
+**Resource lifetimes are first-class.** `using` and `await using` (5.2) provide deterministic cleanup without `try/finally`. Any object implementing `Symbol.dispose` participates. `DisposableStack` handles ad-hoc multi-resource cleanup in functions where creating a full class is overkill.
+
+**Inference is smarter about what it knows.** Inferred type predicates (5.5) let `.filter(x => x !== undefined)` produce `T[]` instead of `(T | undefined)[]` automatically. `NoInfer<T>` (5.4) gives library authors precise control over which parameters drive inference. Narrowing now survives closures after last assignment, constant indexed accesses, and `switch (true)` patterns.
+
+**TypeScript 6.0 is a transition release toward 7.0** (the Go-native port). It turns years of soft deprecations into errors and changes several defaults. Most impactful: `types` defaults to `[]` (must list `@types` packages explicitly), `rootDir` defaults to `.`, `strict` defaults to `true`, `module` defaults to `esnext`. Projects relying on implicit behavior need explicit config. Check the deprecations section before upgrading.
+
+## Replace these patterns
+
+The left column reflects patterns still common before TypeScript 5.x. Write the right column instead. The "Since" column tells you the minimum TypeScript version required.
+
+| Old pattern                                                                                                      | Modern replacement                                                                                                           | Since                            |
+| ---------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | -------------------------------- | ------ |
+| `--experimentalDecorators` + legacy decorator signatures                                                         | Standard decorators (TC39): `function dec(target, context: ClassMethodDecoratorContext)` — no flag needed                    | 5.0                              |
+| Requiring callers to add `as const` at call sites                                                                | `<const T extends HasNames>(arg: T)` — `const` modifier on type parameter                                                    | 5.0                              |
+| `--importsNotUsedAsValues` + `--preserveValueImports`                                                            | `--verbatimModuleSyntax`                                                                                                     | 5.0                              |
+| `import { Foo } from "..."` when `Foo` is only used as a type                                                    | `import { type Foo } from "..."` or `import type { Foo } from "..."`                                                         | 5.0                              |
+| `"extends": "@tsconfig/strictest/tsconfig.json"` chain                                                           | `"extends": ["@tsconfig/strictest/tsconfig.json", "./tsconfig.base.json"]` (array form)                                      | 5.0                              |
+| `try { ... } finally { resource.close(); resource.delete(); }`                                                   | `using resource = acquireResource()` — calls `[Symbol.dispose]()` automatically                                              | 5.2                              |
+| `try { ... } finally { await resource.close() }`                                                                 | `await using resource = acquireAsyncResource()`                                                                              | 5.2                              |
+| Ad-hoc cleanup with multiple `try/finally` blocks                                                                | `using cleanup = new DisposableStack(); cleanup.defer(() => ...)`                                                            | 5.2                              |
+| `import data from "./data.json" assert { type: "json" }`                                                         | `import data from "./data.json" with { type: "json" }`                                                                       | 5.3                              |
+| `.filter(Boolean)` or `.filter(x => !!x)` to remove nulls                                                        | `.filter(x => x !== undefined)` or `.filter(x => x !== null)` (infers type predicate)                                        | 5.5                              |
+| Extra phantom type param to block inference bleed: `<C extends string, D extends C>`                             | `NoInfer<C>` on the parameter you don't want to drive inference                                                              | 5.4                              |
+| `/** @typedef {import("./types").Foo} Foo */` in JS files                                                        | `/** @import { Foo } from "./types" */` (JSDoc `@import` tag)                                                                | 5.5                              |
+| `myArray.reverse()` mutating in place                                                                            | `myArray.toReversed()` (returns new array)                                                                                   | 5.2                              |
+| `myArray.sort(cmp)` mutating in place                                                                            | `myArray.toSorted(cmp)` (returns new array)                                                                                  | 5.2                              |
+| `const copy = [...arr]; copy[i] = v`                                                                             | `arr.with(i, v)` (returns new array)                                                                                         | 5.2                              |
+| Manual `has`/`get`/`set` pattern on `Map`                                                                        | `map.getOrInsert(key, defaultValue)` or `getOrInsertComputed(key, fn)`                                                       | 6.0 RC                           |
+| `new RegExp(str.replace(/[.\*+?^${}()                                                                            | [\]\\]/g, '\\$&'))`                                                                                                          | `new RegExp(RegExp.escape(str))` | 6.0 RC |
+| `--moduleResolution node` (node10)                                                                               | `--moduleResolution nodenext` (Node.js) or `--moduleResolution bundler` (bundlers/Bun)                                       | 6.0 RC                           |
+| `"baseUrl": "./src"` + `"@app/*": ["app/*"]` in paths                                                            | Remove `baseUrl`; use `"@app/*": ["./src/app/*"]` in paths directly                                                          | 6.0 RC                           |
+| `module Foo { export const x = 1; }`                                                                             | `namespace Foo { export const x = 1; }`                                                                                      | 6.0 RC                           |
+| `export * from "..."` when all re-exported members are types                                                     | `export type * from "..."` (or `export type * as ns from "..."`)                                                             | 5.0                              |
+| `function f(): undefined { return undefined; }` — explicit return required in `: undefined`-returning function   | Remove the `return` entirely; `undefined`-returning functions no longer require any return statement                         | 5.1                              |
+| Manual type predicate annotation on a simple arrow: `(x: T \| undefined): x is T => x !== undefined`             | Remove the annotation; TypeScript infers `x is T` from `!== null/undefined` and `instanceof` checks automatically            | 5.5                              |
+| `const val = obj[key]; if (typeof val === "string") { use(val); }` — extract to const to narrow indexed access   | `if (typeof obj[key] === "string") { obj[key].toUpperCase(); }` directly — both `obj` and `key` must be effectively constant | 5.5                              |
+| Copy narrowed `let`/param to a `const`, or restructure code to escape stale closure narrowing after reassignment | Remove the copy; narrowing survives into closures created after the last assignment to the variable                          | 5.4                              |
+| `(arr as string[]).filter(...)` or restructure to avoid "not callable" errors on `string[] \| number[]`          | Call `.filter`, `.find`, `.some`, `.every`, `.reduce` directly on union-of-array types                                       | 5.2                              |
+| `if`/`else` chain used to work around lack of narrowing inside a `switch (true)` body                            | `switch (true)` — each `case` condition now narrows the tested variable in its clause                                        | 5.3                              |
+
+## New capabilities
+
+These enable things that weren't practical before. Reach for them in the described situations.
+
+| What                                            | Since  | When to use it                                                                                                                                                                                                                                |
+| ----------------------------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `using` / `await using` declarations            | 5.2    | Any resource needing deterministic cleanup (file handles, DB connections, locks, event listeners). Object must implement `Symbol.dispose` / `Symbol.asyncDispose`.                                                                            |
+| `DisposableStack` / `AsyncDisposableStack`      | 5.2    | Ad-hoc multi-resource cleanup without creating a class. Call `.defer(fn)` right after acquiring each resource. Stack disposes in LIFO order.                                                                                                  |
+| `const` modifier on type parameters             | 5.0    | Force `const`-like (literal/readonly tuple) inference at call sites without requiring callers to write `as const`. Constraint must use `readonly` arrays.                                                                                     |
+| Decorator metadata (`Symbol.metadata`)          | 5.2    | Attach and read per-class metadata from decorators via `context.metadata`. Retrieved as `MyClass[Symbol.metadata]`. Requires `Symbol.metadata ??= Symbol(...)` polyfill.                                                                      |
+| `NoInfer<T>` utility type                       | 5.4    | Prevent a parameter from contributing inference candidates for `T`. Use when one argument should be the "source of truth" and others should only be checked against it.                                                                       |
+| Inferred type predicates                        | 5.5    | Filter callbacks that test for `!== null` or `instanceof` now automatically produce a type predicate. `Array.prototype.filter` then narrows the result array type.                                                                            |
+| `--isolatedDeclarations`                        | 5.5    | Require explicit return types on exported declarations. Unlocks parallel declaration emit by external tooling (esbuild, oxc, etc.) without needing a full type-checker pass.                                                                  |
+| `${configDir}` in tsconfig paths                | 5.5    | Anchor `typeRoots`, `paths`, `outDir`, etc. in a shared base tsconfig to the _consuming_ project's directory, not the shared file's location.                                                                                                 |
+| Always-truthy/nullish check errors              | 5.6    | Catches regex literals in `if`, arrow functions as comparators, `?? 100` on non-nullable left side, misplaced parentheses. No API to call; existing bugs now surface as errors.                                                               |
+| Iterator helper methods (`IteratorObject`)      | 5.6    | Built-in iterators from `Map`, `Set`, generators, etc. now have `.map()`, `.filter()`, `.take()`, `.drop()`, `.flatMap()`, `.toArray()`, `.reduce()`, etc. Use `Iterator.from(iterable)` to wrap any iterable.                                |
+| `--noUncheckedSideEffectImports`                | 5.6    | Error when a side-effect import (`import "..."`) resolves to nothing. Catches typos in polyfill or CSS imports.                                                                                                                               |
+| `--noCheck`                                     | 5.6    | Skip type checking entirely during emit. Useful for separating "fast emit" from "thorough check" pipeline stages, especially with `--isolatedDeclarations`.                                                                                   |
+| `--rewriteRelativeImportExtensions`             | 5.7    | Rewrite `.ts`→`.js`, `.tsx`→`.jsx`, `.mts`→`.mjs`, `.cts`→`.cjs` in relative imports during emit. Required when writing `.ts` imports for Node.js strip-types mode and still needing `.js` output for library distribution.                   |
+| `--erasableSyntaxOnly`                          | 5.8    | Error on constructs that can't be type-stripped by Node.js `--experimental-strip-types`: `enum`, `namespace` with code, parameter properties, `import =` aliases.                                                                             |
+| `require()` of ESM under `--module nodenext`    | 5.8    | Node.js 22+ allows CJS to `require()` ESM files (no top-level `await`). TypeScript now allows this under `nodenext` without error.                                                                                                            |
+| `import defer * as ns from "..."`               | 5.9    | Defer module _evaluation_ (not loading) until first property access. Module is loaded and verified at import time; side-effects are delayed. Only works with `--module preserve` or `esnext`.                                                 |
+| `Set` algebra methods                           | 5.5    | Non-mutating: `union`, `intersection`, `difference`, `symmetricDifference` → new `Set`. Predicate: `isSubsetOf`, `isSupersetOf`, `isDisjointFrom` → `boolean`. Requires `esnext` or `es2025` lib.                                             |
+| `Object.groupBy` / `Map.groupBy`                | 5.4    | Group an iterable into buckets by key function. Return type has all keys as optional (not every key is guaranteed present). Requires `esnext` or `es2024`+ lib.                                                                               |
+| `Temporal` API types                            | 6.0 RC | `Temporal.Now`, `Temporal.Instant`, `Temporal.PlainDate`, etc. Available under `esnext` or `esnext.temporal` lib. Usable in runtimes that already ship it (V8 118+, SpiderMonkey, etc.).                                                      |
+| `@satisfies` in JSDoc                           | 5.0    | Validates that a JS expression satisfies a type without widening it — the TS `satisfies` operator for `.js` files. Write `/** @satisfies {MyType} */` above the declaration or inline on a parenthesized expression.                          |
+| `@overload` in JSDoc                            | 5.0    | Declare multiple call signatures for a JS function. Each JSDoc comment tagged `@overload` is treated as a distinct overload; the final JSDoc comment (without `@overload`) describes the implementation signature.                            |
+| Getter/setter with completely unrelated types   | 5.1    | `get style(): CSSStyleDeclaration` and `set style(v: string)` can now have fully unrelated types, provided both have explicit type annotations. Previously the getter type was required to be a subtype of the setter type.                   |
+| `instanceof` narrowing via `Symbol.hasInstance` | 5.3    | When a class defines `static [Symbol.hasInstance](val: unknown): val is T`, the `instanceof` operator now narrows to the predicate type `T`, not the class type itself. Useful when the runtime check and the structural type differ.         |
+| Regex literal syntax checking                   | 5.5    | TypeScript validates regex literal syntax: malformed groups, nonexistent backreferences, named capture mismatches, and features not available at the current `--target`. No API needed; existing latent bugs surface as errors automatically. |
+| `--build` continues past intermediate errors    | 5.6    | `tsc --build` no longer stops at the first failing project. All projects are built and errors reported together. Use `--stopOnBuildErrors` to restore the old stop-on-first-error behavior. Useful for monorepos during upgrades.             |
+| `--module node18`                               | 5.8    | Stable `--module` flag for Node.js 18 semantics: disallows `require()` of ESM (unlike `nodenext`) and still allows import assertions. Use when pinned to Node 18 and not ready for `nodenext` behavior changes.                               |
+| `--module node20`                               | 5.9    | Stable `--module` flag for Node.js 20 semantics: permits `require()` of ESM, rejects import assertions. Implies `--target es2023` (unlike `nodenext`, which floats to `esnext`).                                                              |
+
+## Key APIs
+
+### `Disposable` / `AsyncDisposable` / stacks (5.2)
+
+Global types provided by TypeScript's lib (requires `esnext.disposable` or `esnext` in `lib`):
+
+- `Disposable` — `{ [Symbol.dispose](): void }`
+- `AsyncDisposable` — `{ [Symbol.asyncDispose](): PromiseLike<void> }`
+- `DisposableStack` — `defer(fn)`, `use(resource)`, `adopt(value, disposeFn)`, `move()`. Is itself `Disposable`.
+- `AsyncDisposableStack` — async equivalent. Is itself `AsyncDisposable`.
+- `SuppressedError` — thrown when both the scope body and a `[Symbol.dispose]` throw. `.error` holds the dispose-phase error; `.suppressed` holds the original error.
+
+Polyfill the symbols in older runtimes:
+
+```ts
+Symbol.dispose ??= Symbol("Symbol.dispose");
+Symbol.asyncDispose ??= Symbol("Symbol.asyncDispose");
+```
+
+### Decorator context types (5.0)
+
+Each decorator kind receives a typed context object as its second parameter:
+
+- `ClassDecoratorContext`
+- `ClassMethodDecoratorContext`
+- `ClassGetterDecoratorContext`
+- `ClassSetterDecoratorContext`
+- `ClassFieldDecoratorContext`
+- `ClassAccessorDecoratorContext`
+
+All context objects have `.name`, `.kind`, `.static`, `.private`, and `.metadata`. Method/getter/setter/accessor contexts also have `.addInitializer(fn)` for running code at construction time.
+
+### `IteratorObject` (5.6)
+
+`IteratorObject<T, TReturn, TNext>` is the new type for built-in iterable iterators. Key methods: `map`, `filter`, `take`, `drop`, `flatMap`, `forEach`, `reduce`, `some`, `every`, `find`, `toArray`. Not the same as the pre-existing structural `Iterator<T>` protocol.
+
+- Generators produce `Generator<T>` which extends `IteratorObject`.
+- `Map.prototype.entries()` returns `MapIterator<[K, V]>`, `Set.prototype.values()` returns `SetIterator<T>`, etc.
+- `Iterator.from(iterable)` converts any `Iterable` to an `IteratorObject`.
+- `AsyncIteratorObject` exists for async parity.
+- `--strictBuiltinIteratorReturn` (new `--strict`-mode flag in 5.6) makes the return type of `BuiltinIteratorReturn` be `undefined` instead of `any`, catching unchecked `done` access.
+
+### Array copying methods (5.2)
+
+Declared on `Array`, `ReadonlyArray`, and all `TypedArray` types. Use these instead of the mutating variants when you need to preserve the original:
+
+| Mutating                           | Non-mutating copy                     |
+| ---------------------------------- | ------------------------------------- |
+| `arr.sort(cmp)`                    | `arr.toSorted(cmp)`                   |
+| `arr.reverse()`                    | `arr.toReversed()`                    |
+| `arr.splice(start, del, ...items)` | `arr.toSpliced(start, del, ...items)` |
+| `arr[i] = v`                       | `arr.with(i, v)`                      |
+
+## Pitfalls
+
+Things easy to get wrong even when you know the modern API exists. Check your output against these.
+
+**tsconfig defaults changed hard in 6.0.** `types: []` means no `@types/*` packages load implicitly. If you see floods of "cannot find name 'process'" or "cannot find module 'fs'" after upgrading to 6.0, add `"types": ["node"]` (or whatever you need) to `compilerOptions`. `rootDir: "."` means a project with source in `src/` will emit to `dist/src/` instead of `dist/` — add `"rootDir": "./src"` explicitly. `strict: true` by default means projects with loose code see new errors.
+
+**`using` requires a runtime polyfill on older runtimes.** `Symbol.dispose` and `Symbol.asyncDispose` don't exist before Node.js 18.x / Chrome 120. Add the two-line polyfill at your entry point. `DisposableStack` and `AsyncDisposableStack` need a more substantial polyfill (e.g. from `@microsoft/using-polyfill`).
+
+**`using` disposes in LIFO order.** Resources declared later in a scope are disposed first. Declare in the order you want reversed cleanup (acquisition order). `DisposableStack.defer` also runs in LIFO order.
+
+**Inferred type predicates have if-and-only-if semantics.** `x => !!x` does NOT infer `x is NonNullable<T>` because `0`, `""`, and `false` are falsy but not absent. TypeScript correctly refuses the predicate. Use `x => x !== undefined` or `x => x !== null` for precise null/undefined filters. If a predicate isn't being inferred, the false branch is probably ambiguous.
+
+**`--verbatimModuleSyntax` breaks CJS `require` emit.** Under this flag ESM `import`/`export` is emitted verbatim. You cannot produce `require()` calls from standard `import` syntax. For CJS output you must use `import foo = require("foo")` and `export = { ... }` syntax explicitly.
+
+**`NoInfer<T>` doesn't prevent `T` from being resolved, only from being contributed at that position.** Other parameters can still infer `T`. It means "don't use me as an inference candidate", not "block `T` from being resolved".
+
+**`--isolatedDeclarations` requires explicit return types on all exports.** Exported arrow functions, function declarations, and class methods all need annotations if their return type isn't trivially inferrable from a literal or type assertion. Editor quick-fixes can add them automatically.
+
+**Standard decorators are incompatible with `--experimentalDecorators`.** Different type signatures, metadata model, and emit. A decorator written for one will not work with the other. `--emitDecoratorMetadata` is not supported with standard decorators. Don't mix the two systems in one project.
+
+**`import defer` does not downlevel.** TypeScript does not transform `import defer` to polyfill-compatible code. The module is still _loaded_ eagerly (must exist); only _evaluation_ is deferred. Only use it under `--module preserve` or `esnext` with a runtime or bundler that supports it.
+
+**`--erasableSyntaxOnly` prohibits parameter properties.** `constructor(public x: number)` is not allowed. Expand to an explicit field declaration plus assignment in the constructor body.
+
+**Closure narrowing is invalidated if the variable is assigned anywhere in a nested function.** TypeScript cannot know when a nested function will run, so any assignment to a `let`/param inside a nested function — even a no-op like `value = value` — invalidates narrowing for all closures in the outer scope. Only the outer "no further assignments after this point" pattern is safe.
+
+**Constant indexed access narrowing requires both `obj` and `key` to be unmodified between the check and the use.** If either is a `let` that could be reassigned, TypeScript will not narrow `obj[key]`. Extract the value to a `const` in that case.
+
+**`switch (true)` narrowing does not carry across fall-through cases.** In a `switch (true)`, each `case` condition narrows independently. A variable narrowed in `case typeof x === "string":` that falls through to the next case will have its narrowing widened by the next condition, not accumulated from the previous one.
+
+**`const` type parameter modifier falls back when constraint is mutable.** `<const T extends string[]>(args: T)` falls back to `string[]` because `readonly ["a", "b"]` isn't assignable to `string[]`. Use `<const T extends readonly string[]>` for arrays.
+
+**`assert` import syntax errors under `--module nodenext` since 5.8.** Any remaining `import x from "..." assert { ... }` must be updated to `import x from "..." with { ... }`.
+
+**`Array.prototype.filter(x => x !== null)` now narrows to non-null (5.5).** This is almost always correct, but if you intentionally needed the nullable type downstream, add an explicit annotation: `const items: (T | null)[] = arr.filter(x => x !== null)`.
+
+## Behavioral changes that affect code
+
+- **All enums are union enums** (5.0): Every enum member gets its own literal type. Out-of-domain literal assignment to an enum type now errors. Cross-enum assignment between enums with identical names but differing values now errors.
+- **Relational operators no longer allow implicit string/number coercions** (5.0): `ns > 4` where `ns: number | string` is a type error. Use `+ns > 4` to explicitly coerce.
+- **`--module`/`--moduleResolution` must agree on node flavor** (5.2): Mixing `--module nodenext` with `--moduleResolution bundler` is an error. Use `--module nodenext` alone or `--module esnext --moduleResolution bundler`.
+- **Deprecations from 5.0 become hard errors in 5.5**: `--importsNotUsedAsValues`, `--preserveValueImports`, `--target ES3`, `--out`, and several others are fully removed in 5.5. They can no longer be specified, even with `"ignoreDeprecations": "5.0"`. Migrate to `--verbatimModuleSyntax` for the import flags.
+- **Type-only imports conflicting with local values** (5.4): Under `--isolatedModules`, `import { Foo } from "..."` where a local `let Foo` also exists now errors. Use `import type { Foo }` or `import { type Foo }`.
+- **Reference directives no longer synthesized or preserved in declaration emit** (5.5): `/// <reference types="node" />` TypeScript used to add automatically is no longer emitted. User-written directives are dropped unless they carry `preserve="true"`. Update library `tsconfig.json` if you relied on this.
+- **`.mts` files never emit CJS; `.cts` files never emit ESM** (5.6): Regardless of `--module` setting. Previously the extension was ignored in some modes.
+- **JSON imports under `--module nodenext` require `with { type: "json" }`** (5.7): `import data from "./config.json"` without the attribute is now a type error.
+- **`TypedArray`s are now generic** (5.7): `Uint8Array` is `Uint8Array<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike>`. Code passing `Buffer` (from `@types/node`) to typed-array parameters may see new errors. Update `@types/node` to a version that matches.
+- **`import assert { ... }` is an error under `--module nodenext`** (5.8): Node.js 22 dropped support for the old syntax. Use `with { ... }`.
+- **`types` defaults to `[]` in 6.0**: All implicit `@types/*` loading stops. Add an explicit `"types": ["node"]` or the array will remain empty. Using `"types": ["*"]` restores the 5.x behavior.
+- **`rootDir` defaults to `.` (the tsconfig directory) in 6.0**: Previously inferred from the common ancestor of all source files. Projects with `"include": ["./src"]` and no explicit `rootDir` will now emit into `dist/src/` instead of `dist/`. Add `"rootDir": "./src"` to fix.
+- **`strict` defaults to `true` in 6.0**: Projects that were implicitly not strict will see new errors. Set `"strict": false` explicitly if you're not ready to fix them.
+- **`--baseUrl` deprecated in 6.0** and no longer acts as a module resolution root. Add explicit prefixes to your `paths` entries instead.
+- **`--moduleResolution node` (node10) deprecated in 6.0**: Removed in 7.0. Migrate to `nodenext` or `bundler`.
+- **`amd`, `umd`, `systemjs`, `none` module targets deprecated in 6.0**: Removed in 7.0. Migrate to a bundler.
+- **`--outFile` removed in 6.0**: Use a bundler (esbuild, Rollup, Webpack, etc.).
+- **`module Foo { }` syntax removed in 6.0**: Rename all such declarations to `namespace Foo { }`.
+- **`--esModuleInterop false` and `--allowSyntheticDefaultImports false` removed in 6.0**: Safe interop is now always on. Default imports from CJS modules (`import express from "express"`) are always valid.
+- **Explicit `typeRoots` disables upward `node_modules/@types` fallback** (5.1): When `typeRoots` is specified and a lookup fails in those directories, TypeScript no longer walks parent directories for `@types`. If you relied on the fallback, add `"./node_modules/@types"` explicitly to your `typeRoots` array.
+- **`super.` on instance field properties is a type error** (5.3): Calling `super.foo()` where `foo` is a class field (arrow function assigned in the constructor) rather than a prototype method now errors. Instance fields don't exist on the prototype; `super.field` is `undefined` at runtime.
+- **`--build` always emits `.tsbuildinfo`** (5.6): Previously only written when `--incremental` or `--composite` was set. Now written unconditionally in any `--build` invocation. Update `.gitignore` or CI artifact management if needed.
+- **`.mts`/`.cts` extensions and `package.json` `"type"` respected in all module modes** (5.6): Format-specific extensions and the `"type"` field inside `node_modules` are now honored regardless of `--module` setting (except `amd`, `umd`, `system`). A `.mts` file will never emit CJS output even under `--module commonjs`.
+- **Granular return expression checking** (5.8): Each branch of a conditional expression (`cond ? a : b`) directly inside a `return` statement is now checked individually against the declared return type. Previously an `any`-typed branch could silently suppress type errors in the other branch.


### PR DESCRIPTION
Follow-up to #23500. The deep-review skill's Modernization Reviewer spawns per-language instances. The Go instance already had `.claude/docs/GO.md` as a reference. The TypeScript and React instances had no equivalent — they relied on general knowledge.

This adds language reference docs so all three instances review against documented modern patterns:

| File | Lines | Coverage |
|------|-------|----------|
| `references/typescript.md` | 199 | TypeScript 5.0–6.0 RC: replacements, new capabilities, gotchas |
| `references/react.md` | 305 | React 18–19.2 + Compiler 1.0: replacements, new capabilities, compiler patterns |

coder/coder currently uses TypeScript 5.6.3, React 19.2.2, and React Compiler 1.0. The docs cover the full range so the reviewer can distinguish "available in this project" from "requires a newer version."

SKILL.md updated to reference these docs in the spawn prompts and file filter descriptions.