### PR TITLE
fix: show devcontainer Delete menu for failed/error states

### DIFF
--- a/site/src/modules/resources/AgentDevcontainerCard.stories.tsx
+++ b/site/src/modules/resources/AgentDevcontainerCard.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { screen, spyOn, userEvent, within } from "storybook/test";
+import { expect, screen, spyOn, userEvent, within } from "storybook/test";
 import { API } from "#/api/api";
 import { getPreferredProxy } from "#/contexts/ProxyContext";
 import { chromatic } from "#/testHelpers/chromatic";
@@ -56,6 +56,13 @@ export const HasError: Story = {
 			error: "unable to inject devcontainer with agent",
 			agent: undefined,
 		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const moreActionsButton = canvas.getByRole("button", {
+			name: "Dev Container actions",
+		});
+		expect(moreActionsButton).toBeVisible();
 	},
 };
 
@@ -122,6 +129,13 @@ export const NoContainerOrSubAgent: Story = {
 			agent: undefined,
 		},
 		subAgents: [],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const moreActionsButton = canvas.getByRole("button", {
+			name: "Dev Container actions",
+		});
+		expect(moreActionsButton).toBeVisible();
 	},
 };
 

--- a/site/src/modules/resources/AgentDevcontainerCard.tsx
+++ b/site/src/modules/resources/AgentDevcontainerCard.tsx
@@ -274,7 +274,7 @@ export const AgentDevcontainerCard: FC<AgentDevcontainerCardProps> = ({
 							/>
 						)}
 
-					{showDevcontainerControls && (
+					{!isTransitioning && (
 						<AgentDevcontainerMoreActions
 							deleteDevContainer={deleteDevcontainerMutation.mutate}
 						/>


### PR DESCRIPTION
Fixes #23754

## Problem

The three-dot menu (containing "Delete") was gated behind `showDevcontainerControls`, which requires both a `subAgent` AND a `devcontainer.container` to be truthy:

```ts
const showDevcontainerControls = subAgent && devcontainer.container;
```

When a devcontainer fails (e.g. `exit status 1`), the container reference and/or subAgent may be missing, so the Delete menu is never rendered. Users have no way to clean up failed devcontainers from the UI.

## Fix

Decouple `AgentDevcontainerMoreActions` from `showDevcontainerControls`. The delete API only needs `parentAgent.id` + `devcontainer.id` — no dependency on `subAgent` or `container`. The menu is now rendered whenever the devcontainer is not in a transitioning state (`starting`, `stopping`, `deleting`), which are the same states where the rebuild/start button is already disabled.

Other controls (SSH, port forwarding) remain gated behind `showDevcontainerControls` since they genuinely require a connected subAgent and running container.

## Stories updated

- `HasError` — added interaction test asserting the three-dot menu is visible
- `NoContainerOrSubAgent` — added interaction test asserting the three-dot menu is visible

<details><summary>Implementation notes (Coder Agents generated)</summary>

- The `isTransitioning` guard (`starting | stopping | deleting`) was already used to disable the rebuild/start button, so reusing it here is consistent.
- The `deleteWorkspaceAgentDevcontainer` mutation only uses `parentAgent.id` and `devcontainer.id`, confirmed in `site/src/api/queries/workspaces.ts`.
- No backend changes needed.

> This PR was authored by Coder Agents.
</details>