### PR TITLE
feat(site/coderd): add Agent Hours page to agent settings

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -1266,6 +1266,40 @@ const docTemplate = `{
                 ]
             }
         },
+        "/experimental/chats/runtime/summary": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat runtime summary",
+                "operationId": "get-chat-runtime-summary",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Start date (RFC3339)",
+                        "name": "start_date",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End date (RFC3339)",
+                        "name": "end_date",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatRuntimeSummary"
+                        }
+                    }
+                }
+            }
+        },
         "/experimental/watch-all-workspacebuilds": {
             "get": {
                 "produces": [
@@ -14373,6 +14407,46 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "acquire_batch_size": {
+                    "type": "integer"
+                }
+            }
+        },
+        "codersdk.ChatRuntimeDay": {
+            "type": "object",
+            "properties": {
+                "date": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "message_count": {
+                    "type": "integer"
+                },
+                "total_runtime_ms": {
+                    "type": "integer"
+                }
+            }
+        },
+        "codersdk.ChatRuntimeSummary": {
+            "type": "object",
+            "properties": {
+                "daily": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/codersdk.ChatRuntimeDay"
+                    }
+                },
+                "end_date": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "projected_yearly_runtime_ms": {
+                    "type": "integer"
+                },
+                "start_date": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "total_runtime_ms": {
                     "type": "integer"
                 }
             }

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -1103,6 +1103,36 @@
 				]
 			}
 		},
+		"/experimental/chats/runtime/summary": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get chat runtime summary",
+				"operationId": "get-chat-runtime-summary",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Start date (RFC3339)",
+						"name": "start_date",
+						"in": "query"
+					},
+					{
+						"type": "string",
+						"description": "End date (RFC3339)",
+						"name": "end_date",
+						"in": "query"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatRuntimeSummary"
+						}
+					}
+				}
+			}
+		},
 		"/experimental/watch-all-workspacebuilds": {
 			"get": {
 				"produces": ["application/json"],
@@ -12916,6 +12946,46 @@
 			"type": "object",
 			"properties": {
 				"acquire_batch_size": {
+					"type": "integer"
+				}
+			}
+		},
+		"codersdk.ChatRuntimeDay": {
+			"type": "object",
+			"properties": {
+				"date": {
+					"type": "string",
+					"format": "date-time"
+				},
+				"message_count": {
+					"type": "integer"
+				},
+				"total_runtime_ms": {
+					"type": "integer"
+				}
+			}
+		},
+		"codersdk.ChatRuntimeSummary": {
+			"type": "object",
+			"properties": {
+				"daily": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/codersdk.ChatRuntimeDay"
+					}
+				},
+				"end_date": {
+					"type": "string",
+					"format": "date-time"
+				},
+				"projected_yearly_runtime_ms": {
+					"type": "integer"
+				},
+				"start_date": {
+					"type": "string",
+					"format": "date-time"
+				},
+				"total_runtime_ms": {
 					"type": "integer"
 				}
 			}

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1167,6 +1167,9 @@ func New(options *Options) *API {
 					r.Get("/summary", api.chatCostSummary)
 				})
 			})
+			r.Route("/runtime", func(r chi.Router) {
+				r.Get("/summary", api.chatRuntimeSummary)
+			})
 			r.Route("/insights", func(r chi.Router) {
 				r.Get("/pull-requests", api.prInsights)
 			})

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -2682,6 +2682,13 @@ func (q *querier) GetChatQueuedMessages(ctx context.Context, chatID uuid.UUID) (
 	return q.db.GetChatQueuedMessages(ctx, chatID)
 }
 
+func (q *querier) GetChatRuntimeByDay(ctx context.Context, arg database.GetChatRuntimeByDayParams) ([]database.GetChatRuntimeByDayRow, error) {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceChat); err != nil {
+		return nil, err
+	}
+	return q.db.GetChatRuntimeByDay(ctx, arg)
+}
+
 func (q *querier) GetChatSystemPrompt(ctx context.Context) (string, error) {
 	// The system prompt is a deployment-wide setting read during chat
 	// creation by every authenticated user, so no RBAC policy check

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -1216,6 +1216,14 @@ func (m queryMetricsStore) GetChatQueuedMessages(ctx context.Context, chatID uui
 	return r0, r1
 }
 
+func (m queryMetricsStore) GetChatRuntimeByDay(ctx context.Context, arg database.GetChatRuntimeByDayParams) ([]database.GetChatRuntimeByDayRow, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetChatRuntimeByDay(ctx, arg)
+	m.queryLatencies.WithLabelValues("GetChatRuntimeByDay").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetChatRuntimeByDay").Inc()
+	return r0, r1
+}
+
 func (m queryMetricsStore) GetChatSystemPrompt(ctx context.Context) (string, error) {
 	start := time.Now()
 	r0, r1 := m.s.GetChatSystemPrompt(ctx)

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -2238,6 +2238,21 @@ func (mr *MockStoreMockRecorder) GetChatQueuedMessages(ctx, chatID any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChatQueuedMessages", reflect.TypeOf((*MockStore)(nil).GetChatQueuedMessages), ctx, chatID)
 }
 
+// GetChatRuntimeByDay mocks base method.
+func (m *MockStore) GetChatRuntimeByDay(ctx context.Context, arg database.GetChatRuntimeByDayParams) ([]database.GetChatRuntimeByDayRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetChatRuntimeByDay", ctx, arg)
+	ret0, _ := ret[0].([]database.GetChatRuntimeByDayRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetChatRuntimeByDay indicates an expected call of GetChatRuntimeByDay.
+func (mr *MockStoreMockRecorder) GetChatRuntimeByDay(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChatRuntimeByDay", reflect.TypeOf((*MockStore)(nil).GetChatRuntimeByDay), ctx, arg)
+}
+
 // GetChatSystemPrompt mocks base method.
 func (m *MockStore) GetChatSystemPrompt(ctx context.Context) (string, error) {
 	m.ctrl.T.Helper()

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -259,6 +259,9 @@ type sqlcQuerier interface {
 	GetChatProviderByProvider(ctx context.Context, provider string) (ChatProvider, error)
 	GetChatProviders(ctx context.Context) ([]ChatProvider, error)
 	GetChatQueuedMessages(ctx context.Context, chatID uuid.UUID) ([]ChatQueuedMessage, error)
+	// Aggregate runtime_ms from chat_messages by day within a date range.
+	// Only counts messages where runtime_ms is not null.
+	GetChatRuntimeByDay(ctx context.Context, arg GetChatRuntimeByDayParams) ([]GetChatRuntimeByDayRow, error)
 	GetChatSystemPrompt(ctx context.Context) (string, error)
 	// GetChatSystemPromptConfig returns both chat system prompt settings in a
 	// single read to avoid torn reads between separate site-config lookups.

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -5264,6 +5264,61 @@ func (q *sqlQuerier) GetChatQueuedMessages(ctx context.Context, chatID uuid.UUID
 	return items, nil
 }
 
+const getChatRuntimeByDay = `-- name: GetChatRuntimeByDay :many
+SELECT
+    DATE_TRUNC('day', cm.created_at)::timestamptz AS date,
+    COALESCE(SUM(cm.runtime_ms), 0)::bigint AS total_runtime_ms,
+    COUNT(*)::bigint AS message_count
+FROM
+    chat_messages cm
+JOIN
+    chats c ON c.id = cm.chat_id
+WHERE
+    cm.runtime_ms IS NOT NULL
+    AND cm.created_at >= $1::timestamptz
+    AND cm.created_at < $2::timestamptz
+GROUP BY
+    DATE_TRUNC('day', cm.created_at)
+ORDER BY
+    date ASC
+`
+
+type GetChatRuntimeByDayParams struct {
+	StartDate time.Time `db:"start_date" json:"start_date"`
+	EndDate   time.Time `db:"end_date" json:"end_date"`
+}
+
+type GetChatRuntimeByDayRow struct {
+	Date           time.Time `db:"date" json:"date"`
+	TotalRuntimeMs int64     `db:"total_runtime_ms" json:"total_runtime_ms"`
+	MessageCount   int64     `db:"message_count" json:"message_count"`
+}
+
+// Aggregate runtime_ms from chat_messages by day within a date range.
+// Only counts messages where runtime_ms is not null.
+func (q *sqlQuerier) GetChatRuntimeByDay(ctx context.Context, arg GetChatRuntimeByDayParams) ([]GetChatRuntimeByDayRow, error) {
+	rows, err := q.db.QueryContext(ctx, getChatRuntimeByDay, arg.StartDate, arg.EndDate)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetChatRuntimeByDayRow
+	for rows.Next() {
+		var i GetChatRuntimeByDayRow
+		if err := rows.Scan(&i.Date, &i.TotalRuntimeMs, &i.MessageCount); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getChatUsageLimitConfig = `-- name: GetChatUsageLimitConfig :one
 SELECT id, singleton, enabled, default_limit_micros, period, created_at, updated_at FROM chat_usage_limit_config WHERE singleton = TRUE LIMIT 1
 `

--- a/coderd/database/queries/chats.sql
+++ b/coderd/database/queries/chats.sql
@@ -1157,3 +1157,23 @@ LIMIT 1;
 UPDATE chats
 SET last_read_message_id = @last_read_message_id::bigint
 WHERE id = @id::uuid;
+
+-- name: GetChatRuntimeByDay :many
+-- Aggregate runtime_ms from chat_messages by day within a date range.
+-- Only counts messages where runtime_ms is not null.
+SELECT
+    DATE_TRUNC('day', cm.created_at)::timestamptz AS date,
+    COALESCE(SUM(cm.runtime_ms), 0)::bigint AS total_runtime_ms,
+    COUNT(*)::bigint AS message_count
+FROM
+    chat_messages cm
+JOIN
+    chats c ON c.id = cm.chat_id
+WHERE
+    cm.runtime_ms IS NOT NULL
+    AND cm.created_at >= @start_date::timestamptz
+    AND cm.created_at < @end_date::timestamptz
+GROUP BY
+    DATE_TRUNC('day', cm.created_at)
+ORDER BY
+    date ASC;

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -696,6 +696,74 @@ func (api *API) chatCostSummary(rw http.ResponseWriter, r *http.Request) {
 	httpapi.Write(ctx, rw, http.StatusOK, response)
 }
 
+// @Summary Get chat runtime summary
+// @ID get-chat-runtime-summary
+// @Produce json
+// @Tags Chats
+// @Param start_date query string false "Start date (RFC3339)"
+// @Param end_date query string false "End date (RFC3339)"
+// @Success 200 {object} codersdk.ChatRuntimeSummary
+// @Router /experimental/chats/runtime/summary [get]
+func (api *API) chatRuntimeSummary(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	// Default date range: last 30 days.
+	now := time.Now()
+	defaultStart := now.AddDate(0, 0, -30)
+
+	qp := r.URL.Query()
+	p := httpapi.NewQueryParamParser()
+	startDate := p.Time(qp, defaultStart, "start_date", time.RFC3339)
+	endDate := p.Time(qp, now, "end_date", time.RFC3339)
+	p.ErrorExcessParams(qp)
+	if len(p.Errors) > 0 {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message:     "Invalid query parameters.",
+			Validations: p.Errors,
+		})
+		return
+	}
+
+	rows, err := api.Database.GetChatRuntimeByDay(ctx, database.GetChatRuntimeByDayParams{
+		StartDate: startDate,
+		EndDate:   endDate,
+	})
+	if err != nil {
+		if dbauthz.IsNotAuthorizedError(err) {
+			httpapi.Forbidden(rw)
+			return
+		}
+		httpapi.InternalServerError(rw, err)
+		return
+	}
+
+	var totalRuntimeMs int64
+	daily := make([]codersdk.ChatRuntimeDay, 0, len(rows))
+	for _, row := range rows {
+		totalRuntimeMs += row.TotalRuntimeMs
+		daily = append(daily, codersdk.ChatRuntimeDay{
+			Date:           row.Date,
+			TotalRuntimeMs: row.TotalRuntimeMs,
+			MessageCount:   row.MessageCount,
+		})
+	}
+
+	// Project yearly runtime from the trailing period.
+	periodDays := endDate.Sub(startDate).Hours() / 24
+	var projectedYearly int64
+	if periodDays > 0 {
+		projectedYearly = int64(float64(totalRuntimeMs) / periodDays * 365)
+	}
+
+	httpapi.Write(ctx, rw, http.StatusOK, codersdk.ChatRuntimeSummary{
+		StartDate:                startDate,
+		EndDate:                  endDate,
+		TotalRuntimeMs:           totalRuntimeMs,
+		Daily:                    daily,
+		ProjectedYearlyRuntimeMs: projectedYearly,
+	})
+}
+
 func (api *API) chatCostUsers(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	if !api.Authorize(r, policy.ActionRead, rbac.ResourceChat) {

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -945,6 +945,22 @@ type ChatCostSummary struct {
 	UsageLimit               *ChatUsageLimitStatus    `json:"usage_limit,omitempty"`
 }
 
+// ChatRuntimeDay represents a single day's aggregated runtime.
+type ChatRuntimeDay struct {
+	Date           time.Time `json:"date" format:"date-time"`
+	TotalRuntimeMs int64     `json:"total_runtime_ms"`
+	MessageCount   int64     `json:"message_count"`
+}
+
+// ChatRuntimeSummary is the response from the chat runtime summary endpoint.
+type ChatRuntimeSummary struct {
+	StartDate                time.Time        `json:"start_date" format:"date-time"`
+	EndDate                  time.Time        `json:"end_date" format:"date-time"`
+	TotalRuntimeMs           int64            `json:"total_runtime_ms"`
+	Daily                    []ChatRuntimeDay `json:"daily"`
+	ProjectedYearlyRuntimeMs int64            `json:"projected_yearly_runtime_ms"`
+}
+
 // ChatCostModelBreakdown contains per-model cost aggregation.
 type ChatCostModelBreakdown struct {
 	ModelConfigID            uuid.UUID `json:"model_config_id" format:"uuid"`
@@ -1408,6 +1424,29 @@ func (c *ExperimentalClient) GetChatCostSummary(ctx context.Context, user string
 		return ChatCostSummary{}, ReadBodyAsError(res)
 	}
 	var summary ChatCostSummary
+	return summary, json.NewDecoder(res.Body).Decode(&summary)
+}
+
+// GetChatRuntimeSummary returns aggregated runtime_ms data from chat messages.
+func (c *ExperimentalClient) GetChatRuntimeSummary(ctx context.Context, opts ChatCostSummaryOptions) (ChatRuntimeSummary, error) {
+	qp := url.Values{}
+	if !opts.StartDate.IsZero() {
+		qp.Set("start_date", opts.StartDate.Format(time.RFC3339))
+	}
+	if !opts.EndDate.IsZero() {
+		qp.Set("end_date", opts.EndDate.Format(time.RFC3339))
+	}
+	res, err := c.Client.Request(ctx, http.MethodGet, "/api/experimental/chats/runtime/summary", nil, func(r *http.Request) {
+		r.URL.RawQuery = qp.Encode()
+	})
+	if err != nil {
+		return ChatRuntimeSummary{}, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return ChatRuntimeSummary{}, ReadBodyAsError(res)
+	}
+	var summary ChatRuntimeSummary
 	return summary, json.NewDecoder(res.Body).Decode(&summary)
 }
 

--- a/docs/reference/api/chats.md
+++ b/docs/reference/api/chats.md
@@ -1,1 +1,46 @@
 # Chats
+
+## Get chat runtime summary
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/v2/experimental/chats/runtime/summary \
+  -H 'Accept: application/json'
+```
+
+`GET /experimental/chats/runtime/summary`
+
+### Parameters
+
+| Name         | In    | Type   | Required | Description          |
+|--------------|-------|--------|----------|----------------------|
+| `start_date` | query | string | false    | Start date (RFC3339) |
+| `end_date`   | query | string | false    | End date (RFC3339)   |
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "daily": [
+    {
+      "date": "2019-08-24T14:15:22Z",
+      "message_count": 0,
+      "total_runtime_ms": 0
+    }
+  ],
+  "end_date": "2019-08-24T14:15:22Z",
+  "projected_yearly_runtime_ms": 0,
+  "start_date": "2019-08-24T14:15:22Z",
+  "total_runtime_ms": 0
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                               |
+|--------|---------------------------------------------------------|-------------|----------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.ChatRuntimeSummary](schemas.md#codersdkchatruntimesummary) |

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -1986,6 +1986,52 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 |----------------------|---------|----------|--------------|-------------|
 | `acquire_batch_size` | integer | false    |              |             |
 
+## codersdk.ChatRuntimeDay
+
+```json
+{
+  "date": "2019-08-24T14:15:22Z",
+  "message_count": 0,
+  "total_runtime_ms": 0
+}
+```
+
+### Properties
+
+| Name               | Type    | Required | Restrictions | Description |
+|--------------------|---------|----------|--------------|-------------|
+| `date`             | string  | false    |              |             |
+| `message_count`    | integer | false    |              |             |
+| `total_runtime_ms` | integer | false    |              |             |
+
+## codersdk.ChatRuntimeSummary
+
+```json
+{
+  "daily": [
+    {
+      "date": "2019-08-24T14:15:22Z",
+      "message_count": 0,
+      "total_runtime_ms": 0
+    }
+  ],
+  "end_date": "2019-08-24T14:15:22Z",
+  "projected_yearly_runtime_ms": 0,
+  "start_date": "2019-08-24T14:15:22Z",
+  "total_runtime_ms": 0
+}
+```
+
+### Properties
+
+| Name                          | Type                                                        | Required | Restrictions | Description |
+|-------------------------------|-------------------------------------------------------------|----------|--------------|-------------|
+| `daily`                       | array of [codersdk.ChatRuntimeDay](#codersdkchatruntimeday) | false    |              |             |
+| `end_date`                    | string                                                      | false    |              |             |
+| `projected_yearly_runtime_ms` | integer                                                     | false    |              |             |
+| `start_date`                  | string                                                      | false    |              |             |
+| `total_runtime_ms`            | integer                                                     | false    |              |             |
+
 ## codersdk.ConnectionLatency
 
 ```json

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -3444,6 +3444,17 @@ class ExperimentalApiMethods {
 		return response.data;
 	};
 
+	getChatRuntimeSummary = async (
+		params?: ChatCostDateParams,
+	): Promise<TypesGen.ChatRuntimeSummary> => {
+		const url = getURLWithSearchParams(
+			"/api/experimental/chats/runtime/summary",
+			params,
+		);
+		const response = await this.axios.get<TypesGen.ChatRuntimeSummary>(url);
+		return response.data;
+	};
+
 	getChatCostUsers = async (
 		params?: ChatCostUsersParams,
 	): Promise<TypesGen.ChatCostUsersResponse> => {

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -853,6 +853,15 @@ export const chatCostSummary = (user = "me", params?: ChatCostDateParams) => ({
 	staleTime: 60_000,
 });
 
+const chatRuntimeSummaryKey = (params?: ChatCostDateParams) =>
+	[...chatsKey, "runtimeSummary", params] as const;
+
+export const chatRuntimeSummary = (params?: ChatCostDateParams) => ({
+	queryKey: chatRuntimeSummaryKey(params),
+	queryFn: () => API.experimental.getChatRuntimeSummary(params),
+	staleTime: 60_000,
+});
+
 export const chatCostUsersKey = (params?: ChatCostUsersParams) =>
 	[...chatsKey, "costUsers", params] as const;
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1868,6 +1868,28 @@ export interface ChatReasoningPart {
 }
 
 // From codersdk/chats.go
+/**
+ * ChatRuntimeDay represents a single day's aggregated runtime.
+ */
+export interface ChatRuntimeDay {
+	readonly date: string;
+	readonly total_runtime_ms: number;
+	readonly message_count: number;
+}
+
+// From codersdk/chats.go
+/**
+ * ChatRuntimeSummary is the response from the chat runtime summary endpoint.
+ */
+export interface ChatRuntimeSummary {
+	readonly start_date: string;
+	readonly end_date: string;
+	readonly total_runtime_ms: number;
+	readonly daily: readonly ChatRuntimeDay[];
+	readonly projected_yearly_runtime_ms: number;
+}
+
+// From codersdk/chats.go
 export interface ChatSkillPart {
 	readonly type: "skill";
 	/**

--- a/site/src/pages/AgentsPage/AgentSettingsAgentHoursPage.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsAgentHoursPage.tsx
@@ -1,0 +1,51 @@
+import dayjs from "dayjs";
+import { type FC, useState } from "react";
+import { useQuery } from "react-query";
+import { chatRuntimeSummary } from "#/api/queries/chats";
+import { useAuthenticated } from "#/hooks/useAuthenticated";
+import { RequirePermission } from "#/modules/permissions/RequirePermission";
+import { AgentSettingsAgentHoursPageView } from "./AgentSettingsAgentHoursPageView";
+
+const createDateRange = (now?: dayjs.Dayjs) => {
+	const end = now ?? dayjs();
+	const start = end.subtract(30, "day");
+	return {
+		startDate: start.toISOString(),
+		endDate: end.toISOString(),
+		rangeLabel: `${start.format("MMM D")} – ${end.format("MMM D, YYYY")}`,
+	};
+};
+
+interface AgentSettingsAgentHoursPageProps {
+	/** Override the current time for deterministic storybook snapshots. */
+	now?: dayjs.Dayjs;
+}
+
+const AgentSettingsAgentHoursPage: FC<AgentSettingsAgentHoursPageProps> = ({
+	now,
+}) => {
+	const { permissions } = useAuthenticated();
+	const [anchor] = useState<dayjs.Dayjs>(() => dayjs());
+	const dateRange = createDateRange(now ?? anchor);
+
+	const runtimeQuery = useQuery({
+		...chatRuntimeSummary({
+			start_date: dateRange.startDate,
+			end_date: dateRange.endDate,
+		}),
+	});
+
+	return (
+		<RequirePermission isFeatureVisible={permissions.editDeploymentConfig}>
+			<AgentSettingsAgentHoursPageView
+				data={runtimeQuery.data}
+				isLoading={runtimeQuery.isLoading}
+				error={runtimeQuery.error}
+				onRetry={() => void runtimeQuery.refetch()}
+				rangeLabel={dateRange.rangeLabel}
+			/>
+		</RequirePermission>
+	);
+};
+
+export default AgentSettingsAgentHoursPage;

--- a/site/src/pages/AgentsPage/AgentSettingsAgentHoursPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsAgentHoursPageView.stories.tsx
@@ -1,0 +1,168 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, within } from "storybook/test";
+import type { ChatRuntimeSummary } from "#/api/typesGenerated";
+import { AgentSettingsAgentHoursPageView } from "./AgentSettingsAgentHoursPageView";
+
+// Generate 30 days of mock runtime data with realistic variation.
+function generateMockDaily(days: number): ChatRuntimeSummary["daily"] {
+	const daily: Array<ChatRuntimeSummary["daily"][number]> = [];
+	const base = new Date("2026-03-01T00:00:00Z");
+	for (let i = 0; i < days; i++) {
+		const date = new Date(base);
+		date.setDate(base.getDate() + i);
+		// Weekdays get more usage than weekends.
+		const dayOfWeek = date.getDay();
+		const isWeekend = dayOfWeek === 0 || dayOfWeek === 6;
+		const baseMs = isWeekend ? 1_800_000 : 7_200_000;
+		// Add some random-looking variation using a simple deterministic
+		// pattern so the story renders the same every time.
+		const variation = ((i * 7 + 3) % 11) / 11;
+		const totalRuntimeMs = Math.round(baseMs * (0.5 + variation));
+		const messageCount = Math.round(totalRuntimeMs / 120_000);
+
+		daily.push({
+			date: date.toISOString(),
+			total_runtime_ms: totalRuntimeMs,
+			message_count: messageCount,
+		});
+	}
+	return daily;
+}
+
+const mockDaily = generateMockDaily(30);
+const totalRuntimeMs = mockDaily.reduce((s, d) => s + d.total_runtime_ms, 0);
+const projectedYearlyRuntimeMs = Math.round((totalRuntimeMs / 30) * 365);
+
+const mockSummary: ChatRuntimeSummary = {
+	start_date: "2026-03-01T00:00:00Z",
+	end_date: "2026-03-31T00:00:00Z",
+	total_runtime_ms: totalRuntimeMs,
+	daily: mockDaily,
+	projected_yearly_runtime_ms: projectedYearlyRuntimeMs,
+};
+
+const meta = {
+	title: "pages/AgentsPage/AgentSettingsAgentHoursPageView",
+	component: AgentSettingsAgentHoursPageView,
+	args: {
+		data: undefined,
+		isLoading: false,
+		error: undefined,
+		onRetry: fn(),
+		rangeLabel: "Mar 1 – Mar 31, 2026",
+	},
+} satisfies Meta<typeof AgentSettingsAgentHoursPageView>;
+
+export default meta;
+type Story = StoryObj<typeof AgentSettingsAgentHoursPageView>;
+
+export const WithData: Story = {
+	args: {
+		data: mockSummary,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		await canvas.findByText("Agent Hours");
+		await expect(canvas.getByText("Total in Period")).toBeInTheDocument();
+		await expect(canvas.getByText("Projected Yearly")).toBeInTheDocument();
+		await expect(canvas.getByText("Daily Runtime")).toBeInTheDocument();
+	},
+};
+
+export const Loading: Story = {
+	args: {
+		isLoading: true,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		await canvas.findByText("Agent Hours");
+		// Summary cards and chart should not be visible while loading.
+		expect(canvas.queryByText("Total in Period")).not.toBeInTheDocument();
+	},
+};
+
+export const ErrorState: Story = {
+	args: {
+		error: new global.Error("Something went wrong"),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		await canvas.findByText("Failed to load runtime data.");
+		await expect(canvas.getByText("Retry")).toBeInTheDocument();
+	},
+};
+
+export const Empty: Story = {
+	args: {
+		data: {
+			start_date: "2026-03-01T00:00:00Z",
+			end_date: "2026-03-31T00:00:00Z",
+			total_runtime_ms: 0,
+			daily: [],
+			projected_yearly_runtime_ms: 0,
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		await canvas.findByText("Agent Hours");
+		await expect(
+			canvas.getByText("No runtime data available for this period."),
+		).toBeInTheDocument();
+	},
+};
+
+export const SmallValues: Story = {
+	args: {
+		data: {
+			start_date: "2026-03-01T00:00:00Z",
+			end_date: "2026-03-31T00:00:00Z",
+			total_runtime_ms: 180_000, // 3 minutes total
+			daily: [
+				{
+					date: "2026-03-15T00:00:00Z",
+					total_runtime_ms: 60_000,
+					message_count: 2,
+				},
+				{
+					date: "2026-03-16T00:00:00Z",
+					total_runtime_ms: 120_000,
+					message_count: 3,
+				},
+			],
+			projected_yearly_runtime_ms: Math.round((180_000 / 30) * 365),
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		await canvas.findByText("Agent Hours");
+		// Small values should render in minutes.
+		await expect(canvas.getByText("3.0m")).toBeInTheDocument();
+	},
+};
+
+export const LargeValues: Story = {
+	args: {
+		data: {
+			start_date: "2026-03-01T00:00:00Z",
+			end_date: "2026-03-31T00:00:00Z",
+			total_runtime_ms: 5_400_000_000, // 1500 hours
+			daily: generateMockDaily(30).map((d) => ({
+				...d,
+				total_runtime_ms: d.total_runtime_ms * 100,
+			})),
+			projected_yearly_runtime_ms: Math.round((5_400_000_000 / 30) * 365),
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		await canvas.findByText("Agent Hours");
+		// Large values should use the "k hrs" format.
+		await expect(canvas.getByText("1.5k hrs")).toBeInTheDocument();
+	},
+};

--- a/site/src/pages/AgentsPage/AgentSettingsAgentHoursPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsAgentHoursPageView.tsx
@@ -1,0 +1,238 @@
+import { ClockIcon, TrendingUpIcon } from "lucide-react";
+import type { FC } from "react";
+import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
+import type { ChatRuntimeSummary } from "#/api/typesGenerated";
+import {
+	type ChartConfig,
+	ChartContainer,
+	ChartTooltip,
+	ChartTooltipContent,
+} from "#/components/Chart/Chart";
+import { Spinner } from "#/components/Spinner/Spinner";
+import { formatDate } from "#/utils/time";
+import { SectionHeader } from "./components/SectionHeader";
+
+const chartConfig = {
+	hours: {
+		label: "Hours",
+		color: "hsl(var(--highlight-purple))",
+	},
+} satisfies ChartConfig;
+
+/**
+ * Format milliseconds to a human-readable hours string.
+ */
+function formatHours(ms: number): string {
+	const hours = ms / 3_600_000;
+	if (hours < 0.1) {
+		const minutes = ms / 60_000;
+		return `${minutes.toFixed(1)}m`;
+	}
+	if (hours >= 1000) {
+		return `${(hours / 1000).toFixed(1)}k hrs`;
+	}
+	return `${hours.toFixed(1)} hrs`;
+}
+
+interface AgentHoursPageViewProps {
+	data: ChatRuntimeSummary | undefined;
+	isLoading: boolean;
+	error: unknown;
+	onRetry: () => void;
+	rangeLabel: string;
+}
+
+export const AgentSettingsAgentHoursPageView: FC<AgentHoursPageViewProps> = ({
+	data,
+	isLoading,
+	error,
+	onRetry,
+	rangeLabel,
+}) => {
+	const chartData =
+		data?.daily.map((d) => ({
+			date: d.date,
+			hours: d.total_runtime_ms / 3_600_000,
+		})) ?? [];
+
+	return (
+		<div className="flex flex-col gap-6">
+			<SectionHeader
+				label="Agent Hours"
+				description="Track total agent compute time across your deployment."
+				action={
+					<div className="flex items-center gap-2 text-xs text-content-secondary">
+						<ClockIcon className="h-4 w-4" />
+						<span>{rangeLabel}</span>
+					</div>
+				}
+			/>
+
+			{/* Summary Cards */}
+			{isLoading ? (
+				<div className="flex items-center justify-center py-12">
+					<Spinner loading />
+				</div>
+			) : error ? (
+				<div className="flex flex-col items-center gap-3 py-12 text-sm text-content-secondary">
+					<p className="m-0">Failed to load runtime data.</p>
+					<button
+						type="button"
+						onClick={onRetry}
+						className="cursor-pointer border-0 bg-transparent text-sm font-medium text-content-link hover:underline"
+					>
+						Retry
+					</button>
+				</div>
+			) : (
+				<>
+					<div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+						<div className="flex flex-col gap-1 rounded-lg border border-solid border-border p-4">
+							<div className="flex items-center gap-2 text-xs font-medium text-content-secondary">
+								<ClockIcon className="h-3.5 w-3.5" />
+								Total in Period
+							</div>
+							<div className="text-2xl font-semibold text-content-primary">
+								{formatHours(data?.total_runtime_ms ?? 0)}
+							</div>
+							<div className="text-xs text-content-secondary">
+								{data?.daily.reduce((sum, d) => sum + d.message_count, 0) ?? 0}{" "}
+								messages
+							</div>
+						</div>
+
+						<div className="flex flex-col gap-1 rounded-lg border border-solid border-border p-4">
+							<div className="flex items-center gap-2 text-xs font-medium text-content-secondary">
+								<TrendingUpIcon className="h-3.5 w-3.5" />
+								Projected Yearly
+							</div>
+							<div className="text-2xl font-semibold text-content-primary">
+								{formatHours(data?.projected_yearly_runtime_ms ?? 0)}
+							</div>
+							<div className="text-xs text-content-secondary">
+								Based on trailing{" "}
+								{rangeLabel.toLowerCase().includes("day")
+									? rangeLabel.toLowerCase()
+									: "period"}
+							</div>
+						</div>
+					</div>
+
+					{/* Chart */}
+					<div className="rounded-lg border border-solid border-border">
+						<div className="border-0 border-b border-solid border-border p-4">
+							<h3 className="m-0 text-sm font-medium text-content-primary">
+								Daily Runtime
+							</h3>
+						</div>
+						<div className="p-6">
+							<div className="h-64">
+								{chartData.length > 0 ? (
+									<ChartContainer
+										config={chartConfig}
+										className="aspect-auto h-full"
+									>
+										<AreaChart
+											accessibilityLayer
+											data={chartData}
+											margin={{
+												top: 10,
+												left: 0,
+												right: 0,
+											}}
+										>
+											<CartesianGrid vertical={false} />
+											<XAxis
+												dataKey="date"
+												tickLine={false}
+												tickMargin={12}
+												minTickGap={24}
+												tickFormatter={(value: string) =>
+													formatDate(new Date(value), {
+														month: "short",
+														day: "numeric",
+														year: undefined,
+														hour: undefined,
+														minute: undefined,
+														second: undefined,
+													})
+												}
+											/>
+											<YAxis
+												dataKey="hours"
+												tickLine={false}
+												axisLine={false}
+												tickMargin={12}
+												tickFormatter={(value: number) => {
+													if (value === 0) return "";
+													if (value < 1) return `${(value * 60).toFixed(0)}m`;
+													return `${value.toFixed(1)}h`;
+												}}
+											/>
+											<ChartTooltip
+												cursor={false}
+												content={
+													<ChartTooltipContent
+														className="font-medium text-content-secondary"
+														labelClassName="text-content-primary"
+														labelFormatter={(_, p) => {
+															const item = p[0];
+															const hours =
+																typeof item.value === "number" ? item.value : 0;
+															return `${hours.toFixed(2)} hours`;
+														}}
+														formatter={(_v, _n, item) => {
+															const date = new Date(item.payload.date);
+															return date.toLocaleString(undefined, {
+																month: "long",
+																day: "2-digit",
+															});
+														}}
+													/>
+												}
+											/>
+											<defs>
+												<linearGradient
+													id="fillHours"
+													x1="0"
+													y1="0"
+													x2="0"
+													y2="1"
+												>
+													<stop
+														offset="5%"
+														stopColor="var(--color-hours)"
+														stopOpacity={0.8}
+													/>
+													<stop
+														offset="95%"
+														stopColor="var(--color-hours)"
+														stopOpacity={0.1}
+													/>
+												</linearGradient>
+											</defs>
+
+											<Area
+												isAnimationActive={false}
+												dataKey="hours"
+												type="linear"
+												fill="url(#fillHours)"
+												fillOpacity={0.4}
+												stroke="var(--color-hours)"
+												stackId="a"
+											/>
+										</AreaChart>
+									</ChartContainer>
+								) : (
+									<div className="flex h-full w-full items-center justify-center text-sm font-medium text-content-secondary">
+										No runtime data available for this period.
+									</div>
+								)}
+							</div>
+						</div>
+					</div>
+				</>
+			)}
+		</div>
+	);
+};

--- a/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
@@ -26,6 +26,7 @@ import {
 	ChevronDownIcon,
 	ChevronLeftIcon,
 	ChevronRightIcon,
+	ClockIcon,
 	EllipsisIcon,
 	FilterIcon,
 	GitMergeIcon,
@@ -1303,6 +1304,14 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 									label="Analytics"
 									active={sidebarView.section === "insights"}
 									to="/agents/settings/insights"
+									state={location.state}
+									adminOnly
+								/>
+								<SettingsNavItem
+									icon={ClockIcon}
+									label="Agent Hours"
+									active={sidebarView.section === "agent-hours"}
+									to="/agents/settings/agent-hours"
 									state={location.state}
 									adminOnly
 								/>

--- a/site/src/router.tsx
+++ b/site/src/router.tsx
@@ -377,6 +377,9 @@ const AgentSettingsUsagePage = lazy(
 const AgentSettingsInsightsPage = lazy(
 	() => import("./pages/AgentsPage/AgentSettingsInsightsPage"),
 );
+const AgentSettingsAgentHoursPage = lazy(
+	() => import("./pages/AgentsPage/AgentSettingsAgentHoursPage"),
+);
 const AgentSettingsTemplatesPage = lazy(
 	() => import("./pages/AgentsPage/AgentSettingsTemplatesPage"),
 );
@@ -711,6 +714,10 @@ export const router = createBrowserRouter(
 						<Route path="limits" element={<AgentSettingsLimitsPage />} />
 						<Route path="usage" element={<AgentSettingsUsagePage />} />
 						<Route path="insights" element={<AgentSettingsInsightsPage />} />
+						<Route
+							path="agent-hours"
+							element={<AgentSettingsAgentHoursPage />}
+						/>
 						<Route path="templates" element={<AgentSettingsTemplatesPage />} />
 					</Route>
 					<Route path="analytics" element={<AgentAnalyticsPage />} />{" "}


### PR DESCRIPTION
Adds a new "Agent Hours" page in the Agent settings sidebar that displays
`runtime_ms` from `chat_messages` aggregated by day, with a projected
yearly estimate based on the trailing 30-day period.

## Changes

### Backend
- New SQL query `GetChatRuntimeByDay` — aggregates `runtime_ms` from `chat_messages` grouped by day
- New `ChatRuntimeSummary` / `ChatRuntimeDay` SDK types in `codersdk/chats.go`
- New `GET /api/experimental/chats/runtime/summary` endpoint with `start_date`/`end_date` query params (defaults to last 30 days)
- RBAC authorization requiring `ActionRead` on `ResourceChat`
- Yearly projection: `totalRuntimeMs / periodDays * 365`

### Frontend
- `AgentSettingsAgentHoursPage` — fetches runtime summary data
- `AgentSettingsAgentHoursPageView` — area chart (recharts) of daily runtime hours, summary cards for total hours and projected yearly hours
- Route at `/agents/settings/agent-hours`
- `ClockIcon` nav item in agent settings sidebar (admin only)
- API client method `getChatRuntimeSummary` and query helper `chatRuntimeSummary`

<details><summary>Implementation Notes</summary>

- The SQL query filters for `runtime_ms IS NOT NULL` and groups by `DATE_TRUNC('day', created_at)` — this is a deployment-wide aggregate, not per-user.
- The projected yearly estimate is a simple linear extrapolation from the trailing period.
- The page follows existing agent settings page patterns (RequirePermission, SectionHeader, recharts AreaChart matching UserEngagementChart style).
- The endpoint is registered under the experimental chats route group and requires the `agents` experiment.
</details>