### PR TITLE
fix(cli): extend `exp scaletest cleanup` to properly clean up prebuilds

### DIFF
--- a/cli/exp_scaletest.go
+++ b/cli/exp_scaletest.go
@@ -519,6 +519,121 @@ func (r *userCleanupRunner) Run(ctx context.Context, _ string, _ io.Writer) erro
 	return nil
 }
 
+// prebuildTemplateCleanupRunner deletes all workspaces belonging to a
+// scaletest prebuilds template and then deletes the template itself.
+// Workspaces must be gone before the template can be deleted.
+type prebuildTemplateCleanupRunner struct {
+	client   *codersdk.Client
+	template codersdk.Template
+}
+
+var _ harness.Runnable = &prebuildTemplateCleanupRunner{}
+
+// Run implements Runnable.
+func (r *prebuildTemplateCleanupRunner) Run(ctx context.Context, _ string, logs io.Writer) error {
+	ctx, span := tracing.StartSpan(ctx)
+	defer span.End()
+
+	logger := slog.Make(sloghuman.Sink(logs)).Leveled(slog.LevelDebug)
+
+	// Collect all workspaces for this template so they can be deleted before
+	// the template itself. Template deletion fails while workspaces exist.
+	const pageSize = 100
+	var workspaces []codersdk.Workspace
+	for page := 0; ; page++ {
+		resp, err := r.client.Workspaces(ctx, codersdk.WorkspaceFilter{
+			Template: r.template.Name,
+			Offset:   page * pageSize,
+			Limit:    pageSize,
+		})
+		if err != nil {
+			return xerrors.Errorf("list workspaces for template %q page %d: %w", r.template.Name, page, err)
+		}
+		workspaces = append(workspaces, resp.Workspaces...)
+		if len(resp.Workspaces) < pageSize {
+			break
+		}
+	}
+
+	logger.Info(ctx, "deleting workspaces for template",
+		slog.F("count", len(workspaces)),
+		slog.F("template_name", r.template.Name),
+	)
+
+	// Retry failed workspace deletions up to maxDeletionAttempts times to
+	// handle transient errors (e.g. a delete build that fails due to a
+	// provisioner hiccup).
+	const maxDeletionAttempts = 3
+	remaining := workspaces
+	for attempt := range maxDeletionAttempts {
+		if len(remaining) == 0 {
+			break
+		}
+		if attempt > 0 {
+			logger.Info(ctx, "retrying workspace deletions",
+				slog.F("attempt", attempt+1),
+				slog.F("remaining", len(remaining)),
+				slog.F("template_name", r.template.Name),
+			)
+		}
+		var failed []codersdk.Workspace
+		for _, ws := range remaining {
+			cr := workspacebuild.NewCleanupRunner(r.client, ws.ID)
+			if err := cr.Run(ctx, ws.ID.String(), logs); err != nil {
+				logger.Warn(ctx, "failed to delete workspace",
+					slog.F("workspace_id", ws.ID),
+					slog.F("workspace_name", ws.Name),
+					slog.Error(err),
+				)
+				failed = append(failed, ws)
+			}
+		}
+		remaining = failed
+	}
+
+	if len(remaining) > 0 {
+		ids := make([]string, len(remaining))
+		for i, ws := range remaining {
+			ids[i] = ws.ID.String()
+		}
+		logger.Error(ctx, "CLEANUP INCOMPLETE: could not delete all workspaces after retries; template deletion will likely fail",
+			slog.F("template_name", r.template.Name),
+			slog.F("remaining_count", len(remaining)),
+			slog.F("remaining_workspace_ids", ids),
+		)
+	}
+
+	// Always attempt template deletion even if some workspaces could not be
+	// removed. The delete call will fail with a 400 if workspaces remain, but
+	// the error — combined with the log above — makes the state clear to the
+	// operator.
+	if err := r.client.DeleteTemplate(ctx, r.template.ID); err != nil {
+		return xerrors.Errorf("delete template %q: %w", r.template.Name, err)
+	}
+
+	return nil
+}
+
+// getScaletestPrebuildsTemplates returns all templates that look like they were
+// created by the scaletest prebuilds command: they must have the scaletest
+// prefix and contain "prebuild" anywhere in the name.
+func getScaletestPrebuildsTemplates(ctx context.Context, client *codersdk.Client) ([]codersdk.Template, error) {
+	templates, err := client.Templates(ctx, codersdk.TemplateFilter{
+		FuzzyName: "prebuild",
+	})
+	if err != nil {
+		return nil, xerrors.Errorf("list templates: %w", err)
+	}
+
+	var result []codersdk.Template
+	for _, t := range templates {
+		if strings.HasPrefix(t.Name, loadtestutil.ScaleTestPrefix+"-") && strings.Contains(t.Name, "prebuild") {
+			result = append(result, t)
+		}
+	}
+	return result, nil
+}
+
 func (r *RootCmd) scaletestCleanup() *serpent.Command {
 	var template string
 	cleanupStrategy := newScaletestCleanupStrategy()
@@ -552,6 +667,40 @@ func (r *RootCmd) scaletestCleanup() *serpent.Command {
 				_, err := parseTemplate(ctx, client, me.OrganizationIDs, template)
 				if err != nil {
 					return xerrors.Errorf("parse template: %w", err)
+				}
+			}
+
+			cliui.Infof(inv.Stdout, "Fetching scaletest prebuilds templates...")
+			prebuildTemplates, err := getScaletestPrebuildsTemplates(ctx, client)
+			if err != nil {
+				return err
+			}
+
+			cliui.Errorf(inv.Stderr, "Found %d scaletest prebuilds templates\n", len(prebuildTemplates))
+			if len(prebuildTemplates) != 0 {
+				cliui.Infof(inv.Stdout, "Deleting scaletest prebuilds templates and their workspaces...")
+				prebuildHarness := harness.NewTestHarness(cleanupStrategy.toStrategy(), harness.ConcurrentExecutionStrategy{})
+
+				for i, t := range prebuildTemplates {
+					const testName = "cleanup-prebuilds-template"
+					prebuildHarness.AddRun(testName, strconv.Itoa(i), &prebuildTemplateCleanupRunner{
+						client:   client,
+						template: t,
+					})
+				}
+
+				prebuildCtx, prebuildCancel := cleanupStrategy.toContext(ctx)
+				defer prebuildCancel()
+				if err := prebuildHarness.Run(prebuildCtx); err != nil {
+					return xerrors.Errorf("run test harness to delete prebuilds templates (harness failure, not a test failure): %w", err)
+				}
+
+				cliui.Infof(inv.Stdout, "Done deleting scaletest prebuilds templates:")
+				prebuildRes := prebuildHarness.Results()
+				prebuildRes.PrintText(inv.Stderr)
+
+				if prebuildRes.TotalFail > 0 {
+					return xerrors.Errorf("%d/%d scaletest prebuilds template(s) could not be fully cleaned up; check logs above for remaining workspace IDs", prebuildRes.TotalFail, prebuildRes.TotalRuns)
 				}
 			}
 

--- a/cli/exp_scaletest.go
+++ b/cli/exp_scaletest.go
@@ -519,9 +519,8 @@ func (r *userCleanupRunner) Run(ctx context.Context, _ string, _ io.Writer) erro
 	return nil
 }
 
-// prebuildTemplateCleanupRunner deletes all workspaces belonging to a
-// scaletest prebuilds template and then deletes the template itself.
-// Workspaces must be gone before the template can be deleted.
+// prebuildTemplateCleanupRunner deletes a single scaletest prebuilds template.
+// All prebuild workspaces must be deleted before this runs.
 type prebuildTemplateCleanupRunner struct {
 	client   *codersdk.Client
 	template codersdk.Template
@@ -530,88 +529,59 @@ type prebuildTemplateCleanupRunner struct {
 var _ harness.Runnable = &prebuildTemplateCleanupRunner{}
 
 // Run implements Runnable.
-func (r *prebuildTemplateCleanupRunner) Run(ctx context.Context, _ string, logs io.Writer) error {
+func (r *prebuildTemplateCleanupRunner) Run(ctx context.Context, _ string, _ io.Writer) error {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
-	logger := slog.Make(sloghuman.Sink(logs)).Leveled(slog.LevelDebug)
-
-	// Collect all workspaces for this template so they can be deleted before
-	// the template itself. Template deletion fails while workspaces exist.
-	const pageSize = 100
-	var workspaces []codersdk.Workspace
-	for page := 0; ; page++ {
-		resp, err := r.client.Workspaces(ctx, codersdk.WorkspaceFilter{
-			Template: r.template.Name,
-			Offset:   page * pageSize,
-			Limit:    pageSize,
-		})
-		if err != nil {
-			return xerrors.Errorf("list workspaces for template %q page %d: %w", r.template.Name, page, err)
-		}
-		workspaces = append(workspaces, resp.Workspaces...)
-		if len(resp.Workspaces) < pageSize {
-			break
-		}
-	}
-
-	logger.Info(ctx, "deleting workspaces for template",
-		slog.F("count", len(workspaces)),
-		slog.F("template_name", r.template.Name),
-	)
-
-	// Retry failed workspace deletions up to maxDeletionAttempts times to
-	// handle transient errors (e.g. a delete build that fails due to a
-	// provisioner hiccup).
-	const maxDeletionAttempts = 3
-	remaining := workspaces
-	for attempt := range maxDeletionAttempts {
-		if len(remaining) == 0 {
-			break
-		}
-		if attempt > 0 {
-			logger.Info(ctx, "retrying workspace deletions",
-				slog.F("attempt", attempt+1),
-				slog.F("remaining", len(remaining)),
-				slog.F("template_name", r.template.Name),
-			)
-		}
-		var failed []codersdk.Workspace
-		for _, ws := range remaining {
-			cr := workspacebuild.NewCleanupRunner(r.client, ws.ID)
-			if err := cr.Run(ctx, ws.ID.String(), logs); err != nil {
-				logger.Warn(ctx, "failed to delete workspace",
-					slog.F("workspace_id", ws.ID),
-					slog.F("workspace_name", ws.Name),
-					slog.Error(err),
-				)
-				failed = append(failed, ws)
-			}
-		}
-		remaining = failed
-	}
-
-	if len(remaining) > 0 {
-		ids := make([]string, len(remaining))
-		for i, ws := range remaining {
-			ids[i] = ws.ID.String()
-		}
-		logger.Error(ctx, "CLEANUP INCOMPLETE: could not delete all workspaces after retries; template deletion will likely fail",
-			slog.F("template_name", r.template.Name),
-			slog.F("remaining_count", len(remaining)),
-			slog.F("remaining_workspace_ids", ids),
-		)
-	}
-
-	// Always attempt template deletion even if some workspaces could not be
-	// removed. The delete call will fail with a 400 if workspaces remain, but
-	// the error — combined with the log above — makes the state clear to the
-	// operator.
 	if err := r.client.DeleteTemplate(ctx, r.template.ID); err != nil {
 		return xerrors.Errorf("delete template %q: %w", r.template.Name, err)
 	}
-
 	return nil
+}
+
+// getScaletestPrebuildWorkspaces returns all prebuild workspaces by querying
+// on owner (the prebuilds system user) and on name (substring "prebuild"),
+// merging and deduplicating the results. Both filters are used because a
+// workspace might only match one depending on how it was created.
+func getScaletestPrebuildWorkspaces(ctx context.Context, client *codersdk.Client) ([]codersdk.Workspace, error) {
+	const pageSize = 100
+
+	seen := make(map[uuid.UUID]struct{})
+	var result []codersdk.Workspace
+
+	// paginateWorkspaces appends all pages for the given filter, skipping
+	// workspaces already seen by a previous query.
+	paginateWorkspaces := func(filter codersdk.WorkspaceFilter) error {
+		for page := 0; ; page++ {
+			filter.Offset = page * pageSize
+			filter.Limit = pageSize
+			resp, err := client.Workspaces(ctx, filter)
+			if err != nil {
+				return xerrors.Errorf("list prebuild workspaces (page %d): %w", page, err)
+			}
+			for _, ws := range resp.Workspaces {
+				if _, ok := seen[ws.ID]; !ok {
+					seen[ws.ID] = struct{}{}
+					result = append(result, ws)
+				}
+			}
+			if len(resp.Workspaces) < pageSize {
+				break
+			}
+		}
+		return nil
+	}
+
+	// Query by owner first (the prebuilds system user), then by name substring
+	// to catch any workspaces that might not match on owner alone.
+	if err := paginateWorkspaces(codersdk.WorkspaceFilter{Owner: "prebuilds"}); err != nil {
+		return nil, err
+	}
+	if err := paginateWorkspaces(codersdk.WorkspaceFilter{Name: "prebuild"}); err != nil {
+		return nil, err
+	}
+
+	return result, nil
 }
 
 // getScaletestPrebuildsTemplates returns all templates that look like they were
@@ -670,6 +640,37 @@ func (r *RootCmd) scaletestCleanup() *serpent.Command {
 				}
 			}
 
+			cliui.Infof(inv.Stdout, "Fetching scaletest prebuild workspaces...")
+			prebuildWorkspaces, err := getScaletestPrebuildWorkspaces(ctx, client)
+			if err != nil {
+				return err
+			}
+
+			cliui.Errorf(inv.Stderr, "Found %d scaletest prebuild workspaces\n", len(prebuildWorkspaces))
+			if len(prebuildWorkspaces) != 0 {
+				cliui.Infof(inv.Stdout, "Deleting scaletest prebuild workspaces...")
+				prebuildWsHarness := harness.NewTestHarness(cleanupStrategy.toStrategy(), harness.ConcurrentExecutionStrategy{})
+
+				for i, ws := range prebuildWorkspaces {
+					const testName = "cleanup-prebuild-workspace"
+					prebuildWsHarness.AddRun(testName, strconv.Itoa(i), workspacebuild.NewCleanupRunner(client, ws.ID))
+				}
+
+				prebuildWsCtx, prebuildWsCancel := cleanupStrategy.toContext(ctx)
+				defer prebuildWsCancel()
+				if err := prebuildWsHarness.Run(prebuildWsCtx); err != nil {
+					return xerrors.Errorf("run test harness to delete prebuild workspaces (harness failure, not a test failure): %w", err)
+				}
+
+				cliui.Infof(inv.Stdout, "Done deleting scaletest prebuild workspaces:")
+				prebuildWsRes := prebuildWsHarness.Results()
+				prebuildWsRes.PrintText(inv.Stderr)
+
+				if prebuildWsRes.TotalFail > 0 {
+					return xerrors.Errorf("failed to delete %d scaletest prebuild workspace(s)", prebuildWsRes.TotalFail)
+				}
+			}
+
 			cliui.Infof(inv.Stdout, "Fetching scaletest prebuilds templates...")
 			prebuildTemplates, err := getScaletestPrebuildsTemplates(ctx, client)
 			if err != nil {
@@ -678,29 +679,29 @@ func (r *RootCmd) scaletestCleanup() *serpent.Command {
 
 			cliui.Errorf(inv.Stderr, "Found %d scaletest prebuilds templates\n", len(prebuildTemplates))
 			if len(prebuildTemplates) != 0 {
-				cliui.Infof(inv.Stdout, "Deleting scaletest prebuilds templates and their workspaces...")
-				prebuildHarness := harness.NewTestHarness(cleanupStrategy.toStrategy(), harness.ConcurrentExecutionStrategy{})
+				cliui.Infof(inv.Stdout, "Deleting scaletest prebuilds templates...")
+				prebuildTplHarness := harness.NewTestHarness(cleanupStrategy.toStrategy(), harness.ConcurrentExecutionStrategy{})
 
 				for i, t := range prebuildTemplates {
 					const testName = "cleanup-prebuilds-template"
-					prebuildHarness.AddRun(testName, strconv.Itoa(i), &prebuildTemplateCleanupRunner{
+					prebuildTplHarness.AddRun(testName, strconv.Itoa(i), &prebuildTemplateCleanupRunner{
 						client:   client,
 						template: t,
 					})
 				}
 
-				prebuildCtx, prebuildCancel := cleanupStrategy.toContext(ctx)
-				defer prebuildCancel()
-				if err := prebuildHarness.Run(prebuildCtx); err != nil {
+				prebuildTplCtx, prebuildTplCancel := cleanupStrategy.toContext(ctx)
+				defer prebuildTplCancel()
+				if err := prebuildTplHarness.Run(prebuildTplCtx); err != nil {
 					return xerrors.Errorf("run test harness to delete prebuilds templates (harness failure, not a test failure): %w", err)
 				}
 
 				cliui.Infof(inv.Stdout, "Done deleting scaletest prebuilds templates:")
-				prebuildRes := prebuildHarness.Results()
-				prebuildRes.PrintText(inv.Stderr)
+				prebuildTplRes := prebuildTplHarness.Results()
+				prebuildTplRes.PrintText(inv.Stderr)
 
-				if prebuildRes.TotalFail > 0 {
-					return xerrors.Errorf("%d/%d scaletest prebuilds template(s) could not be fully cleaned up; check logs above for remaining workspace IDs", prebuildRes.TotalFail, prebuildRes.TotalRuns)
+				if prebuildTplRes.TotalFail > 0 {
+					return xerrors.Errorf("failed to delete %d scaletest prebuilds template(s)", prebuildTplRes.TotalFail)
 				}
 			}
 

--- a/cli/exp_scaletest.go
+++ b/cli/exp_scaletest.go
@@ -640,10 +640,7 @@ func (r *RootCmd) scaletestCleanup() *serpent.Command {
 
 			cliui.Infof(inv.Stdout, "Pausing prebuilds reconciler...")
 			setPrebuild := func(val bool) error {
-				if err = client.PutPrebuildsSettings(ctx, codersdk.PrebuildsSettings{ReconciliationPaused: val}); err != nil {
-					return err
-				}
-				return nil
+				return client.PutPrebuildsSettings(ctx, codersdk.PrebuildsSettings{ReconciliationPaused: val})
 			}
 			if err = setPrebuild(true); err != nil {
 				return xerrors.Errorf("pause prebuilds reconciler: %w", err)

--- a/cli/exp_scaletest.go
+++ b/cli/exp_scaletest.go
@@ -640,6 +640,23 @@ func (r *RootCmd) scaletestCleanup() *serpent.Command {
 				}
 			}
 
+			cliui.Infof(inv.Stdout, "Pausing prebuilds reconciler...")
+			setPrebuild := func(val bool) error {
+				if err = client.PutPrebuildsSettings(ctx, codersdk.PrebuildsSettings{ReconciliationPaused: val}); err != nil {
+					return err
+				}
+				return nil
+			}
+			if err = setPrebuild(true); err != nil {
+				return xerrors.Errorf("pause prebuilds reconciler: %w", err)
+			}
+			defer func() {
+				cliui.Infof(inv.Stdout, "Resuming prebuilds reconciler...")
+				if resumeErr := setPrebuild(false); resumeErr != nil {
+					cliui.Errorf(inv.Stderr, "Failed to resume prebuilds reconciler: %+v\n", resumeErr)
+				}
+			}()
+
 			cliui.Infof(inv.Stdout, "Fetching scaletest prebuild workspaces...")
 			prebuildWorkspaces, err := getScaletestPrebuildWorkspaces(ctx, client)
 			if err != nil {

--- a/cli/exp_scaletest.go
+++ b/cli/exp_scaletest.go
@@ -38,6 +38,7 @@ import (
 	"github.com/coder/coder/v2/scaletest/dashboard"
 	"github.com/coder/coder/v2/scaletest/harness"
 	"github.com/coder/coder/v2/scaletest/loadtestutil"
+	"github.com/coder/coder/v2/scaletest/prebuilds"
 	"github.com/coder/coder/v2/scaletest/reconnectingpty"
 	"github.com/coder/coder/v2/scaletest/workspacebuild"
 	"github.com/coder/coder/v2/scaletest/workspacetraffic"
@@ -539,25 +540,31 @@ func (r *prebuildTemplateCleanupRunner) Run(ctx context.Context, _ string, _ io.
 	return nil
 }
 
-// getScaletestPrebuildWorkspaces returns all prebuild workspaces by querying
-// on owner (the prebuilds system user) and on name (substring "prebuild"),
-// merging and deduplicating the results. Both filters are used because a
-// workspace might only match one depending on how it was created.
-func getScaletestPrebuildWorkspaces(ctx context.Context, client *codersdk.Client) ([]codersdk.Workspace, error) {
+// getScaletestPrebuildWorkspaces returns all prebuild workspaces that belong
+// to scaletest templates. It uses getScaletestPrebuildsTemplates to scope the
+// query so that legitimate (non-scaletest) prebuilds on the deployment are not
+// caught in the cleanup. If template is non-empty only workspaces for that
+// template are returned.
+func getScaletestPrebuildWorkspaces(ctx context.Context, client *codersdk.Client, template string) ([]codersdk.Workspace, error) {
 	const pageSize = 100
+
+	templates, err := getScaletestPrebuildsTemplates(ctx, client, template)
+	if err != nil {
+		return nil, xerrors.Errorf("list scaletest prebuild templates: %w", err)
+	}
 
 	seen := make(map[uuid.UUID]struct{})
 	var result []codersdk.Workspace
 
-	// paginateWorkspaces appends all pages for the given filter, skipping
-	// workspaces already seen by a previous query.
-	paginateWorkspaces := func(filter codersdk.WorkspaceFilter) error {
+	for _, tmpl := range templates {
 		for page := 0; ; page++ {
-			filter.Offset = page * pageSize
-			filter.Limit = pageSize
-			resp, err := client.Workspaces(ctx, filter)
+			resp, err := client.Workspaces(ctx, codersdk.WorkspaceFilter{
+				Template: tmpl.Name,
+				Offset:   page * pageSize,
+				Limit:    pageSize,
+			})
 			if err != nil {
-				return xerrors.Errorf("list prebuild workspaces (page %d): %w", page, err)
+				return nil, xerrors.Errorf("list workspaces for template %q (page %d): %w", tmpl.Name, page, err)
 			}
 			for _, ws := range resp.Workspaces {
 				if _, ok := seen[ws.ID]; !ok {
@@ -569,39 +576,30 @@ func getScaletestPrebuildWorkspaces(ctx context.Context, client *codersdk.Client
 				break
 			}
 		}
-		return nil
-	}
-
-	// Query by owner first (the prebuilds system user), then by name substring
-	// to catch any workspaces that might not match on owner alone.
-	if err := paginateWorkspaces(codersdk.WorkspaceFilter{Owner: "prebuilds"}); err != nil {
-		return nil, err
-	}
-	if err := paginateWorkspaces(codersdk.WorkspaceFilter{Name: "prebuild"}); err != nil {
-		return nil, err
 	}
 
 	return result, nil
 }
 
-// getScaletestPrebuildsTemplates returns all templates that look like they were
-// created by the scaletest prebuilds command: they must have the scaletest
-// prefix and contain "prebuild" anywhere in the name.
-func getScaletestPrebuildsTemplates(ctx context.Context, client *codersdk.Client) ([]codersdk.Template, error) {
-	templates, err := client.Templates(ctx, codersdk.TemplateFilter{
-		FuzzyName: "prebuild",
-	})
+// getScaletestPrebuildsTemplates returns all templates created by the scaletest
+// prebuilds runner (identified by prebuilds.TemplatePrefix). If template is
+// non-empty only that named template is returned; it must start with
+// prebuilds.TemplatePrefix or an error is returned.
+func getScaletestPrebuildsTemplates(ctx context.Context, client *codersdk.Client, template string) ([]codersdk.Template, error) {
+	var filter codersdk.TemplateFilter
+	if template != "" {
+		if !strings.HasPrefix(template, prebuilds.TemplatePrefix) {
+			return nil, xerrors.Errorf("template %q is not a scaletest prebuilds template (expected prefix %q)", template, prebuilds.TemplatePrefix)
+		}
+		filter = codersdk.TemplateFilter{ExactName: template}
+	} else {
+		filter = codersdk.TemplateFilter{FuzzyName: prebuilds.TemplatePrefix}
+	}
+	templates, err := client.Templates(ctx, filter)
 	if err != nil {
 		return nil, xerrors.Errorf("list templates: %w", err)
 	}
-
-	var result []codersdk.Template
-	for _, t := range templates {
-		if strings.HasPrefix(t.Name, loadtestutil.ScaleTestPrefix+"-") && strings.Contains(t.Name, "prebuild") {
-			result = append(result, t)
-		}
-	}
-	return result, nil
+	return templates, nil
 }
 
 func (r *RootCmd) scaletestCleanup() *serpent.Command {
@@ -658,7 +656,7 @@ func (r *RootCmd) scaletestCleanup() *serpent.Command {
 			}()
 
 			cliui.Infof(inv.Stdout, "Fetching scaletest prebuild workspaces...")
-			prebuildWorkspaces, err := getScaletestPrebuildWorkspaces(ctx, client)
+			prebuildWorkspaces, err := getScaletestPrebuildWorkspaces(ctx, client, template)
 			if err != nil {
 				return err
 			}
@@ -689,7 +687,7 @@ func (r *RootCmd) scaletestCleanup() *serpent.Command {
 			}
 
 			cliui.Infof(inv.Stdout, "Fetching scaletest prebuilds templates...")
-			prebuildTemplates, err := getScaletestPrebuildsTemplates(ctx, client)
+			prebuildTemplates, err := getScaletestPrebuildsTemplates(ctx, client, template)
 			if err != nil {
 				return err
 			}

--- a/cli/exp_scaletest_prebuilds_internal_test.go
+++ b/cli/exp_scaletest_prebuilds_internal_test.go
@@ -1,0 +1,82 @@
+//go:build !slim
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/scaletest/prebuilds"
+	"github.com/coder/coder/v2/testutil"
+)
+
+func Test_getScaletestPrebuildsTemplates(t *testing.T) {
+	t.Parallel()
+
+	client, _, _ := coderdtest.NewWithAPI(t, &coderdtest.Options{
+		IncludeProvisionerDaemon: true,
+	})
+	user := coderdtest.CreateFirstUser(t, client)
+
+	makeTemplate := func(t *testing.T, name string) {
+		t.Helper()
+		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
+		coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+		coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID, func(r *codersdk.CreateTemplateRequest) {
+			r.Name = name
+		})
+	}
+
+	// The real runner uses a small integer suffix (e.g. "0", "1"), keeping the
+	// total name within the 32-character limit enforced by NameValid.
+	const (
+		scaletestPrebuildName = prebuilds.TemplatePrefix + "0"
+		prebuildNoScaletest   = "prebuild-other"
+		scaletestNoPrebuild   = "scaletest-other"
+		unrelatedTemplate     = "unrelated-template"
+	)
+
+	makeTemplate(t, scaletestPrebuildName)
+	makeTemplate(t, prebuildNoScaletest)
+	makeTemplate(t, scaletestNoPrebuild)
+	makeTemplate(t, unrelatedTemplate)
+
+	t.Run("NoFilter", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitMedium)
+		got, err := getScaletestPrebuildsTemplates(ctx, client, "")
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, scaletestPrebuildName, got[0].Name)
+	})
+
+	t.Run("MatchingTemplate", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitMedium)
+		got, err := getScaletestPrebuildsTemplates(ctx, client, scaletestPrebuildName)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, scaletestPrebuildName, got[0].Name)
+	})
+
+	t.Run("NonExistentScaletestTemplate", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitMedium)
+		got, err := getScaletestPrebuildsTemplates(ctx, client, prebuilds.TemplatePrefix+"99")
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("NonScaletestTemplateReturnsError", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitMedium)
+		for _, name := range []string{prebuildNoScaletest, scaletestNoPrebuild, unrelatedTemplate} {
+			_, err := getScaletestPrebuildsTemplates(ctx, client, name)
+			require.Error(t, err, "expected error for template %q", name)
+		}
+	})
+}

--- a/scaletest/prebuilds/run.go
+++ b/scaletest/prebuilds/run.go
@@ -26,6 +26,10 @@ type Runner struct {
 	template codersdk.Template
 }
 
+// TemplatePrefix is the name prefix applied to all templates created by the
+// scaletest prebuilds runner.
+const TemplatePrefix = "scaletest-prebuilds-template-"
+
 var (
 	_ harness.Runnable  = &Runner{}
 	_ harness.Cleanable = &Runner{}
@@ -62,7 +66,7 @@ func (r *Runner) Run(ctx context.Context, id string, logs io.Writer) error {
 	r.client.SetLogger(logger)
 	r.client.SetLogBodies(true)
 
-	templateName := "scaletest-prebuilds-template-" + id
+	templateName := TemplatePrefix + id
 
 	version, err := r.createTemplateVersion(ctx, uuid.Nil, r.cfg.NumPresets, r.cfg.NumPresetPrebuilds)
 	if err != nil {


### PR DESCRIPTION
Similarly to the other PRs I've opened today, this PR helps get a scaletest cluster back into a clean state after a prebuild run so that another load generator or another prebuild run is possible. Currently the CLI `exp scaletest cleanup` command ignores any workspaces/templates created for the prebuilds scaletest.


EDIT: pushed another commit to ensure prebuild reconciler is off when we start cleanup and then turned back on afterwards.