### PR TITLE
fix(site): use async findByLabelText in ProviderAccordionCards story

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ChatModelAdminPanel.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ChatModelAdminPanel.stories.tsx
@@ -255,7 +255,7 @@ export const ProviderAccordionCards: Story = {
 		expect(body.queryByText("OpenAI")).not.toBeInTheDocument();
 
 		await userEvent.click(body.getByRole("button", { name: /OpenRouter/i }));
-		await expect(body.getByLabelText("Base URL")).toBeInTheDocument();
+		await expect(await body.findByLabelText("Base URL")).toBeInTheDocument();
 	},
 };
 


### PR DESCRIPTION
- Use async `findByLabelText` instead of sync `getByLabelText` in `ProviderAccordionCards` story
- The accordion content isn't in the DOM immediately after click, so the sync query fails
- Same bug fixed in #23999 for three other stories but missed for this one

> 🤖 Written by a Coder Agent. Will be reviewed by a human.