### PR TITLE
fix(coderd/x/chatd): teach title generation that URLs are not homework assignments

### DIFF
--- a/coderd/x/chatd/quickgen.go
+++ b/coderd/x/chatd/quickgen.go
@@ -29,6 +29,7 @@ import (
 const titleGenerationPrompt = "Write a short title for the user's message. " +
 	"Return only the title text in 2-8 words. " +
 	"Do not answer the user or describe the title-writing task. " +
+	"Do not attempt to read, visit, or summarize any URLs — treat them as opaque text and extract identifiers such as repo names, issue numbers, or paths from their structure. " +
 	"Preserve specific identifiers such as PR numbers, repo names, file paths, function names, and error messages. " +
 	"If the message is short or vague, stay close to the user's wording instead of inventing context. " +
 	"Sentence case. No quotes, emoji, markdown, or trailing punctuation."
@@ -421,6 +422,7 @@ func renderManualTitlePrompt(
 	write("\n\nRequirements:\n")
 	write("- Return only the title text in 2-8 words.\n")
 	write("- Do not answer the user or describe the title-writing task.\n")
+	write("- Do not read, visit, or summarize URLs — treat them as opaque text and use identifiers from their structure.\n")
 	write("- Preserve specific identifiers (PR numbers, repo names, file paths, function names, error messages).\n")
 	write("- If the conversation is short or vague, stay close to the user's wording.\n")
 	write("- Sentence case. No quotes, emoji, markdown, or trailing punctuation.\n")

--- a/coderd/x/chatd/quickgen_test.go
+++ b/coderd/x/chatd/quickgen_test.go
@@ -333,6 +333,7 @@ func Test_renderManualTitlePrompt(t *testing.T) {
 			require.Contains(t, prompt, "Requirements:")
 			require.Contains(t, prompt, "- Return only the title text in 2-8 words.")
 			require.Contains(t, prompt, "Do not answer the user or describe the title-writing task")
+			require.Contains(t, prompt, "Do not read, visit, or summarize URLs")
 			require.Contains(t, prompt, "stay close to the user's wording")
 
 			if tt.wantConversationSample {
@@ -360,6 +361,7 @@ func Test_titleGenerationPrompt_UsesSlimRules(t *testing.T) {
 	require.Contains(t, titleGenerationPrompt, "Return only the title text in 2-8 words")
 	require.Contains(t, titleGenerationPrompt, "Do not answer the user or describe the title-writing task")
 	require.Contains(t, titleGenerationPrompt, "stay close to the user's wording")
+	require.Contains(t, titleGenerationPrompt, "Do not attempt to read, visit, or summarize any URLs")
 	require.NotContains(t, titleGenerationPrompt, "I am a title generator")
 }
 


### PR DESCRIPTION
When a user's first chat message contains a URL, lightweight title models (Haiku, GPT-4o-mini, etc.) would interpret it as a request to visit the URL and generate titles like "I can't read that URL" instead of something useful.

- Add URL-handling instruction to `titleGenerationPrompt` constant
- Add matching bullet to `renderManualTitlePrompt` requirements list
- Both tell the model to treat URLs as opaque text and extract identifiers (repo names, issue numbers, paths) from their structure

**Closed in favor of #23909** which takes the better approach of using structured output (`object.Generate`) to structurally prevent conversational responses instead of relying on prompt hints.

> 🤖 Written by a Coder Agent. Will be reviewed by a human.