### PR TITLE
fix: remove IndustryType and OrgSize from FirstUserOnboarding telemetry

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -14586,29 +14586,6 @@ const docTemplate = `{
         "codersdk.CreateFirstUserOnboardingInfo": {
             "type": "object",
             "properties": {
-                "industry_type": {
-                    "enum": [
-                        "Technology",
-                        "Financial Services",
-                        "Healthcare",
-                        "Government",
-                        "Education",
-                        "Retail",
-                        "Manufacturing",
-                        "Media",
-                        "Telecom",
-                        "Energy",
-                        "Transportation",
-                        "Consulting",
-                        "Non-Profit",
-                        "Other"
-                    ],
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/codersdk.IndustryType"
-                        }
-                    ]
-                },
                 "is_business": {
                     "type": "boolean"
                 },
@@ -14617,22 +14594,6 @@ const docTemplate = `{
                 },
                 "newsletter_releases": {
                     "type": "boolean"
-                },
-                "org_size": {
-                    "enum": [
-                        "Just me",
-                        "2-10",
-                        "11-50",
-                        "51-200",
-                        "201-1000",
-                        "1001-5000",
-                        "5000+"
-                    ],
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/codersdk.OrgSizeRange"
-                        }
-                    ]
                 }
             }
         },
@@ -16504,41 +16465,6 @@ const docTemplate = `{
                 }
             }
         },
-        "codersdk.IndustryType": {
-            "type": "string",
-            "enum": [
-                "Technology",
-                "Financial Services",
-                "Healthcare",
-                "Government",
-                "Education",
-                "Retail",
-                "Manufacturing",
-                "Media",
-                "Telecom",
-                "Energy",
-                "Transportation",
-                "Consulting",
-                "Non-Profit",
-                "Other"
-            ],
-            "x-enum-varnames": [
-                "IndustryTypeTechnology",
-                "IndustryTypeFinancial",
-                "IndustryTypeHealthcare",
-                "IndustryTypeGovernment",
-                "IndustryTypeEducation",
-                "IndustryTypeRetail",
-                "IndustryTypeManufacturing",
-                "IndustryTypeMedia",
-                "IndustryTypeTelecom",
-                "IndustryTypeEnergy",
-                "IndustryTypeTransportation",
-                "IndustryTypeConsulting",
-                "IndustryTypeNonProfit",
-                "IndustryTypeOther"
-            ]
-        },
         "codersdk.InsightsReportInterval": {
             "type": "string",
             "enum": [
@@ -17723,27 +17649,6 @@ const docTemplate = `{
                 "OptionTypeNumber",
                 "OptionTypeBoolean",
                 "OptionTypeListString"
-            ]
-        },
-        "codersdk.OrgSizeRange": {
-            "type": "string",
-            "enum": [
-                "Just me",
-                "2-10",
-                "11-50",
-                "51-200",
-                "201-1000",
-                "1001-5000",
-                "5000+"
-            ],
-            "x-enum-varnames": [
-                "OrgSizeRangeJustMe",
-                "OrgSizeRange2To10",
-                "OrgSizeRange11To50",
-                "OrgSizeRange51To200",
-                "OrgSizeRange201To1K",
-                "OrgSizeRange1KTo5K",
-                "OrgSizeRange5KPlus"
             ]
         },
         "codersdk.Organization": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -13126,29 +13126,6 @@
 		"codersdk.CreateFirstUserOnboardingInfo": {
 			"type": "object",
 			"properties": {
-				"industry_type": {
-					"enum": [
-						"Technology",
-						"Financial Services",
-						"Healthcare",
-						"Government",
-						"Education",
-						"Retail",
-						"Manufacturing",
-						"Media",
-						"Telecom",
-						"Energy",
-						"Transportation",
-						"Consulting",
-						"Non-Profit",
-						"Other"
-					],
-					"allOf": [
-						{
-							"$ref": "#/definitions/codersdk.IndustryType"
-						}
-					]
-				},
 				"is_business": {
 					"type": "boolean"
 				},
@@ -13157,22 +13134,6 @@
 				},
 				"newsletter_releases": {
 					"type": "boolean"
-				},
-				"org_size": {
-					"enum": [
-						"Just me",
-						"2-10",
-						"11-50",
-						"51-200",
-						"201-1000",
-						"1001-5000",
-						"5000+"
-					],
-					"allOf": [
-						{
-							"$ref": "#/definitions/codersdk.OrgSizeRange"
-						}
-					]
 				}
 			}
 		},
@@ -14988,41 +14949,6 @@
 				}
 			}
 		},
-		"codersdk.IndustryType": {
-			"type": "string",
-			"enum": [
-				"Technology",
-				"Financial Services",
-				"Healthcare",
-				"Government",
-				"Education",
-				"Retail",
-				"Manufacturing",
-				"Media",
-				"Telecom",
-				"Energy",
-				"Transportation",
-				"Consulting",
-				"Non-Profit",
-				"Other"
-			],
-			"x-enum-varnames": [
-				"IndustryTypeTechnology",
-				"IndustryTypeFinancial",
-				"IndustryTypeHealthcare",
-				"IndustryTypeGovernment",
-				"IndustryTypeEducation",
-				"IndustryTypeRetail",
-				"IndustryTypeManufacturing",
-				"IndustryTypeMedia",
-				"IndustryTypeTelecom",
-				"IndustryTypeEnergy",
-				"IndustryTypeTransportation",
-				"IndustryTypeConsulting",
-				"IndustryTypeNonProfit",
-				"IndustryTypeOther"
-			]
-		},
 		"codersdk.InsightsReportInterval": {
 			"type": "string",
 			"enum": ["day", "week"],
@@ -16145,27 +16071,6 @@
 				"OptionTypeNumber",
 				"OptionTypeBoolean",
 				"OptionTypeListString"
-			]
-		},
-		"codersdk.OrgSizeRange": {
-			"type": "string",
-			"enum": [
-				"Just me",
-				"2-10",
-				"11-50",
-				"51-200",
-				"201-1000",
-				"1001-5000",
-				"5000+"
-			],
-			"x-enum-varnames": [
-				"OrgSizeRangeJustMe",
-				"OrgSizeRange2To10",
-				"OrgSizeRange11To50",
-				"OrgSizeRange51To200",
-				"OrgSizeRange201To1K",
-				"OrgSizeRange1KTo5K",
-				"OrgSizeRange5KPlus"
 			]
 		},
 		"codersdk.Organization": {

--- a/coderd/telemetry/telemetry.go
+++ b/coderd/telemetry/telemetry.go
@@ -1557,11 +1557,9 @@ type User struct {
 // once when the first user is created. Pointer fields distinguish an
 // explicit answer from a skipped question.
 type FirstUserOnboarding struct {
-	IsBusiness          *bool  `json:"is_business"`
-	IndustryType        string `json:"industry_type"`
-	OrgSize             string `json:"org_size"`
-	NewsletterMarketing *bool  `json:"newsletter_marketing"`
-	NewsletterReleases  *bool  `json:"newsletter_releases"`
+	IsBusiness          *bool `json:"is_business"`
+	NewsletterMarketing *bool `json:"newsletter_marketing"`
+	NewsletterReleases  *bool `json:"newsletter_releases"`
 }
 
 type Group struct {

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -292,8 +292,6 @@ func (api *API) postFirstUser(rw http.ResponseWriter, r *http.Request) {
 	if createUser.OnboardingInfo != nil {
 		onboarding = &telemetry.FirstUserOnboarding{
 			IsBusiness:          createUser.OnboardingInfo.IsBusiness,
-			IndustryType:        string(createUser.OnboardingInfo.IndustryType),
-			OrgSize:             string(createUser.OnboardingInfo.OrgSize),
 			NewsletterMarketing: createUser.OnboardingInfo.NewsletterMarketing,
 			NewsletterReleases:  createUser.OnboardingInfo.NewsletterReleases,
 		}

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -137,8 +137,6 @@ func TestFirstUser_OnboardingTelemetry(t *testing.T) {
 			Password: "SomeSecurePassword!",
 			OnboardingInfo: &codersdk.CreateFirstUserOnboardingInfo{
 				IsBusiness:          &isBusiness,
-				IndustryType:        codersdk.IndustryTypeTechnology,
-				OrgSize:             codersdk.OrgSizeRange51To200,
 				NewsletterMarketing: &wantMarketing,
 				NewsletterReleases:  &wantReleases,
 			},
@@ -149,8 +147,6 @@ func TestFirstUser_OnboardingTelemetry(t *testing.T) {
 		require.NotNil(t, snapshot.FirstUserOnboarding)
 		require.NotNil(t, snapshot.FirstUserOnboarding.IsBusiness)
 		require.True(t, *snapshot.FirstUserOnboarding.IsBusiness)
-		require.Equal(t, string(codersdk.IndustryTypeTechnology), snapshot.FirstUserOnboarding.IndustryType)
-		require.Equal(t, string(codersdk.OrgSizeRange51To200), snapshot.FirstUserOnboarding.OrgSize)
 		require.NotNil(t, snapshot.FirstUserOnboarding.NewsletterMarketing)
 		require.False(t, *snapshot.FirstUserOnboarding.NewsletterMarketing)
 		require.NotNil(t, snapshot.FirstUserOnboarding.NewsletterReleases)
@@ -198,8 +194,6 @@ func TestFirstUser_OnboardingTelemetry(t *testing.T) {
 			"nil *bool must stay nil, not become false")
 		require.Nil(t, snapshot.FirstUserOnboarding.NewsletterMarketing)
 		require.Nil(t, snapshot.FirstUserOnboarding.NewsletterReleases)
-		require.Empty(t, snapshot.FirstUserOnboarding.IndustryType)
-		require.Empty(t, snapshot.FirstUserOnboarding.OrgSize)
 	})
 }
 

--- a/codersdk/users.go
+++ b/codersdk/users.go
@@ -144,53 +144,14 @@ type CreateFirstUserTrialInfo struct {
 	Developers  string `json:"developers"`
 }
 
-// OrgSizeRange represents a bucketed headcount range for an organization.
-// These values are fixed by agreement with the frontend and the telemetry
-// schema — do not change them without coordinating both sides.
-type OrgSizeRange string
-
-const (
-	OrgSizeRangeJustMe  OrgSizeRange = "Just me"
-	OrgSizeRange2To10   OrgSizeRange = "2-10"
-	OrgSizeRange11To50  OrgSizeRange = "11-50"
-	OrgSizeRange51To200 OrgSizeRange = "51-200"
-	OrgSizeRange201To1K OrgSizeRange = "201-1000"
-	OrgSizeRange1KTo5K  OrgSizeRange = "1001-5000"
-	OrgSizeRange5KPlus  OrgSizeRange = "5000+"
-)
-
-// IndustryType represents the industry vertical an organization operates in.
-// These values are fixed by agreement with the frontend and the telemetry
-// schema — do not change them without coordinating both sides.
-type IndustryType string
-
-const (
-	IndustryTypeTechnology     IndustryType = "Technology"
-	IndustryTypeFinancial      IndustryType = "Financial Services"
-	IndustryTypeHealthcare     IndustryType = "Healthcare"
-	IndustryTypeGovernment     IndustryType = "Government"
-	IndustryTypeEducation      IndustryType = "Education"
-	IndustryTypeRetail         IndustryType = "Retail"
-	IndustryTypeManufacturing  IndustryType = "Manufacturing"
-	IndustryTypeMedia          IndustryType = "Media"
-	IndustryTypeTelecom        IndustryType = "Telecom"
-	IndustryTypeEnergy         IndustryType = "Energy"
-	IndustryTypeTransportation IndustryType = "Transportation"
-	IndustryTypeConsulting     IndustryType = "Consulting"
-	IndustryTypeNonProfit      IndustryType = "Non-Profit"
-	IndustryTypeOther          IndustryType = "Other"
-)
-
 // CreateFirstUserOnboardingInfo contains optional demographic and
 // newsletter preference data collected during first user setup.
 // Pointer fields allow an explicit "no" answer to be distinguished
 // from a skipped question, which matters for the telemetry schema.
 type CreateFirstUserOnboardingInfo struct {
-	IsBusiness          *bool        `json:"is_business"`
-	IndustryType        IndustryType `json:"industry_type" validate:"omitempty,oneof=Technology 'Financial Services' Healthcare Government Education Retail Manufacturing Media Telecom Energy Transportation Consulting Non-Profit Other"`
-	OrgSize             OrgSizeRange `json:"org_size" validate:"omitempty,oneof='Just me' 2-10 11-50 51-200 201-1000 1001-5000 5000+"`
-	NewsletterMarketing *bool        `json:"newsletter_marketing"`
-	NewsletterReleases  *bool        `json:"newsletter_releases"`
+	IsBusiness          *bool `json:"is_business"`
+	NewsletterMarketing *bool `json:"newsletter_marketing"`
+	NewsletterReleases  *bool `json:"newsletter_releases"`
 }
 
 // CreateFirstUserResponse contains IDs for newly created user info.

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -2282,30 +2282,19 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 ```json
 {
-  "industry_type": "Technology",
   "is_business": true,
   "newsletter_marketing": true,
-  "newsletter_releases": true,
-  "org_size": "Just me"
+  "newsletter_releases": true
 }
 ```
 
 ### Properties
 
-| Name                   | Type                                           | Required | Restrictions | Description |
-|------------------------|------------------------------------------------|----------|--------------|-------------|
-| `industry_type`        | [codersdk.IndustryType](#codersdkindustrytype) | false    |              |             |
-| `is_business`          | boolean                                        | false    |              |             |
-| `newsletter_marketing` | boolean                                        | false    |              |             |
-| `newsletter_releases`  | boolean                                        | false    |              |             |
-| `org_size`             | [codersdk.OrgSizeRange](#codersdkorgsizerange) | false    |              |             |
-
-#### Enumerated Values
-
-| Property        | Value(s)                                                                                                                                                                                    |
-|-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `industry_type` | `Consulting`, `Education`, `Energy`, `Financial Services`, `Government`, `Healthcare`, `Manufacturing`, `Media`, `Non-Profit`, `Other`, `Retail`, `Technology`, `Telecom`, `Transportation` |
-| `org_size`      | `1001-5000`, `11-50`, `2-10`, `201-1000`, `5000+`, `51-200`, `Just me`                                                                                                                      |
+| Name                   | Type    | Required | Restrictions | Description |
+|------------------------|---------|----------|--------------|-------------|
+| `is_business`          | boolean | false    |              |             |
+| `newsletter_marketing` | boolean | false    |              |             |
+| `newsletter_releases`  | boolean | false    |              |             |
 
 ## codersdk.CreateFirstUserRequest
 
@@ -2314,11 +2303,9 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
   "email": "string",
   "name": "string",
   "onboarding_info": {
-    "industry_type": "Technology",
     "is_business": true,
     "newsletter_marketing": true,
-    "newsletter_releases": true,
-    "org_size": "Just me"
+    "newsletter_releases": true
   },
   "password": "string",
   "trial": true,
@@ -5197,20 +5184,6 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 | `label` | string | false    |              |             |
 | `url`   | string | false    |              |             |
 
-## codersdk.IndustryType
-
-```json
-"Technology"
-```
-
-### Properties
-
-#### Enumerated Values
-
-| Value(s)                                                                                                                                                                                    |
-|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `Consulting`, `Education`, `Energy`, `Financial Services`, `Government`, `Healthcare`, `Manufacturing`, `Media`, `Non-Profit`, `Other`, `Retail`, `Technology`, `Telecom`, `Transportation` |
-
 ## codersdk.InsightsReportInterval
 
 ```json
@@ -6441,20 +6414,6 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 | Value(s)                                   |
 |--------------------------------------------|
 | `bool`, `list(string)`, `number`, `string` |
-
-## codersdk.OrgSizeRange
-
-```json
-"Just me"
-```
-
-### Properties
-
-#### Enumerated Values
-
-| Value(s)                                                               |
-|------------------------------------------------------------------------|
-| `1001-5000`, `11-50`, `2-10`, `201-1000`, `5000+`, `51-200`, `Just me` |
 
 ## codersdk.Organization
 

--- a/docs/reference/api/users.md
+++ b/docs/reference/api/users.md
@@ -246,11 +246,9 @@ curl -X POST http://coder-server:8080/api/v2/users/first \
   "email": "string",
   "name": "string",
   "onboarding_info": {
-    "industry_type": "Technology",
     "is_business": true,
     "newsletter_marketing": true,
-    "newsletter_releases": true,
-    "org_size": "Just me"
+    "newsletter_releases": true
   },
   "password": "string",
   "trial": true,

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2397,8 +2397,6 @@ export interface CreateChatRequest {
  */
 export interface CreateFirstUserOnboardingInfo {
 	readonly is_business: boolean | null;
-	readonly industry_type: IndustryType;
-	readonly org_size: OrgSizeRange;
 	readonly newsletter_marketing: boolean | null;
 	readonly newsletter_releases: boolean | null;
 }
@@ -3865,40 +3863,6 @@ export const InboxNotificationFallbackIconTemplate = "DEFAULT_ICON_TEMPLATE";
 // From codersdk/inboxnotification.go
 export const InboxNotificationFallbackIconWorkspace = "DEFAULT_ICON_WORKSPACE";
 
-// From codersdk/users.go
-export type IndustryType =
-	| "Consulting"
-	| "Education"
-	| "Energy"
-	| "Financial Services"
-	| "Government"
-	| "Healthcare"
-	| "Manufacturing"
-	| "Media"
-	| "Non-Profit"
-	| "Other"
-	| "Retail"
-	| "Technology"
-	| "Telecom"
-	| "Transportation";
-
-export const IndustryTypes: IndustryType[] = [
-	"Consulting",
-	"Education",
-	"Energy",
-	"Financial Services",
-	"Government",
-	"Healthcare",
-	"Manufacturing",
-	"Media",
-	"Non-Profit",
-	"Other",
-	"Retail",
-	"Technology",
-	"Telecom",
-	"Transportation",
-];
-
 // From codersdk/insights.go
 export type InsightsReportInterval = "day" | "week";
 
@@ -4839,26 +4803,6 @@ export const OptionTypes: OptionType[] = [
 	"list(string)",
 	"number",
 	"string",
-];
-
-// From codersdk/users.go
-export type OrgSizeRange =
-	| "11-50"
-	| "1001-5000"
-	| "201-1000"
-	| "2-10"
-	| "51-200"
-	| "5000+"
-	| "Just me";
-
-export const OrgSizeRanges: OrgSizeRange[] = [
-	"11-50",
-	"1001-5000",
-	"201-1000",
-	"2-10",
-	"51-200",
-	"5000+",
-	"Just me",
 ];
 
 // From codersdk/organizations.go


### PR DESCRIPTION
New `IndustryType` and `OrgSize` enums were added in #23989, but they are no longer desired in the onboarding/marketing telemetry data. This removes them.