### PR TITLE
fix(site): update registry link to point to templates page

### DIFF
--- a/site/src/pages/CreateTemplateGalleryPage/CreateTemplateGalleryPageView.tsx
+++ b/site/src/pages/CreateTemplateGalleryPage/CreateTemplateGalleryPageView.tsx
@@ -32,12 +32,12 @@ export const CreateTemplateGalleryPageView: FC<
 				actions={
 					<Button asChild size="sm" variant="outline">
 						<a
-							href="https://registry.coder.com"
+							href="https://registry.coder.com/templates"
 							target="_blank"
 							rel="noopener noreferrer"
 							className="flex items-center"
 						>
-							Browse the Coder Registry
+							Browse other Templates on the Coder Registry
 							<ExternalLinkIcon className="size-icon-sm ml-1" />
 						</a>
 					</Button>


### PR DESCRIPTION
The "Browse the Coder Registry" button on the create template gallery page linked to the generic `https://registry.coder.com`. Since this button is specifically on the templates page, it should link directly to the templates section: `https://registry.coder.com/templates`.

## Screenshot

![Create Template Gallery page with updated button](https://raw.githubusercontent.com/coder/coder/88a669ca9b313e9be8434c8b7c86defa67d0a325/screenshot.png)