### PR TITLE
feat(site): add purple theme

### DIFF
--- a/site/src/contexts/ThemeProvider.tsx
+++ b/site/src/contexts/ThemeProvider.tsx
@@ -24,6 +24,11 @@ import { appearanceSettings } from "#/api/queries/users";
 import { useEmbeddedMetadata } from "#/hooks/useEmbeddedMetadata";
 import themes, { DEFAULT_THEME, type Theme } from "#/theme";
 
+// Map custom theme names to their underlying color scheme for CSS class.
+const themeToColorScheme: Record<string, string> = {
+	purple: "dark",
+};
+
 /**
  *
  */
@@ -76,12 +81,19 @@ export const ThemeProvider: FC<PropsWithChildren> = ({ children }) => {
 		if (themePreference === "auto") {
 			root.classList.add(preferredColorScheme);
 		} else {
-			root.classList.add(themePreference);
+			// Custom themes (e.g. purple) map to an underlying color scheme
+			// for Tailwind dark/light class, but also set their own class.
+			const colorScheme = themeToColorScheme[themePreference];
+			if (colorScheme) {
+				root.classList.add(colorScheme, themePreference);
+			} else {
+				root.classList.add(themePreference);
+			}
 		}
 
 		return () => {
 			if (!root.dataset.embedTheme) {
-				root.classList.remove("light", "dark");
+				root.classList.remove("light", "dark", "purple");
 			}
 		};
 	}, [themePreference, preferredColorScheme]);

--- a/site/src/pages/UserSettingsPage/AppearancePage/AppearanceForm.tsx
+++ b/site/src/pages/UserSettingsPage/AppearancePage/AppearanceForm.tsx
@@ -96,7 +96,14 @@ export const AppearanceForm: FC<AppearanceFormProps> = ({
 						theme="light"
 						onSelect={() => onChangeTheme("light")}
 					/>
-				</div>
+					<ThemePreviewButton
+						displayName="Purple"
+						active={currentTheme === "purple"}
+						theme="purple"
+						preview
+						onSelect={() => onChangeTheme("purple")}
+					/>
+				</div>{" "}
 			</Section>
 			<Section
 				title={
@@ -139,7 +146,7 @@ function toTerminalFontName(value: string): TerminalFontName {
 		: "";
 }
 
-type ThemeMode = "dark" | "light";
+type ThemeMode = "dark" | "light" | "purple";
 
 interface AutoThemePreviewButtonProps extends Omit<ThemePreviewProps, "theme"> {
 	themes: [ThemeMode, ThemeMode];
@@ -250,7 +257,7 @@ const ThemePreview: FC<ThemePreviewProps> = ({
 	theme,
 }) => {
 	return (
-		<div className={theme}>
+		<div className={theme === "purple" ? "dark" : theme}>
 			<div
 				className={cn(
 					"w-56 overflow-clip rounded-md border border-border border-solid bg-surface-primary text-content-primary select-none",
@@ -267,14 +274,24 @@ const ThemePreview: FC<ThemePreviewProps> = ({
 							<div className="bg-content-secondary h-1.5 w-5 rounded" />
 						</div>
 						<div className="flex items-center gap-1.5">
-							<div className="bg-green-400 h-1.5 w-3 rounded" />
+							<div
+								className={cn(
+									"h-1.5 w-3 rounded",
+									theme === "purple" ? "bg-violet-400" : "bg-green-400",
+								)}
+							/>
 							<div className="bg-content-primary h-2 w-2 rounded-full" />
-						</div>
+						</div>{" "}
 					</div>
 					<div className="w-32 mx-auto">
 						<div className="bg-content-primary h-2 w-11 rounded mb-1.5" />
 						<div className="border border-solid rounded-t overflow-clip">
-							<div className="bg-surface-secondary h-2.5 -m-px" />
+							<div
+								className={cn(
+									"h-2.5 -m-px",
+									theme === "purple" ? "bg-violet-950" : "bg-surface-secondary",
+								)}
+							/>{" "}
 							<div className="h-4 border-0 border-t border-border border-solid">
 								<div className="bg-content-disabled h-1.5 w-8 rounded mt-1 ml-1" />
 							</div>

--- a/site/src/theme/index.ts
+++ b/site/src/theme/index.ts
@@ -6,6 +6,7 @@ import dark from "./dark";
 import type { NewTheme } from "./experimental";
 import type { ExternalImageModeStyles } from "./externalImages";
 import light from "./light";
+import purple from "./purple";
 import type { Roles } from "./roles";
 
 export interface Theme extends Omit<MuiTheme, "palette"> {
@@ -33,6 +34,7 @@ export const DEFAULT_THEME = "dark";
 const theme = {
 	dark,
 	light,
+	purple,
 } satisfies Record<string, Theme>;
 
 export default theme;

--- a/site/src/theme/purple/branding.ts
+++ b/site/src/theme/purple/branding.ts
@@ -1,0 +1,33 @@
+import type { Branding } from "../branding";
+import colors from "../tailwindColors";
+
+const branding: Branding = {
+	enterprise: {
+		background: colors.blue[950],
+		divider: colors.blue[900],
+		border: colors.blue[400],
+		text: colors.blue[50],
+	},
+	premium: {
+		background: colors.violet[950],
+		divider: colors.violet[900],
+		border: colors.violet[400],
+		text: colors.violet[50],
+	},
+
+	featureStage: {
+		background: colors.violet[950],
+		divider: colors.violet[900],
+		border: colors.violet[400],
+		text: colors.violet[400],
+
+		hover: {
+			background: colors.zinc[950],
+			divider: colors.zinc[900],
+			border: colors.violet[400],
+			text: colors.violet[400],
+		},
+	},
+};
+
+export default branding;

--- a/site/src/theme/purple/experimental.ts
+++ b/site/src/theme/purple/experimental.ts
@@ -1,0 +1,52 @@
+import type { NewTheme } from "../experimental";
+import colors from "../tailwindColors";
+
+export default {
+	l1: {
+		background: colors.zinc[950],
+		outline: colors.zinc[700],
+		text: colors.white,
+		fill: {
+			solid: colors.zinc[600],
+			outline: colors.zinc[600],
+			text: colors.white,
+		},
+	},
+
+	l2: {
+		background: colors.zinc[900],
+		outline: colors.zinc[700],
+		text: colors.zinc[50],
+		fill: {
+			solid: colors.zinc[500],
+			outline: colors.zinc[500],
+			text: colors.white,
+		},
+		disabled: {
+			background: colors.gray[900],
+			outline: colors.zinc[700],
+			text: colors.zinc[200],
+			fill: {
+				solid: colors.zinc[500],
+				outline: colors.zinc[500],
+				text: colors.white,
+			},
+		},
+		hover: {
+			background: colors.zinc[800],
+			outline: colors.zinc[600],
+			text: colors.white,
+			fill: {
+				solid: colors.zinc[400],
+				outline: colors.zinc[400],
+				text: colors.white,
+			},
+		},
+	},
+
+	pillDefault: {
+		background: colors.zinc[800],
+		outline: colors.zinc[700],
+		text: colors.zinc[200],
+	},
+} satisfies NewTheme;

--- a/site/src/theme/purple/index.ts
+++ b/site/src/theme/purple/index.ts
@@ -1,0 +1,15 @@
+import { forDarkThemes } from "../externalImages";
+import branding from "./branding";
+import experimental from "./experimental";
+import monaco from "./monaco";
+import muiTheme from "./mui";
+import roles from "./roles";
+
+export default {
+	...muiTheme,
+	externalImages: forDarkThemes,
+	experimental,
+	branding,
+	monaco,
+	roles,
+};

--- a/site/src/theme/purple/monaco.ts
+++ b/site/src/theme/purple/monaco.ts
@@ -1,0 +1,37 @@
+import type * as monaco from "monaco-editor";
+import muiTheme from "./mui";
+
+export default {
+	base: "vs-dark",
+	inherit: true,
+	rules: [
+		{
+			token: "comment",
+			foreground: "6B737C",
+		},
+		{
+			token: "type",
+			foreground: "C4B5FD",
+		},
+		{
+			token: "string",
+			foreground: "A78BFA",
+		},
+		{
+			token: "variable",
+			foreground: "DDDDDD",
+		},
+		{
+			token: "identifier",
+			foreground: "C4B5FD",
+		},
+		{
+			token: "delimiter.curly",
+			foreground: "EBB325",
+		},
+	],
+	colors: {
+		"editor.foreground": muiTheme.palette.text.primary,
+		"editor.background": muiTheme.palette.background.paper,
+	},
+} satisfies monaco.editor.IStandaloneThemeData as monaco.editor.IStandaloneThemeData;

--- a/site/src/theme/purple/mui.ts
+++ b/site/src/theme/purple/mui.ts
@@ -1,0 +1,84 @@
+/**
+ * @deprecated MUI purple theme is deprecated. Migrate to Tailwind CSS theme system.
+ * This file provides MUI theme configuration for legacy compatibility only.
+ */
+
+/** @deprecated MUI createTheme is deprecated. Migrate to Tailwind CSS theme system. */
+import { createTheme } from "@mui/material/styles";
+import { BODY_FONT_FAMILY, borderRadius } from "../constants";
+import { components } from "../mui";
+import tw from "../tailwindColors";
+
+const muiTheme = createTheme({
+	palette: {
+		mode: "dark",
+		primary: {
+			main: tw.violet[500],
+			contrastText: tw.white,
+			light: tw.violet[400],
+			dark: tw.violet[600],
+		},
+		secondary: {
+			main: tw.zinc[500],
+			contrastText: tw.zinc[200],
+			dark: tw.zinc[400],
+		},
+		background: {
+			default: tw.zinc[950],
+			paper: tw.zinc[900],
+		},
+		text: {
+			primary: tw.zinc[50],
+			secondary: tw.zinc[400],
+			disabled: tw.zinc[500],
+		},
+		divider: tw.zinc[700],
+		warning: {
+			light: tw.amber[500],
+			main: tw.amber[800],
+			dark: tw.amber[950],
+		},
+		success: {
+			main: tw.green[500],
+			dark: tw.green[600],
+		},
+		info: {
+			light: tw.blue[400],
+			main: tw.blue[600],
+			dark: tw.blue[950],
+			contrastText: tw.zinc[200],
+		},
+		error: {
+			light: tw.red[400],
+			main: tw.red[500],
+			dark: tw.red[950],
+			contrastText: tw.zinc[200],
+		},
+		action: {
+			hover: tw.zinc[800],
+		},
+		neutral: {
+			main: tw.zinc[50],
+		},
+		dots: tw.zinc[500],
+	},
+	typography: {
+		fontFamily: BODY_FONT_FAMILY,
+
+		body1: {
+			fontSize: "1rem" /* 16px at default scaling */,
+			lineHeight: "160%",
+		},
+
+		body2: {
+			fontSize: "0.875rem" /* 14px at default scaling */,
+			lineHeight: "160%",
+		},
+	},
+	shape: {
+		borderRadius,
+	},
+	components,
+});
+
+export default muiTheme;

--- a/site/src/theme/purple/roles.ts
+++ b/site/src/theme/purple/roles.ts
@@ -1,0 +1,157 @@
+import type { Roles } from "../roles";
+import colors from "../tailwindColors";
+
+const roles: Roles = {
+	danger: {
+		background: colors.orange[950],
+		outline: colors.orange[500],
+		text: colors.orange[50],
+		fill: {
+			solid: colors.orange[500],
+			outline: colors.orange[400],
+			text: colors.white,
+		},
+		disabled: {
+			background: colors.orange[950],
+			outline: colors.orange[800],
+			text: colors.orange[200],
+			fill: {
+				solid: colors.orange[800],
+				outline: colors.orange[800],
+				text: colors.white,
+			},
+		},
+		hover: {
+			background: colors.orange[900],
+			outline: colors.orange[500],
+			text: colors.white,
+			fill: {
+				solid: colors.orange[500],
+				outline: colors.orange[500],
+				text: colors.white,
+			},
+		},
+	},
+	error: {
+		background: colors.red[950],
+		outline: colors.red[600],
+		text: colors.red[50],
+		fill: {
+			solid: colors.red[400],
+			outline: colors.red[400],
+			text: colors.white,
+		},
+	},
+	warning: {
+		background: colors.amber[950],
+		outline: colors.amber[300],
+		text: colors.amber[50],
+		fill: {
+			solid: colors.amber[500],
+			outline: colors.amber[500],
+			text: colors.white,
+		},
+	},
+	notice: {
+		background: colors.blue[950],
+		outline: colors.blue[400],
+		text: colors.blue[50],
+		fill: {
+			solid: colors.blue[500],
+			outline: colors.blue[600],
+			text: colors.white,
+		},
+	},
+	info: {
+		background: colors.zinc[950],
+		outline: colors.zinc[400],
+		text: colors.zinc[50],
+		fill: {
+			solid: colors.zinc[500],
+			outline: colors.zinc[600],
+			text: colors.white,
+		},
+	},
+	success: {
+		background: colors.green[950],
+		outline: colors.green[500],
+		text: colors.green[50],
+		fill: {
+			solid: colors.green[600],
+			outline: colors.green[600],
+			text: colors.white,
+		},
+		disabled: {
+			background: colors.green[950],
+			outline: colors.green[800],
+			text: colors.green[200],
+			fill: {
+				solid: colors.green[800],
+				outline: colors.green[800],
+				text: colors.white,
+			},
+		},
+		hover: {
+			background: colors.green[900],
+			outline: colors.green[500],
+			text: colors.white,
+			fill: {
+				solid: colors.green[500],
+				outline: colors.green[500],
+				text: colors.white,
+			},
+		},
+	},
+	active: {
+		background: colors.violet[950],
+		outline: colors.violet[500],
+		text: colors.violet[50],
+		fill: {
+			solid: colors.violet[600],
+			outline: colors.violet[400],
+			text: colors.white,
+		},
+		disabled: {
+			background: colors.violet[950],
+			outline: colors.violet[800],
+			text: colors.violet[200],
+			fill: {
+				solid: colors.violet[800],
+				outline: colors.violet[800],
+				text: colors.white,
+			},
+		},
+		hover: {
+			background: colors.violet[900],
+			outline: colors.violet[500],
+			text: colors.white,
+			fill: {
+				solid: colors.violet[500],
+				outline: colors.violet[500],
+				text: colors.white,
+			},
+		},
+	},
+	inactive: {
+		background: colors.zinc[950],
+		outline: colors.zinc[500],
+		text: colors.zinc[50],
+		fill: {
+			solid: colors.zinc[400],
+			outline: colors.zinc[400],
+			text: colors.white,
+		},
+	},
+	preview: {
+		background: colors.violet[950],
+		outline: colors.violet[500],
+		text: colors.violet[50],
+		fill: {
+			solid: colors.violet[400],
+			outline: colors.violet[400],
+			text: colors.white,
+		},
+	},
+};
+
+export default roles;


### PR DESCRIPTION
Add a new purple dark theme variant with violet accents.

## What

New `purple` theme option in the appearance settings. It's a dark-mode theme that replaces sky/blue primary and active accent colors with violet throughout the UI.

## Changes

- **New `site/src/theme/purple/` directory** — complete theme with `mui.ts`, `roles.ts`, `branding.ts`, `experimental.ts`, `monaco.ts`, and `index.ts`
- **`site/src/theme/index.ts`** — register the purple theme
- **`site/src/contexts/ThemeProvider.tsx`** — map `purple` to the `dark` CSS class for Tailwind compatibility, and clean up the class on unmount
- **`AppearanceForm.tsx`** — add Purple option with a Preview badge and purple-accented theme preview

## Design decisions

- Based on the dark theme — same zinc backgrounds, same semantic roles for error/warning/success/etc.
- Only primary (MUI) and active (roles) colors change from sky → violet
- Branding `featureStage` also uses violet to match the theme accent
- Monaco editor tokens use violet-tinted syntax highlighting
- Theme preview card shows violet accents (status dot, table header) to visually distinguish from dark
- Marked with `<PreviewBadge />` since this is a new experimental theme

> Generated with [Coder Agents](https://coder.com/agents)