### PR TITLE
fix(site/src/pages/AgentsPage): batch StickyUserMessage layout to prevent scroll drift

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -37,6 +37,7 @@ import { ImageLightbox } from "../ImageLightbox";
 import { TextPreviewDialog } from "../TextPreviewDialog";
 import { getEditableUserMessagePayload } from "./messageParsing";
 import { useSmoothStreamingText } from "./SmoothText";
+import { registerStickyUpdate } from "./stickyCoordinator";
 import type {
 	MergedTool,
 	ParsedMessageContent,
@@ -711,6 +712,13 @@ const StickyUserMessage = memo<{
 		// Sets a single CSS custom property (--clip-h) on the sticky
 		// container. All visual behaviour (max-height, mask fade) is
 		// driven by CSS using this variable.
+		//
+		// Instead of creating per-instance ResizeObserver and scroll
+		// listeners, we register read/write callbacks with a shared
+		// coordinator (stickyCoordinator.ts). The coordinator runs
+		// ALL reads before ANY writes each frame, preventing the
+		// layout thrashing that occurs when N instances each
+		// interleave getBoundingClientRect() with style mutations.
 		useLayoutEffect(() => {
 			const sentinel = sentinelRef.current;
 			const container = containerRef.current;
@@ -721,115 +729,104 @@ const StickyUserMessage = memo<{
 			if (!scroller) return;
 
 			const MIN_HEIGHT = 72;
-			let scrollerTop = scroller.getBoundingClientRect().top;
-			let scrollerHeight = scroller.clientHeight;
 
-			const update = () => {
-				const fullHeight = container.offsetHeight;
+			// Mutable state populated during the read phase and
+			// consumed during the write phase.
+			let readFullHeight = 0;
+			let readTooTall = false;
+			let readSentinelTop = 0;
+			let readNextSentinelTop: number | null = null;
+			let readScrollerTop = 0;
 
-				// Skip sticky behavior for messages that take up
-				// most of the visible area — accounting for the
-				// chat input and some breathing room.
-				const tooTall = fullHeight > scrollerHeight * 0.75;
-				setIsTooTall(tooTall);
-				if (tooTall) {
-					container.style.setProperty("--clip-h", `${fullHeight}px`);
-					container.style.setProperty("--fade-opacity", "0");
-					container.style.top = "0px";
-					return;
-				}
-				const sentinelTop = sentinel.getBoundingClientRect().top;
-				const scrolledPast = scrollerTop - sentinelTop;
+			// Read phase: measure DOM positions without any
+			// style writes so the browser computes layout once
+			// for all StickyUserMessage instances.
+			const read = (scrollerTop: number, scrollerHeight: number) => {
+				readScrollerTop = scrollerTop;
+				readFullHeight = container.offsetHeight;
+				readTooTall = readFullHeight > scrollerHeight * 0.75;
+				readSentinelTop = sentinel.getBoundingClientRect().top;
 
-				if (scrolledPast <= 0) {
-					// Always set a valid value so the overlay has the
-					// correct height immediately when isStuck flips.
-					container.style.setProperty("--clip-h", `${fullHeight}px`);
-					container.style.setProperty("--fade-opacity", "0");
-					container.style.top = "0px";
-					return;
-				}
-				const visible = Math.max(fullHeight - scrolledPast - 48, MIN_HEIGHT);
-				container.style.setProperty("--clip-h", `${visible}px`);
-				// Only show the fade gradient once enough content is
-				// clipped to be visually meaningful.
-				container.style.setProperty(
-					"--fade-opacity",
-					visible < fullHeight - 8 ? "1" : "0",
-				);
-
-				// Push-up effect: when the next user message's sentinel
-				// approaches the bottom of this sticky container, shift
-				// this container upward so it slides out of view — the
-				// same visual as the old section-boundary behavior.
-				let nextSentinel: Element | null = sentinel.nextElementSibling;
-				while (nextSentinel) {
-					if (nextSentinel.hasAttribute("data-user-sentinel")) {
+				// Find the next user sentinel for the push-up
+				// effect.
+				readNextSentinelTop = null;
+				let next: Element | null = sentinel.nextElementSibling;
+				while (next) {
+					if (next.hasAttribute("data-user-sentinel")) {
+						readNextSentinelTop = next.getBoundingClientRect().top;
 						break;
 					}
-					nextSentinel = nextSentinel.nextElementSibling;
+					next = next.nextElementSibling;
 				}
-				if (nextSentinel) {
-					const nextY = nextSentinel.getBoundingClientRect().top - scrollerTop;
+			};
+
+			// Write phase: apply style mutations using values
+			// collected during the read phase.
+			const write = () => {
+				setIsTooTall(readTooTall);
+				if (readTooTall) {
+					container.style.setProperty("--clip-h", `${readFullHeight}px`);
+					container.style.setProperty("--fade-opacity", "0");
+					container.style.top = "0px";
+					return;
+				}
+				const scrolledPast = readScrollerTop - readSentinelTop;
+				if (scrolledPast <= 0) {
+					container.style.setProperty("--clip-h", `${readFullHeight}px`);
+					container.style.setProperty("--fade-opacity", "0");
+					container.style.top = "0px";
+					return;
+				}
+				const visible = Math.max(
+					readFullHeight - scrolledPast - 48,
+					MIN_HEIGHT,
+				);
+				container.style.setProperty("--clip-h", `${visible}px`);
+				container.style.setProperty(
+					"--fade-opacity",
+					visible < readFullHeight - 8 ? "1" : "0",
+				);
+
+				// Push-up effect: shift this container upward
+				// when the next user message's sentinel
+				// approaches.
+				if (readNextSentinelTop !== null) {
+					const nextY = readNextSentinelTop - readScrollerTop;
 					container.style.top = `${Math.min(0, nextY - visible)}px`;
 				} else {
 					container.style.top = "0px";
 				}
 			};
+
+			// Combined update runs both phases in sequence for
+			// synchronous callers (e.g. the isStuck
+			// useLayoutEffect) that bypass the coordinator.
+			const update = () => {
+				const scrollerTop = scroller.getBoundingClientRect().top;
+				const scrollerHeight = scroller.clientHeight;
+				read(scrollerTop, scrollerHeight);
+				write();
+			};
 			updateFnRef.current = update;
 
-			const onResize = () => {
-				scrollerTop = scroller.getBoundingClientRect().top;
-				scrollerHeight = scroller.clientHeight;
-				update();
-			};
+			// Register with the shared coordinator so all
+			// StickyUserMessage instances sharing this scroller
+			// batch their layout reads before writes.
+			const unregister = registerStickyUpdate(scroller, {
+				read,
+				write,
+			});
 
-			// Throttle to one update per animation frame so we don't
-			// do redundant work on high-refresh-rate displays.
-			let rafId: number | null = null;
-			const onScroll = () => {
-				if (rafId !== null) return;
-				rafId = requestAnimationFrame(() => {
-					rafId = null;
-					update();
-				});
-			};
-
-			// Re-run the visual update when the scrollable content height
-			// changes (e.g. streaming responses growing the transcript).
-			// In flex-col-reverse, scrollTop stays at 0 when pinned to
-			// bottom so no scroll event fires — but the content wrapper
-			// resizes and this observer catches that.
-			const contentEl = scroller.firstElementChild as HTMLElement | null;
-			let contentRafId: number | null = null;
-			const contentObserver = contentEl
-				? new ResizeObserver(() => {
-						if (contentRafId !== null) return;
-						contentRafId = requestAnimationFrame(() => {
-							contentRafId = null;
-							update();
-						});
-					})
-				: null;
-			contentObserver?.observe(contentEl!);
-
-			scroller.addEventListener("scroll", onScroll, { passive: true });
-			window.addEventListener("resize", onResize);
 			update();
-			// Set immediately — both --clip-h and --overlay-ready are
-			// applied before the browser paints since we're in a
-			// useLayoutEffect.
+			// Set immediately -- both --clip-h and --overlay-ready
+			// are applied before the browser paints since we are
+			// in a useLayoutEffect.
 			container.style.setProperty("--overlay-ready", "1");
 			return () => {
-				scroller.removeEventListener("scroll", onScroll);
-				window.removeEventListener("resize", onResize);
-				contentObserver?.disconnect();
+				unregister();
 				container.style.removeProperty("--overlay-ready");
-				if (rafId !== null) cancelAnimationFrame(rafId);
-				if (contentRafId !== null) cancelAnimationFrame(contentRafId);
 			};
 		}, []);
-
 		// Re-run the height calculation synchronously whenever
 		// isStuck changes so --clip-h is correct on the same frame
 		// the overlay appears. Without this, the async

--- a/site/src/pages/AgentsPage/components/ChatConversation/stickyCoordinator.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/stickyCoordinator.ts
@@ -1,0 +1,124 @@
+// Coordinates layout reads and writes across all StickyUserMessage
+// instances sharing the same scroll container. Without coordination,
+// each instance creates its own ResizeObserver on the content wrapper
+// and its own scroll listener. When N instances each call
+// getBoundingClientRect() (forced layout) then style.top = ...
+// (layout invalidation), we get N forced layout recalculations per
+// frame. Safari is especially sensitive to this pattern and may
+// adjust scrollTop during the layout thrashing, causing the scroll
+// position to drift away from the bottom.
+//
+// The coordinator creates a single ResizeObserver and scroll listener
+// per scroller element. On each tick, it runs ALL read callbacks
+// (getBoundingClientRect) before ANY write callbacks (style mutations),
+// so the browser computes layout exactly once per frame.
+
+interface StickyRegistration {
+	/** DOM reads: getBoundingClientRect, offsetHeight, etc. */
+	read: (scrollerTop: number, scrollerHeight: number) => void;
+	/** DOM writes: style.top, style.setProperty, setState. */
+	write: () => void;
+}
+
+interface Coordinator {
+	refCount: number;
+	registrations: Set<StickyRegistration>;
+	destroy: () => void;
+}
+
+const coordinators = new WeakMap<Element, Coordinator>();
+
+/**
+ * Register a StickyUserMessage's read/write callbacks with the
+ * shared coordinator for the given scroller element. Returns a
+ * cleanup function that unregisters the callbacks and tears down
+ * the coordinator when the last instance unmounts.
+ */
+export function registerStickyUpdate(
+	scroller: HTMLElement,
+	registration: StickyRegistration,
+): () => void {
+	let coord = coordinators.get(scroller);
+	if (!coord) {
+		coord = createCoordinator(scroller);
+		coordinators.set(scroller, coord);
+	}
+
+	coord.refCount++;
+	coord.registrations.add(registration);
+
+	return () => {
+		const c = coordinators.get(scroller);
+		if (!c) return;
+		c.registrations.delete(registration);
+		c.refCount--;
+		if (c.refCount <= 0) {
+			c.destroy();
+			coordinators.delete(scroller);
+		}
+	};
+}
+
+function createCoordinator(scroller: HTMLElement): Coordinator {
+	const registrations = new Set<StickyRegistration>();
+	let scrollRafId: number | null = null;
+	let resizeRafId: number | null = null;
+	let scrollerTop = scroller.getBoundingClientRect().top;
+	let scrollerHeight = scroller.clientHeight;
+
+	const runBatchedUpdate = () => {
+		// Read phase: all instances measure their DOM positions.
+		// No writes happen between reads, so the browser computes
+		// layout exactly once.
+		for (const reg of registrations) {
+			reg.read(scrollerTop, scrollerHeight);
+		}
+		// Write phase: all instances apply their style mutations.
+		for (const reg of registrations) {
+			reg.write();
+		}
+	};
+
+	const onScroll = () => {
+		if (scrollRafId !== null) return;
+		scrollRafId = requestAnimationFrame(() => {
+			scrollRafId = null;
+			runBatchedUpdate();
+		});
+	};
+
+	const onResize = () => {
+		scrollerTop = scroller.getBoundingClientRect().top;
+		scrollerHeight = scroller.clientHeight;
+		runBatchedUpdate();
+	};
+
+	const contentEl = scroller.firstElementChild as HTMLElement | null;
+	const contentObserver = new ResizeObserver(() => {
+		if (resizeRafId !== null) return;
+		resizeRafId = requestAnimationFrame(() => {
+			resizeRafId = null;
+			runBatchedUpdate();
+		});
+	});
+	if (contentEl) {
+		contentObserver.observe(contentEl);
+	}
+
+	scroller.addEventListener("scroll", onScroll, { passive: true });
+	window.addEventListener("resize", onResize);
+
+	const coord: Coordinator = {
+		refCount: 0,
+		registrations,
+		destroy() {
+			scroller.removeEventListener("scroll", onScroll);
+			window.removeEventListener("resize", onResize);
+			contentObserver.disconnect();
+			if (scrollRafId !== null) cancelAnimationFrame(scrollRafId);
+			if (resizeRafId !== null) cancelAnimationFrame(resizeRafId);
+		},
+	};
+
+	return coord;
+}


### PR DESCRIPTION
Each StickyUserMessage instance was creating its own ResizeObserver on
the scroll container's content wrapper and its own scroll listener.
With N user messages, this produced N interleaved read-write cycles per
frame (`getBoundingClientRect()` then `style.top =`), forcing the
browser to recalculate layout N times. Safari is especially sensitive
to this pattern and may adjust `scrollTop` during the thrashing,
causing the scroll position to drift away from the bottom on idle
chats.

Introduce a shared `stickyCoordinator` that creates a single
ResizeObserver and scroll listener per scroll container. On each
animation frame, the coordinator runs ALL read callbacks before ANY
write callbacks, so the browser computes layout exactly once per frame
regardless of the number of sticky messages.

<details><summary>Investigation notes</summary>

- `overflow-anchor` CSS is not supported in any Safari version;
  `[overflow-anchor:none]` on the scroll container is a no-op.
- Workspace heartbeat comparison was already fixed on main (PR #23736)
  to use primitive field comparisons instead of reference equality on
  `resources`.
- The chatStore uses deep value comparison
  (`chatMessagesEqualByValue`) so background refetches of idle chat
  messages do not cause store subscriber re-renders.
- React Compiler is enabled only for `src/pages/AgentsPage/` via
  babel override in `vite.config.mts`.

</details>

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻