### PR TITLE
fix: use TokenBadges for session list row

### DIFF
--- a/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.tsx
+++ b/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.tsx
@@ -18,6 +18,7 @@ import {
 	getProviderIconName,
 	roundTokenDisplay,
 } from "../utils";
+import { TokenBadges } from "../TokenBadges";
 
 type ListSessionsRowProps = {
 	session: AIBridgeSession;
@@ -111,40 +112,10 @@ export const ListSessionsRow: FC<ListSessionsRowProps> = ({
 			</TableCell>
 			<TableCell className="w-32">
 				<div className="flex items-center">
-					<TooltipProvider>
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<Badge className="gap-0 rounded-e-none">
-									<ArrowDownIcon className="size-icon-lg flex-shrink-0" />
-									<span className="truncate min-w-0 w-full">
-										{roundTokenDisplay(
-											session.token_usage_summary.input_tokens,
-										)}
-									</span>
-								</Badge>
-							</TooltipTrigger>
-							<TooltipContent>
-								{session.token_usage_summary.input_tokens} Input Tokens
-							</TooltipContent>
-						</Tooltip>
-					</TooltipProvider>
-					<TooltipProvider>
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<Badge className="gap-0 bg-surface-tertiary rounded-s-none">
-									<ArrowUpIcon className="size-icon-lg flex-shrink-0" />
-									<span className="truncate min-w-0 w-full">
-										{roundTokenDisplay(
-											session.token_usage_summary.output_tokens,
-										)}
-									</span>
-								</Badge>
-							</TooltipTrigger>
-							<TooltipContent>
-								{session.token_usage_summary.output_tokens} Output Tokens
-							</TooltipContent>
-						</Tooltip>
-					</TooltipProvider>
+					<TokenBadges
+						inputTokens={session.token_usage_summary.input_tokens}
+						outputTokens={session.token_usage_summary.output_tokens}
+					/>
 				</div>
 			</TableCell>
 			<TableCell className="w-32">

--- a/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.tsx
+++ b/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.tsx
@@ -7,18 +7,14 @@ import {
 	TooltipProvider,
 	TooltipTrigger,
 } from "components/Tooltip/Tooltip";
-import { ArrowDownIcon, ArrowUpIcon, ChevronRightIcon } from "lucide-react";
+import { ChevronRightIcon } from "lucide-react";
 import { AIBridgeClientIcon } from "pages/AIBridgePage/RequestLogsPage/icons/AIBridgeClientIcon";
 import { AIBridgeProviderIcon } from "pages/AIBridgePage/RequestLogsPage/icons/AIBridgeProviderIcon";
 import type { FC } from "react";
 import { DATE_FORMAT, formatDateTime } from "utils/time";
 import type { AIBridgeSession } from "#/api/typesGenerated";
-import {
-	getProviderDisplayName,
-	getProviderIconName,
-	roundTokenDisplay,
-} from "../utils";
 import { TokenBadges } from "../TokenBadges";
+import { getProviderDisplayName, getProviderIconName } from "../utils";
 
 type ListSessionsRowProps = {
 	session: AIBridgeSession;

--- a/site/src/pages/AIBridgePage/TokenBadges.tsx
+++ b/site/src/pages/AIBridgePage/TokenBadges.tsx
@@ -56,7 +56,7 @@ export const TokenBadges: FC<TokenBadgesProps> = ({
 							<div className="flex items-center justify-between gap-4">
 								<div className="text-xs text-content-secondary">Input</div>
 								<div className="text-xs text-content-secondary">
-									{roundTokenDisplay(inputTokens)}
+									{inputTokens}
 								</div>
 							</div>
 						</div>
@@ -71,7 +71,7 @@ export const TokenBadges: FC<TokenBadgesProps> = ({
 							<div className="flex items-center justify-between gap-4">
 								<div className="text-xs text-content-secondary">Output</div>
 								<div className="text-xs text-content-secondary">
-									{roundTokenDisplay(outputTokens)}
+									{outputTokens}
 								</div>
 							</div>
 						</div>


### PR DESCRIPTION
The sessions list row uses a bespoke token badge instead of the `<TokenBadge />` component, so this fixes that.

Before

<img width="433" height="145" alt="Screenshot 2026-03-25 at 1 22 33 PM" src="https://github.com/user-attachments/assets/07f1b813-ebfc-4fd3-b8a7-6b25f5f63045" />

After

<img width="445" height="172" alt="Screenshot 2026-03-25 at 9 30 09 PM" src="https://github.com/user-attachments/assets/0acf5b6e-7c85-45c0-a15f-71967d430424" />
