### PR TITLE
fix(coderd/database): return error on nested transaction isolation mismatch

### DIFF
--- a/coderd/database/db.go
+++ b/coderd/database/db.go
@@ -19,6 +19,14 @@ import (
 	slog "cdr.dev/slog/v3"
 )
 
+// ErrNestedTransactionIsolationMismatch is returned when a nested InTx
+// call requests a stricter isolation level than the outer transaction.
+// The inner request would be silently ignored because PostgreSQL does
+// not support changing isolation levels within a transaction. Callers
+// must ensure the outer transaction is started at a sufficiently strict
+// isolation level.
+var ErrNestedTransactionIsolationMismatch = xerrors.New("nested transaction isolation mismatch")
+
 // Store contains all queryable database functions.
 // It extends the generated interface to add transaction support.
 type Store interface {
@@ -206,13 +214,9 @@ func (q *sqlQuerier) runTx(function func(Store) error, txOpts *sql.TxOptions) er
 		parentLevel := normalizeIsolationLevel(q.txIsolationLevel)
 		childLevel := normalizeIsolationLevel(txOpts.Isolation)
 		if childLevel > parentLevel {
-			// The nested call requested a stricter isolation level
-			// than the parent, but it will be silently ignored
-			// because we reuse the parent transaction. Log this so
-			// callers can detect the mismatch.
-			q.logger.Critical(context.Background(), "nested transaction requested stricter isolation level than the outer transaction provides",
-				slog.F("parent_isolation", q.txIsolationLevel.String()),
-				slog.F("requested_isolation", txOpts.Isolation.String()),
+			return xerrors.Errorf(
+				"nested transaction requested stricter isolation level (%s) than the outer transaction provides (%s): %w",
+				txOpts.Isolation, q.txIsolationLevel, ErrNestedTransactionIsolationMismatch,
 			)
 		}
 		err := function(q)

--- a/coderd/database/db.go
+++ b/coderd/database/db.go
@@ -19,6 +19,14 @@ import (
 	slog "cdr.dev/slog/v3"
 )
 
+// ErrNestedTransactionIsolationMismatch is returned when a nested InTx
+// call requests a stricter isolation level than the outer transaction.
+// The inner request would be silently ignored because PostgreSQL does
+// not support changing isolation levels within a transaction. Callers
+// must ensure the outer transaction is started at a sufficiently strict
+// isolation level.
+var ErrNestedTransactionIsolationMismatch = xerrors.New("nested transaction isolation mismatch")
+
 // Store contains all queryable database functions.
 // It extends the generated interface to add transaction support.
 type Store interface {
@@ -215,13 +223,9 @@ func (q *sqlQuerier) runTx(function func(Store) error, txOpts *sql.TxOptions) (e
 		existingLevel := normalizeIsolationLevel(q.txIsolationLevel)
 		requestedLevel := normalizeIsolationLevel(txOpts.Isolation)
 		if requestedLevel > existingLevel {
-			// The nested call requested a stricter isolation level
-			// than the parent, but it will be silently ignored
-			// because we reuse the parent transaction. Log this so
-			// callers can detect the mismatch.
-			q.logger.Critical(context.Background(), "nested transaction requested stricter isolation level than the existing transaction provides",
-				slog.F("existing_isolation", q.txIsolationLevel.String()),
-				slog.F("requested_isolation", txOpts.Isolation.String()),
+			return xerrors.Errorf(
+				"nested transaction requested stricter isolation level (%s) than the existing transaction provides (%s): %w",
+				txOpts.Isolation, q.txIsolationLevel, ErrNestedTransactionIsolationMismatch,
 			)
 		}
 		err := function(q)

--- a/coderd/database/db_test.go
+++ b/coderd/database/db_test.go
@@ -9,12 +9,10 @@ import (
 	"github.com/lib/pq"
 	"github.com/stretchr/testify/require"
 
-	slog "cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/database/migrations"
-	"github.com/coder/coder/v2/testutil"
 )
 
 func TestSerializedRetry(t *testing.T) {
@@ -90,39 +88,18 @@ func TestNestedInTxStricterIsolationDefaultParent(t *testing.T) {
 		t.SkipNow()
 	}
 
-	sink := testutil.NewFakeSink(t)
-	logger := slog.Make(sink).Leveled(slog.LevelDebug)
-
 	sqlDB := testSQLDB(t)
-	db := database.New(sqlDB, database.WithLogger(logger))
+	db := database.New(sqlDB)
 
 	// Outer uses default isolation, inner requests RepeatableRead.
 	// After normalization default becomes ReadCommitted, so the
-	// inner level is stricter and a Warn log should fire.
+	// inner level is stricter and an error should be returned.
 	err := db.InTx(func(outer database.Store) error {
 		return outer.InTx(func(_ database.Store) error {
 			return nil
 		}, &database.TxOptions{Isolation: sql.LevelRepeatableRead})
 	}, nil)
-	require.NoError(t, err)
-
-	entries := sink.Entries(func(e slog.SinkEntry) bool {
-		return e.Level == slog.LevelCritical
-	})
-	require.Len(t, entries, 1, "expected exactly one Critical log entry")
-	require.Contains(t, entries[0].Message, "nested transaction requested stricter isolation level")
-
-	var parentVal, requestedVal string
-	for _, f := range entries[0].Fields {
-		switch f.Name {
-		case "parent_isolation":
-			parentVal, _ = f.Value.(string)
-		case "requested_isolation":
-			requestedVal, _ = f.Value.(string)
-		}
-	}
-	require.Equal(t, sql.LevelDefault.String(), parentVal)
-	require.Equal(t, sql.LevelRepeatableRead.String(), requestedVal)
+	require.ErrorIs(t, err, database.ErrNestedTransactionIsolationMismatch)
 }
 
 func TestNestedInTxStricterIsolationBothExplicit(t *testing.T) {
@@ -131,54 +108,30 @@ func TestNestedInTxStricterIsolationBothExplicit(t *testing.T) {
 		t.SkipNow()
 	}
 
-	sink := testutil.NewFakeSink(t)
-	logger := slog.Make(sink).Leveled(slog.LevelDebug)
-
 	sqlDB := testSQLDB(t)
-	db := database.New(sqlDB, database.WithLogger(logger))
+	db := database.New(sqlDB)
 
 	// Outer uses RepeatableRead, inner requests Serializable.
-	// Both are explicit and the inner is stricter, so a Warn
-	// log should fire.
+	// Both are explicit and the inner is stricter, so an error
+	// should be returned.
 	err := db.InTx(func(outer database.Store) error {
 		return outer.InTx(func(_ database.Store) error {
 			return nil
 		}, &database.TxOptions{Isolation: sql.LevelSerializable})
 	}, &database.TxOptions{Isolation: sql.LevelRepeatableRead})
-	require.NoError(t, err)
-
-	entries := sink.Entries(func(e slog.SinkEntry) bool {
-		return e.Level == slog.LevelCritical
-	})
-	require.Len(t, entries, 1, "expected exactly one Critical log entry")
-	require.Contains(t, entries[0].Message, "nested transaction requested stricter isolation level")
-
-	var parentVal, requestedVal string
-	for _, f := range entries[0].Fields {
-		switch f.Name {
-		case "parent_isolation":
-			parentVal, _ = f.Value.(string)
-		case "requested_isolation":
-			requestedVal, _ = f.Value.(string)
-		}
-	}
-	require.Equal(t, sql.LevelRepeatableRead.String(), parentVal)
-	require.Equal(t, sql.LevelSerializable.String(), requestedVal)
+	require.ErrorIs(t, err, database.ErrNestedTransactionIsolationMismatch)
 }
 
-func TestNestedInTxSameIsolationNoLog(t *testing.T) {
+func TestNestedInTxSameIsolationNoError(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {
 		t.SkipNow()
 	}
 
-	sink := testutil.NewFakeSink(t)
-	logger := slog.Make(sink).Leveled(slog.LevelDebug)
-
 	sqlDB := testSQLDB(t)
-	db := database.New(sqlDB, database.WithLogger(logger))
+	db := database.New(sqlDB)
 
-	// Both use the same isolation level. No log should fire.
+	// Both use the same isolation level. No error should occur.
 	opts := &database.TxOptions{Isolation: sql.LevelRepeatableRead}
 	err := db.InTx(func(outer database.Store) error {
 		return outer.InTx(func(_ database.Store) error {
@@ -186,66 +139,46 @@ func TestNestedInTxSameIsolationNoLog(t *testing.T) {
 		}, opts)
 	}, opts)
 	require.NoError(t, err)
-
-	entries := sink.Entries(func(e slog.SinkEntry) bool {
-		return e.Level == slog.LevelCritical
-	})
-	require.Empty(t, entries, "should not log when isolation levels match")
 }
 
-func TestNestedInTxWeakerIsolationNoLog(t *testing.T) {
+func TestNestedInTxWeakerIsolationNoError(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {
 		t.SkipNow()
 	}
 
-	sink := testutil.NewFakeSink(t)
-	logger := slog.Make(sink).Leveled(slog.LevelDebug)
-
 	sqlDB := testSQLDB(t)
-	db := database.New(sqlDB, database.WithLogger(logger))
+	db := database.New(sqlDB)
 
 	// Outer uses Serializable, inner requests RepeatableRead (weaker).
-	// No log should fire because the inner gets more isolation than needed.
+	// No error should occur because the inner gets more isolation
+	// than needed.
 	err := db.InTx(func(outer database.Store) error {
 		return outer.InTx(func(_ database.Store) error {
 			return nil
 		}, &database.TxOptions{Isolation: sql.LevelRepeatableRead})
 	}, &database.TxOptions{Isolation: sql.LevelSerializable})
 	require.NoError(t, err)
-
-	entries := sink.Entries(func(e slog.SinkEntry) bool {
-		return e.Level == slog.LevelCritical
-	})
-	require.Empty(t, entries, "should not log when inner isolation is weaker than outer")
 }
 
-func TestNestedInTxDefaultVsReadCommittedNoLog(t *testing.T) {
+func TestNestedInTxDefaultVsReadCommittedNoError(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {
 		t.SkipNow()
 	}
 
-	sink := testutil.NewFakeSink(t)
-	logger := slog.Make(sink).Leveled(slog.LevelDebug)
-
 	sqlDB := testSQLDB(t)
-	db := database.New(sqlDB, database.WithLogger(logger))
+	db := database.New(sqlDB)
 
 	// Outer uses default (nil opts), inner requests ReadCommitted.
-	// After normalization both map to ReadCommitted, so no log
-	// should fire.
+	// After normalization both map to ReadCommitted, so no error
+	// should occur.
 	err := db.InTx(func(outer database.Store) error {
 		return outer.InTx(func(_ database.Store) error {
 			return nil
 		}, &database.TxOptions{Isolation: sql.LevelReadCommitted})
 	}, nil)
 	require.NoError(t, err)
-
-	entries := sink.Entries(func(e slog.SinkEntry) bool {
-		return e.Level == slog.LevelCritical
-	})
-	require.Empty(t, entries, "should not log when default and ReadCommitted are equivalent after normalization")
 }
 
 func testSQLDB(t testing.TB) *sql.DB {

--- a/coderd/database/db_test.go
+++ b/coderd/database/db_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/database/migrations"
-	"github.com/coder/coder/v2/testutil"
 )
 
 func TestSerializedRetry(t *testing.T) {
@@ -119,39 +118,18 @@ func TestNestedInTxStricterIsolationDefaultParent(t *testing.T) {
 		t.SkipNow()
 	}
 
-	sink := testutil.NewFakeSink(t)
-	logger := slog.Make(sink).Leveled(slog.LevelDebug)
-
 	sqlDB := testSQLDB(t)
-	db := database.New(sqlDB, logger)
+	db := database.New(sqlDB, slog.Logger{})
 
 	// Outer uses default isolation, inner requests RepeatableRead.
 	// After normalization default becomes ReadCommitted, so the
-	// inner level is stricter and a Critical log should fire.
+	// inner level is stricter and an error should be returned.
 	err := db.InTx(func(outer database.Store) error {
 		return outer.InTx(func(_ database.Store) error {
 			return nil
 		}, &database.TxOptions{Isolation: sql.LevelRepeatableRead})
 	}, nil)
-	require.NoError(t, err)
-
-	entries := sink.Entries(func(e slog.SinkEntry) bool {
-		return e.Level == slog.LevelCritical
-	})
-	require.Len(t, entries, 1, "expected exactly one Critical log entry")
-	require.Contains(t, entries[0].Message, "nested transaction requested stricter isolation level")
-
-	var parentVal, requestedVal string
-	for _, f := range entries[0].Fields {
-		switch f.Name {
-		case "existing_isolation":
-			parentVal, _ = f.Value.(string)
-		case "requested_isolation":
-			requestedVal, _ = f.Value.(string)
-		}
-	}
-	require.Equal(t, sql.LevelDefault.String(), parentVal)
-	require.Equal(t, sql.LevelRepeatableRead.String(), requestedVal)
+	require.ErrorIs(t, err, database.ErrNestedTransactionIsolationMismatch)
 }
 
 func TestNestedInTxStricterIsolationBothExplicit(t *testing.T) {
@@ -160,54 +138,30 @@ func TestNestedInTxStricterIsolationBothExplicit(t *testing.T) {
 		t.SkipNow()
 	}
 
-	sink := testutil.NewFakeSink(t)
-	logger := slog.Make(sink).Leveled(slog.LevelDebug)
-
 	sqlDB := testSQLDB(t)
-	db := database.New(sqlDB, logger)
+	db := database.New(sqlDB, slog.Logger{})
 
 	// Outer uses RepeatableRead, inner requests Serializable.
-	// Both are explicit and the inner is stricter, so a Critical
-	// log should fire.
+	// Both are explicit and the inner is stricter, so an error
+	// should be returned.
 	err := db.InTx(func(outer database.Store) error {
 		return outer.InTx(func(_ database.Store) error {
 			return nil
 		}, &database.TxOptions{Isolation: sql.LevelSerializable})
 	}, &database.TxOptions{Isolation: sql.LevelRepeatableRead})
-	require.NoError(t, err)
-
-	entries := sink.Entries(func(e slog.SinkEntry) bool {
-		return e.Level == slog.LevelCritical
-	})
-	require.Len(t, entries, 1, "expected exactly one Critical log entry")
-	require.Contains(t, entries[0].Message, "nested transaction requested stricter isolation level")
-
-	var parentVal, requestedVal string
-	for _, f := range entries[0].Fields {
-		switch f.Name {
-		case "existing_isolation":
-			parentVal, _ = f.Value.(string)
-		case "requested_isolation":
-			requestedVal, _ = f.Value.(string)
-		}
-	}
-	require.Equal(t, sql.LevelRepeatableRead.String(), parentVal)
-	require.Equal(t, sql.LevelSerializable.String(), requestedVal)
+	require.ErrorIs(t, err, database.ErrNestedTransactionIsolationMismatch)
 }
 
-func TestNestedInTxSameIsolationNoLog(t *testing.T) {
+func TestNestedInTxSameIsolationNoError(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {
 		t.SkipNow()
 	}
 
-	sink := testutil.NewFakeSink(t)
-	logger := slog.Make(sink).Leveled(slog.LevelDebug)
-
 	sqlDB := testSQLDB(t)
-	db := database.New(sqlDB, logger)
+	db := database.New(sqlDB, slog.Logger{})
 
-	// Both use the same isolation level. No log should fire.
+	// Both use the same isolation level. No error should occur.
 	opts := &database.TxOptions{Isolation: sql.LevelRepeatableRead}
 	err := db.InTx(func(outer database.Store) error {
 		return outer.InTx(func(_ database.Store) error {
@@ -215,66 +169,46 @@ func TestNestedInTxSameIsolationNoLog(t *testing.T) {
 		}, opts)
 	}, opts)
 	require.NoError(t, err)
-
-	entries := sink.Entries(func(e slog.SinkEntry) bool {
-		return e.Level == slog.LevelCritical
-	})
-	require.Empty(t, entries, "should not log when isolation levels match")
 }
 
-func TestNestedInTxWeakerIsolationNoLog(t *testing.T) {
+func TestNestedInTxWeakerIsolationNoError(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {
 		t.SkipNow()
 	}
 
-	sink := testutil.NewFakeSink(t)
-	logger := slog.Make(sink).Leveled(slog.LevelDebug)
-
 	sqlDB := testSQLDB(t)
-	db := database.New(sqlDB, logger)
+	db := database.New(sqlDB, slog.Logger{})
 
 	// Outer uses Serializable, inner requests RepeatableRead (weaker).
-	// No log should fire because the inner gets more isolation than needed.
+	// No error should occur because the inner gets more isolation
+	// than needed.
 	err := db.InTx(func(outer database.Store) error {
 		return outer.InTx(func(_ database.Store) error {
 			return nil
 		}, &database.TxOptions{Isolation: sql.LevelRepeatableRead})
 	}, &database.TxOptions{Isolation: sql.LevelSerializable})
 	require.NoError(t, err)
-
-	entries := sink.Entries(func(e slog.SinkEntry) bool {
-		return e.Level == slog.LevelCritical
-	})
-	require.Empty(t, entries, "should not log when inner isolation is weaker than outer")
 }
 
-func TestNestedInTxDefaultVsReadCommittedNoLog(t *testing.T) {
+func TestNestedInTxDefaultVsReadCommittedNoError(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {
 		t.SkipNow()
 	}
 
-	sink := testutil.NewFakeSink(t)
-	logger := slog.Make(sink).Leveled(slog.LevelDebug)
-
 	sqlDB := testSQLDB(t)
-	db := database.New(sqlDB, logger)
+	db := database.New(sqlDB, slog.Logger{})
 
 	// Outer uses default (nil opts), inner requests ReadCommitted.
-	// After normalization both map to ReadCommitted, so no log
-	// should fire.
+	// After normalization both map to ReadCommitted, so no error
+	// should occur.
 	err := db.InTx(func(outer database.Store) error {
 		return outer.InTx(func(_ database.Store) error {
 			return nil
 		}, &database.TxOptions{Isolation: sql.LevelReadCommitted})
 	}, nil)
 	require.NoError(t, err)
-
-	entries := sink.Entries(func(e slog.SinkEntry) bool {
-		return e.Level == slog.LevelCritical
-	})
-	require.Empty(t, entries, "should not log when default and ReadCommitted are equivalent after normalization")
 }
 
 func TestInTransaction_TopLevel(t *testing.T) {


### PR DESCRIPTION
Replaces the Critical log with a hard error when a nested `InTx` call
requests a stricter isolation level than the outer transaction provides.
The inner request would be silently ignored by PostgreSQL, which could
lead to correctness bugs. Returning an error makes this a test-time and
runtime failure rather than a log observation.

Adds `ErrNestedTransactionIsolationMismatch` sentinel error so callers
can check for this specific condition.

### PR stack

This is the third of three PRs addressing #21939:

1. #24265 — Detection and observability (Warn-level log).
2. #24317 — Fixes the two broken nesting sites and elevates to Critical.
3. **This PR** — Replaces the log with a hard error.

Depends on #24317.
Closes https://github.com/coder/coder/issues/21939

Parts 1 and 2 should ship first. This PR should go out in the
following release to allow time to catch any nesting mismatches
that were previously undetected before enforcing a hard error.

With all three merged, any code path that nests transactions with
incompatible isolation levels will fail immediately with a clear error,
rather than silently running at the wrong isolation level.
