### PR TITLE
fix(site): guard scroll anchoring during mobile touch gestures

### DIFF
--- a/site/src/pages/AgentsPage/components/AgentDetailView.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetailView.stories.tsx
@@ -692,6 +692,69 @@ export const ScrollPositionPreservedOnNewContent: Story = {
 	},
 };
 
+/** Active touch scrolling is not snapped back to bottom by a viewport
+ *  resize. */
+export const ScrollNotJumpedDuringTouch: Story = {
+	decorators: scrollStoryDecorators,
+	render: () => (
+		<StoryAgentDetailView
+			store={buildStoreWithMessages(buildLongConversation(30))}
+		/>
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scrollContainer = canvas.getByTestId("scroll-container");
+
+		await waitForScrollOverflow(scrollContainer);
+
+		await waitFor(
+			() => {
+				const dist =
+					scrollContainer.scrollHeight -
+					scrollContainer.scrollTop -
+					scrollContainer.clientHeight;
+				expect(dist).toBeLessThan(5);
+			},
+			{ timeout: 2000 },
+		);
+		expect(
+			canvas.queryByRole("button", { name: "Scroll to bottom" }),
+		).toBeNull();
+
+		scrollContainer.dispatchEvent(new Event("touchstart"));
+
+		const touchScrollTop = Math.max(
+			scrollContainer.scrollHeight - scrollContainer.clientHeight - 50,
+			0,
+		);
+		scrollContainer.scrollTop = touchScrollTop;
+		scrollContainer.dispatchEvent(new Event("scroll"));
+
+		expect(
+			canvas.queryByRole("button", { name: "Scroll to bottom" }),
+		).toBeNull();
+
+		const nextHeight = Math.max(scrollContainer.clientHeight - 24, 200);
+		scrollContainer.style.height = `${nextHeight}px`;
+
+		await new Promise<void>((resolve) => window.setTimeout(resolve, 50));
+
+		await waitFor(
+			() => {
+				const bottomTop =
+					scrollContainer.scrollHeight - scrollContainer.clientHeight;
+				expect(
+					Math.abs(scrollContainer.scrollTop - touchScrollTop),
+				).toBeLessThan(2);
+				expect(scrollContainer.scrollTop).toBeLessThan(bottomTop - 10);
+			},
+			{ timeout: 500 },
+		);
+
+		scrollContainer.dispatchEvent(new Event("touchend"));
+	},
+};
+
 const pinnedScrollStore = buildStoreWithMessages(buildLongConversation(30));
 
 /** When at bottom, new content keeps the user pinned to bottom. */

--- a/site/src/pages/AgentsPage/components/AgentDetailView.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetailView.tsx
@@ -543,6 +543,8 @@ export const AgentDetailNotFoundView: FC<AgentDetailNotFoundViewProps> = ({
  * - Loading older message pages via an IntersectionObserver sentinel.
  * - ResizeObserver-driven scroll anchoring for transcript and viewport
  *   size changes.
+ * - A touch gesture guard so mobile browser chrome resizes do not
+ *   override active user scrolling.
  * - A floating "Scroll to bottom" button when the user is scrolled
  *   away from the bottom.
  *
@@ -612,6 +614,7 @@ const ScrollAnchoredContainer: FC<{
 	const hasFetchedRef = useRef(false);
 	const onFetchRef = useRef(onFetchMoreMessages);
 	const autoScrollRef = useRef(true);
+	const isTouchingRef = useRef(false);
 	const contentRef = useRef<HTMLDivElement>(null);
 	const pendingPrependRef = useRef<{
 		contentHeight: number;
@@ -850,7 +853,7 @@ const ScrollAnchoredContainer: FC<{
 				return;
 			}
 
-			if (autoScrollRef.current) {
+			if (autoScrollRef.current && !isTouchingRef.current) {
 				scheduleBottomPin();
 				return;
 			}
@@ -891,6 +894,9 @@ const ScrollAnchoredContainer: FC<{
 			const delta = nextHeight - prevContainerHeight;
 			prevContainerHeight = nextHeight;
 			if (Math.abs(delta) < 1 || !autoScrollRef.current) {
+				return;
+			}
+			if (isTouchingRef.current) {
 				return;
 			}
 
@@ -968,17 +974,40 @@ const ScrollAnchoredContainer: FC<{
 			}
 		};
 
+		const handleTouchStart = () => {
+			isTouchingRef.current = true;
+			handleUserInterrupt();
+		};
+
+		const handleTouchEnd = () => {
+			isTouchingRef.current = false;
+			// Re-evaluate after the gesture ends because momentum scrolling
+			// can carry the transcript farther away from the bottom.
+			if (!isNearBottom(container)) {
+				autoScrollRef.current = false;
+				cancelPendingPinsRef.current?.();
+			}
+		};
+
 		container.addEventListener("scroll", handleScroll, { passive: true });
 		container.addEventListener("wheel", handleUserInterrupt, {
 			passive: true,
 		});
-		container.addEventListener("touchstart", handleUserInterrupt, {
+		container.addEventListener("touchstart", handleTouchStart, {
+			passive: true,
+		});
+		container.addEventListener("touchend", handleTouchEnd, {
+			passive: true,
+		});
+		container.addEventListener("touchcancel", handleTouchEnd, {
 			passive: true,
 		});
 		return () => {
 			container.removeEventListener("scroll", handleScroll);
 			container.removeEventListener("wheel", handleUserInterrupt);
-			container.removeEventListener("touchstart", handleUserInterrupt);
+			container.removeEventListener("touchstart", handleTouchStart);
+			container.removeEventListener("touchend", handleTouchEnd);
+			container.removeEventListener("touchcancel", handleTouchEnd);
 			if (rafId !== null) {
 				cancelAnimationFrame(rafId);
 			}


### PR DESCRIPTION
## Summary

Fixes a mobile scroll jump where the view snaps a few pixels when the user scrolls up then back down. The browser's address bar showing/hiding triggers a `ResizeObserver` callback that force-scrolls to bottom during an active touch gesture.

## Changes

- Added `isTouchingRef` to track active touch gestures in `ScrollAnchoredContainer`.
- Guarded both ResizeObserver callbacks (container and content) so they skip scroll-to-bottom while a finger is on the screen.
- Replaced the lone `touchstart` listener with a full `touchstart`/`touchend`/`touchcancel` lifecycle. On touch end, re-evaluates `isNearBottom()` to handle momentum drift.
- Added `ScrollNotJumpedDuringTouch` story that verifies scroll position is preserved during a simulated touch + viewport resize.