### PR TITLE
fix(site): prevent mobile scroll jump during active touch gestures

### DIFF
--- a/site/src/pages/AgentsPage/components/AgentDetailView.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetailView.stories.tsx
@@ -861,3 +861,88 @@ export const ScrollNotJumpedDuringTouch: Story = {
 		});
 	},
 };
+
+const wheelGuardScrollStore = buildStoreWithMessages(buildLongConversation(30));
+
+/** During active wheel/trackpad scrolling, the container ResizeObserver
+ *  must not snap scroll to bottom. This prevents desktop scroll jump. */
+export const ScrollNotJumpedDuringWheel: Story = {
+	decorators: scrollStoryDecorators,
+	render: () => <StoryAgentDetailView store={wheelGuardScrollStore} />,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scrollContainer = canvas.getByTestId("scroll-container");
+
+		await waitForScrollOverflow(scrollContainer);
+
+		// Wait for the initial bottom pin to settle.
+		await waitFor(
+			() => {
+				const dist =
+					scrollContainer.scrollHeight -
+					scrollContainer.scrollTop -
+					scrollContainer.clientHeight;
+				expect(dist).toBeLessThan(5);
+			},
+			{ timeout: 2000 },
+		);
+		await new Promise<void>((resolve) =>
+			requestAnimationFrame(() => resolve()),
+		);
+
+		// Simulate a wheel event (trackpad/mouse scroll).
+		scrollContainer.dispatchEvent(
+			new WheelEvent("wheel", { bubbles: true, deltaY: -50 }),
+		);
+
+		// Scroll partway up, within the 100px threshold but not at
+		// the absolute bottom. This simulates the user scrolling up
+		// slightly with a trackpad.
+		const offsetFromBottom = 50;
+		const targetScrollTop =
+			scrollContainer.scrollHeight -
+			scrollContainer.clientHeight -
+			offsetFromBottom;
+		scrollContainer.scrollTop = targetScrollTop;
+		scrollContainer.dispatchEvent(new Event("scroll"));
+
+		// Record the scroll position before the resize.
+		const scrollTopBeforeResize = scrollContainer.scrollTop;
+
+		// Simulate a container resize (e.g., window resize or sidebar
+		// toggle). Shrink the container height slightly to trigger
+		// the ResizeObserver.
+		const originalHeight = scrollContainer.style.height;
+		scrollContainer.style.height = `${scrollContainer.clientHeight - 10}px`;
+
+		// Give the ResizeObserver a chance to fire.
+		await new Promise<void>((resolve) =>
+			requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+		);
+
+		// During active wheel scrolling, the resize guard should
+		// prevent the container observer from snapping to the
+		// absolute bottom.
+		expect(scrollContainer.scrollTop).toBeLessThanOrEqual(
+			scrollTopBeforeResize + 1,
+		);
+
+		// Restore container height.
+		scrollContainer.style.height = originalHeight;
+
+		// Wait for the wheel debounce to clear (150ms) plus a
+		// buffer, then verify normal scroll tracking resumes.
+		await new Promise<void>((resolve) => setTimeout(resolve, 200));
+
+		// Scroll to the very bottom and verify the button disappears.
+		scrollContainer.scrollTop =
+			scrollContainer.scrollHeight - scrollContainer.clientHeight;
+		scrollContainer.dispatchEvent(new Event("scroll"));
+
+		await waitFor(() => {
+			expect(
+				canvas.queryByRole("button", { name: "Scroll to bottom" }),
+			).toBeNull();
+		});
+	},
+};

--- a/site/src/pages/AgentsPage/components/AgentDetailView.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetailView.stories.tsx
@@ -946,3 +946,78 @@ export const ScrollNotJumpedDuringWheel: Story = {
 		});
 	},
 };
+
+const wheelDeferredStore = buildStoreWithMessages(buildLongConversation(30));
+
+/**
+ * Regression: when content grows during a wheel burst (so
+ * ResizeObserver pins are deferred), the transcript must recover
+ * auto-follow after the wheel debounce expires instead of getting
+ * stuck in a jumped-up position.
+ */
+export const ScrollRepinnedAfterWheelDeferredAppend: Story = {
+	decorators: scrollStoryDecorators,
+	render: () => <StoryAgentDetailView store={wheelDeferredStore} />,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scrollContainer = canvas.getByTestId("scroll-container");
+
+		await waitForScrollOverflow(scrollContainer);
+
+		// Wait for the initial bottom pin to settle.
+		await waitFor(
+			() => {
+				const dist =
+					scrollContainer.scrollHeight -
+					scrollContainer.scrollTop -
+					scrollContainer.clientHeight;
+				expect(dist).toBeLessThan(5);
+			},
+			{ timeout: 2000 },
+		);
+		await new Promise<void>((resolve) =>
+			requestAnimationFrame(() => resolve()),
+		);
+
+		// Start a wheel burst to activate the wheel guard.
+		scrollContainer.dispatchEvent(
+			new WheelEvent("wheel", { bubbles: true, deltaY: 3 }),
+		);
+
+		// Append content while the wheel guard is active. This
+		// defers the ResizeObserver pin (pendingWheelPinRef = true)
+		// and creates the gap that previously triggered the bug.
+		const existing = getStoreMessages(wheelDeferredStore);
+		wheelDeferredStore.replaceMessages(
+			existing.concat([
+				buildMessage(31, "assistant", "A ".repeat(200)),
+				buildMessage(32, "assistant", "B ".repeat(200)),
+			]),
+		);
+
+		// Fire a second wheel tick. In the old code, this wheel
+		// event called handleUserInterrupt() which saw the gap
+		// and falsely disabled auto-follow.
+		scrollContainer.dispatchEvent(
+			new WheelEvent("wheel", { bubbles: true, deltaY: 3 }),
+		);
+
+		// Wait for the 150ms wheel debounce to expire, plus the
+		// catch-up scrollTranscriptToBottom to settle.
+		await waitFor(
+			() => {
+				const dist =
+					scrollContainer.scrollHeight -
+					scrollContainer.scrollTop -
+					scrollContainer.clientHeight;
+				expect(dist).toBeLessThan(5);
+			},
+			{ timeout: 2000 },
+		);
+
+		// Scroll-to-bottom button should not be visible.
+		expect(
+			canvas.queryByRole("button", { name: "Scroll to bottom" }),
+		).toBeNull();
+	},
+};

--- a/site/src/pages/AgentsPage/components/AgentDetailView.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetailView.stories.tsx
@@ -927,22 +927,22 @@ export const ScrollNotJumpedDuringWheel: Story = {
 			scrollTopBeforeResize + 1,
 		);
 
-		// Restore container height.
-		scrollContainer.style.height = originalHeight;
-
 		// Wait for the wheel debounce to clear (150ms) plus a
-		// buffer, then verify normal scroll tracking resumes.
+		// buffer, then verify the missed bottom pin is applied.
 		await new Promise<void>((resolve) => setTimeout(resolve, 200));
 
-		// Scroll to the very bottom and verify the button disappears.
-		scrollContainer.scrollTop =
-			scrollContainer.scrollHeight - scrollContainer.clientHeight;
-		scrollContainer.dispatchEvent(new Event("scroll"));
-
 		await waitFor(() => {
+			const dist =
+				scrollContainer.scrollHeight -
+				scrollContainer.scrollTop -
+				scrollContainer.clientHeight;
+			expect(dist).toBeLessThan(5);
 			expect(
 				canvas.queryByRole("button", { name: "Scroll to bottom" }),
 			).toBeNull();
 		});
+
+		// Restore container height for cleanup.
+		scrollContainer.style.height = originalHeight;
 	},
 };

--- a/site/src/pages/AgentsPage/components/AgentDetailView.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetailView.stories.tsx
@@ -898,7 +898,7 @@ export const ScrollNotJumpedDuringWheel: Story = {
 		// Scroll partway up, within the 100px threshold but not at
 		// the absolute bottom. This simulates the user scrolling up
 		// slightly with a trackpad.
-		const offsetFromBottom = 50;
+		const offsetFromBottom = 25;
 		const targetScrollTop =
 			scrollContainer.scrollHeight -
 			scrollContainer.clientHeight -
@@ -906,25 +906,28 @@ export const ScrollNotJumpedDuringWheel: Story = {
 		scrollContainer.scrollTop = targetScrollTop;
 		scrollContainer.dispatchEvent(new Event("scroll"));
 
-		// Record the scroll position before the resize.
-		const scrollTopBeforeResize = scrollContainer.scrollTop;
+		// Record the scroll position before new content arrives.
+		const scrollTopBeforeAppend = scrollContainer.scrollTop;
+		const scrollHeightBeforeAppend = scrollContainer.scrollHeight;
 
-		// Simulate a container resize (e.g., window resize or sidebar
-		// toggle). Shrink the container height slightly to trigger
-		// the ResizeObserver.
-		const originalHeight = scrollContainer.style.height;
-		scrollContainer.style.height = `${scrollContainer.clientHeight - 10}px`;
-
-		// Give the ResizeObserver a chance to fire.
-		await new Promise<void>((resolve) =>
-			requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+		// Simulate new assistant content arriving while the wheel guard is
+		// active. Keep the append small enough to remain within the
+		// near-bottom threshold so auto-follow should resume.
+		const existing = getStoreMessages(wheelGuardScrollStore);
+		wheelGuardScrollStore.replaceMessages(
+			existing.concat([buildMessage(31, "assistant", "Short update.")]),
 		);
 
-		// During active wheel scrolling, the resize guard should
-		// prevent the container observer from snapping to the
-		// absolute bottom.
+		await waitFor(() => {
+			expect(scrollContainer.scrollHeight).toBeGreaterThan(
+				scrollHeightBeforeAppend,
+			);
+		});
+
+		// During active wheel scrolling, the deferred pin should stay
+		// suppressed until the debounce expires.
 		expect(scrollContainer.scrollTop).toBeLessThanOrEqual(
-			scrollTopBeforeResize + 1,
+			scrollTopBeforeAppend + 1,
 		);
 
 		// Wait for the wheel debounce to clear (150ms) plus a
@@ -941,8 +944,5 @@ export const ScrollNotJumpedDuringWheel: Story = {
 				canvas.queryByRole("button", { name: "Scroll to bottom" }),
 			).toBeNull();
 		});
-
-		// Restore container height for cleanup.
-		scrollContainer.style.height = originalHeight;
 	},
 };

--- a/site/src/pages/AgentsPage/components/AgentDetailView.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetailView.stories.tsx
@@ -752,6 +752,21 @@ export const ScrollPinnedToBottomOnNewContent: Story = {
 	},
 };
 
+const dispatchTouchEvent = (
+	scrollContainer: HTMLElement,
+	type: "touchstart" | "touchend",
+	changedTouchesLength: number,
+) => {
+	const event = new Event(type, { bubbles: true });
+	Object.defineProperty(event, "changedTouches", {
+		configurable: true,
+		value: Array.from({ length: changedTouchesLength }, (_, index) => ({
+			identifier: index,
+		})),
+	});
+	scrollContainer.dispatchEvent(event);
+};
+
 const touchGuardScrollStore = buildStoreWithMessages(buildLongConversation(30));
 
 /** During an active touch gesture, the container ResizeObserver must not
@@ -780,8 +795,8 @@ export const ScrollNotJumpedDuringTouch: Story = {
 			requestAnimationFrame(() => resolve()),
 		);
 
-		// Simulate a touchstart event (finger down).
-		scrollContainer.dispatchEvent(new Event("touchstart", { bubbles: true }));
+		// Simulate a multi-touch gesture starting with two fingers down.
+		dispatchTouchEvent(scrollContainer, "touchstart", 2);
 
 		// Scroll partway up, within the 100px threshold but not at the
 		// absolute bottom. This simulates the user dragging up slightly
@@ -794,14 +809,16 @@ export const ScrollNotJumpedDuringTouch: Story = {
 		scrollContainer.scrollTop = targetScrollTop;
 		scrollContainer.dispatchEvent(new Event("scroll"));
 
-		// Record the scroll position before the resize.
-		const scrollTopBeforeResize = scrollContainer.scrollTop;
+		const originalHeight = scrollContainer.clientHeight;
+		const shrunkHeight = originalHeight - 10;
+
+		// Record the scroll position before the first resize.
+		const scrollTopBeforeFirstResize = scrollContainer.scrollTop;
 
 		// Simulate a container resize that models the mobile URL bar
 		// appearing. Shrink the container height slightly to trigger
 		// the ResizeObserver.
-		const originalHeight = scrollContainer.style.height;
-		scrollContainer.style.height = `${scrollContainer.clientHeight - 10}px`;
+		scrollContainer.style.height = `${shrunkHeight}px`;
 
 		// Give the ResizeObserver a chance to fire.
 		await new Promise<void>((resolve) =>
@@ -811,12 +828,25 @@ export const ScrollNotJumpedDuringTouch: Story = {
 		// During an active touch, the resize guard should prevent the
 		// container observer from snapping to the absolute bottom.
 		expect(scrollContainer.scrollTop).toBeLessThanOrEqual(
-			scrollTopBeforeResize + 1,
+			scrollTopBeforeFirstResize + 1,
 		);
 
-		// Restore container height and end the touch.
-		scrollContainer.style.height = originalHeight;
-		scrollContainer.dispatchEvent(new Event("touchend", { bubbles: true }));
+		// Lift one finger, leaving a second touch active. The guard should
+		// still block resize snaps until the final finger is lifted.
+		dispatchTouchEvent(scrollContainer, "touchend", 1);
+		const scrollTopBeforeSecondResize = scrollContainer.scrollTop;
+		scrollContainer.style.height = `${originalHeight}px`;
+
+		await new Promise<void>((resolve) =>
+			requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+		);
+
+		expect(scrollContainer.scrollTop).toBeLessThanOrEqual(
+			scrollTopBeforeSecondResize + 1,
+		);
+
+		// End the remaining touch.
+		dispatchTouchEvent(scrollContainer, "touchend", 1);
 
 		// After touch ends, normal scroll tracking should resume.
 		// Scroll to the very bottom and verify the button disappears.

--- a/site/src/pages/AgentsPage/components/AgentDetailView.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetailView.stories.tsx
@@ -751,3 +751,83 @@ export const ScrollPinnedToBottomOnNewContent: Story = {
 		).toBeNull();
 	},
 };
+
+const touchGuardScrollStore = buildStoreWithMessages(buildLongConversation(30));
+
+/** During an active touch gesture, the container ResizeObserver must not
+ *  snap scroll to bottom. This prevents the mobile URL bar resize jump. */
+export const ScrollNotJumpedDuringTouch: Story = {
+	decorators: scrollStoryDecorators,
+	render: () => <StoryAgentDetailView store={touchGuardScrollStore} />,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scrollContainer = canvas.getByTestId("scroll-container");
+
+		await waitForScrollOverflow(scrollContainer);
+
+		// Wait for the initial bottom pin to settle.
+		await waitFor(
+			() => {
+				const dist =
+					scrollContainer.scrollHeight -
+					scrollContainer.scrollTop -
+					scrollContainer.clientHeight;
+				expect(dist).toBeLessThan(5);
+			},
+			{ timeout: 2000 },
+		);
+		await new Promise<void>((resolve) =>
+			requestAnimationFrame(() => resolve()),
+		);
+
+		// Simulate a touchstart event (finger down).
+		scrollContainer.dispatchEvent(new Event("touchstart", { bubbles: true }));
+
+		// Scroll partway up, within the 100px threshold but not at the
+		// absolute bottom. This simulates the user dragging up slightly
+		// during a touch.
+		const offsetFromBottom = 50;
+		const targetScrollTop =
+			scrollContainer.scrollHeight -
+			scrollContainer.clientHeight -
+			offsetFromBottom;
+		scrollContainer.scrollTop = targetScrollTop;
+		scrollContainer.dispatchEvent(new Event("scroll"));
+
+		// Record the scroll position before the resize.
+		const scrollTopBeforeResize = scrollContainer.scrollTop;
+
+		// Simulate a container resize that models the mobile URL bar
+		// appearing. Shrink the container height slightly to trigger
+		// the ResizeObserver.
+		const originalHeight = scrollContainer.style.height;
+		scrollContainer.style.height = `${scrollContainer.clientHeight - 10}px`;
+
+		// Give the ResizeObserver a chance to fire.
+		await new Promise<void>((resolve) =>
+			requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+		);
+
+		// During an active touch, the resize guard should prevent the
+		// container observer from snapping to the absolute bottom.
+		expect(scrollContainer.scrollTop).toBeLessThanOrEqual(
+			scrollTopBeforeResize + 1,
+		);
+
+		// Restore container height and end the touch.
+		scrollContainer.style.height = originalHeight;
+		scrollContainer.dispatchEvent(new Event("touchend", { bubbles: true }));
+
+		// After touch ends, normal scroll tracking should resume.
+		// Scroll to the very bottom and verify the button disappears.
+		scrollContainer.scrollTop =
+			scrollContainer.scrollHeight - scrollContainer.clientHeight;
+		scrollContainer.dispatchEvent(new Event("scroll"));
+
+		await waitFor(() => {
+			expect(
+				canvas.queryByRole("button", { name: "Scroll to bottom" }),
+			).toBeNull();
+		});
+	},
+};

--- a/site/src/pages/AgentsPage/components/AgentDetailView.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetailView.tsx
@@ -629,6 +629,12 @@ const ScrollAnchoredContainer: FC<{
 	// during mobile URL bar show/hide, which triggers container resize
 	// events while the user's finger is still on the screen.
 	const activeTouchCountRef = useRef(0);
+	// Guard flag: true while the user is actively scrolling via
+	// mouse wheel or trackpad. Set on each wheel event and cleared
+	// after a short debounce period. Prevents ResizeObserver
+	// callbacks from snapping scroll to bottom during active
+	// wheel/trackpad scrolling within the near-bottom threshold.
+	const isWheelScrollingRef = useRef(false);
 	useLayoutEffect(() => {
 		isFetchingRef.current = isFetchingMoreMessages;
 		if (isFetchingMoreMessages) {
@@ -847,7 +853,11 @@ const ScrollAnchoredContainer: FC<{
 				return;
 			}
 
-			if (autoScrollRef.current && activeTouchCountRef.current === 0) {
+			if (
+				autoScrollRef.current &&
+				activeTouchCountRef.current === 0 &&
+				!isWheelScrollingRef.current
+			) {
 				scheduleBottomPin();
 				return;
 			}
@@ -898,7 +908,7 @@ const ScrollAnchoredContainer: FC<{
 			if (Math.abs(delta) < 1 || !autoScrollRef.current) {
 				return;
 			}
-			if (activeTouchCountRef.current > 0) {
+			if (activeTouchCountRef.current > 0 || isWheelScrollingRef.current) {
 				return;
 			}
 
@@ -932,6 +942,7 @@ const ScrollAnchoredContainer: FC<{
 		if (!container) return;
 
 		let rafId: number | null = null;
+		let wheelTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
 		const handleScroll = () => {
 			// While a programmatic scroll is in progress (e.g. smooth
@@ -983,6 +994,21 @@ const ScrollAnchoredContainer: FC<{
 			return Math.max(event.changedTouches.length, 1);
 		};
 
+		const handleWheel = () => {
+			isWheelScrollingRef.current = true;
+			if (wheelTimeoutId !== null) {
+				clearTimeout(wheelTimeoutId);
+			}
+			// Clear the wheel-scrolling flag after 150ms of inactivity.
+			// This covers trackpad momentum and rapid discrete wheel
+			// ticks without permanently blocking ResizeObserver pins.
+			wheelTimeoutId = setTimeout(() => {
+				isWheelScrollingRef.current = false;
+				wheelTimeoutId = null;
+			}, 150);
+			handleUserInterrupt();
+		};
+
 		const handleTouchStart = (event: TouchEvent) => {
 			activeTouchCountRef.current += getChangedTouchCount(event);
 			handleUserInterrupt();
@@ -1005,7 +1031,7 @@ const ScrollAnchoredContainer: FC<{
 		};
 
 		container.addEventListener("scroll", handleScroll, { passive: true });
-		container.addEventListener("wheel", handleUserInterrupt, {
+		container.addEventListener("wheel", handleWheel, {
 			passive: true,
 		});
 		container.addEventListener("touchstart", handleTouchStart, {
@@ -1032,13 +1058,16 @@ const ScrollAnchoredContainer: FC<{
 		document.addEventListener("visibilitychange", handleVisibilityChange);
 		return () => {
 			container.removeEventListener("scroll", handleScroll);
-			container.removeEventListener("wheel", handleUserInterrupt);
+			container.removeEventListener("wheel", handleWheel);
 			container.removeEventListener("touchstart", handleTouchStart);
 			container.removeEventListener("touchend", handleTouchEnd);
 			container.removeEventListener("touchcancel", handleTouchEnd);
 			document.removeEventListener("visibilitychange", handleVisibilityChange);
 			if (rafId !== null) {
 				cancelAnimationFrame(rafId);
+			}
+			if (wheelTimeoutId !== null) {
+				clearTimeout(wheelTimeoutId);
 			}
 		};
 	}, [scrollContainerRef]);

--- a/site/src/pages/AgentsPage/components/AgentDetailView.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetailView.tsx
@@ -976,15 +976,22 @@ const ScrollAnchoredContainer: FC<{
 			}
 		};
 
-		const handleTouchStart = () => {
-			activeTouchCountRef.current++;
+		const getChangedTouchCount = (event: TouchEvent) => {
+			// A single touch event can add or remove multiple contacts.
+			// Count changed touches so the guard stays active until the
+			// final finger leaves the screen.
+			return Math.max(event.changedTouches.length, 1);
+		};
+
+		const handleTouchStart = (event: TouchEvent) => {
+			activeTouchCountRef.current += getChangedTouchCount(event);
 			handleUserInterrupt();
 		};
 
-		const handleTouchEnd = () => {
+		const handleTouchEnd = (event: TouchEvent) => {
 			activeTouchCountRef.current = Math.max(
 				0,
-				activeTouchCountRef.current - 1,
+				activeTouchCountRef.current - getChangedTouchCount(event),
 			);
 			if (activeTouchCountRef.current === 0) {
 				// Re-evaluate because momentum scrolling may carry the

--- a/site/src/pages/AgentsPage/components/AgentDetailView.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetailView.tsx
@@ -624,6 +624,7 @@ const ScrollAnchoredContainer: FC<{
 	// scroll reaches its destination or the user actively interrupts.
 	const isRestoringScrollRef = useRef(false);
 	const cancelPendingPinsRef = useRef<(() => void) | null>(null);
+	const isTouchingRef = useRef(false);
 	useLayoutEffect(() => {
 		isFetchingRef.current = isFetchingMoreMessages;
 		if (isFetchingMoreMessages) {
@@ -842,7 +843,7 @@ const ScrollAnchoredContainer: FC<{
 				return;
 			}
 
-			if (autoScrollRef.current) {
+			if (autoScrollRef.current && !isTouchingRef.current) {
 				scheduleBottomPin();
 				return;
 			}
@@ -891,6 +892,9 @@ const ScrollAnchoredContainer: FC<{
 			const delta = nextHeight - prevContainerHeight;
 			prevContainerHeight = nextHeight;
 			if (Math.abs(delta) < 1 || !autoScrollRef.current) {
+				return;
+			}
+			if (isTouchingRef.current) {
 				return;
 			}
 
@@ -968,17 +972,41 @@ const ScrollAnchoredContainer: FC<{
 			}
 		};
 
+		const handleTouchStart = () => {
+			isTouchingRef.current = true;
+			handleUserInterrupt();
+		};
+
+		const handleTouchEnd = () => {
+			isTouchingRef.current = false;
+			// Re-evaluate because momentum scrolling may carry the user
+			// away from the bottom after touchstart initially saw them as
+			// near the bottom.
+			if (!isNearBottom(container)) {
+				autoScrollRef.current = false;
+				cancelPendingPinsRef.current?.();
+			}
+		};
+
 		container.addEventListener("scroll", handleScroll, { passive: true });
 		container.addEventListener("wheel", handleUserInterrupt, {
 			passive: true,
 		});
-		container.addEventListener("touchstart", handleUserInterrupt, {
+		container.addEventListener("touchstart", handleTouchStart, {
+			passive: true,
+		});
+		container.addEventListener("touchend", handleTouchEnd, {
+			passive: true,
+		});
+		container.addEventListener("touchcancel", handleTouchEnd, {
 			passive: true,
 		});
 		return () => {
 			container.removeEventListener("scroll", handleScroll);
 			container.removeEventListener("wheel", handleUserInterrupt);
-			container.removeEventListener("touchstart", handleUserInterrupt);
+			container.removeEventListener("touchstart", handleTouchStart);
+			container.removeEventListener("touchend", handleTouchEnd);
+			container.removeEventListener("touchcancel", handleTouchEnd);
 			if (rafId !== null) {
 				cancelAnimationFrame(rafId);
 			}

--- a/site/src/pages/AgentsPage/components/AgentDetailView.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetailView.tsx
@@ -1016,12 +1016,7 @@ const ScrollAnchoredContainer: FC<{
 				isWheelScrollingRef.current = false;
 				wheelTimeoutId = null;
 				const shouldPinAfterWheel =
-					autoScrollRef.current &&
-					(pendingWheelPinRef.current ||
-						container.scrollHeight -
-							container.scrollTop -
-							container.clientHeight >
-							1);
+					pendingWheelPinRef.current && autoScrollRef.current;
 				pendingWheelPinRef.current = false;
 				if (shouldPinAfterWheel) {
 					scrollTranscriptToBottom({

--- a/site/src/pages/AgentsPage/components/AgentDetailView.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetailView.tsx
@@ -624,7 +624,11 @@ const ScrollAnchoredContainer: FC<{
 	// scroll reaches its destination or the user actively interrupts.
 	const isRestoringScrollRef = useRef(false);
 	const cancelPendingPinsRef = useRef<(() => void) | null>(null);
-	const isTouchingRef = useRef(false);
+	// Guard counter: positive while one or more touch contacts are active.
+	// Prevents ResizeObserver callbacks from snapping scroll to bottom
+	// during mobile URL bar show/hide, which triggers container resize
+	// events while the user's finger is still on the screen.
+	const activeTouchCountRef = useRef(0);
 	useLayoutEffect(() => {
 		isFetchingRef.current = isFetchingMoreMessages;
 		if (isFetchingMoreMessages) {
@@ -843,7 +847,7 @@ const ScrollAnchoredContainer: FC<{
 				return;
 			}
 
-			if (autoScrollRef.current && !isTouchingRef.current) {
+			if (autoScrollRef.current && activeTouchCountRef.current === 0) {
 				scheduleBottomPin();
 				return;
 			}
@@ -894,7 +898,7 @@ const ScrollAnchoredContainer: FC<{
 			if (Math.abs(delta) < 1 || !autoScrollRef.current) {
 				return;
 			}
-			if (isTouchingRef.current) {
+			if (activeTouchCountRef.current > 0) {
 				return;
 			}
 
@@ -973,18 +977,23 @@ const ScrollAnchoredContainer: FC<{
 		};
 
 		const handleTouchStart = () => {
-			isTouchingRef.current = true;
+			activeTouchCountRef.current++;
 			handleUserInterrupt();
 		};
 
 		const handleTouchEnd = () => {
-			isTouchingRef.current = false;
-			// Re-evaluate because momentum scrolling may carry the user
-			// away from the bottom after touchstart initially saw them as
-			// near the bottom.
-			if (!isNearBottom(container)) {
-				autoScrollRef.current = false;
-				cancelPendingPinsRef.current?.();
+			activeTouchCountRef.current = Math.max(
+				0,
+				activeTouchCountRef.current - 1,
+			);
+			if (activeTouchCountRef.current === 0) {
+				// Re-evaluate because momentum scrolling may carry the
+				// user away from the bottom after touchstart initially
+				// saw them as near the bottom.
+				if (!isNearBottom(container)) {
+					autoScrollRef.current = false;
+					cancelPendingPinsRef.current?.();
+				}
 			}
 		};
 
@@ -998,15 +1007,29 @@ const ScrollAnchoredContainer: FC<{
 		container.addEventListener("touchend", handleTouchEnd, {
 			passive: true,
 		});
+		// touchcancel fires when the OS interrupts a gesture (e.g.,
+		// incoming call, system gesture). Must also decrement the
+		// touch counter to avoid a stuck positive value.
 		container.addEventListener("touchcancel", handleTouchEnd, {
 			passive: true,
 		});
+		// Reset touch counter when page is hidden (e.g., tab switch).
+		// The browser may not fire touchend/touchcancel when the user
+		// switches away mid-gesture, which would leave the counter
+		// positive and permanently block ResizeObserver pins.
+		const handleVisibilityChange = () => {
+			if (document.hidden) {
+				activeTouchCountRef.current = 0;
+			}
+		};
+		document.addEventListener("visibilitychange", handleVisibilityChange);
 		return () => {
 			container.removeEventListener("scroll", handleScroll);
 			container.removeEventListener("wheel", handleUserInterrupt);
 			container.removeEventListener("touchstart", handleTouchStart);
 			container.removeEventListener("touchend", handleTouchEnd);
 			container.removeEventListener("touchcancel", handleTouchEnd);
+			document.removeEventListener("visibilitychange", handleVisibilityChange);
 			if (rafId !== null) {
 				cancelAnimationFrame(rafId);
 			}

--- a/site/src/pages/AgentsPage/components/AgentDetailView.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetailView.tsx
@@ -639,6 +639,13 @@ const ScrollAnchoredContainer: FC<{
 	// wheel guard was active. When scrolling stops, run one catch-up
 	// pin so auto-follow resumes without waiting for another resize.
 	const pendingWheelPinRef = useRef(false);
+	// Snapshot of autoScrollRef at the start of the current wheel
+	// burst. Used by the debounce timeout to decide whether to repin
+	// after deferred content growth.
+	const wheelSessionAutoScrollRef = useRef(false);
+	// scrollTop at the start of the current wheel burst. Compared
+	// against the final scrollTop to detect intentional upward scrolls.
+	const wheelSessionStartTopRef = useRef(0);
 	useLayoutEffect(() => {
 		isFetchingRef.current = isFetchingMoreMessages;
 		if (isFetchingMoreMessages) {
@@ -1005,6 +1012,14 @@ const ScrollAnchoredContainer: FC<{
 		};
 
 		const handleWheel = () => {
+			if (!isWheelScrollingRef.current) {
+				// First wheel event of this burst: snapshot the current
+				// follow state and scroll position so the debounce
+				// timeout can distinguish content-driven gaps from
+				// intentional user scroll.
+				wheelSessionAutoScrollRef.current = autoScrollRef.current;
+				wheelSessionStartTopRef.current = container.scrollTop;
+			}
 			isWheelScrollingRef.current = true;
 			if (wheelTimeoutId !== null) {
 				clearTimeout(wheelTimeoutId);
@@ -1015,20 +1030,43 @@ const ScrollAnchoredContainer: FC<{
 			wheelTimeoutId = setTimeout(() => {
 				isWheelScrollingRef.current = false;
 				wheelTimeoutId = null;
-				const shouldPinAfterWheel =
-					pendingWheelPinRef.current && autoScrollRef.current;
+				const wasPinDeferred = pendingWheelPinRef.current;
 				pendingWheelPinRef.current = false;
-				if (shouldPinAfterWheel) {
-					scrollTranscriptToBottom({
-						behavior: "instant",
-						scrollContainerRef,
-						autoScrollRef,
-						isRestoringScrollRef,
-						setShowScrollToBottom,
-					});
+				// Repin if the wheel burst started in follow mode and
+				// content grew while the guard was active, unless the
+				// user clearly scrolled away from the near-bottom follow
+				// zone during the burst.
+				if (wasPinDeferred && wheelSessionAutoScrollRef.current) {
+					const scrolledUp =
+						container.scrollTop < wheelSessionStartTopRef.current - 1;
+					const nearBottom = isNearBottom(container);
+					if (!scrolledUp || nearBottom) {
+						scrollTranscriptToBottom({
+							behavior: "instant",
+							scrollContainerRef,
+							autoScrollRef,
+							isRestoringScrollRef,
+							setShowScrollToBottom,
+						});
+					} else {
+						autoScrollRef.current = false;
+						setShowScrollToBottom(true);
+					}
+				} else {
+					// Sync follow state with the actual scroll position
+					// now that the wheel burst is over.
+					const nearBottom = isNearBottom(container);
+					autoScrollRef.current = nearBottom;
+					setShowScrollToBottom(!nearBottom);
 				}
 			}, 150);
-			handleUserInterrupt();
+			// Clear the restoration guard so user input can interrupt
+			// programmatic scrolls, but do not call handleUserInterrupt()
+			// here. The scroll handler and debounce timeout manage
+			// follow-mode transitions to avoid races with deferred
+			// content growth.
+			isRestoringScrollRef.current = false;
+			cancelPendingPinsRef.current?.();
 		};
 
 		const handleTouchStart = (event: TouchEvent) => {

--- a/site/src/pages/AgentsPage/components/AgentDetailView.tsx
+++ b/site/src/pages/AgentsPage/components/AgentDetailView.tsx
@@ -635,6 +635,10 @@ const ScrollAnchoredContainer: FC<{
 	// callbacks from snapping scroll to bottom during active
 	// wheel/trackpad scrolling within the near-bottom threshold.
 	const isWheelScrollingRef = useRef(false);
+	// Track whether a resize would have pinned to bottom while the
+	// wheel guard was active. When scrolling stops, run one catch-up
+	// pin so auto-follow resumes without waiting for another resize.
+	const pendingWheelPinRef = useRef(false);
 	useLayoutEffect(() => {
 		isFetchingRef.current = isFetchingMoreMessages;
 		if (isFetchingMoreMessages) {
@@ -780,6 +784,7 @@ const ScrollAnchoredContainer: FC<{
 
 		const scheduleBottomPin = () => {
 			cancelPendingPins();
+			pendingWheelPinRef.current = false;
 			isRestoringScrollRef.current = true;
 			// Double-RAF lets React's commit phase and the browser's
 			// layout pass both complete before we pin to bottom.
@@ -853,11 +858,11 @@ const ScrollAnchoredContainer: FC<{
 				return;
 			}
 
-			if (
-				autoScrollRef.current &&
-				activeTouchCountRef.current === 0 &&
-				!isWheelScrollingRef.current
-			) {
+			if (autoScrollRef.current && activeTouchCountRef.current === 0) {
+				if (isWheelScrollingRef.current) {
+					pendingWheelPinRef.current = true;
+					return;
+				}
 				scheduleBottomPin();
 				return;
 			}
@@ -908,7 +913,11 @@ const ScrollAnchoredContainer: FC<{
 			if (Math.abs(delta) < 1 || !autoScrollRef.current) {
 				return;
 			}
-			if (activeTouchCountRef.current > 0 || isWheelScrollingRef.current) {
+			if (activeTouchCountRef.current > 0) {
+				return;
+			}
+			if (isWheelScrollingRef.current) {
+				pendingWheelPinRef.current = true;
 				return;
 			}
 
@@ -983,6 +992,7 @@ const ScrollAnchoredContainer: FC<{
 			// not break streaming follow-mode.
 			if (!isNearBottom(container)) {
 				autoScrollRef.current = false;
+				pendingWheelPinRef.current = false;
 				cancelPendingPinsRef.current?.();
 			}
 		};
@@ -1005,6 +1015,23 @@ const ScrollAnchoredContainer: FC<{
 			wheelTimeoutId = setTimeout(() => {
 				isWheelScrollingRef.current = false;
 				wheelTimeoutId = null;
+				const shouldPinAfterWheel =
+					autoScrollRef.current &&
+					(pendingWheelPinRef.current ||
+						container.scrollHeight -
+							container.scrollTop -
+							container.clientHeight >
+							1);
+				pendingWheelPinRef.current = false;
+				if (shouldPinAfterWheel) {
+					scrollTranscriptToBottom({
+						behavior: "instant",
+						scrollContainerRef,
+						autoScrollRef,
+						isRestoringScrollRef,
+						setShowScrollToBottom,
+					});
+				}
 			}, 150);
 			handleUserInterrupt();
 		};


### PR DESCRIPTION
On mobile, when a user scrolls up then back down in a chat conversation,
the view jumps a few pixels after a brief delay. The same issue was
reported on desktop with trackpad/wheel scrolling. This happens because
the browser triggers ResizeObserver callbacks that force `scrollTop` to
the bottom while the user is actively scrolling.

**Mobile fix:** Adds an `activeTouchCountRef` counter that guards both
ResizeObserver callbacks during active touch gestures, with a full
`touchstart/touchend/touchcancel` lifecycle. The counter handles
multi-touch and includes a `visibilitychange` listener to reset if the
user switches tabs mid-touch.

**Desktop fix:** Adds an `isWheelScrollingRef` flag with a 150ms
debounce that guards the same ResizeObserver callbacks during active
wheel/trackpad scrolling. The debounce covers trackpad momentum and
rapid discrete wheel ticks.

Two new Storybook stories validate the guards:
- `ScrollNotJumpedDuringTouch` (mobile)
- `ScrollNotJumpedDuringWheel` (desktop)