### PR TITLE
fix: refine chat retry status UX

### DIFF
--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -458,7 +458,7 @@ func TestSubscribeDeliversRetryEventViaPubsubOnce(t *testing.T) {
 	expected := &codersdk.ChatStreamRetry{
 		Attempt:    1,
 		DelayMs:    (1500 * time.Millisecond).Milliseconds(),
-		Error:      "OpenAI is rate limiting requests (HTTP 429). Please try again later.",
+		Error:      "OpenAI is rate limiting requests (HTTP 429).",
 		Kind:       chaterror.KindRateLimit,
 		Provider:   "openai",
 		StatusCode: 429,
@@ -499,7 +499,7 @@ func TestSubscribePrefersStructuredErrorPayloadViaPubsub(t *testing.T) {
 	defer cancel()
 
 	classified := chaterror.ClassifiedError{
-		Message:    "OpenAI is rate limiting requests (HTTP 429). Please try again later.",
+		Message:    "OpenAI is rate limiting requests (HTTP 429).",
 		Kind:       chaterror.KindRateLimit,
 		Provider:   "openai",
 		Retryable:  true,

--- a/coderd/x/chatd/chaterror/classify.go
+++ b/coderd/x/chatd/chaterror/classify.go
@@ -178,7 +178,7 @@ func normalizeClassification(classified ClassifiedError) ClassifiedError {
 		classified.Kind = KindGeneric
 	}
 	if classified.Message == "" {
-		classified.Message = userFacingMessage(classified)
+		classified.Message = buildMessage(classified, false)
 	}
 	return classified
 }

--- a/coderd/x/chatd/chaterror/classify.go
+++ b/coderd/x/chatd/chaterror/classify.go
@@ -178,7 +178,7 @@ func normalizeClassification(classified ClassifiedError) ClassifiedError {
 		classified.Kind = KindGeneric
 	}
 	if classified.Message == "" {
-		classified.Message = buildMessage(classified, false)
+		classified.Message = terminalMessage(classified)
 	}
 	return classified
 }

--- a/coderd/x/chatd/chaterror/classify_test.go
+++ b/coderd/x/chatd/chaterror/classify_test.go
@@ -22,7 +22,7 @@ func TestClassify(t *testing.T) {
 			name: "AmbiguousOverloadKeepsProviderUnknown",
 			err:  xerrors.New("status 529 from upstream"),
 			want: chaterror.ClassifiedError{
-				Message:    "The AI provider is temporarily overloaded (HTTP 529). Please try again later.",
+				Message:    "The AI provider is temporarily overloaded (HTTP 529).",
 				Kind:       chaterror.KindOverloaded,
 				Provider:   "",
 				Retryable:  true,
@@ -33,7 +33,7 @@ func TestClassify(t *testing.T) {
 			name: "ExplicitAnthropicOverload",
 			err:  xerrors.New("anthropic overloaded_error"),
 			want: chaterror.ClassifiedError{
-				Message:    "Anthropic is temporarily overloaded. Please try again later.",
+				Message:    "Anthropic is temporarily overloaded.",
 				Kind:       chaterror.KindOverloaded,
 				Provider:   "anthropic",
 				Retryable:  true,
@@ -110,7 +110,7 @@ func TestClassify(t *testing.T) {
 			name: "ExplicitStatus429ClassifiesAsRateLimit",
 			err:  xerrors.New("status 429 from upstream"),
 			want: chaterror.ClassifiedError{
-				Message:    "The AI provider is rate limiting requests (HTTP 429). Please try again later.",
+				Message:    "The AI provider is rate limiting requests (HTTP 429).",
 				Kind:       chaterror.KindRateLimit,
 				Provider:   "",
 				Retryable:  true,
@@ -132,7 +132,7 @@ func TestClassify(t *testing.T) {
 			name: "ServiceUnavailableClassifiesAsRetryableTimeout",
 			err:  xerrors.New("service unavailable"),
 			want: chaterror.ClassifiedError{
-				Message:    "The AI provider is temporarily unavailable. Please try again later.",
+				Message:    "The AI provider is temporarily unavailable.",
 				Kind:       chaterror.KindTimeout,
 				Provider:   "",
 				Retryable:  true,
@@ -176,7 +176,7 @@ func TestClassify(t *testing.T) {
 			name: "DeadlineExceededStaysNonRetryableTimeout",
 			err:  context.DeadlineExceeded,
 			want: chaterror.ClassifiedError{
-				Message:    "The request timed out before it completed. Please try again.",
+				Message:    "The request timed out before it completed.",
 				Kind:       chaterror.KindTimeout,
 				Provider:   "",
 				Retryable:  false,
@@ -279,7 +279,7 @@ func TestClassify_TransportFailuresUseBroaderRetryMessage(t *testing.T) {
 			require.True(t, classified.Retryable)
 			require.Equal(
 				t,
-				"The AI provider is temporarily unavailable. Please try again later.",
+				"The AI provider is temporarily unavailable.",
 				classified.Message,
 			)
 		})
@@ -299,7 +299,7 @@ func TestClassify_StartupTimeoutWrappedClassificationWins(t *testing.T) {
 	)
 
 	require.Equal(t, chaterror.ClassifiedError{
-		Message:    "OpenAI did not start responding in time. Please try again.",
+		Message:    "OpenAI did not start responding in time.",
 		Kind:       chaterror.KindStartupTimeout,
 		Provider:   "openai",
 		Retryable:  true,
@@ -315,7 +315,7 @@ func TestWithProviderUsesExplicitHint(t *testing.T) {
 
 	enriched := classified.WithProvider("azure openai")
 	require.Equal(t, chaterror.ClassifiedError{
-		Message:    "Azure OpenAI is rate limiting requests (HTTP 429). Please try again later.",
+		Message:    "Azure OpenAI is rate limiting requests (HTTP 429).",
 		Kind:       chaterror.KindRateLimit,
 		Provider:   "azure",
 		Retryable:  true,
@@ -331,7 +331,7 @@ func TestWithProviderAddsProviderWhenUnknown(t *testing.T) {
 
 	enriched := classified.WithProvider("openai")
 	require.Equal(t, chaterror.ClassifiedError{
-		Message:    "OpenAI is rate limiting requests (HTTP 429). Please try again later.",
+		Message:    "OpenAI is rate limiting requests (HTTP 429).",
 		Kind:       chaterror.KindRateLimit,
 		Provider:   "openai",
 		Retryable:  true,

--- a/coderd/x/chatd/chaterror/message.go
+++ b/coderd/x/chatd/chaterror/message.go
@@ -5,73 +5,81 @@ import (
 	"strings"
 )
 
-func userFacingMessage(classified ClassifiedError) string {
+// buildMessage produces the user-facing error description for a
+// classified error. Terminal errors (forRetry=false) include HTTP
+// status codes and actionable guidance; retry messages
+// (forRetry=true) are clean factual statements suitable for display
+// alongside the retry countdown UI.
+func buildMessage(classified ClassifiedError, forRetry bool) string {
 	subject := providerSubject(classified.Provider)
 	switch classified.Kind {
 	case KindOverloaded:
-		return optionalStatusMessage(
-			subject,
-			classified.StatusCode,
-			"%s is temporarily overloaded (HTTP %d).",
-			"%s is temporarily overloaded.",
-		)
+		if !forRetry && classified.StatusCode > 0 {
+			return fmt.Sprintf(
+				"%s is temporarily overloaded (HTTP %d).",
+				subject, classified.StatusCode,
+			)
+		}
+		return fmt.Sprintf("%s is temporarily overloaded.", subject)
+
 	case KindRateLimit:
-		return optionalStatusMessage(
-			subject,
-			classified.StatusCode,
-			"%s is rate limiting requests (HTTP %d).",
-			"%s is rate limiting requests.",
-		)
+		if !forRetry && classified.StatusCode > 0 {
+			return fmt.Sprintf(
+				"%s is rate limiting requests (HTTP %d).",
+				subject, classified.StatusCode,
+			)
+		}
+		return fmt.Sprintf("%s is rate limiting requests.", subject)
+
 	case KindTimeout:
-		if classified.StatusCode > 0 {
+		if !forRetry && classified.StatusCode > 0 {
 			return fmt.Sprintf(
 				"%s is temporarily unavailable (HTTP %d).",
-				subject,
-				classified.StatusCode,
+				subject, classified.StatusCode,
 			)
 		}
-		if classified.Retryable {
-			return fmt.Sprintf("%s is temporarily unavailable.", subject)
+		if !forRetry && !classified.Retryable {
+			return "The request timed out before it completed."
 		}
-		return "The request timed out before it completed."
+		return fmt.Sprintf("%s is temporarily unavailable.", subject)
+
 	case KindStartupTimeout:
-		return fmt.Sprintf("%s did not start responding in time.", subject)
-	case KindAuth:
-		if displayName := providerDisplayName(classified.Provider); displayName != "" {
-			return fmt.Sprintf(
-				"Authentication with %s failed. Check the API key, permissions, and billing settings.",
-				displayName,
-			)
-		}
-		return "Authentication with the AI provider failed. Check the API key, permissions, and billing settings."
-	case KindConfig:
 		return fmt.Sprintf(
-			"%s rejected the model configuration. Check the selected model and provider settings.",
-			subject,
+			"%s did not start responding in time.", subject,
 		)
+
+	case KindAuth:
+		displayName := providerDisplayName(classified.Provider)
+		if displayName == "" {
+			displayName = "the AI provider"
+		}
+		base := fmt.Sprintf("Authentication with %s failed.", displayName)
+		if forRetry {
+			return base
+		}
+		return base + " Check the API key, permissions, and billing settings."
+
+	case KindConfig:
+		base := fmt.Sprintf(
+			"%s rejected the model configuration.", subject,
+		)
+		if forRetry {
+			return base
+		}
+		return base + " Check the selected model and provider settings."
+
 	default:
-		if classified.StatusCode > 0 {
+		if !forRetry && classified.StatusCode > 0 {
 			return fmt.Sprintf(
 				"%s returned an unexpected error (HTTP %d).",
-				subject,
-				classified.StatusCode,
+				subject, classified.StatusCode,
 			)
 		}
-		if classified.Retryable {
-			return fmt.Sprintf(
-				"%s returned an unexpected error.",
-				subject,
-			)
+		if !forRetry && !classified.Retryable {
+			return "The chat request failed unexpectedly."
 		}
-		return "The chat request failed unexpectedly."
+		return fmt.Sprintf("%s returned an unexpected error.", subject)
 	}
-}
-
-func optionalStatusMessage(subject string, statusCode int, withStatus string, withoutStatus string) string {
-	if statusCode > 0 {
-		return fmt.Sprintf(withStatus, subject, statusCode)
-	}
-	return fmt.Sprintf(withoutStatus, subject)
 }
 
 func providerSubject(provider string) string {

--- a/coderd/x/chatd/chaterror/message.go
+++ b/coderd/x/chatd/chaterror/message.go
@@ -5,16 +5,14 @@ import (
 	"strings"
 )
 
-// buildMessage produces the user-facing error description for a
-// classified error. Terminal errors (forRetry=false) include HTTP
-// status codes and actionable guidance; retry messages
-// (forRetry=true) are clean factual statements suitable for display
-// alongside the retry countdown UI.
-func buildMessage(classified ClassifiedError, forRetry bool) string {
+// terminalMessage produces the user-facing error description shown
+// when retries are exhausted. It includes HTTP status codes and
+// actionable remediation guidance.
+func terminalMessage(classified ClassifiedError) string {
 	subject := providerSubject(classified.Provider)
 	switch classified.Kind {
 	case KindOverloaded:
-		if !forRetry && classified.StatusCode > 0 {
+		if classified.StatusCode > 0 {
 			return fmt.Sprintf(
 				"%s is temporarily overloaded (HTTP %d).",
 				subject, classified.StatusCode,
@@ -23,7 +21,7 @@ func buildMessage(classified ClassifiedError, forRetry bool) string {
 		return fmt.Sprintf("%s is temporarily overloaded.", subject)
 
 	case KindRateLimit:
-		if !forRetry && classified.StatusCode > 0 {
+		if classified.StatusCode > 0 {
 			return fmt.Sprintf(
 				"%s is rate limiting requests (HTTP %d).",
 				subject, classified.StatusCode,
@@ -32,13 +30,13 @@ func buildMessage(classified ClassifiedError, forRetry bool) string {
 		return fmt.Sprintf("%s is rate limiting requests.", subject)
 
 	case KindTimeout:
-		if !forRetry && classified.StatusCode > 0 {
+		if classified.StatusCode > 0 {
 			return fmt.Sprintf(
 				"%s is temporarily unavailable (HTTP %d).",
 				subject, classified.StatusCode,
 			)
 		}
-		if !forRetry && !classified.Retryable {
+		if !classified.Retryable {
 			return "The request timed out before it completed."
 		}
 		return fmt.Sprintf("%s is temporarily unavailable.", subject)
@@ -53,32 +51,66 @@ func buildMessage(classified ClassifiedError, forRetry bool) string {
 		if displayName == "" {
 			displayName = "the AI provider"
 		}
-		base := fmt.Sprintf("Authentication with %s failed.", displayName)
-		if forRetry {
-			return base
-		}
-		return base + " Check the API key, permissions, and billing settings."
+		return fmt.Sprintf(
+			"Authentication with %s failed."+
+				" Check the API key, permissions, and billing settings.",
+			displayName,
+		)
 
 	case KindConfig:
-		base := fmt.Sprintf(
-			"%s rejected the model configuration.", subject,
+		return fmt.Sprintf(
+			"%s rejected the model configuration."+
+				" Check the selected model and provider settings.",
+			subject,
 		)
-		if forRetry {
-			return base
-		}
-		return base + " Check the selected model and provider settings."
 
 	default:
-		if !forRetry && classified.StatusCode > 0 {
+		if classified.StatusCode > 0 {
 			return fmt.Sprintf(
 				"%s returned an unexpected error (HTTP %d).",
 				subject, classified.StatusCode,
 			)
 		}
-		if !forRetry && !classified.Retryable {
+		if !classified.Retryable {
 			return "The chat request failed unexpectedly."
 		}
 		return fmt.Sprintf("%s returned an unexpected error.", subject)
+	}
+}
+
+// retryMessage produces a clean factual description suitable for
+// display alongside the retry countdown UI. It omits HTTP status
+// codes (surfaced separately in the payload) and remediation
+// guidance (not actionable while auto-retrying).
+func retryMessage(classified ClassifiedError) string {
+	subject := providerSubject(classified.Provider)
+	switch classified.Kind {
+	case KindOverloaded:
+		return fmt.Sprintf("%s is temporarily overloaded.", subject)
+	case KindRateLimit:
+		return fmt.Sprintf("%s is rate limiting requests.", subject)
+	case KindTimeout:
+		return fmt.Sprintf("%s is temporarily unavailable.", subject)
+	case KindStartupTimeout:
+		return fmt.Sprintf(
+			"%s did not start responding in time.", subject,
+		)
+	case KindAuth:
+		displayName := providerDisplayName(classified.Provider)
+		if displayName == "" {
+			displayName = "the AI provider"
+		}
+		return fmt.Sprintf(
+			"Authentication with %s failed.", displayName,
+		)
+	case KindConfig:
+		return fmt.Sprintf(
+			"%s rejected the model configuration.", subject,
+		)
+	default:
+		return fmt.Sprintf(
+			"%s returned an unexpected error.", subject,
+		)
 	}
 }
 

--- a/coderd/x/chatd/chaterror/message.go
+++ b/coderd/x/chatd/chaterror/message.go
@@ -12,30 +12,30 @@ func userFacingMessage(classified ClassifiedError) string {
 		return optionalStatusMessage(
 			subject,
 			classified.StatusCode,
-			"%s is temporarily overloaded (HTTP %d). Please try again later.",
-			"%s is temporarily overloaded. Please try again later.",
+			"%s is temporarily overloaded (HTTP %d).",
+			"%s is temporarily overloaded.",
 		)
 	case KindRateLimit:
 		return optionalStatusMessage(
 			subject,
 			classified.StatusCode,
-			"%s is rate limiting requests (HTTP %d). Please try again later.",
-			"%s is rate limiting requests. Please try again later.",
+			"%s is rate limiting requests (HTTP %d).",
+			"%s is rate limiting requests.",
 		)
 	case KindTimeout:
 		if classified.StatusCode > 0 {
 			return fmt.Sprintf(
-				"%s is temporarily unavailable (HTTP %d). Please try again later.",
+				"%s is temporarily unavailable (HTTP %d).",
 				subject,
 				classified.StatusCode,
 			)
 		}
 		if classified.Retryable {
-			return fmt.Sprintf("%s is temporarily unavailable. Please try again later.", subject)
+			return fmt.Sprintf("%s is temporarily unavailable.", subject)
 		}
-		return "The request timed out before it completed. Please try again."
+		return "The request timed out before it completed."
 	case KindStartupTimeout:
-		return fmt.Sprintf("%s did not start responding in time. Please try again.", subject)
+		return fmt.Sprintf("%s did not start responding in time.", subject)
 	case KindAuth:
 		if displayName := providerDisplayName(classified.Provider); displayName != "" {
 			return fmt.Sprintf(
@@ -51,24 +51,19 @@ func userFacingMessage(classified ClassifiedError) string {
 		)
 	default:
 		if classified.StatusCode > 0 {
-			suffix := " Please try again."
-			if classified.Retryable {
-				suffix = " Please try again later."
-			}
 			return fmt.Sprintf(
-				"%s returned an unexpected error (HTTP %d).%s",
+				"%s returned an unexpected error (HTTP %d).",
 				subject,
 				classified.StatusCode,
-				suffix,
 			)
 		}
 		if classified.Retryable {
 			return fmt.Sprintf(
-				"%s returned an unexpected error. Please try again later.",
+				"%s returned an unexpected error.",
 				subject,
 			)
 		}
-		return "The chat request failed unexpectedly. Please try again."
+		return "The chat request failed unexpectedly."
 	}
 }
 

--- a/coderd/x/chatd/chaterror/payload.go
+++ b/coderd/x/chatd/chaterror/payload.go
@@ -30,7 +30,7 @@ func StreamRetryPayload(
 	return &codersdk.ChatStreamRetry{
 		Attempt:    attempt,
 		DelayMs:    delay.Milliseconds(),
-		Error:      buildMessage(classified, true),
+		Error:      retryMessage(classified),
 		Kind:       classified.Kind,
 		Provider:   classified.Provider,
 		StatusCode: classified.StatusCode,

--- a/coderd/x/chatd/chaterror/payload.go
+++ b/coderd/x/chatd/chaterror/payload.go
@@ -30,7 +30,7 @@ func StreamRetryPayload(
 	return &codersdk.ChatStreamRetry{
 		Attempt:    attempt,
 		DelayMs:    delay.Milliseconds(),
-		Error:      classified.Message,
+		Error:      buildMessage(classified, true),
 		Kind:       classified.Kind,
 		Provider:   classified.Provider,
 		StatusCode: classified.StatusCode,

--- a/coderd/x/chatd/chaterror/payload_test.go
+++ b/coderd/x/chatd/chaterror/payload_test.go
@@ -20,7 +20,7 @@ func TestStreamErrorPayloadUsesNormalizedClassification(t *testing.T) {
 	payload := chaterror.StreamErrorPayload(classified)
 
 	require.Equal(t, &codersdk.ChatStreamError{
-		Message:    "Azure OpenAI is rate limiting requests (HTTP 429). Please try again later.",
+		Message:    "Azure OpenAI is rate limiting requests (HTTP 429).",
 		Kind:       chaterror.KindRateLimit,
 		Provider:   "azure",
 		Retryable:  true,

--- a/coderd/x/chatd/chaterror/payload_test.go
+++ b/coderd/x/chatd/chaterror/payload_test.go
@@ -40,7 +40,7 @@ func TestStreamRetryPayloadUsesNormalizedClassification(t *testing.T) {
 	delay := 3 * time.Second
 	startedAt := time.Now()
 	payload := chaterror.StreamRetryPayload(2, delay, chaterror.ClassifiedError{
-		Message:    "retry me",
+		Message:    "OpenAI returned an unexpected error (HTTP 503).",
 		Kind:       chaterror.KindGeneric,
 		Provider:   "openai",
 		Retryable:  true,
@@ -50,7 +50,9 @@ func TestStreamRetryPayloadUsesNormalizedClassification(t *testing.T) {
 	require.NotNil(t, payload)
 	require.Equal(t, 2, payload.Attempt)
 	require.Equal(t, delay.Milliseconds(), payload.DelayMs)
-	require.Equal(t, "retry me", payload.Error)
+	// Retry messages omit the HTTP status code; the status code is
+	// surfaced separately in the payload's StatusCode field.
+	require.Equal(t, "OpenAI returned an unexpected error.", payload.Error)
 	require.Equal(t, chaterror.KindGeneric, payload.Kind)
 	require.Equal(t, "openai", payload.Provider)
 	require.Equal(t, 503, payload.StatusCode)

--- a/coderd/x/chatd/chatloop/chatloop_test.go
+++ b/coderd/x/chatd/chatloop/chatloop_test.go
@@ -144,7 +144,7 @@ func TestRun_OnRetryEnrichesProvider(t *testing.T) {
 	require.Equal(t, 429, records[0].classified.StatusCode)
 	require.Equal(
 		t,
-		"OpenAI is rate limiting requests (HTTP 429). Please try again later.",
+		"OpenAI is rate limiting requests (HTTP 429).",
 		records[0].classified.Message,
 	)
 }
@@ -254,7 +254,7 @@ func TestRun_RetriesStartupTimeoutWhileOpeningStream(t *testing.T) {
 	require.Equal(t, "openai", retries[0].Provider)
 	require.Equal(
 		t,
-		"OpenAI did not start responding in time. Please try again.",
+		"OpenAI did not start responding in time.",
 		retries[0].Message,
 	)
 	require.ErrorIs(t, <-attemptCause, errStartupTimeout)
@@ -313,7 +313,7 @@ func TestRun_RetriesStartupTimeoutBeforeFirstPart(t *testing.T) {
 	require.Equal(t, "openai", retries[0].Provider)
 	require.Equal(
 		t,
-		"OpenAI did not start responding in time. Please try again.",
+		"OpenAI did not start responding in time.",
 		retries[0].Message,
 	)
 	require.ErrorIs(t, <-attemptCause, errStartupTimeout)
@@ -475,7 +475,7 @@ func TestRun_RetriesStartupTimeoutWhenStreamClosesSilently(t *testing.T) {
 	require.Equal(t, "openai", retries[0].Provider)
 	require.Equal(
 		t,
-		"OpenAI did not start responding in time. Please try again.",
+		"OpenAI did not start responding in time.",
 		retries[0].Message,
 	)
 	require.ErrorIs(t, <-attemptCause, errStartupTimeout)

--- a/site/src/pages/AgentsPage/AgentDetail.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.tsx
@@ -247,7 +247,7 @@ const getPersistedDetailError = ({
 	chatRecord: TypesGen.Chat | undefined;
 	cachedError: ChatDetailError | undefined;
 }): ChatDetailError | undefined => {
-	if (cachedError?.kind === "usage-limit") {
+	if (cachedError?.kind === "usage_limit") {
 		return cachedError;
 	}
 	if (chatStatus === "error") {
@@ -595,7 +595,7 @@ const AgentDetail: FC = () => {
 			isUsageLimitData(error.response.data)
 		) {
 			const reason: ChatDetailError = {
-				kind: "usage-limit",
+				kind: "usage_limit",
 				message: formatUsageLimitMessage(error.response.data),
 			};
 			store.setStreamError(reason);

--- a/site/src/pages/AgentsPage/components/AgentDetail/ChatStatusCallout.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetail/ChatStatusCallout.tsx
@@ -130,8 +130,7 @@ const StatusAlert: FC<{ status: RetryOrFailedStatus }> = ({ status }) => {
 				: "warning";
 	const hasMetadata =
 		status.phase === "retrying" ||
-		(status.phase === "failed" && status.statusCode !== undefined) ||
-		(status.phase === "failed" && status.retryable !== undefined);
+		(status.phase === "failed" && status.statusCode !== undefined);
 
 	return (
 		<Alert
@@ -173,9 +172,6 @@ const StatusAlert: FC<{ status: RetryOrFailedStatus }> = ({ status }) => {
 
 						{status.phase === "failed" && status.statusCode !== undefined && (
 							<span>HTTP {status.statusCode}</span>
-						)}
-						{status.phase === "failed" && status.retryable !== undefined && (
-							<span>{status.retryable ? "Retryable" : "Not retryable"}</span>
 						)}
 					</div>
 				)}

--- a/site/src/pages/AgentsPage/components/AgentDetail/ChatStatusCallout.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetail/ChatStatusCallout.tsx
@@ -4,7 +4,7 @@ import { Button } from "components/Button/Button";
 import { Pill } from "components/Pill/Pill";
 import { ExternalLinkIcon } from "lucide-react";
 import { type FC, useEffect, useState } from "react";
-import { getProviderStatusURL } from "./chatStatusHelpers";
+import { getKindLabel, getProviderStatusURL } from "./chatStatusHelpers";
 import type { LiveStatusModel } from "./liveStatusModel";
 
 const RESPONSE_STARTUP_GRACE_MS = 15_000;
@@ -130,7 +130,6 @@ const StatusAlert: FC<{ status: RetryOrFailedStatus }> = ({ status }) => {
 				: "warning";
 	const hasMetadata =
 		status.phase === "retrying" ||
-		status.provider !== undefined ||
 		(status.phase === "failed" && status.statusCode !== undefined) ||
 		(status.phase === "failed" && status.retryable !== undefined);
 
@@ -156,7 +155,7 @@ const StatusAlert: FC<{ status: RetryOrFailedStatus }> = ({ status }) => {
 						className="h-5 px-2.5 text-[10px] font-semibold"
 						type={pillType}
 					>
-						{status.kind}
+						{getKindLabel(status.kind)}
 					</Pill>
 				</div>
 				<AlertDescription>{status.message}</AlertDescription>
@@ -171,7 +170,7 @@ const StatusAlert: FC<{ status: RetryOrFailedStatus }> = ({ status }) => {
 						{status.phase === "retrying" && (
 							<span>Attempt {status.attempt}</span>
 						)}
-						{status.provider && <span>Provider {status.provider}</span>}
+
 						{status.phase === "failed" && status.statusCode !== undefined && (
 							<span>HTTP {status.statusCode}</span>
 						)}

--- a/site/src/pages/AgentsPage/components/AgentDetail/LiveStreamTail.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetail/LiveStreamTail.stories.tsx
@@ -93,6 +93,11 @@ export const TerminalOverloadedError: Story = {
 			canvas.getByRole("heading", { name: /service overloaded/i }),
 		).toBeVisible();
 		expect(canvas.getByText("Overloaded")).toBeVisible();
+		expect(
+			canvas.getByText(/anthropic is currently overloaded./i),
+		).toBeVisible();
+		expect(canvas.queryByText(/please try again/i)).not.toBeInTheDocument();
+		expect(canvas.queryByText(/^retryable$/i)).not.toBeInTheDocument();
 		expect(canvas.getByText(/http 529/i)).toBeVisible();
 		expect(canvas.getByRole("link", { name: /status/i })).toBeVisible();
 		expect(canvas.queryByText(/provider anthropic/i)).not.toBeInTheDocument();
@@ -120,9 +125,10 @@ export const TerminalStartupTimeoutError: Story = {
 		).toBeVisible();
 		expect(canvas.getByText("Startup timeout")).toBeVisible();
 		expect(
-			canvas.getByText(/anthropic did not start responding in time/i),
+			canvas.getByText(/anthropic did not start responding in time./i),
 		).toBeVisible();
-		expect(canvas.getByText(/retryable/i)).toBeVisible();
+		expect(canvas.queryByText(/please try again/i)).not.toBeInTheDocument();
+		expect(canvas.queryByText(/^retryable$/i)).not.toBeInTheDocument();
 		expect(
 			canvas.queryByRole("link", { name: /status/i }),
 		).not.toBeInTheDocument();

--- a/site/src/pages/AgentsPage/components/AgentDetail/LiveStreamTail.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetail/LiveStreamTail.stories.tsx
@@ -92,9 +92,41 @@ export const TerminalOverloadedError: Story = {
 		expect(
 			canvas.getByRole("heading", { name: /service overloaded/i }),
 		).toBeVisible();
-		expect(canvas.getByText("overloaded")).toBeVisible();
+		expect(canvas.getByText("Overloaded")).toBeVisible();
 		expect(canvas.getByText(/http 529/i)).toBeVisible();
 		expect(canvas.getByRole("link", { name: /status/i })).toBeVisible();
+		expect(canvas.queryByText(/provider anthropic/i)).not.toBeInTheDocument();
+	},
+};
+
+/** Terminal startup timeouts get a specific heading without provider metadata. */
+export const TerminalStartupTimeoutError: Story = {
+	args: {
+		...defaultArgs,
+		liveStatus: buildLiveStatus({
+			persistedError: {
+				kind: "startup_timeout",
+				message:
+					"Anthropic did not start responding in time. Please try again.",
+				provider: "anthropic",
+				retryable: true,
+			},
+		}),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			canvas.getByRole("heading", { name: /startup timed out/i }),
+		).toBeVisible();
+		expect(canvas.getByText("Startup timeout")).toBeVisible();
+		expect(
+			canvas.getByText(/anthropic did not start responding in time/i),
+		).toBeVisible();
+		expect(canvas.getByText(/retryable/i)).toBeVisible();
+		expect(
+			canvas.queryByRole("link", { name: /status/i }),
+		).not.toBeInTheDocument();
+		expect(canvas.queryByText(/provider anthropic/i)).not.toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/AgentDetail/LiveStreamTail.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetail/LiveStreamTail.stories.tsx
@@ -58,7 +58,7 @@ export const UsageLimitExceeded: Story = {
 		...defaultArgs,
 		liveStatus: buildLiveStatus({
 			persistedError: {
-				kind: "usage-limit",
+				kind: "usage_limit",
 				message:
 					"You've used $50.00 of your $50.00 spend limit. Your limit resets on July 1, 2025.",
 			},

--- a/site/src/pages/AgentsPage/components/AgentDetail/LiveStreamTail.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetail/LiveStreamTail.stories.tsx
@@ -80,7 +80,7 @@ export const TerminalOverloadedError: Story = {
 		liveStatus: buildLiveStatus({
 			persistedError: {
 				kind: "overloaded",
-				message: "Anthropic is currently overloaded. Please try again shortly.",
+				message: "Anthropic is currently overloaded.",
 				provider: "anthropic",
 				retryable: true,
 				statusCode: 529,
@@ -111,8 +111,7 @@ export const TerminalStartupTimeoutError: Story = {
 		liveStatus: buildLiveStatus({
 			persistedError: {
 				kind: "startup_timeout",
-				message:
-					"Anthropic did not start responding in time. Please try again.",
+				message: "Anthropic did not start responding in time.",
 				provider: "anthropic",
 				retryable: true,
 			},

--- a/site/src/pages/AgentsPage/components/AgentDetail/LiveStreamTail.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetail/LiveStreamTail.tsx
@@ -55,7 +55,7 @@ export const LiveStreamTailContent = ({
 	const shouldRenderStreamSection = shouldRenderStreamingSection(liveStatus);
 	const terminalStatus = liveStatus.phase === "failed" ? liveStatus : null;
 	const usageLimitStatus =
-		terminalStatus?.kind === "usage-limit" ? terminalStatus : null;
+		terminalStatus?.kind === "usage_limit" ? terminalStatus : null;
 	const shouldRenderEmptyState =
 		isTranscriptEmpty && liveStatus.phase === "idle";
 

--- a/site/src/pages/AgentsPage/components/AgentDetail/StreamingOutput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetail/StreamingOutput.stories.tsx
@@ -93,9 +93,7 @@ export const RetryWithVisibleReason: Story = {
 			canvas.getByRole("heading", { name: /retrying request/i }),
 		).toBeVisible();
 		expect(
-			canvas.getByText(
-				/retrying because anthropic returned an unexpected error/i,
-			),
+			canvas.getByText(/anthropic returned an unexpected error/i),
 		).toBeVisible();
 		expect(canvas.getByText("Unexpected error")).toBeVisible();
 		expect(canvas.getByText(/attempt 1/i)).toBeVisible();
@@ -125,7 +123,7 @@ export const RetryRateLimited: Story = {
 			canvas.getByRole("heading", { name: /rate limited/i }),
 		).toBeVisible();
 		expect(
-			canvas.getByText(/retrying because anthropic is rate limiting requests/i),
+			canvas.getByText(/anthropic is rate limiting requests/i),
 		).toBeVisible();
 		expect(canvas.getByText("Rate limit")).toBeVisible();
 		await waitFor(() => {
@@ -160,7 +158,7 @@ export const RetryInvalidTimestamp: Story = {
 			canvas.getByRole("heading", { name: /rate limited/i }),
 		).toBeVisible();
 		expect(
-			canvas.getByText(/retrying because anthropic is rate limiting requests/i),
+			canvas.getByText(/anthropic is rate limiting requests/i),
 		).toBeVisible();
 		expect(canvas.getByText("Rate limit")).toBeVisible();
 		expect(canvas.getByText(/attempt 3/i)).toBeVisible();
@@ -192,7 +190,7 @@ export const RetryOverloaded: Story = {
 			canvas.getByRole("heading", { name: /service overloaded/i }),
 		).toBeVisible();
 		expect(
-			canvas.getByText(/retrying because anthropic is temporarily overloaded/i),
+			canvas.getByText(/anthropic is temporarily overloaded/i),
 		).toBeVisible();
 		expect(canvas.getByText("Overloaded")).toBeVisible();
 		const statusLink = screen.getByRole("link", { name: /status/i });
@@ -221,9 +219,7 @@ export const RetryTimeout: Story = {
 			canvas.getByRole("heading", { name: /request timed out/i }),
 		).toBeVisible();
 		expect(
-			canvas.getByText(
-				/retrying because anthropic is temporarily unavailable/i,
-			),
+			canvas.getByText(/anthropic is temporarily unavailable/i),
 		).toBeVisible();
 		expect(canvas.getByText("Timeout")).toBeVisible();
 		expect(
@@ -252,9 +248,7 @@ export const RetryStartupTimeout: Story = {
 			canvas.getByRole("heading", { name: /startup timed out/i }),
 		).toBeVisible();
 		expect(
-			canvas.getByText(
-				/retrying because anthropic did not start responding in time/i,
-			),
+			canvas.getByText(/anthropic did not start responding in time/i),
 		).toBeVisible();
 		expect(canvas.getByText("Startup timeout")).toBeVisible();
 		expect(canvas.queryByText(/please try again/i)).not.toBeInTheDocument();

--- a/site/src/pages/AgentsPage/components/AgentDetail/StreamingOutput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetail/StreamingOutput.stories.tsx
@@ -71,13 +71,13 @@ export const ReconnectingAfterDisconnect: Story = {
 		await waitFor(() => {
 			expect(canvasElement.textContent).toMatch(/reconnecting in \d+s/i);
 		});
-		expect(canvas.queryByText("generic")).not.toBeInTheDocument();
+		expect(canvas.queryByText("Unexpected error")).not.toBeInTheDocument();
 		const thinkingMatches = canvas.getAllByText(/thinking\.\.\./i);
 		expect(thinkingMatches.length).toBeGreaterThanOrEqual(1);
 	},
 };
 
-/** Generic retry reasons show the mux-style retry callout. */
+/** Generic retry reasons show automatic retry copy without a manual CTA. */
 export const RetryWithVisibleReason: Story = {
 	args: {
 		streamState: null,
@@ -92,9 +92,15 @@ export const RetryWithVisibleReason: Story = {
 		expect(
 			canvas.getByRole("heading", { name: /retrying request/i }),
 		).toBeVisible();
-		expect(canvas.getByText(/transient upstream failure/i)).toBeVisible();
-		expect(canvas.getByText("generic")).toBeVisible();
+		expect(
+			canvas.getByText(
+				/retrying because anthropic returned an unexpected error/i,
+			),
+		).toBeVisible();
+		expect(canvas.getByText("Unexpected error")).toBeVisible();
 		expect(canvas.getByText(/attempt 1/i)).toBeVisible();
+		expect(canvas.queryByText(/please try again/i)).not.toBeInTheDocument();
+		expect(canvas.queryByText(/provider anthropic/i)).not.toBeInTheDocument();
 	},
 };
 
@@ -106,7 +112,7 @@ export const RetryRateLimited: Story = {
 		liveStatus: buildLiveStatus({
 			retryState: buildRetryState({
 				attempt: 3,
-				error: "Anthropic asked us to back off briefly before retrying.",
+				error: "Anthropic is rate limiting requests. Please try again later.",
 				kind: "rate_limit",
 				delayMs: 3000,
 			}),
@@ -118,13 +124,17 @@ export const RetryRateLimited: Story = {
 		expect(
 			canvas.getByRole("heading", { name: /rate limited/i }),
 		).toBeVisible();
-		expect(canvas.getByText("rate_limit")).toBeVisible();
+		expect(
+			canvas.getByText(/retrying because anthropic is rate limiting requests/i),
+		).toBeVisible();
+		expect(canvas.getByText("Rate limit")).toBeVisible();
 		await waitFor(() => {
 			expect(canvasElement.textContent).toMatch(/retrying in \d+s/i);
 		});
 		expect(
 			canvas.queryByRole("link", { name: /status/i }),
 		).not.toBeInTheDocument();
+		expect(canvas.queryByText(/provider anthropic/i)).not.toBeInTheDocument();
 	},
 };
 
@@ -136,7 +146,7 @@ export const RetryInvalidTimestamp: Story = {
 		liveStatus: buildLiveStatus({
 			retryState: buildRetryState({
 				attempt: 3,
-				error: "Anthropic asked us to back off briefly before retrying.",
+				error: "Anthropic is rate limiting requests. Please try again later.",
 				kind: "rate_limit",
 				delayMs: 3000,
 				retryingAt: "not-a-date",
@@ -149,12 +159,16 @@ export const RetryInvalidTimestamp: Story = {
 		expect(
 			canvas.getByRole("heading", { name: /rate limited/i }),
 		).toBeVisible();
-		expect(canvas.getByText("rate_limit")).toBeVisible();
+		expect(
+			canvas.getByText(/retrying because anthropic is rate limiting requests/i),
+		).toBeVisible();
+		expect(canvas.getByText("Rate limit")).toBeVisible();
 		expect(canvas.getByText(/attempt 3/i)).toBeVisible();
 		await waitFor(() => {
 			expect(canvas.queryByText(/retrying in nan/i)).not.toBeInTheDocument();
 			expect(canvas.queryByText(/retrying in \d+s/i)).not.toBeInTheDocument();
 		});
+		expect(canvas.queryByText(/provider anthropic/i)).not.toBeInTheDocument();
 	},
 };
 
@@ -167,7 +181,7 @@ export const RetryOverloaded: Story = {
 			retryState: buildRetryState({
 				kind: "overloaded",
 				provider: "anthropic",
-				error: "Anthropic is currently overloaded. Retrying your request.",
+				error: "Anthropic is temporarily overloaded. Please try again later.",
 			}),
 			isAwaitingFirstStreamChunk: true,
 		}),
@@ -177,14 +191,18 @@ export const RetryOverloaded: Story = {
 		expect(
 			canvas.getByRole("heading", { name: /service overloaded/i }),
 		).toBeVisible();
-		expect(canvas.getByText("overloaded")).toBeVisible();
+		expect(
+			canvas.getByText(/retrying because anthropic is temporarily overloaded/i),
+		).toBeVisible();
+		expect(canvas.getByText("Overloaded")).toBeVisible();
 		const statusLink = screen.getByRole("link", { name: /status/i });
 		expect(statusLink).toBeVisible();
 		expect(statusLink).toHaveAttribute("href", "https://status.anthropic.com");
+		expect(canvas.queryByText(/provider anthropic/i)).not.toBeInTheDocument();
 	},
 };
 
-/** Timeout retries render the timeout-specific heading without a status CTA. */
+/** Timeout retries render timeout-specific copy without a status CTA. */
 export const RetryTimeout: Story = {
 	args: {
 		streamState: null,
@@ -192,7 +210,7 @@ export const RetryTimeout: Story = {
 		liveStatus: buildLiveStatus({
 			retryState: buildRetryState({
 				kind: "timeout",
-				error: "The provider took too long to respond. Retrying now.",
+				error: "Anthropic is temporarily unavailable. Please try again later.",
 			}),
 			isAwaitingFirstStreamChunk: true,
 		}),
@@ -200,9 +218,47 @@ export const RetryTimeout: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		expect(
-			canvas.getByRole("heading", { name: /request time(?:out|d out)/i }),
+			canvas.getByRole("heading", { name: /request timed out/i }),
 		).toBeVisible();
-		expect(canvas.getByText("timeout")).toBeVisible();
+		expect(
+			canvas.getByText(
+				/retrying because anthropic is temporarily unavailable/i,
+			),
+		).toBeVisible();
+		expect(canvas.getByText("Timeout")).toBeVisible();
+		expect(
+			canvas.queryByRole("link", { name: /status/i }),
+		).not.toBeInTheDocument();
+		expect(canvas.queryByText(/provider anthropic/i)).not.toBeInTheDocument();
+	},
+};
+
+/** Startup timeouts explain the first-token delay before retrying. */
+export const RetryStartupTimeout: Story = {
+	args: {
+		streamState: null,
+		streamTools: [],
+		liveStatus: buildLiveStatus({
+			retryState: buildRetryState({
+				kind: "startup_timeout",
+				error: "Anthropic did not start responding in time. Please try again.",
+			}),
+			isAwaitingFirstStreamChunk: true,
+		}),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			canvas.getByRole("heading", { name: /startup timed out/i }),
+		).toBeVisible();
+		expect(
+			canvas.getByText(
+				/retrying because anthropic did not start responding in time/i,
+			),
+		).toBeVisible();
+		expect(canvas.getByText("Startup timeout")).toBeVisible();
+		expect(canvas.queryByText(/please try again/i)).not.toBeInTheDocument();
+		expect(canvas.queryByText(/provider anthropic/i)).not.toBeInTheDocument();
 		expect(
 			canvas.queryByRole("link", { name: /status/i }),
 		).not.toBeInTheDocument();

--- a/site/src/pages/AgentsPage/components/AgentDetail/StreamingOutput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetail/StreamingOutput.stories.tsx
@@ -112,7 +112,7 @@ export const RetryRateLimited: Story = {
 		liveStatus: buildLiveStatus({
 			retryState: buildRetryState({
 				attempt: 3,
-				error: "Anthropic is rate limiting requests. Please try again later.",
+				error: "Anthropic is rate limiting requests.",
 				kind: "rate_limit",
 				delayMs: 3000,
 			}),
@@ -146,7 +146,7 @@ export const RetryInvalidTimestamp: Story = {
 		liveStatus: buildLiveStatus({
 			retryState: buildRetryState({
 				attempt: 3,
-				error: "Anthropic is rate limiting requests. Please try again later.",
+				error: "Anthropic is rate limiting requests.",
 				kind: "rate_limit",
 				delayMs: 3000,
 				retryingAt: "not-a-date",
@@ -181,7 +181,7 @@ export const RetryOverloaded: Story = {
 			retryState: buildRetryState({
 				kind: "overloaded",
 				provider: "anthropic",
-				error: "Anthropic is temporarily overloaded. Please try again later.",
+				error: "Anthropic is temporarily overloaded.",
 			}),
 			isAwaitingFirstStreamChunk: true,
 		}),
@@ -210,7 +210,7 @@ export const RetryTimeout: Story = {
 		liveStatus: buildLiveStatus({
 			retryState: buildRetryState({
 				kind: "timeout",
-				error: "Anthropic is temporarily unavailable. Please try again later.",
+				error: "Anthropic is temporarily unavailable.",
 			}),
 			isAwaitingFirstStreamChunk: true,
 		}),
@@ -241,7 +241,7 @@ export const RetryStartupTimeout: Story = {
 		liveStatus: buildLiveStatus({
 			retryState: buildRetryState({
 				kind: "startup_timeout",
-				error: "Anthropic did not start responding in time. Please try again.",
+				error: "Anthropic did not start responding in time.",
 			}),
 			isAwaitingFirstStreamChunk: true,
 		}),

--- a/site/src/pages/AgentsPage/components/AgentDetail/chatStatusHelpers.ts
+++ b/site/src/pages/AgentsPage/components/AgentDetail/chatStatusHelpers.ts
@@ -1,9 +1,62 @@
+import type { ChatProviderFailureKind } from "../../utils/usageLimitMessage";
+
+const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
+	anthropic: "Anthropic",
+	azure: "Azure OpenAI",
+	bedrock: "AWS Bedrock",
+	google: "Google",
+	openai: "OpenAI",
+	"openai-compat": "OpenAI Compatible",
+	openrouter: "OpenRouter",
+	vercel: "Vercel AI Gateway",
+};
+
 const PROVIDER_STATUS_URLS: Record<string, string> = {
 	anthropic: "https://status.anthropic.com",
 };
 
+const normalizeProvider = (provider?: string): string | undefined => {
+	const normalized = provider?.trim().toLowerCase();
+	if (!normalized) {
+		return undefined;
+	}
+
+	switch (normalized) {
+		case "azure openai":
+		case "azure-openai":
+			return "azure";
+		case "openai compat":
+		case "openai compatible":
+		case "openai_compat":
+			return "openai-compat";
+		default:
+			return normalized;
+	}
+};
+
+const humanizeKind = (kind: string): string => {
+	const words = kind
+		.trim()
+		.split(/[_\-\s]+/)
+		.filter(Boolean);
+	if (words.length === 0) {
+		return "Unexpected error";
+	}
+	return words
+		.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+		.join(" ");
+};
+
+const getProviderDisplayName = (provider?: string): string | undefined => {
+	const normalized = normalizeProvider(provider);
+	return normalized ? PROVIDER_DISPLAY_NAMES[normalized] : undefined;
+};
+
+const getRetryProviderSubject = (provider?: string): string =>
+	getProviderDisplayName(provider) ?? "the AI provider";
+
 export const getErrorTitle = (
-	kind: string,
+	kind: ChatProviderFailureKind | (string & {}),
 	mode: "retry" | "error",
 ): string => {
 	switch (kind) {
@@ -12,18 +65,68 @@ export const getErrorTitle = (
 		case "rate_limit":
 			return "Rate limited";
 		case "timeout":
-			return "Request timeout";
+			return "Request timed out";
+		case "startup_timeout":
+			return "Startup timed out";
+		case "auth":
+			return "Authentication failed";
+		case "config":
+			return "Configuration error";
 		default:
 			return mode === "retry" ? "Retrying request" : "Request failed";
 	}
 };
 
+export const getKindLabel = (
+	kind: ChatProviderFailureKind | (string & {}),
+): string => {
+	switch (kind) {
+		case "generic":
+			return "Unexpected error";
+		case "overloaded":
+			return "Overloaded";
+		case "rate_limit":
+			return "Rate limit";
+		case "timeout":
+			return "Timeout";
+		case "startup_timeout":
+			return "Startup timeout";
+		case "auth":
+			return "Authentication";
+		case "config":
+			return "Configuration";
+		default:
+			return humanizeKind(kind);
+	}
+};
+
+export const getRetryMessage = (
+	kind: ChatProviderFailureKind | (string & {}),
+	provider?: string,
+): string => {
+	const subject = getRetryProviderSubject(provider);
+
+	switch (kind) {
+		case "overloaded":
+			return `Retrying because ${subject} is temporarily overloaded.`;
+		case "rate_limit":
+			return `Retrying because ${subject} is rate limiting requests.`;
+		case "timeout":
+			return `Retrying because ${subject} is temporarily unavailable.`;
+		case "startup_timeout":
+			return `Retrying because ${subject} did not start responding in time.`;
+		default:
+			return `Retrying because ${subject} returned an unexpected error.`;
+	}
+};
+
 export const getProviderStatusURL = (
-	kind: string,
+	kind: ChatProviderFailureKind | (string & {}),
 	provider?: string,
 ): string | undefined => {
-	if (!provider || kind !== "overloaded") {
+	if (kind !== "overloaded") {
 		return undefined;
 	}
-	return PROVIDER_STATUS_URLS[provider.toLowerCase()];
+	const normalized = normalizeProvider(provider);
+	return normalized ? PROVIDER_STATUS_URLS[normalized] : undefined;
 };

--- a/site/src/pages/AgentsPage/components/AgentDetail/chatStatusHelpers.ts
+++ b/site/src/pages/AgentsPage/components/AgentDetail/chatStatusHelpers.ts
@@ -52,8 +52,20 @@ const getProviderDisplayName = (provider?: string): string | undefined => {
 	return normalized ? PROVIDER_DISPLAY_NAMES[normalized] : undefined;
 };
 
+const TERMINAL_RETRY_CTA_SUFFIX =
+	/\s+Please try again(?: (?:later|shortly))?\.\s*$/i;
+
 const getRetryProviderSubject = (provider?: string): string =>
 	getProviderDisplayName(provider) ?? "the AI provider";
+
+export const getFailedMessage = (message: string): string => {
+	const trimmed = message.trim();
+	if (!trimmed) {
+		return "Chat processing failed.";
+	}
+
+	return trimmed.replace(TERMINAL_RETRY_CTA_SUFFIX, ".");
+};
 
 export const getErrorTitle = (
 	kind: ChatProviderFailureKind | (string & {}),

--- a/site/src/pages/AgentsPage/components/AgentDetail/chatStatusHelpers.ts
+++ b/site/src/pages/AgentsPage/components/AgentDetail/chatStatusHelpers.ts
@@ -1,16 +1,5 @@
 import type { ChatProviderFailureKind } from "../../utils/usageLimitMessage";
 
-const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
-	anthropic: "Anthropic",
-	azure: "Azure OpenAI",
-	bedrock: "AWS Bedrock",
-	google: "Google",
-	openai: "OpenAI",
-	"openai-compat": "OpenAI Compatible",
-	openrouter: "OpenRouter",
-	vercel: "Vercel AI Gateway",
-};
-
 const PROVIDER_STATUS_URLS: Record<string, string> = {
 	anthropic: "https://status.anthropic.com",
 };
@@ -46,14 +35,6 @@ const humanizeKind = (kind: string): string => {
 		.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
 		.join(" ");
 };
-
-const getProviderDisplayName = (provider?: string): string | undefined => {
-	const normalized = normalizeProvider(provider);
-	return normalized ? PROVIDER_DISPLAY_NAMES[normalized] : undefined;
-};
-
-const getRetryProviderSubject = (provider?: string): string =>
-	getProviderDisplayName(provider) ?? "the AI provider";
 
 export const getErrorTitle = (
 	kind: ChatProviderFailureKind | (string & {}),
@@ -97,26 +78,6 @@ export const getKindLabel = (
 			return "Configuration";
 		default:
 			return humanizeKind(kind);
-	}
-};
-
-export const getRetryMessage = (
-	kind: ChatProviderFailureKind | (string & {}),
-	provider?: string,
-): string => {
-	const subject = getRetryProviderSubject(provider);
-
-	switch (kind) {
-		case "overloaded":
-			return `Retrying because ${subject} is temporarily overloaded.`;
-		case "rate_limit":
-			return `Retrying because ${subject} is rate limiting requests.`;
-		case "timeout":
-			return `Retrying because ${subject} is temporarily unavailable.`;
-		case "startup_timeout":
-			return `Retrying because ${subject} did not start responding in time.`;
-		default:
-			return `Retrying because ${subject} returned an unexpected error.`;
 	}
 };
 

--- a/site/src/pages/AgentsPage/components/AgentDetail/chatStatusHelpers.ts
+++ b/site/src/pages/AgentsPage/components/AgentDetail/chatStatusHelpers.ts
@@ -52,20 +52,8 @@ const getProviderDisplayName = (provider?: string): string | undefined => {
 	return normalized ? PROVIDER_DISPLAY_NAMES[normalized] : undefined;
 };
 
-const TERMINAL_RETRY_CTA_SUFFIX =
-	/\s+Please try again(?: (?:later|shortly))?\.\s*$/i;
-
 const getRetryProviderSubject = (provider?: string): string =>
 	getProviderDisplayName(provider) ?? "the AI provider";
-
-export const getFailedMessage = (message: string): string => {
-	const trimmed = message.trim();
-	if (!trimmed) {
-		return "Chat processing failed.";
-	}
-
-	return trimmed.replace(TERMINAL_RETRY_CTA_SUFFIX, ".");
-};
 
 export const getErrorTitle = (
 	kind: ChatProviderFailureKind | (string & {}),

--- a/site/src/pages/AgentsPage/components/AgentDetail/liveStatusModel.test.ts
+++ b/site/src/pages/AgentsPage/components/AgentDetail/liveStatusModel.test.ts
@@ -62,7 +62,7 @@ describe("deriveLiveStatus", () => {
 		hasAccumulatedOutput: false,
 		title: "Retrying request",
 		kind: "generic",
-		message: "Retrying because Anthropic returned an unexpected error.",
+		message: "Anthropic returned an unexpected error.",
 		attempt: 2,
 		provider: "anthropic",
 		delayMs: 2000,

--- a/site/src/pages/AgentsPage/components/AgentDetail/liveStatusModel.test.ts
+++ b/site/src/pages/AgentsPage/components/AgentDetail/liveStatusModel.test.ts
@@ -84,7 +84,6 @@ describe("deriveLiveStatus", () => {
 		kind: "generic",
 		message: "Chat processing failed.",
 		provider: "anthropic",
-		retryable: false,
 		statusCode: 500,
 	};
 

--- a/site/src/pages/AgentsPage/components/AgentDetail/liveStatusModel.test.ts
+++ b/site/src/pages/AgentsPage/components/AgentDetail/liveStatusModel.test.ts
@@ -15,7 +15,7 @@ const makeStreamState = (
 
 const makeRetryState = (overrides: Partial<RetryState> = {}): RetryState => ({
 	attempt: 2,
-	error: "Anthropic returned an unexpected error. Please try again later.",
+	error: "Anthropic returned an unexpected error.",
 	kind: "generic",
 	provider: "anthropic",
 	delayMs: 2000,

--- a/site/src/pages/AgentsPage/components/AgentDetail/liveStatusModel.test.ts
+++ b/site/src/pages/AgentsPage/components/AgentDetail/liveStatusModel.test.ts
@@ -15,7 +15,7 @@ const makeStreamState = (
 
 const makeRetryState = (overrides: Partial<RetryState> = {}): RetryState => ({
 	attempt: 2,
-	error: "Retrying request shortly.",
+	error: "Anthropic returned an unexpected error. Please try again later.",
 	kind: "generic",
 	provider: "anthropic",
 	delayMs: 2000,
@@ -62,7 +62,7 @@ describe("deriveLiveStatus", () => {
 		hasAccumulatedOutput: false,
 		title: "Retrying request",
 		kind: "generic",
-		message: "Retrying request shortly.",
+		message: "Retrying because Anthropic returned an unexpected error.",
 		attempt: 2,
 		provider: "anthropic",
 		delayMs: 2000,

--- a/site/src/pages/AgentsPage/components/AgentDetail/liveStatusModel.ts
+++ b/site/src/pages/AgentsPage/components/AgentDetail/liveStatusModel.ts
@@ -1,5 +1,5 @@
 import type { ChatDetailError } from "../../utils/usageLimitMessage";
-import { getErrorTitle, getRetryMessage } from "./chatStatusHelpers";
+import { getErrorTitle } from "./chatStatusHelpers";
 import type { ReconnectState, RetryState, StreamState } from "./types";
 
 type LiveStatusBase = {
@@ -71,7 +71,7 @@ const toRetryingLiveStatus = (
 	hasAccumulatedOutput: options.hasAccumulatedOutput ?? false,
 	title: getErrorTitle(retryState.kind, "retry"),
 	kind: retryState.kind,
-	message: getRetryMessage(retryState.kind, retryState.provider),
+	message: retryState.error,
 	attempt: retryState.attempt,
 	provider: retryState.provider,
 	delayMs: retryState.delayMs,

--- a/site/src/pages/AgentsPage/components/AgentDetail/liveStatusModel.ts
+++ b/site/src/pages/AgentsPage/components/AgentDetail/liveStatusModel.ts
@@ -1,5 +1,5 @@
 import type { ChatDetailError } from "../../utils/usageLimitMessage";
-import { getErrorTitle } from "./chatStatusHelpers";
+import { getErrorTitle, getRetryMessage } from "./chatStatusHelpers";
 import type { ReconnectState, RetryState, StreamState } from "./types";
 
 type LiveStatusBase = {
@@ -64,6 +64,21 @@ const toReconnectingLiveStatus = (
 	...reconnectState,
 });
 
+const toRetryingLiveStatus = (
+	retryState: RetryState,
+	options: { hasAccumulatedOutput?: boolean } = {},
+): Extract<LiveStatusModel, { phase: "retrying" }> => ({
+	phase: "retrying",
+	hasAccumulatedOutput: options.hasAccumulatedOutput ?? false,
+	title: getErrorTitle(retryState.kind, "retry"),
+	kind: retryState.kind,
+	message: getRetryMessage(retryState.kind, retryState.provider),
+	attempt: retryState.attempt,
+	provider: retryState.provider,
+	delayMs: retryState.delayMs,
+	retryingAt: retryState.retryingAt,
+});
+
 const toFailedLiveStatus = (
 	error: ChatDetailError,
 	options: { hasAccumulatedOutput?: boolean } = {},
@@ -89,17 +104,7 @@ export const deriveLiveStatus = ({
 	const hasAccumulatedOutput = getHasAccumulatedOutput(streamState);
 
 	if (retryState) {
-		return {
-			phase: "retrying",
-			hasAccumulatedOutput,
-			title: getErrorTitle(retryState.kind, "retry"),
-			kind: retryState.kind,
-			message: retryState.error,
-			attempt: retryState.attempt,
-			provider: retryState.provider,
-			delayMs: retryState.delayMs,
-			retryingAt: retryState.retryingAt,
-		};
+		return toRetryingLiveStatus(retryState, { hasAccumulatedOutput });
 	}
 
 	if (streamError) {

--- a/site/src/pages/AgentsPage/components/AgentDetail/liveStatusModel.ts
+++ b/site/src/pages/AgentsPage/components/AgentDetail/liveStatusModel.ts
@@ -1,9 +1,5 @@
 import type { ChatDetailError } from "../../utils/usageLimitMessage";
-import {
-	getErrorTitle,
-	getFailedMessage,
-	getRetryMessage,
-} from "./chatStatusHelpers";
+import { getErrorTitle, getRetryMessage } from "./chatStatusHelpers";
 import type { ReconnectState, RetryState, StreamState } from "./types";
 
 type LiveStatusBase = {
@@ -90,7 +86,7 @@ const toFailedLiveStatus = (
 	hasAccumulatedOutput: options.hasAccumulatedOutput ?? false,
 	title: getErrorTitle(error.kind, "error"),
 	kind: error.kind,
-	message: getFailedMessage(error.message),
+	message: error.message,
 	provider: error.provider,
 	statusCode: error.statusCode,
 });

--- a/site/src/pages/AgentsPage/components/AgentDetail/liveStatusModel.ts
+++ b/site/src/pages/AgentsPage/components/AgentDetail/liveStatusModel.ts
@@ -1,5 +1,9 @@
 import type { ChatDetailError } from "../../utils/usageLimitMessage";
-import { getErrorTitle, getRetryMessage } from "./chatStatusHelpers";
+import {
+	getErrorTitle,
+	getFailedMessage,
+	getRetryMessage,
+} from "./chatStatusHelpers";
 import type { ReconnectState, RetryState, StreamState } from "./types";
 
 type LiveStatusBase = {
@@ -37,7 +41,6 @@ export type LiveStatusModel =
 			kind: string;
 			message: string;
 			provider?: string;
-			retryable?: boolean;
 			statusCode?: number;
 	  } & LiveStatusBase);
 
@@ -87,9 +90,8 @@ const toFailedLiveStatus = (
 	hasAccumulatedOutput: options.hasAccumulatedOutput ?? false,
 	title: getErrorTitle(error.kind, "error"),
 	kind: error.kind,
-	message: error.message,
+	message: getFailedMessage(error.message),
 	provider: error.provider,
-	retryable: error.retryable,
 	statusCode: error.statusCode,
 });
 

--- a/site/src/pages/AgentsPage/components/AgentDetail/storyFixtures.ts
+++ b/site/src/pages/AgentsPage/components/AgentDetail/storyFixtures.ts
@@ -73,8 +73,7 @@ export const buildRetryState = (
 	overrides: Partial<RetryState> = {},
 ): RetryState => ({
 	attempt: 1,
-	error:
-		"Anthropic is retrying your request after a transient upstream failure.",
+	error: "Anthropic returned an unexpected error. Please try again later.",
 	kind: "generic",
 	provider: "anthropic",
 	delayMs: 2000,

--- a/site/src/pages/AgentsPage/components/AgentDetail/storyFixtures.ts
+++ b/site/src/pages/AgentsPage/components/AgentDetail/storyFixtures.ts
@@ -73,7 +73,7 @@ export const buildRetryState = (
 	overrides: Partial<RetryState> = {},
 ): RetryState => ({
 	attempt: 1,
-	error: "Anthropic returned an unexpected error. Please try again later.",
+	error: "Anthropic returned an unexpected error.",
 	kind: "generic",
 	provider: "anthropic",
 	delayMs: 2000,

--- a/site/src/pages/AgentsPage/components/AgentDetail/types.ts
+++ b/site/src/pages/AgentsPage/components/AgentDetail/types.ts
@@ -1,5 +1,6 @@
 import type { ReconnectSchedule } from "utils/reconnectingWebSocket";
 import type * as TypesGen from "#/api/typesGenerated";
+import type { ChatProviderFailureKind } from "../../utils/usageLimitMessage";
 
 export type ParsedToolCall = {
 	id: string;
@@ -66,7 +67,7 @@ export type ReconnectState = ReconnectSchedule;
 export type RetryState = {
 	attempt: number;
 	error: string;
-	kind: string;
+	kind: ChatProviderFailureKind | (string & {});
 	provider?: string;
 	delayMs?: number;
 	retryingAt?: string;

--- a/site/src/pages/AgentsPage/components/AgentDetailView.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetailView.stories.tsx
@@ -213,6 +213,18 @@ export const WithError: Story = {
 			}}
 		/>
 	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			canvas.getByRole("heading", { name: /service overloaded/i }),
+		).toBeVisible();
+		expect(
+			canvas.getByText(/anthropic is currently overloaded\./i),
+		).toBeVisible();
+		expect(canvas.queryByText(/please try again/i)).not.toBeInTheDocument();
+		expect(canvas.queryByText(/^retryable$/i)).not.toBeInTheDocument();
+		expect(canvas.getByText(/http 529/i)).toBeVisible();
+	},
 };
 
 /** Input area appears disabled when `isInputDisabled` is true. */

--- a/site/src/pages/AgentsPage/components/AgentDetailView.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetailView.stories.tsx
@@ -206,7 +206,7 @@ export const WithError: Story = {
 		<StoryAgentDetailView
 			persistedError={{
 				kind: "overloaded",
-				message: "Anthropic is currently overloaded. Please try again shortly.",
+				message: "Anthropic is currently overloaded.",
 				provider: "anthropic",
 				retryable: true,
 				statusCode: 529,

--- a/site/src/pages/AgentsPage/utils/usageLimitMessage.test.ts
+++ b/site/src/pages/AgentsPage/utils/usageLimitMessage.test.ts
@@ -104,10 +104,10 @@ describe("isUsageLimitData", () => {
 	it("accepts a fully populated valid payload", () => {
 		const error: ChatDetailError = {
 			message: "Your usage limit has been reached.",
-			kind: "usage-limit",
+			kind: "usage_limit",
 		};
 
-		expect(error.kind).toBe("usage-limit");
+		expect(error.kind).toBe("usage_limit");
 		expect(
 			isUsageLimitData({
 				spent_micros: 900_000,

--- a/site/src/pages/AgentsPage/utils/usageLimitMessage.ts
+++ b/site/src/pages/AgentsPage/utils/usageLimitMessage.ts
@@ -11,20 +11,27 @@ interface UsageLimitData {
 }
 
 /**
+ * Known provider failure kinds surfaced in chat retry/error events.
+ */
+export type ChatProviderFailureKind =
+	| "generic"
+	| "overloaded"
+	| "rate_limit"
+	| "timeout"
+	| "startup_timeout"
+	| "auth"
+	| "config";
+
+/**
  * Typed classification for errors surfaced in the agent detail view.
  * - "usage-limit": the user hit a spending cap (409 + valid usage data).
  * - other kinds come from normalized stream/provider failures such as
- *   "generic", "overloaded", "rate_limit", or "timeout".
+ *   "generic", "overloaded", "rate_limit", "timeout",
+ *   "startup_timeout", "auth", and "config".
  */
 export type ChatDetailError = {
 	message: string;
-	kind:
-		| "usage-limit"
-		| "generic"
-		| "overloaded"
-		| "rate_limit"
-		| "timeout"
-		| (string & {});
+	kind: "usage-limit" | ChatProviderFailureKind | (string & {});
 	provider?: string;
 	retryable?: boolean;
 	statusCode?: number;

--- a/site/src/pages/AgentsPage/utils/usageLimitMessage.ts
+++ b/site/src/pages/AgentsPage/utils/usageLimitMessage.ts
@@ -20,18 +20,19 @@ export type ChatProviderFailureKind =
 	| "timeout"
 	| "startup_timeout"
 	| "auth"
-	| "config";
+	| "config"
+	| "usage_limit";
 
 /**
  * Typed classification for errors surfaced in the agent detail view.
- * - "usage-limit": the user hit a spending cap (409 + valid usage data).
+ * - "usage_limit": the user hit a spending cap (409 + valid usage data).
  * - other kinds come from normalized stream/provider failures such as
  *   "generic", "overloaded", "rate_limit", "timeout",
  *   "startup_timeout", "auth", and "config".
  */
 export type ChatDetailError = {
 	message: string;
-	kind: "usage-limit" | ChatProviderFailureKind | (string & {});
+	kind: ChatProviderFailureKind | (string & {});
 	provider?: string;
 	retryable?: boolean;
 	statusCode?: number;


### PR DESCRIPTION
Follow-up to #23282. The retry and terminal error callouts had a few UX oddities:

- Auto-retrying states reused backend error text that said "Please try again" even while the UI was already retrying on behalf of the user.
- Terminal error states also said "Please try again" with no action the user could take.
- `startup_timeout` had no specific title or retry copy — it fell through to the generic "Retrying request" heading.
- The kind pill showed raw enum values like `startup_timeout` and `rate_limit`.
- Terminal error metadata showed a "Retryable" / "Not retryable" label that does not help users.
- A separate "Provider anthropic" metadata row duplicated information already present in the message body.
- The `usage-limit` error kind used a hyphen while every backend kind uses underscores.

Changes:

**Backend (`chaterror/message.go`)**

- Split message generation into `terminalMessage()` and `retryMessage()`, replacing the old `userFacingMessage()`.
- Terminal messages include HTTP status codes and actionable guidance (e.g. "Check the API key, permissions, and billing settings.").
- Retry messages are clean factual statements without status codes or remediation, suitable for the retry countdown UI (e.g. "Anthropic is temporarily overloaded.").
- Removed "Please try again" / "Please try again later" from all paths.
- `StreamRetryPayload` calls `retryMessage()` instead of forwarding `classified.Message`.

**Frontend**

- Removed the parallel frontend message-generation system: `getRetryMessage()`, `getProviderDisplayName()`, `getRetryProviderSubject()`, and the `PROVIDER_DISPLAY_NAMES` map are all deleted from `chatStatusHelpers.ts`.
- `liveStatusModel.ts` passes `retryState.error` through directly — the backend owns the copy.
- Added specific title and retry copy for `startup_timeout`, and extended the title mapping to cover `auth` and `config`.
- Kind pills now show humanized labels ("Startup timeout", "Rate limit", etc.) instead of raw enum strings.
- Removed the redundant "Provider anthropic" metadata row.
- Removed the terminal "Retryable" / "Not retryable" badge.
- Normalized `"usage-limit"` → `"usage_limit"` and added it to `ChatProviderFailureKind` so all error kinds follow the same underscore convention and live in one enum.

Refs #23282.