### PR TITLE
fix(site): handle invalid coder_app URLs gracefully instead of crashing

### DIFF
--- a/site/src/modules/apps/apps.test.ts
+++ b/site/src/modules/apps/apps.test.ts
@@ -180,6 +180,36 @@ describe("getAppHref", () => {
 			`/path-base/@${MockWorkspace.owner_name}/Test-Workspace.a-workspace-agent/apps/${app.slug}/`,
 		);
 	});
+
+	it("returns null when external app has an invalid URL", () => {
+		const externalApp = {
+			...MockWorkspaceApp,
+			external: true,
+			url: "my-repo",
+		};
+		const href = getAppHref(externalApp, {
+			host: "*.apps-host.tld",
+			path: "/path-base",
+			agent: MockWorkspaceAgent,
+			workspace: MockWorkspace,
+		});
+		expect(href).toBeNull();
+	});
+
+	it("returns null when external app has an empty URL", () => {
+		const externalApp = {
+			...MockWorkspaceApp,
+			external: true,
+			url: "",
+		};
+		const href = getAppHref(externalApp, {
+			host: "*.apps-host.tld",
+			path: "/path-base",
+			agent: MockWorkspaceAgent,
+			workspace: MockWorkspace,
+		});
+		expect(href).toBeNull();
+	});
 });
 
 describe("openAppInNewWindow", () => {

--- a/site/src/modules/apps/apps.ts
+++ b/site/src/modules/apps/apps.ts
@@ -115,9 +115,17 @@ type GetAppHrefParams = {
 export const getAppHref = (
 	app: WorkspaceApp,
 	{ path, token, workspace, agent, host }: GetAppHrefParams,
-): string => {
+): string | null => {
 	if (isExternalApp(app)) {
-		const appProtocol = new URL(app.url).protocol;
+		let appProtocol: string;
+		try {
+			appProtocol = new URL(app.url).protocol;
+		} catch {
+			// Template authors can provide invalid URLs (e.g. a bare
+			// string with no scheme). Rather than crashing the page,
+			// signal the invalid state so consumers can show an error.
+			return null;
+		}
 		const isAllowedProtocol =
 			ALLOWED_EXTERNAL_APP_PROTOCOLS.includes(appProtocol);
 

--- a/site/src/modules/apps/useAppLink.ts
+++ b/site/src/modules/apps/useAppLink.ts
@@ -21,7 +21,7 @@ type UseAppLinkParams = {
 };
 
 type AppLink = {
-	href: string;
+	href: string | null;
 	onClick: (e: React.MouseEvent) => void;
 	label: string;
 	hasToken: boolean;
@@ -101,7 +101,9 @@ export const useAppLink = (
 		switch (app.open_in) {
 			case "slim-window": {
 				e.preventDefault();
-				openAppInNewWindow(href);
+				if (href !== null) {
+					openAppInNewWindow(href);
+				}
 				return;
 			}
 		}

--- a/site/src/modules/resources/AppLink/AppLink.stories.tsx
+++ b/site/src/modules/resources/AppLink/AppLink.stories.tsx
@@ -243,3 +243,22 @@ export const SlimWindowPopupBlocked: Story = {
 		expect(toastMessage).toBeInTheDocument();
 	},
 };
+
+export const InvalidExternalURL: Story = {
+	args: {
+		workspace: MockWorkspace,
+		app: {
+			...MockWorkspaceApp,
+			external: true,
+			url: "my-repo",
+		},
+		agent: MockWorkspaceAgent,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		// The link should render as a button (no href) since the URL is
+		// invalid and cannot be parsed.
+		const button = await canvas.findByRole("button");
+		expect(button).not.toHaveAttribute("href");
+	},
+};

--- a/site/src/modules/resources/AppLink/AppLink.tsx
+++ b/site/src/modules/resources/AppLink/AppLink.tsx
@@ -76,6 +76,17 @@ export const AppLink: FC<AppLinkProps> = ({
 		primaryTooltip = "Unhealthy";
 	}
 
+	if (link.href === null) {
+		canClick = false;
+		icon = (
+			<CircleAlertIcon
+				aria-hidden="true"
+				className="size-icon-sm text-content-warning"
+			/>
+		);
+		primaryTooltip = "This app has an invalid URL and cannot be opened";
+	}
+
 	if (!host && app.subdomain) {
 		canClick = false;
 		icon = (
@@ -110,7 +121,12 @@ export const AppLink: FC<AppLinkProps> = ({
 		);
 	}
 
-	if (isExternalApp(app) && needsSessionToken(app) && !link.hasToken) {
+	if (
+		link.href !== null &&
+		isExternalApp(app) &&
+		needsSessionToken(app) &&
+		!link.hasToken
+	) {
 		canClick = false;
 	}
 
@@ -137,7 +153,7 @@ export const AppLink: FC<AppLinkProps> = ({
 	const button = grouped ? (
 		<DropdownMenuItem asChild>
 			<a
-				href={canClick ? link.href : undefined}
+				href={canClick && link.href ? link.href : undefined}
 				onClick={link.onClick}
 				target={app.open_in === "tab" ? "_blank" : undefined}
 				rel={app.open_in === "tab" ? "noreferrer" : undefined}
@@ -150,7 +166,7 @@ export const AppLink: FC<AppLinkProps> = ({
 	) : (
 		<AgentButton asChild>
 			<a
-				href={canClick ? link.href : undefined}
+				href={canClick && link.href ? link.href : undefined}
 				onClick={link.onClick}
 				target={app.open_in === "tab" ? "_blank" : undefined}
 				rel={app.open_in === "tab" ? "noreferrer" : undefined}

--- a/site/src/pages/TaskPage/TaskAppIframe.tsx
+++ b/site/src/pages/TaskPage/TaskAppIframe.tsx
@@ -53,7 +53,7 @@ export const TaskAppIFrame: FC<TaskAppIFrameProps> = ({
 						variant="subtle"
 						onClick={(e) => {
 							e.preventDefault();
-							if (frameRef.current?.contentWindow) {
+							if (frameRef.current?.contentWindow && link.href !== null) {
 								frameRef.current.contentWindow.location.href = link.href;
 							}
 						}}
@@ -75,7 +75,7 @@ export const TaskAppIFrame: FC<TaskAppIFrameProps> = ({
 						</DropdownMenuTrigger>
 						<DropdownMenuContent align="end">
 							<DropdownMenuItem asChild>
-								<RouterLink to={link.href} target="_blank">
+								<RouterLink to={link.href ?? ""} target="_blank">
 									<ExternalLinkIcon />
 									Open app in new tab
 								</RouterLink>
@@ -86,7 +86,11 @@ export const TaskAppIFrame: FC<TaskAppIFrameProps> = ({
 			)}
 
 			{app.health === "healthy" || app.health === "disabled" ? (
-				<TaskIframe ref={frameRef} src={link.href} title={link.label} />
+				<TaskIframe
+					ref={frameRef}
+					src={link.href ?? undefined}
+					title={link.label}
+				/>
 			) : app.health === "unhealthy" ? (
 				<div className="w-full h-full flex flex-col items-center justify-center p-4">
 					<h3 className="m-0 font-medium text-content-primary text-base text-center">

--- a/site/src/pages/TaskPage/TaskApps.tsx
+++ b/site/src/pages/TaskPage/TaskApps.tsx
@@ -170,7 +170,7 @@ const ExternalAppMenuItem: FC<{
 
 	return (
 		<DropdownMenuItem asChild>
-			<RouterLink to={link.href}>
+			<RouterLink to={link.href ?? ""}>
 				{app.icon ? <ExternalImage src={app.icon} /> : <LayoutGridIcon />}
 				{link.label}
 			</RouterLink>
@@ -197,7 +197,7 @@ const TaskAppTab: FC<TaskAppTabProps> = ({
 	});
 
 	return (
-		<TaskTab active={active} to={link.href} onClick={onClick}>
+		<TaskTab active={active} to={link.href ?? ""} onClick={onClick}>
 			{app.icon ? <ExternalImage src={app.icon} /> : <LayoutGridIcon />}
 			{link.label}
 			{app.health === "unhealthy" && (

--- a/site/src/pages/WorkspacePage/AppStatuses.tsx
+++ b/site/src/pages/WorkspacePage/AppStatuses.tsx
@@ -175,7 +175,7 @@ const AppLink: FC<AppLinkProps> = ({ app, agent, workspace }) => {
 	return (
 		<Button asChild variant="outline" size="sm">
 			<a
-				href={link.href}
+				href={link.href ?? undefined}
 				onClick={link.onClick}
 				target="_blank"
 				rel="noreferrer"

--- a/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
@@ -795,6 +795,19 @@ const IconAppLink: FC<IconAppLinkProps> = ({ app, workspace, agent }) => {
 		agent,
 	});
 
+	if (link.href === null) {
+		return (
+			<BaseIconLink
+				key={app.id}
+				label={`${link.label} has an invalid URL`}
+				disabled
+				onClick={(e) => e.stopPropagation()}
+			>
+				<ExternalImage src={app.icon ?? "/icon/widgets.svg"} />
+			</BaseIconLink>
+		);
+	}
+
 	return (
 		<BaseIconLink
 			key={app.id}
@@ -861,6 +874,7 @@ const VSCodeIconLink: FC<VSCodeIconLinkProps> = ({
 type BaseIconLinkCommonProps = PropsWithChildren<{
 	label: string;
 	isLoading?: boolean;
+	disabled?: boolean;
 }>;
 
 type BaseIconLinkAnchorProps = BaseIconLinkCommonProps & {
@@ -878,11 +892,13 @@ type BaseIconLinkProps = BaseIconLinkAnchorProps | BaseIconLinkButtonProps;
 
 const BaseIconLink: FC<BaseIconLinkProps> = ({
 	isLoading,
+	disabled,
 	label,
 	children,
 	...rest
 }) => {
 	const loadingClass = isLoading ? "animate-pulse" : "";
+	const isDisabled = disabled || isLoading;
 
 	return (
 		<TooltipProvider>
@@ -893,7 +909,7 @@ const BaseIconLink: FC<BaseIconLinkProps> = ({
 							variant="outline"
 							size="icon-lg"
 							asChild
-							disabled={isLoading}
+							disabled={isDisabled}
 						>
 							<a
 								target={rest.target}
@@ -917,7 +933,7 @@ const BaseIconLink: FC<BaseIconLinkProps> = ({
 								e.stopPropagation();
 								rest.onClick(e);
 							}}
-							disabled={isLoading}
+							disabled={isDisabled}
 						>
 							{children}
 							<span className="sr-only">{label}</span>


### PR DESCRIPTION
`getAppHref()` called `new URL(app.url)` without error handling, causing `TypeError` crashes on both the Workspace List and Workspace detail pages when a template author provides an invalid URL (e.g. a bare string with no scheme like `"my-repo"`).

The fix wraps the `new URL()` call in a try/catch and returns `null` for unparseable URLs. All consumers now handle the null case: `AppLink` renders a disabled button with a warning tooltip, `IconAppLink` shows a disabled icon with an explanatory tooltip, and other callers (`TaskAppIframe`, `TaskApps`, `AppStatuses`) gracefully degrade.

Fixes #22350

<details>
<summary>Implementation notes</summary>

**Core change** — `getAppHref()` return type: `string` → `string | null`

- `apps.ts`: try/catch around `new URL(app.url)`, returns `null` on failure
- `useAppLink.ts`: `AppLink.href` type updated to `string | null`; null guard on `openAppInNewWindow(href)` in slim-window path
- `AppLink.tsx`: new `link.href === null` check sets `canClick = false` + warning icon + tooltip; session token check skipped when href is null
- `WorkspacesTable.tsx`: `IconAppLink` renders disabled `BaseIconLink` with tooltip; `BaseIconLinkCommonProps` gains `disabled` prop
- `TaskAppIframe.tsx`, `TaskApps.tsx`, `AppStatuses.tsx`: null-coalesce `link.href` to prevent type errors
- `apps.test.ts`: two new tests for invalid/empty URLs returning null
- `AppLink.stories.tsx`: `InvalidExternalURL` story

</details>