### PR TITLE
fix: prevent site storybook tests from hanging after completion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -802,6 +802,7 @@ pre-push:
 	start=$$(date +%s)
 	logdir=$$(mktemp -d "$${TMPDIR:-/tmp}/coder-pre-push.XXXXXX")
 	echo "$(BOLD)pre-push$(RESET) ($$logdir)"
+	test -d site/node_modules/.cache/storybook || (cd site/ && pnpm exec node scripts/warmup-storybook-cache.mjs)
 	echo "test + build site:"
 	$(MAKE) --no-print-directory -j$(PARALLEL_JOBS) MAKE_TIMED=1 MAKE_LOGDIR=$$logdir \
 		test \

--- a/site/scripts/warmup-storybook-cache.mjs
+++ b/site/scripts/warmup-storybook-cache.mjs
@@ -1,0 +1,27 @@
+// Warm vite's transform cache for storybook story files.
+// Only needed on cold cache (first run after pnpm install).
+import { createServer } from "vite";
+import { readdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, "..");
+
+const server = await createServer({
+	configFile: join(root, "vite.config.mts"),
+	root,
+});
+await server.listen();
+
+const stories = readdirSync(join(root, "src"), { recursive: true })
+	.filter((f) => String(f).endsWith(".stories.tsx"))
+	.map((f) => `/src/${f}`);
+
+await Promise.all(
+	stories.map((f) =>
+		server.environments.client.warmupRequest(f).catch(() => {}),
+	),
+);
+
+await server.close();

--- a/site/src/components/Dialogs/DeleteDialog/DeleteDialog.stories.tsx
+++ b/site/src/components/Dialogs/DeleteDialog/DeleteDialog.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { within } from "@testing-library/react";
 import { action } from "storybook/actions";
-import { userEvent } from "storybook/test";
+import { userEvent, within } from "storybook/test";
 import { DeleteDialog } from "./DeleteDialog";
 
 const meta: Meta<typeof DeleteDialog> = {

--- a/site/src/components/ErrorBoundary/GlobalErrorBoundary.stories.tsx
+++ b/site/src/components/ErrorBoundary/GlobalErrorBoundary.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { within } from "@testing-library/react";
 import type { ErrorResponse } from "react-router";
-import { expect, userEvent } from "storybook/test";
+import { expect, userEvent, within } from "storybook/test";
 import { GlobalErrorBoundaryInner } from "./GlobalErrorBoundary";
 
 /**

--- a/site/src/components/SyntaxHighlighter/SyntaxHighlighter.tsx
+++ b/site/src/components/SyntaxHighlighter/SyntaxHighlighter.tsx
@@ -103,6 +103,11 @@ export const SyntaxHighlighter: FC<SyntaxHighlighterProps> = ({
 					original={compareWith}
 					modified={value}
 					{...commonProps}
+					// Let the editor handle model cleanup. Without this,
+					// @monaco-editor/react disposes models before the
+					// DiffEditorWidget and throws an error.
+					keepCurrentOriginalModel
+					keepCurrentModifiedModel
 					onMount={handleDiffEditorMount}
 				/>
 			) : (

--- a/site/src/modules/tasks/TasksSidebar/UserCombobox.stories.tsx
+++ b/site/src/modules/tasks/TasksSidebar/UserCombobox.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { waitFor } from "@testing-library/react";
 import { useState } from "react";
-import { expect, spyOn, userEvent, within } from "storybook/test";
+import { expect, spyOn, userEvent, waitFor, within } from "storybook/test";
 import { API } from "#/api/api";
 import { MockUsers } from "#/pages/UsersPage/storybookData/users";
 import { MockUserOwner } from "#/testHelpers/entities";

--- a/site/src/pages/OrganizationSettingsPage/OrganizationSettingsPageView.stories.tsx
+++ b/site/src/pages/OrganizationSettingsPage/OrganizationSettingsPageView.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { within } from "@testing-library/react";
 import { action } from "storybook/actions";
-import { userEvent } from "storybook/test";
+import { userEvent, within } from "storybook/test";
 import { chromatic } from "#/testHelpers/chromatic";
 import {
 	MockDefaultOrganization,

--- a/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsControls.stories.tsx
+++ b/site/src/pages/TemplatePage/TemplateInsightsPage/TemplateInsightsControls.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { within } from "@testing-library/react";
 import type { ComponentProps } from "react";
-import { userEvent } from "storybook/test";
+import { userEvent, within } from "storybook/test";
 import { TemplateInsightsControls } from "./TemplateInsightsPage";
 
 const meta: Meta<typeof TemplateInsightsControls> = {

--- a/site/vite.config.mts
+++ b/site/vite.config.mts
@@ -90,63 +90,68 @@ export default defineConfig({
 			"Set-Cookie":
 				"csrf_token=JXm9hOUdZctWt0ZZGAy9xiS/gxMKYOThdxjjMnMUyn4=; Path=/; HttpOnly; SameSite=Lax",
 		},
-		proxy: {
-			"//": {
-				changeOrigin: true,
-				target: process.env.CODER_HOST || "http://localhost:3000",
-				secure: process.env.NODE_ENV === "production",
-				rewrite: (path) => path.replace(/\/+/g, "/"),
-			},
-			"/api": {
-				ws: true,
-				changeOrigin: true,
-				target: process.env.CODER_HOST || "http://localhost:3000",
-				secure: process.env.NODE_ENV === "production",
-				configure: (proxy) => {
-					if (process.env.CODER_SESSION_TOKEN) {
-						proxy.on("proxyReq", (proxyReq) => {
-							proxyReq.setHeader(
-								"Coder-Session-Token",
-								process.env.CODER_SESSION_TOKEN!,
-							);
-						});
-					}
-					// Vite does not catch socket errors, and stops the webserver.
-					// As /logs endpoint can return HTTP 4xx status, we need to embrace
-					// Vite with a custom error handler to prevent from quitting.
-					proxy.on("proxyReqWs", (proxyReq, _req, socket) => {
-						if (process.env.NODE_ENV === "development") {
-							proxyReq.setHeader(
-								"origin",
-								process.env.CODER_HOST || "http://localhost:3000",
-							);
+		// The proxy targets localhost:3000 (coderd). During tests no
+		// coderd is running, and the proxy's retry sockets keep the
+		// Node process alive after vitest finishes.
+		proxy: process.env.VITEST
+			? undefined
+			: {
+					"//": {
+						changeOrigin: true,
+						target: process.env.CODER_HOST || "http://localhost:3000",
+						secure: process.env.NODE_ENV === "production",
+						rewrite: (path) => path.replace(/\/+/g, "/"),
+					},
+					"/api": {
+						ws: true,
+						changeOrigin: true,
+						target: process.env.CODER_HOST || "http://localhost:3000",
+						secure: process.env.NODE_ENV === "production",
+						configure: (proxy) => {
 							if (process.env.CODER_SESSION_TOKEN) {
-								proxyReq.setHeader(
-									"Coder-Session-Token",
-									process.env.CODER_SESSION_TOKEN!,
-								);
+								proxy.on("proxyReq", (proxyReq) => {
+									proxyReq.setHeader(
+										"Coder-Session-Token",
+										process.env.CODER_SESSION_TOKEN!,
+									);
+								});
 							}
-						}
+							// Vite does not catch socket errors, and stops the webserver.
+							// As /logs endpoint can return HTTP 4xx status, we need to embrace
+							// Vite with a custom error handler to prevent from quitting.
+							proxy.on("proxyReqWs", (proxyReq, _req, socket) => {
+								if (process.env.NODE_ENV === "development") {
+									proxyReq.setHeader(
+										"origin",
+										process.env.CODER_HOST || "http://localhost:3000",
+									);
+									if (process.env.CODER_SESSION_TOKEN) {
+										proxyReq.setHeader(
+											"Coder-Session-Token",
+											process.env.CODER_SESSION_TOKEN!,
+										);
+									}
+								}
 
-						socket.on("error", (error) => {
-							console.error(error);
-						});
-					});
+								socket.on("error", (error) => {
+									console.error(error);
+								});
+							});
+						},
+					},
+					"/swagger": {
+						target: process.env.CODER_HOST || "http://localhost:3000",
+						secure: process.env.NODE_ENV === "production",
+					},
+					"/healthz": {
+						target: process.env.CODER_HOST || "http://localhost:3000",
+						secure: process.env.NODE_ENV === "production",
+					},
+					"/serviceWorker.js": {
+						target: process.env.CODER_HOST || "http://localhost:3000",
+						secure: process.env.NODE_ENV === "production",
+					},
 				},
-			},
-			"/swagger": {
-				target: process.env.CODER_HOST || "http://localhost:3000",
-				secure: process.env.NODE_ENV === "production",
-			},
-			"/healthz": {
-				target: process.env.CODER_HOST || "http://localhost:3000",
-				secure: process.env.NODE_ENV === "production",
-			},
-			"/serviceWorker.js": {
-				target: process.env.CODER_HOST || "http://localhost:3000",
-				secure: process.env.NODE_ENV === "production",
-			},
-		},
 		allowedHosts: [".coder", ".dev.coder.com"],
 	},
 	// Pre-bundle deps that Vite tends to discover late (deep MUI
@@ -206,6 +211,9 @@ export default defineConfig({
 			"@mui/system/createTheme",
 			"@mui/system/useTheme",
 			"@mui/x-tree-view",
+			// Discovered at runtime without this entry, triggering
+			// a mid-run dep re-optimization that breaks imports.
+			"@tanstack/react-query-devtools",
 		],
 	},
 	resolve: {
@@ -219,6 +227,9 @@ export default defineConfig({
 	},
 	test: {
 		silent: "passed-only",
+		// Rolldown's native threads do not terminate on close,
+		// so vitest always hits this timeout. Keep it short.
+		teardownTimeout: 1000,
 		projects: [
 			{
 				extends: true,
@@ -245,6 +256,27 @@ export default defineConfig({
 					storybookTest({
 						configDir: path.join(__dirname, ".storybook"),
 					}),
+					{
+						name: "storybook-test-setup",
+						// Return 502 for API routes. The proxy is disabled
+						// during tests (see above), so without this vite
+						// serves its HTML fallback for unmatched routes.
+						configureServer(server) {
+							server.middlewares.use((req, res, next) => {
+								const url = req.url ?? "";
+								if (
+									url.startsWith("/api/") ||
+									url.startsWith("/swagger/") ||
+									url.startsWith("/healthz")
+								) {
+									res.statusCode = 502;
+									res.end();
+									return;
+								}
+								next();
+							});
+						},
+					},
 				],
 				test: {
 					name: "storybook",
@@ -255,6 +287,12 @@ export default defineConfig({
 						instances: [{ browser: "chromium" }],
 					},
 					setupFiles: [".storybook/vitest.setup.ts"],
+					// Stop early on systemic failures.
+					bail: 5,
+					// Cap concurrent browser iframes. The default
+					// (os.availableParallelism, 96 on dev workspaces)
+					// overwhelms vite's transform pipeline on cold cache.
+					maxWorkers: 4,
 				},
 			},
 		],


### PR DESCRIPTION
## Problem

`make test-storybook` (and thus `make pre-push`) hangs indefinitely.
All 2132 story tests pass in ~90s, but the vitest process never exits.

## Root causes

There are three independent problems that compound into the hang:

### 1. Vite proxy holds the event loop open

The vite dev server proxies `/api`, `/swagger`, `/healthz`, and `//`
routes to `localhost:3000`. During tests there is no coderd, so the
proxy retries TCP connections that get ECONNREFUSED. The resulting
sockets (both HTTP and WebSocket upgrade) keep the Node event loop
alive after tests finish. Vitest prints "close timed out" and
`process.exit()` fires only after `teardownTimeout` (default 10s),
which Rolldown native threads extend further.

**Fix:** Disable the entire proxy during tests
(`proxy: process.env.VITEST ? undefined : {...}`). A middleware
plugin returns 502 for API routes so components get proper HTTP
errors instead of vite's HTML fallback.

### 2. Too many concurrent browser workers overwhelm vite

Vitest browser mode spawns `os.availableParallelism()` iframes
(96 on dev workspaces). Each iframe requests a dynamic `import()`
from vite's transform pipeline. On cold cache, 96 concurrent
transform requests saturate the pipeline and some never complete.
The browser's `import()` has no timeout or retry, so those files
stay at `(0 test)` permanently.

**Fix:** `maxWorkers: 4` limits the concurrent browser workers
to 4 iframes.

### 3. Runtime dep discovery triggers re-optimization

`@tanstack/react-query-devtools` is not in the `optimizeDeps.include`
list. On cold cache, vite's dep optimizer discovers it at runtime
and triggers a re-optimization that renames the `deps_temp` directory
to `deps`. In-flight module resolutions that referenced the temp path
break, causing additional import failures.

**Fix:** Add `@tanstack/react-query-devtools` to `optimizeDeps.include`.

## Additional fixes

**Rolldown teardown delay.** Vite 8 uses Rolldown (Rust-based bundler)
whose native `napi_rs_threadsafe_function` handles don't terminate on
server close. Vitest waits `teardownTimeout` (default 10s) before
`process.exit()`. Set `teardownTimeout: 1000` to cut the wait.

**Monaco DiffEditor dispose ordering.** `@monaco-editor/react` disposes
TextModel before DiffEditorWidget in its cleanup effect, throwing
"TextModel got disposed before DiffEditorWidget model got reset" as an
unhandled error. Pass `keepCurrentOriginalModel`/`keepCurrentModifiedModel`
to let the editor dispose handle model cleanup in the correct order.

**Cold-cache dep warmup.** On first run (empty `node_modules/.cache/storybook`),
vite's dep bundling takes ~12s. If tests start during bundling, imports
race against the `deps_temp` to `deps` rename. The warmup script in
`pre-push` pre-builds the dep cache before the parallel test phase.

**Import source fixes.** 5 story files imported `waitFor`/`within` from
`@testing-library/react` instead of `storybook/test`.

## Results

| Scenario | Before | After |
|----------|--------|-------|
| `make test-storybook` (warm cache) | Infinite hang | ~116s, 374/374, exit 0 |
| `make test-storybook` (cold cache) | Infinite hang | ~121s, 374/374, exit 0 |
| `make pre-push` (warm cache, parallel) | Infinite hang | 368-374/374, parallel with Go tests |
| `make pre-push` (cold cache, parallel) | Infinite hang | 372+/374 (cold source transforms are stochastic) |

## Changed files

- `site/vite.config.mts` -- proxy disable, 502 middleware, bail,
  maxWorkers, teardownTimeout, optimizeDeps
- `site/src/components/SyntaxHighlighter/SyntaxHighlighter.tsx` --
  Monaco DiffEditor model dispose fix
- `site/scripts/warmup-storybook-cache.mjs` -- cold-cache dep warmup
- `Makefile` -- run warmup in pre-push before parallel phase
- 5 story files -- import source fixes

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻