### PR TITLE
ci: verify community label workflow

### DIFF
--- a/docs/about/contributing/CONTRIBUTING.md
+++ b/docs/about/contributing/CONTRIBUTING.md
@@ -368,3 +368,4 @@ On macOS, a [direnv bug](https://github.com/direnv/direnv/issues/1345) can cause
 use nix
 mkdir -p "$TMPDIR"
 ```
+


### PR DESCRIPTION
Dummy PR to verify the community-label workflow runs correctly after switching to GitHub App installation tokens in #24149.

**Expected behavior:** Since this PR is opened by an org member, the workflow should detect membership via `orgClient.orgs.checkMembershipForUser` and skip adding the `community` label.

Close after verifying.