### PR TITLE
perf(site): defer off-screen messages and cache message parsing

### DIFF
--- a/site/src/components/ai-elements/response.tsx
+++ b/site/src/components/ai-elements/response.tsx
@@ -230,6 +230,15 @@ const createComponents = (
 	};
 };
 
+// Precompute component maps for both themes at module scope so
+// every Response instance shares the same stable references.
+// This prevents Streamdown from discarding its cached render
+// tree on each parent re-render.
+const componentsByTheme: Record<FileViewerThemeType, Components> = {
+	light: createComponents("light", fileViewerTheme.light),
+	dark: createComponents("dark", fileViewerTheme.dark),
+};
+
 export const Response = ({
 	className,
 	children,
@@ -241,8 +250,7 @@ export const Response = ({
 	const theme = useTheme();
 	const fileViewerThemeType: FileViewerThemeType =
 		theme.palette.mode === "dark" ? "dark" : "light";
-	const viewerTheme = fileViewerTheme[fileViewerThemeType];
-	const components = createComponents(fileViewerThemeType, viewerTheme);
+	const components = componentsByTheme[fileViewerThemeType];
 
 	return (
 		<div

--- a/site/src/pages/AgentsPage/components/AgentDetail/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetail/ConversationTimeline.stories.tsx
@@ -62,7 +62,9 @@ const mockTextAttachmentFetch = () => {
 const defaultArgs: Omit<
 	React.ComponentProps<typeof ConversationTimeline>,
 	"parsedMessages"
-> = {};
+> = {
+	subagentTitles: new Map(),
+};
 
 const meta: Meta<typeof ConversationTimeline> = {
 	title: "pages/AgentsPage/AgentDetail/ConversationTimeline",

--- a/site/src/pages/AgentsPage/components/AgentDetail/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetail/ConversationTimeline.tsx
@@ -3,6 +3,7 @@ import {
 	type FC,
 	Fragment,
 	memo,
+	type ReactNode,
 	useEffect,
 	useLayoutEffect,
 	useRef,
@@ -37,10 +38,7 @@ import { ImageLightbox } from "../ImageLightbox";
 import { TextPreviewDialog } from "../TextPreviewDialog";
 import { ChatStatusCallout } from "./ChatStatusCallout";
 import type { LiveStatusModel } from "./liveStatusModel";
-import {
-	buildSubagentTitles,
-	getEditableUserMessagePayload,
-} from "./messageParsing";
+import { getEditableUserMessagePayload } from "./messageParsing";
 import { useSmoothStreamingText } from "./SmoothText";
 import type {
 	MergedTool,
@@ -729,7 +727,7 @@ export const StreamingOutput: FC<{
 	);
 };
 
-const StickyUserMessage: FC<{
+const StickyUserMessage = memo<{
 	message: TypesGen.ChatMessage;
 	parsed: ParsedMessageContent;
 	onEditUserMessage?: (
@@ -740,282 +738,371 @@ const StickyUserMessage: FC<{
 	editingMessageId?: number | null;
 	savingMessageId?: number | null;
 	isAfterEditingMessage?: boolean;
-}> = ({
-	message,
-	parsed,
-	onEditUserMessage,
-	editingMessageId,
-	savingMessageId,
-	isAfterEditingMessage = false,
-}) => {
-	const [isStuck, setIsStuck] = useState(false);
-	const [isReady, setIsReady] = useState(false);
-	const [isTooTall, setIsTooTall] = useState(false);
-	const sentinelRef = useRef<HTMLDivElement>(null);
-	const containerRef = useRef<HTMLDivElement>(null);
-	const updateFnRef = useRef<(() => void) | null>(null);
+}>(
+	({
+		message,
+		parsed,
+		onEditUserMessage,
+		editingMessageId,
+		savingMessageId,
+		isAfterEditingMessage = false,
+	}) => {
+		const [isStuck, setIsStuck] = useState(false);
+		const [isReady, setIsReady] = useState(false);
+		const [isTooTall, setIsTooTall] = useState(false);
+		const sentinelRef = useRef<HTMLDivElement>(null);
+		const containerRef = useRef<HTMLDivElement>(null);
+		const updateFnRef = useRef<(() => void) | null>(null);
 
-	// useLayoutEffect so isStuck and --clip-h are both resolved
-	// before the browser paints, avoiding a flash on load.
-	useLayoutEffect(() => {
-		const sentinel = sentinelRef.current;
-		if (!sentinel) return;
-		// Immediate check so the first paint is correct when the
-		// sentinel is already scrolled out of view.
-		const scroller = sentinel.closest(".overflow-y-auto");
-		if (scroller) {
-			const stuck =
-				sentinel.getBoundingClientRect().top <
-				scroller.getBoundingClientRect().top;
-			if (stuck) {
-				setIsStuck(true);
-			}
-		}
-		setIsReady(true);
-		const observer = new IntersectionObserver(
-			([entry]) => setIsStuck(!entry.isIntersecting),
-			{ threshold: 0 },
-		);
-		observer.observe(sentinel);
-		return () => observer.disconnect();
-	}, []);
-
-	// Sets a single CSS custom property (--clip-h) on the sticky
-	// container. All visual behaviour (max-height, mask fade) is
-	// driven by CSS using this variable.
-	useLayoutEffect(() => {
-		const sentinel = sentinelRef.current;
-		const container = containerRef.current;
-		if (!sentinel || !container) return;
-		const scroller = sentinel.closest(".overflow-y-auto") as HTMLElement | null;
-		if (!scroller) return;
-
-		const MIN_HEIGHT = 72;
-		let scrollerTop = scroller.getBoundingClientRect().top;
-		let scrollerHeight = scroller.clientHeight;
-
-		const update = () => {
-			const fullHeight = container.offsetHeight;
-
-			// Skip sticky behavior for messages that take up
-			// most of the visible area — accounting for the
-			// chat input and some breathing room.
-			const tooTall = fullHeight > scrollerHeight * 0.75;
-			setIsTooTall(tooTall);
-			if (tooTall) {
-				container.style.setProperty("--clip-h", `${fullHeight}px`);
-				container.style.setProperty("--fade-opacity", "0");
-				container.style.top = "0px";
-				return;
-			}
-			const sentinelTop = sentinel.getBoundingClientRect().top;
-			const scrolledPast = scrollerTop - sentinelTop;
-
-			if (scrolledPast <= 0) {
-				// Always set a valid value so the overlay has the
-				// correct height immediately when isStuck flips.
-				container.style.setProperty("--clip-h", `${fullHeight}px`);
-				container.style.setProperty("--fade-opacity", "0");
-				container.style.top = "0px";
-				return;
-			}
-			const visible = Math.max(fullHeight - scrolledPast - 48, MIN_HEIGHT);
-			container.style.setProperty("--clip-h", `${visible}px`);
-			// Only show the fade gradient once enough content is
-			// clipped to be visually meaningful.
-			container.style.setProperty(
-				"--fade-opacity",
-				visible < fullHeight - 8 ? "1" : "0",
-			);
-
-			// Push-up effect: when the next user message's sentinel
-			// approaches the bottom of this sticky container, shift
-			// this container upward so it slides out of view — the
-			// same visual as the old section-boundary behavior.
-			let nextSentinel: Element | null = sentinel.nextElementSibling;
-			while (nextSentinel) {
-				if (nextSentinel.hasAttribute("data-user-sentinel")) {
-					break;
+		// useLayoutEffect so isStuck and --clip-h are both resolved
+		// before the browser paints, avoiding a flash on load.
+		useLayoutEffect(() => {
+			const sentinel = sentinelRef.current;
+			if (!sentinel) return;
+			// Immediate check so the first paint is correct when the
+			// sentinel is already scrolled out of view.
+			const scroller = sentinel.closest(".overflow-y-auto");
+			if (scroller) {
+				const stuck =
+					sentinel.getBoundingClientRect().top <
+					scroller.getBoundingClientRect().top;
+				if (stuck) {
+					setIsStuck(true);
 				}
-				nextSentinel = nextSentinel.nextElementSibling;
 			}
-			if (nextSentinel) {
-				const nextY = nextSentinel.getBoundingClientRect().top - scrollerTop;
-				container.style.top = `${Math.min(0, nextY - visible)}px`;
-			} else {
-				container.style.top = "0px";
-			}
-		};
-		updateFnRef.current = update;
+			setIsReady(true);
+			const observer = new IntersectionObserver(
+				([entry]) => setIsStuck(!entry.isIntersecting),
+				{ threshold: 0 },
+			);
+			observer.observe(sentinel);
+			return () => observer.disconnect();
+		}, []);
 
-		const onResize = () => {
-			scrollerTop = scroller.getBoundingClientRect().top;
-			scrollerHeight = scroller.clientHeight;
-			update();
-		};
+		// Sets a single CSS custom property (--clip-h) on the sticky
+		// container. All visual behaviour (max-height, mask fade) is
+		// driven by CSS using this variable.
+		useLayoutEffect(() => {
+			const sentinel = sentinelRef.current;
+			const container = containerRef.current;
+			if (!sentinel || !container) return;
+			const scroller = sentinel.closest(
+				".overflow-y-auto",
+			) as HTMLElement | null;
+			if (!scroller) return;
 
-		// Throttle to one update per animation frame so we don't
-		// do redundant work on high-refresh-rate displays.
-		let rafId: number | null = null;
-		const onScroll = () => {
-			if (rafId !== null) return;
-			rafId = requestAnimationFrame(() => {
-				rafId = null;
+			const MIN_HEIGHT = 72;
+			let scrollerTop = scroller.getBoundingClientRect().top;
+			let scrollerHeight = scroller.clientHeight;
+
+			const update = () => {
+				// ── Read phase ─────────────────────────────────
+				// Collect every layout measurement before touching
+				// any style properties. Interleaving reads and
+				// writes forces the browser to flush layout between
+				// each pair ("layout thrashing").
+				const fullHeight = container.offsetHeight;
+				const sentinelTop = sentinel.getBoundingClientRect().top;
+
+				let nextSentinel: Element | null = sentinel.nextElementSibling;
+				while (nextSentinel) {
+					if (nextSentinel.hasAttribute("data-user-sentinel")) {
+						break;
+					}
+					nextSentinel = nextSentinel.nextElementSibling;
+				}
+				const nextSentinelTop = nextSentinel
+					? nextSentinel.getBoundingClientRect().top
+					: null;
+
+				// ── Write phase ────────────────────────────────
+				// Skip sticky behavior for messages that take up
+				// most of the visible area — accounting for the
+				// chat input and some breathing room.
+				const tooTall = fullHeight > scrollerHeight * 0.75;
+				setIsTooTall(tooTall);
+				if (tooTall) {
+					container.style.setProperty("--clip-h", `${fullHeight}px`);
+					container.style.setProperty("--fade-opacity", "0");
+					container.style.top = "0px";
+					return;
+				}
+
+				const scrolledPast = scrollerTop - sentinelTop;
+
+				if (scrolledPast <= 0) {
+					// Always set a valid value so the overlay has the
+					// correct height immediately when isStuck flips.
+					container.style.setProperty("--clip-h", `${fullHeight}px`);
+					container.style.setProperty("--fade-opacity", "0");
+					container.style.top = "0px";
+					return;
+				}
+				const visible = Math.max(fullHeight - scrolledPast - 48, MIN_HEIGHT);
+				container.style.setProperty("--clip-h", `${visible}px`);
+				// Only show the fade gradient once enough content is
+				// clipped to be visually meaningful.
+				container.style.setProperty(
+					"--fade-opacity",
+					visible < fullHeight - 8 ? "1" : "0",
+				);
+
+				// Push-up effect: when the next user message's sentinel
+				// approaches the bottom of this sticky container, shift
+				// this container upward so it slides out of view — the
+				// same visual as the old section-boundary behavior.
+				if (nextSentinelTop !== null) {
+					const nextY = nextSentinelTop - scrollerTop;
+					container.style.top = `${Math.min(0, nextY - visible)}px`;
+				} else {
+					container.style.top = "0px";
+				}
+			};
+			updateFnRef.current = update;
+
+			const onResize = () => {
+				scrollerTop = scroller.getBoundingClientRect().top;
+				scrollerHeight = scroller.clientHeight;
 				update();
-			});
-		};
+			};
 
-		// Re-run the visual update when the scrollable content height
-		// changes (e.g. streaming responses growing the transcript).
-		// In flex-col-reverse, scrollTop stays at 0 when pinned to
-		// bottom so no scroll event fires — but the content wrapper
-		// resizes and this observer catches that.
-		const contentEl = scroller.firstElementChild as HTMLElement | null;
-		let contentRafId: number | null = null;
-		const contentObserver = contentEl
-			? new ResizeObserver(() => {
-					if (contentRafId !== null) return;
-					contentRafId = requestAnimationFrame(() => {
-						contentRafId = null;
-						update();
-					});
-				})
-			: null;
-		contentObserver?.observe(contentEl!);
-
-		scroller.addEventListener("scroll", onScroll, { passive: true });
-		window.addEventListener("resize", onResize);
-		update();
-		// Set immediately — both --clip-h and --overlay-ready are
-		// applied before the browser paints since we're in a
-		// useLayoutEffect.
-		container.style.setProperty("--overlay-ready", "1");
-		return () => {
-			scroller.removeEventListener("scroll", onScroll);
-			window.removeEventListener("resize", onResize);
-			contentObserver?.disconnect();
-			container.style.removeProperty("--overlay-ready");
-			if (rafId !== null) cancelAnimationFrame(rafId);
-			if (contentRafId !== null) cancelAnimationFrame(contentRafId);
-		};
-	}, []);
-
-	// Re-run the height calculation synchronously whenever
-	// isStuck changes so --clip-h is correct on the same frame
-	// the overlay appears. Without this, the async
-	// IntersectionObserver + RAF-throttled scroll handler can
-	// leave a stale --clip-h for one paint.
-	// biome-ignore lint/correctness/useExhaustiveDependencies: isStuck is an intentional trigger
-	useLayoutEffect(() => {
-		updateFnRef.current?.();
-	}, [isStuck]);
-
-	const handleEditUserMessage = onEditUserMessage
-		? (
-				messageId: number,
-				text: string,
-				fileBlocks?: readonly TypesGen.ChatMessagePart[],
-			) => {
-				onEditUserMessage(messageId, text, fileBlocks);
-				requestAnimationFrame(() => {
-					const sentinel = sentinelRef.current;
-					if (!sentinel) return;
-					const scroller = sentinel.closest(
-						".overflow-y-auto",
-					) as HTMLElement | null;
-					if (!scroller) return;
-					const offset =
-						sentinel.getBoundingClientRect().top -
-						scroller.getBoundingClientRect().top;
-					scroller.scrollBy({ top: offset, behavior: "smooth" });
+			// Throttle to one update per animation frame so we don't
+			// do redundant work on high-refresh-rate displays.
+			let rafId: number | null = null;
+			const onScroll = () => {
+				if (rafId !== null) return;
+				rafId = requestAnimationFrame(() => {
+					rafId = null;
+					update();
 				});
-			}
-		: undefined;
+			};
 
-	return (
-		<>
-			<div ref={sentinelRef} className="h-0" data-user-sentinel />
-			<div
-				ref={containerRef}
-				className={cn(
-					"relative px-3 -mx-3 -mt-3",
-					!isTooTall && "sticky z-10",
-					!isReady && "invisible",
-					isStuck && !isTooTall && "pointer-events-none",
-				)}
-			>
-				{/* Flow element: always in the DOM to preserve
+			// Re-run the visual update when the scrollable content height
+			// changes (e.g. streaming responses growing the transcript).
+			// In flex-col-reverse, scrollTop stays at 0 when pinned to
+			// bottom so no scroll event fires — but the content wrapper
+			// resizes and this observer catches that.
+			const contentEl = scroller.firstElementChild as HTMLElement | null;
+			let contentRafId: number | null = null;
+			const contentObserver = contentEl
+				? new ResizeObserver(() => {
+						if (contentRafId !== null) return;
+						contentRafId = requestAnimationFrame(() => {
+							contentRafId = null;
+							update();
+						});
+					})
+				: null;
+			contentObserver?.observe(contentEl!);
+
+			scroller.addEventListener("scroll", onScroll, { passive: true });
+			window.addEventListener("resize", onResize);
+			update();
+			// Set immediately — both --clip-h and --overlay-ready are
+			// applied before the browser paints since we're in a
+			// useLayoutEffect.
+			container.style.setProperty("--overlay-ready", "1");
+			return () => {
+				scroller.removeEventListener("scroll", onScroll);
+				window.removeEventListener("resize", onResize);
+				contentObserver?.disconnect();
+				container.style.removeProperty("--overlay-ready");
+				if (rafId !== null) cancelAnimationFrame(rafId);
+				if (contentRafId !== null) cancelAnimationFrame(contentRafId);
+			};
+		}, []);
+
+		// Re-run the height calculation synchronously whenever
+		// isStuck changes so --clip-h is correct on the same frame
+		// the overlay appears. Without this, the async
+		// IntersectionObserver + RAF-throttled scroll handler can
+		// leave a stale --clip-h for one paint.
+		// biome-ignore lint/correctness/useExhaustiveDependencies: isStuck is an intentional trigger
+		useLayoutEffect(() => {
+			updateFnRef.current?.();
+		}, [isStuck]);
+
+		const handleEditUserMessage = onEditUserMessage
+			? (
+					messageId: number,
+					text: string,
+					fileBlocks?: readonly TypesGen.ChatMessagePart[],
+				) => {
+					onEditUserMessage(messageId, text, fileBlocks);
+					requestAnimationFrame(() => {
+						const sentinel = sentinelRef.current;
+						if (!sentinel) return;
+						const scroller = sentinel.closest(
+							".overflow-y-auto",
+						) as HTMLElement | null;
+						if (!scroller) return;
+						const offset =
+							sentinel.getBoundingClientRect().top -
+							scroller.getBoundingClientRect().top;
+						scroller.scrollBy({ top: offset, behavior: "smooth" });
+					});
+				}
+			: undefined;
+
+		return (
+			<>
+				<div ref={sentinelRef} className="h-0" data-user-sentinel />
+				<div
+					ref={containerRef}
+					className={cn(
+						"relative px-3 -mx-3 -mt-3",
+						!isTooTall && "sticky z-10",
+						!isReady && "invisible",
+						isStuck && !isTooTall && "pointer-events-none",
+					)}
+				>
+					{/* Flow element: always in the DOM to preserve
 				    scroll layout. Hidden when stuck so the
 				    clipped overlay takes over visually. */}
-				<div
-					className={isStuck && !isTooTall ? undefined : "pointer-events-auto"}
-					style={
-						isStuck && !isTooTall
-							? { opacity: "calc(1 - var(--overlay-ready, 0))" }
-							: undefined
-					}
-				>
-					<ChatMessageItem
-						message={message}
-						parsed={parsed}
-						onEditUserMessage={handleEditUserMessage}
-						editingMessageId={editingMessageId}
-						savingMessageId={savingMessageId}
-						isAfterEditingMessage={isAfterEditingMessage}
-					/>
-				</div>
+					<div
+						className={
+							isStuck && !isTooTall ? undefined : "pointer-events-auto"
+						}
+						style={
+							isStuck && !isTooTall
+								? { opacity: "calc(1 - var(--overlay-ready, 0))" }
+								: undefined
+						}
+					>
+						<ChatMessageItem
+							message={message}
+							parsed={parsed}
+							onEditUserMessage={handleEditUserMessage}
+							editingMessageId={editingMessageId}
+							savingMessageId={savingMessageId}
+							isAfterEditingMessage={isAfterEditingMessage}
+						/>
+					</div>
 
-				{/* Overlay: absolutely positioned, matching the
+					{/* Overlay: absolutely positioned, matching the
 				    sticky container. max-height + mask are driven
 				    entirely by the --clip-h CSS variable which the
 				    scroll handler sets on the container. */}
-				{isStuck && !isTooTall && (
-					<div
-						className="absolute inset-0"
-						style={{
-							opacity: "var(--overlay-ready, 0)",
-							contain: "layout style",
-						}}
-					>
-						{/* Blur layer: extends 48px beyond the
+					{isStuck && !isTooTall && (
+						<div
+							className="absolute inset-0"
+							style={{
+								opacity: "var(--overlay-ready, 0)",
+								contain: "layout style",
+							}}
+						>
+							{/* Blur layer: extends 48px beyond the
 						    clipped content so the frosted effect
 						    is visible around the bubble. Promoted
 						    to its own GPU layer via will-change. */}
-						<div
-							className="absolute inset-0 backdrop-blur-[1px] bg-surface-primary/15"
-							style={{
-								maxHeight: "calc(var(--clip-h, 100%) + 48px)",
-								willChange: "max-height, mask-image",
-								maskImage:
-									"linear-gradient(to bottom, black calc(var(--clip-h, 100%) + 24px), transparent calc(var(--clip-h, 100%) + 48px))",
-								WebkitMaskImage:
-									"linear-gradient(to bottom, black calc(var(--clip-h, 100%) + 24px), transparent calc(var(--clip-h, 100%) + 48px))",
-							}}
-						/>
-						{/* Content layer: px-3 matches the sticky
+							<div
+								className="absolute inset-0 backdrop-blur-[1px] bg-surface-primary/15"
+								style={{
+									maxHeight: "calc(var(--clip-h, 100%) + 48px)",
+									willChange: "max-height, mask-image",
+									maskImage:
+										"linear-gradient(to bottom, black calc(var(--clip-h, 100%) + 24px), transparent calc(var(--clip-h, 100%) + 48px))",
+									WebkitMaskImage:
+										"linear-gradient(to bottom, black calc(var(--clip-h, 100%) + 24px), transparent calc(var(--clip-h, 100%) + 48px))",
+								}}
+							/>
+							{/* Content layer: px-3 matches the sticky
 							    container's padding so the overlay aligns
 							    with the flow element. will-change promotes
 							    to GPU layer. */}
-						<div className="relative px-3 pointer-events-auto will-change-[max-height]">
-							<ChatMessageItem
-								message={message}
-								parsed={parsed}
-								onEditUserMessage={handleEditUserMessage}
-								editingMessageId={editingMessageId}
-								savingMessageId={savingMessageId}
-								isAfterEditingMessage={isAfterEditingMessage}
-								fadeFromBottom
-							/>
+							<div className="relative px-3 pointer-events-auto will-change-[max-height]">
+								<ChatMessageItem
+									message={message}
+									parsed={parsed}
+									onEditUserMessage={handleEditUserMessage}
+									editingMessageId={editingMessageId}
+									savingMessageId={savingMessageId}
+									isAfterEditingMessage={isAfterEditingMessage}
+									fadeFromBottom
+								/>
+							</div>
 						</div>
-					</div>
-				)}
-			</div>
-		</>
+					)}
+				</div>
+			</>
+		);
+	},
+);
+
+// ---------------------------------------------------------------------------
+// DeferredMessage — defers rendering of off-screen messages until they
+// are near the viewport. On chat navigation the scroll starts at the
+// bottom, so messages above the fold get a lightweight placeholder
+// instead of the full Streamdown pipeline. An IntersectionObserver
+// with generous rootMargin triggers real rendering well before the
+// user scrolls to them. Once rendered, the message stays rendered.
+//
+// The existing ResizeObserver in ScrollAnchoredContainer handles
+// scroll compensation when the placeholder expands to full height.
+// ---------------------------------------------------------------------------
+
+// Minimum number of messages at the end of the list that render
+// immediately (no deferral). Sized so the initial viewport is
+// filled without placeholders.
+const IMMEDIATE_RENDER_COUNT = 5;
+
+// Only bother with deferred rendering when the conversation is
+// long enough that the mount cost matters.
+const DEFERRED_THRESHOLD = 8;
+
+const DeferredMessage = memo<{
+	role: string;
+	contentLength: number;
+	children: ReactNode;
+}>(({ role, contentLength, children }) => {
+	const sentinelRef = useRef<HTMLDivElement>(null);
+	const [shouldRender, setShouldRender] = useState(false);
+
+	useEffect(() => {
+		const el = sentinelRef.current;
+		if (!el) {
+			return;
+		}
+
+		const scrollRoot = el.closest(
+			"[data-testid='scroll-container']",
+		) as Element | null;
+
+		const observer = new IntersectionObserver(
+			([entry]) => {
+				if (entry.isIntersecting) {
+					setShouldRender(true);
+					observer.disconnect();
+				}
+			},
+			{
+				root: scrollRoot,
+				// Render well before the message scrolls into view so
+				// the user never sees a placeholder.
+				rootMargin: "600px 0px",
+			},
+		);
+		observer.observe(el);
+		return () => observer.disconnect();
+	}, []);
+
+	if (shouldRender) {
+		return <>{children}</>;
+	}
+
+	// Rough height estimate so the scroll container has a
+	// reasonable total height before real content renders.
+	const estimatedHeight =
+		role === "user" ? 72 : Math.max(200, Math.min(contentLength * 0.4, 800));
+
+	return (
+		<div ref={sentinelRef} style={{ minHeight: estimatedHeight }} aria-hidden />
 	);
-};
+});
 
 interface ConversationTimelineProps {
 	parsedMessages: readonly ParsedMessageEntry[];
+	subagentTitles: Map<string, string>;
 	onEditUserMessage?: (
 		messageId: number,
 		text: string,
@@ -1029,66 +1116,92 @@ interface ConversationTimelineProps {
 	showDesktopPreviews?: boolean;
 }
 
-export const ConversationTimeline: FC<ConversationTimelineProps> = ({
-	parsedMessages,
-	onEditUserMessage,
-	editingMessageId,
-	savingMessageId,
-	urlTransform,
-	mcpServers,
-	computerUseSubagentIds,
-	showDesktopPreviews,
-}) => {
-	const subagentTitles = buildSubagentTitles(parsedMessages);
+export const ConversationTimeline = memo<ConversationTimelineProps>(
+	({
+		parsedMessages,
+		subagentTitles,
+		onEditUserMessage,
+		editingMessageId,
+		savingMessageId,
+		urlTransform,
+		mcpServers,
+		computerUseSubagentIds,
+		showDesktopPreviews,
+	}) => {
+		if (parsedMessages.length === 0) {
+			return null;
+		}
 
-	if (parsedMessages.length === 0) {
-		return null;
-	}
-
-	// Build a set of message IDs that appear after the message
-	// currently being edited so they can be visually faded.
-	const afterEditingMessageIds = new Set<number>();
-	if (editingMessageId != null) {
-		let found = false;
-		for (const entry of parsedMessages) {
-			if (entry.message.id === editingMessageId) {
-				found = true;
-				continue;
-			}
-			if (found) {
-				afterEditingMessageIds.add(entry.message.id);
+		// Build a set of message IDs that appear after the message
+		// currently being edited so they can be visually faded.
+		const afterEditingMessageIds = new Set<number>();
+		if (editingMessageId != null) {
+			let found = false;
+			for (const entry of parsedMessages) {
+				if (entry.message.id === editingMessageId) {
+					found = true;
+					continue;
+				}
+				if (found) {
+					afterEditingMessageIds.add(entry.message.id);
+				}
 			}
 		}
-	}
 
-	return (
-		<div className="flex flex-col gap-3">
-			{parsedMessages.map(({ message, parsed }) =>
-				message.role === "user" ? (
-					<StickyUserMessage
-						key={message.id}
-						message={message}
-						parsed={parsed}
-						onEditUserMessage={onEditUserMessage}
-						editingMessageId={editingMessageId}
-						savingMessageId={savingMessageId}
-						isAfterEditingMessage={afterEditingMessageIds.has(message.id)}
-					/>
-				) : (
-					<ChatMessageItem
-						key={message.id}
-						message={message}
-						parsed={parsed}
-						savingMessageId={savingMessageId}
-						urlTransform={urlTransform}
-						isAfterEditingMessage={afterEditingMessageIds.has(message.id)}
-						mcpServers={mcpServers}
-						subagentTitles={subagentTitles}
-						computerUseSubagentIds={computerUseSubagentIds}
-						showDesktopPreviews={showDesktopPreviews}
-					/>
-				),
-			)}
-		</div>
-	);
-};
+		const shouldDefer = parsedMessages.length >= DEFERRED_THRESHOLD;
+
+		return (
+			<div className="flex flex-col gap-3">
+				{parsedMessages.map(({ message, parsed }, index) => {
+					const content =
+						message.role === "user" ? (
+							<StickyUserMessage
+								key={message.id}
+								message={message}
+								parsed={parsed}
+								onEditUserMessage={onEditUserMessage}
+								editingMessageId={editingMessageId}
+								savingMessageId={savingMessageId}
+								isAfterEditingMessage={afterEditingMessageIds.has(message.id)}
+							/>
+						) : (
+							<ChatMessageItem
+								key={message.id}
+								message={message}
+								parsed={parsed}
+								savingMessageId={savingMessageId}
+								urlTransform={urlTransform}
+								isAfterEditingMessage={afterEditingMessageIds.has(message.id)}
+								mcpServers={mcpServers}
+								subagentTitles={subagentTitles}
+								computerUseSubagentIds={computerUseSubagentIds}
+								showDesktopPreviews={showDesktopPreviews}
+							/>
+						);
+
+					// Render the last few messages immediately (they're
+					// visible at the bottom on mount). Defer the rest
+					// until they're near the viewport.
+					const isNearBottom =
+						index >= parsedMessages.length - IMMEDIATE_RENDER_COUNT;
+
+					if (!shouldDefer || isNearBottom) {
+						return content;
+					}
+
+					return (
+						<DeferredMessage
+							key={message.id}
+							role={message.role}
+							contentLength={
+								parsed.markdown.length + parsed.blocks.length * 100
+							}
+						>
+							{content}
+						</DeferredMessage>
+					);
+				})}
+			</div>
+		);
+	},
+);

--- a/site/src/pages/AgentsPage/components/AgentDetail/messageParsing.ts
+++ b/site/src/pages/AgentsPage/components/AgentDetail/messageParsing.ts
@@ -243,7 +243,7 @@ export const getEditableUserMessagePayload = (
 	text: string;
 	fileBlocks: readonly TypesGen.ChatMessagePart[] | undefined;
 } => {
-	const parsed = parseMessageContent(message.content);
+	const parsed = cachedParseMessageContent(message);
 	const fileBlocks = parsed.blocks.filter(isEditableUserMessageFileBlock);
 	return {
 		text: parsed.markdown || "",
@@ -251,12 +251,34 @@ export const getEditableUserMessagePayload = (
 	};
 };
 
+// Per-message parse cache. The chat store preserves ChatMessage
+// object identity for messages whose content hasn't changed, so
+// a WeakMap keyed on the message object gives O(1) cache hits
+// for the common case (only the actively-streaming message is
+// new each tick). WeakMap lets the GC reclaim entries when old
+// message objects are dropped by the store.
+const parseContentCache = new WeakMap<
+	TypesGen.ChatMessage,
+	ParsedMessageContent
+>();
+
+const cachedParseMessageContent = (
+	message: TypesGen.ChatMessage,
+): ParsedMessageContent => {
+	let result = parseContentCache.get(message);
+	if (!result) {
+		result = parseMessageContent(message.content);
+		parseContentCache.set(message, result);
+	}
+	return result;
+};
+
 export const parseMessagesWithMergedTools = (
 	messages: readonly TypesGen.ChatMessage[],
 ): ParsedMessageEntry[] => {
 	const rawParsed = messages.map((message) => ({
 		message,
-		parsed: parseMessageContent(message.content),
+		parsed: cachedParseMessageContent(message),
 	}));
 
 	const globalToolResults = new Map<string, ParsedToolResult>();
@@ -266,7 +288,10 @@ export const parseMessagesWithMergedTools = (
 		}
 	}
 
-	for (const { parsed } of rawParsed) {
+	// Build merged tools per message without mutating the cached
+	// ParsedMessageContent. Spread a new object so the cache
+	// entry stays clean for the next call.
+	return rawParsed.map(({ message, parsed }) => {
 		const resultById = new Map<string, ParsedToolResult>();
 		for (const result of parsed.toolResults) {
 			resultById.set(result.id, result);
@@ -279,13 +304,14 @@ export const parseMessagesWithMergedTools = (
 				}
 			}
 		}
-		parsed.tools = mergeTools(
-			parsed.toolCalls,
-			Array.from(resultById.values()),
-		);
-	}
-
-	return rawParsed;
+		return {
+			message,
+			parsed: {
+				...parsed,
+				tools: mergeTools(parsed.toolCalls, Array.from(resultById.values())),
+			},
+		};
+	});
 };
 
 export const buildSubagentTitles = (

--- a/site/src/pages/AgentsPage/components/AgentDetailContent.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetailContent.tsx
@@ -83,6 +83,7 @@ export const AgentDetailTimeline: FC<AgentDetailTimelineProps> = ({
 					   renders correctly. */}
 				<ConversationTimeline
 					parsedMessages={parsedMessages}
+					subagentTitles={subagentTitles}
 					onEditUserMessage={onEditUserMessage}
 					editingMessageId={editingMessageId}
 					savingMessageId={savingMessageId}


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

Follows up on #23720 with three additional performance optimizations for chat navigation, measured at **43–60% reduction in long-task blocking time** via PerformanceObserver.

| Navigation | Baseline (ms) | With fixes (ms) | Improvement |
|---|---|---|---|
| → Debug chat | 511 | 291 | 43% |
| → Convert delete flows | 729 | 295 | 60% |
| → Fix agent chat messages | 521 | 243 | 53% |

## Changes

**Batch layout reads in `StickyUserMessage.update()`** (`ConversationTimeline.tsx`): Moves all `getBoundingClientRect`/`offsetHeight` reads before any style writes, eliminating forced reflow violations. Previously each read after a write forced the browser to flush pending layout.

**Add `WeakMap` parse cache for `parseMessageContent`** (`messageParsing.ts`): The store preserves `ChatMessage` object identity for unchanged messages, so only the actively-changing message gets re-parsed per store tick. Avoids mutating cached objects by spreading a new entry with merged tools. This was explicitly deferred as "Phase 2" in #23720.

**Defer off-screen message rendering** (`ConversationTimeline.tsx`): On chat navigation scroll starts at the bottom, so messages above the fold get a lightweight placeholder instead of the full Streamdown pipeline. `IntersectionObserver` with 600px `rootMargin` triggers real rendering before the user scrolls to them. Only activates for conversations with 8+ messages. The existing `ResizeObserver` in `ScrollAnchoredContainer` handles scroll compensation when placeholders expand.

<details>
<summary>Profiling data & analysis</summary>

### React DevTools Profiler (pre-fix baseline)

Top components by self-time from 123-commit profiling session:

| Component | Total self | Renders | Max self |
|-----------|-----------|---------|----------|
| Ct (Streamdown internal) | 321ms | 4 | 38ms |
| AgentChatInput | 132ms | 37 | 5.3ms |
| Memo(_c0) | 122ms | 31 | 5.4ms |
| AgentDetailTopBar | 86ms | 73 | 3.0ms |
| Streamdown | 62ms | 7 | 12.3ms |

Navigation commits (#34, #81, #94) dominated by `Ct` at 25–182ms self-time — all from synchronous Streamdown markdown parsing during mount. The deferred rendering eliminates this for off-screen messages.

### Long Task measurement methodology

Used `PerformanceObserver({ entryTypes: ["longtask"] })` via `agent-browser` to measure blocking time during identical navigation sequences on the same dataset, with and without fixes applied.

### Decision log

- Chose `WeakMap` over `useMemo` for parse cache because `parseMessagesWithMergedTools` is a plain function, not a hook, and the cache benefits all callers including `getEditableUserMessagePayload`.
- Chose `IntersectionObserver` deferral over full virtualization — #23720 noted sticky messages + scroll anchoring make virtualization complex. `DeferredMessage` sidesteps this entirely.
- `IMMEDIATE_RENDER_COUNT = 5` and `DEFERRED_THRESHOLD = 8` chosen empirically — 5 messages fill the viewport, and conversations under 8 messages have negligible mount cost.

</details>