### PR TITLE
fix: resolve TestScheduleOverride/extend flake caused by timezone hour boundary race

### DIFF
--- a/cli/schedule_test.go
+++ b/cli/schedule_test.go
@@ -352,8 +352,6 @@ func TestScheduleOverride(t *testing.T) {
 			require.NoError(t, err, "invalid schedule")
 			ownerClient, _, _, ws := setupTestSchedule(t, sched)
 			now := time.Now()
-			// To avoid the likelihood of time-related flakes, only matching up to the hour.
-			expectedDeadline := now.In(loc).Add(10 * time.Hour).Format("2006-01-02T15:")
 
 			// When: we override the stop schedule
 			inv, root := clitest.New(t,
@@ -363,6 +361,19 @@ func TestScheduleOverride(t *testing.T) {
 			clitest.SetupConfig(t, ownerClient, root)
 			pty := ptytest.New(t).Attach(inv)
 			require.NoError(t, inv.Run())
+
+			// Fetch the workspace to get the actual deadline set by the
+			// server. Computing our own expected deadline from a separately
+			// captured time.Now() is racy: the CLI command calls time.Now()
+			// internally, and with the Asia/Kolkata +05:30 offset the hour
+			// boundary falls at :30 UTC minutes. A small delay between our
+			// time.Now() and the command's is enough to land in different
+			// hours.
+			updated, err := ownerClient.Workspace(context.Background(), ws[0].ID)
+			require.NoError(t, err)
+			require.False(t, updated.LatestBuild.Deadline.IsZero(), "deadline should be set after extend")
+			require.WithinDuration(t, now.Add(10*time.Hour), updated.LatestBuild.Deadline.Time, 5*time.Minute)
+			expectedDeadline := updated.LatestBuild.Deadline.Time.In(loc).Format(time.RFC3339)
 
 			// Then: the updated schedule should be shown
 			pty.ExpectMatch(ws[0].OwnerName + "/" + ws[0].Name)


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

Fixes https://github.com/coder/internal/issues/559

## Problem

`TestScheduleOverride/extend` flakes when the CI runner's clock is near a UTC `:30` minute boundary.

The test captured `time.Now()` before running the CLI command, then independently computed the expected deadline as `now + 10h` formatted in `Asia/Kolkata` (+05:30). The CLI `schedule extend` command internally calls its own `time.Now()` seconds-to-minutes later to compute the actual deadline. Because the Kolkata offset has a half-hour component, hour boundaries in IST fall at `:30` UTC minutes. A small delay between the two `time.Now()` calls is enough to land in different hours.

Both recorded failures occurred at exactly `:30` UTC (`07:30:15` and `09:30:15`).

## Reproduction

Simulating the original test logic across every second in an hour with a 2-second delay between the test's `time.Now()` and the command's:

```
MISMATCH at UTC 07:29:58 → test expected "2025-04-07T22:", command produced "2025-04-07T23:00:00+05:30"
MISMATCH at UTC 07:29:59 → test expected "2025-04-07T22:", command produced "2025-04-07T23:00:01+05:30"

Total seconds checked: 3600
Mismatches:            2
Mismatch rate:         0.1%
```

Exactly 2 out of 3600 seconds produce a mismatch — both at `07:29:58` and `07:29:59` UTC, right before the IST hour flips at `:30`. The CI log timestamps (`07:30:15`, `09:30:15`) are from after the test ran, consistent with the initial `time.Now()` being captured ~2s before the boundary.

The fixed version: 0 mismatches across all 3600 seconds.

## Fix

After the command runs, fetch the workspace via API to get the actual deadline set by the server. Then:
1. Assert the deadline is within 5 minutes of `now + 10h` (sanity check)
2. Use the actual deadline for the `pty.ExpectMatch` (exact match, no race)

This eliminates the independent `time.Now()` that was the source of the race.