### PR TITLE
feat(site): add banner on request-logs page directing users to sessions

### DIFF
--- a/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsPageView.tsx
+++ b/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsPageView.tsx
@@ -61,6 +61,14 @@ export const RequestLogsPageView: FC<RequestLogsPageViewProps> = ({
 
 	return (
 		<>
+			<Alert severity="info" className="mb-4">
+				Visit the new{" "}
+				<Link href="/aibridge/sessions" className="text-content-link italic">
+					AI Sessions
+				</Link>{" "}
+				page for a more comprehensive view of AI activity.
+			</Alert>
+
 			<RequestLogsFilter {...filterProps} />
 
 			<PaginationContainer


### PR DESCRIPTION
*Disclaimer: implemented by a Coder Agent using Claude Opus 4.6*

Adds an info banner on the `/aibridge/request-logs` page encouraging users to visit `/aibridge/sessions` for an improved audit experience.

This allows us to validate whether customers still find the raw request logs view useful before removing it in a future release.

Fixes #23563