### PR TITLE
fix(coderd): sort pinned chats first in GetChats pagination

### DIFF
--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -3791,8 +3791,6 @@ CREATE INDEX idx_chats_last_model_config_id ON chats USING btree (last_model_con
 
 CREATE INDEX idx_chats_owner ON chats USING btree (owner_id);
 
-CREATE INDEX idx_chats_owner_updated_id ON chats USING btree (owner_id, updated_at DESC, id DESC);
-
 CREATE INDEX idx_chats_parent_chat_id ON chats USING btree (parent_chat_id);
 
 CREATE INDEX idx_chats_pending ON chats USING btree (status) WHERE (status = 'pending'::chat_status);

--- a/coderd/database/migrations/000466_drop_chat_pagination_index.down.sql
+++ b/coderd/database/migrations/000466_drop_chat_pagination_index.down.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_chats_owner_updated_id ON chats (owner_id, updated_at DESC, id DESC);

--- a/coderd/database/migrations/000466_drop_chat_pagination_index.up.sql
+++ b/coderd/database/migrations/000466_drop_chat_pagination_index.up.sql
@@ -1,0 +1,5 @@
+-- The GetChats ORDER BY changed from (updated_at, id) DESC to a 4-column
+-- expression sort (pinned-first flag, negated pin_order, updated_at, id).
+-- This index was purpose-built for the old sort and no longer provides
+-- read benefit. The simpler idx_chats_owner covers the owner_id filter.
+DROP INDEX IF EXISTS idx_chats_owner_updated_id;

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -5823,20 +5823,18 @@ WHERE
         ELSE chats.archived = $2 :: boolean
     END
     AND CASE
-        -- This allows using the last element on a page as effectively a cursor.
-        -- This is an important option for scripts that need to paginate without
-        -- duplicating or missing data.
+        -- Cursor pagination: the last element on a page acts as the cursor.
+        -- The 4-tuple matches the ORDER BY below. All columns sort DESC
+        -- (pin_order is negated so lower values sort first in DESC order),
+        -- which lets us use a single tuple < comparison.
         WHEN $3 :: uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN (
-            -- The pagination cursor is the last ID of the previous page.
-            -- The query is ordered by the updated_at field, so select all
-            -- rows before the cursor.
-            (updated_at, id) < (
+            (CASE WHEN pin_order > 0 THEN 1 ELSE 0 END, -pin_order, updated_at, id) < (
                 SELECT
-                    updated_at, id
+                    CASE WHEN c2.pin_order > 0 THEN 1 ELSE 0 END, -c2.pin_order, c2.updated_at, c2.id
                 FROM
-                    chats
+                    chats c2
                 WHERE
-                    id = $3
+                    c2.id = $3
             )
         )
         ELSE true
@@ -5848,9 +5846,15 @@ WHERE
     -- Authorize Filter clause will be injected below in GetAuthorizedChats
     -- @authorize_filter
 ORDER BY
-    -- Deterministic and consistent ordering of all rows, even if they share
-    -- a timestamp. This is to ensure consistent pagination.
-    (updated_at, id) DESC OFFSET $5
+    -- Pinned chats (pin_order > 0) sort before unpinned ones. Within
+    -- pinned chats, lower pin_order values come first. The negation
+    -- trick (-pin_order) keeps all sort columns DESC so the cursor
+    -- tuple < comparison works with uniform direction.
+    CASE WHEN pin_order > 0 THEN 1 ELSE 0 END DESC,
+    -pin_order DESC,
+    updated_at DESC,
+    id DESC
+OFFSET $5
 LIMIT
     -- The chat list is unbounded and expected to grow large.
     -- Default to 50 to prevent accidental excessively large queries.

--- a/coderd/database/queries/chats.sql
+++ b/coderd/database/queries/chats.sql
@@ -353,20 +353,18 @@ WHERE
         ELSE chats.archived = sqlc.narg('archived') :: boolean
     END
     AND CASE
-        -- This allows using the last element on a page as effectively a cursor.
-        -- This is an important option for scripts that need to paginate without
-        -- duplicating or missing data.
+        -- Cursor pagination: the last element on a page acts as the cursor.
+        -- The 4-tuple matches the ORDER BY below. All columns sort DESC
+        -- (pin_order is negated so lower values sort first in DESC order),
+        -- which lets us use a single tuple < comparison.
         WHEN @after_id :: uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN (
-            -- The pagination cursor is the last ID of the previous page.
-            -- The query is ordered by the updated_at field, so select all
-            -- rows before the cursor.
-            (updated_at, id) < (
+            (CASE WHEN pin_order > 0 THEN 1 ELSE 0 END, -pin_order, updated_at, id) < (
                 SELECT
-                    updated_at, id
+                    CASE WHEN c2.pin_order > 0 THEN 1 ELSE 0 END, -c2.pin_order, c2.updated_at, c2.id
                 FROM
-                    chats
+                    chats c2
                 WHERE
-                    id = @after_id
+                    c2.id = @after_id
             )
         )
         ELSE true
@@ -378,9 +376,15 @@ WHERE
     -- Authorize Filter clause will be injected below in GetAuthorizedChats
     -- @authorize_filter
 ORDER BY
-    -- Deterministic and consistent ordering of all rows, even if they share
-    -- a timestamp. This is to ensure consistent pagination.
-    (updated_at, id) DESC OFFSET @offset_opt
+    -- Pinned chats (pin_order > 0) sort before unpinned ones. Within
+    -- pinned chats, lower pin_order values come first. The negation
+    -- trick (-pin_order) keeps all sort columns DESC so the cursor
+    -- tuple < comparison works with uniform direction.
+    CASE WHEN pin_order > 0 THEN 1 ELSE 0 END DESC,
+    -pin_order DESC,
+    updated_at DESC,
+    id DESC
+OFFSET @offset_opt
 LIMIT
     -- The chat list is unbounded and expected to grow large.
     -- Default to 50 to prevent accidental excessively large queries.

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -1819,9 +1819,9 @@ func (api *API) patchChat(rw http.ResponseWriter, r *http.Request) {
 		// - pinOrder > 0 && already pinned: reorder (shift
 		//   neighbors, clamp to [1, count]).
 		// - pinOrder > 0 && not pinned: append to end. The
-		//   requested value is intentionally ignored because
-		//   PinChatByID also bumps updated_at to keep the
-		//   chat visible in the paginated sidebar.
+		//   requested value is intentionally ignored; the
+		//   SQL ORDER BY sorts pinned chats first so they
+		//   appear on page 1 of the paginated sidebar.
 		var err error
 		errMsg := "Failed to pin chat."
 		switch {

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -900,7 +900,7 @@ func TestListChats(t *testing.T) {
 		// normally be pushed off the first page (default limit 50).
 		const fillerCount = 51
 		fillerChats := make([]codersdk.Chat, 0, fillerCount)
-		for i := 0; i < fillerCount; i++ {
+		for i := range fillerCount {
 			c, createErr := client.CreateChat(ctx, codersdk.CreateChatRequest{
 				Content: []codersdk.ChatInputPart{{
 					Type: codersdk.ChatInputPartTypeText,
@@ -920,7 +920,7 @@ func TestListChats(t *testing.T) {
 		for _, c := range allCreated {
 			pending[c.ID] = struct{}{}
 		}
-		require.Eventually(t, func() bool {
+		testutil.Eventually(ctx, t, func(_ context.Context) bool {
 			all, listErr := client.ListChats(ctx, &codersdk.ListChatsOptions{
 				Pagination: codersdk.Pagination{Limit: fillerCount + 10},
 			})
@@ -933,7 +933,7 @@ func TestListChats(t *testing.T) {
 				}
 			}
 			return len(pending) == 0
-		}, testutil.WaitShort, testutil.IntervalFast)
+		}, testutil.IntervalFast)
 
 		// Pin the earliest chat.
 		err = client.UpdateChat(ctx, pinnedChat.ID, codersdk.UpdateChatRequest{
@@ -971,7 +971,7 @@ func TestListChats(t *testing.T) {
 		// Create 5 chats: 2 will be pinned, 3 unpinned.
 		const totalChats = 5
 		createdChats := make([]codersdk.Chat, 0, totalChats)
-		for i := 0; i < totalChats; i++ {
+		for i := range totalChats {
 			c, createErr := client.CreateChat(ctx, codersdk.CreateChatRequest{
 				Content: []codersdk.ChatInputPart{{
 					Type: codersdk.ChatInputPartTypeText,
@@ -983,20 +983,19 @@ func TestListChats(t *testing.T) {
 		}
 
 		// Wait for all chats to reach terminal status.
-		for _, c := range createdChats {
-			require.Eventually(t, func() bool {
-				all, listErr := client.ListChats(ctx, nil)
-				if listErr != nil {
+		// Check each chat by ID rather than fetching the full list.
+		testutil.Eventually(ctx, t, func(_ context.Context) bool {
+			for _, c := range createdChats {
+				ch, getErr := client.GetChat(ctx, c.ID)
+				if getErr != nil {
 					return false
 				}
-				for _, ch := range all {
-					if ch.ID == c.ID {
-						return ch.Status != codersdk.ChatStatusPending && ch.Status != codersdk.ChatStatusRunning
-					}
+				if ch.Status == codersdk.ChatStatusPending || ch.Status == codersdk.ChatStatusRunning {
+					return false
 				}
-				return false
-			}, testutil.WaitShort, testutil.IntervalFast)
-		}
+			}
+			return true
+		}, testutil.IntervalFast)
 
 		// Pin the first two chats (oldest updated_at).
 		err := client.UpdateChat(ctx, createdChats[0].ID, codersdk.UpdateChatRequest{
@@ -1013,7 +1012,7 @@ func TestListChats(t *testing.T) {
 		maxPages := totalChats/pageSize + 2
 		var allPaginated []codersdk.Chat
 		var afterID uuid.UUID
-		for i := 0; i < maxPages; i++ {
+		for range maxPages {
 			opts := &codersdk.ListChatsOptions{
 				Pagination: codersdk.Pagination{Limit: pageSize},
 			}

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -986,10 +986,8 @@ func TestListChats(t *testing.T) {
 		// Check each chat by ID rather than fetching the full list.
 		testutil.Eventually(ctx, t, func(_ context.Context) bool {
 			for _, c := range createdChats {
-				ch, getErr := client.GetChat(ctx, c.ID)
-				if getErr != nil {
-					return false
-				}
+				ch, err := client.GetChat(ctx, c.ID)
+				require.NoError(t, err, "GetChat should succeed for just-created chat %s", c.ID)
 				if ch.Status == codersdk.ChatStatusPending || ch.Status == codersdk.ChatStatusRunning {
 					return false
 				}

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -876,6 +876,181 @@ func TestListChats(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, allChats, totalChats)
 	})
+
+	// Test that a pinned chat with an old updated_at appears on page 1.
+	t.Run("PinnedOnFirstPage", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client, _ := newChatClientWithDatabase(t)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
+		_ = createChatModelConfig(t, client)
+
+		// Create the chat that will later be pinned. It gets the
+		// earliest updated_at because it is inserted first.
+		pinnedChat, err := client.CreateChat(ctx, codersdk.CreateChatRequest{
+			Content: []codersdk.ChatInputPart{{
+				Type: codersdk.ChatInputPartTypeText,
+				Text: "pinned-chat",
+			}},
+		})
+		require.NoError(t, err)
+
+		// Fill page 1 with newer chats so the pinned chat would
+		// normally be pushed off the first page (default limit 50).
+		const fillerCount = 51
+		fillerChats := make([]codersdk.Chat, 0, fillerCount)
+		for i := 0; i < fillerCount; i++ {
+			c, createErr := client.CreateChat(ctx, codersdk.CreateChatRequest{
+				Content: []codersdk.ChatInputPart{{
+					Type: codersdk.ChatInputPartTypeText,
+					Text: fmt.Sprintf("filler-%d", i),
+				}},
+			})
+			require.NoError(t, createErr)
+			fillerChats = append(fillerChats, c)
+		}
+
+		// Wait for all chats to reach a terminal status so
+		// updated_at is stable before paginating. A single
+		// polling loop checks every chat per tick to avoid
+		// O(N) separate Eventually loops.
+		allCreated := append([]codersdk.Chat{pinnedChat}, fillerChats...)
+		pending := make(map[uuid.UUID]struct{}, len(allCreated))
+		for _, c := range allCreated {
+			pending[c.ID] = struct{}{}
+		}
+		require.Eventually(t, func() bool {
+			all, listErr := client.ListChats(ctx, &codersdk.ListChatsOptions{
+				Pagination: codersdk.Pagination{Limit: fillerCount + 10},
+			})
+			if listErr != nil {
+				return false
+			}
+			for _, ch := range all {
+				if _, ok := pending[ch.ID]; ok && ch.Status != codersdk.ChatStatusPending && ch.Status != codersdk.ChatStatusRunning {
+					delete(pending, ch.ID)
+				}
+			}
+			return len(pending) == 0
+		}, testutil.WaitShort, testutil.IntervalFast)
+
+		// Pin the earliest chat.
+		err = client.UpdateChat(ctx, pinnedChat.ID, codersdk.UpdateChatRequest{
+			PinOrder: ptr.Ref(int32(1)),
+		})
+		require.NoError(t, err)
+
+		// Fetch page 1 with default limit (50).
+		page1, err := client.ListChats(ctx, &codersdk.ListChatsOptions{
+			Pagination: codersdk.Pagination{Limit: 50},
+		})
+		require.NoError(t, err)
+
+		// The pinned chat must appear on page 1.
+		page1IDs := make(map[uuid.UUID]struct{}, len(page1))
+		for _, c := range page1 {
+			page1IDs[c.ID] = struct{}{}
+		}
+		_, found := page1IDs[pinnedChat.ID]
+		require.True(t, found, "pinned chat should appear on page 1")
+
+		// The pinned chat should be the first item in the list.
+		require.Equal(t, pinnedChat.ID, page1[0].ID, "pinned chat should be first")
+	})
+
+	// Test cursor pagination with a mix of pinned and unpinned chats.
+	t.Run("CursorWithPins", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client, _ := newChatClientWithDatabase(t)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
+		_ = createChatModelConfig(t, client)
+
+		// Create 5 chats: 2 will be pinned, 3 unpinned.
+		const totalChats = 5
+		createdChats := make([]codersdk.Chat, 0, totalChats)
+		for i := 0; i < totalChats; i++ {
+			c, createErr := client.CreateChat(ctx, codersdk.CreateChatRequest{
+				Content: []codersdk.ChatInputPart{{
+					Type: codersdk.ChatInputPartTypeText,
+					Text: fmt.Sprintf("cursor-pin-chat-%d", i),
+				}},
+			})
+			require.NoError(t, createErr)
+			createdChats = append(createdChats, c)
+		}
+
+		// Wait for all chats to reach terminal status.
+		for _, c := range createdChats {
+			require.Eventually(t, func() bool {
+				all, listErr := client.ListChats(ctx, nil)
+				if listErr != nil {
+					return false
+				}
+				for _, ch := range all {
+					if ch.ID == c.ID {
+						return ch.Status != codersdk.ChatStatusPending && ch.Status != codersdk.ChatStatusRunning
+					}
+				}
+				return false
+			}, testutil.WaitShort, testutil.IntervalFast)
+		}
+
+		// Pin the first two chats (oldest updated_at).
+		err := client.UpdateChat(ctx, createdChats[0].ID, codersdk.UpdateChatRequest{
+			PinOrder: ptr.Ref(int32(1)),
+		})
+		require.NoError(t, err)
+		err = client.UpdateChat(ctx, createdChats[1].ID, codersdk.UpdateChatRequest{
+			PinOrder: ptr.Ref(int32(1)),
+		})
+		require.NoError(t, err)
+
+		// Paginate with limit=2 using cursor (after_id).
+		const pageSize = 2
+		maxPages := totalChats/pageSize + 2
+		var allPaginated []codersdk.Chat
+		var afterID uuid.UUID
+		for i := 0; i < maxPages; i++ {
+			opts := &codersdk.ListChatsOptions{
+				Pagination: codersdk.Pagination{Limit: pageSize},
+			}
+			if afterID != uuid.Nil {
+				opts.Pagination.AfterID = afterID
+			}
+			page, listErr := client.ListChats(ctx, opts)
+			require.NoError(t, listErr)
+			if len(page) == 0 {
+				break
+			}
+			allPaginated = append(allPaginated, page...)
+			afterID = page[len(page)-1].ID
+		}
+
+		// All chats should appear exactly once.
+		seenIDs := make(map[uuid.UUID]struct{}, len(allPaginated))
+		for _, c := range allPaginated {
+			_, dup := seenIDs[c.ID]
+			require.False(t, dup, "chat %s appeared more than once", c.ID)
+			seenIDs[c.ID] = struct{}{}
+		}
+		require.Len(t, seenIDs, totalChats, "all chats should appear in paginated results")
+
+		// Pinned chats should come before unpinned ones.
+		pinnedSeen := false
+		unpinnedSeen := false
+		for _, c := range allPaginated {
+			if c.PinOrder > 0 {
+				require.False(t, unpinnedSeen, "pinned chat %s appeared after unpinned chat", c.ID)
+				pinnedSeen = true
+			} else {
+				unpinnedSeen = true
+			}
+		}
+		require.True(t, pinnedSeen, "at least one pinned chat should exist")
+	})
 }
 
 func TestListChatModels(t *testing.T) {

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -1038,7 +1038,8 @@ func TestListChats(t *testing.T) {
 		}
 		require.Len(t, seenIDs, totalChats, "all chats should appear in paginated results")
 
-		// Pinned chats should come before unpinned ones.
+		// Pinned chats should come before unpinned ones, and
+		// within the pinned group, lower pin_order sorts first.
 		pinnedSeen := false
 		unpinnedSeen := false
 		for _, c := range allPaginated {
@@ -1050,6 +1051,13 @@ func TestListChats(t *testing.T) {
 			}
 		}
 		require.True(t, pinnedSeen, "at least one pinned chat should exist")
+
+		// Verify within-pinned ordering: pin_order=1 before
+		// pin_order=2 (the -pin_order DESC column).
+		require.Equal(t, createdChats[0].ID, allPaginated[0].ID,
+			"pin_order=1 chat should be first")
+		require.Equal(t, createdChats[1].ID, allPaginated[1].ID,
+			"pin_order=2 chat should be second")
 	})
 }
 


### PR DESCRIPTION
## Why

Pinned chats in the Agents sidebar don't appear until the user scrolls far
enough to load the page containing them. The `GetChats` SQL query ordered by
`(updated_at, id) DESC` with no `pin_order` awareness, so a pinned chat
with an old `updated_at` ends up on page 2+ and is invisible in the Pinned
section.

## What changed

The `GetChats` ORDER BY now uses a 4-column key: pinned-first flag DESC,
negated pin_order DESC, updated_at DESC, id DESC. The negation trick
(`-pin_order`) keeps all sort columns DESC so the existing cursor tuple
`<` comparison still works without decomposing into OR/AND chains.

The `after_id` cursor WHERE clause is updated to match the expanded sort key.

A false handler comment claiming `PinChatByID` bumps `updated_at` is
corrected; the actual SQL never touched `updated_at`.

Migration 000466 drops `idx_chats_owner_updated_id` which was purpose-built
for the old sort and is now pure write overhead. The simpler `idx_chats_owner`
covers the `owner_id` filter.

No frontend changes needed: the sidebar already filters `pin_order > 0` from
loaded chats and sorts client-side.

<details><summary>Implementation plan</summary>

## Problem

Pinned chats in the Agents sidebar don't appear until the user scrolls far enough to load the page containing them. The `GetChats` SQL query orders by `(updated_at, id) DESC` with no `pin_order` awareness. A pinned chat with an old `updated_at` can land on page 2+ and be invisible in the sidebar's "Pinned" section.

## Decisions

| # | Question | Choice | Classification |
|---|----------|--------|----------------|
| D1 | How to guarantee pinned chats appear early | SQL ordering change, following workspace favorites `CASE` pattern | Human ratified agent recommendation |
| D2 | Handle cursor pagination (`after_id`) | Negate `pin_order` so all sort columns are DESC, preserving tuple `<` comparison | Agent-recommended |
| D3 | Pinned chats and pagination boundary | Pinned chats participate in normal pagination, no special guarantee | Human decision |

## Implementation flow

### Phase 1: Red (prove the bug)

Add new subtests to `TestListChats` in `coderd/exp_chats_test.go`.

**Test 1: Pinned chat missing from first page.** Insert a chat, insert 50+ more chats (filling page 1), pin the first chat, list page 1 with `limit=50`, assert the pinned chat appears on page 1. This assertion fails on current code because the pinned chat has the oldest `updated_at` and sorts last.

**Test 2: Cursor pagination with pinned chats.** Creates a mix of pinned and unpinned chats, paginates with `after_id` cursors, and verifies all chats appear exactly once with pinned chats before unpinned ones.

### Phase 2: Green (fix the SQL)

Edit `coderd/database/queries/chats.sql`, modifying only the `GetChats` query.

**ORDER BY change:** Add pinned-first sort terms before the existing `(updated_at, id) DESC`. Use the `-pin_order` negation so all sort columns are DESC.

**Cursor WHERE clause change:** Prepend the two new computed columns to the existing cursor tuple. The comparison remains a single `<` on the expanded tuple.

**No new SQL parameters are introduced.** The `pin_order` column is already on the `chats` table.

### Phase 3: Refactor

Review the SQL for clarity. Fix the false handler comment claiming `PinChatByID` bumps `updated_at`.

### Phase 4: Frontend verification

The frontend sidebar already filters `pin_order > 0` from loaded chats and sorts by `pin_order` ascending. No frontend code changes needed.

### Output files

| File | Change |
|------|--------|
| `coderd/database/queries/chats.sql` | ORDER BY and cursor WHERE clause in `GetChats` |
| `coderd/database/queries.sql.go` | Regenerated (`make gen`) |
| `coderd/exp_chats.go` | Fix false handler comment |
| `coderd/exp_chats_test.go` | New subtests: `PinnedOnFirstPage`, `CursorWithPins` |
| `coderd/database/migrations/000466_*` | Drop dead pagination index |

</details>

<details><summary>Research document</summary>

## Problem context

Pinned chats in the Agents sidebar do not appear until the user scrolls down enough to load the page containing them. This happens because pinned and unpinned chats share a single paginated query ordered by `(updated_at, id) DESC`. A pinned chat last updated weeks ago may live on page 3+, and the frontend cannot display it in the "Pinned" section until that page loads.

The frontend splits pinned from unpinned chats client-side by filtering `pin_order > 0` from `chatsQuery.data.pages.flat()`. If the chat hasn't been loaded yet, it isn't in the flat list and won't appear.

## Key evidence

- **SQL ordering**: `ORDER BY (updated_at, id) DESC` with no `pin_order` awareness.
- **Frontend split**: Filters `pin_order > 0` from already-loaded chats only. No separate pinned-chats query exists.
- **Workspace favorites pattern**: `CASE WHEN favorite ... THEN 0 ELSE 1 END ASC` in ORDER BY is the established codebase convention for sort-priority items.
- **False comment**: Handler comment claims `PinChatByID` bumps `updated_at`, but the SQL only sets `pin_order`. The intended workaround was never implemented.
- **Cursor pagination**: Uses `(updated_at, id) < (SELECT ...)` as a 2-tuple with uniform DESC direction. The `<` operator works because both columns sort DESC.

## Cursor pagination with mixed sort directions

The negation trick (`-pin_order`) keeps all sort columns DESC so a single tuple `<` comparison works:

```sql
ORDER BY
    CASE WHEN pin_order > 0 THEN 1 ELSE 0 END DESC,
    -pin_order DESC,
    updated_at DESC,
    id DESC
```

Verification with sample data (all DESC, `<` gives "next page"):

| Row | Sort tuple |
|-----|-----------|
| Pinned #1 (pin_order=1) | `(1, -1, ts1, id1)` |
| Pinned #2 (pin_order=2) | `(1, -2, ts2, id2)` |
| Unpinned (recent) | `(0, 0, ts4, id4)` |
| Unpinned (old) | `(0, 0, ts5, id5)` where ts5 < ts4 |

DESC order: `(1,-1) > (1,-2) > (0,0,ts4) > (0,0,ts5)`. Correct.

## Decisions

### D1: SQL ordering (Approach B)

Three approaches considered: (A) Separate pinned-chats query, (B) SQL ordering change, (C) Handler-level prepend. Chose B for single query/single cache simplicity, following workspace favorites convention.

### D2: Negated pin_order for cursor compatibility

No production code uses `after_id` for chats (frontend uses offset), but the SQL supports it and tests exercise it. The negation approach avoids complex OR/AND decomposition.

### D3: Pinned chats participate in normal pagination

If a user pins 60 chats, the first 50 appear on page 1 and the rest on page 2. Human decision: "the pins also falls naturally into pagination."

</details>

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻
