### PR TITLE
fix(site): add resize observer to session timeline expandable text

### DIFF
--- a/site/src/pages/AIBridgePage/SessionThreadsPage/SessionTimeline/SessionTimeline.tsx
+++ b/site/src/pages/AIBridgePage/SessionThreadsPage/SessionTimeline/SessionTimeline.tsx
@@ -48,7 +48,18 @@ const ExpandableText: FC<ExpandableTextProps> = ({
 	useEffect(() => {
 		const el = contentRef.current;
 		if (!el) return;
-		setIsExpandable(el.scrollHeight > maxHeight);
+
+		const checkIsExpandable = () => {
+			setIsExpandable(el.scrollHeight > maxHeight);
+		};
+
+		checkIsExpandable();
+
+		const observer = new ResizeObserver(checkIsExpandable);
+
+		observer.observe(el);
+
+		return () => observer.disconnect();
 	}, [maxHeight]);
 
 	return (


### PR DESCRIPTION
I said I wouldn't but the illustrious @jakehwll added a ResizeObserver recently so imma do that too.

This makes `<ExpandableText>` determine if it should be expandable or not on resize