### PR TITLE
fix(site): fix right panel layout issues at responsive breakpoints

### DIFF
--- a/site/src/pages/AgentsPage/components/AgentDetailView.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetailView.tsx
@@ -216,7 +216,7 @@ export const AgentDetailView: FC<AgentDetailViewProps> = ({
 			{titleElement}
 			<div
 				className={cn(
-					"relative flex min-h-0 min-w-0 flex-1 flex-col",
+					"relative flex min-h-0 min-w-0 flex-1 flex-col overflow-x-hidden",
 					visualExpanded && "hidden",
 					shouldShowSidebar && "max-md:hidden",
 				)}

--- a/site/src/pages/AgentsPage/components/RightPanel/RightPanel.tsx
+++ b/site/src/pages/AgentsPage/components/RightPanel/RightPanel.tsx
@@ -247,7 +247,7 @@ export const RightPanel = ({
 					: cn(
 							"relative min-h-0 min-w-0",
 							visualOpen
-								? "flex h-full w-[100vw] min-w-0 flex-col border-0 border-l border-solid border-border-default sm:w-[var(--panel-width)] sm:min-w-[360px] sm:max-w-[70vw]"
+								? "flex h-full w-[100vw] min-w-0 flex-col border-0 border-solid border-border-default md:border-l md:w-[var(--panel-width)] md:min-w-[360px] md:max-w-[70vw]"
 								: "hidden",
 						),
 			)}
@@ -258,7 +258,7 @@ export const RightPanel = ({
 				onPointerMove={handlePointerMove}
 				onPointerUp={handlePointerUp}
 				className={cn(
-					"absolute top-0 left-0 z-20 hidden h-full w-1 cursor-col-resize select-none transition-colors hover:bg-content-link sm:block",
+					"absolute top-0 left-0 z-20 hidden h-full w-1 cursor-col-resize select-none transition-colors hover:bg-content-link md:block",
 					visualExpanded && "-left-1",
 				)}
 			/>


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

The right panel had two layout problems when shrinking the viewport with the panel open:

1. The TopBar's three-dot menu and panel-close button visually overflowed into the right panel area. The chat content column uses `min-w-0` (can shrink freely) while the TopBar wrapper uses `overflow-visible` (for its gradient effect), so as the right panel's 360px min-width squeezed the content column the buttons spilled out. Adding `overflow-x-hidden` to the content column clips horizontal overflow without affecting the vertical gradient.

2. Below the `md` breakpoint the sidebar hides and the chat column gets `max-md:hidden`, but the right panel's width constraints kicked in at `sm` (640px) instead of `md` (768px). Between those breakpoints the panel had a fixed pixel width with nothing beside it — appearing on the left side of the page with whitespace on the right. Moving the panel's width/min-width/max-width, `border-l`, and drag-handle visibility from `sm:` to `md:` makes the panel take full viewport width below `md`.