### PR TITLE
fix: match workspace picker font size to plus menu dropdown

### DIFF
--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -966,12 +966,18 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 											className="w-64 p-0"
 										>
 											<Command loop>
-												<CommandInput placeholder="Search workspaces..." />
+												<CommandInput
+													placeholder="Search workspaces..."
+													className="text-xs"
+												/>
 												<CommandList>
-													<CommandEmpty>No workspaces found</CommandEmpty>
+													<CommandEmpty className="text-xs">
+														No workspaces found
+													</CommandEmpty>
 													<CommandGroup>
 														{workspaceOptions.map((workspace) => (
 															<CommandItem
+																className="text-xs font-normal"
 																key={workspace.id}
 																value={workspace.name}
 																onSelect={() => {


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

## Problem

The workspace picker sub-popover (opened via the "+" button > "Attach workspace" in the chat form) used the default `CommandItem` styling of `text-sm font-medium` (14px), while every other item in the "+" dropdown uses `text-xs` (12px) with normal font weight.

## Fix

Override the `className` on `CommandInput`, `CommandEmpty`, and `CommandItem` in the workspace picker to use `text-xs` (and `font-normal` for items), matching the rest of the dropdown. The `cn()` utility in each Command component handles the merge via tailwind-merge.