### PR TITLE
feat: add chatgpt support for aibridge

### DIFF
--- a/coderd/aibridge/aibridge.go
+++ b/coderd/aibridge/aibridge.go
@@ -28,6 +28,12 @@ const (
 	HostCopilotEnterprise     = "api.enterprise.githubcopilot.com"
 )
 
+// ChatGPT provider.
+const (
+	ProviderChatGPT = "chatgpt"
+	BaseURLChatGPT  = "https://chatgpt.com/backend-api/codex"
+)
+
 // IsBYOK reports whether the request is using BYOK mode, determined
 // by the presence of the X-Coder-AI-Governance-Token header.
 func IsBYOK(header http.Header) bool {

--- a/enterprise/cli/aibridged.go
+++ b/enterprise/cli/aibridged.go
@@ -65,6 +65,12 @@ func newAIBridgeDaemon(coderAPI *coderd.API) (*aibridged.Server, error) {
 			BaseURL:        "https://" + agplaibridge.HostCopilotEnterprise,
 			CircuitBreaker: cbConfig,
 		}),
+		aibridge.NewOpenAIProvider(aibridge.OpenAIConfig{
+			Name:             agplaibridge.ProviderChatGPT,
+			BaseURL:          agplaibridge.BaseURLChatGPT,
+			CircuitBreaker:   cbConfig,
+			SendActorHeaders: cfg.SendActorHeaders.Value(),
+		}),
 	}
 
 	reg := prometheus.WrapRegistererWithPrefix("coder_aibridged_", coderAPI.PrometheusRegistry)


### PR DESCRIPTION
Registers a new aibridge provider for ChatGPT by reusing the existing OpenAI provider with a different `Name` and `BaseURL` (https://chatgpt.com/backend-api/codex). The ChatGPT backend API is OpenAI-compatible, so no new provider type is needed.                           
                                                                                                                                                      
ChatGPT authenticates exclusively via per-user OAuth JWTs (BYOK mode) — no centralized API key is configured. The OpenAI provider already handles this: when no key is set, it falls through to the bearer token from the request's Authorization header.                                             
  
  Depends on #23811