### PR TITLE
fix: remove double bottom border on build logs table

### DIFF
--- a/site/src/modules/workspaces/WorkspaceBuildLogs/WorkspaceBuildLogs.tsx
+++ b/site/src/modules/workspaces/WorkspaceBuildLogs/WorkspaceBuildLogs.tsx
@@ -89,7 +89,7 @@ export const WorkspaceBuildLogs: FC<WorkspaceBuildLogsProps> = ({
 						<div
 							className={cn(
 								"logs-header",
-								"flex items-center border-solid border-0 border-b border-border font-sans",
+								"flex items-center border-solid border-0 border-b last:border-b-0 border-border font-sans",
 								"bg-surface-primary text-xs font-semibold leading-none",
 								"first-of-type:pt-4",
 							)}


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

The last stage header in the build logs (e.g. "Cleaning Up") has `border-b` which doubles up with the container's bottom `border` when no log lines follow it, producing a visible 2px border at the bottom of the table.

Adds `last:border-b-0` to the stage header so the bottom border is removed when it's the last child of the container.

<details><summary>Analysis</summary>

The container div has `border border-border rounded-lg` (1px border on all sides). Each stage header has `border-b` (1px bottom border). When the final stage ("Cleaning Up") is empty, no `<Logs>` component is rendered after its header, so the header's `border-b` sits directly against the container's bottom border — creating a double border.

</details>