### PR TITLE
fix: invalidate PR diff cache on git refresh button click

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -283,6 +283,70 @@ index abc1234..def5678 100644
 	},
 };
 
+/**
+ * Clicking the refresh button in the git panel invalidates the
+ * cached PR diff contents so that React Query re-fetches from
+ * the server.
+ */
+export const RefreshInvalidatesPRDiff: Story = {
+	render: () => (
+		<StoryAgentChatPageView
+			showSidebarPanel
+			prNumber={123}
+			diffStatusData={
+				{
+					chat_id: AGENT_ID,
+					url: "https://github.com/coder/coder/pull/123",
+					pull_request_title: "fix: resolve race condition in workspace builds",
+					pull_request_draft: false,
+					changes_requested: false,
+					additions: 42,
+					deletions: 7,
+					changed_files: 5,
+				} satisfies ChatDiffStatus
+			}
+		/>
+	),
+	beforeEach: () => {
+		spyOn(API.experimental, "getChatDiffContents").mockResolvedValue({
+			chat_id: AGENT_ID,
+			diff: `diff --git a/src/main.ts b/src/main.ts
+index abc1234..def5678 100644
+--- a/src/main.ts
++++ b/src/main.ts
+@@ -1,3 +1,5 @@
+ import { start } from "./server";
++import { logger } from "./logger";
+ const port = 3000;
++logger.info("Starting server...");
+ start(port);`,
+		});
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		// Wait for the initial diff fetch triggered by React Query.
+		await waitFor(() => {
+			expect(API.experimental.getChatDiffContents).toHaveBeenCalled();
+		});
+		const callsBefore = (
+			API.experimental.getChatDiffContents as ReturnType<typeof fn>
+		).mock.calls.length;
+
+		// Click the refresh button in the git panel toolbar.
+		const refreshButton = canvas.getByRole("button", { name: "Refresh" });
+		await userEvent.click(refreshButton);
+
+		// The query should be re-fetched, resulting in an additional call.
+		await waitFor(() => {
+			expect(
+				(API.experimental.getChatDiffContents as ReturnType<typeof fn>).mock
+					.calls.length,
+			).toBeGreaterThan(callsBefore);
+		});
+	},
+};
+
 /** Left sidebar is collapsed. */
 export const SidebarCollapsed: Story = {
 	render: () => <StoryAgentChatPageView isSidebarCollapsed />,

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -2,9 +2,9 @@ import { ArchiveIcon } from "lucide-react";
 import { type FC, type RefObject, useRef, useState } from "react";
 import { useQueryClient } from "react-query";
 import type { UrlTransform } from "streamdown";
+import { chatDiffContentsKey } from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { ChatDiffStatus, ChatMessagePart } from "#/api/typesGenerated";
-import { chatDiffContentsKey } from "#/api/queries/chats";
 import { cn } from "#/utils/cn";
 import { pageTitle } from "#/utils/page";
 import {

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -1,9 +1,10 @@
 import { ArchiveIcon } from "lucide-react";
 import { type FC, type RefObject, useRef, useState } from "react";
+import { useQueryClient } from "react-query";
 import type { UrlTransform } from "streamdown";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { ChatDiffStatus, ChatMessagePart } from "#/api/typesGenerated";
-
+import { chatDiffContentsKey } from "#/api/queries/chats";
 import { cn } from "#/utils/cn";
 import { pageTitle } from "#/utils/page";
 import {
@@ -208,6 +209,21 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	desktopChatId,
 	lastInjectedContext,
 }) => {
+	const queryClient = useQueryClient();
+
+	// Wrap the git watcher refresh to also invalidate the cached
+	// remote/PR diff contents so the panel re-fetches from GitHub.
+	const handleRefresh = () => {
+		const sent = gitWatcher.refresh();
+		if (sent && agentId) {
+			void queryClient.invalidateQueries({
+				queryKey: chatDiffContentsKey(agentId),
+				exact: true,
+			});
+		}
+		return sent;
+	};
+
 	const [isRightPanelExpanded, setIsRightPanelExpanded] = useState(false);
 	const [dragVisualExpanded, setDragVisualExpanded] = useState<boolean | null>(
 		null,
@@ -389,7 +405,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 												: undefined
 										}
 										repositories={gitWatcher.repositories}
-										onRefresh={gitWatcher.refresh}
+										onRefresh={handleRefresh}
 										onCommit={handleCommit}
 										isExpanded={visualExpanded}
 										remoteDiffStats={diffStatusData}


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

The refresh button in the diff viewer on the agents page only refreshes local git status — clicking it while viewing a GitHub PR diff had no effect. Users had to perform a full page refresh to see updated PR information.

## Root Cause

The refresh button sends a `{ type: "refresh" }` WebSocket message to the agent's git watcher, which triggers a local `git` scan. The remote/PR diff contents are fetched separately via a React Query (`chatDiffContents`) that calls `GET /api/experimental/chats/{id}/diff` — which always fetches fresh from GitHub. However, this query was never invalidated by the refresh button, so the cached response was served indefinitely until a `diff_status_change` event arrived via the chat event stream.

## Fix

Wrap the `onRefresh` callback in `AgentChatPageView` so that, in addition to sending the git watcher refresh, it also invalidates the `chatDiffContentsKey` query. This causes the `RemoteDiffPanel` to re-fetch the PR diff from GitHub.

Single file change in `AgentChatPageView.tsx`.