### PR TITLE
fix(coderd/x/chatd): stabilize subagent pubsub completion test

### DIFF
--- a/coderd/x/chatd/subagent_internal_test.go
+++ b/coderd/x/chatd/subagent_internal_test.go
@@ -1012,8 +1012,10 @@ func TestAwaitSubagentCompletion(t *testing.T) {
 		setChatStatus(ctx, t, db, child.ID, database.ChatStatusRunning, "")
 
 		// Trap the fallback poll ticker to know when the
-		// function has subscribed to pubsub and entered
-		// its select loop.
+		// function has entered the wait setup path. We still
+		// need an explicit subscription handshake below because
+		// the ticker can be created before SubscribeWithErr has
+		// finished registering the listener.
 		tickTrap := mClock.Trap().NewTicker("chatd", "subagent_poll")
 
 		type awaitResult struct {
@@ -1029,10 +1031,28 @@ func TestAwaitSubagentCompletion(t *testing.T) {
 			resultCh <- awaitResult{chat, report, err}
 		}()
 
-		// Wait for the ticker to be created (confirms pubsub
-		// subscription is set up and select loop entered).
+		// Wait for the ticker to be created so the waiter has
+		// entered its setup path, then subscribe our own probe on
+		// the same channel. Because MemoryPubsub publishes only to
+		// listeners already present at Publish time, waiting for
+		// our probe to receive a message proves the waiter's
+		// subscription is also registered before we assert on the
+		// wake-up behavior.
 		tickTrap.MustWait(ctx).MustRelease(ctx)
 		tickTrap.Close()
+
+		probeCh := make(chan struct{}, 1)
+		cancelProbe, err := ps.SubscribeWithErr(
+			coderdpubsub.ChatStreamNotifyChannel(child.ID),
+			func(_ context.Context, _ []byte, _ error) {
+				select {
+				case probeCh <- struct{}{}:
+				default:
+				}
+			},
+		)
+		require.NoError(t, err)
+		defer cancelProbe()
 
 		// Transition the child first, then publish once the
 		// durable completion state is observable. Pubsub only
@@ -1040,17 +1060,18 @@ func TestAwaitSubagentCompletion(t *testing.T) {
 		// visible in the same instant as the notification.
 		setChatStatus(ctx, t, db, child.ID, database.ChatStatusWaiting, "")
 		insertAssistantMessage(ctx, t, db, child.ID, model.ID, "pubsub result")
-		require.Eventually(t, func() bool {
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			chat, report, done, err := server.checkSubagentCompletion(ctx, child.ID)
-			if err != nil {
-				return false
-			}
-			return done && chat.ID == child.ID && report == "pubsub result"
+			require.NoError(c, err)
+			assert.True(c, done)
+			assert.Equal(c, child.ID, chat.ID)
+			assert.Equal(c, "pubsub result", report)
 		}, testutil.WaitMedium, testutil.IntervalFast)
-		_ = ps.Publish(
+		require.NoError(t, ps.Publish(
 			coderdpubsub.ChatStreamNotifyChannel(child.ID),
 			[]byte("done"),
-		)
+		))
+		testutil.RequireReceive(ctx, t, probeCh)
 
 		result := testutil.RequireReceive(ctx, t, resultCh)
 		require.NoError(t, result.err)
@@ -1060,17 +1081,14 @@ func TestAwaitSubagentCompletion(t *testing.T) {
 
 	t.Run("AlreadyWaitingNoReport", func(t *testing.T) {
 		t.Parallel()
-
-		db, ps := dbtestutil.NewDB(t)
-		mClock := quartz.NewMock(t)
-		server := newInternalTestServerWithClock(t, db, ps, chatprovider.ProviderAPIKeys{}, mClock)
 		ctx := chatdTestContext(t)
-		user, model := seedInternalChatDeps(ctx, t, db)
 
 		parent, child := createParentChildChats(ctx, t, server, user, model)
 
 		// signalWake from CreateChat may trigger immediate processing.
 		// Wait for it to settle, then set the terminal state we need.
+		// This case should return immediately, so use the shared
+		// real-clock server instead of a mock clock.
 		server.inflight.Wait()
 		setChatStatus(ctx, t, db, child.ID, database.ChatStatusWaiting, "")
 

--- a/coderd/x/chatd/subagent_internal_test.go
+++ b/coderd/x/chatd/subagent_internal_test.go
@@ -1034,10 +1034,19 @@ func TestAwaitSubagentCompletion(t *testing.T) {
 		tickTrap.MustWait(ctx).MustRelease(ctx)
 		tickTrap.Close()
 
-		// Transition child and publish. The pubsub notification
-		// wakes the function without needing a clock advance.
+		// Transition the child first, then publish once the
+		// durable completion state is observable. Pubsub only
+		// wakes the waiter; it does not guarantee the report is
+		// visible in the same instant as the notification.
 		setChatStatus(ctx, t, db, child.ID, database.ChatStatusWaiting, "")
 		insertAssistantMessage(ctx, t, db, child.ID, model.ID, "pubsub result")
+		require.Eventually(t, func() bool {
+			chat, report, done, err := server.checkSubagentCompletion(ctx, child.ID)
+			if err != nil {
+				return false
+			}
+			return done && chat.ID == child.ID && report == "pubsub result"
+		}, testutil.WaitMedium, testutil.IntervalFast)
 		_ = ps.Publish(
 			coderdpubsub.ChatStreamNotifyChannel(child.ID),
 			[]byte("done"),
@@ -1047,6 +1056,30 @@ func TestAwaitSubagentCompletion(t *testing.T) {
 		require.NoError(t, result.err)
 		assert.Equal(t, child.ID, result.chat.ID)
 		assert.Equal(t, "pubsub result", result.report)
+	})
+
+	t.Run("AlreadyWaitingNoReport", func(t *testing.T) {
+		t.Parallel()
+
+		db, ps := dbtestutil.NewDB(t)
+		mClock := quartz.NewMock(t)
+		server := newInternalTestServerWithClock(t, db, ps, chatprovider.ProviderAPIKeys{}, mClock)
+		ctx := chatdTestContext(t)
+		user, model := seedInternalChatDeps(ctx, t, db)
+
+		parent, child := createParentChildChats(ctx, t, server, user, model)
+
+		// signalWake from CreateChat may trigger immediate processing.
+		// Wait for it to settle, then set the terminal state we need.
+		server.inflight.Wait()
+		setChatStatus(ctx, t, db, child.ID, database.ChatStatusWaiting, "")
+
+		gotChat, report, err := server.awaitSubagentCompletion(
+			ctx, parent.ID, child.ID, 5*time.Second,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, child.ID, gotChat.ID)
+		assert.Empty(t, report)
 	})
 
 	t.Run("Timeout", func(t *testing.T) {


### PR DESCRIPTION
- stabilize `TestAwaitSubagentCompletion/CompletesViaPubsub` by waiting for durable completion state before sending the synthetic pubsub wake
- add coverage for successful subagent completion with an empty report

<details>
<summary>Plan</summary>

- Research: `docs/plans/subagent-await-pubsub-flake-research.md`
- Keep runtime behavior unchanged in `coderd/x/chatd`
- Treat empty sub-agent reports as exceptional but valid
- Fix only the brittle test synchronization and make the empty-report contract explicit in tests

</details>

> 🤖 Written by a Coder Agent. Will be reviewed by a human.