### PR TITLE
chore: remove racy ChatStatusPending assertions after CreateChat

### DIFF
--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -216,7 +216,6 @@ func TestPostChats(t *testing.T) {
 		require.Equal(t, member.ID, chat.OwnerID)
 		require.Equal(t, modelConfig.ID, chat.LastModelConfigID)
 		require.Equal(t, "hello from chats route tests", chat.Title)
-		require.Equal(t, codersdk.ChatStatusPending, chat.Status)
 		require.NotZero(t, chat.CreatedAt)
 		require.NotZero(t, chat.UpdatedAt)
 		require.Nil(t, chat.WorkspaceID)

--- a/enterprise/coderd/exp_chats_test.go
+++ b/enterprise/coderd/exp_chats_test.go
@@ -100,7 +100,6 @@ func TestChatStreamRelay(t *testing.T) {
 			ModelConfigID: &model.ID,
 		})
 		require.NoError(t, err)
-		require.Equal(t, codersdk.ChatStatusPending, chat.Status)
 
 		var runningChat database.Chat
 		require.Eventually(t, func() bool {
@@ -289,7 +288,6 @@ func TestChatStreamRelay(t *testing.T) {
 			ModelConfigID: &model.ID,
 		})
 		require.NoError(t, err)
-		require.Equal(t, codersdk.ChatStatusPending, chat.Status)
 
 		var runningChat database.Chat
 		require.Eventually(t, func() bool {
@@ -459,7 +457,6 @@ func TestChatStreamRelay(t *testing.T) {
 			ModelConfigID: &model.ID,
 		})
 		require.NoError(t, err)
-		require.Equal(t, codersdk.ChatStatusPending, chat.Status)
 
 		var runningChat database.Chat
 		require.Eventually(t, func() bool {
@@ -631,7 +628,6 @@ func TestChatStreamRelay(t *testing.T) {
 			ModelConfigID: &model.ID,
 		})
 		require.NoError(t, err)
-		require.Equal(t, codersdk.ChatStatusPending, chat.Status)
 
 		var runningChat database.Chat
 		require.Eventually(t, func() bool {
@@ -779,7 +775,6 @@ func TestChatStreamRelay(t *testing.T) {
 			ModelConfigID: &model.ID,
 		})
 		require.NoError(t, err)
-		require.Equal(t, codersdk.ChatStatusPending, chat.Status)
 
 		var runningChat database.Chat
 		require.Eventually(t, func() bool {


### PR DESCRIPTION
Removes 6 fragile `require.Equal(t, codersdk.ChatStatusPending, chat.Status)` assertions from chat relay and creation tests.

**Root cause**: In HA tests with two replicas sharing the same DB, the worker can acquire a just-created chat (flipping `pending → running` via `AcquireChats`) before the HTTP response reaches the test. All affected tests already synchronize via `require.Eventually` waiting for `running` status, making the initial assertion both redundant and racy.

- Remove 5 assertions in `enterprise/coderd/exp_chats_test.go` (all `TestChatStreamRelay` subtests)
- Remove 1 assertion in `coderd/exp_chats_test.go` (`TestPostChats`)
- An existing comment in `TestPostChats/Success` already documents this exact race

Fixes flake: https://github.com/coder/coder/actions/runs/23807597632/job/69385425724

> 🤖 Written by a Coder Agent. Will be reviewed by a human.