### PR TITLE
fix(scripts/releaser): simplify branch regex and fix changelog range

### DIFF
--- a/scripts/releaser/main.go
+++ b/scripts/releaser/main.go
@@ -23,7 +23,7 @@ func main() {
 	cmd := &serpent.Command{
 		Use:   "releaser",
 		Short: "Interactive release tagging for coder/coder.",
-		Long:  "Run this from a release branch (release/X.Y). The tool detects the branch, infers the next version, and walks you through tagging, pushing, and triggering the release workflow.",
+		Long:  "Run this from a release branch (release/X.Y or release/X.Y.Z). The tool detects the branch, infers the next version, and walks you through tagging, pushing, and triggering the release workflow.",
 		Options: serpent.OptionSet{
 			{
 				Name:        "dry-run",

--- a/scripts/releaser/main.go
+++ b/scripts/releaser/main.go
@@ -23,7 +23,7 @@ func main() {
 	cmd := &serpent.Command{
 		Use:   "releaser",
 		Short: "Interactive release tagging for coder/coder.",
-		Long:  "Run this from a release branch (release/X.Y or release/X.Y.Z). The tool detects the branch, infers the next version, and walks you through tagging, pushing, and triggering the release workflow.",
+		Long:  "Run this from a release branch (release/X.Y). The tool detects the branch, infers the next version, and walks you through tagging, pushing, and triggering the release workflow.",
 		Options: serpent.OptionSet{
 			{
 				Name:        "dry-run",

--- a/scripts/releaser/release.go
+++ b/scripts/releaser/release.go
@@ -68,17 +68,17 @@ func runRelease(ctx context.Context, inv *serpent.Invocation, executor ReleaseEx
 		return xerrors.Errorf("detecting branch: %w", err)
 	}
 
-	// Match standard release branches (release/2.32) and RC
-	// branches (release/2.32-rc.0).
-	branchRe := regexp.MustCompile(`^release/(\d+)\.(\d+)(?:-rc\.(\d+))?$`)
+	// Match standard release branches (release/2.32, release/2.32.0)
+	// and RC branches (release/2.32-rc.0, release/2.32.0-rc.0).
+	branchRe := regexp.MustCompile(`^release/(\d+)\.(\d+)(?:\.(\d+))?(?:-rc\.(\d+))?$`)
 	m := branchRe.FindStringSubmatch(currentBranch)
 	if m == nil {
-		warnf(w, "Current branch %q is not a release branch (release/X.Y or release/X.Y-rc.N).", currentBranch)
+		warnf(w, "Current branch %q is not a release branch (release/X.Y[.Z] or release/X.Y[.Z]-rc.N).", currentBranch)
 		branchInput, err := cliui.Prompt(inv, cliui.PromptOptions{
-			Text: "Enter the release branch to use (e.g. release/2.21 or release/2.21-rc.0)",
+			Text: "Enter the release branch to use (e.g. release/2.21, release/2.21.0, or release/2.21.0-rc.0)",
 			Validate: func(s string) error {
 				if !branchRe.MatchString(s) {
-					return xerrors.New("must be in format release/X.Y or release/X.Y-rc.N (e.g. release/2.21 or release/2.21-rc.0)")
+					return xerrors.New("must be in format release/X.Y[.Z] or release/X.Y[.Z]-rc.N (e.g. release/2.21, release/2.21.0, or release/2.21.0-rc.0)")
 				}
 				return nil
 			},
@@ -91,9 +91,13 @@ func runRelease(ctx context.Context, inv *serpent.Invocation, executor ReleaseEx
 	}
 	branchMajor, _ := strconv.Atoi(m[1])
 	branchMinor, _ := strconv.Atoi(m[2])
-	branchRC := -1 // -1 means not an RC branch.
+	branchPatch := 0
 	if m[3] != "" {
-		branchRC, _ = strconv.Atoi(m[3])
+		branchPatch, _ = strconv.Atoi(m[3])
+	}
+	branchRC := -1 // -1 means not an RC branch.
+	if m[4] != "" {
+		branchRC, _ = strconv.Atoi(m[4])
 	}
 	successf(w, "Using release branch: %s", currentBranch)
 
@@ -138,10 +142,40 @@ func runRelease(ctx context.Context, inv *serpent.Invocation, executor ReleaseEx
 		}
 	}
 
+	// changelogBaseRef is the git ref used as the starting point
+	// for release notes generation. When a tag already exists in
+	// this minor series we use it directly. For the first release
+	// on a new minor (e.g. the first RC) no matching tag exists,
+	// so we compute the merge-base with the previous minor's
+	// release branch instead. This works even when that branch
+	// has no tags yet (it was just cut and pushed). As a last
+	// resort we fall back to the latest reachable tag from a
+	// previous minor.
+	var changelogBaseRef string
+	if prevVersion != nil {
+		changelogBaseRef = prevVersion.String()
+	} else {
+		prevReleaseBranch := fmt.Sprintf("release/%d.%d", branchMajor, branchMinor-1)
+		_ = gitRun("fetch", "--quiet", "origin", prevReleaseBranch)
+		if mb, mbErr := gitOutput("merge-base", "HEAD", "origin/"+prevReleaseBranch); mbErr == nil && mb != "" {
+			changelogBaseRef = mb
+			infof(w, "Using merge-base with %s as changelog base: %s", prevReleaseBranch, mb[:12])
+		} else {
+			// No previous release branch found; fall back to
+			// the latest reachable tag from a previous minor.
+			for _, t := range mergedTags {
+				if t.Major == branchMajor && t.Minor < branchMinor {
+					changelogBaseRef = t.String()
+					break
+				}
+			}
+		}
+	}
+
 	var suggested version
 	if prevVersion == nil {
 		infof(w, "No previous release tag found on this branch.")
-		suggested = version{Major: branchMajor, Minor: branchMinor, Patch: 0}
+		suggested = version{Major: branchMajor, Minor: branchMinor, Patch: branchPatch}
 		if branchRC >= 0 {
 			suggested.Pre = fmt.Sprintf("rc.%d", branchRC)
 		}
@@ -366,8 +400,8 @@ func runRelease(ctx context.Context, inv *serpent.Invocation, executor ReleaseEx
 	infof(w, "Generating release notes...")
 
 	commitRange := "HEAD"
-	if prevVersion != nil {
-		commitRange = prevVersion.String() + "..HEAD"
+	if changelogBaseRef != "" {
+		commitRange = changelogBaseRef + "..HEAD"
 	}
 
 	commits, err := commitLog(commitRange)
@@ -473,16 +507,16 @@ func runRelease(ctx context.Context, inv *serpent.Invocation, executor ReleaseEx
 	}
 	if !hasContent {
 		prevStr := "the beginning of time"
-		if prevVersion != nil {
-			prevStr = prevVersion.String()
+		if changelogBaseRef != "" {
+			prevStr = changelogBaseRef
 		}
 		fmt.Fprintf(&notes, "\n_No changes since %s._\n", prevStr)
 	}
 
 	// Compare link.
-	if prevVersion != nil {
+	if changelogBaseRef != "" {
 		fmt.Fprintf(&notes, "\nCompare: [`%s...%s`](https://github.com/%s/%s/compare/%s...%s)\n",
-			prevVersion, newVersion, owner, repo, prevVersion, newVersion)
+			changelogBaseRef, newVersion, owner, repo, changelogBaseRef, newVersion)
 	}
 
 	// Container image.

--- a/scripts/releaser/release.go
+++ b/scripts/releaser/release.go
@@ -68,17 +68,17 @@ func runRelease(ctx context.Context, inv *serpent.Invocation, executor ReleaseEx
 		return xerrors.Errorf("detecting branch: %w", err)
 	}
 
-	// Match release branches (release/2.32) and RC branches
-	// (release/2.32-rc.0).
-	branchRe := regexp.MustCompile(`^release/(\d+)\.(\d+)(?:-rc\.(\d+))?$`)
+	// Match release branches (release/X.Y). RCs are tagged
+	// from main, not from release branches.
+	branchRe := regexp.MustCompile(`^release/(\d+)\.(\d+)$`)
 	m := branchRe.FindStringSubmatch(currentBranch)
 	if m == nil {
-		warnf(w, "Current branch %q is not a release branch (release/X.Y or release/X.Y-rc.N).", currentBranch)
+		warnf(w, "Current branch %q is not a release branch (release/X.Y).", currentBranch)
 		branchInput, err := cliui.Prompt(inv, cliui.PromptOptions{
-			Text: "Enter the release branch to use (e.g. release/2.21 or release/2.21-rc.0)",
+			Text: "Enter the release branch to use (e.g. release/2.21)",
 			Validate: func(s string) error {
 				if !branchRe.MatchString(s) {
-					return xerrors.New("must be in format release/X.Y or release/X.Y-rc.N (e.g. release/2.21 or release/2.21-rc.0)")
+					return xerrors.New("must be in format release/X.Y (e.g. release/2.21)")
 				}
 				return nil
 			},
@@ -91,10 +91,6 @@ func runRelease(ctx context.Context, inv *serpent.Invocation, executor ReleaseEx
 	}
 	branchMajor, _ := strconv.Atoi(m[1])
 	branchMinor, _ := strconv.Atoi(m[2])
-	branchRC := -1 // -1 means not an RC branch.
-	if m[3] != "" {
-		branchRC, _ = strconv.Atoi(m[3])
-	}
 	successf(w, "Using release branch: %s", currentBranch)
 
 	// --- Fetch & sync check ---
@@ -141,12 +137,11 @@ func runRelease(ctx context.Context, inv *serpent.Invocation, executor ReleaseEx
 	// changelogBaseRef is the git ref used as the starting point
 	// for release notes generation. When a tag already exists in
 	// this minor series we use it directly. For the first release
-	// on a new minor (e.g. the first RC) no matching tag exists,
-	// so we compute the merge-base with the previous minor's
-	// release branch instead. This works even when that branch
-	// has no tags yet (it was just cut and pushed). As a last
-	// resort we fall back to the latest reachable tag from a
-	// previous minor.
+	// on a new minor no matching tag exists, so we compute the
+	// merge-base with the previous minor's release branch instead.
+	// This works even when that branch has no tags yet (it was
+	// just cut and pushed). As a last resort we fall back to the
+	// latest reachable tag from a previous minor.
 	var changelogBaseRef string
 	if prevVersion != nil {
 		changelogBaseRef = prevVersion.String()
@@ -172,27 +167,9 @@ func runRelease(ctx context.Context, inv *serpent.Invocation, executor ReleaseEx
 	if prevVersion == nil {
 		infof(w, "No previous release tag found on this branch.")
 		suggested = version{Major: branchMajor, Minor: branchMinor, Patch: 0}
-		if branchRC >= 0 {
-			suggested.Pre = fmt.Sprintf("rc.%d", branchRC)
-		}
 	} else {
 		infof(w, "Previous release tag: %s", prevVersion.String())
-		if branchRC >= 0 {
-			// On an RC branch, suggest the next RC for
-			// the same base version.
-			nextRC := 0
-			if prevVersion.IsRC() {
-				nextRC = prevVersion.rcNumber() + 1
-			}
-			suggested = version{
-				Major: prevVersion.Major,
-				Minor: prevVersion.Minor,
-				Patch: prevVersion.Patch,
-				Pre:   fmt.Sprintf("rc.%d", nextRC),
-			}
-		} else {
-			suggested = version{Major: prevVersion.Major, Minor: prevVersion.Minor, Patch: prevVersion.Patch + 1}
-		}
+		suggested = version{Major: prevVersion.Major, Minor: prevVersion.Minor, Patch: prevVersion.Patch + 1}
 	}
 
 	fmt.Fprintln(w)

--- a/scripts/releaser/release.go
+++ b/scripts/releaser/release.go
@@ -68,17 +68,17 @@ func runRelease(ctx context.Context, inv *serpent.Invocation, executor ReleaseEx
 		return xerrors.Errorf("detecting branch: %w", err)
 	}
 
-	// Match standard release branches (release/2.32, release/2.32.0)
-	// and RC branches (release/2.32-rc.0, release/2.32.0-rc.0).
-	branchRe := regexp.MustCompile(`^release/(\d+)\.(\d+)(?:\.(\d+))?(?:-rc\.(\d+))?$`)
+	// Match release branches (release/2.32) and RC branches
+	// (release/2.32-rc.0).
+	branchRe := regexp.MustCompile(`^release/(\d+)\.(\d+)(?:-rc\.(\d+))?$`)
 	m := branchRe.FindStringSubmatch(currentBranch)
 	if m == nil {
-		warnf(w, "Current branch %q is not a release branch (release/X.Y[.Z] or release/X.Y[.Z]-rc.N).", currentBranch)
+		warnf(w, "Current branch %q is not a release branch (release/X.Y or release/X.Y-rc.N).", currentBranch)
 		branchInput, err := cliui.Prompt(inv, cliui.PromptOptions{
-			Text: "Enter the release branch to use (e.g. release/2.21, release/2.21.0, or release/2.21.0-rc.0)",
+			Text: "Enter the release branch to use (e.g. release/2.21 or release/2.21-rc.0)",
 			Validate: func(s string) error {
 				if !branchRe.MatchString(s) {
-					return xerrors.New("must be in format release/X.Y[.Z] or release/X.Y[.Z]-rc.N (e.g. release/2.21, release/2.21.0, or release/2.21.0-rc.0)")
+					return xerrors.New("must be in format release/X.Y or release/X.Y-rc.N (e.g. release/2.21 or release/2.21-rc.0)")
 				}
 				return nil
 			},
@@ -91,13 +91,9 @@ func runRelease(ctx context.Context, inv *serpent.Invocation, executor ReleaseEx
 	}
 	branchMajor, _ := strconv.Atoi(m[1])
 	branchMinor, _ := strconv.Atoi(m[2])
-	branchPatch := 0
-	if m[3] != "" {
-		branchPatch, _ = strconv.Atoi(m[3])
-	}
 	branchRC := -1 // -1 means not an RC branch.
-	if m[4] != "" {
-		branchRC, _ = strconv.Atoi(m[4])
+	if m[3] != "" {
+		branchRC, _ = strconv.Atoi(m[3])
 	}
 	successf(w, "Using release branch: %s", currentBranch)
 
@@ -175,7 +171,7 @@ func runRelease(ctx context.Context, inv *serpent.Invocation, executor ReleaseEx
 	var suggested version
 	if prevVersion == nil {
 		infof(w, "No previous release tag found on this branch.")
-		suggested = version{Major: branchMajor, Minor: branchMinor, Patch: branchPatch}
+		suggested = version{Major: branchMajor, Minor: branchMinor, Patch: 0}
 		if branchRC >= 0 {
 			suggested.Pre = fmt.Sprintf("rc.%d", branchRC)
 		}

--- a/scripts/releaser/release.go
+++ b/scripts/releaser/release.go
@@ -147,7 +147,9 @@ func runRelease(ctx context.Context, inv *serpent.Invocation, executor ReleaseEx
 		changelogBaseRef = prevVersion.String()
 	} else {
 		prevReleaseBranch := fmt.Sprintf("release/%d.%d", branchMajor, branchMinor-1)
-		_ = gitRun("fetch", "--quiet", "origin", prevReleaseBranch)
+		if err := gitRun("fetch", "--quiet", "origin", prevReleaseBranch); err != nil {
+			warnf(w, "Could not fetch %s: %v", prevReleaseBranch, err)
+		}
 		if mb, mbErr := gitOutput("merge-base", "HEAD", "origin/"+prevReleaseBranch); mbErr == nil && mb != "" {
 			changelogBaseRef = mb
 			infof(w, "Using merge-base with %s as changelog base: %s", prevReleaseBranch, mb[:12])


### PR DESCRIPTION
Fixes the changelog range for the first release on a new minor branch.

Depends on #24001 — rebased on top of `align-rc-release-branches`.

**Problem:** When no tags match the branch's major.minor (first release on a
new minor), the commit range falls back to `HEAD` — the entire git history
(~13k lines of changelog).

**Fix:** Computes `git merge-base` with the previous minor's release branch
(e.g. `origin/release/2.32`) as the changelog starting point. This works even
when that branch has no tags pushed yet. Falls back to the latest reachable
tag from a previous minor if the branch doesn't exist. Also warns (instead of
silently ignoring) when the fetch of the previous release branch fails.