### PR TITLE
fix(site): clean up ThemeProvider, default to system pref

### DIFF
--- a/site/.storybook/preview.tsx
+++ b/site/.storybook/preview.tsx
@@ -13,7 +13,7 @@ import { StrictMode } from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { withRouter } from "storybook-addon-remix-react-router";
 import { TooltipProvider } from "../src/components/Tooltip/Tooltip";
-import themes from "../src/theme";
+import { themes } from "../src/theme";
 
 DecoratorHelpers.initializeThemeState(Object.keys(themes), "dark");
 

--- a/site/src/contexts/ThemeProvider.tsx
+++ b/site/src/contexts/ThemeProvider.tsx
@@ -22,13 +22,16 @@ import {
 import { useQuery } from "react-query";
 import { appearanceSettings } from "#/api/queries/users";
 import { useEmbeddedMetadata } from "#/hooks/useEmbeddedMetadata";
-import themes, { isValidThemeName, type Theme, type ThemeName } from "#/theme";
+import { type Theme, type ThemeName, themes } from "#/theme";
 
 /**
  * We use theme names as classnames on the html root. Get the string values
  * here.
  */
 const THEME_NAMES = Object.keys(themes);
+
+const isValidThemeName = (name: string | undefined): name is ThemeName =>
+	name !== undefined && name in themes;
 
 /**
  * Returns the user's selected theme in their settings. If the user has "auto"

--- a/site/src/contexts/ThemeProvider.tsx
+++ b/site/src/contexts/ThemeProvider.tsx
@@ -25,6 +25,12 @@ import { useEmbeddedMetadata } from "#/hooks/useEmbeddedMetadata";
 import themes, { isValidThemeName, type Theme, type ThemeName } from "#/theme";
 
 /**
+ * We use theme names as classnames on the html root. Get the string values
+ * here.
+ */
+const THEME_NAMES = Object.keys(themes);
+
+/**
  * Returns the user's selected theme in their settings. If the user has "auto"
  * selected, or we cannot determine the theme for whatever reason, returns
  * undefined
@@ -95,17 +101,14 @@ export const ThemeProvider: FC<PropsWithChildren> = ({ children }) => {
 		if (root.dataset.embedTheme) {
 			return;
 		}
-
-		const themeNames = Object.keys(themes);
-
-		root.classList.remove(...themeNames);
+		root.classList.remove(...THEME_NAMES);
 		root.classList.add(themePreference);
 
 		return () => {
 			if (root.dataset.embedTheme) {
 				return;
 			}
-			root.classList.remove(...themeNames);
+			root.classList.remove(...THEME_NAMES);
 		};
 	}, [themePreference]);
 

--- a/site/src/contexts/ThemeProvider.tsx
+++ b/site/src/contexts/ThemeProvider.tsx
@@ -104,15 +104,9 @@ export const ThemeProvider: FC<PropsWithChildren> = ({ children }) => {
 		if (root.dataset.embedTheme) {
 			return;
 		}
+
 		root.classList.remove(...THEME_NAMES);
 		root.classList.add(themePreference);
-
-		return () => {
-			if (root.dataset.embedTheme) {
-				return;
-			}
-			root.classList.remove(...THEME_NAMES);
-		};
 	}, [themePreference]);
 
 	const theme = themes[themePreference];

--- a/site/src/contexts/ThemeProvider.tsx
+++ b/site/src/contexts/ThemeProvider.tsx
@@ -22,23 +22,41 @@ import {
 import { useQuery } from "react-query";
 import { appearanceSettings } from "#/api/queries/users";
 import { useEmbeddedMetadata } from "#/hooks/useEmbeddedMetadata";
-import themes, { DEFAULT_THEME, type Theme } from "#/theme";
+import themes, { isValidThemeName, type Theme, type ThemeName } from "#/theme";
 
 /**
- *
+ * Returns the user's selected theme in their settings. If the user has "auto"
+ * selected, or we cannot determine the theme for whatever reason, returns
+ * undefined
  */
-export const ThemeProvider: FC<PropsWithChildren> = ({ children }) => {
+const useUserAppearanceTheme = (): ThemeName | undefined => {
 	const { metadata } = useEmbeddedMetadata();
-	const appearanceSettingsQuery = useQuery(
-		appearanceSettings(metadata.userAppearance),
-	);
+	const { data } = useQuery(appearanceSettings(metadata.userAppearance));
+
+	const themePreference = data?.theme_preference;
+
+	// if the user's theme preference is "auto", bail so we can fall back
+	// to system pref
+	if (themePreference === "auto") {
+		return;
+	}
+
+	if (isValidThemeName(themePreference)) {
+		return themePreference;
+	}
+};
+
+/**
+ * Returns the theme name that corresponds to the user's system preference.
+ */
+const useSystemPreferenceTheme = (): ThemeName => {
 	const themeQuery = useMemo(
 		() => window.matchMedia?.("(prefers-color-scheme: light)"),
 		[],
 	);
-	const [preferredColorScheme, setPreferredColorScheme] = useState<
-		"dark" | "light"
-	>(themeQuery?.matches ? "light" : "dark");
+	const [preferredColorScheme, setPreferredColorScheme] = useState<ThemeName>(
+		themeQuery?.matches ? "light" : "dark",
+	);
 
 	useEffect(() => {
 		if (!themeQuery) {
@@ -57,15 +75,19 @@ export const ThemeProvider: FC<PropsWithChildren> = ({ children }) => {
 		};
 	}, [themeQuery]);
 
-	// We might not be logged in yet, or the `theme_preference` could be an empty string.
-	// Prefer JS-fetched value, fall back to server-rendered meta tag, then default.
-	const themePreference =
-		appearanceSettingsQuery.data?.theme_preference ||
-		metadata.userAppearance?.value?.theme_preference ||
-		DEFAULT_THEME;
-	// The janky casting here is fine because of the much more type safe fallback
-	// We need to support `themePreference` being wrong anyway because the database
-	// value could be anything, like an empty string.
+	return preferredColorScheme;
+};
+
+/**
+ * Determines the application theme. Tries to get the theme name from the meta
+ * tags, the user's appearance settings (as returned by the API) and their
+ * system appearance pref as a fallback
+ */
+export const ThemeProvider: FC<PropsWithChildren> = ({ children }) => {
+	const userAppearanceTheme = useUserAppearanceTheme();
+	const systemTheme = useSystemPreferenceTheme();
+
+	const themePreference = userAppearanceTheme || systemTheme;
 
 	useEffect(() => {
 		const root = document.documentElement;
@@ -73,22 +95,21 @@ export const ThemeProvider: FC<PropsWithChildren> = ({ children }) => {
 		if (root.dataset.embedTheme) {
 			return;
 		}
-		if (themePreference === "auto") {
-			root.classList.add(preferredColorScheme);
-		} else {
-			root.classList.add(themePreference);
-		}
+
+		const themeNames = Object.keys(themes);
+
+		root.classList.remove(...themeNames);
+		root.classList.add(themePreference);
 
 		return () => {
-			if (!root.dataset.embedTheme) {
-				root.classList.remove("light", "dark");
+			if (root.dataset.embedTheme) {
+				return;
 			}
+			root.classList.remove(...themeNames);
 		};
-	}, [themePreference, preferredColorScheme]);
+	}, [themePreference]);
 
-	const theme =
-		themes[themePreference as keyof typeof themes] ??
-		themes[preferredColorScheme];
+	const theme = themes[themePreference];
 
 	return (
 		<StyledEngineProvider injectFirst>

--- a/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.test.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.test.tsx
@@ -14,7 +14,7 @@ import {
 	MockEntitlements,
 	MockUserOwner,
 } from "#/testHelpers/entities";
-import { DEFAULT_THEME, themes } from "#/theme";
+import { themes } from "#/theme";
 import { AgentsSidebar } from "./AgentsSidebar";
 
 // ---- IntersectionObserver mock ----
@@ -86,7 +86,7 @@ const Wrapper: FC<PropsWithChildren> = ({ children }) => {
 	});
 	return (
 		<QueryClientProvider client={queryClient}>
-			<ThemeOverride theme={themes[DEFAULT_THEME]}>
+			<ThemeOverride theme={themes.dark}>
 				<MemoryRouter initialEntries={["/agents"]}>
 					<DashboardContext.Provider value={dashboardValue}>
 						{children}

--- a/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.test.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.test.tsx
@@ -14,7 +14,7 @@ import {
 	MockEntitlements,
 	MockUserOwner,
 } from "#/testHelpers/entities";
-import themes, { DEFAULT_THEME } from "#/theme";
+import { DEFAULT_THEME, themes } from "#/theme";
 import { AgentsSidebar } from "./AgentsSidebar";
 
 // ---- IntersectionObserver mock ----

--- a/site/src/pages/TerminalPage/TerminalPage.tsx
+++ b/site/src/pages/TerminalPage/TerminalPage.tsx
@@ -18,7 +18,7 @@ import {
 	type WorkspaceTerminalHandle,
 } from "#/modules/terminal/WorkspaceTerminal";
 import { WorkspaceTerminalAlerts } from "#/modules/terminal/WorkspaceTerminalAlerts";
-import themes from "#/theme";
+import { themes } from "#/theme";
 import { pageTitle } from "#/utils/page";
 import { openMaybePortForwardedURL } from "#/utils/portForward";
 import { getMatchingAgentOrFirst } from "#/utils/workspace";

--- a/site/src/pages/UserSettingsPage/AppearancePage/AppearanceForm.tsx
+++ b/site/src/pages/UserSettingsPage/AppearancePage/AppearanceForm.tsx
@@ -9,7 +9,6 @@ import { PreviewBadge } from "#/components/Badges/Badges";
 import { Label } from "#/components/Label/Label";
 import { RadioGroup, RadioGroupItem } from "#/components/RadioGroup/RadioGroup";
 import { Spinner } from "#/components/Spinner/Spinner";
-import { DEFAULT_THEME } from "#/theme";
 import {
 	DEFAULT_TERMINAL_FONT,
 	terminalFontLabels,
@@ -39,7 +38,7 @@ export const AppearanceForm: FC<AppearanceFormProps> = ({
 	onSubmit,
 	initialValues,
 }) => {
-	const currentTheme = initialValues.theme_preference || DEFAULT_THEME;
+	const currentTheme = initialValues.theme_preference || "dark";
 	const currentTerminalFont =
 		initialValues.terminal_font || DEFAULT_TERMINAL_FONT;
 

--- a/site/src/testHelpers/renderHelpers.tsx
+++ b/site/src/testHelpers/renderHelpers.tsx
@@ -20,7 +20,7 @@ import type { DashboardProvider } from "#/modules/dashboard/DashboardProvider";
 import OrganizationSettingsLayout from "#/modules/management/OrganizationSettingsLayout";
 import { TemplateSettingsLayout } from "#/pages/TemplateSettingsPage/TemplateSettingsLayout";
 import { WorkspaceSettingsLayout } from "#/pages/WorkspaceSettingsPage/WorkspaceSettingsLayout";
-import themes, { DEFAULT_THEME } from "#/theme";
+import { DEFAULT_THEME, themes } from "#/theme";
 import { MockUserOwner } from "./entities";
 
 // Creates one query client for each test case, to make sure that tests are

--- a/site/src/testHelpers/renderHelpers.tsx
+++ b/site/src/testHelpers/renderHelpers.tsx
@@ -20,7 +20,7 @@ import type { DashboardProvider } from "#/modules/dashboard/DashboardProvider";
 import OrganizationSettingsLayout from "#/modules/management/OrganizationSettingsLayout";
 import { TemplateSettingsLayout } from "#/pages/TemplateSettingsPage/TemplateSettingsLayout";
 import { WorkspaceSettingsLayout } from "#/pages/WorkspaceSettingsPage/WorkspaceSettingsLayout";
-import { DEFAULT_THEME, themes } from "#/theme";
+import { themes } from "#/theme";
 import { MockUserOwner } from "./entities";
 
 // Creates one query client for each test case, to make sure that tests are
@@ -240,7 +240,7 @@ export const waitForLoaderToBeRemoved = async (): Promise<void> => {
 export const renderComponent = (component: React.ReactNode) => {
 	return testingLibraryRender(component, {
 		wrapper: ({ children }) => (
-			<ThemeOverride theme={themes[DEFAULT_THEME]}>
+			<ThemeOverride theme={themes.dark}>
 				<TooltipProvider delayDuration={100}>{children}</TooltipProvider>
 			</ThemeOverride>
 		),

--- a/site/src/theme/index.ts
+++ b/site/src/theme/index.ts
@@ -40,4 +40,4 @@ export type ThemeName = keyof typeof theme;
 export const DEFAULT_THEME: ThemeName = "dark";
 
 export const isValidThemeName = (name: string | undefined): name is ThemeName =>
-	name === "light" || name === "dark";
+	name !== undefined && name in theme;

--- a/site/src/theme/index.ts
+++ b/site/src/theme/index.ts
@@ -28,16 +28,11 @@ export interface Theme extends Omit<MuiTheme, "palette"> {
 	externalImages: ExternalImageModeStyles;
 }
 
-const theme = {
+export const themes = {
 	dark,
 	light,
 } satisfies Record<string, Theme>;
 
-export default theme;
-
-export type ThemeName = keyof typeof theme;
+export type ThemeName = keyof typeof themes;
 
 export const DEFAULT_THEME: ThemeName = "dark";
-
-export const isValidThemeName = (name: string | undefined): name is ThemeName =>
-	name !== undefined && name in theme;

--- a/site/src/theme/index.ts
+++ b/site/src/theme/index.ts
@@ -28,11 +28,16 @@ export interface Theme extends Omit<MuiTheme, "palette"> {
 	externalImages: ExternalImageModeStyles;
 }
 
-export const DEFAULT_THEME = "dark";
-
 const theme = {
 	dark,
 	light,
 } satisfies Record<string, Theme>;
 
 export default theme;
+
+export type ThemeName = keyof typeof theme;
+
+export const DEFAULT_THEME: ThemeName = "dark";
+
+export const isValidThemeName = (name: string | undefined): name is ThemeName =>
+	name === "light" || name === "dark";

--- a/site/src/theme/index.ts
+++ b/site/src/theme/index.ts
@@ -34,5 +34,3 @@ export const themes = {
 } satisfies Record<string, Theme>;
 
 export type ThemeName = keyof typeof themes;
-
-export const DEFAULT_THEME: ThemeName = "dark";


### PR DESCRIPTION
Another attempt at fixing https://github.com/coder/coder/issues/20050

The logic in `<ThemeProvider>` has a few flaws:
- theme names are not validated 
- checking the appearance settings and the metadata appears to be redundant because the query uses `cachedQuery`, which [uses the page metadata](https://github.com/coder/coder/blob/95cff8c5fbd8913b932b9cd2be4c3f4d6d5d3143/site/src/api/queries/util.ts#L61) as `initialData` in the query
- the theme preference falls back to `DEFAULT_THEME`, but should probably use the user's system pref, which is always defined

This PR remedies those
- validates theme names against the available themes, and strictly types theme names
- simplify the fallback logic
- default to the preferred color scheme (I suspect this is where the bug lies)