### PR TITLE
refactor(site/src/pages/AgentsPage): remove dead typeof window checks

### DIFF
--- a/site/src/pages/AgentsPage/AgentCreatePage.tsx
+++ b/site/src/pages/AgentsPage/AgentCreatePage.tsx
@@ -66,14 +66,11 @@ const AgentCreatePage: FC = () => {
 				mcpServerIds && mcpServerIds.length > 0 ? mcpServerIds : undefined,
 		});
 
-		if (typeof window !== "undefined") {
-			if (modelConfigID !== nilUUID) {
-				localStorage.setItem(lastModelConfigIDStorageKey, modelConfigID);
-			} else {
-				localStorage.removeItem(lastModelConfigIDStorageKey);
-			}
+		if (modelConfigID !== nilUUID) {
+			localStorage.setItem(lastModelConfigIDStorageKey, modelConfigID);
+		} else {
+			localStorage.removeItem(lastModelConfigIDStorageKey);
 		}
-
 		navigate(`/agents/${createdChat.id}`);
 	};
 

--- a/site/src/pages/AgentsPage/AgentDetail.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.tsx
@@ -184,7 +184,7 @@ export function useConversationEditingState(deps: {
 			chatInputRef.current?.focus();
 		}
 		inputValueRef.current = "";
-		if (typeof window !== "undefined" && draftStorageKey) {
+		if (draftStorageKey) {
 			localStorage.removeItem(draftStorageKey);
 		}
 		if (editingMessageId !== null) {
@@ -202,7 +202,7 @@ export function useConversationEditingState(deps: {
 
 	const handleContentChange = (content: string) => {
 		inputValueRef.current = content;
-		if (typeof window !== "undefined" && draftStorageKey) {
+		if (draftStorageKey) {
 			if (content) {
 				localStorage.setItem(draftStorageKey, content);
 			} else {
@@ -268,7 +268,7 @@ const AgentDetail: FC = () => {
 	const scrollContainerRef = useRef<HTMLDivElement | null>(null);
 	const chatInputRef = useRef<ChatMessageInputRef | null>(null);
 	const inputValueRef = useRef(
-		typeof window !== "undefined" && agentId
+		agentId
 			? (localStorage.getItem(`${draftInputStorageKeyPrefix}${agentId}`) ?? "")
 			: "",
 	);
@@ -277,7 +277,6 @@ const AgentDetail: FC = () => {
 	// skeleton and the loaded view share the same layout, preventing
 	// a horizontal shift when data arrives.
 	const [showSidebarPanel, setShowSidebarPanel] = useState(() => {
-		if (typeof window === "undefined") return false;
 		return localStorage.getItem(RIGHT_PANEL_OPEN_KEY) === "true";
 	});
 	const handleSetShowSidebarPanel = (
@@ -285,9 +284,7 @@ const AgentDetail: FC = () => {
 	) => {
 		setShowSidebarPanel((prev) => {
 			const value = typeof next === "function" ? next(prev) : next;
-			if (typeof window !== "undefined") {
-				localStorage.setItem(RIGHT_PANEL_OPEN_KEY, String(value));
-			}
+			localStorage.setItem(RIGHT_PANEL_OPEN_KEY, String(value));
 			return value;
 		});
 	};
@@ -681,15 +678,10 @@ const AgentDetail: FC = () => {
 		if (!response.queued && response.message) {
 			store.upsertDurableMessage(response.message);
 		}
-		if (typeof window !== "undefined") {
-			if (selectedModelConfigID) {
-				localStorage.setItem(
-					lastModelConfigIDStorageKey,
-					selectedModelConfigID,
-				);
-			} else {
-				localStorage.removeItem(lastModelConfigIDStorageKey);
-			}
+		if (selectedModelConfigID) {
+			localStorage.setItem(lastModelConfigIDStorageKey, selectedModelConfigID);
+		} else {
+			localStorage.removeItem(lastModelConfigIDStorageKey);
 		}
 	};
 

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -328,7 +328,7 @@ const AgentsPage: FC = () => {
 		// Only clear the draft when the user is already on the empty
 		// state and explicitly requests a blank slate.  When navigating
 		// back from a conversation the existing draft is preserved.
-		if (typeof window !== "undefined" && !agentId) {
+		if (!agentId) {
 			localStorage.removeItem(emptyInputStorageKey);
 		}
 		navigate("/agents");

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -67,9 +67,6 @@ export type CreateChatOptions = {
  */
 export function useEmptyStateDraft() {
 	const [initialInputValue] = useState(() => {
-		if (typeof window === "undefined") {
-			return "";
-		}
 		return localStorage.getItem(emptyInputStorageKey) ?? "";
 	});
 	const inputValueRef = useRef(initialInputValue);
@@ -77,7 +74,7 @@ export function useEmptyStateDraft() {
 
 	const handleContentChange = (content: string) => {
 		inputValueRef.current = content;
-		if (typeof window !== "undefined" && !sentRef.current) {
+		if (!sentRef.current) {
 			if (content) {
 				localStorage.setItem(emptyInputStorageKey, content);
 			} else {
@@ -139,9 +136,6 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 	const { initialInputValue, handleContentChange, submitDraft, resetDraft } =
 		useEmptyStateDraft();
 	const [initialLastModelConfigID] = useState(() => {
-		if (typeof window === "undefined") {
-			return "";
-		}
 		return localStorage.getItem(lastModelConfigIDStorageKey) ?? "";
 	});
 	const modelIDByConfigID = (() => {
@@ -197,7 +191,6 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 	const workspacesQuery = useQuery(workspaces({ q: "owner:me", limit: 0 }));
 	const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(
 		() => {
-			if (typeof window === "undefined") return null;
 			return localStorage.getItem(selectedWorkspaceIdStorageKey) || null;
 		},
 	);
@@ -223,9 +216,6 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 			: "No models configured. Ask an admin.";
 
 	useEffect(() => {
-		if (typeof window === "undefined") {
-			return;
-		}
 		if (!initialLastModelConfigID) {
 			return;
 		}
@@ -262,15 +252,11 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 	const handleWorkspaceChange = (value: string) => {
 		if (value === autoCreateWorkspaceValue) {
 			setSelectedWorkspaceId(null);
-			if (typeof window !== "undefined") {
-				localStorage.removeItem(selectedWorkspaceIdStorageKey);
-			}
+			localStorage.removeItem(selectedWorkspaceIdStorageKey);
 			return;
 		}
 		setSelectedWorkspaceId(value);
-		if (typeof window !== "undefined") {
-			localStorage.setItem(selectedWorkspaceIdStorageKey, value);
-		}
+		localStorage.setItem(selectedWorkspaceIdStorageKey, value);
 	};
 
 	const handleModelChange = (value: string) => {

--- a/site/src/pages/AgentsPage/components/AgentsSkeletons.tsx
+++ b/site/src/pages/AgentsPage/components/AgentsSkeletons.tsx
@@ -10,9 +10,6 @@ const MIN_PANEL_WIDTH = 360;
 
 /** Read persisted right-panel state for use in static skeletons. */
 function getRightPanelState(): { open: boolean; width: number } {
-	if (typeof window === "undefined") {
-		return { open: false, width: DEFAULT_PANEL_WIDTH };
-	}
 	const open = localStorage.getItem(RIGHT_PANEL_OPEN_KEY) === "true";
 	const stored = localStorage.getItem(RIGHT_PANEL_WIDTH_KEY);
 	let width = DEFAULT_PANEL_WIDTH;

--- a/site/src/pages/AgentsPage/components/DiffViewer/DiffViewer.tsx
+++ b/site/src/pages/AgentsPage/components/DiffViewer/DiffViewer.tsx
@@ -122,9 +122,6 @@ export type DiffStyle = "unified" | "split";
 const DIFF_STYLE_KEY = "agents.diff-view-style";
 
 export function loadDiffStyle(): DiffStyle {
-	if (typeof window === "undefined") {
-		return "unified";
-	}
 	const stored = localStorage.getItem(DIFF_STYLE_KEY);
 	if (stored === "split" || stored === "unified") {
 		return stored;

--- a/site/src/pages/AgentsPage/components/RightPanel/RightPanel.tsx
+++ b/site/src/pages/AgentsPage/components/RightPanel/RightPanel.tsx
@@ -15,16 +15,10 @@ const DEFAULT_WIDTH = 480;
 const SNAP_THRESHOLD = 80;
 
 function getMaxWidth(): number {
-	if (typeof window === "undefined") {
-		return 960;
-	}
 	return Math.max(MIN_WIDTH, Math.floor(window.innerWidth * MAX_WIDTH_RATIO));
 }
 
 function loadPersistedWidth(): number {
-	if (typeof window === "undefined") {
-		return DEFAULT_WIDTH;
-	}
 	const stored = localStorage.getItem(STORAGE_KEY);
 	if (!stored) {
 		return DEFAULT_WIDTH;
@@ -228,9 +222,7 @@ export const RightPanel = ({
 	});
 
 	useEffect(() => {
-		if (typeof window !== "undefined") {
-			localStorage.setItem(STORAGE_KEY, String(width));
-		}
+		localStorage.setItem(STORAGE_KEY, String(width));
 	}, [width]);
 
 	return (


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

This is a Vite SPA with no server-side rendering, so `window` is always
defined. Every `typeof window !== "undefined"` / `=== "undefined"` check in
the AgentsPage tree was guarding `localStorage` or `window.innerWidth` calls
unnecessarily. Removes 17 occurrences across 7 files with no behavioral
change.