### PR TITLE
fix(site): fix race condition showing default params on workspace settings page

### DIFF
--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageExperimental.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageExperimental.tsx
@@ -8,6 +8,7 @@ import { DetailedError } from "#/api/errors";
 import type {
 	DynamicParametersRequest,
 	DynamicParametersResponse,
+	PreviewParameter,
 	WorkspaceBuildParameter,
 } from "#/api/typesGenerated";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
@@ -22,6 +23,7 @@ import {
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
 import { useEffectEvent } from "#/hooks/hookPolyfills";
+import { getInitialParameterValues } from "#/modules/workspaces/DynamicParameter/DynamicParameter";
 import { docs } from "#/utils/docs";
 import { pageTitle } from "#/utils/page";
 import type { AutofillBuildParameter } from "#/utils/richParameters";
@@ -76,21 +78,32 @@ const WorkspaceParametersPageExperimental: FC = () => {
 	// On page load, sends initial workspace build parameters to the websocket.
 	// This ensures the backend has the form's complete initial state,
 	// vital for rendering dynamic UI elements dependent on initial parameter values.
-	const sendInitialParameters = useEffectEvent(() => {
-		if (initialParamsSentRef.current) return;
-		if (autofillParameters.length === 0) return;
+	const sendInitialParameters = useEffectEvent(
+		(parameters: PreviewParameter[]) => {
+			if (initialParamsSentRef.current) return;
+			if (parameters.length === 0) return;
+			// Wait until build parameters have been fetched so we send the
+			// user's actual values instead of template defaults.
+			if (!latestBuildParameters) return;
 
-		const initialParamsToSend: Record<string, string> = {};
-		for (const param of autofillParameters) {
-			if (param.name && param.value) {
-				initialParamsToSend[param.name] = param.value;
+			const initialFormValues = getInitialParameterValues(
+				parameters,
+				autofillParameters,
+			);
+			if (initialFormValues.length === 0) return;
+
+			const initialParamsToSend: Record<string, string> = {};
+			for (const param of initialFormValues) {
+				if (param.name && param.value) {
+					initialParamsToSend[param.name] = param.value;
+				}
 			}
-		}
-		if (Object.keys(initialParamsToSend).length === 0) return;
+			if (Object.keys(initialParamsToSend).length === 0) return;
 
-		sendMessage(initialParamsToSend);
-		initialParamsSentRef.current = true;
-	});
+			sendMessage(initialParamsToSend);
+			initialParamsSentRef.current = true;
+		},
+	);
 
 	const onMessage = useEffectEvent((response: DynamicParametersResponse) => {
 		if (latestResponse && latestResponse?.id >= response.id) {
@@ -104,12 +117,23 @@ const WorkspaceParametersPageExperimental: FC = () => {
 			return;
 		}
 
-		setLatestResponse(response);
-
 		if (!initialParamsSentRef.current && response.parameters?.length > 0) {
-			sendInitialParameters();
+			sendInitialParameters([...response.parameters]);
 		}
+
+		setLatestResponse(response);
 	});
+
+	// When the WebSocket first message arrives before the REST build
+	// parameters have loaded, sendInitialParameters bails out. This
+	// effect retriggers the send once both data sources are available.
+	useEffect(() => {
+		if (initialParamsSentRef.current) return;
+		if (!latestResponse?.parameters?.length) return;
+		if (!latestBuildParameters) return;
+
+		sendInitialParameters([...latestResponse.parameters]);
+	}, [latestResponse, latestBuildParameters, sendInitialParameters]);
 
 	useEffect(() => {
 		if (!templateVersionId && !workspace.latest_build.template_version_id)


### PR DESCRIPTION
When navigating to the workspace parameters settings page, the WebSocket
first message (with template defaults) could arrive before the REST query
for build parameters (`getWorkspaceBuildParameters`) resolved.
`sendInitialParameters` would bail because `autofillParameters` was still
empty, and nothing retriggered it — leaving the form permanently showing
template defaults instead of the user's actual values.

Three changes, aligned with the working `CreateWorkspacePage` pattern:

1. `sendInitialParameters` now accepts `PreviewParameter[]` and uses
   `getInitialParameterValues()` to properly merge WS parameter schemas
   with the user's build parameter values, with an explicit guard against
   sending before REST data loads.

2. In `onMessage`, `sendInitialParameters` is called **before**
   `setLatestResponse` to avoid the sync hook overwriting form values
   with stale WS defaults.

3. A new `useEffect` retriggers `sendInitialParameters` when the REST
   build parameters arrive after the first WS message, closing the race
   window.

Fixes https://github.com/coder/internal/issues/1414

<details><summary>Analysis & decision log</summary>

### Root cause

`WorkspaceParametersPageExperimental` has two async data sources:
- **WebSocket**: connects to `templateVersionDynamicParameters`, sends an
  initial response with template-default values (`value.valid: true`)
- **REST**: `getWorkspaceBuildParameters(workspace.latest_build.id)` fetches
  the user's actual build parameter values

When the WS message arrives first (common), `onMessage` calls
`sendInitialParameters()`. The old implementation read from
`autofillParameters` (derived from the REST query), which was `[]` because
the query hadn't resolved yet. The `autofillParameters.length === 0` guard
caused an early return **without** setting `initialParamsSentRef.current =
true`. No subsequent code retriggered the send, so the WS backend never
received the user's values, and the form showed defaults permanently.

### Why CreateWorkspacePage doesn't have this bug

`CreateWorkspacePage` uses the same WS pattern but its autofill params come
from URL search params (synchronous). It also passes `PreviewParameter[]`
into `sendInitialParameters` and calls `getInitialParameterValues()` to
merge server params with autofill — giving it valid values to send even
before any REST calls complete.

### Fix approach

Rather than adding complex state tracking (e.g., waiting for the WS
round-trip response before showing the form), the fix aligns the workspace
settings page with the proven `CreateWorkspacePage` pattern and adds a
`useEffect` to handle the async REST timing.

</details>

> Generated by Coder Agents