### PR TITLE
feat(site): add landscape mode for Desktop panel on mobile

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -29,6 +29,7 @@ import { ChatTopBar } from "./components/ChatTopBar";
 import { GitPanel } from "./components/GitPanel/GitPanel";
 import { RightPanel } from "./components/RightPanel/RightPanel";
 import { SidebarTabView } from "./components/Sidebar/SidebarTabView";
+import { useDesktopMode } from "./hooks/useDesktopMode";
 import type { ChatDetailError } from "./utils/usageLimitMessage";
 
 type ChatStoreHandle = ReturnType<typeof useChatStore>["store"];
@@ -215,6 +216,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	// State for programmatically switching the sidebar tab (e.g. when
 	// the user clicks the inline desktop preview card).
 	const [sidebarTabId, setSidebarTabId] = useState<string | null>(null);
+	const desktopMode = useDesktopMode();
 
 	const handleOpenDesktop = () => {
 		onSetShowSidebarPanel(true);
@@ -397,6 +399,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 						onToggleSidebarCollapsed={onToggleSidebarCollapsed}
 						chatTitle={chatTitle}
 						desktopChatId={desktopChatId}
+						desktopMode={desktopMode}
 					/>
 				</RightPanel>
 			</div>

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -29,7 +29,7 @@ import { ChatTopBar } from "./components/ChatTopBar";
 import { GitPanel } from "./components/GitPanel/GitPanel";
 import { RightPanel } from "./components/RightPanel/RightPanel";
 import { SidebarTabView } from "./components/Sidebar/SidebarTabView";
-import { useDesktopMode } from "./hooks/useDesktopMode";
+import { useDesktopLandscape } from "./hooks/useDesktopMode";
 import type { ChatDetailError } from "./utils/usageLimitMessage";
 
 type ChatStoreHandle = ReturnType<typeof useChatStore>["store"];
@@ -216,7 +216,11 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	// State for programmatically switching the sidebar tab (e.g. when
 	// the user clicks the inline desktop preview card).
 	const [sidebarTabId, setSidebarTabId] = useState<string | null>(null);
-	const desktopMode = useDesktopMode();
+
+	// Lock landscape orientation when the Desktop tab is fullscreened
+	// on mobile. Exiting fullscreen (isRightPanelExpanded = false)
+	// automatically restores portrait.
+	useDesktopLandscape(isRightPanelExpanded && sidebarTabId === "desktop");
 
 	const handleOpenDesktop = () => {
 		onSetShowSidebarPanel(true);
@@ -399,7 +403,6 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 						onToggleSidebarCollapsed={onToggleSidebarCollapsed}
 						chatTitle={chatTitle}
 						desktopChatId={desktopChatId}
-						desktopMode={desktopMode}
 					/>
 				</RightPanel>
 			</div>

--- a/site/src/pages/AgentsPage/components/RightPanel/DesktopPanel.tsx
+++ b/site/src/pages/AgentsPage/components/RightPanel/DesktopPanel.tsx
@@ -1,10 +1,8 @@
-import { FullscreenIcon } from "lucide-react";
 import type { FC } from "react";
 import { useState } from "react";
 import { Button } from "#/components/Button/Button";
 import { Spinner } from "#/components/Spinner/Spinner";
 import { useDesktopConnection } from "../../hooks/useDesktopConnection";
-import type { UseDesktopModeResult } from "../../hooks/useDesktopMode";
 
 type DesktopConnectionStatus =
 	| "idle"
@@ -17,22 +15,15 @@ interface DesktopPanelProps {
 	chatId: string;
 	/** When true the panel is the active sidebar tab. */
 	isVisible?: boolean;
-	/** Desktop landscape mode state from useDesktopMode. */
-	desktopMode?: UseDesktopModeResult;
 }
 
 export interface DesktopPanelViewProps {
 	status: DesktopConnectionStatus;
 	reconnect: () => void;
 	attach: (container: HTMLElement) => void;
-	desktopMode?: UseDesktopModeResult;
 }
 
-export const DesktopPanel: FC<DesktopPanelProps> = ({
-	chatId,
-	isVisible,
-	desktopMode,
-}) => {
+export const DesktopPanel: FC<DesktopPanelProps> = ({ chatId, isVisible }) => {
 	// Delay the VNC connection until the desktop tab is first selected.
 	// Once activated, the connection stays alive even when the tab is
 	// switched away — mirrors the terminal panel pattern from PR #23231.
@@ -46,12 +37,7 @@ export const DesktopPanel: FC<DesktopPanelProps> = ({
 		activated,
 	});
 	return (
-		<DesktopPanelView
-			status={status}
-			reconnect={reconnect}
-			attach={attach}
-			desktopMode={desktopMode}
-		/>
+		<DesktopPanelView status={status} reconnect={reconnect} attach={attach} />
 	);
 };
 
@@ -59,7 +45,6 @@ export const DesktopPanelView: FC<DesktopPanelViewProps> = ({
 	status,
 	reconnect,
 	attach,
-	desktopMode,
 }) => {
 	if (status === "connecting") {
 		return (
@@ -104,27 +89,11 @@ export const DesktopPanelView: FC<DesktopPanelViewProps> = ({
 
 	// status === "connected"
 	return (
-		<div className="relative h-full w-full">
-			<div
-				ref={(el) => {
-					if (el) attach(el);
-				}}
-				className="h-full w-full"
-			/>
-			{/* Landscape button — mobile only, overlaid on the VNC
-			   canvas. Tapping rotates the device to landscape so
-			   the desktop view fills the screen. */}
-			{desktopMode?.isSupported && !desktopMode.isLandscape && (
-				<Button
-					variant="outline"
-					size="sm"
-					onClick={desktopMode.enterLandscape}
-					aria-label="Enter landscape mode"
-					className="absolute bottom-3 right-3 z-10 gap-1.5 bg-surface-primary/90 backdrop-blur-sm shadow-md md:hidden"
-				>
-					<FullscreenIcon className="h-3.5 w-3.5" /> Landscape
-				</Button>
-			)}
-		</div>
+		<div
+			ref={(el) => {
+				if (el) attach(el);
+			}}
+			className="h-full w-full"
+		/>
 	);
 };

--- a/site/src/pages/AgentsPage/components/RightPanel/DesktopPanel.tsx
+++ b/site/src/pages/AgentsPage/components/RightPanel/DesktopPanel.tsx
@@ -1,8 +1,10 @@
+import { FullscreenIcon } from "lucide-react";
 import type { FC } from "react";
 import { useState } from "react";
 import { Button } from "#/components/Button/Button";
 import { Spinner } from "#/components/Spinner/Spinner";
 import { useDesktopConnection } from "../../hooks/useDesktopConnection";
+import type { UseDesktopModeResult } from "../../hooks/useDesktopMode";
 
 type DesktopConnectionStatus =
 	| "idle"
@@ -15,15 +17,22 @@ interface DesktopPanelProps {
 	chatId: string;
 	/** When true the panel is the active sidebar tab. */
 	isVisible?: boolean;
+	/** Desktop landscape mode state from useDesktopMode. */
+	desktopMode?: UseDesktopModeResult;
 }
 
 export interface DesktopPanelViewProps {
 	status: DesktopConnectionStatus;
 	reconnect: () => void;
 	attach: (container: HTMLElement) => void;
+	desktopMode?: UseDesktopModeResult;
 }
 
-export const DesktopPanel: FC<DesktopPanelProps> = ({ chatId, isVisible }) => {
+export const DesktopPanel: FC<DesktopPanelProps> = ({
+	chatId,
+	isVisible,
+	desktopMode,
+}) => {
 	// Delay the VNC connection until the desktop tab is first selected.
 	// Once activated, the connection stays alive even when the tab is
 	// switched away — mirrors the terminal panel pattern from PR #23231.
@@ -37,7 +46,12 @@ export const DesktopPanel: FC<DesktopPanelProps> = ({ chatId, isVisible }) => {
 		activated,
 	});
 	return (
-		<DesktopPanelView status={status} reconnect={reconnect} attach={attach} />
+		<DesktopPanelView
+			status={status}
+			reconnect={reconnect}
+			attach={attach}
+			desktopMode={desktopMode}
+		/>
 	);
 };
 
@@ -45,6 +59,7 @@ export const DesktopPanelView: FC<DesktopPanelViewProps> = ({
 	status,
 	reconnect,
 	attach,
+	desktopMode,
 }) => {
 	if (status === "connecting") {
 		return (
@@ -89,11 +104,27 @@ export const DesktopPanelView: FC<DesktopPanelViewProps> = ({
 
 	// status === "connected"
 	return (
-		<div
-			ref={(el) => {
-				if (el) attach(el);
-			}}
-			className="h-full w-full"
-		/>
+		<div className="relative h-full w-full">
+			<div
+				ref={(el) => {
+					if (el) attach(el);
+				}}
+				className="h-full w-full"
+			/>
+			{/* Landscape button — mobile only, overlaid on the VNC
+			   canvas. Tapping rotates the device to landscape so
+			   the desktop view fills the screen. */}
+			{desktopMode?.isSupported && !desktopMode.isLandscape && (
+				<Button
+					variant="outline"
+					size="sm"
+					onClick={desktopMode.enterLandscape}
+					aria-label="Enter landscape mode"
+					className="absolute bottom-3 right-3 z-10 gap-1.5 bg-surface-primary/90 backdrop-blur-sm shadow-md md:hidden"
+				>
+					<FullscreenIcon className="h-3.5 w-3.5" /> Landscape
+				</Button>
+			)}
+		</div>
 	);
 };

--- a/site/src/pages/AgentsPage/components/Sidebar/SidebarTabView.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/SidebarTabView.tsx
@@ -4,12 +4,14 @@ import {
 	MaximizeIcon,
 	MinimizeIcon,
 	PanelLeftIcon,
+	SmartphoneIcon,
 	XIcon,
 } from "lucide-react";
 import type { ReactNode } from "react";
 import { type FC, useEffect, useId, useRef, useState } from "react";
 import { Button } from "#/components/Button/Button";
 import { cn } from "#/utils/cn";
+import type { UseDesktopModeResult } from "../../hooks/useDesktopMode";
 import { DesktopPanel } from "../RightPanel/DesktopPanel";
 
 /** A single tab definition for the sidebar panel. */
@@ -42,6 +44,8 @@ interface SidebarTabViewProps {
 	onClose?: () => void;
 	/** Desktop chat ID. Omitted if desktop is not available. */
 	desktopChatId?: string;
+	/** Desktop landscape mode state from useDesktopMode. */
+	desktopMode?: UseDesktopModeResult;
 	/** The currently active tab ID (controlled by the parent). */
 	activeTabId: string | null;
 	/** Called when the user switches tabs. */
@@ -111,6 +115,7 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 	chatTitle,
 	onClose,
 	desktopChatId,
+	desktopMode,
 	activeTabId,
 	onActiveTabChange,
 }) => {
@@ -146,6 +151,7 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 				<DesktopPanel
 					chatId={desktopChatId}
 					isVisible={effectiveTabId === "desktop"}
+					desktopMode={desktopMode}
 				/>
 			),
 		});
@@ -307,7 +313,7 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 						</span>
 					</div>
 				)}
-				{/* Right side: close (mobile) / expand (desktop) */}
+				{/* Right side: close (mobile) / landscape (mobile desktop tab) / expand (desktop) */}
 				{onClose && (
 					<Button
 						variant="subtle"
@@ -319,6 +325,22 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 						<XIcon />
 					</Button>
 				)}
+				{/* Landscape toggle — mobile only, when the Desktop
+					   tab is active. Tapping unlocks orientation so the
+					   VNC view fills the screen in landscape. */}
+				{desktopMode?.isSupported &&
+					effectiveTabId === "desktop" &&
+					desktopMode.isLandscape && (
+						<Button
+							variant="subtle"
+							size="icon"
+							onClick={desktopMode.exitLandscape}
+							aria-label="Exit landscape"
+							className="h-7 w-7 shrink-0 text-content-primary md:hidden"
+						>
+							<SmartphoneIcon />
+						</Button>
+					)}
 				<Button
 					variant="subtle"
 					size="icon"

--- a/site/src/pages/AgentsPage/components/Sidebar/SidebarTabView.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/SidebarTabView.tsx
@@ -1,17 +1,16 @@
 import {
 	ChevronLeftIcon,
 	ChevronRightIcon,
+	FullscreenIcon,
 	MaximizeIcon,
 	MinimizeIcon,
 	PanelLeftIcon,
-	SmartphoneIcon,
 	XIcon,
 } from "lucide-react";
 import type { ReactNode } from "react";
 import { type FC, useEffect, useId, useRef, useState } from "react";
 import { Button } from "#/components/Button/Button";
 import { cn } from "#/utils/cn";
-import type { UseDesktopModeResult } from "../../hooks/useDesktopMode";
 import { DesktopPanel } from "../RightPanel/DesktopPanel";
 
 /** A single tab definition for the sidebar panel. */
@@ -44,8 +43,6 @@ interface SidebarTabViewProps {
 	onClose?: () => void;
 	/** Desktop chat ID. Omitted if desktop is not available. */
 	desktopChatId?: string;
-	/** Desktop landscape mode state from useDesktopMode. */
-	desktopMode?: UseDesktopModeResult;
 	/** The currently active tab ID (controlled by the parent). */
 	activeTabId: string | null;
 	/** Called when the user switches tabs. */
@@ -115,7 +112,6 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 	chatTitle,
 	onClose,
 	desktopChatId,
-	desktopMode,
 	activeTabId,
 	onActiveTabChange,
 }) => {
@@ -151,7 +147,6 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 				<DesktopPanel
 					chatId={desktopChatId}
 					isVisible={effectiveTabId === "desktop"}
-					desktopMode={desktopMode}
 				/>
 			),
 		});
@@ -164,6 +159,12 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 		scrollLeft: scrollTabsLeft,
 		scrollRight: scrollTabsRight,
 	} = useTabScroll();
+
+	// Whether to show the mobile fullscreen button for the
+	// desktop tab. Visible only on touch devices when the
+	// Desktop tab is active and the panel is not yet expanded.
+	const showDesktopFullscreen =
+		effectiveTabId === "desktop" && desktopChatId && !isExpanded;
 
 	if (tabs.length === 0 && !desktopChatId) {
 		return (
@@ -313,8 +314,8 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 						</span>
 					</div>
 				)}
-				{/* Right side: close (mobile) / landscape (mobile desktop tab) / expand (desktop) */}
-				{onClose && (
+				{/* Right side: close (mobile) / fullscreen (mobile desktop) / expand (desktop) */}
+				{onClose && !isExpanded && (
 					<Button
 						variant="subtle"
 						size="icon"
@@ -325,22 +326,31 @@ export const SidebarTabView: FC<SidebarTabViewProps> = ({
 						<XIcon />
 					</Button>
 				)}
-				{/* Landscape toggle — mobile only, when the Desktop
-					   tab is active. Tapping unlocks orientation so the
-					   VNC view fills the screen in landscape. */}
-				{desktopMode?.isSupported &&
-					effectiveTabId === "desktop" &&
-					desktopMode.isLandscape && (
-						<Button
-							variant="subtle"
-							size="icon"
-							onClick={desktopMode.exitLandscape}
-							aria-label="Exit landscape"
-							className="h-7 w-7 shrink-0 text-content-primary md:hidden"
-						>
-							<SmartphoneIcon />
-						</Button>
-					)}
+				{/* Mobile fullscreen for Desktop tab — enters expanded
+				    mode which the parent ties to landscape orientation. */}
+				{showDesktopFullscreen && (
+					<Button
+						variant="subtle"
+						size="icon"
+						onClick={onToggleExpanded}
+						aria-label="Fullscreen desktop"
+						className="h-7 w-7 shrink-0 text-content-secondary hover:text-content-primary md:hidden"
+					>
+						<FullscreenIcon />
+					</Button>
+				)}
+				{/* Exit fullscreen — visible on mobile when expanded */}
+				{isExpanded && (
+					<Button
+						variant="subtle"
+						size="icon"
+						onClick={onToggleExpanded}
+						aria-label="Exit fullscreen"
+						className="h-7 w-7 shrink-0 text-content-secondary hover:text-content-primary md:hidden"
+					>
+						<MinimizeIcon />
+					</Button>
+				)}
 				<Button
 					variant="subtle"
 					size="icon"

--- a/site/src/pages/AgentsPage/hooks/useAgentsPWA.ts
+++ b/site/src/pages/AgentsPage/hooks/useAgentsPWA.ts
@@ -3,7 +3,9 @@ import { useEffect } from "react";
 /**
  * Injects PWA-related <head> tags while the Agents page is mounted
  * (manifest, apple-touch-icon, mobile-web-app metas) and tweaks the
- * viewport to prevent zooming. Everything is cleaned up on unmount.
+ * viewport to prevent zooming. On mobile it also locks orientation
+ * to portrait; the Desktop panel can override this at runtime.
+ * Everything is cleaned up on unmount.
  */
 export function useAgentsPWA() {
 	useEffect(() => {
@@ -57,6 +59,24 @@ export function useAgentsPWA() {
 				"width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no";
 		}
 
+		// -- Orientation lock ---------------------------------------------------
+		// Lock portrait by default for a native-app feel on mobile.
+		// The useDesktopMode hook overrides this when the user opens
+		// the Desktop panel in landscape. The lock is best-effort —
+		// it only works in PWA standalone mode on Android and is
+		// silently ignored everywhere else.
+		let orientationLocked = false;
+		try {
+			screen.orientation
+				.lock("portrait-primary")
+				.then(() => {
+					orientationLocked = true;
+				})
+				.catch(() => {});
+		} catch {
+			// screen.orientation.lock may not exist at all.
+		}
+
 		// -- Cleanup ------------------------------------------------------------
 		return () => {
 			for (const el of injected) {
@@ -64,6 +84,13 @@ export function useAgentsPWA() {
 			}
 			if (viewport) {
 				viewport.content = prevViewportContent;
+			}
+			if (orientationLocked) {
+				try {
+					screen.orientation.unlock();
+				} catch {
+					// Ignored.
+				}
 			}
 		};
 	}, []);

--- a/site/src/pages/AgentsPage/hooks/useDesktopMode.ts
+++ b/site/src/pages/AgentsPage/hooks/useDesktopMode.ts
@@ -1,0 +1,110 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * Try to lock the screen orientation. This only works in certain
+ * contexts (PWA standalone mode on Android, fullscreen) and throws
+ * or rejects everywhere else. All failures are silently ignored.
+ */
+async function tryOrientationLock(
+	orientation: OrientationLockType,
+): Promise<boolean> {
+	try {
+		await screen.orientation.lock(orientation);
+		return true;
+	} catch {
+		// Expected to fail on iOS Safari, non-fullscreen browsers,
+		// and desktop browsers. This is not an error condition.
+		return false;
+	}
+}
+
+function tryOrientationUnlock(): void {
+	try {
+		screen.orientation.unlock();
+	} catch {
+		// Same as above — expected to fail in most contexts.
+	}
+}
+
+/**
+ * Detect whether the device is likely a mobile/touch device. We use
+ * the coarse pointer media query rather than user-agent sniffing
+ * because it reflects actual input capability.
+ */
+function isTouchDevice(): boolean {
+	if (typeof window === "undefined") return false;
+	return window.matchMedia("(pointer: coarse)").matches;
+}
+
+export interface UseDesktopModeResult {
+	/** Whether landscape mode is currently active. */
+	isLandscape: boolean;
+	/** Enter landscape mode. */
+	enterLandscape: () => void;
+	/** Exit landscape mode and re-lock portrait. */
+	exitLandscape: () => void;
+	/**
+	 * Whether the device supports the feature at all. False on
+	 * desktop browsers and non-touch devices where the button
+	 * should be hidden.
+	 */
+	isSupported: boolean;
+}
+
+/**
+ * Manages landscape orientation for the Desktop panel on mobile.
+ * Follows the YouTube pattern: the app is normally portrait-locked,
+ * and this hook provides an escape hatch to landscape specifically
+ * for the desktop VNC view.
+ *
+ * When the caller signals entry (enterLandscape), the hook attempts
+ * screen.orientation.lock('landscape'). On exit it re-locks portrait.
+ * Unmounting automatically exits landscape.
+ */
+export function useDesktopMode(): UseDesktopModeResult {
+	const [isSupported] = useState(() => isTouchDevice());
+	const [isLandscape, setIsLandscape] = useState(false);
+	const cleanupRef = useRef(false);
+
+	const enterLandscape = useCallback(() => {
+		setIsLandscape(true);
+	}, []);
+
+	const exitLandscape = useCallback(() => {
+		setIsLandscape(false);
+	}, []);
+
+	useEffect(() => {
+		if (!isSupported) return;
+
+		if (isLandscape) {
+			void tryOrientationLock("landscape");
+			cleanupRef.current = true;
+		} else if (cleanupRef.current) {
+			// Re-lock portrait. If that fails (e.g. iOS), just
+			// release whatever lock is active.
+			void tryOrientationLock("portrait-primary").then((locked) => {
+				if (!locked) {
+					tryOrientationUnlock();
+				}
+			});
+			cleanupRef.current = false;
+		}
+
+		return () => {
+			// Restore portrait on unmount so navigating away from
+			// the Desktop panel returns the device to its normal
+			// orientation.
+			if (cleanupRef.current) {
+				void tryOrientationLock("portrait-primary").then((locked) => {
+					if (!locked) {
+						tryOrientationUnlock();
+					}
+				});
+				cleanupRef.current = false;
+			}
+		};
+	}, [isLandscape, isSupported]);
+
+	return { isLandscape, enterLandscape, exitLandscape, isSupported };
+}

--- a/site/src/pages/AgentsPage/hooks/useDesktopMode.ts
+++ b/site/src/pages/AgentsPage/hooks/useDesktopMode.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 /**
  * Try to lock the screen orientation. This only works in certain
@@ -27,84 +27,41 @@ function tryOrientationUnlock(): void {
 }
 
 /**
- * Detect whether the device is likely a mobile/touch device. We use
- * the coarse pointer media query rather than user-agent sniffing
- * because it reflects actual input capability.
- */
-function isTouchDevice(): boolean {
-	if (typeof window === "undefined") return false;
-	return window.matchMedia("(pointer: coarse)").matches;
-}
-
-export interface UseDesktopModeResult {
-	/** Whether landscape mode is currently active. */
-	isLandscape: boolean;
-	/** Enter landscape mode. */
-	enterLandscape: () => void;
-	/** Exit landscape mode and re-lock portrait. */
-	exitLandscape: () => void;
-	/**
-	 * Whether the device supports the feature at all. False on
-	 * desktop browsers and non-touch devices where the button
-	 * should be hidden.
-	 */
-	isSupported: boolean;
-}
-
-/**
- * Manages landscape orientation for the Desktop panel on mobile.
- * Follows the YouTube pattern: the app is normally portrait-locked,
- * and this hook provides an escape hatch to landscape specifically
- * for the desktop VNC view.
+ * Manages landscape orientation for the Desktop panel fullscreen
+ * mode on mobile. The caller tells the hook whether landscape
+ * should be active; the hook handles the Screen Orientation API
+ * and cleans up on unmount.
  *
- * When the caller signals entry (enterLandscape), the hook attempts
- * screen.orientation.lock('landscape'). On exit it re-locks portrait.
- * Unmounting automatically exits landscape.
+ * Portrait is restored automatically when `isLandscape` flips
+ * back to false or when the component unmounts.
  */
-export function useDesktopMode(): UseDesktopModeResult {
-	const [isSupported] = useState(() => isTouchDevice());
-	const [isLandscape, setIsLandscape] = useState(false);
-	const cleanupRef = useRef(false);
+export function useDesktopLandscape(isLandscape: boolean): void {
+	const wasLandscapeRef = useRef(false);
 
-	const enterLandscape = useCallback(() => {
-		setIsLandscape(true);
-	}, []);
-
-	const exitLandscape = useCallback(() => {
-		setIsLandscape(false);
+	const restorePortrait = useCallback(() => {
+		void tryOrientationLock("portrait-primary").then((locked) => {
+			if (!locked) {
+				tryOrientationUnlock();
+			}
+		});
 	}, []);
 
 	useEffect(() => {
-		if (!isSupported) return;
-
 		if (isLandscape) {
 			void tryOrientationLock("landscape");
-			cleanupRef.current = true;
-		} else if (cleanupRef.current) {
-			// Re-lock portrait. If that fails (e.g. iOS), just
-			// release whatever lock is active.
-			void tryOrientationLock("portrait-primary").then((locked) => {
-				if (!locked) {
-					tryOrientationUnlock();
-				}
-			});
-			cleanupRef.current = false;
+			wasLandscapeRef.current = true;
+		} else if (wasLandscapeRef.current) {
+			restorePortrait();
+			wasLandscapeRef.current = false;
 		}
 
 		return () => {
-			// Restore portrait on unmount so navigating away from
-			// the Desktop panel returns the device to its normal
-			// orientation.
-			if (cleanupRef.current) {
-				void tryOrientationLock("portrait-primary").then((locked) => {
-					if (!locked) {
-						tryOrientationUnlock();
-					}
-				});
-				cleanupRef.current = false;
+			// Restore portrait on unmount so navigating away
+			// returns the device to its normal orientation.
+			if (wasLandscapeRef.current) {
+				restorePortrait();
+				wasLandscapeRef.current = false;
 			}
 		};
-	}, [isLandscape, isSupported]);
-
-	return { isLandscape, enterLandscape, exitLandscape, isSupported };
+	}, [isLandscape, restorePortrait]);
 }

--- a/site/static/manifest.json
+++ b/site/static/manifest.json
@@ -5,6 +5,7 @@
 	"start_url": "/agents",
 	"scope": "/",
 	"display": "standalone",
+	"orientation": "portrait",
 	"background_color": "#17172E",
 	"theme_color": "#17172E",
 	"icons": [


### PR DESCRIPTION
## Summary

On mobile, the Desktop tab in the right panel now shows a fullscreen button. Entering fullscreen triggers landscape orientation via the Screen Orientation API so the VNC desktop view fills the screen. Exiting fullscreen automatically restores portrait.

## Changes

- **`manifest.json`** — adds `"orientation": "portrait"` for PWA portrait lock.
- **`useAgentsPWA`** — locks portrait on mount via Screen Orientation API (best-effort, ignored where unsupported).
- **`useDesktopLandscape` hook** — locks/unlocks landscape orientation tied to a boolean. Restores portrait on unmount.
- **`SidebarTabView`** — shows a fullscreen button (`FullscreenIcon`) on mobile when Desktop tab is active. Shows minimize button when expanded.
- **`AgentChatPageView`** — calls `useDesktopLandscape(isRightPanelExpanded && sidebarTabId === "desktop")` to tie orientation to the panel’s expanded state.

## How it works

1. App is portrait-locked by default (manifest + runtime API).
2. User opens the Desktop tab in the right panel on mobile.
3. A fullscreen button appears in the tab bar (mobile only).
4. Tapping it expands the panel to fullscreen and locks landscape.
5. Tapping minimize exits fullscreen and restores portrait.
6. Navigating away or unmounting auto-restores portrait.