### PR TITLE
docs: add early access state to OAuth2 Provider manifest

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -803,7 +803,8 @@
 						{
 							"title": "OAuth2 Provider",
 							"description": "Use Coder as an OAuth2 provider",
-							"path": "./admin/integrations/oauth2-provider.md"
+							"path": "./admin/integrations/oauth2-provider.md",
+							"state": ["early access"]
 						},
 						{
 							"title": "Dev Containers",


### PR DESCRIPTION
## Summary

The OAuth2 Provider feature:
- Requires the `oauth2` experiment flag
- Is documented as 'experimental and unstable'
- Says 'not recommended for production use'

But the manifest.json had no `state` tag, so the docs sidebar showed no feature stage badge. Users could miss that this is an early access feature.

This adds `"state": ["early access"]` to the manifest entry.

<details><summary>Audit context</summary>

Found during a documentation audit of feature stage labels. Every feature that requires an experiment flag should have an appropriate stage label in the manifest to ensure the sidebar badge is displayed.

</details>