### PR TITLE
docs: fix Startup Coordination label from experimental to early access

### DIFF
--- a/docs/admin/templates/startup-coordination/index.md
+++ b/docs/admin/templates/startup-coordination/index.md
@@ -1,7 +1,7 @@
 # Workspace Startup Coordination
 
 > [!NOTE]
-> This feature is experimental and may change without notice in future releases.
+> This feature is in [Early Access](../../../install/releases/feature-stages.md#early-access-features) and may change without notice in future releases.
 
 When workspaces start, scripts often need to run in a specific order.
 For example, an IDE or coding agent might need the repository cloned

--- a/docs/admin/templates/startup-coordination/troubleshooting.md
+++ b/docs/admin/templates/startup-coordination/troubleshooting.md
@@ -1,7 +1,7 @@
 # Workspace Startup Coordination Troubleshooting
 
 > [!NOTE]
-> This feature is experimental and may change without notice in future releases.
+> This feature is in [Early Access](../../../install/releases/feature-stages.md#early-access-features) and may change without notice in future releases.
 
 ## Test Sync Availability
 

--- a/docs/admin/templates/startup-coordination/usage.md
+++ b/docs/admin/templates/startup-coordination/usage.md
@@ -1,7 +1,7 @@
 # Workspace Startup Coordination Usage
 
 > [!NOTE]
-> This feature is experimental and may change without notice in future releases.
+> This feature is in [Early Access](../../../install/releases/feature-stages.md#early-access-features) and may change without notice in future releases.
 
 Startup coordination is built around the concept of **units**. You declare units in your Coder workspace template using the `coder exp sync` command in `coder_script` resources. When the Coder agent starts, it keeps an in-memory directed acyclic graph (DAG) of all units of which it is aware. When you need to synchronize with another unit, you can use `coder exp sync start $UNIT_NAME` to block until all dependencies of that unit have been marked complete.
 


### PR DESCRIPTION
The Startup Coordination docs use the term 'experimental' but the official
feature stage definitions in `feature-stages.md` call this stage 'Early Access'.
The `manifest.json` correctly uses `early access` as the state.

This updates the inline doc terminology to match and adds a link to the
feature stages documentation.

<details><summary>Audit context</summary>

Found during a documentation audit. The `feature-stages.md` defines three stages:
Early Access, Beta, and GA. 'Experimental' is not an official stage name but was
used interchangeably in older docs. This PR normalizes the terminology.

</details>