### PR TITLE
fix: support xhigh reasoning effort for OpenAI models

### DIFF
--- a/coderd/x/chatd/chatprovider/chatprovider.go
+++ b/coderd/x/chatd/chatprovider/chatprovider.go
@@ -487,6 +487,7 @@ func ReasoningEffortFromChat(provider string, value *string) *string {
 			string(fantasyopenai.ReasoningEffortLow),
 			string(fantasyopenai.ReasoningEffortMedium),
 			string(fantasyopenai.ReasoningEffortHigh),
+			string(fantasyopenai.ReasoningEffortXHigh),
 		)
 	case fantasyanthropic.Name:
 		return normalizedEnumValue(

--- a/coderd/x/chatd/chatprovider/chatprovider_test.go
+++ b/coderd/x/chatd/chatprovider/chatprovider_test.go
@@ -30,6 +30,12 @@ func TestReasoningEffortFromChat(t *testing.T) {
 			want:     ptr.Ref(string(fantasyopenai.ReasoningEffortHigh)),
 		},
 		{
+			name:     "OpenAIXHighEffort",
+			provider: "openai",
+			input:    ptr.Ref("xhigh"),
+			want:     ptr.Ref(string(fantasyopenai.ReasoningEffortXHigh)),
+		},
+		{
 			name:     "AnthropicEffort",
 			provider: "anthropic",
 			input:    ptr.Ref("max"),

--- a/go.mod
+++ b/go.mod
@@ -80,7 +80,7 @@ replace github.com/spf13/afero => github.com/aslilac/afero v0.0.0-20250403163713
 // 1) Anthropic computer use + thinking effort
 // 2) Go 1.25 downgrade for Windows CI compat
 // 3) ibetitsmike/fantasy#4 — skip ephemeral replay items when store=false
-replace charm.land/fantasy => github.com/kylecarbs/fantasy v0.0.0-20260320175225-7bcfc3d2021a
+replace charm.land/fantasy => github.com/kylecarbs/fantasy v0.0.0-20260325000648-9d7e25c63746
 
 replace github.com/charmbracelet/anthropic-sdk-go => github.com/kylecarbs/anthropic-sdk-go v0.0.0-20260223140439-63879b0b8dab
 

--- a/go.sum
+++ b/go.sum
@@ -813,8 +813,8 @@ github.com/kylecarbs/anthropic-sdk-go v0.0.0-20260223140439-63879b0b8dab h1:5UMY
 github.com/kylecarbs/anthropic-sdk-go v0.0.0-20260223140439-63879b0b8dab/go.mod h1:hqlYqR7uPKOKfnNeicUbZp0Ps0GeYFlKYtwh5HGDCx8=
 github.com/kylecarbs/chroma/v2 v2.0.0-20240401211003-9e036e0631f3 h1:Z9/bo5PSeMutpdiKYNt/TTSfGM1Ll0naj3QzYX9VxTc=
 github.com/kylecarbs/chroma/v2 v2.0.0-20240401211003-9e036e0631f3/go.mod h1:BUGjjsD+ndS6eX37YgTchSEG+Jg9Jv1GiZs9sqPqztk=
-github.com/kylecarbs/fantasy v0.0.0-20260320175225-7bcfc3d2021a h1:0BNb2AYtzWYH0xAscOICIRInvQylXlF2tuxOjmWhlvE=
-github.com/kylecarbs/fantasy v0.0.0-20260320175225-7bcfc3d2021a/go.mod h1:I/i6LkVAWnSVdFZ37SbcR0IZz6eBhu4P9IK3XHTX6Gk=
+github.com/kylecarbs/fantasy v0.0.0-20260325000648-9d7e25c63746 h1:8ZQH2tg/ALSAvzx5pXMdXZcquoe+oWf9KSNopND8GI8=
+github.com/kylecarbs/fantasy v0.0.0-20260325000648-9d7e25c63746/go.mod h1:I/i6LkVAWnSVdFZ37SbcR0IZz6eBhu4P9IK3XHTX6Gk=
 github.com/kylecarbs/openai-go/v3 v3.0.0-20260319113850-9477dcaedcae h1:xlFZNX4nnxpj9Cf6mTwD3pirXGNtBJ/6COsf9iZmsL0=
 github.com/kylecarbs/openai-go/v3 v3.0.0-20260319113850-9477dcaedcae/go.mod h1:cdufnVK14cWcT9qA1rRtrXx4FTRsgbDPW7Ia7SS5cZo=
 github.com/kylecarbs/spinner v1.18.2-0.20220329160715-20702b5af89e h1:OP0ZMFeZkUnOzTFRfpuK3m7Kp4fNvC6qN+exwj7aI4M=


### PR DESCRIPTION
## Summary

Adds `xhigh` to the OpenAI reasoning effort normalizer so GPT-5.4 class models can use `reasoning_effort: xhigh` without it being silently dropped.

## Problem

The SDK schema (`codersdk/chats.go`) already advertises `xhigh` as a valid `reasoning_effort` value, but the runtime normalizer in `chatprovider.go` only accepts `minimal|low|medium|high` for the OpenAI provider. When a user sets `xhigh`, `ReasoningEffortFromChat()` returns `nil` and the value never reaches the OpenAI API.

## Changes

- **Fantasy dependency**: Updated `kylecarbs/fantasy` (cj/go1.25) which now includes the `ReasoningEffortXHigh` constant ([kylecarbs/fantasy#9](https://github.com/kylecarbs/fantasy/pull/9)).
- **`chatprovider.go`**: Adds `fantasyopenai.ReasoningEffortXHigh` to the OpenAI case in `ReasoningEffortFromChat()`.
- **`chatprovider_test.go`**: Adds `OpenAIXHighEffort` test case.

## Upstream

- [charmbracelet/fantasy#186](https://github.com/charmbracelet/fantasy/pull/186)