### PR TITLE
fix(provisioner/terraform): regenerate fixtures with current provider

### DIFF
--- a/provisioner/terraform/resources_test.go
+++ b/provisioner/terraform/resources_test.go
@@ -325,12 +325,14 @@ func TestConvertResources(t *testing.T) {
 					Architecture:    "amd64",
 					ExtraEnvs: []*proto.Env{
 						{
-							Name:  "ENV_1",
-							Value: "Env 1",
+							Name:          "ENV_1",
+							Value:         "Env 1",
+							MergeStrategy: "replace",
 						},
 						{
-							Name:  "ENV_2",
-							Value: "Env 2",
+							Name:          "ENV_2",
+							Value:         "Env 2",
+							MergeStrategy: "replace",
 						},
 					},
 					Auth:                     &proto.Agent_Token{},
@@ -348,8 +350,9 @@ func TestConvertResources(t *testing.T) {
 					Architecture:    "amd64",
 					ExtraEnvs: []*proto.Env{
 						{
-							Name:  "ENV_3",
-							Value: "Env 3",
+							Name:          "ENV_3",
+							Value:         "Env 3",
+							MergeStrategy: "replace",
 						},
 					},
 					Auth:                     &proto.Agent_Token{},
@@ -1012,8 +1015,9 @@ func TestConvertResources(t *testing.T) {
 								},
 								Envs: []*proto.Env{
 									{
-										Name:  "DEVCONTAINER_ENV",
-										Value: "devcontainer-value",
+										Name:          "DEVCONTAINER_ENV",
+										Value:         "devcontainer-value",
+										MergeStrategy: "replace",
 									},
 								},
 							},

--- a/provisioner/terraform/testdata/resources/devcontainer-resources/converted_state.plan.golden
+++ b/provisioner/terraform/testdata/resources/devcontainer-resources/converted_state.plan.golden
@@ -45,7 +45,8 @@
               "envs": [
                 {
                   "name": "DEVCONTAINER_ENV",
-                  "value": "devcontainer-value"
+                  "value": "devcontainer-value",
+                  "merge_strategy": "replace"
                 }
               ]
             }

--- a/provisioner/terraform/testdata/resources/devcontainer-resources/converted_state.state.golden
+++ b/provisioner/terraform/testdata/resources/devcontainer-resources/converted_state.state.golden
@@ -48,7 +48,8 @@
               "envs": [
                 {
                   "name": "DEVCONTAINER_ENV",
-                  "value": "devcontainer-value"
+                  "value": "devcontainer-value",
+                  "merge_strategy": "replace"
                 }
               ]
             }

--- a/provisioner/terraform/testdata/resources/devcontainer-resources/devcontainer-resources.tfplan.json
+++ b/provisioner/terraform/testdata/resources/devcontainer-resources/devcontainer-resources.tfplan.json
@@ -83,6 +83,7 @@
           "provider_name": "registry.terraform.io/coder/coder",
           "schema_version": 1,
           "values": {
+            "merge_strategy": "replace",
             "name": "DEVCONTAINER_ENV",
             "value": "devcontainer-value"
           },
@@ -243,6 +244,7 @@
         ],
         "before": null,
         "after": {
+          "merge_strategy": "replace",
           "name": "DEVCONTAINER_ENV",
           "value": "devcontainer-value"
         },

--- a/provisioner/terraform/testdata/resources/devcontainer-resources/devcontainer-resources.tfstate.json
+++ b/provisioner/terraform/testdata/resources/devcontainer-resources/devcontainer-resources.tfstate.json
@@ -111,6 +111,7 @@
           "values": {
             "agent_id": "b4db82a1-1cba-4d97-8893-cf2ca9a9fe1a",
             "id": "0982d946-8a12-423a-a316-d4263f94a124",
+            "merge_strategy": "replace",
             "name": "DEVCONTAINER_ENV",
             "value": "devcontainer-value"
           },

--- a/provisioner/terraform/testdata/resources/multiple-agents-multiple-envs/converted_state.plan.golden
+++ b/provisioner/terraform/testdata/resources/multiple-agents-multiple-envs/converted_state.plan.golden
@@ -21,11 +21,13 @@
           "extra_envs": [
             {
               "name": "ENV_1",
-              "value": "Env 1"
+              "value": "Env 1",
+              "merge_strategy": "replace"
             },
             {
               "name": "ENV_2",
-              "value": "Env 2"
+              "value": "Env 2",
+              "merge_strategy": "replace"
             }
           ],
           "resources_monitoring": {},
@@ -54,7 +56,8 @@
           "extra_envs": [
             {
               "name": "ENV_3",
-              "value": "Env 3"
+              "value": "Env 3",
+              "merge_strategy": "replace"
             }
           ],
           "resources_monitoring": {},

--- a/provisioner/terraform/testdata/resources/multiple-agents-multiple-envs/converted_state.state.golden
+++ b/provisioner/terraform/testdata/resources/multiple-agents-multiple-envs/converted_state.state.golden
@@ -22,11 +22,13 @@
           "extra_envs": [
             {
               "name": "ENV_1",
-              "value": "Env 1"
+              "value": "Env 1",
+              "merge_strategy": "replace"
             },
             {
               "name": "ENV_2",
-              "value": "Env 2"
+              "value": "Env 2",
+              "merge_strategy": "replace"
             }
           ],
           "resources_monitoring": {},
@@ -56,7 +58,8 @@
           "extra_envs": [
             {
               "name": "ENV_3",
-              "value": "Env 3"
+              "value": "Env 3",
+              "merge_strategy": "replace"
             }
           ],
           "resources_monitoring": {},

--- a/provisioner/terraform/testdata/resources/multiple-agents-multiple-envs/multiple-agents-multiple-envs.tfplan.json
+++ b/provisioner/terraform/testdata/resources/multiple-agents-multiple-envs/multiple-agents-multiple-envs.tfplan.json
@@ -74,6 +74,7 @@
           "provider_name": "registry.terraform.io/coder/coder",
           "schema_version": 1,
           "values": {
+            "merge_strategy": "replace",
             "name": "ENV_1",
             "value": "Env 1"
           },
@@ -87,6 +88,7 @@
           "provider_name": "registry.terraform.io/coder/coder",
           "schema_version": 1,
           "values": {
+            "merge_strategy": "replace",
             "name": "ENV_2",
             "value": "Env 2"
           },
@@ -100,6 +102,7 @@
           "provider_name": "registry.terraform.io/coder/coder",
           "schema_version": 1,
           "values": {
+            "merge_strategy": "replace",
             "name": "ENV_3",
             "value": "Env 3"
           },
@@ -235,6 +238,7 @@
         ],
         "before": null,
         "after": {
+          "merge_strategy": "replace",
           "name": "ENV_1",
           "value": "Env 1"
         },
@@ -258,6 +262,7 @@
         ],
         "before": null,
         "after": {
+          "merge_strategy": "replace",
           "name": "ENV_2",
           "value": "Env 2"
         },
@@ -281,6 +286,7 @@
         ],
         "before": null,
         "after": {
+          "merge_strategy": "replace",
           "name": "ENV_3",
           "value": "Env 3"
         },

--- a/provisioner/terraform/testdata/resources/multiple-agents-multiple-envs/multiple-agents-multiple-envs.tfstate.json
+++ b/provisioner/terraform/testdata/resources/multiple-agents-multiple-envs/multiple-agents-multiple-envs.tfstate.json
@@ -104,6 +104,7 @@
           "values": {
             "agent_id": "fac6034b-1d42-4407-b266-265e35795241",
             "id": "fd793e28-41fb-4d56-8b22-6a4ad905245a",
+            "merge_strategy": "replace",
             "name": "ENV_1",
             "value": "Env 1"
           },
@@ -122,6 +123,7 @@
           "values": {
             "agent_id": "fac6034b-1d42-4407-b266-265e35795241",
             "id": "809a9f24-48c9-4192-8476-31bca05f2545",
+            "merge_strategy": "replace",
             "name": "ENV_2",
             "value": "Env 2"
           },
@@ -140,6 +142,7 @@
           "values": {
             "agent_id": "a02262af-b94b-4d6d-98ec-6e36b775e328",
             "id": "cb8f717f-0654-48a7-939b-84936be0096d",
+            "merge_strategy": "replace",
             "name": "ENV_3",
             "value": "Env 3"
           },


### PR DESCRIPTION
Two test fixtures (`devcontainer-resources`, `multiple-agents-multiple-envs`) were generated before `terraform-provider-coder` v2.15.0 added `merge_strategy` to `coder_env`. The current provider emits `merge_strategy: "replace"` as the default, so every run of `generate.sh` produced unstable diffs on these fixtures.

Regenerated the JSON fixtures and golden files to match the current provider output.

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻