### PR TITLE
feat: add GET /workspaceagents/me/metadata endpoint

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -10463,6 +10463,34 @@ const docTemplate = `{
                 ]
             }
         },
+        "/workspaceagents/me/metadata": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Agents"
+                ],
+                "summary": "Get workspace agent metadata for the authenticated agent",
+                "operationId": "get-workspace-agent-metadata-me",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/codersdk.WorkspaceAgentMetadata"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
         "/workspaceagents/me/reinit": {
             "get": {
                 "produces": [
@@ -22704,6 +22732,56 @@ const docTemplate = `{
                 "workspace_agent_id": {
                     "type": "string",
                     "format": "uuid"
+                }
+            }
+        },
+        "codersdk.WorkspaceAgentMetadata": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "$ref": "#/definitions/codersdk.WorkspaceAgentMetadataDescription"
+                },
+                "result": {
+                    "$ref": "#/definitions/codersdk.WorkspaceAgentMetadataResult"
+                }
+            }
+        },
+        "codersdk.WorkspaceAgentMetadataDescription": {
+            "type": "object",
+            "properties": {
+                "display_name": {
+                    "type": "string"
+                },
+                "interval": {
+                    "type": "integer"
+                },
+                "key": {
+                    "type": "string"
+                },
+                "script": {
+                    "type": "string"
+                },
+                "timeout": {
+                    "type": "integer"
+                }
+            }
+        },
+        "codersdk.WorkspaceAgentMetadataResult": {
+            "type": "object",
+            "properties": {
+                "age": {
+                    "description": "Age is the number of seconds since the metadata was collected.\nIt is provided in addition to CollectedAt to protect against clock skew.",
+                    "type": "integer"
+                },
+                "collected_at": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "error": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
                 }
             }
         },

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -10471,8 +10471,8 @@ const docTemplate = `{
                 "tags": [
                     "Agents"
                 ],
-                "summary": "Get workspace agent metadata for the authenticated agent",
-                "operationId": "get-workspace-agent-metadata-me",
+                "summary": "Get current workspace agent metadata",
+                "operationId": "get-current-workspace-agent-metadata",
                 "responses": {
                     "200": {
                         "description": "OK",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -9270,6 +9270,30 @@
 				]
 			}
 		},
+		"/workspaceagents/me/metadata": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Agents"],
+				"summary": "Get workspace agent metadata for the authenticated agent",
+				"operationId": "get-workspace-agent-metadata-me",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"type": "array",
+							"items": {
+								"$ref": "#/definitions/codersdk.WorkspaceAgentMetadata"
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
 		"/workspaceagents/me/reinit": {
 			"get": {
 				"produces": ["application/json"],
@@ -20916,6 +20940,56 @@
 				"workspace_agent_id": {
 					"type": "string",
 					"format": "uuid"
+				}
+			}
+		},
+		"codersdk.WorkspaceAgentMetadata": {
+			"type": "object",
+			"properties": {
+				"description": {
+					"$ref": "#/definitions/codersdk.WorkspaceAgentMetadataDescription"
+				},
+				"result": {
+					"$ref": "#/definitions/codersdk.WorkspaceAgentMetadataResult"
+				}
+			}
+		},
+		"codersdk.WorkspaceAgentMetadataDescription": {
+			"type": "object",
+			"properties": {
+				"display_name": {
+					"type": "string"
+				},
+				"interval": {
+					"type": "integer"
+				},
+				"key": {
+					"type": "string"
+				},
+				"script": {
+					"type": "string"
+				},
+				"timeout": {
+					"type": "integer"
+				}
+			}
+		},
+		"codersdk.WorkspaceAgentMetadataResult": {
+			"type": "object",
+			"properties": {
+				"age": {
+					"description": "Age is the number of seconds since the metadata was collected.\nIt is provided in addition to CollectedAt to protect against clock skew.",
+					"type": "integer"
+				},
+				"collected_at": {
+					"type": "string",
+					"format": "date-time"
+				},
+				"error": {
+					"type": "string"
+				},
+				"value": {
+					"type": "string"
 				}
 			}
 		},

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -9274,8 +9274,8 @@
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Agents"],
-				"summary": "Get workspace agent metadata for the authenticated agent",
-				"operationId": "get-workspace-agent-metadata-me",
+				"summary": "Get current workspace agent metadata",
+				"operationId": "get-current-workspace-agent-metadata",
 				"responses": {
 					"200": {
 						"description": "OK",

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1662,6 +1662,7 @@ func New(options *Options) *API {
 				r.Get("/gitsshkey", api.agentGitSSHKey)
 				r.Post("/log-source", api.workspaceAgentPostLogSource)
 				r.Get("/reinit", api.workspaceAgentReinit)
+				r.Get("/metadata", api.workspaceAgentMetadataMe)
 				r.Route("/experimental", func(r chi.Router) {
 					r.Post("/chat-context", api.workspaceAgentAddChatContext)
 					r.Delete("/chat-context", api.workspaceAgentClearChatContext)

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1662,7 +1662,7 @@ func New(options *Options) *API {
 				r.Get("/gitsshkey", api.agentGitSSHKey)
 				r.Post("/log-source", api.workspaceAgentPostLogSource)
 				r.Get("/reinit", api.workspaceAgentReinit)
-				r.Get("/metadata", api.workspaceAgentMetadataMe)
+				r.Get("/metadata", api.workspaceAgentMetadata)
 				r.Route("/experimental", func(r chi.Router) {
 					r.Post("/chat-context", api.workspaceAgentAddChatContext)
 					r.Delete("/chat-context", api.workspaceAgentClearChatContext)

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -1653,6 +1653,32 @@ func convertScripts(dbScripts []database.WorkspaceAgentScript) []codersdk.Worksp
 	return scripts
 }
 
+// @Summary Get workspace agent metadata for the authenticated agent
+// @ID get-workspace-agent-metadata-me
+// @Security CoderSessionToken
+// @Produce json
+// @Tags Agents
+// @Success 200 {array} codersdk.WorkspaceAgentMetadata
+// @Router /workspaceagents/me/metadata [get]
+func (api *API) workspaceAgentMetadataMe(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	workspaceAgent := httpmw.WorkspaceAgent(r)
+
+	md, err := api.Database.GetWorkspaceAgentMetadata(ctx, database.GetWorkspaceAgentMetadataParams{
+		WorkspaceAgentID: workspaceAgent.ID,
+		Keys:             nil,
+	})
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Internal error fetching workspace agent metadata.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
+	httpapi.Write(ctx, rw, http.StatusOK, convertWorkspaceAgentMetadata(md))
+}
+
 // @Summary Watch for workspace agent metadata updates
 // @ID watch-for-workspace-agent-metadata-updates
 // @Security CoderSessionToken

--- a/coderd/workspaceagents.go
+++ b/coderd/workspaceagents.go
@@ -1653,14 +1653,14 @@ func convertScripts(dbScripts []database.WorkspaceAgentScript) []codersdk.Worksp
 	return scripts
 }
 
-// @Summary Get workspace agent metadata for the authenticated agent
-// @ID get-workspace-agent-metadata-me
+// @Summary Get current workspace agent metadata
+// @ID get-current-workspace-agent-metadata
 // @Security CoderSessionToken
 // @Produce json
 // @Tags Agents
 // @Success 200 {array} codersdk.WorkspaceAgentMetadata
 // @Router /workspaceagents/me/metadata [get]
-func (api *API) workspaceAgentMetadataMe(rw http.ResponseWriter, r *http.Request) {
+func (api *API) workspaceAgentMetadata(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	workspaceAgent := httpmw.WorkspaceAgent(r)
 

--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -2407,6 +2407,94 @@ func TestWorkspaceAgent_Metadata(t *testing.T) {
 	post(ctx, "unknown", unknownKeyMetadata)
 }
 
+func TestWorkspaceAgentMetadataMe(t *testing.T) {
+	t.Parallel()
+
+	client, db := coderdtest.NewWithDatabase(t, &coderdtest.Options{
+		MetadataBatcherOptions: []metadatabatcher.Option{
+			metadatabatcher.WithInterval(100 * time.Millisecond),
+		},
+	})
+	user := coderdtest.CreateFirstUser(t, client)
+	r := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
+		OrganizationID: user.OrganizationID,
+		OwnerID:        user.UserID,
+	}).WithAgent(func(agents []*proto.Agent) []*proto.Agent {
+		agents[0].Metadata = []*proto.Agent_Metadata{
+			{
+				DisplayName: "First Meta",
+				Key:         "foo1",
+				Script:      "echo hi",
+				Interval:    10,
+				Timeout:     3,
+			},
+			{
+				DisplayName: "Second Meta",
+				Key:         "foo2",
+				Script:      "echo howdy",
+				Interval:    10,
+				Timeout:     3,
+			},
+		}
+		return agents
+	}).Do()
+
+	agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(r.AgentToken))
+
+	ctx := testutil.Context(t, testutil.WaitMedium)
+	conn, err := agentClient.ConnectRPC(ctx)
+	require.NoError(t, err)
+	defer func() {
+		cErr := conn.Close()
+		require.NoError(t, cErr)
+	}()
+	aAPI := agentproto.NewDRPCAgentClient(conn)
+
+	// Post metadata values so there is something to read.
+	wantValue := codersdk.WorkspaceAgentMetadataResult{
+		CollectedAt: time.Now(),
+		Value:       "bar",
+	}
+	_, err = aAPI.BatchUpdateMetadata(ctx, &agentproto.BatchUpdateMetadataRequest{
+		Metadata: []*agentproto.Metadata{
+			{
+				Key:    "foo1",
+				Result: agentsdk.ProtoFromMetadataResult(wantValue),
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Query the /me/metadata endpoint using the agent client.
+	var md []codersdk.WorkspaceAgentMetadata
+	require.Eventually(t, func() bool {
+		md, err = agentClient.Metadata(ctx)
+		if err != nil {
+			return false
+		}
+		if len(md) != 2 {
+			return false
+		}
+		// Wait until the posted value has propagated.
+		return md[0].Result.Value == "bar"
+	}, testutil.WaitMedium, testutil.IntervalMedium)
+
+	// Verify descriptions are returned correctly.
+	require.Equal(t, "First Meta", md[0].Description.DisplayName)
+	require.Equal(t, "foo1", md[0].Description.Key)
+	require.Equal(t, "echo hi", md[0].Description.Script)
+	require.EqualValues(t, 10, md[0].Description.Interval)
+	require.EqualValues(t, 3, md[0].Description.Timeout)
+
+	// Verify the result value we posted.
+	require.Equal(t, "bar", md[0].Result.Value)
+	require.Empty(t, md[0].Result.Error)
+
+	// Second key should be present but not yet collected.
+	require.Equal(t, "Second Meta", md[1].Description.DisplayName)
+	require.Equal(t, "foo2", md[1].Description.Key)
+}
+
 func TestWorkspaceAgent_Metadata_DisplayOrder(t *testing.T) {
 	t.Parallel()
 

--- a/codersdk/agentsdk/agentsdk.go
+++ b/codersdk/agentsdk/agentsdk.go
@@ -88,6 +88,23 @@ func (c *Client) GitSSHKey(ctx context.Context) (GitSSHKey, error) {
 	return gitSSHKey, json.NewDecoder(res.Body).Decode(&gitSSHKey)
 }
 
+// Metadata returns the current agent's metadata descriptions and
+// collected results.
+func (c *Client) Metadata(ctx context.Context) ([]codersdk.WorkspaceAgentMetadata, error) {
+	res, err := c.SDK.Request(ctx, http.MethodGet, "/api/v2/workspaceagents/me/metadata", nil)
+	if err != nil {
+		return nil, xerrors.Errorf("execute request: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, codersdk.ReadBodyAsError(res)
+	}
+
+	var md []codersdk.WorkspaceAgentMetadata
+	return md, json.NewDecoder(res.Body).Decode(&md)
+}
+
 type Metadata struct {
 	Key string `json:"key"`
 	codersdk.WorkspaceAgentMetadataResult

--- a/docs/admin/templates/extending-templates/agent-metadata.md
+++ b/docs/admin/templates/extending-templates/agent-metadata.md
@@ -142,6 +142,60 @@ You can expect `(10 * 6 * 2) / 4`, or 30 writes per second.
 One of the writes is to the `UNLOGGED` `workspace_agent_metadata` table and the
 other to the `NOTIFY` query that enables live stats streaming in the UI.
 
+## Querying metadata from a workspace
+
+You can query agent metadata from within a running workspace using the
+`GET /api/v2/workspaceagents/me/metadata` endpoint. This is useful for scripts
+or tools inside the workspace that need to read collected metrics
+programmatically.
+
+The Coder agent automatically sets `CODER_AGENT_URL` in the workspace
+environment. To authenticate, expose the agent token as an environment variable
+using the
+[`coder_env`](https://registry.terraform.io/providers/coder/coder/latest/docs/resources/env)
+resource:
+
+```tf
+resource "coder_env" "agent_token" {
+  agent_id = coder_agent.main.id
+  name     = "CODER_AGENT_TOKEN"
+  value    = coder_agent.main.token
+}
+```
+
+Then query the endpoint from inside the workspace:
+
+```sh
+curl -s \
+  -H "Coder-Session-Token: $CODER_AGENT_TOKEN" \
+  "$CODER_AGENT_URL/api/v2/workspaceagents/me/metadata"
+```
+
+The endpoint returns a JSON array of metadata entries:
+
+```json
+[
+  {
+    "result": {
+      "collected_at": "2025-01-01T00:00:00Z",
+      "age": 5,
+      "value": "3.14",
+      "error": ""
+    },
+    "description": {
+      "display_name": "CPU Usage",
+      "key": "cpu",
+      "script": "coder stat cpu",
+      "interval": 10,
+      "timeout": 1
+    }
+  }
+]
+```
+
+Each entry contains a `result` object with the latest collected value and a
+`description` object with the metadata configuration from the template.
+
 ## Next Steps
 
 - [Resource metadata](./resource-metadata.md)

--- a/docs/reference/api/agents.md
+++ b/docs/reference/api/agents.md
@@ -470,7 +470,7 @@ curl -X PATCH http://coder-server:8080/api/v2/workspaceagents/me/logs \
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
-## Get workspace agent metadata for the authenticated agent
+## Get current workspace agent metadata
 
 ### Code samples
 
@@ -513,7 +513,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaceagents/me/metadata \
 |--------|---------------------------------------------------------|-------------|---------------------------------------------------------------------------------------|
 | 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | array of [codersdk.WorkspaceAgentMetadata](schemas.md#codersdkworkspaceagentmetadata) |
 
-<h3 id="get-workspace-agent-metadata-for-the-authenticated-agent-responseschema">Response Schema</h3>
+<h3 id="get-current-workspace-agent-metadata-responseschema">Response Schema</h3>
 
 Status Code **200**
 

--- a/docs/reference/api/agents.md
+++ b/docs/reference/api/agents.md
@@ -470,6 +470,70 @@ curl -X PATCH http://coder-server:8080/api/v2/workspaceagents/me/logs \
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
+## Get workspace agent metadata for the authenticated agent
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/v2/workspaceagents/me/metadata \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /workspaceagents/me/metadata`
+
+### Example responses
+
+> 200 Response
+
+```json
+[
+  {
+    "description": {
+      "display_name": "string",
+      "interval": 0,
+      "key": "string",
+      "script": "string",
+      "timeout": 0
+    },
+    "result": {
+      "age": 0,
+      "collected_at": "2019-08-24T14:15:22Z",
+      "error": "string",
+      "value": "string"
+    }
+  }
+]
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                                |
+|--------|---------------------------------------------------------|-------------|---------------------------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | array of [codersdk.WorkspaceAgentMetadata](schemas.md#codersdkworkspaceagentmetadata) |
+
+<h3 id="get-workspace-agent-metadata-for-the-authenticated-agent-responseschema">Response Schema</h3>
+
+Status Code **200**
+
+| Name              | Type                                                                                               | Required | Restrictions | Description                                                                                                                             |
+|-------------------|----------------------------------------------------------------------------------------------------|----------|--------------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| `[array item]`    | array                                                                                              | false    |              |                                                                                                                                         |
+| `» description`   | [codersdk.WorkspaceAgentMetadataDescription](schemas.md#codersdkworkspaceagentmetadatadescription) | false    |              |                                                                                                                                         |
+| `»» display_name` | string                                                                                             | false    |              |                                                                                                                                         |
+| `»» interval`     | integer                                                                                            | false    |              |                                                                                                                                         |
+| `»» key`          | string                                                                                             | false    |              |                                                                                                                                         |
+| `»» script`       | string                                                                                             | false    |              |                                                                                                                                         |
+| `»» timeout`      | integer                                                                                            | false    |              |                                                                                                                                         |
+| `» result`        | [codersdk.WorkspaceAgentMetadataResult](schemas.md#codersdkworkspaceagentmetadataresult)           | false    |              |                                                                                                                                         |
+| `»» age`          | integer                                                                                            | false    |              | Age is the number of seconds since the metadata was collected. It is provided in addition to CollectedAt to protect against clock skew. |
+| `»» collected_at` | string(date-time)                                                                                  | false    |              |                                                                                                                                         |
+| `»» error`        | string                                                                                             | false    |              |                                                                                                                                         |
+| `»» value`        | string                                                                                             | false    |              |                                                                                                                                         |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
 ## Get workspace agent reinitialization
 
 ### Code samples

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -12241,6 +12241,75 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 | `id`                 | string | false    |              |             |
 | `workspace_agent_id` | string | false    |              |             |
 
+## codersdk.WorkspaceAgentMetadata
+
+```json
+{
+  "description": {
+    "display_name": "string",
+    "interval": 0,
+    "key": "string",
+    "script": "string",
+    "timeout": 0
+  },
+  "result": {
+    "age": 0,
+    "collected_at": "2019-08-24T14:15:22Z",
+    "error": "string",
+    "value": "string"
+  }
+}
+```
+
+### Properties
+
+| Name          | Type                                                                                     | Required | Restrictions | Description |
+|---------------|------------------------------------------------------------------------------------------|----------|--------------|-------------|
+| `description` | [codersdk.WorkspaceAgentMetadataDescription](#codersdkworkspaceagentmetadatadescription) | false    |              |             |
+| `result`      | [codersdk.WorkspaceAgentMetadataResult](#codersdkworkspaceagentmetadataresult)           | false    |              |             |
+
+## codersdk.WorkspaceAgentMetadataDescription
+
+```json
+{
+  "display_name": "string",
+  "interval": 0,
+  "key": "string",
+  "script": "string",
+  "timeout": 0
+}
+```
+
+### Properties
+
+| Name           | Type    | Required | Restrictions | Description |
+|----------------|---------|----------|--------------|-------------|
+| `display_name` | string  | false    |              |             |
+| `interval`     | integer | false    |              |             |
+| `key`          | string  | false    |              |             |
+| `script`       | string  | false    |              |             |
+| `timeout`      | integer | false    |              |             |
+
+## codersdk.WorkspaceAgentMetadataResult
+
+```json
+{
+  "age": 0,
+  "collected_at": "2019-08-24T14:15:22Z",
+  "error": "string",
+  "value": "string"
+}
+```
+
+### Properties
+
+| Name           | Type    | Required | Restrictions | Description                                                                                                                             |
+|----------------|---------|----------|--------------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| `age`          | integer | false    |              | Age is the number of seconds since the metadata was collected. It is provided in addition to CollectedAt to protect against clock skew. |
+| `collected_at` | string  | false    |              |                                                                                                                                         |
+| `error`        | string  | false    |              |                                                                                                                                         |
+| `value`        | string  | false    |              |                                                                                                                                         |
+
 ## codersdk.WorkspaceAgentPortShare
 
 ```json


### PR DESCRIPTION
Adds an agent-token-authenticated endpoint that returns the current agent's metadata descriptions and collected results as a one-shot JSON response. This allows scripts and tools running inside a workspace to query agent metadata programmatically, using the same agent token that is already available via `coder_agent.token`.

- Route: `GET /api/v2/workspaceagents/me/metadata`
- SDK method: `agentsdk.Client.Metadata()`
- Docs: curl/Terraform examples in `agent-metadata.md`

Closes: https://linear.app/codercom/issue/DEVEX-107

<details>
<summary>Implementation notes (Coder Agents generated)</summary>

### Decision log
- Skipped adding `CODER_AGENT_ID` env var — template authors can already expose the agent token via `coder_env` and `coder_agent.token`
- One-shot JSON (not SSE/streaming) — existing watch endpoints serve the dashboard; this is for scripts
- No new CLI command — can follow up separately
- Reuses existing `convertWorkspaceAgentMetadata` helper for consistency with the watch-metadata endpoint

### Files changed
| File | Change |
|------|--------|
| `coderd/coderd.go` | Register route in `/me` group |
| `coderd/workspaceagents.go` | `workspaceAgentMetadataMe` handler |
| `codersdk/agentsdk/agentsdk.go` | `Metadata()` SDK method |
| `coderd/workspaceagents_test.go` | `TestWorkspaceAgentMetadataMe` |
| `docs/.../agent-metadata.md` | Usage docs with curl example |
| `coderd/apidoc/*`, `docs/reference/api/*` | Generated |
</details>

> 🤖 Generated by [Coder Agents](https://coder.com)