### PR TITLE
fix(site/src/pages/AgentsPage): fix scroll-to-bottom pin starvation in agents chat

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -792,7 +792,16 @@ const ScrollAnchoredContainer: FC<{
 		};
 
 		const scheduleBottomPin = () => {
-			cancelPendingPins();
+			// If a pin is already in-flight, let it complete. The
+			// inner RAF reads scrollHeight at execution time so it
+			// always targets the latest bottom. Cancelling and
+			// rescheduling on every ResizeObserver notification
+			// starves the pin on Safari, where sticky-element
+			// repositioning generates extra resize events that
+			// perpetually restart the double-RAF chain.
+			if (pinOuterRafId !== null || pinInnerRafId !== null) {
+				return;
+			}
 			pendingWheelPinRef.current = false;
 			isRestoringScrollRef.current = true;
 			// Double-RAF lets React's commit phase and the browser's
@@ -1149,7 +1158,7 @@ const ScrollAnchoredContainer: FC<{
 			<div
 				ref={scrollContainerRef}
 				data-testid="scroll-container"
-				className="flex min-h-0 flex-1 flex-col overflow-y-auto [overflow-anchor:none] [scrollbar-gutter:stable] [scrollbar-width:thin] [scrollbar-color:hsl(var(--surface-quaternary))_transparent]"
+				className="flex min-h-0 flex-1 flex-col overflow-y-auto [overflow-anchor:none] [overscroll-behavior:contain] [scrollbar-gutter:stable] [scrollbar-width:thin] [scrollbar-color:hsl(var(--surface-quaternary))_transparent]"
 			>
 				<div ref={contentRef}>
 					{hasMoreMessages && (


### PR DESCRIPTION
scheduleBottomPin() cancelled any in-flight pin and restarted the double-RAF
chain on every ResizeObserver notification. When content height changes on
consecutive frames (streaming with SmoothText + markdown re-rendering), the
inner RAF that sets scrollTop is perpetually cancelled before it fires.

Proved via a frame-pipeline simulation that models the browser spec ordering
(RAF callbacks -> layout -> ResizeObserver callbacks): with the original
cancel-and-reschedule pattern, the pin never executes while content grows.
With the idempotent version, it fires every 2 frames.

Two fixes:

1. **Make `scheduleBottomPin()` idempotent.** If a pin is already in-flight,
   skip. The inner RAF reads `scrollHeight` at execution time so it always
   targets the latest bottom. User-interrupt paths (wheel, touch) still
   cancel via `cancelPendingPins()`.

2. **Add `overscroll-behavior: contain`** to the scroll container. Prevents
   elastic overscroll from generating extra scroll events that could flip
   `autoScrollRef` to false.

The idle-after-chat-switch jumping is not addressed here. The initial mount
pin uses the same `scheduleBottomPin()` so fix #1 helps, but the root cause
of repeated jumps after navigation needs further investigation with Safari
instrumentation.

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻