### PR TITLE
feat: add docker-boundary-sandbox example template

### DIFF
--- a/examples/templates/x/docker-boundary-sandbox/Dockerfile.boundary
+++ b/examples/templates/x/docker-boundary-sandbox/Dockerfile.boundary
@@ -1,0 +1,21 @@
+FROM codercom/enterprise-base:ubuntu
+
+USER root
+
+# Install the Coder CLI so Agent Boundaries is available in the image.
+# Matching the CLI version to your deployment avoids boundary drift.
+RUN curl -fsSL https://coder.com/install.sh | sh
+
+# Start the hidden chat agent through a small wrapper so every child process
+# inherits the same network policy.
+COPY boundary-agent.sh /usr/local/bin/boundary-agent
+RUN chmod 755 /usr/local/bin/boundary-agent
+
+# Bake the allowlist into the image so the hidden agent always starts with a
+# known-good policy, even on a fresh shared home volume.
+RUN mkdir -p /etc/coder_boundary
+COPY boundary-config.yaml /etc/coder_boundary/config.yaml
+
+# Keep HOME aligned with the shared Docker volume because the boundary wrapper
+# copies its config into the per-user config directory at startup.
+ENV HOME=/home/coder

--- a/examples/templates/x/docker-boundary-sandbox/README.md
+++ b/examples/templates/x/docker-boundary-sandbox/README.md
@@ -46,7 +46,7 @@ agent can talk to, and bubblewrap limits what it can read or write.
 ## Network policy
 
 | Traffic                               | Policy                                 |
-| ------------------------------------- | -------------------------------------- |
+|---------------------------------------|----------------------------------------|
 | Coder server (`host.docker.internal`) | Allowed                                |
 | Anthropic API                         | Allowed                                |
 | All other HTTP/HTTPS                  | Denied and logged                      |
@@ -68,7 +68,7 @@ agent can talk to, and bubblewrap limits what it can read or write.
 ## Docker runtime requirements
 
 | Requirement          | Why                                                                         |
-| -------------------- | --------------------------------------------------------------------------- |
+|----------------------|-----------------------------------------------------------------------------|
 | `CAP_NET_ADMIN`      | `nsjail` needs it to create network namespaces                              |
 | `seccomp=unconfined` | Docker's default seccomp profile blocks the `clone` patterns `nsjail` needs |
 

--- a/examples/templates/x/docker-boundary-sandbox/README.md
+++ b/examples/templates/x/docker-boundary-sandbox/README.md
@@ -45,13 +45,13 @@ agent can talk to, and bubblewrap limits what it can read or write.
 
 ## Network policy
 
-| Traffic | Policy |
-|---------|--------|
-| Coder server (`host.docker.internal`) | Allowed |
-| Anthropic API | Allowed |
-| All other HTTP/HTTPS | Denied and logged |
-| Non-HTTP traffic (DNS, raw TCP) | Controlled by nsjail network namespace |
-| Visible dev agent | Unrestricted |
+| Traffic                               | Policy                                 |
+| ------------------------------------- | -------------------------------------- |
+| Coder server (`host.docker.internal`) | Allowed                                |
+| Anthropic API                         | Allowed                                |
+| All other HTTP/HTTPS                  | Denied and logged                      |
+| Non-HTTP traffic (DNS, raw TCP)       | Controlled by nsjail network namespace |
+| Visible dev agent                     | Unrestricted                           |
 
 ## How the sandbox works
 
@@ -67,9 +67,9 @@ agent can talk to, and bubblewrap limits what it can read or write.
 
 ## Docker runtime requirements
 
-| Requirement | Why |
-|-------------|-----|
-| `CAP_NET_ADMIN` | `nsjail` needs it to create network namespaces |
+| Requirement          | Why                                                                         |
+| -------------------- | --------------------------------------------------------------------------- |
+| `CAP_NET_ADMIN`      | `nsjail` needs it to create network namespaces                              |
 | `seccomp=unconfined` | Docker's default seccomp profile blocks the `clone` patterns `nsjail` needs |
 
 The visible `dev` container runs without extra capabilities.

--- a/examples/templates/x/docker-boundary-sandbox/README.md
+++ b/examples/templates/x/docker-boundary-sandbox/README.md
@@ -1,0 +1,108 @@
+---
+display_name: Docker + Boundary Sandbox
+description: Two-agent Docker template with an Agent Boundaries network-sandboxed chat agent
+icon: ../../../../site/static/icon/docker.png
+maintainer_github: coder
+tags: [docker, container, chat, boundary]
+---
+
+# Docker + Boundary Sandbox
+
+> [!WARNING]
+> This template is experimental.
+> It depends on the `-coderd-chat` agent naming convention, which is an
+> internal proof-of-concept integration detail.
+> Do not rely on this template shape for production deployments.
+> Agent Boundaries is also a Coder Enterprise feature, so the hidden chat
+> agent will not be network-sandboxed on unlicensed deployments.
+
+This example provisions two Docker-backed agents that share the same
+`/home/coder` volume but run in separate containers. The visible `dev`
+agent behaves like a normal development workspace, while the hidden
+`dev-coderd-chat` agent runs behind Agent Boundaries.
+
+## How it works
+
+The workspace has two agents:
+
+- **`dev`**: Standard development agent with code-server. It is visible in the
+  dashboard and has unrestricted networking.
+- **`dev-coderd-chat`**: Hidden chat-only agent. The `-coderd-chat` suffix tells
+  chat routing to target this agent and keeps it out of the normal UI. Its
+  process tree is wrapped by `coder boundary`.
+
+Both agents mount the same persistent `/home/coder` volume, so they can share
+source code and workspace state while still using different runtime policies.
+
+## Agent Boundaries vs bubblewrap
+
+The `docker-chat-sandbox` example uses bubblewrap for **filesystem isolation**,
+which keeps the chat agent on a read-only root filesystem with a writable home
+mount. This template uses Agent Boundaries for **network policy isolation**,
+which allowlists outbound HTTP and HTTPS destinations and denies everything
+else by default. These controls are complementary: Boundary limits what the
+agent can talk to, and bubblewrap limits what it can read or write.
+
+## Network policy
+
+| Traffic | Policy |
+|---------|--------|
+| Coder server (`host.docker.internal`) | Allowed |
+| Anthropic API | Allowed |
+| All other HTTP/HTTPS | Denied and logged |
+| Non-HTTP traffic (DNS, raw TCP) | Controlled by nsjail network namespace |
+| Visible dev agent | Unrestricted |
+
+## How the sandbox works
+
+1. `boundary-agent.sh` copies `boundary-config.yaml` into
+   `~/.config/coder_boundary/config.yaml` and launches
+   `coder boundary -- sh /tmp/coder-init.sh`.
+2. `nsjail` creates a network namespace for the hidden chat agent.
+3. Boundary routes outbound HTTP and HTTPS traffic through a local proxy.
+4. The proxy checks each request against the allowlist. Matching destinations
+   pass through, and everything else is denied.
+5. Boundary records local logs in `/tmp/boundary_logs/` and streams audit
+   decisions to the Coder control plane.
+
+## Docker runtime requirements
+
+| Requirement | Why |
+|-------------|-----|
+| `CAP_NET_ADMIN` | `nsjail` needs it to create network namespaces |
+| `seccomp=unconfined` | Docker's default seccomp profile blocks the `clone` patterns `nsjail` needs |
+
+The visible `dev` container runs without extra capabilities.
+
+## Customizing the allowlist
+
+Edit `boundary-config.yaml` to add or remove permitted domains for the hidden
+chat agent. Keep comments next to each rule so future readers know why a domain
+is allowed. For more advanced match rules, including method and path filters,
+see the Agent Boundaries rules engine documentation.
+
+## Limitations
+
+- Requires a Coder Enterprise license.
+- The `coder boundary` CLI version should match your Coder deployment.
+- `nsjail` requires Docker with the default `runc` runtime.
+- This example does not provide filesystem isolation. Use the bubblewrap
+  example for that, or combine both approaches.
+
+## Usage
+
+```bash
+cd examples/templates/x/docker-boundary-sandbox
+coder templates push docker-boundary-sandbox \
+  --var docker_socket="$(docker context inspect --format '{{ .Endpoints.docker.Host }}')"
+```
+
+## Smoke test
+
+1. Create a workspace from this template.
+2. Confirm only the `dev` agent appears in the UI.
+3. From the hidden chat agent, verify an allowlisted domain is reachable, for
+   example `curl https://api.anthropic.com`.
+4. From the hidden chat agent, verify a non-allowlisted domain is blocked, for
+   example `curl https://example.com` should fail.
+5. Inspect `/tmp/boundary_logs/` for allow and deny entries.

--- a/examples/templates/x/docker-boundary-sandbox/README.md
+++ b/examples/templates/x/docker-boundary-sandbox/README.md
@@ -36,34 +36,75 @@ source code and workspace state while still using different runtime policies.
 
 ## Agent Boundaries vs bubblewrap
 
-The `docker-chat-sandbox` example uses bubblewrap for **filesystem isolation**,
-which keeps the chat agent on a read-only root filesystem with a writable home
-mount. This template uses Agent Boundaries for **network policy isolation**,
-which allowlists outbound HTTP and HTTPS destinations and denies everything
-else by default. These controls are complementary: Boundary limits what the
-agent can talk to, and bubblewrap limits what it can read or write.
+The `docker-chat-sandbox` example uses bubblewrap for **filesystem isolation**.
+It keeps the chat agent on a read-only root filesystem with a writable home
+mount. This template uses Agent Boundaries with `nsjail` for **namespace and
+network isolation**. The hidden chat agent gets its own network stack, its own
+PID namespace, and an HTTP and HTTPS allowlist enforced by the Boundary proxy.
+These controls are complementary. Bubblewrap limits what the agent can read or
+write, and Boundary limits what the agent can see on the network and which web
+services it can reach.
 
 ## Network policy
 
-| Traffic                               | Policy                                 |
-|---------------------------------------|----------------------------------------|
-| Coder server (`host.docker.internal`) | Allowed                                |
-| Anthropic API                         | Allowed                                |
-| All other HTTP/HTTPS                  | Denied and logged                      |
-| Non-HTTP traffic (DNS, raw TCP)       | Controlled by nsjail network namespace |
-| Visible dev agent                     | Unrestricted                           |
+| Traffic                               | Policy                                      |
+|---------------------------------------|---------------------------------------------|
+| Coder server (`host.docker.internal`) | Allowed                                     |
+| Anthropic API                         | Allowed                                     |
+| All other HTTP/HTTPS                  | Denied by the Boundary allowlist and logged |
+| DNS, UDP, and raw TCP                 | Blocked or intercepted inside the namespace |
+| Visible dev agent                     | Unrestricted                                |
 
 ## How the sandbox works
 
-1. `boundary-agent.sh` copies `boundary-config.yaml` into
-   `~/.config/coder_boundary/config.yaml` and launches
-   `coder boundary -- sh /tmp/coder-init.sh`.
-2. `nsjail` creates a network namespace for the hidden chat agent.
-3. Boundary routes outbound HTTP and HTTPS traffic through a local proxy.
-4. The proxy checks each request against the allowlist. Matching destinations
-   pass through, and everything else is denied.
-5. Boundary records local logs in `/tmp/boundary_logs/` and streams audit
-   decisions to the Coder control plane.
+`boundary-agent.sh` copies `boundary-config.yaml` into
+`~/.config/coder_boundary/config.yaml` and launches
+`coder boundary -- sh /tmp/coder-init.sh`.
+
+At startup, `nsjail` creates a dedicated network namespace for the hidden chat
+agent. The sandboxed process gets its own network stack, so outbound traffic is
+contained inside the namespace instead of sharing the visible agent's network
+view. That boundary applies to more than proxied web requests. DNS, raw TCP,
+and UDP traffic are also constrained inside the namespace, which prevents the
+agent from bypassing the policy with direct connections.
+
+`nsjail` also creates a dedicated PID namespace. Inside the sandbox, the chat
+agent only sees its own process tree. It cannot enumerate, signal, or attach to
+processes that belong to the visible `dev` agent or the Docker host.
+
+Inside that isolated namespace, the Boundary proxy enforces the HTTP and HTTPS
+allowlist. Requests to listed domains are forwarded, and requests to unlisted
+web destinations are denied and logged. Boundary writes local logs to
+`/tmp/boundary_logs/` and streams every allow and deny decision to the Coder
+control plane for auditing.
+
+## Namespace isolation
+
+| Isolation layer      | What it provides                                                        | Provided by       |
+|----------------------|-------------------------------------------------------------------------|-------------------|
+| Network namespace    | Own network stack; all traffic routed through boundary proxy            | nsjail            |
+| PID namespace        | Own process tree; cannot see or signal host processes                   | nsjail            |
+| HTTP/HTTPS allowlist | Domain-level deny-by-default policy for outbound web traffic            | Boundary proxy    |
+| DNS interception     | Prevents DNS-based data exfiltration; queries resolved inside namespace | nsjail + Boundary |
+| UDP/raw TCP control  | Non-HTTP traffic blocked by namespace network rules                     | nsjail (iptables) |
+| Audit logging        | Every allow/deny decision logged and streamed to control plane          | Boundary          |
+
+## nsjail vs landjail
+
+This template uses `nsjail`, which is the default jail type in
+`boundary-config.yaml`.
+
+| Feature                    | nsjail (this template)                 | landjail                          |
+|----------------------------|----------------------------------------|-----------------------------------|
+| Bypass resistance          | Strong: transparent interception       | Medium: bypassable via proxy port |
+| PID isolation              | Yes: own process tree                  | No: can see host processes        |
+| Network isolation          | Full namespace with iptables           | HTTP proxy only                   |
+| UDP/DNS control            | Yes                                    | No (UDP can leak)                 |
+| Linux kernel requirement   | 3.8+ (widely available)                | 6.7+ (very new)                   |
+| Docker capabilities needed | `CAP_NET_ADMIN` + `seccomp=unconfined` | None                              |
+
+To switch to `landjail`, change `jail_type: landjail` in
+`boundary-config.yaml` and remove the extra Docker capabilities from `main.tf`.
 
 ## Docker runtime requirements
 
@@ -105,4 +146,8 @@ coder templates push docker-boundary-sandbox \
    example `curl https://api.anthropic.com`.
 4. From the hidden chat agent, verify a non-allowlisted domain is blocked, for
    example `curl https://example.com` should fail.
-5. Inspect `/tmp/boundary_logs/` for allow and deny entries.
+5. From the hidden chat agent, run `ps aux` and confirm it only shows the
+   agent's own processes, not processes from the visible `dev` agent or host.
+6. From the hidden chat agent, try `ping 8.8.8.8` or `nc` to a non-HTTP port and
+   confirm it fails inside the namespace.
+7. Inspect `/tmp/boundary_logs/` for allow and deny entries.

--- a/examples/templates/x/docker-boundary-sandbox/boundary-agent.sh
+++ b/examples/templates/x/docker-boundary-sandbox/boundary-agent.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# boundary-agent.sh: Start the Coder agent inside an Agent Boundary jail.
+#
+# Agent Boundaries enforce a network allowlist on all outbound HTTP/HTTPS
+# traffic. The agent and every tool it spawns inherit the restricted policy,
+# which keeps the hidden chat agent from reaching unapproved domains.
+
+set -e
+
+# Install the policy into the user config location because coder boundary
+# auto-discovers config there without extra flags.
+mkdir -p ~/.config/coder_boundary
+cp /etc/coder_boundary/config.yaml ~/.config/coder_boundary/config.yaml
+chmod 600 ~/.config/coder_boundary/config.yaml
+
+# Fall back gracefully when the CLI is unavailable so the template still starts
+# on deployments that do not expose Agent Boundaries.
+if ! command -v coder >/dev/null 2>&1; then
+	echo "WARNING: coder CLI not found, running without Agent Boundaries" >&2
+	exec "$@"
+fi
+
+# Launch the target process in an nsjail-backed boundary so all descendant
+# processes inherit the same outbound network restrictions.
+exec coder boundary -- "$@"

--- a/examples/templates/x/docker-boundary-sandbox/boundary-config.yaml
+++ b/examples/templates/x/docker-boundary-sandbox/boundary-config.yaml
@@ -1,0 +1,43 @@
+# Agent Boundaries policy for the hidden chat agent sandbox.
+# Each allowlist rule exists because the sandboxed agent needs that specific
+# destination to register, serve chat traffic, or reach an approved model API.
+# All other outbound HTTP and HTTPS requests are denied.
+#
+# See: https://coder.com/docs/ai-coder/agent-boundaries
+
+allowlist:
+  # Required so the hidden agent can reach a host-local Coder deployment from
+  # inside Docker.
+  - "domain=host.docker.internal"
+
+  # Uncomment this when the same template targets Coder Cloud instead of a
+  # local deployment.
+  # - "domain=*.coder.com"
+
+  # Required for Claude API calls from the hidden chat agent.
+  - "domain=api.anthropic.com"
+  # Required because Anthropic uses Statsig for feature flags and telemetry.
+  - "domain=statsig.anthropic.com"
+
+  # Uncomment this if the hidden chat agent should talk to OpenAI instead.
+  # - "domain=api.openai.com"
+
+  # Uncomment these when the hidden chat agent needs to fetch Git content.
+  # - "domain=github.com"
+  # - "domain=*.github.com"
+
+# Use nsjail for transparent network namespace isolation with deny-by-default
+# policy enforcement.
+jail_type: nsjail
+
+# Write operational logs locally so blocked requests are easy to inspect during
+# smoke tests.
+log_dir: /tmp/boundary_logs
+
+# Keep the proxy on a fixed internal port so the wrapper does not need runtime
+# discovery logic.
+proxy_port: 8087
+
+# Warn-level logging keeps denied requests visible without flooding the example
+# with routine allow entries.
+log_level: warn

--- a/examples/templates/x/docker-boundary-sandbox/main.tf
+++ b/examples/templates/x/docker-boundary-sandbox/main.tf
@@ -21,11 +21,9 @@ variable "docker_socket" {
 }
 
 provider "docker" {
-  host = var.docker_socket != "" ? var.docker_socket : (
-    data.coder_provisioner.me.operating_system == "windows" ?
-    "npipe:////.//pipe//docker_engine" :
-    "unix:///var/run/docker.sock"
-  )
+  # Defaulting to null if the variable is an empty string lets us have
+  # an optional variable without having to set our own default.
+  host = var.docker_socket != "" ? var.docker_socket : null
 }
 
 locals {

--- a/examples/templates/x/docker-boundary-sandbox/main.tf
+++ b/examples/templates/x/docker-boundary-sandbox/main.tf
@@ -1,0 +1,283 @@
+terraform {
+  required_providers {
+    coder = {
+      source = "coder/coder"
+    }
+    docker = {
+      source = "kreuzwerker/docker"
+    }
+  }
+}
+
+data "coder_provisioner" "me" {}
+data "coder_workspace" "me" {}
+data "coder_workspace_owner" "me" {}
+
+variable "docker_socket" {
+  default     = ""
+  description = "Docker socket URI"
+  type        = string
+  sensitive   = true
+}
+
+provider "docker" {
+  host = var.docker_socket != "" ? var.docker_socket : (
+    data.coder_provisioner.me.operating_system == "windows" ?
+    "npipe:////.//pipe//docker_engine" :
+    "unix:///var/run/docker.sock"
+  )
+}
+
+locals {
+  # Terraform treats repeated references to the hidden chat agent as awkward,
+  # so capture the generated bootstrap values once and reuse them below.
+  chat_agent_init  = coder_agent.dev-coderd-chat.init_script
+  chat_agent_token = coder_agent.dev-coderd-chat.token
+}
+
+resource "coder_agent" "dev" {
+  arch = data.coder_provisioner.me.arch
+  os   = "linux"
+
+  startup_script = <<-EOT
+    set -e
+
+    # Seed the home directory and install base packages only on first boot.
+    # The shared Docker volume persists across restarts, so repeating apt work
+    # would slow every start without adding value.
+    if [ ! -f ~/.init_done ]; then
+      cp -rT /etc/skel ~
+      sudo apt-get update
+      sudo apt-get install -y curl git ca-certificates
+      touch ~/.init_done
+    fi
+  EOT
+
+  # Pre-populate Git identity so the visible development agent is ready for
+  # commits without requiring each workspace owner to reconfigure Git.
+  env = {
+    GIT_AUTHOR_NAME     = coalesce(data.coder_workspace_owner.me.full_name, data.coder_workspace_owner.me.name)
+    GIT_AUTHOR_EMAIL    = data.coder_workspace_owner.me.email
+    GIT_COMMITTER_NAME  = coalesce(data.coder_workspace_owner.me.full_name, data.coder_workspace_owner.me.name)
+    GIT_COMMITTER_EMAIL = data.coder_workspace_owner.me.email
+  }
+
+  # Surface a few standard stats on the visible agent so the example still
+  # feels like a normal Docker workspace from the dashboard.
+  metadata {
+    display_name = "CPU Usage"
+    key          = "0_cpu_usage"
+    script       = "coder stat cpu"
+    interval     = 10
+    timeout      = 1
+  }
+
+  metadata {
+    display_name = "RAM Usage"
+    key          = "1_ram_usage"
+    script       = "coder stat mem"
+    interval     = 10
+    timeout      = 1
+  }
+
+  metadata {
+    display_name = "Home Disk"
+    key          = "3_home_disk"
+    script       = "coder stat disk --path $${HOME}"
+    interval     = 60
+    timeout      = 1
+  }
+
+  metadata {
+    display_name = "Load Average (Host)"
+    key          = "6_load_host"
+    # Show load normalized by CPU count so the value stays useful on machines
+    # with different core counts.
+    script   = <<-EOT
+      echo "$(cat /proc/loadavg | awk '{ print $1 }') $(nproc)" |
+        awk '{ printf "%0.2f", $1/$2 }'
+    EOT
+    interval = 60
+    timeout  = 1
+  }
+
+}
+
+resource "coder_agent" "dev-coderd-chat" {
+  arch  = data.coder_provisioner.me.arch
+  os    = "linux"
+  order = 99
+
+  # Mirror the owner Git identity in the hidden chat agent because it shares
+  # the same persistent home directory and may create commits there.
+  env = {
+    GIT_AUTHOR_NAME     = coalesce(data.coder_workspace_owner.me.full_name, data.coder_workspace_owner.me.name)
+    GIT_AUTHOR_EMAIL    = data.coder_workspace_owner.me.email
+    GIT_COMMITTER_NAME  = coalesce(data.coder_workspace_owner.me.full_name, data.coder_workspace_owner.me.name)
+    GIT_COMMITTER_EMAIL = data.coder_workspace_owner.me.email
+  }
+}
+
+resource "docker_volume" "home_volume" {
+  name = "coder-${data.coder_workspace.me.id}-home"
+
+  # Keep the shared home volume stable so restarts do not discard user data or
+  # Terraform-drifted metadata.
+  lifecycle {
+    ignore_changes = all
+  }
+
+  labels {
+    label = "coder.owner"
+    value = data.coder_workspace_owner.me.name
+  }
+  labels {
+    label = "coder.owner_id"
+    value = data.coder_workspace_owner.me.id
+  }
+  labels {
+    label = "coder.workspace_id"
+    value = data.coder_workspace.me.id
+  }
+  labels {
+    label = "coder.workspace_id_at_creation"
+    value = data.coder_workspace.me.id
+  }
+}
+
+resource "docker_image" "boundary_sandbox" {
+  name = "coder-boundary-sandbox-${data.coder_workspace.me.id}"
+
+  build {
+    context    = path.module
+    dockerfile = "Dockerfile.boundary"
+  }
+
+  # Rebuild when the image, wrapper, or policy changes so the hidden agent does
+  # not keep an outdated network policy.
+  triggers = {
+    file_sha1 = sha1(join("", [
+      file("${path.module}/Dockerfile.boundary"),
+      file("${path.module}/boundary-agent.sh"),
+      file("${path.module}/boundary-config.yaml"),
+    ]))
+  }
+}
+
+module "code-server" {
+  source   = "dev.registry.coder.com/modules/code-server/coder"
+  version  = "1.0.18"
+  agent_id = coder_agent.dev.id
+}
+
+resource "docker_container" "dev" {
+  count = data.coder_workspace.me.start_count
+  image = "codercom/enterprise-base:ubuntu"
+
+  # Keep the visible development container name aligned with other Docker
+  # template examples so orphaned resources are easy to identify.
+  name     = "coder-${data.coder_workspace_owner.me.name}-${lower(data.coder_workspace.me.name)}"
+  hostname = data.coder_workspace.me.name
+
+  # Rewrite loopback URLs so the generated init script can still reach a Coder
+  # server bound on the Docker host.
+  entrypoint = [
+    "sh",
+    "-c",
+    replace(coder_agent.dev.init_script, "/localhost|127\\.0\\.0\\.1/", "host.docker.internal"),
+  ]
+
+  env = [
+    "CODER_AGENT_TOKEN=${coder_agent.dev.token}",
+  ]
+
+  host {
+    host = "host.docker.internal"
+    ip   = "host-gateway"
+  }
+
+  volumes {
+    container_path = "/home/coder"
+    volume_name    = docker_volume.home_volume.name
+    read_only      = false
+  }
+
+  labels {
+    label = "coder.owner"
+    value = data.coder_workspace_owner.me.name
+  }
+  labels {
+    label = "coder.owner_id"
+    value = data.coder_workspace_owner.me.id
+  }
+  labels {
+    label = "coder.workspace_id"
+    value = data.coder_workspace.me.id
+  }
+  labels {
+    label = "coder.workspace_name"
+    value = data.coder_workspace.me.name
+  }
+}
+
+resource "docker_container" "chat" {
+  count = data.coder_workspace.me.start_count
+  image = docker_image.boundary_sandbox.image_id
+
+  # Name the hidden container predictably so it is easy to correlate with the
+  # visible workspace container during debugging.
+  name     = "coder-${data.coder_workspace_owner.me.name}-${lower(data.coder_workspace.me.name)}-chat"
+  hostname = "${data.coder_workspace.me.name}-chat"
+
+  # nsjail needs network namespace privileges, but the container should still
+  # drop every capability that the sandbox itself does not require.
+  capabilities {
+    add  = ["NET_ADMIN"]
+    drop = ["ALL"]
+  }
+
+  # Docker's default seccomp profile blocks clone patterns that nsjail needs to
+  # create the boundary namespace.
+  security_opts = ["seccomp=unconfined"]
+
+  # The chat agent runs behind a boundary wrapper. Base64 encoding preserves the
+  # generated init script without fighting Terraform or shell quoting rules.
+  entrypoint = [
+    "sh",
+    "-c",
+    "echo ${base64encode(replace(local.chat_agent_init, "/localhost|127\\.0\\.0\\.1/", "host.docker.internal"))} | base64 -d > /tmp/coder-init.sh && chmod +x /tmp/coder-init.sh && exec boundary-agent sh /tmp/coder-init.sh",
+  ]
+
+  env = [
+    "CODER_AGENT_TOKEN=${local.chat_agent_token}",
+    "CODER_URL=${replace(data.coder_workspace.me.access_url, "/localhost|127\\.0\\.0\\.1/", "host.docker.internal")}",
+  ]
+
+  host {
+    host = "host.docker.internal"
+    ip   = "host-gateway"
+  }
+
+  volumes {
+    container_path = "/home/coder"
+    volume_name    = docker_volume.home_volume.name
+    read_only      = false
+  }
+
+  labels {
+    label = "coder.owner"
+    value = data.coder_workspace_owner.me.name
+  }
+  labels {
+    label = "coder.owner_id"
+    value = data.coder_workspace_owner.me.id
+  }
+  labels {
+    label = "coder.workspace_id"
+    value = data.coder_workspace.me.id
+  }
+  labels {
+    label = "coder.workspace_name"
+    value = data.coder_workspace.me.name
+  }
+}

--- a/scripts/examplegen/main.go
+++ b/scripts/examplegen/main.go
@@ -49,24 +49,31 @@ func run(lint bool) error {
 
 	var paths []string
 	if lint {
-		err := fs.WalkDir(examplesFS, "templates", func(path string, d fs.DirEntry, err error) error {
+		files, err := fs.ReadDir(examplesFS, "templates")
+		if err != nil {
+			return err
+		}
+
+		for _, f := range files {
+			if !f.IsDir() {
+				continue
+			}
+			if f.Name() != "x" {
+				paths = append(paths, filepath.Join("templates", f.Name()))
+				continue
+			}
+
+			experimentalTemplates, err := fs.ReadDir(examplesFS, filepath.Join("templates", f.Name()))
 			if err != nil {
 				return err
 			}
-			if !d.IsDir() {
-				return nil
+
+			for _, experimentalTemplate := range experimentalTemplates {
+				if !experimentalTemplate.IsDir() {
+					continue
+				}
+				paths = append(paths, filepath.Join("templates", f.Name(), experimentalTemplate.Name()))
 			}
-			if path == "templates" {
-				return nil
-			}
-			if !isTemplateExampleDir(examplesFS, path) {
-				return nil
-			}
-			paths = append(paths, path)
-			return fs.SkipDir
-		})
-		if err != nil {
-			return err
 		}
 	} else {
 		for _, comment := range src.Comments {
@@ -108,18 +115,6 @@ func run(lint bool) error {
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "\t")
 	return enc.Encode(examples)
-}
-
-func isTemplateExampleDir(examplesFS fs.FS, name string) bool {
-	readmePath := path.Join(name, "README.md")
-	mainTFPath := path.Join(name, "main.tf")
-	if _, err := fs.Stat(examplesFS, readmePath); err != nil {
-		return false
-	}
-	if _, err := fs.Stat(examplesFS, mainTFPath); err != nil {
-		return false
-	}
-	return true
 }
 
 func parseTemplateExample(projectFS, examplesFS fs.FS, name string) (te *codersdk.TemplateExample, err error) {


### PR DESCRIPTION
Adds an example template at `examples/templates/x/docker-boundary-sandbox/` that demonstrates Agent Boundaries network isolation for a hidden chat agent.

This mirrors the shape of the `docker-chat-sandbox` two-agent workspace (visible `dev` agent + hidden `dev-coderd-chat` agent sharing `/home/coder`), but replaces the bubblewrap filesystem sandbox with Agent Boundaries network policy enforcement.

The example uses nsjail as the jail backend, wraps the entire hidden agent process via `coder boundary`, and ships a minimal allowlist (Coder server + Anthropic API) with deny-by-default for everything else. A graceful fallback runs unsandboxed when the Coder CLI is unavailable.