### PR TITLE
fix: rename "Add member" to "Add" on template permissions page

### DIFF
--- a/site/e2e/tests/updateTemplate.spec.ts
+++ b/site/e2e/tests/updateTemplate.spec.ts
@@ -48,7 +48,7 @@ test("add and remove a group", async ({ page }) => {
 
 	// Select the group from the list and add it
 	await page.getByText(groupName).click();
-	await page.getByText("Add member").click();
+	await page.getByText("Add").click();
 	const row = page.locator(".MuiTableRow-root", { hasText: groupName });
 	await expect(row).toBeVisible();
 

--- a/site/src/pages/TemplateSettingsPage/TemplatePermissionsPage/TemplatePermissionsPageView.tsx
+++ b/site/src/pages/TemplateSettingsPage/TemplatePermissionsPage/TemplatePermissionsPageView.tsx
@@ -129,7 +129,7 @@ const AddTemplateUserOrGroup: FC<AddTemplateUserOrGroupProps> = ({
 					<Spinner loading={isLoading}>
 						<UserPlusIcon className="size-icon-sm" />
 					</Spinner>
-					Add member
+					Add
 				</Button>
 			</div>
 		</form>


### PR DESCRIPTION
The "Add member" button on the template permissions page is used to add both **users and groups**, so the label is misleading when adding a group.

<img width="1238" height="672" alt="image" src="https://github.com/user-attachments/assets/dbdfc79e-9e2e-4f26-9258-418f2038511e" />