### PR TITLE
fix(site): hide bottom spacer on last session thread

### DIFF
--- a/site/src/pages/AIBridgePage/SessionThreadsPage/SessionTimeline/SessionTimeline.tsx
+++ b/site/src/pages/AIBridgePage/SessionThreadsPage/SessionTimeline/SessionTimeline.tsx
@@ -265,14 +265,9 @@ const AgenticActionItem: FC<AgenticActionItemProps> = ({ action }) => {
 interface ThreadItemProps {
 	thread: AIBridgeThread;
 	initiator: MinimalUser;
-	isLastThread: boolean;
 }
 
-const ThreadItem: FC<ThreadItemProps> = ({
-	thread,
-	initiator,
-	isLastThread,
-}) => {
+const ThreadItem: FC<ThreadItemProps> = ({ thread, initiator }) => {
 	const [agenticLoopOpen, setAgenticLoopOpen] = useState(false);
 
 	const durationInMs =
@@ -402,9 +397,9 @@ const ThreadItem: FC<ThreadItemProps> = ({
 					)}
 				</BracketConnector>
 			) : (
-				// if no agentic loop, we need a little spacing element to create
-				// the visual gap between threads, unless this is the last thread
-				!isLastThread && <div className="h-4" />
+				// Spacer to create visual gap between threads. Hidden on the
+				// last thread via the wrapper div's :last-child selector.
+				<div className="h-4 thread-gap" />
 			)}
 		</>
 	);
@@ -530,14 +525,15 @@ export const SessionTimeline: FC<SessionTimelineProps> = ({
 				</div>
 				<div className="row-start-5 col-start-2 col-span-4">
 					{/* threads */}
-					{threads.map((thread, i) => (
-						<ThreadItem
-							key={thread.id}
-							thread={thread}
-							initiator={initiator}
-							isLastThread={i === threads.length - 1}
-						/>
-					))}
+					<div className="[&>.thread-gap:last-child]:hidden">
+						{threads.map((thread) => (
+							<ThreadItem
+								key={thread.id}
+								thread={thread}
+								initiator={initiator}
+							/>
+						))}
+					</div>
 					{/* infinite scroll sentinel — sits 200px below the last thread */}
 					<div ref={sentinelRef} />
 					{isFetchingNextPage && (

--- a/site/src/pages/AIBridgePage/SessionThreadsPage/SessionTimeline/SessionTimeline.tsx
+++ b/site/src/pages/AIBridgePage/SessionThreadsPage/SessionTimeline/SessionTimeline.tsx
@@ -265,9 +265,14 @@ const AgenticActionItem: FC<AgenticActionItemProps> = ({ action }) => {
 interface ThreadItemProps {
 	thread: AIBridgeThread;
 	initiator: MinimalUser;
+	isLastThread: boolean;
 }
 
-const ThreadItem: FC<ThreadItemProps> = ({ thread, initiator }) => {
+const ThreadItem: FC<ThreadItemProps> = ({
+	thread,
+	initiator,
+	isLastThread,
+}) => {
 	const [agenticLoopOpen, setAgenticLoopOpen] = useState(false);
 
 	const durationInMs =
@@ -398,8 +403,8 @@ const ThreadItem: FC<ThreadItemProps> = ({ thread, initiator }) => {
 				</BracketConnector>
 			) : (
 				// if no agentic loop, we need a little spacing element to create
-				// the visual gap between threads
-				<div className="h-4" />
+				// the visual gap between threads, unless this is the last thread
+				!isLastThread && <div className="h-4" />
 			)}
 		</>
 	);
@@ -525,8 +530,13 @@ export const SessionTimeline: FC<SessionTimelineProps> = ({
 				</div>
 				<div className="row-start-5 col-start-2 col-span-4">
 					{/* threads */}
-					{threads.map((thread) => (
-						<ThreadItem key={thread.id} thread={thread} initiator={initiator} />
+					{threads.map((thread, i) => (
+						<ThreadItem
+							key={thread.id}
+							thread={thread}
+							initiator={initiator}
+							isLastThread={i === threads.length - 1}
+						/>
 					))}
 					{/* infinite scroll sentinel — sits 200px below the last thread */}
 					<div ref={sentinelRef} />


### PR DESCRIPTION
If theres is no agentic loop on the last thread, there will be a space between the bottom of the section and the session completed lines. This fixes that

Before
<img width="346" height="333" alt="Screenshot 2026-04-10 at 12 25 39 PM" src="https://github.com/user-attachments/assets/de0a1ebb-ba58-4318-be0d-28dacfd5dcb2" />

After
<img width="222" height="209" alt="Screenshot 2026-04-10 at 12 26 13 PM" src="https://github.com/user-attachments/assets/c2bd5086-6bbd-4c85-ba7b-4955185ddaf1" />
