### PR TITLE
fix(site): make AI Bridge sessions query key more specific

### DIFF
--- a/site/src/api/queries/aiBridge.ts
+++ b/site/src/api/queries/aiBridge.ts
@@ -12,8 +12,8 @@ export const paginatedInterceptions = (
 	return {
 		searchParams,
 		queryPayload: () => searchParams.get(useFilterParamsKey) ?? "",
-		queryKey: ({ payload, pageNumber }) => {
-			return ["aiBridgeInterceptions", payload, pageNumber] as const;
+		queryKey: ({ limit, offset, payload }) => {
+			return ["aiBridgeInterceptions", limit, offset, payload] as const;
 		},
 		queryFn: ({ limit, offset, payload }) =>
 			API.getAIBridgeInterceptions({
@@ -30,10 +30,10 @@ export const paginatedSessions = (
 	return {
 		searchParams,
 		queryPayload: () => searchParams.get(useFilterParamsKey) ?? "",
-		queryKey: ({ payload, pageNumber }) => {
-			return ["aiBridgeSessions", payload, pageNumber] as const;
+		queryKey: ({ limit, offset, payload }) => {
+			return ["aiBridgeSessions", limit, offset, payload] as const;
 		},
-		queryFn: ({ offset, limit, payload }) =>
+		queryFn: ({ limit, offset, payload }) =>
 			API.getAIBridgeSessionList({
 				offset,
 				limit,


### PR DESCRIPTION
Seeing what appears to be a react-query caching issue on dogfood. Not able to repro on my workspace, so this is sort of a shot in the dark 🤷 