### PR TITLE
fix(site): auto-reload on stale chunk after redeploy

### DIFF
--- a/site/src/index.tsx
+++ b/site/src/index.tsx
@@ -11,6 +11,22 @@ console.info(`      -#######          +######-      ########+       ##########  
      .########+        -########.     #########+      ##########  ####    .####   ###########
 `);
 
+// After a redeploy, the SPA still holds old chunk filenames in memory.
+// Navigating to a lazy-loaded route will try to fetch a chunk that no
+// longer exists (the content hash changed), crashing the app. Vite fires
+// this event whenever a dynamic-import preload fails. We catch it and
+// silently reload so the browser fetches a fresh index.html with the new
+// chunk names. A sessionStorage guard prevents infinite reload loops.
+window.addEventListener("vite:preloadError", () => {
+	const key = "preload-reload";
+	const last = sessionStorage.getItem(key);
+	const now = Date.now();
+	if (!last || now - Number(last) > 10_000) {
+		sessionStorage.setItem(key, String(now));
+		window.location.reload();
+	}
+});
+
 const element = document.getElementById("root");
 if (element === null) {
 	throw new Error("root element is null");


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

After a redeploy, the SPA still holds old chunk filenames in memory. Navigating to a lazy-loaded route tries to fetch e.g. `assets/WorkspacePage-abc123.js` which no longer exists, crashing the app into the error boundary.

Vite fires a [`vite:preloadError`](https://vite.dev/guide/build#load-error-handling) event on `window` whenever a dynamic import preload fails. We listen for it in `index.tsx` and silently `window.location.reload()`, which fetches a fresh `index.html` with the new chunk names. A `sessionStorage` timestamp guard prevents infinite reload loops. The user just sees the normal `<Suspense>` loading spinner — no error screen, no prompt.