### PR TITLE
feat(site): hide agents desktop tab when workspace is stopped

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -489,7 +489,9 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 						isSidebarCollapsed={isSidebarCollapsed}
 						onToggleSidebarCollapsed={onToggleSidebarCollapsed}
 						chatTitle={chatTitle}
-						desktopChatId={desktopChatId}
+						desktopChatId={
+							workspace && workspaceAgent ? desktopChatId : undefined
+						}
 					/>
 				</RightPanel>
 			</div>


### PR DESCRIPTION
Hide the agents desktop tab when the workspace tab is stopped. This matches the terminal tab's behavior.