### PR TITLE
ci: fix weekly-docs check failing on pnpm cache save

### DIFF
--- a/.github/workflows/weekly-docs.yaml
+++ b/.github/workflows/weekly-docs.yaml
@@ -49,8 +49,10 @@ jobs:
       # TODO: Remove this workaround once action-linkspector sets
       # package-manager-cache: false in its internal setup-node step.
       # See: https://github.com/UmbrellaDocs/action-linkspector/issues/54
-      - name: Enable corepack
-        run: corepack enable pnpm
+      - name: Enable corepack and create pnpm store
+        run: |
+          corepack enable pnpm
+          mkdir -p "$(pnpm store path --silent)"
 
       - name: Check Markdown links
         uses: umbrelladocs/action-linkspector@37c85bcde51b30bf929936502bac6bfb7e8f0a4d # v1.4.1


### PR DESCRIPTION
## Problem

The `weekly-docs` / `check-docs` job has been failing on PRs that touch `docs/**`. The actual link checking step (`Check Markdown links`) passes fine, but the **`Post Check Markdown links`** step fails.

## Root cause

`actions/setup-node@v5` inside the `action-linkspector` composite action detects pnpm (from `corepack enable pnpm` + `pnpm-lock.yaml` in the repo) and configures cache saving for the pnpm store. Since linkspector uses `npm` internally, the pnpm store directory is never created. The post-step cache save then fails with:

```
##[error]Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
```

## Fix

- Create the pnpm store directory after enabling corepack so the cache save has something to work with

Upstream: https://github.com/UmbrellaDocs/action-linkspector/issues/54

> 🤖 Written by a Coder Agent. Will be reviewed by a human.