### PR TITLE
feat: add EC2 dogfood template for cloud VM deployment pattern

### DIFF
--- a/.github/workflows/dogfood.yaml
+++ b/.github/workflows/dogfood.yaml
@@ -157,6 +157,10 @@ jobs:
           terraform init
           terraform validate
           popd
+          pushd dogfood/coder-ec2
+          terraform init
+          terraform validate
+          popd
 
       - name: Get short commit SHA
         if: github.ref == 'refs/heads/main'

--- a/dogfood/coder-ec2/README.md
+++ b/dogfood/coder-ec2/README.md
@@ -1,0 +1,173 @@
+# coder-ec2: EC2 Dogfood Template
+
+EC2-based dogfood template for exercising the "cloud VM + devcontainer"
+deployment pattern. Companion to
+`coder-k8s` (EKS/Kubernetes) — together they cover the two most common
+production deployment models.
+
+## Architecture
+
+```
+EC2 instance (m5d.xlarge)
+├── /            (root EBS, 50 GB, ephemeral — OS, Docker, agent)
+├── /home/coder  (data EBS, 128 GB, persistent — code, user data)
+├── swap         (NVMe instance store, ~150 GB)
+├── coder agent  (host — monitoring, escape hatch)
+└── devcontainer (codercom/oss-dogfood:latest)
+    ├── docker-in-docker (nested daemon via DinD feature)
+    └── coder sub-agent  (IDE connections route here)
+```
+
+### Storage design
+
+
+Docker and the Coder host agent live on the **root volume**, not
+the data volume. This is a deliberate design decision:
+
+- The devcontainer is the primary workspace entrypoint. If the
+  data volume (`/home/coder`) fills up, Docker and the host agent
+  must keep running so the user can connect to the "parent" host
+  agent and clean up.
+- The host agent is the escape hatch. It runs as a systemd service
+  on the root volume and remains accessible even when Docker or
+  the devcontainer is down.
+- Docker images and layers are ephemeral. They are lost on a
+  workspace rebuild (root is `delete_on_termination = true`) but
+  persist across stop/start. The `docker system prune` in the
+  shutdown script keeps root volume usage bounded.
+
+The devcontainer uses the repo's own `.devcontainer/devcontainer.json`
+(cloned automatically by the `git-clone` module) — no
+template-specific devcontainer config to maintain.
+
+
+## Required IAM Permissions
+
+The Coder provisioner (the entity running `terraform apply`) needs
+an IAM policy with these permissions:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "EC2Instances",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:RunInstances",
+        "ec2:TerminateInstances",
+        "ec2:StartInstances",
+        "ec2:StopInstances",
+        "ec2:DescribeInstances",
+        "ec2:DescribeInstanceStatus",
+        "ec2:DescribeInstanceTypes",
+        "ec2:ModifyInstanceAttribute"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestedRegion": ["eu-west-1", "us-east-2"]
+        }
+      }
+    },
+    {
+      "Sid": "EBSVolumes",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateVolume",
+        "ec2:DeleteVolume",
+        "ec2:AttachVolume",
+        "ec2:DetachVolume",
+        "ec2:ModifyVolume",
+        "ec2:DescribeVolumes",
+        "ec2:DescribeVolumeStatus"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestedRegion": ["eu-west-1", "us-east-2"]
+        }
+      }
+    },
+    {
+      "Sid": "Tagging",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags",
+        "ec2:DescribeTags"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "ReadOnly",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeImages",
+        "ec2:DescribeAvailabilityZones",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeVpcs",
+        "ec2:DescribeIamInstanceProfileAssociations",
+        "iam:GetInstanceProfile"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+### Condition notes
+
+- The region condition restricts instance and volume creation to the
+  regions offered as workspace parameters. Update this list if you add
+  regions.
+- For tighter control, replace `"Resource": "*"` with ARN patterns
+  scoped to the VPC, subnet, and security group used by the template.
+- `iam:GetInstanceProfile` is only needed if the
+  `iam_instance_profile` variable is set.
+
+## Template Variables
+
+These are set at the template level (by an admin), not per workspace:
+
+| Variable               | Required | Description                          |
+|------------------------|----------|--------------------------------------|
+| `vpc_subnet_id`        | Yes      | Subnet to launch instances in        |
+| `security_group_id`    | Yes      | SG for instances (outbound-only OK)  |
+| `iam_instance_profile` | No       | Optional instance profile name       |
+
+## Security Group
+
+The Coder agent dials out to the Coder server — no inbound rules
+are required for normal operation. A minimal security group:
+
+```hcl
+resource "aws_security_group" "coder_workspace" {
+  name_prefix = "coder-workspace-"
+  vpc_id      = var.vpc_id
+
+  # All outbound traffic (agent -> Coder server, package repos, etc.)
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Optional: SSH for debugging.
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["10.0.0.0/8"]  # Internal only
+  }
+}
+```
+
+## Quota
+
+Storage quota uses the same unit as the `coder-k8s` template:
+**1 daily_cost = 1 GB provisioned EBS**. Default workspace =
+128 units (data volume). The root volume is not metered
+(ephemeral, destroyed on rebuild).

--- a/dogfood/coder-ec2/README.md
+++ b/dogfood/coder-ec2/README.md
@@ -130,11 +130,11 @@ an IAM policy with these permissions:
 
 These are set at the template level (by an admin), not per workspace:
 
-| Variable               | Required | Description                          |
-|------------------------|----------|--------------------------------------|
-| `vpc_subnet_id`        | Yes      | Subnet to launch instances in        |
-| `security_group_id`    | Yes      | SG for instances (outbound-only OK)  |
-| `iam_instance_profile` | No       | Optional instance profile name       |
+| Variable               | Required | Description                         |
+|------------------------|----------|-------------------------------------|
+| `vpc_subnet_id`        | Yes      | Subnet to launch instances in       |
+| `security_group_id`    | Yes      | SG for instances (outbound-only OK) |
+| `iam_instance_profile` | No       | Optional instance profile name      |
 
 ## Security Group
 

--- a/dogfood/coder-ec2/README.md
+++ b/dogfood/coder-ec2/README.md
@@ -7,8 +7,9 @@ production deployment models.
 
 ## Architecture
 
-```
+```text
 EC2 instance (m5d.xlarge)
+
 ├── /            (root EBS, 50 GB, ephemeral — OS, Docker, agent)
 ├── /home/coder  (data EBS, 128 GB, persistent — code, user data)
 ├── swap         (NVMe instance store, ~150 GB)
@@ -19,7 +20,6 @@ EC2 instance (m5d.xlarge)
 ```
 
 ### Storage design
-
 
 Docker and the Coder host agent live on the **root volume**, not
 the data volume. This is a deliberate design decision:
@@ -39,7 +39,6 @@ the data volume. This is a deliberate design decision:
 The devcontainer uses the repo's own `.devcontainer/devcontainer.json`
 (cloned automatically by the `git-clone` module) — no
 template-specific devcontainer config to maintain.
-
 
 ## Required IAM Permissions
 

--- a/dogfood/coder-ec2/cloud-init/cloud-config.yaml.tftpl
+++ b/dogfood/coder-ec2/cloud-init/cloud-config.yaml.tftpl
@@ -1,0 +1,69 @@
+#cloud-config
+hostname: ${hostname}
+
+users:
+  - name: ${linux_user}
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [docker]
+
+packages:
+  - docker.io
+  - git
+  - curl
+  - jq
+  - nvme-cli
+
+growpart:
+  mode: auto
+  devices: ["/"]
+
+write_files:
+  # Coder agent systemd service. Runs the init script on every boot
+  # and restarts the agent if it crashes.
+  - path: /etc/systemd/system/coder-agent.service
+    permissions: "0644"
+    content: |
+      [Unit]
+      Description=Coder Agent
+      After=network-online.target docker.service
+      Wants=network-online.target
+
+      [Service]
+      User=${linux_user}
+      EnvironmentFile=/opt/coder/init.env
+      ExecStart=/opt/coder/init
+      Restart=always
+      RestartSec=10
+      TimeoutStopSec=90
+      KillMode=process
+      OOMScoreAdjust=-900
+      SyslogIdentifier=coder-agent
+
+      [Install]
+      WantedBy=multi-user.target
+
+# bootcmd runs on EVERY boot (before runcmd). We use it to set up
+# NVMe swap because the instance store is wiped on stop/start,
+# and to grow filesystems if EBS volumes were resized.
+bootcmd:
+  - |
+    # Find the NVMe instance store device and use it for swap.
+    # EBS-backed NVMe devices report "Amazon Elastic Block Store"
+    # in their model string; instance store reports
+    # "Amazon EC2 NVMe Instance Storage".
+    #
+    # We use lsblk to check the device model rather than nvme-cli,
+    # because bootcmd runs before packages are installed.
+    for dev in /dev/nvme*n1; do
+      model=$(lsblk -no MODEL "$dev" 2>/dev/null | tr -d ' ')
+      if echo "$model" | grep -qi "Instance Storage"; then
+        mkswap "$dev" && swapon "$dev" && break
+      fi
+    done
+  # Only swap under real memory pressure.
+  - sysctl -w vm.swappiness=10
+  # Grow ext4 filesystems on separately-attached EBS volumes if
+  # they were resized via Terraform. resize2fs is a no-op when
+  # the filesystem already fills the device.
+  - resize2fs /dev/disk/by-label/coder-data 2>/dev/null || true

--- a/dogfood/coder-ec2/cloud-init/userdata.sh.tftpl
+++ b/dogfood/coder-ec2/cloud-init/userdata.sh.tftpl
@@ -1,0 +1,89 @@
+#!/bin/bash
+set -euo pipefail
+
+# --- EBS volume helpers ---
+# On Nitro instances, EBS devices appear as /dev/nvmeXn1 with the
+# volume ID (dash removed) as the serial number. These helpers
+# locate a device by volume ID and wait for attachment to complete.
+
+find_ebs_device() {
+  local vol_id="$1"
+  local vol_id_nodash="$${vol_id//-/}"
+  for dev in /dev/nvme*n1; do
+    local serial
+    serial=$(lsblk -no SERIAL "$dev" 2>/dev/null | tr -d ' ')
+    if [ "$serial" = "$vol_id" ] || [ "$serial" = "$vol_id_nodash" ]; then
+      echo "$dev"
+      return 0
+    fi
+  done
+  return 1
+}
+
+wait_for_ebs_device() {
+  local vol_id="$1"
+  local timeout=120
+  local elapsed=0
+  while [ "$elapsed" -lt "$timeout" ]; do
+    local dev
+    if dev=$(find_ebs_device "$vol_id"); then
+      echo "$dev"
+      return 0
+    fi
+    sleep 2
+    elapsed=$((elapsed + 2))
+  done
+  echo "ERROR: timed out waiting for EBS volume $vol_id" >&2
+  return 1
+}
+
+# --- Mount EBS: /home/coder ---
+# Single data volume for persistent user data. Docker lives on
+# the root volume so the workspace remains accessible (via the
+# host agent) even if this volume fills up.
+
+EBS_DATA=$(wait_for_ebs_device "${data_volume_id}")
+
+# Format only on first use (no existing filesystem).
+if ! blkid "$EBS_DATA" &>/dev/null; then
+  mkfs.ext4 -L coder-data "$EBS_DATA"
+fi
+
+mkdir -p /home/${linux_user}
+mount "$EBS_DATA" /home/${linux_user}
+chown ${linux_user}:${linux_user} /home/${linux_user}
+
+# Copy skeleton dotfiles if the home directory is empty (first mount).
+if [ ! -f /home/${linux_user}/.bashrc ]; then
+  cp -a /etc/skel/. /home/${linux_user}/
+  chown -R ${linux_user}:${linux_user} /home/${linux_user}
+fi
+
+# Persist mount across reboots.
+if ! grep -q coder-data /etc/fstab; then
+  echo "LABEL=coder-data /home/${linux_user} ext4 defaults,nofail 0 2" >> /etc/fstab
+fi
+
+# --- Start Docker (uses root volume for /var/lib/docker) ---
+
+systemctl restart docker
+
+# --- Install and start Coder agent ---
+# The agent runs as a systemd service (installed via write_files in
+# cloud-config). We write the init script and environment file here,
+# then enable and start the service. On subsequent boots, systemd
+# starts the agent automatically with the same token.
+
+mkdir -p /opt/coder
+cat > /opt/coder/init.env <<'CODER_ENV'
+CODER_AGENT_TOKEN=${agent_token}
+CODER_ENV
+
+# The init script is base64-encoded to avoid shell quoting issues.
+echo '${agent_init_script}' | base64 -d > /opt/coder/init
+chmod +x /opt/coder/init
+chown -R ${linux_user}:${linux_user} /opt/coder
+
+systemctl daemon-reload
+systemctl enable coder-agent.service
+systemctl start coder-agent.service

--- a/dogfood/coder-ec2/main.tf
+++ b/dogfood/coder-ec2/main.tf
@@ -1,0 +1,347 @@
+terraform {
+  required_providers {
+    coder = {
+      source  = "coder/coder"
+      version = ">= 2.13.0"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+    cloudinit = {
+      source  = "hashicorp/cloudinit"
+      version = ">= 2.0"
+    }
+  }
+}
+
+module "aws_region" {
+  source  = "https://registry.coder.com/modules/aws-region"
+  default = "eu-west-1"
+}
+
+provider "aws" {
+  region = module.aws_region.value
+}
+
+# --- Variables (template-level, set by admin) ---
+
+variable "vpc_subnet_id" {
+  type        = string
+  description = "The VPC subnet to launch instances in."
+}
+
+variable "security_group_id" {
+  type        = string
+  description = "Security group to attach to instances. Agent dials out, so minimal inbound rules are needed."
+}
+
+variable "iam_instance_profile" {
+  type        = string
+  default     = ""
+  description = "Optional IAM instance profile name for the EC2 instance."
+}
+
+# --- Data sources ---
+
+data "coder_workspace" "me" {}
+data "coder_workspace_owner" "me" {}
+
+locals {
+  workspace_name = "coder-${data.coder_workspace_owner.me.name}-${lower(data.coder_workspace.me.name)}"
+  linux_user     = "coder"
+  hostname       = lower(data.coder_workspace.me.name)
+  instance_type  = "m5d.xlarge"
+  data_volume_gb = 128
+  az             = data.aws_subnet.workspace.availability_zone
+  repo_dir       = replace(module.git-clone.repo_dir, "/^~\\//", "/home/coder/")
+}
+
+data "aws_subnet" "workspace" {
+  id = var.vpc_subnet_id
+}
+
+# --- Parameters (per-workspace, set by user) ---
+
+# --- AMI ---
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"]
+  }
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+  owners = ["099720109477"] # Canonical
+}
+
+# --- Cloud-init ---
+
+data "cloudinit_config" "user_data" {
+  gzip          = false
+  base64_encode = false
+  boundary      = "//"
+
+  part {
+    filename     = "cloud-config.yaml"
+    content_type = "text/cloud-config"
+    content = templatefile("${path.module}/cloud-init/cloud-config.yaml.tftpl", {
+      hostname   = local.hostname
+      linux_user = local.linux_user
+    })
+  }
+
+  part {
+    filename     = "userdata.sh"
+    content_type = "text/x-shellscript"
+    content = templatefile("${path.module}/cloud-init/userdata.sh.tftpl", {
+      linux_user        = local.linux_user
+      data_volume_id    = aws_ebs_volume.data.id
+      agent_token       = coder_agent.dev.token
+      agent_init_script = base64encode(coder_agent.dev.init_script)
+    })
+  }
+}
+
+# --- EC2 instance ---
+
+data "aws_iam_instance_profile" "this" {
+  count = var.iam_instance_profile == "" ? 0 : 1
+  name  = var.iam_instance_profile
+}
+
+resource "aws_instance" "workspace" {
+  ami                    = data.aws_ami.ubuntu.id
+  availability_zone      = local.az
+  instance_type          = local.instance_type
+  subnet_id              = var.vpc_subnet_id
+  vpc_security_group_ids = [var.security_group_id]
+  iam_instance_profile   = try(data.aws_iam_instance_profile.this[0].name, null)
+
+  # Enforce IMDSv2 with hop limit 1 to prevent container processes
+  # from accessing instance metadata (agent token, IAM credentials).
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+  }
+
+  root_block_device {
+    volume_size           = 50
+    volume_type           = "gp3"
+    delete_on_termination = true
+  }
+
+  # Expose local NVMe instance store for swap.
+  ephemeral_block_device {
+    device_name  = "/dev/sdb"
+    virtual_name = "ephemeral0"
+  }
+
+  user_data = data.cloudinit_config.user_data.rendered
+
+  tags = {
+    Name              = local.workspace_name
+    Coder_Provisioned = "true"
+  }
+
+  lifecycle {
+    ignore_changes = [ami, user_data]
+  }
+}
+
+resource "aws_ec2_instance_state" "workspace" {
+  instance_id = aws_instance.workspace.id
+  state       = data.coder_workspace.me.transition == "start" ? "running" : "stopped"
+}
+
+# --- Persistent EBS data volume ---
+#
+# Single data volume for /home/coder. Docker lives on the root
+# volume so the workspace remains accessible (via the host agent)
+# even if this volume fills up.
+
+resource "aws_ebs_volume" "data" {
+  availability_zone = local.az
+  size              = local.data_volume_gb
+  type              = "gp3"
+  throughput        = 250 # MB/s
+  iops              = 3000
+
+  tags = {
+    Name              = "${local.workspace_name}-data"
+    Coder_Provisioned = "true"
+  }
+
+  # Protect persistent data: never recreate this volume due to
+  # attribute drift. Size, IOPS, throughput, and type changes are
+  # applied in-place via ModifyVolume. Only availability_zone and
+  # encryption attributes force replacement — ignore those.
+  # See docs/admin/templates/extending-templates/resource-persistence.md
+  lifecycle {
+    ignore_changes = [availability_zone, encrypted, kms_key_id, snapshot_id]
+  }
+}
+
+resource "aws_volume_attachment" "data" {
+  device_name  = "/dev/sdf"
+  volume_id    = aws_ebs_volume.data.id
+  instance_id  = aws_instance.workspace.id
+  force_detach = false
+}
+
+# --- Coder agent (host — bootstrap and monitoring) ---
+
+resource "coder_agent" "dev" {
+  arch                    = "amd64"
+  os                      = "linux"
+  auth                    = "token"
+  dir                     = local.repo_dir
+  startup_script_behavior = "blocking"
+  connection_timeout      = 0
+
+  env = {
+    # Enable devcontainer detection and sub-agent injection.
+    CODER_AGENT_DEVCONTAINERS_ENABLE = "true"
+  }
+
+  # IDEs connect to the devcontainer sub-agent, not the host.
+  display_apps {
+    vscode                 = false
+    vscode_insiders        = false
+    ssh_helper             = true
+    port_forwarding_helper = true
+  }
+
+  metadata {
+    key          = "cpu"
+    display_name = "CPU Usage"
+    interval     = 5
+    timeout      = 5
+    script       = "coder stat cpu"
+  }
+  metadata {
+    key          = "memory"
+    display_name = "Memory Usage"
+    interval     = 5
+    timeout      = 5
+    script       = "coder stat mem"
+  }
+  metadata {
+    key          = "swap"
+    display_name = "Swap Usage"
+    interval     = 15
+    timeout      = 5
+    script       = <<-EOT
+      free -h | awk '/Swap/{print $3"/"$2}'
+    EOT
+  }
+  metadata {
+    key          = "data_disk"
+    display_name = "Data Volume (/home/coder)"
+    interval     = 60
+    timeout      = 5
+    script       = <<-EOT
+      df -h /home/coder | awk 'NR==2{print $3"/"$2" ("$5")"}'
+    EOT
+  }
+
+  resources_monitoring {
+    memory {
+      enabled   = true
+      threshold = 80
+    }
+    volume {
+      path      = "/home/coder"
+      enabled   = true
+      threshold = 90
+    }
+  }
+
+  startup_script = <<-EOT
+    #!/bin/bash
+    set -euo pipefail
+
+    # Authenticate GitHub CLI.
+    if command -v gh &>/dev/null; then
+      gh auth setup-git || true
+    fi
+  EOT
+
+  shutdown_script = <<-EOT
+    #!/bin/bash
+    set -euo pipefail
+
+    # Clean build artifacts to reclaim EBS space.
+    cd "${local.repo_dir}" 2>/dev/null && rm -rf build/ || true
+
+    # Prune Docker to reclaim root volume space.
+    docker system prune -a -f || true
+  EOT
+}
+
+# --- Devcontainer ---
+
+resource "coder_devcontainer" "coder" {
+  count            = data.coder_workspace.me.start_count
+  agent_id         = coder_agent.dev.id
+  workspace_folder = local.repo_dir
+}
+
+module "devcontainers-cli" {
+  source   = "registry.coder.com/coder/devcontainers-cli/coder"
+  version  = "~> 1.0"
+  agent_id = coder_agent.dev.id
+}
+
+# --- Modules ---
+
+module "dotfiles" {
+  source   = "registry.coder.com/coder/dotfiles/coder"
+  version  = "~> 1.0"
+  agent_id = coder_agent.dev.id
+}
+
+module "git-clone" {
+  source   = "registry.coder.com/coder/git-clone/coder"
+  version  = "~> 1.0"
+  agent_id = coder_agent.dev.id
+  url      = "https://github.com/coder/coder.git"
+  base_dir = "/home/coder"
+}
+
+# --- Metadata & Quotas ---
+
+# Quota cost = provisioned storage GB, consistent with the EKS
+# dogfood template (coder-k8s).
+resource "coder_metadata" "data_volume" {
+  resource_id = aws_ebs_volume.data.id
+  daily_cost  = local.data_volume_gb
+  item {
+    key   = "size"
+    value = "${local.data_volume_gb} GB"
+  }
+  item {
+    key   = "mount"
+    value = "/home/coder"
+  }
+}
+
+resource "coder_metadata" "instance_info" {
+  resource_id = aws_instance.workspace.id
+  item {
+    key   = "instance_type"
+    value = local.instance_type
+  }
+  item {
+    key   = "region"
+    value = module.aws_region.value
+  }
+  item {
+    key   = "ami"
+    value = aws_instance.workspace.ami
+  }
+}


### PR DESCRIPTION
Adds a new EC2-based dogfood template that exercises the "cloud VM + devcontainer" deployment pattern. Companion to the existing Docker-on-bare-metal template and the upcoming EKS template (#24188).

- Devcontainer-first: primary entrypoint is the devcontainer (uses repo's `.devcontainer/devcontainer.json`), host agent is the escape hatch
- NVMe instance store used exclusively for swap (graceful OOM degradation)
- Docker on root volume so a full data volume doesn't brick the workspace
- Agent runs as a systemd service (survives stop/start, follows the [incus template pattern](https://github.com/coder/coder/blob/main/examples/templates/incus/main.tf))
- IMDSv2 enforced with hop limit 1
- AZ derived from subnet, not hardcoded
- Quota cost = provisioned storage GB (consistent with `coder-k8s`)

### Prerequisites (separate PRs)

- VPC, subnet, and security group in the target region
- IAM policy for the Coder provisioner (documented in README)
- `coderd_template` registration in `dogfood/main.tf`

> 🤖 Written by a Coder Agent. Will be reviewed by a human.