### PR TITLE
fix(site): use consistent contact sales URL

### DIFF
--- a/site/src/components/Paywall/PaywallAIGovernance.tsx
+++ b/site/src/components/Paywall/PaywallAIGovernance.tsx
@@ -54,7 +54,9 @@ const PaywallAIGovernance = () => {
 						</span>
 					</PaywallFeature>
 				</PaywallFeatures>
-				<PaywallCTA href="https://coder.com/contact/sales">Contact Sales</PaywallCTA>
+				<PaywallCTA href="https://coder.com/contact/sales">
+					Contact Sales
+				</PaywallCTA>
 			</PaywallStack>
 		</Paywall>
 	);

--- a/site/src/components/Paywall/PaywallAIGovernance.tsx
+++ b/site/src/components/Paywall/PaywallAIGovernance.tsx
@@ -54,7 +54,7 @@ const PaywallAIGovernance = () => {
 						</span>
 					</PaywallFeature>
 				</PaywallFeatures>
-				<PaywallCTA href="https://coder.com/contact">Contact Sales</PaywallCTA>
+				<PaywallCTA href="https://coder.com/contact/sales">Contact Sales</PaywallCTA>
 			</PaywallStack>
 		</Paywall>
 	);


### PR DESCRIPTION
PaywallAIGovernance used `https://coder.com/contact` while all other "Contact Sales" links in the codebase use `https://coder.com/contact/sales`. Updated for consistency.