### PR TITLE
perf(site): use lazy iteration in sliceAtGraphemeBoundary

### DIFF
--- a/site/src/pages/AgentsPage/components/AgentDetail/SmoothText.ts
+++ b/site/src/pages/AgentsPage/components/AgentDetail/SmoothText.ts
@@ -327,9 +327,12 @@ function sliceAtGraphemeBoundary(
 
 	if (graphemeSegmenter) {
 		let safeEnd = 0;
-		const segments = Array.from(graphemeSegmenter.segment(text));
-
-		for (const segment of segments) {
+		// Iterate the segmenter lazily instead of materializing
+		// with Array.from(). The early break makes this O(prefix)
+		// instead of O(full text), which matters at 60fps during
+		// streaming where the visible prefix is much shorter than
+		// the full accumulated text.
+		for (const segment of graphemeSegmenter.segment(text)) {
 			const segmentEnd = segment.index + segment.segment.length;
 			if (segmentEnd > maxCodeUnitLength) {
 				break;
@@ -342,9 +345,10 @@ function sliceAtGraphemeBoundary(
 
 	// Fallback: iterate by codepoint to avoid splitting surrogate
 	// pairs. This is less precise than grapheme segmentation but
-	// still safe for rendering.
+	// still safe for rendering. Iterating the string directly with
+	// for...of is lazy and avoids the O(n) Array.from() cost.
 	let safeEnd = 0;
-	for (const codePoint of Array.from(text)) {
+	for (const codePoint of text) {
 		const codePointEnd = safeEnd + codePoint.length;
 		if (codePointEnd > maxCodeUnitLength) {
 			break;


### PR DESCRIPTION
## Summary

Fix O(full-text) per-frame cost in the streaming text smooth-reveal animation by replacing eager array materialization with lazy iteration.

## What changed

`sliceAtGraphemeBoundary` in `SmoothText.ts` used `Array.from(graphemeSegmenter.segment(text))` to materialize the entire grapheme segment iterable into an array before iterating with an early `break`. The fallback codepoint path had the same issue with `Array.from(text)`.

During streaming, this function runs on every animation frame (~60fps) for the actively streaming response block. The visible prefix is typically much shorter than the accumulated full text, so the early `break` should make the function O(prefix), but the eager `Array.from` forces O(full-text) regardless.

Replaced both paths with direct `for...of` iteration, which is lazy and exits at the `break`.

## Benchmark results

| Scenario | Before (per call) | After (per call) | Speedup | Frame budget saved |
|---|---|---|---|---|
| 500 chars, prefix 50 | 0.145ms | 0.016ms | 8.3x | 0.78% |
| 2000 chars, prefix 100 | 0.560ms | 0.031ms | 17.9x | 3.18% |
| 5000 chars, prefix 200 | 1.442ms | 0.063ms | 22.6x | 8.26% |
| 10000 chars, prefix 200 | 2.949ms | 0.064ms | 43.1x | 17.28% |

Frame budget is measured against 16.7ms (60fps). At 10K characters (a medium-length response), the old code consumed 17.66% of the frame budget on grapheme slicing alone.

## Verification

- All 8 existing `SmoothText.test.ts` tests pass.
- `lint:compiler` reports 181 functions compiled, 0 diagnostics.
- `useSmoothStreamingText` hook still compiles cleanly.