### PR TITLE
fix(scripts): exclude RC tags from dogfood version resolution

### DIFF
--- a/scripts/should_deploy.sh
+++ b/scripts/should_deploy.sh
@@ -43,19 +43,32 @@ if ! echo "$release_branches" | grep "release/2.26" >/dev/null; then
 	error "Could not find existing release branches. Did you run 'git fetch -ap ${remote}'?"
 fi
 
-latest_release_branch=$(echo "$release_branches" | tail -n 1)
-latest_release_branch_version=${latest_release_branch#release/}
-log "Latest release branch: $latest_release_branch"
-log "Latest release branch version: $latest_release_branch_version"
+# Step 2: Iterate from the latest release branch backwards to find the deploy
+# branch. A release branch is the deploy target if its `.0` tag does not yet
+# exist (i.e. the release is in progress / frozen). Release branches that only
+# carry RC tags (v<x.y>.0-rc.*) are skipped — they are not considered frozen.
+for branch in $(echo "$release_branches" | sort -Vr); do
+	version=${branch#release/}
+	log "Checking release branch: $branch (version: $version)"
 
-# Step 2: check if a matching tag `v<x.y>.0` exists. If it does not, we will
-# use the release branch as the deploy branch.
-if ! git rev-parse "refs/tags/v${latest_release_branch_version}.0" >/dev/null 2>&1; then
-	log "Tag 'v${latest_release_branch_version}.0' does not exist, using release branch as deploy branch"
-	deploy_branch=$latest_release_branch
-else
-	log "Matching tag 'v${latest_release_branch_version}.0' exists, using main as deploy branch"
-fi
+	if git rev-parse "refs/tags/v${version}.0" >/dev/null 2>&1; then
+		# Final .0 tag exists — this release (and all older ones) are done.
+		log "Tag 'v${version}.0' exists, release is complete"
+		break
+	fi
+
+	# No .0 tag. Check if there are RC tags, which would indicate this is
+	# an RC-only branch that we should skip.
+	if git tag -l "v${version}.0-rc.*" | grep -q .; then
+		log "Branch '$branch' only has RC tags, skipping"
+		continue
+	fi
+
+	# No .0 tag and no RC tags — this is the frozen release branch.
+	log "Branch '$branch' is the frozen release branch"
+	deploy_branch=$branch
+	break
+done
 log "Deploy branch: $deploy_branch"
 
 # Finally, check if the current branch is the deploy branch.

--- a/scripts/should_deploy.sh
+++ b/scripts/should_deploy.sh
@@ -43,32 +43,32 @@ if ! echo "$release_branches" | grep "release/2.26" >/dev/null; then
 	error "Could not find existing release branches. Did you run 'git fetch -ap ${remote}'?"
 fi
 
-# Step 2: Iterate from the latest release branch backwards to find the deploy
-# branch. A release branch is the deploy target if its `.0` tag does not yet
-# exist (i.e. the release is in progress / frozen). Release branches that only
-# carry RC tags (v<x.y>.0-rc.*) are skipped — they are not considered frozen.
-for branch in $(echo "$release_branches" | sort -Vr); do
+# Step 2: Find the latest released branch (has a v<x.y>.0 tag), then check
+# whether the next release branch exists. If it does, that branch is the
+# frozen deploy target. This avoids coupling to any RC tagging convention.
+latest_released=""
+for branch in $(echo "$release_branches" | tac); do
 	version=${branch#release/}
-	log "Checking release branch: $branch (version: $version)"
-
 	if git rev-parse "refs/tags/v${version}.0" >/dev/null 2>&1; then
-		# Final .0 tag exists — this release (and all older ones) are done.
-		log "Tag 'v${version}.0' exists, release is complete"
+		latest_released=$branch
+		log "Latest released branch: $branch (v${version}.0 exists)"
 		break
 	fi
-
-	# No .0 tag. Check if there are RC tags, which would indicate this is
-	# an RC-only branch that we should skip.
-	if git tag -l "v${version}.0-rc.*" | grep -q .; then
-		log "Branch '$branch' only has RC tags, skipping"
-		continue
-	fi
-
-	# No .0 tag and no RC tags — this is the frozen release branch.
-	log "Branch '$branch' is the frozen release branch"
-	deploy_branch=$branch
-	break
 done
+
+if [[ -z "$latest_released" ]]; then
+	log "No released branch found, falling back to main"
+else
+	# The frozen branch is the one immediately after the latest released
+	# branch in version order, if it exists.
+	frozen=$(echo "$release_branches" | grep -A1 "^${latest_released}$" | tail -n1)
+	if [[ "$frozen" != "$latest_released" ]]; then
+		log "Frozen release branch: $frozen"
+		deploy_branch=$frozen
+	else
+		log "No frozen release branch found after $latest_released, falling back to main"
+	fi
+fi
 log "Deploy branch: $deploy_branch"
 
 # Finally, check if the current branch is the deploy branch.

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -44,7 +44,14 @@ else
 	# Try to find the last tag that contains the current commit
 	last_tag=$(git tag --contains "$current_commit" --sort=version:refname | head -n 1)
 	# If there is no tag that contains the current commit,
-	# get the latest tag sorted by semver.
+	# get the latest tag sorted by semver. We exclude RC tags
+	# (v*-rc.*) so that dev builds are based on the latest stable
+	# version rather than an unrelated RC from a newer release.
+	if [[ -z "${last_tag}" ]]; then
+		last_tag=$(git tag --sort=version:refname | grep -v -- '-rc\.' | tail -n 1)
+	fi
+	# If there is still no tag (e.g. only RC tags exist),
+	# fall back to the latest tag including RCs.
 	if [[ -z "${last_tag}" ]]; then
 		last_tag=$(git tag --sort=version:refname | tail -n 1)
 	fi


### PR DESCRIPTION
Closing — the real fix is a process change: push an RC tag when cutting the release branch, then fix `version.sh` to use the nearest ancestor tag instead of the global latest. Will be addressed in a follow-up PR on top of #24167.

> Generated by Coder Agents