### PR TITLE
fix(site): use descriptive confirm label in schedule dialog

### DIFF
--- a/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/ScheduleDialog.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/ScheduleDialog.tsx
@@ -128,7 +128,7 @@ export const ScheduleDialog: FC<ScheduleDialogProps> = ({
 				<DialogActionButtons
 					cancelText={cancelText}
 					confirmLoading={confirmLoading}
-					confirmText="Submit"
+					confirmText="Update schedule"
 					disabled={disabled}
 					onCancel={!hideCancel ? onClose : undefined}
 					onConfirm={onConfirm || onClose}


### PR DESCRIPTION
The template schedule dialog used a generic "Submit" label on a destructively-styled confirmation button. Changed to "Update schedule" to clearly describe what the action does.