### PR TITLE
fix(cli): add dial timeout and keepalive for Coder Connect

### DIFF
--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -1647,7 +1647,11 @@ func WithTestOnlyCoderConnectDialer(ctx context.Context, dialer coderConnectDial
 func testOrDefaultDialer(ctx context.Context) coderConnectDialer {
 	dialer, ok := ctx.Value(coderConnectDialerContextKey{}).(coderConnectDialer)
 	if !ok || dialer == nil {
-		return &net.Dialer{}
+		// Timeout prevents hanging on broken tunnels (OS default is very long).
+		return &net.Dialer{
+			Timeout:   5 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}
 	}
 	return dialer
 }

--- a/cli/ssh_internal_test.go
+++ b/cli/ssh_internal_test.go
@@ -243,6 +243,26 @@ func TestCloserStack_PushAfterClose_ConnClosed(t *testing.T) {
 	require.Equal(t, []*fakeCloser{fc}, *closes, "should close conn on failed push")
 }
 
+func TestCoderConnectDialer_DefaultTimeout(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	dialer := testOrDefaultDialer(ctx)
+	d, ok := dialer.(*net.Dialer)
+	require.True(t, ok, "expected *net.Dialer")
+	assert.Equal(t, 5*time.Second, d.Timeout)
+	assert.Equal(t, 30*time.Second, d.KeepAlive)
+}
+
+func TestCoderConnectDialer_Overridden(t *testing.T) {
+	t.Parallel()
+	custom := &net.Dialer{Timeout: 99 * time.Second}
+	ctx := WithTestOnlyCoderConnectDialer(context.Background(), custom)
+
+	dialer := testOrDefaultDialer(ctx)
+	assert.Equal(t, custom, dialer)
+}
+
 func TestCoderConnectStdio(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The default `net.Dialer` in the Coder Connect path had no timeout, falling back to the OS TCP timeout when the tunnel was broken but DNS still resolved. Add a 5s dial timeout and 30s TCP keepalive.

Depends on #24010

Fixes https://github.com/coder/coder/issues/24006