### PR TITLE
feat: collapse MCP tool results by default

### DIFF
--- a/site/src/components/ai-elements/tool.stories.tsx
+++ b/site/src/components/ai-elements/tool.stories.tsx
@@ -470,6 +470,120 @@ export const TaskNameGenericRendering: Story = {
 };
 
 // ---------------------------------------------------------------------------
+// MCP tool stories (generic renderer with MCP server context)
+// ---------------------------------------------------------------------------
+
+const sampleMCPServers = [
+	{
+		id: "mcp-server-1",
+		slug: "linear",
+		display_name: "Linear",
+		description: "Project management",
+		icon_url: "https://linear.app/favicon.ico",
+		transport: "streamable_http",
+		url: "https://mcp.linear.app",
+		auth_type: "oauth2",
+		has_oauth2_secret: false,
+		has_api_key: false,
+		has_custom_headers: false,
+		tool_allow_list: [],
+		tool_deny_list: [],
+		availability: "default_on",
+		enabled: true,
+		auth_connected: true,
+		created_at: "2025-01-01T00:00:00Z",
+		updated_at: "2025-01-01T00:00:00Z",
+	},
+] satisfies readonly import("api/typesGenerated").MCPServerConfig[];
+
+export const MCPToolRunning: Story = {
+	args: {
+		name: "linear__list_issues",
+		status: "running",
+		args: { project: "backend" },
+		mcpServerConfigId: "mcp-server-1",
+		mcpServers: sampleMCPServers,
+	},
+	play: async ({ canvasElement }) => {
+		// Spinner should be visible while running.
+		expect(canvasElement.querySelector(".animate-spin")).not.toBeNull();
+		// Icon wrapper should have greyscale filter.
+		const icon = canvasElement.querySelector(".grayscale");
+		expect(icon).not.toBeNull();
+	},
+};
+
+export const MCPToolCompleted: Story = {
+	args: {
+		name: "linear__list_issues",
+		status: "completed",
+		args: { project: "backend" },
+		result: {
+			issues: [
+				{ id: "LIN-123", title: "Fix auth flow" },
+				{ id: "LIN-456", title: "Update dashboard" },
+			],
+		},
+		mcpServerConfigId: "mcp-server-1",
+		mcpServers: sampleMCPServers,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		// No spinner when completed.
+		expect(canvasElement.querySelector(".animate-spin")).toBeNull();
+		// No greyscale when completed.
+		expect(canvasElement.querySelector(".grayscale")).toBeNull();
+		// Result should be collapsed by default.
+		const toggle = canvas.getByRole("button");
+		expect(toggle).toBeInTheDocument();
+		// Expand to see result content.
+		await userEvent.click(toggle);
+		// The JSON output is syntax-highlighted, splitting text across
+		// DOM nodes. Check the raw text content of the container instead.
+		expect(canvasElement.textContent).toContain("Fix auth flow");
+	},
+};
+
+export const MCPToolError: Story = {
+	args: {
+		name: "linear__list_issues",
+		status: "error",
+		isError: true,
+		args: { project: "backend" },
+		result: { error: "Authentication token expired" },
+		mcpServerConfigId: "mcp-server-1",
+		mcpServers: sampleMCPServers,
+	},
+};
+
+export const MCPToolNoResult: Story = {
+	args: {
+		name: "linear__create_issue",
+		status: "completed",
+		args: { title: "New issue" },
+		mcpServerConfigId: "mcp-server-1",
+		mcpServers: sampleMCPServers,
+	},
+	play: async ({ canvasElement }) => {
+		// No toggle button when there is no result content.
+		expect(canvasElement.querySelector("button")).toBeNull();
+	},
+};
+
+export const MCPToolNoServer: Story = {
+	args: {
+		name: "some_custom_tool",
+		status: "completed",
+		result: { output: "Tool finished successfully" },
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		// Falls through to generic wrench icon + raw tool name.
+		expect(canvas.getByText("some_custom_tool")).toBeInTheDocument();
+	},
+};
+
+// ---------------------------------------------------------------------------
 // WriteFile stories
 // ---------------------------------------------------------------------------
 

--- a/site/src/components/ai-elements/tool.stories.tsx
+++ b/site/src/components/ai-elements/tool.stories.tsx
@@ -554,6 +554,15 @@ export const MCPToolError: Story = {
 		mcpServerConfigId: "mcp-server-1",
 		mcpServers: sampleMCPServers,
 	},
+	play: async ({ canvasElement }) => {
+		// Error alert icon should be present.
+		expect(canvasElement.querySelector(".lucide-circle-alert")).not.toBeNull();
+		// Label text should use the destructive color.
+		const label = canvasElement.querySelector(
+			".\\[\\&\\>\\*\\]\\:text-content-destructive",
+		);
+		expect(label).not.toBeNull();
+	},
 };
 
 export const MCPToolNoResult: Story = {

--- a/site/src/components/ai-elements/tool.stories.tsx
+++ b/site/src/components/ai-elements/tool.stories.tsx
@@ -507,8 +507,8 @@ export const MCPToolRunning: Story = {
 	play: async ({ canvasElement }) => {
 		// Spinner should be visible while running.
 		expect(canvasElement.querySelector(".animate-spin")).not.toBeNull();
-		// Icon wrapper should have greyscale filter.
-		const icon = canvasElement.querySelector(".grayscale");
+		// Icon should be monochrome (brightness-0 filter).
+		const icon = canvasElement.querySelector(".brightness-0");
 		expect(icon).not.toBeNull();
 	},
 };
@@ -531,8 +531,8 @@ export const MCPToolCompleted: Story = {
 		const canvas = within(canvasElement);
 		// No spinner when completed.
 		expect(canvasElement.querySelector(".animate-spin")).toBeNull();
-		// No greyscale when completed.
-		expect(canvasElement.querySelector(".grayscale")).toBeNull();
+		// Icon should still be monochrome when completed.
+		expect(canvasElement.querySelector(".brightness-0")).not.toBeNull();
 		// Result should be collapsed by default.
 		const toggle = canvas.getByRole("button");
 		expect(toggle).toBeInTheDocument();
@@ -576,6 +576,60 @@ export const MCPToolNoResult: Story = {
 	play: async ({ canvasElement }) => {
 		// No toggle button when there is no result content.
 		expect(canvasElement.querySelector("button")).toBeNull();
+	},
+};
+
+export const MCPToolSlackIcon: Story = {
+	args: {
+		name: "slack__post_message",
+		status: "completed",
+		result: { ok: true, channel: "#general" },
+		mcpServerConfigId: "mcp-server-1",
+		mcpServers: [
+			{
+				...sampleMCPServers[0],
+				slug: "slack",
+				display_name: "Slack",
+				icon_url:
+					"https://upload.wikimedia.org/wikipedia/commons/thumb/d/d5/Slack_icon_2019.svg/500px-Slack_icon_2019.svg.png",
+			},
+		],
+	},
+};
+
+export const MCPToolGitHubIcon: Story = {
+	args: {
+		name: "github__list_prs",
+		status: "completed",
+		result: { prs: [{ id: 1, title: "Fix bug" }] },
+		mcpServerConfigId: "mcp-server-1",
+		mcpServers: [
+			{
+				...sampleMCPServers[0],
+				slug: "github",
+				display_name: "GitHub",
+				icon_url:
+					"https://upload.wikimedia.org/wikipedia/commons/9/91/Octicons-mark-github.svg",
+			},
+		],
+	},
+};
+
+export const MCPToolFigmaIcon: Story = {
+	args: {
+		name: "figma__get_file",
+		status: "completed",
+		result: { file: "design.fig" },
+		mcpServerConfigId: "mcp-server-1",
+		mcpServers: [
+			{
+				...sampleMCPServers[0],
+				slug: "figma",
+				display_name: "Figma",
+				icon_url:
+					"https://upload.wikimedia.org/wikipedia/commons/3/33/Figma-logo.svg",
+			},
+		],
 	},
 };
 

--- a/site/src/components/ai-elements/tool.stories.tsx
+++ b/site/src/components/ai-elements/tool.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, spyOn, userEvent, within } from "storybook/test";
+import { expect, spyOn, userEvent, waitFor, within } from "storybook/test";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
 import { Tool } from "./tool";
 
@@ -539,8 +539,10 @@ export const MCPToolCompleted: Story = {
 		// Expand to see result content.
 		await userEvent.click(toggle);
 		// The JSON output is syntax-highlighted, splitting text across
-		// DOM nodes. Check the raw text content of the container instead.
-		expect(canvasElement.textContent).toContain("Fix auth flow");
+		// DOM nodes, and the file viewer renders lazily after expand.
+		await waitFor(() =>
+			expect(canvasElement.textContent).toContain("Fix auth flow"),
+		);
 	},
 };
 

--- a/site/src/components/ai-elements/tool.stories.tsx
+++ b/site/src/components/ai-elements/tool.stories.tsx
@@ -538,11 +538,13 @@ export const MCPToolCompleted: Story = {
 		expect(toggle).toBeInTheDocument();
 		// Expand to see result content.
 		await userEvent.click(toggle);
-		// The JSON output is syntax-highlighted, splitting text across
-		// DOM nodes, and the file viewer renders lazily after expand.
-		await waitFor(() =>
-			expect(canvasElement.textContent).toContain("Fix auth flow"),
-		);
+		// @pierre/diffs renders inside a Shadow DOM (<diffs-container>)
+		// so textContent on the host element can't see the content.
+		// Query into the shadow root to verify the JSON rendered.
+		await waitFor(() => {
+			const shadow = canvasElement.querySelector("diffs-container")?.shadowRoot;
+			expect(shadow?.textContent).toContain("Fix auth flow");
+		});
 	},
 };
 

--- a/site/src/components/ai-elements/tool/Tool.tsx
+++ b/site/src/components/ai-elements/tool/Tool.tsx
@@ -497,13 +497,12 @@ const GenericToolRenderer: FC<ToolRendererProps> = ({
 			hasContent={hasContent}
 			header={
 				<>
-					<div className={cn("shrink-0", isRunning && "grayscale")}>
-						<ToolIcon
-							name={name}
-							isError={status === "error" || isError}
-							iconUrl={mcpServer?.icon_url}
-						/>
-					</div>
+					<ToolIcon
+						name={name}
+						isError={status === "error" || isError}
+						iconUrl={mcpServer?.icon_url}
+						isRunning={isRunning}
+					/>
 					<span className={cn(isError && "[&>*]:text-content-destructive")}>
 						<ToolLabel
 							name={name}

--- a/site/src/components/ai-elements/tool/Tool.tsx
+++ b/site/src/components/ai-elements/tool/Tool.tsx
@@ -19,6 +19,7 @@ import { ProposePlanTool } from "./ProposePlanTool";
 import { ReadFileTool } from "./ReadFileTool";
 import { ReadTemplateTool } from "./ReadTemplateTool";
 import { SubagentTool } from "./SubagentTool";
+import { ToolCollapsible } from "./ToolCollapsible";
 import { ToolIcon } from "./ToolIcon";
 import { ToolLabel } from "./ToolLabel";
 import {
@@ -480,24 +481,30 @@ const GenericToolRenderer: FC<ToolRendererProps> = ({
 		? mcpServers?.find((s) => s.id === mcpServerConfigId)
 		: undefined;
 
+	const hasContent = Boolean(writeFileDiff || fileContent || resultOutput);
+
 	return (
-		<>
-			<div className="flex items-center gap-2">
-				<ToolIcon
-					name={name}
-					isError={status === "error" || isError}
-					iconUrl={mcpServer?.icon_url}
-				/>
-				<ToolLabel
-					name={name}
-					args={args}
-					result={result}
-					mcpSlug={mcpServer?.slug}
-				/>
-			</div>
+		<ToolCollapsible
+			hasContent={hasContent}
+			header={
+				<>
+					<ToolIcon
+						name={name}
+						isError={status === "error" || isError}
+						iconUrl={mcpServer?.icon_url}
+					/>
+					<ToolLabel
+						name={name}
+						args={args}
+						result={result}
+						mcpSlug={mcpServer?.slug}
+					/>
+				</>
+			}
+		>
 			{writeFileDiff ? (
 				<ScrollArea
-					className="mt-1.5 ml-6 rounded-md border border-solid border-border-default text-2xs"
+					className="mt-1.5 rounded-md border border-solid border-border-default text-2xs"
 					viewportClassName="max-h-64"
 					scrollBarClassName="w-1.5"
 				>
@@ -509,7 +516,7 @@ const GenericToolRenderer: FC<ToolRendererProps> = ({
 				</ScrollArea>
 			) : fileContent ? (
 				<ScrollArea
-					className="mt-1.5 ml-6 rounded-md border border-solid border-border-default text-2xs"
+					className="mt-1.5 rounded-md border border-solid border-border-default text-2xs"
 					viewportClassName="max-h-64"
 					scrollBarClassName="w-1.5"
 				>
@@ -524,7 +531,7 @@ const GenericToolRenderer: FC<ToolRendererProps> = ({
 			) : (
 				resultOutput && (
 					<ScrollArea
-						className="mt-1.5 ml-6 rounded-md border border-solid border-border-default text-2xs"
+						className="mt-1.5 rounded-md border border-solid border-border-default text-2xs"
 						viewportClassName="max-h-64"
 						scrollBarClassName="w-1.5"
 					>
@@ -539,7 +546,7 @@ const GenericToolRenderer: FC<ToolRendererProps> = ({
 					</ScrollArea>
 				)
 			)}
-		</>
+		</ToolCollapsible>
 	);
 };
 

--- a/site/src/components/ai-elements/tool/Tool.tsx
+++ b/site/src/components/ai-elements/tool/Tool.tsx
@@ -1,6 +1,7 @@
 import { useTheme } from "@emotion/react";
 import { FileDiff, File as FileViewer } from "@pierre/diffs/react";
 import type * as TypesGen from "api/typesGenerated";
+import { LoaderIcon } from "lucide-react";
 import { type ComponentPropsWithRef, type FC, memo } from "react";
 import { cn } from "utils/cn";
 import { ScrollArea } from "#/components/ScrollArea/ScrollArea";
@@ -482,23 +483,29 @@ const GenericToolRenderer: FC<ToolRendererProps> = ({
 		: undefined;
 
 	const hasContent = Boolean(writeFileDiff || fileContent || resultOutput);
+	const isRunning = status === "running";
 
 	return (
 		<ToolCollapsible
 			hasContent={hasContent}
 			header={
 				<>
-					<ToolIcon
-						name={name}
-						isError={status === "error" || isError}
-						iconUrl={mcpServer?.icon_url}
-					/>
+					<span className={cn(isRunning && "grayscale")}>
+						<ToolIcon
+							name={name}
+							isError={status === "error" || isError}
+							iconUrl={mcpServer?.icon_url}
+						/>
+					</span>
 					<ToolLabel
 						name={name}
 						args={args}
 						result={result}
 						mcpSlug={mcpServer?.slug}
 					/>
+					{isRunning && (
+						<LoaderIcon className="h-3.5 w-3.5 shrink-0 animate-spin motion-reduce:animate-none text-content-secondary" />
+					)}
 				</>
 			}
 		>

--- a/site/src/components/ai-elements/tool/Tool.tsx
+++ b/site/src/components/ai-elements/tool/Tool.tsx
@@ -1,10 +1,15 @@
 import { useTheme } from "@emotion/react";
 import { FileDiff, File as FileViewer } from "@pierre/diffs/react";
 import type * as TypesGen from "api/typesGenerated";
-import { LoaderIcon } from "lucide-react";
+import { CircleAlertIcon, LoaderIcon } from "lucide-react";
 import { type ComponentPropsWithRef, type FC, memo } from "react";
 import { cn } from "utils/cn";
 import { ScrollArea } from "#/components/ScrollArea/ScrollArea";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "#/components/Tooltip/Tooltip";
 import { ChatSummarizedTool } from "./ChatSummarizedTool";
 import { ComputerTool } from "./ComputerTool";
 import { CreateWorkspaceTool } from "./CreateWorkspaceTool";
@@ -484,6 +489,8 @@ const GenericToolRenderer: FC<ToolRendererProps> = ({
 
 	const hasContent = Boolean(writeFileDiff || fileContent || resultOutput);
 	const isRunning = status === "running";
+	const rec = asRecord(result);
+	const errorMessage = rec ? asString(rec.error || rec.message) : "";
 
 	return (
 		<ToolCollapsible
@@ -497,12 +504,24 @@ const GenericToolRenderer: FC<ToolRendererProps> = ({
 							iconUrl={mcpServer?.icon_url}
 						/>
 					</div>
-					<ToolLabel
-						name={name}
-						args={args}
-						result={result}
-						mcpSlug={mcpServer?.slug}
-					/>
+					<span className={cn(isError && "[&>*]:text-content-destructive")}>
+						<ToolLabel
+							name={name}
+							args={args}
+							result={result}
+							mcpSlug={mcpServer?.slug}
+						/>
+					</span>
+					{isError && (
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<CircleAlertIcon className="h-3.5 w-3.5 shrink-0 text-content-destructive" />
+							</TooltipTrigger>
+							<TooltipContent>
+								{errorMessage || "Tool call failed"}
+							</TooltipContent>
+						</Tooltip>
+					)}
 					{isRunning && (
 						<LoaderIcon className="h-3.5 w-3.5 shrink-0 animate-spin motion-reduce:animate-none text-content-secondary" />
 					)}

--- a/site/src/components/ai-elements/tool/Tool.tsx
+++ b/site/src/components/ai-elements/tool/Tool.tsx
@@ -502,6 +502,7 @@ const GenericToolRenderer: FC<ToolRendererProps> = ({
 						isError={status === "error" || isError}
 						iconUrl={mcpServer?.icon_url}
 						isRunning={isRunning}
+						serverName={mcpServer?.display_name}
 					/>
 					<span className={cn(isError && "[&>*]:text-content-destructive")}>
 						<ToolLabel

--- a/site/src/components/ai-elements/tool/Tool.tsx
+++ b/site/src/components/ai-elements/tool/Tool.tsx
@@ -490,13 +490,13 @@ const GenericToolRenderer: FC<ToolRendererProps> = ({
 			hasContent={hasContent}
 			header={
 				<>
-					<span className={cn(isRunning && "grayscale")}>
+					<div className={cn("shrink-0", isRunning && "grayscale")}>
 						<ToolIcon
 							name={name}
 							isError={status === "error" || isError}
 							iconUrl={mcpServer?.icon_url}
 						/>
-					</span>
+					</div>
 					<ToolLabel
 						name={name}
 						args={args}

--- a/site/src/components/ai-elements/tool/ToolIcon.tsx
+++ b/site/src/components/ai-elements/tool/ToolIcon.tsx
@@ -35,28 +35,37 @@ export const ToolIcon: React.FC<{
 	// mode we invert to white and tune opacity to approximate
 	// content-secondary (light ≈ 34% lightness, dark ≈ 65%).
 	if (iconUrl && !imgError) {
-		// On error we use a drop-shadow trick to recolor the icon to
-		// the exact destructive token: brightness-0 makes the image
-		// black, drop-shadow casts a colored copy 16px to the right,
-		// -translate-x-4 shifts so the colored copy sits where the
-		// original was, and overflow-hidden on the wrapper clips the
-		// black original.
-		const img = isError ? (
+		// Always render the same DOM shape so React never unmounts
+		// the <img> when isError changes (avoids a reload flicker).
+		//
+		// The wrapper clips a translated copy of the image so the
+		// drop-shadow trick can work on error (see image classes).
+		// In the normal state the image is not translated and the
+		// wrapper's overflow-hidden is a harmless no-op.
+		const img = (
 			<div className="h-4 w-4 shrink-0 overflow-hidden">
 				<ExternalImage
 					src={iconUrl}
 					alt={`${name} icon`}
-					className="block h-4 w-4 -translate-x-4 brightness-0 [filter:brightness(0)_drop-shadow(16px_0_0_hsl(var(--content-destructive)))]"
+					className={cn(
+						"block h-4 w-4",
+						isError
+							? // Drop-shadow recolor: brightness-0 makes every
+								// pixel black, drop-shadow casts an exact-color
+								// copy 16px to the right following the alpha
+								// channel, -translate-x-4 shifts the colored copy
+								// into the original position, and the wrapper's
+								// overflow-hidden clips the black original.
+								"-translate-x-4 [filter:brightness(0)_drop-shadow(16px_0_0_hsl(var(--content-destructive)))]"
+							: // Monochrome: brightness-0 strips colour to black,
+								// dark:invert flips to white for dark backgrounds,
+								// opacity tuned per-theme to match content-secondary
+								// (light ~35% lightness, dark ~65%).
+								"brightness-0 opacity-[0.35] dark:invert dark:opacity-[0.65]",
+					)}
 					onError={() => setImgError(true)}
 				/>
 			</div>
-		) : (
-			<ExternalImage
-				src={iconUrl}
-				alt={`${name} icon`}
-				className="block h-4 w-4 shrink-0 brightness-0 opacity-[0.35] dark:invert dark:opacity-[0.65]"
-				onError={() => setImgError(true)}
-			/>
 		);
 
 		if (serverName) {

--- a/site/src/components/ai-elements/tool/ToolIcon.tsx
+++ b/site/src/components/ai-elements/tool/ToolIcon.tsx
@@ -23,35 +23,23 @@ export const ToolIcon: React.FC<{
 	const base = cn("h-4 w-4 shrink-0", color);
 
 	// If an MCP icon URL is provided and hasn't failed, render it.
+	// On error the image is desaturated to white with CSS filters and
+	// a destructive-colored overlay is composited on top via
+	// mix-blend-multiply so the final colour matches the design token
+	// exactly. `isolate` scopes the blend to this container.
 	if (iconUrl && !imgError) {
-		// On error, use the image as a CSS mask so the fill color is
-		// exactly bg-content-destructive, matching the lucide icons.
-		if (isError) {
-			return (
-				<div
-					role="img"
-					aria-label={`${name} icon`}
-					className="h-4 w-4 shrink-0 bg-content-destructive"
-					style={{
-						WebkitMaskImage: `url(${iconUrl})`,
-						maskImage: `url(${iconUrl})`,
-						WebkitMaskSize: "contain",
-						maskSize: "contain",
-						WebkitMaskRepeat: "no-repeat",
-						maskRepeat: "no-repeat",
-						WebkitMaskPosition: "center",
-						maskPosition: "center",
-					}}
-				/>
-			);
-		}
 		return (
-			<ExternalImage
-				src={iconUrl}
-				alt={`${name} icon`}
-				className="block h-4 w-4 shrink-0"
-				onError={() => setImgError(true)}
-			/>
+			<div className={cn("relative h-4 w-4 shrink-0", isError && "isolate")}>
+				<ExternalImage
+					src={iconUrl}
+					alt={`${name} icon`}
+					className={cn("block h-4 w-4", isError && "brightness-0 invert")}
+					onError={() => setImgError(true)}
+				/>
+				{isError && (
+					<div className="absolute inset-0 bg-content-destructive mix-blend-multiply" />
+				)}
+			</div>
 		);
 	}
 

--- a/site/src/components/ai-elements/tool/ToolIcon.tsx
+++ b/site/src/components/ai-elements/tool/ToolIcon.tsx
@@ -24,18 +24,20 @@ export const ToolIcon: React.FC<{
 	const base = cn("h-4 w-4 shrink-0", color, isRunning && "grayscale");
 
 	// If an MCP icon URL is provided and hasn't failed, render it.
-	// External images can't be recolored to an exact CSS token, so
-	// on error the image is shown with reduced opacity. The error
-	// state is communicated by the red label text and alert icon.
+	// Strip colour so external icons match the monochrome lucide
+	// style. brightness-0 forces every pixel to black, then in dark
+	// mode we invert to white and tune opacity to approximate
+	// content-secondary (light ≈ 34% lightness, dark ≈ 65%).
+	// On error we halve opacity further; on running it's the same
+	// monochrome treatment (already desaturated).
 	if (iconUrl && !imgError) {
 		return (
 			<ExternalImage
 				src={iconUrl}
 				alt={`${name} icon`}
 				className={cn(
-					"block h-4 w-4 shrink-0",
-					isError && "opacity-50 grayscale",
-					isRunning && "grayscale",
+					"block h-4 w-4 shrink-0 brightness-0 opacity-[0.35] dark:invert dark:opacity-[0.65]",
+					isError && "!opacity-[0.2] dark:!opacity-[0.35]",
 				)}
 				onError={() => setImgError(true)}
 			/>

--- a/site/src/components/ai-elements/tool/ToolIcon.tsx
+++ b/site/src/components/ai-elements/tool/ToolIcon.tsx
@@ -17,29 +17,28 @@ export const ToolIcon: React.FC<{
 	name: string;
 	isError: boolean;
 	iconUrl?: string;
-}> = ({ name, isError, iconUrl }) => {
+	isRunning?: boolean;
+}> = ({ name, isError, iconUrl, isRunning }) => {
 	const [imgError, setImgError] = useState(false);
 	const color = isError ? "text-content-destructive" : "text-content-secondary";
-	const base = cn("h-4 w-4 shrink-0", color);
+	const base = cn("h-4 w-4 shrink-0", color, isRunning && "grayscale");
 
 	// If an MCP icon URL is provided and hasn't failed, render it.
-	// On error the image is desaturated to white with CSS filters and
-	// a destructive-colored overlay is composited on top via
-	// mix-blend-multiply so the final colour matches the design token
-	// exactly. `isolate` scopes the blend to this container.
+	// External images can't be recolored to an exact CSS token, so
+	// on error the image is shown with reduced opacity. The error
+	// state is communicated by the red label text and alert icon.
 	if (iconUrl && !imgError) {
 		return (
-			<div className={cn("relative h-4 w-4 shrink-0", isError && "isolate")}>
-				<ExternalImage
-					src={iconUrl}
-					alt={`${name} icon`}
-					className={cn("block h-4 w-4", isError && "brightness-0 invert")}
-					onError={() => setImgError(true)}
-				/>
-				{isError && (
-					<div className="absolute inset-0 bg-content-destructive mix-blend-multiply" />
+			<ExternalImage
+				src={iconUrl}
+				alt={`${name} icon`}
+				className={cn(
+					"block h-4 w-4 shrink-0",
+					isError && "opacity-50 grayscale",
+					isRunning && "grayscale",
 				)}
-			</div>
+				onError={() => setImgError(true)}
+			/>
 		);
 	}
 

--- a/site/src/components/ai-elements/tool/ToolIcon.tsx
+++ b/site/src/components/ai-elements/tool/ToolIcon.tsx
@@ -24,15 +24,32 @@ export const ToolIcon: React.FC<{
 
 	// If an MCP icon URL is provided and hasn't failed, render it.
 	if (iconUrl && !imgError) {
+		// On error, use the image as a CSS mask so the fill color is
+		// exactly bg-content-destructive, matching the lucide icons.
+		if (isError) {
+			return (
+				<div
+					role="img"
+					aria-label={`${name} icon`}
+					className="h-4 w-4 shrink-0 bg-content-destructive"
+					style={{
+						WebkitMaskImage: `url(${iconUrl})`,
+						maskImage: `url(${iconUrl})`,
+						WebkitMaskSize: "contain",
+						maskSize: "contain",
+						WebkitMaskRepeat: "no-repeat",
+						maskRepeat: "no-repeat",
+						WebkitMaskPosition: "center",
+						maskPosition: "center",
+					}}
+				/>
+			);
+		}
 		return (
 			<ExternalImage
 				src={iconUrl}
 				alt={`${name} icon`}
-				className={cn(
-					"block h-4 w-4 shrink-0",
-					isError &&
-						"brightness-0 invert-[.35] sepia saturate-[10] hue-rotate-[340deg]",
-				)}
+				className="block h-4 w-4 shrink-0"
 				onError={() => setImgError(true)}
 			/>
 		);

--- a/site/src/components/ai-elements/tool/ToolIcon.tsx
+++ b/site/src/components/ai-elements/tool/ToolIcon.tsx
@@ -35,7 +35,22 @@ export const ToolIcon: React.FC<{
 	// mode we invert to white and tune opacity to approximate
 	// content-secondary (light ≈ 34% lightness, dark ≈ 65%).
 	if (iconUrl && !imgError) {
-		const img = (
+		// On error we use a drop-shadow trick to recolor the icon to
+		// the exact destructive token: brightness-0 makes the image
+		// black, drop-shadow casts a colored copy 16px to the right,
+		// -translate-x-4 shifts so the colored copy sits where the
+		// original was, and overflow-hidden on the wrapper clips the
+		// black original.
+		const img = isError ? (
+			<div className="h-4 w-4 shrink-0 overflow-hidden">
+				<ExternalImage
+					src={iconUrl}
+					alt={`${name} icon`}
+					className="block h-4 w-4 -translate-x-4 brightness-0 [filter:brightness(0)_drop-shadow(16px_0_0_hsl(var(--content-destructive)))]"
+					onError={() => setImgError(true)}
+				/>
+			</div>
+		) : (
 			<ExternalImage
 				src={iconUrl}
 				alt={`${name} icon`}

--- a/site/src/components/ai-elements/tool/ToolIcon.tsx
+++ b/site/src/components/ai-elements/tool/ToolIcon.tsx
@@ -25,20 +25,16 @@ export const ToolIcon: React.FC<{
 	// If an MCP icon URL is provided and hasn't failed, render it.
 	if (iconUrl && !imgError) {
 		return (
-			<div
+			<ExternalImage
+				src={iconUrl}
+				alt={`${name} icon`}
 				className={cn(
-					"flex h-4 w-4 shrink-0 items-center justify-center",
-					"rounded-full bg-surface-secondary",
-					isError && "ring-1 ring-content-destructive",
+					"h-4 w-4 shrink-0",
+					isError &&
+						"brightness-0 invert-[.35] sepia saturate-[10] hue-rotate-[340deg]",
 				)}
-			>
-				<ExternalImage
-					src={iconUrl}
-					alt={`${name} icon`}
-					className="h-3 w-3"
-					onError={() => setImgError(true)}
-				/>
-			</div>
+				onError={() => setImgError(true)}
+			/>
 		);
 	}
 

--- a/site/src/components/ai-elements/tool/ToolIcon.tsx
+++ b/site/src/components/ai-elements/tool/ToolIcon.tsx
@@ -12,13 +12,19 @@ import type React from "react";
 import { useState } from "react";
 import { cn } from "utils/cn";
 import { ExternalImage } from "#/components/ExternalImage/ExternalImage";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "#/components/Tooltip/Tooltip";
 
 export const ToolIcon: React.FC<{
 	name: string;
 	isError: boolean;
 	iconUrl?: string;
 	isRunning?: boolean;
-}> = ({ name, isError, iconUrl, isRunning }) => {
+	serverName?: string;
+}> = ({ name, isError, iconUrl, isRunning, serverName }) => {
 	const [imgError, setImgError] = useState(false);
 	const color = isError ? "text-content-destructive" : "text-content-secondary";
 	const base = cn("h-4 w-4 shrink-0", color, isRunning && "grayscale");
@@ -28,20 +34,26 @@ export const ToolIcon: React.FC<{
 	// style. brightness-0 forces every pixel to black, then in dark
 	// mode we invert to white and tune opacity to approximate
 	// content-secondary (light ≈ 34% lightness, dark ≈ 65%).
-	// On error we halve opacity further; on running it's the same
-	// monochrome treatment (already desaturated).
 	if (iconUrl && !imgError) {
-		return (
+		const img = (
 			<ExternalImage
 				src={iconUrl}
 				alt={`${name} icon`}
-				className={cn(
-					"block h-4 w-4 shrink-0 brightness-0 opacity-[0.35] dark:invert dark:opacity-[0.65]",
-					isError && "!opacity-[0.2] dark:!opacity-[0.35]",
-				)}
+				className="block h-4 w-4 shrink-0 brightness-0 opacity-[0.35] dark:invert dark:opacity-[0.65]"
 				onError={() => setImgError(true)}
 			/>
 		);
+
+		if (serverName) {
+			return (
+				<Tooltip>
+					<TooltipTrigger asChild>{img}</TooltipTrigger>
+					<TooltipContent>{serverName}</TooltipContent>
+				</Tooltip>
+			);
+		}
+
+		return img;
 	}
 
 	switch (name) {

--- a/site/src/components/ai-elements/tool/ToolIcon.tsx
+++ b/site/src/components/ai-elements/tool/ToolIcon.tsx
@@ -29,7 +29,7 @@ export const ToolIcon: React.FC<{
 				src={iconUrl}
 				alt={`${name} icon`}
 				className={cn(
-					"h-4 w-4 shrink-0",
+					"block h-4 w-4 shrink-0",
 					isError &&
 						"brightness-0 invert-[.35] sepia saturate-[10] hue-rotate-[340deg]",
 				)}


### PR DESCRIPTION
Wraps the `GenericToolRenderer` (used for MCP and unrecognized tools) in `ToolCollapsible` so the result content is hidden behind a click-to-expand chevron, matching the pattern used by `read_file`, `write_file`, and other built-in tool renderers.

### Changes

- Move `ToolIcon` + `ToolLabel` into the `ToolCollapsible` `header` prop
- Compute `hasContent` from `writeFileDiff` / `fileContent` / `resultOutput` — when there's no content, the header renders as a plain div with no chevron
- Remove `ml-6` from `ScrollArea` classNames (the `ToolCollapsible` button handles its own layout)
- `defaultExpanded` is `false` by default in `ToolCollapsible`, so results start collapsed

### Before

MCP tool results were always fully visible inline.

### After

MCP tool results are collapsed by default with a chevron toggle, consistent with `read_file`, `edit_files`, `list_templates`, etc.