### PR TITLE
feat: add AI seat filter to users

### DIFF
--- a/coderd/coderdtest/users.go
+++ b/coderd/coderdtest/users.go
@@ -123,14 +123,20 @@ func UsersPagination(
 	require.Contains(t, gotUsers[0].Name, "after")
 }
 
+// UsersFilterOptions controls which shared user-filter cases run.
+type UsersFilterOptions struct {
+	IncludeAISeatFilters bool
+}
+
 // UsersFilter creates a set of users to run various filters against for
-// testing.  It can be used to test filtering both users and group members.
+// testing. It can be used to test filtering both users and group members.
 func UsersFilter(
 	setupCtx context.Context,
 	t *testing.T,
 	client *codersdk.Client,
 	db database.Store,
 	setup func(users []codersdk.User),
+	opts UsersFilterOptions,
 	fetch func(ctx context.Context, req codersdk.UsersRequest) []codersdk.ReducedUser,
 ) {
 	t.Helper()
@@ -208,6 +214,21 @@ func UsersFilter(
 		}
 
 		users = append(users, user)
+
+		if opts.IncludeAISeatFilters && i%3 == 0 {
+			// nolint:gocritic // Setting up unit test data.
+			_, err = db.UpsertAISeatState(dbauthz.AsSystemRestricted(setupCtx), database.UpsertAISeatStateParams{
+				UserID:               user.ID,
+				FirstUsedAt:          dbtime.Now(),
+				LastEventType:        database.AiSeatUsageReasonAibridge,
+				LastEventDescription: fmt.Sprintf("test seat %s", user.ID),
+			})
+			require.NoError(t, err)
+			// Keep expected results aligned with GetUserAISeatStates, which only
+			// marks active users as currently consuming an AI seat.
+			user.HasAISeat = user.Status == codersdk.UserStatusActive
+			users[len(users)-1] = user
+		}
 	}
 
 	// Add some service accounts.
@@ -586,6 +607,39 @@ func UsersFilter(
 				return !u.IsServiceAccount
 			},
 		},
+	}
+
+	if opts.IncludeAISeatFilters {
+		testCases = append(testCases,
+			struct {
+				Name   string
+				Filter codersdk.UsersRequest
+				// If FilterF is true, we include it in the expected results
+				FilterF func(f codersdk.UsersRequest, user codersdk.User) bool
+			}{
+				Name: "HasAISeat",
+				Filter: codersdk.UsersRequest{
+					SearchQuery: "has-ai-seat:true",
+				},
+				FilterF: func(_ codersdk.UsersRequest, u codersdk.User) bool {
+					return u.HasAISeat
+				},
+			},
+			struct {
+				Name   string
+				Filter codersdk.UsersRequest
+				// If FilterF is true, we include it in the expected results
+				FilterF func(f codersdk.UsersRequest, user codersdk.User) bool
+			}{
+				Name: "DoesNotHaveAISeat",
+				Filter: codersdk.UsersRequest{
+					SearchQuery: "has-ai-seat:false",
+				},
+				FilterF: func(_ codersdk.UsersRequest, u codersdk.User) bool {
+					return !u.HasAISeat
+				},
+			},
+		)
 	}
 
 	for _, c := range testCases {

--- a/coderd/database/modelqueries.go
+++ b/coderd/database/modelqueries.go
@@ -423,6 +423,7 @@ func (q *sqlQuerier) GetAuthorizedUsers(ctx context.Context, arg GetUsersParams,
 		arg.GithubComUserID,
 		pq.Array(arg.LoginType),
 		arg.IsServiceAccount,
+		arg.HasAISeat,
 		arg.OffsetOpt,
 		arg.LimitOpt,
 	)

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -22865,22 +22865,40 @@ WHERE
 			login_type = ANY($12 :: login_type[])
 		ELSE true
 	END
-	-- Filter by service account.
-	AND CASE
-		WHEN $13 :: boolean IS NOT NULL THEN
-			is_service_account = $13 :: boolean
-		ELSE true
-	END
-	-- End of filters
+		-- Filter by service account.
+		AND CASE
+			WHEN $13 :: boolean IS NOT NULL THEN
+				is_service_account = $13 :: boolean
+			ELSE true
+		END
+		-- Filter by AI seat.
+		AND CASE
+			WHEN $14 :: boolean IS NOT NULL THEN
+				$14 :: boolean = (
+					users.status = 'active'::user_status
+					AND users.deleted = false
+					AND users.is_system = false
+					AND EXISTS (
+						SELECT
+							1
+						FROM
+							ai_seat_state ais
+						WHERE
+							ais.user_id = users.id
+					)
+				)
+			ELSE true
+		END
+		-- End of filters
 
 	-- Authorize Filter clause will be injected below in GetAuthorizedUsers
 	-- @authorize_filter
 ORDER BY
 	-- Deterministic and consistent ordering of all users. This is to ensure consistent pagination.
-	LOWER(username) ASC OFFSET $14
+	LOWER(username) ASC OFFSET $15
 LIMIT
 	-- A null limit means "no limit", so 0 means return all
-	NULLIF($15 :: int, 0)
+	NULLIF($16 :: int, 0)
 `
 
 type GetUsersParams struct {
@@ -22897,6 +22915,7 @@ type GetUsersParams struct {
 	GithubComUserID  int64        `db:"github_com_user_id" json:"github_com_user_id"`
 	LoginType        []LoginType  `db:"login_type" json:"login_type"`
 	IsServiceAccount sql.NullBool `db:"is_service_account" json:"is_service_account"`
+	HasAISeat        sql.NullBool `db:"has_ai_seat" json:"has_ai_seat"`
 	OffsetOpt        int32        `db:"offset_opt" json:"offset_opt"`
 	LimitOpt         int32        `db:"limit_opt" json:"limit_opt"`
 }
@@ -22941,6 +22960,7 @@ func (q *sqlQuerier) GetUsers(ctx context.Context, arg GetUsersParams) ([]GetUse
 		arg.GithubComUserID,
 		pq.Array(arg.LoginType),
 		arg.IsServiceAccount,
+		arg.HasAISeat,
 		arg.OffsetOpt,
 		arg.LimitOpt,
 	)

--- a/coderd/database/queries/users.sql
+++ b/coderd/database/queries/users.sql
@@ -361,13 +361,31 @@ WHERE
 			login_type = ANY(@login_type :: login_type[])
 		ELSE true
 	END
-	-- Filter by service account.
-	AND CASE
-		WHEN sqlc.narg('is_service_account') :: boolean IS NOT NULL THEN
-			is_service_account = sqlc.narg('is_service_account') :: boolean
-		ELSE true
-	END
-	-- End of filters
+		-- Filter by service account.
+		AND CASE
+			WHEN sqlc.narg('is_service_account') :: boolean IS NOT NULL THEN
+				is_service_account = sqlc.narg('is_service_account') :: boolean
+			ELSE true
+		END
+		-- Filter by AI seat.
+		AND CASE
+			WHEN sqlc.narg('has_ai_seat') :: boolean IS NOT NULL THEN
+				sqlc.narg('has_ai_seat') :: boolean = (
+					users.status = 'active'::user_status
+					AND users.deleted = false
+					AND users.is_system = false
+					AND EXISTS (
+						SELECT
+							1
+						FROM
+							ai_seat_state ais
+						WHERE
+							ais.user_id = users.id
+					)
+				)
+			ELSE true
+		END
+		-- End of filters
 
 	-- Authorize Filter clause will be injected below in GetAuthorizedUsers
 	-- @authorize_filter

--- a/coderd/database/sqlc.yaml
+++ b/coderd/database/sqlc.yaml
@@ -231,6 +231,7 @@ sql:
           crypto_key_feature_oidc_convert: CryptoKeyFeatureOIDCConvert
           stale_interval_ms: StaleIntervalMS
           has_ai_task: HasAITask
+          has_ai_seat: HasAISeat
           ai_task_sidebar_app_id: AITaskSidebarAppID
           latest_build_has_ai_task: LatestBuildHasAITask
           cors_behavior: CorsBehavior

--- a/coderd/members_test.go
+++ b/coderd/members_test.go
@@ -3,6 +3,7 @@ package coderd_test
 import (
 	"context"
 	"database/sql"
+	"net/http"
 	"testing"
 
 	"github.com/google/uuid"
@@ -148,7 +149,7 @@ func TestGetOrgMembersFilter(t *testing.T) {
 	setupCtx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 	defer cancel()
 
-	coderdtest.UsersFilter(setupCtx, t, client, api.Database, nil, func(testCtx context.Context, req codersdk.UsersRequest) []codersdk.ReducedUser {
+	coderdtest.UsersFilter(setupCtx, t, client, api.Database, nil, coderdtest.UsersFilterOptions{}, func(testCtx context.Context, req codersdk.UsersRequest) []codersdk.ReducedUser {
 		res, err := client.OrganizationMembersPaginated(testCtx, first.OrganizationID, req)
 		require.NoError(t, err)
 		reduced := make([]codersdk.ReducedUser, len(res.Members))
@@ -157,6 +158,25 @@ func TestGetOrgMembersFilter(t *testing.T) {
 		}
 		return reduced
 	})
+}
+
+func TestGetOrgMembersFilterByAISeatUnsupported(t *testing.T) {
+	t.Parallel()
+
+	client := coderdtest.New(t, nil)
+	first := coderdtest.CreateFirstUser(t, client)
+
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+	defer cancel()
+
+	_, err := client.OrganizationMembersPaginated(ctx, first.OrganizationID, codersdk.UsersRequest{SearchQuery: "has-ai-seat:true"})
+	require.Error(t, err)
+
+	apiErr, ok := codersdk.AsError(err)
+	require.True(t, ok)
+	require.Equal(t, http.StatusBadRequest, apiErr.StatusCode())
+	require.Contains(t, apiErr.Message, "Invalid member search query")
+	require.Contains(t, apiErr.Error(), `has-ai-seat: "has-ai-seat" is not a valid query param`)
 }
 
 func TestGetOrgMembersPagination(t *testing.T) {

--- a/coderd/searchquery/search.go
+++ b/coderd/searchquery/search.go
@@ -142,7 +142,27 @@ func ConnectionLogs(ctx context.Context, db database.Store, query string, apiKey
 	return filter, countFilter, parser.Errors
 }
 
+type usersFilterMutator func(
+	parser *httpapi.QueryParamParser,
+	values url.Values,
+	filter *database.GetUsersParams,
+)
+
 func Users(query string) (database.GetUsersParams, []codersdk.ValidationError) {
+	return parseUsers(query, nil)
+}
+
+func UsersWithAISeat(query string) (database.GetUsersParams, []codersdk.ValidationError) {
+	return parseUsers(query, func(
+		parser *httpapi.QueryParamParser,
+		values url.Values,
+		filter *database.GetUsersParams,
+	) {
+		filter.HasAISeat = parser.NullableBoolean(values, sql.NullBool{}, "has-ai-seat")
+	})
+}
+
+func parseUsers(query string, mutate usersFilterMutator) (database.GetUsersParams, []codersdk.ValidationError) {
 	// Always lowercase for all searches.
 	query = strings.ToLower(query)
 	values, errors := searchTerms(query, func(term string, values url.Values) error {
@@ -166,6 +186,9 @@ func Users(query string) (database.GetUsersParams, []codersdk.ValidationError) {
 		CreatedBefore:    parser.Time3339Nano(values, time.Time{}, "created_before"),
 		GithubComUserID:  parser.Int64(values, 0, "github_com_user_id"),
 		LoginType:        httpapi.ParseCustomList(parser, values, []database.LoginType{}, "login_type", httpapi.ParseEnum[database.LoginType]),
+	}
+	if mutate != nil {
+		mutate(parser, values, &filter)
 	}
 	parser.ErrorExcessParams(values)
 	return filter, parser.Errors

--- a/coderd/searchquery/search_test.go
+++ b/coderd/searchquery/search_test.go
@@ -748,6 +748,26 @@ func TestSearchUsers(t *testing.T) {
 			},
 		},
 		{
+			Name:  "HasAISeatTrue",
+			Query: "has-ai-seat:true",
+			Expected: database.GetUsersParams{
+				Status:    []database.UserStatus{},
+				HasAISeat: sql.NullBool{Bool: true, Valid: true},
+				RbacRole:  []string{},
+				LoginType: []database.LoginType{},
+			},
+		},
+		{
+			Name:  "HasAISeatFalse",
+			Query: "has-ai-seat:false",
+			Expected: database.GetUsersParams{
+				Status:    []database.UserStatus{},
+				HasAISeat: sql.NullBool{Bool: false, Valid: true},
+				RbacRole:  []string{},
+				LoginType: []database.LoginType{},
+			},
+		},
+		{
 			Name:  "LoginType",
 			Query: "login_type:github",
 			Expected: database.GetUsersParams{
@@ -850,7 +870,7 @@ func TestSearchUsers(t *testing.T) {
 	for _, c := range testCases {
 		t.Run(c.Name, func(t *testing.T) {
 			t.Parallel()
-			values, errs := searchquery.Users(c.Query)
+			values, errs := searchquery.UsersWithAISeat(c.Query)
 			if c.ExpectedErrorContains != "" {
 				require.True(t, len(errs) > 0, "expect some errors")
 				var s strings.Builder

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -361,7 +361,12 @@ func (api *API) users(rw http.ResponseWriter, r *http.Request) {
 func (api *API) GetUsers(rw http.ResponseWriter, r *http.Request) ([]database.User, int64, bool) {
 	ctx := r.Context()
 	query := r.URL.Query().Get("q")
-	params, errs := searchquery.Users(query)
+	usersSearch := searchquery.Users
+	if api.Entitlements.Enabled(codersdk.FeatureAIGovernanceUserLimit) {
+		usersSearch = searchquery.UsersWithAISeat
+	}
+
+	params, errs := usersSearch(query)
 	if len(errs) > 0 {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message:     "Invalid user search query.",
@@ -380,6 +385,7 @@ func (api *API) GetUsers(rw http.ResponseWriter, r *http.Request) ([]database.Us
 		Search:           params.Search,
 		Name:             params.Name,
 		Status:           params.Status,
+		HasAISeat:        params.HasAISeat,
 		IsServiceAccount: params.IsServiceAccount,
 		RbacRole:         params.RbacRole,
 		LastSeenBefore:   params.LastSeenBefore,

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbfake"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
+	"github.com/coder/coder/v2/coderd/entitlements"
 	"github.com/coder/coder/v2/coderd/notifications"
 	"github.com/coder/coder/v2/coderd/notifications/notificationstest"
 	"github.com/coder/coder/v2/coderd/rbac"
@@ -1721,18 +1722,28 @@ func TestGetUser(t *testing.T) {
 func TestGetUsersFilter(t *testing.T) {
 	t.Parallel()
 
+	entSet := entitlements.New()
+	entSet.Modify(func(e *codersdk.Entitlements) {
+		e.HasLicense = true
+		e.Features[codersdk.FeatureAIGovernanceUserLimit] = codersdk.Feature{
+			Enabled:     true,
+			Entitlement: codersdk.EntitlementEntitled,
+		}
+	})
+
 	client, _, api := coderdtest.NewWithAPI(t, &coderdtest.Options{
 		IncludeProvisionerDaemon: true,
 		OIDCConfig: &coderd.OIDCConfig{
 			AllowSignups: true,
 		},
 	})
+	api.Entitlements = entSet
 	_ = coderdtest.CreateFirstUser(t, client)
 
 	setupCtx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 	defer cancel()
 
-	coderdtest.UsersFilter(setupCtx, t, client, api.Database, nil, func(testCtx context.Context, req codersdk.UsersRequest) []codersdk.ReducedUser {
+	coderdtest.UsersFilter(setupCtx, t, client, api.Database, nil, coderdtest.UsersFilterOptions{IncludeAISeatFilters: true}, func(testCtx context.Context, req codersdk.UsersRequest) []codersdk.ReducedUser {
 		res, err := client.Users(testCtx, req)
 		require.NoError(t, err)
 		reduced := make([]codersdk.ReducedUser, len(res.Users))
@@ -1741,6 +1752,25 @@ func TestGetUsersFilter(t *testing.T) {
 		}
 		return reduced
 	})
+}
+
+func TestGetUsersFilterByAISeatRequiresEntitlement(t *testing.T) {
+	t.Parallel()
+
+	client := coderdtest.New(t, nil)
+	_ = coderdtest.CreateFirstUser(t, client)
+
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+	defer cancel()
+
+	_, err := client.Users(ctx, codersdk.UsersRequest{SearchQuery: "has-ai-seat:true"})
+	require.Error(t, err)
+
+	apiErr, ok := codersdk.AsError(err)
+	require.True(t, ok)
+	require.Equal(t, http.StatusBadRequest, apiErr.StatusCode())
+	require.Contains(t, apiErr.Message, "Invalid user search query")
+	require.Contains(t, apiErr.Error(), `has-ai-seat: "has-ai-seat" is not a valid query param`)
 }
 
 func TestGetUsersPagination(t *testing.T) {

--- a/docs/admin/users/index.md
+++ b/docs/admin/users/index.md
@@ -193,6 +193,8 @@ to use the Coder's filter query:
 - To find users who login using Github:
   `login_type:github`
 - To find service accounts: `service_account:true`.
+- To find users consuming an AI seat when the AI governance add-on is enabled:
+  `has-ai-seat:true`.
 
 The following filters are supported:
 
@@ -210,6 +212,9 @@ The following filters are supported:
 - `service_account` - Can be either `true` to only include service accounts or
   `false` to filter them out. If omitted, both service and regular accounts and
   are returned.
+- `has-ai-seat` - Can be either `true` to only include users currently
+  consuming an AI seat or `false` to exclude them. This filter is available
+  when the AI governance add-on is enabled. If omitted, both are returned.
 
 ## Edit a user's profile
 

--- a/enterprise/coderd/groups_test.go
+++ b/enterprise/coderd/groups_test.go
@@ -1191,7 +1191,38 @@ func TestGetGroupMembersFilter(t *testing.T) {
 		require.NoError(t, err)
 		return res.Users
 	}
-	coderdtest.UsersFilter(setupCtx, t, client, db, setup, fetch)
+	coderdtest.UsersFilter(setupCtx, t, client, db, setup, coderdtest.UsersFilterOptions{}, fetch)
+}
+
+func TestGetGroupMembersFilterByAISeatUnsupported(t *testing.T) {
+	t.Parallel()
+
+	client, first := coderdenttest.New(t, &coderdenttest.Options{
+		LicenseOptions: &coderdenttest.LicenseOptions{
+			Features: license.Features{
+				codersdk.FeatureTemplateRBAC: 1,
+			},
+		},
+	})
+
+	userAdminClient, _ := coderdtest.CreateAnotherUser(t, client, first.OrganizationID, rbac.RoleUserAdmin())
+
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+	t.Cleanup(cancel)
+
+	group, err := userAdminClient.CreateGroup(ctx, first.OrganizationID, codersdk.CreateGroupRequest{
+		Name: "ai-seat-unsupported",
+	})
+	require.NoError(t, err)
+
+	_, err = userAdminClient.GroupMembers(ctx, group.ID, codersdk.UsersRequest{SearchQuery: "has-ai-seat:true"})
+	require.Error(t, err)
+
+	apiErr, ok := codersdk.AsError(err)
+	require.True(t, ok)
+	require.Equal(t, http.StatusBadRequest, apiErr.StatusCode())
+	require.Contains(t, apiErr.Message, "Invalid member search query")
+	require.Contains(t, apiErr.Error(), `has-ai-seat: "has-ai-seat" is not a valid query param`)
 }
 
 func TestGetGroupMembersPagination(t *testing.T) {

--- a/site/src/components/Filter/Filter.test.ts
+++ b/site/src/components/Filter/Filter.test.ts
@@ -1,0 +1,19 @@
+import { parseFilterQuery, stringifyFilter } from "./Filter";
+
+describe("Filter query serialization", () => {
+	it("parses hyphenated filter keys", () => {
+		expect(parseFilterQuery("has-ai-seat:true status:active")).toEqual({
+			"has-ai-seat": "true",
+			status: "active",
+		});
+	});
+
+	it("stringifies hyphenated filter keys", () => {
+		expect(
+			stringifyFilter({
+				"has-ai-seat": "false",
+				status: "suspended",
+			}),
+		).toBe("has-ai-seat:false status:suspended");
+	});
+});

--- a/site/src/components/Filter/Filter.tsx
+++ b/site/src/components/Filter/Filter.tsx
@@ -96,13 +96,13 @@ export const useFilter = ({
 	};
 };
 
-const parseFilterQuery = (filterQuery: string): FilterValues => {
+export const parseFilterQuery = (filterQuery: string): FilterValues => {
 	if (filterQuery === "") {
 		return {};
 	}
 
 	const result: FilterValues = {};
-	const keyValuePair = /(\w+):"([^"]+)"|(\w+):(\S+)/g;
+	const keyValuePair = /([\w-]+):"([^"]+)"|([\w-]+):(\S+)/g;
 
 	for (const match of filterQuery.matchAll(keyValuePair)) {
 		const key = match[1] ?? match[3];
@@ -115,7 +115,7 @@ const parseFilterQuery = (filterQuery: string): FilterValues => {
 	return result;
 };
 
-const stringifyFilter = (filterValue: FilterValues): string => {
+export const stringifyFilter = (filterValue: FilterValues): string => {
 	let result = "";
 
 	for (const key in filterValue) {

--- a/site/src/components/Filter/UsersFilter.tsx
+++ b/site/src/components/Filter/UsersFilter.tsx
@@ -1,3 +1,4 @@
+import { CircleCheck, X } from "lucide-react";
 import type { FC } from "react";
 import {
 	Filter,
@@ -17,6 +18,7 @@ import { docs } from "#/utils/docs";
 
 const userFilterQuery = {
 	active: "status:active",
+	aiAddon: "has-ai-seat:true",
 	serviceAccount: "service_account:true",
 	all: "",
 };
@@ -52,34 +54,77 @@ export const useStatusFilterMenu = ({
 	});
 };
 
-type StatusFilterMenu = ReturnType<typeof useStatusFilterMenu>;
+export const useAISeatFilterMenu = ({
+	value,
+	onChange,
+}: Pick<UseFilterMenuOptions, "value" | "onChange">) => {
+	const aiSeatOptions: SelectFilterOption[] = [
+		{
+			value: "true",
+			label: "Consuming AI seat",
+			startIcon: <CircleCheck className="size-icon-sm text-content-success" />,
+		},
+		{
+			value: "false",
+			label: "Not consuming AI seat",
+			startIcon: <X className="size-icon-sm text-content-disabled" />,
+		},
+	];
+	return useFilterMenu({
+		onChange,
+		value,
+		id: "has-ai-seat",
+		getSelectedOption: async () =>
+			aiSeatOptions.find((option) => option.value === value) ?? null,
+		getOptions: async () => aiSeatOptions,
+	});
+};
 
-const PRESET_FILTERS = [
-	{ query: userFilterQuery.active, name: "Active users" },
-	{ query: userFilterQuery.serviceAccount, name: "Service accounts" },
-	{ query: userFilterQuery.all, name: "All users" },
-];
+type StatusFilterMenu = ReturnType<typeof useStatusFilterMenu>;
+type AISeatFilterMenu = ReturnType<typeof useAISeatFilterMenu>;
 
 interface UsersFilterProps {
 	filter: ReturnType<typeof useFilter>;
 	error?: unknown;
 	menus?: {
 		status?: StatusFilterMenu;
+		aiSeat?: AISeatFilterMenu;
 	};
 }
 
 export const UsersFilter: FC<UsersFilterProps> = ({ filter, error, menus }) => {
+	const presets = [
+		{ query: userFilterQuery.active, name: "Active users" },
+		...(menus?.aiSeat
+			? [{ query: userFilterQuery.aiAddon, name: "AI add-on users" }]
+			: []),
+		{ query: userFilterQuery.serviceAccount, name: "Service accounts" },
+		{ query: userFilterQuery.all, name: "All users" },
+	];
+
 	return (
 		<Filter
-			presets={PRESET_FILTERS}
+			presets={presets}
 			learnMoreLink={docs("/admin/users#user-filtering")}
 			learnMoreLabel2="User status"
 			learnMoreLink2={docs("/admin/users#user-status")}
-			isLoading={menus?.status?.isInitializing ?? false}
+			isLoading={
+				menus?.status?.isInitializing || menus?.aiSeat?.isInitializing || false
+			}
 			filter={filter}
 			error={error}
-			options={menus?.status && <StatusMenu {...menus.status} />}
-			optionsSkeleton={menus?.status && <MenuSkeleton />}
+			options={
+				<>
+					{menus?.status && <StatusMenu {...menus.status} />}
+					{menus?.aiSeat && <AISeatMenu {...menus.aiSeat} />}
+				</>
+			}
+			optionsSkeleton={
+				<>
+					{menus?.status && <MenuSkeleton />}
+					{menus?.aiSeat && <MenuSkeleton />}
+				</>
+			}
 		/>
 	);
 };
@@ -89,6 +134,18 @@ const StatusMenu = (menu: StatusFilterMenu) => {
 		<SelectFilter
 			label="Select a status"
 			placeholder="All statuses"
+			options={menu.searchOptions}
+			onSelect={menu.selectOption}
+			selectedOption={menu.selectedOption ?? undefined}
+		/>
+	);
+};
+
+const AISeatMenu = (menu: AISeatFilterMenu) => {
+	return (
+		<SelectFilter
+			label="Select AI add-on status"
+			placeholder="All AI add-ons"
 			options={menu.searchOptions}
 			onSelect={menu.selectOption}
 			selectedOption={menu.selectedOption ?? undefined}

--- a/site/src/pages/UsersPage/UsersPage.stories.tsx
+++ b/site/src/pages/UsersPage/UsersPage.stories.tsx
@@ -17,6 +17,15 @@ import {
 } from "#/testHelpers/storybook";
 import UsersPage from "./UsersPage";
 
+const MockUsersWithAISeats: User[] = MockUsers.map((user, index) => ({
+	...user,
+	has_ai_seat: index % 3 === 0,
+}));
+
+const MockUsersConsumingAISeats = MockUsersWithAISeats.filter(
+	(user) => user.has_ai_seat,
+);
+
 const parameters = {
 	queries: [
 		// This query loads users for the filter menu, not for the table
@@ -31,8 +40,16 @@ const parameters = {
 		{
 			key: usersKey({ limit: 25, offset: 0, q: "" }),
 			data: {
-				users: MockUsers,
+				users: MockUsersWithAISeats,
 				count: 60,
+			},
+		},
+		// Users after applying the AI seat filter
+		{
+			key: usersKey({ limit: 25, offset: 0, q: "has-ai-seat:true" }),
+			data: {
+				users: MockUsersConsumingAISeats,
+				count: MockUsersConsumingAISeats.length,
 			},
 		},
 		{
@@ -107,6 +124,36 @@ export const WithoutAIAddonColumn: Story = {
 		await expect(
 			canvas.queryByRole("columnheader", { name: /AI add-on/i }),
 		).not.toBeInTheDocument();
+	},
+};
+
+export const WithAIAddonFilter: Story = {
+	parameters: {
+		features: ["ai_governance_user_limit"],
+	},
+	play: async ({ canvasElement }) => {
+		const user = userEvent.setup();
+		const canvas = within(canvasElement);
+		const body = within(canvasElement.ownerDocument.body);
+		const aiSeatButton = await canvas.findByRole("button", {
+			name: /select ai add-on status/i,
+		});
+
+		await user.click(aiSeatButton);
+		const options = await body.findAllByRole("option");
+		await expect(options.map((option) => option.textContent)).toEqual(
+			expect.arrayContaining(["Consuming AI seat", "Not consuming AI seat"]),
+		);
+
+		await user.click(
+			await body.findByRole("option", {
+				name: /^Consuming AI seat$/i,
+			}),
+		);
+		await expect(aiSeatButton).toHaveTextContent("Consuming AI seat");
+		await expect(
+			await canvas.findByDisplayValue(/has-ai-seat:true/i),
+		).toBeVisible();
 	},
 };
 

--- a/site/src/pages/UsersPage/UsersPage.tsx
+++ b/site/src/pages/UsersPage/UsersPage.tsx
@@ -19,7 +19,10 @@ import type { User } from "#/api/typesGenerated";
 import { ConfirmDialog } from "#/components/Dialogs/ConfirmDialog/ConfirmDialog";
 import { DeleteDialog } from "#/components/Dialogs/DeleteDialog/DeleteDialog";
 import { useFilter } from "#/components/Filter/Filter";
-import { useStatusFilterMenu } from "#/components/Filter/UsersFilter";
+import {
+	useAISeatFilterMenu,
+	useStatusFilterMenu,
+} from "#/components/Filter/UsersFilter";
 import { isNonInitialPage } from "#/components/PaginationWidget/utils";
 import { useAuthenticated } from "#/hooks/useAuthenticated";
 import { usePaginatedQuery } from "#/hooks/usePaginatedQuery";
@@ -71,6 +74,14 @@ const UsersPage: FC<UserPageProps> = ({ defaultNewPassword }) => {
 			useFilterResult.update({
 				...useFilterResult.values,
 				status: option?.value,
+			}),
+	});
+	const aiSeatMenu = useAISeatFilterMenu({
+		value: useFilterResult.values["has-ai-seat"],
+		onChange: (option) =>
+			useFilterResult.update({
+				...useFilterResult.values,
+				"has-ai-seat": option?.value,
 			}),
 	});
 
@@ -152,7 +163,10 @@ const UsersPage: FC<UserPageProps> = ({ defaultNewPassword }) => {
 				filterProps={{
 					filter: useFilterResult,
 					error: usersQuery.error,
-					menus: { status: statusMenu },
+					menus: {
+						status: statusMenu,
+						...(showAISeatColumn ? { aiSeat: aiSeatMenu } : {}),
+					},
 				}}
 				usersQuery={usersQuery}
 				canCreateUser={canCreateUser}


### PR DESCRIPTION
Adds AI add-on filtering to the users table and keeps the filter scoped to `/users` only.

The backend now applies `has-ai-seat` at the SQL layer when the AI governance entitlement is enabled, while members and group members continue to reject that query param. The users filter UI now exposes an AI add-on menu and preset when the AI seat column is available, and the shared filter parser now round-trips hyphenated keys like `has-ai-seat` correctly.

<details>
<summary>Reviewer notes</summary>

- `has-ai-seat` is intentionally supported on the users page only, not members/org members/group members.
- The filter is applied in SQL rather than client-side so pagination and counts stay correct.
- The SQL predicate matches current AI-seat-consumption semantics by requiring active, non-deleted, non-system users with seat state.
- Added coverage for parser behavior, users API filtering, members/group-members rejection, filter query round-tripping, and the users page story interaction.

</details>
