### PR TITLE
fix(site): prevent chat messages from disappearing and duplicating

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -616,11 +616,17 @@ const AgentChatPage: FC = () => {
 	const chatMessagesList = (() => {
 		const pages = chatMessagesQuery.data?.pages;
 		if (!pages || pages.length === 0) return undefined;
-		// Collect all messages, then sort chronologically by ID.
+		// Collect all messages and deduplicate by ID.
+		// Cross-page duplication can occur when upsertCacheMessages
+		// writes a message into page 0 while the same ID still
+		// exists in a later page. Last occurrence wins so the
+		// most up-to-date content is preserved.
 		const all = pages.flatMap((p) => p.messages);
+		const byID = new Map(all.map((m) => [m.id, m]));
+		const deduped = Array.from(byID.values());
 		// Sort ascending by ID for chronological order.
-		all.sort((a, b) => a.id - b.id);
-		return all;
+		deduped.sort((a, b) => a.id - b.id);
+		return deduped;
 	})();
 
 	// Queued messages are only in the first page (most recent).

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -654,7 +654,7 @@ const AgentChatPage: FC = () => {
 		promoteChatQueuedMessage(queryClient, agentId ?? ""),
 	);
 
-	const { store, clearStreamError } = useChatStore({
+	const { store, clearStreamError, upsertCacheMessages } = useChatStore({
 		chatID: agentId,
 		chatMessages: chatMessagesList,
 		chatRecord,
@@ -891,6 +891,7 @@ const AgentChatPage: FC = () => {
 			store.setChatStatus("running");
 			if (response.message) {
 				store.upsertDurableMessage(response.message);
+				upsertCacheMessages([response.message]);
 			}
 		}
 		if (selectedModelConfigID) {
@@ -935,10 +936,11 @@ const AgentChatPage: FC = () => {
 		store.setChatStatus("pending");
 		try {
 			const promotedMessage = await promoteQueuedMutation.mutateAsync(id);
-			// Insert the promoted message into the store immediately
-			// so it appears in the timeline without waiting for the
-			// WebSocket to deliver it.
+			// Insert the promoted message into the store and cache
+			// immediately so it appears in the timeline without
+			// waiting for the WebSocket to deliver it.
 			store.upsertDurableMessage(promotedMessage);
+			upsertCacheMessages([promotedMessage]);
 		} catch (error) {
 			store.setQueuedMessages(previousQueuedMessages);
 			store.setChatStatus(previousChatStatus);

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.createStore.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.createStore.test.ts
@@ -701,3 +701,21 @@ describe("selectIsAwaitingFirstStreamChunk", () => {
 		expect(selectIsAwaitingFirstStreamChunk(store.getSnapshot())).toBe(true);
 	});
 });
+
+describe("duplicate message deduplication", () => {
+	it("replaceMessages deduplicates orderedMessageIDs when input has duplicate IDs", () => {
+		const store = createChatStore();
+		const msg1 = makeMessage(1, "user", "hello");
+		const msg2 = makeMessage(2, "assistant", "hi");
+		// Simulate cross-page duplication: same ID appears twice.
+		const msg2Copy = makeMessage(2, "assistant", "hi");
+
+		store.replaceMessages([msg1, msg2, msg2Copy]);
+
+		const state = store.getSnapshot();
+		// Map deduplicates by key — only 2 unique entries.
+		expect(state.messagesByID.size).toBe(2);
+		// orderedMessageIDs MUST also have only 2 entries.
+		expect(state.orderedMessageIDs).toEqual([1, 2]);
+	});
+});

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -4033,3 +4033,178 @@ describe("partsBuf cleanup on reconnect (Bug 2)", () => {
 		});
 	});
 });
+
+describe("store/cache desync protection", () => {
+	it("does not wipe a message added via upsertDurableMessage when a genuine refetch follows", async () => {
+		// RED TEST: Simulates what handleSend does today — it calls
+		// store.upsertDurableMessage without writing to the React
+		// Query cache. A subsequent rerender with new message refs
+		// (genuine refetch) should NOT wipe the store-only message.
+		immediateAnimationFrame();
+
+		const chatID = "chat-send-desync";
+		const msg1 = makeMessage(chatID, 1, "user", "hello");
+		const msg2 = makeMessage(chatID, 2, "assistant", "hi");
+		const msg3 = makeMessage(chatID, 3, "user", "follow-up");
+
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createTestQueryClient();
+		queryClient.setQueryData(chatMessagesKey(chatID), {
+			pages: [
+				{
+					messages: [msg2, msg1],
+					queued_messages: [],
+					has_more: false,
+				},
+			],
+			pageParams: [undefined],
+		});
+		const wrapper: FC<PropsWithChildren> = ({ children }) => (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+
+		const initialMessages = [msg1, msg2];
+		const initialOptions = {
+			chatID,
+			chatMessages: initialMessages,
+			chatRecord: makeChat(chatID),
+			chatMessagesData: {
+				messages: initialMessages,
+				queued_messages: [],
+				has_more: false,
+			},
+			chatQueuedMessages: [] as TypesGen.ChatQueuedMessage[],
+			setChatErrorReason: vi.fn(),
+			clearChatErrorReason: vi.fn(),
+		};
+
+		const { result, rerender } = renderHook(
+			(options: Parameters<typeof useChatStore>[0]) => {
+				const { store } = useChatStore(options);
+				return {
+					orderedMessageIDs: useChatSelector(store, selectOrderedMessageIDs),
+					store,
+				};
+			},
+			{ initialProps: initialOptions, wrapper },
+		);
+
+		await waitFor(() => {
+			expect(result.current.orderedMessageIDs).toEqual([1, 2]);
+		});
+
+		act(() => {
+			mockSocket.emitOpen();
+		});
+
+		// Simulate handleSend: write to store only, no cache write.
+		act(() => {
+			result.current.store.upsertDurableMessage(msg3);
+		});
+
+		await waitFor(() => {
+			expect(result.current.orderedMessageIDs).toEqual([1, 2, 3]);
+		});
+
+		// Genuine refetch: new object refs for msg1 and msg2,
+		// msg3 absent from the fetched set.
+		const msg1New = makeMessage(chatID, 1, "user", "hello");
+		const msg2New = makeMessage(chatID, 2, "assistant", "hi");
+		rerender({
+			...initialOptions,
+			chatMessages: [msg1New, msg2New],
+			chatMessagesData: {
+				messages: [msg1New, msg2New],
+				queued_messages: [],
+				has_more: false,
+			},
+		});
+
+		// msg3 was added to the store AFTER the last sync. It
+		// should NOT be classified as stale — it's new, not
+		// something the server removed.
+		await waitFor(() => {
+			expect(result.current.orderedMessageIDs).toEqual([1, 2, 3]);
+		});
+	});
+
+	it("still removes messages that were in the previous sync but are absent from a refetch (edit truncation)", async () => {
+		immediateAnimationFrame();
+
+		const chatID = "chat-edit-truncation";
+		const msg1 = makeMessage(chatID, 1, "user", "hello");
+		const msg2 = makeMessage(chatID, 2, "assistant", "hi");
+		const msg3 = makeMessage(chatID, 3, "user", "more");
+
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createTestQueryClient();
+		queryClient.setQueryData(chatMessagesKey(chatID), {
+			pages: [
+				{
+					messages: [msg3, msg2, msg1],
+					queued_messages: [],
+					has_more: false,
+				},
+			],
+			pageParams: [undefined],
+		});
+		const wrapper: FC<PropsWithChildren> = ({ children }) => (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+
+		const initialOptions = {
+			chatID,
+			chatMessages: [msg1, msg2, msg3],
+			chatRecord: makeChat(chatID),
+			chatMessagesData: {
+				messages: [msg1, msg2, msg3],
+				queued_messages: [],
+				has_more: false,
+			},
+			chatQueuedMessages: [] as TypesGen.ChatQueuedMessage[],
+			setChatErrorReason: vi.fn(),
+			clearChatErrorReason: vi.fn(),
+		};
+
+		const { result, rerender } = renderHook(
+			(options: Parameters<typeof useChatStore>[0]) => {
+				const { store } = useChatStore(options);
+				return {
+					orderedMessageIDs: useChatSelector(store, selectOrderedMessageIDs),
+				};
+			},
+			{ initialProps: initialOptions, wrapper },
+		);
+
+		await waitFor(() => {
+			expect(result.current.orderedMessageIDs).toEqual([1, 2, 3]);
+		});
+
+		act(() => {
+			mockSocket.emitOpen();
+		});
+
+		// Simulate edit truncation: rerender with only msg1.
+		const msg1New = makeMessage(chatID, 1, "user", "hello");
+		rerender({
+			...initialOptions,
+			chatMessages: [msg1New],
+			chatMessagesData: {
+				messages: [msg1New],
+				queued_messages: [],
+				has_more: false,
+			},
+		});
+
+		// msg2 and msg3 WERE in the previous sync data and are
+		// now absent — they are genuinely stale (edit truncation)
+		// and should be removed.
+		await waitFor(() => {
+			expect(result.current.orderedMessageIDs).toEqual([1]);
+		});
+	});
+});

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.ts
@@ -26,7 +26,19 @@ const buildOrderedMessageIDs = (
 ): readonly number[] => {
 	const sorted = [...messages];
 	sorted.sort(byMessageCreatedAt);
-	return sorted.map((message) => message.id);
+	// Deduplicate by ID. The input can contain duplicate IDs when
+	// cross-page duplication occurs in the React Query cache (e.g.
+	// upsertCacheMessages writes to page 0 while the same message
+	// still exists in a later page). The Map-based messagesByID
+	// already deduplicates, but orderedMessageIDs must match.
+	const seen = new Set<number>();
+	return sorted
+		.map((message) => message.id)
+		.filter((id) => {
+			if (seen.has(id)) return false;
+			seen.add(id);
+			return true;
+		});
 };
 
 const mapsEqualByRef = <K, V>(left: Map<K, V>, right: Map<K, V>): boolean => {

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -81,7 +81,11 @@ interface UseChatStoreOptions {
 
 export const useChatStore = (
 	options: UseChatStoreOptions,
-): { store: ChatStore; clearStreamError: () => void } => {
+): {
+	store: ChatStore;
+	clearStreamError: () => void;
+	upsertCacheMessages: (messages: readonly TypesGen.ChatMessage[]) => void;
+} => {
 	const {
 		chatID,
 		chatMessages,
@@ -150,6 +154,56 @@ export const useChatStore = (
 	// its snapshot, defeating pagination.
 	const initialDataLoaded = chatMessages !== undefined;
 
+	// Write WebSocket-delivered durable messages into the React
+	// Query infinite cache so that navigating away and back
+	// serves up-to-date data instead of the stale REST snapshot.
+	// Without this, the cache only contains messages from the
+	// last REST fetch, and structural sharing can suppress the
+	// refetch-driven store update when no new durable messages
+	// have been committed to the DB yet.
+	const upsertCacheMessages = useEffectEvent(
+		(messages: readonly TypesGen.ChatMessage[]) => {
+			if (!chatID || messages.length === 0) {
+				return;
+			}
+			queryClient.setQueryData<
+				InfiniteData<TypesGen.ChatMessagesResponse> | undefined
+			>(chatMessagesKey(chatID), (currentData) => {
+				if (!currentData?.pages?.length) {
+					return currentData;
+				}
+				const firstPage = currentData.pages[0];
+				const existingByID = new Map(firstPage.messages.map((m) => [m.id, m]));
+
+				let changed = false;
+				for (const msg of messages) {
+					const existing = existingByID.get(msg.id);
+					if (!existing || !chatMessagesEqualByValue(existing, msg)) {
+						changed = true;
+						existingByID.set(msg.id, msg);
+					}
+				}
+
+				if (!changed) {
+					return currentData;
+				}
+
+				// Sort descending to match the API page order
+				// (newest first).
+				const updatedMessages = Array.from(existingByID.values());
+				updatedMessages.sort((a, b) => b.id - a.id);
+
+				return {
+					...currentData,
+					pages: [
+						{ ...firstPage, messages: updatedMessages },
+						...currentData.pages.slice(1),
+					],
+				};
+			});
+		},
+	);
+
 	useEffect(() => {
 		store.batch(() => {
 			// When the active chat changes, clear stale messages
@@ -180,9 +234,18 @@ export const useChatStore = (
 
 				const storeSnap = store.getSnapshot();
 				const fetchedIDs = new Set(chatMessages.map((m) => m.id));
+				// Only classify a store-held ID as stale if it was
+				// present in the PREVIOUS sync's fetched data. IDs
+				// added to the store after the last sync (by the WS
+				// handler or handleSend) are new, not stale, and
+				// must not trigger the destructive replaceMessages
+				// path.
+				const prevIDs = new Set(prev.map((m) => m.id));
 				const hasStaleEntries =
 					contentChanged &&
-					storeSnap.orderedMessageIDs.some((id) => !fetchedIDs.has(id));
+					storeSnap.orderedMessageIDs.some(
+						(id) => !fetchedIDs.has(id) && prevIDs.has(id),
+					);
 				if (hasStaleEntries) {
 					store.replaceMessages(chatMessages);
 				} else {
@@ -280,54 +343,6 @@ export const useChatStore = (
 					...currentData,
 					pages: [
 						{ ...firstPage, queued_messages: nextQueuedMessages },
-						...currentData.pages.slice(1),
-					],
-				};
-			});
-		};
-
-		// Write WebSocket-delivered durable messages into the React
-		// Query infinite cache so that navigating away and back
-		// serves up-to-date data instead of the stale REST snapshot.
-		// Without this, the cache only contains messages from the
-		// last REST fetch, and structural sharing can suppress the
-		// refetch-driven store update when no new durable messages
-		// have been committed to the DB yet.
-		const upsertCacheMessages = (messages: readonly TypesGen.ChatMessage[]) => {
-			if (!chatID || messages.length === 0) {
-				return;
-			}
-			queryClient.setQueryData<
-				InfiniteData<TypesGen.ChatMessagesResponse> | undefined
-			>(chatMessagesKey(chatID), (currentData) => {
-				if (!currentData?.pages?.length) {
-					return currentData;
-				}
-				const firstPage = currentData.pages[0];
-				const existingByID = new Map(firstPage.messages.map((m) => [m.id, m]));
-
-				let changed = false;
-				for (const msg of messages) {
-					const existing = existingByID.get(msg.id);
-					if (!existing || !chatMessagesEqualByValue(existing, msg)) {
-						changed = true;
-						existingByID.set(msg.id, msg);
-					}
-				}
-
-				if (!changed) {
-					return currentData;
-				}
-
-				// Sort descending to match the API page order
-				// (newest first).
-				const updatedMessages = Array.from(existingByID.values());
-				updatedMessages.sort((a, b) => b.id - a.id);
-
-				return {
-					...currentData,
-					pages: [
-						{ ...firstPage, messages: updatedMessages },
 						...currentData.pages.slice(1),
 					],
 				};
@@ -652,11 +667,13 @@ export const useChatStore = (
 		store,
 		setChatErrorReasonStable,
 		clearChatErrorReasonStable,
+		upsertCacheMessages,
 	]);
 	return {
 		store,
 		clearStreamError: () => {
 			store.clearStreamError();
 		},
+		upsertCacheMessages,
 	};
 };

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -67,7 +67,17 @@ export const ChatPageTimeline: FC<ChatPageTimelineProps> = ({
 	const orderedMessageIDs = useChatSelector(store, selectOrderedMessageIDs);
 
 	const messages = orderedMessageIDs
-		.map((messageID) => messagesByID.get(messageID))
+		.map((messageID) => {
+			const message = messagesByID.get(messageID);
+			if (!message && process.env.NODE_ENV !== "production") {
+				console.warn(
+					`[ChatPageContent] orderedMessageIDs contains ID ${messageID} ` +
+						"not found in messagesByID. This may indicate a store/cache " +
+						"desync bug.",
+				);
+			}
+			return message;
+		})
 		.filter(isChatMessage);
 	const parsedMessages = parseMessagesWithMergedTools(messages);
 	const subagentTitles = buildSubagentTitles(parsedMessages);
@@ -205,7 +215,17 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 	const queuedMessages = useChatSelector(store, selectQueuedMessages);
 
 	const messages = orderedMessageIDs
-		.map((messageID) => messagesByID.get(messageID))
+		.map((messageID) => {
+			const message = messagesByID.get(messageID);
+			if (!message && process.env.NODE_ENV !== "production") {
+				console.warn(
+					`[ChatPageContent] orderedMessageIDs contains ID ${messageID} ` +
+						"not found in messagesByID. This may indicate a store/cache " +
+						"desync bug.",
+				);
+			}
+			return message;
+		})
 		.filter(isChatMessage);
 	let lastEditableUserMessage: TypesGen.ChatMessage | undefined;
 	for (let index = orderedMessageIDs.length - 1; index >= 0; index--) {


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

Fixes two bugs where agent chat messages could disappear or render twice.

## Bug 1: Message disappearing until page reload

The sync effect's `hasStaleEntries` heuristic treated any store-held message ID absent from the REST-fetched set as stale, triggering the destructive `replaceMessages` path. This was correct for edit truncation (server removed the message) but wrong for messages added to the store by `handleSend`/`handlePromoteQueuedMessage` or the WS handler between syncs — those are new, not stale.

**Core fix:** Add a `prevIDs` guard so only IDs from the *previous* sync's data are classified as stale:

```ts
const prevIDs = new Set(prev.map((m) => m.id));
const hasStaleEntries = contentChanged &&
  storeSnap.orderedMessageIDs.some(
    (id) => !fetchedIDs.has(id) && prevIDs.has(id),
  );
```

**Belt-and-suspenders:** Extract `upsertCacheMessages` from the WebSocket `useEffect` closure (wrapped in `useEffectEvent` for stable identity) and call it alongside `upsertDurableMessage` in `handleSend` and `handlePromoteQueuedMessage`.

**Diagnostic:** Dev-mode `console.warn` in `ChatPageContent` when `orderedMessageIDs` contains an ID missing from `messagesByID`.

## Bug 2: Duplicate messages in timeline

Two vectors:

1. `chatMessagesList`'s `flatMap` across infinite query pages had no dedup. When `upsertCacheMessages` wrote a message into page 0 that also existed in a later page, `flatMap` produced two copies.

2. `buildOrderedMessageIDs` took raw input without dedup, so duplicate IDs from vector 1 flowed into `orderedMessageIDs` and rendered twice with the same React key.

**Fixes:**
- `chatMessagesList` IIFE: deduplicate via `Map` before sorting.
- `buildOrderedMessageIDs`: filter via `Set` so duplicate IDs are dropped.

## TDD cycles

| Test | Red | Green |
|------|-----|-------|
| `upsertDurableMessage` without cache write, genuine refetch follows — asserts message survives | ✗ message wiped by `hasStaleEntries` | ✓ `prevIDs.has(id)` guard excludes new IDs |
| Edit truncation still removes stale messages | ✓ (already worked) | ✓ (no regression) |
| `replaceMessages` with duplicate input — asserts `orderedMessageIDs` has no dupes | ✗ got `[1, 2, 2]` | ✓ `Set`-based filter in `buildOrderedMessageIDs` |

<details><summary>Investigation notes</summary>

### Disappearing messages — root cause

The chat store has one destructive code path — `replaceMessages` — guarded by `contentChanged && hasStaleEntries`. Before this fix, `hasStaleEntries` checked `storeSnap.orderedMessageIDs.some(id => !fetchedIDs.has(id))`. This couldn't distinguish:
- **New IDs:** added to the store since the last sync (by WS handler or handleSend) — should be preserved.
- **Stale IDs:** present in the last sync but removed by the server (edit truncation) — should be wiped.

The fix uses `lastSyncedMessagesRef` (already existed) to build a `prevIDs` set, so only IDs from the previous sync are candidates for staleness.

### Duplicate messages — root cause

`upsertCacheMessages` only operates on `pages[0]` of the infinite query cache. If a WS-delivered message already exists in a later page, it gets added to page 0 while remaining in the later page. `chatMessagesList`'s `flatMap` then produces two copies. `buildOrderedMessageIDs` passed the raw array through without dedup, so `orderedMessageIDs` contained the ID twice. `ChatPageContent` mapped both entries to the same message object and rendered both with the same React key.

### Why also wire `upsertCacheMessages` to callers

The `prevIDs` fix protects at the mechanism level. The `upsertCacheMessages` wiring is belt-and-suspenders: it ensures the React Query cache reflects store-only messages for navigation (going away and back), and makes the `contentChanged` guard more effective since the cache includes the message.

</details>