### PR TITLE
perf(site): optimize Agents chat markdown rendering and streaming

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatConversation/SmoothText.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/SmoothText.test.ts
@@ -1,11 +1,73 @@
-import { describe, expect, it } from "vitest";
-import { SmoothTextEngine, STREAM_SMOOTHING } from "./SmoothText";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	getUpdateBatchChars,
+	SmoothTextEngine,
+	STREAM_SMOOTHING,
+} from "./SmoothText";
 
 function makeText(length: number): string {
 	return "x".repeat(length);
 }
 
+interface RafHarness {
+	nowMs: () => number;
+	runFrames: (frameCount: number, frameMs?: number) => number;
+}
+
+function installRafHarness(): RafHarness {
+	let nowMs = 0;
+	let nextId = 1;
+	const callbacks = new Map<number, FrameRequestCallback>();
+
+	vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+		const id = nextId;
+		nextId += 1;
+		callbacks.set(id, callback);
+		return id;
+	});
+	vi.stubGlobal("cancelAnimationFrame", (id: number) => {
+		callbacks.delete(id);
+	});
+
+	const stepFrame = (frameMs: number): number => {
+		if (callbacks.size === 0) {
+			return 0;
+		}
+		nowMs += frameMs;
+		const currentCallbacks = [...callbacks.values()];
+		callbacks.clear();
+		for (const callback of currentCallbacks) {
+			callback(nowMs);
+		}
+		return currentCallbacks.length;
+	};
+
+	return {
+		nowMs: () => nowMs,
+		runFrames: (frameCount: number, frameMs = 16) => {
+			let executed = 0;
+			for (let frame = 0; frame < frameCount; frame += 1) {
+				const executedThisFrame = stepFrame(frameMs);
+				if (executedThisFrame === 0) {
+					break;
+				}
+				executed += executedThisFrame;
+			}
+			return executed;
+		},
+	};
+}
+
 describe("SmoothTextEngine", () => {
+	let rafHarness: RafHarness;
+
+	beforeEach(() => {
+		rafHarness = installRafHarness();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
 	it("reveals text steadily and reaches full length", () => {
 		const engine = new SmoothTextEngine();
 		const fullText = makeText(200);
@@ -148,5 +210,83 @@ describe("SmoothTextEngine", () => {
 		// Over 1 second of wall time, both refresh rates should reveal
 		// approximately the same number of characters.
 		expect(Math.abs(at60Hz - at240Hz)).toBeLessThanOrEqual(2);
+	});
+
+	it("throttles subscriber updates below RAF cadence during bursts", () => {
+		const engine = new SmoothTextEngine();
+		let notifyCount = 0;
+		engine.subscribe(() => {
+			notifyCount += 1;
+		});
+
+		engine.update(makeText(1200), true, false);
+		const executedFrames = rafHarness.runFrames(240, 16);
+
+		expect(executedFrames).toBeGreaterThan(0);
+		expect(notifyCount).toBeGreaterThan(0);
+		expect(notifyCount).toBeLessThan(Math.floor(executedFrames / 2));
+
+		engine.dispose();
+	});
+
+	it("limits high-backlog update frequency to markdown-friendly cadence", () => {
+		const engine = new SmoothTextEngine();
+		const commitTimes: number[] = [];
+		const commitLengths: number[] = [];
+		engine.subscribe(() => {
+			commitTimes.push(rafHarness.nowMs());
+			commitLengths.push(engine.visibleLength);
+		});
+
+		engine.update(makeText(2000), true, false);
+		rafHarness.runFrames(300, 16);
+
+		for (let index = 1; index < commitTimes.length; index += 1) {
+			if (commitLengths[index] === 2000) {
+				// Final catch-up flush can happen immediately once the
+				// stream is complete.
+				continue;
+			}
+			expect(
+				commitTimes[index] - commitTimes[index - 1],
+			).toBeGreaterThanOrEqual(STREAM_SMOOTHING.MIN_UPDATE_INTERVAL_MS);
+		}
+
+		engine.dispose();
+	});
+
+	it("flushes final state immediately when streaming stops", () => {
+		const engine = new SmoothTextEngine();
+		const fullText = makeText(500);
+		let notifyCount = 0;
+		engine.subscribe(() => {
+			notifyCount += 1;
+		});
+
+		engine.update(fullText, true, false);
+		rafHarness.runFrames(8, 16);
+		const notifyCountBeforeStop = notifyCount;
+
+		engine.update(fullText, false, false);
+
+		expect(engine.visibleLength).toBe(fullText.length);
+		expect(notifyCount).toBeGreaterThan(notifyCountBeforeStop);
+
+		engine.dispose();
+	});
+
+	it("increases markdown commit batch size as backlog pressure rises", () => {
+		expect(getUpdateBatchChars(0)).toBe(
+			STREAM_SMOOTHING.MIN_UPDATE_BATCH_CHARS,
+		);
+		expect(
+			getUpdateBatchChars(STREAM_SMOOTHING.CATCHUP_BACKLOG_CHARS / 2),
+		).toBeGreaterThan(STREAM_SMOOTHING.MIN_UPDATE_BATCH_CHARS);
+		expect(getUpdateBatchChars(STREAM_SMOOTHING.CATCHUP_BACKLOG_CHARS)).toBe(
+			STREAM_SMOOTHING.MAX_UPDATE_BATCH_CHARS,
+		);
+		expect(
+			getUpdateBatchChars(STREAM_SMOOTHING.CATCHUP_BACKLOG_CHARS * 3),
+		).toBe(STREAM_SMOOTHING.MAX_UPDATE_BATCH_CHARS);
 	});
 });

--- a/site/src/pages/AgentsPage/components/ChatConversation/SmoothText.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/SmoothText.ts
@@ -24,6 +24,20 @@ export const STREAM_SMOOTHING = {
 	 * sub-character stalls.
 	 */
 	MIN_FRAME_CHARS: 1,
+	/**
+	 * Minimum wall-clock delay between React-facing updates while
+	 * streaming. This caps markdown re-parse frequency.
+	 */
+	MIN_UPDATE_INTERVAL_MS: 50,
+	/**
+	 * Smallest reveal delta before we publish another update to
+	 * subscribers.
+	 */
+	MIN_UPDATE_BATCH_CHARS: 8,
+	/**
+	 * Largest reveal delta target under heavy catch-up pressure.
+	 */
+	MAX_UPDATE_BATCH_CHARS: 24,
 } as const;
 
 function clamp(value: number, min: number, max: number): number {
@@ -50,6 +64,26 @@ function getAdaptiveRate(backlog: number): number {
 	);
 }
 
+export function getUpdateBatchChars(backlog: number): number {
+	const backlogPressure = clamp(
+		backlog / STREAM_SMOOTHING.CATCHUP_BACKLOG_CHARS,
+		0,
+		1,
+	);
+	const updateBatchChars =
+		STREAM_SMOOTHING.MIN_UPDATE_BATCH_CHARS +
+		backlogPressure *
+			(STREAM_SMOOTHING.MAX_UPDATE_BATCH_CHARS -
+				STREAM_SMOOTHING.MIN_UPDATE_BATCH_CHARS);
+	return Math.round(
+		clamp(
+			updateBatchChars,
+			STREAM_SMOOTHING.MIN_UPDATE_BATCH_CHARS,
+			STREAM_SMOOTHING.MAX_UPDATE_BATCH_CHARS,
+		),
+	);
+}
+
 /**
  * Deterministic text reveal engine for smoothing streamed output.
  *
@@ -70,6 +104,50 @@ export class SmoothTextEngine {
 	private rafId: number | null = null;
 	private previousTimestamp: number | null = null;
 	private listeners = new Set<() => void>();
+
+	private lastCommittedAtMs: number | null = null;
+	private lastNotifiedVisibleLength = 0;
+
+	private nowMs(): number {
+		return typeof performance === "undefined" ? Date.now() : performance.now();
+	}
+
+	private shouldCommitUpdate(timestampMs: number): boolean {
+		if (this.visibleLengthValue === this.lastNotifiedVisibleLength) {
+			return false;
+		}
+
+		if (
+			!this.isStreaming ||
+			this.bypassSmoothing ||
+			this.visibleLengthValue === this.fullLength
+		) {
+			return true;
+		}
+
+		const elapsedMs =
+			this.lastCommittedAtMs === null
+				? 0
+				: Math.max(0, timestampMs - this.lastCommittedAtMs);
+		if (elapsedMs >= STREAM_SMOOTHING.MIN_UPDATE_INTERVAL_MS) {
+			return true;
+		}
+
+		const backlog = this.fullLength - this.visibleLengthValue;
+		const charsSinceLastCommit =
+			this.visibleLengthValue - this.lastNotifiedVisibleLength;
+		const minBatchChars = getUpdateBatchChars(backlog);
+		return charsSinceLastCommit >= minBatchChars;
+	}
+
+	private commitUpdate(timestampMs: number): void {
+		if (this.visibleLengthValue === this.lastNotifiedVisibleLength) {
+			return;
+		}
+		this.lastNotifiedVisibleLength = this.visibleLengthValue;
+		this.lastCommittedAtMs = timestampMs;
+		this.notify();
+	}
 
 	private enforceMaxVisualLag(): void {
 		if (!this.isStreaming || this.bypassSmoothing) {
@@ -114,8 +192,11 @@ export class SmoothTextEngine {
 			const dtMs = timestampMs - this.previousTimestamp;
 			const prevLength = this.visibleLengthValue;
 			this.tick(dtMs);
-			if (this.visibleLengthValue !== prevLength) {
-				this.notify();
+			if (
+				this.visibleLengthValue !== prevLength &&
+				this.shouldCommitUpdate(timestampMs)
+			) {
+				this.commitUpdate(timestampMs);
 			}
 		}
 		this.previousTimestamp = timestampMs;
@@ -130,9 +211,8 @@ export class SmoothTextEngine {
 
 	/**
 	 * Update the ingested text and stream state. Starts or stops the
-	 * internal RAF loop as needed, and notifies subscribers when the
-	 * visible length changes synchronously (e.g. bypass, stream end,
-	 * content shrink).
+	 * internal RAF loop as needed, and only commits React-facing
+	 * updates when batching thresholds are met.
 	 */
 	update(
 		fullText: string,
@@ -140,6 +220,7 @@ export class SmoothTextEngine {
 		bypassSmoothing: boolean,
 	): void {
 		const prevVisible = this.visibleLengthValue;
+		const nowMs = this.nowMs();
 
 		this.fullLength = fullText.length;
 		this.isStreaming = isStreaming;
@@ -154,15 +235,27 @@ export class SmoothTextEngine {
 			this.visibleLengthValue = this.fullLength;
 			this.charBudget = 0;
 			this.stopLoop();
-		} else {
-			this.enforceMaxVisualLag();
-			if (!this.isCaughtUp) {
-				this.startLoop();
-			}
+			this.commitUpdate(nowMs);
+			this.lastCommittedAtMs = null;
+			return;
 		}
 
-		if (this.visibleLengthValue !== prevVisible) {
-			this.notify();
+		this.enforceMaxVisualLag();
+		if (!this.isCaughtUp) {
+			this.startLoop();
+		}
+
+		if (this.lastCommittedAtMs === null) {
+			this.lastCommittedAtMs = nowMs;
+		}
+
+		if (
+			this.visibleLengthValue !== prevVisible &&
+			this.visibleLengthValue < this.lastNotifiedVisibleLength
+		) {
+			// Shrinks should be reflected immediately to avoid rendering
+			// content that no longer exists in the source text.
+			this.commitUpdate(nowMs);
 		}
 	}
 
@@ -242,6 +335,8 @@ export class SmoothTextEngine {
 		this.stopLoop();
 		this.fullLength = 0;
 		this.visibleLengthValue = 0;
+		this.lastNotifiedVisibleLength = 0;
+		this.lastCommittedAtMs = null;
 		this.charBudget = 0;
 		this.isStreaming = false;
 		this.bypassSmoothing = false;

--- a/site/src/pages/AgentsPage/components/ChatConversation/messageParsing.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/messageParsing.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { ChatMessage, ChatMessagePart } from "#/api/typesGenerated";
 import {
+	buildComputerUseSubagentIds,
+	buildSubagentTitles,
+	createCachedParseMessagesWithMergedTools,
 	mergeTools,
 	parseMessageContent,
 	parseMessagesWithMergedTools,
@@ -375,6 +378,171 @@ describe("mergeTools", () => {
 		const merged = mergeTools([{ id: "1", name: "bash" }], []);
 		expect(merged).toHaveLength(1);
 		expect(merged[0].status).toBe("completed");
+	});
+});
+
+describe("parseMessagesWithMergedTools caching", () => {
+	const msg = (
+		id: number,
+		role: "assistant" | "user",
+		parts: ChatMessagePart[],
+	): ChatMessage => ({
+		id,
+		chat_id: "chat-1",
+		created_at: new Date().toISOString(),
+		role,
+		content: parts,
+	});
+
+	it("returns stable references for identical message content", () => {
+		const parse = createCachedParseMessagesWithMergedTools();
+		const messages = [
+			msg(1, "user", [{ type: "text", text: "Hello" }]),
+			msg(2, "assistant", [{ type: "text", text: "Hi there" }]),
+		];
+
+		const first = parse(messages);
+		const second = parse([...messages]);
+		const clonedMessages = messages.map((message) => ({
+			...message,
+			content: message.content?.map((part) => ({ ...part })),
+		}));
+		const third = parse(clonedMessages);
+
+		expect(second).toBe(first);
+		expect(second[0]).toBe(first[0]);
+		expect(second[1]).toBe(first[1]);
+		expect(third).toBe(first);
+		expect(third[0]).toBe(first[0]);
+		expect(third[1]).toBe(first[1]);
+	});
+
+	it("keeps derived subagent metadata references stable", () => {
+		const parse = createCachedParseMessagesWithMergedTools();
+		const messages = [
+			msg(1, "assistant", [
+				{
+					type: "tool-call",
+					tool_call_id: "spawn-1",
+					tool_name: "spawn_agent",
+					args: { prompt: "do work" },
+				},
+			]),
+			msg(2, "assistant", [
+				{
+					type: "tool-result",
+					tool_call_id: "spawn-1",
+					tool_name: "spawn_agent",
+					result: { chat_id: "sub-1", title: "Worker" },
+				},
+				{
+					type: "tool-call",
+					tool_call_id: "spawn-2",
+					tool_name: "spawn_computer_use_agent",
+					args: { prompt: "open browser" },
+				},
+				{
+					type: "tool-result",
+					tool_call_id: "spawn-2",
+					tool_name: "spawn_computer_use_agent",
+					result: { chat_id: "sub-2", title: "Desktop" },
+				},
+			]),
+		];
+
+		const firstParsed = parse(messages);
+		const firstTitles = buildSubagentTitles(firstParsed);
+		const firstComputerUseIds = buildComputerUseSubagentIds(firstParsed);
+
+		const secondParsed = parse([...messages]);
+		const secondTitles = buildSubagentTitles(secondParsed);
+		const secondComputerUseIds = buildComputerUseSubagentIds(secondParsed);
+
+		expect(secondParsed).toBe(firstParsed);
+		expect(secondTitles).toBe(firstTitles);
+		expect(secondComputerUseIds).toBe(firstComputerUseIds);
+		expect(secondTitles.get("sub-1")).toBe("Worker");
+		expect(secondComputerUseIds.has("sub-2")).toBe(true);
+	});
+
+	it("preserves historical entry references when a new message is appended", () => {
+		const parse = createCachedParseMessagesWithMergedTools();
+		const initialMessages = [
+			msg(1, "user", [{ type: "text", text: "Question" }]),
+			msg(2, "assistant", [{ type: "text", text: "Answer" }]),
+		];
+
+		const first = parse(initialMessages);
+		const second = parse([
+			...initialMessages,
+			msg(3, "assistant", [{ type: "text", text: "Follow-up" }]),
+		]);
+
+		expect(second).not.toBe(first);
+		expect(second[0]).toBe(first[0]);
+		expect(second[1]).toBe(first[1]);
+		expect(second[2]).not.toBeUndefined();
+	});
+
+	it("only replaces the tail entry when the last message is updated", () => {
+		const parse = createCachedParseMessagesWithMergedTools();
+		const initialMessages = [
+			msg(1, "user", [{ type: "text", text: "Question" }]),
+			msg(2, "assistant", [{ type: "text", text: "Partial" }]),
+		];
+
+		const first = parse(initialMessages);
+		const updatedMessages = [
+			initialMessages[0],
+			msg(2, "assistant", [{ type: "text", text: "Partial + streamed" }]),
+		];
+		const second = parse(updatedMessages);
+		const third = parse(updatedMessages);
+
+		expect(second[0]).toBe(first[0]);
+		expect(second[1]).not.toBe(first[1]);
+		expect(second[1].parsed.markdown).toBe("Partial + streamed");
+		expect(third).toBe(second);
+		expect(third[0]).toBe(second[0]);
+		expect(third[1]).toBe(second[1]);
+	});
+
+	it("rebuilds earlier entries when a later message backfills tool results", () => {
+		const parse = createCachedParseMessagesWithMergedTools();
+		const initialMessages = [
+			msg(1, "assistant", [
+				{
+					type: "tool-call",
+					tool_call_id: "call-1",
+					tool_name: "bash",
+					args: { command: "ls" },
+				},
+			]),
+		];
+
+		const first = parse(initialMessages);
+		expect(first[0].parsed.tools[0]?.result).toBeUndefined();
+
+		const second = parse([
+			...initialMessages,
+			msg(2, "assistant", [
+				{
+					type: "tool-result",
+					tool_call_id: "call-1",
+					tool_name: "bash",
+					result: { output: "ok" },
+				},
+			]),
+		]);
+
+		expect(second[0]).not.toBe(first[0]);
+		expect(second[0].parsed.tools[0]).toEqual(
+			expect.objectContaining({
+				id: "call-1",
+				name: "bash",
+				result: { output: "ok" },
+			}),
+		);
 	});
 });
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/messageParsing.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/messageParsing.ts
@@ -256,77 +256,236 @@ export const getEditableUserMessagePayload = (
 	};
 };
 
-export const parseMessagesWithMergedTools = (
-	messages: readonly TypesGen.ChatMessage[],
-): ParsedMessageEntry[] => {
-	const rawParsed = messages.map((message) => ({
-		message,
-		parsed: parseMessageContent(message.content),
-	}));
+const buildMessageContentKey = (
+	content: readonly TypesGen.ChatMessagePart[] | undefined,
+): string => JSON.stringify(content ?? []);
 
-	const globalToolResults = new Map<string, ParsedToolResult>();
-	for (const { parsed } of rawParsed) {
-		for (const result of parsed.toolResults) {
-			globalToolResults.set(result.id, result);
+const areMergedToolsEqual = (
+	left: readonly MergedTool[],
+	right: readonly MergedTool[],
+): boolean => {
+	if (left === right) {
+		return true;
+	}
+	if (left.length !== right.length) {
+		return false;
+	}
+	for (const [index, leftTool] of left.entries()) {
+		const rightTool = right[index];
+		if (
+			leftTool.id !== rightTool.id ||
+			leftTool.name !== rightTool.name ||
+			leftTool.isError !== rightTool.isError ||
+			leftTool.status !== rightTool.status ||
+			leftTool.mcpServerConfigId !== rightTool.mcpServerConfigId ||
+			leftTool.modelIntent !== rightTool.modelIntent ||
+			leftTool.killedBySignal !== rightTool.killedBySignal ||
+			!Object.is(leftTool.args, rightTool.args) ||
+			!Object.is(leftTool.result, rightTool.result)
+		) {
+			return false;
 		}
 	}
+	return true;
+};
 
-	for (const { parsed } of rawParsed) {
-		const resultById = new Map<string, ParsedToolResult>();
-		for (const result of parsed.toolResults) {
-			resultById.set(result.id, result);
+type CachedMessageEntry = {
+	readonly role: TypesGen.ChatMessageRole;
+	readonly contentRef: readonly TypesGen.ChatMessagePart[] | undefined;
+	readonly contentKey: string;
+	readonly baseParsed: ParsedMessageContent;
+	readonly parsed: ParsedMessageContent;
+	readonly entry: ParsedMessageEntry;
+};
+
+type PreparedMessage = {
+	readonly currentMessage: TypesGen.ChatMessage;
+	readonly stableMessage: TypesGen.ChatMessage;
+	readonly cached: CachedMessageEntry | undefined;
+	readonly baseParsed: ParsedMessageContent;
+	readonly contentKey: string;
+	readonly contentUnchanged: boolean;
+};
+
+export const createCachedParseMessagesWithMergedTools = (): ((
+	messages: readonly TypesGen.ChatMessage[],
+) => ParsedMessageEntry[]) => {
+	let cachedEntriesById = new Map<number, CachedMessageEntry>();
+	let cachedList: ParsedMessageEntry[] = [];
+
+	return (messages) => {
+		const prepared: PreparedMessage[] = messages.map((currentMessage) => {
+			const cached = cachedEntriesById.get(currentMessage.id);
+			if (
+				cached &&
+				cached.role === currentMessage.role &&
+				cached.contentRef === currentMessage.content
+			) {
+				return {
+					currentMessage,
+					stableMessage: cached.entry.message,
+					cached,
+					baseParsed: cached.baseParsed,
+					contentKey: cached.contentKey,
+					contentUnchanged: true,
+				};
+			}
+
+			const contentKey = buildMessageContentKey(currentMessage.content);
+			const contentUnchanged =
+				cached !== undefined &&
+				cached.role === currentMessage.role &&
+				cached.contentKey === contentKey;
+			const baseParsed =
+				contentUnchanged && cached
+					? cached.baseParsed
+					: parseMessageContent(currentMessage.content);
+
+			return {
+				currentMessage,
+				stableMessage:
+					contentUnchanged && cached ? cached.entry.message : currentMessage,
+				cached,
+				baseParsed,
+				contentKey,
+				contentUnchanged,
+			};
+		});
+
+		const globalToolResults = new Map<string, ParsedToolResult>();
+		for (const { baseParsed } of prepared) {
+			for (const result of baseParsed.toolResults) {
+				globalToolResults.set(result.id, result);
+			}
 		}
-		for (const call of parsed.toolCalls) {
-			if (!resultById.has(call.id)) {
-				const global = globalToolResults.get(call.id);
-				if (global) {
-					resultById.set(global.id, global);
+
+		const mergedToolsByMessage = prepared.map(({ baseParsed }) => {
+			const resultById = new Map<string, ParsedToolResult>();
+			for (const result of baseParsed.toolResults) {
+				resultById.set(result.id, result);
+			}
+			for (const call of baseParsed.toolCalls) {
+				if (!resultById.has(call.id)) {
+					const global = globalToolResults.get(call.id);
+					if (global) {
+						resultById.set(global.id, global);
+					}
+				}
+			}
+			return mergeTools(baseParsed.toolCalls, Array.from(resultById.values()));
+		});
+
+		// Annotate execute/process_output tools whose process was
+		// later killed or terminated via process_signal.
+		const signaledProcesses = new Map<string, "kill" | "terminate">();
+		for (const tools of mergedToolsByMessage) {
+			for (const tool of tools) {
+				if (tool.name !== "process_signal") {
+					continue;
+				}
+				const args = asRecord(tool.args);
+				const result = asRecord(tool.result);
+				if (!args || !result?.success) {
+					continue;
+				}
+				const pid = asString(args.process_id);
+				const sig = asString(args.signal);
+				if (pid && (sig === "kill" || sig === "terminate")) {
+					signaledProcesses.set(pid, sig);
 				}
 			}
 		}
-		parsed.tools = mergeTools(
-			parsed.toolCalls,
-			Array.from(resultById.values()),
-		);
-	}
-
-	// Annotate execute/process_output tools whose process was
-	// later killed or terminated via process_signal.
-	const signaledProcesses = new Map<string, "kill" | "terminate">();
-	for (const { parsed } of rawParsed) {
-		for (const tool of parsed.tools) {
-			if (tool.name !== "process_signal") continue;
-			const args = asRecord(tool.args);
-			const result = asRecord(tool.result);
-			if (!args || !result?.success) continue;
-			const pid = asString(args.process_id);
-			const sig = asString(args.signal);
-			if (pid && (sig === "kill" || sig === "terminate"))
-				signaledProcesses.set(pid, sig);
-		}
-	}
-	if (signaledProcesses.size > 0) {
-		for (const { parsed } of rawParsed) {
-			for (const tool of parsed.tools) {
-				if (tool.name !== "execute" && tool.name !== "process_output") continue;
-				const rec = asRecord(tool.result);
-				const args = asRecord(tool.args);
-				const pid =
-					(rec ? asString(rec.background_process_id) : "") ||
-					(rec ? asString(rec.process_id) : "") ||
-					(args ? asString(args.process_id) : "");
-				const sig = pid ? signaledProcesses.get(pid) : undefined;
-				if (sig) tool.killedBySignal = sig;
+		if (signaledProcesses.size > 0) {
+			for (const tools of mergedToolsByMessage) {
+				for (const tool of tools) {
+					if (tool.name !== "execute" && tool.name !== "process_output") {
+						continue;
+					}
+					const rec = asRecord(tool.result);
+					const args = asRecord(tool.args);
+					const pid =
+						(rec ? asString(rec.background_process_id) : "") ||
+						(rec ? asString(rec.process_id) : "") ||
+						(args ? asString(args.process_id) : "");
+					const sig = pid ? signaledProcesses.get(pid) : undefined;
+					if (sig) {
+						tool.killedBySignal = sig;
+					}
+				}
 			}
 		}
-	}
 
-	return rawParsed;
+		const nextEntriesById = new Map<number, CachedMessageEntry>();
+		const nextList = prepared.map((message, index) => {
+			const tools = mergedToolsByMessage[index];
+			const canReuseParsed =
+				message.cached !== undefined &&
+				message.contentUnchanged &&
+				areMergedToolsEqual(message.cached.parsed.tools, tools);
+			if (canReuseParsed && message.cached) {
+				nextEntriesById.set(message.currentMessage.id, {
+					role: message.currentMessage.role,
+					contentRef: message.currentMessage.content,
+					contentKey: message.contentKey,
+					baseParsed: message.cached.baseParsed,
+					parsed: message.cached.parsed,
+					entry: message.cached.entry,
+				});
+				return message.cached.entry;
+			}
+
+			const parsed: ParsedMessageContent = {
+				markdown: message.baseParsed.markdown,
+				reasoning: message.baseParsed.reasoning,
+				toolCalls: message.baseParsed.toolCalls,
+				toolResults: message.baseParsed.toolResults,
+				tools,
+				blocks: message.baseParsed.blocks,
+				sources: message.baseParsed.sources,
+			};
+			const entry: ParsedMessageEntry = {
+				message: message.stableMessage,
+				parsed,
+			};
+			nextEntriesById.set(message.currentMessage.id, {
+				role: message.currentMessage.role,
+				contentRef: message.currentMessage.content,
+				contentKey: message.contentKey,
+				baseParsed: message.baseParsed,
+				parsed,
+				entry,
+			});
+			return entry;
+		});
+
+		cachedEntriesById = nextEntriesById;
+		if (
+			cachedList.length === nextList.length &&
+			nextList.every((entry, index) => entry === cachedList[index])
+		) {
+			return cachedList;
+		}
+		cachedList = nextList;
+		return nextList;
+	};
 };
+
+export const parseMessagesWithMergedTools =
+	createCachedParseMessagesWithMergedTools();
+
+const subagentTitlesCache = new WeakMap<
+	readonly ParsedMessageEntry[],
+	Map<string, string>
+>();
 
 export const buildSubagentTitles = (
 	parsedMessages: readonly ParsedMessageEntry[],
 ): Map<string, string> => {
+	const cached = subagentTitlesCache.get(parsedMessages);
+	if (cached) {
+		return cached;
+	}
+
 	const map = new Map<string, string>();
 	for (const { parsed } of parsedMessages) {
 		for (const tool of parsed.tools) {
@@ -347,12 +506,23 @@ export const buildSubagentTitles = (
 			}
 		}
 	}
+	subagentTitlesCache.set(parsedMessages, map);
 	return map;
 };
+
+const computerUseSubagentIdsCache = new WeakMap<
+	readonly ParsedMessageEntry[],
+	Set<string>
+>();
 
 export const buildComputerUseSubagentIds = (
 	parsedMessages: readonly ParsedMessageEntry[],
 ): Set<string> => {
+	const cached = computerUseSubagentIdsCache.get(parsedMessages);
+	if (cached) {
+		return cached;
+	}
+
 	const ids = new Set<string>();
 	for (const { parsed } of parsedMessages) {
 		for (const tool of parsed.tools) {
@@ -369,5 +539,6 @@ export const buildComputerUseSubagentIds = (
 			}
 		}
 	}
+	computerUseSubagentIdsCache.set(parsedMessages, ids);
 	return ids;
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/Response.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/Response.stories.tsx
@@ -124,22 +124,20 @@ export const StreamingInlineMarkdown: Story = {
 };
 
 // Verifies that an incomplete fenced code block in streaming mode
-// renders inside a code element rather than showing raw backticks.
-// The FileViewer renders a <diffs-container> web component whose
-// content lives in Shadow DOM, so we assert on DOM structure rather
-// than text content inside the web component.
+// renders as lightweight <pre><code> output (WS2 behavior) rather
+// than FileViewer, while still hiding raw backtick syntax.
 export const StreamingCodeFence: Story = {
 	args: {
 		children: "```ts\nconst x = 1",
 		streaming: true,
 	},
 	play: async ({ canvasElement }) => {
-		// The code fence should be parsed into a FileViewer (web component),
-		// not rendered as raw backtick text.
 		await waitFor(() => {
-			const viewer = canvasElement.querySelector("diffs-container");
-			expect(viewer).toBeInTheDocument();
+			const codeElement = canvasElement.querySelector("pre code");
+			expect(codeElement).toBeInTheDocument();
 		});
+		const viewer = canvasElement.querySelector("diffs-container");
+		expect(viewer).toBeNull();
 		// The raw triple-backtick should not appear as visible text.
 		const bodyText = canvasElement.textContent ?? "";
 		expect(bodyText).not.toContain("```");

--- a/site/src/pages/AgentsPage/components/ChatElements/Response.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/Response.tsx
@@ -89,6 +89,7 @@ const getClassNames = (className: string[] | string | undefined): string[] => {
 const createComponents = (
 	fileViewerThemeType: FileViewerThemeType,
 	viewerTheme: (typeof fileViewerTheme)[FileViewerThemeType],
+	streaming: boolean,
 ): Components => {
 	return {
 		a: ({ href, children }: MarkdownComponentProps) => (
@@ -192,7 +193,8 @@ const createComponents = (
 			</code>
 		),
 		// Fenced code blocks: extract language and content from the HAST
-		// node directly (plain data), then render with FileViewer.
+		// node directly (plain data). Streaming mode renders a
+		// lightweight plain <pre>; settled mode uses FileViewer.
 		pre: ({ node }: MarkdownComponentProps) => {
 			const codeChild = node?.children?.[0];
 			if (codeChild?.tagName === "code") {
@@ -203,6 +205,13 @@ const createComponents = (
 				const lang = langClass ? langClass.replace("language-", "") : "text";
 				const content = getHastText(codeChild).trimEnd();
 				if (content) {
+					if (streaming) {
+						return (
+							<pre className="my-4 overflow-x-auto rounded-xl border border-solid border-border-default bg-surface-quaternary/25 p-3 font-mono text-2xs leading-relaxed text-content-primary">
+								<code>{content}</code>
+							</pre>
+						);
+					}
 					return (
 						<div className="my-4 overflow-hidden rounded-xl border border-solid border-border-default text-2xs">
 							<FileViewer
@@ -234,9 +243,18 @@ const createComponents = (
 // every Response instance shares the same stable references.
 // This prevents Streamdown from discarding its cached render
 // tree on each parent re-render.
-const componentsByTheme: Record<FileViewerThemeType, Components> = {
-	light: createComponents("light", fileViewerTheme.light),
-	dark: createComponents("dark", fileViewerTheme.dark),
+const componentsByTheme: Record<
+	FileViewerThemeType,
+	{ static: Components; streaming: Components }
+> = {
+	light: {
+		static: createComponents("light", fileViewerTheme.light, false),
+		streaming: createComponents("light", fileViewerTheme.light, true),
+	},
+	dark: {
+		static: createComponents("dark", fileViewerTheme.dark, false),
+		streaming: createComponents("dark", fileViewerTheme.dark, true),
+	},
 };
 
 export const Response = ({
@@ -250,7 +268,9 @@ export const Response = ({
 	const theme = useTheme();
 	const fileViewerThemeType: FileViewerThemeType =
 		theme.palette.mode === "dark" ? "dark" : "light";
-	const components = componentsByTheme[fileViewerThemeType];
+	const components = streaming
+		? componentsByTheme[fileViewerThemeType].streaming
+		: componentsByTheme[fileViewerThemeType].static;
 
 	return (
 		<div


### PR DESCRIPTION
## Summary

Reduces main-thread work during chat rendering and streaming in the Agents chat by stabilizing parsed message references and throttling streaming markdown re-parses.

## Problem

Long conversations in Agents chat caused multi-second LCP-window tasks. Two compounding factors: `parseMessagesWithMergedTools` rebuilt all output objects on every render (defeating `React.memo` on `ChatMessageItem`), and the smooth-text engine triggered markdown re-parse at full RAF rate (~60/sec).

## Fix

**Parsing cache** (`messageParsing.ts`): Per-message cache keyed by identity + content. Unchanged messages preserve reference identity (`===`), so `React.memo` on row components now correctly skips re-renders. Derived metadata (`subagentTitles`, `computerUseSubagentIds`) cached via `WeakMap`.

**Streaming throttle** (`SmoothText.ts`, `Response.tsx`): Markdown-aware publish gating limits React updates to ~20/sec during streaming (50ms minimum interval, 8-char minimum batch). Code blocks render as lightweight `<pre><code>` during streaming and promote to full `FileViewer` when the message settles.