### PR TITLE
docs: fix AI Bridge MCP manifest state to deprecated

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1152,7 +1152,7 @@
 									"title": "MCP Tools Injection",
 									"description": "How to configure MCP servers for tools injection through AI Bridge",
 									"path": "./ai-coder/ai-bridge/mcp.md",
-									"state": ["early access"]
+									"state": ["deprecated"]
 								},
 								{
 									"title": "AI Bridge Proxy",


### PR DESCRIPTION
## Summary

The AI Bridge MCP tool injection doc itself says:

> Injected MCP in AI Bridge is deprecated and will be removed in a future release.

But the manifest.json still labels it as `early access`. This PR updates the state to `deprecated` to match the actual feature status.

<details><summary>Audit context</summary>

Found during a documentation audit of feature stage labels. The manifest.json `state` field drives sidebar badges on coder.com/docs, so this was showing an incorrect 'early access' badge on a deprecated feature.

</details>