### PR TITLE
feat: add a debounce to menu filtering

### DIFF
--- a/site/src/components/Combobox/Combobox.stories.tsx
+++ b/site/src/components/Combobox/Combobox.stories.tsx
@@ -37,6 +37,7 @@ const ComboboxWithHooks = ({
 	optionsList?: SelectFilterOption[];
 }) => {
 	const [value, setValue] = useState<string | undefined>(undefined);
+	const [inputValue, setInputValue] = useState("");
 	const selectedOption = optionsList.find((opt) => opt.value === value);
 
 	return (
@@ -48,7 +49,11 @@ const ComboboxWithHooks = ({
 				/>
 			</ComboboxTrigger>
 			<ComboboxContent className="w-60">
-				<ComboboxInput placeholder="Search..." />
+				<ComboboxInput
+					placeholder="Search..."
+					value={inputValue}
+					onValueChange={setInputValue}
+				/>
 				<ComboboxList>
 					{optionsList.map((option) => (
 						<ComboboxItem key={option.value} value={option.value}>

--- a/site/src/components/Combobox/Combobox.tsx
+++ b/site/src/components/Combobox/Combobox.tsx
@@ -1,6 +1,6 @@
 import { CheckIcon } from "lucide-react";
 import type React from "react";
-import { createContext, useContext, useRef, useState } from "react";
+import { type KeyboardEvent, createContext, useContext, useRef, useState } from "react";
 import { ChevronDownIcon } from "#/components/AnimatedIcons/ChevronDown";
 import { Button } from "#/components/Button/Button";
 import {
@@ -131,24 +131,25 @@ export const ComboboxContent = ({
 
 type ComboboxInputProps = Omit<
 	React.ComponentPropsWithRef<typeof CommandInput>,
-	"onValueChange"
+	"onValueChange" | "value" | "defaultValue"
 > & {
-	onValueChange: NonNullable<
-		React.ComponentPropsWithRef<typeof CommandInput>["onValueChange"]
-	>;
+	onValueChange: (value: string) => void;
+	value?: string;
+	defaultValue?: string;
 };
 
-export const ComboboxInput = ({
+export const ComboboxInput: React.FC<ComboboxInputProps> = ({
 	onValueChange,
 	value,
 	defaultValue,
 	onBlur,
+	onKeyDown,
 	...props
-}: ComboboxInputProps) => {
+}) => {
 	const [internalValue, setInternalValue] = useState<string>(
-		String(value ?? defaultValue ?? ""),
+		value ?? defaultValue ?? "",
 	);
-	const externalValue = value === undefined ? undefined : String(value);
+	const externalValue = value;
 	const lastExternalValueRef = useRef(externalValue);
 
 	if (externalValue !== lastExternalValueRef.current) {
@@ -163,6 +164,16 @@ export const ComboboxInput = ({
 		COMBOBOX_DEBOUNCE_MS,
 	);
 
+	const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+		// Flush the pending debounce immediately on Enter so that
+		// parent onKeyDown handlers see up-to-date state.
+		if (event.key === "Enter") {
+			cancelDebounce();
+			onValueChange(internalValue);
+		}
+		onKeyDown?.(event);
+	};
+
 	return (
 		<CommandInput
 			{...props}
@@ -175,6 +186,7 @@ export const ComboboxInput = ({
 				cancelDebounce();
 				onBlur?.(event);
 			}}
+			onKeyDown={handleKeyDown}
 		/>
 	);
 };

--- a/site/src/components/Combobox/Combobox.tsx
+++ b/site/src/components/Combobox/Combobox.tsx
@@ -1,6 +1,6 @@
 import { CheckIcon } from "lucide-react";
 import type React from "react";
-import { createContext, useContext, useState } from "react";
+import { createContext, useContext, useRef, useState } from "react";
 import { ChevronDownIcon } from "#/components/AnimatedIcons/ChevronDown";
 import { Button } from "#/components/Button/Button";
 import {
@@ -16,7 +16,10 @@ import {
 	PopoverContent,
 	PopoverTrigger,
 } from "#/components/Popover/Popover";
+import { useDebouncedFunction } from "#/hooks/debounce";
 import { cn } from "#/utils/cn";
+
+const COMBOBOX_DEBOUNCE_MS = 300;
 
 type ComboboxContextProps = {
 	open: boolean;
@@ -126,7 +129,55 @@ export const ComboboxContent = ({
 	);
 };
 
-export const ComboboxInput = CommandInput;
+type ComboboxInputProps = Omit<
+	React.ComponentPropsWithRef<typeof CommandInput>,
+	"onValueChange"
+> & {
+	onValueChange: NonNullable<
+		React.ComponentPropsWithRef<typeof CommandInput>["onValueChange"]
+	>;
+};
+
+export const ComboboxInput = ({
+	onValueChange,
+	value,
+	defaultValue,
+	onBlur,
+	...props
+}: ComboboxInputProps) => {
+	const [internalValue, setInternalValue] = useState<string>(
+		String(value ?? defaultValue ?? ""),
+	);
+	const externalValue = value === undefined ? undefined : String(value);
+	const lastExternalValueRef = useRef(externalValue);
+
+	if (externalValue !== lastExternalValueRef.current) {
+		lastExternalValueRef.current = externalValue;
+		setInternalValue(externalValue ?? "");
+	}
+
+	const { debounced, cancelDebounce } = useDebouncedFunction(
+		(nextValue: string) => {
+			onValueChange(nextValue);
+		},
+		COMBOBOX_DEBOUNCE_MS,
+	);
+
+	return (
+		<CommandInput
+			{...props}
+			onValueChange={(nextValue) => {
+				setInternalValue(nextValue);
+				debounced(nextValue);
+			}}
+			value={internalValue}
+			onBlur={(event) => {
+				cancelDebounce();
+				onBlur?.(event);
+			}}
+		/>
+	);
+};
 export const ComboboxList = CommandList;
 
 export const ComboboxItem = ({

--- a/site/src/components/Combobox/Combobox.tsx
+++ b/site/src/components/Combobox/Combobox.tsx
@@ -1,6 +1,6 @@
 import { CheckIcon } from "lucide-react";
 import type React from "react";
-import { type KeyboardEvent, createContext, useContext, useRef, useState } from "react";
+import { createContext, useContext, useState } from "react";
 import { ChevronDownIcon } from "#/components/AnimatedIcons/ChevronDown";
 import { Button } from "#/components/Button/Button";
 import {
@@ -16,10 +16,7 @@ import {
 	PopoverContent,
 	PopoverTrigger,
 } from "#/components/Popover/Popover";
-import { useDebouncedFunction } from "#/hooks/debounce";
 import { cn } from "#/utils/cn";
-
-const COMBOBOX_DEBOUNCE_MS = 300;
 
 type ComboboxContextProps = {
 	open: boolean;
@@ -129,67 +126,8 @@ export const ComboboxContent = ({
 	);
 };
 
-type ComboboxInputProps = Omit<
-	React.ComponentPropsWithRef<typeof CommandInput>,
-	"onValueChange" | "value" | "defaultValue"
-> & {
-	onValueChange: (value: string) => void;
-	value?: string;
-	defaultValue?: string;
-};
+export const ComboboxInput = CommandInput;
 
-export const ComboboxInput: React.FC<ComboboxInputProps> = ({
-	onValueChange,
-	value,
-	defaultValue,
-	onBlur,
-	onKeyDown,
-	...props
-}) => {
-	const [internalValue, setInternalValue] = useState<string>(
-		value ?? defaultValue ?? "",
-	);
-	const externalValue = value;
-	const lastExternalValueRef = useRef(externalValue);
-
-	if (externalValue !== lastExternalValueRef.current) {
-		lastExternalValueRef.current = externalValue;
-		setInternalValue(externalValue ?? "");
-	}
-
-	const { debounced, cancelDebounce } = useDebouncedFunction(
-		(nextValue: string) => {
-			onValueChange(nextValue);
-		},
-		COMBOBOX_DEBOUNCE_MS,
-	);
-
-	const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
-		// Flush the pending debounce immediately on Enter so that
-		// parent onKeyDown handlers see up-to-date state.
-		if (event.key === "Enter") {
-			cancelDebounce();
-			onValueChange(internalValue);
-		}
-		onKeyDown?.(event);
-	};
-
-	return (
-		<CommandInput
-			{...props}
-			onValueChange={(nextValue) => {
-				setInternalValue(nextValue);
-				debounced(nextValue);
-			}}
-			value={internalValue}
-			onBlur={(event) => {
-				cancelDebounce();
-				onBlur?.(event);
-			}}
-			onKeyDown={handleKeyDown}
-		/>
-	);
-};
 export const ComboboxList = CommandList;
 
 export const ComboboxItem = ({

--- a/site/src/components/Filter/SelectFilter.tsx
+++ b/site/src/components/Filter/SelectFilter.tsx
@@ -71,6 +71,8 @@ export const SelectFilter: FC<SelectFilterProps> = ({
 					minWidth: width,
 				}}
 				align="end"
+				// We want the backend to handle the filtering, not the client.
+				shouldFilter={false}
 			>
 				{selectFilterSearch}
 				<ComboboxList

--- a/site/src/components/Filter/menu.ts
+++ b/site/src/components/Filter/menu.ts
@@ -49,6 +49,10 @@ export const useFilterMenu = ({
 		enabled,
 	});
 	const searchOptions = useMemo(() => {
+		if (searchOptionsQuery.isFetching) {
+			return undefined;
+		}
+
 		const isDataLoaded =
 			searchOptionsQuery.isFetched && selectedOptionQuery.isFetched;
 
@@ -77,6 +81,7 @@ export const useFilterMenu = ({
 		query,
 		searchOptionsQuery.data,
 		searchOptionsQuery.isFetched,
+		searchOptionsQuery.isFetching,
 		selectedOption,
 	]);
 

--- a/site/src/components/Filter/menu.ts
+++ b/site/src/components/Filter/menu.ts
@@ -1,6 +1,9 @@
 import { useMemo, useRef, useState } from "react";
 import { keepPreviousData, useQuery } from "react-query";
 import type { SelectFilterOption } from "#/components/Filter/SelectFilter";
+import { useDebouncedValue } from "#/hooks/debounce";
+
+const FILTER_DEBOUNCE_MS = 300;
 
 export type UseFilterMenuOptions = {
 	id: string;
@@ -25,6 +28,7 @@ export const useFilterMenu = ({
 		{},
 	);
 	const [query, setQuery] = useState("");
+	const debouncedQuery = useDebouncedValue(query, FILTER_DEBOUNCE_MS);
 	const selectedOptionQuery = useQuery({
 		queryKey: [id, "autocomplete", "selected", value],
 		queryFn: () => {
@@ -44,8 +48,8 @@ export const useFilterMenu = ({
 	});
 	const selectedOption = selectedOptionQuery.data;
 	const searchOptionsQuery = useQuery({
-		queryKey: [id, "autocomplete", "search", query],
-		queryFn: () => getOptions(query),
+		queryKey: [id, "autocomplete", "search", debouncedQuery],
+		queryFn: () => getOptions(debouncedQuery),
 		enabled,
 	});
 	const searchOptions = useMemo(() => {


### PR DESCRIPTION
This pull-request implements a small debounce to ensure we aren't constantly pinging the backend on each keystroke of an input. 

<img width="962" height="317" alt="image" src="https://github.com/user-attachments/assets/4f187c18-0dd8-4456-bcc1-59ad7ce9c7dd" />

https://github.com/user-attachments/assets/5787310a-2c1e-448a-a4b7-123eb9d50124

