### PR TITLE
fix(site): clarify provisioner setup CTA label

### DIFF
--- a/site/src/pages/OrganizationSettingsPage/OrganizationProvisionersPage/OrganizationProvisionersPageView.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationProvisionersPage/OrganizationProvisionersPageView.tsx
@@ -153,7 +153,7 @@ export const OrganizationProvisionersPageView: FC<
 												cta={
 													<Button size="sm" asChild>
 														<Link href={docs("/admin/provisioners")}>
-															Create a provisioner
+															Set up a provisioner
 														</Link>
 													</Button>
 												}


### PR DESCRIPTION
The empty state button said "Create a provisioner" but linked to external documentation rather than an in-app creation flow. Changed to "Set up a provisioner" which better reflects that the link leads to setup instructions.