### PR TITLE
fix: show devcontainer delete menu for failed devcontainers

### DIFF
--- a/site/src/modules/resources/AgentDevcontainerCard.stories.tsx
+++ b/site/src/modules/resources/AgentDevcontainerCard.stories.tsx
@@ -53,9 +53,34 @@ export const HasError: Story = {
 	args: {
 		devcontainer: {
 			...MockWorkspaceAgentDevcontainer,
+			status: "error",
 			error: "unable to inject devcontainer with agent",
+			container: undefined,
 			agent: undefined,
 		},
+		subAgents: [],
+	},
+};
+
+export const HasErrorWithDelete: Story = {
+	args: {
+		devcontainer: {
+			...MockWorkspaceAgentDevcontainer,
+			status: "error",
+			error: "exit status 1",
+			container: undefined,
+			agent: undefined,
+		},
+		subAgents: [],
+	},
+	play: async ({ canvasElement }) => {
+		const user = userEvent.setup();
+		const canvas = within(canvasElement);
+
+		const moreActionsButton = canvas.getByRole("button", {
+			name: "Dev Container actions",
+		});
+		await user.click(moreActionsButton);
 	},
 };
 

--- a/site/src/modules/resources/AgentDevcontainerCard.tsx
+++ b/site/src/modules/resources/AgentDevcontainerCard.tsx
@@ -274,7 +274,7 @@ export const AgentDevcontainerCard: FC<AgentDevcontainerCardProps> = ({
 							/>
 						)}
 
-					{showDevcontainerControls && (
+					{devcontainer.status !== "deleting" && (
 						<AgentDevcontainerMoreActions
 							deleteDevContainer={deleteDevcontainerMutation.mutate}
 						/>


### PR DESCRIPTION
Fixes #23754

## Problem

The three-dot menu (containing the **Delete** option) was not shown on devcontainer cards in a failed/error state. Users had no way to clean up failed devcontainers from the UI.

## Root Cause

The `AgentDevcontainerMoreActions` component was gated on `showDevcontainerControls`, which requires **both** `subAgent` AND `devcontainer.container` to be truthy:

```ts
const showDevcontainerControls = subAgent && devcontainer.container;
```

For failed devcontainers, the container reference and/or sub-agent are typically missing, so the menu never rendered.

## Fix

Decoupled the more-actions menu from `showDevcontainerControls`. The delete API only needs `parentAgent.id` and `devcontainer.id` (both always available), so the menu now renders whenever `devcontainer.status !== "deleting"`. The SSH and port-forwarding buttons remain gated on `showDevcontainerControls` since they genuinely require the sub-agent and container.

Also updated the `HasError` story to better reflect real-world error state (with `container: undefined`, `agent: undefined`, `status: "error"`, and empty `subAgents`), and added a `HasErrorWithDelete` story that exercises the delete menu on a failed devcontainer.

> Generated with [Coder Agents](https://coder.com/agents)