### PR TITLE
fix: resolve TestExecutorAutostartOK flake caused by hour-boundary race

### DIFF
--- a/coderd/autobuild/lifecycle_executor_test.go
+++ b/coderd/autobuild/lifecycle_executor_test.go
@@ -62,9 +62,18 @@ func TestExecutorAutostartOK(t *testing.T) {
 	workspace = coderdtest.MustTransitionWorkspace(t, client, workspace.ID, codersdk.WorkspaceTransitionStart, codersdk.WorkspaceTransitionStop)
 	p, err := coderdtest.GetProvisionerForTags(db, time.Now(), workspace.OrganizationID, map[string]string{})
 	require.NoError(t, err)
+
+	// Use the server-computed next_start_at as the tick time. Using
+	// sched.Next(build.CreatedAt) can diverge when build creation and
+	// completion straddle an hour boundary (coder/internal#1456).
+	ctx := testutil.Context(t, testutil.WaitShort)
+	ws, err := db.GetWorkspaceByID(dbauthz.AsSystemRestricted(ctx), workspace.ID)
+	require.NoError(t, err)
+	require.True(t, ws.NextStartAt.Valid, "expected next_start_at to be set after stop build completes")
+
 	// When: the autobuild executor ticks after the scheduled time
 	go func() {
-		tickTime := sched.Next(workspace.LatestBuild.CreatedAt)
+		tickTime := ws.NextStartAt.Time
 		coderdtest.UpdateProvisionerLastSeenAt(t, db, p.ID, tickTime)
 		tickCh <- tickTime
 		close(tickCh)
@@ -81,7 +90,6 @@ func TestExecutorAutostartOK(t *testing.T) {
 	assert.Equal(t, codersdk.BuildReasonAutostart, workspace.LatestBuild.Reason)
 	// Assert some template props. If this is not set correctly, the test
 	// will fail.
-	ctx := testutil.Context(t, testutil.WaitShort)
 	template, err := client.Template(ctx, workspace.TemplateID)
 	require.NoError(t, err)
 	require.Equal(t, template.AutostartRequirement.DaysOfWeek, []string{"monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"})
@@ -124,8 +132,17 @@ func TestMultipleLifecycleExecutors(t *testing.T) {
 
 	p, err := coderdtest.GetProvisionerForTags(db, time.Now(), workspace.OrganizationID, nil)
 	require.NoError(t, err)
+
+	// Use the server-computed next_start_at as the tick time. Using
+	// sched.Next(build.CreatedAt) can diverge when build creation and
+	// completion straddle an hour boundary (coder/internal#1456).
+	ctx := testutil.Context(t, testutil.WaitShort)
+	ws, err := db.GetWorkspaceByID(dbauthz.AsSystemRestricted(ctx), workspace.ID)
+	require.NoError(t, err)
+	require.True(t, ws.NextStartAt.Valid, "expected next_start_at to be set after stop build completes")
+
 	// Get both clients to perform a lifecycle execution tick
-	next := sched.Next(workspace.LatestBuild.CreatedAt)
+	next := ws.NextStartAt.Time
 	coderdtest.UpdateProvisionerLastSeenAt(t, db, p.ID, next)
 
 	startCh := make(chan struct{})


### PR DESCRIPTION
Fixes https://github.com/coder/internal/issues/1456

## Root Cause

When a workspace build completes, `provisionerdserver.completeWorkspaceBuildJob` sets `next_start_at` using the **wall-clock completion time** (`s.timeNow()`):

```go
now := s.timeNow()
nextStartAt, _ := schedule.NextAllowedAutostart(now, ...)
```

The test was computing the tick time from **build creation time**:

```go
tickTime := sched.Next(workspace.LatestBuild.CreatedAt)
```

When build creation and completion straddle an hour boundary (schedule = `CRON_TZ=UTC 0 * * * *`):

| | Time | `sched.Next(...)` |
|---|---|---|
| Build created | 18:59:59.993 | **19:00:00** |
| Build completed | 19:00:00.238 | **20:00:00** |

The DB stores `next_start_at = 20:00:00`. The test sends `tickTime = 19:00:00`. The SQL eligibility query (`next_start_at <= @now`) evaluates `20:00:00 <= 19:00:00` → **false**. Workspace is not returned. Empty transitions.

The CI logs from the failing run confirm the stop build completed at `19:00:00.238` — just past the hour boundary.

## Reproduction

Confirmed locally by writing a test that forces the straddling condition: after stopping the workspace, manually update `next_start_at` to one hour past `sched.Next(build.CreatedAt)`, then tick with the old derivation.

```
=== RUN   TestExecutorAutostartOK_HourBoundaryRepro
coderd.autobuild: run stats  elapsed=0s  transitions={}
--- PASS  (assert.Empty on transitions succeeds — executor found nothing)

=== RUN   TestExecutorAutostartOK_HourBoundaryFixed
coderd.autobuild: run stats  elapsed=0s  transitions={"60c27598-...": "start"}
--- PASS  (tick aligned with next_start_at — workspace found and started)
```

## Fix

Read `next_start_at` from the database after the stop build completes and use that value as the tick time, ensuring alignment with the SQL query's filter.

Applied to both `TestExecutorAutostartOK` and `TestMultipleLifecycleExecutors` which share the same pattern.

> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖