### PR TITLE
fix(site): align alerts with design system

### DIFF
--- a/site/src/pages/AgentsPage/AgentSettingsBehaviorPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsBehaviorPageView.tsx
@@ -2,7 +2,7 @@ import type { FC, FormEvent } from "react";
 import { useMemo, useState } from "react";
 import TextareaAutosize from "react-textarea-autosize";
 import type * as TypesGen from "#/api/typesGenerated";
-import { Alert } from "#/components/Alert/Alert";
+import { Alert, AlertDescription } from "#/components/Alert/Alert";
 import { Button } from "#/components/Button/Button";
 import { Link } from "#/components/Link/Link";
 import { Switch } from "#/components/Switch/Switch";
@@ -271,9 +271,11 @@ export const AgentSettingsBehaviorPageView: FC<
 				/>
 				{userInvisibleCharCount > 0 && (
 					<Alert severity="warning">
-						This text contains {userInvisibleCharCount} invisible Unicode{" "}
-						{userInvisibleCharCount !== 1 ? "characters" : "character"} that
-						could hide content. These will be stripped on save.
+						<AlertDescription>
+							This text contains {userInvisibleCharCount} invisible Unicode{" "}
+							{userInvisibleCharCount !== 1 ? "characters" : "character"} that
+							could hide content. These will be stripped on save.
+						</AlertDescription>
 					</Alert>
 				)}
 				<div className="flex justify-end gap-2">
@@ -368,9 +370,12 @@ export const AgentSettingsBehaviorPageView: FC<
 						/>
 						{systemInvisibleCharCount > 0 && (
 							<Alert severity="warning">
-								This text contains {systemInvisibleCharCount} invisible Unicode{" "}
-								{systemInvisibleCharCount !== 1 ? "characters" : "character"}{" "}
-								that could hide content. These will be stripped on save.
+								<AlertDescription>
+									This text contains {systemInvisibleCharCount} invisible
+									Unicode{" "}
+									{systemInvisibleCharCount !== 1 ? "characters" : "character"}{" "}
+									that could hide content. These will be stripped on save.
+								</AlertDescription>
 							</Alert>
 						)}
 						<div className="flex justify-end gap-2">

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -22,7 +22,7 @@ import {
 } from "react";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { ChatMessagePart, ChatQueuedMessage } from "#/api/typesGenerated";
-import { Alert } from "#/components/Alert/Alert";
+import { Alert, AlertDescription } from "#/components/Alert/Alert";
 import { Button } from "#/components/Button/Button";
 import {
 	ChatMessageInput,
@@ -666,9 +666,11 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 				{invisibleCharCount > 0 && (
 					<div className="px-3 pb-1">
 						<Alert severity="warning">
-							This message contains {invisibleCharCount} invisible Unicode
-							character{invisibleCharCount !== 1 ? "s" : ""} that could hide
-							content. Review carefully before sending.
+							<AlertDescription>
+								This message contains {invisibleCharCount} invisible Unicode
+								character{invisibleCharCount !== 1 ? "s" : ""} that could hide
+								content. Review carefully before sending.
+							</AlertDescription>
 						</Alert>
 					</div>
 				)}

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router";
 import { toast } from "sonner";
 import { isApiError } from "#/api/errors";
 import type * as TypesGen from "#/api/typesGenerated";
-import { Alert } from "#/components/Alert/Alert";
+import { Alert, AlertDescription } from "#/components/Alert/Alert";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { Button } from "#/components/Button/Button";
 import { useDashboard } from "#/modules/dashboard/useDashboard";
@@ -300,14 +300,15 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 					isUsageLimitData(createError.response.data) ? (
 						<Alert
 							severity="info"
-							className="py-2"
 							actions={
 								<Button asChild size="sm">
 									<Link to="/agents/analytics">View Usage</Link>
 								</Button>
 							}
 						>
-							{formatUsageLimitMessage(createError.response.data)}
+							<AlertDescription>
+								{formatUsageLimitMessage(createError.response.data)}
+							</AlertDescription>
 						</Alert>
 					) : (
 						<ErrorAlert error={createError} />

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -302,7 +302,7 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 							severity="info"
 							className="py-2"
 							actions={
-								<Button asChild variant="subtle" size="sm">
+								<Button asChild size="sm">
 									<Link to="/agents/analytics">View Usage</Link>
 								</Button>
 							}

--- a/site/src/pages/AgentsPage/components/ChatAccessDeniedAlert.tsx
+++ b/site/src/pages/AgentsPage/components/ChatAccessDeniedAlert.tsx
@@ -1,5 +1,5 @@
 import type { FC } from "react";
-import { Alert } from "#/components/Alert/Alert";
+import { Alert, AlertDescription, AlertTitle } from "#/components/Alert/Alert";
 import { Button } from "#/components/Button/Button";
 import { Link } from "#/components/Link/Link";
 import { docs } from "#/utils/docs";
@@ -14,26 +14,24 @@ export const ChatAccessDeniedAlert: FC = () => {
 			severity="info"
 			className="py-2"
 			actions={
-				<div className="flex gap-2">
-					<Button
-						variant="subtle"
-						size="sm"
-						onClick={() => window.location.reload()}
-					>
-						Refresh
-					</Button>
-					<Link href={docsLink} target="_blank" rel="noreferrer" size="sm">
-						View Docs
-					</Link>
-				</div>
+				<Button
+					variant="subtle"
+					size="sm"
+					onClick={() => window.location.reload()}
+				>
+					Refresh
+				</Button>
 			}
 		>
-			<p className="m-0 font-medium">Permission required</p>
-			<p className="m-0 mt-1 text-sm text-content-secondary">
+			<AlertTitle>Permission required</AlertTitle>
+			<AlertDescription>
 				You don't have permission to create chats. Contact your Coder
 				administrator for access. Refresh this page after access has been
-				granted.
-			</p>
+				granted.{" "}
+				<Link href={docsLink} target="_blank" rel="noreferrer">
+					View Docs
+				</Link>
+			</AlertDescription>
 		</Alert>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatAccessDeniedAlert.tsx
+++ b/site/src/pages/AgentsPage/components/ChatAccessDeniedAlert.tsx
@@ -11,11 +11,10 @@ export const ChatAccessDeniedAlert: FC = () => {
 
 	return (
 		<Alert
-				severity="info"			actions={
-					<Button
-						size="sm"
-						onClick={() => window.location.reload()}
-					>					Refresh
+			severity="info"
+			actions={
+				<Button size="sm" onClick={() => window.location.reload()}>
+					Refresh
 				</Button>
 			}
 		>

--- a/site/src/pages/AgentsPage/components/ChatAccessDeniedAlert.tsx
+++ b/site/src/pages/AgentsPage/components/ChatAccessDeniedAlert.tsx
@@ -11,9 +11,7 @@ export const ChatAccessDeniedAlert: FC = () => {
 
 	return (
 		<Alert
-			severity="info"
-			className="py-2"
-			actions={
+				severity="info"			actions={
 					<Button
 						size="sm"
 						onClick={() => window.location.reload()}

--- a/site/src/pages/AgentsPage/components/ChatAccessDeniedAlert.tsx
+++ b/site/src/pages/AgentsPage/components/ChatAccessDeniedAlert.tsx
@@ -14,12 +14,10 @@ export const ChatAccessDeniedAlert: FC = () => {
 			severity="info"
 			className="py-2"
 			actions={
-				<Button
-					variant="subtle"
-					size="sm"
-					onClick={() => window.location.reload()}
-				>
-					Refresh
+					<Button
+						size="sm"
+						onClick={() => window.location.reload()}
+					>					Refresh
 				</Button>
 			}
 		>

--- a/site/src/pages/AgentsPage/components/ChatConversation/ChatStatusCallout.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ChatStatusCallout.tsx
@@ -1,7 +1,6 @@
-import { ExternalLinkIcon } from "lucide-react";
 import { type FC, useEffect, useState } from "react";
 import { Alert, AlertDescription, AlertTitle } from "#/components/Alert/Alert";
-import { Button } from "#/components/Button/Button";
+import { Link } from "#/components/Link/Link";
 import { Pill } from "#/components/Pill/Pill";
 import { Response, Shimmer } from "../ChatElements";
 import { getKindLabel, getProviderStatusURL } from "./chatStatusHelpers";
@@ -133,20 +132,7 @@ const StatusAlert: FC<{ status: RetryOrFailedStatus }> = ({ status }) => {
 		(status.phase === "failed" && status.statusCode !== undefined);
 
 	return (
-		<Alert
-			severity={severity}
-			className="py-3"
-			actions={
-				statusURL && (
-					<Button asChild variant="subtle" size="sm">
-						<a href={statusURL} target="_blank" rel="noreferrer">
-							Status
-							<ExternalLinkIcon />
-						</a>
-					</Button>
-				)
-			}
-		>
+		<Alert severity={severity} className="py-3">
 			<div className="space-y-2.5">
 				<div className="flex flex-wrap items-center gap-2">
 					<AlertTitle>{status.title}</AlertTitle>
@@ -157,7 +143,19 @@ const StatusAlert: FC<{ status: RetryOrFailedStatus }> = ({ status }) => {
 						{getKindLabel(status.kind)}
 					</Pill>
 				</div>
-				<AlertDescription>{status.message}</AlertDescription>
+				<AlertDescription>
+					{status.message}
+					{statusURL && (
+						<Link
+							href={statusURL}
+							target="_blank"
+							rel="noreferrer"
+							className="ml-1"
+						>
+							Status
+						</Link>
+					)}
+				</AlertDescription>
 				{hasMetadata && (
 					<div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-content-secondary">
 						{status.phase === "retrying" && status.retryingAt && (

--- a/site/src/pages/AgentsPage/components/ChatConversation/ChatStatusCallout.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ChatStatusCallout.tsx
@@ -126,51 +126,39 @@ const StatusAlert: FC<{ status: RetryOrFailedStatus }> = ({ status }) => {
 
 	return (
 		<Alert severity={severity}>
-			<div className="space-y-2.5">
-				<AlertTitle>{status.title}</AlertTitle>{" "}
-				<AlertDescription>
-					{status.message}{" "}
-					{statusURL && (
-						<Link href={statusURL} target="_blank" rel="noreferrer">
-							Status
-						</Link>
-					)}
-				</AlertDescription>
-				{hasMetadata && (
-					<div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-content-secondary">
-						{status.phase === "retrying" && status.retryingAt && (
-							<StatusCountdown
-								deadline={status.retryingAt}
-								label="Retrying in"
-							/>
-						)}
-						{status.phase === "retrying" && (
-							<span>Attempt {status.attempt}</span>
-						)}
-
-						{status.phase === "failed" && status.statusCode !== undefined && (
-							<span>HTTP {status.statusCode}</span>
-						)}
-					</div>
+			<AlertTitle>{status.title}</AlertTitle>
+			<AlertDescription>
+				{status.message}{" "}
+				{statusURL && (
+					<Link href={statusURL} target="_blank" rel="noreferrer">
+						Status
+					</Link>
 				)}
-			</div>
+			</AlertDescription>
+			{hasMetadata && (
+				<div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-content-secondary">
+					{status.phase === "retrying" && status.retryingAt && (
+						<StatusCountdown deadline={status.retryingAt} label="Retrying in" />
+					)}
+					{status.phase === "retrying" && <span>Attempt {status.attempt}</span>}
+
+					{status.phase === "failed" && status.statusCode !== undefined && (
+						<span>HTTP {status.statusCode}</span>
+					)}
+				</div>
+			)}
 		</Alert>
 	);
 };
 
 const ReconnectingAlert: FC<{ status: ReconnectingStatus }> = ({ status }) => {
 	return (
-		<Alert severity="info" className="py-3">
-			<div className="space-y-2.5">
-				<AlertTitle>{status.title}</AlertTitle>
-				<AlertDescription>{status.message}</AlertDescription>
-				<div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-content-secondary">
-					<StatusCountdown
-						deadline={status.retryingAt}
-						label="Reconnecting in"
-					/>
-					<span>Attempt {status.attempt}</span>
-				</div>
+		<Alert severity="info">
+			<AlertTitle>{status.title}</AlertTitle>
+			<AlertDescription>{status.message}</AlertDescription>
+			<div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-content-secondary">
+				<StatusCountdown deadline={status.retryingAt} label="Reconnecting in" />
+				<span>Attempt {status.attempt}</span>
 			</div>
 		</Alert>
 	);

--- a/site/src/pages/AgentsPage/components/ChatConversation/ChatStatusCallout.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ChatStatusCallout.tsx
@@ -132,7 +132,7 @@ const StatusAlert: FC<{ status: RetryOrFailedStatus }> = ({ status }) => {
 		(status.phase === "failed" && status.statusCode !== undefined);
 
 	return (
-		<Alert severity={severity} className="py-3">
+		<Alert severity={severity}>
 			<div className="space-y-2.5">
 				<div className="flex flex-wrap items-center gap-2">
 					<AlertTitle>{status.title}</AlertTitle>

--- a/site/src/pages/AgentsPage/components/ChatConversation/ChatStatusCallout.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ChatStatusCallout.tsx
@@ -144,14 +144,9 @@ const StatusAlert: FC<{ status: RetryOrFailedStatus }> = ({ status }) => {
 					</Pill>
 				</div>
 				<AlertDescription>
-					{status.message}
+					{status.message}{" "}
 					{statusURL && (
-						<Link
-							href={statusURL}
-							target="_blank"
-							rel="noreferrer"
-							className="ml-1"
-						>
+						<Link href={statusURL} target="_blank" rel="noreferrer">
 							Status
 						</Link>
 					)}

--- a/site/src/pages/AgentsPage/components/ChatConversation/ChatStatusCallout.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ChatStatusCallout.tsx
@@ -1,9 +1,8 @@
 import { type FC, useEffect, useState } from "react";
 import { Alert, AlertDescription, AlertTitle } from "#/components/Alert/Alert";
 import { Link } from "#/components/Link/Link";
-import { Pill } from "#/components/Pill/Pill";
 import { Response, Shimmer } from "../ChatElements";
-import { getKindLabel, getProviderStatusURL } from "./chatStatusHelpers";
+import { getProviderStatusURL } from "./chatStatusHelpers";
 import type { LiveStatusModel } from "./liveStatusModel";
 
 const RESPONSE_STARTUP_GRACE_MS = 15_000;
@@ -115,12 +114,6 @@ const StatusCountdown: FC<{
 
 const StatusAlert: FC<{ status: RetryOrFailedStatus }> = ({ status }) => {
 	const statusURL = getProviderStatusURL(status.kind, status.provider);
-	const pillType =
-		status.phase === "failed"
-			? "error"
-			: status.kind === "generic"
-				? "inactive"
-				: "warning";
 	const severity =
 		status.phase === "failed"
 			? "error"
@@ -134,15 +127,7 @@ const StatusAlert: FC<{ status: RetryOrFailedStatus }> = ({ status }) => {
 	return (
 		<Alert severity={severity}>
 			<div className="space-y-2.5">
-				<div className="flex flex-wrap items-center gap-2">
-					<AlertTitle>{status.title}</AlertTitle>
-					<Pill
-						className="h-5 px-2.5 text-[10px] font-semibold"
-						type={pillType}
-					>
-						{getKindLabel(status.kind)}
-					</Pill>
-				</div>
+				<AlertTitle>{status.title}</AlertTitle>{" "}
 				<AlertDescription>
 					{status.message}{" "}
 					{statusURL && (

--- a/site/src/pages/AgentsPage/components/ChatConversation/ChatStatusCallout.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ChatStatusCallout.tsx
@@ -120,20 +120,34 @@ const StatusAlert: FC<{ status: RetryOrFailedStatus }> = ({ status }) => {
 			: status.kind === "generic"
 				? "info"
 				: "warning";
-	const metadata = (
-		<div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-content-secondary">
-			{status.phase === "retrying" && status.retryingAt && (
-				<StatusCountdown deadline={status.retryingAt} label="Retrying in" />
-			)}
-			{status.phase === "retrying" && <span>Attempt {status.attempt}</span>}
-			{status.phase === "failed" && status.statusCode !== undefined && (
-				<span>HTTP {status.statusCode}</span>
-			)}
-		</div>
-	);
+	const metadataItems: React.ReactNode[] = [];
+	if (status.phase === "retrying" && status.retryingAt) {
+		metadataItems.push(
+			<StatusCountdown
+				key="countdown"
+				deadline={status.retryingAt}
+				label="Retrying in"
+			/>,
+		);
+	}
+	if (status.phase === "retrying") {
+		metadataItems.push(<span key="attempt">Attempt {status.attempt}</span>);
+	}
+	if (status.phase === "failed" && status.statusCode !== undefined) {
+		metadataItems.push(<span key="code">HTTP {status.statusCode}</span>);
+	}
 
 	return (
-		<Alert severity={severity} actions={metadata}>
+		<Alert
+			severity={severity}
+			actions={
+				metadataItems.length > 0 ? (
+					<div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-content-secondary">
+						{metadataItems}
+					</div>
+				) : undefined
+			}
+		>
 			<AlertTitle>{status.title}</AlertTitle>
 			<AlertDescription>
 				{status.message}{" "}

--- a/site/src/pages/AgentsPage/components/ChatConversation/ChatStatusCallout.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ChatStatusCallout.tsx
@@ -120,12 +120,20 @@ const StatusAlert: FC<{ status: RetryOrFailedStatus }> = ({ status }) => {
 			: status.kind === "generic"
 				? "info"
 				: "warning";
-	const hasMetadata =
-		status.phase === "retrying" ||
-		(status.phase === "failed" && status.statusCode !== undefined);
+	const metadata = (
+		<div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-content-secondary">
+			{status.phase === "retrying" && status.retryingAt && (
+				<StatusCountdown deadline={status.retryingAt} label="Retrying in" />
+			)}
+			{status.phase === "retrying" && <span>Attempt {status.attempt}</span>}
+			{status.phase === "failed" && status.statusCode !== undefined && (
+				<span>HTTP {status.statusCode}</span>
+			)}
+		</div>
+	);
 
 	return (
-		<Alert severity={severity}>
+		<Alert severity={severity} actions={metadata}>
 			<AlertTitle>{status.title}</AlertTitle>
 			<AlertDescription>
 				{status.message}{" "}
@@ -135,31 +143,26 @@ const StatusAlert: FC<{ status: RetryOrFailedStatus }> = ({ status }) => {
 					</Link>
 				)}
 			</AlertDescription>
-			{hasMetadata && (
-				<div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-content-secondary">
-					{status.phase === "retrying" && status.retryingAt && (
-						<StatusCountdown deadline={status.retryingAt} label="Retrying in" />
-					)}
-					{status.phase === "retrying" && <span>Attempt {status.attempt}</span>}
-
-					{status.phase === "failed" && status.statusCode !== undefined && (
-						<span>HTTP {status.statusCode}</span>
-					)}
-				</div>
-			)}
 		</Alert>
 	);
 };
 
 const ReconnectingAlert: FC<{ status: ReconnectingStatus }> = ({ status }) => {
 	return (
-		<Alert severity="info">
+		<Alert
+			severity="info"
+			actions={
+				<div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-content-secondary">
+					<StatusCountdown
+						deadline={status.retryingAt}
+						label="Reconnecting in"
+					/>
+					<span>Attempt {status.attempt}</span>
+				</div>
+			}
+		>
 			<AlertTitle>{status.title}</AlertTitle>
 			<AlertDescription>{status.message}</AlertDescription>
-			<div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-content-secondary">
-				<StatusCountdown deadline={status.retryingAt} label="Reconnecting in" />
-				<span>Attempt {status.attempt}</span>
-			</div>
 		</Alert>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.stories.tsx
@@ -92,7 +92,6 @@ export const TerminalOverloadedError: Story = {
 		expect(
 			canvas.getByRole("heading", { name: /service overloaded/i }),
 		).toBeVisible();
-		expect(canvas.getByText("Overloaded")).toBeVisible();
 		expect(
 			canvas.getByText(/anthropic is currently overloaded./i),
 		).toBeVisible();
@@ -122,7 +121,6 @@ export const TerminalStartupTimeoutError: Story = {
 		expect(
 			canvas.getByRole("heading", { name: /startup timed out/i }),
 		).toBeVisible();
-		expect(canvas.getByText("Startup timeout")).toBeVisible();
 		expect(
 			canvas.getByText(/anthropic did not start responding in time./i),
 		).toBeVisible();

--- a/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.tsx
@@ -92,9 +92,8 @@ export const LiveStreamTailContent = ({
 			{usageLimitStatus ? (
 				<Alert
 					severity="info"
-					className="py-2"
 					actions={
-						<Button asChild variant="subtle" size="sm">
+						<Button asChild size="sm">
 							<Link to="/agents/analytics">View Usage</Link>
 						</Button>
 					}

--- a/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.tsx
@@ -1,7 +1,7 @@
 import { Link } from "react-router";
 import type { UrlTransform } from "streamdown";
 import type * as TypesGen from "#/api/typesGenerated";
-import { Alert } from "#/components/Alert/Alert";
+import { Alert, AlertDescription } from "#/components/Alert/Alert";
 import { Button } from "#/components/Button/Button";
 import type { ChatDetailError } from "../../utils/usageLimitMessage";
 import { ChatStatusCallout } from "./ChatStatusCallout";
@@ -98,7 +98,7 @@ export const LiveStreamTailContent = ({
 						</Button>
 					}
 				>
-					{usageLimitStatus.message}
+					<AlertDescription>{usageLimitStatus.message}</AlertDescription>
 				</Alert>
 			) : terminalStatus ? (
 				<ChatStatusCallout status={terminalStatus} />

--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.stories.tsx
@@ -95,7 +95,6 @@ export const RetryWithVisibleReason: Story = {
 		expect(
 			canvas.getByText(/anthropic returned an unexpected error/i),
 		).toBeVisible();
-		expect(canvas.getByText("Unexpected error")).toBeVisible();
 		expect(canvas.getByText(/attempt 1/i)).toBeVisible();
 		expect(canvas.queryByText(/please try again/i)).not.toBeInTheDocument();
 		expect(canvas.queryByText(/provider anthropic/i)).not.toBeInTheDocument();
@@ -125,7 +124,6 @@ export const RetryRateLimited: Story = {
 		expect(
 			canvas.getByText(/anthropic is rate limiting requests/i),
 		).toBeVisible();
-		expect(canvas.getByText("Rate limit")).toBeVisible();
 		await waitFor(() => {
 			expect(canvasElement.textContent).toMatch(/retrying in \d+s/i);
 		});
@@ -160,7 +158,6 @@ export const RetryInvalidTimestamp: Story = {
 		expect(
 			canvas.getByText(/anthropic is rate limiting requests/i),
 		).toBeVisible();
-		expect(canvas.getByText("Rate limit")).toBeVisible();
 		expect(canvas.getByText(/attempt 3/i)).toBeVisible();
 		await waitFor(() => {
 			expect(canvas.queryByText(/retrying in nan/i)).not.toBeInTheDocument();
@@ -192,7 +189,6 @@ export const RetryOverloaded: Story = {
 		expect(
 			canvas.getByText(/anthropic is temporarily overloaded/i),
 		).toBeVisible();
-		expect(canvas.getByText("Overloaded")).toBeVisible();
 		const statusLink = screen.getByRole("link", { name: /status/i });
 		expect(statusLink).toBeVisible();
 		expect(statusLink).toHaveAttribute("href", "https://status.anthropic.com");
@@ -221,7 +217,6 @@ export const RetryTimeout: Story = {
 		expect(
 			canvas.getByText(/anthropic is temporarily unavailable/i),
 		).toBeVisible();
-		expect(canvas.getByText("Timeout")).toBeVisible();
 		expect(
 			canvas.queryByRole("link", { name: /status/i }),
 		).not.toBeInTheDocument();
@@ -250,7 +245,6 @@ export const RetryStartupTimeout: Story = {
 		expect(
 			canvas.getByText(/anthropic did not start responding in time/i),
 		).toBeVisible();
-		expect(canvas.getByText("Startup timeout")).toBeVisible();
 		expect(canvas.queryByText(/please try again/i)).not.toBeInTheDocument();
 		expect(canvas.queryByText(/provider anthropic/i)).not.toBeInTheDocument();
 		expect(

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStatusHelpers.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStatusHelpers.ts
@@ -23,19 +23,6 @@ const normalizeProvider = (provider?: string): string | undefined => {
 	}
 };
 
-const humanizeKind = (kind: string): string => {
-	const words = kind
-		.trim()
-		.split(/[_\-\s]+/)
-		.filter(Boolean);
-	if (words.length === 0) {
-		return "Unexpected error";
-	}
-	return words
-		.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-		.join(" ");
-};
-
 export const getErrorTitle = (
 	kind: ChatProviderFailureKind | (string & {}),
 	mode: "retry" | "error",
@@ -55,29 +42,6 @@ export const getErrorTitle = (
 			return "Configuration error";
 		default:
 			return mode === "retry" ? "Retrying request" : "Request failed";
-	}
-};
-
-export const getKindLabel = (
-	kind: ChatProviderFailureKind | (string & {}),
-): string => {
-	switch (kind) {
-		case "generic":
-			return "Unexpected error";
-		case "overloaded":
-			return "Overloaded";
-		case "rate_limit":
-			return "Rate limit";
-		case "timeout":
-			return "Timeout";
-		case "startup_timeout":
-			return "Startup timeout";
-		case "auth":
-			return "Authentication";
-		case "config":
-			return "Configuration";
-		default:
-			return humanizeKind(kind);
 	}
 };
 


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

Standardizes every Alert in `AgentsPage/` to use the component properly ahead of #22597.

### What changed

**Inline links instead of action buttons** (`ChatStatusCallout`, `ChatAccessDeniedAlert`)
- "Status" and "View Docs" links moved from the `actions` prop into `AlertDescription` so they sit inline with message text, matching the design system.

**Correct button variants** (`ChatAccessDeniedAlert`, `AgentCreateForm`, `LiveStreamTail`)
- Action buttons (Refresh, View Usage) use the default high-contrast variant instead of `variant="subtle"`.

**Remove redundant kind pill** (`ChatStatusCallout`)
- The pill (e.g. "Overloaded") just repeated the alert title ("Service overloaded"). Removed along with dead `getKindLabel` and `humanizeKind` helpers.

**Use Alert's built-in spacing** (`ChatStatusCallout`, `ChatAccessDeniedAlert`, `AgentCreateForm`)
- Drop custom `py-2`/`py-3` padding overrides and `space-y-2.5` wrapper divs.

**Use `actions` for metadata** (`ChatStatusCallout`)
- Retry/failure metadata (countdown, attempt, HTTP code) moved into the `actions` prop. Only passed when non-empty to avoid extra bottom padding on generic errors.

**Wrap all text in `AlertDescription`** (`AgentCreateForm`, `AgentChatInput`, `AgentSettingsBehaviorPageView`, `LiveStreamTail`)
- Every Alert that was passing raw text children now uses `AlertDescription`.