### PR TITLE
feat: add purple theme

### DIFF
--- a/site/src/contexts/ThemeProvider.tsx
+++ b/site/src/contexts/ThemeProvider.tsx
@@ -81,7 +81,7 @@ export const ThemeProvider: FC<PropsWithChildren> = ({ children }) => {
 
 		return () => {
 			if (!root.dataset.embedTheme) {
-				root.classList.remove("light", "dark");
+				root.classList.remove("light", "dark", "purple");
 			}
 		};
 	}, [themePreference, preferredColorScheme]);

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -154,6 +154,70 @@
 		--primary: 213 94% 68%;
 		--primary-foreground: 240 10% 4%;
 	}
+
+	.purple {
+		--content-primary: 0 0% 100%;
+		--content-secondary: 270 10% 65%;
+		--content-link: 270 91% 75%;
+		--content-invert: 270 20% 8%;
+		--content-disabled: 270 10% 30%;
+		--content-success: 142 76% 36%;
+		--content-warning: 31 97% 72%;
+		--content-destructive: 0 91% 71%;
+		--surface-primary: 270 30% 5%;
+		--surface-secondary: 270 25% 9%;
+		--surface-tertiary: 270 20% 14%;
+		--surface-quaternary: 270 15% 22%;
+		--surface-invert-primary: 270 10% 88%;
+		--surface-invert-secondary: 270 10% 65%;
+		--surface-destructive: 0 75% 15%;
+		--surface-green: 145 80% 10%;
+		--surface-grey: 270 25% 10%;
+		--surface-orange: 13 81% 15%;
+		--surface-sky: 196 67% 12%;
+		--surface-red: 0 75% 15%;
+		--surface-purple: 270 60% 20%;
+		--surface-magenta: 291 74% 15%;
+		--border-purple: 270 80% 70%;
+		--border-default: 270 20% 18%;
+		--border-success: 142 76% 36%;
+		--border-magenta: 292 100% 78%;
+		--border-warning: 31 97% 72%;
+		--border-destructive: 0 91% 71%;
+		--border-sky: 194 90% 62%;
+		--border-green: 143 77% 87%;
+		--border-hover: 270 15% 35%;
+		--overlay-default: 270 30% 5% / 80%;
+		--highlight-purple: 270 100% 80%;
+		--highlight-green: 141 79% 85%;
+		--highlight-orange: 31 100% 70%;
+		--highlight-sky: 188 75% 80%;
+		--highlight-red: 0 91% 71%;
+		--highlight-magenta: 292 100% 78%;
+		--syntax-key: 270 90% 80%;
+		--syntax-string: 300 50% 70%;
+		--syntax-number: 180 40% 70%;
+		--syntax-boolean: 250 70% 70%;
+		--git-added: 142 77% 73%;
+		--git-deleted: 0 94% 82%;
+		--git-modified: 31 97% 72%;
+		--git-merged: 271 91% 65%;
+		--git-added-bright: 142 71% 45%;
+		--git-deleted-bright: 0 91% 71%;
+		--git-merged-bright: 270 95% 75%;
+		--surface-git-added: 145 80% 10%;
+		--surface-git-deleted: 0 75% 15%;
+		--surface-git-merged: 274 87% 21%;
+		--border: 270 20% 18%;
+		--input: 270 20% 18%;
+		--ring: 270 80% 70%;
+		--background: 270 30% 5%;
+		--foreground: 0 0% 98%;
+		--muted: 270 25% 10%;
+		--muted-foreground: 270 10% 65%;
+		--primary: 270 91% 75%;
+		--primary-foreground: 270 30% 5%;
+	}
 }
 
 @layer base {

--- a/site/src/pages/UserSettingsPage/AppearancePage/AppearanceForm.tsx
+++ b/site/src/pages/UserSettingsPage/AppearancePage/AppearanceForm.tsx
@@ -90,13 +90,19 @@ export const AppearanceForm: FC<AppearanceFormProps> = ({
 						theme="dark"
 						onSelect={() => onChangeTheme("dark")}
 					/>
-					<ThemePreviewButton
-						displayName="Light"
-						active={currentTheme === "light"}
-						theme="light"
-						onSelect={() => onChangeTheme("light")}
-					/>
-				</div>
+						<ThemePreviewButton
+							displayName="Light"
+							active={currentTheme === "light"}
+							theme="light"
+							onSelect={() => onChangeTheme("light")}
+						/>
+						<ThemePreviewButton
+							displayName="Purple"
+							active={currentTheme === "purple"}
+							theme="purple"
+							onSelect={() => onChangeTheme("purple")}
+							preview
+						/>				</div>
 			</Section>
 			<Section
 				title={
@@ -139,7 +145,7 @@ function toTerminalFontName(value: string): TerminalFontName {
 		: "";
 }
 
-type ThemeMode = "dark" | "light";
+type ThemeMode = "dark" | "light" | "purple";
 
 interface AutoThemePreviewButtonProps extends Omit<ThemePreviewProps, "theme"> {
 	themes: [ThemeMode, ThemeMode];

--- a/site/src/theme/index.ts
+++ b/site/src/theme/index.ts
@@ -6,6 +6,7 @@ import dark from "./dark";
 import type { NewTheme } from "./experimental";
 import type { ExternalImageModeStyles } from "./externalImages";
 import light from "./light";
+import purple from "./purple";
 import type { Roles } from "./roles";
 
 export interface Theme extends Omit<MuiTheme, "palette"> {
@@ -33,6 +34,7 @@ export const DEFAULT_THEME = "dark";
 const theme = {
 	dark,
 	light,
+	purple,
 } satisfies Record<string, Theme>;
 
 export default theme;

--- a/site/src/theme/purple/branding.ts
+++ b/site/src/theme/purple/branding.ts
@@ -1,0 +1,33 @@
+import type { Branding } from "../branding";
+import colors from "../tailwindColors";
+
+const branding: Branding = {
+	enterprise: {
+		background: colors.purple[950],
+		divider: colors.purple[900],
+		border: colors.purple[400],
+		text: colors.purple[50],
+	},
+	premium: {
+		background: colors.violet[950],
+		divider: colors.violet[900],
+		border: colors.violet[400],
+		text: colors.violet[50],
+	},
+
+	featureStage: {
+		background: colors.purple[950],
+		divider: colors.purple[900],
+		border: colors.purple[400],
+		text: colors.purple[400],
+
+		hover: {
+			background: colors.purple[900],
+			divider: colors.purple[800],
+			border: colors.purple[300],
+			text: colors.purple[300],
+		},
+	},
+};
+
+export default branding;

--- a/site/src/theme/purple/experimental.ts
+++ b/site/src/theme/purple/experimental.ts
@@ -1,0 +1,52 @@
+import type { NewTheme } from "../experimental";
+import colors from "../tailwindColors";
+
+export default {
+	l1: {
+		background: "#0d0816",
+		outline: "#3d3458",
+		text: colors.white,
+		fill: {
+			solid: "#4a3d6b",
+			outline: "#4a3d6b",
+			text: colors.white,
+		},
+	},
+
+	l2: {
+		background: "#150e21",
+		outline: "#3d3458",
+		text: colors.zinc[50],
+		fill: {
+			solid: "#5a4d7a",
+			outline: "#5a4d7a",
+			text: colors.white,
+		},
+		disabled: {
+			background: "#120b1e",
+			outline: "#3d3458",
+			text: colors.zinc[200],
+			fill: {
+				solid: "#4a3d6b",
+				outline: "#4a3d6b",
+				text: colors.white,
+			},
+		},
+		hover: {
+			background: "#1e1632",
+			outline: "#4a3d6b",
+			text: colors.white,
+			fill: {
+				solid: "#6a5d8a",
+				outline: "#6a5d8a",
+				text: colors.white,
+			},
+		},
+	},
+
+	pillDefault: {
+		background: "#1e1632",
+		outline: "#3d3458",
+		text: colors.zinc[200],
+	},
+} satisfies NewTheme;

--- a/site/src/theme/purple/index.ts
+++ b/site/src/theme/purple/index.ts
@@ -1,0 +1,15 @@
+import { forDarkThemes } from "../externalImages";
+import branding from "./branding";
+import experimental from "./experimental";
+import monaco from "./monaco";
+import muiTheme from "./mui";
+import roles from "./roles";
+
+export default {
+	...muiTheme,
+	externalImages: forDarkThemes,
+	experimental,
+	branding,
+	monaco,
+	roles,
+};

--- a/site/src/theme/purple/monaco.ts
+++ b/site/src/theme/purple/monaco.ts
@@ -1,0 +1,37 @@
+import type * as monaco from "monaco-editor";
+import muiTheme from "./mui";
+
+export default {
+	base: "vs-dark",
+	inherit: true,
+	rules: [
+		{
+			token: "comment",
+			foreground: "7B6F9C",
+		},
+		{
+			token: "type",
+			foreground: "C4B5FD",
+		},
+		{
+			token: "string",
+			foreground: "D8B4FE",
+		},
+		{
+			token: "variable",
+			foreground: "DDDDDD",
+		},
+		{
+			token: "identifier",
+			foreground: "C4B5FD",
+		},
+		{
+			token: "delimiter.curly",
+			foreground: "A78BFA",
+		},
+	],
+	colors: {
+		"editor.foreground": muiTheme.palette.text.primary,
+		"editor.background": muiTheme.palette.background.paper,
+	},
+} satisfies monaco.editor.IStandaloneThemeData as monaco.editor.IStandaloneThemeData;

--- a/site/src/theme/purple/mui.ts
+++ b/site/src/theme/purple/mui.ts
@@ -1,0 +1,84 @@
+/**
+ * @deprecated MUI purple theme is deprecated. Migrate to Tailwind CSS theme system.
+ * This file provides MUI theme configuration for legacy compatibility only.
+ */
+
+/** @deprecated MUI createTheme is deprecated. Migrate to Tailwind CSS theme system. */
+import { createTheme } from "@mui/material/styles";
+import { BODY_FONT_FAMILY, borderRadius } from "../constants";
+import { components } from "../mui";
+import tw from "../tailwindColors";
+
+const muiTheme = createTheme({
+	palette: {
+		mode: "dark",
+		primary: {
+			main: tw.purple[500],
+			contrastText: tw.white,
+			light: tw.purple[400],
+			dark: tw.purple[600],
+		},
+		secondary: {
+			main: tw.zinc[500],
+			contrastText: tw.zinc[200],
+			dark: tw.zinc[400],
+		},
+		background: {
+			default: "#0d0816",
+			paper: "#150e21",
+		},
+		text: {
+			primary: tw.zinc[50],
+			secondary: tw.zinc[400],
+			disabled: tw.zinc[500],
+		},
+		divider: "#2d2640",
+		warning: {
+			light: tw.amber[500],
+			main: tw.amber[800],
+			dark: tw.amber[950],
+		},
+		success: {
+			main: tw.green[500],
+			dark: tw.green[600],
+		},
+		info: {
+			light: tw.blue[400],
+			main: tw.blue[600],
+			dark: tw.blue[950],
+			contrastText: tw.zinc[200],
+		},
+		error: {
+			light: tw.red[400],
+			main: tw.red[500],
+			dark: tw.red[950],
+			contrastText: tw.zinc[200],
+		},
+		action: {
+			hover: "#1e1632",
+		},
+		neutral: {
+			main: tw.zinc[50],
+		},
+		dots: tw.zinc[500],
+	},
+	typography: {
+		fontFamily: BODY_FONT_FAMILY,
+
+		body1: {
+			fontSize: "1rem",
+			lineHeight: "160%",
+		},
+
+		body2: {
+			fontSize: "0.875rem",
+			lineHeight: "160%",
+		},
+	},
+	shape: {
+		borderRadius,
+	},
+	components,
+});
+
+export default muiTheme;

--- a/site/src/theme/purple/roles.ts
+++ b/site/src/theme/purple/roles.ts
@@ -1,0 +1,157 @@
+import type { Roles } from "../roles";
+import colors from "../tailwindColors";
+
+const roles: Roles = {
+	danger: {
+		background: colors.orange[950],
+		outline: colors.orange[500],
+		text: colors.orange[50],
+		fill: {
+			solid: colors.orange[500],
+			outline: colors.orange[400],
+			text: colors.white,
+		},
+		disabled: {
+			background: colors.orange[950],
+			outline: colors.orange[800],
+			text: colors.orange[200],
+			fill: {
+				solid: colors.orange[800],
+				outline: colors.orange[800],
+				text: colors.white,
+			},
+		},
+		hover: {
+			background: colors.orange[900],
+			outline: colors.orange[500],
+			text: colors.white,
+			fill: {
+				solid: colors.orange[500],
+				outline: colors.orange[500],
+				text: colors.white,
+			},
+		},
+	},
+	error: {
+		background: colors.red[950],
+		outline: colors.red[600],
+		text: colors.red[50],
+		fill: {
+			solid: colors.red[400],
+			outline: colors.red[400],
+			text: colors.white,
+		},
+	},
+	warning: {
+		background: colors.amber[950],
+		outline: colors.amber[300],
+		text: colors.amber[50],
+		fill: {
+			solid: colors.amber[500],
+			outline: colors.amber[500],
+			text: colors.white,
+		},
+	},
+	notice: {
+		background: colors.blue[950],
+		outline: colors.blue[400],
+		text: colors.blue[50],
+		fill: {
+			solid: colors.blue[500],
+			outline: colors.blue[600],
+			text: colors.white,
+		},
+	},
+	info: {
+		background: colors.purple[950],
+		outline: colors.purple[400],
+		text: colors.purple[50],
+		fill: {
+			solid: colors.purple[500],
+			outline: colors.purple[600],
+			text: colors.white,
+		},
+	},
+	success: {
+		background: colors.green[950],
+		outline: colors.green[500],
+		text: colors.green[50],
+		fill: {
+			solid: colors.green[600],
+			outline: colors.green[600],
+			text: colors.white,
+		},
+		disabled: {
+			background: colors.green[950],
+			outline: colors.green[800],
+			text: colors.green[200],
+			fill: {
+				solid: colors.green[800],
+				outline: colors.green[800],
+				text: colors.white,
+			},
+		},
+		hover: {
+			background: colors.green[900],
+			outline: colors.green[500],
+			text: colors.white,
+			fill: {
+				solid: colors.green[500],
+				outline: colors.green[500],
+				text: colors.white,
+			},
+		},
+	},
+	active: {
+		background: colors.purple[950],
+		outline: colors.purple[500],
+		text: colors.purple[50],
+		fill: {
+			solid: colors.purple[600],
+			outline: colors.purple[400],
+			text: colors.white,
+		},
+		disabled: {
+			background: colors.purple[950],
+			outline: colors.purple[800],
+			text: colors.purple[200],
+			fill: {
+				solid: colors.purple[800],
+				outline: colors.purple[800],
+				text: colors.white,
+			},
+		},
+		hover: {
+			background: colors.purple[900],
+			outline: colors.purple[500],
+			text: colors.white,
+			fill: {
+				solid: colors.purple[500],
+				outline: colors.purple[500],
+				text: colors.white,
+			},
+		},
+	},
+	inactive: {
+		background: colors.purple[950],
+		outline: colors.zinc[500],
+		text: colors.zinc[50],
+		fill: {
+			solid: colors.zinc[400],
+			outline: colors.zinc[400],
+			text: colors.white,
+		},
+	},
+	preview: {
+		background: colors.violet[950],
+		outline: colors.violet[500],
+		text: colors.violet[50],
+		fill: {
+			solid: colors.violet[400],
+			outline: colors.violet[400],
+			text: colors.white,
+		},
+	},
+};
+
+export default roles;


### PR DESCRIPTION
Add a new dark purple theme as a preview option in the appearance settings.

## Changes

- New `site/src/theme/purple/` directory with full theme definition (branding, experimental, monaco, mui, roles)
- Purple CSS variables in `index.css` using hue-270 purple tinting for all surface, content, border, and highlight tokens
- MUI palette uses `purple[500]` primary and deep purple custom backgrounds (`#0d0816`, `#150e21`)
- Semantic roles (error, warning, success, danger) preserved unchanged; `active` and `info` shifted to purple
- Monaco editor uses purple-tinted syntax highlighting colors
- Registered in theme index, ThemeProvider cleanup, and AppearanceForm UI
- Marked as `preview` in the theme selector

## Visual Verification

Verified in Storybook (`AppearanceForm` story):
- Purple theme preview card renders with correct purple-tinted backgrounds (`rgb(23, 17, 29)`) and borders (`rgb(46, 37, 55)`)
- All 4 theme cards display correctly: Auto, Dark, Light, Purple (with Preview badge)
- Clicking Purple card correctly dispatches `"purple"` theme preference
- TypeScript compiles clean, lint passes, build succeeds

<details><summary>Implementation Notes</summary>

### Theme Architecture
The purple theme follows the exact same structure as `dark` and `light` themes:
- `mui.ts` — MUI createTheme with purple primary palette, custom hex dark-purple backgrounds
- `branding.ts` — Enterprise/premium branding in purple/violet
- `experimental.ts` — L1/L2 layer system with purple-tinted custom hex colors
- `monaco.ts` — VS Dark base with purple-shifted token colors
- `roles.ts` — Semantic roles preserved; active/info/inactive use purple tints
- `index.ts` — Composes all modules, uses `forDarkThemes` external image mode

### CSS Variables
All CSS custom properties use HSL hue 270 (purple) for surface, content, border, and highlight tokens, maintaining the same structure as the dark theme but with a distinctly purple character.

### Integration Points
- `site/src/theme/index.ts` — Added to theme registry
- `site/src/contexts/ThemeProvider.tsx` — Added to class cleanup list
- `site/src/index.css` — New `.purple` selector with full CSS variable set
- `AppearanceForm.tsx` — New theme button with `preview` prop, updated `ThemeMode` type

</details>

> Generated with [Coder Agents](https://coder.com/agents)