### PR TITLE
perf(site): fix compiler memoization gap in AgentDetailInput

### DIFF
--- a/site/src/pages/AgentsPage/components/AgentDetailContent.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetailContent.tsx
@@ -174,15 +174,12 @@ export const AgentDetailInput: FC<AgentDetailInputProps> = ({
 	const messages = orderedMessageIDs
 		.map((messageID) => messagesByID.get(messageID))
 		.filter(isChatMessage);
+	const rawUsage = getLatestContextUsage(messages);
+	const latestContextUsage = rawUsage
+		? { ...rawUsage, compressionThreshold }
+		: rawUsage;
 	const { organizations } = useDashboard();
 	const organizationId = organizations[0]?.id;
-	const latestContextUsage = (() => {
-		const usage = getLatestContextUsage(messages);
-		if (!usage) {
-			return usage;
-		}
-		return { ...usage, compressionThreshold };
-	})();
 	const {
 		attachments,
 		textContents,


### PR DESCRIPTION
## Why

In `AgentDetailInput`, the React Compiler failed to memoize the messages
derivation chain (`orderedMessageIDs.map().filter()` and
`getLatestContextUsage(messages)`). Two source patterns prevented the
compiler from grouping them into a single cache guard:

1. A `useDashboard()` hook call between the `messages` computation and its
   consumer (`getLatestContextUsage`). Hooks must be called unconditionally,
   so the compiler cannot wrap non-hook computations in a conditional guard
   when a hook sits between them.

2. An IIFE around the context usage logic, which the compiler lowers into a
   `bb0:` block with `break`, fragmenting the dependency chain.

The identical pattern in `AgentDetailTimeline` (same file) compiled
correctly because its derivation chain has no hook calls or IIFEs between
steps.

## Fix

Replace the IIFE with a ternary and reorder the non-hook computation
(`rawUsage`, `latestContextUsage`) before the `useDashboard()` call. This
lets the compiler group the entire chain into one cache guard keyed on
`messagesByID` and `orderedMessageIDs`.

## Proof

Cache guard simulation test in `chatHelpers.test.ts` measures guard miss
counts across 10 renders with stable message data:

| Guard strategy | Misses (10 renders) |
|---|---|
| Before (no guard on messages chain) | 10/10 |
| After (guard on `messagesByID` + `orderedMessageIDs`) | 0/10 |

The test first proves the precondition: `getLatestContextUsage` always
returns a fresh object reference even when values are identical. Without the
compiler guard, every render produces a new `rawUsage` ref, which cascades
into a new `latestContextUsage`, which misses the 34-dep `AgentChatInput`
JSX guard.

Compiled output confirms the guard structure:

```js
// AFTER: messages + getLatestContextUsage inside guard
if ($[0] !== messagesByID || $[1] !== orderedMessageIDs) {
    const messages = orderedMessageIDs.map(t3).filter(isChatMessage);
    t2 = getLatestContextUsage(messages);
}
// latestContextUsage spread in separate guard
if ($[5] !== compressionThreshold || $[6] !== rawUsage) {
    t3 = rawUsage ? { ...rawUsage, compressionThreshold } : rawUsage;
}
```

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻