### PR TITLE
fix(site): restore mobile back button on agent settings pages

### DIFF
--- a/site/src/pages/AgentsPage/AgentSettingsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsPage.tsx
@@ -1,9 +1,11 @@
 import type { FC } from "react";
-import { Outlet, useParams } from "react-router";
+import { Outlet, useLocation } from "react-router";
 import { AgentPageHeader } from "./components/AgentPageHeader";
 
 const AgentSettingsPage: FC = () => {
-	const { "*": section } = useParams();
+	const location = useLocation();
+	const match = location.pathname.match(/\/agents\/settings\/(.+)/);
+	const section = match?.[1];
 
 	return (
 		<>

--- a/site/src/router.tsx
+++ b/site/src/router.tsx
@@ -696,7 +696,7 @@ export const router = createBrowserRouter(
 				>
 					<Route index element={<AgentCreatePage />} />
 					<Route path="settings" element={<AgentSettingsPage />}>
-						<Route index element={<Navigate to="behavior" replace />} />
+						<Route index element={<AgentSettingsBehaviorPage />} />
 						<Route path="behavior" element={<AgentSettingsBehaviorPage />} />
 						<Route path="providers" element={<AgentSettingsProvidersPage />} />
 						<Route path="models" element={<AgentSettingsModelsPage />} />


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

## Fix

The refactor in #23648 broke mobile navigation in agent settings in two ways:

1. **Back button never rendered** — `AgentSettingsPage` used `useParams()["*"]` to detect the active section, but the route uses `path="settings"` (no wildcard), so the splat param was always `undefined`. This meant `mobileBack` was never set.

2. **Index redirect created a loop** — The index route used `<Navigate to="behavior" replace />`, so `/agents/settings` immediately redirected to `/agents/settings/behavior`. Even if the back button had worked, it would have looped back to the same page.

### Changes

- Derive the section from `useLocation().pathname` instead of `useParams()` so the layout can detect whether a sub-section is active.
- Render `AgentSettingsBehaviorPage` directly as the index route instead of redirecting, so `/agents/settings` is a real landing page.

This restores the pre-refactor mobile behavior: sub-pages show a "< Settings" back link, and the index page shows the standard header with nav icons.