### PR TITLE
fix: address post-merge review findings for chat org scoping

### DIFF
--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -10353,10 +10353,10 @@ func TestGetPRInsights(t *testing.T) {
 	}
 
 	type chatParams struct {
-		Store  database.Store
-		UserID uuid.UUID
-		McID   uuid.UUID
-		OrgID  uuid.UUID
+		Store         database.Store
+		UserID        uuid.UUID
+		ModelConfigID uuid.UUID
+		OrgID         uuid.UUID
 	}
 
 	createChat := func(t *testing.T, p chatParams, title string) database.Chat {
@@ -10365,7 +10365,7 @@ func TestGetPRInsights(t *testing.T) {
 			OrganizationID:    p.OrgID,
 			Status:            database.ChatStatusWaiting,
 			OwnerID:           p.UserID,
-			LastModelConfigID: p.McID,
+			LastModelConfigID: p.ModelConfigID,
 			Title:             title,
 		})
 		require.NoError(t, err)
@@ -10424,7 +10424,7 @@ func TestGetPRInsights(t *testing.T) {
 	t.Run("MultipleChatsSamePR_CostSummed", func(t *testing.T) {
 		t.Parallel()
 		store, userID, mcID, orgID := setupChatInfra(t)
-		p := chatParams{Store: store, UserID: userID, McID: mcID, OrgID: orgID}
+		p := chatParams{Store: store, UserID: userID, ModelConfigID: mcID, OrgID: orgID}
 
 		chatA := createChat(t, p, "chat-A")
 		insertCostMessage(t, store, chatA.ID, userID, mcID, 5_000_000) // $5
@@ -10461,7 +10461,7 @@ func TestGetPRInsights(t *testing.T) {
 	t.Run("DifferentPRs_NoDuplication", func(t *testing.T) {
 		t.Parallel()
 		store, userID, mcID, orgID := setupChatInfra(t)
-		p := chatParams{Store: store, UserID: userID, McID: mcID, OrgID: orgID}
+		p := chatParams{Store: store, UserID: userID, ModelConfigID: mcID, OrgID: orgID}
 
 		chatA := createChat(t, p, "chat-A")
 		insertCostMessage(t, store, chatA.ID, userID, mcID, 5_000_000)
@@ -10502,7 +10502,7 @@ func TestGetPRInsights(t *testing.T) {
 			OrganizationID:    p.OrgID,
 			Status:            database.ChatStatusWaiting,
 			OwnerID:           p.UserID,
-			LastModelConfigID: p.McID,
+			LastModelConfigID: p.ModelConfigID,
 			Title:             title,
 			ParentChatID:      uuid.NullUUID{UUID: parentID, Valid: true},
 			RootChatID:        uuid.NullUUID{UUID: rootID, Valid: true},
@@ -10514,10 +10514,10 @@ func TestGetPRInsights(t *testing.T) {
 	t.Run("DuplicatePRUrl_CountedOnce", func(t *testing.T) {
 		t.Parallel()
 		store, userID, mcID, orgID := setupChatInfra(t)
-		p := chatParams{Store: store, UserID: userID, McID: mcID, OrgID: orgID}
+		p := chatParams{Store: store, UserID: userID, ModelConfigID: mcID, OrgID: orgID}
 
 		prURL := "https://github.com/org/repo/pull/99"
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			chat := createChat(t, p, fmt.Sprintf("chat-%d", i))
 			insertCostMessage(t, store, chat.ID, userID, mcID, 1_000_000)
 			linkPR(t, store, chat.ID, prURL, "merged", "fix: same PR", 40, 10, 3)
@@ -10544,7 +10544,7 @@ func TestGetPRInsights(t *testing.T) {
 	t.Run("ChildChatCostsIncluded", func(t *testing.T) {
 		t.Parallel()
 		store, userID, mcID, orgID := setupChatInfra(t)
-		p := chatParams{Store: store, UserID: userID, McID: mcID, OrgID: orgID}
+		p := chatParams{Store: store, UserID: userID, ModelConfigID: mcID, OrgID: orgID}
 
 		// Parent chat with a $5 cost.
 		parent := createChat(t, p, "parent-chat")
@@ -10587,7 +10587,7 @@ func TestGetPRInsights(t *testing.T) {
 	t.Run("SiblingPRs_NoCrossContamination", func(t *testing.T) {
 		t.Parallel()
 		store, userID, mcID, orgID := setupChatInfra(t)
-		p := chatParams{Store: store, UserID: userID, McID: mcID, OrgID: orgID}
+		p := chatParams{Store: store, UserID: userID, ModelConfigID: mcID, OrgID: orgID}
 
 		// Parent chat with $10 orchestration cost.
 		parent := createChat(t, p, "parent")
@@ -10631,7 +10631,7 @@ func TestGetPRInsights(t *testing.T) {
 	t.Run("ParentAndChildDifferentPRs_NoCrossContamination", func(t *testing.T) {
 		t.Parallel()
 		store, userID, mcID, orgID := setupChatInfra(t)
-		p := chatParams{Store: store, UserID: userID, McID: mcID, OrgID: orgID}
+		p := chatParams{Store: store, UserID: userID, ModelConfigID: mcID, OrgID: orgID}
 
 		// Parent P ($10) creates PR1.
 		parent := createChat(t, p, "parent")
@@ -10677,7 +10677,7 @@ func TestGetPRInsights(t *testing.T) {
 	t.Run("EmptyURLNotCollapsed", func(t *testing.T) {
 		t.Parallel()
 		store, userID, mcID, orgID := setupChatInfra(t)
-		p := chatParams{Store: store, UserID: userID, McID: mcID, OrgID: orgID}
+		p := chatParams{Store: store, UserID: userID, ModelConfigID: mcID, OrgID: orgID}
 
 		// Two chats with empty-string URLs should be treated as
 		// separate PRs (NULLIF converts '' to NULL, falling back
@@ -10711,7 +10711,7 @@ func TestGetPRInsights(t *testing.T) {
 	t.Run("ParentAndChildSameURL_DedupedWithCombinedCost", func(t *testing.T) {
 		t.Parallel()
 		store, userID, mcID, orgID := setupChatInfra(t)
-		p := chatParams{Store: store, UserID: userID, McID: mcID, OrgID: orgID}
+		p := chatParams{Store: store, UserID: userID, ModelConfigID: mcID, OrgID: orgID}
 
 		// Parent P ($10) links to a PR.
 		parent := createChat(t, p, "parent")
@@ -10749,7 +10749,7 @@ func TestGetPRInsights(t *testing.T) {
 	t.Run("ZeroCostChat_StillCounted", func(t *testing.T) {
 		t.Parallel()
 		store, userID, mcID, orgID := setupChatInfra(t)
-		p := chatParams{Store: store, UserID: userID, McID: mcID, OrgID: orgID}
+		p := chatParams{Store: store, UserID: userID, ModelConfigID: mcID, OrgID: orgID}
 
 		// A chat linked to a PR but with NO chat_messages at all.
 		// The PR should still appear with zero cost.
@@ -10794,7 +10794,7 @@ func TestGetPRInsights(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		chat := createChat(t, chatParams{Store: store, UserID: userID, McID: emptyDisplayModel.ID, OrgID: orgID}, "chat-empty-display-name")
+		chat := createChat(t, chatParams{Store: store, UserID: userID, ModelConfigID: emptyDisplayModel.ID, OrgID: orgID}, "chat-empty-display-name")
 		insertCostMessage(t, store, chat.ID, userID, emptyDisplayModel.ID, 1_000_000)
 		linkPR(t, store, chat.ID, "https://github.com/org/repo/pull/72", "merged", "fix: blank display name", 10, 2, 1)
 
@@ -10820,7 +10820,7 @@ func TestGetPRInsights(t *testing.T) {
 	t.Run("MergedCostMicros_OnlyCountsMerged", func(t *testing.T) {
 		t.Parallel()
 		store, userID, mcID, orgID := setupChatInfra(t)
-		p := chatParams{Store: store, UserID: userID, McID: mcID, OrgID: orgID}
+		p := chatParams{Store: store, UserID: userID, ModelConfigID: mcID, OrgID: orgID}
 
 		// Merged PR with $5 cost.
 		chatMerged := createChat(t, p, "chat-merged")
@@ -10847,7 +10847,7 @@ func TestGetPRInsights(t *testing.T) {
 	t.Run("AllPRsReturnedWithSafetyCap", func(t *testing.T) {
 		t.Parallel()
 		store, userID, mcID, orgID := setupChatInfra(t)
-		p := chatParams{Store: store, UserID: userID, McID: mcID, OrgID: orgID}
+		p := chatParams{Store: store, UserID: userID, ModelConfigID: mcID, OrgID: orgID}
 
 		// Create 25 distinct PRs — more than the old LIMIT 20 — and
 		// verify all are returned.

--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -10316,7 +10316,8 @@ func TestGetPRInsights(t *testing.T) {
 	}
 
 	// setupChatInfra creates a fresh database with a user, chat provider,
-	// and model config. Returns the store, user ID, and model config ID.
+	// and model config. Returns the store, user ID, model config ID,
+	// and org ID.
 	setupChatInfra := func(t *testing.T) (database.Store, uuid.UUID, uuid.UUID, uuid.UUID) {
 		t.Helper()
 		store, _ := dbtestutil.NewDB(t)
@@ -10351,13 +10352,20 @@ func TestGetPRInsights(t *testing.T) {
 		return store, user.ID, mc.ID, org.ID
 	}
 
-	createChat := func(t *testing.T, store database.Store, userID, mcID, orgID uuid.UUID, title string) database.Chat {
+	type chatParams struct {
+		Store  database.Store
+		UserID uuid.UUID
+		McID   uuid.UUID
+		OrgID  uuid.UUID
+	}
+
+	createChat := func(t *testing.T, p chatParams, title string) database.Chat {
 		t.Helper()
-		chat, err := store.InsertChat(context.Background(), database.InsertChatParams{
-			OrganizationID:    orgID,
+		chat, err := p.Store.InsertChat(context.Background(), database.InsertChatParams{
+			OrganizationID:    p.OrgID,
 			Status:            database.ChatStatusWaiting,
-			OwnerID:           userID,
-			LastModelConfigID: mcID,
+			OwnerID:           p.UserID,
+			LastModelConfigID: p.McID,
 			Title:             title,
 		})
 		require.NoError(t, err)
@@ -10416,11 +10424,12 @@ func TestGetPRInsights(t *testing.T) {
 	t.Run("MultipleChatsSamePR_CostSummed", func(t *testing.T) {
 		t.Parallel()
 		store, userID, mcID, orgID := setupChatInfra(t)
+		p := chatParams{Store: store, UserID: userID, McID: mcID, OrgID: orgID}
 
-		chatA := createChat(t, store, userID, mcID, orgID, "chat-A")
+		chatA := createChat(t, p, "chat-A")
 		insertCostMessage(t, store, chatA.ID, userID, mcID, 5_000_000) // $5
 
-		chatB := createChat(t, store, userID, mcID, orgID, "chat-B")
+		chatB := createChat(t, p, "chat-B")
 		insertCostMessage(t, store, chatB.ID, userID, mcID, 3_000_000) // $3
 
 		prURL := "https://github.com/org/repo/pull/123"
@@ -10452,12 +10461,13 @@ func TestGetPRInsights(t *testing.T) {
 	t.Run("DifferentPRs_NoDuplication", func(t *testing.T) {
 		t.Parallel()
 		store, userID, mcID, orgID := setupChatInfra(t)
+		p := chatParams{Store: store, UserID: userID, McID: mcID, OrgID: orgID}
 
-		chatA := createChat(t, store, userID, mcID, orgID, "chat-A")
+		chatA := createChat(t, p, "chat-A")
 		insertCostMessage(t, store, chatA.ID, userID, mcID, 5_000_000)
 		linkPR(t, store, chatA.ID, "https://github.com/org/repo/pull/1", "merged", "feat: A", 50, 10, 2)
 
-		chatB := createChat(t, store, userID, mcID, orgID, "chat-B")
+		chatB := createChat(t, p, "chat-B")
 		insertCostMessage(t, store, chatB.ID, userID, mcID, 3_000_000)
 		linkPR(t, store, chatB.ID, "https://github.com/org/repo/pull/2", "open", "feat: B", 80, 30, 4)
 
@@ -10486,13 +10496,13 @@ func TestGetPRInsights(t *testing.T) {
 
 	// createChildChat creates a chat with ParentChatID and RootChatID
 	// set, simulating a subagent/child chat in a tree.
-	createChildChat := func(t *testing.T, store database.Store, userID, mcID, orgID, parentID, rootID uuid.UUID, title string) database.Chat {
+	createChildChat := func(t *testing.T, p chatParams, parentID, rootID uuid.UUID, title string) database.Chat {
 		t.Helper()
-		chat, err := store.InsertChat(context.Background(), database.InsertChatParams{
-			OrganizationID:    orgID,
+		chat, err := p.Store.InsertChat(context.Background(), database.InsertChatParams{
+			OrganizationID:    p.OrgID,
 			Status:            database.ChatStatusWaiting,
-			OwnerID:           userID,
-			LastModelConfigID: mcID,
+			OwnerID:           p.UserID,
+			LastModelConfigID: p.McID,
 			Title:             title,
 			ParentChatID:      uuid.NullUUID{UUID: parentID, Valid: true},
 			RootChatID:        uuid.NullUUID{UUID: rootID, Valid: true},
@@ -10504,10 +10514,11 @@ func TestGetPRInsights(t *testing.T) {
 	t.Run("DuplicatePRUrl_CountedOnce", func(t *testing.T) {
 		t.Parallel()
 		store, userID, mcID, orgID := setupChatInfra(t)
+		p := chatParams{Store: store, UserID: userID, McID: mcID, OrgID: orgID}
 
 		prURL := "https://github.com/org/repo/pull/99"
 		for i := 0; i < 3; i++ {
-			chat := createChat(t, store, userID, mcID, orgID, fmt.Sprintf("chat-%d", i))
+			chat := createChat(t, p, fmt.Sprintf("chat-%d", i))
 			insertCostMessage(t, store, chat.ID, userID, mcID, 1_000_000)
 			linkPR(t, store, chat.ID, prURL, "merged", "fix: same PR", 40, 10, 3)
 		}
@@ -10533,18 +10544,19 @@ func TestGetPRInsights(t *testing.T) {
 	t.Run("ChildChatCostsIncluded", func(t *testing.T) {
 		t.Parallel()
 		store, userID, mcID, orgID := setupChatInfra(t)
+		p := chatParams{Store: store, UserID: userID, McID: mcID, OrgID: orgID}
 
 		// Parent chat with a $5 cost.
-		parent := createChat(t, store, userID, mcID, orgID, "parent-chat")
+		parent := createChat(t, p, "parent-chat")
 		insertCostMessage(t, store, parent.ID, userID, mcID, 5_000_000)
 
 		// Two child chats (subagents) with $2 each. Only the parent
 		// has a chat_diff_statuses entry, but the children's costs
 		// should be included via the tree join.
-		child1 := createChildChat(t, store, userID, mcID, orgID, parent.ID, parent.ID, "child-1")
+		child1 := createChildChat(t, p, parent.ID, parent.ID, "child-1")
 		insertCostMessage(t, store, child1.ID, userID, mcID, 2_000_000)
 
-		child2 := createChildChat(t, store, userID, mcID, orgID, parent.ID, parent.ID, "child-2")
+		child2 := createChildChat(t, p, parent.ID, parent.ID, "child-2")
 		insertCostMessage(t, store, child2.ID, userID, mcID, 2_000_000)
 
 		prURL := "https://github.com/org/repo/pull/42"
@@ -10575,18 +10587,19 @@ func TestGetPRInsights(t *testing.T) {
 	t.Run("SiblingPRs_NoCrossContamination", func(t *testing.T) {
 		t.Parallel()
 		store, userID, mcID, orgID := setupChatInfra(t)
+		p := chatParams{Store: store, UserID: userID, McID: mcID, OrgID: orgID}
 
 		// Parent chat with $10 orchestration cost.
-		parent := createChat(t, store, userID, mcID, orgID, "parent")
+		parent := createChat(t, p, "parent")
 		insertCostMessage(t, store, parent.ID, userID, mcID, 10_000_000)
 
 		// Child C1 ($5) creates PR1.
-		c1 := createChildChat(t, store, userID, mcID, orgID, parent.ID, parent.ID, "child-1")
+		c1 := createChildChat(t, p, parent.ID, parent.ID, "child-1")
 		insertCostMessage(t, store, c1.ID, userID, mcID, 5_000_000)
 		linkPR(t, store, c1.ID, "https://github.com/org/repo/pull/10", "merged", "feat: PR1", 50, 10, 2)
 
 		// Child C2 ($3) creates PR2.
-		c2 := createChildChat(t, store, userID, mcID, orgID, parent.ID, parent.ID, "child-2")
+		c2 := createChildChat(t, p, parent.ID, parent.ID, "child-2")
 		insertCostMessage(t, store, c2.ID, userID, mcID, 3_000_000)
 		linkPR(t, store, c2.ID, "https://github.com/org/repo/pull/11", "open", "feat: PR2", 30, 5, 1)
 
@@ -10618,22 +10631,23 @@ func TestGetPRInsights(t *testing.T) {
 	t.Run("ParentAndChildDifferentPRs_NoCrossContamination", func(t *testing.T) {
 		t.Parallel()
 		store, userID, mcID, orgID := setupChatInfra(t)
+		p := chatParams{Store: store, UserID: userID, McID: mcID, OrgID: orgID}
 
 		// Parent P ($10) creates PR1.
-		parent := createChat(t, store, userID, mcID, orgID, "parent")
+		parent := createChat(t, p, "parent")
 		insertCostMessage(t, store, parent.ID, userID, mcID, 10_000_000)
 		linkPR(t, store, parent.ID, "https://github.com/org/repo/pull/20", "merged", "feat: parent PR", 80, 20, 4)
 
 		// Child C1 ($5) has its own PR2. Because C1 has its own
 		// chat_diff_statuses entry, its cost should NOT be included
 		// under PR1 — it belongs to PR2 only.
-		c1 := createChildChat(t, store, userID, mcID, orgID, parent.ID, parent.ID, "child-1")
+		c1 := createChildChat(t, p, parent.ID, parent.ID, "child-1")
 		insertCostMessage(t, store, c1.ID, userID, mcID, 5_000_000)
 		linkPR(t, store, c1.ID, "https://github.com/org/repo/pull/21", "open", "feat: child PR", 30, 5, 1)
 
 		// Child C2 ($2) has NO cds entry — pure subagent.
 		// Its cost should be included under PR1 (the parent's PR).
-		c2 := createChildChat(t, store, userID, mcID, orgID, parent.ID, parent.ID, "child-2")
+		c2 := createChildChat(t, p, parent.ID, parent.ID, "child-2")
 		insertCostMessage(t, store, c2.ID, userID, mcID, 2_000_000)
 
 		// PR1 cost = parent ($10) + C2 ($2) = $12 (C1 excluded)
@@ -10663,15 +10677,16 @@ func TestGetPRInsights(t *testing.T) {
 	t.Run("EmptyURLNotCollapsed", func(t *testing.T) {
 		t.Parallel()
 		store, userID, mcID, orgID := setupChatInfra(t)
+		p := chatParams{Store: store, UserID: userID, McID: mcID, OrgID: orgID}
 
 		// Two chats with empty-string URLs should be treated as
 		// separate PRs (NULLIF converts '' to NULL, falling back
 		// to c.id::text).
-		chatX := createChat(t, store, userID, mcID, orgID, "chat-X")
+		chatX := createChat(t, p, "chat-X")
 		insertCostMessage(t, store, chatX.ID, userID, mcID, 4_000_000)
 		linkPR(t, store, chatX.ID, "", "open", "draft: X", 10, 2, 1)
 
-		chatY := createChat(t, store, userID, mcID, orgID, "chat-Y")
+		chatY := createChat(t, p, "chat-Y")
 		insertCostMessage(t, store, chatY.ID, userID, mcID, 6_000_000)
 		linkPR(t, store, chatY.ID, "", "merged", "draft: Y", 20, 5, 2)
 
@@ -10696,13 +10711,14 @@ func TestGetPRInsights(t *testing.T) {
 	t.Run("ParentAndChildSameURL_DedupedWithCombinedCost", func(t *testing.T) {
 		t.Parallel()
 		store, userID, mcID, orgID := setupChatInfra(t)
+		p := chatParams{Store: store, UserID: userID, McID: mcID, OrgID: orgID}
 
 		// Parent P ($10) links to a PR.
-		parent := createChat(t, store, userID, mcID, orgID, "parent")
+		parent := createChat(t, p, "parent")
 		insertCostMessage(t, store, parent.ID, userID, mcID, 10_000_000)
 
 		// Child C ($5) also links to the same PR URL.
-		child := createChildChat(t, store, userID, mcID, orgID, parent.ID, parent.ID, "child")
+		child := createChildChat(t, p, parent.ID, parent.ID, "child")
 		insertCostMessage(t, store, child.ID, userID, mcID, 5_000_000)
 
 		prURL := "https://github.com/org/repo/pull/50"
@@ -10733,10 +10749,11 @@ func TestGetPRInsights(t *testing.T) {
 	t.Run("ZeroCostChat_StillCounted", func(t *testing.T) {
 		t.Parallel()
 		store, userID, mcID, orgID := setupChatInfra(t)
+		p := chatParams{Store: store, UserID: userID, McID: mcID, OrgID: orgID}
 
 		// A chat linked to a PR but with NO chat_messages at all.
 		// The PR should still appear with zero cost.
-		chat := createChat(t, store, userID, mcID, orgID, "zero-cost-chat")
+		chat := createChat(t, p, "zero-cost-chat")
 		linkPR(t, store, chat.ID, "https://github.com/org/repo/pull/60", "open", "feat: no messages", 25, 5, 2)
 
 		summary, err := store.GetPRInsightsSummary(context.Background(), database.GetPRInsightsSummaryParams{
@@ -10777,7 +10794,7 @@ func TestGetPRInsights(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		chat := createChat(t, store, userID, emptyDisplayModel.ID, orgID, "chat-empty-display-name")
+		chat := createChat(t, chatParams{Store: store, UserID: userID, McID: emptyDisplayModel.ID, OrgID: orgID}, "chat-empty-display-name")
 		insertCostMessage(t, store, chat.ID, userID, emptyDisplayModel.ID, 1_000_000)
 		linkPR(t, store, chat.ID, "https://github.com/org/repo/pull/72", "merged", "fix: blank display name", 10, 2, 1)
 
@@ -10803,14 +10820,15 @@ func TestGetPRInsights(t *testing.T) {
 	t.Run("MergedCostMicros_OnlyCountsMerged", func(t *testing.T) {
 		t.Parallel()
 		store, userID, mcID, orgID := setupChatInfra(t)
+		p := chatParams{Store: store, UserID: userID, McID: mcID, OrgID: orgID}
 
 		// Merged PR with $5 cost.
-		chatMerged := createChat(t, store, userID, mcID, orgID, "chat-merged")
+		chatMerged := createChat(t, p, "chat-merged")
 		insertCostMessage(t, store, chatMerged.ID, userID, mcID, 5_000_000)
 		linkPR(t, store, chatMerged.ID, "https://github.com/org/repo/pull/70", "merged", "fix: merged", 40, 10, 2)
 
 		// Open PR with $3 cost.
-		chatOpen := createChat(t, store, userID, mcID, orgID, "chat-open")
+		chatOpen := createChat(t, p, "chat-open")
 		insertCostMessage(t, store, chatOpen.ID, userID, mcID, 3_000_000)
 		linkPR(t, store, chatOpen.ID, "https://github.com/org/repo/pull/71", "open", "feat: open", 20, 5, 1)
 
@@ -10829,12 +10847,13 @@ func TestGetPRInsights(t *testing.T) {
 	t.Run("AllPRsReturnedWithSafetyCap", func(t *testing.T) {
 		t.Parallel()
 		store, userID, mcID, orgID := setupChatInfra(t)
+		p := chatParams{Store: store, UserID: userID, McID: mcID, OrgID: orgID}
 
 		// Create 25 distinct PRs — more than the old LIMIT 20 — and
 		// verify all are returned.
 		const prCount = 25
 		for i := range prCount {
-			chat := createChat(t, store, userID, mcID, orgID, fmt.Sprintf("chat-%d", i))
+			chat := createChat(t, p, fmt.Sprintf("chat-%d", i))
 			insertCostMessage(t, store, chat.ID, userID, mcID, 1_000_000)
 			linkPR(t, store, chat.ID,
 				fmt.Sprintf("https://github.com/org/repo/pull/%d", 100+i),

--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -10794,7 +10794,8 @@ func TestGetPRInsights(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		chat := createChat(t, chatParams{Store: store, UserID: userID, ModelConfigID: emptyDisplayModel.ID, OrgID: orgID}, "chat-empty-display-name")
+		p := chatParams{Store: store, UserID: userID, ModelConfigID: emptyDisplayModel.ID, OrgID: orgID}
+		chat := createChat(t, p, "chat-empty-display-name")
 		insertCostMessage(t, store, chat.ID, userID, emptyDisplayModel.ID, 1_000_000)
 		linkPR(t, store, chat.ID, "https://github.com/org/repo/pull/72", "merged", "fix: blank display name", 10, 2, 1)
 

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -5011,8 +5011,7 @@ func (p *Server) runChat(
 			p.publishChatPubsubEvent(updatedChat, codersdk.ChatWatchEventKindStatusChange, nil)
 		}
 		tools = append(tools,
-			chattool.ListTemplates(chat.OrganizationID, chattool.ListTemplatesOptions{
-				DB:                 p.db,
+			chattool.ListTemplates(chat.OrganizationID, p.db, chattool.ListTemplatesOptions{
 				OwnerID:            chat.OwnerID,
 				AllowedTemplateIDs: p.chatTemplateAllowlist,
 			}), chattool.ReadTemplate(chattool.ReadTemplateOptions{
@@ -5020,10 +5019,10 @@ func (p *Server) runChat(
 				OwnerID:            chat.OwnerID,
 				AllowedTemplateIDs: p.chatTemplateAllowlist,
 			}),
-			chattool.CreateWorkspace(chat.OrganizationID, chattool.CreateWorkspaceOptions{
-				DB:      p.db,
+			chattool.CreateWorkspace(chat.OrganizationID, p.db, chattool.CreateWorkspaceOptions{
 				OwnerID: chat.OwnerID,
 				ChatID:  chat.ID, CreateFn: p.createWorkspaceFn,
+
 				AgentConnFn:                    chattool.AgentConnFunc(p.agentConnFn),
 				AgentInactiveDisconnectTimeout: p.agentInactiveDisconnectTimeout,
 				WorkspaceMu:                    &workspaceMu,

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -5014,15 +5014,16 @@ func (p *Server) runChat(
 			chattool.ListTemplates(chat.OrganizationID, p.db, chattool.ListTemplatesOptions{
 				OwnerID:            chat.OwnerID,
 				AllowedTemplateIDs: p.chatTemplateAllowlist,
-			}), chattool.ReadTemplate(chattool.ReadTemplateOptions{
+			}),
+			chattool.ReadTemplate(chattool.ReadTemplateOptions{
 				DB:                 p.db,
 				OwnerID:            chat.OwnerID,
 				AllowedTemplateIDs: p.chatTemplateAllowlist,
 			}),
 			chattool.CreateWorkspace(chat.OrganizationID, p.db, chattool.CreateWorkspaceOptions{
-				OwnerID: chat.OwnerID,
-				ChatID:  chat.ID, CreateFn: p.createWorkspaceFn,
-
+				OwnerID:                        chat.OwnerID,
+				ChatID:                         chat.ID,
+				CreateFn:                       p.createWorkspaceFn,
 				AgentConnFn:                    chattool.AgentConnFunc(p.agentConnFn),
 				AgentInactiveDisconnectTimeout: p.agentInactiveDisconnectTimeout,
 				WorkspaceMu:                    &workspaceMu,
@@ -5030,6 +5031,7 @@ func (p *Server) runChat(
 				Logger:                         p.logger,
 				AllowedTemplateIDs:             p.chatTemplateAllowlist,
 			}),
+
 			chattool.StartWorkspace(chattool.StartWorkspaceOptions{
 				DB:            p.db,
 				OwnerID:       chat.OwnerID,

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -5015,8 +5015,7 @@ func (p *Server) runChat(
 				OwnerID:            chat.OwnerID,
 				AllowedTemplateIDs: p.chatTemplateAllowlist,
 			}),
-			chattool.ReadTemplate(chattool.ReadTemplateOptions{
-				DB:                 p.db,
+			chattool.ReadTemplate(chat.OrganizationID, p.db, chattool.ReadTemplateOptions{
 				OwnerID:            chat.OwnerID,
 				AllowedTemplateIDs: p.chatTemplateAllowlist,
 			}),

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -5011,23 +5011,19 @@ func (p *Server) runChat(
 			p.publishChatPubsubEvent(updatedChat, codersdk.ChatWatchEventKindStatusChange, nil)
 		}
 		tools = append(tools,
-			chattool.ListTemplates(chattool.ListTemplatesOptions{
-				DB:                 p.db,
-				OwnerID:            chat.OwnerID,
-				OrganizationID:     chat.OrganizationID,
-				AllowedTemplateIDs: p.chatTemplateAllowlist,
-			}),
-			chattool.ReadTemplate(chattool.ReadTemplateOptions{
+			chattool.ListTemplates(chat.OrganizationID, chattool.ListTemplatesOptions{
 				DB:                 p.db,
 				OwnerID:            chat.OwnerID,
 				AllowedTemplateIDs: p.chatTemplateAllowlist,
+			}), chattool.ReadTemplate(chattool.ReadTemplateOptions{
+				DB:                 p.db,
+				OwnerID:            chat.OwnerID,
+				AllowedTemplateIDs: p.chatTemplateAllowlist,
 			}),
-			chattool.CreateWorkspace(chattool.CreateWorkspaceOptions{
-				DB:                             p.db,
-				OwnerID:                        chat.OwnerID,
-				OrganizationID:                 chat.OrganizationID,
-				ChatID:                         chat.ID,
-				CreateFn:                       p.createWorkspaceFn,
+			chattool.CreateWorkspace(chat.OrganizationID, chattool.CreateWorkspaceOptions{
+				DB:      p.db,
+				OwnerID: chat.OwnerID,
+				ChatID:  chat.ID, CreateFn: p.createWorkspaceFn,
 				AgentConnFn:                    chattool.AgentConnFunc(p.agentConnFn),
 				AgentInactiveDisconnectTimeout: p.agentInactiveDisconnectTimeout,
 				WorkspaceMu:                    &workspaceMu,

--- a/coderd/x/chatd/chattool/createworkspace.go
+++ b/coderd/x/chatd/chattool/createworkspace.go
@@ -145,22 +145,20 @@ func CreateWorkspace(organizationID uuid.UUID, db database.Store, options Create
 			// Verify the template belongs to the same org as the
 			// chat. Without this check the tool could silently
 			// bind a cross-org workspace to the chat.
-			if organizationID != uuid.Nil {
-				tmpl, tmplErr := db.GetTemplateByID(ctx, templateID)
-				if tmplErr != nil {
-					return fantasy.NewTextErrorResponse(
-						xerrors.Errorf("look up template: %w", tmplErr).Error(),
-					), nil
-				}
-				if tmpl.OrganizationID != organizationID {
-					return fantasy.NewTextErrorResponse(
-						"template belongs to a different organization than this chat; " +
-							"use list_templates to find templates in the correct organization",
-					), nil
-				}
+			tmpl, tmplErr := db.GetTemplateByID(ctx, templateID)
+			if tmplErr != nil {
+				return fantasy.NewTextErrorResponse(
+					xerrors.Errorf("look up template: %w", tmplErr).Error(),
+				), nil
 			}
-			var ttlMs *int64
+			if tmpl.OrganizationID != organizationID {
+				return fantasy.NewTextErrorResponse(
+					"template belongs to a different organization than this chat; " +
+						"use list_templates to find templates in the correct organization",
+				), nil
+			}
 
+			var ttlMs *int64
 			raw, err := db.GetChatWorkspaceTTL(ctx)
 			if err != nil {
 				options.Logger.Error(ctx, "failed to read chat workspace TTL setting, using template default",

--- a/coderd/x/chatd/chattool/createworkspace.go
+++ b/coderd/x/chatd/chattool/createworkspace.go
@@ -146,7 +146,12 @@ func CreateWorkspace(options CreateWorkspaceOptions) fantasy.AgentTool {
 			// Verify the template belongs to the same org as the
 			// chat. Without this check the tool could silently
 			// bind a cross-org workspace to the chat.
-			if options.DB != nil && options.OrganizationID != uuid.Nil {
+			if options.DB != nil {
+				if options.OrganizationID == uuid.Nil {
+					return fantasy.NewTextErrorResponse(
+						"organization ID is required for template org validation",
+					), nil
+				}
 				tmpl, tmplErr := options.DB.GetTemplateByID(ctx, templateID)
 				if tmplErr != nil {
 					return fantasy.NewTextErrorResponse(
@@ -162,6 +167,7 @@ func CreateWorkspace(options CreateWorkspaceOptions) fantasy.AgentTool {
 			}
 
 			var ttlMs *int64
+
 			if options.DB != nil {
 				raw, err := options.DB.GetChatWorkspaceTTL(ctx)
 				if err != nil {

--- a/coderd/x/chatd/chattool/createworkspace.go
+++ b/coderd/x/chatd/chattool/createworkspace.go
@@ -62,7 +62,6 @@ type AgentConnFunc func(
 type CreateWorkspaceOptions struct {
 	DB                             database.Store
 	OwnerID                        uuid.UUID
-	OrganizationID                 uuid.UUID
 	ChatID                         uuid.UUID
 	CreateFn                       CreateWorkspaceFn
 	AgentConnFn                    AgentConnFunc
@@ -84,7 +83,7 @@ type createWorkspaceArgs struct {
 // workspace that is building or running, it returns the existing
 // workspace instead of creating a new one. A mutex prevents parallel
 // calls from creating duplicate workspaces.
-func CreateWorkspace(options CreateWorkspaceOptions) fantasy.AgentTool {
+func CreateWorkspace(organizationID uuid.UUID, options CreateWorkspaceOptions) fantasy.AgentTool {
 	return fantasy.NewAgentTool(
 		"create_workspace",
 		"Create a new workspace from a template. Requires a "+
@@ -146,26 +145,20 @@ func CreateWorkspace(options CreateWorkspaceOptions) fantasy.AgentTool {
 			// Verify the template belongs to the same org as the
 			// chat. Without this check the tool could silently
 			// bind a cross-org workspace to the chat.
-			if options.DB != nil {
-				if options.OrganizationID == uuid.Nil {
-					return fantasy.NewTextErrorResponse(
-						"organization ID is required for template org validation",
-					), nil
-				}
+			if options.DB != nil && organizationID != uuid.Nil {
 				tmpl, tmplErr := options.DB.GetTemplateByID(ctx, templateID)
 				if tmplErr != nil {
 					return fantasy.NewTextErrorResponse(
 						xerrors.Errorf("look up template: %w", tmplErr).Error(),
 					), nil
 				}
-				if tmpl.OrganizationID != options.OrganizationID {
+				if tmpl.OrganizationID != organizationID {
 					return fantasy.NewTextErrorResponse(
 						"template belongs to a different organization than this chat; " +
 							"use list_templates to find templates in the correct organization",
 					), nil
 				}
 			}
-
 			var ttlMs *int64
 
 			if options.DB != nil {

--- a/coderd/x/chatd/chattool/createworkspace.go
+++ b/coderd/x/chatd/chattool/createworkspace.go
@@ -60,7 +60,6 @@ type AgentConnFunc func(
 
 // CreateWorkspaceOptions configures the create_workspace tool.
 type CreateWorkspaceOptions struct {
-	DB                             database.Store
 	OwnerID                        uuid.UUID
 	ChatID                         uuid.UUID
 	CreateFn                       CreateWorkspaceFn
@@ -83,7 +82,7 @@ type createWorkspaceArgs struct {
 // workspace that is building or running, it returns the existing
 // workspace instead of creating a new one. A mutex prevents parallel
 // calls from creating duplicate workspaces.
-func CreateWorkspace(organizationID uuid.UUID, options CreateWorkspaceOptions) fantasy.AgentTool {
+func CreateWorkspace(organizationID uuid.UUID, db database.Store, options CreateWorkspaceOptions) fantasy.AgentTool {
 	return fantasy.NewAgentTool(
 		"create_workspace",
 		"Create a new workspace from a template. Requires a "+
@@ -94,6 +93,9 @@ func CreateWorkspace(organizationID uuid.UUID, options CreateWorkspaceOptions) f
 			"workspace that is building or running, the existing "+
 			"workspace is returned.",
 		func(ctx context.Context, args createWorkspaceArgs, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
+			if db == nil {
+				return fantasy.NewTextErrorResponse("database is not configured"), nil
+			}
 			if options.CreateFn == nil {
 				return fantasy.NewTextErrorResponse("workspace creator is not configured"), nil
 			}
@@ -121,7 +123,7 @@ func CreateWorkspace(organizationID uuid.UUID, options CreateWorkspaceOptions) f
 			}
 
 			// Check for an existing workspace on the chat.
-			check := options.checkExistingWorkspace(ctx)
+			check := options.checkExistingWorkspace(ctx, db)
 			if check.Err != nil {
 				if check.FailedBuildID != uuid.Nil {
 					return buildToolResponse(newBuildError(check.Err.Error(), check.FailedBuildID)), nil
@@ -134,19 +136,17 @@ func CreateWorkspace(organizationID uuid.UUID, options CreateWorkspaceOptions) f
 			ownerID := options.OwnerID
 
 			// Set up dbauthz context for DB lookups.
-			if options.DB != nil {
-				ownerCtx, ownerErr := asOwner(ctx, options.DB, ownerID)
-				if ownerErr != nil {
-					return fantasy.NewTextErrorResponse(ownerErr.Error()), nil
-				}
-				ctx = ownerCtx
+			ownerCtx, ownerErr := asOwner(ctx, db, ownerID)
+			if ownerErr != nil {
+				return fantasy.NewTextErrorResponse(ownerErr.Error()), nil
 			}
+			ctx = ownerCtx
 
 			// Verify the template belongs to the same org as the
 			// chat. Without this check the tool could silently
 			// bind a cross-org workspace to the chat.
-			if options.DB != nil && organizationID != uuid.Nil {
-				tmpl, tmplErr := options.DB.GetTemplateByID(ctx, templateID)
+			if organizationID != uuid.Nil {
+				tmpl, tmplErr := db.GetTemplateByID(ctx, templateID)
 				if tmplErr != nil {
 					return fantasy.NewTextErrorResponse(
 						xerrors.Errorf("look up template: %w", tmplErr).Error(),
@@ -161,23 +161,21 @@ func CreateWorkspace(organizationID uuid.UUID, options CreateWorkspaceOptions) f
 			}
 			var ttlMs *int64
 
-			if options.DB != nil {
-				raw, err := options.DB.GetChatWorkspaceTTL(ctx)
-				if err != nil {
-					options.Logger.Error(ctx, "failed to read chat workspace TTL setting, using template default",
-						slog.Error(err),
+			raw, err := db.GetChatWorkspaceTTL(ctx)
+			if err != nil {
+				options.Logger.Error(ctx, "failed to read chat workspace TTL setting, using template default",
+					slog.Error(err),
+				)
+			} else {
+				d, parseErr := codersdk.ParseChatWorkspaceTTL(raw)
+				if parseErr != nil {
+					options.Logger.Warn(ctx, "invalid chat workspace TTL setting, using template default",
+						slog.F("raw", raw),
+						slog.Error(parseErr),
 					)
-				} else {
-					d, parseErr := codersdk.ParseChatWorkspaceTTL(raw)
-					if parseErr != nil {
-						options.Logger.Warn(ctx, "invalid chat workspace TTL setting, using template default",
-							slog.F("raw", raw),
-							slog.Error(parseErr),
-						)
-					} else if d > 0 {
-						ms := d.Milliseconds()
-						ttlMs = &ms
-					}
+				} else if d > 0 {
+					ms := d.Milliseconds()
+					ttlMs = &ms
 				}
 			}
 
@@ -195,10 +193,8 @@ func CreateWorkspace(organizationID uuid.UUID, options CreateWorkspaceOptions) f
 			name := strings.TrimSpace(args.Name)
 			if name == "" {
 				seed := "workspace"
-				if options.DB != nil {
-					if t, lookupErr := options.DB.GetTemplateByID(ctx, templateID); lookupErr == nil {
-						seed = t.Name
-					}
+				if t, lookupErr := db.GetTemplateByID(ctx, templateID); lookupErr == nil {
+					seed = t.Name
 				}
 				name = generatedWorkspaceName(seed)
 			} else if err := codersdk.NameValid(name); err != nil {
@@ -226,8 +222,8 @@ func CreateWorkspace(organizationID uuid.UUID, options CreateWorkspaceOptions) f
 			// later fails. The checkExistingWorkspace recovery
 			// path handles failed workspaces by allowing
 			// re-creation.
-			if options.DB != nil && options.ChatID != uuid.Nil {
-				updatedChat, err := options.DB.UpdateChatWorkspaceBinding(ctx, database.UpdateChatWorkspaceBindingParams{
+			if options.ChatID != uuid.Nil {
+				updatedChat, err := db.UpdateChatWorkspaceBinding(ctx, database.UpdateChatWorkspaceBindingParams{
 					ID: options.ChatID,
 					WorkspaceID: uuid.NullUUID{
 						UUID:  workspace.ID,
@@ -257,8 +253,8 @@ func CreateWorkspace(organizationID uuid.UUID, options CreateWorkspaceOptions) f
 			// come online so subsequent tools can use the
 			// workspace immediately.
 			buildID := workspace.LatestBuild.ID
-			if options.DB != nil && buildID != uuid.Nil {
-				if err := waitForBuild(ctx, options.DB, buildID); err != nil {
+			if buildID != uuid.Nil {
+				if err := waitForBuild(ctx, db, buildID); err != nil {
 					return buildToolResponse(newBuildError(
 						xerrors.Errorf("workspace build failed: %w", err).Error(),
 						buildID,
@@ -274,26 +270,24 @@ func CreateWorkspace(organizationID uuid.UUID, options CreateWorkspaceOptions) f
 			// Select the chat agent so follow-up tools wait on the
 			// intended workspace agent.
 			workspaceAgentID := uuid.Nil
-			if options.DB != nil {
-				agents, agentErr := options.DB.GetWorkspaceAgentsInLatestBuildByWorkspaceID(ctx, workspace.ID)
-				if agentErr == nil {
-					if len(agents) == 0 {
-						result["agent_status"] = "no_agent"
+			agents, agentErr := db.GetWorkspaceAgentsInLatestBuildByWorkspaceID(ctx, workspace.ID)
+			if agentErr == nil {
+				if len(agents) == 0 {
+					result["agent_status"] = "no_agent"
+				} else {
+					selected, selectErr := agentselect.FindChatAgent(agents)
+					if selectErr != nil {
+						result["agent_status"] = "selection_error"
+						result["agent_error"] = selectErr.Error()
 					} else {
-						selected, selectErr := agentselect.FindChatAgent(agents)
-						if selectErr != nil {
-							result["agent_status"] = "selection_error"
-							result["agent_error"] = selectErr.Error()
-						} else {
-							workspaceAgentID = selected.ID
-						}
+						workspaceAgentID = selected.ID
 					}
 				}
 			}
 
 			// Wait for the agent to come online and startup scripts to finish.
 			if workspaceAgentID != uuid.Nil {
-				agentStatus := waitForAgentReady(ctx, options.DB, workspaceAgentID, options.AgentConnFn)
+				agentStatus := waitForAgentReady(ctx, db, workspaceAgentID, options.AgentConnFn)
 				for k, v := range agentStatus {
 					result[k] = v
 				}
@@ -325,12 +319,12 @@ type existingWorkspaceResult struct {
 // (workspace is dead or missing).
 func (o CreateWorkspaceOptions) checkExistingWorkspace(
 	ctx context.Context,
+	db database.Store,
 ) existingWorkspaceResult {
-	if o.DB == nil || o.ChatID == uuid.Nil {
+	if o.ChatID == uuid.Nil {
 		return existingWorkspaceResult{}
 	}
 
-	db := o.DB
 	chatID := o.ChatID
 	agentConnFn := o.AgentConnFn
 	agentInactiveDisconnectTimeout := o.AgentInactiveDisconnectTimeout

--- a/coderd/x/chatd/chattool/createworkspace.go
+++ b/coderd/x/chatd/chattool/createworkspace.go
@@ -182,19 +182,9 @@ func CreateWorkspace(organizationID uuid.UUID, db database.Store, options Create
 				TTLMillis:  ttlMs,
 			}
 
-			// Resolve workspace name. This does a second
-			// GetTemplateByID when no name is provided; the first
-			// is the org-validation check above. Consolidating
-			// them would couple the security gate to the
-			// name-fallback path, and the cost is negligible next
-			// to the workspace build that follows.
 			name := strings.TrimSpace(args.Name)
 			if name == "" {
-				seed := "workspace"
-				if t, lookupErr := db.GetTemplateByID(ctx, templateID); lookupErr == nil {
-					seed = t.Name
-				}
-				name = generatedWorkspaceName(seed)
+				name = generatedWorkspaceName(tmpl.Name)
 			} else if err := codersdk.NameValid(name); err != nil {
 				name = generatedWorkspaceName(name)
 			}

--- a/coderd/x/chatd/chattool/createworkspace_test.go
+++ b/coderd/x/chatd/chattool/createworkspace_test.go
@@ -195,14 +195,13 @@ func TestCreateWorkspace_PrefersChatSuffixAgent(t *testing.T) {
 		return nil, func() {}, nil
 	}
 
-	tool := CreateWorkspace(CreateWorkspaceOptions{
-		DB:             db,
-		OwnerID:        ownerID,
-		OrganizationID: orgID,
-		CreateFn:       createFn,
-		AgentConnFn:    agentConnFn,
-		WorkspaceMu:    &sync.Mutex{},
-		Logger:         slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+	tool := CreateWorkspace(orgID, CreateWorkspaceOptions{
+		DB:          db,
+		OwnerID:     ownerID,
+		CreateFn:    createFn,
+		AgentConnFn: agentConnFn,
+		WorkspaceMu: &sync.Mutex{},
+		Logger:      slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
 	})
 
 	input := fmt.Sprintf(`{"template_id":%q,"name":"test-chat-agent"}`, templateID.String())
@@ -286,11 +285,10 @@ func TestCreateWorkspace_ReturnsSelectionErrorImmediately(t *testing.T) {
 			{ID: uuid.New(), Name: "beta-coderd-chat", DisplayOrder: 1},
 		}, nil)
 
-	tool := CreateWorkspace(CreateWorkspaceOptions{
-		DB:             db,
-		OwnerID:        ownerID,
-		OrganizationID: orgID,
-		ChatID:         chatID,
+	tool := CreateWorkspace(orgID, CreateWorkspaceOptions{
+		DB:      db,
+		OwnerID: ownerID,
+		ChatID:  chatID,
 		CreateFn: func(_ context.Context, _ uuid.UUID, req codersdk.CreateWorkspaceRequest) (codersdk.Workspace, error) {
 			return codersdk.Workspace{
 				ID:        workspaceID,
@@ -388,14 +386,13 @@ func TestCreateWorkspace_PostCreationBuildFailure(t *testing.T) {
 		}, nil
 	}
 
-	tool := CreateWorkspace(CreateWorkspaceOptions{
-		DB:             db,
-		OwnerID:        ownerID,
-		OrganizationID: orgID,
-		ChatID:         uuid.Nil,
-		CreateFn:       createFn,
-		WorkspaceMu:    &sync.Mutex{},
-		Logger:         slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+	tool := CreateWorkspace(orgID, CreateWorkspaceOptions{
+		DB:          db,
+		OwnerID:     ownerID,
+		ChatID:      uuid.Nil,
+		CreateFn:    createFn,
+		WorkspaceMu: &sync.Mutex{},
+		Logger:      slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
 	})
 
 	input := fmt.Sprintf(`{"template_id":%q,"name":"test-build-fail"}`, templateID.String())
@@ -510,14 +507,13 @@ func TestCreateWorkspace_GlobalTTL(t *testing.T) {
 				}, nil
 			}
 
-			tool := CreateWorkspace(CreateWorkspaceOptions{
-				DB:             db,
-				OwnerID:        ownerID,
-				OrganizationID: orgID,
-				ChatID:         uuid.Nil,
-				CreateFn:       createFn,
-				WorkspaceMu:    &sync.Mutex{},
-				Logger:         slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+			tool := CreateWorkspace(orgID, CreateWorkspaceOptions{
+				DB:          db,
+				OwnerID:     ownerID,
+				ChatID:      uuid.Nil,
+				CreateFn:    createFn,
+				WorkspaceMu: &sync.Mutex{},
+				Logger:      slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
 			})
 
 			input := fmt.Sprintf(`{"template_id":%q,"name":"test-ws-%s"}`, templateID.String(), tc.name)
@@ -582,11 +578,10 @@ func TestCreateWorkspace_RejectsCrossOrgTemplate(t *testing.T) {
 		}, nil)
 
 	createCalled := false
-	tool := CreateWorkspace(CreateWorkspaceOptions{
-		DB:             db,
-		OwnerID:        ownerID,
-		OrganizationID: chatOrgID,
-		ChatID:         chatID,
+	tool := CreateWorkspace(chatOrgID, CreateWorkspaceOptions{
+		DB:      db,
+		OwnerID: ownerID,
+		ChatID:  chatID,
 		CreateFn: func(context.Context, uuid.UUID, codersdk.CreateWorkspaceRequest) (codersdk.Workspace, error) {
 			createCalled = true
 			return codersdk.Workspace{}, nil
@@ -997,14 +992,13 @@ func TestWaitForBuild_CanceledJob(t *testing.T) {
 		}, nil
 	}
 
-	tool := CreateWorkspace(CreateWorkspaceOptions{
-		DB:             db,
-		OwnerID:        ownerID,
-		OrganizationID: orgID,
-		ChatID:         uuid.Nil,
-		CreateFn:       createFn,
-		WorkspaceMu:    &sync.Mutex{},
-		Logger:         slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+	tool := CreateWorkspace(orgID, CreateWorkspaceOptions{
+		DB:          db,
+		OwnerID:     ownerID,
+		ChatID:      uuid.Nil,
+		CreateFn:    createFn,
+		WorkspaceMu: &sync.Mutex{},
+		Logger:      slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
 	})
 
 	input := fmt.Sprintf(`{"template_id":%q,"name":"test-build-cancel"}`, templateID.String())

--- a/coderd/x/chatd/chattool/createworkspace_test.go
+++ b/coderd/x/chatd/chattool/createworkspace_test.go
@@ -144,6 +144,13 @@ func TestCreateWorkspace_PrefersChatSuffixAgent(t *testing.T) {
 		}, nil)
 
 	db.EXPECT().
+		GetTemplateByID(gomock.Any(), templateID).
+		Return(database.Template{
+			ID:             templateID,
+			OrganizationID: orgID,
+		}, nil)
+
+	db.EXPECT().
 		GetChatWorkspaceTTL(gomock.Any()).
 		Return("0s", nil)
 
@@ -239,8 +246,15 @@ func TestCreateWorkspace_ReturnsSelectionErrorImmediately(t *testing.T) {
 			Status: database.UserStatusActive,
 		}, nil)
 	db.EXPECT().
+		GetTemplateByID(gomock.Any(), templateID).
+		Return(database.Template{
+			ID:             templateID,
+			OrganizationID: orgID,
+		}, nil)
+	db.EXPECT().
 		GetChatWorkspaceTTL(gomock.Any()).
 		Return("0s", nil)
+
 	db.EXPECT().
 		GetWorkspaceBuildByID(gomock.Any(), buildID).
 		Return(database.WorkspaceBuild{
@@ -332,6 +346,13 @@ func TestCreateWorkspace_PostCreationBuildFailure(t *testing.T) {
 			Roles:  []string{},
 			Groups: []string{},
 			Status: database.UserStatusActive,
+		}, nil)
+
+	db.EXPECT().
+		GetTemplateByID(gomock.Any(), templateID).
+		Return(database.Template{
+			ID:             templateID,
+			OrganizationID: orgID,
 		}, nil)
 
 	db.EXPECT().
@@ -445,6 +466,13 @@ func TestCreateWorkspace_GlobalTTL(t *testing.T) {
 					Roles:  []string{},
 					Groups: []string{},
 					Status: database.UserStatusActive,
+				}, nil)
+
+			db.EXPECT().
+				GetTemplateByID(gomock.Any(), templateID).
+				Return(database.Template{
+					ID:             templateID,
+					OrganizationID: orgID,
 				}, nil)
 
 			db.EXPECT().
@@ -928,6 +956,13 @@ func TestWaitForBuild_CanceledJob(t *testing.T) {
 			Roles:  []string{},
 			Groups: []string{},
 			Status: database.UserStatusActive,
+		}, nil)
+
+	db.EXPECT().
+		GetTemplateByID(gomock.Any(), templateID).
+		Return(database.Template{
+			ID:             templateID,
+			OrganizationID: orgID,
 		}, nil)
 
 	db.EXPECT().

--- a/coderd/x/chatd/chattool/createworkspace_test.go
+++ b/coderd/x/chatd/chattool/createworkspace_test.go
@@ -641,7 +641,7 @@ func TestCheckExistingWorkspace_ConnectedAgent(t *testing.T) {
 		return nil, nil, xerrors.New("unexpected agent dial")
 	}
 
-	options := testCheckExistingWorkspaceOptions(db, chatID, connFn)
+	options := testCheckExistingWorkspaceOptions(chatID, connFn)
 	check := options.checkExistingWorkspace(context.Background(), db)
 
 	require.NoError(t, check.Err)
@@ -734,7 +734,7 @@ func TestCheckExistingWorkspace_InProgressBuildReturnsBuildID(t *testing.T) {
 		GetWorkspaceAgentsInLatestBuildByWorkspaceID(gomock.Any(), workspaceID).
 		Return([]database.WorkspaceAgent{}, nil)
 
-	options := testCheckExistingWorkspaceOptions(db, chatID, nil)
+	options := testCheckExistingWorkspaceOptions(chatID, nil)
 	check := options.checkExistingWorkspace(context.Background(), db)
 
 	require.NoError(t, check.Err)
@@ -817,7 +817,7 @@ func TestCheckExistingWorkspace_InProgressBuildFailureReturnsBuildID(t *testing.
 			WorkspaceID: uuid.NullUUID{UUID: workspaceID, Valid: true},
 		}, nil)
 
-	options := testCheckExistingWorkspaceOptions(db, chatID, nil)
+	options := testCheckExistingWorkspaceOptions(chatID, nil)
 	check := options.checkExistingWorkspace(context.Background(), db)
 
 	require.Error(t, check.Err)
@@ -865,7 +865,7 @@ func TestCheckExistingWorkspace_ConnectingAgentWaits(t *testing.T) {
 		return nil, func() {}, nil
 	}
 
-	options := testCheckExistingWorkspaceOptions(db, chatID, connFn)
+	options := testCheckExistingWorkspaceOptions(chatID, connFn)
 	check := options.checkExistingWorkspace(context.Background(), db)
 
 	require.NoError(t, check.Err)
@@ -926,7 +926,7 @@ func TestCheckExistingWorkspace_DeadAgentAllowsCreation(t *testing.T) {
 				GetWorkspaceAgentsInLatestBuildByWorkspaceID(gomock.Any(), workspaceID).
 				Return([]database.WorkspaceAgent{tc.agent}, nil)
 
-			options := testCheckExistingWorkspaceOptions(db, chatID, nil)
+			options := testCheckExistingWorkspaceOptions(chatID, nil)
 			check := options.checkExistingWorkspace(context.Background(), db)
 
 			require.NoError(t, check.Err)
@@ -1041,7 +1041,7 @@ func TestCheckExistingWorkspace_StoppedWorkspace(t *testing.T) {
 		database.WorkspaceTransitionStop,
 	)
 
-	options := testCheckExistingWorkspaceOptions(db, chatID, nil)
+	options := testCheckExistingWorkspaceOptions(chatID, nil)
 	check := options.checkExistingWorkspace(context.Background(), db)
 
 	require.True(t, check.Done)
@@ -1074,7 +1074,7 @@ func TestCheckExistingWorkspace_DeletedWorkspace(t *testing.T) {
 			Deleted: true,
 		}, nil)
 
-	options := testCheckExistingWorkspaceOptions(db, chatID, nil)
+	options := testCheckExistingWorkspaceOptions(chatID, nil)
 	check := options.checkExistingWorkspace(context.Background(), db)
 
 	require.NoError(t, check.Err)
@@ -1083,7 +1083,6 @@ func TestCheckExistingWorkspace_DeletedWorkspace(t *testing.T) {
 }
 
 func testCheckExistingWorkspaceOptions(
-	db *dbmock.MockStore,
 	chatID uuid.UUID,
 	agentConnFn AgentConnFunc,
 ) CreateWorkspaceOptions {

--- a/coderd/x/chatd/chattool/createworkspace_test.go
+++ b/coderd/x/chatd/chattool/createworkspace_test.go
@@ -195,9 +195,9 @@ func TestCreateWorkspace_PrefersChatSuffixAgent(t *testing.T) {
 		return nil, func() {}, nil
 	}
 
-	tool := CreateWorkspace(orgID, CreateWorkspaceOptions{
-		DB:          db,
-		OwnerID:     ownerID,
+	tool := CreateWorkspace(orgID, db, CreateWorkspaceOptions{
+		OwnerID: ownerID,
+
 		CreateFn:    createFn,
 		AgentConnFn: agentConnFn,
 		WorkspaceMu: &sync.Mutex{},
@@ -285,10 +285,10 @@ func TestCreateWorkspace_ReturnsSelectionErrorImmediately(t *testing.T) {
 			{ID: uuid.New(), Name: "beta-coderd-chat", DisplayOrder: 1},
 		}, nil)
 
-	tool := CreateWorkspace(orgID, CreateWorkspaceOptions{
-		DB:      db,
+	tool := CreateWorkspace(orgID, db, CreateWorkspaceOptions{
 		OwnerID: ownerID,
-		ChatID:  chatID,
+
+		ChatID: chatID,
 		CreateFn: func(_ context.Context, _ uuid.UUID, req codersdk.CreateWorkspaceRequest) (codersdk.Workspace, error) {
 			return codersdk.Workspace{
 				ID:        workspaceID,
@@ -386,9 +386,9 @@ func TestCreateWorkspace_PostCreationBuildFailure(t *testing.T) {
 		}, nil
 	}
 
-	tool := CreateWorkspace(orgID, CreateWorkspaceOptions{
-		DB:          db,
-		OwnerID:     ownerID,
+	tool := CreateWorkspace(orgID, db, CreateWorkspaceOptions{
+		OwnerID: ownerID,
+
 		ChatID:      uuid.Nil,
 		CreateFn:    createFn,
 		WorkspaceMu: &sync.Mutex{},
@@ -507,9 +507,9 @@ func TestCreateWorkspace_GlobalTTL(t *testing.T) {
 				}, nil
 			}
 
-			tool := CreateWorkspace(orgID, CreateWorkspaceOptions{
-				DB:          db,
-				OwnerID:     ownerID,
+			tool := CreateWorkspace(orgID, db, CreateWorkspaceOptions{
+				OwnerID: ownerID,
+
 				ChatID:      uuid.Nil,
 				CreateFn:    createFn,
 				WorkspaceMu: &sync.Mutex{},
@@ -578,10 +578,10 @@ func TestCreateWorkspace_RejectsCrossOrgTemplate(t *testing.T) {
 		}, nil)
 
 	createCalled := false
-	tool := CreateWorkspace(chatOrgID, CreateWorkspaceOptions{
-		DB:      db,
+	tool := CreateWorkspace(chatOrgID, db, CreateWorkspaceOptions{
 		OwnerID: ownerID,
-		ChatID:  chatID,
+
+		ChatID: chatID,
 		CreateFn: func(context.Context, uuid.UUID, codersdk.CreateWorkspaceRequest) (codersdk.Workspace, error) {
 			createCalled = true
 			return codersdk.Workspace{}, nil
@@ -642,7 +642,8 @@ func TestCheckExistingWorkspace_ConnectedAgent(t *testing.T) {
 	}
 
 	options := testCheckExistingWorkspaceOptions(db, chatID, connFn)
-	check := options.checkExistingWorkspace(context.Background())
+	check := options.checkExistingWorkspace(context.Background(), db)
+
 	require.NoError(t, check.Err)
 	require.True(t, check.Done)
 	require.Equal(t, "already_exists", check.Result["status"])
@@ -734,7 +735,8 @@ func TestCheckExistingWorkspace_InProgressBuildReturnsBuildID(t *testing.T) {
 		Return([]database.WorkspaceAgent{}, nil)
 
 	options := testCheckExistingWorkspaceOptions(db, chatID, nil)
-	check := options.checkExistingWorkspace(context.Background())
+	check := options.checkExistingWorkspace(context.Background(), db)
+
 	require.NoError(t, check.Err)
 	require.True(t, check.Done)
 	require.Equal(t, false, check.Result["created"])
@@ -816,7 +818,8 @@ func TestCheckExistingWorkspace_InProgressBuildFailureReturnsBuildID(t *testing.
 		}, nil)
 
 	options := testCheckExistingWorkspaceOptions(db, chatID, nil)
-	check := options.checkExistingWorkspace(context.Background())
+	check := options.checkExistingWorkspace(context.Background(), db)
+
 	require.Error(t, check.Err)
 	require.Contains(t, check.Err.Error(), "existing workspace build failed")
 	require.Equal(t, buildID, check.FailedBuildID)
@@ -863,7 +866,8 @@ func TestCheckExistingWorkspace_ConnectingAgentWaits(t *testing.T) {
 	}
 
 	options := testCheckExistingWorkspaceOptions(db, chatID, connFn)
-	check := options.checkExistingWorkspace(context.Background())
+	check := options.checkExistingWorkspace(context.Background(), db)
+
 	require.NoError(t, check.Err)
 	require.True(t, check.Done)
 	require.Equal(t, 1, connectCalls)
@@ -923,7 +927,8 @@ func TestCheckExistingWorkspace_DeadAgentAllowsCreation(t *testing.T) {
 				Return([]database.WorkspaceAgent{tc.agent}, nil)
 
 			options := testCheckExistingWorkspaceOptions(db, chatID, nil)
-			check := options.checkExistingWorkspace(context.Background())
+			check := options.checkExistingWorkspace(context.Background(), db)
+
 			require.NoError(t, check.Err)
 			require.False(t, check.Done)
 			require.Nil(t, check.Result)
@@ -992,9 +997,9 @@ func TestWaitForBuild_CanceledJob(t *testing.T) {
 		}, nil
 	}
 
-	tool := CreateWorkspace(orgID, CreateWorkspaceOptions{
-		DB:          db,
-		OwnerID:     ownerID,
+	tool := CreateWorkspace(orgID, db, CreateWorkspaceOptions{
+		OwnerID: ownerID,
+
 		ChatID:      uuid.Nil,
 		CreateFn:    createFn,
 		WorkspaceMu: &sync.Mutex{},
@@ -1037,7 +1042,8 @@ func TestCheckExistingWorkspace_StoppedWorkspace(t *testing.T) {
 	)
 
 	options := testCheckExistingWorkspaceOptions(db, chatID, nil)
-	check := options.checkExistingWorkspace(context.Background())
+	check := options.checkExistingWorkspace(context.Background(), db)
+
 	require.True(t, check.Done)
 	require.NoError(t, check.Err)
 	require.Equal(t, "stopped", check.Result["status"])
@@ -1069,7 +1075,8 @@ func TestCheckExistingWorkspace_DeletedWorkspace(t *testing.T) {
 		}, nil)
 
 	options := testCheckExistingWorkspaceOptions(db, chatID, nil)
-	check := options.checkExistingWorkspace(context.Background())
+	check := options.checkExistingWorkspace(context.Background(), db)
+
 	require.NoError(t, check.Err)
 	require.False(t, check.Done, "should allow creation for deleted workspace")
 	require.Nil(t, check.Result)
@@ -1081,7 +1088,6 @@ func testCheckExistingWorkspaceOptions(
 	agentConnFn AgentConnFunc,
 ) CreateWorkspaceOptions {
 	return CreateWorkspaceOptions{
-		DB:                             db,
 		ChatID:                         chatID,
 		AgentConnFn:                    agentConnFn,
 		AgentInactiveDisconnectTimeout: 30 * time.Second,

--- a/coderd/x/chatd/chattool/createworkspace_test.go
+++ b/coderd/x/chatd/chattool/createworkspace_test.go
@@ -126,6 +126,7 @@ func TestCreateWorkspace_PrefersChatSuffixAgent(t *testing.T) {
 	db := dbmock.NewMockStore(ctrl)
 
 	ownerID := uuid.New()
+	orgID := uuid.New()
 	templateID := uuid.New()
 	workspaceID := uuid.New()
 	jobID := uuid.New()
@@ -188,12 +189,13 @@ func TestCreateWorkspace_PrefersChatSuffixAgent(t *testing.T) {
 	}
 
 	tool := CreateWorkspace(CreateWorkspaceOptions{
-		DB:          db,
-		OwnerID:     ownerID,
-		CreateFn:    createFn,
-		AgentConnFn: agentConnFn,
-		WorkspaceMu: &sync.Mutex{},
-		Logger:      slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+		DB:             db,
+		OwnerID:        ownerID,
+		OrganizationID: orgID,
+		CreateFn:       createFn,
+		AgentConnFn:    agentConnFn,
+		WorkspaceMu:    &sync.Mutex{},
+		Logger:         slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
 	})
 
 	input := fmt.Sprintf(`{"template_id":%q,"name":"test-chat-agent"}`, templateID.String())
@@ -218,6 +220,7 @@ func TestCreateWorkspace_ReturnsSelectionErrorImmediately(t *testing.T) {
 	db := dbmock.NewMockStore(ctrl)
 
 	ownerID := uuid.New()
+	orgID := uuid.New()
 	chatID := uuid.New()
 	templateID := uuid.New()
 	workspaceID := uuid.New()
@@ -270,9 +273,10 @@ func TestCreateWorkspace_ReturnsSelectionErrorImmediately(t *testing.T) {
 		}, nil)
 
 	tool := CreateWorkspace(CreateWorkspaceOptions{
-		DB:      db,
-		OwnerID: ownerID,
-		ChatID:  chatID,
+		DB:             db,
+		OwnerID:        ownerID,
+		OrganizationID: orgID,
+		ChatID:         chatID,
 		CreateFn: func(_ context.Context, _ uuid.UUID, req codersdk.CreateWorkspaceRequest) (codersdk.Workspace, error) {
 			return codersdk.Workspace{
 				ID:        workspaceID,
@@ -315,6 +319,7 @@ func TestCreateWorkspace_PostCreationBuildFailure(t *testing.T) {
 	db := dbmock.NewMockStore(ctrl)
 
 	ownerID := uuid.New()
+	orgID := uuid.New()
 	templateID := uuid.New()
 	workspaceID := uuid.New()
 	jobID := uuid.New()
@@ -363,12 +368,13 @@ func TestCreateWorkspace_PostCreationBuildFailure(t *testing.T) {
 	}
 
 	tool := CreateWorkspace(CreateWorkspaceOptions{
-		DB:          db,
-		OwnerID:     ownerID,
-		ChatID:      uuid.Nil,
-		CreateFn:    createFn,
-		WorkspaceMu: &sync.Mutex{},
-		Logger:      slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+		DB:             db,
+		OwnerID:        ownerID,
+		OrganizationID: orgID,
+		ChatID:         uuid.Nil,
+		CreateFn:       createFn,
+		WorkspaceMu:    &sync.Mutex{},
+		Logger:         slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
 	})
 
 	input := fmt.Sprintf(`{"template_id":%q,"name":"test-build-fail"}`, templateID.String())
@@ -426,6 +432,7 @@ func TestCreateWorkspace_GlobalTTL(t *testing.T) {
 			db := dbmock.NewMockStore(ctrl)
 
 			ownerID := uuid.New()
+			orgID := uuid.New()
 			templateID := uuid.New()
 			workspaceID := uuid.New()
 			jobID := uuid.New()
@@ -476,12 +483,13 @@ func TestCreateWorkspace_GlobalTTL(t *testing.T) {
 			}
 
 			tool := CreateWorkspace(CreateWorkspaceOptions{
-				DB:          db,
-				OwnerID:     ownerID,
-				ChatID:      uuid.Nil,
-				CreateFn:    createFn,
-				WorkspaceMu: &sync.Mutex{},
-				Logger:      slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+				DB:             db,
+				OwnerID:        ownerID,
+				OrganizationID: orgID,
+				ChatID:         uuid.Nil,
+				CreateFn:       createFn,
+				WorkspaceMu:    &sync.Mutex{},
+				Logger:         slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
 			})
 
 			input := fmt.Sprintf(`{"template_id":%q,"name":"test-ws-%s"}`, templateID.String(), tc.name)
@@ -907,6 +915,7 @@ func TestWaitForBuild_CanceledJob(t *testing.T) {
 	db := dbmock.NewMockStore(ctrl)
 
 	ownerID := uuid.New()
+	orgID := uuid.New()
 	templateID := uuid.New()
 	workspaceID := uuid.New()
 	jobID := uuid.New()
@@ -954,12 +963,13 @@ func TestWaitForBuild_CanceledJob(t *testing.T) {
 	}
 
 	tool := CreateWorkspace(CreateWorkspaceOptions{
-		DB:          db,
-		OwnerID:     ownerID,
-		ChatID:      uuid.Nil,
-		CreateFn:    createFn,
-		WorkspaceMu: &sync.Mutex{},
-		Logger:      slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+		DB:             db,
+		OwnerID:        ownerID,
+		OrganizationID: orgID,
+		ChatID:         uuid.Nil,
+		CreateFn:       createFn,
+		WorkspaceMu:    &sync.Mutex{},
+		Logger:         slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
 	})
 
 	input := fmt.Sprintf(`{"template_id":%q,"name":"test-build-cancel"}`, templateID.String())

--- a/coderd/x/chatd/chattool/listtemplates.go
+++ b/coderd/x/chatd/chattool/listtemplates.go
@@ -1,11 +1,11 @@
 package chattool
 
 import (
+	"cmp"
 	"context"
 	"database/sql"
 	"maps"
 	"slices"
-	"sort"
 	"strings"
 
 	"charm.land/fantasy"
@@ -95,10 +95,9 @@ func ListTemplates(organizationID uuid.UUID, db database.Store, options ListTemp
 			}
 
 			// Sort by active developer count descending.
-			sort.SliceStable(templates, func(i, j int) bool {
-				return ownerCounts[templates[i].ID] > ownerCounts[templates[j].ID]
+			slices.SortStableFunc(templates, func(a, b database.Template) int {
+				return cmp.Compare(ownerCounts[b.ID], ownerCounts[a.ID])
 			})
-
 			// Paginate.
 			page := args.Page
 			if page < 1 {

--- a/coderd/x/chatd/chattool/listtemplates.go
+++ b/coderd/x/chatd/chattool/listtemplates.go
@@ -22,7 +22,6 @@ const listTemplatesPageSize = 10
 
 // ListTemplatesOptions configures the list_templates tool.
 type ListTemplatesOptions struct {
-	DB                 database.Store
 	OwnerID            uuid.UUID
 	AllowedTemplateIDs func() map[uuid.UUID]bool
 }
@@ -36,7 +35,7 @@ type listTemplatesArgs struct {
 // The agent uses this to discover templates before creating a workspace.
 // Results are ordered by number of active developers (most popular first)
 // and paginated at 10 per page.
-func ListTemplates(organizationID uuid.UUID, options ListTemplatesOptions) fantasy.AgentTool {
+func ListTemplates(organizationID uuid.UUID, db database.Store, options ListTemplatesOptions) fantasy.AgentTool {
 	return fantasy.NewAgentTool(
 		"list_templates",
 		"List available workspace templates. Optionally filter by a "+
@@ -45,11 +44,11 @@ func ListTemplates(organizationID uuid.UUID, options ListTemplatesOptions) fanta
 			"Results are ordered by number of active developers (most popular first). "+
 			"Returns 10 per page. Use the page parameter to paginate through results.",
 		func(ctx context.Context, args listTemplatesArgs, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
-			if options.DB == nil {
+			if db == nil {
 				return fantasy.NewTextErrorResponse("database is not configured"), nil
 			}
 
-			ctx, err := asOwner(ctx, options.DB, options.OwnerID)
+			ctx, err := asOwner(ctx, db, options.OwnerID)
 			if err != nil {
 				return fantasy.NewTextErrorResponse(err.Error()), nil
 			}
@@ -74,7 +73,7 @@ func ListTemplates(organizationID uuid.UUID, options ListTemplatesOptions) fanta
 			if len(allowlist) > 0 {
 				filterParams.IDs = slices.Collect(maps.Keys(allowlist))
 			}
-			templates, err := options.DB.GetTemplatesWithFilter(ctx, filterParams)
+			templates, err := db.GetTemplatesWithFilter(ctx, filterParams)
 			if err != nil {
 				return fantasy.NewTextErrorResponse(err.Error()), nil
 			}
@@ -86,7 +85,8 @@ func ListTemplates(organizationID uuid.UUID, options ListTemplatesOptions) fanta
 			}
 			ownerCounts := make(map[uuid.UUID]int64)
 			if len(templateIDs) > 0 {
-				rows, countErr := options.DB.GetWorkspaceUniqueOwnerCountByTemplateIDs(ctx, templateIDs)
+				rows, countErr := db.GetWorkspaceUniqueOwnerCountByTemplateIDs(ctx, templateIDs)
+
 				if countErr == nil {
 					for _, row := range rows {
 						ownerCounts[row.TemplateID] = row.UniqueOwnersSum

--- a/coderd/x/chatd/chattool/listtemplates.go
+++ b/coderd/x/chatd/chattool/listtemplates.go
@@ -24,7 +24,6 @@ const listTemplatesPageSize = 10
 type ListTemplatesOptions struct {
 	DB                 database.Store
 	OwnerID            uuid.UUID
-	OrganizationID     uuid.UUID
 	AllowedTemplateIDs func() map[uuid.UUID]bool
 }
 
@@ -37,7 +36,7 @@ type listTemplatesArgs struct {
 // The agent uses this to discover templates before creating a workspace.
 // Results are ordered by number of active developers (most popular first)
 // and paginated at 10 per page.
-func ListTemplates(options ListTemplatesOptions) fantasy.AgentTool {
+func ListTemplates(organizationID uuid.UUID, options ListTemplatesOptions) fantasy.AgentTool {
 	return fantasy.NewAgentTool(
 		"list_templates",
 		"List available workspace templates. Optionally filter by a "+
@@ -57,7 +56,7 @@ func ListTemplates(options ListTemplatesOptions) fantasy.AgentTool {
 
 			filterParams := database.GetTemplatesWithFilterParams{
 				Deleted:        false,
-				OrganizationID: options.OrganizationID,
+				OrganizationID: organizationID,
 				Deprecated: sql.NullBool{
 					Bool:  false,
 					Valid: true,

--- a/coderd/x/chatd/chattool/listtemplates_test.go
+++ b/coderd/x/chatd/chattool/listtemplates_test.go
@@ -71,7 +71,7 @@ func TestListTemplates_OrganizationFilter(t *testing.T) {
 
 		tool := chattool.ListTemplates(uuid.Nil, db, chattool.ListTemplatesOptions{
 			OwnerID: user.ID,
-			// OrganizationID left as uuid.Nil
+			// Pass uuid.Nil to skip org filtering.
 		})
 
 		resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "nil-org", Name: "list_templates", Input: "{}"})

--- a/coderd/x/chatd/chattool/listtemplates_test.go
+++ b/coderd/x/chatd/chattool/listtemplates_test.go
@@ -49,10 +49,9 @@ func TestListTemplates_OrganizationFilter(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitShort)
 
-		tool := chattool.ListTemplates(chattool.ListTemplatesOptions{
-			DB:             db,
-			OwnerID:        user.ID,
-			OrganizationID: orgA.ID,
+		tool := chattool.ListTemplates(orgA.ID, chattool.ListTemplatesOptions{
+			DB:      db,
+			OwnerID: user.ID,
 		})
 		resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "org-a", Name: "list_templates", Input: "{}"})
 		require.NoError(t, err)
@@ -70,7 +69,7 @@ func TestListTemplates_OrganizationFilter(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitShort)
 
-		tool := chattool.ListTemplates(chattool.ListTemplatesOptions{
+		tool := chattool.ListTemplates(uuid.Nil, chattool.ListTemplatesOptions{
 			DB:      db,
 			OwnerID: user.ID,
 			// OrganizationID left as uuid.Nil
@@ -112,7 +111,7 @@ func TestTemplateAllowlistEnforcement(t *testing.T) {
 
 	t.Run("ListTemplates", func(t *testing.T) {
 		t.Run("NoAllowlist", func(t *testing.T) {
-			tool := chattool.ListTemplates(chattool.ListTemplatesOptions{
+			tool := chattool.ListTemplates(uuid.Nil, chattool.ListTemplatesOptions{
 				DB:      db,
 				OwnerID: user.ID,
 			})
@@ -125,7 +124,7 @@ func TestTemplateAllowlistEnforcement(t *testing.T) {
 		})
 
 		t.Run("EmptyAllowlist", func(t *testing.T) {
-			tool := chattool.ListTemplates(chattool.ListTemplatesOptions{
+			tool := chattool.ListTemplates(uuid.Nil, chattool.ListTemplatesOptions{
 				DB:                 db,
 				OwnerID:            user.ID,
 				AllowedTemplateIDs: func() map[uuid.UUID]bool { return map[uuid.UUID]bool{} },
@@ -139,7 +138,7 @@ func TestTemplateAllowlistEnforcement(t *testing.T) {
 		})
 
 		t.Run("OneMatch", func(t *testing.T) {
-			tool := chattool.ListTemplates(chattool.ListTemplatesOptions{
+			tool := chattool.ListTemplates(uuid.Nil, chattool.ListTemplatesOptions{
 				DB:                 db,
 				OwnerID:            user.ID,
 				AllowedTemplateIDs: func() map[uuid.UUID]bool { return map[uuid.UUID]bool{t1.ID: true} },
@@ -155,7 +154,7 @@ func TestTemplateAllowlistEnforcement(t *testing.T) {
 		})
 
 		t.Run("NoMatches", func(t *testing.T) {
-			tool := chattool.ListTemplates(chattool.ListTemplatesOptions{
+			tool := chattool.ListTemplates(uuid.Nil, chattool.ListTemplatesOptions{
 				DB:                 db,
 				OwnerID:            user.ID,
 				AllowedTemplateIDs: func() map[uuid.UUID]bool { return map[uuid.UUID]bool{uuid.New(): true} },
@@ -214,10 +213,9 @@ func TestTemplateAllowlistEnforcement(t *testing.T) {
 	t.Run("CreateWorkspace", func(t *testing.T) {
 		t.Run("Allowed", func(t *testing.T) {
 			createCalled := false
-			tool := chattool.CreateWorkspace(chattool.CreateWorkspaceOptions{
+			tool := chattool.CreateWorkspace(org.ID, chattool.CreateWorkspaceOptions{
 				DB:                 db,
 				OwnerID:            user.ID,
-				OrganizationID:     org.ID,
 				AllowedTemplateIDs: func() map[uuid.UUID]bool { return map[uuid.UUID]bool{t1.ID: true} },
 
 				CreateFn: func(_ context.Context, _ uuid.UUID, _ codersdk.CreateWorkspaceRequest) (codersdk.Workspace, error) {
@@ -238,7 +236,7 @@ func TestTemplateAllowlistEnforcement(t *testing.T) {
 
 		t.Run("Disallowed", func(t *testing.T) {
 			createCalled := false
-			tool := chattool.CreateWorkspace(chattool.CreateWorkspaceOptions{
+			tool := chattool.CreateWorkspace(uuid.Nil, chattool.CreateWorkspaceOptions{
 				DB:                 db,
 				OwnerID:            user.ID,
 				AllowedTemplateIDs: func() map[uuid.UUID]bool { return map[uuid.UUID]bool{uuid.New(): true} },

--- a/coderd/x/chatd/chattool/listtemplates_test.go
+++ b/coderd/x/chatd/chattool/listtemplates_test.go
@@ -49,10 +49,10 @@ func TestListTemplates_OrganizationFilter(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitShort)
 
-		tool := chattool.ListTemplates(orgA.ID, chattool.ListTemplatesOptions{
-			DB:      db,
+		tool := chattool.ListTemplates(orgA.ID, db, chattool.ListTemplatesOptions{
 			OwnerID: user.ID,
 		})
+
 		resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "org-a", Name: "list_templates", Input: "{}"})
 		require.NoError(t, err)
 		require.False(t, resp.IsError)
@@ -69,11 +69,11 @@ func TestListTemplates_OrganizationFilter(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitShort)
 
-		tool := chattool.ListTemplates(uuid.Nil, chattool.ListTemplatesOptions{
-			DB:      db,
+		tool := chattool.ListTemplates(uuid.Nil, db, chattool.ListTemplatesOptions{
 			OwnerID: user.ID,
 			// OrganizationID left as uuid.Nil
 		})
+
 		resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "nil-org", Name: "list_templates", Input: "{}"})
 		require.NoError(t, err)
 		require.False(t, resp.IsError)
@@ -111,10 +111,10 @@ func TestTemplateAllowlistEnforcement(t *testing.T) {
 
 	t.Run("ListTemplates", func(t *testing.T) {
 		t.Run("NoAllowlist", func(t *testing.T) {
-			tool := chattool.ListTemplates(uuid.Nil, chattool.ListTemplatesOptions{
-				DB:      db,
+			tool := chattool.ListTemplates(uuid.Nil, db, chattool.ListTemplatesOptions{
 				OwnerID: user.ID,
 			})
+
 			resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "c1", Name: "list_templates", Input: "{}"})
 			require.NoError(t, err)
 			var result map[string]any
@@ -124,11 +124,11 @@ func TestTemplateAllowlistEnforcement(t *testing.T) {
 		})
 
 		t.Run("EmptyAllowlist", func(t *testing.T) {
-			tool := chattool.ListTemplates(uuid.Nil, chattool.ListTemplatesOptions{
-				DB:                 db,
+			tool := chattool.ListTemplates(uuid.Nil, db, chattool.ListTemplatesOptions{
 				OwnerID:            user.ID,
 				AllowedTemplateIDs: func() map[uuid.UUID]bool { return map[uuid.UUID]bool{} },
 			})
+
 			resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "c2", Name: "list_templates", Input: "{}"})
 			require.NoError(t, err)
 			var result map[string]any
@@ -138,11 +138,11 @@ func TestTemplateAllowlistEnforcement(t *testing.T) {
 		})
 
 		t.Run("OneMatch", func(t *testing.T) {
-			tool := chattool.ListTemplates(uuid.Nil, chattool.ListTemplatesOptions{
-				DB:                 db,
+			tool := chattool.ListTemplates(uuid.Nil, db, chattool.ListTemplatesOptions{
 				OwnerID:            user.ID,
 				AllowedTemplateIDs: func() map[uuid.UUID]bool { return map[uuid.UUID]bool{t1.ID: true} },
 			})
+
 			resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "c3", Name: "list_templates", Input: "{}"})
 			require.NoError(t, err)
 			var result map[string]any
@@ -154,11 +154,11 @@ func TestTemplateAllowlistEnforcement(t *testing.T) {
 		})
 
 		t.Run("NoMatches", func(t *testing.T) {
-			tool := chattool.ListTemplates(uuid.Nil, chattool.ListTemplatesOptions{
-				DB:                 db,
+			tool := chattool.ListTemplates(uuid.Nil, db, chattool.ListTemplatesOptions{
 				OwnerID:            user.ID,
 				AllowedTemplateIDs: func() map[uuid.UUID]bool { return map[uuid.UUID]bool{uuid.New(): true} },
 			})
+
 			resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "c4", Name: "list_templates", Input: "{}"})
 			require.NoError(t, err)
 			var result map[string]any
@@ -213,8 +213,7 @@ func TestTemplateAllowlistEnforcement(t *testing.T) {
 	t.Run("CreateWorkspace", func(t *testing.T) {
 		t.Run("Allowed", func(t *testing.T) {
 			createCalled := false
-			tool := chattool.CreateWorkspace(org.ID, chattool.CreateWorkspaceOptions{
-				DB:                 db,
+			tool := chattool.CreateWorkspace(org.ID, db, chattool.CreateWorkspaceOptions{
 				OwnerID:            user.ID,
 				AllowedTemplateIDs: func() map[uuid.UUID]bool { return map[uuid.UUID]bool{t1.ID: true} },
 
@@ -223,6 +222,7 @@ func TestTemplateAllowlistEnforcement(t *testing.T) {
 					return codersdk.Workspace{}, nil
 				},
 			})
+
 			input := `{"template_id":"` + t1.ID.String() + `"}`
 			resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "c8a", Name: "create_workspace", Input: input})
 			require.NoError(t, err)
@@ -236,8 +236,7 @@ func TestTemplateAllowlistEnforcement(t *testing.T) {
 
 		t.Run("Disallowed", func(t *testing.T) {
 			createCalled := false
-			tool := chattool.CreateWorkspace(uuid.Nil, chattool.CreateWorkspaceOptions{
-				DB:                 db,
+			tool := chattool.CreateWorkspace(uuid.Nil, db, chattool.CreateWorkspaceOptions{
 				OwnerID:            user.ID,
 				AllowedTemplateIDs: func() map[uuid.UUID]bool { return map[uuid.UUID]bool{uuid.New(): true} },
 				CreateFn: func(_ context.Context, _ uuid.UUID, _ codersdk.CreateWorkspaceRequest) (codersdk.Workspace, error) {
@@ -246,6 +245,7 @@ func TestTemplateAllowlistEnforcement(t *testing.T) {
 					return codersdk.Workspace{}, nil
 				},
 			})
+
 			input := `{"template_id":"` + t1.ID.String() + `"}`
 			resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "c8", Name: "create_workspace", Input: input})
 			require.NoError(t, err)

--- a/coderd/x/chatd/chattool/listtemplates_test.go
+++ b/coderd/x/chatd/chattool/listtemplates_test.go
@@ -17,6 +17,75 @@ import (
 	"github.com/coder/coder/v2/testutil"
 )
 
+func TestListTemplates_OrganizationFilter(t *testing.T) {
+	t.Parallel()
+
+	db, _ := dbtestutil.NewDB(t)
+	user := dbgen.User(t, db, database.User{})
+
+	orgA := dbgen.Organization(t, db, database.Organization{})
+	_ = dbgen.OrganizationMember(t, db, database.OrganizationMember{
+		UserID:         user.ID,
+		OrganizationID: orgA.ID,
+	})
+	orgB := dbgen.Organization(t, db, database.Organization{})
+	_ = dbgen.OrganizationMember(t, db, database.OrganizationMember{
+		UserID:         user.ID,
+		OrganizationID: orgB.ID,
+	})
+
+	tAlpha := dbgen.Template(t, db, database.Template{
+		OrganizationID: orgA.ID,
+		CreatedBy:      user.ID,
+		Name:           "alpha",
+	})
+	dbgen.Template(t, db, database.Template{
+		OrganizationID: orgB.ID,
+		CreatedBy:      user.ID,
+		Name:           "beta",
+	})
+
+	t.Run("ScopedToOrgA", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitShort)
+
+		tool := chattool.ListTemplates(chattool.ListTemplatesOptions{
+			DB:             db,
+			OwnerID:        user.ID,
+			OrganizationID: orgA.ID,
+		})
+		resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "org-a", Name: "list_templates", Input: "{}"})
+		require.NoError(t, err)
+		require.False(t, resp.IsError)
+
+		var result map[string]any
+		require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
+		templates := result["templates"].([]any)
+		require.Len(t, templates, 1)
+		m := templates[0].(map[string]any)
+		require.Equal(t, tAlpha.ID.String(), m["id"].(string))
+	})
+
+	t.Run("NilOrgReturnsBoth", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitShort)
+
+		tool := chattool.ListTemplates(chattool.ListTemplatesOptions{
+			DB:      db,
+			OwnerID: user.ID,
+			// OrganizationID left as uuid.Nil
+		})
+		resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "nil-org", Name: "list_templates", Input: "{}"})
+		require.NoError(t, err)
+		require.False(t, resp.IsError)
+
+		var result map[string]any
+		require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
+		templates := result["templates"].([]any)
+		require.Len(t, templates, 2)
+	})
+}
+
 //nolint:tparallel,paralleltest // Subtests share a single DB and run sequentially.
 func TestTemplateAllowlistEnforcement(t *testing.T) {
 	t.Parallel()

--- a/coderd/x/chatd/chattool/listtemplates_test.go
+++ b/coderd/x/chatd/chattool/listtemplates_test.go
@@ -217,7 +217,9 @@ func TestTemplateAllowlistEnforcement(t *testing.T) {
 			tool := chattool.CreateWorkspace(chattool.CreateWorkspaceOptions{
 				DB:                 db,
 				OwnerID:            user.ID,
+				OrganizationID:     org.ID,
 				AllowedTemplateIDs: func() map[uuid.UUID]bool { return map[uuid.UUID]bool{t1.ID: true} },
+
 				CreateFn: func(_ context.Context, _ uuid.UUID, _ codersdk.CreateWorkspaceRequest) (codersdk.Workspace, error) {
 					createCalled = true
 					return codersdk.Workspace{}, nil

--- a/coderd/x/chatd/chattool/listtemplates_test.go
+++ b/coderd/x/chatd/chattool/listtemplates_test.go
@@ -39,7 +39,7 @@ func TestListTemplates_OrganizationFilter(t *testing.T) {
 		CreatedBy:      user.ID,
 		Name:           "alpha",
 	})
-	dbgen.Template(t, db, database.Template{
+	tBeta := dbgen.Template(t, db, database.Template{
 		OrganizationID: orgB.ID,
 		CreatedBy:      user.ID,
 		Name:           "beta",
@@ -82,6 +82,42 @@ func TestListTemplates_OrganizationFilter(t *testing.T) {
 		require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
 		templates := result["templates"].([]any)
 		require.Len(t, templates, 2)
+	})
+
+	t.Run("ReadTemplate_CrossOrgRejected", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitShort)
+
+		// Tool scoped to orgA, but requesting a template in orgB.
+		tool := chattool.ReadTemplate(orgA.ID, db, chattool.ReadTemplateOptions{
+			OwnerID: user.ID,
+		})
+
+		input := `{"template_id":"` + tBeta.ID.String() + `"}`
+		resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "cross-org", Name: "read_template", Input: input})
+		require.NoError(t, err)
+		require.True(t, resp.IsError)
+		require.Contains(t, resp.Content, "not found")
+	})
+
+	t.Run("ReadTemplate_SameOrgAllowed", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitShort)
+
+		// Tool scoped to orgA, requesting a template in orgA.
+		tool := chattool.ReadTemplate(orgA.ID, db, chattool.ReadTemplateOptions{
+			OwnerID: user.ID,
+		})
+
+		input := `{"template_id":"` + tAlpha.ID.String() + `"}`
+		resp, err := tool.Run(ctx, fantasy.ToolCall{ID: "same-org", Name: "read_template", Input: input})
+		require.NoError(t, err)
+		require.False(t, resp.IsError)
+
+		var result map[string]any
+		require.NoError(t, json.Unmarshal([]byte(resp.Content), &result))
+		tmplInfo := result["template"].(map[string]any)
+		require.Equal(t, tAlpha.ID.String(), tmplInfo["id"].(string))
 	})
 }
 
@@ -170,8 +206,7 @@ func TestTemplateAllowlistEnforcement(t *testing.T) {
 
 	t.Run("ReadTemplate", func(t *testing.T) {
 		t.Run("Allowed", func(t *testing.T) {
-			tool := chattool.ReadTemplate(chattool.ReadTemplateOptions{
-				DB:                 db,
+			tool := chattool.ReadTemplate(org.ID, db, chattool.ReadTemplateOptions{
 				OwnerID:            user.ID,
 				AllowedTemplateIDs: func() map[uuid.UUID]bool { return map[uuid.UUID]bool{t1.ID: true} },
 			})
@@ -186,8 +221,7 @@ func TestTemplateAllowlistEnforcement(t *testing.T) {
 		})
 
 		t.Run("Disallowed", func(t *testing.T) {
-			tool := chattool.ReadTemplate(chattool.ReadTemplateOptions{
-				DB:                 db,
+			tool := chattool.ReadTemplate(org.ID, db, chattool.ReadTemplateOptions{
 				OwnerID:            user.ID,
 				AllowedTemplateIDs: func() map[uuid.UUID]bool { return map[uuid.UUID]bool{uuid.New(): true} },
 			})
@@ -199,8 +233,7 @@ func TestTemplateAllowlistEnforcement(t *testing.T) {
 		})
 
 		t.Run("NoAllowlist", func(t *testing.T) {
-			tool := chattool.ReadTemplate(chattool.ReadTemplateOptions{
-				DB:      db,
+			tool := chattool.ReadTemplate(org.ID, db, chattool.ReadTemplateOptions{
 				OwnerID: user.ID,
 			})
 			input := `{"template_id":"` + t2.ID.String() + `"}`

--- a/coderd/x/chatd/chattool/readtemplate.go
+++ b/coderd/x/chatd/chattool/readtemplate.go
@@ -14,7 +14,6 @@ import (
 
 // ReadTemplateOptions configures the read_template tool.
 type ReadTemplateOptions struct {
-	DB                 database.Store
 	OwnerID            uuid.UUID
 	AllowedTemplateIDs func() map[uuid.UUID]bool
 }
@@ -26,7 +25,7 @@ type readTemplateArgs struct {
 // ReadTemplate returns a tool that retrieves details about a specific
 // template, including its configurable rich parameters. The agent
 // uses this after list_templates and before create_workspace.
-func ReadTemplate(options ReadTemplateOptions) fantasy.AgentTool {
+func ReadTemplate(organizationID uuid.UUID, db database.Store, options ReadTemplateOptions) fantasy.AgentTool {
 	return fantasy.NewAgentTool(
 		"read_template",
 		"Get details about a workspace template, including its "+
@@ -34,7 +33,7 @@ func ReadTemplate(options ReadTemplateOptions) fantasy.AgentTool {
 			"template with list_templates and before creating a "+
 			"workspace with create_workspace.",
 		func(ctx context.Context, args readTemplateArgs, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
-			if options.DB == nil {
+			if db == nil {
 				return fantasy.NewTextErrorResponse("database is not configured"), nil
 			}
 
@@ -53,17 +52,21 @@ func ReadTemplate(options ReadTemplateOptions) fantasy.AgentTool {
 				return fantasy.NewTextErrorResponse("template not found"), nil
 			}
 
-			ctx, err = asOwner(ctx, options.DB, options.OwnerID)
+			ctx, err = asOwner(ctx, db, options.OwnerID)
 			if err != nil {
 				return fantasy.NewTextErrorResponse(err.Error()), nil
 			}
 
-			template, err := options.DB.GetTemplateByID(ctx, templateID)
+			template, err := db.GetTemplateByID(ctx, templateID)
 			if err != nil {
 				return fantasy.NewTextErrorResponse("template not found"), nil
 			}
 
-			params, err := options.DB.GetTemplateVersionParameters(ctx, template.ActiveVersionID)
+			if organizationID != uuid.Nil && template.OrganizationID != organizationID {
+				return fantasy.NewTextErrorResponse("template not found"), nil
+			}
+
+			params, err := db.GetTemplateVersionParameters(ctx, template.ActiveVersionID)
 			if err != nil {
 				return fantasy.NewTextErrorResponse(
 					xerrors.Errorf("failed to get template parameters: %w", err).Error(),

--- a/coderd/x/chatd/chattool/readtemplate.go
+++ b/coderd/x/chatd/chattool/readtemplate.go
@@ -62,7 +62,7 @@ func ReadTemplate(organizationID uuid.UUID, db database.Store, options ReadTempl
 				return fantasy.NewTextErrorResponse("template not found"), nil
 			}
 
-			if organizationID != uuid.Nil && template.OrganizationID != organizationID {
+			if template.OrganizationID != organizationID {
 				return fantasy.NewTextErrorResponse("template not found"), nil
 			}
 

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -1702,6 +1702,17 @@ How often to reconcile workspace prebuilds state.
 
 Hide AI tasks from the dashboard.
 
+### --chat-debug-logging-enabled
+
+|             |                                                |
+|-------------|------------------------------------------------|
+| Type        | <code>bool</code>                              |
+| Environment | <code>$CODER_CHAT_DEBUG_LOGGING_ENABLED</code> |
+| YAML        | <code>chat.debugLoggingEnabled</code>          |
+| Default     | <code>false</code>                             |
+
+Force chat debug logging on for every chat, bypassing the runtime admin and user opt-in settings.
+
 ### --aibridge-enabled
 
 |             |                                      |

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -1702,17 +1702,6 @@ How often to reconcile workspace prebuilds state.
 
 Hide AI tasks from the dashboard.
 
-### --chat-debug-logging-enabled
-
-|             |                                                |
-|-------------|------------------------------------------------|
-| Type        | <code>bool</code>                              |
-| Environment | <code>$CODER_CHAT_DEBUG_LOGGING_ENABLED</code> |
-| YAML        | <code>chat.debugLoggingEnabled</code>          |
-| Default     | <code>false</code>                             |
-
-Force chat debug logging on for every chat, bypassing the runtime admin and user opt-in settings.
-
 ### --aibridge-enabled
 
 |             |                                      |

--- a/enterprise/coderd/exp_chats_test.go
+++ b/enterprise/coderd/exp_chats_test.go
@@ -1237,12 +1237,10 @@ func TestListChats_OrgAdminOnlySeesOwnChats(t *testing.T) {
 	require.Equal(t, secondOrg.ID, memberChat.OrganizationID)
 
 	// Create an org admin in the second org with agents access.
-	adminClientRaw, admin := coderdtest.CreateAnotherUser(
+	adminClientRaw, _ := coderdtest.CreateAnotherUser(
 		t, client, firstUser.OrganizationID,
 		rbac.ScopedRoleOrgAdmin(secondOrg.ID), rbac.RoleAgentsAccess(),
 	)
-	_, err = client.PostOrganizationMember(ctx, secondOrg.ID, admin.Username)
-	require.NoError(t, err)
 	adminExp := codersdk.NewExperimentalClient(adminClientRaw)
 
 	// Admin creates a chat in the second org.

--- a/enterprise/coderd/exp_chats_test.go
+++ b/enterprise/coderd/exp_chats_test.go
@@ -1256,7 +1256,7 @@ func TestListChats_OrgAdminOnlySeesOwnChats(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, secondOrg.ID, adminChat.OrganizationID)
 
-	// Admin lists chats — should only see their own chat.
+	// Admin lists chats -- should only see their own chat.
 	// TODO: The handler currently filters by OwnerID (the
 	// authenticated user), so org admins cannot see other
 	// users' chats even though RBAC would allow it. If the

--- a/enterprise/coderd/exp_chats_test.go
+++ b/enterprise/coderd/exp_chats_test.go
@@ -1276,4 +1276,15 @@ func TestListChats_OrgAdminOnlySeesOwnChats(t *testing.T) {
 	}
 	require.True(t, foundAdmin, "admin should see own chat")
 	require.False(t, foundMember, "admin should NOT see member chat (OwnerID filter)")
+
+	// Positive control: member can list their own chat.
+	memberChats, err := memberExp.ListChats(ctx, nil)
+	require.NoError(t, err)
+	var memberSeeOwn bool
+	for _, c := range memberChats {
+		if c.ID == memberChat.ID {
+			memberSeeOwn = true
+		}
+	}
+	require.True(t, memberSeeOwn, "member should see own chat")
 }

--- a/enterprise/coderd/exp_chats_test.go
+++ b/enterprise/coderd/exp_chats_test.go
@@ -1172,3 +1172,110 @@ func TestCreateChatNonDefaultOrg(t *testing.T) {
 	}
 	require.True(t, found, "chat should be visible in list")
 }
+
+func TestListChats_OrgAdminOnlySeesOwnChats(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+
+	client, firstUser := coderdenttest.New(t, &coderdenttest.Options{
+		Options: &coderdtest.Options{
+			DeploymentValues: func() *codersdk.DeploymentValues {
+				v := coderdtest.DeploymentValues(t)
+				v.Experiments = []string{string(codersdk.ExperimentAgents)}
+				return v
+			}(),
+		},
+		LicenseOptions: &coderdenttest.LicenseOptions{
+			Features: license.Features{
+				codersdk.FeatureMultipleOrganizations: 1,
+			},
+		},
+	})
+	expClient := codersdk.NewExperimentalClient(client)
+
+	// Set up a chat provider and model config.
+	provider, err := expClient.CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
+		Provider:    "openai",
+		DisplayName: "OpenAI",
+		APIKey:      "test-key",
+		BaseURL:     "https://example.com",
+	})
+	require.NoError(t, err)
+	_, err = expClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+		Provider:             provider.Provider,
+		Model:                "gpt-4o-mini",
+		DisplayName:          "Test Model",
+		IsDefault:            ptr.Ref(true),
+		ContextLimit:         ptr.Ref(int64(1000)),
+		CompressionThreshold: ptr.Ref(int32(70)),
+	})
+	require.NoError(t, err)
+
+	// Create a second (non-default) org.
+	secondOrg := coderdenttest.CreateOrganization(t, client, coderdenttest.CreateOrganizationOptions{})
+
+	// Create a regular member with agents access in the second org.
+	memberClientRaw, member := coderdtest.CreateAnotherUser(
+		t, client, firstUser.OrganizationID, rbac.RoleAgentsAccess(),
+	)
+	_, err = client.PostOrganizationMember(ctx, secondOrg.ID, member.Username)
+	require.NoError(t, err)
+	memberExp := codersdk.NewExperimentalClient(memberClientRaw)
+
+	// Member creates a chat in the second org.
+	memberChat, err := memberExp.CreateChat(ctx, codersdk.CreateChatRequest{
+		OrganizationID: secondOrg.ID,
+		Content: []codersdk.ChatInputPart{
+			{
+				Type: codersdk.ChatInputPartTypeText,
+				Text: "hello from member",
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, secondOrg.ID, memberChat.OrganizationID)
+
+	// Create an org admin in the second org with agents access.
+	adminClientRaw, admin := coderdtest.CreateAnotherUser(
+		t, client, firstUser.OrganizationID,
+		rbac.ScopedRoleOrgAdmin(secondOrg.ID), rbac.RoleAgentsAccess(),
+	)
+	_, err = client.PostOrganizationMember(ctx, secondOrg.ID, admin.Username)
+	require.NoError(t, err)
+	adminExp := codersdk.NewExperimentalClient(adminClientRaw)
+
+	// Admin creates a chat in the second org.
+	adminChat, err := adminExp.CreateChat(ctx, codersdk.CreateChatRequest{
+		OrganizationID: secondOrg.ID,
+		Content: []codersdk.ChatInputPart{
+			{
+				Type: codersdk.ChatInputPartTypeText,
+				Text: "hello from admin",
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, secondOrg.ID, adminChat.OrganizationID)
+
+	// Admin lists chats — should only see their own chat.
+	// TODO: The handler currently filters by OwnerID (the
+	// authenticated user), so org admins cannot see other
+	// users' chats even though RBAC would allow it. If the
+	// handler gains an owner filter parameter, update this
+	// test to verify cross-user visibility.
+	adminChats, err := adminExp.ListChats(ctx, nil)
+	require.NoError(t, err)
+
+	var foundAdmin, foundMember bool
+	for _, c := range adminChats {
+		if c.ID == adminChat.ID {
+			foundAdmin = true
+		}
+		if c.ID == memberChat.ID {
+			foundMember = true
+		}
+	}
+	require.True(t, foundAdmin, "admin should see own chat")
+	require.False(t, foundMember, "admin should NOT see member chat (OwnerID filter)")
+}

--- a/site/src/modules/dashboard/Navbar/Navbar.tsx
+++ b/site/src/modules/dashboard/Navbar/Navbar.tsx
@@ -27,6 +27,7 @@ export const Navbar: FC = () => {
 		featureVisibility.connection_log && permissions.viewAnyConnectionLog;
 	const canViewAIBridge =
 		featureVisibility.aibridge && permissions.viewAnyAIBridgeInterception;
+	const canCreateChat = permissions.createChat;
 
 	const uniqueLinks = new Map<string, LinkConfig>();
 	for (const link of appearance.support_links ?? []) {
@@ -47,6 +48,7 @@ export const Navbar: FC = () => {
 			canViewAuditLog={canViewAuditLog}
 			canViewConnectionLog={canViewConnectionLog}
 			canViewAIBridge={canViewAIBridge}
+			canCreateChat={canCreateChat}
 			proxyContextValue={proxyContextValue}
 		/>
 	);

--- a/site/src/modules/dashboard/Navbar/NavbarView.stories.tsx
+++ b/site/src/modules/dashboard/Navbar/NavbarView.stories.tsx
@@ -35,6 +35,7 @@ const meta: Meta<typeof NavbarView> = {
 		canViewDeployment: true,
 		canViewHealth: true,
 		canViewOrganizations: true,
+		canCreateChat: true,
 		supportLinks: [],
 	},
 	decorators: [withDashboardProvider],
@@ -91,6 +92,16 @@ export const ForMember: Story = {
 		canViewDeployment: false,
 		canViewHealth: false,
 		canViewOrganizations: false,
+		canCreateChat: false,
+	},
+};
+
+export const AgentsTabHiddenWithoutPermission: Story = {
+	parameters: {
+		experiments: ["agents"],
+	},
+	args: {
+		canCreateChat: false,
 	},
 };
 

--- a/site/src/modules/dashboard/Navbar/NavbarView.stories.tsx
+++ b/site/src/modules/dashboard/Navbar/NavbarView.stories.tsx
@@ -96,6 +96,17 @@ export const ForMember: Story = {
 	},
 };
 
+export const ForMemberWithAgentsAccess: Story = {
+	args: {
+		user: MockUserMember,
+		canViewAuditLog: false,
+		canViewDeployment: false,
+		canViewHealth: false,
+		canViewOrganizations: false,
+		canCreateChat: true,
+	},
+};
+
 export const CustomLogo: Story = {
 	args: {
 		logo_url: "/icon/github.svg",

--- a/site/src/modules/dashboard/Navbar/NavbarView.stories.tsx
+++ b/site/src/modules/dashboard/Navbar/NavbarView.stories.tsx
@@ -96,15 +96,6 @@ export const ForMember: Story = {
 	},
 };
 
-export const AgentsTabHiddenWithoutPermission: Story = {
-	parameters: {
-		experiments: ["agents"],
-	},
-	args: {
-		canCreateChat: false,
-	},
-};
-
 export const CustomLogo: Story = {
 	args: {
 		logo_url: "/icon/github.svg",

--- a/site/src/modules/dashboard/Navbar/NavbarView.tsx
+++ b/site/src/modules/dashboard/Navbar/NavbarView.tsx
@@ -36,6 +36,7 @@ interface NavbarViewProps {
 	canViewConnectionLog: boolean;
 	canViewHealth: boolean;
 	canViewAIBridge: boolean;
+	canCreateChat: boolean;
 	proxyContextValue?: ProxyContextValue;
 }
 
@@ -57,6 +58,7 @@ export const NavbarView: FC<NavbarViewProps> = ({
 	canViewAuditLog,
 	canViewConnectionLog,
 	canViewAIBridge,
+	canCreateChat,
 	proxyContextValue,
 }) => {
 	const isDev = buildInfo ? isDevBuild(buildInfo) : false;
@@ -78,7 +80,7 @@ export const NavbarView: FC<NavbarViewProps> = ({
 				)}
 			</NavLink>
 
-			<NavItems className="ml-4" user={user} />
+			<NavItems className="ml-4" user={user} canCreateChat={canCreateChat} />
 
 			{isPreRelease && buildInfo?.version && (
 				<a
@@ -165,9 +167,10 @@ export const NavbarView: FC<NavbarViewProps> = ({
 interface NavItemsProps {
 	className?: string;
 	user: TypesGen.User;
+	canCreateChat: boolean;
 }
 
-const NavItems: FC<NavItemsProps> = ({ className, user }) => {
+const NavItems: FC<NavItemsProps> = ({ className, user, canCreateChat }) => {
 	const location = useLocation();
 
 	return (
@@ -192,7 +195,7 @@ const NavItems: FC<NavItemsProps> = ({ className, user }) => {
 				Templates
 			</NavLink>
 			<TasksNavItem user={user} />
-			<AgentsNavItem />
+			<AgentsNavItem canCreateChat={canCreateChat} />
 		</nav>
 	);
 };
@@ -257,11 +260,12 @@ function idleTasksLabel(count: number) {
 	return `You have ${count} ${count === 1 ? "task" : "tasks"} waiting for input`;
 }
 
-const AgentsNavItem: FC = () => {
+const AgentsNavItem: FC<{ canCreateChat: boolean }> = ({ canCreateChat }) => {
 	const { experiments, buildInfo } = useDashboard();
-	const canSeeAgents = experiments.includes("agents") || isDevBuild(buildInfo);
+	const experimentEnabled =
+		experiments.includes("agents") || isDevBuild(buildInfo);
 
-	if (!canSeeAgents) {
+	if (!experimentEnabled || !canCreateChat) {
 		return null;
 	}
 

--- a/site/src/pages/AgentsPage/AgentsPage.test.ts
+++ b/site/src/pages/AgentsPage/AgentsPage.test.ts
@@ -506,4 +506,102 @@ describe("useFileAttachments persistence", () => {
 		expect(localStorage.getItem(persistedAttachmentsStorageKey)).toBeNull();
 		unmount();
 	});
+
+	it("restores only attachments matching current organization", () => {
+		const entries = [
+			makePersistedEntry({
+				fileId: "f1",
+				fileName: "a.png",
+				organizationId: "org-1",
+			}),
+			makePersistedEntry({
+				fileId: "f2",
+				fileName: "b.png",
+				organizationId: "org-2",
+			}),
+		];
+		localStorage.setItem(
+			persistedAttachmentsStorageKey,
+			JSON.stringify(entries),
+		);
+
+		const { result, unmount } = renderFileAttachments();
+
+		expect(result.current.attachments).toHaveLength(1);
+		expect(result.current.attachments[0].name).toBe("a.png");
+
+		// localStorage should be pruned to only the matching org.
+		const stored = JSON.parse(
+			localStorage.getItem(persistedAttachmentsStorageKey)!,
+		);
+		expect(stored).toHaveLength(1);
+		expect(stored[0].fileId).toBe("f1");
+		unmount();
+	});
+
+	it("prunes legacy entries without organizationId", () => {
+		const legacy = {
+			fileId: "old-file",
+			fileName: "legacy.png",
+			fileType: "image/png",
+			lastModified: 1000,
+			// No organizationId field — simulates pre-org-scoping data.
+		};
+		localStorage.setItem(
+			persistedAttachmentsStorageKey,
+			JSON.stringify([legacy]),
+		);
+
+		const { result, unmount } = renderFileAttachments();
+
+		expect(result.current.attachments).toHaveLength(0);
+		expect(localStorage.getItem(persistedAttachmentsStorageKey)).toBeNull();
+		unmount();
+	});
+
+	it("skips restoration when organizationId is undefined", () => {
+		const entry = makePersistedEntry();
+		localStorage.setItem(
+			persistedAttachmentsStorageKey,
+			JSON.stringify([entry]),
+		);
+
+		const { result, unmount } = renderHook(() =>
+			useFileAttachments(undefined, { persist: true }),
+		);
+
+		// Should not restore — org not yet known.
+		expect(result.current.attachments).toHaveLength(0);
+		// Should NOT prune — org unknown, so leave storage alone.
+		expect(localStorage.getItem(persistedAttachmentsStorageKey)).not.toBeNull();
+		unmount();
+	});
+
+	it("persists organizationId with attachment metadata", async () => {
+		const { API } = await import("#/api/api");
+		vi.spyOn(API.experimental, "uploadChatFile").mockResolvedValue({
+			id: "new-file-id",
+		});
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response());
+
+		const { result, unmount } = renderFileAttachments();
+
+		const file = new File(["hello"], "test.png", { type: "image/png" });
+
+		act(() => {
+			result.current.handleAttach([file]);
+		});
+
+		await vi.waitFor(() => {
+			const state = result.current.uploadStates.get(file);
+			expect(state?.status).toBe("uploaded");
+		});
+
+		const stored = JSON.parse(
+			localStorage.getItem(persistedAttachmentsStorageKey)!,
+		);
+		expect(stored).toHaveLength(1);
+		expect(stored[0].organizationId).toBe("org-1");
+		unmount();
+	});
 });

--- a/site/src/pages/AgentsPage/AgentsPage.test.ts
+++ b/site/src/pages/AgentsPage/AgentsPage.test.ts
@@ -307,12 +307,14 @@ describe("useFileAttachments persistence", () => {
 			fileName: string;
 			fileType: string;
 			lastModified: number;
+			organizationId: string;
 		}> = {},
 	) => ({
 		fileId: "file-1",
 		fileName: "photo.png",
 		fileType: "image/png",
 		lastModified: 1000,
+		organizationId: "org-1",
 		...overrides,
 	});
 

--- a/site/src/pages/AgentsPage/AgentsPage.test.ts
+++ b/site/src/pages/AgentsPage/AgentsPage.test.ts
@@ -153,7 +153,7 @@ describe("useEmptyStateDraft", () => {
 		});
 		expect(localStorage.getItem(emptyInputStorageKey)).toBeNull();
 
-		// Simulate error recovery — re-enable persistence.
+		// Simulate error recovery -- re-enable persistence.
 		act(() => {
 			result.current.resetDraft();
 		});
@@ -545,7 +545,7 @@ describe("useFileAttachments persistence", () => {
 			fileName: "legacy.png",
 			fileType: "image/png",
 			lastModified: 1000,
-			// No organizationId field — simulates pre-org-scoping data.
+			// No organizationId field -- simulates pre-org-scoping data.
 		};
 		localStorage.setItem(
 			persistedAttachmentsStorageKey,
@@ -570,9 +570,9 @@ describe("useFileAttachments persistence", () => {
 			useFileAttachments(undefined, { persist: true }),
 		);
 
-		// Should not restore — org not yet known.
+		// Should not restore -- org not yet known.
 		expect(result.current.attachments).toHaveLength(0);
-		// Should NOT prune — org unknown, so leave storage alone.
+		// Should NOT prune -- org unknown, so leave storage alone.
 		expect(localStorage.getItem(persistedAttachmentsStorageKey)).not.toBeNull();
 		unmount();
 	});

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -231,6 +231,7 @@ export const PreservesAttachmentsOnFailedSend: Story = {
 					fileName: "photo.png",
 					fileType: "image/png",
 					lastModified: 1000,
+					organizationId: "my-organization-id",
 				},
 			]),
 		);

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -9,6 +9,13 @@ import {
 import { withDashboardProvider } from "#/testHelpers/storybook";
 import { AgentCreateForm } from "./AgentCreateForm";
 
+// Query key used by permittedOrganizations() in the form.
+const permittedOrgsKey = [
+	"organizations",
+	"permitted",
+	{ object: { resource_type: "chat" }, action: "create" },
+];
+
 const modelConfigID = "model-config-1";
 
 const modelOptions = [
@@ -320,6 +327,12 @@ export const WithOrganizationPicker: Story = {
 	parameters: {
 		showOrganizations: true,
 		organizations: [MockDefaultOrganization, MockOrganization2],
+		queries: [
+			{
+				key: permittedOrgsKey,
+				data: [MockDefaultOrganization, MockOrganization2],
+			},
+		],
 	},
 };
 
@@ -340,6 +353,12 @@ export const MultiOrgDoesNotInfiniteRender: Story = {
 	parameters: {
 		showOrganizations: true,
 		organizations: [MockDefaultOrganization, MockOrganization2],
+		queries: [
+			{
+				key: permittedOrgsKey,
+				data: [MockDefaultOrganization, MockOrganization2],
+			},
+		],
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -324,6 +324,43 @@ export const WithOrganizationPicker: Story = {
 };
 
 /**
+ * Regression test for an infinite render loop caused by an unstable
+ * array reference in the `permittedOrgs` fallback. When
+ * `permittedOrgsQuery.data` is undefined (single-org mode or while
+ * loading), the fallback must be referentially stable — otherwise
+ * the render-time adjustment pattern fires `setState` every render,
+ * hitting React's maximum update depth limit.
+ *
+ * This story reproduces the conditions: multi-org enabled with the
+ * permission query still loading (data = undefined), so the
+ * fallback path is exercised. The `play` function types into the
+ * input to trigger re-renders that surface the loop.
+ */
+export const MultiOrgDoesNotInfiniteRender: Story = {
+	parameters: {
+		showOrganizations: true,
+		organizations: [MockDefaultOrganization, MockOrganization2],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		// Verify the org picker rendered (component didn't crash).
+		await waitFor(() => {
+			expect(
+				canvas.getByTestId("organization-autocomplete"),
+			).toBeInTheDocument();
+		});
+		// Type into the chat input to trigger re-renders. If the
+		// permittedOrgs fallback is referentially unstable, this
+		// causes a render cascade that hits React's update limit.
+		const input = canvas.getByTestId("chat-message-input");
+		await userEvent.click(input);
+		await userEvent.keyboard("hello world");
+		// The org picker should still be present after typing.
+		expect(canvas.getByTestId("organization-autocomplete")).toBeInTheDocument();
+	},
+};
+
+/**
  * Standalone story for the org-change confirmation dialog. Renders
  * the ConfirmDialog directly in its open state, following the same
  * pattern as DeleteConfirmationDialog in AgentsPageView.stories.

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -334,24 +334,6 @@ export const WithOrganizationPicker: Story = {
 			},
 		],
 	},
-};
-
-/**
- * Regression guard for the multi-org code path. Exercises
- * AgentCreateForm with showOrganizations enabled and verifies the
- * component renders the org picker and survives user interaction.
- */
-export const MultiOrgDoesNotInfiniteRender: Story = {
-	parameters: {
-		showOrganizations: true,
-		organizations: [MockDefaultOrganization, MockOrganization2],
-		queries: [
-			{
-				key: permittedOrgsKey,
-				data: [MockDefaultOrganization, MockOrganization2],
-			},
-		],
-	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		// Verify the org picker rendered (component didn't crash).

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -337,28 +337,16 @@ export const WithOrganizationPicker: Story = {
 };
 
 /**
- * Regression test for an infinite render loop caused by an unstable
- * array reference in the `permittedOrgs` fallback. When
- * `permittedOrgsQuery.data` is undefined (single-org mode or while
- * loading), the fallback must be referentially stable — otherwise
- * the render-time adjustment pattern fires `setState` every render,
- * hitting React's maximum update depth limit.
- *
- * This story reproduces the conditions: multi-org enabled with the
- * permission query still loading (data = undefined), so the
- * fallback path is exercised. The `play` function types into the
- * input to trigger re-renders that surface the loop.
+ * Regression guard for the multi-org code path. Exercises
+ * AgentCreateForm with showOrganizations enabled and verifies the
+ * component renders the org picker and survives user interaction.
+ * The permittedOrganizations query is intentionally NOT mocked so
+ * the fallback to the unfiltered organizations list is exercised.
  */
 export const MultiOrgDoesNotInfiniteRender: Story = {
 	parameters: {
 		showOrganizations: true,
 		organizations: [MockDefaultOrganization, MockOrganization2],
-		queries: [
-			{
-				key: permittedOrgsKey,
-				data: [MockDefaultOrganization, MockOrganization2],
-			},
-		],
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.stories.tsx
@@ -340,13 +340,17 @@ export const WithOrganizationPicker: Story = {
  * Regression guard for the multi-org code path. Exercises
  * AgentCreateForm with showOrganizations enabled and verifies the
  * component renders the org picker and survives user interaction.
- * The permittedOrganizations query is intentionally NOT mocked so
- * the fallback to the unfiltered organizations list is exercised.
  */
 export const MultiOrgDoesNotInfiniteRender: Story = {
 	parameters: {
 		showOrganizations: true,
 		organizations: [MockDefaultOrganization, MockOrganization2],
+		queries: [
+			{
+				key: permittedOrgsKey,
+				data: [MockDefaultOrganization, MockOrganization2],
+			},
+		],
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -416,28 +416,30 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 						)
 					) : null}
 					{workspacesError != null && <ErrorAlert error={workspacesError} />}
-					{showOrganizations && permittedOrgs.length > 1 && (
-						<div className="flex flex-col gap-2">
-							<Label htmlFor="organization">Organization</Label>
-							<OrganizationAutocomplete
-								id="organization"
-								required
-								value={selectedOrg}
-								options={permittedOrgs}
-								onChange={(newOrg) => {
-									const orgChanged = newOrg?.id !== selectedOrg?.id;
-									if (orgChanged && attachments.length > 0) {
-										setPendingOrgChange(newOrg);
-										return;
-									}
-									if (orgChanged) {
-										handleWorkspaceChange(null);
-									}
-									setSelectedOrg(newOrg);
-								}}
-							/>
-						</div>
-					)}
+					{showOrganizations &&
+						!permittedOrgsQuery.isLoading &&
+						permittedOrgs.length > 1 && (
+							<div className="flex flex-col gap-2">
+								<Label htmlFor="organization">Organization</Label>
+								<OrganizationAutocomplete
+									id="organization"
+									required
+									value={selectedOrg}
+									options={permittedOrgs}
+									onChange={(newOrg) => {
+										const orgChanged = newOrg?.id !== selectedOrg?.id;
+										if (orgChanged && attachments.length > 0) {
+											setPendingOrgChange(newOrg);
+											return;
+										}
+										if (orgChanged) {
+											handleWorkspaceChange(null);
+										}
+										setSelectedOrg(newOrg);
+									}}
+								/>
+							</div>
+						)}
 					<AgentChatInput
 						onSend={handleSendWithAttachments}
 						placeholder="Ask Coder to build, fix bugs, or explore your project..."

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -1,7 +1,9 @@
-import { type FC, useEffect, useRef, useState } from "react";
+import { type FC, useEffect, useEffectEvent, useRef, useState } from "react";
+import { useQuery } from "react-query";
 import { Link } from "react-router";
 import { toast } from "sonner";
 import { isApiError } from "#/api/errors";
+import { permittedOrganizations } from "#/api/queries/organizations";
 import type * as TypesGen from "#/api/typesGenerated";
 import { Alert, AlertDescription } from "#/components/Alert/Alert";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
@@ -191,9 +193,9 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 			const stored = localStorage.getItem(selectedWorkspaceIdStorageKey);
 			if (!stored) return null;
 
-			// If workspaces haven't loaded yet, keep the stored value.
-			// It will be re-validated once the list arrives via
-			// filteredWorkspaces clearing the selection if stale.
+			// The stored value is kept optimistically until workspaces
+			// load. effectiveWorkspaceId (computed after render) drops
+			// it if it doesn't match the current org's workspaces.
 			if (workspaceOptions.length === 0) return stored;
 
 			// Validate the stored workspace still exists and belongs
@@ -255,12 +257,6 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		lastUsedModelID,
 	]);
 
-	// Keep a mutable ref to selectedWorkspaceId and selectedModel so
-	// that the onSend callback always sees the latest values without
-	// the shared input component re-rendering on every change.
-	const selectedWorkspaceIdRef = useRef(selectedWorkspaceId);
-	const selectedModelRef = useRef(selectedModel);
-	const organizationIdRef = useRef(organizationId);
 	const [userMCPServerIds, setUserMCPServerIds] = useState<string[] | null>(
 		null,
 	);
@@ -274,13 +270,6 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		}
 		return getDefaultMCPSelection(mcpServers ?? []);
 	})();
-	const selectedMCPServerIdsRef = useRef(effectiveMCPServerIds);
-	useEffect(() => {
-		selectedWorkspaceIdRef.current = selectedWorkspaceId;
-		selectedModelRef.current = selectedModel;
-		selectedMCPServerIdsRef.current = effectiveMCPServerIds;
-		organizationIdRef.current = organizationId;
-	});
 	const handleWorkspaceChange = (value: string | null) => {
 		if (value === null) {
 			setSelectedWorkspaceId(null);
@@ -296,27 +285,47 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		setUserSelectedModel(value);
 	};
 
-	const handleSend = async (message: string, fileIDs?: string[]) => {
-		submitDraft();
-		await onCreateChat({
-			message,
-			fileIDs,
-			workspaceId: selectedWorkspaceIdRef.current ?? undefined,
-			model: selectedModelRef.current || undefined,
-			organizationId: organizationIdRef.current,
-			mcpServerIds:
-				selectedMCPServerIdsRef.current.length > 0
-					? [...selectedMCPServerIdsRef.current]
-					: undefined,
-		}).catch((err) => {
-			// Re-enable draft persistence so the user can edit
-			// and retry after a failed send attempt, then rethrow
-			// so callers (handleSendWithAttachments) can preserve
-			// attachments on failure.
-			resetDraft();
-			throw err;
-		});
-	};
+	const isForbidden = !canCreateChat;
+
+	// Filter workspaces by the selected organization. We use
+	// client-side filtering of the full "owner:me" fetch rather
+	// than re-querying with an org filter because it avoids
+	// extra loading/error states on org change. The full list is
+	// already small (user's own workspaces) and limit: 0
+	// guarantees completeness. If workspace counts grow large
+	// enough to warrant pagination, this should switch to a
+	// server-side organization:<name> query filter.
+	const filteredWorkspaces =
+		showOrganizations && selectedOrg
+			? workspaceOptions.filter((ws) => ws.organization_id === selectedOrg.id)
+			: workspaceOptions;
+
+	const effectiveWorkspaceId =
+		selectedWorkspaceId !== null &&
+		(isWorkspacesLoading ||
+			filteredWorkspaces.some((ws) => ws.id === selectedWorkspaceId))
+			? selectedWorkspaceId
+			: null;
+
+	const handleSend = useEffectEvent(
+		async (message: string, fileIDs?: string[]) => {
+			submitDraft();
+			await onCreateChat({
+				message,
+				fileIDs,
+				workspaceId: effectiveWorkspaceId ?? undefined,
+				model: selectedModel || undefined,
+				organizationId,
+				mcpServerIds:
+					effectiveMCPServerIds.length > 0
+						? [...effectiveMCPServerIds]
+						: undefined,
+			}).catch((err) => {
+				resetDraft();
+				throw err;
+			});
+		},
+	);
 
 	const {
 		attachments,
@@ -355,20 +364,14 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		}
 	};
 
-	const isForbidden = !canCreateChat;
-
-	// Filter workspaces by the selected organization. We use
-	// client-side filtering of the full "owner:me" fetch rather
-	// than re-querying with an org filter because it avoids
-	// extra loading/error states on org change. The full list is
-	// already small (user's own workspaces) and limit: 0
-	// guarantees completeness. If workspace counts grow large
-	// enough to warrant pagination, this should switch to a
-	// server-side organization:<name> query filter.
-	const filteredWorkspaces =
-		showOrganizations && selectedOrg
-			? workspaceOptions.filter((ws) => ws.organization_id === selectedOrg.id)
-			: workspaceOptions;
+	const permittedOrgsQuery = useQuery({
+		...permittedOrganizations({
+			object: { resource_type: "chat" },
+			action: "create",
+		}),
+		enabled: showOrganizations,
+	});
+	const permittedOrgs = permittedOrgsQuery.data ?? [...organizations];
 
 	return (
 		<>
@@ -404,7 +407,7 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 								id="organization"
 								required
 								value={selectedOrg}
-								options={[...organizations]}
+								options={permittedOrgs}
 								onChange={(newOrg) => {
 									const orgChanged = newOrg?.id !== selectedOrg?.id;
 									if (orgChanged && attachments.length > 0) {
@@ -447,7 +450,7 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 						}}
 						onMCPAuthComplete={onMCPAuthComplete}
 						workspaceOptions={filteredWorkspaces}
-						selectedWorkspaceId={selectedWorkspaceId}
+						selectedWorkspaceId={effectiveWorkspaceId}
 						onWorkspaceChange={handleWorkspaceChange}
 						isWorkspaceLoading={isWorkspacesLoading}
 					/>

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -416,6 +416,9 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 						)
 					) : null}
 					{workspacesError != null && <ErrorAlert error={workspacesError} />}
+					{permittedOrgsQuery.error != null && (
+						<ErrorAlert error={permittedOrgsQuery.error} />
+					)}
 					{showOrganizations &&
 						!permittedOrgsQuery.isLoading &&
 						permittedOrgs.length > 1 && (

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -373,7 +373,21 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		}),
 		enabled: showOrganizations,
 	});
-	const permittedOrgs = permittedOrgsQuery.data ?? [...organizations];
+	const permittedOrgs = permittedOrgsQuery.data ?? organizations;
+
+	// Clear invalid selections when permission filtering removes the
+	// selected org. Uses the React render-time adjustment pattern
+	// (same as CreateTemplateForm) instead of useEffect.
+	const [prevPermittedOrgs, setPrevPermittedOrgs] = useState(permittedOrgs);
+	if (permittedOrgs !== prevPermittedOrgs) {
+		setPrevPermittedOrgs(permittedOrgs);
+		if (selectedOrg && !permittedOrgs.some((o) => o.id === selectedOrg.id)) {
+			const fallback = permittedOrgs[0] ?? null;
+			setSelectedOrg(fallback);
+			handleWorkspaceChange(null);
+			resetAttachments();
+		}
+	}
 
 	// Clear invalid selections when permission filtering removes the
 	// selected org. Uses the React render-time adjustment pattern

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -402,7 +402,7 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 						)
 					) : null}
 					{workspacesError != null && <ErrorAlert error={workspacesError} />}
-					{showOrganizations && (
+					{showOrganizations && permittedOrgs.length > 1 && (
 						<div className="flex flex-col gap-2">
 							<Label htmlFor="organization">Organization</Label>
 							<OrganizationAutocomplete

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -375,19 +375,33 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 	});
 	const permittedOrgs = permittedOrgsQuery.data ?? organizations;
 
-	// Clear invalid selections when permission filtering removes the
-	// selected org. Uses the React render-time adjustment pattern
-	// (same as CreateTemplateForm) instead of useEffect.
+	// Reconcile selectedOrg when permission filtering removes it.
+	// Only pure state setters run during render; side effects
+	// (localStorage, blob URL cleanup) run in the effect below.
 	const [prevPermittedOrgs, setPrevPermittedOrgs] = useState(permittedOrgs);
+	const [orgWasAdjusted, setOrgWasAdjusted] = useState(false);
 	if (permittedOrgs !== prevPermittedOrgs) {
 		setPrevPermittedOrgs(permittedOrgs);
 		if (selectedOrg && !permittedOrgs.some((o) => o.id === selectedOrg.id)) {
-			const fallback = permittedOrgs[0] ?? null;
-			setSelectedOrg(fallback);
-			handleWorkspaceChange(null);
-			resetAttachments();
+			setSelectedOrg(permittedOrgs[0] ?? null);
+			setOrgWasAdjusted(true);
 		}
 	}
+
+	// Clean up workspace and attachment state after a programmatic
+	// org change from permission filtering. These calls have side
+	// effects (localStorage, blob URL revocation) that must not
+	// run during render.
+	const onOrgAdjusted = useEffectEvent(() => {
+		handleWorkspaceChange(null);
+		resetAttachments();
+	});
+	useEffect(() => {
+		if (orgWasAdjusted) {
+			setOrgWasAdjusted(false);
+			onOrgAdjusted();
+		}
+	}, [orgWasAdjusted]);
 
 	return (
 		<>

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -375,6 +375,20 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 	});
 	const permittedOrgs = permittedOrgsQuery.data ?? [...organizations];
 
+	// Clear invalid selections when permission filtering removes the
+	// selected org. Uses the React render-time adjustment pattern
+	// (same as CreateTemplateForm) instead of useEffect.
+	const [prevPermittedOrgs, setPrevPermittedOrgs] = useState(permittedOrgs);
+	if (permittedOrgs !== prevPermittedOrgs) {
+		setPrevPermittedOrgs(permittedOrgs);
+		if (selectedOrg && !permittedOrgs.some((o) => o.id === selectedOrg.id)) {
+			const fallback = permittedOrgs[0] ?? null;
+			setSelectedOrg(fallback);
+			handleWorkspaceChange(null);
+			resetAttachments();
+		}
+	}
+
 	return (
 		<>
 			<div className="flex min-h-0 flex-1 items-start justify-center overflow-auto p-4 pt-12 md:h-full md:items-center md:pt-4">

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -389,20 +389,6 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		}
 	}
 
-	// Clear invalid selections when permission filtering removes the
-	// selected org. Uses the React render-time adjustment pattern
-	// (same as CreateTemplateForm) instead of useEffect.
-	const [prevPermittedOrgs, setPrevPermittedOrgs] = useState(permittedOrgs);
-	if (permittedOrgs !== prevPermittedOrgs) {
-		setPrevPermittedOrgs(permittedOrgs);
-		if (selectedOrg && !permittedOrgs.some((o) => o.id === selectedOrg.id)) {
-			const fallback = permittedOrgs[0] ?? null;
-			setSelectedOrg(fallback);
-			handleWorkspaceChange(null);
-			resetAttachments();
-		}
-	}
-
 	return (
 		<>
 			<div className="flex min-h-0 flex-1 items-start justify-center overflow-auto p-4 pt-12 md:h-full md:items-center md:pt-4">

--- a/site/src/pages/AgentsPage/hooks/useFileAttachments.ts
+++ b/site/src/pages/AgentsPage/hooks/useFileAttachments.ts
@@ -37,6 +37,17 @@ function restorePersistedAttachments(currentOrgId: string): {
 	uploadStates: Map<File, UploadState>;
 	previewUrls: Map<File, string>;
 } {
+	// When the org ID is not yet known (e.g. still loading), skip
+	// restoration entirely so we don't accidentally prune valid
+	// entries. The initializer only runs once, so the caller must
+	// ensure the org ID is available before mounting the hook.
+	if (!currentOrgId) {
+		return {
+			attachments: [],
+			uploadStates: new Map(),
+			previewUrls: new Map(),
+		};
+	}
 	const stored = localStorage.getItem(persistedAttachmentsStorageKey);
 	if (!stored) {
 		return {

--- a/site/src/pages/AgentsPage/hooks/useFileAttachments.ts
+++ b/site/src/pages/AgentsPage/hooks/useFileAttachments.ts
@@ -2,7 +2,7 @@ import {
 	type Dispatch,
 	type SetStateAction,
 	useEffect,
-	useRef,
+	useEffectEvent,
 	useState,
 } from "react";
 import { API } from "#/api/api";
@@ -191,16 +191,13 @@ export function useFileAttachments(
 	);
 
 	// Revoke blob URLs on unmount to prevent memory leaks.
-	const previewUrlsRef = useRef(previewUrls);
-	useEffect(() => {
-		previewUrlsRef.current = previewUrls;
+	const revokePreviewUrls = useEffectEvent(() => {
+		for (const [, url] of previewUrls) {
+			if (url.startsWith("blob:")) URL.revokeObjectURL(url);
+		}
 	});
 	useEffect(() => {
-		return () => {
-			for (const [, url] of previewUrlsRef.current) {
-				if (url.startsWith("blob:")) URL.revokeObjectURL(url);
-			}
-		};
+		return () => revokePreviewUrls();
 	}, []);
 
 	const startUpload = (file: File) => {
@@ -348,9 +345,7 @@ export function useFileAttachments(
 	};
 
 	const resetAttachments = () => {
-		for (const [, url] of previewUrlsRef.current) {
-			if (url.startsWith("blob:")) URL.revokeObjectURL(url);
-		}
+		revokePreviewUrls();
 		setPreviewUrls(new Map());
 		setTextContents(new Map());
 		setUploadStates(new Map());

--- a/site/src/pages/AgentsPage/hooks/useFileAttachments.ts
+++ b/site/src/pages/AgentsPage/hooks/useFileAttachments.ts
@@ -211,7 +211,7 @@ export function useFileAttachments(
 			return;
 		}
 
-		const shouldPersist = persist && !!organizationId;
+		const shouldPersist = persist && Boolean(organizationId);
 		const isImage = file.type.startsWith("image/");
 
 		setUploadStates((prev) => new Map(prev).set(file, { status: "uploading" }));

--- a/site/src/pages/AgentsPage/hooks/useFileAttachments.ts
+++ b/site/src/pages/AgentsPage/hooks/useFileAttachments.ts
@@ -21,14 +21,18 @@ interface PersistedAttachment {
 	fileName: string;
 	fileType: string;
 	lastModified: number;
+	organizationId: string;
 }
 
 /**
  * Restore previously persisted attachments from localStorage.
  * Creates synthetic File objects (empty blobs with correct metadata)
  * and populates the corresponding Maps so the UI can render them.
+ *
+ * Only attachments matching `currentOrgId` are returned. Entries
+ * belonging to a different organization are pruned from storage.
  */
-function restorePersistedAttachments(): {
+function restorePersistedAttachments(currentOrgId: string): {
 	attachments: File[];
 	uploadStates: Map<File, UploadState>;
 	previewUrls: Map<File, string>;
@@ -43,11 +47,25 @@ function restorePersistedAttachments(): {
 	}
 	try {
 		const persisted: PersistedAttachment[] = JSON.parse(stored);
+		const matched = persisted.filter((p) => p.organizationId === currentOrgId);
+
+		// Prune entries that don't match the current org.
+		if (matched.length !== persisted.length) {
+			if (matched.length > 0) {
+				localStorage.setItem(
+					persistedAttachmentsStorageKey,
+					JSON.stringify(matched),
+				);
+			} else {
+				localStorage.removeItem(persistedAttachmentsStorageKey);
+			}
+		}
+
 		const attachments: File[] = [];
 		const uploadStates = new Map<File, UploadState>();
 		const previewUrls = new Map<File, string>();
 
-		for (const p of persisted) {
+		for (const p of matched) {
 			if (!p.fileId || !p.fileName) continue;
 			// Synthetic File used as a Map key only. Its content is
 			// never read because the existing file_id is reused at
@@ -72,7 +90,11 @@ function restorePersistedAttachments(): {
 	}
 }
 
-function addPersistedAttachment(file: File, fileId: string) {
+function addPersistedAttachment(
+	file: File,
+	fileId: string,
+	organizationId: string,
+) {
 	const stored = localStorage.getItem(persistedAttachmentsStorageKey);
 	let persisted: PersistedAttachment[];
 	try {
@@ -85,6 +107,7 @@ function addPersistedAttachment(file: File, fileId: string) {
 		fileName: file.name,
 		fileType: file.type,
 		lastModified: file.lastModified,
+		organizationId,
 	});
 	localStorage.setItem(
 		persistedAttachmentsStorageKey,
@@ -141,7 +164,7 @@ export function useFileAttachments(
 	// when persistence is enabled. Computed once on first render.
 	const [restored] = useState(() =>
 		persist
-			? restorePersistedAttachments()
+			? restorePersistedAttachments(organizationId ?? "")
 			: {
 					attachments: [] as File[],
 					uploadStates: new Map<File, UploadState>(),
@@ -179,6 +202,10 @@ export function useFileAttachments(
 			);
 			return;
 		}
+
+		const shouldPersist = persist && !!organizationId;
+		const isImage = file.type.startsWith("image/");
+
 		setUploadStates((prev) => new Map(prev).set(file, { status: "uploading" }));
 		void (async () => {
 			try {
@@ -192,14 +219,14 @@ export function useFileAttachments(
 						fileId: result.id,
 					}),
 				);
-				if (persist) {
-					addPersistedAttachment(file, result.id);
+				if (shouldPersist) {
+					addPersistedAttachment(file, result.id, organizationId!);
 				}
 				// Pre-warm the browser HTTP cache for images so the
 				// timeline can render them instantly after send. We
 				// intentionally skip text attachments because the
 				// composer already has the text content locally.
-				if (file.type.startsWith("image/")) {
+				if (isImage) {
 					void fetch(`/api/experimental/chats/files/${result.id}`);
 				}
 			} catch (err: unknown) {


### PR DESCRIPTION
Addresses review findings from #23827 that were added post-merge.

## Frontend

- Persisted attachments now store `organizationId`; mismatched orgs pruned on restore
- Workspace selection reconciliation: stale IDs from previous orgs dropped via derived `effectiveWorkspaceId`
- Org picker uses `permittedOrganizations()` for RBAC-aware filtering
- Org picker hidden when user belongs to only one org
- Ref-sync `useEffect` replaced with `useEffectEvent`

## Backend

- `CreateWorkspace()` and `ListTemplates()` take `organizationID` and `db` as required function parameters instead of optional struct fields — compiler enforces them, removes scattered nil guards
- Cross-org template check in `CreateWorkspace` is now unconditional
- `ListTemplates` org-scoping filter now has test coverage
- `setupChatInfra` comment fixed; test helpers use params structs instead of positional UUIDs
- Enterprise test documents that org admin only sees own chats (handler hardcodes `OwnerID` — future work needs sidebar UI before lifting that restriction)

> 🤖