### PR TITLE
fix(site): prevent event listener leak in ChatScrollContainer

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
+++ b/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
@@ -430,7 +430,7 @@ function useStickToBottom(): StickToBottomInstance {
 		}
 	});
 
-	const scrollRef = useEffectEvent((el: HTMLDivElement | null) => {
+	const scrollRef = (el: HTMLDivElement | null) => {
 		const s = stateRef.current;
 		const prev = s.scrollElement;
 
@@ -469,9 +469,9 @@ function useStickToBottom(): StickToBottomInstance {
 			vo.observe(el);
 			s.viewportObserver = vo;
 		}
-	});
+	};
 
-	const contentRef = useEffectEvent((el: HTMLDivElement | null) => {
+	const contentRef = (el: HTMLDivElement | null) => {
 		const s = stateRef.current;
 
 		if (s.resizeObserver) {
@@ -486,10 +486,10 @@ function useStickToBottom(): StickToBottomInstance {
 			ro.observe(el);
 			s.resizeObserver = ro;
 		}
-	});
+	};
 
 	// -----------------------------------------------------------------------
-	// -----------------------------------------------------------------------
+
 	// Mouse tracking (instance-scoped)
 	// -----------------------------------------------------------------------
 
@@ -614,11 +614,12 @@ const ChatScrollContainer: FC<{
 	// Merge our callback ref with the external RefObject so both
 	// point at the same DOM node, and expose scrollToBottom to the
 	// parent via its imperative ref.
-	const mergedScrollRef = useEffectEvent((el: HTMLDivElement | null) => {
+	const mergedScrollRef = (el: HTMLDivElement | null) => {
 		scrollRef(el);
 		scrollContainerRef.current = el;
 		scrollToBottomRef.current = el ? () => scrollToBottom("instant") : null;
-	});
+	};
+
 	// -------------------------------------------------------------------
 	// Pagination sentinel (IntersectionObserver)
 	// -------------------------------------------------------------------


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

Follow-up to #24060. Fixes the P1 event listener leak identified by review.

The polyfill's `useEffectEvent` returned a stable identity via `useCallback(fn, [])`. Native `useEffectEvent` intentionally does not — it returns a new identity every render. `scrollRef`, `contentRef`, and `mergedScrollRef` relied on stable identity as ref callbacks. The native switch broke that, causing React to cycle the callbacks every render and leak event listeners.

Converts the three ref callbacks from `useEffectEvent` to plain functions. The React Compiler auto-memoizes them because every capture is either a ref (`stateRef`) or a `useEffectEvent` handler (excluded from deps by the compiler). Also removes a duplicate separator comment.