### PR TITLE
ci: attribute cherry-pick/backport PRs to the requesting user

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -84,6 +84,7 @@ jobs:
       PR_TITLE: ${{ github.event.pull_request.title }}
       PR_URL: ${{ github.event.pull_request.html_url }}
       MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+      SENDER: ${{ github.event.sender.login }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -139,6 +140,7 @@ jobs:
 
           Original PR: #${PR_NUMBER} — ${PR_TITLE}
           Merge commit: ${MERGE_SHA}
+          Requested by: @${SENDER}
           EOF
           )
 
@@ -171,4 +173,6 @@ jobs:
             --base "$RELEASE_VERSION" \
             --head "$BACKPORT_BRANCH" \
             --title "$TITLE" \
-            --body "$BODY"
+            --body "$BODY" \
+            --assignee "$SENDER" \
+            --reviewer "$SENDER"

--- a/.github/workflows/cherry-pick.yaml
+++ b/.github/workflows/cherry-pick.yaml
@@ -42,6 +42,7 @@ jobs:
       PR_TITLE: ${{ github.event.pull_request.title }}
       PR_URL: ${{ github.event.pull_request.html_url }}
       MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+      SENDER: ${{ github.event.sender.login }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -116,6 +117,7 @@ jobs:
 
           Original PR: #${PR_NUMBER} — ${PR_TITLE}
           Merge commit: ${MERGE_SHA}
+          Requested by: @${SENDER}
           EOF
           )
 
@@ -136,4 +138,6 @@ jobs:
             --base "$RELEASE_BRANCH" \
             --head "$BACKPORT_BRANCH" \
             --title "$TITLE" \
-            --body "$BODY"
+            --body "$BODY" \
+            --assignee "$SENDER" \
+            --reviewer "$SENDER"


### PR DESCRIPTION
The cherry-pick and backport workflows create PRs under `github-actions[bot]`. Since GitHub doesn't support creating PRs on behalf of another user, this adds attribution to the user who added the label (`github.event.sender.login`):

- **Assignee**: the labeler is assigned to the backport PR
- **Reviewer**: the labeler is added as a reviewer
- **PR body**: includes "Requested by: @user"

Applied to both `cherry-pick.yaml` and `backport.yaml`.

---

> Generated by Coder Agents