### PR TITLE
fix(coderd): use RepeatableRead for outer workspace build transactions

### DIFF
--- a/coderd/autobuild/lifecycle_executor.go
+++ b/coderd/autobuild/lifecycle_executor.go
@@ -238,6 +238,14 @@ func (e *Executor) runOnce(t time.Time) Stats {
 					tmpl                  database.Template
 					didAutoUpdate         bool
 				)
+				// This is a plain InTx rather than ReadModifyUpdate, so a 40001
+				// serialization failure in wsbuilder.Build's inner RMU is not
+				// retried here and the current tick fails for this workspace.
+				// That is acceptable: GetWorkspacesEligibleForTransition will
+				// return the workspace again on the next tick (default 1m via
+				// CODER_AUTOBUILD_POLL_INTERVAL) as long as the underlying
+				// eligibility condition still holds, so the system converges to
+				// the correct state without immediate retry. See #21939.
 				err := e.db.InTx(func(tx database.Store) error {
 					var err error
 

--- a/coderd/database/db.go
+++ b/coderd/database/db.go
@@ -210,7 +210,7 @@ func (q *sqlQuerier) runTx(function func(Store) error, txOpts *sql.TxOptions) er
 			// than the parent, but it will be silently ignored
 			// because we reuse the parent transaction. Log this so
 			// callers can detect the mismatch.
-			q.logger.Warn(context.Background(), "nested transaction requested stricter isolation level than the outer transaction provides",
+			q.logger.Critical(context.Background(), "nested transaction requested stricter isolation level than the outer transaction provides",
 				slog.F("parent_isolation", q.txIsolationLevel.String()),
 				slog.F("requested_isolation", txOpts.Isolation.String()),
 			)

--- a/coderd/database/db.go
+++ b/coderd/database/db.go
@@ -205,7 +205,7 @@ func (q *sqlQuerier) runTx(function func(Store) error, txOpts *sql.TxOptions) (e
 			// than the parent, but it will be silently ignored
 			// because we reuse the parent transaction. Log this so
 			// callers can detect the mismatch.
-			q.logger.Warn(context.Background(), "nested transaction requested stricter isolation level than the existing transaction provides",
+			q.logger.Critical(context.Background(), "nested transaction requested stricter isolation level than the existing transaction provides",
 				slog.F("existing_isolation", q.txIsolationLevel.String()),
 				slog.F("requested_isolation", txOpts.Isolation.String()),
 			)

--- a/coderd/database/db.go
+++ b/coderd/database/db.go
@@ -31,6 +31,12 @@ type Store interface {
 	Ping(ctx context.Context) (time.Duration, error)
 	PGLocks(ctx context.Context) (PGLocks, error)
 	InTx(func(Store) error, *TxOptions) error
+
+	// InTransaction reports whether this Store is already wrapped in an open
+	// database transaction. Callers can use this to detect nesting and avoid
+	// duplicating retry loops that would re-execute against an aborted parent
+	// transaction.
+	InTransaction() bool
 }
 
 type wrapper interface {
@@ -135,6 +141,14 @@ type sqlQuerier struct {
 
 func (*sqlQuerier) Wrappers() []string {
 	return []string{}
+}
+
+// InTransaction reports whether this Store is wrapped in an open database
+// transaction. Returns true on the inner Store passed into an InTx closure,
+// false on a top-level Store.
+func (q *sqlQuerier) InTransaction() bool {
+	_, ok := q.db.(*sqlx.Tx)
+	return ok
 }
 
 // Ping returns the time it takes to ping the database.

--- a/coderd/database/db_test.go
+++ b/coderd/database/db_test.go
@@ -107,9 +107,9 @@ func TestNestedInTxStricterIsolationDefaultParent(t *testing.T) {
 	require.NoError(t, err)
 
 	entries := sink.Entries(func(e slog.SinkEntry) bool {
-		return e.Level == slog.LevelWarn
+		return e.Level == slog.LevelCritical
 	})
-	require.Len(t, entries, 1, "expected exactly one Warn log entry")
+	require.Len(t, entries, 1, "expected exactly one Critical log entry")
 	require.Contains(t, entries[0].Message, "nested transaction requested stricter isolation level")
 
 	var parentVal, requestedVal string
@@ -148,9 +148,9 @@ func TestNestedInTxStricterIsolationBothExplicit(t *testing.T) {
 	require.NoError(t, err)
 
 	entries := sink.Entries(func(e slog.SinkEntry) bool {
-		return e.Level == slog.LevelWarn
+		return e.Level == slog.LevelCritical
 	})
-	require.Len(t, entries, 1, "expected exactly one Warn log entry")
+	require.Len(t, entries, 1, "expected exactly one Critical log entry")
 	require.Contains(t, entries[0].Message, "nested transaction requested stricter isolation level")
 
 	var parentVal, requestedVal string
@@ -188,7 +188,7 @@ func TestNestedInTxSameIsolationNoLog(t *testing.T) {
 	require.NoError(t, err)
 
 	entries := sink.Entries(func(e slog.SinkEntry) bool {
-		return e.Level == slog.LevelWarn
+		return e.Level == slog.LevelCritical
 	})
 	require.Empty(t, entries, "should not log when isolation levels match")
 }
@@ -215,7 +215,7 @@ func TestNestedInTxWeakerIsolationNoLog(t *testing.T) {
 	require.NoError(t, err)
 
 	entries := sink.Entries(func(e slog.SinkEntry) bool {
-		return e.Level == slog.LevelWarn
+		return e.Level == slog.LevelCritical
 	})
 	require.Empty(t, entries, "should not log when inner isolation is weaker than outer")
 }
@@ -243,7 +243,7 @@ func TestNestedInTxDefaultVsReadCommittedNoLog(t *testing.T) {
 	require.NoError(t, err)
 
 	entries := sink.Entries(func(e slog.SinkEntry) bool {
-		return e.Level == slog.LevelWarn
+		return e.Level == slog.LevelCritical
 	})
 	require.Empty(t, entries, "should not log when default and ReadCommitted are equivalent after normalization")
 }

--- a/coderd/database/db_test.go
+++ b/coderd/database/db_test.go
@@ -127,7 +127,7 @@ func TestNestedInTxStricterIsolationDefaultParent(t *testing.T) {
 
 	// Outer uses default isolation, inner requests RepeatableRead.
 	// After normalization default becomes ReadCommitted, so the
-	// inner level is stricter and a Warn log should fire.
+	// inner level is stricter and a Critical log should fire.
 	err := db.InTx(func(outer database.Store) error {
 		return outer.InTx(func(_ database.Store) error {
 			return nil
@@ -167,7 +167,7 @@ func TestNestedInTxStricterIsolationBothExplicit(t *testing.T) {
 	db := database.New(sqlDB, logger)
 
 	// Outer uses RepeatableRead, inner requests Serializable.
-	// Both are explicit and the inner is stricter, so a Warn
+	// Both are explicit and the inner is stricter, so a Critical
 	// log should fire.
 	err := db.InTx(func(outer database.Store) error {
 		return outer.InTx(func(_ database.Store) error {
@@ -275,6 +275,38 @@ func TestNestedInTxDefaultVsReadCommittedNoLog(t *testing.T) {
 		return e.Level == slog.LevelCritical
 	})
 	require.Empty(t, entries, "should not log when default and ReadCommitted are equivalent after normalization")
+}
+
+func TestInTransaction_TopLevel(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	sqlDB := testSQLDB(t)
+	db := database.New(sqlDB, slog.Logger{})
+	require.False(t, db.InTransaction(),
+		"top-level Store should not report itself in a transaction")
+}
+
+func TestInTransaction_Nested(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	sqlDB := testSQLDB(t)
+	db := database.New(sqlDB, slog.Logger{})
+
+	require.False(t, db.InTransaction())
+	var innerVal bool
+	err := db.InTx(func(tx database.Store) error {
+		innerVal = tx.InTransaction()
+		return nil
+	}, nil)
+	require.NoError(t, err)
+	require.True(t, innerVal,
+		"Store passed into InTx closure should report itself in a transaction")
 }
 
 func testSQLDB(t testing.TB) *sql.DB {

--- a/coderd/database/db_test.go
+++ b/coderd/database/db_test.go
@@ -136,9 +136,9 @@ func TestNestedInTxStricterIsolationDefaultParent(t *testing.T) {
 	require.NoError(t, err)
 
 	entries := sink.Entries(func(e slog.SinkEntry) bool {
-		return e.Level == slog.LevelWarn
+		return e.Level == slog.LevelCritical
 	})
-	require.Len(t, entries, 1, "expected exactly one Warn log entry")
+	require.Len(t, entries, 1, "expected exactly one Critical log entry")
 	require.Contains(t, entries[0].Message, "nested transaction requested stricter isolation level")
 
 	var parentVal, requestedVal string
@@ -177,9 +177,9 @@ func TestNestedInTxStricterIsolationBothExplicit(t *testing.T) {
 	require.NoError(t, err)
 
 	entries := sink.Entries(func(e slog.SinkEntry) bool {
-		return e.Level == slog.LevelWarn
+		return e.Level == slog.LevelCritical
 	})
-	require.Len(t, entries, 1, "expected exactly one Warn log entry")
+	require.Len(t, entries, 1, "expected exactly one Critical log entry")
 	require.Contains(t, entries[0].Message, "nested transaction requested stricter isolation level")
 
 	var parentVal, requestedVal string
@@ -217,7 +217,7 @@ func TestNestedInTxSameIsolationNoLog(t *testing.T) {
 	require.NoError(t, err)
 
 	entries := sink.Entries(func(e slog.SinkEntry) bool {
-		return e.Level == slog.LevelWarn
+		return e.Level == slog.LevelCritical
 	})
 	require.Empty(t, entries, "should not log when isolation levels match")
 }
@@ -244,7 +244,7 @@ func TestNestedInTxWeakerIsolationNoLog(t *testing.T) {
 	require.NoError(t, err)
 
 	entries := sink.Entries(func(e slog.SinkEntry) bool {
-		return e.Level == slog.LevelWarn
+		return e.Level == slog.LevelCritical
 	})
 	require.Empty(t, entries, "should not log when inner isolation is weaker than outer")
 }
@@ -272,7 +272,7 @@ func TestNestedInTxDefaultVsReadCommittedNoLog(t *testing.T) {
 	require.NoError(t, err)
 
 	entries := sink.Entries(func(e slog.SinkEntry) bool {
-		return e.Level == slog.LevelWarn
+		return e.Level == slog.LevelCritical
 	})
 	require.Empty(t, entries, "should not log when default and ReadCommitted are equivalent after normalization")
 }

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -1119,6 +1119,10 @@ func (q *querier) Ping(ctx context.Context) (time.Duration, error) {
 	return q.db.Ping(ctx)
 }
 
+func (q *querier) InTransaction() bool {
+	return q.db.InTransaction()
+}
+
 func (q *querier) PGLocks(ctx context.Context) (database.PGLocks, error) {
 	return q.db.PGLocks(ctx)
 }

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -190,7 +190,8 @@ func TestDBAuthzRecursive(t *testing.T) {
 		if method.Name == "InTx" ||
 			method.Name == "Ping" ||
 			method.Name == "Wrappers" ||
-			method.Name == "PGLocks" {
+			method.Name == "PGLocks" ||
+			method.Name == "InTransaction" {
 			continue
 		}
 		// easy to know which method failed.

--- a/coderd/database/dbauthz/setup_test.go
+++ b/coderd/database/dbauthz/setup_test.go
@@ -43,6 +43,7 @@ var skipMethods = map[string]string{
 	"Wrappers":       "Not relevant",
 	"AcquireLock":    "Not relevant",
 	"TryAcquireLock": "Not relevant",
+	"InTransaction":  "Not relevant",
 }
 
 // TestMethodTestSuite runs MethodTestSuite.

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -81,6 +81,10 @@ func (m queryMetricsStore) Ping(ctx context.Context) (time.Duration, error) {
 	return duration, err
 }
 
+func (m queryMetricsStore) InTransaction() bool {
+	return m.s.InTransaction()
+}
+
 func (m queryMetricsStore) PGLocks(ctx context.Context) (database.PGLocks, error) {
 	start := time.Now()
 	locks, err := m.s.PGLocks(ctx)

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -6437,6 +6437,20 @@ func (mr *MockStoreMockRecorder) GetWorkspacesForWorkspaceMetrics(ctx any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspacesForWorkspaceMetrics", reflect.TypeOf((*MockStore)(nil).GetWorkspacesForWorkspaceMetrics), ctx)
 }
 
+// InTransaction mocks base method.
+func (m *MockStore) InTransaction() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InTransaction")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// InTransaction indicates an expected call of InTransaction.
+func (mr *MockStoreMockRecorder) InTransaction() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InTransaction", reflect.TypeOf((*MockStore)(nil).InTransaction))
+}
+
 // InTx mocks base method.
 func (m *MockStore) InTx(arg0 func(database.Store) error, arg1 *database.TxOptions) error {
 	m.ctrl.T.Helper()

--- a/coderd/database/tx.go
+++ b/coderd/database/tx.go
@@ -29,8 +29,20 @@ const maxRetries = 5
 // fail.  Let's say the transaction that sets A=2 succeeds.  Then the first B=2
 // transaction fails, but here we retry.  The second attempt we read A=2, B=1,
 // then write A=2, B=2 as desired, and this succeeds.
+//
+// When called inside an existing transaction, ReadModifyUpdate runs the
+// closure once at RepeatableRead isolation without its own retry loop and
+// lets the outermost ReadModifyUpdate handle retries. A nested retry loop
+// would re-execute against an aborted parent transaction; PostgreSQL would
+// turn the next statement into SQLSTATE 25P02 (in_failed_sql_transaction),
+// which would mask the original 40001 from the outermost retry loop.
 func ReadModifyUpdate(db Store, f func(tx Store) error,
 ) error {
+	if db.InTransaction() {
+		return db.InTx(f, &TxOptions{
+			Isolation: sql.LevelRepeatableRead,
+		})
+	}
 	var err error
 	for retries := 0; retries < maxRetries; retries++ {
 		err = db.InTx(f, &TxOptions{

--- a/coderd/database/tx_test.go
+++ b/coderd/database/tx_test.go
@@ -18,6 +18,7 @@ func TestReadModifyUpdate_OK(t *testing.T) {
 
 	mDB := dbmock.NewMockStore(gomock.NewController(t))
 
+	mDB.EXPECT().InTransaction().Return(false)
 	mDB.EXPECT().
 		InTx(gomock.Any(), &database.TxOptions{Isolation: sql.LevelRepeatableRead}).
 		Times(1).
@@ -33,6 +34,7 @@ func TestReadModifyUpdate_RetryOK(t *testing.T) {
 
 	mDB := dbmock.NewMockStore(gomock.NewController(t))
 
+	mDB.EXPECT().InTransaction().Return(false)
 	firstUpdate := mDB.EXPECT().
 		InTx(gomock.Any(), &database.TxOptions{Isolation: sql.LevelRepeatableRead}).
 		Times(1).
@@ -54,6 +56,7 @@ func TestReadModifyUpdate_HardError(t *testing.T) {
 
 	mDB := dbmock.NewMockStore(gomock.NewController(t))
 
+	mDB.EXPECT().InTransaction().Return(false)
 	mDB.EXPECT().
 		InTx(gomock.Any(), &database.TxOptions{Isolation: sql.LevelRepeatableRead}).
 		Times(1).
@@ -70,6 +73,7 @@ func TestReadModifyUpdate_TooManyRetries(t *testing.T) {
 
 	mDB := dbmock.NewMockStore(gomock.NewController(t))
 
+	mDB.EXPECT().InTransaction().Return(false)
 	mDB.EXPECT().
 		InTx(gomock.Any(), &database.TxOptions{Isolation: sql.LevelRepeatableRead}).
 		Times(5).
@@ -78,4 +82,63 @@ func TestReadModifyUpdate_TooManyRetries(t *testing.T) {
 		return nil
 	})
 	require.ErrorContains(t, err, "too many errors")
+}
+
+// TestReadModifyUpdate_NestedSkipsRetry verifies that a nested
+// ReadModifyUpdate (one whose Store is already in a transaction) does not
+// run its own retry loop. The inner closure must be invoked exactly once
+// per outer attempt; on a serialization failure the error must propagate
+// to the outermost ReadModifyUpdate, which retries.
+func TestReadModifyUpdate_NestedSkipsRetry(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mOuter := dbmock.NewMockStore(ctrl)
+	mInner := dbmock.NewMockStore(ctrl)
+
+	// Outer is the top-level Store. RMU asks once and runs its retry loop.
+	mOuter.EXPECT().InTransaction().Return(false)
+
+	// Outer InTx is invoked twice: first attempt fails with 40001, second
+	// attempt succeeds. DoAndReturn lets us run the user closure so the
+	// nested RMU below executes against mInner.
+	attempt := 0
+	mOuter.EXPECT().
+		InTx(gomock.Any(), &database.TxOptions{Isolation: sql.LevelRepeatableRead}).
+		Times(2).
+		DoAndReturn(func(f func(database.Store) error, _ *database.TxOptions) error {
+			attempt++
+			err := f(mInner)
+			if err != nil {
+				return err
+			}
+			return nil
+		})
+
+	// Inner is the in-transaction Store. RMU asks once per outer attempt
+	// and takes the fast path (no retry loop). The inner InTx is invoked
+	// once per outer attempt: the first attempt returns 40001, the second
+	// returns nil. Crucially, mInner.InTx is NOT called more than twice
+	// total; proof that the inner RMU did not retry.
+	mInner.EXPECT().InTransaction().Return(true).Times(2)
+	firstInner := mInner.EXPECT().
+		InTx(gomock.Any(), &database.TxOptions{Isolation: sql.LevelRepeatableRead}).
+		Times(1).
+		Return(&pq.Error{Code: pq.ErrorCode("40001")})
+	mInner.EXPECT().
+		InTx(gomock.Any(), &database.TxOptions{Isolation: sql.LevelRepeatableRead}).
+		After(firstInner).
+		Times(1).
+		Return(nil)
+
+	innerCalls := 0
+	err := database.ReadModifyUpdate(mOuter, func(tx database.Store) error {
+		innerCalls++
+		return database.ReadModifyUpdate(tx, func(_ database.Store) error {
+			return nil
+		})
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, attempt, "outer InTx should run twice")
+	require.Equal(t, 2, innerCalls, "user closure should run twice")
 }

--- a/coderd/httpapi/httperror/responserror.go
+++ b/coderd/httpapi/httperror/responserror.go
@@ -29,6 +29,19 @@ func NewResponseError(status int, resp codersdk.Response) error {
 	}
 }
 
+// NewResponseWithError is like NewResponseError but preserves the underlying
+// error in the chain so callers traversing with errors.As / errors.Is can
+// inspect it. Use this when you want to surface a Responder for
+// httperror.WriteResponseError while keeping the typed cause reachable for
+// upstream logic (for example, ReadModifyUpdate's pq.Error retry detection).
+func NewResponseWithError(status int, resp codersdk.Response, err error) error {
+	return &responseError{
+		status:   status,
+		response: resp,
+		inner:    err,
+	}
+}
+
 func WriteResponseError(ctx context.Context, rw http.ResponseWriter, err error) {
 	if responseErr, ok := IsResponder(err); ok {
 		code, resp := responseErr.Response()
@@ -46,6 +59,11 @@ func WriteResponseError(ctx context.Context, rw http.ResponseWriter, err error) 
 type responseError struct {
 	status   int
 	response codersdk.Response
+	// inner is the wrapped underlying error, exposed via Unwrap so that
+	// errors.As / errors.Is callers can drill through this layer. Nil for
+	// errors constructed via NewResponseError, which means errors.As against
+	// a non-Responder target stops here.
+	inner error
 }
 
 var (
@@ -63,6 +81,13 @@ func (e *responseError) Status() int {
 
 func (e *responseError) Response() (int, codersdk.Response) {
 	return e.status, e.response
+}
+
+// Unwrap returns the underlying error supplied at construction time, or nil
+// for response errors built without an underlying cause. errors.As / errors.Is
+// treat a nil Unwrap as the end of the chain.
+func (e *responseError) Unwrap() error {
+	return e.inner
 }
 
 var ErrResourceNotFound = NewResponseError(http.StatusNotFound, httpapi.ResourceNotFoundResponse)

--- a/coderd/httpapi/httperror/responserror_test.go
+++ b/coderd/httpapi/httperror/responserror_test.go
@@ -1,0 +1,63 @@
+package httperror_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/coderd/httpapi/httperror"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+func TestResponseError_Unwrap_PreservesPQError(t *testing.T) {
+	t.Parallel()
+
+	inner := &pq.Error{Code: "40001"}
+	wrapped := httperror.NewResponseWithError(
+		http.StatusInternalServerError,
+		codersdk.Response{Message: "boom", Detail: inner.Error()},
+		inner,
+	)
+
+	var pqe *pq.Error
+	require.True(t, xerrors.As(wrapped, &pqe),
+		"xerrors.As must walk the responseError chain to the inner pq.Error")
+	require.Equal(t, pq.ErrorCode("40001"), pqe.Code)
+}
+
+func TestResponseError_Unwrap_NoInner(t *testing.T) {
+	t.Parallel()
+
+	// NewResponseError carries no inner cause. errors.As against a
+	// non-Responder target must not match anything.
+	wrapped := httperror.NewResponseError(
+		http.StatusBadRequest,
+		codersdk.Response{Message: "validation failed"},
+	)
+
+	var pqe *pq.Error
+	require.False(t, xerrors.As(wrapped, &pqe),
+		"NewResponseError without inner err must not surface a spurious match")
+}
+
+func TestResponseError_Responder_Unaffected(t *testing.T) {
+	t.Parallel()
+
+	// IsResponder must keep returning the responseError regardless of
+	// whether it was built with NewResponseError or NewResponseWithError.
+	inner := xerrors.New("underlying cause")
+	wrapped := httperror.NewResponseWithError(
+		http.StatusInternalServerError,
+		codersdk.Response{Message: "boom"},
+		inner,
+	)
+	resp, ok := httperror.IsResponder(wrapped)
+	require.True(t, ok)
+	require.NotNil(t, resp)
+	status, body := resp.Response()
+	require.Equal(t, http.StatusInternalServerError, status)
+	require.Equal(t, "boom", body.Message)
+}

--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -396,22 +396,12 @@ func (api *API) postWorkspaceBuildsInternal(
 		provisionerDaemons     []database.GetEligibleProvisionerDaemonsByProvisionerJobIDsRow
 	)
 
-	// TODO: This transaction uses the default isolation level, but
-	// builder.Build() calls ReadModifyUpdate internally which needs
-	// RepeatableRead to detect concurrent modifications and retry.
-	// Because InTx reuses the parent transaction, the RepeatableRead
-	// request is silently ignored and its retry loop is ineffective.
-	//
-	// ReadModifyUpdate was added in #10277 (Oct 2023) when Build()
-	// was called directly on api.Database with no outer transaction.
-	// This outer InTx was introduced later in #15979 (Jan 2025) for
-	// workspace update notifications, unintentionally nesting the
-	// repeatable-read transaction inside a default-isolation parent.
-	//
-	// This should be elevated to sql.LevelRepeatableRead to match
-	// what the lifecycle executor already does, with the retry loop
-	// moved to wrap the outer transaction.
-	err := api.Database.InTx(func(tx database.Store) error {
+	// Use ReadModifyUpdate to run at RepeatableRead isolation with
+	// retries on serialization errors. Build() also calls
+	// ReadModifyUpdate internally, but since InTx reuses the parent
+	// transaction the inner call becomes a no-op — the isolation
+	// and retry behavior are provided by this outer call.
+	err := database.ReadModifyUpdate(api.Database, func(tx database.Store) error {
 		var err error
 
 		// #20925: if the workspace is dormant and we are starting the workspace,
@@ -497,7 +487,7 @@ func (api *API) postWorkspaceBuildsInternal(
 			workspaceBuildBaggage,
 		)
 		return err
-	}, nil)
+	})
 	if err != nil {
 		return codersdk.WorkspaceBuild{}, err
 	}

--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -397,6 +397,11 @@ func (api *API) postWorkspaceBuildsInternal(
 		provisionerDaemons     []database.GetEligibleProvisionerDaemonsByProvisionerJobIDsRow
 	)
 
+	// Track whether dormancy was unset so we can emit the audit
+	// entry after the transaction commits, avoiding duplicate
+	// audit logs on serialization retries.
+	var dormancyUnset bool
+
 	// Use ReadModifyUpdate to run at RepeatableRead isolation with
 	// retries on serialization errors. Build() also calls
 	// ReadModifyUpdate internally, but since InTx reuses the parent
@@ -404,6 +409,7 @@ func (api *API) postWorkspaceBuildsInternal(
 	// and retry behavior are provided by this outer call.
 	err := database.ReadModifyUpdate(api.Database, func(tx database.Store) error {
 		var err error
+		dormancyUnset = false
 
 		// #20925: if the workspace is dormant and we are starting the workspace,
 		// we need to unset that status before inserting a new build.
@@ -420,23 +426,7 @@ func (api *API) postWorkspaceBuildsInternal(
 					Detail:  err.Error(),
 				})
 			}
-			// We need to audit this change separately.
-			updatedWorkspace := workspace.WorkspaceTable()
-			updatedWorkspace.DormantAt = sql.NullTime{Valid: false}
-			auditor := api.Auditor.Load()
-			bag := audit.BaggageFromContext(ctx)
-			audit.BackgroundAudit(ctx, &audit.BackgroundAuditParams[database.WorkspaceTable]{
-				Audit:          *auditor,
-				Old:            workspace.WorkspaceTable(),
-				New:            updatedWorkspace,
-				Log:            api.Logger,
-				UserID:         apiKey.UserID,
-				OrganizationID: workspace.OrganizationID,
-				RequestID:      workspace.ID,
-				IP:             bag.IP,
-				Action:         database.AuditActionWrite,
-				Status:         http.StatusOK,
-			})
+			dormancyUnset = true
 		}
 
 		previousWorkspaceBuild, err = tx.GetLatestWorkspaceBuildByWorkspaceID(ctx, workspace.ID)
@@ -491,6 +481,27 @@ func (api *API) postWorkspaceBuildsInternal(
 	})
 	if err != nil {
 		return codersdk.WorkspaceBuild{}, err
+	}
+
+	// Emit the dormancy audit entry after the transaction commits
+	// so it is only recorded once, even if the transaction retried.
+	if dormancyUnset {
+		updatedWorkspace := workspace.WorkspaceTable()
+		updatedWorkspace.DormantAt = sql.NullTime{Valid: false}
+		auditor := api.Auditor.Load()
+		bag := audit.BaggageFromContext(ctx)
+		audit.BackgroundAudit(ctx, &audit.BackgroundAuditParams[database.WorkspaceTable]{
+			Audit:          *auditor,
+			Old:            workspace.WorkspaceTable(),
+			New:            updatedWorkspace,
+			Log:            api.Logger,
+			UserID:         apiKey.UserID,
+			OrganizationID: workspace.OrganizationID,
+			RequestID:      workspace.ID,
+			IP:             bag.IP,
+			Action:         database.AuditActionWrite,
+			Status:         http.StatusOK,
+		})
 	}
 
 	var queuePos database.GetProvisionerJobsByIDsWithQueuePositionRow

--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -397,22 +397,12 @@ func (api *API) postWorkspaceBuildsInternal(
 		provisionerDaemons     []database.GetEligibleProvisionerDaemonsByProvisionerJobIDsRow
 	)
 
-	// TODO: This transaction uses the default isolation level, but
-	// builder.Build() calls ReadModifyUpdate internally which needs
-	// RepeatableRead to detect concurrent modifications and retry.
-	// Because InTx reuses the parent transaction, the RepeatableRead
-	// request is silently ignored and its retry loop is ineffective.
-	//
-	// ReadModifyUpdate was added in #10277 (Oct 2023) when Build()
-	// was called directly on api.Database with no outer transaction.
-	// This outer InTx was introduced later in #15979 (Jan 2025) for
-	// workspace update notifications, unintentionally nesting the
-	// repeatable-read transaction inside a default-isolation parent.
-	//
-	// This should be elevated to sql.LevelRepeatableRead to match
-	// what the lifecycle executor already does, with the retry loop
-	// moved to wrap the outer transaction.
-	err := api.Database.InTx(func(tx database.Store) error {
+	// Use ReadModifyUpdate to run at RepeatableRead isolation with
+	// retries on serialization errors. Build() also calls
+	// ReadModifyUpdate internally, but since InTx reuses the parent
+	// transaction the inner call becomes a no-op; the isolation
+	// and retry behavior are provided by this outer call.
+	err := database.ReadModifyUpdate(api.Database, func(tx database.Store) error {
 		var err error
 
 		// #20925: if the workspace is dormant and we are starting the workspace,
@@ -498,7 +488,7 @@ func (api *API) postWorkspaceBuildsInternal(
 			workspaceBuildBaggage,
 		)
 		return err
-	}, nil)
+	})
 	if err != nil {
 		return codersdk.WorkspaceBuild{}, err
 	}

--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -421,10 +421,10 @@ func (api *API) postWorkspaceBuildsInternal(
 				ID:        workspace.ID,
 				DormantAt: sql.NullTime{Valid: false},
 			}); err != nil {
-				return httperror.NewResponseError(http.StatusInternalServerError, codersdk.Response{
+				return httperror.NewResponseWithError(http.StatusInternalServerError, codersdk.Response{
 					Message: "Internal error unsetting workspace dormant status",
 					Detail:  err.Error(),
-				})
+				}, err)
 			}
 			dormancyUnset = true
 		}
@@ -432,10 +432,10 @@ func (api *API) postWorkspaceBuildsInternal(
 		previousWorkspaceBuild, err = tx.GetLatestWorkspaceBuildByWorkspaceID(ctx, workspace.ID)
 		if err != nil && !xerrors.Is(err, sql.ErrNoRows) {
 			api.Logger.Error(ctx, "failed fetching previous workspace build", slog.F("workspace_id", workspace.ID), slog.Error(err))
-			return httperror.NewResponseError(http.StatusInternalServerError, codersdk.Response{
+			return httperror.NewResponseWithError(http.StatusInternalServerError, codersdk.Response{
 				Message: "Internal error fetching previous workspace build",
 				Detail:  err.Error(),
-			})
+			}, err)
 		}
 
 		if createBuild.TemplateVersionID != uuid.Nil {

--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -396,6 +396,11 @@ func (api *API) postWorkspaceBuildsInternal(
 		provisionerDaemons     []database.GetEligibleProvisionerDaemonsByProvisionerJobIDsRow
 	)
 
+	// Track whether dormancy was unset so we can emit the audit
+	// entry after the transaction commits, avoiding duplicate
+	// audit logs on serialization retries.
+	var dormancyUnset bool
+
 	// Use ReadModifyUpdate to run at RepeatableRead isolation with
 	// retries on serialization errors. Build() also calls
 	// ReadModifyUpdate internally, but since InTx reuses the parent
@@ -403,6 +408,7 @@ func (api *API) postWorkspaceBuildsInternal(
 	// and retry behavior are provided by this outer call.
 	err := database.ReadModifyUpdate(api.Database, func(tx database.Store) error {
 		var err error
+		dormancyUnset = false
 
 		// #20925: if the workspace is dormant and we are starting the workspace,
 		// we need to unset that status before inserting a new build.
@@ -419,23 +425,7 @@ func (api *API) postWorkspaceBuildsInternal(
 					Detail:  err.Error(),
 				})
 			}
-			// We need to audit this change separately.
-			updatedWorkspace := workspace.WorkspaceTable()
-			updatedWorkspace.DormantAt = sql.NullTime{Valid: false}
-			auditor := api.Auditor.Load()
-			bag := audit.BaggageFromContext(ctx)
-			audit.BackgroundAudit(ctx, &audit.BackgroundAuditParams[database.WorkspaceTable]{
-				Audit:          *auditor,
-				Old:            workspace.WorkspaceTable(),
-				New:            updatedWorkspace,
-				Log:            api.Logger,
-				UserID:         apiKey.UserID,
-				OrganizationID: workspace.OrganizationID,
-				RequestID:      workspace.ID,
-				IP:             bag.IP,
-				Action:         database.AuditActionWrite,
-				Status:         http.StatusOK,
-			})
+			dormancyUnset = true
 		}
 
 		previousWorkspaceBuild, err = tx.GetLatestWorkspaceBuildByWorkspaceID(ctx, workspace.ID)
@@ -490,6 +480,27 @@ func (api *API) postWorkspaceBuildsInternal(
 	})
 	if err != nil {
 		return codersdk.WorkspaceBuild{}, err
+	}
+
+	// Emit the dormancy audit entry after the transaction commits
+	// so it is only recorded once, even if the transaction retried.
+	if dormancyUnset {
+		updatedWorkspace := workspace.WorkspaceTable()
+		updatedWorkspace.DormantAt = sql.NullTime{Valid: false}
+		auditor := api.Auditor.Load()
+		bag := audit.BaggageFromContext(ctx)
+		audit.BackgroundAudit(ctx, &audit.BackgroundAuditParams[database.WorkspaceTable]{
+			Audit:          *auditor,
+			Old:            workspace.WorkspaceTable(),
+			New:            updatedWorkspace,
+			Log:            api.Logger,
+			UserID:         apiKey.UserID,
+			OrganizationID: workspace.OrganizationID,
+			RequestID:      workspace.ID,
+			IP:             bag.IP,
+			Action:         database.AuditActionWrite,
+			Status:         http.StatusOK,
+		})
 	}
 
 	var queuePos database.GetProvisionerJobsByIDsWithQueuePositionRow

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -668,22 +668,12 @@ func createWorkspace(
 		provisionerDaemons []database.GetEligibleProvisionerDaemonsByProvisionerJobIDsRow
 	)
 
-	// TODO: This transaction uses the default isolation level, but
-	// builder.Build() calls ReadModifyUpdate internally which needs
-	// RepeatableRead to detect concurrent modifications and retry.
-	// Because InTx reuses the parent transaction, the RepeatableRead
-	// request is silently ignored and its retry loop is ineffective.
-	//
-	// This outer InTx dates back to #1486 (May 2022) and predates
-	// ReadModifyUpdate, which was added in #10277 (Oct 2023). The
-	// repeatable-read transaction and retry loop inside Build() have
-	// never worked correctly in this code path — they were always
-	// nested inside this default-isolation parent.
-	//
-	// This should be elevated to sql.LevelRepeatableRead to match
-	// what the lifecycle executor already does, with the retry loop
-	// moved to wrap the outer transaction.
-	err = api.Database.InTx(func(db database.Store) error {
+	// Use ReadModifyUpdate to run at RepeatableRead isolation with
+	// retries on serialization errors. Build() also calls
+	// ReadModifyUpdate internally, but since InTx reuses the parent
+	// transaction the inner call becomes a no-op — the isolation
+	// and retry behavior are provided by this outer call.
+	err = database.ReadModifyUpdate(api.Database, func(db database.Store) error {
 		var (
 			prebuildsClaimer = *api.PrebuildsClaimer.Load()
 			workspaceID      uuid.UUID
@@ -830,7 +820,7 @@ func createWorkspace(
 			audit.WorkspaceBuildBaggage{IP: opts.remoteAddr},
 		)
 		return err
-	}, nil)
+	})
 	if err != nil {
 		return codersdk.Workspace{}, err
 	}

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -668,22 +668,12 @@ func createWorkspace(
 		provisionerDaemons []database.GetEligibleProvisionerDaemonsByProvisionerJobIDsRow
 	)
 
-	// TODO: This transaction uses the default isolation level, but
-	// builder.Build() calls ReadModifyUpdate internally which needs
-	// RepeatableRead to detect concurrent modifications and retry.
-	// Because InTx reuses the parent transaction, the RepeatableRead
-	// request is silently ignored and its retry loop is ineffective.
-	//
-	// This outer InTx dates back to #1486 (May 2022) and predates
-	// ReadModifyUpdate, which was added in #10277 (Oct 2023). The
-	// repeatable-read transaction and retry loop inside Build() have
-	// never worked correctly in this code path; they were always
-	// nested inside this default-isolation parent.
-	//
-	// This should be elevated to sql.LevelRepeatableRead to match
-	// what the lifecycle executor already does, with the retry loop
-	// moved to wrap the outer transaction.
-	err = api.Database.InTx(func(db database.Store) error {
+	// Use ReadModifyUpdate to run at RepeatableRead isolation with
+	// retries on serialization errors. Build() also calls
+	// ReadModifyUpdate internally, but since InTx reuses the parent
+	// transaction the inner call becomes a no-op; the isolation
+	// and retry behavior are provided by this outer call.
+	err = database.ReadModifyUpdate(api.Database, func(db database.Store) error {
 		var (
 			prebuildsClaimer = *api.PrebuildsClaimer.Load()
 			workspaceID      uuid.UUID
@@ -831,7 +821,7 @@ func createWorkspace(
 			audit.WorkspaceBuildBaggage{IP: opts.remoteAddr},
 		)
 		return err
-	}, nil)
+	})
 	if err != nil {
 		return codersdk.Workspace{}, err
 	}

--- a/coderd/wsbuilder/wsbuilder.go
+++ b/coderd/wsbuilder/wsbuilder.go
@@ -95,6 +95,30 @@ type Builder struct {
 	buildMetrics *Metrics
 }
 
+// resetCache clears all lazily-populated fields so that a retry within
+// ReadModifyUpdate re-reads everything from the new transaction snapshot.
+func (b *Builder) resetCache() {
+	b.template = nil
+	b.templateVersion = nil
+	b.templateVersionJob = nil
+	b.terraformValues = nil
+	b.templateVersionParameters = nil
+	b.templateVersionVariables = nil
+	b.templateVersionWorkspaceTags = nil
+	b.lastBuild = nil
+	b.lastBuildErr = nil
+	b.lastBuildParameters = nil
+	b.lastBuildJob = nil
+	b.parameterNames = nil
+	b.parameterValues = nil
+	b.templateVersionPresetParameterValues = nil
+	b.parameterRender = nil
+	b.workspaceTags = nil
+	b.task = nil
+	b.hasTask = nil
+	b.verifyNoLegacyParametersOnce = false
+}
+
 type UsageChecker interface {
 	CheckBuildUsage(ctx context.Context, store database.Store, templateVersion *database.TemplateVersion, task *database.Task, transition database.WorkspaceTransition) (UsageCheckResponse, error)
 }
@@ -320,18 +344,12 @@ func (b *Builder) Build(
 	// computing the new build.  This simplifies the logic so that we do not need to worry if
 	// later reads are consistent with earlier ones.
 	//
-	// TODO: On retry, the Builder's lazy-cached fields (b.template,
-	// b.templateVersion, b.lastBuild, etc.) retain stale data from the
-	// failed attempt because the getters short-circuit when the cache is
-	// non-nil. This means a retry may compute the new build using a
-	// snapshot that no longer matches the database. The caches should be
-	// reset at the top of each attempt so that buildTx re-reads
-	// everything from the new transaction snapshot.
 	var workspaceBuild *database.WorkspaceBuild
 	var provisionerJob *database.ProvisionerJob
 	var provisionerDaemons []database.GetEligibleProvisionerDaemonsByProvisionerJobIDsRow
 	err = database.ReadModifyUpdate(store, func(tx database.Store) error {
 		var err error
+		b.resetCache()
 		b.store = tx
 		workspaceBuild, provisionerJob, provisionerDaemons, err = b.buildTx(authFunc)
 		return err

--- a/coderd/wsbuilder/wsbuilder.go
+++ b/coderd/wsbuilder/wsbuilder.go
@@ -319,6 +319,14 @@ func (b *Builder) Build(
 	// RepeatableRead isolation ensures that we get a consistent view of the database while
 	// computing the new build.  This simplifies the logic so that we do not need to worry if
 	// later reads are consistent with earlier ones.
+	//
+	// TODO: On retry, the Builder's lazy-cached fields (b.template,
+	// b.templateVersion, b.lastBuild, etc.) retain stale data from the
+	// failed attempt because the getters short-circuit when the cache is
+	// non-nil. This means a retry may compute the new build using a
+	// snapshot that no longer matches the database. The caches should be
+	// reset at the top of each attempt so that buildTx re-reads
+	// everything from the new transaction snapshot.
 	var workspaceBuild *database.WorkspaceBuild
 	var provisionerJob *database.ProvisionerJob
 	var provisionerDaemons []database.GetEligibleProvisionerDaemonsByProvisionerJobIDsRow

--- a/coderd/wsbuilder/wsbuilder.go
+++ b/coderd/wsbuilder/wsbuilder.go
@@ -333,6 +333,14 @@ func (b *Builder) Build(
 	// RepeatableRead isolation ensures that we get a consistent view of the database while
 	// computing the new build.  This simplifies the logic so that we do not need to worry if
 	// later reads are consistent with earlier ones.
+	//
+	// TODO: On retry, the Builder's lazy-cached fields (b.template,
+	// b.templateVersion, b.lastBuild, etc.) retain stale data from the
+	// failed attempt because the getters short-circuit when the cache is
+	// non-nil. This means a retry may compute the new build using a
+	// snapshot that no longer matches the database. The caches should be
+	// reset at the top of each attempt so that buildTx re-reads
+	// everything from the new transaction snapshot.
 	var workspaceBuild *database.WorkspaceBuild
 	var provisionerJob *database.ProvisionerJob
 	var provisionerDaemons []database.GetEligibleProvisionerDaemonsByProvisionerJobIDsRow

--- a/coderd/wsbuilder/wsbuilder.go
+++ b/coderd/wsbuilder/wsbuilder.go
@@ -98,6 +98,30 @@ type Builder struct {
 	buildMetrics *Metrics
 }
 
+// resetCache clears all lazily-populated fields so that a retry within
+// ReadModifyUpdate re-reads everything from the new transaction snapshot.
+func (b *Builder) resetCache() {
+	b.template = nil
+	b.templateVersion = nil
+	b.templateVersionJob = nil
+	b.terraformValues = nil
+	b.templateVersionParameters = nil
+	b.templateVersionVariables = nil
+	b.templateVersionWorkspaceTags = nil
+	b.lastBuild = nil
+	b.lastBuildErr = nil
+	b.lastBuildParameters = nil
+	b.lastBuildJob = nil
+	b.parameterNames = nil
+	b.parameterValues = nil
+	b.templateVersionPresetParameterValues = nil
+	b.parameterRender = nil
+	b.workspaceTags = nil
+	b.task = nil
+	b.hasTask = nil
+	b.verifyNoLegacyParametersOnce = false
+}
+
 type UsageChecker interface {
 	CheckBuildUsage(ctx context.Context, store database.Store, templateVersion *database.TemplateVersion, task *database.Task, transition database.WorkspaceTransition) (UsageCheckResponse, error)
 }
@@ -334,18 +358,12 @@ func (b *Builder) Build(
 	// computing the new build.  This simplifies the logic so that we do not need to worry if
 	// later reads are consistent with earlier ones.
 	//
-	// TODO: On retry, the Builder's lazy-cached fields (b.template,
-	// b.templateVersion, b.lastBuild, etc.) retain stale data from the
-	// failed attempt because the getters short-circuit when the cache is
-	// non-nil. This means a retry may compute the new build using a
-	// snapshot that no longer matches the database. The caches should be
-	// reset at the top of each attempt so that buildTx re-reads
-	// everything from the new transaction snapshot.
 	var workspaceBuild *database.WorkspaceBuild
 	var provisionerJob *database.ProvisionerJob
 	var provisionerDaemons []database.GetEligibleProvisionerDaemonsByProvisionerJobIDsRow
 	err = database.ReadModifyUpdate(store, func(tx database.Store) error {
 		var err error
+		b.resetCache()
 		b.store = tx
 		workspaceBuild, provisionerJob, provisionerDaemons, err = b.buildTx(authFunc)
 		return err

--- a/coderd/wsbuilder/wsbuilder_test.go
+++ b/coderd/wsbuilder/wsbuilder_test.go
@@ -1242,6 +1242,12 @@ func expectDB(t *testing.T, opts ...txExpect) *dbmock.MockStore {
 	mDB := dbmock.NewMockStore(ctrl)
 	mTx := dbmock.NewMockStore(ctrl)
 
+	// ReadModifyUpdate queries InTransaction once on the top-level Store
+	// to decide whether to run its retry loop, and once on the inner
+	// Store to take the no-retry fast path when nested.
+	mDB.EXPECT().InTransaction().Return(false).AnyTimes()
+	mTx.EXPECT().InTransaction().Return(true).AnyTimes()
+
 	// we expect to be run in a transaction; we use mTx to record the
 	// "in transaction" calls.
 	mDB.EXPECT().InTx(

--- a/enterprise/coderd/prebuilds/reconcile.go
+++ b/enterprise/coderd/prebuilds/reconcile.go
@@ -890,6 +890,14 @@ func (c *StoreReconciler) createPrebuiltWorkspace(ctx context.Context, prebuiltW
 	}
 
 	var provisionerJob *database.ProvisionerJob
+	// This is a plain InTx rather than ReadModifyUpdate, so a 40001
+	// serialization failure in wsbuilder.Build's inner RMU is not retried
+	// here and this create attempt fails for the current reconciliation
+	// cycle. That is acceptable: the next cycle (default 1m via
+	// CODER_WORKSPACE_PREBUILDS_RECONCILIATION_INTERVAL) recomputes the
+	// desired prebuild pool from current state and will re-issue a Create
+	// action for the missing prebuild, so the system converges to the
+	// correct state without immediate retry. See #21939.
 	err = c.store.InTx(func(db database.Store) error {
 		template, err := db.GetTemplateByID(ctx, templateID)
 		if err != nil {
@@ -1060,6 +1068,14 @@ func (c *StoreReconciler) deletePrebuiltWorkspace(ctx context.Context, prebuiltW
 	defer span.End()
 
 	var provisionerJob *database.ProvisionerJob
+	// This is a plain InTx rather than ReadModifyUpdate, so a 40001
+	// serialization failure in wsbuilder.Build's inner RMU is not retried
+	// here and this delete attempt fails for the current reconciliation
+	// cycle. That is acceptable: the next cycle (default 1m via
+	// CODER_WORKSPACE_PREBUILDS_RECONCILIATION_INTERVAL) recomputes the
+	// desired prebuild pool from current state and will re-issue a Delete
+	// action for the still-extra prebuild, so the system converges to the
+	// correct state without immediate retry. See #21939.
 	err := c.store.InTx(func(db database.Store) (err error) {
 		provisionerJob, err = c.provisionDelete(ctx, db, prebuiltWorkspaceID, templateID, presetID, DeprovisionModeNormal)
 		return err


### PR DESCRIPTION
The outer `InTx` calls wrapping `wsbuilder.Build()` used the default
isolation level, which silently defeated the `RepeatableRead` isolation
and retry logic inside `Build()`'s `ReadModifyUpdate` call. The inner
transaction was reused from the parent, so its isolation request was
ignored and its retry loop was ineffective.

This change replaces both outer `InTx` calls with
`database.ReadModifyUpdate` so the entire transaction runs at
`RepeatableRead` with serialization-error retries. It also hardens
`ReadModifyUpdate` itself against this class of bug: nested invocations
skip their retry loop and let the outermost `ReadModifyUpdate` handle
retries, so future changes to the outer wrapper cannot silently
re-introduce the trap.

It also elevates the nested-transaction isolation log from Warn to
Critical so any remaining mismatches fail tests via `slogtest`.

### Why RepeatableRead

`wsbuilder.Build()` issues many reads (template, template version, job,
terraform values, workspace tags, variables, last build, preset
parameters) and derives the new build from them. `RepeatableRead`
guarantees those reads all see the same snapshot, so `Build()` does
not have to reason about whether a later read is consistent with an
earlier one (e.g. the template version's active job status changing
mid-build). It also turns read-modify-write races on workspace-scoped
rows into clean `40001` retries rather than silent last-writer-wins
clobbers under the default `ReadCommitted` level.

### PR stack

This is the second of three PRs addressing #21939:

1. #24265 — Detection and observability (Warn-level log).
2. **This PR** — Fixes the two broken nesting sites and elevates to Critical.
3. #24319 — Replaces the log with a hard error.

Parts 1 and 2 can ship in the same release. Part 3 should go out in
the following release to allow time to catch any nesting mismatches
that were previously undetected.

Depends on #24265.
Refs https://github.com/coder/coder/issues/21939

## Call sites fixed

1. **`coderd/workspacebuilds.go` — `postWorkspaceBuilds`**: The outer
   `InTx` was introduced in #15979 (Jan 2025) for workspace update
   notifications, after `RepeatableRead` isolation was added in #7541
   (May 2023). The nesting was unintentional. (#10277 later refactored
   the inline retry loop into `ReadModifyUpdate`.)

2. **`coderd/workspaces.go` — `createWorkspace`**: The outer `InTx`
   dates back to #1486 (May 2022) and predates `ReadModifyUpdate`
   entirely. The repeatable-read isolation never worked in this path.

## Call sites intentionally left as plain `InTx`

Three other callers of `wsbuilder.Build()` wrap it in a plain
`InTx(RepeatableRead)` without an outer retry loop and are not
converted to `ReadModifyUpdate` here:

- `coderd/autobuild/lifecycle_executor.go` (autobuild tick)
- `enterprise/coderd/prebuilds/reconcile.go` (prebuild create)
- `enterprise/coderd/prebuilds/reconcile.go` (prebuild delete)

They were left out of this PR for three reasons:

1. **No retry-path test coverage exists for these call sites.** Adding
   `ReadModifyUpdate` here without tests that exercise a 40001 path
   would ship retry behavior that has never been verified.
2. **The lifecycle-executor closure is not retry-idempotent as
   written.** Several outer-scope variables (`job`, `auditLog`,
   `shouldNotifyDormancy`, `shouldNotifyTaskPause`, `didAutoUpdate`,
   `nextBuild`) are set inside transition-specific branches and
   consumed post-tx behind an `err == nil` gate. If attempt-N+1 takes
   a different branch than attempt-N (the canonical 40001 cause),
   stale flags from the earlier attempt would leak out as bogus audit
   rows, notifications, or pubsub posts of a never-committed job UUID.
   Making this site retry-safe is a non-trivial refactor of a
   ~270-line closure and is best done as its own change.
3. **The system converges without immediate retry.** A failed tick
   leaves eligibility unchanged: the lifecycle executor's
   `GetWorkspacesEligibleForTransition` returns the same workspace on
   the next tick (default 1m via `CODER_AUTOBUILD_POLL_INTERVAL`), and
   the prebuilds reconciler recomputes desired pool size each cycle
   (default 1m via `CODER_WORKSPACE_PREBUILDS_RECONCILIATION_INTERVAL`)
   and re-issues the missing Create/Delete action. The user-visible
   latency under contention is bounded to roughly one minute. Inline
   comments at all three sites document this convergence model.

The nestable-`ReadModifyUpdate` change in this PR still benefits these
sites: it ensures the original `40001` surfaces cleanly to the caller
instead of being replaced with `25P02` by the inner retry loop running
against an aborted parent transaction.
