### PR TITLE
chore: switch agent gone response from 502 to 404 (backport #23090)

### DIFF
--- a/coderd/coderd_test.go
+++ b/coderd/coderd_test.go
@@ -384,9 +384,9 @@ func TestCSRFExempt(t *testing.T) {
 		data, _ := io.ReadAll(resp.Body)
 		_ = resp.Body.Close()
 
-		// A StatusBadGateway means Coderd tried to proxy to the agent and failed because the agent
+		// A StatusNotFound means Coderd tried to proxy to the agent and failed because the agent
 		// was not there. This means CSRF did not block the app request, which is what we want.
-		require.Equal(t, http.StatusBadGateway, resp.StatusCode, "status code 500 is CSRF failure")
+		require.Equal(t, http.StatusNotFound, resp.StatusCode, "status code 500 is CSRF failure")
 		require.NotContains(t, string(data), "CSRF")
 	})
 }

--- a/coderd/workspaceapps/db_test.go
+++ b/coderd/workspaceapps/db_test.go
@@ -1015,7 +1015,7 @@ func Test_ResolveRequest(t *testing.T) {
 
 		w := rw.Result()
 		defer w.Body.Close()
-		require.Equal(t, http.StatusBadGateway, w.StatusCode)
+		require.Equal(t, http.StatusNotFound, w.StatusCode)
 		assertConnLogContains(t, rw, r, connLogger, workspace, agentNameUnhealthy, appNameAgentUnhealthy, database.ConnectionTypeWorkspaceApp, me.ID)
 		require.Len(t, connLogger.ConnectionLogs(), 1)
 

--- a/coderd/workspaceapps/errors.go
+++ b/coderd/workspaceapps/errors.go
@@ -77,7 +77,7 @@ func WriteWorkspaceApp500(log slog.Logger, accessURL *url.URL, rw http.ResponseW
 	})
 }
 
-// WriteWorkspaceAppOffline writes a HTML 502 error page for a workspace app. If
+// WriteWorkspaceAppOffline writes a HTML 404 error page for a workspace app. If
 // appReq is not nil, it will be used to log the request details at debug level.
 func WriteWorkspaceAppOffline(log slog.Logger, accessURL *url.URL, rw http.ResponseWriter, r *http.Request, appReq *Request, msg string) {
 	if appReq != nil {
@@ -94,7 +94,7 @@ func WriteWorkspaceAppOffline(log slog.Logger, accessURL *url.URL, rw http.Respo
 	}
 
 	site.RenderStaticErrorPage(rw, r, site.ErrorPageData{
-		Status:      http.StatusBadGateway,
+		Status:      http.StatusNotFound,
 		Title:       "Application Unavailable",
 		Description: msg,
 		Actions: []site.Action{


### PR DESCRIPTION
Backport of #23090 to `release/2.31`.

When a user creates a workspace, opens the web terminal, then the workspace stops but the web terminal remains open, the web terminal will retry the connection. Coder would issue a HTTP 502 Bad Gateway response when this occurred because coderd could not connect to the workspace agent, however this is problematic as any load balancer sitting in front of Coder sees a 502 and thinks Coder is unhealthy.

This PR changes the response to a HTTP 404 after internal discussion.

Cherry-picked from merge commit c33812a430ad6a5f1fe83256434796f90838baff.