### PR TITLE
fix(agent): exorcise data race haunting contextConfigAPI on reconnect

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -403,6 +403,12 @@ func (a *agent) init() {
 	a.desktopAPI = agentdesktop.NewAPI(a.logger.Named("desktop"), desktop, a.clock)
 	a.mcpManager = agentmcp.NewManager(a.logger.Named("mcp"))
 	a.mcpAPI = agentmcp.NewAPI(a.logger.Named("mcp"), a.mcpManager)
+	a.contextConfigAPI = agentcontextconfig.NewAPI(func() string {
+		if m := a.manifest.Load(); m != nil {
+			return m.Directory
+		}
+		return ""
+	})
 	a.reconnectingPTYServer = reconnectingpty.NewServer(
 		a.logger.Named("reconnecting-pty"),
 		a.sshServer,
@@ -1265,12 +1271,6 @@ func (a *agent) handleManifest(manifestOK *checkpoint) func(ctx context.Context,
 			return xerrors.Errorf("update workspace agent startup: %w", err)
 		}
 
-		// Initialize the context config API with the expanded
-		// working directory so that it is ready before the HTTP
-		// handler is created (which happens after manifestOK).
-		a.contextConfigAPI = agentcontextconfig.NewAPI(
-			manifest.Directory,
-		)
 		oldManifest := a.manifest.Swap(&manifest)
 		manifestOK.complete(nil)
 		sentResult = true

--- a/agent/agent_internal_test.go
+++ b/agent/agent_internal_test.go
@@ -58,7 +58,15 @@ func TestReportConnectionEmpty(t *testing.T) {
 }
 
 func TestContextConfigAPI_InitOnce(t *testing.T) {
-	t.Parallel()
+	// Not parallel: uses t.Setenv to clear env vars.
+
+	// Clear env vars so defaults are used and the test is
+	// hermetic regardless of the surrounding environment.
+	t.Setenv(agentcontextconfig.EnvInstructionsDirs, "")
+	t.Setenv(agentcontextconfig.EnvInstructionsFile, "")
+	t.Setenv(agentcontextconfig.EnvSkillsDirs, "")
+	t.Setenv(agentcontextconfig.EnvSkillMetaFile, "")
+	t.Setenv(agentcontextconfig.EnvMCPConfigFiles, "")
 
 	// After the fix, contextConfigAPI is set once in init() and
 	// never reassigned. Config() evaluates lazily via the

--- a/agent/agent_internal_test.go
+++ b/agent/agent_internal_test.go
@@ -8,7 +8,9 @@ import (
 
 	"cdr.dev/slog/v3"
 	"cdr.dev/slog/v3/sloggers/slogtest"
+	"github.com/coder/coder/v2/agent/agentcontextconfig"
 	"github.com/coder/coder/v2/agent/proto"
+	agentsdk "github.com/coder/coder/v2/codersdk/agentsdk"
 	"github.com/coder/coder/v2/testutil"
 )
 
@@ -41,4 +43,31 @@ func TestReportConnectionEmpty(t *testing.T) {
 	require.Equal(t, connID[:], req1.GetConnection().GetId())
 	require.Equal(t, proto.Connection_DISCONNECT, req1.GetConnection().GetAction())
 	require.Equal(t, "because", req1.GetConnection().GetReason())
+}
+
+func TestContextConfigAPI_InitOnce(t *testing.T) {
+	t.Parallel()
+
+	// After the fix, contextConfigAPI is set once in init() and
+	// never reassigned. Config() evaluates lazily via the
+	// manifest, so there is no concurrent write to race with.
+	a := &agent{}
+	a.manifest.Store(&agentsdk.Manifest{Directory: "/dir1"})
+	a.contextConfigAPI = agentcontextconfig.NewAPI(func() string {
+		if m := a.manifest.Load(); m != nil {
+			return m.Directory
+		}
+		return ""
+	})
+
+	cfg1 := a.contextConfigAPI.Config()
+	require.NotEmpty(t, cfg1.MCPConfigFiles)
+	require.Contains(t, cfg1.MCPConfigFiles[0], "/dir1")
+
+	// Simulate manifest update on reconnection — no field
+	// reassignment needed, the lazy closure picks it up.
+	a.manifest.Store(&agentsdk.Manifest{Directory: "/dir2"})
+	cfg2 := a.contextConfigAPI.Config()
+	require.NotEmpty(t, cfg2.MCPConfigFiles)
+	require.Contains(t, cfg2.MCPConfigFiles[0], "/dir2")
 }

--- a/agent/agent_internal_test.go
+++ b/agent/agent_internal_test.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/google/uuid"
@@ -13,6 +15,16 @@ import (
 	agentsdk "github.com/coder/coder/v2/codersdk/agentsdk"
 	"github.com/coder/coder/v2/testutil"
 )
+
+// platformAbsPath constructs an absolute path that is valid
+// on the current platform. On Windows, paths must include a
+// drive letter to be considered absolute.
+func platformAbsPath(parts ...string) string {
+	if runtime.GOOS == "windows" {
+		return `C:\` + filepath.Join(parts...)
+	}
+	return "/" + filepath.Join(parts...)
+}
 
 // TestReportConnectionEmpty tests that reportConnection() doesn't choke if given an empty IP string, which is what we
 // send if we cannot get the remote address.
@@ -51,8 +63,11 @@ func TestContextConfigAPI_InitOnce(t *testing.T) {
 	// After the fix, contextConfigAPI is set once in init() and
 	// never reassigned. Config() evaluates lazily via the
 	// manifest, so there is no concurrent write to race with.
+	dir1 := platformAbsPath("dir1")
+	dir2 := platformAbsPath("dir2")
+
 	a := &agent{}
-	a.manifest.Store(&agentsdk.Manifest{Directory: "/dir1"})
+	a.manifest.Store(&agentsdk.Manifest{Directory: dir1})
 	a.contextConfigAPI = agentcontextconfig.NewAPI(func() string {
 		if m := a.manifest.Load(); m != nil {
 			return m.Directory
@@ -62,12 +77,12 @@ func TestContextConfigAPI_InitOnce(t *testing.T) {
 
 	cfg1 := a.contextConfigAPI.Config()
 	require.NotEmpty(t, cfg1.MCPConfigFiles)
-	require.Contains(t, cfg1.MCPConfigFiles[0], "/dir1")
+	require.Contains(t, cfg1.MCPConfigFiles[0], dir1)
 
 	// Simulate manifest update on reconnection — no field
 	// reassignment needed, the lazy closure picks it up.
-	a.manifest.Store(&agentsdk.Manifest{Directory: "/dir2"})
+	a.manifest.Store(&agentsdk.Manifest{Directory: dir2})
 	cfg2 := a.contextConfigAPI.Config()
 	require.NotEmpty(t, cfg2.MCPConfigFiles)
-	require.Contains(t, cfg2.MCPConfigFiles[0], "/dir2")
+	require.Contains(t, cfg2.MCPConfigFiles[0], dir2)
 }

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -3007,7 +3007,7 @@ func TestAgent_Speedtest(t *testing.T) {
 
 func TestAgent_Reconnect(t *testing.T) {
 	t.Parallel()
-	ctx := testutil.Context(t, testutil.WaitShort)
+	ctx := testutil.Context(t, testutil.WaitLong)
 	logger := testutil.Logger(t)
 	// After the agent is disconnected from a coordinator, it's supposed
 	// to reconnect!
@@ -3020,7 +3020,8 @@ func TestAgent_Reconnect(t *testing.T) {
 		logger,
 		agentID,
 		agentsdk.Manifest{
-			DERPMap: derpMap,
+			DERPMap:   derpMap,
+			Directory: "/test/workspace",
 		},
 		statsCh,
 		fCoordinator,
@@ -3033,13 +3034,18 @@ func TestAgent_Reconnect(t *testing.T) {
 	})
 	defer closer.Close()
 
-	call1 := testutil.RequireReceive(ctx, t, fCoordinator.CoordinateCalls)
-	require.Equal(t, client.GetNumRefreshTokenCalls(), 1)
-	close(call1.Resps) // hang up
-	// expect reconnect
+	// Each iteration writes a.contextConfigAPI in handleManifest
+	// while the tracked HTTP server goroutine (from connection 1's
+	// createTailnet) is still alive, widening the race window.
+	const reconnections = 5
+	for i := range reconnections {
+		call := testutil.RequireReceive(ctx, t, fCoordinator.CoordinateCalls)
+		require.Equal(t, i+1, client.GetNumRefreshTokenCalls())
+		close(call.Resps) // hang up — triggers reconnect
+	}
+	// Verify final reconnect succeeds.
 	testutil.RequireReceive(ctx, t, fCoordinator.CoordinateCalls)
-	// Check that the agent refreshes the token when it reconnects.
-	require.Equal(t, client.GetNumRefreshTokenCalls(), 2)
+	require.Equal(t, reconnections+1, client.GetNumRefreshTokenCalls())
 	closer.Close()
 }
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -3034,9 +3034,10 @@ func TestAgent_Reconnect(t *testing.T) {
 	})
 	defer closer.Close()
 
-	// Each iteration writes a.contextConfigAPI in handleManifest
-	// while the tracked HTTP server goroutine (from connection 1's
-	// createTailnet) is still alive, widening the race window.
+	// Each iteration forces the agent to reconnect by closing
+	// the current coordinate call while the tracked HTTP server
+	// goroutine (from connection 1's createTailnet) is still
+	// alive, widening the race window.
 	const reconnections = 5
 	for i := range reconnections {
 		call := testutil.RequireReceive(ctx, t, fCoordinator.CoordinateCalls)

--- a/agent/agentcontextconfig/api.go
+++ b/agent/agentcontextconfig/api.go
@@ -36,6 +36,9 @@ type API struct {
 // The directory is evaluated lazily on each call to Config(),
 // so the caller can update it after construction.
 func NewAPI(workingDir func() string) *API {
+	if workingDir == nil {
+		workingDir = func() string { return "" }
+	}
 	return &API{workingDir: workingDir}
 }
 

--- a/agent/agentcontextconfig/api.go
+++ b/agent/agentcontextconfig/api.go
@@ -29,16 +29,14 @@ const (
 // API exposes the resolved context configuration through the
 // agent's HTTP API.
 type API struct {
-	config workspacesdk.ContextConfigResponse
+	workingDir func() string
 }
 
-// NewAPI reads context configuration from environment variables,
-// resolves all paths relative to workingDir, and returns an API
-// handler that serves the result.
-func NewAPI(workingDir string) *API {
-	return &API{
-		config: Config(workingDir),
-	}
+// NewAPI accepts a closure that returns the working directory.
+// The directory is evaluated lazily on each call to Config(),
+// so the caller can update it after construction.
+func NewAPI(workingDir func() string) *API {
+	return &API{workingDir: workingDir}
 }
 
 // Config reads env vars and resolves paths. Exported for use
@@ -67,7 +65,7 @@ func Config(workingDir string) workspacesdk.ContextConfigResponse {
 // Config returns the resolved config for use by other agent
 // components (e.g. MCP manager).
 func (api *API) Config() workspacesdk.ContextConfigResponse {
-	return api.config
+	return Config(api.workingDir())
 }
 
 // Routes returns the HTTP handler for the context config
@@ -79,5 +77,5 @@ func (api *API) Routes() http.Handler {
 }
 
 func (api *API) handleGet(rw http.ResponseWriter, r *http.Request) {
-	httpapi.Write(r.Context(), rw, http.StatusOK, api.config)
+	httpapi.Write(r.Context(), rw, http.StatusOK, api.Config())
 }

--- a/agent/agentcontextconfig/api_test.go
+++ b/agent/agentcontextconfig/api_test.go
@@ -93,3 +93,25 @@ func TestConfig(t *testing.T) {
 		require.Equal(t, []string{a, b}, cfg.InstructionsDirs)
 	})
 }
+
+func TestNewAPI_LazyDirectory(t *testing.T) {
+	t.Setenv(agentcontextconfig.EnvInstructionsDirs, "")
+	t.Setenv(agentcontextconfig.EnvInstructionsFile, "")
+	t.Setenv(agentcontextconfig.EnvSkillsDirs, "")
+	t.Setenv(agentcontextconfig.EnvSkillMetaFile, "")
+	t.Setenv(agentcontextconfig.EnvMCPConfigFiles, "")
+
+	dir := ""
+	api := agentcontextconfig.NewAPI(func() string { return dir })
+
+	// Before directory is set, relative paths resolve to nothing.
+	cfg := api.Config()
+	require.Empty(t, cfg.SkillsDirs)
+	require.Empty(t, cfg.MCPConfigFiles)
+
+	// After setting the directory, Config() picks it up lazily.
+	dir = platformAbsPath("work")
+	cfg = api.Config()
+	require.NotEmpty(t, cfg.SkillsDirs)
+	require.Equal(t, []string{filepath.Join(dir, ".agents", "skills")}, cfg.SkillsDirs)
+}


### PR DESCRIPTION
Fixes: coder/internal#1441

- Move `contextConfigAPI` init from `handleManifest` to `init()`, matching all other API fields
- Change `agentcontextconfig.NewAPI` to accept `func() string` closure (lazy directory evaluation)
- `Config()` and HTTP handler now compute on demand via `a.manifest.Load().Directory`
- Widen `TestAgent_Reconnect` to loop 5 reconnections with a non-empty manifest directory
- Add `TestContextConfigAPI_InitOnce` internal test verifying lazy eval across manifest changes
- Add `TestNewAPI_LazyDirectory` unit test for the lazy contract

<details>
<summary>Investigation and plan</summary>

### Root cause

`contextConfigAPI` was the only API field on the `agent` struct initialized in `handleManifest` (a connection-scoped goroutine) instead of `init()`. On reconnection, the bare pointer assignment raced with reads from tracked goroutines that survive across connections (`apiHandler` in `createTailnet`, MCP connect goroutine).

### Fix approach

Follow the same lazy closure pattern as `processAPI`: create the API once in `init()` with a `func() string` that reads `a.manifest.Load().Directory` at call time. The field becomes write-once before any goroutines start. No synchronization primitives needed.

### Decision log

| Decision | Choice | Reasoning |
|----------|--------|-----------|
| How to eliminate the race | Init in `init()` with lazy closure | Matches every other API field; eliminates race by construction |
| Eager vs lazy env var reads | Lazy (on each `Config()` call) | Avoids reconstructing API on reconnect; trivial cost |

</details>

> 🤖 Written by a Coder Agent. Will be reviewed by a human.