### PR TITLE
fix(site/src/pages/AgentsPage): reset provider form after create

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ChatModelAdminPanel.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ChatModelAdminPanel.stories.tsx
@@ -462,6 +462,9 @@ export const CreateAndUpdateProvider: Story = {
 		await waitFor(() => {
 			expect(args.onCreateProvider).toHaveBeenCalledTimes(1);
 		});
+		await waitFor(() => {
+			expect(body.getByRole("button", { name: "Save changes" })).toBeDisabled();
+		});
 		expect(args.onCreateProvider).toHaveBeenCalledWith(
 			expect.objectContaining({
 				provider: "openai",


### PR DESCRIPTION
Previously, after creating a provider config in the agents provider editor, the Save changes button stayed enabled for the lifetime of the mounted form. The form kept the pre-create local baseline, so the freshly-saved values still looked dirty.

Key `ProviderForm` by provider config identity so React remounts the form when a config is created and re-establishes the pristine state from the saved provider values.
