### PR TITLE
fix: add missing AI Bridge links to mobile admin menu

### DIFF
--- a/site/src/modules/dashboard/Navbar/MobileMenu.stories.tsx
+++ b/site/src/modules/dashboard/Navbar/MobileMenu.stories.tsx
@@ -45,6 +45,7 @@ const meta: Meta<typeof MobileMenu> = {
 		canViewDeployment: true,
 		canViewHealth: true,
 		canViewOrganizations: true,
+		canViewAIBridge: true,
 	},
 	decorators: [withNavbarMock],
 };

--- a/site/src/modules/dashboard/Navbar/MobileMenu.tsx
+++ b/site/src/modules/dashboard/Navbar/MobileMenu.tsx
@@ -39,6 +39,7 @@ type MobileMenuPermissions = {
 	canViewAuditLog: boolean;
 	canViewConnectionLog: boolean;
 	canViewHealth: boolean;
+	canViewAIBridge: boolean;
 };
 
 type MobileMenuProps = MobileMenuPermissions & {
@@ -197,6 +198,7 @@ const AdminSettingsSub: FC<MobileMenuPermissions> = ({
 	canViewAuditLog,
 	canViewConnectionLog,
 	canViewHealth,
+	canViewAIBridge,
 }) => {
 	const [open, setOpen] = useState(false);
 
@@ -248,6 +250,22 @@ const AdminSettingsSub: FC<MobileMenuPermissions> = ({
 					>
 						<Link to="/connectionlog">Connection logs</Link>
 					</DropdownMenuItem>
+				)}
+				{canViewAIBridge && (
+					<>
+						<DropdownMenuItem
+							asChild
+							className={cn(itemStyles.default, itemStyles.sub)}
+						>
+							<Link to="/aibridge">AI Bridge Logs</Link>
+						</DropdownMenuItem>
+						<DropdownMenuItem
+							asChild
+							className={cn(itemStyles.default, itemStyles.sub)}
+						>
+							<Link to="/aibridge/sessions">AI Bridge Sessions</Link>
+						</DropdownMenuItem>
+					</>
 				)}
 				{canViewHealth && (
 					<DropdownMenuItem

--- a/site/src/modules/dashboard/Navbar/NavbarView.tsx
+++ b/site/src/modules/dashboard/Navbar/NavbarView.tsx
@@ -129,6 +129,7 @@ export const NavbarView: FC<NavbarViewProps> = ({
 						canViewOrganizations={canViewOrganizations}
 						canViewDeployment={canViewDeployment}
 						canViewHealth={canViewHealth}
+						canViewAIBridge={canViewAIBridge}
 					/>
 				</div>
 			</div>


### PR DESCRIPTION
The desktop `Admin settings` dropdown includes AI Bridge Logs and AI Bridge Sessions links, but the mobile menu was missing them because:

1. `MobileMenuPermissions` type lacked `canViewAIBridge`
2. `NavbarView` didn't pass `canViewAIBridge` to `MobileMenu`
3. `AdminSettingsSub` didn't render the AI Bridge links

This PR adds the `canViewAIBridge` permission and both links (`/aibridge`, `/aibridge/sessions`) to the mobile admin menu, matching the desktop dropdown ordering.