### PR TITLE
test(coderd/x/chatd/chatprovider): add coverage for pure and near-pure functions

### DIFF
--- a/coderd/x/chatd/chatprovider/chatprovider_internal_test.go
+++ b/coderd/x/chatd/chatprovider/chatprovider_internal_test.go
@@ -1,0 +1,685 @@
+package chatprovider
+
+import (
+	"testing"
+
+	fantasyanthropic "charm.land/fantasy/providers/anthropic"
+	fantasygoogle "charm.land/fantasy/providers/google"
+	fantasyopenai "charm.land/fantasy/providers/openai"
+	fantasyopenaicompat "charm.land/fantasy/providers/openaicompat"
+	fantasyopenrouter "charm.land/fantasy/providers/openrouter"
+	fantasyvercel "charm.land/fantasy/providers/vercel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/codersdk"
+)
+
+func ptr[T any](v T) *T {
+	return &v
+}
+
+func TestIsOpenAIReasoningModel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		modelID string
+		want    bool
+	}{
+		{name: "o1", modelID: "o1", want: true},
+		{name: "o3", modelID: "o3", want: true},
+		{name: "o4", modelID: "o4", want: true},
+		{name: "o1-mini", modelID: "o1-mini", want: true},
+		{name: "o3-mini", modelID: "o3-mini", want: true},
+		{name: "o4-mini", modelID: "o4-mini", want: true},
+		{name: "o1.5", modelID: "o1.5", want: true},
+		{name: "o12", modelID: "o12", want: true},
+		{name: "empty", modelID: "", want: false},
+		{name: "single_char_o", modelID: "o", want: false},
+		{name: "gpt-4", modelID: "gpt-4", want: false},
+		{name: "claude-3", modelID: "claude-3", want: false},
+		{name: "oops", modelID: "oops", want: false},
+		{name: "o_no_digit", modelID: "oa", want: false},
+		{name: "o1x_non_sep", modelID: "o1x", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := isOpenAIReasoningModel(tt.modelID)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIsChatModelForProvider(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		provider string
+		modelID  string
+		want     bool
+	}{
+		// OpenAI matches.
+		{name: "openai_gpt", provider: "openai", modelID: "gpt-4o", want: true},
+		{name: "openai_chatgpt", provider: "openai", modelID: "chatgpt-4o-latest", want: true},
+		{name: "openai_reasoning", provider: "openai", modelID: "o3-mini", want: true},
+		{name: "openai_no_match", provider: "openai", modelID: "claude-3", want: false},
+
+		// Anthropic matches.
+		{name: "anthropic_claude", provider: "anthropic", modelID: "claude-3.5-sonnet", want: true},
+		{name: "anthropic_no_match", provider: "anthropic", modelID: "gpt-4", want: false},
+
+		// Google matches.
+		{name: "google_gemini", provider: "google", modelID: "gemini-2.5-flash", want: true},
+		{name: "google_gemma", provider: "google", modelID: "gemma-7b", want: true},
+		{name: "google_no_match", provider: "google", modelID: "gpt-4", want: false},
+
+		// Unknown provider.
+		{name: "unknown_provider", provider: "unknown", modelID: "gpt-4", want: false},
+		{name: "empty_provider", provider: "", modelID: "gpt-4", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := isChatModelForProvider(tt.provider, tt.modelID)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCanonicalModelID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		provider string
+		modelID  string
+		want     string
+	}{
+		{name: "openai_gpt4", provider: "openai", modelID: "gpt-4", want: "openai:gpt-4"},
+		{name: "anthropic_claude", provider: "anthropic", modelID: "claude-3", want: "anthropic:claude-3"},
+		{name: "trims_model_whitespace", provider: "openai", modelID: "  gpt-4  ", want: "openai:gpt-4"},
+		{name: "unknown_provider_empty", provider: "unknown", modelID: "model", want: ":model"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := canonicalModelID(tt.provider, tt.modelID)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMissingProviderAPIKeyError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		provider string
+		wantMsg  string
+	}{
+		{name: "anthropic", provider: "anthropic", wantMsg: "ANTHROPIC_API_KEY is not set"},
+		{name: "azure", provider: "azure", wantMsg: "AZURE_OPENAI_API_KEY is not set"},
+		{name: "bedrock", provider: "bedrock", wantMsg: "BEDROCK_API_KEY is not set"},
+		{name: "google", provider: "google", wantMsg: "GOOGLE_API_KEY is not set"},
+		{name: "openai", provider: "openai", wantMsg: "OPENAI_API_KEY is not set"},
+		{name: "openai-compat", provider: "openai-compat", wantMsg: "OPENAI_COMPAT_API_KEY is not set"},
+		{name: "openrouter", provider: "openrouter", wantMsg: "OPENROUTER_API_KEY is not set"},
+		{name: "vercel", provider: "vercel", wantMsg: "VERCEL_API_KEY is not set"},
+		{name: "unknown", provider: "custom", wantMsg: "API key for provider \"custom\" is not set"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := missingProviderAPIKeyError(tt.provider)
+			require.Error(t, err)
+			assert.Equal(t, tt.wantMsg, err.Error())
+		})
+	}
+}
+
+func TestNormalizedEnumValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		value   string
+		allowed []string
+		want    *string
+	}{
+		{name: "exact_match", value: "low", allowed: []string{"low", "medium", "high"}, want: ptr("low")},
+		{name: "case_insensitive_match", value: "low", allowed: []string{"Low", "Medium", "High"}, want: ptr("Low")},
+		{name: "no_match", value: "extreme", allowed: []string{"low", "medium", "high"}, want: nil},
+		{name: "empty_value", value: "", allowed: []string{"low", "medium", "high"}, want: nil},
+		{name: "empty_allowed", value: "low", allowed: []string{}, want: nil},
+		{name: "no_allowed", value: "low", allowed: nil, want: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := normalizedEnumValue(tt.value, tt.allowed...)
+			if tt.want == nil {
+				assert.Nil(t, got)
+			} else {
+				require.NotNil(t, got)
+				assert.Equal(t, *tt.want, *got)
+			}
+		})
+	}
+}
+
+func TestNormalizedStringPointer(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input *string
+		want  *string
+	}{
+		{name: "nil", input: nil, want: nil},
+		{name: "empty", input: ptr(""), want: nil},
+		{name: "whitespace_only", input: ptr("   "), want: nil},
+		{name: "value", input: ptr("hello"), want: ptr("hello")},
+		{name: "trims_whitespace", input: ptr("  hello  "), want: ptr("hello")},
+		{name: "tab_and_newline", input: ptr("\t\n"), want: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := normalizedStringPointer(tt.input)
+			if tt.want == nil {
+				assert.Nil(t, got)
+			} else {
+				require.NotNil(t, got)
+				assert.Equal(t, *tt.want, *got)
+			}
+		})
+	}
+}
+
+func TestBoolPtrOrDefault(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		val  *bool
+		def  bool
+		want bool
+	}{
+		{name: "nil_default_true", val: nil, def: true, want: true},
+		{name: "nil_default_false", val: nil, def: false, want: false},
+		{name: "true_overrides", val: ptr(true), def: false, want: true},
+		{name: "false_overrides", val: ptr(false), def: true, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := boolPtrOrDefault(tt.val, tt.def)
+			require.NotNil(t, got)
+			assert.Equal(t, tt.want, *got)
+		})
+	}
+}
+
+func TestAnthropicProviderOptionsFromChatConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		input  *codersdk.ChatModelAnthropicProviderOptions
+		assert func(t *testing.T, got *fantasyanthropic.ProviderOptions)
+	}{
+		{
+			name: "all_fields_set",
+			input: &codersdk.ChatModelAnthropicProviderOptions{
+				SendReasoning:          ptr(true),
+				Effort:                 ptr("high"),
+				DisableParallelToolUse: ptr(true),
+				Thinking: &codersdk.ChatModelAnthropicThinkingOptions{
+					BudgetTokens: ptr(int64(10000)),
+				},
+			},
+			assert: func(t *testing.T, got *fantasyanthropic.ProviderOptions) {
+				t.Helper()
+				require.NotNil(t, got.SendReasoning)
+				assert.True(t, *got.SendReasoning)
+				require.NotNil(t, got.Effort)
+				assert.Equal(t, fantasyanthropic.EffortHigh, *got.Effort)
+				require.NotNil(t, got.DisableParallelToolUse)
+				assert.True(t, *got.DisableParallelToolUse)
+				require.NotNil(t, got.Thinking)
+				assert.Equal(t, int64(10000), got.Thinking.BudgetTokens)
+			},
+		},
+		{
+			name:  "minimal_fields",
+			input: &codersdk.ChatModelAnthropicProviderOptions{},
+			assert: func(t *testing.T, got *fantasyanthropic.ProviderOptions) {
+				t.Helper()
+				assert.Nil(t, got.SendReasoning)
+				assert.Nil(t, got.Effort)
+				assert.Nil(t, got.DisableParallelToolUse)
+				assert.Nil(t, got.Thinking)
+			},
+		},
+		{
+			name: "thinking_without_budget",
+			input: &codersdk.ChatModelAnthropicProviderOptions{
+				Thinking: &codersdk.ChatModelAnthropicThinkingOptions{},
+			},
+			assert: func(t *testing.T, got *fantasyanthropic.ProviderOptions) {
+				t.Helper()
+				// BudgetTokens is nil, so Thinking should not be set.
+				assert.Nil(t, got.Thinking)
+			},
+		},
+		{
+			name: "invalid_effort_returns_nil",
+			input: &codersdk.ChatModelAnthropicProviderOptions{
+				Effort: ptr("nonexistent"),
+			},
+			assert: func(t *testing.T, got *fantasyanthropic.ProviderOptions) {
+				t.Helper()
+				assert.Nil(t, got.Effort)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := anthropicProviderOptionsFromChatConfig(tt.input)
+			require.NotNil(t, got)
+			tt.assert(t, got)
+		})
+	}
+}
+
+func TestGoogleProviderOptionsFromChatConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		input  *codersdk.ChatModelGoogleProviderOptions
+		assert func(t *testing.T, got *fantasygoogle.ProviderOptions)
+	}{
+		{
+			name: "all_fields_set",
+			input: &codersdk.ChatModelGoogleProviderOptions{
+				CachedContent: "cachedContents/abc123",
+				Threshold:     "BLOCK_NONE",
+				ThinkingConfig: &codersdk.ChatModelGoogleThinkingConfig{
+					ThinkingBudget:  ptr(int64(8000)),
+					IncludeThoughts: ptr(true),
+				},
+				SafetySettings: []codersdk.ChatModelGoogleSafetySetting{
+					{Category: "HARM_CATEGORY_HATE_SPEECH", Threshold: "BLOCK_LOW_AND_ABOVE"},
+					{Category: "HARM_CATEGORY_HARASSMENT", Threshold: "BLOCK_NONE"},
+				},
+			},
+			assert: func(t *testing.T, got *fantasygoogle.ProviderOptions) {
+				t.Helper()
+				assert.Equal(t, "cachedContents/abc123", got.CachedContent)
+				assert.Equal(t, "BLOCK_NONE", got.Threshold)
+				require.NotNil(t, got.ThinkingConfig)
+				require.NotNil(t, got.ThinkingConfig.ThinkingBudget)
+				assert.Equal(t, int64(8000), *got.ThinkingConfig.ThinkingBudget)
+				require.NotNil(t, got.ThinkingConfig.IncludeThoughts)
+				assert.True(t, *got.ThinkingConfig.IncludeThoughts)
+				require.Len(t, got.SafetySettings, 2)
+				assert.Equal(t, "HARM_CATEGORY_HATE_SPEECH", got.SafetySettings[0].Category)
+				assert.Equal(t, "BLOCK_LOW_AND_ABOVE", got.SafetySettings[0].Threshold)
+			},
+		},
+		{
+			name:  "minimal_fields",
+			input: &codersdk.ChatModelGoogleProviderOptions{},
+			assert: func(t *testing.T, got *fantasygoogle.ProviderOptions) {
+				t.Helper()
+				assert.Empty(t, got.CachedContent)
+				assert.Empty(t, got.Threshold)
+				assert.Nil(t, got.ThinkingConfig)
+				assert.Nil(t, got.SafetySettings)
+			},
+		},
+		{
+			name: "trims_whitespace_in_strings",
+			input: &codersdk.ChatModelGoogleProviderOptions{
+				CachedContent: "  cachedContents/abc  ",
+				Threshold:     "  BLOCK_NONE  ",
+				SafetySettings: []codersdk.ChatModelGoogleSafetySetting{
+					{Category: "  HARM_CATEGORY_HATE_SPEECH  ", Threshold: "  BLOCK_NONE  "},
+				},
+			},
+			assert: func(t *testing.T, got *fantasygoogle.ProviderOptions) {
+				t.Helper()
+				assert.Equal(t, "cachedContents/abc", got.CachedContent)
+				assert.Equal(t, "BLOCK_NONE", got.Threshold)
+				require.Len(t, got.SafetySettings, 1)
+				assert.Equal(t, "HARM_CATEGORY_HATE_SPEECH", got.SafetySettings[0].Category)
+				assert.Equal(t, "BLOCK_NONE", got.SafetySettings[0].Threshold)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := googleProviderOptionsFromChatConfig(tt.input)
+			require.NotNil(t, got)
+			tt.assert(t, got)
+		})
+	}
+}
+
+func TestOpenAICompatProviderOptionsFromChatConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		input  *codersdk.ChatModelOpenAICompatProviderOptions
+		assert func(t *testing.T, got *fantasyopenaicompat.ProviderOptions)
+	}{
+		{
+			name: "all_fields_set",
+			input: &codersdk.ChatModelOpenAICompatProviderOptions{
+				User:            ptr("user-123"),
+				ReasoningEffort: ptr("high"),
+			},
+			assert: func(t *testing.T, got *fantasyopenaicompat.ProviderOptions) {
+				t.Helper()
+				require.NotNil(t, got.User)
+				assert.Equal(t, "user-123", *got.User)
+				require.NotNil(t, got.ReasoningEffort)
+				assert.Equal(t, fantasyopenai.ReasoningEffortHigh, *got.ReasoningEffort)
+			},
+		},
+		{
+			name:  "minimal_fields",
+			input: &codersdk.ChatModelOpenAICompatProviderOptions{},
+			assert: func(t *testing.T, got *fantasyopenaicompat.ProviderOptions) {
+				t.Helper()
+				assert.Nil(t, got.User)
+				assert.Nil(t, got.ReasoningEffort)
+			},
+		},
+		{
+			name: "whitespace_user_returns_nil",
+			input: &codersdk.ChatModelOpenAICompatProviderOptions{
+				User: ptr("   "),
+			},
+			assert: func(t *testing.T, got *fantasyopenaicompat.ProviderOptions) {
+				t.Helper()
+				assert.Nil(t, got.User)
+			},
+		},
+		{
+			name: "invalid_effort_returns_nil",
+			input: &codersdk.ChatModelOpenAICompatProviderOptions{
+				ReasoningEffort: ptr("nonexistent"),
+			},
+			assert: func(t *testing.T, got *fantasyopenaicompat.ProviderOptions) {
+				t.Helper()
+				assert.Nil(t, got.ReasoningEffort)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := openAICompatProviderOptionsFromChatConfig(tt.input)
+			require.NotNil(t, got)
+			tt.assert(t, got)
+		})
+	}
+}
+
+func TestOpenRouterProviderOptionsFromChatConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		input  *codersdk.ChatModelOpenRouterProviderOptions
+		assert func(t *testing.T, got *fantasyopenrouter.ProviderOptions)
+	}{
+		{
+			name: "all_fields_set",
+			input: &codersdk.ChatModelOpenRouterProviderOptions{
+				ExtraBody:         map[string]any{"key": "value"},
+				IncludeUsage:      ptr(true),
+				LogitBias:         map[string]int64{"50256": -100},
+				LogProbs:          ptr(true),
+				ParallelToolCalls: ptr(false),
+				User:              ptr("user-456"),
+				Reasoning: &codersdk.ChatModelReasoningOptions{
+					Enabled:   ptr(true),
+					Exclude:   ptr(false),
+					MaxTokens: ptr(int64(4096)),
+					Effort:    ptr("high"),
+				},
+				Provider: &codersdk.ChatModelOpenRouterProvider{
+					Order:             []string{"anthropic", "openai"},
+					AllowFallbacks:    ptr(true),
+					RequireParameters: ptr(false),
+					DataCollection:    ptr("deny"),
+					Only:              []string{"anthropic"},
+					Ignore:            []string{"openai"},
+					Quantizations:     []string{"int8"},
+					Sort:              ptr("price"),
+				},
+			},
+			assert: func(t *testing.T, got *fantasyopenrouter.ProviderOptions) {
+				t.Helper()
+				assert.Equal(t, map[string]any{"key": "value"}, got.ExtraBody)
+				require.NotNil(t, got.IncludeUsage)
+				assert.True(t, *got.IncludeUsage)
+				assert.Equal(t, map[string]int64{"50256": -100}, got.LogitBias)
+				require.NotNil(t, got.LogProbs)
+				assert.True(t, *got.LogProbs)
+				require.NotNil(t, got.ParallelToolCalls)
+				assert.False(t, *got.ParallelToolCalls)
+				require.NotNil(t, got.User)
+				assert.Equal(t, "user-456", *got.User)
+
+				require.NotNil(t, got.Reasoning)
+				require.NotNil(t, got.Reasoning.Enabled)
+				assert.True(t, *got.Reasoning.Enabled)
+				require.NotNil(t, got.Reasoning.Exclude)
+				assert.False(t, *got.Reasoning.Exclude)
+				require.NotNil(t, got.Reasoning.MaxTokens)
+				assert.Equal(t, int64(4096), *got.Reasoning.MaxTokens)
+				require.NotNil(t, got.Reasoning.Effort)
+				assert.Equal(t, fantasyopenrouter.ReasoningEffortHigh, *got.Reasoning.Effort)
+
+				require.NotNil(t, got.Provider)
+				assert.Equal(t, []string{"anthropic", "openai"}, got.Provider.Order)
+				require.NotNil(t, got.Provider.AllowFallbacks)
+				assert.True(t, *got.Provider.AllowFallbacks)
+				require.NotNil(t, got.Provider.RequireParameters)
+				assert.False(t, *got.Provider.RequireParameters)
+				require.NotNil(t, got.Provider.DataCollection)
+				assert.Equal(t, "deny", *got.Provider.DataCollection)
+				assert.Equal(t, []string{"anthropic"}, got.Provider.Only)
+				assert.Equal(t, []string{"openai"}, got.Provider.Ignore)
+				assert.Equal(t, []string{"int8"}, got.Provider.Quantizations)
+				require.NotNil(t, got.Provider.Sort)
+				assert.Equal(t, "price", *got.Provider.Sort)
+			},
+		},
+		{
+			name:  "minimal_fields",
+			input: &codersdk.ChatModelOpenRouterProviderOptions{},
+			assert: func(t *testing.T, got *fantasyopenrouter.ProviderOptions) {
+				t.Helper()
+				assert.Nil(t, got.ExtraBody)
+				assert.Nil(t, got.IncludeUsage)
+				assert.Nil(t, got.LogitBias)
+				assert.Nil(t, got.LogProbs)
+				assert.Nil(t, got.ParallelToolCalls)
+				assert.Nil(t, got.User)
+				assert.Nil(t, got.Reasoning)
+				assert.Nil(t, got.Provider)
+			},
+		},
+		{
+			name: "reasoning_without_provider",
+			input: &codersdk.ChatModelOpenRouterProviderOptions{
+				Reasoning: &codersdk.ChatModelReasoningOptions{
+					Enabled: ptr(true),
+				},
+			},
+			assert: func(t *testing.T, got *fantasyopenrouter.ProviderOptions) {
+				t.Helper()
+				require.NotNil(t, got.Reasoning)
+				require.NotNil(t, got.Reasoning.Enabled)
+				assert.True(t, *got.Reasoning.Enabled)
+				assert.Nil(t, got.Provider)
+			},
+		},
+		{
+			name: "provider_without_reasoning",
+			input: &codersdk.ChatModelOpenRouterProviderOptions{
+				Provider: &codersdk.ChatModelOpenRouterProvider{
+					Order: []string{"anthropic"},
+				},
+			},
+			assert: func(t *testing.T, got *fantasyopenrouter.ProviderOptions) {
+				t.Helper()
+				assert.Nil(t, got.Reasoning)
+				require.NotNil(t, got.Provider)
+				assert.Equal(t, []string{"anthropic"}, got.Provider.Order)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := openRouterProviderOptionsFromChatConfig(tt.input)
+			require.NotNil(t, got)
+			tt.assert(t, got)
+		})
+	}
+}
+
+func TestVercelProviderOptionsFromChatConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		input  *codersdk.ChatModelVercelProviderOptions
+		assert func(t *testing.T, got *fantasyvercel.ProviderOptions)
+	}{
+		{
+			name: "all_fields_set",
+			input: &codersdk.ChatModelVercelProviderOptions{
+				User:              ptr("user-789"),
+				LogitBias:         map[string]int64{"50256": 50},
+				LogProbs:          ptr(true),
+				TopLogProbs:       ptr(int64(5)),
+				ParallelToolCalls: ptr(true),
+				ExtraBody:         map[string]any{"custom": true},
+				Reasoning: &codersdk.ChatModelReasoningOptions{
+					Enabled:   ptr(true),
+					MaxTokens: ptr(int64(2048)),
+					Effort:    ptr("high"),
+					Exclude:   ptr(false),
+				},
+				ProviderOptions: &codersdk.ChatModelVercelGatewayProviderOptions{
+					Order:  []string{"vertex", "anthropic"},
+					Models: []string{"claude-3", "gemini-2"},
+				},
+			},
+			assert: func(t *testing.T, got *fantasyvercel.ProviderOptions) {
+				t.Helper()
+				require.NotNil(t, got.User)
+				assert.Equal(t, "user-789", *got.User)
+				assert.Equal(t, map[string]int64{"50256": 50}, got.LogitBias)
+				require.NotNil(t, got.LogProbs)
+				assert.True(t, *got.LogProbs)
+				require.NotNil(t, got.TopLogProbs)
+				assert.Equal(t, int64(5), *got.TopLogProbs)
+				require.NotNil(t, got.ParallelToolCalls)
+				assert.True(t, *got.ParallelToolCalls)
+				assert.Equal(t, map[string]any{"custom": true}, got.ExtraBody)
+
+				require.NotNil(t, got.Reasoning)
+				require.NotNil(t, got.Reasoning.Enabled)
+				assert.True(t, *got.Reasoning.Enabled)
+				require.NotNil(t, got.Reasoning.MaxTokens)
+				assert.Equal(t, int64(2048), *got.Reasoning.MaxTokens)
+				require.NotNil(t, got.Reasoning.Effort)
+				assert.Equal(t, fantasyvercel.ReasoningEffortHigh, *got.Reasoning.Effort)
+				require.NotNil(t, got.Reasoning.Exclude)
+				assert.False(t, *got.Reasoning.Exclude)
+
+				require.NotNil(t, got.ProviderOptions)
+				assert.Equal(t, []string{"vertex", "anthropic"}, got.ProviderOptions.Order)
+				assert.Equal(t, []string{"claude-3", "gemini-2"}, got.ProviderOptions.Models)
+			},
+		},
+		{
+			name:  "minimal_fields",
+			input: &codersdk.ChatModelVercelProviderOptions{},
+			assert: func(t *testing.T, got *fantasyvercel.ProviderOptions) {
+				t.Helper()
+				assert.Nil(t, got.User)
+				assert.Nil(t, got.LogitBias)
+				assert.Nil(t, got.LogProbs)
+				assert.Nil(t, got.TopLogProbs)
+				assert.Nil(t, got.ParallelToolCalls)
+				assert.Nil(t, got.ExtraBody)
+				assert.Nil(t, got.Reasoning)
+				assert.Nil(t, got.ProviderOptions)
+			},
+		},
+		{
+			name: "reasoning_only",
+			input: &codersdk.ChatModelVercelProviderOptions{
+				Reasoning: &codersdk.ChatModelReasoningOptions{
+					Enabled: ptr(true),
+				},
+			},
+			assert: func(t *testing.T, got *fantasyvercel.ProviderOptions) {
+				t.Helper()
+				require.NotNil(t, got.Reasoning)
+				require.NotNil(t, got.Reasoning.Enabled)
+				assert.True(t, *got.Reasoning.Enabled)
+				assert.Nil(t, got.ProviderOptions)
+			},
+		},
+		{
+			name: "provider_options_only",
+			input: &codersdk.ChatModelVercelProviderOptions{
+				ProviderOptions: &codersdk.ChatModelVercelGatewayProviderOptions{
+					Order: []string{"vertex"},
+				},
+			},
+			assert: func(t *testing.T, got *fantasyvercel.ProviderOptions) {
+				t.Helper()
+				assert.Nil(t, got.Reasoning)
+				require.NotNil(t, got.ProviderOptions)
+				assert.Equal(t, []string{"vertex"}, got.ProviderOptions.Order)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := vercelProviderOptionsFromChatConfig(tt.input)
+			require.NotNil(t, got)
+			tt.assert(t, got)
+		})
+	}
+}

--- a/coderd/x/chatd/chatprovider/chatprovider_test.go
+++ b/coderd/x/chatd/chatprovider/chatprovider_test.go
@@ -869,6 +869,357 @@ func TestModelFromConfig_NilExtraHeaders(t *testing.T) {
 	})
 	require.NoError(t, err)
 	_ = testutil.TryReceive(ctx, t, called)
+func TestSupportedProviders(t *testing.T) {
+	t.Parallel()
+
+	providers := chatprovider.SupportedProviders()
+
+	// Must contain all known providers.
+	require.Contains(t, providers, "openai")
+	require.Contains(t, providers, "anthropic")
+	require.Contains(t, providers, "azure")
+	require.Contains(t, providers, "bedrock")
+	require.Contains(t, providers, "google")
+	require.Contains(t, providers, "openai-compat")
+	require.Contains(t, providers, "openrouter")
+	require.Contains(t, providers, "vercel")
+	require.Len(t, providers, 8)
+
+	// Returns a copy, not the original slice.
+	providers[0] = "mutated"
+	fresh := chatprovider.SupportedProviders()
+	require.NotEqual(t, "mutated", fresh[0],
+		"SupportedProviders must return a defensive copy")
+}
+
+func TestIsEnvPresetProvider(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{name: "OpenAI", input: "openai", expected: true},
+		{name: "Anthropic", input: "anthropic", expected: true},
+		{name: "OpenAIUpperCase", input: "OPENAI", expected: true},
+		{name: "AnthropicMixedCase", input: "Anthropic", expected: true},
+		{name: "OpenAIWithSpaces", input: "  openai  ", expected: true},
+		{name: "Google", input: "google", expected: false},
+		{name: "OpenRouter", input: "openrouter", expected: false},
+		{name: "Azure", input: "azure", expected: false},
+		{name: "Unknown", input: "unknown", expected: false},
+		{name: "Empty", input: "", expected: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := chatprovider.IsEnvPresetProvider(tt.input)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestProviderDisplayName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "OpenAI", input: "openai", expected: "OpenAI"},
+		{name: "Anthropic", input: "anthropic", expected: "Anthropic"},
+		{name: "Azure", input: "azure", expected: "Azure OpenAI"},
+		{name: "Bedrock", input: "bedrock", expected: "AWS Bedrock"},
+		{name: "Google", input: "google", expected: "Google"},
+		{name: "OpenAICompat", input: "openai-compat", expected: "OpenAI Compatible"},
+		{name: "OpenRouter", input: "openrouter", expected: "OpenRouter"},
+		{name: "Vercel", input: "vercel", expected: "Vercel AI Gateway"},
+		{name: "UpperCase", input: "OPENAI", expected: "OpenAI"},
+		{name: "UnknownReturnsEmpty", input: "unknown", expected: ""},
+		{name: "EmptyReturnsEmpty", input: "", expected: ""},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := chatprovider.ProviderDisplayName(tt.input)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestNormalizeProvider(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "OpenAI", input: "openai", expected: "openai"},
+		{name: "Anthropic", input: "anthropic", expected: "anthropic"},
+		{name: "Azure", input: "azure", expected: "azure"},
+		{name: "Bedrock", input: "bedrock", expected: "bedrock"},
+		{name: "Google", input: "google", expected: "google"},
+		{name: "OpenAICompat", input: "openai-compat", expected: "openai-compat"},
+		{name: "OpenRouter", input: "openrouter", expected: "openrouter"},
+		{name: "Vercel", input: "vercel", expected: "vercel"},
+		{name: "UpperCase", input: "OPENAI", expected: "openai"},
+		{name: "MixedCase", input: "OpenRouter", expected: "openrouter"},
+		{name: "LeadingTrailingSpaces", input: "  anthropic  ", expected: "anthropic"},
+		{name: "UnknownReturnsEmpty", input: "unknown", expected: ""},
+		{name: "EmptyReturnsEmpty", input: "", expected: ""},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := chatprovider.NormalizeProvider(tt.input)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestResolveModelWithProviderHint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		model        string
+		providerHint string
+		wantProvider string
+		wantModel    string
+		wantErr      bool
+	}{
+		// Canonical provider:model references.
+		{
+			name:         "CanonicalColonSeparator",
+			model:        "openai:gpt-4o",
+			providerHint: "",
+			wantProvider: "openai",
+			wantModel:    "gpt-4o",
+		},
+		{
+			name:         "CanonicalSlashSeparator",
+			model:        "anthropic/claude-sonnet-4-20250514",
+			providerHint: "",
+			wantProvider: "anthropic",
+			wantModel:    "claude-sonnet-4-20250514",
+		},
+		{
+			name:         "CanonicalOverridesHint",
+			model:        "google:gemini-2.5-flash",
+			providerHint: "openai",
+			wantProvider: "google",
+			wantModel:    "gemini-2.5-flash",
+		},
+		// Provider hint used when no canonical prefix.
+		{
+			name:         "HintUsedForBareModel",
+			model:        "my-custom-model",
+			providerHint: "openai-compat",
+			wantProvider: "openai-compat",
+			wantModel:    "my-custom-model",
+		},
+		// Well-known model shortcuts.
+		{
+			name:         "WellKnownClaudeOpus",
+			model:        "claude-opus-4-6",
+			providerHint: "",
+			wantProvider: "anthropic",
+			wantModel:    "claude-opus-4-6",
+		},
+		{
+			name:         "WellKnownGPT",
+			model:        "gpt-5.2",
+			providerHint: "",
+			wantProvider: "openai",
+			wantModel:    "gpt-5.2",
+		},
+		{
+			name:         "WellKnownGemini",
+			model:        "gemini-2.5-flash",
+			providerHint: "",
+			wantProvider: "google",
+			wantModel:    "gemini-2.5-flash",
+		},
+		// Prefix-based inference.
+		{
+			name:         "ClaudePrefixInfersAnthropic",
+			model:        "claude-sonnet-4-20250514",
+			providerHint: "",
+			wantProvider: "anthropic",
+			wantModel:    "claude-sonnet-4-20250514",
+		},
+		{
+			name:         "GPTPrefixInfersOpenAI",
+			model:        "gpt-4o-mini",
+			providerHint: "",
+			wantProvider: "openai",
+			wantModel:    "gpt-4o-mini",
+		},
+		// Error cases.
+		{
+			name:    "EmptyModelErrors",
+			model:   "",
+			wantErr: true,
+		},
+		{
+			name:    "WhitespaceOnlyModelErrors",
+			model:   "   ",
+			wantErr: true,
+		},
+		{
+			name:    "UnknownModelNoHintErrors",
+			model:   "totally-unknown-model",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			provider, model, err := chatprovider.ResolveModelWithProviderHint(tt.model, tt.providerHint)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantProvider, provider)
+			assert.Equal(t, tt.wantModel, model)
+		})
+	}
+}
+
+func TestOpenAITextVerbosityFromChat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input *string
+		want  *fantasyopenai.TextVerbosity
+	}{
+		{name: "NilReturnsNil", input: nil, want: nil},
+		{name: "EmptyReturnsNil", input: ptr.Ref(""), want: nil},
+		{name: "WhitespaceReturnsNil", input: ptr.Ref("  "), want: nil},
+		{name: "InvalidReturnsNil", input: ptr.Ref("extreme"), want: nil},
+		{name: "Low", input: ptr.Ref("low"), want: ptr.Ref(fantasyopenai.TextVerbosityLow)},
+		{name: "Medium", input: ptr.Ref("medium"), want: ptr.Ref(fantasyopenai.TextVerbosityMedium)},
+		{name: "High", input: ptr.Ref("high"), want: ptr.Ref(fantasyopenai.TextVerbosityHigh)},
+		{name: "CaseInsensitive", input: ptr.Ref("HIGH"), want: ptr.Ref(fantasyopenai.TextVerbosityHigh)},
+		{name: "TrimmedAndLowered", input: ptr.Ref("  Medium  "), want: ptr.Ref(fantasyopenai.TextVerbosityMedium)},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := chatprovider.OpenAITextVerbosityFromChat(tt.input)
+			if tt.want == nil {
+				assert.Nil(t, got)
+			} else {
+				require.NotNil(t, got)
+				assert.Equal(t, *tt.want, *got)
+			}
+		})
+	}
+}
+
+func TestIsResponsesStoreEnabled(t *testing.T) {
+	t.Parallel()
+
+	storeTrue := true
+	storeFalse := false
+
+	tests := []struct {
+		name     string
+		opts     fantasy.ProviderOptions
+		expected bool
+	}{
+		{name: "NilOptions", opts: nil, expected: false},
+		{name: "EmptyOptions", opts: fantasy.ProviderOptions{}, expected: false},
+		{name: "WrongProviderKey", opts: fantasy.ProviderOptions{"anthropic": &fantasyopenai.ResponsesProviderOptions{Store: &storeTrue}}, expected: false},
+		{name: "WrongType", opts: fantasy.ProviderOptions{"openai": &fantasyopenai.ProviderOptions{}}, expected: false},
+		{name: "NilStore", opts: fantasy.ProviderOptions{"openai": &fantasyopenai.ResponsesProviderOptions{}}, expected: false},
+		{name: "StoreFalse", opts: fantasy.ProviderOptions{"openai": &fantasyopenai.ResponsesProviderOptions{Store: &storeFalse}}, expected: false},
+		{name: "StoreTrue", opts: fantasy.ProviderOptions{"openai": &fantasyopenai.ResponsesProviderOptions{Store: &storeTrue}}, expected: true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := chatprovider.IsResponsesStoreEnabled(tt.opts)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestCloneWithPreviousResponseID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("SetsResponseIDOnClone", func(t *testing.T) {
+		t.Parallel()
+
+		storeTrue := true
+		originalOpts := &fantasyopenai.ResponsesProviderOptions{
+			Store: &storeTrue,
+		}
+		opts := fantasy.ProviderOptions{
+			"openai":    originalOpts,
+			"anthropic": &fantasyanthropic.ProviderOptions{},
+		}
+
+		cloned := chatprovider.CloneWithPreviousResponseID(opts, "resp_abc123")
+
+		// Cloned map must have the response ID set.
+		respOpts, ok := cloned["openai"].(*fantasyopenai.ResponsesProviderOptions)
+		require.True(t, ok)
+		require.NotNil(t, respOpts.PreviousResponseID)
+		assert.Equal(t, "resp_abc123", *respOpts.PreviousResponseID)
+
+		// Store value must be preserved in clone.
+		require.NotNil(t, respOpts.Store)
+		assert.True(t, *respOpts.Store)
+
+		// Original must not be mutated.
+		assert.Nil(t, originalOpts.PreviousResponseID,
+			"original options must not be mutated")
+
+		// Non-openai entries are preserved.
+		_, hasAnthropic := cloned["anthropic"]
+		assert.True(t, hasAnthropic)
+	})
+
+	t.Run("NoOpenAIEntryIsNoop", func(t *testing.T) {
+		t.Parallel()
+
+		opts := fantasy.ProviderOptions{
+			"anthropic": &fantasyanthropic.ProviderOptions{},
+		}
+
+		cloned := chatprovider.CloneWithPreviousResponseID(opts, "resp_xyz")
+
+		// Should still have anthropic, no openai added.
+		assert.Len(t, cloned, 1)
+		_, hasAnthropic := cloned["anthropic"]
+		assert.True(t, hasAnthropic)
+	})
+
+	t.Run("NilOptionsReturnsEmptyMap", func(t *testing.T) {
+		t.Parallel()
+
+		cloned := chatprovider.CloneWithPreviousResponseID(nil, "resp_nil")
+		assert.NotNil(t, cloned)
+		assert.Empty(t, cloned)
+	})
 }
 
 func TestModelFromConfig_HTTPClient(t *testing.T) {
@@ -971,4 +1322,555 @@ func TestMergeMissingProviderOptions_OpenRouterNested(t *testing.T) {
 	require.Equal(t, []string{"foo"}, options.OpenRouter.Provider.Ignore)
 	require.Equal(t, []string{"int8"}, options.OpenRouter.Provider.Quantizations)
 	require.Equal(t, "latency", *options.OpenRouter.Provider.Sort)
+}
+
+func TestProviderAPIKeys_APIKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		keys     chatprovider.ProviderAPIKeys
+		provider string
+		want     string
+	}{
+		{
+			name:     "EmptyProvider",
+			keys:     chatprovider.ProviderAPIKeys{},
+			provider: "",
+			want:     "",
+		},
+		{
+			name:     "UnknownProvider",
+			keys:     chatprovider.ProviderAPIKeys{},
+			provider: "unknown-provider",
+			want:     "",
+		},
+		{
+			name: "FallbackOpenAI",
+			keys: chatprovider.ProviderAPIKeys{
+				OpenAI: "sk-openai",
+			},
+			provider: "openai",
+			want:     "sk-openai",
+		},
+		{
+			name: "FallbackAnthropic",
+			keys: chatprovider.ProviderAPIKeys{
+				Anthropic: "sk-anthropic",
+			},
+			provider: "anthropic",
+			want:     "sk-anthropic",
+		},
+		{
+			name: "ByProviderTakesPriority",
+			keys: chatprovider.ProviderAPIKeys{
+				OpenAI:     "sk-fallback",
+				ByProvider: map[string]string{"openai": "sk-override"},
+			},
+			provider: "openai",
+			want:     "sk-override",
+		},
+		{
+			name: "ProviderNormalization",
+			keys: chatprovider.ProviderAPIKeys{
+				ByProvider: map[string]string{"anthropic": "sk-key"},
+			},
+			provider: " Anthropic ",
+			want:     "sk-key",
+		},
+		{
+			name: "WhitespaceKeyTrimmed",
+			keys: chatprovider.ProviderAPIKeys{
+				OpenAI: "  sk-padded  ",
+			},
+			provider: "openai",
+			want:     "sk-padded",
+		},
+		{
+			name: "WhitespaceOnlyKeyIsEmpty",
+			keys: chatprovider.ProviderAPIKeys{
+				ByProvider: map[string]string{"openai": "   "},
+				OpenAI:     "sk-fallback",
+			},
+			provider: "openai",
+			want:     "sk-fallback",
+		},
+		{
+			name: "NilByProviderMap",
+			keys: chatprovider.ProviderAPIKeys{
+				Anthropic: "sk-ant",
+			},
+			provider: "anthropic",
+			want:     "sk-ant",
+		},
+		{
+			name: "GoogleKeyFromByProvider",
+			keys: chatprovider.ProviderAPIKeys{
+				ByProvider: map[string]string{"google": "goog-key"},
+			},
+			provider: "google",
+			want:     "goog-key",
+		},
+		{
+			name: "GoogleNoFallback",
+			keys: chatprovider.ProviderAPIKeys{
+				OpenAI:    "sk-openai",
+				Anthropic: "sk-anthropic",
+			},
+			provider: "google",
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.keys.APIKey(tt.provider)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestProviderAPIKeys_BaseURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		keys     chatprovider.ProviderAPIKeys
+		provider string
+		want     string
+	}{
+		{
+			name:     "EmptyProvider",
+			keys:     chatprovider.ProviderAPIKeys{},
+			provider: "",
+			want:     "",
+		},
+		{
+			name:     "NilMap",
+			keys:     chatprovider.ProviderAPIKeys{},
+			provider: "openai",
+			want:     "",
+		},
+		{
+			name: "ReturnsURL",
+			keys: chatprovider.ProviderAPIKeys{
+				BaseURLByProvider: map[string]string{
+					"openai": "https://custom.openai.example.com",
+				},
+			},
+			provider: "openai",
+			want:     "https://custom.openai.example.com",
+		},
+		{
+			name: "TrimsWhitespace",
+			keys: chatprovider.ProviderAPIKeys{
+				BaseURLByProvider: map[string]string{
+					"anthropic": "  https://proxy.example.com  ",
+				},
+			},
+			provider: "anthropic",
+			want:     "https://proxy.example.com",
+		},
+		{
+			name: "NormalizesProvider",
+			keys: chatprovider.ProviderAPIKeys{
+				BaseURLByProvider: map[string]string{
+					"google": "https://google.proxy",
+				},
+			},
+			provider: " Google ",
+			want:     "https://google.proxy",
+		},
+		{
+			name: "MissingProviderEntry",
+			keys: chatprovider.ProviderAPIKeys{
+				BaseURLByProvider: map[string]string{
+					"openai": "https://openai.proxy",
+				},
+			},
+			provider: "anthropic",
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.keys.BaseURL(tt.provider)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMergeProviderAPIKeys(t *testing.T) {
+	t.Parallel()
+
+	t.Run("EmptyInputs", func(t *testing.T) {
+		t.Parallel()
+		merged := chatprovider.MergeProviderAPIKeys(
+			chatprovider.ProviderAPIKeys{},
+			nil,
+		)
+		require.Empty(t, merged.OpenAI)
+		require.Empty(t, merged.Anthropic)
+		require.NotNil(t, merged.ByProvider)
+		require.NotNil(t, merged.BaseURLByProvider)
+	})
+
+	t.Run("StaticKeysPreserved", func(t *testing.T) {
+		t.Parallel()
+		static := chatprovider.ProviderAPIKeys{
+			OpenAI:    "sk-openai",
+			Anthropic: "sk-anthropic",
+			ByProvider: map[string]string{
+				"google": "goog-key",
+			},
+			BaseURLByProvider: map[string]string{
+				"google": "https://google.proxy",
+			},
+		}
+		merged := chatprovider.MergeProviderAPIKeys(static, nil)
+
+		require.Equal(t, "sk-openai", merged.OpenAI)
+		require.Equal(t, "sk-anthropic", merged.Anthropic)
+		// Static OpenAI/Anthropic also get promoted into ByProvider.
+		require.Equal(t, "sk-openai", merged.ByProvider["openai"])
+		require.Equal(t, "sk-anthropic", merged.ByProvider["anthropic"])
+		require.Equal(t, "goog-key", merged.ByProvider["google"])
+		require.Equal(t, "https://google.proxy", merged.BaseURLByProvider["google"])
+	})
+
+	t.Run("DBProviderOverridesStatic", func(t *testing.T) {
+		t.Parallel()
+		static := chatprovider.ProviderAPIKeys{
+			OpenAI: "sk-old",
+		}
+		dbProviders := []chatprovider.ConfiguredProvider{
+			{Provider: "openai", APIKey: "sk-new", BaseURL: "https://new.openai.com"},
+		}
+		merged := chatprovider.MergeProviderAPIKeys(static, dbProviders)
+
+		require.Equal(t, "sk-new", merged.OpenAI)
+		require.Equal(t, "sk-new", merged.ByProvider["openai"])
+		require.Equal(t, "https://new.openai.com", merged.BaseURLByProvider["openai"])
+	})
+
+	t.Run("DBAnthropicOverridesStatic", func(t *testing.T) {
+		t.Parallel()
+		static := chatprovider.ProviderAPIKeys{
+			Anthropic: "sk-old-ant",
+		}
+		dbProviders := []chatprovider.ConfiguredProvider{
+			{Provider: "anthropic", APIKey: "sk-new-ant"},
+		}
+		merged := chatprovider.MergeProviderAPIKeys(static, dbProviders)
+
+		require.Equal(t, "sk-new-ant", merged.Anthropic)
+		require.Equal(t, "sk-new-ant", merged.ByProvider["anthropic"])
+	})
+
+	t.Run("MixedProviders", func(t *testing.T) {
+		t.Parallel()
+		static := chatprovider.ProviderAPIKeys{
+			OpenAI: "sk-openai",
+			ByProvider: map[string]string{
+				"google": "goog-static",
+			},
+		}
+		dbProviders := []chatprovider.ConfiguredProvider{
+			{Provider: "anthropic", APIKey: "sk-ant-db"},
+			{Provider: "google", APIKey: "goog-db", BaseURL: "https://goog.proxy"},
+		}
+		merged := chatprovider.MergeProviderAPIKeys(static, dbProviders)
+
+		// OpenAI comes from static.
+		require.Equal(t, "sk-openai", merged.ByProvider["openai"])
+		// DB overrides static for google.
+		require.Equal(t, "goog-db", merged.ByProvider["google"])
+		require.Equal(t, "https://goog.proxy", merged.BaseURLByProvider["google"])
+		// Anthropic from DB.
+		require.Equal(t, "sk-ant-db", merged.ByProvider["anthropic"])
+		require.Equal(t, "sk-ant-db", merged.Anthropic)
+	})
+
+	t.Run("WhitespaceHandling", func(t *testing.T) {
+		t.Parallel()
+		static := chatprovider.ProviderAPIKeys{
+			OpenAI: "  sk-padded  ",
+		}
+		dbProviders := []chatprovider.ConfiguredProvider{
+			{Provider: "  google  ", APIKey: "  goog-key  ", BaseURL: "  https://g.proxy  "},
+		}
+		merged := chatprovider.MergeProviderAPIKeys(static, dbProviders)
+
+		require.Equal(t, "sk-padded", merged.OpenAI)
+		require.Equal(t, "goog-key", merged.ByProvider["google"])
+		require.Equal(t, "https://g.proxy", merged.BaseURLByProvider["google"])
+	})
+
+	t.Run("InvalidProviderSkipped", func(t *testing.T) {
+		t.Parallel()
+		static := chatprovider.ProviderAPIKeys{
+			ByProvider: map[string]string{
+				"not-a-provider": "sk-invalid",
+			},
+		}
+		dbProviders := []chatprovider.ConfiguredProvider{
+			{Provider: "also-invalid", APIKey: "sk-bad"},
+		}
+		merged := chatprovider.MergeProviderAPIKeys(static, dbProviders)
+
+		require.Empty(t, merged.ByProvider)
+		require.Empty(t, merged.BaseURLByProvider)
+	})
+}
+
+func TestModelCatalog_ListConfiguredModels(t *testing.T) {
+	t.Parallel()
+
+	t.Run("EmptyModelsReturnsFalse", func(t *testing.T) {
+		t.Parallel()
+		catalog := chatprovider.NewModelCatalog(chatprovider.ProviderAPIKeys{})
+		resp, changed := catalog.ListConfiguredModels(nil, nil)
+		require.False(t, changed)
+		require.Empty(t, resp.Providers)
+	})
+
+	t.Run("SingleModel", func(t *testing.T) {
+		t.Parallel()
+		keys := chatprovider.ProviderAPIKeys{
+			ByProvider: map[string]string{"openai": "sk-test"},
+		}
+		catalog := chatprovider.NewModelCatalog(keys)
+		models := []chatprovider.ConfiguredModel{
+			{Provider: "openai", Model: "gpt-4o", DisplayName: "GPT-4o"},
+		}
+		resp, changed := catalog.ListConfiguredModels(nil, models)
+
+		require.True(t, changed)
+		require.Len(t, resp.Providers, 1)
+		require.Equal(t, "openai", resp.Providers[0].Provider)
+		require.True(t, resp.Providers[0].Available)
+		require.Len(t, resp.Providers[0].Models, 1)
+		require.Equal(t, "gpt-4o", resp.Providers[0].Models[0].Model)
+		require.Equal(t, "GPT-4o", resp.Providers[0].Models[0].DisplayName)
+		require.Equal(t, "openai:gpt-4o", resp.Providers[0].Models[0].ID)
+	})
+
+	t.Run("DuplicateModelDedup", func(t *testing.T) {
+		t.Parallel()
+		keys := chatprovider.ProviderAPIKeys{
+			ByProvider: map[string]string{"anthropic": "sk-ant"},
+		}
+		catalog := chatprovider.NewModelCatalog(keys)
+		models := []chatprovider.ConfiguredModel{
+			{Provider: "anthropic", Model: "claude-sonnet-4-20250514", DisplayName: "Claude Sonnet"},
+			{Provider: "anthropic", Model: "claude-sonnet-4-20250514", DisplayName: "Claude Sonnet Dup"},
+		}
+		resp, changed := catalog.ListConfiguredModels(nil, models)
+
+		require.True(t, changed)
+		require.Len(t, resp.Providers, 1)
+		// Only one model after dedup.
+		require.Len(t, resp.Providers[0].Models, 1)
+		require.Equal(t, "Claude Sonnet", resp.Providers[0].Models[0].DisplayName)
+	})
+
+	t.Run("ProviderOrdering", func(t *testing.T) {
+		t.Parallel()
+		keys := chatprovider.ProviderAPIKeys{
+			ByProvider: map[string]string{
+				"openai":    "sk-openai",
+				"anthropic": "sk-ant",
+			},
+		}
+		catalog := chatprovider.NewModelCatalog(keys)
+		models := []chatprovider.ConfiguredModel{
+			// Anthropic listed first, but openai should appear first
+			// in output (supportedProviderNames order: anthropic
+			// before openai is wrong, let me check).
+			{Provider: "openai", Model: "gpt-4o"},
+			{Provider: "anthropic", Model: "claude-sonnet-4-20250514"},
+		}
+		resp, changed := catalog.ListConfiguredModels(nil, models)
+
+		require.True(t, changed)
+		require.Len(t, resp.Providers, 2)
+		// supportedProviderNames order: anthropic, azure, bedrock,
+		// google, openai, openai-compat, openrouter, vercel.
+		require.Equal(t, "anthropic", resp.Providers[0].Provider)
+		require.Equal(t, "openai", resp.Providers[1].Provider)
+	})
+
+	t.Run("UnavailableWithoutKey", func(t *testing.T) {
+		t.Parallel()
+		// No API keys at all.
+		catalog := chatprovider.NewModelCatalog(chatprovider.ProviderAPIKeys{})
+		models := []chatprovider.ConfiguredModel{
+			{Provider: "openai", Model: "gpt-4o"},
+		}
+		resp, changed := catalog.ListConfiguredModels(nil, models)
+
+		require.True(t, changed)
+		require.Len(t, resp.Providers, 1)
+		require.False(t, resp.Providers[0].Available)
+		require.Equal(t,
+			codersdk.ChatModelProviderUnavailableMissingAPIKey,
+			resp.Providers[0].UnavailableReason,
+		)
+	})
+
+	t.Run("ModelsWithinProviderSorted", func(t *testing.T) {
+		t.Parallel()
+		keys := chatprovider.ProviderAPIKeys{
+			ByProvider: map[string]string{"openai": "sk-test"},
+		}
+		catalog := chatprovider.NewModelCatalog(keys)
+		models := []chatprovider.ConfiguredModel{
+			{Provider: "openai", Model: "gpt-4o"},
+			{Provider: "openai", Model: "gpt-3.5-turbo"},
+			{Provider: "openai", Model: "gpt-4o-mini"},
+		}
+		resp, changed := catalog.ListConfiguredModels(nil, models)
+
+		require.True(t, changed)
+		require.Len(t, resp.Providers[0].Models, 3)
+		require.Equal(t, "gpt-3.5-turbo", resp.Providers[0].Models[0].Model)
+		require.Equal(t, "gpt-4o", resp.Providers[0].Models[1].Model)
+		require.Equal(t, "gpt-4o-mini", resp.Providers[0].Models[2].Model)
+	})
+
+	t.Run("DisplayNameFallsBackToModel", func(t *testing.T) {
+		t.Parallel()
+		keys := chatprovider.ProviderAPIKeys{
+			ByProvider: map[string]string{"openai": "sk-test"},
+		}
+		catalog := chatprovider.NewModelCatalog(keys)
+		models := []chatprovider.ConfiguredModel{
+			{Provider: "openai", Model: "gpt-4o", DisplayName: ""},
+		}
+		resp, changed := catalog.ListConfiguredModels(nil, models)
+
+		require.True(t, changed)
+		require.Equal(t, "gpt-4o", resp.Providers[0].Models[0].DisplayName)
+	})
+
+	t.Run("ConfiguredProvidersAddedToProviderSet", func(t *testing.T) {
+		t.Parallel()
+		// Provider has a key via ConfiguredProvider but no models.
+		// Models reference the same provider, so it appears.
+		keys := chatprovider.ProviderAPIKeys{}
+		catalog := chatprovider.NewModelCatalog(keys)
+		providers := []chatprovider.ConfiguredProvider{
+			{Provider: "openai", APIKey: "sk-test"},
+		}
+		models := []chatprovider.ConfiguredModel{
+			{Provider: "openai", Model: "gpt-4o"},
+		}
+		resp, changed := catalog.ListConfiguredModels(providers, models)
+
+		require.True(t, changed)
+		require.Len(t, resp.Providers, 1)
+		require.True(t, resp.Providers[0].Available)
+	})
+
+	t.Run("CanonicalModelRef", func(t *testing.T) {
+		t.Parallel()
+		keys := chatprovider.ProviderAPIKeys{
+			ByProvider: map[string]string{"anthropic": "sk-ant"},
+		}
+		catalog := chatprovider.NewModelCatalog(keys)
+		models := []chatprovider.ConfiguredModel{
+			// Model with provider:model canonical ref.
+			{Model: "anthropic:claude-sonnet-4-20250514"},
+		}
+		resp, changed := catalog.ListConfiguredModels(nil, models)
+
+		require.True(t, changed)
+		require.Len(t, resp.Providers, 1)
+		require.Equal(t, "anthropic", resp.Providers[0].Provider)
+		require.Equal(t, "claude-sonnet-4-20250514", resp.Providers[0].Models[0].Model)
+	})
+}
+
+func TestModelCatalog_ListConfiguredProviderAvailability(t *testing.T) {
+	t.Parallel()
+
+	t.Run("AllUnavailableWithoutKeys", func(t *testing.T) {
+		t.Parallel()
+		catalog := chatprovider.NewModelCatalog(chatprovider.ProviderAPIKeys{})
+		resp := catalog.ListConfiguredProviderAvailability(nil)
+
+		// All supported providers listed.
+		require.Len(t, resp.Providers, len(chatprovider.SupportedProviders()))
+		for _, p := range resp.Providers {
+			require.False(t, p.Available, "provider %s should be unavailable", p.Provider)
+			require.Equal(t,
+				codersdk.ChatModelProviderUnavailableMissingAPIKey,
+				p.UnavailableReason,
+			)
+			// Models list is empty but non-nil.
+			require.NotNil(t, p.Models)
+			require.Empty(t, p.Models)
+		}
+	})
+
+	t.Run("StaticKeyMakesAvailable", func(t *testing.T) {
+		t.Parallel()
+		keys := chatprovider.ProviderAPIKeys{
+			OpenAI: "sk-openai",
+		}
+		catalog := chatprovider.NewModelCatalog(keys)
+		resp := catalog.ListConfiguredProviderAvailability(nil)
+
+		for _, p := range resp.Providers {
+			if p.Provider == "openai" {
+				require.True(t, p.Available)
+				require.Empty(t, p.UnavailableReason)
+			} else {
+				require.False(t, p.Available, "provider %s should be unavailable", p.Provider)
+			}
+		}
+	})
+
+	t.Run("DBProviderKeyMakesAvailable", func(t *testing.T) {
+		t.Parallel()
+		catalog := chatprovider.NewModelCatalog(chatprovider.ProviderAPIKeys{})
+		dbProviders := []chatprovider.ConfiguredProvider{
+			{Provider: "google", APIKey: "goog-key"},
+		}
+		resp := catalog.ListConfiguredProviderAvailability(dbProviders)
+
+		for _, p := range resp.Providers {
+			if p.Provider == "google" {
+				require.True(t, p.Available)
+			} else {
+				require.False(t, p.Available, "provider %s should be unavailable", p.Provider)
+			}
+		}
+	})
+
+	t.Run("MultipleKeysAvailable", func(t *testing.T) {
+		t.Parallel()
+		keys := chatprovider.ProviderAPIKeys{
+			OpenAI:    "sk-openai",
+			Anthropic: "sk-anthropic",
+		}
+		catalog := chatprovider.NewModelCatalog(keys)
+		dbProviders := []chatprovider.ConfiguredProvider{
+			{Provider: "google", APIKey: "goog-key"},
+		}
+		resp := catalog.ListConfiguredProviderAvailability(dbProviders)
+
+		available := map[string]bool{}
+		for _, p := range resp.Providers {
+			available[p.Provider] = p.Available
+		}
+		require.True(t, available["openai"])
+		require.True(t, available["anthropic"])
+		require.True(t, available["google"])
+		require.False(t, available["azure"])
+		require.False(t, available["bedrock"])
+	})
 }

--- a/coderd/x/chatd/chatprovider/chatprovider_test.go
+++ b/coderd/x/chatd/chatprovider/chatprovider_test.go
@@ -869,6 +869,8 @@ func TestModelFromConfig_NilExtraHeaders(t *testing.T) {
 	})
 	require.NoError(t, err)
 	_ = testutil.TryReceive(ctx, t, called)
+}
+
 func TestSupportedProviders(t *testing.T) {
 	t.Parallel()
 
@@ -1631,22 +1633,23 @@ func TestModelCatalog_ListConfiguredModels(t *testing.T) {
 
 	t.Run("EmptyModelsReturnsFalse", func(t *testing.T) {
 		t.Parallel()
-		catalog := chatprovider.NewModelCatalog(chatprovider.ProviderAPIKeys{})
-		resp, changed := catalog.ListConfiguredModels(nil, nil)
+		catalog := chatprovider.NewModelCatalog()
+		resp, changed := catalog.ListConfiguredModels(nil, nil, nil, nil)
 		require.False(t, changed)
 		require.Empty(t, resp.Providers)
 	})
 
 	t.Run("SingleModel", func(t *testing.T) {
 		t.Parallel()
-		keys := chatprovider.ProviderAPIKeys{
-			ByProvider: map[string]string{"openai": "sk-test"},
-		}
-		catalog := chatprovider.NewModelCatalog(keys)
+		catalog := chatprovider.NewModelCatalog()
 		models := []chatprovider.ConfiguredModel{
 			{Provider: "openai", Model: "gpt-4o", DisplayName: "GPT-4o"},
 		}
-		resp, changed := catalog.ListConfiguredModels(nil, models)
+		availability := map[string]chatprovider.ProviderAvailability{
+			"openai": {Available: true},
+		}
+		enabled := map[string]struct{}{"openai": {}}
+		resp, changed := catalog.ListConfiguredModels(nil, models, availability, enabled)
 
 		require.True(t, changed)
 		require.Len(t, resp.Providers, 1)
@@ -1660,15 +1663,16 @@ func TestModelCatalog_ListConfiguredModels(t *testing.T) {
 
 	t.Run("DuplicateModelDedup", func(t *testing.T) {
 		t.Parallel()
-		keys := chatprovider.ProviderAPIKeys{
-			ByProvider: map[string]string{"anthropic": "sk-ant"},
-		}
-		catalog := chatprovider.NewModelCatalog(keys)
+		catalog := chatprovider.NewModelCatalog()
 		models := []chatprovider.ConfiguredModel{
 			{Provider: "anthropic", Model: "claude-sonnet-4-20250514", DisplayName: "Claude Sonnet"},
 			{Provider: "anthropic", Model: "claude-sonnet-4-20250514", DisplayName: "Claude Sonnet Dup"},
 		}
-		resp, changed := catalog.ListConfiguredModels(nil, models)
+		availability := map[string]chatprovider.ProviderAvailability{
+			"anthropic": {Available: true},
+		}
+		enabled := map[string]struct{}{"anthropic": {}}
+		resp, changed := catalog.ListConfiguredModels(nil, models, availability, enabled)
 
 		require.True(t, changed)
 		require.Len(t, resp.Providers, 1)
@@ -1679,13 +1683,7 @@ func TestModelCatalog_ListConfiguredModels(t *testing.T) {
 
 	t.Run("ProviderOrdering", func(t *testing.T) {
 		t.Parallel()
-		keys := chatprovider.ProviderAPIKeys{
-			ByProvider: map[string]string{
-				"openai":    "sk-openai",
-				"anthropic": "sk-ant",
-			},
-		}
-		catalog := chatprovider.NewModelCatalog(keys)
+		catalog := chatprovider.NewModelCatalog()
 		models := []chatprovider.ConfiguredModel{
 			// Anthropic listed first, but openai should appear first
 			// in output (supportedProviderNames order: anthropic
@@ -1693,7 +1691,12 @@ func TestModelCatalog_ListConfiguredModels(t *testing.T) {
 			{Provider: "openai", Model: "gpt-4o"},
 			{Provider: "anthropic", Model: "claude-sonnet-4-20250514"},
 		}
-		resp, changed := catalog.ListConfiguredModels(nil, models)
+		availability := map[string]chatprovider.ProviderAvailability{
+			"openai":    {Available: true},
+			"anthropic": {Available: true},
+		}
+		enabled := map[string]struct{}{"openai": {}, "anthropic": {}}
+		resp, changed := catalog.ListConfiguredModels(nil, models, availability, enabled)
 
 		require.True(t, changed)
 		require.Len(t, resp.Providers, 2)
@@ -1705,12 +1708,13 @@ func TestModelCatalog_ListConfiguredModels(t *testing.T) {
 
 	t.Run("UnavailableWithoutKey", func(t *testing.T) {
 		t.Parallel()
-		// No API keys at all.
-		catalog := chatprovider.NewModelCatalog(chatprovider.ProviderAPIKeys{})
+		// No API keys at all, but provider is enabled.
+		catalog := chatprovider.NewModelCatalog()
 		models := []chatprovider.ConfiguredModel{
 			{Provider: "openai", Model: "gpt-4o"},
 		}
-		resp, changed := catalog.ListConfiguredModels(nil, models)
+		enabled := map[string]struct{}{"openai": {}}
+		resp, changed := catalog.ListConfiguredModels(nil, models, nil, enabled)
 
 		require.True(t, changed)
 		require.Len(t, resp.Providers, 1)
@@ -1723,16 +1727,17 @@ func TestModelCatalog_ListConfiguredModels(t *testing.T) {
 
 	t.Run("ModelsWithinProviderSorted", func(t *testing.T) {
 		t.Parallel()
-		keys := chatprovider.ProviderAPIKeys{
-			ByProvider: map[string]string{"openai": "sk-test"},
-		}
-		catalog := chatprovider.NewModelCatalog(keys)
+		catalog := chatprovider.NewModelCatalog()
 		models := []chatprovider.ConfiguredModel{
 			{Provider: "openai", Model: "gpt-4o"},
 			{Provider: "openai", Model: "gpt-3.5-turbo"},
 			{Provider: "openai", Model: "gpt-4o-mini"},
 		}
-		resp, changed := catalog.ListConfiguredModels(nil, models)
+		availability := map[string]chatprovider.ProviderAvailability{
+			"openai": {Available: true},
+		}
+		enabled := map[string]struct{}{"openai": {}}
+		resp, changed := catalog.ListConfiguredModels(nil, models, availability, enabled)
 
 		require.True(t, changed)
 		require.Len(t, resp.Providers[0].Models, 3)
@@ -1743,14 +1748,15 @@ func TestModelCatalog_ListConfiguredModels(t *testing.T) {
 
 	t.Run("DisplayNameFallsBackToModel", func(t *testing.T) {
 		t.Parallel()
-		keys := chatprovider.ProviderAPIKeys{
-			ByProvider: map[string]string{"openai": "sk-test"},
-		}
-		catalog := chatprovider.NewModelCatalog(keys)
+		catalog := chatprovider.NewModelCatalog()
 		models := []chatprovider.ConfiguredModel{
 			{Provider: "openai", Model: "gpt-4o", DisplayName: ""},
 		}
-		resp, changed := catalog.ListConfiguredModels(nil, models)
+		availability := map[string]chatprovider.ProviderAvailability{
+			"openai": {Available: true},
+		}
+		enabled := map[string]struct{}{"openai": {}}
+		resp, changed := catalog.ListConfiguredModels(nil, models, availability, enabled)
 
 		require.True(t, changed)
 		require.Equal(t, "gpt-4o", resp.Providers[0].Models[0].DisplayName)
@@ -1760,15 +1766,18 @@ func TestModelCatalog_ListConfiguredModels(t *testing.T) {
 		t.Parallel()
 		// Provider has a key via ConfiguredProvider but no models.
 		// Models reference the same provider, so it appears.
-		keys := chatprovider.ProviderAPIKeys{}
-		catalog := chatprovider.NewModelCatalog(keys)
+		catalog := chatprovider.NewModelCatalog()
 		providers := []chatprovider.ConfiguredProvider{
 			{Provider: "openai", APIKey: "sk-test"},
 		}
 		models := []chatprovider.ConfiguredModel{
 			{Provider: "openai", Model: "gpt-4o"},
 		}
-		resp, changed := catalog.ListConfiguredModels(providers, models)
+		availability := map[string]chatprovider.ProviderAvailability{
+			"openai": {Available: true},
+		}
+		enabled := map[string]struct{}{"openai": {}}
+		resp, changed := catalog.ListConfiguredModels(providers, models, availability, enabled)
 
 		require.True(t, changed)
 		require.Len(t, resp.Providers, 1)
@@ -1777,15 +1786,16 @@ func TestModelCatalog_ListConfiguredModels(t *testing.T) {
 
 	t.Run("CanonicalModelRef", func(t *testing.T) {
 		t.Parallel()
-		keys := chatprovider.ProviderAPIKeys{
-			ByProvider: map[string]string{"anthropic": "sk-ant"},
-		}
-		catalog := chatprovider.NewModelCatalog(keys)
+		catalog := chatprovider.NewModelCatalog()
 		models := []chatprovider.ConfiguredModel{
 			// Model with provider:model canonical ref.
 			{Model: "anthropic:claude-sonnet-4-20250514"},
 		}
-		resp, changed := catalog.ListConfiguredModels(nil, models)
+		availability := map[string]chatprovider.ProviderAvailability{
+			"anthropic": {Available: true},
+		}
+		enabled := map[string]struct{}{"anthropic": {}}
+		resp, changed := catalog.ListConfiguredModels(nil, models, availability, enabled)
 
 		require.True(t, changed)
 		require.Len(t, resp.Providers, 1)
@@ -1799,8 +1809,9 @@ func TestModelCatalog_ListConfiguredProviderAvailability(t *testing.T) {
 
 	t.Run("AllUnavailableWithoutKeys", func(t *testing.T) {
 		t.Parallel()
-		catalog := chatprovider.NewModelCatalog(chatprovider.ProviderAPIKeys{})
-		resp := catalog.ListConfiguredProviderAvailability(nil)
+		catalog := chatprovider.NewModelCatalog()
+		allProviders := allSupportedEnabled()
+		resp := catalog.ListConfiguredProviderAvailability(nil, allProviders)
 
 		// All supported providers listed.
 		require.Len(t, resp.Providers, len(chatprovider.SupportedProviders()))
@@ -1818,11 +1829,12 @@ func TestModelCatalog_ListConfiguredProviderAvailability(t *testing.T) {
 
 	t.Run("StaticKeyMakesAvailable", func(t *testing.T) {
 		t.Parallel()
-		keys := chatprovider.ProviderAPIKeys{
-			OpenAI: "sk-openai",
+		availability := map[string]chatprovider.ProviderAvailability{
+			"openai": {Available: true},
 		}
-		catalog := chatprovider.NewModelCatalog(keys)
-		resp := catalog.ListConfiguredProviderAvailability(nil)
+		catalog := chatprovider.NewModelCatalog()
+		allProviders := allSupportedEnabled()
+		resp := catalog.ListConfiguredProviderAvailability(availability, allProviders)
 
 		for _, p := range resp.Providers {
 			if p.Provider == "openai" {
@@ -1836,11 +1848,12 @@ func TestModelCatalog_ListConfiguredProviderAvailability(t *testing.T) {
 
 	t.Run("DBProviderKeyMakesAvailable", func(t *testing.T) {
 		t.Parallel()
-		catalog := chatprovider.NewModelCatalog(chatprovider.ProviderAPIKeys{})
-		dbProviders := []chatprovider.ConfiguredProvider{
-			{Provider: "google", APIKey: "goog-key"},
+		availability := map[string]chatprovider.ProviderAvailability{
+			"google": {Available: true},
 		}
-		resp := catalog.ListConfiguredProviderAvailability(dbProviders)
+		catalog := chatprovider.NewModelCatalog()
+		allProviders := allSupportedEnabled()
+		resp := catalog.ListConfiguredProviderAvailability(availability, allProviders)
 
 		for _, p := range resp.Providers {
 			if p.Provider == "google" {
@@ -1853,15 +1866,14 @@ func TestModelCatalog_ListConfiguredProviderAvailability(t *testing.T) {
 
 	t.Run("MultipleKeysAvailable", func(t *testing.T) {
 		t.Parallel()
-		keys := chatprovider.ProviderAPIKeys{
-			OpenAI:    "sk-openai",
-			Anthropic: "sk-anthropic",
+		availability := map[string]chatprovider.ProviderAvailability{
+			"openai":    {Available: true},
+			"anthropic": {Available: true},
+			"google":    {Available: true},
 		}
-		catalog := chatprovider.NewModelCatalog(keys)
-		dbProviders := []chatprovider.ConfiguredProvider{
-			{Provider: "google", APIKey: "goog-key"},
-		}
-		resp := catalog.ListConfiguredProviderAvailability(dbProviders)
+		catalog := chatprovider.NewModelCatalog()
+		allProviders := allSupportedEnabled()
+		resp := catalog.ListConfiguredProviderAvailability(availability, allProviders)
 
 		available := map[string]bool{}
 		for _, p := range resp.Providers {
@@ -1873,4 +1885,14 @@ func TestModelCatalog_ListConfiguredProviderAvailability(t *testing.T) {
 		require.False(t, available["azure"])
 		require.False(t, available["bedrock"])
 	})
+}
+
+// allSupportedEnabled returns an enabled set containing all supported
+// providers, useful for tests that want every provider visible.
+func allSupportedEnabled() map[string]struct{} {
+	m := make(map[string]struct{})
+	for _, p := range chatprovider.SupportedProviders() {
+		m[p] = struct{}{}
+	}
+	return m
 }


### PR DESCRIPTION
## What

Adds ~30 test functions covering the chatprovider package, which was at 19.9% coverage. Tests cover string classification, model resolution, enum normalization, ProviderAPIKeys methods, model catalog operations, and per-provider option converters (Anthropic, Google, OpenAI-compat, OpenRouter, Vercel).

## Coverage

chatprovider: **19.9% → 58.7%**. 33 functions now at 100%.

Remaining 0% functions are OpenAI-specific helpers (`openAIProviderOptionsFromChatConfig`, `ProviderOptionsFromChatModelConfig`, `openAIResponsesLogProbsFromChat`, etc.) and `MergeMissingModelCostConfig`. These need a `LanguageModel` interface mock or more complex setup.

## Structure

- `chatprovider_test.go` (external): exported function tests (Groups A-E)
- `chatprovider_internal_test.go` (internal): unexported function tests (Groups G + helpers)

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻