### PR TITLE
fix(coderd): register as confidential client during MCP OAuth2 DCR

### DIFF
--- a/coderd/mcp.go
+++ b/coderd/mcp.go
@@ -1,12 +1,15 @@
 package coderd
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 
 	"github.com/go-chi/chi/v5"
@@ -198,7 +201,7 @@ func (api *API) createMCPServerConfig(rw http.ResponseWriter, r *http.Request) {
 					slog.Error(err),
 				)
 				httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-					Message: "OAuth2 auto-discovery failed. Provide oauth2_client_id, oauth2_auth_url, and oauth2_token_url manually, or ensure the MCP server supports RFC 9728 (Protected Resource Metadata) and RFC 7591 (Dynamic Client Registration).",
+					Message: "This MCP server requires manual OAuth2 configuration.",
 					Detail:  err.Error(),
 				})
 				return
@@ -1072,13 +1075,10 @@ type mcpOAuth2Discovery struct {
 	scopes       string // space-separated
 }
 
-// discoverAndRegisterMCPOAuth2 uses the mcp-go library's OAuthHandler to
-// perform the MCP OAuth2 discovery and Dynamic Client Registration flow:
-//
-//  1. Discover the authorization server via Protected Resource Metadata
-//     (RFC 9728) and Authorization Server Metadata (RFC 8414).
-//  2. Register a client via Dynamic Client Registration (RFC 7591).
-//  3. Return the discovered endpoints and generated credentials.
+// discoverAndRegisterMCPOAuth2 discovers the authorization server via
+// Protected Resource Metadata (RFC 9728) and Authorization Server
+// Metadata (RFC 8414), then registers a client via Dynamic Client
+// Registration (RFC 7591).
 func discoverAndRegisterMCPOAuth2(ctx context.Context, mcpServerURL, callbackURL string) (*mcpOAuth2Discovery, error) {
 	// Per the MCP spec, the authorization base URL is the MCP server
 	// URL with the path component discarded (scheme + host only).
@@ -1109,18 +1109,161 @@ func discoverAndRegisterMCPOAuth2(ctx context.Context, mcpServerURL, callbackURL
 		return nil, xerrors.New("authorization server does not advertise a registration_endpoint (dynamic client registration may not be supported)")
 	}
 
-	// Step 2: Register a client via Dynamic Client Registration (RFC 7591).
-	if err := oauthHandler.RegisterClient(ctx, "Coder"); err != nil {
+	// Step 2: Register a client via Dynamic Client Registration
+	// (RFC 7591).  We perform this ourselves rather than using
+	// mcp-go's RegisterClient because it always registers as a
+	// public client (token_endpoint_auth_method="none").  Many
+	// authorization servers restrict public clients to loopback
+	// redirect URIs per RFC 8252, which rejects the non-loopback
+	// callback URL that Coder uses.  Registering as a confidential
+	// client lets the server generate a secret and typically
+	// relaxes redirect-URI restrictions.
+	authMethod := pickTokenEndpointAuthMethod(metadata.TokenEndpointAuthMethodsSupported)
+
+	// If the server only supports public clients and Coder's
+	// callback URL is not a loopback address, DCR will fail.
+	// Most OAuth2 providers that only support public clients
+	// restrict redirect URIs to loopback addresses (RFC 8252
+	// section 7.3), which only works for desktop MCP clients
+	// like Claude and VS Code that run on the user's machine.
+	// Server-side clients like Coder need a non-loopback
+	// callback, which requires creating an OAuth2 app in the
+	// provider's dashboard and supplying the credentials
+	// manually.
+	if authMethod == "none" && !callbackURLIsLoopback(callbackURL) {
+		return nil, xerrors.Errorf(
+			"this MCP server's authorization provider only supports "+
+				"automatic setup for desktop MCP clients (like Claude "+
+				"or VS Code). To connect from Coder, create an OAuth2 "+
+				"application in the provider's dashboard with %s as "+
+				"the redirect URI, then add this MCP server with the "+
+				"oauth2_client_id, oauth2_auth_url, and oauth2_token_url "+
+				"fields set manually (discovered auth_url: %s, "+
+				"token_url: %s)",
+			callbackURL,
+			metadata.AuthorizationEndpoint,
+			metadata.TokenEndpoint,
+		)
+	}
+	result, err := registerDynamicOAuth2Client(ctx, metadata.RegistrationEndpoint, callbackURL, authMethod)
+	if err != nil {
 		return nil, xerrors.Errorf("dynamic client registration: %w", err)
 	}
 
 	scopes := strings.Join(metadata.ScopesSupported, " ")
 
 	return &mcpOAuth2Discovery{
-		clientID:     oauthHandler.GetClientID(),
-		clientSecret: oauthHandler.GetClientSecret(),
+		clientID:     result.clientID,
+		clientSecret: result.clientSecret,
 		authURL:      metadata.AuthorizationEndpoint,
 		tokenURL:     metadata.TokenEndpoint,
 		scopes:       scopes,
+	}, nil
+}
+
+// callbackURLIsLoopback reports whether the callback URL points
+// at a loopback address (localhost, 127.0.0.1, or [::1]).
+func callbackURLIsLoopback(callbackURL string) bool {
+	parsed, err := url.Parse(callbackURL)
+	if err != nil {
+		return false
+	}
+	h := parsed.Hostname()
+	return h == "localhost" || h == "127.0.0.1" || h == "::1"
+}
+
+// pickTokenEndpointAuthMethod selects the best auth method for
+// Dynamic Client Registration.  It prefers confidential-client
+// methods because many authorization servers restrict public
+// clients ("none") to loopback-only redirect URIs per RFC 8252.
+// If the server does not advertise supported methods, it defaults
+// to client_secret_post (a safe confidential-client method).
+func pickTokenEndpointAuthMethod(supported []string) string {
+	// Prefer confidential methods in order of preference.
+	for _, method := range []string{"client_secret_post", "client_secret_basic"} {
+		if len(supported) == 0 || slices.Contains(supported, method) {
+			return method
+		}
+	}
+	// Fall back to "none" (public client) if the server only
+	// supports that.
+	if slices.Contains(supported, "none") {
+		return "none"
+	}
+	// Default to client_secret_post when we cannot determine the
+	// server's capabilities.
+	return "client_secret_post"
+}
+
+// dcrClientResponse is the relevant subset of an RFC 7591 Dynamic
+// Client Registration response.
+type dcrClientResponse struct {
+	clientID     string
+	clientSecret string
+}
+
+// registerDynamicOAuth2Client sends an RFC 7591 Dynamic Client
+// Registration request and returns the generated credentials.
+func registerDynamicOAuth2Client(ctx context.Context, registrationEndpoint, callbackURL, authMethod string) (*dcrClientResponse, error) {
+	regRequest := map[string]any{
+		"client_name":                "Coder",
+		"redirect_uris":              []string{callbackURL},
+		"token_endpoint_auth_method": authMethod,
+		"grant_types":                []string{"authorization_code", "refresh_token"},
+		"response_types":             []string{"code"},
+	}
+
+	reqBody, err := json.Marshal(regRequest)
+	if err != nil {
+		return nil, xerrors.Errorf("marshal registration request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, registrationEndpoint, bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, xerrors.Errorf("create registration request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, xerrors.Errorf("send registration request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, xerrors.Errorf("read registration response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		// Try to parse as an RFC 7591 error.
+		var oauthErr struct {
+			Error            string `json:"error"`
+			ErrorDescription string `json:"error_description"`
+		}
+		if jsonErr := json.Unmarshal(body, &oauthErr); jsonErr == nil && oauthErr.Error != "" {
+			if oauthErr.ErrorDescription != "" {
+				return nil, xerrors.Errorf("registration request failed: OAuth error: %s - %s", oauthErr.Error, oauthErr.ErrorDescription)
+			}
+			return nil, xerrors.Errorf("registration request failed: OAuth error: %s", oauthErr.Error)
+		}
+		return nil, xerrors.Errorf("registration request failed with status %d: %s", resp.StatusCode, body)
+	}
+
+	var regResponse struct {
+		ClientID     string `json:"client_id"`
+		ClientSecret string `json:"client_secret,omitempty"`
+	}
+	if err := json.Unmarshal(body, &regResponse); err != nil {
+		return nil, xerrors.Errorf("decode registration response: %w", err)
+	}
+	if regResponse.ClientID == "" {
+		return nil, xerrors.New("registration response missing client_id")
+	}
+
+	return &dcrClientResponse{
+		clientID:     regResponse.ClientID,
+		clientSecret: regResponse.ClientSecret,
 	}, nil
 }

--- a/coderd/mcp_internal_test.go
+++ b/coderd/mcp_internal_test.go
@@ -1,0 +1,82 @@
+package coderd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPickTokenEndpointAuthMethod(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		supported []string
+		want      string
+	}{
+		{
+			name:      "PreferClientSecretPostWhenSupported",
+			supported: []string{"client_secret_post", "client_secret_basic", "none"},
+			want:      "client_secret_post",
+		},
+		{
+			name:      "FallBackToClientSecretBasic",
+			supported: []string{"client_secret_basic", "none"},
+			want:      "client_secret_basic",
+		},
+		{
+			name:      "FallBackToNoneWhenOnlyOption",
+			supported: []string{"none"},
+			want:      "none",
+		},
+		{
+			name:      "DefaultToClientSecretPostWhenEmpty",
+			supported: nil,
+			want:      "client_secret_post",
+		},
+		{
+			name:      "DefaultToClientSecretPostWhenEmptySlice",
+			supported: []string{},
+			want:      "client_secret_post",
+		},
+		{
+			name:      "DefaultToClientSecretPostForUnknownMethods",
+			supported: []string{"private_key_jwt", "tls_client_auth"},
+			want:      "client_secret_post",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := pickTokenEndpointAuthMethod(tt.supported)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCallbackURLIsLoopback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{"Localhost", "http://localhost:3000/callback", true},
+		{"IPv4Loopback", "http://127.0.0.1:8080/callback", true},
+		{"IPv6Loopback", "http://[::1]:8080/callback", true},
+		{"PublicHTTPS", "https://coder.example.com/callback", false},
+		{"PublicHTTP", "http://coder.example.com/callback", false},
+		{"PrivateIP", "http://192.168.1.1:3000/callback", false},
+		{"Empty", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := callbackURLIsLoopback(tt.url)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/coderd/mcp_test.go
+++ b/coderd/mcp_test.go
@@ -543,7 +543,8 @@ func TestMCPServerConfigsOAuth2AutoDiscovery(t *testing.T) {
 					return
 				}
 
-				// Decode the registration body and capture redirect_uris.
+				// Decode the registration body and capture
+				// redirect_uris and token_endpoint_auth_method.
 				var body map[string]interface{}
 				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 					http.Error(w, "bad json", http.StatusBadRequest)
@@ -554,7 +555,13 @@ func TestMCPServerConfigsOAuth2AutoDiscovery(t *testing.T) {
 						registeredRedirectURI <- uri
 					}
 				}
-
+				// Reject public clients (token_endpoint_auth_method="none")				// to simulate strict auth servers per RFC 8252.
+				if authMethod, ok := body["token_endpoint_auth_method"].(string); ok && authMethod == "none" {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusBadRequest)
+					_, _ = w.Write([]byte(`{"error":"invalid_redirect_uri","error_description":"The provided redirect URIs are not approved for use by this authorization server."}`))
+					return
+				}
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusCreated)
 				_, _ = w.Write([]byte(`{
@@ -644,6 +651,90 @@ func TestMCPServerConfigsOAuth2AutoDiscovery(t *testing.T) {
 			"redirect URI path should contain a valid UUID segment")
 	})
 
+	// Regression test: verify that Coder registers as a confidential
+	// client rather than a public client during Dynamic Client
+	// Registration.  Public clients (token_endpoint_auth_method=none)
+	// are restricted to loopback redirect URIs by many auth servers
+	// per RFC 8252, which causes failures for server-side Coder
+	// callbacks.
+	t.Run("RegistersAsConfidentialClient", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		registeredAuthMethod := make(chan string, 1)
+
+		authServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/.well-known/oauth-authorization-server":
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{
+					"issuer": "` + "http://" + r.Host + `",
+					"authorization_endpoint": "` + "http://" + r.Host + `/authorize",
+					"token_endpoint": "` + "http://" + r.Host + `/token",
+					"registration_endpoint": "` + "http://" + r.Host + `/register",
+					"response_types_supported": ["code"],
+					"token_endpoint_auth_methods_supported": ["client_secret_post", "client_secret_basic"],
+					"scopes_supported": ["read"]
+				}`))
+			case "/register":
+				var body map[string]interface{}
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					http.Error(w, "bad json", http.StatusBadRequest)
+					return
+				}
+				if method, ok := body["token_endpoint_auth_method"].(string); ok {
+					registeredAuthMethod <- method
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write([]byte(`{"client_id":"conf-id","client_secret":"conf-secret"}`))
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		t.Cleanup(authServer.Close)
+
+		mcpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/.well-known/oauth-protected-resource" {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{
+					"resource": "` + "http://" + r.Host + `",
+					"authorization_servers": ["` + authServer.URL + `"]
+				}`))
+				return
+			}
+			http.NotFound(w, r)
+		}))
+		t.Cleanup(mcpServer.Close)
+
+		client := newMCPClient(t)
+		_ = coderdtest.CreateFirstUser(t, client)
+
+		_, err := client.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+			DisplayName:   "Confidential Client Test",
+			Slug:          "confidential-client",
+			Transport:     "streamable_http",
+			URL:           mcpServer.URL + "/v1/mcp",
+			AuthType:      "oauth2",
+			Availability:  "default_on",
+			Enabled:       true,
+			ToolAllowList: []string{},
+			ToolDenyList:  []string{},
+		})
+		require.NoError(t, err)
+
+		var authMethod string
+		select {
+		case authMethod = <-registeredAuthMethod:
+		case <-ctx.Done():
+			t.Fatal("timed out waiting for registration auth method")
+		}
+
+		assert.Equal(t, "client_secret_post", authMethod,
+			"DCR should register as a confidential client to avoid redirect URI restrictions on public clients")
+	})
+
 	t.Run("PartialOAuth2FieldsRejected", func(t *testing.T) {
 		t.Parallel()
 
@@ -702,7 +793,7 @@ func TestMCPServerConfigsOAuth2AutoDiscovery(t *testing.T) {
 		var sdkErr *codersdk.Error
 		require.ErrorAs(t, err, &sdkErr)
 		require.Equal(t, http.StatusBadRequest, sdkErr.StatusCode())
-		require.Contains(t, sdkErr.Message, "auto-discovery failed")
+		require.Contains(t, sdkErr.Message, "manual OAuth2 configuration")
 	})
 
 	t.Run("ManualConfigStillWorks", func(t *testing.T) {


### PR DESCRIPTION
## Problem

During MCP OAuth2 auto-discovery, Dynamic Client Registration (DCR) fails
with `invalid_redirect_uri` against auth servers like Vercel that restrict
public clients to loopback redirect URIs.

The `mcp-go` library's `RegisterClient` always sends
`token_endpoint_auth_method="none"` (public client). Per RFC 8252, many
authorization servers restrict public clients to loopback-only redirect URIs
(`http://localhost:*`, `http://127.0.0.1:*`). This works for desktop MCP
clients (Claude, VS Code, Cursor) that run on the user's machine and can
receive localhost callbacks, but fails for server-side clients like Coder
whose callback URL is a non-loopback HTTPS endpoint.

Verified against Vercel's live DCR endpoint:
```
# Only loopback accepted:
redirect_uris: ["https://coder.example.com/..."]  → invalid_redirect_uri
redirect_uris: ["http://127.0.0.1:0/callback"]    → 201 Created
```

## Fix

Two changes:

1. **Register as confidential client when possible**: Replace `mcp-go`'s
   `RegisterClient` with our own DCR request. `pickTokenEndpointAuthMethod`
   inspects the server's `token_endpoint_auth_methods_supported` metadata
   and prefers `client_secret_post` (confidential) over `none` (public).
   Confidential clients typically have no redirect URI restrictions.

2. **Early detection with actionable error**: When the auth server only
   supports public clients (`none`) and Coder is not on localhost, bail out
   before attempting DCR with a clear message explaining that this provider
   only supports desktop MCP clients for automatic setup, and that the user
   needs to create an OAuth2 app in the provider's dashboard manually. The
   error includes the discovered auth/token URLs and the redirect URI to
   register.

## Testing

- `TestPickTokenEndpointAuthMethod` — unit tests for auth method selection
- `TestCallbackURLIsLoopback` — unit tests for loopback detection  
- `TestMCPServerConfigsOAuth2AutoDiscovery/RegistersAsConfidentialClient` —
  verifies confidential client registration when server supports it
- `TestMCPServerConfigsOAuth2AutoDiscovery/RedirectURIContainsRealConfigID` —
  existing regression test, updated to simulate strict auth server
- All existing MCP tests continue to pass