### PR TITLE
docs: add AI Bridge structured log record types and monitoring cross-link

### DIFF
--- a/docs/ai-coder/ai-bridge/monitoring.md
+++ b/docs/ai-coder/ai-bridge/monitoring.md
@@ -10,6 +10,13 @@ We provide an example Grafana dashboard that you can import as a starting point 
 
 These logs and metrics can be used to determine usage patterns, track costs, and evaluate tooling adoption.
 
+## Structured Logging
+
+AI Bridge can emit structured logs for every interception event to your
+existing log pipeline. This is useful for exporting data to external SIEM or
+observability platforms. See [Structured Logging](./setup.md#structured-logging)
+in the setup guide for configuration and a full list of record types.
+
 ## Exporting Data
 
 AI Bridge interception data can be exported for external analysis, compliance reporting, or integration with log aggregation systems.

--- a/docs/ai-coder/ai-bridge/setup.md
+++ b/docs/ai-coder/ai-bridge/setup.md
@@ -150,4 +150,14 @@ ingestion, set `--log-json` to a file path or `/dev/stderr` so that records are
 emitted as JSON.
 
 Filter for AI Bridge records in your logging pipeline by matching on the
-`"interception log"` message.
+`"interception log"` message. Each log line includes a `record_type` field that
+indicates the kind of event captured:
+
+| `record_type` | Description | Key fields |
+|---|---|---|
+| `interception_start` | A new intercepted request begins. | `interception_id`, `initiator_id`, `provider`, `model`, `client`, `started_at` |
+| `interception_end` | An intercepted request completes. | `interception_id`, `ended_at` |
+| `token_usage` | Token consumption for a response. | `interception_id`, `input_tokens`, `output_tokens`, `created_at` |
+| `prompt_usage` | The last user prompt in a request. | `interception_id`, `prompt`, `created_at` |
+| `tool_usage` | A tool/function call made by the model. | `interception_id`, `tool`, `input`, `server_url`, `injected`, `created_at` |
+| `model_thought` | Model reasoning or thinking content. | `interception_id`, `content`, `created_at` |

--- a/docs/ai-coder/ai-bridge/setup.md
+++ b/docs/ai-coder/ai-bridge/setup.md
@@ -153,11 +153,11 @@ Filter for AI Bridge records in your logging pipeline by matching on the
 `"interception log"` message. Each log line includes a `record_type` field that
 indicates the kind of event captured:
 
-| `record_type` | Description | Key fields |
-|---|---|---|
-| `interception_start` | A new intercepted request begins. | `interception_id`, `initiator_id`, `provider`, `model`, `client`, `started_at` |
-| `interception_end` | An intercepted request completes. | `interception_id`, `ended_at` |
-| `token_usage` | Token consumption for a response. | `interception_id`, `input_tokens`, `output_tokens`, `created_at` |
-| `prompt_usage` | The last user prompt in a request. | `interception_id`, `prompt`, `created_at` |
-| `tool_usage` | A tool/function call made by the model. | `interception_id`, `tool`, `input`, `server_url`, `injected`, `created_at` |
-| `model_thought` | Model reasoning or thinking content. | `interception_id`, `content`, `created_at` |
+| `record_type`        | Description                             | Key fields                                                                     |
+|----------------------|-----------------------------------------|--------------------------------------------------------------------------------|
+| `interception_start` | A new intercepted request begins.       | `interception_id`, `initiator_id`, `provider`, `model`, `client`, `started_at` |
+| `interception_end`   | An intercepted request completes.       | `interception_id`, `ended_at`                                                  |
+| `token_usage`        | Token consumption for a response.       | `interception_id`, `input_tokens`, `output_tokens`, `created_at`               |
+| `prompt_usage`       | The last user prompt in a request.      | `interception_id`, `prompt`, `created_at`                                      |
+| `tool_usage`         | A tool/function call made by the model. | `interception_id`, `tool`, `input`, `server_url`, `injected`, `created_at`     |
+| `model_thought`      | Model reasoning or thinking content.    | `interception_id`, `content`, `created_at`                                     |


### PR DESCRIPTION
## What

Two small docs improvements for AI Bridge:

1. **`setup.md` – Structured Logging section**: Added a `record_type` table documenting the six event types emitted by AI Bridge structured logs (`interception_start`, `interception_end`, `token_usage`, `prompt_usage`, `tool_usage`, `model_thought`) along with their key fields. Previously only the `"interception log"` message prefix was mentioned.

2. **`monitoring.md`**: Added a "Structured Logging" section that cross-links to `setup.md#structured-logging`, so users landing on the monitoring page can discover the feature without navigating to the setup guide first.

<details><summary>Source reference</summary>

Record types and fields were extracted from `enterprise/aibridgedserver/aibridgedserver.go` where they are emitted as `slog.F("record_type", "...")` string literals under the `InterceptionLogMarker` (`"interception log"`) message.

</details>