### PR TITLE
fix(site): align plus menu icons and add small switch variant

### DIFF
--- a/site/src/components/Switch/Switch.stories.tsx
+++ b/site/src/components/Switch/Switch.stories.tsx
@@ -36,3 +36,35 @@ export const DisabledOff: Story = {
 		disabled: true,
 	},
 };
+
+export const SmallOn: Story = {
+	args: {
+		checked: true,
+		disabled: false,
+		size: "sm",
+	},
+};
+
+export const SmallOff: Story = {
+	args: {
+		checked: false,
+		disabled: false,
+		size: "sm",
+	},
+};
+
+export const SmallDisabledOn: Story = {
+	args: {
+		checked: true,
+		disabled: true,
+		size: "sm",
+	},
+};
+
+export const SmallDisabledOff: Story = {
+	args: {
+		checked: false,
+		disabled: true,
+		size: "sm",
+	},
+};

--- a/site/src/components/Switch/Switch.tsx
+++ b/site/src/components/Switch/Switch.tsx
@@ -35,7 +35,7 @@ const thumbVariants = cva(
 			size: {
 				default:
 					"h-4 w-4 data-[state=checked]:translate-x-2.5 data-[state=unchecked]:-translate-x-1.5",
-				sm: "h-3 w-3 data-[state=checked]:translate-x-2 data-[state=unchecked]:-translate-x-1",
+				sm: "h-3 w-3 data-[state=checked]:translate-x-1.5 data-[state=unchecked]:-translate-x-1.5",
 			},
 		},
 		defaultVariants: {

--- a/site/src/components/Switch/Switch.tsx
+++ b/site/src/components/Switch/Switch.tsx
@@ -3,30 +3,59 @@
  * @see {@link https://ui.shadcn.com/docs/components/switch}
  */
 import * as SwitchPrimitives from "@radix-ui/react-switch";
+import { type VariantProps, cva } from "class-variance-authority";
 import { cn } from "#/utils/cn";
 
-export const Switch: React.FC<
-	React.ComponentPropsWithRef<typeof SwitchPrimitives.Root>
-> = ({ className, ...props }) => (
+const switchVariants = cva(
+	`peer inline-flex shrink-0 cursor-pointer items-center rounded-full shadow-sm transition-colors
+	border-2 border-transparent
+	focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-content-link
+	focus-visible:ring-offset-2 focus-visible:ring-offset-surface-primary
+	disabled:cursor-not-allowed
+	data-[state=checked]:disabled:bg-surface-tertiary data-[state=unchecked]:disabled:bg-surface-tertiary
+	data-[state=checked]:hover:bg-surface-invert-secondary data-[state=unchecked]:hover:bg-surface-tertiary
+	data-[state=checked]:bg-surface-invert-primary data-[state=unchecked]:bg-surface-quaternary`,
+	{
+		variants: {
+			size: {
+				default: "h-5 w-9",
+				sm: "h-4 w-7",
+			},
+		},
+		defaultVariants: {
+			size: "default",
+		},
+	},
+);
+
+const thumbVariants = cva(
+	"pointer-events-none block rounded-full bg-surface-primary shadow-lg ring-0 transition-transform",
+	{
+		variants: {
+			size: {
+				default:
+					"h-4 w-4 data-[state=checked]:translate-x-2.5 data-[state=unchecked]:-translate-x-1.5",
+				sm: "h-3 w-3 data-[state=checked]:translate-x-2 data-[state=unchecked]:-translate-x-1",
+			},
+		},
+		defaultVariants: {
+			size: "default",
+		},
+	},
+);
+
+type SwitchProps = React.ComponentPropsWithRef<typeof SwitchPrimitives.Root> &
+	VariantProps<typeof switchVariants>;
+
+export const Switch: React.FC<SwitchProps> = ({
+	className,
+	size,
+	...props
+}) => (
 	<SwitchPrimitives.Root
-		className={cn(
-			`peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full shadow-sm transition-colors
-			border-2 border-transparent
-			focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-content-link
-			focus-visible:ring-offset-2 focus-visible:ring-offset-surface-primary
-			disabled:cursor-not-allowed
-			data-[state=checked]:disabled:bg-surface-tertiary data-[state=unchecked]:disabled:bg-surface-tertiary
-			data-[state=checked]:hover:bg-surface-invert-secondary data-[state=unchecked]:hover:bg-surface-tertiary
-			data-[state=checked]:bg-surface-invert-primary data-[state=unchecked]:bg-surface-quaternary`,
-			className,
-		)}
+		className={cn(switchVariants({ size }), className)}
 		{...props}
 	>
-		<SwitchPrimitives.Thumb
-			className={cn(
-				`pointer-events-none block h-4 w-4 rounded-full bg-surface-primary shadow-lg ring-0 transition-transform
-				data-[state=checked]:translate-x-2.5 data-[state=unchecked]:-translate-x-1.5`,
-			)}
-		/>
+		<SwitchPrimitives.Thumb className={cn(thumbVariants({ size }))} />
 	</SwitchPrimitives.Root>
 );

--- a/site/src/components/Switch/Switch.tsx
+++ b/site/src/components/Switch/Switch.tsx
@@ -3,7 +3,7 @@
  * @see {@link https://ui.shadcn.com/docs/components/switch}
  */
 import * as SwitchPrimitives from "@radix-ui/react-switch";
-import { type VariantProps, cva } from "class-variance-authority";
+import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "#/utils/cn";
 
 const switchVariants = cva(

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -1126,7 +1126,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 													) : (
 														<ServerIcon className="h-3.5 w-3.5 shrink-0 text-content-secondary" />
 													)}
-													<span className="min-w-0 flex-1 truncate text-xs text-content-primary">
+													<span className="min-w-0 flex-1 truncate text-xs text-content-secondary">
 														{server.display_name}
 													</span>
 													{needsAuth ? (

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -1038,7 +1038,8 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 										}}
 										className="group flex h-8 w-full cursor-pointer items-center gap-1.5 border-none bg-transparent px-1 text-xs text-content-secondary shadow-none transition-colors hover:text-content-primary"
 									>
-										<ImageIcon className="size-3.5 shrink-0" /> Attach image
+										<ImageIcon className="size-3.5 shrink-0" />
+										Attach image
 									</button>
 								)}
 								{workspaceOptions && onWorkspaceChange && (

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -1052,7 +1052,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 												disabled={isDisabled || isWorkspaceLoading}
 												className="group flex h-8 w-full cursor-pointer items-center gap-1.5 border-none bg-transparent px-1 text-xs text-content-secondary shadow-none transition-colors hover:text-content-primary disabled:cursor-not-allowed disabled:opacity-50"
 											>
-												<MonitorIcon className="size-3.5 shrink-0" />{" "}
+												<MonitorIcon className="size-3.5 shrink-0" />
 												<span>Attach workspace</span>
 												<ChevronRightIcon
 													className={cn(

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -1036,9 +1036,9 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 											setPlusMenuOpen(false);
 											fileInputRef.current?.click();
 										}}
-										className="group flex h-8 w-full cursor-pointer items-center gap-1.5 border-none bg-transparent px-1 text-xs text-content-secondary shadow-none transition-colors hover:text-content-primary"
+										className="group flex h-8 w-full cursor-pointer items-center gap-2 border-none bg-transparent px-2 text-xs text-content-secondary shadow-none transition-colors hover:text-content-primary"
 									>
-										<ImageIcon className="h-3.5 w-3.5 shrink-0" />
+										<ImageIcon className="size-4 shrink-0" />
 										Attach image
 									</button>
 								)}
@@ -1051,9 +1051,9 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 											<button
 												type="button"
 												disabled={isDisabled || isWorkspaceLoading}
-												className="group flex h-8 w-full cursor-pointer items-center gap-1.5 border-none bg-transparent px-1 text-xs text-content-secondary shadow-none transition-colors hover:text-content-primary disabled:cursor-not-allowed disabled:opacity-50"
+												className="group flex h-8 w-full cursor-pointer items-center gap-2 border-none bg-transparent px-2 text-xs text-content-secondary shadow-none transition-colors hover:text-content-primary disabled:cursor-not-allowed disabled:opacity-50"
 											>
-												<MonitorIcon className="h-3.5 w-3.5 shrink-0" />
+												<MonitorIcon className="size-4 shrink-0" />
 												<span>Attach workspace</span>
 												<ChevronRightIcon
 													className={cn(
@@ -1145,6 +1145,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 														</Button>
 													) : (
 														<Switch
+															size="sm"
 															checked={isSelected}
 															onCheckedChange={(checked) =>
 																handleMcpToggle(server.id, checked)

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -1038,7 +1038,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 										}}
 										className="group flex h-8 w-full cursor-pointer items-center gap-1.5 border-none bg-transparent px-1 text-xs text-content-secondary shadow-none transition-colors hover:text-content-primary"
 									>
-										<ImageIcon className="h-3.5 w-3.5 shrink-0" /> Attach image
+										<ImageIcon className="size-3.5 shrink-0" /> Attach image
 									</button>
 								)}
 								{workspaceOptions && onWorkspaceChange && (
@@ -1052,7 +1052,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 												disabled={isDisabled || isWorkspaceLoading}
 												className="group flex h-8 w-full cursor-pointer items-center gap-1.5 border-none bg-transparent px-1 text-xs text-content-secondary shadow-none transition-colors hover:text-content-primary disabled:cursor-not-allowed disabled:opacity-50"
 											>
-												<MonitorIcon className="h-3.5 w-3.5 shrink-0" />{" "}
+												<MonitorIcon className="size-3.5 shrink-0" />{" "}
 												<span>Attach workspace</span>
 												<ChevronRightIcon
 													className={cn(
@@ -1121,10 +1121,10 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 														<ExternalImage
 															src={server.icon_url}
 															alt=""
-															className="h-3.5 w-3.5 shrink-0 rounded-sm"
+															className="size-3.5 shrink-0 rounded-sm"
 														/>
 													) : (
-														<ServerIcon className="h-3.5 w-3.5 shrink-0 text-content-secondary" />
+														<ServerIcon className="size-3.5 shrink-0 text-content-secondary" />
 													)}
 													<span className="min-w-0 flex-1 truncate text-xs text-content-secondary">
 														{server.display_name}

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -1036,10 +1036,9 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 											setPlusMenuOpen(false);
 											fileInputRef.current?.click();
 										}}
-										className="group flex h-8 w-full cursor-pointer items-center gap-2 border-none bg-transparent px-2 text-xs text-content-secondary shadow-none transition-colors hover:text-content-primary"
+										className="group flex h-8 w-full cursor-pointer items-center gap-1.5 border-none bg-transparent px-1 text-xs text-content-secondary shadow-none transition-colors hover:text-content-primary"
 									>
-										<ImageIcon className="size-4 shrink-0" />
-										Attach image
+										<ImageIcon className="h-3.5 w-3.5 shrink-0" /> Attach image
 									</button>
 								)}
 								{workspaceOptions && onWorkspaceChange && (
@@ -1051,9 +1050,9 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 											<button
 												type="button"
 												disabled={isDisabled || isWorkspaceLoading}
-												className="group flex h-8 w-full cursor-pointer items-center gap-2 border-none bg-transparent px-2 text-xs text-content-secondary shadow-none transition-colors hover:text-content-primary disabled:cursor-not-allowed disabled:opacity-50"
+												className="group flex h-8 w-full cursor-pointer items-center gap-1.5 border-none bg-transparent px-1 text-xs text-content-secondary shadow-none transition-colors hover:text-content-primary disabled:cursor-not-allowed disabled:opacity-50"
 											>
-												<MonitorIcon className="size-4 shrink-0" />
+												<MonitorIcon className="h-3.5 w-3.5 shrink-0" />{" "}
 												<span>Attach workspace</span>
 												<ChevronRightIcon
 													className={cn(
@@ -1116,16 +1115,16 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 											return (
 												<div
 													key={server.id}
-													className="flex items-center gap-2 px-2 py-1.5"
+													className="flex items-center gap-1.5 px-1 py-1.5"
 												>
 													{server.icon_url ? (
 														<ExternalImage
 															src={server.icon_url}
 															alt=""
-															className="size-4 shrink-0 rounded-sm"
+															className="h-3.5 w-3.5 shrink-0 rounded-sm"
 														/>
 													) : (
-														<ServerIcon className="size-4 shrink-0 text-content-secondary" />
+														<ServerIcon className="h-3.5 w-3.5 shrink-0 text-content-secondary" />
 													)}
 													<span className="min-w-0 flex-1 truncate text-xs text-content-primary">
 														{server.display_name}


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

The plus menu popover had inconsistent alignment: "Attach image" used `px-1 gap-1.5` with a 14px icon while MCP server rows used `px-2 gap-2` with 16px icons. The Switch component also felt oversized for the compact popover context.

Normalized all rows to `px-2 gap-2` with `size-4` icons so left edges align. Added a `size="sm"` variant to the Switch component (`h-4 w-7` root, `h-3 w-3` thumb) and used it on the MCP server toggles.