### PR TITLE
fix(site): correct observability paywall documentation link

### DIFF
--- a/site/src/pages/DeploymentSettingsPage/ObservabilitySettingsPage/ObservabilitySettingsPageView.tsx
+++ b/site/src/pages/DeploymentSettingsPage/ObservabilitySettingsPage/ObservabilitySettingsPageView.tsx
@@ -71,7 +71,7 @@ export const ObservabilitySettingsPageView: FC<
 							<PopoverPaywall
 								message="Observability"
 								description="With a Premium license, you can monitor your application with logs and metrics."
-								documentationLink="https://coder.com/docs/admin/appearance"
+								documentationLink={docs("/admin/monitoring")}
 							/>
 						</TooltipContent>
 					</Tooltip>


### PR DESCRIPTION
The Observability settings paywall linked to the Appearance docs page (`/admin/appearance`) instead of the Monitoring docs page. This was a copy-paste error from the Appearance paywall. Also switches from a hardcoded URL to the `docs()` helper for version-aware linking.