### PR TITLE
DONT MERGE TEST feat: implement Review Unread Chats feature

### DIFF
--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -737,7 +737,7 @@ const AgentsPage: FC = () => {
 				onArchivedFilterChange={setArchivedFilter}
 				reviewDialogOpen={reviewDialogOpen}
 				onOpenReviewDialog={() => setReviewDialogOpen(true)}
-				onCloseReviewDialog={() => setReviewDialogOpen(false)}
+				onReviewDialogOpenChange={setReviewDialogOpen}
 				onChatReviewed={markChatAsRead}
 			/>
 			<ConfirmDialog

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -1,4 +1,4 @@
-import { type FC, useEffect, useRef, useState } from "react";
+import { type FC, useCallback, useEffect, useRef, useState } from "react";
 import {
 	useInfiniteQuery,
 	useMutation,
@@ -268,6 +268,21 @@ const AgentsPage: FC = () => {
 		readonly string[]
 	>([]);
 	const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
+	const [reviewDialogOpen, setReviewDialogOpen] = useState(false);
+	const markChatAsRead = useCallback(
+		(chatId: string) => {
+			updateInfiniteChatsCache(queryClient, (chats) => {
+				let changed = false;
+				const next = chats.map((c) => {
+					if (c.id !== chatId || !c.has_unread) return c;
+					changed = true;
+					return { ...c, has_unread: false };
+				});
+				return changed ? next : chats;
+			});
+		},
+		[queryClient],
+	);
 	const catalogModelOptions = getModelOptionsFromConfigs(
 		chatModelConfigsQuery.data,
 		chatModelsQuery.data,
@@ -720,6 +735,10 @@ const AgentsPage: FC = () => {
 				isFetchingNextPage={chatsQuery.isFetchingNextPage}
 				archivedFilter={archivedFilter}
 				onArchivedFilterChange={setArchivedFilter}
+				reviewDialogOpen={reviewDialogOpen}
+				onOpenReviewDialog={() => setReviewDialogOpen(true)}
+				onCloseReviewDialog={() => setReviewDialogOpen(false)}
+				onChatReviewed={markChatAsRead}
 			/>
 			<ConfirmDialog
 				open={pendingArchiveChatId !== null}

--- a/site/src/pages/AgentsPage/AgentsPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageView.stories.tsx
@@ -252,7 +252,7 @@ const defaultArgs: ComponentProps<typeof AgentsPageView> = {
 	isFetchingNextPage: false,
 	reviewDialogOpen: false,
 	onOpenReviewDialog: fn(),
-	onCloseReviewDialog: fn(),
+	onReviewDialogOpenChange: fn(),
 	onChatReviewed: fn(),
 };
 

--- a/site/src/pages/AgentsPage/AgentsPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageView.stories.tsx
@@ -250,6 +250,10 @@ const defaultArgs: ComponentProps<typeof AgentsPageView> = {
 	hasNextPage: false,
 	onLoadMore: fn(),
 	isFetchingNextPage: false,
+	reviewDialogOpen: false,
+	onOpenReviewDialog: fn(),
+	onCloseReviewDialog: fn(),
+	onChatReviewed: fn(),
 };
 
 const meta: Meta<typeof AgentsPageView> = {

--- a/site/src/pages/AgentsPage/AgentsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageView.tsx
@@ -74,7 +74,7 @@ interface AgentsPageViewProps {
 	onArchivedFilterChange: (filter: "active" | "archived") => void;
 	reviewDialogOpen: boolean;
 	onOpenReviewDialog: () => void;
-	onCloseReviewDialog: () => void;
+	onReviewDialogOpenChange: (open: boolean) => void;
 	onChatReviewed: (chatId: string) => void;
 }
 
@@ -114,7 +114,7 @@ export const AgentsPageView: FC<AgentsPageViewProps> = ({
 	onArchivedFilterChange,
 	reviewDialogOpen,
 	onOpenReviewDialog,
-	onCloseReviewDialog,
+	onReviewDialogOpenChange,
 	onChatReviewed,
 }) => {
 	const location = useLocation();
@@ -219,7 +219,7 @@ export const AgentsPageView: FC<AgentsPageViewProps> = ({
 			</div>
 			<ReviewUnreadDialog
 				open={reviewDialogOpen}
-				onOpenChange={onCloseReviewDialog}
+				onOpenChange={onReviewDialogOpenChange}
 				unreadChats={unreadChats}
 				onChatReviewed={onChatReviewed}
 			/>

--- a/site/src/pages/AgentsPage/AgentsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageView.tsx
@@ -4,10 +4,12 @@ import type * as TypesGen from "#/api/typesGenerated";
 import { cn } from "#/utils/cn";
 import { pageTitle } from "#/utils/page";
 import type { ModelSelectorOption } from "./components/ChatElements";
+import { ReviewUnreadDialog } from "./components/ReviewUnreadDialog";
 import {
 	AgentsSidebar,
 	sidebarViewFromPath,
 } from "./components/Sidebar/AgentsSidebar";
+import { useUnreadChats } from "./hooks/useUnreadChats";
 import type { ChatDetailError } from "./utils/usageLimitMessage";
 
 export interface AgentsOutletContext {
@@ -70,6 +72,10 @@ interface AgentsPageViewProps {
 	isFetchingNextPage: boolean;
 	archivedFilter: "active" | "archived";
 	onArchivedFilterChange: (filter: "active" | "archived") => void;
+	reviewDialogOpen: boolean;
+	onOpenReviewDialog: () => void;
+	onCloseReviewDialog: () => void;
+	onChatReviewed: (chatId: string) => void;
 }
 
 export const AgentsPageView: FC<AgentsPageViewProps> = ({
@@ -106,9 +112,15 @@ export const AgentsPageView: FC<AgentsPageViewProps> = ({
 	isFetchingNextPage,
 	archivedFilter,
 	onArchivedFilterChange,
+	reviewDialogOpen,
+	onOpenReviewDialog,
+	onCloseReviewDialog,
+	onChatReviewed,
 }) => {
 	const location = useLocation();
 	const sidebarView = sidebarViewFromPath(location.pathname);
+
+	const { unreadChats } = useUnreadChats(chatList);
 
 	// Mobile can't fit the sidebar nav and content side by side,
 	// so we show one or the other depending on the route depth.
@@ -190,6 +202,7 @@ export const AgentsPageView: FC<AgentsPageViewProps> = ({
 					onArchivedFilterChange={onArchivedFilterChange}
 					onCollapse={onCollapseSidebar}
 					isAdmin={isAgentsAdmin}
+					onOpenReviewDialog={onOpenReviewDialog}
 				/>
 			</div>
 			<div
@@ -204,6 +217,12 @@ export const AgentsPageView: FC<AgentsPageViewProps> = ({
 			>
 				<Outlet context={outletContextValue} />
 			</div>
+			<ReviewUnreadDialog
+				open={reviewDialogOpen}
+				onOpenChange={onCloseReviewDialog}
+				unreadChats={unreadChats}
+				onChatReviewed={onChatReviewed}
+			/>
 		</div>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ReviewUnreadDialog.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ReviewUnreadDialog.stories.tsx
@@ -1,0 +1,91 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+import type { Chat } from "#/api/typesGenerated";
+import { MockUserOwner } from "#/testHelpers/entities";
+import {
+	withAuthProvider,
+	withDashboardProvider,
+} from "#/testHelpers/storybook";
+import { ReviewUnreadDialog } from "./ReviewUnreadDialog";
+
+const now = new Date().toISOString();
+const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+
+const buildChat = (overrides: Partial<Chat> = {}): Chat => ({
+	id: `chat-${Math.random().toString(36).slice(2)}`,
+	owner_id: "owner-1",
+	title: "Untitled chat",
+	status: "completed",
+	last_model_config_id: "config-1",
+	mcp_server_ids: [],
+	labels: {},
+	created_at: oneHourAgo,
+	updated_at: now,
+	archived: false,
+	pin_order: 0,
+	has_unread: true,
+	last_error: null,
+	...overrides,
+});
+
+const unreadChats = [
+	buildChat({
+		id: "chat-1",
+		title: "Fix authentication bug in login flow",
+		status: "completed",
+	}),
+	buildChat({
+		id: "chat-2",
+		title: "Add dark mode support to settings page",
+		status: "waiting",
+	}),
+	buildChat({
+		id: "chat-3",
+		title: "Refactor database queries for performance",
+		status: "running",
+	}),
+	buildChat({
+		id: "chat-4",
+		title: "Write unit tests for user service",
+		status: "error",
+		last_error: "Test runner process exited unexpectedly",
+	}),
+	buildChat({
+		id: "chat-5",
+		title: "Update API documentation for v2 endpoints",
+		status: "completed",
+	}),
+];
+
+const meta: Meta<typeof ReviewUnreadDialog> = {
+	title: "pages/AgentsPage/ReviewUnreadDialog",
+	component: ReviewUnreadDialog,
+	decorators: [withAuthProvider, withDashboardProvider],
+	args: {
+		open: true,
+		onOpenChange: fn(),
+		onChatReviewed: fn(),
+		unreadChats,
+	},
+	parameters: {
+		layout: "fullscreen",
+		user: MockUserOwner,
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof ReviewUnreadDialog>;
+
+export const Default: Story = {};
+
+export const LastChat: Story = {
+	args: {
+		unreadChats: [unreadChats[0]],
+	},
+};
+
+export const WithError: Story = {
+	args: {
+		unreadChats: [unreadChats[3], unreadChats[0]],
+	},
+};

--- a/site/src/pages/AgentsPage/components/ReviewUnreadDialog.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ReviewUnreadDialog.stories.tsx
@@ -89,3 +89,9 @@ export const WithError: Story = {
 		unreadChats: [unreadChats[3], unreadChats[0]],
 	},
 };
+
+export const Empty: Story = {
+	args: {
+		unreadChats: [],
+	},
+};

--- a/site/src/pages/AgentsPage/components/ReviewUnreadDialog.tsx
+++ b/site/src/pages/AgentsPage/components/ReviewUnreadDialog.tsx
@@ -1,11 +1,22 @@
-import { ChevronLeftIcon, ChevronRightIcon, XIcon } from "lucide-react";
-import { type FC, useEffect, useState } from "react";
+import {
+	ChevronLeftIcon,
+	ChevronRightIcon,
+	ExternalLinkIcon,
+	XIcon,
+} from "lucide-react";
+import { type FC, useEffect, useRef, useState } from "react";
 import { useInfiniteQuery } from "react-query";
+import { useNavigate } from "react-router";
 import { chatMessagesForInfiniteScroll } from "#/api/queries/chats";
 import type { Chat, ChatMessage } from "#/api/typesGenerated";
 import { Button } from "#/components/Button/Button";
 import { Dialog, DialogContent, DialogTitle } from "#/components/Dialog/Dialog";
 import { Spinner } from "#/components/Spinner/Spinner";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "#/components/Tooltip/Tooltip";
 import { deriveChatSummary } from "../hooks/useChatSummary";
 import { ConversationTimeline } from "./ChatConversation/ConversationTimeline";
 import {
@@ -28,20 +39,30 @@ export const ReviewUnreadDialog: FC<ReviewUnreadDialogProps> = ({
 	onChatReviewed,
 }) => {
 	const [currentIndex, setCurrentIndex] = useState(0);
+	const navigate = useNavigate();
 
-	// Reset index when dialog opens or unread list changes
+	// Snapshot the unread chat list when the dialog opens so that
+	// marking chats as read doesn't shift indices mid-review.
+	const [snapshotChats, setSnapshotChats] = useState<Chat[]>([]);
+
+	// Capture a stable snapshot when the dialog opens and reset
+	// the index so every review session starts from the first
+	// chat. We intentionally omit unreadChats from the deps so
+	// the snapshot stays frozen for the duration of the session.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: snapshot only on open
 	useEffect(() => {
 		if (open) {
+			setSnapshotChats(unreadChats);
 			setCurrentIndex(0);
 		}
 	}, [open]);
 
-	const currentChat = unreadChats[currentIndex];
+	const currentChat = snapshotChats[currentIndex];
 
 	const handleNext = () => {
 		if (!currentChat) return;
 		onChatReviewed(currentChat.id);
-		if (currentIndex >= unreadChats.length - 1) {
+		if (currentIndex >= snapshotChats.length - 1) {
 			onOpenChange(false);
 		} else {
 			setCurrentIndex((prev) => prev + 1);
@@ -52,6 +73,12 @@ export const ReviewUnreadDialog: FC<ReviewUnreadDialogProps> = ({
 		if (currentIndex > 0) {
 			setCurrentIndex((prev) => prev - 1);
 		}
+	};
+
+	const handleOpenInChat = () => {
+		if (!currentChat) return;
+		onOpenChange(false);
+		navigate(`/agents/${currentChat.id}`);
 	};
 
 	if (!currentChat) {
@@ -69,31 +96,46 @@ export const ReviewUnreadDialog: FC<ReviewUnreadDialogProps> = ({
 					<DialogTitle className="truncate text-lg">
 						{currentChat.title || "Untitled chat"}
 					</DialogTitle>
-					<Button
-						variant="subtle"
-						size="icon"
-						onClick={() => onOpenChange(false)}
-						aria-label="Close"
-					>
-						<XIcon className="size-4" />
-					</Button>
+					<div className="flex items-center gap-1 shrink-0">
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<Button
+									variant="subtle"
+									size="icon"
+									onClick={handleOpenInChat}
+									aria-label="Open in chat"
+								>
+									<ExternalLinkIcon className="size-4" />
+								</Button>
+							</TooltipTrigger>
+							<TooltipContent>Open in chat</TooltipContent>
+						</Tooltip>
+						<Button
+							variant="subtle"
+							size="icon"
+							onClick={() => onOpenChange(false)}
+							aria-label="Close"
+						>
+							<XIcon className="size-4" />
+						</Button>
+					</div>
 				</div>
 
 				{/* Review Banner */}
 				<ReviewBanner chat={currentChat} />
 
 				{/* Chat Content */}
-				<div className="flex-1 overflow-y-auto min-h-0">
+				<div className="flex-1 min-h-0">
 					<ReviewChatContent chatId={currentChat.id} />
 				</div>
 
 				{/* Navigation Bar */}
 				<ReviewNavigationBar
 					currentIndex={currentIndex}
-					totalCount={unreadChats.length}
+					totalCount={snapshotChats.length}
 					onPrevious={handlePrevious}
 					onNext={handleNext}
-					isLast={currentIndex >= unreadChats.length - 1}
+					isLast={currentIndex >= snapshotChats.length - 1}
 				/>
 			</DialogContent>
 		</Dialog>
@@ -143,6 +185,7 @@ interface ReviewChatContentProps {
 }
 
 const ReviewChatContent: FC<ReviewChatContentProps> = ({ chatId }) => {
+	const bottomRef = useRef<HTMLDivElement>(null);
 	const messagesQuery = useInfiniteQuery({
 		...chatMessagesForInfiniteScroll(chatId),
 	});
@@ -153,6 +196,20 @@ const ReviewChatContent: FC<ReviewChatContentProps> = ({ chatId }) => {
 	const parsedMessages = parseMessagesWithMergedTools(allMessages);
 	const subagentTitles = buildSubagentTitles(parsedMessages);
 	const computerUseSubagentIds = buildComputerUseSubagentIds(parsedMessages);
+
+	// Scroll to the bottom once messages finish loading so the
+	// user sees the most recent activity first. A double-rAF
+	// ensures the browser has completed layout after React
+	// commits the DOM update.
+	useEffect(() => {
+		if (!messagesQuery.isLoading && allMessages.length > 0) {
+			requestAnimationFrame(() => {
+				requestAnimationFrame(() => {
+					bottomRef.current?.scrollIntoView({ block: "end" });
+				});
+			});
+		}
+	}, [messagesQuery.isLoading, allMessages.length]);
 
 	if (messagesQuery.isLoading) {
 		return (
@@ -171,13 +228,16 @@ const ReviewChatContent: FC<ReviewChatContentProps> = ({ chatId }) => {
 	}
 
 	return (
-		<div className="mx-auto flex w-full max-w-3xl flex-col gap-2 py-6">
-			<ConversationTimeline
-				parsedMessages={parsedMessages}
-				subagentTitles={subagentTitles}
-				computerUseSubagentIds={computerUseSubagentIds}
-				showDesktopPreviews={false}
-			/>
+		<div className="h-full overflow-y-auto">
+			<div className="mx-auto flex w-full max-w-3xl flex-col gap-2 py-6">
+				<ConversationTimeline
+					parsedMessages={parsedMessages}
+					subagentTitles={subagentTitles}
+					computerUseSubagentIds={computerUseSubagentIds}
+					showDesktopPreviews={false}
+				/>
+				<div ref={bottomRef} />
+			</div>
 		</div>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ReviewUnreadDialog.tsx
+++ b/site/src/pages/AgentsPage/components/ReviewUnreadDialog.tsx
@@ -1,0 +1,226 @@
+import { ChevronLeftIcon, ChevronRightIcon, XIcon } from "lucide-react";
+import { type FC, useEffect, useState } from "react";
+import { useInfiniteQuery } from "react-query";
+import { chatMessagesForInfiniteScroll } from "#/api/queries/chats";
+import type { Chat, ChatMessage } from "#/api/typesGenerated";
+import { Button } from "#/components/Button/Button";
+import { Dialog, DialogContent, DialogTitle } from "#/components/Dialog/Dialog";
+import { Spinner } from "#/components/Spinner/Spinner";
+import { deriveChatSummary } from "../hooks/useChatSummary";
+import { ConversationTimeline } from "./ChatConversation/ConversationTimeline";
+import {
+	buildComputerUseSubagentIds,
+	buildSubagentTitles,
+	parseMessagesWithMergedTools,
+} from "./ChatConversation/messageParsing";
+
+interface ReviewUnreadDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	unreadChats: Chat[];
+	onChatReviewed: (chatId: string) => void;
+}
+
+export const ReviewUnreadDialog: FC<ReviewUnreadDialogProps> = ({
+	open,
+	onOpenChange,
+	unreadChats,
+	onChatReviewed,
+}) => {
+	const [currentIndex, setCurrentIndex] = useState(0);
+
+	// Reset index when dialog opens or unread list changes
+	useEffect(() => {
+		if (open) {
+			setCurrentIndex(0);
+		}
+	}, [open]);
+
+	const currentChat = unreadChats[currentIndex];
+
+	const handleNext = () => {
+		if (!currentChat) return;
+		onChatReviewed(currentChat.id);
+		if (currentIndex >= unreadChats.length - 1) {
+			onOpenChange(false);
+		} else {
+			setCurrentIndex((prev) => prev + 1);
+		}
+	};
+
+	const handlePrevious = () => {
+		if (currentIndex > 0) {
+			setCurrentIndex((prev) => prev - 1);
+		}
+	};
+
+	if (!currentChat) {
+		return null;
+	}
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent
+				className="flex max-w-5xl flex-col gap-0 overflow-hidden p-0 h-[85vh]"
+				aria-describedby={undefined}
+			>
+				{/* Header */}
+				<div className="flex items-center justify-between border-b border-border-default px-6 py-4">
+					<DialogTitle className="truncate text-lg">
+						{currentChat.title || "Untitled chat"}
+					</DialogTitle>
+					<Button
+						variant="subtle"
+						size="icon"
+						onClick={() => onOpenChange(false)}
+						aria-label="Close"
+					>
+						<XIcon className="size-4" />
+					</Button>
+				</div>
+
+				{/* Review Banner */}
+				<ReviewBanner chat={currentChat} />
+
+				{/* Chat Content */}
+				<div className="flex-1 overflow-y-auto min-h-0">
+					<ReviewChatContent chatId={currentChat.id} />
+				</div>
+
+				{/* Navigation Bar */}
+				<ReviewNavigationBar
+					currentIndex={currentIndex}
+					totalCount={unreadChats.length}
+					onPrevious={handlePrevious}
+					onNext={handleNext}
+					isLast={currentIndex >= unreadChats.length - 1}
+				/>
+			</DialogContent>
+		</Dialog>
+	);
+};
+
+interface ReviewBannerProps {
+	chat: Chat;
+}
+
+const ReviewBanner: FC<ReviewBannerProps> = ({ chat }) => {
+	const messagesQuery = useInfiniteQuery({
+		...chatMessagesForInfiniteScroll(chat.id),
+		enabled: true,
+	});
+
+	const allMessages: ChatMessage[] =
+		messagesQuery.data?.pages.flatMap((page) => page.messages).reverse() ?? [];
+
+	const firstUserMessage = allMessages.find((m) => m.role === "user");
+	const firstUserText = firstUserMessage?.content
+		?.filter(
+			(part): part is { type: "text"; text: string } => part.type === "text",
+		)
+		.map((part) => part.text)
+		.join(" ");
+
+	const summary = deriveChatSummary(chat, allMessages);
+
+	return (
+		<div className="border-b border-border-default bg-surface-secondary px-6 py-4 space-y-2">
+			{firstUserText && (
+				<p className="text-sm text-content-secondary line-clamp-2">
+					<span className="font-medium text-content-primary">
+						Original message:
+					</span>{" "}
+					{firstUserText}
+				</p>
+			)}
+			{summary && <p className="text-sm text-content-secondary">{summary}</p>}
+		</div>
+	);
+};
+
+interface ReviewChatContentProps {
+	chatId: string;
+}
+
+const ReviewChatContent: FC<ReviewChatContentProps> = ({ chatId }) => {
+	const messagesQuery = useInfiniteQuery({
+		...chatMessagesForInfiniteScroll(chatId),
+	});
+
+	const allMessages: ChatMessage[] =
+		messagesQuery.data?.pages.flatMap((page) => page.messages).reverse() ?? [];
+
+	const parsedMessages = parseMessagesWithMergedTools(allMessages);
+	const subagentTitles = buildSubagentTitles(parsedMessages);
+	const computerUseSubagentIds = buildComputerUseSubagentIds(parsedMessages);
+
+	if (messagesQuery.isLoading) {
+		return (
+			<div className="flex h-full items-center justify-center">
+				<Spinner loading className="size-8 text-content-secondary" />
+			</div>
+		);
+	}
+
+	if (allMessages.length === 0) {
+		return (
+			<div className="flex h-full items-center justify-center text-sm text-content-secondary">
+				No messages in this chat.
+			</div>
+		);
+	}
+
+	return (
+		<div className="mx-auto flex w-full max-w-3xl flex-col gap-2 py-6">
+			<ConversationTimeline
+				parsedMessages={parsedMessages}
+				subagentTitles={subagentTitles}
+				computerUseSubagentIds={computerUseSubagentIds}
+				showDesktopPreviews={false}
+			/>
+		</div>
+	);
+};
+
+interface ReviewNavigationBarProps {
+	currentIndex: number;
+	totalCount: number;
+	onPrevious: () => void;
+	onNext: () => void;
+	isLast: boolean;
+}
+
+const ReviewNavigationBar: FC<ReviewNavigationBarProps> = ({
+	currentIndex,
+	totalCount,
+	onPrevious,
+	onNext,
+	isLast,
+}) => {
+	return (
+		<div className="flex items-center justify-between border-t border-border-default px-6 py-3 bg-surface-primary">
+			<Button
+				variant="outline"
+				size="sm"
+				onClick={onPrevious}
+				disabled={currentIndex === 0}
+			>
+				<ChevronLeftIcon className="size-4" />
+				Previous
+			</Button>
+
+			<span className="text-sm text-content-secondary">
+				{currentIndex + 1} of {totalCount}
+			</span>
+
+			<Button
+				variant={isLast ? "default" : "outline"}
+				size="sm"
+				onClick={onNext}
+			>
+				{isLast ? "Done" : "Next"}
+				{!isLast && <ChevronRightIcon className="size-4" />}
+			</Button>
+		</div>
+	);
+};

--- a/site/src/pages/AgentsPage/components/ReviewUnreadDialog.tsx
+++ b/site/src/pages/AgentsPage/components/ReviewUnreadDialog.tsx
@@ -1,4 +1,5 @@
 import {
+	ArrowUpIcon,
 	ChevronLeftIcon,
 	ChevronRightIcon,
 	ExternalLinkIcon,
@@ -126,6 +127,16 @@ export const ReviewUnreadDialog: FC<ReviewUnreadDialogProps> = ({
 						<div className="flex-1 min-h-0">
 							<ReviewChatContent chatId={currentChat.id} />
 						</div>
+
+						{/* Reply Input */}
+						<ReviewReplyInput
+							onSend={(message) => {
+								onOpenChange(false);
+								navigate(`/agents/${currentChat.id}`, {
+									state: { pendingMessage: message },
+								});
+							}}
+						/>
 
 						{/* Navigation Bar */}
 						<ReviewNavigationBar
@@ -300,6 +311,66 @@ const ReviewNavigationBar: FC<ReviewNavigationBarProps> = ({
 				{isLast ? "Done" : "Next"}
 				{!isLast && <ChevronRightIcon className="size-4" />}
 			</Button>
+		</div>
+	);
+};
+
+interface ReviewReplyInputProps {
+	onSend: (message: string) => void;
+}
+
+const ReviewReplyInput: FC<ReviewReplyInputProps> = ({ onSend }) => {
+	const [value, setValue] = useState("");
+	const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+	const handleSubmit = () => {
+		const trimmed = value.trim();
+		if (!trimmed) return;
+		onSend(trimmed);
+		setValue("");
+	};
+
+	const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+		if (e.key === "Enter" && !e.shiftKey) {
+			e.preventDefault();
+			handleSubmit();
+		}
+	};
+
+	// Auto-resize the textarea to fit content.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: value drives the resize
+	useEffect(() => {
+		const el = textareaRef.current;
+		if (!el) return;
+		el.style.height = "auto";
+		el.style.height = `${Math.min(el.scrollHeight, 120)}px`;
+	}, [value]);
+
+	return (
+		<div className="border-t border-border-default px-6 py-3">
+			<div className="rounded-2xl border border-border-default/80 bg-surface-secondary/45 p-1 shadow-sm has-[textarea:focus]:ring-2 has-[textarea:focus]:ring-content-link/40">
+				<textarea
+					ref={textareaRef}
+					value={value}
+					onChange={(e) => setValue(e.target.value)}
+					onKeyDown={handleKeyDown}
+					placeholder="Reply to this agent…"
+					rows={1}
+					className="min-h-[44px] w-full resize-none bg-transparent px-3 py-2 font-sans text-[15px] leading-6 text-content-primary placeholder:text-content-secondary focus:outline-none"
+				/>
+				<div className="flex items-center justify-end px-2.5 pb-1.5">
+					<Button
+						size="icon"
+						variant="default"
+						className="size-7 rounded-full [&>svg]:!size-5 [&>svg]:p-0"
+						onClick={handleSubmit}
+						disabled={!value.trim()}
+						aria-label="Send and open chat"
+					>
+						<ArrowUpIcon />
+					</Button>
+				</div>
+			</div>
 		</div>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ReviewUnreadDialog.tsx
+++ b/site/src/pages/AgentsPage/components/ReviewUnreadDialog.tsx
@@ -81,62 +81,81 @@ export const ReviewUnreadDialog: FC<ReviewUnreadDialogProps> = ({
 		navigate(`/agents/${currentChat.id}`);
 	};
 
-	if (!currentChat) {
-		return null;
-	}
-
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
 			<DialogContent
 				className="flex max-w-5xl flex-col gap-0 overflow-hidden p-0 h-[85vh]"
 				aria-describedby={undefined}
 			>
-				{/* Header */}
-				<div className="flex items-center justify-between border-b border-border-default px-6 py-4">
-					<DialogTitle className="truncate text-lg">
-						{currentChat.title || "Untitled chat"}
-					</DialogTitle>
-					<div className="flex items-center gap-1 shrink-0">
-						<Tooltip>
-							<TooltipTrigger asChild>
+				{currentChat ? (
+					<>
+						{/* Header */}
+						<div className="flex items-center justify-between border-b border-border-default px-6 py-4">
+							<DialogTitle className="truncate text-lg">
+								{currentChat.title || "Untitled chat"}
+							</DialogTitle>
+							<div className="flex items-center gap-1 shrink-0">
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<Button
+											variant="subtle"
+											size="icon"
+											onClick={handleOpenInChat}
+											aria-label="Open in chat"
+										>
+											<ExternalLinkIcon className="size-4" />
+										</Button>
+									</TooltipTrigger>
+									<TooltipContent>Open in chat</TooltipContent>
+								</Tooltip>
 								<Button
 									variant="subtle"
 									size="icon"
-									onClick={handleOpenInChat}
-									aria-label="Open in chat"
+									onClick={() => onOpenChange(false)}
+									aria-label="Close"
 								>
-									<ExternalLinkIcon className="size-4" />
+									<XIcon className="size-4" />
 								</Button>
-							</TooltipTrigger>
-							<TooltipContent>Open in chat</TooltipContent>
-						</Tooltip>
-						<Button
-							variant="subtle"
-							size="icon"
-							onClick={() => onOpenChange(false)}
-							aria-label="Close"
-						>
-							<XIcon className="size-4" />
-						</Button>
-					</div>
-				</div>
+							</div>
+						</div>
 
-				{/* Review Banner */}
-				<ReviewBanner chat={currentChat} />
+						{/* Review Banner */}
+						<ReviewBanner chat={currentChat} />
 
-				{/* Chat Content */}
-				<div className="flex-1 min-h-0">
-					<ReviewChatContent chatId={currentChat.id} />
-				</div>
+						{/* Chat Content */}
+						<div className="flex-1 min-h-0">
+							<ReviewChatContent chatId={currentChat.id} />
+						</div>
 
-				{/* Navigation Bar */}
-				<ReviewNavigationBar
-					currentIndex={currentIndex}
-					totalCount={snapshotChats.length}
-					onPrevious={handlePrevious}
-					onNext={handleNext}
-					isLast={currentIndex >= snapshotChats.length - 1}
-				/>
+						{/* Navigation Bar */}
+						<ReviewNavigationBar
+							currentIndex={currentIndex}
+							totalCount={snapshotChats.length}
+							onPrevious={handlePrevious}
+							onNext={handleNext}
+							isLast={currentIndex >= snapshotChats.length - 1}
+						/>
+					</>
+				) : (
+					<>
+						<div className="flex items-center justify-between border-b border-border-default px-6 py-4">
+							<DialogTitle className="text-lg">Review unread chats</DialogTitle>
+							<Button
+								variant="subtle"
+								size="icon"
+								onClick={() => onOpenChange(false)}
+								aria-label="Close"
+							>
+								<XIcon className="size-4" />
+							</Button>
+						</div>
+						<div className="flex flex-1 items-center justify-center">
+							<p className="text-sm text-content-secondary">
+								No agent chats to review
+							</p>
+						</div>
+					</>
+				)}
 			</DialogContent>
 		</Dialog>
 	);

--- a/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
@@ -94,6 +94,7 @@ import { getTimeGroup, TIME_GROUPS } from "../../utils/timeGroups";
 import type { ModelSelectorOption } from "../ChatElements";
 import { asString } from "../ChatElements/runtimeTypeUtils";
 import { UsageIndicator } from "../UsageIndicator";
+import { ReviewUnreadButton } from "./ReviewUnreadButton";
 
 type SidebarView =
 	| { panel: "chats" }
@@ -142,6 +143,7 @@ interface AgentsSidebarProps {
 	onArchivedFilterChange?: (filter: "active" | "archived") => void;
 	onCollapse?: () => void;
 	isAdmin?: boolean;
+	onOpenReviewDialog?: () => void;
 }
 
 const statusConfig = {
@@ -757,6 +759,7 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 		onArchivedFilterChange,
 		onCollapse,
 		isAdmin = false,
+		onOpenReviewDialog,
 	} = props;
 	const { agentId, chatId } = useParams<{
 		agentId?: string;
@@ -1032,6 +1035,9 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 						onClick={onBeforeNewAgent}
 						disabled={isCreating}
 					/>
+					{onOpenReviewDialog && (
+						<ReviewUnreadButton chatList={chats} onClick={onOpenReviewDialog} />
+					)}
 				</div>
 				<ScrollArea
 					className="flex-1 [&_[data-radix-scroll-area-viewport]>div]:!block"

--- a/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
@@ -1035,11 +1035,10 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 						onClick={onBeforeNewAgent}
 						disabled={isCreating}
 					/>
-						{onOpenReviewDialog && (
-							<div className="mt-1">
-								<ReviewUnreadButton chatList={chats} onClick={onOpenReviewDialog} />
-							</div>
-						)}				</div>
+					{onOpenReviewDialog && (
+						<ReviewUnreadButton chatList={chats} onClick={onOpenReviewDialog} />
+					)}{" "}
+				</div>{" "}
 				<ScrollArea
 					className="flex-1 [&_[data-radix-scroll-area-viewport]>div]:!block"
 					scrollBarClassName="w-1.5"

--- a/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
@@ -1035,10 +1035,11 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 						onClick={onBeforeNewAgent}
 						disabled={isCreating}
 					/>
-					{onOpenReviewDialog && (
-						<ReviewUnreadButton chatList={chats} onClick={onOpenReviewDialog} />
-					)}
-				</div>
+						{onOpenReviewDialog && (
+							<div className="mt-1">
+								<ReviewUnreadButton chatList={chats} onClick={onOpenReviewDialog} />
+							</div>
+						)}				</div>
 				<ScrollArea
 					className="flex-1 [&_[data-radix-scroll-area-viewport]>div]:!block"
 					scrollBarClassName="w-1.5"

--- a/site/src/pages/AgentsPage/components/Sidebar/ReviewUnreadButton.stories.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/ReviewUnreadButton.stories.tsx
@@ -40,17 +40,16 @@ const meta: Meta<typeof ReviewUnreadButton> = {
 export default meta;
 type Story = StoryObj<typeof ReviewUnreadButton>;
 
-export const Hidden: Story = {
+export const NoUnread: Story = {
 	args: {
 		chatList: [
-			buildChat({ has_unread: true }),
-			buildChat({ has_unread: true }),
+			buildChat({ has_unread: false }),
 			buildChat({ has_unread: false }),
 		],
 	},
 };
 
-export const Visible: Story = {
+export const WithUnread: Story = {
 	args: {
 		chatList: [
 			buildChat({ has_unread: true }),

--- a/site/src/pages/AgentsPage/components/Sidebar/ReviewUnreadButton.stories.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/ReviewUnreadButton.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+import type { Chat } from "#/api/typesGenerated";
+import { ReviewUnreadButton } from "./ReviewUnreadButton";
+
+const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+
+const buildChat = (overrides: Partial<Chat> = {}): Chat => ({
+	id: `chat-${Math.random().toString(36).slice(2)}`,
+	owner_id: "owner-1",
+	title: "Agent",
+	status: "completed",
+	last_model_config_id: "config-1",
+	mcp_server_ids: [],
+	labels: {},
+	created_at: oneHourAgo,
+	updated_at: oneHourAgo,
+	archived: false,
+	pin_order: 0,
+	has_unread: false,
+	last_error: null,
+	...overrides,
+});
+
+const meta: Meta<typeof ReviewUnreadButton> = {
+	title: "pages/AgentsPage/ReviewUnreadButton",
+	component: ReviewUnreadButton,
+	args: {
+		onClick: fn(),
+	},
+	decorators: [
+		(Story) => (
+			<div className="w-[280px] p-4 bg-surface-primary">
+				<Story />
+			</div>
+		),
+	],
+};
+
+export default meta;
+type Story = StoryObj<typeof ReviewUnreadButton>;
+
+export const Hidden: Story = {
+	args: {
+		chatList: [
+			buildChat({ has_unread: true }),
+			buildChat({ has_unread: true }),
+			buildChat({ has_unread: false }),
+		],
+	},
+};
+
+export const Visible: Story = {
+	args: {
+		chatList: [
+			buildChat({ has_unread: true }),
+			buildChat({ has_unread: true }),
+			buildChat({ has_unread: true }),
+			buildChat({ has_unread: false }),
+			buildChat({ has_unread: false }),
+		],
+	},
+};
+
+export const HighCount: Story = {
+	args: {
+		chatList: Array.from({ length: 12 }, (_, i) =>
+			buildChat({ has_unread: i < 10 }),
+		),
+	},
+};

--- a/site/src/pages/AgentsPage/components/Sidebar/ReviewUnreadButton.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/ReviewUnreadButton.tsx
@@ -23,16 +23,16 @@ export const ReviewUnreadButton: FC<ReviewUnreadButtonProps> = ({
 		<button
 			type="button"
 			className={cn(
-				"relative flex w-full items-center gap-2.5 rounded-md px-2.5 py-2",
-				"text-left text-sm cursor-pointer transition-all",
-				"bg-surface-orange/30 text-content-warning",
+				"relative mt-1.5 flex w-full items-center gap-2.5 rounded-md border-0 px-2.5 py-2",
+				"text-left text-sm cursor-pointer transition-colors no-underline",
+				"bg-transparent text-content-secondary",
+				"hover:bg-surface-tertiary/50 hover:text-content-primary",
 				"shadow-[0_0_0_2px_hsla(var(--border-warning),0.6)]",
-				"hover:bg-surface-orange/50",
 			)}
 			onClick={onClick}
 		>
-			<ClipboardListIcon className="size-4 shrink-0" />
-			<span className="truncate font-medium">Review unread chats</span>
+			<ClipboardListIcon className="h-4 w-4 shrink-0" />
+			<span className="truncate">Review unread chats</span>
 			<span className="absolute -top-1.5 -right-1.5 flex h-5 min-w-5 items-center justify-center rounded-full bg-content-warning px-1 text-xs font-bold text-white">
 				{unreadCount}
 			</span>

--- a/site/src/pages/AgentsPage/components/Sidebar/ReviewUnreadButton.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/ReviewUnreadButton.tsx
@@ -13,11 +13,8 @@ export const ReviewUnreadButton: FC<ReviewUnreadButtonProps> = ({
 	chatList,
 	onClick,
 }) => {
-	const { unreadCount, hasReviewThreshold } = useUnreadChats(chatList);
-
-	if (!hasReviewThreshold) {
-		return null;
-	}
+	const { unreadCount } = useUnreadChats(chatList);
+	const hasUnread = unreadCount > 0;
 
 	return (
 		<button
@@ -27,15 +24,17 @@ export const ReviewUnreadButton: FC<ReviewUnreadButtonProps> = ({
 				"text-left text-sm cursor-pointer transition-colors no-underline",
 				"bg-transparent text-content-secondary",
 				"hover:bg-surface-tertiary/50 hover:text-content-primary",
-				"shadow-[0_0_0_2px_hsla(var(--border-warning),0.6)]",
+				hasUnread && "shadow-[0_0_0_2px_hsla(var(--border-warning),0.6)]",
 			)}
 			onClick={onClick}
 		>
 			<ClipboardListIcon className="h-4 w-4 shrink-0" />
 			<span className="truncate">Review unread chats</span>
-			<span className="absolute -top-1.5 -right-1.5 flex h-5 min-w-5 items-center justify-center rounded-full bg-content-warning px-1 text-xs font-bold text-white">
-				{unreadCount}
-			</span>
+			{hasUnread && (
+				<span className="absolute -top-1.5 -right-1.5 flex h-5 min-w-5 items-center justify-center rounded-full bg-content-warning px-1 text-xs font-bold text-white">
+					{unreadCount}
+				</span>
+			)}
 		</button>
 	);
 };

--- a/site/src/pages/AgentsPage/components/Sidebar/ReviewUnreadButton.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/ReviewUnreadButton.tsx
@@ -1,0 +1,41 @@
+import { ClipboardListIcon } from "lucide-react";
+import type { FC } from "react";
+import type { Chat } from "#/api/typesGenerated";
+import { cn } from "#/utils/cn";
+import { useUnreadChats } from "../../hooks/useUnreadChats";
+
+interface ReviewUnreadButtonProps {
+	chatList: readonly Chat[];
+	onClick: () => void;
+}
+
+export const ReviewUnreadButton: FC<ReviewUnreadButtonProps> = ({
+	chatList,
+	onClick,
+}) => {
+	const { unreadCount, hasReviewThreshold } = useUnreadChats(chatList);
+
+	if (!hasReviewThreshold) {
+		return null;
+	}
+
+	return (
+		<button
+			type="button"
+			className={cn(
+				"relative flex w-full items-center gap-2.5 rounded-md px-2.5 py-2",
+				"text-left text-sm cursor-pointer transition-all",
+				"bg-surface-orange/30 text-content-warning",
+				"shadow-[0_0_0_2px_hsla(var(--border-warning),0.6)]",
+				"hover:bg-surface-orange/50",
+			)}
+			onClick={onClick}
+		>
+			<ClipboardListIcon className="size-4 shrink-0" />
+			<span className="truncate font-medium">Review unread chats</span>
+			<span className="absolute -top-1.5 -right-1.5 flex h-5 min-w-5 items-center justify-center rounded-full bg-content-warning px-1 text-xs font-bold text-white">
+				{unreadCount}
+			</span>
+		</button>
+	);
+};

--- a/site/src/pages/AgentsPage/hooks/useChatSummary.ts
+++ b/site/src/pages/AgentsPage/hooks/useChatSummary.ts
@@ -1,0 +1,61 @@
+import { useMemo } from "react";
+import type { Chat, ChatMessage } from "#/api/typesGenerated";
+
+export function deriveChatSummary(
+	chat: Chat,
+	messages: readonly ChatMessage[],
+): string {
+	const parts: string[] = [];
+
+	// Status-based summary
+	switch (chat.status) {
+		case "completed":
+			parts.push("Agent finished its work.");
+			break;
+		case "waiting":
+			parts.push("Agent is waiting for your input.");
+			break;
+		case "error":
+			parts.push(
+				`Agent encountered an error${chat.last_error ? `: ${chat.last_error}` : "."}`,
+			);
+			break;
+		case "running":
+			parts.push("Agent is still working.");
+			break;
+		case "pending":
+			parts.push("Agent is starting up.");
+			break;
+		case "paused":
+			parts.push("Agent is paused.");
+			break;
+		case "requires_action":
+			parts.push("Agent requires your action.");
+			break;
+	}
+
+	// Count tool calls
+	const toolCalls = messages.filter((m) => m.role === "tool").length;
+	if (toolCalls > 0) {
+		parts.push(`Used ${toolCalls} tool${toolCalls === 1 ? "" : "s"}.`);
+	}
+
+	// Diff status
+	if (chat.diff_status) {
+		parts.push("Has pending code changes to review.");
+	}
+
+	return parts.join(" ");
+}
+
+export function useChatSummary(
+	chat: Chat | undefined,
+	messages: readonly ChatMessage[],
+): string {
+	return useMemo(() => {
+		if (!chat) {
+			return "";
+		}
+		return deriveChatSummary(chat, messages);
+	}, [chat, messages]);
+}

--- a/site/src/pages/AgentsPage/hooks/useUnreadChats.ts
+++ b/site/src/pages/AgentsPage/hooks/useUnreadChats.ts
@@ -1,12 +1,9 @@
 import { useMemo } from "react";
 import type { Chat } from "#/api/typesGenerated";
 
-const REVIEW_THRESHOLD = 3;
-
 interface UseUnreadChatsResult {
 	unreadChats: Chat[];
 	unreadCount: number;
-	hasReviewThreshold: boolean;
 }
 
 export function useUnreadChats(
@@ -19,7 +16,6 @@ export function useUnreadChats(
 		return {
 			unreadChats,
 			unreadCount: unreadChats.length,
-			hasReviewThreshold: unreadChats.length >= REVIEW_THRESHOLD,
 		};
 	}, [chatList]);
 }

--- a/site/src/pages/AgentsPage/hooks/useUnreadChats.ts
+++ b/site/src/pages/AgentsPage/hooks/useUnreadChats.ts
@@ -13,7 +13,9 @@ export function useUnreadChats(
 	chatList: readonly Chat[],
 ): UseUnreadChatsResult {
 	return useMemo(() => {
-		const unreadChats = chatList.filter((chat) => chat.has_unread);
+		const unreadChats = chatList.filter(
+			(chat) => chat.has_unread && !chat.parent_chat_id,
+		);
 		return {
 			unreadChats,
 			unreadCount: unreadChats.length,

--- a/site/src/pages/AgentsPage/hooks/useUnreadChats.ts
+++ b/site/src/pages/AgentsPage/hooks/useUnreadChats.ts
@@ -1,0 +1,23 @@
+import { useMemo } from "react";
+import type { Chat } from "#/api/typesGenerated";
+
+const REVIEW_THRESHOLD = 3;
+
+interface UseUnreadChatsResult {
+	unreadChats: Chat[];
+	unreadCount: number;
+	hasReviewThreshold: boolean;
+}
+
+export function useUnreadChats(
+	chatList: readonly Chat[],
+): UseUnreadChatsResult {
+	return useMemo(() => {
+		const unreadChats = chatList.filter((chat) => chat.has_unread);
+		return {
+			unreadChats,
+			unreadCount: unreadChats.length,
+			hasReviewThreshold: unreadChats.length >= REVIEW_THRESHOLD,
+		};
+	}, [chatList]);
+}


### PR DESCRIPTION
## Summary

Implements the "Review Unread Chats" feature as specified in `docs/plans/review-unread-chats.md`.

This adds a **sidebar button** and **review dialog** that lets users step through unread chats one-by-one with Previous/Next navigation, marking each as read as they go.

## What's included

### New files
| File | Purpose |
|---|---|
| `hooks/useUnreadChats.ts` | Derives unread chat list from `chatList` with `useMemo`. Exposes `unreadChats`, `unreadCount`, and `hasReviewThreshold` (≥3). |
| `hooks/useChatSummary.ts` | Client-side heuristic chat summary based on status, tool call count, and diff status. |
| `components/Sidebar/ReviewUnreadButton.tsx` | Orange-bordered sidebar button with unread count badge. Hidden when < 3 unread chats. |
| `components/ReviewUnreadDialog.tsx` | Large dialog (85vh) with: chat title header, activity summary banner, conversation timeline (read-only), and Previous/Next/Done navigation bar. |

### Modified files
| File | Changes |
|---|---|
| `AgentsPage.tsx` | Adds `reviewDialogOpen` state and `markChatAsRead` callback (optimistic cache update matching existing pattern). |
| `AgentsPageView.tsx` | Accepts new props, passes `onOpenReviewDialog` to sidebar, renders `ReviewUnreadDialog`. |
| `AgentsSidebar.tsx` | Accepts `onOpenReviewDialog` prop, renders `ReviewUnreadButton` after "New Agent" button. |
| `AgentsPageView.stories.tsx` | Adds default args for the new props. |

## Architecture decisions

- **Threshold**: Button appears when ≥ 3 chats have `has_unread === true` (hardcoded, configurable later)
- **Queue snapshotting**: The unread list is passed as a prop; the dialog resets its index when opened. New unreads during review don't enter the current session.
- **Mark as read**: Each navigation action calls `onChatReviewed` which optimistically updates the infinite chats cache (mirrors the existing pattern at lines 455–473 in `AgentsPage.tsx`).
- **Chat content**: Uses `ConversationTimeline` with `parseMessagesWithMergedTools` for a read-only view of the conversation. Full embedded `ChatPageContent` with input/streaming is deferred per the plan's Risk #1.
- **Summary**: Client-side heuristic from chat status + tool count + diff status. Can be enhanced with LLM summarization later.

## Implements steps from the plan
- ✅ Step 1: `useUnreadChats` hook
- ✅ Step 2: `ReviewUnreadButton` component
- ✅ Step 3: `ReviewUnreadDialog` component (shell + conversation timeline)
- ✅ Step 4: `useChatSummary` hook
- ✅ Step 5: Wire into `AgentsPage.tsx`
- ✅ Step 6: Wire into `AgentsPageView.tsx`
- ✅ Step 7: Wire into `AgentsSidebar.tsx`
- ⏳ Step 8: Stories + tests (storybook default args updated; dedicated stories/tests are a follow-up)
- ⏳ Step 9: Polish (animations, mobile, edge cases)