### PR TITLE
chore(coderd/database): add pruning for orphaned chat file_ids entries

### DIFF
--- a/cli/testdata/coder_templates_push_--help.golden
+++ b/cli/testdata/coder_templates_push_--help.golden
@@ -16,8 +16,20 @@ OPTIONS:
           Always prompt all parameters. Does not pull parameter values from
           active template version.
 
+      --description string
+          Set the description of the template. Overrides any value from
+          README.md frontmatter.
+
   -d, --directory string (default: .)
           Specify the directory to create from, use '-' to read tar from stdin.
+
+      --display-name string
+          Set the display name of the template. Overrides any value from
+          README.md frontmatter.
+
+      --icon string
+          Set the icon of the template. Overrides any value from README.md
+          frontmatter.
 
       --ignore-lockfile bool (default: false)
           Ignore warnings about not having a .terraform.lock.hcl file present in

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -2081,6 +2081,13 @@ func (q *querier) DeleteOrganizationMember(ctx context.Context, arg database.Del
 	}, q.db.DeleteOrganizationMember)(ctx, arg)
 }
 
+func (q *querier) DeleteOrphanedChatFiles(ctx context.Context, before time.Time) (int64, error) {
+	if err := q.authorizeContext(ctx, policy.ActionDelete, rbac.ResourceSystem); err != nil {
+		return 0, err
+	}
+	return q.db.DeleteOrphanedChatFiles(ctx, before)
+}
+
 func (q *querier) DeleteProvisionerKey(ctx context.Context, id uuid.UUID) error {
 	return deleteQ(q.log, q.auth, q.db.GetProvisionerKeyByID, q.db.DeleteProvisionerKey)(ctx, id)
 }

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -640,6 +640,14 @@ func (m queryMetricsStore) DeleteOrganizationMember(ctx context.Context, arg dat
 	return r0
 }
 
+func (m queryMetricsStore) DeleteOrphanedChatFiles(ctx context.Context, before time.Time) (int64, error) {
+	start := time.Now()
+	r0, r1 := m.s.DeleteOrphanedChatFiles(ctx, before)
+	m.queryLatencies.WithLabelValues("DeleteOrphanedChatFiles").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "DeleteOrphanedChatFiles").Inc()
+	return r0, r1
+}
+
 func (m queryMetricsStore) DeleteProvisionerKey(ctx context.Context, id uuid.UUID) error {
 	start := time.Now()
 	r0 := m.s.DeleteProvisionerKey(ctx, id)

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -1070,6 +1070,21 @@ func (mr *MockStoreMockRecorder) DeleteOrganizationMember(ctx, arg any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteOrganizationMember", reflect.TypeOf((*MockStore)(nil).DeleteOrganizationMember), ctx, arg)
 }
 
+// DeleteOrphanedChatFiles mocks base method.
+func (m *MockStore) DeleteOrphanedChatFiles(ctx context.Context, before time.Time) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteOrphanedChatFiles", ctx, before)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteOrphanedChatFiles indicates an expected call of DeleteOrphanedChatFiles.
+func (mr *MockStoreMockRecorder) DeleteOrphanedChatFiles(ctx, before any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteOrphanedChatFiles", reflect.TypeOf((*MockStore)(nil).DeleteOrphanedChatFiles), ctx, before)
+}
+
 // DeleteProvisionerKey mocks base method.
 func (m *MockStore) DeleteProvisionerKey(ctx context.Context, id uuid.UUID) error {
 	m.ctrl.T.Helper()

--- a/coderd/database/dbpurge/dbpurge.go
+++ b/coderd/database/dbpurge/dbpurge.go
@@ -34,6 +34,9 @@ const (
 	// long enough to cover the maximum interval of a heartbeat event (currently
 	// 1 hour) plus some buffer.
 	maxTelemetryHeartbeatAge = 24 * time.Hour
+	// Chat files not referenced by any chat message that are older
+	// than this threshold are considered orphaned and deleted.
+	maxOrphanedChatFileAge = 24 * time.Hour
 )
 
 // New creates a new periodically purging database instance.
@@ -213,12 +216,19 @@ func (i *instance) purgeTick(ctx context.Context, db database.Store, start time.
 			}
 		}
 
+		deleteOrphanedChatFilesBefore := start.Add(-maxOrphanedChatFileAge)
+		purgedChatFiles, err := tx.DeleteOrphanedChatFiles(ctx, deleteOrphanedChatFilesBefore)
+		if err != nil {
+			return xerrors.Errorf("failed to delete orphaned chat files: %w", err)
+		}
+
 		i.logger.Debug(ctx, "purged old database entries",
 			slog.F("workspace_agent_logs", purgedWorkspaceAgentLogs),
 			slog.F("expired_api_keys", expiredAPIKeys),
 			slog.F("aibridge_records", purgedAIBridgeRecords),
 			slog.F("connection_logs", purgedConnectionLogs),
 			slog.F("audit_logs", purgedAuditLogs),
+			slog.F("orphaned_chat_files", purgedChatFiles),
 			slog.F("duration", i.clk.Since(start)),
 		)
 
@@ -232,6 +242,7 @@ func (i *instance) purgeTick(ctx context.Context, db database.Store, start time.
 			i.recordsPurged.WithLabelValues("aibridge_records").Add(float64(purgedAIBridgeRecords))
 			i.recordsPurged.WithLabelValues("connection_logs").Add(float64(purgedConnectionLogs))
 			i.recordsPurged.WithLabelValues("audit_logs").Add(float64(purgedAuditLogs))
+			i.recordsPurged.WithLabelValues("orphaned_chat_files").Add(float64(purgedChatFiles))
 		}
 
 		return nil

--- a/coderd/database/dbpurge/dbpurge_test.go
+++ b/coderd/database/dbpurge/dbpurge_test.go
@@ -1630,6 +1630,74 @@ func TestDeleteExpiredAPIKeys(t *testing.T) {
 	}
 }
 
+//nolint:paralleltest // It uses LockIDDBPurge.
+func TestDeleteOrphanedChatFiles(t *testing.T) {
+	ctx := testutil.Context(t, testutil.WaitShort)
+	clk := quartz.NewMock(t)
+	now := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+	clk.Set(now).MustWait(ctx)
+
+	db, _, sqlDB := dbtestutil.NewDBWithSQLDB(t, dbtestutil.WithDumpOnFailure())
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+
+	user := dbgen.User(t, db, database.User{})
+	org := dbgen.Organization(t, db, database.Organization{})
+	_ = dbgen.OrganizationMember(t, db, database.OrganizationMember{UserID: user.ID, OrganizationID: org.ID})
+
+	modelCfg, err := db.InsertChatModelConfig(ctx, database.InsertChatModelConfigParams{
+		Provider: "test", Model: "test", DisplayName: "Test", Enabled: true, Options: json.RawMessage("{}"),
+	})
+	require.NoError(t, err)
+	chat, err := db.InsertChat(ctx, database.InsertChatParams{
+		OwnerID: user.ID, LastModelConfigID: modelCfg.ID, Title: "test chat",
+	})
+	require.NoError(t, err)
+
+	referencedFile, err := db.InsertChatFile(ctx, database.InsertChatFileParams{
+		OwnerID: user.ID, OrganizationID: org.ID, Name: "ref.png", Mimetype: "image/png", Data: []byte("ref"),
+	})
+	require.NoError(t, err)
+
+	fileContent := fmt.Sprintf("[{\"type\":\"file\",\"media_type\":\"image/png\",\"file_id\":\"%s\"}]", referencedFile.ID)
+	_, err = db.InsertChatMessages(ctx, database.InsertChatMessagesParams{
+		ChatID: chat.ID, CreatedBy: []uuid.UUID{user.ID}, ModelConfigID: []uuid.UUID{modelCfg.ID},
+		Role: []database.ChatMessageRole{database.ChatMessageRoleUser}, Content: []string{fileContent},
+		ContentVersion: []int16{1}, Visibility: []database.ChatMessageVisibility{database.ChatMessageVisibilityBoth},
+		InputTokens: []int64{0}, OutputTokens: []int64{0}, TotalTokens: []int64{0}, ReasoningTokens: []int64{0},
+		CacheCreationTokens: []int64{0}, CacheReadTokens: []int64{0}, ContextLimit: []int64{0},
+		Compressed: []bool{false}, TotalCostMicros: []int64{0}, RuntimeMs: []int64{0}, ProviderResponseID: []string{""},
+	})
+	require.NoError(t, err)
+
+	orphanedFile, err := db.InsertChatFile(ctx, database.InsertChatFileParams{
+		OwnerID: user.ID, OrganizationID: org.ID, Name: "orphan.png", Mimetype: "image/png", Data: []byte("orphan"),
+	})
+	require.NoError(t, err)
+
+	recentOrphanedFile, err := db.InsertChatFile(ctx, database.InsertChatFileParams{
+		OwnerID: user.ID, OrganizationID: org.ID, Name: "recent.png", Mimetype: "image/png", Data: []byte("recent"),
+	})
+	require.NoError(t, err)
+
+	// Backdate old files past the 24h threshold.
+	_, err = sqlDB.ExecContext(ctx, "UPDATE chat_files SET created_at = $1 WHERE id = $2", now.Add(-48*time.Hour), orphanedFile.ID)
+	require.NoError(t, err)
+	_, err = sqlDB.ExecContext(ctx, "UPDATE chat_files SET created_at = $1 WHERE id = $2", now.Add(-48*time.Hour), referencedFile.ID)
+	require.NoError(t, err)
+
+	done := awaitDoTick(ctx, t, clk)
+	closer := dbpurge.New(ctx, logger, db, &codersdk.DeploymentValues{}, clk, prometheus.NewRegistry())
+	defer closer.Close()
+	<-done
+
+	_, err = db.GetChatFileByID(ctx, orphanedFile.ID)
+	require.Error(t, err, "orphaned file should be deleted after purge")
+	_, err = db.GetChatFileByID(ctx, referencedFile.ID)
+	require.NoError(t, err, "referenced file should still exist after purge")
+	_, err = db.GetChatFileByID(ctx, recentOrphanedFile.ID)
+	require.NoError(t, err, "recent orphaned file should still exist after purge")
+}
+
 // ptr is a helper to create a pointer to a value.
 func ptr[T any](v T) *T {
 	return &v

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -143,6 +143,11 @@ type sqlcQuerier interface {
 	DeleteOldWorkspaceAgentLogs(ctx context.Context, threshold time.Time) (int64, error)
 	DeleteOldWorkspaceAgentStats(ctx context.Context) error
 	DeleteOrganizationMember(ctx context.Context, arg DeleteOrganizationMemberParams) error
+	// Deletes chat_files rows older than the given threshold that are
+	// not referenced by any non-deleted chat message. File references
+	// live inside the JSONB content array of chat_messages as
+	// {"file_id": "<uuid>"} entries in file-type parts.
+	DeleteOrphanedChatFiles(ctx context.Context, before time.Time) (int64, error)
 	DeleteProvisionerKey(ctx context.Context, id uuid.UUID) error
 	DeleteReplicasUpdatedBefore(ctx context.Context, updatedAt time.Time) error
 	DeleteRuntimeConfig(ctx context.Context, key string) error

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -2865,6 +2865,30 @@ func (q *sqlQuerier) UpsertBoundaryUsageStats(ctx context.Context, arg UpsertBou
 	return new_period, err
 }
 
+const deleteOrphanedChatFiles = `-- name: DeleteOrphanedChatFiles :execrows
+DELETE FROM chat_files
+WHERE created_at < $1::timestamptz
+AND NOT EXISTS (
+    SELECT 1
+    FROM chat_messages cm,
+         jsonb_array_elements(cm.content) AS elem
+    WHERE (elem ->> 'file_id')::uuid = chat_files.id
+    AND cm.deleted = false
+)
+`
+
+// Deletes chat_files rows older than the given threshold that are
+// not referenced by any non-deleted chat message. File references
+// live inside the JSONB content array of chat_messages as
+// {"file_id": "<uuid>"} entries in file-type parts.
+func (q *sqlQuerier) DeleteOrphanedChatFiles(ctx context.Context, before time.Time) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deleteOrphanedChatFiles, before)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const getChatFileByID = `-- name: GetChatFileByID :one
 SELECT id, owner_id, organization_id, created_at, name, mimetype, data FROM chat_files WHERE id = $1::uuid
 `

--- a/coderd/database/queries/chatfiles.sql
+++ b/coderd/database/queries/chatfiles.sql
@@ -8,3 +8,18 @@ SELECT * FROM chat_files WHERE id = @id::uuid;
 
 -- name: GetChatFilesByIDs :many
 SELECT * FROM chat_files WHERE id = ANY(@ids::uuid[]);
+
+-- name: DeleteOrphanedChatFiles :execrows
+-- Deletes chat_files rows older than the given threshold that are
+-- not referenced by any non-deleted chat message. File references
+-- live inside the JSONB content array of chat_messages as
+-- {"file_id": "<uuid>"} entries in file-type parts.
+DELETE FROM chat_files
+WHERE created_at < @before::timestamptz
+AND NOT EXISTS (
+    SELECT 1
+    FROM chat_messages cm,
+         jsonb_array_elements(cm.content) AS elem
+    WHERE (elem ->> 'file_id')::uuid = chat_files.id
+    AND cm.deleted = false
+);


### PR DESCRIPTION
## Summary

Add a `dbpurge` job that periodically deletes orphaned `chat_files` rows — files uploaded for chats but no longer referenced by any non-deleted chat message.

### Changes

- **New SQL query** `DeleteOrphanedChatFiles` in `coderd/database/queries/chatfiles.sql`: deletes `chat_files` rows older than 24 hours that are not referenced by any non-deleted `chat_messages` content (JSONB `file_id` field).
- **dbpurge integration**: registered in the existing `purgeTick` loop with a 24-hour age threshold, matching the pattern of other purge jobs (logging, metrics).
- **Authorization**: uses `rbac.ResourceSystem` / `policy.ActionDelete` in dbauthz, consistent with other bulk-delete operations.
- **Test**: `TestDeleteOrphanedChatFiles` validates three scenarios: orphaned old file (deleted), referenced old file (kept), recent orphaned file (kept).

Closes https://github.com/coder/coder/issues/23910