### PR TITLE
fix(site/e2e): fix flaky updateTemplate test expecting transient URL

### DIFF
--- a/site/e2e/helpers.ts
+++ b/site/e2e/helpers.ts
@@ -1171,7 +1171,7 @@ export const updateTemplateSettings = async (
 	await page.getByRole("button", { name: /save/i }).click();
 
 	const name = templateSettingValues.name ?? templateName;
-	await expectUrl(page).toHavePathNameEndingWith(`/${name}`);
+	await expectUrl(page).toHavePathNameEndingWith(`/${name}/docs`);
 };
 
 export const updateWorkspace = async (


### PR DESCRIPTION
_PR generated by Mux but reviewed by a human_

## Problem

The e2e test `template update with new name redirects on successful submit` is flaky.

After saving template settings, the app navigates to `/templates/<name>`, which immediately redirects to `/templates/<name>/docs` via the router's index route (`<Navigate to="docs" replace />`). The assertion used `expect.poll()` with `toHavePathNameEndingWith(`/${name}`)`, which matches only the **transient intermediate URL** — it only exists while `TemplateLayout`'s async data fetch is pending. Once the fetch resolves and the `<Outlet />` renders, the index route fires the `/docs` redirect and the URL no longer matches.

## Why it's flaky (not deterministic)

The flakiness depends on whether the template query cache is warm:

- **Cache miss → PASSES**: The mutation's `onSuccess` handler invalidates the query cache. If `TemplateLayout` needs to re-fetch, it shows a `<Loader />`, which delays rendering the `<Outlet />` that contains the `<Navigate to="docs">`. This gives `expect.poll()` time to see the transient `/new-name` URL → **pass**.
- **Cache hit → FAILS**: If the template data is still in the query client, `TemplateLayout` renders immediately and the `<Navigate to="docs" replace />` fires nearly instantly. By the time the first poll runs, the URL is already `/new-name/docs` → **fail**.

## Fix

Assert the **final stable URL** (`/${name}/docs`) instead of the transient one.

This is safe because `expect.poll()` is retry-based: it keeps sampling until a match is found (or timeout). Seeing the transient `/new-name` URL just causes harmless retries — once the redirect completes and the URL settles on `/new-name/docs`, the poll matches and the test passes.

| Poll | URL | Ends with `/new-name/docs`? | Action |
|---|---|---|---|
| 1st | `/templates/new-name` | No | Retry |
| 2nd | `/templates/new-name` | No | Retry |
| 3rd | `/templates/new-name/docs` | Yes | **Pass** ✅ |

Closes https://github.com/coder/internal/issues/1403