### PR TITLE
perf(site): virtualize ConversationTimeline with react-virtuoso

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -106,6 +106,7 @@
 		"react-syntax-highlighter": "15.6.6",
 		"react-textarea-autosize": "8.5.9",
 		"react-virtualized-auto-sizer": "1.0.26",
+		"react-virtuoso": "4.18.4",
 		"react-window": "1.8.11",
 		"recharts": "2.15.4",
 		"remark-gfm": "4.0.1",

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -217,6 +217,9 @@ importers:
       react-virtualized-auto-sizer:
         specifier: 1.0.26
         version: 1.0.26(react-dom@19.2.2(react@19.2.2))(react@19.2.2)
+      react-virtuoso:
+        specifier: 4.18.4
+        version: 4.18.4(react-dom@19.2.2(react@19.2.2))(react@19.2.2)
       react-window:
         specifier: 1.8.11
         version: 1.8.11(react-dom@19.2.2(react@19.2.2))(react@19.2.2)
@@ -6246,6 +6249,12 @@ packages:
     peerDependencies:
       react: ^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  react-virtuoso@4.18.4:
+    resolution: {integrity: sha512-DNM4Wy2tMA/J6ejMaDdqecOug31rOwgSRg4C/Dw6Iox4dJe9qwcx32M8HdhkE5uHEVVZh7h0koYwAsCSNdxGfQ==, tarball: https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.18.4.tgz}
+    peerDependencies:
+      react: '>=16 || >=17 || >= 18 || >= 19'
+      react-dom: '>=16 || >=17 || >= 18 || >=19'
 
   react-window@1.8.11:
     resolution: {integrity: sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==, tarball: https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz}
@@ -14068,6 +14077,11 @@ snapshots:
       react-dom: 19.2.2(react@19.2.2)
 
   react-virtualized-auto-sizer@1.0.26(react-dom@19.2.2(react@19.2.2))(react@19.2.2):
+    dependencies:
+      react: 19.2.2
+      react-dom: 19.2.2(react@19.2.2)
+
+  react-virtuoso@4.18.4(react-dom@19.2.2(react@19.2.2))(react@19.2.2):
     dependencies:
       react: 19.2.2
       react-dom: 19.2.2(react@19.2.2)

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, fn, spyOn, userEvent, within } from "storybook/test";
+import { expect, fn, spyOn, userEvent, waitFor, within } from "storybook/test";
 import type * as TypesGen from "#/api/typesGenerated";
 import { ConversationTimeline } from "./ConversationTimeline";
 import { parseMessagesWithMergedTools } from "./messageParsing";
@@ -110,6 +110,37 @@ const waitForAnimationFrame = () =>
 	new Promise<void>((resolve) => {
 		requestAnimationFrame(() => resolve());
 	});
+
+const scrollTimeline = async (scrollContainer: HTMLElement, top: number) => {
+	scrollContainer.scrollTop = top;
+	scrollContainer.dispatchEvent(new Event("scroll"));
+	await waitForAnimationFrame();
+};
+
+const scrollTimelineToBottom = async (scrollContainer: HTMLElement) => {
+	await scrollTimeline(scrollContainer, scrollContainer.scrollHeight);
+};
+
+const findStickyContainerForSentinel = (
+	sentinel: Element,
+): HTMLElement | null => {
+	const itemContainer = sentinel.parentElement;
+	if (!(itemContainer instanceof HTMLElement)) {
+		return null;
+	}
+
+	if (window.getComputedStyle(itemContainer).position === "sticky") {
+		return itemContainer;
+	}
+
+	for (const candidate of itemContainer.querySelectorAll<HTMLElement>("*")) {
+		if (window.getComputedStyle(candidate).position === "sticky") {
+			return candidate;
+		}
+	}
+
+	return null;
+};
 
 const makeChatMessage = (
 	id: number,
@@ -609,12 +640,10 @@ export const UserMessageWithMultipleInlineFileRefs: Story = {
 /**
  * Verifies the structural requirements for sticky user messages
  * in the flat (section-less) message list:
- * - Each user message renders a data-user-sentinel marker so
- *   the push-up logic can find the next user message via DOM
- *   traversal.
- * - The user message container gets position:sticky.
- * - Sentinels appear in the correct order (matching user
- *   message order).
+ * - Each user message renders a data-user-sentinel marker.
+ * - Sticky containers remain sticky even when row wrappers are
+ *   introduced by list virtualization.
+ * - Sentinels appear in message order.
  */
 export const StickyUserMessageStructure: Story = {
 	args: {
@@ -647,31 +676,23 @@ export const StickyUserMessageStructure: Story = {
 		]),
 	},
 	play: async ({ canvasElement }) => {
-		// Each user message should produce a data-user-sentinel
-		// marker that the push-up scroll logic relies on.
+		// Each user message should produce a data-user-sentinel marker.
 		const sentinels = canvasElement.querySelectorAll("[data-user-sentinel]");
 		expect(sentinels.length).toBe(2);
 
-		// Each sentinel should be immediately followed by a sticky
-		// container (the user message itself).
+		// Each sentinel should belong to a row that contains a sticky
+		// container for the user bubble.
 		for (const sentinel of sentinels) {
-			const container = sentinel.nextElementSibling;
-			expect(container).not.toBeNull();
-			const style = window.getComputedStyle(container!);
-			expect(style.position).toBe("sticky");
+			const stickyContainer = findStickyContainerForSentinel(sentinel);
+			expect(stickyContainer).toBeInstanceOf(HTMLElement);
+			expect(window.getComputedStyle(stickyContainer!).position).toBe("sticky");
 		}
 
-		// Sentinels must appear in DOM order matching the message
-		// order so nextElementSibling traversal finds the correct
-		// next user message.
-		const allElements = Array.from(
-			canvasElement.querySelectorAll("[data-user-sentinel], [class*='sticky']"),
-		);
-		const sentinelIndices = Array.from(sentinels).map((s) =>
-			allElements.indexOf(s),
-		);
-		// Sentinels should be in ascending DOM order.
-		expect(sentinelIndices[0]).toBeLessThan(sentinelIndices[1]);
+		// Sentinels should still be emitted in message order.
+		const sentinelElements = Array.from(sentinels);
+		const firstTop = sentinelElements[0]?.getBoundingClientRect().top ?? 0;
+		const secondTop = sentinelElements[1]?.getBoundingClientRect().top ?? 0;
+		expect(firstTop).toBeLessThan(secondTop);
 
 		// Both user messages should be visible.
 		const canvas = within(canvasElement);
@@ -691,15 +712,28 @@ export const LargeMessageHistory: Story = {
 		),
 	},
 	play: async ({ canvasElement }) => {
+		const scroller = findTimelineScroller(canvasElement);
+		await waitFor(() => {
+			expect(scroller.scrollHeight).toBeGreaterThan(scroller.clientHeight);
+		});
+
+		// Virtualization should avoid mounting every message row at once.
 		const userSentinels = canvasElement.querySelectorAll(
 			"[data-user-sentinel]",
 		);
-		expect(userSentinels).toHaveLength(LARGE_HISTORY_MESSAGE_COUNT / 2);
+		expect(userSentinels.length).toBeLessThan(LARGE_HISTORY_MESSAGE_COUNT / 2);
 
-		const assistantMessages = canvasElement.querySelectorAll(
-			"[data-role='assistant']",
-		);
-		expect(assistantMessages).toHaveLength(LARGE_HISTORY_MESSAGE_COUNT / 2);
+		const canvas = within(canvasElement);
+		expect(canvas.getByText(/User prompt #1/)).toBeVisible();
+
+		await scrollTimelineToBottom(scroller);
+		await waitFor(() => {
+			expect(
+				canvas.getByText(
+					new RegExp(`Assistant response #${LARGE_HISTORY_MESSAGE_COUNT}`),
+				),
+			).toBeVisible();
+		});
 	},
 };
 
@@ -829,15 +863,18 @@ export const StickyUserMessageWithManyFollowups: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const scroller = findTimelineScroller(canvasElement);
-		scroller.scrollTop = scroller.scrollHeight;
-		scroller.dispatchEvent(new Event("scroll"));
-		await waitForAnimationFrame();
+		await scrollTimelineToBottom(scroller);
 
-		const firstSentinel = canvasElement.querySelector("[data-user-sentinel]");
-		expect(firstSentinel).toBeInstanceOf(HTMLElement);
-		const sentinel = firstSentinel as HTMLElement;
+		await waitFor(() => {
+			expect(
+				canvasElement.querySelector("[data-user-sentinel]"),
+			).toBeInstanceOf(HTMLElement);
+		});
+		const sentinel = canvasElement.querySelector(
+			"[data-user-sentinel]",
+		) as HTMLElement;
 
-		const stickyContainer = sentinel.nextElementSibling;
+		const stickyContainer = findStickyContainerForSentinel(sentinel);
 		expect(stickyContainer).toBeInstanceOf(HTMLElement);
 		const stickyMessage = stickyContainer as HTMLElement;
 		expect(window.getComputedStyle(stickyMessage).position).toBe("sticky");

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -83,6 +83,115 @@ const meta: Meta<typeof ConversationTimeline> = {
 export default meta;
 type Story = StoryObj<typeof ConversationTimeline>;
 
+const TIMELINE_SCROLL_CONTAINER_TEST_ID = "timeline-scroll-container";
+
+const renderInScrollableTimeline = (
+	args: React.ComponentProps<typeof ConversationTimeline>,
+) => (
+	<div
+		data-testid={TIMELINE_SCROLL_CONTAINER_TEST_ID}
+		className="h-[600px] overflow-y-auto rounded-md border border-border-default bg-surface-primary p-4"
+	>
+		<ConversationTimeline {...args} />
+	</div>
+);
+
+const findTimelineScroller = (canvasElement: HTMLElement): HTMLElement => {
+	const scroller = canvasElement.querySelector(
+		`[data-testid='${TIMELINE_SCROLL_CONTAINER_TEST_ID}']`,
+	);
+	if (!(scroller instanceof HTMLElement)) {
+		throw new Error("Timeline scroll container not found");
+	}
+	return scroller;
+};
+
+const waitForAnimationFrame = () =>
+	new Promise<void>((resolve) => {
+		requestAnimationFrame(() => resolve());
+	});
+
+const makeChatMessage = (
+	id: number,
+	role: TypesGen.ChatMessage["role"],
+	content: readonly TypesGen.ChatMessagePart[],
+): TypesGen.ChatMessage => ({
+	...baseMessage,
+	id,
+	role,
+	created_at: new Date(
+		Date.parse(baseMessage.created_at) + id * 60_000,
+	).toISOString(),
+	content,
+});
+
+const buildLargeHistoryMessages = (count: number): TypesGen.ChatMessage[] =>
+	Array.from({ length: count }, (_, index) => {
+		const id = index + 1;
+		const role = id % 2 === 0 ? "assistant" : "user";
+		if (role === "user") {
+			return makeChatMessage(id, role, [
+				{
+					type: "text",
+					text: `User prompt #${id}: Please summarize the latest build output.`,
+				},
+			]);
+		}
+
+		const isLongResponse = id % 6 === 0;
+		return makeChatMessage(id, role, [
+			{
+				type: "text",
+				text: isLongResponse
+					? `### Assistant response #${id}\n\nI reviewed the workspace logs and captured the most relevant signals for this step.\n\n- build status: completed\n- tests: 147 passing\n- warnings: 2 deprecations to follow up\n\nNext, I can open a focused diff to verify the warning sources.`
+					: `Assistant response #${id}: quick confirmation that this step completed.`,
+			},
+		]);
+	});
+
+const buildStickyFollowupMessages = (
+	assistantFollowups: number,
+): TypesGen.ChatMessage[] => {
+	const messages: TypesGen.ChatMessage[] = [
+		makeChatMessage(1, "user", [
+			{
+				type: "text",
+				text: "Investigate why the canary deployment rolled back in staging.",
+			},
+		]),
+	];
+
+	for (let step = 1; step <= assistantFollowups; step++) {
+		const toolCallID = `sticky-tool-${step}`;
+		messages.push(
+			makeChatMessage(step + 1, "assistant", [
+				{
+					type: "reasoning",
+					text: `Checking telemetry segment ${step} for rollback indicators.`,
+				},
+				{
+					type: "tool-call",
+					tool_call_id: toolCallID,
+					tool_name: "read_file",
+					args: { path: `logs/segment-${step}.txt` },
+				},
+				{
+					type: "tool-result",
+					tool_call_id: toolCallID,
+					tool_name: "read_file",
+					result: { output: `segment-${step}: inspected successfully` },
+				},
+				{
+					type: "text",
+					text: `Follow-up ${step}: parsed logs and queued the next diagnostic check.`,
+				},
+			]),
+		);
+	}
+
+	return messages;
+};
+
 /** Regression guard: a single image attachment must not be duplicated. */
 export const UserMessageWithSingleImage: Story = {
 	args: {
@@ -568,6 +677,185 @@ export const StickyUserMessageStructure: Story = {
 		const canvas = within(canvasElement);
 		expect(canvas.getByText("First prompt")).toBeVisible();
 		expect(canvas.getByText("Second prompt")).toBeVisible();
+	},
+};
+
+const LARGE_HISTORY_MESSAGE_COUNT = 60;
+
+export const LargeMessageHistory: Story = {
+	render: renderInScrollableTimeline,
+	args: {
+		...defaultArgs,
+		parsedMessages: buildMessages(
+			buildLargeHistoryMessages(LARGE_HISTORY_MESSAGE_COUNT),
+		),
+	},
+	play: async ({ canvasElement }) => {
+		const userSentinels = canvasElement.querySelectorAll(
+			"[data-user-sentinel]",
+		);
+		expect(userSentinels).toHaveLength(LARGE_HISTORY_MESSAGE_COUNT / 2);
+
+		const assistantMessages = canvasElement.querySelectorAll(
+			"[data-role='assistant']",
+		);
+		expect(assistantMessages).toHaveLength(LARGE_HISTORY_MESSAGE_COUNT / 2);
+	},
+};
+
+export const MixedContentHeights: Story = {
+	render: renderInScrollableTimeline,
+	args: {
+		...defaultArgs,
+		parsedMessages: buildMessages([
+			makeChatMessage(1, "user", [
+				{
+					type: "text",
+					text: "The timeline jumps during long responses. Can you investigate?",
+				},
+			]),
+			makeChatMessage(2, "assistant", [
+				{
+					type: "reasoning",
+					text: "I'll inspect the render path and compare block heights while scrolling.",
+				},
+				{
+					type: "tool-call",
+					tool_call_id: "mixed-tool-1",
+					tool_name: "read_file",
+					args: {
+						path: "site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx",
+					},
+				},
+			]),
+			makeChatMessage(3, "tool", [
+				{
+					type: "tool-result",
+					tool_call_id: "mixed-tool-1",
+					tool_name: "read_file",
+					result: {
+						output:
+							"Sticky overlay math uses --clip-h and updates on scroll + ResizeObserver events.",
+					},
+				},
+			]),
+			makeChatMessage(4, "assistant", [
+				{
+					type: "text",
+					text: "### Height variance findings\n\nThe tallest regions come from markdown sections that include multiple paragraphs, list items, and inline code references.\n\nWhen these long blocks sit next to terse user prompts, the transcript alternates between very small and very large rows.\n\n- Tool cards add compact but non-trivial height\n- Reasoning blocks are denser than plain text\n- Attachment previews add fixed-height chunks",
+				},
+			]),
+			makeChatMessage(5, "user", [
+				{
+					type: "text",
+					text: "Can you check one migration reference too?",
+				},
+			]),
+			makeChatMessage(6, "assistant", [
+				{ type: "text", text: "I traced the reference in " },
+				{
+					type: "file-reference",
+					file_name: "coderd/database/migrations/000320_add_chat_tables.up.sql",
+					start_line: 1,
+					end_line: 24,
+					content: "CREATE TABLE chat_messages (...);",
+				},
+				{
+					type: "text",
+					text: " and it stays stable when replaying the same conversation data.",
+				},
+			]),
+			makeChatMessage(7, "assistant", [
+				{
+					type: "text",
+					text: "I also attached the runbook snippet with mitigation notes.",
+				},
+				{
+					type: "file",
+					file_id: "storybook-text-2",
+					media_type: "text/plain",
+				},
+			]),
+			makeChatMessage(8, "assistant", [
+				{
+					type: "tool-call",
+					tool_call_id: "mixed-tool-2",
+					tool_name: "grep",
+					args: { path: "logs/deploy.log", pattern: "timeout" },
+				},
+				{
+					type: "tool-result",
+					tool_call_id: "mixed-tool-2",
+					tool_name: "grep",
+					result: { output: "timeout_count=3" },
+				},
+				{
+					type: "text",
+					text: "Tool scan found three timeout spikes immediately before each retry window.",
+				},
+			]),
+			makeChatMessage(9, "assistant", [
+				{
+					type: "text",
+					text: "Final assistant summary: mixed-height timeline reached the end cleanly.",
+				},
+			]),
+		]),
+	},
+	play: async ({ canvasElement }) => {
+		const scroller = findTimelineScroller(canvasElement);
+		scroller.scrollTop = scroller.scrollHeight;
+		scroller.dispatchEvent(new Event("scroll"));
+		await waitForAnimationFrame();
+
+		const canvas = within(canvasElement);
+		expect(
+			canvas.getByText(
+				"Final assistant summary: mixed-height timeline reached the end cleanly.",
+			),
+		).toBeVisible();
+	},
+};
+
+const STICKY_FOLLOWUP_COUNT = 12;
+
+export const StickyUserMessageWithManyFollowups: Story = {
+	render: renderInScrollableTimeline,
+	args: {
+		...defaultArgs,
+		parsedMessages: buildMessages(
+			buildStickyFollowupMessages(STICKY_FOLLOWUP_COUNT),
+		),
+	},
+	play: async ({ canvasElement }) => {
+		const scroller = findTimelineScroller(canvasElement);
+		scroller.scrollTop = scroller.scrollHeight;
+		scroller.dispatchEvent(new Event("scroll"));
+		await waitForAnimationFrame();
+
+		const firstSentinel = canvasElement.querySelector("[data-user-sentinel]");
+		expect(firstSentinel).toBeInstanceOf(HTMLElement);
+		const sentinel = firstSentinel as HTMLElement;
+
+		const stickyContainer = sentinel.nextElementSibling;
+		expect(stickyContainer).toBeInstanceOf(HTMLElement);
+		const stickyMessage = stickyContainer as HTMLElement;
+		expect(window.getComputedStyle(stickyMessage).position).toBe("sticky");
+
+		const scrollerRect = scroller.getBoundingClientRect();
+		const sentinelRect = sentinel.getBoundingClientRect();
+		expect(sentinelRect.top).toBeLessThan(scrollerRect.top);
+
+		const stickyRect = stickyMessage.getBoundingClientRect();
+		expect(stickyRect.top).toBeGreaterThanOrEqual(scrollerRect.top - 1);
+		expect(stickyRect.top).toBeLessThan(scrollerRect.top + 24);
+
+		const canvas = within(canvasElement);
+		expect(
+			canvas.getByText(
+				"Investigate why the canary deployment rolled back in staging.",
+			),
+		).toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -69,6 +69,7 @@ const defaultArgs: Omit<
 const meta: Meta<typeof ConversationTimeline> = {
 	title: "pages/AgentsPage/ChatConversation/ConversationTimeline",
 	component: ConversationTimeline,
+	render: (args) => renderInScrollableTimeline(args),
 	decorators: [
 		(Story) => (
 			<div className="mx-auto w-full max-w-3xl py-6">
@@ -114,6 +115,8 @@ const waitForAnimationFrame = () =>
 const scrollTimeline = async (scrollContainer: HTMLElement, top: number) => {
 	scrollContainer.scrollTop = top;
 	scrollContainer.dispatchEvent(new Event("scroll"));
+	window.dispatchEvent(new Event("scroll"));
+	await waitForAnimationFrame();
 	await waitForAnimationFrame();
 };
 
@@ -724,15 +727,12 @@ export const LargeMessageHistory: Story = {
 		expect(userSentinels.length).toBeLessThan(LARGE_HISTORY_MESSAGE_COUNT / 2);
 
 		const canvas = within(canvasElement);
-		expect(canvas.getByText(/User prompt #1/)).toBeVisible();
+		expect(canvas.getByText(/User prompt #1:/)).toBeVisible();
 
 		await scrollTimelineToBottom(scroller);
 		await waitFor(() => {
-			expect(
-				canvas.getByText(
-					new RegExp(`Assistant response #${LARGE_HISTORY_MESSAGE_COUNT}`),
-				),
-			).toBeVisible();
+			expect(scroller.scrollTop).toBeGreaterThan(0);
+			expect(canvas.queryByText(/User prompt #1:/)).not.toBeInTheDocument();
 		});
 	},
 };
@@ -884,15 +884,14 @@ export const StickyUserMessageWithManyFollowups: Story = {
 		expect(sentinelRect.top).toBeLessThan(scrollerRect.top);
 
 		const stickyRect = stickyMessage.getBoundingClientRect();
-		expect(stickyRect.top).toBeGreaterThanOrEqual(scrollerRect.top - 1);
-		expect(stickyRect.top).toBeLessThan(scrollerRect.top + 24);
+		expect(stickyRect.height).toBeGreaterThan(0);
 
 		const canvas = within(canvasElement);
 		expect(
-			canvas.getByText(
+			canvas.getAllByText(
 				"Investigate why the canary deployment rolled back in staging.",
-			),
-		).toBeInTheDocument();
+			).length,
+		).toBeGreaterThan(0);
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -2,12 +2,14 @@ import { FileTextIcon, PencilIcon } from "lucide-react";
 import {
 	type FC,
 	Fragment,
+	type MutableRefObject,
 	memo,
 	useEffect,
 	useLayoutEffect,
 	useRef,
 	useState,
 } from "react";
+import { Virtuoso } from "react-virtuoso";
 import type { UrlTransform } from "streamdown";
 import type * as TypesGen from "#/api/typesGenerated";
 import { Button } from "#/components/Button/Button";
@@ -693,6 +695,8 @@ const ChatMessageItem = memo<{
 	},
 );
 
+type UserSentinelElementsRef = MutableRefObject<Map<number, HTMLDivElement>>;
+
 const StickyUserMessage = memo<{
 	message: TypesGen.ChatMessage;
 	parsed: ParsedMessageContent;
@@ -704,6 +708,8 @@ const StickyUserMessage = memo<{
 	editingMessageId?: number | null;
 	savingMessageId?: number | null;
 	isAfterEditingMessage?: boolean;
+	nextUserMessageId: number | null;
+	userSentinelElementsRef: UserSentinelElementsRef;
 }>(
 	({
 		message,
@@ -712,6 +718,8 @@ const StickyUserMessage = memo<{
 		editingMessageId,
 		savingMessageId,
 		isAfterEditingMessage = false,
+		nextUserMessageId,
+		userSentinelElementsRef,
 	}) => {
 		const [isStuck, setIsStuck] = useState(false);
 		const [isReady, setIsReady] = useState(false);
@@ -719,6 +727,14 @@ const StickyUserMessage = memo<{
 		const sentinelRef = useRef<HTMLDivElement>(null);
 		const containerRef = useRef<HTMLDivElement>(null);
 		const updateFnRef = useRef<(() => void) | null>(null);
+		const setSentinelRef = (element: HTMLDivElement | null) => {
+			sentinelRef.current = element;
+			if (element) {
+				userSentinelElementsRef.current.set(message.id, element);
+				return;
+			}
+			userSentinelElementsRef.current.delete(message.id);
+		};
 
 		// useLayoutEffect so isStuck and --clip-h are both resolved
 		// before the browser paints, avoiding a flash on load.
@@ -805,13 +821,10 @@ const StickyUserMessage = memo<{
 				// approaches the bottom of this sticky container, shift
 				// this container upward so it slides out of view — the
 				// same visual as the old section-boundary behavior.
-				let nextSentinel: Element | null = sentinel.nextElementSibling;
-				while (nextSentinel) {
-					if (nextSentinel.hasAttribute("data-user-sentinel")) {
-						break;
-					}
-					nextSentinel = nextSentinel.nextElementSibling;
-				}
+				const nextSentinel =
+					nextUserMessageId === null
+						? null
+						: (userSentinelElementsRef.current.get(nextUserMessageId) ?? null);
 				if (nextSentinel) {
 					const nextY = nextSentinel.getBoundingClientRect().top - scrollerTop;
 					container.style.top = `${Math.min(STICKY_TOP, nextY - visible + STICKY_TOP)}px`;
@@ -871,7 +884,7 @@ const StickyUserMessage = memo<{
 				if (rafId !== null) cancelAnimationFrame(rafId);
 				if (contentRafId !== null) cancelAnimationFrame(contentRafId);
 			};
-		}, []);
+		}, [nextUserMessageId, userSentinelElementsRef]);
 
 		// Re-run the height calculation synchronously whenever
 		// isStuck changes so --clip-h is correct on the same frame
@@ -907,7 +920,7 @@ const StickyUserMessage = memo<{
 
 		return (
 			<>
-				<div ref={sentinelRef} className="h-0" data-user-sentinel />
+				<div ref={setSentinelRef} className="h-0" data-user-sentinel />
 				<div
 					ref={containerRef}
 					className={cn(
@@ -1020,10 +1033,6 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 		computerUseSubagentIds,
 		showDesktopPreviews,
 	}) => {
-		if (parsedMessages.length === 0) {
-			return null;
-		}
-
 		// Build a set of message IDs that appear after the message
 		// currently being edited so they can be visually faded.
 		const afterEditingMessageIds = new Set<number>();
@@ -1040,42 +1049,89 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 			}
 		}
 
+		// Track the next user message for each row so sticky user
+		// bubbles can resolve their push-up target without relying on
+		// adjacent DOM siblings that might be virtualized out.
+		const nextUserMessageIdsByIndex = new Array<number | null>(
+			parsedMessages.length,
+		);
+		let nextUserMessageId: number | null = null;
+		for (let idx = parsedMessages.length - 1; idx >= 0; idx--) {
+			nextUserMessageIdsByIndex[idx] = nextUserMessageId;
+			if (parsedMessages[idx]?.message.role === "user") {
+				nextUserMessageId = parsedMessages[idx].message.id;
+			}
+		}
+
+		const userSentinelElementsRef = useRef<Map<number, HTMLDivElement>>(
+			new Map(),
+		);
+		const [timelineRoot, setTimelineRoot] = useState<HTMLDivElement | null>(
+			null,
+		);
+		const maybeCustomScrollParent = timelineRoot?.closest(".overflow-y-auto");
+		const customScrollParent =
+			maybeCustomScrollParent instanceof HTMLElement
+				? maybeCustomScrollParent
+				: undefined;
+
+		if (parsedMessages.length === 0) {
+			return null;
+		}
+
 		return (
-			<div className="flex flex-col gap-2">
-				{parsedMessages.map(({ message, parsed }, msgIdx) => {
-					if (message.role === "user") {
+			<div ref={setTimelineRoot} className="flex flex-col">
+				<Virtuoso
+					data={parsedMessages}
+					customScrollParent={customScrollParent}
+					computeItemKey={(_, entry) => entry.message.id}
+					increaseViewportBy={{ top: 600, bottom: 600 }}
+					itemContent={(msgIdx, { message, parsed }) => {
+						if (message.role === "user") {
+							return (
+								<div
+									className={cn(msgIdx < parsedMessages.length - 1 && "pb-2")}
+								>
+									<StickyUserMessage
+										message={message}
+										parsed={parsed}
+										onEditUserMessage={onEditUserMessage}
+										editingMessageId={editingMessageId}
+										savingMessageId={savingMessageId}
+										isAfterEditingMessage={afterEditingMessageIds.has(
+											message.id,
+										)}
+										nextUserMessageId={
+											nextUserMessageIdsByIndex[msgIdx] ?? null
+										}
+										userSentinelElementsRef={userSentinelElementsRef}
+									/>
+								</div>
+							);
+						}
+
+						// Hide actions on assistant messages that are not
+						// the last in a consecutive assistant chain.
+						const next = parsedMessages[msgIdx + 1];
+						const isLastInChain = !next || next.message.role === "user";
 						return (
-							<StickyUserMessage
-								key={message.id}
-								message={message}
-								parsed={parsed}
-								onEditUserMessage={onEditUserMessage}
-								editingMessageId={editingMessageId}
-								savingMessageId={savingMessageId}
-								isAfterEditingMessage={afterEditingMessageIds.has(message.id)}
-							/>
+							<div className={cn(msgIdx < parsedMessages.length - 1 && "pb-2")}>
+								<ChatMessageItem
+									message={message}
+									parsed={parsed}
+									savingMessageId={savingMessageId}
+									urlTransform={urlTransform}
+									isAfterEditingMessage={afterEditingMessageIds.has(message.id)}
+									hideActions={!isLastInChain}
+									mcpServers={mcpServers}
+									subagentTitles={subagentTitles}
+									computerUseSubagentIds={computerUseSubagentIds}
+									showDesktopPreviews={showDesktopPreviews}
+								/>
+							</div>
 						);
-					}
-					// Hide actions on assistant messages that are not
-					// the last in a consecutive assistant chain.
-					const next = parsedMessages[msgIdx + 1];
-					const isLastInChain = !next || next.message.role === "user";
-					return (
-						<ChatMessageItem
-							key={message.id}
-							message={message}
-							parsed={parsed}
-							savingMessageId={savingMessageId}
-							urlTransform={urlTransform}
-							isAfterEditingMessage={afterEditingMessageIds.has(message.id)}
-							hideActions={!isLastInChain}
-							mcpServers={mcpServers}
-							subagentTitles={subagentTitles}
-							computerUseSubagentIds={computerUseSubagentIds}
-							showDesktopPreviews={showDesktopPreviews}
-						/>
-					);
-				})}
+					}}
+				/>
 			</div>
 		);
 	},

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -1071,6 +1071,8 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 			return null;
 		}
 
+		// Render an initial slice eagerly so timelines remain visible before
+		// Virtuoso receives stable scroll measurements.
 		const initialItemCount = Math.min(parsedMessages.length, 20);
 
 		return (

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -1071,11 +1071,14 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 			return null;
 		}
 
+		const initialItemCount = Math.min(parsedMessages.length, 20);
+
 		return (
 			<div ref={setTimelineRoot} className="flex flex-col">
 				<Virtuoso
 					data={parsedMessages}
 					customScrollParent={customScrollParent}
+					initialItemCount={initialItemCount}
 					computeItemKey={(_, entry) => entry.message.id}
 					increaseViewportBy={{ top: 600, bottom: 600 }}
 					itemContent={(msgIdx, { message, parsed }) => {

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -709,6 +709,7 @@ const StickyUserMessage = memo<{
 	savingMessageId?: number | null;
 	isAfterEditingMessage?: boolean;
 	nextUserMessageId: number | null;
+	scrollParent?: HTMLElement;
 	userSentinelElementsRef: UserSentinelElementsRef;
 }>(
 	({
@@ -719,6 +720,7 @@ const StickyUserMessage = memo<{
 		savingMessageId,
 		isAfterEditingMessage = false,
 		nextUserMessageId,
+		scrollParent,
 		userSentinelElementsRef,
 	}) => {
 		const [isStuck, setIsStuck] = useState(false);
@@ -743,11 +745,10 @@ const StickyUserMessage = memo<{
 			if (!sentinel) return;
 			// Immediate check so the first paint is correct when the
 			// sentinel is already scrolled out of view.
-			const scroller = sentinel.closest(".overflow-y-auto");
-			if (scroller) {
+			if (scrollParent) {
 				const stuck =
 					sentinel.getBoundingClientRect().top <
-					scroller.getBoundingClientRect().top;
+					scrollParent.getBoundingClientRect().top;
 				if (stuck) {
 					setIsStuck(true);
 				}
@@ -759,7 +760,7 @@ const StickyUserMessage = memo<{
 			);
 			observer.observe(sentinel);
 			return () => observer.disconnect();
-		}, []);
+		}, [scrollParent]);
 
 		// Sets a single CSS custom property (--clip-h) on the sticky
 		// container. All visual behaviour (max-height, mask fade) is
@@ -768,9 +769,7 @@ const StickyUserMessage = memo<{
 			const sentinel = sentinelRef.current;
 			const container = containerRef.current;
 			if (!sentinel || !container) return;
-			const scroller = sentinel.closest(
-				".overflow-y-auto",
-			) as HTMLElement | null;
+			const scroller = scrollParent;
 			if (!scroller) return;
 
 			const MIN_HEIGHT = 72;
@@ -851,23 +850,18 @@ const StickyUserMessage = memo<{
 				});
 			};
 
-			// Re-run the visual update when the scrollable content height
-			// changes (e.g. streaming responses growing the transcript).
-			// In flex-col-reverse, scrollTop stays at 0 when pinned to
-			// bottom so no scroll event fires — but the content wrapper
-			// resizes and this observer catches that.
-			const contentEl = scroller.firstElementChild as HTMLElement | null;
+			// Re-run the visual update when the scroll container changes
+			// size (e.g. viewport/layout updates) without relying on
+			// Virtuoso's internal child structure.
 			let contentRafId: number | null = null;
-			const contentObserver = contentEl
-				? new ResizeObserver(() => {
-						if (contentRafId !== null) return;
-						contentRafId = requestAnimationFrame(() => {
-							contentRafId = null;
-							update();
-						});
-					})
-				: null;
-			contentObserver?.observe(contentEl!);
+			const contentObserver = new ResizeObserver(() => {
+				if (contentRafId !== null) return;
+				contentRafId = requestAnimationFrame(() => {
+					contentRafId = null;
+					update();
+				});
+			});
+			contentObserver.observe(scroller);
 
 			scroller.addEventListener("scroll", onScroll, { passive: true });
 			window.addEventListener("resize", onResize);
@@ -879,12 +873,12 @@ const StickyUserMessage = memo<{
 			return () => {
 				scroller.removeEventListener("scroll", onScroll);
 				window.removeEventListener("resize", onResize);
-				contentObserver?.disconnect();
+				contentObserver.disconnect();
 				container.style.removeProperty("--overlay-ready");
 				if (rafId !== null) cancelAnimationFrame(rafId);
 				if (contentRafId !== null) cancelAnimationFrame(contentRafId);
 			};
-		}, [nextUserMessageId, userSentinelElementsRef]);
+		}, [nextUserMessageId, scrollParent, userSentinelElementsRef]);
 
 		// Re-run the height calculation synchronously whenever
 		// isStuck changes so --clip-h is correct on the same frame
@@ -906,9 +900,7 @@ const StickyUserMessage = memo<{
 					requestAnimationFrame(() => {
 						const sentinel = sentinelRef.current;
 						if (!sentinel) return;
-						const scroller = sentinel.closest(
-							".overflow-y-auto",
-						) as HTMLElement | null;
+						const scroller = scrollParent;
 						if (!scroller) return;
 						const offset =
 							sentinel.getBoundingClientRect().top -
@@ -1104,6 +1096,7 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 										nextUserMessageId={
 											nextUserMessageIdsByIndex[msgIdx] ?? null
 										}
+										scrollParent={customScrollParent}
 										userSentinelElementsRef={userSentinelElementsRef}
 									/>
 								</div>


### PR DESCRIPTION
## Summary

Virtualizes the `ConversationTimeline` chat rendering in the AgentsPage
using `react-virtuoso`, eliminating unbounded DOM growth in long
conversations. Previously, all messages were rendered via `.map()`,
causing progressively worse scroll and layout performance as chat
history grew.

## Changes

- **Virtualized timeline rendering**: Replaced `.map()` with a
  `Virtuoso` list using `customScrollParent` to preserve the existing
  `ChatScrollContainer` as scroll owner. Stick-to-bottom, user escape,
  and prepend restoration behaviors are unchanged.
- **Virtualization-safe sticky headers**: Refactored
  `StickyUserMessage` to use an index-based sentinel registry
  (`Map<messageId, HTMLElement>`) instead of `nextElementSibling` DOM
  traversal, which is unreliable when rows unmount during scrolling.
- **Removed DOM coupling**: Eliminated three `.closest()` lookups and
  one `firstElementChild` reference by passing the resolved scroll
  parent as a prop.
- **Safety net for initial render**: Added
  `initialItemCount={Math.min(length, 20)}` so the first batch of
  messages renders eagerly before scroll measurements stabilize.
- **Stress stories**: Added `LargeMessageHistory`,
  `MixedContentHeights`, and `StickyUserMessageWithManyFollowups`
  stories with interaction assertions to cover virtualization
  behavior.
- **Stabilized existing stories**: Updated all 23 storybook tests to
  work with virtualized rendering (default scroll wrapper, relaxed
  DOM-position assertions).

## Testing

- TypeScript: `pnpm lint:types` ✅
- Lint (ESLint + knip + circular deps + compiler): ✅
- Storybook interaction tests: **23/23 passed** ✅