### PR TITLE
ci: use GitHub App token for community label org membership check

### DIFF
--- a/.github/workflows/contrib.yaml
+++ b/.github/workflows/contrib.yaml
@@ -30,16 +30,28 @@ jobs:
     if: >-
       ${{
         github.event_name == 'pull_request_target' &&
-        github.event.action == 'opened' &&
-        github.event.pull_request.author_association != 'MEMBER' &&
-        github.event.pull_request.author_association != 'COLLABORATOR' &&
-        github.event.pull_request.author_association != 'OWNER'
+        github.event.action == 'opened'
       }}
     steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ vars.ORG_MEMBERSHIP_APP_ID }}
+          private-key: ${{ secrets.ORG_MEMBERSHIP_APP_PRIVATE_KEY }}
+
       - name: Add community label
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
+          # Default GITHUB_TOKEN — only needs pull-requests: write
+          # for adding labels. The App token (members: read only)
+          # is used via a separate Octokit client below.
           script: |
+            const { Octokit } = require("@octokit/rest")
+            const orgClient = new Octokit({ auth: process.env.APP_TOKEN })
+
             const params = {
               issue_number: context.issue.number,
               owner: context.repo.owner,
@@ -52,10 +64,27 @@ jobs:
               return
             }
 
-            console.log(
-              'Adding "community" label for author association "%s".',
-              context.payload.pull_request.author_association,
-            )
+            // author_association can be unreliable: it returns
+            // CONTRIBUTOR instead of MEMBER when both apply, and
+            // returns NONE for members with private org visibility.
+            // Use the org membership API as the source of truth.
+            // See: https://github.com/actions/github-script/issues/643
+            const author = context.payload.pull_request.user.login
+            try {
+              await orgClient.orgs.checkMembershipForUser({
+                org: context.repo.owner,
+                username: author,
+              })
+              console.log('Author "%s" is an org member, skipping.', author)
+              return
+            } catch (error) {
+              if (error.status !== 404 && error.status !== 302) {
+                throw error
+              }
+            }
+
+            console.log('Adding "community" label for author "%s".', author)
+            // Uses the default GITHUB_TOKEN via the `github` object.
             await github.rest.issues.addLabels({
               ...params,
               labels: ["community"],


### PR DESCRIPTION
## Problem

`author_association` on `pull_request_target` events is unreliable:

- Returns `CONTRIBUTOR` instead of `MEMBER` when both apply ([actions/github-script#643](https://github.com/actions/github-script/issues/643)).
- Returns `NONE` for members with private org visibility ([community#18690](https://github.com/orgs/community/discussions/18690)).

Most coder org members have private membership, so the existing check is largely broken and org members incorrectly receive the `community` label.

## Fix

Replace the `author_association` filter with an explicit `orgs.checkMembershipForUser()` API call. Instead of a long-lived PAT (as proposed in #24149 / #23343), this uses a GitHub App installation token via `actions/create-github-app-token`. Tokens are ephemeral (1 hour, auto-revoked on step completion), not tied to any individual user account, and scoped to the minimum permission needed.

Token separation for least privilege:

- **App token** (`orgClient`) — `members: read` only. Used solely for the membership check.
- **Default `GITHUB_TOKEN`** (`github`) — `pull-requests: write` from the job-level permissions block. Used solely for adding labels.

Neither token carries permissions it does not need.

### Setup required

A repo admin needs to:
1. Register a GitHub App with only **Organization permissions → Members: Read-only**.
2. Install the App on the `coder` org, scoped to `coder/coder`.
3. Store the App ID as variable `ORG_MEMBERSHIP_APP_ID` and private key as secret `ORG_MEMBERSHIP_APP_PRIVATE_KEY`.

Supersedes #24149 and #23343.