### PR TITLE
refactor: redesign compaction settings to table layout with batch save

### DIFF
--- a/site/src/pages/AgentsPage/components/UserCompactionThresholdSettings.stories.tsx
+++ b/site/src/pages/AgentsPage/components/UserCompactionThresholdSettings.stories.tsx
@@ -183,8 +183,8 @@ export const InvalidDraftShowsFooter: Story = {
 			name: /GPT-4o compaction threshold/i,
 		});
 
-		// Type an invalid value
-		await userEvent.type(gpt4oInput, "abc");
+		// Type an out-of-range value (number inputs reject non-numeric chars)
+		await userEvent.type(gpt4oInput, "150");
 
 		// Input should be marked invalid
 		await waitFor(() => {

--- a/site/src/pages/AgentsPage/components/UserCompactionThresholdSettings.stories.tsx
+++ b/site/src/pages/AgentsPage/components/UserCompactionThresholdSettings.stories.tsx
@@ -68,7 +68,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-	play: async ({ canvasElement, args }) => {
+	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const gpt4oInput = await canvas.findByRole("spinbutton", {
 			name: /GPT-4o compaction threshold/i,
@@ -78,23 +78,44 @@ export const Default: Story = {
 		expect(canvas.getByText("Claude Sonnet")).toBeInTheDocument();
 		expect(canvas.queryByText("GPT-3.5 (Disabled)")).not.toBeInTheDocument();
 
-		await userEvent.type(gpt4oInput, "100");
+		// No footer visible when nothing is dirty
 		expect(
-			canvas.getByText(
-				"⚠ Setting 100% will disable auto-compaction for this model.",
-			),
-		).toBeInTheDocument();
-		await userEvent.clear(gpt4oInput);
-		await userEvent.type(gpt4oInput, "95");
+			canvas.queryByRole("button", { name: /Save/i }),
+		).not.toBeInTheDocument();
 
-		const saveButtons = canvas.getAllByRole("button", { name: "Save" });
+		// Type a value to make the footer appear
+		await userEvent.type(gpt4oInput, "95");
 		await waitFor(() => {
-			expect(saveButtons[0]).toBeEnabled();
+			expect(
+				canvas.getByRole("button", { name: /Save 1 change/i }),
+			).toBeInTheDocument();
+		});
+	},
+};
+
+export const SaveAll: Story = {
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		const gpt4oInput = await canvas.findByRole("spinbutton", {
+			name: /GPT-4o compaction threshold/i,
+		});
+		const claudeInput = await canvas.findByRole("spinbutton", {
+			name: /Claude Sonnet compaction threshold/i,
 		});
 
-		await userEvent.click(saveButtons[0]);
+		// Edit both models
+		await userEvent.type(gpt4oInput, "95");
+		await userEvent.type(claudeInput, "50");
+
+		// Footer should show "Save 2 changes"
+		const saveButton = await canvas.findByRole("button", {
+			name: /Save 2 changes/i,
+		});
+		await userEvent.click(saveButton);
+
 		await waitFor(() => {
 			expect(args.onSaveThreshold).toHaveBeenCalledWith("model-1", 95);
+			expect(args.onSaveThreshold).toHaveBeenCalledWith("model-2", 50);
 		});
 	},
 };
@@ -118,11 +139,39 @@ export const WithOverrides: Story = {
 		expect(gpt4oInput).toHaveValue(90);
 		expect(claudeInput).toHaveValue(50);
 
-		const resetButtons = canvas.getAllByRole("button", { name: "Reset" });
+		// Reset buttons should be visible for both overridden models
+		const resetButtons = canvas.getAllByRole("button", {
+			name: /Reset .+ to default/i,
+		});
+		expect(resetButtons).toHaveLength(2);
+
 		await userEvent.click(resetButtons[0]);
 		await waitFor(() => {
 			expect(args.onResetThreshold).toHaveBeenCalledWith("model-1");
 		});
+	},
+};
+
+export const CancelChanges: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const gpt4oInput = await canvas.findByRole("spinbutton", {
+			name: /GPT-4o compaction threshold/i,
+		});
+
+		await userEvent.type(gpt4oInput, "42");
+		const cancelButton = await canvas.findByRole("button", { name: /Cancel/i });
+		await userEvent.click(cancelButton);
+
+		// Footer should disappear after cancel
+		await waitFor(() => {
+			expect(
+				canvas.queryByRole("button", { name: /Save/i }),
+			).not.toBeInTheDocument();
+		});
+
+		// Input should be cleared back to empty (no override)
+		expect(gpt4oInput).toHaveValue(null);
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/UserCompactionThresholdSettings.stories.tsx
+++ b/site/src/pages/AgentsPage/components/UserCompactionThresholdSettings.stories.tsx
@@ -181,6 +181,44 @@ export const Loading: Story = {
 	},
 };
 
+export const PartialSaveFailure: Story = {
+	name: "Partial Save Failure",
+	args: {
+		onSaveThreshold: fn(async (modelConfigId: string) => {
+			if (modelConfigId === "model-2") {
+				throw new globalThis.Error("Network error");
+			}
+		}),
+	},
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		const gpt4oInput = await canvas.findByRole("spinbutton", {
+			name: /GPT-4o compaction threshold/i,
+		});
+		const claudeInput = await canvas.findByRole("spinbutton", {
+			name: /Claude Sonnet compaction threshold/i,
+		});
+
+		await userEvent.type(gpt4oInput, "90");
+		await userEvent.type(claudeInput, "55");
+
+		const saveButton = await canvas.findByRole("button", {
+			name: /Save 2 changes/i,
+		});
+		await userEvent.click(saveButton);
+
+		await waitFor(() => {
+			expect(args.onSaveThreshold).toHaveBeenCalledWith("model-1", 90);
+			expect(args.onSaveThreshold).toHaveBeenCalledWith("model-2", 55);
+		});
+
+		// model-2 should show an error, footer should still be visible
+		await waitFor(() => {
+			expect(canvas.getByText("Network error")).toBeInTheDocument();
+		});
+	},
+};
+
 export const ErrorState: Story = {
 	name: "Error",
 	args: {

--- a/site/src/pages/AgentsPage/components/UserCompactionThresholdSettings.stories.tsx
+++ b/site/src/pages/AgentsPage/components/UserCompactionThresholdSettings.stories.tsx
@@ -175,6 +175,53 @@ export const CancelChanges: Story = {
 	},
 };
 
+export const InvalidDraftShowsFooter: Story = {
+	name: "Invalid Draft Shows Footer",
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const gpt4oInput = await canvas.findByRole("spinbutton", {
+			name: /GPT-4o compaction threshold/i,
+		});
+
+		// Type an invalid value
+		await userEvent.type(gpt4oInput, "abc");
+
+		// Input should be marked invalid
+		await waitFor(() => {
+			expect(gpt4oInput).toHaveAttribute("aria-invalid", "true");
+		});
+
+		// Cancel button should be visible so user can discard the edit
+		expect(canvas.getByRole("button", { name: /Cancel/i })).toBeInTheDocument();
+
+		// Save button should NOT be visible (nothing valid to save)
+		expect(
+			canvas.queryByRole("button", { name: /Save/i }),
+		).not.toBeInTheDocument();
+	},
+};
+
+export const DisableCompactionWarning: Story = {
+	name: "100% Disable Compaction Warning",
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const gpt4oInput = await canvas.findByRole("spinbutton", {
+			name: /GPT-4o compaction threshold/i,
+		});
+
+		await userEvent.type(gpt4oInput, "100");
+
+		// sr-only warning should be in the DOM for screen readers
+		await waitFor(() => {
+			expect(
+				canvas.getByText(
+					"Setting 100% will disable auto-compaction for this model.",
+				),
+			).toBeInTheDocument();
+		});
+	},
+};
+
 export const Loading: Story = {
 	args: {
 		isThresholdsLoading: true,
@@ -213,8 +260,12 @@ export const PartialSaveFailure: Story = {
 		});
 
 		// model-2 should show an error, footer should still be visible
+		// with Save showing "Save 1 change" for the failed row
 		await waitFor(() => {
 			expect(canvas.getByText("Network error")).toBeInTheDocument();
+			expect(
+				canvas.getByRole("button", { name: /Save 1 change/i }),
+			).toBeInTheDocument();
 		});
 	},
 };

--- a/site/src/pages/AgentsPage/components/UserCompactionThresholdSettings.tsx
+++ b/site/src/pages/AgentsPage/components/UserCompactionThresholdSettings.tsx
@@ -385,10 +385,9 @@ export const UserCompactionThresholdSettings: FC<
 									</div>
 								</TableCell>
 							</TableRow>
-						</TableFooter>
-					)}{" "}
-				</Table>
-			)}
+</TableFooter>
+					)}
+					</Table>			)}
 		</div>
 	);
 };

--- a/site/src/pages/AgentsPage/components/UserCompactionThresholdSettings.tsx
+++ b/site/src/pages/AgentsPage/components/UserCompactionThresholdSettings.tsx
@@ -1,9 +1,15 @@
+import { RotateCcwIcon } from "lucide-react";
 import { type FC, useState } from "react";
 import { getErrorMessage } from "#/api/errors";
 import type * as TypesGen from "#/api/typesGenerated";
 import { Button } from "#/components/Button/Button";
 import { Input } from "#/components/Input/Input";
 import { Spinner } from "#/components/Spinner/Spinner";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "#/components/Tooltip/Tooltip";
 
 interface UserCompactionThresholdSettingsProps {
 	modelConfigs: readonly TypesGen.ChatModelConfig[];
@@ -49,6 +55,16 @@ export const UserCompactionThresholdSettings: FC<
 	const [rowErrors, setRowErrors] = useState<Record<string, string>>({});
 	const [pendingModels, setPendingModels] = useState<Set<string>>(new Set());
 
+	const enabledModelConfigs = modelConfigs.filter((config) => config.enabled);
+	const overridesByModelID = new Map(
+		(thresholds ?? []).map(
+			(threshold: TypesGen.UserChatCompactionThreshold) => [
+				threshold.model_config_id,
+				threshold.threshold_percent,
+			],
+		),
+	);
+
 	const clearDraft = (modelConfigID: string) => {
 		setDrafts((currentDrafts) => {
 			const nextDrafts = { ...currentDrafts };
@@ -68,39 +84,21 @@ export const UserCompactionThresholdSettings: FC<
 		});
 	};
 
-	const handleSave = (modelConfigId: string, thresholdPercent: number) => {
-		clearRowError(modelConfigId);
-		setPendingModels((currentPendingModels) =>
-			new Set(currentPendingModels).add(modelConfigId),
-		);
-		onSaveThreshold(modelConfigId, thresholdPercent)
-			.then(() => {
-				clearDraft(modelConfigId);
-				clearRowError(modelConfigId);
-			})
-			.catch((error: unknown) => {
-				setRowErrors((currentErrors) => ({
-					...currentErrors,
-					[modelConfigId]: getErrorMessage(
-						error,
-						"Failed to save compaction threshold.",
-					),
-				}));
-			})
-			.finally(() => {
-				setPendingModels((currentPendingModels) => {
-					const nextPendingModels = new Set(currentPendingModels);
-					nextPendingModels.delete(modelConfigId);
-					return nextPendingModels;
-				});
-			});
+	const addPending = (id: string) => {
+		setPendingModels((s) => new Set(s).add(id));
+	};
+
+	const removePending = (id: string) => {
+		setPendingModels((s) => {
+			const next = new Set(s);
+			next.delete(id);
+			return next;
+		});
 	};
 
 	const handleReset = (modelConfigId: string) => {
 		clearRowError(modelConfigId);
-		setPendingModels((currentPendingModels) =>
-			new Set(currentPendingModels).add(modelConfigId),
-		);
+		addPending(modelConfigId);
 		onResetThreshold(modelConfigId)
 			.then(() => {
 				clearDraft(modelConfigId);
@@ -116,23 +114,55 @@ export const UserCompactionThresholdSettings: FC<
 				}));
 			})
 			.finally(() => {
-				setPendingModels((currentPendingModels) => {
-					const nextPendingModels = new Set(currentPendingModels);
-					nextPendingModels.delete(modelConfigId);
-					return nextPendingModels;
-				});
+				removePending(modelConfigId);
 			});
 	};
 
-	const enabledModelConfigs = modelConfigs.filter((config) => config.enabled);
-	const overridesByModelID = new Map(
-		(thresholds ?? []).map(
-			(threshold: TypesGen.UserChatCompactionThreshold) => [
-				threshold.model_config_id,
-				threshold.threshold_percent,
-			],
-		),
-	);
+	// Compute dirty rows: rows where the user has typed a valid value
+	// that differs from the current server-side override.
+	const dirtyRows: Array<{ modelConfigId: string; value: number }> = [];
+	for (const modelConfig of enabledModelConfigs) {
+		const draft = drafts[modelConfig.id];
+		if (draft === undefined) continue;
+		const parsed = parseThresholdDraft(draft);
+		if (parsed === null) continue;
+		const existingOverride = overridesByModelID.get(modelConfig.id);
+		if (parsed === existingOverride) continue;
+		dirtyRows.push({ modelConfigId: modelConfig.id, value: parsed });
+	}
+
+	const handleSaveAll = () => {
+		for (const { modelConfigId, value } of dirtyRows) {
+			clearRowError(modelConfigId);
+			addPending(modelConfigId);
+			onSaveThreshold(modelConfigId, value)
+				.then(() => {
+					clearDraft(modelConfigId);
+					clearRowError(modelConfigId);
+				})
+				.catch((error: unknown) => {
+					setRowErrors((currentErrors) => ({
+						...currentErrors,
+						[modelConfigId]: getErrorMessage(
+							error,
+							"Failed to save compaction threshold.",
+						),
+					}));
+				})
+				.finally(() => {
+					removePending(modelConfigId);
+				});
+		}
+	};
+
+	const handleCancelAll = () => {
+		setDrafts({});
+		setRowErrors({});
+	};
+
+	const hasAnyPending = pendingModels.size > 0;
+	const hasAnyErrors = Object.keys(rowErrors).length > 0;
+
 	if (isThresholdsLoading) {
 		return (
 			<div className="space-y-2">
@@ -198,106 +228,153 @@ export const UserCompactionThresholdSettings: FC<
 					models before compaction thresholds can be set.
 				</p>
 			) : (
-				<div className="space-y-2">
-					{enabledModelConfigs.map((modelConfig) => {
-						const existingOverride = overridesByModelID.get(modelConfig.id);
-						const hasOverride = overridesByModelID.has(modelConfig.id);
-						const draftValue =
-							drafts[modelConfig.id] ??
-							(existingOverride !== undefined ? String(existingOverride) : "");
-						const parsedDraftValue = parseThresholdDraft(draftValue);
-						const isThisModelMutating = pendingModels.has(modelConfig.id);
-						const isSaveDisabled =
-							draftValue.length === 0 ||
-							parsedDraftValue === null ||
-							parsedDraftValue === existingOverride ||
-							isThisModelMutating;
+				<div className="overflow-hidden rounded-md border border-solid border-border">
+					<table className="w-full border-collapse text-xs">
+						<thead>
+							<tr className="border-0 border-b border-solid border-border bg-surface-secondary">
+								<th className="px-3 py-2 text-left font-semibold text-content-primary">
+									Model
+								</th>
+								<th className="px-3 py-2 text-right font-semibold text-content-primary">
+									Default
+								</th>
+								<th className="px-3 py-2 text-right font-semibold text-content-primary">
+									Threshold
+								</th>
+							</tr>
+						</thead>
+						<tbody>
+							{enabledModelConfigs.map((modelConfig) => {
+								const existingOverride = overridesByModelID.get(modelConfig.id);
+								const hasOverride = overridesByModelID.has(modelConfig.id);
+								const draftValue =
+									drafts[modelConfig.id] ??
+									(existingOverride !== undefined
+										? String(existingOverride)
+										: "");
+								const parsedDraftValue = parseThresholdDraft(draftValue);
+								const isThisModelMutating = pendingModels.has(modelConfig.id);
+								const isInvalid =
+									draftValue.length > 0 && parsedDraftValue === null;
+								const isWarning100 = draftValue === "100";
+								const rowError = rowErrors[modelConfig.id];
+								const modelName = modelConfig.display_name || modelConfig.model;
 
-						return (
-							<div key={modelConfig.id} className="space-y-1">
-								<div className="flex items-center justify-between gap-3">
-									<div className="flex min-w-0 flex-1 items-baseline gap-2">
-										<span className="text-[13px] font-medium text-content-primary">
-											{modelConfig.display_name || modelConfig.model}
-										</span>
-										<span className="ml-auto text-xs text-content-secondary">
-											System default:{" "}
-											<span className="inline-block w-[4ch] text-right tabular-nums">
-												{modelConfig.compression_threshold}%
-											</span>
-										</span>
-									</div>
-									<div className="flex items-center gap-1.5">
-										<Input
-											aria-label={`${modelConfig.display_name || modelConfig.model} compaction threshold`}
-											type="number"
-											min={0}
-											max={100}
-											inputMode="numeric"
-											className="h-7 w-16 px-2 text-xs"
-											value={draftValue}
-											placeholder={String(modelConfig.compression_threshold)}
-											onChange={(event) => {
-												setDrafts((currentDrafts) => ({
-													...currentDrafts,
-													[modelConfig.id]: event.target.value,
-												}));
-												clearRowError(modelConfig.id);
-											}}
-											disabled={isThisModelMutating}
-										/>
-										<span className="text-xs text-content-secondary">%</span>
-										<Button
-											size="sm"
-											className="h-7"
-											type="button"
-											disabled={isSaveDisabled}
-											onClick={() => {
-												if (parsedDraftValue === null) {
-													return;
-												}
-												handleSave(modelConfig.id, parsedDraftValue);
-											}}
-										>
-											Save
-										</Button>
-										{hasOverride && (
-											<Button
-												size="sm"
-												className="h-7"
-												variant="outline"
-												type="button"
-												disabled={isThisModelMutating}
-												onClick={() => {
-													handleReset(modelConfig.id);
-												}}
-											>
-												Reset
-											</Button>
-										)}
-									</div>
-								</div>
-								{draftValue.length > 0 && parsedDraftValue === null && (
-									<p className="m-0 text-xs text-content-destructive">
-										Enter a whole number between 0 and 100.
-									</p>
-								)}
-								{rowErrors[modelConfig.id] && (
-									<p
-										aria-live="polite"
-										className="m-0 text-xs text-content-destructive"
+								return (
+									<tr
+										key={modelConfig.id}
+										className="border-0 border-b border-solid border-border last:border-b-0"
 									>
-										{rowErrors[modelConfig.id]}
-									</p>
-								)}
-								{draftValue === "100" && (
-									<p className="m-0 text-xs text-content-secondary">
-										⚠ Setting 100% will disable auto-compaction for this model.
-									</p>
-								)}
-							</div>
-						);
-					})}
+										<td className="px-3 py-2 text-[13px] font-medium text-content-primary">
+											{modelName}
+											{rowError && (
+												<p
+													aria-live="polite"
+													className="m-0 mt-0.5 text-2xs font-normal text-content-destructive"
+												>
+													{rowError}
+												</p>
+											)}
+										</td>
+										<td className="px-3 py-2 text-right tabular-nums text-content-secondary">
+											{modelConfig.compression_threshold}%
+										</td>
+										<td className="px-3 py-2">
+											<div className="flex items-center justify-end gap-1.5">
+												<Tooltip>
+													<TooltipTrigger asChild>
+														<Input
+															aria-label={`${modelName} compaction threshold`}
+															type="number"
+															min={0}
+															max={100}
+															inputMode="numeric"
+															className={`h-7 w-16 px-2 text-xs tabular-nums ${
+																isInvalid
+																	? "border-content-destructive focus:ring-content-destructive/30"
+																	: ""
+															}`}
+															value={draftValue}
+															placeholder={String(
+																modelConfig.compression_threshold,
+															)}
+															onChange={(event) => {
+																setDrafts((currentDrafts) => ({
+																	...currentDrafts,
+																	[modelConfig.id]: event.target.value,
+																}));
+																clearRowError(modelConfig.id);
+															}}
+															disabled={isThisModelMutating}
+														/>
+													</TooltipTrigger>
+													{(isInvalid || isWarning100) && (
+														<TooltipContent>
+															{isInvalid
+																? "Enter a whole number between 0 and 100."
+																: "Setting 100% will disable auto-compaction for this model."}
+														</TooltipContent>
+													)}
+												</Tooltip>
+												<span className="text-xs text-content-secondary">
+													%
+												</span>
+												<Tooltip>
+													<TooltipTrigger asChild>
+														<Button
+															size="icon"
+															variant="subtle"
+															className={`size-7 ${
+																hasOverride
+																	? "opacity-100"
+																	: "pointer-events-none opacity-0"
+															}`}
+															aria-label={`Reset ${modelName} to default`}
+															aria-hidden={!hasOverride}
+															tabIndex={hasOverride ? 0 : -1}
+															disabled={isThisModelMutating || !hasOverride}
+															onClick={() => handleReset(modelConfig.id)}
+														>
+															<RotateCcwIcon className="size-3.5" />
+														</Button>
+													</TooltipTrigger>
+													{hasOverride && (
+														<TooltipContent>
+															Reset to default (
+															{modelConfig.compression_threshold}%)
+														</TooltipContent>
+													)}
+												</Tooltip>
+											</div>
+										</td>
+									</tr>
+								);
+							})}
+						</tbody>
+					</table>
+					{(dirtyRows.length > 0 || hasAnyErrors) && (
+						<div className="flex items-center justify-end gap-2 border-0 border-t border-solid border-border bg-surface-secondary px-3 py-2">
+							<Button
+								size="sm"
+								variant="outline"
+								type="button"
+								onClick={handleCancelAll}
+								disabled={hasAnyPending}
+							>
+								Cancel
+							</Button>
+							<Button
+								size="sm"
+								type="button"
+								disabled={dirtyRows.length === 0 || hasAnyPending}
+								onClick={handleSaveAll}
+							>
+								{hasAnyPending
+									? "Saving..."
+									: `Save ${dirtyRows.length} ${dirtyRows.length === 1 ? "change" : "changes"}`}
+							</Button>
+						</div>
+					)}
 				</div>
 			)}
 		</div>

--- a/site/src/pages/AgentsPage/components/UserCompactionThresholdSettings.tsx
+++ b/site/src/pages/AgentsPage/components/UserCompactionThresholdSettings.tsx
@@ -317,11 +317,6 @@ export const UserCompactionThresholdSettings: FC<
 													</TooltipContent>
 												)}
 											</Tooltip>
-											{isInvalid && (
-												<span className="sr-only" aria-live="polite">
-													Enter a whole number between 0 and 100.
-												</span>
-											)}{" "}
 											<span className="text-xs text-content-secondary">%</span>
 											<Tooltip>
 												<TooltipTrigger asChild>
@@ -350,6 +345,11 @@ export const UserCompactionThresholdSettings: FC<
 												)}
 											</Tooltip>
 										</div>
+										{isInvalid && (
+											<span className="sr-only" aria-live="polite">
+												Enter a whole number between 0 and 100.
+											</span>
+										)}
 									</TableCell>
 								</TableRow>
 							);
@@ -359,7 +359,6 @@ export const UserCompactionThresholdSettings: FC<
 						<TableFooter className="bg-transparent">
 							<TableRow className="border-0">
 								<TableCell colSpan={3} className="border-0 p-0">
-									{" "}
 									<div className="flex items-center justify-end gap-2 px-3 py-1.5">
 										<Button
 											size="sm"
@@ -385,9 +384,10 @@ export const UserCompactionThresholdSettings: FC<
 									</div>
 								</TableCell>
 							</TableRow>
-</TableFooter>
+						</TableFooter>
 					)}
-					</Table>			)}
+				</Table>
+			)}
 		</div>
 	);
 };

--- a/site/src/pages/AgentsPage/components/UserCompactionThresholdSettings.tsx
+++ b/site/src/pages/AgentsPage/components/UserCompactionThresholdSettings.tsx
@@ -9,6 +9,7 @@ import {
 	Table,
 	TableBody,
 	TableCell,
+	TableFooter,
 	TableHead,
 	TableHeader,
 	TableRow,
@@ -354,12 +355,11 @@ export const UserCompactionThresholdSettings: FC<
 							);
 						})}
 					</TableBody>
-					{/* Raw tfoot because TableFooter adds bg-muted/50 styling
-						   that doesn't suit this compact inline footer. */}
 					{(dirtyRows.length > 0 || hasAnyErrors) && (
-						<tfoot>
-							<tr>
-								<td colSpan={3} className="p-0">
+						<TableFooter className="bg-transparent">
+							<TableRow className="border-0">
+								<TableCell colSpan={3} className="border-0 p-0">
+									{" "}
 									<div className="flex items-center justify-end gap-2 px-3 py-1.5">
 										<Button
 											size="sm"
@@ -383,9 +383,9 @@ export const UserCompactionThresholdSettings: FC<
 											</Button>
 										)}
 									</div>
-								</td>
-							</tr>
-						</tfoot>
+								</TableCell>
+							</TableRow>
+						</TableFooter>
 					)}{" "}
 				</Table>
 			)}

--- a/site/src/pages/AgentsPage/components/UserCompactionThresholdSettings.tsx
+++ b/site/src/pages/AgentsPage/components/UserCompactionThresholdSettings.tsx
@@ -257,7 +257,8 @@ export const UserCompactionThresholdSettings: FC<
 							const isThisModelMutating = pendingModels.has(modelConfig.id);
 							const isInvalid =
 								draftValue.length > 0 && parsedDraftValue === null;
-							const isWarning100 = draftValue === "100";
+							const isWarning100 =
+								draftValue === "100" && drafts[modelConfig.id] !== undefined;
 							const rowError = rowErrors[modelConfig.id];
 							const modelName = modelConfig.display_name || modelConfig.model;
 
@@ -283,6 +284,7 @@ export const UserCompactionThresholdSettings: FC<
 												<TooltipTrigger asChild>
 													<Input
 														aria-label={`${modelName} compaction threshold`}
+														aria-invalid={isInvalid || undefined}
 														type="number"
 														min={0}
 														max={100}
@@ -314,6 +316,11 @@ export const UserCompactionThresholdSettings: FC<
 													</TooltipContent>
 												)}
 											</Tooltip>
+											{isInvalid && (
+												<span className="sr-only" aria-live="polite">
+													Enter a whole number between 0 and 100.
+												</span>
+											)}{" "}
 											<span className="text-xs text-content-secondary">%</span>
 											<Tooltip>
 												<TooltipTrigger asChild>
@@ -347,6 +354,8 @@ export const UserCompactionThresholdSettings: FC<
 							);
 						})}
 					</TableBody>
+					{/* Raw tfoot because TableFooter adds bg-muted/50 styling
+						   that doesn't suit this compact inline footer. */}
 					{(dirtyRows.length > 0 || hasAnyErrors) && (
 						<tfoot>
 							<tr>
@@ -361,21 +370,23 @@ export const UserCompactionThresholdSettings: FC<
 										>
 											Cancel
 										</Button>
-										<Button
-											size="sm"
-											type="button"
-											disabled={dirtyRows.length === 0 || hasAnyPending}
-											onClick={handleSaveAll}
-										>
-											{hasAnyPending
-												? "Saving..."
-												: `Save ${dirtyRows.length} ${dirtyRows.length === 1 ? "change" : "changes"}`}
-										</Button>
+										{dirtyRows.length > 0 && (
+											<Button
+												size="sm"
+												type="button"
+												disabled={hasAnyPending}
+												onClick={handleSaveAll}
+											>
+												{hasAnyPending
+													? "Saving..."
+													: `Save ${dirtyRows.length} ${dirtyRows.length === 1 ? "change" : "changes"}`}
+											</Button>
+										)}
 									</div>
 								</td>
 							</tr>
 						</tfoot>
-					)}
+					)}{" "}
 				</Table>
 			)}
 		</div>

--- a/site/src/pages/AgentsPage/components/UserCompactionThresholdSettings.tsx
+++ b/site/src/pages/AgentsPage/components/UserCompactionThresholdSettings.tsx
@@ -235,12 +235,12 @@ export const UserCompactionThresholdSettings: FC<
 								<th className="px-3 py-2 text-left font-semibold text-content-primary">
 									Model
 								</th>
-								<th className="px-3 py-2 text-right font-semibold text-content-primary">
+								<th className="w-0 whitespace-nowrap px-3 py-2 text-right font-semibold text-content-primary">
 									Default
 								</th>
-								<th className="px-3 py-2 text-right font-semibold text-content-primary">
+								<th className="w-0 whitespace-nowrap px-3 py-2 text-right font-semibold text-content-primary">
 									Threshold
-								</th>
+								</th>{" "}
 							</tr>
 						</thead>
 						<tbody>
@@ -276,11 +276,12 @@ export const UserCompactionThresholdSettings: FC<
 												</p>
 											)}
 										</td>
-										<td className="px-3 py-2 text-right tabular-nums text-content-secondary">
+										<td className="w-0 whitespace-nowrap px-3 py-2 text-right tabular-nums text-content-secondary">
 											{modelConfig.compression_threshold}%
 										</td>
-										<td className="px-3 py-2">
+										<td className="w-0 whitespace-nowrap px-3 py-2">
 											<div className="flex items-center justify-end gap-1.5">
+												{" "}
 												<Tooltip>
 													<TooltipTrigger asChild>
 														<Input
@@ -353,7 +354,7 @@ export const UserCompactionThresholdSettings: FC<
 						</tbody>
 					</table>
 					{(dirtyRows.length > 0 || hasAnyErrors) && (
-						<div className="flex items-center justify-end gap-2 border-0 border-t border-solid border-border bg-surface-secondary px-3 py-2">
+						<div className="flex items-center justify-end gap-2 border-0 border-t border-solid border-border bg-surface-secondary px-3 py-1.5">
 							<Button
 								size="sm"
 								variant="outline"

--- a/site/src/pages/AgentsPage/components/UserCompactionThresholdSettings.tsx
+++ b/site/src/pages/AgentsPage/components/UserCompactionThresholdSettings.tsx
@@ -6,6 +6,14 @@ import { Button } from "#/components/Button/Button";
 import { Input } from "#/components/Input/Input";
 import { Spinner } from "#/components/Spinner/Spinner";
 import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "#/components/Table/Table";
+import {
 	Tooltip,
 	TooltipContent,
 	TooltipTrigger,
@@ -228,155 +236,147 @@ export const UserCompactionThresholdSettings: FC<
 					models before compaction thresholds can be set.
 				</p>
 			) : (
-				<div className="overflow-hidden rounded-md border border-solid border-border">
-					<table className="w-full border-collapse text-xs">
-						<thead>
-							<tr className="border-0 border-b border-solid border-border bg-surface-secondary">
-								<th className="px-3 py-2 text-left font-semibold text-content-primary">
-									Model
-								</th>
-								<th className="w-0 whitespace-nowrap px-3 py-2 text-right font-semibold text-content-primary">
-									Default
-								</th>
-								<th className="w-0 whitespace-nowrap px-3 py-2 text-right font-semibold text-content-primary">
-									Threshold
-								</th>{" "}
-							</tr>
-						</thead>
-						<tbody>
-							{enabledModelConfigs.map((modelConfig) => {
-								const existingOverride = overridesByModelID.get(modelConfig.id);
-								const hasOverride = overridesByModelID.has(modelConfig.id);
-								const draftValue =
-									drafts[modelConfig.id] ??
-									(existingOverride !== undefined
-										? String(existingOverride)
-										: "");
-								const parsedDraftValue = parseThresholdDraft(draftValue);
-								const isThisModelMutating = pendingModels.has(modelConfig.id);
-								const isInvalid =
-									draftValue.length > 0 && parsedDraftValue === null;
-								const isWarning100 = draftValue === "100";
-								const rowError = rowErrors[modelConfig.id];
-								const modelName = modelConfig.display_name || modelConfig.model;
+				<Table>
+					<TableHeader>
+						<TableRow>
+							<TableHead>Model</TableHead>
+							<TableHead className="w-0 whitespace-nowrap">Default</TableHead>
+							<TableHead className="w-0 whitespace-nowrap">Threshold</TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{enabledModelConfigs.map((modelConfig) => {
+							const existingOverride = overridesByModelID.get(modelConfig.id);
+							const hasOverride = overridesByModelID.has(modelConfig.id);
+							const draftValue =
+								drafts[modelConfig.id] ??
+								(existingOverride !== undefined
+									? String(existingOverride)
+									: "");
+							const parsedDraftValue = parseThresholdDraft(draftValue);
+							const isThisModelMutating = pendingModels.has(modelConfig.id);
+							const isInvalid =
+								draftValue.length > 0 && parsedDraftValue === null;
+							const isWarning100 = draftValue === "100";
+							const rowError = rowErrors[modelConfig.id];
+							const modelName = modelConfig.display_name || modelConfig.model;
 
-								return (
-									<tr
-										key={modelConfig.id}
-										className="border-0 border-b border-solid border-border last:border-b-0"
-									>
-										<td className="px-3 py-2 text-[13px] font-medium text-content-primary">
-											{modelName}
-											{rowError && (
-												<p
-													aria-live="polite"
-													className="m-0 mt-0.5 text-2xs font-normal text-content-destructive"
-												>
-													{rowError}
-												</p>
-											)}
-										</td>
-										<td className="w-0 whitespace-nowrap px-3 py-2 text-right tabular-nums text-content-secondary">
-											{modelConfig.compression_threshold}%
-										</td>
-										<td className="w-0 whitespace-nowrap px-3 py-2">
-											<div className="flex items-center justify-end gap-1.5">
-												{" "}
-												<Tooltip>
-													<TooltipTrigger asChild>
-														<Input
-															aria-label={`${modelName} compaction threshold`}
-															type="number"
-															min={0}
-															max={100}
-															inputMode="numeric"
-															className={`h-7 w-16 px-2 text-xs tabular-nums ${
-																isInvalid
-																	? "border-content-destructive focus:ring-content-destructive/30"
-																	: ""
-															}`}
-															value={draftValue}
-															placeholder={String(
-																modelConfig.compression_threshold,
-															)}
-															onChange={(event) => {
-																setDrafts((currentDrafts) => ({
-																	...currentDrafts,
-																	[modelConfig.id]: event.target.value,
-																}));
-																clearRowError(modelConfig.id);
-															}}
-															disabled={isThisModelMutating}
-														/>
-													</TooltipTrigger>
-													{(isInvalid || isWarning100) && (
-														<TooltipContent>
-															{isInvalid
-																? "Enter a whole number between 0 and 100."
-																: "Setting 100% will disable auto-compaction for this model."}
-														</TooltipContent>
-													)}
-												</Tooltip>
-												<span className="text-xs text-content-secondary">
-													%
-												</span>
-												<Tooltip>
-													<TooltipTrigger asChild>
-														<Button
-															size="icon"
-															variant="subtle"
-															className={`size-7 ${
-																hasOverride
-																	? "opacity-100"
-																	: "pointer-events-none opacity-0"
-															}`}
-															aria-label={`Reset ${modelName} to default`}
-															aria-hidden={!hasOverride}
-															tabIndex={hasOverride ? 0 : -1}
-															disabled={isThisModelMutating || !hasOverride}
-															onClick={() => handleReset(modelConfig.id)}
-														>
-															<RotateCcwIcon className="size-3.5" />
-														</Button>
-													</TooltipTrigger>
-													{hasOverride && (
-														<TooltipContent>
-															Reset to default (
-															{modelConfig.compression_threshold}%)
-														</TooltipContent>
-													)}
-												</Tooltip>
-											</div>
-										</td>
-									</tr>
-								);
-							})}
-						</tbody>
-					</table>
+							return (
+								<TableRow key={modelConfig.id}>
+									<TableCell className="text-[13px] font-medium text-content-primary">
+										{modelName}
+										{rowError && (
+											<p
+												aria-live="polite"
+												className="m-0 mt-0.5 text-2xs font-normal text-content-destructive"
+											>
+												{rowError}
+											</p>
+										)}
+									</TableCell>
+									<TableCell className="w-0 whitespace-nowrap tabular-nums">
+										{modelConfig.compression_threshold}%
+									</TableCell>
+									<TableCell className="w-0 whitespace-nowrap">
+										<div className="flex items-center gap-1.5">
+											<Tooltip>
+												<TooltipTrigger asChild>
+													<Input
+														aria-label={`${modelName} compaction threshold`}
+														type="number"
+														min={0}
+														max={100}
+														inputMode="numeric"
+														className={`h-7 w-16 px-2 text-xs tabular-nums ${
+															isInvalid
+																? "border-content-destructive focus:ring-content-destructive/30"
+																: ""
+														}`}
+														value={draftValue}
+														placeholder={String(
+															modelConfig.compression_threshold,
+														)}
+														onChange={(event) => {
+															setDrafts((currentDrafts) => ({
+																...currentDrafts,
+																[modelConfig.id]: event.target.value,
+															}));
+															clearRowError(modelConfig.id);
+														}}
+														disabled={isThisModelMutating}
+													/>
+												</TooltipTrigger>
+												{(isInvalid || isWarning100) && (
+													<TooltipContent>
+														{isInvalid
+															? "Enter a whole number between 0 and 100."
+															: "Setting 100% will disable auto-compaction for this model."}
+													</TooltipContent>
+												)}
+											</Tooltip>
+											<span className="text-xs text-content-secondary">%</span>
+											<Tooltip>
+												<TooltipTrigger asChild>
+													<Button
+														size="icon"
+														variant="subtle"
+														className={`size-7 ${
+															hasOverride
+																? "opacity-100"
+																: "pointer-events-none opacity-0"
+														}`}
+														aria-label={`Reset ${modelName} to default`}
+														aria-hidden={!hasOverride}
+														tabIndex={hasOverride ? 0 : -1}
+														disabled={isThisModelMutating || !hasOverride}
+														onClick={() => handleReset(modelConfig.id)}
+													>
+														<RotateCcwIcon className="size-3.5" />
+													</Button>
+												</TooltipTrigger>
+												{hasOverride && (
+													<TooltipContent>
+														Reset to default (
+														{modelConfig.compression_threshold}%)
+													</TooltipContent>
+												)}
+											</Tooltip>
+										</div>
+									</TableCell>
+								</TableRow>
+							);
+						})}
+					</TableBody>
 					{(dirtyRows.length > 0 || hasAnyErrors) && (
-						<div className="flex items-center justify-end gap-2 border-0 border-t border-solid border-border bg-surface-secondary px-3 py-1.5">
-							<Button
-								size="sm"
-								variant="outline"
-								type="button"
-								onClick={handleCancelAll}
-								disabled={hasAnyPending}
-							>
-								Cancel
-							</Button>
-							<Button
-								size="sm"
-								type="button"
-								disabled={dirtyRows.length === 0 || hasAnyPending}
-								onClick={handleSaveAll}
-							>
-								{hasAnyPending
-									? "Saving..."
-									: `Save ${dirtyRows.length} ${dirtyRows.length === 1 ? "change" : "changes"}`}
-							</Button>
-						</div>
+						<tfoot>
+							<tr>
+								<td colSpan={3} className="p-0">
+									<div className="flex items-center justify-end gap-2 px-3 py-1.5">
+										<Button
+											size="xs"
+											variant="outline"
+											type="button"
+											onClick={handleCancelAll}
+											disabled={hasAnyPending}
+										>
+											Cancel
+										</Button>
+										<Button
+											size="xs"
+											type="button"
+											disabled={dirtyRows.length === 0 || hasAnyPending}
+											onClick={handleSaveAll}
+										>
+											{hasAnyPending
+												? "Saving..."
+												: `Save ${dirtyRows.length} ${dirtyRows.length === 1 ? "change" : "changes"}`}
+										</Button>
+									</div>
+								</td>
+							</tr>
+						</tfoot>
 					)}
-				</div>
+				</Table>
 			)}
 		</div>
 	);

--- a/site/src/pages/AgentsPage/components/UserCompactionThresholdSettings.tsx
+++ b/site/src/pages/AgentsPage/components/UserCompactionThresholdSettings.tsx
@@ -353,7 +353,7 @@ export const UserCompactionThresholdSettings: FC<
 								<td colSpan={3} className="p-0">
 									<div className="flex items-center justify-end gap-2 px-3 py-1.5">
 										<Button
-											size="xs"
+											size="sm"
 											variant="outline"
 											type="button"
 											onClick={handleCancelAll}
@@ -362,7 +362,7 @@ export const UserCompactionThresholdSettings: FC<
 											Cancel
 										</Button>
 										<Button
-											size="xs"
+											size="sm"
 											type="button"
 											disabled={dirtyRows.length === 0 || hasAnyPending}
 											onClick={handleSaveAll}

--- a/site/src/pages/AgentsPage/components/UserCompactionThresholdSettings.tsx
+++ b/site/src/pages/AgentsPage/components/UserCompactionThresholdSettings.tsx
@@ -19,6 +19,7 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
+import { cn } from "#/utils/cn";
 
 interface UserCompactionThresholdSettingsProps {
 	modelConfigs: readonly TypesGen.ChatModelConfig[];
@@ -94,12 +95,12 @@ export const UserCompactionThresholdSettings: FC<
 	};
 
 	const addPending = (id: string) => {
-		setPendingModels((s) => new Set(s).add(id));
+		setPendingModels((pending) => new Set(pending).add(id));
 	};
 
 	const removePending = (id: string) => {
-		setPendingModels((s) => {
-			const next = new Set(s);
+		setPendingModels((pending) => {
+			const next = new Set(pending);
 			next.delete(id);
 			return next;
 		});
@@ -141,10 +142,10 @@ export const UserCompactionThresholdSettings: FC<
 	}
 
 	const handleSaveAll = () => {
-		for (const { modelConfigId, value } of dirtyRows) {
+		const saves = dirtyRows.map(({ modelConfigId, value }) => {
 			clearRowError(modelConfigId);
 			addPending(modelConfigId);
-			onSaveThreshold(modelConfigId, value)
+			return onSaveThreshold(modelConfigId, value)
 				.then(() => {
 					clearDraft(modelConfigId);
 					clearRowError(modelConfigId);
@@ -161,7 +162,8 @@ export const UserCompactionThresholdSettings: FC<
 				.finally(() => {
 					removePending(modelConfigId);
 				});
-		}
+		});
+		void Promise.allSettled(saves);
 	};
 
 	const handleCancelAll = () => {
@@ -171,6 +173,7 @@ export const UserCompactionThresholdSettings: FC<
 
 	const hasAnyPending = pendingModels.size > 0;
 	const hasAnyErrors = Object.keys(rowErrors).length > 0;
+	const hasAnyDrafts = Object.keys(drafts).length > 0;
 
 	if (isThresholdsLoading) {
 		return (
@@ -258,7 +261,9 @@ export const UserCompactionThresholdSettings: FC<
 							const isThisModelMutating = pendingModels.has(modelConfig.id);
 							const isInvalid =
 								draftValue.length > 0 && parsedDraftValue === null;
-							const isWarning100 =
+							// Only warn when user-typed, not when loaded from
+							// the server.
+							const isDraftDisablingCompaction =
 								draftValue === "100" && drafts[modelConfig.id] !== undefined;
 							const rowError = rowErrors[modelConfig.id];
 							const modelName = modelConfig.display_name || modelConfig.model;
@@ -290,11 +295,11 @@ export const UserCompactionThresholdSettings: FC<
 														min={0}
 														max={100}
 														inputMode="numeric"
-														className={`h-7 w-16 px-2 text-xs tabular-nums ${
-															isInvalid
-																? "border-content-destructive focus:ring-content-destructive/30"
-																: ""
-														}`}
+														className={cn(
+															"h-7 w-16 px-2 text-xs tabular-nums",
+															isInvalid &&
+																"border-content-destructive focus:ring-content-destructive/30",
+														)}
 														value={draftValue}
 														placeholder={String(
 															modelConfig.compression_threshold,
@@ -309,7 +314,7 @@ export const UserCompactionThresholdSettings: FC<
 														disabled={isThisModelMutating}
 													/>
 												</TooltipTrigger>
-												{(isInvalid || isWarning100) && (
+												{(isInvalid || isDraftDisablingCompaction) && (
 													<TooltipContent>
 														{isInvalid
 															? "Enter a whole number between 0 and 100."
@@ -323,11 +328,12 @@ export const UserCompactionThresholdSettings: FC<
 													<Button
 														size="icon"
 														variant="subtle"
-														className={`size-7 ${
+														className={cn(
+															"size-7",
 															hasOverride
 																? "opacity-100"
-																: "pointer-events-none opacity-0"
-														}`}
+																: "pointer-events-none opacity-0",
+														)}
 														aria-label={`Reset ${modelName} to default`}
 														aria-hidden={!hasOverride}
 														tabIndex={hasOverride ? 0 : -1}
@@ -350,12 +356,18 @@ export const UserCompactionThresholdSettings: FC<
 												Enter a whole number between 0 and 100.
 											</span>
 										)}
+										{isDraftDisablingCompaction && (
+											<span className="sr-only" aria-live="polite">
+												Setting 100% will disable auto-compaction for this
+												model.
+											</span>
+										)}
 									</TableCell>
 								</TableRow>
 							);
 						})}
 					</TableBody>
-					{(dirtyRows.length > 0 || hasAnyErrors) && (
+					{(dirtyRows.length > 0 || hasAnyErrors || hasAnyDrafts) && (
 						<TableFooter className="bg-transparent">
 							<TableRow className="border-0">
 								<TableCell colSpan={3} className="border-0 p-0">


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

Replaces the bloated per-row Save/Reset button pattern in Context Compaction settings with a compact table layout and single batch-save footer.

## What changed

- **Table layout** — three columns (Model, Default, Threshold) instead of flex rows with inline buttons
- **Single save footer** — appears when any row is dirty, shows `Save N change(s)`. Fires all pending saves in parallel. Disappears after success.
- **Reset as icon button** — `RotateCcwIcon` always occupies space (`opacity-0` when no override), eliminating the layout shift caused by conditional `{hasOverride && <Button>Reset</Button>}`
- **Validation in tooltips** — invalid input gets a red border ring; error text and the 100% warning are shown in tooltips instead of extra `<p>` lines below each row
- **Cancel button** — clears all drafts and errors in one click

## Accessibility

- Reset icon: `aria-label="Reset {model} to default"`, tooltip shows the default value
- When no override exists: `aria-hidden={true}`, `tabIndex={-1}` (removed from tab order and screen reader tree)
- Row errors: `aria-live="polite"` preserved
- Input `aria-label` preserved from original

<details>
<summary>Design rationale</summary>

### Problems
1. N save buttons (one per model) — visual clutter
2. Conditional Reset button — layout shift on save
3. Validation `<p>` elements below rows — vertical layout instability

### Solution
- Batch save eliminates N-1 buttons while keeping per-row reset precision via the icon
- Always-allocated icon space (`opacity-0`/`opacity-100`) prevents reflow
- Tooltip-based validation keeps rows at constant height
- No backend changes — same `onSaveThreshold`/`onResetThreshold` API
</details>