### PR TITLE
fix(site): decrease chevron size in AI Bridge session row

### DIFF
--- a/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.tsx
+++ b/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.tsx
@@ -160,7 +160,7 @@ export const ListSessionsRow: FC<ListSessionsRowProps> = ({
 							DATE_FORMAT.FULL_DATETIME,
 						)}
 					</span>
-					<ChevronRightIcon className="ml-4" />
+					<ChevronRightIcon className="ml-4 size-icon-sm" />
 				</div>
 			</TableCell>
 		</TableRow>


### PR DESCRIPTION
The Sessions table row chevron icon is too big. Make it smaller 🤏 

Before

<img width="273" height="183" alt="Screenshot 2026-03-26 at 2 51 28 PM" src="https://github.com/user-attachments/assets/25c57c07-c405-447b-a5cc-ed3c6b5f68ca" />

After

<img width="254" height="186" alt="Screenshot 2026-03-26 at 2 51 45 PM" src="https://github.com/user-attachments/assets/6f18f9a9-caa6-445a-9e2b-4b6e594785d7" />
