### PR TITLE
ci: add automatic backport workflow

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,0 +1,141 @@
+# Automatically backport merged PRs to the last N release branches when the
+# "backport" label is applied. Works whether the label is added before or
+# after the PR is merged.
+#
+# Usage:
+#   1. Add the "backport" label to a PR targeting main.
+#   2. When the PR merges (or if already merged), the workflow detects the
+#      latest release/* branches and opens one cherry-pick PR per branch.
+#
+# The created backport PRs follow existing repo conventions:
+#   - Branch:  backport/<pr>-to-<version>
+#   - Title:   chore: backport #<pr> to <version>
+#   - Label:   cherry-pick/v<version>
+#   - Body:    links back to the original PR and merge commit
+
+name: Backport
+on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - closed
+      - labeled
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# Prevent duplicate runs for the same PR when both 'closed' and 'labeled'
+# fire in quick succession.
+concurrency:
+  group: backport-${{ github.event.pull_request.number }}
+
+jobs:
+  detect:
+    name: Detect target branches
+    if: >
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'backport')
+    runs-on: ubuntu-latest
+    outputs:
+      branches: ${{ steps.find.outputs.branches }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Need all refs to discover release branches.
+          fetch-depth: 0
+
+      - name: Find latest release branches
+        id: find
+        run: |
+          # List remote release branches matching the exact release/2.X
+          # pattern (no suffixes like release/2.31_hotfix), sort by minor
+          # version descending, and take the top 3.
+          BRANCHES=$(
+            git branch -r \
+              | grep -E '^\s*origin/release/2\.[0-9]+$' \
+              | sed 's|.*origin/||' \
+              | sort -t. -k2 -n -r \
+              | head -3
+          )
+
+          if [ -z "$BRANCHES" ]; then
+            echo "No release branches found."
+            echo "branches=[]" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Convert to JSON array for the matrix.
+          JSON=$(echo "$BRANCHES" | jq -Rnc '[inputs | select(length > 0)]')
+          echo "branches=$JSON" >> "$GITHUB_OUTPUT"
+          echo "Will backport to: $JSON"
+
+  backport:
+    name: "Backport to ${{ matrix.branch }}"
+    needs: detect
+    if: needs.detect.outputs.branches != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        branch: ${{ fromJson(needs.detect.outputs.branches) }}
+      fail-fast: false
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      PR_TITLE: ${{ github.event.pull_request.title }}
+      PR_URL: ${{ github.event.pull_request.html_url }}
+      MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Full history required for cherry-pick.
+          fetch-depth: 0
+
+      - name: Cherry-pick and open PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          RELEASE_VERSION="${{ matrix.branch }}"
+          # Strip the release/ prefix for naming.
+          VERSION="${RELEASE_VERSION#release/}"
+          BACKPORT_BRANCH="backport/${PR_NUMBER}-to-${VERSION}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Create the backport branch from the target release branch.
+          git checkout -b "$BACKPORT_BRANCH" "origin/${RELEASE_VERSION}"
+
+          # Cherry-pick the merge commit. Use -x to record provenance and
+          # -m1 to pick the first parent (the main branch side).
+          if ! git cherry-pick -x -m1 "$MERGE_SHA"; then
+            echo "::warning::Cherry-pick to ${RELEASE_VERSION} had conflicts."
+
+            # Stage conflicts so the PR can be opened for manual resolution.
+            git add -A
+            git -c core.editor=true cherry-pick --continue || true
+          fi
+
+          git push origin "$BACKPORT_BRANCH"
+
+          # Ensure the cherry-pick label exists (create if missing).
+          LABEL="cherry-pick/v${VERSION}"
+          gh label create "$LABEL" --color "0E8A16" --force 2>/dev/null || true
+
+          BODY=$(cat <<EOF
+          Backport of ${PR_URL}
+
+          Original PR: #${PR_NUMBER} — ${PR_TITLE}
+          Merge commit: ${MERGE_SHA}
+          EOF
+          )
+
+          gh pr create \
+            --draft \
+            --base "$RELEASE_VERSION" \
+            --head "$BACKPORT_BRANCH" \
+            --label "$LABEL" \
+            --title "chore: backport #${PR_NUMBER} to ${VERSION}" \
+            --body "$BODY"

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -10,7 +10,6 @@
 # The created backport PRs follow existing repo conventions:
 #   - Branch:  backport/<pr>-to-<version>
 #   - Title:   <original PR title> (<version>)
-#   - Label:   cherry-pick/v<version>
 #   - Body:    links back to the original PR and merge commit
 
 name: Backport
@@ -120,10 +119,6 @@ jobs:
 
           git push origin "$BACKPORT_BRANCH"
 
-          # Ensure the cherry-pick label exists (create if missing).
-          LABEL="cherry-pick/v${VERSION}"
-          gh label create "$LABEL" --color "0E8A16" --force 2>/dev/null || true
-
           BODY=$(cat <<EOF
           Backport of ${PR_URL}
 
@@ -136,6 +131,5 @@ jobs:
             --draft \
             --base "$RELEASE_VERSION" \
             --head "$BACKPORT_BRANCH" \
-            --label "$LABEL" \
             --title "${PR_TITLE} (${VERSION})" \
             --body "$BODY"

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -128,7 +128,6 @@ jobs:
           )
 
           gh pr create \
-            --draft \
             --base "$RELEASE_VERSION" \
             --head "$BACKPORT_BRANCH" \
             --title "${PR_TITLE} (${VERSION})" \

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -9,7 +9,7 @@
 #
 # The created backport PRs follow existing repo conventions:
 #   - Branch:  backport/<pr>-to-<version>
-#   - Title:   chore: backport #<pr> to <version>
+#   - Title:   <original PR title> (<version>)
 #   - Label:   cherry-pick/v<version>
 #   - Body:    links back to the original PR and merge commit
 
@@ -137,5 +137,5 @@ jobs:
             --base "$RELEASE_VERSION" \
             --head "$BACKPORT_BRANCH" \
             --label "$LABEL" \
-            --title "chore: backport #${PR_NUMBER} to ${VERSION}" \
+            --title "${PR_TITLE} (${VERSION})" \
             --body "$BODY"

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -104,21 +104,36 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+          # Check if backport branch already exists (idempotency for re-runs).
+          if git ls-remote --exit-code origin "refs/heads/${BACKPORT_BRANCH}" >/dev/null 2>&1; then
+            echo "Backport branch ${BACKPORT_BRANCH} already exists, skipping."
+            exit 0
+          fi
+
           # Create the backport branch from the target release branch.
           git checkout -b "$BACKPORT_BRANCH" "origin/${RELEASE_VERSION}"
 
           # Cherry-pick the merge commit. Use -x to record provenance and
           # -m1 to pick the first parent (the main branch side).
+          CONFLICTS=false
           if ! git cherry-pick -x -m1 "$MERGE_SHA"; then
             echo "::warning::Cherry-pick to ${RELEASE_VERSION} had conflicts."
+            CONFLICTS=true
 
-            # Stage conflicts so the PR can be opened for manual resolution.
-            git add -A
-            git -c core.editor=true cherry-pick --continue || true
+            # Abort the failed cherry-pick and create an empty commit
+            # explaining the situation.
+            git cherry-pick --abort
+            git commit --allow-empty -m "Cherry-pick of #${PR_NUMBER} requires manual resolution
+
+          The automatic cherry-pick of ${MERGE_SHA} to ${RELEASE_VERSION} had conflicts.
+          Please cherry-pick manually:
+
+              git cherry-pick -x -m1 ${MERGE_SHA}"
           fi
 
           git push origin "$BACKPORT_BRANCH"
 
+          TITLE="${PR_TITLE} (#${PR_NUMBER})"
           BODY=$(cat <<EOF
           Backport of ${PR_URL}
 
@@ -127,8 +142,33 @@ jobs:
           EOF
           )
 
+          if [ "$CONFLICTS" = true ]; then
+            TITLE="${TITLE} (conflicts)"
+            BODY="${BODY}
+
+          > [!WARNING]
+          > The automatic cherry-pick had conflicts.
+          > Please resolve manually by cherry-picking the original merge commit:
+          >
+          > \`\`\`
+          > git fetch origin ${BACKPORT_BRANCH}
+          > git checkout ${BACKPORT_BRANCH}
+          > git reset --hard origin/${RELEASE_VERSION}
+          > git cherry-pick -x -m1 ${MERGE_SHA}
+          > # resolve conflicts, then push
+          > \`\`\`"
+          fi
+
+          # Check if a PR already exists for this branch (idempotency
+          # for re-runs).
+          EXISTING_PR=$(gh pr list --head "$BACKPORT_BRANCH" --base "$RELEASE_VERSION" --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING_PR" ]; then
+            echo "PR #${EXISTING_PR} already exists for ${BACKPORT_BRANCH}, skipping."
+            exit 0
+          fi
+
           gh pr create \
             --base "$RELEASE_VERSION" \
             --head "$BACKPORT_BRANCH" \
-            --title "${PR_TITLE} (#${PR_NUMBER})" \
+            --title "$TITLE" \
             --body "$BODY"

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -9,7 +9,7 @@
 #
 # The created backport PRs follow existing repo conventions:
 #   - Branch:  backport/<pr>-to-<version>
-#   - Title:   <original PR title> (<version>)
+#   - Title:   <original PR title> (#<pr>) (<version>)
 #   - Body:    links back to the original PR and merge commit
 
 name: Backport
@@ -130,5 +130,5 @@ jobs:
           gh pr create \
             --base "$RELEASE_VERSION" \
             --head "$BACKPORT_BRANCH" \
-            --title "${PR_TITLE} (${VERSION})" \
+            --title "${PR_TITLE} (#${PR_NUMBER}) (${VERSION})" \
             --body "$BODY"

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -161,7 +161,7 @@ jobs:
 
           # Check if a PR already exists for this branch (idempotency
           # for re-runs).
-          EXISTING_PR=$(gh pr list --head "$BACKPORT_BRANCH" --base "$RELEASE_VERSION" --json number --jq '.[0].number // empty')
+          EXISTING_PR=$(gh pr list --head "$BACKPORT_BRANCH" --base "$RELEASE_VERSION" --state all --json number --jq '.[0].number // empty')
           if [ -n "$EXISTING_PR" ]; then
             echo "PR #${EXISTING_PR} already exists for ${BACKPORT_BRANCH}, skipping."
             exit 0

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -9,7 +9,7 @@
 #
 # The created backport PRs follow existing repo conventions:
 #   - Branch:  backport/<pr>-to-<version>
-#   - Title:   <original PR title> (#<pr>) (<version>)
+#   - Title:   <original PR title> (#<pr>)
 #   - Body:    links back to the original PR and merge commit
 
 name: Backport
@@ -130,5 +130,5 @@ jobs:
           gh pr create \
             --base "$RELEASE_VERSION" \
             --head "$BACKPORT_BRANCH" \
-            --title "${PR_TITLE} (#${PR_NUMBER}) (${VERSION})" \
+            --title "${PR_TITLE} (#${PR_NUMBER})" \
             --body "$BODY"

--- a/docs/about/contributing/CONTRIBUTING.md
+++ b/docs/about/contributing/CONTRIBUTING.md
@@ -291,18 +291,22 @@ specification, however, it's still possible to merge PRs on GitHub with a badly
 formatted title. Take care when merging single-commit PRs as GitHub may prefer
 to use the original commit title instead of the PR title.
 
-### Cherry-picking to the latest release branch
+### Backporting fixes to release branches
 
-When a merged PR on `main` should also ship in the current release,
-add the **`cherry-pick`** label to the PR (before or after merge).
+When a merged PR on `main` should also ship in older releases, add the
+`backport` label to the PR. The
+[backport workflow](https://github.com/coder/coder/blob/main/.github/workflows/backport.yaml)
+will automatically detect the latest three `release/*` branches,
+cherry-pick the merge commit onto each one, and open draft PRs for
+review.
 
-The automation detects the latest `release/*` branch, cherry-picks the
-merge commit, and opens a PR for review. The PR reuses the original
-title (e.g. `fix(site): correct button alignment (#12345)`) so the
-change is meaningful in release notes.
+The label can be added before or after the PR is merged. Each backport
+PR reuses the original title with a version suffix (e.g.
+`fix(site): correct button alignment (2.32)`) so the change is
+meaningful in release notes.
 
-If the cherry-pick encounters conflicts, the PR is still created with
-instructions for manual resolution.
+If the cherry-pick encounters conflicts, the backport PR is still
+created with conflict markers so you can resolve them manually.
 
 ### Breaking changes
 

--- a/docs/about/contributing/CONTRIBUTING.md
+++ b/docs/about/contributing/CONTRIBUTING.md
@@ -297,7 +297,7 @@ When a merged PR on `main` should also ship in older releases, add the
 `backport` label to the PR. The
 [backport workflow](https://github.com/coder/coder/blob/main/.github/workflows/backport.yaml)
 will automatically detect the latest three `release/*` branches,
-cherry-pick the merge commit onto each one, and open draft PRs for
+cherry-pick the merge commit onto each one, and open PRs for
 review.
 
 The label can be added before or after the PR is merged. Each backport

--- a/docs/about/contributing/CONTRIBUTING.md
+++ b/docs/about/contributing/CONTRIBUTING.md
@@ -305,8 +305,8 @@ PR reuses the original title (e.g.
 `fix(site): correct button alignment (#12345)`) so the change is
 meaningful in release notes.
 
-If the cherry-pick encounters conflicts, the backport PR is still
-created with conflict markers so you can resolve them manually.
+If the cherry-pick encounters conflicts, the backport PR is still created
+with instructions for manual resolution — no conflict markers are committed.
 
 ### Breaking changes
 

--- a/docs/about/contributing/CONTRIBUTING.md
+++ b/docs/about/contributing/CONTRIBUTING.md
@@ -301,8 +301,8 @@ cherry-pick the merge commit onto each one, and open PRs for
 review.
 
 The label can be added before or after the PR is merged. Each backport
-PR reuses the original title with a version suffix (e.g.
-`fix(site): correct button alignment (2.32)`) so the change is
+PR reuses the original title (e.g.
+`fix(site): correct button alignment (#12345)`) so the change is
 meaningful in release notes.
 
 If the cherry-pick encounters conflicts, the backport PR is still


### PR DESCRIPTION
Adds a GitHub Actions workflow that automatically cherry-picks merged PRs to the last 3 release branches when the `backport` label is applied.

## How it works

1. Add the `backport` label to any PR targeting `main` (before or after merge).
2. On merge (or on label if already merged), the workflow discovers the latest 3 `release/*` branches by semver.
3. For each branch, it cherry-picks the merge commit (`-x -m1`) and opens a PR.

Created backport PRs follow existing repo conventions:
- **Branch:** `backport/<pr>-to-<version>`
- **Title:** `<original PR title> (#<pr>)` — e.g. `fix(site): correct button alignment (#12345)`
- **Body:** links back to the original PR and merge commit

If cherry-pick has conflicts, the PR is still opened with instructions for manual resolution — no conflict markers are committed.

Also:
- Removes `scripts/backport-pr.sh` (replaced by this workflow)
- Removes `.github/cherry-pick-bot.yml` (old bot config)
- Adds a section to the contributing docs explaining how to use the backport label

> [!NOTE]
> Generated with [Coder Agents](https://coder.com/agents)