### PR TITLE
feat: add Cancel to bulk actions dropdown in workspaces page

### DIFF
--- a/docs/user-guides/workspace-management.md
+++ b/docs/user-guides/workspace-management.md
@@ -102,14 +102,16 @@ manually updated the workspace.
 
 ## Bulk operations
 
-Admins may apply bulk operations (update, delete, start, stop) in the
+Admins may apply bulk operations (update, delete, start, stop, cancel) in the
 **Workspaces** tab. Select the workspaces you'd like to modify with the
 checkboxes on the left, then use the top-right **Actions** dropdown to apply the
 operation.
 
 The start and stop operations can only be applied to a set of workspaces which
-are all in the same state. For update and delete, the user will be prompted for
-confirmation before any action is taken.
+are all in the same state. The cancel operation is available when at least one
+selected workspace has an active build (starting, stopping, pending, or
+deleting). For update and delete, the user will be prompted for confirmation
+before any action is taken.
 
 ![Bulk workspace actions](../images/user-guides/workspace-bulk-actions.png)
 

--- a/site/src/modules/workspaces/actions.test.ts
+++ b/site/src/modules/workspaces/actions.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import type { Workspace } from "#/api/typesGenerated";
+import { MockWorkspace } from "#/testHelpers/entities";
+import { abilitiesByWorkspaceStatus, canCancelWorkspaceBuild } from "./actions";
+
+const buildWorkspace = (
+	status: Workspace["latest_build"]["status"],
+	overrides: Partial<Workspace> = {},
+): Workspace => ({
+	...MockWorkspace,
+	...overrides,
+	latest_build: {
+		...MockWorkspace.latest_build,
+		status,
+		...overrides.latest_build,
+	},
+});
+
+describe("canCancelWorkspaceBuild", () => {
+	it("allows pending builds for non-owners", () => {
+		const workspace = buildWorkspace("pending", {
+			template_allow_user_cancel_workspace_jobs: false,
+		});
+
+		expect(canCancelWorkspaceBuild(workspace, { isOwner: false })).toBe(true);
+	});
+
+	it("denies deleting builds for non-owners without template permission", () => {
+		const workspace = buildWorkspace("deleting", {
+			template_allow_user_cancel_workspace_jobs: false,
+		});
+
+		expect(canCancelWorkspaceBuild(workspace, { isOwner: false })).toBe(false);
+	});
+
+	it("allows deleting builds when the template permits user cancels", () => {
+		const workspace = buildWorkspace("deleting", {
+			template_allow_user_cancel_workspace_jobs: true,
+		});
+
+		expect(canCancelWorkspaceBuild(workspace, { isOwner: false })).toBe(true);
+	});
+
+	it("allows deleting builds for owners", () => {
+		const workspace = buildWorkspace("deleting", {
+			template_allow_user_cancel_workspace_jobs: false,
+		});
+
+		expect(canCancelWorkspaceBuild(workspace, { isOwner: true })).toBe(true);
+	});
+});
+
+describe("abilitiesByWorkspaceStatus", () => {
+	it("matches deleting cancel permissions for non-owners", () => {
+		const workspace = buildWorkspace("deleting", {
+			template_allow_user_cancel_workspace_jobs: false,
+		});
+
+		expect(
+			abilitiesByWorkspaceStatus(workspace, {
+				canDebug: false,
+				isOwner: false,
+			}).canCancel,
+		).toBe(false);
+	});
+});

--- a/site/src/modules/workspaces/actions.ts
+++ b/site/src/modules/workspaces/actions.ts
@@ -1,4 +1,5 @@
 import type { Workspace } from "#/api/typesGenerated";
+import { CANCELLABLE_BUILD_STATUSES } from "#/modules/workspaces/status";
 
 /**
  * An iterable of all action types supported by the workspace UI
@@ -42,19 +43,44 @@ type ActionPermissions = {
 	isOwner: boolean;
 };
 
+type CancelPermissions = Pick<ActionPermissions, "isOwner">;
+
 type WorkspaceAbilities = {
 	actions: readonly ActionType[];
 	canCancel: boolean;
 	canAcceptJobs: boolean;
 };
 
+// Share the cancellability rules between row and bulk actions so they stay
+// in sync with the backend permission checks.
+export const canCancelWorkspaceBuild = (
+	workspace: Pick<
+		Workspace,
+		"dormant_at" | "latest_build" | "template_allow_user_cancel_workspace_jobs"
+	>,
+	permissions: CancelPermissions,
+): boolean => {
+	if (workspace.dormant_at || workspace.latest_build.has_external_agent) {
+		return false;
+	}
+
+	if (!CANCELLABLE_BUILD_STATUSES.includes(workspace.latest_build.status)) {
+		return false;
+	}
+
+	if (workspace.latest_build.status === "pending") {
+		return true;
+	}
+
+	return (
+		workspace.template_allow_user_cancel_workspace_jobs || permissions.isOwner
+	);
+};
+
 export const abilitiesByWorkspaceStatus = (
 	workspace: Workspace,
 	permissions: ActionPermissions,
 ): WorkspaceAbilities => {
-	const hasPermissionToCancel =
-		workspace.template_allow_user_cancel_workspace_jobs || permissions.isOwner;
-
 	if (workspace.dormant_at) {
 		return {
 			actions: ["activate"],
@@ -72,12 +98,13 @@ export const abilitiesByWorkspaceStatus = (
 	}
 
 	const status = workspace.latest_build.status;
+	const canCancel = canCancelWorkspaceBuild(workspace, permissions);
 
 	switch (status) {
 		case "starting": {
 			return {
 				actions: ["starting"],
-				canCancel: hasPermissionToCancel,
+				canCancel,
 				canAcceptJobs: false,
 			};
 		}
@@ -102,7 +129,7 @@ export const abilitiesByWorkspaceStatus = (
 		case "stopping": {
 			return {
 				actions: ["stopping"],
-				canCancel: hasPermissionToCancel,
+				canCancel,
 				canAcceptJobs: false,
 			};
 		}
@@ -153,7 +180,7 @@ export const abilitiesByWorkspaceStatus = (
 		case "pending": {
 			return {
 				actions: ["pending"],
-				canCancel: true,
+				canCancel,
 				canAcceptJobs: false,
 			};
 		}
@@ -167,7 +194,7 @@ export const abilitiesByWorkspaceStatus = (
 		case "deleting": {
 			return {
 				actions: ["deleting"],
-				canCancel: true,
+				canCancel,
 				canAcceptJobs: false,
 			};
 		}

--- a/site/src/modules/workspaces/status.ts
+++ b/site/src/modules/workspaces/status.ts
@@ -12,3 +12,13 @@ export const ACTIVE_BUILD_STATUSES: readonly WorkspaceStatus[] = [
 	"starting",
 	"stopping",
 ];
+
+/**
+ * The set of workspace statuses where the current build can be cancelled.
+ */
+export const CANCELLABLE_BUILD_STATUSES: readonly WorkspaceStatus[] = [
+	"starting",
+	"stopping",
+	"pending",
+	"deleting",
+];

--- a/site/src/pages/WorkspacesPage/WorkspacesPage.test.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.test.tsx
@@ -297,6 +297,65 @@ describe("WorkspacesPage", () => {
 		);
 	});
 
+	it("cancels only the selected workspaces with active builds", async () => {
+		const workspaces = [
+			{
+				...MockWorkspace,
+				id: "1",
+				latest_build: {
+					...MockWorkspace.latest_build,
+					status: "starting" as const,
+				},
+			},
+			{
+				...MockWorkspace,
+				id: "2",
+				latest_build: {
+					...MockWorkspace.latest_build,
+					status: "starting" as const,
+				},
+			},
+			{
+				...MockWorkspace,
+				id: "3",
+				latest_build: {
+					...MockWorkspace.latest_build,
+					status: "running" as const,
+				},
+			},
+		];
+		vi.spyOn(API, "getWorkspaces").mockResolvedValue({
+			workspaces,
+			count: workspaces.length,
+		});
+		const cancelWorkspaceBuild = vi
+			.spyOn(API, "cancelWorkspaceBuild")
+			.mockResolvedValue({ message: "build canceled" });
+		const user = userEvent.setup();
+		renderWithAuth(<WorkspacesPage />);
+		await waitForLoaderToBeRemoved();
+
+		await user.click(getWorkspaceCheckbox(workspaces[0]));
+		await user.click(getWorkspaceCheckbox(workspaces[1]));
+		await user.click(getWorkspaceCheckbox(workspaces[2]));
+
+		await user.click(screen.getByRole("button", { name: /bulk actions/i }));
+		const cancelButton = await screen.findByRole("menuitem", {
+			name: /cancel/i,
+		});
+		await user.click(cancelButton);
+
+		await waitFor(() => {
+			expect(cancelWorkspaceBuild).toHaveBeenCalledTimes(2);
+		});
+		expect(cancelWorkspaceBuild).toHaveBeenCalledWith(
+			workspaces[0].latest_build.id,
+		);
+		expect(cancelWorkspaceBuild).toHaveBeenCalledWith(
+			workspaces[1].latest_build.id,
+		);
+	});
+
 	it("correctly handles pagination by including pagination parameters in query key", async () => {
 		const totalWorkspaces = 50;
 		const workspacesPage1 = Array.from({ length: 25 }, (_, i) => ({

--- a/site/src/pages/WorkspacesPage/WorkspacesPage.test.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.test.tsx
@@ -312,7 +312,7 @@ describe("WorkspacesPage", () => {
 				id: "2",
 				latest_build: {
 					...MockWorkspace.latest_build,
-					status: "starting" as const,
+					status: "stopping" as const,
 				},
 			},
 			{
@@ -348,11 +348,14 @@ describe("WorkspacesPage", () => {
 		await waitFor(() => {
 			expect(cancelWorkspaceBuild).toHaveBeenCalledTimes(2);
 		});
+		// "starting" and "stopping" don't send expect_status.
 		expect(cancelWorkspaceBuild).toHaveBeenCalledWith(
 			workspaces[0].latest_build.id,
+			undefined,
 		);
 		expect(cancelWorkspaceBuild).toHaveBeenCalledWith(
 			workspaces[1].latest_build.id,
+			undefined,
 		);
 	});
 

--- a/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
@@ -157,6 +157,7 @@ const WorkspacesPage: FC = () => {
 			<WorkspacesPageView
 				canCreateTemplate={permissions.createTemplates}
 				canChangeVersions={permissions.updateTemplates}
+				canCancelAllBuilds={me.roles.some((role) => role.name === "owner")}
 				checkedWorkspaces={checkedWorkspaces}
 				chatsByWorkspace={chatsByWorkspaceQuery.data}
 				onCheckChange={(newWorkspaces) => {

--- a/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
@@ -140,11 +140,13 @@ const WorkspacesPage: FC = () => {
 	});
 
 	const [activeBatchAction, setActiveBatchAction] = useState<BatchAction>();
+	const isOwner = me.roles.some((role) => role.name === "owner");
 	const batchActions = useBatchActions({
 		onSuccess: async () => {
 			await refetch();
 			resetChecked();
 		},
+		canCancelAllBuilds: isOwner,
 	});
 
 	const checkedWorkspaces =
@@ -157,7 +159,7 @@ const WorkspacesPage: FC = () => {
 			<WorkspacesPageView
 				canCreateTemplate={permissions.createTemplates}
 				canChangeVersions={permissions.updateTemplates}
-				canCancelAllBuilds={me.roles.some((role) => role.name === "owner")}
+				canCancelAllBuilds={isOwner}
 				checkedWorkspaces={checkedWorkspaces}
 				chatsByWorkspace={chatsByWorkspaceQuery.data}
 				onCheckChange={(newWorkspaces) => {

--- a/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
@@ -184,6 +184,7 @@ const WorkspacesPage: FC = () => {
 				onBatchDeleteTransition={() => setActiveBatchAction("delete")}
 				onBatchStartTransition={() => batchActions.start(checkedWorkspaces)}
 				onBatchStopTransition={() => batchActions.stop(checkedWorkspaces)}
+				onBatchCancelTransition={() => batchActions.cancel(checkedWorkspaces)}
 				onBatchUpdateTransition={() => {
 					// Just because batch-updating can be really dangerous
 					// action for running workspaces, we're going to invalidate

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.stories.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.stories.tsx
@@ -172,6 +172,7 @@ const meta: Meta<typeof WorkspacesPageView> = {
 		templatesFetchStatus: "success",
 		count: 13,
 		page: 1,
+		canCancelAllBuilds: true,
 	},
 	parameters: {
 		queries: [

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
@@ -61,6 +61,7 @@ interface WorkspacesPageViewProps {
 	templates: TemplateQuery["data"];
 	canCreateTemplate: boolean;
 	canChangeVersions: boolean;
+	canCancelAllBuilds: boolean;
 	onActionSuccess: () => Promise<void>;
 	onActionError: (error: unknown) => void;
 	chatsByWorkspace?: Record<string, string>;
@@ -86,6 +87,7 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({
 	templatesFetchStatus,
 	canCreateTemplate,
 	canChangeVersions,
+	canCancelAllBuilds,
 	onActionSuccess,
 	onActionError,
 	chatsByWorkspace,
@@ -177,10 +179,13 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({
 								</DropdownMenuItem>
 								<DropdownMenuItem
 									disabled={
-										!checkedWorkspaces?.some((w) =>
-											CANCELLABLE_BUILD_STATUSES.includes(
-												w.latest_build.status,
-											),
+										!checkedWorkspaces?.some(
+											(w) =>
+												CANCELLABLE_BUILD_STATUSES.includes(
+													w.latest_build.status,
+												) &&
+												(w.template_allow_user_cancel_workspace_jobs ||
+													canCancelAllBuilds),
 										)
 									}
 									onClick={onBatchCancelTransition}

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
@@ -1,4 +1,10 @@
-import { CloudIcon, PlayIcon, SquareIcon, TrashIcon } from "lucide-react";
+import {
+	CircleXIcon,
+	CloudIcon,
+	PlayIcon,
+	SquareIcon,
+	TrashIcon,
+} from "lucide-react";
 import type { FC } from "react";
 import type { UseQueryResult } from "react-query";
 import { hasError, isApiValidationError } from "#/api/errors";
@@ -24,6 +30,7 @@ import { PaginationWidgetBase } from "#/components/PaginationWidget/PaginationWi
 import { Spinner } from "#/components/Spinner/Spinner";
 import { Stack } from "#/components/Stack/Stack";
 import { TableToolbar } from "#/components/TableToolbar/TableToolbar";
+import { CANCELLABLE_BUILD_STATUSES } from "#/modules/workspaces/status";
 import { WorkspacesTable } from "#/pages/WorkspacesPage/WorkspacesTable";
 import { mustUpdateWorkspace } from "#/utils/workspace";
 import {
@@ -49,6 +56,7 @@ interface WorkspacesPageViewProps {
 	onBatchUpdateTransition: () => void;
 	onBatchStartTransition: () => void;
 	onBatchStopTransition: () => void;
+	onBatchCancelTransition: () => void;
 	templatesFetchStatus: TemplateQuery["status"];
 	templates: TemplateQuery["data"];
 	canCreateTemplate: boolean;
@@ -72,6 +80,7 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({
 	onBatchUpdateTransition,
 	onBatchStopTransition,
 	onBatchStartTransition,
+	onBatchCancelTransition,
 	isRunningBatchAction,
 	templates,
 	templatesFetchStatus,
@@ -165,6 +174,18 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({
 									onClick={onBatchStopTransition}
 								>
 									<SquareIcon /> Stop
+								</DropdownMenuItem>
+								<DropdownMenuItem
+									disabled={
+										!checkedWorkspaces?.some((w) =>
+											CANCELLABLE_BUILD_STATUSES.includes(
+												w.latest_build.status,
+											),
+										)
+									}
+									onClick={onBatchCancelTransition}
+								>
+									<CircleXIcon /> Cancel
 								</DropdownMenuItem>
 								<DropdownMenuSeparator />
 								<DropdownMenuItem onClick={onBatchUpdateTransition}>

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
@@ -30,7 +30,7 @@ import { PaginationWidgetBase } from "#/components/PaginationWidget/PaginationWi
 import { Spinner } from "#/components/Spinner/Spinner";
 import { Stack } from "#/components/Stack/Stack";
 import { TableToolbar } from "#/components/TableToolbar/TableToolbar";
-import { CANCELLABLE_BUILD_STATUSES } from "#/modules/workspaces/status";
+import { canCancelWorkspaceBuild } from "#/modules/workspaces/actions";
 import { WorkspacesTable } from "#/pages/WorkspacesPage/WorkspacesTable";
 import { mustUpdateWorkspace } from "#/utils/workspace";
 import {
@@ -179,14 +179,10 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({
 								</DropdownMenuItem>
 								<DropdownMenuItem
 									disabled={
-										!checkedWorkspaces?.some(
-											(w) =>
-												CANCELLABLE_BUILD_STATUSES.includes(
-													w.latest_build.status,
-												) &&
-												(w.latest_build.status === "pending" ||
-													w.template_allow_user_cancel_workspace_jobs ||
-													canCancelAllBuilds),
+										!checkedWorkspaces?.some((w) =>
+											canCancelWorkspaceBuild(w, {
+												isOwner: canCancelAllBuilds,
+											}),
 										)
 									}
 									onClick={onBatchCancelTransition}

--- a/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPageView.tsx
@@ -184,7 +184,8 @@ export const WorkspacesPageView: FC<WorkspacesPageViewProps> = ({
 												CANCELLABLE_BUILD_STATUSES.includes(
 													w.latest_build.status,
 												) &&
-												(w.template_allow_user_cancel_workspace_jobs ||
+												(w.latest_build.status === "pending" ||
+													w.template_allow_user_cancel_workspace_jobs ||
 													canCancelAllBuilds),
 										)
 									}

--- a/site/src/pages/WorkspacesPage/batchActions.ts
+++ b/site/src/pages/WorkspacesPage/batchActions.ts
@@ -7,6 +7,7 @@ import { CANCELLABLE_BUILD_STATUSES } from "#/modules/workspaces/status";
 
 interface UseBatchActionsOptions {
 	onSuccess: () => Promise<void>;
+	canCancelAllBuilds: boolean;
 }
 
 type UpdateAllPayload = Readonly<{
@@ -30,7 +31,7 @@ type UseBatchActionsResult = Readonly<{
 export function useBatchActions(
 	options: UseBatchActionsOptions,
 ): UseBatchActionsResult {
-	const { onSuccess } = options;
+	const { onSuccess, canCancelAllBuilds } = options;
 
 	const startAllMutation = useMutation({
 		mutationFn: (workspaces: readonly Workspace[]) => {
@@ -64,8 +65,12 @@ export function useBatchActions(
 		mutationFn: (workspaces: readonly Workspace[]) => {
 			return Promise.all(
 				workspaces
-					.filter((w) =>
-						CANCELLABLE_BUILD_STATUSES.includes(w.latest_build.status),
+					.filter(
+						(w) =>
+							CANCELLABLE_BUILD_STATUSES.includes(w.latest_build.status) &&
+							(w.latest_build.status === "pending" ||
+								w.template_allow_user_cancel_workspace_jobs ||
+								canCancelAllBuilds),
 					)
 					.map((w) => {
 						const { status } = w.latest_build;

--- a/site/src/pages/WorkspacesPage/batchActions.ts
+++ b/site/src/pages/WorkspacesPage/batchActions.ts
@@ -3,7 +3,7 @@ import { toast } from "sonner";
 import { API } from "#/api/api";
 import { getErrorDetail } from "#/api/errors";
 import type { Response, Workspace, WorkspaceBuild } from "#/api/typesGenerated";
-import { CANCELLABLE_BUILD_STATUSES } from "#/modules/workspaces/status";
+import { canCancelWorkspaceBuild } from "#/modules/workspaces/actions";
 
 interface UseBatchActionsOptions {
 	onSuccess: () => Promise<void>;
@@ -65,12 +65,8 @@ export function useBatchActions(
 		mutationFn: (workspaces: readonly Workspace[]) => {
 			return Promise.all(
 				workspaces
-					.filter(
-						(w) =>
-							CANCELLABLE_BUILD_STATUSES.includes(w.latest_build.status) &&
-							(w.latest_build.status === "pending" ||
-								w.template_allow_user_cancel_workspace_jobs ||
-								canCancelAllBuilds),
+					.filter((w) =>
+						canCancelWorkspaceBuild(w, { isOwner: canCancelAllBuilds }),
 					)
 					.map((w) => {
 						const { status } = w.latest_build;

--- a/site/src/pages/WorkspacesPage/batchActions.ts
+++ b/site/src/pages/WorkspacesPage/batchActions.ts
@@ -2,7 +2,8 @@ import { useMutation } from "react-query";
 import { toast } from "sonner";
 import { API } from "#/api/api";
 import { getErrorDetail } from "#/api/errors";
-import type { Workspace, WorkspaceBuild } from "#/api/typesGenerated";
+import type { Response, Workspace, WorkspaceBuild } from "#/api/typesGenerated";
+import { CANCELLABLE_BUILD_STATUSES } from "#/modules/workspaces/status";
 
 interface UseBatchActionsOptions {
 	onSuccess: () => Promise<void>;
@@ -17,6 +18,7 @@ type UseBatchActionsResult = Readonly<{
 	isProcessing: boolean;
 	start: (workspaces: readonly Workspace[]) => Promise<WorkspaceBuild[]>;
 	stop: (workspaces: readonly Workspace[]) => Promise<WorkspaceBuild[]>;
+	cancel: (workspaces: readonly Workspace[]) => Promise<Response[]>;
 	delete: (workspaces: readonly Workspace[]) => Promise<WorkspaceBuild[]>;
 	updateTemplateVersions: (
 		payload: UpdateAllPayload,
@@ -53,6 +55,24 @@ export function useBatchActions(
 		onSuccess,
 		onError: (error) => {
 			toast.error("Failed to stop workspaces.", {
+				description: getErrorDetail(error),
+			});
+		},
+	});
+
+	const cancelAllMutation = useMutation({
+		mutationFn: (workspaces: readonly Workspace[]) => {
+			return Promise.all(
+				workspaces
+					.filter((w) =>
+						CANCELLABLE_BUILD_STATUSES.includes(w.latest_build.status),
+					)
+					.map((w) => API.cancelWorkspaceBuild(w.latest_build.id)),
+			);
+		},
+		onSuccess,
+		onError: (error) => {
+			toast.error("Failed to cancel some workspace builds.", {
 				description: getErrorDetail(error),
 			});
 		},
@@ -129,6 +149,7 @@ export function useBatchActions(
 		unfavorite: unfavoriteAllMutation.mutateAsync,
 		start: startAllMutation.mutateAsync,
 		stop: stopAllMutation.mutateAsync,
+		cancel: cancelAllMutation.mutateAsync,
 		delete: deleteAllMutation.mutateAsync,
 		updateTemplateVersions: updateAllMutation.mutateAsync,
 		isProcessing:
@@ -136,6 +157,7 @@ export function useBatchActions(
 			unfavoriteAllMutation.isPending ||
 			startAllMutation.isPending ||
 			stopAllMutation.isPending ||
+			cancelAllMutation.isPending ||
 			deleteAllMutation.isPending,
 	};
 }

--- a/site/src/pages/WorkspacesPage/batchActions.ts
+++ b/site/src/pages/WorkspacesPage/batchActions.ts
@@ -67,7 +67,14 @@ export function useBatchActions(
 					.filter((w) =>
 						CANCELLABLE_BUILD_STATUSES.includes(w.latest_build.status),
 					)
-					.map((w) => API.cancelWorkspaceBuild(w.latest_build.id)),
+					.map((w) => {
+						const { status } = w.latest_build;
+						const params =
+							status === "pending" || status === "running"
+								? { expect_status: status }
+								: undefined;
+						return API.cancelWorkspaceBuild(w.latest_build.id, params);
+					}),
 			);
 		},
 		onSuccess,


### PR DESCRIPTION
Adds a Cancel option to the bulk actions dropdown in the workspaces page, allowing users to cancel in-progress workspace builds in bulk.

Closes #23198

## Changes

- batchActions.ts - Added cancelAllMutation that calls API.cancelWorkspaceBuild for each workspace with a cancellable status
- WorkspacesPageView.tsx - Added Cancel dropdown menu item with CircleXIcon, enabled when any selected workspace has a cancellable build
- WorkspacesPage.tsx - Wired up onBatchCancelTransition callback
- status.ts - Exported CANCELLABLE_BUILD_STATUSES (starting, stopping, pending, deleting) for shared use
- WorkspacesPage.test.tsx - Added test verifying only cancellable workspaces are cancelled
- workspace-management.md - Updated bulk operations docs to mention cancel

Cancel is enabled when at least one selected workspace has a cancellable status. The mutation filters to only cancellable workspaces before calling the API. No confirmation dialog since cancel is non-destructive.