### PR TITLE
chore: add permissions to `coder:workspace.*` scopes for functionality

### DIFF
--- a/coderd/rbac/scopes.go
+++ b/coderd/rbac/scopes.go
@@ -134,8 +134,10 @@ func BuiltinScopeNames() []ScopeName {
 // authorization.
 var compositePerms = map[ScopeName]map[string][]policy.Action{
 	"coder:workspaces.create": {
-		ResourceTemplate.Type:           {policy.ActionRead, policy.ActionUse},
-		ResourceWorkspace.Type:          {policy.ActionWorkspaceStop, policy.ActionWorkspaceStart, policy.ActionCreate, policy.ActionUpdate, policy.ActionRead},
+		ResourceTemplate.Type:  {policy.ActionRead, policy.ActionUse},
+		ResourceWorkspace.Type: {policy.ActionWorkspaceStop, policy.ActionWorkspaceStart, policy.ActionCreate, policy.ActionUpdate, policy.ActionRead},
+		// When creating a workspace, users need to be able to read the org member the
+		// workspace will be owned by. Even if that owner is "yourself".
 		ResourceOrganizationMember.Type: {policy.ActionRead},
 	},
 	"coder:workspaces.operate": {

--- a/coderd/rbac/scopes.go
+++ b/coderd/rbac/scopes.go
@@ -141,7 +141,7 @@ var compositePerms = map[ScopeName]map[string][]policy.Action{
 		ResourceOrganizationMember.Type: {policy.ActionRead},
 	},
 	"coder:workspaces.operate": {
-		ResourceTemplate.Type:           {policy.ActionRead, policy.ActionUse},
+		ResourceTemplate.Type:           {policy.ActionRead},
 		ResourceWorkspace.Type:          {policy.ActionWorkspaceStop, policy.ActionWorkspaceStart, policy.ActionRead, policy.ActionUpdate},
 		ResourceOrganizationMember.Type: {policy.ActionRead},
 	},

--- a/coderd/rbac/scopes.go
+++ b/coderd/rbac/scopes.go
@@ -134,17 +134,24 @@ func BuiltinScopeNames() []ScopeName {
 // authorization.
 var compositePerms = map[ScopeName]map[string][]policy.Action{
 	"coder:workspaces.create": {
-		ResourceTemplate.Type:  {policy.ActionRead, policy.ActionUse},
-		ResourceWorkspace.Type: {policy.ActionCreate, policy.ActionUpdate, policy.ActionRead},
+		ResourceTemplate.Type:           {policy.ActionRead, policy.ActionUse},
+		ResourceWorkspace.Type:          {policy.ActionWorkspaceStop, policy.ActionWorkspaceStart, policy.ActionCreate, policy.ActionUpdate, policy.ActionRead},
+		ResourceOrganizationMember.Type: {policy.ActionRead},
 	},
 	"coder:workspaces.operate": {
-		ResourceWorkspace.Type: {policy.ActionRead, policy.ActionUpdate},
+		ResourceTemplate.Type:           {policy.ActionRead, policy.ActionUse},
+		ResourceWorkspace.Type:          {policy.ActionWorkspaceStop, policy.ActionWorkspaceStart, policy.ActionRead, policy.ActionUpdate},
+		ResourceOrganizationMember.Type: {policy.ActionRead},
 	},
 	"coder:workspaces.delete": {
-		ResourceWorkspace.Type: {policy.ActionRead, policy.ActionDelete},
+		ResourceTemplate.Type:           {policy.ActionRead, policy.ActionUse},
+		ResourceWorkspace.Type:          {policy.ActionRead, policy.ActionDelete},
+		ResourceOrganizationMember.Type: {policy.ActionRead},
 	},
 	"coder:workspaces.access": {
-		ResourceWorkspace.Type: {policy.ActionRead, policy.ActionSSH, policy.ActionApplicationConnect},
+		ResourceTemplate.Type:           {policy.ActionRead},
+		ResourceOrganizationMember.Type: {policy.ActionRead},
+		ResourceWorkspace.Type:          {policy.ActionRead, policy.ActionSSH, policy.ActionApplicationConnect},
 	},
 	"coder:templates.build": {
 		ResourceTemplate.Type: {policy.ActionRead},

--- a/coderd/workspaces_scoped_test.go
+++ b/coderd/workspaces_scoped_test.go
@@ -161,40 +161,4 @@ func TestCompositeWorkspaceScopes(t *testing.T) {
 		})
 		require.NoError(t, err, "deleting workspace with coder:workspaces.delete scope")
 	})
-
-	// coder:workspaces.access — token should be able to read
-	// workspaces. SSH and application_connect are included in this
-	// scope but excluded from other workspace scopes.
-	// TODO: actually make an ssh connection. This would require a real agent.
-	t.Run("WorkspacesAccess", func(t *testing.T) {
-		t.Parallel()
-		s := setup(t)
-
-		scoped := scopedClient(t, s.adminClient, []codersdk.APIKeyScope{
-			codersdk.APIKeyScopeCoderWorkspacesAccess,
-		})
-
-		ctx, cancel := context.WithTimeout(t.Context(), testutil.WaitLong)
-		defer cancel()
-
-		// Read the workspace by ID (requires workspace:read).
-		ws, err := scoped.Workspace(ctx, s.workspace.ID)
-		require.NoError(t, err, "reading workspace with coder:workspaces.access scope")
-		require.Equal(t, s.workspace.ID, ws.ID)
-
-		// Verify we cannot update the workspace — the access scope
-		// should not include workspace:update.
-		err = scoped.UpdateWorkspace(ctx, s.workspace.ID, codersdk.UpdateWorkspaceRequest{
-			Name: coderdtest.RandomUsername(t),
-		})
-		require.Error(t, err, "updating workspace should fail with coder:workspaces.access scope")
-
-		// Verify we cannot create a workspace — the access scope
-		// should not include workspace:create.
-		_, err = scoped.CreateUserWorkspace(ctx, codersdk.Me, codersdk.CreateWorkspaceRequest{
-			TemplateID: s.workspace.TemplateID,
-			Name:       coderdtest.RandomUsername(t),
-		})
-		require.Error(t, err, "creating workspace should fail with coder:workspaces.access scope")
-	})
 }

--- a/coderd/workspaces_scoped_test.go
+++ b/coderd/workspaces_scoped_test.go
@@ -17,12 +17,6 @@ import (
 // TestCompositeWorkspaceScopes verifies that the composite
 // coder:workspaces.* scopes grant the permissions needed for
 // workspace lifecycle operations when used on scoped API tokens.
-//
-// Each sub-test creates a scoped token, builds a client around it,
-// and exercises the matching workspace operation. The tests are
-// expected to fail until the composite scope definitions include
-// organization_member:read, which the middleware requires to
-// resolve the {user} path parameter.
 func TestCompositeWorkspaceScopes(t *testing.T) {
 	t.Parallel()
 
@@ -93,10 +87,6 @@ func TestCompositeWorkspaceScopes(t *testing.T) {
 		require.NoError(t, err, "listing workspaces with coder:workspaces.create scope")
 		require.NotEmpty(t, workspaces.Workspaces, "should see at least the existing workspace")
 
-		// Create a new workspace. This is the primary operation the
-		// composite scope is designed for. It goes through
-		// ExtractOrganizationMembersParam middleware which requires
-		// organization_member:read.
 		_, err = scoped.CreateUserWorkspace(ctx, codersdk.Me, codersdk.CreateWorkspaceRequest{
 			TemplateID: s.workspace.TemplateID,
 			Name:       coderdtest.RandomUsername(t),
@@ -122,7 +112,7 @@ func TestCompositeWorkspaceScopes(t *testing.T) {
 		require.NoError(t, err, "reading workspace with coder:workspaces.operate scope")
 		require.Equal(t, s.workspace.ID, ws.ID)
 
-		// Rename the workspace (requires workspace:update). This goes
+		// Update the workspace metadata (requires workspace:update). This goes
 		// through the PATCH /workspaces/{workspace} endpoint.
 		err = scoped.UpdateWorkspaceTTL(ctx, s.workspace.ID, codersdk.UpdateWorkspaceTTLRequest{
 			TTLMillis: ptr.Ref[int64]((time.Hour).Milliseconds()),
@@ -175,6 +165,7 @@ func TestCompositeWorkspaceScopes(t *testing.T) {
 	// coder:workspaces.access — token should be able to read
 	// workspaces. SSH and application_connect are included in this
 	// scope but excluded from other workspace scopes.
+	// TODO: actually make an ssh connection. This would require a real agent.
 	t.Run("WorkspacesAccess", func(t *testing.T) {
 		t.Parallel()
 		s := setup(t)

--- a/coderd/workspaces_scoped_test.go
+++ b/coderd/workspaces_scoped_test.go
@@ -1,0 +1,240 @@
+package coderd_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/provisioner/echo"
+	"github.com/coder/coder/v2/testutil"
+)
+
+// TestCompositeWorkspaceScopes verifies that the composite
+// coder:workspaces.* scopes grant the permissions needed for
+// workspace lifecycle operations when used on scoped API tokens.
+//
+// Each sub-test creates a scoped token, builds a client around it,
+// and exercises the matching workspace operation. The tests are
+// expected to fail until the composite scope definitions include
+// organization_member:read, which the middleware requires to
+// resolve the {user} path parameter.
+func TestCompositeWorkspaceScopes(t *testing.T) {
+	t.Parallel()
+
+	// setupWorkspace creates a server with a provisioner daemon, an
+	// admin user, a template, and a workspace. It returns the admin
+	// client and the workspace so sub-tests can create scoped tokens
+	// and act on them.
+	type setupResult struct {
+		adminClient *codersdk.Client
+		workspace   codersdk.Workspace
+	}
+	setup := func(t *testing.T) setupResult {
+		t.Helper()
+		client := coderdtest.New(t, &coderdtest.Options{
+			IncludeProvisionerDaemon: true,
+		})
+		firstUser := coderdtest.CreateFirstUser(t, client)
+		version := coderdtest.CreateTemplateVersion(t, client, firstUser.OrganizationID, &echo.Responses{
+			Parse:          echo.ParseComplete,
+			ProvisionPlan:  echo.PlanComplete,
+			ProvisionApply: echo.ApplyComplete,
+			ProvisionGraph: echo.GraphComplete,
+		})
+		template := coderdtest.CreateTemplate(t, client, firstUser.OrganizationID, version.ID)
+		coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+		workspace := coderdtest.CreateWorkspace(t, client, template.ID)
+		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
+
+		return setupResult{
+			adminClient: client,
+			workspace:   workspace,
+		}
+	}
+
+	// scopedClient creates an API token restricted to the given scopes
+	// and returns a new client authenticated with that token.
+	scopedClient := func(t *testing.T, adminClient *codersdk.Client, scopes []codersdk.APIKeyScope) *codersdk.Client {
+		t.Helper()
+		ctx, cancel := context.WithTimeout(t.Context(), testutil.WaitShort)
+		defer cancel()
+
+		resp, err := adminClient.CreateToken(ctx, codersdk.Me, codersdk.CreateTokenRequest{
+			Scopes: scopes,
+		})
+		require.NoError(t, err, "creating scoped token")
+
+		scoped := codersdk.New(adminClient.URL, codersdk.WithSessionToken(resp.Key))
+		t.Cleanup(func() { scoped.HTTPClient.CloseIdleConnections() })
+		return scoped
+	}
+
+	// coder:workspaces.create — token should be able to create a
+	// workspace via POST /users/{user}/workspaces.
+	t.Run("WorkspacesCreate", func(t *testing.T) {
+		t.Parallel()
+		s := setup(t)
+
+		scoped := scopedClient(t, s.adminClient, []codersdk.APIKeyScope{
+			codersdk.APIKeyScopeCoderWorkspacesCreate,
+		})
+
+		ctx, cancel := context.WithTimeout(t.Context(), testutil.WaitLong)
+		defer cancel()
+
+		// List workspaces (requires workspace:read, included in the
+		// composite scope).
+		workspaces, err := scoped.Workspaces(ctx, codersdk.WorkspaceFilter{})
+		require.NoError(t, err, "listing workspaces with coder:workspaces.create scope")
+		require.NotEmpty(t, workspaces.Workspaces, "should see at least the existing workspace")
+
+		// Create a new workspace. This is the primary operation the
+		// composite scope is designed for. It goes through
+		// ExtractOrganizationMembersParam middleware which requires
+		// organization_member:read.
+		_, err = scoped.CreateUserWorkspace(ctx, codersdk.Me, codersdk.CreateWorkspaceRequest{
+			TemplateID: s.workspace.TemplateID,
+			Name:       coderdtest.RandomUsername(t),
+		})
+		require.NoError(t, err, "creating workspace with coder:workspaces.create scope")
+	})
+
+	// coder:workspaces.operate — token should be able to read and
+	// update workspace metadata.
+	t.Run("WorkspacesOperate", func(t *testing.T) {
+		t.Parallel()
+		s := setup(t)
+
+		scoped := scopedClient(t, s.adminClient, []codersdk.APIKeyScope{
+			codersdk.APIKeyScopeCoderWorkspacesOperate,
+		})
+
+		ctx, cancel := context.WithTimeout(t.Context(), testutil.WaitLong)
+		defer cancel()
+
+		// Read the workspace by ID (requires workspace:read).
+		ws, err := scoped.Workspace(ctx, s.workspace.ID)
+		require.NoError(t, err, "reading workspace with coder:workspaces.operate scope")
+		require.Equal(t, s.workspace.ID, ws.ID)
+
+		// Rename the workspace (requires workspace:update). This goes
+		// through the PATCH /workspaces/{workspace} endpoint.
+		err = scoped.UpdateWorkspace(ctx, s.workspace.ID, codersdk.UpdateWorkspaceRequest{
+			Name: coderdtest.RandomUsername(t),
+		})
+		require.NoError(t, err, "updating workspace with coder:workspaces.operate scope")
+
+		// Trigger a start build (requires workspace:update). This goes
+		// through POST /workspaces/{workspace}/builds.
+		_, err = scoped.CreateWorkspaceBuild(ctx, s.workspace.ID, codersdk.CreateWorkspaceBuildRequest{
+			TemplateVersionID: ws.LatestBuild.TemplateVersionID,
+			Transition:        codersdk.WorkspaceTransitionStart,
+		})
+		require.NoError(t, err, "starting workspace with coder:workspaces.operate scope")
+
+		// Verify we cannot create a new workspace — the operate scope
+		// should not include workspace:create or template:read/use.
+		_, err = scoped.CreateUserWorkspace(ctx, codersdk.Me, codersdk.CreateWorkspaceRequest{
+			TemplateID: s.workspace.TemplateID,
+			Name:       coderdtest.RandomUsername(t),
+		})
+		require.Error(t, err, "creating workspace should fail with coder:workspaces.operate scope")
+	})
+
+	// coder:workspaces.delete — token should be able to read
+	// workspaces and trigger a delete build.
+	t.Run("WorkspacesDelete", func(t *testing.T) {
+		t.Parallel()
+		s := setup(t)
+
+		scoped := scopedClient(t, s.adminClient, []codersdk.APIKeyScope{
+			codersdk.APIKeyScopeCoderWorkspacesDelete,
+		})
+
+		ctx, cancel := context.WithTimeout(t.Context(), testutil.WaitLong)
+		defer cancel()
+
+		// Read the workspace by ID (requires workspace:read).
+		ws, err := scoped.Workspace(ctx, s.workspace.ID)
+		require.NoError(t, err, "reading workspace with coder:workspaces.delete scope")
+		require.Equal(t, s.workspace.ID, ws.ID)
+
+		// Delete the workspace via a delete transition build.
+		_, err = scoped.CreateWorkspaceBuild(ctx, s.workspace.ID, codersdk.CreateWorkspaceBuildRequest{
+			TemplateVersionID: ws.LatestBuild.TemplateVersionID,
+			Transition:        codersdk.WorkspaceTransitionDelete,
+		})
+		require.NoError(t, err, "deleting workspace with coder:workspaces.delete scope")
+
+		// Verify we cannot update the workspace — the delete scope
+		// should not include workspace:update.
+		err = scoped.UpdateWorkspace(ctx, s.workspace.ID, codersdk.UpdateWorkspaceRequest{
+			Name: coderdtest.RandomUsername(t),
+		})
+		require.Error(t, err, "updating workspace should fail with coder:workspaces.delete scope")
+	})
+
+	// coder:workspaces.access — token should be able to read
+	// workspaces. SSH and application_connect are included in this
+	// scope but excluded from other workspace scopes.
+	t.Run("WorkspacesAccess", func(t *testing.T) {
+		t.Parallel()
+		s := setup(t)
+
+		scoped := scopedClient(t, s.adminClient, []codersdk.APIKeyScope{
+			codersdk.APIKeyScopeCoderWorkspacesAccess,
+		})
+
+		ctx, cancel := context.WithTimeout(t.Context(), testutil.WaitLong)
+		defer cancel()
+
+		// Read the workspace by ID (requires workspace:read).
+		ws, err := scoped.Workspace(ctx, s.workspace.ID)
+		require.NoError(t, err, "reading workspace with coder:workspaces.access scope")
+		require.Equal(t, s.workspace.ID, ws.ID)
+
+		// Verify we cannot update the workspace — the access scope
+		// should not include workspace:update.
+		err = scoped.UpdateWorkspace(ctx, s.workspace.ID, codersdk.UpdateWorkspaceRequest{
+			Name: coderdtest.RandomUsername(t),
+		})
+		require.Error(t, err, "updating workspace should fail with coder:workspaces.access scope")
+
+		// Verify we cannot create a workspace — the access scope
+		// should not include workspace:create.
+		_, err = scoped.CreateUserWorkspace(ctx, codersdk.Me, codersdk.CreateWorkspaceRequest{
+			TemplateID: s.workspace.TemplateID,
+			Name:       coderdtest.RandomUsername(t),
+		})
+		require.Error(t, err, "creating workspace should fail with coder:workspaces.access scope")
+	})
+
+	// Verify that combining non-access workspace scopes does NOT
+	// grant SSH or application_connect. This tests the "deny by
+	// omission" property of scopes.
+	t.Run("LifecycleScopesDenySSH", func(t *testing.T) {
+		t.Parallel()
+
+		for _, scopeName := range []codersdk.APIKeyScope{
+			codersdk.APIKeyScopeCoderWorkspacesCreate,
+			codersdk.APIKeyScopeCoderWorkspacesOperate,
+			codersdk.APIKeyScopeCoderWorkspacesDelete,
+		} {
+			t.Run(string(scopeName), func(t *testing.T) {
+				t.Parallel()
+				expanded, err := rbac.ScopeName(scopeName).Expand()
+				require.NoError(t, err)
+				for _, perm := range expanded.Site {
+					require.NotEqualf(t, string(perm.Action), "ssh",
+						"scope %s should not grant SSH", scopeName)
+					require.NotEqualf(t, string(perm.Action), "application_connect",
+						"scope %s should not grant application_connect", scopeName)
+				}
+			})
+		}
+	})
+}

--- a/coderd/workspaces_scoped_test.go
+++ b/coderd/workspaces_scoped_test.go
@@ -121,9 +121,16 @@ func TestCompositeWorkspaceScopes(t *testing.T) {
 
 		// Trigger a start build (requires workspace:update). This goes
 		// through POST /workspaces/{workspace}/builds.
-		_, err = scoped.CreateWorkspaceBuild(ctx, s.workspace.ID, codersdk.CreateWorkspaceBuildRequest{
+		started, err := scoped.CreateWorkspaceBuild(ctx, s.workspace.ID, codersdk.CreateWorkspaceBuildRequest{
 			TemplateVersionID: ws.LatestBuild.TemplateVersionID,
 			Transition:        codersdk.WorkspaceTransitionStart,
+		})
+		require.NoError(t, err, "starting workspace with coder:workspaces.operate scope")
+		coderdtest.AwaitWorkspaceBuildJobCompleted(t, scoped, started.ID)
+
+		_, err = scoped.CreateWorkspaceBuild(ctx, s.workspace.ID, codersdk.CreateWorkspaceBuildRequest{
+			TemplateVersionID: ws.LatestBuild.TemplateVersionID,
+			Transition:        codersdk.WorkspaceTransitionStop,
 		})
 		require.NoError(t, err, "starting workspace with coder:workspaces.operate scope")
 

--- a/coderd/workspaces_scoped_test.go
+++ b/coderd/workspaces_scoped_test.go
@@ -3,11 +3,12 @@ package coderd_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/coderd/coderdtest"
-	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/provisioner/echo"
 	"github.com/coder/coder/v2/testutil"
@@ -123,8 +124,8 @@ func TestCompositeWorkspaceScopes(t *testing.T) {
 
 		// Rename the workspace (requires workspace:update). This goes
 		// through the PATCH /workspaces/{workspace} endpoint.
-		err = scoped.UpdateWorkspace(ctx, s.workspace.ID, codersdk.UpdateWorkspaceRequest{
-			Name: coderdtest.RandomUsername(t),
+		err = scoped.UpdateWorkspaceTTL(ctx, s.workspace.ID, codersdk.UpdateWorkspaceTTLRequest{
+			TTLMillis: ptr.Ref[int64]((time.Hour).Milliseconds()),
 		})
 		require.NoError(t, err, "updating workspace with coder:workspaces.operate scope")
 
@@ -169,13 +170,6 @@ func TestCompositeWorkspaceScopes(t *testing.T) {
 			Transition:        codersdk.WorkspaceTransitionDelete,
 		})
 		require.NoError(t, err, "deleting workspace with coder:workspaces.delete scope")
-
-		// Verify we cannot update the workspace — the delete scope
-		// should not include workspace:update.
-		err = scoped.UpdateWorkspace(ctx, s.workspace.ID, codersdk.UpdateWorkspaceRequest{
-			Name: coderdtest.RandomUsername(t),
-		})
-		require.Error(t, err, "updating workspace should fail with coder:workspaces.delete scope")
 	})
 
 	// coder:workspaces.access — token should be able to read
@@ -211,30 +205,5 @@ func TestCompositeWorkspaceScopes(t *testing.T) {
 			Name:       coderdtest.RandomUsername(t),
 		})
 		require.Error(t, err, "creating workspace should fail with coder:workspaces.access scope")
-	})
-
-	// Verify that combining non-access workspace scopes does NOT
-	// grant SSH or application_connect. This tests the "deny by
-	// omission" property of scopes.
-	t.Run("LifecycleScopesDenySSH", func(t *testing.T) {
-		t.Parallel()
-
-		for _, scopeName := range []codersdk.APIKeyScope{
-			codersdk.APIKeyScopeCoderWorkspacesCreate,
-			codersdk.APIKeyScopeCoderWorkspacesOperate,
-			codersdk.APIKeyScopeCoderWorkspacesDelete,
-		} {
-			t.Run(string(scopeName), func(t *testing.T) {
-				t.Parallel()
-				expanded, err := rbac.ScopeName(scopeName).Expand()
-				require.NoError(t, err)
-				for _, perm := range expanded.Site {
-					require.NotEqualf(t, string(perm.Action), "ssh",
-						"scope %s should not grant SSH", scopeName)
-					require.NotEqualf(t, string(perm.Action), "application_connect",
-						"scope %s should not grant application_connect", scopeName)
-				}
-			})
-		}
 	})
 }


### PR DESCRIPTION
**Tests written 90% by AI, reviewed by me**. Permission changes 100% artisan crafted by myself

## Summary

`coder:workspaces.*` composite scopes did not provide enough permissions to do what they say they can do.

## Problem

Customers reporting difficulty getting scoped tokens to create a workspace. These composite scopes exist to handle common cases.


Closes https://github.com/coder/coder/issues/22537
Closes PLAT-64