### PR TITLE
fix(site/src/api/queries): optimistically truncate cache on chat message edit

### DIFF
--- a/site/src/api/queries/chats.test.ts
+++ b/site/src/api/queries/chats.test.ts
@@ -778,23 +778,29 @@ describe("mutation invalidation scope", () => {
 		).toBe(true);
 	});
 
+	// Shared type for the infinite messages cache shape used by
+	// editChatMessage tests below.
+	type InfMessages = {
+		pages: TypesGen.ChatMessagesResponse[];
+		pageParams: (number | undefined)[];
+	};
+
+	const makeMsg = (chatId: string, id: number): TypesGen.ChatMessage => ({
+		id,
+		chat_id: chatId,
+		created_at: `2025-01-01T00:00:0${id}Z`,
+		role: "user" as const,
+		content: [{ type: "text" as const, text: `msg ${id}` }],
+	});
+
+	const editReq = {
+		content: [{ type: "text" as const, text: "edited" }],
+	};
+
 	it("editChatMessage optimistically removes truncated messages from cache", async () => {
 		const queryClient = createTestQueryClient();
 		const chatId = "chat-1";
-
-		// Seed the infinite messages cache with 5 messages (desc order).
-		const messages: TypesGen.ChatMessage[] = [5, 4, 3, 2, 1].map((id) => ({
-			id,
-			chat_id: chatId,
-			created_at: `2025-01-0${id}T00:00:00Z`,
-			role: "user" as const,
-			content: [{ type: "text" as const, text: `msg ${id}` }],
-		}));
-
-		type InfMessages = {
-			pages: TypesGen.ChatMessagesResponse[];
-			pageParams: (number | undefined)[];
-		};
+		const messages = [5, 4, 3, 2, 1].map((id) => makeMsg(chatId, id));
 
 		queryClient.setQueryData<InfMessages>(chatMessagesKey(chatId), {
 			pages: [{ messages, queued_messages: [], has_more: false }],
@@ -802,38 +808,20 @@ describe("mutation invalidation scope", () => {
 		});
 
 		const mutation = editChatMessage(queryClient, chatId);
-
-		// Invoke onMutate — this should optimistically truncate messages >= 3.
 		const context = await mutation.onMutate({
 			messageId: 3,
-			req: { content: [{ type: "text", text: "edited" }] },
+			req: editReq,
 		});
 
-		// Cache should only contain messages with id < 3.
 		const data = queryClient.getQueryData<InfMessages>(chatMessagesKey(chatId));
-		const remainingIds = data?.pages[0]?.messages.map((m) => m.id);
-		expect(remainingIds).toEqual([2, 1]);
-
-		// Context should contain the previous data for rollback.
+		expect(data?.pages[0]?.messages.map((m) => m.id)).toEqual([2, 1]);
 		expect(context?.previousData?.pages[0]?.messages).toHaveLength(5);
 	});
 
 	it("editChatMessage restores cache on error", async () => {
 		const queryClient = createTestQueryClient();
 		const chatId = "chat-1";
-
-		const messages: TypesGen.ChatMessage[] = [5, 4, 3, 2, 1].map((id) => ({
-			id,
-			chat_id: chatId,
-			created_at: `2025-01-0${id}T00:00:00Z`,
-			role: "user" as const,
-			content: [{ type: "text" as const, text: `msg ${id}` }],
-		}));
-
-		type InfMessages = {
-			pages: TypesGen.ChatMessagesResponse[];
-			pageParams: (number | undefined)[];
-		};
+		const messages = [5, 4, 3, 2, 1].map((id) => makeMsg(chatId, id));
 
 		queryClient.setQueryData<InfMessages>(chatMessagesKey(chatId), {
 			pages: [{ messages, queued_messages: [], has_more: false }],
@@ -841,45 +829,102 @@ describe("mutation invalidation scope", () => {
 		});
 
 		const mutation = editChatMessage(queryClient, chatId);
-
-		// Optimistically truncate.
 		const context = await mutation.onMutate({
 			messageId: 3,
-			req: { content: [{ type: "text", text: "edited" }] },
+			req: editReq,
 		});
 
-		// Verify truncation happened.
-		let data = queryClient.getQueryData<InfMessages>(chatMessagesKey(chatId));
-		expect(data?.pages[0]?.messages).toHaveLength(2);
+		expect(
+			queryClient.getQueryData<InfMessages>(chatMessagesKey(chatId))?.pages[0]
+				?.messages,
+		).toHaveLength(2);
 
-		// Simulate error — onError should restore the original data.
 		mutation.onError(
 			new Error("network failure"),
-			{ messageId: 3, req: { content: [{ type: "text", text: "edited" }] } },
+			{ messageId: 3, req: editReq },
 			context,
 		);
 
-		// Cache should be fully restored.
-		data = queryClient.getQueryData<InfMessages>(chatMessagesKey(chatId));
-		const restoredIds = data?.pages[0]?.messages.map((m) => m.id);
-		expect(restoredIds).toEqual([5, 4, 3, 2, 1]);
+		const data = queryClient.getQueryData<InfMessages>(chatMessagesKey(chatId));
+		expect(data?.pages[0]?.messages.map((m) => m.id)).toEqual([5, 4, 3, 2, 1]);
 	});
 
 	it("editChatMessage onMutate is a no-op when cache is empty", async () => {
 		const queryClient = createTestQueryClient();
 		const chatId = "chat-1";
 
-		// Don't seed the cache — it should be undefined.
 		const mutation = editChatMessage(queryClient, chatId);
 		const context = await mutation.onMutate({
 			messageId: 3,
-			req: { content: [{ type: "text", text: "edited" }] },
+			req: editReq,
 		});
 
-		// previousData should be undefined since nothing was cached.
 		expect(context.previousData).toBeUndefined();
-		// Cache should still be undefined — no crash.
 		expect(queryClient.getQueryData(chatMessagesKey(chatId))).toBeUndefined();
+	});
+
+	it("editChatMessage onMutate filters across multiple pages", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+
+		// Page 0 (newest): IDs 10–6. Page 1 (older): IDs 5–1.
+		const page0 = [10, 9, 8, 7, 6].map((id) => makeMsg(chatId, id));
+		const page1 = [5, 4, 3, 2, 1].map((id) => makeMsg(chatId, id));
+
+		queryClient.setQueryData<InfMessages>(chatMessagesKey(chatId), {
+			pages: [
+				{ messages: page0, queued_messages: [], has_more: true },
+				{ messages: page1, queued_messages: [], has_more: false },
+			],
+			pageParams: [undefined, 6],
+		});
+
+		const mutation = editChatMessage(queryClient, chatId);
+		await mutation.onMutate({ messageId: 7, req: editReq });
+
+		const data = queryClient.getQueryData<InfMessages>(chatMessagesKey(chatId));
+		// Page 0: only ID 6 survives (< 7).
+		expect(data?.pages[0]?.messages.map((m) => m.id)).toEqual([6]);
+		// Page 1: all survive (all < 7).
+		expect(data?.pages[1]?.messages.map((m) => m.id)).toEqual([5, 4, 3, 2, 1]);
+	});
+
+	it("editChatMessage onMutate editing the first message empties all pages", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		const messages = [5, 4, 3, 2, 1].map((id) => makeMsg(chatId, id));
+
+		queryClient.setQueryData<InfMessages>(chatMessagesKey(chatId), {
+			pages: [{ messages, queued_messages: [], has_more: false }],
+			pageParams: [undefined],
+		});
+
+		const mutation = editChatMessage(queryClient, chatId);
+		await mutation.onMutate({ messageId: 1, req: editReq });
+
+		const data = queryClient.getQueryData<InfMessages>(chatMessagesKey(chatId));
+		// All messages have id >= 1, so the page is empty.
+		expect(data?.pages[0]?.messages).toHaveLength(0);
+		// Sibling fields survive the spread.
+		expect(data?.pages[0]?.queued_messages).toEqual([]);
+		expect(data?.pages[0]?.has_more).toBe(false);
+	});
+
+	it("editChatMessage onMutate editing the latest message keeps earlier ones", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		const messages = [5, 4, 3, 2, 1].map((id) => makeMsg(chatId, id));
+
+		queryClient.setQueryData<InfMessages>(chatMessagesKey(chatId), {
+			pages: [{ messages, queued_messages: [], has_more: false }],
+			pageParams: [undefined],
+		});
+
+		const mutation = editChatMessage(queryClient, chatId);
+		await mutation.onMutate({ messageId: 5, req: editReq });
+
+		const data = queryClient.getQueryData<InfMessages>(chatMessagesKey(chatId));
+		expect(data?.pages[0]?.messages.map((m) => m.id)).toEqual([4, 3, 2, 1]);
 	});
 
 	it("interruptChat does not invalidate unrelated queries", async () => {

--- a/site/src/api/queries/chats.test.ts
+++ b/site/src/api/queries/chats.test.ts
@@ -778,6 +778,93 @@ describe("mutation invalidation scope", () => {
 		).toBe(true);
 	});
 
+	it("editChatMessage optimistically removes truncated messages from cache", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+
+		// Seed the infinite messages cache with 5 messages (desc order).
+		const messages: TypesGen.ChatMessage[] = [5, 4, 3, 2, 1].map((id) => ({
+			id,
+			chat_id: chatId,
+			created_at: `2025-01-0${id}T00:00:00Z`,
+			role: "user" as const,
+			content: [{ type: "text" as const, text: `msg ${id}` }],
+		}));
+
+		type InfData = {
+			pages: TypesGen.ChatMessagesResponse[];
+			pageParams: (number | undefined)[];
+		};
+
+		queryClient.setQueryData<InfData>(chatMessagesKey(chatId), {
+			pages: [{ messages, queued_messages: [], has_more: false }],
+			pageParams: [undefined],
+		});
+
+		const mutation = editChatMessage(queryClient, chatId);
+
+		// Invoke onMutate — this should optimistically truncate messages >= 3.
+		const context = await mutation.onMutate!({
+			messageId: 3,
+			req: { content: [{ type: "text", text: "edited" }] },
+		});
+
+		// Cache should only contain messages with id < 3.
+		const data = queryClient.getQueryData<InfData>(chatMessagesKey(chatId));
+		const remainingIds = data?.pages[0]?.messages.map((m) => m.id);
+		expect(remainingIds).toEqual([2, 1]);
+
+		// Context should contain the previous data for rollback.
+		expect(context?.previousData?.pages[0]?.messages).toHaveLength(5);
+	});
+
+	it("editChatMessage restores cache on error", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+
+		const messages: TypesGen.ChatMessage[] = [5, 4, 3, 2, 1].map((id) => ({
+			id,
+			chat_id: chatId,
+			created_at: `2025-01-0${id}T00:00:00Z`,
+			role: "user" as const,
+			content: [{ type: "text" as const, text: `msg ${id}` }],
+		}));
+
+		type InfData = {
+			pages: TypesGen.ChatMessagesResponse[];
+			pageParams: (number | undefined)[];
+		};
+
+		queryClient.setQueryData<InfData>(chatMessagesKey(chatId), {
+			pages: [{ messages, queued_messages: [], has_more: false }],
+			pageParams: [undefined],
+		});
+
+		const mutation = editChatMessage(queryClient, chatId);
+
+		// Optimistically truncate.
+		const context = await mutation.onMutate!({
+			messageId: 3,
+			req: { content: [{ type: "text", text: "edited" }] },
+		});
+
+		// Verify truncation happened.
+		let data = queryClient.getQueryData<InfData>(chatMessagesKey(chatId));
+		expect(data?.pages[0]?.messages).toHaveLength(2);
+
+		// Simulate error — onError should restore the original data.
+		mutation.onError!(
+			new Error("network failure"),
+			{ messageId: 3, req: { content: [{ type: "text", text: "edited" }] } },
+			context,
+		);
+
+		// Cache should be fully restored.
+		data = queryClient.getQueryData<InfData>(chatMessagesKey(chatId));
+		const restoredIds = data?.pages[0]?.messages.map((m) => m.id);
+		expect(restoredIds).toEqual([5, 4, 3, 2, 1]);
+	});
+
 	it("interruptChat does not invalidate unrelated queries", async () => {
 		const queryClient = createTestQueryClient();
 		const chatId = "chat-1";

--- a/site/src/api/queries/chats.test.ts
+++ b/site/src/api/queries/chats.test.ts
@@ -788,7 +788,7 @@ describe("mutation invalidation scope", () => {
 	const makeMsg = (chatId: string, id: number): TypesGen.ChatMessage => ({
 		id,
 		chat_id: chatId,
-		created_at: `2025-01-01T00:00:0${id}Z`,
+		created_at: `2025-01-01T00:00:${String(id).padStart(2, "0")}Z`,
 		role: "user" as const,
 		content: [{ type: "text" as const, text: `msg ${id}` }],
 	});
@@ -861,6 +861,31 @@ describe("mutation invalidation scope", () => {
 
 		expect(context.previousData).toBeUndefined();
 		expect(queryClient.getQueryData(chatMessagesKey(chatId))).toBeUndefined();
+	});
+
+	it("editChatMessage onError handles undefined context gracefully", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		const messages = [3, 2, 1].map((id) => makeMsg(chatId, id));
+
+		queryClient.setQueryData<InfMessages>(chatMessagesKey(chatId), {
+			pages: [{ messages, queued_messages: [], has_more: false }],
+			pageParams: [undefined],
+		});
+
+		const mutation = editChatMessage(queryClient, chatId);
+
+		// Pass undefined context — simulates onMutate throwing before
+		// it could return a snapshot.
+		mutation.onError(
+			new Error("fail"),
+			{ messageId: 2, req: editReq },
+			undefined,
+		);
+
+		// Cache should be untouched — no crash, no corruption.
+		const data = queryClient.getQueryData<InfMessages>(chatMessagesKey(chatId));
+		expect(data?.pages[0]?.messages.map((m) => m.id)).toEqual([3, 2, 1]);
 	});
 
 	it("editChatMessage onMutate filters across multiple pages", async () => {

--- a/site/src/api/queries/chats.test.ts
+++ b/site/src/api/queries/chats.test.ts
@@ -741,7 +741,7 @@ describe("mutation invalidation scope", () => {
 		seedAllActiveQueries(queryClient, chatId);
 
 		const mutation = editChatMessage(queryClient, chatId);
-		mutation.onSuccess();
+		mutation.onSettled();
 
 		await new Promise((r) => setTimeout(r, 0));
 
@@ -760,7 +760,7 @@ describe("mutation invalidation scope", () => {
 		seedAllActiveQueries(queryClient, chatId);
 
 		const mutation = editChatMessage(queryClient, chatId);
-		mutation.onSuccess();
+		mutation.onSettled();
 
 		await new Promise((r) => setTimeout(r, 0));
 

--- a/site/src/api/queries/chats.test.ts
+++ b/site/src/api/queries/chats.test.ts
@@ -791,12 +791,12 @@ describe("mutation invalidation scope", () => {
 			content: [{ type: "text" as const, text: `msg ${id}` }],
 		}));
 
-		type InfData = {
+		type InfMessages = {
 			pages: TypesGen.ChatMessagesResponse[];
 			pageParams: (number | undefined)[];
 		};
 
-		queryClient.setQueryData<InfData>(chatMessagesKey(chatId), {
+		queryClient.setQueryData<InfMessages>(chatMessagesKey(chatId), {
 			pages: [{ messages, queued_messages: [], has_more: false }],
 			pageParams: [undefined],
 		});
@@ -804,13 +804,13 @@ describe("mutation invalidation scope", () => {
 		const mutation = editChatMessage(queryClient, chatId);
 
 		// Invoke onMutate — this should optimistically truncate messages >= 3.
-		const context = await mutation.onMutate!({
+		const context = await mutation.onMutate({
 			messageId: 3,
 			req: { content: [{ type: "text", text: "edited" }] },
 		});
 
 		// Cache should only contain messages with id < 3.
-		const data = queryClient.getQueryData<InfData>(chatMessagesKey(chatId));
+		const data = queryClient.getQueryData<InfMessages>(chatMessagesKey(chatId));
 		const remainingIds = data?.pages[0]?.messages.map((m) => m.id);
 		expect(remainingIds).toEqual([2, 1]);
 
@@ -830,12 +830,12 @@ describe("mutation invalidation scope", () => {
 			content: [{ type: "text" as const, text: `msg ${id}` }],
 		}));
 
-		type InfData = {
+		type InfMessages = {
 			pages: TypesGen.ChatMessagesResponse[];
 			pageParams: (number | undefined)[];
 		};
 
-		queryClient.setQueryData<InfData>(chatMessagesKey(chatId), {
+		queryClient.setQueryData<InfMessages>(chatMessagesKey(chatId), {
 			pages: [{ messages, queued_messages: [], has_more: false }],
 			pageParams: [undefined],
 		});
@@ -843,26 +843,43 @@ describe("mutation invalidation scope", () => {
 		const mutation = editChatMessage(queryClient, chatId);
 
 		// Optimistically truncate.
-		const context = await mutation.onMutate!({
+		const context = await mutation.onMutate({
 			messageId: 3,
 			req: { content: [{ type: "text", text: "edited" }] },
 		});
 
 		// Verify truncation happened.
-		let data = queryClient.getQueryData<InfData>(chatMessagesKey(chatId));
+		let data = queryClient.getQueryData<InfMessages>(chatMessagesKey(chatId));
 		expect(data?.pages[0]?.messages).toHaveLength(2);
 
 		// Simulate error — onError should restore the original data.
-		mutation.onError!(
+		mutation.onError(
 			new Error("network failure"),
 			{ messageId: 3, req: { content: [{ type: "text", text: "edited" }] } },
 			context,
 		);
 
 		// Cache should be fully restored.
-		data = queryClient.getQueryData<InfData>(chatMessagesKey(chatId));
+		data = queryClient.getQueryData<InfMessages>(chatMessagesKey(chatId));
 		const restoredIds = data?.pages[0]?.messages.map((m) => m.id);
 		expect(restoredIds).toEqual([5, 4, 3, 2, 1]);
+	});
+
+	it("editChatMessage onMutate is a no-op when cache is empty", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+
+		// Don't seed the cache — it should be undefined.
+		const mutation = editChatMessage(queryClient, chatId);
+		const context = await mutation.onMutate({
+			messageId: 3,
+			req: { content: [{ type: "text", text: "edited" }] },
+		});
+
+		// previousData should be undefined since nothing was cached.
+		expect(context.previousData).toBeUndefined();
+		// Cache should still be undefined — no crash.
+		expect(queryClient.getQueryData(chatMessagesKey(chatId))).toBeUndefined();
 	});
 
 	it("interruptChat does not invalidate unrelated queries", async () => {

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -620,12 +620,13 @@ export const editChatMessage = (queryClient: QueryClient, chatId: string) => ({
 			queryClient.setQueryData(chatMessagesKey(chatId), context.previousData);
 		}
 	},
-	onSuccess: () => {
-		// Editing truncates all messages after the edited one on
-		// the server. A full refetch confirms the server state and
-		// picks up the replacement message. Use exact matching to
-		// avoid cascading to unrelated queries (diff-status,
-		// diff-contents, cost summaries, etc.).
+	onSettled: () => {
+		// Always reconcile with the server regardless of whether
+		// the mutation succeeded or failed. On success this picks
+		// up the replacement message; on failure it confirms the
+		// restore from onError matches the server state. Use exact
+		// matching to avoid cascading to unrelated queries
+		// (diff-status, diff-contents, cost summaries, etc.).
 		void queryClient.invalidateQueries({
 			queryKey: chatKey(chatId),
 			exact: true,

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -1,4 +1,8 @@
-import type { QueryClient, UseInfiniteQueryOptions } from "react-query";
+import type {
+	InfiniteData,
+	QueryClient,
+	UseInfiniteQueryOptions,
+} from "react-query";
 import { API } from "#/api/api";
 import type * as TypesGen from "#/api/typesGenerated";
 
@@ -563,12 +567,65 @@ type EditChatMessageMutationArgs = {
 export const editChatMessage = (queryClient: QueryClient, chatId: string) => ({
 	mutationFn: ({ messageId, req }: EditChatMessageMutationArgs) =>
 		API.experimental.editChatMessage(chatId, messageId, req),
+	onMutate: async ({ messageId }: EditChatMessageMutationArgs) => {
+		// Cancel in-flight refetches so they don't overwrite the
+		// optimistic update before the mutation completes.
+		await queryClient.cancelQueries({
+			queryKey: chatMessagesKey(chatId),
+			exact: true,
+		});
+
+		const previousData = queryClient.getQueryData<
+			InfiniteData<TypesGen.ChatMessagesResponse>
+		>(chatMessagesKey(chatId));
+
+		// Optimistically remove the edited message and everything
+		// after it. The server soft-deletes these and inserts a
+		// replacement with a new ID. Without this, the WebSocket
+		// handler's upsertCacheMessages adds new messages to the
+		// React Query cache without removing the soft-deleted ones,
+		// causing deleted messages to flash back into view until
+		// the full REST refetch resolves.
+		queryClient.setQueryData<
+			InfiniteData<TypesGen.ChatMessagesResponse> | undefined
+		>(chatMessagesKey(chatId), (current) => {
+			if (!current?.pages?.length) {
+				return current;
+			}
+			return {
+				...current,
+				pages: current.pages.map((page) => ({
+					...page,
+					messages: page.messages.filter((m) => m.id < messageId),
+				})),
+			};
+		});
+
+		return { previousData };
+	},
+	onError: (
+		_error: unknown,
+		_variables: EditChatMessageMutationArgs,
+		context:
+			| {
+					previousData?:
+						| InfiniteData<TypesGen.ChatMessagesResponse>
+						| undefined;
+			  }
+			| undefined,
+	) => {
+		// Restore the cache on failure so the user sees the
+		// original messages again.
+		if (context?.previousData) {
+			queryClient.setQueryData(chatMessagesKey(chatId), context.previousData);
+		}
+	},
 	onSuccess: () => {
-		// Editing truncates all messages after the edited one on the
-		// server. The WebSocket can insert/update messages but cannot
-		// remove stale ones, so a full messages refetch is required.
-		// Use exact matching to avoid cascading to unrelated queries
-		// (diff-status, diff-contents, cost summaries, etc.).
+		// Editing truncates all messages after the edited one on
+		// the server. A full refetch confirms the server state and
+		// picks up the replacement message. Use exact matching to
+		// avoid cascading to unrelated queries (diff-status,
+		// diff-contents, cost summaries, etc.).
 		void queryClient.invalidateQueries({
 			queryKey: chatKey(chatId),
 			exact: true,


### PR DESCRIPTION
When editing a non-latest message, the server soft-deletes the edited message and all subsequent messages. The WebSocket delivers the replacement message via `upsertCacheMessages`, but that function only adds/updates — it never removes soft-deleted entries from the React Query cache. The sync effect sees all store IDs present in the polluted cache, merges instead of replacing, and deleted messages flash back into view until the REST refetch lands.

Add an `onMutate` handler to `editChatMessage` that optimistically removes the edited message and everything after it from the cache before the HTTP request fires. This keeps the cache clean when WebSocket events arrive, so the sync effect's `hasStaleEntries` check works correctly from the start. `onError` restores the previous cache on mutation failure.

<details><summary>Implementation notes</summary>

### Root cause trace

1. `editChatMessage.onSuccess` fires `void invalidateQueries()` — REST refetch starts in background.
2. Server's `publishEditedMessage` sends the replacement message over WebSocket with `FullRefresh`.
3. Client's `handleMessage` → `upsertCacheMessages` adds the new message to the React Query cache without removing soft-deleted messages 102–104.
4. Cache = `[100, 101, 102, 103, 104, 105]` — polluted with deleted entries.
5. Sync effect: `fetchedIDs` includes all IDs → `hasStaleEntries = false` → merges instead of replacing → deleted messages visible.
6. REST refetch resolves → `hasStaleEntries = true` → `replaceMessages` → correct state.

### Why `onMutate` fixes it

- Runs synchronously when `mutateAsync()` is called, before the HTTP request.
- Cache is truncated to messages before the edit point → no deleted messages.
- Sync effect fires → `hasStaleEntries = true` → `replaceMessages` cleans the store immediately.
- WebSocket delivers replacement into clean cache → no pollution.
- REST refetch confirms final state.

### Decision: `onMutate` vs suppressing `upsertCacheMessages`

Considered adding an `editInFlightRef` to suppress `upsertCacheMessages` during the edit window, but `onMutate` is simpler (single-file change, uses React Query's built-in optimistic update pattern, automatic rollback via `onError`) and sufficient because the FullRefresh DB catchup only returns non-deleted messages (`deleted = false` in the SQL query).

</details>

> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖