### PR TITLE
fix: specify allowed hosts for storybook dev server

### DIFF
--- a/site/.storybook/main.ts
+++ b/site/.storybook/main.ts
@@ -18,6 +18,10 @@ export default {
 		options: {},
 	},
 
+	core: {
+		allowedHosts: [".coder", ".dev.coder.com"],
+	},
+
 	async viteFinal(config) {
 		// Storybook seems to strip this setting out of our Vite config. We need to
 		// put it back in order to be able to access Storybook with Coder Desktop or


### PR DESCRIPTION
We recently upgraded storybook and vite in #23485 which bumped our `storybook` version from 10.2.10 to 10.3.3. In 10.2.16, storybookjs/storybook#34045 was merged that changes the list of default allowed hosts to an empty array. This means if you have custom DNS set up (like through the Coder desktop app) your `.coder` domain will no longer be able to reach storybook and you'll get an `Invalid host` response. This is a breaking change, but storybook didn't treat it as such.

This PR adds the `core.allowedHosts` config to our storybook dev server. I'm not sure this has the same effect for build so I left the other `viteFinal` `server.allowedHosts` config, but it may be defunct