### PR TITLE
ci: add artifact-metadata permission for attestation storage records

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1091,6 +1091,8 @@ jobs:
       id-token: write
       # Required for GitHub Actions attestation
       attestations: write
+      # Required for artifact storage records (linked artifacts)
+      artifact-metadata: write
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     outputs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,6 +73,8 @@ jobs:
       id-token: write
       # Required for GitHub Actions attestation
       attestations: write
+      # Required for artifact storage records (linked artifacts)
+      artifact-metadata: write
     env:
       # Necessary for Docker manifest
       DOCKER_CLI_EXPERIMENTAL: "enabled"


### PR DESCRIPTION
Follow-up to #23768.

Attestations now succeed but log:

```
Warning: Failed to create storage record: no artifacts found
Warning: Please check that the "artifact-metadata:write" permission has been included
```

Add `artifact-metadata: write` to the build job permissions in both `ci.yaml` and `release.yaml`. This enables [linked artifact storage records](https://docs.github.com/en/rest/orgs/artifact-metadata) visible at https://github.com/orgs/coder/artifacts.

🤖 Generated with [Claude Code](https://claude.ai/code)

> 🤖 This PR was created with the help of Coder Agents, and needs a human review.  🧑💻