### PR TITLE
fix: resolve style not passing in `<LogLine />`

### DIFF
--- a/site/src/components/Logs/LogLine.tsx
+++ b/site/src/components/Logs/LogLine.tsx
@@ -16,7 +16,12 @@ type LogLineProps = {
 	level: LogLevel;
 } & HTMLAttributes<HTMLPreElement>;
 
-export const LogLine: FC<LogLineProps> = ({ level, className, ...props }) => {
+export const LogLine: FC<LogLineProps> = ({
+	level,
+	className,
+	style,
+	...props
+}) => {
 	return (
 		<pre
 			{...props}
@@ -33,7 +38,10 @@ export const LogLine: FC<LogLineProps> = ({ level, className, ...props }) => {
 				className,
 			)}
 			style={{
-				padding: `0 var(--log-line-side-padding, ${DEFAULT_LOG_LINE_SIDE_PADDING}px)`,
+				...style,
+				padding:
+					style?.padding ??
+					`0 var(--log-line-side-padding, ${DEFAULT_LOG_LINE_SIDE_PADDING}px)`,
 			}}
 		/>
 	);


### PR DESCRIPTION
This pull-request resolves an regression where the spread was overriding the required styles from the `react-window` virtualised rows. This was causing the scroll to act a little crazy.