### PR TITLE
fix: separate default and additional agents system prompts

### DIFF
--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -1516,6 +1516,25 @@ func (q *querier) authorizeProvisionerJob(ctx context.Context, job database.Prov
 	return nil
 }
 
+func (q *querier) GetChatSystemPromptSettings(ctx context.Context) (database.GetChatSystemPromptSettingsRow, error) {
+	// The system prompt settings are deployment-wide values read during
+	// chat creation by every authenticated user, so no RBAC policy check
+	// is needed. We still verify that a valid actor exists in the
+	// context to ensure this is never callable by an unauthenticated
+	// or system-internal path without an explicit actor.
+	if _, ok := ActorFromContext(ctx); !ok {
+		return database.GetChatSystemPromptSettingsRow{}, ErrNoActor
+	}
+	return q.db.GetChatSystemPromptSettings(ctx)
+}
+
+func (q *querier) UpsertChatSystemPromptSettings(ctx context.Context, arg database.UpsertChatSystemPromptSettingsParams) error {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceDeploymentConfig); err != nil {
+		return err
+	}
+	return q.db.UpsertChatSystemPromptSettings(ctx, arg)
+}
+
 func (q *querier) AcquireChats(ctx context.Context, arg database.AcquireChatsParams) ([]database.Chat, error) {
 	// AcquireChats is a system-level operation used by the chat processor.
 	// Authorization is done at the system level, not per-user.
@@ -2660,18 +2679,6 @@ func (q *querier) GetChatQueuedMessages(ctx context.Context, chatID uuid.UUID) (
 		return nil, err
 	}
 	return q.db.GetChatQueuedMessages(ctx, chatID)
-}
-
-func (q *querier) GetChatSystemPrompt(ctx context.Context) (string, error) {
-	// The system prompt is a deployment-wide setting read during chat
-	// creation by every authenticated user, so no RBAC policy check
-	// is needed. We still verify that a valid actor exists in the
-	// context to ensure this is never callable by an unauthenticated
-	// or system-internal path without an explicit actor.
-	if _, ok := ActorFromContext(ctx); !ok {
-		return "", ErrNoActor
-	}
-	return q.db.GetChatSystemPrompt(ctx)
 }
 
 func (q *querier) GetChatUsageLimitConfig(ctx context.Context) (database.ChatUsageLimitConfig, error) {
@@ -6803,13 +6810,6 @@ func (q *querier) UpsertChatDiffStatusReference(ctx context.Context, arg databas
 		return database.ChatDiffStatus{}, err
 	}
 	return q.db.UpsertChatDiffStatusReference(ctx, arg)
-}
-
-func (q *querier) UpsertChatSystemPrompt(ctx context.Context, value string) error {
-	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceDeploymentConfig); err != nil {
-		return err
-	}
-	return q.db.UpsertChatSystemPrompt(ctx, value)
 }
 
 func (q *querier) UpsertChatUsageLimitConfig(ctx context.Context, arg database.UpsertChatUsageLimitConfigParams) (database.ChatUsageLimitConfig, error) {

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -648,8 +648,9 @@ func (s *MethodTestSuite) TestChats() {
 		dbm.EXPECT().GetChatQueuedMessages(gomock.Any(), chat.ID).Return(qms, nil).AnyTimes()
 		check.Args(chat.ID).Asserts(chat, policy.ActionRead).Returns(qms)
 	}))
-	s.Run("GetChatSystemPrompt", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
-		dbm.EXPECT().GetChatSystemPrompt(gomock.Any()).Return("prompt", nil).AnyTimes()
+	s.Run("GetChatSystemPromptSettings", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
+		row := database.GetChatSystemPromptSettingsRow{IncludeDefaultSystemPrompt: true, AdditionalSystemPrompt: "prompt"}
+		dbm.EXPECT().GetChatSystemPromptSettings(gomock.Any()).Return(row, nil).AnyTimes()
 		check.Args().Asserts()
 	}))
 	s.Run("GetChatDesktopEnabled", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
@@ -865,9 +866,10 @@ func (s *MethodTestSuite) TestChats() {
 		dbm.EXPECT().BackoffChatDiffStatus(gomock.Any(), arg).Return(nil).AnyTimes()
 		check.Args(arg).Asserts(rbac.ResourceChat, policy.ActionUpdate).Returns()
 	}))
-	s.Run("UpsertChatSystemPrompt", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
-		dbm.EXPECT().UpsertChatSystemPrompt(gomock.Any(), "").Return(nil).AnyTimes()
-		check.Args("").Asserts(rbac.ResourceDeploymentConfig, policy.ActionUpdate)
+	s.Run("UpsertChatSystemPromptSettings", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
+		arg := database.UpsertChatSystemPromptSettingsParams{IncludeDefaultSystemPrompt: true, AdditionalSystemPrompt: ""}
+		dbm.EXPECT().UpsertChatSystemPromptSettings(gomock.Any(), arg).Return(nil).AnyTimes()
+		check.Args(arg).Asserts(rbac.ResourceDeploymentConfig, policy.ActionUpdate)
 	}))
 	s.Run("UpsertChatDesktopEnabled", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
 		dbm.EXPECT().UpsertChatDesktopEnabled(gomock.Any(), false).Return(nil).AnyTimes()

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -1200,11 +1200,11 @@ func (m queryMetricsStore) GetChatQueuedMessages(ctx context.Context, chatID uui
 	return r0, r1
 }
 
-func (m queryMetricsStore) GetChatSystemPrompt(ctx context.Context) (string, error) {
+func (m queryMetricsStore) GetChatSystemPromptSettings(ctx context.Context) (database.GetChatSystemPromptSettingsRow, error) {
 	start := time.Now()
-	r0, r1 := m.s.GetChatSystemPrompt(ctx)
-	m.queryLatencies.WithLabelValues("GetChatSystemPrompt").Observe(time.Since(start).Seconds())
-	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetChatSystemPrompt").Inc()
+	r0, r1 := m.s.GetChatSystemPromptSettings(ctx)
+	m.queryLatencies.WithLabelValues("GetChatSystemPromptSettings").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetChatSystemPromptSettings").Inc()
 	return r0, r1
 }
 
@@ -4800,11 +4800,11 @@ func (m queryMetricsStore) UpsertChatDiffStatusReference(ctx context.Context, ar
 	return r0, r1
 }
 
-func (m queryMetricsStore) UpsertChatSystemPrompt(ctx context.Context, value string) error {
+func (m queryMetricsStore) UpsertChatSystemPromptSettings(ctx context.Context, arg database.UpsertChatSystemPromptSettingsParams) error {
 	start := time.Now()
-	r0 := m.s.UpsertChatSystemPrompt(ctx, value)
-	m.queryLatencies.WithLabelValues("UpsertChatSystemPrompt").Observe(time.Since(start).Seconds())
-	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "UpsertChatSystemPrompt").Inc()
+	r0 := m.s.UpsertChatSystemPromptSettings(ctx, arg)
+	m.queryLatencies.WithLabelValues("UpsertChatSystemPromptSettings").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "UpsertChatSystemPromptSettings").Inc()
 	return r0
 }
 

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -2208,19 +2208,19 @@ func (mr *MockStoreMockRecorder) GetChatQueuedMessages(ctx, chatID any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChatQueuedMessages", reflect.TypeOf((*MockStore)(nil).GetChatQueuedMessages), ctx, chatID)
 }
 
-// GetChatSystemPrompt mocks base method.
-func (m *MockStore) GetChatSystemPrompt(ctx context.Context) (string, error) {
+// GetChatSystemPromptSettings mocks base method.
+func (m *MockStore) GetChatSystemPromptSettings(ctx context.Context) (database.GetChatSystemPromptSettingsRow, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetChatSystemPrompt", ctx)
-	ret0, _ := ret[0].(string)
+	ret := m.ctrl.Call(m, "GetChatSystemPromptSettings", ctx)
+	ret0, _ := ret[0].(database.GetChatSystemPromptSettingsRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetChatSystemPrompt indicates an expected call of GetChatSystemPrompt.
-func (mr *MockStoreMockRecorder) GetChatSystemPrompt(ctx any) *gomock.Call {
+// GetChatSystemPromptSettings indicates an expected call of GetChatSystemPromptSettings.
+func (mr *MockStoreMockRecorder) GetChatSystemPromptSettings(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChatSystemPrompt", reflect.TypeOf((*MockStore)(nil).GetChatSystemPrompt), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChatSystemPromptSettings", reflect.TypeOf((*MockStore)(nil).GetChatSystemPromptSettings), ctx)
 }
 
 // GetChatUsageLimitConfig mocks base method.
@@ -8999,18 +8999,18 @@ func (mr *MockStoreMockRecorder) UpsertChatDiffStatusReference(ctx, arg any) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertChatDiffStatusReference", reflect.TypeOf((*MockStore)(nil).UpsertChatDiffStatusReference), ctx, arg)
 }
 
-// UpsertChatSystemPrompt mocks base method.
-func (m *MockStore) UpsertChatSystemPrompt(ctx context.Context, value string) error {
+// UpsertChatSystemPromptSettings mocks base method.
+func (m *MockStore) UpsertChatSystemPromptSettings(ctx context.Context, arg database.UpsertChatSystemPromptSettingsParams) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpsertChatSystemPrompt", ctx, value)
+	ret := m.ctrl.Call(m, "UpsertChatSystemPromptSettings", ctx, arg)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// UpsertChatSystemPrompt indicates an expected call of UpsertChatSystemPrompt.
-func (mr *MockStoreMockRecorder) UpsertChatSystemPrompt(ctx, value any) *gomock.Call {
+// UpsertChatSystemPromptSettings indicates an expected call of UpsertChatSystemPromptSettings.
+func (mr *MockStoreMockRecorder) UpsertChatSystemPromptSettings(ctx, arg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertChatSystemPrompt", reflect.TypeOf((*MockStore)(nil).UpsertChatSystemPrompt), ctx, value)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertChatSystemPromptSettings", reflect.TypeOf((*MockStore)(nil).UpsertChatSystemPromptSettings), ctx, arg)
 }
 
 // UpsertChatUsageLimitConfig mocks base method.

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -253,7 +253,7 @@ type sqlcQuerier interface {
 	GetChatProviderByProvider(ctx context.Context, provider string) (ChatProvider, error)
 	GetChatProviders(ctx context.Context) ([]ChatProvider, error)
 	GetChatQueuedMessages(ctx context.Context, chatID uuid.UUID) ([]ChatQueuedMessage, error)
-	GetChatSystemPrompt(ctx context.Context) (string, error)
+	GetChatSystemPromptSettings(ctx context.Context) (GetChatSystemPromptSettingsRow, error)
 	GetChatUsageLimitConfig(ctx context.Context) (ChatUsageLimitConfig, error)
 	GetChatUsageLimitGroupOverride(ctx context.Context, groupID uuid.UUID) (GetChatUsageLimitGroupOverrideRow, error)
 	GetChatUsageLimitUserOverride(ctx context.Context, userID uuid.UUID) (GetChatUsageLimitUserOverrideRow, error)
@@ -932,7 +932,7 @@ type sqlcQuerier interface {
 	UpsertChatDesktopEnabled(ctx context.Context, enableDesktop bool) error
 	UpsertChatDiffStatus(ctx context.Context, arg UpsertChatDiffStatusParams) (ChatDiffStatus, error)
 	UpsertChatDiffStatusReference(ctx context.Context, arg UpsertChatDiffStatusReferenceParams) (ChatDiffStatus, error)
-	UpsertChatSystemPrompt(ctx context.Context, value string) error
+	UpsertChatSystemPromptSettings(ctx context.Context, arg UpsertChatSystemPromptSettingsParams) error
 	UpsertChatUsageLimitConfig(ctx context.Context, arg UpsertChatUsageLimitConfigParams) (ChatUsageLimitConfig, error)
 	UpsertChatUsageLimitGroupOverride(ctx context.Context, arg UpsertChatUsageLimitGroupOverrideParams) (UpsertChatUsageLimitGroupOverrideRow, error)
 	UpsertChatUsageLimitUserOverride(ctx context.Context, arg UpsertChatUsageLimitUserOverrideParams) (UpsertChatUsageLimitUserOverrideRow, error)

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -17473,16 +17473,22 @@ func (q *sqlQuerier) GetChatDesktopEnabled(ctx context.Context) (bool, error) {
 	return enable_desktop, err
 }
 
-const getChatSystemPrompt = `-- name: GetChatSystemPrompt :one
+const getChatSystemPromptSettings = `-- name: GetChatSystemPromptSettings :one
 SELECT
-	COALESCE((SELECT value FROM site_configs WHERE key = 'agents_chat_system_prompt'), '') :: text AS chat_system_prompt
+	COALESCE((SELECT value = 'true' FROM site_configs WHERE key = 'agents_chat_include_default_system_prompt'), true) :: boolean AS include_default_system_prompt,
+	COALESCE((SELECT value FROM site_configs WHERE key = 'agents_chat_system_prompt'), '') :: text AS additional_system_prompt
 `
 
-func (q *sqlQuerier) GetChatSystemPrompt(ctx context.Context) (string, error) {
-	row := q.db.QueryRowContext(ctx, getChatSystemPrompt)
-	var chat_system_prompt string
-	err := row.Scan(&chat_system_prompt)
-	return chat_system_prompt, err
+type GetChatSystemPromptSettingsRow struct {
+	IncludeDefaultSystemPrompt bool   `db:"include_default_system_prompt" json:"include_default_system_prompt"`
+	AdditionalSystemPrompt     string `db:"additional_system_prompt" json:"additional_system_prompt"`
+}
+
+func (q *sqlQuerier) GetChatSystemPromptSettings(ctx context.Context) (GetChatSystemPromptSettingsRow, error) {
+	row := q.db.QueryRowContext(ctx, getChatSystemPromptSettings)
+	var i GetChatSystemPromptSettingsRow
+	err := row.Scan(&i.IncludeDefaultSystemPrompt, &i.AdditionalSystemPrompt)
+	return i, err
 }
 
 const getChatWorkspaceTTL = `-- name: GetChatWorkspaceTTL :one
@@ -17706,13 +17712,22 @@ func (q *sqlQuerier) UpsertChatDesktopEnabled(ctx context.Context, enableDesktop
 	return err
 }
 
-const upsertChatSystemPrompt = `-- name: UpsertChatSystemPrompt :exec
-INSERT INTO site_configs (key, value) VALUES ('agents_chat_system_prompt', $1)
-ON CONFLICT (key) DO UPDATE SET value = $1 WHERE site_configs.key = 'agents_chat_system_prompt'
+const upsertChatSystemPromptSettings = `-- name: UpsertChatSystemPromptSettings :exec
+INSERT INTO site_configs (key, value)
+VALUES
+	('agents_chat_include_default_system_prompt', CASE WHEN $1::bool THEN 'true' ELSE 'false' END),
+	('agents_chat_system_prompt', $2::text)
+ON CONFLICT (key) DO UPDATE
+SET value = EXCLUDED.value WHERE site_configs.key = EXCLUDED.key
 `
 
-func (q *sqlQuerier) UpsertChatSystemPrompt(ctx context.Context, value string) error {
-	_, err := q.db.ExecContext(ctx, upsertChatSystemPrompt, value)
+type UpsertChatSystemPromptSettingsParams struct {
+	IncludeDefaultSystemPrompt bool   `db:"include_default_system_prompt" json:"include_default_system_prompt"`
+	AdditionalSystemPrompt     string `db:"additional_system_prompt" json:"additional_system_prompt"`
+}
+
+func (q *sqlQuerier) UpsertChatSystemPromptSettings(ctx context.Context, arg UpsertChatSystemPromptSettingsParams) error {
+	_, err := q.db.ExecContext(ctx, upsertChatSystemPromptSettings, arg.IncludeDefaultSystemPrompt, arg.AdditionalSystemPrompt)
 	return err
 }
 

--- a/coderd/database/queries/siteconfig.sql
+++ b/coderd/database/queries/siteconfig.sql
@@ -133,13 +133,18 @@ SELECT
     COALESCE((SELECT value FROM site_configs WHERE key = 'webpush_vapid_public_key'), '') :: text AS vapid_public_key,
     COALESCE((SELECT value FROM site_configs WHERE key = 'webpush_vapid_private_key'), '') :: text AS vapid_private_key;
 
--- name: GetChatSystemPrompt :one
+-- name: GetChatSystemPromptSettings :one
 SELECT
-	COALESCE((SELECT value FROM site_configs WHERE key = 'agents_chat_system_prompt'), '') :: text AS chat_system_prompt;
+	COALESCE((SELECT value = 'true' FROM site_configs WHERE key = 'agents_chat_include_default_system_prompt'), true) :: boolean AS include_default_system_prompt,
+	COALESCE((SELECT value FROM site_configs WHERE key = 'agents_chat_system_prompt'), '') :: text AS additional_system_prompt;
 
--- name: UpsertChatSystemPrompt :exec
-INSERT INTO site_configs (key, value) VALUES ('agents_chat_system_prompt', $1)
-ON CONFLICT (key) DO UPDATE SET value = $1 WHERE site_configs.key = 'agents_chat_system_prompt';
+-- name: UpsertChatSystemPromptSettings :exec
+INSERT INTO site_configs (key, value)
+VALUES
+	('agents_chat_include_default_system_prompt', CASE WHEN @include_default_system_prompt::bool THEN 'true' ELSE 'false' END),
+	('agents_chat_system_prompt', @additional_system_prompt::text)
+ON CONFLICT (key) DO UPDATE
+SET value = EXCLUDED.value WHERE site_configs.key = EXCLUDED.key;
 
 -- name: GetChatDesktopEnabled :one
 SELECT

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -2603,26 +2603,36 @@ func detectChatFileType(data []byte) string {
 //nolint:revive // get-return: revive assumes get* must be a getter, but this is an HTTP handler.
 func (api *API) getChatSystemPrompt(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	prompt, err := api.Database.GetChatSystemPrompt(ctx)
+	settings, err := api.Database.GetChatSystemPromptSettings(ctx)
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-			Message: "Internal error fetching chat system prompt.",
+			Message: "Internal error fetching chat system prompt settings.",
 			Detail:  err.Error(),
 		})
 		return
 	}
-	httpapi.Write(ctx, rw, http.StatusOK, codersdk.ChatSystemPrompt{
-		SystemPrompt: prompt,
+	httpapi.Write(ctx, rw, http.StatusOK, codersdk.ChatSystemPromptSettings{
+		IncludeDefaultSystemPrompt: settings.IncludeDefaultSystemPrompt,
+		AdditionalSystemPrompt:     settings.AdditionalSystemPrompt,
+		DefaultSystemPromptPreview: chatd.DefaultSystemPrompt,
+		SystemPrompt:               settings.AdditionalSystemPrompt,
 	})
 }
 
 func (api *API) putChatSystemPrompt(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	var req codersdk.ChatSystemPrompt
+	var req codersdk.ChatSystemPromptSettings
 	if !httpapi.Read(ctx, rw, r, &req) {
 		return
 	}
-	trimmedPrompt := strings.TrimSpace(req.SystemPrompt)
+	usesLegacyShape := req.SystemPrompt != "" ||
+		(!req.IncludeDefaultSystemPrompt && req.AdditionalSystemPrompt == "" && req.SystemPrompt == "")
+	trimmedPrompt := strings.TrimSpace(req.AdditionalSystemPrompt)
+	includeDefault := req.IncludeDefaultSystemPrompt
+	if usesLegacyShape {
+		trimmedPrompt = strings.TrimSpace(req.SystemPrompt)
+		includeDefault = false
+	}
 	// 128 KiB is generous for a system prompt while still
 	// preventing abuse or accidental pastes of large content.
 	if len(trimmedPrompt) > maxSystemPromptLenBytes {
@@ -2632,13 +2642,23 @@ func (api *API) putChatSystemPrompt(rw http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	err := api.Database.UpsertChatSystemPrompt(ctx, trimmedPrompt)
+	if !includeDefault && trimmedPrompt == "" {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "System prompt configuration is invalid.",
+			Detail:  "Either include the Coder Agents default system prompt or provide an additional system prompt.",
+		})
+		return
+	}
+	err := api.Database.UpsertChatSystemPromptSettings(ctx, database.UpsertChatSystemPromptSettingsParams{
+		IncludeDefaultSystemPrompt: includeDefault,
+		AdditionalSystemPrompt:     trimmedPrompt,
+	})
 	if httpapi.Is404Error(err) { // also catches authz error
 		httpapi.ResourceNotFound(rw)
 		return
 	} else if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-			Message: "Internal error updating chat system prompt.",
+			Message: "Internal error updating chat system prompt settings.",
 			Detail:  err.Error(),
 		})
 		return
@@ -3004,18 +3024,30 @@ func (api *API) deleteUserChatCompactionThreshold(rw http.ResponseWriter, r *htt
 	rw.WriteHeader(http.StatusNoContent)
 }
 
+func composeChatSystemPrompt(settings database.GetChatSystemPromptSettingsRow) string {
+	parts := make([]string, 0, 2)
+	if settings.IncludeDefaultSystemPrompt {
+		parts = append(parts, chatd.DefaultSystemPrompt)
+	}
+	if trimmedAdditional := strings.TrimSpace(settings.AdditionalSystemPrompt); trimmedAdditional != "" {
+		parts = append(parts, trimmedAdditional)
+	}
+	return strings.Join(parts, "\n\n")
+}
+
 func (api *API) resolvedChatSystemPrompt(ctx context.Context) string {
-	custom, err := api.Database.GetChatSystemPrompt(ctx)
+	settings, err := api.Database.GetChatSystemPromptSettings(ctx)
 	if err != nil {
 		// Log but don't fail chat creation — fall back to the
 		// built-in default so the user isn't blocked.
-		api.Logger.Error(ctx, "failed to fetch custom chat system prompt, using default", slog.Error(err))
+		api.Logger.Error(ctx, "failed to fetch chat system prompt settings, using default", slog.Error(err))
 		return chatd.DefaultSystemPrompt
 	}
-	if strings.TrimSpace(custom) != "" {
-		return custom
+	resolved := composeChatSystemPrompt(settings)
+	if resolved == "" {
+		return chatd.DefaultSystemPrompt
 	}
-	return chatd.DefaultSystemPrompt
+	return resolved
 }
 
 func (api *API) postChatFile(rw http.ResponseWriter, r *http.Request) {

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -4755,46 +4755,52 @@ func TestChatSystemPrompt(t *testing.T) {
 	memberClientRaw, _ := coderdtest.CreateAnotherUser(t, adminClient.Client, firstUser.OrganizationID)
 	memberClient := codersdk.NewExperimentalClient(memberClientRaw)
 
-	t.Run("ReturnsEmptyWhenUnset", func(t *testing.T) {
+	t.Run("ReturnsDefaultEnabledWhenUnset", func(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitLong)
 
 		resp, err := adminClient.GetChatSystemPrompt(ctx)
 		require.NoError(t, err)
-		require.Equal(t, "", resp.SystemPrompt)
+		require.True(t, resp.IncludeDefaultSystemPrompt)
+		require.Equal(t, "", resp.AdditionalSystemPrompt)
+		require.Equal(t, chatd.DefaultSystemPrompt, resp.DefaultSystemPromptPreview)
 	})
 
-	t.Run("AdminCanSet", func(t *testing.T) {
+	t.Run("AdminCanSetAdditionalPrompt", func(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitLong)
 
-		err := adminClient.UpdateChatSystemPrompt(ctx, codersdk.ChatSystemPrompt{
-			SystemPrompt: "You are a helpful coding assistant.",
+		err := adminClient.UpdateChatSystemPrompt(ctx, codersdk.ChatSystemPromptSettings{
+			IncludeDefaultSystemPrompt: true,
+			AdditionalSystemPrompt:     "You are a helpful coding assistant.",
 		})
 		require.NoError(t, err)
 
 		resp, err := adminClient.GetChatSystemPrompt(ctx)
 		require.NoError(t, err)
-		require.Equal(t, "You are a helpful coding assistant.", resp.SystemPrompt)
+		require.True(t, resp.IncludeDefaultSystemPrompt)
+		require.Equal(t, "You are a helpful coding assistant.", resp.AdditionalSystemPrompt)
 	})
 
-	t.Run("AdminCanUnset", func(t *testing.T) {
+	t.Run("AdminCanExcludeDefaultWithAdditionalPrompt", func(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitLong)
 
-		// Unset by sending an empty string.
-		err := adminClient.UpdateChatSystemPrompt(ctx, codersdk.ChatSystemPrompt{
-			SystemPrompt: "",
+		err := adminClient.UpdateChatSystemPrompt(ctx, codersdk.ChatSystemPromptSettings{
+			IncludeDefaultSystemPrompt: false,
+			AdditionalSystemPrompt:     "Only follow these instructions.",
 		})
 		require.NoError(t, err)
 
 		resp, err := adminClient.GetChatSystemPrompt(ctx)
 		require.NoError(t, err)
-		require.Equal(t, "", resp.SystemPrompt)
+		require.False(t, resp.IncludeDefaultSystemPrompt)
+		require.Equal(t, "Only follow these instructions.", resp.AdditionalSystemPrompt)
 	})
 
 	t.Run("NonAdminFails", func(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitLong)
 
-		err := memberClient.UpdateChatSystemPrompt(ctx, codersdk.ChatSystemPrompt{
-			SystemPrompt: "This should fail.",
+		err := memberClient.UpdateChatSystemPrompt(ctx, codersdk.ChatSystemPromptSettings{
+			IncludeDefaultSystemPrompt: true,
+			AdditionalSystemPrompt:     "This should fail.",
 		})
 		requireSDKError(t, err, http.StatusNotFound)
 	})
@@ -4810,12 +4816,24 @@ func TestChatSystemPrompt(t *testing.T) {
 		require.Equal(t, http.StatusUnauthorized, sdkErr.StatusCode())
 	})
 
+	t.Run("RejectsEmptyPromptWhenDefaultExcluded", func(t *testing.T) {
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		err := adminClient.UpdateChatSystemPrompt(ctx, codersdk.ChatSystemPromptSettings{
+			IncludeDefaultSystemPrompt: false,
+			AdditionalSystemPrompt:     "",
+		})
+		sdkErr := requireSDKError(t, err, http.StatusBadRequest)
+		require.Equal(t, "System prompt configuration is invalid.", sdkErr.Message)
+	})
+
 	t.Run("TooLong", func(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitLong)
 
 		tooLong := strings.Repeat("a", 131073)
-		err := adminClient.UpdateChatSystemPrompt(ctx, codersdk.ChatSystemPrompt{
-			SystemPrompt: tooLong,
+		err := adminClient.UpdateChatSystemPrompt(ctx, codersdk.ChatSystemPromptSettings{
+			IncludeDefaultSystemPrompt: true,
+			AdditionalSystemPrompt:     tooLong,
 		})
 		sdkErr := requireSDKError(t, err, http.StatusBadRequest)
 		require.Equal(t, "System prompt exceeds maximum length.", sdkErr.Message)

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -347,10 +347,18 @@ type ChatModelsResponse struct {
 	Providers []ChatModelProvider `json:"providers"`
 }
 
-// ChatSystemPrompt is the request and response body for the chat
-// system prompt configuration endpoint.
-type ChatSystemPrompt struct {
-	SystemPrompt string `json:"system_prompt"`
+// ChatSystemPromptSettings is the shared request/response body for the
+// chat system prompt configuration endpoint.
+//
+// DefaultSystemPromptPreview is returned on GET for UI preview and is
+// ignored on PUT. SystemPrompt is preserved for backward compatibility
+// with older clients that still treat this endpoint as a single-string
+// replacement prompt.
+type ChatSystemPromptSettings struct {
+	IncludeDefaultSystemPrompt bool   `json:"include_default_system_prompt"`
+	AdditionalSystemPrompt     string `json:"additional_system_prompt"`
+	DefaultSystemPromptPreview string `json:"default_system_prompt_preview,omitempty"`
+	SystemPrompt               string `json:"system_prompt,omitempty"`
 }
 
 // UserChatCustomPrompt is the request and response body for the
@@ -1333,22 +1341,22 @@ func (c *ExperimentalClient) GetChatCostUsers(ctx context.Context, opts ChatCost
 	return resp, json.NewDecoder(res.Body).Decode(&resp)
 }
 
-// GetChatSystemPrompt returns the deployment-wide chat system prompt.
-func (c *ExperimentalClient) GetChatSystemPrompt(ctx context.Context) (ChatSystemPrompt, error) {
+// GetChatSystemPrompt returns the deployment-wide chat system prompt settings.
+func (c *ExperimentalClient) GetChatSystemPrompt(ctx context.Context) (ChatSystemPromptSettings, error) {
 	res, err := c.Request(ctx, http.MethodGet, "/api/experimental/chats/config/system-prompt", nil)
 	if err != nil {
-		return ChatSystemPrompt{}, err
+		return ChatSystemPromptSettings{}, err
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return ChatSystemPrompt{}, ReadBodyAsError(res)
+		return ChatSystemPromptSettings{}, ReadBodyAsError(res)
 	}
-	var resp ChatSystemPrompt
+	var resp ChatSystemPromptSettings
 	return resp, json.NewDecoder(res.Body).Decode(&resp)
 }
 
-// UpdateChatSystemPrompt updates the deployment-wide chat system prompt.
-func (c *ExperimentalClient) UpdateChatSystemPrompt(ctx context.Context, req ChatSystemPrompt) error {
+// UpdateChatSystemPrompt updates the deployment-wide chat system prompt settings.
+func (c *ExperimentalClient) UpdateChatSystemPrompt(ctx context.Context, req ChatSystemPromptSettings) error {
 	res, err := c.Request(ctx, http.MethodPut, "/api/experimental/chats/config/system-prompt", req)
 	if err != nil {
 		return err

--- a/docs/ai-coder/agents/getting-started.md
+++ b/docs/ai-coder/agents/getting-started.md
@@ -123,10 +123,16 @@ dedicated test or staging deployment to avoid disruption to production
 developer workflows. See [Early Access](./early-access.md) for the full
 set of expectations and limitations.
 
-### Set a deployment-wide system prompt
+### Set deployment-wide system instructions
 
-Administrators can set a system prompt that applies to all chats across the
-deployment. Use this to encode organizational conventions:
+Administrators can configure deployment-wide system instructions that apply to
+all chats across the deployment. Coder Agents includes a built-in default
+system prompt, and administrators can choose whether to include that default
+prompt for all chats.
+
+Administrators can also add an additional system prompt that is appended after
+that built-in default prompt. Use these controls to encode organizational
+conventions such as:
 
 - Coding standards and style guidelines.
 - Commit message formats.
@@ -134,9 +140,12 @@ deployment. Use this to encode organizational conventions:
 - Required review processes before merging.
 - Any guardrails specific to your environment.
 
-Configure the system prompt from the **Admin** dialog on the Agents page
-or via the API at `PUT /api/experimental/chats/config/system-prompt`.
-See [Platform Controls](./platform-controls/index.md) for details.
+If you disable the built-in default prompt, you must provide an additional
+system prompt so chats still have system instructions.
+
+Configure these settings from the **Admin** dialog on the Agents page or via
+the API at `PUT /api/experimental/chats/config/system-prompt`. See
+[Platform Controls](./platform-controls/index.md) for details.
 
 ### Understand the security model
 

--- a/docs/ai-coder/agents/platform-controls/index.md
+++ b/docs/ai-coder/agents/platform-controls/index.md
@@ -43,9 +43,18 @@ See [Models](../models.md) for setup instructions.
 
 ### System prompt
 
-Administrators can set a system prompt that applies to all agent sessions. This
-is useful for establishing organizational conventions — coding standards,
-commit message formats, preferred libraries, or repository-specific context.
+Administrators can configure deployment-wide system instructions that apply to
+all agent sessions. Coder Agents includes a built-in default system prompt,
+which is enabled by default, and administrators can choose whether to include
+it.
+
+Administrators can also add an additional system prompt that is appended after
+that built-in default prompt. This is useful for establishing organizational
+conventions — coding standards, commit message formats, preferred libraries, or
+repository-specific context.
+
+If administrators disable the built-in default prompt, they must provide an
+additional system prompt so sessions still have system instructions.
 
 The system prompt configuration is only accessible to administrators in the
 dashboard. Developers do not see or interact with it.

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -3170,15 +3170,16 @@ class ExperimentalApiMethods {
 		return response.data;
 	};
 
-	getChatSystemPrompt = async (): Promise<TypesGen.ChatSystemPrompt> => {
-		const response = await this.axios.get<TypesGen.ChatSystemPrompt>(
-			"/api/experimental/chats/config/system-prompt",
-		);
-		return response.data;
-	};
+	getChatSystemPrompt =
+		async (): Promise<TypesGen.ChatSystemPromptSettings> => {
+			const response = await this.axios.get<TypesGen.ChatSystemPromptSettings>(
+				"/api/experimental/chats/config/system-prompt",
+			);
+			return response.data;
+		};
 
 	updateChatSystemPrompt = async (
-		req: TypesGen.ChatSystemPrompt,
+		req: TypesGen.ChatSystemPromptSettings,
 	): Promise<void> => {
 		await this.axios.put("/api/experimental/chats/config/system-prompt", req);
 	};

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1842,11 +1842,19 @@ export interface ChatStreamStatus {
 
 // From codersdk/chats.go
 /**
- * ChatSystemPrompt is the request and response body for the chat
- * system prompt configuration endpoint.
+ * ChatSystemPromptSettings is the shared request/response body for the
+ * chat system prompt configuration endpoint.
+ *
+ * DefaultSystemPromptPreview is returned on GET for UI preview and is
+ * ignored on PUT. SystemPrompt is preserved for backward compatibility
+ * with older clients that still treat this endpoint as a single-string
+ * replacement prompt.
  */
-export interface ChatSystemPrompt {
-	readonly system_prompt: string;
+export interface ChatSystemPromptSettings {
+	readonly include_default_system_prompt: boolean;
+	readonly additional_system_prompt: string;
+	readonly default_system_prompt_preview?: string;
+	readonly system_prompt?: string;
 }
 
 // From codersdk/chats.go

--- a/site/src/pages/AgentsPage/AgentSettingsPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsPageView.stories.tsx
@@ -5,7 +5,14 @@ import { API } from "api/api";
 import { userKey } from "api/queries/users";
 import type * as TypesGen from "api/typesGenerated";
 import dayjs from "dayjs";
-import { expect, spyOn, userEvent, waitFor, within } from "storybook/test";
+import {
+	expect,
+	getByText,
+	spyOn,
+	userEvent,
+	waitFor,
+	within,
+} from "storybook/test";
 import { AgentSettingsPageView } from "./AgentSettingsPageView";
 
 // ── Usage mock helpers ─────────────────────────────────────────
@@ -146,7 +153,9 @@ const meta = {
 	},
 	beforeEach: () => {
 		spyOn(API.experimental, "getChatSystemPrompt").mockResolvedValue({
-			system_prompt: "",
+			include_default_system_prompt: true,
+			additional_system_prompt: "",
+			default_system_prompt_preview: "Default prompt preview",
 		});
 		spyOn(API.experimental, "updateChatSystemPrompt").mockResolvedValue();
 		spyOn(API.experimental, "getChatDesktopEnabled").mockResolvedValue({
@@ -177,6 +186,45 @@ export default meta;
 type Story = StoryObj<typeof AgentSettingsPageView>;
 
 // ── Behavior tab stories ───────────────────────────────────────
+
+export const SystemPromptPreview: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await canvas.findByText("System Instructions");
+		const previewButton = await canvas.findByRole("button", {
+			name: "Preview default prompt",
+		});
+		await userEvent.click(previewButton);
+		await waitFor(() => {
+			expect(
+				getByText(document.body, "Coder Agents default system prompt"),
+			).toBeVisible();
+			expect(getByText(document.body, "Default prompt preview")).toBeVisible();
+		});
+	},
+};
+
+export const SystemPromptValidation: Story = {
+	beforeEach: () => {
+		spyOn(API.experimental, "getChatSystemPrompt").mockResolvedValue({
+			include_default_system_prompt: true,
+			additional_system_prompt: "",
+			default_system_prompt_preview: "Default prompt preview",
+		});
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const toggle = await canvas.findByRole("switch", {
+			name: "Include Coder Agents default system prompt",
+		});
+		await userEvent.click(toggle);
+		await canvas.findByText(
+			"Either include the default system prompt or provide an additional system prompt.",
+		);
+		const saveButton = await canvas.findByRole("button", { name: "Save" });
+		expect(saveButton).toBeDisabled();
+	},
+};
 
 export const DesktopSetting: Story = {
 	play: async ({ canvasElement }) => {

--- a/site/src/pages/AgentsPage/AgentSettingsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsPageView.tsx
@@ -62,6 +62,7 @@ import { InsightsContent } from "./components/InsightsContent";
 import { LimitsTab } from "./components/LimitsTab";
 import { MCPServerAdminPanel } from "./components/MCPServerAdminPanel";
 import { SectionHeader } from "./components/SectionHeader";
+import { TextPreviewDialog } from "./components/TextPreviewDialog";
 import { UserCompactionThresholdSettings } from "./UserCompactionThresholdSettings";
 
 const AdminBadge: FC = () => (
@@ -537,15 +538,36 @@ export const AgentSettingsPageView: FC<AgentSettingsPageViewProps> = ({
 		isError: isSaveWorkspaceTTLError,
 	} = useMutation(updateChatWorkspaceTTL(queryClient));
 
-	const serverPrompt = systemPromptQuery.data?.system_prompt ?? "";
-	const [localEdit, setLocalEdit] = useState<string | null>(null);
-	const systemPromptDraft = localEdit ?? serverPrompt;
+	const serverIncludeDefaultSystemPrompt =
+		systemPromptQuery.data?.include_default_system_prompt ?? true;
+	const serverAdditionalSystemPrompt =
+		systemPromptQuery.data?.additional_system_prompt ?? "";
+	const defaultSystemPromptPreviewText =
+		systemPromptQuery.data?.default_system_prompt_preview ?? "";
+	const [localIncludeDefaultSystemPrompt, setLocalIncludeDefaultSystemPrompt] =
+		useState<boolean | null>(null);
+	const [localAdditionalSystemPrompt, setLocalAdditionalSystemPrompt] =
+		useState<string | null>(null);
+	const [
+		isDefaultSystemPromptPreviewOpen,
+		setIsDefaultSystemPromptPreviewOpen,
+	] = useState(false);
+	const includeDefaultSystemPrompt =
+		localIncludeDefaultSystemPrompt ?? serverIncludeDefaultSystemPrompt;
+	const additionalSystemPromptDraft =
+		localAdditionalSystemPrompt ?? serverAdditionalSystemPrompt;
 
 	const serverUserPrompt = userPromptQuery.data?.custom_prompt ?? "";
 	const [localUserEdit, setLocalUserEdit] = useState<string | null>(null);
 	const userPromptDraft = localUserEdit ?? serverUserPrompt;
 
-	const isSystemPromptDirty = localEdit !== null && localEdit !== serverPrompt;
+	const isSystemPromptDirty =
+		(localIncludeDefaultSystemPrompt !== null &&
+			localIncludeDefaultSystemPrompt !== serverIncludeDefaultSystemPrompt) ||
+		(localAdditionalSystemPrompt !== null &&
+			localAdditionalSystemPrompt !== serverAdditionalSystemPrompt);
+	const isSystemPromptInvalid =
+		!includeDefaultSystemPrompt && additionalSystemPromptDraft.trim() === "";
 	const isUserPromptDirty =
 		localUserEdit !== null && localUserEdit !== serverUserPrompt;
 	const desktopEnabled = desktopEnabledQuery.data?.enable_desktop ?? false;
@@ -559,16 +581,25 @@ export const AgentSettingsPageView: FC<AgentSettingsPageViewProps> = ({
 	const isTTLOverMax = ttlMs > maxTTLMs;
 	const isTTLZero = isAutostopEnabled && ttlMs === 0;
 	const isPromptSaving = isSavingSystemPrompt || isSavingUserPrompt;
+	const isSystemPromptLoading = systemPromptQuery.isLoading;
 	const isDesktopSaving = isSavingDesktopEnabled;
 	const isTTLSaving = isSavingWorkspaceTTL;
 	const isTTLLoading = workspaceTTLQuery.isLoading;
 
 	const handleSaveSystemPrompt = (event: FormEvent) => {
 		event.preventDefault();
-		if (!isSystemPromptDirty) return;
+		if (!isSystemPromptDirty || isSystemPromptInvalid) return;
 		saveSystemPrompt(
-			{ system_prompt: systemPromptDraft },
-			{ onSuccess: () => setLocalEdit(null) },
+			{
+				include_default_system_prompt: includeDefaultSystemPrompt,
+				additional_system_prompt: additionalSystemPromptDraft,
+			},
+			{
+				onSuccess: () => {
+					setLocalIncludeDefaultSystemPrompt(null);
+					setLocalAdditionalSystemPrompt(null);
+				},
+			},
 		);
 	};
 
@@ -678,6 +709,14 @@ export const AgentSettingsPageView: FC<AgentSettingsPageViewProps> = ({
 							isLoadingModelConfigs={modelConfigsQuery.isLoading}
 						/>
 
+						{isDefaultSystemPromptPreviewOpen && (
+							<TextPreviewDialog
+								content={defaultSystemPromptPreviewText}
+								fileName="Coder Agents default system prompt"
+								onClose={() => setIsDefaultSystemPromptPreviewOpen(false)}
+							/>
+						)}
+
 						{/* ── Admin system prompt (admin only) ── */}
 						{canSetSystemPrompt && (
 							<>
@@ -692,16 +731,60 @@ export const AgentSettingsPageView: FC<AgentSettingsPageViewProps> = ({
 										</h3>
 										<AdminBadge />
 									</div>
-									<p className="!mt-0.5 m-0 text-xs text-content-secondary">
-										Applied to all chats for every user. When empty, the
-										built-in default is used.
-									</p>
+									<div className="!mt-0.5 m-0 flex items-start justify-between gap-4 text-xs text-content-secondary">
+										<p className="m-0 flex-1">
+											Applied to all chats for every user. When enabled, the
+											additional system prompt is appended after the built-in
+											Coder Agents default system prompt.
+										</p>
+										<Button
+											size="sm"
+											variant="outline"
+											type="button"
+											onClick={() => setIsDefaultSystemPromptPreviewOpen(true)}
+											disabled={
+												isSystemPromptLoading || !defaultSystemPromptPreviewText
+											}
+										>
+											Preview default prompt
+										</Button>
+									</div>
+									<div className="flex items-center justify-between gap-4 rounded-md border border-border bg-surface-secondary px-3 py-2">
+										<label
+											id="include-default-system-prompt-label"
+											className="flex-1 text-xs text-content-secondary"
+											htmlFor="include-default-system-prompt"
+										>
+											<span className="block font-medium text-content-primary">
+												Include Coder Agents default system prompt
+											</span>
+											<span className="mt-1 block">
+												Disable this to use only the additional system prompt.
+											</span>
+										</label>
+										<Switch
+											id="include-default-system-prompt"
+											checked={includeDefaultSystemPrompt}
+											onCheckedChange={setLocalIncludeDefaultSystemPrompt}
+											aria-labelledby="include-default-system-prompt-label"
+											disabled={isPromptSaving || isSystemPromptLoading}
+										/>
+									</div>
+									<label
+										className="m-0 block text-xs font-medium text-content-primary"
+										htmlFor="additional-system-prompt"
+									>
+										Additional system prompt
+									</label>
 									<TextareaAutosize
+										id="additional-system-prompt"
 										className={textareaClassName}
 										placeholder="Additional behavior, style, and tone preferences for all users"
-										value={systemPromptDraft}
-										onChange={(event) => setLocalEdit(event.target.value)}
-										disabled={isPromptSaving}
+										value={additionalSystemPromptDraft}
+										onChange={(event) =>
+											setLocalAdditionalSystemPrompt(event.target.value)
+										}
+										disabled={isPromptSaving || isSystemPromptLoading}
 										minRows={1}
 									/>
 									<div className="flex justify-end gap-2">
@@ -709,19 +792,29 @@ export const AgentSettingsPageView: FC<AgentSettingsPageViewProps> = ({
 											size="sm"
 											variant="outline"
 											type="button"
-											onClick={() => setLocalEdit("")}
-											disabled={isPromptSaving || !systemPromptDraft}
+											onClick={() => setLocalAdditionalSystemPrompt("")}
+											disabled={isPromptSaving || !additionalSystemPromptDraft}
 										>
 											Clear
 										</Button>
 										<Button
 											size="sm"
 											type="submit"
-											disabled={isPromptSaving || !isSystemPromptDirty}
+											disabled={
+												isPromptSaving ||
+												!isSystemPromptDirty ||
+												isSystemPromptInvalid
+											}
 										>
 											Save
 										</Button>
 									</div>
+									{isSystemPromptInvalid && (
+										<p className="m-0 text-xs text-content-destructive">
+											Either include the default system prompt or provide an
+											additional system prompt.
+										</p>
+									)}
 									{isSaveSystemPromptError && (
 										<p className="m-0 text-xs text-content-destructive">
 											Failed to save system prompt.

--- a/site/src/pages/AgentsPage/AgentsPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageView.stories.tsx
@@ -198,7 +198,9 @@ const meta: Meta<typeof AgentsPageView> = {
 			mockUsageUsers,
 		);
 		spyOn(API.experimental, "getChatSystemPrompt").mockResolvedValue({
-			system_prompt: "",
+			include_default_system_prompt: true,
+			additional_system_prompt: "",
+			default_system_prompt_preview: "Default prompt preview",
 		});
 		spyOn(API.experimental, "updateChatSystemPrompt").mockResolvedValue();
 		spyOn(API.experimental, "getUserChatCustomPrompt").mockResolvedValue({


### PR DESCRIPTION
## Summary
- split deployment-wide agents system prompt settings into an include-default toggle plus an additional system prompt
- update backend prompt composition and persistence so the default prompt is appended unless explicitly excluded
- add the new `/agents` settings UI, preview dialog, validation, accessibility fixes, and backward-compatible handling for older clients

## Why
Admins could previously set an additional system prompt in `/agents`, but that replaced the built-in Coder Agents default prompt entirely. This change separates those behaviors so admins can independently include the default prompt and add extra instructions.

## Validation
- `make gen`
- `go test ./coderd/... ./codersdk/...`
- `make lint`
- `make pre-commit`
- visual validation in the local app for the `/agents/settings` behavior UI
- deep-review rerun and follow-up fixes
