### PR TITLE
fix(site/AgentsPage): fix Safari scroll jumping in agents chat

### DIFF
--- a/site/src/pages/AgentsPage/components/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatPageView.tsx
@@ -789,7 +789,16 @@ const ScrollAnchoredContainer: FC<{
 		};
 
 		const scheduleBottomPin = () => {
-			cancelPendingPins();
+			// If a pin is already in-flight, let it complete. The
+			// inner RAF reads scrollHeight at execution time so it
+			// always targets the latest bottom. Cancelling and
+			// rescheduling on every ResizeObserver notification
+			// starves the pin on Safari, where sticky-element
+			// repositioning generates extra resize events that
+			// perpetually restart the double-RAF chain.
+			if (pinOuterRafId !== null || pinInnerRafId !== null) {
+				return;
+			}
 			pendingWheelPinRef.current = false;
 			isRestoringScrollRef.current = true;
 			// Double-RAF lets React's commit phase and the browser's
@@ -1146,7 +1155,7 @@ const ScrollAnchoredContainer: FC<{
 			<div
 				ref={scrollContainerRef}
 				data-testid="scroll-container"
-				className="flex min-h-0 flex-1 flex-col overflow-y-auto [overflow-anchor:none] [scrollbar-gutter:stable] [scrollbar-width:thin] [scrollbar-color:hsl(var(--surface-quaternary))_transparent]"
+				className="flex min-h-0 flex-1 flex-col overflow-y-auto [overflow-anchor:none] [overscroll-behavior:contain] [scrollbar-gutter:stable] [scrollbar-width:thin] [scrollbar-color:hsl(var(--surface-quaternary))_transparent]"
 			>
 				<div ref={contentRef}>
 					{hasMoreMessages && (

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -698,9 +698,13 @@ const StickyUserMessage = memo<{
 				}
 			}
 			setIsReady(true);
+			// Use the scroll container as root so the observer is
+			// insensitive to viewport changes (e.g. Safari address
+			// bar show/hide), which would otherwise fire spurious
+			// isStuck toggles and trigger re-renders.
 			const observer = new IntersectionObserver(
 				([entry]) => setIsStuck(!entry.isIntersecting),
-				{ threshold: 0 },
+				{ threshold: 0, root: scroller },
 			);
 			observer.observe(sentinel);
 			return () => observer.disconnect();
@@ -866,7 +870,7 @@ const StickyUserMessage = memo<{
 				<div
 					ref={containerRef}
 					className={cn(
-						"relative px-3 -mx-3 -mt-3",
+						"relative px-3 -mx-3 -mt-3 [contain:layout_style]",
 						!isTooTall && "sticky z-10",
 						!isReady && "invisible",
 						isStuck && !isTooTall && "pointer-events-none",


### PR DESCRIPTION
The scroll-to-bottom pin uses double-RAF but cancelled the pending pin on
every new ResizeObserver notification. During streaming, SmoothText changes
content height every frame. In Chrome/Firefox, sub-pixel deltas fall below
the 1px threshold between line wraps, giving the pin time to complete. In
Safari, each StickyUserMessage's dynamic `position:sticky` `top` changes
generate extra resize events that perpetually restart the double-RAF chain,
starving the pin so it never fires.

The idle jumping comes from the StickyUserMessage IntersectionObserver using
the viewport as root (Safari address bar changes fire it) and the 60s
`chatUsageLimitStatus` refetch.

Four fixes:

1. **Make `scheduleBottomPin()` idempotent.** If a pin is already
   in-flight, skip. The inner RAF reads `scrollHeight` at execution time so
   it always targets the latest bottom. User-interrupt paths (wheel, touch)
   still cancel via `cancelPendingPins()`.

2. **Add `overscroll-behavior:contain`** to the scroll container. Prevents
   elastic scrolling from generating extra scroll events.

3. **Use scroll container as IntersectionObserver root** for
   StickyUserMessage. Makes `isStuck` insensitive to viewport changes.

4. **Add `contain:layout style`** to the sticky container. Isolates its
   `style.top` mutations from the parent ResizeObserver.

<details><summary>Diagnostic notes</summary>

The root cause is a feedback loop between `StickyUserMessage` and
`ScrollAnchoredContainer`. Each user message creates its own
ResizeObserver on `scroller.firstElementChild` (same element as
`contentRef`). When content resizes, `update()` forces layout via
`getBoundingClientRect()` then sets `container.style.top` on the sticky
element. In Safari, this triggers an additional layout recalculation that
the content ResizeObserver picks up, calling `scheduleBottomPin()` again
and cancelling the pending pin.

With N user messages, there are N ResizeObservers on the same element,
N forced layouts, and N `style.top` mutations per frame. Deduplicating
these into a shared observer is a further improvement but a larger
refactor, deferred.

</details>

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻