### PR TITLE
refactor(site/src/pages/AgentsPage): replace ScrollAnchoredContainer with useStickToBottom

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -914,8 +914,6 @@ export const ScrollNotJumpedDuringWheel: Story = {
 		scrollContainer.scrollTop = targetScrollTop;
 		scrollContainer.dispatchEvent(new Event("scroll"));
 
-		// Record the scroll position before new content arrives.
-		const scrollTopBeforeAppend = scrollContainer.scrollTop;
 		const scrollHeightBeforeAppend = scrollContainer.scrollHeight;
 
 		// Simulate new assistant content arriving while the wheel guard is
@@ -932,16 +930,9 @@ export const ScrollNotJumpedDuringWheel: Story = {
 			);
 		});
 
-		// During active wheel scrolling, the deferred pin should stay
-		// suppressed until the debounce expires.
-		expect(scrollContainer.scrollTop).toBeLessThanOrEqual(
-			scrollTopBeforeAppend + 1,
-		);
-
-		// Wait for the wheel debounce to clear (150ms) plus a
-		// buffer, then verify the missed bottom pin is applied.
-		await new Promise<void>((resolve) => setTimeout(resolve, 200));
-
+		// The new scroll implementation follows content growth
+		// immediately when near the bottom, regardless of active
+		// wheel state. Verify we tracked the new content.
 		await waitFor(() => {
 			const dist =
 				scrollContainer.scrollHeight -

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -930,18 +930,19 @@ export const ScrollNotJumpedDuringWheel: Story = {
 			);
 		});
 
-		// The new scroll implementation follows content growth
-		// immediately when near the bottom, regardless of active
-		// wheel state. Verify we tracked the new content.
+		// After wheeling up, the user has expressed intent to
+		// disengage auto-follow. Content growth should NOT yank
+		// them back to the bottom — they keep their position.
 		await waitFor(() => {
 			const dist =
 				scrollContainer.scrollHeight -
 				scrollContainer.scrollTop -
 				scrollContainer.clientHeight;
-			expect(dist).toBeLessThan(5);
-			expect(
-				canvas.queryByRole("button", { name: "Scroll to bottom" }),
-			).toBeNull();
+			// The user should NOT have been yanked to the absolute
+			// bottom. They may still be within the "near bottom"
+			// visual threshold, but scrollTop must not have been
+			// forced to maxScrollTop.
+			expect(dist).toBeGreaterThan(5);
 		});
 	},
 };

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -978,14 +978,14 @@ export const ScrollRepinnedAfterWheelDeferredAppend: Story = {
 			requestAnimationFrame(() => resolve()),
 		);
 
-		// Start a wheel burst to activate the wheel guard.
+		// Simulate a wheel event (no debounce guard in the new code).
 		scrollContainer.dispatchEvent(
 			new WheelEvent("wheel", { bubbles: true, deltaY: 3 }),
 		);
 
-		// Append content while the wheel guard is active. This
-		// defers the ResizeObserver pin (pendingWheelPinRef = true)
-		// and creates the gap that previously triggered the bug.
+		// Append content while a wheel event is active. The new
+		// implementation pins immediately via ResizeObserver rather
+		// than deferring through a wheel guard.
 		const existing = getStoreMessages(wheelDeferredStore);
 		wheelDeferredStore.replaceMessages(
 			existing.concat([
@@ -994,15 +994,15 @@ export const ScrollRepinnedAfterWheelDeferredAppend: Story = {
 			]),
 		);
 
-		// Fire a second wheel tick. In the old code, this wheel
-		// event called handleUserInterrupt() which saw the gap
-		// and falsely disabled auto-follow.
+		// Fire a second wheel tick. The new code processes this
+		// as a downward wheel event and does not disengage
+		// follow mode.
 		scrollContainer.dispatchEvent(
 			new WheelEvent("wheel", { bubbles: true, deltaY: 3 }),
 		);
 
-		// Wait for the 150ms wheel debounce to expire, plus the
-		// catch-up scrollTranscriptToBottom to settle.
+		// The new code pins synchronously via ResizeObserver.
+		// Verify the scroll position settled at the bottom.
 		await waitFor(
 			() => {
 				const dist =

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -294,6 +294,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 						/>
 					</div>
 					<ChatScrollContainer
+						key={agentId}
 						scrollContainerRef={scrollContainerRef}
 						scrollToBottomRef={effectiveScrollToBottomRef}
 						isFetchingMoreMessages={isFetchingMoreMessages}

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -1,17 +1,9 @@
-import { ArchiveIcon, ArrowDownIcon } from "lucide-react";
-import {
-	type FC,
-	type RefObject,
-	useEffect,
-	useLayoutEffect,
-	useRef,
-	useState,
-} from "react";
+import { ArchiveIcon } from "lucide-react";
+import { type FC, type RefObject, useRef, useState } from "react";
 import type { UrlTransform } from "streamdown";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { ChatDiffStatus, ChatMessagePart } from "#/api/typesGenerated";
-import { Button } from "#/components/Button/Button";
-import { useEffectEvent } from "#/hooks/hookPolyfills";
+
 import { cn } from "#/utils/cn";
 import { pageTitle } from "#/utils/page";
 import {
@@ -26,11 +18,11 @@ import type { useChatStore } from "./components/ChatConversation/chatStore";
 import type { ModelSelectorOption } from "./components/ChatElements";
 import { DesktopPanelContext } from "./components/ChatElements/tools/DesktopPanelContext";
 import { ChatPageInput, ChatPageTimeline } from "./components/ChatPageContent";
+import { ChatScrollContainer } from "./components/ChatScrollContainer";
 import { ChatTopBar } from "./components/ChatTopBar";
 import { GitPanel } from "./components/GitPanel/GitPanel";
 import { RightPanel } from "./components/RightPanel/RightPanel";
 import { SidebarTabView } from "./components/Sidebar/SidebarTabView";
-import { useStickToBottom } from "./components/StickToBottom";
 import type { ChatDetailError } from "./utils/usageLimitMessage";
 
 type ChatStoreHandle = ReturnType<typeof useChatStore>["store"];
@@ -534,182 +526,6 @@ export const AgentChatPageNotFoundView: FC<AgentChatPageNotFoundViewProps> = ({
 			/>
 			<div className="flex flex-1 items-center justify-center text-content-secondary">
 				Chat not found
-			</div>
-		</div>
-	);
-};
-
-/**
- * Scroll container that keeps the transcript pinned to the bottom using
- * spring-physics animation. Handles:
- * - Stick-to-bottom with automatic re-engagement when content grows.
- * - Loading older message pages via an IntersectionObserver sentinel.
- * - Scroll position restoration when older messages are prepended.
- * - A floating "Scroll to bottom" button when the user scrolls away.
- */
-const ChatScrollContainer: FC<{
-	scrollContainerRef: RefObject<HTMLDivElement | null>;
-	scrollToBottomRef: RefObject<(() => void) | null>;
-	isFetchingMoreMessages: boolean;
-	hasMoreMessages: boolean;
-	onFetchMoreMessages: () => void;
-	children: React.ReactNode;
-}> = ({
-	scrollContainerRef,
-	scrollToBottomRef,
-	isFetchingMoreMessages,
-	hasMoreMessages,
-	onFetchMoreMessages,
-	children,
-}) => {
-	const { scrollRef, contentRef, scrollToBottom, isAtBottom } =
-		useStickToBottom();
-
-	// Merge our callback ref with the external RefObject so both
-	// point at the same DOM node, and expose scrollToBottom to the
-	// parent via its imperative ref.
-	const mergedScrollRef = useEffectEvent((el: HTMLDivElement | null) => {
-		scrollRef(el);
-		scrollContainerRef.current = el;
-		scrollToBottomRef.current = el ? () => scrollToBottom("instant") : null;
-	});
-
-	// -------------------------------------------------------------------
-	// Pagination sentinel (IntersectionObserver)
-	// -------------------------------------------------------------------
-
-	const sentinelRef = useRef<HTMLDivElement>(null);
-	const observerRef = useRef<IntersectionObserver | null>(null);
-	const isFetchingRef = useRef(isFetchingMoreMessages);
-	const hasFetchedRef = useRef(false);
-
-	useLayoutEffect(() => {
-		isFetchingRef.current = isFetchingMoreMessages;
-		if (isFetchingMoreMessages) {
-			hasFetchedRef.current = true;
-		}
-	}, [isFetchingMoreMessages]);
-
-	// Snapshot captured before a fetch so we can restore scroll
-	// position after older messages are prepended.
-	const pendingPrependRef = useRef<{
-		scrollHeight: number;
-	} | null>(null);
-
-	useEffect(() => {
-		const sentinel = sentinelRef.current;
-		const container = scrollContainerRef.current;
-		if (!sentinel || !container) return;
-
-		const observer = new IntersectionObserver(
-			([entry]) => {
-				if (entry.isIntersecting && !isFetchingRef.current) {
-					const container = scrollContainerRef.current;
-					if (container) {
-						pendingPrependRef.current = {
-							scrollHeight: container.scrollHeight,
-						};
-					}
-					onFetchMoreMessages();
-				}
-			},
-			{
-				root: container,
-				rootMargin: "600px 0px 0px 0px",
-				threshold: 0.01,
-			},
-		);
-		observerRef.current = observer;
-
-		// Defer observation via double-rAF so the initial bottom
-		// pin settles before the sentinel can trigger.
-		let deferInnerId: number | null = null;
-		const deferOuterId = requestAnimationFrame(() => {
-			deferInnerId = requestAnimationFrame(() => {
-				observer.observe(sentinel);
-			});
-		});
-		return () => {
-			cancelAnimationFrame(deferOuterId);
-			if (deferInnerId !== null) {
-				cancelAnimationFrame(deferInnerId);
-			}
-			observer.disconnect();
-			observerRef.current = null;
-		};
-	}, [scrollContainerRef, onFetchMoreMessages]);
-
-	// Re-observe the sentinel after a fetch completes so the
-	// IntersectionObserver fires again if it stayed visible.
-	useEffect(() => {
-		if (isFetchingMoreMessages) return;
-		if (!hasFetchedRef.current) return;
-
-		const sentinel = sentinelRef.current;
-		const observer = observerRef.current;
-		if (sentinel && observer) {
-			observer.unobserve(sentinel);
-			observer.observe(sentinel);
-		}
-	}, [isFetchingMoreMessages]);
-
-	// -------------------------------------------------------------------
-	// Prepend scroll restoration
-	// -------------------------------------------------------------------
-
-	// When older messages are prepended the browser keeps scrollTop
-	// constant while scrollHeight grows, shifting the viewport down.
-	// Compensate by adding the height delta to scrollTop.
-	useLayoutEffect(() => {
-		if (isFetchingMoreMessages) return;
-		const pending = pendingPrependRef.current;
-		const container = scrollContainerRef.current;
-		if (!pending || !container) return;
-
-		const delta = container.scrollHeight - pending.scrollHeight;
-		if (delta > 0) {
-			container.scrollTop += delta;
-		}
-		pendingPrependRef.current = null;
-	}, [isFetchingMoreMessages, scrollContainerRef]);
-
-	// -------------------------------------------------------------------
-	// Render
-	// -------------------------------------------------------------------
-
-	const showButton = !isAtBottom;
-
-	return (
-		<div className="relative flex min-h-0 flex-1 flex-col">
-			<div
-				ref={mergedScrollRef}
-				data-testid="scroll-container"
-				className="flex min-h-0 flex-1 flex-col overflow-y-auto [overflow-anchor:none] [overscroll-behavior:contain] [scrollbar-gutter:stable] [scrollbar-width:thin] [scrollbar-color:hsl(var(--surface-quaternary))_transparent]"
-			>
-				<div ref={contentRef}>
-					{hasMoreMessages && (
-						<div ref={sentinelRef} className="h-px shrink-0" />
-					)}
-					{children}
-				</div>
-			</div>
-			<div className="pointer-events-none absolute inset-x-0 bottom-2 z-10 flex justify-center overflow-y-auto py-2 [scrollbar-gutter:stable] [scrollbar-width:thin]">
-				<Button
-					variant="outline"
-					size="icon"
-					className={cn(
-						"rounded-full bg-surface-primary shadow-md transition-all duration-200",
-						showButton
-							? "pointer-events-auto translate-y-0 opacity-100"
-							: "translate-y-2 opacity-0",
-					)}
-					onClick={() => scrollToBottom()}
-					aria-label="Scroll to bottom"
-					aria-hidden={!showButton || undefined}
-					tabIndex={showButton ? undefined : -1}
-				>
-					<ArrowDownIcon />
-				</Button>
 			</div>
 		</div>
 	);

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -312,7 +312,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 								mcpServers={mcpServers}
 							/>
 						</div>
-					</ChatScrollContainer>{" "}
+					</ChatScrollContainer>
 					<div className="shrink-0 overflow-y-auto px-4 pb-4 md:pb-0 [scrollbar-gutter:stable] [scrollbar-width:thin]">
 						<ChatPageInput
 							store={store}

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -11,6 +11,7 @@ import type { UrlTransform } from "streamdown";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { ChatDiffStatus, ChatMessagePart } from "#/api/typesGenerated";
 import { Button } from "#/components/Button/Button";
+import { useEffectEvent } from "#/hooks/hookPolyfills";
 import { cn } from "#/utils/cn";
 import { pageTitle } from "#/utils/page";
 import {
@@ -29,6 +30,7 @@ import { ChatTopBar } from "./components/ChatTopBar";
 import { GitPanel } from "./components/GitPanel/GitPanel";
 import { RightPanel } from "./components/RightPanel/RightPanel";
 import { SidebarTabView } from "./components/Sidebar/SidebarTabView";
+import { useStickToBottom } from "./components/StickToBottom";
 import type { ChatDetailError } from "./utils/usageLimitMessage";
 
 type ChatStoreHandle = ReturnType<typeof useChatStore>["store"];
@@ -299,7 +301,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 							}}
 						/>
 					</div>
-					<ScrollAnchoredContainer
+					<ChatScrollContainer
 						scrollContainerRef={scrollContainerRef}
 						scrollToBottomRef={effectiveScrollToBottomRef}
 						isFetchingMoreMessages={isFetchingMoreMessages}
@@ -318,7 +320,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 								mcpServers={mcpServers}
 							/>
 						</div>
-					</ScrollAnchoredContainer>
+					</ChatScrollContainer>{" "}
 					<div className="shrink-0 overflow-y-auto px-4 pb-4 md:pb-0 [scrollbar-gutter:stable] [scrollbar-width:thin]">
 						<ChatPageInput
 							store={store}
@@ -538,72 +540,14 @@ export const AgentChatPageNotFoundView: FC<AgentChatPageNotFoundViewProps> = ({
 };
 
 /**
- * Scroll container that keeps the transcript in normal top-to-bottom
- * document flow while preserving a bottom-anchored chat experience.
- * The user is at the bottom when the remaining scroll distance to the
- * end of the container is within SCROLL_THRESHOLD.
- *
- * Handles:
+ * Scroll container that keeps the transcript pinned to the bottom using
+ * spring-physics animation. Handles:
+ * - Stick-to-bottom with automatic re-engagement when content grows.
  * - Loading older message pages via an IntersectionObserver sentinel.
- * - ResizeObserver-driven scroll anchoring for transcript and viewport
- *   size changes.
- * - A floating "Scroll to bottom" button when the user is scrolled
- *   away from the bottom.
- *
- * CSS overflow anchoring is disabled on the container, so all position
- * restoration is done manually.
+ * - Scroll position restoration when older messages are prepended.
+ * - A floating "Scroll to bottom" button when the user scrolls away.
  */
-const SCROLL_THRESHOLD = 100;
-
-function isNearBottom(container: HTMLElement): boolean {
-	return (
-		container.scrollHeight - container.scrollTop - container.clientHeight <
-		SCROLL_THRESHOLD
-	);
-}
-
-function scrollTranscriptToBottom({
-	behavior,
-	scrollContainerRef,
-	autoScrollRef,
-	isRestoringScrollRef,
-	restoreGuardRafIdRef,
-	setShowScrollToBottom,
-}: {
-	behavior: "smooth" | "instant";
-	scrollContainerRef: RefObject<HTMLDivElement | null>;
-	autoScrollRef: { current: boolean };
-	isRestoringScrollRef: { current: boolean };
-	restoreGuardRafIdRef: { current: number | null };
-	setShowScrollToBottom: (next: boolean) => void;
-}): void {
-	const container = scrollContainerRef.current;
-	if (!container) {
-		return;
-	}
-
-	// Cancel any pending guard-clear so it cannot drop the flag
-	// during a smooth scroll animation.
-	if (restoreGuardRafIdRef.current !== null) {
-		cancelAnimationFrame(restoreGuardRafIdRef.current);
-		restoreGuardRafIdRef.current = null;
-	}
-	autoScrollRef.current = true;
-	isRestoringScrollRef.current = true;
-	const top = Math.max(container.scrollHeight - container.clientHeight, 0);
-	if (behavior === "smooth") {
-		container.scrollTo({ top, behavior: "smooth" });
-	} else {
-		container.scrollTop = top;
-		// Instant scrollTop assignment may not fire a scroll event when the
-		// container is already at the target position, so clear the restoring
-		// guard immediately to avoid blocking subsequent scroll handling.
-		isRestoringScrollRef.current = false;
-	}
-	setShowScrollToBottom(false);
-}
-
-const ScrollAnchoredContainer: FC<{
+const ChatScrollContainer: FC<{
 	scrollContainerRef: RefObject<HTMLDivElement | null>;
 	scrollToBottomRef: RefObject<(() => void) | null>;
 	isFetchingMoreMessages: boolean;
@@ -618,80 +562,40 @@ const ScrollAnchoredContainer: FC<{
 	onFetchMoreMessages,
 	children,
 }) => {
+	const { scrollRef, contentRef, scrollToBottom, isAtBottom } =
+		useStickToBottom();
+
+	// Merge our callback ref with the external RefObject so both
+	// point at the same DOM node, and expose scrollToBottom to the
+	// parent via its imperative ref.
+	const mergedScrollRef = useEffectEvent((el: HTMLDivElement | null) => {
+		scrollRef(el);
+		scrollContainerRef.current = el;
+		scrollToBottomRef.current = el ? () => scrollToBottom("instant") : null;
+	});
+
+	// -------------------------------------------------------------------
+	// Pagination sentinel (IntersectionObserver)
+	// -------------------------------------------------------------------
+
 	const sentinelRef = useRef<HTMLDivElement>(null);
 	const observerRef = useRef<IntersectionObserver | null>(null);
 	const isFetchingRef = useRef(isFetchingMoreMessages);
 	const hasFetchedRef = useRef(false);
-	const autoScrollRef = useRef(true);
-	const contentRef = useRef<HTMLDivElement>(null);
-	const pendingPrependRef = useRef<{
-		contentHeight: number;
-		scrollHeight: number;
-		contentWidth: number;
-	} | null>(null);
-	// Guard flag: true while a programmatic scroll adjustment is in-flight.
-	// The scroll handler skips autoScrollRef updates and re-render triggers
-	// when this is set, preventing user-visible jitter. Cleared when the
-	// scroll reaches its destination or the user actively interrupts.
-	const isRestoringScrollRef = useRef(false);
-	// Shared guard-clear RAF ID across both the content and container
-	// ResizeObservers. Both observers set isRestoringScrollRef before
-	// pinning and schedule a one-frame-delayed clear. Without a shared
-	// ID, one observer's clear can fire while the other's pin chain is
-	// still in-flight, leaving a window where the scroll handler reads
-	// stale position data and disables auto-scroll.
-	const restoreGuardRafIdRef = useRef<number | null>(null);
-	const cancelPendingPinsRef = useRef<(() => void) | null>(null);
-	// Guard counter: positive while one or more touch contacts are active.
-	// Prevents ResizeObserver callbacks from snapping scroll to bottom
-	// during mobile URL bar show/hide, which triggers container resize
-	// events while the user's finger is still on the screen.
-	const activeTouchCountRef = useRef(0);
-	// Guard flag: true while the user is actively scrolling via
-	// mouse wheel or trackpad. Set on each wheel event and cleared
-	// after a short debounce period. Prevents ResizeObserver
-	// callbacks from snapping scroll to bottom during active
-	// wheel/trackpad scrolling within the near-bottom threshold.
-	const isWheelScrollingRef = useRef(false);
-	// Track whether a resize would have pinned to bottom while the
-	// wheel guard was active. When scrolling stops, run one catch-up
-	// pin so auto-follow resumes without waiting for another resize.
-	const pendingWheelPinRef = useRef(false);
-	// Snapshot of autoScrollRef at the start of the current wheel
-	// burst. Used by the debounce timeout to decide whether to repin
-	// after deferred content growth.
-	const wheelSessionAutoScrollRef = useRef(false);
-	// scrollTop at the start of the current wheel burst. Compared
-	// against the final scrollTop to detect intentional upward scrolls.
-	const wheelSessionStartTopRef = useRef(0);
+
 	useLayoutEffect(() => {
 		isFetchingRef.current = isFetchingMoreMessages;
 		if (isFetchingMoreMessages) {
 			hasFetchedRef.current = true;
 		}
 	}, [isFetchingMoreMessages]);
-	const [showScrollToBottom, setShowScrollToBottom] = useState(false);
 
-	useEffect(() => {
-		scrollToBottomRef.current = () => {
-			scrollTranscriptToBottom({
-				behavior: "instant",
-				scrollContainerRef,
-				autoScrollRef,
-				isRestoringScrollRef,
-				restoreGuardRafIdRef,
-				setShowScrollToBottom,
-			});
-		};
-		return () => {
-			scrollToBottomRef.current = null;
-		};
-	}, [scrollContainerRef, scrollToBottomRef]);
+	// Snapshot captured before a fetch so we can restore scroll
+	// position after older messages are prepended.
+	const pendingPrependRef = useRef<{
+		scrollHeight: number;
+	} | null>(null);
 
-	// Sentinel observer, triggers loading older messages.
-	// All changing values are read from refs so the observer
-	// is created once and never torn down / recreated, which
-	// would cause spurious intersection callbacks.
 	useEffect(() => {
 		const sentinel = sentinelRef.current;
 		const container = scrollContainerRef.current;
@@ -701,15 +605,9 @@ const ScrollAnchoredContainer: FC<{
 			([entry]) => {
 				if (entry.isIntersecting && !isFetchingRef.current) {
 					const container = scrollContainerRef.current;
-					const content = contentRef.current;
-					if (container && content) {
-						const contentRect = content.getBoundingClientRect();
-						// Capture the current viewport snapshot before the fetch so
-						// prepended content can be restored after layout updates.
+					if (container) {
 						pendingPrependRef.current = {
-							contentHeight: contentRect.height,
 							scrollHeight: container.scrollHeight,
-							contentWidth: contentRect.width,
 						};
 					}
 					onFetchMoreMessages();
@@ -722,10 +620,9 @@ const ScrollAnchoredContainer: FC<{
 			},
 		);
 		observerRef.current = observer;
-		// Defer sentinel observation until after the initial bottom
-		// pin settles. In normal flex-col flow, scrollTop starts at 0,
-		// which places the sentinel in the viewport and would trigger
-		// an eager history fetch before the transcript pins to bottom.
+
+		// Defer observation via double-rAF so the initial bottom
+		// pin settles before the sentinel can trigger.
 		let deferInnerId: number | null = null;
 		const deferOuterId = requestAnimationFrame(() => {
 			deferInnerId = requestAnimationFrame(() => {
@@ -742,522 +639,50 @@ const ScrollAnchoredContainer: FC<{
 		};
 	}, [scrollContainerRef, onFetchMoreMessages]);
 
-	// When a fetch completes, re-observe the sentinel to force
-	// the IntersectionObserver to re-evaluate. The observer only
-	// fires on state *changes* (entering/leaving), so if the
-	// sentinel stayed visible throughout the fetch it won't fire
-	// again on its own.
+	// Re-observe the sentinel after a fetch completes so the
+	// IntersectionObserver fires again if it stayed visible.
 	useEffect(() => {
 		if (isFetchingMoreMessages) return;
-		// Skip re-observation on initial mount. The sentinel setup
-		// effect defers observation via double-RAF to avoid an eager
-		// fetch before the initial bottom pin settles. This effect
-		// would bypass that defer since isFetchingMoreMessages starts
-		// as false.
 		if (!hasFetchedRef.current) return;
-		const pendingPrepend = pendingPrependRef.current;
-		const cleanupId = requestAnimationFrame(() => {
-			const container = scrollContainerRef.current;
-			if (
-				!pendingPrepend ||
-				pendingPrependRef.current !== pendingPrepend ||
-				!container
-			) {
-				return;
-			}
-			// If the fetch did not change the container scroll height, the
-			// ResizeObserver never runs to clear the pending prepend snapshot.
-			// Clear it after layout settles so later resizes do not apply stale
-			// scroll compensation.
-			if (Math.abs(container.scrollHeight - pendingPrepend.scrollHeight) < 1) {
-				pendingPrependRef.current = null;
-			}
-		});
+
 		const sentinel = sentinelRef.current;
 		const observer = observerRef.current;
 		if (sentinel && observer) {
 			observer.unobserve(sentinel);
 			observer.observe(sentinel);
 		}
-		return () => {
-			cancelAnimationFrame(cleanupId);
-		};
+	}, [isFetchingMoreMessages]);
+
+	// -------------------------------------------------------------------
+	// Prepend scroll restoration
+	// -------------------------------------------------------------------
+
+	// When older messages are prepended the browser keeps scrollTop
+	// constant while scrollHeight grows, shifting the viewport down.
+	// Compensate by adding the height delta to scrollTop.
+	useLayoutEffect(() => {
+		if (isFetchingMoreMessages) return;
+		const pending = pendingPrependRef.current;
+		const container = scrollContainerRef.current;
+		if (!pending || !container) return;
+
+		const delta = container.scrollHeight - pending.scrollHeight;
+		if (delta > 0) {
+			container.scrollTop += delta;
+		}
+		pendingPrependRef.current = null;
 	}, [isFetchingMoreMessages, scrollContainerRef]);
 
-	useEffect(() => {
-		const container = scrollContainerRef.current;
-		const content = contentRef.current;
-		if (!container || !content) return;
+	// -------------------------------------------------------------------
+	// Render
+	// -------------------------------------------------------------------
 
-		const initialContentRect = content.getBoundingClientRect();
-		let prevContentHeight = initialContentRect.height;
-		let prevContentWidth = initialContentRect.width;
-		let pinOuterRafId: number | null = null;
-		let pinInnerRafId: number | null = null;
-
-		const cancelPendingPins = () => {
-			if (pinOuterRafId !== null) {
-				cancelAnimationFrame(pinOuterRafId);
-			}
-			if (pinInnerRafId !== null) {
-				cancelAnimationFrame(pinInnerRafId);
-			}
-			pinOuterRafId = null;
-			pinInnerRafId = null;
-		};
-
-		const scheduleBottomPin = () => {
-			// If a pin is already in-flight, let it complete. The
-			// inner RAF reads scrollHeight at execution time so it
-			// always targets the latest bottom. Cancelling and
-			// rescheduling on every ResizeObserver notification
-			// starves the pin on Safari, where sticky-element
-			// repositioning generates extra resize events that
-			// perpetually restart the double-RAF chain.
-			if (pinOuterRafId !== null || pinInnerRafId !== null) {
-				return;
-			}
-			// Cancel any pending guard-clear from a previous pin
-			// chain (or the container resize observer). Without
-			// this, the stale guard-clear fires during the new
-			// chain's double-RAF window, setting
-			// isRestoringScrollRef to false. A scroll event in
-			// that gap reads the wrong position and disables
-			// auto-scroll, causing the pin to be skipped.
-			if (restoreGuardRafIdRef.current !== null) {
-				cancelAnimationFrame(restoreGuardRafIdRef.current);
-				restoreGuardRafIdRef.current = null;
-			}
-			pendingWheelPinRef.current = false;
-			isRestoringScrollRef.current = true;
-			// Double-RAF lets React's commit phase and the browser's
-			// layout pass both complete before we pin to bottom.
-			pinOuterRafId = requestAnimationFrame(() => {
-				pinOuterRafId = null;
-				pinInnerRafId = requestAnimationFrame(() => {
-					pinInnerRafId = null;
-					if (!autoScrollRef.current) {
-						isRestoringScrollRef.current = false;
-						return;
-					}
-					if (restoreGuardRafIdRef.current !== null) {
-						cancelAnimationFrame(restoreGuardRafIdRef.current);
-						restoreGuardRafIdRef.current = null;
-					}
-					container.scrollTop = Math.max(
-						container.scrollHeight - container.clientHeight,
-						0,
-					);
-					setShowScrollToBottom(false);
-					restoreGuardRafIdRef.current = requestAnimationFrame(() => {
-						restoreGuardRafIdRef.current = null;
-						// Content may have grown between the pin and
-						// this callback. Re-pin instead of dropping the
-						// guard if we drifted off-bottom.
-						if (!isNearBottom(container)) {
-							scheduleBottomPin();
-							return;
-						}
-						isRestoringScrollRef.current = false;
-					});
-				});
-			});
-		};
-
-		cancelPendingPinsRef.current = cancelPendingPins;
-		const observer = new ResizeObserver((entries) => {
-			const entry = entries[0];
-			const nextHeight =
-				entry?.contentRect.height ?? content.getBoundingClientRect().height;
-			const nextWidth =
-				entry?.contentRect.width ?? content.getBoundingClientRect().width;
-			const delta = nextHeight - prevContentHeight;
-			const widthChanged = Math.abs(nextWidth - prevContentWidth) > 1;
-			prevContentHeight = nextHeight;
-			prevContentWidth = nextWidth;
-
-			const pending = pendingPrependRef.current;
-			if (pending !== null && isFetchingRef.current) {
-				pending.contentHeight = nextHeight;
-				pending.scrollHeight = container.scrollHeight;
-				pending.contentWidth = nextWidth;
-				return;
-			}
-			if (Math.abs(delta) < 1) {
-				return;
-			}
-
-			// Restore the viewport after older messages are prepended.
-			if (pending !== null && !isFetchingRef.current) {
-				pendingPrependRef.current = null;
-				// Width changes indicate reflow rather than a true prepend.
-				if (!widthChanged) {
-					const scrollHeightDelta =
-						container.scrollHeight - pending.scrollHeight;
-					if (scrollHeightDelta > 0) {
-						if (restoreGuardRafIdRef.current !== null) {
-							cancelAnimationFrame(restoreGuardRafIdRef.current);
-						}
-						isRestoringScrollRef.current = true;
-						container.scrollTop = container.scrollTop + scrollHeightDelta;
-						restoreGuardRafIdRef.current = requestAnimationFrame(() => {
-							isRestoringScrollRef.current = false;
-							restoreGuardRafIdRef.current = null;
-						});
-					}
-				}
-				return;
-			}
-
-			if (autoScrollRef.current && activeTouchCountRef.current === 0) {
-				if (isWheelScrollingRef.current) {
-					pendingWheelPinRef.current = true;
-					return;
-				}
-				scheduleBottomPin();
-				return;
-			}
-
-			// Skip compensation during reflow. Width changes indicate the
-			// height delta is distributed through the transcript rather than
-			// appended at the bottom, so applying the full delta would
-			// overcompensate and jump the user.
-			if (widthChanged) {
-				return;
-			}
-
-			// In normal flow, appends grow below the viewport, so users reading
-			// history do not need scroll compensation.
-		});
-		observer.observe(content);
-
-		// In normal flex-col flow, scrollTop starts at 0 (top).
-		// Pin to bottom on initial mount so existing chats open
-		// at the most recent messages.
-		if (autoScrollRef.current) {
-			scheduleBottomPin();
-		}
-
-		return () => {
-			cancelPendingPinsRef.current = null;
-			observer.disconnect();
-			cancelPendingPins();
-			if (restoreGuardRafIdRef.current !== null) {
-				cancelAnimationFrame(restoreGuardRafIdRef.current);
-				restoreGuardRafIdRef.current = null;
-			}
-			isRestoringScrollRef.current = false;
-		};
-	}, [scrollContainerRef]);
-
-	useEffect(() => {
-		const container = scrollContainerRef.current;
-		if (!container) return;
-
-		let prevContainerHeight = container.clientHeight;
-
-		const observer = new ResizeObserver((entries) => {
-			const nextHeight =
-				entries[0]?.contentRect.height ?? container.clientHeight;
-			const delta = nextHeight - prevContainerHeight;
-			prevContainerHeight = nextHeight;
-			if (Math.abs(delta) < 1 || !autoScrollRef.current) {
-				return;
-			}
-			if (activeTouchCountRef.current > 0) {
-				return;
-			}
-			if (isWheelScrollingRef.current) {
-				pendingWheelPinRef.current = true;
-				return;
-			}
-
-			if (restoreGuardRafIdRef.current !== null) {
-				cancelAnimationFrame(restoreGuardRafIdRef.current);
-			}
-			isRestoringScrollRef.current = true;
-			container.scrollTop = Math.max(
-				container.scrollHeight - container.clientHeight,
-				0,
-			);
-			restoreGuardRafIdRef.current = requestAnimationFrame(() => {
-				restoreGuardRafIdRef.current = null;
-				if (!isNearBottom(container)) {
-					// Content grew between the pin and this frame.
-					// Re-pin directly since scheduleBottomPin is in
-					// a different effect closure.
-					container.scrollTop = Math.max(
-						container.scrollHeight - container.clientHeight,
-						0,
-					);
-					restoreGuardRafIdRef.current = requestAnimationFrame(() => {
-						restoreGuardRafIdRef.current = null;
-						isRestoringScrollRef.current = false;
-					});
-					return;
-				}
-				isRestoringScrollRef.current = false;
-			});
-		});
-		observer.observe(container);
-		return () => {
-			observer.disconnect();
-			// The shared restoreGuardRafIdRef is cancelled by the
-			// content observer's cleanup (same dependency array, React
-			// runs cleanups in declaration order). Reset the guard
-			// defensively so this effect is self-contained if the
-			// ordering ever changes.
-			isRestoringScrollRef.current = false;
-		};
-	}, [scrollContainerRef]);
-
-	// Track scroll position to show/hide the scroll-to-bottom button.
-	useEffect(() => {
-		const container = scrollContainerRef.current;
-		if (!container) return;
-
-		let rafId: number | null = null;
-		let wheelTimeoutId: ReturnType<typeof setTimeout> | null = null;
-
-		const handleScroll = () => {
-			// While a programmatic scroll is in progress (e.g. smooth
-			// scroll-to-bottom), suppress normal handling. Clear the
-			// guard once the scroll reaches the bottom so normal
-			// tracking resumes. User-input interruptions are handled
-			// separately via wheel/touchstart/pointerdown listeners.
-			if (isRestoringScrollRef.current) {
-				if (isNearBottom(container)) {
-					isRestoringScrollRef.current = false;
-					autoScrollRef.current = true;
-					setShowScrollToBottom(false);
-				}
-				return;
-			}
-
-			const nearBottom = isNearBottom(container);
-			// Only ENABLE follow mode from the scroll handler.
-			// Never disable it here. WebKit internally adjusts
-			// scrollTop during layout when content above the
-			// viewport changes height (a form of scroll anchoring
-			// it applies even with overflow-anchor:none). These
-			// browser-initiated adjustments fire scroll events
-			// that see isNearBottom=false and would permanently
-			// kill follow mode. Disabling follow is exclusive to
-			// user-interaction handlers (wheel, touch, scrollbar
-			// pointer) which call handleUserInterrupt directly.
-			if (nearBottom) {
-				autoScrollRef.current = true;
-			} else if (
-				autoScrollRef.current &&
-				!isWheelScrollingRef.current &&
-				activeTouchCountRef.current === 0
-			) {
-				// Follow mode is on but we are not at bottom, and
-				// the user is not actively scrolling. This indicates
-				// WebKit adjusted scrollTop during layout (a form of
-				// scroll anchoring it applies even with
-				// overflow-anchor:none). Re-pin immediately and keep
-				// the restore guard up so the next scroll event from
-				// this pin is suppressed.
-				isRestoringScrollRef.current = true;
-				container.scrollTop = Math.max(
-					container.scrollHeight - container.clientHeight,
-					0,
-				);
-				if (restoreGuardRafIdRef.current !== null) {
-					cancelAnimationFrame(restoreGuardRafIdRef.current);
-				}
-				restoreGuardRafIdRef.current = requestAnimationFrame(() => {
-					restoreGuardRafIdRef.current = null;
-					isRestoringScrollRef.current = false;
-				});
-				return;
-			}
-
-			// Throttle the button visibility state update to once per
-			// frame. This is the only part that triggers a re-render.
-			if (rafId !== null) return;
-			rafId = requestAnimationFrame(() => {
-				setShowScrollToBottom((prev) => {
-					const shouldShow = !isNearBottom(container);
-					return prev === shouldShow ? prev : shouldShow;
-				});
-				rafId = null;
-			});
-		};
-
-		const handleUserInterrupt = () => {
-			// Always clear the restoration guard so the next scroll event is
-			// processed normally.
-			isRestoringScrollRef.current = false;
-			// Only disable auto-scroll when the user is away from the bottom.
-			// Trackpad noise or accidental wheel events at the bottom should
-			// not break streaming follow-mode.
-			if (!isNearBottom(container)) {
-				autoScrollRef.current = false;
-				pendingWheelPinRef.current = false;
-				cancelPendingPinsRef.current?.();
-			}
-		};
-
-		const getChangedTouchCount = (event: TouchEvent) => {
-			// A single touch event can add or remove multiple contacts.
-			// Count changed touches so the guard stays active until the
-			// final finger leaves the screen.
-			return Math.max(event.changedTouches.length, 1);
-		};
-
-		const handleWheel = () => {
-			if (!isWheelScrollingRef.current) {
-				// First wheel event of this burst: snapshot the current
-				// follow state and scroll position so the debounce
-				// timeout can distinguish content-driven gaps from
-				// intentional user scroll.
-				wheelSessionAutoScrollRef.current = autoScrollRef.current;
-				wheelSessionStartTopRef.current = container.scrollTop;
-			}
-			isWheelScrollingRef.current = true;
-			if (wheelTimeoutId !== null) {
-				clearTimeout(wheelTimeoutId);
-			}
-			// Clear the wheel-scrolling flag after 150ms of inactivity.
-			// This covers trackpad momentum and rapid discrete wheel
-			// ticks without permanently blocking ResizeObserver pins.
-			wheelTimeoutId = setTimeout(() => {
-				isWheelScrollingRef.current = false;
-				wheelTimeoutId = null;
-				const wasPinDeferred = pendingWheelPinRef.current;
-				pendingWheelPinRef.current = false;
-				// Repin if the wheel burst started in follow mode and
-				// content grew while the guard was active, unless the
-				// user clearly scrolled away from the near-bottom follow
-				// zone during the burst.
-				if (wasPinDeferred && wheelSessionAutoScrollRef.current) {
-					const scrolledUp =
-						container.scrollTop < wheelSessionStartTopRef.current - 1;
-					const nearBottom = isNearBottom(container);
-					if (!scrolledUp || nearBottom) {
-						scrollTranscriptToBottom({
-							behavior: "instant",
-							scrollContainerRef,
-							autoScrollRef,
-							isRestoringScrollRef,
-							restoreGuardRafIdRef,
-							setShowScrollToBottom,
-						});
-					} else {
-						autoScrollRef.current = false;
-						setShowScrollToBottom(true);
-					}
-				} else {
-					// Sync follow state with the actual scroll position
-					// now that the wheel burst is over.
-					const nearBottom = isNearBottom(container);
-					autoScrollRef.current = nearBottom;
-					setShowScrollToBottom(!nearBottom);
-				}
-			}, 150);
-			// Clear the restoration guard so user input can interrupt
-			// programmatic scrolls, but do not call handleUserInterrupt()
-			// here. The scroll handler and debounce timeout manage
-			// follow-mode transitions to avoid races with deferred
-			// content growth.
-			isRestoringScrollRef.current = false;
-			cancelPendingPinsRef.current?.();
-		};
-
-		const handleTouchStart = (event: TouchEvent) => {
-			activeTouchCountRef.current += getChangedTouchCount(event);
-			handleUserInterrupt();
-		};
-
-		const handleTouchEnd = (event: TouchEvent) => {
-			activeTouchCountRef.current = Math.max(
-				0,
-				activeTouchCountRef.current - getChangedTouchCount(event),
-			);
-			if (activeTouchCountRef.current === 0) {
-				// Re-evaluate because momentum scrolling may carry the
-				// user away from the bottom after touchstart initially
-				// saw them as near the bottom.
-				if (!isNearBottom(container)) {
-					autoScrollRef.current = false;
-					cancelPendingPinsRef.current?.();
-				}
-			}
-		};
-
-		container.addEventListener("scroll", handleScroll, { passive: true });
-		container.addEventListener("wheel", handleWheel, {
-			passive: true,
-		});
-		// Scrollbar-track drags don't fire wheel or touch events.
-		// Detect them via pointerdown on the container element
-		// itself (content clicks target child elements, scrollbar
-		// clicks target the scroller). This is the only non-wheel,
-		// non-touch user interaction that scrolls.
-		const handlePointerDown = (event: PointerEvent) => {
-			if (event.target === container) {
-				handleUserInterrupt();
-			}
-		};
-		container.addEventListener("pointerdown", handlePointerDown, {
-			passive: true,
-		});
-		container.addEventListener("touchstart", handleTouchStart, {
-			passive: true,
-		});
-		container.addEventListener("touchend", handleTouchEnd, {
-			passive: true,
-		});
-		// touchcancel fires when the OS interrupts a gesture (e.g.,
-		// incoming call, system gesture). Must also decrement the
-		// touch counter to avoid a stuck positive value.
-		container.addEventListener("touchcancel", handleTouchEnd, {
-			passive: true,
-		});
-		// Reset touch counter when page is hidden (e.g., tab switch).
-		// The browser may not fire touchend/touchcancel when the user
-		// switches away mid-gesture, which would leave the counter
-		// positive and permanently block ResizeObserver pins.
-		const handleVisibilityChange = () => {
-			if (document.hidden) {
-				activeTouchCountRef.current = 0;
-			}
-		};
-		document.addEventListener("visibilitychange", handleVisibilityChange);
-		return () => {
-			container.removeEventListener("scroll", handleScroll);
-			container.removeEventListener("wheel", handleWheel);
-			container.removeEventListener("pointerdown", handlePointerDown);
-			container.removeEventListener("touchstart", handleTouchStart);
-			container.removeEventListener("touchend", handleTouchEnd);
-			container.removeEventListener("touchcancel", handleTouchEnd);
-			document.removeEventListener("visibilitychange", handleVisibilityChange);
-			if (rafId !== null) {
-				cancelAnimationFrame(rafId);
-			}
-			if (wheelTimeoutId !== null) {
-				clearTimeout(wheelTimeoutId);
-			}
-		};
-	}, [scrollContainerRef]);
-
-	const handleScrollToBottom = () => {
-		scrollTranscriptToBottom({
-			behavior: "smooth",
-			scrollContainerRef,
-			autoScrollRef,
-			isRestoringScrollRef,
-			restoreGuardRafIdRef,
-			setShowScrollToBottom,
-		});
-	};
+	const showButton = !isAtBottom;
 
 	return (
 		<div className="relative flex min-h-0 flex-1 flex-col">
 			<div
-				ref={scrollContainerRef}
+				ref={mergedScrollRef}
 				data-testid="scroll-container"
 				className="flex min-h-0 flex-1 flex-col overflow-y-auto [overflow-anchor:none] [overscroll-behavior:contain] [scrollbar-gutter:stable] [scrollbar-width:thin] [scrollbar-color:hsl(var(--surface-quaternary))_transparent]"
 			>
@@ -1274,14 +699,14 @@ const ScrollAnchoredContainer: FC<{
 					size="icon"
 					className={cn(
 						"rounded-full bg-surface-primary shadow-md transition-all duration-200",
-						showScrollToBottom
+						showButton
 							? "pointer-events-auto translate-y-0 opacity-100"
 							: "translate-y-2 opacity-0",
 					)}
-					onClick={handleScrollToBottom}
+					onClick={() => scrollToBottom()}
 					aria-label="Scroll to bottom"
-					aria-hidden={!showScrollToBottom || undefined}
-					tabIndex={showScrollToBottom ? undefined : -1}
+					aria-hidden={!showButton || undefined}
+					tabIndex={showButton ? undefined : -1}
 				>
 					<ArrowDownIcon />
 				</Button>

--- a/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
+++ b/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
@@ -605,12 +605,39 @@ const ChatScrollContainer: FC<{
 	const isFetchingRef = useRef(isFetchingMoreMessages);
 	const hasFetchedRef = useRef(false);
 
+	const wasFetchingRef = useRef(false);
+
 	useLayoutEffect(() => {
+		const wasFetching = wasFetchingRef.current;
 		isFetchingRef.current = isFetchingMoreMessages;
-		if (isFetchingMoreMessages) {
+		wasFetchingRef.current = isFetchingMoreMessages;
+
+		if (!wasFetching && isFetchingMoreMessages) {
+			// false -> true: fetch just started. Capture scrollHeight
+			// so we can restore position after prepend.
 			hasFetchedRef.current = true;
+			const container = scrollContainerRef.current;
+			if (container) {
+				pendingPrependRef.current = {
+					scrollHeight: container.scrollHeight,
+				};
+			}
+		} else if (wasFetching && !isFetchingMoreMessages) {
+			// true -> false: fetch completed, new messages in DOM.
+			// Adjust scrollTop by the height delta to maintain the
+			// user's visual position.
+			const pending = pendingPrependRef.current;
+			const container = scrollContainerRef.current;
+			if (pending && container) {
+				const delta = container.scrollHeight - pending.scrollHeight;
+				if (delta > 0) {
+					suppressNextResize();
+					container.scrollTop += delta;
+				}
+			}
+			pendingPrependRef.current = null;
 		}
-	}, [isFetchingMoreMessages]);
+	}, [isFetchingMoreMessages, scrollContainerRef, suppressNextResize]);
 
 	// Snapshot captured before a fetch so we can restore scroll
 	// position after older messages are prepended.
@@ -626,12 +653,6 @@ const ChatScrollContainer: FC<{
 		const observer = new IntersectionObserver(
 			([entry]) => {
 				if (entry.isIntersecting && !isFetchingRef.current) {
-					const container = scrollContainerRef.current;
-					if (container) {
-						pendingPrependRef.current = {
-							scrollHeight: container.scrollHeight,
-						};
-					}
 					onFetchMoreMessages();
 				}
 			},
@@ -674,45 +695,6 @@ const ChatScrollContainer: FC<{
 			observer.observe(sentinel);
 		}
 	}, [isFetchingMoreMessages]);
-
-	// Keep the prepend scrollHeight snapshot current while
-	// streaming, so the restoration delta only reflects
-	// prepended content, not streaming growth during fetch.
-	useLayoutEffect(() => {
-		if (!isFetchingMoreMessages) return;
-		const pending = pendingPrependRef.current;
-		const container = scrollContainerRef.current;
-		if (pending && container) {
-			pending.scrollHeight = container.scrollHeight;
-		}
-	});
-
-	// -------------------------------------------------------------------
-	// Prepend scroll restoration
-	// -------------------------------------------------------------------
-	// When older messages are prepended the browser keeps scrollTop
-	// constant while scrollHeight grows, shifting the viewport down.
-	// Compensate by adding the height delta to scrollTop.
-	useLayoutEffect(() => {
-		if (isFetchingMoreMessages) return;
-		const pending = pendingPrependRef.current;
-		const container = scrollContainerRef.current;
-		if (!pending || !container) return;
-
-		const delta = container.scrollHeight - pending.scrollHeight;
-		// biome-ignore lint/suspicious/noConsole: temporary debug
-		console.debug("[STB] prepend-restore", {
-			delta,
-			snapshotH: pending.scrollHeight,
-			currentH: container.scrollHeight,
-			scrollTopBefore: container.scrollTop,
-		});
-		if (delta > 0) {
-			suppressNextResize();
-			container.scrollTop += delta;
-		}
-		pendingPrependRef.current = null;
-	}, [isFetchingMoreMessages, scrollContainerRef, suppressNextResize]);
 
 	// -------------------------------------------------------------------
 	// Render

--- a/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
+++ b/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
@@ -35,6 +35,7 @@ interface InternalState {
 	viewportObserver: ResizeObserver | null;
 	previousContentHeight: number | undefined;
 	mouseDown: boolean;
+	suppressNextResize: boolean;
 }
 
 /** The maximum scrollable offset for the container. */
@@ -82,6 +83,8 @@ interface StickToBottomInstance {
 	scrollToBottom: (behavior?: ScrollBehavior) => void;
 	/** True when the view is locked to the bottom or physically near it. */
 	isAtBottom: boolean;
+	/** Tell the hook to skip the next content resize auto-pin. */
+	suppressNextResize: () => void;
 }
 
 function useStickToBottom(): StickToBottomInstance {
@@ -100,6 +103,7 @@ function useStickToBottom(): StickToBottomInstance {
 		viewportObserver: null,
 		previousContentHeight: undefined,
 		mouseDown: false,
+		suppressNextResize: false,
 	});
 
 	// Sync helpers — keep mutable state and React state in lockstep.
@@ -137,6 +141,10 @@ function useStickToBottom(): StickToBottomInstance {
 		}
 	});
 
+	const suppressNextResize = useEffectEvent(() => {
+		stateRef.current.suppressNextResize = true;
+	});
+
 	// -----------------------------------------------------------------------
 	// Event handlers
 	// -----------------------------------------------------------------------
@@ -160,12 +168,25 @@ function useStickToBottom(): StickToBottomInstance {
 
 		setNearBottom(isNearBottom(s));
 
+		// Synchronous escape logic — must run before any resize
+		// handler so they see up-to-date internalIsAtBottom.
+		if (s.resizeDifference === 0) {
+			if (currentScrollTop < lastST) {
+				syncEscapedFromLock(true);
+				syncIsAtBottom(false);
+			} else if (currentScrollTop > lastST) {
+				syncEscapedFromLock(false);
+			}
+
+			if (!s.escapedFromLock && isNearBottom(s)) {
+				syncIsAtBottom(true);
+			}
+		}
+
+		// Text-selection escape deferred — getSelection() needs
+		// post-layout DOM state to reflect the current drag.
 		setTimeout(() => {
 			if (s.resizeDifference !== 0) return;
-
-			// If the user is selecting text inside the scroll
-			// container, treat it as an escape so the selection
-			// isn't fought by auto-scroll.
 			if (s.mouseDown && s.scrollElement) {
 				const sel = window.getSelection();
 				if (sel && sel.rangeCount > 0) {
@@ -178,20 +199,8 @@ function useStickToBottom(): StickToBottomInstance {
 					) {
 						syncEscapedFromLock(true);
 						syncIsAtBottom(false);
-						return;
 					}
 				}
-			}
-
-			if (currentScrollTop < lastST) {
-				syncEscapedFromLock(true);
-				syncIsAtBottom(false);
-			} else if (currentScrollTop > lastST) {
-				syncEscapedFromLock(false);
-			}
-
-			if (!s.escapedFromLock && isNearBottom(s)) {
-				syncIsAtBottom(true);
 			}
 		}, 1);
 	});
@@ -202,14 +211,16 @@ function useStickToBottom(): StickToBottomInstance {
 		// Walk up from target to find the nearest scrollable ancestor.
 		let el = e.target as HTMLElement | null;
 		while (el && el !== s.scrollElement) {
-			const style = getComputedStyle(el);
-			if (
-				style.overflow === "scroll" ||
-				style.overflow === "auto" ||
-				style.overflowY === "scroll" ||
-				style.overflowY === "auto"
-			) {
-				break;
+			if (el.scrollHeight > el.clientHeight) {
+				const style = getComputedStyle(el);
+				if (
+					style.overflow === "scroll" ||
+					style.overflow === "auto" ||
+					style.overflowY === "scroll" ||
+					style.overflowY === "auto"
+				) {
+					break;
+				}
 			}
 			el = el.parentElement;
 		}
@@ -244,7 +255,12 @@ function useStickToBottom(): StickToBottomInstance {
 
 		setNearBottom(isNearBottom(s));
 
-		if (difference >= 0) {
+		// If a prepend restoration just adjusted scrollTop, skip
+		// the auto-pin logic so the wasAtBottom heuristic doesn't
+		// undo the restoration.
+		if (s.suppressNextResize) {
+			s.suppressNextResize = false;
+		} else if (difference >= 0) {
 			if (previousHeight === undefined) {
 				// First observation — jump to bottom instantly.
 				if (s.internalIsAtBottom) {
@@ -396,6 +412,7 @@ function useStickToBottom(): StickToBottomInstance {
 		contentRef,
 		scrollToBottom,
 		isAtBottom: isAtBottom || nearBottom,
+		suppressNextResize,
 	};
 }
 
@@ -426,8 +443,13 @@ const ChatScrollContainer: FC<{
 	onFetchMoreMessages,
 	children,
 }) => {
-	const { scrollRef, contentRef, scrollToBottom, isAtBottom } =
-		useStickToBottom();
+	const {
+		scrollRef,
+		contentRef,
+		scrollToBottom,
+		isAtBottom,
+		suppressNextResize,
+	} = useStickToBottom();
 
 	// Merge our callback ref with the external RefObject so both
 	// point at the same DOM node, and expose scrollToBottom to the
@@ -532,10 +554,11 @@ const ChatScrollContainer: FC<{
 
 		const delta = container.scrollHeight - pending.scrollHeight;
 		if (delta > 0) {
+			suppressNextResize();
 			container.scrollTop += delta;
 		}
 		pendingPrependRef.current = null;
-	}, [isFetchingMoreMessages, scrollContainerRef]);
+	}, [isFetchingMoreMessages, scrollContainerRef, suppressNextResize]);
 
 	// -------------------------------------------------------------------
 	// Render

--- a/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
+++ b/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
@@ -29,6 +29,7 @@ interface InternalState {
 	programmaticScrollCount: number;
 	resizeDifference: number;
 	lastScrollTop: number;
+	lastClientHeight: number;
 	escapedFromLock: boolean;
 	internalIsAtBottom: boolean;
 	resizeObserver: ResizeObserver | null;
@@ -103,6 +104,7 @@ function useStickToBottom(): StickToBottomInstance {
 		programmaticScrollCount: 0,
 		resizeDifference: 0,
 		lastScrollTop: 0,
+		lastClientHeight: 0,
 		escapedFromLock: false,
 		internalIsAtBottom: true,
 		resizeObserver: null,
@@ -164,6 +166,15 @@ function useStickToBottom(): StickToBottomInstance {
 
 		const currentScrollTop = scrollElement.scrollTop;
 
+		// Detect viewport-size changes (e.g. Safari PWA toolbar
+		// settling, virtual keyboard, safe-area inset shifts).
+		// The browser may clamp scrollTop before the
+		// ResizeObserver fires, so this scroll event would look
+		// like an upward user scroll without this guard.
+		const currentClientHeight = scrollElement.clientHeight;
+		const viewportChanged = currentClientHeight !== s.lastClientHeight;
+		s.lastClientHeight = currentClientHeight;
+
 		// If this event was caused by a programmatic scrollTo,
 		// consume the counter and skip escape processing.
 		if (s.programmaticScrollCount > 0) {
@@ -180,7 +191,10 @@ function useStickToBottom(): StickToBottomInstance {
 
 		// Synchronous escape logic — must run before any resize
 		// handler so they see up-to-date internalIsAtBottom.
-		if (s.resizeDifference === 0) {
+		// Skip when a content resize or viewport resize is in
+		// progress — the browser may fire scroll events during
+		// layout that aren’t user-initiated.
+		if (s.resizeDifference === 0 && !viewportChanged) {
 			if (currentScrollTop < lastST) {
 				syncEscapedFromLock(true);
 				syncIsAtBottom(false);
@@ -378,6 +392,7 @@ function useStickToBottom(): StickToBottomInstance {
 		s.scrollElement = el;
 
 		if (el) {
+			s.lastClientHeight = el.clientHeight;
 			el.addEventListener("scroll", handleScroll, { passive: true });
 			el.addEventListener("wheel", handleWheel, { passive: true });
 			el.addEventListener("touchstart", handleTouchStart, {

--- a/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
+++ b/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
@@ -36,6 +36,7 @@ interface InternalState {
 	previousContentHeight: number | undefined;
 	mouseDown: boolean;
 	suppressNextResize: boolean;
+	activeTouchCount: number;
 }
 
 /** The maximum scrollable offset for the container. */
@@ -104,6 +105,7 @@ function useStickToBottom(): StickToBottomInstance {
 		previousContentHeight: undefined,
 		mouseDown: false,
 		suppressNextResize: false,
+		activeTouchCount: 0,
 	});
 
 	// Sync helpers — keep mutable state and React state in lockstep.
@@ -135,9 +137,12 @@ function useStickToBottom(): StickToBottomInstance {
 				top,
 				behavior: behavior ?? "smooth",
 			});
-			// Record the target so the scroll handler doesn't
-			// interpret the smooth-scroll frames as user scrolls.
-			s.ignoreScrollToTop = top;
+			// Don't set ignoreScrollToTop for smooth scroll.
+			// Each animation frame naturally reads as a downward
+			// scroll (currentScrollTop > lastScrollTop), which
+			// correctly clears escapedFromLock. Setting it to
+			// the target inflates lastST, making intermediate
+			// frames look like upward scrolls.
 		}
 	});
 
@@ -255,10 +260,12 @@ function useStickToBottom(): StickToBottomInstance {
 
 		setNearBottom(isNearBottom(s));
 
-		// If a prepend restoration just adjusted scrollTop, skip
-		// the auto-pin logic so the wasAtBottom heuristic doesn't
-		// undo the restoration.
-		if (s.suppressNextResize) {
+		// Skip auto-pin while touch contacts are active to
+		// prevent mobile URL bar resizes from fighting the
+		// user's finger.
+		if (s.activeTouchCount > 0) {
+			// No auto-pin during active touch.
+		} else if (s.suppressNextResize) {
 			s.suppressNextResize = false;
 		} else if (difference >= 0) {
 			if (previousHeight === undefined) {
@@ -314,11 +321,23 @@ function useStickToBottom(): StickToBottomInstance {
 	// shifts and we may no longer be at the bottom. Re-pin if locked.
 	const handleViewportResize = useEffectEvent(() => {
 		const s = stateRef.current;
-		if (!s.scrollElement || !s.internalIsAtBottom) {
+		if (!s.scrollElement || !s.internalIsAtBottom || s.activeTouchCount > 0) {
 			return;
 		}
 
 		scrollTo(s, maxScrollTop(s));
+	});
+
+	const handleTouchStart = useEffectEvent((e: TouchEvent) => {
+		stateRef.current.activeTouchCount += Math.max(e.changedTouches.length, 1);
+	});
+
+	const handleTouchEnd = useEffectEvent((e: TouchEvent) => {
+		const s = stateRef.current;
+		s.activeTouchCount = Math.max(
+			0,
+			s.activeTouchCount - Math.max(e.changedTouches.length, 1),
+		);
 	});
 
 	// -----------------------------------------------------------------------
@@ -330,6 +349,9 @@ function useStickToBottom(): StickToBottomInstance {
 		const prev = s.scrollElement;
 
 		if (prev) {
+			prev.removeEventListener("touchstart", handleTouchStart);
+			prev.removeEventListener("touchend", handleTouchEnd);
+			prev.removeEventListener("touchcancel", handleTouchEnd);
 			prev.removeEventListener("scroll", handleScroll);
 			prev.removeEventListener("wheel", handleWheel);
 		}
@@ -344,6 +366,15 @@ function useStickToBottom(): StickToBottomInstance {
 		if (el) {
 			el.addEventListener("scroll", handleScroll, { passive: true });
 			el.addEventListener("wheel", handleWheel, { passive: true });
+			el.addEventListener("touchstart", handleTouchStart, {
+				passive: true,
+			});
+			el.addEventListener("touchend", handleTouchEnd, {
+				passive: true,
+			});
+			el.addEventListener("touchcancel", handleTouchEnd, {
+				passive: true,
+			});
 
 			const vo = new ResizeObserver(handleViewportResize);
 			vo.observe(el);
@@ -390,6 +421,23 @@ function useStickToBottom(): StickToBottomInstance {
 		};
 	}, []);
 
+	// Reset touch counter on tab switch. The browser may not
+	// fire touchend/touchcancel when the user switches away
+	// mid-gesture, leaving the counter positive and blocking
+	// resize observer pins permanently.
+	useEffect(() => {
+		const s = stateRef.current;
+		const handleVisibilityChange = () => {
+			if (document.hidden) {
+				s.activeTouchCount = 0;
+			}
+		};
+		document.addEventListener("visibilitychange", handleVisibilityChange);
+		return () => {
+			document.removeEventListener("visibilitychange", handleVisibilityChange);
+		};
+	}, []);
+
 	// Cleanup on unmount.
 	useEffect(() => {
 		return () => {
@@ -397,6 +445,9 @@ function useStickToBottom(): StickToBottomInstance {
 			if (s.scrollElement) {
 				s.scrollElement.removeEventListener("scroll", handleScroll);
 				s.scrollElement.removeEventListener("wheel", handleWheel);
+				s.scrollElement.removeEventListener("touchstart", handleTouchStart);
+				s.scrollElement.removeEventListener("touchend", handleTouchEnd);
+				s.scrollElement.removeEventListener("touchcancel", handleTouchEnd);
 			}
 			if (s.resizeObserver) {
 				s.resizeObserver.disconnect();
@@ -405,7 +456,7 @@ function useStickToBottom(): StickToBottomInstance {
 				s.viewportObserver.disconnect();
 			}
 		};
-	}, [handleScroll, handleWheel]);
+	}, [handleScroll, handleWheel, handleTouchStart, handleTouchEnd]);
 
 	return {
 		scrollRef,
@@ -476,8 +527,7 @@ const ChatScrollContainer: FC<{
 		}
 	}, [isFetchingMoreMessages]);
 
-	// Snapshot captured before a fetch so we can restore scroll
-	// position after older messages are prepended.
+	// Snapshot captured before a fetch so we can restore scroll	// position after older messages are prepended.
 	const pendingPrependRef = useRef<{
 		scrollHeight: number;
 	} | null>(null);
@@ -539,10 +589,21 @@ const ChatScrollContainer: FC<{
 		}
 	}, [isFetchingMoreMessages]);
 
+	// Keep the prepend scrollHeight snapshot current while
+	// streaming, so the restoration delta only reflects
+	// prepended content, not streaming growth during fetch.
+	useLayoutEffect(() => {
+		if (!isFetchingMoreMessages) return;
+		const pending = pendingPrependRef.current;
+		const container = scrollContainerRef.current;
+		if (pending && container) {
+			pending.scrollHeight = container.scrollHeight;
+		}
+	});
+
 	// -------------------------------------------------------------------
 	// Prepend scroll restoration
 	// -------------------------------------------------------------------
-
 	// When older messages are prepended the browser keeps scrollTop
 	// constant while scrollHeight grows, shifting the viewport down.
 	// Compensate by adding the height delta to scrollTop.

--- a/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
+++ b/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
@@ -63,14 +63,19 @@ function isNearBottom(s: InternalState): boolean {
 }
 
 /** Assign scrollTop and bump the programmatic-scroll counter so
- *  the next scroll event is not misread as a user-initiated scroll. */
+ *  the next scroll event is not misread as a user-initiated scroll.
+ *  Only bumps the counter when scrollTop actually changes, so no-op
+ *  writes don't orphan a counter increment without a matching event. */
 function scrollTo(s: InternalState, value: number) {
 	if (!s.scrollElement) {
 		return;
 	}
 
+	const prev = s.scrollElement.scrollTop;
 	s.scrollElement.scrollTop = value;
-	s.programmaticScrollCount++;
+	if (s.scrollElement.scrollTop !== prev) {
+		s.programmaticScrollCount++;
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -168,13 +173,13 @@ function useStickToBottom(): StickToBottomInstance {
 			return;
 		}
 
+		const lastST = s.lastScrollTop;
 		s.lastScrollTop = currentScrollTop;
 
 		setNearBottom(isNearBottom(s));
 
 		// Synchronous escape logic — must run before any resize
 		// handler so they see up-to-date internalIsAtBottom.
-		const lastST = s.lastScrollTop;
 		if (s.resizeDifference === 0) {
 			if (currentScrollTop < lastST) {
 				syncEscapedFromLock(true);

--- a/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
+++ b/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
@@ -164,7 +164,7 @@ function useStickToBottom(): StickToBottomInstance {
 
 		if (
 			s.ignoreScrollToTop !== undefined &&
-			s.ignoreScrollToTop > currentScrollTop
+			s.ignoreScrollToTop >= currentScrollTop
 		) {
 			lastST = s.ignoreScrollToTop;
 		}

--- a/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
+++ b/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
@@ -315,6 +315,20 @@ function useStickToBottom(): StickToBottomInstance {
 		// user's finger.
 		if (s.activeTouchCount > 0) {
 			// No auto-pin during active touch.
+		} else if (s.pendingPrepend) {
+			// Prepend restoration: older messages were just added
+			// to the DOM. Adjust scrollTop by the height delta so
+			// the user's visual position stays the same.
+			const delta =
+				s.scrollElement.scrollHeight - s.pendingPrepend.scrollHeight;
+			if (delta > 0) {
+				const prev = s.scrollElement.scrollTop;
+				s.scrollElement.scrollTop = prev + delta;
+				if (s.scrollElement.scrollTop !== prev) {
+					s.programmaticScrollCount++;
+				}
+			}
+			s.pendingPrepend = null;
 		} else if (s.suppressNextResize) {
 			s.suppressNextResize = false;
 		} else if (difference >= 0) {

--- a/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
+++ b/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
@@ -621,21 +621,41 @@ const ChatScrollContainer: FC<{
 				pendingPrependRef.current = {
 					scrollHeight: container.scrollHeight,
 				};
+				// biome-ignore lint/suspicious/noConsole: temporary debug
+				console.debug("[STB] snapshot", {
+					scrollHeight: container.scrollHeight,
+				});
 			}
 		} else if (wasFetching && !isFetchingMoreMessages) {
-			// true -> false: fetch completed, new messages in DOM.
-			// Adjust scrollTop by the height delta to maintain the
-			// user's visual position.
 			const pending = pendingPrependRef.current;
 			const container = scrollContainerRef.current;
 			if (pending && container) {
 				const delta = container.scrollHeight - pending.scrollHeight;
+				// biome-ignore lint/suspicious/noConsole: temporary debug
+				console.debug("[STB] restore", {
+					delta,
+					snapshotH: pending.scrollHeight,
+					currentH: container.scrollHeight,
+					scrollTop: container.scrollTop,
+				});
 				if (delta > 0) {
 					suppressNextResize();
 					container.scrollTop += delta;
 				}
+			} else {
+				// biome-ignore lint/suspicious/noConsole: temporary debug
+				console.debug("[STB] restore SKIPPED", {
+					pending: !!pending,
+					container: !!container,
+				});
 			}
 			pendingPrependRef.current = null;
+		} else {
+			// biome-ignore lint/suspicious/noConsole: temporary debug
+			console.debug("[STB] transition", {
+				wasFetching,
+				isFetchingMoreMessages,
+			});
 		}
 	}, [isFetchingMoreMessages, scrollContainerRef, suppressNextResize]);
 

--- a/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
+++ b/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
@@ -26,7 +26,7 @@ const STICK_TO_BOTTOM_OFFSET_PX = 70;
 interface InternalState {
 	scrollElement: HTMLElement | null;
 	contentElement: HTMLElement | null;
-	ignoreScrollToTop: number | undefined;
+	programmaticScrollCount: number;
 	resizeDifference: number;
 	lastScrollTop: number;
 	escapedFromLock: boolean;
@@ -62,15 +62,15 @@ function isNearBottom(s: InternalState): boolean {
 	return distance <= STICK_TO_BOTTOM_OFFSET_PX;
 }
 
-/** Assign scrollTop and record the value so the scroll handler can
- *  distinguish this programmatic write from a user-initiated scroll. */
+/** Assign scrollTop and bump the programmatic-scroll counter so
+ *  the next scroll event is not misread as a user-initiated scroll. */
 function scrollTo(s: InternalState, value: number) {
 	if (!s.scrollElement) {
 		return;
 	}
 
 	s.scrollElement.scrollTop = value;
-	s.ignoreScrollToTop = s.scrollElement.scrollTop;
+	s.programmaticScrollCount++;
 }
 
 // ---------------------------------------------------------------------------
@@ -95,7 +95,7 @@ function useStickToBottom(): StickToBottomInstance {
 	const stateRef = useRef<InternalState>({
 		scrollElement: null,
 		contentElement: null,
-		ignoreScrollToTop: undefined,
+		programmaticScrollCount: 0,
 		resizeDifference: 0,
 		lastScrollTop: 0,
 		escapedFromLock: false,
@@ -137,12 +137,10 @@ function useStickToBottom(): StickToBottomInstance {
 				top,
 				behavior: behavior ?? "smooth",
 			});
-			// Don't set ignoreScrollToTop for smooth scroll.
+			// Don't bump programmaticScrollCount for smooth scroll.
 			// Each animation frame naturally reads as a downward
 			// scroll (currentScrollTop > lastScrollTop), which
-			// correctly clears escapedFromLock. Setting it to
-			// the target inflates lastST, making intermediate
-			// frames look like upward scrolls.
+			// correctly clears escapedFromLock.
 		}
 	});
 
@@ -160,21 +158,23 @@ function useStickToBottom(): StickToBottomInstance {
 		if (e.target !== scrollElement || !scrollElement) return;
 
 		const currentScrollTop = scrollElement.scrollTop;
-		let lastST = s.lastScrollTop;
 
-		if (
-			s.ignoreScrollToTop !== undefined &&
-			s.ignoreScrollToTop >= currentScrollTop
-		) {
-			lastST = s.ignoreScrollToTop;
+		// If this event was caused by a programmatic scrollTo,
+		// consume the counter and skip escape processing.
+		if (s.programmaticScrollCount > 0) {
+			s.programmaticScrollCount--;
+			s.lastScrollTop = currentScrollTop;
+			setNearBottom(isNearBottom(s));
+			return;
 		}
-		s.ignoreScrollToTop = undefined;
+
 		s.lastScrollTop = currentScrollTop;
 
 		setNearBottom(isNearBottom(s));
 
 		// Synchronous escape logic — must run before any resize
 		// handler so they see up-to-date internalIsAtBottom.
+		const lastST = s.lastScrollTop;
 		if (s.resizeDifference === 0) {
 			if (currentScrollTop < lastST) {
 				syncEscapedFromLock(true);
@@ -187,7 +187,6 @@ function useStickToBottom(): StickToBottomInstance {
 				syncIsAtBottom(true);
 			}
 		}
-
 		// Text-selection escape deferred — getSelection() needs
 		// post-layout DOM state to reflect the current drag.
 		setTimeout(() => {

--- a/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
+++ b/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
@@ -351,8 +351,9 @@ function useStickToBottom(): StickToBottomInstance {
 				);
 				const wasAtBottom =
 					s.internalIsAtBottom ||
-					s.scrollElement.scrollTop >=
-						prevMaxScroll - STICK_TO_BOTTOM_OFFSET_PX;
+					(!s.escapedFromLock &&
+						s.scrollElement.scrollTop >=
+							prevMaxScroll - STICK_TO_BOTTOM_OFFSET_PX);
 
 				if (wasAtBottom) {
 					scrollTo(s, target);

--- a/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
+++ b/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
@@ -196,6 +196,13 @@ function useStickToBottom(): StickToBottomInstance {
 		// layout that aren’t user-initiated.
 		if (s.resizeDifference === 0 && !viewportChanged) {
 			if (currentScrollTop < lastST) {
+				// biome-ignore lint/suspicious/noConsole: temporary debug
+				console.debug("[STB] escape UP", {
+					from: lastST,
+					to: currentScrollTop,
+					clientH: scrollElement.clientHeight,
+					maxST: maxScrollTop(s),
+				});
 				syncEscapedFromLock(true);
 				syncIsAtBottom(false);
 			} else if (currentScrollTop > lastST) {
@@ -290,6 +297,13 @@ function useStickToBottom(): StickToBottomInstance {
 				// First observation — jump to bottom instantly.
 				if (s.internalIsAtBottom) {
 					scrollTo(s, target);
+					// biome-ignore lint/suspicious/noConsole: temporary debug
+					console.debug("[STB] firstPin", {
+						target,
+						scrollTop: s.scrollElement.scrollTop,
+						clientH: s.scrollElement.clientHeight,
+						scrollH: s.scrollElement.scrollHeight,
+					});
 				}
 			} else {
 				// Check whether we were near the OLD bottom before
@@ -313,6 +327,16 @@ function useStickToBottom(): StickToBottomInstance {
 					syncIsAtBottom(true);
 					syncEscapedFromLock(false);
 				}
+				// biome-ignore lint/suspicious/noConsole: temporary debug
+				console.debug("[STB] contentResize", {
+					diff: difference,
+					wasAtBottom,
+					internalIsAtBottom: s.internalIsAtBottom,
+					scrollTop: s.scrollElement.scrollTop,
+					maxST: target,
+					clientH: s.scrollElement.clientHeight,
+					scrollH: s.scrollElement.scrollHeight,
+				});
 			}
 		} else if (isNearBottom(s)) {
 			// Content shrank and we ended up near bottom — re-engage.
@@ -343,15 +367,25 @@ function useStickToBottom(): StickToBottomInstance {
 	// handleScroll to disengage the lock.
 	const handleViewportResize = useEffectEvent(() => {
 		const s = stateRef.current;
-		if (
-			!s.scrollElement ||
-			s.activeTouchCount > 0 ||
-			(!s.internalIsAtBottom && !isNearBottom(s))
-		) {
+		if (!s.scrollElement) return;
+		const maxST = maxScrollTop(s);
+		const near = isNearBottom(s);
+		// biome-ignore lint/suspicious/noConsole: temporary debug
+		console.debug("[STB] viewportResize", {
+			internalIsAtBottom: s.internalIsAtBottom,
+			escapedFromLock: s.escapedFromLock,
+			nearBottom: near,
+			scrollTop: s.scrollElement.scrollTop,
+			maxST,
+			clientH: s.scrollElement.clientHeight,
+			scrollH: s.scrollElement.scrollHeight,
+			skip: s.activeTouchCount > 0 || (!s.internalIsAtBottom && !near),
+		});
+		if (s.activeTouchCount > 0 || (!s.internalIsAtBottom && !near)) {
 			return;
 		}
 
-		scrollTo(s, maxScrollTop(s));
+		scrollTo(s, maxST);
 		syncIsAtBottom(true);
 		syncEscapedFromLock(false);
 	});

--- a/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
+++ b/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
@@ -317,14 +317,24 @@ function useStickToBottom(): StickToBottomInstance {
 
 	// When the scroll container's viewport dimensions change (e.g.
 	// the top bar gains elements after async data loads), maxScrollTop
-	// shifts and we may no longer be at the bottom. Re-pin if locked.
+	// shifts and we may no longer be at the bottom. Re-pin if locked
+	// or physically near the bottom. The near-bottom fallback handles
+	// the case where the browser clamped scrollTop before this
+	// observer fired, causing the synchronous escape logic in
+	// handleScroll to disengage the lock.
 	const handleViewportResize = useEffectEvent(() => {
 		const s = stateRef.current;
-		if (!s.scrollElement || !s.internalIsAtBottom || s.activeTouchCount > 0) {
+		if (
+			!s.scrollElement ||
+			s.activeTouchCount > 0 ||
+			(!s.internalIsAtBottom && !isNearBottom(s))
+		) {
 			return;
 		}
 
 		scrollTo(s, maxScrollTop(s));
+		syncIsAtBottom(true);
+		syncEscapedFromLock(false);
 	});
 
 	const handleTouchStart = useEffectEvent((e: TouchEvent) => {

--- a/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
+++ b/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
@@ -700,6 +700,13 @@ const ChatScrollContainer: FC<{
 		if (!pending || !container) return;
 
 		const delta = container.scrollHeight - pending.scrollHeight;
+		// biome-ignore lint/suspicious/noConsole: temporary debug
+		console.debug("[STB] prepend-restore", {
+			delta,
+			snapshotH: pending.scrollHeight,
+			currentH: container.scrollHeight,
+			scrollTopBefore: container.scrollTop,
+		});
 		if (delta > 0) {
 			suppressNextResize();
 			container.scrollTop += delta;

--- a/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
+++ b/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
@@ -1,9 +1,20 @@
-import { type RefCallback, useEffect, useRef, useState } from "react";
+import { ArrowDownIcon } from "lucide-react";
+import {
+	type FC,
+	type RefCallback,
+	type RefObject,
+	useEffect,
+	useLayoutEffect,
+	useRef,
+	useState,
+} from "react";
+import { Button } from "#/components/Button/Button";
 import { useEffectEvent } from "#/hooks/hookPolyfills";
+import { cn } from "#/utils/cn";
 
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
+// ===========================================================================
+// useStickToBottom — scroll-lock hook
+// ===========================================================================
 
 /** Pixel threshold for "near bottom" detection. */
 const STICK_TO_BOTTOM_OFFSET_PX = 70;
@@ -388,4 +399,184 @@ function useStickToBottom(): StickToBottomInstance {
 	};
 }
 
-export { useStickToBottom };
+// ===========================================================================
+// ChatScrollContainer — the scroll-anchored wrapper for the chat transcript
+// ===========================================================================
+
+/**
+ * Scroll container that keeps the transcript pinned to the bottom using
+ * ResizeObserver-driven scroll tracking. Handles:
+ * - Stick-to-bottom with automatic re-engagement when content grows.
+ * - Loading older message pages via an IntersectionObserver sentinel.
+ * - Scroll position restoration when older messages are prepended.
+ * - A floating "Scroll to bottom" button when the user scrolls away.
+ */
+const ChatScrollContainer: FC<{
+	scrollContainerRef: RefObject<HTMLDivElement | null>;
+	scrollToBottomRef: RefObject<(() => void) | null>;
+	isFetchingMoreMessages: boolean;
+	hasMoreMessages: boolean;
+	onFetchMoreMessages: () => void;
+	children: React.ReactNode;
+}> = ({
+	scrollContainerRef,
+	scrollToBottomRef,
+	isFetchingMoreMessages,
+	hasMoreMessages,
+	onFetchMoreMessages,
+	children,
+}) => {
+	const { scrollRef, contentRef, scrollToBottom, isAtBottom } =
+		useStickToBottom();
+
+	// Merge our callback ref with the external RefObject so both
+	// point at the same DOM node, and expose scrollToBottom to the
+	// parent via its imperative ref.
+	const mergedScrollRef = useEffectEvent((el: HTMLDivElement | null) => {
+		scrollRef(el);
+		scrollContainerRef.current = el;
+		scrollToBottomRef.current = el ? () => scrollToBottom("instant") : null;
+	});
+
+	// -------------------------------------------------------------------
+	// Pagination sentinel (IntersectionObserver)
+	// -------------------------------------------------------------------
+
+	const sentinelRef = useRef<HTMLDivElement>(null);
+	const observerRef = useRef<IntersectionObserver | null>(null);
+	const isFetchingRef = useRef(isFetchingMoreMessages);
+	const hasFetchedRef = useRef(false);
+
+	useLayoutEffect(() => {
+		isFetchingRef.current = isFetchingMoreMessages;
+		if (isFetchingMoreMessages) {
+			hasFetchedRef.current = true;
+		}
+	}, [isFetchingMoreMessages]);
+
+	// Snapshot captured before a fetch so we can restore scroll
+	// position after older messages are prepended.
+	const pendingPrependRef = useRef<{
+		scrollHeight: number;
+	} | null>(null);
+
+	useEffect(() => {
+		const sentinel = sentinelRef.current;
+		const container = scrollContainerRef.current;
+		if (!sentinel || !container) return;
+
+		const observer = new IntersectionObserver(
+			([entry]) => {
+				if (entry.isIntersecting && !isFetchingRef.current) {
+					const container = scrollContainerRef.current;
+					if (container) {
+						pendingPrependRef.current = {
+							scrollHeight: container.scrollHeight,
+						};
+					}
+					onFetchMoreMessages();
+				}
+			},
+			{
+				root: container,
+				rootMargin: "600px 0px 0px 0px",
+				threshold: 0.01,
+			},
+		);
+		observerRef.current = observer;
+
+		// Defer observation via double-rAF so the initial bottom
+		// pin settles before the sentinel can trigger.
+		let deferInnerId: number | null = null;
+		const deferOuterId = requestAnimationFrame(() => {
+			deferInnerId = requestAnimationFrame(() => {
+				observer.observe(sentinel);
+			});
+		});
+		return () => {
+			cancelAnimationFrame(deferOuterId);
+			if (deferInnerId !== null) {
+				cancelAnimationFrame(deferInnerId);
+			}
+			observer.disconnect();
+			observerRef.current = null;
+		};
+	}, [scrollContainerRef, onFetchMoreMessages]);
+
+	// Re-observe the sentinel after a fetch completes so the
+	// IntersectionObserver fires again if it stayed visible.
+	useEffect(() => {
+		if (isFetchingMoreMessages) return;
+		if (!hasFetchedRef.current) return;
+
+		const sentinel = sentinelRef.current;
+		const observer = observerRef.current;
+		if (sentinel && observer) {
+			observer.unobserve(sentinel);
+			observer.observe(sentinel);
+		}
+	}, [isFetchingMoreMessages]);
+
+	// -------------------------------------------------------------------
+	// Prepend scroll restoration
+	// -------------------------------------------------------------------
+
+	// When older messages are prepended the browser keeps scrollTop
+	// constant while scrollHeight grows, shifting the viewport down.
+	// Compensate by adding the height delta to scrollTop.
+	useLayoutEffect(() => {
+		if (isFetchingMoreMessages) return;
+		const pending = pendingPrependRef.current;
+		const container = scrollContainerRef.current;
+		if (!pending || !container) return;
+
+		const delta = container.scrollHeight - pending.scrollHeight;
+		if (delta > 0) {
+			container.scrollTop += delta;
+		}
+		pendingPrependRef.current = null;
+	}, [isFetchingMoreMessages, scrollContainerRef]);
+
+	// -------------------------------------------------------------------
+	// Render
+	// -------------------------------------------------------------------
+
+	const showButton = !isAtBottom;
+
+	return (
+		<div className="relative flex min-h-0 flex-1 flex-col">
+			<div
+				ref={mergedScrollRef}
+				data-testid="scroll-container"
+				className="flex min-h-0 flex-1 flex-col overflow-y-auto [overflow-anchor:none] [overscroll-behavior:contain] [scrollbar-gutter:stable] [scrollbar-width:thin] [scrollbar-color:hsl(var(--surface-quaternary))_transparent]"
+			>
+				<div ref={contentRef}>
+					{hasMoreMessages && (
+						<div ref={sentinelRef} className="h-px shrink-0" />
+					)}
+					{children}
+				</div>
+			</div>
+			<div className="pointer-events-none absolute inset-x-0 bottom-2 z-10 flex justify-center overflow-y-auto py-2 [scrollbar-gutter:stable] [scrollbar-width:thin]">
+				<Button
+					variant="outline"
+					size="icon"
+					className={cn(
+						"rounded-full bg-surface-primary shadow-md transition-all duration-200",
+						showButton
+							? "pointer-events-auto translate-y-0 opacity-100"
+							: "translate-y-2 opacity-0",
+					)}
+					onClick={() => scrollToBottom()}
+					aria-label="Scroll to bottom"
+					aria-hidden={!showButton || undefined}
+					tabIndex={showButton ? undefined : -1}
+				>
+					<ArrowDownIcon />
+				</Button>
+			</div>
+		</div>
+	);
+};
+
+export { ChatScrollContainer };

--- a/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
+++ b/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
@@ -487,6 +487,22 @@ function useStickToBottom(): StickToBottomInstance {
 		};
 	}, [handleScroll, handleWheel, handleTouchStart, handleTouchEnd]);
 
+	// Post-render consistency check. If we believe we're pinned
+	// to the bottom but the physical scroll position disagrees,
+	// correct it before the browser paints. This catches any
+	// race between ResizeObserver callbacks, browser scroll
+	// clamping, and React re-renders (e.g. Safari PWA viewport
+	// settling after navigation).
+	useLayoutEffect(() => {
+		const s = stateRef.current;
+		if (!s.scrollElement || !s.internalIsAtBottom) return;
+		const target = maxScrollTop(s);
+		// 1px tolerance for sub-pixel rounding.
+		if (target - s.scrollElement.scrollTop > 1) {
+			scrollTo(s, target);
+		}
+	});
+
 	return {
 		scrollRef,
 		contentRef,

--- a/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
+++ b/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
@@ -194,12 +194,16 @@ function useStickToBottom(): StickToBottomInstance {
 		// Skip when a content resize or viewport resize is in
 		// progress — the browser may fire scroll events during
 		// layout that aren’t user-initiated.
-		if (s.resizeDifference === 0 && !viewportChanged) {
+		if (
+			s.resizeDifference === 0 &&
+			!viewportChanged &&
+			s.activeTouchCount === 0
+		) {
 			if (currentScrollTop < lastST) {
 				// If we believe we're at the bottom and the user
-				// hasn't escaped via wheel/touch, this upward
-				// movement is browser-initiated (e.g. Safari
-				// scroll restoration, focus-driven scroll).
+				// hasn't escaped via wheel, touch, or scrollbar,
+				// this upward movement is browser-initiated (e.g.
+				// Safari scroll restoration, focus-driven scroll).
 				// Re-pin instead of escaping.
 				if (s.internalIsAtBottom && !s.escapedFromLock) {
 					scrollTo(s, maxScrollTop(s));
@@ -265,6 +269,12 @@ function useStickToBottom(): StickToBottomInstance {
 		) {
 			syncEscapedFromLock(true);
 			syncIsAtBottom(false);
+			// Cancel any in-progress smooth scroll so the animation
+			// doesn't override the user's escape intent.
+			s.scrollElement.scrollTo({
+				top: s.scrollElement.scrollTop,
+				behavior: "instant",
+			});
 		}
 	});
 
@@ -366,6 +376,8 @@ function useStickToBottom(): StickToBottomInstance {
 
 	const handleTouchStart = useEffectEvent((e: TouchEvent) => {
 		stateRef.current.activeTouchCount += Math.max(e.changedTouches.length, 1);
+		syncEscapedFromLock(true);
+		syncIsAtBottom(false);
 	});
 
 	const handleTouchEnd = useEffectEvent((e: TouchEvent) => {
@@ -380,6 +392,16 @@ function useStickToBottom(): StickToBottomInstance {
 	// Ref callbacks
 	// -----------------------------------------------------------------------
 
+	const handlePointerDown = useEffectEvent((e: PointerEvent) => {
+		const s = stateRef.current;
+		// e.target === s.scrollElement is only true when clicking
+		// the scrollbar track/thumb, not content inside the container.
+		if (e.target === s.scrollElement) {
+			syncEscapedFromLock(true);
+			syncIsAtBottom(false);
+		}
+	});
+
 	const scrollRef = useEffectEvent((el: HTMLDivElement | null) => {
 		const s = stateRef.current;
 		const prev = s.scrollElement;
@@ -390,6 +412,7 @@ function useStickToBottom(): StickToBottomInstance {
 			prev.removeEventListener("touchcancel", handleTouchEnd);
 			prev.removeEventListener("scroll", handleScroll);
 			prev.removeEventListener("wheel", handleWheel);
+			prev.removeEventListener("pointerdown", handlePointerDown);
 		}
 
 		if (s.viewportObserver) {
@@ -412,6 +435,7 @@ function useStickToBottom(): StickToBottomInstance {
 			el.addEventListener("touchcancel", handleTouchEnd, {
 				passive: true,
 			});
+			el.addEventListener("pointerdown", handlePointerDown);
 
 			const vo = new ResizeObserver(handleViewportResize);
 			vo.observe(el);
@@ -485,6 +509,7 @@ function useStickToBottom(): StickToBottomInstance {
 				s.scrollElement.removeEventListener("touchstart", handleTouchStart);
 				s.scrollElement.removeEventListener("touchend", handleTouchEnd);
 				s.scrollElement.removeEventListener("touchcancel", handleTouchEnd);
+				s.scrollElement.removeEventListener("pointerdown", handlePointerDown);
 			}
 			if (s.resizeObserver) {
 				s.resizeObserver.disconnect();
@@ -493,7 +518,13 @@ function useStickToBottom(): StickToBottomInstance {
 				s.viewportObserver.disconnect();
 			}
 		};
-	}, [handleScroll, handleWheel, handleTouchStart, handleTouchEnd]);
+	}, [
+		handleScroll,
+		handleWheel,
+		handleTouchStart,
+		handleTouchEnd,
+		handlePointerDown,
+	]);
 
 	// Post-render consistency check. If we believe we're pinned
 	// to the bottom but the physical scroll position disagrees,
@@ -501,6 +532,7 @@ function useStickToBottom(): StickToBottomInstance {
 	// race between ResizeObserver callbacks, browser scroll
 	// clamping, and React re-renders (e.g. Safari PWA viewport
 	// settling after navigation).
+	// Intentionally no deps — runs every render as a safety net.
 	useLayoutEffect(() => {
 		const s = stateRef.current;
 		if (!s.scrollElement || !s.internalIsAtBottom) return;
@@ -580,7 +612,8 @@ const ChatScrollContainer: FC<{
 		}
 	}, [isFetchingMoreMessages]);
 
-	// Snapshot captured before a fetch so we can restore scroll	// position after older messages are prepended.
+	// Snapshot captured before a fetch so we can restore scroll
+	// position after older messages are prepended.
 	const pendingPrependRef = useRef<{
 		scrollHeight: number;
 	} | null>(null);

--- a/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
+++ b/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
@@ -196,15 +196,17 @@ function useStickToBottom(): StickToBottomInstance {
 		// layout that aren’t user-initiated.
 		if (s.resizeDifference === 0 && !viewportChanged) {
 			if (currentScrollTop < lastST) {
-				// biome-ignore lint/suspicious/noConsole: temporary debug
-				console.debug("[STB] escape UP", {
-					from: lastST,
-					to: currentScrollTop,
-					clientH: scrollElement.clientHeight,
-					maxST: maxScrollTop(s),
-				});
-				syncEscapedFromLock(true);
-				syncIsAtBottom(false);
+				// If we believe we're at the bottom and the user
+				// hasn't escaped via wheel/touch, this upward
+				// movement is browser-initiated (e.g. Safari
+				// scroll restoration, focus-driven scroll).
+				// Re-pin instead of escaping.
+				if (s.internalIsAtBottom && !s.escapedFromLock) {
+					scrollTo(s, maxScrollTop(s));
+				} else {
+					syncEscapedFromLock(true);
+					syncIsAtBottom(false);
+				}
 			} else if (currentScrollTop > lastST) {
 				syncEscapedFromLock(false);
 			}
@@ -297,13 +299,6 @@ function useStickToBottom(): StickToBottomInstance {
 				// First observation — jump to bottom instantly.
 				if (s.internalIsAtBottom) {
 					scrollTo(s, target);
-					// biome-ignore lint/suspicious/noConsole: temporary debug
-					console.debug("[STB] firstPin", {
-						target,
-						scrollTop: s.scrollElement.scrollTop,
-						clientH: s.scrollElement.clientHeight,
-						scrollH: s.scrollElement.scrollHeight,
-					});
 				}
 			} else {
 				// Check whether we were near the OLD bottom before
@@ -327,16 +322,6 @@ function useStickToBottom(): StickToBottomInstance {
 					syncIsAtBottom(true);
 					syncEscapedFromLock(false);
 				}
-				// biome-ignore lint/suspicious/noConsole: temporary debug
-				console.debug("[STB] contentResize", {
-					diff: difference,
-					wasAtBottom,
-					internalIsAtBottom: s.internalIsAtBottom,
-					scrollTop: s.scrollElement.scrollTop,
-					maxST: target,
-					clientH: s.scrollElement.clientHeight,
-					scrollH: s.scrollElement.scrollHeight,
-				});
 			}
 		} else if (isNearBottom(s)) {
 			// Content shrank and we ended up near bottom — re-engage.
@@ -370,17 +355,6 @@ function useStickToBottom(): StickToBottomInstance {
 		if (!s.scrollElement) return;
 		const maxST = maxScrollTop(s);
 		const near = isNearBottom(s);
-		// biome-ignore lint/suspicious/noConsole: temporary debug
-		console.debug("[STB] viewportResize", {
-			internalIsAtBottom: s.internalIsAtBottom,
-			escapedFromLock: s.escapedFromLock,
-			nearBottom: near,
-			scrollTop: s.scrollElement.scrollTop,
-			maxST,
-			clientH: s.scrollElement.clientHeight,
-			scrollH: s.scrollElement.scrollHeight,
-			skip: s.activeTouchCount > 0 || (!s.internalIsAtBottom && !near),
-		});
 		if (s.activeTouchCount > 0 || (!s.internalIsAtBottom && !near)) {
 			return;
 		}

--- a/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
+++ b/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
@@ -38,6 +38,7 @@ interface InternalState {
 	mouseDown: boolean;
 	suppressNextResize: boolean;
 	activeTouchCount: number;
+	pendingPrepend: { scrollHeight: number } | null;
 }
 
 /** The maximum scrollable offset for the container. */
@@ -92,6 +93,8 @@ interface StickToBottomInstance {
 	isAtBottom: boolean;
 	/** Tell the hook to skip the next content resize auto-pin. */
 	suppressNextResize: () => void;
+	/** Capture scrollHeight for prepend restoration. */
+	capturePrependSnapshot: () => void;
 }
 
 function useStickToBottom(): StickToBottomInstance {
@@ -113,6 +116,7 @@ function useStickToBottom(): StickToBottomInstance {
 		mouseDown: false,
 		suppressNextResize: false,
 		activeTouchCount: 0,
+		pendingPrepend: null,
 	});
 
 	// Sync helpers — keep mutable state and React state in lockstep.
@@ -153,6 +157,15 @@ function useStickToBottom(): StickToBottomInstance {
 
 	const suppressNextResize = useEffectEvent(() => {
 		stateRef.current.suppressNextResize = true;
+	});
+
+	const capturePrependSnapshot = useEffectEvent(() => {
+		const s = stateRef.current;
+		if (s.scrollElement) {
+			s.pendingPrepend = {
+				scrollHeight: s.scrollElement.scrollHeight,
+			};
+		}
 	});
 
 	// -----------------------------------------------------------------------
@@ -549,6 +562,7 @@ function useStickToBottom(): StickToBottomInstance {
 		scrollToBottom,
 		isAtBottom: isAtBottom || nearBottom,
 		suppressNextResize,
+		capturePrependSnapshot,
 	};
 }
 
@@ -584,7 +598,7 @@ const ChatScrollContainer: FC<{
 		contentRef,
 		scrollToBottom,
 		isAtBottom,
-		suppressNextResize,
+		capturePrependSnapshot,
 	} = useStickToBottom();
 
 	// Merge our callback ref with the external RefObject so both
@@ -613,57 +627,14 @@ const ChatScrollContainer: FC<{
 		wasFetchingRef.current = isFetchingMoreMessages;
 
 		if (!wasFetching && isFetchingMoreMessages) {
-			// false -> true: fetch just started. Capture scrollHeight
-			// so we can restore position after prepend.
 			hasFetchedRef.current = true;
-			const container = scrollContainerRef.current;
-			if (container) {
-				pendingPrependRef.current = {
-					scrollHeight: container.scrollHeight,
-				};
-				// biome-ignore lint/suspicious/noConsole: temporary debug
-				console.debug("[STB] snapshot", {
-					scrollHeight: container.scrollHeight,
-				});
-			}
-		} else if (wasFetching && !isFetchingMoreMessages) {
-			const pending = pendingPrependRef.current;
-			const container = scrollContainerRef.current;
-			if (pending && container) {
-				const delta = container.scrollHeight - pending.scrollHeight;
-				// biome-ignore lint/suspicious/noConsole: temporary debug
-				console.debug("[STB] restore", {
-					delta,
-					snapshotH: pending.scrollHeight,
-					currentH: container.scrollHeight,
-					scrollTop: container.scrollTop,
-				});
-				if (delta > 0) {
-					suppressNextResize();
-					container.scrollTop += delta;
-				}
-			} else {
-				// biome-ignore lint/suspicious/noConsole: temporary debug
-				console.debug("[STB] restore SKIPPED", {
-					pending: !!pending,
-					container: !!container,
-				});
-			}
-			pendingPrependRef.current = null;
-		} else {
-			// biome-ignore lint/suspicious/noConsole: temporary debug
-			console.debug("[STB] transition", {
-				wasFetching,
-				isFetchingMoreMessages,
-			});
+			capturePrependSnapshot();
 		}
-	}, [isFetchingMoreMessages, scrollContainerRef, suppressNextResize]);
-
-	// Snapshot captured before a fetch so we can restore scroll
-	// position after older messages are prepended.
-	const pendingPrependRef = useRef<{
-		scrollHeight: number;
-	} | null>(null);
+		// Restoration happens in handleContentResize (via
+		// pendingPrepend) when the DOM actually reflects the
+		// prepended content — not here, because the store
+		// update may lag behind isFetchingMoreMessages.
+	}, [isFetchingMoreMessages, capturePrependSnapshot]);
 
 	useEffect(() => {
 		const sentinel = sentinelRef.current;

--- a/site/src/pages/AgentsPage/components/StickToBottom.tsx
+++ b/site/src/pages/AgentsPage/components/StickToBottom.tsx
@@ -1,0 +1,346 @@
+import { type RefCallback, useEffect, useRef, useState } from "react";
+import { useEffectEvent } from "#/hooks/hookPolyfills";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Pixel threshold for "near bottom" detection. */
+const STICK_TO_BOTTOM_OFFSET_PX = 70;
+
+// ---------------------------------------------------------------------------
+// Mutable state (not tied to React render cycle)
+// ---------------------------------------------------------------------------
+
+interface InternalState {
+	scrollElement: HTMLElement | null;
+	contentElement: HTMLElement | null;
+	ignoreScrollToTop: number | undefined;
+	resizeDifference: number;
+	lastScrollTop: number;
+	escapedFromLock: boolean;
+	internalIsAtBottom: boolean;
+	resizeObserver: ResizeObserver | null;
+	previousContentHeight: number | undefined;
+	mouseDown: boolean;
+}
+
+/** The maximum scrollable offset for the container. */
+function maxScrollTop(s: InternalState): number {
+	if (!s.scrollElement) {
+		return 0;
+	}
+
+	return Math.max(
+		0,
+		s.scrollElement.scrollHeight - s.scrollElement.clientHeight,
+	);
+}
+
+/** Whether the scroll position is within the stick-to-bottom threshold. */
+function isNearBottom(s: InternalState): boolean {
+	if (!s.scrollElement) {
+		return false;
+	}
+
+	const distance = maxScrollTop(s) - s.scrollElement.scrollTop;
+
+	return distance <= STICK_TO_BOTTOM_OFFSET_PX;
+}
+
+/** Assign scrollTop and record the value so the scroll handler can
+ *  distinguish this programmatic write from a user-initiated scroll. */
+function scrollTo(s: InternalState, value: number) {
+	if (!s.scrollElement) {
+		return;
+	}
+
+	s.scrollElement.scrollTop = value;
+	s.ignoreScrollToTop = s.scrollElement.scrollTop;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+interface StickToBottomInstance {
+	scrollRef: RefCallback<HTMLDivElement>;
+	contentRef: RefCallback<HTMLDivElement>;
+	/** Scroll to the bottom. Pass `"instant"` to jump; omit for smooth. */
+	scrollToBottom: (behavior?: ScrollBehavior) => void;
+	/** True when the view is locked to the bottom or physically near it. */
+	isAtBottom: boolean;
+}
+
+function useStickToBottom(): StickToBottomInstance {
+	const [isAtBottom, setIsAtBottom] = useState(true);
+	const [nearBottom, setNearBottom] = useState(false);
+
+	const stateRef = useRef<InternalState>({
+		scrollElement: null,
+		contentElement: null,
+		ignoreScrollToTop: undefined,
+		resizeDifference: 0,
+		lastScrollTop: 0,
+		escapedFromLock: false,
+		internalIsAtBottom: true,
+		resizeObserver: null,
+		previousContentHeight: undefined,
+		mouseDown: false,
+	});
+
+	// Sync helpers — keep mutable state and React state in lockstep.
+	const syncIsAtBottom = useEffectEvent((v: boolean) => {
+		stateRef.current.internalIsAtBottom = v;
+		setIsAtBottom(v);
+	});
+
+	const syncEscapedFromLock = useEffectEvent((v: boolean) => {
+		stateRef.current.escapedFromLock = v;
+	});
+
+	// -----------------------------------------------------------------------
+	// scrollToBottom
+	// -----------------------------------------------------------------------
+
+	const scrollToBottom = useEffectEvent((behavior?: ScrollBehavior) => {
+		const s = stateRef.current;
+		if (!s.scrollElement) return;
+
+		syncIsAtBottom(true);
+		syncEscapedFromLock(false);
+
+		const top = maxScrollTop(s);
+		if (behavior === "instant") {
+			scrollTo(s, top);
+		} else {
+			s.scrollElement.scrollTo({
+				top,
+				behavior: behavior ?? "smooth",
+			});
+			// Record the target so the scroll handler doesn't
+			// interpret the smooth-scroll frames as user scrolls.
+			s.ignoreScrollToTop = top;
+		}
+	});
+
+	// -----------------------------------------------------------------------
+	// Event handlers
+	// -----------------------------------------------------------------------
+
+	const handleScroll = useEffectEvent((e: Event) => {
+		const s = stateRef.current;
+		const { scrollElement } = s;
+		if (e.target !== scrollElement || !scrollElement) return;
+
+		const currentScrollTop = scrollElement.scrollTop;
+		let lastST = s.lastScrollTop;
+
+		if (
+			s.ignoreScrollToTop !== undefined &&
+			s.ignoreScrollToTop > currentScrollTop
+		) {
+			lastST = s.ignoreScrollToTop;
+		}
+		s.ignoreScrollToTop = undefined;
+		s.lastScrollTop = currentScrollTop;
+
+		setNearBottom(isNearBottom(s));
+
+		setTimeout(() => {
+			if (s.resizeDifference !== 0) return;
+
+			// If the user is selecting text inside the scroll
+			// container, treat it as an escape so the selection
+			// isn't fought by auto-scroll.
+			if (s.mouseDown && s.scrollElement) {
+				const sel = window.getSelection();
+				if (sel && sel.rangeCount > 0) {
+					const ancestor = sel.getRangeAt(0).commonAncestorContainer;
+					const el =
+						ancestor instanceof HTMLElement ? ancestor : ancestor.parentElement;
+					if (
+						el &&
+						(s.scrollElement.contains(el) || el.contains(s.scrollElement))
+					) {
+						syncEscapedFromLock(true);
+						syncIsAtBottom(false);
+						return;
+					}
+				}
+			}
+
+			if (currentScrollTop < lastST) {
+				syncEscapedFromLock(true);
+				syncIsAtBottom(false);
+			} else if (currentScrollTop > lastST) {
+				syncEscapedFromLock(false);
+			}
+
+			if (!s.escapedFromLock && isNearBottom(s)) {
+				syncIsAtBottom(true);
+			}
+		}, 1);
+	});
+
+	const handleWheel = useEffectEvent((e: WheelEvent) => {
+		const s = stateRef.current;
+
+		// Walk up from target to find the nearest scrollable ancestor.
+		let el = e.target as HTMLElement | null;
+		while (el && el !== s.scrollElement) {
+			const style = getComputedStyle(el);
+			if (
+				style.overflow === "scroll" ||
+				style.overflow === "auto" ||
+				style.overflowY === "scroll" ||
+				style.overflowY === "auto"
+			) {
+				break;
+			}
+			el = el.parentElement;
+		}
+
+		if (
+			el === s.scrollElement &&
+			e.deltaY < 0 &&
+			s.scrollElement &&
+			s.scrollElement.scrollHeight > s.scrollElement.clientHeight
+		) {
+			syncEscapedFromLock(true);
+			syncIsAtBottom(false);
+		}
+	});
+
+	const handleContentResize = useEffectEvent(() => {
+		const s = stateRef.current;
+		if (!s.contentElement || !s.scrollElement) return;
+
+		const currentHeight = s.contentElement.getBoundingClientRect().height;
+		const previousHeight = s.previousContentHeight;
+		const difference =
+			previousHeight !== undefined ? currentHeight - previousHeight : 0;
+
+		s.resizeDifference = difference;
+
+		// Clamp browser overscroll.
+		const target = maxScrollTop(s);
+		if (s.scrollElement.scrollTop > target) {
+			scrollTo(s, target);
+		}
+
+		setNearBottom(isNearBottom(s));
+
+		if (difference >= 0) {
+			if (previousHeight === undefined) {
+				// First observation — jump to bottom instantly.
+				if (s.internalIsAtBottom) {
+					scrollTo(s, target);
+				}
+			} else if (s.internalIsAtBottom) {
+				// Content grew while locked — follow instantly.
+				scrollTo(s, target);
+			}
+		} else if (isNearBottom(s)) {
+			// Content shrank and we ended up near bottom — re-engage.
+			syncEscapedFromLock(false);
+			syncIsAtBottom(true);
+		}
+
+		s.previousContentHeight = currentHeight;
+
+		// Clear after rAF + setTimeout(1) so the scroll handler has
+		// a chance to see the resize flag before it resets.
+		const captured = s.resizeDifference;
+		requestAnimationFrame(() => {
+			setTimeout(() => {
+				if (s.resizeDifference === captured) {
+					s.resizeDifference = 0;
+				}
+			}, 1);
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// Ref callbacks
+	// -----------------------------------------------------------------------
+
+	const scrollRef = useEffectEvent((el: HTMLDivElement | null) => {
+		const s = stateRef.current;
+		const prev = s.scrollElement;
+
+		if (prev) {
+			prev.removeEventListener("scroll", handleScroll);
+			prev.removeEventListener("wheel", handleWheel);
+		}
+
+		s.scrollElement = el;
+
+		if (el) {
+			el.addEventListener("scroll", handleScroll, { passive: true });
+			el.addEventListener("wheel", handleWheel, { passive: true });
+		}
+	});
+
+	const contentRef = useEffectEvent((el: HTMLDivElement | null) => {
+		const s = stateRef.current;
+
+		if (s.resizeObserver) {
+			s.resizeObserver.disconnect();
+			s.resizeObserver = null;
+		}
+
+		s.contentElement = el;
+
+		if (el) {
+			const ro = new ResizeObserver(handleContentResize);
+			ro.observe(el);
+			s.resizeObserver = ro;
+		}
+	});
+
+	// -----------------------------------------------------------------------
+	// Mouse tracking (instance-scoped)
+	// -----------------------------------------------------------------------
+
+	useEffect(() => {
+		const s = stateRef.current;
+		const onDown = () => {
+			s.mouseDown = true;
+		};
+		const onUp = () => {
+			s.mouseDown = false;
+		};
+		document.addEventListener("mousedown", onDown);
+		document.addEventListener("mouseup", onUp);
+		document.addEventListener("click", onUp);
+		return () => {
+			document.removeEventListener("mousedown", onDown);
+			document.removeEventListener("mouseup", onUp);
+			document.removeEventListener("click", onUp);
+		};
+	}, []);
+
+	// Cleanup on unmount.
+	useEffect(() => {
+		return () => {
+			const s = stateRef.current;
+			if (s.scrollElement) {
+				s.scrollElement.removeEventListener("scroll", handleScroll);
+				s.scrollElement.removeEventListener("wheel", handleWheel);
+			}
+			if (s.resizeObserver) {
+				s.resizeObserver.disconnect();
+			}
+		};
+	}, [handleScroll, handleWheel]);
+
+	return {
+		scrollRef,
+		contentRef,
+		scrollToBottom,
+		isAtBottom: isAtBottom || nearBottom,
+	};
+}
+
+export { useStickToBottom };

--- a/site/src/pages/AgentsPage/components/StickToBottom.tsx
+++ b/site/src/pages/AgentsPage/components/StickToBottom.tsx
@@ -21,6 +21,7 @@ interface InternalState {
 	escapedFromLock: boolean;
 	internalIsAtBottom: boolean;
 	resizeObserver: ResizeObserver | null;
+	viewportObserver: ResizeObserver | null;
 	previousContentHeight: number | undefined;
 	mouseDown: boolean;
 }
@@ -85,6 +86,7 @@ function useStickToBottom(): StickToBottomInstance {
 		escapedFromLock: false,
 		internalIsAtBottom: true,
 		resizeObserver: null,
+		viewportObserver: null,
 		previousContentHeight: undefined,
 		mouseDown: false,
 	});
@@ -237,9 +239,28 @@ function useStickToBottom(): StickToBottomInstance {
 				if (s.internalIsAtBottom) {
 					scrollTo(s, target);
 				}
-			} else if (s.internalIsAtBottom) {
-				// Content grew while locked — follow instantly.
-				scrollTo(s, target);
+			} else {
+				// Check whether we were near the OLD bottom before
+				// this resize. We can't rely on internalIsAtBottom
+				// alone because scroll events fire during browser
+				// layout (before this ResizeObserver callback), and
+				// the handler may have disengaged the lock when it
+				// saw the scroll position was far from the new,
+				// taller bottom.
+				const prevMaxScroll = Math.max(
+					0,
+					previousHeight - s.scrollElement.clientHeight,
+				);
+				const wasAtBottom =
+					s.internalIsAtBottom ||
+					s.scrollElement.scrollTop >=
+						prevMaxScroll - STICK_TO_BOTTOM_OFFSET_PX;
+
+				if (wasAtBottom) {
+					scrollTo(s, target);
+					syncIsAtBottom(true);
+					syncEscapedFromLock(false);
+				}
 			}
 		} else if (isNearBottom(s)) {
 			// Content shrank and we ended up near bottom — re-engage.
@@ -261,6 +282,18 @@ function useStickToBottom(): StickToBottomInstance {
 		});
 	});
 
+	// When the scroll container's viewport dimensions change (e.g.
+	// the top bar gains elements after async data loads), maxScrollTop
+	// shifts and we may no longer be at the bottom. Re-pin if locked.
+	const handleViewportResize = useEffectEvent(() => {
+		const s = stateRef.current;
+		if (!s.scrollElement || !s.internalIsAtBottom) {
+			return;
+		}
+
+		scrollTo(s, maxScrollTop(s));
+	});
+
 	// -----------------------------------------------------------------------
 	// Ref callbacks
 	// -----------------------------------------------------------------------
@@ -274,11 +307,20 @@ function useStickToBottom(): StickToBottomInstance {
 			prev.removeEventListener("wheel", handleWheel);
 		}
 
+		if (s.viewportObserver) {
+			s.viewportObserver.disconnect();
+			s.viewportObserver = null;
+		}
+
 		s.scrollElement = el;
 
 		if (el) {
 			el.addEventListener("scroll", handleScroll, { passive: true });
 			el.addEventListener("wheel", handleWheel, { passive: true });
+
+			const vo = new ResizeObserver(handleViewportResize);
+			vo.observe(el);
+			s.viewportObserver = vo;
 		}
 	});
 
@@ -331,6 +373,9 @@ function useStickToBottom(): StickToBottomInstance {
 			}
 			if (s.resizeObserver) {
 				s.resizeObserver.disconnect();
+			}
+			if (s.viewportObserver) {
+				s.viewportObserver.disconnect();
 			}
 		};
 	}, [handleScroll, handleWheel]);


### PR DESCRIPTION
Replace the 686-line hand-rolled `ScrollAnchoredContainer` with a dedicated `useStickToBottom` hook (346 lines) that handles stick-to-bottom scroll behavior via ResizeObserver, passive scroll/wheel listeners, and text-selection detection.

The new `ChatScrollContainer` retains the IntersectionObserver sentinel for older message pagination and prepend scroll restoration, wiring them alongside the hook. `AgentChatPageView` drops from 1292 to 720 lines.

> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖