### PR TITLE
feat(cli/templatepush): read display_name, description, and icon from README.md frontmatter

### DIFF
--- a/cli/templatepush.go
+++ b/cli/templatepush.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bufio"
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -14,6 +15,7 @@ import (
 	"time"
 
 	"github.com/briandowns/spinner"
+	"github.com/gohugoio/hugo/parser/pageparser"
 	"github.com/google/uuid"
 	"golang.org/x/xerrors"
 
@@ -36,6 +38,9 @@ func (r *RootCmd) templatePush() *serpent.Command {
 		provisionerTags      []string
 		uploadFlags          templateUploadFlags
 		activate             bool
+		displayName          string
+		icon                 string
+		description          string
 		orgContext           = NewOrganizationContext()
 	)
 	cmd := &serpent.Command{
@@ -182,10 +187,29 @@ func (r *RootCmd) templatePush() *serpent.Command {
 				return xerrors.Errorf("job failed: %s", job.Job.Status)
 			}
 
+			// Read frontmatter from README.md if pushing from a
+			// directory (not stdin). CLI flags take precedence.
+			var fm templateFrontmatter
+			if !uploadFlags.stdin(inv) {
+				fm, _ = readTemplateFrontmatter(uploadFlags.directory)
+			}
+			if !userSetOption(inv, "display-name") {
+				displayName = fm.DisplayName
+			}
+			if !userSetOption(inv, "description") {
+				description = fm.Description
+			}
+			if !userSetOption(inv, "icon") {
+				icon = fm.Icon
+			}
+
 			if createTemplate {
 				_, err = client.CreateTemplate(inv.Context(), organization.ID, codersdk.CreateTemplateRequest{
-					Name:      name,
-					VersionID: job.ID,
+					Name:        name,
+					DisplayName: displayName,
+					Description: description,
+					Icon:        icon,
+					VersionID:   job.ID,
 				})
 				if err != nil {
 					return err
@@ -204,13 +228,38 @@ func (r *RootCmd) templatePush() *serpent.Command {
 				}
 			}
 
-			_, _ = fmt.Fprintf(inv.Stdout, "Updated version at %s!\n", pretty.Sprint(cliui.DefaultStyles.DateTimeStamp, time.Now().Format(time.Stamp)))
-			return nil
-		},
-	}
+			// Update template metadata if frontmatter or flags
+			// provided values that differ from the current
+			// template.
+			if !createTemplate && (displayName != "" || description != "" || icon != "") {
+				updatedDisplayName := displayName
+				if updatedDisplayName == "" {
+					updatedDisplayName = template.DisplayName
+				}
+				updatedDescription := description
+				if updatedDescription == "" {
+					updatedDescription = template.Description
+				}
+				updatedIcon := icon
+				if updatedIcon == "" {
+					updatedIcon = template.Icon
+				}
+				_, err = client.UpdateTemplateMeta(inv.Context(), template.ID, codersdk.UpdateTemplateMeta{
+					DisplayName: &updatedDisplayName,
+					Description: &updatedDescription,
+					Icon:        &updatedIcon,
+				})
+				if err != nil {
+					return xerrors.Errorf("update template metadata: %w", err)
+				}
+			}
 
-	cmd.Options = serpent.OptionSet{
-		{
+			_, _ = fmt.Fprintf(inv.Stdout, "Updated version at %s!\n", pretty.Sprint(cliui.DefaultStyles.DateTimeStamp, time.Now().Format(time.Stamp)))
+				return nil
+			},
+		}
+
+		cmd.Options = serpent.OptionSet{		{
 			Flag:        "test.provisioner",
 			Description: "Customize the provisioner backend.",
 			Default:     "terraform",
@@ -261,6 +310,21 @@ func (r *RootCmd) templatePush() *serpent.Command {
 			Description: "Whether the new template will be marked active.",
 			Default:     "true",
 			Value:       serpent.BoolOf(&activate),
+		},
+		{
+			Flag:        "display-name",
+			Description: "Set the display name of the template. If unset, the display_name field from the template's README.md frontmatter will be used, if available.",
+			Value:       serpent.StringOf(&displayName),
+		},
+		{
+			Flag:        "description",
+			Description: "Set the description of the template. If unset, the description field from the template's README.md frontmatter will be used, if available.",
+			Value:       serpent.StringOf(&description),
+		},
+		{
+			Flag:        "icon",
+			Description: "Set the icon of the template. If unset, the icon field from the template's README.md frontmatter will be used, if available.",
+			Value:       serpent.StringOf(&icon),
 		},
 		cliui.SkipPromptOption(),
 	}
@@ -682,4 +746,47 @@ func createVariableValidator(variable codersdk.TemplateVersionVariable) func(str
 		}
 		return nil
 	}
+}
+
+// templateFrontmatter holds metadata parsed from the YAML frontmatter
+// of a template's README.md. This uses the same schema as
+// coder/registry and our example templates.
+type templateFrontmatter struct {
+	DisplayName string
+	Description string
+	Icon        string
+}
+
+// readTemplateFrontmatter reads and parses YAML frontmatter from a
+// README.md in the given directory. It returns zero values without
+// error when the file is missing or has no frontmatter.
+func readTemplateFrontmatter(dir string) (templateFrontmatter, error) {
+	var fm templateFrontmatter
+	readme, err := os.ReadFile(filepath.Join(dir, "README.md"))
+	if err != nil {
+		return fm, nil //nolint:nilerr // Missing README is not an error.
+	}
+
+	parsed, err := pageparser.ParseFrontMatterAndContent(bytes.NewReader(readme))
+	if err != nil {
+		return fm, xerrors.Errorf("parse README.md frontmatter: %w", err)
+	}
+
+	if v, ok := parsed.FrontMatter["display_name"]; ok {
+		if s, ok := v.(string); ok {
+			fm.DisplayName = s
+		}
+	}
+	if v, ok := parsed.FrontMatter["description"]; ok {
+		if s, ok := v.(string); ok {
+			fm.Description = s
+		}
+	}
+	if v, ok := parsed.FrontMatter["icon"]; ok {
+		if s, ok := v.(string); ok {
+			fm.Icon = s
+		}
+	}
+
+	return fm, nil
 }

--- a/cli/templatepush_test.go
+++ b/cli/templatepush_test.go
@@ -1285,6 +1285,165 @@ cli_overrides_file_var: from-file`)
 			require.Equal(t, "from-cli-override", varMap["cli_overrides_file_var"])
 		})
 	})
+
+	t.Run("Frontmatter", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("CreateTemplateFromFrontmatter", func(t *testing.T) {
+			t.Parallel()
+			client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+			owner := coderdtest.CreateFirstUser(t, client)
+			templateAdmin, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID, rbac.RoleTemplateAdmin())
+
+			source := clitest.CreateTemplateVersionSource(t, &echo.Responses{
+				Parse:          echo.ParseComplete,
+				ProvisionApply: echo.ApplyComplete,
+			})
+
+			readme := `---
+display_name: My Template
+description: A template from frontmatter
+icon: /icon/docker.png
+---
+# My Template
+`
+			err := os.WriteFile(filepath.Join(source, "README.md"), []byte(readme), 0o600)
+			require.NoError(t, err)
+
+			const templateName = "frontmatter-test"
+			inv, root := clitest.New(t, "templates", "push", templateName,
+				"--directory", source,
+				"--test.provisioner", string(database.ProvisionerTypeEcho),
+				"--yes",
+			)
+			clitest.SetupConfig(t, templateAdmin, root)
+
+			ctx := testutil.Context(t, testutil.WaitMedium)
+			err = inv.WithContext(ctx).Run()
+			require.NoError(t, err)
+
+			template, err := client.TemplateByName(ctx, owner.OrganizationID, templateName)
+			require.NoError(t, err)
+			require.Equal(t, "My Template", template.DisplayName)
+			require.Equal(t, "A template from frontmatter", template.Description)
+			require.Equal(t, "/icon/docker.png", template.Icon)
+		})
+
+		t.Run("CLIFlagsOverrideFrontmatter", func(t *testing.T) {
+			t.Parallel()
+			client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+			owner := coderdtest.CreateFirstUser(t, client)
+			templateAdmin, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID, rbac.RoleTemplateAdmin())
+
+			source := clitest.CreateTemplateVersionSource(t, &echo.Responses{
+				Parse:          echo.ParseComplete,
+				ProvisionApply: echo.ApplyComplete,
+			})
+
+			readme := `---
+display_name: Frontmatter Name
+description: Frontmatter description
+icon: /icon/frontmatter.png
+---
+# My Template
+`
+			err := os.WriteFile(filepath.Join(source, "README.md"), []byte(readme), 0o600)
+			require.NoError(t, err)
+
+			const templateName = "flag-override-test"
+			inv, root := clitest.New(t, "templates", "push", templateName,
+				"--directory", source,
+				"--test.provisioner", string(database.ProvisionerTypeEcho),
+				"--display-name", "CLI Name",
+				"--description", "CLI description",
+				"--icon", "/icon/cli.png",
+				"--yes",
+			)
+			clitest.SetupConfig(t, templateAdmin, root)
+
+			ctx := testutil.Context(t, testutil.WaitMedium)
+			err = inv.WithContext(ctx).Run()
+			require.NoError(t, err)
+
+			template, err := client.TemplateByName(ctx, owner.OrganizationID, templateName)
+			require.NoError(t, err)
+			require.Equal(t, "CLI Name", template.DisplayName)
+			require.Equal(t, "CLI description", template.Description)
+			require.Equal(t, "/icon/cli.png", template.Icon)
+		})
+
+		t.Run("UpdateExistingTemplateMetadata", func(t *testing.T) {
+			t.Parallel()
+			client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+			owner := coderdtest.CreateFirstUser(t, client)
+			templateAdmin, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID, rbac.RoleTemplateAdmin())
+
+			version := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, nil)
+			_ = coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+			template := coderdtest.CreateTemplate(t, client, owner.OrganizationID, version.ID)
+
+			source := clitest.CreateTemplateVersionSource(t, &echo.Responses{
+				Parse:          echo.ParseComplete,
+				ProvisionApply: echo.ApplyComplete,
+			})
+
+			readme := `---
+display_name: Updated Name
+description: Updated description
+icon: /icon/updated.png
+---
+# Updated
+`
+			err := os.WriteFile(filepath.Join(source, "README.md"), []byte(readme), 0o600)
+			require.NoError(t, err)
+
+			inv, root := clitest.New(t, "templates", "push", template.Name,
+				"--directory", source,
+				"--test.provisioner", string(database.ProvisionerTypeEcho),
+				"--yes",
+			)
+			clitest.SetupConfig(t, templateAdmin, root)
+
+			ctx := testutil.Context(t, testutil.WaitMedium)
+			err = inv.WithContext(ctx).Run()
+			require.NoError(t, err)
+
+			updated, err := client.Template(ctx, template.ID)
+			require.NoError(t, err)
+			require.Equal(t, "Updated Name", updated.DisplayName)
+			require.Equal(t, "Updated description", updated.Description)
+			require.Equal(t, "/icon/updated.png", updated.Icon)
+		})
+
+		t.Run("NoReadmeNoError", func(t *testing.T) {
+			t.Parallel()
+			client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+			owner := coderdtest.CreateFirstUser(t, client)
+			templateAdmin, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID, rbac.RoleTemplateAdmin())
+
+			source := clitest.CreateTemplateVersionSource(t, &echo.Responses{
+				Parse:          echo.ParseComplete,
+				ProvisionApply: echo.ApplyComplete,
+			})
+			// No README.md written — should still succeed.
+
+			const templateName = "no-readme-test"
+			inv, root := clitest.New(t, "templates", "push", templateName,
+				"--directory", source,
+				"--test.provisioner", string(database.ProvisionerTypeEcho),
+				"--yes",
+			)
+			clitest.SetupConfig(t, templateAdmin, root)
+
+			ctx := testutil.Context(t, testutil.WaitMedium)
+			err := inv.WithContext(ctx).Run()
+			require.NoError(t, err)
+
+			template, err := client.TemplateByName(ctx, owner.OrganizationID, templateName)
+			require.NoError(t, err)
+			require.Empty(t, template.Icon)
+		})
+	})
 }
 
 func createEchoResponsesWithTemplateVariables(templateVariables []*proto.TemplateVariable) *echo.Responses {

--- a/cli/testdata/coder_templates_push_--help.golden
+++ b/cli/testdata/coder_templates_push_--help.golden
@@ -16,8 +16,20 @@ OPTIONS:
           Always prompt all parameters. Does not pull parameter values from
           active template version.
 
+      --description string
+          Set the description of the template. If unset, the description field
+          from the template's README.md frontmatter will be used, if available.
+
   -d, --directory string (default: .)
           Specify the directory to create from, use '-' to read tar from stdin.
+
+      --display-name string
+          Set the display name of the template. If unset, the display_name field
+          from the template's README.md frontmatter will be used, if available.
+
+      --icon string
+          Set the icon of the template. If unset, the icon field from the
+          template's README.md frontmatter will be used, if available.
 
       --ignore-lockfile bool (default: false)
           Ignore warnings about not having a .terraform.lock.hcl file present in


### PR DESCRIPTION
\`coder templates push\` now reads YAML frontmatter from the template directory's \`README.md\` and uses \`display_name\`, \`description\`, and \`icon\` when creating or updating a template. This uses the same Hugo \`pageparser\` already used by \`scripts/examplegen\` for starter templates.

- **Create path**: populates \`DisplayName\`, \`Description\`, and \`Icon\` in \`CreateTemplateRequest\`.
- **Update path**: calls \`UpdateTemplateMeta\` with frontmatter values.
- **CLI flags override**: new \`--display-name\`, \`--description\`, and \`--icon\` flags take precedence over frontmatter.
- **Stdin/missing README**: gracefully skipped.

Closes https://github.com/coder/coder/issues/23735

<details><summary>Implementation notes</summary>

- Reuses \`github.com/gohugoio/hugo/parser/pageparser\` (already in go.mod) for frontmatter parsing, same approach as \`scripts/examplegen/main.go\`.
- \`readTemplateFrontmatter()\` returns zero values without error when README.md is missing or has no frontmatter.
- On the update path, only calls \`UpdateTemplateMeta\` when at least one of display_name/description/icon is non-empty, preserving existing values for unset fields.
- \`userSetOption()\` (from \`cli/util.go\`) determines whether a CLI flag was explicitly set, so frontmatter is only used as a fallback.

</details>