### PR TITLE
refactor(site): consolidate duplicated AgentsPage utilities

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatConversation/chatHelpers.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatHelpers.ts
@@ -1,4 +1,5 @@
 import type * as TypesGen from "#/api/typesGenerated";
+import { resolveModelOptionId } from "../../utils/modelOptions";
 import type { AgentContextUsage } from "../AgentChatInput";
 import type { ModelSelectorOption } from "../ChatElements";
 import { asString } from "../ChatElements/runtimeTypeUtils";
@@ -82,18 +83,17 @@ export const resolveModelFromChatConfig = (
 	const model = asString(typedModelConfig.model);
 	const provider = asString(typedModelConfig.provider);
 
-	const candidates = [model];
-	if (provider && model) {
-		candidates.push(`${provider}:${model}`);
-	}
-
+	// Try direct ID match and legacy "provider:model" match via the
+	// shared resolver.
+	const candidates = [model, provider && model ? `${provider}:${model}` : ""];
 	for (const candidate of candidates) {
-		const match = modelOptions.find((option) => option.id === candidate);
-		if (match) {
-			return match.id;
+		const resolved = resolveModelOptionId(candidate, modelOptions);
+		if (resolved) {
+			return resolved;
 		}
 	}
 
+	// Fall back to matching by model name + optional provider.
 	if (model) {
 		const modelMatch = modelOptions.find(
 			(option) =>

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStatusHelpers.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStatusHelpers.ts
@@ -1,11 +1,19 @@
 import type { ChatProviderFailureKind } from "../../utils/usageLimitMessage";
+import { normalizeProvider } from "../ChatModelAdminPanel/helpers";
 
 const PROVIDER_STATUS_URLS: Record<string, string> = {
 	anthropic: "https://status.anthropic.com",
 };
 
-const normalizeProvider = (provider?: string): string | undefined => {
-	const normalized = provider?.trim().toLowerCase();
+/**
+ * Resolves aliases for provider names used in status lookups.
+ * Falls back to the base normalization for unknown providers.
+ */
+const resolveProviderAlias = (provider?: string): string | undefined => {
+	if (!provider) {
+		return undefined;
+	}
+	const normalized = normalizeProvider(provider);
 	if (!normalized) {
 		return undefined;
 	}
@@ -52,6 +60,6 @@ export const getProviderStatusURL = (
 	if (kind !== "overloaded") {
 		return undefined;
 	}
-	const normalized = normalizeProvider(provider);
-	return normalized ? PROVIDER_STATUS_URLS[normalized] : undefined;
+	const resolved = resolveProviderAlias(provider);
+	return resolved ? PROVIDER_STATUS_URLS[resolved] : undefined;
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/utils.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/utils.ts
@@ -4,6 +4,8 @@ import * as Diff from "diff";
 import type React from "react";
 import { asRecord, asString } from "../runtimeTypeUtils";
 
+export { shortDurationMs } from "#/utils/time";
+
 export type ToolStatus = "completed" | "error" | "running";
 
 export interface EditFilesFileEntry {
@@ -26,26 +28,6 @@ export const toProviderLabel = (
 		return providerType;
 	}
 	return "Git provider";
-};
-
-/**
- * Formats a duration in milliseconds into a compact label using
- * the same style as {@link shortRelativeTime} in utils/time.
- */
-export const shortDurationMs = (durationMs: number | undefined): string => {
-	if (durationMs === undefined || durationMs < 0) {
-		return "";
-	}
-	const seconds = Math.round(durationMs / 1000);
-	if (seconds < 60) {
-		return `${seconds}s`;
-	}
-	const minutes = Math.round(seconds / 60);
-	if (minutes < 60) {
-		return `${minutes}m`;
-	}
-	const hours = Math.round(minutes / 60);
-	return `${hours}h`;
 };
 
 export const normalizeStatus = (status: string): string =>

--- a/site/src/pages/AgentsPage/utils/modelOptions.ts
+++ b/site/src/pages/AgentsPage/utils/modelOptions.ts
@@ -4,6 +4,7 @@ import {
 	asNumber,
 	asString,
 } from "../components/ChatElements/runtimeTypeUtils";
+import { normalizeProvider } from "../components/ChatModelAdminPanel/helpers";
 
 type RuntimeModelRef = {
 	readonly provider?: unknown;
@@ -44,7 +45,7 @@ export const getNormalizedModelRef = (
 ): { readonly provider: string; readonly model: string } => {
 	const modelRef = value ?? {};
 	return {
-		provider: asString(modelRef.provider).trim().toLowerCase(),
+		provider: normalizeProvider(asString(modelRef.provider)),
 		model: asString(modelRef.model).trim(),
 	};
 };

--- a/site/src/pages/AgentsPage/utils/usageLimitMessage.ts
+++ b/site/src/pages/AgentsPage/utils/usageLimitMessage.ts
@@ -1,4 +1,5 @@
 import { formatCostMicros } from "#/utils/currency";
+import { formatDate } from "#/utils/time";
 
 /**
  * Shape of structured usage-limit fields added to 409 responses
@@ -69,12 +70,14 @@ function formatResetDate(isoString: string): string {
 	if (Number.isNaN(date.getTime())) {
 		return "";
 	}
-	return date.toLocaleDateString("en-US", {
+	return formatDate(date, {
+		locale: "en-US",
 		month: "short",
 		day: "numeric",
 		year: "numeric",
 		hour: "numeric",
 		minute: "2-digit",
+		second: undefined,
 	});
 }
 

--- a/site/src/utils/time.test.ts
+++ b/site/src/utils/time.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { shortRelativeTime } from "./time";
+import { shortDurationMs, shortRelativeTime } from "./time";
 
 describe("shortRelativeTime", () => {
 	// Pin "now" so tests are deterministic.
@@ -100,5 +100,42 @@ describe("shortRelativeTime", () => {
 	it("accepts numeric timestamp input", () => {
 		const timestamp = NOW.getTime() - 10 * 60 * 1000;
 		expect(shortRelativeTime(timestamp)).toBe("10m");
+	});
+});
+
+describe("shortDurationMs", () => {
+	it("returns empty string for undefined", () => {
+		expect(shortDurationMs(undefined)).toBe("");
+	});
+
+	it("returns empty string for negative values", () => {
+		expect(shortDurationMs(-1)).toBe("");
+		expect(shortDurationMs(-1000)).toBe("");
+	});
+
+	it("returns 0s for zero milliseconds", () => {
+		expect(shortDurationMs(0)).toBe("0s");
+	});
+
+	it("formats sub-second durations", () => {
+		expect(shortDurationMs(500)).toBe("1s");
+		expect(shortDurationMs(100)).toBe("0s");
+	});
+
+	it("formats seconds", () => {
+		expect(shortDurationMs(1000)).toBe("1s");
+		expect(shortDurationMs(30_000)).toBe("30s");
+		expect(shortDurationMs(59_000)).toBe("59s");
+	});
+
+	it("formats minutes", () => {
+		expect(shortDurationMs(60_000)).toBe("1m");
+		expect(shortDurationMs(300_000)).toBe("5m");
+		expect(shortDurationMs(3_540_000)).toBe("59m");
+	});
+
+	it("formats hours", () => {
+		expect(shortDurationMs(3_600_000)).toBe("1h");
+		expect(shortDurationMs(7_200_000)).toBe("2h");
 	});
 });

--- a/site/src/utils/time.ts
+++ b/site/src/utils/time.ts
@@ -176,6 +176,30 @@ export function daysAgo(count: number) {
 	return dayjs().subtract(count, "day").toISOString();
 }
 
+/**
+ * Formats a duration in milliseconds into a compact label like
+ * "0s", "30s", "5m", or "2h". Useful for tight UI spaces like
+ * tool-call duration badges. Unlike {@link shortRelativeTime},
+ * this operates on a raw duration rather than a point in time,
+ * preserves sub-minute precision, and is a pure function of its
+ * input.
+ */
+export function shortDurationMs(durationMs: number | undefined): string {
+	if (durationMs === undefined || durationMs < 0) {
+		return "";
+	}
+	const seconds = Math.round(durationMs / 1000);
+	if (seconds < 60) {
+		return `${seconds}s`;
+	}
+	const minutes = Math.round(seconds / 60);
+	if (minutes < 60) {
+		return `${minutes}m`;
+	}
+	const hours = Math.round(minutes / 60);
+	return `${hours}h`;
+}
+
 // Date comparison functions
 export function isAfter(date1: DateTimeInput, date2: DateTimeInput) {
 	return dayjs(date1).isAfter(dayjs(date2));


### PR DESCRIPTION
Consolidates four duplicated utility patterns within `site/src/pages/AgentsPage/`:

- **`shortDurationMs`** — Moved to `site/src/utils/time.ts` to fill a gap in the shared duration formatting API (`shortRelativeTime` formats timestamps, not raw durations). Re-exported from `tools/utils.ts` for backward compatibility.
- **`normalizeProvider`** — Three independent copies (`ChatModelAdminPanel/helpers.ts`, `chatStatusHelpers.ts`, `modelOptions.ts`) consolidated to import from the single existing export in `helpers.ts`.
- **`resolveModelFromChatConfig`** — Now delegates to `resolveModelOptionId` for ID and legacy-format matching instead of reimplementing the same loop.
- **`formatResetDate`** — Replaced inline `toLocaleDateString` with the shared `formatDate` from `utils/time.ts`.

> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖