### PR TITLE
fix(site): stabilize mutation callbacks for React Compiler memoization

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -646,35 +646,23 @@ const AgentChatPage: FC = () => {
 	const isRegenerateTitleDisabled = isArchived || isRegeneratingThisChat;
 	const chatLastModelConfigID = chatRecord?.last_model_config_id;
 
-	// Destructure mutation results into individual properties so the
-	// React Compiler tracks stable primitives/functions instead of the
-	// whole result object (which TanStack Query recreates every render
-	// via object spread).
-	const sendMutation = useMutation(
-		createChatMessage(queryClient, agentId ?? ""),
-	);
+	// Destructure mutation results directly so the React Compiler
+	// tracks stable primitives/functions instead of the whole result
+	// object (TanStack Query v5 recreates it every render via object
+	// spread). Keeping no intermediate variable prevents future code
+	// from accidentally closing over the unstable object.
 	const { isPending: isSendPending, mutateAsync: sendMutateAsync } =
-		sendMutation;
-
-	const editMutation = useMutation(editChatMessage(queryClient, agentId ?? ""));
+		useMutation(createChatMessage(queryClient, agentId ?? ""));
 	const { isPending: isEditPending, mutateAsync: editMutateAsync } =
-		editMutation;
-
-	const interruptMutation = useMutation(
-		interruptChat(queryClient, agentId ?? ""),
-	);
+		useMutation(editChatMessage(queryClient, agentId ?? ""));
 	const { isPending: isInterruptPending, mutateAsync: interruptMutateAsync } =
-		interruptMutation;
-
-	const deleteQueuedMutation = useMutation(
+		useMutation(interruptChat(queryClient, agentId ?? ""));
+	const { mutateAsync: deleteQueuedMutateAsync } = useMutation(
 		deleteChatQueuedMessage(queryClient, agentId ?? ""),
 	);
-	const { mutateAsync: deleteQueuedMutateAsync } = deleteQueuedMutation;
-
-	const promoteQueuedMutation = useMutation(
+	const { mutateAsync: promoteQueuedMutateAsync } = useMutation(
 		promoteChatQueuedMessage(queryClient, agentId ?? ""),
 	);
-	const { mutateAsync: promoteQueuedMutateAsync } = promoteQueuedMutation;
 
 	const { store, clearStreamError, upsertCacheMessages } = useChatStore({
 		chatID: agentId,
@@ -1004,10 +992,10 @@ const AgentChatPage: FC = () => {
 			? `ssh ${workspaceAgent.name}.${workspace.name}.${workspace.owner_name}.${sshConfigQuery.data.hostname_suffix}`
 			: undefined;
 
-	const generateKeyMutation = useMutation({
+	// See mutation destructuring comment above (React Compiler).
+	const { mutate: generateKeyMutate } = useMutation({
 		mutationFn: () => API.getApiKey(),
 	});
-	const { mutate: generateKeyMutate } = generateKeyMutation;
 
 	const handleOpenInEditor = (editor: "cursor" | "vscode") => {
 		if (!workspace || !workspaceAgent) {

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -646,19 +646,35 @@ const AgentChatPage: FC = () => {
 	const isRegenerateTitleDisabled = isArchived || isRegeneratingThisChat;
 	const chatLastModelConfigID = chatRecord?.last_model_config_id;
 
+	// Destructure mutation results into individual properties so the
+	// React Compiler tracks stable primitives/functions instead of the
+	// whole result object (which TanStack Query recreates every render
+	// via object spread).
 	const sendMutation = useMutation(
 		createChatMessage(queryClient, agentId ?? ""),
 	);
+	const { isPending: isSendPending, mutateAsync: sendMutateAsync } =
+		sendMutation;
+
 	const editMutation = useMutation(editChatMessage(queryClient, agentId ?? ""));
+	const { isPending: isEditPending, mutateAsync: editMutateAsync } =
+		editMutation;
+
 	const interruptMutation = useMutation(
 		interruptChat(queryClient, agentId ?? ""),
 	);
+	const { isPending: isInterruptPending, mutateAsync: interruptMutateAsync } =
+		interruptMutation;
+
 	const deleteQueuedMutation = useMutation(
 		deleteChatQueuedMessage(queryClient, agentId ?? ""),
 	);
+	const { mutateAsync: deleteQueuedMutateAsync } = deleteQueuedMutation;
+
 	const promoteQueuedMutation = useMutation(
 		promoteChatQueuedMessage(queryClient, agentId ?? ""),
 	);
+	const { mutateAsync: promoteQueuedMutateAsync } = promoteQueuedMutation;
 
 	const { store, clearStreamError, upsertCacheMessages } = useChatStore({
 		chatID: agentId,
@@ -754,9 +770,7 @@ const AgentChatPage: FC = () => {
 		hasUserFixableModelProviders,
 	});
 	const isSubmissionPending =
-		sendMutation.isPending ||
-		editMutation.isPending ||
-		interruptMutation.isPending;
+		isSendPending || isEditPending || isInterruptPending;
 	const isInputDisabled = !hasModelOptions || isArchived;
 
 	const handleUsageLimitError = (error: unknown): void => {
@@ -842,7 +856,7 @@ const AgentChatPage: FC = () => {
 			setPendingEditMessageId(editedMessageID);
 			scrollToBottomRef.current?.();
 			try {
-				await editMutation.mutateAsync({
+				await editMutateAsync({
 					messageId: editedMessageID,
 					req: request,
 				});
@@ -873,9 +887,9 @@ const AgentChatPage: FC = () => {
 		// For queued sends the WebSocket status events handle
 		// clearing; for non-queued sends we clear explicitly
 		// below. Clearing eagerly causes a visible cutoff.
-		let response: Awaited<ReturnType<typeof sendMutation.mutateAsync>>;
+		let response: Awaited<ReturnType<typeof sendMutateAsync>>;
 		try {
-			response = await sendMutation.mutateAsync(request);
+			response = await sendMutateAsync(request);
 		} catch (error) {
 			handleUsageLimitError(error);
 			throw error;
@@ -908,10 +922,10 @@ const AgentChatPage: FC = () => {
 	};
 
 	const handleInterrupt = () => {
-		if (!agentId || interruptMutation.isPending) {
+		if (!agentId || isInterruptPending) {
 			return;
 		}
-		void interruptMutation.mutateAsync();
+		void interruptMutateAsync();
 	};
 
 	const handleDeleteQueuedMessage = async (id: number) => {
@@ -920,7 +934,7 @@ const AgentChatPage: FC = () => {
 			previousQueuedMessages.filter((message) => message.id !== id),
 		);
 		try {
-			await deleteQueuedMutation.mutateAsync(id);
+			await deleteQueuedMutateAsync(id);
 		} catch (error) {
 			store.setQueuedMessages(previousQueuedMessages);
 			throw error;
@@ -941,7 +955,7 @@ const AgentChatPage: FC = () => {
 		store.clearStreamError();
 		store.setChatStatus("pending");
 		try {
-			const promotedMessage = await promoteQueuedMutation.mutateAsync(id);
+			const promotedMessage = await promoteQueuedMutateAsync(id);
 			// Insert the promoted message into the store and cache
 			// immediately so it appears in the timeline without
 			// waiting for the WebSocket to deliver it.
@@ -993,6 +1007,7 @@ const AgentChatPage: FC = () => {
 	const generateKeyMutation = useMutation({
 		mutationFn: () => API.getApiKey(),
 	});
+	const { mutate: generateKeyMutate } = generateKeyMutation;
 
 	const handleOpenInEditor = (editor: "cursor" | "vscode") => {
 		if (!workspace || !workspaceAgent) {
@@ -1005,7 +1020,7 @@ const AgentChatPage: FC = () => {
 		const repoRoots = Array.from(gitWatcher.repositories.keys()).sort();
 		const folder = repoRoots[0] ?? workspaceAgent.expanded_directory;
 
-		generateKeyMutation.mutate(undefined, {
+		generateKeyMutate(undefined, {
 			onSuccess: ({ key }) => {
 				location.href = getVSCodeHref(editor, {
 					owner: workspace.owner_name,
@@ -1141,7 +1156,7 @@ const AgentChatPage: FC = () => {
 			compressionThreshold={compressionThreshold}
 			isInputDisabled={isInputDisabled}
 			isSubmissionPending={isSubmissionPending}
-			isInterruptPending={interruptMutation.isPending}
+			isInterruptPending={isInterruptPending}
 			isSidebarCollapsed={isSidebarCollapsed}
 			onToggleSidebarCollapsed={onToggleSidebarCollapsed}
 			showSidebarPanel={showSidebarPanel}

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -651,16 +651,19 @@ const AgentChatPage: FC = () => {
 	// object (TanStack Query v5 recreates it every render via object
 	// spread). Keeping no intermediate variable prevents future code
 	// from accidentally closing over the unstable object.
-	const { isPending: isSendPending, mutateAsync: sendMutateAsync } =
-		useMutation(createChatMessage(queryClient, agentId ?? ""));
-	const { isPending: isEditPending, mutateAsync: editMutateAsync } =
-		useMutation(editChatMessage(queryClient, agentId ?? ""));
-	const { isPending: isInterruptPending, mutateAsync: interruptMutateAsync } =
-		useMutation(interruptChat(queryClient, agentId ?? ""));
-	const { mutateAsync: deleteQueuedMutateAsync } = useMutation(
+	const { isPending: isSendPending, mutateAsync: sendMessage } = useMutation(
+		createChatMessage(queryClient, agentId ?? ""),
+	);
+	const { isPending: isEditPending, mutateAsync: editMessage } = useMutation(
+		editChatMessage(queryClient, agentId ?? ""),
+	);
+	const { isPending: isInterruptPending, mutateAsync: interrupt } = useMutation(
+		interruptChat(queryClient, agentId ?? ""),
+	);
+	const { mutateAsync: deleteQueuedMessage } = useMutation(
 		deleteChatQueuedMessage(queryClient, agentId ?? ""),
 	);
-	const { mutateAsync: promoteQueuedMutateAsync } = useMutation(
+	const { mutateAsync: promoteQueuedMessage } = useMutation(
 		promoteChatQueuedMessage(queryClient, agentId ?? ""),
 	);
 
@@ -844,7 +847,7 @@ const AgentChatPage: FC = () => {
 			setPendingEditMessageId(editedMessageID);
 			scrollToBottomRef.current?.();
 			try {
-				await editMutateAsync({
+				await editMessage({
 					messageId: editedMessageID,
 					req: request,
 				});
@@ -875,9 +878,9 @@ const AgentChatPage: FC = () => {
 		// For queued sends the WebSocket status events handle
 		// clearing; for non-queued sends we clear explicitly
 		// below. Clearing eagerly causes a visible cutoff.
-		let response: Awaited<ReturnType<typeof sendMutateAsync>>;
+		let response: Awaited<ReturnType<typeof sendMessage>>;
 		try {
-			response = await sendMutateAsync(request);
+			response = await sendMessage(request);
 		} catch (error) {
 			handleUsageLimitError(error);
 			throw error;
@@ -913,7 +916,7 @@ const AgentChatPage: FC = () => {
 		if (!agentId || isInterruptPending) {
 			return;
 		}
-		void interruptMutateAsync();
+		void interrupt();
 	};
 
 	const handleDeleteQueuedMessage = async (id: number) => {
@@ -922,7 +925,7 @@ const AgentChatPage: FC = () => {
 			previousQueuedMessages.filter((message) => message.id !== id),
 		);
 		try {
-			await deleteQueuedMutateAsync(id);
+			await deleteQueuedMessage(id);
 		} catch (error) {
 			store.setQueuedMessages(previousQueuedMessages);
 			throw error;
@@ -943,7 +946,7 @@ const AgentChatPage: FC = () => {
 		store.clearStreamError();
 		store.setChatStatus("pending");
 		try {
-			const promotedMessage = await promoteQueuedMutateAsync(id);
+			const promotedMessage = await promoteQueuedMessage(id);
 			// Insert the promoted message into the store and cache
 			// immediately so it appears in the timeline without
 			// waiting for the WebSocket to deliver it.
@@ -993,7 +996,7 @@ const AgentChatPage: FC = () => {
 			: undefined;
 
 	// See mutation destructuring comment above (React Compiler).
-	const { mutate: generateKeyMutate } = useMutation({
+	const { mutate: generateKey } = useMutation({
 		mutationFn: () => API.getApiKey(),
 	});
 
@@ -1008,7 +1011,7 @@ const AgentChatPage: FC = () => {
 		const repoRoots = Array.from(gitWatcher.repositories.keys()).sort();
 		const folder = repoRoots[0] ?? workspaceAgent.expanded_directory;
 
-		generateKeyMutate(undefined, {
+		generateKey(undefined, {
 			onSuccess: ({ key }) => {
 				location.href = getVSCodeHref(editor, {
 					owner: workspace.owner_name,


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

TanStack Query v5's `useMutation` returns `{ ...result, mutate, mutateAsync: result.mutate }` — a new object spread on every render. The React Compiler tracks the whole mutation object as a dependency when it appears inside callback closures, so every re-render produces new callback identities. These cascade through `AgentChatPageView`'s 52-dep JSX memoization block, forcing the entire view subtree (including `ChatTopBar`) to re-render on every frame during streaming.

Fix: destructure mutation results into individual stable properties (`isPending` booleans, bound `mutateAsync`/`mutate` functions) before using them in callbacks. The compiler now tracks these primitives instead of the wrapper objects.

<details>
<summary>Investigation details</summary>

### Root cause chain

1. During streaming, WebSocket messages trigger `store.upsertDurableMessages()` + `upsertCacheMessages()` (which calls `queryClient.setQueryData`)
2. `setQueryData` causes `chatMessagesQuery` to update → `AgentChatPage` re-renders
3. On re-render, `useMutation(...)` returns a new result object (object spread in TanStack Query's hook)
4. Callbacks like `handleInterrupt`, `handleDeleteQueuedMessage`, `handlePromoteQueuedMessage`, `handleOpenInEditor` close over the mutation object
5. The compiler's memoization check `$[N] !== interruptMutation` always fails (new object)
6. Callbacks get new identities → the 52-dep check for `<AgentChatPageView>` fails
7. `AgentChatPageView` re-renders → `ChatTopBar` and other children re-render

### Verification method

Compiled output comparison using `babel-plugin-react-compiler`:

**Before** — compiler tracks whole mutation object:
```js
if ($[96] !== agentId || $[97] !== interruptMutation) {
  t56 = () => { ... };
}
```

**After** — compiler tracks stable primitives:
```js
if ($[96] !== agentId || $[97] !== interruptMutateAsync || $[98] !== isInterruptPending) {
  t56 = () => { ... };
}
```

`interruptMutateAsync` is bound once in TanStack Query's constructor (`this.mutate = this.mutate.bind(this)`), and `isInterruptPending` is a boolean — both are stable across renders.

### Affected mutations

| Mutation | Callback | Old dep | New deps |
|----------|----------|---------|----------|
| `interruptMutation` | `handleInterrupt` | whole object | `isInterruptPending` (bool), `interruptMutateAsync` (bound fn) |
| `deleteQueuedMutation` | `handleDeleteQueuedMessage` | whole object | `deleteQueuedMutateAsync` (bound fn) |
| `promoteQueuedMutation` | `handlePromoteQueuedMessage` | whole object | `promoteQueuedMutateAsync` (bound fn) |
| `generateKeyMutation` | `handleOpenInEditor` | whole object | `generateKeyMutate` (useCallback-wrapped fn) |
| `sendMutation` | `handleSend`, `isSubmissionPending` | `.isPending` reads | `isSendPending` (bool), `sendMutateAsync` (bound fn) |
| `editMutation` | `handleSend`, `isSubmissionPending` | `.isPending` reads | `isEditPending` (bool), `editMutateAsync` (bound fn) |

</details>