### PR TITLE
feat: link group names to group page in agents limit settings

### DIFF
--- a/site/src/pages/AgentsPage/AgentSettingsSpendPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsSpendPageView.tsx
@@ -415,6 +415,7 @@ export const AgentSettingsSpendPageView: FC<
 										<GroupLimitsSection
 											hideHeader
 											groupOverrides={groupOverrides}
+											groupOrganizationNames={groupCtrl.groupOrganizationNames}
 											showGroupForm={groupCtrl.showGroupForm}
 											onShowGroupFormChange={
 												groupCtrl.handleShowGroupFormChange

--- a/site/src/pages/AgentsPage/components/LimitsTab/GroupLimitsSection.stories.tsx
+++ b/site/src/pages/AgentsPage/components/LimitsTab/GroupLimitsSection.stories.tsx
@@ -72,6 +72,11 @@ const meta: Meta<typeof GroupLimitsSection> = {
 	component: GroupLimitsSection,
 	args: {
 		groupOverrides: mockGroupOverrides,
+		groupOrganizationNames: {
+			"group-1": "acme",
+			"group-2": "acme",
+			"group-4": "acme",
+		},
 		showGroupForm: false,
 		onShowGroupFormChange: fn(),
 		selectedGroup: null,

--- a/site/src/pages/AgentsPage/components/LimitsTab/GroupLimitsSection.tsx
+++ b/site/src/pages/AgentsPage/components/LimitsTab/GroupLimitsSection.tsx
@@ -129,7 +129,7 @@ export const GroupLimitsSection: FC<GroupLimitsSectionProps> = ({
 											{groupLink ? (
 												<Link
 													to={groupLink}
-													className="inline-flex no-underline hover:underline"
+													className="inline-flex rounded-md no-underline text-inherit -m-1.5 p-1.5 transition-colors hover:bg-surface-secondary"
 												>
 													{avatar}
 												</Link>

--- a/site/src/pages/AgentsPage/components/LimitsTab/GroupLimitsSection.tsx
+++ b/site/src/pages/AgentsPage/components/LimitsTab/GroupLimitsSection.tsx
@@ -2,7 +2,7 @@ import { Check } from "lucide-react";
 import { type FC, useId, useState } from "react";
 import { Link } from "react-router";
 import { getErrorMessage } from "#/api/errors";
-import type { Group } from "#/api/typesGenerated";
+import type { ChatUsageLimitGroupOverride, Group } from "#/api/typesGenerated";
 import { Autocomplete } from "#/components/Autocomplete/Autocomplete";
 import { AvatarData } from "#/components/Avatar/AvatarData";
 import { Button } from "#/components/Button/Button";
@@ -27,14 +27,7 @@ import { SectionHeader } from "../SectionHeader";
 
 interface GroupLimitsSectionProps {
 	hideHeader?: boolean;
-	groupOverrides: ReadonlyArray<{
-		group_id: string;
-		group_display_name: string;
-		group_name: string;
-		group_avatar_url: string;
-		member_count: number;
-		spend_limit_micros: number | null;
-	}>;
+	groupOverrides: readonly ChatUsageLimitGroupOverride[];
 	/** Maps group_id → organization_name for building links to the group page. */
 	groupOrganizationNames?: Record<string, string>;
 	showGroupForm: boolean;

--- a/site/src/pages/AgentsPage/components/LimitsTab/GroupLimitsSection.tsx
+++ b/site/src/pages/AgentsPage/components/LimitsTab/GroupLimitsSection.tsx
@@ -1,5 +1,6 @@
 import { Check } from "lucide-react";
 import { type FC, useId, useState } from "react";
+import { Link } from "react-router";
 import { getErrorMessage } from "#/api/errors";
 import type { Group } from "#/api/typesGenerated";
 import { Autocomplete } from "#/components/Autocomplete/Autocomplete";
@@ -34,6 +35,8 @@ interface GroupLimitsSectionProps {
 		member_count: number;
 		spend_limit_micros: number | null;
 	}>;
+	/** Maps group_id → organization_name for building links to the group page. */
+	groupOrganizationNames?: Record<string, string>;
 	showGroupForm: boolean;
 	onShowGroupFormChange: (show: boolean) => void;
 	selectedGroup: Group | null;
@@ -65,6 +68,7 @@ interface GroupLimitsSectionProps {
 export const GroupLimitsSection: FC<GroupLimitsSectionProps> = ({
 	hideHeader,
 	groupOverrides,
+	groupOrganizationNames,
 	showGroupForm,
 	onShowGroupFormChange,
 	selectedGroup,
@@ -111,49 +115,69 @@ export const GroupLimitsSection: FC<GroupLimitsSectionProps> = ({
 							</TableRow>
 						</TableHeader>
 						<TableBody>
-							{groupOverrides.map((override) => (
-								<TableRow key={override.group_id}>
-									<TableCell>
-										<AvatarData
-											title={override.group_display_name || override.group_name}
-											subtitle={override.group_name}
-											src={override.group_avatar_url}
-											imgFallbackText={override.group_name}
-										/>
-									</TableCell>
-									<TableCell>{override.member_count}</TableCell>
-									<TableCell>
-										{override.spend_limit_micros !== null
-											? formatCostMicros(override.spend_limit_micros)
-											: "Unlimited"}
-									</TableCell>
-									<TableCell>
-										<div className="flex gap-2">
-											<Button
-												variant="outline"
-												size="sm"
-												type="button"
-												onClick={() => onEditGroupOverride(override)}
-												disabled={deletePending || upsertPending}
-											>
-												Edit
-											</Button>
-											<Button
-												variant="outline"
-												size="sm"
-												type="button"
-												onClick={() =>
-													setPendingDeleteGroupId(override.group_id)
-												}
-												disabled={deletePending || upsertPending || isEditing}
-											>
-												Delete
-											</Button>
-										</div>
-									</TableCell>
-								</TableRow>
-							))}
-						</TableBody>
+							{groupOverrides.map((override) => {
+								const orgName = groupOrganizationNames?.[override.group_id];
+								const groupLink = orgName
+									? `/organizations/${orgName}/groups/${override.group_name}`
+									: undefined;
+
+								const avatar = (
+									<AvatarData
+										title={override.group_display_name || override.group_name}
+										subtitle={override.group_name}
+										src={override.group_avatar_url}
+										imgFallbackText={override.group_name}
+									/>
+								);
+
+								return (
+									<TableRow key={override.group_id}>
+										<TableCell>
+											{groupLink ? (
+												<Link
+													to={groupLink}
+													className="inline-flex no-underline hover:underline"
+												>
+													{avatar}
+												</Link>
+											) : (
+												avatar
+											)}
+										</TableCell>
+										<TableCell>{override.member_count}</TableCell>
+										<TableCell>
+											{override.spend_limit_micros !== null
+												? formatCostMicros(override.spend_limit_micros)
+												: "Unlimited"}
+										</TableCell>
+										<TableCell>
+											<div className="flex gap-2">
+												<Button
+													variant="outline"
+													size="sm"
+													type="button"
+													onClick={() => onEditGroupOverride(override)}
+													disabled={deletePending || upsertPending}
+												>
+													Edit
+												</Button>
+												<Button
+													variant="outline"
+													size="sm"
+													type="button"
+													onClick={() =>
+														setPendingDeleteGroupId(override.group_id)
+													}
+													disabled={deletePending || upsertPending || isEditing}
+												>
+													Delete
+												</Button>
+											</div>
+										</TableCell>
+									</TableRow>
+								);
+							})}
+						</TableBody>{" "}
 					</Table>
 				) : (
 					<div className="rounded-lg border border-border bg-surface-secondary px-4 py-6 text-center text-sm text-content-secondary">

--- a/site/src/pages/AgentsPage/components/LimitsTab/GroupLimitsSection.tsx
+++ b/site/src/pages/AgentsPage/components/LimitsTab/GroupLimitsSection.tsx
@@ -170,7 +170,7 @@ export const GroupLimitsSection: FC<GroupLimitsSectionProps> = ({
 									</TableRow>
 								);
 							})}
-						</TableBody>{" "}
+						</TableBody>
 					</Table>
 				) : (
 					<div className="rounded-lg border border-border bg-surface-secondary px-4 py-6 text-center text-sm text-content-secondary">

--- a/site/src/pages/AgentsPage/components/LimitsTab/GroupLimitsSection.tsx
+++ b/site/src/pages/AgentsPage/components/LimitsTab/GroupLimitsSection.tsx
@@ -129,7 +129,7 @@ export const GroupLimitsSection: FC<GroupLimitsSectionProps> = ({
 											{groupLink ? (
 												<Link
 													to={groupLink}
-													className="inline-flex rounded-md no-underline text-inherit -m-1.5 p-1.5 transition-colors hover:bg-surface-secondary"
+													className="flex rounded-md no-underline text-inherit -m-1.5 p-1.5 transition-colors hover:bg-surface-secondary"
 												>
 													{avatar}
 												</Link>

--- a/site/src/pages/AgentsPage/components/LimitsTab/GroupOverrideController.tsx
+++ b/site/src/pages/AgentsPage/components/LimitsTab/GroupOverrideController.tsx
@@ -37,6 +37,7 @@ type GroupOverrideChildProps = {
 	existingGroupIds: Set<string>;
 	availableGroups: Group[];
 	groupAutocompleteNoOptionsText: string;
+	groupOrganizationNames: Record<string, string>;
 };
 
 interface GroupOverrideControllerProps {
@@ -67,6 +68,10 @@ export const GroupOverrideController: FC<GroupOverrideControllerProps> = ({
 	// Derived values.
 	const existingGroupIds = new Set(groupOverrides.map((g) => g.group_id));
 	const availableGroups = groups.filter((g) => !existingGroupIds.has(g.id));
+	const groupOrganizationNames: Record<string, string> = {};
+	for (const g of groups) {
+		groupOrganizationNames[g.id] = g.organization_name;
+	}
 	const groupAutocompleteNoOptionsText = isLoadingGroups
 		? "Loading groups..."
 		: groups.length === 0
@@ -137,5 +142,6 @@ export const GroupOverrideController: FC<GroupOverrideControllerProps> = ({
 		existingGroupIds,
 		availableGroups,
 		groupAutocompleteNoOptionsText,
+		groupOrganizationNames,
 	});
 };


### PR DESCRIPTION
Wraps the group name/avatar in the spend limit overrides table with a link to the corresponding group page (`/organizations/:org/groups/:name`), so admins can quickly see who belongs to each group.

## Changes

- **GroupLimitsSection.tsx**: Group names in the overrides table are now clickable links to the group detail page. Falls back to plain text if organization info is unavailable.
- **GroupOverrideController.tsx**: Derives a `groupOrganizationNames` mapping (`group_id → organization_name`) from the already-fetched groups data and exposes it via render props.
- **AgentSettingsSpendPageView.tsx**: Wires `groupOrganizationNames` through to `GroupLimitsSection`.
- **GroupLimitsSection.stories.tsx**: Adds mock `groupOrganizationNames` data.

No backend changes required — organization names come from the existing `groups()` query.

> Generated with [Coder Agents](https://coder.com/agents)