### PR TITLE
fix: remove bold font-weight from unread chats in agents sidebar

### DIFF
--- a/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
@@ -528,7 +528,6 @@ const ChatTreeNode: FC<ChatTreeNodeProps> = ({ chat, isChildNode }) => {
 										className={cn(
 											"block flex-1 truncate text-[13px] text-content-primary",
 											isActive && "font-medium",
-											chat.has_unread && !isActiveChat && "font-semibold",
 											// Pulse-only in sidebar (no spinner) — space-constrained card layout.
 											isRegeneratingThisChat && "animate-pulse",
 										)}


### PR DESCRIPTION
Removes the `font-semibold` class applied to unread chat titles in the `/agents` sidebar. The unread indicator dot already provides sufficient visual distinction for unread chats.