### PR TITLE
docs: add Release Candidates section to releases page

### DIFF
--- a/docs/install/releases/index.md
+++ b/docs/install/releases/index.md
@@ -9,7 +9,7 @@ deployment.
 
 ## Release channels
 
-We support four release channels, with ad-hoc release candidates:
+We support four primary release channels, as well as ad-hoc release candidates:
 
 - **Mainline:** The bleeding edge version of Coder
 - **Stable:** N-1 of the mainline release

--- a/docs/install/releases/index.md
+++ b/docs/install/releases/index.md
@@ -9,12 +9,13 @@ deployment.
 
 ## Release channels
 
-We support four release channels:
+We support four release channels, with ad-hoc release candidates:
 
 - **Mainline:** The bleeding edge version of Coder
 - **Stable:** N-1 of the mainline release
 - **Security Support:** N-2 of the mainline release
 - **Extended Support Release:** Biannually released version of Coder
+- **Release Candidates:** Ad-hoc builds to validate in-development features
 
 We field our mainline releases publicly for one month before promoting them to stable. The security support version, so n-2 from mainline, receives patches
 only for security issues or CVEs.
@@ -48,6 +49,15 @@ For more information on feature rollout, see our
 ESR releases will be updated with critical bugfixes and security patches that are available to paying customers. This extended support model provides predictable, long-term maintenance for organizations that require enhanced stability. Because ESR forgoes new features in favor of maintenance and stability, it is best suited for teams with strict upgrade constraints. The latest ESR version is [Coder 2.29](https://github.com/coder/coder/releases/tag/v2.29.0).
 
 For more information, see the [Coder ESR announcement](https://coder.com/blog/esr) or our [ESR Upgrade Guide](./esr-2.24-2.29-upgrade.md).
+
+### Release Candidates
+
+- Ad-hoc builds that Coder releases to validate in-development features with select customers
+- Not guaranteed to be stable or free of bugs
+- Features introduced in an RC are not guaranteed to be included in a mainline or stable release
+- Not intended for production use
+
+Release candidates give Coder a way to push out builds for customers and other users to try out new, under-development functionality without cutting a new minor version. Unlike mainline and stable releases, RCs do not follow a fixed schedule and carry no guarantees around stability or long-term support. They exist purely as a feedback mechanism: Coder can ship targeted builds, gather real-world input, and iterate before committing changes to the standard release channels.
 
 ## Installing stable
 


### PR DESCRIPTION
Adds a new **Release Candidates** section to the [Releases](https://coder.com/docs/install/releases) docs page, placed after the Extended Support Release section.

## Changes

- Added Release Candidates to the release channels summary list
- Added a new `### Release Candidates` subsection with bullet points and an explanatory paragraph covering:
  - RCs are ad-hoc builds to validate in-development features with select customers
  - No guarantees around stability or inclusion in mainline/stable releases
  - Not intended for production use
  - Purpose: allow Coder to ship targeted builds for early feedback without cutting new minor versions