### PR TITLE
feat: implement new workspace download logs dropdown

### DIFF
--- a/site/src/components/Tabs/Tabs.tsx
+++ b/site/src/components/Tabs/Tabs.tsx
@@ -61,7 +61,6 @@ export const TabsList: FC<TabsListProps> = ({
 }) => {
 	return (
 		<TabsPrimitive.List
-			data-slot="tabs-list"
 			className={cn(
 				tabsListVariants({ variant }),
 				overflowKebabMenu && "flex-nowrap",

--- a/site/src/components/Tabs/Tabs.tsx
+++ b/site/src/components/Tabs/Tabs.tsx
@@ -75,7 +75,7 @@ export const TabsList: FC<TabsListProps> = ({
 type TabsTriggerProps = ComponentProps<typeof TabsPrimitive.Trigger>;
 
 export const TabsTrigger: FC<TabsTriggerProps> = ({
-	type: triggerType,
+	type: triggerType = "button",
 	...props
 }) => {
 	const type = props.asChild ? undefined : (triggerType ?? "button");

--- a/site/src/components/Tabs/Tabs.tsx
+++ b/site/src/components/Tabs/Tabs.tsx
@@ -61,6 +61,7 @@ export const TabsList: FC<TabsListProps> = ({
 }) => {
 	return (
 		<TabsPrimitive.List
+			data-slot="tabs-list"
 			className={cn(
 				tabsListVariants({ variant }),
 				overflowKebabMenu && "flex-nowrap",
@@ -81,6 +82,7 @@ export const TabsTrigger: FC<TabsTriggerProps> = ({
 
 	return (
 		<TabsPrimitive.Trigger
+			data-slot="tabs-trigger"
 			type={type}
 			className={cn(
 				"border-none py-3 bg-transparent",

--- a/site/src/components/Tabs/Tabs.tsx
+++ b/site/src/components/Tabs/Tabs.tsx
@@ -75,14 +75,13 @@ export const TabsList: FC<TabsListProps> = ({
 type TabsTriggerProps = ComponentProps<typeof TabsPrimitive.Trigger>;
 
 export const TabsTrigger: FC<TabsTriggerProps> = ({
-	type: triggerType = "button",
+	type: triggerType,
 	...props
 }) => {
-	const type = props.asChild ? undefined : triggerType;
+	const type = props.asChild ? undefined : (triggerType ?? "button");
 
 	return (
 		<TabsPrimitive.Trigger
-			data-slot="tabs-trigger"
 			type={type}
 			className={cn(
 				"border-none py-3 bg-transparent",

--- a/site/src/components/Tabs/Tabs.tsx
+++ b/site/src/components/Tabs/Tabs.tsx
@@ -78,7 +78,7 @@ export const TabsTrigger: FC<TabsTriggerProps> = ({
 	type: triggerType = "button",
 	...props
 }) => {
-	const type = props.asChild ? undefined : (triggerType ?? "button");
+	const type = props.asChild ? undefined : triggerType;
 
 	return (
 		<TabsPrimitive.Trigger

--- a/site/src/components/Tabs/utils/useTabOverflowKebabMenu.ts
+++ b/site/src/components/Tabs/utils/useTabOverflowKebabMenu.ts
@@ -1,12 +1,4 @@
-import {
-	type RefObject,
-	useCallback,
-	useEffect,
-	useLayoutEffect,
-	useMemo,
-	useRef,
-	useState,
-} from "react";
+import { type RefObject, useEffect, useMemo, useRef, useState } from "react";
 
 type TabLike = {
 	value: string;
@@ -38,97 +30,85 @@ export const useTabOverflowKebabMenu = <TTab extends TabLike>({
 }: UseTabOverflowKebabMenuOptions<TTab>): UseTabOverflowKebabMenuResult<TTab> => {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const tabWidthByValueRef = useRef<Record<string, number>>({});
+	const tabsRef = useRef(tabs);
 	const [overflowTabValues, setOverflowTabValues] = useState<string[]>([]);
-
-	const recalculateOverflow = useCallback(() => {
-		if (!enabled) {
-			setOverflowTabValues([]);
-			return;
-		}
-
-		const container = containerRef.current;
-		if (!container) {
-			return;
-		}
-
-		for (const tab of tabs) {
-			const tabElement = container.querySelector<HTMLElement>(
-				`[${DATA_ATTR_TAB_VALUE}="${tab.value}"]`,
-			);
-			if (tabElement) {
-				tabWidthByValueRef.current[tab.value] = tabElement.offsetWidth;
-			}
-		}
-
-		const alwaysVisibleTabs = tabs.slice(0, alwaysVisibleTabsCount);
-		const optionalTabs = tabs.slice(alwaysVisibleTabsCount);
-		if (optionalTabs.length === 0) {
-			setOverflowTabValues([]);
-			return;
-		}
-
-		const alwaysVisibleWidth = alwaysVisibleTabs.reduce((total, tab) => {
-			return total + (tabWidthByValueRef.current[tab.value] ?? 0);
-		}, 0);
-
-		const availableWidth = container.clientWidth;
-		let usedWidth = alwaysVisibleWidth;
-		const nextOverflowValues: string[] = [];
-
-		for (let i = 0; i < optionalTabs.length; i++) {
-			const tab = optionalTabs[i];
-			const tabWidth = tabWidthByValueRef.current[tab.value] ?? 0;
-			const hasMoreTabsAfterCurrent = i < optionalTabs.length - 1;
-			const widthNeeded =
-				usedWidth +
-				tabWidth +
-				(hasMoreTabsAfterCurrent ? overflowTriggerWidthPx : 0);
-
-			if (widthNeeded <= availableWidth) {
-				usedWidth += tabWidth;
-				continue;
-			}
-
-			nextOverflowValues.push(
-				...optionalTabs.slice(i).map((overflowTab) => overflowTab.value),
-			);
-			break;
-		}
-
-		setOverflowTabValues((currentValues) => {
-			if (
-				currentValues.length === nextOverflowValues.length &&
-				currentValues.every(
-					(value, index) => value === nextOverflowValues[index],
-				)
-			) {
-				return currentValues;
-			}
-			return nextOverflowValues;
-		});
-	}, [alwaysVisibleTabsCount, enabled, overflowTriggerWidthPx, tabs]);
-
-	useLayoutEffect(() => {
-		if (!isActive) {
-			return;
-		}
-		recalculateOverflow();
-	}, [isActive, recalculateOverflow]);
+	tabsRef.current = tabs;
 
 	useEffect(() => {
-		if (!isActive) {
+		if (!enabled || !isActive) {
+			setOverflowTabValues([]);
 			return;
 		}
+
 		const container = containerRef.current;
 		if (!container) {
 			return;
 		}
-		const observer = new ResizeObserver(() => {
-			recalculateOverflow();
-		});
+
+		const recalculateOverflow = () => {
+			const currentTabs = tabsRef.current;
+			for (const tab of currentTabs) {
+				const tabElement = container.querySelector<HTMLElement>(
+					`[${DATA_ATTR_TAB_VALUE}="${tab.value}"]`,
+				);
+				if (tabElement) {
+					tabWidthByValueRef.current[tab.value] = tabElement.offsetWidth;
+				}
+			}
+
+			const alwaysVisibleTabs = currentTabs.slice(0, alwaysVisibleTabsCount);
+			const optionalTabs = currentTabs.slice(alwaysVisibleTabsCount);
+			if (optionalTabs.length === 0) {
+				setOverflowTabValues([]);
+				return;
+			}
+
+			const alwaysVisibleWidth = alwaysVisibleTabs.reduce((total, tab) => {
+				return total + (tabWidthByValueRef.current[tab.value] ?? 0);
+			}, 0);
+
+			const availableWidth = container.clientWidth;
+			let usedWidth = alwaysVisibleWidth;
+			const nextOverflowValues: string[] = [];
+
+			for (let i = 0; i < optionalTabs.length; i++) {
+				const tab = optionalTabs[i];
+				const tabWidth = tabWidthByValueRef.current[tab.value] ?? 0;
+				const hasMoreTabsAfterCurrent = i < optionalTabs.length - 1;
+				const widthNeeded =
+					usedWidth +
+					tabWidth +
+					(hasMoreTabsAfterCurrent ? overflowTriggerWidthPx : 0);
+
+				if (widthNeeded <= availableWidth) {
+					usedWidth += tabWidth;
+					continue;
+				}
+
+				nextOverflowValues.push(
+					...optionalTabs.slice(i).map((overflowTab) => overflowTab.value),
+				);
+				break;
+			}
+
+			setOverflowTabValues((currentValues) => {
+				if (
+					currentValues.length === nextOverflowValues.length &&
+					currentValues.every(
+						(value, index) => value === nextOverflowValues[index],
+					)
+				) {
+					return currentValues;
+				}
+				return nextOverflowValues;
+			});
+		};
+
+		recalculateOverflow();
+		const observer = new ResizeObserver(recalculateOverflow);
 		observer.observe(container);
 		return () => observer.disconnect();
-	}, [isActive, recalculateOverflow]);
+	}, [alwaysVisibleTabsCount, enabled, isActive, overflowTriggerWidthPx]);
 
 	const overflowTabValuesSet = useMemo(
 		() => new Set(overflowTabValues),
@@ -144,9 +124,9 @@ export const useTabOverflowKebabMenu = <TTab extends TabLike>({
 		[tabs, overflowTabValuesSet],
 	);
 
-	const getTabMeasureProps = useCallback((tabValue: string) => {
+	const getTabMeasureProps = (tabValue: string) => {
 		return { [DATA_ATTR_TAB_VALUE]: tabValue };
-	}, []);
+	};
 
 	return {
 		containerRef,

--- a/site/src/modules/resources/AgentRow.stories.tsx
+++ b/site/src/modules/resources/AgentRow.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, spyOn, userEvent, waitFor, within } from "storybook/test";
 import { API } from "#/api/api";
 import { workspaceAgentContainersKey } from "#/api/queries/workspaces";
-import type { WorkspaceAgentLogSource } from "#/api/typesGenerated";
+import type * as TypesGen from "#/api/typesGenerated";
 import { getPreferredProxy } from "#/contexts/ProxyContext";
 import { chromatic } from "#/testHelpers/chromatic";
 import * as M from "#/testHelpers/entities";
@@ -92,7 +92,7 @@ const logs = [
 	created_at: fixedLogTimestamp,
 }));
 
-const installScriptLogSource: WorkspaceAgentLogSource = {
+const installScriptLogSource: TypesGen.WorkspaceAgentLogSource = {
 	...M.MockWorkspaceAgentLogSource,
 	id: "f2ee4b8d-b09d-4f4e-a1f1-5e4adf7d53bb",
 	display_name: "Install Script",
@@ -121,6 +121,42 @@ const tabbedLogs = [
 		created_at: fixedLogTimestamp,
 	},
 ];
+
+const overflowLogSources: TypesGen.WorkspaceAgentLogSource[] = [
+	M.MockWorkspaceAgentLogSource,
+	{
+		...M.MockWorkspaceAgentLogSource,
+		id: "58f5db69-5f78-496f-bce1-0686f5525aa1",
+		display_name: "code-server",
+		icon: "/icon/code.svg",
+	},
+	{
+		...M.MockWorkspaceAgentLogSource,
+		id: "f39d758c-bce2-4f41-8d70-58fdb1f0f729",
+		display_name: "Install and start AgentAPI",
+		icon: "/icon/claude.svg",
+	},
+	{
+		...M.MockWorkspaceAgentLogSource,
+		id: "bf7529b8-1787-4a20-b54f-eb894680e48f",
+		display_name: "Mux",
+		icon: "/icon/mux.svg",
+	},
+	{
+		...M.MockWorkspaceAgentLogSource,
+		id: "0d6ebde6-c534-4551-9f91-bfd98bfb04f4",
+		display_name: "Portable Desktop",
+		icon: "/icon/portable-desktop.svg",
+	},
+];
+
+const overflowLogs = overflowLogSources.map((source, index) => ({
+	id: 200 + index,
+	level: "info",
+	output: `${source.display_name}: line`,
+	source_id: source.id,
+	created_at: new Date().toISOString(),
+}));
 
 const meta: Meta<typeof AgentRow> = {
 	title: "components/AgentRow",

--- a/site/src/modules/resources/AgentRow.stories.tsx
+++ b/site/src/modules/resources/AgentRow.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, spyOn, userEvent, waitFor, within } from "storybook/test";
 import { API } from "#/api/api";
 import { workspaceAgentContainersKey } from "#/api/queries/workspaces";
-import type * as TypesGen from "#/api/typesGenerated";
+import type { WorkspaceAgentLogSource } from "#/api/typesGenerated";
 import { getPreferredProxy } from "#/contexts/ProxyContext";
 import { chromatic } from "#/testHelpers/chromatic";
 import * as M from "#/testHelpers/entities";
@@ -92,7 +92,7 @@ const logs = [
 	created_at: fixedLogTimestamp,
 }));
 
-const installScriptLogSource: TypesGen.WorkspaceAgentLogSource = {
+const installScriptLogSource: WorkspaceAgentLogSource = {
 	...M.MockWorkspaceAgentLogSource,
 	id: "f2ee4b8d-b09d-4f4e-a1f1-5e4adf7d53bb",
 	display_name: "Install Script",
@@ -121,42 +121,6 @@ const tabbedLogs = [
 		created_at: fixedLogTimestamp,
 	},
 ];
-
-const overflowLogSources: TypesGen.WorkspaceAgentLogSource[] = [
-	M.MockWorkspaceAgentLogSource,
-	{
-		...M.MockWorkspaceAgentLogSource,
-		id: "58f5db69-5f78-496f-bce1-0686f5525aa1",
-		display_name: "code-server",
-		icon: "/icon/code.svg",
-	},
-	{
-		...M.MockWorkspaceAgentLogSource,
-		id: "f39d758c-bce2-4f41-8d70-58fdb1f0f729",
-		display_name: "Install and start AgentAPI",
-		icon: "/icon/claude.svg",
-	},
-	{
-		...M.MockWorkspaceAgentLogSource,
-		id: "bf7529b8-1787-4a20-b54f-eb894680e48f",
-		display_name: "Mux",
-		icon: "/icon/mux.svg",
-	},
-	{
-		...M.MockWorkspaceAgentLogSource,
-		id: "0d6ebde6-c534-4551-9f91-bfd98bfb04f4",
-		display_name: "Portable Desktop",
-		icon: "/icon/portable-desktop.svg",
-	},
-];
-
-const overflowLogs = overflowLogSources.map((source, index) => ({
-	id: 200 + index,
-	level: "info",
-	output: `${source.display_name}: line`,
-	source_id: source.id,
-	created_at: new Date().toISOString(),
-}));
 
 const meta: Meta<typeof AgentRow> = {
 	title: "components/AgentRow",

--- a/site/src/modules/resources/AgentRow.stories.tsx
+++ b/site/src/modules/resources/AgentRow.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, spyOn, userEvent, waitFor, within } from "storybook/test";
 import { API } from "#/api/api";
 import { workspaceAgentContainersKey } from "#/api/queries/workspaces";
-import type * as TypesGen from "#/api/typesGenerated";
+import type { WorkspaceAgentLogSource } from "#/api/typesGenerated";
 import { getPreferredProxy } from "#/contexts/ProxyContext";
 import { chromatic } from "#/testHelpers/chromatic";
 import * as M from "#/testHelpers/entities";
@@ -92,7 +92,7 @@ const logs = [
 	created_at: fixedLogTimestamp,
 }));
 
-const installScriptLogSource: TypesGen.WorkspaceAgentLogSource = {
+const installScriptLogSource: WorkspaceAgentLogSource = {
 	...M.MockWorkspaceAgentLogSource,
 	id: "f2ee4b8d-b09d-4f4e-a1f1-5e4adf7d53bb",
 	display_name: "Install Script",
@@ -121,48 +121,6 @@ const tabbedLogs = [
 		created_at: fixedLogTimestamp,
 	},
 ];
-
-const overflowLogSources = [
-	M.MockWorkspaceAgentLogSource,
-	{
-		...M.MockWorkspaceAgentLogSource,
-		id: "58f5db69-5f78-496f-bce1-0686f5525aa1",
-		display_name: "Install Script Dependencies",
-	},
-	{
-		...M.MockWorkspaceAgentLogSource,
-		id: "f39d758c-bce2-4f41-8d70-58fdb1f0f729",
-		display_name: "Dependency Synchronization",
-	},
-	{
-		...M.MockWorkspaceAgentLogSource,
-		id: "bf7529b8-1787-4a20-b54f-eb894680e48f",
-		display_name: "Runtime Bootstrap Checks",
-	},
-	{
-		...M.MockWorkspaceAgentLogSource,
-		id: "0d6ebde6-c534-4551-9f91-bfd98bfb04f4",
-		display_name: "Tooling Validation Stage",
-	},
-	{
-		...M.MockWorkspaceAgentLogSource,
-		id: "ac9b4bce-2b3d-40ad-a970-66f0705c7995",
-		display_name: "Environment Variable Expansion",
-	},
-	{
-		...M.MockWorkspaceAgentLogSource,
-		id: "8cef9a7f-f010-4dfa-9ee7-f7bd09f7ff94",
-		display_name: "Finalization and Warmup",
-	},
-];
-
-const overflowLogs = overflowLogSources.map((source, index) => ({
-	id: 200 + index,
-	level: "info",
-	output: `${source.display_name}: line`,
-	source_id: source.id,
-	created_at: fixedLogTimestamp,
-}));
 
 const meta: Meta<typeof AgentRow> = {
 	title: "components/AgentRow",
@@ -444,46 +402,5 @@ export const LogsTabs: Story = {
 			).not.toBeInTheDocument(),
 		);
 		await expect(canvas.getByText("install: pnpm install")).toBeVisible();
-	},
-};
-
-export const LogsTabsOverflow: Story = {
-	args: {
-		agent: {
-			...M.MockWorkspaceAgentReady,
-			logs_length: overflowLogs.length,
-			log_sources: overflowLogSources,
-		},
-	},
-	parameters: {
-		webSocket: [
-			{
-				event: "message",
-				data: JSON.stringify(overflowLogs),
-			},
-		],
-	},
-	render: (args) => (
-		<div className="max-w-[320px]">
-			<AgentRow {...args} />
-		</div>
-	),
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const page = within(canvasElement.ownerDocument.body);
-		await userEvent.click(canvas.getByRole("button", { name: "Logs" }));
-		await userEvent.click(
-			canvas.getByRole("button", { name: "More log tabs" }),
-		);
-		const overflowItems = await page.findAllByRole("menuitemradio");
-		const selectedItem = overflowItems[0];
-		const selectedSource = selectedItem.textContent;
-		if (!selectedSource) {
-			throw new Error("Overflow menu item must have text content.");
-		}
-		await userEvent.click(selectedItem);
-		await waitFor(() =>
-			expect(canvas.getByText(`${selectedSource}: line`)).toBeVisible(),
-		);
 	},
 };

--- a/site/src/modules/resources/AgentRow.stories.tsx
+++ b/site/src/modules/resources/AgentRow.stories.tsx
@@ -122,31 +122,37 @@ const tabbedLogs = [
 	},
 ];
 
-const overflowLogSources: TypesGen.WorkspaceAgentLogSource[] = [
+const overflowLogSources = [
 	M.MockWorkspaceAgentLogSource,
 	{
 		...M.MockWorkspaceAgentLogSource,
 		id: "58f5db69-5f78-496f-bce1-0686f5525aa1",
-		display_name: "code-server",
-		icon: "/icon/code.svg",
+		display_name: "Install Script Dependencies",
 	},
 	{
 		...M.MockWorkspaceAgentLogSource,
 		id: "f39d758c-bce2-4f41-8d70-58fdb1f0f729",
-		display_name: "Install and start AgentAPI",
-		icon: "/icon/claude.svg",
+		display_name: "Dependency Synchronization",
 	},
 	{
 		...M.MockWorkspaceAgentLogSource,
 		id: "bf7529b8-1787-4a20-b54f-eb894680e48f",
-		display_name: "Mux",
-		icon: "/icon/mux.svg",
+		display_name: "Runtime Bootstrap Checks",
 	},
 	{
 		...M.MockWorkspaceAgentLogSource,
 		id: "0d6ebde6-c534-4551-9f91-bfd98bfb04f4",
-		display_name: "Portable Desktop",
-		icon: "/icon/portable-desktop.svg",
+		display_name: "Tooling Validation Stage",
+	},
+	{
+		...M.MockWorkspaceAgentLogSource,
+		id: "ac9b4bce-2b3d-40ad-a970-66f0705c7995",
+		display_name: "Environment Variable Expansion",
+	},
+	{
+		...M.MockWorkspaceAgentLogSource,
+		id: "8cef9a7f-f010-4dfa-9ee7-f7bd09f7ff94",
+		display_name: "Finalization and Warmup",
 	},
 ];
 

--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -222,8 +222,10 @@ export const AgentRow: FC<AgentRowProps> = ({
 		},
 		...agent.log_sources
 			.filter((logSource) => {
-				const log = agentLogs.find((log) => log.source_id === logSource.id);
-				return (log?.output?.length ?? 0) > 0;
+				return agentLogs.some(
+					(log) =>
+						log.source_id === logSource.id && (log.output?.length ?? 0) > 0,
+				);
 			})
 			.map((logSource) => ({
 				startIcon: logSource.icon ? (

--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -6,14 +6,7 @@ import {
 	PlayIcon,
 	SquareCheckBigIcon,
 } from "lucide-react";
-import {
-	type FC,
-	useEffect,
-	useLayoutEffect,
-	useMemo,
-	useRef,
-	useState,
-} from "react";
+import { type FC, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { Link as RouterLink } from "react-router";
 import AutoSizer from "react-virtualized-auto-sizer";
 import type { FixedSizeList as List, ListOnScrollProps } from "react-window";

--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -6,7 +6,14 @@ import {
 	PlayIcon,
 	SquareCheckBigIcon,
 } from "lucide-react";
-import { type FC, useEffect, useLayoutEffect, useRef, useState } from "react";
+import {
+	type FC,
+	type ReactNode,
+	useEffect,
+	useLayoutEffect,
+	useRef,
+	useState,
+} from "react";
 import { Link as RouterLink } from "react-router";
 import AutoSizer from "react-virtualized-auto-sizer";
 import type { FixedSizeList as List, ListOnScrollProps } from "react-window";
@@ -233,7 +240,7 @@ export const AgentRow: FC<AgentRowProps> = ({
 		.filter((tab) => tab !== startupScriptLogTab)
 		.sort((a, b) => a.title.localeCompare(b.title));
 	const logTabs: {
-		startIcon?: React.ReactNode;
+		startIcon?: ReactNode;
 		title: string;
 		value: string;
 	}[] = [

--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -27,13 +27,6 @@ import type {
 import { CheckIcon } from "#/components/AnimatedIcons/Check";
 import { ChevronDownIcon } from "#/components/AnimatedIcons/ChevronDown";
 import { Button } from "#/components/Button/Button";
-import {
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuRadioGroup,
-	DropdownMenuRadioItem,
-	DropdownMenuTrigger,
-} from "#/components/DropdownMenu/DropdownMenu";
 import { ExternalImage } from "#/components/ExternalImage/ExternalImage";
 import type { Line } from "#/components/Logs/LogLine";
 import {
@@ -42,7 +35,6 @@ import {
 	TabsList,
 	TabsTrigger,
 } from "#/components/Tabs/Tabs";
-import { useTabOverflowKebabMenu } from "#/components/Tabs/utils";
 import { useProxy } from "#/contexts/ProxyContext";
 import { useClipboard } from "#/hooks/useClipboard";
 import { useFeatureVisibility } from "#/modules/dashboard/useFeatureVisibility";
@@ -211,63 +203,38 @@ export const AgentRow: FC<AgentRowProps> = ({
 	);
 
 	const [selectedLogTab, setSelectedLogTab] = useState("all");
-	const logTabs = useMemo(() => {
-		const sourceLogTabs = agent.log_sources
+	const logTabs: {
+		startIcon?: React.ReactNode;
+		title: string;
+		value: string;
+	}[] = [
+		{
+			title: "All Logs",
+			value: "all",
+		},
+		...agent.log_sources
 			.filter((logSource) => {
-				// Remove the logSources that have no entries.
-				return agentLogs.some(
-					(log) =>
-						log.source_id === logSource.id && (log.output?.length ?? 0) > 0,
-				);
+				const log = agentLogs.find((log) => log.source_id === logSource.id);
+				return (log?.output?.length ?? 0) > 0;
 			})
 			.map((logSource) => ({
-				// Show the icon for the log source if it has one.
-				// In the startup script case, we show a bespoke play icon.
 				startIcon: logSource.icon ? (
 					<ExternalImage
 						src={logSource.icon}
 						alt=""
 						className="size-icon-xs shrink-0"
 					/>
-				) : logSource.display_name === STARTUP_SCRIPT_DISPLAY_NAME ? (
-					<PlayIcon className="size-icon-xs shrink-0" />
 				) : null,
 				title: logSource.display_name,
 				value: logSource.id,
-			}));
-		const startupScriptLogTab = sourceLogTabs.find(
-			(tab) => tab.title === STARTUP_SCRIPT_DISPLAY_NAME,
-		);
-		const sortedSourceLogTabs = sourceLogTabs
-			.filter((tab) => tab !== startupScriptLogTab)
-			.sort((a, b) => a.title.localeCompare(b.title));
-		return [
-			{
-				title: "All Logs",
-				value: "all",
-			},
-			...(startupScriptLogTab ? [startupScriptLogTab] : []),
-			...sortedSourceLogTabs,
-		] as {
-			startIcon?: React.ReactNode;
-			title: string;
-			value: string;
-		}[];
-	}, [agent.log_sources, agentLogs]);
-	const {
-		containerRef: logTabsListContainerRef,
-		visibleTabs: visibleLogTabs,
-		overflowTabs: overflowLogTabs,
-		getTabMeasureProps,
-	} = useTabOverflowKebabMenu({
-		tabs: logTabs,
-		enabled: true,
-		isActive: showLogs,
-		alwaysVisibleTabsCount: 1,
-	});
-	const overflowLogTabValuesSet = new Set(
-		overflowLogTabs.map((tab) => tab.value),
-	);
+			}))
+			.sort((a, b) => {
+				if (a.title === "Startup Script") {
+					return -1;
+				}
+				return a.title.localeCompare(b.title);
+			}),
+	];
 	const selectedLogs =
 		selectedLogTab === "all"
 			? agentLogs
@@ -279,16 +246,6 @@ export const AgentRow: FC<AgentRowProps> = ({
 		level: log.level,
 		sourceId: log.source_id,
 	}));
-	const selectedLogsText = selectedLogs.map((log) => log.output).join("\n");
-	const hasSelectedLogs = selectedLogs.length > 0;
-	const { showCopiedSuccess, copyToClipboard } = useClipboard();
-	const selectedLogTabTitle =
-		logTabs.find((tab) => tab.value === selectedLogTab)?.title ?? "Logs";
-	const sanitizedTabTitle = selectedLogTabTitle
-		.toLowerCase()
-		.replaceAll(/[^a-z0-9]+/g, "-")
-		.replaceAll(/(^-|-$)/g, "");
-	const logFilenameSuffix = sanitizedTabTitle || "logs";
 
 	return (
 		<div
@@ -452,7 +409,7 @@ export const AgentRow: FC<AgentRowProps> = ({
 
 			{hasStartupFeatures && (
 				<section className="border-0 border-t border-solid border-border">
-					<div className="px-4 py-2 relative">
+					<div className="flex flex-row gap-2 px-4 py-3">
 						<Button
 							variant="subtle"
 							onClick={() => setShowLogs((v) => !v)}
@@ -470,89 +427,14 @@ export const AgentRow: FC<AgentRowProps> = ({
 									value={selectedLogTab}
 									onValueChange={setSelectedLogTab}
 								>
-									<div className="flex items-stretch">
-										<div
-											ref={logTabsListContainerRef}
-											className="min-w-0 flex-1"
-										>
-											<TabsList variant="insideBox" overflowKebabMenu>
-												{visibleLogTabs.map((tab) => (
-													<TabsTrigger
-														key={tab.value}
-														value={tab.value}
-														{...getTabMeasureProps(tab.value)}
-													>
-														{tab.startIcon}
-														<span className="whitespace-nowrap">
-															{tab.title}
-														</span>
-													</TabsTrigger>
-												))}
-												{overflowLogTabs.length > 0 && (
-													<DropdownMenu>
-														<DropdownMenuTrigger asChild>
-															<button
-																type="button"
-																data-slot="tabs-trigger"
-																data-log-overflow-trigger
-																data-state={
-																	overflowLogTabValuesSet.has(selectedLogTab)
-																		? "active"
-																		: "inactive"
-																}
-																aria-label="More log tabs"
-																className="border-none py-4 bg-transparent text-inherit inline-flex items-center justify-center cursor-pointer transition-colors duration-150 ease-linear"
-															>
-																<EllipsisIcon className="size-icon-sm" />
-																<span className="sr-only">More log tabs</span>
-															</button>
-														</DropdownMenuTrigger>
-														<DropdownMenuContent align="end">
-															<DropdownMenuRadioGroup
-																value={selectedLogTab}
-																onValueChange={setSelectedLogTab}
-															>
-																{overflowLogTabs.map((tab) => (
-																	<DropdownMenuRadioItem
-																		key={tab.value}
-																		value={tab.value}
-																		className="gap-2"
-																	>
-																		{tab.startIcon}
-																		<span className="whitespace-nowrap">
-																			{tab.title}
-																		</span>
-																	</DropdownMenuRadioItem>
-																))}
-															</DropdownMenuRadioGroup>
-														</DropdownMenuContent>
-													</DropdownMenu>
-												)}
-											</TabsList>
-										</div>
-										<div
-											className={cn(
-												"h-12.5 shrink-0 flex items-center gap-2 pl-2 pr-3",
-												"border-solid border-0 border-b",
-											)}
-										>
-											<Button
-												variant="subtle"
-												size="sm"
-												disabled={!hasSelectedLogs}
-												onClick={() => copyToClipboard(selectedLogsText)}
-											>
-												{showCopiedSuccess ? <CheckIcon /> : <CopyIcon />}
-												<span>Copy logs</span>
-											</Button>
-											<DownloadSelectedAgentLogsButton
-												agentName={agent.name}
-												filenameSuffix={logFilenameSuffix}
-												logsText={selectedLogsText}
-												disabled={!hasSelectedLogs}
-											/>
-										</div>
-									</div>
+									<TabsList variant="insideBox">
+										{logTabs.map((tab) => (
+											<TabsTrigger key={tab.value} value={tab.value}>
+												{tab.startIcon}
+												<span>{tab.title}</span>
+											</TabsTrigger>
+										))}
+									</TabsList>
 									{/*
 										Using a singular TabsContent is necessary to avoid scrolling
 										issues when the selected log tab changes.

--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -1,11 +1,6 @@
 import Collapse from "@mui/material/Collapse";
 import Skeleton from "@mui/material/Skeleton";
-import {
-	CopyIcon,
-	EllipsisIcon,
-	PlayIcon,
-	SquareCheckBigIcon,
-} from "lucide-react";
+import { PlayIcon, SquareCheckBigIcon } from "lucide-react";
 import {
 	type FC,
 	useCallback,
@@ -224,6 +219,8 @@ export const AgentRow: FC<AgentRowProps> = ({
 						alt=""
 						className="size-icon-xs shrink-0"
 					/>
+				) : logSource.display_name === "Startup Script" ? (
+					<PlayIcon className="size-icon-xs shrink-0" />
 				) : null,
 				title: logSource.display_name,
 				value: logSource.id,

--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -206,61 +206,40 @@ export const AgentRow: FC<AgentRowProps> = ({
 	);
 
 	const [selectedLogTab, setSelectedLogTab] = useState("all");
-	const logTabs = useMemo(
-		() =>
-			[
-				{
-					title: "All Logs",
-					value: "all",
-				},
-				...agent.log_sources
-					.filter((logSource) => {
-						return agentLogs.some(
-							(log) =>
-								log.source_id === logSource.id && (log.output?.length ?? 0) > 0,
-						);
-					})
-					.map((logSource) => ({
-						startIcon: logSource.icon ? (
-							<ExternalImage
-								src={logSource.icon}
-								alt=""
-								className="size-icon-xs shrink-0"
-							/>
-						) : logSource.display_name === STARTUP_SCRIPT_DISPLAY_NAME ? (
-							<PlayIcon className="size-icon-xs shrink-0" />
-						) : null,
-						title: logSource.display_name,
-						value: logSource.id,
-					}))
-					.sort((a, b) => {
-						// Ensure that "Startup Script" is always the first tab.
-						const startupPriorityDiff =
-							Number(a.title !== STARTUP_SCRIPT_DISPLAY_NAME) -
-							Number(b.title !== STARTUP_SCRIPT_DISPLAY_NAME);
-						return startupPriorityDiff || a.title.localeCompare(b.title);
-					}),
-			] as {
-				startIcon?: React.ReactNode;
-				title: string;
-				value: string;
-			}[],
-		[agent.log_sources, agentLogs],
-	);
-	const {
-		containerRef: logTabsListContainerRef,
-		visibleTabs: visibleLogTabs,
-		overflowTabs: overflowLogTabs,
-		getTabMeasureProps,
-	} = useTabOverflowKebabMenu({
-		tabs: logTabs,
-		enabled: true,
-		isActive: showLogs,
-		alwaysVisibleTabsCount: 1,
-	});
-	const overflowLogTabValuesSet = new Set(
-		overflowLogTabs.map((tab) => tab.value),
-	);
+	const logTabs: {
+		startIcon?: React.ReactNode;
+		title: string;
+		value: string;
+	}[] = [
+		{
+			title: "All Logs",
+			value: "all",
+		},
+		...agent.log_sources
+			.filter((logSource) => {
+				const log = agentLogs.find((log) => log.source_id === logSource.id);
+				return (log?.output?.length ?? 0) > 0;
+			})
+			.map((logSource) => ({
+				startIcon: logSource.icon ? (
+					<ExternalImage
+						src={logSource.icon}
+						alt=""
+						className="size-icon-xs shrink-0"
+					/>
+				) : logSource.display_name === STARTUP_SCRIPT_DISPLAY_NAME ? (
+					<PlayIcon className="size-icon-xs shrink-0" />
+				) : null,
+				title: logSource.display_name,
+				value: logSource.id,
+			}))
+			.sort((a, b) => {
+				if (a.title === STARTUP_SCRIPT_DISPLAY_NAME) {
+					return -1;
+				}
+				return a.title.localeCompare(b.title);
+			}),
+	];
 	const selectedLogs =
 		selectedLogTab === "all"
 			? agentLogs

--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -1,6 +1,11 @@
 import Collapse from "@mui/material/Collapse";
 import Skeleton from "@mui/material/Skeleton";
-import { EllipsisIcon, PlayIcon, SquareCheckBigIcon } from "lucide-react";
+import {
+	CopyIcon,
+	EllipsisIcon,
+	PlayIcon,
+	SquareCheckBigIcon,
+} from "lucide-react";
 import {
 	type FC,
 	useCallback,
@@ -252,6 +257,16 @@ export const AgentRow: FC<AgentRowProps> = ({
 		level: log.level,
 		sourceId: log.source_id,
 	}));
+	const selectedLogsText = selectedLogs.map((log) => log.output).join("\n");
+	const hasSelectedLogs = selectedLogs.length > 0;
+	const { showCopiedSuccess, copyToClipboard } = useClipboard();
+	const selectedLogTabTitle =
+		logTabs.find((tab) => tab.value === selectedLogTab)?.title ?? "Logs";
+	const sanitizedTabTitle = selectedLogTabTitle
+		.toLowerCase()
+		.replaceAll(/[^a-z0-9]+/g, "-")
+		.replaceAll(/(^-|-$)/g, "");
+	const logFilenameSuffix = sanitizedTabTitle || "logs";
 
 	return (
 		<div
@@ -415,7 +430,7 @@ export const AgentRow: FC<AgentRowProps> = ({
 
 			{hasStartupFeatures && (
 				<section className="border-0 border-t border-solid border-border">
-					<div className="flex flex-row gap-2 px-4 py-3">
+					<div className="px-4 py-2 relative">
 						<Button
 							variant="subtle"
 							onClick={() => setShowLogs((v) => !v)}
@@ -433,58 +448,87 @@ export const AgentRow: FC<AgentRowProps> = ({
 									value={selectedLogTab}
 									onValueChange={setSelectedLogTab}
 								>
-									<div ref={logTabsListContainerRef}>
-										<TabsList variant="insideBox" overflowKebabMenu>
-											{visibleLogTabs.map((tab) => (
-												<TabsTrigger
-													key={tab.value}
-													value={tab.value}
-													{...getTabMeasureProps(tab.value)}
-												>
-													{tab.startIcon}
-													<span className="whitespace-nowrap">{tab.title}</span>
-												</TabsTrigger>
-											))}
-											{overflowLogTabs.length > 0 && (
-												<DropdownMenu>
-													<DropdownMenuTrigger asChild>
-														<button
-															type="button"
-															data-log-overflow-trigger
-															data-state={
-																overflowLogTabValuesSet.has(selectedLogTab)
-																	? "active"
-																	: "inactive"
-															}
-															aria-label="More log tabs"
-															className="border-none py-4 bg-transparent text-inherit inline-flex items-center justify-center cursor-pointer transition-colors duration-150 ease-linear"
-														>
-															<EllipsisIcon className="size-icon-sm" />
-															<span className="sr-only">More log tabs</span>
-														</button>
-													</DropdownMenuTrigger>
-													<DropdownMenuContent align="end">
-														<DropdownMenuRadioGroup
-															value={selectedLogTab}
-															onValueChange={setSelectedLogTab}
-														>
-															{overflowLogTabs.map((tab) => (
-																<DropdownMenuRadioItem
-																	key={tab.value}
-																	value={tab.value}
-																	className="gap-2"
-																>
-																	{tab.startIcon}
-																	<span className="whitespace-nowrap">
-																		{tab.title}
-																	</span>
-																</DropdownMenuRadioItem>
-															))}
-														</DropdownMenuRadioGroup>
-													</DropdownMenuContent>
-												</DropdownMenu>
+									<div className="flex items-stretch">
+										<div
+											ref={logTabsListContainerRef}
+											className="min-w-0 flex-1"
+										>
+											<TabsList variant="insideBox" overflowKebabMenu>
+												{visibleLogTabs.map((tab) => (
+													<TabsTrigger
+														key={tab.value}
+														value={tab.value}
+														{...getTabMeasureProps(tab.value)}
+													>
+														{tab.startIcon}
+														<span className="whitespace-nowrap">
+															{tab.title}
+														</span>
+													</TabsTrigger>
+												))}
+												{overflowLogTabs.length > 0 && (
+													<DropdownMenu>
+														<DropdownMenuTrigger asChild>
+															<button
+																type="button"
+																data-log-overflow-trigger
+																data-state={
+																	overflowLogTabValuesSet.has(selectedLogTab)
+																		? "active"
+																		: "inactive"
+																}
+																aria-label="More log tabs"
+																className="border-none py-4 bg-transparent text-inherit inline-flex items-center justify-center cursor-pointer transition-colors duration-150 ease-linear"
+															>
+																<EllipsisIcon className="size-icon-sm" />
+																<span className="sr-only">More log tabs</span>
+															</button>
+														</DropdownMenuTrigger>
+														<DropdownMenuContent align="end">
+															<DropdownMenuRadioGroup
+																value={selectedLogTab}
+																onValueChange={setSelectedLogTab}
+															>
+																{overflowLogTabs.map((tab) => (
+																	<DropdownMenuRadioItem
+																		key={tab.value}
+																		value={tab.value}
+																		className="gap-2"
+																	>
+																		{tab.startIcon}
+																		<span className="whitespace-nowrap">
+																			{tab.title}
+																		</span>
+																	</DropdownMenuRadioItem>
+																))}
+															</DropdownMenuRadioGroup>
+														</DropdownMenuContent>
+													</DropdownMenu>
+												)}
+											</TabsList>
+										</div>
+										<div
+											className={cn(
+												"h-12.5 shrink-0 flex items-center gap-2 pl-2 pr-3",
+												"border-solid border-0 border-b",
 											)}
-										</TabsList>
+										>
+											<Button
+												variant="subtle"
+												size="sm"
+												disabled={!hasSelectedLogs}
+												onClick={() => copyToClipboard(selectedLogsText)}
+											>
+												{showCopiedSuccess ? <CheckIcon /> : <CopyIcon />}
+												<span>Copy logs</span>
+											</Button>
+											<DownloadSelectedAgentLogsButton
+												agentName={agent.name}
+												filenameSuffix={logFilenameSuffix}
+												logsText={selectedLogsText}
+												disabled={!hasSelectedLogs}
+											/>
+										</div>
 									</div>
 									{/*
 										Using a singular TabsContent is necessary to avoid scrolling

--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -6,15 +6,7 @@ import {
 	PlayIcon,
 	SquareCheckBigIcon,
 } from "lucide-react";
-import {
-	type FC,
-	useCallback,
-	useEffect,
-	useLayoutEffect,
-	useMemo,
-	useRef,
-	useState,
-} from "react";
+import { type FC, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { Link as RouterLink } from "react-router";
 import AutoSizer from "react-virtualized-auto-sizer";
 import type { FixedSizeList as List, ListOnScrollProps } from "react-window";
@@ -162,7 +154,7 @@ export const AgentRow: FC<AgentRowProps> = ({
 	// This is a bit of a hack on the react-window API to get the scroll position.
 	// If we're scrolled to the bottom, we want to keep the list scrolled to the bottom.
 	// This makes it feel similar to a terminal that auto-scrolls downwards!
-	const handleLogScroll = useCallback((props: ListOnScrollProps) => {
+	const handleLogScroll = (props: ListOnScrollProps) => {
 		if (
 			props.scrollOffset === 0 ||
 			props.scrollUpdateWasRequested ||
@@ -179,7 +171,7 @@ export const AgentRow: FC<AgentRowProps> = ({
 			logListDivRef.current.scrollHeight -
 			(props.scrollOffset + parent.clientHeight);
 		setBottomOfLogs(distanceFromBottom < AGENT_LOG_LINE_HEIGHT);
-	}, []);
+	};
 
 	const devcontainers = useAgentContainers(agent);
 
@@ -248,6 +240,20 @@ export const AgentRow: FC<AgentRowProps> = ({
 				return startupPriorityDiff || a.title.localeCompare(b.title);
 			}),
 	];
+	const {
+		containerRef: logTabsListContainerRef,
+		visibleTabs: visibleLogTabs,
+		overflowTabs: overflowLogTabs,
+		getTabMeasureProps,
+	} = useTabOverflowKebabMenu({
+		tabs: logTabs,
+		enabled: true,
+		isActive: showLogs,
+		alwaysVisibleTabsCount: 1,
+	});
+	const overflowLogTabValuesSet = new Set(
+		overflowLogTabs.map((tab) => tab.value),
+	);
 	const selectedLogs =
 		selectedLogTab === "all"
 			? agentLogs
@@ -259,16 +265,29 @@ export const AgentRow: FC<AgentRowProps> = ({
 		level: log.level,
 		sourceId: log.source_id,
 	}));
+	const allLogsText = agentLogs.map((log) => log.output).join("\n");
 	const selectedLogsText = selectedLogs.map((log) => log.output).join("\n");
 	const hasSelectedLogs = selectedLogs.length > 0;
+	const hasAnyLogs = agentLogs.length > 0;
 	const { showCopiedSuccess, copyToClipboard } = useClipboard();
-	const selectedLogTabTitle =
-		logTabs.find((tab) => tab.value === selectedLogTab)?.title ?? "Logs";
-	const sanitizedTabTitle = selectedLogTabTitle
-		.toLowerCase()
-		.replaceAll(/[^a-z0-9]+/g, "-")
-		.replaceAll(/(^-|-$)/g, "");
-	const logFilenameSuffix = sanitizedTabTitle || "logs";
+	const downloadableLogSets = logTabs
+		.filter((tab) => tab.value !== "all")
+		.map((tab) => {
+			const logsText = agentLogs
+				.filter((log) => log.source_id === tab.value)
+				.map((log) => log.output)
+				.join("\n");
+			const filenameSuffix = tab.title
+				.toLowerCase()
+				.replaceAll(/[^a-z0-9]+/g, "-")
+				.replaceAll(/(^-|-$)/g, "");
+			return {
+				label: tab.title,
+				filenameSuffix: filenameSuffix || tab.value,
+				logsText,
+				startIcon: tab.startIcon,
+			};
+		});
 
 	return (
 		<div
@@ -526,9 +545,9 @@ export const AgentRow: FC<AgentRowProps> = ({
 											</Button>
 											<DownloadSelectedAgentLogsButton
 												agentName={agent.name}
-												filenameSuffix={logFilenameSuffix}
-												logsText={selectedLogsText}
-												disabled={!hasSelectedLogs}
+												logSets={downloadableLogSets}
+												allLogsText={allLogsText}
+												disabled={!hasAnyLogs}
 											/>
 										</div>
 									</div>

--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -234,10 +234,11 @@ export const AgentRow: FC<AgentRowProps> = ({
 				value: logSource.id,
 			}))
 			.sort((a, b) => {
-				if (a.title === STARTUP_SCRIPT_DISPLAY_NAME) {
-					return -1;
-				}
-				return a.title.localeCompare(b.title);
+				// Ensure that "Startup Script" is always the first tab.
+				const startupPriorityDiff =
+					Number(a.title !== STARTUP_SCRIPT_DISPLAY_NAME) -
+					Number(b.title !== STARTUP_SCRIPT_DISPLAY_NAME);
+				return startupPriorityDiff || a.title.localeCompare(b.title);
 			}),
 	];
 	const selectedLogs =

--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -6,7 +6,14 @@ import {
 	PlayIcon,
 	SquareCheckBigIcon,
 } from "lucide-react";
-import { type FC, useEffect, useLayoutEffect, useRef, useState } from "react";
+import {
+	type FC,
+	useEffect,
+	useLayoutEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import { Link as RouterLink } from "react-router";
 import AutoSizer from "react-virtualized-auto-sizer";
 import type { FixedSizeList as List, ListOnScrollProps } from "react-window";

--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -203,6 +203,35 @@ export const AgentRow: FC<AgentRowProps> = ({
 	);
 
 	const [selectedLogTab, setSelectedLogTab] = useState("all");
+	const sourceLogTabs = agent.log_sources
+		.filter((logSource) => {
+			// Remove the logSources that have no entries.
+			return agentLogs.some(
+				(log) =>
+					log.source_id === logSource.id && (log.output?.length ?? 0) > 0,
+			);
+		})
+		.map((logSource) => ({
+			// Show the icon for the log source if it has one.
+			// In the startup script case, we show a bespoke play icon.
+			startIcon: logSource.icon ? (
+				<ExternalImage
+					src={logSource.icon}
+					alt=""
+					className="size-icon-xs shrink-0"
+				/>
+			) : logSource.display_name === STARTUP_SCRIPT_DISPLAY_NAME ? (
+				<PlayIcon className="size-icon-xs shrink-0" />
+			) : null,
+			title: logSource.display_name,
+			value: logSource.id,
+		}));
+	const startupScriptLogTab = sourceLogTabs.find(
+		(tab) => tab.title === STARTUP_SCRIPT_DISPLAY_NAME,
+	);
+	const sortedSourceLogTabs = sourceLogTabs
+		.filter((tab) => tab !== startupScriptLogTab)
+		.sort((a, b) => a.title.localeCompare(b.title));
 	const logTabs: {
 		startIcon?: React.ReactNode;
 		title: string;
@@ -212,33 +241,8 @@ export const AgentRow: FC<AgentRowProps> = ({
 			title: "All Logs",
 			value: "all",
 		},
-		...agent.log_sources
-			.filter((logSource) => {
-				return agentLogs.some(
-					(log) =>
-						log.source_id === logSource.id && (log.output?.length ?? 0) > 0,
-				);
-			})
-			.map((logSource) => ({
-				startIcon: logSource.icon ? (
-					<ExternalImage
-						src={logSource.icon}
-						alt=""
-						className="size-icon-xs shrink-0"
-					/>
-				) : logSource.display_name === STARTUP_SCRIPT_DISPLAY_NAME ? (
-					<PlayIcon className="size-icon-xs shrink-0" />
-				) : null,
-				title: logSource.display_name,
-				value: logSource.id,
-			}))
-			.sort((a, b) => {
-				// Ensure that "Startup Script" is always the first tab.
-				const startupPriorityDiff =
-					Number(a.title !== STARTUP_SCRIPT_DISPLAY_NAME) -
-					Number(b.title !== STARTUP_SCRIPT_DISPLAY_NAME);
-				return startupPriorityDiff || a.title.localeCompare(b.title);
-			}),
+		...(startupScriptLogTab ? [startupScriptLogTab] : []),
+		...sortedSourceLogTabs,
 	];
 	const {
 		containerRef: logTabsListContainerRef,

--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -496,6 +496,7 @@ export const AgentRow: FC<AgentRowProps> = ({
 														<DropdownMenuTrigger asChild>
 															<button
 																type="button"
+																data-slot="tabs-trigger"
 																data-log-overflow-trigger
 																data-state={
 																	overflowLogTabValuesSet.has(selectedLogTab)

--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -477,7 +477,7 @@ export const AgentRow: FC<AgentRowProps> = ({
 																	: "inactive"
 															}
 															aria-label="More log tabs"
-															className="border-none py-3 bg-transparent text-inherit inline-flex items-center justify-center cursor-pointer transition-colors duration-150 ease-linear"
+															className="border-none py-4 bg-transparent text-inherit inline-flex items-center justify-center cursor-pointer transition-colors duration-150 ease-linear"
 														>
 															<EllipsisIcon className="size-icon-sm" />
 															<span className="sr-only">More log tabs</span>
@@ -492,6 +492,7 @@ export const AgentRow: FC<AgentRowProps> = ({
 																<DropdownMenuRadioItem
 																	key={tab.value}
 																	value={tab.value}
+																	className="gap-2"
 																>
 																	{tab.startIcon}
 																	<span className="whitespace-nowrap">

--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -1,6 +1,6 @@
 import Collapse from "@mui/material/Collapse";
 import Skeleton from "@mui/material/Skeleton";
-import { PlayIcon, SquareCheckBigIcon } from "lucide-react";
+import { EllipsisIcon, PlayIcon, SquareCheckBigIcon } from "lucide-react";
 import {
 	type FC,
 	useCallback,
@@ -22,6 +22,13 @@ import type {
 import { CheckIcon } from "#/components/AnimatedIcons/Check";
 import { ChevronDownIcon } from "#/components/AnimatedIcons/ChevronDown";
 import { Button } from "#/components/Button/Button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuRadioGroup,
+	DropdownMenuRadioItem,
+	DropdownMenuTrigger,
+} from "#/components/DropdownMenu/DropdownMenu";
 import { ExternalImage } from "#/components/ExternalImage/ExternalImage";
 import type { Line } from "#/components/Logs/LogLine";
 import {
@@ -30,6 +37,7 @@ import {
 	TabsList,
 	TabsTrigger,
 } from "#/components/Tabs/Tabs";
+import { useTabOverflowKebabMenu } from "#/components/Tabs/utils";
 import { useProxy } from "#/contexts/ProxyContext";
 import { useClipboard } from "#/hooks/useClipboard";
 import { useFeatureVisibility } from "#/modules/dashboard/useFeatureVisibility";
@@ -198,40 +206,61 @@ export const AgentRow: FC<AgentRowProps> = ({
 	);
 
 	const [selectedLogTab, setSelectedLogTab] = useState("all");
-	const logTabs: {
-		startIcon?: React.ReactNode;
-		title: string;
-		value: string;
-	}[] = [
-		{
-			title: "All Logs",
-			value: "all",
-		},
-		...agent.log_sources
-			.filter((logSource) => {
-				const log = agentLogs.find((log) => log.source_id === logSource.id);
-				return (log?.output?.length ?? 0) > 0;
-			})
-			.map((logSource) => ({
-				startIcon: logSource.icon ? (
-					<ExternalImage
-						src={logSource.icon}
-						alt=""
-						className="size-icon-xs shrink-0"
-					/>
-				) : logSource.display_name === "Startup Script" ? (
-					<PlayIcon className="size-icon-xs shrink-0" />
-				) : null,
-				title: logSource.display_name,
-				value: logSource.id,
-			}))
-			.sort((a, b) => {
-				if (a.title === "Startup Script") {
-					return -1;
-				}
-				return a.title.localeCompare(b.title);
-			}),
-	];
+	const logTabs = useMemo(
+		() =>
+			[
+				{
+					title: "All Logs",
+					value: "all",
+				},
+				...agent.log_sources
+					.filter((logSource) => {
+						return agentLogs.some(
+							(log) =>
+								log.source_id === logSource.id && (log.output?.length ?? 0) > 0,
+						);
+					})
+					.map((logSource) => ({
+						startIcon: logSource.icon ? (
+							<ExternalImage
+								src={logSource.icon}
+								alt=""
+								className="size-icon-xs shrink-0"
+							/>
+						) : logSource.display_name === STARTUP_SCRIPT_DISPLAY_NAME ? (
+							<PlayIcon className="size-icon-xs shrink-0" />
+						) : null,
+						title: logSource.display_name,
+						value: logSource.id,
+					}))
+					.sort((a, b) => {
+						// Ensure that "Startup Script" is always the first tab.
+						const startupPriorityDiff =
+							Number(a.title !== STARTUP_SCRIPT_DISPLAY_NAME) -
+							Number(b.title !== STARTUP_SCRIPT_DISPLAY_NAME);
+						return startupPriorityDiff || a.title.localeCompare(b.title);
+					}),
+			] as {
+				startIcon?: React.ReactNode;
+				title: string;
+				value: string;
+			}[],
+		[agent.log_sources, agentLogs],
+	);
+	const {
+		containerRef: logTabsListContainerRef,
+		visibleTabs: visibleLogTabs,
+		overflowTabs: overflowLogTabs,
+		getTabMeasureProps,
+	} = useTabOverflowKebabMenu({
+		tabs: logTabs,
+		enabled: true,
+		isActive: showLogs,
+		alwaysVisibleTabsCount: 1,
+	});
+	const overflowLogTabValuesSet = new Set(
+		overflowLogTabs.map((tab) => tab.value),
+	);
 	const selectedLogs =
 		selectedLogTab === "all"
 			? agentLogs
@@ -424,14 +453,58 @@ export const AgentRow: FC<AgentRowProps> = ({
 									value={selectedLogTab}
 									onValueChange={setSelectedLogTab}
 								>
-									<TabsList variant="insideBox">
-										{logTabs.map((tab) => (
-											<TabsTrigger key={tab.value} value={tab.value}>
-												{tab.startIcon}
-												<span>{tab.title}</span>
-											</TabsTrigger>
-										))}
-									</TabsList>
+									<div ref={logTabsListContainerRef}>
+										<TabsList variant="insideBox" overflowKebabMenu>
+											{visibleLogTabs.map((tab) => (
+												<TabsTrigger
+													key={tab.value}
+													value={tab.value}
+													{...getTabMeasureProps(tab.value)}
+												>
+													{tab.startIcon}
+													<span className="whitespace-nowrap">{tab.title}</span>
+												</TabsTrigger>
+											))}
+											{overflowLogTabs.length > 0 && (
+												<DropdownMenu>
+													<DropdownMenuTrigger asChild>
+														<button
+															type="button"
+															data-log-overflow-trigger
+															data-state={
+																overflowLogTabValuesSet.has(selectedLogTab)
+																	? "active"
+																	: "inactive"
+															}
+															aria-label="More log tabs"
+															className="border-none py-3 bg-transparent text-inherit inline-flex items-center justify-center cursor-pointer transition-colors duration-150 ease-linear"
+														>
+															<EllipsisIcon className="size-icon-sm" />
+															<span className="sr-only">More log tabs</span>
+														</button>
+													</DropdownMenuTrigger>
+													<DropdownMenuContent align="end">
+														<DropdownMenuRadioGroup
+															value={selectedLogTab}
+															onValueChange={setSelectedLogTab}
+														>
+															{overflowLogTabs.map((tab) => (
+																<DropdownMenuRadioItem
+																	key={tab.value}
+																	value={tab.value}
+																>
+																	{tab.startIcon}
+																	<span className="whitespace-nowrap">
+																		{tab.title}
+																	</span>
+																</DropdownMenuRadioItem>
+															))}
+														</DropdownMenuRadioGroup>
+													</DropdownMenuContent>
+												</DropdownMenu>
+											)}
+										</TabsList>
+									</div>
 									{/*
 										Using a singular TabsContent is necessary to avoid scrolling
 										issues when the selected log tab changes.

--- a/site/src/modules/resources/DownloadSelectedAgentLogsButton.tsx
+++ b/site/src/modules/resources/DownloadSelectedAgentLogsButton.tsx
@@ -1,14 +1,27 @@
 import { saveAs } from "file-saver";
-import { DownloadIcon } from "lucide-react";
-import { type FC, useState } from "react";
+import { ChevronDownIcon, DownloadIcon, PackageIcon } from "lucide-react";
+import { type FC, type ReactNode, useState } from "react";
 import { toast } from "sonner";
 import { getErrorDetail } from "#/api/errors";
 import { Button } from "#/components/Button/Button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "#/components/DropdownMenu/DropdownMenu";
+
+type DownloadableLogSet = {
+	label: string;
+	filenameSuffix: string;
+	logsText: string;
+	startIcon?: ReactNode;
+};
 
 type DownloadSelectedAgentLogsButtonProps = {
 	agentName: string;
-	filenameSuffix: string;
-	logsText: string;
+	logSets: readonly DownloadableLogSet[];
+	allLogsText: string;
 	disabled?: boolean;
 	download?: (file: Blob, filename: string) => void;
 };
@@ -17,35 +30,62 @@ export const DownloadSelectedAgentLogsButton: FC<
 	DownloadSelectedAgentLogsButtonProps
 > = ({
 	agentName,
-	filenameSuffix,
-	logsText,
+	logSets,
+	allLogsText,
 	disabled = false,
 	download = saveAs,
 }) => {
 	const [isDownloading, setIsDownloading] = useState(false);
 
+	const downloadLogs = (logsText: string, filenameSuffix: string) => {
+		try {
+			setIsDownloading(true);
+			const file = new Blob([logsText], { type: "text/plain" });
+			download(file, `${agentName}-${filenameSuffix}.txt`);
+		} catch (error) {
+			console.error(error);
+			toast.error(`Failed to download "${agentName}" logs.`, {
+				description: getErrorDetail(error),
+			});
+		} finally {
+			setIsDownloading(false);
+		}
+	};
+
+	const hasAllLogs = allLogsText.length > 0;
+
 	return (
-		<Button
-			variant="subtle"
-			size="sm"
-			disabled={disabled || isDownloading}
-			onClick={() => {
-				try {
-					setIsDownloading(true);
-					const file = new Blob([logsText], { type: "text/plain" });
-					download(file, `${agentName}-${filenameSuffix}.txt`);
-				} catch (error) {
-					console.error(error);
-					toast.error(`Failed to download "${agentName}" logs.`, {
-						description: getErrorDetail(error),
-					});
-				} finally {
-					setIsDownloading(false);
-				}
-			}}
-		>
-			<DownloadIcon />
-			{isDownloading ? "Downloading..." : "Download logs"}
-		</Button>
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<Button variant="subtle" size="sm" disabled={disabled || isDownloading}>
+					<DownloadIcon />
+					{isDownloading ? "Downloading..." : "Download logs"}
+					<ChevronDownIcon className="size-icon-sm" />
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end">
+				<DropdownMenuItem
+					disabled={!hasAllLogs}
+					onSelect={() => {
+						downloadLogs(allLogsText, "all-logs");
+					}}
+				>
+					<PackageIcon />
+					Download all logs
+				</DropdownMenuItem>
+				{logSets.map((logSet) => (
+					<DropdownMenuItem
+						key={logSet.filenameSuffix}
+						disabled={logSet.logsText.length === 0}
+						onSelect={() => {
+							downloadLogs(logSet.logsText, logSet.filenameSuffix);
+						}}
+					>
+						{logSet.startIcon}
+						<span>Download {logSet.label}</span>
+					</DropdownMenuItem>
+				))}
+			</DropdownMenuContent>
+		</DropdownMenu>
 	);
 };

--- a/site/src/modules/resources/DownloadSelectedAgentLogsButton.tsx
+++ b/site/src/modules/resources/DownloadSelectedAgentLogsButton.tsx
@@ -10,7 +10,7 @@ type DownloadSelectedAgentLogsButtonProps = {
 	filenameSuffix: string;
 	logsText: string;
 	disabled?: boolean;
-	download?: (file: Blob, filename: string) => void | Promise<void>;
+	download?: (file: Blob, filename: string) => void;
 };
 
 export const DownloadSelectedAgentLogsButton: FC<
@@ -23,26 +23,26 @@ export const DownloadSelectedAgentLogsButton: FC<
 	download = saveAs,
 }) => {
 	const [isDownloading, setIsDownloading] = useState(false);
-	const handleDownload = async () => {
-		try {
-			setIsDownloading(true);
-			const file = new Blob([logsText], { type: "text/plain" });
-			await download(file, `${agentName}-${filenameSuffix}.txt`);
-		} catch (error) {
-			toast.error(`Failed to download "${agentName}" logs.`, {
-				description: getErrorDetail(error),
-			});
-		} finally {
-			setIsDownloading(false);
-		}
-	};
 
 	return (
 		<Button
 			variant="subtle"
 			size="sm"
 			disabled={disabled || isDownloading}
-			onClick={handleDownload}
+			onClick={() => {
+				try {
+					setIsDownloading(true);
+					const file = new Blob([logsText], { type: "text/plain" });
+					download(file, `${agentName}-${filenameSuffix}.txt`);
+				} catch (error) {
+					console.error(error);
+					toast.error(`Failed to download "${agentName}" logs.`, {
+						description: getErrorDetail(error),
+					});
+				} finally {
+					setIsDownloading(false);
+				}
+			}}
 		>
 			<DownloadIcon />
 			{isDownloading ? "Downloading..." : "Download logs"}

--- a/site/src/modules/resources/DownloadSelectedAgentLogsButton.tsx
+++ b/site/src/modules/resources/DownloadSelectedAgentLogsButton.tsx
@@ -23,7 +23,7 @@ type DownloadSelectedAgentLogsButtonProps = {
 	logSets: readonly DownloadableLogSet[];
 	allLogsText: string;
 	disabled?: boolean;
-	download?: (file: Blob, filename: string) => void;
+	download?: (file: Blob, filename: string) => void | Promise<void>;
 };
 
 export const DownloadSelectedAgentLogsButton: FC<
@@ -36,6 +36,19 @@ export const DownloadSelectedAgentLogsButton: FC<
 	download = saveAs,
 }) => {
 	const [isDownloading, setIsDownloading] = useState(false);
+	const handleDownload = async () => {
+		try {
+			setIsDownloading(true);
+			const file = new Blob([logsText], { type: "text/plain" });
+			await download(file, `${agentName}-${filenameSuffix}.txt`);
+		} catch (error) {
+			toast.error(`Failed to download "${agentName}" logs.`, {
+				description: getErrorDetail(error),
+			});
+		} finally {
+			setIsDownloading(false);
+		}
+	};
 
 	const downloadLogs = (logsText: string, filenameSuffix: string) => {
 		try {
@@ -55,37 +68,14 @@ export const DownloadSelectedAgentLogsButton: FC<
 	const hasAllLogs = allLogsText.length > 0;
 
 	return (
-		<DropdownMenu>
-			<DropdownMenuTrigger asChild>
-				<Button variant="subtle" size="sm" disabled={disabled || isDownloading}>
-					<DownloadIcon />
-					{isDownloading ? "Downloading..." : "Download logs"}
-					<ChevronDownIcon className="size-icon-sm" />
-				</Button>
-			</DropdownMenuTrigger>
-			<DropdownMenuContent align="end">
-				<DropdownMenuItem
-					disabled={!hasAllLogs}
-					onSelect={() => {
-						downloadLogs(allLogsText, "all-logs");
-					}}
-				>
-					<PackageIcon />
-					Download all logs
-				</DropdownMenuItem>
-				{logSets.map((logSet) => (
-					<DropdownMenuItem
-						key={logSet.filenameSuffix}
-						disabled={logSet.logsText.length === 0}
-						onSelect={() => {
-							downloadLogs(logSet.logsText, logSet.filenameSuffix);
-						}}
-					>
-						{logSet.startIcon}
-						<span>Download {logSet.label}</span>
-					</DropdownMenuItem>
-				))}
-			</DropdownMenuContent>
-		</DropdownMenu>
+		<Button
+			variant="subtle"
+			size="sm"
+			disabled={disabled || isDownloading}
+			onClick={handleDownload}
+		>
+			<DownloadIcon />
+			{isDownloading ? "Downloading..." : "Download logs"}
+		</Button>
 	);
 };

--- a/site/src/modules/resources/DownloadSelectedAgentLogsButton.tsx
+++ b/site/src/modules/resources/DownloadSelectedAgentLogsButton.tsx
@@ -36,7 +36,7 @@ export const DownloadSelectedAgentLogsButton: FC<
 	download = saveAs,
 }) => {
 	const [isDownloading, setIsDownloading] = useState(false);
-	const handleDownload = async () => {
+	const downloadLogs = async (logsText: string, filenameSuffix: string) => {
 		try {
 			setIsDownloading(true);
 			const file = new Blob([logsText], { type: "text/plain" });
@@ -50,32 +50,40 @@ export const DownloadSelectedAgentLogsButton: FC<
 		}
 	};
 
-	const downloadLogs = (logsText: string, filenameSuffix: string) => {
-		try {
-			setIsDownloading(true);
-			const file = new Blob([logsText], { type: "text/plain" });
-			download(file, `${agentName}-${filenameSuffix}.txt`);
-		} catch (error) {
-			console.error(error);
-			toast.error(`Failed to download "${agentName}" logs.`, {
-				description: getErrorDetail(error),
-			});
-		} finally {
-			setIsDownloading(false);
-		}
-	};
-
 	const hasAllLogs = allLogsText.length > 0;
 
 	return (
-		<Button
-			variant="subtle"
-			size="sm"
-			disabled={disabled || isDownloading}
-			onClick={handleDownload}
-		>
-			<DownloadIcon />
-			{isDownloading ? "Downloading..." : "Download logs"}
-		</Button>
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<Button variant="subtle" size="sm" disabled={disabled || isDownloading}>
+					<DownloadIcon />
+					{isDownloading ? "Downloading..." : "Download logs"}
+					<ChevronDownIcon className="size-icon-sm" />
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end">
+				<DropdownMenuItem
+					disabled={!hasAllLogs}
+					onSelect={() => {
+						downloadLogs(allLogsText, "all-logs");
+					}}
+				>
+					<PackageIcon />
+					Download all logs
+				</DropdownMenuItem>
+				{logSets.map((logSet) => (
+					<DropdownMenuItem
+						key={logSet.filenameSuffix}
+						disabled={logSet.logsText.length === 0}
+						onSelect={() => {
+							downloadLogs(logSet.logsText, logSet.filenameSuffix);
+						}}
+					>
+						{logSet.startIcon}
+						<span>Download {logSet.label}</span>
+					</DropdownMenuItem>
+				))}
+			</DropdownMenuContent>
+		</DropdownMenu>
 	);
 };


### PR DESCRIPTION
This PR improves the agent log download functionality by replacing the single download button with a comprehensive dropdown menu system.

- Replaced single download button with a dropdown menu offering multiple download options
- Added ability to download all logs or individual log sources separately
- Updated download button to show chevron icon indicating dropdown functionality
- Enhanced download options with appropriate icons for each log source

<img width="370" height="305" alt="image" src="https://github.com/user-attachments/assets/ddf025f5-f936-499a-9165-6e81b62d6860" />
