### PR TITLE
perf(site): lazy-load Monaco editor to unblock chat first paint

### DIFF
--- a/site/src/components/SyntaxHighlighter/SyntaxHighlighter.tsx
+++ b/site/src/components/SyntaxHighlighter/SyntaxHighlighter.tsx
@@ -1,11 +1,15 @@
 import { useTheme } from "@emotion/react";
-import Editor, { DiffEditor, loader } from "@monaco-editor/react";
+import Editor, { DiffEditor } from "@monaco-editor/react";
 import type * as Monaco from "monaco-editor";
-import * as monaco from "monaco-editor";
-import { type ComponentProps, type FC, useCallback } from "react";
+import {
+	type ComponentProps,
+	type FC,
+	useCallback,
+	useEffect,
+	useState,
+} from "react";
+import { ensureMonacoIsLoaded } from "#/utils/monaco";
 import { useCoderTheme } from "./coderTheme";
-
-loader.config({ monaco });
 
 // Shared editor props with onMount typed to accept either editor variant,
 // so callers don't need to know which underlying component will render.
@@ -37,6 +41,25 @@ export const SyntaxHighlighter: FC<SyntaxHighlighterProps> = ({
 	const hasDiff = compareWith && value !== compareWith;
 	const theme = useTheme();
 	const coderTheme = useCoderTheme();
+	const [monacoReady, setMonacoReady] = useState(false);
+
+	useEffect(() => {
+		let isMounted = true;
+
+		void ensureMonacoIsLoaded()
+			.then(() => {
+				if (isMounted) {
+					setMonacoReady(true);
+				}
+			})
+			.catch(() => {
+				// Not a biggie!
+			});
+
+		return () => {
+			isMounted = false;
+		};
+	}, []);
 
 	// Auto-scroll to first diff when the diff editor mounts and diffs are computed.
 	const handleDiffEditorMount = useCallback(
@@ -86,7 +109,7 @@ export const SyntaxHighlighter: FC<SyntaxHighlighterProps> = ({
 		...editorProps,
 	};
 
-	if (coderTheme.isLoading) {
+	if (coderTheme.isLoading || !monacoReady) {
 		return null;
 	}
 

--- a/site/src/pages/TemplateVersionEditorPage/MonacoEditor.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/MonacoEditor.tsx
@@ -1,10 +1,9 @@
 import { useTheme } from "@emotion/react";
-import Editor, { loader } from "@monaco-editor/react";
-import * as monaco from "monaco-editor";
-import { type FC, useEffect } from "react";
+import Editor from "@monaco-editor/react";
+import type * as Monaco from "monaco-editor";
+import { type FC, useCallback, useEffect, useRef, useState } from "react";
 import { MONOSPACE_FONT_FAMILY } from "#/theme/constants";
-
-loader.config({ monaco });
+import { ensureMonacoIsLoaded } from "#/utils/monaco";
 
 export interface MonacoEditorProps {
 	value?: string;
@@ -18,20 +17,56 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({
 	path,
 }) => {
 	const theme = useTheme();
+	const monacoRef = useRef<typeof Monaco | null>(null);
+	const [monacoReady, setMonacoReady] = useState(false);
+
+	const configureMonacoTheme = useCallback(
+		(monacoInstance: typeof Monaco) => {
+			document.fonts.ready
+				.then(() => {
+					// Ensures that all text is measured properly.
+					// If this isn't done, there can be weird selection issues.
+					monacoInstance.editor.remeasureFonts();
+				})
+				.catch(() => {
+					// Not a biggie!
+				});
+
+			monacoInstance.editor.defineTheme("min", theme.monaco);
+		},
+		[theme],
+	);
 
 	useEffect(() => {
-		document.fonts.ready
-			.then(() => {
-				// Ensures that all text is measured properly.
-				// If this isn't done, there can be weird selection issues.
-				monaco.editor.remeasureFonts();
+		let isMounted = true;
+
+		void ensureMonacoIsLoaded()
+			.then((monacoInstance) => {
+				monacoRef.current = monacoInstance;
+				if (isMounted) {
+					setMonacoReady(true);
+				}
 			})
 			.catch(() => {
 				// Not a biggie!
 			});
 
-		monaco.editor.defineTheme("min", theme.monaco);
-	}, [theme]);
+		return () => {
+			isMounted = false;
+		};
+	}, []);
+
+	useEffect(() => {
+		if (!monacoReady || !monacoRef.current) {
+			return;
+		}
+
+		configureMonacoTheme(monacoRef.current);
+	}, [configureMonacoTheme, monacoReady]);
+
+	if (!monacoReady) {
+		return null;
+	}
 
 	return (
 		<Editor
@@ -53,13 +88,17 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({
 					onChange(newValue);
 				}
 			}}
-			onMount={(editor) => {
+			onMount={(editor, monacoInstance) => {
+				monacoRef.current = monacoInstance;
+				setMonacoReady(true);
+				configureMonacoTheme(monacoInstance);
+
 				// This jank allows for Ctrl + Enter to work outside the editor.
 				// We use this keybind to trigger a build.
 				// biome-ignore lint/suspicious/noExplicitAny: Private type in Monaco!
 				(editor as any)._standaloneKeybindingService.addDynamicKeybinding(
 					"-editor.action.insertLineAfter",
-					monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,
+					monacoInstance.KeyMod.CtrlCmd | monacoInstance.KeyCode.Enter,
 					() => {},
 				);
 

--- a/site/src/utils/monaco.test.ts
+++ b/site/src/utils/monaco.test.ts
@@ -1,0 +1,47 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+type FsGlob = (
+	pattern: string,
+	options?: {
+		cwd?: string;
+	},
+) => AsyncIterable<string>;
+
+const glob = (fs as typeof fs & { glob: FsGlob }).glob;
+const eagerMonacoImportPattern =
+	/^\s*import\s+(?!type\b)[^;]*\bfrom\s*["']monaco-editor["']\s*;?/m;
+
+describe("monaco loading", () => {
+	it("does not use eager monaco-editor imports in production source files", async () => {
+		const srcDir = path.resolve(process.cwd(), "src");
+		const sourceFiles: string[] = [];
+
+		for await (const filePath of glob("**/*.{ts,tsx}", { cwd: srcDir })) {
+			sourceFiles.push(filePath);
+		}
+
+		const violations: string[] = [];
+		const filesToCheck = sourceFiles
+			.map((filePath) => filePath.replaceAll(path.sep, "/"))
+			.filter((filePath) => !filePath.includes("node_modules"))
+			.filter((filePath) => !filePath.includes(".stories."))
+			.filter((filePath) => !filePath.includes(".test."))
+			.filter((filePath) => filePath !== "utils/monaco.ts")
+			.sort();
+
+		for (const relativePath of filesToCheck) {
+			const absolutePath = path.join(srcDir, relativePath);
+			const fileContents = await fs.readFile(absolutePath, "utf8");
+
+			if (eagerMonacoImportPattern.test(fileContents)) {
+				violations.push(
+					`Found eager monaco-editor import in src/${relativePath}. Use ensureMonacoIsLoaded() from #/utils/monaco instead.`,
+				);
+			}
+		}
+
+		expect(violations.join("\n")).toBe("");
+	});
+});

--- a/site/src/utils/monaco.ts
+++ b/site/src/utils/monaco.ts
@@ -1,0 +1,25 @@
+import { loader } from "@monaco-editor/react";
+
+let configurePromise: Promise<typeof import("monaco-editor")> | null = null;
+
+/**
+ * Lazily loads the local Monaco editor module and configures
+ * @monaco-editor/react to use it instead of the CDN. This keeps the heavy
+ * Monaco bundle out of the critical path for routes that never render an
+ * editor.
+ *
+ * Returns a promise that resolves to the Monaco namespace. Safe to call
+ * multiple times; only the first call triggers the dynamic import.
+ */
+export const ensureMonacoIsLoaded = (): Promise<
+	typeof import("monaco-editor")
+> => {
+	if (!configurePromise) {
+		configurePromise = import("monaco-editor").then((monaco) => {
+			loader.config({ monaco });
+			return monaco;
+		});
+	}
+
+	return configurePromise;
+};


### PR DESCRIPTION
Chat route first paint was blocked by Monaco editor assets (~4 MB) even though
the chat page never renders a Monaco editor. Both `SyntaxHighlighter.tsx` and
`MonacoEditor.tsx` had top-level `import * as monaco from "monaco-editor"` plus
a module-scope `loader.config({ monaco })` call, which pulled the entire Monaco
bundle into the module graph as soon as either file was resolved — even through
lazy route boundaries.

This PR introduces a shared lazy initializer (`site/src/utils/monaco.ts`) that
defers the Monaco import to a dynamic `import("monaco-editor")` triggered only
when a component that actually needs Monaco is about to mount. Both consumer
files now gate rendering on a `monacoReady` state and use the lazily loaded
instance for runtime calls (theme setup, keybindings, font remeasurement).

A vitest regression guard scans all production source files to prevent eager
static Monaco imports from being reintroduced.