### PR TITLE
fix(site): disable refetchInterval in storybook QueryClient

### DIFF
--- a/site/.storybook/preview.tsx
+++ b/site/.storybook/preview.tsx
@@ -66,6 +66,7 @@ const withQuery: Decorator = (Story, { parameters }) => {
 		defaultOptions: {
 			queries: {
 				staleTime: Number.POSITIVE_INFINITY,
+				refetchInterval: false,
 				retry: false,
 			},
 		},


### PR DESCRIPTION
The storybook QueryClient sets `staleTime: Infinity` and `retry: false` to keep stories self-contained, but components that set `refetchInterval` (e.g. `HealthLayout` with 30s polling) still fire real fetches on a timer. In environments without a running coderd, the Vite proxy loops on connection errors and `test-storybook` hangs indefinitely.

Add `refetchInterval: false` to the storybook QueryClient defaults so interval polling never fires during story tests.

**Before:** `make pre-push` hangs on `test-storybook` with repeating `/api/v2/debug/health` proxy errors every 30s. Never completes.

**After:** All 333 story files (428 tests) complete in ~57s. Zero health endpoint polls in the log.

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻