### PR TITLE
fix(site/AgentsPage): re-pin at guard-clear when content grew between pin and clear

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -850,15 +850,25 @@ const ScrollAnchoredContainer: FC<{
 					);
 					setShowScrollToBottom(false);
 					restoreGuardRafIdRef.current = requestAnimationFrame(() => {
-						isRestoringScrollRef.current = false;
 						restoreGuardRafIdRef.current = null;
+						// Content may have grown between the pin and
+						// this frame (e.g. a query response arrived or
+						// a WebSocket message triggered a re-render).
+						// If we are no longer near bottom, re-pin
+						// instead of dropping the guard -- otherwise
+						// the next scroll event flips autoScrollRef
+						// to false and the pin is lost permanently.
+						if (!isNearBottom(container)) {
+							scheduleBottomPin();
+							return;
+						}
+						isRestoringScrollRef.current = false;
 					});
 				});
 			});
 		};
 
 		cancelPendingPinsRef.current = cancelPendingPins;
-
 		const observer = new ResizeObserver((entries) => {
 			const entry = entries[0];
 			const nextHeight =
@@ -975,8 +985,27 @@ const ScrollAnchoredContainer: FC<{
 				0,
 			);
 			restoreGuardRafIdRef.current = requestAnimationFrame(() => {
-				isRestoringScrollRef.current = false;
 				restoreGuardRafIdRef.current = null;
+				// Content may have grown between the pin and this
+				// frame. If not near bottom, re-pin via the content
+				// observer's scheduleBottomPin (which handles the
+				// double-RAF chain correctly) instead of dropping
+				// the guard.
+				if (!isNearBottom(container)) {
+					cancelPendingPinsRef.current?.();
+					// Direct re-pin since we don't have access to
+					// scheduleBottomPin from this effect.
+					container.scrollTop = Math.max(
+						container.scrollHeight - container.clientHeight,
+						0,
+					);
+					restoreGuardRafIdRef.current = requestAnimationFrame(() => {
+						restoreGuardRafIdRef.current = null;
+						isRestoringScrollRef.current = false;
+					});
+					return;
+				}
+				isRestoringScrollRef.current = false;
 			});
 		});
 		observer.observe(container);


### PR DESCRIPTION
The `scheduleBottomPin` guard-clear RAF blindly set `isRestoringScrollRef` to `false` regardless of scroll position. If content grew between the pin and the guard-clear (query response, WebSocket message, React re-render), the guard dropped while off-bottom. Any scroll event at that moment -- Safari's sticky-element repositioning noise being the common trigger -- would set `autoScrollRef` to `false` permanently, losing the bottom pin.

The fix checks `isNearBottom` in the guard-clear callback. If not at bottom, re-pin instead of dropping the guard. Applied to both the content observer's `scheduleBottomPin` and the container observer's direct pin.

Builds on #23809 which unified the guard-clear lifecycle into a shared ref.

<details><summary>Browser proof (Playwright, headless Chromium)</summary>

```
[BUGGY]
  resize: pinned #2 (dist=0)
  injected 200px growth (dist=200)
  guard-clear: cleared (dist=200)        <-- guard drops 200px off-bottom
  resize: d=200, scheduling pin          <-- ResizeObserver re-pins (lucky recovery)

[FIXED]
  resize: pinned #2 (dist=0)
  injected 200px growth (dist=200)
  guard-clear: not at bottom (dist=200), re-pinning   <-- detects and re-pins
  re-pin: pinned #3 (dist=0)
  guard-clear: at bottom, cleared        <-- safe clear
```

In the buggy code, the guard drops while 200px off-bottom. Chromium's ResizeObserver fires in the same frame and recovers, but in Safari, scroll events from sticky-element repositioning fire between the guard-clear and the ResizeObserver, setting `autoScrollRef=false` permanently.

The fixed code never drops the guard while off-bottom -- it re-pins first.

</details>

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻