### PR TITLE
fix(cli): bump embedded PostgreSQL from 13 to 16

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -2291,7 +2291,7 @@ func startBuiltinPostgres(ctx context.Context, cfg config.Root, logger slog.Logg
 
 		ep := embeddedpostgres.NewDatabase(
 			embeddedpostgres.DefaultConfig().
-				Version(embeddedpostgres.V13).
+				Version(embeddedpostgres.V16).
 				BinariesPath(filepath.Join(cfg.PostgresPath(), "bin")).
 				// Default BinaryRepositoryURL repo1.maven.org is flaky.
 				BinaryRepositoryURL("https://repo.maven.apache.org/maven2").


### PR DESCRIPTION
## Problem

The built-in PostgreSQL (used when no `--postgres-url` is provided) is pinned to **v13**, which:

1. **Reached EOL in November 2025** — no longer receives security updates.

2. **Fails to start on some ARM64 systems** (e.g. Raspberry Pi) with:
   ```
   error while loading shared libraries: libcrypto.so.1.1:
   ELF load command address/offset not page-aligned
   ```
   Caused by an [outdated patchelf in the upstream build pipeline](https://github.com/zonkyio/embedded-postgres-binaries/issues/105) corrupting ELF page alignment. Fixed upstream in v14.21.0+ but never backported to v13 since it's EOL.

## Fix

Bump `embeddedpostgres.V13` → `embeddedpostgres.V16`. The CI test helper (`scripts/embedded-pg`) already uses V16.

## ⚠️ Breaking: built-in database data loss on upgrade

The embedded-postgres library detects the major version mismatch via `PG_VERSION` and **wipes the data directory** to reinitialize. The bundled distribution only includes `initdb`, `pg_ctl`, and `postgres` — no `pg_dump` or `pg_upgrade` — so there's no automatic migration path.

Users running `coder server` with the built-in database will lose their data (workspaces, templates, users) on upgrade. They should either:
- **Back up first**: use an external `pg_dump` against the built-in database (`coder server postgres-builtin-url`) before upgrading
- **Switch to external PostgreSQL**: recommended for any non-ephemeral deployment

This does **not** affect users who provide `--postgres-url` (external database).

Open question: should we add a pre-flight check that detects an existing v13 data directory and refuses to start with instructions, rather than silently wiping it?