### PR TITLE
fix(site): prevent spurious startup warning during pending status

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.createStore.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.createStore.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type * as TypesGen from "#/api/typesGenerated";
-import { createChatStore } from "./chatStore";
+import { createChatStore, selectIsAwaitingFirstStreamChunk } from "./chatStore";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -582,5 +582,76 @@ describe("subscribe", () => {
 
 		expect(countA).toBe(1);
 		expect(countB).toBe(1);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// selectIsAwaitingFirstStreamChunk
+// ---------------------------------------------------------------------------
+
+describe("selectIsAwaitingFirstStreamChunk", () => {
+	it("returns true when running with no stream state and no assistant message", () => {
+		const store = createChatStore();
+		store.setChatStatus("running");
+		store.upsertDurableMessage(makeMessage(1, "user", "hello"));
+
+		expect(selectIsAwaitingFirstStreamChunk(store.getSnapshot())).toBe(true);
+	});
+
+	it("returns false when the latest message is from the assistant", () => {
+		const store = createChatStore();
+		store.setChatStatus("running");
+		store.upsertDurableMessage(makeMessage(1, "user", "hello"));
+		store.upsertDurableMessage(makeMessage(2, "assistant", "hi there"));
+
+		expect(selectIsAwaitingFirstStreamChunk(store.getSnapshot())).toBe(false);
+	});
+
+	it("returns false when stream state is present", () => {
+		const store = createChatStore();
+		store.setChatStatus("running");
+		store.upsertDurableMessage(makeMessage(1, "user", "hello"));
+		store.applyMessagePart({ type: "text", text: "response" });
+
+		expect(selectIsAwaitingFirstStreamChunk(store.getSnapshot())).toBe(false);
+	});
+
+	it("returns false during pending status even when stream state is null", () => {
+		const store = createChatStore();
+		store.setChatStatus("pending");
+		store.upsertDurableMessage(makeMessage(1, "user", "hello"));
+
+		// "pending" should NOT be treated as awaiting because the
+		// transport drops message_part events during pending status.
+		expect(selectIsAwaitingFirstStreamChunk(store.getSnapshot())).toBe(false);
+	});
+
+	it("returns false when chat status is null", () => {
+		const store = createChatStore();
+		store.upsertDurableMessage(makeMessage(1, "user", "hello"));
+
+		expect(selectIsAwaitingFirstStreamChunk(store.getSnapshot())).toBe(false);
+	});
+
+	it("returns true when latest message is a tool result during running", () => {
+		const store = createChatStore();
+		store.setChatStatus("running");
+		store.upsertDurableMessage(makeMessage(1, "user", "hello"));
+		store.upsertDurableMessage(makeMessage(2, "assistant", "calling tool"));
+		store.upsertDurableMessage(makeMessage(3, "tool", "tool result"));
+
+		expect(selectIsAwaitingFirstStreamChunk(store.getSnapshot())).toBe(true);
+	});
+
+	it("returns false when latest message is a tool result during pending", () => {
+		const store = createChatStore();
+		store.setChatStatus("pending");
+		store.upsertDurableMessage(makeMessage(1, "user", "hello"));
+		store.upsertDurableMessage(makeMessage(2, "assistant", "calling tool"));
+		store.upsertDurableMessage(makeMessage(3, "tool", "tool result"));
+
+		// During "pending", the transport cannot deliver parts, so
+		// we should not be in a "starting" state.
+		expect(selectIsAwaitingFirstStreamChunk(store.getSnapshot())).toBe(false);
 	});
 });

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.ts
@@ -551,9 +551,15 @@ export const selectIsAwaitingFirstStreamChunk = (
 	const latestMessage = selectLatestDurableMessage(state);
 	const latestMessageNeedsAssistantResponse =
 		!latestMessage || latestMessage.role !== "assistant";
+	// Only treat "running" as awaiting a first chunk. During "pending"
+	// status the transport drops incoming message_part events
+	// (shouldApplyMessagePart returns false), so streamState can never
+	// transition away from null. Including "pending" here caused the
+	// "Response startup is taking longer than expected" warning to
+	// fire spuriously during multi-turn tool-call cycles.
 	return (
 		state.streamState === null &&
-		isActiveChatStatus(state.chatStatus) &&
+		state.chatStatus === "running" &&
 		latestMessageNeedsAssistantResponse
 	);
 };


### PR DESCRIPTION
## Problem

The `/agents` page frequently shows "Response startup is taking longer than expected" even while the agent is actively working and messages are appearing in the transcript.

## Root Cause

There's an inconsistency between `isActiveChatStatus` and `shouldApplyMessagePart` during `"pending"` status (the state between agent tool-call turns):

| Component | Treats `"pending"` as... |
|---|---|
| `isActiveChatStatus` | **active** — includes both `"running"` and `"pending"` |
| `shouldApplyMessagePart` | **inactive** — drops all `message_part` events during `"pending"` |
| Status handler | clears `streamState` to `null` on `"pending"` |

This creates a dead state during multi-turn tool-call cycles:

1. Agent finishes a turn → status = `"pending"` → `streamState` cleared to `null`
2. `selectIsAwaitingFirstStreamChunk` returns `true` (status is "active", stream is null, latest message isn't assistant)
3. Phase = `"starting"` → 15s timer starts
4. Stream parts from the server are **silently dropped** (`shouldApplyMessagePart()` returns `false` for `"pending"`)
5. `streamState` stays `null` — phase is stuck at `"starting"`
6. Meanwhile, durable messages (tool calls, tool results) appear normally in the transcript
7. After 15s → "Response startup is taking longer than expected" fires

## Fix

Narrow `selectIsAwaitingFirstStreamChunk` to only check `chatStatus === "running"` instead of `isActiveChatStatus(chatStatus)`. `"running"` is the only status where the transport actually accepts stream parts, so it's the only status where we should be showing the "starting" indicator.

`isActiveChatStatus` is left unchanged since its other caller (`shouldSurfaceReconnectState`) correctly needs to include `"pending"`.