### PR TITLE
fix(agent): use Eventually in TestAgent_DevcontainersDisabledForSubAgent

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -2527,15 +2527,26 @@ func TestAgent_DevcontainersDisabledForSubAgent(t *testing.T) {
 
 	// Query the containers API endpoint. This should fail because
 	// devcontainers have been disabled for the sub agent.
+	// Use Eventually since the agent HTTP API may not be serving
+	// immediately after the tailnet connection is reachable.
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitMedium)
 	defer cancel()
 
-	_, err := conn.ListContainers(ctx)
-	require.Error(t, err)
+	var listErr string
+	testutil.Eventually(ctx, t, func(ctx context.Context) bool {
+		_, err := conn.ListContainers(ctx)
+		if err == nil {
+			return false
+		}
+		listErr = err.Error()
+		// Ensure we get the specific sub-agent error, not a transient
+		// connection error from the API server still starting.
+		return strings.Contains(listErr, "Dev Container feature not supported.")
+	}, testutil.IntervalFast, "ListContainers should return the sub-agent 403 error")
 
-	// Verify the error message contains the expected text.
-	require.Contains(t, err.Error(), "Dev Container feature not supported.")
-	require.Contains(t, err.Error(), "Dev Container integration inside other Dev Containers is explicitly not supported.")
+	// Verify the full error message.
+	require.Contains(t, listErr, "Dev Container feature not supported.")
+	require.Contains(t, listErr, "Dev Container integration inside other Dev Containers is explicitly not supported.")
 }
 
 // TestAgent_DevcontainerPrebuildClaim tests that we correctly handle


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

Fixes https://linear.app/codercom/issue/ENG-2331

## Problem

`TestAgent_DevcontainersDisabledForSubAgent` flakes in CI under race detection + parallel test execution.

The test was making a single `ListContainers` call immediately after `setupAgent` returns. `setupAgent` only waits for tailnet reachability (`AwaitReachable`), but the agent's HTTP API server starts in a separate goroutine inside `createTailnet`. Under race-detector overhead, the request can arrive before the HTTP handler is fully serving, causing a transient connection error whose message doesn't contain the expected error text — failing the `require.Contains` assertions.

## Fix

Switch to `testutil.Eventually` to retry until the expected sub-agent 403 response is received. This matches the pattern used by other `ListContainers` callers in this test file.

<details><summary>Investigation notes</summary>

- The route handler in `agent/api.go` correctly checks `a.devcontainers` and `a.manifest.Load()` at route construction time
- The `manifestOK` checkpoint mechanism guarantees these fields are set before `apiHandler()` is called
- No data race exists on the `devcontainers` field (confirmed by 50+ race-detector runs)
- The flake is a timing issue between tailnet reachability and HTTP API readiness
</details>