### PR TITLE
ci: remove mainline/stable channel distinction from release workflow

### DIFF
--- a/scripts/release-action/calculate.go
+++ b/scripts/release-action/calculate.go
@@ -67,7 +67,7 @@ func calculateRC(commitSHA string) (*CalculateResult, error) {
 		return nil, xerrors.Errorf("listing tags: %w", err)
 	}
 
-	// Find latest mainline (non-RC, non-prerelease) release.
+	// Find latest stable (non-RC, non-prerelease) release.
 	var latestMainline *version
 	for _, t := range allTags {
 		if t.Pre == "" {
@@ -215,7 +215,7 @@ func calculateRelease(branch string) (*CalculateResult, error) {
 	}
 
 	// Determine channel: compare this minor against the
-	// latest mainline release globally.
+	// latest stable release globally.
 	channel := determineChannel(branchMajor, branchMinor, allTags)
 
 	return &CalculateResult{
@@ -248,7 +248,7 @@ func calculateCreateBranch(commitSHA string) (*CalculateResult, error) {
 		return nil, xerrors.Errorf("listing tags: %w", err)
 	}
 
-	// Find latest mainline (non-RC, non-prerelease) release.
+	// Find latest stable (non-RC, non-prerelease) release.
 	var latestMainline *version
 	for _, t := range allTags {
 		if t.Pre == "" {
@@ -264,7 +264,7 @@ func calculateCreateBranch(commitSHA string) (*CalculateResult, error) {
 		major = latestMainline.Major
 		minor = latestMainline.Minor + 1
 	} else {
-		// No mainline release found — start from a safe default.
+		// No stable release found — start from a safe default.
 		major = 2
 		minor = 0
 	}
@@ -320,29 +320,8 @@ func calculateCreateBranch(commitSHA string) (*CalculateResult, error) {
 	}, nil
 }
 
-// determineChannel finds the latest mainline (non-RC,
-// non-prerelease) release globally and compares it against the
-// given major.minor to decide the channel.
-func determineChannel(major, minor int, allTags []version) string {
-	var latestMainline *version
-	for _, t := range allTags {
-		if t.Pre == "" {
-			v := t
-			latestMainline = &v
-			break
-		}
-	}
-
-	if latestMainline == nil {
-		return "mainline"
-	}
-
-	if major == latestMainline.Major && minor == latestMainline.Minor {
-		return "mainline"
-	}
-	if major == latestMainline.Major && minor == latestMainline.Minor-1 {
-		return "stable"
-	}
-
-	return "mainline"
+// determineChannel returns the release channel. All non-RC
+// releases are stable from day one.
+func determineChannel(_ int, _ int, _ []version) string {
+	return "stable"
 }

--- a/scripts/release-action/docs.go
+++ b/scripts/release-action/docs.go
@@ -157,7 +157,7 @@ func updateCalendar(
 				fmt.Sprintf(releaseTagURLFmt, newVer.String()),
 			)
 			if r.Status == "Not Released" {
-				rows[i].Status = "Mainline"
+				rows[i].Status = "Stable"
 				rows[i].ReleaseDate = time.Now().Format("January 02, 2006")
 				rows[i].ReleaseName = fmt.Sprintf(
 					"[%d.%d](%s)",
@@ -173,15 +173,13 @@ func updateCalendar(
 		return rows
 	}
 
-	// For new mainline releases (patch == 0), apply status
+	// For new stable releases (patch == 0), apply status
 	// transitions.
-	if channel == "mainline" {
+	if channel == "stable" {
 		for i, r := range rows {
 			switch {
 			case r.Major == newVer.Major && r.Minor == newVer.Minor:
 				continue
-			case r.Status == "Mainline":
-				rows[i].Status = "Stable"
 			case strings.Contains(r.Status, "Stable"):
 				rows[i].Status = "Security Support"
 			case r.Status == "Security Support":
@@ -340,11 +338,6 @@ func updateRancherFile(path, channel, newVer string) error {
 	s := string(content)
 
 	switch channel {
-	case "mainline":
-		re := regexp.MustCompile(
-			`(\*\*Mainline\*\*: ` + "`)" + `\d+\.\d+\.\d+` + "(`)",
-		)
-		s = re.ReplaceAllString(s, "${1}"+newVer+"${2}")
 	case "stable":
 		re := regexp.MustCompile(
 			`(\*\*Stable\*\*: ` + "`)" + `\d+\.\d+\.\d+` + "(`)",

--- a/scripts/release-action/main.go
+++ b/scripts/release-action/main.go
@@ -94,7 +94,7 @@ func main() {
 					{
 						Name:        "channel",
 						Flag:        "channel",
-						Description: "Release channel: rc, mainline, or stable.",
+						Description: "Release channel: rc or stable.",
 						Required:    true,
 						Value:       serpent.StringOf(&gnChannel),
 					},
@@ -130,7 +130,7 @@ func main() {
 					{
 						Name:        "channel",
 						Flag:        "channel",
-						Description: "Release channel: mainline or stable.",
+						Description: "Release channel: stable.",
 						Required:    true,
 						Value:       serpent.StringOf(&udChannel),
 					},

--- a/scripts/release-action/notes.go
+++ b/scripts/release-action/notes.go
@@ -83,8 +83,7 @@ func generateReleaseNotes(newVersion, previousVersion version, channel string) (
 
 	_, _ = fmt.Fprintln(&notes, "## Changelog")
 
-	switch channel {
-	case "rc":
+	if channel == "rc" {
 		_, _ = fmt.Fprintln(&notes)
 		_, _ = fmt.Fprintln(&notes, "> [!NOTE]")
 		_, _ = fmt.Fprintln(&notes, "> This is a **release candidate** (RC) for testing purposes. It is not recommended for production use. Please report any issues you encounter. Learn more about our [Release Schedule](https://coder.com/docs/install/releases).")

--- a/scripts/release-action/notes.go
+++ b/scripts/release-action/notes.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"golang.org/x/xerrors"
 )
@@ -82,9 +81,6 @@ func generateReleaseNotes(newVersion, previousVersion version, channel string) (
 
 	var notes strings.Builder
 
-	if channel == "stable" {
-		_, _ = fmt.Fprintf(&notes, "> ## Stable (since %s)\n\n", time.Now().Format("January 02, 2006"))
-	}
 	_, _ = fmt.Fprintln(&notes, "## Changelog")
 
 	switch channel {
@@ -92,10 +88,6 @@ func generateReleaseNotes(newVersion, previousVersion version, channel string) (
 		_, _ = fmt.Fprintln(&notes)
 		_, _ = fmt.Fprintln(&notes, "> [!NOTE]")
 		_, _ = fmt.Fprintln(&notes, "> This is a **release candidate** (RC) for testing purposes. It is not recommended for production use. Please report any issues you encounter. Learn more about our [Release Schedule](https://coder.com/docs/install/releases).")
-	case "mainline":
-		_, _ = fmt.Fprintln(&notes)
-		_, _ = fmt.Fprintln(&notes, "> [!NOTE]")
-		_, _ = fmt.Fprintln(&notes, "> This is a mainline Coder release. We advise enterprise customers without a staging environment to install our [latest stable release](https://github.com/coder/coder/releases/latest) while we refine this version. Learn more about our [Release Schedule](https://coder.com/docs/install/releases).")
 	}
 
 	hasContent := false


### PR DESCRIPTION
Builds on #24167 and #24184.

## Context

Per the new release process, the mainline/stable distinction is being
removed. All releases are stable from day one — we no longer wait one
month to call a release stable.

## Changes

**`calculate.go`** — `determineChannel()` always returns `"stable"`
for non-RC releases. Removed the logic that compared the release
minor against the latest non-RC tag to decide mainline vs stable.

**`notes.go`** — Removed the mainline warning banner from release
notes and the redundant "Stable (since ...)" header.

**`docs.go`** — Calendar status transitions go straight to `Stable`
(no more `Mainline` → `Stable` step). Rancher file updates only
handle the `stable` channel.

**`main.go`** — Updated channel descriptions to reflect `rc` and
`stable` as the only options.

> Generated by Coder Agents