### PR TITLE
fix: backport dogfood CI fixes to release/2.29

### DIFF
--- a/dogfood/coder/Dockerfile
+++ b/dogfood/coder/Dockerfile
@@ -298,7 +298,6 @@ ARG CLOUD_SQL_PROXY_VERSION=2.2.0 \
 	KUBECTX_VERSION=0.9.4 \
 	STRIPE_VERSION=1.14.5 \
 	TERRAGRUNT_VERSION=0.45.11 \
-	TRIVY_VERSION=0.41.0 \
 	SYFT_VERSION=1.20.0 \
 	COSIGN_VERSION=2.4.3 \
 	BUN_VERSION=1.2.15
@@ -337,9 +336,6 @@ RUN curl --silent --show-error --location --output /usr/local/bin/cloud_sql_prox
 	# terragrunt for running Terraform and Terragrunt files
 	curl --silent --show-error --location --output /usr/local/bin/terragrunt "https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_linux_amd64" && \
 	chmod a=rx /usr/local/bin/terragrunt && \
-	# AquaSec Trivy for scanning container images for security issues
-	curl --silent --show-error --location "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" | \
-	tar --extract --gzip --directory=/usr/local/bin --file=- trivy && \
 	# Anchore Syft for SBOM generation
 	curl --silent --show-error --location "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.tar.gz" | \
 	tar --extract --gzip --directory=/usr/local/bin --file=- syft && \

--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -890,7 +890,6 @@ resource "coder_app" "develop_sh" {
   icon         = "${data.coder_workspace.me.access_url}/emojis/1f4bb.png" // 💻
   command      = "screen -x develop_sh"
   share        = "authenticated"
-  subdomain    = true
   open_in      = "tab"
   order        = 0
 }


### PR DESCRIPTION
Cherry-picks two fixes onto `release/2.29` that are both needed together to unblock CI:

1. **Remove trivy from Dockerfile** (original: #23367, commit `4c9041b2`) — upstream Trivy v0.41.0 release artifact was deleted, causing `gzip: stdin: not in gzip format` in the `build_image` job.
2. **Remove subdomain from coder_app with command** (original: #22990, commit `fd634626`) — `coder_app` no longer supports both `command` and `subdomain`, causing `deploy_template` to fail on `terraform validate`.

Both commits are required for CI to pass — the first fixes the Docker build and the second fixes Terraform validation.

> 🤖 Generated by Coder Agents