### PR TITLE
test: use non-monitoring RPC role in apptest setup

### DIFF
--- a/coderd/workspaceapps/apptest/setup.go
+++ b/coderd/workspaceapps/apptest/setup.go
@@ -515,7 +515,11 @@ func createWorkspaceWithApps(t *testing.T, client *codersdk.Client, orgID uuid.U
 	primaryAppHost, err := client.AppHost(appHostCtx)
 	require.NoError(t, err)
 	if primaryAppHost.Host != "" {
-		rpcConn, err := agentClient.ConnectRPC(appHostCtx)
+		// Fetch the manifest without marking this short-lived helper
+		// connection as the workspace agent. Closing a monitored RPC
+		// connection races with the real agent startup and can
+		// transiently mark the agent disconnected.
+		rpcConn, err := agentClient.ConnectRPCWithRole(appHostCtx, "apptest-manifest")
 		require.NoError(t, err)
 		aAPI := agentproto.NewDRPCAgentClient(rpcConn)
 		manifest, err := aAPI.GetManifest(appHostCtx, &agentproto.GetManifestRequest{})


### PR DESCRIPTION
Closes https://github.com/coder/internal/issues/1432
Closes https://github.com/coder/internal/issues/1399

The test setup in `createWorkspaceWithApps` opens a short-lived RPC connection to fetch the agent manifest before starting the real agent. This connection used `ConnectRPC()` which sends no `role` parameter, so the server treated it as a real agent connection and enabled connection monitoring. When the helper closed, its monitor asynchronously wrote `disconnectedAt` to the DB — racing with the real agent's monitor and transiently marking the agent as disconnected.

The fix uses `ConnectRPCWithRole(ctx, "apptest-manifest")` so the helper doesn't trigger connection monitoring. The server already has this role-based distinction for non-agent clients like `coder-logstream-kube`; the test helper just wasn't using it.

Both issues share this codepath: `setupProxyTest` → `createWorkspaceWithApps` → the `ConnectRPC` call at `setup.go:518`. Both test configurations have a non-empty `PrimaryAppHost`, so both enter the affected block.

This is not masking a product issue — the "disconnected" state was caused by two competing monitors writing to the same agent DB row, a scenario that only exists in this test setup. No assertions were weakened; the proxy still checks real agent connectivity on every request.
