### PR TITLE
fix: rename user-facing 'chats' to 'Coder Agents'

### DIFF
--- a/docs/ai-coder/agents/getting-started.md
+++ b/docs/ai-coder/agents/getting-started.md
@@ -245,7 +245,7 @@ narrowly scoped.
 Create an `AGENTS.md` file in the home directory (`~/.coder/AGENTS.md`) or
 the workspace agent's working directory to provide persistent context to the
 agent. This file is automatically read and included in the system prompt
-for every Coder Agent that uses that workspace.
+for every conversation with a Coder Agent that uses that workspace.
 
 Use it for:
 
@@ -275,7 +275,7 @@ Good feedback includes:
 - **What you tried** — the prompt, the template, and the model.
 - **What happened** — the agent's behavior, any errors, unexpected results.
 - **What you expected** — the outcome you were looking for.
-- **Context** — screenshots, Coder Agent IDs, or links to the Agents page help
+- **Context** — screenshots, `chat_id` values, or links to the Agents page help
   the team investigate quickly.
 
 Your input directly influences product direction during Early Access.

--- a/docs/ai-coder/agents/getting-started.md
+++ b/docs/ai-coder/agents/getting-started.md
@@ -1,7 +1,7 @@
 # Getting Started
 
 This guide walks platform teams and administrators through enabling Coder
-Agents, preparing your deployment, and running your first conversation.
+Agents, preparing your deployment, and running your first Coder Agent.
 
 > [!NOTE]
 > Coder Agents is in [Early Access](./early-access.md). Deploy to a
@@ -24,7 +24,7 @@ Before you begin, confirm the following:
   for the agent to select when provisioning workspaces.
 - **Admin access** to the Coder deployment for enabling the experiment and
   configuring providers.
-- **Coder Agents User role** assigned to each user who needs to create or use conversations.
+- **Coder Agents User role** assigned to each user who needs to interact with Coder Agents.
   Owners can assign this from **Admin** > **Users**. See
   [Grant Coder Agents User](#step-3-grant-coder-agents-user) below.
 
@@ -74,7 +74,7 @@ Detailed instructions for each provider and model option are in the
 
 ## Step 3: Grant Coder Agents User
 
-The **Coder Agents User** role controls which users can create and use conversations.
+The **Coder Agents User** role controls which users can interact with Coder Agents.
 Members do not have Coder Agents User by default.
 
 1. Go to **Admin** > **Users** in the Coder dashboard.
@@ -88,7 +88,7 @@ and do not need the role.
 > Users who created conversations before this role was introduced are
 > automatically granted the role during upgrade.
 
-## Step 4: Start your first conversation
+## Step 4: Start your first Coder Agent
 
 1. Go to the **Agents** page in the Coder dashboard.
 1. Select a model from the dropdown (your default will be pre-selected).
@@ -144,7 +144,7 @@ set of expectations and limitations.
 
 ### Set a deployment-wide system prompt
 
-Administrators can set a system prompt that applies to all conversations across the
+Administrators can set a system prompt that applies to all Coder Agents across the
 deployment. Use this to encode organizational conventions:
 
 - Coding standards and style guidelines.
@@ -207,12 +207,12 @@ multiplier, not a replacement for developer judgment.
 The [Chats API](./chats-api.md) enables programmatic access to Coder Agents.
 This is useful for building automations such as:
 
-- Triggering conversations from CI/CD pipelines when builds fail.
-- Creating conversations from GitHub webhooks on new issues or PRs.
+- Triggering Coder Agents from CI/CD pipelines when builds fail.
+- Creating Coder Agents from GitHub webhooks on new issues or PRs.
 - Building internal tools or dashboards on top of the API.
 - Scripting batch operations across repositories.
 
-**Quick example — create a conversation via the API:**
+**Quick example — create a Coder Agent via the API:**
 
 ```sh
 curl -X POST https://coder.example.com/api/experimental/chats \
@@ -245,7 +245,7 @@ narrowly scoped.
 Create an `AGENTS.md` file in the home directory (`~/.coder/AGENTS.md`) or
 the workspace agent's working directory to provide persistent context to the
 agent. This file is automatically read and included in the system prompt
-for every conversation that uses that workspace.
+for every Coder Agent that uses that workspace.
 
 Use it for:
 
@@ -275,7 +275,7 @@ Good feedback includes:
 - **What you tried** — the prompt, the template, and the model.
 - **What happened** — the agent's behavior, any errors, unexpected results.
 - **What you expected** — the outcome you were looking for.
-- **Context** — screenshots, conversation IDs, or links to the Agents page help
+- **Context** — screenshots, Coder Agent IDs, or links to the Agents page help
   the team investigate quickly.
 
 Your input directly influences product direction during Early Access.

--- a/docs/ai-coder/agents/getting-started.md
+++ b/docs/ai-coder/agents/getting-started.md
@@ -1,7 +1,7 @@
 # Getting Started
 
 This guide walks platform teams and administrators through enabling Coder
-Agents, preparing your deployment, and running your first chat.
+Agents, preparing your deployment, and running your first conversation.
 
 > [!NOTE]
 > Coder Agents is in [Early Access](./early-access.md). Deploy to a
@@ -24,7 +24,7 @@ Before you begin, confirm the following:
   for the agent to select when provisioning workspaces.
 - **Admin access** to the Coder deployment for enabling the experiment and
   configuring providers.
-- **Coder Agents User role** assigned to each user who needs to create or use chats.
+- **Coder Agents User role** assigned to each user who needs to create or use conversations.
   Owners can assign this from **Admin** > **Users**. See
   [Grant Coder Agents User](#step-3-grant-coder-agents-user) below.
 
@@ -74,7 +74,7 @@ Detailed instructions for each provider and model option are in the
 
 ## Step 3: Grant Coder Agents User
 
-The **Coder Agents User** role controls which users can create and use chats.
+The **Coder Agents User** role controls which users can create and use conversations.
 Members do not have Coder Agents User by default.
 
 1. Go to **Admin** > **Users** in the Coder dashboard.
@@ -85,7 +85,7 @@ Repeat for each user who needs access. Owners always have full access
 and do not need the role.
 
 > [!NOTE]
-> Users who created chats before this role was introduced are
+> Users who created conversations before this role was introduced are
 > automatically granted the role during upgrade.
 
 ## Step 4: Start your first chat
@@ -144,7 +144,7 @@ set of expectations and limitations.
 
 ### Set a deployment-wide system prompt
 
-Administrators can set a system prompt that applies to all chats across the
+Administrators can set a system prompt that applies to all conversations across the
 deployment. Use this to encode organizational conventions:
 
 - Coding standards and style guidelines.
@@ -207,8 +207,8 @@ multiplier, not a replacement for developer judgment.
 The [Chats API](./chats-api.md) enables programmatic access to Coder Agents.
 This is useful for building automations such as:
 
-- Triggering chats from CI/CD pipelines when builds fail.
-- Creating chats from GitHub webhooks on new issues or PRs.
+- Triggering conversations from CI/CD pipelines when builds fail.
+- Creating conversations from GitHub webhooks on new issues or PRs.
 - Building internal tools or dashboards on top of the API.
 - Scripting batch operations across repositories.
 

--- a/docs/ai-coder/agents/getting-started.md
+++ b/docs/ai-coder/agents/getting-started.md
@@ -88,7 +88,7 @@ and do not need the role.
 > Users who created conversations before this role was introduced are
 > automatically granted the role during upgrade.
 
-## Step 4: Start your first chat
+## Step 4: Start your first conversation
 
 1. Go to the **Agents** page in the Coder dashboard.
 1. Select a model from the dropdown (your default will be pre-selected).
@@ -177,7 +177,7 @@ with tighter network policies.
 
 ### Plan for LLM costs
 
-Every chat turn sends tokens to your LLM provider. Long-running tasks,
+Every conversation turn sends tokens to your LLM provider. Long-running tasks,
 sub-agent delegation, and complex multi-step work can consume significant
 token volume. Consider:
 
@@ -212,7 +212,7 @@ This is useful for building automations such as:
 - Building internal tools or dashboards on top of the API.
 - Scripting batch operations across repositories.
 
-**Quick example — create a chat via the API:**
+**Quick example — create a conversation via the API:**
 
 ```sh
 curl -X POST https://coder.example.com/api/experimental/chats \
@@ -245,7 +245,7 @@ narrowly scoped.
 Create an `AGENTS.md` file in the home directory (`~/.coder/AGENTS.md`) or
 the workspace agent's working directory to provide persistent context to the
 agent. This file is automatically read and included in the system prompt
-for every chat that uses that workspace.
+for every conversation that uses that workspace.
 
 Use it for:
 
@@ -275,7 +275,7 @@ Good feedback includes:
 - **What you tried** — the prompt, the template, and the model.
 - **What happened** — the agent's behavior, any errors, unexpected results.
 - **What you expected** — the outcome you were looking for.
-- **Context** — screenshots, chat IDs, or links to the Agents page help
+- **Context** — screenshots, conversation IDs, or links to the Agents page help
   the team investigate quickly.
 
 Your input directly influences product direction during Early Access.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1204,7 +1204,7 @@
 					"children": [
 						{
 							"title": "Getting Started",
-							"description": "Enable Coder Agents, prepare your deployment, and run your first chat",
+							"description": "Enable Coder Agents, prepare your deployment, and run your first Coder Agent",
 							"path": "./ai-coder/agents/getting-started.md",
 							"state": ["early access"]
 						},

--- a/site/src/pages/AgentsPage/AgentAnalyticsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentAnalyticsPageView.tsx
@@ -24,7 +24,7 @@ export const AgentAnalyticsPageView: FC<AgentAnalyticsPageViewProps> = ({
 			<div className="mx-auto w-full max-w-3xl">
 				<SectionHeader
 					label="Analytics"
-					description="Review your personal chat usage and cost breakdowns."
+					description="Review your personal Coder Agents usage and cost breakdowns."
 					action={
 						<div className="flex items-center gap-2 text-xs text-content-secondary">
 							<BarChart3Icon className="h-4 w-4" />

--- a/site/src/pages/AgentsPage/AgentSettingsBehaviorPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsBehaviorPageView.tsx
@@ -249,7 +249,7 @@ export const AgentSettingsBehaviorPageView: FC<
 		<>
 			<SectionHeader
 				label="Behavior"
-				description="Custom instructions that shape how the agent responds in your chats."
+				description="Custom instructions that shape how the agent responds in your conversations."
 			/>
 			{/* ── Personal prompt (always visible) ── */}
 			<form
@@ -260,7 +260,7 @@ export const AgentSettingsBehaviorPageView: FC<
 					Personal Instructions
 				</h3>
 				<p className="!mt-0.5 m-0 text-xs text-content-secondary">
-					Applied to all your chats. Only visible to you.
+					Applied to all your conversations. Only visible to you.
 				</p>
 				<TextareaAutosize
 					className={cn(
@@ -462,8 +462,8 @@ export const AgentSettingsBehaviorPageView: FC<
 							<p className="!mt-0.5 m-0 flex-1 text-xs text-content-secondary">
 								Set a default autostop for agent-created workspaces that don't
 								have one defined in their template. Template-defined autostop
-								rules always take precedence. Active chats will extend the stop
-								time.
+								rules always take precedence. Active conversations will extend
+								the stop time.
 							</p>
 							<Switch
 								checked={isAutostopEnabled}

--- a/site/src/pages/AgentsPage/AgentSettingsMCPServersPage.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsMCPServersPage.tsx
@@ -25,7 +25,7 @@ const AgentSettingsMCPServersPage: FC = () => {
 		<RequirePermission isFeatureVisible={permissions.editDeploymentConfig}>
 			<MCPServerAdminPanel
 				sectionLabel="MCP Servers"
-				sectionDescription="Configure external MCP servers that provide additional tools for AI chat sessions."
+				sectionDescription="Configure external MCP servers that provide additional tools for Coder Agents."
 				sectionBadge={<AdminBadge />}
 				serversData={serversQuery.data}
 				isLoadingServers={serversQuery.isLoading}

--- a/site/src/pages/AgentsPage/AgentSettingsProvidersPage.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsProvidersPage.tsx
@@ -45,7 +45,7 @@ const AgentSettingsProvidersPage: FC = () => {
 			<ChatModelAdminPanel
 				section="providers"
 				sectionLabel="Providers"
-				sectionDescription="Connect third-party LLM services like OpenAI, Anthropic, or Google. Each provider supplies models that users can select for their chats."
+				sectionDescription="Connect third-party LLM services like OpenAI, Anthropic, or Google. Each provider supplies models that users can select for their conversations."
 				sectionBadge={<AdminBadge />}
 				providerConfigsData={providerConfigsQuery.data}
 				modelConfigsData={modelConfigsQuery.data}

--- a/site/src/pages/AgentsPage/AgentSettingsUsagePageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsUsagePageView.tsx
@@ -188,8 +188,8 @@ export const AgentSettingsUsagePageView: FC<
 			label="Usage"
 			description={
 				selectedUserId
-					? "Review deployment chat usage for a specific user."
-					: "Review deployment chat usage and drill into individual users."
+					? "Review deployment Coder Agents usage for a specific user."
+					: "Review deployment Coder Agents usage and drill into individual users."
 			}
 			badge={<AdminBadge />}
 			action={

--- a/site/src/pages/AgentsPage/AgentsPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageView.stories.tsx
@@ -704,7 +704,7 @@ export const SettingsViewResets: Story = {
 		});
 
 		// Go back to conversations
-		const backButton = screen.getByLabelText("Back to conversations");
+		const backButton = screen.getByLabelText("Back to Agents");
 		await userEvent.click(backButton);
 
 		// Re-open settings, should reset to Behavior

--- a/site/src/pages/AgentsPage/AgentsPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageView.stories.tsx
@@ -611,7 +611,7 @@ export const OpensAnalyticsForAdmins: Story = {
 		await waitFor(() => {
 			expect(
 				screen.getByText(
-					"Review your personal chat usage and cost breakdowns.",
+					"Review your personal Coder Agents usage and cost breakdowns.",
 				),
 			).toBeInTheDocument();
 		});
@@ -633,7 +633,7 @@ export const OpensAnalyticsForNonAdmins: Story = {
 		await waitFor(() => {
 			expect(
 				screen.getByText(
-					"Review your personal chat usage and cost breakdowns.",
+					"Review your personal Coder Agents usage and cost breakdowns.",
 				),
 			).toBeInTheDocument();
 		});
@@ -650,7 +650,7 @@ export const OpensSettingsForAdmins: Story = {
 		await waitFor(() => {
 			expect(
 				screen.getByText(
-					"Custom instructions that shape how the agent responds in your chats.",
+					"Custom instructions that shape how the agent responds in your conversations.",
 				),
 			).toBeInTheDocument();
 		});
@@ -670,7 +670,7 @@ export const OpensSettingsForNonAdmins: Story = {
 		await waitFor(() => {
 			expect(
 				screen.getByText(
-					"Custom instructions that shape how the agent responds in your chats.",
+					"Custom instructions that shape how the agent responds in your conversations.",
 				),
 			).toBeInTheDocument();
 		});
@@ -688,7 +688,7 @@ export const SettingsViewResets: Story = {
 		await waitFor(() => {
 			expect(
 				screen.getByText(
-					"Custom instructions that shape how the agent responds in your chats.",
+					"Custom instructions that shape how the agent responds in your conversations.",
 				),
 			).toBeInTheDocument();
 		});
@@ -698,13 +698,13 @@ export const SettingsViewResets: Story = {
 		await waitFor(() => {
 			expect(
 				screen.getByText(
-					"Review deployment chat usage and drill into individual users.",
+					"Review deployment Coder Agents usage and drill into individual users.",
 				),
 			).toBeInTheDocument();
 		});
 
-		// Go back to chats
-		const backButton = screen.getByLabelText("Back to chats");
+		// Go back to conversations
+		const backButton = screen.getByLabelText("Back to conversations");
 		await userEvent.click(backButton);
 
 		// Re-open settings, should reset to Behavior
@@ -712,7 +712,7 @@ export const SettingsViewResets: Story = {
 		await waitFor(() => {
 			expect(
 				screen.getByText(
-					"Custom instructions that shape how the agent responds in your chats.",
+					"Custom instructions that shape how the agent responds in your conversations.",
 				),
 			).toBeInTheDocument();
 		});

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -24,7 +24,7 @@ const mock403Error = Object.assign(
 			statusText: "Forbidden",
 			data: {
 				message: "Forbidden.",
-				detail: "Insufficient permissions to create chat.",
+				detail: "Insufficient permissions to use Coder Agents.",
 			},
 			headers: {},
 			config: {},

--- a/site/src/pages/AgentsPage/components/ChatAccessDeniedAlert.tsx
+++ b/site/src/pages/AgentsPage/components/ChatAccessDeniedAlert.tsx
@@ -30,7 +30,7 @@ export const ChatAccessDeniedAlert: FC = () => {
 		>
 			<p className="m-0 font-medium">Permission required</p>
 			<p className="m-0 mt-1 text-sm text-content-secondary">
-				You don't have permission to create chats. Contact your Coder
+				You don't have permission to use Coder Agents. Contact your Coder
 				administrator for access. Refresh this page after access has been
 				granted.
 			</p>

--- a/site/src/pages/AgentsPage/components/ChatCostSummaryView.tsx
+++ b/site/src/pages/AgentsPage/components/ChatCostSummaryView.tsx
@@ -298,7 +298,10 @@ export const ChatCostSummaryView: FC<ChatCostSummaryViewProps> = ({
 					</div>
 
 					<div className="overflow-x-auto rounded-lg border border-border-default">
-						<Table className="text-sm" aria-label="Cost breakdown by chat">
+						<Table
+							className="text-sm"
+							aria-label="Cost breakdown by conversation"
+						>
 							<TableHeader>
 								<TableRow className="text-left text-xs font-medium uppercase tracking-wide text-content-secondary">
 									<TableHead className="px-4 py-3">Chat</TableHead>

--- a/site/src/pages/AgentsPage/components/ChatCostSummaryView.tsx
+++ b/site/src/pages/AgentsPage/components/ChatCostSummaryView.tsx
@@ -304,7 +304,7 @@ export const ChatCostSummaryView: FC<ChatCostSummaryViewProps> = ({
 						>
 							<TableHeader>
 								<TableRow className="text-left text-xs font-medium uppercase tracking-wide text-content-secondary">
-									<TableHead className="px-4 py-3">Chat</TableHead>
+									<TableHead className="px-4 py-3">Conversation</TableHead>
 									<TableHead className="px-4 py-3 text-right">Cost</TableHead>
 									<TableHead className="px-4 py-3 text-right">
 										Messages
@@ -328,7 +328,7 @@ export const ChatCostSummaryView: FC<ChatCostSummaryViewProps> = ({
 										<TableCell className="px-4 py-3">
 											{chat.chat_title || (
 												<span className="italic text-content-secondary">
-													Untitled chat
+													Untitled conversation
 												</span>
 											)}
 										</TableCell>

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ChatSummarizedTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ChatSummarizedTool.tsx
@@ -39,7 +39,7 @@ export const ChatSummarizedTool: React.FC<{
 								<TriangleAlertIcon className="h-3.5 w-3.5 shrink-0 text-content-secondary" />
 							</TooltipTrigger>
 							<TooltipContent>
-								{errorMessage || "Failed to summarize chat"}
+								{errorMessage || "Failed to summarize conversation"}
 							</TooltipContent>
 						</Tooltip>
 					)}

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelsSection.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelsSection.tsx
@@ -341,8 +341,8 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 										{!modelConfig.enabled
 											? "Cannot set a disabled model as default"
 											: modelConfig.is_default
-												? "Pinned as default for new chats"
-												: "Pin as default for new chats"}
+												? "Pinned as default for new conversations"
+												: "Pin as default for new conversations"}
 									</TooltipContent>
 								</Tooltip>
 								<ChevronRightIcon className="h-5 w-5 shrink-0 text-content-secondary" />

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
@@ -64,7 +64,7 @@ const AVAILABILITY_OPTIONS = [
 	{
 		value: "force_on",
 		label: "Force On",
-		description: "Always injected into every chat session.",
+		description: "Always injected into every conversation.",
 	},
 	{
 		value: "default_on",
@@ -158,7 +158,7 @@ const ServerList: FC<ServerListProps> = ({
 			label={sectionLabel ?? "MCP Servers"}
 			description={
 				sectionDescription ??
-				"Configure external MCP servers that provide additional tools for AI chat sessions."
+				"Configure external MCP servers that provide additional tools for Coder Agents."
 			}
 			badge={sectionBadge}
 			action={
@@ -744,7 +744,7 @@ const ServerForm: FC<ServerFormProps> = ({
 					<Field
 						label="Availability"
 						htmlFor={`${formId}-availability`}
-						description="Controls how this server appears in new chats."
+						description="Controls how this server appears in new conversations."
 					>
 						<Select
 							value={form.values.availability}

--- a/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
@@ -1221,7 +1221,7 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 							asChild
 							variant="subtle"
 							size="icon"
-							aria-label="Back to chats"
+							aria-label="Back to conversations"
 							className="relative z-10 h-7 w-7 min-w-0 text-content-secondary hover:text-content-primary"
 						>
 							<Link

--- a/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
@@ -1221,7 +1221,7 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 							asChild
 							variant="subtle"
 							size="icon"
-							aria-label="Back to conversations"
+							aria-label="Back to Agents"
 							className="relative z-10 h-7 w-7 min-w-0 text-content-secondary hover:text-content-primary"
 						>
 							<Link

--- a/site/src/pages/AgentsPage/components/UserCompactionThresholdSettings.tsx
+++ b/site/src/pages/AgentsPage/components/UserCompactionThresholdSettings.tsx
@@ -182,8 +182,8 @@ export const UserCompactionThresholdSettings: FC<
 					Context Compaction
 				</h3>
 				<p className="!mt-0.5 m-0 text-xs text-content-secondary">
-					Control when chat context is automatically summarized for each model.
-					Setting 100% means the chat will never auto-compact.
+					Control when conversation context is automatically summarized for each
+					model. Setting 100% means the conversation will never auto-compact.
 				</p>
 				<div className="flex items-center gap-2 text-sm text-content-secondary">
 					<Spinner loading className="h-4 w-4" />
@@ -200,8 +200,8 @@ export const UserCompactionThresholdSettings: FC<
 					Context Compaction
 				</h3>
 				<p className="!mt-0.5 m-0 text-xs text-content-secondary">
-					Control when chat context is automatically summarized for each model.
-					Setting 100% means the chat will never auto-compact.
+					Control when conversation context is automatically summarized for each
+					model. Setting 100% means the conversation will never auto-compact.
 				</p>
 				<p className="m-0 text-xs text-content-destructive">
 					{getErrorMessage(
@@ -219,8 +219,8 @@ export const UserCompactionThresholdSettings: FC<
 				Context Compaction
 			</h3>
 			<p className="!mt-0.5 m-0 text-xs text-content-secondary">
-				Control when chat context is automatically summarized for each model.
-				Setting 100% means the chat will never auto-compact.
+				Control when conversation context is automatically summarized for each
+				model. Setting 100% means the conversation will never auto-compact.
 			</p>
 			{isLoadingModelConfigs ? (
 				<div className="flex items-center gap-2 text-sm text-content-secondary">

--- a/site/src/pages/OrganizationSettingsPage/UserTable/EditRolesButton.tsx
+++ b/site/src/pages/OrganizationSettingsPage/UserTable/EditRolesButton.tsx
@@ -29,7 +29,7 @@ const roleDescriptions: Record<string, string> = {
 	"user-admin": "User admin can manage all users and groups.",
 	"template-admin": "Template admin can manage all templates and workspaces.",
 	auditor: "Auditor can access the audit logs.",
-	"agents-access": "Coder Agents User allows creating and using AI chats.",
+	"agents-access": "Coder Agents User allows creating and using Coder Agents.",
 	member:
 		"Everybody is a member. This is a shared and default role for all users.",
 };

--- a/site/src/pages/TaskPage/TaskPage.tsx
+++ b/site/src/pages/TaskPage/TaskPage.tsx
@@ -471,12 +471,12 @@ type TaskLogPreviewProps = {
 
 function logPreviewLabel(count: number): string {
 	if (count === 0) {
-		return "AI agent logs";
+		return "AI chat logs";
 	}
 	if (count === 1) {
-		return "Last message of AI agent logs";
+		return "Last message of AI chat logs";
 	}
-	return `Last ${count} messages of AI agent logs`;
+	return `Last ${count} messages of AI chat logs`;
 }
 
 const TaskLogPreview: FC<TaskLogPreviewProps> = ({

--- a/site/src/pages/TaskPage/TaskPage.tsx
+++ b/site/src/pages/TaskPage/TaskPage.tsx
@@ -471,12 +471,12 @@ type TaskLogPreviewProps = {
 
 function logPreviewLabel(count: number): string {
 	if (count === 0) {
-		return "AI chat logs";
+		return "AI agent logs";
 	}
 	if (count === 1) {
-		return "Last message of AI chat logs";
+		return "Last message of AI agent logs";
 	}
-	return `Last ${count} messages of AI chat logs`;
+	return `Last ${count} messages of AI agent logs`;
 }
 
 const TaskLogPreview: FC<TaskLogPreviewProps> = ({

--- a/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesTable.tsx
@@ -227,7 +227,7 @@ export const WorkspacesTable: FC<WorkspacesTableProps> = ({
 														<Link
 															to={`/agents/${chatsByWorkspace[workspace.id]}`}
 															onClick={(e) => e.stopPropagation()}
-															aria-label={`View agent chat for ${workspace.name}`}
+															aria-label={`View agent conversation for ${workspace.name}`}
 														>
 															Agent
 														</Link>


### PR DESCRIPTION
Refs #23897

- Rename user-facing "chats" to "Coder Agents" (feature name) or "conversations" (individual instances)
- Covers UI strings, docs prose, Storybook stories, and aria labels
- API paths, internal code identifiers, and the "Chats API" docs page name are intentionally left unchanged
- TaskPage / AI Tasks are out of scope

> 🤖 Written by a Coder Agent. Will be reviewed by a human.