### PR TITLE
feat(site): force-enable kyleosophy on dev.coder.com

### DIFF
--- a/site/src/pages/AgentsPage/AgentSettingsBehaviorPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsBehaviorPageView.tsx
@@ -13,7 +13,11 @@ import { DurationField } from "./components/DurationField/DurationField";
 import { SectionHeader } from "./components/SectionHeader";
 import { TextPreviewDialog } from "./components/TextPreviewDialog";
 import { UserCompactionThresholdSettings } from "./components/UserCompactionThresholdSettings";
-import { getKylesophyEnabled, setKylesophyEnabled } from "./utils/chime";
+import {
+	getKylesophyEnabled,
+	isKylesophyForced,
+	setKylesophyEnabled,
+} from "./utils/chime";
 
 const textareaMaxHeight = 240;
 const textareaBaseClassName =
@@ -125,6 +129,7 @@ export const AgentSettingsBehaviorPageView: FC<
 	const [isUserPromptOverflowing, setIsUserPromptOverflowing] = useState(false);
 	const [isSystemPromptOverflowing, setIsSystemPromptOverflowing] =
 		useState(false);
+	const kylesophyForced = isKylesophyForced();
 	const [kylesophyEnabled, setKylesophyLocal] = useState(getKylesophyEnabled);
 
 	// ── Derived state ──
@@ -521,14 +526,20 @@ export const AgentSettingsBehaviorPageView: FC<
 				<div className="flex items-center justify-between gap-4">
 					<p className="!mt-0.5 m-0 flex-1 text-xs text-content-secondary">
 						Replace the standard completion chime. IYKYK.
+						{kylesophyForced && (
+							<span className="ml-1 font-semibold">
+								Kyleosophy is mandatory on <code>dev.coder.com</code>.
+							</span>
+						)}
 					</p>
 					<Switch
-						checked={kylesophyEnabled}
+						checked={kylesophyEnabled || kylesophyForced}
 						onCheckedChange={(checked) => {
 							setKylesophyEnabled(checked);
 							setKylesophyLocal(checked);
 						}}
 						aria-label="Enable Kyleosophy"
+						disabled={kylesophyForced}
 					/>
 				</div>
 			</div>

--- a/site/src/pages/AgentsPage/AgentSettingsBehaviorPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsBehaviorPageView.tsx
@@ -533,7 +533,7 @@ export const AgentSettingsBehaviorPageView: FC<
 						)}
 					</p>
 					<Switch
-						checked={kylesophyEnabled || kylesophyForced}
+						checked={kylesophyEnabled}
 						onCheckedChange={(checked) => {
 							setKylesophyEnabled(checked);
 							setKylesophyLocal(checked);

--- a/site/src/pages/AgentsPage/utils/chime.test.ts
+++ b/site/src/pages/AgentsPage/utils/chime.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	getChimeEnabled,
 	getKylesophyEnabled,
+	isKylesophyForced,
 	KYLEOSOPHY_SOUNDS,
 	LOCK_HOLD_MS,
 	maybePlayChime,
@@ -311,5 +312,40 @@ describe("maybePlayChime", () => {
 		const url = (audioSpy as unknown as ReturnType<typeof vi.fn>).mock
 			.calls[0][0] as string;
 		expect(url).toBe("/chime.mp3");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// isKylesophyForced
+// ---------------------------------------------------------------------------
+
+describe("isKylesophyForced", () => {
+	const originalLocation = globalThis.location;
+
+	afterEach(() => {
+		Object.defineProperty(globalThis, "location", {
+			value: originalLocation,
+			writable: true,
+			configurable: true,
+		});
+	});
+
+	it("returns true on dev.coder.com", () => {
+		Object.defineProperty(globalThis, "location", {
+			value: { hostname: "dev.coder.com" },
+			writable: true,
+			configurable: true,
+		});
+		expect(isKylesophyForced()).toBe(true);
+		expect(getKylesophyEnabled()).toBe(true);
+	});
+
+	it("returns false on other hosts", () => {
+		Object.defineProperty(globalThis, "location", {
+			value: { hostname: "coder.example.com" },
+			writable: true,
+			configurable: true,
+		});
+		expect(isKylesophyForced()).toBe(false);
 	});
 });

--- a/site/src/pages/AgentsPage/utils/chime.ts
+++ b/site/src/pages/AgentsPage/utils/chime.ts
@@ -20,10 +20,29 @@ export function setChimeEnabled(enabled: boolean): void {
 	}
 }
 
+/**
+ * Whether Kyleosophy mode is active. Force-enabled on
+ * dev.coder.com because the people deserve Kyle.
+ */
 export function getKylesophyEnabled(): boolean {
+	if (isKylesophyForced()) {
+		return true;
+	}
 	try {
 		const stored = localStorage.getItem(KYLEOSOPHY_PREFERENCE_KEY);
 		return stored === null ? false : stored === "true";
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Whether the current deployment force-enables Kyleosophy,
+ * bypassing the user preference.
+ */
+export function isKylesophyForced(): boolean {
+	try {
+		return globalThis.location?.hostname === "dev.coder.com";
 	} catch {
 		return false;
 	}


### PR DESCRIPTION
- Force-enable Kyleosophy on `dev.coder.com` via hostname check
- Toggle shows as checked + disabled with "Kyleosophy is mandatory on `dev.coder.com`"
- `isKylesophyForced()` exported for UI and testability
- Tests for forced/non-forced hostname behavior

> 🤖 Written by a Coder Agent. Will be reviewed by a human.