### PR TITLE
fix: persist session cookie to disk to prevent PWA logout

### DIFF
--- a/coderd/apikey.go
+++ b/coderd/apikey.go
@@ -582,15 +582,20 @@ func (api *API) createAPIKey(ctx context.Context, params apikey.CreateParams) (*
 		Value:    sessionToken,
 		Path:     "/",
 		HttpOnly: true,
-		// MaxAge is set to the key's lifetime so the cookie is persisted to
-		// disk by the browser. Without this the cookie is a "session cookie"
-		// that lives only in memory. Standalone PWAs (display: standalone)
-		// run in their own browser process, and mobile OSes kill that
-		// process when the app is swiped away — which deletes in-memory
-		// cookies and forces an unexpected login.
+		// MaxAge is set so the browser persists the cookie to disk rather
+		// than keeping it in memory as a session cookie. Standalone PWAs
+		// (display: standalone) run in their own browser process, and
+		// mobile OSes kill that process when the app is swiped away —
+		// deleting in-memory cookies and forcing an unexpected login.
 		//
-		// Security is not affected: the server already validates the key's
-		// ExpiresAt on every request and refreshes it on activity.
-		MaxAge: int(newkey.LifetimeSeconds),
+		// We use a long static value (1 year) instead of the key's
+		// LifetimeSeconds because the server refreshes the key's
+		// ExpiresAt on activity but does not re-set the cookie. Tying
+		// MaxAge to the key lifetime would cause the cookie to expire
+		// client-side even when the server-side key is still valid.
+		//
+		// Security is not affected: the server validates ExpiresAt on
+		// every request regardless of the cookie's MaxAge.
+		MaxAge: int((365 * 24 * time.Hour).Seconds()),
 	}), &newkey, nil
 }

--- a/coderd/apikey.go
+++ b/coderd/apikey.go
@@ -582,5 +582,15 @@ func (api *API) createAPIKey(ctx context.Context, params apikey.CreateParams) (*
 		Value:    sessionToken,
 		Path:     "/",
 		HttpOnly: true,
+		// MaxAge is set to the key's lifetime so the cookie is persisted to
+		// disk by the browser. Without this the cookie is a "session cookie"
+		// that lives only in memory. Standalone PWAs (display: standalone)
+		// run in their own browser process, and mobile OSes kill that
+		// process when the app is swiped away — which deletes in-memory
+		// cookies and forces an unexpected login.
+		//
+		// Security is not affected: the server already validates the key's
+		// ExpiresAt on every request and refreshes it on activity.
+		MaxAge: int(newkey.LifetimeSeconds),
 	}), &newkey, nil
 }

--- a/coderd/apikey_test.go
+++ b/coderd/apikey_test.go
@@ -405,12 +405,7 @@ func TestSessionCookieMaxAge(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 	defer cancel()
 
-	dc := coderdtest.DeploymentValues(t)
-	dc.Sessions.DefaultDuration = serpent.Duration(time.Hour * 12)
-
-	client := coderdtest.New(t, &coderdtest.Options{
-		DeploymentValues: dc,
-	})
+	client := coderdtest.New(t, nil)
 
 	// Create the first user (password-based login).
 	req := codersdk.CreateFirstUserRequest{
@@ -433,13 +428,15 @@ func TestSessionCookieMaxAge(t *testing.T) {
 	defer res.Body.Close()
 	require.Equal(t, http.StatusCreated, res.StatusCode)
 
+	oneYear := int((365 * 24 * time.Hour).Seconds())
 	var found bool
 	for _, cookie := range res.Cookies() {
 		if cookie.Name == codersdk.SessionTokenCookie {
-			// MaxAge should match the configured session duration so the
-			// browser persists the cookie to disk.
-			require.Equal(t, int(dc.Sessions.DefaultDuration.Value().Seconds()), cookie.MaxAge,
-				"Session cookie MaxAge should match the configured session duration")
+			// MaxAge should be set to a long value so the browser
+			// persists the cookie to disk. The server handles real
+			// expiry via the API key's ExpiresAt field.
+			require.Equal(t, oneYear, cookie.MaxAge,
+				"Session cookie MaxAge should be set to 1 year for disk persistence")
 			found = true
 		}
 	}

--- a/coderd/apikey_test.go
+++ b/coderd/apikey_test.go
@@ -394,6 +394,58 @@ func TestSessionExpiry(t *testing.T) {
 	}
 }
 
+// TestSessionCookieMaxAge verifies that the session cookie is a persistent
+// cookie (has MaxAge set) rather than a session cookie. Standalone PWAs
+// run in their own browser process and mobile OSes purge in-memory
+// (session) cookies when that process is killed, so the cookie must be
+// persisted to disk.
+func TestSessionCookieMaxAge(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+	defer cancel()
+
+	dc := coderdtest.DeploymentValues(t)
+	dc.Sessions.DefaultDuration = serpent.Duration(time.Hour * 12)
+
+	client := coderdtest.New(t, &coderdtest.Options{
+		DeploymentValues: dc,
+	})
+
+	// Create the first user (password-based login).
+	req := codersdk.CreateFirstUserRequest{
+		Email:    "testuser@coder.com",
+		Username: "testuser",
+		Password: "SomeSecurePassword!",
+	}
+	_, err := client.CreateFirstUser(ctx, req)
+	require.NoError(t, err)
+
+	// Login via the raw HTTP endpoint so we can inspect the Set-Cookie header.
+	loginURL, err := client.URL.Parse("/api/v2/users/login")
+	require.NoError(t, err)
+
+	res, err := client.Request(ctx, http.MethodPost, loginURL.String(), codersdk.LoginWithPasswordRequest{
+		Email:    req.Email,
+		Password: req.Password,
+	})
+	require.NoError(t, err)
+	defer res.Body.Close()
+	require.Equal(t, http.StatusCreated, res.StatusCode)
+
+	var found bool
+	for _, cookie := range res.Cookies() {
+		if cookie.Name == codersdk.SessionTokenCookie {
+			// MaxAge should match the configured session duration so the
+			// browser persists the cookie to disk.
+			require.Equal(t, int(dc.Sessions.DefaultDuration.Value().Seconds()), cookie.MaxAge,
+				"Session cookie MaxAge should match the configured session duration")
+			found = true
+		}
+	}
+	require.True(t, found, "session cookie should be present in login response")
+}
+
 func TestAPIKey_OK(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem

The `/agents` PWA logs users out frequently when the app is backgrounded or swiped away, even though the normal site doesn't.

## Root Cause

The `coder_session_token` cookie was created **without `Expires` or `MaxAge`**, making it a transient session cookie that only lives in memory:

```go
return api.DeploymentValues.HTTPCookies.Apply(&http.Cookie{
    Name:     codersdk.SessionTokenCookie,
    Value:    sessionToken,
    Path:     "/",
    HttpOnly: true,
    // no Expires or MaxAge
})
```

- **Normal browser**: Session cookies persist because the browser process rarely fully terminates, and modern browsers restore them on restart.
- **Standalone PWA** (`display: standalone`): Runs in its own isolated browser process. When mobile OSes kill that process (user swipes the app away), **in-memory cookies are purged** — forcing re-login even though the server-side API key is still valid (default 24h, refreshed on activity).

## Fix

Set `MaxAge` on the cookie to match the API key's `LifetimeSeconds`, making it a persistent cookie written to disk.

This is safe because:
- The server already validates `ExpiresAt` on every request
- The server already refreshes expiry on activity (unless `DisableSessionExpiryRefresh` is set)
- The security model is unchanged — `MaxAge` only controls whether the browser writes the cookie to disk vs. keeping it in memory

<details><summary>Analysis details</summary>

### Cookie creation path
`coderd/apikey.go:createAPIKey()` → used by login, OAuth flows, and workspace app token issuance.

### Session lifetime flow
1. `apikey.Generate()` sets `LifetimeSeconds` from `Sessions.DefaultDuration` (default 24h)
2. `ValidateAPIKey()` in `httpmw/apikey.go` refreshes `ExpiresAt` in the DB when `ExpiresAt - now <= lifetime - 1h`
3. The cookie just needs to survive long enough to be sent with the next request — the server handles the rest

### Why the normal site isn't affected
Regular browser tabs share a long-lived browser process. Session cookies persist across tab closes and most browsers restore them on restart. The standalone PWA gets its own WebKit/Chromium instance that the OS can terminate independently.
</details>