### PR TITLE
fix(site): prevent dynamic parameter forms from showing template defaults

### DIFF
--- a/site/src/modules/hooks/useSyncFormParameters.ts
+++ b/site/src/modules/hooks/useSyncFormParameters.ts
@@ -9,12 +9,18 @@ type UseSyncFormParametersProps = {
 		field: string,
 		value: TypesGen.WorkspaceBuildParameter[],
 	) => void;
+	// When false the WebSocket has not yet returned a response that
+	// reflects the initial form values we sent (autofill / previous
+	// build). Preserve existing form values so the sync hook does not
+	// overwrite them with stale server defaults.
+	initialParamsAcknowledged?: boolean;
 };
 
 export function useSyncFormParameters({
 	parameters,
 	formValues,
 	setFieldValue,
+	initialParamsAcknowledged = true,
 }: UseSyncFormParametersProps) {
 	// Form values only needs to be updated when parameters change
 	// Keep track of form values in a ref to avoid unnecessary updates to rich_parameter_values
@@ -36,7 +42,13 @@ export function useSyncFormParameters({
 			// hook from overwriting autofilled values (from the
 			// previous build) with empty strings before the server
 			// has had a chance to process them.
-			if (!param.value.valid) {
+			//
+			// Also preserve the form value when the server has not yet
+			// acknowledged the initial parameters we sent. The first
+			// WS response (id -1) carries template defaults which
+			// would overwrite autofilled values from a previous build
+			// or URL search params.
+			if (!param.value.valid || !initialParamsAcknowledged) {
 				const existingValue = currentFormValuesMap.get(param.name);
 				if (existingValue !== undefined) {
 					return { name: param.name, value: existingValue };
@@ -60,5 +72,5 @@ export function useSyncFormParameters({
 		if (isChanged) {
 			setFieldValue("rich_parameter_values", newParameterValues);
 		}
-	}, [parameters, setFieldValue]);
+	}, [parameters, setFieldValue, initialParamsAcknowledged]);
 }

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
@@ -148,6 +148,13 @@ const CreateWorkspacePage: FC = () => {
 			return;
 		}
 
+		// Skip stale responses. If we've already sent a newer request,
+		// this response contains outdated parameter values that would
+		// overwrite the user's more recent input.
+		if (response.id < wsResponseId.current) {
+			return;
+		}
+
 		if (!initialParamsSentRef.current && response.parameters?.length > 0) {
 			sendInitialParameters([...response.parameters]);
 		}
@@ -287,12 +294,22 @@ const CreateWorkspacePage: FC = () => {
 		return [...latestResponse.parameters].sort((a, b) => a.order - b.order);
 	}, [latestResponse?.parameters]);
 
+	// The initial WS response (id: -1) contains only template defaults.
+	// Keep the loader visible until a response reflecting the user's
+	// actual parameter values arrives (id >= 0).
+	const awaitingUserValues =
+		latestResponse !== null &&
+		latestResponse.id < 0 &&
+		latestResponse.parameters.length > 0 &&
+		!wsError;
+
 	const shouldShowLoader =
 		!templateQuery.data ||
 		isLoadingFormData ||
 		isLoadingExternalAuth ||
 		autoCreateReady ||
-		(!latestResponse && !wsError);
+		(!latestResponse && !wsError) ||
+		awaitingUserValues;
 
 	return (
 		<>

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
@@ -294,22 +294,19 @@ const CreateWorkspacePage: FC = () => {
 		return [...latestResponse.parameters].sort((a, b) => a.order - b.order);
 	}, [latestResponse?.parameters]);
 
-	// The initial WS response (id: -1) contains only template defaults.
-	// Keep the loader visible until a response reflecting the user's
-	// actual parameter values arrives (id >= 0).
-	const awaitingUserValues =
-		latestResponse !== null &&
-		latestResponse.id < 0 &&
-		latestResponse.parameters.length > 0 &&
-		!wsError;
-
 	const shouldShowLoader =
 		!templateQuery.data ||
 		isLoadingFormData ||
 		isLoadingExternalAuth ||
 		autoCreateReady ||
-		(!latestResponse && !wsError) ||
-		awaitingUserValues;
+		(!latestResponse && !wsError);
+
+	// True once the WebSocket has returned a response that reflects
+	// the initial parameter values we sent (id >= 0), or when we
+	// never sent initial params at all.
+	const initialParamsAcknowledged =
+		!initialParamsSentRef.current ||
+		(latestResponse !== null && latestResponse.id >= 0);
 
 	return (
 		<>
@@ -354,6 +351,7 @@ const CreateWorkspacePage: FC = () => {
 					parameters={sortedParams}
 					presets={templateVersionPresetsQuery.data ?? []}
 					creatingWorkspace={createWorkspaceMutation.isPending}
+					initialParamsAcknowledged={initialParamsAcknowledged}
 					sendMessage={sendMessage}
 					onCancel={() => {
 						navigate(-1);

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
@@ -84,6 +84,7 @@ interface CreateWorkspacePageViewProps {
 	startPollingExternalAuth: () => void;
 	owner: TypesGen.MinimalUser;
 	setOwner: (user: TypesGen.MinimalUser) => void;
+	initialParamsAcknowledged?: boolean;
 }
 
 export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
@@ -112,6 +113,7 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 	startPollingExternalAuth,
 	owner,
 	setOwner,
+	initialParamsAcknowledged = true,
 }) => {
 	const [suggestedName, setSuggestedName] = useState(generateWorkspaceName);
 	const [showPresetParameters, setShowPresetParameters] = useState(false);
@@ -361,6 +363,7 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 		parameters,
 		formValues: form.values.rich_parameter_values ?? [],
 		setFieldValue: form.setFieldValue,
+		initialParamsAcknowledged,
 	});
 
 	const disabled =

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageExperimental.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageExperimental.tsx
@@ -8,6 +8,7 @@ import { DetailedError } from "#/api/errors";
 import type {
 	DynamicParametersRequest,
 	DynamicParametersResponse,
+	PreviewParameter,
 	WorkspaceBuildParameter,
 } from "#/api/typesGenerated";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
@@ -21,6 +22,7 @@ import {
 	TooltipProvider,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
+import { getInitialParameterValues } from "#/modules/workspaces/DynamicParameter/DynamicParameter";
 import { docs } from "#/utils/docs";
 import { pageTitle } from "#/utils/page";
 import type { AutofillBuildParameter } from "#/utils/richParameters";
@@ -72,24 +74,31 @@ const WorkspaceParametersPageExperimental: FC = () => {
 		}
 	});
 
-	// On page load, sends initial workspace build parameters to the websocket.
-	// This ensures the backend has the form's complete initial state,
-	// vital for rendering dynamic UI elements dependent on initial parameter values.
-	const sendInitialParameters = useEffectEvent(() => {
-		if (initialParamsSentRef.current) return;
-		if (autofillParameters.length === 0) return;
+	// Sends the user's build parameter values to the WebSocket so the
+	// backend evaluates dynamic expressions against real values instead
+	// of template defaults. Bails when the REST build parameters
+	// haven't loaded yet; the retrigger effect below covers that case.
+	const sendInitialParameters = useEffectEvent(
+		(parameters: PreviewParameter[]) => {
+			if (initialParamsSentRef.current) return;
+			if (parameters.length === 0) return;
+			if (!latestBuildParameters) return;
 
-		const initialParamsToSend: Record<string, string> = {};
-		for (const param of autofillParameters) {
-			if (param.name && param.value) {
-				initialParamsToSend[param.name] = param.value;
+			const inputs: Record<string, string> = {};
+			for (const p of getInitialParameterValues(
+				parameters,
+				autofillParameters,
+			)) {
+				if (p.name && p.value) {
+					inputs[p.name] = p.value;
+				}
 			}
-		}
-		if (Object.keys(initialParamsToSend).length === 0) return;
+			if (Object.keys(inputs).length === 0) return;
 
-		sendMessage(initialParamsToSend);
-		initialParamsSentRef.current = true;
-	});
+			sendMessage(inputs);
+			initialParamsSentRef.current = true;
+		},
+	);
 
 	const onMessage = useEffectEvent((response: DynamicParametersResponse) => {
 		if (latestResponse && latestResponse?.id >= response.id) {
@@ -103,12 +112,26 @@ const WorkspaceParametersPageExperimental: FC = () => {
 			return;
 		}
 
-		setLatestResponse(response);
-
+		// Send initial params before storing the response so the
+		// stale-response guard above filters the defaults on the
+		// next WS message.
 		if (!initialParamsSentRef.current && response.parameters?.length > 0) {
-			sendInitialParameters();
+			sendInitialParameters([...response.parameters]);
 		}
+
+		setLatestResponse(response);
 	});
+
+	// When the WS first message arrives before the REST build
+	// parameters have loaded, sendInitialParameters bails. This
+	// effect retriggers the send once both sources are available.
+	useEffect(() => {
+		if (initialParamsSentRef.current) return;
+		if (!latestResponse?.parameters?.length) return;
+		if (!latestBuildParameters) return;
+
+		sendInitialParameters([...latestResponse.parameters]);
+	}, [latestResponse, latestBuildParameters]);
 
 	useEffect(() => {
 		if (!templateVersionId && !workspace.latest_build.template_version_id)
@@ -226,10 +249,24 @@ const WorkspaceParametersPageExperimental: FC = () => {
 	const error =
 		wsError || startWithParameters.error || restartWithParameters.error;
 
+	// Keep the loader visible until a WS response reflecting
+	// the user's actual build parameter values arrives (id >= 0).
+	// Without this, the initial id -1 response (template defaults)
+	// can overwrite the correct autofill values from the previous
+	// build before the form has a chance to render them.
+	// We check latestBuildParameters instead of initialParamsSentRef
+	// because the ref doesn't trigger re-renders.
+	const awaitingUserValues =
+		latestResponse !== null &&
+		latestResponse.id < 0 &&
+		latestBuildParameters !== undefined &&
+		!wsError;
+
 	if (
 		latestBuildParametersLoading ||
 		(!latestResponse && !wsError) ||
-		(ws.current && ws.current.readyState === WebSocket.CONNECTING)
+		(ws.current && ws.current.readyState === WebSocket.CONNECTING) ||
+		awaitingUserValues
 	) {
 		return <Loader />;
 	}
@@ -285,6 +322,10 @@ const WorkspaceParametersPageExperimental: FC = () => {
 					canChangeVersions={canChangeVersions}
 					parameters={sortedParams}
 					diagnostics={latestResponse?.diagnostics ?? []}
+					initialParamsAcknowledged={
+						!initialParamsSentRef.current ||
+						(latestResponse !== null && latestResponse.id >= 0)
+					}
 					isSubmitting={
 						startWithParameters.isPending || restartWithParameters.isPending
 					}

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageViewExperimental.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageViewExperimental.tsx
@@ -27,6 +27,7 @@ type WorkspaceParametersPageViewExperimentalProps = {
 	parameters: PreviewParameter[];
 	diagnostics: PreviewParameter["diagnostics"];
 	canChangeVersions: boolean;
+	initialParamsAcknowledged: boolean;
 	isSubmitting: boolean;
 	submitLabel: string;
 	onCancel: () => void;
@@ -45,6 +46,7 @@ export const WorkspaceParametersPageViewExperimental: FC<
 	parameters,
 	diagnostics,
 	canChangeVersions,
+	initialParamsAcknowledged,
 	isSubmitting,
 	submitLabel,
 	onSubmit,
@@ -104,6 +106,7 @@ export const WorkspaceParametersPageViewExperimental: FC<
 		parameters,
 		formValues: form.values.rich_parameter_values ?? [],
 		setFieldValue: form.setFieldValue,
+		initialParamsAcknowledged,
 	});
 
 	// True when the form holds values the backend hasn't evaluated


### PR DESCRIPTION
## Problem

The workspace parameters settings page intermittently shows template
defaults instead of the workspace's actual build parameter values.

The dynamic-parameters WebSocket sends an initial response (id: -1)
containing template defaults. On the parameters page, a parallel REST
query (`getWorkspaceBuildParameters`) fetches the workspace's actual
values. When the WebSocket response arrives before the REST query
completes, `sendInitialParameters` bails (no build params yet) and is
never retried. `useSyncFormParameters` then overwrites the correct
autofilled form values with the stale server defaults, and for
immutable parameters (disabled inputs), the value is stuck permanently.

## Fix

**WorkspaceParametersPageExperimental:**
- Accept `PreviewParameter[]` in `sendInitialParameters` and use
  `getInitialParameterValues` to merge schemas with autofill values.
- Guard on REST data readiness and add a `useEffect` retrigger so the
  send fires once both data sources are available.
- Add `awaitingUserValues` loader gate: keep the Loader visible while
  `latestResponse.id < 0` so the form never mounts against stale
  defaults.
- Add stale-response guard (`response.id < wsResponseId.current`) to
  drop outdated WebSocket messages.

**CreateWorkspacePage:** add the same stale-response guard to
`onMessage`.

**useSyncFormParameters:** add `initialParamsAcknowledged` prop. When
false (WebSocket hasn't returned a response reflecting initial values),
the hook preserves existing form values instead of overwriting them with
server defaults. Passed through both page Views.

Fixes https://github.com/coder/internal/issues/1414

> Generated by Coder Agents