### PR TITLE
docs: replace dockerd with service docker start in Sysbox examples

### DIFF
--- a/docs/admin/templates/extending-templates/docker-in-workspaces.md
+++ b/docs/admin/templates/extending-templates/docker-in-workspaces.md
@@ -37,14 +37,11 @@ resource "docker_container" "workspace" {
 resource "coder_agent" "main" {
   arch           = data.coder_provisioner.me.arch
   os             = "linux"
-  startup_script = <<EOF
+  startup_script = <<-EOF
     #!/bin/sh
-
-    # Start Docker
-    sudo dockerd &
-
-    # ...
-    EOF
+    set -e
+    sudo service docker start
+  EOF
 }
 ```
 
@@ -78,13 +75,10 @@ resource "coder_agent" "main" {
   os   = "linux"
   arch = "amd64"
   dir  = "/home/coder"
-  startup_script = <<EOF
+  startup_script = <<-EOF
     #!/bin/sh
-
-    # Start Docker
-    sudo dockerd &
-
-    # ...
+    set -e
+    sudo service docker start
   EOF
 }
 


### PR DESCRIPTION
## Problem

The Sysbox docker-in-workspaces docs examples use `sudo dockerd &` in `startup_script` to start Docker. This causes workspaces to report as unhealthy because `dockerd` keeps references to stdout/stderr after the script exits.

## Fix

Replace `sudo dockerd &` with `sudo service docker start`, which properly daemonizes Docker through the service manager and returns cleanly. This matches the pattern used in our [dogfood template](https://github.com/coder/coder/blob/main/dogfood/coder/main.tf#L614).

## Validation

Created a test template and workspace on dogfood — agent reported `✔ healthy` and `docker info` confirmed the daemon running inside the workspace.

Fixes #21166

> 🤖 This PR was created with the help of Coder Agents, and has been reviewed by my human.  🧑💻