### PR TITLE
feat(coderd/x/chatd): skip workspace/template tools when org has no visible templates

### DIFF
--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -194,6 +194,32 @@ func (p *Server) chatTemplateAllowlist() map[uuid.UUID]bool {
 	return m
 }
 
+// orgHasVisibleChatTemplates returns true when the org has at least one
+// non-deleted, non-deprecated template that the owner can see AND that
+// the chat template allowlist (if set) permits. We use this to skip
+// workspace/template tools when there is nothing the agent can act on.
+func (p *Server) orgHasVisibleChatTemplates(
+	ctx context.Context, orgID, ownerID uuid.UUID,
+) (bool, error) {
+	ownerCtx, err := chattool.AsOwner(ctx, p.db, ownerID)
+	if err != nil {
+		return false, err
+	}
+	params := database.GetTemplatesWithFilterParams{
+		OrganizationID: orgID,
+		Deleted:        false,
+		Deprecated:     sql.NullBool{Bool: false, Valid: true},
+	}
+	if allowlist := p.chatTemplateAllowlist(); len(allowlist) > 0 {
+		params.IDs = slices.Collect(maps.Keys(allowlist))
+	}
+	templates, err := p.db.GetTemplatesWithFilter(ownerCtx, params)
+	if err != nil {
+		return false, err
+	}
+	return len(templates) > 0, nil
+}
+
 // cachedWorkspaceMCPTools stores workspace MCP tools discovered
 // from a workspace agent, keyed by the agent ID that provided them.
 type cachedWorkspaceMCPTools struct {
@@ -5010,42 +5036,70 @@ func (p *Server) runChat(
 			// completes.
 			p.publishChatPubsubEvent(updatedChat, codersdk.ChatWatchEventKindStatusChange, nil)
 		}
-		tools = append(tools,
-			chattool.ListTemplates(chattool.ListTemplatesOptions{
-				DB:                 p.db,
-				OwnerID:            chat.OwnerID,
-				OrganizationID:     chat.OrganizationID,
-				AllowedTemplateIDs: p.chatTemplateAllowlist,
-			}),
-			chattool.ReadTemplate(chattool.ReadTemplateOptions{
-				DB:                 p.db,
-				OwnerID:            chat.OwnerID,
-				AllowedTemplateIDs: p.chatTemplateAllowlist,
-			}),
-			chattool.CreateWorkspace(chattool.CreateWorkspaceOptions{
-				DB:                             p.db,
-				OwnerID:                        chat.OwnerID,
-				OrganizationID:                 chat.OrganizationID,
-				ChatID:                         chat.ID,
-				CreateFn:                       p.createWorkspaceFn,
-				AgentConnFn:                    chattool.AgentConnFunc(p.agentConnFn),
-				AgentInactiveDisconnectTimeout: p.agentInactiveDisconnectTimeout,
-				WorkspaceMu:                    &workspaceMu,
-				OnChatUpdated:                  onChatUpdated,
-				Logger:                         p.logger,
-				AllowedTemplateIDs:             p.chatTemplateAllowlist,
-			}),
-			chattool.StartWorkspace(chattool.StartWorkspaceOptions{
-				DB:            p.db,
-				OwnerID:       chat.OwnerID,
-				ChatID:        chat.ID,
-				StartFn:       p.startWorkspaceFn,
-				AgentConnFn:   chattool.AgentConnFunc(p.agentConnFn),
-				WorkspaceMu:   &workspaceMu,
-				OnChatUpdated: onChatUpdated,
-				Logger:        p.logger,
-			}),
-		)
+		hasTemplates, templErr := p.orgHasVisibleChatTemplates(ctx, chat.OrganizationID, chat.OwnerID)
+		if templErr != nil {
+			// Degrade gracefully: log and assume templates exist so the
+			// agent is not silently crippled by a transient DB error.
+			p.logger.Warn(ctx, "failed to check org template visibility, including provisioning tools",
+				slog.F("org_id", chat.OrganizationID),
+				slog.Error(templErr),
+			)
+			hasTemplates = true
+		}
+		if hasTemplates {
+			tools = append(tools,
+				chattool.ListTemplates(chattool.ListTemplatesOptions{
+					DB:                 p.db,
+					OwnerID:            chat.OwnerID,
+					OrganizationID:     chat.OrganizationID,
+					AllowedTemplateIDs: p.chatTemplateAllowlist,
+				}),
+				chattool.ReadTemplate(chattool.ReadTemplateOptions{
+					DB:                 p.db,
+					OwnerID:            chat.OwnerID,
+					AllowedTemplateIDs: p.chatTemplateAllowlist,
+				}),
+				chattool.CreateWorkspace(chattool.CreateWorkspaceOptions{
+					DB:                             p.db,
+					OwnerID:                        chat.OwnerID,
+					OrganizationID:                 chat.OrganizationID,
+					ChatID:                         chat.ID,
+					CreateFn:                       p.createWorkspaceFn,
+					AgentConnFn:                    chattool.AgentConnFunc(p.agentConnFn),
+					AgentInactiveDisconnectTimeout: p.agentInactiveDisconnectTimeout,
+					WorkspaceMu:                    &workspaceMu,
+					OnChatUpdated:                  onChatUpdated,
+					Logger:                         p.logger,
+					AllowedTemplateIDs:             p.chatTemplateAllowlist,
+				}),
+				chattool.StartWorkspace(chattool.StartWorkspaceOptions{
+					DB:            p.db,
+					OwnerID:       chat.OwnerID,
+					ChatID:        chat.ID,
+					StartFn:       p.startWorkspaceFn,
+					AgentConnFn:   chattool.AgentConnFunc(p.agentConnFn),
+					WorkspaceMu:   &workspaceMu,
+					OnChatUpdated: onChatUpdated,
+					Logger:        p.logger,
+				}),
+			)
+		} else if chat.WorkspaceID.Valid {
+			// No visible templates but the chat has a workspace already
+			// bound — the user may need to restart it.
+			ws, wsErr := p.db.GetWorkspaceByID(ctx, chat.WorkspaceID.UUID)
+			if wsErr == nil && !ws.Deleted {
+				tools = append(tools, chattool.StartWorkspace(chattool.StartWorkspaceOptions{
+					DB:            p.db,
+					OwnerID:       chat.OwnerID,
+					ChatID:        chat.ID,
+					StartFn:       p.startWorkspaceFn,
+					AgentConnFn:   chattool.AgentConnFunc(p.agentConnFn),
+					WorkspaceMu:   &workspaceMu,
+					OnChatUpdated: onChatUpdated,
+					Logger:        p.logger,
+				}))
+			}
+		}
 		// Plan presentation tool.
 		tools = append(tools, chattool.ProposePlan(chattool.ProposePlanOptions{
 			GetWorkspaceConn: workspaceCtx.getWorkspaceConn,

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -5036,16 +5036,27 @@ func (p *Server) runChat(
 			// completes.
 			p.publishChatPubsubEvent(updatedChat, codersdk.ChatWatchEventKindStatusChange, nil)
 		}
-		hasTemplates, templErr := p.orgHasVisibleChatTemplates(ctx, chat.OrganizationID, chat.OwnerID)
-		if templErr != nil {
+		hasTemplates, tmplErr := p.orgHasVisibleChatTemplates(ctx, chat.OrganizationID, chat.OwnerID)
+		if tmplErr != nil {
 			// Degrade gracefully: log and assume templates exist so the
 			// agent is not silently crippled by a transient DB error.
 			p.logger.Warn(ctx, "failed to check org template visibility, including provisioning tools",
 				slog.F("org_id", chat.OrganizationID),
-				slog.Error(templErr),
+				slog.Error(tmplErr),
 			)
 			hasTemplates = true
 		}
+		startWSOpts := chattool.StartWorkspaceOptions{
+			DB:            p.db,
+			OwnerID:       chat.OwnerID,
+			ChatID:        chat.ID,
+			StartFn:       p.startWorkspaceFn,
+			AgentConnFn:   chattool.AgentConnFunc(p.agentConnFn),
+			WorkspaceMu:   &workspaceMu,
+			OnChatUpdated: onChatUpdated,
+			Logger:        p.logger,
+		}
+
 		if hasTemplates {
 			tools = append(tools,
 				chattool.ListTemplates(chattool.ListTemplatesOptions{
@@ -5072,34 +5083,23 @@ func (p *Server) runChat(
 					Logger:                         p.logger,
 					AllowedTemplateIDs:             p.chatTemplateAllowlist,
 				}),
-				chattool.StartWorkspace(chattool.StartWorkspaceOptions{
-					DB:            p.db,
-					OwnerID:       chat.OwnerID,
-					ChatID:        chat.ID,
-					StartFn:       p.startWorkspaceFn,
-					AgentConnFn:   chattool.AgentConnFunc(p.agentConnFn),
-					WorkspaceMu:   &workspaceMu,
-					OnChatUpdated: onChatUpdated,
-					Logger:        p.logger,
-				}),
+				chattool.StartWorkspace(startWSOpts),
 			)
 		} else if chat.WorkspaceID.Valid {
-			// No visible templates but the chat has a workspace already
-			// bound — the user may need to restart it.
+			// No visible templates but the chat has a workspace
+			// already bound — the user may need to restart it.
 			ws, wsErr := p.db.GetWorkspaceByID(ctx, chat.WorkspaceID.UUID)
-			if wsErr == nil && !ws.Deleted {
-				tools = append(tools, chattool.StartWorkspace(chattool.StartWorkspaceOptions{
-					DB:            p.db,
-					OwnerID:       chat.OwnerID,
-					ChatID:        chat.ID,
-					StartFn:       p.startWorkspaceFn,
-					AgentConnFn:   chattool.AgentConnFunc(p.agentConnFn),
-					WorkspaceMu:   &workspaceMu,
-					OnChatUpdated: onChatUpdated,
-					Logger:        p.logger,
-				}))
+			if wsErr != nil {
+				p.logger.Warn(ctx, "failed to look up chat workspace, including start_workspace tool",
+					slog.F("workspace_id", chat.WorkspaceID.UUID),
+					slog.Error(wsErr),
+				)
+			}
+			if wsErr != nil || !ws.Deleted {
+				tools = append(tools, chattool.StartWorkspace(startWSOpts))
 			}
 		}
+
 		// Plan presentation tool.
 		tools = append(tools, chattool.ProposePlan(chattool.ProposePlanOptions{
 			GetWorkspaceConn: workspaceCtx.getWorkspaceConn,

--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -5745,3 +5745,274 @@ func TestAgentContextFilesAndSkillsLoadedIntoChat(t *testing.T) {
 	require.Contains(t, allSystemContent, "A test skill",
 		"system prompt should include the skill description")
 }
+
+// TestOmitsProvisioningToolsWhenOrgHasNoTemplates verifies that
+// list_templates, read_template, create_workspace, and start_workspace
+// are all absent from the LLM tool list when the org contains no
+// templates visible to the chat owner.
+func TestOmitsProvisioningToolsWhenOrgHasNoTemplates(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	db, ps := dbtestutil.NewDB(t)
+
+	var toolsMu sync.Mutex
+	var capturedTools []string
+
+	openAIURL := chattest.NewOpenAI(t, func(req *chattest.OpenAIRequest) chattest.OpenAIResponse {
+		if !req.Stream {
+			return chattest.OpenAINonStreamingResponse("title")
+		}
+		toolsMu.Lock()
+		if capturedTools == nil {
+			capturedTools = make([]string, 0, len(req.Tools))
+			for _, tool := range req.Tools {
+				capturedTools = append(capturedTools, tool.Function.Name)
+			}
+		}
+		toolsMu.Unlock()
+		return chattest.OpenAIStreamingResponse(
+			chattest.OpenAITextChunks("done")...,
+		)
+	})
+
+	user, org, model := seedChatDependenciesWithProvider(ctx, t, db, "openai-compat", openAIURL)
+	// No templates are created for this org — orgHasVisibleChatTemplates
+	// must return false and the provisioning tools must be omitted.
+
+	server := newActiveTestServer(t, db, ps)
+
+	chat, err := server.CreateChat(ctx, chatd.CreateOptions{
+		OrganizationID: org.ID,
+		OwnerID:        user.ID,
+		Title:          "no-templates-test",
+		ModelConfigID:  model.ID,
+		InitialUserContent: []codersdk.ChatMessagePart{
+			codersdk.ChatMessageText("hello"),
+		},
+	})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		got, getErr := db.GetChatByID(ctx, chat.ID)
+		if getErr != nil {
+			return false
+		}
+		return got.Status == database.ChatStatusWaiting || got.Status == database.ChatStatusError
+	}, testutil.WaitLong, testutil.IntervalFast)
+
+	toolsMu.Lock()
+	tools := append([]string(nil), capturedTools...)
+	toolsMu.Unlock()
+
+	require.NotEmpty(t, tools, "LLM should have received at least one streaming request with tools")
+
+	// All four provisioning tools must be absent when no templates are
+	// visible in the org.
+	for _, tool := range []string{"list_templates", "read_template", "create_workspace", "start_workspace"} {
+		require.NotContains(t, tools, tool,
+			"provisioning tool %q should be absent when org has no templates", tool)
+	}
+
+	// Standard filesystem and process tools must remain present.
+	for _, tool := range []string{
+		"read_file", "write_file", "edit_files", "execute",
+		"process_output", "process_list", "process_signal", "propose_plan",
+	} {
+		require.Contains(t, tools, tool,
+			"standard tool %q should be present regardless of template visibility", tool)
+	}
+
+	// Subagent tools must be present on a root chat.
+	for _, tool := range []string{"spawn_agent", "wait_agent", "message_agent", "close_agent"} {
+		require.Contains(t, tools, tool,
+			"subagent tool %q should be present on root chat", tool)
+	}
+}
+
+// TestIncludesStartWorkspaceWhenWorkspaceBoundButNoTemplates verifies
+// that start_workspace is present when a workspace is bound to the
+// chat even if no templates are visible in the org, while
+// list_templates, read_template, and create_workspace are still absent.
+func TestIncludesStartWorkspaceWhenWorkspaceBoundButNoTemplates(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	db, ps := dbtestutil.NewDB(t)
+
+	var toolsMu sync.Mutex
+	var capturedTools []string
+
+	openAIURL := chattest.NewOpenAI(t, func(req *chattest.OpenAIRequest) chattest.OpenAIResponse {
+		if !req.Stream {
+			return chattest.OpenAINonStreamingResponse("title")
+		}
+		toolsMu.Lock()
+		if capturedTools == nil {
+			capturedTools = make([]string, 0, len(req.Tools))
+			for _, tool := range req.Tools {
+				capturedTools = append(capturedTools, tool.Function.Name)
+			}
+		}
+		toolsMu.Unlock()
+		return chattest.OpenAIStreamingResponse(
+			chattest.OpenAITextChunks("done")...,
+		)
+	})
+
+	user, org, model := seedChatDependenciesWithProvider(ctx, t, db, "openai-compat", openAIURL)
+
+	// Create a template and workspace so the chat has a bound workspace.
+	// An allowlist pointing at a different UUID ensures the org has no
+	// *visible* templates while the workspace itself still exists.
+	tv := dbgen.TemplateVersion(t, db, database.TemplateVersion{
+		OrganizationID: org.ID,
+		CreatedBy:      user.ID,
+	})
+	tpl := dbgen.Template(t, db, database.Template{
+		CreatedBy:       user.ID,
+		OrganizationID:  org.ID,
+		ActiveVersionID: tv.ID,
+	})
+	ws := dbgen.Workspace(t, db, database.WorkspaceTable{
+		OrganizationID: org.ID,
+		OwnerID:        user.ID,
+		TemplateID:     tpl.ID,
+	})
+	pj := dbgen.ProvisionerJob(t, db, nil, database.ProvisionerJob{
+		InitiatorID:    user.ID,
+		OrganizationID: org.ID,
+	})
+	_ = dbgen.WorkspaceBuild(t, db, database.WorkspaceBuild{
+		WorkspaceID:       ws.ID,
+		TemplateVersionID: tv.ID,
+		JobID:             pj.ID,
+	})
+
+	// Point the allowlist at a UUID that matches no template so
+	// orgHasVisibleChatTemplates returns false.
+	allowlistJSON, err := json.Marshal([]string{uuid.New().String()})
+	require.NoError(t, err)
+	err = db.UpsertChatTemplateAllowlist(dbauthz.AsSystemRestricted(ctx), string(allowlistJSON))
+	require.NoError(t, err)
+
+	server := newActiveTestServer(t, db, ps)
+
+	chat, err := server.CreateChat(ctx, chatd.CreateOptions{
+		OrganizationID: org.ID,
+		OwnerID:        user.ID,
+		Title:          "workspace-bound-no-templates",
+		ModelConfigID:  model.ID,
+		WorkspaceID:    uuid.NullUUID{UUID: ws.ID, Valid: true},
+		InitialUserContent: []codersdk.ChatMessagePart{
+			codersdk.ChatMessageText("hello"),
+		},
+	})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		got, getErr := db.GetChatByID(ctx, chat.ID)
+		if getErr != nil {
+			return false
+		}
+		return got.Status == database.ChatStatusWaiting || got.Status == database.ChatStatusError
+	}, testutil.WaitLong, testutil.IntervalFast)
+
+	toolsMu.Lock()
+	tools := append([]string(nil), capturedTools...)
+	toolsMu.Unlock()
+
+	require.NotEmpty(t, tools, "LLM should have received at least one streaming request with tools")
+
+	// start_workspace must be present because the workspace is bound.
+	require.Contains(t, tools, "start_workspace",
+		"start_workspace should be present when workspace is bound")
+
+	// Template browsing and creation tools must be absent when no
+	// templates are visible, even though a workspace is bound.
+	for _, tool := range []string{"list_templates", "read_template", "create_workspace"} {
+		require.NotContains(t, tools, tool,
+			"tool %q should be absent when no templates are visible", tool)
+	}
+}
+
+// TestOmitsProvisioningToolsWhenAllowlistExcludesAllOrgTemplates
+// verifies that all four provisioning tools are absent when the
+// template allowlist is set to a UUID that does not match any template
+// in the org, making the effective visible template list empty.
+func TestOmitsProvisioningToolsWhenAllowlistExcludesAllOrgTemplates(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	db, ps := dbtestutil.NewDB(t)
+
+	var toolsMu sync.Mutex
+	var capturedTools []string
+
+	openAIURL := chattest.NewOpenAI(t, func(req *chattest.OpenAIRequest) chattest.OpenAIResponse {
+		if !req.Stream {
+			return chattest.OpenAINonStreamingResponse("title")
+		}
+		toolsMu.Lock()
+		if capturedTools == nil {
+			capturedTools = make([]string, 0, len(req.Tools))
+			for _, tool := range req.Tools {
+				capturedTools = append(capturedTools, tool.Function.Name)
+			}
+		}
+		toolsMu.Unlock()
+		return chattest.OpenAIStreamingResponse(
+			chattest.OpenAITextChunks("done")...,
+		)
+	})
+
+	user, org, model := seedChatDependenciesWithProvider(ctx, t, db, "openai-compat", openAIURL)
+
+	// Create a template in the org so the DB has something to filter.
+	_ = dbgen.Template(t, db, database.Template{
+		OrganizationID: org.ID,
+		CreatedBy:      user.ID,
+	})
+
+	// Set the allowlist to a UUID that does not match the template so
+	// orgHasVisibleChatTemplates returns false despite the template
+	// existing in the org.
+	allowlistJSON, err := json.Marshal([]string{uuid.New().String()})
+	require.NoError(t, err)
+	err = db.UpsertChatTemplateAllowlist(dbauthz.AsSystemRestricted(ctx), string(allowlistJSON))
+	require.NoError(t, err)
+
+	server := newActiveTestServer(t, db, ps)
+
+	chat, err := server.CreateChat(ctx, chatd.CreateOptions{
+		OrganizationID: org.ID,
+		OwnerID:        user.ID,
+		Title:          "allowlist-excludes-all",
+		ModelConfigID:  model.ID,
+		InitialUserContent: []codersdk.ChatMessagePart{
+			codersdk.ChatMessageText("hello"),
+		},
+	})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		got, getErr := db.GetChatByID(ctx, chat.ID)
+		if getErr != nil {
+			return false
+		}
+		return got.Status == database.ChatStatusWaiting || got.Status == database.ChatStatusError
+	}, testutil.WaitLong, testutil.IntervalFast)
+
+	toolsMu.Lock()
+	tools := append([]string(nil), capturedTools...)
+	toolsMu.Unlock()
+
+	require.NotEmpty(t, tools, "LLM should have received at least one streaming request with tools")
+
+	// All four provisioning tools must be absent when the allowlist
+	// excludes every template in the org.
+	for _, tool := range []string{"list_templates", "read_template", "create_workspace", "start_workspace"} {
+		require.NotContains(t, tools, tool,
+			"provisioning tool %q should be absent when allowlist excludes all org templates", tool)
+	}
+}

--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -5793,13 +5793,18 @@ func TestOmitsProvisioningToolsWhenOrgHasNoTemplates(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	var chatResult database.Chat
 	require.Eventually(t, func() bool {
 		got, getErr := db.GetChatByID(ctx, chat.ID)
 		if getErr != nil {
 			return false
 		}
+		chatResult = got
 		return got.Status == database.ChatStatusWaiting || got.Status == database.ChatStatusError
 	}, testutil.WaitLong, testutil.IntervalFast)
+	if chatResult.Status == database.ChatStatusError {
+		require.FailNowf(t, "chat run failed", "last_error=%q", chatResult.LastError.String)
+	}
 
 	toolsMu.Lock()
 	tools := append([]string(nil), capturedTools...)
@@ -5910,13 +5915,18 @@ func TestIncludesStartWorkspaceWhenWorkspaceBoundButNoTemplates(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	var chatResult database.Chat
 	require.Eventually(t, func() bool {
 		got, getErr := db.GetChatByID(ctx, chat.ID)
 		if getErr != nil {
 			return false
 		}
+		chatResult = got
 		return got.Status == database.ChatStatusWaiting || got.Status == database.ChatStatusError
 	}, testutil.WaitLong, testutil.IntervalFast)
+	if chatResult.Status == database.ChatStatusError {
+		require.FailNowf(t, "chat run failed", "last_error=%q", chatResult.LastError.String)
+	}
 
 	toolsMu.Lock()
 	tools := append([]string(nil), capturedTools...)
@@ -5995,13 +6005,18 @@ func TestOmitsProvisioningToolsWhenAllowlistExcludesAllOrgTemplates(t *testing.T
 	})
 	require.NoError(t, err)
 
+	var chatResult database.Chat
 	require.Eventually(t, func() bool {
 		got, getErr := db.GetChatByID(ctx, chat.ID)
 		if getErr != nil {
 			return false
 		}
+		chatResult = got
 		return got.Status == database.ChatStatusWaiting || got.Status == database.ChatStatusError
 	}, testutil.WaitLong, testutil.IntervalFast)
+	if chatResult.Status == database.ChatStatusError {
+		require.FailNowf(t, "chat run failed", "last_error=%q", chatResult.LastError.String)
+	}
 
 	toolsMu.Lock()
 	tools := append([]string(nil), capturedTools...)

--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -5946,6 +5946,126 @@ func TestIncludesStartWorkspaceWhenWorkspaceBoundButNoTemplates(t *testing.T) {
 	}
 }
 
+// TestOmitsStartWorkspaceWhenBoundWorkspaceIsDeleted verifies that when
+// a chat's org has no visible templates AND the bound workspace is
+// soft-deleted, start_workspace is NOT included in the tool list.
+func TestOmitsStartWorkspaceWhenBoundWorkspaceIsDeleted(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	db, ps := dbtestutil.NewDB(t)
+
+	var toolsMu sync.Mutex
+	var capturedTools []string
+
+	openAIURL := chattest.NewOpenAI(t, func(req *chattest.OpenAIRequest) chattest.OpenAIResponse {
+		if !req.Stream {
+			return chattest.OpenAINonStreamingResponse("title")
+		}
+		toolsMu.Lock()
+		if capturedTools == nil {
+			capturedTools = make([]string, 0, len(req.Tools))
+			for _, tool := range req.Tools {
+				capturedTools = append(capturedTools, tool.Function.Name)
+			}
+		}
+		toolsMu.Unlock()
+		return chattest.OpenAIStreamingResponse(
+			chattest.OpenAITextChunks("done")...,
+		)
+	})
+
+	user, org, model := seedChatDependenciesWithProvider(ctx, t, db, "openai-compat", openAIURL)
+
+	// Create a template and workspace so the chat has a bound workspace.
+	tv := dbgen.TemplateVersion(t, db, database.TemplateVersion{
+		OrganizationID: org.ID,
+		CreatedBy:      user.ID,
+	})
+	tpl := dbgen.Template(t, db, database.Template{
+		CreatedBy:       user.ID,
+		OrganizationID:  org.ID,
+		ActiveVersionID: tv.ID,
+	})
+	ws := dbgen.Workspace(t, db, database.WorkspaceTable{
+		OrganizationID: org.ID,
+		OwnerID:        user.ID,
+		TemplateID:     tpl.ID,
+	})
+	pj := dbgen.ProvisionerJob(t, db, nil, database.ProvisionerJob{
+		InitiatorID:    user.ID,
+		OrganizationID: org.ID,
+	})
+	_ = dbgen.WorkspaceBuild(t, db, database.WorkspaceBuild{
+		WorkspaceID:       ws.ID,
+		TemplateVersionID: tv.ID,
+		JobID:             pj.ID,
+	})
+
+	// Soft-delete the workspace.
+	err := db.UpdateWorkspaceDeletedByID(dbauthz.AsSystemRestricted(ctx), database.UpdateWorkspaceDeletedByIDParams{
+		ID:      ws.ID,
+		Deleted: true,
+	})
+	require.NoError(t, err)
+
+	// Point the allowlist at a UUID that matches no template so
+	// orgHasVisibleChatTemplates returns false.
+	allowlistJSON, err := json.Marshal([]string{uuid.New().String()})
+	require.NoError(t, err)
+	err = db.UpsertChatTemplateAllowlist(dbauthz.AsSystemRestricted(ctx), string(allowlistJSON))
+	require.NoError(t, err)
+
+	server := newActiveTestServer(t, db, ps)
+
+	chat, err := server.CreateChat(ctx, chatd.CreateOptions{
+		OrganizationID: org.ID,
+		OwnerID:        user.ID,
+		Title:          "deleted-workspace-no-templates",
+		ModelConfigID:  model.ID,
+		WorkspaceID:    uuid.NullUUID{UUID: ws.ID, Valid: true},
+		InitialUserContent: []codersdk.ChatMessagePart{
+			codersdk.ChatMessageText("hello"),
+		},
+	})
+	require.NoError(t, err)
+
+	var chatResult database.Chat
+	require.Eventually(t, func() bool {
+		got, getErr := db.GetChatByID(ctx, chat.ID)
+		if getErr != nil {
+			return false
+		}
+		chatResult = got
+		return got.Status == database.ChatStatusWaiting || got.Status == database.ChatStatusError
+	}, testutil.WaitLong, testutil.IntervalFast)
+	if chatResult.Status == database.ChatStatusError {
+		require.FailNowf(t, "chat run failed", "last_error=%q", chatResult.LastError.String)
+	}
+
+	toolsMu.Lock()
+	tools := append([]string(nil), capturedTools...)
+	toolsMu.Unlock()
+
+	require.NotEmpty(t, tools, "LLM should have received at least one streaming request with tools")
+
+	// All four provisioning tools must be absent: the workspace is
+	// soft-deleted and there are no visible templates.
+	for _, tool := range []string{"list_templates", "read_template", "create_workspace", "start_workspace"} {
+		require.NotContains(t, tools, tool,
+			"provisioning tool %q should be absent when workspace is deleted and org has no templates", tool)
+	}
+
+	// Standard filesystem and process tools must remain present.
+	for _, tool := range []string{
+		"read_file", "write_file", "edit_files", "execute",
+		"process_output", "process_list", "process_signal", "propose_plan",
+	} {
+		require.Contains(t, tools, tool,
+			"standard tool %q should be present regardless of template visibility", tool)
+	}
+}
+
 // TestOmitsProvisioningToolsWhenAllowlistExcludesAllOrgTemplates
 // verifies that all four provisioning tools are absent when the
 // template allowlist is set to a UUID that does not match any template

--- a/coderd/x/chatd/chattool/createworkspace.go
+++ b/coderd/x/chatd/chattool/createworkspace.go
@@ -136,7 +136,7 @@ func CreateWorkspace(options CreateWorkspaceOptions) fantasy.AgentTool {
 
 			// Set up dbauthz context for DB lookups.
 			if options.DB != nil {
-				ownerCtx, ownerErr := asOwner(ctx, options.DB, ownerID)
+				ownerCtx, ownerErr := AsOwner(ctx, options.DB, ownerID)
 				if ownerErr != nil {
 					return fantasy.NewTextErrorResponse(ownerErr.Error()), nil
 				}

--- a/coderd/x/chatd/chattool/listtemplates.go
+++ b/coderd/x/chatd/chattool/listtemplates.go
@@ -50,7 +50,7 @@ func ListTemplates(options ListTemplatesOptions) fantasy.AgentTool {
 				return fantasy.NewTextErrorResponse("database is not configured"), nil
 			}
 
-			ctx, err := asOwner(ctx, options.DB, options.OwnerID)
+			ctx, err := AsOwner(ctx, options.DB, options.OwnerID)
 			if err != nil {
 				return fantasy.NewTextErrorResponse(err.Error()), nil
 			}
@@ -150,9 +150,9 @@ func ListTemplates(options ListTemplatesOptions) fantasy.AgentTool {
 	)
 }
 
-// asOwner sets up a dbauthz context for the given owner so that
+// AsOwner sets up a dbauthz context for the given owner so that
 // subsequent database calls are scoped to what that user can access.
-func asOwner(ctx context.Context, db database.Store, ownerID uuid.UUID) (context.Context, error) {
+func AsOwner(ctx context.Context, db database.Store, ownerID uuid.UUID) (context.Context, error) {
 	actor, _, err := httpmw.UserRBACSubject(ctx, db, ownerID, rbac.ScopeAll)
 	if err != nil {
 		return ctx, xerrors.Errorf("load user authorization: %w", err)

--- a/coderd/x/chatd/chattool/readtemplate.go
+++ b/coderd/x/chatd/chattool/readtemplate.go
@@ -53,7 +53,7 @@ func ReadTemplate(options ReadTemplateOptions) fantasy.AgentTool {
 				return fantasy.NewTextErrorResponse("template not found"), nil
 			}
 
-			ctx, err = asOwner(ctx, options.DB, options.OwnerID)
+			ctx, err = AsOwner(ctx, options.DB, options.OwnerID)
 			if err != nil {
 				return fantasy.NewTextErrorResponse(err.Error()), nil
 			}

--- a/coderd/x/chatd/chattool/startworkspace.go
+++ b/coderd/x/chatd/chattool/startworkspace.go
@@ -149,7 +149,7 @@ func StartWorkspace(options StartWorkspaceOptions) fantasy.AgentTool {
 			}
 
 			// Set up dbauthz context for the start call.
-			ownerCtx, ownerErr := asOwner(ctx, options.DB, options.OwnerID)
+			ownerCtx, ownerErr := AsOwner(ctx, options.DB, options.OwnerID)
 			if ownerErr != nil {
 				return fantasy.NewTextErrorResponse(ownerErr.Error()), nil
 			}


### PR DESCRIPTION
Closes https://github.com/coder/internal/issues/1464

When a chat is scoped to an org with no templates visible to the owner (RBAC + allowlist), the LLM was still receiving `list_templates`, `read_template`, `create_workspace`, and `start_workspace` — burning tokens on tools that can only return empty results.

- Export `chattool.asOwner` → `AsOwner` so `chatd` package can use it
- Add `Server.orgHasVisibleChatTemplates` helper: queries templates with RBAC-scoped context and respects the deployment allowlist
- Conditionally register the four provisioning tools only when the org has ≥1 visible template
- `start_workspace` still included when a non-deleted workspace is already bound to the chat (user may need to restart it)
- Graceful degradation: DB error logs a warning and includes tools rather than silently crippling the chat
- 3 new tests covering: no templates, workspace bound with no templates, allowlist excludes all templates

> 🤖 PR initially created by Claude Opus 4.6