### PR TITLE
refactor(site): move AgentChatPageView to correct directory

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -43,7 +43,7 @@ import {
 	AgentChatPageLoadingView,
 	AgentChatPageNotFoundView,
 	AgentChatPageView,
-} from "./components/AgentChatPageView";
+} from "./AgentChatPageView";
 import {
 	getParentChatID,
 	getWorkspaceAgent,

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -37,13 +37,13 @@ import {
 import { isMobileViewport } from "#/utils/mobile";
 import { pageTitle } from "#/utils/page";
 import { rewriteLocalhostURL } from "#/utils/portForward";
-import type { AgentsOutletContext } from "./AgentsPage";
-import type { ChatMessageInputRef } from "./components/AgentChatInput";
 import {
 	AgentChatPageLoadingView,
 	AgentChatPageNotFoundView,
 	AgentChatPageView,
 } from "./AgentChatPageView";
+import type { AgentsOutletContext } from "./AgentsPage";
+import type { ChatMessageInputRef } from "./components/AgentChatInput";
 import {
 	getParentChatID,
 	getWorkspaceAgent,

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -10,14 +10,14 @@ import {
 	withAuthProvider,
 	withDashboardProvider,
 } from "#/testHelpers/storybook";
-import type { ChatDetailError } from "../utils/usageLimitMessage";
+import type { ChatDetailError } from "./utils/usageLimitMessage";
 import {
 	AgentChatPageLoadingView,
 	AgentChatPageNotFoundView,
 	AgentChatPageView,
 } from "./AgentChatPageView";
-import { createChatStore } from "./ChatConversation/chatStore";
-import type { ModelSelectorOption } from "./ChatElements";
+import { createChatStore } from "./components/ChatConversation/chatStore";
+import type { ModelSelectorOption } from "./components/ChatElements";
 
 // ---------------------------------------------------------------------------
 // Shared constants & helpers

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -10,7 +10,6 @@ import {
 	withAuthProvider,
 	withDashboardProvider,
 } from "#/testHelpers/storybook";
-import type { ChatDetailError } from "./utils/usageLimitMessage";
 import {
 	AgentChatPageLoadingView,
 	AgentChatPageNotFoundView,
@@ -18,6 +17,7 @@ import {
 } from "./AgentChatPageView";
 import { createChatStore } from "./components/ChatConversation/chatStore";
 import type { ModelSelectorOption } from "./components/ChatElements";
+import type { ChatDetailError } from "./utils/usageLimitMessage";
 
 // ---------------------------------------------------------------------------
 // Shared constants & helpers

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -13,7 +13,6 @@ import type { ChatDiffStatus, ChatMessagePart } from "#/api/typesGenerated";
 import { Button } from "#/components/Button/Button";
 import { cn } from "#/utils/cn";
 import { pageTitle } from "#/utils/page";
-import type { ChatDetailError } from "./utils/usageLimitMessage";
 import {
 	AgentChatInput,
 	type ChatMessageInputRef,
@@ -30,6 +29,7 @@ import { ChatTopBar } from "./components/ChatTopBar";
 import { GitPanel } from "./components/GitPanel/GitPanel";
 import { RightPanel } from "./components/RightPanel/RightPanel";
 import { SidebarTabView } from "./components/Sidebar/SidebarTabView";
+import type { ChatDetailError } from "./utils/usageLimitMessage";
 
 type ChatStoreHandle = ReturnType<typeof useChatStore>["store"];
 

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -13,20 +13,20 @@ import type { ChatDiffStatus, ChatMessagePart } from "#/api/typesGenerated";
 import { Button } from "#/components/Button/Button";
 import { cn } from "#/utils/cn";
 import { pageTitle } from "#/utils/page";
-import type { ChatDetailError } from "../utils/usageLimitMessage";
-import { AgentChatInput, type ChatMessageInputRef } from "./AgentChatInput";
+import type { ChatDetailError } from "./utils/usageLimitMessage";
+import { AgentChatInput, type ChatMessageInputRef } from "./components/AgentChatInput";
 import {
 	ChatConversationSkeleton,
 	RightPanelSkeleton,
-} from "./AgentsSkeletons";
-import type { useChatStore } from "./ChatConversation/chatStore";
-import type { ModelSelectorOption } from "./ChatElements";
-import { DesktopPanelContext } from "./ChatElements/tools/DesktopPanelContext";
-import { ChatPageInput, ChatPageTimeline } from "./ChatPageContent";
-import { ChatTopBar } from "./ChatTopBar";
-import { GitPanel } from "./GitPanel/GitPanel";
-import { RightPanel } from "./RightPanel/RightPanel";
-import { SidebarTabView } from "./Sidebar/SidebarTabView";
+} from "./components/AgentsSkeletons";
+import type { useChatStore } from "./components/ChatConversation/chatStore";
+import type { ModelSelectorOption } from "./components/ChatElements";
+import { DesktopPanelContext } from "./components/ChatElements/tools/DesktopPanelContext";
+import { ChatPageInput, ChatPageTimeline } from "./components/ChatPageContent";
+import { ChatTopBar } from "./components/ChatTopBar";
+import { GitPanel } from "./components/GitPanel/GitPanel";
+import { RightPanel } from "./components/RightPanel/RightPanel";
+import { SidebarTabView } from "./components/Sidebar/SidebarTabView";
 
 type ChatStoreHandle = ReturnType<typeof useChatStore>["store"];
 

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -14,7 +14,10 @@ import { Button } from "#/components/Button/Button";
 import { cn } from "#/utils/cn";
 import { pageTitle } from "#/utils/page";
 import type { ChatDetailError } from "./utils/usageLimitMessage";
-import { AgentChatInput, type ChatMessageInputRef } from "./components/AgentChatInput";
+import {
+	AgentChatInput,
+	type ChatMessageInputRef,
+} from "./components/AgentChatInput";
 import {
 	ChatConversationSkeleton,
 	RightPanelSkeleton,


### PR DESCRIPTION
Moves `AgentChatPageView.tsx` and its stories file out of `components/` up to
`AgentsPage/`, matching the convention used by every other `*PageView.tsx` in
that directory. Updates all imports accordingly.

> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖