### PR TITLE
feat(site): add Arch Linux icon to bundled icon set

### DIFF
--- a/site/src/theme/icons.json
+++ b/site/src/theme/icons.json
@@ -10,6 +10,7 @@
 	"apache-guacamole.svg",
 	"apple-black.svg",
 	"apple-grey.svg",
+	"archlinux.svg",
 	"argo-workflows.svg",
 	"auggie.svg",
 	"auto-dev-server.svg",

--- a/site/static/icon/archlinux.svg
+++ b/site/static/icon/archlinux.svg
@@ -1,0 +1,3 @@
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M128 16C132 80 208 210 238 244H178C168 214 141 166 128 142C115 166 88 214 78 244H18C48 210 124 80 128 16Z" fill="#1793D1"/>
+</svg>


### PR DESCRIPTION
Closes https://github.com/coder/coder/issues/23760

## Changes

Adds an `archlinux.svg` icon to `site/static/icon/` so it is served at
`/icon/archlinux.svg`, alongside other Linux distribution icons (ubuntu,
debian, fedora, almalinux, rockylinux).

- Uses the official Arch Linux blue (`#1793D1`) and the characteristic
  inverted-V / mountain-arch silhouette from the Simple Icons project (CC0).
- Matches the existing 256×256 viewBox convention.
- Registered in `site/src/theme/icons.json` so it appears in the icon
  picker.