### PR TITLE
fix: center X icon in agent chat chip close buttons

### DIFF
--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -1044,10 +1044,10 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 								<button
 									type="button"
 									onClick={() => onWorkspaceChange(null)}
-									className="ml-0.5 cursor-pointer rounded-full border-0 bg-transparent p-0.5 text-content-secondary transition-colors hover:bg-surface-tertiary hover:text-content-primary"
+									className="ml-0.5 inline-flex cursor-pointer items-center justify-center rounded-full border-0 bg-transparent p-0.5 text-content-secondary transition-colors hover:bg-surface-tertiary hover:text-content-primary"
 									aria-label={`Remove workspace ${selectedWorkspace.name}`}
 								>
-									<XIcon className="size-3" />
+									<XIcon className="!size-2.5" />
 								</button>
 							</span>
 						)}
@@ -1072,10 +1072,10 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 										<button
 											type="button"
 											onClick={() => handleMcpToggle(server.id, false)}
-											className="ml-0.5 cursor-pointer rounded-full border-0 bg-transparent p-0.5 text-content-secondary transition-colors hover:bg-surface-tertiary hover:text-content-primary"
+											className="ml-0.5 inline-flex cursor-pointer items-center justify-center rounded-full border-0 bg-transparent p-0.5 text-content-secondary transition-colors hover:bg-surface-tertiary hover:text-content-primary"
 											aria-label={`Remove ${server.display_name}`}
 										>
-											<XIcon className="size-3" />
+											<XIcon className="!size-2.5" />
 										</button>
 									)}
 								</span>


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

The close buttons on workspace and MCP server chips in the agent chat input had two visual issues:

1. **X sat too high** — the XIcon rendered as an inline SVG, aligning to the text baseline instead of being vertically centered. Fixed by adding `inline-flex items-center justify-center` to the button.

2. **X appeared taller than wide** — at `size-3` (12px), the stroke geometry made the icon look non-square. Reduced to `size-2.5` (10px) for better visual proportion within the `p-0.5` button padding.