### PR TITLE
refactor: send raw typed payloads over chat WebSockets

### DIFF
--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -2269,7 +2269,7 @@ func (api *API) streamChat(rw http.ResponseWriter, r *http.Request) {
 			end = len(snapshot)
 		}
 		if err := sendChatStreamBatch(snapshot[start:end]); err != nil {
-			api.Logger.Debug(ctx, "failed to send chat stream snapshot", slog.Error(err))
+			logger.Debug(ctx, "failed to send chat stream snapshot", slog.Error(err))
 			return
 		}
 	}
@@ -2287,7 +2287,7 @@ func (api *API) streamChat(rw http.ResponseWriter, r *http.Request) {
 				chatStreamBatchSize,
 			)
 			if err := sendChatStreamBatch(batch); err != nil {
-				api.Logger.Debug(ctx, "failed to send chat stream event", slog.Error(err))
+				logger.Debug(ctx, "failed to send chat stream event", slog.Error(err))
 				return
 			}
 			if streamClosed {
@@ -2302,6 +2302,7 @@ func (api *API) interruptChat(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	chat := httpmw.ChatParam(r)
 	chatID := chat.ID
+	logger := api.Logger.Named("chat_interrupt").With(slog.F("chat_id", chatID))
 
 	if api.chatDaemon != nil {
 		chat = api.chatDaemon.InterruptChat(ctx, chat)
@@ -2315,8 +2316,7 @@ func (api *API) interruptChat(rw http.ResponseWriter, r *http.Request) {
 			LastError:   sql.NullString{},
 		})
 		if updateErr != nil {
-			api.Logger.Error(ctx, "failed to mark chat as waiting",
-				slog.F("chat_id", chatID), slog.Error(updateErr))
+			logger.Error(ctx, "failed to mark chat as waiting", slog.Error(updateErr))
 			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 				Message: "Failed to interrupt chat.",
 				Detail:  updateErr.Error(),

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -158,6 +158,9 @@ func (api *API) watchChats(rw http.ResponseWriter, r *http.Request) {
 
 	go httpapi.HeartbeatClose(ctx, logger, cancel, conn)
 
+	// The encoder is only written from the pubsub delivery
+	// goroutine (msgQueue.run). Do not add a second write path
+	// without introducing synchronization.
 	encoder := json.NewEncoder(wsNetConn)
 
 	cancelSubscribe, err := api.Pubsub.SubscribeWithErr(pubsub.ChatEventChannel(apiKey.UserID),
@@ -174,6 +177,7 @@ func (api *API) watchChats(rw http.ResponseWriter, r *http.Request) {
 		))
 	if err != nil {
 		api.Logger.Error(ctx, "failed to subscribe to chat events", slog.Error(err))
+		_ = conn.Close(websocket.StatusInternalError, "Failed to subscribe to chat events.")
 		return
 	}
 	defer cancelSubscribe()

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -167,18 +167,18 @@ func (api *API) watchChats(rw http.ResponseWriter, r *http.Request) {
 		pubsub.HandleChatWatchEvent(
 			func(ctx context.Context, payload codersdk.ChatWatchEvent, err error) {
 				if err != nil {
-					api.Logger.Error(ctx, "chat watch event subscription error", slog.Error(err))
+					logger.Error(ctx, "chat watch event subscription error", slog.Error(err))
 					return
 				}
 				if err := encoder.Encode(payload); err != nil {
-					api.Logger.Debug(ctx, "failed to send chat watch event", slog.Error(err))
+					logger.Debug(ctx, "failed to send chat watch event", slog.Error(err))
 					cancel()
 					return
 				}
 			},
 		))
 	if err != nil {
-		api.Logger.Error(ctx, "failed to subscribe to chat watch events", slog.Error(err))
+		logger.Error(ctx, "failed to subscribe to chat watch events", slog.Error(err))
 		_ = conn.Close(websocket.StatusInternalError, "Failed to subscribe to chat events.")
 		return
 	}

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -158,25 +158,25 @@ func (api *API) watchChats(rw http.ResponseWriter, r *http.Request) {
 
 	go httpapi.HeartbeatClose(ctx, logger, cancel, conn)
 
-	// The encoder is only written from the pubsub delivery
-	// goroutine (msgQueue.run). Do not add a second write path
-	// without introducing synchronization.
+	// The encoder is only written from the SubscribeWithErr callback,
+	// which delivers serially per subscription. Do not add a second
+	// write path without introducing synchronization.
 	encoder := json.NewEncoder(wsNetConn)
 
-	cancelSubscribe, err := api.Pubsub.SubscribeWithErr(pubsub.ChatEventChannel(apiKey.UserID),
-		pubsub.HandleChatEvent(
+	cancelSubscribe, err := api.Pubsub.SubscribeWithErr(pubsub.ChatWatchEventChannel(apiKey.UserID),
+		pubsub.HandleChatWatchEvent(
 			func(ctx context.Context, payload codersdk.ChatWatchEvent, err error) {
 				if err != nil {
-					api.Logger.Error(ctx, "chat event subscription error", slog.Error(err))
+					api.Logger.Error(ctx, "chat watch event subscription error", slog.Error(err))
 					return
 				}
 				if err := encoder.Encode(payload); err != nil {
-					api.Logger.Debug(ctx, "failed to send chat event", slog.Error(err))
+					api.Logger.Debug(ctx, "failed to send chat watch event", slog.Error(err))
 				}
 			},
 		))
 	if err != nil {
-		api.Logger.Error(ctx, "failed to subscribe to chat events", slog.Error(err))
+		api.Logger.Error(ctx, "failed to subscribe to chat watch events", slog.Error(err))
 		_ = conn.Close(websocket.StatusInternalError, "Failed to subscribe to chat events.")
 		return
 	}
@@ -2191,6 +2191,9 @@ func (api *API) streamChat(rw http.ResponseWriter, r *http.Request) {
 	// Subscribe before accepting the WebSocket so that failures
 	// can still be reported as normal HTTP errors.
 	snapshot, events, cancelSub, ok := api.chatDaemon.Subscribe(ctx, chatID, r.Header, afterMessageID)
+	// Subscribe only fails today when the receiver is nil, which
+	// the chatDaemon == nil guard above already catches. This is
+	// defensive against future Subscribe failure modes.
 	if !ok {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Chat streaming is not available.",

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -137,8 +137,9 @@ func publishChatConfigEvent(logger slog.Logger, ps dbpubsub.Pubsub, kind pubsub.
 func (api *API) watchChats(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	apiKey := httpmw.APIKey(r)
+	logger := api.Logger.Named("chat_watcher")
 
-	sendEvent, senderClosed, err := httpapi.OneWayWebSocketEventSender(api.Logger)(rw, r)
+	conn, err := websocket.Accept(rw, r, nil)
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Failed to open chat watch stream.",
@@ -146,54 +147,38 @@ func (api *API) watchChats(rw http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	defer func() {
-		<-senderClosed
-	}()
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	_ = conn.CloseRead(context.Background())
+
+	ctx, wsNetConn := codersdk.WebsocketNetConn(ctx, conn, websocket.MessageText)
+	defer wsNetConn.Close()
+
+	go httpapi.HeartbeatClose(ctx, logger, cancel, conn)
+
+	encoder := json.NewEncoder(wsNetConn)
 
 	cancelSubscribe, err := api.Pubsub.SubscribeWithErr(pubsub.ChatEventChannel(apiKey.UserID),
 		pubsub.HandleChatEvent(
-			func(ctx context.Context, payload pubsub.ChatEvent, err error) {
+			func(ctx context.Context, payload codersdk.ChatWatchEvent, err error) {
 				if err != nil {
 					api.Logger.Error(ctx, "chat event subscription error", slog.Error(err))
 					return
 				}
-				if err := sendEvent(codersdk.ServerSentEvent{
-					Type: codersdk.ServerSentEventTypeData,
-					Data: payload,
-				}); err != nil {
+				if err := encoder.Encode(payload); err != nil {
 					api.Logger.Debug(ctx, "failed to send chat event", slog.Error(err))
 				}
 			},
 		))
 	if err != nil {
-		if err := sendEvent(codersdk.ServerSentEvent{
-			Type: codersdk.ServerSentEventTypeError,
-			Data: codersdk.Response{
-				Message: "Internal error subscribing to chat events.",
-				Detail:  err.Error(),
-			},
-		}); err != nil {
-			api.Logger.Debug(ctx, "failed to send chat subscribe error event", slog.Error(err))
-		}
+		api.Logger.Error(ctx, "failed to subscribe to chat events", slog.Error(err))
 		return
 	}
 	defer cancelSubscribe()
 
-	// Send initial ping to signal the connection is ready.
-	if err := sendEvent(codersdk.ServerSentEvent{
-		Type: codersdk.ServerSentEventTypePing,
-	}); err != nil {
-		api.Logger.Debug(ctx, "failed to send chat ping event", slog.Error(err))
-	}
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-senderClosed:
-			return
-		}
-	}
+	<-ctx.Done()
 }
 
 // EXPERIMENTAL: chatsByWorkspace returns a mapping of workspace ID to
@@ -2176,6 +2161,7 @@ func (api *API) streamChat(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	chat := httpmw.ChatParam(r)
 	chatID := chat.ID
+	logger := api.Logger.Named("chat_streamer")
 
 	if api.chatDaemon == nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
@@ -2198,7 +2184,19 @@ func (api *API) streamChat(rw http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	sendEvent, senderClosed, err := httpapi.OneWayWebSocketEventSender(api.Logger)(rw, r)
+	// Subscribe before accepting the WebSocket so that failures
+	// can still be reported as normal HTTP errors.
+	snapshot, events, cancelSub, ok := api.chatDaemon.Subscribe(ctx, chatID, r.Header, afterMessageID)
+	if !ok {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Chat streaming is not available.",
+			Detail:  "Chat stream state is not configured.",
+		})
+		return
+	}
+	defer cancelSub()
+
+	conn, err := websocket.Accept(rw, r, nil)
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Failed to open chat stream.",
@@ -2206,26 +2204,16 @@ func (api *API) streamChat(rw http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	snapshot, events, cancel, ok := api.chatDaemon.Subscribe(ctx, chatID, r.Header, afterMessageID)
-	if !ok {
-		if err := sendEvent(codersdk.ServerSentEvent{
-			Type: codersdk.ServerSentEventTypeError,
-			Data: codersdk.Response{
-				Message: "Chat streaming is not available.",
-				Detail:  "Chat stream state is not configured.",
-			},
-		}); err != nil {
-			api.Logger.Debug(ctx, "failed to send chat stream unavailable event", slog.Error(err))
-		}
-		// Ensure the WebSocket is closed so senderClosed
-		// completes and the handler can return.
-		<-senderClosed
-		return
-	}
-	defer func() {
-		<-senderClosed
-	}()
+
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
+
+	_ = conn.CloseRead(context.Background())
+
+	ctx, wsNetConn := codersdk.WebsocketNetConn(ctx, conn, websocket.MessageText)
+	defer wsNetConn.Close()
+
+	go httpapi.HeartbeatClose(ctx, logger, cancel, conn)
 
 	// Mark the chat as read when the stream connects and again
 	// when it disconnects so we avoid per-message API calls while
@@ -2233,14 +2221,13 @@ func (api *API) streamChat(rw http.ResponseWriter, r *http.Request) {
 	api.markChatAsRead(ctx, chatID)
 	defer api.markChatAsRead(context.WithoutCancel(ctx), chatID)
 
+	encoder := json.NewEncoder(wsNetConn)
+
 	sendChatStreamBatch := func(batch []codersdk.ChatStreamEvent) error {
 		if len(batch) == 0 {
 			return nil
 		}
-		return sendEvent(codersdk.ServerSentEvent{
-			Type: codersdk.ServerSentEventTypeData,
-			Data: batch,
-		})
+		return encoder.Encode(batch)
 	}
 
 	drainChatStreamBatch := func(
@@ -2281,8 +2268,6 @@ func (api *API) streamChat(rw http.ResponseWriter, r *http.Request) {
 	for {
 		select {
 		case <-ctx.Done():
-			return
-		case <-senderClosed:
 			return
 		case firstEvent, ok := <-events:
 			if !ok {

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -172,6 +172,8 @@ func (api *API) watchChats(rw http.ResponseWriter, r *http.Request) {
 				}
 				if err := encoder.Encode(payload); err != nil {
 					api.Logger.Debug(ctx, "failed to send chat watch event", slog.Error(err))
+					cancel()
+					return
 				}
 			},
 		))
@@ -2165,7 +2167,7 @@ func (api *API) streamChat(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	chat := httpmw.ChatParam(r)
 	chatID := chat.ID
-	logger := api.Logger.Named("chat_streamer")
+	logger := api.Logger.Named("chat_streamer").With(slog.F("chat_id", chatID))
 
 	if api.chatDaemon == nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -1114,17 +1114,6 @@ func TestWatchChats(t *testing.T) {
 		require.NoError(t, err)
 		defer conn.Close(websocket.StatusNormalClosure, "done")
 
-		type watchEvent struct {
-			Type codersdk.ServerSentEventType `json:"type"`
-			Data json.RawMessage              `json:"data,omitempty"`
-		}
-
-		var event watchEvent
-		err = wsjson.Read(ctx, conn, &event)
-		require.NoError(t, err)
-		require.Equal(t, codersdk.ServerSentEventTypePing, event.Type)
-		require.True(t, len(event.Data) == 0 || string(event.Data) == "null")
-
 		createdChat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
 			Content: []codersdk.ChatInputPart{
 				{
@@ -1136,25 +1125,16 @@ func TestWatchChats(t *testing.T) {
 		require.NoError(t, err)
 
 		for {
-			var update watchEvent
-			err = wsjson.Read(ctx, conn, &update)
+			var payload codersdk.ChatWatchEvent
+			err = wsjson.Read(ctx, conn, &payload)
 			require.NoError(t, err)
 
-			if update.Type == codersdk.ServerSentEventTypePing {
-				continue
-			}
-			require.Equal(t, codersdk.ServerSentEventTypeData, update.Type)
-
-			var payload coderdpubsub.ChatEvent
-			err = json.Unmarshal(update.Data, &payload)
-			require.NoError(t, err)
-			if payload.Kind == coderdpubsub.ChatEventKindCreated &&
+			if payload.Kind == codersdk.ChatWatchEventKindCreated &&
 				payload.Chat.ID == createdChat.ID {
 				break
 			}
 		}
 	})
-
 	t.Run("CreatedEventIncludesAllChatFields", func(t *testing.T) {
 		t.Parallel()
 
@@ -1174,18 +1154,6 @@ func TestWatchChats(t *testing.T) {
 		require.NoError(t, err)
 		defer conn.Close(websocket.StatusNormalClosure, "done")
 
-		type watchEvent struct {
-			Type codersdk.ServerSentEventType `json:"type"`
-			Data json.RawMessage              `json:"data,omitempty"`
-		}
-
-		// Skip the initial ping.
-		var event watchEvent
-		err = wsjson.Read(ctx, conn, &event)
-		require.NoError(t, err)
-		require.Equal(t, codersdk.ServerSentEventTypePing, event.Type)
-		require.True(t, len(event.Data) == 0 || string(event.Data) == "null")
-
 		createdChat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
 			Content: []codersdk.ChatInputPart{
 				{
@@ -1198,24 +1166,17 @@ func TestWatchChats(t *testing.T) {
 
 		var got codersdk.Chat
 		testutil.Eventually(ctx, t, func(_ context.Context) bool {
-			var update watchEvent
-			if readErr := wsjson.Read(ctx, conn, &update); readErr != nil {
+			var payload codersdk.ChatWatchEvent
+			if readErr := wsjson.Read(ctx, conn, &payload); readErr != nil {
 				return false
 			}
-			if update.Type != codersdk.ServerSentEventTypeData {
-				return false
-			}
-			var payload coderdpubsub.ChatEvent
-			if unmarshalErr := json.Unmarshal(update.Data, &payload); unmarshalErr != nil {
-				return false
-			}
-			if payload.Kind == coderdpubsub.ChatEventKindCreated &&
+			if payload.Kind == codersdk.ChatWatchEventKindCreated &&
 				payload.Chat.ID == createdChat.ID {
 				got = payload.Chat
 				return true
 			}
 			return false
-		}, testutil.IntervalFast, "expected a created event for chat %s", createdChat.ID)
+		}, testutil.IntervalFast)
 
 		require.Equal(t, createdChat.ID, got.ID)
 		require.Equal(t, createdChat.OwnerID, got.OwnerID)
@@ -1282,25 +1243,14 @@ func TestWatchChats(t *testing.T) {
 		require.NoError(t, err)
 		defer conn.Close(websocket.StatusNormalClosure, "done")
 
-		type watchEvent struct {
-			Type codersdk.ServerSentEventType `json:"type"`
-			Data json.RawMessage              `json:"data,omitempty"`
-		}
-
-		// Read the initial ping.
-		var ping watchEvent
-		err = wsjson.Read(ctx, conn, &ping)
-		require.NoError(t, err)
-		require.Equal(t, codersdk.ServerSentEventTypePing, ping.Type)
-
 		// Publish a diff_status_change event via pubsub,
 		// mimicking what PublishDiffStatusChange does after
 		// it reads the diff status from the DB.
 		dbStatus, err := db.GetChatDiffStatusByChatID(dbauthz.AsSystemRestricted(ctx), chat.ID)
 		require.NoError(t, err)
 		sdkDiffStatus := db2sdk.ChatDiffStatus(chat.ID, &dbStatus)
-		event := coderdpubsub.ChatEvent{
-			Kind: coderdpubsub.ChatEventKindDiffStatusChange,
+		event := codersdk.ChatWatchEvent{
+			Kind: codersdk.ChatWatchEventKindDiffStatusChange,
 			Chat: codersdk.Chat{
 				ID:         chat.ID,
 				OwnerID:    chat.OwnerID,
@@ -1316,22 +1266,12 @@ func TestWatchChats(t *testing.T) {
 		err = api.Pubsub.Publish(coderdpubsub.ChatEventChannel(user.UserID), payload)
 		require.NoError(t, err)
 
-		// Read events until we find the diff_status_change.
 		for {
-			var update watchEvent
-			err = wsjson.Read(ctx, conn, &update)
+			var received codersdk.ChatWatchEvent
+			err = wsjson.Read(ctx, conn, &received)
 			require.NoError(t, err)
 
-			if update.Type == codersdk.ServerSentEventTypePing {
-				continue
-			}
-			require.Equal(t, codersdk.ServerSentEventTypeData, update.Type)
-
-			var received coderdpubsub.ChatEvent
-			err = json.Unmarshal(update.Data, &received)
-			require.NoError(t, err)
-
-			if received.Kind != coderdpubsub.ChatEventKindDiffStatusChange ||
+			if received.Kind != codersdk.ChatWatchEventKindDiffStatusChange ||
 				received.Chat.ID != chat.ID {
 				continue
 			}
@@ -1350,7 +1290,6 @@ func TestWatchChats(t *testing.T) {
 			break
 		}
 	})
-
 	t.Run("ArchiveAndUnarchiveEmitEventsForDescendants", func(t *testing.T) {
 		t.Parallel()
 
@@ -1393,31 +1332,13 @@ func TestWatchChats(t *testing.T) {
 		require.NoError(t, err)
 		defer conn.Close(websocket.StatusNormalClosure, "done")
 
-		type watchEvent struct {
-			Type codersdk.ServerSentEventType `json:"type"`
-			Data json.RawMessage              `json:"data,omitempty"`
-		}
-
-		var ping watchEvent
-		err = wsjson.Read(ctx, conn, &ping)
-		require.NoError(t, err)
-		require.Equal(t, codersdk.ServerSentEventTypePing, ping.Type)
-
-		collectLifecycleEvents := func(expectedKind coderdpubsub.ChatEventKind) map[uuid.UUID]coderdpubsub.ChatEvent {
+		collectLifecycleEvents := func(expectedKind codersdk.ChatWatchEventKind) map[uuid.UUID]codersdk.ChatWatchEvent {
 			t.Helper()
 
-			events := make(map[uuid.UUID]coderdpubsub.ChatEvent, 3)
+			events := make(map[uuid.UUID]codersdk.ChatWatchEvent, 3)
 			for len(events) < 3 {
-				var update watchEvent
-				err = wsjson.Read(ctx, conn, &update)
-				require.NoError(t, err)
-				if update.Type == codersdk.ServerSentEventTypePing {
-					continue
-				}
-				require.Equal(t, codersdk.ServerSentEventTypeData, update.Type)
-
-				var payload coderdpubsub.ChatEvent
-				err = json.Unmarshal(update.Data, &payload)
+				var payload codersdk.ChatWatchEvent
+				err = wsjson.Read(ctx, conn, &payload)
 				require.NoError(t, err)
 				if payload.Kind != expectedKind {
 					continue
@@ -1427,7 +1348,7 @@ func TestWatchChats(t *testing.T) {
 			return events
 		}
 
-		assertLifecycleEvents := func(events map[uuid.UUID]coderdpubsub.ChatEvent, archived bool) {
+		assertLifecycleEvents := func(events map[uuid.UUID]codersdk.ChatWatchEvent, archived bool) {
 			t.Helper()
 
 			require.Len(t, events, 3)
@@ -1440,12 +1361,12 @@ func TestWatchChats(t *testing.T) {
 
 		err = client.UpdateChat(ctx, parentChat.ID, codersdk.UpdateChatRequest{Archived: ptr.Ref(true)})
 		require.NoError(t, err)
-		deletedEvents := collectLifecycleEvents(coderdpubsub.ChatEventKindDeleted)
+		deletedEvents := collectLifecycleEvents(codersdk.ChatWatchEventKindDeleted)
 		assertLifecycleEvents(deletedEvents, true)
 
 		err = client.UpdateChat(ctx, parentChat.ID, codersdk.UpdateChatRequest{Archived: ptr.Ref(false)})
 		require.NoError(t, err)
-		createdEvents := collectLifecycleEvents(coderdpubsub.ChatEventKindCreated)
+		createdEvents := collectLifecycleEvents(codersdk.ChatWatchEventKindCreated)
 		assertLifecycleEvents(createdEvents, false)
 	})
 

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -1176,7 +1176,7 @@ func TestWatchChats(t *testing.T) {
 				return true
 			}
 			return false
-		}, testutil.IntervalFast)
+		}, testutil.IntervalFast, "expected a created event for chat %s", createdChat.ID)
 
 		require.Equal(t, createdChat.ID, got.ID)
 		require.Equal(t, createdChat.OwnerID, got.OwnerID)

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -1263,7 +1263,7 @@ func TestWatchChats(t *testing.T) {
 		}
 		payload, err := json.Marshal(event)
 		require.NoError(t, err)
-		err = api.Pubsub.Publish(coderdpubsub.ChatEventChannel(user.UserID), payload)
+		err = api.Pubsub.Publish(coderdpubsub.ChatWatchEventChannel(user.UserID), payload)
 		require.NoError(t, err)
 
 		for {

--- a/coderd/pubsub/chatconfigevent.go
+++ b/coderd/pubsub/chatconfigevent.go
@@ -14,7 +14,7 @@ import (
 const ChatConfigEventChannel = "chat:config_change"
 
 // HandleChatConfigEvent wraps a typed callback for ChatConfigEvent
-// messages, following the same pattern as HandleChatEvent.
+// messages, following the same pattern as HandleChatWatchEvent.
 func HandleChatConfigEvent(cb func(ctx context.Context, payload ChatConfigEvent, err error)) func(ctx context.Context, message []byte, err error) {
 	return func(ctx context.Context, message []byte, err error) {
 		if err != nil {

--- a/coderd/pubsub/chatevent.go
+++ b/coderd/pubsub/chatevent.go
@@ -15,35 +15,18 @@ func ChatEventChannel(ownerID uuid.UUID) string {
 	return fmt.Sprintf("chat:owner:%s", ownerID)
 }
 
-func HandleChatEvent(cb func(ctx context.Context, payload ChatEvent, err error)) func(ctx context.Context, message []byte, err error) {
+func HandleChatEvent(cb func(ctx context.Context, payload codersdk.ChatWatchEvent, err error)) func(ctx context.Context, message []byte, err error) {
 	return func(ctx context.Context, message []byte, err error) {
 		if err != nil {
-			cb(ctx, ChatEvent{}, xerrors.Errorf("chat event pubsub: %w", err))
+			cb(ctx, codersdk.ChatWatchEvent{}, xerrors.Errorf("chat event pubsub: %w", err))
 			return
 		}
-		var payload ChatEvent
+		var payload codersdk.ChatWatchEvent
 		if err := json.Unmarshal(message, &payload); err != nil {
-			cb(ctx, ChatEvent{}, xerrors.Errorf("unmarshal chat event: %w", err))
+			cb(ctx, codersdk.ChatWatchEvent{}, xerrors.Errorf("unmarshal chat event: %w", err))
 			return
 		}
 
 		cb(ctx, payload, err)
 	}
 }
-
-type ChatEvent struct {
-	Kind      ChatEventKind                 `json:"kind"`
-	Chat      codersdk.Chat                 `json:"chat"`
-	ToolCalls []codersdk.ChatStreamToolCall `json:"tool_calls,omitempty"`
-}
-
-type ChatEventKind string
-
-const (
-	ChatEventKindStatusChange     ChatEventKind = "status_change"
-	ChatEventKindTitleChange      ChatEventKind = "title_change"
-	ChatEventKindCreated          ChatEventKind = "created"
-	ChatEventKindDeleted          ChatEventKind = "deleted"
-	ChatEventKindDiffStatusChange ChatEventKind = "diff_status_change"
-	ChatEventKindActionRequired   ChatEventKind = "action_required"
-)

--- a/coderd/pubsub/chatwatchevent.go
+++ b/coderd/pubsub/chatwatchevent.go
@@ -11,19 +11,19 @@ import (
 	"github.com/coder/coder/v2/codersdk"
 )
 
-func ChatEventChannel(ownerID uuid.UUID) string {
+func ChatWatchEventChannel(ownerID uuid.UUID) string {
 	return fmt.Sprintf("chat:owner:%s", ownerID)
 }
 
-func HandleChatEvent(cb func(ctx context.Context, payload codersdk.ChatWatchEvent, err error)) func(ctx context.Context, message []byte, err error) {
+func HandleChatWatchEvent(cb func(ctx context.Context, payload codersdk.ChatWatchEvent, err error)) func(ctx context.Context, message []byte, err error) {
 	return func(ctx context.Context, message []byte, err error) {
 		if err != nil {
-			cb(ctx, codersdk.ChatWatchEvent{}, xerrors.Errorf("chat event pubsub: %w", err))
+			cb(ctx, codersdk.ChatWatchEvent{}, xerrors.Errorf("chat watch event pubsub: %w", err))
 			return
 		}
 		var payload codersdk.ChatWatchEvent
 		if err := json.Unmarshal(message, &payload); err != nil {
-			cb(ctx, codersdk.ChatWatchEvent{}, xerrors.Errorf("unmarshal chat event: %w", err))
+			cb(ctx, codersdk.ChatWatchEvent{}, xerrors.Errorf("unmarshal chat watch event: %w", err))
 			return
 		}
 

--- a/coderd/pubsub/chatwatchevent.go
+++ b/coderd/pubsub/chatwatchevent.go
@@ -11,10 +11,14 @@ import (
 	"github.com/coder/coder/v2/codersdk"
 )
 
+// ChatWatchEventChannel returns the pubsub channel for chat
+// lifecycle events scoped to a single user.
 func ChatWatchEventChannel(ownerID uuid.UUID) string {
 	return fmt.Sprintf("chat:owner:%s", ownerID)
 }
 
+// HandleChatWatchEvent wraps a typed callback for
+// ChatWatchEvent messages delivered via pubsub.
 func HandleChatWatchEvent(cb func(ctx context.Context, payload codersdk.ChatWatchEvent, err error)) func(ctx context.Context, message []byte, err error) {
 	return func(ctx context.Context, message []byte, err error) {
 		if err != nil {

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -996,7 +996,7 @@ func (p *Server) CreateChat(ctx context.Context, opts CreateOptions) (database.C
 		return database.Chat{}, txErr
 	}
 
-	p.publishChatPubsubEvent(chat, coderdpubsub.ChatEventKindCreated, nil)
+	p.publishChatPubsubEvent(chat, codersdk.ChatWatchEventKindCreated, nil)
 	p.signalWake()
 	return chat, nil
 }
@@ -1158,7 +1158,7 @@ func (p *Server) SendMessage(
 
 	p.publishMessage(opts.ChatID, result.Message)
 	p.publishStatus(opts.ChatID, result.Chat.Status, result.Chat.WorkerID)
-	p.publishChatPubsubEvent(result.Chat, coderdpubsub.ChatEventKindStatusChange, nil)
+	p.publishChatPubsubEvent(result.Chat, codersdk.ChatWatchEventKindStatusChange, nil)
 	p.signalWake()
 	return result, nil
 }
@@ -1301,7 +1301,7 @@ func (p *Server) EditMessage(
 		QueueUpdate: true,
 	})
 	p.publishStatus(opts.ChatID, result.Chat.Status, result.Chat.WorkerID)
-	p.publishChatPubsubEvent(result.Chat, coderdpubsub.ChatEventKindStatusChange, nil)
+	p.publishChatPubsubEvent(result.Chat, codersdk.ChatWatchEventKindStatusChange, nil)
 	p.signalWake()
 
 	return result, nil
@@ -1355,10 +1355,10 @@ func (p *Server) ArchiveChat(ctx context.Context, chat database.Chat) error {
 
 	if interrupted {
 		p.publishStatus(chat.ID, statusChat.Status, statusChat.WorkerID)
-		p.publishChatPubsubEvent(statusChat, coderdpubsub.ChatEventKindStatusChange, nil)
+		p.publishChatPubsubEvent(statusChat, codersdk.ChatWatchEventKindStatusChange, nil)
 	}
 
-	p.publishChatPubsubEvents(archivedChats, coderdpubsub.ChatEventKindDeleted)
+	p.publishChatPubsubEvents(archivedChats, codersdk.ChatWatchEventKindDeleted)
 	return nil
 }
 
@@ -1373,7 +1373,7 @@ func (p *Server) UnarchiveChat(ctx context.Context, chat database.Chat) error {
 		ctx,
 		chat.ID,
 		"unarchive",
-		coderdpubsub.ChatEventKindCreated,
+		codersdk.ChatWatchEventKindCreated,
 		p.db.UnarchiveChatByID,
 	)
 }
@@ -1382,7 +1382,7 @@ func (p *Server) applyChatLifecycleTransition(
 	ctx context.Context,
 	chatID uuid.UUID,
 	action string,
-	kind coderdpubsub.ChatEventKind,
+	kind codersdk.ChatWatchEventKind,
 	transition func(context.Context, uuid.UUID) ([]database.Chat, error),
 ) error {
 	updatedChats, err := transition(ctx, chatID)
@@ -1545,7 +1545,7 @@ func (p *Server) PromoteQueued(
 	})
 	p.publishMessage(opts.ChatID, promoted)
 	p.publishStatus(opts.ChatID, updatedChat.Status, updatedChat.WorkerID)
-	p.publishChatPubsubEvent(updatedChat, coderdpubsub.ChatEventKindStatusChange, nil)
+	p.publishChatPubsubEvent(updatedChat, codersdk.ChatWatchEventKindStatusChange, nil)
 	p.signalWake()
 
 	return result, nil
@@ -2092,7 +2092,7 @@ func (p *Server) regenerateChatTitleWithStore(
 		return updatedChat, nil
 	}
 
-	p.publishChatPubsubEvent(updatedChat, coderdpubsub.ChatEventKindTitleChange, nil)
+	p.publishChatPubsubEvent(updatedChat, codersdk.ChatWatchEventKindTitleChange, nil)
 	return updatedChat, nil
 }
 
@@ -2347,7 +2347,7 @@ func (p *Server) setChatWaiting(ctx context.Context, chatID uuid.UUID) (database
 		return database.Chat{}, err
 	}
 	p.publishStatus(chatID, updatedChat.Status, updatedChat.WorkerID)
-	p.publishChatPubsubEvent(updatedChat, coderdpubsub.ChatEventKindStatusChange, nil)
+	p.publishChatPubsubEvent(updatedChat, codersdk.ChatWatchEventKindStatusChange, nil)
 	return updatedChat, nil
 }
 
@@ -3627,7 +3627,7 @@ func (p *Server) publishChatStreamNotify(chatID uuid.UUID, notify coderdpubsub.C
 }
 
 // publishChatPubsubEvents broadcasts a lifecycle event for each affected chat.
-func (p *Server) publishChatPubsubEvents(chats []database.Chat, kind coderdpubsub.ChatEventKind) {
+func (p *Server) publishChatPubsubEvents(chats []database.Chat, kind codersdk.ChatWatchEventKind) {
 	for _, chat := range chats {
 		p.publishChatPubsubEvent(chat, kind, nil)
 	}
@@ -3635,7 +3635,7 @@ func (p *Server) publishChatPubsubEvents(chats []database.Chat, kind coderdpubsu
 
 // publishChatPubsubEvent broadcasts a chat lifecycle event via PostgreSQL
 // pubsub so that all replicas can push updates to watching clients.
-func (p *Server) publishChatPubsubEvent(chat database.Chat, kind coderdpubsub.ChatEventKind, diffStatus *codersdk.ChatDiffStatus) {
+func (p *Server) publishChatPubsubEvent(chat database.Chat, kind codersdk.ChatWatchEventKind, diffStatus *codersdk.ChatDiffStatus) {
 	if p.pubsub == nil {
 		return
 	}
@@ -3647,7 +3647,7 @@ func (p *Server) publishChatPubsubEvent(chat database.Chat, kind coderdpubsub.Ch
 	if diffStatus != nil {
 		sdkChat.DiffStatus = diffStatus
 	}
-	event := coderdpubsub.ChatEvent{
+	event := codersdk.ChatWatchEvent{
 		Kind: kind,
 		Chat: sdkChat,
 	}
@@ -3733,7 +3733,7 @@ func (p *Server) PublishDiffStatusChange(ctx context.Context, chatID uuid.UUID) 
 	}
 
 	sdkStatus := db2sdk.ChatDiffStatus(chatID, &dbStatus)
-	p.publishChatPubsubEvent(chat, coderdpubsub.ChatEventKindDiffStatusChange, &sdkStatus)
+	p.publishChatPubsubEvent(chat, codersdk.ChatWatchEventKindDiffStatusChange, &sdkStatus)
 	return nil
 }
 
@@ -4215,7 +4215,7 @@ func (p *Server) processChat(ctx context.Context, chat database.Chat) {
 		if title, ok := generatedTitle.Load(); ok {
 			updatedChat.Title = title
 		}
-		p.publishChatPubsubEvent(updatedChat, coderdpubsub.ChatEventKindStatusChange, nil)
+		p.publishChatPubsubEvent(updatedChat, codersdk.ChatWatchEventKindStatusChange, nil)
 
 		// When the chat is parked in requires_action,
 		// publish the stream event and global pubsub event

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -3692,8 +3692,8 @@ func (p *Server) publishChatActionRequired(chat database.Chat, pending []chatloo
 	toolCalls := pendingToStreamToolCalls(pending)
 	sdkChat := db2sdk.Chat(chat, nil, nil)
 
-	event := coderdpubsub.ChatEvent{
-		Kind:      coderdpubsub.ChatEventKindActionRequired,
+	event := codersdk.ChatWatchEvent{
+		Kind:      codersdk.ChatWatchEventKindActionRequired,
 		Chat:      sdkChat,
 		ToolCalls: toolCalls,
 	}

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -3659,7 +3659,7 @@ func (p *Server) publishChatPubsubEvent(chat database.Chat, kind codersdk.ChatWa
 		)
 		return
 	}
-	if err := p.pubsub.Publish(coderdpubsub.ChatEventChannel(chat.OwnerID), payload); err != nil {
+	if err := p.pubsub.Publish(coderdpubsub.ChatWatchEventChannel(chat.OwnerID), payload); err != nil {
 		p.logger.Error(context.Background(), "failed to publish chat pubsub event",
 			slog.F("chat_id", chat.ID),
 			slog.F("kind", kind),
@@ -3705,7 +3705,7 @@ func (p *Server) publishChatActionRequired(chat database.Chat, pending []chatloo
 		)
 		return
 	}
-	if err := p.pubsub.Publish(coderdpubsub.ChatEventChannel(chat.OwnerID), payload); err != nil {
+	if err := p.pubsub.Publish(coderdpubsub.ChatWatchEventChannel(chat.OwnerID), payload); err != nil {
 		p.logger.Error(context.Background(), "failed to publish chat action_required pubsub event",
 			slog.F("chat_id", chat.ID),
 			slog.Error(err),

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -71,14 +71,14 @@ func TestRegenerateChatTitle_PersistsAndBroadcasts(t *testing.T) {
 	updatedChat.Title = wantTitle
 
 	messageEvents := make(chan struct {
-		payload coderdpubsub.ChatEvent
+		payload codersdk.ChatWatchEvent
 		err     error
 	}, 1)
 	cancelSub, err := pubsub.SubscribeWithErr(
 		coderdpubsub.ChatEventChannel(ownerID),
-		coderdpubsub.HandleChatEvent(func(_ context.Context, payload coderdpubsub.ChatEvent, err error) {
+		coderdpubsub.HandleChatEvent(func(_ context.Context, payload codersdk.ChatWatchEvent, err error) {
 			messageEvents <- struct {
-				payload coderdpubsub.ChatEvent
+				payload codersdk.ChatWatchEvent
 				err     error
 			}{payload: payload, err: err}
 		}),
@@ -184,7 +184,7 @@ func TestRegenerateChatTitle_PersistsAndBroadcasts(t *testing.T) {
 	select {
 	case event := <-messageEvents:
 		require.NoError(t, event.err)
-		require.Equal(t, coderdpubsub.ChatEventKindTitleChange, event.payload.Kind)
+		require.Equal(t, codersdk.ChatWatchEventKindTitleChange, event.payload.Kind)
 		require.Equal(t, chatID, event.payload.Chat.ID)
 		require.Equal(t, wantTitle, event.payload.Chat.Title)
 	case <-time.After(time.Second):
@@ -234,14 +234,14 @@ func TestRegenerateChatTitle_PersistsAndBroadcasts_IdleChatReleasesManualLock(t 
 	unlockedChat.StartedAt = sql.NullTime{}
 
 	messageEvents := make(chan struct {
-		payload coderdpubsub.ChatEvent
+		payload codersdk.ChatWatchEvent
 		err     error
 	}, 1)
 	cancelSub, err := pubsub.SubscribeWithErr(
 		coderdpubsub.ChatEventChannel(ownerID),
-		coderdpubsub.HandleChatEvent(func(_ context.Context, payload coderdpubsub.ChatEvent, err error) {
+		coderdpubsub.HandleChatEvent(func(_ context.Context, payload codersdk.ChatWatchEvent, err error) {
 			messageEvents <- struct {
-				payload coderdpubsub.ChatEvent
+				payload codersdk.ChatWatchEvent
 				err     error
 			}{payload: payload, err: err}
 		}),
@@ -373,7 +373,7 @@ func TestRegenerateChatTitle_PersistsAndBroadcasts_IdleChatReleasesManualLock(t 
 	select {
 	case event := <-messageEvents:
 		require.NoError(t, event.err)
-		require.Equal(t, coderdpubsub.ChatEventKindTitleChange, event.payload.Kind)
+		require.Equal(t, codersdk.ChatWatchEventKindTitleChange, event.payload.Kind)
 		require.Equal(t, chatID, event.payload.Chat.ID)
 		require.Equal(t, wantTitle, event.payload.Chat.Title)
 	case <-time.After(time.Second):

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -75,8 +75,8 @@ func TestRegenerateChatTitle_PersistsAndBroadcasts(t *testing.T) {
 		err     error
 	}, 1)
 	cancelSub, err := pubsub.SubscribeWithErr(
-		coderdpubsub.ChatEventChannel(ownerID),
-		coderdpubsub.HandleChatEvent(func(_ context.Context, payload codersdk.ChatWatchEvent, err error) {
+		coderdpubsub.ChatWatchEventChannel(ownerID),
+		coderdpubsub.HandleChatWatchEvent(func(_ context.Context, payload codersdk.ChatWatchEvent, err error) {
 			messageEvents <- struct {
 				payload codersdk.ChatWatchEvent
 				err     error
@@ -238,8 +238,8 @@ func TestRegenerateChatTitle_PersistsAndBroadcasts_IdleChatReleasesManualLock(t 
 		err     error
 	}, 1)
 	cancelSub, err := pubsub.SubscribeWithErr(
-		coderdpubsub.ChatEventChannel(ownerID),
-		coderdpubsub.HandleChatEvent(func(_ context.Context, payload codersdk.ChatWatchEvent, err error) {
+		coderdpubsub.ChatWatchEventChannel(ownerID),
+		coderdpubsub.HandleChatWatchEvent(func(_ context.Context, payload codersdk.ChatWatchEvent, err error) {
 			messageEvents <- struct {
 				payload codersdk.ChatWatchEvent
 				err     error

--- a/coderd/x/chatd/quickgen.go
+++ b/coderd/x/chatd/quickgen.go
@@ -21,7 +21,6 @@ import (
 
 	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/coderd/database"
-	coderdpubsub "github.com/coder/coder/v2/coderd/pubsub"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatprompt"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatprovider"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatretry"
@@ -160,7 +159,7 @@ func (p *Server) maybeGenerateChatTitle(
 		}
 		chat.Title = title
 		generatedTitle.Store(title)
-		p.publishChatPubsubEvent(chat, coderdpubsub.ChatEventKindTitleChange, nil)
+		p.publishChatPubsubEvent(chat, codersdk.ChatWatchEventKindTitleChange, nil)
 		return
 	}
 

--- a/coderd/x/chatd/subagent.go
+++ b/coderd/x/chatd/subagent.go
@@ -574,7 +574,7 @@ func (p *Server) createChildSubagentChatWithOptions(
 		return database.Chat{}, xerrors.Errorf("create child chat: %w", txErr)
 	}
 
-	p.publishChatPubsubEvent(child, coderdpubsub.ChatEventKindCreated, nil)
+	p.publishChatPubsubEvent(child, codersdk.ChatWatchEventKindCreated, nil)
 	p.signalWake()
 	return child, nil
 }

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -1130,11 +1130,6 @@ type ChatStreamEvent struct {
 	ActionRequired *ChatStreamActionRequired `json:"action_required,omitempty"`
 }
 
-type chatStreamEnvelope struct {
-	Type ServerSentEventType `json:"type"`
-	Data json.RawMessage     `json:"data,omitempty"`
-}
-
 // ChatCostSummaryOptions are optional query parameters for GetChatCostSummary.
 type ChatCostSummaryOptions struct {
 	StartDate time.Time
@@ -1987,8 +1982,8 @@ func (c *ExperimentalClient) StreamChat(ctx context.Context, chatID uuid.UUID, o
 		}()
 
 		for {
-			var envelope chatStreamEnvelope
-			if err := wsjson.Read(streamCtx, conn, &envelope); err != nil {
+			var batch []ChatStreamEvent
+			if err := wsjson.Read(streamCtx, conn, &batch); err != nil {
 				if streamCtx.Err() != nil {
 					return
 				}
@@ -2005,61 +2000,10 @@ func (c *ExperimentalClient) StreamChat(ctx context.Context, chatID uuid.UUID, o
 				return
 			}
 
-			switch envelope.Type {
-			case ServerSentEventTypePing:
-				continue
-			case ServerSentEventTypeData:
-				var batch []ChatStreamEvent
-				decodeErr := json.Unmarshal(envelope.Data, &batch)
-				if decodeErr == nil {
-					for _, streamedEvent := range batch {
-						if !send(streamedEvent) {
-							return
-						}
-					}
-					continue
-				}
-
-				{
-					_ = send(ChatStreamEvent{
-						Type: ChatStreamEventTypeError,
-						Error: &ChatStreamError{
-							Message: fmt.Sprintf(
-								"decode chat stream event batch: %v",
-								decodeErr,
-							),
-						},
-					})
+			for _, event := range batch {
+				if !send(event) {
 					return
 				}
-			case ServerSentEventTypeError:
-				message := "chat stream returned an error"
-				if len(envelope.Data) > 0 {
-					var response Response
-					if err := json.Unmarshal(envelope.Data, &response); err == nil {
-						message = formatChatStreamResponseError(response)
-					} else {
-						trimmed := strings.TrimSpace(string(envelope.Data))
-						if trimmed != "" {
-							message = trimmed
-						}
-					}
-				}
-				_ = send(ChatStreamEvent{
-					Type: ChatStreamEventTypeError,
-					Error: &ChatStreamError{
-						Message: message,
-					},
-				})
-				return
-			default:
-				_ = send(ChatStreamEvent{
-					Type: ChatStreamEventTypeError,
-					Error: &ChatStreamError{
-						Message: fmt.Sprintf("unknown chat stream event type %q", envelope.Type),
-					},
-				})
-				return
 			}
 		}
 	}()
@@ -2098,8 +2042,8 @@ func (c *ExperimentalClient) WatchChats(ctx context.Context) (<-chan ChatWatchEv
 		}()
 
 		for {
-			var envelope chatStreamEnvelope
-			if err := wsjson.Read(streamCtx, conn, &envelope); err != nil {
+			var event ChatWatchEvent
+			if err := wsjson.Read(streamCtx, conn, &event); err != nil {
 				if streamCtx.Err() != nil {
 					return
 				}
@@ -2110,23 +2054,10 @@ func (c *ExperimentalClient) WatchChats(ctx context.Context) (<-chan ChatWatchEv
 				return
 			}
 
-			switch envelope.Type {
-			case ServerSentEventTypePing:
-				continue
-			case ServerSentEventTypeData:
-				var event ChatWatchEvent
-				if err := json.Unmarshal(envelope.Data, &event); err != nil {
-					return
-				}
-				select {
-				case <-streamCtx.Done():
-					return
-				case events <- event:
-				}
-			case ServerSentEventTypeError:
+			select {
+			case <-streamCtx.Done():
 				return
-			default:
-				return
+			case events <- event:
 			}
 		}
 	}()
@@ -2478,21 +2409,6 @@ func (c *ExperimentalClient) GetChatsByWorkspace(ctx context.Context, workspaceI
 	return result, json.NewDecoder(res.Body).Decode(&result)
 }
 
-func formatChatStreamResponseError(response Response) string {
-	message := strings.TrimSpace(response.Message)
-	detail := strings.TrimSpace(response.Detail)
-	switch {
-	case message == "" && detail == "":
-		return "chat stream returned an error"
-	case message == "":
-		return detail
-	case detail == "":
-		return message
-	default:
-		return fmt.Sprintf("%s: %s", message, detail)
-	}
-}
-
 // PRInsightsResponse is the response from the PR insights endpoint.
 type PRInsightsResponse struct {
 	Summary    PRInsightsSummary           `json:"summary"`
@@ -2563,21 +2479,4 @@ type PRInsightsPullRequest struct {
 	ModelDisplayName string    `json:"model_display_name"`
 	CostMicros       int64     `json:"cost_micros"`
 	CreatedAt        time.Time `json:"created_at" format:"date-time"`
-}
-
-// ChatWatchEventKind classifies the type of chat watch event.
-type ChatWatchEventKind string
-
-const (
-	ChatWatchEventKindStatusChange     ChatWatchEventKind = "status_change"
-	ChatWatchEventKindTitleChange      ChatWatchEventKind = "title_change"
-	ChatWatchEventKindCreated          ChatWatchEventKind = "created"
-	ChatWatchEventKindDeleted          ChatWatchEventKind = "deleted"
-	ChatWatchEventKindDiffStatusChange ChatWatchEventKind = "diff_status_change"
-)
-
-// ChatWatchEvent is a real-time notification about a chat changing.
-type ChatWatchEvent struct {
-	Kind ChatWatchEventKind `json:"kind"`
-	Chat Chat               `json:"chat"`
 }

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -2564,3 +2564,20 @@ type PRInsightsPullRequest struct {
 	CostMicros       int64     `json:"cost_micros"`
 	CreatedAt        time.Time `json:"created_at" format:"date-time"`
 }
+
+// ChatWatchEventKind classifies the type of chat watch event.
+type ChatWatchEventKind string
+
+const (
+	ChatWatchEventKindStatusChange     ChatWatchEventKind = "status_change"
+	ChatWatchEventKindTitleChange      ChatWatchEventKind = "title_change"
+	ChatWatchEventKindCreated          ChatWatchEventKind = "created"
+	ChatWatchEventKindDeleted          ChatWatchEventKind = "deleted"
+	ChatWatchEventKindDiffStatusChange ChatWatchEventKind = "diff_status_change"
+)
+
+// ChatWatchEvent is a real-time notification about a chat changing.
+type ChatWatchEvent struct {
+	Kind ChatWatchEventKind `json:"kind"`
+	Chat Chat               `json:"chat"`
+}

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -145,7 +145,7 @@ export const watchWorkspace = (
 export const watchChat = (
 	chatId: string,
 	afterMessageId?: number,
-): OneWayWebSocketApi<TypesGen.ServerSentEvent> => {
+): OneWayWebSocketApi<TypesGen.ChatStreamEvent[]> => {
 	const params = new URLSearchParams();
 	if (afterMessageId !== undefined && afterMessageId > 0) {
 		params.set("after_id", afterMessageId.toString());
@@ -161,7 +161,7 @@ export const watchChat = (
 	});
 };
 
-export const watchChats = (): OneWayWebSocket<TypesGen.ServerSentEvent> => {
+export const watchChats = (): OneWayWebSocket<TypesGen.ChatWatchEvent> => {
 	const searchParams: Record<string, string> = {};
 	const token = API.getSessionToken();
 	if (token) {

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1904,14 +1904,6 @@ export interface ChatReasoningPart {
 }
 
 // From codersdk/chats.go
-/**
- * ChatRetentionDaysResponse contains the current chat retention setting.
- */
-export interface ChatRetentionDaysResponse {
-	readonly retention_days: number;
-}
-
-// From codersdk/chats.go
 export interface ChatSkillPart {
 	readonly type: "skill";
 	/**
@@ -1940,7 +1932,6 @@ export type ChatStatus =
 	| "error"
 	| "paused"
 	| "pending"
-	| "requires_action"
 	| "running"
 	| "waiting";
 
@@ -1949,18 +1940,9 @@ export const ChatStatuses: ChatStatus[] = [
 	"error",
 	"paused",
 	"pending",
-	"requires_action",
 	"running",
 	"waiting",
 ];
-
-// From codersdk/chats.go
-/**
- * ChatStreamActionRequired is the payload of an action_required stream event.
- */
-export interface ChatStreamActionRequired {
-	readonly tool_calls: readonly ChatStreamToolCall[];
-}
 
 // From codersdk/chats.go
 /**
@@ -2002,12 +1984,10 @@ export interface ChatStreamEvent {
 	readonly error?: ChatStreamError;
 	readonly retry?: ChatStreamRetry;
 	readonly queued_messages?: readonly ChatQueuedMessage[];
-	readonly action_required?: ChatStreamActionRequired;
 }
 
 // From codersdk/chats.go
 export type ChatStreamEventType =
-	| "action_required"
 	| "error"
 	| "message"
 	| "message_part"
@@ -2016,7 +1996,6 @@ export type ChatStreamEventType =
 	| "status";
 
 export const ChatStreamEventTypes: ChatStreamEventType[] = [
-	"action_required",
 	"error",
 	"message",
 	"message_part",
@@ -2080,17 +2059,6 @@ export interface ChatStreamStatus {
 
 // From codersdk/chats.go
 /**
- * ChatStreamToolCall describes a pending dynamic tool call that the client
- * must execute.
- */
-export interface ChatStreamToolCall {
-	readonly tool_call_id: string;
-	readonly tool_name: string;
-	readonly args: string;
-}
-
-// From codersdk/chats.go
-/**
  * ChatSystemPromptResponse is the response body for the chat system prompt
  * configuration endpoint.
  */
@@ -2129,12 +2097,6 @@ export interface ChatToolCallPart {
 	 * the provider (e.g. Anthropic computer use).
 	 */
 	readonly provider_executed?: boolean;
-	/**
-	 * CreatedAt records when this part was produced. Present on
-	 * tool-call and tool-result parts so the frontend can compute
-	 * tool execution duration.
-	 */
-	readonly created_at?: string;
 }
 
 // From codersdk/chats.go
@@ -2151,12 +2113,6 @@ export interface ChatToolResultPart {
 	 * the provider (e.g. Anthropic computer use).
 	 */
 	readonly provider_executed?: boolean;
-	/**
-	 * CreatedAt records when this part was produced. Present on
-	 * tool-call and tool-result parts so the frontend can compute
-	 * tool execution duration.
-	 */
-	readonly created_at?: string;
 }
 
 // From codersdk/chats.go
@@ -2255,21 +2211,15 @@ export interface ChatUsageLimitStatus {
 
 // From codersdk/chats.go
 /**
- * ChatWatchEvent represents an event from the global chat watch stream.
- * It delivers lifecycle events (created, status change, title change)
- * for all of the authenticated user's chats. When Kind is
- * ActionRequired, ToolCalls contains the pending dynamic tool
- * invocations the client must execute and submit back.
+ * ChatWatchEvent is a real-time notification about a chat changing.
  */
 export interface ChatWatchEvent {
 	readonly kind: ChatWatchEventKind;
 	readonly chat: Chat;
-	readonly tool_calls?: readonly ChatStreamToolCall[];
 }
 
 // From codersdk/chats.go
 export type ChatWatchEventKind =
-	| "action_required"
 	| "created"
 	| "deleted"
 	| "diff_status_change"
@@ -2277,7 +2227,6 @@ export type ChatWatchEventKind =
 	| "title_change";
 
 export const ChatWatchEventKinds: ChatWatchEventKind[] = [
-	"action_required",
 	"created",
 	"deleted",
 	"diff_status_change",
@@ -2492,12 +2441,6 @@ export interface CreateChatRequest {
 	readonly model_config_id?: string;
 	readonly mcp_server_ids?: readonly string[];
 	readonly labels?: Record<string, string>;
-	/**
-	 * UnsafeDynamicTools declares client-executed tools that the
-	 * LLM can invoke. This API is highly experimental and highly
-	 * subject to change.
-	 */
-	readonly unsafe_dynamic_tools?: readonly DynamicTool[];
 }
 
 // From codersdk/users.go
@@ -2809,20 +2752,6 @@ export interface CreateUserRequestWithOrgs {
 	 * Service accounts are admin-managed accounts that cannot login.
 	 */
 	readonly service_account?: boolean;
-}
-
-// From codersdk/usersecrets.go
-/**
- * CreateUserSecretRequest is the payload for creating a new user
- * secret. Name and Value are required. All other fields are optional
- * and default to empty string.
- */
-export interface CreateUserSecretRequest {
-	readonly name: string;
-	readonly value: string;
-	readonly description?: string;
-	readonly env_name?: string;
-	readonly file_path?: string;
 }
 
 // From codersdk/workspaces.go
@@ -3310,47 +3239,6 @@ export interface DynamicParametersResponse {
 	readonly id: number;
 	readonly diagnostics: readonly FriendlyDiagnostic[];
 	readonly parameters: readonly PreviewParameter[];
-}
-
-// From codersdk/chats.go
-/**
- * DynamicTool describes a client-declared tool definition. On the
- * client side, the Handler callback executes the tool when the LLM
- * invokes it. On the server side, only Name, Description, and
- * InputSchema are used (Handler is not serialized).
- */
-export interface DynamicTool {
-	readonly name: string;
-	readonly description?: string;
-	/**
-	 * InputSchema's JSON key "input_schema" uses snake_case for
-	 * SDK consistency, deviating from the camelCase "inputSchema"
-	 * convention used by MCP.
-	 */
-	readonly input_schema: Record<string, string>;
-}
-
-// From codersdk/chats.go
-/**
- * DynamicToolCall represents a pending tool invocation from the
- * chat stream that the client must execute and submit back.
- */
-export interface DynamicToolCall {
-	readonly tool_call_id: string;
-	readonly tool_name: string;
-	readonly args: string;
-}
-
-// From codersdk/chats.go
-/**
- * DynamicToolResponse holds the output of a dynamic tool
- * execution. IsError indicates a tool-level error the LLM
- * should see, as opposed to an infrastructure failure
- * (returned as the error return value).
- */
-export interface DynamicToolResponse {
-	readonly content: string;
-	readonly is_error: boolean;
 }
 
 // From codersdk/chats.go
@@ -6561,14 +6449,6 @@ export interface StreamChatOptions {
 export const SubdomainAppSessionTokenCookie =
 	"coder_subdomain_app_session_token";
 
-// From codersdk/chats.go
-/**
- * SubmitToolResultsRequest is the body for POST /chats/{id}/tool-results.
- */
-export interface SubmitToolResultsRequest {
-	readonly results: readonly ToolResult[];
-}
-
 // From codersdk/deployment.go
 export interface SupportConfig {
 	readonly links: SerpentStruct<LinkConfig[]>;
@@ -7317,16 +7197,6 @@ export interface TokensFilter {
 	readonly include_expired: boolean;
 }
 
-// From codersdk/chats.go
-/**
- * ToolResult is the client's response to a dynamic tool call.
- */
-export interface ToolResult {
-	readonly tool_call_id: string;
-	readonly output: Record<string, string>;
-	readonly is_error: boolean;
-}
-
 // From codersdk/deployment.go
 export interface TraceConfig {
 	readonly enable: boolean;
@@ -7414,15 +7284,6 @@ export interface UpdateChatRequest {
 	 */
 	readonly pin_order?: number;
 	readonly labels?: Record<string, string>;
-}
-
-// From codersdk/chats.go
-/**
- * UpdateChatRetentionDaysRequest is a request to update the chat
- * retention period.
- */
-export interface UpdateChatRetentionDaysRequest {
-	readonly retention_days: number;
 }
 
 // From codersdk/chats.go
@@ -7698,20 +7559,6 @@ export interface UpdateUserQuietHoursScheduleRequest {
 	 * schedule.
 	 */
 	readonly schedule: string;
-}
-
-// From codersdk/usersecrets.go
-/**
- * UpdateUserSecretRequest is the payload for partially updating a
- * user secret. At least one field must be non-nil. Pointer fields
- * distinguish "not sent" (nil) from "set to empty string" (pointer
- * to empty string).
- */
-export interface UpdateUserSecretRequest {
-	readonly value?: string;
-	readonly description?: string;
-	readonly env_name?: string;
-	readonly file_path?: string;
 }
 
 // From codersdk/workspaces.go
@@ -8064,35 +7911,6 @@ export interface UserQuietHoursScheduleResponse {
 export interface UserRoles {
 	readonly roles: readonly string[];
 	readonly organization_roles: Record<string, string[]>;
-}
-
-// From codersdk/usersecrets.go
-/**
- * UserSecret represents a user secret's metadata. The secret value
- * is never included in API responses.
- */
-export interface UserSecret {
-	readonly id: string;
-	readonly name: string;
-	readonly description: string;
-	readonly env_name: string;
-	readonly file_path: string;
-	readonly created_at: string;
-	readonly updated_at: string;
-}
-
-// From codersdk/usersecretvalidation.go
-/**
- * UserSecretEnvValidationOptions controls deployment-aware behavior
- * in environment variable name validation.
- */
-export interface UserSecretEnvValidationOptions {
-	/**
-	 * AIGatewayEnabled indicates that the deployment has AI Gateway
-	 * configured. When true, AI Gateway environment variables
-	 * (OPENAI_API_KEY, etc.) are reserved to prevent conflicts.
-	 */
-	readonly AIGatewayEnabled: boolean;
 }
 
 // From codersdk/users.go

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1904,6 +1904,14 @@ export interface ChatReasoningPart {
 }
 
 // From codersdk/chats.go
+/**
+ * ChatRetentionDaysResponse contains the current chat retention setting.
+ */
+export interface ChatRetentionDaysResponse {
+	readonly retention_days: number;
+}
+
+// From codersdk/chats.go
 export interface ChatSkillPart {
 	readonly type: "skill";
 	/**
@@ -1932,6 +1940,7 @@ export type ChatStatus =
 	| "error"
 	| "paused"
 	| "pending"
+	| "requires_action"
 	| "running"
 	| "waiting";
 
@@ -1940,9 +1949,18 @@ export const ChatStatuses: ChatStatus[] = [
 	"error",
 	"paused",
 	"pending",
+	"requires_action",
 	"running",
 	"waiting",
 ];
+
+// From codersdk/chats.go
+/**
+ * ChatStreamActionRequired is the payload of an action_required stream event.
+ */
+export interface ChatStreamActionRequired {
+	readonly tool_calls: readonly ChatStreamToolCall[];
+}
 
 // From codersdk/chats.go
 /**
@@ -1984,10 +2002,12 @@ export interface ChatStreamEvent {
 	readonly error?: ChatStreamError;
 	readonly retry?: ChatStreamRetry;
 	readonly queued_messages?: readonly ChatQueuedMessage[];
+	readonly action_required?: ChatStreamActionRequired;
 }
 
 // From codersdk/chats.go
 export type ChatStreamEventType =
+	| "action_required"
 	| "error"
 	| "message"
 	| "message_part"
@@ -1996,6 +2016,7 @@ export type ChatStreamEventType =
 	| "status";
 
 export const ChatStreamEventTypes: ChatStreamEventType[] = [
+	"action_required",
 	"error",
 	"message",
 	"message_part",
@@ -2059,6 +2080,17 @@ export interface ChatStreamStatus {
 
 // From codersdk/chats.go
 /**
+ * ChatStreamToolCall describes a pending dynamic tool call that the client
+ * must execute.
+ */
+export interface ChatStreamToolCall {
+	readonly tool_call_id: string;
+	readonly tool_name: string;
+	readonly args: string;
+}
+
+// From codersdk/chats.go
+/**
  * ChatSystemPromptResponse is the response body for the chat system prompt
  * configuration endpoint.
  */
@@ -2097,6 +2129,12 @@ export interface ChatToolCallPart {
 	 * the provider (e.g. Anthropic computer use).
 	 */
 	readonly provider_executed?: boolean;
+	/**
+	 * CreatedAt records when this part was produced. Present on
+	 * tool-call and tool-result parts so the frontend can compute
+	 * tool execution duration.
+	 */
+	readonly created_at?: string;
 }
 
 // From codersdk/chats.go
@@ -2113,6 +2151,12 @@ export interface ChatToolResultPart {
 	 * the provider (e.g. Anthropic computer use).
 	 */
 	readonly provider_executed?: boolean;
+	/**
+	 * CreatedAt records when this part was produced. Present on
+	 * tool-call and tool-result parts so the frontend can compute
+	 * tool execution duration.
+	 */
+	readonly created_at?: string;
 }
 
 // From codersdk/chats.go
@@ -2211,15 +2255,21 @@ export interface ChatUsageLimitStatus {
 
 // From codersdk/chats.go
 /**
- * ChatWatchEvent is a real-time notification about a chat changing.
+ * ChatWatchEvent represents an event from the global chat watch stream.
+ * It delivers lifecycle events (created, status change, title change)
+ * for all of the authenticated user's chats. When Kind is
+ * ActionRequired, ToolCalls contains the pending dynamic tool
+ * invocations the client must execute and submit back.
  */
 export interface ChatWatchEvent {
 	readonly kind: ChatWatchEventKind;
 	readonly chat: Chat;
+	readonly tool_calls?: readonly ChatStreamToolCall[];
 }
 
 // From codersdk/chats.go
 export type ChatWatchEventKind =
+	| "action_required"
 	| "created"
 	| "deleted"
 	| "diff_status_change"
@@ -2227,6 +2277,7 @@ export type ChatWatchEventKind =
 	| "title_change";
 
 export const ChatWatchEventKinds: ChatWatchEventKind[] = [
+	"action_required",
 	"created",
 	"deleted",
 	"diff_status_change",
@@ -2441,6 +2492,12 @@ export interface CreateChatRequest {
 	readonly model_config_id?: string;
 	readonly mcp_server_ids?: readonly string[];
 	readonly labels?: Record<string, string>;
+	/**
+	 * UnsafeDynamicTools declares client-executed tools that the
+	 * LLM can invoke. This API is highly experimental and highly
+	 * subject to change.
+	 */
+	readonly unsafe_dynamic_tools?: readonly DynamicTool[];
 }
 
 // From codersdk/users.go
@@ -2752,6 +2809,20 @@ export interface CreateUserRequestWithOrgs {
 	 * Service accounts are admin-managed accounts that cannot login.
 	 */
 	readonly service_account?: boolean;
+}
+
+// From codersdk/usersecrets.go
+/**
+ * CreateUserSecretRequest is the payload for creating a new user
+ * secret. Name and Value are required. All other fields are optional
+ * and default to empty string.
+ */
+export interface CreateUserSecretRequest {
+	readonly name: string;
+	readonly value: string;
+	readonly description?: string;
+	readonly env_name?: string;
+	readonly file_path?: string;
 }
 
 // From codersdk/workspaces.go
@@ -3239,6 +3310,47 @@ export interface DynamicParametersResponse {
 	readonly id: number;
 	readonly diagnostics: readonly FriendlyDiagnostic[];
 	readonly parameters: readonly PreviewParameter[];
+}
+
+// From codersdk/chats.go
+/**
+ * DynamicTool describes a client-declared tool definition. On the
+ * client side, the Handler callback executes the tool when the LLM
+ * invokes it. On the server side, only Name, Description, and
+ * InputSchema are used (Handler is not serialized).
+ */
+export interface DynamicTool {
+	readonly name: string;
+	readonly description?: string;
+	/**
+	 * InputSchema's JSON key "input_schema" uses snake_case for
+	 * SDK consistency, deviating from the camelCase "inputSchema"
+	 * convention used by MCP.
+	 */
+	readonly input_schema: Record<string, string>;
+}
+
+// From codersdk/chats.go
+/**
+ * DynamicToolCall represents a pending tool invocation from the
+ * chat stream that the client must execute and submit back.
+ */
+export interface DynamicToolCall {
+	readonly tool_call_id: string;
+	readonly tool_name: string;
+	readonly args: string;
+}
+
+// From codersdk/chats.go
+/**
+ * DynamicToolResponse holds the output of a dynamic tool
+ * execution. IsError indicates a tool-level error the LLM
+ * should see, as opposed to an infrastructure failure
+ * (returned as the error return value).
+ */
+export interface DynamicToolResponse {
+	readonly content: string;
+	readonly is_error: boolean;
 }
 
 // From codersdk/chats.go
@@ -6449,6 +6561,14 @@ export interface StreamChatOptions {
 export const SubdomainAppSessionTokenCookie =
 	"coder_subdomain_app_session_token";
 
+// From codersdk/chats.go
+/**
+ * SubmitToolResultsRequest is the body for POST /chats/{id}/tool-results.
+ */
+export interface SubmitToolResultsRequest {
+	readonly results: readonly ToolResult[];
+}
+
 // From codersdk/deployment.go
 export interface SupportConfig {
 	readonly links: SerpentStruct<LinkConfig[]>;
@@ -7197,6 +7317,16 @@ export interface TokensFilter {
 	readonly include_expired: boolean;
 }
 
+// From codersdk/chats.go
+/**
+ * ToolResult is the client's response to a dynamic tool call.
+ */
+export interface ToolResult {
+	readonly tool_call_id: string;
+	readonly output: Record<string, string>;
+	readonly is_error: boolean;
+}
+
 // From codersdk/deployment.go
 export interface TraceConfig {
 	readonly enable: boolean;
@@ -7284,6 +7414,15 @@ export interface UpdateChatRequest {
 	 */
 	readonly pin_order?: number;
 	readonly labels?: Record<string, string>;
+}
+
+// From codersdk/chats.go
+/**
+ * UpdateChatRetentionDaysRequest is a request to update the chat
+ * retention period.
+ */
+export interface UpdateChatRetentionDaysRequest {
+	readonly retention_days: number;
 }
 
 // From codersdk/chats.go
@@ -7559,6 +7698,20 @@ export interface UpdateUserQuietHoursScheduleRequest {
 	 * schedule.
 	 */
 	readonly schedule: string;
+}
+
+// From codersdk/usersecrets.go
+/**
+ * UpdateUserSecretRequest is the payload for partially updating a
+ * user secret. At least one field must be non-nil. Pointer fields
+ * distinguish "not sent" (nil) from "set to empty string" (pointer
+ * to empty string).
+ */
+export interface UpdateUserSecretRequest {
+	readonly value?: string;
+	readonly description?: string;
+	readonly env_name?: string;
+	readonly file_path?: string;
 }
 
 // From codersdk/workspaces.go
@@ -7911,6 +8064,35 @@ export interface UserQuietHoursScheduleResponse {
 export interface UserRoles {
 	readonly roles: readonly string[];
 	readonly organization_roles: Record<string, string[]>;
+}
+
+// From codersdk/usersecrets.go
+/**
+ * UserSecret represents a user secret's metadata. The secret value
+ * is never included in API responses.
+ */
+export interface UserSecret {
+	readonly id: string;
+	readonly name: string;
+	readonly description: string;
+	readonly env_name: string;
+	readonly file_path: string;
+	readonly created_at: string;
+	readonly updated_at: string;
+}
+
+// From codersdk/usersecretvalidation.go
+/**
+ * UserSecretEnvValidationOptions controls deployment-aware behavior
+ * in environment variable name validation.
+ */
+export interface UserSecretEnvValidationOptions {
+	/**
+	 * AIGatewayEnabled indicates that the deployment has AI Gateway
+	 * configured. When true, AI Gateway environment variables
+	 * (OPENAI_API_KEY, etc.) are reserved to prevent conflicts.
+	 */
+	readonly AIGatewayEnabled: boolean;
 }
 
 // From codersdk/users.go

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -851,6 +851,7 @@ export const StreamedSubagentTitle: Story = {
 					data: JSON.stringify([
 						{
 							type: "message_part",
+							chat_id: CHAT_ID,
 							message_part: {
 								part: {
 									type: "tool-call",
@@ -860,7 +861,7 @@ export const StreamedSubagentTitle: Story = {
 								},
 							},
 						},
-					]),
+					] satisfies TypesGen.ChatStreamEvent[]),
 				},
 			],
 		},
@@ -1147,6 +1148,7 @@ export const StreamedReasoning: Story = {
 					data: JSON.stringify([
 						{
 							type: "message_part",
+							chat_id: CHAT_ID,
 							message_part: {
 								part: {
 									type: "reasoning",
@@ -1154,7 +1156,7 @@ export const StreamedReasoning: Story = {
 								},
 							},
 						},
-					]),
+					] satisfies TypesGen.ChatStreamEvent[]),
 				},
 			],
 		},
@@ -1239,7 +1241,7 @@ export const WithWaitAgentComputerUseVNC: Story = {
 								},
 							},
 						},
-					]),
+					] satisfies TypesGen.ChatStreamEvent[]),
 				},
 			],
 		},

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -198,14 +198,6 @@ const buildQueries = (
 	];
 };
 
-/**
- * Wrap a chat stream event payload in the JSON string format that
- * OneWayWebSocket expects when receiving a WebSocket message event.
- * The result is a `ServerSentEvent` of type `"data"` serialised to JSON.
- */
-const wrapSSE = (payload: unknown): string =>
-	JSON.stringify({ type: "data", data: payload });
-
 // ---------------------------------------------------------------------------
 // Meta
 // ---------------------------------------------------------------------------
@@ -856,17 +848,19 @@ export const StreamedSubagentTitle: Story = {
 			"/chats/": [
 				{
 					event: "message",
-					data: wrapSSE({
-						type: "message_part",
-						message_part: {
-							part: {
-								type: "tool-call",
-								tool_call_id: "tool-subagent-stream-1",
-								tool_name: "spawn_agent",
-								args_delta: '{"title":"Streamed Child"',
+					data: JSON.stringify([
+						{
+							type: "message_part",
+							message_part: {
+								part: {
+									type: "tool-call",
+									tool_call_id: "tool-subagent-stream-1",
+									tool_name: "spawn_agent",
+									args_delta: '{"title":"Streamed Child"',
+								},
 							},
 						},
-					}),
+					]),
 				},
 			],
 		},
@@ -1150,15 +1144,17 @@ export const StreamedReasoning: Story = {
 			"/chats/": [
 				{
 					event: "message",
-					data: wrapSSE({
-						type: "message_part",
-						message_part: {
-							part: {
-								type: "reasoning",
-								text: "Streaming reasoning body",
+					data: JSON.stringify([
+						{
+							type: "message_part",
+							message_part: {
+								part: {
+									type: "reasoning",
+									text: "Streaming reasoning body",
+								},
 							},
 						},
-					}),
+					]),
 				},
 			],
 		},
@@ -1230,18 +1226,20 @@ export const WithWaitAgentComputerUseVNC: Story = {
 			"/chats/": [
 				{
 					event: "message",
-					data: wrapSSE({
-						type: "message_part",
-						chat_id: CHAT_ID,
-						message_part: {
-							part: {
-								type: "tool-call",
-								tool_call_id: "tool-wait-desktop",
-								tool_name: "wait_agent",
-								args_delta: '{"chat_id":"desktop-child-1"}',
+					data: JSON.stringify([
+						{
+							type: "message_part",
+							chat_id: CHAT_ID,
+							message_part: {
+								part: {
+									type: "tool-call",
+									tool_call_id: "tool-wait-desktop",
+									tool_name: "wait_agent",
+									args_delta: '{"chat_id":"desktop-child-1"}',
+								},
 							},
 						},
-					}),
+					]),
 				},
 			],
 		},

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -75,19 +75,6 @@ function diffStatusEqual(
 	);
 }
 
-function isChatListSSEEvent(
-	data: unknown,
-): data is { kind: string; chat: TypesGen.Chat } {
-	if (typeof data !== "object" || data === null) return false;
-	const obj = data as Record<string, unknown>;
-	return (
-		typeof obj.kind === "string" &&
-		typeof obj.chat === "object" &&
-		obj.chat !== null &&
-		"id" in obj.chat
-	);
-}
-
 export type { AgentsOutletContext } from "./AgentsPageView";
 
 const AgentsPage: FC = () => {
@@ -495,14 +482,7 @@ const AgentsPage: FC = () => {
 						console.warn("Failed to parse chat watch event:", event.parseError);
 						return;
 					}
-					const sse = event.parsedMessage;
-					if (sse?.type !== "data" || !sse.data) {
-						return;
-					}
-					if (!isChatListSSEEvent(sse.data)) {
-						return;
-					}
-					const chatEvent = sse.data;
+					const chatEvent = event.parsedMessage;
 					const updatedChat = chatEvent.chat;
 					// Read the previous status from the infinite chat list
 					// cache before we write the update below. The per-chat

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -51,7 +51,6 @@ import {
 	chatDetailErrorsEqual,
 } from "./utils/usageLimitMessage";
 
-// Type guard for SSE events from the chat list watch endpoint.
 // Shallow-compare two ChatDiffStatus objects by their meaningful
 // fields, ignoring refreshed_at/stale_at which change on every poll.
 function diffStatusEqual(

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -67,6 +67,7 @@ type MockSocketHelpers = {
 	emitOpen: () => void;
 	emitData: (event: TypesGen.ChatStreamEvent) => void;
 	emitDataBatch: (events: readonly TypesGen.ChatStreamEvent[]) => void;
+	emitParseError: () => void;
 	emitError: () => void;
 	emitClose: () => void;
 };
@@ -157,6 +158,16 @@ const createMockSocket = (): MockSocket => {
 				sourceEvent: {} as MessageEvent<string>,
 				parseError: undefined,
 				parsedMessage: events as TypesGen.ChatStreamEvent[],
+			};
+			for (const listener of messageListeners) {
+				listener(payload);
+			}
+		},
+		emitParseError: () => {
+			const payload: OneWayMessageEvent<TypesGen.ChatStreamEvent[]> = {
+				sourceEvent: {} as MessageEvent<string>,
+				parseError: new Error("bad json"),
+				parsedMessage: undefined,
 			};
 			for (const listener of messageListeners) {
 				listener(payload);
@@ -4200,6 +4211,212 @@ describe("store/cache desync protection", () => {
 		// and should be removed.
 		await waitFor(() => {
 			expect(result.current.orderedMessageIDs).toEqual([1]);
+		});
+	});
+});
+
+describe("parse errors", () => {
+	it("surfaces parseError as streamError", async () => {
+		immediateAnimationFrame();
+
+		const chatID = "chat-parse-error";
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createTestQueryClient();
+		const wrapper = ({ children }: PropsWithChildren) => (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+		const setChatErrorReason = vi.fn();
+		const clearChatErrorReason = vi.fn();
+
+		const { result } = renderHook(
+			() => {
+				const { store } = useChatStore({
+					chatID,
+					chatMessages: [],
+					chatRecord: makeChat(chatID),
+					chatMessagesData: {
+						messages: [],
+						queued_messages: [],
+						has_more: false,
+					},
+					chatQueuedMessages: [],
+					setChatErrorReason,
+					clearChatErrorReason,
+				});
+				return {
+					streamError: useChatSelector(store, selectStreamError),
+					chatStatus: useChatSelector(store, selectChatStatus),
+				};
+			},
+			{ wrapper },
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, undefined);
+		});
+
+		act(() => {
+			mockSocket.emitParseError();
+		});
+
+		await waitFor(() => {
+			expect(result.current.streamError).toEqual({
+				kind: "generic",
+				message: "Failed to parse chat stream update.",
+			});
+		});
+		expect(result.current.chatStatus).not.toBe("error");
+	});
+
+	it("does not corrupt in-progress stream state", async () => {
+		immediateAnimationFrame();
+
+		const chatID = "chat-parse-no-corrupt";
+		const existingMessage = makeMessage(chatID, 1, "user", "hello");
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createTestQueryClient();
+		const wrapper = ({ children }: PropsWithChildren) => (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+		const setChatErrorReason = vi.fn();
+		const clearChatErrorReason = vi.fn();
+
+		const { result } = renderHook(
+			() => {
+				const { store } = useChatStore({
+					chatID,
+					chatMessages: [existingMessage],
+					chatRecord: makeChat(chatID),
+					chatMessagesData: {
+						messages: [existingMessage],
+						queued_messages: [],
+						has_more: false,
+					},
+					chatQueuedMessages: [],
+					setChatErrorReason,
+					clearChatErrorReason,
+				});
+				return {
+					streamState: useChatSelector(store, selectStreamState),
+					streamError: useChatSelector(store, selectStreamError),
+				};
+			},
+			{ wrapper },
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, 1);
+		});
+
+		// Build up some stream state first.
+		act(() => {
+			mockSocket.emitData({
+				type: "message_part",
+				chat_id: chatID,
+				message_part: {
+					role: "assistant",
+					part: { type: "text", text: "partial response" },
+				},
+			});
+		});
+
+		await waitFor(() => {
+			expect(result.current.streamState?.blocks).toEqual([
+				{ type: "response", text: "partial response" },
+			]);
+		});
+
+		// Now fire a parse error — stream blocks should survive.
+		act(() => {
+			mockSocket.emitParseError();
+		});
+
+		await waitFor(() => {
+			expect(result.current.streamError).toEqual({
+				kind: "generic",
+				message: "Failed to parse chat stream update.",
+			});
+		});
+		expect(result.current.streamState?.blocks).toEqual([
+			{ type: "response", text: "partial response" },
+		]);
+	});
+
+	it("recovers after parse error", async () => {
+		immediateAnimationFrame();
+
+		const chatID = "chat-parse-recover";
+		const existingMessage = makeMessage(chatID, 1, "user", "hello");
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createTestQueryClient();
+		const wrapper = ({ children }: PropsWithChildren) => (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+		const setChatErrorReason = vi.fn();
+		const clearChatErrorReason = vi.fn();
+
+		const { result } = renderHook(
+			() => {
+				const { store } = useChatStore({
+					chatID,
+					chatMessages: [existingMessage],
+					chatRecord: makeChat(chatID),
+					chatMessagesData: {
+						messages: [existingMessage],
+						queued_messages: [],
+						has_more: false,
+					},
+					chatQueuedMessages: [],
+					setChatErrorReason,
+					clearChatErrorReason,
+				});
+				return {
+					streamState: useChatSelector(store, selectStreamState),
+					streamError: useChatSelector(store, selectStreamError),
+				};
+			},
+			{ wrapper },
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, 1);
+		});
+
+		// Trigger a parse error first.
+		act(() => {
+			mockSocket.emitParseError();
+		});
+
+		await waitFor(() => {
+			expect(result.current.streamError).toEqual({
+				kind: "generic",
+				message: "Failed to parse chat stream update.",
+			});
+		});
+
+		// Send a valid message_part after the parse error.
+		act(() => {
+			mockSocket.emitData({
+				type: "message_part",
+				chat_id: chatID,
+				message_part: {
+					role: "assistant",
+					part: { type: "text", text: "recovered" },
+				},
+			});
+		});
+
+		// The stream should process the new part normally.
+		await waitFor(() => {
+			expect(result.current.streamState?.blocks).toEqual([
+				{ type: "response", text: "recovered" },
+			]);
 		});
 	});
 });

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -4330,7 +4330,7 @@ describe("parse errors", () => {
 			]);
 		});
 
-		// Now fire a parse error — stream blocks should survive.
+		// Fire a parse error and verify the existing stream blocks survive.
 		act(() => {
 			mockSocket.emitParseError();
 		});
@@ -4346,7 +4346,7 @@ describe("parse errors", () => {
 		]);
 	});
 
-	it("recovers after parse error", async () => {
+	it("continues processing after parse error", async () => {
 		immediateAnimationFrame();
 
 		const chatID = "chat-parse-recover";
@@ -4417,6 +4417,12 @@ describe("parse errors", () => {
 			expect(result.current.streamState?.blocks).toEqual([
 				{ type: "response", text: "recovered" },
 			]);
+		});
+
+		// streamError is sticky and is not cleared by valid messages.
+		expect(result.current.streamError).toEqual({
+			kind: "generic",
+			message: "Failed to parse chat stream update.",
 		});
 	});
 });

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -55,7 +55,7 @@ vi.mock("#/api/api", () => ({
 }));
 
 type MessageListener = (
-	payload: OneWayMessageEvent<TypesGen.ServerSentEvent>,
+	payload: OneWayMessageEvent<TypesGen.ChatStreamEvent[]>,
 ) => void;
 type ErrorListener = (payload: Event) => void;
 type OpenListener = (payload: Event) => void;
@@ -143,26 +143,20 @@ const createMockSocket = (): MockSocket => {
 		removeEventListener,
 		close: vi.fn(),
 		emitData: (event) => {
-			const payload: OneWayMessageEvent<TypesGen.ServerSentEvent> = {
+			const payload: OneWayMessageEvent<TypesGen.ChatStreamEvent[]> = {
 				sourceEvent: {} as MessageEvent<string>,
 				parseError: undefined,
-				parsedMessage: {
-					type: "data",
-					data: event,
-				},
+				parsedMessage: [event],
 			};
 			for (const listener of messageListeners) {
 				listener(payload);
 			}
 		},
 		emitDataBatch: (events) => {
-			const payload: OneWayMessageEvent<TypesGen.ServerSentEvent> = {
+			const payload: OneWayMessageEvent<TypesGen.ChatStreamEvent[]> = {
 				sourceEvent: {} as MessageEvent<string>,
 				parseError: undefined,
-				parsedMessage: {
-					type: "data",
-					data: events,
-				},
+				parsedMessage: events as TypesGen.ChatStreamEvent[],
 			};
 			for (const listener of messageListeners) {
 				listener(payload);

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -6,7 +6,6 @@ import type * as TypesGen from "#/api/typesGenerated";
 import type { OneWayMessageEvent } from "#/utils/OneWayWebSocket";
 import { createReconnectingWebSocket } from "#/utils/reconnectingWebSocket";
 import type { ChatDetailError } from "../../utils/usageLimitMessage";
-import { asNumber, asString } from "../ChatElements/runtimeTypeUtils";
 import {
 	type ChatStore,
 	type ChatStoreState,
@@ -17,50 +16,24 @@ import {
 } from "./chatStore";
 import type { RetryState } from "./types";
 
-const isChatStreamEvent = (data: unknown): data is TypesGen.ChatStreamEvent =>
-	typeof data === "object" &&
-	data !== null &&
-	"type" in data &&
-	typeof (data as Record<string, unknown>).type === "string";
-
-const isChatStreamEventArray = (
-	data: unknown,
-): data is TypesGen.ChatStreamEvent[] =>
-	Array.isArray(data) && data.every(isChatStreamEvent);
-
-const toChatStreamEvents = (data: unknown): TypesGen.ChatStreamEvent[] => {
-	if (isChatStreamEvent(data)) {
-		return [data];
-	}
-	if (isChatStreamEventArray(data)) {
-		return data;
-	}
-	return [];
-};
-
 const normalizeChatDetailError = (
-	error: TypesGen.ChatStreamError | Record<string, unknown> | undefined,
+	error: TypesGen.ChatStreamError | undefined,
 ): ChatDetailError => ({
-	message: asString(error?.message).trim() || "Chat processing failed.",
-	kind: asString(error?.kind).trim() || "generic",
-	provider: asString(error?.provider).trim() || undefined,
-	retryable:
-		typeof error?.retryable === "boolean" ? error.retryable : undefined,
-	statusCode: asNumber(error?.status_code),
+	message: error?.message.trim() || "Chat processing failed.",
+	kind: error?.kind?.trim() || "generic",
+	provider: error?.provider?.trim() || undefined,
+	retryable: error?.retryable,
+	statusCode: error?.status_code,
 });
 
-const normalizeRetryState = (retry: TypesGen.ChatStreamRetry): RetryState => {
-	const delayMs = asNumber(retry.delay_ms);
-	const retryingAt = asString(retry.retrying_at).trim() || undefined;
-	return {
-		attempt: Math.max(1, asNumber(retry.attempt) ?? 1),
-		error: asString(retry.error).trim() || "Retrying request shortly.",
-		kind: asString(retry.kind).trim() || "generic",
-		provider: asString(retry.provider).trim() || undefined,
-		...(delayMs !== undefined ? { delayMs } : {}),
-		...(retryingAt ? { retryingAt } : {}),
-	};
-};
+const normalizeRetryState = (retry: TypesGen.ChatStreamRetry): RetryState => ({
+	attempt: Math.max(1, retry.attempt),
+	error: retry.error.trim() || "Retrying request shortly.",
+	kind: retry.kind?.trim() || "generic",
+	provider: retry.provider?.trim() || undefined,
+	delayMs: retry.delay_ms,
+	retryingAt: retry.retrying_at.trim() || undefined,
+});
 
 const shouldSurfaceReconnectState = (state: ChatStoreState): boolean =>
 	state.streamError === null &&
@@ -419,7 +392,7 @@ export const useChatStore = (
 		};
 
 		const handleMessage = (
-			payload: OneWayMessageEvent<TypesGen.ServerSentEvent>,
+			payload: OneWayMessageEvent<TypesGen.ChatStreamEvent[]>,
 		) => {
 			if (disposed) {
 				return;
@@ -431,11 +404,8 @@ export const useChatStore = (
 				});
 				return;
 			}
-			if (payload.parsedMessage.type !== "data") {
-				return;
-			}
 
-			const streamEvents = toChatStreamEvents(payload.parsedMessage.data);
+			const streamEvents = payload.parsedMessage;
 			if (streamEvents.length === 0) {
 				return;
 			}


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

`watchChats` and `streamChat` inherited the `ServerSentEvent` envelope from the pre-WebSocket SSE era. The newer WebSocket endpoints (`watchAgentContainers`, `watchInboxNotifications`, agent logs) already send raw typed payloads — these two were the last holdouts.

Backend: replace `OneWayWebSocketEventSender` with `websocket.Accept` + `json.NewEncoder` for both endpoints. Move `ChatWatchEvent` to `codersdk` so it gets codegen'd. Frontend consumers receive typed data directly instead of unwrapping an `unknown` envelope.

This removes `isChatListSSEEvent`, `isChatStreamEvent`, `isChatStreamEventArray`, `toChatStreamEvents`, and the `asString`/`asNumber` wrappers in `normalizeChatDetailError`/`normalizeRetryState` — all of which existed solely because the SSE envelope erased type information.

<details>
<summary>Decision log</summary>

- Scoped to `watchChats` and `streamChat` only — `watchWorkspace` and `watchAgentMetadata` still use the SSE envelope (different consumers, separate cleanup)
- `ChatWatchEvent` moved from `coderd/pubsub` to `codersdk` for codegen; pubsub aliases removed, all consumers reference `codersdk` directly
- `streamChat` subscribes before `websocket.Accept` so failures return proper HTTP errors instead of WebSocket error frames
- `ChatEvent` channel helper and `HandleChatEvent` remain in `coderd/pubsub` (server-internal plumbing)

</details>