### PR TITLE
fix: guard per-chat cancelQueries to prevent 'Chat not found' race

### DIFF
--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -424,10 +424,17 @@ const AgentsPage: FC = () => {
 					// title generation finished, so its response carries
 					// the fallback title.
 					void cancelChatListQueries(queryClient);
-					void queryClient.cancelQueries({
-						queryKey: chatKey(updatedChat.id),
-						exact: true,
-					});
+					// Only cancel a per-chat refetch when the cache
+					// already has data. Cancelling a first-time fetch
+					// reverts the query to pending/idle with no data
+					// and no retry, which AgentDetail shows as
+					// "Chat not found".
+					if (queryClient.getQueryData(chatKey(updatedChat.id))) {
+						void queryClient.cancelQueries({
+							queryKey: chatKey(updatedChat.id),
+							exact: true,
+						});
+					}
 
 					// For "created" events, use a cross-page existence
 					// check and prepend only to the first page.


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

## Problem

When restoring a browser session, users intermittently see "Chat not found" for a chat that definitely exists. Refreshing fixes it.

## Root Cause

A race condition between the `chatQuery` fetch in `AgentDetail` and the `watchChats` WebSocket handler in `AgentsPage`.

1. User navigates to `/agents/:id`. `chatQuery` starts fetching (`pending/fetching`).
2. A WebSocket SSE event arrives for this chat (e.g. `status_change`).
3. The handler unconditionally calls `cancelQueries({ queryKey: chatKey(id) })`.
4. TanStack Query v5 reverts the query to `pending/idle` with `data: undefined` and no retry (`retry: false` global default).
5. `AgentDetail` checks `isLoading` (`isPending && isFetching` = `false`) → passes. Then `!chatQuery.data` → renders "Chat not found".

Refresh works because the cache is empty and the fetch completes before the WebSocket connects.

## Fix

Guard the `cancelQueries` call with `getQueryData` — only cancel a refetch when the cache already has data for that chat. This matches the existing `setQueryData` guard at line 488 which already skips writes when `previousChat` is undefined.

```diff
 void cancelChatListQueries(queryClient);
-void queryClient.cancelQueries({
-    queryKey: chatKey(updatedChat.id),
-    exact: true,
-});
+if (queryClient.getQueryData(chatKey(updatedChat.id))) {
+    void queryClient.cancelQueries({
+        queryKey: chatKey(updatedChat.id),
+        exact: true,
+    });
+}
```