### PR TITLE
fix: resolve `<WorkspaceTimings />` size

### DIFF
--- a/site/src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.tsx
+++ b/site/src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.tsx
@@ -100,22 +100,24 @@ export const WorkspaceTimings: FC<WorkspaceTimingsProps> = ({
 
 	return (
 		<div className="rounded-lg border-solid bg-surface-primary">
-			<Button
-				disabled={isLoading}
-				variant="subtle"
-				className="w-full flex items-center"
-				onClick={() => setIsOpen((o) => !o)}
-			>
-				<ChevronDownIcon open={isOpen} className="size-4 mr-4" />
-				<span>Build timeline</span>
-				<span className="ml-auto text-content-secondary">
+			<div className="flex items-center justify-between px-4 py-1.5 relative">
+				<Button
+					disabled={isLoading}
+					variant="subtle"
+					onClick={() => setIsOpen((o) => !o)}
+					className="after:content-[''] after:absolute after:inset-0"
+				>
+					<ChevronDownIcon open={isOpen} />
+					<span>Build timeline</span>
+				</Button>
+				<span className="ml-auto text-sm text-content-secondary pr-2">
 					{isLoading ? (
 						<Skeleton variant="text" width={40} height={16} />
 					) : (
 						displayProvisioningTime()
 					)}
 				</span>
-			</Button>
+			</div>
 			{!isLoading && (
 				<Collapse in={isOpen}>
 					<div


### PR DESCRIPTION
This pull-request matches the hit-target request for `<WorkspaceTimings />` so that its matched inline with `Logs` for the agent logs above it 🙂 One step closer to the new workspace design system.

<img width="950" height="172" alt="image" src="https://github.com/user-attachments/assets/7bcdbd0d-9761-46a9-bbd3-e3729b1dd468" />
