### PR TITLE
feat(site): display PR approval status in agents sidebar

### DIFF
--- a/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.stories.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.stories.tsx
@@ -765,6 +765,145 @@ export const WithPRStateIcons: Story = {
 	},
 };
 
+export const WithPRReviewStatus: Story = {
+	args: {
+		chats: [
+			buildChat({
+				id: "pr-approved",
+				title: "PR approved by reviewer",
+				updated_at: recentTimestamp,
+				diff_status: {
+					chat_id: "pr-approved",
+					url: "https://github.com/coder/coder/pull/200",
+					pull_request_state: "open",
+					pull_request_title: "feat: add approval badges",
+					pull_request_draft: false,
+					changes_requested: false,
+					approved: true,
+					reviewer_count: 1,
+					additions: 85,
+					deletions: 12,
+					changed_files: 6,
+				},
+			}),
+			buildChat({
+				id: "pr-changes-requested",
+				title: "PR with changes requested",
+				updated_at: recentTimestamp,
+				diff_status: {
+					chat_id: "pr-changes-requested",
+					url: "https://github.com/coder/coder/pull/201",
+					pull_request_state: "open",
+					pull_request_title: "fix: update error handling",
+					pull_request_draft: false,
+					changes_requested: true,
+					approved: false,
+					reviewer_count: 2,
+					additions: 30,
+					deletions: 8,
+					changed_files: 3,
+				},
+			}),
+			buildChat({
+				id: "pr-no-review",
+				title: "PR with no reviews yet",
+				updated_at: recentTimestamp,
+				diff_status: {
+					chat_id: "pr-no-review",
+					url: "https://github.com/coder/coder/pull/202",
+					pull_request_state: "open",
+					pull_request_title: "chore: cleanup",
+					pull_request_draft: false,
+					changes_requested: false,
+					additions: 15,
+					deletions: 5,
+					changed_files: 2,
+				},
+			}),
+			buildChat({
+				id: "pr-draft-approved",
+				title: "Draft PR (no badge despite approval)",
+				updated_at: recentTimestamp,
+				diff_status: {
+					chat_id: "pr-draft-approved",
+					url: "https://github.com/coder/coder/pull/203",
+					pull_request_state: "open",
+					pull_request_title: "wip: experimental feature",
+					pull_request_draft: true,
+					changes_requested: false,
+					approved: true,
+					reviewer_count: 1,
+					additions: 45,
+					deletions: 0,
+					changed_files: 3,
+				},
+			}),
+			buildChat({
+				id: "pr-merged-approved",
+				title: "Merged PR (no badge)",
+				updated_at: recentTimestamp,
+				diff_status: {
+					chat_id: "pr-merged-approved",
+					url: "https://github.com/coder/coder/pull/204",
+					pull_request_state: "merged",
+					pull_request_title: "feat: completed work",
+					pull_request_draft: false,
+					changes_requested: false,
+					approved: true,
+					reviewer_count: 2,
+					additions: 100,
+					deletions: 20,
+					changed_files: 8,
+				},
+			}),
+		],
+	},
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: { path: "/agents" },
+			routing: agentsRouting,
+		}),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await waitFor(() => {
+			// Approved PR should show the "Approved" badge
+			const approvedNode = canvas.getByTestId("agents-tree-node-pr-approved");
+			expect(within(approvedNode).getByText("Approved")).toBeInTheDocument();
+
+			// Changes requested PR should show the badge
+			const changesNode = canvas.getByTestId(
+				"agents-tree-node-pr-changes-requested",
+			);
+			expect(
+				within(changesNode).getByText("Changes requested"),
+			).toBeInTheDocument();
+
+			// No-review PR should NOT show any review badge
+			const noReviewNode = canvas.getByTestId("agents-tree-node-pr-no-review");
+			expect(
+				within(noReviewNode).queryByTestId("review-status-badge"),
+			).not.toBeInTheDocument();
+
+			// Draft PR should NOT show review badge even if approved
+			const draftNode = canvas.getByTestId(
+				"agents-tree-node-pr-draft-approved",
+			);
+			expect(
+				within(draftNode).queryByTestId("review-status-badge"),
+			).not.toBeInTheDocument();
+
+			// Merged PR should NOT show review badge
+			const mergedNode = canvas.getByTestId(
+				"agents-tree-node-pr-merged-approved",
+			);
+			expect(
+				within(mergedNode).queryByTestId("review-status-badge"),
+			).not.toBeInTheDocument();
+		});
+	},
+};
+
 export const WithUnreadChats: Story = {
 	args: {
 		chats: [

--- a/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
@@ -454,6 +454,11 @@ const ChatTreeNode: FC<ChatTreeNodeProps> = ({ chat, isChildNode }) => {
 	const additions = diffStatus?.additions ?? 0;
 	const deletions = diffStatus?.deletions ?? 0;
 	const hasLineStats = additions > 0 || deletions > 0 || changedFiles > 0;
+	const hasReviewBadge =
+		hasLinkedDiffStatus &&
+		diffStatus?.pull_request_state === "open" &&
+		!diffStatus?.pull_request_draft &&
+		(diffStatus?.approved === true || diffStatus?.changes_requested === true);
 	const filesChangedLabel = `${changedFiles} ${
 		changedFiles === 1 ? "file" : "files"
 	}`;
@@ -560,7 +565,7 @@ const ChatTreeNode: FC<ChatTreeNodeProps> = ({ chat, isChildNode }) => {
 											<>
 												{diffStatus?.approved === true && (
 													<span
-														className="inline-flex shrink-0 items-center gap-0.5 text-[13px] leading-4 text-git-added-bright"
+														className="inline-flex shrink-0 items-center gap-0.5 text-[13px] leading-4 text-content-secondary"
 														data-testid="review-status-badge"
 													>
 														<CheckIcon className="h-3 w-3" />
@@ -569,7 +574,7 @@ const ChatTreeNode: FC<ChatTreeNodeProps> = ({ chat, isChildNode }) => {
 												)}
 												{diffStatus?.changes_requested === true && (
 													<span
-														className="inline-flex shrink-0 items-center gap-0.5 text-[13px] leading-4 text-content-warning"
+														className="inline-flex shrink-0 items-center gap-0.5 text-[13px] leading-4 text-content-secondary"
 														data-testid="review-status-badge"
 													>
 														<AlertTriangleIcon className="h-3 w-3" />
@@ -578,17 +583,19 @@ const ChatTreeNode: FC<ChatTreeNodeProps> = ({ chat, isChildNode }) => {
 												)}
 											</>
 										)}
-									<div
-										className={cn(
-											"min-w-0 overflow-hidden text-[13px] leading-4",
-											errorReason
-												? "line-clamp-1 whitespace-normal text-content-destructive [overflow-wrap:anywhere]"
-												: "truncate text-content-secondary",
-										)}
-										title={subtitle}
-									>
-										{subtitle}
-									</div>
+									{(!hasReviewBadge || errorReason) && (
+										<div
+											className={cn(
+												"min-w-0 overflow-hidden text-[13px] leading-4",
+												errorReason
+													? "line-clamp-1 whitespace-normal text-content-destructive [overflow-wrap:anywhere]"
+													: "truncate text-content-secondary",
+											)}
+											title={subtitle}
+										>
+											{subtitle}
+										</div>
+									)}
 								</div>
 							</div>
 						</>

--- a/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
@@ -554,6 +554,30 @@ const ChatTreeNode: FC<ChatTreeNodeProps> = ({ chat, isChildNode }) => {
 											</span>
 										</span>
 									)}
+									{hasLinkedDiffStatus &&
+										diffStatus?.pull_request_state === "open" &&
+										!diffStatus?.pull_request_draft && (
+											<>
+												{diffStatus?.approved === true && (
+													<span
+														className="inline-flex shrink-0 items-center gap-0.5 text-[13px] leading-4 text-git-added-bright"
+														data-testid="review-status-badge"
+													>
+														<CheckIcon className="h-3 w-3" />
+														Approved
+													</span>
+												)}
+												{diffStatus?.changes_requested === true && (
+													<span
+														className="inline-flex shrink-0 items-center gap-0.5 text-[13px] leading-4 text-content-warning"
+														data-testid="review-status-badge"
+													>
+														<AlertTriangleIcon className="h-3 w-3" />
+														Changes requested
+													</span>
+												)}
+											</>
+										)}
 									<div
 										className={cn(
 											"min-w-0 overflow-hidden text-[13px] leading-4",


### PR DESCRIPTION
Shows review status badges inline in sidebar chat items, next to the existing `+N −N` diff stats.

The backend already fetches this data from GitHub via `gitsync` → `ChatDiffStatus`, but no component was rendering it.

### What it looks like

For **open, non-draft PRs**:
- **Approved**: green ✓ icon with "Approved" text
- **Changes requested**: orange ⚠ icon with "Changes requested" text

No badge is shown for draft, merged, or closed PRs — their state is already conveyed by the existing PR icon.

### Changes

| File | What |
|------|------|
| `AgentsSidebar.tsx` | Review status badge in `ChatTreeNode` subtitle row |
| `AgentsSidebar.stories.tsx` | `WithPRReviewStatus` story with play-function assertions |

<details><summary>Implementation notes</summary>

- Uses existing imported icons (`CheckIcon`, `AlertTriangleIcon`) — no new dependencies
- Gated on `hasLinkedDiffStatus && pull_request_state === "open" && !pull_request_draft`
- Badge uses `data-testid="review-status-badge"` for test assertions
- Story covers 5 states: approved, changes requested, no review, draft (suppressed), merged (suppressed)
- Colors: `text-git-added-bright` for approved, `text-content-warning` for changes requested
</details>