### PR TITLE
feat: add custom headers support to chat provider config

### DIFF
--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -723,10 +723,11 @@ func (s *MethodTestSuite) TestChats() {
 	}))
 	s.Run("InsertChatProvider", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		arg := database.InsertChatProviderParams{
-			Provider:    "test-provider",
-			DisplayName: "Test Provider",
-			APIKey:      "test-api-key",
-			Enabled:     true,
+			Provider:      "test-provider",
+			DisplayName:   "Test Provider",
+			APIKey:        "test-api-key",
+			Enabled:       true,
+			CustomHeaders: "{}",
 		}
 		provider := testutil.Fake(s.T(), faker, database.ChatProvider{Provider: arg.Provider, DisplayName: arg.DisplayName, APIKey: arg.APIKey, Enabled: arg.Enabled})
 		dbm.EXPECT().InsertChatProvider(gomock.Any(), arg).Return(provider, nil).AnyTimes()
@@ -801,10 +802,11 @@ func (s *MethodTestSuite) TestChats() {
 	s.Run("UpdateChatProvider", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		provider := testutil.Fake(s.T(), faker, database.ChatProvider{})
 		arg := database.UpdateChatProviderParams{
-			ID:          provider.ID,
-			DisplayName: "Updated Provider",
-			APIKey:      "updated-api-key",
-			Enabled:     true,
+			ID:            provider.ID,
+			DisplayName:   "Updated Provider",
+			APIKey:        "updated-api-key",
+			Enabled:       true,
+			CustomHeaders: "{}",
 		}
 		dbm.EXPECT().UpdateChatProvider(gomock.Any(), arg).Return(provider, nil).AnyTimes()
 		check.Args(arg).Asserts(rbac.ResourceDeploymentConfig, policy.ActionUpdate).Returns(provider)

--- a/coderd/database/migrations/000452_chat_provider_custom_headers.down.sql
+++ b/coderd/database/migrations/000452_chat_provider_custom_headers.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE chat_providers
+    DROP COLUMN IF EXISTS custom_headers_key_id,
+    DROP COLUMN IF EXISTS custom_headers;

--- a/coderd/database/migrations/000452_chat_provider_custom_headers.up.sql
+++ b/coderd/database/migrations/000452_chat_provider_custom_headers.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE chat_providers
+    ADD COLUMN custom_headers TEXT NOT NULL DEFAULT '{}',
+    ADD COLUMN custom_headers_key_id TEXT REFERENCES dbcrypt_keys(active_key_digest);

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -4257,12 +4257,14 @@ type ChatProvider struct {
 	DisplayName string    `db:"display_name" json:"display_name"`
 	APIKey      string    `db:"api_key" json:"api_key"`
 	// The ID of the key used to encrypt the provider API key. If this is NULL, the API key is not encrypted
-	ApiKeyKeyID sql.NullString `db:"api_key_key_id" json:"api_key_key_id"`
-	CreatedBy   uuid.NullUUID  `db:"created_by" json:"created_by"`
-	Enabled     bool           `db:"enabled" json:"enabled"`
-	CreatedAt   time.Time      `db:"created_at" json:"created_at"`
-	UpdatedAt   time.Time      `db:"updated_at" json:"updated_at"`
-	BaseUrl     string         `db:"base_url" json:"base_url"`
+	ApiKeyKeyID        sql.NullString `db:"api_key_key_id" json:"api_key_key_id"`
+	CreatedBy          uuid.NullUUID  `db:"created_by" json:"created_by"`
+	Enabled            bool           `db:"enabled" json:"enabled"`
+	CreatedAt          time.Time      `db:"created_at" json:"created_at"`
+	UpdatedAt          time.Time      `db:"updated_at" json:"updated_at"`
+	BaseUrl            string         `db:"base_url" json:"base_url"`
+	CustomHeaders      string         `db:"custom_headers" json:"custom_headers"`
+	CustomHeadersKeyID sql.NullString `db:"custom_headers_key_id" json:"custom_headers_key_id"`
 }
 
 type ChatQueuedMessage struct {

--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -1257,15 +1257,15 @@ func TestGetAuthorizedChats(t *testing.T) {
 	// Create FK dependencies: a chat provider and model config.
 	ctx := testutil.Context(t, testutil.WaitMedium)
 	_, err = db.InsertChatProvider(ctx, database.InsertChatProviderParams{
-		Provider:    "openai",
-		DisplayName: "OpenAI",
-		APIKey:      "test-key",
-		Enabled:     true,
+		Provider:      "openai",
+		DisplayName:   "OpenAI",
+		APIKey:        "test-key",
+		Enabled:       true,
+		CustomHeaders: "{}",
 	})
 	require.NoError(t, err)
 
-	modelCfg, err := db.InsertChatModelConfig(ctx, database.InsertChatModelConfigParams{
-		Provider:             "openai",
+	modelCfg, err := db.InsertChatModelConfig(ctx, database.InsertChatModelConfigParams{Provider: "openai",
 		Model:                "test-model",
 		DisplayName:          "Test Model",
 		CreatedBy:            uuid.NullUUID{UUID: owner.ID, Valid: true},
@@ -9447,15 +9447,15 @@ func TestInsertChatMessages(t *testing.T) {
 		provider := "openai"
 
 		_, err := store.InsertChatProvider(ctx, database.InsertChatProviderParams{
-			Provider:    provider,
-			DisplayName: "OpenAI",
-			APIKey:      "test-key",
-			Enabled:     true,
+			Provider:      provider,
+			DisplayName:   "OpenAI",
+			APIKey:        "test-key",
+			Enabled:       true,
+			CustomHeaders: "{}",
 		})
 		require.NoError(t, err)
 
-		modelConfigA := insertModelConfig(
-			t,
+		modelConfigA := insertModelConfig(t,
 			store,
 			ctx,
 			user.ID,
@@ -9611,16 +9611,16 @@ func TestGetChatMessagesForPromptByChatID(t *testing.T) {
 
 	// A chat_providers row is required as a FK for model configs.
 	_, err := db.InsertChatProvider(ctx, database.InsertChatProviderParams{
-		Provider:    "openai",
-		DisplayName: "OpenAI",
-		APIKey:      "test-key",
-		Enabled:     true,
+		Provider:      "openai",
+		DisplayName:   "OpenAI",
+		APIKey:        "test-key",
+		Enabled:       true,
+		CustomHeaders: "{}",
 	})
 	require.NoError(t, err)
 
 	modelCfg, err := db.InsertChatModelConfig(ctx, database.InsertChatModelConfigParams{
-		Provider:             "openai",
-		Model:                "test-model",
+		Provider: "openai", Model: "test-model",
 		DisplayName:          "Test Model",
 		CreatedBy:            uuid.NullUUID{UUID: user.ID, Valid: true},
 		UpdatedBy:            uuid.NullUUID{UUID: user.ID, Valid: true},
@@ -9981,13 +9981,13 @@ func TestGetPRInsights(t *testing.T) {
 		user := dbgen.User(t, store, database.User{})
 
 		_, err := store.InsertChatProvider(ctx, database.InsertChatProviderParams{
-			Provider:    "anthropic",
-			DisplayName: "Anthropic",
-			APIKey:      "test-key",
-			Enabled:     true,
+			Provider:      "anthropic",
+			DisplayName:   "Anthropic",
+			APIKey:        "test-key",
+			Enabled:       true,
+			CustomHeaders: "{}",
 		})
 		require.NoError(t, err)
-
 		mc, err := store.InsertChatModelConfig(ctx, database.InsertChatModelConfigParams{
 			Provider:             "anthropic",
 			Model:                "claude-4",
@@ -10502,10 +10502,11 @@ func TestChatLabels(t *testing.T) {
 	owner := dbgen.User(t, db, database.User{})
 
 	_, err = db.InsertChatProvider(ctx, database.InsertChatProviderParams{
-		Provider:    "openai",
-		DisplayName: "OpenAI",
-		APIKey:      "test-key",
-		Enabled:     true,
+		Provider:      "openai",
+		DisplayName:   "OpenAI",
+		APIKey:        "test-key",
+		Enabled:       true,
+		CustomHeaders: "{}",
 	})
 	require.NoError(t, err)
 

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -3550,7 +3550,7 @@ func (q *sqlQuerier) DeleteChatProviderByID(ctx context.Context, id uuid.UUID) e
 
 const getChatProviderByID = `-- name: GetChatProviderByID :one
 SELECT
-    id, provider, display_name, api_key, api_key_key_id, created_by, enabled, created_at, updated_at, base_url
+    id, provider, display_name, api_key, api_key_key_id, created_by, enabled, created_at, updated_at, base_url, custom_headers, custom_headers_key_id
 FROM
     chat_providers
 WHERE
@@ -3571,13 +3571,15 @@ func (q *sqlQuerier) GetChatProviderByID(ctx context.Context, id uuid.UUID) (Cha
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.BaseUrl,
+		&i.CustomHeaders,
+		&i.CustomHeadersKeyID,
 	)
 	return i, err
 }
 
 const getChatProviderByProvider = `-- name: GetChatProviderByProvider :one
 SELECT
-    id, provider, display_name, api_key, api_key_key_id, created_by, enabled, created_at, updated_at, base_url
+    id, provider, display_name, api_key, api_key_key_id, created_by, enabled, created_at, updated_at, base_url, custom_headers, custom_headers_key_id
 FROM
     chat_providers
 WHERE
@@ -3598,13 +3600,15 @@ func (q *sqlQuerier) GetChatProviderByProvider(ctx context.Context, provider str
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.BaseUrl,
+		&i.CustomHeaders,
+		&i.CustomHeadersKeyID,
 	)
 	return i, err
 }
 
 const getChatProviders = `-- name: GetChatProviders :many
 SELECT
-    id, provider, display_name, api_key, api_key_key_id, created_by, enabled, created_at, updated_at, base_url
+    id, provider, display_name, api_key, api_key_key_id, created_by, enabled, created_at, updated_at, base_url, custom_headers, custom_headers_key_id
 FROM
     chat_providers
 ORDER BY
@@ -3631,6 +3635,8 @@ func (q *sqlQuerier) GetChatProviders(ctx context.Context) ([]ChatProvider, erro
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.BaseUrl,
+			&i.CustomHeaders,
+			&i.CustomHeadersKeyID,
 		); err != nil {
 			return nil, err
 		}
@@ -3647,7 +3653,7 @@ func (q *sqlQuerier) GetChatProviders(ctx context.Context) ([]ChatProvider, erro
 
 const getEnabledChatProviders = `-- name: GetEnabledChatProviders :many
 SELECT
-    id, provider, display_name, api_key, api_key_key_id, created_by, enabled, created_at, updated_at, base_url
+    id, provider, display_name, api_key, api_key_key_id, created_by, enabled, created_at, updated_at, base_url, custom_headers, custom_headers_key_id
 FROM
     chat_providers
 WHERE
@@ -3676,6 +3682,8 @@ func (q *sqlQuerier) GetEnabledChatProviders(ctx context.Context) ([]ChatProvide
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.BaseUrl,
+			&i.CustomHeaders,
+			&i.CustomHeadersKeyID,
 		); err != nil {
 			return nil, err
 		}
@@ -3698,7 +3706,9 @@ INSERT INTO chat_providers (
     base_url,
     api_key_key_id,
     created_by,
-    enabled
+    enabled,
+    custom_headers,
+    custom_headers_key_id
 ) VALUES (
     $1::text,
     $2::text,
@@ -3706,20 +3716,24 @@ INSERT INTO chat_providers (
     $4::text,
     $5::text,
     $6::uuid,
-    $7::boolean
+    $7::boolean,
+    $8::text,
+    $9::text
 )
 RETURNING
-    id, provider, display_name, api_key, api_key_key_id, created_by, enabled, created_at, updated_at, base_url
+    id, provider, display_name, api_key, api_key_key_id, created_by, enabled, created_at, updated_at, base_url, custom_headers, custom_headers_key_id
 `
 
 type InsertChatProviderParams struct {
-	Provider    string         `db:"provider" json:"provider"`
-	DisplayName string         `db:"display_name" json:"display_name"`
-	APIKey      string         `db:"api_key" json:"api_key"`
-	BaseUrl     string         `db:"base_url" json:"base_url"`
-	ApiKeyKeyID sql.NullString `db:"api_key_key_id" json:"api_key_key_id"`
-	CreatedBy   uuid.NullUUID  `db:"created_by" json:"created_by"`
-	Enabled     bool           `db:"enabled" json:"enabled"`
+	Provider           string         `db:"provider" json:"provider"`
+	DisplayName        string         `db:"display_name" json:"display_name"`
+	APIKey             string         `db:"api_key" json:"api_key"`
+	BaseUrl            string         `db:"base_url" json:"base_url"`
+	ApiKeyKeyID        sql.NullString `db:"api_key_key_id" json:"api_key_key_id"`
+	CreatedBy          uuid.NullUUID  `db:"created_by" json:"created_by"`
+	Enabled            bool           `db:"enabled" json:"enabled"`
+	CustomHeaders      string         `db:"custom_headers" json:"custom_headers"`
+	CustomHeadersKeyID sql.NullString `db:"custom_headers_key_id" json:"custom_headers_key_id"`
 }
 
 func (q *sqlQuerier) InsertChatProvider(ctx context.Context, arg InsertChatProviderParams) (ChatProvider, error) {
@@ -3731,6 +3745,8 @@ func (q *sqlQuerier) InsertChatProvider(ctx context.Context, arg InsertChatProvi
 		arg.ApiKeyKeyID,
 		arg.CreatedBy,
 		arg.Enabled,
+		arg.CustomHeaders,
+		arg.CustomHeadersKeyID,
 	)
 	var i ChatProvider
 	err := row.Scan(
@@ -3744,6 +3760,8 @@ func (q *sqlQuerier) InsertChatProvider(ctx context.Context, arg InsertChatProvi
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.BaseUrl,
+		&i.CustomHeaders,
+		&i.CustomHeadersKeyID,
 	)
 	return i, err
 }
@@ -3757,20 +3775,24 @@ SET
     base_url = $3::text,
     api_key_key_id = $4::text,
     enabled = $5::boolean,
+    custom_headers = $6::text,
+    custom_headers_key_id = $7::text,
     updated_at = NOW()
 WHERE
-    id = $6::uuid
+    id = $8::uuid
 RETURNING
-    id, provider, display_name, api_key, api_key_key_id, created_by, enabled, created_at, updated_at, base_url
+    id, provider, display_name, api_key, api_key_key_id, created_by, enabled, created_at, updated_at, base_url, custom_headers, custom_headers_key_id
 `
 
 type UpdateChatProviderParams struct {
-	DisplayName string         `db:"display_name" json:"display_name"`
-	APIKey      string         `db:"api_key" json:"api_key"`
-	BaseUrl     string         `db:"base_url" json:"base_url"`
-	ApiKeyKeyID sql.NullString `db:"api_key_key_id" json:"api_key_key_id"`
-	Enabled     bool           `db:"enabled" json:"enabled"`
-	ID          uuid.UUID      `db:"id" json:"id"`
+	DisplayName        string         `db:"display_name" json:"display_name"`
+	APIKey             string         `db:"api_key" json:"api_key"`
+	BaseUrl            string         `db:"base_url" json:"base_url"`
+	ApiKeyKeyID        sql.NullString `db:"api_key_key_id" json:"api_key_key_id"`
+	Enabled            bool           `db:"enabled" json:"enabled"`
+	CustomHeaders      string         `db:"custom_headers" json:"custom_headers"`
+	CustomHeadersKeyID sql.NullString `db:"custom_headers_key_id" json:"custom_headers_key_id"`
+	ID                 uuid.UUID      `db:"id" json:"id"`
 }
 
 func (q *sqlQuerier) UpdateChatProvider(ctx context.Context, arg UpdateChatProviderParams) (ChatProvider, error) {
@@ -3780,6 +3802,8 @@ func (q *sqlQuerier) UpdateChatProvider(ctx context.Context, arg UpdateChatProvi
 		arg.BaseUrl,
 		arg.ApiKeyKeyID,
 		arg.Enabled,
+		arg.CustomHeaders,
+		arg.CustomHeadersKeyID,
 		arg.ID,
 	)
 	var i ChatProvider
@@ -3794,6 +3818,8 @@ func (q *sqlQuerier) UpdateChatProvider(ctx context.Context, arg UpdateChatProvi
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.BaseUrl,
+		&i.CustomHeaders,
+		&i.CustomHeadersKeyID,
 	)
 	return i, err
 }

--- a/coderd/database/queries/chatproviders.sql
+++ b/coderd/database/queries/chatproviders.sql
@@ -40,7 +40,9 @@ INSERT INTO chat_providers (
     base_url,
     api_key_key_id,
     created_by,
-    enabled
+    enabled,
+    custom_headers,
+    custom_headers_key_id
 ) VALUES (
     @provider::text,
     @display_name::text,
@@ -48,7 +50,9 @@ INSERT INTO chat_providers (
     @base_url::text,
     sqlc.narg('api_key_key_id')::text,
     sqlc.narg('created_by')::uuid,
-    @enabled::boolean
+    @enabled::boolean,
+    @custom_headers::text,
+    sqlc.narg('custom_headers_key_id')::text
 )
 RETURNING
     *;
@@ -62,6 +66,8 @@ SET
     base_url = @base_url::text,
     api_key_key_id = sqlc.narg('api_key_key_id')::text,
     enabled = @enabled::boolean,
+    custom_headers = @custom_headers::text,
+    custom_headers_key_id = sqlc.narg('custom_headers_key_id')::text,
     updated_at = NOW()
 WHERE
     id = @id::uuid

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -437,9 +437,10 @@ func (api *API) listChatModels(rw http.ResponseWriter, r *http.Request) {
 	for _, provider := range enabledProviders {
 		configuredProviders = append(
 			configuredProviders, chatprovider.ConfiguredProvider{
-				Provider: provider.Provider,
-				APIKey:   provider.APIKey,
-				BaseURL:  provider.BaseUrl,
+				Provider:      provider.Provider,
+				APIKey:        provider.APIKey,
+				BaseURL:       provider.BaseUrl,
+				CustomHeaders: provider.CustomHeaders,
 			},
 		)
 	}
@@ -3743,9 +3744,10 @@ func (api *API) listChatProviders(rw http.ResponseWriter, r *http.Request) {
 		provider.Provider = normalizedProvider
 		providersByName[normalizedProvider] = provider
 		configuredProviders = append(configuredProviders, chatprovider.ConfiguredProvider{
-			Provider: normalizedProvider,
-			APIKey:   provider.APIKey,
-			BaseURL:  provider.BaseUrl,
+			Provider:      normalizedProvider,
+			APIKey:        provider.APIKey,
+			BaseURL:       provider.BaseUrl,
+			CustomHeaders: provider.CustomHeaders,
 		})
 	}
 	if api.chatDaemon == nil {
@@ -3773,9 +3775,10 @@ func (api *API) listChatProviders(rw http.ResponseWriter, r *http.Request) {
 	for _, provider := range enabledProviders {
 		enabledConfiguredProviders = append(
 			enabledConfiguredProviders, chatprovider.ConfiguredProvider{
-				Provider: provider.Provider,
-				APIKey:   provider.APIKey,
-				BaseURL:  provider.BaseUrl,
+				Provider:      provider.Provider,
+				APIKey:        provider.APIKey,
+				BaseURL:       provider.BaseUrl,
+				CustomHeaders: provider.CustomHeaders,
 			},
 		)
 	}
@@ -3784,9 +3787,7 @@ func (api *API) listChatProviders(rw http.ResponseWriter, r *http.Request) {
 		chatProviderAPIKeysFromDeploymentValues(api.DeploymentValues),
 		enabledConfiguredProviders,
 	)
-	effectiveKeys = chatprovider.MergeProviderAPIKeys(
-		effectiveKeys, configuredProviders,
-	)
+	effectiveKeys = chatprovider.MergeProviderAPIKeys(effectiveKeys, configuredProviders)
 
 	supportedProviders := chatprovider.SupportedProviders()
 	resp := make([]codersdk.ChatProviderConfig, 0, len(supportedProviders))
@@ -3861,14 +3862,25 @@ func (api *API) createChatProvider(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	customHeadersJSON, err := marshalChatProviderCustomHeaders(req.CustomHeaders)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "Invalid custom headers.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
 	inserted, err := api.Database.InsertChatProvider(ctx, database.InsertChatProviderParams{
-		Provider:    provider,
-		DisplayName: strings.TrimSpace(req.DisplayName),
-		APIKey:      strings.TrimSpace(req.APIKey),
-		BaseUrl:     baseURL,
-		ApiKeyKeyID: sql.NullString{},
-		CreatedBy:   uuid.NullUUID{UUID: apiKey.UserID, Valid: apiKey.UserID != uuid.Nil},
-		Enabled:     enabled,
+		Provider:           provider,
+		DisplayName:        strings.TrimSpace(req.DisplayName),
+		APIKey:             strings.TrimSpace(req.APIKey),
+		BaseUrl:            baseURL,
+		ApiKeyKeyID:        sql.NullString{},
+		CreatedBy:          uuid.NullUUID{UUID: apiKey.UserID, Valid: apiKey.UserID != uuid.Nil},
+		Enabled:            enabled,
+		CustomHeaders:      customHeadersJSON,
+		CustomHeadersKeyID: sql.NullString{},
 	})
 	if err != nil {
 		switch {
@@ -3963,13 +3975,29 @@ func (api *API) updateChatProvider(rw http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	customHeaders := existing.CustomHeaders
+	customHeadersKeyID := existing.CustomHeadersKeyID
+	if req.CustomHeaders != nil {
+		customHeaders, err = marshalChatProviderCustomHeaders(*req.CustomHeaders)
+		if err != nil {
+			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+				Message: "Invalid custom headers.",
+				Detail:  err.Error(),
+			})
+			return
+		}
+		customHeadersKeyID = sql.NullString{}
+	}
+
 	updated, err := api.Database.UpdateChatProvider(ctx, database.UpdateChatProviderParams{
-		DisplayName: displayName,
-		APIKey:      apiKey,
-		BaseUrl:     baseURL,
-		ApiKeyKeyID: apiKeyKeyID,
-		Enabled:     enabled,
-		ID:          existing.ID,
+		DisplayName:        displayName,
+		APIKey:             apiKey,
+		BaseUrl:            baseURL,
+		ApiKeyKeyID:        apiKeyKeyID,
+		Enabled:            enabled,
+		CustomHeaders:      customHeaders,
+		CustomHeadersKeyID: customHeadersKeyID,
+		ID:                 existing.ID,
 	})
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
@@ -4570,16 +4598,31 @@ func convertChatProviderConfig(
 	}
 
 	return codersdk.ChatProviderConfig{
-		ID:          provider.ID,
-		Provider:    provider.Provider,
-		DisplayName: displayName,
-		Enabled:     provider.Enabled,
-		HasAPIKey:   hasAPIKey,
-		BaseURL:     strings.TrimSpace(provider.BaseUrl),
-		Source:      source,
-		CreatedAt:   provider.CreatedAt,
-		UpdatedAt:   provider.UpdatedAt,
+		ID:               provider.ID,
+		Provider:         provider.Provider,
+		DisplayName:      displayName,
+		Enabled:          provider.Enabled,
+		HasAPIKey:        hasAPIKey,
+		HasCustomHeaders: provider.CustomHeaders != "" && provider.CustomHeaders != "{}",
+		BaseURL:          strings.TrimSpace(provider.BaseUrl),
+		Source:           source,
+		CreatedAt:        provider.CreatedAt,
+		UpdatedAt:        provider.UpdatedAt,
 	}
+}
+
+// marshalChatProviderCustomHeaders encodes a map of custom headers
+// to JSON for database storage. A nil map produces an empty JSON
+// object.
+func marshalChatProviderCustomHeaders(headers map[string]string) (string, error) {
+	if headers == nil {
+		return "{}", nil
+	}
+	encoded, err := json.Marshal(headers)
+	if err != nil {
+		return "", err
+	}
+	return string(encoded), nil
 }
 
 func convertChatModelConfig(config database.ChatModelConfig) codersdk.ChatModelConfig {
@@ -4780,16 +4823,16 @@ func (api *API) hasEffectiveProviderAPIKey(ctx context.Context, provider databas
 	for _, configured := range enabledProviders {
 		enabledConfiguredProviders = append(
 			enabledConfiguredProviders, chatprovider.ConfiguredProvider{
-				Provider: configured.Provider,
-				APIKey:   configured.APIKey,
-				BaseURL:  configured.BaseUrl,
+				Provider:      configured.Provider,
+				APIKey:        configured.APIKey,
+				BaseURL:       configured.BaseUrl,
+				CustomHeaders: configured.CustomHeaders,
 			},
 		)
 	}
 
 	effectiveKeys := chatprovider.MergeProviderAPIKeys(
-		chatProviderAPIKeysFromDeploymentValues(api.DeploymentValues),
-		enabledConfiguredProviders,
+		chatProviderAPIKeysFromDeploymentValues(api.DeploymentValues), enabledConfiguredProviders,
 	)
 	return effectiveKeys.APIKey(provider.Provider) != ""
 }

--- a/coderd/httpmw/chatparam_test.go
+++ b/coderd/httpmw/chatparam_test.go
@@ -46,6 +46,7 @@ func TestChatParam(t *testing.T) {
 			ApiKeyKeyID: sql.NullString{},
 			CreatedBy:   uuid.NullUUID{UUID: ownerID, Valid: true},
 			Enabled:     true,
+			CustomHeaders: "{}",
 		})
 		require.NoError(t, err)
 

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -3803,9 +3803,10 @@ func (p *Server) resolveChatModel(
 	)
 	for _, provider := range providers {
 		dbProviders = append(dbProviders, chatprovider.ConfiguredProvider{
-			Provider: provider.Provider,
-			APIKey:   provider.APIKey,
-			BaseURL:  provider.BaseUrl,
+			Provider:      provider.Provider,
+			APIKey:        provider.APIKey,
+			BaseURL:       provider.BaseUrl,
+			CustomHeaders: provider.CustomHeaders,
 		})
 	}
 	keys := chatprovider.MergeProviderAPIKeys(

--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -2478,6 +2478,7 @@ func seedChatDependenciesWithProvider(
 		BaseUrl:     baseURL,
 		CreatedBy:   uuid.NullUUID{UUID: user.ID, Valid: true},
 		Enabled:     true,
+		CustomHeaders: "{}",
 	})
 	require.NoError(t, err)
 	model, err := db.InsertChatModelConfig(ctx, database.InsertChatModelConfigParams{
@@ -2558,6 +2559,8 @@ func setOpenAIProviderBaseURL(
 		BaseUrl:     baseURL,
 		ApiKeyKeyID: provider.ApiKeyKeyID,
 		Enabled:     provider.Enabled,
+		CustomHeaders:      "{}",
+		CustomHeadersKeyID: sql.NullString{},
 	})
 	require.NoError(t, err)
 }
@@ -3137,6 +3140,7 @@ func TestComputerUseSubagentToolsAndModel(t *testing.T) {
 		BaseUrl:     anthropicSrv.URL,
 		CreatedBy:   uuid.NullUUID{UUID: user.ID, Valid: true},
 		Enabled:     true,
+		CustomHeaders: "{}",
 	})
 	require.NoError(t, err)
 

--- a/coderd/x/chatd/chatprompt/chatprompt_test.go
+++ b/coderd/x/chatd/chatprompt/chatprompt_test.go
@@ -1464,6 +1464,7 @@ func TestNulEscapeRoundTrip(t *testing.T) {
 		APIKey:      "test-key",
 		CreatedBy:   uuid.NullUUID{UUID: user.ID, Valid: true},
 		Enabled:     true,
+		CustomHeaders: "{}",
 	})
 	require.NoError(t, err)
 
@@ -1947,6 +1948,7 @@ func TestMediaToolResultRoundTrip(t *testing.T) {
 		APIKey:      "test-key",
 		CreatedBy:   uuid.NullUUID{UUID: user.ID, Valid: true},
 		Enabled:     true,
+		CustomHeaders: "{}",
 	})
 	require.NoError(t, err)
 

--- a/coderd/x/chatd/chatprovider/chatprovider.go
+++ b/coderd/x/chatd/chatprovider/chatprovider.go
@@ -2,6 +2,7 @@ package chatprovider
 
 import (
 	"context"
+	"encoding/json"
 	"sort"
 	"strings"
 
@@ -75,17 +76,19 @@ func ProviderDisplayName(provider string) string {
 
 // ProviderAPIKeys contains API keys for provider calls.
 type ProviderAPIKeys struct {
-	OpenAI            string
-	Anthropic         string
-	ByProvider        map[string]string
-	BaseURLByProvider map[string]string
+	OpenAI                  string
+	Anthropic               string
+	ByProvider              map[string]string
+	BaseURLByProvider       map[string]string
+	CustomHeadersByProvider map[string]map[string]string
 }
 
 // ConfiguredProvider is an enabled provider loaded from database config.
 type ConfiguredProvider struct {
-	Provider string
-	APIKey   string
-	BaseURL  string
+	Provider      string
+	APIKey        string
+	BaseURL       string
+	CustomHeaders string
 }
 
 // ConfiguredModel is an enabled model loaded from database config.
@@ -132,13 +135,23 @@ func (k ProviderAPIKeys) BaseURL(provider string) string {
 	return strings.TrimSpace(k.BaseURLByProvider[normalized])
 }
 
+// CustomHeaders returns the configured custom headers for a provider.
+func (k ProviderAPIKeys) CustomHeaders(provider string) map[string]string {
+	normalized := NormalizeProvider(provider)
+	if normalized == "" || k.CustomHeadersByProvider == nil {
+		return nil
+	}
+	return k.CustomHeadersByProvider[normalized]
+}
+
 // MergeProviderAPIKeys overlays configured provider keys over fallback keys.
 func MergeProviderAPIKeys(fallback ProviderAPIKeys, providers []ConfiguredProvider) ProviderAPIKeys {
 	merged := ProviderAPIKeys{
-		OpenAI:            strings.TrimSpace(fallback.OpenAI),
-		Anthropic:         strings.TrimSpace(fallback.Anthropic),
-		ByProvider:        map[string]string{},
-		BaseURLByProvider: map[string]string{},
+		OpenAI:                  strings.TrimSpace(fallback.OpenAI),
+		Anthropic:               strings.TrimSpace(fallback.Anthropic),
+		ByProvider:              map[string]string{},
+		BaseURLByProvider:       map[string]string{},
+		CustomHeadersByProvider: map[string]map[string]string{},
 	}
 	for provider, apiKey := range fallback.ByProvider {
 		normalizedProvider := NormalizeProvider(provider)
@@ -156,6 +169,15 @@ func MergeProviderAPIKeys(fallback ProviderAPIKeys, providers []ConfiguredProvid
 		}
 		if url := strings.TrimSpace(baseURL); url != "" {
 			merged.BaseURLByProvider[normalizedProvider] = url
+		}
+	}
+	for provider, headers := range fallback.CustomHeadersByProvider {
+		normalizedProvider := NormalizeProvider(provider)
+		if normalizedProvider == "" {
+			continue
+		}
+		if len(headers) > 0 {
+			merged.CustomHeadersByProvider[normalizedProvider] = headers
 		}
 	}
 
@@ -177,6 +199,12 @@ func MergeProviderAPIKeys(fallback ProviderAPIKeys, providers []ConfiguredProvid
 		}
 		if url := strings.TrimSpace(provider.BaseURL); url != "" {
 			merged.BaseURLByProvider[normalizedProvider] = url
+		}
+		if provider.CustomHeaders != "" && provider.CustomHeaders != "{}" {
+			var headers map[string]string
+			if err := json.Unmarshal([]byte(provider.CustomHeaders), &headers); err == nil && len(headers) > 0 {
+				merged.CustomHeadersByProvider[normalizedProvider] = headers
+			}
 		}
 
 		switch normalizedProvider {
@@ -966,6 +994,21 @@ func ModelFromConfig(
 		return nil, missingProviderAPIKeyError(provider)
 	}
 	baseURL := providerKeys.BaseURL(provider)
+
+	// Merge provider-level custom headers with the caller's extra headers.
+	providerCustomHeaders := providerKeys.CustomHeaders(provider)
+	if len(providerCustomHeaders) > 0 {
+		mergedHeaders := make(map[string]string, len(providerCustomHeaders)+len(extraHeaders))
+		for k, v := range providerCustomHeaders {
+			mergedHeaders[k] = v
+		}
+		// Caller's extra headers (e.g. Coder identity headers) take
+		// precedence.
+		for k, v := range extraHeaders {
+			mergedHeaders[k] = v
+		}
+		extraHeaders = mergedHeaders
+	}
 
 	var providerClient fantasy.Provider
 	switch provider {

--- a/coderd/x/chatd/chattool/startworkspace_test.go
+++ b/coderd/x/chatd/chattool/startworkspace_test.go
@@ -238,6 +238,7 @@ func seedModelConfig(
 		ApiKeyKeyID: sql.NullString{},
 		CreatedBy:   uuid.NullUUID{UUID: userID, Valid: true},
 		Enabled:     true,
+		CustomHeaders: "{}",
 	})
 	require.NoError(t, err)
 

--- a/coderd/x/chatd/subagent_internal_test.go
+++ b/coderd/x/chatd/subagent_internal_test.go
@@ -129,6 +129,7 @@ func seedInternalChatDeps(
 		ApiKeyKeyID: sql.NullString{},
 		CreatedBy:   uuid.NullUUID{UUID: user.ID, Valid: true},
 		Enabled:     true,
+		CustomHeaders: "{}",
 	})
 	require.NoError(t, err)
 

--- a/coderd/x/gitsync/worker_test.go
+++ b/coderd/x/gitsync/worker_test.go
@@ -818,6 +818,7 @@ func TestWorker(t *testing.T) {
 		Provider:    "openai",
 		DisplayName: "OpenAI",
 		Enabled:     true,
+		CustomHeaders: "{}",
 	})
 	require.NoError(t, err)
 

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -481,32 +481,35 @@ const (
 
 // ChatProviderConfig is an admin-managed provider configuration.
 type ChatProviderConfig struct {
-	ID          uuid.UUID                `json:"id" format:"uuid"`
-	Provider    string                   `json:"provider"`
-	DisplayName string                   `json:"display_name"`
-	Enabled     bool                     `json:"enabled"`
-	HasAPIKey   bool                     `json:"has_api_key"`
-	BaseURL     string                   `json:"base_url,omitempty"`
-	Source      ChatProviderConfigSource `json:"source"`
-	CreatedAt   time.Time                `json:"created_at,omitempty" format:"date-time"`
-	UpdatedAt   time.Time                `json:"updated_at,omitempty" format:"date-time"`
+	ID               uuid.UUID                `json:"id" format:"uuid"`
+	Provider         string                   `json:"provider"`
+	DisplayName      string                   `json:"display_name"`
+	Enabled          bool                     `json:"enabled"`
+	HasAPIKey        bool                     `json:"has_api_key"`
+	HasCustomHeaders bool                     `json:"has_custom_headers"`
+	BaseURL          string                   `json:"base_url,omitempty"`
+	Source           ChatProviderConfigSource `json:"source"`
+	CreatedAt        time.Time                `json:"created_at,omitempty" format:"date-time"`
+	UpdatedAt        time.Time                `json:"updated_at,omitempty" format:"date-time"`
 }
 
 // CreateChatProviderConfigRequest creates a chat provider config.
 type CreateChatProviderConfigRequest struct {
-	Provider    string `json:"provider"`
-	DisplayName string `json:"display_name,omitempty"`
-	APIKey      string `json:"api_key,omitempty"`
-	BaseURL     string `json:"base_url,omitempty"`
-	Enabled     *bool  `json:"enabled,omitempty"`
+	Provider      string            `json:"provider"`
+	DisplayName   string            `json:"display_name,omitempty"`
+	APIKey        string            `json:"api_key,omitempty"`
+	BaseURL       string            `json:"base_url,omitempty"`
+	Enabled       *bool             `json:"enabled,omitempty"`
+	CustomHeaders map[string]string `json:"custom_headers,omitempty"`
 }
 
 // UpdateChatProviderConfigRequest updates a chat provider config.
 type UpdateChatProviderConfigRequest struct {
-	DisplayName string  `json:"display_name,omitempty"`
-	APIKey      *string `json:"api_key,omitempty"`
-	BaseURL     *string `json:"base_url,omitempty"`
-	Enabled     *bool   `json:"enabled,omitempty"`
+	DisplayName   string             `json:"display_name,omitempty"`
+	APIKey        *string            `json:"api_key,omitempty"`
+	BaseURL       *string            `json:"base_url,omitempty"`
+	Enabled       *bool              `json:"enabled,omitempty"`
+	CustomHeaders *map[string]string `json:"custom_headers,omitempty"`
 }
 
 // ChatModelConfig is an admin-managed model configuration.

--- a/enterprise/coderd/x/chatd/chatd_test.go
+++ b/enterprise/coderd/x/chatd/chatd_test.go
@@ -103,6 +103,7 @@ func seedChatDependencies(
 		ApiKeyKeyID: sql.NullString{},
 		CreatedBy:   uuid.NullUUID{UUID: user.ID, Valid: true},
 		Enabled:     true,
+		CustomHeaders: "{}",
 	})
 	require.NoError(t, err)
 	model, err := db.InsertChatModelConfig(ctx, database.InsertChatModelConfigParams{
@@ -139,6 +140,8 @@ func setOpenAIProviderBaseURL(
 		BaseUrl:     baseURL,
 		ApiKeyKeyID: provider.ApiKeyKeyID,
 		Enabled:     provider.Enabled,
+		CustomHeaders:      "{}",
+		CustomHeadersKeyID: sql.NullString{},
 	})
 	require.NoError(t, err)
 }

--- a/enterprise/dbcrypt/cliutil.go
+++ b/enterprise/dbcrypt/cliutil.go
@@ -97,12 +97,14 @@ func Rotate(ctx context.Context, log slog.Logger, sqlDB *sql.DB, ciphers []Ciphe
 			continue
 		}
 		if _, err := cryptDB.UpdateChatProvider(ctx, database.UpdateChatProviderParams{
-			DisplayName: provider.DisplayName,
-			APIKey:      provider.APIKey,
-			BaseUrl:     provider.BaseUrl,
-			ApiKeyKeyID: sql.NullString{}, // dbcrypt will update as required
-			Enabled:     provider.Enabled,
-			ID:          provider.ID,
+			DisplayName:        provider.DisplayName,
+			APIKey:             provider.APIKey,
+			BaseUrl:            provider.BaseUrl,
+			ApiKeyKeyID:        sql.NullString{}, // dbcrypt will update as required
+			Enabled:            provider.Enabled,
+			CustomHeaders:      provider.CustomHeaders,
+			CustomHeadersKeyID: sql.NullString{}, // dbcrypt will update as required
+			ID:                 provider.ID,
 		}); err != nil {
 			return xerrors.Errorf("update chat provider id=%s provider=%s: %w", provider.ID, provider.Provider, err)
 		}
@@ -209,12 +211,14 @@ func Decrypt(ctx context.Context, log slog.Logger, sqlDB *sql.DB, ciphers []Ciph
 			continue
 		}
 		if _, err := cryptDB.UpdateChatProvider(ctx, database.UpdateChatProviderParams{
-			DisplayName: provider.DisplayName,
-			APIKey:      provider.APIKey,
-			BaseUrl:     provider.BaseUrl,
-			ApiKeyKeyID: sql.NullString{}, // we explicitly want to clear the key id
-			Enabled:     provider.Enabled,
-			ID:          provider.ID,
+			DisplayName:        provider.DisplayName,
+			APIKey:             provider.APIKey,
+			BaseUrl:            provider.BaseUrl,
+			ApiKeyKeyID:        sql.NullString{}, // we explicitly want to clear the key id
+			Enabled:            provider.Enabled,
+			CustomHeaders:      provider.CustomHeaders,
+			CustomHeadersKeyID: sql.NullString{}, // we explicitly want to clear the key id
+			ID:                 provider.ID,
 		}); err != nil {
 			return xerrors.Errorf("update chat provider id=%s provider=%s: %w", provider.ID, provider.Provider, err)
 		}

--- a/enterprise/dbcrypt/dbcrypt.go
+++ b/enterprise/dbcrypt/dbcrypt.go
@@ -393,6 +393,9 @@ func (db *dbCrypt) GetChatProviderByID(ctx context.Context, id uuid.UUID) (datab
 	if err := db.decryptField(&provider.APIKey, provider.ApiKeyKeyID); err != nil {
 		return database.ChatProvider{}, err
 	}
+	if err := db.decryptField(&provider.CustomHeaders, provider.CustomHeadersKeyID); err != nil {
+		return database.ChatProvider{}, err
+	}
 	return provider, nil
 }
 
@@ -402,6 +405,9 @@ func (db *dbCrypt) GetChatProviderByProvider(ctx context.Context, providerName s
 		return database.ChatProvider{}, err
 	}
 	if err := db.decryptField(&provider.APIKey, provider.ApiKeyKeyID); err != nil {
+		return database.ChatProvider{}, err
+	}
+	if err := db.decryptField(&provider.CustomHeaders, provider.CustomHeadersKeyID); err != nil {
 		return database.ChatProvider{}, err
 	}
 	return provider, nil
@@ -415,6 +421,9 @@ func (db *dbCrypt) GetChatProviders(ctx context.Context) ([]database.ChatProvide
 
 	for i := range providers {
 		if err := db.decryptField(&providers[i].APIKey, providers[i].ApiKeyKeyID); err != nil {
+			return nil, err
+		}
+		if err := db.decryptField(&providers[i].CustomHeaders, providers[i].CustomHeadersKeyID); err != nil {
 			return nil, err
 		}
 	}
@@ -432,6 +441,9 @@ func (db *dbCrypt) GetEnabledChatProviders(ctx context.Context) ([]database.Chat
 		if err := db.decryptField(&providers[i].APIKey, providers[i].ApiKeyKeyID); err != nil {
 			return nil, err
 		}
+		if err := db.decryptField(&providers[i].CustomHeaders, providers[i].CustomHeadersKeyID); err != nil {
+			return nil, err
+		}
 	}
 
 	return providers, nil
@@ -443,12 +455,20 @@ func (db *dbCrypt) InsertChatProvider(ctx context.Context, params database.Inser
 	} else if err := db.encryptField(&params.APIKey, &params.ApiKeyKeyID); err != nil {
 		return database.ChatProvider{}, err
 	}
+	if strings.TrimSpace(params.CustomHeaders) == "" || params.CustomHeaders == "{}" {
+		params.CustomHeadersKeyID = sql.NullString{}
+	} else if err := db.encryptField(&params.CustomHeaders, &params.CustomHeadersKeyID); err != nil {
+		return database.ChatProvider{}, err
+	}
 
 	provider, err := db.Store.InsertChatProvider(ctx, params)
 	if err != nil {
 		return database.ChatProvider{}, err
 	}
 	if err := db.decryptField(&provider.APIKey, provider.ApiKeyKeyID); err != nil {
+		return database.ChatProvider{}, err
+	}
+	if err := db.decryptField(&provider.CustomHeaders, provider.CustomHeadersKeyID); err != nil {
 		return database.ChatProvider{}, err
 	}
 	return provider, nil
@@ -460,12 +480,20 @@ func (db *dbCrypt) UpdateChatProvider(ctx context.Context, params database.Updat
 	} else if err := db.encryptField(&params.APIKey, &params.ApiKeyKeyID); err != nil {
 		return database.ChatProvider{}, err
 	}
+	if strings.TrimSpace(params.CustomHeaders) == "" || params.CustomHeaders == "{}" {
+		params.CustomHeadersKeyID = sql.NullString{}
+	} else if err := db.encryptField(&params.CustomHeaders, &params.CustomHeadersKeyID); err != nil {
+		return database.ChatProvider{}, err
+	}
 
 	provider, err := db.Store.UpdateChatProvider(ctx, params)
 	if err != nil {
 		return database.ChatProvider{}, err
 	}
 	if err := db.decryptField(&provider.APIKey, provider.ApiKeyKeyID); err != nil {
+		return database.ChatProvider{}, err
+	}
+	if err := db.decryptField(&provider.CustomHeaders, provider.CustomHeadersKeyID); err != nil {
 		return database.ChatProvider{}, err
 	}
 	return provider, nil

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1726,6 +1726,7 @@ export interface ChatProviderConfig {
 	readonly display_name: string;
 	readonly enabled: boolean;
 	readonly has_api_key: boolean;
+	readonly has_custom_headers: boolean;
 	readonly base_url?: string;
 	readonly source: ChatProviderConfigSource;
 	readonly created_at?: string;
@@ -2235,6 +2236,7 @@ export interface CreateChatProviderConfigRequest {
 	readonly api_key?: string;
 	readonly base_url?: string;
 	readonly enabled?: boolean;
+	readonly custom_headers?: Record<string, string>;
 }
 
 // From codersdk/chats.go
@@ -7002,6 +7004,7 @@ export interface UpdateChatProviderConfigRequest {
 	readonly api_key?: string;
 	readonly base_url?: string;
 	readonly enabled?: boolean;
+	readonly custom_headers?: Record<string, string>;
 }
 
 // From codersdk/chats.go

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ChatModelAdminPanel.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ChatModelAdminPanel.stories.tsx
@@ -21,6 +21,7 @@ const createProviderConfig = (
 	display_name: overrides.display_name ?? "",
 	enabled: overrides.enabled ?? true,
 	has_api_key: overrides.has_api_key ?? false,
+	has_custom_headers: overrides.has_custom_headers ?? false,
 	base_url: overrides.base_url ?? "",
 	source: overrides.source ?? "database",
 	created_at: overrides.created_at ?? now,
@@ -71,14 +72,16 @@ const setupChatSpies = (state: {
 	spyOn(API.experimental, "createChatProviderConfig").mockImplementation(
 		async (req) => {
 			const created = createProviderConfig({
-				id: `provider-${Date.now()}`,
-				provider: req.provider,
-				display_name: req.display_name ?? "",
-				has_api_key: (req.api_key ?? "").trim().length > 0,
-				base_url: req.base_url ?? "",
-				source: "database",
-			});
-			state.providerConfigs = [
+					id: `provider-${Date.now()}`,
+					provider: req.provider,
+					display_name: req.display_name ?? "",
+					has_api_key: (req.api_key ?? "").trim().length > 0,
+					has_custom_headers:
+						req.custom_headers !== undefined &&
+						Object.keys(req.custom_headers).length > 0,
+					base_url: req.base_url ?? "",
+					source: "database",
+				});			state.providerConfigs = [
 				...state.providerConfigs.filter((p) => p.provider !== req.provider),
 				created,
 			];
@@ -96,20 +99,23 @@ const setupChatSpies = (state: {
 			}
 			const current = state.providerConfigs[idx];
 			const updated: TypesGen.ChatProviderConfig = {
-				...current,
-				display_name:
-					typeof req.display_name === "string"
-						? req.display_name
-						: current.display_name,
-				has_api_key:
-					typeof req.api_key === "string"
-						? req.api_key.trim().length > 0
-						: current.has_api_key,
-				base_url:
-					typeof req.base_url === "string" ? req.base_url : current.base_url,
-				updated_at: now,
-			};
-			state.providerConfigs = state.providerConfigs.map((p, i) =>
+					...current,
+					display_name:
+						typeof req.display_name === "string"
+							? req.display_name
+							: current.display_name,
+					has_api_key:
+						typeof req.api_key === "string"
+							? req.api_key.trim().length > 0
+							: current.has_api_key,
+					has_custom_headers:
+						req.custom_headers !== undefined
+							? Object.keys(req.custom_headers).length > 0
+							: current.has_custom_headers,
+					base_url:
+						typeof req.base_url === "string" ? req.base_url : current.base_url,
+					updated_at: now,
+				};			state.providerConfigs = state.providerConfigs.map((p, i) =>
 				i === idx ? updated : p,
 			);
 			return updated;
@@ -884,6 +890,108 @@ export const ProviderDeleteCancelled: Story = {
 		await expect(
 			await body.findByRole("button", { name: "Save changes" }),
 		).toBeInTheDocument();
+	},
+};
+
+export const CustomHeadersCreateProvider: Story = {
+	args: { section: "providers" as ChatModelAdminSection },
+	beforeEach: () => {
+		setupChatSpies({
+			providerConfigs: [
+				createProviderConfig({
+					id: nilProviderConfigID,
+					provider: "openai",
+					display_name: "OpenAI",
+					source: "supported",
+					enabled: false,
+					has_api_key: false,
+				}),
+			],
+			modelConfigs: [],
+			modelCatalog: { providers: [] },
+		});
+	},
+	play: async ({ canvasElement }) => {
+		const body = within(canvasElement.ownerDocument.body);
+
+		// Navigate to the OpenAI detail view.
+		await userEvent.click(
+			await body.findByRole("button", { name: /OpenAI/i }),
+		);
+
+		// Fill in the API key.
+		await userEvent.type(
+			await body.findByLabelText(/API key/i),
+			"sk-test-key",
+		);
+
+		// Add custom headers.
+		await userEvent.click(body.getByText("Add header"));
+		const headerNameInputs = body.getAllByPlaceholderText("Header name");
+		const headerValueInputs = body.getAllByPlaceholderText("Value");
+		await userEvent.type(headerNameInputs[0], "X-Custom-Auth");
+		await userEvent.type(headerValueInputs[0], "Bearer token123");
+
+		// Add a second header.
+		await userEvent.click(body.getByText("Add header"));
+		const updatedNameInputs = body.getAllByPlaceholderText("Header name");
+		const updatedValueInputs = body.getAllByPlaceholderText("Value");
+		await userEvent.type(updatedNameInputs[1], "X-Org-ID");
+		await userEvent.type(updatedValueInputs[1], "org-456");
+
+		// Submit.
+		await userEvent.click(
+			body.getByRole("button", { name: "Create provider config" }),
+		);
+
+		await waitFor(() => {
+			expect(
+				API.experimental.createChatProviderConfig,
+			).toHaveBeenCalledTimes(1);
+		});
+		expect(API.experimental.createChatProviderConfig).toHaveBeenCalledWith(
+			expect.objectContaining({
+				provider: "openai",
+				api_key: "sk-test-key",
+				custom_headers: {
+					"X-Custom-Auth": "Bearer token123",
+					"X-Org-ID": "org-456",
+				},
+			}),
+		);
+	},
+};
+
+export const CustomHeadersExistingProvider: Story = {
+	args: { section: "providers" as ChatModelAdminSection },
+	beforeEach: () => {
+		setupChatSpies({
+			providerConfigs: [
+				createProviderConfig({
+					id: "provider-openai",
+					provider: "openai",
+					display_name: "OpenAI",
+					source: "database",
+					has_api_key: true,
+					has_custom_headers: true,
+				}),
+			],
+			modelConfigs: [],
+			modelCatalog: { providers: [] },
+		});
+	},
+	play: async ({ canvasElement }) => {
+		const body = within(canvasElement.ownerDocument.body);
+
+		// Navigate to OpenAI detail view.
+		await userEvent.click(
+			await body.findByRole("button", { name: /OpenAI/i }),
+		);
+
+		// The custom headers section should show a masked placeholder row.
+		await expect(body.getByText("Custom Headers")).toBeInTheDocument();
+		// The Add header button should be visible.
+		await expect(body.getByText("Add header")).toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelsSection.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelsSection.stories.tsx
@@ -14,6 +14,7 @@ const providerState: ProviderState = {
 		display_name: "OpenAI",
 		enabled: true,
 		has_api_key: true,
+		has_custom_headers: false,
 		base_url: undefined,
 		source: "database",
 		created_at: "2025-01-01T00:00:00Z",

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ProviderForm.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ProviderForm.tsx
@@ -1,5 +1,5 @@
 import type * as TypesGen from "api/typesGenerated";
-import { ChevronLeftIcon, InfoIcon } from "lucide-react";
+import { ChevronLeftIcon, InfoIcon, PlusIcon, TrashIcon } from "lucide-react";
 import { type FC, type FormEvent, useId, useState } from "react";
 import { Alert, AlertDescription, AlertTitle } from "#/components/Alert/Alert";
 import { Button } from "#/components/Button/Button";
@@ -19,6 +19,12 @@ import { ProviderIcon } from "./ProviderIcon";
 // backend won't reveal. If the user hasn't touched the field,
 // we know nothing changed.
 const API_KEY_PLACEHOLDER = "••••••••••••••••";
+
+// Sentinel value used when the provider already has custom headers
+// stored on the backend.
+const CUSTOM_HEADERS_PLACEHOLDER = "••••••••";
+
+type HeaderEntry = { key: string; value: string };
 
 interface ProviderFormProps {
 	providerState: ProviderState;
@@ -71,6 +77,17 @@ export const ProviderForm: FC<ProviderFormProps> = ({
 	const [baseURLValue, setBaseURLValue] = useState(initialValues.baseURL);
 	const [confirmingDelete, setConfirmingDelete] = useState(false);
 
+	// Custom headers state — a list of key-value pairs.
+	const hasExistingHeaders = providerConfig?.has_custom_headers ?? false;
+	const [headers, setHeaders] = useState<HeaderEntry[]>(() => {
+		// For existing providers with headers, show placeholder row.
+		if (hasExistingHeaders) {
+			return [{ key: CUSTOM_HEADERS_PLACEHOLDER, value: CUSTOM_HEADERS_PLACEHOLDER }];
+		}
+		return [];
+	});
+	const [headersTouched, setHeadersTouched] = useState(false);
+
 	const isAPIKeyEnvManaged = isEnvPreset && !providerConfig;
 	const requiresAPIKey = !providerConfig && !isAPIKeyEnvManaged;
 
@@ -78,11 +95,26 @@ export const ProviderForm: FC<ProviderFormProps> = ({
 	const effectiveApiKey =
 		apiKeyTouched && apiKey !== API_KEY_PLACEHOLDER ? apiKey.trim() : "";
 
+	// Build the effective custom headers map to submit.
+	const buildEffectiveHeaders = (): Record<string, string> | undefined => {
+		if (!headersTouched) return undefined;
+		const result: Record<string, string> = {};
+		for (const h of headers) {
+			const key = h.key.trim();
+			const value = h.value.trim();
+			if (key && key !== CUSTOM_HEADERS_PLACEHOLDER) {
+				result[key] = value;
+			}
+		}
+		return result;
+	};
+
 	// Dirty detection: has anything changed from the initial state?
 	const isDirty =
 		displayName.trim() !== initialValues.displayName ||
 		effectiveApiKey !== "" ||
-		baseURLValue.trim() !== initialValues.baseURL.trim();
+		baseURLValue.trim() !== initialValues.baseURL.trim() ||
+		headersTouched;
 
 	const canSave =
 		!providerConfigsUnavailable &&
@@ -103,6 +135,7 @@ export const ProviderForm: FC<ProviderFormProps> = ({
 
 		const trimmedDisplayName = displayName.trim();
 		const trimmedBaseURL = baseURLValue.trim();
+		const effectiveHeaders = buildEffectiveHeaders();
 
 		if (providerConfig) {
 			const currentDisplayName =
@@ -116,9 +149,17 @@ export const ProviderForm: FC<ProviderFormProps> = ({
 				...(trimmedBaseURL !== currentBaseURL && {
 					base_url: trimmedBaseURL,
 				}),
+				...(effectiveHeaders !== undefined && {
+					custom_headers: effectiveHeaders,
+				}),
 			};
 
-			if (!req.display_name && !req.api_key && !req.base_url) {
+			if (
+				!req.display_name &&
+				!req.api_key &&
+				!req.base_url &&
+				req.custom_headers === undefined
+			) {
 				return;
 			}
 
@@ -141,6 +182,10 @@ export const ProviderForm: FC<ProviderFormProps> = ({
 					display_name: trimmedDisplayName,
 				}),
 				...(trimmedBaseURL && { base_url: trimmedBaseURL }),
+				...(effectiveHeaders !== undefined &&
+					Object.keys(effectiveHeaders).length > 0 && {
+						custom_headers: effectiveHeaders,
+					}),
 			};
 
 			try {
@@ -153,6 +198,7 @@ export const ProviderForm: FC<ProviderFormProps> = ({
 		}
 
 		setApiKeyTouched(false);
+		setHeadersTouched(false);
 	};
 
 	const handleApiKeyFocus = () => {
@@ -162,6 +208,38 @@ export const ProviderForm: FC<ProviderFormProps> = ({
 			setApiKey("");
 			setApiKeyTouched(true);
 		}
+	};
+
+	// ── Custom header helpers ──────────────────────────────────
+
+	const handleHeaderFocus = (_index: number) => {
+		if (!headersTouched && hasExistingHeaders) {
+			// First interaction — clear placeholder rows and start fresh.
+			setHeaders([{ key: "", value: "" }]);
+			setHeadersTouched(true);
+			return;
+		}
+	};
+
+	const addHeader = () => {
+		setHeaders((prev) => [...prev, { key: "", value: "" }]);
+		setHeadersTouched(true);
+	};
+
+	const removeHeader = (index: number) => {
+		setHeaders((prev) => prev.filter((_, i) => i !== index));
+		setHeadersTouched(true);
+	};
+
+	const updateHeader = (
+		index: number,
+		field: "key" | "value",
+		value: string,
+	) => {
+		setHeaders((prev) =>
+			prev.map((h, i) => (i === index ? { ...h, [field]: value } : h)),
+		);
+		setHeadersTouched(true);
 	};
 
 	const isDisabled = providerConfigsUnavailable || isProviderMutationPending;
@@ -261,6 +339,66 @@ export const ProviderForm: FC<ProviderFormProps> = ({
 								onChange={(e) => setBaseURLValue(e.target.value)}
 								disabled={isDisabled}
 							/>
+						</ProviderField>
+
+						<ProviderField
+							label="Custom Headers"
+							description="Additional HTTP headers sent with every request to this provider."
+						>
+							<div className="space-y-2">
+								{headers.map((header, index) => (
+									<div key={index} className="flex items-center gap-2">
+										<Input
+											className="h-9 flex-1 text-[13px]"
+											placeholder="Header name"
+											value={header.key}
+											onFocus={() => handleHeaderFocus(index)}
+											onChange={(e) =>
+												updateHeader(index, "key", e.target.value)
+											}
+											disabled={isDisabled}
+											style={
+												header.key === CUSTOM_HEADERS_PLACEHOLDER
+													? ({ WebkitTextSecurity: "disc" } as React.CSSProperties)
+													: undefined
+											}
+										/>
+										<Input
+											className="h-9 flex-1 text-[13px]"
+											placeholder="Value"
+											value={header.value}
+											onFocus={() => handleHeaderFocus(index)}
+											onChange={(e) =>
+												updateHeader(index, "value", e.target.value)
+											}
+											disabled={isDisabled}
+											style={
+												header.value === CUSTOM_HEADERS_PLACEHOLDER
+													? ({ WebkitTextSecurity: "disc" } as React.CSSProperties)
+													: undefined
+											}
+										/>
+										<button
+											type="button"
+											onClick={() => removeHeader(index)}
+											disabled={isDisabled}
+											className="flex h-9 w-9 shrink-0 cursor-pointer items-center justify-center rounded-md border border-solid border-border bg-transparent text-content-secondary transition-colors hover:border-border-hover hover:text-content-primary disabled:cursor-not-allowed disabled:opacity-50"
+											aria-label="Remove header"
+										>
+											<TrashIcon className="h-4 w-4" />
+										</button>
+									</div>
+								))}
+								<button
+									type="button"
+									onClick={addHeader}
+									disabled={isDisabled}
+									className="inline-flex cursor-pointer items-center gap-1.5 border-0 bg-transparent p-0 text-sm text-content-secondary transition-colors hover:text-content-primary disabled:cursor-not-allowed disabled:opacity-50"
+								>
+									<PlusIcon className="h-3.5 w-3.5" />
+									Add header
+								</button>
+							</div>
 						</ProviderField>
 					</div>
 


### PR DESCRIPTION
*Disclaimer: implemented by a Coder Agent using Claude Opus 4.6*

## Summary

Adds the ability to configure custom HTTP headers per chat provider. These headers are sent with every outgoing LLM API request, enabling proxy authentication, org-id injection, and similar patterns that require custom headers.

## Changes

### Database
- New migration `000452` adds `custom_headers` (TEXT, encrypted at rest) and `custom_headers_key_id` columns to `chat_providers`.
- SQL queries updated for INSERT and UPDATE.

### Backend
- `codersdk`: `ChatProviderConfig` response gains `has_custom_headers` boolean; create/update request types gain `custom_headers` field (`map[string]string` / `*map[string]string`).
- `coderd/exp_chats.go`: Handlers marshal/unmarshal custom headers JSON and thread through to DB params.
- `chatprovider`: `ProviderAPIKeys` gains `CustomHeadersByProvider` map; `MergeProviderAPIKeys` merges configured headers; `ModelFromConfig` merges provider-level custom headers with caller extra headers (caller headers like Coder identity headers take precedence).
- `enterprise/dbcrypt`: Encrypt/decrypt `custom_headers` alongside `api_key` following the existing MCP server pattern.

### Frontend
- `typesGenerated.ts` updated with new fields.
- `ProviderForm.tsx`: Dynamic key-value header editor with add/remove rows, placeholder masking for existing headers (like API key masking), dirty tracking, and submit integration for both create and update flows.
- Two new Storybook stories: `CustomHeadersCreateProvider` and `CustomHeadersExistingProvider`.

## Screenshot

The provider settings form now includes a "Custom Headers" section below the Base URL field, with an "Add header" button and inline key/value inputs with remove buttons.