### PR TITLE
fix(site): archive chats when workspace is already deleted

### DIFF
--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -11,7 +11,7 @@ export const chatKey = (chatId: string) => ["chats", chatId] as const;
 export const chatMessagesKey = (chatId: string) =>
 	["chats", chatId, "messages"] as const;
 
-const chatsByWorkspaceKeyPrefix = [...chatsKey, "by-workspace"] as const;
+export const chatsByWorkspaceKeyPrefix = [...chatsKey, "by-workspace"] as const;
 
 export const chatsByWorkspace = (workspaceIds: string[]) => {
 	const sorted = workspaceIds.toSorted();

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -16,6 +16,7 @@ import {
 	chatKey,
 	chatModelConfigs,
 	chatModels,
+	chatsByWorkspaceKeyPrefix,
 	infiniteChats,
 	invalidateChatListQueries,
 	pinChat,
@@ -39,7 +40,7 @@ import { emptyInputStorageKey } from "./components/AgentCreateForm";
 import { useAgentsPageKeybindings } from "./hooks/useAgentsPageKeybindings";
 import { useAgentsPWA } from "./hooks/useAgentsPWA";
 import {
-	isWorkspaceNotFound,
+	archiveAndDeleteWorkspace,
 	resolveArchiveAndDeleteAction,
 	shouldNavigateAfterArchive,
 } from "./utils/agentWorkspaceUtils";
@@ -166,29 +167,28 @@ const AgentsPage: FC = () => {
 		},
 	});
 	const archiveAndDeleteMutation = useMutation({
-		mutationFn: async ({
+		mutationFn: ({
 			chatId,
 			workspaceId,
 		}: {
 			chatId: string;
 			workspaceId: string;
-		}) => {
-			await API.experimental.updateChat(chatId, { archived: true });
-			try {
-				await API.deleteWorkspace(workspaceId);
-			} catch (error) {
-				if (!isWorkspaceNotFound(error)) {
-					throw error;
-				}
-			}
-			return { chatId, workspaceId };
-		},
+		}) =>
+			archiveAndDeleteWorkspace(
+				chatId,
+				workspaceId,
+				(id) => API.experimental.updateChat(id, { archived: true }),
+				(id) => API.deleteWorkspace(id),
+			),
 		onSuccess: async ({ chatId }) => {
 			clearChatErrorReason(chatId);
 			await invalidateChatListQueries(queryClient);
 			await queryClient.invalidateQueries({
 				queryKey: chatKey(chatId),
 				exact: true,
+			});
+			await queryClient.invalidateQueries({
+				queryKey: chatsByWorkspaceKeyPrefix,
 			});
 		},
 		onError: (error) => {
@@ -343,7 +343,7 @@ const AgentsPage: FC = () => {
 				);
 			} else if (action === "archive") {
 				archiveAgentMutation.mutate(chatId, {
-					onSettled: () => {
+					onSuccess: () => {
 						navigateAfterArchive(chatId);
 					},
 				});
@@ -362,19 +362,7 @@ const AgentsPage: FC = () => {
 			archiveAndDeleteMutation.mutate(pendingArchiveAndDelete, {
 				onSettled: () => {
 					setPendingArchiveAndDelete(null);
-					const activeChatId = activeChatIDRef.current;
-					if (
-						shouldNavigateAfterArchive(
-							activeChatId,
-							archivedChatId,
-							activeChatId
-								? queryClient.getQueryData<TypesGen.Chat>(chatKey(activeChatId))
-										?.root_chat_id
-								: undefined,
-						)
-					) {
-						navigate("/agents");
-					}
+					navigateAfterArchive(archivedChatId);
 				},
 			});
 		}

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -39,6 +39,7 @@ import { emptyInputStorageKey } from "./components/AgentCreateForm";
 import { useAgentsPageKeybindings } from "./hooks/useAgentsPageKeybindings";
 import { useAgentsPWA } from "./hooks/useAgentsPWA";
 import {
+	isWorkspaceNotFound,
 	resolveArchiveAndDeleteAction,
 	shouldNavigateAfterArchive,
 } from "./utils/agentWorkspaceUtils";
@@ -173,7 +174,13 @@ const AgentsPage: FC = () => {
 			workspaceId: string;
 		}) => {
 			await API.experimental.updateChat(chatId, { archived: true });
-			await API.deleteWorkspace(workspaceId);
+			try {
+				await API.deleteWorkspace(workspaceId);
+			} catch (error) {
+				if (!isWorkspaceNotFound(error)) {
+					throw error;
+				}
+			}
 			return { chatId, workspaceId };
 		},
 		onSuccess: async ({ chatId }) => {
@@ -330,33 +337,23 @@ const AgentsPage: FC = () => {
 					{ chatId, workspaceId },
 					{
 						onSettled: () => {
-							const activeChatId = activeChatIDRef.current;
-							if (
-								shouldNavigateAfterArchive(
-									activeChatId,
-									chatId,
-									// Read root_chat_id from the per-chat
-									// cache, which survives WebSocket eviction
-									// of sub-agents (only the parent's chatKey
-									// is removed). Must be read at settle time
-									// so it reflects the user's current location.
-									activeChatId
-										? queryClient.getQueryData<TypesGen.Chat>(
-												chatKey(activeChatId),
-											)?.root_chat_id
-										: undefined,
-								)
-							) {
-								navigate("/agents");
-							}
+							navigateAfterArchive(chatId);
 						},
 					},
 				);
+			} else if (action === "archive") {
+				archiveAgentMutation.mutate(chatId, {
+					onSettled: () => {
+						navigateAfterArchive(chatId);
+					},
+				});
 			} else {
 				setPendingArchiveAndDelete({ chatId, workspaceId });
 			}
-		} catch {
-			toast.error("Failed to look up workspace for deletion.");
+		} catch (error) {
+			toast.error(
+				getErrorMessage(error, "Failed to look up workspace for deletion."),
+			);
 		}
 	};
 	const handleConfirmArchiveAndDelete = () => {
@@ -443,6 +440,26 @@ const AgentsPage: FC = () => {
 	// WebSocket handler can read it without re-subscribing on
 	// every navigation.
 	const activeChatIDRef = useRef(agentId);
+	const navigateAfterArchive = (archivedChatId: string) => {
+		const activeChatId = activeChatIDRef.current;
+		if (
+			shouldNavigateAfterArchive(
+				activeChatId,
+				archivedChatId,
+				// Read root_chat_id from the per-chat cache, which
+				// survives WebSocket eviction of sub-agents (only the
+				// parent's chatKey is removed). This must be read at
+				// settle time so it reflects the user's current
+				// location.
+				activeChatId
+					? queryClient.getQueryData<TypesGen.Chat>(chatKey(activeChatId))
+							?.root_chat_id
+					: undefined,
+			)
+		) {
+			navigate("/agents");
+		}
+	};
 	useEffect(() => {
 		activeChatIDRef.current = agentId;
 	});

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -40,7 +40,7 @@ import { emptyInputStorageKey } from "./components/AgentCreateForm";
 import { useAgentsPageKeybindings } from "./hooks/useAgentsPageKeybindings";
 import { useAgentsPWA } from "./hooks/useAgentsPWA";
 import {
-	archiveAndDeleteWorkspace,
+	archiveChatAndDeleteWorkspace,
 	resolveArchiveAndDeleteAction,
 	shouldNavigateAfterArchive,
 } from "./utils/agentWorkspaceUtils";
@@ -174,7 +174,7 @@ const AgentsPage: FC = () => {
 			chatId: string;
 			workspaceId: string;
 		}) =>
-			archiveAndDeleteWorkspace(
+			archiveChatAndDeleteWorkspace(
 				chatId,
 				workspaceId,
 				(id) => API.experimental.updateChat(id, { archived: true }),
@@ -192,7 +192,9 @@ const AgentsPage: FC = () => {
 			});
 		},
 		onError: (error) => {
-			toast.error(getErrorMessage(error, "Failed to archive agent."));
+			toast.error(
+				getErrorMessage(error, "Failed to archive and delete workspace."),
+			);
 		},
 	});
 	const [pendingArchiveChatId, setPendingArchiveChatId] = useState<
@@ -341,12 +343,17 @@ const AgentsPage: FC = () => {
 						},
 					},
 				);
-			} else if (action === "archive") {
+			} else if (action === "archive-only") {
 				// The workspace is already gone (404), so we skip the
 				// running-agent confirmation dialog. That dialog warns
 				// about interrupting a live workspace, which is moot
 				// when the workspace no longer exists.
 				archiveAgentMutation.mutate(chatId, {
+					// Navigate only on success. The proceed/confirm paths
+					// use onSettled because their pre-existing behavior
+					// navigates regardless of delete outcome. This path
+					// has no delete step, so a failed archive should not
+					// redirect the user.
 					onSuccess: () => {
 						navigateAfterArchive(chatId);
 					},
@@ -441,7 +448,7 @@ const AgentsPage: FC = () => {
 				// Read root_chat_id from the per-chat cache, which
 				// survives WebSocket eviction of sub-agents (only the
 				// parent's chatKey is removed). This must be read at
-				// settle time so it reflects the user's current
+				// callback time so it reflects the user's current
 				// location.
 				activeChatId
 					? queryClient.getQueryData<TypesGen.Chat>(chatKey(activeChatId))

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -342,6 +342,10 @@ const AgentsPage: FC = () => {
 					},
 				);
 			} else if (action === "archive") {
+				// The workspace is already gone (404), so we skip the
+				// running-agent confirmation dialog. That dialog warns
+				// about interrupting a live workspace, which is moot
+				// when the workspace no longer exists.
 				archiveAgentMutation.mutate(chatId, {
 					onSuccess: () => {
 						navigateAfterArchive(chatId);

--- a/site/src/pages/AgentsPage/utils/agentWorkspaceUtils.test.ts
+++ b/site/src/pages/AgentsPage/utils/agentWorkspaceUtils.test.ts
@@ -81,6 +81,15 @@ describe("isWorkspaceNotFound", () => {
 		expect(isWorkspaceNotFound(error)).toBe(false);
 	});
 
+	it("returns false for axios errors without a response (network error)", () => {
+		const error = {
+			isAxiosError: true,
+			response: undefined,
+		};
+
+		expect(isWorkspaceNotFound(error)).toBe(false);
+	});
+
 	it("returns false for plain Error objects", () => {
 		expect(isWorkspaceNotFound(new Error("Workspace not found"))).toBe(false);
 	});

--- a/site/src/pages/AgentsPage/utils/agentWorkspaceUtils.test.ts
+++ b/site/src/pages/AgentsPage/utils/agentWorkspaceUtils.test.ts
@@ -45,7 +45,7 @@ describe("isWorkspaceAutoCreated", () => {
 });
 
 describe("isWorkspaceNotFound", () => {
-	it("returns true for Axios-style 404 errors", () => {
+	it("returns true for Axios-style 404 Not Found errors", () => {
 		const error = {
 			isAxiosError: true,
 			response: {
@@ -57,7 +57,19 @@ describe("isWorkspaceNotFound", () => {
 		expect(isWorkspaceNotFound(error)).toBe(true);
 	});
 
-	it("returns false for Axios-style non-404 errors", () => {
+	it("returns true for Axios-style 410 errors", () => {
+		const error = {
+			isAxiosError: true,
+			response: {
+				status: 410,
+				data: { message: "Workspace gone" },
+			},
+		};
+
+		expect(isWorkspaceNotFound(error)).toBe(true);
+	});
+
+	it("returns false for Axios-style non-404-or-410 errors", () => {
 		const error = {
 			isAxiosError: true,
 			response: {
@@ -118,7 +130,26 @@ describe("archiveAndDeleteWorkspace", () => {
 		expect(doDelete).toHaveBeenCalledTimes(1);
 	});
 
-	it("throws when delete returns non-404 error", async () => {
+	it("succeeds when delete returns 410", async () => {
+		const doArchive = vi.fn(async () => undefined);
+		const doDelete = vi.fn(async () => {
+			throw {
+				isAxiosError: true,
+				response: {
+					status: 410,
+					data: { message: "Workspace gone" },
+				},
+			};
+		});
+
+		await expect(
+			archiveAndDeleteWorkspace("chat-1", "workspace-1", doArchive, doDelete),
+		).resolves.toEqual({ chatId: "chat-1", workspaceId: "workspace-1" });
+		expect(doArchive).toHaveBeenCalledTimes(1);
+		expect(doDelete).toHaveBeenCalledTimes(1);
+	});
+
+	it("throws when delete returns non-404-or-410 error", async () => {
 		const doArchive = vi.fn(async () => undefined);
 		const error = {
 			isAxiosError: true,
@@ -181,7 +212,7 @@ describe("resolveArchiveAndDeleteAction", () => {
 		expect(result).toBe(expected);
 	});
 
-	it("propagates non-404 workspace fetch errors", async () => {
+	it("propagates non-404-or-410 workspace fetch errors", async () => {
 		const error = {
 			isAxiosError: true,
 			response: {
@@ -206,6 +237,25 @@ describe("resolveArchiveAndDeleteAction", () => {
 			response: {
 				status: 404,
 				data: { message: "Workspace not found" },
+			},
+		};
+
+		await expect(
+			resolveArchiveAndDeleteAction(
+				async () => {
+					throw error;
+				},
+				() => "2026-01-01T00:00:00Z",
+			),
+		).resolves.toBe("archive");
+	});
+
+	it("returns archive when the workspace fetch returns 410", async () => {
+		const error = {
+			isAxiosError: true,
+			response: {
+				status: 410,
+				data: { message: "Workspace gone" },
 			},
 		};
 

--- a/site/src/pages/AgentsPage/utils/agentWorkspaceUtils.test.ts
+++ b/site/src/pages/AgentsPage/utils/agentWorkspaceUtils.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
+	archiveAndDeleteWorkspace,
 	isWorkspaceAutoCreated,
 	isWorkspaceNotFound,
 	resolveArchiveAndDeleteAction,
@@ -75,6 +76,74 @@ describe("isWorkspaceNotFound", () => {
 	it("returns false for non-error values", () => {
 		expect(isWorkspaceNotFound("nope")).toBe(false);
 		expect(isWorkspaceNotFound(null)).toBe(false);
+	});
+});
+
+describe("archiveAndDeleteWorkspace", () => {
+	it("archives and deletes when both succeed", async () => {
+		const doArchive = vi.fn(async () => undefined);
+		const doDelete = vi.fn(async () => undefined);
+
+		await expect(
+			archiveAndDeleteWorkspace("chat-1", "workspace-1", doArchive, doDelete),
+		).resolves.toEqual({ chatId: "chat-1", workspaceId: "workspace-1" });
+		expect(doArchive).toHaveBeenCalledTimes(1);
+		expect(doArchive).toHaveBeenCalledWith("chat-1");
+		expect(doDelete).toHaveBeenCalledTimes(1);
+		expect(doDelete).toHaveBeenCalledWith("workspace-1");
+	});
+
+	it("succeeds when delete returns 404", async () => {
+		const doArchive = vi.fn(async () => undefined);
+		const doDelete = vi.fn(async () => {
+			throw {
+				isAxiosError: true,
+				response: {
+					status: 404,
+					data: { message: "Workspace not found" },
+				},
+			};
+		});
+
+		await expect(
+			archiveAndDeleteWorkspace("chat-1", "workspace-1", doArchive, doDelete),
+		).resolves.toEqual({ chatId: "chat-1", workspaceId: "workspace-1" });
+		expect(doArchive).toHaveBeenCalledTimes(1);
+		expect(doDelete).toHaveBeenCalledTimes(1);
+	});
+
+	it("throws when delete returns non-404 error", async () => {
+		const doArchive = vi.fn(async () => undefined);
+		const error = {
+			isAxiosError: true,
+			response: {
+				status: 500,
+				data: { message: "Internal server error" },
+			},
+		};
+		const doDelete = vi.fn(async () => {
+			throw error;
+		});
+
+		await expect(
+			archiveAndDeleteWorkspace("chat-1", "workspace-1", doArchive, doDelete),
+		).rejects.toBe(error);
+		expect(doArchive).toHaveBeenCalledTimes(1);
+		expect(doDelete).toHaveBeenCalledTimes(1);
+	});
+
+	it("throws when archive fails without attempting delete", async () => {
+		const error = new Error("archive failed");
+		const doArchive = vi.fn(async () => {
+			throw error;
+		});
+		const doDelete = vi.fn(async () => undefined);
+
+		await expect(
+			archiveAndDeleteWorkspace("chat-1", "workspace-1", doArchive, doDelete),
+		).rejects.toBe(error);
+		expect(doArchive).toHaveBeenCalledTimes(1);
+		expect(doDelete).not.toHaveBeenCalled();
 	});
 });
 

--- a/site/src/pages/AgentsPage/utils/agentWorkspaceUtils.test.ts
+++ b/site/src/pages/AgentsPage/utils/agentWorkspaceUtils.test.ts
@@ -81,8 +81,13 @@ describe("isWorkspaceNotFound", () => {
 
 describe("archiveAndDeleteWorkspace", () => {
 	it("archives and deletes when both succeed", async () => {
-		const doArchive = vi.fn(async () => undefined);
-		const doDelete = vi.fn(async () => undefined);
+		const callOrder: string[] = [];
+		const doArchive = vi.fn(async () => {
+			callOrder.push("archive");
+		});
+		const doDelete = vi.fn(async () => {
+			callOrder.push("delete");
+		});
 
 		await expect(
 			archiveAndDeleteWorkspace("chat-1", "workspace-1", doArchive, doDelete),
@@ -91,6 +96,7 @@ describe("archiveAndDeleteWorkspace", () => {
 		expect(doArchive).toHaveBeenCalledWith("chat-1");
 		expect(doDelete).toHaveBeenCalledTimes(1);
 		expect(doDelete).toHaveBeenCalledWith("workspace-1");
+		expect(callOrder).toEqual(["archive", "delete"]);
 	});
 
 	it("succeeds when delete returns 404", async () => {

--- a/site/src/pages/AgentsPage/utils/agentWorkspaceUtils.test.ts
+++ b/site/src/pages/AgentsPage/utils/agentWorkspaceUtils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
-	archiveAndDeleteWorkspace,
+	archiveChatAndDeleteWorkspace,
 	isWorkspaceAutoCreated,
 	isWorkspaceNotFound,
 	resolveArchiveAndDeleteAction,
@@ -91,7 +91,7 @@ describe("isWorkspaceNotFound", () => {
 	});
 });
 
-describe("archiveAndDeleteWorkspace", () => {
+describe("archiveChatAndDeleteWorkspace", () => {
 	it("archives and deletes when both succeed", async () => {
 		const callOrder: string[] = [];
 		const doArchive = vi.fn(async () => {
@@ -102,7 +102,12 @@ describe("archiveAndDeleteWorkspace", () => {
 		});
 
 		await expect(
-			archiveAndDeleteWorkspace("chat-1", "workspace-1", doArchive, doDelete),
+			archiveChatAndDeleteWorkspace(
+				"chat-1",
+				"workspace-1",
+				doArchive,
+				doDelete,
+			),
 		).resolves.toEqual({ chatId: "chat-1", workspaceId: "workspace-1" });
 		expect(doArchive).toHaveBeenCalledTimes(1);
 		expect(doArchive).toHaveBeenCalledWith("chat-1");
@@ -124,7 +129,12 @@ describe("archiveAndDeleteWorkspace", () => {
 		});
 
 		await expect(
-			archiveAndDeleteWorkspace("chat-1", "workspace-1", doArchive, doDelete),
+			archiveChatAndDeleteWorkspace(
+				"chat-1",
+				"workspace-1",
+				doArchive,
+				doDelete,
+			),
 		).resolves.toEqual({ chatId: "chat-1", workspaceId: "workspace-1" });
 		expect(doArchive).toHaveBeenCalledTimes(1);
 		expect(doDelete).toHaveBeenCalledTimes(1);
@@ -143,7 +153,12 @@ describe("archiveAndDeleteWorkspace", () => {
 		});
 
 		await expect(
-			archiveAndDeleteWorkspace("chat-1", "workspace-1", doArchive, doDelete),
+			archiveChatAndDeleteWorkspace(
+				"chat-1",
+				"workspace-1",
+				doArchive,
+				doDelete,
+			),
 		).resolves.toEqual({ chatId: "chat-1", workspaceId: "workspace-1" });
 		expect(doArchive).toHaveBeenCalledTimes(1);
 		expect(doDelete).toHaveBeenCalledTimes(1);
@@ -163,7 +178,12 @@ describe("archiveAndDeleteWorkspace", () => {
 		});
 
 		await expect(
-			archiveAndDeleteWorkspace("chat-1", "workspace-1", doArchive, doDelete),
+			archiveChatAndDeleteWorkspace(
+				"chat-1",
+				"workspace-1",
+				doArchive,
+				doDelete,
+			),
 		).rejects.toBe(error);
 		expect(doArchive).toHaveBeenCalledTimes(1);
 		expect(doDelete).toHaveBeenCalledTimes(1);
@@ -177,7 +197,12 @@ describe("archiveAndDeleteWorkspace", () => {
 		const doDelete = vi.fn(async () => undefined);
 
 		await expect(
-			archiveAndDeleteWorkspace("chat-1", "workspace-1", doArchive, doDelete),
+			archiveChatAndDeleteWorkspace(
+				"chat-1",
+				"workspace-1",
+				doArchive,
+				doDelete,
+			),
 		).rejects.toBe(error);
 		expect(doArchive).toHaveBeenCalledTimes(1);
 		expect(doDelete).not.toHaveBeenCalled();
@@ -231,7 +256,7 @@ describe("resolveArchiveAndDeleteAction", () => {
 		).rejects.toBe(error);
 	});
 
-	it("returns archive when the workspace fetch returns 404", async () => {
+	it("returns archive-only when the workspace fetch returns 404", async () => {
 		const error = {
 			isAxiosError: true,
 			response: {
@@ -247,10 +272,10 @@ describe("resolveArchiveAndDeleteAction", () => {
 				},
 				() => "2026-01-01T00:00:00Z",
 			),
-		).resolves.toBe("archive");
+		).resolves.toBe("archive-only");
 	});
 
-	it("returns archive when the workspace fetch returns 410", async () => {
+	it("returns archive-only when the workspace fetch returns 410", async () => {
 		const error = {
 			isAxiosError: true,
 			response: {
@@ -266,7 +291,7 @@ describe("resolveArchiveAndDeleteAction", () => {
 				},
 				() => "2026-01-01T00:00:00Z",
 			),
-		).resolves.toBe("archive");
+		).resolves.toBe("archive-only");
 	});
 });
 

--- a/site/src/pages/AgentsPage/utils/agentWorkspaceUtils.test.ts
+++ b/site/src/pages/AgentsPage/utils/agentWorkspaceUtils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
 	isWorkspaceAutoCreated,
+	isWorkspaceNotFound,
 	resolveArchiveAndDeleteAction,
 	shouldNavigateAfterArchive,
 } from "./agentWorkspaceUtils";
@@ -42,6 +43,41 @@ describe("isWorkspaceAutoCreated", () => {
 	});
 });
 
+describe("isWorkspaceNotFound", () => {
+	it("returns true for Axios-style 404 errors", () => {
+		const error = {
+			isAxiosError: true,
+			response: {
+				status: 404,
+				data: { message: "Workspace not found" },
+			},
+		};
+
+		expect(isWorkspaceNotFound(error)).toBe(true);
+	});
+
+	it("returns false for Axios-style non-404 errors", () => {
+		const error = {
+			isAxiosError: true,
+			response: {
+				status: 500,
+				data: { message: "Internal server error" },
+			},
+		};
+
+		expect(isWorkspaceNotFound(error)).toBe(false);
+	});
+
+	it("returns false for plain Error objects", () => {
+		expect(isWorkspaceNotFound(new Error("Workspace not found"))).toBe(false);
+	});
+
+	it("returns false for non-error values", () => {
+		expect(isWorkspaceNotFound("nope")).toBe(false);
+		expect(isWorkspaceNotFound(null)).toBe(false);
+	});
+});
+
 describe("resolveArchiveAndDeleteAction", () => {
 	it.each([
 		{
@@ -70,15 +106,42 @@ describe("resolveArchiveAndDeleteAction", () => {
 		expect(result).toBe(expected);
 	});
 
-	it("propagates workspace fetch errors", async () => {
+	it("propagates non-404 workspace fetch errors", async () => {
+		const error = {
+			isAxiosError: true,
+			response: {
+				status: 500,
+				data: { message: "Internal server error" },
+			},
+		};
+
 		await expect(
 			resolveArchiveAndDeleteAction(
 				async () => {
-					throw new Error("not found");
+					throw error;
 				},
 				() => "2026-01-01T00:00:00Z",
 			),
-		).rejects.toThrow("not found");
+		).rejects.toBe(error);
+	});
+
+	it("returns archive when the workspace fetch returns 404", async () => {
+		const error = {
+			isAxiosError: true,
+			response: {
+				status: 404,
+				data: { message: "Workspace not found" },
+			},
+		};
+
+		await expect(
+			resolveArchiveAndDeleteAction(
+				async () => {
+					throw error;
+				},
+				() => "2026-01-01T00:00:00Z",
+			),
+		).resolves.toBe("archive");
 	});
 });
 

--- a/site/src/pages/AgentsPage/utils/agentWorkspaceUtils.ts
+++ b/site/src/pages/AgentsPage/utils/agentWorkspaceUtils.ts
@@ -15,23 +15,27 @@ export function isWorkspaceAutoCreated(
 }
 
 /**
- * Detects whether an error indicates a missing workspace (HTTP 404).
+ * Detects whether an error indicates a missing or deleted workspace.
  *
- * The Coder backend returns 404 for both genuinely deleted resources
- * and unauthorized access to avoid leaking resource existence. In the
- * archive-and-delete flow this is acceptable: the workspace ID comes
- * from the chat's own metadata, so if the user can see the chat they
- * almost certainly had access to the workspace. Treating an auth 404
- * as "already gone" is a safe degradation because the user cannot
- * delete a workspace they lack access to anyway.
+ * The Coder backend returns 404 when a workspace does not exist or
+ * the user lacks access (to avoid leaking resource existence), and
+ * 410 Gone when a workspace has been soft-deleted. Both cases mean
+ * the workspace is unavailable for deletion.
+ *
+ * In the archive-and-delete flow this is acceptable: the workspace
+ * ID comes from the chat's own metadata, so if the user can see the
+ * chat they almost certainly had access to the workspace. Treating
+ * an auth 404 as "already gone" is a safe degradation because the
+ * user cannot delete a workspace they lack access to anyway.
  */
 export function isWorkspaceNotFound(error: unknown): boolean {
-	return isAxiosError(error) && error.response?.status === 404;
+	const status = isAxiosError(error) ? error.response?.status : undefined;
+	return status === 404 || status === 410;
 }
 
 /**
  * Archives a chat and then deletes its associated workspace.
- * If the workspace is already gone (404), the delete step is
+ * If the workspace is already gone (404 or 410), the delete step is
  * treated as a no-op so the archive still succeeds.
  */
 export async function archiveAndDeleteWorkspace(

--- a/site/src/pages/AgentsPage/utils/agentWorkspaceUtils.ts
+++ b/site/src/pages/AgentsPage/utils/agentWorkspaceUtils.ts
@@ -38,7 +38,7 @@ export function isWorkspaceNotFound(error: unknown): boolean {
  * If the workspace is already gone (404 or 410), the delete step is
  * treated as a no-op so the archive still succeeds.
  */
-export async function archiveAndDeleteWorkspace(
+export async function archiveChatAndDeleteWorkspace(
 	chatId: string,
 	workspaceId: string,
 	doArchive: (chatId: string) => Promise<unknown>,
@@ -88,20 +88,20 @@ export function shouldNavigateAfterArchive(
  *   `created_at`.
  * @param getChatCreatedAt - Returns the chat's `created_at`
  *   timestamp, or `undefined` if the chat is not in the cache.
- * @returns `"proceed"` to skip the dialog, `"archive"` to archive
+ * @returns `"proceed"` to skip the dialog, `"archive-only"` to archive
  *   without deleting because the workspace is already gone, or
  *   `"confirm"` to show the dialog.
  */
 export async function resolveArchiveAndDeleteAction(
 	fetchWorkspace: () => Promise<{ created_at: string }>,
 	getChatCreatedAt: () => string | undefined,
-): Promise<"proceed" | "confirm" | "archive"> {
+): Promise<"proceed" | "confirm" | "archive-only"> {
 	let workspace: { created_at: string };
 	try {
 		workspace = await fetchWorkspace();
 	} catch (error) {
 		if (isWorkspaceNotFound(error)) {
-			return "archive";
+			return "archive-only";
 		}
 		throw error;
 	}

--- a/site/src/pages/AgentsPage/utils/agentWorkspaceUtils.ts
+++ b/site/src/pages/AgentsPage/utils/agentWorkspaceUtils.ts
@@ -1,3 +1,5 @@
+import { isAxiosError } from "axios";
+
 /**
  * Determines whether a workspace was auto-created by a chat.
  * Workspaces created at or after the chat's creation time are
@@ -10,6 +12,10 @@ export function isWorkspaceAutoCreated(
 	chatCreatedAt: string,
 ): boolean {
 	return new Date(workspaceCreatedAt) >= new Date(chatCreatedAt);
+}
+
+export function isWorkspaceNotFound(error: unknown): boolean {
+	return isAxiosError(error) && error.response?.status === 404;
 }
 
 /**
@@ -45,13 +51,23 @@ export function shouldNavigateAfterArchive(
  *   `created_at`.
  * @param getChatCreatedAt - Returns the chat's `created_at`
  *   timestamp, or `undefined` if the chat is not in the cache.
- * @returns `"proceed"` to skip the dialog, `"confirm"` to show it.
+ * @returns `"proceed"` to skip the dialog, `"archive"` to archive
+ *   without deleting because the workspace is already gone, or
+ *   `"confirm"` to show the dialog.
  */
 export async function resolveArchiveAndDeleteAction(
 	fetchWorkspace: () => Promise<{ created_at: string }>,
 	getChatCreatedAt: () => string | undefined,
-): Promise<"proceed" | "confirm"> {
-	const workspace = await fetchWorkspace();
+): Promise<"proceed" | "confirm" | "archive"> {
+	let workspace: { created_at: string };
+	try {
+		workspace = await fetchWorkspace();
+	} catch (error) {
+		if (isWorkspaceNotFound(error)) {
+			return "archive";
+		}
+		throw error;
+	}
 	const chatCreatedAt = getChatCreatedAt();
 	if (
 		chatCreatedAt &&

--- a/site/src/pages/AgentsPage/utils/agentWorkspaceUtils.ts
+++ b/site/src/pages/AgentsPage/utils/agentWorkspaceUtils.ts
@@ -14,8 +14,41 @@ export function isWorkspaceAutoCreated(
 	return new Date(workspaceCreatedAt) >= new Date(chatCreatedAt);
 }
 
+/**
+ * Detects whether an error indicates a missing workspace (HTTP 404).
+ *
+ * The Coder backend returns 404 for both genuinely deleted resources
+ * and unauthorized access to avoid leaking resource existence. In the
+ * archive-and-delete flow this is acceptable: the workspace ID comes
+ * from the chat's own metadata, so if the user can see the chat they
+ * almost certainly had access to the workspace. Treating an auth 404
+ * as "already gone" is a safe degradation because the user cannot
+ * delete a workspace they lack access to anyway.
+ */
 export function isWorkspaceNotFound(error: unknown): boolean {
 	return isAxiosError(error) && error.response?.status === 404;
+}
+
+/**
+ * Archives a chat and then deletes its associated workspace.
+ * If the workspace is already gone (404), the delete step is
+ * treated as a no-op so the archive still succeeds.
+ */
+export async function archiveAndDeleteWorkspace(
+	chatId: string,
+	workspaceId: string,
+	doArchive: (chatId: string) => Promise<unknown>,
+	doDelete: (workspaceId: string) => Promise<unknown>,
+): Promise<{ chatId: string; workspaceId: string }> {
+	await doArchive(chatId);
+	try {
+		await doDelete(workspaceId);
+	} catch (error) {
+		if (!isWorkspaceNotFound(error)) {
+			throw error;
+		}
+	}
+	return { chatId, workspaceId };
 }
 
 /**


### PR DESCRIPTION
When a user tries to archive-and-delete a chat from /agents but the workspace is already gone, the UI showed a "Failed to look up workspace for deletion" toast and blocked the archive. This change detects the workspace-gone response and archives the chat without attempting deletion.

## Changes

The backend returns 410 Gone for soft-deleted workspaces and 404 for workspaces that do not exist or the user cannot access. `isWorkspaceNotFound()` detects both status codes.

`resolveArchiveAndDeleteAction()` now returns `"archive"` when the workspace preflight fetch gets a 404 or 410, and the page branches on that action to call the existing archive mutation directly. The `archiveAndDeleteMutation` also tolerates these status codes from `deleteWorkspace()` to handle the race where the workspace disappears between the preflight lookup and the actual delete call.

The mutation body was extracted into a testable `archiveAndDeleteWorkspace()` utility so the tolerance logic has direct test coverage. A `navigateAfterArchive()` helper consolidates the post-archive redirect logic that was previously duplicated across the proceed, confirm, and archive paths.

## Pre-existing patterns preserved

- The `"proceed"` and `"confirm"` archive-and-delete paths use `onSettled` for navigation, matching the existing behavior before this change. Only the new `"archive"` path uses `onSuccess` since it has no workspace deletion step that should still navigate on partial failure.
- `isWorkspaceNotFound()` uses the same `isAxiosError(error) && error.response?.status` pattern already used in several places in `site/src/api/api.ts`. The backend 404 ambiguity (deleted vs unauthorized) is documented in the JSDoc.
- The pre-existing double-submit race during the async preflight window is unchanged.