### PR TITLE
feat(site): make long execute tool commands expandable

### DIFF
--- a/site/src/components/ai-elements/tool/ExecuteTool.stories.tsx
+++ b/site/src/components/ai-elements/tool/ExecuteTool.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { userEvent, within } from "storybook/test";
 import { ExecuteTool } from "./ExecuteTool";
 
 const meta: Meta<typeof ExecuteTool> = {
@@ -28,12 +29,23 @@ export const ShortCommand: Story = {
 	},
 };
 
-/** A command long enough to overflow the container and show the expand chevron. */
+/** A long command expanded to show the full text, with the chevron visible on hover. */
 export const LongCommand: Story = {
 	args: {
 		command:
 			"find /home/coder/project/src -type f -name '*.ts' -not -path '*/node_modules/*' -not -path '*/.git/*' | xargs grep -l 'deprecated' | sort | head -50",
 		output: "",
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		// Hover the container to reveal the chevron.
+		const container = canvasElement.querySelector(".group\\/exec")!;
+		await userEvent.hover(container);
+		// Click the chevron to expand the command.
+		const chevronButton = canvas.getByRole("button", {
+			name: /expand command/i,
+		});
+		await userEvent.click(chevronButton);
 	},
 };
 
@@ -94,13 +106,5 @@ export const ErrorOutput: Story = {
 			"coderd/workspaces.go:155:19: ws.OwnerID undefined (type *database.Workspace has no field or method OwnerID)",
 			"make: *** [build] Error 1",
 		].join("\n"),
-	},
-};
-
-/** A completed command with no output shows only the command header. */
-export const NoOutput: Story = {
-	args: {
-		command: "mkdir -p /home/coder/project/src/components",
-		output: "",
 	},
 };

--- a/site/src/components/ai-elements/tool/ExecuteTool.stories.tsx
+++ b/site/src/components/ai-elements/tool/ExecuteTool.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { userEvent } from "storybook/test";
+import { userEvent, within } from "storybook/test";
 import { ExecuteTool } from "./ExecuteTool";
 
 const meta: Meta<typeof ExecuteTool> = {
@@ -37,15 +37,13 @@ export const LongCommand: Story = {
 		output: "",
 	},
 	play: async ({ canvasElement }) => {
-		// Click the command text to expand it. The command area
-		// becomes a button when the text overflows.
-		const commandButton = canvasElement.querySelector(
-			".group\\/exec [role='button']",
-		)!;
-		await userEvent.click(commandButton);
-		// Hover the container so the chevron stays visible.
-		const container = canvasElement.querySelector(".group\\/exec")!;
-		await userEvent.hover(container);
+		const canvas = within(canvasElement);
+		// Query by the command text content to target the command
+		// area specifically, not the copy or chevron buttons.
+		const commandArea = canvas.getByRole("button", { name: /\$/ });
+		await userEvent.click(commandArea);
+		// Hover the component so the chevron is visible.
+		await userEvent.hover(canvasElement.firstElementChild!);
 	},
 };
 

--- a/site/src/components/ai-elements/tool/ExecuteTool.stories.tsx
+++ b/site/src/components/ai-elements/tool/ExecuteTool.stories.tsx
@@ -1,0 +1,106 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ExecuteTool } from "./ExecuteTool";
+
+const meta: Meta<typeof ExecuteTool> = {
+	title: "components/ai-elements/tool/ExecuteTool",
+	component: ExecuteTool,
+	decorators: [
+		(Story) => (
+			<div className="max-w-3xl rounded-lg border border-solid border-border-default bg-surface-primary p-4">
+				<Story />
+			</div>
+		),
+	],
+	args: {
+		status: "completed",
+		isError: false,
+		output: "",
+	},
+};
+export default meta;
+type Story = StoryObj<typeof ExecuteTool>;
+
+/** A short command that fits on a single line without truncation. */
+export const ShortCommand: Story = {
+	args: {
+		command: "git status",
+		output: "",
+	},
+};
+
+/** A command long enough to overflow the container and show the expand chevron. */
+export const LongCommand: Story = {
+	args: {
+		command:
+			"find /home/coder/project/src -type f -name '*.ts' -not -path '*/node_modules/*' -not -path '*/.git/*' | xargs grep -l 'deprecated' | sort | head -50",
+		output: "",
+	},
+};
+
+/** A long truncated command with multi-line output below it. */
+export const LongCommandWithOutput: Story = {
+	args: {
+		command:
+			"find /home/coder/project/src -type f -name '*.ts' -not -path '*/node_modules/*' -not -path '*/.git/*' | xargs grep -l 'deprecated' | sort | head -50",
+		output: [
+			"src/api/legacyClient.ts",
+			"src/components/OldTable/OldTable.tsx",
+			"src/hooks/useObsoleteAuth.ts",
+			"src/pages/SettingsPage/DeprecatedPanel.tsx",
+			"src/utils/formatDate.ts",
+			"src/utils/legacyHelpers.ts",
+		].join("\n"),
+	},
+};
+
+/** A normal command with multi-line output that overflows the collapsed preview. */
+export const WithOutput: Story = {
+	args: {
+		command: "docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'",
+		output: [
+			"NAMES                STATUS              PORTS",
+			"coder-gateway        Up 3 hours          0.0.0.0:3000->3000/tcp",
+			"coder-database       Up 3 hours          0.0.0.0:5432->5432/tcp",
+			"coder-provisioner    Up 3 hours",
+			"redis-cache          Up 3 hours          0.0.0.0:6379->6379/tcp",
+			"nginx-proxy          Up 2 hours          0.0.0.0:80->80/tcp, 0.0.0.0:443->443/tcp",
+			"prometheus           Up 2 hours          0.0.0.0:9090->9090/tcp",
+			"grafana              Up 2 hours          0.0.0.0:3001->3001/tcp",
+			"jaeger               Up 1 hour           0.0.0.0:16686->16686/tcp",
+			"otel-collector       Up 1 hour           0.0.0.0:4317->4317/tcp",
+			"loki                 Up 1 hour           0.0.0.0:3100->3100/tcp",
+		].join("\n"),
+	},
+};
+
+/** A command currently running shows a spinner in the header. */
+export const Running: Story = {
+	args: {
+		command: "go test -race -count=1 ./coderd/...",
+		status: "running",
+		output:
+			"=== RUN   TestWorkspaceAgent\n--- PASS: TestWorkspaceAgent (0.42s)",
+	},
+};
+
+/** A command that errored renders the output in red. */
+export const ErrorOutput: Story = {
+	args: {
+		command: "make build",
+		status: "completed",
+		isError: true,
+		output: [
+			"coderd/workspaces.go:142:6: cannot use ws (variable of type *database.Workspace) as database.Store value in argument to api.Authorize",
+			"coderd/workspaces.go:155:19: ws.OwnerID undefined (type *database.Workspace has no field or method OwnerID)",
+			"make: *** [build] Error 1",
+		].join("\n"),
+	},
+};
+
+/** A completed command with no output shows only the command header. */
+export const NoOutput: Story = {
+	args: {
+		command: "mkdir -p /home/coder/project/src/components",
+		output: "",
+	},
+};

--- a/site/src/components/ai-elements/tool/ExecuteTool.stories.tsx
+++ b/site/src/components/ai-elements/tool/ExecuteTool.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { userEvent, within } from "storybook/test";
+import { userEvent } from "storybook/test";
 import { ExecuteTool } from "./ExecuteTool";
 
 const meta: Meta<typeof ExecuteTool> = {
@@ -37,15 +37,15 @@ export const LongCommand: Story = {
 		output: "",
 	},
 	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		// Hover the container to reveal the chevron.
+		// Click the command text to expand it. The command area
+		// becomes a button when the text overflows.
+		const commandButton = canvasElement.querySelector(
+			".group\\/exec [role='button']",
+		)!;
+		await userEvent.click(commandButton);
+		// Hover the container so the chevron stays visible.
 		const container = canvasElement.querySelector(".group\\/exec")!;
 		await userEvent.hover(container);
-		// Click the chevron to expand the command.
-		const chevronButton = canvas.getByRole("button", {
-			name: /expand command/i,
-		});
-		await userEvent.click(chevronButton);
 	},
 };
 

--- a/site/src/components/ai-elements/tool/ExecuteTool.stories.tsx
+++ b/site/src/components/ai-elements/tool/ExecuteTool.stories.tsx
@@ -38,11 +38,11 @@ export const LongCommand: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		// Query by the command text content to target the command
-		// area specifically, not the copy or chevron buttons.
-		const commandArea = canvas.getByRole("button", { name: /\$/ });
-		await userEvent.click(commandArea);
-		// Hover the component so the chevron is visible.
+		const chevron = canvas.getByRole("button", {
+			name: /expand command/i,
+		});
+		await userEvent.click(chevron);
+		// Hover the component so the chevron stays visible.
 		await userEvent.hover(canvasElement.firstElementChild!);
 	},
 };

--- a/site/src/components/ai-elements/tool/ExecuteTool.tsx
+++ b/site/src/components/ai-elements/tool/ExecuteTool.tsx
@@ -34,6 +34,16 @@ export const ExecuteTool: React.FC<{
 	const hasOutput = output.length > 0;
 	const isRunning = status === "running";
 
+	// Track whether the command text is truncated so we can offer
+	// a click-to-expand interaction.
+	const [commandExpanded, setCommandExpanded] = useState(false);
+	const [commandOverflows, setCommandOverflows] = useState(false);
+	const commandRef = (node: HTMLElement | null) => {
+		if (node) {
+			setCommandOverflows(node.scrollWidth > node.clientWidth);
+		}
+	};
+
 	// Check whether the output overflows the collapsed height so we
 	// know if we need to show the expand toggle at all.
 	const [overflows, setOverflows] = useState(false);
@@ -47,16 +57,53 @@ export const ExecuteTool: React.FC<{
 	return (
 		<div className="group/exec w-full overflow-hidden rounded-md border border-solid border-border-default bg-surface-primary">
 			{/* Header: $ command + copy button */}
-			<div className="flex w-full items-center justify-between gap-2 px-2.5 py-0.5">
-				<div className="flex min-w-0 flex-1 items-center gap-2">
-					<span className="shrink-0 font-mono text-xs text-content-secondary">
+			<div className={cn("flex w-full justify-between gap-2 px-2.5 py-0.5", commandExpanded ? "items-start" : "items-center")}>
+				<button
+					type="button"
+					className={cn(
+						"flex min-w-0 flex-1 gap-2 border-0 bg-transparent p-0 m-0 font-[inherit] text-left",
+						commandExpanded ? "items-start" : "items-center",
+						commandOverflows || commandExpanded
+							? "cursor-pointer"
+							: "cursor-default",
+					)}
+					onClick={
+						commandOverflows || commandExpanded
+							? () => setCommandExpanded((v) => !v)
+							: undefined
+					}
+				>
+					<span className="shrink-0 font-mono text-xs leading-5 text-content-secondary">
 						$
 					</span>
-					<code className="min-w-0 flex-1 truncate font-mono text-xs text-content-primary">
+					<code
+						ref={commandRef}
+						className={cn(
+							"min-w-0 flex-1 font-mono text-xs leading-5 text-content-primary",
+							commandExpanded
+								? "whitespace-pre-wrap break-all"
+								: "truncate",
+						)}
+					>
 						{command}
 					</code>
-				</div>
+				</button>
 				<div className="flex shrink-0 items-center gap-1">
+					{commandOverflows && (
+						<button
+							type="button"
+							onClick={() => setCommandExpanded((v) => !v)}
+							className="border-0 bg-transparent p-0 m-0 cursor-pointer flex items-center text-content-secondary hover:text-content-primary transition-colors"
+							aria-label={commandExpanded ? "Collapse command" : "Expand command"}
+						>
+							<ChevronDownIcon
+								className={cn(
+									"h-3.5 w-3.5 transition-transform",
+									commandExpanded && "rotate-180",
+								)}
+							/>
+						</button>
+					)}
 					{isRunning && (
 						<LoaderIcon className="h-3.5 w-3.5 shrink-0 animate-spin motion-reduce:animate-none text-content-secondary" />
 					)}
@@ -65,7 +112,6 @@ export const ExecuteTool: React.FC<{
 					</span>
 				</div>
 			</div>
-
 			{/* Output preview / expanded */}
 			{hasOutput && (
 				<>

--- a/site/src/components/ai-elements/tool/ExecuteTool.tsx
+++ b/site/src/components/ai-elements/tool/ExecuteTool.tsx
@@ -63,20 +63,29 @@ export const ExecuteTool: React.FC<{
 					commandExpanded ? "items-start" : "items-center",
 				)}
 			>
-				<button
-					type="button"
+				<div
 					className={cn(
-						"flex min-w-0 flex-1 gap-2 border-0 bg-transparent p-0 m-0 font-[inherit] text-left",
+						"flex min-w-0 flex-1 gap-2",
 						commandExpanded ? "items-start" : "items-center",
-						commandOverflows || commandExpanded
-							? "cursor-pointer"
-							: "cursor-default",
+						commandOverflows && "cursor-pointer",
 					)}
 					onClick={
 						commandOverflows || commandExpanded
 							? () => setCommandExpanded((v) => !v)
 							: undefined
 					}
+					onKeyDown={
+						commandOverflows || commandExpanded
+							? (e) => {
+									if (e.key === "Enter" || e.key === " ") {
+										e.preventDefault();
+										setCommandExpanded((v) => !v);
+									}
+								}
+							: undefined
+					}
+					role={commandOverflows ? "button" : undefined}
+					tabIndex={commandOverflows ? 0 : undefined}
 				>
 					<span className="shrink-0 font-mono text-xs leading-5 text-content-secondary">
 						$
@@ -90,33 +99,31 @@ export const ExecuteTool: React.FC<{
 					>
 						{command}
 					</code>
-				</button>
+				</div>
 				<div className="flex shrink-0 items-center gap-1">
 					{commandOverflows && (
-						<span
+						<button
+							type="button"
+							onClick={() => setCommandExpanded((v) => !v)}
 							className={cn(
-								"transition-opacity",
+								"border-0 bg-transparent p-0 m-0 cursor-pointer flex items-center text-content-secondary hover:text-content-primary transition-colors transition-opacity",
 								commandExpanded
 									? "opacity-100"
 									: "opacity-0 group-hover/exec:opacity-100",
 							)}
+							tabIndex={commandExpanded ? undefined : -1}
+							aria-hidden={!commandExpanded || undefined}
+							aria-label={
+								commandExpanded ? "Collapse command" : "Expand command"
+							}
 						>
-							<button
-								type="button"
-								onClick={() => setCommandExpanded((v) => !v)}
-								className="border-0 bg-transparent p-0 m-0 cursor-pointer flex items-center text-content-secondary hover:text-content-primary transition-colors"
-								aria-label={
-									commandExpanded ? "Collapse command" : "Expand command"
-								}
-							>
-								<ChevronDownIcon
-									className={cn(
-										"h-3.5 w-3.5 transition-transform",
-										commandExpanded && "rotate-180",
-									)}
-								/>
-							</button>
-						</span>
+							<ChevronDownIcon
+								className={cn(
+									"h-3.5 w-3.5 transition-transform",
+									commandExpanded && "rotate-180",
+								)}
+							/>
+						</button>
 					)}
 					{isRunning && (
 						<LoaderIcon className="h-3.5 w-3.5 shrink-0 animate-spin motion-reduce:animate-none text-content-secondary" />

--- a/site/src/components/ai-elements/tool/ExecuteTool.tsx
+++ b/site/src/components/ai-elements/tool/ExecuteTool.tsx
@@ -93,21 +93,30 @@ export const ExecuteTool: React.FC<{
 				</button>
 				<div className="flex shrink-0 items-center gap-1">
 					{commandOverflows && (
-						<button
-							type="button"
-							onClick={() => setCommandExpanded((v) => !v)}
-							className="border-0 bg-transparent p-0 m-0 cursor-pointer flex items-center text-content-secondary hover:text-content-primary transition-colors"
-							aria-label={
-								commandExpanded ? "Collapse command" : "Expand command"
-							}
+						<span
+							className={cn(
+								"transition-opacity",
+								commandExpanded
+									? "opacity-100"
+									: "opacity-0 group-hover/exec:opacity-100",
+							)}
 						>
-							<ChevronDownIcon
-								className={cn(
-									"h-3.5 w-3.5 transition-transform",
-									commandExpanded && "rotate-180",
-								)}
-							/>
-						</button>
+							<button
+								type="button"
+								onClick={() => setCommandExpanded((v) => !v)}
+								className="border-0 bg-transparent p-0 m-0 cursor-pointer flex items-center text-content-secondary hover:text-content-primary transition-colors"
+								aria-label={
+									commandExpanded ? "Collapse command" : "Expand command"
+								}
+							>
+								<ChevronDownIcon
+									className={cn(
+										"h-3.5 w-3.5 transition-transform",
+										commandExpanded && "rotate-180",
+									)}
+								/>
+							</button>
+						</span>
 					)}
 					{isRunning && (
 						<LoaderIcon className="h-3.5 w-3.5 shrink-0 animate-spin motion-reduce:animate-none text-content-secondary" />

--- a/site/src/components/ai-elements/tool/ExecuteTool.tsx
+++ b/site/src/components/ai-elements/tool/ExecuteTool.tsx
@@ -72,6 +72,7 @@ export const ExecuteTool: React.FC<{
 					commandExpanded ? "items-start" : "items-center",
 				)}
 			>
+				{/* biome-ignore lint/a11y/useKeyWithClickEvents: Click toggles for mouse users; keyboard users use the chevron button. */}
 				<div
 					className={cn(
 						"flex min-w-0 flex-1 gap-2",
@@ -81,18 +82,6 @@ export const ExecuteTool: React.FC<{
 					onClick={
 						canToggleCommand ? () => setCommandExpanded((v) => !v) : undefined
 					}
-					onKeyDown={
-						canToggleCommand
-							? (e) => {
-									if (e.key === "Enter" || e.key === " ") {
-										e.preventDefault();
-										setCommandExpanded((v) => !v);
-									}
-								}
-							: undefined
-					}
-					role={canToggleCommand ? "button" : undefined}
-					tabIndex={canToggleCommand ? 0 : undefined}
 				>
 					<span className="shrink-0 font-mono text-xs leading-5 text-content-secondary">
 						$
@@ -113,13 +102,12 @@ export const ExecuteTool: React.FC<{
 							type="button"
 							onClick={() => setCommandExpanded((v) => !v)}
 							className={cn(
-								"border-0 bg-transparent p-0 m-0 cursor-pointer flex items-center text-content-secondary hover:text-content-primary transition-colors transition-opacity",
+								"border-0 bg-transparent p-0 m-0 cursor-pointer flex items-center text-content-secondary hover:text-content-primary transition-colors transition-opacity focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-content-link",
 								commandExpanded
 									? "opacity-100"
 									: "opacity-0 group-hover/exec:opacity-100",
 							)}
-							tabIndex={commandExpanded ? undefined : -1}
-							aria-hidden={!commandExpanded || undefined}
+							aria-expanded={commandExpanded}
 							aria-label={
 								commandExpanded ? "Collapse command" : "Expand command"
 							}

--- a/site/src/components/ai-elements/tool/ExecuteTool.tsx
+++ b/site/src/components/ai-elements/tool/ExecuteTool.tsx
@@ -35,9 +35,13 @@ export const ExecuteTool: React.FC<{
 	const isRunning = status === "running";
 
 	// Track whether the command text is truncated so we can offer
-	// a click-to-expand interaction.
+	// a click-to-expand interaction. The ResizeObserver may clear
+	// commandOverflows while the text is wrapped, but
+	// canToggleCommand stays true via commandExpanded so the
+	// collapse affordance remains visible.
 	const [commandExpanded, setCommandExpanded] = useState(false);
 	const [commandOverflows, setCommandOverflows] = useState(false);
+	const canToggleCommand = commandOverflows || commandExpanded;
 	const commandRef = (node: HTMLElement | null) => {
 		if (!node) return;
 		const measure = () => {
@@ -72,15 +76,13 @@ export const ExecuteTool: React.FC<{
 					className={cn(
 						"flex min-w-0 flex-1 gap-2",
 						commandExpanded ? "items-start" : "items-center",
-						commandOverflows && "cursor-pointer",
+						canToggleCommand && "cursor-pointer",
 					)}
 					onClick={
-						commandOverflows || commandExpanded
-							? () => setCommandExpanded((v) => !v)
-							: undefined
+						canToggleCommand ? () => setCommandExpanded((v) => !v) : undefined
 					}
 					onKeyDown={
-						commandOverflows || commandExpanded
+						canToggleCommand
 							? (e) => {
 									if (e.key === "Enter" || e.key === " ") {
 										e.preventDefault();
@@ -89,8 +91,8 @@ export const ExecuteTool: React.FC<{
 								}
 							: undefined
 					}
-					role={commandOverflows ? "button" : undefined}
-					tabIndex={commandOverflows ? 0 : undefined}
+					role={canToggleCommand ? "button" : undefined}
+					tabIndex={canToggleCommand ? 0 : undefined}
 				>
 					<span className="shrink-0 font-mono text-xs leading-5 text-content-secondary">
 						$
@@ -106,7 +108,7 @@ export const ExecuteTool: React.FC<{
 					</code>
 				</div>
 				<div className="flex shrink-0 items-center gap-1">
-					{commandOverflows && (
+					{canToggleCommand && (
 						<button
 							type="button"
 							onClick={() => setCommandExpanded((v) => !v)}

--- a/site/src/components/ai-elements/tool/ExecuteTool.tsx
+++ b/site/src/components/ai-elements/tool/ExecuteTool.tsx
@@ -3,6 +3,7 @@ import {
 	ChevronDownIcon,
 	CircleAlertIcon,
 	ExternalLinkIcon,
+	LayersIcon,
 	LoaderIcon,
 	TriangleAlertIcon,
 } from "lucide-react";
@@ -12,6 +13,11 @@ import { cn } from "utils/cn";
 import { Button } from "#/components/Button/Button";
 import { CopyButton } from "#/components/CopyButton/CopyButton";
 import { ScrollArea } from "#/components/ScrollArea/ScrollArea";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "#/components/Tooltip/Tooltip";
 import {
 	BORDER_BG_STYLE,
 	COLLAPSED_OUTPUT_HEIGHT,
@@ -28,7 +34,8 @@ export const ExecuteTool: React.FC<{
 	output: string;
 	status: ToolStatus;
 	isError: boolean;
-}> = ({ command, output, status }) => {
+	isBackgrounded?: boolean;
+}> = ({ command, output, status, isBackgrounded = false }) => {
 	const [expanded, setExpanded] = useState(false);
 	const outputRef = useRef<HTMLPreElement | null>(null);
 	const hasOutput = output.length > 0;
@@ -122,6 +129,14 @@ export const ExecuteTool: React.FC<{
 					)}
 					{isRunning && (
 						<LoaderIcon className="h-3.5 w-3.5 shrink-0 animate-spin motion-reduce:animate-none text-content-secondary" />
+					)}
+					{isBackgrounded && !isRunning && (
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<LayersIcon className="h-3.5 w-3.5 shrink-0 text-content-secondary" />
+							</TooltipTrigger>
+							<TooltipContent>Running in background</TooltipContent>
+						</Tooltip>
 					)}
 					<span className="opacity-0 transition-opacity group-hover/exec:opacity-100">
 						<CopyButton text={command} label="Copy command" />

--- a/site/src/components/ai-elements/tool/ExecuteTool.tsx
+++ b/site/src/components/ai-elements/tool/ExecuteTool.tsx
@@ -57,7 +57,12 @@ export const ExecuteTool: React.FC<{
 	return (
 		<div className="group/exec w-full overflow-hidden rounded-md border border-solid border-border-default bg-surface-primary">
 			{/* Header: $ command + copy button */}
-			<div className={cn("flex w-full justify-between gap-2 px-2.5 py-0.5", commandExpanded ? "items-start" : "items-center")}>
+			<div
+				className={cn(
+					"flex w-full justify-between gap-2 px-2.5 py-0.5",
+					commandExpanded ? "items-start" : "items-center",
+				)}
+			>
 				<button
 					type="button"
 					className={cn(
@@ -80,9 +85,7 @@ export const ExecuteTool: React.FC<{
 						ref={commandRef}
 						className={cn(
 							"min-w-0 flex-1 font-mono text-xs leading-5 text-content-primary",
-							commandExpanded
-								? "whitespace-pre-wrap break-all"
-								: "truncate",
+							commandExpanded ? "whitespace-pre-wrap break-all" : "truncate",
 						)}
 					>
 						{command}
@@ -94,7 +97,9 @@ export const ExecuteTool: React.FC<{
 							type="button"
 							onClick={() => setCommandExpanded((v) => !v)}
 							className="border-0 bg-transparent p-0 m-0 cursor-pointer flex items-center text-content-secondary hover:text-content-primary transition-colors"
-							aria-label={commandExpanded ? "Collapse command" : "Expand command"}
+							aria-label={
+								commandExpanded ? "Collapse command" : "Expand command"
+							}
 						>
 							<ChevronDownIcon
 								className={cn(

--- a/site/src/components/ai-elements/tool/ExecuteTool.tsx
+++ b/site/src/components/ai-elements/tool/ExecuteTool.tsx
@@ -39,9 +39,14 @@ export const ExecuteTool: React.FC<{
 	const [commandExpanded, setCommandExpanded] = useState(false);
 	const [commandOverflows, setCommandOverflows] = useState(false);
 	const commandRef = (node: HTMLElement | null) => {
-		if (node) {
+		if (!node) return;
+		const measure = () => {
 			setCommandOverflows(node.scrollWidth > node.clientWidth);
-		}
+		};
+		measure();
+		const ro = new ResizeObserver(measure);
+		ro.observe(node);
+		return () => ro.disconnect();
 	};
 
 	// Check whether the output overflows the collapsed height so we


### PR DESCRIPTION
Previously, long bash commands in the execute tool were truncated with an ellipsis and could not be viewed in full. The only way to see the full command was to copy it via the copy button.

Adds overflow detection and an inline expand/collapse chevron next to the copy button. Clicking the command text or the chevron toggles between truncated and wrapped views. Short commands that fit on one line are visually unchanged.


https://github.com/user-attachments/assets/88ec6cd4-5212-4608-9a90-9ce217d5dce7

EDIT: couldn't be bothered re-recording the video but the chevron is hidden until hovered now, like the copy button.

