### PR TITLE
fix(site): collapse token columns in agent usage table

### DIFF
--- a/site/src/pages/AgentsPage/AgentSettingsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsPageView.tsx
@@ -17,12 +17,7 @@ import type * as TypesGen from "api/typesGenerated";
 import dayjs from "dayjs";
 import { useDebouncedValue } from "hooks/debounce";
 import { useClickableTableRow } from "hooks/useClickableTableRow";
-import {
-	ArrowDownIcon,
-	ArrowUpIcon,
-	ChevronLeftIcon,
-	ShieldIcon,
-} from "lucide-react";
+import { ChevronLeftIcon, ShieldIcon } from "lucide-react";
 import { type FC, type FormEvent, useState } from "react";
 import {
 	keepPreviousData,
@@ -32,7 +27,6 @@ import {
 } from "react-query";
 import { useSearchParams } from "react-router";
 import TextareaAutosize from "react-textarea-autosize";
-import { formatTokenCount } from "utils/analytics";
 import { cn } from "utils/cn";
 import { formatCostMicros } from "utils/currency";
 import { AvatarData } from "#/components/Avatar/AvatarData";
@@ -57,7 +51,10 @@ import {
 	TooltipProvider,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
-import { ChatCostSummaryView } from "./components/ChatCostSummaryView";
+import {
+	ChatCostSummaryView,
+	TokensCell,
+} from "./components/ChatCostSummaryView";
 import { ChatModelAdminPanel } from "./components/ChatModelAdminPanel/ChatModelAdminPanel";
 import {
 	DateRangePicker,
@@ -144,43 +141,12 @@ const UserRow: FC<{
 			<TableCell>{user.message_count.toLocaleString()}</TableCell>
 			<TableCell>{user.chat_count.toLocaleString()}</TableCell>
 			<TableCell>
-				<TooltipProvider delayDuration={0}>
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<span className="inline-flex items-center gap-1 whitespace-nowrap">
-								<span className="inline-flex items-center gap-0.5">
-									<ArrowDownIcon className="h-3 w-3" />
-									{formatTokenCount(user.total_input_tokens)}
-								</span>
-								<span className="text-content-secondary">/</span>
-								<span className="inline-flex items-center gap-0.5">
-									<ArrowUpIcon className="h-3 w-3" />
-									{formatTokenCount(user.total_output_tokens)}
-								</span>
-							</span>
-						</TooltipTrigger>
-						<TooltipContent side="top">
-							<div className="grid grid-cols-[auto_auto] gap-x-3 gap-y-1 text-xs">
-								<span className="text-content-secondary">Input</span>
-								<span className="text-right font-mono">
-									{user.total_input_tokens.toLocaleString()}
-								</span>
-								<span className="text-content-secondary">Output</span>
-								<span className="text-right font-mono">
-									{user.total_output_tokens.toLocaleString()}
-								</span>
-								<span className="text-content-secondary">Cache read</span>
-								<span className="text-right font-mono">
-									{user.total_cache_read_tokens.toLocaleString()}
-								</span>
-								<span className="text-content-secondary">Cache write</span>
-								<span className="text-right font-mono">
-									{user.total_cache_creation_tokens.toLocaleString()}
-								</span>
-							</div>
-						</TooltipContent>
-					</Tooltip>
-				</TooltipProvider>
+				<TokensCell
+					inputTokens={user.total_input_tokens}
+					outputTokens={user.total_output_tokens}
+					cacheReadTokens={user.total_cache_read_tokens}
+					cacheWriteTokens={user.total_cache_creation_tokens}
+				/>
 			</TableCell>
 		</TableRow>
 	);

--- a/site/src/pages/AgentsPage/AgentSettingsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsPageView.tsx
@@ -424,7 +424,7 @@ const UsageContent: FC<UsageContentProps> = ({ now }) => {
 							No usage data for this period.
 						</p>
 					) : (
-						<>
+						<div className="flex flex-col gap-4">
 							<div className="overflow-hidden rounded-lg border border-border-default">
 								<Table>
 									<TableHeader>
@@ -462,7 +462,7 @@ const UsageContent: FC<UsageContentProps> = ({ now }) => {
 								hasPreviousPage={hasPreviousPage}
 								hasNextPage={hasNextPage}
 							/>
-						</>
+						</div>
 					)}
 				</div>
 			)}

--- a/site/src/pages/AgentsPage/AgentSettingsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsPageView.tsx
@@ -132,7 +132,7 @@ const UserRow: FC<{
 			{...clickableRowProps}
 			aria-label={`View details for ${user.name || user.username}`}
 		>
-			<TableCell className="px-4 py-3">
+			<TableCell>
 				<AvatarData
 					title={user.name || user.username}
 					subtitle={`@${user.username}`}
@@ -140,16 +140,10 @@ const UserRow: FC<{
 					imgFallbackText={user.username}
 				/>
 			</TableCell>
-			<TableCell className="px-4 py-3 text-right">
-				{formatCostMicros(user.total_cost_micros)}
-			</TableCell>
-			<TableCell className="px-4 py-3 text-right">
-				{user.message_count.toLocaleString()}
-			</TableCell>
-			<TableCell className="px-4 py-3 text-right">
-				{user.chat_count.toLocaleString()}
-			</TableCell>
-			<TableCell className="px-4 py-3 text-right">
+			<TableCell>{formatCostMicros(user.total_cost_micros)}</TableCell>
+			<TableCell>{user.message_count.toLocaleString()}</TableCell>
+			<TableCell>{user.chat_count.toLocaleString()}</TableCell>
+			<TableCell>
 				<TooltipProvider delayDuration={0}>
 					<Tooltip>
 						<TooltipTrigger asChild>
@@ -463,22 +457,16 @@ const UsageContent: FC<UsageContentProps> = ({ now }) => {
 							<div className="overflow-hidden rounded-lg border border-border-default">
 								<Table>
 									<TableHeader>
-										<TableRow className="text-left text-xs uppercase tracking-wide text-content-secondary">
-											<TableHead className="px-4 py-3">User</TableHead>
-												<TableHead className="px-4 py-3 text-right">
-													Cost
-												</TableHead>											<TableHead className="px-4 py-3 text-right">
-												Messages
-											</TableHead>
-											<TableHead className="px-4 py-3 text-right">
-												Chats
-											</TableHead>
-											<TableHead className="px-4 py-3 text-right">
-												Tokens
-											</TableHead>
+										<TableRow>
+											<TableHead>User</TableHead>
+											<TableHead>Cost</TableHead>
+											<TableHead>Messages</TableHead>
+											<TableHead>Chats</TableHead>
+											<TableHead>Tokens</TableHead>
 										</TableRow>
-										</TableHeader>
-										<TableBody>										{usersQuery.data.users.map((user) => (
+									</TableHeader>
+									<TableBody>
+										{usersQuery.data.users.map((user) => (
 											<UserRow
 												key={user.user_id}
 												user={user}

--- a/site/src/pages/AgentsPage/AgentSettingsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsPageView.tsx
@@ -465,10 +465,9 @@ const UsageContent: FC<UsageContentProps> = ({ now }) => {
 									<TableHeader>
 										<TableRow className="text-left text-xs uppercase tracking-wide text-content-secondary">
 											<TableHead className="px-4 py-3">User</TableHead>
-											<TableHead className="px-4 py-3 text-right">
-												Total Cost
-											</TableHead>
-											<TableHead className="px-4 py-3 text-right">
+												<TableHead className="px-4 py-3 text-right">
+													Cost
+												</TableHead>											<TableHead className="px-4 py-3 text-right">
 												Messages
 											</TableHead>
 											<TableHead className="px-4 py-3 text-right">

--- a/site/src/pages/AgentsPage/AgentSettingsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsPageView.tsx
@@ -17,7 +17,12 @@ import type * as TypesGen from "api/typesGenerated";
 import dayjs from "dayjs";
 import { useDebouncedValue } from "hooks/debounce";
 import { useClickableTableRow } from "hooks/useClickableTableRow";
-import { ChevronLeftIcon, ShieldIcon } from "lucide-react";
+import {
+	ArrowDownIcon,
+	ArrowUpIcon,
+	ChevronLeftIcon,
+	ShieldIcon,
+} from "lucide-react";
 import { type FC, type FormEvent, useState } from "react";
 import {
 	keepPreviousData,
@@ -127,7 +132,7 @@ const UserRow: FC<{
 			{...clickableRowProps}
 			aria-label={`View details for ${user.name || user.username}`}
 		>
-			<TableCell className="min-w-[220px] px-4 py-3">
+			<TableCell className="px-4 py-3">
 				<AvatarData
 					title={user.name || user.username}
 					subtitle={`@${user.username}`}
@@ -145,16 +150,43 @@ const UserRow: FC<{
 				{user.chat_count.toLocaleString()}
 			</TableCell>
 			<TableCell className="px-4 py-3 text-right">
-				{formatTokenCount(user.total_input_tokens)}
-			</TableCell>
-			<TableCell className="px-4 py-3 text-right">
-				{formatTokenCount(user.total_output_tokens)}
-			</TableCell>
-			<TableCell className="px-4 py-3 text-right">
-				{formatTokenCount(user.total_cache_read_tokens)}
-			</TableCell>
-			<TableCell className="px-4 py-3 text-right">
-				{formatTokenCount(user.total_cache_creation_tokens)}
+				<TooltipProvider delayDuration={0}>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<span className="inline-flex items-center gap-1 whitespace-nowrap">
+								<span className="inline-flex items-center gap-0.5">
+									<ArrowDownIcon className="h-3 w-3" />
+									{formatTokenCount(user.total_input_tokens)}
+								</span>
+								<span className="text-content-secondary">/</span>
+								<span className="inline-flex items-center gap-0.5">
+									<ArrowUpIcon className="h-3 w-3" />
+									{formatTokenCount(user.total_output_tokens)}
+								</span>
+							</span>
+						</TooltipTrigger>
+						<TooltipContent side="top">
+							<div className="grid grid-cols-[auto_auto] gap-x-3 gap-y-1 text-xs">
+								<span className="text-content-secondary">Input</span>
+								<span className="text-right font-mono">
+									{user.total_input_tokens.toLocaleString()}
+								</span>
+								<span className="text-content-secondary">Output</span>
+								<span className="text-right font-mono">
+									{user.total_output_tokens.toLocaleString()}
+								</span>
+								<span className="text-content-secondary">Cache read</span>
+								<span className="text-right font-mono">
+									{user.total_cache_read_tokens.toLocaleString()}
+								</span>
+								<span className="text-content-secondary">Cache write</span>
+								<span className="text-right font-mono">
+									{user.total_cache_creation_tokens.toLocaleString()}
+								</span>
+							</div>
+						</TooltipContent>
+					</Tooltip>
+				</TooltipProvider>
 			</TableCell>
 		</TableRow>
 	);
@@ -443,21 +475,11 @@ const UsageContent: FC<UsageContentProps> = ({ now }) => {
 												Chats
 											</TableHead>
 											<TableHead className="px-4 py-3 text-right">
-												Input Tokens
-											</TableHead>
-											<TableHead className="px-4 py-3 text-right">
-												Output Tokens
-											</TableHead>
-											<TableHead className="px-4 py-3 text-right">
-												Cache Read
-											</TableHead>
-											<TableHead className="px-4 py-3 text-right">
-												Cache Write
+												Tokens
 											</TableHead>
 										</TableRow>
-									</TableHeader>
-									<TableBody>
-										{usersQuery.data.users.map((user) => (
+										</TableHeader>
+										<TableBody>										{usersQuery.data.users.map((user) => (
 											<UserRow
 												key={user.user_id}
 												user={user}

--- a/site/src/pages/AgentsPage/AgentSettingsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsPageView.tsx
@@ -53,7 +53,8 @@ import {
 } from "#/components/Tooltip/Tooltip";
 import {
 	ChatCostSummaryView,
-	TokensCell,
+	InputTokensCell,
+	OutputTokensCell,
 } from "./components/ChatCostSummaryView";
 import { ChatModelAdminPanel } from "./components/ChatModelAdminPanel/ChatModelAdminPanel";
 import {
@@ -141,10 +142,14 @@ const UserRow: FC<{
 			<TableCell>{user.message_count.toLocaleString()}</TableCell>
 			<TableCell>{user.chat_count.toLocaleString()}</TableCell>
 			<TableCell>
-				<TokensCell
+				<InputTokensCell
 					inputTokens={user.total_input_tokens}
-					outputTokens={user.total_output_tokens}
 					cacheReadTokens={user.total_cache_read_tokens}
+				/>
+			</TableCell>
+			<TableCell>
+				<OutputTokensCell
+					outputTokens={user.total_output_tokens}
 					cacheWriteTokens={user.total_cache_creation_tokens}
 				/>
 			</TableCell>
@@ -428,7 +433,8 @@ const UsageContent: FC<UsageContentProps> = ({ now }) => {
 											<TableHead>Cost</TableHead>
 											<TableHead>Messages</TableHead>
 											<TableHead>Chats</TableHead>
-											<TableHead>Tokens</TableHead>
+											<TableHead>Input</TableHead>
+											<TableHead>Output</TableHead>
 										</TableRow>
 									</TableHeader>
 									<TableBody>

--- a/site/src/pages/AgentsPage/components/ChatCostSummaryView.tsx
+++ b/site/src/pages/AgentsPage/components/ChatCostSummaryView.tsx
@@ -291,7 +291,8 @@ export const ChatCostSummaryView: FC<ChatCostSummaryViewProps> = ({
 					{emptyMessage}
 				</p>
 			) : (
-				<>
+				<div className="flex flex-col gap-6">
+					{" "}
 					<div className="overflow-x-auto rounded-lg border border-border-default">
 						<Table className="text-sm" aria-label="Cost breakdown by model">
 							<TableHeader>
@@ -332,7 +333,6 @@ export const ChatCostSummaryView: FC<ChatCostSummaryViewProps> = ({
 							</TableBody>
 						</Table>
 					</div>
-
 					<div className="overflow-x-auto rounded-lg border border-border-default">
 						<Table className="text-sm" aria-label="Cost breakdown by chat">
 							<TableHeader>
@@ -373,7 +373,7 @@ export const ChatCostSummaryView: FC<ChatCostSummaryViewProps> = ({
 							</TableBody>
 						</Table>
 					</div>
-				</>
+				</div>
 			)}
 		</div>
 	);

--- a/site/src/pages/AgentsPage/components/ChatCostSummaryView.tsx
+++ b/site/src/pages/AgentsPage/components/ChatCostSummaryView.tsx
@@ -1,7 +1,7 @@
 import { getErrorMessage } from "api/errors";
 import type * as TypesGen from "api/typesGenerated";
 import dayjs from "dayjs";
-import { TriangleAlertIcon } from "lucide-react";
+import { ArrowDownIcon, ArrowUpIcon, TriangleAlertIcon } from "lucide-react";
 import type { FC } from "react";
 import { formatTokenCount } from "utils/analytics";
 import { formatCostMicros } from "utils/currency";
@@ -15,6 +15,57 @@ import {
 	TableHeader,
 	TableRow,
 } from "#/components/Table/Table";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "#/components/Tooltip/Tooltip";
+
+export const TokensCell: FC<{
+	inputTokens: number;
+	outputTokens: number;
+	cacheReadTokens: number;
+	cacheWriteTokens: number;
+}> = ({ inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens }) => (
+	<TooltipProvider delayDuration={0}>
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<span className="inline-flex items-center gap-1 whitespace-nowrap">
+					<span className="inline-flex items-center gap-0.5">
+						<ArrowDownIcon className="h-3 w-3" />
+						{formatTokenCount(inputTokens)}
+					</span>
+					<span className="text-content-secondary">/</span>
+					<span className="inline-flex items-center gap-0.5">
+						<ArrowUpIcon className="h-3 w-3" />
+						{formatTokenCount(outputTokens)}
+					</span>
+				</span>
+			</TooltipTrigger>
+			<TooltipContent side="top">
+				<div className="grid grid-cols-[auto_auto] gap-x-3 gap-y-1 text-xs">
+					<span className="text-content-secondary">Input</span>
+					<span className="text-right font-mono">
+						{inputTokens.toLocaleString()}
+					</span>
+					<span className="text-content-secondary">Output</span>
+					<span className="text-right font-mono">
+						{outputTokens.toLocaleString()}
+					</span>
+					<span className="text-content-secondary">Cache read</span>
+					<span className="text-right font-mono">
+						{cacheReadTokens.toLocaleString()}
+					</span>
+					<span className="text-content-secondary">Cache write</span>
+					<span className="text-right font-mono">
+						{cacheWriteTokens.toLocaleString()}
+					</span>
+				</div>
+			</TooltipContent>
+		</Tooltip>
+	</TooltipProvider>
+);
 
 interface ChatCostSummaryViewProps {
 	summary: TypesGen.ChatCostSummary | undefined;
@@ -249,10 +300,7 @@ export const ChatCostSummaryView: FC<ChatCostSummaryViewProps> = ({
 									<TableHead>Provider</TableHead>
 									<TableHead>Cost</TableHead>
 									<TableHead>Messages</TableHead>
-									<TableHead>Input</TableHead>
-									<TableHead>Output</TableHead>
-									<TableHead>Cache Read</TableHead>
-									<TableHead>Cache Write</TableHead>
+									<TableHead>Tokens</TableHead>
 								</TableRow>
 							</TableHeader>
 							<TableBody>
@@ -272,16 +320,12 @@ export const ChatCostSummaryView: FC<ChatCostSummaryViewProps> = ({
 											{model.message_count.toLocaleString()}
 										</TableCell>
 										<TableCell>
-											{formatTokenCount(model.total_input_tokens)}
-										</TableCell>
-										<TableCell>
-											{formatTokenCount(model.total_output_tokens)}
-										</TableCell>
-										<TableCell>
-											{formatTokenCount(model.total_cache_read_tokens)}
-										</TableCell>
-										<TableCell>
-											{formatTokenCount(model.total_cache_creation_tokens)}
+											<TokensCell
+												inputTokens={model.total_input_tokens}
+												outputTokens={model.total_output_tokens}
+												cacheReadTokens={model.total_cache_read_tokens}
+												cacheWriteTokens={model.total_cache_creation_tokens}
+											/>
 										</TableCell>
 									</TableRow>
 								))}
@@ -296,10 +340,7 @@ export const ChatCostSummaryView: FC<ChatCostSummaryViewProps> = ({
 									<TableHead>Chat</TableHead>
 									<TableHead>Cost</TableHead>
 									<TableHead>Messages</TableHead>
-									<TableHead>Input</TableHead>
-									<TableHead>Output</TableHead>
-									<TableHead>Cache Read</TableHead>
-									<TableHead>Cache Write</TableHead>
+									<TableHead>Tokens</TableHead>
 								</TableRow>
 							</TableHeader>
 							<TableBody>
@@ -320,16 +361,12 @@ export const ChatCostSummaryView: FC<ChatCostSummaryViewProps> = ({
 										</TableCell>
 										<TableCell>{chat.message_count.toLocaleString()}</TableCell>
 										<TableCell>
-											{formatTokenCount(chat.total_input_tokens)}
-										</TableCell>
-										<TableCell>
-											{formatTokenCount(chat.total_output_tokens)}
-										</TableCell>
-										<TableCell>
-											{formatTokenCount(chat.total_cache_read_tokens)}
-										</TableCell>
-										<TableCell>
-											{formatTokenCount(chat.total_cache_creation_tokens)}
+											<TokensCell
+												inputTokens={chat.total_input_tokens}
+												outputTokens={chat.total_output_tokens}
+												cacheReadTokens={chat.total_cache_read_tokens}
+												cacheWriteTokens={chat.total_cache_creation_tokens}
+											/>
 										</TableCell>
 									</TableRow>
 								))}

--- a/site/src/pages/AgentsPage/components/ChatCostSummaryView.tsx
+++ b/site/src/pages/AgentsPage/components/ChatCostSummaryView.tsx
@@ -31,8 +31,8 @@ export const TokensCell: FC<{
 	<TooltipProvider delayDuration={0}>
 		<Tooltip>
 			<TooltipTrigger asChild>
-				<span className="inline-flex items-center gap-1 whitespace-nowrap">
-					<span className="inline-flex items-center gap-0.5">
+				<span className="inline-grid grid-cols-[1fr_auto_1fr] items-center gap-1 whitespace-nowrap">
+					<span className="inline-flex items-center justify-end gap-0.5">
 						<ArrowDownIcon className="h-3 w-3" />
 						{formatTokenCount(inputTokens)}
 					</span>
@@ -171,7 +171,7 @@ export const ChatCostSummaryView: FC<ChatCostSummaryViewProps> = ({
 		<div className="space-y-6">
 			<div className="grid grid-cols-2 gap-4 md:grid-cols-3">
 				<div className="rounded-lg border border-border-default bg-surface-secondary p-4">
-					<p className="text-xs font-medium uppercase tracking-wide text-content-secondary">
+					<p className="text-xs font-medium tracking-wide text-content-secondary">
 						Total Cost
 					</p>
 					<p className="mt-1 text-2xl font-semibold text-content-primary">
@@ -179,7 +179,7 @@ export const ChatCostSummaryView: FC<ChatCostSummaryViewProps> = ({
 					</p>
 				</div>
 				<div className="rounded-lg border border-border-default bg-surface-secondary p-4">
-					<p className="text-xs font-medium uppercase tracking-wide text-content-secondary">
+					<p className="text-xs font-medium tracking-wide text-content-secondary">
 						Input Tokens
 					</p>
 					<p className="mt-1 text-2xl font-semibold text-content-primary">
@@ -187,7 +187,7 @@ export const ChatCostSummaryView: FC<ChatCostSummaryViewProps> = ({
 					</p>
 				</div>
 				<div className="rounded-lg border border-border-default bg-surface-secondary p-4">
-					<p className="text-xs font-medium uppercase tracking-wide text-content-secondary">
+					<p className="text-xs font-medium tracking-wide text-content-secondary">
 						Output Tokens
 					</p>
 					<p className="mt-1 text-2xl font-semibold text-content-primary">
@@ -195,7 +195,7 @@ export const ChatCostSummaryView: FC<ChatCostSummaryViewProps> = ({
 					</p>
 				</div>
 				<div className="rounded-lg border border-border-default bg-surface-secondary p-4">
-					<p className="text-xs font-medium uppercase tracking-wide text-content-secondary">
+					<p className="text-xs font-medium tracking-wide text-content-secondary">
 						Cache Read
 					</p>
 					<p className="mt-1 text-2xl font-semibold text-content-primary">
@@ -203,7 +203,7 @@ export const ChatCostSummaryView: FC<ChatCostSummaryViewProps> = ({
 					</p>
 				</div>
 				<div className="rounded-lg border border-border-default bg-surface-secondary p-4">
-					<p className="text-xs font-medium uppercase tracking-wide text-content-secondary">
+					<p className="text-xs font-medium tracking-wide text-content-secondary">
 						Cache Write
 					</p>
 					<p className="mt-1 text-2xl font-semibold text-content-primary">
@@ -211,7 +211,7 @@ export const ChatCostSummaryView: FC<ChatCostSummaryViewProps> = ({
 					</p>
 				</div>
 				<div className="rounded-lg border border-border-default bg-surface-secondary p-4">
-					<p className="text-xs font-medium uppercase tracking-wide text-content-secondary">
+					<p className="text-xs font-medium tracking-wide text-content-secondary">
 						Messages
 					</p>
 					<p className="mt-1 text-2xl font-semibold text-content-primary">
@@ -227,7 +227,7 @@ export const ChatCostSummaryView: FC<ChatCostSummaryViewProps> = ({
 					<div className="flex flex-col gap-4">
 						<div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
 							<div>
-								<p className="text-xs font-medium uppercase tracking-wide text-content-secondary">
+								<p className="text-xs font-medium tracking-wide text-content-secondary">
 									{usageLimitPeriodLabel} Spend Limit
 								</p>
 								{usageLimitCurrentPeriod && (

--- a/site/src/pages/AgentsPage/components/ChatCostSummaryView.tsx
+++ b/site/src/pages/AgentsPage/components/ChatCostSummaryView.tsx
@@ -34,11 +34,11 @@ export const InputTokensCell: FC<{
 			<TooltipContent side="top">
 				<div className="grid grid-cols-[auto_auto] gap-x-3 gap-y-1 text-xs">
 					<span className="text-content-secondary">Input</span>
-					<span className="text-right font-mono">
+					<span className="text-right tabular-nums">
 						{inputTokens.toLocaleString()}
 					</span>
 					<span className="text-content-secondary">Cache read</span>
-					<span className="text-right font-mono">
+					<span className="text-right tabular-nums">
 						{cacheReadTokens.toLocaleString()}
 					</span>
 				</div>
@@ -59,11 +59,11 @@ export const OutputTokensCell: FC<{
 			<TooltipContent side="top">
 				<div className="grid grid-cols-[auto_auto] gap-x-3 gap-y-1 text-xs">
 					<span className="text-content-secondary">Output</span>
-					<span className="text-right font-mono">
+					<span className="text-right tabular-nums">
 						{outputTokens.toLocaleString()}
 					</span>
 					<span className="text-content-secondary">Cache write</span>
-					<span className="text-right font-mono">
+					<span className="text-right tabular-nums">
 						{cacheWriteTokens.toLocaleString()}
 					</span>
 				</div>

--- a/site/src/pages/AgentsPage/components/ChatCostSummaryView.tsx
+++ b/site/src/pages/AgentsPage/components/ChatCostSummaryView.tsx
@@ -1,7 +1,7 @@
 import { getErrorMessage } from "api/errors";
 import type * as TypesGen from "api/typesGenerated";
 import dayjs from "dayjs";
-import { ArrowDownIcon, ArrowUpIcon, TriangleAlertIcon } from "lucide-react";
+import { TriangleAlertIcon } from "lucide-react";
 import type { FC } from "react";
 import { formatTokenCount } from "utils/analytics";
 import { formatCostMicros } from "utils/currency";
@@ -22,26 +22,14 @@ import {
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
 
-export const TokensCell: FC<{
+export const InputTokensCell: FC<{
 	inputTokens: number;
-	outputTokens: number;
 	cacheReadTokens: number;
-	cacheWriteTokens: number;
-}> = ({ inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens }) => (
+}> = ({ inputTokens, cacheReadTokens }) => (
 	<TooltipProvider delayDuration={0}>
 		<Tooltip>
 			<TooltipTrigger asChild>
-				<span className="inline-grid grid-cols-[1fr_auto_1fr] items-center gap-1 whitespace-nowrap">
-					<span className="inline-flex items-center justify-end gap-0.5">
-						<ArrowDownIcon className="h-3 w-3" />
-						{formatTokenCount(inputTokens)}
-					</span>
-					<span className="text-content-secondary">/</span>
-					<span className="inline-flex items-center gap-0.5">
-						<ArrowUpIcon className="h-3 w-3" />
-						{formatTokenCount(outputTokens)}
-					</span>
-				</span>
+				<span>{formatTokenCount(inputTokens)}</span>
 			</TooltipTrigger>
 			<TooltipContent side="top">
 				<div className="grid grid-cols-[auto_auto] gap-x-3 gap-y-1 text-xs">
@@ -49,13 +37,30 @@ export const TokensCell: FC<{
 					<span className="text-right font-mono">
 						{inputTokens.toLocaleString()}
 					</span>
-					<span className="text-content-secondary">Output</span>
-					<span className="text-right font-mono">
-						{outputTokens.toLocaleString()}
-					</span>
 					<span className="text-content-secondary">Cache read</span>
 					<span className="text-right font-mono">
 						{cacheReadTokens.toLocaleString()}
+					</span>
+				</div>
+			</TooltipContent>
+		</Tooltip>
+	</TooltipProvider>
+);
+
+export const OutputTokensCell: FC<{
+	outputTokens: number;
+	cacheWriteTokens: number;
+}> = ({ outputTokens, cacheWriteTokens }) => (
+	<TooltipProvider delayDuration={0}>
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<span>{formatTokenCount(outputTokens)}</span>
+			</TooltipTrigger>
+			<TooltipContent side="top">
+				<div className="grid grid-cols-[auto_auto] gap-x-3 gap-y-1 text-xs">
+					<span className="text-content-secondary">Output</span>
+					<span className="text-right font-mono">
+						{outputTokens.toLocaleString()}
 					</span>
 					<span className="text-content-secondary">Cache write</span>
 					<span className="text-right font-mono">
@@ -292,7 +297,6 @@ export const ChatCostSummaryView: FC<ChatCostSummaryViewProps> = ({
 				</p>
 			) : (
 				<div className="flex flex-col gap-6">
-					{" "}
 					<div className="overflow-x-auto rounded-lg border border-border-default">
 						<Table className="text-sm" aria-label="Cost breakdown by model">
 							<TableHeader>
@@ -301,7 +305,8 @@ export const ChatCostSummaryView: FC<ChatCostSummaryViewProps> = ({
 									<TableHead>Provider</TableHead>
 									<TableHead>Cost</TableHead>
 									<TableHead>Messages</TableHead>
-									<TableHead>Tokens</TableHead>
+									<TableHead>Input</TableHead>
+									<TableHead>Output</TableHead>
 								</TableRow>
 							</TableHeader>
 							<TableBody>
@@ -321,10 +326,14 @@ export const ChatCostSummaryView: FC<ChatCostSummaryViewProps> = ({
 											{model.message_count.toLocaleString()}
 										</TableCell>
 										<TableCell>
-											<TokensCell
+											<InputTokensCell
 												inputTokens={model.total_input_tokens}
-												outputTokens={model.total_output_tokens}
 												cacheReadTokens={model.total_cache_read_tokens}
+											/>
+										</TableCell>
+										<TableCell>
+											<OutputTokensCell
+												outputTokens={model.total_output_tokens}
 												cacheWriteTokens={model.total_cache_creation_tokens}
 											/>
 										</TableCell>
@@ -340,7 +349,8 @@ export const ChatCostSummaryView: FC<ChatCostSummaryViewProps> = ({
 									<TableHead>Chat</TableHead>
 									<TableHead>Cost</TableHead>
 									<TableHead>Messages</TableHead>
-									<TableHead>Tokens</TableHead>
+									<TableHead>Input</TableHead>
+									<TableHead>Output</TableHead>
 								</TableRow>
 							</TableHeader>
 							<TableBody>
@@ -361,10 +371,14 @@ export const ChatCostSummaryView: FC<ChatCostSummaryViewProps> = ({
 										</TableCell>
 										<TableCell>{chat.message_count.toLocaleString()}</TableCell>
 										<TableCell>
-											<TokensCell
+											<InputTokensCell
 												inputTokens={chat.total_input_tokens}
-												outputTokens={chat.total_output_tokens}
 												cacheReadTokens={chat.total_cache_read_tokens}
+											/>
+										</TableCell>
+										<TableCell>
+											<OutputTokensCell
+												outputTokens={chat.total_output_tokens}
 												cacheWriteTokens={chat.total_cache_creation_tokens}
 											/>
 										</TableCell>

--- a/site/src/pages/AgentsPage/components/ChatCostSummaryView.tsx
+++ b/site/src/pages/AgentsPage/components/ChatCostSummaryView.tsx
@@ -244,21 +244,15 @@ export const ChatCostSummaryView: FC<ChatCostSummaryViewProps> = ({
 					<div className="overflow-x-auto rounded-lg border border-border-default">
 						<Table className="text-sm" aria-label="Cost breakdown by model">
 							<TableHeader>
-								<TableRow className="text-left text-xs font-medium uppercase tracking-wide text-content-secondary">
-									<TableHead className="px-4 py-3">Model</TableHead>
-									<TableHead className="px-4 py-3">Provider</TableHead>
-									<TableHead className="px-4 py-3 text-right">Cost</TableHead>
-									<TableHead className="px-4 py-3 text-right">
-										Messages
-									</TableHead>
-									<TableHead className="px-4 py-3 text-right">Input</TableHead>
-									<TableHead className="px-4 py-3 text-right">Output</TableHead>
-									<TableHead className="px-4 py-3 text-right">
-										Cache Read
-									</TableHead>
-									<TableHead className="px-4 py-3 text-right">
-										Cache Write
-									</TableHead>
+								<TableRow>
+									<TableHead>Model</TableHead>
+									<TableHead>Provider</TableHead>
+									<TableHead>Cost</TableHead>
+									<TableHead>Messages</TableHead>
+									<TableHead>Input</TableHead>
+									<TableHead>Output</TableHead>
+									<TableHead>Cache Read</TableHead>
+									<TableHead>Cache Write</TableHead>
 								</TableRow>
 							</TableHeader>
 							<TableBody>
@@ -267,28 +261,26 @@ export const ChatCostSummaryView: FC<ChatCostSummaryViewProps> = ({
 										key={model.model_config_id}
 										className="border-t border-border-default"
 									>
-										<TableCell className="px-4 py-3">
-											{model.display_name || model.model}
-										</TableCell>
-										<TableCell className="px-4 py-3 text-content-secondary">
+										<TableCell>{model.display_name || model.model}</TableCell>
+										<TableCell className="text-content-secondary">
 											{model.provider}
 										</TableCell>
-										<TableCell className="px-4 py-3 text-right">
+										<TableCell>
 											{formatCostMicros(model.total_cost_micros)}
 										</TableCell>
-										<TableCell className="px-4 py-3 text-right">
+										<TableCell>
 											{model.message_count.toLocaleString()}
 										</TableCell>
-										<TableCell className="px-4 py-3 text-right">
+										<TableCell>
 											{formatTokenCount(model.total_input_tokens)}
 										</TableCell>
-										<TableCell className="px-4 py-3 text-right">
+										<TableCell>
 											{formatTokenCount(model.total_output_tokens)}
 										</TableCell>
-										<TableCell className="px-4 py-3 text-right">
+										<TableCell>
 											{formatTokenCount(model.total_cache_read_tokens)}
 										</TableCell>
-										<TableCell className="px-4 py-3 text-right">
+										<TableCell>
 											{formatTokenCount(model.total_cache_creation_tokens)}
 										</TableCell>
 									</TableRow>
@@ -300,20 +292,14 @@ export const ChatCostSummaryView: FC<ChatCostSummaryViewProps> = ({
 					<div className="overflow-x-auto rounded-lg border border-border-default">
 						<Table className="text-sm" aria-label="Cost breakdown by chat">
 							<TableHeader>
-								<TableRow className="text-left text-xs font-medium uppercase tracking-wide text-content-secondary">
-									<TableHead className="px-4 py-3">Chat</TableHead>
-									<TableHead className="px-4 py-3 text-right">Cost</TableHead>
-									<TableHead className="px-4 py-3 text-right">
-										Messages
-									</TableHead>
-									<TableHead className="px-4 py-3 text-right">Input</TableHead>
-									<TableHead className="px-4 py-3 text-right">Output</TableHead>
-									<TableHead className="px-4 py-3 text-right">
-										Cache Read
-									</TableHead>
-									<TableHead className="px-4 py-3 text-right">
-										Cache Write
-									</TableHead>
+								<TableRow>
+									<TableHead>Chat</TableHead>
+									<TableHead>Cost</TableHead>
+									<TableHead>Messages</TableHead>
+									<TableHead>Input</TableHead>
+									<TableHead>Output</TableHead>
+									<TableHead>Cache Read</TableHead>
+									<TableHead>Cache Write</TableHead>
 								</TableRow>
 							</TableHeader>
 							<TableBody>
@@ -322,29 +308,27 @@ export const ChatCostSummaryView: FC<ChatCostSummaryViewProps> = ({
 										key={chat.root_chat_id}
 										className="border-t border-border-default"
 									>
-										<TableCell className="px-4 py-3">
+										<TableCell>
 											{chat.chat_title || (
 												<span className="italic text-content-secondary">
 													Untitled chat
 												</span>
 											)}
 										</TableCell>
-										<TableCell className="px-4 py-3 text-right">
+										<TableCell>
 											{formatCostMicros(chat.total_cost_micros)}
 										</TableCell>
-										<TableCell className="px-4 py-3 text-right">
-											{chat.message_count.toLocaleString()}
-										</TableCell>
-										<TableCell className="px-4 py-3 text-right">
+										<TableCell>{chat.message_count.toLocaleString()}</TableCell>
+										<TableCell>
 											{formatTokenCount(chat.total_input_tokens)}
 										</TableCell>
-										<TableCell className="px-4 py-3 text-right">
+										<TableCell>
 											{formatTokenCount(chat.total_output_tokens)}
 										</TableCell>
-										<TableCell className="px-4 py-3 text-right">
+										<TableCell>
 											{formatTokenCount(chat.total_cache_read_tokens)}
 										</TableCell>
-										<TableCell className="px-4 py-3 text-right">
+										<TableCell>
 											{formatTokenCount(chat.total_cache_creation_tokens)}
 										</TableCell>
 									</TableRow>

--- a/site/src/pages/AgentsPage/components/PRInsightsView.tsx
+++ b/site/src/pages/AgentsPage/components/PRInsightsView.tsx
@@ -328,9 +328,8 @@ export const PRInsightsView: FC<PRInsightsViewProps> = ({
 							label="Cost / merge"
 							value={formatCostMicros(summary.cost_per_merged_pr_micros)}
 							detail={`${formatCostMicros(summary.total_cost_micros)} total`}
-						/>{" "}
+						/>
 					</div>
-
 					{/* ── Activity chart ── */}
 					<section>
 						<div className="mb-4 flex items-center justify-between">
@@ -355,7 +354,7 @@ export const PRInsightsView: FC<PRInsightsViewProps> = ({
 					</section>
 
 					{/* ── Model breakdown + Recent PRs side by side ── */}
-					<div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+					<div className="grid grid-cols-1 gap-6">
 						{/* ── Model performance (simplified) ── */}
 						{by_model.length > 0 && (
 							<section>
@@ -365,15 +364,11 @@ export const PRInsightsView: FC<PRInsightsViewProps> = ({
 								<div className="overflow-hidden rounded-lg border border-border-default">
 									<Table className="text-sm">
 										<TableHeader>
-											<TableRow className="text-left text-xs text-content-secondary [&>th]:font-normal">
-												<TableHead className="px-4 py-3">Model</TableHead>
-												<TableHead className="px-4 py-3 text-right">
-													Merged
-												</TableHead>
-												<TableHead className="px-4 py-3">Merge rate</TableHead>
-												<TableHead className="px-4 py-3 text-right">
-													Cost / merge
-												</TableHead>
+											<TableRow>
+												<TableHead>Model</TableHead>
+												<TableHead>Merged</TableHead>
+												<TableHead>Merge rate</TableHead>
+												<TableHead>Cost / merge</TableHead>
 											</TableRow>
 										</TableHeader>
 										<TableBody>
@@ -382,21 +377,21 @@ export const PRInsightsView: FC<PRInsightsViewProps> = ({
 													key={m.model_config_id}
 													className="border-t border-border-default"
 												>
-													<TableCell className="px-4 py-3">
+													<TableCell>
 														<span className="font-medium text-content-primary">
 															{m.display_name}
 														</span>
 													</TableCell>
-													<TableCell className="px-4 py-3 text-right tabular-nums text-content-primary">
+													<TableCell className="tabular-nums text-content-primary">
 														<span>{m.merged_prs}</span>
 														<span className="text-content-disabled">
 															/{m.total_prs}
 														</span>
 													</TableCell>
-													<TableCell className="px-4 py-3">
+													<TableCell>
 														<InlineMergeBar rate={m.merge_rate} />
 													</TableCell>
-													<TableCell className="px-4 py-3 text-right tabular-nums text-content-primary">
+													<TableCell className="tabular-nums text-content-primary">
 														{m.merged_prs > 0
 															? formatCostMicros(m.cost_per_merged_pr_micros)
 															: "—"}
@@ -424,25 +419,20 @@ export const PRInsightsView: FC<PRInsightsViewProps> = ({
 											<col style={{ width: 72 }} />
 										</colgroup>
 										<TableHeader>
-											<TableRow className="text-left text-xs text-content-secondary [&>th]:font-normal">
-												<TableHead className="px-4 py-3">Title</TableHead>
-												<TableHead className="px-4 py-3">Status</TableHead>
-												<TableHead className="px-4 py-3 text-right">
-													Cost
-												</TableHead>
-												<TableHead className="px-4 py-3 text-right">
-													Created
-												</TableHead>
+											<TableRow>
+												<TableHead>Title</TableHead>
+												<TableHead>Status</TableHead>
+												<TableHead>Cost</TableHead>
+												<TableHead>Created</TableHead>
 											</TableRow>
-										</TableHeader>{" "}
+										</TableHeader>
 										<TableBody>
 											{recent_prs.map((pr) => (
 												<TableRow
 													key={pr.chat_id}
 													className="border-t border-border-default transition-colors hover:bg-surface-secondary/50"
 												>
-													<TableCell className="overflow-hidden px-4 py-3">
-														{" "}
+													<TableCell className="overflow-hidden">
 														<a
 															href={pr.pr_url}
 															target="_blank"
@@ -455,7 +445,6 @@ export const PRInsightsView: FC<PRInsightsViewProps> = ({
 															<ExternalLinkIcon className="mt-0.5 size-3 shrink-0 text-content-disabled opacity-0 transition-opacity group-hover:opacity-100" />
 														</a>
 														<div className="mt-1 flex items-center gap-1.5 truncate text-xs text-content-disabled">
-															{" "}
 															<img
 																src={pr.author_avatar_url}
 																alt=""
@@ -466,13 +455,13 @@ export const PRInsightsView: FC<PRInsightsViewProps> = ({
 															<span className="font-mono">#{pr.pr_number}</span>
 														</div>
 													</TableCell>
-													<TableCell className="px-4 py-3">
+													<TableCell>
 														<PRStateBadge state={pr.state} draft={pr.draft} />
 													</TableCell>
-													<TableCell className="px-4 py-3 text-right tabular-nums text-content-secondary">
+													<TableCell className="tabular-nums text-content-secondary">
 														{formatCostMicros(pr.cost_micros)}
 													</TableCell>
-													<TableCell className="whitespace-nowrap px-4 py-3 text-right text-xs text-content-disabled">
+													<TableCell className="whitespace-nowrap text-xs text-content-disabled">
 														{dayjs(pr.created_at).format("MMM D")}
 													</TableCell>
 												</TableRow>


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

## Summary

The usage table on the agent settings page had 8 columns (User, Total Cost, Messages, Chats, Input Tokens, Output Tokens, Cache Read, Cache Write) which caused a horizontal scrollbar within the `max-w-3xl` (768px) container.

## Changes

- Collapse the 4 separate token columns into a single **Tokens** column showing a compact `↓ input / ↑ output` display with `ArrowDownIcon`/`ArrowUpIcon`, matching the pattern used by AIBridge tables (`TokenBadges`, `ListSessionsRow`, `RequestLogsRow`).
- Full token breakdown (input, output, cache read, cache write) is available in a hover tooltip with `.toLocaleString()` precision.
- Remove the `min-w-[220px]` constraint on the User column, which is no longer needed with fewer columns.
- Table goes from 8 columns to 5 (User, Total Cost, Messages, Chats, Tokens), fitting comfortably within the container.