### PR TITLE
feat(site): add "starting" status to workspace filter dropdown

### DIFF
--- a/site/src/pages/WorkspacesPage/filter/menus.tsx
+++ b/site/src/pages/WorkspacesPage/filter/menus.tsx
@@ -103,6 +103,7 @@ export const useStatusFilterMenu = ({
 }: Pick<UseFilterMenuOptions, "value" | "onChange">) => {
 	const statusesToFilter: WorkspaceStatus[] = [
 		"running",
+		"starting",
 		"stopped",
 		"failed",
 		"pending",


### PR DESCRIPTION
The workspace status filter dropdown was missing the "starting" option.
This adds it between "running" and "stopped" so users can filter for
workspaces that are currently starting up.

No backend changes needed — the `status:starting` query was already
supported.