### PR TITLE
ci: pin coder/create-task-action checkout to commit SHA

### DIFF
--- a/.github/workflows/classify-issue-severity.yml
+++ b/.github/workflows/classify-issue-severity.yml
@@ -222,7 +222,7 @@ jobs:
           fetch-depth: 1
           path: ./.github/actions/create-task-action
           persist-credentials: false
-          ref: main
+          ref: a89819fd195cf920224a3236eb05ff02e23bcbc5 # main
           repository: coder/create-task-action
 
       - name: Create Coder Task for Severity Classification

--- a/.github/workflows/code-review.yaml
+++ b/.github/workflows/code-review.yaml
@@ -206,7 +206,7 @@ jobs:
           fetch-depth: 1
           path: ./.github/actions/create-task-action
           persist-credentials: false
-          ref: main
+          ref: a89819fd195cf920224a3236eb05ff02e23bcbc5 # main
           repository: coder/create-task-action
 
       - name: Create Coder Task for Code Review

--- a/.github/workflows/doc-check.yaml
+++ b/.github/workflows/doc-check.yaml
@@ -234,7 +234,7 @@ jobs:
           fetch-depth: 1
           path: ./.github/actions/create-task-action
           persist-credentials: false
-          ref: main
+          ref: a89819fd195cf920224a3236eb05ff02e23bcbc5 # main
           repository: coder/create-task-action
 
       - name: Create Coder Task for Documentation Check

--- a/.github/workflows/traiage.yaml
+++ b/.github/workflows/traiage.yaml
@@ -160,7 +160,7 @@ jobs:
           fetch-depth: 1
           path: ./.github/actions/create-task-action
           persist-credentials: false
-          ref: main
+          ref: a89819fd195cf920224a3236eb05ff02e23bcbc5 # main
           repository: coder/create-task-action
 
       - name: Create Coder Task


### PR DESCRIPTION
## Summary

- Four AI-automation workflows (`code-review`, `traiage`, `classify-issue-severity`, `doc-check`) checked out `coder/create-task-action` at the mutable ref `ref: main`
- A single malicious commit to that repo's main branch would execute with access to `GITHUB_TOKEN` and the Coder session tokens passed to the action
- Pinned all four to the current HEAD SHA (`a89819fd195cf920224a3236eb05ff02e23bcbc5`) so future runs are deterministic

**Affected workflows:**
- `.github/workflows/code-review.yaml`
- `.github/workflows/traiage.yaml`
- `.github/workflows/classify-issue-severity.yml`
- `.github/workflows/doc-check.yaml`

**Note:** When `coder/create-task-action` is updated, bump this SHA accordingly.

## Test plan

- [ ] Verify AI code review still triggers on `code-review` label
- [ ] Verify triage still triggers on `traiage` label
- [ ] Verify severity classification still triggers on `triage-check` label
- [ ] Verify doc-check still triggers as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)