### PR TITLE
test(coderd/x/chatd): avoid zero-ttl config cache flake

### DIFF
--- a/coderd/x/chatd/configcache_test.go
+++ b/coderd/x/chatd/configcache_test.go
@@ -278,7 +278,7 @@ func TestConfigCache_UserPrompt_ExpiredEntryRefetches(t *testing.T) {
 		return fmt.Sprintf("prompt-%d", call), nil
 	}
 	cache := newChatConfigCache(ctx, store, clock)
-	cache.userPrompts.Set(userID, "stale", 0)
+	cache.userPrompts.Set(userID, "stale", -time.Second)
 
 	first, err := cache.UserPrompt(ctx, userID)
 	require.NoError(t, err)


### PR DESCRIPTION
This fixes a flaky `TestConfigCache_UserPrompt_ExpiredEntryRefetches` by making the seeded user prompt entry unambiguously expired before the cache lookup runs.

The test previously inserted a `tlru` entry with a zero TTL, which depends on `Set` and `Get` landing in different clock ticks. Switching that seed entry to a negative TTL keeps the bounded `tlru` cache behavior while removing the same-tick race.

Close https://github.com/coder/internal/issues/1431
