### PR TITLE
docs: use coder-api-token instead of coder-session-token

### DIFF
--- a/docs/ai-coder/ai-gateway/clients/claude-code.md
+++ b/docs/ai-coder/ai-gateway/clients/claude-code.md
@@ -1,6 +1,6 @@
 # Claude Code
 
-Claude Code can be configured using environment variables. All modes require a **[Coder session token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)** for authentication with AI Gateway.
+Claude Code can be configured using environment variables. All modes require a **[Coder API token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)** for authentication with AI Gateway.
 
 ## Centralized API Key
 
@@ -8,8 +8,8 @@ Claude Code can be configured using environment variables. All modes require a *
 # AI Gateway base URL.
 export ANTHROPIC_BASE_URL="<your-deployment-url>/api/v2/aibridge/anthropic"
 
-# Your Coder session token, used for authentication with AI Gateway.
-export ANTHROPIC_AUTH_TOKEN="<your-coder-session-token>"
+# Your Coder API token, used for authentication with AI Gateway.
+export ANTHROPIC_AUTH_TOKEN="<your-coder-api-token>"
 ```
 
 ## BYOK (Personal API Key)
@@ -21,8 +21,8 @@ export ANTHROPIC_BASE_URL="<your-deployment-url>/api/v2/aibridge/anthropic"
 # Your personal Anthropic API key, forwarded to Anthropic.
 export ANTHROPIC_API_KEY="<your-anthropic-api-key>"
 
-# Your Coder session token, used for authentication with AI Gateway.
-export ANTHROPIC_CUSTOM_HEADERS="X-Coder-AI-Governance-Token: <your-coder-session-token>"
+# Your Coder API token, used for authentication with AI Gateway.
+export ANTHROPIC_CUSTOM_HEADERS="X-Coder-AI-Governance-Token: <your-coder-api-token>"
 
 # Ensure no auth token is set so Claude Code uses the API key instead.
 unset ANTHROPIC_AUTH_TOKEN
@@ -34,8 +34,8 @@ unset ANTHROPIC_AUTH_TOKEN
 # AI Gateway base URL.
 export ANTHROPIC_BASE_URL="<your-deployment-url>/api/v2/aibridge/anthropic"
 
-# Your Coder session token, used for authentication with AI Gateway.
-export ANTHROPIC_CUSTOM_HEADERS="X-Coder-AI-Governance-Token: <your-coder-session-token>"
+# Your Coder API token, used for authentication with AI Gateway.
+export ANTHROPIC_CUSTOM_HEADERS="X-Coder-AI-Governance-Token: <your-coder-api-token>"
 
 # Ensure no auth token is set so Claude Code uses subscription login instead.
 unset ANTHROPIC_AUTH_TOKEN

--- a/docs/ai-coder/ai-gateway/clients/cline.md
+++ b/docs/ai-coder/ai-gateway/clients/cline.md
@@ -17,7 +17,7 @@ To configure Cline to use AI Gateway, follow these steps:
 1. Go to **Settings**.
 1. **API Provider**: Select **OpenAI Compatible**.
 1. **Base URL**: Enter `https://coder.example.com/api/v2/aibridge/openai/v1`.
-1. **OpenAI Compatible API Key**: Enter your **[Coder Session Token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)**.
+1. **OpenAI Compatible API Key**: Enter your **[Coder API token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)**.
 1. **Model ID** (Optional): Enter the model you wish to use (e.g., `gpt-5.2-codex`).
 
 ![Cline OpenAI Settings](../../../images/aibridge/clients/cline-openai.png)
@@ -27,7 +27,7 @@ To configure Cline to use AI Gateway, follow these steps:
 1. Open Cline in VS Code.
 1. Go to **Settings**.
 1. **API Provider**: Select **Anthropic**.
-1. **Anthropic API Key**: Enter your **Coder Session Token**.
+1. **Anthropic API Key**: Enter your **Coder API token**.
 1. **Base URL**: Enter `https://coder.example.com/api/v2/aibridge/anthropic` after checking **_Use custom base URL_**.
 1. **Model ID** (Optional): Select your desired Claude model.
 
@@ -47,7 +47,7 @@ To configure Cline to use AI Gateway, follow these steps:
 1. **Base URL**: Enter `https://coder.example.com/api/v2/aibridge/openai/v1`.
 1. **OpenAI Compatible API Key**: Enter your personal OpenAI API key.
 1. **Model ID** (Optional): Enter the model you wish to use (e.g., `gpt-5.2-codex`).
-1. **Custom Headers**: Add `X-Coder-AI-Governance-Token` with your **[Coder Session Token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)**.
+1. **Custom Headers**: Add `X-Coder-AI-Governance-Token` with your **[Coder API token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)**.
 
 ![Cline BYOK OpenAI Settings](../../../images/aibridge/clients/cline-byok-openai.png)
 

--- a/docs/ai-coder/ai-gateway/clients/codex.md
+++ b/docs/ai-coder/ai-gateway/clients/codex.md
@@ -16,10 +16,10 @@ env_key = "OPENAI_API_KEY"
 wire_api = "responses"
 ```
 
-To authenticate with AI Gateway, get your **[Coder session token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)** and set it in your environment:
+To authenticate with AI Gateway, get your **[Coder API token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)** and set it in your environment:
 
 ```bash
-export OPENAI_API_KEY="<your-coder-session-token>"
+export OPENAI_API_KEY="<your-coder-api-token>"
 ```
 
 Run Codex as usual. It will automatically use the `aibridge` model provider from your configuration.
@@ -45,8 +45,8 @@ Set both environment variables:
 # Your personal OpenAI API key, forwarded to OpenAI.
 export OPENAI_API_KEY="<your-openai-api-key>"
 
-# Your Coder session token, used for authentication with AI Gateway.
-export CODER_SESSION_TOKEN="<your-coder-session-token>"
+# Your Coder API token, used for authentication with AI Gateway.
+export CODER_SESSION_TOKEN="<your-coder-api-token>"
 ```
 
 ## BYOK (ChatGPT Subscription)
@@ -67,11 +67,11 @@ env_http_headers = { "X-Coder-AI-Governance-Token" = "CODER_SESSION_TOKEN" }
 > [!NOTE]
 > The `base_url` uses `/aibridge/chatgpt/v1` instead of `/aibridge/openai/v1` to route requests through the ChatGPT provider.
 
-Set your Coder session token and ensure `OPENAI_API_KEY` is not set:
+Set your Coder API token and ensure `OPENAI_API_KEY` is not set:
 
 ```bash
-# Your Coder session token, used for authentication with AI Gateway.
-export CODER_SESSION_TOKEN="<your-coder-session-token>"
+# Your Coder API token, used for authentication with AI Gateway.
+export CODER_SESSION_TOKEN="<your-coder-api-token>"
 
 # Ensure no OpenAI API key is set so Codex uses ChatGPT login instead.
 unset OPENAI_API_KEY

--- a/docs/ai-coder/ai-gateway/clients/codex.md
+++ b/docs/ai-coder/ai-gateway/clients/codex.md
@@ -36,7 +36,7 @@ name = "AI Bridge"
 base_url = "<your-deployment-url>/api/v2/aibridge/openai/v1"
 wire_api = "responses"
 requires_openai_auth = true
-env_http_headers = { "X-Coder-AI-Governance-Token" = "CODER_SESSION_TOKEN" }
+env_http_headers = { "X-Coder-AI-Governance-Token" = "CODER_API_TOKEN" }
 ```
 
 Set both environment variables:
@@ -46,7 +46,7 @@ Set both environment variables:
 export OPENAI_API_KEY="<your-openai-api-key>"
 
 # Your Coder API token, used for authentication with AI Gateway.
-export CODER_SESSION_TOKEN="<your-coder-api-token>"
+export CODER_API_TOKEN="<your-coder-api-token>"
 ```
 
 ## BYOK (ChatGPT Subscription)
@@ -61,7 +61,7 @@ name = "AI Bridge"
 base_url = "<your-deployment-url>/api/v2/aibridge/chatgpt/v1"
 wire_api = "responses"
 requires_openai_auth = true
-env_http_headers = { "X-Coder-AI-Governance-Token" = "CODER_SESSION_TOKEN" }
+env_http_headers = { "X-Coder-AI-Governance-Token" = "CODER_API_TOKEN" }
 ```
 
 > [!NOTE]
@@ -71,7 +71,7 @@ Set your Coder API token and ensure `OPENAI_API_KEY` is not set:
 
 ```bash
 # Your Coder API token, used for authentication with AI Gateway.
-export CODER_SESSION_TOKEN="<your-coder-api-token>"
+export CODER_API_TOKEN="<your-coder-api-token>"
 
 # Ensure no OpenAI API key is set so Codex uses ChatGPT login instead.
 unset OPENAI_API_KEY

--- a/docs/ai-coder/ai-gateway/clients/copilot.md
+++ b/docs/ai-coder/ai-gateway/clients/copilot.md
@@ -21,7 +21,7 @@ For installation instructions, see [GitHub Copilot CLI documentation](https://do
 Set the `HTTPS_PROXY` environment variable:
 
 ```shell
-export HTTPS_PROXY="https://coder:${CODER_SESSION_TOKEN}@<proxy-host>:8888"
+export HTTPS_PROXY="https://coder:${CODER_API_TOKEN}@<proxy-host>:8888"
 ```
 
 Replace `<proxy-host>` with your AI Gateway Proxy hostname.
@@ -62,20 +62,20 @@ Alternatively, you can configure the proxy directly in VS Code settings:
 
 1. Open Settings (`Ctrl+,` for Windows or `Cmd+,` for macOS)
 1. Search for `HTTP: Proxy`
-1. Set the proxy URL using the format `https://coder:<CODER_SESSION_TOKEN>@<proxy-host>:8888`
+1. Set the proxy URL using the format `https://coder:<CODER_API_TOKEN>@<proxy-host>:8888`
 
 Or add directly to your `settings.json`:
 
 ```json
 {
-    "http.proxy": "https://coder:<CODER_SESSION_TOKEN>@<proxy-host>:8888"
+    "http.proxy": "https://coder:<CODER_API_TOKEN>@<proxy-host>:8888"
 }
 ```
 
 Note: if [TLS is not enabled](../ai-gateway-proxy/setup.md#proxy-tls-configuration) on the proxy, replace `https://` with `http://` in the proxy URL.
 
 The `http.proxy` setting is used for both HTTP and HTTPS requests.
-Replace `<proxy-host>` with your AI Gateway Proxy hostname and `<CODER_SESSION_TOKEN>` with your coder session token.
+Replace `<proxy-host>` with your AI Gateway Proxy hostname and `<CODER_API_TOKEN>` with your coder api token.
 
 Restart VS Code for changes to take effect.
 
@@ -105,11 +105,11 @@ Configure the proxy in VS Code's remote settings:
 1. Open Settings (`Ctrl+,` for Windows or `Cmd+,` for macOS)
 1. Select the **Remote** tab
 1. Search for `HTTP: Proxy`
-1. Set the proxy URL using the format `https://coder:<CODER_SESSION_TOKEN>@<proxy-host>:8888`
+1. Set the proxy URL using the format `https://coder:<CODER_API_TOKEN>@<proxy-host>:8888`
 
 Note: if [TLS is not enabled](../ai-gateway-proxy/setup.md#proxy-tls-configuration) on the proxy, replace `https://` with `http://` in the proxy URL.
 
-Replace `<proxy-host>` with your AI Gateway Proxy hostname and `<CODER_SESSION_TOKEN>` with your coder session token.
+Replace `<proxy-host>` with your AI Gateway Proxy hostname and `<CODER_API_TOKEN>` with your coder api token.
 
 #### CA certificate trust
 
@@ -132,7 +132,7 @@ Configure the proxy directly in JetBrains IDE settings:
 1. Enter the proxy hostname and port (default: 8888)
 1. Select `Proxy authentication` and enter:
    1. Login: `coder` (this value is ignored)
-   1. Password: Your Coder session token
+   1. Password: Your Coder api token
    1. Check `Remember` to save the password
 1. Restart the IDE for changes to take effect
 

--- a/docs/ai-coder/ai-gateway/clients/copilot.md
+++ b/docs/ai-coder/ai-gateway/clients/copilot.md
@@ -75,7 +75,7 @@ Or add directly to your `settings.json`:
 Note: if [TLS is not enabled](../ai-gateway-proxy/setup.md#proxy-tls-configuration) on the proxy, replace `https://` with `http://` in the proxy URL.
 
 The `http.proxy` setting is used for both HTTP and HTTPS requests.
-Replace `<proxy-host>` with your AI Gateway Proxy hostname and `<CODER_API_TOKEN>` with your coder api token.
+Replace `<proxy-host>` with your AI Gateway Proxy hostname and `<CODER_API_TOKEN>` with your Coder API token.
 
 Restart VS Code for changes to take effect.
 
@@ -109,7 +109,7 @@ Configure the proxy in VS Code's remote settings:
 
 Note: if [TLS is not enabled](../ai-gateway-proxy/setup.md#proxy-tls-configuration) on the proxy, replace `https://` with `http://` in the proxy URL.
 
-Replace `<proxy-host>` with your AI Gateway Proxy hostname and `<CODER_API_TOKEN>` with your coder api token.
+Replace `<proxy-host>` with your AI Gateway Proxy hostname and `<CODER_API_TOKEN>` with your Coder API token.
 
 #### CA certificate trust
 
@@ -132,7 +132,7 @@ Configure the proxy directly in JetBrains IDE settings:
 1. Enter the proxy hostname and port (default: 8888)
 1. Select `Proxy authentication` and enter:
    1. Login: `coder` (this value is ignored)
-   1. Password: Your Coder api token
+   1. Password: Your Coder API token
    1. Check `Remember` to save the password
 1. Restart the IDE for changes to take effect
 

--- a/docs/ai-coder/ai-gateway/clients/factory.md
+++ b/docs/ai-coder/ai-gateway/clients/factory.md
@@ -7,7 +7,7 @@ Factort's Droid agent can be configured to use AI Gateway by setting up custom m
 1. Open `~/.factory/settings.json` (create it if it does not exist).
 2. Add a `customModels` entry for each provider you want to use with AI Gateway.
 3. Replace `coder.example.com` with your Coder deployment URL.
-4. Use a **[Coder session token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)** for `apiKey`.
+4. Use a **[Coder API token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)** for `apiKey`.
 
 ```json
 {
@@ -16,7 +16,7 @@ Factort's Droid agent can be configured to use AI Gateway by setting up custom m
       "model": "claude-sonnet-4-5-20250929",
       "displayName": "Claude (Coder AI Bridge)",
       "baseUrl": "https://coder.example.com/api/v2/aibridge/anthropic",
-      "apiKey": "<your-coder-session-token>",
+      "apiKey": "<your-coder-api-token>",
       "provider": "anthropic",
       "maxOutputTokens": 8192
     },
@@ -24,7 +24,7 @@ Factort's Droid agent can be configured to use AI Gateway by setting up custom m
       "model": "gpt-5.2-codex",
       "displayName": "GPT (Coder AI Bridge)",
       "baseUrl": "https://coder.example.com/api/v2/aibridge/openai/v1",
-      "apiKey": "<your-coder-session-token>",
+      "apiKey": "<your-coder-api-token>",
       "provider": "openai",
       "maxOutputTokens": 16384
     }
@@ -38,7 +38,7 @@ Factort's Droid agent can be configured to use AI Gateway by setting up custom m
 2. Add a `customModels` entry for each provider you want to use with AI Bridge.
 3. Replace `coder.example.com` with your Coder deployment URL.
 4. Use your personal API key for `apiKey`.
-5. Set the `X-Coder-AI-Governance-Token` header to your **[Coder session token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)**.
+5. Set the `X-Coder-AI-Governance-Token` header to your **[Coder API token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)**.
 
 ```json
 {
@@ -51,7 +51,7 @@ Factort's Droid agent can be configured to use AI Gateway by setting up custom m
       "provider": "anthropic",
       "maxOutputTokens": 8192,
       "extraHeaders": {
-        "X-Coder-AI-Governance-Token": "<your-coder-session-token>"
+        "X-Coder-AI-Governance-Token": "<your-coder-api-token>"
       }
     },
     {
@@ -62,7 +62,7 @@ Factort's Droid agent can be configured to use AI Gateway by setting up custom m
       "provider": "openai",
       "maxOutputTokens": 16384,
       "extraHeaders": {
-        "X-Coder-AI-Governance-Token": "<your-coder-session-token>"
+        "X-Coder-AI-Governance-Token": "<your-coder-api-token>"
       }
     }
   ]

--- a/docs/ai-coder/ai-gateway/clients/index.md
+++ b/docs/ai-coder/ai-gateway/clients/index.md
@@ -20,10 +20,10 @@ Replace `coder.example.com` with your actual Coder deployment URL.
 
 ## Authentication
 
-Instead of distributing provider-specific API keys (OpenAI/Anthropic keys) to users, they authenticate to AI Gateway using their **Coder session token** or **API key**:
+Instead of distributing provider-specific API keys (OpenAI/Anthropic keys) to users, they authenticate to AI Gateway using their **Coder API token**:
 
-- **OpenAI clients**: Users set `OPENAI_API_KEY` to their Coder session token or API key
-- **Anthropic clients**: Users set `ANTHROPIC_API_KEY` to their Coder session token or API key
+- **OpenAI clients**: Users set `OPENAI_API_KEY` to their Coder API token
+- **Anthropic clients**: Users set `ANTHROPIC_API_KEY` to their Coder API token
 
 > [!NOTE]
 > Only Coder-issued tokens can authenticate users against AI Gateway.
@@ -54,7 +54,7 @@ AI Gateway continues to provide observability and governance.
 
 In BYOK mode, users need two credentials:
 
-- A **Coder session token** to authenticate with AI Gateway.
+- A **Coder API token** to authenticate with AI Gateway.
 - Their **own LLM credential** (personal API key or subscription token) which AI Gateway forwards
   to the upstream provider.
 

--- a/docs/ai-coder/ai-gateway/clients/jetbrains.md
+++ b/docs/ai-coder/ai-gateway/clients/jetbrains.md
@@ -5,7 +5,7 @@ JetBrains IDE (IntelliJ IDEA, PyCharm, WebStorm, etc.) support AI Gateway via th
 ## Prerequisites
 
 * [**JetBrains AI Assistant**](https://www.jetbrains.com/help/ai-assistant/installation-guide-ai-assistant.html): Installed and enabled.
-* **Authentication**: Your **[Coder session token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)**.
+* **Authentication**: Your **[Coder API token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)**.
 
 ## Centralized API Key
 
@@ -13,7 +13,7 @@ JetBrains IDE (IntelliJ IDEA, PyCharm, WebStorm, etc.) support AI Gateway via th
 1. **Configure Provider**: Go to **Third-party AI providers**.
 1. **Choose Provider**: Choose **OpenAI-compatible**.
 1. **URL**: `https://coder.example.com/api/v2/aibridge/openai/v1`
-1. **API Key**: Paste your **[Coder session token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)**.
+1. **API Key**: Paste your **[Coder API token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)**.
 1. **Apply**: Click **Apply** and **OK**.
 
 ![JetBrains AI Assistant Settings](../../../images/aibridge/clients/jetbrains-ai-settings.png)

--- a/docs/ai-coder/ai-gateway/clients/kilo-code.md
+++ b/docs/ai-coder/ai-gateway/clients/kilo-code.md
@@ -12,7 +12,7 @@ Kilo Code allows you to configure providers via the UI and can be set up to use 
 1. Go to **Settings**.
 1. **Provider**: Select **OpenAI**.
 1. **Base URL**: Enter `https://coder.example.com/api/v2/aibridge/openai/v1`.
-1. **API Key**: Enter your **[Coder Session Token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)**.
+1. **API Key**: Enter your **[Coder API token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)**.
 1. **Model ID**: Enter the model you wish to use (e.g., `gpt-5.2-codex`).
 
 ![Kilo Code OpenAI Settings](../../../images/aibridge/clients/kilo-code-openai.png)
@@ -23,7 +23,7 @@ Kilo Code allows you to configure providers via the UI and can be set up to use 
 1. Go to **Settings**.
 1. **Provider**: Select **Anthropic**.
 1. **Base URL**: Enter `https://coder.example.com/api/v2/aibridge/anthropic`.
-1. **API Key**: Enter your **Coder Session Token**.
+1. **API Key**: Enter your **Coder API token**.
 1. **Model ID**: Select your desired Claude model.
 
 ![Kilo Code Anthropic Settings](../../../images/aibridge/clients/kilo-code-anthropic.png)

--- a/docs/ai-coder/ai-gateway/clients/mux.md
+++ b/docs/ai-coder/ai-gateway/clients/mux.md
@@ -7,7 +7,7 @@ Mux can be configured to route OpenAI- and Anthropic-compatible traffic through 
 ## Prerequisites
 
 - AI Gateway is enabled on your Coder deployment.
-- A **[Coder session token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)** or long-lived API key.
+- A **[Coder API token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)**.
 
 ## Configuration
 
@@ -17,14 +17,14 @@ Mux can be configured to route OpenAI- and Anthropic-compatible traffic through 
 
 1. Open Mux settings (`Cmd+,` / `Ctrl+,`).
 2. Go to **Providers** → **OpenAI**.
-3. Set **API Key** to your Coder session token.
+3. Set **API Key** to your Coder API token.
 4. Set **Base URL** to `https://coder.example.com/api/v2/aibridge/openai/v1`.
 
 ### Anthropic
 
 1. Open Mux settings (`Cmd+,` / `Ctrl+,`).
 2. Go to **Providers** → **Anthropic**.
-3. Set **API Key** to your Coder session token.
+3. Set **API Key** to your Coder API token.
 4. Set **Base URL** to `https://coder.example.com/api/v2/aibridge/anthropic`.
 
 </div>
@@ -42,11 +42,11 @@ Environment variables are useful in CI or when running Mux inside a Coder worksp
 
 ```sh
 # OpenAI-compatible traffic (GPT, Codex, etc.)
-export OPENAI_API_KEY="<your-coder-session-token>"
+export OPENAI_API_KEY="<your-coder-api-token>"
 export OPENAI_BASE_URL="https://coder.example.com/api/v2/aibridge/openai/v1"
 
 # Anthropic-compatible traffic (Claude, etc.)
-export ANTHROPIC_API_KEY="<your-coder-session-token>"
+export ANTHROPIC_API_KEY="<your-coder-api-token>"
 export ANTHROPIC_BASE_URL="https://coder.example.com/api/v2/aibridge/anthropic"
 ```
 
@@ -83,11 +83,11 @@ If you prefer a file-based config, edit `~/.mux/providers.jsonc`:
 ```jsonc
 {
   "openai": {
-    "apiKey": "<your-coder-session-token>",
+    "apiKey": "<your-coder-api-token>",
     "baseUrl": "https://coder.example.com/api/v2/aibridge/openai/v1"
   },
   "anthropic": {
-    "apiKey": "<your-coder-session-token>",
+    "apiKey": "<your-coder-api-token>",
     "baseUrl": "https://coder.example.com/api/v2/aibridge/anthropic"
   }
 }

--- a/docs/ai-coder/ai-gateway/clients/opencode.md
+++ b/docs/ai-coder/ai-gateway/clients/opencode.md
@@ -24,24 +24,24 @@ You can configure OpenCode to connect to AI Gateway by setting the following con
 }
 ```
 
-To authenticate with AI Gateway, get your **[Coder session token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)** and replace `<your-coder-session-token>` in `~/.local/share/opencode/auth.json`
+To authenticate with AI Gateway, get your **[Coder API token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)** and replace `<your-coder-api-token>` in `~/.local/share/opencode/auth.json`
 
 ```json
 {
   "anthropic": {
     "type": "api",
-    "key": "<your-coder-session-token>"
+    "key": "<your-coder-api-token>"
   },
   "openai": {
     "type": "api",
-    "key": "<your-coder-session-token>"
+    "key": "<your-coder-api-token>"
   }
 }
 ```
 
 ## BYOK (Personal API Key)
 
-Set the following in `~/.config/opencode/opencode.json`, including the `X-Coder-AI-Governance-Token` header with your Coder session token:
+Set the following in `~/.config/opencode/opencode.json`, including the `X-Coder-AI-Governance-Token` header with your Coder API token:
 
 ```json
 {
@@ -51,7 +51,7 @@ Set the following in `~/.config/opencode/opencode.json`, including the `X-Coder-
       "options": {
         "baseURL": "https://coder.example.com/api/v2/aibridge/anthropic/v1",
         "headers": {
-          "X-Coder-AI-Governance-Token": "<your-coder-session-token>"
+          "X-Coder-AI-Governance-Token": "<your-coder-api-token>"
         }
       }
     },
@@ -59,7 +59,7 @@ Set the following in `~/.config/opencode/opencode.json`, including the `X-Coder-
       "options": {
         "baseURL": "https://coder.example.com/api/v2/aibridge/openai/v1",
         "headers": {
-          "X-Coder-AI-Governance-Token": "<your-coder-session-token>"
+          "X-Coder-AI-Governance-Token": "<your-coder-api-token>"
         }
       }
     }

--- a/docs/ai-coder/ai-gateway/clients/roo-code.md
+++ b/docs/ai-coder/ai-gateway/clients/roo-code.md
@@ -16,7 +16,7 @@ Roo Code allows you to configure providers via the UI.
 1. Go to **Settings**.
 1. **Provider**: Select **OpenAI**.
 1. **Base URL**: Enter `https://coder.example.com/api/v2/aibridge/openai/v1`.
-1. **API Key**: Enter your **[Coder Session Token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)**.
+1. **API Key**: Enter your **[Coder API token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)**.
 1. **Model ID**: Enter the model you wish to use (e.g., `gpt-5.2-codex`).
 ![Roo Code OpenAI Settings](../../../images/aibridge/clients/roo-code-openai.png)
 
@@ -26,7 +26,7 @@ Roo Code allows you to configure providers via the UI.
 1. Go to **Settings**.
 1. **Provider**: Select **Anthropic**.
 1. **Base URL**: Enter `https://coder.example.com/api/v2/aibridge/anthropic`.
-1. **API Key**: Enter your **Coder Session Token**.
+1. **API Key**: Enter your **Coder API token**.
 1. **Model ID**: Select your desired Claude model.
 
 ![Roo Code Anthropic Settings](../../../images/aibridge/clients/roo-code-anthropic.png)
@@ -50,7 +50,7 @@ Roo Code allows you to configure providers via the UI.
 1. **Base URL**: Enter `https://coder.example.com/api/v2/aibridge/openai/v1`.
 1. **API Key**: Enter your personal OpenAI API key.
 1. **Model ID**: Enter the model you wish to use (e.g., `gpt-4o`).
-1. **Custom Headers**: Add `X-Coder-AI-Governance-Token` with your **[Coder Session Token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)**.
+1. **Custom Headers**: Add `X-Coder-AI-Governance-Token` with your **[Coder API token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)**.
 
 ![Roo Code BYOK OpenAI Settings](../../../images/aibridge/clients/roo-code-byok-openai.png)
 

--- a/docs/ai-coder/ai-gateway/clients/vscode.md
+++ b/docs/ai-coder/ai-gateway/clients/vscode.md
@@ -15,7 +15,7 @@ VS Code's native chat can be configured to use AI Gateway with the GitHub Copilo
     {
         "name": "Coder",
         "vendor": "customoai",
-        "apiKey": "your-coder-api-token>",
+        "apiKey": "<your-coder-api-token>",
         "models": [
             {
                 "name": "GPT 5.2",

--- a/docs/ai-coder/ai-gateway/clients/vscode.md
+++ b/docs/ai-coder/ai-gateway/clients/vscode.md
@@ -8,14 +8,14 @@ VS Code's native chat can be configured to use AI Gateway with the GitHub Copilo
 > You need the **Pre-release** version of the [GitHub Copilot Chat extension](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot-chat) and [VS Code Insiders](https://code.visualstudio.com/insiders/).
 
 1. Open command palette (`Ctrl+Shift+P` or `Cmd+Shift+P` on Mac) and search for _Chat: Open Language Models (JSON)_.
-1. Paste the following JSON configuration, replacing `<your-coder-session-token>` with your **[Coder Session Token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)**:
+1. Paste the following JSON configuration, replacing `<your-coder-api-token>` with your **[Coder API token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)**:
 
 ```json
 [
     {
         "name": "Coder",
         "vendor": "customoai",
-        "apiKey": "your-coder-session-token>",
+        "apiKey": "your-coder-api-token>",
         "models": [
             {
                 "name": "GPT 5.2",

--- a/docs/ai-coder/ai-gateway/clients/zed.md
+++ b/docs/ai-coder/ai-gateway/clients/zed.md
@@ -41,7 +41,7 @@ You can configure both Anthropic and OpenAI providers to point to AI Gateway.
 
 ## Authentication
 
-Zed requires an API key for these providers. For AI Gateway, this key is your **[Coder Session Token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)**.
+Zed requires an API key for these providers. For AI Gateway, this key is your **[Coder API token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)**.
 
 You can set this in two ways:
 
@@ -52,11 +52,11 @@ You can set this in two ways:
 1. Open the **Assistant Panel** (right sidebar).
 1. Click **Configuration** or the settings icon.
 1. Select your provider ("Anthropic" or "OpenAI").
-1. Paste your **[Coder Session Token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)** for the API Key.
+1. Paste your **[Coder API token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)** for the API Key.
 
 ### Environment Variables
 
-1. Set `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` to your **[Coder Session Token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)** in the environment where you launch Zed.
+1. Set `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` to your **[Coder API token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)** in the environment where you launch Zed.
 
 </div>
 


### PR DESCRIPTION
## Summary

Follows up on https://github.com/coder/coder/pull/24032
                                                                                                                                                      
Renames "Coder session token" to "Coder API token" in AI Gateway client documentation pages.                                                                           
                                                                                                                                                      
Also renames the `CODER_SESSION_TOKEN` env var to `CODER_API_TOKEN` in Codex CLI examples and Copilot proxy configuration. 

Note: "Coder session token" is still used in some parts of the documentation where it make sense.
