### PR TITLE
ci: add create-release-branch type to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,11 +5,12 @@ on:
     inputs:
       release_type:
         type: choice
-        description: "Type of release: rc (from main) or release (from release branch)"
+        description: "Type of release: rc (from main), release (from release branch), or create-release-branch (cut branch + tag RC)"
         required: true
         options:
           - rc
           - release
+          - create-release-branch
       commit_sha:
         description: "Commit SHA to tag (required for RC, must be on main)"
         type: string
@@ -67,6 +68,7 @@ jobs:
       previous_version: ${{ steps.prepare.outputs.previous_version }}
       channel: ${{ steps.prepare.outputs.channel }}
       target_ref: ${{ steps.prepare.outputs.target_ref }}
+      create_branch: ${{ steps.prepare.outputs.create_branch }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
@@ -94,7 +96,7 @@ jobs:
 
           # Calculate the next version
           args=(--type "$RELEASE_TYPE")
-          if [[ "$RELEASE_TYPE" == "rc" ]]; then
+          if [[ "$RELEASE_TYPE" == "rc" || "$RELEASE_TYPE" == "create-release-branch" ]]; then
             args+=(--commit "$COMMIT_SHA")
           else
             args+=(--branch "$RELEASE_BRANCH")
@@ -105,16 +107,19 @@ jobs:
           previous_version=$(echo "$result" | jq -r .previous_version)
           channel=$(echo "$result" | jq -r .channel)
           target_ref=$(echo "$result" | jq -r .target_ref)
+          create_branch=$(echo "$result" | jq -r '.create_branch // ""')
 
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "previous_version=$previous_version" >> "$GITHUB_OUTPUT"
           echo "channel=$channel" >> "$GITHUB_OUTPUT"
           echo "target_ref=$target_ref" >> "$GITHUB_OUTPUT"
+          echo "create_branch=$create_branch" >> "$GITHUB_OUTPUT"
 
           echo "Calculated version: $version"
           echo "Previous version: $previous_version"
           echo "Channel: $channel"
           echo "Target ref: $target_ref"
+          echo "Create branch: $create_branch"
         env:
           RELEASE_TYPE: ${{ inputs.release_type }}
           COMMIT_SHA: ${{ inputs.commit_sha }}
@@ -143,6 +148,21 @@ jobs:
           git tag -a "$VERSION" -m "Dry-run release $VERSION" "$TARGET_REF" 2>/dev/null || true
         env:
           VERSION: ${{ steps.prepare.outputs.version }}
+          TARGET_REF: ${{ steps.prepare.outputs.target_ref }}
+
+      - name: Create release branch
+        if: ${{ steps.prepare.outputs.create_branch != '' && !inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code origin "refs/heads/$CREATE_BRANCH" >/dev/null 2>&1; then
+            echo "Branch $CREATE_BRANCH already exists, skipping."
+          else
+            git branch "$CREATE_BRANCH" "$TARGET_REF"
+            git push origin "$CREATE_BRANCH"
+            echo "Created branch $CREATE_BRANCH at $TARGET_REF"
+          fi
+        env:
+          CREATE_BRANCH: ${{ steps.prepare.outputs.create_branch }}
           TARGET_REF: ${{ steps.prepare.outputs.target_ref }}
 
       - name: Generate release notes

--- a/scripts/release-action/calculate.go
+++ b/scripts/release-action/calculate.go
@@ -17,6 +17,7 @@ type CalculateResult struct {
 	PreviousVersion string `json:"previous_version"`
 	Channel         string `json:"channel"`
 	TargetRef       string `json:"target_ref"`
+	CreateBranch    string `json:"create_branch,omitempty"`
 }
 
 // String returns the JSON representation of the result.
@@ -37,8 +38,10 @@ func calculateNextVersion(releaseType, commitSHA, branch string) (*CalculateResu
 		return calculateRC(commitSHA)
 	case "release":
 		return calculateRelease(branch)
+	case "create-release-branch":
+		return calculateCreateBranch(commitSHA)
 	default:
-		return nil, xerrors.Errorf("unknown release type %q, must be rc or release", releaseType)
+		return nil, xerrors.Errorf("unknown release type %q, must be rc, release, or create-release-branch", releaseType)
 	}
 }
 
@@ -220,6 +223,114 @@ func calculateRelease(branch string) (*CalculateResult, error) {
 		PreviousVersion: prevVersionStr,
 		Channel:         channel,
 		TargetRef:       targetRef,
+	}, nil
+}
+
+func calculateCreateBranch(commitSHA string) (*CalculateResult, error) {
+	if commitSHA == "" {
+		return nil, xerrors.New("--commit is required for create-release-branch")
+	}
+
+	// Validate that the commit SHA looks like a hex string to
+	// prevent shell injection via git arguments.
+	hexRe := regexp.MustCompile(`^[0-9a-fA-F]+$`)
+	if !hexRe.MatchString(commitSHA) {
+		return nil, xerrors.Errorf("--commit must be a hex SHA (got %q)", commitSHA)
+	}
+
+	// Verify the commit is an ancestor of origin/main.
+	if err := gitRun("merge-base", "--is-ancestor", commitSHA, "origin/main"); err != nil {
+		return nil, xerrors.Errorf("commit %s is not an ancestor of origin/main", commitSHA)
+	}
+
+	allTags, err := allSemverTags()
+	if err != nil {
+		return nil, xerrors.Errorf("listing tags: %w", err)
+	}
+
+	// Find latest mainline (non-RC, non-prerelease) release.
+	var latestMainline *version
+	for _, t := range allTags {
+		if t.Pre == "" {
+			v := t
+			latestMainline = &v
+			break
+		}
+	}
+
+	// Find the latest RC tag.
+	var latestRC *version
+	for _, t := range allTags {
+		if t.IsRC() {
+			v := t
+			latestRC = &v
+			break
+		}
+	}
+
+	// Determine the next minor version for the branch.
+	var major, minor int
+	if latestMainline != nil {
+		major = latestMainline.Major
+		minor = latestMainline.Minor + 1
+		// If the latest RC already targets this minor, use it.
+		if latestRC != nil && latestRC.Major == major && latestRC.Minor == minor {
+			// Already aligned, keep major.minor.
+		}
+	} else {
+		// No mainline release found — start from a safe default.
+		major = 2
+		minor = 0
+	}
+
+	branchName := fmt.Sprintf("release/%d.%d", major, minor)
+
+	// Check whether the branch already exists on the remote.
+	if err := gitRun("rev-parse", "--verify", "origin/"+branchName); err == nil {
+		return nil, xerrors.Errorf("branch %s already exists", branchName)
+	}
+
+	// Find the latest RC tag for this major.minor series.
+	var seriesRC *version
+	for _, t := range allTags {
+		if t.IsRC() && t.Major == major && t.Minor == minor {
+			v := t
+			seriesRC = &v
+			break
+		}
+	}
+
+	var suggested version
+	var prevVersionStr string
+
+	if seriesRC != nil {
+		prevVersionStr = seriesRC.String()
+		suggested = version{
+			Major: major,
+			Minor: minor,
+			Patch: 0,
+			Pre:   fmt.Sprintf("rc.%d", seriesRC.rcNumber()+1),
+		}
+	} else {
+		if latestMainline != nil {
+			prevVersionStr = latestMainline.String()
+		} else {
+			prevVersionStr = "v0.0.0"
+		}
+		suggested = version{
+			Major: major,
+			Minor: minor,
+			Patch: 0,
+			Pre:   "rc.0",
+		}
+	}
+
+	return &CalculateResult{
+		Version:         suggested.String(),
+		PreviousVersion: prevVersionStr,
+		Channel:         "rc",
+		TargetRef:       commitSHA,
+		CreateBranch:    branchName,
 	}, nil
 }
 

--- a/scripts/release-action/calculate.go
+++ b/scripts/release-action/calculate.go
@@ -258,25 +258,13 @@ func calculateCreateBranch(commitSHA string) (*CalculateResult, error) {
 		}
 	}
 
-	// Find the latest RC tag.
-	var latestRC *version
-	for _, t := range allTags {
-		if t.IsRC() {
-			v := t
-			latestRC = &v
-			break
-		}
-	}
+
 
 	// Determine the next minor version for the branch.
 	var major, minor int
 	if latestMainline != nil {
 		major = latestMainline.Major
 		minor = latestMainline.Minor + 1
-		// If the latest RC already targets this minor, use it.
-		if latestRC != nil && latestRC.Major == major && latestRC.Minor == minor {
-			// Already aligned, keep major.minor.
-		}
 	} else {
 		// No mainline release found — start from a safe default.
 		major = 2

--- a/scripts/release-action/calculate.go
+++ b/scripts/release-action/calculate.go
@@ -258,8 +258,6 @@ func calculateCreateBranch(commitSHA string) (*CalculateResult, error) {
 		}
 	}
 
-
-
 	// Determine the next minor version for the branch.
 	var major, minor int
 	if latestMainline != nil {

--- a/scripts/release-action/main.go
+++ b/scripts/release-action/main.go
@@ -47,14 +47,14 @@ func main() {
 					{
 						Name:        "type",
 						Flag:        "type",
-						Description: "Release type: rc or release.",
+						Description: "Release type: rc, release, or create-release-branch.",
 						Required:    true,
 						Value:       serpent.StringOf(&releaseType),
 					},
 					{
 						Name:        "commit",
 						Flag:        "commit",
-						Description: "Commit SHA to tag (RC only).",
+						Description: "Commit SHA to tag (RC and create-release-branch).",
 						Value:       serpent.StringOf(&commitSHA),
 					},
 					{

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -43,8 +43,15 @@ else
 	current_commit=$(git rev-parse HEAD)
 	# Try to find the last tag that contains the current commit
 	last_tag=$(git tag --contains "$current_commit" --sort=version:refname | head -n 1)
-	# If there is no tag that contains the current commit,
-	# get the latest tag sorted by semver.
+	# If there is no tag that contains the current commit, find
+	# the nearest ancestor tag. This keeps the version anchored
+	# to the correct release series on release branches instead
+	# of picking up an unrelated RC from a newer series.
+	if [[ -z "${last_tag}" ]]; then
+		last_tag=$(git describe --tags --match 'v*' --abbrev=0 2>/dev/null || true)
+	fi
+	# If git describe found nothing (e.g. shallow clone or fork
+	# without tags in ancestry), fall back to the global latest.
 	if [[ -z "${last_tag}" ]]; then
 		last_tag=$(git tag --sort=version:refname | tail -n 1)
 	fi


### PR DESCRIPTION
Builds on #24167.

## Context

Aligns the release workflow with the new release process:
- **No more mainline/stable distinction** — all releases are stable
  from day one.
- **RC-first workflow** — RCs are cut from main, then when ready to
  freeze, a release branch is created with an RC tag in one step.
- The ESR/LTS model is a process decision that doesn't require code
  changes here.

## Changes

### New `create-release-branch` release type

A single workflow dispatch that atomically creates the release branch
and tags it with the next RC:

- RCs are still cut from main via the `rc` type.
- When ready to freeze (~1 week before release), the release manager
  triggers `create-release-branch` with the commit SHA.
- The workflow computes the next RC number (incrementing from any
  prior RCs on main for that series, or `rc.0` if none), tags the
  commit, and creates `release/<major>.<minor>`.
- The `release` type then cuts the final `.0` from the branch.

### Remove mainline/stable distinction

- `determineChannel()` always returns `"stable"` for non-RC releases.
- Release notes no longer add mainline warning banners.
- Docs calendar transitions skip the `Mainline` → `Stable` step —
  new releases go straight to `Stable`.
- Rancher file updates only handle the `stable` channel.

### `version.sh` ancestor tag fallback

Replaces `git tag --sort=version:refname | tail -n 1` (global latest)
with `git describe --tags --match 'v*' --abbrev=0` (nearest ancestor).
This anchors dev builds on release branches to the correct version
series even when newer RC tags exist globally.

## Example flow

1. `rc` from main → `v2.33.0-rc.0` tagged on main.
2. More RCs from main → `v2.33.0-rc.1`.
3. `create-release-branch` from `v2.33.0-rc.1` commit → creates
   `release/2.33`, tags `v2.33.0-rc.2`.
4. QA/UAT on `release/2.33`. Dogfood shows `2.33.0-rc.2-devel+sha`.
5. `release` from `release/2.33` → tags `v2.33.0` (stable from day 1).

> Generated by Coder Agents