### PR TITLE
fix(site): make settings and analytics headers scrollable in Safari PWA

### DIFF
--- a/site/src/pages/AgentsPage/AgentAnalyticsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentAnalyticsPage.tsx
@@ -2,6 +2,7 @@ import dayjs, { type Dayjs } from "dayjs";
 import { type FC, useState } from "react";
 import { useQuery } from "react-query";
 import { chatCostSummary } from "#/api/queries/chats";
+import { ScrollArea } from "#/components/ScrollArea/ScrollArea";
 import { useAuthContext } from "#/contexts/auth/AuthProvider";
 import { AgentAnalyticsPageView } from "./AgentAnalyticsPageView";
 import { AgentPageHeader } from "./components/AgentPageHeader";
@@ -35,7 +36,7 @@ const AgentAnalyticsPage: FC<AgentAnalyticsPageProps> = ({ now }) => {
 	});
 
 	return (
-		<>
+		<ScrollArea className="min-h-0 flex-1" viewportClassName="[&>div]:!block">
 			<AgentPageHeader mobileBack={{ to: "/agents", label: "Agents" }} />
 			<AgentAnalyticsPageView
 				summary={summaryQuery.data}
@@ -44,7 +45,7 @@ const AgentAnalyticsPage: FC<AgentAnalyticsPageProps> = ({ now }) => {
 				onRetry={() => void summaryQuery.refetch()}
 				rangeLabel={dateRange.rangeLabel}
 			/>
-		</>
+		</ScrollArea>
 	);
 };
 

--- a/site/src/pages/AgentsPage/AgentAnalyticsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentAnalyticsPageView.tsx
@@ -20,7 +20,7 @@ export const AgentAnalyticsPageView: FC<AgentAnalyticsPageViewProps> = ({
 	rangeLabel,
 }) => {
 	return (
-		<div className="flex min-h-0 flex-1 flex-col overflow-y-auto p-4 pt-8 [scrollbar-width:thin] [scrollbar-color:hsl(var(--surface-quaternary))_transparent]">
+		<div className="flex flex-col p-4 pt-8">
 			<div className="mx-auto w-full max-w-3xl">
 				<SectionHeader
 					label="Analytics"

--- a/site/src/pages/AgentsPage/AgentSettingsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsPage.tsx
@@ -1,5 +1,6 @@
 import type { FC } from "react";
 import { Outlet, useLocation } from "react-router";
+import { ScrollArea } from "#/components/ScrollArea/ScrollArea";
 import { AgentPageHeader } from "./components/AgentPageHeader";
 
 const AgentSettingsPage: FC = () => {
@@ -8,18 +9,18 @@ const AgentSettingsPage: FC = () => {
 	const section = match?.[1];
 
 	return (
-		<>
+		<ScrollArea className="min-h-0 flex-1" viewportClassName="[&>div]:!block">
 			<AgentPageHeader
 				mobileBack={
 					section ? { to: "/agents/settings", label: "Settings" } : undefined
 				}
 			/>
-			<div className="flex min-h-0 flex-1 flex-col overflow-y-auto p-4 pt-8 [scrollbar-width:thin] [scrollbar-color:hsl(var(--surface-quaternary))_transparent]">
+			<div className="p-4 pt-8">
 				<div className="mx-auto w-full max-w-3xl">
 					<Outlet />
 				</div>
 			</div>
-		</>
+		</ScrollArea>
 	);
 };
 


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

In Safari standalone (PWA) mode, the virtual keyboard pushes the visual viewport upward without resizing it. When the keyboard dismisses, Safari often fails to restore the scroll position. On the agent settings and analytics pages, the `AgentPageHeader` (with the back button) was a sibling *above* the scroll container, making it permanently unreachable once the viewport shifted.

Moves the header inside a `ScrollArea` so both the header and page content scroll as a single unit. The back button is always reachable by scrolling up. Also replaces manual `overflow-y-auto` + `[scrollbar-width:thin]` styling with the existing `ScrollArea` component for consistency with the rest of the agents page.

<details><summary>Decision log</summary>

- Considered a `focusout` + `setTimeout` + `window.scrollTo(0, 0)` workaround in `useAgentsPWA` but rejected it as fragile (magic timeout, browser-behavior dependent).
- Structural fix preferred: making the header part of the scrollable area is a common mobile pattern and works across all browsers without JS hacks.
- Uses `viewportClassName="[&>div]:!block"` to override Radix's internal `display: table` wrapper, consistent with existing `ScrollArea` usage in the sidebar and diff viewer.
- Applied to both settings and analytics pages — both had the same header-outside-scroll-container pattern with `mobileBack`.
- `AgentCreatePage` was not changed: it doesn't use `mobileBack` (no back button to get stuck on).

</details>