### PR TITLE
fix(site): correct autostart section description

### DIFF
--- a/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateScheduleForm.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplateSchedulePage/TemplateScheduleForm.tsx
@@ -397,7 +397,7 @@ export const TemplateScheduleForm: FC<TemplateScheduleForm> = ({
 
 			<FormSection
 				title="Autostart"
-				description="Allow users to set custom autostart and autostop scheduling options for workspaces created from this template."
+				description="Allow users to set custom autostart scheduling options for workspaces created from this template."
 			>
 				<div className="flex flex-col gap-4">
 					<div className="flex items-start">


### PR DESCRIPTION
The "Autostart" form section description mentioned both "autostart and autostop" but only contains autostart controls. Autostop has its own dedicated section. Removed the incorrect "and autostop" reference.