### PR TITLE
fix(chat): prefer devcontainer sub-agents over host agent in AI chat

### DIFF
--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -1292,6 +1292,23 @@ func (api *API) getChatMessages(rw http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// selectPreferredAgent returns the preferred agent for chat operations.
+// In workspaces with devcontainers, sub-agents (parent_id IS NOT NULL) are
+// preferred over the parent (host) agent so that AI chat runs inside the
+// devcontainer rather than on the host. Falls back to agents[0] if no
+// sub-agents are found.
+func selectPreferredAgent(agents []database.WorkspaceAgent) database.WorkspaceAgent {
+	if len(agents) == 0 {
+		return database.WorkspaceAgent{}
+	}
+	for _, agent := range agents {
+		if agent.ParentID.Valid {
+			return agent
+		}
+	}
+	return agents[0]
+}
+
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
 //
 //nolint:revive // HTTP handler writes to ResponseWriter.
@@ -1324,10 +1341,11 @@ func (api *API) watchChatGit(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	preferredAgent := selectPreferredAgent(agents)
 	apiAgent, err := db2sdk.WorkspaceAgent(
 		api.DERPMap(),
 		*api.TailnetCoordinator.Load(),
-		agents[0],
+		preferredAgent,
 		nil,
 		nil,
 		nil,
@@ -1351,7 +1369,7 @@ func (api *API) watchChatGit(rw http.ResponseWriter, r *http.Request) {
 	dialCtx, dialCancel := context.WithTimeout(ctx, 30*time.Second)
 	defer dialCancel()
 
-	agentConn, release, err := api.agentProvider.AgentConn(dialCtx, agents[0].ID)
+	agentConn, release, err := api.agentProvider.AgentConn(dialCtx, preferredAgent.ID)
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Internal error dialing workspace agent.",
@@ -1485,10 +1503,11 @@ func (api *API) watchChatDesktop(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	preferredAgent := selectPreferredAgent(agents)
 	apiAgent, err := db2sdk.WorkspaceAgent(
 		api.DERPMap(),
 		*api.TailnetCoordinator.Load(),
-		agents[0],
+		preferredAgent,
 		nil,
 		nil,
 		nil,
@@ -1512,7 +1531,7 @@ func (api *API) watchChatDesktop(rw http.ResponseWriter, r *http.Request) {
 	dialCtx, dialCancel := context.WithTimeout(ctx, 30*time.Second)
 	defer dialCancel()
 
-	agentConn, release, err := api.agentProvider.AgentConn(dialCtx, agents[0].ID)
+	agentConn, release, err := api.agentProvider.AgentConn(dialCtx, preferredAgent.ID)
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Failed to dial workspace agent.",

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -274,6 +274,25 @@ func (c *turnWorkspaceContext) ensureWorkspaceAgent(
 	return c.loadWorkspaceAgentLocked(ctx)
 }
 
+// selectPreferredAgent returns the preferred agent for chat operations.
+// In workspaces with devcontainers, sub-agents (parent_id IS NOT NULL) are
+// preferred over the parent (host) agent so that AI chat runs inside the
+// devcontainer rather than on the host. Falls back to agents[0] if no
+// sub-agents are found.
+func selectPreferredAgent(agents []database.WorkspaceAgent) database.WorkspaceAgent {
+	if len(agents) == 0 {
+		return database.WorkspaceAgent{}
+	}
+	// Prefer a sub-agent (one with a parent) over the parent agent.
+	for _, agent := range agents {
+		if agent.ParentID.Valid {
+			return agent
+		}
+	}
+	// Fall back to the first agent (typically the parent/host agent).
+	return agents[0]
+}
+
 func (c *turnWorkspaceContext) loadWorkspaceAgentLocked(
 	ctx context.Context,
 ) (database.Chat, database.WorkspaceAgent, error) {
@@ -333,11 +352,12 @@ func (c *turnWorkspaceContext) loadWorkspaceAgentLocked(
 			return chatSnapshot, database.WorkspaceAgent{}, xerrors.Errorf("get latest workspace build: %w", err)
 		}
 
+		preferredAgent := selectPreferredAgent(agents)
 		updatedChat, err := c.persistBuildAgentBinding(
 			ctx,
 			chatSnapshot,
 			build.ID,
-			agents[0].ID,
+			preferredAgent.ID,
 		)
 		if err != nil {
 			return chatSnapshot, database.WorkspaceAgent{}, err
@@ -349,7 +369,7 @@ func (c *turnWorkspaceContext) loadWorkspaceAgentLocked(
 			chatSnapshot = latestChat
 			continue
 		}
-		c.agent = agents[0]
+		c.agent = preferredAgent
 		c.agentLoaded = true
 		c.cachedWorkspaceID = chatSnapshot.WorkspaceID
 		return chatSnapshot, c.agent, nil
@@ -414,7 +434,7 @@ func (c *turnWorkspaceContext) getWorkspaceConn(ctx context.Context) (workspaces
 				if err != nil || len(agents) == 0 {
 					return uuid.Nil, xerrors.New("chat has no workspace agent")
 				}
-				return agents[0].ID, nil
+				return selectPreferredAgent(agents).ID, nil
 			},
 			workspaceDialValidationDelay,
 		)


### PR DESCRIPTION
## Description

In workspaces with devcontainers, the AI chat always connected to `agents[0]` from `GetWorkspaceAgentsInLatestBuildByWorkspaceID`, which is always the host agent. This caused all AI chat commands to run on the host instead of inside the devcontainer.

This PR adds a `selectPreferredAgent()` helper that prefers agents with a `parent_id` (sub-agents) over the parent/host agent. Applied to 5 locations across two files.

## Changes

- **coderd/x/chatd/chatd.go**:
  - Added `selectPreferredAgent()` helper that iterates agents and returns the first one with a valid `ParentID` (sub-agent), falling back to `agents[0]`
  - `loadWorkspaceAgentLocked`: Use `selectPreferredAgent()` when creating the initial agent binding and persisting it
  - `getWorkspaceConn`: Use `selectPreferredAgent()` in the lazy dial validation fallback
- **coderd/exp_chats.go**:
  - Added identical `selectPreferredAgent()` helper (separate package)
  - `watchChatGit`: Use `selectPreferredAgent()` for both the agent status check and the dial
  - `watchChatDesktop`: Use `selectPreferredAgent()` for both the agent status check and the dial

## No Schema Changes Required

The `parent_id` field already exists on `workspace_agents` and is populated for devcontainer sub-agents.

## Fixes

Fixes coder/coder#23547

## Testing

No new tests were added. The change is intentionally minimal and localized. The existing tests for `GetWorkspaceAgentsInLatestBuildByWorkspaceID` already cover the agent ordering.

