### PR TITLE
ci: yeet depot runners in favour of GitHub runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1081,7 +1081,7 @@ jobs:
     needs:
       - changes
     if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && needs.changes.outputs.docs-only == 'false' && !github.event.pull_request.head.repo.fork
-    runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-8' || 'ubuntu-22.04' }}
+    runs-on: ubuntu-latest
     permissions:
       # Necessary to push docker images to ghcr.io.
       packages: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ env:
 jobs:
   # Only allow maintainers/admins to release.
   check-perms:
-    runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-8' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     steps:
       - name: Allow only maintainers/admins
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
@@ -61,7 +61,7 @@ jobs:
   release:
     name: Build and publish
     needs: [check-perms]
-    runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-8' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     permissions:
       # Required to publish a release
       contents: write


### PR DESCRIPTION
Depot runners are running out of disk space and blocking builds. Temporarily switch the build and release jobs from depot runners to GitHub-hosted runners:

- `ci.yaml` build job: `depot-ubuntu-22.04-8` → `ubuntu-latest`
- `release.yaml` check-perms + release jobs: `depot-ubuntu-22.04-8` → `ubuntu-latest`

**This is intended to be reverted once depot resolves their disk space issues.**

> 🤖 This PR was created with the help of Coder Agents, and will be reviewed by my human.  🧑‍💻