### PR TITLE
fix: show message action tooltips at bottom on agents page

### DIFF
--- a/site/src/components/CopyButton/CopyButton.tsx
+++ b/site/src/components/CopyButton/CopyButton.tsx
@@ -12,11 +12,13 @@ import { useClipboard } from "#/hooks/useClipboard";
 type CopyButtonProps = ButtonProps & {
 	text: string;
 	label: string;
+	tooltipSide?: "top" | "bottom" | "left" | "right";
 };
 
 export const CopyButton: FC<CopyButtonProps> = ({
 	text,
 	label,
+	tooltipSide,
 	...buttonProps
 }) => {
 	const { showCopiedSuccess, copyToClipboard } = useClipboard();
@@ -34,7 +36,7 @@ export const CopyButton: FC<CopyButtonProps> = ({
 					<span className="sr-only">{label}</span>
 				</Button>
 			</TooltipTrigger>
-			<TooltipContent>{label}</TooltipContent>
+			<TooltipContent side={tooltipSide}>{label}</TooltipContent>
 		</Tooltip>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -643,6 +643,7 @@ const ChatMessageItem = memo<{
 									text={parsed.markdown}
 									label="Copy message"
 									className="size-6"
+									tooltipSide="bottom"
 								/>
 							)}
 							{isUser && onEditUserMessage && (


### PR DESCRIPTION
The CopyButton tooltip on `/agents` defaulted to top (Radix default), while the Edit button already used `side="bottom"`. This adds an optional `tooltipSide` prop to `CopyButton` and passes `"bottom"` in the agents `ConversationTimeline` so both tooltips appear below the buttons consistently.

## Changes

- `CopyButton`: added optional `tooltipSide` prop, forwarded to `<TooltipContent side={tooltipSide}>`
- `ConversationTimeline`: passed `tooltipSide="bottom"` to the copy-message `CopyButton`

> Generated by Coder Agents