### PR TITLE
feat: log warning on nested transaction isolation mismatch

### DIFF
--- a/cli/resetpassword.go
+++ b/cli/resetpassword.go
@@ -51,7 +51,7 @@ func (*RootCmd) resetPassword() *serpent.Command {
 			}
 			defer sqlDB.Close()
 
-			db := database.New(sqlDB)
+			db := database.New(sqlDB, database.WithLogger(logger.Named("database")))
 
 			user, err := db.GetUserByEmailOrUsername(inv.Context(), database.GetUserByEmailOrUsernameParams{
 				Username: username,

--- a/cli/resetpassword.go
+++ b/cli/resetpassword.go
@@ -51,7 +51,7 @@ func (*RootCmd) resetPassword() *serpent.Command {
 			}
 			defer sqlDB.Close()
 
-			db := database.New(sqlDB, database.WithLogger(logger.Named("database")))
+			db := database.New(sqlDB, logger.Named("database"))
 
 			user, err := db.GetUserByEmailOrUsername(inv.Context(), database.GetUserByEmailOrUsernameParams{
 				Username: username,

--- a/cli/server.go
+++ b/cli/server.go
@@ -762,7 +762,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 				options.PrometheusRegistry.MustRegister(collectors.NewDBStatsCollector(sqlDB, ""))
 			}
 
-			options.Database = database.New(sqlDB)
+			options.Database = database.New(sqlDB, database.WithLogger(logger.Named("database")))
 			ps, err := pubsub.New(ctx, logger.Named("pubsub"), sqlDB, dbURL)
 			if err != nil {
 				return xerrors.Errorf("create pubsub: %w", err)

--- a/cli/server.go
+++ b/cli/server.go
@@ -776,7 +776,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 				options.PrometheusRegistry.MustRegister(collectors.NewDBStatsCollector(sqlDB, ""))
 			}
 
-			options.Database = database.New(sqlDB, database.WithLogger(logger.Named("database")))
+			options.Database = database.New(sqlDB, logger.Named("database"))
 			ps, err := pubsub.New(ctx, logger.Named("pubsub"), sqlDB, dbURL)
 			if err != nil {
 				return xerrors.Errorf("create pubsub: %w", err)

--- a/cli/server.go
+++ b/cli/server.go
@@ -776,7 +776,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 				options.PrometheusRegistry.MustRegister(collectors.NewDBStatsCollector(sqlDB, ""))
 			}
 
-			options.Database = database.New(sqlDB)
+			options.Database = database.New(sqlDB, database.WithLogger(logger.Named("database")))
 			ps, err := pubsub.New(ctx, logger.Named("pubsub"), sqlDB, dbURL)
 			if err != nil {
 				return xerrors.Errorf("create pubsub: %w", err)

--- a/cli/server_createadminuser.go
+++ b/cli/server_createadminuser.go
@@ -79,7 +79,7 @@ func (r *RootCmd) newCreateAdminUserCommand() *serpent.Command {
 			defer func() {
 				_ = sqlDB.Close()
 			}()
-			db := database.New(sqlDB)
+			db := database.New(sqlDB, database.WithLogger(logger.Named("database")))
 
 			validateInputs := func(username, email, password string) error {
 				// Use the validator tags so we match the API's validation.

--- a/cli/server_createadminuser.go
+++ b/cli/server_createadminuser.go
@@ -79,7 +79,7 @@ func (r *RootCmd) newCreateAdminUserCommand() *serpent.Command {
 			defer func() {
 				_ = sqlDB.Close()
 			}()
-			db := database.New(sqlDB, database.WithLogger(logger.Named("database")))
+			db := database.New(sqlDB, logger.Named("database"))
 
 			validateInputs := func(username, email, password string) error {
 				// Use the validator tags so we match the API's validation.

--- a/cli/server_createadminuser_test.go
+++ b/cli/server_createadminuser_test.go
@@ -39,7 +39,7 @@ func TestServerCreateAdminUser(t *testing.T) {
 		sqlDB, err := sql.Open("postgres", dbURL)
 		require.NoError(t, err)
 		defer sqlDB.Close()
-		db := database.New(sqlDB)
+		db := database.New(sqlDB, testutil.Logger(t))
 
 		pingCtx, pingCancel := context.WithTimeout(ctx, testutil.WaitShort)
 		defer pingCancel()
@@ -91,7 +91,7 @@ func TestServerCreateAdminUser(t *testing.T) {
 		sqlDB, err := sql.Open("postgres", connectionURL)
 		require.NoError(t, err)
 		defer sqlDB.Close()
-		db := database.New(sqlDB)
+		db := database.New(sqlDB, testutil.Logger(t))
 
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitMedium)
 		defer cancel()

--- a/cli/server_regenerate_vapid_keypair.go
+++ b/cli/server_regenerate_vapid_keypair.go
@@ -66,7 +66,7 @@ func (r *RootCmd) newRegenerateVapidKeypairCommand() *serpent.Command {
 			defer func() {
 				_ = sqlDB.Close()
 			}()
-			db := database.New(sqlDB)
+			db := database.New(sqlDB, database.WithLogger(logger.Named("database")))
 
 			// Confirm that the user really wants to regenerate the VAPID keypair.
 			cliui.Infof(inv.Stdout, "Regenerating VAPID keypair...")

--- a/cli/server_regenerate_vapid_keypair.go
+++ b/cli/server_regenerate_vapid_keypair.go
@@ -66,7 +66,7 @@ func (r *RootCmd) newRegenerateVapidKeypairCommand() *serpent.Command {
 			defer func() {
 				_ = sqlDB.Close()
 			}()
-			db := database.New(sqlDB, database.WithLogger(logger.Named("database")))
+			db := database.New(sqlDB, logger.Named("database"))
 
 			// Confirm that the user really wants to regenerate the VAPID keypair.
 			cliui.Infof(inv.Stdout, "Regenerating VAPID keypair...")

--- a/cli/server_regenerate_vapid_keypair_test.go
+++ b/cli/server_regenerate_vapid_keypair_test.go
@@ -31,7 +31,7 @@ func TestRegenerateVapidKeypair(t *testing.T) {
 		require.NoError(t, err)
 		defer sqlDB.Close()
 
-		db := database.New(sqlDB)
+		db := database.New(sqlDB, testutil.Logger(t))
 		// Ensure there is no existing VAPID keypair.
 		rows, err := db.GetWebpushVAPIDKeys(ctx)
 		require.NoError(t, err)
@@ -70,7 +70,7 @@ func TestRegenerateVapidKeypair(t *testing.T) {
 		require.NoError(t, err)
 		defer sqlDB.Close()
 
-		db := database.New(sqlDB)
+		db := database.New(sqlDB, testutil.Logger(t))
 		for i := 0; i < 10; i++ {
 			// Insert a few fake users.
 			u := dbgen.User(t, db, database.User{})

--- a/coderd/database/db.go
+++ b/coderd/database/db.go
@@ -203,19 +203,13 @@ func (q *sqlQuerier) runTx(function func(Store) error, txOpts *sql.TxOptions) er
 		// If the current inner "db" is already a transaction, we just reuse it.
 		// We do not need to handle commit/rollback as the outer tx will handle
 		// that.
-		if txOpts.Isolation > q.txIsolationLevel {
-			// The nested call requested a stricter isolation level than
-			// the parent, but it will be silently ignored because we
-			// reuse the parent transaction. Log this so callers can
-			// detect the mismatch.
-			//
-			// NOTE: this comparison relies on sql.IsolationLevel's iota
-			// ordering matching strictness for the standard SQL levels
-			// (ReadUncommitted < ReadCommitted < RepeatableRead <
-			// Serializable). Non-standard levels like WriteCommitted,
-			// Snapshot, and Linearizable also exist in the enum but are
-			// never used by this codebase. If that changes, this numeric
-			// comparison may need revisiting.
+		parentLevel := normalizeIsolationLevel(q.txIsolationLevel)
+		childLevel := normalizeIsolationLevel(txOpts.Isolation)
+		if childLevel > parentLevel {
+			// The nested call requested a stricter isolation level
+			// than the parent, but it will be silently ignored
+			// because we reuse the parent transaction. Log this so
+			// callers can detect the mismatch.
 			q.logger.Warn(context.Background(), "nested transaction requested stricter isolation level than the outer transaction provides",
 				slog.F("parent_isolation", q.txIsolationLevel.String()),
 				slog.F("requested_isolation", txOpts.Isolation.String()),
@@ -254,6 +248,23 @@ func (q *sqlQuerier) runTx(function func(Store) error, txOpts *sql.TxOptions) er
 		return xerrors.Errorf("commit transaction: %w", err)
 	}
 	return nil
+}
+
+// normalizeIsolationLevel maps sql.LevelDefault to sql.LevelReadCommitted
+// for comparison purposes. The Go sql package defines LevelDefault as 0,
+// which sits below LevelReadUncommitted (1) in the iota ordering. When
+// LevelDefault is passed to the database driver, no explicit isolation
+// clause is sent, and the server applies its configured default. In
+// standard PostgreSQL this is "read committed". We normalize to
+// LevelReadCommitted so that the strictness comparison in runTx produces
+// correct results for the common case. If your PostgreSQL instance uses a
+// non-standard default_transaction_isolation (e.g. serializable), this
+// assumption may produce false negatives.
+func normalizeIsolationLevel(level sql.IsolationLevel) sql.IsolationLevel {
+	if level == sql.LevelDefault {
+		return sql.LevelReadCommitted
+	}
+	return level
 }
 
 func safeString(s *string) string {

--- a/coderd/database/db.go
+++ b/coderd/database/db.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/jmoiron/sqlx"
 	"golang.org/x/xerrors"
+
+	slog "cdr.dev/slog/v3"
 )
 
 // Store contains all queryable database functions.
@@ -51,6 +53,12 @@ type DBTX interface {
 func WithSerialRetryCount(count int) func(*sqlQuerier) {
 	return func(q *sqlQuerier) {
 		q.serialRetryCount = count
+	}
+}
+
+func WithLogger(logger slog.Logger) func(*sqlQuerier) {
+	return func(q *sqlQuerier) {
+		q.logger = logger
 	}
 }
 
@@ -120,6 +128,14 @@ type sqlQuerier struct {
 	// serialRetryCount is the number of times to retry a transaction
 	// if it fails with a serialization error.
 	serialRetryCount int
+
+	// logger is used to log warnings about transaction nesting.
+	// Zero value (slog.Logger{}) is a no-op logger.
+	logger slog.Logger
+
+	// txIsolationLevel tracks the isolation level of the current
+	// transaction, so nested InTx calls can report a mismatch.
+	txIsolationLevel sql.IsolationLevel
 }
 
 func (*sqlQuerier) Wrappers() []string {
@@ -187,6 +203,15 @@ func (q *sqlQuerier) runTx(function func(Store) error, txOpts *sql.TxOptions) er
 		// If the current inner "db" is already a transaction, we just reuse it.
 		// We do not need to handle commit/rollback as the outer tx will handle
 		// that.
+		if txOpts.Isolation != sql.LevelDefault {
+			// The nested call requested a specific isolation level, but
+			// it will be silently ignored because we reuse the parent
+			// transaction. Log this so callers can detect the mismatch.
+			q.logger.Critical(context.Background(), "nested transaction requested specific isolation level; the outer transaction's isolation level will be used",
+				slog.F("parent_isolation", q.txIsolationLevel.String()),
+				slog.F("requested_isolation", txOpts.Isolation.String()),
+			)
+		}
 		err := function(q)
 		if err != nil {
 			return xerrors.Errorf("execute transaction: %w", err)
@@ -207,7 +232,11 @@ func (q *sqlQuerier) runTx(function func(Store) error, txOpts *sql.TxOptions) er
 		// couldn't roll back for some reason, extend returned error
 		err = xerrors.Errorf("defer (%s): %w", rerr.Error(), err)
 	}()
-	err = function(&sqlQuerier{db: transaction})
+	err = function(&sqlQuerier{
+		db:               transaction,
+		logger:           q.logger,
+		txIsolationLevel: txOpts.Isolation,
+	})
 	if err != nil {
 		return xerrors.Errorf("execute transaction: %w", err)
 	}

--- a/coderd/database/db.go
+++ b/coderd/database/db.go
@@ -208,7 +208,7 @@ func (q *sqlQuerier) runTx(function func(Store) error, txOpts *sql.TxOptions) er
 			// the parent, but it will be silently ignored because we
 			// reuse the parent transaction. Log this so callers can
 			// detect the mismatch.
-			q.logger.Critical(context.Background(), "nested transaction requested stricter isolation level than the outer transaction provides",
+			q.logger.Warn(context.Background(), "nested transaction requested stricter isolation level than the outer transaction provides",
 				slog.F("parent_isolation", q.txIsolationLevel.String()),
 				slog.F("requested_isolation", txOpts.Isolation.String()),
 			)

--- a/coderd/database/db.go
+++ b/coderd/database/db.go
@@ -208,6 +208,14 @@ func (q *sqlQuerier) runTx(function func(Store) error, txOpts *sql.TxOptions) er
 			// the parent, but it will be silently ignored because we
 			// reuse the parent transaction. Log this so callers can
 			// detect the mismatch.
+			//
+			// NOTE: this comparison relies on sql.IsolationLevel's iota
+			// ordering matching strictness for the standard SQL levels
+			// (ReadUncommitted < ReadCommitted < RepeatableRead <
+			// Serializable). Non-standard levels like WriteCommitted,
+			// Snapshot, and Linearizable also exist in the enum but are
+			// never used by this codebase. If that changes, this numeric
+			// comparison may need revisiting.
 			q.logger.Warn(context.Background(), "nested transaction requested stricter isolation level than the outer transaction provides",
 				slog.F("parent_isolation", q.txIsolationLevel.String()),
 				slog.F("requested_isolation", txOpts.Isolation.String()),

--- a/coderd/database/db.go
+++ b/coderd/database/db.go
@@ -203,11 +203,12 @@ func (q *sqlQuerier) runTx(function func(Store) error, txOpts *sql.TxOptions) er
 		// If the current inner "db" is already a transaction, we just reuse it.
 		// We do not need to handle commit/rollback as the outer tx will handle
 		// that.
-		if txOpts.Isolation != sql.LevelDefault {
-			// The nested call requested a specific isolation level, but
-			// it will be silently ignored because we reuse the parent
-			// transaction. Log this so callers can detect the mismatch.
-			q.logger.Critical(context.Background(), "nested transaction requested specific isolation level; the outer transaction's isolation level will be used",
+		if txOpts.Isolation > q.txIsolationLevel {
+			// The nested call requested a stricter isolation level than
+			// the parent, but it will be silently ignored because we
+			// reuse the parent transaction. Log this so callers can
+			// detect the mismatch.
+			q.logger.Critical(context.Background(), "nested transaction requested stricter isolation level than the outer transaction provides",
 				slog.F("parent_isolation", q.txIsolationLevel.String()),
 				slog.F("requested_isolation", txOpts.Isolation.String()),
 			)

--- a/coderd/database/db.go
+++ b/coderd/database/db.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/jmoiron/sqlx"
 	"golang.org/x/xerrors"
+
+	slog "cdr.dev/slog/v3"
 )
 
 // Store contains all queryable database functions.
@@ -51,6 +53,12 @@ type DBTX interface {
 func WithSerialRetryCount(count int) func(*sqlQuerier) {
 	return func(q *sqlQuerier) {
 		q.serialRetryCount = count
+	}
+}
+
+func WithLogger(logger slog.Logger) func(*sqlQuerier) {
+	return func(q *sqlQuerier) {
+		q.logger = logger
 	}
 }
 
@@ -120,6 +128,14 @@ type sqlQuerier struct {
 	// serialRetryCount is the number of times to retry a transaction
 	// if it fails with a serialization error.
 	serialRetryCount int
+
+	// logger is used to log warnings about transaction nesting.
+	// Zero value (slog.Logger{}) is a no-op logger.
+	logger slog.Logger
+
+	// txIsolationLevel tracks the isolation level of the current
+	// transaction, so nested InTx calls can report a mismatch.
+	txIsolationLevel sql.IsolationLevel
 }
 
 func (*sqlQuerier) Wrappers() []string {
@@ -187,6 +203,15 @@ func (q *sqlQuerier) runTx(function func(Store) error, txOpts *sql.TxOptions) (e
 		// If the current inner "db" is already a transaction, we just reuse it.
 		// We do not need to handle commit/rollback as the outer tx will handle
 		// that.
+		if txOpts.Isolation != sql.LevelDefault {
+			// The nested call requested a specific isolation level, but
+			// it will be silently ignored because we reuse the parent
+			// transaction. Log this so callers can detect the mismatch.
+			q.logger.Critical(context.Background(), "nested transaction requested specific isolation level; the outer transaction's isolation level will be used",
+				slog.F("parent_isolation", q.txIsolationLevel.String()),
+				slog.F("requested_isolation", txOpts.Isolation.String()),
+			)
+		}
 		err := function(q)
 		if err != nil {
 			return xerrors.Errorf("execute transaction: %w", err)
@@ -207,7 +232,11 @@ func (q *sqlQuerier) runTx(function func(Store) error, txOpts *sql.TxOptions) (e
 		// couldn't roll back for some reason, extend returned error
 		err = xerrors.Errorf("defer (%s): %w", rerr.Error(), err)
 	}()
-	err = function(&sqlQuerier{db: transaction})
+	err = function(&sqlQuerier{
+		db:               transaction,
+		logger:           q.logger,
+		txIsolationLevel: txOpts.Isolation,
+	})
 	if err != nil {
 		return xerrors.Errorf("execute transaction: %w", err)
 	}

--- a/coderd/database/db.go
+++ b/coderd/database/db.go
@@ -203,11 +203,12 @@ func (q *sqlQuerier) runTx(function func(Store) error, txOpts *sql.TxOptions) (e
 		// If the current inner "db" is already a transaction, we just reuse it.
 		// We do not need to handle commit/rollback as the outer tx will handle
 		// that.
-		if txOpts.Isolation != sql.LevelDefault {
-			// The nested call requested a specific isolation level, but
-			// it will be silently ignored because we reuse the parent
-			// transaction. Log this so callers can detect the mismatch.
-			q.logger.Critical(context.Background(), "nested transaction requested specific isolation level; the outer transaction's isolation level will be used",
+		if txOpts.Isolation > q.txIsolationLevel {
+			// The nested call requested a stricter isolation level than
+			// the parent, but it will be silently ignored because we
+			// reuse the parent transaction. Log this so callers can
+			// detect the mismatch.
+			q.logger.Critical(context.Background(), "nested transaction requested stricter isolation level than the outer transaction provides",
 				slog.F("parent_isolation", q.txIsolationLevel.String()),
 				slog.F("requested_isolation", txOpts.Isolation.String()),
 			)

--- a/coderd/database/db.go
+++ b/coderd/database/db.go
@@ -208,7 +208,7 @@ func (q *sqlQuerier) runTx(function func(Store) error, txOpts *sql.TxOptions) (e
 			// the parent, but it will be silently ignored because we
 			// reuse the parent transaction. Log this so callers can
 			// detect the mismatch.
-			q.logger.Critical(context.Background(), "nested transaction requested stricter isolation level than the outer transaction provides",
+			q.logger.Warn(context.Background(), "nested transaction requested stricter isolation level than the outer transaction provides",
 				slog.F("parent_isolation", q.txIsolationLevel.String()),
 				slog.F("requested_isolation", txOpts.Isolation.String()),
 			)

--- a/coderd/database/db.go
+++ b/coderd/database/db.go
@@ -203,19 +203,13 @@ func (q *sqlQuerier) runTx(function func(Store) error, txOpts *sql.TxOptions) (e
 		// If the current inner "db" is already a transaction, we just reuse it.
 		// We do not need to handle commit/rollback as the outer tx will handle
 		// that.
-		if txOpts.Isolation > q.txIsolationLevel {
-			// The nested call requested a stricter isolation level than
-			// the parent, but it will be silently ignored because we
-			// reuse the parent transaction. Log this so callers can
-			// detect the mismatch.
-			//
-			// NOTE: this comparison relies on sql.IsolationLevel's iota
-			// ordering matching strictness for the standard SQL levels
-			// (ReadUncommitted < ReadCommitted < RepeatableRead <
-			// Serializable). Non-standard levels like WriteCommitted,
-			// Snapshot, and Linearizable also exist in the enum but are
-			// never used by this codebase. If that changes, this numeric
-			// comparison may need revisiting.
+		parentLevel := normalizeIsolationLevel(q.txIsolationLevel)
+		childLevel := normalizeIsolationLevel(txOpts.Isolation)
+		if childLevel > parentLevel {
+			// The nested call requested a stricter isolation level
+			// than the parent, but it will be silently ignored
+			// because we reuse the parent transaction. Log this so
+			// callers can detect the mismatch.
 			q.logger.Warn(context.Background(), "nested transaction requested stricter isolation level than the outer transaction provides",
 				slog.F("parent_isolation", q.txIsolationLevel.String()),
 				slog.F("requested_isolation", txOpts.Isolation.String()),
@@ -254,6 +248,23 @@ func (q *sqlQuerier) runTx(function func(Store) error, txOpts *sql.TxOptions) (e
 		return xerrors.Errorf("commit transaction: %w", err)
 	}
 	return nil
+}
+
+// normalizeIsolationLevel maps sql.LevelDefault to sql.LevelReadCommitted
+// for comparison purposes. The Go sql package defines LevelDefault as 0,
+// which sits below LevelReadUncommitted (1) in the iota ordering. When
+// LevelDefault is passed to the database driver, no explicit isolation
+// clause is sent, and the server applies its configured default. In
+// standard PostgreSQL this is "read committed". We normalize to
+// LevelReadCommitted so that the strictness comparison in runTx produces
+// correct results for the common case. If your PostgreSQL instance uses a
+// non-standard default_transaction_isolation (e.g. serializable), this
+// assumption may produce false negatives.
+func normalizeIsolationLevel(level sql.IsolationLevel) sql.IsolationLevel {
+	if level == sql.LevelDefault {
+		return sql.LevelReadCommitted
+	}
+	return level
 }
 
 func safeString(s *string) string {

--- a/coderd/database/db.go
+++ b/coderd/database/db.go
@@ -208,6 +208,14 @@ func (q *sqlQuerier) runTx(function func(Store) error, txOpts *sql.TxOptions) (e
 			// the parent, but it will be silently ignored because we
 			// reuse the parent transaction. Log this so callers can
 			// detect the mismatch.
+			//
+			// NOTE: this comparison relies on sql.IsolationLevel's iota
+			// ordering matching strictness for the standard SQL levels
+			// (ReadUncommitted < ReadCommitted < RepeatableRead <
+			// Serializable). Non-standard levels like WriteCommitted,
+			// Snapshot, and Linearizable also exist in the enum but are
+			// never used by this codebase. If that changes, this numeric
+			// comparison may need revisiting.
 			q.logger.Warn(context.Background(), "nested transaction requested stricter isolation level than the outer transaction provides",
 				slog.F("parent_isolation", q.txIsolationLevel.String()),
 				slog.F("requested_isolation", txOpts.Isolation.String()),

--- a/coderd/database/db.go
+++ b/coderd/database/db.go
@@ -203,15 +203,15 @@ func (q *sqlQuerier) runTx(function func(Store) error, txOpts *sql.TxOptions) (e
 		// If the current inner "db" is already a transaction, we just reuse it.
 		// We do not need to handle commit/rollback as the outer tx will handle
 		// that.
-		parentLevel := normalizeIsolationLevel(q.txIsolationLevel)
-		childLevel := normalizeIsolationLevel(txOpts.Isolation)
-		if childLevel > parentLevel {
+		existingLevel := normalizeIsolationLevel(q.txIsolationLevel)
+		requestedLevel := normalizeIsolationLevel(txOpts.Isolation)
+		if requestedLevel > existingLevel {
 			// The nested call requested a stricter isolation level
 			// than the parent, but it will be silently ignored
 			// because we reuse the parent transaction. Log this so
 			// callers can detect the mismatch.
-			q.logger.Warn(context.Background(), "nested transaction requested stricter isolation level than the outer transaction provides",
-				slog.F("parent_isolation", q.txIsolationLevel.String()),
+			q.logger.Warn(context.Background(), "nested transaction requested stricter isolation level than the existing transaction provides",
+				slog.F("existing_isolation", q.txIsolationLevel.String()),
 				slog.F("requested_isolation", txOpts.Isolation.String()),
 			)
 		}

--- a/coderd/database/db.go
+++ b/coderd/database/db.go
@@ -56,20 +56,15 @@ func WithSerialRetryCount(count int) func(*sqlQuerier) {
 	}
 }
 
-func WithLogger(logger slog.Logger) func(*sqlQuerier) {
-	return func(q *sqlQuerier) {
-		q.logger = logger
-	}
-}
-
 // New creates a new database store using a SQL database connection.
-func New(sdb *sql.DB, opts ...func(*sqlQuerier)) Store {
+func New(sdb *sql.DB, logger slog.Logger, opts ...func(*sqlQuerier)) Store {
 	dbx := sqlx.NewDb(sdb, "postgres")
 	q := &sqlQuerier{
 		db:  dbx,
 		sdb: dbx,
 		// This is an arbitrary number.
 		serialRetryCount: 3,
+		logger:           logger,
 	}
 
 	for _, opt := range opts {

--- a/coderd/database/db_test.go
+++ b/coderd/database/db_test.go
@@ -9,10 +9,13 @@ import (
 	"github.com/lib/pq"
 	"github.com/stretchr/testify/require"
 
+	slog "cdr.dev/slog/v3"
+
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/database/migrations"
+	"github.com/coder/coder/v2/testutil"
 )
 
 func TestSerializedRetry(t *testing.T) {
@@ -80,6 +83,100 @@ func TestNestedInTx(t *testing.T) {
 	user, err := db.GetUserByID(context.Background(), uid)
 	require.NoError(t, err, "user exists")
 	require.Equal(t, uid, user.ID, "user id expected")
+}
+
+func TestNestedInTxStricterIsolation(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	sink := testutil.NewFakeSink(t)
+	logger := slog.Make(sink).Leveled(slog.LevelDebug)
+
+	sqlDB := testSQLDB(t)
+	db := database.New(sqlDB, database.WithLogger(logger))
+
+	// Outer uses default isolation, inner requests RepeatableRead.
+	// The inner level is stricter, so a Critical log should fire.
+	err := db.InTx(func(outer database.Store) error {
+		return outer.InTx(func(_ database.Store) error {
+			return nil
+		}, &database.TxOptions{Isolation: sql.LevelRepeatableRead})
+	}, nil)
+	require.NoError(t, err)
+
+	entries := sink.Entries(func(e slog.SinkEntry) bool {
+		return e.Level == slog.LevelCritical
+	})
+	require.Len(t, entries, 1, "expected exactly one Critical log entry")
+	require.Contains(t, entries[0].Message, "nested transaction requested stricter isolation level")
+
+	var parentVal, requestedVal string
+	for _, f := range entries[0].Fields {
+		switch f.Name {
+		case "parent_isolation":
+			parentVal, _ = f.Value.(string)
+		case "requested_isolation":
+			requestedVal, _ = f.Value.(string)
+		}
+	}
+	require.Equal(t, sql.LevelDefault.String(), parentVal)
+	require.Equal(t, sql.LevelRepeatableRead.String(), requestedVal)
+}
+
+func TestNestedInTxSameIsolationNoLog(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	sink := testutil.NewFakeSink(t)
+	logger := slog.Make(sink).Leveled(slog.LevelDebug)
+
+	sqlDB := testSQLDB(t)
+	db := database.New(sqlDB, database.WithLogger(logger))
+
+	// Both use the same isolation level. No log should fire.
+	opts := &database.TxOptions{Isolation: sql.LevelRepeatableRead}
+	err := db.InTx(func(outer database.Store) error {
+		return outer.InTx(func(_ database.Store) error {
+			return nil
+		}, opts)
+	}, opts)
+	require.NoError(t, err)
+
+	entries := sink.Entries(func(e slog.SinkEntry) bool {
+		return e.Level == slog.LevelCritical
+	})
+	require.Empty(t, entries, "should not log when isolation levels match")
+}
+
+func TestNestedInTxWeakerIsolationNoLog(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	sink := testutil.NewFakeSink(t)
+	logger := slog.Make(sink).Leveled(slog.LevelDebug)
+
+	sqlDB := testSQLDB(t)
+	db := database.New(sqlDB, database.WithLogger(logger))
+
+	// Outer uses Serializable, inner requests RepeatableRead (weaker).
+	// No log should fire because the inner gets more isolation than needed.
+	err := db.InTx(func(outer database.Store) error {
+		return outer.InTx(func(_ database.Store) error {
+			return nil
+		}, &database.TxOptions{Isolation: sql.LevelRepeatableRead})
+	}, &database.TxOptions{Isolation: sql.LevelSerializable})
+	require.NoError(t, err)
+
+	entries := sink.Entries(func(e slog.SinkEntry) bool {
+		return e.Level == slog.LevelCritical
+	})
+	require.Empty(t, entries, "should not log when inner isolation is weaker than outer")
 }
 
 func testSQLDB(t testing.TB) *sql.DB {

--- a/coderd/database/db_test.go
+++ b/coderd/database/db_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	slog "cdr.dev/slog/v3"
-
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
@@ -107,9 +106,9 @@ func TestNestedInTxStricterIsolationDefaultParent(t *testing.T) {
 	require.NoError(t, err)
 
 	entries := sink.Entries(func(e slog.SinkEntry) bool {
-		return e.Level == slog.LevelCritical
+		return e.Level == slog.LevelWarn
 	})
-	require.Len(t, entries, 1, "expected exactly one Critical log entry")
+	require.Len(t, entries, 1, "expected exactly one Warn log entry")
 	require.Contains(t, entries[0].Message, "nested transaction requested stricter isolation level")
 
 	var parentVal, requestedVal string
@@ -138,7 +137,7 @@ func TestNestedInTxStricterIsolationBothExplicit(t *testing.T) {
 	db := database.New(sqlDB, database.WithLogger(logger))
 
 	// Outer uses RepeatableRead, inner requests Serializable.
-	// Both are explicit and the inner is stricter, so a Critical
+	// Both are explicit and the inner is stricter, so a Warn
 	// log should fire.
 	err := db.InTx(func(outer database.Store) error {
 		return outer.InTx(func(_ database.Store) error {
@@ -148,9 +147,9 @@ func TestNestedInTxStricterIsolationBothExplicit(t *testing.T) {
 	require.NoError(t, err)
 
 	entries := sink.Entries(func(e slog.SinkEntry) bool {
-		return e.Level == slog.LevelCritical
+		return e.Level == slog.LevelWarn
 	})
-	require.Len(t, entries, 1, "expected exactly one Critical log entry")
+	require.Len(t, entries, 1, "expected exactly one Warn log entry")
 	require.Contains(t, entries[0].Message, "nested transaction requested stricter isolation level")
 
 	var parentVal, requestedVal string
@@ -188,7 +187,7 @@ func TestNestedInTxSameIsolationNoLog(t *testing.T) {
 	require.NoError(t, err)
 
 	entries := sink.Entries(func(e slog.SinkEntry) bool {
-		return e.Level == slog.LevelCritical
+		return e.Level == slog.LevelWarn
 	})
 	require.Empty(t, entries, "should not log when isolation levels match")
 }
@@ -215,7 +214,7 @@ func TestNestedInTxWeakerIsolationNoLog(t *testing.T) {
 	require.NoError(t, err)
 
 	entries := sink.Entries(func(e slog.SinkEntry) bool {
-		return e.Level == slog.LevelCritical
+		return e.Level == slog.LevelWarn
 	})
 	require.Empty(t, entries, "should not log when inner isolation is weaker than outer")
 }

--- a/coderd/database/db_test.go
+++ b/coderd/database/db_test.go
@@ -97,7 +97,8 @@ func TestNestedInTxStricterIsolationDefaultParent(t *testing.T) {
 	db := database.New(sqlDB, database.WithLogger(logger))
 
 	// Outer uses default isolation, inner requests RepeatableRead.
-	// The inner level is stricter, so a Critical log should fire.
+	// After normalization default becomes ReadCommitted, so the
+	// inner level is stricter and a Warn log should fire.
 	err := db.InTx(func(outer database.Store) error {
 		return outer.InTx(func(_ database.Store) error {
 			return nil
@@ -217,6 +218,34 @@ func TestNestedInTxWeakerIsolationNoLog(t *testing.T) {
 		return e.Level == slog.LevelWarn
 	})
 	require.Empty(t, entries, "should not log when inner isolation is weaker than outer")
+}
+
+func TestNestedInTxDefaultVsReadCommittedNoLog(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	sink := testutil.NewFakeSink(t)
+	logger := slog.Make(sink).Leveled(slog.LevelDebug)
+
+	sqlDB := testSQLDB(t)
+	db := database.New(sqlDB, database.WithLogger(logger))
+
+	// Outer uses default (nil opts), inner requests ReadCommitted.
+	// After normalization both map to ReadCommitted, so no log
+	// should fire.
+	err := db.InTx(func(outer database.Store) error {
+		return outer.InTx(func(_ database.Store) error {
+			return nil
+		}, &database.TxOptions{Isolation: sql.LevelReadCommitted})
+	}, nil)
+	require.NoError(t, err)
+
+	entries := sink.Entries(func(e slog.SinkEntry) bool {
+		return e.Level == slog.LevelWarn
+	})
+	require.Empty(t, entries, "should not log when default and ReadCommitted are equivalent after normalization")
 }
 
 func testSQLDB(t testing.TB) *sql.DB {

--- a/coderd/database/db_test.go
+++ b/coderd/database/db_test.go
@@ -85,7 +85,7 @@ func TestNestedInTx(t *testing.T) {
 	require.Equal(t, uid, user.ID, "user id expected")
 }
 
-func TestNestedInTxStricterIsolation(t *testing.T) {
+func TestNestedInTxStricterIsolationDefaultParent(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {
 		t.SkipNow()
@@ -123,6 +123,47 @@ func TestNestedInTxStricterIsolation(t *testing.T) {
 	}
 	require.Equal(t, sql.LevelDefault.String(), parentVal)
 	require.Equal(t, sql.LevelRepeatableRead.String(), requestedVal)
+}
+
+func TestNestedInTxStricterIsolationBothExplicit(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	sink := testutil.NewFakeSink(t)
+	logger := slog.Make(sink).Leveled(slog.LevelDebug)
+
+	sqlDB := testSQLDB(t)
+	db := database.New(sqlDB, database.WithLogger(logger))
+
+	// Outer uses RepeatableRead, inner requests Serializable.
+	// Both are explicit and the inner is stricter, so a Critical
+	// log should fire.
+	err := db.InTx(func(outer database.Store) error {
+		return outer.InTx(func(_ database.Store) error {
+			return nil
+		}, &database.TxOptions{Isolation: sql.LevelSerializable})
+	}, &database.TxOptions{Isolation: sql.LevelRepeatableRead})
+	require.NoError(t, err)
+
+	entries := sink.Entries(func(e slog.SinkEntry) bool {
+		return e.Level == slog.LevelCritical
+	})
+	require.Len(t, entries, 1, "expected exactly one Critical log entry")
+	require.Contains(t, entries[0].Message, "nested transaction requested stricter isolation level")
+
+	var parentVal, requestedVal string
+	for _, f := range entries[0].Fields {
+		switch f.Name {
+		case "parent_isolation":
+			parentVal, _ = f.Value.(string)
+		case "requested_isolation":
+			requestedVal, _ = f.Value.(string)
+		}
+	}
+	require.Equal(t, sql.LevelRepeatableRead.String(), parentVal)
+	require.Equal(t, sql.LevelSerializable.String(), requestedVal)
 }
 
 func TestNestedInTxSameIsolationNoLog(t *testing.T) {

--- a/coderd/database/db_test.go
+++ b/coderd/database/db_test.go
@@ -114,7 +114,7 @@ func TestInTx_CapturesRollbackError(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestNestedInTxStricterIsolation(t *testing.T) {
+func TestNestedInTxStricterIsolationDefaultParent(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {
 		t.SkipNow()
@@ -152,6 +152,47 @@ func TestNestedInTxStricterIsolation(t *testing.T) {
 	}
 	require.Equal(t, sql.LevelDefault.String(), parentVal)
 	require.Equal(t, sql.LevelRepeatableRead.String(), requestedVal)
+}
+
+func TestNestedInTxStricterIsolationBothExplicit(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	sink := testutil.NewFakeSink(t)
+	logger := slog.Make(sink).Leveled(slog.LevelDebug)
+
+	sqlDB := testSQLDB(t)
+	db := database.New(sqlDB, database.WithLogger(logger))
+
+	// Outer uses RepeatableRead, inner requests Serializable.
+	// Both are explicit and the inner is stricter, so a Critical
+	// log should fire.
+	err := db.InTx(func(outer database.Store) error {
+		return outer.InTx(func(_ database.Store) error {
+			return nil
+		}, &database.TxOptions{Isolation: sql.LevelSerializable})
+	}, &database.TxOptions{Isolation: sql.LevelRepeatableRead})
+	require.NoError(t, err)
+
+	entries := sink.Entries(func(e slog.SinkEntry) bool {
+		return e.Level == slog.LevelCritical
+	})
+	require.Len(t, entries, 1, "expected exactly one Critical log entry")
+	require.Contains(t, entries[0].Message, "nested transaction requested stricter isolation level")
+
+	var parentVal, requestedVal string
+	for _, f := range entries[0].Fields {
+		switch f.Name {
+		case "parent_isolation":
+			parentVal, _ = f.Value.(string)
+		case "requested_isolation":
+			requestedVal, _ = f.Value.(string)
+		}
+	}
+	require.Equal(t, sql.LevelRepeatableRead.String(), parentVal)
+	require.Equal(t, sql.LevelSerializable.String(), requestedVal)
 }
 
 func TestNestedInTxSameIsolationNoLog(t *testing.T) {

--- a/coderd/database/db_test.go
+++ b/coderd/database/db_test.go
@@ -12,7 +12,6 @@ import (
 	"golang.org/x/xerrors"
 
 	slog "cdr.dev/slog/v3"
-
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
@@ -136,9 +135,9 @@ func TestNestedInTxStricterIsolationDefaultParent(t *testing.T) {
 	require.NoError(t, err)
 
 	entries := sink.Entries(func(e slog.SinkEntry) bool {
-		return e.Level == slog.LevelCritical
+		return e.Level == slog.LevelWarn
 	})
-	require.Len(t, entries, 1, "expected exactly one Critical log entry")
+	require.Len(t, entries, 1, "expected exactly one Warn log entry")
 	require.Contains(t, entries[0].Message, "nested transaction requested stricter isolation level")
 
 	var parentVal, requestedVal string
@@ -167,7 +166,7 @@ func TestNestedInTxStricterIsolationBothExplicit(t *testing.T) {
 	db := database.New(sqlDB, database.WithLogger(logger))
 
 	// Outer uses RepeatableRead, inner requests Serializable.
-	// Both are explicit and the inner is stricter, so a Critical
+	// Both are explicit and the inner is stricter, so a Warn
 	// log should fire.
 	err := db.InTx(func(outer database.Store) error {
 		return outer.InTx(func(_ database.Store) error {
@@ -177,9 +176,9 @@ func TestNestedInTxStricterIsolationBothExplicit(t *testing.T) {
 	require.NoError(t, err)
 
 	entries := sink.Entries(func(e slog.SinkEntry) bool {
-		return e.Level == slog.LevelCritical
+		return e.Level == slog.LevelWarn
 	})
-	require.Len(t, entries, 1, "expected exactly one Critical log entry")
+	require.Len(t, entries, 1, "expected exactly one Warn log entry")
 	require.Contains(t, entries[0].Message, "nested transaction requested stricter isolation level")
 
 	var parentVal, requestedVal string
@@ -217,7 +216,7 @@ func TestNestedInTxSameIsolationNoLog(t *testing.T) {
 	require.NoError(t, err)
 
 	entries := sink.Entries(func(e slog.SinkEntry) bool {
-		return e.Level == slog.LevelCritical
+		return e.Level == slog.LevelWarn
 	})
 	require.Empty(t, entries, "should not log when isolation levels match")
 }
@@ -244,7 +243,7 @@ func TestNestedInTxWeakerIsolationNoLog(t *testing.T) {
 	require.NoError(t, err)
 
 	entries := sink.Entries(func(e slog.SinkEntry) bool {
-		return e.Level == slog.LevelCritical
+		return e.Level == slog.LevelWarn
 	})
 	require.Empty(t, entries, "should not log when inner isolation is weaker than outer")
 }

--- a/coderd/database/db_test.go
+++ b/coderd/database/db_test.go
@@ -26,7 +26,7 @@ func TestSerializedRetry(t *testing.T) {
 	}
 
 	sqlDB := testSQLDB(t)
-	db := database.New(sqlDB)
+	db := database.New(sqlDB, slog.Logger{})
 
 	called := 0
 	txOpts := &database.TxOptions{Isolation: sql.LevelSerializable}
@@ -60,7 +60,7 @@ func TestNestedInTx(t *testing.T) {
 	err := migrations.Up(sqlDB)
 	require.NoError(t, err, "migrations")
 
-	db := database.New(sqlDB)
+	db := database.New(sqlDB, slog.Logger{})
 	err = db.InTx(func(outer database.Store) error {
 		return outer.InTx(func(inner database.Store) error {
 			//nolint:gocritic
@@ -93,7 +93,7 @@ func TestInTx_CapturesRollbackError(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = sqlDB.Close() })
 
-	db := database.New(sqlDB)
+	db := database.New(sqlDB, slog.Logger{})
 
 	callbackErr := xerrors.New("callback failed")
 	rollbackErr := xerrors.New("rollback failed")
@@ -123,7 +123,7 @@ func TestNestedInTxStricterIsolationDefaultParent(t *testing.T) {
 	logger := slog.Make(sink).Leveled(slog.LevelDebug)
 
 	sqlDB := testSQLDB(t)
-	db := database.New(sqlDB, database.WithLogger(logger))
+	db := database.New(sqlDB, logger)
 
 	// Outer uses default isolation, inner requests RepeatableRead.
 	// After normalization default becomes ReadCommitted, so the
@@ -164,7 +164,7 @@ func TestNestedInTxStricterIsolationBothExplicit(t *testing.T) {
 	logger := slog.Make(sink).Leveled(slog.LevelDebug)
 
 	sqlDB := testSQLDB(t)
-	db := database.New(sqlDB, database.WithLogger(logger))
+	db := database.New(sqlDB, logger)
 
 	// Outer uses RepeatableRead, inner requests Serializable.
 	// Both are explicit and the inner is stricter, so a Warn
@@ -205,7 +205,7 @@ func TestNestedInTxSameIsolationNoLog(t *testing.T) {
 	logger := slog.Make(sink).Leveled(slog.LevelDebug)
 
 	sqlDB := testSQLDB(t)
-	db := database.New(sqlDB, database.WithLogger(logger))
+	db := database.New(sqlDB, logger)
 
 	// Both use the same isolation level. No log should fire.
 	opts := &database.TxOptions{Isolation: sql.LevelRepeatableRead}
@@ -232,7 +232,7 @@ func TestNestedInTxWeakerIsolationNoLog(t *testing.T) {
 	logger := slog.Make(sink).Leveled(slog.LevelDebug)
 
 	sqlDB := testSQLDB(t)
-	db := database.New(sqlDB, database.WithLogger(logger))
+	db := database.New(sqlDB, logger)
 
 	// Outer uses Serializable, inner requests RepeatableRead (weaker).
 	// No log should fire because the inner gets more isolation than needed.
@@ -259,7 +259,7 @@ func TestNestedInTxDefaultVsReadCommittedNoLog(t *testing.T) {
 	logger := slog.Make(sink).Leveled(slog.LevelDebug)
 
 	sqlDB := testSQLDB(t)
-	db := database.New(sqlDB, database.WithLogger(logger))
+	db := database.New(sqlDB, logger)
 
 	// Outer uses default (nil opts), inner requests ReadCommitted.
 	// After normalization both map to ReadCommitted, so no log

--- a/coderd/database/db_test.go
+++ b/coderd/database/db_test.go
@@ -126,7 +126,8 @@ func TestNestedInTxStricterIsolationDefaultParent(t *testing.T) {
 	db := database.New(sqlDB, database.WithLogger(logger))
 
 	// Outer uses default isolation, inner requests RepeatableRead.
-	// The inner level is stricter, so a Critical log should fire.
+	// After normalization default becomes ReadCommitted, so the
+	// inner level is stricter and a Warn log should fire.
 	err := db.InTx(func(outer database.Store) error {
 		return outer.InTx(func(_ database.Store) error {
 			return nil
@@ -246,6 +247,34 @@ func TestNestedInTxWeakerIsolationNoLog(t *testing.T) {
 		return e.Level == slog.LevelWarn
 	})
 	require.Empty(t, entries, "should not log when inner isolation is weaker than outer")
+}
+
+func TestNestedInTxDefaultVsReadCommittedNoLog(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	sink := testutil.NewFakeSink(t)
+	logger := slog.Make(sink).Leveled(slog.LevelDebug)
+
+	sqlDB := testSQLDB(t)
+	db := database.New(sqlDB, database.WithLogger(logger))
+
+	// Outer uses default (nil opts), inner requests ReadCommitted.
+	// After normalization both map to ReadCommitted, so no log
+	// should fire.
+	err := db.InTx(func(outer database.Store) error {
+		return outer.InTx(func(_ database.Store) error {
+			return nil
+		}, &database.TxOptions{Isolation: sql.LevelReadCommitted})
+	}, nil)
+	require.NoError(t, err)
+
+	entries := sink.Entries(func(e slog.SinkEntry) bool {
+		return e.Level == slog.LevelWarn
+	})
+	require.Empty(t, entries, "should not log when default and ReadCommitted are equivalent after normalization")
 }
 
 func testSQLDB(t testing.TB) *sql.DB {

--- a/coderd/database/db_test.go
+++ b/coderd/database/db_test.go
@@ -11,10 +11,13 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
 
+	slog "cdr.dev/slog/v3"
+
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/database/migrations"
+	"github.com/coder/coder/v2/testutil"
 )
 
 func TestSerializedRetry(t *testing.T) {
@@ -109,6 +112,100 @@ func TestInTx_CapturesRollbackError(t *testing.T) {
 		"rollback failure should be reported in the message, not wrapped in the error chain")
 
 	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestNestedInTxStricterIsolation(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	sink := testutil.NewFakeSink(t)
+	logger := slog.Make(sink).Leveled(slog.LevelDebug)
+
+	sqlDB := testSQLDB(t)
+	db := database.New(sqlDB, database.WithLogger(logger))
+
+	// Outer uses default isolation, inner requests RepeatableRead.
+	// The inner level is stricter, so a Critical log should fire.
+	err := db.InTx(func(outer database.Store) error {
+		return outer.InTx(func(_ database.Store) error {
+			return nil
+		}, &database.TxOptions{Isolation: sql.LevelRepeatableRead})
+	}, nil)
+	require.NoError(t, err)
+
+	entries := sink.Entries(func(e slog.SinkEntry) bool {
+		return e.Level == slog.LevelCritical
+	})
+	require.Len(t, entries, 1, "expected exactly one Critical log entry")
+	require.Contains(t, entries[0].Message, "nested transaction requested stricter isolation level")
+
+	var parentVal, requestedVal string
+	for _, f := range entries[0].Fields {
+		switch f.Name {
+		case "parent_isolation":
+			parentVal, _ = f.Value.(string)
+		case "requested_isolation":
+			requestedVal, _ = f.Value.(string)
+		}
+	}
+	require.Equal(t, sql.LevelDefault.String(), parentVal)
+	require.Equal(t, sql.LevelRepeatableRead.String(), requestedVal)
+}
+
+func TestNestedInTxSameIsolationNoLog(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	sink := testutil.NewFakeSink(t)
+	logger := slog.Make(sink).Leveled(slog.LevelDebug)
+
+	sqlDB := testSQLDB(t)
+	db := database.New(sqlDB, database.WithLogger(logger))
+
+	// Both use the same isolation level. No log should fire.
+	opts := &database.TxOptions{Isolation: sql.LevelRepeatableRead}
+	err := db.InTx(func(outer database.Store) error {
+		return outer.InTx(func(_ database.Store) error {
+			return nil
+		}, opts)
+	}, opts)
+	require.NoError(t, err)
+
+	entries := sink.Entries(func(e slog.SinkEntry) bool {
+		return e.Level == slog.LevelCritical
+	})
+	require.Empty(t, entries, "should not log when isolation levels match")
+}
+
+func TestNestedInTxWeakerIsolationNoLog(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	sink := testutil.NewFakeSink(t)
+	logger := slog.Make(sink).Leveled(slog.LevelDebug)
+
+	sqlDB := testSQLDB(t)
+	db := database.New(sqlDB, database.WithLogger(logger))
+
+	// Outer uses Serializable, inner requests RepeatableRead (weaker).
+	// No log should fire because the inner gets more isolation than needed.
+	err := db.InTx(func(outer database.Store) error {
+		return outer.InTx(func(_ database.Store) error {
+			return nil
+		}, &database.TxOptions{Isolation: sql.LevelRepeatableRead})
+	}, &database.TxOptions{Isolation: sql.LevelSerializable})
+	require.NoError(t, err)
+
+	entries := sink.Entries(func(e slog.SinkEntry) bool {
+		return e.Level == slog.LevelCritical
+	})
+	require.Empty(t, entries, "should not log when inner isolation is weaker than outer")
 }
 
 func testSQLDB(t testing.TB) *sql.DB {

--- a/coderd/database/db_test.go
+++ b/coderd/database/db_test.go
@@ -144,7 +144,7 @@ func TestNestedInTxStricterIsolationDefaultParent(t *testing.T) {
 	var parentVal, requestedVal string
 	for _, f := range entries[0].Fields {
 		switch f.Name {
-		case "parent_isolation":
+		case "existing_isolation":
 			parentVal, _ = f.Value.(string)
 		case "requested_isolation":
 			requestedVal, _ = f.Value.(string)
@@ -185,7 +185,7 @@ func TestNestedInTxStricterIsolationBothExplicit(t *testing.T) {
 	var parentVal, requestedVal string
 	for _, f := range entries[0].Fields {
 		switch f.Name {
-		case "parent_isolation":
+		case "existing_isolation":
 			parentVal, _ = f.Value.(string)
 		case "requested_isolation":
 			requestedVal, _ = f.Value.(string)

--- a/coderd/database/dbtestutil/db.go
+++ b/coderd/database/dbtestutil/db.go
@@ -133,7 +133,7 @@ func NewDB(t testing.TB, opts ...Option) (database.Store, pubsub.Pubsub) {
 		t.Cleanup(func() { DumpOnFailure(t, connectionURL) })
 	}
 	// Unit tests should not retry serial transaction failures.
-	db = database.New(sqlDB, database.WithSerialRetryCount(1))
+	db = database.New(sqlDB, database.WithSerialRetryCount(1), database.WithLogger(o.logger.Named("database")))
 
 	ps, err = pubsub.New(context.Background(), o.logger, sqlDB, connectionURL)
 	require.NoError(t, err)

--- a/coderd/database/dbtestutil/db.go
+++ b/coderd/database/dbtestutil/db.go
@@ -133,7 +133,7 @@ func NewDB(t testing.TB, opts ...Option) (database.Store, pubsub.Pubsub) {
 		t.Cleanup(func() { DumpOnFailure(t, connectionURL) })
 	}
 	// Unit tests should not retry serial transaction failures.
-	db = database.New(sqlDB, database.WithSerialRetryCount(1), database.WithLogger(o.logger.Named("database")))
+	db = database.New(sqlDB, o.logger.Named("database"), database.WithSerialRetryCount(1))
 
 	ps, err = pubsub.New(context.Background(), o.logger, sqlDB, connectionURL)
 	require.NoError(t, err)

--- a/coderd/database/migrations/migrate_test.go
+++ b/coderd/database/migrations/migrate_test.go
@@ -372,7 +372,7 @@ func TestMigration000362AggregateUsageEvents(t *testing.T) {
 	const migrationVersion = 362
 
 	sqlDB := testSQLDB(t)
-	db := database.New(sqlDB)
+	db := database.New(sqlDB, testutil.Logger(t))
 
 	// Migrate up to the migration before the one that aggregates usage events.
 	next, err := migrations.Stepper(sqlDB)

--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -50,7 +50,7 @@ func TestGetDeploymentWorkspaceAgentStats(t *testing.T) {
 		sqlDB := testSQLDB(t)
 		err := migrations.Up(sqlDB)
 		require.NoError(t, err)
-		db := database.New(sqlDB)
+		db := database.New(sqlDB, slogtest.Make(t, nil))
 		ctx := context.Background()
 		dbgen.WorkspaceAgentStat(t, db, database.WorkspaceAgentStat{
 			TxBytes:                   1,
@@ -80,7 +80,7 @@ func TestGetDeploymentWorkspaceAgentStats(t *testing.T) {
 		sqlDB := testSQLDB(t)
 		err := migrations.Up(sqlDB)
 		require.NoError(t, err)
-		db := database.New(sqlDB)
+		db := database.New(sqlDB, slogtest.Make(t, nil))
 		ctx := context.Background()
 		agentID := uuid.New()
 		insertTime := dbtime.Now()
@@ -1119,7 +1119,7 @@ func TestGetAuthorizedWorkspacesAndAgentsByOwnerID(t *testing.T) {
 	sqlDB := testSQLDB(t)
 	err := migrations.Up(sqlDB)
 	require.NoError(t, err)
-	db := database.New(sqlDB)
+	db := database.New(sqlDB, slogtest.Make(t, nil))
 	authorizer := rbac.NewStrictCachingAuthorizer(prometheus.NewRegistry())
 
 	org := dbgen.Organization(t, db, database.Organization{})
@@ -1244,7 +1244,7 @@ func TestGetAuthorizedChats(t *testing.T) {
 	sqlDB := testSQLDB(t)
 	err := migrations.Up(sqlDB)
 	require.NoError(t, err)
-	db := database.New(sqlDB)
+	db := database.New(sqlDB, slogtest.Make(t, nil))
 	authorizer := rbac.NewStrictCachingAuthorizer(prometheus.NewRegistry())
 
 	// Create users with different roles.
@@ -1479,7 +1479,7 @@ func TestInsertWorkspaceAgentLogs(t *testing.T) {
 	ctx := context.Background()
 	err := migrations.Up(sqlDB)
 	require.NoError(t, err)
-	db := database.New(sqlDB)
+	db := database.New(sqlDB, slogtest.Make(t, nil))
 	org := dbgen.Organization(t, db, database.Organization{})
 	job := dbgen.ProvisionerJob(t, db, nil, database.ProvisionerJob{
 		OrganizationID: org.ID,
@@ -1524,7 +1524,7 @@ func TestProxyByHostname(t *testing.T) {
 	sqlDB := testSQLDB(t)
 	err := migrations.Up(sqlDB)
 	require.NoError(t, err)
-	db := database.New(sqlDB)
+	db := database.New(sqlDB, slogtest.Make(t, nil))
 
 	// Insert a bunch of different proxies.
 	proxies := []struct {
@@ -1652,7 +1652,7 @@ func TestDefaultProxy(t *testing.T) {
 	sqlDB := testSQLDB(t)
 	err := migrations.Up(sqlDB)
 	require.NoError(t, err)
-	db := database.New(sqlDB)
+	db := database.New(sqlDB, slogtest.Make(t, nil))
 
 	ctx := testutil.Context(t, testutil.WaitLong)
 	depID := uuid.NewString()
@@ -1707,7 +1707,7 @@ func TestQueuePosition(t *testing.T) {
 	sqlDB := testSQLDB(t)
 	err := migrations.Up(sqlDB)
 	require.NoError(t, err)
-	db := database.New(sqlDB)
+	db := database.New(sqlDB, slogtest.Make(t, nil))
 	ctx := testutil.Context(t, testutil.WaitLong)
 
 	org := dbgen.Organization(t, db, database.Organization{})
@@ -1939,7 +1939,7 @@ func TestUserLastSeenFilter(t *testing.T) {
 		sqlDB := testSQLDB(t)
 		err := migrations.Up(sqlDB)
 		require.NoError(t, err)
-		db := database.New(sqlDB)
+		db := database.New(sqlDB, slogtest.Make(t, nil))
 		ctx := context.Background()
 		now := dbtime.Now()
 
@@ -2177,7 +2177,7 @@ func TestUserChangeLoginType(t *testing.T) {
 	sqlDB := testSQLDB(t)
 	err := migrations.Up(sqlDB)
 	require.NoError(t, err)
-	db := database.New(sqlDB)
+	db := database.New(sqlDB, slogtest.Make(t, nil))
 	ctx := context.Background()
 
 	alice := dbgen.User(t, db, database.User{
@@ -2224,7 +2224,7 @@ func TestDefaultOrg(t *testing.T) {
 	sqlDB := testSQLDB(t)
 	err := migrations.Up(sqlDB)
 	require.NoError(t, err)
-	db := database.New(sqlDB)
+	db := database.New(sqlDB, slogtest.Make(t, nil))
 	ctx := context.Background()
 
 	// Should start with the default org
@@ -2243,7 +2243,7 @@ func TestAuditLogDefaultLimit(t *testing.T) {
 	sqlDB := testSQLDB(t)
 	err := migrations.Up(sqlDB)
 	require.NoError(t, err)
-	db := database.New(sqlDB)
+	db := database.New(sqlDB, slogtest.Make(t, nil))
 
 	for i := 0; i < 110; i++ {
 		dbgen.AuditLog(t, db, database.AuditLog{})
@@ -2266,7 +2266,7 @@ func TestAuditLogCount(t *testing.T) {
 	sqlDB := testSQLDB(t)
 	err := migrations.Up(sqlDB)
 	require.NoError(t, err)
-	db := database.New(sqlDB)
+	db := database.New(sqlDB, slogtest.Make(t, nil))
 
 	ctx := testutil.Context(t, testutil.WaitLong)
 
@@ -2376,7 +2376,7 @@ func TestReadCustomRoles(t *testing.T) {
 	err := migrations.Up(sqlDB)
 	require.NoError(t, err)
 
-	db := database.New(sqlDB)
+	db := database.New(sqlDB, slogtest.Make(t, nil))
 	ctx := testutil.Context(t, testutil.WaitLong)
 
 	// Make a few site roles, and a few org roles
@@ -4266,7 +4266,7 @@ func TestArchiveVersions(t *testing.T) {
 		sqlDB := testSQLDB(t)
 		err := migrations.Up(sqlDB)
 		require.NoError(t, err)
-		db := database.New(sqlDB)
+		db := database.New(sqlDB, slogtest.Make(t, nil))
 		ctx := context.Background()
 
 		org := dbgen.Organization(t, db, database.Organization{})
@@ -4333,7 +4333,7 @@ func TestExpectOne(t *testing.T) {
 		sqlDB := testSQLDB(t)
 		err := migrations.Up(sqlDB)
 		require.NoError(t, err)
-		db := database.New(sqlDB)
+		db := database.New(sqlDB, slogtest.Make(t, nil))
 		ctx := context.Background()
 
 		_, err = database.ExpectOne(db.GetUsers(ctx, database.GetUsersParams{}))
@@ -4345,7 +4345,7 @@ func TestExpectOne(t *testing.T) {
 		sqlDB := testSQLDB(t)
 		err := migrations.Up(sqlDB)
 		require.NoError(t, err)
-		db := database.New(sqlDB)
+		db := database.New(sqlDB, slogtest.Make(t, nil))
 		ctx := context.Background()
 
 		// Create 2 organizations so the query returns >1
@@ -6059,7 +6059,7 @@ func TestWorkspacePrebuildsView(t *testing.T) {
 			sqlDB := testSQLDB(t)
 			err := migrations.Up(sqlDB)
 			require.NoError(t, err)
-			db := database.New(sqlDB)
+			db := database.New(sqlDB, slogtest.Make(t, nil))
 
 			ctx := testutil.Context(t, testutil.WaitShort)
 
@@ -9313,7 +9313,7 @@ func TestGetAuthenticatedWorkspaceAgentAndBuildByAuthToken_ShutdownScripts(t *te
 	sqlDB := testSQLDB(t)
 	err := migrations.Up(sqlDB)
 	require.NoError(t, err)
-	db := database.New(sqlDB)
+	db := database.New(sqlDB, slogtest.Make(t, nil))
 
 	org := dbgen.Organization(t, db, database.Organization{})
 	owner := dbgen.User(t, db, database.User{})
@@ -10350,7 +10350,7 @@ func TestUpsertAISeats(t *testing.T) {
 	sqlDB := testSQLDB(t)
 	err := migrations.Up(sqlDB)
 	require.NoError(t, err)
-	db := database.New(sqlDB)
+	db := database.New(sqlDB, slogtest.Make(t, nil))
 	ctx := testutil.Context(t, testutil.WaitShort)
 
 	now := dbtime.Now()
@@ -11229,7 +11229,7 @@ func TestChatLabels(t *testing.T) {
 	sqlDB := testSQLDB(t)
 	err := migrations.Up(sqlDB)
 	require.NoError(t, err)
-	db := database.New(sqlDB)
+	db := database.New(sqlDB, slogtest.Make(t, nil))
 
 	ctx := testutil.Context(t, testutil.WaitMedium)
 	owner := dbgen.User(t, db, database.User{})

--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -396,6 +396,13 @@ func (api *API) postWorkspaceBuildsInternal(
 		provisionerDaemons     []database.GetEligibleProvisionerDaemonsByProvisionerJobIDsRow
 	)
 
+	// TODO: This transaction uses the default isolation level, but
+	// builder.Build() calls ReadModifyUpdate internally which needs
+	// RepeatableRead to detect concurrent modifications and retry.
+	// Because InTx reuses the parent transaction, the RepeatableRead
+	// request is silently ignored and its retry loop is ineffective.
+	// This should be elevated to sql.LevelRepeatableRead to match
+	// what the lifecycle executor already does.
 	err := api.Database.InTx(func(tx database.Store) error {
 		var err error
 

--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -401,8 +401,16 @@ func (api *API) postWorkspaceBuildsInternal(
 	// RepeatableRead to detect concurrent modifications and retry.
 	// Because InTx reuses the parent transaction, the RepeatableRead
 	// request is silently ignored and its retry loop is ineffective.
+	//
+	// ReadModifyUpdate was added in #10277 (Oct 2023) when Build()
+	// was called directly on api.Database with no outer transaction.
+	// This outer InTx was introduced later in #15979 (Jan 2025) for
+	// workspace update notifications, unintentionally nesting the
+	// repeatable-read transaction inside a default-isolation parent.
+	//
 	// This should be elevated to sql.LevelRepeatableRead to match
-	// what the lifecycle executor already does.
+	// what the lifecycle executor already does, with the retry loop
+	// moved to wrap the outer transaction.
 	err := api.Database.InTx(func(tx database.Store) error {
 		var err error
 

--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -402,8 +402,16 @@ func (api *API) postWorkspaceBuildsInternal(
 	// RepeatableRead to detect concurrent modifications and retry.
 	// Because InTx reuses the parent transaction, the RepeatableRead
 	// request is silently ignored and its retry loop is ineffective.
+	//
+	// ReadModifyUpdate was added in #10277 (Oct 2023) when Build()
+	// was called directly on api.Database with no outer transaction.
+	// This outer InTx was introduced later in #15979 (Jan 2025) for
+	// workspace update notifications, unintentionally nesting the
+	// repeatable-read transaction inside a default-isolation parent.
+	//
 	// This should be elevated to sql.LevelRepeatableRead to match
-	// what the lifecycle executor already does.
+	// what the lifecycle executor already does, with the retry loop
+	// moved to wrap the outer transaction.
 	err := api.Database.InTx(func(tx database.Store) error {
 		var err error
 

--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -397,6 +397,13 @@ func (api *API) postWorkspaceBuildsInternal(
 		provisionerDaemons     []database.GetEligibleProvisionerDaemonsByProvisionerJobIDsRow
 	)
 
+	// TODO: This transaction uses the default isolation level, but
+	// builder.Build() calls ReadModifyUpdate internally which needs
+	// RepeatableRead to detect concurrent modifications and retry.
+	// Because InTx reuses the parent transaction, the RepeatableRead
+	// request is silently ignored and its retry loop is ineffective.
+	// This should be elevated to sql.LevelRepeatableRead to match
+	// what the lifecycle executor already does.
 	err := api.Database.InTx(func(tx database.Store) error {
 		var err error
 

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -668,6 +668,13 @@ func createWorkspace(
 		provisionerDaemons []database.GetEligibleProvisionerDaemonsByProvisionerJobIDsRow
 	)
 
+	// TODO: This transaction uses the default isolation level, but
+	// builder.Build() calls ReadModifyUpdate internally which needs
+	// RepeatableRead to detect concurrent modifications and retry.
+	// Because InTx reuses the parent transaction, the RepeatableRead
+	// request is silently ignored and its retry loop is ineffective.
+	// This should be elevated to sql.LevelRepeatableRead to match
+	// what the lifecycle executor already does.
 	err = api.Database.InTx(func(db database.Store) error {
 		var (
 			prebuildsClaimer = *api.PrebuildsClaimer.Load()

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -673,8 +673,16 @@ func createWorkspace(
 	// RepeatableRead to detect concurrent modifications and retry.
 	// Because InTx reuses the parent transaction, the RepeatableRead
 	// request is silently ignored and its retry loop is ineffective.
+	//
+	// This outer InTx dates back to #1486 (May 2022) and predates
+	// ReadModifyUpdate, which was added in #10277 (Oct 2023). The
+	// repeatable-read transaction and retry loop inside Build() have
+	// never worked correctly in this code path — they were always
+	// nested inside this default-isolation parent.
+	//
 	// This should be elevated to sql.LevelRepeatableRead to match
-	// what the lifecycle executor already does.
+	// what the lifecycle executor already does, with the retry loop
+	// moved to wrap the outer transaction.
 	err = api.Database.InTx(func(db database.Store) error {
 		var (
 			prebuildsClaimer = *api.PrebuildsClaimer.Load()

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -673,8 +673,16 @@ func createWorkspace(
 	// RepeatableRead to detect concurrent modifications and retry.
 	// Because InTx reuses the parent transaction, the RepeatableRead
 	// request is silently ignored and its retry loop is ineffective.
+	//
+	// This outer InTx dates back to #1486 (May 2022) and predates
+	// ReadModifyUpdate, which was added in #10277 (Oct 2023). The
+	// repeatable-read transaction and retry loop inside Build() have
+	// never worked correctly in this code path; they were always
+	// nested inside this default-isolation parent.
+	//
 	// This should be elevated to sql.LevelRepeatableRead to match
-	// what the lifecycle executor already does.
+	// what the lifecycle executor already does, with the retry loop
+	// moved to wrap the outer transaction.
 	err = api.Database.InTx(func(db database.Store) error {
 		var (
 			prebuildsClaimer = *api.PrebuildsClaimer.Load()

--- a/enterprise/cli/server_dbcrypt_test.go
+++ b/enterprise/cli/server_dbcrypt_test.go
@@ -37,7 +37,7 @@ func TestServerDBCrypt(t *testing.T) {
 	t.Cleanup(func() {
 		_ = sqlDB.Close()
 	})
-	db := database.New(sqlDB)
+	db := database.New(sqlDB, testutil.Logger(t))
 
 	// Populate the database with some unencrypted data.
 	t.Log("Generating unencrypted data")

--- a/enterprise/dbcrypt/cliutil.go
+++ b/enterprise/dbcrypt/cliutil.go
@@ -14,7 +14,7 @@ import (
 // Rotate rotates the database encryption keys by re-encrypting all user tokens
 // with the first cipher and revoking all other ciphers.
 func Rotate(ctx context.Context, log slog.Logger, sqlDB *sql.DB, ciphers []Cipher) error {
-	db := database.New(sqlDB)
+	db := database.New(sqlDB, database.WithLogger(log.Named("database")))
 	cryptDB, err := New(ctx, db, ciphers...)
 	if err != nil {
 		return xerrors.Errorf("create cryptdb: %w", err)
@@ -176,7 +176,7 @@ func Rotate(ctx context.Context, log slog.Logger, sqlDB *sql.DB, ciphers []Ciphe
 
 // Decrypt decrypts all user tokens and revokes all ciphers.
 func Decrypt(ctx context.Context, log slog.Logger, sqlDB *sql.DB, ciphers []Cipher) error {
-	db := database.New(sqlDB)
+	db := database.New(sqlDB, database.WithLogger(log.Named("database")))
 	cdb, err := New(ctx, db, ciphers...)
 	if err != nil {
 		return xerrors.Errorf("create cryptdb: %w", err)
@@ -362,7 +362,7 @@ COMMIT;
 // as a last resort, for example, if the database encryption key has been
 // lost.
 func Delete(ctx context.Context, log slog.Logger, sqlDB *sql.DB) error {
-	store := database.New(sqlDB)
+	store := database.New(sqlDB, database.WithLogger(log.Named("database")))
 	_, err := sqlDB.ExecContext(ctx, sqlDeleteEncryptedUserTokens)
 	if err != nil {
 		return xerrors.Errorf("delete encrypted tokens and chat provider keys: %w", err)

--- a/enterprise/dbcrypt/cliutil.go
+++ b/enterprise/dbcrypt/cliutil.go
@@ -14,7 +14,7 @@ import (
 // Rotate rotates the database encryption keys by re-encrypting all user tokens
 // with the first cipher and revoking all other ciphers.
 func Rotate(ctx context.Context, log slog.Logger, sqlDB *sql.DB, ciphers []Cipher) error {
-	db := database.New(sqlDB, database.WithLogger(log.Named("database")))
+	db := database.New(sqlDB, log.Named("database"))
 	cryptDB, err := New(ctx, db, ciphers...)
 	if err != nil {
 		return xerrors.Errorf("create cryptdb: %w", err)
@@ -176,7 +176,7 @@ func Rotate(ctx context.Context, log slog.Logger, sqlDB *sql.DB, ciphers []Ciphe
 
 // Decrypt decrypts all user tokens and revokes all ciphers.
 func Decrypt(ctx context.Context, log slog.Logger, sqlDB *sql.DB, ciphers []Cipher) error {
-	db := database.New(sqlDB, database.WithLogger(log.Named("database")))
+	db := database.New(sqlDB, log.Named("database"))
 	cdb, err := New(ctx, db, ciphers...)
 	if err != nil {
 		return xerrors.Errorf("create cryptdb: %w", err)
@@ -362,7 +362,7 @@ COMMIT;
 // as a last resort, for example, if the database encryption key has been
 // lost.
 func Delete(ctx context.Context, log slog.Logger, sqlDB *sql.DB) error {
-	store := database.New(sqlDB, database.WithLogger(log.Named("database")))
+	store := database.New(sqlDB, log.Named("database"))
 	_, err := sqlDB.ExecContext(ctx, sqlDeleteEncryptedUserTokens)
 	if err != nil {
 		return xerrors.Errorf("delete encrypted tokens and chat provider keys: %w", err)


### PR DESCRIPTION
When `InTx` is called inside an existing transaction with a stricter
isolation level, the requested level is silently ignored because the
inner call reuses the outer transaction. This adds a Warn-level log
when a nested call requests a stricter isolation level than the parent,
reporting both levels.

### PR stack

This is the first of three PRs addressing #21939:

1. **This PR** — Detection and observability.
2. #24317 — Fixes the two broken nesting sites and elevates to Critical.
3. #24319 — Replaces the log with a hard error.

Refs https://github.com/coder/coder/issues/21939

Parts 1 and 2 can ship in the same release. Part 3 should go out in
the following release to allow time to catch any nesting mismatches
that were previously undetected.

## Changes

- Add `logger` and `txIsolationLevel` fields to `sqlQuerier`.
- Add `WithLogger` functional option for `database.New`.
- Log at Warn in `runTx` when a nested call requests a stricter
  isolation level than the outer transaction provides.
- Normalize `sql.LevelDefault` to `sql.LevelReadCommitted` before
  comparing, since the Go driver sends no isolation clause for
  `LevelDefault` and PostgreSQL defaults to read committed.
- Propagate `logger` and `txIsolationLevel` to inner querier so
  deeper nesting also logs correctly.
- Wire `WithLogger` into all `database.New` call sites.

The log level is Warn rather than Critical because `slogtest` treats
Critical logs as test failures. Two existing code paths in
`postWorkspaceBuilds` and `createWorkspace` nest a `RepeatableRead`
transaction inside a default-isolation parent, so using Critical here
would break unrelated tests. These nesting issues are fixed in #24317.

## Implementation notes

Detection normalizes `sql.LevelDefault` to `sql.LevelReadCommitted`
(the standard PostgreSQL default) and then compares using numeric
ordering — higher values are stricter. The log fires only when
`normalized(requested) > normalized(parent)`, so same-level or
weaker-than-parent nesting is silent. If your PostgreSQL instance
uses a non-standard `default_transaction_isolation`, this
normalization may produce false negatives.

`WithLogger` defaults to zero-value `slog.Logger{}` (no-op), so
existing `database.New` call sites are unaffected until `WithLogger`
is passed.
