### PR TITLE
refactor(site): replace `!!` with `Boolean()` for boolean coercion

### DIFF
--- a/site/src/api/queries/organizations.ts
+++ b/site/src/api/queries/organizations.ts
@@ -304,7 +304,7 @@ export const organizationsPermissions = (
 	organizationIds: string[] | undefined,
 ) => {
 	return {
-		enabled: !!organizationIds,
+		enabled: Boolean(organizationIds),
 		queryKey: [
 			"organizations",
 			[...(organizationIds ?? []).sort()],
@@ -351,7 +351,7 @@ export const workspacePermissionsByOrganization = (
 	userId: string,
 ) => {
 	return {
-		enabled: !!organizationIds,
+		enabled: Boolean(organizationIds),
 		queryKey: [
 			"workspaces",
 			[...(organizationIds ?? []).sort()],

--- a/site/src/contexts/useWebpushNotifications.ts
+++ b/site/src/contexts/useWebpushNotifications.ts
@@ -35,7 +35,7 @@ export const useWebpushNotifications = (): WebpushNotifications => {
 			try {
 				const registration = await navigator.serviceWorker.ready;
 				const subscription = await registration.pushManager.getSubscription();
-				setSubscribed(!!subscription);
+				setSubscribed(Boolean(subscription));
 			} catch (error) {
 				console.error("Error checking push subscription:", error);
 				setSubscribed(false);

--- a/site/src/hooks/useExternalAuth.ts
+++ b/site/src/hooks/useExternalAuth.ts
@@ -18,7 +18,7 @@ export const useExternalAuth = (versionId: string | undefined) => {
 		error,
 	} = useQuery({
 		...templateVersionExternalAuth(versionId ?? ""),
-		enabled: !!versionId,
+		enabled: Boolean(versionId),
 		refetchInterval: externalAuthPollingState === "polling" ? 1000 : false,
 	});
 

--- a/site/src/modules/apps/useAppLink.ts
+++ b/site/src/modules/apps/useAppLink.ts
@@ -111,6 +111,6 @@ export const useAppLink = (
 		href,
 		onClick,
 		label,
-		hasToken: !!apiKeyResponse?.key,
+		hasToken: Boolean(apiKeyResponse?.key),
 	};
 };

--- a/site/src/modules/workspaces/WorkspaceMoreActions/WorkspaceDeleteDialog.tsx
+++ b/site/src/modules/workspaces/WorkspaceMoreActions/WorkspaceDeleteDialog.tsx
@@ -56,7 +56,7 @@ export const WorkspaceDeleteDialog: FC<WorkspaceDeleteDialogProps> = ({
 		(workspace.latest_build.status === "failed" ||
 			workspace.latest_build.status === "canceled");
 
-	const hasTask = !!workspace.task_id;
+	const hasTask = Boolean(workspace.task_id);
 
 	return (
 		<ConfirmDialog

--- a/site/src/modules/workspaces/WorkspaceMoreActions/WorkspaceMoreActions.tsx
+++ b/site/src/modules/workspaces/WorkspaceMoreActions/WorkspaceMoreActions.tsx
@@ -256,7 +256,7 @@ export const WorkspaceMoreActions: FC<WorkspaceMoreActionsProps> = ({
 
 			<WorkspaceDeleteDialog
 				workspace={workspace}
-				canDeleteFailedWorkspace={!!permissions?.deleteFailedWorkspace}
+				canDeleteFailedWorkspace={Boolean(permissions?.deleteFailedWorkspace)}
 				isOpen={isConfirmingDelete}
 				onCancel={() => {
 					setIsConfirmingDelete(false);

--- a/site/src/modules/workspaces/WorkspaceMoreActions/useWorkspaceDuplication.ts
+++ b/site/src/modules/workspaces/WorkspaceMoreActions/useWorkspaceDuplication.ts
@@ -36,7 +36,7 @@ export function useWorkspaceDuplication(workspace?: Workspace) {
 	const getLink = useLinks();
 	const buildParametersQuery = useQuery({
 		...workspaceBuildParameters(workspace?.latest_build.id ?? ""),
-		enabled: !!workspace,
+		enabled: Boolean(workspace),
 	});
 
 	// Not using useEffectEvent for this, because useEffect isn't really an

--- a/site/src/pages/AgentsPage/AgentSettingsTemplatesPage.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsTemplatesPage.tsx
@@ -27,7 +27,7 @@ const AgentSettingsTemplatesPage: FC = () => {
 				templatesData={templatesQuery.data}
 				allowlistData={allowlistQuery.data}
 				isLoading={isLoading}
-				hasError={!!(templatesQuery.error || allowlistQuery.error)}
+				hasError={Boolean(templatesQuery.error || allowlistQuery.error)}
 				onRetry={() => {
 					void templatesQuery.refetch();
 					void allowlistQuery.refetch();

--- a/site/src/pages/AgentsPage/components/ChatMessageInput/ChatMessageInput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatMessageInput/ChatMessageInput.tsx
@@ -709,7 +709,7 @@ const ChatMessageInput = ({
 					initialEditorState={initialEditorState}
 				/>
 				<InsertTextPlugin onEditorReady={handleEditorReady} />
-				<EditableStatePlugin disabled={!!disabled} />
+				<EditableStatePlugin disabled={Boolean(disabled)} />
 				{autoFocus && <AutoFocusPlugin />}
 			</div>
 		</LexicalComposer>

--- a/site/src/pages/AgentsPage/components/DiffViewer/DiffViewer.tsx
+++ b/site/src/pages/AgentsPage/components/DiffViewer/DiffViewer.tsx
@@ -540,7 +540,7 @@ export const DiffViewer: FC<DiffViewerProps> = ({
 	// When the parent provides per-file callbacks (e.g. line click
 	// handlers for comment inputs), build options per file. Otherwise
 	// share a single stable object to avoid unnecessary re-highlights.
-	const hasPerFileCallbacks = !!(onLineNumberClick || onLineSelected);
+	const hasPerFileCallbacks = Boolean(onLineNumberClick || onLineSelected);
 
 	const getOptionsForFile = (fileName: string) => ({
 		...diffOptions,

--- a/site/src/pages/AgentsPage/components/GitPanel/GitPanel.tsx
+++ b/site/src/pages/AgentsPage/components/GitPanel/GitPanel.tsx
@@ -72,8 +72,8 @@ export const GitPanel: FC<GitPanelProps> = ({
 	chatInputRef,
 }) => {
 	const hasRemoteStats =
-		remoteDiffStats != null &&
-		(remoteDiffStats.additions > 0 || remoteDiffStats.deletions > 0);
+		(remoteDiffStats?.additions ?? 0) > 0 ||
+		(remoteDiffStats?.deletions ?? 0) > 0;
 
 	const showRemoteTab = Boolean(prTab) || hasRemoteStats;
 

--- a/site/src/pages/AgentsPage/components/GitPanel/GitPanel.tsx
+++ b/site/src/pages/AgentsPage/components/GitPanel/GitPanel.tsx
@@ -72,10 +72,10 @@ export const GitPanel: FC<GitPanelProps> = ({
 	chatInputRef,
 }) => {
 	const hasRemoteStats =
-		!!remoteDiffStats &&
+		remoteDiffStats != null &&
 		(remoteDiffStats.additions > 0 || remoteDiffStats.deletions > 0);
 
-	const showRemoteTab = !!prTab || hasRemoteStats;
+	const showRemoteTab = Boolean(prTab) || hasRemoteStats;
 
 	const prTitle = remoteDiffStats?.pull_request_title;
 	const prState = remoteDiffStats?.pull_request_state;

--- a/site/src/pages/AgentsPage/components/RetentionPeriodSettings.tsx
+++ b/site/src/pages/AgentsPage/components/RetentionPeriodSettings.tsx
@@ -141,7 +141,7 @@ export const RetentionPeriodSettings: FC<RetentionPeriodSettingsProps> = ({
 							disabled={
 								isSavingRetentionDays ||
 								!form.dirty ||
-								!!form.errors.retention_days
+								Boolean(form.errors.retention_days)
 							}
 						>
 							Save

--- a/site/src/pages/AgentsPage/components/WorkspaceAutostopSettings.tsx
+++ b/site/src/pages/AgentsPage/components/WorkspaceAutostopSettings.tsx
@@ -137,7 +137,7 @@ export const WorkspaceAutostopSettings: FC<WorkspaceAutostopSettingsProps> = ({
 					onChange={handleTTLChange}
 					label="Autostop Fallback"
 					disabled={isSavingWorkspaceTTL || isWorkspaceTTLLoading}
-					error={!!fieldError}
+					error={Boolean(fieldError)}
 					helperText={fieldError}
 				/>
 			)}
@@ -146,7 +146,9 @@ export const WorkspaceAutostopSettings: FC<WorkspaceAutostopSettingsProps> = ({
 					<Button
 						size="sm"
 						type="submit"
-						disabled={isSavingWorkspaceTTL || !form.dirty || !!fieldError}
+						disabled={
+							isSavingWorkspaceTTL || !form.dirty || Boolean(fieldError)
+						}
 					>
 						Save
 					</Button>

--- a/site/src/pages/CreateTemplatePage/CreateTemplateForm.tsx
+++ b/site/src/pages/CreateTemplatePage/CreateTemplateForm.tsx
@@ -224,7 +224,7 @@ export const CreateTemplateForm: FC<CreateTemplateFormProps> = (props) => {
 
 	const { data: provisioners } = useQuery({
 		...provisionerDaemons(selectedOrg?.id ?? ""),
-		enabled: showOrganizationPicker && !!selectedOrg,
+		enabled: showOrganizationPicker && Boolean(selectedOrg),
 	});
 
 	// TODO: Ideally, we would have a backend endpoint that could notify the

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
@@ -78,7 +78,7 @@ const CreateWorkspacePage: FC = () => {
 	);
 	const templateVersionPresetsQuery = useQuery({
 		...templateVersionPresets(templateQuery.data?.active_version_id ?? ""),
-		enabled: !!templateQuery.data,
+		enabled: Boolean(templateQuery.data),
 	});
 	const permissionsQuery = useQuery({
 		...checkAuthorization({
@@ -87,7 +87,7 @@ const CreateWorkspacePage: FC = () => {
 				templateQuery.data?.id,
 			),
 		}),
-		enabled: !!templateQuery.data,
+		enabled: Boolean(templateQuery.data),
 	});
 	const realizedVersionId =
 		customVersionId ?? templateQuery.data?.active_version_id;

--- a/site/src/pages/DeploymentSettingsPage/IdpOrgSyncPage/IdpOrgSyncPage.tsx
+++ b/site/src/pages/DeploymentSettingsPage/IdpOrgSyncPage/IdpOrgSyncPage.tsx
@@ -36,7 +36,7 @@ const IdpOrgSyncPage: FC = () => {
 
 	const fieldValuesQuery = useQuery({
 		...deploymentIdpSyncFieldValues(field),
-		enabled: !!field,
+		enabled: Boolean(field),
 	});
 
 	const patchOrganizationSyncSettingsMutation = useMutation(

--- a/site/src/pages/DeploymentSettingsPage/NotificationsPage/NotificationsPage.tsx
+++ b/site/src/pages/DeploymentSettingsPage/NotificationsPage/NotificationsPage.tsx
@@ -65,11 +65,10 @@ const NotificationsPage: FC = () => {
 		? tabState.value
 		: NOTIFICATION_TABS[0];
 
-	const ready = !!(
-		systemTemplatesByGroup.data &&
-		customTemplatesByGroup.data &&
-		dispatchMethods.data
-	);
+	const ready =
+		systemTemplatesByGroup.data != null &&
+		customTemplatesByGroup.data != null &&
+		dispatchMethods.data != null;
 	// Combine system and custom notification templates
 	const allTemplatesByGroup = {
 		...systemTemplatesByGroup.data,

--- a/site/src/pages/GroupsPage/GroupPage.tsx
+++ b/site/src/pages/GroupsPage/GroupPage.tsx
@@ -67,7 +67,7 @@ const GroupPage: FC = () => {
 	const groupData = groupQuery.data;
 	const { data: permissions } = useQuery({
 		...groupPermissions(groupData?.id ?? ""),
-		enabled: !!groupData,
+		enabled: Boolean(groupData),
 	});
 	const deleteGroupMutation = useMutation(
 		deleteGroup(queryClient, organization),

--- a/site/src/pages/GroupsPage/GroupsPage.tsx
+++ b/site/src/pages/GroupsPage/GroupsPage.tsx
@@ -25,11 +25,11 @@ const GroupsPage: FC = () => {
 	const { organization, showOrganizations } = useGroupsSettings();
 	const groupsQuery = useQuery({
 		...groupsByOrganization(organization?.name ?? ""),
-		enabled: !!organization,
+		enabled: Boolean(organization),
 	});
 	const permissionsQuery = useQuery({
 		...organizationsPermissions([organization?.id ?? ""]),
-		enabled: !!organization,
+		enabled: Boolean(organization),
 	});
 
 	useEffect(() => {

--- a/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpSyncPage.tsx
+++ b/site/src/pages/OrganizationSettingsPage/IdpSyncPage/IdpSyncPage.tsx
@@ -70,7 +70,7 @@ const IdpSyncPage: FC = () => {
 
 	const fieldValuesQuery = useQuery({
 		...organizationIdpSyncClaimFieldValues(organizationName, field),
-		enabled: !!field,
+		enabled: Boolean(field),
 	});
 
 	const patchGroupSyncSettingsMutation = useMutation(

--- a/site/src/pages/TaskPage/TaskPage.tsx
+++ b/site/src/pages/TaskPage/TaskPage.tsx
@@ -900,7 +900,7 @@ const TaskStartingAgent: FC<TaskStartingAgentProps> = ({ task, agent }) => {
 function selectAgent(workspace: Workspace) {
 	const agents = workspace.latest_build.resources
 		.flatMap((r) => r.agents)
-		.filter((a) => !!a);
+		.filter(Boolean);
 
 	return agents.at(0);
 }

--- a/site/src/pages/TemplatePage/TemplateLayout.tsx
+++ b/site/src/pages/TemplatePage/TemplateLayout.tsx
@@ -92,7 +92,7 @@ export const TemplateLayout: FC<PropsWithChildren> = ({
 				me.id,
 			),
 		}),
-		enabled: !!data,
+		enabled: Boolean(data),
 	});
 
 	const location = useLocation();

--- a/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceActions/WorkspaceActions.tsx
@@ -66,7 +66,7 @@ export const WorkspaceActions: FC<WorkspaceActionsProps> = ({
 	const { actions, canCancel, canAcceptJobs } = abilitiesByWorkspaceStatus(
 		workspace,
 		{
-			canDebug: !!deployment?.config.enable_terraform_debug_mode,
+			canDebug: Boolean(deployment?.config.enable_terraform_debug_mode),
 			isOwner: user.roles.some((role) => role.name === "owner"),
 		},
 	);

--- a/site/src/pages/WorkspacePage/WorkspacePage.tsx
+++ b/site/src/pages/WorkspacePage/WorkspacePage.tsx
@@ -35,7 +35,7 @@ const WorkspacePage: FC = () => {
 	// Template
 	const templateQuery = useQuery({
 		...templateQueryOptions(workspace?.template_id ?? ""),
-		enabled: !!workspace,
+		enabled: Boolean(workspace),
 	});
 	const template = templateQuery.data;
 

--- a/site/src/utils/platform.ts
+++ b/site/src/utils/platform.ts
@@ -2,7 +2,7 @@
  * Returns true if the current platform is macOS.
  */
 function isMac(): boolean {
-	return !!navigator.platform.match("Mac");
+	return Boolean(navigator.platform.match("Mac"));
 }
 
 /**


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood 🤖

Replaces all `!!<variable>` double-negation patterns in the frontend with `Boolean(<variable>)` for explicit boolean coercion.

**Two special cases** where `!!` was serving as a type-narrowing mechanism (TypeScript's aliased conditional narrowing):

- `GitPanel.tsx` — `!!remoteDiffStats && remoteDiffStats.additions` replaced with `remoteDiffStats != null && ...` to preserve narrowing.
- `NotificationsPage.tsx` — `const ready = !!(...data && ...data && ...data)` replaced with explicit `!= null` checks to preserve aliased narrowing through the `ready` variable.
- `TaskPage.tsx` — `.filter((a) => !!a)` replaced with `.filter(Boolean)` which is idiomatic and type-safe in TypeScript 5.5+.

25 files changed, zero `!!` remaining in `site/src`.