### PR TITLE
chore: set tls.VersionTLS12 MinVersion in cli/server.go to address gosec warning

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -2331,7 +2331,8 @@ func ConfigureHTTPClient(ctx context.Context, clientCertFile, clientKeyFile stri
 			return ctx, nil, err
 		}
 
-		tlsClientConfig := &tls.Config{ //nolint:gosec
+		tlsClientConfig := &tls.Config{
+			MinVersion:   tls.VersionTLS12,
 			Certificates: certificates,
 			NextProtos:   []string{"h2", "http/1.1"},
 		}


### PR DESCRIPTION
I was investigating `//nolint` comments and this one popped up.
It raised my eyebrows enough to warrant its own PR.