### PR TITLE
docs: require flat branch names for docs-only PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,6 +184,15 @@ git pull origin branch-name
 
 Don't use `git push --force` unless explicitly requested.
 
+### Docs-only PRs
+
+For PRs that change **only** `docs/` files, use a flat branch name
+without `/` (e.g., `docs-fix-gateway-setup`, not
+`user/docs-fix-gateway-setup`). The docs preview site serves branch
+previews at `https://coder.com/docs/@<branch-name>` and `/` in the
+branch name breaks this URL. Include the preview base URL in the PR
+description so reviewers can browse the rendered changes.
+
 ### New Feature Checklist
 
 - [ ] Run `git pull` to ensure latest code


### PR DESCRIPTION
Docs preview URLs (`coder.com/docs/@branch-name`) break when the branch name contains a `/` because the coder.com Next.js router cannot disambiguate branch segments from doc path segments. A fix was attempted on the website side ([coder/coder.com#379](https://github.com/coder/coder.com/pull/379)) but was rejected.

Adds a "Docs-only PRs" section to `AGENTS.md` instructing agents to use flat branch names (no `/`) for docs-only PRs and to include the preview base URL in the PR description.

> [!NOTE]
> Generated by Coder Agents