### PR TITLE
fix: preserve stream state on interrupt, fix auto-promote error handling

### DIFF
--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -3966,7 +3966,7 @@ func (p *Server) tryAutoPromoteQueuedMessage(
 	).withCreatedBy(chat.OwnerID))
 	msgs, err := insertChatMessageWithStore(ctx, tx, msgParams)
 	if err != nil {
-		return nil, nil, false, xerrors.Errorf("promote queued message: %w", err)
+		return nil, nil, false, xerrors.Errorf("insert promoted message: %w", err)
 	}
 	msg := msgs[0]
 
@@ -4212,6 +4212,15 @@ func (p *Server) processChat(ctx context.Context, chat database.Chat) {
 
 		p.publishStatus(chat.ID, status, uuid.NullUUID{})
 
+		// Best-effort: use any generated title captured during
+		// processing so push notifications and the status snapshot
+		// can reflect it without another DB read. The dedicated
+		// title_change event remains the source of truth.
+		if title, ok := generatedTitle.Load(); ok {
+			updatedChat.Title = title
+		}
+		p.publishChatPubsubEvent(updatedChat, codersdk.ChatWatchEventKindStatusChange, nil)
+
 		// Wake the run loop immediately when auto-promote
 		// transitioned the chat to pending, matching every
 		// other pending-transition path (CreateChat,
@@ -4220,16 +4229,6 @@ func (p *Server) processChat(ctx context.Context, chat database.Chat) {
 		if status == database.ChatStatusPending {
 			p.signalWake()
 		}
-
-		// Best-effort: use any generated title captured during
-		// processing so push notifications and the status snapshot
-		// can reflect it without another DB read. The dedicated
-		// title_change event remains the source of truth.
-
-		if title, ok := generatedTitle.Load(); ok {
-			updatedChat.Title = title
-		}
-		p.publishChatPubsubEvent(updatedChat, codersdk.ChatWatchEventKindStatusChange, nil)
 
 		// When the chat is parked in requires_action,
 		// publish the stream event and global pubsub event

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -3966,9 +3966,7 @@ func (p *Server) tryAutoPromoteQueuedMessage(
 	).withCreatedBy(chat.OwnerID))
 	msgs, err := insertChatMessageWithStore(ctx, tx, msgParams)
 	if err != nil {
-		logger.Error(ctx, "failed to promote queued message",
-			slog.F("queued_message_id", nextQueued.ID), slog.Error(err))
-		return nil, nil, false, nil
+		return nil, nil, false, xerrors.Errorf("promote queued message: %w", err)
 	}
 	msg := msgs[0]
 
@@ -4171,7 +4169,7 @@ func (p *Server) processChat(ctx context.Context, chat database.Chat) {
 				var promoteErr error
 				promotedMessage, remainingQueuedMessages, shouldPublishQueueUpdate, promoteErr = p.tryAutoPromoteQueuedMessage(cleanupCtx, tx, latestChat)
 				if promoteErr != nil {
-					logger.Error(cleanupCtx, "failed to auto-promote queued message", slog.Error(promoteErr))
+					return xerrors.Errorf("auto-promote queued message: %w", promoteErr)
 				} else if promotedMessage != nil {
 					status = database.ChatStatusPending
 				}
@@ -4213,10 +4211,21 @@ func (p *Server) processChat(ctx context.Context, chat database.Chat) {
 		}
 
 		p.publishStatus(chat.ID, status, uuid.NullUUID{})
+
+		// Wake the run loop immediately when auto-promote
+		// transitioned the chat to pending, matching every
+		// other pending-transition path (CreateChat,
+		// SendMessage, EditMessage, PromoteQueued,
+		// SubmitToolResults).
+		if status == database.ChatStatusPending {
+			p.signalWake()
+		}
+
 		// Best-effort: use any generated title captured during
 		// processing so push notifications and the status snapshot
 		// can reflect it without another DB read. The dedicated
 		// title_change event remains the source of truth.
+
 		if title, ok := generatedTitle.Load(); ok {
 			updatedChat.Title = title
 		}

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -5145,6 +5145,7 @@ func (p *Server) finishActiveChat(
 			var promoteErr error
 			result.promotedMessage, result.remainingQueuedMessages, result.shouldPublishQueueUpdate, promoteErr = p.tryAutoPromoteQueuedMessage(ctx, tx, latestChat)
 			if promoteErr != nil {
+				logger.Error(ctx, "auto-promote queued message failed, rolling back", slog.Error(promoteErr))
 				return xerrors.Errorf("auto-promote queued message: %w", promoteErr)
 			} else if result.promotedMessage != nil {
 				status = database.ChatStatusPending

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -5039,9 +5039,7 @@ func (p *Server) tryAutoPromoteQueuedMessage(
 	).withCreatedBy(chat.OwnerID))
 	msgs, err := insertChatMessageWithStore(ctx, tx, msgParams)
 	if err != nil {
-		logger.Error(ctx, "failed to promote queued message",
-			slog.F("queued_message_id", nextQueued.ID), slog.Error(err))
-		return nil, nil, false, nil
+		return nil, nil, false, xerrors.Errorf("insert promoted message: %w", err)
 	}
 	msg := msgs[0]
 
@@ -5147,7 +5145,7 @@ func (p *Server) finishActiveChat(
 			var promoteErr error
 			result.promotedMessage, result.remainingQueuedMessages, result.shouldPublishQueueUpdate, promoteErr = p.tryAutoPromoteQueuedMessage(ctx, tx, latestChat)
 			if promoteErr != nil {
-				logger.Error(ctx, "failed to auto-promote queued message", slog.Error(promoteErr))
+				return xerrors.Errorf("auto-promote queued message: %w", promoteErr)
 			} else if result.promotedMessage != nil {
 				status = database.ChatStatusPending
 			}

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -2799,3 +2799,243 @@ func TestHeartbeatTick_DBErrorDoesNotInterruptChats(t *testing.T) {
 	require.NoError(t, chatCtx.Err(),
 		"chat context should not be canceled on transient DB error")
 }
+
+// TestAutoPromote_InsertFailureRollsBackTransaction verifies that when
+// tryAutoPromoteQueuedMessage pops a queued message but the subsequent
+// insert fails, the error propagates to the InTx callback, causing the
+// transaction to roll back and preserving the queued message.
+func TestAutoPromote_InsertFailureRollsBackTransaction(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+	tx := dbmock.NewMockStore(ctrl)
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	ps := dbpubsub.NewInMemory()
+	clock := quartz.NewReal()
+
+	chatID := uuid.New()
+	workerID := uuid.New()
+	ownerID := uuid.New()
+	modelConfigID := uuid.New()
+
+	waitingChat := database.Chat{
+		ID:                chatID,
+		OwnerID:           ownerID,
+		LastModelConfigID: modelConfigID,
+		Status:            database.ChatStatusWaiting,
+		WorkerID:          uuid.NullUUID{UUID: workerID, Valid: true},
+	}
+	queuedMsg := database.ChatQueuedMessage{
+		ID:      1,
+		ChatID:  chatID,
+		Content: []byte(`[{"type":"text","text":"queued"}]`),
+	}
+	insertErr := xerrors.New("insert failed")
+
+	server := &Server{
+		db:          db,
+		logger:      logger,
+		pubsub:      ps,
+		configCache: newChatConfigCache(ctx, db, clock),
+	}
+
+	// The caller runs tryAutoPromoteQueuedMessage inside InTx.
+	// Wire the mock to execute the callback against the TX mock.
+	var txErr error
+	db.EXPECT().InTx(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(fn func(database.Store) error, _ *database.TxOptions) error {
+			txErr = fn(tx)
+			return txErr
+		},
+	)
+
+	// Inside the TX: lock chat, pop queued message, insert fails.
+	tx.EXPECT().GetChatByIDForUpdate(gomock.Any(), chatID).Return(waitingChat, nil)
+	tx.EXPECT().PopNextQueuedMessage(gomock.Any(), chatID).Return(queuedMsg, nil)
+	tx.EXPECT().InsertChatMessages(gomock.Any(), gomock.Any()).Return(nil, insertErr)
+
+	// Invoke tryAutoPromoteQueuedMessage through the same InTx
+	// pattern the processChat defer uses. The test directly calls
+	// the production path to verify error propagation.
+	_ = db.InTx(func(txStore database.Store) error {
+		latestChat, err := txStore.GetChatByIDForUpdate(ctx, chatID)
+		if err != nil {
+			return err
+		}
+
+		_, _, _, promoteErr := server.tryAutoPromoteQueuedMessage(ctx, txStore, latestChat)
+		if promoteErr != nil {
+			return promoteErr
+		}
+
+		// This code path should not be reached when the insert
+		// fails, because promoteErr should be non-nil.
+		return nil
+	}, nil)
+
+	// The InTx callback must return a non-nil error so the
+	// transaction rolls back, preserving the queued message.
+	require.Error(t, txErr, "InTx callback should return error when insert fails")
+}
+
+// TestAutoPromote_WakesRunLoopAfterPromotion verifies that after the
+// processChat defer successfully auto-promotes a queued message to
+// pending status, signalWake is called so the run loop picks up the
+// chat immediately instead of waiting for the acquire ticker.
+func TestAutoPromote_WakesRunLoopAfterPromotion(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	ps := dbpubsub.NewInMemory()
+	clock := quartz.NewReal()
+
+	chatID := uuid.New()
+	workerID := uuid.New()
+	ownerID := uuid.New()
+	modelConfigID := uuid.New()
+
+	waitingChat := database.Chat{
+		ID:                chatID,
+		OwnerID:           ownerID,
+		LastModelConfigID: modelConfigID,
+		Status:            database.ChatStatusWaiting,
+		WorkerID:          uuid.NullUUID{UUID: workerID, Valid: true},
+	}
+	queuedMsg := database.ChatQueuedMessage{
+		ID:      1,
+		ChatID:  chatID,
+		Content: []byte(`[{"type":"text","text":"queued"}]`),
+	}
+	insertedMsg := database.ChatMessage{
+		ID:     42,
+		ChatID: chatID,
+		Role:   database.ChatMessageRoleUser,
+	}
+
+	wakeCh := make(chan struct{}, 1)
+	server := &Server{
+		db:                    db,
+		logger:                logger,
+		pubsub:                ps,
+		clock:                 clock,
+		workerID:              workerID,
+		wakeCh:                wakeCh,
+		chatHeartbeatInterval: time.Minute,
+		configCache:           newChatConfigCache(ctx, db, clock),
+		heartbeatRegistry:     make(map[uuid.UUID]*heartbeatEntry),
+	}
+
+	// Block model resolution until the control subscriber fires the
+	// interrupt. This gives us a controlled window: processChat has
+	// armed the control subscriber and published "running", and we
+	// can then publish an interrupt notification.
+	modelBlocked := make(chan struct{})
+	db.EXPECT().GetChatModelConfigByID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, _ uuid.UUID) (database.ChatModelConfig, error) {
+			<-modelBlocked
+			return database.ChatModelConfig{}, xerrors.New("no model")
+		},
+	).AnyTimes()
+	db.EXPECT().GetEnabledChatProviders(gomock.Any()).Return(nil, nil).AnyTimes()
+	db.EXPECT().GetEnabledChatModelConfigs(gomock.Any()).Return(nil, nil).AnyTimes()
+	db.EXPECT().GetChatUsageLimitConfig(gomock.Any()).Return(
+		database.ChatUsageLimitConfig{}, sql.ErrNoRows,
+	).AnyTimes()
+	db.EXPECT().GetChatMessagesForPromptByChatID(gomock.Any(), chatID).Return(nil, nil).AnyTimes()
+
+	// The deferred cleanup transaction: auto-promote the queued
+	// message, then update status to pending.
+	db.EXPECT().InTx(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(fn func(database.Store) error, _ *database.TxOptions) error {
+			return fn(db)
+		},
+	)
+	db.EXPECT().GetChatByIDForUpdate(gomock.Any(), chatID).Return(waitingChat, nil)
+	db.EXPECT().PopNextQueuedMessage(gomock.Any(), chatID).Return(queuedMsg, nil)
+	db.EXPECT().InsertChatMessages(gomock.Any(), gomock.Any()).Return(
+		[]database.ChatMessage{insertedMsg}, nil,
+	)
+	db.EXPECT().GetChatQueuedMessages(gomock.Any(), chatID).Return(nil, nil)
+	db.EXPECT().UpdateChatStatus(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, params database.UpdateChatStatusParams) (database.Chat, error) {
+			return database.Chat{
+				ID:      chatID,
+				OwnerID: ownerID,
+				Status:  params.Status,
+			}, nil
+		},
+	)
+
+	chat := database.Chat{ID: chatID, OwnerID: ownerID, LastModelConfigID: modelConfigID}
+	processDone := make(chan struct{})
+	go func() {
+		defer close(processDone)
+		server.processChat(ctx, chat)
+	}()
+
+	// Wait for processChat to publish "running" and arm the control
+	// subscriber. We detect this by subscribing to the stream
+	// notify channel and waiting for a "running" status.
+	runningCh := make(chan struct{}, 1)
+	unsubRunning, err := ps.SubscribeWithErr(
+		coderdpubsub.ChatStreamNotifyChannel(chatID),
+		func(_ context.Context, msg []byte, err error) {
+			if err != nil {
+				return
+			}
+			var notify coderdpubsub.ChatStreamNotifyMessage
+			if json.Unmarshal(msg, &notify) != nil {
+				return
+			}
+			if notify.Status == string(database.ChatStatusRunning) {
+				select {
+				case runningCh <- struct{}{}:
+				default:
+				}
+			}
+		},
+	)
+	require.NoError(t, err)
+	defer unsubRunning()
+
+	select {
+	case <-runningCh:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for running status")
+	}
+
+	// Now publish an interrupt on the control channel. The
+	// subscriber sees status=waiting and cancels the context
+	// with ErrInterrupted.
+	interruptMsg, err := json.Marshal(coderdpubsub.ChatStreamNotifyMessage{
+		Status: string(database.ChatStatusWaiting),
+	})
+	require.NoError(t, err)
+	err = ps.Publish(coderdpubsub.ChatStreamNotifyChannel(chatID), interruptMsg)
+	require.NoError(t, err)
+
+	// Unblock model resolution so runChat can exit.
+	close(modelBlocked)
+
+	// Wait for the full processChat (including post-TX defer
+	// code) to finish.
+	select {
+	case <-processDone:
+	case <-ctx.Done():
+		t.Fatal("processChat did not complete")
+	}
+
+	// The wake channel should have a pending signal because the
+	// auto-promote set status to pending.
+	select {
+	case <-wakeCh:
+		// Signal received.
+	default:
+		t.Fatal("wake channel should have a pending signal after auto-promote")
+	}
+}

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -2963,6 +2963,7 @@ func TestAutoPromote_WakesRunLoopAfterPromotion(t *testing.T) {
 	db.EXPECT().GetChatQueuedMessages(gomock.Any(), chatID).Return(nil, nil)
 	db.EXPECT().UpdateChatStatus(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, params database.UpdateChatStatusParams) (database.Chat, error) {
+			require.Equal(t, database.ChatStatusPending, params.Status)
 			return database.Chat{
 				ID:      chatID,
 				OwnerID: ownerID,
@@ -2971,16 +2972,9 @@ func TestAutoPromote_WakesRunLoopAfterPromotion(t *testing.T) {
 		},
 	)
 
-	chat := database.Chat{ID: chatID, OwnerID: ownerID, LastModelConfigID: modelConfigID}
-	processDone := make(chan struct{})
-	go func() {
-		defer close(processDone)
-		server.processChat(ctx, chat)
-	}()
-
-	// Wait for processChat to publish "running" and arm the control
-	// subscriber. We detect this by subscribing to the stream
-	// notify channel and waiting for a "running" status.
+	// Subscribe BEFORE launching the goroutine to avoid a race
+	// where processChat publishes "running" before the subscription
+	// registers.
 	runningCh := make(chan struct{}, 1)
 	unsubRunning, err := ps.SubscribeWithErr(
 		coderdpubsub.ChatStreamNotifyChannel(chatID),
@@ -3002,6 +2996,13 @@ func TestAutoPromote_WakesRunLoopAfterPromotion(t *testing.T) {
 	)
 	require.NoError(t, err)
 	defer unsubRunning()
+
+	chat := database.Chat{ID: chatID, OwnerID: ownerID, LastModelConfigID: modelConfigID}
+	processDone := make(chan struct{})
+	go func() {
+		defer close(processDone)
+		server.processChat(ctx, chat)
+	}()
 
 	select {
 	case <-runningCh:
@@ -3034,8 +3035,145 @@ func TestAutoPromote_WakesRunLoopAfterPromotion(t *testing.T) {
 	// auto-promote set status to pending.
 	select {
 	case <-wakeCh:
-		// Signal received.
+	// Signal received.
 	default:
 		t.Fatal("wake channel should have a pending signal after auto-promote")
+	}
+}
+
+// TestAutoPromote_InsertFailureSkipsStatusUpdate verifies that when
+// InsertChatMessages fails inside the deferred auto-promote transaction,
+// UpdateChatStatus is never called and no wake signal is sent.
+func TestAutoPromote_InsertFailureSkipsStatusUpdate(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+	tx := dbmock.NewMockStore(ctrl)
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	ps := dbpubsub.NewInMemory()
+	clock := quartz.NewReal()
+
+	chatID := uuid.New()
+	workerID := uuid.New()
+	ownerID := uuid.New()
+	modelConfigID := uuid.New()
+
+	waitingChat := database.Chat{
+		ID:                chatID,
+		OwnerID:           ownerID,
+		LastModelConfigID: modelConfigID,
+		Status:            database.ChatStatusWaiting,
+		WorkerID:          uuid.NullUUID{UUID: workerID, Valid: true},
+	}
+	queuedMsg := database.ChatQueuedMessage{
+		ID:      1,
+		ChatID:  chatID,
+		Content: []byte(`[{"type":"text","text":"queued"}]`),
+	}
+
+	wakeCh := make(chan struct{}, 1)
+	server := &Server{
+		db:                    db,
+		logger:                logger,
+		pubsub:                ps,
+		clock:                 clock,
+		workerID:              workerID,
+		wakeCh:                wakeCh,
+		chatHeartbeatInterval: time.Minute,
+		configCache:           newChatConfigCache(ctx, db, clock),
+		heartbeatRegistry:     make(map[uuid.UUID]*heartbeatEntry),
+	}
+
+	// Block model resolution until the control subscriber fires.
+	modelBlocked := make(chan struct{})
+	db.EXPECT().GetChatModelConfigByID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, _ uuid.UUID) (database.ChatModelConfig, error) {
+			<-modelBlocked
+			return database.ChatModelConfig{}, xerrors.New("no model")
+		},
+	).AnyTimes()
+	db.EXPECT().GetEnabledChatProviders(gomock.Any()).Return(nil, nil).AnyTimes()
+	db.EXPECT().GetEnabledChatModelConfigs(gomock.Any()).Return(nil, nil).AnyTimes()
+	db.EXPECT().GetChatUsageLimitConfig(gomock.Any()).Return(
+		database.ChatUsageLimitConfig{}, sql.ErrNoRows,
+	).AnyTimes()
+	db.EXPECT().GetChatMessagesForPromptByChatID(gomock.Any(), chatID).Return(nil, nil).AnyTimes()
+
+	// The deferred cleanup transaction: InsertChatMessages fails,
+	// so UpdateChatStatus must NOT be called.
+	db.EXPECT().InTx(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(fn func(database.Store) error, _ *database.TxOptions) error {
+			return fn(tx)
+		},
+	)
+	tx.EXPECT().GetChatByIDForUpdate(gomock.Any(), chatID).Return(waitingChat, nil)
+	tx.EXPECT().PopNextQueuedMessage(gomock.Any(), chatID).Return(queuedMsg, nil)
+	tx.EXPECT().InsertChatMessages(gomock.Any(), gomock.Any()).Return(
+		nil, xerrors.New("insert failed"),
+	)
+	tx.EXPECT().UpdateChatStatus(gomock.Any(), gomock.Any()).Times(0)
+
+	// Subscribe BEFORE launching the goroutine.
+	runningCh := make(chan struct{}, 1)
+	unsubRunning, err := ps.SubscribeWithErr(
+		coderdpubsub.ChatStreamNotifyChannel(chatID),
+		func(_ context.Context, msg []byte, err error) {
+			if err != nil {
+				return
+			}
+			var notify coderdpubsub.ChatStreamNotifyMessage
+			if json.Unmarshal(msg, &notify) != nil {
+				return
+			}
+			if notify.Status == string(database.ChatStatusRunning) {
+				select {
+				case runningCh <- struct{}{}:
+				default:
+				}
+			}
+		},
+	)
+	require.NoError(t, err)
+	defer unsubRunning()
+
+	chat := database.Chat{ID: chatID, OwnerID: ownerID, LastModelConfigID: modelConfigID}
+	processDone := make(chan struct{})
+	go func() {
+		defer close(processDone)
+		server.processChat(ctx, chat)
+	}()
+
+	select {
+	case <-runningCh:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for running status")
+	}
+
+	// Publish an interrupt so processChat exits runChat.
+	interruptMsg, err := json.Marshal(coderdpubsub.ChatStreamNotifyMessage{
+		Status: string(database.ChatStatusWaiting),
+	})
+	require.NoError(t, err)
+	err = ps.Publish(coderdpubsub.ChatStreamNotifyChannel(chatID), interruptMsg)
+	require.NoError(t, err)
+
+	// Unblock model resolution so runChat can exit.
+	close(modelBlocked)
+
+	select {
+	case <-processDone:
+	case <-ctx.Done():
+		t.Fatal("processChat did not complete")
+	}
+
+	// The wake channel should NOT have a signal because the
+	// transaction failed before reaching UpdateChatStatus.
+	select {
+	case <-wakeCh:
+		t.Fatal("wake channel should not have a signal after insert failure")
+	default:
+		// No signal, as expected.
 	}
 }

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -3524,9 +3524,9 @@ func TestProcessChat_IgnoresStaleControlNotification(t *testing.T) {
 		clock:                 clock,
 		workerID:              workerID,
 		chatHeartbeatInterval: time.Minute,
+		metrics:                chatloop.NopMetrics(),
 		configCache:           newChatConfigCache(ctx, db, clock),
 		heartbeatRegistry:     make(map[uuid.UUID]*heartbeatEntry),
-		metrics:               chatloop.NopMetrics(),
 	}
 
 	// Publish a stale "pending" notification on the control channel
@@ -3680,6 +3680,7 @@ func TestHeartbeatTick_StolenChatIsInterrupted(t *testing.T) {
 		clock:                 clock,
 		workerID:              workerID,
 		chatHeartbeatInterval: time.Minute,
+		metrics:                chatloop.NopMetrics(),
 		heartbeatRegistry:     make(map[uuid.UUID]*heartbeatEntry),
 	}
 
@@ -3760,6 +3761,7 @@ func TestHeartbeatTick_DBErrorDoesNotInterruptChats(t *testing.T) {
 		clock:                 clock,
 		workerID:              uuid.New(),
 		chatHeartbeatInterval: time.Minute,
+		metrics:                chatloop.NopMetrics(),
 		heartbeatRegistry:     make(map[uuid.UUID]*heartbeatEntry),
 	}
 
@@ -4716,4 +4718,407 @@ func TestGetWorkspaceConn_DialErrorNotMisclassifiedAsTimeout(t *testing.T) {
 	require.NotErrorIs(t, err, errChatDialTimeout)
 	// The original dial error should propagate.
 	require.ErrorContains(t, err, "authentication failed")
+}
+
+// TestAutoPromote_InsertFailureRollsBackTransaction verifies that when
+// tryAutoPromoteQueuedMessage pops a queued message but the subsequent
+// insert fails, the error propagates to the InTx callback, causing the
+// transaction to roll back and preserving the queued message.
+func TestAutoPromote_InsertFailureRollsBackTransaction(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+	tx := dbmock.NewMockStore(ctrl)
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	ps := dbpubsub.NewInMemory()
+	clock := quartz.NewReal()
+
+	chatID := uuid.New()
+	workerID := uuid.New()
+	ownerID := uuid.New()
+	modelConfigID := uuid.New()
+
+	waitingChat := database.Chat{
+		ID:                chatID,
+		OwnerID:           ownerID,
+		LastModelConfigID: modelConfigID,
+		Status:            database.ChatStatusWaiting,
+		WorkerID:          uuid.NullUUID{UUID: workerID, Valid: true},
+	}
+	queuedMsg := database.ChatQueuedMessage{
+		ID:      1,
+		ChatID:  chatID,
+		Content: []byte(`[{"type":"text","text":"queued"}]`),
+	}
+	insertErr := xerrors.New("insert failed")
+
+	server := &Server{
+		db:          db,
+		logger:      logger,
+		pubsub:      ps,
+		configCache: newChatConfigCache(ctx, db, clock),
+	}
+
+	// The caller runs tryAutoPromoteQueuedMessage inside InTx.
+	// Wire the mock to execute the callback against the TX mock.
+	var txErr error
+	db.EXPECT().InTx(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(fn func(database.Store) error, _ *database.TxOptions) error {
+			txErr = fn(tx)
+			return txErr
+		},
+	)
+
+	// Inside the TX: lock chat, get queued messages, resolve model
+	// config, pop queued message, insert fails.
+	tx.EXPECT().GetChatByIDForUpdate(gomock.Any(), chatID).Return(waitingChat, nil)
+	tx.EXPECT().GetChatQueuedMessages(gomock.Any(), chatID).Return([]database.ChatQueuedMessage{queuedMsg}, nil)
+	tx.EXPECT().GetChatModelConfigByID(gomock.Any(), modelConfigID).Return(database.ChatModelConfig{ID: modelConfigID}, nil)
+	tx.EXPECT().PopNextQueuedMessage(gomock.Any(), chatID).Return(queuedMsg, nil)
+	tx.EXPECT().InsertChatMessages(gomock.Any(), gomock.Any()).Return(nil, insertErr)
+
+	// Invoke tryAutoPromoteQueuedMessage through the same InTx
+	// pattern the processChat defer uses. The test directly calls
+	// the production path to verify error propagation.
+	_ = db.InTx(func(txStore database.Store) error {
+		latestChat, err := txStore.GetChatByIDForUpdate(ctx, chatID)
+		if err != nil {
+			return err
+		}
+
+		_, _, _, promoteErr := server.tryAutoPromoteQueuedMessage(ctx, txStore, latestChat)
+		if promoteErr != nil {
+			return promoteErr
+		}
+
+		// This code path should not be reached when the insert
+		// fails, because promoteErr should be non-nil.
+		return nil
+	}, nil)
+
+	// The InTx callback must return a non-nil error so the
+	// transaction rolls back, preserving the queued message.
+	require.Error(t, txErr, "InTx callback should return error when insert fails")
+}
+
+// TestAutoPromote_WakesRunLoopAfterPromotion verifies that after the
+// processChat defer successfully auto-promotes a queued message to
+// pending status, signalWake is called so the run loop picks up the
+// chat immediately instead of waiting for the acquire ticker.
+func TestAutoPromote_WakesRunLoopAfterPromotion(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	ps := dbpubsub.NewInMemory()
+	clock := quartz.NewReal()
+
+	chatID := uuid.New()
+	workerID := uuid.New()
+	ownerID := uuid.New()
+	modelConfigID := uuid.New()
+
+	waitingChat := database.Chat{
+		ID:                chatID,
+		OwnerID:           ownerID,
+		LastModelConfigID: modelConfigID,
+		Status:            database.ChatStatusWaiting,
+		WorkerID:          uuid.NullUUID{UUID: workerID, Valid: true},
+	}
+	queuedMsg := database.ChatQueuedMessage{
+		ID:      1,
+		ChatID:  chatID,
+		Content: []byte(`[{"type":"text","text":"queued"}]`),
+	}
+	insertedMsg := database.ChatMessage{
+		ID:     42,
+		ChatID: chatID,
+		Role:   database.ChatMessageRoleUser,
+	}
+
+	wakeCh := make(chan struct{}, 1)
+	server := &Server{
+		db:                    db,
+		logger:                logger,
+		pubsub:                ps,
+		clock:                 clock,
+		workerID:              workerID,
+		wakeCh:                wakeCh,
+		chatHeartbeatInterval: time.Minute,
+		metrics:                chatloop.NopMetrics(),
+		configCache:           newChatConfigCache(ctx, db, clock),
+		heartbeatRegistry:     make(map[uuid.UUID]*heartbeatEntry),
+	}
+
+	// Block model resolution until the control subscriber fires the
+	// interrupt. This gives us a controlled window: processChat has
+	// armed the control subscriber and published "running", and we
+	// can then publish an interrupt notification.
+	//
+	// The deferred auto-promote path also calls GetChatModelConfigByID
+	// with modelConfigID. By that point modelBlocked is closed, so we
+	// branch on the ID: return success for modelConfigID (auto-promote)
+	// and error for anything else (runChat model resolution).
+	modelBlocked := make(chan struct{})
+	db.EXPECT().GetChatModelConfigByID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, id uuid.UUID) (database.ChatModelConfig, error) {
+			<-modelBlocked
+			if id == modelConfigID {
+				return database.ChatModelConfig{ID: modelConfigID}, nil
+			}
+			return database.ChatModelConfig{}, xerrors.New("no model")
+		},
+	).AnyTimes()
+	db.EXPECT().GetEnabledChatProviders(gomock.Any()).Return(nil, nil).AnyTimes()
+	db.EXPECT().GetEnabledChatModelConfigs(gomock.Any()).Return(nil, nil).AnyTimes()
+	db.EXPECT().GetChatUsageLimitConfig(gomock.Any()).Return(
+		database.ChatUsageLimitConfig{}, sql.ErrNoRows,
+	).AnyTimes()
+	db.EXPECT().GetChatMessagesForPromptByChatID(gomock.Any(), chatID).Return(nil, nil).AnyTimes()
+
+	// The deferred cleanup transaction: auto-promote the queued
+	// message, then update status to pending.
+	db.EXPECT().InTx(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(fn func(database.Store) error, _ *database.TxOptions) error {
+			return fn(db)
+		},
+	)
+	db.EXPECT().GetChatByIDForUpdate(gomock.Any(), chatID).Return(waitingChat, nil)
+	db.EXPECT().GetChatQueuedMessages(gomock.Any(), chatID).Return([]database.ChatQueuedMessage{queuedMsg}, nil)
+	db.EXPECT().PopNextQueuedMessage(gomock.Any(), chatID).Return(queuedMsg, nil)
+	db.EXPECT().InsertChatMessages(gomock.Any(), gomock.Any()).Return(
+		[]database.ChatMessage{insertedMsg}, nil,
+	)
+	db.EXPECT().GetChatQueuedMessages(gomock.Any(), chatID).Return(nil, nil)
+	db.EXPECT().UpdateChatStatus(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, params database.UpdateChatStatusParams) (database.Chat, error) {
+			require.Equal(t, database.ChatStatusPending, params.Status)
+			return database.Chat{
+				ID:       chatID,
+				OwnerID:  ownerID,
+				Status:   params.Status,
+				WorkerID: uuid.NullUUID{},
+			}, nil
+		},
+	)
+	// shouldPublishFinishedChatState re-reads the chat to guard
+	// against stale publishes.
+	db.EXPECT().GetChatByID(gomock.Any(), chatID).Return(database.Chat{
+		ID:       chatID,
+		OwnerID:  ownerID,
+		Status:   database.ChatStatusPending,
+		WorkerID: uuid.NullUUID{},
+	}, nil)
+
+	// Subscribe BEFORE launching the goroutine to avoid a race
+	// where processChat publishes "running" before the subscription
+	// registers.
+	runningCh := make(chan struct{}, 1)
+	unsubRunning, err := ps.SubscribeWithErr(
+		coderdpubsub.ChatStreamNotifyChannel(chatID),
+		func(_ context.Context, msg []byte, err error) {
+			if err != nil {
+				return
+			}
+			var notify coderdpubsub.ChatStreamNotifyMessage
+			if json.Unmarshal(msg, &notify) != nil {
+				return
+			}
+			if notify.Status == string(database.ChatStatusRunning) {
+				select {
+				case runningCh <- struct{}{}:
+				default:
+				}
+			}
+		},
+	)
+	require.NoError(t, err)
+	defer unsubRunning()
+
+	chat := database.Chat{ID: chatID, OwnerID: ownerID, LastModelConfigID: modelConfigID}
+	processDone := make(chan struct{})
+	go func() {
+		defer close(processDone)
+		server.processChat(ctx, chat)
+	}()
+
+	select {
+	case <-runningCh:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for running status")
+	}
+
+	// Now publish an interrupt on the control channel. The
+	// subscriber sees status=waiting and cancels the context
+	// with ErrInterrupted.
+	interruptMsg, err := json.Marshal(coderdpubsub.ChatStreamNotifyMessage{
+		Status: string(database.ChatStatusWaiting),
+	})
+	require.NoError(t, err)
+	err = ps.Publish(coderdpubsub.ChatStreamNotifyChannel(chatID), interruptMsg)
+	require.NoError(t, err)
+
+	// Unblock model resolution so runChat can exit.
+	close(modelBlocked)
+
+	// Wait for the full processChat (including post-TX defer
+	// code) to finish.
+	select {
+	case <-processDone:
+	case <-ctx.Done():
+		t.Fatal("processChat did not complete")
+	}
+
+	// The wake channel should have a pending signal because the
+	// auto-promote set status to pending.
+	select {
+	case <-wakeCh:
+	// Signal received.
+	default:
+		t.Fatal("wake channel should have a pending signal after auto-promote")
+	}
+}
+
+// TestAutoPromote_InsertFailureSkipsStatusUpdate verifies that when
+// InsertChatMessages fails inside the deferred auto-promote transaction,
+// UpdateChatStatus is never called and no wake signal is sent.
+func TestAutoPromote_InsertFailureSkipsStatusUpdate(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+	tx := dbmock.NewMockStore(ctrl)
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	ps := dbpubsub.NewInMemory()
+	clock := quartz.NewReal()
+
+	chatID := uuid.New()
+	workerID := uuid.New()
+	ownerID := uuid.New()
+	modelConfigID := uuid.New()
+
+	waitingChat := database.Chat{
+		ID:                chatID,
+		OwnerID:           ownerID,
+		LastModelConfigID: modelConfigID,
+		Status:            database.ChatStatusWaiting,
+		WorkerID:          uuid.NullUUID{UUID: workerID, Valid: true},
+	}
+	queuedMsg := database.ChatQueuedMessage{
+		ID:      1,
+		ChatID:  chatID,
+		Content: []byte(`[{"type":"text","text":"queued"}]`),
+	}
+
+	wakeCh := make(chan struct{}, 1)
+	server := &Server{
+		db:                    db,
+		logger:                logger,
+		pubsub:                ps,
+		clock:                 clock,
+		workerID:              workerID,
+		wakeCh:                wakeCh,
+		chatHeartbeatInterval: time.Minute,
+		metrics:                chatloop.NopMetrics(),
+		configCache:           newChatConfigCache(ctx, db, clock),
+		heartbeatRegistry:     make(map[uuid.UUID]*heartbeatEntry),
+	}
+
+	// Block model resolution until the control subscriber fires.
+	modelBlocked := make(chan struct{})
+	db.EXPECT().GetChatModelConfigByID(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, _ uuid.UUID) (database.ChatModelConfig, error) {
+			<-modelBlocked
+			return database.ChatModelConfig{}, xerrors.New("no model")
+		},
+	).AnyTimes()
+	db.EXPECT().GetEnabledChatProviders(gomock.Any()).Return(nil, nil).AnyTimes()
+	db.EXPECT().GetEnabledChatModelConfigs(gomock.Any()).Return(nil, nil).AnyTimes()
+	db.EXPECT().GetChatUsageLimitConfig(gomock.Any()).Return(
+		database.ChatUsageLimitConfig{}, sql.ErrNoRows,
+	).AnyTimes()
+	db.EXPECT().GetChatMessagesForPromptByChatID(gomock.Any(), chatID).Return(nil, nil).AnyTimes()
+
+	// The deferred cleanup transaction: InsertChatMessages fails,
+	// so UpdateChatStatus must NOT be called.
+	db.EXPECT().InTx(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(fn func(database.Store) error, _ *database.TxOptions) error {
+			return fn(tx)
+		},
+	)
+	tx.EXPECT().GetChatByIDForUpdate(gomock.Any(), chatID).Return(waitingChat, nil)
+	tx.EXPECT().GetChatQueuedMessages(gomock.Any(), chatID).Return([]database.ChatQueuedMessage{queuedMsg}, nil)
+	tx.EXPECT().GetChatModelConfigByID(gomock.Any(), modelConfigID).Return(database.ChatModelConfig{ID: modelConfigID}, nil)
+	tx.EXPECT().PopNextQueuedMessage(gomock.Any(), chatID).Return(queuedMsg, nil)
+	tx.EXPECT().InsertChatMessages(gomock.Any(), gomock.Any()).Return(
+		nil, xerrors.New("insert failed"),
+	)
+	tx.EXPECT().UpdateChatStatus(gomock.Any(), gomock.Any()).Times(0)
+
+	// Subscribe BEFORE launching the goroutine.
+	runningCh := make(chan struct{}, 1)
+	unsubRunning, err := ps.SubscribeWithErr(
+		coderdpubsub.ChatStreamNotifyChannel(chatID),
+		func(_ context.Context, msg []byte, err error) {
+			if err != nil {
+				return
+			}
+			var notify coderdpubsub.ChatStreamNotifyMessage
+			if json.Unmarshal(msg, &notify) != nil {
+				return
+			}
+			if notify.Status == string(database.ChatStatusRunning) {
+				select {
+				case runningCh <- struct{}{}:
+				default:
+				}
+			}
+		},
+	)
+	require.NoError(t, err)
+	defer unsubRunning()
+
+	chat := database.Chat{ID: chatID, OwnerID: ownerID, LastModelConfigID: modelConfigID}
+	processDone := make(chan struct{})
+	go func() {
+		defer close(processDone)
+		server.processChat(ctx, chat)
+	}()
+
+	select {
+	case <-runningCh:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for running status")
+	}
+
+	// Publish an interrupt so processChat exits runChat.
+	interruptMsg, err := json.Marshal(coderdpubsub.ChatStreamNotifyMessage{
+		Status: string(database.ChatStatusWaiting),
+	})
+	require.NoError(t, err)
+	err = ps.Publish(coderdpubsub.ChatStreamNotifyChannel(chatID), interruptMsg)
+	require.NoError(t, err)
+
+	// Unblock model resolution so runChat can exit.
+	close(modelBlocked)
+
+	select {
+	case <-processDone:
+	case <-ctx.Done():
+		t.Fatal("processChat did not complete")
+	}
+
+	// The wake channel should NOT have a signal because the
+	// transaction failed before reaching UpdateChatStatus.
+	select {
+	case <-wakeCh:
+		t.Fatal("wake channel should not have a signal after insert failure")
+	default:
+		// No signal, as expected.
+	}
 }

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -3524,7 +3524,7 @@ func TestProcessChat_IgnoresStaleControlNotification(t *testing.T) {
 		clock:                 clock,
 		workerID:              workerID,
 		chatHeartbeatInterval: time.Minute,
-		metrics:                chatloop.NopMetrics(),
+		metrics:               chatloop.NopMetrics(),
 		configCache:           newChatConfigCache(ctx, db, clock),
 		heartbeatRegistry:     make(map[uuid.UUID]*heartbeatEntry),
 	}
@@ -3680,7 +3680,7 @@ func TestHeartbeatTick_StolenChatIsInterrupted(t *testing.T) {
 		clock:                 clock,
 		workerID:              workerID,
 		chatHeartbeatInterval: time.Minute,
-		metrics:                chatloop.NopMetrics(),
+		metrics:               chatloop.NopMetrics(),
 		heartbeatRegistry:     make(map[uuid.UUID]*heartbeatEntry),
 	}
 
@@ -3761,7 +3761,7 @@ func TestHeartbeatTick_DBErrorDoesNotInterruptChats(t *testing.T) {
 		clock:                 clock,
 		workerID:              uuid.New(),
 		chatHeartbeatInterval: time.Minute,
-		metrics:                chatloop.NopMetrics(),
+		metrics:               chatloop.NopMetrics(),
 		heartbeatRegistry:     make(map[uuid.UUID]*heartbeatEntry),
 	}
 
@@ -4804,188 +4804,6 @@ func TestAutoPromote_InsertFailureRollsBackTransaction(t *testing.T) {
 }
 
 // TestAutoPromote_WakesRunLoopAfterPromotion verifies that after the
-// processChat defer successfully auto-promotes a queued message to
-// pending status, signalWake is called so the run loop picks up the
-// chat immediately instead of waiting for the acquire ticker.
-func TestAutoPromote_WakesRunLoopAfterPromotion(t *testing.T) {
-	t.Parallel()
-
-	ctx := testutil.Context(t, testutil.WaitLong)
-	ctrl := gomock.NewController(t)
-	db := dbmock.NewMockStore(ctrl)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
-	ps := dbpubsub.NewInMemory()
-	clock := quartz.NewReal()
-
-	chatID := uuid.New()
-	workerID := uuid.New()
-	ownerID := uuid.New()
-	modelConfigID := uuid.New()
-
-	waitingChat := database.Chat{
-		ID:                chatID,
-		OwnerID:           ownerID,
-		LastModelConfigID: modelConfigID,
-		Status:            database.ChatStatusWaiting,
-		WorkerID:          uuid.NullUUID{UUID: workerID, Valid: true},
-	}
-	queuedMsg := database.ChatQueuedMessage{
-		ID:      1,
-		ChatID:  chatID,
-		Content: []byte(`[{"type":"text","text":"queued"}]`),
-	}
-	insertedMsg := database.ChatMessage{
-		ID:     42,
-		ChatID: chatID,
-		Role:   database.ChatMessageRoleUser,
-	}
-
-	wakeCh := make(chan struct{}, 1)
-	server := &Server{
-		db:                    db,
-		logger:                logger,
-		pubsub:                ps,
-		clock:                 clock,
-		workerID:              workerID,
-		wakeCh:                wakeCh,
-		chatHeartbeatInterval: time.Minute,
-		metrics:                chatloop.NopMetrics(),
-		configCache:           newChatConfigCache(ctx, db, clock),
-		heartbeatRegistry:     make(map[uuid.UUID]*heartbeatEntry),
-	}
-
-	// Block model resolution until the control subscriber fires the
-	// interrupt. This gives us a controlled window: processChat has
-	// armed the control subscriber and published "running", and we
-	// can then publish an interrupt notification.
-	//
-	// The deferred auto-promote path also calls GetChatModelConfigByID
-	// with modelConfigID. By that point modelBlocked is closed, so we
-	// branch on the ID: return success for modelConfigID (auto-promote)
-	// and error for anything else (runChat model resolution).
-	modelBlocked := make(chan struct{})
-	db.EXPECT().GetChatModelConfigByID(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(ctx context.Context, id uuid.UUID) (database.ChatModelConfig, error) {
-			<-modelBlocked
-			if id == modelConfigID {
-				return database.ChatModelConfig{ID: modelConfigID}, nil
-			}
-			return database.ChatModelConfig{}, xerrors.New("no model")
-		},
-	).AnyTimes()
-	db.EXPECT().GetEnabledChatProviders(gomock.Any()).Return(nil, nil).AnyTimes()
-	db.EXPECT().GetEnabledChatModelConfigs(gomock.Any()).Return(nil, nil).AnyTimes()
-	db.EXPECT().GetChatUsageLimitConfig(gomock.Any()).Return(
-		database.ChatUsageLimitConfig{}, sql.ErrNoRows,
-	).AnyTimes()
-	db.EXPECT().GetChatMessagesForPromptByChatID(gomock.Any(), chatID).Return(nil, nil).AnyTimes()
-
-	// The deferred cleanup transaction: auto-promote the queued
-	// message, then update status to pending.
-	db.EXPECT().InTx(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(fn func(database.Store) error, _ *database.TxOptions) error {
-			return fn(db)
-		},
-	)
-	db.EXPECT().GetChatByIDForUpdate(gomock.Any(), chatID).Return(waitingChat, nil)
-	db.EXPECT().GetChatQueuedMessages(gomock.Any(), chatID).Return([]database.ChatQueuedMessage{queuedMsg}, nil)
-	db.EXPECT().PopNextQueuedMessage(gomock.Any(), chatID).Return(queuedMsg, nil)
-	db.EXPECT().InsertChatMessages(gomock.Any(), gomock.Any()).Return(
-		[]database.ChatMessage{insertedMsg}, nil,
-	)
-	db.EXPECT().GetChatQueuedMessages(gomock.Any(), chatID).Return(nil, nil)
-	db.EXPECT().UpdateChatStatus(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, params database.UpdateChatStatusParams) (database.Chat, error) {
-			require.Equal(t, database.ChatStatusPending, params.Status)
-			return database.Chat{
-				ID:       chatID,
-				OwnerID:  ownerID,
-				Status:   params.Status,
-				WorkerID: uuid.NullUUID{},
-			}, nil
-		},
-	)
-	// shouldPublishFinishedChatState re-reads the chat to guard
-	// against stale publishes.
-	db.EXPECT().GetChatByID(gomock.Any(), chatID).Return(database.Chat{
-		ID:       chatID,
-		OwnerID:  ownerID,
-		Status:   database.ChatStatusPending,
-		WorkerID: uuid.NullUUID{},
-	}, nil)
-
-	// Subscribe BEFORE launching the goroutine to avoid a race
-	// where processChat publishes "running" before the subscription
-	// registers.
-	runningCh := make(chan struct{}, 1)
-	unsubRunning, err := ps.SubscribeWithErr(
-		coderdpubsub.ChatStreamNotifyChannel(chatID),
-		func(_ context.Context, msg []byte, err error) {
-			if err != nil {
-				return
-			}
-			var notify coderdpubsub.ChatStreamNotifyMessage
-			if json.Unmarshal(msg, &notify) != nil {
-				return
-			}
-			if notify.Status == string(database.ChatStatusRunning) {
-				select {
-				case runningCh <- struct{}{}:
-				default:
-				}
-			}
-		},
-	)
-	require.NoError(t, err)
-	defer unsubRunning()
-
-	chat := database.Chat{ID: chatID, OwnerID: ownerID, LastModelConfigID: modelConfigID}
-	processDone := make(chan struct{})
-	go func() {
-		defer close(processDone)
-		server.processChat(ctx, chat)
-	}()
-
-	select {
-	case <-runningCh:
-	case <-ctx.Done():
-		t.Fatal("timed out waiting for running status")
-	}
-
-	// Now publish an interrupt on the control channel. The
-	// subscriber sees status=waiting and cancels the context
-	// with ErrInterrupted.
-	interruptMsg, err := json.Marshal(coderdpubsub.ChatStreamNotifyMessage{
-		Status: string(database.ChatStatusWaiting),
-	})
-	require.NoError(t, err)
-	err = ps.Publish(coderdpubsub.ChatStreamNotifyChannel(chatID), interruptMsg)
-	require.NoError(t, err)
-
-	// Unblock model resolution so runChat can exit.
-	close(modelBlocked)
-
-	// Wait for the full processChat (including post-TX defer
-	// code) to finish.
-	select {
-	case <-processDone:
-	case <-ctx.Done():
-		t.Fatal("processChat did not complete")
-	}
-
-	// The wake channel should have a pending signal because the
-	// auto-promote set status to pending.
-	select {
-	case <-wakeCh:
-	// Signal received.
-	default:
-		t.Fatal("wake channel should have a pending signal after auto-promote")
-	}
-}
-
-// TestAutoPromote_InsertFailureSkipsStatusUpdate verifies that when
-// InsertChatMessages fails inside the deferred auto-promote transaction,
-// UpdateChatStatus is never called and no wake signal is sent.
 func TestAutoPromote_InsertFailureSkipsStatusUpdate(t *testing.T) {
 	t.Parallel()
 
@@ -5024,7 +4842,7 @@ func TestAutoPromote_InsertFailureSkipsStatusUpdate(t *testing.T) {
 		workerID:              workerID,
 		wakeCh:                wakeCh,
 		chatHeartbeatInterval: time.Minute,
-		metrics:                chatloop.NopMetrics(),
+		metrics:               chatloop.NopMetrics(),
 		configCache:           newChatConfigCache(ctx, db, clock),
 		heartbeatRegistry:     make(map[uuid.UUID]*heartbeatEntry),
 	}

--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -1118,22 +1118,10 @@ func TestInterruptAutoPromotionIgnoresLaterUsageLimitIncrease(t *testing.T) {
 	acquireTrap := clock.Trap().NewTicker("chatd", "acquire")
 	defer acquireTrap.Close()
 
-	assertPendingWithoutQueuedMessages := func(chatID uuid.UUID) {
-		t.Helper()
-
-		queued, dbErr := db.GetChatQueuedMessages(ctx, chatID)
-		require.NoError(t, dbErr)
-		require.Empty(t, queued)
-
-		fromDB, dbErr := db.GetChatByID(ctx, chatID)
-		require.NoError(t, dbErr)
-		require.Equal(t, database.ChatStatusPending, fromDB.Status)
-		require.False(t, fromDB.WorkerID.Valid)
-	}
-
 	streamStarted := make(chan struct{})
 	interrupted := make(chan struct{})
 	secondRequestStarted := make(chan struct{})
+	secondRequestReady := make(chan struct{})
 	thirdRequestStarted := make(chan struct{})
 	allowFinish := make(chan struct{})
 	var requestCount atomic.Int32
@@ -1163,7 +1151,20 @@ func TestInterruptAutoPromotionIgnoresLaterUsageLimitIncrease(t *testing.T) {
 			}()
 			return chattest.OpenAIResponse{StreamingChunks: chunks}
 		case 2:
+			// Signal that the second request started. signalWake after
+			// auto-promote causes this to fire immediately rather than
+			// waiting for a clock advance. Block until the test has
+			// queued the next message and inserted the spend record.
 			close(secondRequestStarted)
+			chunks := make(chan chattest.OpenAIChunk, 10)
+			go func() {
+				defer close(chunks)
+				<-secondRequestReady
+				for _, chunk := range chattest.OpenAITextChunks("done") {
+					chunks <- chunk
+				}
+			}()
+			return chattest.OpenAIResponse{StreamingChunks: chunks}
 		case 3:
 			close(thirdRequestStarted)
 		}
@@ -1207,12 +1208,16 @@ func TestInterruptAutoPromotionIgnoresLaterUsageLimitIncrease(t *testing.T) {
 	testutil.TryReceive(ctx, t, interrupted)
 
 	close(allowFinish)
-	chatd.WaitUntilIdleForTest(server)
-	assertPendingWithoutQueuedMessages(chat.ID)
 
-	// Keep the acquire loop frozen here so "queued" stays pending.
-	// That makes the later send queue because the chat is still busy,
-	// rather than because the scheduler happened to be slow.
+	// signalWake after auto-promote causes the run loop to pick up
+	// the pending chat immediately, so the second request starts
+	// before any clock advance. Wait for it here.
+	testutil.TryReceive(ctx, t, secondRequestStarted)
+
+	// While the second request is running, queue another message
+	// and exhaust the usage limit. The queued message was already
+	// admitted through SendMessage, so auto-promote should still
+	// process it despite the limit increase.
 	laterQueuedResult, err := server.SendMessage(ctx, chatd.SendMessageOptions{
 		ChatID:  chat.ID,
 		Content: []codersdk.ChatMessagePart{codersdk.ChatMessageText("later queued")},
@@ -1260,12 +1265,9 @@ func TestInterruptAutoPromotionIgnoresLaterUsageLimitIncrease(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	clock.Advance(acquireInterval).MustWait(ctx)
-	testutil.TryReceive(ctx, t, secondRequestStarted)
-	chatd.WaitUntilIdleForTest(server)
-	assertPendingWithoutQueuedMessages(chat.ID)
-
-	clock.Advance(acquireInterval).MustWait(ctx)
+	// Unblock the second request so it completes and auto-promotes
+	// "later queued". signalWake triggers the third request.
+	close(secondRequestReady)
 	testutil.TryReceive(ctx, t, thirdRequestStarted)
 	chatd.WaitUntilIdleForTest(server)
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -729,7 +729,14 @@ describe("useChatStore", () => {
 		});
 
 		await waitFor(() => {
-			expect(result.current.streamState).toBeNull();
+			// Stream state is preserved after status=pending (the
+			// durable message event handles cleanup via
+			// needsStreamReset). Only new message_parts should be
+			// blocked by the shouldApplyMessagePart gate.
+			expect(result.current.streamState).not.toBeNull();
+			expect(result.current.streamState?.blocks).toEqual([
+				{ type: "response", text: "first" },
+			]);
 		});
 
 		act(() => {
@@ -747,7 +754,12 @@ describe("useChatStore", () => {
 		});
 
 		await waitFor(() => {
-			expect(result.current.streamState).toBeNull();
+			// The late message_part should not be applied because
+			// shouldApplyMessagePart gates on pending/waiting.
+			// Stream state still shows the original "first".
+			expect(result.current.streamState?.blocks).toEqual([
+				{ type: "response", text: "first" },
+			]);
 		});
 	});
 
@@ -3029,6 +3041,172 @@ describe("useChatStore", () => {
 		// WS already delivered a status event for this chat.
 		await waitFor(() => {
 			expect(result.current.chatStatus).toBe("running");
+		});
+	});
+
+	it("preserves stream state when status transitions to waiting", async () => {
+		immediateAnimationFrame();
+
+		const chatID = "chat-preserve-stream";
+		const existingMessage = makeMessage(chatID, 1, "user", "hello");
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createTestQueryClient();
+		const wrapper = ({ children }: PropsWithChildren) => (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+		const setChatErrorReason = vi.fn();
+		const clearChatErrorReason = vi.fn();
+
+		const { result } = renderHook(
+			() => {
+				const { store } = useChatStore({
+					chatID,
+					chatMessages: [existingMessage],
+					chatRecord: makeChat(chatID),
+					chatMessagesData: {
+						messages: [existingMessage],
+						queued_messages: [],
+						has_more: false,
+					},
+					chatQueuedMessages: [],
+					setChatErrorReason,
+					clearChatErrorReason,
+				});
+				return {
+					streamState: useChatSelector(store, selectStreamState),
+				};
+			},
+			{ wrapper },
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, 1);
+		});
+
+		// Build up stream state with a message_part.
+		act(() => {
+			mockSocket.emitData({
+				type: "message_part",
+				chat_id: chatID,
+				message_part: {
+					role: "assistant",
+					part: { type: "text", text: "thinking..." },
+				},
+			});
+		});
+
+		await waitFor(() => {
+			expect(result.current.streamState?.blocks).toEqual([
+				{ type: "response", text: "thinking..." },
+			]);
+		});
+
+		// Deliver a status=waiting event (interrupt). Stream state
+		// should be preserved so the user continues to see the
+		// partial response until the durable message arrives.
+		act(() => {
+			mockSocket.emitData({
+				type: "status",
+				chat_id: chatID,
+				status: { status: "waiting" },
+			});
+		});
+
+		await waitFor(() => {
+			expect(result.current.streamState).not.toBeNull();
+			expect(result.current.streamState?.blocks).toEqual([
+				{ type: "response", text: "thinking..." },
+			]);
+		});
+	});
+
+	it("clears stream state when durable message follows waiting status", async () => {
+		immediateAnimationFrame();
+
+		const chatID = "chat-durable-clears";
+		const existingMessage = makeMessage(chatID, 1, "user", "hello");
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createTestQueryClient();
+		const wrapper = ({ children }: PropsWithChildren) => (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+		const setChatErrorReason = vi.fn();
+		const clearChatErrorReason = vi.fn();
+
+		const { result } = renderHook(
+			() => {
+				const { store } = useChatStore({
+					chatID,
+					chatMessages: [existingMessage],
+					chatRecord: makeChat(chatID),
+					chatMessagesData: {
+						messages: [existingMessage],
+						queued_messages: [],
+						has_more: false,
+					},
+					chatQueuedMessages: [],
+					setChatErrorReason,
+					clearChatErrorReason,
+				});
+				return {
+					streamState: useChatSelector(store, selectStreamState),
+					orderedIDs: useChatSelector(store, selectOrderedMessageIDs),
+				};
+			},
+			{ wrapper },
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, 1);
+		});
+
+		// Build up stream state.
+		act(() => {
+			mockSocket.emitData({
+				type: "message_part",
+				chat_id: chatID,
+				message_part: {
+					role: "assistant",
+					part: { type: "text", text: "partial response" },
+				},
+			});
+		});
+
+		await waitFor(() => {
+			expect(result.current.streamState?.blocks).toEqual([
+				{ type: "response", text: "partial response" },
+			]);
+		});
+
+		// Deliver status=waiting (interrupt) followed by a durable
+		// assistant message. Stream state should be preserved through
+		// the status change, then cleared by the durable message via
+		// the needsStreamReset path.
+		act(() => {
+			mockSocket.emitDataBatch([
+				{
+					type: "status",
+					chat_id: chatID,
+					status: { status: "waiting" },
+				},
+				{
+					type: "message",
+					chat_id: chatID,
+					message: makeMessage(chatID, 2, "assistant", "partial response"),
+				},
+			]);
+		});
+
+		// After the batch, stream state should be null (cleared by
+		// needsStreamReset) and the durable message should be in
+		// the message store.
+		await waitFor(() => {
+			expect(result.current.streamState).toBeNull();
+			expect(result.current.orderedIDs).toContain(2);
 		});
 	});
 });

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -3182,28 +3182,37 @@ describe("useChatStore", () => {
 			]);
 		});
 
-		// Deliver status=waiting (interrupt) followed by a durable
-		// assistant message. Stream state should be preserved through
-		// the status change, then cleared by the durable message via
-		// the needsStreamReset path.
+		// Deliver status=waiting (interrupt). Stream state should be
+		// preserved so the user continues to see the partial response
+		// until the durable message arrives.
 		act(() => {
-			mockSocket.emitDataBatch([
-				{
-					type: "status",
-					chat_id: chatID,
-					status: { status: "waiting" },
-				},
-				{
-					type: "message",
-					chat_id: chatID,
-					message: makeMessage(chatID, 2, "assistant", "partial response"),
-				},
+			mockSocket.emitData({
+				type: "status",
+				chat_id: chatID,
+				status: { status: "waiting" },
+			});
+		});
+
+		// Stream state must still be present after the status change.
+		await waitFor(() => {
+			expect(result.current.streamState).not.toBeNull();
+			expect(result.current.streamState?.blocks).toEqual([
+				{ type: "response", text: "partial response" },
 			]);
 		});
 
-		// After the batch, stream state should be null (cleared by
-		// needsStreamReset) and the durable message should be in
-		// the message store.
+		// Now deliver the durable assistant message. This should
+		// clear stream state via the needsStreamReset path.
+		act(() => {
+			mockSocket.emitData({
+				type: "message",
+				chat_id: chatID,
+				message: makeMessage(chatID, 2, "assistant", "partial response"),
+			});
+		});
+
+		// Stream state should now be null and the durable message
+		// should be in the message store.
 		await waitFor(() => {
 			expect(result.current.streamState).toBeNull();
 			expect(result.current.orderedIDs).toContain(2);

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -3187,28 +3187,37 @@ describe("useChatStore", () => {
 			]);
 		});
 
-		// Deliver status=waiting (interrupt) followed by a durable
-		// assistant message. Stream state should be preserved through
-		// the status change, then cleared by the durable message via
-		// the needsStreamReset path.
+		// Deliver status=waiting (interrupt). Stream state should be
+		// preserved so the user continues to see the partial response
+		// until the durable message arrives.
 		act(() => {
-			mockSocket.emitDataBatch([
-				{
-					type: "status",
-					chat_id: chatID,
-					status: { status: "waiting" },
-				},
-				{
-					type: "message",
-					chat_id: chatID,
-					message: makeMessage(chatID, 2, "assistant", "partial response"),
-				},
+			mockSocket.emitData({
+				type: "status",
+				chat_id: chatID,
+				status: { status: "waiting" },
+			});
+		});
+
+		// Stream state must still be present after the status change.
+		await waitFor(() => {
+			expect(result.current.streamState).not.toBeNull();
+			expect(result.current.streamState?.blocks).toEqual([
+				{ type: "response", text: "partial response" },
 			]);
 		});
 
-		// After the batch, stream state should be null (cleared by
-		// needsStreamReset) and the durable message should be in
-		// the message store.
+		// Now deliver the durable assistant message. This should
+		// clear stream state via the needsStreamReset path.
+		act(() => {
+			mockSocket.emitData({
+				type: "message",
+				chat_id: chatID,
+				message: makeMessage(chatID, 2, "assistant", "partial response"),
+			});
+		});
+
+		// Stream state should now be null and the durable message
+		// should be in the message store.
 		await waitFor(() => {
 			expect(result.current.streamState).toBeNull();
 			expect(result.current.orderedIDs).toContain(2);

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -731,7 +731,14 @@ describe("useChatStore", () => {
 		});
 
 		await waitFor(() => {
-			expect(result.current.streamState).toBeNull();
+			// Stream state is preserved after status=pending (the
+			// durable message event handles cleanup via
+			// needsStreamReset). Only new message_parts should be
+			// blocked by the shouldApplyMessagePart gate.
+			expect(result.current.streamState).not.toBeNull();
+			expect(result.current.streamState?.blocks).toEqual([
+				{ type: "response", text: "first" },
+			]);
 		});
 
 		act(() => {
@@ -749,7 +756,12 @@ describe("useChatStore", () => {
 		});
 
 		await waitFor(() => {
-			expect(result.current.streamState).toBeNull();
+			// The late message_part should not be applied because
+			// shouldApplyMessagePart gates on pending/waiting.
+			// Stream state still shows the original "first".
+			expect(result.current.streamState?.blocks).toEqual([
+				{ type: "response", text: "first" },
+			]);
 		});
 	});
 
@@ -3034,6 +3046,172 @@ describe("useChatStore", () => {
 		// WS already delivered a status event for this chat.
 		await waitFor(() => {
 			expect(result.current.chatStatus).toBe("running");
+		});
+	});
+
+	it("preserves stream state when status transitions to waiting", async () => {
+		immediateAnimationFrame();
+
+		const chatID = "chat-preserve-stream";
+		const existingMessage = makeMessage(chatID, 1, "user", "hello");
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createTestQueryClient();
+		const wrapper = ({ children }: PropsWithChildren) => (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+		const setChatErrorReason = vi.fn();
+		const clearChatErrorReason = vi.fn();
+
+		const { result } = renderHook(
+			() => {
+				const { store } = useChatStore({
+					chatID,
+					chatMessages: [existingMessage],
+					chatRecord: makeChat(chatID),
+					chatMessagesData: {
+						messages: [existingMessage],
+						queued_messages: [],
+						has_more: false,
+					},
+					chatQueuedMessages: [],
+					setChatErrorReason,
+					clearChatErrorReason,
+				});
+				return {
+					streamState: useChatSelector(store, selectStreamState),
+				};
+			},
+			{ wrapper },
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, 1);
+		});
+
+		// Build up stream state with a message_part.
+		act(() => {
+			mockSocket.emitData({
+				type: "message_part",
+				chat_id: chatID,
+				message_part: {
+					role: "assistant",
+					part: { type: "text", text: "thinking..." },
+				},
+			});
+		});
+
+		await waitFor(() => {
+			expect(result.current.streamState?.blocks).toEqual([
+				{ type: "response", text: "thinking..." },
+			]);
+		});
+
+		// Deliver a status=waiting event (interrupt). Stream state
+		// should be preserved so the user continues to see the
+		// partial response until the durable message arrives.
+		act(() => {
+			mockSocket.emitData({
+				type: "status",
+				chat_id: chatID,
+				status: { status: "waiting" },
+			});
+		});
+
+		await waitFor(() => {
+			expect(result.current.streamState).not.toBeNull();
+			expect(result.current.streamState?.blocks).toEqual([
+				{ type: "response", text: "thinking..." },
+			]);
+		});
+	});
+
+	it("clears stream state when durable message follows waiting status", async () => {
+		immediateAnimationFrame();
+
+		const chatID = "chat-durable-clears";
+		const existingMessage = makeMessage(chatID, 1, "user", "hello");
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createTestQueryClient();
+		const wrapper = ({ children }: PropsWithChildren) => (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+		const setChatErrorReason = vi.fn();
+		const clearChatErrorReason = vi.fn();
+
+		const { result } = renderHook(
+			() => {
+				const { store } = useChatStore({
+					chatID,
+					chatMessages: [existingMessage],
+					chatRecord: makeChat(chatID),
+					chatMessagesData: {
+						messages: [existingMessage],
+						queued_messages: [],
+						has_more: false,
+					},
+					chatQueuedMessages: [],
+					setChatErrorReason,
+					clearChatErrorReason,
+				});
+				return {
+					streamState: useChatSelector(store, selectStreamState),
+					orderedIDs: useChatSelector(store, selectOrderedMessageIDs),
+				};
+			},
+			{ wrapper },
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, 1);
+		});
+
+		// Build up stream state.
+		act(() => {
+			mockSocket.emitData({
+				type: "message_part",
+				chat_id: chatID,
+				message_part: {
+					role: "assistant",
+					part: { type: "text", text: "partial response" },
+				},
+			});
+		});
+
+		await waitFor(() => {
+			expect(result.current.streamState?.blocks).toEqual([
+				{ type: "response", text: "partial response" },
+			]);
+		});
+
+		// Deliver status=waiting (interrupt) followed by a durable
+		// assistant message. Stream state should be preserved through
+		// the status change, then cleared by the durable message via
+		// the needsStreamReset path.
+		act(() => {
+			mockSocket.emitDataBatch([
+				{
+					type: "status",
+					chat_id: chatID,
+					status: { status: "waiting" },
+				},
+				{
+					type: "message",
+					chat_id: chatID,
+					message: makeMessage(chatID, 2, "assistant", "partial response"),
+				},
+			]);
+		});
+
+		// After the batch, stream state should be null (cleared by
+		// needsStreamReset) and the durable message should be in
+		// the message store.
+		await waitFor(() => {
+			expect(result.current.streamState).toBeNull();
+			expect(result.current.orderedIDs).toContain(2);
 		});
 	});
 });

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -497,7 +497,6 @@ export const useChatStore = (
 							store.setChatStatus(nextStatus);
 							if (nextStatus === "pending" || nextStatus === "waiting") {
 								discardBufferedParts();
-								store.clearStreamState();
 								store.clearRetryState();
 							}
 							if (nextStatus === "running") {

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -379,9 +379,9 @@ export const useChatStore = (
 		};
 
 		// Discard buffered parts without applying them. Used when
-		// stream state is about to be cleared (pending, waiting,
-		// retry) — flushing would re-populate the state that the
-		// event is about to clear.
+		// the stream is no longer active (pending, waiting, retry)
+		// so stale buffered parts are not applied after the
+		// status transition.
 		const discardBufferedParts = () => {
 			partsBuf.length = 0;
 			if (partsFlushTimer !== null) {

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -390,9 +390,9 @@ export const useChatStore = (
 		};
 
 		// Discard buffered parts without applying them. Used when
-		// stream state is about to be cleared (pending, waiting,
-		// retry) — flushing would re-populate the state that the
-		// event is about to clear.
+		// the stream is no longer active (pending, waiting, retry)
+		// so stale buffered parts are not applied after the
+		// status transition.
 		const discardBufferedParts = () => {
 			partsBuf.length = 0;
 			if (partsFlushTimer !== null) {

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -508,7 +508,6 @@ export const useChatStore = (
 							store.setChatStatus(nextStatus);
 							if (nextStatus === "pending" || nextStatus === "waiting") {
 								discardBufferedParts();
-								store.clearStreamState();
 								store.clearRetryState();
 							}
 							if (nextStatus === "running") {


### PR DESCRIPTION
## Problem

When a user promotes a queued message while the chat is running, `PromoteQueued` sets status to `pending`, the control subscriber treats this as an interrupt, and two things go wrong: the frontend clears the visible streaming content before the durable message replaces it (jarring flash), and the auto-promote path silently loses queued messages if the insert fails.

Fixes https://linear.app/codercom/issue/CODAGT-61

## Fix

Two changes:

1. **Auto-promote error propagation**: `tryAutoPromoteQueuedMessage` now returns the insert error instead of swallowing it. The caller in `finishActiveChat` propagates it to the `InTx` callback return, causing the transaction to roll back and preserving the queued message. Previously the POP DELETE committed while the INSERT silently failed, permanently losing the message.

2. **Frontend stream state preservation**: Removed `clearStreamState()` from the `pending`/`waiting` status handler. The durable message event clears stream state via the existing `needsStreamReset` path, eliminating the visual gap between interrupt and message persistence.

<details>
<summary>Plan and research (Coder Agents generated)</summary>

Plan: `docs/plans/interrupt-clears-streaming-message.md`
Research: `docs/plans/interrupt-clears-streaming-message-research.md`
Trace: `docs/plans/interrupt-clears-streaming-message-trace.md`

Note: the research document (Finding 1) incorrectly attributes the interrupt trigger to `InterruptChat`/stop button. The actual trigger is `PromoteQueued` setting status to `pending`, which the control subscriber treats as an interrupt. The code fix is correct for both paths.

</details>

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻
