### PR TITLE
chore: update EA text and docs link in Coder Agents UI

### DIFF
--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -383,15 +383,15 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 					</div>
 				) : null}
 				<p className="mt-1 text-center text-xs text-content-secondary/50">
-					Coder Agents is available via{" "}
 					<a
-						href={docs("/ai-coder/agents/early-access")}
+						href={docs("/ai-coder/agents")}
 						target="_blank"
 						rel="noreferrer"
 						className="text-content-secondary/50 underline hover:text-content-secondary"
 					>
-						Early Access
-					</a>
+						Introductory access
+					</a>{" "}
+					to Coder Agents through September 2026
 				</p>
 			</div>
 		</div>


### PR DESCRIPTION
Updates the early access copy in the Coder Agents create form:

- **Before:** "Coder Agents is available via Early Access" (linked to `/ai-coder/agents/early-access`)
- **After:** "Introductory access to Coder Agents through September 2026" (linked to `/ai-coder/agents`)

The docs link now points to the main [Coder Agents overview page](https://coder.com/docs/ai-coder/agents) instead of the early-access subpage.

Fixes: [CODAGT-152](https://linear.app/codercom/issue/CODAGT-152/update-ea-text-and-docs-link-in-coder-agents-ui)

<img width="1341" height="995" alt="image" src="https://github.com/user-attachments/assets/051a3bd6-ff11-43e1-bdf1-9b409e8fb97f" />


> 🤖 Generated by Coder Agents