### PR TITLE
fix(scripts): fix Windows version format for RC builds (backport v2.29)

### DIFF
--- a/scripts/build_go.sh
+++ b/scripts/build_go.sh
@@ -238,7 +238,7 @@ if [[ "$windows_resources" == 1 ]] && [[ "$os" == "windows" ]]; then
 	# Remove any trailing data after a "+" or "-".
 	version_windows=$version
 	version_windows="${version_windows%+*}"
-	version_windows="${version_windows%-*}"
+	version_windows="${version_windows%%-*}"
 	# If there wasn't any extra data, add a .0 to the version. Otherwise, add
 	# a .1 to the version to signify that this is not a release build so it can
 	# be distinguished from a release build.


### PR DESCRIPTION
Cherry-pick of https://github.com/coder/coder/commit/7f75670f8d9695c0024aab836748d7d46cc25f76 onto `release/2.29`.

Original PR: #23542

`scripts/build_go.sh` uses `${var%-*}` (shortest suffix match) to strip pre-release segments for Windows version format, but for RC versions like `2.33.0-rc.1-devel` this only removes `-devel`, leaving `2.33.0-rc.1` which becomes the invalid `2.33.0-rc.1.1`. Fix: switch to `${var%%-*}` (longest suffix match) to strip from the first hyphen.

> 🤖 Generated by Coder Agents