### PR TITLE
ci: fix pnpm not found in check-docs job

### DIFF
--- a/.github/workflows/weekly-docs.yaml
+++ b/.github/workflows/weekly-docs.yaml
@@ -48,7 +48,7 @@ jobs:
 
       # TODO: Remove this workaround once action-linkspector sets
       # package-manager-cache: false in its internal setup-node step.
-      # See: https://github.com/coder/coder/actions/runs/23751836569
+      # See: https://github.com/UmbrellaDocs/action-linkspector/issues/54
       - name: Enable corepack
         run: corepack enable pnpm
 

--- a/.github/workflows/weekly-docs.yaml
+++ b/.github/workflows/weekly-docs.yaml
@@ -46,6 +46,12 @@ jobs:
             echo "    replacement: \"https://github.com/coder/coder/tree/${HEAD_SHA}/\""
           } >> .github/.linkspector.yml
 
+      # TODO: Remove this workaround once action-linkspector sets
+      # package-manager-cache: false in its internal setup-node step.
+      # See: https://github.com/coder/coder/actions/runs/23751836569
+      - name: Enable corepack
+        run: corepack enable pnpm
+
       - name: Check Markdown links
         uses: umbrelladocs/action-linkspector@37c85bcde51b30bf929936502bac6bfb7e8f0a4d # v1.4.1
         id: markdown-link-check


### PR DESCRIPTION
- Enable corepack before the linkspector step so `pnpm` shim is in PATH
- `action-linkspector@v1.4.1` internally calls `actions/setup-node@v5`, which now defaults `package-manager-cache: true` — it detects `pnpm-lock.yaml` and tries to resolve the `pnpm` binary, but it's not installed on the runner
- Add TODO to remove the workaround when upstream is fixed

Upstream: https://github.com/UmbrellaDocs/action-linkspector/issues/54

> 🤖 Cian asked a Coder Agent to make this PR and then reviewed the change.