### PR TITLE
fix(site): remove non-null assertion on optional chain in ExternalAuthPage

### DIFF
--- a/site/src/pages/UserSettingsPage/ExternalAuthPage/ExternalAuthPage.tsx
+++ b/site/src/pages/UserSettingsPage/ExternalAuthPage/ExternalAuthPage.tsx
@@ -70,9 +70,12 @@ const ExternalAuthPage: FC = () => {
 				entity="application"
 				onCancel={() => setAppToUnlink(undefined)}
 				onConfirm={async () => {
+					if (!appToUnlink) {
+						return;
+					}
 					try {
 						const unlinkResp = await unlinkAppMutation.mutateAsync(
-							appToUnlink?.id!,
+							appToUnlink.id,
 						);
 						// setAppToUnlink closes the modal
 						setAppToUnlink(undefined);


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

`appToUnlink?.id!` combined optional chaining with a non-null assertion, which contradicts itself. Add an early return guard to narrow the type, matching the existing convention used in `LicenseCard.tsx`.