### PR TITLE
feat(scripts/releaser): add release candidate (RC) support

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -121,21 +121,11 @@ jobs:
 
           # 2.10.2 -> release/2.10
           version="$(./scripts/version.sh)"
-          # Strip any pre-release suffix (e.g. 2.32.0-rc.0 -> 2.32.0)
-          # before extracting the release branch name.
-          base_version="${version%%-*}"
-          release_branch=release/${base_version%.*}
-
-          # RC tags (pre-release versions) are tagged directly from
-          # main and are not expected to exist on a release branch.
-          if [[ "${version}" == *-* ]]; then
-            echo "Pre-release version detected (${version}), skipping branch check."
-          else
-            branch_contains_tag=$(git branch --remotes --contains "${GITHUB_REF}" --list "*/${release_branch}" --format='%(refname)')
-            if [[ -z "${branch_contains_tag}" ]]; then
-              echo "Ref tag must exist in a branch named ${release_branch} when creating a release, did you use scripts/release.sh?"
-              exit 1
-            fi
+          release_branch=release/${version%.*}
+          branch_contains_tag=$(git branch --remotes --contains "${GITHUB_REF}" --list "*/${release_branch}" --format='%(refname)')
+          if [[ -z "${branch_contains_tag}" ]]; then
+            echo "Ref tag must exist in a branch named ${release_branch} when creating a release, did you use scripts/release.sh?"
+            exit 1
           fi
 
           if [[ -z "${CODER_RELEASE_NOTES}" ]]; then

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -121,11 +121,21 @@ jobs:
 
           # 2.10.2 -> release/2.10
           version="$(./scripts/version.sh)"
-          release_branch=release/${version%.*}
-          branch_contains_tag=$(git branch --remotes --contains "${GITHUB_REF}" --list "*/${release_branch}" --format='%(refname)')
-          if [[ -z "${branch_contains_tag}" ]]; then
-            echo "Ref tag must exist in a branch named ${release_branch} when creating a release, did you use scripts/release.sh?"
-            exit 1
+          # Strip any pre-release suffix (e.g. 2.32.0-rc.0 -> 2.32.0)
+          # before extracting the release branch name.
+          base_version="${version%%-*}"
+          release_branch=release/${base_version%.*}
+
+          # RC tags (pre-release versions) are tagged directly from
+          # main and are not expected to exist on a release branch.
+          if [[ "${version}" == *-* ]]; then
+            echo "Pre-release version detected (${version}), skipping branch check."
+          else
+            branch_contains_tag=$(git branch --remotes --contains "${GITHUB_REF}" --list "*/${release_branch}" --format='%(refname)')
+            if [[ -z "${branch_contains_tag}" ]]; then
+              echo "Ref tag must exist in a branch named ${release_branch} when creating a release, did you use scripts/release.sh?"
+              exit 1
+            fi
           fi
 
           if [[ -z "${CODER_RELEASE_NOTES}" ]]; then

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ PLAN.md
 
 # Ignore any dev licenses
 license.txt
+scripts/releaser/releaser

--- a/scripts/releaser/release.go
+++ b/scripts/releaser/release.go
@@ -29,9 +29,13 @@ func runRelease(ctx context.Context, inv *serpent.Invocation, executor ReleaseEx
 		return xerrors.Errorf("listing tags: %w", err)
 	}
 
+	// Use only stable (non-prerelease) tags for the landscape
+	// display so RC tags don't skew the "latest" detection.
+	stableTags := filterStable(allTags)
+
 	var latestMainline *version
-	if len(allTags) > 0 {
-		v := allTags[0]
+	if len(stableTags) > 0 {
+		v := stableTags[0]
 		latestMainline = &v
 	}
 
@@ -40,7 +44,7 @@ func runRelease(ctx context.Context, inv *serpent.Invocation, executor ReleaseEx
 	if latestMainline != nil {
 		stableMinor = latestMainline.Minor - 1
 		// Find highest tag in the stable minor series.
-		for _, t := range allTags {
+		for _, t := range stableTags {
 			if t.Major == latestMainline.Major && t.Minor == stableMinor {
 				latestStableStr = t.String()
 				break
@@ -60,21 +64,48 @@ func runRelease(ctx context.Context, inv *serpent.Invocation, executor ReleaseEx
 	fmt.Fprintf(w, "  Latest stable release:   %s\n", pretty.Sprint(cliui.BoldFmt(), latestStableStr))
 	fmt.Fprintln(w)
 
-	// --- Branch detection ---
-	currentBranch, err := gitOutput("branch", "--show-current")
-	if err != nil {
-		return xerrors.Errorf("detecting branch: %w", err)
+	// --- Release type prompt ---
+	isRC := false
+	_, err = cliui.Prompt(inv, cliui.PromptOptions{
+		Text:      "Is this a release candidate (RC)?",
+		Default:   cliui.ConfirmNo,
+		IsConfirm: true,
+	})
+	if err == nil {
+		isRC = true
+	} else if !errors.Is(err, cliui.ErrCanceled) {
+		return err
 	}
+	fmt.Fprintln(w)
 
-	branchRe := regexp.MustCompile(`^release/(\d+)\.(\d+)$`)
-	m := branchRe.FindStringSubmatch(currentBranch)
-	if m == nil {
-		warnf(w, "Current branch %q is not a release branch (release/X.Y).", currentBranch)
-		branchInput, err := cliui.Prompt(inv, cliui.PromptOptions{
-			Text: "Enter the release branch to use (e.g. release/2.21)",
+	// rcRef holds the commit SHA to tag for RC releases. For
+	// standard releases the tag target is resolved later from HEAD.
+	var rcRef string
+
+	var currentBranch string
+	var branchMajor, branchMinor int
+	var prevVersion *version
+	var newVersion version
+	var tagExists bool
+	channel := "mainline"
+
+	if isRC {
+		// --- RC flow: commit selection & version ---
+		infof(w, "Fetching tags from origin...")
+		if err := gitRun("fetch", "--quiet", "--tags", "origin"); err != nil {
+			return xerrors.Errorf("fetching tags: %w", err)
+		}
+
+		// Ask for the commit to tag.
+		commitInput, err := cliui.Prompt(inv, cliui.PromptOptions{
+			Text: "Enter commit SHA to tag",
 			Validate: func(s string) error {
-				if !branchRe.MatchString(s) {
-					return xerrors.New("must be in format release/X.Y (e.g. release/2.21)")
+				if strings.TrimSpace(s) == "" {
+					return xerrors.New("a commit SHA is required")
+				}
+				_, err := gitOutput("rev-parse", "--verify", strings.TrimSpace(s)+"^{commit}")
+				if err != nil {
+					return xerrors.Errorf("could not resolve %q to a commit", s)
 				}
 				return nil
 			},
@@ -82,259 +113,419 @@ func runRelease(ctx context.Context, inv *serpent.Invocation, executor ReleaseEx
 		if err != nil {
 			return err
 		}
-		currentBranch = branchInput
-		m = branchRe.FindStringSubmatch(currentBranch)
-	}
-	branchMajor, _ := strconv.Atoi(m[1])
-	branchMinor, _ := strconv.Atoi(m[2])
-	successf(w, "Using release branch: %s", currentBranch)
 
-	// --- Fetch & sync check ---
-	infof(w, "Fetching latest from origin...")
-	if err := gitRun("fetch", "--quiet", "--tags", "origin", currentBranch); err != nil {
-		return xerrors.Errorf("fetching: %w", err)
-	}
-
-	localHead, err := gitOutput("rev-parse", "HEAD")
-	if err != nil {
-		return xerrors.Errorf("resolving HEAD: %w", err)
-	}
-	remoteHead, _ := gitOutput("rev-parse", "origin/"+currentBranch)
-
-	if remoteHead != "" && localHead != remoteHead {
-		warnf(w, "Your local branch is not up to date with origin/%s.", currentBranch)
-		fmt.Fprintf(w, "  Local:  %s\n", localHead[:12])
-		fmt.Fprintf(w, "  Remote: %s\n", remoteHead[:12])
-		if err := confirmWithDefault(inv, "Continue anyway?", cliui.ConfirmNo); err != nil {
-			return err
-		}
-		fmt.Fprintln(w)
-	}
-
-	// --- Find previous version & suggest next ---
-	mergedTags, err := mergedSemverTags()
-	if err != nil {
-		return xerrors.Errorf("listing merged tags: %w", err)
-	}
-
-	// Find the latest tag matching this branch's major.minor.
-	// Without this filter, tags from newer branches (e.g. v2.31.0)
-	// that are reachable via merge history would be picked up
-	// incorrectly on older release branches (e.g. release/2.30).
-	var prevVersion *version
-	for _, t := range mergedTags {
-		if t.Major == branchMajor && t.Minor == branchMinor {
-			v := t
-			prevVersion = &v
-			break
-		}
-	}
-
-	var suggested version
-	if prevVersion == nil {
-		infof(w, "No previous release tag found on this branch.")
-		suggested = version{Major: branchMajor, Minor: branchMinor, Patch: 0}
-	} else {
-		infof(w, "Previous release tag: %s", prevVersion.String())
-		suggested = version{Major: prevVersion.Major, Minor: prevVersion.Minor, Patch: prevVersion.Patch + 1}
-	}
-
-	fmt.Fprintln(w)
-
-	// --- Version prompt ---
-	versionInput, err := cliui.Prompt(inv, cliui.PromptOptions{
-		Text:    "Version to release",
-		Default: suggested.String(),
-		Validate: func(s string) error {
-			if _, ok := parseVersion(s); !ok {
-				return xerrors.New("must be in format vMAJOR.MINOR.PATCH (e.g. v2.31.1)")
-			}
-			return nil
-		},
-	})
-	if err != nil {
-		return err
-	}
-	newVersion, _ := parseVersion(versionInput)
-
-	// Warn if version doesn't match branch.
-	if newVersion.Major != branchMajor || newVersion.Minor != branchMinor {
-		warnf(w, "Version %s does not match branch %s (expected v%d.%d.X).",
-			newVersion, currentBranch, branchMajor, branchMinor)
-		if err := confirmWithDefault(inv, "Continue anyway?", cliui.ConfirmNo); err != nil {
-			return err
-		}
-		fmt.Fprintln(w)
-	}
-
-	fmt.Fprintln(w)
-	infof(w, "=== Coder Release: %s ===", newVersion)
-	fmt.Fprintln(w)
-
-	// --- Check if tag already exists ---
-	tagExists := false
-	existingTag, _ := gitOutput("tag", "-l", newVersion.String())
-	if existingTag != "" {
-		tagExists = true
-		warnf(w, "Tag '%s' already exists!", newVersion)
-		if err := confirmWithDefault(inv, "This will skip tagging. Continue?", cliui.ConfirmNo); err != nil {
-			return err
-		}
-		fmt.Fprintln(w)
-	}
-
-	// --- Check open PRs ---
-	// This runs before breaking changes so any last-minute merges
-	// are caught by the subsequent checks.
-	infof(w, "Checking for open PRs against %s...", currentBranch)
-	var openPRs []ghPR
-	if ghAvailable {
-		openPRs, err = ghListOpenPRs(currentBranch)
+		rcRef, err = gitOutput("rev-parse", strings.TrimSpace(commitInput))
 		if err != nil {
-			warnf(w, "Failed to check open PRs: %v", err)
+			return xerrors.Errorf("resolving commit: %w", err)
 		}
-	} else {
-		infof(w, "Skipping (no gh CLI).")
-	}
 
-	if len(openPRs) > 0 {
+		// Display commit details and confirm.
+		subject, _ := gitOutput("log", "-1", "--format=%s", rcRef)
+		author, _ := gitOutput("log", "-1", "--format=%an", rcRef)
+		date, _ := gitOutput("log", "-1", "--format=%ci", rcRef)
+
 		fmt.Fprintln(w)
-		warnf(w, "There are open PRs targeting %s that may need merging first:", currentBranch)
+		fmt.Fprintln(w, pretty.Sprint(cliui.BoldFmt(), "Will tag commit:"))
+		fmt.Fprintf(w, "  SHA:     %s\n", rcRef[:12])
+		fmt.Fprintf(w, "  Subject: %s\n", subject)
+		fmt.Fprintf(w, "  Author:  %s\n", author)
+		fmt.Fprintf(w, "  Date:    %s\n", date)
 		fmt.Fprintln(w)
-		for _, pr := range openPRs {
-			fmt.Fprintf(w, "  #%d %s (@%s)\n", pr.Number, pr.Title, pr.Author)
+		if err := confirm(inv, "Continue?"); err != nil {
+			return xerrors.New("aborted")
 		}
 		fmt.Fprintln(w)
-		if err := confirmWithDefault(inv, "Continue without merging these?", cliui.ConfirmNo); err != nil {
+
+		// Suggest the next minor version based on the latest
+		// mainline release. For example, if the latest is v2.31.5
+		// the suggested target is v2.32.0.
+		var suggestedTarget string
+		if latestMainline != nil {
+			suggestedTarget = version{
+				Major: latestMainline.Major,
+				Minor: latestMainline.Minor + 1,
+				Patch: 0,
+			}.String()
+		}
+
+		// Ask for the target version (e.g. v2.32.0).
+		targetInput, err := cliui.Prompt(inv, cliui.PromptOptions{
+			Text:    "Target release version (e.g. v2.32.0)",
+			Default: suggestedTarget,
+			Validate: func(s string) error {
+				v, ok := parseVersion(s)
+				if !ok {
+					return xerrors.New("must be in format vMAJOR.MINOR.PATCH (e.g. v2.32.0)")
+				}
+				if v.IsPrerelease() {
+					return xerrors.New("enter the base version without a pre-release suffix")
+				}
+				return nil
+			},
+		})
+		if err != nil {
 			return err
 		}
+		targetVersion, _ := parseVersion(targetInput)
+
+		// Auto-detect the next RC number by scanning existing tags.
+		nextRC := 0
+		for _, t := range allTags {
+			if t.baseEqual(targetVersion) && t.rcNumber() >= nextRC {
+				nextRC = t.rcNumber() + 1
+			}
+		}
+		suggestedRC := version{
+			Major: targetVersion.Major,
+			Minor: targetVersion.Minor,
+			Patch: targetVersion.Patch,
+			Pre:   fmt.Sprintf("rc.%d", nextRC),
+		}
+
+		// Find previous RC or stable tag for release notes range.
+		// Prefer the last RC for this target, falling back to the
+		// latest stable tag.
+		for i := range allTags {
+			t := allTags[i]
+			if t.baseEqual(targetVersion) && t.IsPrerelease() {
+				prevVersion = &t
+				break
+			}
+		}
+		if prevVersion == nil {
+			for i := range stableTags {
+				t := stableTags[i]
+				if !t.GreaterThan(targetVersion) {
+					prevVersion = &t
+					break
+				}
+			}
+		}
+
+		versionInput, err := cliui.Prompt(inv, cliui.PromptOptions{
+			Text:    "Version to release",
+			Default: suggestedRC.String(),
+			Validate: func(s string) error {
+				v, ok := parseVersion(s)
+				if !ok {
+					return xerrors.New("must be in format vMAJOR.MINOR.PATCH-rc.N (e.g. v2.32.0-rc.0)")
+				}
+				if !v.IsPrerelease() {
+					return xerrors.New("RC version must include a pre-release suffix (e.g. -rc.0)")
+				}
+				return nil
+			},
+		})
+		if err != nil {
+			return err
+		}
+		newVersion, _ = parseVersion(versionInput)
+
+		fmt.Fprintln(w)
+		infof(w, "=== Coder Release Candidate: %s ===", newVersion)
+		fmt.Fprintln(w)
+
+		// Check if tag already exists.
+		existingTag, _ := gitOutput("tag", "-l", newVersion.String())
+		if existingTag != "" {
+			tagExists = true
+			warnf(w, "Tag '%s' already exists!", newVersion)
+			if err := confirmWithDefault(inv, "This will skip tagging. Continue?", cliui.ConfirmNo); err != nil {
+				return err
+			}
+			fmt.Fprintln(w)
+		}
+
+		// RC is always mainline (prerelease on GitHub).
+		infof(w, "Channel: mainline (RC is always marked as prerelease).")
 		fmt.Fprintln(w)
 	} else {
-		successf(w, "No open PRs against %s.", currentBranch)
-	}
-	fmt.Fprintln(w)
+		// --- Standard release flow ---
 
-	// --- Semver sanity checks ---
-	if prevVersion != nil { //nolint:nestif // Sequential release checks are inherently nested.
-		// Downgrade check.
-		if prevVersion.GreaterThan(newVersion) {
-			warnf(w, "Version DOWNGRADE detected: %s → %s.", prevVersion, newVersion)
-			if err := confirmWithDefault(inv, "Continue?", cliui.ConfirmNo); err != nil {
+		// --- Branch detection ---
+		currentBranch, err = gitOutput("branch", "--show-current")
+		if err != nil {
+			return xerrors.Errorf("detecting branch: %w", err)
+		}
+
+		branchRe := regexp.MustCompile(`^release/(\d+)\.(\d+)$`)
+		m := branchRe.FindStringSubmatch(currentBranch)
+		if m == nil {
+			warnf(w, "Current branch %q is not a release branch (release/X.Y).", currentBranch)
+			branchInput, err := cliui.Prompt(inv, cliui.PromptOptions{
+				Text: "Enter the release branch to use (e.g. release/2.21)",
+				Validate: func(s string) error {
+					if !branchRe.MatchString(s) {
+						return xerrors.New("must be in format release/X.Y (e.g. release/2.21)")
+					}
+					return nil
+				},
+			})
+			if err != nil {
+				return err
+			}
+			currentBranch = branchInput
+			m = branchRe.FindStringSubmatch(currentBranch)
+		}
+		branchMajor, _ = strconv.Atoi(m[1])
+		branchMinor, _ = strconv.Atoi(m[2])
+		successf(w, "Using release branch: %s", currentBranch)
+
+		// --- Fetch & sync check ---
+		infof(w, "Fetching latest from origin...")
+		if err := gitRun("fetch", "--quiet", "--tags", "origin", currentBranch); err != nil {
+			return xerrors.Errorf("fetching: %w", err)
+		}
+
+		localHead, err := gitOutput("rev-parse", "HEAD")
+		if err != nil {
+			return xerrors.Errorf("resolving HEAD: %w", err)
+		}
+		remoteHead, _ := gitOutput("rev-parse", "origin/"+currentBranch)
+
+		if remoteHead != "" && localHead != remoteHead {
+			warnf(w, "Your local branch is not up to date with origin/%s.", currentBranch)
+			fmt.Fprintf(w, "  Local:  %s\n", localHead[:12])
+			fmt.Fprintf(w, "  Remote: %s\n", remoteHead[:12])
+			if err := confirmWithDefault(inv, "Continue anyway?", cliui.ConfirmNo); err != nil {
 				return err
 			}
 			fmt.Fprintln(w)
 		}
 
-		// Duplicate check.
-		if prevVersion.Equal(newVersion) {
-			warnf(w, "Version %s is the SAME as the previous tag %s.", newVersion, prevVersion)
-			if err := confirmWithDefault(inv, "Continue?", cliui.ConfirmNo); err != nil {
+		// --- Find previous version & suggest next ---
+		mergedTags, err := mergedSemverTags()
+		if err != nil {
+			return xerrors.Errorf("listing merged tags: %w", err)
+		}
+
+		// Find the latest stable tag matching this branch's
+		// major.minor. Without this filter, tags from newer
+		// branches that are reachable via merge history would be
+		// picked up incorrectly.
+		for _, t := range mergedTags {
+			if t.Major == branchMajor && t.Minor == branchMinor && !t.IsPrerelease() {
+				v := t
+				prevVersion = &v
+				break
+			}
+		}
+
+		var suggested version
+		if prevVersion == nil {
+			infof(w, "No previous release tag found on this branch.")
+			suggested = version{Major: branchMajor, Minor: branchMinor, Patch: 0}
+		} else {
+			infof(w, "Previous release tag: %s", prevVersion.String())
+			suggested = version{Major: prevVersion.Major, Minor: prevVersion.Minor, Patch: prevVersion.Patch + 1}
+		}
+
+		fmt.Fprintln(w)
+
+		// --- Version prompt ---
+		versionInput, err := cliui.Prompt(inv, cliui.PromptOptions{
+			Text:    "Version to release",
+			Default: suggested.String(),
+			Validate: func(s string) error {
+				v, ok := parseVersion(s)
+				if !ok {
+					return xerrors.New("must be in format vMAJOR.MINOR.PATCH (e.g. v2.31.1)")
+				}
+				if v.IsPrerelease() {
+					return xerrors.New("use RC mode for pre-release versions")
+				}
+				return nil
+			},
+		})
+		if err != nil {
+			return err
+		}
+		newVersion, _ = parseVersion(versionInput)
+
+		// Warn if version doesn't match branch.
+		if newVersion.Major != branchMajor || newVersion.Minor != branchMinor {
+			warnf(w, "Version %s does not match branch %s (expected v%d.%d.X).",
+				newVersion, currentBranch, branchMajor, branchMinor)
+			if err := confirmWithDefault(inv, "Continue anyway?", cliui.ConfirmNo); err != nil {
 				return err
 			}
 			fmt.Fprintln(w)
 		}
 
-		// Skipped patch check.
-		if newVersion.Major == prevVersion.Major && newVersion.Minor == prevVersion.Minor {
-			expectedPatch := prevVersion.Patch + 1
-			if newVersion.Patch > expectedPatch {
-				warnf(w, "Skipping patch version(s): expected v%d.%d.%d, got %s.",
-					newVersion.Major, newVersion.Minor, expectedPatch, newVersion)
+		fmt.Fprintln(w)
+		infof(w, "=== Coder Release: %s ===", newVersion)
+		fmt.Fprintln(w)
+
+		// --- Check if tag already exists ---
+		existingTag, _ := gitOutput("tag", "-l", newVersion.String())
+		if existingTag != "" {
+			tagExists = true
+			warnf(w, "Tag '%s' already exists!", newVersion)
+			if err := confirmWithDefault(inv, "This will skip tagging. Continue?", cliui.ConfirmNo); err != nil {
+				return err
+			}
+			fmt.Fprintln(w)
+		}
+
+		// --- Check open PRs ---
+		// This runs before breaking changes so any last-minute
+		// merges are caught by the subsequent checks.
+		infof(w, "Checking for open PRs against %s...", currentBranch)
+		var openPRs []ghPR
+		if ghAvailable {
+			openPRs, err = ghListOpenPRs(currentBranch)
+			if err != nil {
+				warnf(w, "Failed to check open PRs: %v", err)
+			}
+		} else {
+			infof(w, "Skipping (no gh CLI).")
+		}
+
+		if len(openPRs) > 0 {
+			fmt.Fprintln(w)
+			warnf(w, "There are open PRs targeting %s that may need merging first:", currentBranch)
+			fmt.Fprintln(w)
+			for _, pr := range openPRs {
+				fmt.Fprintf(w, "  #%d %s (@%s)\n", pr.Number, pr.Title, pr.Author)
+			}
+			fmt.Fprintln(w)
+			if err := confirmWithDefault(inv, "Continue without merging these?", cliui.ConfirmNo); err != nil {
+				return err
+			}
+			fmt.Fprintln(w)
+		} else {
+			successf(w, "No open PRs against %s.", currentBranch)
+		}
+		fmt.Fprintln(w)
+
+		// --- Semver sanity checks ---
+		if prevVersion != nil { //nolint:nestif // Sequential release checks are inherently nested.
+			// Downgrade check.
+			if prevVersion.GreaterThan(newVersion) {
+				warnf(w, "Version DOWNGRADE detected: %s → %s.", prevVersion, newVersion)
 				if err := confirmWithDefault(inv, "Continue?", cliui.ConfirmNo); err != nil {
 					return err
 				}
 				fmt.Fprintln(w)
 			}
-		}
 
-		// Breaking changes in patch release check.
-		if newVersion.Major == prevVersion.Major && newVersion.Minor == prevVersion.Minor && newVersion.Patch > prevVersion.Patch {
-			infof(w, "Checking for breaking changes in patch release...")
-
-			commitRange := prevVersion.String() + "..HEAD"
-			commits, err := commitLog(commitRange)
-			if err != nil {
-				return xerrors.Errorf("reading commit log: %w", err)
-			}
-
-			var breakingCommits []commitEntry
-			for _, c := range commits {
-				if breakingCommitRe.MatchString(c.Title) {
-					breakingCommits = append(breakingCommits, c)
-				}
-			}
-
-			// Check PR labels for release/breaking.
-			var breakingPRLabeled []ghPR
-			if ghAvailable {
-				breakingPRLabeled, err = ghListPRsWithLabel(currentBranch, "release/breaking")
-				if err != nil {
-					warnf(w, "Failed to check PR labels: %v", err)
-				}
-			}
-
-			if len(breakingCommits) > 0 || len(breakingPRLabeled) > 0 {
-				fmt.Fprintln(w)
-				warnf(w, "BREAKING CHANGES detected in a PATCH release — this violates semver!")
-				fmt.Fprintln(w)
-				if len(breakingCommits) > 0 {
-					fmt.Fprintln(w, "  Breaking commits (by conventional commit prefix):")
-					for _, c := range breakingCommits {
-						fmt.Fprintf(w, "    - %s %s\n", c.SHA, c.Title)
-					}
-				}
-				if len(breakingPRLabeled) > 0 {
-					fmt.Fprintln(w, "  PRs labeled release/breaking:")
-					for _, pr := range breakingPRLabeled {
-						fmt.Fprintf(w, "    - #%d %s\n", pr.Number, pr.Title)
-					}
-				}
-				fmt.Fprintln(w)
-				if err := confirmWithDefault(inv, "Continue with patch release despite breaking changes?", cliui.ConfirmNo); err != nil {
+			// Duplicate check.
+			if prevVersion.Equal(newVersion) {
+				warnf(w, "Version %s is the SAME as the previous tag %s.", newVersion, prevVersion)
+				if err := confirmWithDefault(inv, "Continue?", cliui.ConfirmNo); err != nil {
 					return err
 				}
 				fmt.Fprintln(w)
-			} else {
-				successf(w, "No breaking changes detected.")
+			}
+
+			// Skipped patch check.
+			if newVersion.Major == prevVersion.Major && newVersion.Minor == prevVersion.Minor {
+				expectedPatch := prevVersion.Patch + 1
+				if newVersion.Patch > expectedPatch {
+					warnf(w, "Skipping patch version(s): expected v%d.%d.%d, got %s.",
+						newVersion.Major, newVersion.Minor, expectedPatch, newVersion)
+					if err := confirmWithDefault(inv, "Continue?", cliui.ConfirmNo); err != nil {
+						return err
+					}
+					fmt.Fprintln(w)
+				}
+			}
+
+			// Breaking changes in patch release check.
+			if newVersion.Major == prevVersion.Major && newVersion.Minor == prevVersion.Minor && newVersion.Patch > prevVersion.Patch {
+				infof(w, "Checking for breaking changes in patch release...")
+
+				commitRange := prevVersion.String() + "..HEAD"
+				commits, err := commitLog(commitRange)
+				if err != nil {
+					return xerrors.Errorf("reading commit log: %w", err)
+				}
+
+				var breakingCommits []commitEntry
+				for _, c := range commits {
+					if breakingCommitRe.MatchString(c.Title) {
+						breakingCommits = append(breakingCommits, c)
+					}
+				}
+
+				// Check PR labels for release/breaking.
+				var breakingPRLabeled []ghPR
+				if ghAvailable {
+					breakingPRLabeled, err = ghListPRsWithLabel(currentBranch, "release/breaking")
+					if err != nil {
+						warnf(w, "Failed to check PR labels: %v", err)
+					}
+				}
+
+				if len(breakingCommits) > 0 || len(breakingPRLabeled) > 0 {
+					fmt.Fprintln(w)
+					warnf(w, "BREAKING CHANGES detected in a PATCH release — this violates semver!")
+					fmt.Fprintln(w)
+					if len(breakingCommits) > 0 {
+						fmt.Fprintln(w, "  Breaking commits (by conventional commit prefix):")
+						for _, c := range breakingCommits {
+							fmt.Fprintf(w, "    - %s %s\n", c.SHA, c.Title)
+						}
+					}
+					if len(breakingPRLabeled) > 0 {
+						fmt.Fprintln(w, "  PRs labeled release/breaking:")
+						for _, pr := range breakingPRLabeled {
+							fmt.Fprintf(w, "    - #%d %s\n", pr.Number, pr.Title)
+						}
+					}
+					fmt.Fprintln(w)
+					if err := confirmWithDefault(inv, "Continue with patch release despite breaking changes?", cliui.ConfirmNo); err != nil {
+						return err
+					}
+					fmt.Fprintln(w)
+				} else {
+					successf(w, "No breaking changes detected.")
+				}
 			}
 		}
-	}
 
-	// --- Channel selection ---
-	// This is done before release notes generation because the
-	// notes format differs between mainline and stable channels.
-	channelDefault := cliui.ConfirmNo
-	channelHint := ""
-	if newVersion.Minor == stableMinor {
-		channelDefault = cliui.ConfirmYes
-		channelHint = " (this looks like a stable release)"
-	}
+		// --- Channel selection ---
+		// This is done before release notes generation because the
+		// notes format differs between mainline and stable channels.
+		channelDefault := cliui.ConfirmNo
+		channelHint := ""
+		if newVersion.Minor == stableMinor {
+			channelDefault = cliui.ConfirmYes
+			channelHint = " (this looks like a stable release)"
+		}
 
-	channel := "mainline"
-	_, err = cliui.Prompt(inv, cliui.PromptOptions{
-		Text:      fmt.Sprintf("Mark this as the latest stable release on GitHub?%s", channelHint),
-		Default:   channelDefault,
-		IsConfirm: true,
-	})
-	if err == nil {
-		channel = "stable"
-	} else if !errors.Is(err, cliui.ErrCanceled) {
-		return err
-	}
+		_, err = cliui.Prompt(inv, cliui.PromptOptions{
+			Text:      fmt.Sprintf("Mark this as the latest stable release on GitHub?%s", channelHint),
+			Default:   channelDefault,
+			IsConfirm: true,
+		})
+		if err == nil {
+			channel = "stable"
+		} else if !errors.Is(err, cliui.ErrCanceled) {
+			return err
+		}
 
-	if channel == "stable" {
-		infof(w, "Channel: stable (will be marked as GitHub Latest).")
-	} else {
-		infof(w, "Channel: mainline (will be marked as prerelease).")
+		if channel == "stable" {
+			infof(w, "Channel: stable (will be marked as GitHub Latest).")
+		} else {
+			infof(w, "Channel: mainline (will be marked as prerelease).")
+		}
+		fmt.Fprintln(w)
 	}
-	fmt.Fprintln(w)
 
 	// --- Generate release notes ---
 	infof(w, "Generating release notes...")
 
-	commitRange := "HEAD"
+	// For RC releases, use the chosen commit ref; for standard
+	// releases, use HEAD.
+	notesRef := "HEAD"
+	if rcRef != "" {
+		notesRef = rcRef
+	}
+
+	commitRange := notesRef
 	if prevVersion != nil {
-		commitRange = prevVersion.String() + "..HEAD"
+		commitRange = prevVersion.String() + ".." + notesRef
 	}
 
 	commits, err := commitLog(commitRange)
@@ -412,8 +603,15 @@ func runRelease(ctx context.Context, inv *serpent.Invocation, executor ReleaseEx
 	if channel == "stable" {
 		fmt.Fprintf(&notes, "> ## Stable (since %s)\n\n", time.Now().Format("January 02, 2006"))
 	}
-	fmt.Fprintln(&notes, "## Changelog")
-	if channel == "mainline" {
+	if isRC {
+		fmt.Fprintf(&notes, "## [RC] Changelog\n")
+		fmt.Fprintln(&notes)
+		fmt.Fprintln(&notes, "> [!NOTE]")
+		fmt.Fprintln(&notes, "> This is a **release candidate**. It is not intended for production use. Please test and report issues.")
+	} else {
+		fmt.Fprintln(&notes, "## Changelog")
+	}
+	if channel == "mainline" && !isRC {
 		fmt.Fprintln(&notes)
 		fmt.Fprintln(&notes, "> [!NOTE]")
 		fmt.Fprintln(&notes, "> This is a mainline Coder release. We advise enterprise customers without a staging environment to install our [latest stable release](https://github.com/coder/coder/releases/latest) while we refine this version. Learn more about our [Release Schedule](https://coder.com/docs/install/releases).")
@@ -503,9 +701,12 @@ func runRelease(ctx context.Context, inv *serpent.Invocation, executor ReleaseEx
 	}
 
 	// --- Tag ---
-	ref, err := gitOutput("rev-parse", "HEAD")
-	if err != nil {
-		return xerrors.Errorf("resolving HEAD: %w", err)
+	ref := rcRef
+	if ref == "" {
+		ref, err = gitOutput("rev-parse", "HEAD")
+		if err != nil {
+			return xerrors.Errorf("resolving HEAD: %w", err)
+		}
 	}
 	shortRef := ref[:12]
 
@@ -513,7 +714,9 @@ func runRelease(ctx context.Context, inv *serpent.Invocation, executor ReleaseEx
 		fmt.Fprintln(w, pretty.Sprint(cliui.BoldFmt(), "Next step: create an annotated tag."))
 		fmt.Fprintf(w, "  Tag:    %s\n", newVersion)
 		fmt.Fprintf(w, "  Commit: %s\n", shortRef)
-		fmt.Fprintf(w, "  Branch: %s\n", currentBranch)
+		if currentBranch != "" {
+			fmt.Fprintf(w, "  Branch: %s\n", currentBranch)
+		}
 		fmt.Fprintln(w)
 		if err := confirm(inv, "Create tag?"); err != nil {
 			return xerrors.New("cannot proceed without a tag")
@@ -576,7 +779,11 @@ func runRelease(ctx context.Context, inv *serpent.Invocation, executor ReleaseEx
 	successf(w, "Release workflow triggered!")
 
 	// --- Update release docs ---
-	promptAndUpdateDocs(inv, newVersion, channel, dryRun)
+	// Skip doc updates for RC releases — no release calendar or
+	// autoversion changes are needed for pre-releases.
+	if !isRC {
+		promptAndUpdateDocs(inv, newVersion, channel, dryRun)
+	}
 
 	fmt.Fprintln(w)
 	successf(w, "Done! 🎉")

--- a/scripts/releaser/version.go
+++ b/scripts/releaser/version.go
@@ -7,14 +7,16 @@ import (
 	"strings"
 )
 
-// version holds a parsed semver version.
+// version holds a parsed semver version with optional pre-release
+// suffix (e.g. "rc.0").
 type version struct {
 	Major int
 	Minor int
 	Patch int
+	Pre   string // e.g. "rc.0", empty for stable releases.
 }
 
-var semverRe = regexp.MustCompile(`^v(\d+)\.(\d+)\.(\d+)$`)
+var semverRe = regexp.MustCompile(`^v(\d+)\.(\d+)\.(\d+)(-([a-zA-Z0-9.]+))?$`)
 
 func parseVersion(s string) (version, bool) {
 	m := semverRe.FindStringSubmatch(s)
@@ -24,11 +26,34 @@ func parseVersion(s string) (version, bool) {
 	maj, _ := strconv.Atoi(m[1])
 	mnr, _ := strconv.Atoi(m[2])
 	pat, _ := strconv.Atoi(m[3])
-	return version{Major: maj, Minor: mnr, Patch: pat}, true
+	return version{Major: maj, Minor: mnr, Patch: pat, Pre: m[5]}, true
 }
 
 func (v version) String() string {
-	return fmt.Sprintf("v%d.%d.%d", v.Major, v.Minor, v.Patch)
+	s := fmt.Sprintf("v%d.%d.%d", v.Major, v.Minor, v.Patch)
+	if v.Pre != "" {
+		s += "-" + v.Pre
+	}
+	return s
+}
+
+// IsPrerelease returns true for versions with a pre-release suffix
+// (e.g. v2.32.0-rc.0).
+func (v version) IsPrerelease() bool {
+	return v.Pre != ""
+}
+
+// rcNumber extracts the numeric RC identifier from a pre-release
+// suffix like "rc.3". Returns -1 when the suffix is not an RC.
+func (v version) rcNumber() int {
+	if !strings.HasPrefix(v.Pre, "rc.") {
+		return -1
+	}
+	n, err := strconv.Atoi(strings.TrimPrefix(v.Pre, "rc."))
+	if err != nil {
+		return -1
+	}
+	return n
 }
 
 func (v version) GreaterThan(b version) bool {
@@ -38,11 +63,45 @@ func (v version) GreaterThan(b version) bool {
 	if v.Minor != b.Minor {
 		return v.Minor > b.Minor
 	}
-	return v.Patch > b.Patch
+	if v.Patch != b.Patch {
+		return v.Patch > b.Patch
+	}
+	// Per semver: a version without a pre-release suffix has
+	// higher precedence than one with a suffix.
+	if v.Pre == "" && b.Pre != "" {
+		return true
+	}
+	if v.Pre != "" && b.Pre == "" {
+		return false
+	}
+	// Both have pre-release suffixes — compare RC numbers if
+	// applicable, otherwise fall back to lexicographic order.
+	vRC, bRC := v.rcNumber(), b.rcNumber()
+	if vRC >= 0 && bRC >= 0 {
+		return vRC > bRC
+	}
+	return v.Pre > b.Pre
 }
 
 func (v version) Equal(b version) bool {
+	return v.Major == b.Major && v.Minor == b.Minor && v.Patch == b.Patch && v.Pre == b.Pre
+}
+
+// baseEqual returns true when two versions share the same
+// major.minor.patch triple, ignoring the pre-release suffix.
+func (v version) baseEqual(b version) bool {
 	return v.Major == b.Major && v.Minor == b.Minor && v.Patch == b.Patch
+}
+
+// filterStable returns only non-prerelease versions.
+func filterStable(tags []version) []version {
+	var out []version
+	for _, t := range tags {
+		if !t.IsPrerelease() {
+			out = append(out, t)
+		}
+	}
+	return out
 }
 
 // allSemverTags returns all semver tags sorted descending.

--- a/scripts/releaser/version_test.go
+++ b/scripts/releaser/version_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseVersion(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input string
+		want  version
+		ok    bool
+	}{
+		{"v2.32.0", version{Major: 2, Minor: 32, Patch: 0}, true},
+		{"v2.32.1", version{Major: 2, Minor: 32, Patch: 1}, true},
+		{"v2.32.0-rc.0", version{Major: 2, Minor: 32, Patch: 0, Pre: "rc.0"}, true},
+		{"v2.32.0-rc.12", version{Major: 2, Minor: 32, Patch: 0, Pre: "rc.12"}, true},
+		{"v1.0.0-beta.1", version{Major: 1, Minor: 0, Patch: 0, Pre: "beta.1"}, true},
+		{"2.32.0", version{}, false},          // missing v prefix
+		{"v2.32", version{}, false},            // missing patch
+		{"v2.32.0-", version{}, false},         // trailing dash
+		{"vx.y.z", version{}, false},           // non-numeric
+		{"v2.32.0-rc 1", version{}, false},     // space in pre-release
+		{"v2.32.0-rc.0.1", version{Major: 2, Minor: 32, Patch: 0, Pre: "rc.0.1"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			got, ok := parseVersion(tt.input)
+			assert.Equal(t, tt.ok, ok)
+			if ok {
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestVersionString(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "v2.32.0", version{Major: 2, Minor: 32, Patch: 0}.String())
+	assert.Equal(t, "v2.32.0-rc.0", version{Major: 2, Minor: 32, Patch: 0, Pre: "rc.0"}.String())
+	assert.Equal(t, "v1.0.0-beta.1", version{Major: 1, Minor: 0, Patch: 0, Pre: "beta.1"}.String())
+}
+
+func TestVersionIsPrerelease(t *testing.T) {
+	t.Parallel()
+	assert.False(t, version{Major: 2, Minor: 32, Patch: 0}.IsPrerelease())
+	assert.True(t, version{Major: 2, Minor: 32, Patch: 0, Pre: "rc.0"}.IsPrerelease())
+}
+
+func TestVersionGreaterThan(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		a, b version
+		want bool
+	}{
+		{"major", version{Major: 3}, version{Major: 2}, true},
+		{"minor", version{Major: 2, Minor: 32}, version{Major: 2, Minor: 31}, true},
+		{"patch", version{Major: 2, Minor: 32, Patch: 1}, version{Major: 2, Minor: 32, Patch: 0}, true},
+		{"stable > rc", version{Major: 2, Minor: 32, Patch: 0}, version{Major: 2, Minor: 32, Patch: 0, Pre: "rc.1"}, true},
+		{"rc < stable", version{Major: 2, Minor: 32, Patch: 0, Pre: "rc.1"}, version{Major: 2, Minor: 32, Patch: 0}, false},
+		{"rc.1 > rc.0", version{Major: 2, Minor: 32, Patch: 0, Pre: "rc.1"}, version{Major: 2, Minor: 32, Patch: 0, Pre: "rc.0"}, true},
+		{"rc.0 < rc.1", version{Major: 2, Minor: 32, Patch: 0, Pre: "rc.0"}, version{Major: 2, Minor: 32, Patch: 0, Pre: "rc.1"}, false},
+		{"equal not greater", version{Major: 2, Minor: 32, Patch: 0}, version{Major: 2, Minor: 32, Patch: 0}, false},
+		{"equal rc not greater", version{Major: 2, Minor: 32, Patch: 0, Pre: "rc.0"}, version{Major: 2, Minor: 32, Patch: 0, Pre: "rc.0"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.a.GreaterThan(tt.b))
+		})
+	}
+}
+
+func TestVersionEqual(t *testing.T) {
+	t.Parallel()
+	assert.True(t, version{Major: 2, Minor: 32, Patch: 0}.Equal(version{Major: 2, Minor: 32, Patch: 0}))
+	assert.False(t, version{Major: 2, Minor: 32, Patch: 0}.Equal(version{Major: 2, Minor: 32, Patch: 0, Pre: "rc.0"}))
+	assert.True(t, version{Major: 2, Minor: 32, Patch: 0, Pre: "rc.0"}.Equal(version{Major: 2, Minor: 32, Patch: 0, Pre: "rc.0"}))
+}
+
+func TestVersionBaseEqual(t *testing.T) {
+	t.Parallel()
+	assert.True(t, version{Major: 2, Minor: 32, Patch: 0}.baseEqual(version{Major: 2, Minor: 32, Patch: 0, Pre: "rc.0"}))
+	assert.False(t, version{Major: 2, Minor: 32, Patch: 0}.baseEqual(version{Major: 2, Minor: 32, Patch: 1}))
+}
+
+func TestFilterStable(t *testing.T) {
+	t.Parallel()
+	tags := []version{
+		{Major: 2, Minor: 32, Patch: 0},
+		{Major: 2, Minor: 32, Patch: 0, Pre: "rc.1"},
+		{Major: 2, Minor: 32, Patch: 0, Pre: "rc.0"},
+		{Major: 2, Minor: 31, Patch: 1},
+	}
+	stable := filterStable(tags)
+	require.Len(t, stable, 2)
+	assert.Equal(t, "v2.32.0", stable[0].String())
+	assert.Equal(t, "v2.31.1", stable[1].String())
+}
+
+func TestRCNumber(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, 0, version{Pre: "rc.0"}.rcNumber())
+	assert.Equal(t, 12, version{Pre: "rc.12"}.rcNumber())
+	assert.Equal(t, -1, version{Pre: "beta.1"}.rcNumber())
+	assert.Equal(t, -1, version{}.rcNumber())
+}


### PR DESCRIPTION
Add an RC release flow to the releaser tool that allows tagging any commit as a release candidate (e.g. `v2.32.0-rc.0`) without requiring a release branch.

## Changes

**`scripts/releaser/version.go`** — Pre-release support in the version struct:
- `Pre` field for pre-release suffixes like `rc.0`
- Updated regex, `parseVersion`, `String`, `GreaterThan`, `Equal`
- Semver-correct ordering: `v2.32.0 > v2.32.0-rc.1 > v2.32.0-rc.0`
- Helpers: `IsPrerelease()`, `rcNumber()`, `baseEqual()`, `filterStable()`

**`scripts/releaser/release.go`** — New RC flow alongside the existing standard flow:
1. Prompts "Is this a release candidate?"
2. Skips branch detection entirely for RCs
3. Asks for a commit SHA (required), shows details, requires confirmation
4. Auto-suggests target version from latest mainline tag (e.g. `v2.31.5` -> `v2.32.0`)
5. Auto-increments RC number from existing tags (e.g. `v2.32.0-rc.0` -> `v2.32.0-rc.1`)
6. Always marks as prerelease, skips doc updates
7. Uses `prevVersion..<chosen-ref>` for release notes

The standard release flow is unchanged. It now rejects pre-release versions with "use RC mode" and filters RC tags from landscape display.

**`scripts/releaser/version_test.go`** — Tests for parsing, ordering, and helpers.