### PR TITLE
fix: make IndustryType and OrgSize onboarding fields optional

### DIFF
--- a/coderd/users.go
+++ b/coderd/users.go
@@ -292,8 +292,8 @@ func (api *API) postFirstUser(rw http.ResponseWriter, r *http.Request) {
 	if createUser.OnboardingInfo != nil {
 		onboarding = &telemetry.FirstUserOnboarding{
 			IsBusiness:          createUser.OnboardingInfo.IsBusiness,
-			IndustryType:        string(createUser.OnboardingInfo.IndustryType),
-			OrgSize:             string(createUser.OnboardingInfo.OrgSize),
+			IndustryType:        string(ptr.NilToEmpty(createUser.OnboardingInfo.IndustryType)),
+			OrgSize:             string(ptr.NilToEmpty(createUser.OnboardingInfo.OrgSize)),
 			NewsletterMarketing: createUser.OnboardingInfo.NewsletterMarketing,
 			NewsletterReleases:  createUser.OnboardingInfo.NewsletterReleases,
 		}

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -137,8 +137,8 @@ func TestFirstUser_OnboardingTelemetry(t *testing.T) {
 			Password: "SomeSecurePassword!",
 			OnboardingInfo: &codersdk.CreateFirstUserOnboardingInfo{
 				IsBusiness:          &isBusiness,
-				IndustryType:        codersdk.IndustryTypeTechnology,
-				OrgSize:             codersdk.OrgSizeRange51To200,
+				IndustryType:        ptr.Ref(codersdk.IndustryTypeTechnology),
+				OrgSize:             ptr.Ref(codersdk.OrgSizeRange51To200),
 				NewsletterMarketing: &wantMarketing,
 				NewsletterReleases:  &wantReleases,
 			},

--- a/codersdk/users.go
+++ b/codersdk/users.go
@@ -186,11 +186,11 @@ const (
 // Pointer fields allow an explicit "no" answer to be distinguished
 // from a skipped question, which matters for the telemetry schema.
 type CreateFirstUserOnboardingInfo struct {
-	IsBusiness          *bool        `json:"is_business"`
-	IndustryType        IndustryType `json:"industry_type" validate:"omitempty,oneof=Technology 'Financial Services' Healthcare Government Education Retail Manufacturing Media Telecom Energy Transportation Consulting Non-Profit Other"`
-	OrgSize             OrgSizeRange `json:"org_size" validate:"omitempty,oneof='Just me' 2-10 11-50 51-200 201-1000 1001-5000 5000+"`
-	NewsletterMarketing *bool        `json:"newsletter_marketing"`
-	NewsletterReleases  *bool        `json:"newsletter_releases"`
+	IsBusiness          *bool         `json:"is_business"`
+	IndustryType        *IndustryType `json:"industry_type" validate:"omitempty,oneof=Technology 'Financial Services' Healthcare Government Education Retail Manufacturing Media Telecom Energy Transportation Consulting Non-Profit Other"`
+	OrgSize             *OrgSizeRange `json:"org_size" validate:"omitempty,oneof='Just me' 2-10 11-50 51-200 201-1000 1001-5000 5000+"`
+	NewsletterMarketing *bool         `json:"newsletter_marketing"`
+	NewsletterReleases  *bool         `json:"newsletter_releases"`
 }
 
 // CreateFirstUserResponse contains IDs for newly created user info.

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2392,8 +2392,8 @@ export interface CreateChatRequest {
  */
 export interface CreateFirstUserOnboardingInfo {
 	readonly is_business: boolean | null;
-	readonly industry_type: IndustryType;
-	readonly org_size: OrgSizeRange;
+	readonly industry_type: IndustryType | null;
+	readonly org_size: OrgSizeRange | null;
 	readonly newsletter_marketing: boolean | null;
 	readonly newsletter_releases: boolean | null;
 }


### PR DESCRIPTION
The new `IndustryType` and `OrgSize` enums from #23989 are `validate:"omitempty"` but are not optional in the types. This makes the fields in `FirstUserOnboarding` pointers, thereby allowing `null` as a value from the frontend.