### PR TITLE
fix: suppress duplicate status events and stale stream wipes in chat

### DIFF
--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -2881,6 +2881,38 @@ func (p *Server) Subscribe(
 		if statusNotifications != nil {
 			defer close(statusNotifications)
 		}
+		// statusDedupCount pairs local-stream status events with
+		// their pubsub duplicates. Each publishStatus call writes
+		// to both paths; local increments the count, pubsub
+		// decrements and skips when positive. If pubsub publish
+		// fails (logged, not propagated), the unmatched entry
+		// persists until the goroutine exits. A subsequent
+		// cross-replica pubsub event with the same status value
+		// would be incorrectly suppressed in this window. The
+		// goroutine exits on pubsub disconnect
+		// (ErrDroppedMessages), so the window is bounded by
+		// connection lifetime.
+		statusDedupCount := make(map[codersdk.ChatStatus]int)
+
+		// forwardLocalEvent filters and forwards a local stream
+		// event when pubsub is active. Status events increment
+		// the dedup counter so their pubsub duplicate can be
+		// suppressed. Returns false if mergedCtx was canceled.
+		forwardLocalEvent := func(ev codersdk.ChatStreamEvent) bool {
+			if ev.Type == codersdk.ChatStreamEventTypeMessagePart ||
+				ev.Type == codersdk.ChatStreamEventTypeStatus {
+				if ev.Type == codersdk.ChatStreamEventTypeStatus && ev.Status != nil {
+					statusDedupCount[ev.Status.Status]++
+				}
+				select {
+				case <-mergedCtx.Done():
+					return false
+				case mergedEvents <- ev:
+				}
+			}
+			return true
+		}
+
 		for {
 			select {
 			case <-mergedCtx.Done():
@@ -2902,6 +2934,27 @@ func (p *Server) Subscribe(
 				}
 				return
 			case notify := <-notifications:
+				// Drain pending local events so the dedup
+				// counter is up to date. Go's select picks
+				// among ready cases at random; without this
+				// drain, a pubsub notification can be read
+				// before its local counterpart, bypassing
+				// the counter-map.
+			drainLocal:
+				for localParts != nil {
+					select {
+					case ev, ok := <-localParts:
+						if !ok {
+							localParts = nil
+							break drainLocal
+						}
+						if !forwardLocalEvent(ev) {
+							return
+						}
+					default:
+						break drainLocal
+					}
+				}
 				if notify.AfterMessageID > 0 || notify.FullRefresh {
 					if notify.FullRefresh {
 						lastMessageID = 0
@@ -2944,15 +2997,28 @@ func (p *Server) Subscribe(
 					}
 				}
 				if notify.Status != "" {
-					status := database.ChatStatus(notify.Status)
-					select {
-					case <-mergedCtx.Done():
-						return
-					case mergedEvents <- codersdk.ChatStreamEvent{
-						Type:   codersdk.ChatStreamEventTypeStatus,
-						ChatID: chatID,
-						Status: &codersdk.ChatStreamStatus{Status: codersdk.ChatStatus(status)},
-					}:
+					sdkStatus := codersdk.ChatStatus(notify.Status)
+					if statusDedupCount[sdkStatus] > 0 {
+						// This pubsub notification is the duplicate
+						// of a status event already forwarded from
+						// the local stream. Decrement and skip.
+						statusDedupCount[sdkStatus]--
+						if statusDedupCount[sdkStatus] == 0 {
+							delete(statusDedupCount, sdkStatus)
+						}
+					} else {
+						// No local counterpart: this status
+						// originated on a different replica.
+						// Forward it.
+						select {
+						case <-mergedCtx.Done():
+							return
+						case mergedEvents <- codersdk.ChatStreamEvent{
+							Type:   codersdk.ChatStreamEventTypeStatus,
+							ChatID: chatID,
+							Status: &codersdk.ChatStreamStatus{Status: sdkStatus},
+						}:
+						}
 					}
 					// Notify enterprise relay manager if present.
 					if statusNotifications != nil {
@@ -2963,7 +3029,7 @@ func (p *Server) Subscribe(
 							}
 						}
 						select {
-						case statusNotifications <- StatusNotification{Status: status, WorkerID: workerID}:
+						case statusNotifications <- StatusNotification{Status: database.ChatStatus(notify.Status), WorkerID: workerID}:
 						case <-mergedCtx.Done():
 							return
 						}
@@ -3034,25 +3100,8 @@ func (p *Server) Subscribe(
 					continue
 				}
 				if hasPubsub {
-					// Forward transient events from local.
-					// Durable events (messages, queue updates)
-					// come via pubsub + cache.  Status is
-					// included alongside message_part because
-					// both travel through the same ordered
-					// channel: publishStatus is called before
-					// the first message_part, so FIFO delivery
-					// guarantees the frontend sees
-					// status=running before any content.
-					// Pubsub will deliver a duplicate status
-					// later; the frontend deduplicates it
-					// (setChatStatus is idempotent).
-					if event.Type == codersdk.ChatStreamEventTypeMessagePart ||
-						event.Type == codersdk.ChatStreamEventTypeStatus {
-						select {
-						case <-mergedCtx.Done():
-							return
-						case mergedEvents <- event:
-						}
+					if !forwardLocalEvent(event) {
+						return
 					}
 				} else {
 					// No pubsub: forward all event types.

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -2280,3 +2280,307 @@ func TestProcessChat_IgnoresStaleControlNotification(t *testing.T) {
 	require.Equal(t, database.ChatStatusError, finalStatus,
 		"processChat should have reached runChat (error), not been interrupted (waiting)")
 }
+
+// drainStreamStatusEvents reads status events from the merged events
+// channel until no more arrive. Uses the same timeout pattern as
+// requireNoStreamEvent. The subscriber goroutine processes events
+// at CPU speed with NewInMemory pubsub, so a short real-time window
+// is sufficient.
+func drainStreamStatusEvents(
+	t *testing.T,
+	events <-chan codersdk.ChatStreamEvent,
+) []codersdk.ChatStatus {
+	t.Helper()
+
+	var statuses []codersdk.ChatStatus
+	for {
+		select {
+		case event, ok := <-events:
+			require.True(t, ok, "events channel closed unexpectedly")
+			if event.Type == codersdk.ChatStreamEventTypeStatus {
+				statuses = append(statuses, event.Status.Status)
+			}
+		case <-time.After(200 * time.Millisecond):
+			return statuses
+		}
+	}
+}
+
+// TestSubscribeSuppressesDuplicatePubsubStatus verifies that when
+// publishStatus delivers a status via both the local stream and
+// pubsub, the subscriber goroutine forwards it exactly once.
+func TestSubscribeSuppressesDuplicatePubsubStatus(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+
+	chatID := uuid.New()
+	chat := database.Chat{ID: chatID, Status: database.ChatStatusWaiting}
+	initialMessage := database.ChatMessage{
+		ID:     1,
+		ChatID: chatID,
+		Role:   database.ChatMessageRoleUser,
+	}
+
+	gomock.InOrder(
+		db.EXPECT().GetChatMessagesByChatID(gomock.Any(), database.GetChatMessagesByChatIDParams{
+			ChatID:  chatID,
+			AfterID: 0,
+		}).Return([]database.ChatMessage{initialMessage}, nil),
+		db.EXPECT().GetChatQueuedMessages(gomock.Any(), chatID).Return(nil, nil),
+		db.EXPECT().GetChatByID(gomock.Any(), chatID).Return(chat, nil),
+	)
+
+	server := newSubscribeTestServer(t, db)
+	_, events, cancel, ok := server.Subscribe(ctx, chatID, nil, 0)
+	require.True(t, ok)
+	defer cancel()
+
+	// Production code path: publishStatus publishes to both
+	// local stream and pubsub in one call.
+	server.publishStatus(chatID, database.ChatStatusPending, uuid.NullUUID{})
+
+	// Drain all status events. Should be exactly 1 (from local).
+	// Before the counter-map dedup, this returned 2
+	// (the pubsub duplicate leaked through).
+	statuses := drainStreamStatusEvents(t, events)
+	require.Equal(t, []codersdk.ChatStatus{codersdk.ChatStatusPending}, statuses,
+		"expected exactly 1 pending status, got %d: %v", len(statuses), statuses)
+}
+
+// TestSubscribeSuppressesDuplicateAutoPromote verifies that the
+// counter-map dedup handles repeated status values correctly. The
+// auto-promote path publishes pending twice (SendMessage + cleanup)
+// without an intervening waiting. A plain boolean set would treat
+// the second pending as a no-op and leak one pubsub duplicate.
+// The counter map tracks both and suppresses both.
+func TestSubscribeSuppressesDuplicateAutoPromote(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+
+	chatID := uuid.New()
+	chat := database.Chat{ID: chatID, Status: database.ChatStatusWaiting}
+	initialMessage := database.ChatMessage{
+		ID:     1,
+		ChatID: chatID,
+		Role:   database.ChatMessageRoleUser,
+	}
+
+	gomock.InOrder(
+		db.EXPECT().GetChatMessagesByChatID(gomock.Any(), database.GetChatMessagesByChatIDParams{
+			ChatID:  chatID,
+			AfterID: 0,
+		}).Return([]database.ChatMessage{initialMessage}, nil),
+		db.EXPECT().GetChatQueuedMessages(gomock.Any(), chatID).Return(nil, nil),
+		db.EXPECT().GetChatByID(gomock.Any(), chatID).Return(chat, nil),
+	)
+
+	server := newSubscribeTestServer(t, db)
+	_, events, cancel, ok := server.Subscribe(ctx, chatID, nil, 0)
+	require.True(t, ok)
+	defer cancel()
+
+	// Simulate: SendMessage -> pending, processChat -> running,
+	// processChat cleanup auto-promote -> pending.
+	server.publishStatus(chatID, database.ChatStatusPending, uuid.NullUUID{})
+	server.publishStatus(chatID, database.ChatStatusRunning, uuid.NullUUID{})
+	server.publishStatus(chatID, database.ChatStatusPending, uuid.NullUUID{})
+
+	// Expect exactly 3 status events (one per publishStatus call),
+	// not 6 (which would mean all pubsub duplicates leaked).
+	statuses := drainStreamStatusEvents(t, events)
+	require.Equal(t,
+		[]codersdk.ChatStatus{
+			codersdk.ChatStatusPending,
+			codersdk.ChatStatusRunning,
+			codersdk.ChatStatusPending,
+		},
+		statuses,
+		"expected exactly 3 statuses (pending, running, pending), got %d: %v",
+		len(statuses), statuses,
+	)
+}
+
+// TestSubscribeForwardsRemoteReplicaStatus verifies that a status
+// published only via pubsub (simulating a remote replica) is
+// forwarded to the subscriber. The counter-map should not suppress
+// it because no local counterpart was delivered.
+func TestSubscribeForwardsRemoteReplicaStatus(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+
+	chatID := uuid.New()
+	chat := database.Chat{ID: chatID, Status: database.ChatStatusWaiting}
+	initialMessage := database.ChatMessage{
+		ID:     1,
+		ChatID: chatID,
+		Role:   database.ChatMessageRoleUser,
+	}
+
+	gomock.InOrder(
+		db.EXPECT().GetChatMessagesByChatID(gomock.Any(), database.GetChatMessagesByChatIDParams{
+			ChatID:  chatID,
+			AfterID: 0,
+		}).Return([]database.ChatMessage{initialMessage}, nil),
+		db.EXPECT().GetChatQueuedMessages(gomock.Any(), chatID).Return(nil, nil),
+		db.EXPECT().GetChatByID(gomock.Any(), chatID).Return(chat, nil),
+	)
+
+	server := newSubscribeTestServer(t, db)
+	_, events, cancel, ok := server.Subscribe(ctx, chatID, nil, 0)
+	require.True(t, ok)
+	defer cancel()
+
+	// Publish directly to pubsub, bypassing the local stream.
+	// This simulates a status change from a remote replica where
+	// processChat runs on a different server.
+	server.publishChatStreamNotify(chatID, coderdpubsub.ChatStreamNotifyMessage{
+		Status: string(database.ChatStatusRunning),
+	})
+
+	statuses := drainStreamStatusEvents(t, events)
+	require.Equal(t,
+		[]codersdk.ChatStatus{codersdk.ChatStatusRunning},
+		statuses,
+		"remote-replica status should be forwarded (counter == 0), got %d: %v",
+		len(statuses), statuses,
+	)
+}
+
+// TestSubscribeDedupPreventsStalePendingWipe reproduces the
+// full Race 1 production scenario: SendMessage publishes pending,
+// processChat publishes running and streams message_parts, and a
+// stale pubsub pending arrives after parts have been delivered.
+//
+// The harmful interleaving depends on Go's select scheduling and
+// may not trigger on every run. When it does trigger, it proves
+// that a consumer tracking status+stream state (like the frontend)
+// would have its in-progress stream wiped by the stale pending.
+//
+// After the fix (counter-map dedup), the stale pending is never
+// delivered, so the harmful pattern is impossible.
+func TestSubscribeDedupPreventsStalePendingWipe(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+
+	chatID := uuid.New()
+	chat := database.Chat{ID: chatID, Status: database.ChatStatusWaiting}
+	initialMessage := database.ChatMessage{
+		ID:     1,
+		ChatID: chatID,
+		Role:   database.ChatMessageRoleUser,
+	}
+
+	gomock.InOrder(
+		db.EXPECT().GetChatMessagesByChatID(gomock.Any(), database.GetChatMessagesByChatIDParams{
+			ChatID:  chatID,
+			AfterID: 0,
+		}).Return([]database.ChatMessage{initialMessage}, nil),
+		db.EXPECT().GetChatQueuedMessages(gomock.Any(), chatID).Return(nil, nil),
+		db.EXPECT().GetChatByID(gomock.Any(), chatID).Return(chat, nil),
+	)
+
+	server := newSubscribeTestServer(t, db)
+
+	// Start buffering so publishMessagePart events are delivered
+	// to subscribers (processChat does this at chatd.go:3548-3553).
+	streamState := server.getOrCreateStreamState(chatID)
+	streamState.mu.Lock()
+	streamState.buffering = true
+	streamState.mu.Unlock()
+	defer func() {
+		streamState.mu.Lock()
+		streamState.buffering = false
+		server.cleanupStreamIfIdle(chatID, streamState)
+		streamState.mu.Unlock()
+	}()
+
+	_, events, cancel, ok := server.Subscribe(ctx, chatID, nil, 0)
+	require.True(t, ok)
+	defer cancel()
+
+	// Full production scenario:
+	// 1. SendMessage publishes pending status.
+	server.publishStatus(chatID, database.ChatStatusPending, uuid.NullUUID{})
+	// 2. processChat publishes running status.
+	server.publishStatus(chatID, database.ChatStatusRunning, uuid.NullUUID{
+		UUID:  uuid.New(),
+		Valid: true,
+	})
+	// 3. LLM streams message parts.
+	for i := range 5 {
+		server.publishMessagePart(chatID, codersdk.ChatMessageRoleAssistant, codersdk.ChatMessagePart{
+			Type: "text",
+			Text: strings.Repeat("word ", i+1),
+		})
+	}
+
+	// Consume events as the frontend would: track status and
+	// whether stream content has been received.
+	var (
+		currentStatus        codersdk.ChatStatus
+		hasStreamContent     bool
+		streamWipedByPending bool
+	)
+
+	allEvents := drainAllEvents(t, events)
+	for _, event := range allEvents {
+		switch event.Type {
+		case codersdk.ChatStreamEventTypeStatus:
+			nextStatus := event.Status.Status
+			// Reproduce the frontend's destructive cleanup:
+			// when pending/waiting arrives, stream is wiped.
+			if nextStatus == codersdk.ChatStatusPending || nextStatus == codersdk.ChatStatusWaiting {
+				if currentStatus == codersdk.ChatStatusRunning && hasStreamContent {
+					// The harmful pattern: pending arrived while
+					// stream was active. This would wipe the
+					// frontend's in-progress stream.
+					streamWipedByPending = true
+				}
+				hasStreamContent = false
+			}
+			currentStatus = nextStatus
+		case codersdk.ChatStreamEventTypeMessagePart:
+			hasStreamContent = true
+		}
+	}
+
+	require.False(t, streamWipedByPending,
+		"stale pubsub pending arrived after running + message parts, wiping the active stream")
+}
+
+// drainAllEvents reads all events from the channel until no more
+// arrive within a short window. Returns them as a slice for
+// iteration.
+func drainAllEvents(
+	t *testing.T,
+	events <-chan codersdk.ChatStreamEvent,
+) []codersdk.ChatStreamEvent {
+	t.Helper()
+
+	var result []codersdk.ChatStreamEvent
+	for {
+		select {
+		case event, ok := <-events:
+			require.True(t, ok, "events channel closed unexpectedly")
+			result = append(result, event)
+		case <-time.After(200 * time.Millisecond):
+			return result
+		}
+	}
+}

--- a/site/src/api/queries/chats.test.ts
+++ b/site/src/api/queries/chats.test.ts
@@ -697,13 +697,15 @@ describe("mutation invalidation scope", () => {
 		const chatId = "chat-1";
 		seedAllActiveQueries(queryClient, chatId);
 
-		// createChatMessage has no onSuccess handler — the WebSocket
-		// stream covers all real-time updates. Verify that constructing
-		// the mutation config does not define one.
+		// Without a store, onSuccess returns early.
 		const mutation = createChatMessage(queryClient, chatId);
-		expect(mutation).not.toHaveProperty("onSuccess");
+		mutation.onSuccess({
+			queued: false,
+			message: {} as TypesGen.ChatMessage,
+		} as TypesGen.CreateChatMessageResponse);
 
-		// Since there is no onSuccess, no queries should be invalidated.
+		await new Promise((r) => setTimeout(r, 0));
+
 		for (const { label, key } of unrelatedKeys(chatId)) {
 			const state = queryClient.getQueryState(key);
 			expect(
@@ -718,9 +720,14 @@ describe("mutation invalidation scope", () => {
 		const chatId = "chat-1";
 		seedAllActiveQueries(queryClient, chatId);
 
-		// No onSuccess handler exists.
+		// Without a store, onSuccess returns early.
 		const mutation = createChatMessage(queryClient, chatId);
-		expect(mutation).not.toHaveProperty("onSuccess");
+		mutation.onSuccess({
+			queued: false,
+			message: {} as TypesGen.ChatMessage,
+		} as TypesGen.CreateChatMessageResponse);
+
+		await new Promise((r) => setTimeout(r, 0));
 
 		const chatState = queryClient.getQueryState(chatKey(chatId));
 		expect(
@@ -733,6 +740,24 @@ describe("mutation invalidation scope", () => {
 			messagesState?.isInvalidated,
 			"chatMessagesKey should NOT be invalidated",
 		).not.toBe(true);
+	});
+
+	it("createChatMessage onSuccess skips optimistic updates for queued responses", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+
+		const mockStore: Parameters<typeof createChatMessage>[2] = {
+			setChatStatus: vi.fn(),
+			upsertDurableMessage: vi.fn(),
+		};
+
+		const mutation = createChatMessage(queryClient, chatId, mockStore);
+		mutation.onSuccess({
+			queued: true,
+		} as TypesGen.CreateChatMessageResponse);
+
+		expect(mockStore.setChatStatus).not.toHaveBeenCalled();
+		expect(mockStore.upsertDurableMessage).not.toHaveBeenCalled();
 	});
 
 	it("editChatMessage does not invalidate unrelated queries", async () => {

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -2,6 +2,19 @@ import type { QueryClient, UseInfiniteQueryOptions } from "react-query";
 import { API } from "#/api/api";
 import type * as TypesGen from "#/api/typesGenerated";
 
+/**
+ * Minimal store interface for optimistic updates in mutation
+ * callbacks. Avoids importing the full ChatStore from the page
+ * layer (api/queries should not depend on pages/).
+ */
+interface ChatMutationStore {
+	setChatStatus: (status: TypesGen.ChatStatus | null) => void;
+	upsertDurableMessage: (message: TypesGen.ChatMessage) => {
+		isDuplicate: boolean;
+		changed: boolean;
+	};
+}
+
 export const chatsKey = ["chats"] as const;
 export const chatKey = (chatId: string) => ["chats", chatId] as const;
 export const chatMessagesKey = (chatId: string) =>
@@ -586,14 +599,27 @@ export const createChat = (queryClient: QueryClient) => ({
 export const createChatMessage = (
 	_queryClient: QueryClient,
 	chatId: string,
+	store?: ChatMutationStore,
 ) => ({
 	mutationFn: (req: TypesGen.CreateChatMessageRequest) =>
 		API.experimental.createChatMessage(chatId, req),
-	// No onSuccess invalidation needed: the per-chat WebSocket delivers
-	// the response message via upsertDurableMessage, and the global
-	// watchChats() WebSocket updates the sidebar sort order.
+	onSuccess: (response: TypesGen.CreateChatMessageResponse) => {
+		if (!store || response.queued) {
+			return;
+		}
+		// Optimistic updates: set status to running so the
+		// Thinking indicator appears immediately, and insert
+		// the user's message without waiting for the WebSocket.
+		// Do NOT call clearStreamState here. The previous
+		// turn's state is already null, and clearing would wipe
+		// any stream content the WebSocket delivered before this
+		// callback fires (Race 2).
+		store.setChatStatus("running");
+		if (response.message) {
+			store.upsertDurableMessage(response.message);
+		}
+	},
 });
-
 type EditChatMessageMutationArgs = {
 	messageId: number;
 	req: TypesGen.EditChatMessageRequest;

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -637,8 +637,18 @@ const AgentChatPage: FC = () => {
 	const isRegenerateTitleDisabled = isArchived || isRegeneratingThisChat;
 	const chatLastModelConfigID = chatRecord?.last_model_config_id;
 
+	const { store, clearStreamError } = useChatStore({
+		chatID: agentId,
+		chatMessages: chatMessagesList,
+		chatRecord,
+		chatMessagesData,
+		chatQueuedMessages,
+		setChatErrorReason,
+		clearChatErrorReason,
+	});
+
 	const sendMutation = useMutation(
-		createChatMessage(queryClient, agentId ?? ""),
+		createChatMessage(queryClient, agentId ?? "", store),
 	);
 	const editMutation = useMutation(editChatMessage(queryClient, agentId ?? ""));
 	const interruptMutation = useMutation(
@@ -650,16 +660,6 @@ const AgentChatPage: FC = () => {
 	const promoteQueuedMutation = useMutation(
 		promoteChatQueuedMessage(queryClient, agentId ?? ""),
 	);
-
-	const { store, clearStreamError } = useChatStore({
-		chatID: agentId,
-		chatMessages: chatMessagesList,
-		chatRecord,
-		chatMessagesData,
-		chatQueuedMessages,
-		setChatErrorReason,
-		clearChatErrorReason,
-	});
 	const liveChatStatus =
 		useChatSelector(store, selectChatStatus) ?? chatRecord?.status ?? null;
 	const persistedError = getPersistedDetailError({
@@ -829,7 +829,6 @@ const AgentChatPage: FC = () => {
 					messageId: editedMessageID,
 					req: request,
 				});
-				store.clearStreamState();
 				store.setChatStatus("running");
 				setPendingEditMessageId(null);
 			} catch (error) {
@@ -854,33 +853,13 @@ const AgentChatPage: FC = () => {
 
 		// Don't clear stream state before the POST completes.
 		// For queued sends the WebSocket status events handle
-		// clearing; for non-queued sends we clear explicitly
-		// below. Clearing eagerly causes a visible cutoff.
-		let response: Awaited<ReturnType<typeof sendMutation.mutateAsync>>;
+		// clearing; for non-queued sends the mutation's onSuccess
+		// callback handles optimistic store updates.
 		try {
-			response = await sendMutation.mutateAsync(request);
+			await sendMutation.mutateAsync(request);
 		} catch (error) {
 			handleUsageLimitError(error);
 			throw error;
-		}
-		// When the server accepts the message immediately (not
-		// queued), clear the stream and insert the user's message
-		// so it appears in the timeline without waiting for the
-		// WebSocket stream.
-		if (!response.queued) {
-			store.clearStreamState();
-			// Optimistically set status to "running" so the
-			// "Thinking..." indicator appears immediately.
-			// The server accepted the message (not queued),
-			// so it will start processing. The WebSocket
-			// status:running event no-ops via the
-			// setChatStatus guard. If the server transitions
-			// to error/pending instead, the WebSocket event
-			// overrides this optimistic value.
-			store.setChatStatus("running");
-			if (response.message) {
-				store.upsertDurableMessage(response.message);
-			}
 		}
 		if (selectedModelConfigID) {
 			localStorage.setItem(lastModelConfigIDStorageKey, selectedModelConfigID);

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -1,6 +1,10 @@
 import { act, render, renderHook, waitFor } from "@testing-library/react";
 import { watchChat } from "#/api/api";
-import { chatMessagesKey, chatsKey } from "#/api/queries/chats";
+import {
+	chatMessagesKey,
+	chatsKey,
+	createChatMessage,
+} from "#/api/queries/chats";
 
 // The infinite query key used by useInfiniteQuery(infiniteChats())
 // is [...chatsKey, undefined] = ["chats", undefined].
@@ -31,7 +35,7 @@ const readInfiniteChats = (
 };
 
 import type { FC, PropsWithChildren } from "react";
-import { QueryClient, QueryClientProvider } from "react-query";
+import { QueryClient, QueryClientProvider, useMutation } from "react-query";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { OneWayMessageEvent } from "#/utils/OneWayWebSocket";
@@ -3960,5 +3964,127 @@ describe("partsBuf cleanup on reconnect (Bug 2)", () => {
 				{ type: "response", text: "fresh content" },
 			]);
 		});
+	});
+});
+
+describe("Race 2: REST response wipes in-progress WS stream", () => {
+	it("stream state survives REST response arriving after WS content", async () => {
+		immediateAnimationFrame();
+
+		const chatID = "chat-race2";
+		const userMsg = makeMessage(chatID, 1, "user", "hello");
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		// Deferred promise so we control when the REST response arrives.
+		let resolveREST!: (value: TypesGen.CreateChatMessageResponse) => void;
+		const createChatMessageMock = vi.fn(
+			(_req: TypesGen.CreateChatMessageRequest) =>
+				new Promise<TypesGen.CreateChatMessageResponse>((resolve) => {
+					resolveREST = resolve;
+				}),
+		);
+
+		const queryClient = createTestQueryClient();
+		const wrapper = ({ children }: PropsWithChildren) => (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+
+		// Render useChatStore (WS handler) and useMutation with
+		// the production createChatMessage factory. The factory's
+		// onSuccess applies optimistic updates (setChatStatus,
+		// upsertDurableMessage) without calling clearStreamState.
+		// We only override mutationFn to use the deferred mock;
+		// onSuccess is real.
+		const { result } = renderHook(
+			() => {
+				const { store } = useChatStore({
+					chatID,
+					chatMessages: [userMsg],
+					chatRecord: makeChat(chatID),
+					chatMessagesData: {
+						messages: [userMsg],
+						queued_messages: [],
+						has_more: false,
+					},
+					chatQueuedMessages: [],
+					setChatErrorReason: vi.fn(),
+					clearChatErrorReason: vi.fn(),
+				});
+				const mutation = useMutation({
+					...createChatMessage(queryClient, chatID, store),
+					mutationFn: createChatMessageMock,
+				});
+				return {
+					mutation,
+					streamState: useChatSelector(store, selectStreamState),
+				};
+			},
+			{ wrapper },
+		);
+
+		// Wait for WS to connect.
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, 1);
+		});
+
+		// Start the mutation (REST call in flight).
+		let mutationDone = false;
+		const mutationPromise = act(async () => {
+			await result.current.mutation.mutateAsync({
+				content: [{ type: "text", text: "follow-up" }],
+			});
+			mutationDone = true;
+		});
+
+		// While REST is in-flight, WS delivers status=running
+		// and a message part via the production handler.
+		act(() => {
+			mockSocket.emitData({
+				type: "status",
+				chat_id: chatID,
+				status: { status: "running" },
+			});
+		});
+		act(() => {
+			mockSocket.emitData({
+				type: "message_part",
+				chat_id: chatID,
+				message_part: {
+					role: "assistant",
+					part: { type: "text", text: "The answer is 42" },
+				},
+			});
+		});
+
+		// Verify stream state was built via the production WS path.
+		await waitFor(() => {
+			expect(result.current.streamState?.blocks).toEqual([
+				{ type: "response", text: "The answer is 42" },
+			]);
+		});
+
+		// REST hasn't resolved yet.
+		expect(mutationDone).toBe(false);
+
+		// Resolve the REST response. The mutation's production
+		// onSuccess callback runs automatically, applying
+		// optimistic updates.
+		await act(async () => {
+			resolveREST({
+				queued: false,
+				message: makeMessage(chatID, 2, "user", "follow-up"),
+			} as TypesGen.CreateChatMessageResponse);
+		});
+
+		await mutationPromise;
+		expect(mutationDone).toBe(true);
+
+		// Stream state survives because onSuccess no longer
+		// calls clearStreamState.
+		expect(result.current.streamState).not.toBeNull();
+		expect(result.current.streamState?.blocks).toEqual([
+			{ type: "response", text: "The answer is 42" },
+		]);
 	});
 });


### PR DESCRIPTION
Superseded. Race 1 frontend symptom fixed by #24314. Backend dedup extracted to #24659. Race 2 fix rebased as a focused one-liner in a new PR.

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻