### PR TITLE
fix(install.sh): filter pre-release tags from mainline version resolution

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -126,9 +126,12 @@ echo_latest_mainline_version() {
 		exit 1
 	fi
 
+	# Filter to strict semver (MAJOR.MINOR.PATCH) to exclude
+	# pre-release tags like RC builds from version resolution.
 	echo "$body" |
 		awk -F'"' '/"tag_name"/ {print $4}' |
 		tr -d v |
+		grep '^[0-9]\+\.[0-9]\+\.[0-9]\+$' |
 		tr . ' ' |
 		sort -k1,1nr -k2,2nr -k3,3nr |
 		head -n1 |


### PR DESCRIPTION
The `echo_latest_mainline_version()` function fetches all GitHub releases and sorts by version number to find the latest mainline release. It did not filter out pre-release tags (e.g. `v2.32.0-rc.0`), so publishing an RC release caused `coder.com/install.sh` to resolve the RC as the latest mainline version instead of the actual mainline release.

Adds a `grep` filter for strict semver (`MAJOR.MINOR.PATCH`) before sorting, so tags with pre-release suffixes like `-rc.0` are excluded from version resolution.