### PR TITLE
fix(coderd/x/chatd): gate control subscriber to ignore stale pubsub notifications

### DIFF
--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -3487,7 +3487,25 @@ func (p *Server) processChat(ctx context.Context, chat database.Chat) {
 	chatCtx, cancel := context.WithCancelCause(ctx)
 	defer cancel(nil)
 
-	controlCancel := p.subscribeChatControl(chatCtx, chat.ID, cancel, logger)
+	// Gate the control subscriber behind a channel that is closed
+	// after we publish "running" status. This prevents stale
+	// pubsub notifications (e.g. the "pending" notification from
+	// SendMessage that triggered this processing) from
+	// interrupting us before we start work. Due to async
+	// PostgreSQL NOTIFY delivery, a notification published before
+	// subscribeChatControl registers its queue can still arrive
+	// after registration.
+	controlArmed := make(chan struct{})
+	gatedCancel := func(cause error) {
+		select {
+		case <-controlArmed:
+			cancel(cause)
+		default:
+			logger.Debug(ctx, "ignoring control notification before armed")
+		}
+	}
+
+	controlCancel := p.subscribeChatControl(chatCtx, chat.ID, gatedCancel, logger)
 	defer func() {
 		if controlCancel != nil {
 			controlCancel()
@@ -3547,6 +3565,12 @@ func (p *Server) processChat(ctx context.Context, chat database.Chat) {
 		UUID:  p.workerID,
 		Valid: true,
 	})
+
+	// Arm the control subscriber. Closing the channel is a
+	// happens-before guarantee in the Go memory model — any
+	// notification dispatched after this point will correctly
+	// interrupt processing.
+	close(controlArmed)
 
 	// Determine the final status and last error to set when we're done.
 	status := database.ChatStatusWaiting

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -2019,132 +2019,94 @@ func chatMessageWithParts(parts []codersdk.ChatMessagePart) database.ChatMessage
 	}
 }
 
-// TestGatedControlCancel verifies the channel-based gate used by
-// processChat to ignore stale pubsub notifications that arrive
-// before the processor has finished initializing.
-func TestGatedControlCancel(t *testing.T) {
+// TestProcessChat_IgnoresStaleControlNotification verifies that
+// processChat is not interrupted by a "pending" notification
+// published before processing begins. This is the race that caused
+// TestOpenAIReasoningWithWebSearchRoundTripStoreFalse to flake:
+// SendMessage publishes "pending" via PostgreSQL NOTIFY, and due
+// to async delivery the notification can arrive at the control
+// subscriber after it registers but before the processor publishes
+// "running".
+func TestProcessChat_IgnoresStaleControlNotification(t *testing.T) {
 	t.Parallel()
 
-	t.Run("IgnoredBeforeArmed", func(t *testing.T) {
-		t.Parallel()
+	ctx := testutil.Context(t, testutil.WaitShort)
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+	ps := dbpubsub.NewInMemory()
+	clock := quartz.NewMock(t)
 
-		ctx, cancel := context.WithCancelCause(context.Background())
-		defer cancel(nil)
+	chatID := uuid.New()
+	workerID := uuid.New()
 
-		controlArmed := make(chan struct{})
-		gatedCancel := func(cause error) {
-			select {
-			case <-controlArmed:
-				cancel(cause)
-			default:
-			}
-		}
+	server := &Server{
+		db:                    db,
+		logger:                logger,
+		pubsub:                ps,
+		clock:                 clock,
+		workerID:              workerID,
+		chatHeartbeatInterval: time.Minute,
+		configCache:           newChatConfigCache(ctx, db, clock),
+	}
 
-		// Simulate a stale "pending" notification arriving before
-		// the gate is armed. This mirrors the race where
-		// SendMessage's pubsub notification is dispatched after
-		// the control subscriber registers its queue.
-		notify := coderdpubsub.ChatStreamNotifyMessage{
-			Status: string(database.ChatStatusPending),
-		}
-		workerID := uuid.New()
-		if shouldCancelChatFromControlNotification(notify, workerID) {
-			gatedCancel(xerrors.New("stale pending"))
-		}
-
-		// The context must still be alive — the gate blocked the cancel.
-		require.NoError(t, ctx.Err(),
-			"stale notification must not cancel before the gate is armed")
+	// Publish a stale "pending" notification on the control channel
+	// BEFORE processChat subscribes. In production this is the
+	// notification from SendMessage that triggered the processing.
+	staleNotify, err := json.Marshal(coderdpubsub.ChatStreamNotifyMessage{
+		Status: string(database.ChatStatusPending),
 	})
+	require.NoError(t, err)
+	err = ps.Publish(coderdpubsub.ChatStreamNotifyChannel(chatID), staleNotify)
+	require.NoError(t, err)
 
-	t.Run("AllowedAfterArmed", func(t *testing.T) {
-		t.Parallel()
+	// Track which status processChat writes during cleanup.
+	var finalStatus database.ChatStatus
+	cleanupDone := make(chan struct{})
 
-		ctx, cancel := context.WithCancelCause(context.Background())
-		defer cancel(nil)
+	// The deferred cleanup in processChat runs a transaction.
+	db.EXPECT().InTx(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(fn func(database.Store) error, _ *database.TxOptions) error {
+			return fn(db)
+		},
+	)
+	db.EXPECT().GetChatByIDForUpdate(gomock.Any(), chatID).Return(
+		database.Chat{ID: chatID, Status: database.ChatStatusRunning, WorkerID: uuid.NullUUID{UUID: workerID, Valid: true}}, nil,
+	)
+	db.EXPECT().UpdateChatStatus(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, params database.UpdateChatStatusParams) (database.Chat, error) {
+			finalStatus = params.Status
+			close(cleanupDone)
+			return database.Chat{ID: chatID, Status: params.Status}, nil
+		},
+	)
 
-		controlArmed := make(chan struct{})
-		gatedCancel := func(cause error) {
-			select {
-			case <-controlArmed:
-				cancel(cause)
-			default:
-			}
-		}
+	// resolveChatModel fails immediately — that's fine, we only
+	// need processChat to get past initialization without being
+	// interrupted by the stale notification.
+	db.EXPECT().GetChatModelConfigByID(gomock.Any(), gomock.Any()).Return(
+		database.ChatModelConfig{}, xerrors.New("no model configured"),
+	).AnyTimes()
+	db.EXPECT().GetEnabledChatProviders(gomock.Any()).Return(nil, nil).AnyTimes()
+	db.EXPECT().GetEnabledChatModelConfigs(gomock.Any()).Return(nil, nil).AnyTimes()
+	db.EXPECT().GetChatUsageLimitConfig(gomock.Any()).Return(
+		database.ChatUsageLimitConfig{}, sql.ErrNoRows,
+	).AnyTimes()
+	db.EXPECT().GetChatMessagesForPromptByChatID(gomock.Any(), chatID).Return(nil, nil).AnyTimes()
 
-		// Arm the gate (simulates publishStatus("running") having
-		// completed).
-		close(controlArmed)
+	chat := database.Chat{ID: chatID, LastModelConfigID: uuid.New()}
+	go server.processChat(ctx, chat)
 
-		// A "waiting" notification after arming should interrupt.
-		notify := coderdpubsub.ChatStreamNotifyMessage{
-			Status: string(database.ChatStatusWaiting),
-		}
-		workerID := uuid.New()
-		if shouldCancelChatFromControlNotification(notify, workerID) {
-			gatedCancel(xerrors.New("interrupted"))
-		}
+	select {
+	case <-cleanupDone:
+	case <-ctx.Done():
+		t.Fatal("processChat did not complete")
+	}
 
-		require.ErrorIs(t, ctx.Err(), context.Canceled,
-			"notification after arming must cancel the context")
-	})
-
-	t.Run("RunningFromSameWorkerIgnored", func(t *testing.T) {
-		t.Parallel()
-
-		ctx, cancel := context.WithCancelCause(context.Background())
-		defer cancel(nil)
-
-		controlArmed := make(chan struct{})
-		close(controlArmed)
-		gatedCancel := func(cause error) {
-			select {
-			case <-controlArmed:
-				cancel(cause)
-			default:
-			}
-		}
-
-		workerID := uuid.New()
-		notify := coderdpubsub.ChatStreamNotifyMessage{
-			Status:   string(database.ChatStatusRunning),
-			WorkerID: workerID.String(),
-		}
-		if shouldCancelChatFromControlNotification(notify, workerID) {
-			gatedCancel(xerrors.New("same worker running"))
-		}
-
-		require.NoError(t, ctx.Err(),
-			"running notification from the same worker must not cancel")
-	})
-
-	t.Run("RunningFromDifferentWorkerCancels", func(t *testing.T) {
-		t.Parallel()
-
-		ctx, cancel := context.WithCancelCause(context.Background())
-		defer cancel(nil)
-
-		controlArmed := make(chan struct{})
-		close(controlArmed)
-		gatedCancel := func(cause error) {
-			select {
-			case <-controlArmed:
-				cancel(cause)
-			default:
-			}
-		}
-
-		workerID := uuid.New()
-		otherWorkerID := uuid.New()
-		notify := coderdpubsub.ChatStreamNotifyMessage{
-			Status:   string(database.ChatStatusRunning),
-			WorkerID: otherWorkerID.String(),
-		}
-		if shouldCancelChatFromControlNotification(notify, workerID) {
-			gatedCancel(xerrors.New("different worker took over"))
-		}
-
-		require.ErrorIs(t, ctx.Err(), context.Canceled,
-			"running notification from a different worker must cancel")
-	})
+	// If the stale notification interrupted us, status would be
+	// "waiting" (the ErrInterrupted path). Since the gate blocked
+	// it, processChat reached runChat, which failed on model
+	// resolution → status is "error".
+	require.Equal(t, database.ChatStatusError, finalStatus,
+		"processChat should have reached runChat (error), not been interrupted (waiting)")
 }

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -2018,3 +2018,133 @@ func chatMessageWithParts(parts []codersdk.ChatMessagePart) database.ChatMessage
 		Content: pqtype.NullRawMessage{RawMessage: raw, Valid: true},
 	}
 }
+
+// TestGatedControlCancel verifies the channel-based gate used by
+// processChat to ignore stale pubsub notifications that arrive
+// before the processor has finished initializing.
+func TestGatedControlCancel(t *testing.T) {
+	t.Parallel()
+
+	t.Run("IgnoredBeforeArmed", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancelCause(context.Background())
+		defer cancel(nil)
+
+		controlArmed := make(chan struct{})
+		gatedCancel := func(cause error) {
+			select {
+			case <-controlArmed:
+				cancel(cause)
+			default:
+			}
+		}
+
+		// Simulate a stale "pending" notification arriving before
+		// the gate is armed. This mirrors the race where
+		// SendMessage's pubsub notification is dispatched after
+		// the control subscriber registers its queue.
+		notify := coderdpubsub.ChatStreamNotifyMessage{
+			Status: string(database.ChatStatusPending),
+		}
+		workerID := uuid.New()
+		if shouldCancelChatFromControlNotification(notify, workerID) {
+			gatedCancel(xerrors.New("stale pending"))
+		}
+
+		// The context must still be alive — the gate blocked the cancel.
+		require.NoError(t, ctx.Err(),
+			"stale notification must not cancel before the gate is armed")
+	})
+
+	t.Run("AllowedAfterArmed", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancelCause(context.Background())
+		defer cancel(nil)
+
+		controlArmed := make(chan struct{})
+		gatedCancel := func(cause error) {
+			select {
+			case <-controlArmed:
+				cancel(cause)
+			default:
+			}
+		}
+
+		// Arm the gate (simulates publishStatus("running") having
+		// completed).
+		close(controlArmed)
+
+		// A "waiting" notification after arming should interrupt.
+		notify := coderdpubsub.ChatStreamNotifyMessage{
+			Status: string(database.ChatStatusWaiting),
+		}
+		workerID := uuid.New()
+		if shouldCancelChatFromControlNotification(notify, workerID) {
+			gatedCancel(xerrors.New("interrupted"))
+		}
+
+		require.ErrorIs(t, ctx.Err(), context.Canceled,
+			"notification after arming must cancel the context")
+	})
+
+	t.Run("RunningFromSameWorkerIgnored", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancelCause(context.Background())
+		defer cancel(nil)
+
+		controlArmed := make(chan struct{})
+		close(controlArmed)
+		gatedCancel := func(cause error) {
+			select {
+			case <-controlArmed:
+				cancel(cause)
+			default:
+			}
+		}
+
+		workerID := uuid.New()
+		notify := coderdpubsub.ChatStreamNotifyMessage{
+			Status:   string(database.ChatStatusRunning),
+			WorkerID: workerID.String(),
+		}
+		if shouldCancelChatFromControlNotification(notify, workerID) {
+			gatedCancel(xerrors.New("same worker running"))
+		}
+
+		require.NoError(t, ctx.Err(),
+			"running notification from the same worker must not cancel")
+	})
+
+	t.Run("RunningFromDifferentWorkerCancels", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancelCause(context.Background())
+		defer cancel(nil)
+
+		controlArmed := make(chan struct{})
+		close(controlArmed)
+		gatedCancel := func(cause error) {
+			select {
+			case <-controlArmed:
+				cancel(cause)
+			default:
+			}
+		}
+
+		workerID := uuid.New()
+		otherWorkerID := uuid.New()
+		notify := coderdpubsub.ChatStreamNotifyMessage{
+			Status:   string(database.ChatStatusRunning),
+			WorkerID: otherWorkerID.String(),
+		}
+		if shouldCancelChatFromControlNotification(notify, workerID) {
+			gatedCancel(xerrors.New("different worker took over"))
+		}
+
+		require.ErrorIs(t, ctx.Err(), context.Canceled,
+			"running notification from a different worker must cancel")
+	})
+}


### PR DESCRIPTION
Fixes flaky `TestOpenAIReasoningWithWebSearchRoundTripStoreFalse` and `TestOpenAIReasoningWithWebSearchRoundTrip`.

## Changes

- Gate the `processChat` control subscriber's cancel callback behind a `chan struct{}` that is closed after publishing `"running"` status
- Add `TestGatedControlCancel` with 4 subtests exercising the gate logic

<details>
<summary>Root cause analysis</summary>

`SendMessage` publishes a `"pending"` notification on `chat:stream:<chatID>` via PostgreSQL `NOTIFY`. `processChat` subscribes to the same channel for control signals. Due to async NOTIFY delivery, the `"pending"` notification can arrive at the control subscriber **after** it registers its queue — even though it was published **before**. `shouldCancelChatFromControlNotification("pending")` returns `true`, immediately self-interrupting the processor before it does any work.

The fix gates the cancel callback behind a closed channel. The channel is closed after `processChat` publishes `"running"` status, so stale notifications from before initialization are harmlessly ignored. `close()` provides a happens-before guarantee in the Go memory model.
</details>

> 🤖 Written by a Coder Agent. Will be reviewed by a human.