### PR TITLE
fix(site): show delete menu for failed devcontainers

### DIFF
--- a/site/src/modules/resources/AgentDevcontainerCard.stories.tsx
+++ b/site/src/modules/resources/AgentDevcontainerCard.stories.tsx
@@ -59,6 +59,26 @@ export const HasError: Story = {
 	},
 };
 
+export const HasErrorMenuOpen: Story = {
+	args: {
+		devcontainer: {
+			...MockWorkspaceAgentDevcontainer,
+			error: "unable to inject devcontainer with agent",
+			container: undefined,
+			agent: undefined,
+		},
+		subAgents: [],
+	},
+	play: async ({ canvasElement }) => {
+		const user = userEvent.setup();
+		const canvas = within(canvasElement);
+
+		await user.click(
+			canvas.getByRole("button", { name: "Dev Container actions" }),
+		);
+	},
+};
+
 export const NoPorts: Story = {};
 
 export const WithPorts: Story = {

--- a/site/src/modules/resources/AgentDevcontainerCard.tsx
+++ b/site/src/modules/resources/AgentDevcontainerCard.tsx
@@ -274,11 +274,9 @@ export const AgentDevcontainerCard: FC<AgentDevcontainerCardProps> = ({
 							/>
 						)}
 
-					{showDevcontainerControls && (
-						<AgentDevcontainerMoreActions
-							deleteDevContainer={deleteDevcontainerMutation.mutate}
-						/>
-					)}
+					<AgentDevcontainerMoreActions
+						deleteDevContainer={deleteDevcontainerMutation.mutate}
+					/>
 
 					<DevcontainerDeleteErrorDialog
 						open={deleteDevcontainerMutation.isError}


### PR DESCRIPTION
## Problem

The three-dot menu (containing the Delete option) was not shown on devcontainer cards in a failed/error state. The `AgentDevcontainerMoreActions` component was gated behind `showDevcontainerControls`, which requires both a sub-agent and container reference to be truthy. For failed devcontainers, neither is typically present.

## Fix

Decouple the `AgentDevcontainerMoreActions` rendering from `showDevcontainerControls` so the Delete action is always available regardless of container state. The SSH and port forwarding controls remain gated behind `showDevcontainerControls` since they genuinely need the sub-agent and container.

A new Storybook story (`HasErrorMenuOpen`) is added to verify the delete menu is accessible for a failed devcontainer with no container or sub-agent.

Closes https://github.com/coder/coder/issues/23754