### PR TITLE
fix(site): remove rounded-full override from agent sidebar avatar

### DIFF
--- a/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
@@ -905,7 +905,6 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 										fallback={user.username}
 										src={user.avatar_url}
 										size="sm"
-										className="rounded-full"
 									/>
 									<span className="truncate text-sm text-content-secondary">
 										{user.name || user.username}


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

The user avatar in the agents sidebar was using `className="rounded-full"`, overriding the design system's default `rounded` corners. No other Avatar usage in the codebase applies this override.