### PR TITLE
docs: add early access notice to External Workspaces

### DIFF
--- a/docs/admin/templates/managing-templates/external-workspaces.md
+++ b/docs/admin/templates/managing-templates/external-workspaces.md
@@ -1,5 +1,9 @@
 # External Workspaces
 
+> [!NOTE]
+> External Workspaces is an [Early Access](../../../install/releases/feature-stages.md#early-access-features) feature.
+> It is not yet feature-complete and may change without notice.
+
 External workspaces allow you to seamlessly connect externally managed infrastructure as Coder workspaces. This enables you to integrate existing servers, on-premises systems, or any capable machine with the Coder environment, ensuring a smooth and efficient development workflow without requiring Coder to provision additional compute resources.
 
 ## Prerequisites

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -803,7 +803,8 @@
 						{
 							"title": "OAuth2 Provider",
 							"description": "Use Coder as an OAuth2 provider",
-							"path": "./admin/integrations/oauth2-provider.md"
+							"path": "./admin/integrations/oauth2-provider.md",
+							"state": ["early access"]
 						},
 						{
 							"title": "Dev Containers",
@@ -1152,7 +1153,7 @@
 									"title": "MCP Tools Injection",
 									"description": "How to configure MCP servers for tools injection through AI Bridge",
 									"path": "./ai-coder/ai-bridge/mcp.md",
-									"state": ["early access"]
+									"state": ["deprecated"]
 								},
 								{
 									"title": "AI Bridge Proxy",


### PR DESCRIPTION
The manifest.json correctly labels External Workspaces as `['premium', 'early access']` but the documentation page itself had no inline warning. Users reading the doc directly had no indication this is an early access feature.

This adds a standard early access notice callout after the heading, matching the pattern used in other early access docs (e.g., `docs/ai-coder/agents/getting-started.md`).

Found during a documentation audit of feature stage labels. The manifest state drives the sidebar badge, but users who navigate directly to the page or view it on GitHub would miss the early access status entirely.