### PR TITLE
feat: make service accounts a Premium feature

### DIFF
--- a/cli/usercreate_test.go
+++ b/cli/usercreate_test.go
@@ -134,6 +134,7 @@ func TestUserCreate(t *testing.T) {
 		{
 			name: "ServiceAccount",
 			args: []string{"--service-account", "-u", "dean"},
+			err:  "Premium feature",
 		},
 		{
 			name: "ServiceAccountLoginType",

--- a/coderd/coderdtest/users.go
+++ b/coderd/coderdtest/users.go
@@ -220,11 +220,13 @@ func UsersFilter(
 	}
 
 	// Add some service accounts.
-	for range 3 {
-		_, user := CreateAnotherUserMutators(t, client, orgID, nil, func(r *codersdk.CreateUserRequestWithOrgs) {
-			r.ServiceAccount = true
-		})
-		users = append(users, user)
+	if options.CreateServiceAccounts {
+		for range 3 {
+			_, user := CreateAnotherUserMutators(t, client, orgID, nil, func(r *codersdk.CreateUserRequestWithOrgs) {
+				r.ServiceAccount = true
+			})
+			users = append(users, user)
+		}
 	}
 
 	hashedPassword, err := userpassword.Hash("SomeStrongPassword!")

--- a/coderd/coderdtest/users.go
+++ b/coderd/coderdtest/users.go
@@ -123,6 +123,10 @@ func UsersPagination(
 	require.Contains(t, gotUsers[0].Name, "after")
 }
 
+type UsersFilterOptions struct {
+	CreateServiceAccounts bool
+}
+
 // UsersFilter creates a set of users to run various filters against for
 // testing.  It can be used to test filtering both users and group members.
 func UsersFilter(
@@ -130,10 +134,15 @@ func UsersFilter(
 	t *testing.T,
 	client *codersdk.Client,
 	db database.Store,
+	options *UsersFilterOptions,
 	setup func(users []codersdk.User),
 	fetch func(ctx context.Context, req codersdk.UsersRequest) []codersdk.ReducedUser,
 ) {
 	t.Helper()
+
+	if options == nil {
+		options = &UsersFilterOptions{}
+	}
 
 	firstUser, err := client.User(setupCtx, codersdk.Me)
 	require.NoError(t, err, "fetch me")

--- a/coderd/members_test.go
+++ b/coderd/members_test.go
@@ -148,7 +148,7 @@ func TestGetOrgMembersFilter(t *testing.T) {
 	setupCtx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 	defer cancel()
 
-	coderdtest.UsersFilter(setupCtx, t, client, api.Database, nil, func(testCtx context.Context, req codersdk.UsersRequest) []codersdk.ReducedUser {
+	coderdtest.UsersFilter(setupCtx, t, client, api.Database, nil, nil, func(testCtx context.Context, req codersdk.UsersRequest) []codersdk.ReducedUser {
 		res, err := client.OrganizationMembersPaginated(testCtx, first.OrganizationID, req)
 		require.NoError(t, err)
 		reduced := make([]codersdk.ReducedUser, len(res.Members))

--- a/coderd/users.go
+++ b/coderd/users.go
@@ -480,6 +480,14 @@ func (api *API) postUser(rw http.ResponseWriter, r *http.Request) {
 		}
 
 		req.UserLoginType = codersdk.LoginTypeNone
+
+		// Service accounts are a Premium feature.
+		if !api.Entitlements.Enabled(codersdk.FeatureServiceAccounts) {
+			httpapi.Write(ctx, rw, http.StatusForbidden, codersdk.Response{
+				Message: fmt.Sprintf("%s is a Premium feature. Contact sales!", codersdk.FeatureServiceAccounts.Humanize()),
+			})
+			return
+		}
 	} else if req.UserLoginType == "" {
 		// Default to password auth
 		req.UserLoginType = codersdk.LoginTypePassword

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -1724,7 +1724,7 @@ func TestGetUsersFilter(t *testing.T) {
 	setupCtx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 	defer cancel()
 
-	coderdtest.UsersFilter(setupCtx, t, client, api.Database, nil, func(testCtx context.Context, req codersdk.UsersRequest) []codersdk.ReducedUser {
+	coderdtest.UsersFilter(setupCtx, t, client, api.Database, nil, nil, func(testCtx context.Context, req codersdk.UsersRequest) []codersdk.ReducedUser {
 		res, err := client.Users(testCtx, req)
 		require.NoError(t, err)
 		reduced := make([]codersdk.ReducedUser, len(res.Users))

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -1009,85 +1009,6 @@ func TestPostUsers(t *testing.T) {
 		require.Contains(t, apiErr.Message, "Premium feature")
 	})
 
-	t.Run("ServiceAccount/WithEmail", func(t *testing.T) {
-		t.Parallel()
-		client := coderdtest.New(t, nil)
-		first := coderdtest.CreateFirstUser(t, client)
-
-		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
-		defer cancel()
-
-		_, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
-			OrganizationIDs: []uuid.UUID{first.OrganizationID},
-			Username:        "service-acct-email",
-			Email:           "should-not-have@email.com",
-			ServiceAccount:  true,
-		})
-		var apiErr *codersdk.Error
-		require.ErrorAs(t, err, &apiErr)
-		require.Equal(t, http.StatusBadRequest, apiErr.StatusCode())
-		require.Contains(t, apiErr.Message, "Email cannot be set for service accounts")
-	})
-
-	t.Run("ServiceAccount/WithPassword", func(t *testing.T) {
-		t.Parallel()
-		client := coderdtest.New(t, nil)
-		first := coderdtest.CreateFirstUser(t, client)
-
-		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
-		defer cancel()
-
-		_, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
-			OrganizationIDs: []uuid.UUID{first.OrganizationID},
-			Username:        "service-acct-password",
-			Password:        "ShouldNotHavePassword123!",
-			ServiceAccount:  true,
-		})
-		var apiErr *codersdk.Error
-		require.ErrorAs(t, err, &apiErr)
-		require.Equal(t, http.StatusBadRequest, apiErr.StatusCode())
-		require.Contains(t, apiErr.Message, "Password cannot be set for service accounts")
-	})
-
-	t.Run("ServiceAccount/WithInvalidLoginType", func(t *testing.T) {
-		t.Parallel()
-		client := coderdtest.New(t, nil)
-		first := coderdtest.CreateFirstUser(t, client)
-
-		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
-		defer cancel()
-
-		_, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
-			OrganizationIDs: []uuid.UUID{first.OrganizationID},
-			Username:        "service-acct-login-type",
-			UserLoginType:   codersdk.LoginTypePassword,
-			ServiceAccount:  true,
-		})
-		var apiErr *codersdk.Error
-		require.ErrorAs(t, err, &apiErr)
-		require.Equal(t, http.StatusBadRequest, apiErr.StatusCode())
-		require.Contains(t, apiErr.Message, "Service accounts must use login type 'none'")
-	})
-
-	t.Run("ServiceAccount/DefaultLoginType", func(t *testing.T) {
-		t.Parallel()
-		client := coderdtest.New(t, nil)
-		first := coderdtest.CreateFirstUser(t, client)
-
-		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
-		defer cancel()
-
-		_, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
-			OrganizationIDs: []uuid.UUID{first.OrganizationID},
-			Username:        "service-acct-default-login",
-			ServiceAccount:  true,
-		})
-		var apiErr *codersdk.Error
-		require.ErrorAs(t, err, &apiErr)
-		require.Equal(t, http.StatusForbidden, apiErr.StatusCode())
-		require.Contains(t, apiErr.Message, "Premium feature")
-	})
-
 	t.Run("NonServiceAccount/WithoutEmail", func(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, nil)
@@ -1104,25 +1025,6 @@ func TestPostUsers(t *testing.T) {
 		var apiErr *codersdk.Error
 		require.ErrorAs(t, err, &apiErr)
 		require.Equal(t, http.StatusBadRequest, apiErr.StatusCode())
-	})
-
-	t.Run("ServiceAccount/MultipleWithoutEmail", func(t *testing.T) {
-		t.Parallel()
-		client := coderdtest.New(t, nil)
-		first := coderdtest.CreateFirstUser(t, client)
-
-		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
-		defer cancel()
-
-		_, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
-			OrganizationIDs: []uuid.UUID{first.OrganizationID},
-			Username:        "service-acct-multi-1",
-			ServiceAccount:  true,
-		})
-		var apiErr *codersdk.Error
-		require.ErrorAs(t, err, &apiErr)
-		require.Equal(t, http.StatusForbidden, apiErr.StatusCode())
-		require.Contains(t, apiErr.Message, "Premium feature")
 	})
 }
 

--- a/coderd/users_test.go
+++ b/coderd/users_test.go
@@ -989,7 +989,7 @@ func TestPostUsers(t *testing.T) {
 		require.Equal(t, found.LoginType, codersdk.LoginTypeOIDC)
 	})
 
-	t.Run("ServiceAccount/OK", func(t *testing.T) {
+	t.Run("ServiceAccount/Unlicensed", func(t *testing.T) {
 		t.Parallel()
 		client := coderdtest.New(t, nil)
 		first := coderdtest.CreateFirstUser(t, client)
@@ -997,17 +997,16 @@ func TestPostUsers(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
-		user, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
+		_, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			OrganizationIDs: []uuid.UUID{first.OrganizationID},
 			Username:        "service-acct-ok",
 			UserLoginType:   codersdk.LoginTypeNone,
 			ServiceAccount:  true,
 		})
-		require.NoError(t, err)
-		require.Equal(t, codersdk.LoginTypeNone, user.LoginType)
-		require.Empty(t, user.Email)
-		require.Equal(t, "service-acct-ok", user.Username)
-		require.Equal(t, codersdk.UserStatusDormant, user.Status)
+		var apiErr *codersdk.Error
+		require.ErrorAs(t, err, &apiErr)
+		require.Equal(t, http.StatusForbidden, apiErr.StatusCode())
+		require.Contains(t, apiErr.Message, "Premium feature")
 	})
 
 	t.Run("ServiceAccount/WithEmail", func(t *testing.T) {
@@ -1078,17 +1077,15 @@ func TestPostUsers(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
-		user, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
+		_, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			OrganizationIDs: []uuid.UUID{first.OrganizationID},
 			Username:        "service-acct-default-login",
 			ServiceAccount:  true,
 		})
-		require.NoError(t, err)
-
-		found, err := client.User(ctx, user.ID.String())
-		require.NoError(t, err)
-		require.Equal(t, codersdk.LoginTypeNone, found.LoginType)
-		require.Empty(t, found.Email)
+		var apiErr *codersdk.Error
+		require.ErrorAs(t, err, &apiErr)
+		require.Equal(t, http.StatusForbidden, apiErr.StatusCode())
+		require.Contains(t, apiErr.Message, "Premium feature")
 	})
 
 	t.Run("NonServiceAccount/WithoutEmail", func(t *testing.T) {
@@ -1117,22 +1114,15 @@ func TestPostUsers(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
-		user1, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
+		_, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			OrganizationIDs: []uuid.UUID{first.OrganizationID},
 			Username:        "service-acct-multi-1",
 			ServiceAccount:  true,
 		})
-		require.NoError(t, err)
-		require.Empty(t, user1.Email)
-
-		user2, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
-			OrganizationIDs: []uuid.UUID{first.OrganizationID},
-			Username:        "service-acct-multi-2",
-			ServiceAccount:  true,
-		})
-		require.NoError(t, err)
-		require.Empty(t, user2.Email)
-		require.NotEqual(t, user1.ID, user2.ID)
+		var apiErr *codersdk.Error
+		require.ErrorAs(t, err, &apiErr)
+		require.Equal(t, http.StatusForbidden, apiErr.StatusCode())
+		require.Contains(t, apiErr.Message, "Premium feature")
 	})
 }
 

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -196,6 +196,7 @@ const (
 	FeatureWorkspaceExternalAgent FeatureName = "workspace_external_agent"
 	FeatureAIBridge               FeatureName = "aibridge"
 	FeatureBoundary               FeatureName = "boundary"
+	FeatureServiceAccounts        FeatureName = "service_accounts"
 	FeatureAIGovernanceUserLimit  FeatureName = "ai_governance_user_limit"
 )
 
@@ -227,6 +228,7 @@ var (
 		FeatureWorkspaceExternalAgent,
 		FeatureAIBridge,
 		FeatureBoundary,
+		FeatureServiceAccounts,
 		FeatureAIGovernanceUserLimit,
 	}
 
@@ -275,6 +277,7 @@ func (n FeatureName) AlwaysEnable() bool {
 		FeatureWorkspacePrebuilds:         true,
 		FeatureWorkspaceExternalAgent:     true,
 		FeatureBoundary:                   true,
+		FeatureServiceAccounts:            true,
 	}[n]
 }
 
@@ -282,7 +285,7 @@ func (n FeatureName) AlwaysEnable() bool {
 func (n FeatureName) Enterprise() bool {
 	switch n {
 	// Add all features that should be excluded in the Enterprise feature set.
-	case FeatureMultipleOrganizations, FeatureCustomRoles:
+	case FeatureMultipleOrganizations, FeatureCustomRoles, FeatureServiceAccounts:
 		return false
 	default:
 		return true

--- a/docs/admin/users/headless-auth.md
+++ b/docs/admin/users/headless-auth.md
@@ -1,31 +1,43 @@
 # Headless Authentication
 
-Headless user accounts that cannot use the web UI to log in to Coder. This is
-useful for creating accounts for automated systems, such as CI/CD pipelines or
-for users who only consume Coder via another client/API.
+> [!NOTE]
+> Creating service accounts with the `--service-account` flag or the **None** login
+type in the UI requires a [Premium license](https://coder.com/pricing).
 
-You must have the User Admin role or above to create headless users.
+Service accounts are headless user accounts that cannot use the web UI to log in
+to Coder. This is useful for creating accounts for automated systems, such as
+CI/CD pipelines or for users who only consume Coder via another client/API.
 
-## Create a headless user
+You must have the User Admin role or above to create service accounts.
+
+## Create a service account
 
 <div class="tabs">
 
 ## CLI
 
+Use the `--service-account` flag to create a dedicated service account.
+This flag is a Premium feature and automatically sets the login type to `none`,
+prevents setting an email or password, and applies additional server-side
+validations:
+
 ```sh
 coder users create \
-  --email="coder-bot@coder.com" \
   --username="coder-bot" \
-  --login-type="none" \
+  --service-account
 ```
 
 ## UI
 
-Navigate to the `Users` > `Create user` in the topbar
+Navigate to **Users** > **Create user** in the top bar, then select
+**Service account** as the login type. This option is only available with
+a Premium license.
 
 ![Create a user via the UI](../../images/admin/users/headless-user.png)
 
 </div>
+
+## Authenticate as a service account
 
 To make API or CLI requests on behalf of the headless user, learn how to
 [generate API tokens on behalf of a user](./sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-another-user).

--- a/docs/admin/users/headless-auth.md
+++ b/docs/admin/users/headless-auth.md
@@ -23,7 +23,6 @@ coder users create \
   --service-account
 ```
 
-
 ## UI
 
 Navigate to **Deployment** > **Users** > **Create user**, then select

--- a/docs/admin/users/headless-auth.md
+++ b/docs/admin/users/headless-auth.md
@@ -1,12 +1,11 @@
 # Headless Authentication
 
 > [!NOTE]
-> Creating service accounts with the `--service-account` flag or the **None** login
-type in the UI requires a [Premium license](https://coder.com/pricing).
+> Creating service accounts requires a [Premium license](https://coder.com/pricing).
 
 Service accounts are headless user accounts that cannot use the web UI to log in
 to Coder. This is useful for creating accounts for automated systems, such as
-CI/CD pipelines or for users who only consume Coder via another client/API.
+CI/CD pipelines or for users who only consume Coder via another client/API. Service accounts do not have passwords or associated email addresses.
 
 You must have the User Admin role or above to create service accounts.
 
@@ -16,10 +15,7 @@ You must have the User Admin role or above to create service accounts.
 
 ## CLI
 
-Use the `--service-account` flag to create a dedicated service account.
-This flag is a Premium feature and automatically sets the login type to `none`,
-prevents setting an email or password, and applies additional server-side
-validations:
+Use the `--service-account` flag to create a dedicated service account:
 
 ```sh
 coder users create \
@@ -27,11 +23,11 @@ coder users create \
   --service-account
 ```
 
+
 ## UI
 
-Navigate to **Users** > **Create user** in the top bar, then select
-**Service account** as the login type. This option is only available with
-a Premium license.
+Navigate to **Deployment** > **Users** > **Create user**, then select
+**Service account** as the login type.
 
 ![Create a user via the UI](../../images/admin/users/headless-user.png)
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -495,7 +495,8 @@
 						{
 							"title": "Headless Authentication",
 							"description": "Create and manage headless service accounts for automated systems and API integrations",
-							"path": "./admin/users/headless-auth.md"
+							"path": "./admin/users/headless-auth.md",
+							"state": ["premium"]
 						},
 						{
 							"title": "Groups \u0026 Roles",

--- a/enterprise/coderd/groups_test.go
+++ b/enterprise/coderd/groups_test.go
@@ -1161,7 +1161,8 @@ func TestGetGroupMembersFilter(t *testing.T) {
 		},
 		LicenseOptions: &coderdenttest.LicenseOptions{
 			Features: license.Features{
-				codersdk.FeatureTemplateRBAC: 1,
+				codersdk.FeatureTemplateRBAC:    1,
+				codersdk.FeatureServiceAccounts: 1,
 			},
 		},
 	})
@@ -1191,7 +1192,8 @@ func TestGetGroupMembersFilter(t *testing.T) {
 		require.NoError(t, err)
 		return res.Users
 	}
-	coderdtest.UsersFilter(setupCtx, t, client, db, setup, fetch)
+	options := &coderdtest.UsersFilterOptions{CreateServiceAccounts: true}
+	coderdtest.UsersFilter(setupCtx, t, client, db, options, setup, fetch)
 }
 
 func TestGetGroupMembersPagination(t *testing.T) {

--- a/enterprise/coderd/users_test.go
+++ b/enterprise/coderd/users_test.go
@@ -628,6 +628,7 @@ func TestEnterprisePostUser(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
+		//nolint:gocritic
 		user, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			OrganizationIDs: []uuid.UUID{first.OrganizationID},
 			Username:        "service-acct-ok",
@@ -654,6 +655,7 @@ func TestEnterprisePostUser(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
+		//nolint:gocritic
 		_, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			OrganizationIDs: []uuid.UUID{first.OrganizationID},
 			Username:        "service-acct-email",
@@ -679,6 +681,7 @@ func TestEnterprisePostUser(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
+		//nolint:gocritic
 		_, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			OrganizationIDs: []uuid.UUID{first.OrganizationID},
 			Username:        "service-acct-password",
@@ -704,6 +707,7 @@ func TestEnterprisePostUser(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
+		//nolint:gocritic
 		_, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			OrganizationIDs: []uuid.UUID{first.OrganizationID},
 			Username:        "service-acct-login-type",
@@ -729,6 +733,7 @@ func TestEnterprisePostUser(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
+		//nolint:gocritic
 		user, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			OrganizationIDs: []uuid.UUID{first.OrganizationID},
 			Username:        "service-acct-default-login",
@@ -755,6 +760,7 @@ func TestEnterprisePostUser(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
+		//nolint:gocritic
 		user1, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
 			OrganizationIDs: []uuid.UUID{first.OrganizationID},
 			Username:        "service-acct-multi-1",

--- a/enterprise/coderd/users_test.go
+++ b/enterprise/coderd/users_test.go
@@ -615,3 +615,87 @@ func TestEnterprisePostUser(t *testing.T) {
 		require.ElementsMatch(t, []uuid.UUID{second.ID, third.ID}, []uuid.UUID{memberedOrgs[0].ID, memberedOrgs[1].ID})
 	})
 }
+
+func TestEnterpriseServiceAccounts(t *testing.T) {
+	t.Parallel()
+
+	t.Run("OK", func(t *testing.T) {
+		t.Parallel()
+		client, first := coderdenttest.New(t, &coderdenttest.Options{
+			LicenseOptions: &coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureServiceAccounts: 1,
+				},
+			},
+		})
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		user, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
+			OrganizationIDs: []uuid.UUID{first.OrganizationID},
+			Username:        "service-acct-ok",
+			UserLoginType:   codersdk.LoginTypeNone,
+			ServiceAccount:  true,
+		})
+		require.NoError(t, err)
+		require.Equal(t, codersdk.LoginTypeNone, user.LoginType)
+		require.Empty(t, user.Email)
+		require.Equal(t, "service-acct-ok", user.Username)
+		require.True(t, user.IsServiceAccount)
+	})
+
+	t.Run("DefaultLoginType", func(t *testing.T) {
+		t.Parallel()
+		client, first := coderdenttest.New(t, &coderdenttest.Options{
+			LicenseOptions: &coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureServiceAccounts: 1,
+				},
+			},
+		})
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		user, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
+			OrganizationIDs: []uuid.UUID{first.OrganizationID},
+			Username:        "service-acct-default-login",
+			ServiceAccount:  true,
+		})
+		require.NoError(t, err)
+		require.Equal(t, codersdk.LoginTypeNone, user.LoginType)
+		require.Empty(t, user.Email)
+	})
+
+	t.Run("MultipleWithoutEmail", func(t *testing.T) {
+		t.Parallel()
+		client, first := coderdenttest.New(t, &coderdenttest.Options{
+			LicenseOptions: &coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureServiceAccounts: 1,
+				},
+			},
+		})
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		user1, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
+			OrganizationIDs: []uuid.UUID{first.OrganizationID},
+			Username:        "service-acct-multi-1",
+			ServiceAccount:  true,
+		})
+		require.NoError(t, err)
+		require.Empty(t, user1.Email)
+
+		user2, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
+			OrganizationIDs: []uuid.UUID{first.OrganizationID},
+			Username:        "service-acct-multi-2",
+			ServiceAccount:  true,
+		})
+		require.NoError(t, err)
+		require.Empty(t, user2.Email)
+		require.NotEqual(t, user1.ID, user2.ID)
+	})
+}

--- a/enterprise/coderd/users_test.go
+++ b/enterprise/coderd/users_test.go
@@ -617,8 +617,13 @@ func TestEnterprisePostUser(t *testing.T) {
 
 	t.Run("ServiceAccount/OK", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, nil)
-		first := coderdtest.CreateFirstUser(t, client)
+		client, first := coderdenttest.New(t, &coderdenttest.Options{
+			LicenseOptions: &coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureServiceAccounts: 1,
+				},
+			},
+		})
 
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
@@ -638,8 +643,13 @@ func TestEnterprisePostUser(t *testing.T) {
 
 	t.Run("ServiceAccount/WithEmail", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, nil)
-		first := coderdtest.CreateFirstUser(t, client)
+		client, first := coderdenttest.New(t, &coderdenttest.Options{
+			LicenseOptions: &coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureServiceAccounts: 1,
+				},
+			},
+		})
 
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
@@ -658,8 +668,13 @@ func TestEnterprisePostUser(t *testing.T) {
 
 	t.Run("ServiceAccount/WithPassword", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, nil)
-		first := coderdtest.CreateFirstUser(t, client)
+		client, first := coderdenttest.New(t, &coderdenttest.Options{
+			LicenseOptions: &coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureServiceAccounts: 1,
+				},
+			},
+		})
 
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
@@ -678,8 +693,13 @@ func TestEnterprisePostUser(t *testing.T) {
 
 	t.Run("ServiceAccount/WithInvalidLoginType", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, nil)
-		first := coderdtest.CreateFirstUser(t, client)
+		client, first := coderdenttest.New(t, &coderdenttest.Options{
+			LicenseOptions: &coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureServiceAccounts: 1,
+				},
+			},
+		})
 
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
@@ -698,8 +718,13 @@ func TestEnterprisePostUser(t *testing.T) {
 
 	t.Run("ServiceAccount/DefaultLoginType", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, nil)
-		first := coderdtest.CreateFirstUser(t, client)
+		client, first := coderdenttest.New(t, &coderdenttest.Options{
+			LicenseOptions: &coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureServiceAccounts: 1,
+				},
+			},
+		})
 
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
@@ -717,28 +742,15 @@ func TestEnterprisePostUser(t *testing.T) {
 		require.Empty(t, found.Email)
 	})
 
-	t.Run("NonServiceAccount/WithoutEmail", func(t *testing.T) {
-		t.Parallel()
-		client := coderdtest.New(t, nil)
-		first := coderdtest.CreateFirstUser(t, client)
-
-		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
-		defer cancel()
-
-		_, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
-			OrganizationIDs: []uuid.UUID{first.OrganizationID},
-			Username:        "regular-no-email",
-			UserLoginType:   codersdk.LoginTypePassword,
-		})
-		var apiErr *codersdk.Error
-		require.ErrorAs(t, err, &apiErr)
-		require.Equal(t, http.StatusBadRequest, apiErr.StatusCode())
-	})
-
 	t.Run("ServiceAccount/MultipleWithoutEmail", func(t *testing.T) {
 		t.Parallel()
-		client := coderdtest.New(t, nil)
-		first := coderdtest.CreateFirstUser(t, client)
+		client, first := coderdenttest.New(t, &coderdenttest.Options{
+			LicenseOptions: &coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureServiceAccounts: 1,
+				},
+			},
+		})
 
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()

--- a/enterprise/coderd/users_test.go
+++ b/enterprise/coderd/users_test.go
@@ -614,20 +614,11 @@ func TestEnterprisePostUser(t *testing.T) {
 		require.Len(t, memberedOrgs, 2)
 		require.ElementsMatch(t, []uuid.UUID{second.ID, third.ID}, []uuid.UUID{memberedOrgs[0].ID, memberedOrgs[1].ID})
 	})
-}
 
-func TestEnterpriseServiceAccounts(t *testing.T) {
-	t.Parallel()
-
-	t.Run("OK", func(t *testing.T) {
+	t.Run("ServiceAccount/OK", func(t *testing.T) {
 		t.Parallel()
-		client, first := coderdenttest.New(t, &coderdenttest.Options{
-			LicenseOptions: &coderdenttest.LicenseOptions{
-				Features: license.Features{
-					codersdk.FeatureServiceAccounts: 1,
-				},
-			},
-		})
+		client := coderdtest.New(t, nil)
+		first := coderdtest.CreateFirstUser(t, client)
 
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
@@ -642,18 +633,73 @@ func TestEnterpriseServiceAccounts(t *testing.T) {
 		require.Equal(t, codersdk.LoginTypeNone, user.LoginType)
 		require.Empty(t, user.Email)
 		require.Equal(t, "service-acct-ok", user.Username)
-		require.True(t, user.IsServiceAccount)
+		require.Equal(t, codersdk.UserStatusDormant, user.Status)
 	})
 
-	t.Run("DefaultLoginType", func(t *testing.T) {
+	t.Run("ServiceAccount/WithEmail", func(t *testing.T) {
 		t.Parallel()
-		client, first := coderdenttest.New(t, &coderdenttest.Options{
-			LicenseOptions: &coderdenttest.LicenseOptions{
-				Features: license.Features{
-					codersdk.FeatureServiceAccounts: 1,
-				},
-			},
+		client := coderdtest.New(t, nil)
+		first := coderdtest.CreateFirstUser(t, client)
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		_, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
+			OrganizationIDs: []uuid.UUID{first.OrganizationID},
+			Username:        "service-acct-email",
+			Email:           "should-not-have@email.com",
+			ServiceAccount:  true,
 		})
+		var apiErr *codersdk.Error
+		require.ErrorAs(t, err, &apiErr)
+		require.Equal(t, http.StatusBadRequest, apiErr.StatusCode())
+		require.Contains(t, apiErr.Message, "Email cannot be set for service accounts")
+	})
+
+	t.Run("ServiceAccount/WithPassword", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, nil)
+		first := coderdtest.CreateFirstUser(t, client)
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		_, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
+			OrganizationIDs: []uuid.UUID{first.OrganizationID},
+			Username:        "service-acct-password",
+			Password:        "ShouldNotHavePassword123!",
+			ServiceAccount:  true,
+		})
+		var apiErr *codersdk.Error
+		require.ErrorAs(t, err, &apiErr)
+		require.Equal(t, http.StatusBadRequest, apiErr.StatusCode())
+		require.Contains(t, apiErr.Message, "Password cannot be set for service accounts")
+	})
+
+	t.Run("ServiceAccount/WithInvalidLoginType", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, nil)
+		first := coderdtest.CreateFirstUser(t, client)
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		_, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
+			OrganizationIDs: []uuid.UUID{first.OrganizationID},
+			Username:        "service-acct-login-type",
+			UserLoginType:   codersdk.LoginTypePassword,
+			ServiceAccount:  true,
+		})
+		var apiErr *codersdk.Error
+		require.ErrorAs(t, err, &apiErr)
+		require.Equal(t, http.StatusBadRequest, apiErr.StatusCode())
+		require.Contains(t, apiErr.Message, "Service accounts must use login type 'none'")
+	})
+
+	t.Run("ServiceAccount/DefaultLoginType", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, nil)
+		first := coderdtest.CreateFirstUser(t, client)
 
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
@@ -664,19 +710,35 @@ func TestEnterpriseServiceAccounts(t *testing.T) {
 			ServiceAccount:  true,
 		})
 		require.NoError(t, err)
-		require.Equal(t, codersdk.LoginTypeNone, user.LoginType)
-		require.Empty(t, user.Email)
+
+		found, err := client.User(ctx, user.ID.String())
+		require.NoError(t, err)
+		require.Equal(t, codersdk.LoginTypeNone, found.LoginType)
+		require.Empty(t, found.Email)
 	})
 
-	t.Run("MultipleWithoutEmail", func(t *testing.T) {
+	t.Run("NonServiceAccount/WithoutEmail", func(t *testing.T) {
 		t.Parallel()
-		client, first := coderdenttest.New(t, &coderdenttest.Options{
-			LicenseOptions: &coderdenttest.LicenseOptions{
-				Features: license.Features{
-					codersdk.FeatureServiceAccounts: 1,
-				},
-			},
+		client := coderdtest.New(t, nil)
+		first := coderdtest.CreateFirstUser(t, client)
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		_, err := client.CreateUserWithOrgs(ctx, codersdk.CreateUserRequestWithOrgs{
+			OrganizationIDs: []uuid.UUID{first.OrganizationID},
+			Username:        "regular-no-email",
+			UserLoginType:   codersdk.LoginTypePassword,
 		})
+		var apiErr *codersdk.Error
+		require.ErrorAs(t, err, &apiErr)
+		require.Equal(t, http.StatusBadRequest, apiErr.StatusCode())
+	})
+
+	t.Run("ServiceAccount/MultipleWithoutEmail", func(t *testing.T) {
+		t.Parallel()
+		client := coderdtest.New(t, nil)
+		first := coderdtest.CreateFirstUser(t, client)
 
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()

--- a/enterprise/coderd/workspacesharing_test.go
+++ b/enterprise/coderd/workspacesharing_test.go
@@ -231,7 +231,13 @@ func TestWorkspaceSharingDisabled(t *testing.T) {
 	t.Run("ACLEndpointsForbiddenServiceAccountsMode", func(t *testing.T) {
 		t.Parallel()
 
-		client, db, owner := coderdenttest.NewWithDatabase(t, nil)
+		client, db, owner := coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
+			LicenseOptions: &coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureServiceAccounts: 1,
+				},
+			},
+		})
 
 		regularClient, regularUser := coderdtest.CreateAnotherUser(t, client, owner.OrganizationID)
 		regularWS := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
@@ -444,7 +450,8 @@ func TestWorkspaceSharingDisabled(t *testing.T) {
 			},
 			LicenseOptions: &coderdenttest.LicenseOptions{
 				Features: license.Features{
-					codersdk.FeatureTemplateRBAC: 1,
+					codersdk.FeatureTemplateRBAC:    1,
+					codersdk.FeatureServiceAccounts: 1,
 				},
 			},
 		})

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -3473,6 +3473,7 @@ export type FeatureName =
 	| "multiple_external_auth"
 	| "multiple_organizations"
 	| "scim"
+	| "service_accounts"
 	| "task_batch_actions"
 	| "template_rbac"
 	| "user_limit"
@@ -3501,6 +3502,7 @@ export const FeatureNames: FeatureName[] = [
 	"multiple_external_auth",
 	"multiple_organizations",
 	"scim",
+	"service_accounts",
 	"task_batch_actions",
 	"template_rbac",
 	"user_limit",

--- a/site/src/pages/CreateUserPage/CreateUserForm.stories.tsx
+++ b/site/src/pages/CreateUserPage/CreateUserForm.stories.tsx
@@ -17,6 +17,7 @@ const meta: Meta<typeof CreateUserForm> = {
 		onCancel: action("cancel"),
 		onSubmit: action("submit"),
 		isLoading: false,
+		serviceAccountsEnabled: true,
 	},
 };
 

--- a/site/src/pages/CreateUserPage/CreateUserForm.tsx
+++ b/site/src/pages/CreateUserPage/CreateUserForm.tsx
@@ -87,6 +87,7 @@ interface CreateUserFormProps {
 	onCancel: () => void;
 	authMethods?: TypesGen.AuthMethods;
 	showOrganizations: boolean;
+	serviceAccountsEnabled: boolean;
 }
 
 export const CreateUserForm: FC<CreateUserFormProps> = ({
@@ -96,12 +97,13 @@ export const CreateUserForm: FC<CreateUserFormProps> = ({
 	onCancel,
 	showOrganizations,
 	authMethods,
+	serviceAccountsEnabled,
 }) => {
 	const availableLoginTypes = [
 		authMethods?.password.enabled && "password",
 		authMethods?.oidc.enabled && "oidc",
 		authMethods?.github.enabled && "github",
-		"none",
+		serviceAccountsEnabled && "none",
 	].filter(Boolean) as Array<keyof typeof loginTypeOptions>;
 
 	const defaultLoginType = availableLoginTypes[0];

--- a/site/src/pages/CreateUserPage/CreateUserPage.tsx
+++ b/site/src/pages/CreateUserPage/CreateUserPage.tsx
@@ -6,6 +6,7 @@ import { getErrorDetail, getErrorMessage } from "#/api/errors";
 import { authMethods, createUser } from "#/api/queries/users";
 import { Margins } from "#/components/Margins/Margins";
 import { useDashboard } from "#/modules/dashboard/useDashboard";
+import { useFeatureVisibility } from "#/modules/dashboard/useFeatureVisibility";
 import { pageTitle } from "#/utils/page";
 import { CreateUserForm } from "./CreateUserForm";
 
@@ -15,6 +16,7 @@ const CreateUserPage: FC = () => {
 	const createUserMutation = useMutation(createUser(queryClient));
 	const authMethodsQuery = useQuery(authMethods());
 	const { showOrganizations } = useDashboard();
+	const { service_accounts: serviceAccountsEnabled } = useFeatureVisibility();
 
 	return (
 		<Margins>
@@ -58,6 +60,7 @@ const CreateUserPage: FC = () => {
 				}}
 				authMethods={authMethodsQuery.data}
 				showOrganizations={showOrganizations}
+				serviceAccountsEnabled={serviceAccountsEnabled}
 			/>
 		</Margins>
 	);


### PR DESCRIPTION
Simple tweak to make service accounts premium only

- Add a new service accounts entitlement
- Make creating a service account require that
- Check whether it's available or not on the frontend to conditionally hide the service account option
- Move most of the service accounts tests in to enterprise, because yes
- Test that you can't create a service account without a license