### PR TITLE
fix(site): show delete menu for failed devcontainers

### DIFF
--- a/site/src/modules/resources/AgentDevcontainerCard.stories.tsx
+++ b/site/src/modules/resources/AgentDevcontainerCard.stories.tsx
@@ -53,9 +53,29 @@ export const HasError: Story = {
 	args: {
 		devcontainer: {
 			...MockWorkspaceAgentDevcontainer,
+			status: "error",
 			error: "unable to inject devcontainer with agent",
 			agent: undefined,
+			container: undefined,
 		},
+		subAgents: [],
+	},
+	play: async ({ canvasElement }) => {
+		const user = userEvent.setup();
+		const body = canvasElement.ownerDocument.body;
+		const canvas = within(canvasElement);
+
+		// Verify the three-dot menu is accessible on errored devcontainers.
+		const moreActionsButton = canvas.getByRole("button", {
+			name: "Dev Container actions",
+		});
+		await user.click(moreActionsButton);
+
+		const deleteButton = await within(body).findByText("Delete…");
+		await user.click(deleteButton);
+
+		// Confirm the delete dialog opens.
+		within(body).getByRole("button", { name: "Delete" });
 	},
 };
 

--- a/site/src/modules/resources/AgentDevcontainerCard.tsx
+++ b/site/src/modules/resources/AgentDevcontainerCard.tsx
@@ -274,12 +274,11 @@ export const AgentDevcontainerCard: FC<AgentDevcontainerCardProps> = ({
 							/>
 						)}
 
-					{showDevcontainerControls && (
+					{devcontainer.status !== "deleting" && (
 						<AgentDevcontainerMoreActions
 							deleteDevContainer={deleteDevcontainerMutation.mutate}
 						/>
 					)}
-
 					<DevcontainerDeleteErrorDialog
 						open={deleteDevcontainerMutation.isError}
 						error={deleteDevcontainerMutation.error}


### PR DESCRIPTION
The three-dot menu (containing "Delete") was gated behind `showDevcontainerControls`, which requires both a connected sub-agent and a container reference. Failed devcontainers typically have neither, making it impossible to delete them from the UI.

Decouple the menu from `showDevcontainerControls` so it renders whenever the devcontainer is not actively being deleted. SSH and port-forward buttons still require a live container and sub-agent.

Fixes #23754