### PR TITLE
fix(site): show delete menu for failed devcontainers

### DIFF
--- a/site/src/modules/resources/AgentDevcontainerCard.stories.tsx
+++ b/site/src/modules/resources/AgentDevcontainerCard.stories.tsx
@@ -53,9 +53,12 @@ export const HasError: Story = {
 	args: {
 		devcontainer: {
 			...MockWorkspaceAgentDevcontainer,
+			status: "error",
 			error: "unable to inject devcontainer with agent",
+			container: undefined,
 			agent: undefined,
 		},
+		subAgents: [],
 	},
 };
 

--- a/site/src/modules/resources/AgentDevcontainerCard.tsx
+++ b/site/src/modules/resources/AgentDevcontainerCard.tsx
@@ -274,12 +274,11 @@ export const AgentDevcontainerCard: FC<AgentDevcontainerCardProps> = ({
 							/>
 						)}
 
-					{showDevcontainerControls && (
+					{!isTransitioning && (
 						<AgentDevcontainerMoreActions
 							deleteDevContainer={deleteDevcontainerMutation.mutate}
 						/>
 					)}
-
 					<DevcontainerDeleteErrorDialog
 						open={deleteDevcontainerMutation.isError}
 						error={deleteDevcontainerMutation.error}


### PR DESCRIPTION
The three-dot menu (Delete option) was hidden for failed/error devcontainers because it was gated on `showDevcontainerControls`, which requires both a sub-agent and container to be present. Failed devcontainers typically have neither.

Change the rendering condition from `showDevcontainerControls` to `!isTransitioning`, since delete only needs `parentAgent.id` and `devcontainer.id` (always available). SSH and port forward buttons remain behind `showDevcontainerControls` as they genuinely need the sub-agent and container.

Fixes https://github.com/coder/coder/issues/23754

<details><summary>Implementation Notes</summary>

**Root cause**: `AgentDevcontainerCard.tsx` line 154 defines `showDevcontainerControls = subAgent && devcontainer.container`. When a devcontainer fails, `agent` is undefined (no sub-agent was injected) and `container` may also be undefined. The three-dot menu was behind this same guard at line 277.

**Fix**: The `AgentDevcontainerMoreActions` component only triggers `deleteDevContainer`, which calls `API.deleteDevContainer({ parentAgentId, devcontainerId })` — no container or sub-agent reference needed. Moved the menu out of `showDevcontainerControls` and gated it on `!isTransitioning` instead (hidden only during starting/stopping/deleting).

**Story update**: Updated `HasError` story to set `status: "error"`, `container: undefined`, and `subAgents: []` to realistically reflect a failed devcontainer.

</details>