### PR TITLE
fix: open coder_app links in new tab when open_in is tab (cherry-pick #23000)

### DIFF
--- a/site/src/modules/resources/AppLink/AppLink.test.tsx
+++ b/site/src/modules/resources/AppLink/AppLink.test.tsx
@@ -1,0 +1,25 @@
+import {
+	MockWorkspace,
+	MockWorkspaceAgent,
+	MockWorkspaceApp,
+} from "testHelpers/entities";
+import { renderWithAuth } from "testHelpers/renderHelpers";
+import { screen } from "@testing-library/react";
+import { AppLink } from "./AppLink";
+
+const renderAppLink = (app: typeof MockWorkspaceApp) => {
+	return renderWithAuth(
+		<AppLink app={app} workspace={MockWorkspace} agent={MockWorkspaceAgent} />,
+	);
+};
+
+// Regression test for https://github.com/coder/coder/issues/18573:
+// open_in="tab" was not opening links in a new tab.
+describe("AppLink", () => {
+	it("sets target=_blank and rel=noreferrer when open_in is tab", async () => {
+		renderAppLink({ ...MockWorkspaceApp, open_in: "tab" });
+		const link = await screen.findByRole("link");
+		expect(link).toHaveAttribute("target", "_blank");
+		expect(link).toHaveAttribute("rel", "noreferrer");
+	});
+});

--- a/site/src/modules/resources/AppLink/AppLink.tsx
+++ b/site/src/modules/resources/AppLink/AppLink.tsx
@@ -135,7 +135,12 @@ export const AppLink: FC<AppLinkProps> = ({
 
 	const button = grouped ? (
 		<DropdownMenuItem asChild>
-			<a href={canClick ? link.href : undefined} onClick={link.onClick}>
+			<a
+				href={canClick ? link.href : undefined}
+				onClick={link.onClick}
+				target={app.open_in === "tab" ? "_blank" : undefined}
+				rel={app.open_in === "tab" ? "noreferrer" : undefined}
+			>
 				{icon}
 				{link.label}
 				{ShareIcon && <ShareIcon />}
@@ -143,7 +148,12 @@ export const AppLink: FC<AppLinkProps> = ({
 		</DropdownMenuItem>
 	) : (
 		<AgentButton asChild>
-			<a href={canClick ? link.href : undefined} onClick={link.onClick}>
+			<a
+				href={canClick ? link.href : undefined}
+				onClick={link.onClick}
+				target={app.open_in === "tab" ? "_blank" : undefined}
+				rel={app.open_in === "tab" ? "noreferrer" : undefined}
+			>
 				{icon}
 				{link.label}
 				{ShareIcon && <ShareIcon />}


### PR DESCRIPTION
Cherry-pick of #23000 onto release/2.31.