### PR TITLE
feat: use -x option in backport script to improve tracability

### DIFF
--- a/scripts/backport-pr.sh
+++ b/scripts/backport-pr.sh
@@ -96,7 +96,7 @@ git checkout -b "$backport_branch" "origin/${release_branch}"
 
 # Cherry-pick the merge commit.
 log "Cherry-picking ${merge_commit}..."
-if ! git cherry-pick "$merge_commit"; then
+if ! git cherry-pick -x "$merge_commit"; then
 	log ""
 	log "Cherry-pick failed due to conflicts."
 	log "Resolve the conflicts, then run:"


### PR DESCRIPTION
Add `-x` to backport script `git cherry-pick` command to include a commit message reference to the original commit. This makes it easier to trace where a cherry picked commit actually came from.

From git docs https://git-scm.com/docs/git-cherry-pick
> -x
>
> When recording the commit, append a line that says "(cherry picked from commit …​)" to the original commit message in order to indicate which commit this change was cherry-picked from. This is done only for cherry picks without conflicts. Do not use this option if you are cherry-picking from your private branch because the information is useless to the recipient. If on the other hand you are cherry-picking between two publicly visible branches (e.g. backporting a fix to a maintenance branch for an older release from a development branch), adding this information can be useful.
