### PR TITLE
fix(site/scripts): guard check-compiler main block from test imports

### DIFF
--- a/site/scripts/check-compiler.mjs
+++ b/site/scripts/check-compiler.mjs
@@ -10,6 +10,7 @@
  */
 import { readFileSync, readdirSync } from "node:fs";
 import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
 import { transformSync } from "@babel/core";
 
 // Resolve the site/ directory (ESM equivalent of __dirname + "..").
@@ -205,9 +206,12 @@ function printReport(failures, totalCompiled, fileCount, hadErrors) {
 // Main
 // ---------------------------------------------------------------------------
 
-let hadCollectionErrors = false;
+// Only run the main block when executed directly, not when imported
+// by tests for the exported pure functions.
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+	let hadCollectionErrors = false;
 
-const files = targetDirs.flatMap((d) => collectFiles(join(siteDir, d)));
+	const files = targetDirs.flatMap((d) => collectFiles(join(siteDir, d)));
 
 let totalCompiled = 0;
 const failures = [];
@@ -224,4 +228,5 @@ printReport(failures, totalCompiled, files.length, hadCollectionErrors);
 
 if (failures.length > 0 || hadCollectionErrors) {
 	process.exitCode = 1;
+}
 }

--- a/site/scripts/check-compiler.test.mjs
+++ b/site/scripts/check-compiler.test.mjs
@@ -35,7 +35,7 @@ describe("shortenMessage", () => {
 		expect(shortenMessage("Single sentence.")).toBe("Single sentence");
 	});
 
-	it("returns (unknown) for empty input", () => {
+	it("preserves empty string and (unknown) sentinel", () => {
 		expect(shortenMessage("")).toBe("");
 		expect(shortenMessage("(unknown)")).toBe("(unknown)");
 	});


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

Follow-up to #23812. The exported pure functions caused the main block to run on test import, adding ~6.5s of compiler transforms as a side effect. Guards the main block with `process.argv[1] === fileURLToPath(import.meta.url)` so it only runs when executed directly.

Also fixes a misleading test name: `"returns (unknown) for empty input"` → `"preserves empty string and (unknown) sentinel"` since `shortenMessage("")` returns `""`, not `"(unknown)"`.