### PR TITLE
fix(coderd/x/chatd): normalize OAuth2 token type to canonical Bearer case

### DIFF
--- a/coderd/x/chatd/mcpclient/mcpclient.go
+++ b/coderd/x/chatd/mcpclient/mcpclient.go
@@ -288,6 +288,12 @@ func buildAuthHeaders(
 		if tokenType == "" {
 			tokenType = "Bearer"
 		}
+		// RFC 6750 says the scheme is case-insensitive, but
+		// some servers (e.g. Linear) reject lowercase
+		// "bearer". Normalize to the canonical form.
+		if strings.EqualFold(tokenType, "bearer") {
+			tokenType = "Bearer"
+		}
 		headers["Authorization"] = tokenType + " " + tok.AccessToken
 	case "api_key":
 		if cfg.APIKeyHeader != "" && cfg.APIKeyValue != "" {


### PR DESCRIPTION
Linear's MCP server (`mcp.linear.app`) returns `token_type="bearer"` (lowercase) in its OAuth2 token response but rejects requests that use the lowercase form in the `Authorization` header. RFC 6750 says the scheme is case-insensitive, but Linear enforces capital-B `Bearer`.

Confirmed by running the actual Linear MCP OAuth flow end-to-end:
- `Authorization: Bearer <token>` → **42 tools, works**
- `Authorization: bearer <token>` → **401 invalid_token**

This is a one-line fix: normalize any case variant of `bearer` to `Bearer` before building the `Authorization` header, matching the behavior of the mcp-go library's own OAuth handler.