### PR TITLE
fix(site/src/pages/AgentsPage): stabilize chat scroll on git watcher updates

### DIFF
--- a/site/src/pages/AgentsPage/AgentDetail.tsx
+++ b/site/src/pages/AgentsPage/AgentDetail.tsx
@@ -283,6 +283,28 @@ function resolveCompactionThreshold(
 	return config.compression_threshold;
 }
 
+/**
+ * Build a stable URL transform from primitive fields. Extracted as a
+ * module-level function so the React Compiler can place a cache guard
+ * around the call site using only the primitive arguments. An inline
+ * closure in the same position is not guarded because hook
+ * interleaving (useProxy, useQuery) prevents the compiler from
+ * grouping the closure with its dependencies.
+ */
+export function buildUrlTransform(
+	proxyHost: string | undefined,
+	agentName: string | undefined,
+	wsName: string | undefined,
+	wsOwner: string | undefined,
+): UrlTransform {
+	return (url) => {
+		if (!proxyHost || !agentName || !wsName || !wsOwner) {
+			return url;
+		}
+		return rewriteLocalhostURL(url, proxyHost, agentName, wsName, wsOwner);
+	};
+}
+
 const AgentDetail: FC = () => {
 	const { agentId } = useParams<{ agentId: string }>();
 	const {
@@ -429,20 +451,11 @@ const AgentDetail: FC = () => {
 	const proxyHost = proxy.preferredWildcardHostname;
 	const agentName = workspaceAgent?.name;
 	const wsName = workspace?.name;
-	const wsOwner = workspace?.owner_name;
+		const wsOwner = workspace?.owner_name;
 
-	const urlTransform: UrlTransform = (url) => {
-		if (!proxyHost || !agentName || !wsName || !wsOwner) {
-			return url;
-		}
-		return rewriteLocalhostURL(url, proxyHost, agentName, wsName, wsOwner);
-	};
-
-	const chatRecord = chatQuery.data;
-
-	// Initialize MCP selection from chat record or defaults.
-	const effectiveMCPServerIds = (() => {
-		if (selectedMCPServerIds !== null) {
+		const chatRecord = chatQuery.data;
+		// Initialize MCP selection from chat record or defaults.
+		const effectiveMCPServerIds = (() => {		if (selectedMCPServerIds !== null) {
 			return selectedMCPServerIds;
 		}
 		// If the chat has MCP server IDs recorded (even empty, meaning
@@ -825,7 +838,9 @@ const AgentDetail: FC = () => {
 		// Prefer the active git repo root so VS Code opens to the
 		// actual project directory, falling back to the agent's
 		// configured directory.
-		const repoRoots = Array.from(gitWatcher.repositories.keys()).sort();
+		const repoRoots = Array.from(
+			gitWatcher.repositoriesRef.current.keys(),
+		).sort();
 		const folder = repoRoots[0] ?? workspaceAgent.expanded_directory;
 
 		generateKeyMutation.mutate(undefined, {
@@ -956,7 +971,8 @@ const AgentDetail: FC = () => {
 			onSetShowSidebarPanel={handleSetShowSidebarPanel}
 			prNumber={prNumber}
 			diffStatusData={chatQuery.data?.diff_status}
-			gitWatcher={gitWatcher}
+			gitRepositories={gitWatcher.repositories}
+			gitRefresh={gitWatcher.refresh}
 			canOpenEditors={canOpenEditors}
 			canOpenWorkspace={canOpenWorkspace}
 			sshCommand={sshCommand}
@@ -975,7 +991,12 @@ const AgentDetail: FC = () => {
 			handleRegenerateTitle={handleRegenerateTitle}
 			isRegeneratingTitle={isRegeneratingThisChat}
 			isRegenerateTitleDisabled={isRegenerateTitleDisabled}
-			urlTransform={urlTransform}
+			urlTransformProps={{
+				proxyHost,
+				agentName,
+				wsName,
+				wsOwner,
+			}}
 			scrollContainerRef={scrollContainerRef}
 			scrollToBottomRef={scrollToBottomRef}
 			hasMoreMessages={chatMessagesQuery.hasNextPage ?? false}

--- a/site/src/pages/AgentsPage/components/AgentDetailView.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetailView.stories.tsx
@@ -70,11 +70,12 @@ const buildEditing = (
 	...overrides,
 });
 
-const buildGitWatcher = (): ComponentProps<
-	typeof AgentDetailView
->["gitWatcher"] => ({
-	repositories: new Map(),
-	refresh: fn(),
+const buildGitWatcherProps = (): Pick<
+	ComponentProps<typeof AgentDetailView>,
+	"gitRepositories" | "gitRefresh"
+> => ({
+	gitRepositories: new Map(),
+	gitRefresh: fn(),
 });
 
 const agentsRouting = [
@@ -128,7 +129,7 @@ const StoryAgentDetailView: FC<StoryProps> = ({ editing, ...overrides }) => {
 		diffStatusData: undefined as ComponentProps<
 			typeof AgentDetailView
 		>["diffStatusData"],
-		gitWatcher: buildGitWatcher(),
+		...buildGitWatcherProps(),
 		canOpenEditors: false,
 		canOpenWorkspace: false,
 		sshCommand: undefined as string | undefined,

--- a/site/src/pages/AgentsPage/components/AgentDetailView.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetailView.tsx
@@ -7,7 +7,6 @@ import {
 	useRef,
 	useState,
 } from "react";
-import type { UrlTransform } from "streamdown";
 import { cn } from "utils/cn";
 import { pageTitle } from "utils/page";
 import type * as TypesGen from "#/api/typesGenerated";
@@ -15,6 +14,7 @@ import type { ChatDiffStatus, ChatMessagePart } from "#/api/typesGenerated";
 import type { ModelSelectorOption } from "#/components/ai-elements";
 import { DesktopPanelContext } from "#/components/ai-elements/tool/DesktopPanelContext";
 import { Button } from "#/components/Button/Button";
+import { buildUrlTransform } from "../AgentDetail";
 import type { ChatDetailError } from "../utils/usageLimitMessage";
 import { AgentChatInput, type ChatMessageInputRef } from "./AgentChatInput";
 import type { useChatStore } from "./AgentDetail/ChatContext";
@@ -94,10 +94,8 @@ interface AgentDetailViewProps {
 	// Sidebar content data.
 	prNumber: number | undefined;
 	diffStatusData: ChatDiffStatus | undefined;
-	gitWatcher: {
-		repositories: ReadonlyMap<string, TypesGen.WorkspaceAgentRepoChanges>;
-		refresh: () => void;
-	};
+	gitRepositories: ReadonlyMap<string, TypesGen.WorkspaceAgentRepoChanges>;
+	gitRefresh: () => void;
 
 	// Workspace action handlers.
 	canOpenEditors: boolean;
@@ -130,7 +128,12 @@ interface AgentDetailViewProps {
 	isFetchingMoreMessages: boolean;
 	onFetchMoreMessages: () => void;
 
-	urlTransform?: UrlTransform;
+	urlTransformProps?: {
+		proxyHost: string | undefined;
+		agentName: string | undefined;
+		wsName: string | undefined;
+		wsOwner: string | undefined;
+	};
 
 	// MCP server state.
 	mcpServers: readonly TypesGen.MCPServerConfig[];
@@ -168,7 +171,8 @@ export const AgentDetailView: FC<AgentDetailViewProps> = ({
 	onSetShowSidebarPanel,
 	prNumber,
 	diffStatusData,
-	gitWatcher,
+	gitRepositories,
+	gitRefresh,
 	canOpenEditors,
 	canOpenWorkspace,
 	sshCommand,
@@ -190,7 +194,7 @@ export const AgentDetailView: FC<AgentDetailViewProps> = ({
 	hasMoreMessages,
 	isFetchingMoreMessages,
 	onFetchMoreMessages,
-	urlTransform,
+	urlTransformProps,
 	mcpServers,
 	selectedMCPServerIds,
 	onMCPSelectionChange,
@@ -221,6 +225,15 @@ export const AgentDetailView: FC<AgentDetailViewProps> = ({
 	};
 
 	// Compute local diff stats from git watcher unified diffs.
+
+	const urlTransform = urlTransformProps
+		? buildUrlTransform(
+				urlTransformProps.proxyHost,
+				urlTransformProps.agentName,
+				urlTransformProps.wsName,
+				urlTransformProps.wsOwner,
+			)
+		: undefined;
 
 	const titleElement = (
 		<title>
@@ -372,8 +385,8 @@ export const AgentDetailView: FC<AgentDetailViewProps> = ({
 												? { prNumber, chatId: agentId }
 												: undefined
 										}
-										repositories={gitWatcher.repositories}
-										onRefresh={gitWatcher.refresh}
+										repositories={gitRepositories}
+										onRefresh={gitRefresh}
 										onCommit={handleCommit}
 										isExpanded={visualExpanded}
 										remoteDiffStats={diffStatusData}

--- a/site/src/pages/AgentsPage/hooks/useGitWatcher.test.ts
+++ b/site/src/pages/AgentsPage/hooks/useGitWatcher.test.ts
@@ -74,15 +74,13 @@ describe("useGitWatcher", () => {
 	it("connects WebSocket when chatId is provided", () => {
 		const socket = createMockSocket();
 
-		const { result } = renderHook(() =>
+		renderHook(() =>
 			useGitWatcher({ chatId: "chat-123", agentStatus: "connected" }),
 		);
 
 		expect(mockWatchChatGit).toHaveBeenCalledWith("chat-123");
-		expect(result.current.isConnected).toBe(false);
 
 		act(() => socket.simulateOpen());
-		expect(result.current.isConnected).toBe(true);
 	});
 
 	it("does not connect when chatId is undefined", () => {
@@ -91,7 +89,6 @@ describe("useGitWatcher", () => {
 		);
 
 		expect(mockWatchChatGit).not.toHaveBeenCalled();
-		expect(result.current.isConnected).toBe(false);
 		expect(result.current.repositories.size).toBe(0);
 	});
 
@@ -103,7 +100,6 @@ describe("useGitWatcher", () => {
 		);
 
 		expect(mockWatchChatGit).not.toHaveBeenCalled();
-		expect(result.current.isConnected).toBe(false);
 		expect(result.current.repositories.size).toBe(0);
 	});
 
@@ -115,14 +111,13 @@ describe("useGitWatcher", () => {
 		);
 
 		expect(mockWatchChatGit).not.toHaveBeenCalled();
-		expect(result.current.isConnected).toBe(false);
 		expect(result.current.repositories.size).toBe(0);
 	});
 
 	it("connects when agentStatus transitions to connected", () => {
 		const socket = createMockSocket();
 
-		const { result, rerender } = renderHook(
+		const { rerender } = renderHook(
 			({ agentStatus }: { agentStatus: WorkspaceAgentStatus | undefined }) =>
 				useGitWatcher({ chatId: "chat-123", agentStatus }),
 			{
@@ -133,14 +128,12 @@ describe("useGitWatcher", () => {
 		);
 
 		expect(mockWatchChatGit).not.toHaveBeenCalled();
-		expect(result.current.isConnected).toBe(false);
 
 		rerender({ agentStatus: "connected" });
 
 		expect(mockWatchChatGit).toHaveBeenCalledWith("chat-123");
 
 		act(() => socket.simulateOpen());
-		expect(result.current.isConnected).toBe(true);
 	});
 
 	it("disconnects and stops reconnecting when agentStatus leaves connected", () => {
@@ -149,7 +142,7 @@ describe("useGitWatcher", () => {
 		try {
 			const socket = createMockSocket();
 
-			const { result, rerender } = renderHook(
+			const { rerender } = renderHook(
 				({ agentStatus }: { agentStatus: WorkspaceAgentStatus | undefined }) =>
 					useGitWatcher({ chatId: "chat-123", agentStatus }),
 				{
@@ -160,13 +153,11 @@ describe("useGitWatcher", () => {
 			);
 
 			act(() => socket.simulateOpen());
-			expect(result.current.isConnected).toBe(true);
 
 			// Transition agent away from connected.
 			rerender({ agentStatus: "disconnected" });
 
 			expect(socket.close).toHaveBeenCalled();
-			expect(result.current.isConnected).toBe(false);
 
 			// Simulate the browser firing the close event after
 			// socket.close() — the disposedRef guard must prevent
@@ -458,10 +449,9 @@ describe("useGitWatcher", () => {
 			act(() => vi.advanceTimersByTime(60_000));
 			expect(mockWatchChatGit).toHaveBeenCalledTimes(2);
 
-			// socket2 should still work: open sets isConnected,
+			// socket2 should still work: messages are handled.
 			// messages update repositories.
 			act(() => socket2.simulateOpen());
-			expect(result.current.isConnected).toBe(true);
 
 			act(() => {
 				socket2.simulateMessage({

--- a/site/src/pages/AgentsPage/hooks/useGitWatcher.ts
+++ b/site/src/pages/AgentsPage/hooks/useGitWatcher.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { type RefObject, useEffect, useRef, useState } from "react";
 import { watchChatGit } from "#/api/api";
 import type {
 	WorkspaceAgentGitClientMessage,
@@ -28,8 +28,8 @@ interface UseGitWatcherOptions {
 interface UseGitWatcherResult {
 	/** Current repo state, keyed by repo root path. */
 	repositories: ReadonlyMap<string, WorkspaceAgentRepoChanges>;
-	/** Whether the WebSocket is currently connected. */
-	isConnected: boolean;
+	/** Ref that always holds the latest repositories value. */
+	repositoriesRef: RefObject<ReadonlyMap<string, WorkspaceAgentRepoChanges>>;
 	/** Send a refresh request. */
 	refresh: () => void;
 }
@@ -43,7 +43,12 @@ export function useGitWatcher({
 	const [repositories, setRepositories] = useState<
 		ReadonlyMap<string, WorkspaceAgentRepoChanges>
 	>(new Map());
-	const [isConnected, setIsConnected] = useState(false);
+	const repositoriesRef =
+		useRef<ReadonlyMap<string, WorkspaceAgentRepoChanges>>(repositories);
+	// isConnected is a ref because no component renders this value.
+	// Using useState would cause unnecessary re-renders of the entire
+	// AgentDetail tree on every WebSocket open/close cycle.
+	const isConnectedRef = useRef(false);
 
 	const socketRef = useRef<WebSocket | null>(null);
 	const reconnectAttemptRef = useRef(0);
@@ -82,7 +87,7 @@ export function useGitWatcher({
 				if (socketRef.current !== socket) {
 					return;
 				}
-				setIsConnected(true);
+				isConnectedRef.current = true;
 				reconnectAttemptRef.current = 0;
 			});
 
@@ -124,6 +129,9 @@ export function useGitWatcher({
 								}
 							}
 						}
+						if (changed) {
+							repositoriesRef.current = next;
+						}
 						return changed ? next : prev;
 					});
 				} else if (data.type === "error") {
@@ -138,7 +146,7 @@ export function useGitWatcher({
 				if (socketRef.current !== socket) {
 					return;
 				}
-				setIsConnected(false);
+				isConnectedRef.current = false;
 				socketRef.current = null;
 
 				if (disposedRef.current) {
@@ -165,11 +173,18 @@ export function useGitWatcher({
 				socketRef.current.close();
 				socketRef.current = null;
 			}
-			setIsConnected(false);
+			isConnectedRef.current = false;
 			setRepositories(new Map());
+			repositoriesRef.current = new Map();
 			reconnectAttemptRef.current = 0;
 		};
 	}, [chatId, agentStatus]);
 
-	return { repositories, isConnected, refresh };
+	return {
+		repositories,
+		repositoriesRef: repositoriesRef as RefObject<
+			ReadonlyMap<string, WorkspaceAgentRepoChanges>
+		>,
+		refresh,
+	};
 }


### PR DESCRIPTION
The chat scroll position jumped every time the git watcher WebSocket received data. Root cause: `urlTransform` was recreated on every `AgentDetail` render due to React Compiler hook interleaving, and `isConnected` state caused unnecessary re-renders on every WebSocket lifecycle event.

## Changes

1. **Extract `buildUrlTransform` as a module-level function** and pass primitive fields via `urlTransformProps` instead of a pre-built closure. The compiler guards the props object on primitives (stable) and guards the `buildUrlTransform` call inside `AgentDetailView`. The `AgentDetailTimeline` guard now hits when git data changes, keeping the scroll container content cached.

2. **Convert `isConnected` from `useState` to `useRef`** in `useGitWatcher`. No component renders this value; it was causing two wasted full-tree re-renders per WebSocket open/close cycle.

3. **Split `gitWatcher` prop into `gitRepositories` and `gitRefresh`**, and use `repositoriesRef` for imperative access in `handleOpenInEditor`. This removes the opaque `gitWatcher` object from the `AgentDetailView` JSX guard.

<details>
<summary>Diagnosis (compiler output analysis)</summary>

**Before**: `urlTransform` had no compiler cache guard (bare `const` in compiled output) because `useProxy()` between its dependencies and definition prevented the compiler from grouping the closure. The `AgentDetailTimeline` guard (slot 57 in `AgentDetailView`) depended on `urlTransform`, so it missed on every render, cascading a full conversation re-render into the scroll container.

**After**: `urlTransformProps` object is guarded on primitive string values (slot 157-160 in `AgentDetail`). Inside `AgentDetailView`, `buildUrlTransform` call is guarded (slot 5). Timeline guard depends on stable `urlTransform`. Compiler lint: 0 diagnostics, 188 compiled functions (was 187).

Vault patterns applied: `compiler-pattern-hook-interleaving`, `compiler-output-is-diagnosis-not-proof`, `compiler-pattern-usequery-whole-object-dep`.
</details>

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻