### PR TITLE
perf(enterprise/tailnet): improve coordinator peer mapping performance

### DIFF
--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -1602,6 +1602,15 @@ func (q *querier) BackoffChatDiffStatus(ctx context.Context, arg database.Backof
 	return q.db.BackoffChatDiffStatus(ctx, arg)
 }
 
+func (q *querier) BatchUpdateWorkspaceAgentConnections(ctx context.Context, arg database.BatchUpdateWorkspaceAgentConnectionsParams) error {
+	// Could be any workspace agent and checking auth to each workspace
+	// agent is overkill for the purpose of this function.
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceWorkspace.All()); err != nil {
+		return err
+	}
+	return q.db.BatchUpdateWorkspaceAgentConnections(ctx, arg)
+}
+
 func (q *querier) BatchUpdateWorkspaceAgentMetadata(ctx context.Context, arg database.BatchUpdateWorkspaceAgentMetadataParams) error {
 	// Could be any workspace agent and checking auth to each workspace agent is overkill for
 	// the purpose of this function.
@@ -1625,6 +1634,13 @@ func (q *querier) BatchUpdateWorkspaceNextStartAt(ctx context.Context, arg datab
 		return err
 	}
 	return q.db.BatchUpdateWorkspaceNextStartAt(ctx, arg)
+}
+
+func (q *querier) BatchUpsertConnectionLogs(ctx context.Context, arg database.BatchUpsertConnectionLogsParams) error {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceConnectionLog); err != nil {
+		return err
+	}
+	return q.db.BatchUpsertConnectionLogs(ctx, arg)
 }
 
 func (q *querier) BulkMarkNotificationMessagesFailed(ctx context.Context, arg database.BulkMarkNotificationMessagesFailedParams) (int64, error) {
@@ -3598,11 +3614,25 @@ func (q *querier) GetTailnetTunnelPeerBindings(ctx context.Context, srcID uuid.U
 	return q.db.GetTailnetTunnelPeerBindings(ctx, srcID)
 }
 
+func (q *querier) GetTailnetTunnelPeerBindingsBatch(ctx context.Context, ids []uuid.UUID) ([]database.GetTailnetTunnelPeerBindingsBatchRow, error) {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceTailnetCoordinator); err != nil {
+		return nil, err
+	}
+	return q.db.GetTailnetTunnelPeerBindingsBatch(ctx, ids)
+}
+
 func (q *querier) GetTailnetTunnelPeerIDs(ctx context.Context, srcID uuid.UUID) ([]database.GetTailnetTunnelPeerIDsRow, error) {
 	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceTailnetCoordinator); err != nil {
 		return nil, err
 	}
 	return q.db.GetTailnetTunnelPeerIDs(ctx, srcID)
+}
+
+func (q *querier) GetTailnetTunnelPeerIDsBatch(ctx context.Context, ids []uuid.UUID) ([]database.GetTailnetTunnelPeerIDsBatchRow, error) {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceTailnetCoordinator); err != nil {
+		return nil, err
+	}
+	return q.db.GetTailnetTunnelPeerIDsBatch(ctx, ids)
 }
 
 func (q *querier) GetTaskByID(ctx context.Context, id uuid.UUID) (database.Task, error) {

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -184,6 +184,14 @@ func (m queryMetricsStore) BackoffChatDiffStatus(ctx context.Context, arg databa
 	return r0
 }
 
+func (m queryMetricsStore) BatchUpdateWorkspaceAgentConnections(ctx context.Context, arg database.BatchUpdateWorkspaceAgentConnectionsParams) error {
+	start := time.Now()
+	r0 := m.s.BatchUpdateWorkspaceAgentConnections(ctx, arg)
+	m.queryLatencies.WithLabelValues("BatchUpdateWorkspaceAgentConnections").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "BatchUpdateWorkspaceAgentConnections").Inc()
+	return r0
+}
+
 func (m queryMetricsStore) BatchUpdateWorkspaceAgentMetadata(ctx context.Context, arg database.BatchUpdateWorkspaceAgentMetadataParams) error {
 	start := time.Now()
 	r0 := m.s.BatchUpdateWorkspaceAgentMetadata(ctx, arg)
@@ -205,6 +213,14 @@ func (m queryMetricsStore) BatchUpdateWorkspaceNextStartAt(ctx context.Context, 
 	r0 := m.s.BatchUpdateWorkspaceNextStartAt(ctx, arg)
 	m.queryLatencies.WithLabelValues("BatchUpdateWorkspaceNextStartAt").Observe(time.Since(start).Seconds())
 	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "BatchUpdateWorkspaceNextStartAt").Inc()
+	return r0
+}
+
+func (m queryMetricsStore) BatchUpsertConnectionLogs(ctx context.Context, arg database.BatchUpsertConnectionLogsParams) error {
+	start := time.Now()
+	r0 := m.s.BatchUpsertConnectionLogs(ctx, arg)
+	m.queryLatencies.WithLabelValues("BatchUpsertConnectionLogs").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "BatchUpsertConnectionLogs").Inc()
 	return r0
 }
 
@@ -2184,11 +2200,27 @@ func (m queryMetricsStore) GetTailnetTunnelPeerBindings(ctx context.Context, src
 	return r0, r1
 }
 
+func (m queryMetricsStore) GetTailnetTunnelPeerBindingsBatch(ctx context.Context, ids []uuid.UUID) ([]database.GetTailnetTunnelPeerBindingsBatchRow, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetTailnetTunnelPeerBindingsBatch(ctx, ids)
+	m.queryLatencies.WithLabelValues("GetTailnetTunnelPeerBindingsBatch").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetTailnetTunnelPeerBindingsBatch").Inc()
+	return r0, r1
+}
+
 func (m queryMetricsStore) GetTailnetTunnelPeerIDs(ctx context.Context, srcID uuid.UUID) ([]database.GetTailnetTunnelPeerIDsRow, error) {
 	start := time.Now()
 	r0, r1 := m.s.GetTailnetTunnelPeerIDs(ctx, srcID)
 	m.queryLatencies.WithLabelValues("GetTailnetTunnelPeerIDs").Observe(time.Since(start).Seconds())
 	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetTailnetTunnelPeerIDs").Inc()
+	return r0, r1
+}
+
+func (m queryMetricsStore) GetTailnetTunnelPeerIDsBatch(ctx context.Context, ids []uuid.UUID) ([]database.GetTailnetTunnelPeerIDsBatchRow, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetTailnetTunnelPeerIDsBatch(ctx, ids)
+	m.queryLatencies.WithLabelValues("GetTailnetTunnelPeerIDsBatch").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetTailnetTunnelPeerIDsBatch").Inc()
 	return r0, r1
 }
 

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -190,6 +190,20 @@ func (mr *MockStoreMockRecorder) BackoffChatDiffStatus(ctx, arg any) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackoffChatDiffStatus", reflect.TypeOf((*MockStore)(nil).BackoffChatDiffStatus), ctx, arg)
 }
 
+// BatchUpdateWorkspaceAgentConnections mocks base method.
+func (m *MockStore) BatchUpdateWorkspaceAgentConnections(ctx context.Context, arg database.BatchUpdateWorkspaceAgentConnectionsParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BatchUpdateWorkspaceAgentConnections", ctx, arg)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BatchUpdateWorkspaceAgentConnections indicates an expected call of BatchUpdateWorkspaceAgentConnections.
+func (mr *MockStoreMockRecorder) BatchUpdateWorkspaceAgentConnections(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchUpdateWorkspaceAgentConnections", reflect.TypeOf((*MockStore)(nil).BatchUpdateWorkspaceAgentConnections), ctx, arg)
+}
+
 // BatchUpdateWorkspaceAgentMetadata mocks base method.
 func (m *MockStore) BatchUpdateWorkspaceAgentMetadata(ctx context.Context, arg database.BatchUpdateWorkspaceAgentMetadataParams) error {
 	m.ctrl.T.Helper()
@@ -230,6 +244,20 @@ func (m *MockStore) BatchUpdateWorkspaceNextStartAt(ctx context.Context, arg dat
 func (mr *MockStoreMockRecorder) BatchUpdateWorkspaceNextStartAt(ctx, arg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchUpdateWorkspaceNextStartAt", reflect.TypeOf((*MockStore)(nil).BatchUpdateWorkspaceNextStartAt), ctx, arg)
+}
+
+// BatchUpsertConnectionLogs mocks base method.
+func (m *MockStore) BatchUpsertConnectionLogs(ctx context.Context, arg database.BatchUpsertConnectionLogsParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BatchUpsertConnectionLogs", ctx, arg)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BatchUpsertConnectionLogs indicates an expected call of BatchUpsertConnectionLogs.
+func (mr *MockStoreMockRecorder) BatchUpsertConnectionLogs(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchUpsertConnectionLogs", reflect.TypeOf((*MockStore)(nil).BatchUpsertConnectionLogs), ctx, arg)
 }
 
 // BulkMarkNotificationMessagesFailed mocks base method.
@@ -4053,6 +4081,21 @@ func (mr *MockStoreMockRecorder) GetTailnetTunnelPeerBindings(ctx, srcID any) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTailnetTunnelPeerBindings", reflect.TypeOf((*MockStore)(nil).GetTailnetTunnelPeerBindings), ctx, srcID)
 }
 
+// GetTailnetTunnelPeerBindingsBatch mocks base method.
+func (m *MockStore) GetTailnetTunnelPeerBindingsBatch(ctx context.Context, ids []uuid.UUID) ([]database.GetTailnetTunnelPeerBindingsBatchRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTailnetTunnelPeerBindingsBatch", ctx, ids)
+	ret0, _ := ret[0].([]database.GetTailnetTunnelPeerBindingsBatchRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTailnetTunnelPeerBindingsBatch indicates an expected call of GetTailnetTunnelPeerBindingsBatch.
+func (mr *MockStoreMockRecorder) GetTailnetTunnelPeerBindingsBatch(ctx, ids any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTailnetTunnelPeerBindingsBatch", reflect.TypeOf((*MockStore)(nil).GetTailnetTunnelPeerBindingsBatch), ctx, ids)
+}
+
 // GetTailnetTunnelPeerIDs mocks base method.
 func (m *MockStore) GetTailnetTunnelPeerIDs(ctx context.Context, srcID uuid.UUID) ([]database.GetTailnetTunnelPeerIDsRow, error) {
 	m.ctrl.T.Helper()
@@ -4066,6 +4109,21 @@ func (m *MockStore) GetTailnetTunnelPeerIDs(ctx context.Context, srcID uuid.UUID
 func (mr *MockStoreMockRecorder) GetTailnetTunnelPeerIDs(ctx, srcID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTailnetTunnelPeerIDs", reflect.TypeOf((*MockStore)(nil).GetTailnetTunnelPeerIDs), ctx, srcID)
+}
+
+// GetTailnetTunnelPeerIDsBatch mocks base method.
+func (m *MockStore) GetTailnetTunnelPeerIDsBatch(ctx context.Context, ids []uuid.UUID) ([]database.GetTailnetTunnelPeerIDsBatchRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTailnetTunnelPeerIDsBatch", ctx, ids)
+	ret0, _ := ret[0].([]database.GetTailnetTunnelPeerIDsBatchRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTailnetTunnelPeerIDsBatch indicates an expected call of GetTailnetTunnelPeerIDsBatch.
+func (mr *MockStoreMockRecorder) GetTailnetTunnelPeerIDsBatch(ctx, ids any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTailnetTunnelPeerIDsBatch", reflect.TypeOf((*MockStore)(nil).GetTailnetTunnelPeerIDsBatch), ctx, ids)
 }
 
 // GetTaskByID mocks base method.

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -62,9 +62,11 @@ type sqlcQuerier interface {
 	// referenced by the latest build of a workspace.
 	ArchiveUnusedTemplateVersions(ctx context.Context, arg ArchiveUnusedTemplateVersionsParams) ([]uuid.UUID, error)
 	BackoffChatDiffStatus(ctx context.Context, arg BackoffChatDiffStatusParams) error
+	BatchUpdateWorkspaceAgentConnections(ctx context.Context, arg BatchUpdateWorkspaceAgentConnectionsParams) error
 	BatchUpdateWorkspaceAgentMetadata(ctx context.Context, arg BatchUpdateWorkspaceAgentMetadataParams) error
 	BatchUpdateWorkspaceLastUsedAt(ctx context.Context, arg BatchUpdateWorkspaceLastUsedAtParams) error
 	BatchUpdateWorkspaceNextStartAt(ctx context.Context, arg BatchUpdateWorkspaceNextStartAtParams) error
+	BatchUpsertConnectionLogs(ctx context.Context, arg BatchUpsertConnectionLogsParams) error
 	BulkMarkNotificationMessagesFailed(ctx context.Context, arg BulkMarkNotificationMessagesFailedParams) (int64, error)
 	BulkMarkNotificationMessagesSent(ctx context.Context, arg BulkMarkNotificationMessagesSentParams) (int64, error)
 	// Calculates the telemetry summary for a given provider, model, and client
@@ -464,7 +466,9 @@ type sqlcQuerier interface {
 	GetStaleChats(ctx context.Context, staleThreshold time.Time) ([]Chat, error)
 	GetTailnetPeers(ctx context.Context, id uuid.UUID) ([]TailnetPeer, error)
 	GetTailnetTunnelPeerBindings(ctx context.Context, srcID uuid.UUID) ([]GetTailnetTunnelPeerBindingsRow, error)
+	GetTailnetTunnelPeerBindingsBatch(ctx context.Context, ids []uuid.UUID) ([]GetTailnetTunnelPeerBindingsBatchRow, error)
 	GetTailnetTunnelPeerIDs(ctx context.Context, srcID uuid.UUID) ([]GetTailnetTunnelPeerIDsRow, error)
+	GetTailnetTunnelPeerIDsBatch(ctx context.Context, ids []uuid.UUID) ([]GetTailnetTunnelPeerIDsBatchRow, error)
 	GetTaskByID(ctx context.Context, id uuid.UUID) (Task, error)
 	GetTaskByOwnerIDAndName(ctx context.Context, arg GetTaskByOwnerIDAndNameParams) (Task, error)
 	GetTaskByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) (Task, error)

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -6322,6 +6322,89 @@ func (q *sqlQuerier) UpsertChatUsageLimitUserOverride(ctx context.Context, arg U
 	return i, err
 }
 
+const batchUpsertConnectionLogs = `-- name: BatchUpsertConnectionLogs :exec
+INSERT INTO connection_logs (
+    id, connect_time, organization_id, workspace_owner_id, workspace_id,
+    workspace_name, agent_name, type, code, ip, user_agent, user_id,
+    slug_or_port, connection_id, disconnect_reason, disconnect_time
+)
+SELECT
+    unnest($1::uuid[]),
+    unnest($2::timestamptz[]),
+    unnest($3::uuid[]),
+    unnest($4::uuid[]),
+    unnest($5::uuid[]),
+    unnest($6::text[]),
+    unnest($7::text[]),
+    unnest($8::connection_type[]),
+    unnest($9::int4[]),
+    unnest($10::inet[]),
+    unnest($11::text[]),
+    unnest($12::uuid[]),
+    unnest($13::text[]),
+    unnest($14::uuid[]),
+    unnest($15::text[]),
+    unnest($16::timestamptz[])
+ON CONFLICT (connection_id, workspace_id, agent_name)
+DO UPDATE SET
+    disconnect_time = CASE
+        WHEN connection_logs.disconnect_time IS NULL
+        THEN EXCLUDED.disconnect_time
+        ELSE connection_logs.disconnect_time
+    END,
+    disconnect_reason = CASE
+        WHEN connection_logs.disconnect_reason IS NULL
+        THEN EXCLUDED.disconnect_reason
+        ELSE connection_logs.disconnect_reason
+    END,
+    code = CASE
+        WHEN connection_logs.code IS NULL
+        THEN EXCLUDED.code
+        ELSE connection_logs.code
+    END
+`
+
+type BatchUpsertConnectionLogsParams struct {
+	ID               []uuid.UUID      `db:"id" json:"id"`
+	ConnectTime      []time.Time      `db:"connect_time" json:"connect_time"`
+	OrganizationID   []uuid.UUID      `db:"organization_id" json:"organization_id"`
+	WorkspaceOwnerID []uuid.UUID      `db:"workspace_owner_id" json:"workspace_owner_id"`
+	WorkspaceID      []uuid.UUID      `db:"workspace_id" json:"workspace_id"`
+	WorkspaceName    []string         `db:"workspace_name" json:"workspace_name"`
+	AgentName        []string         `db:"agent_name" json:"agent_name"`
+	Type             []ConnectionType `db:"type" json:"type"`
+	Code             []int32          `db:"code" json:"code"`
+	Ip               []pqtype.Inet    `db:"ip" json:"ip"`
+	UserAgent        []string         `db:"user_agent" json:"user_agent"`
+	UserID           []uuid.UUID      `db:"user_id" json:"user_id"`
+	SlugOrPort       []string         `db:"slug_or_port" json:"slug_or_port"`
+	ConnectionID     []uuid.UUID      `db:"connection_id" json:"connection_id"`
+	DisconnectReason []string         `db:"disconnect_reason" json:"disconnect_reason"`
+	DisconnectTime   []time.Time      `db:"disconnect_time" json:"disconnect_time"`
+}
+
+func (q *sqlQuerier) BatchUpsertConnectionLogs(ctx context.Context, arg BatchUpsertConnectionLogsParams) error {
+	_, err := q.db.ExecContext(ctx, batchUpsertConnectionLogs,
+		pq.Array(arg.ID),
+		pq.Array(arg.ConnectTime),
+		pq.Array(arg.OrganizationID),
+		pq.Array(arg.WorkspaceOwnerID),
+		pq.Array(arg.WorkspaceID),
+		pq.Array(arg.WorkspaceName),
+		pq.Array(arg.AgentName),
+		pq.Array(arg.Type),
+		pq.Array(arg.Code),
+		pq.Array(arg.Ip),
+		pq.Array(arg.UserAgent),
+		pq.Array(arg.UserID),
+		pq.Array(arg.SlugOrPort),
+		pq.Array(arg.ConnectionID),
+		pq.Array(arg.DisconnectReason),
+		pq.Array(arg.DisconnectTime),
+	)
+	return err
+}
+
 const countConnectionLogs = `-- name: CountConnectionLogs :one
 SELECT
 	COUNT(*) AS count
@@ -18252,6 +18335,59 @@ func (q *sqlQuerier) GetTailnetTunnelPeerBindings(ctx context.Context, srcID uui
 	return items, nil
 }
 
+const getTailnetTunnelPeerBindingsBatch = `-- name: GetTailnetTunnelPeerBindingsBatch :many
+SELECT tp.id AS peer_id, tp.coordinator_id, tp.updated_at, tp.node, tp.status,
+       tt.src_id AS lookup_id
+FROM tailnet_peers tp
+INNER JOIN tailnet_tunnels tt ON tp.id = tt.dst_id
+WHERE tt.src_id = ANY($1 :: uuid[])
+UNION ALL
+SELECT tp.id AS peer_id, tp.coordinator_id, tp.updated_at, tp.node, tp.status,
+       tt.dst_id AS lookup_id
+FROM tailnet_peers tp
+INNER JOIN tailnet_tunnels tt ON tp.id = tt.src_id
+WHERE tt.dst_id = ANY($1 :: uuid[])
+`
+
+type GetTailnetTunnelPeerBindingsBatchRow struct {
+	PeerID        uuid.UUID     `db:"peer_id" json:"peer_id"`
+	CoordinatorID uuid.UUID     `db:"coordinator_id" json:"coordinator_id"`
+	UpdatedAt     time.Time     `db:"updated_at" json:"updated_at"`
+	Node          []byte        `db:"node" json:"node"`
+	Status        TailnetStatus `db:"status" json:"status"`
+	LookupID      uuid.UUID     `db:"lookup_id" json:"lookup_id"`
+}
+
+func (q *sqlQuerier) GetTailnetTunnelPeerBindingsBatch(ctx context.Context, ids []uuid.UUID) ([]GetTailnetTunnelPeerBindingsBatchRow, error) {
+	rows, err := q.db.QueryContext(ctx, getTailnetTunnelPeerBindingsBatch, pq.Array(ids))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetTailnetTunnelPeerBindingsBatchRow
+	for rows.Next() {
+		var i GetTailnetTunnelPeerBindingsBatchRow
+		if err := rows.Scan(
+			&i.PeerID,
+			&i.CoordinatorID,
+			&i.UpdatedAt,
+			&i.Node,
+			&i.Status,
+			&i.LookupID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getTailnetTunnelPeerIDs = `-- name: GetTailnetTunnelPeerIDs :many
 SELECT dst_id as peer_id, coordinator_id, updated_at
 FROM tailnet_tunnels
@@ -18278,6 +18414,49 @@ func (q *sqlQuerier) GetTailnetTunnelPeerIDs(ctx context.Context, srcID uuid.UUI
 	for rows.Next() {
 		var i GetTailnetTunnelPeerIDsRow
 		if err := rows.Scan(&i.PeerID, &i.CoordinatorID, &i.UpdatedAt); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getTailnetTunnelPeerIDsBatch = `-- name: GetTailnetTunnelPeerIDsBatch :many
+SELECT src_id AS lookup_id, dst_id AS peer_id, coordinator_id, updated_at
+FROM tailnet_tunnels WHERE src_id = ANY($1 :: uuid[])
+UNION ALL
+SELECT dst_id AS lookup_id, src_id AS peer_id, coordinator_id, updated_at
+FROM tailnet_tunnels WHERE dst_id = ANY($1 :: uuid[])
+`
+
+type GetTailnetTunnelPeerIDsBatchRow struct {
+	LookupID      uuid.UUID `db:"lookup_id" json:"lookup_id"`
+	PeerID        uuid.UUID `db:"peer_id" json:"peer_id"`
+	CoordinatorID uuid.UUID `db:"coordinator_id" json:"coordinator_id"`
+	UpdatedAt     time.Time `db:"updated_at" json:"updated_at"`
+}
+
+func (q *sqlQuerier) GetTailnetTunnelPeerIDsBatch(ctx context.Context, ids []uuid.UUID) ([]GetTailnetTunnelPeerIDsBatchRow, error) {
+	rows, err := q.db.QueryContext(ctx, getTailnetTunnelPeerIDsBatch, pq.Array(ids))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetTailnetTunnelPeerIDsBatchRow
+	for rows.Next() {
+		var i GetTailnetTunnelPeerIDsBatchRow
+		if err := rows.Scan(
+			&i.LookupID,
+			&i.PeerID,
+			&i.CoordinatorID,
+			&i.UpdatedAt,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, i)
@@ -23423,6 +23602,51 @@ func (q *sqlQuerier) UpdateVolumeResourceMonitor(ctx context.Context, arg Update
 		arg.UpdatedAt,
 		arg.State,
 		arg.DebouncedUntil,
+	)
+	return err
+}
+
+const batchUpdateWorkspaceAgentConnections = `-- name: BatchUpdateWorkspaceAgentConnections :exec
+WITH agents AS (
+	SELECT
+		unnest($1::uuid[]) AS id,
+		unnest($2::timestamptz[]) AS first_connected_at,
+		unnest($3::timestamptz[]) AS last_connected_at,
+		unnest($4::uuid[]) AS last_connected_replica_id,
+		unnest($5::timestamptz[]) AS disconnected_at,
+		unnest($6::timestamptz[]) AS updated_at
+)
+UPDATE
+	workspace_agents wa
+SET
+	first_connected_at = a.first_connected_at,
+	last_connected_at = a.last_connected_at,
+	last_connected_replica_id = a.last_connected_replica_id,
+	disconnected_at = a.disconnected_at,
+	updated_at = a.updated_at
+FROM
+	agents a
+WHERE
+	wa.id = a.id
+`
+
+type BatchUpdateWorkspaceAgentConnectionsParams struct {
+	ID                     []uuid.UUID `db:"id" json:"id"`
+	FirstConnectedAt       []time.Time `db:"first_connected_at" json:"first_connected_at"`
+	LastConnectedAt        []time.Time `db:"last_connected_at" json:"last_connected_at"`
+	LastConnectedReplicaID []uuid.UUID `db:"last_connected_replica_id" json:"last_connected_replica_id"`
+	DisconnectedAt         []time.Time `db:"disconnected_at" json:"disconnected_at"`
+	UpdatedAt              []time.Time `db:"updated_at" json:"updated_at"`
+}
+
+func (q *sqlQuerier) BatchUpdateWorkspaceAgentConnections(ctx context.Context, arg BatchUpdateWorkspaceAgentConnectionsParams) error {
+	_, err := q.db.ExecContext(ctx, batchUpdateWorkspaceAgentConnections,
+		pq.Array(arg.ID),
+		pq.Array(arg.FirstConnectedAt),
+		pq.Array(arg.LastConnectedAt),
+		pq.Array(arg.LastConnectedReplicaID),
+		pq.Array(arg.DisconnectedAt),
+		pq.Array(arg.UpdatedAt),
 	)
 	return err
 }

--- a/coderd/database/queries/tailnet.sql
+++ b/coderd/database/queries/tailnet.sql
@@ -118,6 +118,26 @@ WHERE id IN (
   WHERE tailnet_tunnels.dst_id = $1
 );
 
+-- name: GetTailnetTunnelPeerIDsBatch :many
+SELECT src_id AS lookup_id, dst_id AS peer_id, coordinator_id, updated_at
+FROM tailnet_tunnels WHERE src_id = ANY(@ids :: uuid[])
+UNION ALL
+SELECT dst_id AS lookup_id, src_id AS peer_id, coordinator_id, updated_at
+FROM tailnet_tunnels WHERE dst_id = ANY(@ids :: uuid[]);
+
+-- name: GetTailnetTunnelPeerBindingsBatch :many
+SELECT tp.id AS peer_id, tp.coordinator_id, tp.updated_at, tp.node, tp.status,
+       tt.src_id AS lookup_id
+FROM tailnet_peers tp
+INNER JOIN tailnet_tunnels tt ON tp.id = tt.dst_id
+WHERE tt.src_id = ANY(@ids :: uuid[])
+UNION ALL
+SELECT tp.id AS peer_id, tp.coordinator_id, tp.updated_at, tp.node, tp.status,
+       tt.dst_id AS lookup_id
+FROM tailnet_peers tp
+INNER JOIN tailnet_tunnels tt ON tp.id = tt.src_id
+WHERE tt.dst_id = ANY(@ids :: uuid[]);
+
 -- For PG Coordinator HTMLDebug
 
 -- name: GetAllTailnetCoordinators :many

--- a/enterprise/tailnet/pgcoord.go
+++ b/enterprise/tailnet/pgcoord.go
@@ -150,11 +150,11 @@ func newPGCoordInternal(
 		logger:           logger,
 		pubsub:           ps,
 		store:            store,
-		binder:           newBinder(ctx, logger, id, store, bCh, fHB),
+		binder:           newBinder(ctx, logger, id, store, bCh, fHB, numBinderWorkers),
 		bindings:         bCh,
 		newConnections:   cCh,
 		closeConnections: ccCh,
-		tunneler:         newTunneler(ctx, logger, id, store, sCh, fHB),
+		tunneler:         newTunneler(ctx, logger, id, store, sCh, fHB, numTunnelerWorkers),
 		tunnelerCh:       sCh,
 		handshaker:       newHandshaker(ctx, logger, id, ps, rfhCh, fHB),
 		handshakerCh:     rfhCh,
@@ -286,6 +286,7 @@ func newTunneler(ctx context.Context,
 	store database.Store,
 	updates <-chan tunnel,
 	startWorkers <-chan struct{},
+	numWorkers int,
 ) *tunneler {
 	s := &tunneler{
 		ctx:           ctx,
@@ -299,10 +300,10 @@ func newTunneler(ctx context.Context,
 	go s.handle()
 	// add to the waitgroup immediately to avoid any races waiting for it before
 	// the workers start.
-	s.workerWG.Add(numTunnelerWorkers)
+	s.workerWG.Add(numWorkers)
 	go func() {
 		<-startWorkers
-		for i := 0; i < numTunnelerWorkers; i++ {
+		for i := 0; i < numWorkers; i++ {
 			go s.worker()
 		}
 	}()
@@ -473,6 +474,7 @@ func newBinder(ctx context.Context,
 	store database.Store,
 	bindings <-chan binding,
 	startWorkers <-chan struct{},
+	numWorkers int,
 ) *binder {
 	b := &binder{
 		ctx:           ctx,
@@ -487,10 +489,10 @@ func newBinder(ctx context.Context,
 	go b.handleBindings()
 	// add to the waitgroup immediately to avoid any races waiting for it before
 	// the workers start.
-	b.workerWG.Add(numBinderWorkers)
+	b.workerWG.Add(numWorkers)
 	go func() {
 		<-startWorkers
-		for i := 0; i < numBinderWorkers; i++ {
+		for i := 0; i < numWorkers; i++ {
 			go b.worker()
 		}
 	}()
@@ -814,9 +816,10 @@ type querier struct {
 	heartbeats *heartbeats
 	updates    <-chan hbUpdate
 
-	mu      sync.Mutex
-	mappers map[mKey]*mapper
-	healthy bool
+	mu             sync.Mutex
+	mappers        map[mKey]*mapper
+	tunnelsByPeer  map[uuid.UUID]map[mKey]struct{} // remote peer → local mapper keys with tunnels
+	healthy        bool
 }
 
 func newQuerier(ctx context.Context,
@@ -843,6 +846,7 @@ func newQuerier(ctx context.Context,
 		workQ:            newWorkQ[querierWorkKey](ctx),
 		heartbeats:       newHeartbeats(ctx, logger, ps, store, self, updates, firstHeartbeat, clk),
 		mappers:          make(map[mKey]*mapper),
+		tunnelsByPeer:    make(map[uuid.UUID]map[mKey]struct{}),
 		updates:          updates,
 		healthy:          true, // assume we start healthy
 	}
@@ -925,6 +929,28 @@ func (q *querier) isHealthy() bool {
 	return q.healthy
 }
 
+// addTunnelPeerLocked adds mk to the set of local mappers interested in
+// updates for the given remote peer. Caller must hold q.mu.
+func (q *querier) addTunnelPeerLocked(peer uuid.UUID, mk mKey) {
+	s, ok := q.tunnelsByPeer[peer]
+	if !ok {
+		s = make(map[mKey]struct{})
+		q.tunnelsByPeer[peer] = s
+	}
+	s[mk] = struct{}{}
+}
+
+// removeTunnelsByMapperLocked removes mk from every entry in
+// tunnelsByPeer, cleaning up empty sets. Caller must hold q.mu.
+func (q *querier) removeTunnelsByMapperLocked(mk mKey) {
+	for peer, s := range q.tunnelsByPeer {
+		delete(s, mk)
+		if len(s) == 0 {
+			delete(q.tunnelsByPeer, peer)
+		}
+	}
+}
+
 func (q *querier) cleanupConn(c *connIO) {
 	logger := q.logger.With(slog.F("peer_id", c.UniqueID()))
 	q.mu.Lock()
@@ -944,8 +970,14 @@ func (q *querier) cleanupConn(c *connIO) {
 		logger.Error(q.ctx, "failed to close connIO", slog.Error(err))
 	}
 	delete(q.mappers, mk)
+	q.removeTunnelsByMapperLocked(mk)
 	q.logger.Debug(q.ctx, "removed mapper", slog.F("peer_id", c.UniqueID()))
 }
+
+// maxBatchSize is the maximum number of keys to process in a single batch
+// query.  The first key is acquired via the blocking acquire() call, and up to
+// maxBatchSize-1 additional same-type keys are grabbed opportunistically.
+const maxBatchSize = 50
 
 func (q *querier) worker() {
 	defer q.wg.Done()
@@ -960,14 +992,36 @@ func (q *querier) worker() {
 			// context expired
 			return
 		}
+		// Try to batch same-type work items together to reduce DB
+		// round trips under load.
+		extras := q.acquireSameType(qk)
+		allKeys := append([]querierWorkKey{qk}, extras...)
 		err = backoff.Retry(func() error {
-			return q.query(qk)
+			return q.queryBatch(allKeys)
 		}, bkoff)
 		if err != nil {
 			bkoff.Reset()
 		}
-		q.workQ.done(qk)
+		for _, k := range allKeys {
+			q.workQ.done(k)
+		}
 	}
+}
+
+// acquireSameType grabs up to maxBatchSize-1 additional pending keys of the
+// same type (peerUpdate or mappingQuery) as the given key.
+func (q *querier) acquireSameType(qk querierWorkKey) []querierWorkKey {
+	if qk.peerUpdate != uuid.Nil {
+		return q.workQ.acquireBatch(func(k querierWorkKey) bool {
+			return k.peerUpdate != uuid.Nil
+		}, maxBatchSize-1)
+	}
+	if uuid.UUID(qk.mappingQuery) != uuid.Nil {
+		return q.workQ.acquireBatch(func(k querierWorkKey) bool {
+			return uuid.UUID(k.mappingQuery) != uuid.Nil
+		}, maxBatchSize-1)
+	}
+	return nil
 }
 
 func (q *querier) query(qk querierWorkKey) error {
@@ -981,6 +1035,37 @@ func (q *querier) query(qk querierWorkKey) error {
 	return backoff.Permanent(xerrors.Errorf("bad querierWorkKey %v", qk))
 }
 
+// queryBatch dispatches a batch of same-type work keys to the appropriate batch
+// handler.  Falls back to single-key queries when the batch has only one item.
+func (q *querier) queryBatch(keys []querierWorkKey) error {
+	if len(keys) == 0 {
+		return nil
+	}
+	// All keys in the batch are the same type (enforced by acquireSameType).
+	first := keys[0]
+	if first.peerUpdate != uuid.Nil {
+		peers := make([]uuid.UUID, 0, len(keys))
+		for _, k := range keys {
+			peers = append(peers, k.peerUpdate)
+		}
+		if len(peers) == 1 {
+			return q.peerUpdate(peers[0])
+		}
+		return q.peerUpdateBatch(peers)
+	}
+	if uuid.UUID(first.mappingQuery) != uuid.Nil {
+		mkeys := make([]mKey, 0, len(keys))
+		for _, k := range keys {
+			mkeys = append(mkeys, k.mappingQuery)
+		}
+		if len(mkeys) == 1 {
+			return q.mappingQuery(mkeys[0])
+		}
+		return q.mappingQueryBatch(mkeys)
+	}
+	return q.query(first)
+}
+
 // peerUpdate is work scheduled in response to a new peer->binding.  We need to find out all the
 // other peers that share a tunnel with the indicated peer, and then schedule a mapping update on
 // each, so that they can find out about the new binding.
@@ -992,6 +1077,14 @@ func (q *querier) peerUpdate(peer uuid.UUID) error {
 		return err
 	}
 	logger.Debug(q.ctx, "queried peers that share a tunnel", slog.F("num_peers", len(others)))
+	q.mu.Lock()
+	for _, other := range others {
+		mk := mKey(other.PeerID)
+		if _, ok := q.mappers[mk]; ok {
+			q.addTunnelPeerLocked(peer, mk)
+		}
+	}
+	q.mu.Unlock()
 	for _, other := range others {
 		logger.Debug(q.ctx, "got tunnel peer", slog.F("other_id", other.PeerID))
 		q.workQ.enqueue(querierWorkKey{mappingQuery: mKey(other.PeerID)})
@@ -1006,6 +1099,15 @@ func (q *querier) peerUpdate(peer uuid.UUID) error {
 func (q *querier) mappingQuery(peer mKey) error {
 	logger := q.logger.With(slog.F("peer_id", uuid.UUID(peer)))
 	logger.Debug(q.ctx, "querying mappings")
+	// Fast path: skip DB query if no local mapper exists for this peer.
+	q.mu.Lock()
+	_, ok := q.mappers[peer]
+	q.mu.Unlock()
+	if !ok {
+		logger.Debug(q.ctx, "skipping query for missing mapper")
+		return nil
+	}
+
 	bindings, err := q.store.GetTailnetTunnelPeerBindings(q.ctx, uuid.UUID(peer))
 	logger.Debug(q.ctx, "queried mappings", slog.F("num_mappings", len(bindings)))
 	if err != nil && !xerrors.Is(err, sql.ErrNoRows) {
@@ -1025,6 +1127,108 @@ func (q *querier) mappingQuery(peer mKey) error {
 	}
 	logger.Debug(q.ctx, "sending mappings", slog.F("mapping_len", len(mappings)))
 	return agpl.SendCtx(mpr.ctx, mpr.mappings, mappings)
+}
+
+// peerUpdateBatch is the batched version of peerUpdate.  It queries tunnel
+// peers for multiple peer IDs in a single DB round trip.
+func (q *querier) peerUpdateBatch(peers []uuid.UUID) error {
+	q.logger.Debug(q.ctx, "batch querying peers that share tunnels",
+		slog.F("num_peers", len(peers)))
+	others, err := q.store.GetTailnetTunnelPeerIDsBatch(q.ctx, peers)
+	if err != nil && !xerrors.Is(err, sql.ErrNoRows) {
+		return xerrors.Errorf("get tunnel peer IDs batch: %w", err)
+	}
+	q.logger.Debug(q.ctx, "batch queried tunnel peers",
+		slog.F("num_results", len(others)))
+	for _, other := range others {
+		q.workQ.enqueue(querierWorkKey{mappingQuery: mKey(other.PeerID)})
+	}
+	return nil
+}
+
+// mappingQueryBatch is the batched version of mappingQuery.  It queries
+// bindings for multiple peers in a single DB round trip and dispatches each
+// peer's mappings to its mapper.
+func (q *querier) mappingQueryBatch(peers []mKey) error {
+	// Filter to peers with active mappers before hitting the DB.
+	q.mu.Lock()
+	active := make([]uuid.UUID, 0, len(peers))
+	activeKeys := make([]mKey, 0, len(peers))
+	for _, p := range peers {
+		if _, ok := q.mappers[p]; ok {
+			active = append(active, uuid.UUID(p))
+			activeKeys = append(activeKeys, p)
+		}
+	}
+	q.mu.Unlock()
+	if len(active) == 0 {
+		q.logger.Debug(q.ctx, "batch mapping query: no active mappers")
+		return nil
+	}
+
+	q.logger.Debug(q.ctx, "batch querying mappings",
+		slog.F("num_peers", len(active)))
+	bindings, err := q.store.GetTailnetTunnelPeerBindingsBatch(q.ctx, active)
+	if err != nil && !xerrors.Is(err, sql.ErrNoRows) {
+		return xerrors.Errorf("get tunnel peer bindings batch: %w", err)
+	}
+	q.logger.Debug(q.ctx, "batch queried mappings",
+		slog.F("num_bindings", len(bindings)))
+
+	// Group bindings by lookup_id (the peer that needs the mapping).
+	grouped := make(map[uuid.UUID][]database.GetTailnetTunnelPeerBindingsBatchRow)
+	for _, b := range bindings {
+		grouped[b.LookupID] = append(grouped[b.LookupID], b)
+	}
+
+	// Dispatch each peer's mappings to its mapper.
+	for _, mk := range activeKeys {
+		peerID := uuid.UUID(mk)
+		rows := grouped[peerID]
+		mappings, err := q.batchBindingsToMappings(rows)
+		if err != nil {
+			q.logger.Debug(q.ctx, "failed to convert batch mappings",
+				slog.F("peer_id", peerID), slog.Error(err))
+			return err
+		}
+		q.mu.Lock()
+		mpr, ok := q.mappers[mk]
+		q.mu.Unlock()
+		if !ok {
+			continue
+		}
+		if err := agpl.SendCtx(mpr.ctx, mpr.mappings, mappings); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// batchBindingsToMappings converts batch binding rows to mappings, analogous
+// to bindingsToMappings but for the batch row type.
+func (q *querier) batchBindingsToMappings(bindings []database.GetTailnetTunnelPeerBindingsBatchRow) ([]mapping, error) {
+	slog.Helper()
+	mappings := make([]mapping, 0, len(bindings))
+	for _, binding := range bindings {
+		node := new(proto.Node)
+		err := gProto.Unmarshal(binding.Node, node)
+		if err != nil {
+			q.logger.Error(q.ctx, "failed to unmarshal node", slog.Error(err))
+			return nil, backoff.Permanent(err)
+		}
+		kind := proto.CoordinateResponse_PeerUpdate_NODE
+		if binding.Status == database.TailnetStatusLost {
+			kind = proto.CoordinateResponse_PeerUpdate_LOST
+		}
+		mappings = append(mappings, mapping{
+			peer:        binding.PeerID,
+			coordinator: binding.CoordinatorID,
+			updatedAt:   binding.UpdatedAt,
+			node:        node,
+			kind:        kind,
+		})
+	}
+	return mappings, nil
 }
 
 func (q *querier) bindingsToMappings(bindings []database.GetTailnetTunnelPeerBindingsRow) ([]mapping, error) {
@@ -1159,6 +1363,19 @@ func (q *querier) listenPeer(_ context.Context, msg []byte, err error) {
 	logger := q.logger.With(slog.F("peer_id", peer))
 	logger.Debug(q.ctx, "got peer update")
 
+	// Fast path: skip the peer update entirely when this coordinator has
+	// no local mapper for the peer and no known tunnel partners that are
+	// local mappers. Without local interest the resulting DB query and
+	// enqueued mapping queries would all be no-ops.
+	q.mu.Lock()
+	_, isLocalMapper := q.mappers[mKey(peer)]
+	_, hasTunnelPartners := q.tunnelsByPeer[peer]
+	q.mu.Unlock()
+	if !isLocalMapper && !hasTunnelPartners {
+		logger.Debug(q.ctx, "skipping peer update: no local interest")
+		return
+	}
+
 	// we know that this peer has an updated node mapping, but we don't yet know who to send that
 	// update to. We need to query the database to find all the other peers that share a tunnel with
 	// this one, and then run mapping queries against all of them.
@@ -1182,6 +1399,19 @@ func (q *querier) listenTunnel(_ context.Context, msg []byte, err error) {
 		return
 	}
 	q.logger.Debug(q.ctx, "got tunnel update", slog.F("peers", peers))
+	// Update the reverse tunnel index so listenPeer knows which remote
+	// peers have local interest.
+	if len(peers) == 2 {
+		q.mu.Lock()
+		for i := 0; i < 2; i++ {
+			other := 1 - i
+			mk := mKey(peers[i])
+			if _, ok := q.mappers[mk]; ok {
+				q.addTunnelPeerLocked(peers[other], mk)
+			}
+		}
+		q.mu.Unlock()
+	}
 	for _, peer := range peers {
 		mk := mKey(peer)
 		q.mu.Lock()
@@ -1197,8 +1427,12 @@ func (q *querier) listenTunnel(_ context.Context, msg []byte, err error) {
 }
 
 func (q *querier) listenReadyForHandshake(_ context.Context, msg []byte, err error) {
-	if err != nil && !xerrors.Is(err, pubsub.ErrDroppedMessages) {
-		q.logger.Warn(q.ctx, "unhandled pubsub error", slog.Error(err))
+	if err != nil {
+		if xerrors.Is(err, pubsub.ErrDroppedMessages) {
+			q.logger.Warn(q.ctx, "pubsub dropped ready-for-handshake messages")
+		} else {
+			q.logger.Warn(q.ctx, "unhandled pubsub error", slog.Error(err))
+		}
 		return
 	}
 
@@ -1229,6 +1463,9 @@ func (q *querier) listenReadyForHandshake(_ context.Context, msg []byte, err err
 func (q *querier) resyncPeerMappings() {
 	q.mu.Lock()
 	defer q.mu.Unlock()
+	// Clear the reverse tunnel index; it will be repopulated organically
+	// as peerUpdate and listenTunnel callbacks fire.
+	q.tunnelsByPeer = make(map[uuid.UUID]map[mKey]struct{})
 	for mk := range q.mappers {
 		q.workQ.enqueue(querierWorkKey{mappingQuery: mk})
 	}
@@ -1367,6 +1604,7 @@ type workQ[K queueKey] struct {
 
 	cond       *sync.Cond
 	pending    []K
+	pendingSet map[K]struct{}
 	inProgress map[K]bool
 }
 
@@ -1374,6 +1612,7 @@ func newWorkQ[K queueKey](ctx context.Context) *workQ[K] {
 	q := &workQ[K]{
 		ctx:        ctx,
 		cond:       sync.NewCond(&sync.Mutex{}),
+		pendingSet: make(map[K]struct{}),
 		inProgress: make(map[K]bool),
 	}
 	// wake up all waiting workers when context is done
@@ -1390,13 +1629,12 @@ func newWorkQ[K queueKey](ctx context.Context) *workQ[K] {
 func (q *workQ[K]) enqueue(key K) {
 	q.cond.L.Lock()
 	defer q.cond.L.Unlock()
-	for _, mk := range q.pending {
-		if mk == key {
-			// already pending, no-op
-			return
-		}
+	if _, ok := q.pendingSet[key]; ok {
+		// already pending, no-op
+		return
 	}
 	q.pending = append(q.pending, key)
+	q.pendingSet[key] = struct{}{}
 	q.cond.Signal()
 }
 
@@ -1416,6 +1654,7 @@ func (q *workQ[K]) acquire() (key K, err error) {
 		_, ok := q.inProgress[mk]
 		if !ok {
 			q.pending = append(q.pending[:i], q.pending[i+1:]...)
+			delete(q.pendingSet, mk)
 			q.inProgress[mk] = true
 			return mk, nil
 		}
@@ -1425,6 +1664,31 @@ func (q *workQ[K]) acquire() (key K, err error) {
 }
 
 // workAvailable returns true if there is work we can do.  Must be called while holding q.cond.L
+// acquireBatch acquires up to max additional pending keys matching matchFn, moving them to
+// inProgress.  Must be called without holding the lock.  Returns nil if none match.  Caller must
+// call done() for each returned key.
+func (q *workQ[K]) acquireBatch(matchFn func(K) bool, max int) []K {
+	q.cond.L.Lock()
+	defer q.cond.L.Unlock()
+	var batch []K
+	remaining := make([]K, 0, len(q.pending))
+	for _, k := range q.pending {
+		if len(batch) >= max {
+			remaining = append(remaining, k)
+			continue
+		}
+		if _, inProg := q.inProgress[k]; !inProg && matchFn(k) {
+			batch = append(batch, k)
+			q.inProgress[k] = true
+			delete(q.pendingSet, k)
+		} else {
+			remaining = append(remaining, k)
+		}
+	}
+	q.pending = remaining
+	return batch
+}
+
 func (q workQ[K]) workAvailable() bool {
 	for _, mk := range q.pending {
 		_, ok := q.inProgress[mk]


### PR DESCRIPTION
- Skip DB query in mappingQuery when no local mapper exists (~90% reduction)
- Add O(1) set-based dedup to workQ (eliminates O(n²) during bursts)
- Add tunnelsByPeer reverse index to skip irrelevant peer updates
- Batch tailnet tunnel queries for reduced DB round-trips
- Fix listenReadyForHandshake to return early on ErrDroppedMessages

<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->
