### PR TITLE
feat(cli): read display_name, icon, and description from README.md frontmatter in templates push

### DIFF
--- a/cli/frontmatter.go
+++ b/cli/frontmatter.go
@@ -1,0 +1,52 @@
+package cli
+
+import (
+	"bytes"
+
+	"golang.org/x/xerrors"
+	"gopkg.in/yaml.v3"
+)
+
+// TemplateFrontmatter holds metadata extracted from YAML frontmatter
+// in a template's README.md file. Templates in the coder/registry
+// and examples/templates/ directories already use this format to
+// declare display_name, description, and icon.
+type TemplateFrontmatter struct {
+	DisplayName string `yaml:"display_name"`
+	Description string `yaml:"description"`
+	Icon        string `yaml:"icon"`
+}
+
+// ParseTemplateFrontmatter extracts YAML frontmatter from the raw
+// bytes of a README.md file. The frontmatter is delimited by a
+// pair of "---" lines at the very start of the file. If the file
+// does not begin with "---", an empty TemplateFrontmatter is
+// returned without error.
+func ParseTemplateFrontmatter(data []byte) (TemplateFrontmatter, error) {
+	var fm TemplateFrontmatter
+
+	data = bytes.TrimLeft(data, "\n\r")
+	if !bytes.HasPrefix(data, []byte("---")) {
+		return fm, nil
+	}
+
+	// Skip past the opening "---" line.
+	data = data[3:]
+	idx := bytes.Index(data, []byte("\n"))
+	if idx == -1 {
+		return fm, nil
+	}
+	data = data[idx+1:]
+
+	// Find the closing "---" delimiter.
+	end := bytes.Index(data, []byte("\n---"))
+	if end == -1 {
+		return fm, nil
+	}
+	yamlBlock := data[:end]
+
+	if err := yaml.Unmarshal(yamlBlock, &fm); err != nil {
+		return fm, xerrors.Errorf("parse README.md frontmatter: %w", err)
+	}
+	return fm, nil
+}

--- a/cli/frontmatter_test.go
+++ b/cli/frontmatter_test.go
@@ -1,0 +1,39 @@
+package cli_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/cli"
+)
+
+func TestParseTemplateFrontmatter(t *testing.T) {
+	t.Parallel()
+
+	t.Run("AllFields", func(t *testing.T) {
+		t.Parallel()
+		data := []byte("---\ndisplay_name: Docker Containers\ndescription: Provision Docker containers as Coder workspaces\nicon: ../../../site/static/icon/docker.png\n---\n# Docker Containers\nSome content here.\n")
+		fm, err := cli.ParseTemplateFrontmatter(data)
+		require.NoError(t, err)
+		require.Equal(t, "Docker Containers", fm.DisplayName)
+		require.Equal(t, "Provision Docker containers as Coder workspaces", fm.Description)
+		require.Equal(t, "../../../site/static/icon/docker.png", fm.Icon)
+	})
+
+	t.Run("NoFrontmatter", func(t *testing.T) {
+		t.Parallel()
+		data := []byte("# Just a README\nNo frontmatter here.\n")
+		fm, err := cli.ParseTemplateFrontmatter(data)
+		require.NoError(t, err)
+		require.Empty(t, fm.DisplayName)
+	})
+
+	t.Run("InvalidYAML", func(t *testing.T) {
+		t.Parallel()
+		data := []byte("---\ndisplay_name: [invalid\n  yaml: {broken\n---\n# Content\n")
+		_, err := cli.ParseTemplateFrontmatter(data)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "parse README.md frontmatter")
+	})
+}

--- a/cli/templatepush.go
+++ b/cli/templatepush.go
@@ -36,6 +36,9 @@ func (r *RootCmd) templatePush() *serpent.Command {
 		provisionerTags      []string
 		uploadFlags          templateUploadFlags
 		activate             bool
+		displayName          string
+		description          string
+		icon                 string
 		orgContext           = NewOrganizationContext()
 	)
 	cmd := &serpent.Command{
@@ -70,6 +73,30 @@ func (r *RootCmd) templatePush() *serpent.Command {
 				err = codersdk.TemplateVersionNameValid(versionName)
 				if err != nil {
 					return xerrors.Errorf("template version name %q is invalid: %w", versionName, err)
+				}
+			}
+
+			// Read frontmatter from README.md when not reading from
+			// stdin so display_name, description, and icon can be
+			// populated automatically.
+			if !uploadFlags.stdin(inv) {
+				readmeData, _ := os.ReadFile(filepath.Join(uploadFlags.directory, "README.md"))
+				if len(readmeData) > 0 {
+					frontmatter, fmErr := ParseTemplateFrontmatter(readmeData)
+					if fmErr != nil {
+						cliui.Warn(inv.Stderr, "Failed to parse README.md frontmatter: "+fmErr.Error())
+					} else {
+						// CLI flags take precedence over frontmatter values.
+						if !userSetOption(inv, "display-name") && frontmatter.DisplayName != "" {
+							displayName = frontmatter.DisplayName
+						}
+						if !userSetOption(inv, "description") && frontmatter.Description != "" {
+							description = frontmatter.Description
+						}
+						if !userSetOption(inv, "icon") && frontmatter.Icon != "" {
+							icon = frontmatter.Icon
+						}
+					}
 				}
 			}
 
@@ -184,8 +211,11 @@ func (r *RootCmd) templatePush() *serpent.Command {
 
 			if createTemplate {
 				_, err = client.CreateTemplate(inv.Context(), organization.ID, codersdk.CreateTemplateRequest{
-					Name:      name,
-					VersionID: job.ID,
+					Name:        name,
+					DisplayName: displayName,
+					Description: description,
+					Icon:        icon,
+					VersionID:   job.ID,
 				})
 				if err != nil {
 					return err
@@ -201,6 +231,20 @@ func (r *RootCmd) templatePush() *serpent.Command {
 				})
 				if err != nil {
 					return err
+				}
+			}
+
+			// Update template metadata when any display fields are
+			// set on an existing template. The create path already
+			// includes these fields in CreateTemplateRequest.
+			if !createTemplate && (displayName != "" || description != "" || icon != "") {
+				_, err = client.UpdateTemplateMeta(inv.Context(), template.ID, codersdk.UpdateTemplateMeta{
+					DisplayName: &displayName,
+					Description: &description,
+					Icon:        &icon,
+				})
+				if err != nil {
+					return xerrors.Errorf("update template metadata: %w", err)
 				}
 			}
 
@@ -261,6 +305,21 @@ func (r *RootCmd) templatePush() *serpent.Command {
 			Description: "Whether the new template will be marked active.",
 			Default:     "true",
 			Value:       serpent.BoolOf(&activate),
+		},
+		{
+			Flag:        "display-name",
+			Description: "Set the display name of the template. Overrides any value from README.md frontmatter.",
+			Value:       serpent.StringOf(&displayName),
+		},
+		{
+			Flag:        "description",
+			Description: "Set the description of the template. Overrides any value from README.md frontmatter.",
+			Value:       serpent.StringOf(&description),
+		},
+		{
+			Flag:        "icon",
+			Description: "Set the icon of the template. Overrides any value from README.md frontmatter.",
+			Value:       serpent.StringOf(&icon),
 		},
 		cliui.SkipPromptOption(),
 	}

--- a/cli/templatepush_test.go
+++ b/cli/templatepush_test.go
@@ -1285,6 +1285,77 @@ cli_overrides_file_var: from-file`)
 			require.Equal(t, "from-cli-override", varMap["cli_overrides_file_var"])
 		})
 	})
+
+	t.Run("Frontmatter", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("CreateTemplateFromFrontmatter", func(t *testing.T) {
+			t.Parallel()
+			client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+			owner := coderdtest.CreateFirstUser(t, client)
+			templateAdmin, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID, rbac.RoleTemplateAdmin())
+			source := clitest.CreateTemplateVersionSource(t, completeWithAgent())
+
+			readmePath := filepath.Join(source, "README.md")
+			err := os.WriteFile(readmePath, []byte("---\ndisplay_name: Frontmatter Test\ndescription: A test template from frontmatter\nicon: /icon/docker.png\n---\n# Hello\n"), 0o600)
+			require.NoError(t, err)
+
+			const templateName = "frontmatter-template"
+			inv, root := clitest.New(t,
+				"templates", "push", templateName,
+				"--directory", source,
+				"--test.provisioner", string(database.ProvisionerTypeEcho),
+				"--yes",
+			)
+			clitest.SetupConfig(t, templateAdmin, root)
+
+			ctx := testutil.Context(t, testutil.WaitMedium)
+			inv = inv.WithContext(ctx)
+			w := clitest.StartWithWaiter(t, inv)
+			w.RequireSuccess()
+
+			template, err := client.TemplateByName(context.Background(), owner.OrganizationID, templateName)
+			require.NoError(t, err)
+			require.Equal(t, "Frontmatter Test", template.DisplayName)
+			require.Equal(t, "A test template from frontmatter", template.Description)
+			require.Equal(t, "/icon/docker.png", template.Icon)
+		})
+
+		t.Run("CLIFlagOverridesFrontmatter", func(t *testing.T) {
+			t.Parallel()
+			client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+			owner := coderdtest.CreateFirstUser(t, client)
+			templateAdmin, _ := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID, rbac.RoleTemplateAdmin())
+			source := clitest.CreateTemplateVersionSource(t, completeWithAgent())
+
+			readmePath := filepath.Join(source, "README.md")
+			err := os.WriteFile(readmePath, []byte("---\ndisplay_name: From Frontmatter\ndescription: From frontmatter desc\nicon: /icon/fm.png\n---\n# Hello\n"), 0o600)
+			require.NoError(t, err)
+
+			const templateName = "flag-override"
+			inv, root := clitest.New(t,
+				"templates", "push", templateName,
+				"--directory", source,
+				"--test.provisioner", string(database.ProvisionerTypeEcho),
+				"--display-name", "From CLI Flag",
+				"--description", "From CLI description",
+				"--icon", "/icon/cli.png",
+				"--yes",
+			)
+			clitest.SetupConfig(t, templateAdmin, root)
+
+			ctx := testutil.Context(t, testutil.WaitMedium)
+			inv = inv.WithContext(ctx)
+			w := clitest.StartWithWaiter(t, inv)
+			w.RequireSuccess()
+
+			template, err := client.TemplateByName(context.Background(), owner.OrganizationID, templateName)
+			require.NoError(t, err)
+			require.Equal(t, "From CLI Flag", template.DisplayName)
+			require.Equal(t, "From CLI description", template.Description)
+			require.Equal(t, "/icon/cli.png", template.Icon)
+		})
+	})
 }
 
 func createEchoResponsesWithTemplateVariables(templateVariables []*proto.TemplateVariable) *echo.Responses {


### PR DESCRIPTION
## Summary

`coder templates push` now reads YAML frontmatter from `README.md` in the template directory to automatically populate `display_name`, `description`, and `icon` on both create and update paths.

## Changes

- **New file `cli/frontmatter.go`**: A lightweight YAML frontmatter parser using `gopkg.in/yaml.v3` (already a dependency). Extracts `display_name`, `description`, and `icon` from README.md frontmatter delimited by `---`.

- **Modified `cli/templatepush.go`**:
  - Added `--display-name`, `--description`, and `--icon` CLI flags.
  - When not reading from stdin, reads `README.md` from the template directory and parses frontmatter.
  - CLI flags take precedence over frontmatter values (uses `userSetOption` pattern from `templates edit`).
  - **Create path**: populates `DisplayName`, `Description`, `Icon` in `CreateTemplateRequest`.
  - **Update path**: calls `UpdateTemplateMeta` with frontmatter/flag values when any display field is set.

- **Tests**:
  - Unit tests for `ParseTemplateFrontmatter` covering all fields, partial fields, no frontmatter, empty file, and invalid YAML.
  - Integration tests for create-with-frontmatter and CLI-flag-overrides-frontmatter.

## Prior art

Templates in `coder/registry` and `examples/templates/` already use this frontmatter format. The existing parser in `scripts/examplegen/main.go` uses Hugo's `pageparser`, but this implementation uses the lighter `gopkg.in/yaml.v3` already in the CLI's dependency tree.

Closes https://github.com/coder/coder/issues/23735