### PR TITLE
feat: add per-chat tree-level spend limits

### DIFF
--- a/coderd/database/check_constraint.go
+++ b/coderd/database/check_constraint.go
@@ -14,6 +14,7 @@ const (
 	CheckChatUsageLimitConfigDefaultLimitMicrosCheck CheckConstraint = "chat_usage_limit_config_default_limit_micros_check" // chat_usage_limit_config
 	CheckChatUsageLimitConfigPeriodCheck             CheckConstraint = "chat_usage_limit_config_period_check"               // chat_usage_limit_config
 	CheckChatUsageLimitConfigSingletonCheck          CheckConstraint = "chat_usage_limit_config_singleton_check"            // chat_usage_limit_config
+	CheckChatsSpendLimitMicrosPositive               CheckConstraint = "chats_spend_limit_micros_positive"                  // chats
 	CheckOrganizationIDNotZero                       CheckConstraint = "organization_id_not_zero"                           // custom_roles
 	CheckGroupsChatSpendLimitMicrosCheck             CheckConstraint = "groups_chat_spend_limit_micros_check"               // groups
 	CheckOneTimePasscodeSet                          CheckConstraint = "one_time_passcode_set"                              // users

--- a/coderd/database/db2sdk/db2sdk.go
+++ b/coderd/database/db2sdk/db2sdk.go
@@ -1580,6 +1580,10 @@ func Chat(c database.Chat, diffStatus *database.ChatDiffStatus, files []database
 	if c.AgentID.Valid {
 		chat.AgentID = &c.AgentID.UUID
 	}
+	if c.SpendLimitMicros.Valid {
+		v := c.SpendLimitMicros.Int64
+		chat.SpendLimitMicros = &v
+	}
 	if diffStatus != nil {
 		convertedDiffStatus := ChatDiffStatus(c.ID, diffStatus)
 		chat.DiffStatus = &convertedDiffStatus

--- a/coderd/database/db2sdk/db2sdk_test.go
+++ b/coderd/database/db2sdk/db2sdk_test.go
@@ -545,6 +545,7 @@ func TestChat_AllFieldsPopulated(t *testing.T) {
 		PinOrder:          1,
 		MCPServerIDs:      []uuid.UUID{uuid.New()},
 		Labels:            database.StringMap{"env": "prod"},
+		SpendLimitMicros:  sql.NullInt64{Int64: 5000000, Valid: true},
 		LastInjectedContext: pqtype.NullRawMessage{
 			// Use a context-file part to verify internal
 			// fields are not present (they are stripped at

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -2704,14 +2704,6 @@ func (q *querier) GetChatQueuedMessages(ctx context.Context, chatID uuid.UUID) (
 	return q.db.GetChatQueuedMessages(ctx, chatID)
 }
 
-func (q *querier) GetChatSpendTotal(ctx context.Context, chatID uuid.UUID) (int64, error) {
-	_, err := q.GetChatByID(ctx, chatID)
-	if err != nil {
-		return 0, err
-	}
-	return q.db.GetChatSpendTotal(ctx, chatID)
-}
-
 func (q *querier) GetChatSystemPrompt(ctx context.Context) (string, error) {
 	// The system prompt is a deployment-wide setting read during chat
 	// creation by every authenticated user, so no RBAC policy check
@@ -2745,6 +2737,14 @@ func (q *querier) GetChatTemplateAllowlist(ctx context.Context) (string, error) 
 		return "", err
 	}
 	return q.db.GetChatTemplateAllowlist(ctx)
+}
+
+func (q *querier) GetChatTreeSpendTotal(ctx context.Context, rootChatID uuid.UUID) (int64, error) {
+	_, err := q.GetChatByID(ctx, rootChatID)
+	if err != nil {
+		return 0, err
+	}
+	return q.db.GetChatTreeSpendTotal(ctx, rootChatID)
 }
 
 func (q *querier) GetChatUsageLimitConfig(ctx context.Context) (database.ChatUsageLimitConfig, error) {

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -2704,6 +2704,14 @@ func (q *querier) GetChatQueuedMessages(ctx context.Context, chatID uuid.UUID) (
 	return q.db.GetChatQueuedMessages(ctx, chatID)
 }
 
+func (q *querier) GetChatSpendTotal(ctx context.Context, chatID uuid.UUID) (int64, error) {
+	_, err := q.GetChatByID(ctx, chatID)
+	if err != nil {
+		return 0, err
+	}
+	return q.db.GetChatSpendTotal(ctx, chatID)
+}
+
 func (q *querier) GetChatSystemPrompt(ctx context.Context) (string, error) {
 	// The system prompt is a deployment-wide setting read during chat
 	// creation by every authenticated user, so no RBAC policy check

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -466,6 +466,12 @@ func (s *MethodTestSuite) TestChats() {
 		dbm.EXPECT().GetChatByID(gomock.Any(), chat.ID).Return(chat, nil).AnyTimes()
 		check.Args(chat.ID).Asserts(chat, policy.ActionRead).Returns(chat)
 	}))
+	s.Run("GetChatTreeSpendTotal", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
+		chat := testutil.Fake(s.T(), faker, database.Chat{})
+		dbm.EXPECT().GetChatByID(gomock.Any(), chat.ID).Return(chat, nil).AnyTimes()
+		dbm.EXPECT().GetChatTreeSpendTotal(gomock.Any(), chat.ID).Return(int64(123), nil).AnyTimes()
+		check.Args(chat.ID).Asserts(chat, policy.ActionRead).Returns(int64(123))
+	}))
 	s.Run("GetChatByIDForUpdate", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		chat := testutil.Fake(s.T(), faker, database.Chat{})
 		dbm.EXPECT().GetChatByIDForUpdate(gomock.Any(), chat.ID).Return(chat, nil).AnyTimes()

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -745,7 +745,7 @@ func (s *MethodTestSuite) TestChats() {
 	}))
 	s.Run("InsertChat", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		arg := testutil.Fake(s.T(), faker, database.InsertChatParams{
-			Status: database.ChatStatusWaiting,
+			Status: database.ChatStatusWaiting, SpendLimitMicros: sql.NullInt64{},
 		})
 		chat := testutil.Fake(s.T(), faker, database.Chat{OwnerID: arg.OwnerID})
 		dbm.EXPECT().InsertChat(gomock.Any(), arg).Return(chat, nil).AnyTimes()

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -1240,14 +1240,6 @@ func (m queryMetricsStore) GetChatQueuedMessages(ctx context.Context, chatID uui
 	return r0, r1
 }
 
-func (m queryMetricsStore) GetChatSpendTotal(ctx context.Context, chatID uuid.UUID) (int64, error) {
-	start := time.Now()
-	r0, r1 := m.s.GetChatSpendTotal(ctx, chatID)
-	m.queryLatencies.WithLabelValues("GetChatSpendTotal").Observe(time.Since(start).Seconds())
-	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetChatSpendTotal").Inc()
-	return r0, r1
-}
-
 func (m queryMetricsStore) GetChatSystemPrompt(ctx context.Context) (string, error) {
 	start := time.Now()
 	r0, r1 := m.s.GetChatSystemPrompt(ctx)
@@ -1269,6 +1261,14 @@ func (m queryMetricsStore) GetChatTemplateAllowlist(ctx context.Context) (string
 	r0, r1 := m.s.GetChatTemplateAllowlist(ctx)
 	m.queryLatencies.WithLabelValues("GetChatTemplateAllowlist").Observe(time.Since(start).Seconds())
 	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetChatTemplateAllowlist").Inc()
+	return r0, r1
+}
+
+func (m queryMetricsStore) GetChatTreeSpendTotal(ctx context.Context, rootChatID uuid.UUID) (int64, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetChatTreeSpendTotal(ctx, rootChatID)
+	m.queryLatencies.WithLabelValues("GetChatTreeSpendTotal").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetChatTreeSpendTotal").Inc()
 	return r0, r1
 }
 

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -1240,6 +1240,14 @@ func (m queryMetricsStore) GetChatQueuedMessages(ctx context.Context, chatID uui
 	return r0, r1
 }
 
+func (m queryMetricsStore) GetChatSpendTotal(ctx context.Context, chatID uuid.UUID) (int64, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetChatSpendTotal(ctx, chatID)
+	m.queryLatencies.WithLabelValues("GetChatSpendTotal").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetChatSpendTotal").Inc()
+	return r0, r1
+}
+
 func (m queryMetricsStore) GetChatSystemPrompt(ctx context.Context) (string, error) {
 	start := time.Now()
 	r0, r1 := m.s.GetChatSystemPrompt(ctx)

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -2282,6 +2282,21 @@ func (mr *MockStoreMockRecorder) GetChatQueuedMessages(ctx, chatID any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChatQueuedMessages", reflect.TypeOf((*MockStore)(nil).GetChatQueuedMessages), ctx, chatID)
 }
 
+// GetChatSpendTotal mocks base method.
+func (m *MockStore) GetChatSpendTotal(ctx context.Context, chatID uuid.UUID) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetChatSpendTotal", ctx, chatID)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetChatSpendTotal indicates an expected call of GetChatSpendTotal.
+func (mr *MockStoreMockRecorder) GetChatSpendTotal(ctx, chatID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChatSpendTotal", reflect.TypeOf((*MockStore)(nil).GetChatSpendTotal), ctx, chatID)
+}
+
 // GetChatSystemPrompt mocks base method.
 func (m *MockStore) GetChatSystemPrompt(ctx context.Context) (string, error) {
 	m.ctrl.T.Helper()

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -2282,21 +2282,6 @@ func (mr *MockStoreMockRecorder) GetChatQueuedMessages(ctx, chatID any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChatQueuedMessages", reflect.TypeOf((*MockStore)(nil).GetChatQueuedMessages), ctx, chatID)
 }
 
-// GetChatSpendTotal mocks base method.
-func (m *MockStore) GetChatSpendTotal(ctx context.Context, chatID uuid.UUID) (int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetChatSpendTotal", ctx, chatID)
-	ret0, _ := ret[0].(int64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetChatSpendTotal indicates an expected call of GetChatSpendTotal.
-func (mr *MockStoreMockRecorder) GetChatSpendTotal(ctx, chatID any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChatSpendTotal", reflect.TypeOf((*MockStore)(nil).GetChatSpendTotal), ctx, chatID)
-}
-
 // GetChatSystemPrompt mocks base method.
 func (m *MockStore) GetChatSystemPrompt(ctx context.Context) (string, error) {
 	m.ctrl.T.Helper()
@@ -2340,6 +2325,21 @@ func (m *MockStore) GetChatTemplateAllowlist(ctx context.Context) (string, error
 func (mr *MockStoreMockRecorder) GetChatTemplateAllowlist(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChatTemplateAllowlist", reflect.TypeOf((*MockStore)(nil).GetChatTemplateAllowlist), ctx)
+}
+
+// GetChatTreeSpendTotal mocks base method.
+func (m *MockStore) GetChatTreeSpendTotal(ctx context.Context, rootChatID uuid.UUID) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetChatTreeSpendTotal", ctx, rootChatID)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetChatTreeSpendTotal indicates an expected call of GetChatTreeSpendTotal.
+func (mr *MockStoreMockRecorder) GetChatTreeSpendTotal(ctx, rootChatID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChatTreeSpendTotal", reflect.TypeOf((*MockStore)(nil).GetChatTreeSpendTotal), ctx, rootChatID)
 }
 
 // GetChatUsageLimitConfig mocks base method.

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -1418,7 +1418,9 @@ CREATE TABLE chats (
     agent_id uuid,
     pin_order integer DEFAULT 0 NOT NULL,
     last_read_message_id bigint,
-    last_injected_context jsonb
+    last_injected_context jsonb,
+    spend_limit_micros bigint,
+    CONSTRAINT chats_spend_limit_micros_positive CHECK ((spend_limit_micros > 0))
 );
 
 CREATE TABLE connection_logs (

--- a/coderd/database/migrations/000463_chat_spend_limit.down.sql
+++ b/coderd/database/migrations/000463_chat_spend_limit.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE chats DROP CONSTRAINT IF EXISTS chats_spend_limit_micros_positive;
+ALTER TABLE chats DROP COLUMN IF EXISTS spend_limit_micros;

--- a/coderd/database/migrations/000463_chat_spend_limit.up.sql
+++ b/coderd/database/migrations/000463_chat_spend_limit.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE chats ADD COLUMN spend_limit_micros BIGINT NULL;
+ALTER TABLE chats ADD CONSTRAINT chats_spend_limit_micros_positive CHECK (spend_limit_micros > 0);

--- a/coderd/database/modelqueries.go
+++ b/coderd/database/modelqueries.go
@@ -796,6 +796,7 @@ func (q *sqlQuerier) GetAuthorizedChats(ctx context.Context, arg GetChatsParams,
 			&i.Chat.PinOrder,
 			&i.Chat.LastReadMessageID,
 			&i.Chat.LastInjectedContext,
+			&i.Chat.SpendLimitMicros,
 			&i.HasUnread); err != nil {
 			return nil, err
 		}

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -4180,6 +4180,7 @@ type Chat struct {
 	PinOrder            int32                 `db:"pin_order" json:"pin_order"`
 	LastReadMessageID   sql.NullInt64         `db:"last_read_message_id" json:"last_read_message_id"`
 	LastInjectedContext pqtype.NullRawMessage `db:"last_injected_context" json:"last_injected_context"`
+	SpendLimitMicros    sql.NullInt64         `db:"spend_limit_micros" json:"spend_limit_micros"`
 }
 
 type ChatDiffStatus struct {

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -265,6 +265,7 @@ type sqlcQuerier interface {
 	GetChatProviderByProvider(ctx context.Context, provider string) (ChatProvider, error)
 	GetChatProviders(ctx context.Context) ([]ChatProvider, error)
 	GetChatQueuedMessages(ctx context.Context, chatID uuid.UUID) ([]ChatQueuedMessage, error)
+	GetChatSpendTotal(ctx context.Context, chatID uuid.UUID) (int64, error)
 	GetChatSystemPrompt(ctx context.Context) (string, error)
 	// GetChatSystemPromptConfig returns both chat system prompt settings in a
 	// single read to avoid torn reads between separate site-config lookups.

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -265,7 +265,6 @@ type sqlcQuerier interface {
 	GetChatProviderByProvider(ctx context.Context, provider string) (ChatProvider, error)
 	GetChatProviders(ctx context.Context) ([]ChatProvider, error)
 	GetChatQueuedMessages(ctx context.Context, chatID uuid.UUID) ([]ChatQueuedMessage, error)
-	GetChatSpendTotal(ctx context.Context, chatID uuid.UUID) (int64, error)
 	GetChatSystemPrompt(ctx context.Context) (string, error)
 	// GetChatSystemPromptConfig returns both chat system prompt settings in a
 	// single read to avoid torn reads between separate site-config lookups.
@@ -276,6 +275,8 @@ type sqlcQuerier interface {
 	// GetChatTemplateAllowlist returns the JSON-encoded template allowlist.
 	// Returns an empty string when no allowlist has been configured (all templates allowed).
 	GetChatTemplateAllowlist(ctx context.Context) (string, error)
+	// Returns the total spend across a chat tree (root + all descendants).
+	GetChatTreeSpendTotal(ctx context.Context, rootChatID uuid.UUID) (int64, error)
 	GetChatUsageLimitConfig(ctx context.Context) (ChatUsageLimitConfig, error)
 	GetChatUsageLimitGroupOverride(ctx context.Context, groupID uuid.UUID) (GetChatUsageLimitGroupOverrideRow, error)
 	GetChatUsageLimitUserOverride(ctx context.Context, userID uuid.UUID) (GetChatUsageLimitUserOverrideRow, error)

--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -1289,7 +1289,7 @@ func TestGetAuthorizedChats(t *testing.T) {
 			Status:            database.ChatStatusWaiting,
 			OwnerID:           owner.ID,
 			LastModelConfigID: modelCfg.ID,
-			Title:             fmt.Sprintf("owner chat %d", i+1),
+			Title:             fmt.Sprintf("owner chat %d", i+1), SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 	}
@@ -1300,7 +1300,7 @@ func TestGetAuthorizedChats(t *testing.T) {
 			Status:            database.ChatStatusWaiting,
 			OwnerID:           member.ID,
 			LastModelConfigID: modelCfg.ID,
-			Title:             fmt.Sprintf("member chat %d", i+1),
+			Title:             fmt.Sprintf("member chat %d", i+1), SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 	}
@@ -1422,7 +1422,7 @@ func TestGetAuthorizedChats(t *testing.T) {
 				Status:            database.ChatStatusWaiting,
 				OwnerID:           paginationUser.ID,
 				LastModelConfigID: modelCfg.ID,
-				Title:             fmt.Sprintf("pagination chat %d", i+1),
+				Title:             fmt.Sprintf("pagination chat %d", i+1), SpendLimitMicros: sql.NullInt64{},
 			})
 			require.NoError(t, err)
 		}
@@ -9765,7 +9765,7 @@ func TestInsertChatMessages(t *testing.T) {
 			Status:            database.ChatStatusWaiting,
 			OwnerID:           user.ID,
 			LastModelConfigID: modelConfigA.ID,
-			Title:             "test-chat-" + uuid.NewString(),
+			Title:             "test-chat-" + uuid.NewString(), SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 
@@ -9936,7 +9936,7 @@ func TestGetChatMessagesForPromptByChatID(t *testing.T) {
 			Status:            database.ChatStatusWaiting,
 			OwnerID:           user.ID,
 			LastModelConfigID: modelCfg.ID,
-			Title:             "test-chat-" + uuid.NewString(),
+			Title:             "test-chat-" + uuid.NewString(), SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 		return chat
@@ -10311,7 +10311,7 @@ func TestGetPRInsights(t *testing.T) {
 			Status:            database.ChatStatusWaiting,
 			OwnerID:           userID,
 			LastModelConfigID: mcID,
-			Title:             title,
+			Title:             title, SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 		return chat
@@ -10449,7 +10449,7 @@ func TestGetPRInsights(t *testing.T) {
 			LastModelConfigID: mcID,
 			Title:             title,
 			ParentChatID:      uuid.NullUUID{UUID: parentID, Valid: true},
-			RootChatID:        uuid.NullUUID{UUID: rootID, Valid: true},
+			RootChatID:        uuid.NullUUID{UUID: rootID, Valid: true}, SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 		return chat
@@ -10838,7 +10838,7 @@ func TestChatPinOrderQueries(t *testing.T) {
 			Status:            database.ChatStatusWaiting,
 			OwnerID:           ownerID,
 			LastModelConfigID: modelCfgID,
-			Title:             title,
+			Title:             title, SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 		return chat
@@ -11024,7 +11024,7 @@ func TestChatLabels(t *testing.T) {
 			Labels: pqtype.NullRawMessage{
 				RawMessage: labelsJSON,
 				Valid:      true,
-			},
+			}, SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 		require.Equal(t, database.StringMap{"github.repo": "coder/coder", "env": "prod"}, chat.Labels)
@@ -11043,7 +11043,7 @@ func TestChatLabels(t *testing.T) {
 			Status:            database.ChatStatusWaiting,
 			OwnerID:           owner.ID,
 			LastModelConfigID: modelCfg.ID,
-			Title:             "no-labels-chat",
+			Title:             "no-labels-chat", SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 		// Default should be an empty map, not nil.
@@ -11059,7 +11059,7 @@ func TestChatLabels(t *testing.T) {
 			Status:            database.ChatStatusWaiting,
 			OwnerID:           owner.ID,
 			LastModelConfigID: modelCfg.ID,
-			Title:             "update-labels-chat",
+			Title:             "update-labels-chat", SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 		require.Empty(t, chat.Labels)
@@ -11104,7 +11104,7 @@ func TestChatLabels(t *testing.T) {
 			Labels: pqtype.NullRawMessage{
 				RawMessage: labelsJSON,
 				Valid:      true,
-			},
+			}, SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 
@@ -11141,7 +11141,7 @@ func TestChatLabels(t *testing.T) {
 				Labels: pqtype.NullRawMessage{
 					RawMessage: labelsJSON,
 					Valid:      true,
-				},
+				}, SpendLimitMicros: sql.NullInt64{},
 			})
 			require.NoError(t, err)
 		}
@@ -11224,7 +11224,7 @@ func TestChatHasUnread(t *testing.T) {
 		Status:            database.ChatStatusWaiting,
 		OwnerID:           user.ID,
 		LastModelConfigID: modelCfg.ID,
-		Title:             "test-chat-" + uuid.NewString(),
+		Title:             "test-chat-" + uuid.NewString(), SpendLimitMicros: sql.NullInt64{},
 	})
 	require.NoError(t, err)
 

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -4166,7 +4166,7 @@ WHERE
             $3::int
     )
 RETURNING
-    id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_server_ids, labels, build_id, agent_id, pin_order, last_read_message_id, last_injected_context
+    id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_server_ids, labels, build_id, agent_id, pin_order, last_read_message_id, last_injected_context, spend_limit_micros
 `
 
 type AcquireChatsParams struct {
@@ -4210,6 +4210,7 @@ func (q *sqlQuerier) AcquireChats(ctx context.Context, arg AcquireChatsParams) (
 			&i.PinOrder,
 			&i.LastReadMessageID,
 			&i.LastInjectedContext,
+			&i.SpendLimitMicros,
 		); err != nil {
 			return nil, err
 		}
@@ -4348,9 +4349,9 @@ WITH chats AS (
     UPDATE chats
     SET archived = true, pin_order = 0, updated_at = NOW()
     WHERE id = $1::uuid OR root_chat_id = $1::uuid
-    RETURNING id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_server_ids, labels, build_id, agent_id, pin_order, last_read_message_id, last_injected_context
+    RETURNING id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_server_ids, labels, build_id, agent_id, pin_order, last_read_message_id, last_injected_context, spend_limit_micros
 )
-SELECT id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_server_ids, labels, build_id, agent_id, pin_order, last_read_message_id, last_injected_context
+SELECT id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_server_ids, labels, build_id, agent_id, pin_order, last_read_message_id, last_injected_context, spend_limit_micros
 FROM chats
 ORDER BY (id = $1::uuid) DESC, created_at ASC, id ASC
 `
@@ -4388,6 +4389,7 @@ func (q *sqlQuerier) ArchiveChatByID(ctx context.Context, id uuid.UUID) ([]Chat,
 			&i.PinOrder,
 			&i.LastReadMessageID,
 			&i.LastInjectedContext,
+			&i.SpendLimitMicros,
 		); err != nil {
 			return nil, err
 		}
@@ -4492,7 +4494,7 @@ func (q *sqlQuerier) DeleteChatUsageLimitUserOverride(ctx context.Context, userI
 
 const getChatByID = `-- name: GetChatByID :one
 SELECT
-    id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_server_ids, labels, build_id, agent_id, pin_order, last_read_message_id, last_injected_context
+    id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_server_ids, labels, build_id, agent_id, pin_order, last_read_message_id, last_injected_context, spend_limit_micros
 FROM
     chats
 WHERE
@@ -4526,12 +4528,13 @@ func (q *sqlQuerier) GetChatByID(ctx context.Context, id uuid.UUID) (Chat, error
 		&i.PinOrder,
 		&i.LastReadMessageID,
 		&i.LastInjectedContext,
+		&i.SpendLimitMicros,
 	)
 	return i, err
 }
 
 const getChatByIDForUpdate = `-- name: GetChatByIDForUpdate :one
-SELECT id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_server_ids, labels, build_id, agent_id, pin_order, last_read_message_id, last_injected_context FROM chats WHERE id = $1::uuid FOR UPDATE
+SELECT id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_server_ids, labels, build_id, agent_id, pin_order, last_read_message_id, last_injected_context, spend_limit_micros FROM chats WHERE id = $1::uuid FOR UPDATE
 `
 
 func (q *sqlQuerier) GetChatByIDForUpdate(ctx context.Context, id uuid.UUID) (Chat, error) {
@@ -4561,6 +4564,7 @@ func (q *sqlQuerier) GetChatByIDForUpdate(ctx context.Context, id uuid.UUID) (Ch
 		&i.PinOrder,
 		&i.LastReadMessageID,
 		&i.LastInjectedContext,
+		&i.SpendLimitMicros,
 	)
 	return i, err
 }
@@ -5429,6 +5433,20 @@ func (q *sqlQuerier) GetChatQueuedMessages(ctx context.Context, chatID uuid.UUID
 	return items, nil
 }
 
+const getChatSpendTotal = `-- name: GetChatSpendTotal :one
+SELECT COALESCE(SUM(total_cost_micros), 0)::bigint AS total_cost_micros
+FROM chat_messages
+WHERE chat_id = $1
+  AND total_cost_micros IS NOT NULL
+`
+
+func (q *sqlQuerier) GetChatSpendTotal(ctx context.Context, chatID uuid.UUID) (int64, error) {
+	row := q.db.QueryRowContext(ctx, getChatSpendTotal, chatID)
+	var total_cost_micros int64
+	err := row.Scan(&total_cost_micros)
+	return total_cost_micros, err
+}
+
 const getChatUsageLimitConfig = `-- name: GetChatUsageLimitConfig :one
 SELECT id, singleton, enabled, default_limit_micros, period, created_at, updated_at FROM chat_usage_limit_config WHERE singleton = TRUE LIMIT 1
 `
@@ -5486,7 +5504,7 @@ func (q *sqlQuerier) GetChatUsageLimitUserOverride(ctx context.Context, userID u
 
 const getChats = `-- name: GetChats :many
 SELECT
-    chats.id, chats.owner_id, chats.workspace_id, chats.title, chats.status, chats.worker_id, chats.started_at, chats.heartbeat_at, chats.created_at, chats.updated_at, chats.parent_chat_id, chats.root_chat_id, chats.last_model_config_id, chats.archived, chats.last_error, chats.mode, chats.mcp_server_ids, chats.labels, chats.build_id, chats.agent_id, chats.pin_order, chats.last_read_message_id, chats.last_injected_context,
+    chats.id, chats.owner_id, chats.workspace_id, chats.title, chats.status, chats.worker_id, chats.started_at, chats.heartbeat_at, chats.created_at, chats.updated_at, chats.parent_chat_id, chats.root_chat_id, chats.last_model_config_id, chats.archived, chats.last_error, chats.mode, chats.mcp_server_ids, chats.labels, chats.build_id, chats.agent_id, chats.pin_order, chats.last_read_message_id, chats.last_injected_context, chats.spend_limit_micros,
     EXISTS (
         SELECT 1 FROM chat_messages cm
         WHERE cm.chat_id = chats.id
@@ -5594,6 +5612,7 @@ func (q *sqlQuerier) GetChats(ctx context.Context, arg GetChatsParams) ([]GetCha
 			&i.Chat.PinOrder,
 			&i.Chat.LastReadMessageID,
 			&i.Chat.LastInjectedContext,
+			&i.Chat.SpendLimitMicros,
 			&i.HasUnread,
 		); err != nil {
 			return nil, err
@@ -5610,7 +5629,7 @@ func (q *sqlQuerier) GetChats(ctx context.Context, arg GetChatsParams) ([]GetCha
 }
 
 const getChatsByWorkspaceIDs = `-- name: GetChatsByWorkspaceIDs :many
-SELECT id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_server_ids, labels, build_id, agent_id, pin_order, last_read_message_id, last_injected_context
+SELECT id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_server_ids, labels, build_id, agent_id, pin_order, last_read_message_id, last_injected_context, spend_limit_micros
 FROM chats
 WHERE archived = false
   AND workspace_id = ANY($1::uuid[])
@@ -5650,6 +5669,7 @@ func (q *sqlQuerier) GetChatsByWorkspaceIDs(ctx context.Context, ids []uuid.UUID
 			&i.PinOrder,
 			&i.LastReadMessageID,
 			&i.LastInjectedContext,
+			&i.SpendLimitMicros,
 		); err != nil {
 			return nil, err
 		}
@@ -5715,7 +5735,7 @@ func (q *sqlQuerier) GetLastChatMessageByRole(ctx context.Context, arg GetLastCh
 
 const getStaleChats = `-- name: GetStaleChats :many
 SELECT
-    id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_server_ids, labels, build_id, agent_id, pin_order, last_read_message_id, last_injected_context
+    id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_server_ids, labels, build_id, agent_id, pin_order, last_read_message_id, last_injected_context, spend_limit_micros
 FROM
     chats
 WHERE
@@ -5758,6 +5778,7 @@ func (q *sqlQuerier) GetStaleChats(ctx context.Context, staleThreshold time.Time
 			&i.PinOrder,
 			&i.LastReadMessageID,
 			&i.LastInjectedContext,
+			&i.SpendLimitMicros,
 		); err != nil {
 			return nil, err
 		}
@@ -5825,7 +5846,8 @@ INSERT INTO chats (
     mode,
     status,
     mcp_server_ids,
-    labels
+    labels,
+    spend_limit_micros
 ) VALUES (
     $1::uuid,
     $2::uuid,
@@ -5838,10 +5860,11 @@ INSERT INTO chats (
     $9::chat_mode,
     $10::chat_status,
     COALESCE($11::uuid[], '{}'::uuid[]),
-    COALESCE($12::jsonb, '{}'::jsonb)
+    COALESCE($12::jsonb, '{}'::jsonb),
+    $13::bigint
 )
 RETURNING
-    id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_server_ids, labels, build_id, agent_id, pin_order, last_read_message_id, last_injected_context
+    id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_server_ids, labels, build_id, agent_id, pin_order, last_read_message_id, last_injected_context, spend_limit_micros
 `
 
 type InsertChatParams struct {
@@ -5857,6 +5880,7 @@ type InsertChatParams struct {
 	Status            ChatStatus            `db:"status" json:"status"`
 	MCPServerIDs      []uuid.UUID           `db:"mcp_server_ids" json:"mcp_server_ids"`
 	Labels            pqtype.NullRawMessage `db:"labels" json:"labels"`
+	SpendLimitMicros  sql.NullInt64         `db:"spend_limit_micros" json:"spend_limit_micros"`
 }
 
 func (q *sqlQuerier) InsertChat(ctx context.Context, arg InsertChatParams) (Chat, error) {
@@ -5873,6 +5897,7 @@ func (q *sqlQuerier) InsertChat(ctx context.Context, arg InsertChatParams) (Chat
 		arg.Status,
 		pq.Array(arg.MCPServerIDs),
 		arg.Labels,
+		arg.SpendLimitMicros,
 	)
 	var i Chat
 	err := row.Scan(
@@ -5899,6 +5924,7 @@ func (q *sqlQuerier) InsertChat(ctx context.Context, arg InsertChatParams) (Chat
 		&i.PinOrder,
 		&i.LastReadMessageID,
 		&i.LastInjectedContext,
+		&i.SpendLimitMicros,
 	)
 	return i, err
 }
@@ -6393,9 +6419,9 @@ WITH chats AS (
     UPDATE chats
     SET archived = false, updated_at = NOW()
     WHERE id = $1::uuid OR root_chat_id = $1::uuid
-    RETURNING id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_server_ids, labels, build_id, agent_id, pin_order, last_read_message_id, last_injected_context
+    RETURNING id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_server_ids, labels, build_id, agent_id, pin_order, last_read_message_id, last_injected_context, spend_limit_micros
 )
-SELECT id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_server_ids, labels, build_id, agent_id, pin_order, last_read_message_id, last_injected_context
+SELECT id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_server_ids, labels, build_id, agent_id, pin_order, last_read_message_id, last_injected_context, spend_limit_micros
 FROM chats
 ORDER BY (id = $1::uuid) DESC, created_at ASC, id ASC
 `
@@ -6433,6 +6459,7 @@ func (q *sqlQuerier) UnarchiveChatByID(ctx context.Context, id uuid.UUID) ([]Cha
 			&i.PinOrder,
 			&i.LastReadMessageID,
 			&i.LastInjectedContext,
+			&i.SpendLimitMicros,
 		); err != nil {
 			return nil, err
 		}
@@ -6513,7 +6540,7 @@ UPDATE chats SET
     updated_at = NOW()
 WHERE
     id = $3::uuid
-RETURNING id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_server_ids, labels, build_id, agent_id, pin_order, last_read_message_id, last_injected_context
+RETURNING id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_server_ids, labels, build_id, agent_id, pin_order, last_read_message_id, last_injected_context, spend_limit_micros
 `
 
 type UpdateChatBuildAgentBindingParams struct {
@@ -6549,6 +6576,7 @@ func (q *sqlQuerier) UpdateChatBuildAgentBinding(ctx context.Context, arg Update
 		&i.PinOrder,
 		&i.LastReadMessageID,
 		&i.LastInjectedContext,
+		&i.SpendLimitMicros,
 	)
 	return i, err
 }
@@ -6562,7 +6590,7 @@ SET
 WHERE
     id = $2::uuid
 RETURNING
-    id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_server_ids, labels, build_id, agent_id, pin_order, last_read_message_id, last_injected_context
+    id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_server_ids, labels, build_id, agent_id, pin_order, last_read_message_id, last_injected_context, spend_limit_micros
 `
 
 type UpdateChatByIDParams struct {
@@ -6597,6 +6625,7 @@ func (q *sqlQuerier) UpdateChatByID(ctx context.Context, arg UpdateChatByIDParam
 		&i.PinOrder,
 		&i.LastReadMessageID,
 		&i.LastInjectedContext,
+		&i.SpendLimitMicros,
 	)
 	return i, err
 }
@@ -6636,7 +6665,7 @@ SET
 WHERE
     id = $2::uuid
 RETURNING
-    id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_server_ids, labels, build_id, agent_id, pin_order, last_read_message_id, last_injected_context
+    id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_server_ids, labels, build_id, agent_id, pin_order, last_read_message_id, last_injected_context, spend_limit_micros
 `
 
 type UpdateChatLabelsByIDParams struct {
@@ -6671,6 +6700,7 @@ func (q *sqlQuerier) UpdateChatLabelsByID(ctx context.Context, arg UpdateChatLab
 		&i.PinOrder,
 		&i.LastReadMessageID,
 		&i.LastInjectedContext,
+		&i.SpendLimitMicros,
 	)
 	return i, err
 }
@@ -6680,7 +6710,7 @@ UPDATE chats SET
     last_injected_context = $1::jsonb
 WHERE
     id = $2::uuid
-RETURNING id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_server_ids, labels, build_id, agent_id, pin_order, last_read_message_id, last_injected_context
+RETURNING id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_server_ids, labels, build_id, agent_id, pin_order, last_read_message_id, last_injected_context, spend_limit_micros
 `
 
 type UpdateChatLastInjectedContextParams struct {
@@ -6719,6 +6749,7 @@ func (q *sqlQuerier) UpdateChatLastInjectedContext(ctx context.Context, arg Upda
 		&i.PinOrder,
 		&i.LastReadMessageID,
 		&i.LastInjectedContext,
+		&i.SpendLimitMicros,
 	)
 	return i, err
 }
@@ -6732,7 +6763,7 @@ SET
 WHERE
     id = $2::uuid
 RETURNING
-    id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_server_ids, labels, build_id, agent_id, pin_order, last_read_message_id, last_injected_context
+    id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_server_ids, labels, build_id, agent_id, pin_order, last_read_message_id, last_injected_context, spend_limit_micros
 `
 
 type UpdateChatLastModelConfigByIDParams struct {
@@ -6767,6 +6798,7 @@ func (q *sqlQuerier) UpdateChatLastModelConfigByID(ctx context.Context, arg Upda
 		&i.PinOrder,
 		&i.LastReadMessageID,
 		&i.LastInjectedContext,
+		&i.SpendLimitMicros,
 	)
 	return i, err
 }
@@ -6798,7 +6830,7 @@ SET
 WHERE
     id = $2::uuid
 RETURNING
-    id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_server_ids, labels, build_id, agent_id, pin_order, last_read_message_id, last_injected_context
+    id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_server_ids, labels, build_id, agent_id, pin_order, last_read_message_id, last_injected_context, spend_limit_micros
 `
 
 type UpdateChatMCPServerIDsParams struct {
@@ -6833,6 +6865,7 @@ func (q *sqlQuerier) UpdateChatMCPServerIDs(ctx context.Context, arg UpdateChatM
 		&i.PinOrder,
 		&i.LastReadMessageID,
 		&i.LastInjectedContext,
+		&i.SpendLimitMicros,
 	)
 	return i, err
 }
@@ -6968,7 +7001,7 @@ SET
 WHERE
     id = $6::uuid
 RETURNING
-    id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_server_ids, labels, build_id, agent_id, pin_order, last_read_message_id, last_injected_context
+    id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_server_ids, labels, build_id, agent_id, pin_order, last_read_message_id, last_injected_context, spend_limit_micros
 `
 
 type UpdateChatStatusParams struct {
@@ -7014,6 +7047,7 @@ func (q *sqlQuerier) UpdateChatStatus(ctx context.Context, arg UpdateChatStatusP
 		&i.PinOrder,
 		&i.LastReadMessageID,
 		&i.LastInjectedContext,
+		&i.SpendLimitMicros,
 	)
 	return i, err
 }
@@ -7031,7 +7065,7 @@ SET
 WHERE
     id = $7::uuid
 RETURNING
-    id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_server_ids, labels, build_id, agent_id, pin_order, last_read_message_id, last_injected_context
+    id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_server_ids, labels, build_id, agent_id, pin_order, last_read_message_id, last_injected_context, spend_limit_micros
 `
 
 type UpdateChatStatusPreserveUpdatedAtParams struct {
@@ -7079,6 +7113,7 @@ func (q *sqlQuerier) UpdateChatStatusPreserveUpdatedAt(ctx context.Context, arg 
 		&i.PinOrder,
 		&i.LastReadMessageID,
 		&i.LastInjectedContext,
+		&i.SpendLimitMicros,
 	)
 	return i, err
 }
@@ -7090,7 +7125,7 @@ UPDATE chats SET
     agent_id = $3::uuid,
     updated_at = NOW()
 WHERE id = $4::uuid
-RETURNING id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_server_ids, labels, build_id, agent_id, pin_order, last_read_message_id, last_injected_context
+RETURNING id, owner_id, workspace_id, title, status, worker_id, started_at, heartbeat_at, created_at, updated_at, parent_chat_id, root_chat_id, last_model_config_id, archived, last_error, mode, mcp_server_ids, labels, build_id, agent_id, pin_order, last_read_message_id, last_injected_context, spend_limit_micros
 `
 
 type UpdateChatWorkspaceBindingParams struct {
@@ -7132,6 +7167,7 @@ func (q *sqlQuerier) UpdateChatWorkspaceBinding(ctx context.Context, arg UpdateC
 		&i.PinOrder,
 		&i.LastReadMessageID,
 		&i.LastInjectedContext,
+		&i.SpendLimitMicros,
 	)
 	return i, err
 }

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -5433,18 +5433,22 @@ func (q *sqlQuerier) GetChatQueuedMessages(ctx context.Context, chatID uuid.UUID
 	return items, nil
 }
 
-const getChatSpendTotal = `-- name: GetChatSpendTotal :one
-SELECT COALESCE(SUM(total_cost_micros), 0)::bigint AS total_cost_micros
+const getChatTreeSpendTotal = `-- name: GetChatTreeSpendTotal :one
+SELECT COALESCE(SUM(total_cost_micros), 0)::bigint AS total_cost
 FROM chat_messages
-WHERE chat_id = $1
-  AND total_cost_micros IS NOT NULL
+WHERE chat_id IN (
+    SELECT chats.id
+    FROM chats
+    WHERE chats.id = $1 OR chats.root_chat_id = $1
+)
 `
 
-func (q *sqlQuerier) GetChatSpendTotal(ctx context.Context, chatID uuid.UUID) (int64, error) {
-	row := q.db.QueryRowContext(ctx, getChatSpendTotal, chatID)
-	var total_cost_micros int64
-	err := row.Scan(&total_cost_micros)
-	return total_cost_micros, err
+// Returns the total spend across a chat tree (root + all descendants).
+func (q *sqlQuerier) GetChatTreeSpendTotal(ctx context.Context, rootChatID uuid.UUID) (int64, error) {
+	row := q.db.QueryRowContext(ctx, getChatTreeSpendTotal, rootChatID)
+	var total_cost int64
+	err := row.Scan(&total_cost)
+	return total_cost, err
 }
 
 const getChatUsageLimitConfig = `-- name: GetChatUsageLimitConfig :one

--- a/coderd/database/queries/chats.sql
+++ b/coderd/database/queries/chats.sql
@@ -222,11 +222,15 @@ WHERE
     id = @id::bigint
     AND deleted = false;
 
--- name: GetChatSpendTotal :one
-SELECT COALESCE(SUM(total_cost_micros), 0)::bigint AS total_cost_micros
+-- name: GetChatTreeSpendTotal :one
+-- Returns the total spend across a chat tree (root + all descendants).
+SELECT COALESCE(SUM(total_cost_micros), 0)::bigint AS total_cost
 FROM chat_messages
-WHERE chat_id = @chat_id
-  AND total_cost_micros IS NOT NULL;
+WHERE chat_id IN (
+    SELECT chats.id
+    FROM chats
+    WHERE chats.id = @root_chat_id OR chats.root_chat_id = @root_chat_id
+);
 
 -- name: GetChatMessagesByChatID :many
 SELECT

--- a/coderd/database/queries/chats.sql
+++ b/coderd/database/queries/chats.sql
@@ -222,6 +222,12 @@ WHERE
     id = @id::bigint
     AND deleted = false;
 
+-- name: GetChatSpendTotal :one
+SELECT COALESCE(SUM(total_cost_micros), 0)::bigint AS total_cost_micros
+FROM chat_messages
+WHERE chat_id = @chat_id
+  AND total_cost_micros IS NOT NULL;
+
 -- name: GetChatMessagesByChatID :many
 SELECT
     *
@@ -394,7 +400,8 @@ INSERT INTO chats (
     mode,
     status,
     mcp_server_ids,
-    labels
+    labels,
+    spend_limit_micros
 ) VALUES (
     @owner_id::uuid,
     sqlc.narg('workspace_id')::uuid,
@@ -407,7 +414,8 @@ INSERT INTO chats (
     sqlc.narg('mode')::chat_mode,
     @status::chat_status,
     COALESCE(@mcp_server_ids::uuid[], '{}'::uuid[]),
-    COALESCE(sqlc.narg('labels')::jsonb, '{}'::jsonb)
+    COALESCE(sqlc.narg('labels')::jsonb, '{}'::jsonb),
+    sqlc.narg('spend_limit_micros')::bigint
 )
 RETURNING
     *;

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -96,6 +96,7 @@ func writeChatUsageLimitExceeded(
 		Response: codersdk.Response{
 			Message: "Chat usage limit exceeded.",
 		},
+		Scope:       limitErr.Scope,
 		SpentMicros: limitErr.ConsumedMicros,
 		LimitMicros: limitErr.LimitMicros,
 		ResetsAt:    limitErr.PeriodEnd,
@@ -412,6 +413,13 @@ func (api *API) postChats(rw http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
+	if req.SpendLimitMicros != nil && *req.SpendLimitMicros <= 0 {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "Invalid spend limit.",
+			Detail:  "spend_limit_micros must be greater than zero.",
+		})
+		return
+	}
 
 	contentBlocks, titleSource, fileIDs, inputError := createChatInputFromRequest(ctx, api.Database, req)
 	if inputError != nil {
@@ -497,6 +505,7 @@ func (api *API) postChats(rw http.ResponseWriter, r *http.Request) {
 		InitialUserContent: contentBlocks,
 		MCPServerIDs:       mcpServerIDs,
 		Labels:             labels,
+		SpendLimitMicros:   req.SpendLimitMicros,
 	})
 	if err != nil {
 		if maybeWriteLimitErr(ctx, rw, err) {

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -626,7 +626,7 @@ func TestPostChats(t *testing.T) {
 			Status:            database.ChatStatusWaiting,
 			OwnerID:           user.UserID,
 			LastModelConfigID: modelConfig.ID,
-			Title:             "existing-limit-chat",
+			Title:             "existing-limit-chat", SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 
@@ -679,7 +679,7 @@ func TestListChats(t *testing.T) {
 			Status:            database.ChatStatusWaiting,
 			OwnerID:           member.ID,
 			LastModelConfigID: modelConfig.ID,
-			Title:             "member chat only",
+			Title:             "member chat only", SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 
@@ -768,7 +768,7 @@ func TestListChats(t *testing.T) {
 			Status:            database.ChatStatusWaiting,
 			OwnerID:           member.ID,
 			LastModelConfigID: modelConfig.ID,
-			Title:             "member chat",
+			Title:             "member chat", SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 
@@ -1257,7 +1257,7 @@ func TestWatchChats(t *testing.T) {
 			Status:            database.ChatStatusWaiting,
 			OwnerID:           user.UserID,
 			LastModelConfigID: modelConfig.ID,
-			Title:             "diff status watch test",
+			Title:             "diff status watch test", SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 
@@ -1387,7 +1387,7 @@ func TestWatchChats(t *testing.T) {
 			LastModelConfigID: modelConfig.ID,
 			Title:             "watch child 1",
 			ParentChatID:      uuid.NullUUID{UUID: parentChat.ID, Valid: true},
-			RootChatID:        uuid.NullUUID{UUID: parentChat.ID, Valid: true},
+			RootChatID:        uuid.NullUUID{UUID: parentChat.ID, Valid: true}, SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 
@@ -1397,7 +1397,7 @@ func TestWatchChats(t *testing.T) {
 			LastModelConfigID: modelConfig.ID,
 			Title:             "watch child 2",
 			ParentChatID:      uuid.NullUUID{UUID: parentChat.ID, Valid: true},
-			RootChatID:        uuid.NullUUID{UUID: parentChat.ID, Valid: true},
+			RootChatID:        uuid.NullUUID{UUID: parentChat.ID, Valid: true}, SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 
@@ -3475,7 +3475,7 @@ func TestArchiveChat(t *testing.T) {
 			LastModelConfigID: modelConfig.ID,
 			Title:             "child 1",
 			ParentChatID:      uuid.NullUUID{UUID: parentChat.ID, Valid: true},
-			RootChatID:        uuid.NullUUID{UUID: parentChat.ID, Valid: true},
+			RootChatID:        uuid.NullUUID{UUID: parentChat.ID, Valid: true}, SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 
@@ -3485,7 +3485,7 @@ func TestArchiveChat(t *testing.T) {
 			LastModelConfigID: modelConfig.ID,
 			Title:             "child 2",
 			ParentChatID:      uuid.NullUUID{UUID: parentChat.ID, Valid: true},
-			RootChatID:        uuid.NullUUID{UUID: parentChat.ID, Valid: true},
+			RootChatID:        uuid.NullUUID{UUID: parentChat.ID, Valid: true}, SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 
@@ -3592,7 +3592,7 @@ func TestUnarchiveChat(t *testing.T) {
 			LastModelConfigID: modelConfig.ID,
 			Title:             "child 1",
 			ParentChatID:      uuid.NullUUID{UUID: parentChat.ID, Valid: true},
-			RootChatID:        uuid.NullUUID{UUID: parentChat.ID, Valid: true},
+			RootChatID:        uuid.NullUUID{UUID: parentChat.ID, Valid: true}, SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 
@@ -3602,7 +3602,7 @@ func TestUnarchiveChat(t *testing.T) {
 			LastModelConfigID: modelConfig.ID,
 			Title:             "child 2",
 			ParentChatID:      uuid.NullUUID{UUID: parentChat.ID, Valid: true},
-			RootChatID:        uuid.NullUUID{UUID: parentChat.ID, Valid: true},
+			RootChatID:        uuid.NullUUID{UUID: parentChat.ID, Valid: true}, SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 
@@ -5228,7 +5228,7 @@ func TestInterruptChat(t *testing.T) {
 			Status:            database.ChatStatusWaiting,
 			OwnerID:           user.UserID,
 			LastModelConfigID: modelConfig.ID,
-			Title:             "interrupt route test",
+			Title:             "interrupt route test", SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 
@@ -5308,7 +5308,7 @@ func TestRegenerateChatTitle(t *testing.T) {
 			Status:            database.ChatStatusWaiting,
 			OwnerID:           user.UserID,
 			LastModelConfigID: modelConfig.ID,
-			Title:             "chat with update denied",
+			Title:             "chat with update denied", SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 
@@ -5417,7 +5417,7 @@ func TestRegenerateChatTitle(t *testing.T) {
 			Status:            database.ChatStatusWaiting,
 			OwnerID:           user.UserID,
 			LastModelConfigID: modelConfig.ID,
-			Title:             "chat with lock held",
+			Title:             "chat with lock held", SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 
@@ -5458,7 +5458,7 @@ func TestRegenerateChatTitle(t *testing.T) {
 			Status:            database.ChatStatusWaiting,
 			OwnerID:           user.UserID,
 			LastModelConfigID: modelConfig.ID,
-			Title:             "pending chat without worker",
+			Title:             "pending chat without worker", SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 
@@ -5574,7 +5574,7 @@ func TestGetChatDiffStatus(t *testing.T) {
 			Status:            database.ChatStatusWaiting,
 			OwnerID:           user.UserID,
 			LastModelConfigID: modelConfig.ID,
-			Title:             "get diff status route no cache",
+			Title:             "get diff status route no cache", SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 
@@ -5587,7 +5587,7 @@ func TestGetChatDiffStatus(t *testing.T) {
 			Status:            database.ChatStatusWaiting,
 			OwnerID:           user.UserID,
 			LastModelConfigID: modelConfig.ID,
-			Title:             "get diff status route cached",
+			Title:             "get diff status route cached", SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 
@@ -5694,7 +5694,7 @@ func TestGetChatDiffContents(t *testing.T) {
 			Status:            database.ChatStatusWaiting,
 			OwnerID:           user.UserID,
 			LastModelConfigID: modelConfig.ID,
-			Title:             "diff contents with cached repository reference",
+			Title:             "diff contents with cached repository reference", SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 
@@ -5791,7 +5791,7 @@ func TestDeleteChatQueuedMessage(t *testing.T) {
 			Status:            database.ChatStatusWaiting,
 			OwnerID:           user.UserID,
 			LastModelConfigID: modelConfig.ID,
-			Title:             "delete queued message route test",
+			Title:             "delete queued message route test", SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 
@@ -5843,7 +5843,7 @@ func TestDeleteChatQueuedMessage(t *testing.T) {
 			Status:            database.ChatStatusWaiting,
 			OwnerID:           user.UserID,
 			LastModelConfigID: modelConfig.ID,
-			Title:             "delete queued invalid id",
+			Title:             "delete queued invalid id", SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 
@@ -5878,7 +5878,7 @@ func TestPromoteChatQueuedMessage(t *testing.T) {
 			Status:            database.ChatStatusWaiting,
 			OwnerID:           user.UserID,
 			LastModelConfigID: modelConfig.ID,
-			Title:             "promote queued message route test",
+			Title:             "promote queued message route test", SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 
@@ -5949,7 +5949,7 @@ func TestPromoteChatQueuedMessage(t *testing.T) {
 			Status:            database.ChatStatusWaiting,
 			OwnerID:           user.UserID,
 			LastModelConfigID: modelConfig.ID,
-			Title:             "promote queued usage limit",
+			Title:             "promote queued usage limit", SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 
@@ -6024,7 +6024,7 @@ func TestPromoteChatQueuedMessage(t *testing.T) {
 			Status:            database.ChatStatusWaiting,
 			OwnerID:           user.UserID,
 			LastModelConfigID: modelConfig.ID,
-			Title:             "promote queued invalid id",
+			Title:             "promote queued invalid id", SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 
@@ -6607,7 +6607,7 @@ func seedChatCostFixture(t *testing.T) chatCostTestFixture {
 		Status:            database.ChatStatusWaiting,
 		OwnerID:           firstUser.UserID,
 		LastModelConfigID: modelConfig.ID,
-		Title:             "test chat",
+		Title:             "test chat", SpendLimitMicros: sql.NullInt64{},
 	})
 	require.NoError(t, err)
 
@@ -6728,7 +6728,7 @@ func TestChatCostSummary_AdminDrilldown(t *testing.T) {
 		Status:            database.ChatStatusWaiting,
 		OwnerID:           member.ID,
 		LastModelConfigID: modelConfig.ID,
-		Title:             "member chat",
+		Title:             "member chat", SpendLimitMicros: sql.NullInt64{},
 	})
 	require.NoError(t, err)
 
@@ -6797,7 +6797,7 @@ func TestChatCostUsers(t *testing.T) {
 		Status:            database.ChatStatusWaiting,
 		OwnerID:           firstUser.UserID,
 		LastModelConfigID: modelConfig.ID,
-		Title:             "admin chat",
+		Title:             "admin chat", SpendLimitMicros: sql.NullInt64{},
 	})
 	require.NoError(t, err)
 	_, err = db.InsertChatMessages(dbauthz.AsSystemRestricted(seedCtx), database.InsertChatMessagesParams{
@@ -6825,7 +6825,7 @@ func TestChatCostUsers(t *testing.T) {
 		Status:            database.ChatStatusWaiting,
 		OwnerID:           member.ID,
 		LastModelConfigID: modelConfig.ID,
-		Title:             "member chat",
+		Title:             "member chat", SpendLimitMicros: sql.NullInt64{},
 	})
 	require.NoError(t, err)
 	_, err = db.InsertChatMessages(dbauthz.AsSystemRestricted(seedCtx), database.InsertChatMessagesParams{
@@ -6909,7 +6909,7 @@ func TestChatCostSummary_DateRange(t *testing.T) {
 		Status:            database.ChatStatusWaiting,
 		OwnerID:           firstUser.UserID,
 		LastModelConfigID: modelConfig.ID,
-		Title:             "date range test",
+		Title:             "date range test", SpendLimitMicros: sql.NullInt64{},
 	})
 	require.NoError(t, err)
 
@@ -6975,7 +6975,7 @@ func TestChatCostSummary_UnpricedMessages(t *testing.T) {
 		Status:            database.ChatStatusWaiting,
 		OwnerID:           firstUser.UserID,
 		LastModelConfigID: modelConfig.ID,
-		Title:             "unpriced test",
+		Title:             "unpriced test", SpendLimitMicros: sql.NullInt64{},
 	})
 	require.NoError(t, err)
 
@@ -8043,7 +8043,7 @@ func TestGetChatsByWorkspace(t *testing.T) {
 			OwnerID:           user.UserID,
 			LastModelConfigID: modelConfig.ID,
 			Title:             title,
-			WorkspaceID:       uuid.NullUUID{UUID: workspaceID, Valid: true},
+			WorkspaceID:       uuid.NullUUID{UUID: workspaceID, Valid: true}, SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 		return chat

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -129,8 +129,10 @@ func requireChatUsageLimitExceededError(
 	limitErr := codersdk.ChatUsageLimitExceededFrom(err)
 	require.NotNil(t, limitErr)
 	require.Equal(t, "Chat usage limit exceeded.", limitErr.Message)
+	require.Equal(t, "account_period", limitErr.Scope)
 	require.Equal(t, wantSpentMicros, limitErr.SpentMicros)
 	require.Equal(t, wantLimitMicros, limitErr.LimitMicros)
+	require.NotNil(t, limitErr.ResetsAt)
 	require.True(
 		t,
 		limitErr.ResetsAt.Equal(wantResetsAt),
@@ -257,6 +259,84 @@ func TestPostChats(t *testing.T) {
 			}
 		}
 		require.True(t, foundUserMessage)
+	})
+
+	t.Run("WithSpendLimit", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newChatClient(t)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
+		_ = createChatModelConfig(t, client)
+
+		chat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
+			Content: []codersdk.ChatInputPart{{
+				Type: codersdk.ChatInputPartTypeText,
+				Text: "chat with spend limit",
+			}},
+			SpendLimitMicros: ptr.Ref(int64(500000)),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, chat.SpendLimitMicros)
+		require.EqualValues(t, 500000, *chat.SpendLimitMicros)
+	})
+
+	t.Run("OmittedSpendLimit", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newChatClient(t)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
+		_ = createChatModelConfig(t, client)
+
+		chat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
+			Content: []codersdk.ChatInputPart{{
+				Type: codersdk.ChatInputPartTypeText,
+				Text: "chat without spend limit",
+			}},
+		})
+		require.NoError(t, err)
+		require.Nil(t, chat.SpendLimitMicros)
+	})
+
+	t.Run("ZeroSpendLimit", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newChatClient(t)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
+		_ = createChatModelConfig(t, client)
+
+		_, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
+			Content: []codersdk.ChatInputPart{{
+				Type: codersdk.ChatInputPartTypeText,
+				Text: "invalid zero spend limit",
+			}},
+			SpendLimitMicros: ptr.Ref(int64(0)),
+		})
+		sdkErr := requireSDKError(t, err, http.StatusBadRequest)
+		require.Equal(t, "Invalid spend limit.", sdkErr.Message)
+		require.Equal(t, "spend_limit_micros must be greater than zero.", sdkErr.Detail)
+	})
+
+	t.Run("NegativeSpendLimit", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newChatClient(t)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
+		_ = createChatModelConfig(t, client)
+
+		_, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
+			Content: []codersdk.ChatInputPart{{
+				Type: codersdk.ChatInputPartTypeText,
+				Text: "invalid negative spend limit",
+			}},
+			SpendLimitMicros: ptr.Ref(int64(-100)),
+		})
+		sdkErr := requireSDKError(t, err, http.StatusBadRequest)
+		require.Equal(t, "Invalid spend limit.", sdkErr.Message)
+		require.Equal(t, "spend_limit_micros must be greater than zero.", sdkErr.Detail)
 	})
 
 	t.Run("MemberWithoutAgentsAccess", func(t *testing.T) {
@@ -5394,8 +5474,10 @@ func TestRegenerateChatTitle(t *testing.T) {
 		limitErr := codersdk.ChatUsageLimitExceededFrom(err)
 		require.NotNil(t, limitErr)
 		require.Equal(t, "Chat usage limit exceeded.", limitErr.Message)
+		require.Equal(t, "account_period", limitErr.Scope)
 		require.Equal(t, int64(100), limitErr.SpentMicros)
 		require.Equal(t, int64(100), limitErr.LimitMicros)
+		require.NotNil(t, limitErr.ResetsAt)
 		require.True(
 			t,
 			limitErr.ResetsAt.Equal(wantResetsAt),

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -6018,14 +6018,14 @@ func TestPromoteChatQueuedMessage(t *testing.T) {
 		}
 	})
 
-	t.Run("PromotesAlreadyQueuedMessageAfterLimitReached", func(t *testing.T) {
+	t.Run("RejectsQueuedMessagePromotionAfterLimitReached", func(t *testing.T) {
 		t.Parallel()
 
 		ctx := testutil.Context(t, testutil.WaitLong)
 		client, db := newChatClientWithDatabase(t)
 		user := coderdtest.CreateFirstUser(t, client.Client)
 		modelConfig := createChatModelConfig(t, client)
-		enableDailyChatUsageLimit(ctx, t, db, 100)
+		wantResetsAt := enableDailyChatUsageLimit(ctx, t, db, 100)
 
 		chat, err := db.InsertChat(dbauthz.AsSystemRestricted(ctx), database.InsertChatParams{
 			Status:            database.ChatStatusWaiting,
@@ -6069,29 +6069,34 @@ func TestPromoteChatQueuedMessage(t *testing.T) {
 		)
 		require.NoError(t, err)
 		defer promoteRes.Body.Close()
-		require.Equal(t, http.StatusOK, promoteRes.StatusCode)
+		require.Equal(t, http.StatusConflict, promoteRes.StatusCode)
 
-		var promoted codersdk.ChatMessage
-		err = json.NewDecoder(promoteRes.Body).Decode(&promoted)
+		var limitErr codersdk.ChatUsageLimitExceededResponse
+		err = json.NewDecoder(promoteRes.Body).Decode(&limitErr)
 		require.NoError(t, err)
-		require.NotZero(t, promoted.ID)
-		require.Equal(t, chat.ID, promoted.ChatID)
-		require.Equal(t, codersdk.ChatMessageRoleUser, promoted.Role)
-
-		foundPromotedText := false
-		for _, part := range promoted.Content {
-			if part.Type == codersdk.ChatMessagePartTypeText && part.Text == queuedText {
-				foundPromotedText = true
-				break
-			}
-		}
-		require.True(t, foundPromotedText)
+		require.Equal(t, "Chat usage limit exceeded.", limitErr.Message)
+		require.Equal(t, "account_period", limitErr.Scope)
+		require.Equal(t, int64(100), limitErr.SpentMicros)
+		require.Equal(t, int64(100), limitErr.LimitMicros)
+		require.NotNil(t, limitErr.ResetsAt)
+		require.True(
+			t,
+			limitErr.ResetsAt.Equal(wantResetsAt),
+			"expected resets_at %s, got %s",
+			wantResetsAt.UTC().Format(time.RFC3339),
+			limitErr.ResetsAt.UTC().Format(time.RFC3339),
+		)
 
 		queuedMessages, err := db.GetChatQueuedMessages(dbauthz.AsSystemRestricted(ctx), chat.ID)
 		require.NoError(t, err)
+		foundQueuedMessage := false
 		for _, queued := range queuedMessages {
-			require.NotEqual(t, queuedMessage.ID, queued.ID)
+			if queued.ID == queuedMessage.ID {
+				foundQueuedMessage = true
+				break
+			}
 		}
+		require.True(t, foundQueuedMessage)
 	})
 
 	t.Run("InvalidQueuedMessageID", func(t *testing.T) {

--- a/coderd/httpmw/chatparam_test.go
+++ b/coderd/httpmw/chatparam_test.go
@@ -69,7 +69,7 @@ func TestChatParam(t *testing.T) {
 			ParentChatID:      uuid.NullUUID{},
 			RootChatID:        uuid.NullUUID{},
 			LastModelConfigID: modelConfig.ID,
-			Title:             "Test chat",
+			Title:             "Test chat", SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -1031,10 +1031,8 @@ func (p *Server) SendMessage(
 		}
 
 		// Enforce usage limits before queueing or inserting.
-		if lockedChat.SpendLimitMicros.Valid {
-			if limitErr := p.checkChatSpendLimit(ctx, tx, lockedChat.ID, lockedChat.SpendLimitMicros.Int64); limitErr != nil {
-				return limitErr
-			}
+		if limitErr := p.checkChatTreeSpendLimit(ctx, tx, lockedChat); limitErr != nil {
+			return limitErr
 		}
 		if limitErr := p.checkUsageLimit(ctx, tx, lockedChat.OwnerID); limitErr != nil {
 			return limitErr
@@ -1158,21 +1156,55 @@ func (p *Server) SendMessage(
 	return result, nil
 }
 
-func (p *Server) checkChatSpendLimit(ctx context.Context, store database.Store, chatID uuid.UUID, limitMicros int64) error {
-	spent, err := store.GetChatSpendTotal(ctx, chatID)
+// checkChatTreeSpendLimit resolves the root chat's lifetime spend limit
+// and checks whether the tree's total spend has reached or exceeded it.
+// It fails open (allows the message) on any lookup error.
+func (p *Server) checkChatTreeSpendLimit(ctx context.Context, store database.Store, chat database.Chat) error {
+	// Resolve root chat ID: prefer RootChatID, then ParentChatID, then own ID.
+	rootChatID := chat.ID
+	if chat.RootChatID.Valid {
+		rootChatID = chat.RootChatID.UUID
+	} else if chat.ParentChatID.Valid {
+		rootChatID = chat.ParentChatID.UUID
+	}
+
+	// Read the spend limit. For root chats use the passed-in chat directly;
+	// for child chats fetch the root row.
+	var limitMicros int64
+	if rootChatID == chat.ID {
+		if !chat.SpendLimitMicros.Valid {
+			return nil
+		}
+		limitMicros = chat.SpendLimitMicros.Int64
+	} else {
+		rootChat, err := store.GetChatByID(ctx, rootChatID)
+		if err != nil {
+			p.logger.Warn(ctx, "failed to look up root chat for spend-limit check, allowing message",
+				slog.F("root_chat_id", rootChatID),
+				slog.Error(err),
+			)
+			return nil
+		}
+		if !rootChat.SpendLimitMicros.Valid {
+			return nil
+		}
+		limitMicros = rootChat.SpendLimitMicros.Int64
+	}
+
+	spent, err := store.GetChatTreeSpendTotal(ctx, rootChatID)
 	if err != nil {
-		p.logger.Warn(ctx, "chat spend lookup failed, allowing message",
-			slog.F("chat_id", chatID),
+		p.logger.Warn(ctx, "failed to look up tree spend total, allowing message",
+			slog.F("root_chat_id", rootChatID),
 			slog.Error(err),
 		)
 		return nil
 	}
+
 	if spent >= limitMicros {
 		return &UsageLimitExceededError{
 			Scope:          "chat_lifetime",
 			LimitMicros:    limitMicros,
 			ConsumedMicros: spent,
-			PeriodEnd:      nil,
 		}
 	}
 	return nil
@@ -1234,10 +1266,8 @@ func (p *Server) EditMessage(
 			return xerrors.Errorf("lock chat: %w", err)
 		}
 
-		if lockedChat.SpendLimitMicros.Valid {
-			if limitErr := p.checkChatSpendLimit(ctx, tx, lockedChat.ID, lockedChat.SpendLimitMicros.Int64); limitErr != nil {
-				return limitErr
-			}
+		if limitErr := p.checkChatTreeSpendLimit(ctx, tx, lockedChat); limitErr != nil {
+			return limitErr
 		}
 		if limitErr := p.checkUsageLimit(ctx, tx, lockedChat.OwnerID); limitErr != nil {
 			return limitErr
@@ -1498,10 +1528,8 @@ func (p *Server) PromoteQueued(
 		if err != nil {
 			return xerrors.Errorf("lock chat: %w", err)
 		}
-		if lockedChat.SpendLimitMicros.Valid {
-			if limitErr := p.checkChatSpendLimit(ctx, tx, lockedChat.ID, lockedChat.SpendLimitMicros.Int64); limitErr != nil {
-				return limitErr
-			}
+		if limitErr := p.checkChatTreeSpendLimit(ctx, tx, lockedChat); limitErr != nil {
+			return limitErr
 		}
 		if limitErr := p.checkUsageLimit(ctx, tx, lockedChat.OwnerID); limitErr != nil {
 			return limitErr

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -749,7 +749,8 @@ func formatMicrosAsDollars(micros int64) string {
 
 func (e *UsageLimitExceededError) Error() string {
 	msg := fmt.Sprintf(
-		"usage limit exceeded: spent %s of %s limit",
+		"usage limit exceeded (scope: %s): spent %s of %s limit",
+		e.Scope,
 		formatMicrosAsDollars(e.ConsumedMicros),
 		formatMicrosAsDollars(e.LimitMicros),
 	)
@@ -1156,9 +1157,12 @@ func (p *Server) SendMessage(
 	return result, nil
 }
 
-// checkChatTreeSpendLimit resolves the root chat's lifetime spend limit
-// and checks whether the tree's total spend has reached or exceeded it.
-// It fails open (allows the message) on any lookup error.
+// checkChatTreeSpendLimit enforces the root chat's lifetime spend
+// cap against the cumulative cost of all messages in the chat tree.
+// It fails open: if the root chat or tree spend total cannot be
+// resolved, the message is allowed and a warning is logged. This
+// matches the account-period limit's fail-open behavior and avoids
+// blocking users when the database is temporarily degraded.
 func (p *Server) checkChatTreeSpendLimit(ctx context.Context, store database.Store, chat database.Chat) error {
 	// Resolve root chat ID: prefer RootChatID, then ParentChatID, then own ID.
 	rootChatID := chat.ID
@@ -1189,6 +1193,16 @@ func (p *Server) checkChatTreeSpendLimit(ctx context.Context, store database.Sto
 			return nil
 		}
 		limitMicros = rootChat.SpendLimitMicros.Int64
+	}
+
+	if limitMicros <= 0 {
+		// Should never happen due to CHECK constraint, but fail open
+		// to avoid blocking users on data corruption.
+		p.logger.Warn(ctx, "chat tree spend limit is non-positive, allowing message",
+			slog.F("root_chat_id", rootChatID),
+			slog.F("limit_micros", limitMicros),
+		)
+		return nil
 	}
 
 	spent, err := store.GetChatTreeSpendTotal(ctx, rootChatID)

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -880,7 +880,7 @@ func (p *Server) CreateChat(ctx context.Context, opts CreateOptions) (database.C
 			Labels: pqtype.NullRawMessage{
 				RawMessage: labelsJSON,
 				Valid:      true,
-			},
+			}, SpendLimitMicros: sql.NullInt64{},
 		})
 		if err != nil {
 			return xerrors.Errorf("insert chat: %w", err)

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -737,9 +737,10 @@ var (
 // UsageLimitExceededError indicates the user has exceeded their chat spend
 // limit.
 type UsageLimitExceededError struct {
+	Scope          string
 	LimitMicros    int64
 	ConsumedMicros int64
-	PeriodEnd      time.Time
+	PeriodEnd      *time.Time
 }
 
 func formatMicrosAsDollars(micros int64) string {
@@ -747,12 +748,15 @@ func formatMicrosAsDollars(micros int64) string {
 }
 
 func (e *UsageLimitExceededError) Error() string {
-	return fmt.Sprintf(
-		"usage limit exceeded: spent %s of %s limit, resets at %s",
+	msg := fmt.Sprintf(
+		"usage limit exceeded: spent %s of %s limit",
 		formatMicrosAsDollars(e.ConsumedMicros),
 		formatMicrosAsDollars(e.LimitMicros),
-		e.PeriodEnd.Format(time.RFC3339),
 	)
+	if e.PeriodEnd != nil {
+		msg += fmt.Sprintf(", resets at %s", e.PeriodEnd.Format(time.RFC3339))
+	}
+	return msg
 }
 
 // CreateOptions controls chat creation in the shared chat mutation path.
@@ -770,6 +774,7 @@ type CreateOptions struct {
 	InitialUserContent []codersdk.ChatMessagePart
 	MCPServerIDs       []uuid.UUID
 	Labels             database.StringMap
+	SpendLimitMicros   *int64
 }
 
 // SendMessageBusyBehavior controls what happens when a chat is already active.
@@ -830,6 +835,13 @@ type PromoteQueuedResult struct {
 	PromotedMessage database.ChatMessage
 }
 
+func int64PtrToNullInt64(p *int64) sql.NullInt64 {
+	if p == nil {
+		return sql.NullInt64{}
+	}
+	return sql.NullInt64{Int64: *p, Valid: true}
+}
+
 // CreateChat creates a chat, inserts optional system prompt and initial user
 // message, and moves the chat into pending status.
 func (p *Server) CreateChat(ctx context.Context, opts CreateOptions) (database.Chat, error) {
@@ -880,7 +892,8 @@ func (p *Server) CreateChat(ctx context.Context, opts CreateOptions) (database.C
 			Labels: pqtype.NullRawMessage{
 				RawMessage: labelsJSON,
 				Valid:      true,
-			}, SpendLimitMicros: sql.NullInt64{},
+			},
+			SpendLimitMicros: int64PtrToNullInt64(opts.SpendLimitMicros),
 		})
 		if err != nil {
 			return xerrors.Errorf("insert chat: %w", err)
@@ -1018,6 +1031,11 @@ func (p *Server) SendMessage(
 		}
 
 		// Enforce usage limits before queueing or inserting.
+		if lockedChat.SpendLimitMicros.Valid {
+			if limitErr := p.checkChatSpendLimit(ctx, tx, lockedChat.ID, lockedChat.SpendLimitMicros.Int64); limitErr != nil {
+				return limitErr
+			}
+		}
 		if limitErr := p.checkUsageLimit(ctx, tx, lockedChat.OwnerID); limitErr != nil {
 			return limitErr
 		}
@@ -1140,6 +1158,26 @@ func (p *Server) SendMessage(
 	return result, nil
 }
 
+func (p *Server) checkChatSpendLimit(ctx context.Context, store database.Store, chatID uuid.UUID, limitMicros int64) error {
+	spent, err := store.GetChatSpendTotal(ctx, chatID)
+	if err != nil {
+		p.logger.Warn(ctx, "chat spend lookup failed, allowing message",
+			slog.F("chat_id", chatID),
+			slog.Error(err),
+		)
+		return nil
+	}
+	if spent >= limitMicros {
+		return &UsageLimitExceededError{
+			Scope:          "chat_lifetime",
+			LimitMicros:    limitMicros,
+			ConsumedMicros: spent,
+			PeriodEnd:      nil,
+		}
+	}
+	return nil
+}
+
 func (p *Server) checkUsageLimit(ctx context.Context, store database.Store, ownerID uuid.UUID) error {
 	status, err := ResolveUsageLimitStatus(ctx, store, ownerID, time.Now())
 	if err != nil {
@@ -1156,10 +1194,12 @@ func (p *Server) checkUsageLimit(ctx context.Context, store database.Store, owne
 	// Block when current spend reaches or exceeds limit (>= ensures
 	// the user cannot start new conversations once the limit is hit).
 	if status.SpendLimitMicros != nil && status.CurrentSpend >= *status.SpendLimitMicros {
+		periodEnd := status.PeriodEnd
 		return &UsageLimitExceededError{
+			Scope:          "account_period",
 			LimitMicros:    *status.SpendLimitMicros,
 			ConsumedMicros: status.CurrentSpend,
-			PeriodEnd:      status.PeriodEnd,
+			PeriodEnd:      &periodEnd,
 		}
 	}
 	return nil
@@ -1194,6 +1234,11 @@ func (p *Server) EditMessage(
 			return xerrors.Errorf("lock chat: %w", err)
 		}
 
+		if lockedChat.SpendLimitMicros.Valid {
+			if limitErr := p.checkChatSpendLimit(ctx, tx, lockedChat.ID, lockedChat.SpendLimitMicros.Int64); limitErr != nil {
+				return limitErr
+			}
+		}
 		if limitErr := p.checkUsageLimit(ctx, tx, lockedChat.OwnerID); limitErr != nil {
 			return limitErr
 		}
@@ -1452,6 +1497,14 @@ func (p *Server) PromoteQueued(
 		lockedChat, err := tx.GetChatByIDForUpdate(ctx, opts.ChatID)
 		if err != nil {
 			return xerrors.Errorf("lock chat: %w", err)
+		}
+		if lockedChat.SpendLimitMicros.Valid {
+			if limitErr := p.checkChatSpendLimit(ctx, tx, lockedChat.ID, lockedChat.SpendLimitMicros.Int64); limitErr != nil {
+				return limitErr
+			}
+		}
+		if limitErr := p.checkUsageLimit(ctx, tx, lockedChat.OwnerID); limitErr != nil {
+			return limitErr
 		}
 		modelConfigID := lockedChat.LastModelConfigID
 		if opts.ModelConfigID != nil {

--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -1319,6 +1319,98 @@ func TestSendMessageRejectsWhenChatSpendLimitReached(t *testing.T) {
 	require.Equal(t, int64(100), limitErr.ConsumedMicros)
 }
 
+func TestSendMessageOnChildRejectsWhenTreeSpendLimitReached(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+	replica := newTestServer(t, db, ps, uuid.New())
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	user, model := seedChatDependencies(ctx, t, db)
+
+	rootChat, err := db.InsertChat(ctx, database.InsertChatParams{
+		Status:            database.ChatStatusWaiting,
+		OwnerID:           user.ID,
+		Title:             "chat-tree-spend-limit-root",
+		LastModelConfigID: model.ID,
+		SpendLimitMicros:  sql.NullInt64{Int64: 1000, Valid: true},
+	})
+	require.NoError(t, err)
+
+	childChat, err := db.InsertChat(ctx, database.InsertChatParams{
+		Status:            database.ChatStatusWaiting,
+		OwnerID:           user.ID,
+		Title:             "chat-tree-spend-limit-child",
+		LastModelConfigID: model.ID,
+		ParentChatID:      uuid.NullUUID{UUID: rootChat.ID, Valid: true},
+		RootChatID:        uuid.NullUUID{UUID: rootChat.ID, Valid: true},
+		SpendLimitMicros:  sql.NullInt64{},
+	})
+	require.NoError(t, err)
+
+	insertChatMessage(ctx, t, db, rootChat.ID, uuid.Nil, model.ID, database.ChatMessageRoleAssistant, "assistant", 1000)
+
+	_, err = replica.SendMessage(ctx, chatd.SendMessageOptions{
+		ChatID:       childChat.ID,
+		CreatedBy:    user.ID,
+		Content:      []codersdk.ChatMessagePart{codersdk.ChatMessageText("hello")},
+		BusyBehavior: chatd.SendMessageBusyBehaviorQueue,
+	})
+	require.Error(t, err)
+
+	var limitErr *chatd.UsageLimitExceededError
+	require.ErrorAs(t, err, &limitErr)
+	require.Equal(t, "chat_lifetime", limitErr.Scope)
+	require.Equal(t, int64(1000), limitErr.LimitMicros)
+	require.Equal(t, int64(1000), limitErr.ConsumedMicros)
+}
+
+func TestSendMessageOnRootRejectsWhenChildSpendPushesOverLimit(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+	replica := newTestServer(t, db, ps, uuid.New())
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	user, model := seedChatDependencies(ctx, t, db)
+
+	rootChat, err := db.InsertChat(ctx, database.InsertChatParams{
+		Status:            database.ChatStatusWaiting,
+		OwnerID:           user.ID,
+		Title:             "chat-tree-spend-limit-root-send",
+		LastModelConfigID: model.ID,
+		SpendLimitMicros:  sql.NullInt64{Int64: 1000, Valid: true},
+	})
+	require.NoError(t, err)
+
+	childChat, err := db.InsertChat(ctx, database.InsertChatParams{
+		Status:            database.ChatStatusWaiting,
+		OwnerID:           user.ID,
+		Title:             "chat-tree-spend-limit-child-send",
+		LastModelConfigID: model.ID,
+		ParentChatID:      uuid.NullUUID{UUID: rootChat.ID, Valid: true},
+		RootChatID:        uuid.NullUUID{UUID: rootChat.ID, Valid: true},
+		SpendLimitMicros:  sql.NullInt64{},
+	})
+	require.NoError(t, err)
+
+	insertChatMessage(ctx, t, db, childChat.ID, uuid.Nil, model.ID, database.ChatMessageRoleAssistant, "assistant", 1000)
+
+	_, err = replica.SendMessage(ctx, chatd.SendMessageOptions{
+		ChatID:       rootChat.ID,
+		CreatedBy:    user.ID,
+		Content:      []codersdk.ChatMessagePart{codersdk.ChatMessageText("hello")},
+		BusyBehavior: chatd.SendMessageBusyBehaviorQueue,
+	})
+	require.Error(t, err)
+
+	var limitErr *chatd.UsageLimitExceededError
+	require.ErrorAs(t, err, &limitErr)
+	require.Equal(t, "chat_lifetime", limitErr.Scope)
+	require.Equal(t, int64(1000), limitErr.LimitMicros)
+	require.Equal(t, int64(1000), limitErr.ConsumedMicros)
+}
+
 func TestEditMessageRejectsWhenChatSpendLimitReached(t *testing.T) {
 	t.Parallel()
 

--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -914,7 +914,7 @@ func TestCreateChatRejectsWhenUsageLimitReached(t *testing.T) {
 		Status:            database.ChatStatusWaiting,
 		OwnerID:           user.ID,
 		Title:             "existing-limit-chat",
-		LastModelConfigID: model.ID,
+		LastModelConfigID: model.ID, SpendLimitMicros: sql.NullInt64{},
 	})
 	require.NoError(t, err)
 
@@ -1209,7 +1209,7 @@ func TestInterruptAutoPromotionIgnoresLaterUsageLimitIncrease(t *testing.T) {
 		RootChatID:        uuid.NullUUID{},
 		LastModelConfigID: model.ID,
 		Title:             "other-spend",
-		Mode:              database.NullChatMode{},
+		Mode:              database.NullChatMode{}, SpendLimitMicros: sql.NullInt64{},
 	})
 	require.NoError(t, err)
 
@@ -1456,7 +1456,7 @@ func TestRecoverStaleChatsPeriodically(t *testing.T) {
 		Status:            database.ChatStatusWaiting,
 		OwnerID:           user.ID,
 		Title:             "stale-recovery-periodic",
-		LastModelConfigID: model.ID,
+		LastModelConfigID: model.ID, SpendLimitMicros: sql.NullInt64{},
 	})
 	require.NoError(t, err)
 
@@ -1502,7 +1502,7 @@ func TestRecoverStaleChatsPeriodically(t *testing.T) {
 		Status:            database.ChatStatusWaiting,
 		OwnerID:           user.ID,
 		Title:             "stale-recovery-periodic-2",
-		LastModelConfigID: model.ID,
+		LastModelConfigID: model.ID, SpendLimitMicros: sql.NullInt64{},
 	})
 	require.NoError(t, err)
 
@@ -1541,7 +1541,7 @@ func TestNewReplicaRecoversStaleChatFromDeadReplica(t *testing.T) {
 		Status:            database.ChatStatusWaiting,
 		OwnerID:           user.ID,
 		Title:             "orphaned-chat",
-		LastModelConfigID: model.ID,
+		LastModelConfigID: model.ID, SpendLimitMicros: sql.NullInt64{},
 	})
 	require.NoError(t, err)
 
@@ -1584,7 +1584,7 @@ func TestWaitingChatsAreNotRecoveredAsStale(t *testing.T) {
 		Status:            database.ChatStatusWaiting,
 		OwnerID:           user.ID,
 		Title:             "waiting-chat",
-		LastModelConfigID: model.ID,
+		LastModelConfigID: model.ID, SpendLimitMicros: sql.NullInt64{},
 	})
 	require.NoError(t, err)
 
@@ -1627,7 +1627,7 @@ func TestUpdateChatStatusPersistsLastError(t *testing.T) {
 		Status:            database.ChatStatusWaiting,
 		OwnerID:           user.ID,
 		Title:             "error-persisted",
-		LastModelConfigID: model.ID,
+		LastModelConfigID: model.ID, SpendLimitMicros: sql.NullInt64{},
 	})
 	require.NoError(t, err)
 

--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -1019,7 +1019,7 @@ func TestCreateChatRejectsWhenUsageLimitReached(t *testing.T) {
 	require.Len(t, afterChats, len(beforeChats))
 }
 
-func TestPromoteQueuedAllowsAlreadyQueuedMessageWhenUsageLimitReached(t *testing.T) {
+func TestPromoteQueuedRejectsWhenAccountLimitReached(t *testing.T) {
 	t.Parallel()
 
 	db, ps := dbtestutil.NewDB(t)

--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -54,6 +54,49 @@ import (
 	"github.com/coder/quartz"
 )
 
+func insertChatMessage(
+	ctx context.Context,
+	t *testing.T,
+	db database.Store,
+	chatID uuid.UUID,
+	createdBy uuid.UUID,
+	modelConfigID uuid.UUID,
+	role database.ChatMessageRole,
+	text string,
+	totalCostMicros int64,
+) database.ChatMessage {
+	t.Helper()
+
+	content, err := chatprompt.MarshalParts([]codersdk.ChatMessagePart{
+		codersdk.ChatMessageText(text),
+	})
+	require.NoError(t, err)
+
+	messages, err := db.InsertChatMessages(ctx, database.InsertChatMessagesParams{
+		ChatID:              chatID,
+		CreatedBy:           []uuid.UUID{createdBy},
+		ModelConfigID:       []uuid.UUID{modelConfigID},
+		Role:                []database.ChatMessageRole{role},
+		ContentVersion:      []int16{chatprompt.CurrentContentVersion},
+		Content:             []string{string(content.RawMessage)},
+		Visibility:          []database.ChatMessageVisibility{database.ChatMessageVisibilityBoth},
+		InputTokens:         []int64{0},
+		OutputTokens:        []int64{0},
+		TotalTokens:         []int64{0},
+		ReasoningTokens:     []int64{0},
+		CacheCreationTokens: []int64{0},
+		CacheReadTokens:     []int64{0},
+		ContextLimit:        []int64{0},
+		Compressed:          []bool{false},
+		TotalCostMicros:     []int64{totalCostMicros},
+		RuntimeMs:           []int64{0},
+	})
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+
+	return messages[0]
+}
+
 func TestInterruptChatBroadcastsStatusAcrossInstances(t *testing.T) {
 	t.Parallel()
 
@@ -1000,9 +1043,6 @@ func TestPromoteQueuedAllowsAlreadyQueuedMessageWhenUsageLimitReached(t *testing
 	})
 	require.NoError(t, err)
 
-	// CreateChat calls signalWake which triggers processOnce in
-	// the background. Wait for that processing to finish so it
-	// doesn't race with the manual status update below.
 	waitForChatProcessed(ctx, t, db, chat.ID, replica)
 
 	chat, err = db.UpdateChatStatus(ctx, database.UpdateChatStatusParams{
@@ -1023,31 +1063,7 @@ func TestPromoteQueuedAllowsAlreadyQueuedMessageWhenUsageLimitReached(t *testing
 	require.True(t, queuedResult.Queued)
 	require.NotNil(t, queuedResult.QueuedMessage)
 
-	assistantContent, err := chatprompt.MarshalParts([]codersdk.ChatMessagePart{
-		codersdk.ChatMessageText("assistant"),
-	})
-	require.NoError(t, err)
-
-	_, err = db.InsertChatMessages(ctx, database.InsertChatMessagesParams{
-		ChatID:              chat.ID,
-		CreatedBy:           []uuid.UUID{uuid.Nil},
-		ModelConfigID:       []uuid.UUID{model.ID},
-		Role:                []database.ChatMessageRole{database.ChatMessageRoleAssistant},
-		ContentVersion:      []int16{chatprompt.CurrentContentVersion},
-		Content:             []string{string(assistantContent.RawMessage)},
-		Visibility:          []database.ChatMessageVisibility{database.ChatMessageVisibilityBoth},
-		InputTokens:         []int64{0},
-		OutputTokens:        []int64{0},
-		TotalTokens:         []int64{0},
-		ReasoningTokens:     []int64{0},
-		CacheCreationTokens: []int64{0},
-		CacheReadTokens:     []int64{0},
-		ContextLimit:        []int64{0},
-		Compressed:          []bool{false},
-		TotalCostMicros:     []int64{100},
-		RuntimeMs:           []int64{0},
-	})
-	require.NoError(t, err)
+	insertChatMessage(ctx, t, db, chat.ID, uuid.Nil, model.ID, database.ChatMessageRoleAssistant, "assistant", 100)
 
 	chat, err = db.UpdateChatStatus(ctx, database.UpdateChatStatusParams{
 		ID:          chat.ID,
@@ -1059,25 +1075,16 @@ func TestPromoteQueuedAllowsAlreadyQueuedMessageWhenUsageLimitReached(t *testing
 	})
 	require.NoError(t, err)
 
-	result, err := replica.PromoteQueued(ctx, chatd.PromoteQueuedOptions{
+	_, err = replica.PromoteQueued(ctx, chatd.PromoteQueuedOptions{
 		ChatID:          chat.ID,
 		QueuedMessageID: queuedResult.QueuedMessage.ID,
 		CreatedBy:       user.ID,
 	})
-	require.NoError(t, err)
-	require.Equal(t, database.ChatMessageRoleUser, result.PromotedMessage.Role)
+	require.Error(t, err)
 
-	queued, err := db.GetChatQueuedMessages(ctx, chat.ID)
-	require.NoError(t, err)
-	require.Empty(t, queued)
-
-	messages, err := db.GetChatMessagesByChatID(ctx, database.GetChatMessagesByChatIDParams{
-		ChatID:  chat.ID,
-		AfterID: 0,
-	})
-	require.NoError(t, err)
-	require.Len(t, messages, 3)
-	require.Equal(t, database.ChatMessageRoleUser, messages[2].Role)
+	var limitErr *chatd.UsageLimitExceededError
+	require.ErrorAs(t, err, &limitErr)
+	require.Equal(t, "account_period", limitErr.Scope)
 }
 
 func TestInterruptAutoPromotionIgnoresLaterUsageLimitIncrease(t *testing.T) {
@@ -1277,7 +1284,88 @@ func TestInterruptAutoPromotionIgnoresLaterUsageLimitIncrease(t *testing.T) {
 	require.Equal(t, []string{"hello", "queued", "later queued"}, userTexts)
 }
 
-func TestEditMessageRejectsWhenUsageLimitReached(t *testing.T) {
+func TestSendMessageRejectsWhenChatSpendLimitReached(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+	replica := newTestServer(t, db, ps, uuid.New())
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	user, model := seedChatDependencies(ctx, t, db)
+
+	chat, err := db.InsertChat(ctx, database.InsertChatParams{
+		Status:            database.ChatStatusWaiting,
+		OwnerID:           user.ID,
+		Title:             "chat-spend-limit-send",
+		LastModelConfigID: model.ID,
+		SpendLimitMicros:  sql.NullInt64{Int64: 100, Valid: true},
+	})
+	require.NoError(t, err)
+
+	insertChatMessage(ctx, t, db, chat.ID, uuid.Nil, model.ID, database.ChatMessageRoleAssistant, "assistant", 100)
+
+	_, err = replica.SendMessage(ctx, chatd.SendMessageOptions{
+		ChatID:       chat.ID,
+		CreatedBy:    user.ID,
+		Content:      []codersdk.ChatMessagePart{codersdk.ChatMessageText("hello")},
+		BusyBehavior: chatd.SendMessageBusyBehaviorQueue,
+	})
+	require.Error(t, err)
+
+	var limitErr *chatd.UsageLimitExceededError
+	require.ErrorAs(t, err, &limitErr)
+	require.Equal(t, "chat_lifetime", limitErr.Scope)
+	require.Equal(t, int64(100), limitErr.LimitMicros)
+	require.Equal(t, int64(100), limitErr.ConsumedMicros)
+}
+
+func TestEditMessageRejectsWhenChatSpendLimitReached(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+	replica := newTestServer(t, db, ps, uuid.New())
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	user, model := seedChatDependencies(ctx, t, db)
+
+	chat, err := db.InsertChat(ctx, database.InsertChatParams{
+		Status:            database.ChatStatusWaiting,
+		OwnerID:           user.ID,
+		Title:             "chat-spend-limit-edit",
+		LastModelConfigID: model.ID,
+		SpendLimitMicros:  sql.NullInt64{Int64: 100, Valid: true},
+	})
+	require.NoError(t, err)
+
+	originalMessage := insertChatMessage(ctx, t, db, chat.ID, user.ID, model.ID, database.ChatMessageRoleUser, "original", 0)
+	insertChatMessage(ctx, t, db, chat.ID, uuid.Nil, model.ID, database.ChatMessageRoleAssistant, "assistant", 100)
+
+	_, err = replica.EditMessage(ctx, chatd.EditMessageOptions{
+		ChatID:          chat.ID,
+		CreatedBy:       user.ID,
+		EditedMessageID: originalMessage.ID,
+		Content:         []codersdk.ChatMessagePart{codersdk.ChatMessageText("edited")},
+	})
+	require.Error(t, err)
+
+	var limitErr *chatd.UsageLimitExceededError
+	require.ErrorAs(t, err, &limitErr)
+	require.Equal(t, "chat_lifetime", limitErr.Scope)
+	require.Equal(t, int64(100), limitErr.LimitMicros)
+	require.Equal(t, int64(100), limitErr.ConsumedMicros)
+
+	messages, err := db.GetChatMessagesByChatID(ctx, database.GetChatMessagesByChatIDParams{
+		ChatID:  chat.ID,
+		AfterID: 0,
+	})
+	require.NoError(t, err)
+	require.Len(t, messages, 2)
+	sdkMessage := db2sdk.ChatMessage(messages[0])
+	require.Len(t, sdkMessage.Content, 1)
+	require.Equal(t, "original", sdkMessage.Content[0].Text)
+}
+
+func TestSendMessageRejectsWhenAccountPeriodLimitReachedWithoutChatCap(t *testing.T) {
 	t.Parallel()
 
 	db, ps := dbtestutil.NewDB(t)
@@ -1293,69 +1381,72 @@ func TestEditMessageRejectsWhenUsageLimitReached(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	chat, err := replica.CreateChat(ctx, chatd.CreateOptions{
-		OwnerID:            user.ID,
-		Title:              "edit-limit-reached",
-		ModelConfigID:      model.ID,
-		InitialUserContent: []codersdk.ChatMessagePart{codersdk.ChatMessageText("original")},
+	chat, err := db.InsertChat(ctx, database.InsertChatParams{
+		Status:            database.ChatStatusWaiting,
+		OwnerID:           user.ID,
+		Title:             "account-period-limit-send",
+		LastModelConfigID: model.ID,
+		SpendLimitMicros:  sql.NullInt64{},
 	})
 	require.NoError(t, err)
 
-	messages, err := db.GetChatMessagesByChatID(ctx, database.GetChatMessagesByChatIDParams{
-		ChatID:  chat.ID,
-		AfterID: 0,
-	})
-	require.NoError(t, err)
-	require.Len(t, messages, 1)
-	editedMessageID := messages[0].ID
+	insertChatMessage(ctx, t, db, chat.ID, uuid.Nil, model.ID, database.ChatMessageRoleAssistant, "assistant", 100)
 
-	assistantContent, err := chatprompt.MarshalParts([]codersdk.ChatMessagePart{
-		codersdk.ChatMessageText("assistant"),
-	})
-	require.NoError(t, err)
-
-	_, err = db.InsertChatMessages(ctx, database.InsertChatMessagesParams{
-		ChatID:              chat.ID,
-		CreatedBy:           []uuid.UUID{uuid.Nil},
-		ModelConfigID:       []uuid.UUID{model.ID},
-		Role:                []database.ChatMessageRole{database.ChatMessageRoleAssistant},
-		ContentVersion:      []int16{chatprompt.CurrentContentVersion},
-		Content:             []string{string(assistantContent.RawMessage)},
-		Visibility:          []database.ChatMessageVisibility{database.ChatMessageVisibilityBoth},
-		InputTokens:         []int64{0},
-		OutputTokens:        []int64{0},
-		TotalTokens:         []int64{0},
-		ReasoningTokens:     []int64{0},
-		CacheCreationTokens: []int64{0},
-		CacheReadTokens:     []int64{0},
-		ContextLimit:        []int64{0},
-		Compressed:          []bool{false},
-		TotalCostMicros:     []int64{100},
-		RuntimeMs:           []int64{0},
-	})
-	require.NoError(t, err)
-
-	_, err = replica.EditMessage(ctx, chatd.EditMessageOptions{
-		ChatID:          chat.ID,
-		EditedMessageID: editedMessageID,
-		Content:         []codersdk.ChatMessagePart{codersdk.ChatMessageText("edited")},
+	_, err = replica.SendMessage(ctx, chatd.SendMessageOptions{
+		ChatID:       chat.ID,
+		CreatedBy:    user.ID,
+		Content:      []codersdk.ChatMessagePart{codersdk.ChatMessageText("hello")},
+		BusyBehavior: chatd.SendMessageBusyBehaviorQueue,
 	})
 	require.Error(t, err)
 
 	var limitErr *chatd.UsageLimitExceededError
 	require.ErrorAs(t, err, &limitErr)
+	require.Equal(t, "account_period", limitErr.Scope)
 	require.Equal(t, int64(100), limitErr.LimitMicros)
 	require.Equal(t, int64(100), limitErr.ConsumedMicros)
+}
 
-	messages, err = db.GetChatMessagesByChatID(ctx, database.GetChatMessagesByChatIDParams{
-		ChatID:  chat.ID,
-		AfterID: 0,
+func TestSendMessagePrefersChatSpendLimitOverAccountPeriodLimit(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+	replica := newTestServer(t, db, ps, uuid.New())
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	user, model := seedChatDependencies(ctx, t, db)
+
+	_, err := db.UpsertChatUsageLimitConfig(ctx, database.UpsertChatUsageLimitConfigParams{
+		Enabled:            true,
+		DefaultLimitMicros: 200,
+		Period:             string(codersdk.ChatUsageLimitPeriodDay),
 	})
 	require.NoError(t, err)
-	require.Len(t, messages, 2)
-	originalMessage := db2sdk.ChatMessage(messages[0])
-	require.Len(t, originalMessage.Content, 1)
-	require.Equal(t, "original", originalMessage.Content[0].Text)
+
+	chat, err := db.InsertChat(ctx, database.InsertChatParams{
+		Status:            database.ChatStatusWaiting,
+		OwnerID:           user.ID,
+		Title:             "prefer-chat-spend-limit",
+		LastModelConfigID: model.ID,
+		SpendLimitMicros:  sql.NullInt64{Int64: 100, Valid: true},
+	})
+	require.NoError(t, err)
+
+	insertChatMessage(ctx, t, db, chat.ID, uuid.Nil, model.ID, database.ChatMessageRoleAssistant, "assistant", 100)
+
+	_, err = replica.SendMessage(ctx, chatd.SendMessageOptions{
+		ChatID:       chat.ID,
+		CreatedBy:    user.ID,
+		Content:      []codersdk.ChatMessagePart{codersdk.ChatMessageText("hello")},
+		BusyBehavior: chatd.SendMessageBusyBehaviorQueue,
+	})
+	require.Error(t, err)
+
+	var limitErr *chatd.UsageLimitExceededError
+	require.ErrorAs(t, err, &limitErr)
+	require.Equal(t, "chat_lifetime", limitErr.Scope)
+	require.Equal(t, int64(100), limitErr.LimitMicros)
+	require.Equal(t, int64(100), limitErr.ConsumedMicros)
 }
 
 func TestEditMessageRejectsMissingMessage(t *testing.T) {

--- a/coderd/x/chatd/chatprompt/chatprompt_test.go
+++ b/coderd/x/chatd/chatprompt/chatprompt_test.go
@@ -3,6 +3,7 @@ package chatprompt_test
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -1486,7 +1487,7 @@ func TestNulEscapeRoundTrip(t *testing.T) {
 		Status:            database.ChatStatusWaiting,
 		OwnerID:           user.ID,
 		LastModelConfigID: model.ID,
-		Title:             "nul-roundtrip-test",
+		Title:             "nul-roundtrip-test", SpendLimitMicros: sql.NullInt64{},
 	})
 	require.NoError(t, err)
 
@@ -1984,7 +1985,7 @@ func TestMediaToolResultRoundTrip(t *testing.T) {
 			Status:            database.ChatStatusWaiting,
 			OwnerID:           user.ID,
 			LastModelConfigID: model.ID,
-			Title:             "media-roundtrip-" + callID,
+			Title:             "media-roundtrip-" + callID, SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, chatErr)
 

--- a/coderd/x/chatd/chattool/startworkspace_test.go
+++ b/coderd/x/chatd/chattool/startworkspace_test.go
@@ -38,7 +38,7 @@ func TestStartWorkspace(t *testing.T) {
 			Status:            database.ChatStatusWaiting,
 			OwnerID:           user.ID,
 			LastModelConfigID: modelCfg.ID,
-			Title:             "test-no-workspace",
+			Title:             "test-no-workspace", SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 
@@ -82,7 +82,7 @@ func TestStartWorkspace(t *testing.T) {
 			OwnerID:           user.ID,
 			WorkspaceID:       uuid.NullUUID{UUID: ws.ID, Valid: true},
 			LastModelConfigID: modelCfg.ID,
-			Title:             "test-already-running",
+			Title:             "test-already-running", SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 
@@ -161,7 +161,7 @@ func TestStartWorkspace(t *testing.T) {
 			OwnerID:           user.ID,
 			WorkspaceID:       uuid.NullUUID{UUID: ws.ID, Valid: true},
 			LastModelConfigID: modelCfg.ID,
-			Title:             "test-running-preferred-agent",
+			Title:             "test-running-preferred-agent", SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 
@@ -221,7 +221,7 @@ func TestStartWorkspace(t *testing.T) {
 			OwnerID:           user.ID,
 			WorkspaceID:       uuid.NullUUID{UUID: ws.ID, Valid: true},
 			LastModelConfigID: modelCfg.ID,
-			Title:             "test-running-no-agent",
+			Title:             "test-running-no-agent", SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 
@@ -284,7 +284,7 @@ func TestStartWorkspace(t *testing.T) {
 			OwnerID:           user.ID,
 			WorkspaceID:       uuid.NullUUID{UUID: ws.ID, Valid: true},
 			LastModelConfigID: modelCfg.ID,
-			Title:             "test-running-selection-error",
+			Title:             "test-running-selection-error", SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 
@@ -341,7 +341,7 @@ func TestStartWorkspace(t *testing.T) {
 			OwnerID:           user.ID,
 			WorkspaceID:       uuid.NullUUID{UUID: ws.ID, Valid: true},
 			LastModelConfigID: modelCfg.ID,
-			Title:             "test-stopped-workspace",
+			Title:             "test-stopped-workspace", SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 
@@ -410,7 +410,7 @@ func TestStartWorkspace(t *testing.T) {
 			OwnerID:           user.ID,
 			WorkspaceID:       uuid.NullUUID{UUID: ws.ID, Valid: true},
 			LastModelConfigID: modelCfg.ID,
-			Title:             "test-deleted-workspace",
+			Title:             "test-deleted-workspace", SpendLimitMicros: sql.NullInt64{},
 		})
 		require.NoError(t, err)
 

--- a/coderd/x/chatd/recording_internal_test.go
+++ b/coderd/x/chatd/recording_internal_test.go
@@ -3,6 +3,7 @@ package chatd
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"io"
 	"strings"
@@ -59,7 +60,7 @@ func createComputerUseParentChild(
 		AgentID:           uuid.NullUUID{UUID: agent.ID, Valid: true},
 		LastModelConfigID: model.ID,
 		Title:             parentTitle,
-		Status:            database.ChatStatusPending,
+		Status:            database.ChatStatusPending, SpendLimitMicros: sql.NullInt64{},
 	})
 	require.NoError(t, err)
 
@@ -75,7 +76,7 @@ func createComputerUseParentChild(
 		LastModelConfigID: model.ID,
 		Title:             childTitle,
 		Mode:              database.NullChatMode{ChatMode: database.ChatModeComputerUse, Valid: true},
-		Status:            database.ChatStatusPending,
+		Status:            database.ChatStatusPending, SpendLimitMicros: sql.NullInt64{},
 	})
 	require.NoError(t, err)
 

--- a/coderd/x/gitsync/worker_test.go
+++ b/coderd/x/gitsync/worker_test.go
@@ -981,7 +981,7 @@ func TestWorker(t *testing.T) {
 		Status:            database.ChatStatusWaiting,
 		OwnerID:           user.ID,
 		LastModelConfigID: modelCfg.ID,
-		Title:             "integration-test",
+		Title:             "integration-test", SpendLimitMicros: sql.NullInt64{},
 	})
 	require.NoError(t, err)
 

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -364,13 +364,16 @@ type ChatInputPart struct {
 
 // CreateChatRequest is the request to create a new chat.
 type CreateChatRequest struct {
-	Content          []ChatInputPart   `json:"content"`
-	SystemPrompt     string            `json:"system_prompt,omitempty"`
-	WorkspaceID      *uuid.UUID        `json:"workspace_id,omitempty" format:"uuid"`
-	ModelConfigID    *uuid.UUID        `json:"model_config_id,omitempty" format:"uuid"`
-	MCPServerIDs     []uuid.UUID       `json:"mcp_server_ids,omitempty" format:"uuid"`
-	Labels           map[string]string `json:"labels,omitempty"`
-	SpendLimitMicros *int64            `json:"spend_limit_micros,omitempty"`
+	Content       []ChatInputPart   `json:"content"`
+	SystemPrompt  string            `json:"system_prompt,omitempty"`
+	WorkspaceID   *uuid.UUID        `json:"workspace_id,omitempty" format:"uuid"`
+	ModelConfigID *uuid.UUID        `json:"model_config_id,omitempty" format:"uuid"`
+	MCPServerIDs  []uuid.UUID       `json:"mcp_server_ids,omitempty" format:"uuid"`
+	Labels        map[string]string `json:"labels,omitempty"`
+	// SpendLimitMicros is the lifetime spend limit in micros for this
+	// chat tree (root plus all subagent descendants), or nil for no
+	// limit. Must be greater than zero when set.
+	SpendLimitMicros *int64 `json:"spend_limit_micros,omitempty"`
 }
 
 // UpdateChatRequest is the request to update a chat.
@@ -1083,6 +1086,12 @@ type ChatCostUsersResponse struct {
 // chat operation exceeds the caller's usage limit. The structured fields let
 // frontends render user-friendly spend, limit, and reset information without
 // parsing debug text.
+//
+// Scope determines which limit was hit:
+//   - "account_period": the user's account-level periodic budget. ResetsAt
+//     is always populated with the period boundary.
+//   - "chat_lifetime": the root chat's lifetime spend cap. ResetsAt is
+//     always nil because the limit does not reset.
 type ChatUsageLimitExceededResponse struct {
 	Response
 	Scope       string     `json:"scope"`
@@ -1134,7 +1143,8 @@ func readBodyAsChatUsageLimitError(res *http.Response) error {
 }
 
 func isChatUsageLimitExceededResponse(resp ChatUsageLimitExceededResponse) bool {
-	return resp.Message != "" && resp.Scope != ""
+	return resp.Message != "" &&
+		(resp.Scope == "account_period" || resp.Scope == "chat_lifetime")
 }
 
 func readRawBodyAsError(res *http.Response, rawBody []byte) error {

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -71,6 +71,7 @@ type Chat struct {
 	MCPServerIDs      []uuid.UUID        `json:"mcp_server_ids" format:"uuid"`
 	Labels            map[string]string  `json:"labels"`
 	Files             []ChatFileMetadata `json:"files,omitempty"`
+	SpendLimitMicros  *int64             `json:"spend_limit_micros,omitempty"`
 	// HasUnread is true when assistant messages exist beyond
 	// the owner's read cursor, which updates on stream
 	// connect and disconnect.
@@ -363,12 +364,13 @@ type ChatInputPart struct {
 
 // CreateChatRequest is the request to create a new chat.
 type CreateChatRequest struct {
-	Content       []ChatInputPart   `json:"content"`
-	SystemPrompt  string            `json:"system_prompt,omitempty"`
-	WorkspaceID   *uuid.UUID        `json:"workspace_id,omitempty" format:"uuid"`
-	ModelConfigID *uuid.UUID        `json:"model_config_id,omitempty" format:"uuid"`
-	MCPServerIDs  []uuid.UUID       `json:"mcp_server_ids,omitempty" format:"uuid"`
-	Labels        map[string]string `json:"labels,omitempty"`
+	Content          []ChatInputPart   `json:"content"`
+	SystemPrompt     string            `json:"system_prompt,omitempty"`
+	WorkspaceID      *uuid.UUID        `json:"workspace_id,omitempty" format:"uuid"`
+	ModelConfigID    *uuid.UUID        `json:"model_config_id,omitempty" format:"uuid"`
+	MCPServerIDs     []uuid.UUID       `json:"mcp_server_ids,omitempty" format:"uuid"`
+	Labels           map[string]string `json:"labels,omitempty"`
+	SpendLimitMicros *int64            `json:"spend_limit_micros,omitempty"`
 }
 
 // UpdateChatRequest is the request to update a chat.
@@ -1083,9 +1085,10 @@ type ChatCostUsersResponse struct {
 // parsing debug text.
 type ChatUsageLimitExceededResponse struct {
 	Response
-	SpentMicros int64     `json:"spent_micros"`
-	LimitMicros int64     `json:"limit_micros"`
-	ResetsAt    time.Time `json:"resets_at" format:"date-time"`
+	Scope       string     `json:"scope"`
+	SpentMicros int64      `json:"spent_micros"`
+	LimitMicros int64      `json:"limit_micros"`
+	ResetsAt    *time.Time `json:"resets_at,omitempty" format:"date-time"`
 }
 
 type chatUsageLimitExceededError struct {
@@ -1131,7 +1134,7 @@ func readBodyAsChatUsageLimitError(res *http.Response) error {
 }
 
 func isChatUsageLimitExceededResponse(resp ChatUsageLimitExceededResponse) bool {
-	return resp.Message != "" && !resp.ResetsAt.IsZero()
+	return resp.Message != "" && resp.Scope != ""
 }
 
 func readRawBodyAsError(res *http.Response, rawBody []byte) error {

--- a/codersdk/chats_test.go
+++ b/codersdk/chats_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/codersdk"
 )
 
@@ -68,11 +69,13 @@ func TestChatUsageLimitExceededFrom(t *testing.T) {
 	t.Run("ExtractsTyped409", func(t *testing.T) {
 		t.Parallel()
 
+		resetsAt := time.Date(2026, time.March, 16, 12, 0, 0, 0, time.UTC)
 		want := codersdk.ChatUsageLimitExceededResponse{
 			Response:    codersdk.Response{Message: "Chat usage limit exceeded."},
+			Scope:       "account_period",
 			SpentMicros: 123,
 			LimitMicros: 456,
-			ResetsAt:    time.Date(2026, time.March, 16, 12, 0, 0, 0, time.UTC),
+			ResetsAt:    &resetsAt,
 		}
 
 		srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
@@ -104,6 +107,46 @@ func TestChatUsageLimitExceededFrom(t *testing.T) {
 		limitErr := codersdk.ChatUsageLimitExceededFrom(err)
 		require.NotNil(t, limitErr)
 		require.Equal(t, want, *limitErr)
+		require.Equal(t, "account_period", limitErr.Scope)
+		require.NotNil(t, limitErr.ResetsAt)
+	})
+
+	t.Run("ExtractsChatLifetimeLimit", func(t *testing.T) {
+		t.Parallel()
+
+		want := codersdk.ChatUsageLimitExceededResponse{
+			Response:    codersdk.Response{Message: "Chat usage limit exceeded."},
+			Scope:       "chat_lifetime",
+			SpentMicros: 789,
+			LimitMicros: 789,
+		}
+
+		srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			require.Equal(t, http.MethodPost, r.Method)
+			require.Equal(t, "/api/experimental/chats", r.URL.Path)
+			rw.Header().Set("Content-Type", "application/json")
+			rw.WriteHeader(http.StatusConflict)
+			require.NoError(t, json.NewEncoder(rw).Encode(want))
+		}))
+		defer srv.Close()
+
+		serverURL, err := url.Parse(srv.URL)
+		require.NoError(t, err)
+
+		client := codersdk.NewExperimentalClient(codersdk.New(serverURL))
+		_, err = client.CreateChat(context.Background(), codersdk.CreateChatRequest{
+			Content: []codersdk.ChatInputPart{{
+				Type: codersdk.ChatInputPartTypeText,
+				Text: "hello",
+			}},
+		})
+		require.Error(t, err)
+
+		limitErr := codersdk.ChatUsageLimitExceededFrom(err)
+		require.NotNil(t, limitErr)
+		require.Equal(t, want, *limitErr)
+		require.Equal(t, "chat_lifetime", limitErr.Scope)
+		require.Nil(t, limitErr.ResetsAt)
 	})
 
 	t.Run("ReturnsNilForNonLimitErrors", func(t *testing.T) {
@@ -436,6 +479,7 @@ func TestChat_JSONRoundTrip(t *testing.T) {
 		Archived:          true,
 		MCPServerIDs:      []uuid.UUID{uuid.New()},
 		Labels:            map[string]string{"env": "prod"},
+		SpendLimitMicros:  ptr.Ref(int64(500000)),
 		DiffStatus: &codersdk.ChatDiffStatus{
 			ChatID:           uuid.New(),
 			URL:              &prURL,

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1201,6 +1201,7 @@ export interface Chat {
 	readonly mcp_server_ids: readonly string[];
 	readonly labels: Record<string, string>;
 	readonly files?: readonly ChatFileMetadata[];
+	readonly spend_limit_micros?: number;
 	/**
 	 * HasUnread is true when assistant messages exist beyond
 	 * the owner's read cursor, which updates on stream
@@ -2147,9 +2148,10 @@ export interface ChatUsageLimitConfigResponse extends ChatUsageLimitConfig {
  * parsing debug text.
  */
 export interface ChatUsageLimitExceededResponse extends Response {
+	readonly scope: string;
 	readonly spent_micros: number;
 	readonly limit_micros: number;
-	readonly resets_at: string;
+	readonly resets_at?: string;
 }
 
 // From codersdk/chats.go
@@ -2414,6 +2416,7 @@ export interface CreateChatRequest {
 	readonly model_config_id?: string;
 	readonly mcp_server_ids?: readonly string[];
 	readonly labels?: Record<string, string>;
+	readonly spend_limit_micros?: number;
 }
 
 // From codersdk/users.go

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2146,6 +2146,12 @@ export interface ChatUsageLimitConfigResponse extends ChatUsageLimitConfig {
  * chat operation exceeds the caller's usage limit. The structured fields let
  * frontends render user-friendly spend, limit, and reset information without
  * parsing debug text.
+ *
+ * Scope determines which limit was hit:
+ *   - "account_period": the user's account-level periodic budget. ResetsAt
+ *     is always populated with the period boundary.
+ *   - "chat_lifetime": the root chat's lifetime spend cap. ResetsAt is
+ *     always nil because the limit does not reset.
  */
 export interface ChatUsageLimitExceededResponse extends Response {
 	readonly scope: string;
@@ -2416,6 +2422,11 @@ export interface CreateChatRequest {
 	readonly model_config_id?: string;
 	readonly mcp_server_ids?: readonly string[];
 	readonly labels?: Record<string, string>;
+	/**
+	 * SpendLimitMicros is the lifetime spend limit in micros for this
+	 * chat tree (root plus all subagent descendants), or nil for no
+	 * limit. Must be greater than zero when set.
+	 */
 	readonly spend_limit_micros?: number;
 }
 


### PR DESCRIPTION
Adds an optional per-chat spend limit that governs the total cost of a
chat tree (root chat plus all subagent descendants). When the cumulative
`total_cost_micros` across the tree reaches the limit, further messages
are rejected with a 409 containing `scope: "chat_lifetime"`.

**Database**: migration 000463 adds nullable `spend_limit_micros` column
with a `CHECK (> 0)` constraint. `GetChatTreeSpendTotal` sums priced
messages across the root and all descendants.

**Enforcement**: `checkChatTreeSpendLimit` resolves the root chat,
fetches its limit, and compares against tree spend. Runs before the
existing account-period check in `SendMessage`, `EditMessage`, and
`PromoteQueued`. Fails open on lookup errors to avoid blocking users
during transient DB issues.

**API**: `CreateChatRequest` accepts optional `spend_limit_micros`
(validated > 0). `ChatUsageLimitExceededResponse` gains a `scope` field
(`account_period` or `chat_lifetime`) and `resets_at` is now optional
(nil for lifetime limits).

> This PR was authored by Mux on behalf of Mike.
