### PR TITLE
ci: don't cancel in-progress linear release runs on main

### DIFF
--- a/.github/workflows/linear-release.yaml
+++ b/.github/workflows/linear-release.yaml
@@ -13,7 +13,8 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Queue rather than cancel so back-to-back pushes to main don't cancel the first sync.
+  cancel-in-progress: false
 
 jobs:
   sync-main:


### PR DESCRIPTION
The Linear Release workflow had `cancel-in-progress: true` unconditionally, so a new push to `main` would cancel an already-running sync. This meant successive PR merges would show you a bunch of red Xs on CI, even though nothing was wrong.

<img width="958" height="305" alt="image" src="https://github.com/user-attachments/assets/1bd06948-ef2d-469f-9d48-a82277a6110c" />

Other workflows like CI guard against this with `cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}`.

This PR does the same thing to the linear release workflow. The job will be queued instead.

<img width="678" height="105" alt="image" src="https://github.com/user-attachments/assets/931e38c8-3de4-40d6-b156-d5de5726d094" />

Letting the job finish is not particularly wasteful or anything since the sync takes 30~ seconds in CI time.

