### PR TITLE
fix(coderd/externalauth): prevent concurrent token refresh from poisoning cache

### DIFF
--- a/coderd/externalauth/externalauth.go
+++ b/coderd/externalauth/externalauth.go
@@ -200,6 +200,24 @@ func (c *Config) RefreshToken(ctx context.Context, db database.Store, externalAu
 		//
 		// The error message is saved for debugging purposes.
 		if isFailedRefresh(existingToken, err) {
+			// Before caching the failure, re-read the external auth link
+			// from the database. A concurrent request may have already
+			// refreshed the token successfully, consuming the single-use
+			// refresh token (e.g., GitHub App tokens). In that case our
+			// "bad_refresh_token" error is a false positive from losing
+			// the race, and we should use the winner's updated token
+			// instead of poisoning the database with a cached failure.
+			currentLink, readErr := db.GetExternalAuthLink(ctx, database.GetExternalAuthLinkParams{
+				ProviderID: externalAuthLink.ProviderID,
+				UserID:     externalAuthLink.UserID,
+			})
+			if readErr == nil && currentLink.OAuthRefreshToken != externalAuthLink.OAuthRefreshToken {
+				// Another caller won the refresh race and stored a new
+				// refresh token. Return their updated link instead of
+				// caching a failure.
+				return currentLink, nil
+			}
+
 			reason := err.Error()
 			if len(reason) > failureReasonLimit {
 				// Limit the length of the error message to prevent
@@ -266,7 +284,10 @@ func (c *Config) RefreshToken(ctx context.Context, db database.Store, externalAu
 	retryCtx, retryCtxCancel := context.WithTimeout(ctx, time.Second)
 	defer retryCtxCancel()
 validate:
-	valid, user, err := c.ValidateToken(ctx, token)
+	// Use retryCtx so the validation HTTP request has its own timeout
+	// and is not cancelled if the caller's context (e.g., the HTTP
+	// request from a workspace agent) is short-lived.
+	valid, user, err := c.ValidateToken(retryCtx, token)
 	if err != nil {
 		return externalAuthLink, xerrors.Errorf("validate external auth token: %w", err)
 	}

--- a/coderd/externalauth/externalauth_test.go
+++ b/coderd/externalauth/externalauth_test.go
@@ -196,7 +196,9 @@ func TestRefreshToken(t *testing.T) {
 		}
 
 		// Try again with a bad refresh token error. This will invalidate the
-		// refresh token, and not retry again. Expect DB call to remove the refresh token
+		// refresh token, and not retry again. Expect DB calls to check for
+		// concurrent refresh (GetExternalAuthLink) and then remove the refresh token.
+		mDB.EXPECT().GetExternalAuthLink(gomock.Any(), gomock.Any()).Return(link, nil).Times(1)
 		mDB.EXPECT().UpdateExternalAuthLinkRefreshToken(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		refreshErr = &oauth2.RetrieveError{ // github error
 			Response: &http.Response{
@@ -216,6 +218,57 @@ func TestRefreshToken(t *testing.T) {
 		require.Error(t, err)
 		require.True(t, externalauth.IsInvalidTokenError(err))
 		require.Equal(t, refreshCount, totalRefreshes)
+	})
+
+	// ConcurrentRefreshRace tests that when multiple concurrent requests
+	// race to refresh the same token, the loser does not poison the
+	// database with a cached "bad_refresh_token" failure. This
+	// reproduces the issue described in coder/coder#17069 where
+	// providers with single-use refresh tokens (e.g., GitHub Apps)
+	// reject the second refresh attempt, and the resulting error was
+	// incorrectly cached.
+	t.Run("ConcurrentRefreshRace", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mDB := dbmock.NewMockStore(ctrl)
+
+		fake, config, link := setupOauth2Test(t, testConfig{
+			FakeIDPOpts: []oidctest.FakeIDPOpt{
+				oidctest.WithRefresh(func(_ string) error {
+					return &oauth2.RetrieveError{
+						Response: &http.Response{
+							StatusCode: http.StatusOK,
+						},
+						ErrorCode: "bad_refresh_token",
+					}
+				}),
+			},
+			ExternalAuthOpt: func(cfg *externalauth.Config) {},
+		})
+
+		ctx := oidc.ClientContext(context.Background(), fake.HTTPClient(nil))
+		link.OAuthExpiry = time.Now().Add(time.Hour * -1)
+
+		// Simulate a concurrent winner: when the loser re-reads the
+		// DB, the refresh token has changed (the winner stored a new
+		// one). The loser should return the updated link instead of
+		// caching the failure.
+		winnerLink := link
+		winnerLink.OAuthRefreshToken = "winner-refresh-token"
+		winnerLink.OAuthAccessToken = "winner-access-token"
+		mDB.EXPECT().GetExternalAuthLink(gomock.Any(), database.GetExternalAuthLinkParams{
+			ProviderID: link.ProviderID,
+			UserID:     link.UserID,
+		}).Return(winnerLink, nil).Times(1)
+
+		// UpdateExternalAuthLinkRefreshToken should NOT be called
+		// because the re-read detected the concurrent refresh.
+
+		result, err := config.RefreshToken(ctx, mDB, link)
+		require.NoError(t, err, "loser should succeed using the winner's token")
+		require.Equal(t, "winner-access-token", result.OAuthAccessToken)
+		require.Equal(t, "winner-refresh-token", result.OAuthRefreshToken)
 	})
 
 	// ValidateFailure tests if the token is no longer valid with a 401 response.


### PR DESCRIPTION
<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->

Fixes https://github.com/coder/coder/issues/17069

## Problem

When multiple concurrent requests race to refresh an expiring external auth token, providers with single-use refresh tokens (e.g., GitHub Apps) reject all but the first refresh attempt with `bad_refresh_token`. The losing request was caching this transient error in the database (`oauth_refresh_failure_reason`), which cleared the refresh token and blocked all subsequent refresh attempts until the user manually re-authenticated.

This is particularly common for users with multiple terminals, IDE connections, or workspaces open simultaneously — all of which poll the external auth endpoint and can trigger concurrent refreshes when the token nears expiry.

### Reproduction

We confirmed the race by setting `oauth_expiry = NOW() + interval '5 seconds'` on a user's external auth link and firing 10 concurrent requests. All 10 returned a valid token (the winner refreshed successfully), but the database was left with `oauth_refresh_failure_reason = 'bad_refresh_token'` and an empty refresh token — meaning the next expiry would require manual re-authentication.

## Fix

**Concurrent refresh race detection** (`externalauth.go`): Before caching a `bad_refresh_token` failure, re-read the external auth link from the database. If the refresh token has changed (indicating a concurrent caller already refreshed successfully), return the winner's updated link instead of writing a failure to the database.

**ValidateToken context fix** (`externalauth.go`): Changed `ValidateToken` to use `retryCtx` (with its own 1-second timeout) instead of the caller's HTTP request context. This prevents the validation HTTP request to the provider (e.g., `https://api.github.com/user`) from being cancelled when the workspace agent's request context is short-lived or times out.