### PR TITLE
fix: use dedicated http transport in tests to prevent default transport interference

### DIFF
--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -3521,84 +3521,81 @@ func TestReinit(t *testing.T) {
 		var sdkErr *codersdk.Error
 		require.ErrorAs(t, err, &sdkErr)
 		require.Equal(t, http.StatusConflict, sdkErr.StatusCode())
+	})
+
+	// Verifies the full disconnect-claim-reconnect flow: the
+	// prebuild agent connects to the reinit SSE endpoint, the
+	// connection drops, the prebuild is claimed while the SSE is
+	// down, and the new agent (from the claim build) receives the
+	// reinit event on its first connection via the durable claim
+	// check. This is the sequence that occurs in production when
+	// a network interruption coincides with a claim.
+	t.Run("agent receives claim on reconnect after SSE disconnect", func(t *testing.T) {
+		t.Parallel()
+
+		db, ps, sqlDB := dbtestutil.NewDBWithSQLDB(t)
+		pubsubSpy := pubsubReinitSpy{
+			Pubsub:           ps,
+			triedToSubscribe: make(chan string),
+		}
+		client := coderdtest.New(t, &coderdtest.Options{
+			Database: db,
+			Pubsub:   &pubsubSpy,
 		})
+		user := coderdtest.CreateFirstUser(t, client)
 
+		// Create an unclaimed prebuild.
+		r := setupPrebuildWorkspace(t, db, user.OrganizationID)
 
-		// Verifies the full disconnect-claim-reconnect flow: the
-		// prebuild agent connects to the reinit SSE endpoint, the
-		// connection drops, the prebuild is claimed while the SSE is
-		// down, and the new agent (from the claim build) receives the
-		// reinit event on its first connection via the durable claim
-		// check. This is the sequence that occurs in production when
-		// a network interruption coincides with a claim.
-		t.Run("agent receives claim on reconnect after SSE disconnect", func(t *testing.T) {
-			t.Parallel()
+		pubsubSpy.Lock()
+		pubsubSpy.expectedEvent = agentsdk.PrebuildClaimedChannel(r.Workspace.ID)
+		pubsubSpy.Unlock()
 
-			db, ps, sqlDB := dbtestutil.NewDBWithSQLDB(t)
-			pubsubSpy := pubsubReinitSpy{
-				Pubsub:           ps,
-				triedToSubscribe: make(chan string),
-			}
-			client := coderdtest.New(t, &coderdtest.Options{
-				Database: db,
-				Pubsub:   &pubsubSpy,
-			})
-			user := coderdtest.CreateFirstUser(t, client)
+		agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(r.AgentToken))
 
-			// Create an unclaimed prebuild.
-			r := setupPrebuildWorkspace(t, db, user.OrganizationID)
+		// Step 1: Prebuild agent connects to the reinit SSE
+		// endpoint (build 1 token, workspace is still unclaimed).
+		firstCtx, cancelFirst := context.WithCancel(testutil.Context(t, testutil.WaitShort))
+		firstDone := make(chan error, 1)
+		go func() {
+			_, err := agentClient.WaitForReinit(firstCtx)
+			firstDone <- err
+		}()
 
-			pubsubSpy.Lock()
-			pubsubSpy.expectedEvent = agentsdk.PrebuildClaimedChannel(r.Workspace.ID)
-			pubsubSpy.Unlock()
+		// Wait for the SSE subscription to be established.
+		ctx := testutil.Context(t, testutil.WaitShort)
+		testutil.TryReceive(ctx, t, pubsubSpy.triedToSubscribe)
 
-			agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(r.AgentToken))
+		// Step 2: Disconnect the agent by canceling its request
+		// context, simulating a network interruption.
+		cancelFirst()
+		err := testutil.TryReceive(ctx, t, firstDone)
+		require.Error(t, err)
 
-			// Step 1: Prebuild agent connects to the reinit SSE
-			// endpoint (build 1 token, workspace is still unclaimed).
-			firstCtx, cancelFirst := context.WithCancel(testutil.Context(t, testutil.WaitShort))
-			firstDone := make(chan error, 1)
-			go func() {
-				_, err := agentClient.WaitForReinit(firstCtx)
-				firstDone <- err
-			}()
+		// Prevent the spy from panicking on the second subscribe.
+		pubsubSpy.Lock()
+		pubsubSpy.expectedEvent = ""
+		pubsubSpy.Unlock()
 
-			// Wait for the SSE subscription to be established.
-			ctx := testutil.Context(t, testutil.WaitShort)
-			testutil.TryReceive(ctx, t, pubsubSpy.triedToSubscribe)
+		// Step 3: Claim the prebuild while no SSE connection is
+		// active. The pubsub event fires but nobody is listening.
+		claimR := claimPrebuild(t, db, sqlDB, r.Workspace, user.UserID, r.TemplateVersion.ID, true)
 
-			// Step 2: Disconnect the agent by canceling its request
-			// context, simulating a network interruption.
-			cancelFirst()
-			err := testutil.TryReceive(ctx, t, firstDone)
-			require.Error(t, err)
-
-			// Prevent the spy from panicking on the second subscribe.
-			pubsubSpy.Lock()
-			pubsubSpy.expectedEvent = ""
-			pubsubSpy.Unlock()
-
-			// Step 3: Claim the prebuild while no SSE connection is
-			// active. The pubsub event fires but nobody is listening.
-			claimR := claimPrebuild(t, db, sqlDB, r.Workspace, user.UserID, r.TemplateVersion.ID, true)
-
-			// Step 4: The new agent (from the claim build) connects.
-			// In production, provisionerd starts a new agent process
-			// with the claim build's token after the build completes.
-			// The handler's durable claim check detects the completed
-			// claim and delivers a one-shot reinit immediately.
-			reconnectCtx := testutil.Context(t, testutil.WaitShort)
-			newAgentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(claimR.AgentToken))
-			reinitEvent, err := newAgentClient.WaitForReinit(reconnectCtx)
-			require.NoError(t, err)
-			require.NotNil(t, reinitEvent)
-			require.Equal(t, r.Workspace.ID, reinitEvent.WorkspaceID)
-			require.Equal(t, agentsdk.ReinitializeReasonPrebuildClaimed, reinitEvent.Reason)
-			require.Equal(t, user.UserID, reinitEvent.OwnerID)
-		})
-	}
-
-
+		// Step 4: The new agent (from the claim build) connects.
+		// In production, provisionerd starts a new agent process
+		// with the claim build's token after the build completes.
+		// The handler's durable claim check detects the completed
+		// claim and delivers a one-shot reinit immediately.
+		reconnectCtx := testutil.Context(t, testutil.WaitShort)
+		newAgentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(claimR.AgentToken))
+		reinitEvent, err := newAgentClient.WaitForReinit(reconnectCtx)
+		require.NoError(t, err)
+		require.NotNil(t, reinitEvent)
+		require.Equal(t, r.Workspace.ID, reinitEvent.WorkspaceID)
+		require.Equal(t, agentsdk.ReinitializeReasonPrebuildClaimed, reinitEvent.Reason)
+		require.Equal(t, user.UserID, reinitEvent.OwnerID)
+	})
+}
 
 type pubsubReinitSpy struct {
 	pubsub.Pubsub

--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -3521,8 +3521,84 @@ func TestReinit(t *testing.T) {
 		var sdkErr *codersdk.Error
 		require.ErrorAs(t, err, &sdkErr)
 		require.Equal(t, http.StatusConflict, sdkErr.StatusCode())
-	})
-}
+		})
+
+
+		// Verifies the full disconnect-claim-reconnect flow: the
+		// prebuild agent connects to the reinit SSE endpoint, the
+		// connection drops, the prebuild is claimed while the SSE is
+		// down, and the new agent (from the claim build) receives the
+		// reinit event on its first connection via the durable claim
+		// check. This is the sequence that occurs in production when
+		// a network interruption coincides with a claim.
+		t.Run("agent receives claim on reconnect after SSE disconnect", func(t *testing.T) {
+			t.Parallel()
+
+			db, ps, sqlDB := dbtestutil.NewDBWithSQLDB(t)
+			pubsubSpy := pubsubReinitSpy{
+				Pubsub:           ps,
+				triedToSubscribe: make(chan string),
+			}
+			client := coderdtest.New(t, &coderdtest.Options{
+				Database: db,
+				Pubsub:   &pubsubSpy,
+			})
+			user := coderdtest.CreateFirstUser(t, client)
+
+			// Create an unclaimed prebuild.
+			r := setupPrebuildWorkspace(t, db, user.OrganizationID)
+
+			pubsubSpy.Lock()
+			pubsubSpy.expectedEvent = agentsdk.PrebuildClaimedChannel(r.Workspace.ID)
+			pubsubSpy.Unlock()
+
+			agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(r.AgentToken))
+
+			// Step 1: Prebuild agent connects to the reinit SSE
+			// endpoint (build 1 token, workspace is still unclaimed).
+			firstCtx, cancelFirst := context.WithCancel(testutil.Context(t, testutil.WaitShort))
+			firstDone := make(chan error, 1)
+			go func() {
+				_, err := agentClient.WaitForReinit(firstCtx)
+				firstDone <- err
+			}()
+
+			// Wait for the SSE subscription to be established.
+			ctx := testutil.Context(t, testutil.WaitShort)
+			testutil.TryReceive(ctx, t, pubsubSpy.triedToSubscribe)
+
+			// Step 2: Disconnect the agent by canceling its request
+			// context, simulating a network interruption.
+			cancelFirst()
+			err := testutil.TryReceive(ctx, t, firstDone)
+			require.Error(t, err)
+
+			// Prevent the spy from panicking on the second subscribe.
+			pubsubSpy.Lock()
+			pubsubSpy.expectedEvent = ""
+			pubsubSpy.Unlock()
+
+			// Step 3: Claim the prebuild while no SSE connection is
+			// active. The pubsub event fires but nobody is listening.
+			claimR := claimPrebuild(t, db, sqlDB, r.Workspace, user.UserID, r.TemplateVersion.ID, true)
+
+			// Step 4: The new agent (from the claim build) connects.
+			// In production, provisionerd starts a new agent process
+			// with the claim build's token after the build completes.
+			// The handler's durable claim check detects the completed
+			// claim and delivers a one-shot reinit immediately.
+			reconnectCtx := testutil.Context(t, testutil.WaitShort)
+			newAgentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(claimR.AgentToken))
+			reinitEvent, err := newAgentClient.WaitForReinit(reconnectCtx)
+			require.NoError(t, err)
+			require.NotNil(t, reinitEvent)
+			require.Equal(t, r.Workspace.ID, reinitEvent.WorkspaceID)
+			require.Equal(t, agentsdk.ReinitializeReasonPrebuildClaimed, reinitEvent.Reason)
+			require.Equal(t, user.UserID, reinitEvent.OwnerID)
+		})
+	}
+
+
 
 type pubsubReinitSpy struct {
 	pubsub.Pubsub

--- a/codersdk/agentsdk/agentsdk_test.go
+++ b/codersdk/agentsdk/agentsdk_test.go
@@ -43,7 +43,10 @@ func TestStreamAgentReinitEvents(t *testing.T) {
 		requestCtx := testutil.Context(t, testutil.WaitShort)
 		req, err := http.NewRequestWithContext(requestCtx, "GET", srv.URL, nil)
 		require.NoError(t, err)
-		client := &http.Client{}
+		// Use a dedicated transport to avoid flakes from httptest.Server.Close()
+		// calling CloseIdleConnections on http.DefaultTransport.
+		client := &http.Client{Transport: &http.Transport{}}
+		t.Cleanup(func() { client.CloseIdleConnections() })
 		resp, err := client.Do(req)
 		require.NoError(t, err)
 		defer resp.Body.Close()
@@ -79,7 +82,10 @@ func TestStreamAgentReinitEvents(t *testing.T) {
 		requestCtx := testutil.Context(t, testutil.WaitShort)
 		req, err := http.NewRequestWithContext(requestCtx, "GET", srv.URL, nil)
 		require.NoError(t, err)
-		client := &http.Client{}
+		// Use a dedicated transport to avoid flakes from httptest.Server.Close()
+		// calling CloseIdleConnections on http.DefaultTransport.
+		client := &http.Client{Transport: &http.Transport{}}
+		t.Cleanup(func() { client.CloseIdleConnections() })
 		resp, err := client.Do(req)
 		require.NoError(t, err)
 		defer resp.Body.Close()
@@ -113,7 +119,10 @@ func TestStreamAgentReinitEvents(t *testing.T) {
 		requestCtx := testutil.Context(t, testutil.WaitShort)
 		req, err := http.NewRequestWithContext(requestCtx, "GET", srv.URL, nil)
 		require.NoError(t, err)
-		client := &http.Client{}
+		// Use a dedicated transport to avoid flakes from httptest.Server.Close()
+		// calling CloseIdleConnections on http.DefaultTransport.
+		client := &http.Client{Transport: &http.Transport{}}
+		t.Cleanup(func() { client.CloseIdleConnections() })
 		resp, err := client.Do(req)
 		require.NoError(t, err)
 		defer resp.Body.Close()


### PR DESCRIPTION
## Problem

`TestStreamAgentReinitEvents/doesn't_transmit_events_if_the_transmitter_context_is_canceled` flakes in CI with:

```
Get "http://127.0.0.1:35719": net/http: HTTP/1.x transport connection broken: http: CloseIdleConnections called
```

The error message implicates `CloseIdleConnections` on `http.DefaultTransport`. All three subtests run in parallel and use `&http.Client{}` (which shares `http.DefaultTransport`), and each calls `defer srv.Close()` — which in turn calls `http.DefaultTransport.CloseIdleConnections()`.

However, the exact failure path is unclear. In this test the connections are actively reading SSE response bodies and are never idle, so `CloseIdleConnections` should not affect them. I was unable to reproduce the failure locally even with 500 iterations and aggressive concurrent `CloseIdleConnections` bombardment. The race window likely requires specific CI-level contention to trigger.

## Fix

Give each subtest its own `&http.Transport{}` so connections are fully isolated from the shared default transport. This is a **defensive** change — it eliminates the `CloseIdleConnections` vector regardless of the exact failure mechanism.

This matches the pattern already adopted in `coderd/x/chatd/mcpclient/mcpclient.go`:
```go
// Each connection gets its own HTTP client with a dedicated
// transport so that httptest.Server.Close() (which calls
// CloseIdleConnections on http.DefaultTransport) does not
// disrupt unrelated connections during parallel tests.
```

## Additional test

Adds a `TestReinit` subtest covering the full disconnect-claim-reconnect flow:
1. Prebuild agent connects to the reinit SSE endpoint
2. SSE connection drops (simulated via context cancellation)
3. Prebuild is claimed while no SSE connection is active
4. New agent (claim build token) connects and receives the reinit event from the durable claim check

Relates to https://github.com/coder/internal/issues/1451
Relates to https://github.com/coder/internal/issues/1020

> Generated with [Coder Agents](https://coder.com/agents)