### PR TITLE
feat(site): add organizationId prop to OrganizationAutocomplete

### DIFF
--- a/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.stories.tsx
+++ b/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.stories.tsx
@@ -1,12 +1,15 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { action } from "storybook/actions";
-import { expect, fn, userEvent, waitFor, within } from "storybook/test";
+import { expect, fn, screen, userEvent, waitFor, within } from "storybook/test";
+import type { Organization } from "#/api/typesGenerated";
 import {
 	MockOrganization,
 	MockOrganization2,
 	MockUserOwner,
 } from "#/testHelpers/entities";
 import { OrganizationAutocomplete } from "./OrganizationAutocomplete";
+
+type OnChangeFn = (org: Organization | null) => void;
 
 const meta: Meta<typeof OrganizationAutocomplete> = {
 	title: "components/OrganizationAutocomplete",
@@ -57,7 +60,7 @@ export const OneOrg: Story = {
 export const PreselectedOrg: Story = {
 	args: {
 		organizationId: MockOrganization2.id,
-		onChange: fn<(value: unknown) => void>(),
+		onChange: fn<OnChangeFn>(),
 	},
 	parameters: {
 		showOrganizations: true,
@@ -77,9 +80,7 @@ export const PreselectedOrg: Story = {
 		await waitFor(() =>
 			expect(button).toHaveTextContent(MockOrganization2.display_name),
 		);
-		const onChangeSpy = args.onChange as ReturnType<
-			typeof fn<(value: unknown) => void>
-		>;
+		const onChangeSpy = args.onChange as ReturnType<typeof fn<OnChangeFn>>;
 		expect(onChangeSpy).not.toHaveBeenCalled();
 	},
 };
@@ -103,14 +104,69 @@ export const PreselectedOrgNotFound: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const button = canvas.getByRole("button");
-		expect(button).toHaveTextContent("Select an organization");
+		// Open the dropdown to verify data has loaded.
+		await userEvent.click(button);
+		await waitFor(() =>
+			expect(
+				screen.getByText(MockOrganization.display_name),
+			).toBeInTheDocument(),
+		);
+		// Close and verify the button still shows placeholder
+		// (the org ID doesn't match any loaded option).
+		await userEvent.keyboard("{Escape}");
+		await waitFor(() =>
+			expect(button).toHaveTextContent("Select an organization"),
+		);
+	},
+};
+
+export const PreselectedOrgUserSelects: Story = {
+	args: {
+		organizationId: MockOrganization2.id,
+		onChange: fn<OnChangeFn>(),
+	},
+	parameters: {
+		showOrganizations: true,
+		user: MockUserOwner,
+		features: ["multiple_organizations"],
+		permissions: { viewDeploymentConfig: true },
+		queries: [
+			{
+				key: ["organizations"],
+				data: [MockOrganization, MockOrganization2],
+			},
+		],
+	},
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		const button = canvas.getByRole("button");
+		// Wait for the preselected org to appear.
+		await waitFor(() =>
+			expect(button).toHaveTextContent(MockOrganization2.display_name),
+		);
+		const onChangeSpy = args.onChange as ReturnType<typeof fn<OnChangeFn>>;
+		onChangeSpy.mockClear();
+		// Open dropdown and select a different org.
+		await userEvent.click(button);
+		await waitFor(() =>
+			expect(
+				screen.getByText(MockOrganization.display_name),
+			).toBeInTheDocument(),
+		);
+		await userEvent.click(screen.getByText(MockOrganization.display_name));
+		// Verify onChange was called with the new org.
+		await waitFor(() =>
+			expect(onChangeSpy).toHaveBeenCalledWith(
+				expect.objectContaining({ id: MockOrganization.id }),
+			),
+		);
 	},
 };
 
 export const OneOrgWithControlledId: Story = {
 	args: {
 		organizationId: MockOrganization.id,
-		onChange: fn<(value: unknown) => void>(),
+		onChange: fn<OnChangeFn>(),
 	},
 	parameters: {
 		showOrganizations: true,
@@ -130,9 +186,7 @@ export const OneOrgWithControlledId: Story = {
 		await waitFor(() =>
 			expect(button).toHaveTextContent(MockOrganization.display_name),
 		);
-		const onChangeSpy = args.onChange as ReturnType<
-			typeof fn<(value: unknown) => void>
-		>;
+		const onChangeSpy = args.onChange as ReturnType<typeof fn<OnChangeFn>>;
 		expect(onChangeSpy).not.toHaveBeenCalled();
 	},
 };

--- a/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.stories.tsx
+++ b/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { action } from "storybook/actions";
-import { userEvent, within } from "storybook/test";
+import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import {
 	MockOrganization,
 	MockOrganization2,
@@ -51,5 +51,88 @@ export const OneOrg: Story = {
 				data: [MockOrganization],
 			},
 		],
+	},
+};
+
+export const PreselectedOrg: Story = {
+	args: {
+		organizationId: MockOrganization2.id,
+		onChange: fn<(value: unknown) => void>(),
+	},
+	parameters: {
+		showOrganizations: true,
+		user: MockUserOwner,
+		features: ["multiple_organizations"],
+		permissions: { viewDeploymentConfig: true },
+		queries: [
+			{
+				key: ["organizations"],
+				data: [MockOrganization, MockOrganization2],
+			},
+		],
+	},
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		const button = canvas.getByRole("button");
+		await waitFor(() =>
+			expect(button).toHaveTextContent(MockOrganization2.display_name),
+		);
+		const onChangeSpy = args.onChange as ReturnType<
+			typeof fn<(value: unknown) => void>
+		>;
+		expect(onChangeSpy).not.toHaveBeenCalled();
+	},
+};
+
+export const PreselectedOrgNotFound: Story = {
+	args: {
+		organizationId: "nonexistent-id",
+	},
+	parameters: {
+		showOrganizations: true,
+		user: MockUserOwner,
+		features: ["multiple_organizations"],
+		permissions: { viewDeploymentConfig: true },
+		queries: [
+			{
+				key: ["organizations"],
+				data: [MockOrganization, MockOrganization2],
+			},
+		],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const button = canvas.getByRole("button");
+		expect(button).toHaveTextContent("Select an organization");
+	},
+};
+
+export const OneOrgWithControlledId: Story = {
+	args: {
+		organizationId: MockOrganization.id,
+		onChange: fn<(value: unknown) => void>(),
+	},
+	parameters: {
+		showOrganizations: true,
+		user: MockUserOwner,
+		features: ["multiple_organizations"],
+		permissions: { viewDeploymentConfig: true },
+		queries: [
+			{
+				key: ["organizations"],
+				data: [MockOrganization],
+			},
+		],
+	},
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		const button = canvas.getByRole("button");
+		await waitFor(() =>
+			expect(button).toHaveTextContent(MockOrganization.display_name),
+		);
+		const onChangeSpy = args.onChange as ReturnType<
+			typeof fn<(value: unknown) => void>
+		>;
+		expect(onChangeSpy).not.toHaveBeenCalled();
 	},
 };

--- a/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.stories.tsx
+++ b/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.stories.tsx
@@ -160,6 +160,11 @@ export const PreselectedOrgUserSelects: Story = {
 				expect.objectContaining({ id: MockOrganization.id }),
 			),
 		);
+		// Button should still show the prop-controlled value since
+		// the parent hasn't updated organizationId.
+		await waitFor(() =>
+			expect(button).toHaveTextContent(MockOrganization2.display_name),
+		);
 	},
 };
 

--- a/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.tsx
+++ b/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.tsx
@@ -35,7 +35,8 @@ type OrganizationAutocompleteProps = {
 	 * When combined with `check`, the ID must reference an org
 	 * the user is authorized for — if the org fails the check,
 	 * the button silently shows placeholder text without firing
-	 * onChange(null). The follow-up full-object refactor will
+	 * onChange(null). The follow-up full-object refactor
+	 * (https://github.com/coder/internal/issues/1440) will
 	 * address this.
 	 */
 	organizationId?: string;

--- a/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.tsx
+++ b/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.tsx
@@ -26,6 +26,8 @@ type OrganizationAutocompleteProps = {
 	id?: string;
 	required?: boolean;
 	check?: AuthorizationCheck;
+	/** When provided, controls which organization is displayed as selected. */
+	organizationId?: string;
 };
 
 export const OrganizationAutocomplete: FC<OrganizationAutocompleteProps> = ({
@@ -33,6 +35,7 @@ export const OrganizationAutocomplete: FC<OrganizationAutocompleteProps> = ({
 	id,
 	required,
 	check,
+	organizationId,
 }) => {
 	const [open, setOpen] = useState(false);
 	const [selected, setSelected] = useState<Organization | null>(null);
@@ -66,10 +69,25 @@ export const OrganizationAutocomplete: FC<OrganizationAutocompleteProps> = ({
 			: [];
 	}
 
-	// Unfortunate: this useEffect sets a default org value
-	// if only one is available and is necessary as the autocomplete loads
-	// its own data. Until we refactor, proceed cautiously!
+	// Sync internal selection state from the controlled `organizationId` prop
+	// when the options finish loading. This ensures the button shows
+	// the correct org name instead of the placeholder text.
 	useEffect(() => {
+		if (organizationId === undefined || options.length === 0) {
+			return;
+		}
+		const match = options.find((o) => o.id === organizationId);
+		if (match && match.id !== selected?.id) {
+			setSelected(match);
+		}
+	}, [organizationId, options, selected?.id]);
+
+	// Auto-select when only one option exists and no controlled organizationId
+	// was provided. This preserves the original single-org behavior.
+	useEffect(() => {
+		if (organizationId !== undefined) {
+			return;
+		}
 		const org = options[0];
 		if (options.length !== 1 || org === selected) {
 			return;
@@ -77,7 +95,7 @@ export const OrganizationAutocomplete: FC<OrganizationAutocompleteProps> = ({
 
 		setSelected(org);
 		onChange(org);
-	}, [options, selected, onChange]);
+	}, [options, selected, onChange, organizationId]);
 
 	return (
 		<Popover open={open} onOpenChange={setOpen}>

--- a/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.tsx
+++ b/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.tsx
@@ -31,6 +31,12 @@ type OrganizationAutocompleteProps = {
 	 * displayed selection is derived from this prop. The parent
 	 * is responsible for updating this prop in response to user
 	 * selections via onChange.
+	 *
+	 * When combined with `check`, the ID must reference an org
+	 * the user is authorized for — if the org fails the check,
+	 * the button silently shows placeholder text without firing
+	 * onChange(null). The follow-up full-object refactor will
+	 * address this.
 	 */
 	organizationId?: string;
 };

--- a/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.tsx
+++ b/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.tsx
@@ -99,7 +99,7 @@ export const OrganizationAutocomplete: FC<OrganizationAutocompleteProps> = ({
 			return;
 		}
 		const org = options[0];
-		if (options.length !== 1 || org === selected) {
+		if (options.length !== 1 || org.id === selected?.id) {
 			return;
 		}
 

--- a/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.tsx
+++ b/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.tsx
@@ -76,6 +76,10 @@ export const OrganizationAutocomplete: FC<OrganizationAutocompleteProps> = ({
 
 	// In controlled mode, derive the displayed selection from the
 	// prop so we never need to sync prop → state via an effect.
+	// Note: when `check` is also provided, options may be empty
+	// until permissions load, causing a brief placeholder flash.
+	// The follow-up refactor (passing the full Organization object
+	// instead of just an ID) will eliminate this.
 	const displayedSelection = organizationId
 		? (options.find((o) => o.id === organizationId) ?? null)
 		: selected;
@@ -140,7 +144,12 @@ export const OrganizationAutocomplete: FC<OrganizationAutocompleteProps> = ({
 									key={org.id}
 									value={`${org.display_name} ${org.name}`}
 									onSelect={() => {
-										setSelected(org);
+										// Only update internal state in uncontrolled mode.
+										// In controlled mode, displayedSelection is derived
+										// from the organizationId prop.
+										if (!organizationId) {
+											setSelected(org);
+										}
 										onChange(org);
 										setOpen(false);
 									}}

--- a/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.tsx
+++ b/site/src/components/OrganizationAutocomplete/OrganizationAutocomplete.tsx
@@ -26,7 +26,12 @@ type OrganizationAutocompleteProps = {
 	id?: string;
 	required?: boolean;
 	check?: AuthorizationCheck;
-	/** When provided, controls which organization is displayed as selected. */
+	/**
+	 * Pre-selects an organization by ID. When provided, the
+	 * displayed selection is derived from this prop. The parent
+	 * is responsible for updating this prop in response to user
+	 * selections via onChange.
+	 */
 	organizationId?: string;
 };
 
@@ -69,23 +74,17 @@ export const OrganizationAutocomplete: FC<OrganizationAutocompleteProps> = ({
 			: [];
 	}
 
-	// Sync internal selection state from the controlled `organizationId` prop
-	// when the options finish loading. This ensures the button shows
-	// the correct org name instead of the placeholder text.
-	useEffect(() => {
-		if (organizationId === undefined || options.length === 0) {
-			return;
-		}
-		const match = options.find((o) => o.id === organizationId);
-		if (match && match.id !== selected?.id) {
-			setSelected(match);
-		}
-	}, [organizationId, options, selected?.id]);
+	// In controlled mode, derive the displayed selection from the
+	// prop so we never need to sync prop → state via an effect.
+	const displayedSelection = organizationId
+		? (options.find((o) => o.id === organizationId) ?? null)
+		: selected;
 
-	// Auto-select when only one option exists and no controlled organizationId
-	// was provided. This preserves the original single-org behavior.
+	// Auto-select when only one option exists. Only active in
+	// uncontrolled mode — when the parent controls the value via
+	// organizationId it is responsible for the initial selection.
 	useEffect(() => {
-		if (organizationId !== undefined) {
+		if (organizationId) {
 			return;
 		}
 		const org = options[0];
@@ -108,14 +107,16 @@ export const OrganizationAutocomplete: FC<OrganizationAutocompleteProps> = ({
 					data-testid="organization-autocomplete"
 					className="w-full justify-start gap-2 font-normal"
 				>
-					{selected ? (
+					{displayedSelection ? (
 						<>
 							<Avatar
 								size="sm"
-								src={selected.icon}
-								fallback={selected.display_name}
+								src={displayedSelection.icon}
+								fallback={displayedSelection.display_name}
 							/>
-							<span className="truncate">{selected.display_name}</span>
+							<span className="truncate">
+								{displayedSelection.display_name}
+							</span>
 						</>
 					) : (
 						<span className="text-content-secondary">
@@ -152,7 +153,7 @@ export const OrganizationAutocomplete: FC<OrganizationAutocompleteProps> = ({
 									<span className="truncate">
 										{org.display_name || org.name}
 									</span>
-									{selected?.id === org.id && (
+									{displayedSelection?.id === org.id && (
 										<Check className="ml-auto size-icon-sm shrink-0" />
 									)}
 								</CommandItem>


### PR DESCRIPTION
Enabling change for #23827 (organization-scoped chats), which reuses `OrganizationAutocomplete` in the chat creation form. This PR adds the controlled pre-selection capability so callers can pre-fill the org picker instead of requiring the user to select each time.

- Replace useEffect prop→state sync with render-time derivation
- Guard auto-select effect to only fire in uncontrolled mode
- Guard `setSelected` in `onSelect` to prevent shadow state in controlled mode
- Use ID comparison in auto-select to survive react-query refetches
- Handle empty string `organizationId` as "not provided" (falsy check)
- Add five Storybook stories covering controlled pre-selection, unmatched ID, user interaction, and single-org suppression

Follow-up for full controlled refactor: https://github.com/coder/internal/issues/1440

<details><summary>Implementation plan & decision log</summary>

**Decisions:**
- **D1 (human ratified):** Derive displayed selection during render instead of useEffect sync. Aligns with `MultiSelectCombobox` precedent.
- **D2 (human decided):** No `onChange` on controlled initialization — parent already knows the ID, parent handles side-effects.
- **D3 (human decided):** Filed follow-up issue for full controlled refactor (coder/internal#1440).

**Deep review findings addressed:**
- P1: Selection-revert loop (`selected?.id` in deps) → eliminated by removing the useEffect
- P1: Missing `onChange` in controlled sync → eliminated by removing the useEffect
- P1: Unnecessary useEffect anti-pattern → replaced with render-time derivation
- P2: Empty string trap (`"" === undefined` is `true`) → falsy guard catches it
- P2: `PreselectedOrgNotFound` vacuously true → fixed to prove data loaded first
- P3: Shadow `setSelected` in controlled mode → guarded behind `if (!organizationId)`
- P3: No interaction story → `PreselectedOrgUserSelects` added with display-revert assertion
- P3: Auth edge case with `check` + `organizationId` → JSDoc warning added
- Pre-existing: Reference equality in auto-select → switched to ID comparison

</details>

> 🤖 Written by a Coder Agent. Will be reviewed by a human.