### PR TITLE
perf(site): memo-wrap SmoothedResponse and ReasoningDisclosure to skip completed blocks during streaming

### DIFF
--- a/site/src/pages/AgentsPage/components/AgentDetail/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetail/ConversationTimeline.tsx
@@ -48,12 +48,12 @@ import type {
 	StreamState,
 } from "./types";
 
-const ReasoningDisclosure: FC<{
+const ReasoningDisclosure = memo<{
 	id: string;
 	text: string;
 	isStreaming?: boolean;
 	urlTransform?: UrlTransform;
-}> = ({ id, text, isStreaming = false, urlTransform }) => {
+}>(({ id, text, isStreaming = false, urlTransform }) => {
 	const { visibleText } = useSmoothStreamingText({
 		fullText: text,
 		isStreaming,
@@ -86,7 +86,7 @@ const ReasoningDisclosure: FC<{
 			</div>
 		</div>
 	);
-};
+});
 
 // Shared block renderer used by both ChatMessageItem (historical
 // messages) and StreamingOutput (live stream). Encapsulates the
@@ -107,11 +107,11 @@ type RenderBlockListParams = {
 // Wrapper that runs the smooth-streaming jitter buffer on a single
 // response block. Only used during live streaming — historical
 // messages render through <Response> directly.
-const SmoothedResponse: FC<{
+const SmoothedResponse = memo<{
 	text: string;
 	streamKey: string;
 	urlTransform?: UrlTransform;
-}> = ({ text, streamKey, urlTransform }) => {
+}>(({ text, streamKey, urlTransform }) => {
 	const { visibleText } = useSmoothStreamingText({
 		fullText: text,
 		isStreaming: true,
@@ -123,7 +123,7 @@ const SmoothedResponse: FC<{
 			{visibleText}
 		</Response>
 	);
-};
+});
 
 const InlineTextAttachmentButton: FC<{
 	content: string;


### PR DESCRIPTION
## Summary

Wrap `SmoothedResponse` and `ReasoningDisclosure` in `React.memo` to prevent re-rendering completed stream blocks on every chunk.

## Target

`ConversationTimeline.tsx` — the `SmoothedResponse` and `ReasoningDisclosure` components rendered by `renderBlockList` inside `StreamingOutput`.

Interaction: agent chat streaming (text arriving chunk-by-chunk via WebSocket).

## Compiler analysis

### Why the parent re-renders all children

`StreamingOutput` compiles with a 39-slot cache. The guard covering `renderBlockList` and all child element creation (compiled output, before):

```js
// StreamingOutput compiled output — 8-dependency guard
if ($[3] !== isStreaming || $[4] !== mcpServers || $[5] !== shouldShowBlocks
    || $[6] !== streamState?.blocks || $[7] !== streamTools
    || $[8] !== subagentStatusOverrides || $[9] !== subagentTitles
    || $[10] !== urlTransform) {
  const toolByID = new Map(streamTools.map(_temp8));
  const blocks = shouldShowBlocks ? streamState?.blocks ?? [] : [];
  const { elements: orderedBlocks, renderedToolIDs } = renderBlockList({...});
  // ... creates JSX for ALL blocks ...
}
```

`$[6]` (`streamState?.blocks`) is a new array every chunk — `appendTextBlock` does `[...blocks]`. `$[7]` (`streamTools`) is new every render — `buildStreamTools` creates fresh objects unconditionally. Guard misses every chunk, `renderBlockList` runs, new JSX elements created for all blocks.

### SmoothedResponse before (no memo)

```js
// Compiled output — no memo wrapper, _c(6)
const SmoothedResponse: FC<{...}> = t0 => {
  const $ = _c(6);
  const { text, streamKey, urlTransform } = t0;
  let t1;
  if ($[0] !== streamKey || $[1] !== text) {        // guard 1: hook arg
    t1 = { fullText: text, isStreaming: true, bypassSmoothing: false, streamKey };
    $[0] = streamKey; $[1] = text; $[2] = t1;
  } else { t1 = $[2]; }
  const { visibleText } = useSmoothStreamingText(t1); // ALWAYS RUNS
  let t2;
  if ($[3] !== urlTransform || $[4] !== visibleText) { // guard 2: JSX
    t2 = <Response urlTransform={urlTransform}>{visibleText}</Response>;
    $[3] = urlTransform; $[4] = visibleText; $[5] = t2;
  } else { t2 = $[5]; }
  return t2;
};
```

React always calls this function when the parent creates a new `<SmoothedResponse>` element. Internal guards memoize expressions but don't prevent the call. `useSmoothStreamingText` runs every time (calls `engine.update()`, `useSyncExternalStore`, `sliceAtGraphemeBoundary`).

### SmoothedResponse after (with memo)

```js
// Compiled output — memo wrapper present, same _c(6) inner function
const SmoothedResponse = memo<{...}>(t0 => {
  const $ = _c(6);
  // ... identical body ...
});
```

`React.memo` compares `text`, `streamKey`, `urlTransform` via `Object.is` before calling the function. For completed blocks all three are stable strings/references → function body never executes. Same pattern for `ReasoningDisclosure` (`_c(12)`).

## Empirical proof

Test: render `StreamingOutput` with 5 response blocks, then re-render with a new `streamState` reference (shallow-copied blocks array, same text content). Spy on `useSmoothStreamingText` to count how many SmoothedResponse function bodies execute.

**Before (no memo):**
```
First render:  5 hook calls (5 blocks)
Second render: 5 hook calls        ← all 5 completed blocks re-render
```

**After (with memo):**
```
First render:  5 hook calls (5 blocks)
Second render: 0 hook calls         ← zero completed blocks re-render
```

Re-render hook calls: **5 → 0.** Generalizes to N+M+1 → 1 for N completed response + M completed thinking blocks.

Compiler output: 181 functions compiled across 118 files, 0 diagnostics (before and after).

## Remaining opportunities

1. `buildStreamTools` creates new `MergedTool` objects unconditionally — stabilizing these would eliminate `$[7]` as an unstable dependency in `StreamingOutput`'s guard.
2. `AgentChatInput` (1208 lines) and `AgentsSidebar` (1187 lines) are large compiled components worth dedicated analysis sessions.

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻
