### PR TITLE
feat: resolve `useTime()` `thunk()` error

### DIFF
--- a/site/src/hooks/useTime.ts
+++ b/site/src/hooks/useTime.ts
@@ -30,7 +30,7 @@ export function useTime<T>(func: () => T, options: UseTimeOptions = {}): T {
 		}
 
 		const handle = setInterval(() => {
-			setComputedValue(() => thunk());
+			setComputedValue(thunk());
 		}, interval);
 
 		return () => {

--- a/site/src/hooks/useTime.ts
+++ b/site/src/hooks/useTime.ts
@@ -30,7 +30,8 @@ export function useTime<T>(func: () => T, options: UseTimeOptions = {}): T {
 		}
 
 		const handle = setInterval(() => {
-			setComputedValue(thunk());
+			const next = thunk();
+			setComputedValue(() => next);
 		}, interval);
 
 		return () => {


### PR DESCRIPTION
Fixes a regression introduced in #24060 that could crash the frontend.

`thunk` is created by `useEffectEvent()`, and React 19.2 enforces that effect-event functions are not invoked during render. The previous code called `thunk()` inside a `setState` updater function, and React executes updater
functions during render, so this became an illegal render-phase call.

The fix computes `next` in the interval callback (`const next = thunk()`) and then stores it via `setComputedValue(() => next)`. This keeps the `useEffectEvent` call outside render and also preserves correct behavior when `func` returns a function value, because React stores `next` instead of treating it as a functional updater.