### PR TITLE
fix(site): use restartWorkspace instead of startWorkspace in schedule dialog

### DIFF
--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceSchedulePage.test.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceSchedulePage.test.tsx
@@ -1,4 +1,8 @@
-import { MockUserOwner, MockWorkspace } from "testHelpers/entities";
+import {
+	MockUserOwner,
+	MockWorkspace,
+	MockWorkspaceBuild,
+} from "testHelpers/entities";
 import { renderWithWorkspaceSettingsLayout } from "testHelpers/renderHelpers";
 import { server } from "testHelpers/server";
 import { screen } from "@testing-library/react";
@@ -299,6 +303,41 @@ describe("WorkspaceSchedulePage", () => {
 
 			const dialog = await screen.findByText("Restart workspace?");
 			expect(dialog).toBeInTheDocument();
+		});
+
+		it("doesn't show if workspace is stopped", async () => {
+			server.use(
+				http.get("/api/v2/users/:userId/workspace/:workspaceName", () => {
+					return HttpResponse.json({
+						...MockWorkspace,
+						latest_build: { ...MockWorkspaceBuild, status: "stopped" },
+					});
+				}),
+			);
+			renderWithWorkspaceSettingsLayout(<WorkspaceSchedulePage />, {
+				route: `/@${MockUserOwner.username}/${MockWorkspace.name}/schedule`,
+				path: "/:username/:workspace/schedule",
+				extraRoutes: [
+					{ path: "/:username/:workspace", element: <div>Workspace</div> },
+				],
+			});
+			const user = userEvent.setup();
+			const autostopToggle = await screen.findByLabelText(
+				FormLanguage.stopSwitch,
+			);
+			await user.click(autostopToggle);
+			const submitButton = await screen.findByRole("button", {
+				name: /save/i,
+			});
+			await user.click(submitButton);
+
+			const notification = await screen.findByText(
+				`Schedule for workspace "Test-Workspace" updated successfully.`,
+			);
+			expect(notification).toBeInTheDocument();
+
+			const dialog = screen.queryByText("Restart workspace?");
+			expect(dialog).not.toBeInTheDocument();
 		});
 
 		it("doesn't show if autostop is not changed", async () => {

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceSchedulePage.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSchedulePage/WorkspaceSchedulePage.tsx
@@ -66,9 +66,8 @@ const WorkspaceSchedulePage: FC = () => {
 	const isLoading = !template;
 
 	const [isConfirmingApply, setIsConfirmingApply] = useState(false);
-	const { mutate: updateWorkspace } = useMutation({
-		mutationFn: () =>
-			API.startWorkspace(workspace.id, workspace.template_active_version_id),
+	const { mutate: restartWorkspace } = useMutation({
+		mutationFn: () => API.restartWorkspace({ workspace }),
 	});
 
 	return (
@@ -139,7 +138,8 @@ const WorkspaceSchedulePage: FC = () => {
 
 							if (
 								data.autostopChanged &&
-								getAutostop(workspace).autostopEnabled
+								getAutostop(workspace).autostopEnabled &&
+								workspace.latest_build.status === "running"
 							) {
 								setIsConfirmingApply(true);
 							}
@@ -155,7 +155,7 @@ const WorkspaceSchedulePage: FC = () => {
 				cancelText="Apply later"
 				hideCancel={false}
 				onConfirm={() => {
-					updateWorkspace();
+					restartWorkspace();
 					navigate(`/@${username}/${workspaceName}`);
 				}}
 				onClose={() => {


### PR DESCRIPTION
The "Restart" button in the workspace schedule confirmation dialog was calling `API.startWorkspace()`, which triggers a start build on an already-running workspace. This can put the workspace in an unhealthy state. Changed it to call `API.restartWorkspace()` so the button does what it says.

<img width="2518" height="1568" alt="image" src="https://github.com/user-attachments/assets/c5893b2c-697e-4ac6-995a-0daea3709d1b" />


Also added a `workspace.latest_build.status === "running"` guard so the restart dialog only appears when the workspace is actually running. For stopped workspaces, the new schedule settings apply on next start — no restart prompt needed.

Added a test to verify the dialog does not appear for stopped workspaces.

Note: `restartWorkspace` currently restarts on the same template version rather than upgrading to the active version when the template requires it. This will be addressed in #23659.

> 🤖 This PR was created with the help of Coder Agents, and has been reviewed by my human.  🧑💻