### PR TITLE
fix: preserve duplicate model form state

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ChatModelAdminPanel.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ChatModelAdminPanel.stories.tsx
@@ -401,9 +401,9 @@ const openModelActionsMenu = async (
 	if (!row) {
 		throw new Error(`Could not find row for model ${modelName}`);
 	}
-	const actionsButton = within(row).getByRole("button", {
+	const actionsButton = within(row).getAllByRole("button", {
 		name: "Model actions",
-	});
+	})[0];
 	await userEvent.click(actionsButton);
 };
 

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ChatModelAdminPanel.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ChatModelAdminPanel.stories.tsx
@@ -392,6 +392,21 @@ const openAddModelForm = async (
 	});
 };
 
+const openModelActionsMenu = async (
+	body: ReturnType<typeof within>,
+	modelName: string,
+) => {
+	const editButton = await body.findByRole("button", { name: modelName });
+	const row = editButton.parentElement;
+	if (!row) {
+		throw new Error(`Could not find row for model ${modelName}`);
+	}
+	const actionsButton = within(row).getByRole("button", {
+		name: "Model actions",
+	});
+	await userEvent.click(actionsButton);
+};
+
 export const NoModelConfigByDefault: Story = {
 	args: { section: "models" as ChatModelAdminSection },
 	beforeEach: () => {
@@ -923,6 +938,154 @@ export const ProviderDeleteConfirmed: Story = {
 		expect(API.experimental.deleteChatProviderConfig).toHaveBeenCalledWith(
 			"provider-openai",
 		);
+	},
+};
+
+export const ModelActionsAndDuplicateFlow: Story = {
+	args: { section: "models" as ChatModelAdminSection },
+	beforeEach: () => {
+		setupChatSpies({
+			providerConfigs: [
+				createProviderConfig({
+					id: "provider-openai",
+					provider: "openai",
+					display_name: "OpenAI",
+					source: "database",
+					has_api_key: true,
+				}),
+			],
+			modelConfigs: [
+				createModelConfig({
+					id: "model-openai-1",
+					provider: "openai",
+					model: "gpt-5",
+					display_name: "GPT 5",
+					is_default: true,
+					context_limit: 123456,
+					compression_threshold: 61,
+					model_config: {
+						max_output_tokens: 32000,
+						provider_options: {
+							openai: {
+								reasoning_effort: "high",
+							},
+						},
+					},
+				}),
+			],
+			modelCatalog: { providers: [] },
+		});
+	},
+	play: async ({ canvasElement }) => {
+		const body = within(canvasElement.ownerDocument.body);
+
+		await openModelActionsMenu(body, "GPT 5");
+		await expect(
+			await body.findByRole("menuitem", { name: "Edit model" }),
+		).toBeInTheDocument();
+		await expect(
+			body.getByRole("menuitem", { name: "Duplicate model" }),
+		).toBeInTheDocument();
+
+		await userEvent.click(body.getByRole("menuitem", { name: "Edit model" }));
+		await expect(await body.findByText("Edit Model")).toBeInTheDocument();
+		await expect(body.getByDisplayValue("gpt-5")).toBeInTheDocument();
+		await userEvent.click(body.getByRole("button", { name: "Back" }));
+
+		await openModelActionsMenu(body, "GPT 5");
+		await userEvent.click(
+			body.getByRole("menuitem", { name: "Duplicate model" }),
+		);
+		await expect(await body.findByText("Add Model")).toBeInTheDocument();
+		await expect(body.getByDisplayValue("gpt-5")).toBeInTheDocument();
+		await expect(body.getByDisplayValue("GPT 5 copy")).toBeInTheDocument();
+		await expect(body.getByDisplayValue("123456")).toBeInTheDocument();
+		await expect(body.getByDisplayValue("61")).toBeInTheDocument();
+		const submitButton = body.getByRole("button", { name: "Add model" });
+		await expect(submitButton).toBeInTheDocument();
+		await userEvent.click(submitButton);
+
+		await waitFor(() => {
+			expect(API.experimental.createChatModelConfig).toHaveBeenCalledTimes(1);
+		});
+		expect(API.experimental.updateChatModelConfig).not.toHaveBeenCalled();
+		expect(API.experimental.createChatModelConfig).toHaveBeenCalledWith(
+			expect.objectContaining({
+				provider: "openai",
+				model: "gpt-5",
+				display_name: "GPT 5 copy",
+				context_limit: 123456,
+				compression_threshold: 61,
+				model_config: expect.objectContaining({
+					max_output_tokens: 32000,
+					provider_options: {
+						openai: {
+							reasoning_effort: "high",
+						},
+					},
+				}),
+			}),
+		);
+		const callArgs = (
+			API.experimental.createChatModelConfig as unknown as ReturnType<
+				typeof spyOn
+			>
+		).mock.calls[0][0] as Record<string, unknown>;
+		expect(callArgs.is_default).toBeUndefined();
+	},
+};
+
+export const DuplicateModelWithoutProviderApiKey: Story = {
+	args: { section: "models" as ChatModelAdminSection },
+	beforeEach: () => {
+		setupChatSpies({
+			providerConfigs: [
+				createProviderConfig({
+					id: "provider-openai",
+					provider: "openai",
+					display_name: "OpenAI",
+					source: "database",
+					has_api_key: false,
+				}),
+			],
+			modelConfigs: [
+				createModelConfig({
+					id: "model-openai-no-key",
+					provider: "openai",
+					model: "gpt-5-mini",
+					display_name: "GPT 5 Mini",
+					context_limit: 64000,
+					compression_threshold: 77,
+					model_config: {
+						max_output_tokens: 16000,
+					},
+				}),
+			],
+			modelCatalog: { providers: [] },
+		});
+	},
+	play: async ({ canvasElement }) => {
+		const body = within(canvasElement.ownerDocument.body);
+
+		await openModelActionsMenu(body, "GPT 5 Mini");
+		await userEvent.click(
+			body.getByRole("menuitem", { name: "Duplicate model" }),
+		);
+
+		await expect(await body.findByText("Add Model")).toBeInTheDocument();
+		await expect(body.getByDisplayValue("gpt-5-mini")).toBeInTheDocument();
+		await expect(body.getByDisplayValue("GPT 5 Mini copy")).toBeInTheDocument();
+		await expect(body.getByDisplayValue("64000")).toBeInTheDocument();
+		await expect(body.getByDisplayValue("77")).toBeInTheDocument();
+		await expect(
+			body.getByText(/Create a managed provider config or set an API key/i),
+		).toBeInTheDocument();
+		await expect(
+			body.getByRole("button", { name: "Set an API key" }),
+		).toBeInTheDocument();
+		await expect(
+			body.getByRole("button", { name: "Add model" }),
+		).toBeDisabled();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelForm.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelForm.tsx
@@ -61,6 +61,7 @@ const validationSchema = Yup.object({
 interface ModelFormProps {
 	/** When set, the form is in "edit" mode for the given model. */
 	editingModel?: TypesGen.ChatModelConfig;
+	duplicateFromModel?: TypesGen.ChatModelConfig;
 	providerStates: readonly ProviderState[];
 	selectedProvider: string | null;
 	selectedProviderState: ProviderState | null;
@@ -81,6 +82,7 @@ interface ModelFormProps {
 
 export const ModelForm: FC<ModelFormProps> = ({
 	editingModel,
+	duplicateFromModel,
 	providerStates,
 	selectedProvider,
 	selectedProviderState,
@@ -104,7 +106,10 @@ export const ModelForm: FC<ModelFormProps> = ({
 	);
 
 	const form = useFormik<ModelFormValues>({
-		initialValues: buildInitialModelFormValues(editingModel),
+		initialValues: buildInitialModelFormValues(
+			editingModel,
+			duplicateFromModel,
+		),
 		validationSchema,
 		validateOnMount: true,
 		validateOnBlur: false,

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelsSection.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelsSection.tsx
@@ -14,7 +14,7 @@ import {
 } from "components/Tooltip/Tooltip";
 import {
 	ChevronDownIcon,
-	ChevronRightIcon,
+	EllipsisVertical,
 	PlusIcon,
 	StarIcon,
 	TriangleAlertIcon,
@@ -31,7 +31,8 @@ import { hasCustomPricing } from "./pricingFields";
 type ModelView =
 	| { mode: "list" }
 	| { mode: "add"; provider: string }
-	| { mode: "edit"; model: TypesGen.ChatModelConfig };
+	| { mode: "edit"; model: TypesGen.ChatModelConfig }
+	| { mode: "duplicate"; model: TypesGen.ChatModelConfig };
 
 interface ModelsSectionProps {
 	sectionLabel?: string;
@@ -92,18 +93,23 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 			const model = modelConfigs.find((m) => m.id === editModelId);
 			return model ? { mode: "edit", model } : { mode: "list" };
 		}
+		const duplicateModelId = searchParams.get("duplicateModel");
+		if (duplicateModelId) {
+			const model = modelConfigs.find((m) => m.id === duplicateModelId);
+			return model ? { mode: "duplicate", model } : { mode: "list" };
+		}
 		const addProvider = searchParams.get("newModel");
 		if (addProvider) {
 			return { mode: "add", provider: addProvider };
 		}
 		return { mode: "list" };
 	})();
-
 	// Clear model-related search params and return to the list.
 	const clearModelView = () => {
 		setSearchParams((prev) => {
 			const next = new URLSearchParams(prev);
 			next.delete("model");
+			next.delete("duplicateModel");
 			next.delete("newModel");
 			return next;
 		});
@@ -121,6 +127,7 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 				(prev) => {
 					const next = new URLSearchParams(prev);
 					next.delete("model");
+					next.delete("duplicateModel");
 					next.delete("newModel");
 					return next;
 				},
@@ -130,8 +137,14 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 	};
 
 	// When the form is open it takes over the full panel.
-	if (view.mode === "add" || view.mode === "edit") {
+	if (
+		view.mode === "add" ||
+		view.mode === "edit" ||
+		view.mode === "duplicate"
+	) {
 		const editingModel = view.mode === "edit" ? view.model : undefined;
+		const duplicateFromModel =
+			view.mode === "duplicate" ? view.model : undefined;
 
 		const getEffectiveProvider = () => {
 			if (editingModel) {
@@ -139,6 +152,9 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 			}
 			if (view.mode === "add") {
 				return view.provider;
+			}
+			if (duplicateFromModel) {
+				return duplicateFromModel.provider;
 			}
 			return selectedProvider;
 		};
@@ -150,8 +166,14 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 
 		return (
 			<ModelForm
-				key={editingModel?.id ?? effectiveProvider ?? "new"}
+				key={
+					editingModel?.id ??
+					duplicateFromModel?.id ??
+					effectiveProvider ??
+					"new"
+				}
 				editingModel={editingModel}
+				duplicateFromModel={duplicateFromModel}
 				providerStates={providerStates}
 				selectedProvider={effectiveProvider}
 				selectedProviderState={effectiveProviderState}
@@ -222,6 +244,16 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 		void onUpdateModel(modelConfig.id, { is_default: true });
 	};
 
+	const openEditModel = (modelConfigId: string) => {
+		setSearchParams({ model: modelConfigId }, { state: { pushed: true } });
+	};
+
+	const openDuplicateModel = (modelConfigId: string) => {
+		setSearchParams(
+			{ duplicateModel: modelConfigId },
+			{ state: { pushed: true } },
+		);
+	};
 	return (
 		<>
 			{sectionLabel && (
@@ -295,15 +327,9 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 											: "Set as default for new chats"}
 									</TooltipContent>
 								</Tooltip>
-								{/* Clickable row content */}
 								<button
 									type="button"
-									onClick={() =>
-										setSearchParams(
-											{ model: modelConfig.id },
-											{ state: { pushed: true } },
-										)
-									}
+									onClick={() => openEditModel(modelConfig.id)}
 									className="flex min-w-0 flex-1 cursor-pointer items-center gap-3.5 bg-transparent border-0 p-0 text-left transition-colors hover:opacity-80"
 								>
 									<ProviderIcon
@@ -333,7 +359,31 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 											disabled
 										</Badge>
 									)}
-									<ChevronRightIcon className="h-5 w-5 shrink-0 text-content-secondary" />
+									<DropdownMenu>
+										<DropdownMenuTrigger asChild>
+											<Button
+												size="icon-lg"
+												variant="subtle"
+												aria-label="Model actions"
+												onClick={(e) => e.stopPropagation()}
+											>
+												<EllipsisVertical aria-hidden="true" />
+												<span className="sr-only">Model actions</span>
+											</Button>
+										</DropdownMenuTrigger>
+										<DropdownMenuContent align="end">
+											<DropdownMenuItem
+												onClick={() => openEditModel(modelConfig.id)}
+											>
+												Edit model
+											</DropdownMenuItem>
+											<DropdownMenuItem
+												onClick={() => openDuplicateModel(modelConfig.id)}
+											>
+												Duplicate model
+											</DropdownMenuItem>
+										</DropdownMenuContent>
+									</DropdownMenu>
 								</button>
 							</div>
 						);

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelsSection.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelsSection.tsx
@@ -359,32 +359,31 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 											disabled
 										</Badge>
 									)}
-									<DropdownMenu>
-										<DropdownMenuTrigger asChild>
-											<Button
-												size="icon-lg"
-												variant="subtle"
-												aria-label="Model actions"
-												onClick={(e) => e.stopPropagation()}
-											>
-												<EllipsisVertical aria-hidden="true" />
-												<span className="sr-only">Model actions</span>
-											</Button>
-										</DropdownMenuTrigger>
-										<DropdownMenuContent align="end">
-											<DropdownMenuItem
-												onClick={() => openEditModel(modelConfig.id)}
-											>
-												Edit model
-											</DropdownMenuItem>
-											<DropdownMenuItem
-												onClick={() => openDuplicateModel(modelConfig.id)}
-											>
-												Duplicate model
-											</DropdownMenuItem>
-										</DropdownMenuContent>
-									</DropdownMenu>
 								</button>
+								<DropdownMenu>
+									<DropdownMenuTrigger asChild>
+										<Button
+											size="icon-lg"
+											variant="subtle"
+											aria-label="Model actions"
+										>
+											<EllipsisVertical aria-hidden="true" />
+											<span className="sr-only">Model actions</span>
+										</Button>
+									</DropdownMenuTrigger>
+									<DropdownMenuContent align="end">
+										<DropdownMenuItem
+											onClick={() => openEditModel(modelConfig.id)}
+										>
+											Edit model
+										</DropdownMenuItem>
+										<DropdownMenuItem
+											onClick={() => openDuplicateModel(modelConfig.id)}
+										>
+											Duplicate model
+										</DropdownMenuItem>
+									</DropdownMenuContent>
+								</DropdownMenu>{" "}
 							</div>
 						);
 					})}

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/modelConfigFormLogic.ts
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/modelConfigFormLogic.ts
@@ -219,20 +219,43 @@ export const extractModelConfigFormState = (
 
 // ── Build initial model form values ────────────────────────────
 
+const duplicateModelDisplayNameSuffix = "copy";
+
+const buildDuplicateModelDisplayName = (
+	sourceModel: TypesGen.ChatModelConfig,
+): string => {
+	const baseName = sourceModel.display_name || sourceModel.model;
+	const normalizedBaseName = baseName.endsWith(
+		` ${duplicateModelDisplayNameSuffix}`,
+	)
+		? baseName
+		: `${baseName} ${duplicateModelDisplayNameSuffix}`;
+	return normalizedBaseName;
+};
+
 export const buildInitialModelFormValues = (
 	editingModel?: TypesGen.ChatModelConfig,
-): ModelFormValues => ({
-	model: editingModel?.model ?? "",
-	displayName: editingModel?.display_name ?? "",
-	contextLimit: editingModel ? String(editingModel.context_limit) : "",
-	compressionThreshold: editingModel
-		? String(editingModel.compression_threshold)
-		: "",
-	isDefault: editingModel?.is_default ?? false,
-	config: editingModel
-		? extractModelConfigFormState(editingModel)
-		: structuredClone(emptyModelConfigFormState),
-});
+	duplicateFromModel?: TypesGen.ChatModelConfig,
+): ModelFormValues => {
+	const sourceModel = editingModel ?? duplicateFromModel;
+	const isDuplicate = Boolean(duplicateFromModel) && !editingModel;
+
+	return {
+		model: sourceModel?.model ?? "",
+		displayName:
+			isDuplicate && sourceModel
+				? buildDuplicateModelDisplayName(sourceModel)
+				: (sourceModel?.display_name ?? ""),
+		contextLimit: sourceModel ? String(sourceModel.context_limit) : "",
+		compressionThreshold: sourceModel
+			? String(sourceModel.compression_threshold)
+			: "",
+		isDefault: isDuplicate ? false : (sourceModel?.is_default ?? false),
+		config: sourceModel
+			? extractModelConfigFormState(sourceModel)
+			: structuredClone(emptyModelConfigFormState),
+	};
+};
 
 function isNonNegativePricingField(field: FieldSchema): boolean {
 	return pricingFieldNames.has(field.json_name);


### PR DESCRIPTION
$Duplicating a model previously fell back to the plain add-model flow when the provider had no effective API key, so the copied model values were lost and admins landed in a confusing blank form.\n\nThis change keeps the duplicate flow intact so the form remains prefilled even when saving is blocked by provider configuration, and adds Storybook coverage for both the normal duplicate path and the no-API-key case.