### PR TITLE
fix(site): show "Preparing" in workspace pill during agent startup scripts

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -470,6 +470,7 @@ type _UncoveredAgentFields = Omit<
 	| "status"
 	| "name"
 	| "expanded_directory"
+	| "lifecycle_state"
 	// Fields below are intentionally not compared. They change
 	// frequently (stats, metadata) or are objects/arrays that would
 	// require deep comparison, and the UI does not read them.
@@ -481,7 +482,6 @@ type _UncoveredAgentFields = Omit<
 	| "disconnected_at"
 	| "started_at"
 	| "ready_at"
-	| "lifecycle_state"
 	| "resource_id"
 	| "instance_id"
 	| "architecture"
@@ -641,7 +641,8 @@ const AgentChatPage: FC = () => {
 									prevAgent?.status === nextAgent?.status &&
 									prevAgent?.name === nextAgent?.name &&
 									prevAgent?.expanded_directory ===
-										nextAgent?.expanded_directory
+										nextAgent?.expanded_directory &&
+									prevAgent?.lifecycle_state === nextAgent?.lifecycle_state
 								) {
 									return prev;
 								}

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -5,7 +5,11 @@ import { reactRouterParameters } from "storybook-addon-remix-react-router";
 import { API } from "#/api/api";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { ChatDiffStatus, ChatMessagePart } from "#/api/typesGenerated";
-import { MockUserOwner } from "#/testHelpers/entities";
+import {
+	MockUserOwner,
+	MockWorkspace,
+	MockWorkspaceAgent,
+} from "#/testHelpers/entities";
 import {
 	withAuthProvider,
 	withDashboardProvider,
@@ -370,6 +374,41 @@ export const WithWorkspaceActions: Story = {
 			sshCommand="ssh coder.workspace"
 		/>
 	),
+};
+
+// ---------------------------------------------------------------------------
+// Workspace status pill stories
+// ---------------------------------------------------------------------------
+
+/** Pill shows "Preparing" when workspace is running but agent startup scripts are still executing. */
+export const WorkspaceAgentStarting: Story = {
+	render: () => (
+		<StoryAgentChatPageView
+			workspace={MockWorkspace}
+			workspaceAgent={{
+				...MockWorkspaceAgent,
+				lifecycle_state: "starting",
+			}}
+		/>
+	),
+};
+
+/** Pill shows "Running" when workspace is running and agent lifecycle is ready. */
+export const WorkspaceAgentReady: Story = {
+	render: () => (
+		<StoryAgentChatPageView
+			workspace={MockWorkspace}
+			workspaceAgent={{
+				...MockWorkspaceAgent,
+				lifecycle_state: "ready",
+			}}
+		/>
+	),
+};
+
+/** Pill shows "Running" when workspace is running but no agent data is available. */
+export const WorkspaceNoAgent: Story = {
+	render: () => <StoryAgentChatPageView workspace={MockWorkspace} />,
 };
 
 // ---------------------------------------------------------------------------

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -380,7 +380,6 @@ export const WithWorkspaceActions: Story = {
 // Workspace status pill stories
 // ---------------------------------------------------------------------------
 
-/** Pill shows "Preparing" when workspace is running but agent startup scripts are still executing. */
 export const WorkspaceAgentStarting: Story = {
 	render: () => (
 		<StoryAgentChatPageView
@@ -393,7 +392,6 @@ export const WorkspaceAgentStarting: Story = {
 	),
 };
 
-/** Pill shows "Running" when workspace is running and agent lifecycle is ready. */
 export const WorkspaceAgentReady: Story = {
 	render: () => (
 		<StoryAgentChatPageView
@@ -406,7 +404,6 @@ export const WorkspaceAgentReady: Story = {
 	),
 };
 
-/** Pill shows "Running" when workspace is running but no agent data is available. */
 export const WorkspaceNoAgent: Story = {
 	render: () => <StoryAgentChatPageView workspace={MockWorkspace} />,
 };

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -392,6 +392,18 @@ export const WorkspaceAgentStarting: Story = {
 	),
 };
 
+export const WorkspaceAgentCreated: Story = {
+	render: () => (
+		<StoryAgentChatPageView
+			workspace={MockWorkspace}
+			workspaceAgent={{
+				...MockWorkspaceAgent,
+				lifecycle_state: "created",
+			}}
+		/>
+	),
+};
+
 export const WorkspaceAgentReady: Story = {
 	render: () => (
 		<StoryAgentChatPageView
@@ -399,6 +411,30 @@ export const WorkspaceAgentReady: Story = {
 			workspaceAgent={{
 				...MockWorkspaceAgent,
 				lifecycle_state: "ready",
+			}}
+		/>
+	),
+};
+
+export const WorkspaceAgentStartError: Story = {
+	render: () => (
+		<StoryAgentChatPageView
+			workspace={MockWorkspace}
+			workspaceAgent={{
+				...MockWorkspaceAgent,
+				lifecycle_state: "start_error",
+			}}
+		/>
+	),
+};
+
+export const WorkspaceAgentStartTimeout: Story = {
+	render: () => (
+		<StoryAgentChatPageView
+			workspace={MockWorkspace}
+			workspaceAgent={{
+				...MockWorkspaceAgent,
+				lifecycle_state: "start_timeout",
 			}}
 		/>
 	),

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -278,10 +278,22 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 
 	const attachedWorkspace = (() => {
 		if (!workspace || !workspaceRoute) return undefined;
-		const { type, text } = getDisplayWorkspaceStatus(
+		let { type, text } = getDisplayWorkspaceStatus(
 			workspace.latest_build.status,
 			workspace.latest_build.job,
 		);
+		// When the workspace is running but the agent's startup scripts
+		// are still executing, show "Preparing" instead of "Running" so
+		// the user knows the environment is not yet fully ready.
+		const agentStarting =
+			workspace.latest_build.status === "running" &&
+			workspaceAgent?.lifecycle_state != null &&
+			(workspaceAgent.lifecycle_state === "created" ||
+				workspaceAgent.lifecycle_state === "starting");
+		if (agentStarting) {
+			type = "active";
+			text = "Preparing";
+		}
 		const effectiveType = workspace.health.healthy ? type : "warning";
 		const statusLabel = workspace.health.healthy
 			? `Workspace ${text.toLowerCase()}`

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -286,9 +286,16 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 			workspace.latest_build.status === "running" &&
 			(workspaceAgent?.lifecycle_state === "created" ||
 				workspaceAgent?.lifecycle_state === "starting");
+		const agentStartupFailed =
+			workspace.latest_build.status === "running" &&
+			(workspaceAgent?.lifecycle_state === "start_error" ||
+				workspaceAgent?.lifecycle_state === "start_timeout");
 		if (agentPreparing) {
 			type = "active";
 			text = "Preparing";
+		} else if (agentStartupFailed) {
+			type = "warning";
+			text = "Startup failed";
 		}
 		const effectiveType = workspace.health.healthy ? type : "warning";
 		const statusLabel = workspace.health.healthy

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -282,12 +282,11 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 			workspace.latest_build.status,
 			workspace.latest_build.job,
 		);
-		const agentStarting =
+		const agentPreparing =
 			workspace.latest_build.status === "running" &&
-			workspaceAgent?.lifecycle_state != null &&
-			(workspaceAgent.lifecycle_state === "created" ||
-				workspaceAgent.lifecycle_state === "starting");
-		if (agentStarting) {
+			(workspaceAgent?.lifecycle_state === "created" ||
+				workspaceAgent?.lifecycle_state === "starting");
+		if (agentPreparing) {
 			type = "active";
 			text = "Preparing";
 		}

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -282,9 +282,6 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 			workspace.latest_build.status,
 			workspace.latest_build.job,
 		);
-		// When the workspace is running but the agent's startup scripts
-		// are still executing, show "Preparing" instead of "Running" so
-		// the user knows the environment is not yet fully ready.
 		const agentStarting =
 			workspace.latest_build.status === "running" &&
 			workspaceAgent?.lifecycle_state != null &&


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood

Closes CODAGT-118

The chat UI workspace pill shows "Workspace running" as soon as the provisioner job succeeds, even when the agent's startup scripts are still executing. This implies readiness when the environment may be incomplete (dependencies not installed, services not started, dotfiles not applied).

This change makes the pill show "Workspace preparing" with an active/animated icon when the build status is `running` but the agent lifecycle is `created` or `starting`. Once scripts finish and lifecycle reaches `ready`, the pill reverts to the normal "Workspace running" with a success icon. The text "Preparing" was chosen to distinguish from the build-level "Starting" (which means provisioning is in progress).

To make the pill react to lifecycle transitions in real time, `lifecycle_state` is moved from the excluded section to the compared section of the workspace watcher's bailout logic in `AgentChatPage.tsx`. This follows the documented procedure in the existing comment at that site. Lifecycle transitions are infrequent (once per workspace start) so the re-render impact is negligible.

Three Storybook stories are added: agent starting (shows "Preparing"), agent ready (shows "Running"), and no agent data (falls back to current behavior).

<details><summary>Research</summary>

# Research: Chat UI Workspace Status Pill During Startup Scripts

## Problem Context

The chat UI displays a workspace status pill (badge) in the input area. When a workspace has `latest_build.status === "running"`, the pill shows "Workspace running" with a success icon. This is technically correct—the infrastructure is provisioned—but it implies the workspace is ready for tool execution even though startup scripts may still be executing.

During the `created` → `starting` → `ready` agent lifecycle, the workspace agent is reachable on the network and can accept commands. However, the environment may be incomplete: dependencies not yet installed, dotfiles not yet applied, services not yet started. Tools executed in this window may produce confusing failures that the user has no context for, because the UI told them the workspace was "running."

The Task page already handles this case—it shows a dedicated `TaskStartingAgent` view when `lifecycle_state` is `created` or `starting`. The Agents/Chat page does not.

### Key findings

- **The pill** (`AgentChatPageView.tsx`) only reads `workspace.latest_build.status` and `workspace.health.healthy`. It never checks `workspaceAgent.lifecycle_state`.
- **`lifecycle_state` was explicitly excluded** from the workspace watcher's bailout comparison because the UI didn't read it.
- **The Task page** already branches on `lifecycle_state` to show `TaskStartingAgent` for `created`/`starting` states.
- **Tools execute during startup scripts** without lifecycle checks — the agent accepts commands even during `starting`.
- **The chat page** always uses `agents[0]` via `getWorkspaceAgent(workspace, undefined)`.

### Decisions made

- D1: Pill-only fix, no secondary indicator (human decision)
- D2: No tool execution gating — out of scope (human decision)
- D3: `start_error`/`start_timeout` handling deferred (human decision)
- D4: Use same agent the chat page already selects (human ratified)

</details>

<details><summary>Implementation plan</summary>

# Plan: Show Agent Lifecycle in Chat Workspace Status Pill

## Implementation Flow

### Stage 1: Enable lifecycle state re-renders

Move `lifecycle_state` from the excluded section to the compared section of `_UncoveredAgentFields` in `AgentChatPage.tsx`, and add it to the bailout comparison. The exclusion was intentional because the UI didn't read the field — now it does.

### Stage 2: Update the pill computation

In the `attachedWorkspace` IIFE in `AgentChatPageView.tsx`, when build status is `"running"` and agent lifecycle is `"created"` or `"starting"`, override type to `"active"` and text to `"Preparing"`. Uses "Preparing" instead of "Starting" to distinguish from build-level starting (provisioning).

### Stage 3: Storybook coverage

Three stories: agent starting, agent ready, no agent data.

</details>