### PR TITLE
fix: populate all chat fields in pubsub events

### DIFF
--- a/coderd/database/db2sdk/db2sdk.go
+++ b/coderd/database/db2sdk/db2sdk.go
@@ -1235,7 +1235,9 @@ func nullInt64Ptr(v sql.NullInt64) *int64 {
 	return &value
 }
 
-// Chat converts a database.Chat to a codersdk.Chat.
+// Chat converts a database.Chat to a codersdk.Chat. It coalesces
+// nil slices and maps to empty values for JSON serialization and
+// derives RootChatID from the parent chain when not explicitly set.
 func Chat(c database.Chat, diffStatus *database.ChatDiffStatus) codersdk.Chat {
 	mcpServerIDs := c.MCPServerIDs
 	if mcpServerIDs == nil {
@@ -1292,7 +1294,8 @@ func Chat(c database.Chat, diffStatus *database.ChatDiffStatus) codersdk.Chat {
 }
 
 // Chats converts a slice of database.Chat to codersdk.Chat, looking
-// up diff statuses from the provided map.
+// up diff statuses from the provided map. When diffStatusesByChatID
+// is non-nil, chats without an entry receive an empty DiffStatus.
 func Chats(chats []database.Chat, diffStatusesByChatID map[uuid.UUID]database.ChatDiffStatus) []codersdk.Chat {
 	result := make([]codersdk.Chat, len(chats))
 	for i, c := range chats {

--- a/coderd/database/db2sdk/db2sdk.go
+++ b/coderd/database/db2sdk/db2sdk.go
@@ -1235,6 +1235,82 @@ func nullInt64Ptr(v sql.NullInt64) *int64 {
 	return &value
 }
 
+// Chat converts a database.Chat to a codersdk.Chat.
+func Chat(c database.Chat, diffStatus *database.ChatDiffStatus) codersdk.Chat {
+	mcpServerIDs := c.MCPServerIDs
+	if mcpServerIDs == nil {
+		mcpServerIDs = []uuid.UUID{}
+	}
+	labels := map[string]string(c.Labels)
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	chat := codersdk.Chat{
+		ID:                c.ID,
+		OwnerID:           c.OwnerID,
+		LastModelConfigID: c.LastModelConfigID,
+		Title:             c.Title,
+		Status:            codersdk.ChatStatus(c.Status),
+		Archived:          c.Archived,
+		CreatedAt:         c.CreatedAt,
+		UpdatedAt:         c.UpdatedAt,
+		MCPServerIDs:      mcpServerIDs,
+		Labels:            labels,
+	}
+	if c.LastError.Valid {
+		chat.LastError = &c.LastError.String
+	}
+	if c.ParentChatID.Valid {
+		parentChatID := c.ParentChatID.UUID
+		chat.ParentChatID = &parentChatID
+	}
+	switch {
+	case c.RootChatID.Valid:
+		rootChatID := c.RootChatID.UUID
+		chat.RootChatID = &rootChatID
+	case c.ParentChatID.Valid:
+		rootChatID := c.ParentChatID.UUID
+		chat.RootChatID = &rootChatID
+	default:
+		rootChatID := c.ID
+		chat.RootChatID = &rootChatID
+	}
+	if c.WorkspaceID.Valid {
+		chat.WorkspaceID = &c.WorkspaceID.UUID
+	}
+	if c.BuildID.Valid {
+		chat.BuildID = &c.BuildID.UUID
+	}
+	if c.AgentID.Valid {
+		chat.AgentID = &c.AgentID.UUID
+	}
+	if diffStatus != nil {
+		convertedDiffStatus := ChatDiffStatus(c.ID, diffStatus)
+		chat.DiffStatus = &convertedDiffStatus
+	}
+	return chat
+}
+
+// Chats converts a slice of database.Chat to codersdk.Chat, looking
+// up diff statuses from the provided map.
+func Chats(chats []database.Chat, diffStatusesByChatID map[uuid.UUID]database.ChatDiffStatus) []codersdk.Chat {
+	result := make([]codersdk.Chat, len(chats))
+	for i, c := range chats {
+		diffStatus, ok := diffStatusesByChatID[c.ID]
+		if ok {
+			result[i] = Chat(c, &diffStatus)
+			continue
+		}
+
+		result[i] = Chat(c, nil)
+		if diffStatusesByChatID != nil {
+			emptyDiffStatus := ChatDiffStatus(c.ID, nil)
+			result[i].DiffStatus = &emptyDiffStatus
+		}
+	}
+	return result
+}
+
 // ChatDiffStatus converts a database.ChatDiffStatus to a
 // codersdk.ChatDiffStatus. When status is nil an empty value
 // containing only the chatID is returned.

--- a/coderd/database/db2sdk/db2sdk_test.go
+++ b/coderd/database/db2sdk/db2sdk_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
@@ -511,6 +512,54 @@ func TestChatQueuedMessage_ParsesUserContentParts(t *testing.T) {
 	require.Len(t, queued.Content, 1)
 	require.Equal(t, codersdk.ChatMessagePartTypeText, queued.Content[0].Type)
 	require.Equal(t, "queued text", queued.Content[0].Text)
+}
+
+func TestChat_AllFieldsPopulated(t *testing.T) {
+	t.Parallel()
+
+	// Every field of database.Chat is set to a non-zero value so
+	// that the reflection check below catches any field that
+	// db2sdk.Chat forgets to populate. When someone adds a new
+	// field to codersdk.Chat, this test will fail until the
+	// converter is updated.
+	now := dbtime.Now()
+	input := database.Chat{
+		ID:                uuid.New(),
+		OwnerID:           uuid.New(),
+		WorkspaceID:       uuid.NullUUID{UUID: uuid.New(), Valid: true},
+		BuildID:           uuid.NullUUID{UUID: uuid.New(), Valid: true},
+		AgentID:           uuid.NullUUID{UUID: uuid.New(), Valid: true},
+		ParentChatID:      uuid.NullUUID{UUID: uuid.New(), Valid: true},
+		RootChatID:        uuid.NullUUID{UUID: uuid.New(), Valid: true},
+		LastModelConfigID: uuid.New(),
+		Title:             "all-fields-test",
+		Status:            database.ChatStatusRunning,
+		LastError:         sql.NullString{String: "boom", Valid: true},
+		CreatedAt:         now,
+		UpdatedAt:         now,
+		Archived:          true,
+		MCPServerIDs:      []uuid.UUID{uuid.New()},
+		Labels:            database.StringMap{"env": "prod"},
+	}
+	// Only ChatID is needed here. This test checks that
+	// Chat.DiffStatus is non-nil, not that every DiffStatus
+	// field is populated — that would be a separate test for
+	// the ChatDiffStatus converter.
+	diffStatus := &database.ChatDiffStatus{
+		ChatID: input.ID,
+	}
+
+	got := db2sdk.Chat(input, diffStatus)
+
+	v := reflect.ValueOf(got)
+	typ := v.Type()
+	for i := range typ.NumField() {
+		field := typ.Field(i)
+		require.False(t, v.Field(i).IsZero(),
+			"codersdk.Chat field %q is zero-valued — db2sdk.Chat may not be populating it",
+			field.Name,
+		)
+	}
 }
 
 func TestChatQueuedMessage_MalformedContent(t *testing.T) {

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -272,7 +272,7 @@ func (api *API) listChats(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	httpapi.Write(ctx, rw, http.StatusOK, convertChats(chats, diffStatusesByChatID))
+	httpapi.Write(ctx, rw, http.StatusOK, db2sdk.Chats(chats, diffStatusesByChatID))
 }
 
 func (api *API) getChatDiffStatusesByChatID(
@@ -417,7 +417,7 @@ func (api *API) postChats(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	httpapi.Write(ctx, rw, http.StatusCreated, convertChat(chat, nil))
+	httpapi.Write(ctx, rw, http.StatusCreated, db2sdk.Chat(chat, nil))
 }
 
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
@@ -1142,7 +1142,7 @@ func (api *API) getChat(rw http.ResponseWriter, r *http.Request) {
 			slog.Error(err),
 		)
 	}
-	httpapi.Write(ctx, rw, http.StatusOK, convertChat(chat, diffStatus))
+	httpapi.Write(ctx, rw, http.StatusOK, db2sdk.Chat(chat, diffStatus))
 }
 
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
@@ -1972,7 +1972,7 @@ func (api *API) interruptChat(rw http.ResponseWriter, r *http.Request) {
 		chat = updatedChat
 	}
 
-	httpapi.Write(ctx, rw, http.StatusOK, convertChat(chat, nil))
+	httpapi.Write(ctx, rw, http.StatusOK, db2sdk.Chat(chat, nil))
 }
 
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
@@ -3583,78 +3583,6 @@ func truncateRunes(value string, maxLen int) string {
 	return string(runes[:maxLen])
 }
 
-func convertChat(c database.Chat, diffStatus *database.ChatDiffStatus) codersdk.Chat {
-	mcpServerIDs := c.MCPServerIDs
-	if mcpServerIDs == nil {
-		mcpServerIDs = []uuid.UUID{}
-	}
-	labels := map[string]string(c.Labels)
-	if labels == nil {
-		labels = map[string]string{}
-	}
-	chat := codersdk.Chat{
-		ID:                c.ID,
-		OwnerID:           c.OwnerID,
-		LastModelConfigID: c.LastModelConfigID,
-		Title:             c.Title,
-		Status:            codersdk.ChatStatus(c.Status),
-		Archived:          c.Archived,
-		CreatedAt:         c.CreatedAt,
-		UpdatedAt:         c.UpdatedAt,
-		MCPServerIDs:      mcpServerIDs,
-		Labels:            labels,
-	}
-	if c.LastError.Valid {
-		chat.LastError = &c.LastError.String
-	}
-	if c.ParentChatID.Valid {
-		parentChatID := c.ParentChatID.UUID
-		chat.ParentChatID = &parentChatID
-	}
-	switch {
-	case c.RootChatID.Valid:
-		rootChatID := c.RootChatID.UUID
-		chat.RootChatID = &rootChatID
-	case c.ParentChatID.Valid:
-		rootChatID := c.ParentChatID.UUID
-		chat.RootChatID = &rootChatID
-	default:
-		rootChatID := c.ID
-		chat.RootChatID = &rootChatID
-	}
-	if c.WorkspaceID.Valid {
-		chat.WorkspaceID = &c.WorkspaceID.UUID
-	}
-	if c.BuildID.Valid {
-		chat.BuildID = &c.BuildID.UUID
-	}
-	if c.AgentID.Valid {
-		chat.AgentID = &c.AgentID.UUID
-	}
-	if diffStatus != nil {
-		convertedDiffStatus := db2sdk.ChatDiffStatus(c.ID, diffStatus)
-		chat.DiffStatus = &convertedDiffStatus
-	}
-	return chat
-}
-
-func convertChats(chats []database.Chat, diffStatusesByChatID map[uuid.UUID]database.ChatDiffStatus) []codersdk.Chat {
-	result := make([]codersdk.Chat, len(chats))
-	for i, c := range chats {
-		diffStatus, ok := diffStatusesByChatID[c.ID]
-		if ok {
-			result[i] = convertChat(c, &diffStatus)
-			continue
-		}
-
-		result[i] = convertChat(c, nil)
-		if diffStatusesByChatID != nil {
-			emptyDiffStatus := db2sdk.ChatDiffStatus(c.ID, nil)
-			result[i].DiffStatus = &emptyDiffStatus
-		}
-	}
-	return result
-}
 
 func convertChatCostModelBreakdown(model database.GetChatCostPerModelRow) codersdk.ChatCostModelBreakdown {
 	displayName := strings.TrimSpace(model.DisplayName)

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -3583,7 +3583,6 @@ func truncateRunes(value string, maxLen int) string {
 	return string(runes[:maxLen])
 }
 
-
 func convertChatCostModelBreakdown(model database.GetChatCostPerModelRow) codersdk.ChatCostModelBreakdown {
 	displayName := strings.TrimSpace(model.DisplayName)
 	if displayName == "" {

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -743,6 +743,77 @@ func TestWatchChats(t *testing.T) {
 		}
 	})
 
+	t.Run("CreatedEventIncludesAllChatFields", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newChatClient(t)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
+		modelConfig := createChatModelConfig(t, client)
+
+		conn, err := client.Dial(ctx, "/api/experimental/chats/watch", nil)
+		require.NoError(t, err)
+		defer conn.Close(websocket.StatusNormalClosure, "done")
+
+		type watchEvent struct {
+			Type codersdk.ServerSentEventType `json:"type"`
+			Data json.RawMessage              `json:"data,omitempty"`
+		}
+
+		// Skip the initial ping.
+		var event watchEvent
+		err = wsjson.Read(ctx, conn, &event)
+		require.NoError(t, err)
+		require.Equal(t, codersdk.ServerSentEventTypePing, event.Type)
+		require.True(t, len(event.Data) == 0 || string(event.Data) == "null")
+
+		createdChat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
+			Content: []codersdk.ChatInputPart{
+				{
+					Type: codersdk.ChatInputPartTypeText,
+					Text: "watch route fields completeness test",
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		for {
+			var update watchEvent
+			err = wsjson.Read(ctx, conn, &update)
+			require.NoError(t, err)
+
+			if update.Type == codersdk.ServerSentEventTypePing {
+				continue
+			}
+			require.Equal(t, codersdk.ServerSentEventTypeData, update.Type)
+
+			var payload coderdpubsub.ChatEvent
+			err = json.Unmarshal(update.Data, &payload)
+			require.NoError(t, err)
+			if payload.Kind == coderdpubsub.ChatEventKindCreated &&
+				payload.Chat.ID == createdChat.ID {
+				// The pubsub event must carry all chat fields, not
+				// just the subset used for routing. A partial Chat
+				// causes the frontend sidebar to lose the model name.
+				require.Equal(t, modelConfig.ID, payload.Chat.LastModelConfigID,
+					"LastModelConfigID must match the model config used to create the chat")
+				require.NotNil(t, payload.Chat.MCPServerIDs,
+					"MCPServerIDs must not be nil")
+				require.NotNil(t, payload.Chat.Labels,
+					"Labels must not be nil")
+				require.False(t, payload.Chat.Archived,
+					"Archived must be false for a new chat")
+				require.NotEmpty(t, payload.Chat.Title,
+					"Title must not be empty")
+				require.NotEmpty(t, payload.Chat.Status,
+					"Status must not be empty")
+				require.NotNil(t, payload.Chat.RootChatID,
+					"RootChatID must not be nil for a root chat")
+				break
+			}
+		}
+	})
+
 	t.Run("DiffStatusChangeIncludesDiffStatus", func(t *testing.T) {
 		t.Parallel()
 

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -744,86 +744,87 @@ func TestWatchChats(t *testing.T) {
 		}
 	})
 
-		t.Run("CreatedEventIncludesAllChatFields", func(t *testing.T) {
-			t.Parallel()
+	t.Run("CreatedEventIncludesAllChatFields", func(t *testing.T) {
+		t.Parallel()
 
-			ctx := testutil.Context(t, testutil.WaitLong)
-			client := newChatClient(t)
-			_ = coderdtest.CreateFirstUser(t, client.Client)
-			modelConfig := createChatModelConfig(t, client)
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newChatClient(t)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
+		modelConfig := createChatModelConfig(t, client)
 
-			conn, err := client.Dial(ctx, "/api/experimental/chats/watch", nil)
-			require.NoError(t, err)
-			defer conn.Close(websocket.StatusNormalClosure, "done")
+		conn, err := client.Dial(ctx, "/api/experimental/chats/watch", nil)
+		require.NoError(t, err)
+		defer conn.Close(websocket.StatusNormalClosure, "done")
 
-			type watchEvent struct {
-				Type codersdk.ServerSentEventType `json:"type"`
-				Data json.RawMessage              `json:"data,omitempty"`
-			}
+		type watchEvent struct {
+			Type codersdk.ServerSentEventType `json:"type"`
+			Data json.RawMessage              `json:"data,omitempty"`
+		}
 
-			// Skip the initial ping.
-			var event watchEvent
-			err = wsjson.Read(ctx, conn, &event)
-			require.NoError(t, err)
-			require.Equal(t, codersdk.ServerSentEventTypePing, event.Type)
-			require.True(t, len(event.Data) == 0 || string(event.Data) == "null")
+		// Skip the initial ping.
+		var event watchEvent
+		err = wsjson.Read(ctx, conn, &event)
+		require.NoError(t, err)
+		require.Equal(t, codersdk.ServerSentEventTypePing, event.Type)
+		require.True(t, len(event.Data) == 0 || string(event.Data) == "null")
 
-			createdChat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
-				Content: []codersdk.ChatInputPart{
-					{
-						Type: codersdk.ChatInputPartTypeText,
-						Text: "watch route fields completeness test",
-					},
+		createdChat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
+			Content: []codersdk.ChatInputPart{
+				{
+					Type: codersdk.ChatInputPartTypeText,
+					Text: "watch route fields completeness test",
 				},
-			})
-			require.NoError(t, err)
+			},
+		})
+		require.NoError(t, err)
 
-			// The pubsub event must carry all chat fields, not
-			// just the subset used for routing. A partial Chat
-			// causes the frontend sidebar to lose the model name.
-			rootChatID := createdChat.ID
-				want := codersdk.Chat{
-					ID:                createdChat.ID,
-					OwnerID:           createdChat.OwnerID,
-					LastModelConfigID: modelConfig.ID,
-					Title:             createdChat.Title,
-					Status:            codersdk.ChatStatusPending,
-					RootChatID:        &rootChatID,
-					Archived:          false,
-					MCPServerIDs:      []uuid.UUID{},
-					Labels:            map[string]string{},
-				}
-			var got codersdk.Chat
-			testutil.Eventually(ctx, t, func(_ context.Context) bool {
-				var update watchEvent
-				if readErr := wsjson.Read(ctx, conn, &update); readErr != nil {
-					return false
-				}
-				if update.Type != codersdk.ServerSentEventTypeData {
-					return false
-				}
-				var payload coderdpubsub.ChatEvent
-				if unmarshalErr := json.Unmarshal(update.Data, &payload); unmarshalErr != nil {
-					return false
-				}
-				if payload.Kind == coderdpubsub.ChatEventKindCreated &&
-					payload.Chat.ID == createdChat.ID {
-					got = payload.Chat
-					return true
-				}
+		// The pubsub event must carry all chat fields, not
+		// just the subset used for routing. A partial Chat
+		// causes the frontend sidebar to lose the model name.
+		rootChatID := createdChat.ID
+		want := codersdk.Chat{
+			ID:                createdChat.ID,
+			OwnerID:           createdChat.OwnerID,
+			LastModelConfigID: modelConfig.ID,
+			Title:             createdChat.Title,
+			Status:            codersdk.ChatStatusPending,
+			RootChatID:        &rootChatID,
+			Archived:          false,
+			MCPServerIDs:      []uuid.UUID{},
+			Labels:            map[string]string{},
+		}
+		var got codersdk.Chat
+		testutil.Eventually(ctx, t, func(_ context.Context) bool {
+			var update watchEvent
+			if readErr := wsjson.Read(ctx, conn, &update); readErr != nil {
 				return false
-			}, testutil.IntervalFast, "expected a created event for chat %s", createdChat.ID)
+			}
+			if update.Type != codersdk.ServerSentEventTypeData {
+				return false
+			}
+			var payload coderdpubsub.ChatEvent
+			if unmarshalErr := json.Unmarshal(update.Data, &payload); unmarshalErr != nil {
+				return false
+			}
+			if payload.Kind == coderdpubsub.ChatEventKindCreated &&
+				payload.Chat.ID == createdChat.ID {
+				got = payload.Chat
+				return true
+			}
+			return false
+		}, testutil.IntervalFast, "expected a created event for chat %s", createdChat.ID)
 
-				// Compare the fields we care about, ignoring
-				// server-assigned timestamps.
-				got.CreatedAt = want.CreatedAt
-				got.UpdatedAt = want.UpdatedAt
-				if diff := cmp.Diff(want, got); diff != "" {
-					t.Fatalf("created event chat mismatch (-want +got):\n%s", diff)
-				}
-			})
+		// Compare the fields we care about, ignoring
+		// server-assigned timestamps.
+		got.CreatedAt = want.CreatedAt
+		got.UpdatedAt = want.UpdatedAt
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Fatalf("created event chat mismatch (-want +got):\n%s", diff)
+		}
+	})
 
-		t.Run("DiffStatusChangeIncludesDiffStatus", func(t *testing.T) {		t.Parallel()
+	t.Run("DiffStatusChangeIncludesDiffStatus", func(t *testing.T) {
+		t.Parallel()
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		rawClient, _, api := coderdtest.NewWithAPI(t, &coderdtest.Options{

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
@@ -743,77 +744,85 @@ func TestWatchChats(t *testing.T) {
 		}
 	})
 
-	t.Run("CreatedEventIncludesAllChatFields", func(t *testing.T) {
-		t.Parallel()
+		t.Run("CreatedEventIncludesAllChatFields", func(t *testing.T) {
+			t.Parallel()
 
-		ctx := testutil.Context(t, testutil.WaitLong)
-		client := newChatClient(t)
-		_ = coderdtest.CreateFirstUser(t, client.Client)
-		modelConfig := createChatModelConfig(t, client)
+			ctx := testutil.Context(t, testutil.WaitLong)
+			client := newChatClient(t)
+			_ = coderdtest.CreateFirstUser(t, client.Client)
+			modelConfig := createChatModelConfig(t, client)
 
-		conn, err := client.Dial(ctx, "/api/experimental/chats/watch", nil)
-		require.NoError(t, err)
-		defer conn.Close(websocket.StatusNormalClosure, "done")
+			conn, err := client.Dial(ctx, "/api/experimental/chats/watch", nil)
+			require.NoError(t, err)
+			defer conn.Close(websocket.StatusNormalClosure, "done")
 
-		type watchEvent struct {
-			Type codersdk.ServerSentEventType `json:"type"`
-			Data json.RawMessage              `json:"data,omitempty"`
-		}
+			type watchEvent struct {
+				Type codersdk.ServerSentEventType `json:"type"`
+				Data json.RawMessage              `json:"data,omitempty"`
+			}
 
-		// Skip the initial ping.
-		var event watchEvent
-		err = wsjson.Read(ctx, conn, &event)
-		require.NoError(t, err)
-		require.Equal(t, codersdk.ServerSentEventTypePing, event.Type)
-		require.True(t, len(event.Data) == 0 || string(event.Data) == "null")
+			// Skip the initial ping.
+			var event watchEvent
+			err = wsjson.Read(ctx, conn, &event)
+			require.NoError(t, err)
+			require.Equal(t, codersdk.ServerSentEventTypePing, event.Type)
+			require.True(t, len(event.Data) == 0 || string(event.Data) == "null")
 
-		createdChat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
-			Content: []codersdk.ChatInputPart{
-				{
-					Type: codersdk.ChatInputPartTypeText,
-					Text: "watch route fields completeness test",
+			createdChat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
+				Content: []codersdk.ChatInputPart{
+					{
+						Type: codersdk.ChatInputPartTypeText,
+						Text: "watch route fields completeness test",
+					},
 				},
-			},
+			})
+			require.NoError(t, err)
+
+			// The pubsub event must carry all chat fields, not
+			// just the subset used for routing. A partial Chat
+			// causes the frontend sidebar to lose the model name.
+			rootChatID := createdChat.ID
+			want := codersdk.Chat{
+				ID:                createdChat.ID,
+				OwnerID:           createdChat.OwnerID,
+				LastModelConfigID: modelConfig.ID,
+				Title:             createdChat.Title,
+				RootChatID:        &rootChatID,
+				Archived:          false,
+				MCPServerIDs:      []uuid.UUID{},
+				Labels:            map[string]string{},
+			}
+
+			var got codersdk.Chat
+			testutil.Eventually(ctx, t, func(_ context.Context) bool {
+				var update watchEvent
+				if readErr := wsjson.Read(ctx, conn, &update); readErr != nil {
+					return false
+				}
+				if update.Type != codersdk.ServerSentEventTypeData {
+					return false
+				}
+				var payload coderdpubsub.ChatEvent
+				if unmarshalErr := json.Unmarshal(update.Data, &payload); unmarshalErr != nil {
+					return false
+				}
+				if payload.Kind == coderdpubsub.ChatEventKindCreated &&
+					payload.Chat.ID == createdChat.ID {
+					got = payload.Chat
+					return true
+				}
+				return false
+			}, testutil.IntervalFast, "expected a created event for chat %s", createdChat.ID)
+
+			// Compare the fields we care about, ignoring
+			// server-assigned timestamps and status.
+			got.CreatedAt = want.CreatedAt
+			got.UpdatedAt = want.UpdatedAt
+			got.Status = want.Status
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Fatalf("created event chat mismatch (-want +got):\n%s", diff)
+			}
 		})
-		require.NoError(t, err)
-
-		for {
-			var update watchEvent
-			err = wsjson.Read(ctx, conn, &update)
-			require.NoError(t, err)
-
-			if update.Type == codersdk.ServerSentEventTypePing {
-				continue
-			}
-			require.Equal(t, codersdk.ServerSentEventTypeData, update.Type)
-
-			var payload coderdpubsub.ChatEvent
-			err = json.Unmarshal(update.Data, &payload)
-			require.NoError(t, err)
-			if payload.Kind == coderdpubsub.ChatEventKindCreated &&
-				payload.Chat.ID == createdChat.ID {
-				// The pubsub event must carry all chat fields, not
-				// just the subset used for routing. A partial Chat
-				// causes the frontend sidebar to lose the model name.
-				require.Equal(t, modelConfig.ID, payload.Chat.LastModelConfigID,
-					"LastModelConfigID must match the model config used to create the chat")
-				require.NotNil(t, payload.Chat.MCPServerIDs,
-					"MCPServerIDs must not be nil")
-				require.NotNil(t, payload.Chat.Labels,
-					"Labels must not be nil")
-				require.False(t, payload.Chat.Archived,
-					"Archived must be false for a new chat")
-				require.NotEmpty(t, payload.Chat.Title,
-					"Title must not be empty")
-				require.NotEmpty(t, payload.Chat.Status,
-					"Status must not be empty")
-				require.NotNil(t, payload.Chat.RootChatID,
-					"RootChatID must not be nil for a root chat")
-				break
-			}
-		}
-	})
-
 	t.Run("DiffStatusChangeIncludesDiffStatus", func(t *testing.T) {
 		t.Parallel()
 

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
@@ -747,6 +746,13 @@ func TestWatchChats(t *testing.T) {
 	t.Run("CreatedEventIncludesAllChatFields", func(t *testing.T) {
 		t.Parallel()
 
+		// This test verifies that the pubsub "created" event
+		// carries a fully-populated codersdk.Chat. Exhaustive
+		// field-level coverage of the converter is handled by
+		// TestChat_AllFieldsPopulated (db2sdk) and
+		// TestChat_JSONRoundTrip (codersdk). This integration
+		// test only checks that key fields survive the full
+		// API → pubsub → websocket pipeline.
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client := newChatClient(t)
 		_ = coderdtest.CreateFirstUser(t, client.Client)
@@ -778,21 +784,6 @@ func TestWatchChats(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		// The pubsub event must carry all chat fields, not
-		// just the subset used for routing. A partial Chat
-		// causes the frontend sidebar to lose the model name.
-		rootChatID := createdChat.ID
-		want := codersdk.Chat{
-			ID:                createdChat.ID,
-			OwnerID:           createdChat.OwnerID,
-			LastModelConfigID: modelConfig.ID,
-			Title:             createdChat.Title,
-			Status:            codersdk.ChatStatusPending,
-			RootChatID:        &rootChatID,
-			Archived:          false,
-			MCPServerIDs:      []uuid.UUID{},
-			Labels:            map[string]string{},
-		}
 		var got codersdk.Chat
 		testutil.Eventually(ctx, t, func(_ context.Context) bool {
 			var update watchEvent
@@ -814,13 +805,15 @@ func TestWatchChats(t *testing.T) {
 			return false
 		}, testutil.IntervalFast, "expected a created event for chat %s", createdChat.ID)
 
-		// Compare the fields we care about, ignoring
-		// server-assigned timestamps.
-		got.CreatedAt = want.CreatedAt
-		got.UpdatedAt = want.UpdatedAt
-		if diff := cmp.Diff(want, got); diff != "" {
-			t.Fatalf("created event chat mismatch (-want +got):\n%s", diff)
-		}
+		require.Equal(t, createdChat.ID, got.ID)
+		require.Equal(t, createdChat.OwnerID, got.OwnerID)
+		require.Equal(t, modelConfig.ID, got.LastModelConfigID)
+		require.Equal(t, createdChat.Title, got.Title)
+		require.Equal(t, codersdk.ChatStatusPending, got.Status)
+		require.NotNil(t, got.RootChatID)
+		require.Equal(t, createdChat.ID, *got.RootChatID)
+		require.NotZero(t, got.CreatedAt)
+		require.NotZero(t, got.UpdatedAt)
 	})
 
 	t.Run("DiffStatusChangeIncludesDiffStatus", func(t *testing.T) {

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -782,17 +782,17 @@ func TestWatchChats(t *testing.T) {
 			// just the subset used for routing. A partial Chat
 			// causes the frontend sidebar to lose the model name.
 			rootChatID := createdChat.ID
-			want := codersdk.Chat{
-				ID:                createdChat.ID,
-				OwnerID:           createdChat.OwnerID,
-				LastModelConfigID: modelConfig.ID,
-				Title:             createdChat.Title,
-				RootChatID:        &rootChatID,
-				Archived:          false,
-				MCPServerIDs:      []uuid.UUID{},
-				Labels:            map[string]string{},
-			}
-
+				want := codersdk.Chat{
+					ID:                createdChat.ID,
+					OwnerID:           createdChat.OwnerID,
+					LastModelConfigID: modelConfig.ID,
+					Title:             createdChat.Title,
+					Status:            codersdk.ChatStatusPending,
+					RootChatID:        &rootChatID,
+					Archived:          false,
+					MCPServerIDs:      []uuid.UUID{},
+					Labels:            map[string]string{},
+				}
 			var got codersdk.Chat
 			testutil.Eventually(ctx, t, func(_ context.Context) bool {
 				var update watchEvent
@@ -814,17 +814,16 @@ func TestWatchChats(t *testing.T) {
 				return false
 			}, testutil.IntervalFast, "expected a created event for chat %s", createdChat.ID)
 
-			// Compare the fields we care about, ignoring
-			// server-assigned timestamps and status.
-			got.CreatedAt = want.CreatedAt
-			got.UpdatedAt = want.UpdatedAt
-			got.Status = want.Status
-			if diff := cmp.Diff(want, got); diff != "" {
-				t.Fatalf("created event chat mismatch (-want +got):\n%s", diff)
-			}
-		})
-	t.Run("DiffStatusChangeIncludesDiffStatus", func(t *testing.T) {
-		t.Parallel()
+				// Compare the fields we care about, ignoring
+				// server-assigned timestamps.
+				got.CreatedAt = want.CreatedAt
+				got.UpdatedAt = want.UpdatedAt
+				if diff := cmp.Diff(want, got); diff != "" {
+					t.Fatalf("created event chat mismatch (-want +got):\n%s", diff)
+				}
+			})
+
+		t.Run("DiffStatusChangeIncludesDiffStatus", func(t *testing.T) {		t.Parallel()
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		rawClient, _, api := coderdtest.NewWithAPI(t, &coderdtest.Options{

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -2479,7 +2479,7 @@ func (p *Server) publishChatPubsubEvent(chat database.Chat, kind coderdpubsub.Ch
 	if p.pubsub == nil {
 		return
 	}
-	sdkChat := db2sdk.Chat(chat, nil)
+	sdkChat := db2sdk.Chat(chat, nil) // we have diffStatus already converted
 	if diffStatus != nil {
 		sdkChat.DiffStatus = diffStatus
 	}

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -2479,13 +2479,28 @@ func (p *Server) publishChatPubsubEvent(chat database.Chat, kind coderdpubsub.Ch
 	if p.pubsub == nil {
 		return
 	}
+	mcpServerIDs := chat.MCPServerIDs
+	if mcpServerIDs == nil {
+		mcpServerIDs = []uuid.UUID{}
+	}
+	labels := map[string]string(chat.Labels)
+	if labels == nil {
+		labels = map[string]string{}
+	}
 	sdkChat := codersdk.Chat{
-		ID:        chat.ID,
-		OwnerID:   chat.OwnerID,
-		Title:     chat.Title,
-		Status:    codersdk.ChatStatus(chat.Status),
-		CreatedAt: chat.CreatedAt,
-		UpdatedAt: chat.UpdatedAt,
+		ID:                chat.ID,
+		OwnerID:           chat.OwnerID,
+		LastModelConfigID: chat.LastModelConfigID,
+		Title:             chat.Title,
+		Status:            codersdk.ChatStatus(chat.Status),
+		Archived:          chat.Archived,
+		CreatedAt:         chat.CreatedAt,
+		UpdatedAt:         chat.UpdatedAt,
+		MCPServerIDs:      mcpServerIDs,
+		Labels:            labels,
+	}
+	if chat.LastError.Valid {
+		sdkChat.LastError = &chat.LastError.String
 	}
 	if chat.ParentChatID.Valid {
 		parentChatID := chat.ParentChatID.UUID
@@ -2500,6 +2515,12 @@ func (p *Server) publishChatPubsubEvent(chat database.Chat, kind coderdpubsub.Ch
 	}
 	if chat.WorkspaceID.Valid {
 		sdkChat.WorkspaceID = &chat.WorkspaceID.UUID
+	}
+	if chat.BuildID.Valid {
+		sdkChat.BuildID = &chat.BuildID.UUID
+	}
+	if chat.AgentID.Valid {
+		sdkChat.AgentID = &chat.AgentID.UUID
 	}
 	if diffStatus != nil {
 		sdkChat.DiffStatus = diffStatus

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -2506,10 +2506,14 @@ func (p *Server) publishChatPubsubEvent(chat database.Chat, kind coderdpubsub.Ch
 		parentChatID := chat.ParentChatID.UUID
 		sdkChat.ParentChatID = &parentChatID
 	}
-	if chat.RootChatID.Valid {
+	switch {
+	case chat.RootChatID.Valid:
 		rootChatID := chat.RootChatID.UUID
 		sdkChat.RootChatID = &rootChatID
-	} else if !chat.ParentChatID.Valid {
+	case chat.ParentChatID.Valid:
+		rootChatID := chat.ParentChatID.UUID
+		sdkChat.RootChatID = &rootChatID
+	default:
 		rootChatID := chat.ID
 		sdkChat.RootChatID = &rootChatID
 	}

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -2479,53 +2479,7 @@ func (p *Server) publishChatPubsubEvent(chat database.Chat, kind coderdpubsub.Ch
 	if p.pubsub == nil {
 		return
 	}
-	mcpServerIDs := chat.MCPServerIDs
-	if mcpServerIDs == nil {
-		mcpServerIDs = []uuid.UUID{}
-	}
-	labels := map[string]string(chat.Labels)
-	if labels == nil {
-		labels = map[string]string{}
-	}
-	sdkChat := codersdk.Chat{
-		ID:                chat.ID,
-		OwnerID:           chat.OwnerID,
-		LastModelConfigID: chat.LastModelConfigID,
-		Title:             chat.Title,
-		Status:            codersdk.ChatStatus(chat.Status),
-		Archived:          chat.Archived,
-		CreatedAt:         chat.CreatedAt,
-		UpdatedAt:         chat.UpdatedAt,
-		MCPServerIDs:      mcpServerIDs,
-		Labels:            labels,
-	}
-	if chat.LastError.Valid {
-		sdkChat.LastError = &chat.LastError.String
-	}
-	if chat.ParentChatID.Valid {
-		parentChatID := chat.ParentChatID.UUID
-		sdkChat.ParentChatID = &parentChatID
-	}
-	switch {
-	case chat.RootChatID.Valid:
-		rootChatID := chat.RootChatID.UUID
-		sdkChat.RootChatID = &rootChatID
-	case chat.ParentChatID.Valid:
-		rootChatID := chat.ParentChatID.UUID
-		sdkChat.RootChatID = &rootChatID
-	default:
-		rootChatID := chat.ID
-		sdkChat.RootChatID = &rootChatID
-	}
-	if chat.WorkspaceID.Valid {
-		sdkChat.WorkspaceID = &chat.WorkspaceID.UUID
-	}
-	if chat.BuildID.Valid {
-		sdkChat.BuildID = &chat.BuildID.UUID
-	}
-	if chat.AgentID.Valid {
-		sdkChat.AgentID = &chat.AgentID.UUID
-	}
+	sdkChat := db2sdk.Chat(chat, nil)
 	if diffStatus != nil {
 		sdkChat.DiffStatus = diffStatus
 	}

--- a/codersdk/chats_test.go
+++ b/codersdk/chats_test.go
@@ -387,6 +387,84 @@ func TestChatCostSummary_JSONRoundTrip(t *testing.T) {
 	require.Equal(t, original.TotalCostMicros, decoded.TotalCostMicros)
 }
 
+// TestChat_JSONRoundTrip verifies that every field of codersdk.Chat
+// survives a JSON marshal/unmarshal cycle. This catches omitempty
+// silently eating zero-ish values, struct tag typos, and similar
+// serialization bugs in the pubsub path.
+func TestChat_JSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	prState := "open"
+	prTitle := "test PR"
+	authorLogin := "testuser"
+	avatarURL := "https://example.com/avatar.png"
+	baseBranch := "main"
+	headBranch := "feature/test"
+	prNumber := int32(42)
+	commits := int32(3)
+	approved := true
+	reviewerCount := int32(2)
+	refreshedAt := now
+	staleAt := now.Add(time.Hour)
+	lastError := "boom"
+	prURL := "https://github.com/coder/coder/pull/42"
+	workspaceID := uuid.New()
+	buildID := uuid.New()
+	agentID := uuid.New()
+	parentChatID := uuid.New()
+	rootChatID := uuid.New()
+
+	original := codersdk.Chat{
+		ID:                uuid.New(),
+		OwnerID:           uuid.New(),
+		WorkspaceID:       &workspaceID,
+		BuildID:           &buildID,
+		AgentID:           &agentID,
+		ParentChatID:      &parentChatID,
+		RootChatID:        &rootChatID,
+		LastModelConfigID: uuid.New(),
+		Title:             "round-trip-test",
+		Status:            codersdk.ChatStatusRunning,
+		LastError:         &lastError,
+		CreatedAt:         now,
+		UpdatedAt:         now,
+		Archived:          true,
+		MCPServerIDs:      []uuid.UUID{uuid.New()},
+		Labels:            map[string]string{"env": "prod"},
+		DiffStatus: &codersdk.ChatDiffStatus{
+			ChatID:           uuid.New(),
+			URL:              &prURL,
+			PullRequestState: &prState,
+			PullRequestTitle: prTitle,
+			PullRequestDraft: true,
+			ChangesRequested: true,
+			Additions:        10,
+			Deletions:        5,
+			ChangedFiles:     3,
+			AuthorLogin:      &authorLogin,
+			AuthorAvatarURL:  &avatarURL,
+			BaseBranch:       &baseBranch,
+			HeadBranch:       &headBranch,
+			PRNumber:         &prNumber,
+			Commits:          &commits,
+			Approved:         &approved,
+			ReviewerCount:    &reviewerCount,
+			RefreshedAt:      &refreshedAt,
+			StaleAt:          &staleAt,
+		},
+	}
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var decoded codersdk.Chat
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	require.Equal(t, original, decoded)
+}
+
 //nolint:tparallel,paralleltest
 func TestParseChatWorkspaceTTL(t *testing.T) {
 	t.Parallel()

--- a/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.test.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.test.tsx
@@ -436,7 +436,7 @@ describe("AgentsSidebar model display names", () => {
 			</Wrapper>,
 		);
 
-		// A nil UUID means the pubsub event omitted LastModelConfigID,
+		// A nil UUID means LastModelConfigID was left at its zero value,
 		// so the sidebar cannot resolve the model and falls back.
 		expect(getByText("Default model")).toBeInTheDocument();
 	});

--- a/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.test.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.test.tsx
@@ -411,4 +411,63 @@ describe("AgentsSidebar model display names", () => {
 
 		expect(getByText("GPT-4o (Quality)")).toBeInTheDocument();
 	});
+
+	it("shows Default model when last_model_config_id is a nil UUID", () => {
+		const { getByText } = render(
+			<Wrapper>
+				<AgentsSidebar
+					{...defaultProps}
+					chats={[
+						buildChat({
+							id: "nil-uuid-chat",
+							title: "Chat from pubsub",
+							last_model_config_id: "00000000-0000-0000-0000-000000000000",
+						}),
+					]}
+					modelOptions={[
+						{
+							id: "config-real",
+							provider: "openai",
+							model: "gpt-4o",
+							displayName: "GPT-4o",
+						},
+					]}
+				/>
+			</Wrapper>,
+		);
+
+		// A nil UUID means the pubsub event omitted LastModelConfigID,
+		// so the sidebar cannot resolve the model and falls back.
+		expect(getByText("Default model")).toBeInTheDocument();
+	});
+
+	it("shows model name when last_model_config_id matches a config", () => {
+		const { getByText, queryByText } = render(
+			<Wrapper>
+				<AgentsSidebar
+					{...defaultProps}
+					chats={[
+						buildChat({
+							id: "matched-chat",
+							title: "Chat with valid model",
+							last_model_config_id: "config-real",
+						}),
+					]}
+					modelOptions={[
+						{
+							id: "config-real",
+							provider: "openai",
+							model: "gpt-4o",
+							displayName: "GPT-4o",
+						},
+					]}
+				/>
+			</Wrapper>,
+		);
+
+		// Regression guard: a valid last_model_config_id must resolve
+		// to the actual model display name, not "Default model".
+		expect(getByText("GPT-4o")).toBeInTheDocument();
+		expect(queryByText("Default model")).not.toBeInTheDocument();
+	});
 });


### PR DESCRIPTION
*Problem:* `publishChatPubsubEvent` was constructing a partial `codersdk.Chat` that omitted `LastModelConfigID` and other fields. Go's zero-value UUID caused the sidebar to show "Default model" for chats received via SSE.

*Solution:*
- Extracted `convertChat`/`convertChats` from `exp_chats.go` into `db2sdk.Chat`/`db2sdk.Chats`, alongside existing `ChatMessage`, `ChatQueuedMessage`, and `ChatDiffStatus` converters. `publishChatPubsubEvent` now calls `db2sdk.Chat(chat, nil)` instead of maintaining its own copy of the conversion logic
- Added backend integration test `TestWatchChats/CreatedEventIncludesAllChatFields`
- Added frontend regression tests for nil-UUID and valid model config ID cases

> 🤖 Created by Coder Agents, reviewed by this human.