### PR TITLE
fix(site/src/pages/AgentsPage): preserve right panel tab state across switches

### DIFF
--- a/site/src/pages/AgentsPage/components/Sidebar/SidebarTabView.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/SidebarTabView.tsx
@@ -324,20 +324,21 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 					{isExpanded ? <MinimizeIcon /> : <MaximizeIcon />}
 				</Button>
 			</div>
-					{/* Tab panels – all stay mounted, only the active one visible. */}
-					{allPanels.map((panel) => {
-						const isActive = effectiveTabId === panel.id;
-						return (
-							<div
-								key={panel.id}
-								role="tabpanel"
-								aria-labelledby={`${tabIdPrefix}-tab-${panel.id}`}
-								className={cn("min-h-0 flex-1", !isActive && "hidden")}
-								inert={!isActive}
-							>
-								{panel.content}
-							</div>
-						);
-					})}				</div>
-			);
-	};
+			{/* Tab panels – all stay mounted, only the active one visible. */}
+			{allPanels.map((panel) => {
+				const isActive = effectiveTabId === panel.id;
+				return (
+					<div
+						key={panel.id}
+						role="tabpanel"
+						aria-labelledby={`${tabIdPrefix}-tab-${panel.id}`}
+						className={cn("min-h-0 flex-1", !isActive && "hidden")}
+						inert={!isActive}
+					>
+						{panel.content}
+					</div>
+				);
+			})}
+		</div>
+	);
+};

--- a/site/src/pages/AgentsPage/components/Sidebar/SidebarTabView.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/SidebarTabView.tsx
@@ -133,8 +133,6 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 					? "desktop"
 					: null;
 
-	const activeTab = tabs.find((t) => t.id === effectiveTabId) ?? null;
-
 	const {
 		ref: tabScrollRef,
 		canScrollLeft,
@@ -313,20 +311,36 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 					{isExpanded ? <MinimizeIcon /> : <MaximizeIcon />}
 				</Button>
 			</div>
-			{/* Tab content */}
-			<div
-				role="tabpanel"
-				aria-labelledby={
-					effectiveTabId ? `${tabIdPrefix}-tab-${effectiveTabId}` : undefined
-				}
-				className="min-h-0 flex-1"
-			>
-				{effectiveTabId === "desktop" && desktopChatId ? (
-					<DesktopPanel chatId={desktopChatId} />
-				) : (
-					activeTab?.content
-				)}
-			</div>
-		</div>
-	);
-};
+				{/* Tab panels – all stay mounted, only the active one visible. */}
+				{tabs.map((tab) => {
+					const isActive = effectiveTabId === tab.id;
+					return (
+						<div
+							key={tab.id}
+							role="tabpanel"
+							aria-labelledby={`${tabIdPrefix}-tab-${tab.id}`}
+							className={cn("min-h-0 flex-1", !isActive && "hidden")}
+							{...(!isActive && { inert: true as unknown as boolean })}
+						>
+							{tab.content}
+						</div>
+					);
+				})}
+				{desktopChatId && (
+					<div
+						role="tabpanel"
+						aria-labelledby={`${tabIdPrefix}-tab-desktop`}
+						className={cn(
+							"min-h-0 flex-1",
+							effectiveTabId !== "desktop" && "hidden",
+						)}
+						{...(effectiveTabId !== "desktop" && {
+							inert: true as unknown as boolean,
+						})}
+					>
+						<DesktopPanel chatId={desktopChatId} />
+					</div>
+					)}
+				</div>
+			);
+	};

--- a/site/src/pages/AgentsPage/components/Sidebar/SidebarTabView.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/SidebarTabView.tsx
@@ -133,6 +133,19 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 					? "desktop"
 					: null;
 
+	// Unified list of panels for rendering. Includes the desktop
+	// tab when available so we don't need to special-case it.
+	const allPanels: { id: string; content: ReactNode }[] = tabs.map((t) => ({
+		id: t.id,
+		content: t.content,
+	}));
+	if (desktopChatId) {
+		allPanels.push({
+			id: "desktop",
+			content: <DesktopPanel chatId={desktopChatId} />,
+		});
+	}
+
 	const {
 		ref: tabScrollRef,
 		canScrollLeft,
@@ -311,34 +324,20 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 					{isExpanded ? <MinimizeIcon /> : <MaximizeIcon />}
 				</Button>
 			</div>
-				{/* Tab panels – all stay mounted, only the active one visible. */}
-				{tabs.map((tab) => {
-					const isActive = effectiveTabId === tab.id;
-					return (
-						<div
-							key={tab.id}
-							role="tabpanel"
-							aria-labelledby={`${tabIdPrefix}-tab-${tab.id}`}
-							className={cn("min-h-0 flex-1", !isActive && "hidden")}
-							inert={!isActive}
-						>
-							{tab.content}
-						</div>
-					);
-				})}
-				{desktopChatId && (
-					<div
-						role="tabpanel"
-						aria-labelledby={`${tabIdPrefix}-tab-desktop`}
-						className={cn(
-							"min-h-0 flex-1",
-							effectiveTabId !== "desktop" && "hidden",
-						)}
-						inert={effectiveTabId !== "desktop"}
-					>
-						<DesktopPanel chatId={desktopChatId} />
-					</div>
-					)}
-				</div>
+					{/* Tab panels – all stay mounted, only the active one visible. */}
+					{allPanels.map((panel) => {
+						const isActive = effectiveTabId === panel.id;
+						return (
+							<div
+								key={panel.id}
+								role="tabpanel"
+								aria-labelledby={`${tabIdPrefix}-tab-${panel.id}`}
+								className={cn("min-h-0 flex-1", !isActive && "hidden")}
+								inert={!isActive}
+							>
+								{panel.content}
+							</div>
+						);
+					})}				</div>
 			);
 	};

--- a/site/src/pages/AgentsPage/components/Sidebar/SidebarTabView.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/SidebarTabView.tsx
@@ -320,7 +320,7 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 							role="tabpanel"
 							aria-labelledby={`${tabIdPrefix}-tab-${tab.id}`}
 							className={cn("min-h-0 flex-1", !isActive && "hidden")}
-							{...(!isActive && { inert: true as unknown as boolean })}
+							inert={!isActive}
 						>
 							{tab.content}
 						</div>
@@ -334,9 +334,7 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 							"min-h-0 flex-1",
 							effectiveTabId !== "desktop" && "hidden",
 						)}
-						{...(effectiveTabId !== "desktop" && {
-							inert: true as unknown as boolean,
-						})}
+						inert={effectiveTabId !== "desktop"}
 					>
 						<DesktopPanel chatId={desktopChatId} />
 					</div>


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

Switching between the Git and Desktop tabs in the right panel unmounted the inactive tab, destroying scroll position, expanded file sections, commit message drafts, and tearing down the Desktop VNC connection.

Now all tab panels stay mounted. Inactive ones are hidden with `display: none` (Tailwind `hidden`) + `inert` to block focus/interaction. The Desktop panel's existing `ResizeObserver` already handles canvas rescaling after `display: none`, so the VNC stream stays alive with no reconnection flicker.

<details>
<summary>Design notes</summary>

We considered React 19.2's `<Activity>` component, which would clean up effects on hidden panels. This is normally desirable, but the Desktop panel holds a VNC WebSocket — `<Activity>` would tear it down on every tab switch and force a visible reconnection cycle. The simpler CSS approach keeps the connection alive, which matches the existing code's intent (the `ResizeObserver` workaround in `useDesktopConnection` was already designed for `display: none` ancestors).

</details>