### PR TITLE
fix(scripts): fix Windows version format for RC builds

### DIFF
--- a/scripts/build_go.sh
+++ b/scripts/build_go.sh
@@ -209,7 +209,7 @@ if [[ "$windows_resources" == 1 ]] && [[ "$os" == "windows" ]]; then
 	# Remove any trailing data after a "+" or "-".
 	version_windows=$version
 	version_windows="${version_windows%+*}"
-	version_windows="${version_windows%-*}"
+	version_windows="${version_windows%%-*}"
 	# If there wasn't any extra data, add a .0 to the version. Otherwise, add
 	# a .1 to the version to signify that this is not a release build so it can
 	# be distinguished from a release build.


### PR DESCRIPTION
## Summary

The `build` CI job on `main` is failing with:

```
ERROR: Computed invalid windows version format: 2.32.0-rc.0.1
```

This started when the `v2.32.0-rc.0` tag was created, making `git describe` produce versions like `2.32.0-rc.0-devel+4f571f8ff`.

## Root cause

`scripts/build_go.sh` converts the version to a Windows-compatible `X.Y.Z.{0,1}` format by stripping pre-release segments. It uses `${var%-*}` (shortest suffix match), which only removes the last `-segment`. For RC versions this leaves `-rc.0` intact:

```
2.32.0-rc.0-devel  →  strip %-*  →  2.32.0-rc.0  →  + .1  →  2.32.0-rc.0.1  ✗
```

## Fix

Switch to `${var%%-*}` (longest suffix match) so all pre-release segments are stripped from the first hyphen onward:

```
2.32.0-rc.0-devel  →  strip %%-*  →  2.32.0  →  + .1  →  2.32.0.1  ✓
```

Verified all version patterns produce valid output:

| Input | Output |
|---|---|
| `2.32.0` | `2.32.0.0` |
| `2.32.0-devel` | `2.32.0.1` |
| `2.32.0-rc.0-devel` | `2.32.0.1` |
| `2.32.0-rc.0` | `2.32.0.1` |

Fixes https://github.com/coder/coder/actions/runs/23511163474/job/68434008241