### PR TITLE
feat: improve coordinator peer mapping performance

### DIFF
--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -3561,18 +3561,18 @@ func (q *querier) GetTailnetPeers(ctx context.Context, id uuid.UUID) ([]database
 	return q.db.GetTailnetPeers(ctx, id)
 }
 
-func (q *querier) GetTailnetTunnelPeerBindings(ctx context.Context, srcID uuid.UUID) ([]database.GetTailnetTunnelPeerBindingsRow, error) {
+func (q *querier) GetTailnetTunnelPeerBindingsBatch(ctx context.Context, ids []uuid.UUID) ([]database.GetTailnetTunnelPeerBindingsBatchRow, error) {
 	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceTailnetCoordinator); err != nil {
 		return nil, err
 	}
-	return q.db.GetTailnetTunnelPeerBindings(ctx, srcID)
+	return q.db.GetTailnetTunnelPeerBindingsBatch(ctx, ids)
 }
 
-func (q *querier) GetTailnetTunnelPeerIDs(ctx context.Context, srcID uuid.UUID) ([]database.GetTailnetTunnelPeerIDsRow, error) {
+func (q *querier) GetTailnetTunnelPeerIDsBatch(ctx context.Context, ids []uuid.UUID) ([]database.GetTailnetTunnelPeerIDsBatchRow, error) {
 	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceTailnetCoordinator); err != nil {
 		return nil, err
 	}
-	return q.db.GetTailnetTunnelPeerIDs(ctx, srcID)
+	return q.db.GetTailnetTunnelPeerIDsBatch(ctx, ids)
 }
 
 func (q *querier) GetTaskByID(ctx context.Context, id uuid.UUID) (database.Task, error) {

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -3603,14 +3603,12 @@ func (s *MethodTestSuite) TestTailnetFunctions() {
 	s.Run("GetTailnetPeers", s.Subtest(func(_ database.Store, check *expects) {
 		check.Args(uuid.New()).
 			Asserts(rbac.ResourceTailnetCoordinator, policy.ActionRead)
+	s.Run("GetTailnetTunnelPeerBindingsBatch", s.Subtest(func(_ database.Store, check *expects) {
+		check.Args([]uuid.UUID{uuid.New()}).Asserts(rbac.ResourceTailnetCoordinator, policy.ActionRead)
 	}))
-	s.Run("GetTailnetTunnelPeerBindings", s.Subtest(func(_ database.Store, check *expects) {
-		check.Args(uuid.New()).
-			Asserts(rbac.ResourceTailnetCoordinator, policy.ActionRead)
+	s.Run("GetTailnetTunnelPeerIDsBatch", s.Subtest(func(_ database.Store, check *expects) {
+		check.Args([]uuid.UUID{uuid.New()}).Asserts(rbac.ResourceTailnetCoordinator, policy.ActionRead)
 	}))
-	s.Run("GetTailnetTunnelPeerIDs", s.Subtest(func(_ database.Store, check *expects) {
-		check.Args(uuid.New()).
-			Asserts(rbac.ResourceTailnetCoordinator, policy.ActionRead)
 	}))
 	s.Run("GetAllTailnetCoordinators", s.Subtest(func(_ database.Store, check *expects) {
 		check.Args().

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -3603,12 +3603,12 @@ func (s *MethodTestSuite) TestTailnetFunctions() {
 	s.Run("GetTailnetPeers", s.Subtest(func(_ database.Store, check *expects) {
 		check.Args(uuid.New()).
 			Asserts(rbac.ResourceTailnetCoordinator, policy.ActionRead)
+	}))
 	s.Run("GetTailnetTunnelPeerBindingsBatch", s.Subtest(func(_ database.Store, check *expects) {
 		check.Args([]uuid.UUID{uuid.New()}).Asserts(rbac.ResourceTailnetCoordinator, policy.ActionRead)
 	}))
 	s.Run("GetTailnetTunnelPeerIDsBatch", s.Subtest(func(_ database.Store, check *expects) {
 		check.Args([]uuid.UUID{uuid.New()}).Asserts(rbac.ResourceTailnetCoordinator, policy.ActionRead)
-	}))
 	}))
 	s.Run("GetAllTailnetCoordinators", s.Subtest(func(_ database.Store, check *expects) {
 		check.Args().

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -2152,19 +2152,19 @@ func (m queryMetricsStore) GetTailnetPeers(ctx context.Context, id uuid.UUID) ([
 	return r0, r1
 }
 
-func (m queryMetricsStore) GetTailnetTunnelPeerBindings(ctx context.Context, srcID uuid.UUID) ([]database.GetTailnetTunnelPeerBindingsRow, error) {
+func (m queryMetricsStore) GetTailnetTunnelPeerBindingsBatch(ctx context.Context, ids []uuid.UUID) ([]database.GetTailnetTunnelPeerBindingsBatchRow, error) {
 	start := time.Now()
-	r0, r1 := m.s.GetTailnetTunnelPeerBindings(ctx, srcID)
-	m.queryLatencies.WithLabelValues("GetTailnetTunnelPeerBindings").Observe(time.Since(start).Seconds())
-	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetTailnetTunnelPeerBindings").Inc()
+	r0, r1 := m.s.GetTailnetTunnelPeerBindingsBatch(ctx, ids)
+	m.queryLatencies.WithLabelValues("GetTailnetTunnelPeerBindingsBatch").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetTailnetTunnelPeerBindingsBatch").Inc()
 	return r0, r1
 }
 
-func (m queryMetricsStore) GetTailnetTunnelPeerIDs(ctx context.Context, srcID uuid.UUID) ([]database.GetTailnetTunnelPeerIDsRow, error) {
+func (m queryMetricsStore) GetTailnetTunnelPeerIDsBatch(ctx context.Context, ids []uuid.UUID) ([]database.GetTailnetTunnelPeerIDsBatchRow, error) {
 	start := time.Now()
-	r0, r1 := m.s.GetTailnetTunnelPeerIDs(ctx, srcID)
-	m.queryLatencies.WithLabelValues("GetTailnetTunnelPeerIDs").Observe(time.Since(start).Seconds())
-	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetTailnetTunnelPeerIDs").Inc()
+	r0, r1 := m.s.GetTailnetTunnelPeerIDsBatch(ctx, ids)
+	m.queryLatencies.WithLabelValues("GetTailnetTunnelPeerIDsBatch").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetTailnetTunnelPeerIDsBatch").Inc()
 	return r0, r1
 }
 

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -3979,34 +3979,34 @@ func (mr *MockStoreMockRecorder) GetTailnetPeers(ctx, id any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTailnetPeers", reflect.TypeOf((*MockStore)(nil).GetTailnetPeers), ctx, id)
 }
 
-// GetTailnetTunnelPeerBindings mocks base method.
-func (m *MockStore) GetTailnetTunnelPeerBindings(ctx context.Context, srcID uuid.UUID) ([]database.GetTailnetTunnelPeerBindingsRow, error) {
+// GetTailnetTunnelPeerBindingsBatch mocks base method.
+func (m *MockStore) GetTailnetTunnelPeerBindingsBatch(ctx context.Context, ids []uuid.UUID) ([]database.GetTailnetTunnelPeerBindingsBatchRow, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTailnetTunnelPeerBindings", ctx, srcID)
-	ret0, _ := ret[0].([]database.GetTailnetTunnelPeerBindingsRow)
+	ret := m.ctrl.Call(m, "GetTailnetTunnelPeerBindingsBatch", ctx, ids)
+	ret0, _ := ret[0].([]database.GetTailnetTunnelPeerBindingsBatchRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetTailnetTunnelPeerBindings indicates an expected call of GetTailnetTunnelPeerBindings.
-func (mr *MockStoreMockRecorder) GetTailnetTunnelPeerBindings(ctx, srcID any) *gomock.Call {
+// GetTailnetTunnelPeerBindingsBatch indicates an expected call of GetTailnetTunnelPeerBindingsBatch.
+func (mr *MockStoreMockRecorder) GetTailnetTunnelPeerBindingsBatch(ctx, ids any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTailnetTunnelPeerBindings", reflect.TypeOf((*MockStore)(nil).GetTailnetTunnelPeerBindings), ctx, srcID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTailnetTunnelPeerBindingsBatch", reflect.TypeOf((*MockStore)(nil).GetTailnetTunnelPeerBindingsBatch), ctx, ids)
 }
 
-// GetTailnetTunnelPeerIDs mocks base method.
-func (m *MockStore) GetTailnetTunnelPeerIDs(ctx context.Context, srcID uuid.UUID) ([]database.GetTailnetTunnelPeerIDsRow, error) {
+// GetTailnetTunnelPeerIDsBatch mocks base method.
+func (m *MockStore) GetTailnetTunnelPeerIDsBatch(ctx context.Context, ids []uuid.UUID) ([]database.GetTailnetTunnelPeerIDsBatchRow, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTailnetTunnelPeerIDs", ctx, srcID)
-	ret0, _ := ret[0].([]database.GetTailnetTunnelPeerIDsRow)
+	ret := m.ctrl.Call(m, "GetTailnetTunnelPeerIDsBatch", ctx, ids)
+	ret0, _ := ret[0].([]database.GetTailnetTunnelPeerIDsBatchRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetTailnetTunnelPeerIDs indicates an expected call of GetTailnetTunnelPeerIDs.
-func (mr *MockStoreMockRecorder) GetTailnetTunnelPeerIDs(ctx, srcID any) *gomock.Call {
+// GetTailnetTunnelPeerIDsBatch indicates an expected call of GetTailnetTunnelPeerIDsBatch.
+func (mr *MockStoreMockRecorder) GetTailnetTunnelPeerIDsBatch(ctx, ids any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTailnetTunnelPeerIDs", reflect.TypeOf((*MockStore)(nil).GetTailnetTunnelPeerIDs), ctx, srcID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTailnetTunnelPeerIDsBatch", reflect.TypeOf((*MockStore)(nil).GetTailnetTunnelPeerIDsBatch), ctx, ids)
 }
 
 // GetTaskByID mocks base method.

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -458,8 +458,8 @@ type sqlcQuerier interface {
 	// Used for recovery after coderd crashes or long hangs.
 	GetStaleChats(ctx context.Context, staleThreshold time.Time) ([]Chat, error)
 	GetTailnetPeers(ctx context.Context, id uuid.UUID) ([]TailnetPeer, error)
-	GetTailnetTunnelPeerBindings(ctx context.Context, srcID uuid.UUID) ([]GetTailnetTunnelPeerBindingsRow, error)
-	GetTailnetTunnelPeerIDs(ctx context.Context, srcID uuid.UUID) ([]GetTailnetTunnelPeerIDsRow, error)
+	GetTailnetTunnelPeerBindingsBatch(ctx context.Context, ids []uuid.UUID) ([]GetTailnetTunnelPeerBindingsBatchRow, error)
+	GetTailnetTunnelPeerIDsBatch(ctx context.Context, ids []uuid.UUID) ([]GetTailnetTunnelPeerIDsBatchRow, error)
 	GetTaskByID(ctx context.Context, id uuid.UUID) (Task, error)
 	GetTaskByOwnerIDAndName(ctx context.Context, arg GetTaskByOwnerIDAndNameParams) (Task, error)
 	GetTaskByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) (Task, error)

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -17636,43 +17636,44 @@ func (q *sqlQuerier) GetTailnetPeers(ctx context.Context, id uuid.UUID) ([]Tailn
 	return items, nil
 }
 
-const getTailnetTunnelPeerBindings = `-- name: GetTailnetTunnelPeerBindings :many
-SELECT id AS peer_id, coordinator_id, updated_at, node, status
-FROM tailnet_peers
-WHERE id IN (
-  SELECT dst_id as peer_id
-  FROM tailnet_tunnels
-  WHERE tailnet_tunnels.src_id = $1
+const getTailnetTunnelPeerBindingsBatch = `-- name: GetTailnetTunnelPeerBindingsBatch :many
+SELECT tp.id AS peer_id, tp.coordinator_id, tp.updated_at, tp.node, tp.status,
+       tunnels.lookup_id
+FROM (
+  SELECT dst_id AS peer_id, src_id AS lookup_id
+  FROM tailnet_tunnels WHERE src_id = ANY($1 :: uuid[])
   UNION
-  SELECT src_id as peer_id
-  FROM tailnet_tunnels
-  WHERE tailnet_tunnels.dst_id = $1
-)
+  SELECT src_id AS peer_id, dst_id AS lookup_id
+  FROM tailnet_tunnels WHERE dst_id = ANY($1 :: uuid[])
+) tunnels
+INNER JOIN tailnet_peers tp ON tp.id = tunnels.peer_id
 `
 
-type GetTailnetTunnelPeerBindingsRow struct {
+type GetTailnetTunnelPeerBindingsBatchRow struct {
 	PeerID        uuid.UUID     `db:"peer_id" json:"peer_id"`
 	CoordinatorID uuid.UUID     `db:"coordinator_id" json:"coordinator_id"`
 	UpdatedAt     time.Time     `db:"updated_at" json:"updated_at"`
 	Node          []byte        `db:"node" json:"node"`
 	Status        TailnetStatus `db:"status" json:"status"`
+	LookupID      uuid.UUID     `db:"lookup_id" json:"lookup_id"`
 }
 
-func (q *sqlQuerier) GetTailnetTunnelPeerBindings(ctx context.Context, srcID uuid.UUID) ([]GetTailnetTunnelPeerBindingsRow, error) {
-	rows, err := q.db.QueryContext(ctx, getTailnetTunnelPeerBindings, srcID)
+func (q *sqlQuerier) GetTailnetTunnelPeerBindingsBatch(ctx context.Context, ids []uuid.UUID) ([]GetTailnetTunnelPeerBindingsBatchRow, error) {
+	rows, err := q.db.QueryContext(ctx, getTailnetTunnelPeerBindingsBatch, pq.Array(ids))
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []GetTailnetTunnelPeerBindingsRow
+	var items []GetTailnetTunnelPeerBindingsBatchRow
 	for rows.Next() {
-		var i GetTailnetTunnelPeerBindingsRow
+		var i GetTailnetTunnelPeerBindingsBatchRow
 		if err := rows.Scan(
 			&i.PeerID,
 			&i.CoordinatorID,
 			&i.UpdatedAt,
 			&i.Node,
 			&i.Status,
+			&i.LookupID,
 		); err != nil {
 			return nil, err
 		}
@@ -17687,32 +17688,36 @@ func (q *sqlQuerier) GetTailnetTunnelPeerBindings(ctx context.Context, srcID uui
 	return items, nil
 }
 
-const getTailnetTunnelPeerIDs = `-- name: GetTailnetTunnelPeerIDs :many
-SELECT dst_id as peer_id, coordinator_id, updated_at
-FROM tailnet_tunnels
-WHERE tailnet_tunnels.src_id = $1
-UNION
-SELECT src_id as peer_id, coordinator_id, updated_at
-FROM tailnet_tunnels
-WHERE tailnet_tunnels.dst_id = $1
+const getTailnetTunnelPeerIDsBatch = `-- name: GetTailnetTunnelPeerIDsBatch :many
+SELECT src_id AS lookup_id, dst_id AS peer_id, coordinator_id, updated_at
+FROM tailnet_tunnels WHERE src_id = ANY($1 :: uuid[])
+UNION ALL
+SELECT dst_id AS lookup_id, src_id AS peer_id, coordinator_id, updated_at
+FROM tailnet_tunnels WHERE dst_id = ANY($1 :: uuid[])
 `
 
-type GetTailnetTunnelPeerIDsRow struct {
+type GetTailnetTunnelPeerIDsBatchRow struct {
+	LookupID      uuid.UUID `db:"lookup_id" json:"lookup_id"`
 	PeerID        uuid.UUID `db:"peer_id" json:"peer_id"`
 	CoordinatorID uuid.UUID `db:"coordinator_id" json:"coordinator_id"`
 	UpdatedAt     time.Time `db:"updated_at" json:"updated_at"`
 }
 
-func (q *sqlQuerier) GetTailnetTunnelPeerIDs(ctx context.Context, srcID uuid.UUID) ([]GetTailnetTunnelPeerIDsRow, error) {
-	rows, err := q.db.QueryContext(ctx, getTailnetTunnelPeerIDs, srcID)
+func (q *sqlQuerier) GetTailnetTunnelPeerIDsBatch(ctx context.Context, ids []uuid.UUID) ([]GetTailnetTunnelPeerIDsBatchRow, error) {
+	rows, err := q.db.QueryContext(ctx, getTailnetTunnelPeerIDsBatch, pq.Array(ids))
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []GetTailnetTunnelPeerIDsRow
+	var items []GetTailnetTunnelPeerIDsBatchRow
 	for rows.Next() {
-		var i GetTailnetTunnelPeerIDsRow
-		if err := rows.Scan(&i.PeerID, &i.CoordinatorID, &i.UpdatedAt); err != nil {
+		var i GetTailnetTunnelPeerIDsBatchRow
+		if err := rows.Scan(
+			&i.LookupID,
+			&i.PeerID,
+			&i.CoordinatorID,
+			&i.UpdatedAt,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/coderd/database/queries/tailnet.sql
+++ b/coderd/database/queries/tailnet.sql
@@ -96,28 +96,6 @@ DELETE
 FROM tailnet_tunnels
 WHERE coordinator_id = $1 and src_id = $2;
 
--- name: GetTailnetTunnelPeerIDs :many
-SELECT dst_id as peer_id, coordinator_id, updated_at
-FROM tailnet_tunnels
-WHERE tailnet_tunnels.src_id = $1
-UNION
-SELECT src_id as peer_id, coordinator_id, updated_at
-FROM tailnet_tunnels
-WHERE tailnet_tunnels.dst_id = $1;
-
--- name: GetTailnetTunnelPeerBindings :many
-SELECT id AS peer_id, coordinator_id, updated_at, node, status
-FROM tailnet_peers
-WHERE id IN (
-  SELECT dst_id as peer_id
-  FROM tailnet_tunnels
-  WHERE tailnet_tunnels.src_id = $1
-  UNION
-  SELECT src_id as peer_id
-  FROM tailnet_tunnels
-  WHERE tailnet_tunnels.dst_id = $1
-);
-
 -- For PG Coordinator HTMLDebug
 
 -- name: GetAllTailnetCoordinators :many
@@ -128,3 +106,22 @@ SELECT * FROM tailnet_peers;
 
 -- name: GetAllTailnetTunnels :many
 SELECT * FROM tailnet_tunnels;
+
+-- name: GetTailnetTunnelPeerIDsBatch :many
+SELECT src_id AS lookup_id, dst_id AS peer_id, coordinator_id, updated_at
+FROM tailnet_tunnels WHERE src_id = ANY(@ids :: uuid[])
+UNION ALL
+SELECT dst_id AS lookup_id, src_id AS peer_id, coordinator_id, updated_at
+FROM tailnet_tunnels WHERE dst_id = ANY(@ids :: uuid[]);
+
+-- name: GetTailnetTunnelPeerBindingsBatch :many
+SELECT tp.id AS peer_id, tp.coordinator_id, tp.updated_at, tp.node, tp.status,
+       tunnels.lookup_id
+FROM (
+  SELECT dst_id AS peer_id, src_id AS lookup_id
+  FROM tailnet_tunnels WHERE src_id = ANY(@ids :: uuid[])
+  UNION
+  SELECT src_id AS peer_id, dst_id AS lookup_id
+  FROM tailnet_tunnels WHERE dst_id = ANY(@ids :: uuid[])
+) tunnels
+INNER JOIN tailnet_peers tp ON tp.id = tunnels.peer_id;

--- a/enterprise/tailnet/pgcoord.go
+++ b/enterprise/tailnet/pgcoord.go
@@ -3,6 +3,7 @@ package tailnet
 import (
 	"context"
 	"database/sql"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -807,7 +808,8 @@ type querier struct {
 	newConnections   chan *connIO
 	closeConnections chan *connIO
 
-	workQ *workQ[querierWorkKey]
+	peerUpdateQ *workQ[querierWorkKey]
+	mappingQ    *workQ[querierWorkKey]
 
 	wg sync.WaitGroup
 
@@ -840,7 +842,8 @@ func newQuerier(ctx context.Context,
 		store:            store,
 		newConnections:   newConnections,
 		closeConnections: closeConnections,
-		workQ:            newWorkQ[querierWorkKey](ctx),
+		peerUpdateQ:      newWorkQ[querierWorkKey](ctx),
+		mappingQ:         newWorkQ[querierWorkKey](ctx),
 		heartbeats:       newHeartbeats(ctx, logger, ps, store, self, updates, firstHeartbeat, clk),
 		mappers:          make(map[mKey]*mapper),
 		updates:          updates,
@@ -848,12 +851,13 @@ func newQuerier(ctx context.Context,
 	}
 	q.subscribe()
 
-	q.wg.Add(2 + numWorkers)
+	q.wg.Add(2 + 2*numWorkers)
 	go func() {
 		<-firstHeartbeat
 		go q.handleIncoming()
 		for i := 0; i < numWorkers; i++ {
-			go q.worker()
+			go q.peerUpdateWorker()
+			go q.mappingWorker()
 		}
 		go q.handleUpdates()
 	}()
@@ -913,7 +917,7 @@ func (q *querier) newConn(c *connIO) {
 		}
 	}
 	q.mappers[mk] = mpr
-	q.workQ.enqueue(querierWorkKey{
+	q.mappingQ.enqueue(querierWorkKey{
 		mappingQuery: mk,
 	})
 	q.logger.Debug(q.ctx, "added new mapper", slog.F("peer_id", c.UniqueID()))
@@ -947,87 +951,153 @@ func (q *querier) cleanupConn(c *connIO) {
 	q.logger.Debug(q.ctx, "removed mapper", slog.F("peer_id", c.UniqueID()))
 }
 
-func (q *querier) worker() {
+// maxBatchSize is the maximum number of keys to process in a single batch
+// query.  The first key is acquired via the blocking acquire() call, and up to
+// maxBatchSize-1 additional same-type keys are grabbed opportunistically.
+const maxBatchSize = 50
+
+func (q *querier) peerUpdateWorker() {
 	defer q.wg.Done()
-	defer q.logger.Debug(q.ctx, "worker exited")
+	defer q.logger.Debug(q.ctx, "peerUpdate worker exited")
 	eb := backoff.NewExponentialBackOff()
 	eb.MaxElapsedTime = 0 // retry indefinitely
 	eb.MaxInterval = dbMaxBackoff
 	bkoff := backoff.WithContext(eb, q.ctx)
 	for {
-		qk, err := q.workQ.acquire()
+		allKeys, err := q.peerUpdateQ.acquireBatch(maxBatchSize)
 		if err != nil {
-			// context expired
 			return
 		}
+		peers := make([]uuid.UUID, 0, len(allKeys))
+		for _, k := range allKeys {
+			peers = append(peers, k.peerUpdate)
+		}
 		err = backoff.Retry(func() error {
-			return q.query(qk)
+			return q.peerUpdate(peers)
 		}, bkoff)
 		if err != nil {
 			bkoff.Reset()
 		}
-		q.workQ.done(qk)
+		q.peerUpdateQ.done(allKeys...)
 	}
 }
 
-func (q *querier) query(qk querierWorkKey) error {
-	if uuid.UUID(qk.mappingQuery) != uuid.Nil {
-		return q.mappingQuery(qk.mappingQuery)
+func (q *querier) mappingWorker() {
+	defer q.wg.Done()
+	defer q.logger.Debug(q.ctx, "mapping worker exited")
+	eb := backoff.NewExponentialBackOff()
+	eb.MaxElapsedTime = 0 // retry indefinitely
+	eb.MaxInterval = dbMaxBackoff
+	bkoff := backoff.WithContext(eb, q.ctx)
+	for {
+		allKeys, err := q.mappingQ.acquireBatch(maxBatchSize)
+		if err != nil {
+			return
+		}
+		mkeys := make([]mKey, 0, len(allKeys))
+		for _, k := range allKeys {
+			mkeys = append(mkeys, k.mappingQuery)
+		}
+		err = backoff.Retry(func() error {
+			return q.mappingQuery(mkeys)
+		}, bkoff)
+		if err != nil {
+			bkoff.Reset()
+		}
+		q.mappingQ.done(allKeys...)
 	}
-	if qk.peerUpdate != uuid.Nil {
-		return q.peerUpdate(qk.peerUpdate)
-	}
-	q.logger.Critical(q.ctx, "bad querierWorkKey", slog.F("work_key", qk))
-	return backoff.Permanent(xerrors.Errorf("bad querierWorkKey %v", qk))
 }
 
 // peerUpdate is work scheduled in response to a new peer->binding.  We need to find out all the
 // other peers that share a tunnel with the indicated peer, and then schedule a mapping update on
 // each, so that they can find out about the new binding.
-func (q *querier) peerUpdate(peer uuid.UUID) error {
-	logger := q.logger.With(slog.F("peer_id", peer))
-	logger.Debug(q.ctx, "querying peers that share a tunnel")
-	others, err := q.store.GetTailnetTunnelPeerIDs(q.ctx, peer)
+// mappingQuery queries bindings for the given peers and dispatches each
+// that is, all the peers that it shares a tunnel with and their current node mappings (if they
+// exist).  It then sends the mapping snapshot to the corresponding mapper, where it will get
+// transmitted to the peer.
+// peerUpdate queries tunnel peers for the given peer IDs and enqueues
+// mapping queries for each tunnel partner found.
+func (q *querier) peerUpdate(peers []uuid.UUID) error {
+	q.logger.Debug(q.ctx, "batch querying peers that share tunnels",
+		slog.F("num_peers", len(peers)))
+	others, err := q.store.GetTailnetTunnelPeerIDsBatch(q.ctx, peers)
 	if err != nil && !xerrors.Is(err, sql.ErrNoRows) {
-		return err
+		return xerrors.Errorf("get tunnel peer IDs batch: %w", err)
 	}
-	logger.Debug(q.ctx, "queried peers that share a tunnel", slog.F("num_peers", len(others)))
+	q.logger.Debug(q.ctx, "batch queried tunnel peers",
+		slog.F("num_results", len(others)))
+	q.mu.Lock()
 	for _, other := range others {
-		logger.Debug(q.ctx, "got tunnel peer", slog.F("other_id", other.PeerID))
-		q.workQ.enqueue(querierWorkKey{mappingQuery: mKey(other.PeerID)})
+		mk := mKey(other.PeerID)
+		if _, ok := q.mappers[mk]; ok {
+			q.mappingQ.enqueue(querierWorkKey{mappingQuery: mk})
+		}
+	}
+	q.mu.Unlock()
+	return nil
+}
+
+// mappingQuery queries the database for the node mappings that each given
+// peer should know about and sends them to the corresponding mapper.
+func (q *querier) mappingQuery(peers []mKey) error {
+	// Filter to peers with active mappers before hitting the DB.
+	q.mu.Lock()
+	active := make([]uuid.UUID, 0, len(peers))
+	activeKeys := make([]mKey, 0, len(peers))
+	for _, p := range peers {
+		if _, ok := q.mappers[p]; ok {
+			active = append(active, uuid.UUID(p))
+			activeKeys = append(activeKeys, p)
+		}
+	}
+	q.mu.Unlock()
+	if len(active) == 0 {
+		q.logger.Debug(q.ctx, "batch mapping query: no active mappers")
+		return nil
+	}
+
+	q.logger.Debug(q.ctx, "batch querying mappings",
+		slog.F("num_peers", len(active)))
+	bindings, err := q.store.GetTailnetTunnelPeerBindingsBatch(q.ctx, active)
+	if err != nil && !xerrors.Is(err, sql.ErrNoRows) {
+		return xerrors.Errorf("get tunnel peer bindings batch: %w", err)
+	}
+	q.logger.Debug(q.ctx, "batch queried mappings",
+		slog.F("num_bindings", len(bindings)))
+
+	// Group bindings by lookup_id (the peer that needs the mapping).
+	grouped := make(map[uuid.UUID][]database.GetTailnetTunnelPeerBindingsBatchRow)
+	for _, b := range bindings {
+		grouped[b.LookupID] = append(grouped[b.LookupID], b)
+	}
+
+	// Dispatch each peer's mappings to its mapper.
+	for _, mk := range activeKeys {
+		peerID := uuid.UUID(mk)
+		rows := grouped[peerID]
+		mappings, err := q.bindingsToMappings(rows)
+		if err != nil {
+			q.logger.Error(q.ctx, "failed to convert batch mappings",
+				slog.F("peer_id", peerID), slog.Error(err))
+			continue
+		}
+		q.mu.Lock()
+		mpr, ok := q.mappers[mk]
+		q.mu.Unlock()
+		if !ok {
+			continue
+		}
+		if err := agpl.SendCtx(mpr.ctx, mpr.mappings, mappings); err != nil {
+			q.logger.Debug(q.ctx, "failed to send mappings to peer",
+				slog.F("peer_id", peerID), slog.Error(err))
+			continue
+		}
 	}
 	return nil
 }
 
-// mappingQuery queries the database for all the mappings that the given peer should know about,
-// that is, all the peers that it shares a tunnel with and their current node mappings (if they
-// exist).  It then sends the mapping snapshot to the corresponding mapper, where it will get
-// transmitted to the peer.
-func (q *querier) mappingQuery(peer mKey) error {
-	logger := q.logger.With(slog.F("peer_id", uuid.UUID(peer)))
-	logger.Debug(q.ctx, "querying mappings")
-	bindings, err := q.store.GetTailnetTunnelPeerBindings(q.ctx, uuid.UUID(peer))
-	logger.Debug(q.ctx, "queried mappings", slog.F("num_mappings", len(bindings)))
-	if err != nil && !xerrors.Is(err, sql.ErrNoRows) {
-		return err
-	}
-	mappings, err := q.bindingsToMappings(bindings)
-	if err != nil {
-		logger.Debug(q.ctx, "failed to convert mappings", slog.Error(err))
-		return err
-	}
-	q.mu.Lock()
-	mpr, ok := q.mappers[peer]
-	q.mu.Unlock()
-	if !ok {
-		logger.Debug(q.ctx, "query for missing mapper")
-		return nil
-	}
-	logger.Debug(q.ctx, "sending mappings", slog.F("mapping_len", len(mappings)))
-	return agpl.SendCtx(mpr.ctx, mpr.mappings, mappings)
-}
-
-func (q *querier) bindingsToMappings(bindings []database.GetTailnetTunnelPeerBindingsRow) ([]mapping, error) {
+// bindingsToMappings converts binding rows to mappings.
+func (q *querier) bindingsToMappings(bindings []database.GetTailnetTunnelPeerBindingsBatchRow) ([]mapping, error) {
 	slog.Helper()
 	mappings := make([]mapping, 0, len(bindings))
 	for _, binding := range bindings {
@@ -1162,7 +1232,7 @@ func (q *querier) listenPeer(_ context.Context, msg []byte, err error) {
 	// we know that this peer has an updated node mapping, but we don't yet know who to send that
 	// update to. We need to query the database to find all the other peers that share a tunnel with
 	// this one, and then run mapping queries against all of them.
-	q.workQ.enqueue(querierWorkKey{peerUpdate: peer})
+	q.peerUpdateQ.enqueue(querierWorkKey{peerUpdate: peer})
 }
 
 func (q *querier) listenTunnel(_ context.Context, msg []byte, err error) {
@@ -1192,13 +1262,17 @@ func (q *querier) listenTunnel(_ context.Context, msg []byte, err error) {
 				slog.F("peer_id", peer))
 			continue
 		}
-		q.workQ.enqueue(querierWorkKey{mappingQuery: mk})
+		q.mappingQ.enqueue(querierWorkKey{mappingQuery: mk})
 	}
 }
 
 func (q *querier) listenReadyForHandshake(_ context.Context, msg []byte, err error) {
-	if err != nil && !xerrors.Is(err, pubsub.ErrDroppedMessages) {
-		q.logger.Warn(q.ctx, "unhandled pubsub error", slog.Error(err))
+	if err != nil {
+		if xerrors.Is(err, pubsub.ErrDroppedMessages) {
+			q.logger.Warn(q.ctx, "pubsub dropped ready-for-handshake messages")
+		} else {
+			q.logger.Warn(q.ctx, "unhandled pubsub error", slog.Error(err))
+		}
 		return
 	}
 
@@ -1230,7 +1304,7 @@ func (q *querier) resyncPeerMappings() {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	for mk := range q.mappers {
-		q.workQ.enqueue(querierWorkKey{mappingQuery: mk})
+		q.mappingQ.enqueue(querierWorkKey{mappingQuery: mk})
 	}
 }
 
@@ -1390,56 +1464,63 @@ func newWorkQ[K queueKey](ctx context.Context) *workQ[K] {
 func (q *workQ[K]) enqueue(key K) {
 	q.cond.L.Lock()
 	defer q.cond.L.Unlock()
-	for _, mk := range q.pending {
-		if mk == key {
-			// already pending, no-op
-			return
-		}
+	if slices.Contains(q.pending, key) {
+		return
 	}
 	q.pending = append(q.pending, key)
 	q.cond.Signal()
 }
 
-// acquire gets a new key to begin working on.  This call blocks until work is available.  After acquiring a key, the
-// worker MUST call done() with the same key to mark it complete and allow new pending work to be acquired for the key.
-// An error is returned if the workQ context is canceled to unblock waiting workers.
-func (q *workQ[K]) acquire() (key K, err error) {
+// acquireBatch blocks until at least one pending key is available, then
+// returns up to limit keys, moving them to inProgress. Caller must call
+// done() for each returned key.
+func (q *workQ[K]) acquireBatch(limit int) ([]K, error) {
 	q.cond.L.Lock()
 	defer q.cond.L.Unlock()
-	for !q.workAvailable() && q.ctx.Err() == nil {
+	for {
+		if q.ctx.Err() != nil {
+			return nil, q.ctx.Err()
+		}
+		var batch []K
+		remaining := make([]K, 0, len(q.pending))
+		for _, k := range q.pending {
+			if len(batch) >= limit {
+				remaining = append(remaining, k)
+				continue
+			}
+			if _, inProg := q.inProgress[k]; inProg {
+				remaining = append(remaining, k)
+				continue
+			}
+			batch = append(batch, k)
+			q.inProgress[k] = true
+		}
+		q.pending = remaining
+		if len(batch) > 0 {
+			return batch, nil
+		}
 		q.cond.Wait()
 	}
-	if q.ctx.Err() != nil {
-		return key, q.ctx.Err()
-	}
-	for i, mk := range q.pending {
-		_, ok := q.inProgress[mk]
-		if !ok {
-			q.pending = append(q.pending[:i], q.pending[i+1:]...)
-			q.inProgress[mk] = true
-			return mk, nil
-		}
-	}
-	// this should not be possible because we are holding the lock when we exit the loop that waits
-	panic("woke with no work available")
 }
 
-// workAvailable returns true if there is work we can do.  Must be called while holding q.cond.L
-func (q workQ[K]) workAvailable() bool {
-	for _, mk := range q.pending {
-		_, ok := q.inProgress[mk]
-		if !ok {
-			return true
-		}
+// acquire blocks until a work item is available and returns it. After
+// acquiring a key, the worker MUST call done() with the same key to mark
+// it complete and allow new pending work to be acquired for the key.
+func (q *workQ[K]) acquire() (key K, err error) {
+	items, err := q.acquireBatch(1)
+	if err != nil {
+		return key, err
 	}
-	return false
+	return items[0], nil
 }
 
 // done marks the key completed; MUST be called after acquire() for each key.
-func (q *workQ[K]) done(key K) {
+func (q *workQ[K]) done(keys ...K) {
 	q.cond.L.Lock()
 	defer q.cond.L.Unlock()
-	delete(q.inProgress, key)
+	for _, key := range keys {
+		delete(q.inProgress, key)
+	}
 	q.cond.Signal()
 }
 

--- a/enterprise/tailnet/pgcoord.go
+++ b/enterprise/tailnet/pgcoord.go
@@ -1417,15 +1417,6 @@ type mapping struct {
 	kind        proto.CoordinateResponse_PeerUpdate_Kind
 }
 
-// querierWorkKey describes two kinds of work the querier needs to do.  If peerUpdate
-// is not uuid.Nil, then the querier needs to find all tunnel peers of the given peer and
-// mark them for a mapping query.  If mappingQuery is not uuid.Nil, then the querier has to
-// query the mappings of the tunnel peers of the given peer.
-type querierWorkKey struct {
-	peerUpdate   uuid.UUID
-	mappingQuery mKey
-}
-
 type queueKey interface {
 	bKey | tKey | uuid.UUID | mKey
 }

--- a/enterprise/tailnet/pgcoord.go
+++ b/enterprise/tailnet/pgcoord.go
@@ -3,6 +3,7 @@ package tailnet
 import (
 	"context"
 	"database/sql"
+	"math"
 	"slices"
 	"strings"
 	"sync"
@@ -808,8 +809,8 @@ type querier struct {
 	newConnections   chan *connIO
 	closeConnections chan *connIO
 
-	peerUpdateQ *workQ[querierWorkKey]
-	mappingQ    *workQ[querierWorkKey]
+	peerUpdateQ *workQ[uuid.UUID]
+	mappingQ    *workQ[mKey]
 
 	wg sync.WaitGroup
 
@@ -842,8 +843,8 @@ func newQuerier(ctx context.Context,
 		store:            store,
 		newConnections:   newConnections,
 		closeConnections: closeConnections,
-		peerUpdateQ:      newWorkQ[querierWorkKey](ctx),
-		mappingQ:         newWorkQ[querierWorkKey](ctx),
+		peerUpdateQ:      newWorkQ[uuid.UUID](ctx),
+		mappingQ:         newWorkQ[mKey](ctx),
 		heartbeats:       newHeartbeats(ctx, logger, ps, store, self, updates, firstHeartbeat, clk),
 		mappers:          make(map[mKey]*mapper),
 		updates:          updates,
@@ -851,18 +852,21 @@ func newQuerier(ctx context.Context,
 	}
 	q.subscribe()
 
-	q.wg.Add(2 + numWorkers)
+	// For an odd number of workers we allocate more to the mapping workers since they're busier.
+	mappingWorkers := int(math.Ceil(float64(numWorkers) / 2))
+	peerWorkers := numWorkers - mappingWorkers
+
+	q.wg.Add(2 + mappingWorkers + peerWorkers)
 	go func() {
 		<-firstHeartbeat
 		go q.handleIncoming()
-		for i := 0; i < numWorkers; i++ {
-			if i%2 == 0 {
-				go q.mappingWorker()
-			} else {
-				go q.peerUpdateWorker()
-			}
-		}
 		go q.handleUpdates()
+		for range mappingWorkers {
+			go q.mappingWorker()
+		}
+		for range peerWorkers {
+			go q.peerUpdateWorker()
+		}
 	}()
 	return q
 }
@@ -920,9 +924,7 @@ func (q *querier) newConn(c *connIO) {
 		}
 	}
 	q.mappers[mk] = mpr
-	q.mappingQ.enqueue(querierWorkKey{
-		mappingQuery: mk,
-	})
+	q.mappingQ.enqueue(mk)
 	q.logger.Debug(q.ctx, "added new mapper", slog.F("peer_id", c.UniqueID()))
 }
 
@@ -971,9 +973,7 @@ func (q *querier) peerUpdateWorker() {
 			return
 		}
 		peers := make([]uuid.UUID, 0, len(allKeys))
-		for _, k := range allKeys {
-			peers = append(peers, k.peerUpdate)
-		}
+		peers = append(peers, allKeys...)
 		err = backoff.Retry(func() error {
 			return q.peerUpdate(peers)
 		}, bkoff)
@@ -997,9 +997,7 @@ func (q *querier) mappingWorker() {
 			return
 		}
 		mkeys := make([]mKey, 0, len(allKeys))
-		for _, k := range allKeys {
-			mkeys = append(mkeys, k.mappingQuery)
-		}
+		mkeys = append(mkeys, allKeys...)
 		err = backoff.Retry(func() error {
 			return q.mappingQuery(mkeys)
 		}, bkoff)
@@ -1026,7 +1024,7 @@ func (q *querier) peerUpdate(peers []uuid.UUID) error {
 	for _, other := range others {
 		mk := mKey(other.PeerID)
 		if _, ok := q.mappers[mk]; ok {
-			q.mappingQ.enqueue(querierWorkKey{mappingQuery: mk})
+			q.mappingQ.enqueue(mk)
 		}
 	}
 	q.mu.Unlock()
@@ -1230,7 +1228,7 @@ func (q *querier) listenPeer(_ context.Context, msg []byte, err error) {
 	// we know that this peer has an updated node mapping, but we don't yet know who to send that
 	// update to. We need to query the database to find all the other peers that share a tunnel with
 	// this one, and then run mapping queries against all of them.
-	q.peerUpdateQ.enqueue(querierWorkKey{peerUpdate: peer})
+	q.peerUpdateQ.enqueue(peer)
 }
 
 func (q *querier) listenTunnel(_ context.Context, msg []byte, err error) {
@@ -1260,7 +1258,7 @@ func (q *querier) listenTunnel(_ context.Context, msg []byte, err error) {
 				slog.F("peer_id", peer))
 			continue
 		}
-		q.mappingQ.enqueue(querierWorkKey{mappingQuery: mk})
+		q.mappingQ.enqueue(mk)
 	}
 }
 
@@ -1302,7 +1300,7 @@ func (q *querier) resyncPeerMappings() {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	for mk := range q.mappers {
-		q.mappingQ.enqueue(querierWorkKey{mappingQuery: mk})
+		q.mappingQ.enqueue(mk)
 	}
 }
 
@@ -1429,7 +1427,7 @@ type querierWorkKey struct {
 }
 
 type queueKey interface {
-	bKey | tKey | querierWorkKey
+	bKey | tKey | uuid.UUID | mKey
 }
 
 // workQ allows scheduling work based on a key.  Multiple enqueue requests for the same key are coalesced, and
@@ -1459,13 +1457,15 @@ func newWorkQ[K queueKey](ctx context.Context) *workQ[K] {
 }
 
 // enqueue adds the key to the workQ if it is not already pending.
-func (q *workQ[K]) enqueue(key K) {
+func (q *workQ[K]) enqueue(keys ...K) {
 	q.cond.L.Lock()
 	defer q.cond.L.Unlock()
-	if slices.Contains(q.pending, key) {
-		return
+	for _, key := range keys {
+		if slices.Contains(q.pending, key) {
+			continue
+		}
+		q.pending = append(q.pending, key)
 	}
-	q.pending = append(q.pending, key)
 	q.cond.Signal()
 }
 

--- a/enterprise/tailnet/pgcoord.go
+++ b/enterprise/tailnet/pgcoord.go
@@ -955,8 +955,7 @@ func (q *querier) cleanupConn(c *connIO) {
 }
 
 // maxBatchSize is the maximum number of keys to process in a single batch
-// query.  The first key is acquired via the blocking acquire() call, and up to
-// maxBatchSize-1 additional same-type keys are grabbed opportunistically.
+// query.
 const maxBatchSize = 50
 
 func (q *querier) peerUpdateWorker() {
@@ -1014,12 +1013,6 @@ func (q *querier) mappingWorker() {
 // peerUpdate is work scheduled in response to a new peer->binding.  We need to find out all the
 // other peers that share a tunnel with the indicated peer, and then schedule a mapping update on
 // each, so that they can find out about the new binding.
-// mappingQuery queries bindings for the given peers and dispatches each
-// that is, all the peers that it shares a tunnel with and their current node mappings (if they
-// exist).  It then sends the mapping snapshot to the corresponding mapper, where it will get
-// transmitted to the peer.
-// peerUpdate queries tunnel peers for the given peer IDs and enqueues
-// mapping queries for each tunnel partner found.
 func (q *querier) peerUpdate(peers []uuid.UUID) error {
 	q.logger.Debug(q.ctx, "batch querying peers that share tunnels",
 		slog.F("num_peers", len(peers)))
@@ -1040,8 +1033,10 @@ func (q *querier) peerUpdate(peers []uuid.UUID) error {
 	return nil
 }
 
-// mappingQuery queries the database for the node mappings that each given
-// peer should know about and sends them to the corresponding mapper.
+// mappingQuery queries bindings for the given peers and dispatches each
+// that is, all the peers that it shares a tunnel with and their current node mappings (if they
+// exist).  It then sends the mapping snapshot to the corresponding mapper, where it will get
+// transmitted to the peer.
 func (q *querier) mappingQuery(peers []mKey) error {
 	// Filter to peers with active mappers before hitting the DB.
 	q.mu.Lock()

--- a/enterprise/tailnet/pgcoord.go
+++ b/enterprise/tailnet/pgcoord.go
@@ -1033,7 +1033,7 @@ func (q *querier) peerUpdate(peers []uuid.UUID) error {
 	return nil
 }
 
-// mappingQuery queries bindings for the given peers and dispatches each
+// mappingQuery queries the database for all the mappings that the given peers should know about,
 // that is, all the peers that it shares a tunnel with and their current node mappings (if they
 // exist).  It then sends the mapping snapshot to the corresponding mapper, where it will get
 // transmitted to the peer.
@@ -1472,6 +1472,7 @@ func (q *workQ[K]) enqueue(key K) {
 // acquireBatch blocks until at least one pending key is available, then
 // returns up to limit keys, moving them to inProgress. Caller must call
 // done() for each returned key.
+// An error is returned if the workQ context is canceled to unblock waiting workers.
 func (q *workQ[K]) acquireBatch(limit int) ([]K, error) {
 	q.cond.L.Lock()
 	defer q.cond.L.Unlock()

--- a/enterprise/tailnet/pgcoord.go
+++ b/enterprise/tailnet/pgcoord.go
@@ -851,13 +851,16 @@ func newQuerier(ctx context.Context,
 	}
 	q.subscribe()
 
-	q.wg.Add(2 + 2*numWorkers)
+	q.wg.Add(2 + numWorkers)
 	go func() {
 		<-firstHeartbeat
 		go q.handleIncoming()
 		for i := 0; i < numWorkers; i++ {
-			go q.peerUpdateWorker()
-			go q.mappingWorker()
+			if i%2 == 0 {
+				go q.mappingWorker()
+			} else {
+				go q.peerUpdateWorker()
+			}
 		}
 		go q.handleUpdates()
 	}()

--- a/enterprise/tailnet/pgcoord_internal_test.go
+++ b/enterprise/tailnet/pgcoord_internal_test.go
@@ -439,10 +439,10 @@ func TestWorkQ_AcquireBatch_RespectsMax(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	q := newWorkQ[querierWorkKey](ctx)
+	q := newWorkQ[uuid.UUID](ctx)
 
 	for i := 0; i < 5; i++ {
-		q.enqueue(querierWorkKey{peerUpdate: uuid.New()})
+		q.enqueue(uuid.New())
 	}
 
 	batch, err := q.acquireBatch(3)
@@ -468,26 +468,26 @@ func TestWorkQ_AcquireBatch_SkipsInProgress(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	q := newWorkQ[querierWorkKey](ctx)
+	q := newWorkQ[uuid.UUID](ctx)
 
 	peer1 := uuid.New()
 	peer2 := uuid.New()
-	q.enqueue(querierWorkKey{peerUpdate: peer1})
-	q.enqueue(querierWorkKey{peerUpdate: peer2})
+	q.enqueue(peer1)
+	q.enqueue(peer2)
 
 	// Acquire one item.
 	key, err := q.acquire()
 	require.NoError(t, err)
-	assert.Equal(t, peer1, key.peerUpdate)
+	assert.Equal(t, peer1, key)
 
 	// Re-enqueue peer1 (simulating a new update while in progress).
-	q.enqueue(querierWorkKey{peerUpdate: peer1})
+	q.enqueue(peer1)
 
 	// acquireBatch should only return peer2 (peer1 is in progress).
 	batch, err := q.acquireBatch(10)
 	require.NoError(t, err)
 	require.Len(t, batch, 1)
-	assert.Equal(t, peer2, batch[0].peerUpdate)
+	assert.Equal(t, peer2, batch[0])
 
 	q.done(key)
 	for _, k := range batch {
@@ -498,7 +498,7 @@ func TestWorkQ_AcquireBatch_SkipsInProgress(t *testing.T) {
 	batch, err = q.acquireBatch(10)
 	require.NoError(t, err)
 	require.Len(t, batch, 1)
-	assert.Equal(t, peer1, batch[0].peerUpdate)
+	assert.Equal(t, peer1, batch[0])
 }
 
 func TestWorkQ_Acquire_WrapsAcquireBatch(t *testing.T) {
@@ -506,13 +506,13 @@ func TestWorkQ_Acquire_WrapsAcquireBatch(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	q := newWorkQ[querierWorkKey](ctx)
+	q := newWorkQ[uuid.UUID](ctx)
 
 	peer := uuid.New()
-	q.enqueue(querierWorkKey{peerUpdate: peer})
+	q.enqueue(peer)
 
 	key, err := q.acquire()
 	require.NoError(t, err)
-	assert.Equal(t, peer, key.peerUpdate)
+	assert.Equal(t, peer, key)
 	q.done(key)
 }

--- a/enterprise/tailnet/pgcoord_internal_test.go
+++ b/enterprise/tailnet/pgcoord_internal_test.go
@@ -433,3 +433,86 @@ func TestPGCoordinatorUnhealthy(t *testing.T) {
 	_ = coordinator.Close()
 	require.Eventually(t, ctrl.Satisfied, testutil.WaitShort, testutil.IntervalFast)
 }
+
+func TestWorkQ_AcquireBatch_RespectsMax(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	q := newWorkQ[querierWorkKey](ctx)
+
+	for i := 0; i < 5; i++ {
+		q.enqueue(querierWorkKey{peerUpdate: uuid.New()})
+	}
+
+	batch, err := q.acquireBatch(3)
+	require.NoError(t, err)
+	assert.Len(t, batch, 3, "should respect max parameter")
+
+	for _, k := range batch {
+		q.done(k)
+	}
+
+	// Remaining 2 should be available.
+	batch, err = q.acquireBatch(10)
+	require.NoError(t, err)
+	assert.Len(t, batch, 2)
+
+	for _, k := range batch {
+		q.done(k)
+	}
+}
+
+func TestWorkQ_AcquireBatch_SkipsInProgress(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	q := newWorkQ[querierWorkKey](ctx)
+
+	peer1 := uuid.New()
+	peer2 := uuid.New()
+	q.enqueue(querierWorkKey{peerUpdate: peer1})
+	q.enqueue(querierWorkKey{peerUpdate: peer2})
+
+	// Acquire one item.
+	key, err := q.acquire()
+	require.NoError(t, err)
+	assert.Equal(t, peer1, key.peerUpdate)
+
+	// Re-enqueue peer1 (simulating a new update while in progress).
+	q.enqueue(querierWorkKey{peerUpdate: peer1})
+
+	// acquireBatch should only return peer2 (peer1 is in progress).
+	batch, err := q.acquireBatch(10)
+	require.NoError(t, err)
+	require.Len(t, batch, 1)
+	assert.Equal(t, peer2, batch[0].peerUpdate)
+
+	q.done(key)
+	for _, k := range batch {
+		q.done(k)
+	}
+
+	// Now peer1 (re-enqueued) should be available.
+	batch, err = q.acquireBatch(10)
+	require.NoError(t, err)
+	require.Len(t, batch, 1)
+	assert.Equal(t, peer1, batch[0].peerUpdate)
+}
+
+func TestWorkQ_Acquire_WrapsAcquireBatch(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	q := newWorkQ[querierWorkKey](ctx)
+
+	peer := uuid.New()
+	q.enqueue(querierWorkKey{peerUpdate: peer})
+
+	key, err := q.acquire()
+	require.NoError(t, err)
+	assert.Equal(t, peer, key.peerUpdate)
+	q.done(key)
+}

--- a/enterprise/tailnet/pgcoord_test.go
+++ b/enterprise/tailnet/pgcoord_test.go
@@ -50,7 +50,7 @@ func TestPGCoordinatorSingle_ClientWithoutAgent(t *testing.T) {
 	defer client.Close(ctx)
 	client.UpdateDERP(10)
 	require.Eventually(t, func() bool {
-		clients, err := store.GetTailnetTunnelPeerBindings(ctx, agentID)
+		clients, err := store.GetTailnetTunnelPeerBindingsBatch(ctx, []uuid.UUID{agentID})
 		if err != nil && !xerrors.Is(err, sql.ErrNoRows) {
 			t.Fatalf("database error: %v", err)
 		}
@@ -590,9 +590,8 @@ func TestPGCoordinator_Unhealthy(t *testing.T) {
 	mStore.EXPECT().CleanTailnetCoordinators(gomock.Any()).AnyTimes().Return(nil)
 	mStore.EXPECT().CleanTailnetLostPeers(gomock.Any()).AnyTimes().Return(nil)
 	mStore.EXPECT().CleanTailnetTunnels(gomock.Any()).AnyTimes().Return(nil)
-	mStore.EXPECT().GetTailnetTunnelPeerIDs(gomock.Any(), gomock.Any()).AnyTimes().Return(nil, nil)
-	mStore.EXPECT().GetTailnetTunnelPeerBindings(gomock.Any(), gomock.Any()).
-		AnyTimes().Return(nil, nil)
+	mStore.EXPECT().GetTailnetTunnelPeerIDsBatch(gomock.Any(), gomock.Any()).AnyTimes().Return(nil, nil)
+	mStore.EXPECT().GetTailnetTunnelPeerBindingsBatch(gomock.Any(), gomock.Any()).AnyTimes().Return(nil, nil)
 	mStore.EXPECT().DeleteTailnetPeer(gomock.Any(), gomock.Any()).
 		AnyTimes().Return(database.DeleteTailnetPeerRow{}, nil)
 	mStore.EXPECT().DeleteAllTailnetTunnels(gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
@@ -934,7 +933,7 @@ func assertEventuallyLost(ctx context.Context, t *testing.T, store database.Stor
 func assertEventuallyNoClientsForAgent(ctx context.Context, t *testing.T, store database.Store, agentID uuid.UUID) {
 	t.Helper()
 	assert.Eventually(t, func() bool {
-		clients, err := store.GetTailnetTunnelPeerIDs(ctx, agentID)
+		clients, err := store.GetTailnetTunnelPeerIDsBatch(ctx, []uuid.UUID{agentID})
 		if xerrors.Is(err, sql.ErrNoRows) {
 			return true
 		}


### PR DESCRIPTION
The two big changes here are:
- Skipping DB querying entirely for peers that aren't actually connected to our coordinator
- Opportunistically batching the queries for peers who are 

fixes https://github.com/coder/scaletest/issues/85