### PR TITLE
fix(site): use locale string for token usage tooltip

### DIFF
--- a/site/src/pages/AIBridgePage/TokenBadges.tsx
+++ b/site/src/pages/AIBridgePage/TokenBadges.tsx
@@ -57,7 +57,7 @@ export const TokenBadges: FC<TokenBadgesProps> = ({
 							<div className="flex items-center justify-between gap-4">
 								<div className="text-sm text-content-secondary">Input</div>
 								<div className="text-sm text-content-secondary">
-									{inputTokens}
+									{inputTokens.toLocaleString()}
 								</div>
 							</div>
 						</div>
@@ -72,7 +72,7 @@ export const TokenBadges: FC<TokenBadgesProps> = ({
 							<div className="flex items-center justify-between gap-4">
 								<div className="text-sm text-content-secondary">Output</div>
 								<div className="text-sm text-content-secondary">
-									{outputTokens}
+									{outputTokens.toLocaleString()}
 								</div>
 							</div>
 						</div>


### PR DESCRIPTION
quality of life improvement

<img width="353" height="291" alt="Screenshot 2026-04-08 at 5 04 55 PM" src="https://github.com/user-attachments/assets/f1165b03-c82d-4135-97a5-ce04ec7c41c0" />
