### PR TITLE
dogfood: add shared bridge-dump volume for dogfood-v2

### DIFF
--- a/dogfood/clusters/dogfood-v2/coder/README.md
+++ b/dogfood/clusters/dogfood-v2/coder/README.md
@@ -1,0 +1,54 @@
+# Bridge Dump Volume — dogfood-v2
+
+Shared `ReadWriteMany` volume for collecting intercepted LLM request/response
+dumps written by `coder/aibridge` via the `BRIDGE_DUMP_DIR` environment
+variable.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `bridge-dump-pvc.yaml` | `PersistentVolumeClaim` (`ReadWriteMany`, `standard-rwx` storage class) |
+| `bridge-dump-values.yaml` | Helm values overlay that mounts the PVC and sets `BRIDGE_DUMP_DIR` |
+
+## How it works
+
+When `BRIDGE_DUMP_DIR` is set, each aibridge provider (Anthropic, OpenAI,
+Copilot) writes raw HTTP request/response pairs to disk as they are
+intercepted. The directory layout is:
+
+```
+/var/run/bridge-dump/
+  {provider}/
+    {model}/
+      {timestamp}-{uuid}.req.txt
+      {timestamp}-{uuid}.resp.txt
+    passthrough/
+      {timestamp}-{urlpath}-{uuid}.req.txt
+      {timestamp}-{urlpath}-{uuid}.resp.txt
+```
+
+Because the PVC uses `ReadWriteMany`, every coderd replica in the deployment
+can write concurrently—dumps land in the same filesystem regardless of which
+replica handles the request.
+
+## Deploying
+
+```bash
+# 1. Create the PVC (once)
+kubectl apply -f bridge-dump-pvc.yaml -n <namespace>
+
+# 2. Upgrade the Helm release with the values overlay
+helm upgrade coder coder-v2/coder \
+  -n <namespace> \
+  -f values.yaml \
+  -f bridge-dump-values.yaml
+```
+
+## Notes
+
+- `standard-rwx` on GKE is backed by Cloud Filestore (basic tier, 1 TiB
+  minimum). If a smaller volume is needed, consider a custom NFS provisioner
+  or a different `ReadWriteMany`-capable storage class.
+- Sensitive headers (`Authorization`, `X-Api-Key`, etc.) are automatically
+  redacted by the aibridge dump middleware.

--- a/dogfood/clusters/dogfood-v2/coder/bridge-dump-pvc.yaml
+++ b/dogfood/clusters/dogfood-v2/coder/bridge-dump-pvc.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: bridge-dump
+  labels:
+    app.kubernetes.io/name: coder
+    app.kubernetes.io/component: bridge-dump
+spec:
+  accessModes:
+    - ReadWriteMany
+  # standard-rwx is backed by Google Cloud Filestore and supports
+  # ReadWriteMany. The minimum size for the basic-rwx tier is 1Ti;
+  # use premium-rwx for a 2.5Ti minimum with higher throughput.
+  storageClassName: standard-rwx
+  resources:
+    requests:
+      storage: 1Ti

--- a/dogfood/clusters/dogfood-v2/coder/bridge-dump-values.yaml
+++ b/dogfood/clusters/dogfood-v2/coder/bridge-dump-values.yaml
@@ -1,0 +1,25 @@
+# Helm values overlay for mounting the bridge-dump volume into
+# all Coder coderd replicas.
+#
+# The PVC is created separately (bridge-dump-pvc.yaml) because its
+# lifecycle should outlive individual Helm releases; alternatively it
+# can be inlined via `extraTemplates`.
+#
+# Usage:
+#   helm upgrade coder coder-v2/coder \
+#     -f values.yaml \
+#     -f bridge-dump-values.yaml
+
+coder:
+  env:
+    - name: BRIDGE_DUMP_DIR
+      value: /var/run/bridge-dump
+
+  volumes:
+    - name: bridge-dump
+      persistentVolumeClaim:
+        claimName: bridge-dump
+
+  volumeMounts:
+    - name: bridge-dump
+      mountPath: /var/run/bridge-dump


### PR DESCRIPTION
*Disclaimer: implemented by a Coder Agent using claude-sonnet-4-20250514.*

Adds a `ReadWriteMany` PVC and Helm values overlay under `dogfood/clusters/dogfood-v2/coder/` so that all coderd replicas on the dogfood-v2 cluster can write aibridge request/response dumps to a shared filesystem.

## What

| File | Purpose |
|---|---|
| `bridge-dump-pvc.yaml` | `PersistentVolumeClaim` — `ReadWriteMany` via `standard-rwx` (GKE Filestore) |
| `bridge-dump-values.yaml` | Helm values overlay: mounts the PVC at `/var/run/bridge-dump` and sets `BRIDGE_DUMP_DIR` |
| `README.md` | Docs: directory layout, deployment steps, notes |

## Why

`BRIDGE_DUMP_DIR` is an env var consumed by all `coder/aibridge` providers (Anthropic, OpenAI, Copilot). When set, the aibridge dump middleware writes raw HTTP request/response pairs to disk. A shared RWX volume ensures dumps land in one filesystem regardless of which coderd replica handles the request.

<details>
<summary>Context: how BRIDGE_DUMP_DIR is wired</summary>

Each provider constructor in `coder/aibridge` falls back to `os.Getenv("BRIDGE_DUMP_DIR")` when `APIDumpDir` is not set in config. The enterprise `newAIBridgeDaemon` in `enterprise/cli/aibridged.go` does not set `APIDumpDir` explicitly, so the env var is the activation mechanism.

Dump files are structured as:
```
{BRIDGE_DUMP_DIR}/{provider}/{model}/{timestamp}-{uuid}.{req,resp}.txt
```

Sensitive headers (`Authorization`, `X-Api-Key`, etc.) are redacted automatically.
</details>
