### PR TITLE
feat(site): harden Agents embed frame communication and add theme sync

### DIFF
--- a/site/src/contexts/ThemeProvider.tsx
+++ b/site/src/contexts/ThemeProvider.tsx
@@ -69,6 +69,10 @@ export const ThemeProvider: FC<PropsWithChildren> = ({ children }) => {
 
 	useEffect(() => {
 		const root = document.documentElement;
+		// Embedded pages manage theme independently.
+		if (root.dataset.embedTheme) {
+			return;
+		}
 		if (themePreference === "auto") {
 			root.classList.add(preferredColorScheme);
 		} else {
@@ -76,7 +80,9 @@ export const ThemeProvider: FC<PropsWithChildren> = ({ children }) => {
 		}
 
 		return () => {
-			root.classList.remove("light", "dark");
+			if (!root.dataset.embedTheme) {
+				root.classList.remove("light", "dark");
+			}
 		};
 	}, [themePreference, preferredColorScheme]);
 

--- a/site/src/pages/AgentsPage/AgentDetail.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.stories.tsx
@@ -54,6 +54,7 @@ const AgentDetailLayout: FC = () => {
 							isSidebarCollapsed: false,
 							onToggleSidebarCollapsed: () => {},
 							onExpandSidebar: () => {},
+							onChatReady: () => {},
 						} satisfies AgentsOutletContext
 					}
 				/>

--- a/site/src/pages/AgentsPage/AgentDetail.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.stories.tsx
@@ -11,6 +11,7 @@ import {
 } from "testHelpers/storybook";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { FC } from "react";
+import { useRef } from "react";
 import { Outlet } from "react-router";
 import { expect, spyOn, userEvent, waitFor, within } from "storybook/test";
 import {
@@ -36,6 +37,7 @@ import type { AgentsOutletContext } from "./AgentsPage";
 // Layout wrapper – provides outlet context for the child route.
 // ---------------------------------------------------------------------------
 const AgentDetailLayout: FC = () => {
+	const scrollContainerRef = useRef<HTMLDivElement | null>(null);
 	return (
 		<div className="flex h-full">
 			<div className="flex min-w-0 flex-1 flex-col overflow-hidden">
@@ -55,6 +57,7 @@ const AgentDetailLayout: FC = () => {
 							onToggleSidebarCollapsed: () => {},
 							onExpandSidebar: () => {},
 							onChatReady: () => {},
+							scrollContainerRef,
 						} satisfies AgentsOutletContext
 					}
 				/>

--- a/site/src/pages/AgentsPage/AgentDetail.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.tsx
@@ -54,7 +54,6 @@ import {
 	AgentDetailNotFoundView,
 	AgentDetailView,
 } from "./components/AgentDetailView";
-import { useEmbedContext } from "./components/EmbedContext";
 import {
 	getDefaultMCPSelection,
 	getSavedMCPSelection,
@@ -303,7 +302,6 @@ const AgentDetail: FC = () => {
 		number | null
 	>(null);
 	const scrollContainerRef = useRef<HTMLDivElement | null>(null);
-	const { isEmbedded } = useEmbedContext();
 	const chatInputRef = useRef<ChatMessageInputRef | null>(null);
 	const inputValueRef = useRef(
 		agentId
@@ -887,30 +885,6 @@ const AgentDetail: FC = () => {
 		chatReadyFiredRef.current = agentId ?? null;
 		onChatReady();
 	}, [onChatReady, chatMessagesQuery.isSuccess, agentId]);
-
-	// Handle scroll-to-bottom requests from the parent frame.
-	// In the flex-col-reverse layout, scrollTop = 0 is the
-	// visual bottom.
-	useEffect(() => {
-		if (!isEmbedded) {
-			return;
-		}
-		const parentWindow = window.parent;
-		const handler = (event: MessageEvent) => {
-			if (
-				event.source !== parentWindow ||
-				event.data?.type !== "coder:scroll-to-bottom"
-			) {
-				return;
-			}
-			if (scrollContainerRef.current) {
-				scrollContainerRef.current.scrollTop = 0;
-			}
-		};
-
-		window.addEventListener("message", handler);
-		return () => window.removeEventListener("message", handler);
-	}, [isEmbedded]);
 
 	if (chatQuery.isLoading || chatMessagesQuery.isLoading) {
 		return (

--- a/site/src/pages/AgentsPage/AgentDetail.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.tsx
@@ -295,6 +295,7 @@ const AgentDetail: FC = () => {
 		requestUnarchiveAgent,
 		isSidebarCollapsed,
 		onToggleSidebarCollapsed,
+		onChatReady,
 	} = useOutletContext<AgentsOutletContext>();
 	const queryClient = useQueryClient();
 	const [selectedModel, setSelectedModel] = useState("");
@@ -303,7 +304,6 @@ const AgentDetail: FC = () => {
 	>(null);
 	const scrollContainerRef = useRef<HTMLDivElement | null>(null);
 	const { isEmbedded } = useEmbedContext();
-	const chatReadyAgentIdRef = useRef<string | null>(null);
 	const chatInputRef = useRef<ChatMessageInputRef | null>(null);
 	const inputValueRef = useRef(
 		agentId
@@ -878,32 +878,15 @@ const AgentDetail: FC = () => {
 		requestUnarchiveAgent(agentId);
 	};
 
-	// When embedded, scroll to bottom once messages load and
-	// notify the parent frame that the chat is ready. Comparing
-	// against the last signaled agentId re-fires the notification
-	// when the user switches agents without a full remount.
+	// Signal the parent layout that messages have loaded.
+	const chatReadyFiredRef = useRef<string | null>(null);
 	useEffect(() => {
-		if (
-			!isEmbedded ||
-			chatReadyAgentIdRef.current === agentId ||
-			!chatMessagesQuery.isSuccess
-		) {
+		if (chatReadyFiredRef.current === agentId || !chatMessagesQuery.isSuccess) {
 			return;
 		}
-		chatReadyAgentIdRef.current = agentId ?? null;
-
-		// A rAF lets the browser finish layout after React's
-		// commit before we scroll.
-		const rafId = requestAnimationFrame(() => {
-			if (scrollContainerRef.current) {
-				// flex-col-reverse: scrollTop 0 is the visual bottom.
-				scrollContainerRef.current.scrollTop = 0;
-			}
-			window.parent.postMessage({ type: "coder:chat-ready" }, "*");
-		});
-
-		return () => cancelAnimationFrame(rafId);
-	}, [isEmbedded, chatMessagesQuery.isSuccess, agentId]);
+		chatReadyFiredRef.current = agentId ?? null;
+		onChatReady();
+	}, [onChatReady, chatMessagesQuery.isSuccess, agentId]);
 
 	// Handle scroll-to-bottom requests from the parent frame.
 	// In the flex-col-reverse layout, scrollTop = 0 is the

--- a/site/src/pages/AgentsPage/AgentDetail.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.tsx
@@ -295,13 +295,13 @@ const AgentDetail: FC = () => {
 		isSidebarCollapsed,
 		onToggleSidebarCollapsed,
 		onChatReady,
+		scrollContainerRef,
 	} = useOutletContext<AgentsOutletContext>();
 	const queryClient = useQueryClient();
 	const [selectedModel, setSelectedModel] = useState("");
 	const [pendingEditMessageId, setPendingEditMessageId] = useState<
 		number | null
 	>(null);
-	const scrollContainerRef = useRef<HTMLDivElement | null>(null);
 	const chatInputRef = useRef<ChatMessageInputRef | null>(null);
 	const inputValueRef = useRef(
 		agentId

--- a/site/src/pages/AgentsPage/AgentDetail.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.tsx
@@ -54,6 +54,7 @@ import {
 	AgentDetailNotFoundView,
 	AgentDetailView,
 } from "./components/AgentDetailView";
+import { useEmbedContext } from "./components/EmbedContext";
 import {
 	getDefaultMCPSelection,
 	getSavedMCPSelection,
@@ -301,6 +302,8 @@ const AgentDetail: FC = () => {
 		number | null
 	>(null);
 	const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+	const { isEmbedded } = useEmbedContext();
+	const chatReadyAgentIdRef = useRef<string | null>(null);
 	const chatInputRef = useRef<ChatMessageInputRef | null>(null);
 	const inputValueRef = useRef(
 		agentId
@@ -874,6 +877,57 @@ const AgentDetail: FC = () => {
 		}
 		requestUnarchiveAgent(agentId);
 	};
+
+	// When embedded, scroll to bottom once messages load and
+	// notify the parent frame that the chat is ready. Comparing
+	// against the last signaled agentId re-fires the notification
+	// when the user switches agents without a full remount.
+	useEffect(() => {
+		if (
+			!isEmbedded ||
+			chatReadyAgentIdRef.current === agentId ||
+			!chatMessagesQuery.isSuccess
+		) {
+			return;
+		}
+		chatReadyAgentIdRef.current = agentId ?? null;
+
+		// A rAF lets the browser finish layout after React's
+		// commit before we scroll.
+		const rafId = requestAnimationFrame(() => {
+			if (scrollContainerRef.current) {
+				// flex-col-reverse: scrollTop 0 is the visual bottom.
+				scrollContainerRef.current.scrollTop = 0;
+			}
+			window.parent.postMessage({ type: "coder:chat-ready" }, "*");
+		});
+
+		return () => cancelAnimationFrame(rafId);
+	}, [isEmbedded, chatMessagesQuery.isSuccess, agentId]);
+
+	// Handle scroll-to-bottom requests from the parent frame.
+	// In the flex-col-reverse layout, scrollTop = 0 is the
+	// visual bottom.
+	useEffect(() => {
+		if (!isEmbedded) {
+			return;
+		}
+		const parentWindow = window.parent;
+		const handler = (event: MessageEvent) => {
+			if (
+				event.source !== parentWindow ||
+				event.data?.type !== "coder:scroll-to-bottom"
+			) {
+				return;
+			}
+			if (scrollContainerRef.current) {
+				scrollContainerRef.current.scrollTop = 0;
+			}
+		};
+
+		window.addEventListener("message", handler);
+		return () => window.removeEventListener("message", handler);
+	}, [isEmbedded]);
 
 	if (chatQuery.isLoading || chatMessagesQuery.isLoading) {
 		return (

--- a/site/src/pages/AgentsPage/AgentEmbedPage.tsx
+++ b/site/src/pages/AgentsPage/AgentEmbedPage.tsx
@@ -2,23 +2,10 @@ import { useAuthContext } from "contexts/auth/AuthProvider";
 import { ProxyProvider } from "contexts/ProxyContext";
 import { DashboardProvider } from "modules/dashboard/DashboardProvider";
 import { permissionChecks } from "modules/permissions";
-import {
-	type FC,
-	useCallback,
-	useEffect,
-	useLayoutEffect,
-	useRef,
-	useState,
-} from "react";
+import { type FC, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useMutation, useQueryClient } from "react-query";
+import { Outlet, useBlocker, useParams, useSearchParams } from "react-router";
 import { getErrorMessage } from "#/api/errors";
-import {
-	type BlockerFunction,
-	Outlet,
-	useBlocker,
-	useParams,
-	useSearchParams,
-} from "react-router";
 import { Button } from "#/components/Button/Button";
 import { Loader } from "#/components/Loader/Loader";
 import type { AgentsOutletContext } from "./AgentsPage";
@@ -166,27 +153,21 @@ const AgentEmbedPage: FC = () => {
 
 	// Block navigations that leave the embed route and forward
 	// the target URL to the parent frame.
-	useBlocker(
-		useCallback<BlockerFunction>(
-			({ nextLocation }) => {
-				if (nextLocation.pathname.startsWith(`/agents/${agentId}/embed`)) {
-					return false;
-				}
-				window.parent.postMessage(
-					{
-						type: "coder:navigate",
-						payload: {
-							url:
-								nextLocation.pathname + nextLocation.search + nextLocation.hash,
-						},
-					},
-					"*",
-				);
-				return true;
+	useBlocker(({ nextLocation }) => {
+		if (nextLocation.pathname.startsWith(`/agents/${agentId}/embed`)) {
+			return false;
+		}
+		window.parent.postMessage(
+			{
+				type: "coder:navigate",
+				payload: {
+					url: nextLocation.pathname + nextLocation.search + nextLocation.hash,
+				},
 			},
-			[agentId],
-		),
-	);
+			"*",
+		);
+		return true;
+	});
 
 	// Apply the initial theme from the URL query param
 	// (?theme=light|dark) or fall back to prefers-color-scheme.
@@ -203,9 +184,15 @@ const AgentEmbedPage: FC = () => {
 			applyEmbedTheme(prefersDark ? "dark" : "light");
 		}
 		return () => {
+			document.documentElement.classList.remove("light", "dark");
 			delete document.documentElement.dataset.embedTheme;
 		};
 	}, [searchParams]);
+
+	// Shared ref for the chat scroll container. Passed through the
+	// outlet context so AgentDetail attaches it to the DOM element
+	// instead of creating its own.
+	const scrollContainerRef = useRef<HTMLDivElement | null>(null);
 
 	// Listen for parent frame commands: theme changes and
 	// scroll-to-bottom requests.
@@ -222,11 +209,8 @@ const AgentEmbedPage: FC = () => {
 			}
 			if (event.data?.type === "coder:scroll-to-bottom") {
 				// flex-col-reverse: scrollTop 0 is the visual bottom.
-				const container = document.querySelector<HTMLElement>(
-					'[data-testid="scroll-container"]',
-				);
-				if (container) {
-					container.scrollTop = 0;
+				if (scrollContainerRef.current) {
+					scrollContainerRef.current.scrollTop = 0;
 				}
 			}
 		};
@@ -250,6 +234,7 @@ const AgentEmbedPage: FC = () => {
 		onToggleSidebarCollapsed,
 		onExpandSidebar: () => {},
 		onChatReady,
+		scrollContainerRef,
 	};
 
 	// When signed out and not already bootstrapping, listen for the

--- a/site/src/pages/AgentsPage/AgentEmbedPage.tsx
+++ b/site/src/pages/AgentsPage/AgentEmbedPage.tsx
@@ -2,10 +2,15 @@ import { useAuthContext } from "contexts/auth/AuthProvider";
 import { ProxyProvider } from "contexts/ProxyContext";
 import { DashboardProvider } from "modules/dashboard/DashboardProvider";
 import { permissionChecks } from "modules/permissions";
-import { type FC, useEffect, useRef, useState } from "react";
+import { type FC, useCallback, useEffect, useRef, useState } from "react";
 import { useMutation, useQueryClient } from "react-query";
-import { Outlet, useParams } from "react-router";
 import { getErrorMessage } from "#/api/errors";
+import {
+	type BlockerFunction,
+	Outlet,
+	useBlocker,
+	useParams,
+} from "react-router";
 import { Button } from "#/components/Button/Button";
 import { Loader } from "#/components/Loader/Loader";
 import type { AgentsOutletContext } from "./AgentsPage";
@@ -118,6 +123,30 @@ const AgentEmbedPage: FC = () => {
 		setIsSidebarCollapsed((current) => !current);
 	};
 
+	// Block navigations that leave the embed route and forward
+	// the target URL to the parent frame.
+	useBlocker(
+		useCallback<BlockerFunction>(
+			({ nextLocation }) => {
+				if (nextLocation.pathname.startsWith(`/agents/${agentId}/embed`)) {
+					return false;
+				}
+				window.parent.postMessage(
+					{
+						type: "coder:navigate",
+						payload: {
+							url:
+								nextLocation.pathname + nextLocation.search + nextLocation.hash,
+						},
+					},
+					"*",
+				);
+				return true;
+			},
+			[agentId],
+		),
+	);
+
 	const outletContext: AgentsOutletContext = {
 		chatErrorReasons,
 		setChatErrorReason,
@@ -129,6 +158,7 @@ const AgentEmbedPage: FC = () => {
 		onToggleSidebarCollapsed,
 		onExpandSidebar: () => {},
 	};
+
 	// When signed out and not already bootstrapping, listen for the
 	// postMessage from the parent frame carrying the session token.
 	const isAwaitingBootstrapMessage =

--- a/site/src/pages/AgentsPage/AgentEmbedPage.tsx
+++ b/site/src/pages/AgentsPage/AgentEmbedPage.tsx
@@ -53,6 +53,39 @@ const getBootstrapToken = (data: unknown): string | undefined => {
 	return token.length > 0 ? token : undefined;
 };
 
+const getThemeFromMessage = (data: unknown): "light" | "dark" | undefined => {
+	if (typeof data !== "object" || data === null) {
+		return undefined;
+	}
+	const msg = data as { type?: unknown; payload?: unknown };
+	if (msg.type !== "coder:set-theme") {
+		return undefined;
+	}
+	if (typeof msg.payload !== "object" || msg.payload === null) {
+		return undefined;
+	}
+	const payload = msg.payload as { theme?: unknown };
+	if (payload.theme !== "light" && payload.theme !== "dark") {
+		return undefined;
+	}
+	return payload.theme;
+};
+
+/**
+ * Sets the embed theme on <html> and marks it with a data
+ * attribute so ThemeProvider skips its own class manipulation.
+ * No-ops when the requested theme is already active.
+ */
+const applyEmbedTheme = (theme: "light" | "dark") => {
+	const root = document.documentElement;
+	if (root.dataset.embedTheme === theme) {
+		return;
+	}
+	root.classList.remove("light", "dark");
+	root.classList.add(theme);
+	root.dataset.embedTheme = theme;
+};
+
 const AgentEmbedPage: FC = () => {
 	const { agentId } = useParams<{ agentId: string }>();
 	if (!agentId) {
@@ -146,6 +179,34 @@ const AgentEmbedPage: FC = () => {
 			[agentId],
 		),
 	);
+
+	// Apply the system color scheme on mount so the first paint
+	// matches VS Code before a coder:set-theme message arrives.
+	// Then listen for theme changes from the parent frame. On
+	// unmount, remove the marker so ThemeProvider resumes control.
+	useEffect(() => {
+		const prefersDark = window.matchMedia(
+			"(prefers-color-scheme: dark)",
+		).matches;
+		applyEmbedTheme(prefersDark ? "dark" : "light");
+
+		const parentWindow = window.parent;
+		const handler = (event: MessageEvent) => {
+			if (event.source !== parentWindow) {
+				return;
+			}
+			const theme = getThemeFromMessage(event.data);
+			if (theme) {
+				applyEmbedTheme(theme);
+			}
+		};
+
+		window.addEventListener("message", handler);
+		return () => {
+			window.removeEventListener("message", handler);
+			delete document.documentElement.dataset.embedTheme;
+		};
+	}, []);
 
 	const outletContext: AgentsOutletContext = {
 		chatErrorReasons,

--- a/site/src/pages/AgentsPage/AgentEmbedPage.tsx
+++ b/site/src/pages/AgentsPage/AgentEmbedPage.tsx
@@ -207,7 +207,8 @@ const AgentEmbedPage: FC = () => {
 		};
 	}, [searchParams]);
 
-	// Listen for live theme changes from the parent frame.
+	// Listen for parent frame commands: theme changes and
+	// scroll-to-bottom requests.
 	useEffect(() => {
 		const parentWindow = window.parent;
 		const handler = (event: MessageEvent) => {
@@ -217,6 +218,16 @@ const AgentEmbedPage: FC = () => {
 			const theme = getThemeFromMessage(event.data);
 			if (theme) {
 				applyEmbedTheme(theme);
+				return;
+			}
+			if (event.data?.type === "coder:scroll-to-bottom") {
+				// flex-col-reverse: scrollTop 0 is the visual bottom.
+				const container = document.querySelector<HTMLElement>(
+					'[data-testid="scroll-container"]',
+				);
+				if (container) {
+					container.scrollTop = 0;
+				}
 			}
 		};
 

--- a/site/src/pages/AgentsPage/AgentEmbedPage.tsx
+++ b/site/src/pages/AgentsPage/AgentEmbedPage.tsx
@@ -2,7 +2,14 @@ import { useAuthContext } from "contexts/auth/AuthProvider";
 import { ProxyProvider } from "contexts/ProxyContext";
 import { DashboardProvider } from "modules/dashboard/DashboardProvider";
 import { permissionChecks } from "modules/permissions";
-import { type FC, useCallback, useEffect, useRef, useState } from "react";
+import {
+	type FC,
+	useCallback,
+	useEffect,
+	useLayoutEffect,
+	useRef,
+	useState,
+} from "react";
 import { useMutation, useQueryClient } from "react-query";
 import { getErrorMessage } from "#/api/errors";
 import {
@@ -10,6 +17,7 @@ import {
 	Outlet,
 	useBlocker,
 	useParams,
+	useSearchParams,
 } from "react-router";
 import { Button } from "#/components/Button/Button";
 import { Loader } from "#/components/Loader/Loader";
@@ -180,16 +188,27 @@ const AgentEmbedPage: FC = () => {
 		),
 	);
 
-	// Apply the system color scheme on mount so the first paint
-	// matches VS Code before a coder:set-theme message arrives.
-	// Then listen for theme changes from the parent frame. On
-	// unmount, remove the marker so ThemeProvider resumes control.
-	useEffect(() => {
-		const prefersDark = window.matchMedia(
-			"(prefers-color-scheme: dark)",
-		).matches;
-		applyEmbedTheme(prefersDark ? "dark" : "light");
+	// Apply the initial theme from the URL query param
+	// (?theme=light|dark) or fall back to prefers-color-scheme.
+	// useLayoutEffect runs before paint to prevent a flash.
+	const [searchParams] = useSearchParams();
+	useLayoutEffect(() => {
+		const paramTheme = searchParams.get("theme");
+		if (paramTheme === "light" || paramTheme === "dark") {
+			applyEmbedTheme(paramTheme);
+		} else {
+			const prefersDark = window.matchMedia(
+				"(prefers-color-scheme: dark)",
+			).matches;
+			applyEmbedTheme(prefersDark ? "dark" : "light");
+		}
+		return () => {
+			delete document.documentElement.dataset.embedTheme;
+		};
+	}, [searchParams]);
 
+	// Listen for live theme changes from the parent frame.
+	useEffect(() => {
 		const parentWindow = window.parent;
 		const handler = (event: MessageEvent) => {
 			if (event.source !== parentWindow) {
@@ -202,11 +221,12 @@ const AgentEmbedPage: FC = () => {
 		};
 
 		window.addEventListener("message", handler);
-		return () => {
-			window.removeEventListener("message", handler);
-			delete document.documentElement.dataset.embedTheme;
-		};
+		return () => window.removeEventListener("message", handler);
 	}, []);
+
+	const onChatReady = () => {
+		window.parent.postMessage({ type: "coder:chat-ready" }, "*");
+	};
 
 	const outletContext: AgentsOutletContext = {
 		chatErrorReasons,
@@ -218,6 +238,7 @@ const AgentEmbedPage: FC = () => {
 		isSidebarCollapsed,
 		onToggleSidebarCollapsed,
 		onExpandSidebar: () => {},
+		onChatReady,
 	};
 
 	// When signed out and not already bootstrapping, listen for the

--- a/site/src/pages/AgentsPage/AgentsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageView.tsx
@@ -23,6 +23,7 @@ export interface AgentsOutletContext {
 	isSidebarCollapsed: boolean;
 	onToggleSidebarCollapsed: () => void;
 	onExpandSidebar: () => void;
+	onChatReady: () => void;
 }
 
 interface AgentsPageViewProps {
@@ -119,6 +120,7 @@ export const AgentsPageView: FC<AgentsPageViewProps> = ({
 		isSidebarCollapsed,
 		onToggleSidebarCollapsed,
 		onExpandSidebar,
+		onChatReady: () => {},
 	};
 
 	return (

--- a/site/src/pages/AgentsPage/AgentsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageView.tsx
@@ -1,4 +1,4 @@
-import type { FC } from "react";
+import { type FC, type RefObject, useRef } from "react";
 import { Outlet, useLocation } from "react-router";
 import { cn } from "utils/cn";
 import { pageTitle } from "utils/page";
@@ -24,6 +24,8 @@ export interface AgentsOutletContext {
 	onToggleSidebarCollapsed: () => void;
 	onExpandSidebar: () => void;
 	onChatReady: () => void;
+	/** Ref attached to the chat scroll container by AgentDetail. */
+	scrollContainerRef: RefObject<HTMLDivElement | null>;
 }
 
 interface AgentsPageViewProps {
@@ -110,6 +112,8 @@ export const AgentsPageView: FC<AgentsPageViewProps> = ({
 		]),
 	);
 
+	const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+
 	const outletContextValue: AgentsOutletContext = {
 		chatErrorReasons,
 		setChatErrorReason,
@@ -121,6 +125,7 @@ export const AgentsPageView: FC<AgentsPageViewProps> = ({
 		onToggleSidebarCollapsed,
 		onExpandSidebar,
 		onChatReady: () => {},
+		scrollContainerRef,
 	};
 
 	return (


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Ehab Younes 🤖

- Move the scroll-to-bottom message handler from `AgentEmbedPage` into `AgentDetail` so it uses the existing `scrollContainerRef` instead of a brittle `querySelector` lookup.
- Track the last signaled agent ID in the chat-ready effect so the `coder:chat-ready` notification re-fires when the user switches agents without a full remount.                                                                                                             
- Block in-app navigations that leave the embed route and forward the target URL to the parent frame via `coder:navigate`.                                                                                
- Add `coder:set-theme` message support so the parent frame (e.g. VS Code) can control the embed's color scheme. On mount, `theme` query is applied immediately to avoid a theme flash; explicit messages override it at any time. ThemeProvider skips its own class manipulation while the embed is active.