### PR TITLE
refactor(site): remove mui from a few components

### DIFF
--- a/site/src/components/Avatar/AvatarDataSkeleton.tsx
+++ b/site/src/components/Avatar/AvatarDataSkeleton.tsx
@@ -7,8 +7,8 @@ export const AvatarDataSkeleton: FC = () => {
 			<Skeleton className="size-10 rounded-sm shrink-0" />
 
 			<div className="flex flex-col w-full">
-				<Skeleton variant="text" width={100} height={16} />
-				<Skeleton variant="text" width={60} height={16} />
+				<Skeleton variant="text" width={100} />
+				<Skeleton variant="text" width={60} />
 			</div>
 		</div>
 	);

--- a/site/src/components/Avatar/AvatarDataSkeleton.tsx
+++ b/site/src/components/Avatar/AvatarDataSkeleton.tsx
@@ -1,13 +1,14 @@
-import Skeleton from "@mui/material/Skeleton";
 import type { FC } from "react";
+import { Skeleton } from "#/components/Skeleton/Skeleton";
+
 export const AvatarDataSkeleton: FC = () => {
 	return (
 		<div className="flex items-center gap-3 w-full">
-			<Skeleton variant="rectangular" className="size-10 rounded-sm shrink-0" />
+			<Skeleton className="size-10 rounded-sm shrink-0" />
 
 			<div className="flex flex-col w-full">
-				<Skeleton variant="text" width={100} />
-				<Skeleton variant="text" width={60} />
+				<Skeleton variant="text" width={100} height={16} />
+				<Skeleton variant="text" width={60} height={16} />
 			</div>
 		</div>
 	);

--- a/site/src/components/Latency/Latency.tsx
+++ b/site/src/components/Latency/Latency.tsx
@@ -1,7 +1,7 @@
-import CircularProgress from "@mui/material/CircularProgress";
 import { CircleHelpIcon } from "lucide-react";
 import type { FC } from "react";
 import { Abbr } from "#/components/Abbr/Abbr";
+import { Spinner } from "#/components/Spinner/Spinner";
 import {
 	Tooltip,
 	TooltipContent,
@@ -38,7 +38,7 @@ export const Latency: FC<LatencyProps> = ({
 							className,
 						)}
 					>
-						<CircularProgress className={cn("!size-icon-xs", latencyColor)} />
+						<Spinner loading className={cn("!size-icon-xs", latencyColor)} />
 					</div>
 				</TooltipTrigger>
 				<TooltipContent side="bottom">Loading latency...</TooltipContent>

--- a/site/src/components/Skeleton/Skeleton.tsx
+++ b/site/src/components/Skeleton/Skeleton.tsx
@@ -1,6 +1,5 @@
 /**
- * Copied from shadcn/ui on 06/20/2025, extended with shape variants and
- * width/height props to ease migration from MUI Skeleton.
+ * Copied from shadcn/ui on 06/20/2025.
  * @see {@link https://ui.shadcn.com/docs/components/skeleton}
  */
 import { cva, type VariantProps } from "class-variance-authority";
@@ -10,7 +9,7 @@ const skeletonVariants = cva("bg-surface-tertiary animate-pulse", {
 	variants: {
 		variant: {
 			default: "rounded-md",
-			text: "rounded",
+			text: "rounded-full py-1",
 			circular: "rounded-full",
 		},
 	},
@@ -27,26 +26,20 @@ type SkeletonProps = React.ComponentProps<"div"> &
 		height?: number | string;
 	};
 
-function Skeleton({
+export const Skeleton: React.FC<SkeletonProps> = ({
 	className,
 	variant,
 	width,
 	height,
 	style,
 	...props
-}: SkeletonProps) {
+}) => {
 	return (
 		<div
 			data-slot="skeleton"
 			className={cn(skeletonVariants({ variant }), className)}
-			style={{
-				width: typeof width === "number" ? `${width}px` : width,
-				height: typeof height === "number" ? `${height}px` : height,
-				...style,
-			}}
+			style={{ width, height, ...style }}
 			{...props}
 		/>
 	);
-}
-
-export { Skeleton };
+};

--- a/site/src/components/Skeleton/Skeleton.tsx
+++ b/site/src/components/Skeleton/Skeleton.tsx
@@ -9,7 +9,7 @@ const skeletonVariants = cva("bg-surface-tertiary animate-pulse", {
 	variants: {
 		variant: {
 			default: "rounded-md",
-			text: "rounded-full py-1",
+			text: "rounded-full h-2 my-1",
 			circular: "rounded-full",
 		},
 	},

--- a/site/src/components/Skeleton/Skeleton.tsx
+++ b/site/src/components/Skeleton/Skeleton.tsx
@@ -1,14 +1,49 @@
 /**
- * Copied from shadc/ui on 06/20/2025
+ * Copied from shadcn/ui on 06/20/2025, extended with shape variants and
+ * width/height props to ease migration from MUI Skeleton.
  * @see {@link https://ui.shadcn.com/docs/components/skeleton}
  */
+import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "#/utils/cn";
 
-function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+const skeletonVariants = cva("bg-surface-tertiary animate-pulse", {
+	variants: {
+		variant: {
+			default: "rounded-md",
+			text: "rounded",
+			circular: "rounded-full",
+		},
+	},
+	defaultVariants: {
+		variant: "default",
+	},
+});
+
+type SkeletonProps = React.ComponentProps<"div"> &
+	VariantProps<typeof skeletonVariants> & {
+		/** Width in pixels (number) or any CSS value (string). */
+		width?: number | string;
+		/** Height in pixels (number) or any CSS value (string). */
+		height?: number | string;
+	};
+
+function Skeleton({
+	className,
+	variant,
+	width,
+	height,
+	style,
+	...props
+}: SkeletonProps) {
 	return (
 		<div
 			data-slot="skeleton"
-			className={cn("bg-surface-tertiary animate-pulse rounded-md", className)}
+			className={cn(skeletonVariants({ variant }), className)}
+			style={{
+				width: typeof width === "number" ? `${width}px` : width,
+				height: typeof height === "number" ? `${height}px` : height,
+				...style,
+			}}
 			{...props}
 		/>
 	);

--- a/site/src/components/StackLabel/StackLabel.tsx
+++ b/site/src/components/StackLabel/StackLabel.tsx
@@ -1,6 +1,3 @@
-import FormHelperText, {
-	type FormHelperTextProps,
-} from "@mui/material/FormHelperText";
 import type { ComponentProps, FC } from "react";
 import { Stack } from "#/components/Stack/Stack";
 import { cn } from "#/utils/cn";
@@ -23,13 +20,16 @@ export const StackLabel: FC<ComponentProps<typeof Stack>> = ({
 	);
 };
 
-export const StackLabelHelperText: FC<FormHelperTextProps> = ({
+export const StackLabelHelperText: FC<ComponentProps<"p">> = ({
 	className,
 	...props
 }) => {
 	return (
-		<FormHelperText
-			className={cn("mt-0 [&_strong]:text-content-primary", className)}
+		<p
+			className={cn(
+				"mt-0 text-xs text-content-secondary leading-[1.66] [&_strong]:text-content-primary",
+				className,
+			)}
 			{...props}
 		/>
 	);

--- a/site/src/components/TableToolbar/TableToolbar.tsx
+++ b/site/src/components/TableToolbar/TableToolbar.tsx
@@ -1,5 +1,5 @@
-import Skeleton from "@mui/material/Skeleton";
 import type { FC, PropsWithChildren } from "react";
+import { Skeleton } from "#/components/Skeleton/Skeleton";
 export const TableToolbar: FC<PropsWithChildren> = ({ children }) => {
 	return (
 		<div className="text-sm mb-2 mt-0 h-9 text-content-secondary flex items-center [&_strong]:text-content-primary">

--- a/site/src/pages/TemplatesPage/TemplatesPageView.tsx
+++ b/site/src/pages/TemplatesPage/TemplatesPageView.tsx
@@ -1,5 +1,4 @@
 import type { Interpolation, Theme } from "@emotion/react";
-import Skeleton from "@mui/material/Skeleton";
 import { ArrowRightIcon, PlusIcon } from "lucide-react";
 import type { FC } from "react";
 import { Link as RouterLink, useNavigate } from "react-router";
@@ -26,6 +25,7 @@ import {
 	PageHeaderSubtitle,
 	PageHeaderTitle,
 } from "#/components/PageHeader/PageHeader";
+import { Skeleton } from "#/components/Skeleton/Skeleton";
 import { Stack } from "#/components/Stack/Stack";
 import {
 	Table,
@@ -290,9 +290,7 @@ const TableLoader: FC = () => {
 		<TableLoaderSkeleton>
 			<TableRowSkeleton>
 				<TableCell>
-					<div className="flex items-center gap-2">
-						<AvatarDataSkeleton />
-					</div>
+					<AvatarDataSkeleton />
 				</TableCell>
 				<TableCell>
 					<Skeleton variant="text" width="25%" />


### PR DESCRIPTION
Replace three MUI component dependencies with existing project alternatives:

- **`AvatarDataSkeleton`** and **`TableToolbar`** (`PaginationStatus`): MUI `Skeleton` → existing shadcn `Skeleton` from `#/components/Skeleton/Skeleton`
- **`Latency`**: MUI `CircularProgress` → existing `Spinner` from `#/components/Spinner/Spinner`
- **`StackLabelHelperText`**: MUI `FormHelperText` → native `<p>` with equivalent Tailwind classes (`text-xs text-content-secondary leading-[1.66]`)

> 🤖 Generated by Coder Agents