### PR TITLE
fix(cli): retry dial timeouts in SSH connection setup

### DIFF
--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -69,14 +69,16 @@ var (
 // isRetryableError checks for transient connection errors worth
 // retrying: DNS failures, connection refused, and server 5xx.
 func isRetryableError(err error) bool {
-	if err == nil {
+	if err == nil || xerrors.Is(err, context.Canceled) {
 		return false
 	}
-	if xerrors.Is(err, context.Canceled) || xerrors.Is(err, context.DeadlineExceeded) {
-		return false
-	}
+	// Check connection errors before context.DeadlineExceeded because
+	// net.Dialer.Timeout produces *net.OpError that matches both.
 	if codersdk.IsConnectionError(err) {
 		return true
+	}
+	if xerrors.Is(err, context.DeadlineExceeded) {
+		return false
 	}
 	var sdkErr *codersdk.Error
 	if xerrors.As(err, &sdkErr) {

--- a/cli/ssh_internal_test.go
+++ b/cli/ssh_internal_test.go
@@ -516,6 +516,23 @@ func TestIsRetryableError(t *testing.T) {
 			assert.Equal(t, tt.retryable, isRetryableError(tt.err))
 		})
 	}
+
+	// net.Dialer.Timeout produces *net.OpError that matches both
+	// IsConnectionError and context.DeadlineExceeded. Verify it is retryable.
+	t.Run("DialTimeout", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now())
+		defer cancel()
+		<-ctx.Done() // ensure deadline has fired
+		_, err := (&net.Dialer{}).DialContext(ctx, "tcp", "127.0.0.1:1")
+		require.Error(t, err)
+		// Proves the ambiguity: this error matches BOTH checks.
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.ErrorAs(t, err, new(*net.OpError))
+		assert.True(t, isRetryableError(err))
+		// Also when wrapped, as runCoderConnectStdio does.
+		assert.True(t, isRetryableError(xerrors.Errorf("dial coder connect: %w", err)))
+	})
 }
 
 func TestRetryWithInterval(t *testing.T) {


### PR DESCRIPTION
`net.Dialer.Timeout` expiry produces `*net.OpError` wrapping `context.DeadlineExceeded`. In `isRetryableError`, the `DeadlineExceeded` check fired before `IsConnectionError`, so dial timeouts were never retried.

This caused Coder Connect dial failures (broken tunnel, valid DNS) to immediately fail despite the retry logic from #24010.

Fix: check `IsConnectionError` before `context.DeadlineExceeded`. Network errors are now retried even when they wrap a deadline error. `context.Canceled` stays non-retryable.

Fixes #24201. Depends on #24010.