### PR TITLE
fix(site): show Agents tab on dev builds without page refresh

### DIFF
--- a/site/src/modules/dashboard/Navbar/NavbarView.stories.tsx
+++ b/site/src/modules/dashboard/Navbar/NavbarView.stories.tsx
@@ -15,6 +15,7 @@ const meta: Meta<typeof NavbarView> = {
 	parameters: {
 		chromatic: chromaticWithTablet,
 		layout: "fullscreen",
+		experiments: ["agents"],
 		queries: [
 			{
 				key: ["tasks", tasksFilter],

--- a/site/src/modules/dashboard/Navbar/NavbarView.tsx
+++ b/site/src/modules/dashboard/Navbar/NavbarView.tsx
@@ -11,10 +11,12 @@ import {
 } from "components/Tooltip/Tooltip";
 import type { ProxyContextValue } from "contexts/ProxyContext";
 import { useEmbeddedMetadata } from "hooks/useEmbeddedMetadata";
+import { useDashboard } from "modules/dashboard/useDashboard";
 import { NotificationsInbox } from "modules/notifications/NotificationsInbox/NotificationsInbox";
 import type { FC } from "react";
 import { useQuery } from "react-query";
 import { NavLink, useLocation } from "react-router";
+import { isDevBuild } from "utils/buildInfo";
 import { cn } from "utils/cn";
 import { DeploymentDropdown } from "./DeploymentDropdown";
 import { MobileMenu } from "./MobileMenu";
@@ -230,12 +232,8 @@ function idleTasksLabel(count: number) {
 }
 
 const AgentsNavItem: FC = () => {
-	const { metadata } = useEmbeddedMetadata();
-	const canSeeAgents = Boolean(
-		metadata["agents-tab-visible"].value ||
-			process.env.NODE_ENV === "development" ||
-			process.env.STORYBOOK,
-	);
+	const { experiments, buildInfo } = useDashboard();
+	const canSeeAgents = experiments.includes("agents") || isDevBuild(buildInfo);
 
 	if (!canSeeAgents) {
 		return null;


### PR DESCRIPTION
## Problem

The Agents tab was not appearing in the navbar on `coder-preview:latest` and other dev builds, even though navigating directly to `/agents` worked. Users also had to manually refresh after login for the tab to appear.

## Root Cause

`AgentsNavItem` read visibility from the `agents-tab-visible` HTML meta tag, which is only populated for authenticated requests. On the first (unauthenticated) page load the tag is empty, and after login the SPA navigates client-side without a full reload so the stale value sticks.

The frontend's `process.env.NODE_ENV === "development"` dev bypass is also ineffective in Docker images where the frontend is built in production mode, even though the Go binary is a dev build (`buildinfo.IsDev() = true`) and the API routes work via `RequireExperimentWithDevBypass`.

## Fix

Read `experiments` and `buildInfo` from `useDashboard()` instead of the HTML metadata. The `DashboardProvider` already fetches both via API after authentication, and the `cachedQuery` pattern handles the empty-metadata case transparently. The visibility check now mirrors the existing `DeploymentSidebarView` pattern:

```ts
experiments.includes("agents") || isDevBuild(buildInfo)
```

No backend changes. One file, +5/-6 lines.

> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖