### PR TITLE
perf(site/AgentsPage): replace conditional spread on ChatTopBar

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -344,9 +344,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 							onArchiveAndDeleteWorkspace={
 								handleArchiveAndDeleteWorkspaceAction
 							}
-							{...(handleRegenerateTitle
-								? { onRegenerateTitle: handleRegenerateTitle }
-								: {})}
+							onRegenerateTitle={handleRegenerateTitle}
 							isRegeneratingTitle={isRegeneratingTitle}
 							isRegenerateTitleDisabled={isRegenerateTitleDisabled}
 							hasWorkspace={Boolean(workspace)}


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

**Closing — verified via compiler output that the conditional spread is NOT the cause of ChatTopBar re-renders.** The React Compiler handles both the spread and plain prop forms identically, producing the same memoization structure. The real cause of the 295 re-renders is an unstable prop reference passed from `AgentChatPage` into `AgentChatPageView` during streaming — investigation ongoing.