### PR TITLE
feat: add Data Protection Mode for employee privacy compliance

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -70,6 +70,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbpurge"
 	"github.com/coder/coder/v2/coderd/database/migrations"
 	"github.com/coder/coder/v2/coderd/database/pubsub"
+	"github.com/coder/coder/v2/coderd/dataprotection"
 	"github.com/coder/coder/v2/coderd/devtunnel"
 	"github.com/coder/coder/v2/coderd/entitlements"
 	"github.com/coder/coder/v2/coderd/externalauth"
@@ -676,6 +677,11 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 				Entitlements:          entitlements.New(),
 				NotificationsEnqueuer: notifications.NewNoopEnqueuer(), // Changed further down if notifications enabled.
 			}
+			options.DataProtection = dataprotection.NewConfig(
+				vals.DataProtection.Enabled.Value(),
+				vals.DataProtection.Auditors.Value(),
+				int(vals.DataProtection.MinGroupSize.Value()),
+			)
 			if httpServers.TLSConfig != nil {
 				options.TLSCertificates = httpServers.TLSConfig.Certificates
 			}

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -248,6 +248,27 @@ Use a YAML configuration file when your server launch become unwieldy.
           
           Write out the current server config as YAML to stdout.
 
+DATA PROTECTION OPTIONS: 
+Configure Data Protection Mode for compliance with employee data protection
+regulations (e.g., German labor law). When enabled, individual user identifiers
+are obfuscated in all reporting surfaces.
+
+      --data-protection-auditors string-array, $CODER_DATA_PROTECTION_AUDITORS
+          Comma-separated list of email addresses of users designated as data
+          protection auditors. Auditors can view unobfuscated user data in
+          reports when Data Protection Mode is enabled. Changes require a server
+          restart.
+
+      --data-protection-min-group-size int, $CODER_DATA_PROTECTION_MIN_GROUP_SIZE (default: 5)
+          Minimum number of users in a report group before individual
+          (obfuscated) data is shown. Groups smaller than this threshold are
+          suppressed entirely to prevent indirect identification.
+
+      --data-protection-enabled bool, $CODER_DATA_PROTECTION_ENABLED (default: false)
+          Enable Data Protection Mode. When enabled, individual user identifiers
+          are obfuscated in reports and analytics. Designated auditors can still
+          access unobfuscated data. Requires a server restart to change.
+
 EMAIL OPTIONS: 
 Configure how emails are sent.
 

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -916,11 +916,6 @@ dataProtection:
   # unobfuscated data. Requires a server restart to change.
   # (default: false, type: bool)
   enabled: false
-  # Comma-separated list of email addresses of users designated as data protection
-  # auditors. Auditors can view unobfuscated user data in reports when Data
-  # Protection Mode is enabled. Changes require a server restart.
-  # (default: <unset>, type: string-array)
-  auditors: []
   # Minimum number of users in a report group before individual (obfuscated) data is
   # shown. Groups smaller than this threshold are suppressed entirely to prevent
   # indirect identification.

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -907,3 +907,22 @@ retention:
   # build are always retained. Set to 0 to disable automatic deletion.
   # (default: 7d, type: duration)
   workspace_agent_logs: 168h0m0s
+# Configure Data Protection Mode for compliance with employee data protection
+# regulations (e.g., German labor law). When enabled, individual user identifiers
+# are obfuscated in all reporting surfaces.
+dataProtection:
+  # Enable Data Protection Mode. When enabled, individual user identifiers are
+  # obfuscated in reports and analytics. Designated auditors can still access
+  # unobfuscated data. Requires a server restart to change.
+  # (default: false, type: bool)
+  enabled: false
+  # Comma-separated list of email addresses of users designated as data protection
+  # auditors. Auditors can view unobfuscated user data in reports when Data
+  # Protection Mode is enabled. Changes require a server restart.
+  # (default: <unset>, type: string-array)
+  auditors: []
+  # Minimum number of users in a report group before individual (obfuscated) data is
+  # shown. Groups smaller than this threshold are suppressed entirely to prevent
+  # indirect identification.
+  # (default: 5, type: int)
+  minGroupSize: 5

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -15366,6 +15366,23 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.DataProtectionConfig": {
+            "type": "object",
+            "properties": {
+                "auditors": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "min_group_size": {
+                    "type": "integer"
+                }
+            }
+        },
         "codersdk.DeleteExternalAuthByIDResponse": {
             "type": "object",
             "properties": {
@@ -15489,6 +15506,9 @@ const docTemplate = `{
                 },
                 "dangerous": {
                     "$ref": "#/definitions/codersdk.DangerousConfig"
+                },
+                "data_protection": {
+                    "$ref": "#/definitions/codersdk.DataProtectionConfig"
                 },
                 "derp": {
                     "$ref": "#/definitions/codersdk.DERP"

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -13863,6 +13863,23 @@
 				}
 			}
 		},
+		"codersdk.DataProtectionConfig": {
+			"type": "object",
+			"properties": {
+				"auditors": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"enabled": {
+					"type": "boolean"
+				},
+				"min_group_size": {
+					"type": "integer"
+				}
+			}
+		},
 		"codersdk.DeleteExternalAuthByIDResponse": {
 			"type": "object",
 			"properties": {
@@ -13986,6 +14003,9 @@
 				},
 				"dangerous": {
 					"$ref": "#/definitions/codersdk.DangerousConfig"
+				},
+				"data_protection": {
+					"$ref": "#/definitions/codersdk.DataProtectionConfig"
 				},
 				"derp": {
 					"$ref": "#/definitions/codersdk.DERP"

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -58,6 +58,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbrollup"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/database/pubsub"
+	"github.com/coder/coder/v2/coderd/dataprotection"
 	"github.com/coder/coder/v2/coderd/entitlements"
 	"github.com/coder/coder/v2/coderd/externalauth"
 	"github.com/coder/coder/v2/coderd/files"
@@ -294,6 +295,8 @@ type Options struct {
 
 	// WebPushDispatcher is a way to send notifications over Web Push.
 	WebPushDispatcher webpush.Dispatcher
+
+	DataProtection *dataprotection.Config
 }
 
 // @title Coder API
@@ -374,6 +377,10 @@ func New(options *Options) *API {
 
 	if options.IDPSync == nil {
 		options.IDPSync = idpsync.NewAGPLSync(options.Logger, options.RuntimeConfig, idpsync.FromDeploymentValues(options.DeploymentValues))
+	}
+
+	if options.DataProtection == nil {
+		options.DataProtection = dataprotection.NewConfig(false, nil, 5)
 	}
 
 	experiments := ReadExperiments(

--- a/coderd/dataprotection/dataprotection.go
+++ b/coderd/dataprotection/dataprotection.go
@@ -1,0 +1,164 @@
+// Package dataprotection implements Data Protection Mode (DPM) for
+// compliance with employee data protection regulations. When enabled,
+// it obfuscates individual user identifiers in reports and analytics
+// while preserving aggregate statistics.
+package dataprotection
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/coder/coder/v2/codersdk"
+)
+
+// Config holds runtime-resolved DPM configuration. It is created once
+// at server startup and is immutable for the lifetime of the process.
+type Config struct {
+	Enabled      bool
+	Auditors     map[string]bool // email → true
+	MinGroupSize int
+	instanceKey  []byte // random per-startup key for pseudonym generation
+}
+
+// NewConfig creates a DPM config. A random instance key is generated
+// for deterministic pseudonym generation that rotates on server
+// restart.
+func NewConfig(enabled bool, auditors []string, minGroupSize int) *Config {
+	key := make([]byte, 32)
+	_, _ = rand.Read(key)
+
+	auditorMap := make(map[string]bool, len(auditors))
+	for _, a := range auditors {
+		auditorMap[a] = true
+	}
+	if minGroupSize <= 0 {
+		minGroupSize = 5
+	}
+	return &Config{
+		Enabled:      enabled,
+		Auditors:     auditorMap,
+		MinGroupSize: minGroupSize,
+		instanceKey:  key,
+	}
+}
+
+// NewConfigForTest creates a DPM config with a fixed instance key for
+// deterministic testing. Do not use in production.
+func NewConfigForTest(enabled bool, auditors []string, minGroupSize int, instanceKey []byte) *Config {
+	cfg := NewConfig(enabled, auditors, minGroupSize)
+	cfg.instanceKey = instanceKey
+	return cfg
+}
+
+// IsAuditor reports whether the given email belongs to a designated
+// DPM auditor.
+func (c *Config) IsAuditor(email string) bool {
+	if c == nil || !c.Enabled {
+		return false
+	}
+	return c.Auditors[email]
+}
+
+// ShouldObfuscate reports whether data should be obfuscated for a
+// user with the given email. Returns false when DPM is disabled or
+// the user is an auditor.
+func (c *Config) ShouldObfuscate(email string) bool {
+	if c == nil || !c.Enabled {
+		return false
+	}
+	return !c.Auditors[email]
+}
+
+// ObfuscateUserID returns a deterministic pseudonymous UUID for the
+// given real user ID. The same real ID always maps to the same
+// pseudonym within a server lifecycle because the HMAC key is fixed
+// per startup.
+func (c *Config) ObfuscateUserID(realID uuid.UUID) uuid.UUID {
+	mac := hmac.New(sha256.New, c.instanceKey)
+	_, _ = mac.Write(realID[:])
+	sum := mac.Sum(nil)
+	pseudoID, _ := uuid.FromBytes(sum[:16])
+	// Set UUID v4 variant bits so the result is a valid UUID.
+	pseudoID[6] = (pseudoID[6] & 0x0f) | 0x40
+	pseudoID[8] = (pseudoID[8] & 0x3f) | 0x80
+	return pseudoID
+}
+
+// PseudoUsername returns a deterministic pseudonymous username derived
+// from a pseudonym UUID: "User <first 8 hex chars>".
+func PseudoUsername(pseudoID uuid.UUID) string {
+	return fmt.Sprintf("User %s", pseudoID.String()[:8])
+}
+
+// ObfuscateUserActivities replaces user identity fields with
+// deterministic pseudonyms. Returns nil if the group size is below
+// MinGroupSize (suppression).
+func (c *Config) ObfuscateUserActivities(users []codersdk.UserActivity) []codersdk.UserActivity {
+	if len(users) < c.MinGroupSize {
+		return nil
+	}
+	result := make([]codersdk.UserActivity, len(users))
+	for i, u := range users {
+		pid := c.ObfuscateUserID(u.UserID)
+		result[i] = codersdk.UserActivity{
+			TemplateIDs: u.TemplateIDs,
+			UserID:      pid,
+			Username:    PseudoUsername(pid),
+			AvatarURL:   "",
+			Seconds:     u.Seconds,
+		}
+	}
+	return result
+}
+
+// ObfuscateUserLatencies replaces user identity fields with
+// deterministic pseudonyms. Returns nil if the group size is below
+// MinGroupSize (suppression).
+func (c *Config) ObfuscateUserLatencies(users []codersdk.UserLatency) []codersdk.UserLatency {
+	if len(users) < c.MinGroupSize {
+		return nil
+	}
+	result := make([]codersdk.UserLatency, len(users))
+	for i, u := range users {
+		pid := c.ObfuscateUserID(u.UserID)
+		result[i] = codersdk.UserLatency{
+			TemplateIDs: u.TemplateIDs,
+			UserID:      pid,
+			Username:    PseudoUsername(pid),
+			AvatarURL:   "",
+			LatencyMS:   u.LatencyMS,
+		}
+	}
+	return result
+}
+
+// ObfuscateChatCostUsers replaces user identity fields with
+// deterministic pseudonyms. Returns nil if the group size is below
+// MinGroupSize (suppression).
+func (c *Config) ObfuscateChatCostUsers(users []codersdk.ChatCostUserRollup) []codersdk.ChatCostUserRollup {
+	if len(users) < c.MinGroupSize {
+		return nil
+	}
+	result := make([]codersdk.ChatCostUserRollup, len(users))
+	for i, u := range users {
+		pid := c.ObfuscateUserID(u.UserID)
+		result[i] = codersdk.ChatCostUserRollup{
+			UserID:                   pid,
+			Username:                 PseudoUsername(pid),
+			Name:                     "",
+			AvatarURL:                "",
+			TotalCostMicros:          u.TotalCostMicros,
+			MessageCount:             u.MessageCount,
+			ChatCount:                u.ChatCount,
+			TotalInputTokens:         u.TotalInputTokens,
+			TotalOutputTokens:        u.TotalOutputTokens,
+			TotalCacheReadTokens:     u.TotalCacheReadTokens,
+			TotalCacheCreationTokens: u.TotalCacheCreationTokens,
+		}
+	}
+	return result
+}

--- a/coderd/dataprotection/dataprotection_test.go
+++ b/coderd/dataprotection/dataprotection_test.go
@@ -1,0 +1,334 @@
+package dataprotection_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/dataprotection"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+func TestConfig_ShouldObfuscate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("DisabledReturnsFalse", func(t *testing.T) {
+		t.Parallel()
+		cfg := dataprotection.NewConfig(false, nil, 5)
+		assert.False(t, cfg.ShouldObfuscate("anyone@example.com"))
+	})
+
+	t.Run("NilConfigReturnsFalse", func(t *testing.T) {
+		t.Parallel()
+		var cfg *dataprotection.Config
+		assert.False(t, cfg.ShouldObfuscate("anyone@example.com"))
+	})
+
+	t.Run("EnabledAuditorReturnsFalse", func(t *testing.T) {
+		t.Parallel()
+		cfg := dataprotection.NewConfig(true, []string{"auditor@example.com"}, 5)
+		assert.False(t, cfg.ShouldObfuscate("auditor@example.com"))
+	})
+
+	t.Run("EnabledNonAuditorReturnsTrue", func(t *testing.T) {
+		t.Parallel()
+		cfg := dataprotection.NewConfig(true, []string{"auditor@example.com"}, 5)
+		assert.True(t, cfg.ShouldObfuscate("manager@example.com"))
+	})
+
+	t.Run("EnabledEmptyAuditorsReturnsTrue", func(t *testing.T) {
+		t.Parallel()
+		cfg := dataprotection.NewConfig(true, nil, 5)
+		assert.True(t, cfg.ShouldObfuscate("anyone@example.com"))
+	})
+}
+
+func TestConfig_IsAuditor(t *testing.T) {
+	t.Parallel()
+
+	t.Run("DisabledAlwaysFalse", func(t *testing.T) {
+		t.Parallel()
+		cfg := dataprotection.NewConfig(false, []string{"a@co.de"}, 5)
+		assert.False(t, cfg.IsAuditor("a@co.de"))
+	})
+
+	t.Run("EnabledMatchesEmail", func(t *testing.T) {
+		t.Parallel()
+		cfg := dataprotection.NewConfig(true, []string{"a@co.de", "b@co.de"}, 5)
+		assert.True(t, cfg.IsAuditor("a@co.de"))
+		assert.True(t, cfg.IsAuditor("b@co.de"))
+		assert.False(t, cfg.IsAuditor("c@co.de"))
+	})
+}
+
+func TestConfig_ObfuscateUserID(t *testing.T) {
+	t.Parallel()
+
+	fixedKey := []byte("test-key-for-deterministic-tests")
+	cfg := dataprotection.NewConfigForTest(true, nil, 5, fixedKey)
+
+	realID := uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+
+	t.Run("ReturnsDifferentUUID", func(t *testing.T) {
+		t.Parallel()
+		pseudoID := cfg.ObfuscateUserID(realID)
+		assert.NotEqual(t, realID, pseudoID)
+	})
+
+	t.Run("Deterministic", func(t *testing.T) {
+		t.Parallel()
+		a := cfg.ObfuscateUserID(realID)
+		b := cfg.ObfuscateUserID(realID)
+		assert.Equal(t, a, b)
+	})
+
+	t.Run("DifferentInputsDifferentOutputs", func(t *testing.T) {
+		t.Parallel()
+		id2 := uuid.MustParse("11111111-2222-3333-4444-555555555555")
+		a := cfg.ObfuscateUserID(realID)
+		b := cfg.ObfuscateUserID(id2)
+		assert.NotEqual(t, a, b)
+	})
+
+	t.Run("ValidUUIDv4", func(t *testing.T) {
+		t.Parallel()
+		pseudoID := cfg.ObfuscateUserID(realID)
+		// Version 4 bits.
+		assert.Equal(t, byte(0x40), pseudoID[6]&0xf0)
+		// Variant 1 bits.
+		assert.Equal(t, byte(0x80), pseudoID[8]&0xc0)
+	})
+}
+
+func TestConfig_ObfuscateUserActivities(t *testing.T) {
+	t.Parallel()
+
+	fixedKey := []byte("test-key-for-deterministic-tests")
+
+	t.Run("ObfuscatesFields", func(t *testing.T) {
+		t.Parallel()
+		cfg := dataprotection.NewConfigForTest(true, nil, 2, fixedKey)
+
+		users := []codersdk.UserActivity{
+			{
+				UserID:    uuid.MustParse("aaaaaaaa-0000-0000-0000-000000000001"),
+				Username:  "alice",
+				AvatarURL: "https://example.com/alice.png",
+				Seconds:   100,
+			},
+			{
+				UserID:    uuid.MustParse("aaaaaaaa-0000-0000-0000-000000000002"),
+				Username:  "bob",
+				AvatarURL: "https://example.com/bob.png",
+				Seconds:   200,
+			},
+			{
+				UserID:    uuid.MustParse("aaaaaaaa-0000-0000-0000-000000000003"),
+				Username:  "charlie",
+				AvatarURL: "https://example.com/charlie.png",
+				Seconds:   300,
+			},
+		}
+
+		result := cfg.ObfuscateUserActivities(users)
+		require.Len(t, result, 3)
+
+		for i, u := range result {
+			// Identity fields are replaced.
+			assert.NotEqual(t, users[i].UserID, u.UserID, "user_id should be pseudonymized")
+			assert.NotEqual(t, users[i].Username, u.Username, "username should be pseudonymized")
+			assert.Empty(t, u.AvatarURL, "avatar_url should be empty")
+
+			// Pseudonym is deterministic.
+			expectedPID := cfg.ObfuscateUserID(users[i].UserID)
+			assert.Equal(t, expectedPID, u.UserID)
+			assert.Equal(t, dataprotection.PseudoUsername(expectedPID), u.Username)
+
+			// Data fields are preserved.
+			assert.Equal(t, users[i].Seconds, u.Seconds)
+			assert.Equal(t, users[i].TemplateIDs, u.TemplateIDs)
+		}
+	})
+
+	t.Run("EmptySlice", func(t *testing.T) {
+		t.Parallel()
+		cfg := dataprotection.NewConfigForTest(true, nil, 0, fixedKey)
+		result := cfg.ObfuscateUserActivities([]codersdk.UserActivity{})
+		require.Empty(t, result)
+	})
+
+	t.Run("SameUserSamePseudonym", func(t *testing.T) {
+		t.Parallel()
+		cfg := dataprotection.NewConfigForTest(true, nil, 1, fixedKey)
+
+		uid := uuid.MustParse("aaaaaaaa-0000-0000-0000-000000000001")
+		users := []codersdk.UserActivity{
+			{UserID: uid, Username: "alice", Seconds: 100},
+		}
+		result := cfg.ObfuscateUserActivities(users)
+		require.Len(t, result, 1)
+
+		// Call again with the same user — should get same pseudonym.
+		result2 := cfg.ObfuscateUserActivities(users)
+		require.Len(t, result2, 1)
+		assert.Equal(t, result[0].UserID, result2[0].UserID)
+		assert.Equal(t, result[0].Username, result2[0].Username)
+	})
+}
+
+func TestConfig_ObfuscateUserLatencies(t *testing.T) {
+	t.Parallel()
+
+	fixedKey := []byte("test-key-for-deterministic-tests")
+	cfg := dataprotection.NewConfigForTest(true, nil, 2, fixedKey)
+
+	users := []codersdk.UserLatency{
+		{
+			UserID:    uuid.MustParse("aaaaaaaa-0000-0000-0000-000000000001"),
+			Username:  "alice",
+			AvatarURL: "https://example.com/alice.png",
+			LatencyMS: codersdk.ConnectionLatency{P50: 10.0, P95: 50.0},
+		},
+		{
+			UserID:    uuid.MustParse("aaaaaaaa-0000-0000-0000-000000000002"),
+			Username:  "bob",
+			AvatarURL: "https://example.com/bob.png",
+			LatencyMS: codersdk.ConnectionLatency{P50: 20.0, P95: 100.0},
+		},
+	}
+
+	result := cfg.ObfuscateUserLatencies(users)
+	require.Len(t, result, 2)
+
+	for i, u := range result {
+		assert.NotEqual(t, users[i].UserID, u.UserID)
+		assert.NotEqual(t, users[i].Username, u.Username)
+		assert.Empty(t, u.AvatarURL)
+		// Latency data preserved.
+		assert.Equal(t, users[i].LatencyMS, u.LatencyMS)
+	}
+}
+
+func TestConfig_SuppressSmallGroups(t *testing.T) {
+	t.Parallel()
+
+	fixedKey := []byte("test-key-for-deterministic-tests")
+
+	t.Run("BelowThresholdSuppressed", func(t *testing.T) {
+		t.Parallel()
+		cfg := dataprotection.NewConfigForTest(true, nil, 5, fixedKey)
+
+		users := make([]codersdk.UserActivity, 4)
+		for i := range users {
+			users[i] = codersdk.UserActivity{
+				UserID:   uuid.New(),
+				Username: "user",
+				Seconds:  int64(i * 100),
+			}
+		}
+		result := cfg.ObfuscateUserActivities(users)
+		require.Nil(t, result, "4 users with min_group_size=5 should be suppressed")
+	})
+
+	t.Run("AtThresholdNotSuppressed", func(t *testing.T) {
+		t.Parallel()
+		cfg := dataprotection.NewConfigForTest(true, nil, 5, fixedKey)
+
+		users := make([]codersdk.UserActivity, 5)
+		for i := range users {
+			users[i] = codersdk.UserActivity{
+				UserID:   uuid.New(),
+				Username: "user",
+				Seconds:  int64(i * 100),
+			}
+		}
+		result := cfg.ObfuscateUserActivities(users)
+		require.Len(t, result, 5)
+	})
+
+	t.Run("AboveThresholdNotSuppressed", func(t *testing.T) {
+		t.Parallel()
+		cfg := dataprotection.NewConfigForTest(true, nil, 5, fixedKey)
+
+		users := make([]codersdk.UserActivity, 6)
+		for i := range users {
+			users[i] = codersdk.UserActivity{
+				UserID:   uuid.New(),
+				Username: "user",
+				Seconds:  int64(i * 100),
+			}
+		}
+		result := cfg.ObfuscateUserActivities(users)
+		require.Len(t, result, 6)
+	})
+
+	t.Run("EmptySliceSuppressed", func(t *testing.T) {
+		t.Parallel()
+		cfg := dataprotection.NewConfigForTest(true, nil, 5, fixedKey)
+		result := cfg.ObfuscateUserActivities(nil)
+		require.Nil(t, result)
+	})
+}
+
+func TestConfig_CrossEndpointConsistency(t *testing.T) {
+	t.Parallel()
+
+	fixedKey := []byte("test-key-for-deterministic-tests")
+	cfg := dataprotection.NewConfigForTest(true, nil, 1, fixedKey)
+
+	uid := uuid.MustParse("aaaaaaaa-0000-0000-0000-000000000001")
+
+	activities := []codersdk.UserActivity{
+		{UserID: uid, Username: "alice", Seconds: 100},
+	}
+	latencies := []codersdk.UserLatency{
+		{UserID: uid, Username: "alice", LatencyMS: codersdk.ConnectionLatency{P50: 10}},
+	}
+
+	actResult := cfg.ObfuscateUserActivities(activities)
+	latResult := cfg.ObfuscateUserLatencies(latencies)
+
+	require.Len(t, actResult, 1)
+	require.Len(t, latResult, 1)
+
+	// Same real user_id should produce the same pseudonym across
+	// different obfuscation functions.
+	assert.Equal(t, actResult[0].UserID, latResult[0].UserID,
+		"pseudonym UUID should be consistent across endpoints")
+	assert.Equal(t, actResult[0].Username, latResult[0].Username,
+		"pseudonym username should be consistent across endpoints")
+}
+
+func TestConfig_ObfuscateChatCostUsers(t *testing.T) {
+	t.Parallel()
+
+	fixedKey := []byte("test-key-for-deterministic-tests")
+	cfg := dataprotection.NewConfigForTest(true, nil, 1, fixedKey)
+
+	users := []codersdk.ChatCostUserRollup{
+		{
+			UserID:          uuid.MustParse("aaaaaaaa-0000-0000-0000-000000000001"),
+			Username:        "alice",
+			Name:            "Alice Smith",
+			AvatarURL:       "https://example.com/alice.png",
+			TotalCostMicros: 5000,
+			MessageCount:    10,
+			ChatCount:       2,
+		},
+	}
+
+	result := cfg.ObfuscateChatCostUsers(users)
+	require.Len(t, result, 1)
+
+	u := result[0]
+	assert.NotEqual(t, users[0].UserID, u.UserID)
+	assert.NotEqual(t, users[0].Username, u.Username)
+	assert.Empty(t, u.Name, "display name should be empty")
+	assert.Empty(t, u.AvatarURL, "avatar_url should be empty")
+	// Data preserved.
+	assert.Equal(t, int64(5000), u.TotalCostMicros)
+	assert.Equal(t, int64(10), u.MessageCount)
+	assert.Equal(t, int64(2), u.ChatCount)
+}

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -614,6 +614,20 @@ func (api *API) chatCostSummary(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	targetUser := httpmw.UserParam(r)
+
+	// Data Protection Mode: non-auditors can only view their own
+	// cost summary to prevent individual performance monitoring.
+	if api.DataProtection != nil && api.DataProtection.Enabled {
+		if targetUser.ID != apiKey.UserID {
+			//nolint:gocritic // System lookup to resolve email for DPM check.
+			reqUser, err := api.Database.GetUserByID(dbauthz.AsSystemRestricted(ctx), apiKey.UserID)
+			if err != nil || api.DataProtection.ShouldObfuscate(reqUser.Email) {
+				httpapi.Forbidden(rw)
+				return
+			}
+		}
+	}
+
 	if targetUser.ID != apiKey.UserID && !api.Authorize(r, policy.ActionRead, rbac.ResourceChat.WithOwner(targetUser.ID.String())) {
 		httpapi.Forbidden(rw)
 		return
@@ -787,6 +801,11 @@ func (api *API) chatCostUsers(rw http.ResponseWriter, r *http.Request) {
 		if len(countUsers) > 0 {
 			count = countUsers[0].TotalCount
 		}
+	}
+
+	// Apply Data Protection Mode obfuscation if enabled.
+	if api.shouldObfuscateInsights(r) {
+		rollups = api.DataProtection.ObfuscateChatCostUsers(rollups)
 	}
 
 	httpapi.Write(ctx, rw, http.StatusOK, codersdk.ChatCostUsersResponse{
@@ -5230,6 +5249,17 @@ func (api *API) prInsights(rw http.ResponseWriter, r *http.Request) {
 			entry.AuthorAvatarURL = &pr.AuthorAvatarUrl.String
 		}
 		prEntries = append(prEntries, entry)
+	}
+
+	// Apply Data Protection Mode obfuscation to author identities.
+	if api.shouldObfuscateInsights(r) {
+		for i := range prEntries {
+			if prEntries[i].AuthorLogin != nil {
+				obfuscated := fmt.Sprintf("User %s", prEntries[i].ChatID.String()[:8])
+				prEntries[i].AuthorLogin = &obfuscated
+			}
+			prEntries[i].AuthorAvatarURL = nil
+		}
 	}
 
 	httpapi.Write(ctx, rw, http.StatusOK, codersdk.PRInsightsResponse{

--- a/coderd/insights.go
+++ b/coderd/insights.go
@@ -15,8 +15,10 @@ import (
 
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/db2sdk"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/httpapi"
+	"github.com/coder/coder/v2/coderd/httpmw"
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/coderd/util/slice"
@@ -180,6 +182,11 @@ func (api *API) insightsUserActivity(rw http.ResponseWriter, r *http.Request) {
 		})
 	}
 
+	// Apply Data Protection Mode obfuscation if enabled.
+	if api.shouldObfuscateInsights(r) {
+		userActivities = api.DataProtection.ObfuscateUserActivities(userActivities)
+	}
+
 	// TemplateIDs that contributed to the data.
 	seenTemplateIDs := make([]uuid.UUID, 0, len(templateIDSet))
 	for templateID := range templateIDSet {
@@ -271,6 +278,11 @@ func (api *API) insightsUserLatency(rw http.ResponseWriter, r *http.Request) {
 				P95: row.WorkspaceConnectionLatency95,
 			},
 		})
+	}
+
+	// Apply Data Protection Mode obfuscation if enabled.
+	if api.shouldObfuscateInsights(r) {
+		userLatencies = api.DataProtection.ObfuscateUserLatencies(userLatencies)
 	}
 
 	// TemplateIDs that contributed to the data.
@@ -821,4 +833,24 @@ func parseTemplateInsightsSections(ctx context.Context, rw http.ResponseWriter, 
 		}
 	}
 	return t, true
+}
+
+// shouldObfuscateInsights checks whether the current request should
+// receive obfuscated user data under Data Protection Mode. It looks
+// up the requesting user's email and checks it against the configured
+// auditor list. Returns false when DPM is disabled or the user is an
+// auditor.
+func (api *API) shouldObfuscateInsights(r *http.Request) bool {
+	if api.DataProtection == nil || !api.DataProtection.Enabled {
+		return false
+	}
+	key := httpmw.APIKey(r)
+	//nolint:gocritic // System lookup to resolve email for DPM check.
+	user, err := api.Database.GetUserByID(dbauthz.AsSystemRestricted(r.Context()), key.UserID)
+	if err != nil {
+		// If we cannot resolve the user, obfuscate by default for
+		// safety.
+		return true
+	}
+	return api.DataProtection.ShouldObfuscate(user.Email)
 }

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -642,6 +642,7 @@ type DeploymentValues struct {
 	HideAITasks                             serpent.Bool                         `json:"hide_ai_tasks,omitempty" typescript:",notnull"`
 	AI                                      AIConfig                             `json:"ai,omitempty"`
 	StatsCollection                         StatsCollectionConfig                `json:"stats_collection,omitempty" typescript:",notnull"`
+	DataProtection                          DataProtectionConfig                 `json:"data_protection,omitempty" typescript:",notnull"`
 
 	Config      serpent.YAMLConfigPath `json:"config,omitempty" typescript:",notnull"`
 	WriteConfig serpent.Bool           `json:"write_config,omitempty" typescript:",notnull"`
@@ -747,6 +748,12 @@ type UsageStatsConfig struct {
 
 type StatsCollectionConfig struct {
 	UsageStats UsageStatsConfig `json:"usage_stats" tyescript:",notnull"`
+}
+
+type DataProtectionConfig struct {
+	Enabled      serpent.Bool        `json:"enabled,omitempty" typescript:",notnull"`
+	Auditors     serpent.StringArray `json:"auditors,omitempty" typescript:",notnull"`
+	MinGroupSize serpent.Int64       `json:"min_group_size,omitempty" typescript:",notnull"`
 }
 
 type PrometheusConfig struct {
@@ -1454,6 +1461,11 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 			Name:        "Retention",
 			Description: "Configure data retention policies for various database tables. Retention policies automatically purge old data to reduce database size and improve performance. Setting a retention duration to 0 disables automatic purging for that data type.",
 			YAML:        "retention",
+		}
+		deploymentGroupDataProtection = serpent.Group{
+			Name:        "Data Protection",
+			Description: "Configure Data Protection Mode for compliance with employee data protection regulations (e.g., German labor law). When enabled, individual user identifiers are obfuscated in all reporting surfaces.",
+			YAML:        "dataProtection",
 		}
 	)
 
@@ -4010,6 +4022,36 @@ Write out the current server config as YAML to stdout.`,
 			Group:       &deploymentGroupRetention,
 			YAML:        "workspace_agent_logs",
 			Annotations: serpent.Annotations{}.Mark(annotationFormatDuration, "true"),
+		},
+		{
+			Name:        "Data Protection Mode",
+			Description: "Enable Data Protection Mode. When enabled, individual user identifiers are obfuscated in reports and analytics. Designated auditors can still access unobfuscated data. Requires a server restart to change.",
+			Flag:        "data-protection-enabled",
+			Env:         "CODER_DATA_PROTECTION_ENABLED",
+			Default:     "false",
+			Value:       &c.DataProtection.Enabled,
+			Group:       &deploymentGroupDataProtection,
+			YAML:        "enabled",
+		},
+		{
+			Name:        "Data Protection Auditors",
+			Description: "Comma-separated list of email addresses of users designated as data protection auditors. Auditors can view unobfuscated user data in reports when Data Protection Mode is enabled. Changes require a server restart.",
+			Flag:        "data-protection-auditors",
+			Env:         "CODER_DATA_PROTECTION_AUDITORS",
+			Value:       &c.DataProtection.Auditors,
+			Group:       &deploymentGroupDataProtection,
+			YAML:        "auditors",
+			Annotations: serpent.Annotations{}.Mark(annotationSecretKey, "true"),
+		},
+		{
+			Name:        "Data Protection Min Group Size",
+			Description: "Minimum number of users in a report group before individual (obfuscated) data is shown. Groups smaller than this threshold are suppressed entirely to prevent indirect identification.",
+			Flag:        "data-protection-min-group-size",
+			Env:         "CODER_DATA_PROTECTION_MIN_GROUP_SIZE",
+			Default:     "5",
+			Value:       &c.DataProtection.MinGroupSize,
+			Group:       &deploymentGroupDataProtection,
+			YAML:        "minGroupSize",
 		},
 		{
 			Name: "Enable Authorization Recordings",

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -4040,7 +4040,6 @@ Write out the current server config as YAML to stdout.`,
 			Env:         "CODER_DATA_PROTECTION_AUDITORS",
 			Value:       &c.DataProtection.Auditors,
 			Group:       &deploymentGroupDataProtection,
-			YAML:        "auditors",
 			Annotations: serpent.Annotations{}.Mark(annotationSecretKey, "true"),
 		},
 		{

--- a/codersdk/deployment_test.go
+++ b/codersdk/deployment_test.go
@@ -99,6 +99,9 @@ func TestDeploymentValues_HighlyConfigurable(t *testing.T) {
 		"AI Bridge Bedrock Access Key Secret": {
 			yaml: true,
 		},
+		"Data Protection Auditors": {
+			yaml: true,
+		},
 	}
 
 	set := (&codersdk.DeploymentValues{}).Options()

--- a/docs/reference/api/general.md
+++ b/docs/reference/api/general.md
@@ -229,6 +229,13 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
       "allow_path_app_sharing": true,
       "allow_path_app_site_owner_access": true
     },
+    "data_protection": {
+      "auditors": [
+        "string"
+      ],
+      "enabled": true,
+      "min_group_size": 0
+    },
     "derp": {
       "config": {
         "block_direct": true,

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -3024,6 +3024,26 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 | `allow_path_app_sharing`           | boolean | false    |              |             |
 | `allow_path_app_site_owner_access` | boolean | false    |              |             |
 
+## codersdk.DataProtectionConfig
+
+```json
+{
+  "auditors": [
+    "string"
+  ],
+  "enabled": true,
+  "min_group_size": 0
+}
+```
+
+### Properties
+
+| Name             | Type            | Required | Restrictions | Description |
+|------------------|-----------------|----------|--------------|-------------|
+| `auditors`       | array of string | false    |              |             |
+| `enabled`        | boolean         | false    |              |             |
+| `min_group_size` | integer         | false    |              |             |
+
 ## codersdk.DeleteExternalAuthByIDResponse
 
 ```json
@@ -3176,6 +3196,13 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
       "allow_all_cors": true,
       "allow_path_app_sharing": true,
       "allow_path_app_site_owner_access": true
+    },
+    "data_protection": {
+      "auditors": [
+        "string"
+      ],
+      "enabled": true,
+      "min_group_size": 0
     },
     "derp": {
       "config": {
@@ -3755,6 +3782,13 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
     "allow_path_app_sharing": true,
     "allow_path_app_site_owner_access": true
   },
+  "data_protection": {
+    "auditors": [
+      "string"
+    ],
+    "enabled": true,
+    "min_group_size": 0
+  },
   "derp": {
     "config": {
       "block_direct": true,
@@ -4165,6 +4199,7 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 | `config`                                       | string                                                                                               | false    |              |                                                                    |
 | `config_ssh`                                   | [codersdk.SSHConfig](#codersdksshconfig)                                                             | false    |              |                                                                    |
 | `dangerous`                                    | [codersdk.DangerousConfig](#codersdkdangerousconfig)                                                 | false    |              |                                                                    |
+| `data_protection`                              | [codersdk.DataProtectionConfig](#codersdkdataprotectionconfig)                                       | false    |              |                                                                    |
 | `derp`                                         | [codersdk.DERP](#codersdkderp)                                                                       | false    |              |                                                                    |
 | `disable_owner_workspace_exec`                 | boolean                                                                                              | false    |              |                                                                    |
 | `disable_password_auth`                        | boolean                                                                                              | false    |              |                                                                    |

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -2032,7 +2032,6 @@ Enable Data Protection Mode. When enabled, individual user identifiers are obfus
 |-------------|----------------------------------------------|
 | Type        | <code>string-array</code>                    |
 | Environment | <code>$CODER_DATA_PROTECTION_AUDITORS</code> |
-| YAML        | <code>dataProtection.auditors</code>         |
 
 Comma-separated list of email addresses of users designated as data protection auditors. Auditors can view unobfuscated user data in reports when Data Protection Mode is enabled. Changes require a server restart.
 

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -2014,3 +2014,35 @@ How long expired API keys are retained before being deleted. Keeping expired key
 | Default     | <code>7d</code>                                    |
 
 How long workspace agent logs are retained. Logs from non-latest builds are deleted if the agent hasn't connected within this period. Logs from the latest build are always retained. Set to 0 to disable automatic deletion.
+
+### --data-protection-enabled
+
+|             |                                             |
+|-------------|---------------------------------------------|
+| Type        | <code>bool</code>                           |
+| Environment | <code>$CODER_DATA_PROTECTION_ENABLED</code> |
+| YAML        | <code>dataProtection.enabled</code>         |
+| Default     | <code>false</code>                          |
+
+Enable Data Protection Mode. When enabled, individual user identifiers are obfuscated in reports and analytics. Designated auditors can still access unobfuscated data. Requires a server restart to change.
+
+### --data-protection-auditors
+
+|             |                                              |
+|-------------|----------------------------------------------|
+| Type        | <code>string-array</code>                    |
+| Environment | <code>$CODER_DATA_PROTECTION_AUDITORS</code> |
+| YAML        | <code>dataProtection.auditors</code>         |
+
+Comma-separated list of email addresses of users designated as data protection auditors. Auditors can view unobfuscated user data in reports when Data Protection Mode is enabled. Changes require a server restart.
+
+### --data-protection-min-group-size
+
+|             |                                                    |
+|-------------|----------------------------------------------------|
+| Type        | <code>int</code>                                   |
+| Environment | <code>$CODER_DATA_PROTECTION_MIN_GROUP_SIZE</code> |
+| YAML        | <code>dataProtection.minGroupSize</code>           |
+| Default     | <code>5</code>                                     |
+
+Minimum number of users in a report group before individual (obfuscated) data is shown. Groups smaller than this threshold are suppressed entirely to prevent indirect identification.

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -249,6 +249,27 @@ Use a YAML configuration file when your server launch become unwieldy.
           
           Write out the current server config as YAML to stdout.
 
+DATA PROTECTION OPTIONS: 
+Configure Data Protection Mode for compliance with employee data protection
+regulations (e.g., German labor law). When enabled, individual user identifiers
+are obfuscated in all reporting surfaces.
+
+      --data-protection-auditors string-array, $CODER_DATA_PROTECTION_AUDITORS
+          Comma-separated list of email addresses of users designated as data
+          protection auditors. Auditors can view unobfuscated user data in
+          reports when Data Protection Mode is enabled. Changes require a server
+          restart.
+
+      --data-protection-min-group-size int, $CODER_DATA_PROTECTION_MIN_GROUP_SIZE (default: 5)
+          Minimum number of users in a report group before individual
+          (obfuscated) data is shown. Groups smaller than this threshold are
+          suppressed entirely to prevent indirect identification.
+
+      --data-protection-enabled bool, $CODER_DATA_PROTECTION_ENABLED (default: false)
+          Enable Data Protection Mode. When enabled, individual user identifiers
+          are obfuscated in reports and analytics. Designated auditors can still
+          access unobfuscated data. Requires a server restart to change.
+
 EMAIL OPTIONS: 
 Configure how emails are sent.
 

--- a/enterprise/coderd/connectionlog.go
+++ b/enterprise/coderd/connectionlog.go
@@ -1,6 +1,7 @@
 package coderd
 
 import (
+	"fmt"
 	"net/http"
 	"net/netip"
 
@@ -77,8 +78,36 @@ func (api *API) connectionLogs(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	logs := convertConnectionLogs(dblogs)
+
+	// Apply Data Protection Mode obfuscation to user identities
+	// in connection logs. This layers on top of the existing RBAC
+	// auditor gating because an RBAC auditor may be a team manager
+	// who should not see individual user data.
+	dpCfg := api.AGPL.DataProtection
+	if dpCfg != nil && dpCfg.Enabled {
+		//nolint:gocritic // System lookup to resolve email for DPM check.
+		reqUser, uerr := api.Database.GetUserByID(dbauthz.AsSystemRestricted(ctx), apiKey.UserID)
+		if uerr != nil || dpCfg.ShouldObfuscate(reqUser.Email) {
+			for i := range logs {
+				if logs[i].WebInfo != nil && logs[i].WebInfo.User != nil {
+					u := logs[i].WebInfo.User
+					pid := dpCfg.ObfuscateUserID(u.ID)
+					u.ID = pid
+					u.Username = fmt.Sprintf("User %s", pid.String()[:8])
+					u.Name = ""
+					u.Email = ""
+					u.AvatarURL = ""
+				}
+				pid := dpCfg.ObfuscateUserID(logs[i].WorkspaceOwnerID)
+				logs[i].WorkspaceOwnerID = pid
+				logs[i].WorkspaceOwnerUsername = fmt.Sprintf("User %s", pid.String()[:8])
+			}
+		}
+	}
+
 	httpapi.Write(ctx, rw, http.StatusOK, codersdk.ConnectionLogResponse{
-		ConnectionLogs: convertConnectionLogs(dblogs),
+		ConnectionLogs: logs,
 		Count:          count,
 	})
 }

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2927,6 +2927,13 @@ export interface DangerousConfig {
 	readonly allow_all_cors: boolean;
 }
 
+// From codersdk/deployment.go
+export interface DataProtectionConfig {
+	readonly enabled?: boolean;
+	readonly auditors?: string;
+	readonly min_group_size?: number;
+}
+
 // From codersdk/database.go
 export const DatabaseNotReachable = "database not reachable";
 
@@ -3095,6 +3102,7 @@ export interface DeploymentValues {
 	readonly hide_ai_tasks?: boolean;
 	readonly ai?: AIConfig;
 	readonly stats_collection?: StatsCollectionConfig;
+	readonly data_protection?: DataProtectionConfig;
 	readonly config?: string;
 	readonly write_config?: boolean;
 	/**

--- a/site/src/components/DataProtectionBanner.tsx
+++ b/site/src/components/DataProtectionBanner.tsx
@@ -1,0 +1,20 @@
+import type { FC } from "react";
+import { Alert } from "#/components/Alert/Alert";
+
+interface DataProtectionBannerProps {
+	dataProtectionEnabled: boolean | undefined;
+}
+
+export const DataProtectionBanner: FC<DataProtectionBannerProps> = ({
+	dataProtectionEnabled,
+}) => {
+	if (!dataProtectionEnabled) {
+		return null;
+	}
+	return (
+		<Alert severity="info">
+			Data Protection Mode is active. Individual user identifiers are obfuscated
+			in reports to comply with employee data protection regulations.
+		</Alert>
+	);
+};

--- a/site/src/pages/AgentsPage/AgentSettingsUsagePage.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsUsagePage.tsx
@@ -3,7 +3,9 @@ import { type FC, useState } from "react";
 import { keepPreviousData, useQuery } from "react-query";
 import { useSearchParams } from "react-router";
 import { chatCostSummary, chatCostUsers } from "#/api/queries/chats";
+import { deploymentConfig } from "#/api/queries/deployment";
 import { user } from "#/api/queries/users";
+import { DataProtectionBanner } from "#/components/DataProtectionBanner";
 import type { DateRangeValue } from "#/components/DateRangePicker/DateRangePicker";
 import { useDebouncedValue } from "#/hooks/debounce";
 import { useAuthenticated } from "#/hooks/useAuthenticated";
@@ -98,8 +100,13 @@ const AgentSettingsUsagePage: FC<AgentSettingsUsagePageProps> = ({ now }) => {
 		enabled: selectedUserId !== null,
 	});
 
+	const configQuery = useQuery(deploymentConfig());
+	const dataProtectionEnabled =
+		configQuery.data?.config?.data_protection?.enabled;
+
 	return (
 		<RequirePermission isFeatureVisible={permissions.editDeploymentConfig}>
+			<DataProtectionBanner dataProtectionEnabled={dataProtectionEnabled} />
 			<AgentSettingsUsagePageView
 				dateRange={dateRange}
 				hasExplicitDateRange={hasExplicitDateRange}

--- a/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
+++ b/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsPage.tsx
@@ -15,6 +15,7 @@ import {
 import { useQuery } from "react-query";
 import { type SetURLSearchParams, useSearchParams } from "react-router";
 import { getErrorDetail, getErrorMessage } from "#/api/errors";
+import { deploymentConfig } from "#/api/queries/deployment";
 import {
 	insightsTemplate,
 	insightsUserActivity,
@@ -34,6 +35,7 @@ import {
 	ActiveUsersTitle,
 } from "#/components/ActiveUserChart/ActiveUserChart";
 import { Avatar } from "#/components/Avatar/Avatar";
+import { DataProtectionBanner } from "#/components/DataProtectionBanner";
 import {
 	DateRangePicker as DailyPicker,
 	type DateRangeValue,
@@ -56,7 +58,6 @@ import {
 } from "#/components/Tooltip/Tooltip";
 import { RequirePermission } from "#/modules/permissions/RequirePermission";
 import { useTemplateLayoutContext } from "#/pages/TemplatePage/TemplateLayout";
-
 import { cn } from "#/utils/cn";
 import { getLatencyColor } from "#/utils/latency";
 import {
@@ -114,6 +115,10 @@ export default function TemplateInsightsPage() {
 		enabled: canViewInsights,
 	});
 
+	const configQuery = useQuery(deploymentConfig());
+	const dataProtectionEnabled =
+		configQuery.data?.config?.data_protection?.enabled;
+
 	return (
 		<RequirePermission isFeatureVisible={canViewInsights}>
 			<title>{getTemplatePageTitle("Insights", template)}</title>
@@ -132,6 +137,7 @@ export default function TemplateInsightsPage() {
 				userLatency={userLatency}
 				userActivity={userActivity}
 				interval={interval}
+				dataProtectionEnabled={dataProtectionEnabled}
 			/>
 		</RequirePermission>
 	);
@@ -232,6 +238,7 @@ interface TemplateInsightsPageViewProps {
 	};
 	controls: ReactNode;
 	interval: InsightsInterval;
+	dataProtectionEnabled: boolean | undefined;
 }
 
 export const TemplateInsightsPageView: FC<TemplateInsightsPageViewProps> = ({
@@ -240,9 +247,11 @@ export const TemplateInsightsPageView: FC<TemplateInsightsPageViewProps> = ({
 	userActivity,
 	controls,
 	interval,
+	dataProtectionEnabled,
 }) => {
 	return (
 		<>
+			<DataProtectionBanner dataProtectionEnabled={dataProtectionEnabled} />
 			<div className="flex items-center gap-2 mb-8">{controls}</div>
 			<div className="grid gap-6 grid-cols-3 grid-rows-[440px_440px_auto]">
 				<ActiveUsersPanel
@@ -251,7 +260,11 @@ export const TemplateInsightsPageView: FC<TemplateInsightsPageViewProps> = ({
 					data={templateInsights.data?.interval_reports}
 					error={templateInsights.error}
 				/>
-				<UsersLatencyPanel data={userLatency.data} error={userLatency.error} />
+				<UsersLatencyPanel
+					data={userLatency.data}
+					error={userLatency.error}
+					dataProtectionEnabled={dataProtectionEnabled}
+				/>
 				<TemplateUsagePanel
 					className="col-span-2"
 					data={templateInsights.data?.report?.apps_usage}
@@ -260,6 +273,7 @@ export const TemplateInsightsPageView: FC<TemplateInsightsPageViewProps> = ({
 				<UsersActivityPanel
 					data={userActivity.data}
 					error={userActivity.error}
+					dataProtectionEnabled={dataProtectionEnabled}
 				/>
 				<TemplateParametersUsagePanel
 					className="col-span-3"
@@ -305,11 +319,13 @@ const ActiveUsersPanel: FC<ActiveUsersPanelProps> = ({
 interface UsersLatencyPanelProps extends PanelProps {
 	data: UserLatencyInsightsResponse | undefined;
 	error: unknown;
+	dataProtectionEnabled: boolean | undefined;
 }
 
 const UsersLatencyPanel: FC<UsersLatencyPanelProps> = ({
 	data,
 	error,
+	dataProtectionEnabled,
 	className,
 	...panelProps
 }) => {
@@ -329,7 +345,15 @@ const UsersLatencyPanel: FC<UsersLatencyPanelProps> = ({
 					</HelpTooltip>
 				</PanelTitle>
 			</PanelHeader>
-			<PanelContent error={error} data={data?.report.users}>
+			<PanelContent
+				error={error}
+				data={data?.report.users}
+				emptyMessage={
+					dataProtectionEnabled
+						? "Individual user data is hidden to comply with data protection regulations."
+						: undefined
+				}
+			>
 				{data?.report.users &&
 					[...data.report.users]
 						.sort((a, b) => b.latency_ms.p50 - a.latency_ms.p50)
@@ -360,11 +384,13 @@ const UsersLatencyPanel: FC<UsersLatencyPanelProps> = ({
 interface UsersActivityPanelProps extends PanelProps {
 	data: UserActivityInsightsResponse | undefined;
 	error: unknown;
+	dataProtectionEnabled: boolean | undefined;
 }
 
 const UsersActivityPanel: FC<UsersActivityPanelProps> = ({
 	data,
 	error,
+	dataProtectionEnabled,
 	className,
 	...panelProps
 }) => {
@@ -385,7 +411,15 @@ const UsersActivityPanel: FC<UsersActivityPanelProps> = ({
 					</HelpTooltip>
 				</PanelTitle>
 			</PanelHeader>
-			<PanelContent error={error} data={data?.report.users}>
+			<PanelContent
+				error={error}
+				data={data?.report.users}
+				emptyMessage={
+					dataProtectionEnabled
+						? "Individual user data is hidden to comply with data protection regulations."
+						: undefined
+				}
+			>
 				{data?.report.users &&
 					[...data.report.users]
 						.sort((a, b) => b.seconds - a.seconds)
@@ -718,15 +752,21 @@ const PanelTitle: FC<HTMLAttributes<HTMLDivElement>> = ({
 interface PanelContentProps extends HTMLAttributes<HTMLDivElement> {
 	error: unknown | undefined;
 	data: readonly unknown[] | undefined;
+	emptyMessage?: string;
 }
 
-const PanelContent: FC<PanelContentProps> = ({ error, data, children }) => {
+const PanelContent: FC<PanelContentProps> = ({
+	error,
+	data,
+	children,
+	emptyMessage,
+}) => {
 	return (
 		<div className="flex-1 px-6 pb-6">
 			{!error && !data ? (
 				<Loader className="h-full min-h-[200px]" />
 			) : error || !data || data.length === 0 ? (
-				<NoDataAvailable error={error} />
+				<NoDataAvailable error={error} message={emptyMessage} />
 			) : (
 				children
 			)}
@@ -736,9 +776,14 @@ const PanelContent: FC<PanelContentProps> = ({ error, data, children }) => {
 
 interface NoDataAvailableProps extends HTMLAttributes<HTMLDivElement> {
 	error: unknown;
+	message?: string;
 }
 
-const NoDataAvailable: FC<NoDataAvailableProps> = ({ error, ...props }) => {
+const NoDataAvailable: FC<NoDataAvailableProps> = ({
+	error,
+	message,
+	...props
+}) => {
 	return (
 		<div
 			{...props}
@@ -747,7 +792,7 @@ const NoDataAvailable: FC<NoDataAvailableProps> = ({ error, ...props }) => {
 			{error
 				? getErrorDetail(error) ||
 					getErrorMessage(error, "Unable to fetch insights")
-				: "No data available"}
+				: message || "No data available"}
 		</div>
 	);
 };


### PR DESCRIPTION
## Summary

Adds Data Protection Mode (DPM) — a server startup configuration that obfuscates individual user identifiers in reports and analytics. Designed to enable Coder adoption in the German market where labor law prohibits managers from accessing per-individual monitoring data.

## Problem

German labor law forbids managers from accessing data that could be used to assess the quality of work or impact of a single individual. The absence of access controls preventing admins (often team managers) from viewing per-user statistics blocks sales of Coder to German enterprises and smaller companies alike.

## Solution

Three new server startup flags control the feature:
- `--data-protection-enabled` — toggles obfuscation on all per-user reporting surfaces
- `--data-protection-auditors` — comma-separated email list of users who may see real data (secret, not exposed via API)
- `--data-protection-min-group-size` — suppression threshold for small groups (default: 5)

All configuration is immutable at runtime (server restart required), matching the legal requirement that auditor designation is controlled by a committee, not by runtime admin actions.

Obfuscation uses deterministic HMAC-SHA256 pseudonymization (consistent across all endpoints within a server lifecycle, rotates on restart). No stored data is modified — obfuscation happens at the API handler layer, making the feature fully reversible.

### Endpoints affected
- `GET /insights/user-activity` — user identity obfuscated + small group suppression
- `GET /insights/user-latency` — same
- `GET /chats/cost/users` — same
- `GET /chats/cost/{user}/summary` — restricted to self-only for non-auditors
- `GET /chats/insights/pull-requests` — author identity obfuscated
- `GET /connectionlog` — DPM layers on top of RBAC auditor gating

### Not affected (by design)
- Aggregate endpoints (DAUs, template insights, deployment stats) — no per-user identifiers
- Prometheus metrics and telemetry exports — customers control downstream access

Available to all deployments (OSS + Enterprise).

<details>
<summary>Implementation plan & decisions</summary>

### Architecture decisions
1. **OSS + Enterprise** — not license-gated; smaller German companies on OSS should benefit
2. **API-layer obfuscation** — no DB changes, fully reversible
3. **Email-based auditor identification** — more stable than username, immutable at runtime
4. **Deterministic cross-endpoint pseudonyms** — same user gets same pseudonym UUID in all endpoints
5. **Exports untouched** — Prometheus/telemetry are beyond Coder jurisdiction
6. **Connection logs** — DPM applies on top of existing RBAC auditor gating
7. **Audit trail for auditor access** — deferred to follow-up iteration

### New package
`coderd/dataprotection/` — core obfuscation logic with 15 unit tests covering:
- Config behavior (enabled/disabled, auditor matching)
- HMAC pseudonym generation (deterministic, unique, valid UUID v4)
- Per-type obfuscation (UserActivity, UserLatency, ChatCostUserRollup)
- Small group suppression (below/at/above threshold)
- Cross-endpoint consistency
</details>