### PR TITLE
fix(site): use ResizeObserver to keep build timeline bars sized correctly

### DIFF
--- a/site/src/modules/workspaces/WorkspaceTiming/Chart/XAxis.tsx
+++ b/site/src/modules/workspaces/WorkspaceTiming/Chart/XAxis.tsx
@@ -1,4 +1,10 @@
-import { type FC, type HTMLProps, useLayoutEffect, useRef } from "react";
+import {
+	type FC,
+	type HTMLProps,
+	useCallback,
+	useLayoutEffect,
+	useRef,
+} from "react";
 import { cn } from "#/utils/cn";
 import { formatTime } from "./utils";
 
@@ -15,17 +21,41 @@ export const XAxis: FC<XAxisProps> = ({ ticks, scale, ...htmlProps }) => {
 	// The X axis should occupy all available space. If there is extra space,
 	// increase the column width accordingly. Use a CSS variable to propagate the
 	// value to the child components.
+	//
+	// A ResizeObserver supplements the synchronous measurement so that
+	// --x-axis-width stays correct when the available width changes *outside*
+	// React's render cycle (e.g. the MUI Collapse finishing its open animation,
+	// scrollbar appearance/disappearance, or window resize).
+	const tickCount = ticks.length;
+
+	const updateWidth = useCallback(
+		(el: HTMLElement) => {
+			// We always add one extra column to the grid to ensure that the last
+			// column is fully visible.
+			const avgWidth = el.clientWidth / (tickCount + 1);
+			const width = avgWidth > XAxisMinWidth ? avgWidth : XAxisMinWidth;
+			el.style.setProperty("--x-axis-width", `${width}px`);
+		},
+		[tickCount],
+	);
+
 	useLayoutEffect(() => {
 		const rootEl = rootRef.current;
 		if (!rootEl) {
 			return;
 		}
-		// We always add one extra column to the grid to ensure that the last column
-		// is fully visible.
-		const avgWidth = rootEl.clientWidth / (ticks.length + 1);
-		const width = avgWidth > XAxisMinWidth ? avgWidth : XAxisMinWidth;
-		rootEl.style.setProperty("--x-axis-width", `${width}px`);
-	}, [ticks]);
+
+		// Synchronous measurement prevents a flash of unstyled bars on first
+		// paint.
+		updateWidth(rootEl);
+
+		const observer = new ResizeObserver(() => {
+			updateWidth(rootEl);
+		});
+		observer.observe(rootEl);
+
+		return () => observer.disconnect();
+	}, [updateWidth]);
 
 	return (
 		<div

--- a/site/src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.stories.tsx
+++ b/site/src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.stories.tsx
@@ -49,6 +49,25 @@ export const ClickToOpen: Story = {
 		const canvas = within(canvasElement);
 		await user.click(canvas.getByText("Build timeline", { exact: false }));
 		await canvas.findByText("provisioning");
+
+		// Verify that --x-axis-width is set on the XAxis root after the
+		// Collapse animation so that bars render at proportional widths.
+		// Regression: https://github.com/coder/coder/issues/24055
+		await waitFor(() => {
+			const xAxisEl = canvasElement.querySelector("[style*='--x-axis-width']");
+			expect(xAxisEl).not.toBeNull();
+			const value = xAxisEl
+				?.computedStyleMap?.()
+				?.get?.("--x-axis-width")
+				?.toString();
+			// Fallback: read it from the inline style attribute directly.
+			const inlineValue =
+				xAxisEl instanceof HTMLElement
+					? xAxisEl.style.getPropertyValue("--x-axis-width")
+					: "";
+			const raw = value ?? inlineValue;
+			expect(raw).toBeTruthy();
+		});
 	},
 };
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/coder/coder/issues/24055

The build timeline bars displayed at incorrect widths on first load. Reloading
the page fixed it.

### Root cause

`XAxis` measured its `clientWidth` once via `useLayoutEffect` and set the
`--x-axis-width` CSS variable. This measurement could become stale when the
available width changed outside React's render cycle — most notably when the
MUI `<Collapse>` finished its open animation (changing overflow / triggering
scrollbar changes), or on window resize. Since all bar widths and offsets
depend on `--x-axis-width`, a stale value produced visibly wrong proportions.

### Fix

Add a `ResizeObserver` alongside the existing synchronous measurement so
`--x-axis-width` stays current whenever the element's actual width changes.

- The synchronous `updateWidth()` call in `useLayoutEffect` prevents a flash
  of unstyled bars on first paint.
- The `ResizeObserver` catches later width changes (Collapse animation
  completing, scrollbar toggle, window resize).
- The observer is torn down in the effect cleanup.

<details><summary>Implementation notes</summary>

- `updateWidth` is extracted into a `useCallback` keyed on `ticks.length` so
  the observer always uses the current tick count.
- The `useLayoutEffect` depends on `updateWidth` (stable unless tick count
  changes), which means the observer is only reconnected when the number of
  ticks actually changes — not on every render.
- Added a regression assertion to the `ClickToOpen` Storybook interaction
  test that verifies `--x-axis-width` is set after opening the Collapse.

</details>

> 🤖 Generated by Coder Agents