### PR TITLE
fix(site): use focus-visible instead of focus for keyboard-only outlines

### DIFF
--- a/site/src/components/MultiSelectCombobox/MultiSelectCombobox.tsx
+++ b/site/src/components/MultiSelectCombobox/MultiSelectCombobox.tsx
@@ -512,7 +512,7 @@ export const MultiSelectCombobox: React.FC<MultiSelectComboboxProps> = ({
 										data-testid="clear-option-button"
 										className={cn(
 											`ml-1 pr-0 rounded-sm bg-transparent border-none outline-none
-												focus:ring-2 focus:ring-content-link focus:ml-2.5 focus:pl-0 cursor-pointer`,
+												focus-visible:ring-2 focus-visible:ring-content-link focus-visible:ml-2.5 focus-visible:pl-0 cursor-pointer`,
 											(disabled || option.fixed) && "hidden",
 										)}
 										onKeyDown={(e) => {
@@ -585,7 +585,7 @@ export const MultiSelectCombobox: React.FC<MultiSelectComboboxProps> = ({
 							className={cn(
 								"bg-transparent mt-1 border-none rounded-sm",
 								"cursor-pointer text-content-secondary hover:text-content-primary",
-								"outline-none focus:ring-2 focus:ring-content-link [&>svg]:p-0.5",
+								"outline-none focus-visible:ring-2 focus-visible:ring-content-link [&>svg]:p-0.5",
 								(hideClearAllButton ||
 									disabled ||
 									selected.length < 1 ||

--- a/site/src/components/Select/Select.tsx
+++ b/site/src/components/Select/Select.tsx
@@ -30,8 +30,8 @@ export const SelectTrigger: React.FC<SelectTriggerProps> = ({
 		className={cn(
 			`flex h-10 w-full font-medium items-center justify-between whitespace-nowrap rounded-md
 			border border-border border-solid bg-transparent px-3 py-2 text-sm shadow-sm
-			ring-offset-background text-content-secondary placeholder:text-content-secondary focus:outline-none,
-			focus:ring-2 focus:ring-content-link disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1
+			ring-offset-background text-content-secondary placeholder:text-content-secondary
+			disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1
 			focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-content-link group`,
 			className,
 		)}

--- a/site/src/components/Table/Table.tsx
+++ b/site/src/components/Table/Table.tsx
@@ -72,7 +72,7 @@ const tableRowVariants = cva(
 			hover: {
 				false: null,
 				true: cn(
-					"cursor-pointer hover:outline focus:outline outline-1 -outline-offset-1 outline-border-hover",
+					"cursor-pointer hover:outline focus-visible:outline outline-1 -outline-offset-1 outline-border-hover",
 					"first:rounded-t-md last:rounded-b-md",
 				),
 			},

--- a/site/src/components/Timeline/TimelineEntry.tsx
+++ b/site/src/components/Timeline/TimelineEntry.tsx
@@ -15,7 +15,7 @@ export const TimelineEntry: React.FC<TimelineEntryProps> = ({
 	return (
 		<TableRow
 			className={cn(
-				"focus:outline focus:-outline-offset-1 focus:outline-2 focus:outline-content-primary ",
+				"focus-visible:outline focus-visible:-outline-offset-1 focus-visible:outline-2 focus-visible:outline-content-primary ",
 				"[&_td]:relative [&_td]:overflow-hidden",
 				"[&_td:before]:absolute [&_td:before]:block [&_td:before]:h-full [&_td:before]:content-[''] [&_td:before]:bg-border [&_td:before]:w-0.5 [&_td:before]:left-[calc((32px+(var(--avatar-default)/2))-1px)]",
 				clickable && "cursor-pointer hover:bg-surface-secondary",

--- a/site/src/hooks/useClickableTableRow.ts
+++ b/site/src/hooks/useClickableTableRow.ts
@@ -58,7 +58,7 @@ export const useClickableTableRow = <
 	return {
 		...clickableProps,
 		className: cn([
-			"cursor-pointer hover:outline focus:outline outline-1 -outline-offset-1 outline-border-hover",
+			"cursor-pointer hover:outline focus-visible:outline outline-1 -outline-offset-1 outline-border-hover",
 			"first:rounded-t-md last:rounded-b-md",
 		]),
 		hover: true,

--- a/site/src/modules/dashboard/DashboardLayout.tsx
+++ b/site/src/modules/dashboard/DashboardLayout.tsx
@@ -33,7 +33,7 @@ export const DashboardLayout: FC = () => {
 						const main = document.getElementById("main-content");
 						main?.focus();
 					}}
-					className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:p-4 focus:bg-surface-primary focus:text-content-primary"
+					className="sr-only focus-visible:not-sr-only focus-visible:absolute focus-visible:z-50 focus-visible:p-4 focus-visible:bg-surface-primary focus-visible:text-content-primary"
 				>
 					Skip to main content
 				</a>


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

## Problem

Several components used Tailwind's `focus:` variant (CSS `:focus`) for outline and ring styles. The `:focus` pseudo-class fires on **all** focus events including mouse clicks, causing visible focus outlines when interacting with the mouse even though they are intended only for keyboard navigation.

## Changes

Replaced `focus:` with `focus-visible:` (CSS `:focus-visible`) on outline and ring styles in:

- `SelectTrigger` — also removed redundant `focus:` classes that duplicated the existing `focus-visible:` ones
- `Table` hover row variant
- `TimelineEntry`
- `MultiSelectCombobox` clear buttons (per-option and clear-all)
- `useClickableTableRow` hook
- Skip navigation link in `DashboardLayout`

## Not changed

`focus:bg-*` and `focus:text-*` styles on `DropdownMenuItem`, `DropdownMenuRadioItem`, `SelectItem`, and destructive menu items are intentionally left as `focus:`. These are within Radix-managed menus where focus is set programmatically during keyboard arrow navigation, and `:focus-visible` does not reliably match in that context.