### PR TITLE
fix(site): use mock client model in sessions list view

### DIFF
--- a/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsPageView.stories.tsx
+++ b/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsPageView.stories.tsx
@@ -23,7 +23,7 @@ const defaultFilterProps = getDefaultFilterProps<FilterProps>({
 	menus: {
 		user: MockMenu,
 		provider: MockMenu,
-		model: MockMenu,
+		client: MockMenu,
 	},
 });
 


### PR DESCRIPTION
Missed this lil guy when adding the `<ClientFilter />` in #23733 