### PR TITLE
feat: add onboarding info fields to first user setup

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -14546,6 +14546,26 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.CreateFirstUserOnboardingInfo": {
+            "type": "object",
+            "properties": {
+                "industry_type": {
+                    "type": "string"
+                },
+                "is_business": {
+                    "type": "boolean"
+                },
+                "newsletter_marketing": {
+                    "type": "boolean"
+                },
+                "newsletter_releases": {
+                    "type": "boolean"
+                },
+                "org_size": {
+                    "type": "string"
+                }
+            }
+        },
         "codersdk.CreateFirstUserRequest": {
             "type": "object",
             "required": [
@@ -14559,6 +14579,9 @@ const docTemplate = `{
                 },
                 "name": {
                     "type": "string"
+                },
+                "onboarding_info": {
+                    "$ref": "#/definitions/codersdk.CreateFirstUserOnboardingInfo"
                 },
                 "password": {
                     "type": "string"

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -14550,7 +14550,27 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "industry_type": {
-                    "$ref": "#/definitions/codersdk.IndustryType"
+                    "enum": [
+                        "Technology",
+                        "Financial Services",
+                        "Healthcare",
+                        "Government",
+                        "Education",
+                        "Retail",
+                        "Manufacturing",
+                        "Media",
+                        "Telecom",
+                        "Energy",
+                        "Transportation",
+                        "Consulting",
+                        "Non-Profit",
+                        "Other"
+                    ],
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/codersdk.IndustryType"
+                        }
+                    ]
                 },
                 "is_business": {
                     "type": "boolean"
@@ -14562,7 +14582,20 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "org_size": {
-                    "$ref": "#/definitions/codersdk.OrgSizeRange"
+                    "enum": [
+                        "Just me",
+                        "2-10",
+                        "11-50",
+                        "51-200",
+                        "201-1000",
+                        "1001-5000",
+                        "5000+"
+                    ],
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/codersdk.OrgSizeRange"
+                        }
+                    ]
                 }
             }
         },

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -14550,8 +14550,7 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "industry_type": {
-                    "description": "IndustryType is a free-form string supplied by the frontend.\nExpected values include \"Technology\", \"Finance\", \"Healthcare\",\n\"Education\", \"Government\", \"Retail\", \"Media\", \"Manufacturing\",\n\"Transportation\", \"Energy\", \"Other\".",
-                    "type": "string"
+                    "$ref": "#/definitions/codersdk.IndustryType"
                 },
                 "is_business": {
                     "type": "boolean"
@@ -16435,6 +16434,41 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.IndustryType": {
+            "type": "string",
+            "enum": [
+                "Technology",
+                "Financial Services",
+                "Healthcare",
+                "Government",
+                "Education",
+                "Retail",
+                "Manufacturing",
+                "Media",
+                "Telecom",
+                "Energy",
+                "Transportation",
+                "Consulting",
+                "Non-Profit",
+                "Other"
+            ],
+            "x-enum-varnames": [
+                "IndustryTypeTechnology",
+                "IndustryTypeFinancial",
+                "IndustryTypeHealthcare",
+                "IndustryTypeGovernment",
+                "IndustryTypeEducation",
+                "IndustryTypeRetail",
+                "IndustryTypeManufacturing",
+                "IndustryTypeMedia",
+                "IndustryTypeTelecom",
+                "IndustryTypeEnergy",
+                "IndustryTypeTransportation",
+                "IndustryTypeConsulting",
+                "IndustryTypeNonProfit",
+                "IndustryTypeOther"
+            ]
+        },
         "codersdk.InsightsReportInterval": {
             "type": "string",
             "enum": [
@@ -17624,16 +17658,22 @@ const docTemplate = `{
         "codersdk.OrgSizeRange": {
             "type": "string",
             "enum": [
-                "1-50",
+                "Just me",
+                "2-10",
+                "11-50",
                 "51-200",
-                "201-2000",
-                "2001+"
+                "201-1000",
+                "1001-5000",
+                "5000+"
             ],
             "x-enum-varnames": [
-                "OrgSizeRangeSmall",
-                "OrgSizeRangeMedium",
-                "OrgSizeRangeLarge",
-                "OrgSizeRangeXL"
+                "OrgSizeRangeJustMe",
+                "OrgSizeRange2To10",
+                "OrgSizeRange11To50",
+                "OrgSizeRange51To200",
+                "OrgSizeRange201To1K",
+                "OrgSizeRange1KTo5K",
+                "OrgSizeRange5KPlus"
             ]
         },
         "codersdk.Organization": {

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -14550,6 +14550,7 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "industry_type": {
+                    "description": "IndustryType is a free-form string supplied by the frontend.\nExpected values include \"Technology\", \"Finance\", \"Healthcare\",\n\"Education\", \"Government\", \"Retail\", \"Media\", \"Manufacturing\",\n\"Transportation\", \"Energy\", \"Other\".",
                     "type": "string"
                 },
                 "is_business": {
@@ -14562,7 +14563,7 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "org_size": {
-                    "type": "string"
+                    "$ref": "#/definitions/codersdk.OrgSizeRange"
                 }
             }
         },
@@ -17618,6 +17619,21 @@ const docTemplate = `{
                 "OptionTypeNumber",
                 "OptionTypeBoolean",
                 "OptionTypeListString"
+            ]
+        },
+        "codersdk.OrgSizeRange": {
+            "type": "string",
+            "enum": [
+                "1-50",
+                "51-200",
+                "201-2000",
+                "2001+"
+            ],
+            "x-enum-varnames": [
+                "OrgSizeRangeSmall",
+                "OrgSizeRangeMedium",
+                "OrgSizeRangeLarge",
+                "OrgSizeRangeXL"
             ]
         },
         "codersdk.Organization": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -13090,7 +13090,27 @@
 			"type": "object",
 			"properties": {
 				"industry_type": {
-					"$ref": "#/definitions/codersdk.IndustryType"
+					"enum": [
+						"Technology",
+						"Financial Services",
+						"Healthcare",
+						"Government",
+						"Education",
+						"Retail",
+						"Manufacturing",
+						"Media",
+						"Telecom",
+						"Energy",
+						"Transportation",
+						"Consulting",
+						"Non-Profit",
+						"Other"
+					],
+					"allOf": [
+						{
+							"$ref": "#/definitions/codersdk.IndustryType"
+						}
+					]
 				},
 				"is_business": {
 					"type": "boolean"
@@ -13102,7 +13122,20 @@
 					"type": "boolean"
 				},
 				"org_size": {
-					"$ref": "#/definitions/codersdk.OrgSizeRange"
+					"enum": [
+						"Just me",
+						"2-10",
+						"11-50",
+						"51-200",
+						"201-1000",
+						"1001-5000",
+						"5000+"
+					],
+					"allOf": [
+						{
+							"$ref": "#/definitions/codersdk.OrgSizeRange"
+						}
+					]
 				}
 			}
 		},

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -13090,6 +13090,7 @@
 			"type": "object",
 			"properties": {
 				"industry_type": {
+					"description": "IndustryType is a free-form string supplied by the frontend.\nExpected values include \"Technology\", \"Finance\", \"Healthcare\",\n\"Education\", \"Government\", \"Retail\", \"Media\", \"Manufacturing\",\n\"Transportation\", \"Energy\", \"Other\".",
 					"type": "string"
 				},
 				"is_business": {
@@ -13102,7 +13103,7 @@
 					"type": "boolean"
 				},
 				"org_size": {
-					"type": "string"
+					"$ref": "#/definitions/codersdk.OrgSizeRange"
 				}
 			}
 		},
@@ -16040,6 +16041,16 @@
 				"OptionTypeNumber",
 				"OptionTypeBoolean",
 				"OptionTypeListString"
+			]
+		},
+		"codersdk.OrgSizeRange": {
+			"type": "string",
+			"enum": ["1-50", "51-200", "201-2000", "2001+"],
+			"x-enum-varnames": [
+				"OrgSizeRangeSmall",
+				"OrgSizeRangeMedium",
+				"OrgSizeRangeLarge",
+				"OrgSizeRangeXL"
 			]
 		},
 		"codersdk.Organization": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -13090,8 +13090,7 @@
 			"type": "object",
 			"properties": {
 				"industry_type": {
-					"description": "IndustryType is a free-form string supplied by the frontend.\nExpected values include \"Technology\", \"Finance\", \"Healthcare\",\n\"Education\", \"Government\", \"Retail\", \"Media\", \"Manufacturing\",\n\"Transportation\", \"Energy\", \"Other\".",
-					"type": "string"
+					"$ref": "#/definitions/codersdk.IndustryType"
 				},
 				"is_business": {
 					"type": "boolean"
@@ -14919,6 +14918,41 @@
 				}
 			}
 		},
+		"codersdk.IndustryType": {
+			"type": "string",
+			"enum": [
+				"Technology",
+				"Financial Services",
+				"Healthcare",
+				"Government",
+				"Education",
+				"Retail",
+				"Manufacturing",
+				"Media",
+				"Telecom",
+				"Energy",
+				"Transportation",
+				"Consulting",
+				"Non-Profit",
+				"Other"
+			],
+			"x-enum-varnames": [
+				"IndustryTypeTechnology",
+				"IndustryTypeFinancial",
+				"IndustryTypeHealthcare",
+				"IndustryTypeGovernment",
+				"IndustryTypeEducation",
+				"IndustryTypeRetail",
+				"IndustryTypeManufacturing",
+				"IndustryTypeMedia",
+				"IndustryTypeTelecom",
+				"IndustryTypeEnergy",
+				"IndustryTypeTransportation",
+				"IndustryTypeConsulting",
+				"IndustryTypeNonProfit",
+				"IndustryTypeOther"
+			]
+		},
 		"codersdk.InsightsReportInterval": {
 			"type": "string",
 			"enum": ["day", "week"],
@@ -16045,12 +16079,23 @@
 		},
 		"codersdk.OrgSizeRange": {
 			"type": "string",
-			"enum": ["1-50", "51-200", "201-2000", "2001+"],
+			"enum": [
+				"Just me",
+				"2-10",
+				"11-50",
+				"51-200",
+				"201-1000",
+				"1001-5000",
+				"5000+"
+			],
 			"x-enum-varnames": [
-				"OrgSizeRangeSmall",
-				"OrgSizeRangeMedium",
-				"OrgSizeRangeLarge",
-				"OrgSizeRangeXL"
+				"OrgSizeRangeJustMe",
+				"OrgSizeRange2To10",
+				"OrgSizeRange11To50",
+				"OrgSizeRange51To200",
+				"OrgSizeRange201To1K",
+				"OrgSizeRange1KTo5K",
+				"OrgSizeRange5KPlus"
 			]
 		},
 		"codersdk.Organization": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -13086,6 +13086,26 @@
 				}
 			}
 		},
+		"codersdk.CreateFirstUserOnboardingInfo": {
+			"type": "object",
+			"properties": {
+				"industry_type": {
+					"type": "string"
+				},
+				"is_business": {
+					"type": "boolean"
+				},
+				"newsletter_marketing": {
+					"type": "boolean"
+				},
+				"newsletter_releases": {
+					"type": "boolean"
+				},
+				"org_size": {
+					"type": "string"
+				}
+			}
+		},
 		"codersdk.CreateFirstUserRequest": {
 			"type": "object",
 			"required": ["email", "password", "username"],
@@ -13095,6 +13115,9 @@
 				},
 				"name": {
 					"type": "string"
+				},
+				"onboarding_info": {
+					"$ref": "#/definitions/codersdk.CreateFirstUserOnboardingInfo"
 				},
 				"password": {
 					"type": "string"

--- a/coderd/telemetry/telemetry.go
+++ b/coderd/telemetry/telemetry.go
@@ -1502,6 +1502,7 @@ type Snapshot struct {
 	PrebuiltWorkspaces                   []PrebuiltWorkspace                   `json:"prebuilt_workspaces"`
 	AIBridgeInterceptionsSummaries       []AIBridgeInterceptionsSummary        `json:"aibridge_interceptions_summaries"`
 	BoundaryUsageSummary                 *BoundaryUsageSummary                 `json:"boundary_usage_summary"`
+	FirstUserOnboarding                  *FirstUserOnboarding                  `json:"first_user_onboarding"`
 }
 
 // Deployment contains information about the host running Coder.
@@ -1549,6 +1550,17 @@ type User struct {
 	GithubComUserID int64               `json:"github_com_user_id"`
 	// Omitempty for backwards compatibility.
 	LoginType string `json:"login_type,omitempty"`
+}
+
+// FirstUserOnboarding contains optional demographic and newsletter
+// preference data collected during first user setup. This is sent
+// once when the first user is created.
+type FirstUserOnboarding struct {
+	IsBusiness          bool   `json:"is_business"`
+	IndustryType        string `json:"industry_type"`
+	OrgSize             string `json:"org_size"`
+	NewsletterMarketing bool   `json:"newsletter_marketing"`
+	NewsletterReleases  bool   `json:"newsletter_releases"`
 }
 
 type Group struct {

--- a/coderd/telemetry/telemetry.go
+++ b/coderd/telemetry/telemetry.go
@@ -1554,13 +1554,14 @@ type User struct {
 
 // FirstUserOnboarding contains optional demographic and newsletter
 // preference data collected during first user setup. This is sent
-// once when the first user is created.
+// once when the first user is created. Pointer fields distinguish an
+// explicit answer from a skipped question.
 type FirstUserOnboarding struct {
-	IsBusiness          bool   `json:"is_business"`
+	IsBusiness          *bool  `json:"is_business"`
 	IndustryType        string `json:"industry_type"`
 	OrgSize             string `json:"org_size"`
-	NewsletterMarketing bool   `json:"newsletter_marketing"`
-	NewsletterReleases  bool   `json:"newsletter_releases"`
+	NewsletterMarketing *bool  `json:"newsletter_marketing"`
+	NewsletterReleases  *bool  `json:"newsletter_releases"`
 }
 
 type Group struct {

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -292,7 +292,7 @@ func (api *API) postFirstUser(rw http.ResponseWriter, r *http.Request) {
 	if createUser.OnboardingInfo != nil {
 		onboarding = &telemetry.FirstUserOnboarding{
 			IsBusiness:          createUser.OnboardingInfo.IsBusiness,
-			IndustryType:        createUser.OnboardingInfo.IndustryType,
+			IndustryType:        string(createUser.OnboardingInfo.IndustryType),
 			OrgSize:             string(createUser.OnboardingInfo.OrgSize),
 			NewsletterMarketing: createUser.OnboardingInfo.NewsletterMarketing,
 			NewsletterReleases:  createUser.OnboardingInfo.NewsletterReleases,

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -281,15 +281,26 @@ func (api *API) postFirstUser(rw http.ResponseWriter, r *http.Request) {
 	telemetryUser := telemetry.ConvertUser(user)
 	// Send the initial users email address!
 	telemetryUser.Email = &user.Email
-	api.Telemetry.Report(&telemetry.Snapshot{
-		Users: []telemetry.User{telemetryUser},
-		FirstUserOnboarding: &telemetry.FirstUserOnboarding{
+	// Only populate onboarding data when the client actually sent it. A nil
+	// OnboardingInfo means the request came from an older client, the CLI, or
+	// the OIDC flow — not from a user who answered "no" to every question.
+	//
+	// Note: newsletter consent (NewsletterMarketing) is bundled here alongside
+	// product-analytics fields. These may have different legal bases under GDPR
+	// and should be separated in a follow-up once the legal posture is clarified.
+	var onboarding *telemetry.FirstUserOnboarding
+	if createUser.OnboardingInfo != nil {
+		onboarding = &telemetry.FirstUserOnboarding{
 			IsBusiness:          createUser.OnboardingInfo.IsBusiness,
 			IndustryType:        createUser.OnboardingInfo.IndustryType,
-			OrgSize:             createUser.OnboardingInfo.OrgSize,
+			OrgSize:             string(createUser.OnboardingInfo.OrgSize),
 			NewsletterMarketing: createUser.OnboardingInfo.NewsletterMarketing,
 			NewsletterReleases:  createUser.OnboardingInfo.NewsletterReleases,
-		},
+		}
+	}
+	api.Telemetry.Report(&telemetry.Snapshot{
+		Users:               []telemetry.User{telemetryUser},
+		FirstUserOnboarding: onboarding,
 	})
 
 	httpapi.Write(ctx, rw, http.StatusCreated, codersdk.CreateFirstUserResponse{

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -283,6 +283,13 @@ func (api *API) postFirstUser(rw http.ResponseWriter, r *http.Request) {
 	telemetryUser.Email = &user.Email
 	api.Telemetry.Report(&telemetry.Snapshot{
 		Users: []telemetry.User{telemetryUser},
+		FirstUserOnboarding: &telemetry.FirstUserOnboarding{
+			IsBusiness:          createUser.OnboardingInfo.IsBusiness,
+			IndustryType:        createUser.OnboardingInfo.IndustryType,
+			OrgSize:             createUser.OnboardingInfo.OrgSize,
+			NewsletterMarketing: createUser.OnboardingInfo.NewsletterMarketing,
+			NewsletterReleases:  createUser.OnboardingInfo.NewsletterReleases,
+		},
 	})
 
 	httpapi.Write(ctx, rw, http.StatusCreated, codersdk.CreateFirstUserResponse{

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -116,6 +116,69 @@ func TestFirstUser(t *testing.T) {
 	})
 }
 
+func TestFirstUser_OnboardingTelemetry(t *testing.T) {
+	t.Parallel()
+
+	t.Run("OnboardingInfoFlowsToSnapshot", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitMedium)
+		fTelemetry := newFakeTelemetryReporter(ctx, t, 10)
+		client := coderdtest.New(t, &coderdtest.Options{
+			TelemetryReporter: fTelemetry,
+		})
+
+		isBusiness := true
+		wantMarketing := false
+		wantReleases := true
+		_, err := client.CreateFirstUser(ctx, codersdk.CreateFirstUserRequest{
+			Email:    "admin@coder.com",
+			Username: "admin",
+			Password: "SomeSecurePassword!",
+			OnboardingInfo: &codersdk.CreateFirstUserOnboardingInfo{
+				IsBusiness:          &isBusiness,
+				IndustryType:        "Technology",
+				OrgSize:             codersdk.OrgSizeRangeMedium,
+				NewsletterMarketing: &wantMarketing,
+				NewsletterReleases:  &wantReleases,
+			},
+		})
+		require.NoError(t, err)
+
+		snapshot := testutil.TryReceive(ctx, t, fTelemetry.snapshots)
+		require.NotNil(t, snapshot.FirstUserOnboarding)
+		require.NotNil(t, snapshot.FirstUserOnboarding.IsBusiness)
+		require.True(t, *snapshot.FirstUserOnboarding.IsBusiness)
+		require.Equal(t, "Technology", snapshot.FirstUserOnboarding.IndustryType)
+		require.Equal(t, string(codersdk.OrgSizeRangeMedium), snapshot.FirstUserOnboarding.OrgSize)
+		require.NotNil(t, snapshot.FirstUserOnboarding.NewsletterMarketing)
+		require.False(t, *snapshot.FirstUserOnboarding.NewsletterMarketing)
+		require.NotNil(t, snapshot.FirstUserOnboarding.NewsletterReleases)
+		require.True(t, *snapshot.FirstUserOnboarding.NewsletterReleases)
+	})
+
+	t.Run("NilWhenOnboardingInfoOmitted", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitMedium)
+		fTelemetry := newFakeTelemetryReporter(ctx, t, 10)
+		client := coderdtest.New(t, &coderdtest.Options{
+			TelemetryReporter: fTelemetry,
+		})
+
+		_, err := client.CreateFirstUser(ctx, codersdk.CreateFirstUserRequest{
+			Email:    "admin@coder.com",
+			Username: "admin",
+			Password: "SomeSecurePassword!",
+			// No OnboardingInfo — simulates old CLI or OIDC flow.
+		})
+		require.NoError(t, err)
+
+		snapshot := testutil.TryReceive(ctx, t, fTelemetry.snapshots)
+		require.Nil(t, snapshot.FirstUserOnboarding)
+	})
+}
+
 func TestPostLogin(t *testing.T) {
 	t.Parallel()
 	t.Run("InvalidUser", func(t *testing.T) {

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -137,8 +137,8 @@ func TestFirstUser_OnboardingTelemetry(t *testing.T) {
 			Password: "SomeSecurePassword!",
 			OnboardingInfo: &codersdk.CreateFirstUserOnboardingInfo{
 				IsBusiness:          &isBusiness,
-				IndustryType:        "Technology",
-				OrgSize:             codersdk.OrgSizeRangeMedium,
+				IndustryType:        codersdk.IndustryTypeTechnology,
+				OrgSize:             codersdk.OrgSizeRange51To200,
 				NewsletterMarketing: &wantMarketing,
 				NewsletterReleases:  &wantReleases,
 			},
@@ -149,8 +149,8 @@ func TestFirstUser_OnboardingTelemetry(t *testing.T) {
 		require.NotNil(t, snapshot.FirstUserOnboarding)
 		require.NotNil(t, snapshot.FirstUserOnboarding.IsBusiness)
 		require.True(t, *snapshot.FirstUserOnboarding.IsBusiness)
-		require.Equal(t, "Technology", snapshot.FirstUserOnboarding.IndustryType)
-		require.Equal(t, string(codersdk.OrgSizeRangeMedium), snapshot.FirstUserOnboarding.OrgSize)
+		require.Equal(t, string(codersdk.IndustryTypeTechnology), snapshot.FirstUserOnboarding.IndustryType)
+		require.Equal(t, string(codersdk.OrgSizeRange51To200), snapshot.FirstUserOnboarding.OrgSize)
 		require.NotNil(t, snapshot.FirstUserOnboarding.NewsletterMarketing)
 		require.False(t, *snapshot.FirstUserOnboarding.NewsletterMarketing)
 		require.NotNil(t, snapshot.FirstUserOnboarding.NewsletterReleases)

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -177,6 +177,30 @@ func TestFirstUser_OnboardingTelemetry(t *testing.T) {
 		snapshot := testutil.TryReceive(ctx, t, fTelemetry.snapshots)
 		require.Nil(t, snapshot.FirstUserOnboarding)
 	})
+
+	t.Run("EmptyOnboardingInfoIsNonNilWithZeroFields", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitMedium)
+		fTelemetry := newFakeTelemetryReporter(ctx, t, 10)
+		client := coderdtest.New(t, &coderdtest.Options{
+			TelemetryReporter: fTelemetry,
+		})
+		_, err := client.CreateFirstUser(ctx, codersdk.CreateFirstUserRequest{
+			Email: "admin@coder.com", Username: "admin",
+			Password:       "SomeSecurePassword!",
+			OnboardingInfo: &codersdk.CreateFirstUserOnboardingInfo{},
+		})
+		require.NoError(t, err)
+		snapshot := testutil.TryReceive(ctx, t, fTelemetry.snapshots)
+		require.NotNil(t, snapshot.FirstUserOnboarding,
+			"non-nil OnboardingInfo must produce non-nil telemetry")
+		require.Nil(t, snapshot.FirstUserOnboarding.IsBusiness,
+			"nil *bool must stay nil, not become false")
+		require.Nil(t, snapshot.FirstUserOnboarding.NewsletterMarketing)
+		require.Nil(t, snapshot.FirstUserOnboarding.NewsletterReleases)
+		require.Empty(t, snapshot.FirstUserOnboarding.IndustryType)
+		require.Empty(t, snapshot.FirstUserOnboarding.OrgSize)
+	})
 }
 
 func TestPostLogin(t *testing.T) {

--- a/codersdk/users.go
+++ b/codersdk/users.go
@@ -187,8 +187,8 @@ const (
 // from a skipped question, which matters for the telemetry schema.
 type CreateFirstUserOnboardingInfo struct {
 	IsBusiness          *bool        `json:"is_business"`
-	IndustryType        IndustryType `json:"industry_type"`
-	OrgSize             OrgSizeRange `json:"org_size"`
+	IndustryType        IndustryType `json:"industry_type" validate:"omitempty,oneof=Technology 'Financial Services' Healthcare Government Education Retail Manufacturing Media Telecom Energy Transportation Consulting Non-Profit Other"`
+	OrgSize             OrgSizeRange `json:"org_size" validate:"omitempty,oneof='Just me' 2-10 11-50 51-200 201-1000 1001-5000 5000+"`
 	NewsletterMarketing *bool        `json:"newsletter_marketing"`
 	NewsletterReleases  *bool        `json:"newsletter_releases"`
 }

--- a/codersdk/users.go
+++ b/codersdk/users.go
@@ -125,13 +125,13 @@ type LicensorTrialRequest struct {
 }
 
 type CreateFirstUserRequest struct {
-	Email          string                        `json:"email" validate:"required,email"`
-	Username       string                        `json:"username" validate:"required,username"`
-	Name           string                        `json:"name" validate:"user_real_name"`
-	Password       string                        `json:"password" validate:"required"`
-	Trial          bool                          `json:"trial"`
-	TrialInfo      CreateFirstUserTrialInfo      `json:"trial_info"`
-	OnboardingInfo CreateFirstUserOnboardingInfo `json:"onboarding_info"`
+	Email          string                         `json:"email" validate:"required,email"`
+	Username       string                         `json:"username" validate:"required,username"`
+	Name           string                         `json:"name" validate:"user_real_name"`
+	Password       string                         `json:"password" validate:"required"`
+	Trial          bool                           `json:"trial"`
+	TrialInfo      CreateFirstUserTrialInfo       `json:"trial_info"`
+	OnboardingInfo *CreateFirstUserOnboardingInfo `json:"onboarding_info,omitempty"`
 }
 
 type CreateFirstUserTrialInfo struct {
@@ -144,14 +144,32 @@ type CreateFirstUserTrialInfo struct {
 	Developers  string `json:"developers"`
 }
 
+// OrgSizeRange represents a bucketed headcount range for an organization.
+// These values are fixed by agreement with the frontend and the telemetry
+// schema — do not change them without coordinating both sides.
+type OrgSizeRange string
+
+const (
+	OrgSizeRangeSmall  OrgSizeRange = "1-50"
+	OrgSizeRangeMedium OrgSizeRange = "51-200"
+	OrgSizeRangeLarge  OrgSizeRange = "201-2000"
+	OrgSizeRangeXL     OrgSizeRange = "2001+"
+)
+
 // CreateFirstUserOnboardingInfo contains optional demographic and
 // newsletter preference data collected during first user setup.
+// Pointer fields allow an explicit "no" answer to be distinguished
+// from a skipped question, which matters for the telemetry schema.
 type CreateFirstUserOnboardingInfo struct {
-	IsBusiness          bool   `json:"is_business"`
-	IndustryType        string `json:"industry_type"`
-	OrgSize             string `json:"org_size"`
-	NewsletterMarketing bool   `json:"newsletter_marketing"`
-	NewsletterReleases  bool   `json:"newsletter_releases"`
+	IsBusiness *bool `json:"is_business"`
+	// IndustryType is a free-form string supplied by the frontend.
+	// Expected values include "Technology", "Finance", "Healthcare",
+	// "Education", "Government", "Retail", "Media", "Manufacturing",
+	// "Transportation", "Energy", "Other".
+	IndustryType        string       `json:"industry_type"`
+	OrgSize             OrgSizeRange `json:"org_size"`
+	NewsletterMarketing *bool        `json:"newsletter_marketing"`
+	NewsletterReleases  *bool        `json:"newsletter_releases"`
 }
 
 // CreateFirstUserResponse contains IDs for newly created user info.

--- a/codersdk/users.go
+++ b/codersdk/users.go
@@ -125,12 +125,13 @@ type LicensorTrialRequest struct {
 }
 
 type CreateFirstUserRequest struct {
-	Email     string                   `json:"email" validate:"required,email"`
-	Username  string                   `json:"username" validate:"required,username"`
-	Name      string                   `json:"name" validate:"user_real_name"`
-	Password  string                   `json:"password" validate:"required"`
-	Trial     bool                     `json:"trial"`
-	TrialInfo CreateFirstUserTrialInfo `json:"trial_info"`
+	Email          string                        `json:"email" validate:"required,email"`
+	Username       string                        `json:"username" validate:"required,username"`
+	Name           string                        `json:"name" validate:"user_real_name"`
+	Password       string                        `json:"password" validate:"required"`
+	Trial          bool                          `json:"trial"`
+	TrialInfo      CreateFirstUserTrialInfo      `json:"trial_info"`
+	OnboardingInfo CreateFirstUserOnboardingInfo `json:"onboarding_info"`
 }
 
 type CreateFirstUserTrialInfo struct {
@@ -141,6 +142,16 @@ type CreateFirstUserTrialInfo struct {
 	CompanyName string `json:"company_name"`
 	Country     string `json:"country"`
 	Developers  string `json:"developers"`
+}
+
+// CreateFirstUserOnboardingInfo contains optional demographic and
+// newsletter preference data collected during first user setup.
+type CreateFirstUserOnboardingInfo struct {
+	IsBusiness          bool   `json:"is_business"`
+	IndustryType        string `json:"industry_type"`
+	OrgSize             string `json:"org_size"`
+	NewsletterMarketing bool   `json:"newsletter_marketing"`
+	NewsletterReleases  bool   `json:"newsletter_releases"`
 }
 
 // CreateFirstUserResponse contains IDs for newly created user info.

--- a/codersdk/users.go
+++ b/codersdk/users.go
@@ -150,10 +150,35 @@ type CreateFirstUserTrialInfo struct {
 type OrgSizeRange string
 
 const (
-	OrgSizeRangeSmall  OrgSizeRange = "1-50"
-	OrgSizeRangeMedium OrgSizeRange = "51-200"
-	OrgSizeRangeLarge  OrgSizeRange = "201-2000"
-	OrgSizeRangeXL     OrgSizeRange = "2001+"
+	OrgSizeRangeJustMe  OrgSizeRange = "Just me"
+	OrgSizeRange2To10   OrgSizeRange = "2-10"
+	OrgSizeRange11To50  OrgSizeRange = "11-50"
+	OrgSizeRange51To200 OrgSizeRange = "51-200"
+	OrgSizeRange201To1K OrgSizeRange = "201-1000"
+	OrgSizeRange1KTo5K  OrgSizeRange = "1001-5000"
+	OrgSizeRange5KPlus  OrgSizeRange = "5000+"
+)
+
+// IndustryType represents the industry vertical an organization operates in.
+// These values are fixed by agreement with the frontend and the telemetry
+// schema — do not change them without coordinating both sides.
+type IndustryType string
+
+const (
+	IndustryTypeTechnology     IndustryType = "Technology"
+	IndustryTypeFinancial      IndustryType = "Financial Services"
+	IndustryTypeHealthcare     IndustryType = "Healthcare"
+	IndustryTypeGovernment     IndustryType = "Government"
+	IndustryTypeEducation      IndustryType = "Education"
+	IndustryTypeRetail         IndustryType = "Retail"
+	IndustryTypeManufacturing  IndustryType = "Manufacturing"
+	IndustryTypeMedia          IndustryType = "Media"
+	IndustryTypeTelecom        IndustryType = "Telecom"
+	IndustryTypeEnergy         IndustryType = "Energy"
+	IndustryTypeTransportation IndustryType = "Transportation"
+	IndustryTypeConsulting     IndustryType = "Consulting"
+	IndustryTypeNonProfit      IndustryType = "Non-Profit"
+	IndustryTypeOther          IndustryType = "Other"
 )
 
 // CreateFirstUserOnboardingInfo contains optional demographic and
@@ -161,12 +186,8 @@ const (
 // Pointer fields allow an explicit "no" answer to be distinguished
 // from a skipped question, which matters for the telemetry schema.
 type CreateFirstUserOnboardingInfo struct {
-	IsBusiness *bool `json:"is_business"`
-	// IndustryType is a free-form string supplied by the frontend.
-	// Expected values include "Technology", "Finance", "Healthcare",
-	// "Education", "Government", "Retail", "Media", "Manufacturing",
-	// "Transportation", "Energy", "Other".
-	IndustryType        string       `json:"industry_type"`
+	IsBusiness          *bool        `json:"is_business"`
+	IndustryType        IndustryType `json:"industry_type"`
 	OrgSize             OrgSizeRange `json:"org_size"`
 	NewsletterMarketing *bool        `json:"newsletter_marketing"`
 	NewsletterReleases  *bool        `json:"newsletter_releases"`

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -2266,6 +2266,13 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `newsletter_releases`  | boolean                                        | false    |              |             |
 | `org_size`             | [codersdk.OrgSizeRange](#codersdkorgsizerange) | false    |              |             |
 
+#### Enumerated Values
+
+| Property        | Value(s)                                                                                                                                                                                    |
+|-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `industry_type` | `Consulting`, `Education`, `Energy`, `Financial Services`, `Government`, `Healthcare`, `Manufacturing`, `Media`, `Non-Profit`, `Other`, `Retail`, `Technology`, `Telecom`, `Transportation` |
+| `org_size`      | `1001-5000`, `11-50`, `2-10`, `201-1000`, `5000+`, `51-200`, `Just me`                                                                                                                      |
+
 ## codersdk.CreateFirstUserRequest
 
 ```json

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -2248,23 +2248,23 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 ```json
 {
-  "industry_type": "string",
+  "industry_type": "Technology",
   "is_business": true,
   "newsletter_marketing": true,
   "newsletter_releases": true,
-  "org_size": "1-50"
+  "org_size": "Just me"
 }
 ```
 
 ### Properties
 
-| Name                   | Type                                           | Required | Restrictions | Description                                                                                                                                                                                                                      |
-|------------------------|------------------------------------------------|----------|--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `industry_type`        | string                                         | false    |              | Industry type is a free-form string supplied by the frontend. Expected values include "Technology", "Finance", "Healthcare", "Education", "Government", "Retail", "Media", "Manufacturing", "Transportation", "Energy", "Other". |
-| `is_business`          | boolean                                        | false    |              |                                                                                                                                                                                                                                  |
-| `newsletter_marketing` | boolean                                        | false    |              |                                                                                                                                                                                                                                  |
-| `newsletter_releases`  | boolean                                        | false    |              |                                                                                                                                                                                                                                  |
-| `org_size`             | [codersdk.OrgSizeRange](#codersdkorgsizerange) | false    |              |                                                                                                                                                                                                                                  |
+| Name                   | Type                                           | Required | Restrictions | Description |
+|------------------------|------------------------------------------------|----------|--------------|-------------|
+| `industry_type`        | [codersdk.IndustryType](#codersdkindustrytype) | false    |              |             |
+| `is_business`          | boolean                                        | false    |              |             |
+| `newsletter_marketing` | boolean                                        | false    |              |             |
+| `newsletter_releases`  | boolean                                        | false    |              |             |
+| `org_size`             | [codersdk.OrgSizeRange](#codersdkorgsizerange) | false    |              |             |
 
 ## codersdk.CreateFirstUserRequest
 
@@ -2273,11 +2273,11 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
   "email": "string",
   "name": "string",
   "onboarding_info": {
-    "industry_type": "string",
+    "industry_type": "Technology",
     "is_business": true,
     "newsletter_marketing": true,
     "newsletter_releases": true,
-    "org_size": "1-50"
+    "org_size": "Just me"
   },
   "password": "string",
   "trial": true,
@@ -5156,6 +5156,20 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 | `label` | string | false    |              |             |
 | `url`   | string | false    |              |             |
 
+## codersdk.IndustryType
+
+```json
+"Technology"
+```
+
+### Properties
+
+#### Enumerated Values
+
+| Value(s)                                                                                                                                                                                    |
+|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `Consulting`, `Education`, `Energy`, `Financial Services`, `Government`, `Healthcare`, `Manufacturing`, `Media`, `Non-Profit`, `Other`, `Retail`, `Technology`, `Telecom`, `Transportation` |
+
 ## codersdk.InsightsReportInterval
 
 ```json
@@ -6390,16 +6404,16 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 ## codersdk.OrgSizeRange
 
 ```json
-"1-50"
+"Just me"
 ```
 
 ### Properties
 
 #### Enumerated Values
 
-| Value(s)                              |
-|---------------------------------------|
-| `1-50`, `2001+`, `201-2000`, `51-200` |
+| Value(s)                                                               |
+|------------------------------------------------------------------------|
+| `1001-5000`, `11-50`, `2-10`, `201-1000`, `5000+`, `51-200`, `Just me` |
 
 ## codersdk.Organization
 

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -2252,19 +2252,19 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
   "is_business": true,
   "newsletter_marketing": true,
   "newsletter_releases": true,
-  "org_size": "string"
+  "org_size": "1-50"
 }
 ```
 
 ### Properties
 
-| Name                   | Type    | Required | Restrictions | Description |
-|------------------------|---------|----------|--------------|-------------|
-| `industry_type`        | string  | false    |              |             |
-| `is_business`          | boolean | false    |              |             |
-| `newsletter_marketing` | boolean | false    |              |             |
-| `newsletter_releases`  | boolean | false    |              |             |
-| `org_size`             | string  | false    |              |             |
+| Name                   | Type                                           | Required | Restrictions | Description                                                                                                                                                                                                                      |
+|------------------------|------------------------------------------------|----------|--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `industry_type`        | string                                         | false    |              | Industry type is a free-form string supplied by the frontend. Expected values include "Technology", "Finance", "Healthcare", "Education", "Government", "Retail", "Media", "Manufacturing", "Transportation", "Energy", "Other". |
+| `is_business`          | boolean                                        | false    |              |                                                                                                                                                                                                                                  |
+| `newsletter_marketing` | boolean                                        | false    |              |                                                                                                                                                                                                                                  |
+| `newsletter_releases`  | boolean                                        | false    |              |                                                                                                                                                                                                                                  |
+| `org_size`             | [codersdk.OrgSizeRange](#codersdkorgsizerange) | false    |              |                                                                                                                                                                                                                                  |
 
 ## codersdk.CreateFirstUserRequest
 
@@ -2277,7 +2277,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
     "is_business": true,
     "newsletter_marketing": true,
     "newsletter_releases": true,
-    "org_size": "string"
+    "org_size": "1-50"
   },
   "password": "string",
   "trial": true,
@@ -6386,6 +6386,20 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 | Value(s)                                   |
 |--------------------------------------------|
 | `bool`, `list(string)`, `number`, `string` |
+
+## codersdk.OrgSizeRange
+
+```json
+"1-50"
+```
+
+### Properties
+
+#### Enumerated Values
+
+| Value(s)                              |
+|---------------------------------------|
+| `1-50`, `2001+`, `201-2000`, `51-200` |
 
 ## codersdk.Organization
 

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -2244,12 +2244,41 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `password` | string                                   | true     |              |                                          |
 | `to_type`  | [codersdk.LoginType](#codersdklogintype) | true     |              | To type is the login type to convert to. |
 
+## codersdk.CreateFirstUserOnboardingInfo
+
+```json
+{
+  "industry_type": "string",
+  "is_business": true,
+  "newsletter_marketing": true,
+  "newsletter_releases": true,
+  "org_size": "string"
+}
+```
+
+### Properties
+
+| Name                   | Type    | Required | Restrictions | Description |
+|------------------------|---------|----------|--------------|-------------|
+| `industry_type`        | string  | false    |              |             |
+| `is_business`          | boolean | false    |              |             |
+| `newsletter_marketing` | boolean | false    |              |             |
+| `newsletter_releases`  | boolean | false    |              |             |
+| `org_size`             | string  | false    |              |             |
+
 ## codersdk.CreateFirstUserRequest
 
 ```json
 {
   "email": "string",
   "name": "string",
+  "onboarding_info": {
+    "industry_type": "string",
+    "is_business": true,
+    "newsletter_marketing": true,
+    "newsletter_releases": true,
+    "org_size": "string"
+  },
   "password": "string",
   "trial": true,
   "trial_info": {
@@ -2267,14 +2296,15 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 ### Properties
 
-| Name         | Type                                                                   | Required | Restrictions | Description |
-|--------------|------------------------------------------------------------------------|----------|--------------|-------------|
-| `email`      | string                                                                 | true     |              |             |
-| `name`       | string                                                                 | false    |              |             |
-| `password`   | string                                                                 | true     |              |             |
-| `trial`      | boolean                                                                | false    |              |             |
-| `trial_info` | [codersdk.CreateFirstUserTrialInfo](#codersdkcreatefirstusertrialinfo) | false    |              |             |
-| `username`   | string                                                                 | true     |              |             |
+| Name              | Type                                                                             | Required | Restrictions | Description |
+|-------------------|----------------------------------------------------------------------------------|----------|--------------|-------------|
+| `email`           | string                                                                           | true     |              |             |
+| `name`            | string                                                                           | false    |              |             |
+| `onboarding_info` | [codersdk.CreateFirstUserOnboardingInfo](#codersdkcreatefirstuseronboardinginfo) | false    |              |             |
+| `password`        | string                                                                           | true     |              |             |
+| `trial`           | boolean                                                                          | false    |              |             |
+| `trial_info`      | [codersdk.CreateFirstUserTrialInfo](#codersdkcreatefirstusertrialinfo)           | false    |              |             |
+| `username`        | string                                                                           | true     |              |             |
 
 ## codersdk.CreateFirstUserResponse
 

--- a/docs/reference/api/users.md
+++ b/docs/reference/api/users.md
@@ -246,11 +246,11 @@ curl -X POST http://coder-server:8080/api/v2/users/first \
   "email": "string",
   "name": "string",
   "onboarding_info": {
-    "industry_type": "string",
+    "industry_type": "Technology",
     "is_business": true,
     "newsletter_marketing": true,
     "newsletter_releases": true,
-    "org_size": "1-50"
+    "org_size": "Just me"
   },
   "password": "string",
   "trial": true,

--- a/docs/reference/api/users.md
+++ b/docs/reference/api/users.md
@@ -250,7 +250,7 @@ curl -X POST http://coder-server:8080/api/v2/users/first \
     "is_business": true,
     "newsletter_marketing": true,
     "newsletter_releases": true,
-    "org_size": "string"
+    "org_size": "1-50"
   },
   "password": "string",
   "trial": true,

--- a/docs/reference/api/users.md
+++ b/docs/reference/api/users.md
@@ -245,6 +245,13 @@ curl -X POST http://coder-server:8080/api/v2/users/first \
 {
   "email": "string",
   "name": "string",
+  "onboarding_info": {
+    "industry_type": "string",
+    "is_business": true,
+    "newsletter_marketing": true,
+    "newsletter_releases": true,
+    "org_size": "string"
+  },
   "password": "string",
   "trial": true,
   "trial_info": {

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2377,6 +2377,19 @@ export interface CreateChatRequest {
 }
 
 // From codersdk/users.go
+/**
+ * CreateFirstUserOnboardingInfo contains optional demographic and
+ * newsletter preference data collected during first user setup.
+ */
+export interface CreateFirstUserOnboardingInfo {
+	readonly is_business: boolean;
+	readonly industry_type: string;
+	readonly org_size: string;
+	readonly newsletter_marketing: boolean;
+	readonly newsletter_releases: boolean;
+}
+
+// From codersdk/users.go
 export interface CreateFirstUserRequest {
 	readonly email: string;
 	readonly username: string;
@@ -2384,6 +2397,7 @@ export interface CreateFirstUserRequest {
 	readonly password: string;
 	readonly trial: boolean;
 	readonly trial_info: CreateFirstUserTrialInfo;
+	readonly onboarding_info: CreateFirstUserOnboardingInfo;
 }
 
 // From codersdk/users.go

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2385,13 +2385,7 @@ export interface CreateChatRequest {
  */
 export interface CreateFirstUserOnboardingInfo {
 	readonly is_business: boolean | null;
-	/**
-	 * IndustryType is a free-form string supplied by the frontend.
-	 * Expected values include "Technology", "Finance", "Healthcare",
-	 * "Education", "Government", "Retail", "Media", "Manufacturing",
-	 * "Transportation", "Energy", "Other".
-	 */
-	readonly industry_type: string;
+	readonly industry_type: IndustryType;
 	readonly org_size: OrgSizeRange;
 	readonly newsletter_marketing: boolean | null;
 	readonly newsletter_releases: boolean | null;
@@ -3850,6 +3844,40 @@ export const InboxNotificationFallbackIconTemplate = "DEFAULT_ICON_TEMPLATE";
 // From codersdk/inboxnotification.go
 export const InboxNotificationFallbackIconWorkspace = "DEFAULT_ICON_WORKSPACE";
 
+// From codersdk/users.go
+export type IndustryType =
+	| "Consulting"
+	| "Education"
+	| "Energy"
+	| "Financial Services"
+	| "Government"
+	| "Healthcare"
+	| "Manufacturing"
+	| "Media"
+	| "Non-Profit"
+	| "Other"
+	| "Retail"
+	| "Technology"
+	| "Telecom"
+	| "Transportation";
+
+export const IndustryTypes: IndustryType[] = [
+	"Consulting",
+	"Education",
+	"Energy",
+	"Financial Services",
+	"Government",
+	"Healthcare",
+	"Manufacturing",
+	"Media",
+	"Non-Profit",
+	"Other",
+	"Retail",
+	"Technology",
+	"Telecom",
+	"Transportation",
+];
+
 // From codersdk/insights.go
 export type InsightsReportInterval = "day" | "week";
 
@@ -4793,13 +4821,23 @@ export const OptionTypes: OptionType[] = [
 ];
 
 // From codersdk/users.go
-export type OrgSizeRange = "201-2000" | "51-200" | "1-50" | "2001+";
+export type OrgSizeRange =
+	| "11-50"
+	| "1001-5000"
+	| "201-1000"
+	| "2-10"
+	| "51-200"
+	| "5000+"
+	| "Just me";
 
 export const OrgSizeRanges: OrgSizeRange[] = [
-	"201-2000",
+	"11-50",
+	"1001-5000",
+	"201-1000",
+	"2-10",
 	"51-200",
-	"1-50",
-	"2001+",
+	"5000+",
+	"Just me",
 ];
 
 // From codersdk/organizations.go

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2380,13 +2380,21 @@ export interface CreateChatRequest {
 /**
  * CreateFirstUserOnboardingInfo contains optional demographic and
  * newsletter preference data collected during first user setup.
+ * Pointer fields allow an explicit "no" answer to be distinguished
+ * from a skipped question, which matters for the telemetry schema.
  */
 export interface CreateFirstUserOnboardingInfo {
-	readonly is_business: boolean;
+	readonly is_business: boolean | null;
+	/**
+	 * IndustryType is a free-form string supplied by the frontend.
+	 * Expected values include "Technology", "Finance", "Healthcare",
+	 * "Education", "Government", "Retail", "Media", "Manufacturing",
+	 * "Transportation", "Energy", "Other".
+	 */
 	readonly industry_type: string;
-	readonly org_size: string;
-	readonly newsletter_marketing: boolean;
-	readonly newsletter_releases: boolean;
+	readonly org_size: OrgSizeRange;
+	readonly newsletter_marketing: boolean | null;
+	readonly newsletter_releases: boolean | null;
 }
 
 // From codersdk/users.go
@@ -2397,7 +2405,7 @@ export interface CreateFirstUserRequest {
 	readonly password: string;
 	readonly trial: boolean;
 	readonly trial_info: CreateFirstUserTrialInfo;
-	readonly onboarding_info: CreateFirstUserOnboardingInfo;
+	readonly onboarding_info?: CreateFirstUserOnboardingInfo;
 }
 
 // From codersdk/users.go
@@ -4782,6 +4790,16 @@ export const OptionTypes: OptionType[] = [
 	"list(string)",
 	"number",
 	"string",
+];
+
+// From codersdk/users.go
+export type OrgSizeRange = "201-2000" | "51-200" | "1-50" | "2001+";
+
+export const OrgSizeRanges: OrgSizeRange[] = [
+	"201-2000",
+	"51-200",
+	"1-50",
+	"2001+",
 ];
 
 // From codersdk/organizations.go


### PR DESCRIPTION
Add optional demographic and newsletter preference fields to the setup page: business use (yes/no), industry type, organization size, and two newsletter toggles (marketing, release/security updates).

The new data flows through telemetry via a FirstUserOnboarding struct in the snapshot payload, sent once when the first user is created. The telemetry-server and BigQuery schema changes are required separately to persist this data.
