### PR TITLE
chore: update Go from 1.25.6 to 1.25.7 (#22042)

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -4,7 +4,7 @@ description: |
 inputs:
   version:
     description: "The Go version to use."
-    default: "1.25.6"
+    default: "1.25.7"
   use-preinstalled-go:
     description: "Whether to use preinstalled Go."
     default: "false"

--- a/dogfood/coder/Dockerfile
+++ b/dogfood/coder/Dockerfile
@@ -11,8 +11,8 @@ RUN cargo install jj-cli typos-cli watchexec-cli@2.3.2
 FROM ubuntu:jammy@sha256:104ae83764a5119017b8e8d6218fa0832b09df65aae7d5a6de29a85d813da2fb AS go
 
 # Install Go manually, so that we can control the version
-ARG GO_VERSION=1.25.6
-ARG GO_CHECKSUM="f022b6aad78e362bcba9b0b94d09ad58c5a70c6ba3b7582905fababf5fe0181a"
+ARG GO_VERSION=1.25.7
+ARG GO_CHECKSUM="12e6d6a191091ae27dc31f6efc630e3a3b8ba409baf3573d955b196fdf086005"
 
 # Boring Go is needed to build FIPS-compliant binaries.
 RUN apt-get update && \

--- a/flake.nix
+++ b/flake.nix
@@ -94,7 +94,7 @@
         # 3. Update the sha256 and run again
         # 4. Nix will fail with the correct vendorHash
         # 5. Update the vendorHash
-        sqlc-custom = unstablePkgs.buildGo124Module {
+        sqlc-custom = unstablePkgs.buildGo125Module {
           pname = "sqlc";
           version = "coder-fork-aab4e865a51df0c43e1839f81a9d349b41d14f05";
 
@@ -156,7 +156,7 @@
             gnused
             gnugrep
             gnutar
-            unstablePkgs.go_1_24
+            unstablePkgs.go_1_25
             gofumpt
             go-migrate
             (pinnedPkgs.golangci-lint)
@@ -224,7 +224,7 @@
         # slim bundle into it's own derivation.
         buildFat =
           osArch:
-          unstablePkgs.buildGo124Module {
+          unstablePkgs.buildGo125Module {
             name = "coder-${osArch}";
             # Updated with ./scripts/update-flake.sh`.
             # This should be updated whenever go.mod changes!

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coder/coder/v2
 
-go 1.25.6
+go 1.25.7
 
 // Required until a v3 of chroma is created to lazily initialize all XML files.
 // None of our dependencies seem to use the registries anyways, so this


### PR DESCRIPTION
Cherry-pick of e82edf1b6b20c4baca86394a828b688cc19548fb onto `release/2.29`.

Original PR: #22042

**Conflict resolution:** `testutil/unixsocket.go` was deleted on `release/2.29` but modified in the original commit — resolved by keeping it deleted.

**Note:** Merge #24245 first to fix pre-existing CI failures on `release/2.29`.

> 🤖 Generated by Coder Agents