### PR TITLE
test: fix TestServer_X11_EvictionLRU hang on fish shell

### DIFF
--- a/agent/agentssh/x11_test.go
+++ b/agent/agentssh/x11_test.go
@@ -211,7 +211,7 @@ func TestServer_X11_EvictionLRU(t *testing.T) {
 		require.NoError(t, err)
 		stderr, err := sess.StderrPipe()
 		require.NoError(t, err)
-		require.NoError(t, sess.Shell())
+		require.NoError(t, sess.Start("sh"))
 
 		// The SSH server lazily starts the session. We need to write a command
 		// and read back to ensure the X11 forwarding is started.


### PR DESCRIPTION
`TestServer_X11_EvictionLRU` hangs forever when the developer's login shell is `fish`. This is the only test in the repo that breaks on fish, and it meant I couldn't run `make test` or similar without it blocking indefinitely.

The test uses `sess.Shell()` to start interactive shell sessions, which causes the SSH server to run the user's login shell directly (`fish -l`). Fish buffers all piped stdin to EOF before executing any of it, so the test's `echo ready-0\n` write never gets processed — fish sits waiting for the pipe to close, and the test sits waiting for the echo response.

The fix is a one-line change: `sess.Shell()` → `sess.Start("sh")`. The test is exercising X11 LRU eviction, not shell behavior, so using `sh` explicitly is both correct and shell-agnostic. The DISPLAY environment variable is set identically either way since the x11-req handler runs before `sessionStart`.
