### PR TITLE
fix(site): use Anthropic icon instead of Claude icon for provider

### DIFF
--- a/site/src/pages/AIBridgePage/RequestLogsPage/icons/AIBridgeProviderIcon.tsx
+++ b/site/src/pages/AIBridgePage/RequestLogsPage/icons/AIBridgeProviderIcon.tsx
@@ -22,7 +22,7 @@ export const AIBridgeProviderIcon = ({
 		case "anthropic":
 			return (
 				<ExternalImage
-					src="/icon/claude.svg"
+					src="/icon/anthropic.svg"
 					className={cn(iconClassName, className)}
 				/>
 			);

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ProviderIcon.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ProviderIcon.tsx
@@ -7,7 +7,7 @@ import { normalizeProvider } from "./helpers";
 
 const providerIconMap: Record<string, string> = {
 	openai: "/icon/openai.svg",
-	anthropic: "/icon/claude.svg",
+	anthropic: "/icon/anthropic.svg",
 	azure: "/icon/azure.svg",
 	bedrock: "/icon/aws.svg",
 	google: "/icon/google.svg",


### PR DESCRIPTION
## Summary

The Anthropic provider icon in dropdowns was incorrectly showing the Claude model icon (`/icon/claude.svg`) instead of the Anthropic company icon (`/icon/anthropic.svg`).

## Changes

- `AIBridgeProviderIcon.tsx`: Fixed `"anthropic"` case to use `/icon/anthropic.svg`
- `ProviderIcon.tsx`: Fixed `anthropic` entry in `providerIconMap` to use `/icon/anthropic.svg`

> 🤖 This PR was created with the help of Coder Agents, and needs a human review.  🧑💻