### PR TITLE
fix: use per-chat plan file paths

### DIFF
--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -5946,34 +5946,11 @@ func (p *Server) resolveUserPrompt(ctx context.Context, userID uuid.UUID) string
 	return "<user-instructions>\n" + trimmed + "\n</user-instructions>"
 }
 
-// renderPlanPathPrompt fills the plan-path placeholder for new chats and
-// appends the block to the main system prompt for persisted chats that
-// predate the placeholder.
+// renderPlanPathPrompt fills the plan-path placeholder when it is
+// present in the prompt.
 func renderPlanPathPrompt(prompt []fantasy.Message, planPathBlock string) []fantasy.Message {
-	prompt, hadPlaceholder := replacePlanPathPlaceholder(prompt, planPathBlock)
-	if hadPlaceholder || planPathBlock == "" {
-		return prompt
-	}
-
-	for i, message := range prompt {
-		if message.Role != fantasy.MessageRoleSystem {
-			continue
-		}
-		updatedMessage, ok := appendPlanPathBlock(message, planPathBlock)
-		if !ok {
-			continue
-		}
-		updatedPrompt := slices.Clone(prompt)
-		updatedPrompt[i] = updatedMessage
-		return updatedPrompt
-	}
-
-	return append([]fantasy.Message{{
-		Role: fantasy.MessageRoleSystem,
-		Content: []fantasy.MessagePart{
-			fantasy.TextPart{Text: planPathBlock},
-		},
-	}}, prompt...)
+	prompt, _ = replacePlanPathPlaceholder(prompt, planPathBlock)
+	return prompt
 }
 
 func replacePlanPathPlaceholder(
@@ -6028,34 +6005,9 @@ func replacePlanPathPlaceholderInMessage(
 	return message, true
 }
 
-func appendPlanPathBlock(
-	message fantasy.Message,
-	planPathBlock string,
-) (fantasy.Message, bool) {
-	if message.Role != fantasy.MessageRoleSystem {
-		return message, false
-	}
-
-	content := slices.Clone(message.Content)
-	for i, part := range content {
-		textPart, ok := fantasy.AsMessagePart[fantasy.TextPart](part)
-		if !ok {
-			continue
-		}
-		text := strings.TrimRight(textPart.Text, "\n")
-		if text != "" {
-			text += "\n\n"
-		}
-		content[i] = fantasy.TextPart{Text: text + planPathBlock}
-		message.Content = content
-		return message, true
-	}
-	return message, false
-}
-
-func formatPlanPathBlock(planPath, home string) string {
-	planPath = strings.TrimSpace(planPath)
-	if planPath == "" {
+func formatPlanPathBlock(chatPath, home string) string {
+	chatPath = strings.TrimSpace(chatPath)
+	if chatPath == "" {
 		return ""
 	}
 
@@ -6068,7 +6020,7 @@ func formatPlanPathBlock(planPath, home string) string {
 	var b strings.Builder
 	_, _ = b.WriteString("<plan-file-path>\n")
 	_, _ = b.WriteString("Your plan file path for this chat is: ")
-	_, _ = b.WriteString(planPath)
+	_, _ = b.WriteString(chatPath)
 	_, _ = b.WriteString("\n")
 	_, _ = b.WriteString("Always use this exact path when creating or proposing plan files. Do not use ")
 	_, _ = b.WriteString(avoidPlanPath)

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -4503,7 +4503,7 @@ func (p *Server) runChat(
 			return ""
 		}
 
-		planPath, _, err := planPathFn(planCtx)
+		planPath, home, err := planPathFn(planCtx)
 		if err != nil {
 			p.logger.Debug(resolveCtx, "plan path instruction: failed to resolve plan path",
 				slog.Error(err),
@@ -4512,7 +4512,7 @@ func (p *Server) runChat(
 			return ""
 		}
 
-		return formatPlanPathInstruction(planPath)
+		return formatPlanPathInstruction(planPath, home)
 	}
 
 	// Connect to MCP servers in parallel with instruction
@@ -5950,10 +5950,20 @@ func (p *Server) resolveUserPrompt(ctx context.Context, userID uuid.UUID) string
 	return "<user-instructions>\n" + trimmed + "\n</user-instructions>"
 }
 
-func formatPlanPathInstruction(planPath string) string {
+func formatPlanPathInstruction(planPath, home string) string {
 	planPath = strings.TrimSpace(planPath)
 	if planPath == "" {
 		return ""
+	}
+
+	avoidPlanPath := chattool.LegacySharedPlanPath
+	home = strings.TrimSpace(home)
+	if home != "" {
+		separator := "/"
+		if strings.Contains(home, "\\") && !strings.Contains(home, "/") {
+			separator = "\\"
+		}
+		avoidPlanPath = strings.TrimRight(home, "/\\") + separator + "PLAN.md"
 	}
 
 	var b strings.Builder
@@ -5962,7 +5972,7 @@ func formatPlanPathInstruction(planPath string) string {
 	_, _ = b.WriteString(planPath)
 	_, _ = b.WriteString("\n")
 	_, _ = b.WriteString("Always use this exact path when creating or proposing plan files. Do not use ")
-	_, _ = b.WriteString(chattool.LegacySharedPlanPath)
+	_, _ = b.WriteString(avoidPlanPath)
 	_, _ = b.WriteString(".\n")
 	_, _ = b.WriteString("</plan-file-path>")
 	return b.String()

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -56,6 +56,7 @@ const (
 	DefaultInFlightChatStaleAfter = 5 * time.Minute
 
 	homeInstructionLookupTimeout = 5 * time.Second
+	planPathLookupTimeout        = 5 * time.Second
 	instructionCacheTTL          = 5 * time.Minute
 	workspaceDialValidationDelay = 5 * time.Second
 	workspaceMCPDiscoveryTimeout = 5 * time.Second
@@ -4470,6 +4471,37 @@ func (p *Server) runChat(
 	}
 	defer workspaceCtx.close()
 
+	planPathFn := func(ctx context.Context) (string, error) {
+		conn, err := workspaceCtx.getWorkspaceConn(ctx)
+		if err != nil {
+			return "", err
+		}
+		home, err := chattool.ResolveWorkspaceHome(ctx, conn)
+		if err != nil {
+			return "", err
+		}
+		return chattool.PlanPathForChat(home, chat.ID), nil
+	}
+	resolvePlanPathInstruction := func(resolveCtx context.Context) string {
+		if chat.ParentChatID.Valid {
+			return ""
+		}
+
+		planCtx, cancel := context.WithTimeout(resolveCtx, planPathLookupTimeout)
+		defer cancel()
+
+		if _, _, err := workspaceCtx.workspaceAgentIDForConn(planCtx); err != nil {
+			return ""
+		}
+
+		planPath, err := planPathFn(planCtx)
+		if err != nil {
+			return ""
+		}
+
+		return formatPlanPathInstruction(planPath)
+	}
+
 	// Connect to MCP servers in parallel with instruction
 	// resolution. ConnectAll only depends on mcpConfigs and
 	// mcpTokens which are available after g.Wait() above.
@@ -4662,6 +4694,9 @@ func (p *Server) runChat(
 
 	if instruction != "" {
 		prompt = chatprompt.InsertSystem(prompt, instruction)
+	}
+	if planPathInstruction := resolvePlanPathInstruction(ctx); planPathInstruction != "" {
+		prompt = chatprompt.InsertSystem(prompt, planPathInstruction)
 	}
 	if skillIndex := chattool.FormatSkillIndex(skills); skillIndex != "" {
 		prompt = chatprompt.InsertSystem(prompt, skillIndex)
@@ -4975,9 +5010,11 @@ func (p *Server) runChat(
 		}),
 		chattool.WriteFile(chattool.WriteFileOptions{
 			GetWorkspaceConn: workspaceCtx.getWorkspaceConn,
+			PlanPath:         planPathFn,
 		}),
 		chattool.EditFiles(chattool.EditFilesOptions{
 			GetWorkspaceConn: workspaceCtx.getWorkspaceConn,
+			PlanPath:         planPathFn,
 		}),
 		chattool.Execute(chattool.ExecuteOptions{
 			GetWorkspaceConn: workspaceCtx.getWorkspaceConn,
@@ -5033,6 +5070,7 @@ func (p *Server) runChat(
 		// Plan presentation tool.
 		tools = append(tools, chattool.ProposePlan(chattool.ProposePlanOptions{
 			GetWorkspaceConn: workspaceCtx.getWorkspaceConn,
+			PlanPath:         planPathFn,
 			StoreFile: func(ctx context.Context, name string, mediaType string, data []byte) (uuid.UUID, error) {
 				workspaceCtx.chatStateMu.Lock()
 				chatSnapshot := *workspaceCtx.currentChat
@@ -5224,6 +5262,9 @@ func (p *Server) runChat(
 			}
 			if instruction != "" {
 				reloadedPrompt = chatprompt.InsertSystem(reloadedPrompt, instruction)
+			}
+			if planPathInstruction := resolvePlanPathInstruction(reloadCtx); planPathInstruction != "" {
+				reloadedPrompt = chatprompt.InsertSystem(reloadedPrompt, planPathInstruction)
 			}
 			if skillIndex := chattool.FormatSkillIndex(skills); skillIndex != "" {
 				reloadedPrompt = chatprompt.InsertSystem(reloadedPrompt, skillIndex)
@@ -5894,6 +5935,24 @@ func (p *Server) resolveUserPrompt(ctx context.Context, userID uuid.UUID) string
 		return ""
 	}
 	return "<user-instructions>\n" + trimmed + "\n</user-instructions>"
+}
+
+func formatPlanPathInstruction(planPath string) string {
+	planPath = strings.TrimSpace(planPath)
+	if planPath == "" {
+		return ""
+	}
+
+	var b strings.Builder
+	_, _ = b.WriteString("<plan-file-path>\n")
+	_, _ = b.WriteString("Your plan file path for this chat is: ")
+	_, _ = b.WriteString(planPath)
+	_, _ = b.WriteString("\n")
+	_, _ = b.WriteString("Always use this exact path when creating or proposing plan files. Do not use ")
+	_, _ = b.WriteString(chattool.LegacySharedPlanPath)
+	_, _ = b.WriteString(".\n")
+	_, _ = b.WriteString("</plan-file-path>")
+	return b.String()
 }
 
 func (p *Server) recoverStaleChats(ctx context.Context) {

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -4471,16 +4471,16 @@ func (p *Server) runChat(
 	}
 	defer workspaceCtx.close()
 
-	planPathFn := func(ctx context.Context) (string, error) {
+	planPathFn := func(ctx context.Context) (string, string, error) {
 		conn, err := workspaceCtx.getWorkspaceConn(ctx)
 		if err != nil {
-			return "", err
+			return "", "", err
 		}
 		home, err := chattool.ResolveWorkspaceHome(ctx, conn)
 		if err != nil {
-			return "", err
+			return "", "", err
 		}
-		return chattool.PlanPathForChat(home, chat.ID), nil
+		return chattool.PlanPathForChat(home, chat.ID), home, nil
 	}
 	resolvePlanPathInstruction := func(resolveCtx context.Context) string {
 		if chat.ParentChatID.Valid {
@@ -4494,7 +4494,7 @@ func (p *Server) runChat(
 			return ""
 		}
 
-		planPath, err := planPathFn(planCtx)
+		planPath, _, err := planPathFn(planCtx)
 		if err != nil {
 			return ""
 		}

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -5010,11 +5010,11 @@ func (p *Server) runChat(
 		}),
 		chattool.WriteFile(chattool.WriteFileOptions{
 			GetWorkspaceConn: workspaceCtx.getWorkspaceConn,
-			PlanPath:         planPathFn,
+			ResolvePlanPath:  planPathFn,
 		}),
 		chattool.EditFiles(chattool.EditFilesOptions{
 			GetWorkspaceConn: workspaceCtx.getWorkspaceConn,
-			PlanPath:         planPathFn,
+			ResolvePlanPath:  planPathFn,
 		}),
 		chattool.Execute(chattool.ExecuteOptions{
 			GetWorkspaceConn: workspaceCtx.getWorkspaceConn,
@@ -5070,7 +5070,7 @@ func (p *Server) runChat(
 		// Plan presentation tool.
 		tools = append(tools, chattool.ProposePlan(chattool.ProposePlanOptions{
 			GetWorkspaceConn: workspaceCtx.getWorkspaceConn,
-			PlanPath:         planPathFn,
+			ResolvePlanPath:  planPathFn,
 			StoreFile: func(ctx context.Context, name string, mediaType string, data []byte) (uuid.UUID, error) {
 				workspaceCtx.chatStateMu.Lock()
 				chatSnapshot := *workspaceCtx.currentChat

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -4487,7 +4487,7 @@ func (p *Server) runChat(
 		defer cancel()
 		return planPathFn(ctx)
 	}
-	resolvePlanPathInstruction := func(resolveCtx context.Context) string {
+	resolvePlanPathBlock := func(resolveCtx context.Context) string {
 		if chat.ParentChatID.Valid {
 			return ""
 		}
@@ -4512,7 +4512,7 @@ func (p *Server) runChat(
 			return ""
 		}
 
-		return formatPlanPathInstruction(planPath, home)
+		return formatPlanPathBlock(planPath, home)
 	}
 
 	// Connect to MCP servers in parallel with instruction
@@ -4708,9 +4708,7 @@ func (p *Server) runChat(
 	if instruction != "" {
 		prompt = chatprompt.InsertSystem(prompt, instruction)
 	}
-	if planPathInstruction := resolvePlanPathInstruction(ctx); planPathInstruction != "" {
-		prompt = chatprompt.InsertSystem(prompt, planPathInstruction)
-	}
+	prompt = renderPlanPathPrompt(prompt, resolvePlanPathBlock(ctx))
 	if skillIndex := chattool.FormatSkillIndex(skills); skillIndex != "" {
 		prompt = chatprompt.InsertSystem(prompt, skillIndex)
 	}
@@ -5276,9 +5274,7 @@ func (p *Server) runChat(
 			if instruction != "" {
 				reloadedPrompt = chatprompt.InsertSystem(reloadedPrompt, instruction)
 			}
-			if planPathInstruction := resolvePlanPathInstruction(reloadCtx); planPathInstruction != "" {
-				reloadedPrompt = chatprompt.InsertSystem(reloadedPrompt, planPathInstruction)
-			}
+			reloadedPrompt = renderPlanPathPrompt(reloadedPrompt, resolvePlanPathBlock(reloadCtx))
 			if skillIndex := chattool.FormatSkillIndex(skills); skillIndex != "" {
 				reloadedPrompt = chatprompt.InsertSystem(reloadedPrompt, skillIndex)
 			}
@@ -5950,7 +5946,114 @@ func (p *Server) resolveUserPrompt(ctx context.Context, userID uuid.UUID) string
 	return "<user-instructions>\n" + trimmed + "\n</user-instructions>"
 }
 
-func formatPlanPathInstruction(planPath, home string) string {
+// renderPlanPathPrompt fills the plan-path placeholder for new chats and
+// appends the block to the main system prompt for persisted chats that
+// predate the placeholder.
+func renderPlanPathPrompt(prompt []fantasy.Message, planPathBlock string) []fantasy.Message {
+	prompt, hadPlaceholder := replacePlanPathPlaceholder(prompt, planPathBlock)
+	if hadPlaceholder || planPathBlock == "" {
+		return prompt
+	}
+
+	for i, message := range prompt {
+		if message.Role != fantasy.MessageRoleSystem {
+			continue
+		}
+		updatedMessage, ok := appendPlanPathBlock(message, planPathBlock)
+		if !ok {
+			continue
+		}
+		updatedPrompt := slices.Clone(prompt)
+		updatedPrompt[i] = updatedMessage
+		return updatedPrompt
+	}
+
+	return append([]fantasy.Message{{
+		Role: fantasy.MessageRoleSystem,
+		Content: []fantasy.MessagePart{
+			fantasy.TextPart{Text: planPathBlock},
+		},
+	}}, prompt...)
+}
+
+func replacePlanPathPlaceholder(
+	prompt []fantasy.Message,
+	planPathBlock string,
+) ([]fantasy.Message, bool) {
+	var updatedPrompt []fantasy.Message
+	replaced := false
+	for i, message := range prompt {
+		updatedMessage, ok := replacePlanPathPlaceholderInMessage(message, planPathBlock)
+		if !ok {
+			continue
+		}
+		if updatedPrompt == nil {
+			updatedPrompt = slices.Clone(prompt)
+		}
+		updatedPrompt[i] = updatedMessage
+		replaced = true
+	}
+	if !replaced {
+		return prompt, false
+	}
+	return updatedPrompt, true
+}
+
+func replacePlanPathPlaceholderInMessage(
+	message fantasy.Message,
+	planPathBlock string,
+) (fantasy.Message, bool) {
+	if message.Role != fantasy.MessageRoleSystem {
+		return message, false
+	}
+
+	content := slices.Clone(message.Content)
+	replaced := false
+	for i, part := range content {
+		textPart, ok := fantasy.AsMessagePart[fantasy.TextPart](part)
+		if !ok || !strings.Contains(textPart.Text, defaultSystemPromptPlanPathBlockPlaceholder) {
+			continue
+		}
+		replaced = true
+		content[i] = fantasy.TextPart{Text: strings.ReplaceAll(
+			textPart.Text,
+			defaultSystemPromptPlanPathBlockPlaceholder,
+			planPathBlock,
+		)}
+	}
+	if !replaced {
+		return message, false
+	}
+	message.Content = content
+	return message, true
+}
+
+func appendPlanPathBlock(
+	message fantasy.Message,
+	planPathBlock string,
+) (fantasy.Message, bool) {
+	if message.Role != fantasy.MessageRoleSystem {
+		return message, false
+	}
+
+	content := slices.Clone(message.Content)
+	for i, part := range content {
+		textPart, ok := fantasy.AsMessagePart[fantasy.TextPart](part)
+		if !ok {
+			continue
+		}
+		text := strings.TrimRight(textPart.Text, "\n")
+		if text != "" {
+			text += "\n\n"
+		}
+		content[i] = fantasy.TextPart{Text: text + planPathBlock}
+		message.Content = content
+		return message, true
+	}
+	return message, false
+}
+
+func formatPlanPathBlock(planPath, home string) string {
 	planPath = strings.TrimSpace(planPath)
 	if planPath == "" {
 		return ""
@@ -5959,11 +6062,7 @@ func formatPlanPathInstruction(planPath, home string) string {
 	avoidPlanPath := chattool.LegacySharedPlanPath
 	home = strings.TrimSpace(home)
 	if home != "" {
-		separator := "/"
-		if strings.Contains(home, "\\") && !strings.Contains(home, "/") {
-			separator = "\\"
-		}
-		avoidPlanPath = strings.TrimRight(home, "/\\") + separator + "PLAN.md"
+		avoidPlanPath = strings.TrimRight(home, "/") + "/PLAN.md"
 	}
 
 	var b strings.Builder

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -4482,6 +4482,11 @@ func (p *Server) runChat(
 		}
 		return chattool.PlanPathForChat(home, chat.ID), home, nil
 	}
+	resolvePlanPathForTools := func(ctx context.Context) (string, string, error) {
+		ctx, cancel := context.WithTimeout(ctx, planPathLookupTimeout)
+		defer cancel()
+		return planPathFn(ctx)
+	}
 	resolvePlanPathInstruction := func(resolveCtx context.Context) string {
 		if chat.ParentChatID.Valid {
 			return ""
@@ -4491,11 +4496,19 @@ func (p *Server) runChat(
 		defer cancel()
 
 		if _, _, err := workspaceCtx.workspaceAgentIDForConn(planCtx); err != nil {
+			p.logger.Debug(resolveCtx, "plan path instruction: agent not reachable",
+				slog.Error(err),
+				slog.F("chat_id", chat.ID),
+			)
 			return ""
 		}
 
 		planPath, _, err := planPathFn(planCtx)
 		if err != nil {
+			p.logger.Debug(resolveCtx, "plan path instruction: failed to resolve plan path",
+				slog.Error(err),
+				slog.F("chat_id", chat.ID),
+			)
 			return ""
 		}
 
@@ -5010,11 +5023,11 @@ func (p *Server) runChat(
 		}),
 		chattool.WriteFile(chattool.WriteFileOptions{
 			GetWorkspaceConn: workspaceCtx.getWorkspaceConn,
-			ResolvePlanPath:  planPathFn,
+			ResolvePlanPath:  resolvePlanPathForTools,
 		}),
 		chattool.EditFiles(chattool.EditFilesOptions{
 			GetWorkspaceConn: workspaceCtx.getWorkspaceConn,
-			ResolvePlanPath:  planPathFn,
+			ResolvePlanPath:  resolvePlanPathForTools,
 		}),
 		chattool.Execute(chattool.ExecuteOptions{
 			GetWorkspaceConn: workspaceCtx.getWorkspaceConn,
@@ -5070,7 +5083,7 @@ func (p *Server) runChat(
 		// Plan presentation tool.
 		tools = append(tools, chattool.ProposePlan(chattool.ProposePlanOptions{
 			GetWorkspaceConn: workspaceCtx.getWorkspaceConn,
-			ResolvePlanPath:  planPathFn,
+			ResolvePlanPath:  resolvePlanPathForTools,
 			StoreFile: func(ctx context.Context, name string, mediaType string, data []byte) (uuid.UUID, error) {
 				workspaceCtx.chatStateMu.Lock()
 				chatSnapshot := *workspaceCtx.currentChat

--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -5688,7 +5688,10 @@ func TestAgentContextFilesAndSkillsLoadedIntoChat(t *testing.T) {
 		if msg.Role != "system" {
 			continue
 		}
-		planBlockCount += strings.Count(msg.Content, "<plan-file-path>")
+		planBlockCount += strings.Count(
+			msg.Content,
+			"<plan-file-path>\nYour plan file path for this chat is:",
+		)
 		trimmed := strings.TrimSpace(msg.Content)
 		if strings.HasPrefix(trimmed, "<plan-file-path>") &&
 			strings.HasSuffix(trimmed, "</plan-file-path>") {
@@ -5706,7 +5709,8 @@ func TestAgentContextFilesAndSkillsLoadedIntoChat(t *testing.T) {
 		"system prompt should contain the plan-file-path block")
 	require.Contains(t, allSystemContent, "PLAN-"+chat.ID.String()+".md",
 		"system prompt should use the chat-specific plan path")
-	require.Contains(t, allSystemContent, "Do not use /home/coder/PLAN.md.",
+	require.Contains(t, allSystemContent,
+		"Do not use "+strings.TrimRight(fakeHome, "/")+"/PLAN.md.",
 		"system prompt should warn against the home-root plan path")
 	require.Equal(t, 1, planBlockCount,
 		"system prompt should contain a single plan-file-path block")

--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -5682,10 +5682,34 @@ func TestAgentContextFilesAndSkillsLoadedIntoChat(t *testing.T) {
 	require.Contains(t, allSystemContent, "AGENTS.md",
 		"system prompt should reference the source file")
 
+	planBlockCount := 0
+	standalonePlanBlockCount := 0
+	for _, msg := range recordedCalls[0] {
+		if msg.Role != "system" {
+			continue
+		}
+		planBlockCount += strings.Count(msg.Content, "<plan-file-path>")
+		trimmed := strings.TrimSpace(msg.Content)
+		if strings.HasPrefix(trimmed, "<plan-file-path>") &&
+			strings.HasSuffix(trimmed, "</plan-file-path>") {
+			standalonePlanBlockCount++
+		}
+	}
+
 	require.Contains(t, allSystemContent, "<available-skills>",
 		"system prompt should contain available-skills block")
 	require.Contains(t, allSystemContent, "my-cool-skill",
 		"system prompt should list the discovered skill")
 	require.Contains(t, allSystemContent, "A test skill",
 		"system prompt should include the skill description")
+	require.Contains(t, allSystemContent, "<plan-file-path>",
+		"system prompt should contain the plan-file-path block")
+	require.Contains(t, allSystemContent, "PLAN-"+chat.ID.String()+".md",
+		"system prompt should use the chat-specific plan path")
+	require.Contains(t, allSystemContent, "Do not use /home/coder/PLAN.md.",
+		"system prompt should warn against the home-root plan path")
+	require.Equal(t, 1, planBlockCount,
+		"system prompt should contain a single plan-file-path block")
+	require.Zero(t, standalonePlanBlockCount,
+		"plan-file-path block should be part of the main system prompt, not a standalone message")
 }

--- a/coderd/x/chatd/chattool/editfiles.go
+++ b/coderd/x/chatd/chattool/editfiles.go
@@ -2,6 +2,7 @@ package chattool
 
 import (
 	"context"
+	"path"
 
 	"charm.land/fantasy"
 
@@ -10,7 +11,7 @@ import (
 
 type EditFilesOptions struct {
 	GetWorkspaceConn func(context.Context) (workspacesdk.AgentConn, error)
-	PlanPath         func(context.Context) (chatPath string, home string, err error)
+	ResolvePlanPath  func(context.Context) (chatPath string, home string, err error)
 }
 
 type EditFilesArgs struct {
@@ -30,7 +31,7 @@ func EditFiles(options EditFilesOptions) fantasy.AgentTool {
 			if err != nil {
 				return fantasy.NewTextErrorResponse(err.Error()), nil
 			}
-			return executeEditFilesTool(ctx, conn, args, options.PlanPath)
+			return executeEditFilesTool(ctx, conn, args, options.ResolvePlanPath)
 		},
 	)
 }
@@ -52,7 +53,13 @@ func executeEditFilesTool(
 		planPathLoaded bool
 	)
 	for _, file := range args.Files {
-		if resolvePlanPath == nil || !looksLikePlanFileName(file.Path) {
+		looksLikePlanPath := looksLikePlanFileName(file.Path)
+		if looksLikePlanPath && !path.IsAbs(file.Path) {
+			return fantasy.NewTextErrorResponse(
+				"plan files must use absolute paths; use the chat-specific plan path from your instructions",
+			), nil
+		}
+		if resolvePlanPath == nil || !looksLikePlanPath {
 			continue
 		}
 		if !planPathLoaded {

--- a/coderd/x/chatd/chattool/editfiles.go
+++ b/coderd/x/chatd/chattool/editfiles.go
@@ -10,7 +10,7 @@ import (
 
 type EditFilesOptions struct {
 	GetWorkspaceConn func(context.Context) (workspacesdk.AgentConn, error)
-	PlanPath         func(context.Context) (string, error)
+	PlanPath         func(context.Context) (chatPath string, home string, err error)
 }
 
 type EditFilesArgs struct {
@@ -39,14 +39,27 @@ func executeEditFilesTool(
 	ctx context.Context,
 	conn workspacesdk.AgentConn,
 	args EditFilesArgs,
-	resolvePlanPath func(context.Context) (string, error),
+	resolvePlanPath func(context.Context) (chatPath string, home string, err error),
 ) (fantasy.ToolResponse, error) {
 	if len(args.Files) == 0 {
 		return fantasy.NewTextErrorResponse("files is required"), nil
 	}
 
+	var (
+		chatPath       string
+		home           string
+		planPathErr    error
+		planPathLoaded bool
+	)
 	for _, file := range args.Files {
-		if resp, rejected := rejectSharedPlanPath(ctx, file.Path, resolvePlanPath); rejected {
+		if resolvePlanPath == nil || !looksLikePlanFileName(file.Path) {
+			continue
+		}
+		if !planPathLoaded {
+			chatPath, home, planPathErr = resolvePlanPath(ctx)
+			planPathLoaded = true
+		}
+		if resp, rejected := rejectSharedPlanPath(file.Path, home, chatPath, planPathErr); rejected {
 			return resp, nil
 		}
 	}

--- a/coderd/x/chatd/chattool/editfiles.go
+++ b/coderd/x/chatd/chattool/editfiles.go
@@ -10,6 +10,7 @@ import (
 
 type EditFilesOptions struct {
 	GetWorkspaceConn func(context.Context) (workspacesdk.AgentConn, error)
+	PlanPath         func(context.Context) (string, error)
 }
 
 type EditFilesArgs struct {
@@ -29,7 +30,7 @@ func EditFiles(options EditFilesOptions) fantasy.AgentTool {
 			if err != nil {
 				return fantasy.NewTextErrorResponse(err.Error()), nil
 			}
-			return executeEditFilesTool(ctx, conn, args)
+			return executeEditFilesTool(ctx, conn, args, options.PlanPath)
 		},
 	)
 }
@@ -38,9 +39,16 @@ func executeEditFilesTool(
 	ctx context.Context,
 	conn workspacesdk.AgentConn,
 	args EditFilesArgs,
+	resolvePlanPath func(context.Context) (string, error),
 ) (fantasy.ToolResponse, error) {
 	if len(args.Files) == 0 {
 		return fantasy.NewTextErrorResponse("files is required"), nil
+	}
+
+	for _, file := range args.Files {
+		if resp, rejected := rejectSharedPlanPath(ctx, file.Path, resolvePlanPath); rejected {
+			return resp, nil
+		}
 	}
 
 	if err := conn.EditFiles(ctx, workspacesdk.FileEditRequest{Files: args.Files}); err != nil {

--- a/coderd/x/chatd/chattool/editfiles.go
+++ b/coderd/x/chatd/chattool/editfiles.go
@@ -59,7 +59,7 @@ func executeEditFilesTool(
 		looksLikePlanPath := looksLikePlanFileName(file.Path)
 		if looksLikePlanPath && !isAbsolutePath(file.Path) {
 			return fantasy.NewTextErrorResponse(
-				"plan files must use absolute paths; use the chat-specific plan path from your instructions",
+				"plan files must use absolute paths; use the chat-specific plan path from your instructions; no files in this batch were applied",
 			), nil
 		}
 		if resolvePlanPath == nil || !looksLikePlanPath {

--- a/coderd/x/chatd/chattool/editfiles.go
+++ b/coderd/x/chatd/chattool/editfiles.go
@@ -56,13 +56,13 @@ func executeEditFilesTool(
 		args.Files[i].Path = strings.TrimSpace(args.Files[i].Path)
 		file := args.Files[i]
 
-		looksLikePlanPath := looksLikePlanFileName(file.Path)
-		if looksLikePlanPath && !isAbsolutePath(file.Path) {
+		hasPlanFileName := looksLikePlanFileName(file.Path)
+		if hasPlanFileName && !isAbsolutePath(file.Path) {
 			return fantasy.NewTextErrorResponse(
 				"plan files must use absolute paths; use the chat-specific absolute plan path; no files in this batch were applied",
 			), nil
 		}
-		if resolvePlanPath == nil || !looksLikePlanPath {
+		if resolvePlanPath == nil || !hasPlanFileName {
 			continue
 		}
 		if !planPathLoaded {

--- a/coderd/x/chatd/chattool/editfiles.go
+++ b/coderd/x/chatd/chattool/editfiles.go
@@ -2,7 +2,6 @@ package chattool
 
 import (
 	"context"
-	"path"
 
 	"charm.land/fantasy"
 
@@ -54,7 +53,7 @@ func executeEditFilesTool(
 	)
 	for _, file := range args.Files {
 		looksLikePlanPath := looksLikePlanFileName(file.Path)
-		if looksLikePlanPath && !path.IsAbs(file.Path) {
+		if looksLikePlanPath && !isAbsolutePath(file.Path) {
 			return fantasy.NewTextErrorResponse(
 				"plan files must use absolute paths; use the chat-specific plan path from your instructions",
 			), nil

--- a/coderd/x/chatd/chattool/editfiles.go
+++ b/coderd/x/chatd/chattool/editfiles.go
@@ -2,6 +2,7 @@ package chattool
 
 import (
 	"context"
+	"strings"
 
 	"charm.land/fantasy"
 
@@ -51,7 +52,10 @@ func executeEditFilesTool(
 		planPathErr    error
 		planPathLoaded bool
 	)
-	for _, file := range args.Files {
+	for i := range args.Files {
+		args.Files[i].Path = strings.TrimSpace(args.Files[i].Path)
+		file := args.Files[i]
+
 		looksLikePlanPath := looksLikePlanFileName(file.Path)
 		if looksLikePlanPath && !isAbsolutePath(file.Path) {
 			return fantasy.NewTextErrorResponse(
@@ -66,7 +70,9 @@ func executeEditFilesTool(
 			planPathLoaded = true
 		}
 		if resp, rejected := rejectSharedPlanPath(file.Path, home, chatPath, planPathErr); rejected {
-			return resp, nil
+			return fantasy.NewTextErrorResponse(
+				resp.Content + "; no files in this batch were applied",
+			), nil
 		}
 	}
 

--- a/coderd/x/chatd/chattool/editfiles.go
+++ b/coderd/x/chatd/chattool/editfiles.go
@@ -59,7 +59,7 @@ func executeEditFilesTool(
 		looksLikePlanPath := looksLikePlanFileName(file.Path)
 		if looksLikePlanPath && !isAbsolutePath(file.Path) {
 			return fantasy.NewTextErrorResponse(
-				"plan files must use absolute paths; use the chat-specific plan path from your instructions; no files in this batch were applied",
+				"plan files must use absolute paths; use the chat-specific absolute plan path; no files in this batch were applied",
 			), nil
 		}
 		if resolvePlanPath == nil || !looksLikePlanPath {

--- a/coderd/x/chatd/chattool/editfiles_test.go
+++ b/coderd/x/chatd/chattool/editfiles_test.go
@@ -18,7 +18,7 @@ import (
 func TestEditFiles(t *testing.T) {
 	t.Parallel()
 
-	t.Run("RejectsSharedPlanPathWhenPlanPathIsConfigured", func(t *testing.T) {
+	t.Run("RejectsHomeRootPlanPathsWhenPlanPathIsConfigured", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
 		mockConn := agentconnmock.NewMockAgentConn(ctrl)
@@ -26,21 +26,21 @@ func TestEditFiles(t *testing.T) {
 			GetWorkspaceConn: func(context.Context) (workspacesdk.AgentConn, error) {
 				return mockConn, nil
 			},
-			PlanPath: func(context.Context) (string, error) {
-				return "/home/coder/.coder/plans/PLAN-chat.md", nil
+			PlanPath: func(context.Context) (string, string, error) {
+				return "/Users/dev/.coder/plans/PLAN-chat.md", "/Users/dev", nil
 			},
 		})
 
 		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
 			ID:    "call-1",
 			Name:  "edit_files",
-			Input: `{"files":[{"path":"` + chattool.LegacySharedPlanPath + `","edits":[{"search":"old","replace":"new"}]}]}`,
+			Input: `{"files":[{"path":"/Users/dev/plan.md","edits":[{"search":"old","replace":"new"}]}]}`,
 		})
 		require.NoError(t, err)
 		assert.True(t, resp.IsError)
 		assert.Equal(
 			t,
-			sharedPlanPathResolvedMessage("/home/coder/.coder/plans/PLAN-chat.md"),
+			sharedPlanPathResolvedMessage("/Users/dev/.coder/plans/PLAN-chat.md"),
 			resp.Content,
 		)
 	})
@@ -63,9 +63,9 @@ func TestEditFiles(t *testing.T) {
 			GetWorkspaceConn: func(context.Context) (workspacesdk.AgentConn, error) {
 				return mockConn, nil
 			},
-			PlanPath: func(context.Context) (string, error) {
+			PlanPath: func(context.Context) (string, string, error) {
 				planPathCalled = true
-				return "", xerrors.New("should not be called")
+				return "", "", xerrors.New("should not be called")
 			},
 		})
 

--- a/coderd/x/chatd/chattool/editfiles_test.go
+++ b/coderd/x/chatd/chattool/editfiles_test.go
@@ -126,6 +126,72 @@ func TestEditFiles(t *testing.T) {
 		assert.Equal(t, relativePlanPathMessage(), resp.Content)
 	})
 
+	t.Run("PerChatPlanPathIsAllowed", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		chatPlanPath := "/home/coder/.coder/plans/PLAN-123e4567-e89b-12d3-a456-426614174000.md"
+		request := workspacesdk.FileEditRequest{Files: []workspacesdk.FileEdits{{
+			Path: chatPlanPath,
+			Edits: []workspacesdk.FileEdit{{
+				Search:  "old",
+				Replace: "new",
+			}},
+		}}}
+		mockConn.EXPECT().EditFiles(gomock.Any(), request).Return(nil)
+
+		resolvePlanPathCalled := false
+		tool := chattool.EditFiles(chattool.EditFilesOptions{
+			GetWorkspaceConn: func(context.Context) (workspacesdk.AgentConn, error) {
+				return mockConn, nil
+			},
+			ResolvePlanPath: func(context.Context) (string, string, error) {
+				resolvePlanPathCalled = true
+				return chatPlanPath, "/home/coder", nil
+			},
+		})
+
+		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "edit_files",
+			Input: `{"files":[{"path":"` + chatPlanPath + `","edits":[{"search":"old","replace":"new"}]}]}`,
+		})
+		require.NoError(t, err)
+		assert.False(t, resp.IsError)
+		assert.False(t, resolvePlanPathCalled)
+	})
+
+	t.Run("NestedPlanPathAllowedWhenResolverFails", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		request := workspacesdk.FileEditRequest{Files: []workspacesdk.FileEdits{{
+			Path: "/home/coder/myproject/plan.md",
+			Edits: []workspacesdk.FileEdit{{
+				Search:  "old",
+				Replace: "new",
+			}},
+		}}}
+		mockConn.EXPECT().EditFiles(gomock.Any(), request).Return(nil)
+
+		tool := chattool.EditFiles(chattool.EditFilesOptions{
+			GetWorkspaceConn: func(context.Context) (workspacesdk.AgentConn, error) {
+				return mockConn, nil
+			},
+			ResolvePlanPath: func(context.Context) (string, string, error) {
+				return "", "", xerrors.New("workspace unavailable")
+			},
+		})
+
+		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "edit_files",
+			Input: `{"files":[{"path":"/home/coder/myproject/plan.md","edits":[{"search":"old","replace":"new"}]}]}`,
+		})
+		require.NoError(t, err)
+		assert.False(t, resp.IsError)
+	})
+
 	t.Run("NestedPlanPathUnderHomeIsAllowed", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)

--- a/coderd/x/chatd/chattool/editfiles_test.go
+++ b/coderd/x/chatd/chattool/editfiles_test.go
@@ -18,7 +18,66 @@ import (
 func TestEditFiles(t *testing.T) {
 	t.Parallel()
 
-	t.Run("RejectsHomeRootPlanPathsWhenPlanPathIsConfigured", func(t *testing.T) {
+	t.Run("RejectsPlanPathsWhenResolvePlanPathIsConfigured", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name                 string
+			input                string
+			expectedRejectedPath string
+		}{
+			{
+				name:                 "SingleHomeRootPlanPath",
+				input:                `{"files":[{"path":"/Users/dev/plan.md","edits":[{"search":"old","replace":"new"}]}]}`,
+				expectedRejectedPath: "/Users/dev/plan.md",
+			},
+			{
+				name: "MultiFileBatchWithHomeRootPlanPath",
+				input: `{"files":[` +
+					`{"path":"/Users/dev/notes.md","edits":[{"search":"old","replace":"new"}]},` +
+					`{"path":"/Users/dev/plan.md","edits":[{"search":"old","replace":"new"}]}` +
+					`]}`,
+				expectedRejectedPath: "/Users/dev/plan.md",
+			},
+		}
+
+		for _, testCase := range tests {
+			t.Run(testCase.name, func(t *testing.T) {
+				t.Parallel()
+				ctrl := gomock.NewController(t)
+				mockConn := agentconnmock.NewMockAgentConn(ctrl)
+				resolvePlanPathCalls := 0
+				tool := chattool.EditFiles(chattool.EditFilesOptions{
+					GetWorkspaceConn: func(context.Context) (workspacesdk.AgentConn, error) {
+						return mockConn, nil
+					},
+					ResolvePlanPath: func(context.Context) (string, string, error) {
+						resolvePlanPathCalls++
+						return "/Users/dev/.coder/plans/PLAN-chat.md", "/Users/dev", nil
+					},
+				})
+
+				resp, err := tool.Run(context.Background(), fantasy.ToolCall{
+					ID:    "call-1",
+					Name:  "edit_files",
+					Input: testCase.input,
+				})
+				require.NoError(t, err)
+				assert.True(t, resp.IsError)
+				assert.Equal(t, 1, resolvePlanPathCalls)
+				assert.Equal(
+					t,
+					sharedPlanPathResolvedMessage(
+						testCase.expectedRejectedPath,
+						"/Users/dev/.coder/plans/PLAN-chat.md",
+					),
+					resp.Content,
+				)
+			})
+		}
+	})
+
+	t.Run("RejectsSharedPlanPathWhenResolverFails", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
 		mockConn := agentconnmock.NewMockAgentConn(ctrl)
@@ -26,23 +85,45 @@ func TestEditFiles(t *testing.T) {
 			GetWorkspaceConn: func(context.Context) (workspacesdk.AgentConn, error) {
 				return mockConn, nil
 			},
-			PlanPath: func(context.Context) (string, string, error) {
-				return "/Users/dev/.coder/plans/PLAN-chat.md", "/Users/dev", nil
+			ResolvePlanPath: func(context.Context) (string, string, error) {
+				return "", "", xerrors.New("workspace unavailable")
 			},
 		})
 
 		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
 			ID:    "call-1",
 			Name:  "edit_files",
-			Input: `{"files":[{"path":"/Users/dev/plan.md","edits":[{"search":"old","replace":"new"}]}]}`,
+			Input: `{"files":[{"path":"/home/coder/plan.md","edits":[{"search":"old","replace":"new"}]}]}`,
 		})
 		require.NoError(t, err)
 		assert.True(t, resp.IsError)
-		assert.Equal(
-			t,
-			sharedPlanPathResolvedMessage("/Users/dev/.coder/plans/PLAN-chat.md"),
-			resp.Content,
-		)
+		assert.Equal(t, sharedPlanPathFallbackMessage("/home/coder/plan.md"), resp.Content)
+	})
+
+	t.Run("RejectsRelativePlanPathsWhenResolvePlanPathIsConfigured", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		resolvePlanPathCalled := false
+		tool := chattool.EditFiles(chattool.EditFilesOptions{
+			GetWorkspaceConn: func(context.Context) (workspacesdk.AgentConn, error) {
+				return mockConn, nil
+			},
+			ResolvePlanPath: func(context.Context) (string, string, error) {
+				resolvePlanPathCalled = true
+				return "/home/coder/.coder/plans/PLAN-chat.md", "/home/coder", nil
+			},
+		})
+
+		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "edit_files",
+			Input: `{"files":[{"path":"plan.md","edits":[{"search":"old","replace":"new"}]}]}`,
+		})
+		require.NoError(t, err)
+		assert.True(t, resp.IsError)
+		assert.False(t, resolvePlanPathCalled)
+		assert.Equal(t, relativePlanPathMessage(), resp.Content)
 	})
 
 	t.Run("AllowsNonSharedPath", func(t *testing.T) {
@@ -58,13 +139,13 @@ func TestEditFiles(t *testing.T) {
 		}}}
 		mockConn.EXPECT().EditFiles(gomock.Any(), request).Return(nil)
 
-		planPathCalled := false
+		resolvePlanPathCalled := false
 		tool := chattool.EditFiles(chattool.EditFilesOptions{
 			GetWorkspaceConn: func(context.Context) (workspacesdk.AgentConn, error) {
 				return mockConn, nil
 			},
-			PlanPath: func(context.Context) (string, string, error) {
-				planPathCalled = true
+			ResolvePlanPath: func(context.Context) (string, string, error) {
+				resolvePlanPathCalled = true
 				return "", "", xerrors.New("should not be called")
 			},
 		})
@@ -76,6 +157,34 @@ func TestEditFiles(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.False(t, resp.IsError)
-		assert.False(t, planPathCalled)
+		assert.False(t, resolvePlanPathCalled)
+	})
+
+	t.Run("AllowsSharedPlanPathWhenResolvePlanPathIsNil", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		request := workspacesdk.FileEditRequest{Files: []workspacesdk.FileEdits{{
+			Path: chattool.LegacySharedPlanPath,
+			Edits: []workspacesdk.FileEdit{{
+				Search:  "old",
+				Replace: "new",
+			}},
+		}}}
+		mockConn.EXPECT().EditFiles(gomock.Any(), request).Return(nil)
+
+		tool := chattool.EditFiles(chattool.EditFilesOptions{
+			GetWorkspaceConn: func(context.Context) (workspacesdk.AgentConn, error) {
+				return mockConn, nil
+			},
+		})
+
+		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "edit_files",
+			Input: `{"files":[{"path":"` + chattool.LegacySharedPlanPath + `","edits":[{"search":"old","replace":"new"}]}]}`,
+		})
+		require.NoError(t, err)
+		assert.False(t, resp.IsError)
 	})
 }

--- a/coderd/x/chatd/chattool/editfiles_test.go
+++ b/coderd/x/chatd/chattool/editfiles_test.go
@@ -1,0 +1,81 @@
+package chattool_test
+
+import (
+	"context"
+	"testing"
+
+	"charm.land/fantasy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/coderd/x/chatd/chattool"
+	"github.com/coder/coder/v2/codersdk/workspacesdk"
+	"github.com/coder/coder/v2/codersdk/workspacesdk/agentconnmock"
+)
+
+func TestEditFiles(t *testing.T) {
+	t.Parallel()
+
+	t.Run("RejectsSharedPlanPathWhenPlanPathIsConfigured", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		tool := chattool.EditFiles(chattool.EditFilesOptions{
+			GetWorkspaceConn: func(context.Context) (workspacesdk.AgentConn, error) {
+				return mockConn, nil
+			},
+			PlanPath: func(context.Context) (string, error) {
+				return "/home/coder/.coder/plans/PLAN-chat.md", nil
+			},
+		})
+
+		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "edit_files",
+			Input: `{"files":[{"path":"` + chattool.LegacySharedPlanPath + `","edits":[{"search":"old","replace":"new"}]}]}`,
+		})
+		require.NoError(t, err)
+		assert.True(t, resp.IsError)
+		assert.Equal(
+			t,
+			sharedPlanPathResolvedMessage("/home/coder/.coder/plans/PLAN-chat.md"),
+			resp.Content,
+		)
+	})
+
+	t.Run("AllowsNonSharedPath", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		request := workspacesdk.FileEditRequest{Files: []workspacesdk.FileEdits{{
+			Path: "/home/dev/my-plan.md",
+			Edits: []workspacesdk.FileEdit{{
+				Search:  "old",
+				Replace: "new",
+			}},
+		}}}
+		mockConn.EXPECT().EditFiles(gomock.Any(), request).Return(nil)
+
+		planPathCalled := false
+		tool := chattool.EditFiles(chattool.EditFilesOptions{
+			GetWorkspaceConn: func(context.Context) (workspacesdk.AgentConn, error) {
+				return mockConn, nil
+			},
+			PlanPath: func(context.Context) (string, error) {
+				planPathCalled = true
+				return "", xerrors.New("should not be called")
+			},
+		})
+
+		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "edit_files",
+			Input: `{"files":[{"path":"/home/dev/my-plan.md","edits":[{"search":"old","replace":"new"}]}]}`,
+		})
+		require.NoError(t, err)
+		assert.False(t, resp.IsError)
+		assert.False(t, planPathCalled)
+	})
+}

--- a/coderd/x/chatd/chattool/editfiles_test.go
+++ b/coderd/x/chatd/chattool/editfiles_test.go
@@ -67,10 +67,10 @@ func TestEditFiles(t *testing.T) {
 				assert.Equal(t, 1, resolvePlanPathCalls)
 				assert.Equal(
 					t,
-					sharedPlanPathResolvedMessage(
+					editFilesBatchRejectedMessage(sharedPlanPathResolvedMessage(
 						testCase.expectedRejectedPath,
 						"/Users/dev/.coder/plans/PLAN-chat.md",
-					),
+					)),
 					resp.Content,
 				)
 			})
@@ -97,7 +97,7 @@ func TestEditFiles(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.True(t, resp.IsError)
-		assert.Equal(t, sharedPlanPathFallbackMessage("/home/coder/plan.md"), resp.Content)
+		assert.Equal(t, editFilesBatchRejectedMessage(planPathVerificationMessage("/home/coder/plan.md")), resp.Content)
 	})
 
 	t.Run("RejectsRelativePlanPathsWhenResolvePlanPathIsConfigured", func(t *testing.T) {
@@ -124,6 +124,40 @@ func TestEditFiles(t *testing.T) {
 		assert.True(t, resp.IsError)
 		assert.False(t, resolvePlanPathCalled)
 		assert.Equal(t, relativePlanPathMessage(), resp.Content)
+	})
+
+	t.Run("NestedPlanPathUnderHomeIsAllowed", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		request := workspacesdk.FileEditRequest{Files: []workspacesdk.FileEdits{{
+			Path: "/home/coder/myproject/plan.md",
+			Edits: []workspacesdk.FileEdit{{
+				Search:  "old",
+				Replace: "new",
+			}},
+		}}}
+		mockConn.EXPECT().EditFiles(gomock.Any(), request).Return(nil)
+
+		planPathCalled := false
+		tool := chattool.EditFiles(chattool.EditFilesOptions{
+			GetWorkspaceConn: func(context.Context) (workspacesdk.AgentConn, error) {
+				return mockConn, nil
+			},
+			ResolvePlanPath: func(context.Context) (string, string, error) {
+				planPathCalled = true
+				return "/home/coder/.coder/plans/PLAN-chat.md", "/home/coder", nil
+			},
+		})
+
+		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "edit_files",
+			Input: `{"files":[{"path":"/home/coder/myproject/plan.md","edits":[{"search":"old","replace":"new"}]}]}`,
+		})
+		require.NoError(t, err)
+		assert.False(t, resp.IsError)
+		assert.True(t, planPathCalled)
 	})
 
 	t.Run("AllowsNonSharedPath", func(t *testing.T) {

--- a/coderd/x/chatd/chattool/editfiles_test.go
+++ b/coderd/x/chatd/chattool/editfiles_test.go
@@ -34,7 +34,7 @@ func TestEditFiles(t *testing.T) {
 			{
 				name: "MultiFileBatchWithHomeRootPlanPath",
 				input: `{"files":[` +
-					`{"path":"/Users/dev/notes.md","edits":[{"search":"old","replace":"new"}]},` +
+					`{"path":"/Users/dev/subdir/plan.md","edits":[{"search":"old","replace":"new"}]},` +
 					`{"path":"/Users/dev/plan.md","edits":[{"search":"old","replace":"new"}]}` +
 					`]}`,
 				expectedRejectedPath: "/Users/dev/plan.md",

--- a/coderd/x/chatd/chattool/editfiles_test.go
+++ b/coderd/x/chatd/chattool/editfiles_test.go
@@ -123,7 +123,7 @@ func TestEditFiles(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, resp.IsError)
 		assert.False(t, resolvePlanPathCalled)
-		assert.Equal(t, relativePlanPathMessage(), resp.Content)
+		assert.Equal(t, editFilesBatchRejectedMessage(relativePlanPathMessage()), resp.Content)
 	})
 
 	t.Run("PerChatPlanPathIsAllowed", func(t *testing.T) {

--- a/coderd/x/chatd/chattool/planpath.go
+++ b/coderd/x/chatd/chattool/planpath.go
@@ -53,6 +53,8 @@ func PlanPathForChat(home string, chatID uuid.UUID) string {
 	)
 }
 
+// looksLikePlanFileName reports whether the base name of requestedPath
+// is "plan.md" (case-insensitive), ignoring the directory component.
 func looksLikePlanFileName(requestedPath string) bool {
 	cleaned := path.Clean(strings.ReplaceAll(requestedPath, "\\", "/"))
 	return strings.EqualFold(path.Base(cleaned), "plan.md")
@@ -61,9 +63,11 @@ func looksLikePlanFileName(requestedPath string) bool {
 // LooksLikeHomePlanFile reports whether requestedPath is a plan.md
 // variant (case-insensitive) sitting directly in the workspace home
 // directory.
+// The filename is compared case-insensitively because LLM output varies.
+// The directory is compared exactly because it comes from the system.
 func LooksLikeHomePlanFile(requestedPath, home string) bool {
 	// Normalize backslashes so Windows workspace paths (for example,
-	// C:\Users\coder\PLAN.md) are handled correctly. The chatd server
+	// C:\\Users\\coder\\PLAN.md) are handled correctly. The chatd server
 	// runs on Linux, so path.Clean alone only parses forward slashes.
 	normalized := path.Clean(strings.ReplaceAll(requestedPath, "\\", "/"))
 	normalizedHome := path.Clean(strings.ReplaceAll(home, "\\", "/"))

--- a/coderd/x/chatd/chattool/planpath.go
+++ b/coderd/x/chatd/chattool/planpath.go
@@ -1,0 +1,60 @@
+package chattool
+
+import (
+	"context"
+	"path"
+	"strings"
+
+	"github.com/google/uuid"
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/codersdk/workspacesdk"
+)
+
+const planFileNamePrefix = "PLAN-"
+
+// LegacySharedPlanPath is the original shared plan file path used by
+// every chat in a workspace.
+const LegacySharedPlanPath = "/home/coder/PLAN.md"
+
+// ResolveWorkspaceHome returns the workspace user's home directory.
+func ResolveWorkspaceHome(
+	ctx context.Context,
+	conn workspacesdk.AgentConn,
+) (string, error) {
+	if conn == nil {
+		return "", xerrors.New("workspace connection is required")
+	}
+
+	resp, err := conn.LS(ctx, "", workspacesdk.LSRequest{
+		Path:       []string{},
+		Relativity: workspacesdk.LSRelativityHome,
+	})
+	if err != nil {
+		return "", xerrors.Errorf("resolve workspace home: %w", err)
+	}
+
+	home := strings.TrimSpace(resp.AbsolutePathString)
+	if home == "" {
+		return "", xerrors.New("workspace home path is empty")
+	}
+
+	return home, nil
+}
+
+// PlanPathForChat returns the per-chat plan file path rooted in the
+// workspace home directory.
+func PlanPathForChat(home string, chatID uuid.UUID) string {
+	return path.Join(
+		home,
+		".coder",
+		"plans",
+		planFileNamePrefix+chatID.String()+".md",
+	)
+}
+
+// IsLegacySharedPlanPath reports whether requested is the exact legacy
+// shared plan file path.
+func IsLegacySharedPlanPath(requested string) bool {
+	return requested == LegacySharedPlanPath
+}

--- a/coderd/x/chatd/chattool/planpath.go
+++ b/coderd/x/chatd/chattool/planpath.go
@@ -2,7 +2,7 @@ package chattool
 
 import (
 	"context"
-	"path"
+	pathpkg "path"
 	"strings"
 
 	"github.com/google/uuid"
@@ -45,7 +45,7 @@ func ResolveWorkspaceHome(
 // PlanPathForChat returns the per-chat plan file path rooted in the
 // workspace home directory.
 func PlanPathForChat(home string, chatID uuid.UUID) string {
-	return path.Join(
+	return pathpkg.Join(
 		home,
 		".coder",
 		"plans",
@@ -53,11 +53,27 @@ func PlanPathForChat(home string, chatID uuid.UUID) string {
 	)
 }
 
+// isAbsolutePath reports whether p is an absolute path on either
+// POSIX or Windows. Since chatd runs on Linux, the POSIX
+// absolute-path check only recognizes forward-slash roots. This
+// also detects Windows drive letter prefixes (for example, C:\ or
+// C:/).
+func isAbsolutePath(p string) bool {
+	if pathpkg.IsAbs(p) {
+		return true
+	}
+	if len(p) >= 3 && p[1] == ':' && (p[2] == '/' || p[2] == '\\') {
+		c := p[0]
+		return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+	}
+	return false
+}
+
 // looksLikePlanFileName reports whether the base name of requestedPath
 // is "plan.md" (case-insensitive), ignoring the directory component.
 func looksLikePlanFileName(requestedPath string) bool {
-	cleaned := path.Clean(strings.ReplaceAll(requestedPath, "\\", "/"))
-	return strings.EqualFold(path.Base(cleaned), "plan.md")
+	cleaned := pathpkg.Clean(strings.ReplaceAll(requestedPath, "\\", "/"))
+	return strings.EqualFold(pathpkg.Base(cleaned), "plan.md")
 }
 
 // LooksLikeHomePlanFile reports whether requestedPath is a plan.md
@@ -68,12 +84,12 @@ func looksLikePlanFileName(requestedPath string) bool {
 func LooksLikeHomePlanFile(requestedPath, home string) bool {
 	// Normalize backslashes so Windows workspace paths (for example,
 	// C:\\Users\\coder\\PLAN.md) are handled correctly. The chatd server
-	// runs on Linux, so path.Clean alone only parses forward slashes.
-	normalized := path.Clean(strings.ReplaceAll(requestedPath, "\\", "/"))
-	normalizedHome := path.Clean(strings.ReplaceAll(home, "\\", "/"))
+	// runs on Linux, so the POSIX cleaner alone only parses forward slashes.
+	normalized := pathpkg.Clean(strings.ReplaceAll(requestedPath, "\\", "/"))
+	normalizedHome := pathpkg.Clean(strings.ReplaceAll(home, "\\", "/"))
 
 	return looksLikePlanFileName(normalized) &&
-		path.Dir(normalized) == normalizedHome
+		pathpkg.Dir(normalized) == normalizedHome
 }
 
 // IsLegacySharedPlanPath reports whether requested is the exact legacy

--- a/coderd/x/chatd/chattool/planpath.go
+++ b/coderd/x/chatd/chattool/planpath.go
@@ -2,7 +2,7 @@ package chattool
 
 import (
 	"context"
-	pathpkg "path"
+	"path"
 	"strings"
 
 	"github.com/google/uuid"
@@ -45,7 +45,7 @@ func ResolveWorkspaceHome(
 // PlanPathForChat returns the per-chat plan file path rooted in the
 // workspace home directory.
 func PlanPathForChat(home string, chatID uuid.UUID) string {
-	return pathpkg.Join(
+	return path.Join(
 		home,
 		".coder",
 		"plans",
@@ -53,51 +53,38 @@ func PlanPathForChat(home string, chatID uuid.UUID) string {
 	)
 }
 
-// isAbsolutePath reports whether p is an absolute path on either
-// POSIX or Windows. Since chatd runs on Linux, the POSIX
-// absolute-path check only recognizes forward-slash roots. This
-// also detects Windows drive letter prefixes (for example, C:\ or
-// C:/).
+// chatd consumes agent-normalized POSIX paths. Workspace agents are
+// expected to convert separators to forward slashes before these
+// helpers run.
+
+// isAbsolutePath reports whether p is an absolute POSIX path.
 func isAbsolutePath(p string) bool {
-	if pathpkg.IsAbs(p) {
-		return true
-	}
-	if len(p) >= 3 && p[1] == ':' && (p[2] == '/' || p[2] == '\\') {
-		c := p[0]
-		return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
-	}
-	return false
+	return path.IsAbs(p)
 }
 
 // looksLikePlanFileName reports whether the base name of requestedPath
 // is "plan.md" (case-insensitive), ignoring the directory component.
 func looksLikePlanFileName(requestedPath string) bool {
-	cleaned := pathpkg.Clean(strings.ReplaceAll(requestedPath, "\\", "/"))
-	return strings.EqualFold(pathpkg.Base(cleaned), "plan.md")
+	cleaned := path.Clean(requestedPath)
+	return strings.EqualFold(path.Base(cleaned), "plan.md")
 }
 
 // LooksLikeHomePlanFile reports whether requestedPath is a plan.md
 // variant (case-insensitive) sitting directly in the workspace home
 // directory.
 // The filename is compared case-insensitively because LLM output varies.
-// The directory comparison also ignores case so Windows drive-letter
-// casing mismatches do not bypass the guard.
 func LooksLikeHomePlanFile(requestedPath, home string) bool {
-	// Normalize backslashes so Windows workspace paths (for example,
-	// C:\\Users\\coder\\PLAN.md) are handled correctly. The chatd server
-	// runs on Linux, so the POSIX cleaner alone only parses forward slashes.
-	normalized := pathpkg.Clean(strings.ReplaceAll(requestedPath, "\\", "/"))
-	normalizedHome := pathpkg.Clean(strings.ReplaceAll(home, "\\", "/"))
+	normalized := path.Clean(requestedPath)
+	normalizedHome := path.Clean(home)
 
 	return looksLikePlanFileName(normalized) &&
-		strings.EqualFold(pathpkg.Dir(normalized), normalizedHome)
+		strings.EqualFold(path.Dir(normalized), normalizedHome)
 }
 
 // looksLikeLegacySharedPlanPath reports whether requestedPath
-// matches the legacy shared plan path (case-insensitive, with
-// backslash normalization). Used as a narrow fallback when the
-// workspace home cannot be resolved.
+// matches the legacy shared plan path (case-insensitive). Used as a
+// narrow fallback when the workspace home cannot be resolved.
 func looksLikeLegacySharedPlanPath(requestedPath string) bool {
-	normalized := pathpkg.Clean(strings.ReplaceAll(requestedPath, "\\", "/"))
+	normalized := path.Clean(requestedPath)
 	return strings.EqualFold(normalized, LegacySharedPlanPath)
 }

--- a/coderd/x/chatd/chattool/planpath.go
+++ b/coderd/x/chatd/chattool/planpath.go
@@ -54,7 +54,7 @@ func PlanPathForChat(home string, chatID uuid.UUID) string {
 }
 
 func looksLikePlanFileName(requestedPath string) bool {
-	cleaned := path.Clean(requestedPath)
+	cleaned := path.Clean(strings.ReplaceAll(requestedPath, "\\", "/"))
 	return strings.EqualFold(path.Base(cleaned), "plan.md")
 }
 

--- a/coderd/x/chatd/chattool/planpath.go
+++ b/coderd/x/chatd/chattool/planpath.go
@@ -93,6 +93,11 @@ func LooksLikeHomePlanFile(requestedPath, home string) bool {
 		strings.EqualFold(pathpkg.Dir(normalized), normalizedHome)
 }
 
-func isLegacySharedPlanPath(requested string) bool {
-	return requested == LegacySharedPlanPath
+// looksLikeLegacySharedPlanPath reports whether requestedPath
+// matches the legacy shared plan path (case-insensitive, with
+// backslash normalization). Used as a narrow fallback when the
+// workspace home cannot be resolved.
+func looksLikeLegacySharedPlanPath(requestedPath string) bool {
+	normalized := pathpkg.Clean(strings.ReplaceAll(requestedPath, "\\", "/"))
+	return strings.EqualFold(normalized, LegacySharedPlanPath)
 }

--- a/coderd/x/chatd/chattool/planpath.go
+++ b/coderd/x/chatd/chattool/planpath.go
@@ -80,7 +80,8 @@ func looksLikePlanFileName(requestedPath string) bool {
 // variant (case-insensitive) sitting directly in the workspace home
 // directory.
 // The filename is compared case-insensitively because LLM output varies.
-// The directory is compared exactly because it comes from the system.
+// The directory comparison also ignores case so Windows drive-letter
+// casing mismatches do not bypass the guard.
 func LooksLikeHomePlanFile(requestedPath, home string) bool {
 	// Normalize backslashes so Windows workspace paths (for example,
 	// C:\\Users\\coder\\PLAN.md) are handled correctly. The chatd server
@@ -89,7 +90,7 @@ func LooksLikeHomePlanFile(requestedPath, home string) bool {
 	normalizedHome := pathpkg.Clean(strings.ReplaceAll(home, "\\", "/"))
 
 	return looksLikePlanFileName(normalized) &&
-		pathpkg.Dir(normalized) == normalizedHome
+		strings.EqualFold(pathpkg.Dir(normalized), normalizedHome)
 }
 
 func isLegacySharedPlanPath(requested string) bool {

--- a/coderd/x/chatd/chattool/planpath.go
+++ b/coderd/x/chatd/chattool/planpath.go
@@ -53,6 +53,22 @@ func PlanPathForChat(home string, chatID uuid.UUID) string {
 	)
 }
 
+func looksLikePlanFileName(requestedPath string) bool {
+	cleaned := path.Clean(requestedPath)
+	return strings.EqualFold(path.Base(cleaned), "plan.md")
+}
+
+// LooksLikeHomePlanFile reports whether requestedPath is a plan.md
+// variant (case-insensitive) sitting directly in the workspace home
+// directory.
+func LooksLikeHomePlanFile(requestedPath, home string) bool {
+	cleaned := path.Clean(requestedPath)
+	cleanedHome := path.Clean(home)
+
+	return looksLikePlanFileName(cleaned) &&
+		path.Dir(cleaned) == cleanedHome
+}
+
 // IsLegacySharedPlanPath reports whether requested is the exact legacy
 // shared plan file path.
 func IsLegacySharedPlanPath(requested string) bool {

--- a/coderd/x/chatd/chattool/planpath.go
+++ b/coderd/x/chatd/chattool/planpath.go
@@ -92,8 +92,6 @@ func LooksLikeHomePlanFile(requestedPath, home string) bool {
 		pathpkg.Dir(normalized) == normalizedHome
 }
 
-// IsLegacySharedPlanPath reports whether requested is the exact legacy
-// shared plan file path.
-func IsLegacySharedPlanPath(requested string) bool {
+func isLegacySharedPlanPath(requested string) bool {
 	return requested == LegacySharedPlanPath
 }

--- a/coderd/x/chatd/chattool/planpath.go
+++ b/coderd/x/chatd/chattool/planpath.go
@@ -62,11 +62,14 @@ func looksLikePlanFileName(requestedPath string) bool {
 // variant (case-insensitive) sitting directly in the workspace home
 // directory.
 func LooksLikeHomePlanFile(requestedPath, home string) bool {
-	cleaned := path.Clean(requestedPath)
-	cleanedHome := path.Clean(home)
+	// Normalize backslashes so Windows workspace paths (for example,
+	// C:\Users\coder\PLAN.md) are handled correctly. The chatd server
+	// runs on Linux, so path.Clean alone only parses forward slashes.
+	normalized := path.Clean(strings.ReplaceAll(requestedPath, "\\", "/"))
+	normalizedHome := path.Clean(strings.ReplaceAll(home, "\\", "/"))
 
-	return looksLikePlanFileName(cleaned) &&
-		path.Dir(cleaned) == cleanedHome
+	return looksLikePlanFileName(normalized) &&
+		path.Dir(normalized) == normalizedHome
 }
 
 // IsLegacySharedPlanPath reports whether requested is the exact legacy

--- a/coderd/x/chatd/chattool/planpath_internal_test.go
+++ b/coderd/x/chatd/chattool/planpath_internal_test.go
@@ -91,6 +91,28 @@ func TestLooksLikeLegacySharedPlanPath(t *testing.T) {
 	}
 }
 
+func TestRejectSharedPlanPath(t *testing.T) {
+	t.Parallel()
+
+	resp, rejected := rejectSharedPlanPath(
+		LegacySharedPlanPath,
+		"/Users/dev",
+		"/Users/dev/.coder/plans/PLAN-chat.md",
+		nil,
+	)
+
+	require.True(t, rejected)
+	require.True(t, resp.IsError)
+	require.Equal(
+		t,
+		sharedPlanPathMessage(
+			LegacySharedPlanPath,
+			"/Users/dev/.coder/plans/PLAN-chat.md",
+		),
+		resp.Content,
+	)
+}
+
 func TestSharedPlanPathMessage(t *testing.T) {
 	t.Parallel()
 

--- a/coderd/x/chatd/chattool/planpath_internal_test.go
+++ b/coderd/x/chatd/chattool/planpath_internal_test.go
@@ -1,0 +1,15 @@
+package chattool
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLooksLikePlanFileName(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, looksLikePlanFileName(`C:\Users\coder\PLAN.md`))
+	require.True(t, looksLikePlanFileName(`C:\Users\coder\plan.md`))
+	require.False(t, looksLikePlanFileName(`C:\Users\coder\README.md`))
+}

--- a/coderd/x/chatd/chattool/planpath_internal_test.go
+++ b/coderd/x/chatd/chattool/planpath_internal_test.go
@@ -14,9 +14,7 @@ func TestIsAbsolutePath(t *testing.T) {
 		want bool
 	}{
 		{"/home/coder/PLAN.md", true},
-		{`C:\\Users\\coder\\PLAN.md`, true},
-		{"C:/Users/coder/PLAN.md", true},
-		{`d:\\data\\plan.md`, true},
+		{"/workspace/project/plan.md", true},
 		{"plan.md", false},
 		{"./plan.md", false},
 		{"../plan.md", false},
@@ -36,15 +34,8 @@ func TestLooksLikePlanFileName(t *testing.T) {
 
 	require.True(t, looksLikePlanFileName("plan.md"))
 	require.True(t, looksLikePlanFileName("./Plan.md"))
-	require.True(t, looksLikePlanFileName(`C:\\Users\\coder\\PLAN.md`))
-	require.True(t, looksLikePlanFileName(`C:\\Users\\coder\\plan.md`))
-	require.False(t, looksLikePlanFileName(`C:\\Users\\coder\\README.md`))
-}
-
-func TestLooksLikeHomePlanFileWindowsDriveLetterCaseMismatch(t *testing.T) {
-	t.Parallel()
-
-	require.True(t, LooksLikeHomePlanFile("C:/Users/coder/plan.md", "c:/Users/coder"))
+	require.True(t, looksLikePlanFileName("/home/coder/PLAN.md"))
+	require.False(t, looksLikePlanFileName("/home/coder/README.md"))
 }
 
 func TestLooksLikeLegacySharedPlanPath(t *testing.T) {

--- a/coderd/x/chatd/chattool/planpath_internal_test.go
+++ b/coderd/x/chatd/chattool/planpath_internal_test.go
@@ -41,6 +41,12 @@ func TestLooksLikePlanFileName(t *testing.T) {
 	require.False(t, looksLikePlanFileName(`C:\\Users\\coder\\README.md`))
 }
 
+func TestLooksLikeHomePlanFileWindowsDriveLetterCaseMismatch(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, LooksLikeHomePlanFile("C:/Users/coder/plan.md", "c:/Users/coder"))
+}
+
 func TestIsLegacySharedPlanPath(t *testing.T) {
 	t.Parallel()
 

--- a/coderd/x/chatd/chattool/planpath_internal_test.go
+++ b/coderd/x/chatd/chattool/planpath_internal_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/xerrors"
 )
 
 func TestIsAbsolutePath(t *testing.T) {
@@ -15,9 +14,9 @@ func TestIsAbsolutePath(t *testing.T) {
 		want bool
 	}{
 		{"/home/coder/PLAN.md", true},
-		{`C:\Users\coder\PLAN.md`, true},
+		{`C:\\Users\\coder\\PLAN.md`, true},
 		{"C:/Users/coder/PLAN.md", true},
-		{`d:\data\plan.md`, true},
+		{`d:\\data\\plan.md`, true},
 		{"plan.md", false},
 		{"./plan.md", false},
 		{"../plan.md", false},
@@ -42,6 +41,57 @@ func TestLooksLikePlanFileName(t *testing.T) {
 	require.False(t, looksLikePlanFileName(`C:\\Users\\coder\\README.md`))
 }
 
+func TestIsLegacySharedPlanPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		requested string
+		want      bool
+	}{
+		{
+			name:      "ExactMatch",
+			requested: "/home/coder/PLAN.md",
+			want:      true,
+		},
+		{
+			name:      "DifferentFilename",
+			requested: "/home/coder/OTHER.md",
+			want:      false,
+		},
+		{
+			name:      "DifferentDirectory",
+			requested: "/home/dev/PLAN.md",
+			want:      false,
+		},
+		{
+			name:      "PerChatPath",
+			requested: "/home/coder/.coder/plans/PLAN-123e4567-e89b-12d3-a456-426614174000.md",
+			want:      false,
+		},
+		{
+			name:      "EmptyString",
+			requested: "",
+			want:      false,
+		},
+		{
+			name:      "SubstringMatch",
+			requested: "/home/coder/PLAN.md/extra",
+			want:      false,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := isLegacySharedPlanPath(testCase.requested)
+
+			require.Equal(t, testCase.want, got)
+		})
+	}
+}
+
 func TestLooksLikeLegacyHomePlanPath(t *testing.T) {
 	t.Parallel()
 
@@ -59,16 +109,11 @@ func TestSharedPlanPathMessage(t *testing.T) {
 		sharedPlanPathMessage(
 			"/home/coder/plan.md",
 			"/home/coder/.coder/plans/PLAN-chat.md",
-			nil,
 		),
 	)
 	require.Equal(
 		t,
-		"the plan path /home/coder/plan.md is no longer supported at the home root; the workspace is currently unavailable to resolve the chat-specific plan path, try again shortly",
-		sharedPlanPathMessage(
-			"/home/coder/plan.md",
-			"",
-			xerrors.New("workspace unavailable"),
-		),
+		"the plan path /home/coder/plan.md could not be verified because the workspace is currently unavailable to resolve the chat-specific plan path, try again shortly",
+		planPathVerificationMessage("/home/coder/plan.md"),
 	)
 }

--- a/coderd/x/chatd/chattool/planpath_internal_test.go
+++ b/coderd/x/chatd/chattool/planpath_internal_test.go
@@ -4,12 +4,46 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
 )
 
 func TestLooksLikePlanFileName(t *testing.T) {
 	t.Parallel()
 
-	require.True(t, looksLikePlanFileName(`C:\Users\coder\PLAN.md`))
-	require.True(t, looksLikePlanFileName(`C:\Users\coder\plan.md`))
-	require.False(t, looksLikePlanFileName(`C:\Users\coder\README.md`))
+	require.True(t, looksLikePlanFileName("plan.md"))
+	require.True(t, looksLikePlanFileName("./Plan.md"))
+	require.True(t, looksLikePlanFileName(`C:\\Users\\coder\\PLAN.md`))
+	require.True(t, looksLikePlanFileName(`C:\\Users\\coder\\plan.md`))
+	require.False(t, looksLikePlanFileName(`C:\\Users\\coder\\README.md`))
+}
+
+func TestLooksLikeLegacyHomePlanPath(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, looksLikeLegacyHomePlanPath(LegacySharedPlanPath, ""))
+	require.True(t, looksLikeLegacyHomePlanPath("/home/coder/plan.md", ""))
+	require.False(t, looksLikeLegacyHomePlanPath("/home/coder/notes.md", ""))
+}
+
+func TestSharedPlanPathMessage(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(
+		t,
+		"the plan path /home/coder/plan.md is no longer supported at the home root; use the chat-specific plan path: /home/coder/.coder/plans/PLAN-chat.md",
+		sharedPlanPathMessage(
+			"/home/coder/plan.md",
+			"/home/coder/.coder/plans/PLAN-chat.md",
+			nil,
+		),
+	)
+	require.Equal(
+		t,
+		"the plan path /home/coder/plan.md is no longer supported at the home root; the workspace is currently unavailable to resolve the chat-specific plan path, try again shortly",
+		sharedPlanPathMessage(
+			"/home/coder/plan.md",
+			"",
+			xerrors.New("workspace unavailable"),
+		),
+	)
 }

--- a/coderd/x/chatd/chattool/planpath_internal_test.go
+++ b/coderd/x/chatd/chattool/planpath_internal_test.go
@@ -47,7 +47,7 @@ func TestLooksLikeHomePlanFileWindowsDriveLetterCaseMismatch(t *testing.T) {
 	require.True(t, LooksLikeHomePlanFile("C:/Users/coder/plan.md", "c:/Users/coder"))
 }
 
-func TestIsLegacySharedPlanPath(t *testing.T) {
+func TestLooksLikeLegacySharedPlanPath(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -61,13 +61,23 @@ func TestIsLegacySharedPlanPath(t *testing.T) {
 			want:      true,
 		},
 		{
-			name:      "DifferentFilename",
-			requested: "/home/coder/OTHER.md",
+			name:      "CaseInsensitive",
+			requested: "/home/coder/plan.md",
+			want:      true,
+		},
+		{
+			name:      "MixedCase",
+			requested: "/home/coder/Plan.md",
+			want:      true,
+		},
+		{
+			name:      "NestedPath",
+			requested: "/home/coder/myproject/plan.md",
 			want:      false,
 		},
 		{
-			name:      "DifferentDirectory",
-			requested: "/home/dev/PLAN.md",
+			name:      "DifferentHome",
+			requested: "/Users/dev/PLAN.md",
 			want:      false,
 		},
 		{
@@ -80,30 +90,14 @@ func TestIsLegacySharedPlanPath(t *testing.T) {
 			requested: "",
 			want:      false,
 		},
-		{
-			name:      "SubstringMatch",
-			requested: "/home/coder/PLAN.md/extra",
-			want:      false,
-		},
 	}
 
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
-
-			got := isLegacySharedPlanPath(testCase.requested)
-
-			require.Equal(t, testCase.want, got)
+			require.Equal(t, testCase.want, looksLikeLegacySharedPlanPath(testCase.requested))
 		})
 	}
-}
-
-func TestLooksLikeLegacyHomePlanPath(t *testing.T) {
-	t.Parallel()
-
-	require.True(t, looksLikeLegacyHomePlanPath(LegacySharedPlanPath, ""))
-	require.True(t, looksLikeLegacyHomePlanPath("/home/coder/plan.md", ""))
-	require.False(t, looksLikeLegacyHomePlanPath("/home/coder/notes.md", ""))
 }
 
 func TestSharedPlanPathMessage(t *testing.T) {

--- a/coderd/x/chatd/chattool/planpath_internal_test.go
+++ b/coderd/x/chatd/chattool/planpath_internal_test.go
@@ -7,6 +7,31 @@ import (
 	"golang.org/x/xerrors"
 )
 
+func TestIsAbsolutePath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"/home/coder/PLAN.md", true},
+		{`C:\Users\coder\PLAN.md`, true},
+		{"C:/Users/coder/PLAN.md", true},
+		{`d:\data\plan.md`, true},
+		{"plan.md", false},
+		{"./plan.md", false},
+		{"../plan.md", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, isAbsolutePath(tt.path))
+		})
+	}
+}
+
 func TestLooksLikePlanFileName(t *testing.T) {
 	t.Parallel()
 

--- a/coderd/x/chatd/chattool/planpath_test.go
+++ b/coderd/x/chatd/chattool/planpath_test.go
@@ -270,4 +270,13 @@ func TestLooksLikeHomePlanFile(t *testing.T) {
 			require.Equal(t, testCase.want, got)
 		})
 	}
+
+	t.Run("WindowsBackslashPaths", func(t *testing.T) {
+		t.Parallel()
+
+		require.True(t, chattool.LooksLikeHomePlanFile(`C:\Users\coder\PLAN.md`, `C:\Users\coder`))
+		require.True(t, chattool.LooksLikeHomePlanFile(`C:\Users\coder\plan.md`, `C:\Users\coder`))
+		require.False(t, chattool.LooksLikeHomePlanFile(`C:\Users\coder\project\plan.md`, `C:\Users\coder`))
+		require.True(t, chattool.LooksLikeHomePlanFile("C:/Users/coder/PLAN.md", `C:\Users\coder`))
+	})
 }

--- a/coderd/x/chatd/chattool/planpath_test.go
+++ b/coderd/x/chatd/chattool/planpath_test.go
@@ -130,57 +130,6 @@ func TestPlanPathForChat(t *testing.T) {
 	})
 }
 
-func TestIsLegacySharedPlanPath(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name      string
-		requested string
-		want      bool
-	}{
-		{
-			name:      "ExactMatch",
-			requested: "/home/coder/PLAN.md",
-			want:      true,
-		},
-		{
-			name:      "DifferentFilename",
-			requested: "/home/coder/OTHER.md",
-			want:      false,
-		},
-		{
-			name:      "DifferentDirectory",
-			requested: "/home/dev/PLAN.md",
-			want:      false,
-		},
-		{
-			name:      "PerChatPath",
-			requested: "/home/coder/.coder/plans/PLAN-123e4567-e89b-12d3-a456-426614174000.md",
-			want:      false,
-		},
-		{
-			name:      "EmptyString",
-			requested: "",
-			want:      false,
-		},
-		{
-			name:      "SubstringMatch",
-			requested: "/home/coder/PLAN.md/extra",
-			want:      false,
-		},
-	}
-
-	for _, testCase := range tests {
-		t.Run(testCase.name, func(t *testing.T) {
-			t.Parallel()
-
-			got := chattool.IsLegacySharedPlanPath(testCase.requested)
-
-			require.Equal(t, testCase.want, got)
-		})
-	}
-}
-
 func TestLooksLikeHomePlanFile(t *testing.T) {
 	t.Parallel()
 

--- a/coderd/x/chatd/chattool/planpath_test.go
+++ b/coderd/x/chatd/chattool/planpath_test.go
@@ -1,0 +1,184 @@
+package chattool_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/coderd/x/chatd/chattool"
+	"github.com/coder/coder/v2/codersdk/workspacesdk"
+	"github.com/coder/coder/v2/codersdk/workspacesdk/agentconnmock"
+)
+
+func TestResolveWorkspaceHome(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		resp     workspacesdk.LSResponse
+		lsErr    error
+		want     string
+		wantErr  bool
+		errMatch string
+	}{
+		{
+			name: "StandardLinuxHome",
+			resp: workspacesdk.LSResponse{AbsolutePathString: "/home/coder"},
+			want: "/home/coder",
+		},
+		{
+			name: "NonStandardHome",
+			resp: workspacesdk.LSResponse{AbsolutePathString: "/Users/dev"},
+			want: "/Users/dev",
+		},
+		{
+			name:     "LSError",
+			lsErr:    xerrors.New("list failed"),
+			wantErr:  true,
+			errMatch: "list failed",
+		},
+		{
+			name:     "EmptyAbsolutePathString",
+			resp:     workspacesdk.LSResponse{AbsolutePathString: ""},
+			wantErr:  true,
+			errMatch: "workspace home path is empty",
+		},
+		{
+			name:     "WhitespaceOnlyAbsolutePathString",
+			resp:     workspacesdk.LSResponse{AbsolutePathString: " \t\n "},
+			wantErr:  true,
+			errMatch: "workspace home path is empty",
+		},
+	}
+
+	for _, testCase := range tests {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			conn := agentconnmock.NewMockAgentConn(ctrl)
+
+			conn.EXPECT().LS(
+				gomock.Any(),
+				"",
+				workspacesdk.LSRequest{
+					Path:       []string{},
+					Relativity: workspacesdk.LSRelativityHome,
+				},
+			).Return(testCase.resp, testCase.lsErr)
+
+			got, err := chattool.ResolveWorkspaceHome(context.Background(), conn)
+			if testCase.wantErr {
+				require.Error(t, err)
+				require.ErrorContains(t, err, testCase.errMatch)
+				require.Empty(t, got)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, testCase.want, got)
+		})
+	}
+}
+
+func TestPlanPathForChat(t *testing.T) {
+	t.Parallel()
+
+	t.Run("StandardHome", func(t *testing.T) {
+		t.Parallel()
+
+		chatID := uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")
+
+		got := chattool.PlanPathForChat("/home/coder", chatID)
+
+		require.Equal(
+			t,
+			"/home/coder/.coder/plans/PLAN-123e4567-e89b-12d3-a456-426614174000.md",
+			got,
+		)
+	})
+
+	t.Run("NonStandardHome", func(t *testing.T) {
+		t.Parallel()
+
+		chatID := uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+
+		got := chattool.PlanPathForChat("/Users/dev", chatID)
+
+		require.Equal(
+			t,
+			"/Users/dev/.coder/plans/PLAN-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.md",
+			got,
+		)
+	})
+
+	t.Run("MatchesExpectedFormat", func(t *testing.T) {
+		t.Parallel()
+
+		home := "/workspace/home"
+		chatID := uuid.MustParse("f47ac10b-58cc-4372-a567-0e02b2c3d479")
+
+		got := chattool.PlanPathForChat(home, chatID)
+
+		require.True(t, strings.HasPrefix(got, home+"/.coder/plans/PLAN-"))
+		require.True(t, strings.HasSuffix(got, chatID.String()+".md"))
+	})
+}
+
+func TestIsLegacySharedPlanPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		requested string
+		want      bool
+	}{
+		{
+			name:      "ExactMatch",
+			requested: "/home/coder/PLAN.md",
+			want:      true,
+		},
+		{
+			name:      "DifferentFilename",
+			requested: "/home/coder/OTHER.md",
+			want:      false,
+		},
+		{
+			name:      "DifferentDirectory",
+			requested: "/home/dev/PLAN.md",
+			want:      false,
+		},
+		{
+			name:      "PerChatPath",
+			requested: "/home/coder/.coder/plans/PLAN-123e4567-e89b-12d3-a456-426614174000.md",
+			want:      false,
+		},
+		{
+			name:      "EmptyString",
+			requested: "",
+			want:      false,
+		},
+		{
+			name:      "SubstringMatch",
+			requested: "/home/coder/PLAN.md/extra",
+			want:      false,
+		},
+	}
+
+	for _, testCase := range tests {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := chattool.IsLegacySharedPlanPath(testCase.requested)
+
+			require.Equal(t, testCase.want, got)
+		})
+	}
+}

--- a/coderd/x/chatd/chattool/planpath_test.go
+++ b/coderd/x/chatd/chattool/planpath_test.go
@@ -182,3 +182,92 @@ func TestIsLegacySharedPlanPath(t *testing.T) {
 		})
 	}
 }
+
+func TestLooksLikeHomePlanFile(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		requested string
+		home      string
+		want      bool
+	}{
+		{
+			name:      "UppercaseHomeRootPlan",
+			requested: "/home/coder/PLAN.md",
+			home:      "/home/coder",
+			want:      true,
+		},
+		{
+			name:      "LowercaseHomeRootPlan",
+			requested: "/home/coder/plan.md",
+			home:      "/home/coder",
+			want:      true,
+		},
+		{
+			name:      "MixedCaseHomeRootPlan",
+			requested: "/home/coder/Plan.md",
+			home:      "/home/coder",
+			want:      true,
+		},
+		{
+			name:      "UppercaseExtension",
+			requested: "/home/coder/PLAN.MD",
+			home:      "/home/coder",
+			want:      true,
+		},
+		{
+			name:      "CustomHomeRootPlan",
+			requested: "/Users/dev/plan.md",
+			home:      "/Users/dev",
+			want:      true,
+		},
+		{
+			name:      "NestedPlanUnderHome",
+			requested: "/home/coder/myproject/plan.md",
+			home:      "/home/coder",
+			want:      false,
+		},
+		{
+			name:      "PerChatPlanPath",
+			requested: "/home/coder/.coder/plans/PLAN-123e4567-e89b-12d3-a456-426614174000.md",
+			home:      "/home/coder",
+			want:      false,
+		},
+		{
+			name:      "DifferentFilename",
+			requested: "/home/coder/README.md",
+			home:      "/home/coder",
+			want:      false,
+		},
+		{
+			name:      "DifferentExtension",
+			requested: "/home/coder/plan.txt",
+			home:      "/home/coder",
+			want:      false,
+		},
+		{
+			name:      "EmptyPath",
+			requested: "",
+			home:      "/home/coder",
+			want:      false,
+		},
+		{
+			name:      "DifferentHomeMismatch",
+			requested: "/home/coder/plan.md",
+			home:      "/Users/dev",
+			want:      false,
+		},
+	}
+
+	for _, testCase := range tests {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := chattool.LooksLikeHomePlanFile(testCase.requested, testCase.home)
+
+			require.Equal(t, testCase.want, got)
+		})
+	}
+}

--- a/coderd/x/chatd/chattool/planpath_test.go
+++ b/coderd/x/chatd/chattool/planpath_test.go
@@ -216,13 +216,4 @@ func TestLooksLikeHomePlanFile(t *testing.T) {
 			require.Equal(t, testCase.want, got)
 		})
 	}
-
-	t.Run("WindowsBackslashPaths", func(t *testing.T) {
-		t.Parallel()
-
-		require.True(t, chattool.LooksLikeHomePlanFile(`C:\Users\coder\PLAN.md`, `C:\Users\coder`))
-		require.True(t, chattool.LooksLikeHomePlanFile(`C:\Users\coder\plan.md`, `C:\Users\coder`))
-		require.False(t, chattool.LooksLikeHomePlanFile(`C:\Users\coder\project\plan.md`, `C:\Users\coder`))
-		require.True(t, chattool.LooksLikeHomePlanFile("C:/Users/coder/PLAN.md", `C:\Users\coder`))
-	})
 }

--- a/coderd/x/chatd/chattool/planpath_test.go
+++ b/coderd/x/chatd/chattool/planpath_test.go
@@ -57,7 +57,6 @@ func TestResolveWorkspaceHome(t *testing.T) {
 	}
 
 	for _, testCase := range tests {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -172,7 +171,6 @@ func TestIsLegacySharedPlanPath(t *testing.T) {
 	}
 
 	for _, testCase := range tests {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -261,7 +259,6 @@ func TestLooksLikeHomePlanFile(t *testing.T) {
 	}
 
 	for _, testCase := range tests {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/coderd/x/chatd/chattool/planpathmessage.go
+++ b/coderd/x/chatd/chattool/planpathmessage.go
@@ -6,10 +6,13 @@ import (
 	"charm.land/fantasy"
 )
 
+// rejectSharedPlanPath reports whether requestedPath targets the shared
+// home-root plan file and, if so, returns a rejection response that
+// points callers at the chat-specific plan path.
 func rejectSharedPlanPath(
 	requestedPath string,
 	home string,
-	planPath string,
+	chatPath string,
 	planPathErr error,
 ) (fantasy.ToolResponse, bool) {
 	if planPathErr != nil {
@@ -26,20 +29,20 @@ func rejectSharedPlanPath(
 		), true
 	}
 
-	if !LooksLikeHomePlanFile(requestedPath, home) {
+	if !LooksLikeHomePlanFile(requestedPath, home) && !looksLikeLegacySharedPlanPath(requestedPath) {
 		return fantasy.ToolResponse{}, false
 	}
 
 	return fantasy.NewTextErrorResponse(
-		sharedPlanPathMessage(requestedPath, planPath),
+		sharedPlanPathMessage(requestedPath, chatPath),
 	), true
 }
 
-func sharedPlanPathMessage(requestedPath, planPath string) string {
+func sharedPlanPathMessage(requestedPath, chatPath string) string {
 	return fmt.Sprintf(
 		"the plan path %s is no longer supported at the home root; use the chat-specific plan path: %s",
 		requestedPath,
-		planPath,
+		chatPath,
 	)
 }
 

--- a/coderd/x/chatd/chattool/planpathmessage.go
+++ b/coderd/x/chatd/chattool/planpathmessage.go
@@ -2,7 +2,6 @@ package chattool
 
 import (
 	"fmt"
-	"strings"
 
 	"charm.land/fantasy"
 )
@@ -14,7 +13,11 @@ func rejectSharedPlanPath(
 	planPathErr error,
 ) (fantasy.ToolResponse, bool) {
 	if planPathErr != nil {
-		if !looksLikePlanFileName(requestedPath) {
+		// When the resolver fails, we cannot determine the actual
+		// home directory. Fall back to rejecting only the exact
+		// legacy shared path (case-insensitive) rather than every
+		// file named plan.md.
+		if !looksLikeLegacySharedPlanPath(requestedPath) {
 			return fantasy.ToolResponse{}, false
 		}
 
@@ -23,21 +26,13 @@ func rejectSharedPlanPath(
 		), true
 	}
 
-	if !looksLikeLegacyHomePlanPath(requestedPath, home) {
+	if !LooksLikeHomePlanFile(requestedPath, home) {
 		return fantasy.ToolResponse{}, false
 	}
 
 	return fantasy.NewTextErrorResponse(
 		sharedPlanPathMessage(requestedPath, planPath),
 	), true
-}
-
-func looksLikeLegacyHomePlanPath(requestedPath, home string) bool {
-	if strings.TrimSpace(home) == "" {
-		return strings.EqualFold(requestedPath, LegacySharedPlanPath)
-	}
-
-	return LooksLikeHomePlanFile(requestedPath, home)
 }
 
 func sharedPlanPathMessage(requestedPath, planPath string) string {

--- a/coderd/x/chatd/chattool/planpathmessage.go
+++ b/coderd/x/chatd/chattool/planpathmessage.go
@@ -1,7 +1,6 @@
 package chattool
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -9,22 +8,27 @@ import (
 )
 
 func rejectSharedPlanPath(
-	ctx context.Context,
 	requestedPath string,
-	resolvePlanPath func(context.Context) (string, error),
+	home string,
+	planPath string,
+	planPathErr error,
 ) (fantasy.ToolResponse, bool) {
-	if resolvePlanPath == nil || !IsLegacySharedPlanPath(requestedPath) {
+	if !looksLikeLegacyHomePlanPath(requestedPath, home) {
 		return fantasy.ToolResponse{}, false
 	}
 
-	return fantasy.NewTextErrorResponse(sharedPlanPathMessage(ctx, resolvePlanPath)), true
+	return fantasy.NewTextErrorResponse(sharedPlanPathMessage(planPath, planPathErr)), true
 }
 
-func sharedPlanPathMessage(
-	ctx context.Context,
-	resolvePlanPath func(context.Context) (string, error),
-) string {
-	planPath, err := resolvePlanPath(ctx)
+func looksLikeLegacyHomePlanPath(requestedPath, home string) bool {
+	if strings.TrimSpace(home) == "" {
+		return IsLegacySharedPlanPath(requestedPath)
+	}
+
+	return LooksLikeHomePlanFile(requestedPath, home)
+}
+
+func sharedPlanPathMessage(planPath string, err error) string {
 	if err == nil && strings.TrimSpace(planPath) != "" {
 		return fmt.Sprintf(
 			"the shared plan path %s is no longer supported; use the chat-specific plan path: %s",

--- a/coderd/x/chatd/chattool/planpathmessage.go
+++ b/coderd/x/chatd/chattool/planpathmessage.go
@@ -13,12 +13,22 @@ func rejectSharedPlanPath(
 	planPath string,
 	planPathErr error,
 ) (fantasy.ToolResponse, bool) {
+	if planPathErr != nil {
+		if !looksLikePlanFileName(requestedPath) {
+			return fantasy.ToolResponse{}, false
+		}
+
+		return fantasy.NewTextErrorResponse(
+			planPathVerificationMessage(requestedPath),
+		), true
+	}
+
 	if !looksLikeLegacyHomePlanPath(requestedPath, home) {
 		return fantasy.ToolResponse{}, false
 	}
 
 	return fantasy.NewTextErrorResponse(
-		sharedPlanPathMessage(requestedPath, planPath, planPathErr),
+		sharedPlanPathMessage(requestedPath, planPath),
 	), true
 }
 
@@ -30,17 +40,17 @@ func looksLikeLegacyHomePlanPath(requestedPath, home string) bool {
 	return LooksLikeHomePlanFile(requestedPath, home)
 }
 
-func sharedPlanPathMessage(requestedPath, planPath string, err error) string {
-	if err == nil && strings.TrimSpace(planPath) != "" {
-		return fmt.Sprintf(
-			"the plan path %s is no longer supported at the home root; use the chat-specific plan path: %s",
-			requestedPath,
-			planPath,
-		)
-	}
-
+func sharedPlanPathMessage(requestedPath, planPath string) string {
 	return fmt.Sprintf(
-		"the plan path %s is no longer supported at the home root; the workspace is currently unavailable to resolve the chat-specific plan path, try again shortly",
+		"the plan path %s is no longer supported at the home root; use the chat-specific plan path: %s",
+		requestedPath,
+		planPath,
+	)
+}
+
+func planPathVerificationMessage(requestedPath string) string {
+	return fmt.Sprintf(
+		"the plan path %s could not be verified because the workspace is currently unavailable to resolve the chat-specific plan path, try again shortly",
 		requestedPath,
 	)
 }

--- a/coderd/x/chatd/chattool/planpathmessage.go
+++ b/coderd/x/chatd/chattool/planpathmessage.go
@@ -1,0 +1,40 @@
+package chattool
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"charm.land/fantasy"
+)
+
+func rejectSharedPlanPath(
+	ctx context.Context,
+	requestedPath string,
+	resolvePlanPath func(context.Context) (string, error),
+) (fantasy.ToolResponse, bool) {
+	if resolvePlanPath == nil || !IsLegacySharedPlanPath(requestedPath) {
+		return fantasy.ToolResponse{}, false
+	}
+
+	return fantasy.NewTextErrorResponse(sharedPlanPathMessage(ctx, resolvePlanPath)), true
+}
+
+func sharedPlanPathMessage(
+	ctx context.Context,
+	resolvePlanPath func(context.Context) (string, error),
+) string {
+	planPath, err := resolvePlanPath(ctx)
+	if err == nil && strings.TrimSpace(planPath) != "" {
+		return fmt.Sprintf(
+			"the shared plan path %s is no longer supported; use the chat-specific plan path: %s",
+			LegacySharedPlanPath,
+			planPath,
+		)
+	}
+
+	return fmt.Sprintf(
+		"the shared plan path %s is no longer supported; use the chat-specific plan path provided in your instructions",
+		LegacySharedPlanPath,
+	)
+}

--- a/coderd/x/chatd/chattool/planpathmessage.go
+++ b/coderd/x/chatd/chattool/planpathmessage.go
@@ -17,28 +17,30 @@ func rejectSharedPlanPath(
 		return fantasy.ToolResponse{}, false
 	}
 
-	return fantasy.NewTextErrorResponse(sharedPlanPathMessage(planPath, planPathErr)), true
+	return fantasy.NewTextErrorResponse(
+		sharedPlanPathMessage(requestedPath, planPath, planPathErr),
+	), true
 }
 
 func looksLikeLegacyHomePlanPath(requestedPath, home string) bool {
 	if strings.TrimSpace(home) == "" {
-		return IsLegacySharedPlanPath(requestedPath)
+		return strings.EqualFold(requestedPath, LegacySharedPlanPath)
 	}
 
 	return LooksLikeHomePlanFile(requestedPath, home)
 }
 
-func sharedPlanPathMessage(planPath string, err error) string {
+func sharedPlanPathMessage(requestedPath, planPath string, err error) string {
 	if err == nil && strings.TrimSpace(planPath) != "" {
 		return fmt.Sprintf(
-			"the shared plan path %s is no longer supported; use the chat-specific plan path: %s",
-			LegacySharedPlanPath,
+			"the plan path %s is no longer supported at the home root; use the chat-specific plan path: %s",
+			requestedPath,
 			planPath,
 		)
 	}
 
 	return fmt.Sprintf(
-		"the shared plan path %s is no longer supported; use the chat-specific plan path provided in your instructions",
-		LegacySharedPlanPath,
+		"the plan path %s is no longer supported at the home root; the workspace is currently unavailable to resolve the chat-specific plan path, try again shortly",
+		requestedPath,
 	)
 }

--- a/coderd/x/chatd/chattool/proposeplan.go
+++ b/coderd/x/chatd/chattool/proposeplan.go
@@ -3,6 +3,7 @@ package chattool
 import (
 	"context"
 	"io"
+	pathpkg "path"
 	"path/filepath"
 	"strings"
 
@@ -17,7 +18,7 @@ const maxProposePlanSize = 32 * 1024 // 32 KiB
 // ProposePlanOptions configures the propose_plan tool.
 type ProposePlanOptions struct {
 	GetWorkspaceConn func(context.Context) (workspacesdk.AgentConn, error)
-	PlanPath         func(context.Context) (chatPath string, home string, err error)
+	ResolvePlanPath  func(context.Context) (chatPath string, home string, err error)
 	StoreFile        func(ctx context.Context, name string, mediaType string, data []byte) (uuid.UUID, error)
 }
 
@@ -46,7 +47,7 @@ func ProposePlan(options ProposePlanOptions) fantasy.AgentTool {
 			if err != nil {
 				return fantasy.NewTextErrorResponse(err.Error()), nil
 			}
-			return executeProposePlanTool(ctx, conn, args, options.PlanPath, options.StoreFile)
+			return executeProposePlanTool(ctx, conn, args, options.ResolvePlanPath, options.StoreFile)
 		},
 	)
 }
@@ -58,22 +59,29 @@ func executeProposePlanTool(
 	resolvePlanPath func(context.Context) (chatPath string, home string, err error),
 	storeFile func(ctx context.Context, name string, mediaType string, data []byte) (uuid.UUID, error),
 ) (fantasy.ToolResponse, error) {
-	path := strings.TrimSpace(args.Path)
-	if path == "" {
+	requestedPath := strings.TrimSpace(args.Path)
+	if requestedPath == "" {
 		return fantasy.NewTextErrorResponse("path is required (use the chat-specific plan path from your instructions)"), nil
 	}
-	if !strings.HasSuffix(path, ".md") {
+	if !strings.HasSuffix(requestedPath, ".md") {
 		return fantasy.NewTextErrorResponse("path must end with .md"), nil
 	}
 
-	if resolvePlanPath != nil && looksLikePlanFileName(path) {
+	looksLikePlanPath := looksLikePlanFileName(requestedPath)
+	if looksLikePlanPath && !pathpkg.IsAbs(requestedPath) {
+		return fantasy.NewTextErrorResponse(
+			"plan files must use absolute paths; use the chat-specific plan path from your instructions",
+		), nil
+	}
+
+	if resolvePlanPath != nil && looksLikePlanPath {
 		chatPath, home, err := resolvePlanPath(ctx)
-		if resp, rejected := rejectSharedPlanPath(path, home, chatPath, err); rejected {
+		if resp, rejected := rejectSharedPlanPath(requestedPath, home, chatPath, err); rejected {
 			return resp, nil
 		}
 	}
 
-	rc, _, err := conn.ReadFile(ctx, path, 0, maxProposePlanSize+1)
+	rc, _, err := conn.ReadFile(ctx, requestedPath, 0, maxProposePlanSize+1)
 	if err != nil {
 		return fantasy.NewTextErrorResponse(err.Error()), nil
 	}
@@ -87,14 +95,14 @@ func executeProposePlanTool(
 		return fantasy.NewTextErrorResponse("plan file exceeds 32 KiB size limit"), nil
 	}
 
-	fileID, err := storeFile(ctx, filepath.Base(path), "text/markdown", data)
+	fileID, err := storeFile(ctx, filepath.Base(requestedPath), "text/markdown", data)
 	if err != nil {
 		return fantasy.NewTextErrorResponse("failed to store plan file: " + err.Error()), nil
 	}
 
 	return toolResponse(map[string]any{
 		"ok":         true,
-		"path":       path,
+		"path":       requestedPath,
 		"kind":       "plan",
 		"file_id":    fileID.String(),
 		"media_type": "text/markdown",

--- a/coderd/x/chatd/chattool/proposeplan.go
+++ b/coderd/x/chatd/chattool/proposeplan.go
@@ -33,7 +33,7 @@ func ProposePlan(options ProposePlanOptions) fantasy.AgentTool {
 		"propose_plan",
 		"Present a Markdown plan file from the workspace for user review. "+
 			"The file must already exist with a .md extension. Use write_file to create it or edit_files to refine it before calling this tool. "+
-			"Pass the absolute chat-specific plan file path from your instructions. The tool reads the content from the workspace.",
+			"Pass the absolute file path to the plan. Use the chat-specific plan path provided in your instructions. The tool reads the content from the workspace.",
 		func(ctx context.Context, args ProposePlanArgs, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
 			if options.GetWorkspaceConn == nil {
 				return fantasy.NewTextErrorResponse("workspace connection resolver is not configured"), nil
@@ -59,7 +59,7 @@ func executeProposePlanTool(
 ) (fantasy.ToolResponse, error) {
 	path := strings.TrimSpace(args.Path)
 	if path == "" {
-		return fantasy.NewTextErrorResponse("path is required (use the absolute chat-specific plan file path from your instructions)"), nil
+		return fantasy.NewTextErrorResponse("path is required (use the chat-specific plan path from your instructions)"), nil
 	}
 	if !strings.HasSuffix(path, ".md") {
 		return fantasy.NewTextErrorResponse("path must end with .md"), nil

--- a/coderd/x/chatd/chattool/proposeplan.go
+++ b/coderd/x/chatd/chattool/proposeplan.go
@@ -3,7 +3,6 @@ package chattool
 import (
 	"context"
 	"io"
-	pathpkg "path"
 	"path/filepath"
 	"strings"
 
@@ -68,7 +67,7 @@ func executeProposePlanTool(
 	}
 
 	looksLikePlanPath := looksLikePlanFileName(requestedPath)
-	if looksLikePlanPath && !pathpkg.IsAbs(requestedPath) {
+	if looksLikePlanPath && !isAbsolutePath(requestedPath) {
 		return fantasy.NewTextErrorResponse(
 			"plan files must use absolute paths; use the chat-specific plan path from your instructions",
 		), nil

--- a/coderd/x/chatd/chattool/proposeplan.go
+++ b/coderd/x/chatd/chattool/proposeplan.go
@@ -17,7 +17,7 @@ const maxProposePlanSize = 32 * 1024 // 32 KiB
 // ProposePlanOptions configures the propose_plan tool.
 type ProposePlanOptions struct {
 	GetWorkspaceConn func(context.Context) (workspacesdk.AgentConn, error)
-	PlanPath         func(context.Context) (string, error)
+	PlanPath         func(context.Context) (chatPath string, home string, err error)
 	StoreFile        func(ctx context.Context, name string, mediaType string, data []byte) (uuid.UUID, error)
 }
 
@@ -33,7 +33,8 @@ func ProposePlan(options ProposePlanOptions) fantasy.AgentTool {
 		"propose_plan",
 		"Present a Markdown plan file from the workspace for user review. "+
 			"The file must already exist with a .md extension. Use write_file to create it or edit_files to refine it before calling this tool. "+
-			"Pass the absolute file path to the plan. Use the chat-specific plan path provided in your instructions. The tool reads the content from the workspace.",
+			"Pass the absolute file path to the plan. Important: use the chat-specific plan path from your runtime instructions, not a generic path like PLAN.md in the home directory. "+
+			"The tool reads the content from the workspace.",
 		func(ctx context.Context, args ProposePlanArgs, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
 			if options.GetWorkspaceConn == nil {
 				return fantasy.NewTextErrorResponse("workspace connection resolver is not configured"), nil
@@ -54,7 +55,7 @@ func executeProposePlanTool(
 	ctx context.Context,
 	conn workspacesdk.AgentConn,
 	args ProposePlanArgs,
-	resolvePlanPath func(context.Context) (string, error),
+	resolvePlanPath func(context.Context) (chatPath string, home string, err error),
 	storeFile func(ctx context.Context, name string, mediaType string, data []byte) (uuid.UUID, error),
 ) (fantasy.ToolResponse, error) {
 	path := strings.TrimSpace(args.Path)
@@ -65,8 +66,11 @@ func executeProposePlanTool(
 		return fantasy.NewTextErrorResponse("path must end with .md"), nil
 	}
 
-	if resp, rejected := rejectSharedPlanPath(ctx, path, resolvePlanPath); rejected {
-		return resp, nil
+	if resolvePlanPath != nil && looksLikePlanFileName(path) {
+		chatPath, home, err := resolvePlanPath(ctx)
+		if resp, rejected := rejectSharedPlanPath(path, home, chatPath, err); rejected {
+			return resp, nil
+		}
 	}
 
 	rc, _, err := conn.ReadFile(ctx, path, 0, maxProposePlanSize+1)

--- a/coderd/x/chatd/chattool/proposeplan.go
+++ b/coderd/x/chatd/chattool/proposeplan.go
@@ -33,7 +33,7 @@ func ProposePlan(options ProposePlanOptions) fantasy.AgentTool {
 		"propose_plan",
 		"Present a Markdown plan file from the workspace for user review. "+
 			"The file must already exist with a .md extension. Use write_file to create it or edit_files to refine it before calling this tool. "+
-			"Pass the absolute file path to the plan. Important: use the chat-specific plan path from your runtime instructions, not a generic path like PLAN.md in the home directory. "+
+			"Pass the absolute file path to the plan. Important: use the chat-specific absolute plan path, not a generic path like PLAN.md in the home directory. "+
 			"The tool reads the content from the workspace.",
 		func(ctx context.Context, args ProposePlanArgs, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
 			if options.GetWorkspaceConn == nil {
@@ -60,7 +60,7 @@ func executeProposePlanTool(
 ) (fantasy.ToolResponse, error) {
 	requestedPath := strings.TrimSpace(args.Path)
 	if requestedPath == "" {
-		return fantasy.NewTextErrorResponse("path is required (use the chat-specific plan path from your instructions)"), nil
+		return fantasy.NewTextErrorResponse("path is required (use the chat-specific absolute plan path)"), nil
 	}
 	if !strings.HasSuffix(requestedPath, ".md") {
 		return fantasy.NewTextErrorResponse("path must end with .md"), nil
@@ -69,7 +69,7 @@ func executeProposePlanTool(
 	looksLikePlanPath := looksLikePlanFileName(requestedPath)
 	if looksLikePlanPath && !isAbsolutePath(requestedPath) {
 		return fantasy.NewTextErrorResponse(
-			"plan files must use absolute paths; use the chat-specific plan path from your instructions",
+			"plan files must use absolute paths; use the chat-specific absolute plan path",
 		), nil
 	}
 

--- a/coderd/x/chatd/chattool/proposeplan.go
+++ b/coderd/x/chatd/chattool/proposeplan.go
@@ -66,14 +66,14 @@ func executeProposePlanTool(
 		return fantasy.NewTextErrorResponse("path must end with .md"), nil
 	}
 
-	looksLikePlanPath := looksLikePlanFileName(requestedPath)
-	if looksLikePlanPath && !isAbsolutePath(requestedPath) {
+	hasPlanFileName := looksLikePlanFileName(requestedPath)
+	if hasPlanFileName && !isAbsolutePath(requestedPath) {
 		return fantasy.NewTextErrorResponse(
 			"plan files must use absolute paths; use the chat-specific absolute plan path",
 		), nil
 	}
 
-	if resolvePlanPath != nil && looksLikePlanPath {
+	if resolvePlanPath != nil && hasPlanFileName {
 		chatPath, home, err := resolvePlanPath(ctx)
 		if resp, rejected := rejectSharedPlanPath(requestedPath, home, chatPath, err); rejected {
 			return resp, nil

--- a/coderd/x/chatd/chattool/proposeplan.go
+++ b/coderd/x/chatd/chattool/proposeplan.go
@@ -17,6 +17,7 @@ const maxProposePlanSize = 32 * 1024 // 32 KiB
 // ProposePlanOptions configures the propose_plan tool.
 type ProposePlanOptions struct {
 	GetWorkspaceConn func(context.Context) (workspacesdk.AgentConn, error)
+	PlanPath         func(context.Context) (string, error)
 	StoreFile        func(ctx context.Context, name string, mediaType string, data []byte) (uuid.UUID, error)
 }
 
@@ -31,8 +32,8 @@ func ProposePlan(options ProposePlanOptions) fantasy.AgentTool {
 	return fantasy.NewAgentTool(
 		"propose_plan",
 		"Present a Markdown plan file from the workspace for user review. "+
-			"The file must already exist with a .md extension — use write_file to create it or edit_files to refine it before calling this tool. "+
-			"Pass the absolute file path (e.g. /home/coder/PLAN.md). The tool reads the content from the workspace.",
+			"The file must already exist with a .md extension. Use write_file to create it or edit_files to refine it before calling this tool. "+
+			"Pass the absolute chat-specific plan file path from your instructions. The tool reads the content from the workspace.",
 		func(ctx context.Context, args ProposePlanArgs, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
 			if options.GetWorkspaceConn == nil {
 				return fantasy.NewTextErrorResponse("workspace connection resolver is not configured"), nil
@@ -44,7 +45,7 @@ func ProposePlan(options ProposePlanOptions) fantasy.AgentTool {
 			if err != nil {
 				return fantasy.NewTextErrorResponse(err.Error()), nil
 			}
-			return executeProposePlanTool(ctx, conn, args, options.StoreFile)
+			return executeProposePlanTool(ctx, conn, args, options.PlanPath, options.StoreFile)
 		},
 	)
 }
@@ -53,14 +54,19 @@ func executeProposePlanTool(
 	ctx context.Context,
 	conn workspacesdk.AgentConn,
 	args ProposePlanArgs,
+	resolvePlanPath func(context.Context) (string, error),
 	storeFile func(ctx context.Context, name string, mediaType string, data []byte) (uuid.UUID, error),
 ) (fantasy.ToolResponse, error) {
 	path := strings.TrimSpace(args.Path)
 	if path == "" {
-		return fantasy.NewTextErrorResponse("path is required (use an absolute path, e.g. /home/coder/PLAN.md)"), nil
+		return fantasy.NewTextErrorResponse("path is required (use the absolute chat-specific plan file path from your instructions)"), nil
 	}
 	if !strings.HasSuffix(path, ".md") {
 		return fantasy.NewTextErrorResponse("path must end with .md"), nil
+	}
+
+	if resp, rejected := rejectSharedPlanPath(ctx, path, resolvePlanPath); rejected {
+		return resp, nil
 	}
 
 	rc, _, err := conn.ReadFile(ctx, path, 0, maxProposePlanSize+1)

--- a/coderd/x/chatd/chattool/proposeplan_test.go
+++ b/coderd/x/chatd/chattool/proposeplan_test.go
@@ -135,7 +135,16 @@ func TestProposePlan(t *testing.T) {
 			Return(io.NopCloser(strings.NewReader("# Plan\n\nContent")), "text/markdown", nil)
 
 		storeFile, stored := fakeStoreFile(t)
-		tool := newProposePlanTool(t, mockConn, storeFile)
+		planPathCalled := false
+		tool := newProposePlanToolWithPlanPath(
+			t,
+			mockConn,
+			storeFile,
+			func(context.Context) (string, error) {
+				planPathCalled = true
+				return "", xerrors.New("should not be called")
+			},
+		)
 		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
 			ID:    "call-1",
 			Name:  "propose_plan",
@@ -143,6 +152,7 @@ func TestProposePlan(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.False(t, resp.IsError)
+		assert.False(t, planPathCalled)
 
 		result := decodeProposePlanResponse(t, resp)
 		assert.True(t, result.OK)
@@ -218,6 +228,60 @@ func TestProposePlan(t *testing.T) {
 		assert.Contains(t, resp.Content, "storage unavailable")
 	})
 
+	t.Run("RejectsSharedPlanPathWithResolvedPath", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+
+		storeFile, _ := fakeStoreFile(t)
+		tool := newProposePlanToolWithPlanPath(
+			t,
+			mockConn,
+			storeFile,
+			func(context.Context) (string, error) {
+				return "/home/coder/.coder/plans/PLAN-chat.md", nil
+			},
+		)
+
+		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "propose_plan",
+			Input: `{"path":"` + chattool.LegacySharedPlanPath + `"}`,
+		})
+		require.NoError(t, err)
+		assert.True(t, resp.IsError)
+		assert.Equal(
+			t,
+			sharedPlanPathResolvedMessage("/home/coder/.coder/plans/PLAN-chat.md"),
+			resp.Content,
+		)
+	})
+
+	t.Run("RejectsSharedPlanPathWhenResolverFails", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+
+		storeFile, _ := fakeStoreFile(t)
+		tool := newProposePlanToolWithPlanPath(
+			t,
+			mockConn,
+			storeFile,
+			func(context.Context) (string, error) {
+				return "", xerrors.New("workspace unavailable")
+			},
+		)
+
+		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "propose_plan",
+			Input: `{"path":"` + chattool.LegacySharedPlanPath + `"}`,
+		})
+		require.NoError(t, err)
+		assert.True(t, resp.IsError)
+		assert.Equal(t, sharedPlanPathFallbackMessage(), resp.Content)
+	})
+
 	t.Run("WorkspaceConnectionError", func(t *testing.T) {
 		t.Parallel()
 		storeFile, _ := fakeStoreFile(t)
@@ -280,12 +344,33 @@ func newProposePlanTool(
 	storeFile func(ctx context.Context, name string, mediaType string, data []byte) (uuid.UUID, error),
 ) fantasy.AgentTool {
 	t.Helper()
+	return newProposePlanToolWithPlanPath(t, mockConn, storeFile, nil)
+}
+
+func newProposePlanToolWithPlanPath(
+	t *testing.T,
+	mockConn *agentconnmock.MockAgentConn,
+	storeFile func(ctx context.Context, name string, mediaType string, data []byte) (uuid.UUID, error),
+	planPath func(context.Context) (string, error),
+) fantasy.AgentTool {
+	t.Helper()
 	return chattool.ProposePlan(chattool.ProposePlanOptions{
 		GetWorkspaceConn: func(_ context.Context) (workspacesdk.AgentConn, error) {
 			return mockConn, nil
 		},
+		PlanPath:  planPath,
 		StoreFile: storeFile,
 	})
+}
+
+func sharedPlanPathResolvedMessage(planPath string) string {
+	return "the shared plan path " + chattool.LegacySharedPlanPath +
+		" is no longer supported; use the chat-specific plan path: " + planPath
+}
+
+func sharedPlanPathFallbackMessage() string {
+	return "the shared plan path " + chattool.LegacySharedPlanPath +
+		" is no longer supported; use the chat-specific plan path provided in your instructions"
 }
 
 func fakeStoreFile(t *testing.T) (func(ctx context.Context, name string, mediaType string, data []byte) (uuid.UUID, error), *[]byte) {

--- a/coderd/x/chatd/chattool/proposeplan_test.go
+++ b/coderd/x/chatd/chattool/proposeplan_test.go
@@ -82,6 +82,34 @@ func TestProposePlan(t *testing.T) {
 		assert.Contains(t, resp.Content, "path must end with .md")
 	})
 
+	t.Run("RelativePlanPathReturnsError", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+
+		storeFile, _ := fakeStoreFile(t)
+		resolvePlanPathCalled := false
+		tool := newProposePlanToolWithPlanPath(
+			t,
+			mockConn,
+			storeFile,
+			func(context.Context) (string, string, error) {
+				resolvePlanPathCalled = true
+				return "/home/coder/.coder/plans/PLAN-chat.md", "/home/coder", nil
+			},
+		)
+
+		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "propose_plan",
+			Input: `{"path":"plan.md"}`,
+		})
+		require.NoError(t, err)
+		assert.True(t, resp.IsError)
+		assert.False(t, resolvePlanPathCalled)
+		assert.Equal(t, relativePlanPathMessage(), resp.Content)
+	})
+
 	t.Run("OversizedFileRejected", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
@@ -142,7 +170,7 @@ func TestProposePlan(t *testing.T) {
 			storeFile,
 			func(context.Context) (string, string, error) {
 				planPathCalled = true
-				return "", "", xerrors.New("should not be called")
+				return "/home/coder/.coder/plans/PLAN-xxx.md", "/home/coder", nil
 			},
 		)
 		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
@@ -286,7 +314,7 @@ func TestProposePlan(t *testing.T) {
 		assert.True(t, resp.IsError)
 		assert.Equal(
 			t,
-			sharedPlanPathResolvedMessage("/home/coder/.coder/plans/PLAN-chat.md"),
+			sharedPlanPathResolvedMessage(chattool.LegacySharedPlanPath, "/home/coder/.coder/plans/PLAN-chat.md"),
 			resp.Content,
 		)
 	})
@@ -313,7 +341,7 @@ func TestProposePlan(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.True(t, resp.IsError)
-		assert.Equal(t, sharedPlanPathFallbackMessage(), resp.Content)
+		assert.Equal(t, sharedPlanPathFallbackMessage(chattool.LegacySharedPlanPath), resp.Content)
 	})
 
 	t.Run("WorkspaceConnectionError", func(t *testing.T) {
@@ -385,26 +413,30 @@ func newProposePlanToolWithPlanPath(
 	t *testing.T,
 	mockConn *agentconnmock.MockAgentConn,
 	storeFile func(ctx context.Context, name string, mediaType string, data []byte) (uuid.UUID, error),
-	planPath func(context.Context) (string, string, error),
+	resolvePlanPath func(context.Context) (string, string, error),
 ) fantasy.AgentTool {
 	t.Helper()
 	return chattool.ProposePlan(chattool.ProposePlanOptions{
 		GetWorkspaceConn: func(_ context.Context) (workspacesdk.AgentConn, error) {
 			return mockConn, nil
 		},
-		PlanPath:  planPath,
-		StoreFile: storeFile,
+		ResolvePlanPath: resolvePlanPath,
+		StoreFile:       storeFile,
 	})
 }
 
-func sharedPlanPathResolvedMessage(planPath string) string {
-	return "the shared plan path " + chattool.LegacySharedPlanPath +
-		" is no longer supported; use the chat-specific plan path: " + planPath
+func sharedPlanPathResolvedMessage(requestedPath, planPath string) string {
+	return "the plan path " + requestedPath +
+		" is no longer supported at the home root; use the chat-specific plan path: " + planPath
 }
 
-func sharedPlanPathFallbackMessage() string {
-	return "the shared plan path " + chattool.LegacySharedPlanPath +
-		" is no longer supported; use the chat-specific plan path provided in your instructions"
+func sharedPlanPathFallbackMessage(requestedPath string) string {
+	return "the plan path " + requestedPath +
+		" is no longer supported at the home root; the workspace is currently unavailable to resolve the chat-specific plan path, try again shortly"
+}
+
+func relativePlanPathMessage() string {
+	return "plan files must use absolute paths; use the chat-specific plan path from your instructions"
 }
 
 func fakeStoreFile(t *testing.T) (func(ctx context.Context, name string, mediaType string, data []byte) (uuid.UUID, error), *[]byte) {

--- a/coderd/x/chatd/chattool/proposeplan_test.go
+++ b/coderd/x/chatd/chattool/proposeplan_test.go
@@ -341,7 +341,7 @@ func TestProposePlan(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.True(t, resp.IsError)
-		assert.Equal(t, sharedPlanPathFallbackMessage(chattool.LegacySharedPlanPath), resp.Content)
+		assert.Equal(t, planPathVerificationMessage(chattool.LegacySharedPlanPath), resp.Content)
 	})
 
 	t.Run("WorkspaceConnectionError", func(t *testing.T) {
@@ -430,9 +430,13 @@ func sharedPlanPathResolvedMessage(requestedPath, planPath string) string {
 		" is no longer supported at the home root; use the chat-specific plan path: " + planPath
 }
 
-func sharedPlanPathFallbackMessage(requestedPath string) string {
+func planPathVerificationMessage(requestedPath string) string {
 	return "the plan path " + requestedPath +
-		" is no longer supported at the home root; the workspace is currently unavailable to resolve the chat-specific plan path, try again shortly"
+		" could not be verified because the workspace is currently unavailable to resolve the chat-specific plan path, try again shortly"
+}
+
+func editFilesBatchRejectedMessage(message string) string {
+	return message + "; no files in this batch were applied"
 }
 
 func relativePlanPathMessage() string {

--- a/coderd/x/chatd/chattool/proposeplan_test.go
+++ b/coderd/x/chatd/chattool/proposeplan_test.go
@@ -140,9 +140,9 @@ func TestProposePlan(t *testing.T) {
 			t,
 			mockConn,
 			storeFile,
-			func(context.Context) (string, error) {
+			func(context.Context) (string, string, error) {
 				planPathCalled = true
-				return "", xerrors.New("should not be called")
+				return "", "", xerrors.New("should not be called")
 			},
 		)
 		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
@@ -152,7 +152,7 @@ func TestProposePlan(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.False(t, resp.IsError)
-		assert.False(t, planPathCalled)
+		assert.True(t, planPathCalled)
 
 		result := decodeProposePlanResponse(t, resp)
 		assert.True(t, result.OK)
@@ -164,6 +164,40 @@ func TestProposePlan(t *testing.T) {
 		assert.NotContains(t, resp.Content, "content")
 	})
 
+	t.Run("NestedPlanPathUnderHomeIsAllowed", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+
+		mockConn.EXPECT().
+			ReadFile(gomock.Any(), "/home/coder/myproject/plan.md", int64(0), int64(32*1024+1)).
+			Return(io.NopCloser(strings.NewReader("# Nested Plan")), "text/markdown", nil)
+
+		storeFile, stored := fakeStoreFile(t)
+		planPathCalled := false
+		tool := newProposePlanToolWithPlanPath(
+			t,
+			mockConn,
+			storeFile,
+			func(context.Context) (string, string, error) {
+				planPathCalled = true
+				return "/home/coder/.coder/plans/PLAN-chat.md", "/home/coder", nil
+			},
+		)
+		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "propose_plan",
+			Input: `{"path":"/home/coder/myproject/plan.md"}`,
+		})
+		require.NoError(t, err)
+		assert.False(t, resp.IsError)
+		assert.True(t, planPathCalled)
+
+		result := decodeProposePlanResponse(t, resp)
+		assert.True(t, result.OK)
+		assert.Equal(t, "/home/coder/myproject/plan.md", result.Path)
+		assert.Equal(t, []byte("# Nested Plan"), *stored)
+	})
 	t.Run("FileNotFound", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
@@ -238,8 +272,8 @@ func TestProposePlan(t *testing.T) {
 			t,
 			mockConn,
 			storeFile,
-			func(context.Context) (string, error) {
-				return "/home/coder/.coder/plans/PLAN-chat.md", nil
+			func(context.Context) (string, string, error) {
+				return "/home/coder/.coder/plans/PLAN-chat.md", "/home/coder", nil
 			},
 		)
 
@@ -267,8 +301,8 @@ func TestProposePlan(t *testing.T) {
 			t,
 			mockConn,
 			storeFile,
-			func(context.Context) (string, error) {
-				return "", xerrors.New("workspace unavailable")
+			func(context.Context) (string, string, error) {
+				return "", "", xerrors.New("workspace unavailable")
 			},
 		)
 
@@ -351,7 +385,7 @@ func newProposePlanToolWithPlanPath(
 	t *testing.T,
 	mockConn *agentconnmock.MockAgentConn,
 	storeFile func(ctx context.Context, name string, mediaType string, data []byte) (uuid.UUID, error),
-	planPath func(context.Context) (string, error),
+	planPath func(context.Context) (string, string, error),
 ) fantasy.AgentTool {
 	t.Helper()
 	return chattool.ProposePlan(chattool.ProposePlanOptions{

--- a/coderd/x/chatd/chattool/proposeplan_test.go
+++ b/coderd/x/chatd/chattool/proposeplan_test.go
@@ -509,7 +509,7 @@ func editFilesBatchRejectedMessage(message string) string {
 }
 
 func relativePlanPathMessage() string {
-	return "plan files must use absolute paths; use the chat-specific plan path from your instructions"
+	return "plan files must use absolute paths; use the chat-specific absolute plan path"
 }
 
 func fakeStoreFile(t *testing.T) (func(ctx context.Context, name string, mediaType string, data []byte) (uuid.UUID, error), *[]byte) {

--- a/coderd/x/chatd/chattool/proposeplan_test.go
+++ b/coderd/x/chatd/chattool/proposeplan_test.go
@@ -344,6 +344,74 @@ func TestProposePlan(t *testing.T) {
 		assert.Equal(t, planPathVerificationMessage(chattool.LegacySharedPlanPath), resp.Content)
 	})
 
+	t.Run("PerChatPlanPathIsAllowed", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		chatPlanPath := "/home/coder/.coder/plans/PLAN-123e4567-e89b-12d3-a456-426614174000.md"
+
+		mockConn.EXPECT().
+			ReadFile(gomock.Any(), chatPlanPath, int64(0), int64(32*1024+1)).
+			Return(io.NopCloser(strings.NewReader("# Per-Chat Plan")), "text/markdown", nil)
+
+		storeFile, stored := fakeStoreFile(t)
+		resolvePlanPathCalled := false
+		tool := newProposePlanToolWithPlanPath(
+			t,
+			mockConn,
+			storeFile,
+			func(context.Context) (string, string, error) {
+				resolvePlanPathCalled = true
+				return chatPlanPath, "/home/coder", nil
+			},
+		)
+		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "propose_plan",
+			Input: `{"path":"` + chatPlanPath + `"}`,
+		})
+		require.NoError(t, err)
+		assert.False(t, resp.IsError)
+		assert.False(t, resolvePlanPathCalled)
+
+		result := decodeProposePlanResponse(t, resp)
+		assert.True(t, result.OK)
+		assert.Equal(t, chatPlanPath, result.Path)
+		assert.Equal(t, []byte("# Per-Chat Plan"), *stored)
+	})
+
+	t.Run("NestedPlanPathAllowedWhenResolverFails", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+
+		mockConn.EXPECT().
+			ReadFile(gomock.Any(), "/home/coder/myproject/plan.md", int64(0), int64(32*1024+1)).
+			Return(io.NopCloser(strings.NewReader("# Nested Plan")), "text/markdown", nil)
+
+		storeFile, stored := fakeStoreFile(t)
+		tool := newProposePlanToolWithPlanPath(
+			t,
+			mockConn,
+			storeFile,
+			func(context.Context) (string, string, error) {
+				return "", "", xerrors.New("workspace unavailable")
+			},
+		)
+		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "propose_plan",
+			Input: `{"path":"/home/coder/myproject/plan.md"}`,
+		})
+		require.NoError(t, err)
+		assert.False(t, resp.IsError)
+
+		result := decodeProposePlanResponse(t, resp)
+		assert.True(t, result.OK)
+		assert.Equal(t, "/home/coder/myproject/plan.md", result.Path)
+		assert.Equal(t, []byte("# Nested Plan"), *stored)
+	})
+
 	t.Run("WorkspaceConnectionError", func(t *testing.T) {
 		t.Parallel()
 		storeFile, _ := fakeStoreFile(t)

--- a/coderd/x/chatd/chattool/proposeplan_test.go
+++ b/coderd/x/chatd/chattool/proposeplan_test.go
@@ -226,6 +226,7 @@ func TestProposePlan(t *testing.T) {
 		assert.Equal(t, "/home/coder/myproject/plan.md", result.Path)
 		assert.Equal(t, []byte("# Nested Plan"), *stored)
 	})
+
 	t.Run("FileNotFound", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)

--- a/coderd/x/chatd/chattool/writefile.go
+++ b/coderd/x/chatd/chattool/writefile.go
@@ -42,12 +42,13 @@ func executeWriteFileTool(
 	args WriteFileArgs,
 	resolvePlanPath func(context.Context) (chatPath string, home string, err error),
 ) (fantasy.ToolResponse, error) {
-	if args.Path == "" {
+	requestedPath := strings.TrimSpace(args.Path)
+	if requestedPath == "" {
 		return fantasy.NewTextErrorResponse("path is required"), nil
 	}
 
-	looksLikePlanPath := looksLikePlanFileName(args.Path)
-	if looksLikePlanPath && !isAbsolutePath(args.Path) {
+	looksLikePlanPath := looksLikePlanFileName(requestedPath)
+	if looksLikePlanPath && !isAbsolutePath(requestedPath) {
 		return fantasy.NewTextErrorResponse(
 			"plan files must use absolute paths; use the chat-specific plan path from your instructions",
 		), nil
@@ -55,12 +56,12 @@ func executeWriteFileTool(
 
 	if resolvePlanPath != nil && looksLikePlanPath {
 		chatPath, home, err := resolvePlanPath(ctx)
-		if resp, rejected := rejectSharedPlanPath(args.Path, home, chatPath, err); rejected {
+		if resp, rejected := rejectSharedPlanPath(requestedPath, home, chatPath, err); rejected {
 			return resp, nil
 		}
 	}
 
-	if err := conn.WriteFile(ctx, args.Path, strings.NewReader(args.Content)); err != nil {
+	if err := conn.WriteFile(ctx, requestedPath, strings.NewReader(args.Content)); err != nil {
 		return fantasy.NewTextErrorResponse(err.Error()), nil
 	}
 	return toolResponse(map[string]any{"ok": true}), nil

--- a/coderd/x/chatd/chattool/writefile.go
+++ b/coderd/x/chatd/chattool/writefile.go
@@ -50,7 +50,7 @@ func executeWriteFileTool(
 	looksLikePlanPath := looksLikePlanFileName(requestedPath)
 	if looksLikePlanPath && !isAbsolutePath(requestedPath) {
 		return fantasy.NewTextErrorResponse(
-			"plan files must use absolute paths; use the chat-specific plan path from your instructions",
+			"plan files must use absolute paths; use the chat-specific absolute plan path",
 		), nil
 	}
 

--- a/coderd/x/chatd/chattool/writefile.go
+++ b/coderd/x/chatd/chattool/writefile.go
@@ -11,7 +11,7 @@ import (
 
 type WriteFileOptions struct {
 	GetWorkspaceConn func(context.Context) (workspacesdk.AgentConn, error)
-	PlanPath         func(context.Context) (string, error)
+	PlanPath         func(context.Context) (chatPath string, home string, err error)
 }
 
 type WriteFileArgs struct {
@@ -40,14 +40,17 @@ func executeWriteFileTool(
 	ctx context.Context,
 	conn workspacesdk.AgentConn,
 	args WriteFileArgs,
-	resolvePlanPath func(context.Context) (string, error),
+	resolvePlanPath func(context.Context) (chatPath string, home string, err error),
 ) (fantasy.ToolResponse, error) {
 	if args.Path == "" {
 		return fantasy.NewTextErrorResponse("path is required"), nil
 	}
 
-	if resp, rejected := rejectSharedPlanPath(ctx, args.Path, resolvePlanPath); rejected {
-		return resp, nil
+	if resolvePlanPath != nil && looksLikePlanFileName(args.Path) {
+		chatPath, home, err := resolvePlanPath(ctx)
+		if resp, rejected := rejectSharedPlanPath(args.Path, home, chatPath, err); rejected {
+			return resp, nil
+		}
 	}
 
 	if err := conn.WriteFile(ctx, args.Path, strings.NewReader(args.Content)); err != nil {

--- a/coderd/x/chatd/chattool/writefile.go
+++ b/coderd/x/chatd/chattool/writefile.go
@@ -2,7 +2,6 @@ package chattool
 
 import (
 	"context"
-	"path"
 	"strings"
 
 	"charm.land/fantasy"
@@ -48,7 +47,7 @@ func executeWriteFileTool(
 	}
 
 	looksLikePlanPath := looksLikePlanFileName(args.Path)
-	if looksLikePlanPath && !path.IsAbs(args.Path) {
+	if looksLikePlanPath && !isAbsolutePath(args.Path) {
 		return fantasy.NewTextErrorResponse(
 			"plan files must use absolute paths; use the chat-specific plan path from your instructions",
 		), nil

--- a/coderd/x/chatd/chattool/writefile.go
+++ b/coderd/x/chatd/chattool/writefile.go
@@ -47,14 +47,14 @@ func executeWriteFileTool(
 		return fantasy.NewTextErrorResponse("path is required"), nil
 	}
 
-	looksLikePlanPath := looksLikePlanFileName(requestedPath)
-	if looksLikePlanPath && !isAbsolutePath(requestedPath) {
+	hasPlanFileName := looksLikePlanFileName(requestedPath)
+	if hasPlanFileName && !isAbsolutePath(requestedPath) {
 		return fantasy.NewTextErrorResponse(
 			"plan files must use absolute paths; use the chat-specific absolute plan path",
 		), nil
 	}
 
-	if resolvePlanPath != nil && looksLikePlanPath {
+	if resolvePlanPath != nil && hasPlanFileName {
 		chatPath, home, err := resolvePlanPath(ctx)
 		if resp, rejected := rejectSharedPlanPath(requestedPath, home, chatPath, err); rejected {
 			return resp, nil

--- a/coderd/x/chatd/chattool/writefile.go
+++ b/coderd/x/chatd/chattool/writefile.go
@@ -11,6 +11,7 @@ import (
 
 type WriteFileOptions struct {
 	GetWorkspaceConn func(context.Context) (workspacesdk.AgentConn, error)
+	PlanPath         func(context.Context) (string, error)
 }
 
 type WriteFileArgs struct {
@@ -30,7 +31,7 @@ func WriteFile(options WriteFileOptions) fantasy.AgentTool {
 			if err != nil {
 				return fantasy.NewTextErrorResponse(err.Error()), nil
 			}
-			return executeWriteFileTool(ctx, conn, args)
+			return executeWriteFileTool(ctx, conn, args, options.PlanPath)
 		},
 	)
 }
@@ -39,9 +40,14 @@ func executeWriteFileTool(
 	ctx context.Context,
 	conn workspacesdk.AgentConn,
 	args WriteFileArgs,
+	resolvePlanPath func(context.Context) (string, error),
 ) (fantasy.ToolResponse, error) {
 	if args.Path == "" {
 		return fantasy.NewTextErrorResponse("path is required"), nil
+	}
+
+	if resp, rejected := rejectSharedPlanPath(ctx, args.Path, resolvePlanPath); rejected {
+		return resp, nil
 	}
 
 	if err := conn.WriteFile(ctx, args.Path, strings.NewReader(args.Content)); err != nil {

--- a/coderd/x/chatd/chattool/writefile.go
+++ b/coderd/x/chatd/chattool/writefile.go
@@ -2,6 +2,7 @@ package chattool
 
 import (
 	"context"
+	"path"
 	"strings"
 
 	"charm.land/fantasy"
@@ -11,7 +12,7 @@ import (
 
 type WriteFileOptions struct {
 	GetWorkspaceConn func(context.Context) (workspacesdk.AgentConn, error)
-	PlanPath         func(context.Context) (chatPath string, home string, err error)
+	ResolvePlanPath  func(context.Context) (chatPath string, home string, err error)
 }
 
 type WriteFileArgs struct {
@@ -31,7 +32,7 @@ func WriteFile(options WriteFileOptions) fantasy.AgentTool {
 			if err != nil {
 				return fantasy.NewTextErrorResponse(err.Error()), nil
 			}
-			return executeWriteFileTool(ctx, conn, args, options.PlanPath)
+			return executeWriteFileTool(ctx, conn, args, options.ResolvePlanPath)
 		},
 	)
 }
@@ -46,7 +47,14 @@ func executeWriteFileTool(
 		return fantasy.NewTextErrorResponse("path is required"), nil
 	}
 
-	if resolvePlanPath != nil && looksLikePlanFileName(args.Path) {
+	looksLikePlanPath := looksLikePlanFileName(args.Path)
+	if looksLikePlanPath && !path.IsAbs(args.Path) {
+		return fantasy.NewTextErrorResponse(
+			"plan files must use absolute paths; use the chat-specific plan path from your instructions",
+		), nil
+	}
+
+	if resolvePlanPath != nil && looksLikePlanPath {
 		chatPath, home, err := resolvePlanPath(ctx)
 		if resp, rejected := rejectSharedPlanPath(args.Path, home, chatPath, err); rejected {
 			return resp, nil

--- a/coderd/x/chatd/chattool/writefile_test.go
+++ b/coderd/x/chatd/chattool/writefile_test.go
@@ -20,31 +20,61 @@ import (
 func TestWriteFile(t *testing.T) {
 	t.Parallel()
 
-	t.Run("RejectsSharedPlanPathWhenPlanPathIsConfigured", func(t *testing.T) {
+	t.Run("RejectsHomeRootPlanVariantsWhenPlanPathIsConfigured", func(t *testing.T) {
 		t.Parallel()
-		ctrl := gomock.NewController(t)
-		mockConn := agentconnmock.NewMockAgentConn(ctrl)
-		tool := chattool.WriteFile(chattool.WriteFileOptions{
-			GetWorkspaceConn: func(context.Context) (workspacesdk.AgentConn, error) {
-				return mockConn, nil
-			},
-			PlanPath: func(context.Context) (string, error) {
-				return "/home/coder/.coder/plans/PLAN-chat.md", nil
-			},
-		})
 
-		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
-			ID:    "call-1",
-			Name:  "write_file",
-			Input: `{"path":"` + chattool.LegacySharedPlanPath + `","content":"# Plan"}`,
-		})
-		require.NoError(t, err)
-		assert.True(t, resp.IsError)
-		assert.Equal(
-			t,
-			sharedPlanPathResolvedMessage("/home/coder/.coder/plans/PLAN-chat.md"),
-			resp.Content,
-		)
+		tests := []struct {
+			name      string
+			requested string
+			home      string
+		}{
+			{
+				name:      "ExactLegacyPath",
+				requested: chattool.LegacySharedPlanPath,
+				home:      "/home/coder",
+			},
+			{
+				name:      "LowercasePlanAtHomeRoot",
+				requested: "/home/coder/plan.md",
+				home:      "/home/coder",
+			},
+			{
+				name:      "MixedCasePlanAtHomeRoot",
+				requested: "/home/coder/Plan.md",
+				home:      "/home/coder",
+			},
+		}
+
+		for _, testCase := range tests {
+			testCase := testCase
+			t.Run(testCase.name, func(t *testing.T) {
+				t.Parallel()
+
+				ctrl := gomock.NewController(t)
+				mockConn := agentconnmock.NewMockAgentConn(ctrl)
+				tool := chattool.WriteFile(chattool.WriteFileOptions{
+					GetWorkspaceConn: func(context.Context) (workspacesdk.AgentConn, error) {
+						return mockConn, nil
+					},
+					PlanPath: func(context.Context) (string, string, error) {
+						return "/home/coder/.coder/plans/PLAN-chat.md", testCase.home, nil
+					},
+				})
+
+				resp, err := tool.Run(context.Background(), fantasy.ToolCall{
+					ID:    "call-1",
+					Name:  "write_file",
+					Input: `{"path":"` + testCase.requested + `","content":"# Plan"}`,
+				})
+				require.NoError(t, err)
+				assert.True(t, resp.IsError)
+				assert.Equal(
+					t,
+					sharedPlanPathResolvedMessage("/home/coder/.coder/plans/PLAN-chat.md"),
+					resp.Content,
+				)
+			})
+		}
 	})
 
 	t.Run("AllowsNonSharedPath", func(t *testing.T) {
@@ -66,9 +96,9 @@ func TestWriteFile(t *testing.T) {
 			GetWorkspaceConn: func(context.Context) (workspacesdk.AgentConn, error) {
 				return mockConn, nil
 			},
-			PlanPath: func(context.Context) (string, error) {
+			PlanPath: func(context.Context) (string, string, error) {
 				planPathCalled = true
-				return "", xerrors.New("should not be called")
+				return "", "", xerrors.New("should not be called")
 			},
 		})
 

--- a/coderd/x/chatd/chattool/writefile_test.go
+++ b/coderd/x/chatd/chattool/writefile_test.go
@@ -126,6 +126,65 @@ func TestWriteFile(t *testing.T) {
 		}
 	})
 
+	t.Run("RejectsSharedPlanPathWhenResolverFails", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		tool := chattool.WriteFile(chattool.WriteFileOptions{
+			GetWorkspaceConn: func(context.Context) (workspacesdk.AgentConn, error) {
+				return mockConn, nil
+			},
+			ResolvePlanPath: func(context.Context) (string, string, error) {
+				return "", "", xerrors.New("workspace unavailable")
+			},
+		})
+
+		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "write_file",
+			Input: `{"path":"/home/coder/plan.md","content":"# Plan"}`,
+		})
+		require.NoError(t, err)
+		assert.True(t, resp.IsError)
+		assert.Equal(t, planPathVerificationMessage("/home/coder/plan.md"), resp.Content)
+	})
+
+	t.Run("NestedPlanPathUnderHomeIsAllowed", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		mockConn.EXPECT().
+			WriteFile(gomock.Any(), "/home/coder/myproject/plan.md", gomock.Any()).
+			DoAndReturn(func(_ context.Context, path string, reader io.Reader) error {
+				data, err := io.ReadAll(reader)
+				require.NoError(t, err)
+				require.Equal(t, "/home/coder/myproject/plan.md", path)
+				require.Equal(t, "# Plan", string(data))
+				return nil
+			})
+
+		planPathCalled := false
+		tool := chattool.WriteFile(chattool.WriteFileOptions{
+			GetWorkspaceConn: func(context.Context) (workspacesdk.AgentConn, error) {
+				return mockConn, nil
+			},
+			ResolvePlanPath: func(context.Context) (string, string, error) {
+				planPathCalled = true
+				return "/home/coder/.coder/plans/PLAN-chat.md", "/home/coder", nil
+			},
+		})
+
+		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "write_file",
+			Input: `{"path":"/home/coder/myproject/plan.md","content":"# Plan"}`,
+		})
+		require.NoError(t, err)
+		assert.False(t, resp.IsError)
+		assert.True(t, planPathCalled)
+		assert.Equal(t, `{"ok":true}`, strings.TrimSpace(resp.Content))
+	})
+
 	t.Run("AllowsNonSharedPath", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)

--- a/coderd/x/chatd/chattool/writefile_test.go
+++ b/coderd/x/chatd/chattool/writefile_test.go
@@ -149,6 +149,76 @@ func TestWriteFile(t *testing.T) {
 		assert.Equal(t, planPathVerificationMessage("/home/coder/plan.md"), resp.Content)
 	})
 
+	t.Run("PerChatPlanPathIsAllowed", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		chatPlanPath := "/home/coder/.coder/plans/PLAN-123e4567-e89b-12d3-a456-426614174000.md"
+		mockConn.EXPECT().
+			WriteFile(gomock.Any(), chatPlanPath, gomock.Any()).
+			DoAndReturn(func(_ context.Context, path string, reader io.Reader) error {
+				data, err := io.ReadAll(reader)
+				require.NoError(t, err)
+				require.Equal(t, chatPlanPath, path)
+				require.Equal(t, "# Plan", string(data))
+				return nil
+			})
+
+		resolvePlanPathCalled := false
+		tool := chattool.WriteFile(chattool.WriteFileOptions{
+			GetWorkspaceConn: func(context.Context) (workspacesdk.AgentConn, error) {
+				return mockConn, nil
+			},
+			ResolvePlanPath: func(context.Context) (string, string, error) {
+				resolvePlanPathCalled = true
+				return chatPlanPath, "/home/coder", nil
+			},
+		})
+
+		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "write_file",
+			Input: `{"path":"` + chatPlanPath + `","content":"# Plan"}`,
+		})
+		require.NoError(t, err)
+		assert.False(t, resp.IsError)
+		assert.False(t, resolvePlanPathCalled)
+		assert.Equal(t, `{"ok":true}`, strings.TrimSpace(resp.Content))
+	})
+
+	t.Run("NestedPlanPathAllowedWhenResolverFails", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		mockConn.EXPECT().
+			WriteFile(gomock.Any(), "/home/coder/myproject/plan.md", gomock.Any()).
+			DoAndReturn(func(_ context.Context, path string, reader io.Reader) error {
+				data, err := io.ReadAll(reader)
+				require.NoError(t, err)
+				require.Equal(t, "/home/coder/myproject/plan.md", path)
+				require.Equal(t, "# Plan", string(data))
+				return nil
+			})
+
+		tool := chattool.WriteFile(chattool.WriteFileOptions{
+			GetWorkspaceConn: func(context.Context) (workspacesdk.AgentConn, error) {
+				return mockConn, nil
+			},
+			ResolvePlanPath: func(context.Context) (string, string, error) {
+				return "", "", xerrors.New("workspace unavailable")
+			},
+		})
+
+		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "write_file",
+			Input: `{"path":"/home/coder/myproject/plan.md","content":"# Plan"}`,
+		})
+		require.NoError(t, err)
+		assert.False(t, resp.IsError)
+		assert.Equal(t, `{"ok":true}`, strings.TrimSpace(resp.Content))
+	})
+
 	t.Run("NestedPlanPathUnderHomeIsAllowed", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)

--- a/coderd/x/chatd/chattool/writefile_test.go
+++ b/coderd/x/chatd/chattool/writefile_test.go
@@ -1,0 +1,113 @@
+package chattool_test
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"charm.land/fantasy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/coderd/x/chatd/chattool"
+	"github.com/coder/coder/v2/codersdk/workspacesdk"
+	"github.com/coder/coder/v2/codersdk/workspacesdk/agentconnmock"
+)
+
+func TestWriteFile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("RejectsSharedPlanPathWhenPlanPathIsConfigured", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		tool := chattool.WriteFile(chattool.WriteFileOptions{
+			GetWorkspaceConn: func(context.Context) (workspacesdk.AgentConn, error) {
+				return mockConn, nil
+			},
+			PlanPath: func(context.Context) (string, error) {
+				return "/home/coder/.coder/plans/PLAN-chat.md", nil
+			},
+		})
+
+		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "write_file",
+			Input: `{"path":"` + chattool.LegacySharedPlanPath + `","content":"# Plan"}`,
+		})
+		require.NoError(t, err)
+		assert.True(t, resp.IsError)
+		assert.Equal(
+			t,
+			sharedPlanPathResolvedMessage("/home/coder/.coder/plans/PLAN-chat.md"),
+			resp.Content,
+		)
+	})
+
+	t.Run("AllowsNonSharedPath", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		mockConn.EXPECT().
+			WriteFile(gomock.Any(), "/home/dev/my-plan.md", gomock.Any()).
+			DoAndReturn(func(_ context.Context, path string, reader io.Reader) error {
+				data, err := io.ReadAll(reader)
+				require.NoError(t, err)
+				require.Equal(t, "/home/dev/my-plan.md", path)
+				require.Equal(t, "# Plan", string(data))
+				return nil
+			})
+
+		planPathCalled := false
+		tool := chattool.WriteFile(chattool.WriteFileOptions{
+			GetWorkspaceConn: func(context.Context) (workspacesdk.AgentConn, error) {
+				return mockConn, nil
+			},
+			PlanPath: func(context.Context) (string, error) {
+				planPathCalled = true
+				return "", xerrors.New("should not be called")
+			},
+		})
+
+		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "write_file",
+			Input: `{"path":"/home/dev/my-plan.md","content":"# Plan"}`,
+		})
+		require.NoError(t, err)
+		assert.False(t, resp.IsError)
+		assert.False(t, planPathCalled)
+		assert.Equal(t, `{"ok":true}`, strings.TrimSpace(resp.Content))
+	})
+
+	t.Run("AllowsSharedPlanPathWhenPlanPathIsNil", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		mockConn.EXPECT().
+			WriteFile(gomock.Any(), chattool.LegacySharedPlanPath, gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ string, reader io.Reader) error {
+				data, err := io.ReadAll(reader)
+				require.NoError(t, err)
+				require.Equal(t, "# Plan", string(data))
+				return nil
+			})
+
+		tool := chattool.WriteFile(chattool.WriteFileOptions{
+			GetWorkspaceConn: func(context.Context) (workspacesdk.AgentConn, error) {
+				return mockConn, nil
+			},
+		})
+
+		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "write_file",
+			Input: `{"path":"` + chattool.LegacySharedPlanPath + `","content":"# Plan"}`,
+		})
+		require.NoError(t, err)
+		assert.False(t, resp.IsError)
+	})
+}

--- a/coderd/x/chatd/chattool/writefile_test.go
+++ b/coderd/x/chatd/chattool/writefile_test.go
@@ -20,7 +20,7 @@ import (
 func TestWriteFile(t *testing.T) {
 	t.Parallel()
 
-	t.Run("RejectsHomeRootPlanVariantsWhenPlanPathIsConfigured", func(t *testing.T) {
+	t.Run("RejectsHomeRootPlanVariantsWhenResolvePlanPathIsConfigured", func(t *testing.T) {
 		t.Parallel()
 
 		tests := []struct {
@@ -46,7 +46,6 @@ func TestWriteFile(t *testing.T) {
 		}
 
 		for _, testCase := range tests {
-			testCase := testCase
 			t.Run(testCase.name, func(t *testing.T) {
 				t.Parallel()
 
@@ -56,7 +55,7 @@ func TestWriteFile(t *testing.T) {
 					GetWorkspaceConn: func(context.Context) (workspacesdk.AgentConn, error) {
 						return mockConn, nil
 					},
-					PlanPath: func(context.Context) (string, string, error) {
+					ResolvePlanPath: func(context.Context) (string, string, error) {
 						return "/home/coder/.coder/plans/PLAN-chat.md", testCase.home, nil
 					},
 				})
@@ -70,9 +69,59 @@ func TestWriteFile(t *testing.T) {
 				assert.True(t, resp.IsError)
 				assert.Equal(
 					t,
-					sharedPlanPathResolvedMessage("/home/coder/.coder/plans/PLAN-chat.md"),
+					sharedPlanPathResolvedMessage(
+						testCase.requested,
+						"/home/coder/.coder/plans/PLAN-chat.md",
+					),
 					resp.Content,
 				)
+			})
+		}
+	})
+
+	t.Run("RejectsRelativePlanPathsWhenResolvePlanPathIsConfigured", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name      string
+			requested string
+		}{
+			{
+				name:      "PlainRelativePath",
+				requested: "plan.md",
+			},
+			{
+				name:      "DotSlashRelativePath",
+				requested: "./plan.md",
+			},
+		}
+
+		for _, testCase := range tests {
+			t.Run(testCase.name, func(t *testing.T) {
+				t.Parallel()
+
+				ctrl := gomock.NewController(t)
+				mockConn := agentconnmock.NewMockAgentConn(ctrl)
+				resolvePlanPathCalled := false
+				tool := chattool.WriteFile(chattool.WriteFileOptions{
+					GetWorkspaceConn: func(context.Context) (workspacesdk.AgentConn, error) {
+						return mockConn, nil
+					},
+					ResolvePlanPath: func(context.Context) (string, string, error) {
+						resolvePlanPathCalled = true
+						return "/home/coder/.coder/plans/PLAN-chat.md", "/home/coder", nil
+					},
+				})
+
+				resp, err := tool.Run(context.Background(), fantasy.ToolCall{
+					ID:    "call-1",
+					Name:  "write_file",
+					Input: `{"path":"` + testCase.requested + `","content":"# Plan"}`,
+				})
+				require.NoError(t, err)
+				assert.True(t, resp.IsError)
+				assert.False(t, resolvePlanPathCalled)
+				assert.Equal(t, relativePlanPathMessage(), resp.Content)
 			})
 		}
 	})
@@ -91,13 +140,13 @@ func TestWriteFile(t *testing.T) {
 				return nil
 			})
 
-		planPathCalled := false
+		resolvePlanPathCalled := false
 		tool := chattool.WriteFile(chattool.WriteFileOptions{
 			GetWorkspaceConn: func(context.Context) (workspacesdk.AgentConn, error) {
 				return mockConn, nil
 			},
-			PlanPath: func(context.Context) (string, string, error) {
-				planPathCalled = true
+			ResolvePlanPath: func(context.Context) (string, string, error) {
+				resolvePlanPathCalled = true
 				return "", "", xerrors.New("should not be called")
 			},
 		})
@@ -109,11 +158,11 @@ func TestWriteFile(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.False(t, resp.IsError)
-		assert.False(t, planPathCalled)
+		assert.False(t, resolvePlanPathCalled)
 		assert.Equal(t, `{"ok":true}`, strings.TrimSpace(resp.Content))
 	})
 
-	t.Run("AllowsSharedPlanPathWhenPlanPathIsNil", func(t *testing.T) {
+	t.Run("AllowsSharedPlanPathWhenResolvePlanPathIsNil", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
 		mockConn := agentconnmock.NewMockAgentConn(ctrl)

--- a/coderd/x/chatd/instruction_test.go
+++ b/coderd/x/chatd/instruction_test.go
@@ -68,7 +68,7 @@ func TestRenderPlanPathPrompt(t *testing.T) {
 		require.Contains(t, text, "Do not use "+chattool.LegacySharedPlanPath+".")
 	})
 
-	t.Run("AppendsBlockToMainSystemMessageWhenPlaceholderMissing", func(t *testing.T) {
+	t.Run("LeavesPromptUnchangedWhenPlaceholderMissing", func(t *testing.T) {
 		t.Parallel()
 
 		prompt := []fantasy.Message{
@@ -97,11 +97,7 @@ func TestRenderPlanPathPrompt(t *testing.T) {
 			"/home/coder",
 		))
 
-		require.Len(t, got, len(prompt))
-		firstText := messageText(t, got[0])
-		require.Contains(t, firstText, "base instructions")
-		require.Contains(t, firstText, "<plan-file-path>")
-		require.Equal(t, "workspace awareness", messageText(t, got[1]))
+		require.Equal(t, prompt, got)
 	})
 
 	t.Run("RemovesPlaceholderWhenPlanPathBlockIsEmpty", func(t *testing.T) {

--- a/coderd/x/chatd/instruction_test.go
+++ b/coderd/x/chatd/instruction_test.go
@@ -12,28 +12,108 @@ import (
 	"github.com/coder/coder/v2/codersdk"
 )
 
-func TestFormatPlanPathInstruction(t *testing.T) {
+func TestRenderPlanPathPrompt(t *testing.T) {
 	t.Parallel()
 
-	t.Run("UsesResolvedHomeInWarning", func(t *testing.T) {
+	newPromptWithPlaceholder := func() []fantasy.Message {
+		return []fantasy.Message{
+			{
+				Role: fantasy.MessageRoleSystem,
+				Content: []fantasy.MessagePart{
+					fantasy.TextPart{Text: "<planning>\n" + defaultSystemPromptPlanPathBlockPlaceholder + "\n</planning>"},
+				},
+			},
+			{
+				Role: fantasy.MessageRoleUser,
+				Content: []fantasy.MessagePart{
+					fantasy.TextPart{Text: "hello"},
+				},
+			},
+		}
+	}
+
+	messageText := func(t *testing.T, message fantasy.Message) string {
+		t.Helper()
+		part, ok := fantasy.AsMessagePart[fantasy.TextPart](message.Content[0])
+		require.True(t, ok)
+		return part.Text
+	}
+
+	t.Run("ReplacesPlaceholderWithResolvedHome", func(t *testing.T) {
 		t.Parallel()
 
-		got := formatPlanPathInstruction(
+		prompt := newPromptWithPlaceholder()
+		got := renderPlanPathPrompt(prompt, formatPlanPathBlock(
 			"/Users/dev/.coder/plans/PLAN-chat.md",
 			"/Users/dev",
-		)
+		))
 
-		require.Contains(t, got, "Your plan file path for this chat is: /Users/dev/.coder/plans/PLAN-chat.md")
-		require.Contains(t, got, "Do not use /Users/dev/PLAN.md.")
-		require.NotContains(t, got, chattool.LegacySharedPlanPath)
+		require.Len(t, got, len(prompt))
+		text := messageText(t, got[0])
+		require.Contains(t, text, "Your plan file path for this chat is: /Users/dev/.coder/plans/PLAN-chat.md")
+		require.Contains(t, text, "Do not use /Users/dev/PLAN.md.")
+		require.NotContains(t, text, defaultSystemPromptPlanPathBlockPlaceholder)
 	})
 
 	t.Run("FallsBackToLegacySharedPathWhenHomeIsEmpty", func(t *testing.T) {
 		t.Parallel()
 
-		got := formatPlanPathInstruction("/home/coder/.coder/plans/PLAN-chat.md", "")
+		prompt := newPromptWithPlaceholder()
+		got := renderPlanPathPrompt(prompt, formatPlanPathBlock(
+			"/home/coder/.coder/plans/PLAN-chat.md",
+			"",
+		))
 
-		require.Contains(t, got, "Do not use "+chattool.LegacySharedPlanPath+".")
+		text := messageText(t, got[0])
+		require.Contains(t, text, "Do not use "+chattool.LegacySharedPlanPath+".")
+	})
+
+	t.Run("AppendsBlockToMainSystemMessageWhenPlaceholderMissing", func(t *testing.T) {
+		t.Parallel()
+
+		prompt := []fantasy.Message{
+			{
+				Role: fantasy.MessageRoleSystem,
+				Content: []fantasy.MessagePart{
+					fantasy.TextPart{Text: "base instructions"},
+				},
+			},
+			{
+				Role: fantasy.MessageRoleSystem,
+				Content: []fantasy.MessagePart{
+					fantasy.TextPart{Text: "workspace awareness"},
+				},
+			},
+			{
+				Role: fantasy.MessageRoleUser,
+				Content: []fantasy.MessagePart{
+					fantasy.TextPart{Text: "hello"},
+				},
+			},
+		}
+
+		got := renderPlanPathPrompt(prompt, formatPlanPathBlock(
+			"/home/coder/.coder/plans/PLAN-chat.md",
+			"/home/coder",
+		))
+
+		require.Len(t, got, len(prompt))
+		firstText := messageText(t, got[0])
+		require.Contains(t, firstText, "base instructions")
+		require.Contains(t, firstText, "<plan-file-path>")
+		require.Equal(t, "workspace awareness", messageText(t, got[1]))
+	})
+
+	t.Run("RemovesPlaceholderWhenPlanPathBlockIsEmpty", func(t *testing.T) {
+		t.Parallel()
+
+		prompt := newPromptWithPlaceholder()
+		got := renderPlanPathPrompt(prompt, "")
+
+		require.Len(t, got, len(prompt))
+		text := messageText(t, got[0])
+		require.NotContains(t, text, defaultSystemPromptPlanPathBlockPlaceholder)
+		require.NotContains(t, text, "<plan-file-path>")
 	})
 }
 

--- a/coderd/x/chatd/instruction_test.go
+++ b/coderd/x/chatd/instruction_test.go
@@ -8,8 +8,34 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/coderd/x/chatd/chatprompt"
+	"github.com/coder/coder/v2/coderd/x/chatd/chattool"
 	"github.com/coder/coder/v2/codersdk"
 )
+
+func TestFormatPlanPathInstruction(t *testing.T) {
+	t.Parallel()
+
+	t.Run("UsesResolvedHomeInWarning", func(t *testing.T) {
+		t.Parallel()
+
+		got := formatPlanPathInstruction(
+			"/Users/dev/.coder/plans/PLAN-chat.md",
+			"/Users/dev",
+		)
+
+		require.Contains(t, got, "Your plan file path for this chat is: /Users/dev/.coder/plans/PLAN-chat.md")
+		require.Contains(t, got, "Do not use /Users/dev/PLAN.md.")
+		require.NotContains(t, got, chattool.LegacySharedPlanPath)
+	})
+
+	t.Run("FallsBackToLegacySharedPathWhenHomeIsEmpty", func(t *testing.T) {
+		t.Parallel()
+
+		got := formatPlanPathInstruction("/home/coder/.coder/plans/PLAN-chat.md", "")
+
+		require.Contains(t, got, "Do not use "+chattool.LegacySharedPlanPath+".")
+	})
+}
 
 func TestInsertSystemInstructionAfterSystemMessages(t *testing.T) {
 	t.Parallel()

--- a/coderd/x/chatd/prompt.go
+++ b/coderd/x/chatd/prompt.go
@@ -88,9 +88,11 @@ Propose a plan when:
 If no workspace is attached to this chat yet, create and start one first using create_workspace and start_workspace.
 Once a workspace is available:
 1. Use spawn_agent and wait_agent to research the codebase and gather context as needed.
-2. Use write_file to create a Markdown plan file at the chat-specific plan path provided in your instructions.
+2. Use write_file to create a Markdown plan file at the chat-specific
+   plan path provided in your runtime instructions (if available).
 3. Iterate on the plan with edit_files if needed.
-4. Call propose_plan with the absolute plan file path from your instructions to present the plan to the user.
+4. Call propose_plan with the absolute plan file path from your runtime
+   instructions to present the plan to the user.
 5. Wait for the user to review and approve the plan before starting implementation.
 
 The propose_plan tool reads the file from the workspace. Do not pass content directly.

--- a/coderd/x/chatd/prompt.go
+++ b/coderd/x/chatd/prompt.go
@@ -88,7 +88,7 @@ Propose a plan when:
 If no workspace is attached to this chat yet, create and start one first using create_workspace and start_workspace.
 Once a workspace is available:
 1. Use spawn_agent and wait_agent to research the codebase and gather context as needed.
-2. Use write_file to create a Markdown plan file in the workspace at the chat-specific plan path provided in your instructions.
+2. Use write_file to create a Markdown plan file at the chat-specific plan path provided in your instructions.
 3. Iterate on the plan with edit_files if needed.
 4. Call propose_plan with the absolute plan file path from your instructions to present the plan to the user.
 5. Wait for the user to review and approve the plan before starting implementation.

--- a/coderd/x/chatd/prompt.go
+++ b/coderd/x/chatd/prompt.go
@@ -1,5 +1,7 @@
 package chatd
 
+const defaultSystemPromptPlanPathBlockPlaceholder = "{{CODER_CHAT_PLAN_FILE_PATH_BLOCK}}"
+
 // DefaultSystemPrompt is used for new chats when no deployment override is
 // configured.
 const DefaultSystemPrompt = `You are the Coder agent — an interactive chat tool that helps users with software-engineering tasks inside of the Coder product.
@@ -88,13 +90,16 @@ Propose a plan when:
 If no workspace is attached to this chat yet, create and start one first using create_workspace and start_workspace.
 Once a workspace is available:
 1. Use spawn_agent and wait_agent to research the codebase and gather context as needed.
-2. Use write_file to create a Markdown plan file at the chat-specific
-   plan path provided in your runtime instructions (if available).
+2. Use write_file to create a Markdown plan file at the absolute
+   chat-specific path from the <plan-file-path> block below when it is
+   available.
 3. Iterate on the plan with edit_files if needed.
-4. Call propose_plan with the absolute plan file path from your runtime
-   instructions to present the plan to the user.
+4. Call propose_plan with the same absolute plan file path from the
+   <plan-file-path> block below.
 5. Wait for the user to review and approve the plan before starting implementation.
 
 The propose_plan tool reads the file from the workspace. Do not pass content directly.
 Write the file first, then present it. All file paths must be absolute.
+When the <plan-file-path> block below is present, use that exact path.
+` + defaultSystemPromptPlanPathBlockPlaceholder + `
 </planning>`

--- a/coderd/x/chatd/prompt.go
+++ b/coderd/x/chatd/prompt.go
@@ -88,11 +88,11 @@ Propose a plan when:
 If no workspace is attached to this chat yet, create and start one first using create_workspace and start_workspace.
 Once a workspace is available:
 1. Use spawn_agent and wait_agent to research the codebase and gather context as needed.
-2. Use write_file to create a Markdown plan file in the workspace (e.g. /home/coder/PLAN.md).
+2. Use write_file to create a Markdown plan file in the workspace at the chat-specific plan path provided in your instructions.
 3. Iterate on the plan with edit_files if needed.
-4. Call propose_plan with the absolute file path to present the plan to the user.
+4. Call propose_plan with the absolute plan file path from your instructions to present the plan to the user.
 5. Wait for the user to review and approve the plan before starting implementation.
 
-The propose_plan tool reads the file from the workspace — do not pass content directly.
+The propose_plan tool reads the file from the workspace. Do not pass content directly.
 Write the file first, then present it. All file paths must be absolute.
 </planning>`

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ProposePlanTool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ProposePlanTool.stories.tsx
@@ -35,6 +35,10 @@ const samplePlan = [
 	"> **Note**: Based on [RFC 6749](https://tools.ietf.org/html/rfc6749).",
 ].join("\n");
 
+const defaultPlanPath =
+	"/home/coder/.coder/plans/PLAN-a1b2c3d4-e5f6-7890-abcd-ef1234567890.md";
+const defaultPlanFilename = defaultPlanPath.split("/").pop() ?? "PLAN.md";
+
 const meta: Meta<typeof Tool> = {
 	title: "pages/AgentsPage/ChatElements/tools/ProposePlan",
 	component: Tool,
@@ -54,20 +58,22 @@ export default meta;
 type Story = StoryObj<typeof Tool>;
 
 export const Running: Story = {
-	args: { status: "running", args: { path: "/home/coder/PLAN.md" } },
+	args: { status: "running", args: { path: defaultPlanPath } },
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		expect(canvas.getByText(/Proposing PLAN\.md/)).toBeInTheDocument();
+		expect(
+			canvas.getByText(`Proposing ${defaultPlanFilename}…`),
+		).toBeInTheDocument();
 	},
 };
 
 export const Completed: Story = {
 	args: {
 		status: "completed",
-		args: { path: "/home/coder/PLAN.md" },
+		args: { path: defaultPlanPath },
 		result: {
 			ok: true,
-			path: "/home/coder/PLAN.md",
+			path: defaultPlanPath,
 			kind: "plan",
 			file_id: "test-file-id-completed",
 			media_type: "text/markdown",
@@ -138,12 +144,14 @@ export const ErrorState: Story = {
 	args: {
 		status: "completed",
 		isError: true,
-		args: { path: "/home/coder/PLAN.md" },
+		args: { path: defaultPlanPath },
 		result: "Failed to read file: file not found",
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		expect(canvas.getByText(/Proposed PLAN\.md/)).toBeInTheDocument();
+		expect(
+			canvas.getByText(`Proposed ${defaultPlanFilename}`),
+		).toBeInTheDocument();
 		expect(canvas.getByLabelText("Error")).toBeInTheDocument();
 	},
 };
@@ -151,10 +159,10 @@ export const ErrorState: Story = {
 export const EmptyContent: Story = {
 	args: {
 		status: "completed",
-		args: { path: "/home/coder/PLAN.md" },
+		args: { path: defaultPlanPath },
 		result: {
 			ok: true,
-			path: "/home/coder/PLAN.md",
+			path: defaultPlanPath,
 			kind: "plan",
 			file_id: "test-file-id-empty-content",
 			media_type: "text/markdown",
@@ -172,10 +180,10 @@ export const EmptyContent: Story = {
 export const FileIDLoading: Story = {
 	args: {
 		status: "completed",
-		args: { path: "/home/coder/PLAN.md" },
+		args: { path: defaultPlanPath },
 		result: {
 			ok: true,
-			path: "/home/coder/PLAN.md",
+			path: defaultPlanPath,
 			kind: "plan",
 			file_id: "test-file-id-loading",
 			media_type: "text/markdown",
@@ -195,10 +203,10 @@ export const FileIDLoading: Story = {
 export const FileIDCompleted: Story = {
 	args: {
 		status: "completed",
-		args: { path: "/home/coder/PLAN.md" },
+		args: { path: defaultPlanPath },
 		result: {
 			ok: true,
-			path: "/home/coder/PLAN.md",
+			path: defaultPlanPath,
 			kind: "plan",
 			file_id: "test-file-id-success",
 			media_type: "text/markdown",
@@ -216,10 +224,10 @@ export const FileIDCompleted: Story = {
 export const FileIDFetchError: Story = {
 	args: {
 		status: "completed",
-		args: { path: "/home/coder/PLAN.md" },
+		args: { path: defaultPlanPath },
 		result: {
 			ok: true,
-			path: "/home/coder/PLAN.md",
+			path: defaultPlanPath,
 			kind: "plan",
 			file_id: "test-file-id-error",
 			media_type: "text/markdown",


### PR DESCRIPTION
> This PR was authored by Mux on behalf of Mike.

Chats sharing one workspace (e.g. sibling subagents) all wrote to `/home/coder/PLAN.md`, causing plan file collisions. This change derives a unique plan path per chat from the workspace home directory and chat ID.

## Changes

* `write_file`, `edit_files`, and `propose_plan` reject any `plan.md` variant (case-insensitive) at the workspace home root, with a clear error pointing to the chat-specific path.
* Root chats receive a `<plan-file-path>` block inlined in the main system prompt with the concrete path.
* Prompt and tool descriptions no longer hardcode `/home/coder/PLAN.md`.
* Plan path handling is POSIX-only (forward-slash), relying on the contract that workspace agent paths are normalized before reaching chatd.
* Updated `ProposePlanTool.stories.tsx` to use per-chat path examples.
* Full test coverage for plan path detection, legacy-path rejection in all three tools, inline prompt rendering, and fallback behavior.
