### PR TITLE
fix(coderd/x/chatd): detect disconnected agents in getWorkspaceConn

### DIFF
--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -30,7 +30,6 @@ import (
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/db2sdk"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
-	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/database/pubsub"
 	coderdpubsub "github.com/coder/coder/v2/coderd/pubsub"
 	"github.com/coder/coder/v2/coderd/util/ptr"
@@ -564,11 +563,10 @@ func (c *turnWorkspaceContext) getWorkspaceConnLocked() (workspacesdk.AgentConn,
 
 // isAgentUnreachable reports whether the given agent row's
 // status is disconnected or timed out. It uses timestamp
-// arithmetic on the cached row (no DB re-fetch). The
-// "connecting" state is allowed through because it is normal
-// after a fresh workspace build.
-func isAgentUnreachable(agent database.WorkspaceAgent, inactiveTimeout time.Duration) bool {
-	status := agent.Status(dbtime.Now(), inactiveTimeout)
+// arithmetic on the row. The "connecting" state is allowed
+// through because it is normal after a fresh workspace build.
+func isAgentUnreachable(now time.Time, agent database.WorkspaceAgent, inactiveTimeout time.Duration) bool {
+	status := agent.Status(now, inactiveTimeout)
 	return status.Status == database.WorkspaceAgentStatusDisconnected ||
 		status.Status == database.WorkspaceAgentStatusTimeout
 }
@@ -581,23 +579,21 @@ func (c *turnWorkspaceContext) getWorkspaceConn(ctx context.Context) (workspaces
 	for attempt := 0; attempt < 2; attempt++ {
 		c.mu.Lock()
 		currentConn, staleRelease := c.getWorkspaceConnLocked()
+		agentID := c.agent.ID
 		c.mu.Unlock()
 
 		// Status check on cache hit: re-fetch the agent
 		// row so we see the latest heartbeat rather than
 		// a potentially stale cached copy.
 		if currentConn != nil {
-			c.mu.Lock()
-			agentID := c.agent.ID
-			c.mu.Unlock()
 			if agentID != uuid.Nil {
 				freshAgent, err := c.server.db.GetWorkspaceAgentByID(ctx, agentID)
-				if err == nil && isAgentUnreachable(freshAgent, c.server.agentInactiveDisconnectTimeout) {
+				if err == nil && isAgentUnreachable(c.server.clock.Now(), freshAgent, c.server.agentInactiveDisconnectTimeout) {
 					c.clearCachedWorkspaceState()
 					return nil, errChatAgentDisconnected
 				}
-				// On DB error we allow through; dial
-				// timeout is the safety net.
+				// On DB error the check re-runs on the
+				// next tool call.
 			}
 			return currentConn, nil
 		}
@@ -612,7 +608,7 @@ func (c *turnWorkspaceContext) getWorkspaceConn(ctx context.Context) (workspaces
 
 		// Status check on cache miss: the freshly fetched
 		// agent row may already show disconnected.
-		if isAgentUnreachable(agent, c.server.agentInactiveDisconnectTimeout) {
+		if isAgentUnreachable(c.server.clock.Now(), agent, c.server.agentInactiveDisconnectTimeout) {
 			c.clearCachedWorkspaceState()
 			return nil, errChatAgentDisconnected
 		}

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -64,6 +64,7 @@ const (
 	instructionCacheTTL          = 5 * time.Minute
 	workspaceDialValidationDelay = 5 * time.Second
 	workspaceMCPDiscoveryTimeout = 5 * time.Second
+	defaultDialTimeout           = 30 * time.Second
 	// DefaultChatHeartbeatInterval is the default time between chat
 	// heartbeat updates while a chat is being processed.
 	DefaultChatHeartbeatInterval = 30 * time.Second
@@ -116,7 +117,19 @@ const (
 	defaultSubagentInstruction = "You are running as a delegated sub-agent chat. Complete the delegated task and provide clear, concise assistant responses for the parent agent."
 )
 
-var errChatHasNoWorkspaceAgent = xerrors.New("workspace has no running agent: the workspace is likely stopped. Use the start_workspace tool to start it")
+var (
+	errChatHasNoWorkspaceAgent = xerrors.New("workspace has no running agent: the workspace is likely stopped. Use the start_workspace tool to start it")
+	errChatAgentDisconnected   = xerrors.New(
+		"workspace agent is disconnected and cannot execute tools. " +
+			"Inform the user that the workspace agent has disconnected " +
+			"and the workspace may need to be restarted from the Coder dashboard",
+	)
+	errChatDialTimeout = xerrors.New(
+		"connection to the workspace agent timed out. " +
+			"Inform the user that the workspace agent could not be reached " +
+			"and the workspace may need to be restarted from the Coder dashboard",
+	)
+)
 
 // Server handles background processing of pending chats.
 type Server struct {
@@ -133,6 +146,7 @@ type Server struct {
 
 	agentConnFn                    AgentConnFunc
 	agentInactiveDisconnectTimeout time.Duration
+	dialTimeout                    time.Duration
 	instructionLookupTimeout       time.Duration
 	createWorkspaceFn              chattool.CreateWorkspaceFn
 	startWorkspaceFn               chattool.StartWorkspaceFn
@@ -547,6 +561,17 @@ func (c *turnWorkspaceContext) getWorkspaceConnLocked() (workspacesdk.AgentConn,
 	return nil, agentRelease
 }
 
+// isAgentDisconnected reports whether the cached agent row's
+// status is disconnected or timed out. It uses timestamp
+// arithmetic on the cached row (no DB re-fetch). The
+// "connecting" state is allowed through because it is normal
+// after a fresh workspace build.
+func (c *turnWorkspaceContext) isAgentDisconnected() bool {
+	status := c.agent.Status(c.server.agentInactiveDisconnectTimeout)
+	return status.Status == database.WorkspaceAgentStatusDisconnected ||
+		status.Status == database.WorkspaceAgentStatusTimeout
+}
+
 func (c *turnWorkspaceContext) getWorkspaceConn(ctx context.Context) (workspacesdk.AgentConn, error) {
 	if c.server.agentConnFn == nil {
 		return nil, xerrors.New("workspace agent connector is not configured")
@@ -556,7 +581,16 @@ func (c *turnWorkspaceContext) getWorkspaceConn(ctx context.Context) (workspaces
 		c.mu.Lock()
 		currentConn, staleRelease := c.getWorkspaceConnLocked()
 		c.mu.Unlock()
+
+		// Status check on cache hit: the agent may have
+		// disconnected since the connection was cached.
+		// Status() uses timestamp arithmetic on the cached
+		// row, no DB re-fetch needed.
 		if currentConn != nil {
+			if c.agentLoaded && c.isAgentDisconnected() {
+				c.clearCachedWorkspaceState()
+				return nil, errChatAgentDisconnected
+			}
 			return currentConn, nil
 		}
 		if staleRelease != nil {
@@ -568,8 +602,20 @@ func (c *turnWorkspaceContext) getWorkspaceConn(ctx context.Context) (workspaces
 			return nil, err
 		}
 
+		// Status check on cache miss: the freshly fetched
+		// agent row may already show disconnected.
+		if c.isAgentDisconnected() {
+			c.clearCachedWorkspaceState()
+			return nil, errChatAgentDisconnected
+		}
+
+		// Wrap the dial in a timeout to bound the time spent
+		// waiting for an unreachable agent. The timeout scopes
+		// only dialWithLazyValidation, not ensureWorkspaceAgent
+		// or the post-dial binding steps.
+		dialCtx, dialCancel := context.WithTimeout(ctx, c.server.dialTimeout)
 		dialResult, err := dialWithLazyValidation(
-			ctx,
+			dialCtx,
 			agent.ID,
 			chatSnapshot.WorkspaceID.UUID,
 			DialFunc(c.server.agentConnFn),
@@ -578,13 +624,24 @@ func (c *turnWorkspaceContext) getWorkspaceConn(ctx context.Context) (workspaces
 			},
 			workspaceDialValidationDelay,
 		)
+		dialTimedOut := dialCtx.Err() != nil
+		dialCancel()
 		if err != nil {
 			if xerrors.Is(err, errChatHasNoWorkspaceAgent) {
 				c.clearCachedWorkspaceState()
+				return nil, err
+			}
+			// Convert dial timeout to a sentinel only when the
+			// parent context is still alive. If the parent was
+			// canceled (e.g. ErrInterrupted), its error must
+			// propagate unchanged so the chatloop can detect it.
+			// Check dialTimedOut (captured before dialCancel) to
+			// avoid misclassifying non-timeout dial errors.
+			if ctx.Err() == nil && dialTimedOut {
+				return nil, errChatDialTimeout
 			}
 			return nil, err
 		}
-
 		agentConn := dialResult.Conn
 		agentRelease := dialResult.Release
 		if dialResult.WasSwitched {
@@ -3353,6 +3410,7 @@ func New(cfg Config) *Server {
 		subscribeFn:                    cfg.SubscribeFn,
 		agentConnFn:                    cfg.AgentConn,
 		agentInactiveDisconnectTimeout: cfg.AgentInactiveDisconnectTimeout,
+		dialTimeout:                    defaultDialTimeout,
 		instructionLookupTimeout:       instructionLookupTimeout,
 		createWorkspaceFn:              cfg.CreateWorkspace,
 		startWorkspaceFn:               cfg.StartWorkspace,

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -579,6 +579,9 @@ func (c *turnWorkspaceContext) getWorkspaceConn(ctx context.Context) (workspaces
 	for attempt := 0; attempt < 2; attempt++ {
 		c.mu.Lock()
 		currentConn, staleRelease := c.getWorkspaceConnLocked()
+		// Capture agentID in the same lock section as
+		// currentConn to prevent a TOCTOU race with
+		// concurrent clearCachedWorkspaceState calls.
 		agentID := c.agent.ID
 		c.mu.Unlock()
 
@@ -588,12 +591,17 @@ func (c *turnWorkspaceContext) getWorkspaceConn(ctx context.Context) (workspaces
 		if currentConn != nil {
 			if agentID != uuid.Nil {
 				freshAgent, err := c.server.db.GetWorkspaceAgentByID(ctx, agentID)
-				if err == nil && isAgentUnreachable(c.server.clock.Now(), freshAgent, c.server.agentInactiveDisconnectTimeout) {
+				if err != nil {
+					c.server.logger.Warn(ctx, "failed to re-fetch agent for status check",
+						slog.F("agent_id", agentID),
+						slog.Error(err),
+					)
+					// On DB error the check re-runs on the
+					// next tool call.
+				} else if isAgentUnreachable(c.server.clock.Now(), freshAgent, c.server.agentInactiveDisconnectTimeout) {
 					c.clearCachedWorkspaceState()
 					return nil, errChatAgentDisconnected
 				}
-				// On DB error the check re-runs on the
-				// next tool call.
 			}
 			return currentConn, nil
 		}

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -30,6 +30,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/db2sdk"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
+	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/database/pubsub"
 	coderdpubsub "github.com/coder/coder/v2/coderd/pubsub"
 	"github.com/coder/coder/v2/coderd/util/ptr"
@@ -64,7 +65,9 @@ const (
 	instructionCacheTTL          = 5 * time.Minute
 	workspaceDialValidationDelay = 5 * time.Second
 	workspaceMCPDiscoveryTimeout = 5 * time.Second
-	defaultDialTimeout           = 30 * time.Second
+	// defaultDialTimeout matches the timeout used by ~8 other
+	// server-side AgentConn callers.
+	defaultDialTimeout = 30 * time.Second
 	// DefaultChatHeartbeatInterval is the default time between chat
 	// heartbeat updates while a chat is being processed.
 	DefaultChatHeartbeatInterval = 30 * time.Second
@@ -121,13 +124,11 @@ var (
 	errChatHasNoWorkspaceAgent = xerrors.New("workspace has no running agent: the workspace is likely stopped. Use the start_workspace tool to start it")
 	errChatAgentDisconnected   = xerrors.New(
 		"workspace agent is disconnected and cannot execute tools. " +
-			"Inform the user that the workspace agent has disconnected " +
-			"and the workspace may need to be restarted from the Coder dashboard",
+			"The workspace may need to be restarted from the Coder dashboard",
 	)
 	errChatDialTimeout = xerrors.New(
 		"connection to the workspace agent timed out. " +
-			"Inform the user that the workspace agent could not be reached " +
-			"and the workspace may need to be restarted from the Coder dashboard",
+			"The workspace may need to be restarted from the Coder dashboard",
 	)
 )
 
@@ -561,13 +562,13 @@ func (c *turnWorkspaceContext) getWorkspaceConnLocked() (workspacesdk.AgentConn,
 	return nil, agentRelease
 }
 
-// isAgentDisconnected reports whether the cached agent row's
+// isAgentUnreachable reports whether the given agent row's
 // status is disconnected or timed out. It uses timestamp
 // arithmetic on the cached row (no DB re-fetch). The
 // "connecting" state is allowed through because it is normal
 // after a fresh workspace build.
-func (c *turnWorkspaceContext) isAgentDisconnected() bool {
-	status := c.agent.Status(c.server.agentInactiveDisconnectTimeout)
+func isAgentUnreachable(agent database.WorkspaceAgent, inactiveTimeout time.Duration) bool {
+	status := agent.Status(dbtime.Now(), inactiveTimeout)
 	return status.Status == database.WorkspaceAgentStatusDisconnected ||
 		status.Status == database.WorkspaceAgentStatusTimeout
 }
@@ -582,14 +583,21 @@ func (c *turnWorkspaceContext) getWorkspaceConn(ctx context.Context) (workspaces
 		currentConn, staleRelease := c.getWorkspaceConnLocked()
 		c.mu.Unlock()
 
-		// Status check on cache hit: the agent may have
-		// disconnected since the connection was cached.
-		// Status() uses timestamp arithmetic on the cached
-		// row, no DB re-fetch needed.
+		// Status check on cache hit: re-fetch the agent
+		// row so we see the latest heartbeat rather than
+		// a potentially stale cached copy.
 		if currentConn != nil {
-			if c.agentLoaded && c.isAgentDisconnected() {
-				c.clearCachedWorkspaceState()
-				return nil, errChatAgentDisconnected
+			c.mu.Lock()
+			agentID := c.agent.ID
+			c.mu.Unlock()
+			if agentID != uuid.Nil {
+				freshAgent, err := c.server.db.GetWorkspaceAgentByID(ctx, agentID)
+				if err == nil && isAgentUnreachable(freshAgent, c.server.agentInactiveDisconnectTimeout) {
+					c.clearCachedWorkspaceState()
+					return nil, errChatAgentDisconnected
+				}
+				// On DB error we allow through; dial
+				// timeout is the safety net.
 			}
 			return currentConn, nil
 		}
@@ -604,7 +612,7 @@ func (c *turnWorkspaceContext) getWorkspaceConn(ctx context.Context) (workspaces
 
 		// Status check on cache miss: the freshly fetched
 		// agent row may already show disconnected.
-		if c.isAgentDisconnected() {
+		if isAgentUnreachable(agent, c.server.agentInactiveDisconnectTimeout) {
 			c.clearCachedWorkspaceState()
 			return nil, errChatAgentDisconnected
 		}
@@ -613,7 +621,7 @@ func (c *turnWorkspaceContext) getWorkspaceConn(ctx context.Context) (workspaces
 		// waiting for an unreachable agent. The timeout scopes
 		// only dialWithLazyValidation, not ensureWorkspaceAgent
 		// or the post-dial binding steps.
-		dialCtx, dialCancel := context.WithTimeout(ctx, c.server.dialTimeout)
+		dialCtx, dialCancel := context.WithTimeoutCause(ctx, c.server.dialTimeout, errChatDialTimeout)
 		dialResult, err := dialWithLazyValidation(
 			dialCtx,
 			agent.ID,
@@ -624,20 +632,17 @@ func (c *turnWorkspaceContext) getWorkspaceConn(ctx context.Context) (workspaces
 			},
 			workspaceDialValidationDelay,
 		)
-		dialTimedOut := dialCtx.Err() != nil
 		dialCancel()
 		if err != nil {
 			if xerrors.Is(err, errChatHasNoWorkspaceAgent) {
 				c.clearCachedWorkspaceState()
 				return nil, err
 			}
-			// Convert dial timeout to a sentinel only when the
+			// Surface the dial timeout sentinel only when the
 			// parent context is still alive. If the parent was
 			// canceled (e.g. ErrInterrupted), its error must
 			// propagate unchanged so the chatloop can detect it.
-			// Check dialTimedOut (captured before dialCancel) to
-			// avoid misclassifying non-timeout dial errors.
-			if ctx.Err() == nil && dialTimedOut {
+			if ctx.Err() == nil && errors.Is(context.Cause(dialCtx), errChatDialTimeout) {
 				return nil, errChatDialTimeout
 			}
 			return nil, err

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -60,7 +60,9 @@ const (
 	instructionCacheTTL          = 5 * time.Minute
 	workspaceDialValidationDelay = 5 * time.Second
 	workspaceMCPDiscoveryTimeout = 5 * time.Second
-	defaultDialTimeout           = 30 * time.Second
+	// defaultDialTimeout matches the timeout used by ~8 other
+	// server-side AgentConn callers.
+	defaultDialTimeout = 30 * time.Second
 	// DefaultChatHeartbeatInterval is the default time between chat
 	// heartbeat updates while a chat is being processed.
 	DefaultChatHeartbeatInterval = 30 * time.Second
@@ -112,13 +114,11 @@ var (
 	errChatHasNoWorkspaceAgent = xerrors.New("workspace has no running agent: the workspace is likely stopped. Use the start_workspace tool to start it")
 	errChatAgentDisconnected   = xerrors.New(
 		"workspace agent is disconnected and cannot execute tools. " +
-			"Inform the user that the workspace agent has disconnected " +
-			"and the workspace may need to be restarted from the Coder dashboard",
+			"The workspace may need to be restarted from the Coder dashboard",
 	)
 	errChatDialTimeout = xerrors.New(
 		"connection to the workspace agent timed out. " +
-			"Inform the user that the workspace agent could not be reached " +
-			"and the workspace may need to be restarted from the Coder dashboard",
+			"The workspace may need to be restarted from the Coder dashboard",
 	)
 )
 
@@ -547,13 +547,13 @@ func (c *turnWorkspaceContext) getWorkspaceConnLocked() (workspacesdk.AgentConn,
 	return nil, agentRelease
 }
 
-// isAgentDisconnected reports whether the cached agent row's
+// isAgentUnreachable reports whether the given agent row's
 // status is disconnected or timed out. It uses timestamp
 // arithmetic on the cached row (no DB re-fetch). The
 // "connecting" state is allowed through because it is normal
 // after a fresh workspace build.
-func (c *turnWorkspaceContext) isAgentDisconnected() bool {
-	status := c.agent.Status(c.server.agentInactiveDisconnectTimeout)
+func isAgentUnreachable(agent database.WorkspaceAgent, inactiveTimeout time.Duration) bool {
+	status := agent.Status(inactiveTimeout)
 	return status.Status == database.WorkspaceAgentStatusDisconnected ||
 		status.Status == database.WorkspaceAgentStatusTimeout
 }
@@ -568,14 +568,21 @@ func (c *turnWorkspaceContext) getWorkspaceConn(ctx context.Context) (workspaces
 		currentConn, staleRelease := c.getWorkspaceConnLocked()
 		c.mu.Unlock()
 
-		// Status check on cache hit: the agent may have
-		// disconnected since the connection was cached.
-		// Status() uses timestamp arithmetic on the cached
-		// row, no DB re-fetch needed.
+		// Status check on cache hit: re-fetch the agent
+		// row so we see the latest heartbeat rather than
+		// a potentially stale cached copy.
 		if currentConn != nil {
-			if c.agentLoaded && c.isAgentDisconnected() {
-				c.clearCachedWorkspaceState()
-				return nil, errChatAgentDisconnected
+			c.mu.Lock()
+			agentID := c.agent.ID
+			c.mu.Unlock()
+			if agentID != uuid.Nil {
+				freshAgent, err := c.server.db.GetWorkspaceAgentByID(ctx, agentID)
+				if err == nil && isAgentUnreachable(freshAgent, c.server.agentInactiveDisconnectTimeout) {
+					c.clearCachedWorkspaceState()
+					return nil, errChatAgentDisconnected
+				}
+				// On DB error we allow through; dial
+				// timeout is the safety net.
 			}
 			return currentConn, nil
 		}
@@ -590,7 +597,7 @@ func (c *turnWorkspaceContext) getWorkspaceConn(ctx context.Context) (workspaces
 
 		// Status check on cache miss: the freshly fetched
 		// agent row may already show disconnected.
-		if c.isAgentDisconnected() {
+		if isAgentUnreachable(agent, c.server.agentInactiveDisconnectTimeout) {
 			c.clearCachedWorkspaceState()
 			return nil, errChatAgentDisconnected
 		}
@@ -599,7 +606,7 @@ func (c *turnWorkspaceContext) getWorkspaceConn(ctx context.Context) (workspaces
 		// waiting for an unreachable agent. The timeout scopes
 		// only dialWithLazyValidation, not ensureWorkspaceAgent
 		// or the post-dial binding steps.
-		dialCtx, dialCancel := context.WithTimeout(ctx, c.server.dialTimeout)
+		dialCtx, dialCancel := context.WithTimeoutCause(ctx, c.server.dialTimeout, errChatDialTimeout)
 		dialResult, err := dialWithLazyValidation(
 			dialCtx,
 			agent.ID,
@@ -610,20 +617,17 @@ func (c *turnWorkspaceContext) getWorkspaceConn(ctx context.Context) (workspaces
 			},
 			workspaceDialValidationDelay,
 		)
-		dialTimedOut := dialCtx.Err() != nil
 		dialCancel()
 		if err != nil {
 			if xerrors.Is(err, errChatHasNoWorkspaceAgent) {
 				c.clearCachedWorkspaceState()
 				return nil, err
 			}
-			// Convert dial timeout to a sentinel only when the
+			// Surface the dial timeout sentinel only when the
 			// parent context is still alive. If the parent was
 			// canceled (e.g. ErrInterrupted), its error must
 			// propagate unchanged so the chatloop can detect it.
-			// Check dialTimedOut (captured before dialCancel) to
-			// avoid misclassifying non-timeout dial errors.
-			if ctx.Err() == nil && dialTimedOut {
+			if ctx.Err() == nil && errors.Is(context.Cause(dialCtx), errChatDialTimeout) {
 				return nil, errChatDialTimeout
 			}
 			return nil, err

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -60,6 +60,7 @@ const (
 	instructionCacheTTL          = 5 * time.Minute
 	workspaceDialValidationDelay = 5 * time.Second
 	workspaceMCPDiscoveryTimeout = 5 * time.Second
+	defaultDialTimeout           = 30 * time.Second
 	// DefaultChatHeartbeatInterval is the default time between chat
 	// heartbeat updates while a chat is being processed.
 	DefaultChatHeartbeatInterval = 30 * time.Second
@@ -107,7 +108,19 @@ const (
 	defaultSubagentInstruction = "You are running as a delegated sub-agent chat. Complete the delegated task and provide clear, concise assistant responses for the parent agent."
 )
 
-var errChatHasNoWorkspaceAgent = xerrors.New("workspace has no running agent: the workspace is likely stopped. Use the start_workspace tool to start it")
+var (
+	errChatHasNoWorkspaceAgent = xerrors.New("workspace has no running agent: the workspace is likely stopped. Use the start_workspace tool to start it")
+	errChatAgentDisconnected   = xerrors.New(
+		"workspace agent is disconnected and cannot execute tools. " +
+			"Inform the user that the workspace agent has disconnected " +
+			"and the workspace may need to be restarted from the Coder dashboard",
+	)
+	errChatDialTimeout = xerrors.New(
+		"connection to the workspace agent timed out. " +
+			"Inform the user that the workspace agent could not be reached " +
+			"and the workspace may need to be restarted from the Coder dashboard",
+	)
+)
 
 // Server handles background processing of pending chats.
 type Server struct {
@@ -124,6 +137,7 @@ type Server struct {
 
 	agentConnFn                    AgentConnFunc
 	agentInactiveDisconnectTimeout time.Duration
+	dialTimeout                    time.Duration
 	instructionLookupTimeout       time.Duration
 	createWorkspaceFn              chattool.CreateWorkspaceFn
 	startWorkspaceFn               chattool.StartWorkspaceFn
@@ -533,6 +547,17 @@ func (c *turnWorkspaceContext) getWorkspaceConnLocked() (workspacesdk.AgentConn,
 	return nil, agentRelease
 }
 
+// isAgentDisconnected reports whether the cached agent row's
+// status is disconnected or timed out. It uses timestamp
+// arithmetic on the cached row (no DB re-fetch). The
+// "connecting" state is allowed through because it is normal
+// after a fresh workspace build.
+func (c *turnWorkspaceContext) isAgentDisconnected() bool {
+	status := c.agent.Status(c.server.agentInactiveDisconnectTimeout)
+	return status.Status == database.WorkspaceAgentStatusDisconnected ||
+		status.Status == database.WorkspaceAgentStatusTimeout
+}
+
 func (c *turnWorkspaceContext) getWorkspaceConn(ctx context.Context) (workspacesdk.AgentConn, error) {
 	if c.server.agentConnFn == nil {
 		return nil, xerrors.New("workspace agent connector is not configured")
@@ -542,7 +567,16 @@ func (c *turnWorkspaceContext) getWorkspaceConn(ctx context.Context) (workspaces
 		c.mu.Lock()
 		currentConn, staleRelease := c.getWorkspaceConnLocked()
 		c.mu.Unlock()
+
+		// Status check on cache hit: the agent may have
+		// disconnected since the connection was cached.
+		// Status() uses timestamp arithmetic on the cached
+		// row, no DB re-fetch needed.
 		if currentConn != nil {
+			if c.agentLoaded && c.isAgentDisconnected() {
+				c.clearCachedWorkspaceState()
+				return nil, errChatAgentDisconnected
+			}
 			return currentConn, nil
 		}
 		if staleRelease != nil {
@@ -554,8 +588,20 @@ func (c *turnWorkspaceContext) getWorkspaceConn(ctx context.Context) (workspaces
 			return nil, err
 		}
 
+		// Status check on cache miss: the freshly fetched
+		// agent row may already show disconnected.
+		if c.isAgentDisconnected() {
+			c.clearCachedWorkspaceState()
+			return nil, errChatAgentDisconnected
+		}
+
+		// Wrap the dial in a timeout to bound the time spent
+		// waiting for an unreachable agent. The timeout scopes
+		// only dialWithLazyValidation, not ensureWorkspaceAgent
+		// or the post-dial binding steps.
+		dialCtx, dialCancel := context.WithTimeout(ctx, c.server.dialTimeout)
 		dialResult, err := dialWithLazyValidation(
-			ctx,
+			dialCtx,
 			agent.ID,
 			chatSnapshot.WorkspaceID.UUID,
 			DialFunc(c.server.agentConnFn),
@@ -564,13 +610,24 @@ func (c *turnWorkspaceContext) getWorkspaceConn(ctx context.Context) (workspaces
 			},
 			workspaceDialValidationDelay,
 		)
+		dialTimedOut := dialCtx.Err() != nil
+		dialCancel()
 		if err != nil {
 			if xerrors.Is(err, errChatHasNoWorkspaceAgent) {
 				c.clearCachedWorkspaceState()
+				return nil, err
+			}
+			// Convert dial timeout to a sentinel only when the
+			// parent context is still alive. If the parent was
+			// canceled (e.g. ErrInterrupted), its error must
+			// propagate unchanged so the chatloop can detect it.
+			// Check dialTimedOut (captured before dialCancel) to
+			// avoid misclassifying non-timeout dial errors.
+			if ctx.Err() == nil && dialTimedOut {
+				return nil, errChatDialTimeout
 			}
 			return nil, err
 		}
-
 		agentConn := dialResult.Conn
 		agentRelease := dialResult.Release
 		if dialResult.WasSwitched {
@@ -2749,6 +2806,7 @@ func New(cfg Config) *Server {
 		subscribeFn:                    cfg.SubscribeFn,
 		agentConnFn:                    cfg.AgentConn,
 		agentInactiveDisconnectTimeout: cfg.AgentInactiveDisconnectTimeout,
+		dialTimeout:                    defaultDialTimeout,
 		instructionLookupTimeout:       instructionLookupTimeout,
 		createWorkspaceFn:              cfg.CreateWorkspace,
 		startWorkspaceFn:               cfg.StartWorkspace,

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -1113,6 +1113,7 @@ func TestPersistInstructionFilesIncludesAgentMetadata(t *testing.T) {
 	server := &Server{
 		db:                             db,
 		logger:                         logger,
+		clock:                          quartz.NewReal(),
 		instructionLookupTimeout:       5 * time.Second,
 		agentInactiveDisconnectTimeout: 30 * time.Second,
 		dialTimeout:                    30 * time.Second,
@@ -1280,6 +1281,7 @@ func TestPersistInstructionFilesSentinelWithSkills(t *testing.T) {
 	server := &Server{
 		db:                             db,
 		logger:                         logger,
+		clock:                          quartz.NewReal(),
 		instructionLookupTimeout:       5 * time.Second,
 		agentInactiveDisconnectTimeout: 30 * time.Second,
 		dialTimeout:                    30 * time.Second,
@@ -1367,6 +1369,7 @@ func TestPersistInstructionFilesSentinelNoSkillsClearsColumn(t *testing.T) {
 	server := &Server{
 		db:                             db,
 		logger:                         logger,
+		clock:                          quartz.NewReal(),
 		instructionLookupTimeout:       5 * time.Second,
 		agentInactiveDisconnectTimeout: 30 * time.Second,
 		dialTimeout:                    30 * time.Second,
@@ -1597,6 +1600,7 @@ func TestTurnWorkspaceContextGetWorkspaceConnLazyValidationSwitchesWorkspaceAgen
 	var dialed []uuid.UUID
 	server := &Server{
 		db:                             db,
+		clock:                          quartz.NewReal(),
 		agentInactiveDisconnectTimeout: 30 * time.Second,
 		dialTimeout:                    30 * time.Second,
 	}
@@ -1661,6 +1665,7 @@ func TestTurnWorkspaceContextGetWorkspaceConnFastFailsWithoutCurrentAgent(t *tes
 
 	server := &Server{
 		db:                             db,
+		clock:                          quartz.NewReal(),
 		agentInactiveDisconnectTimeout: 30 * time.Second,
 		dialTimeout:                    30 * time.Second,
 	}
@@ -3748,6 +3753,7 @@ func TestGetWorkspaceConn_DisconnectedAgentCacheMiss(t *testing.T) {
 	var dialCalled bool
 	server := &Server{
 		db:                             db,
+		clock:                          quartz.NewReal(),
 		agentInactiveDisconnectTimeout: 30 * time.Second,
 		dialTimeout:                    defaultDialTimeout,
 	}
@@ -3828,6 +3834,7 @@ func TestGetWorkspaceConn_DisconnectedAgentCacheHit(t *testing.T) {
 
 	server := &Server{
 		db:                             db,
+		clock:                          quartz.NewReal(),
 		agentInactiveDisconnectTimeout: 30 * time.Second,
 		dialTimeout:                    defaultDialTimeout,
 	}
@@ -3905,6 +3912,7 @@ func TestGetWorkspaceConn_TimedOutAgentCacheMiss(t *testing.T) {
 	var dialCalled bool
 	server := &Server{
 		db:                             db,
+		clock:                          quartz.NewReal(),
 		agentInactiveDisconnectTimeout: 30 * time.Second,
 		dialTimeout:                    defaultDialTimeout,
 	}
@@ -3973,6 +3981,7 @@ func TestGetWorkspaceConn_ConnectingAgentProceeds(t *testing.T) {
 
 	server := &Server{
 		db:                             db,
+		clock:                          quartz.NewReal(),
 		agentInactiveDisconnectTimeout: 30 * time.Second,
 		dialTimeout:                    defaultDialTimeout,
 	}
@@ -4041,6 +4050,7 @@ func TestGetWorkspaceConn_DialTimeout(t *testing.T) {
 
 	server := &Server{
 		db:                             db,
+		clock:                          quartz.NewReal(),
 		agentInactiveDisconnectTimeout: 30 * time.Second,
 		dialTimeout:                    10 * time.Millisecond,
 	}
@@ -4110,6 +4120,7 @@ func TestGetWorkspaceConn_DialTimeoutParentCanceled(t *testing.T) {
 
 	server := &Server{
 		db:                             db,
+		clock:                          quartz.NewReal(),
 		agentInactiveDisconnectTimeout: 30 * time.Second,
 		// Use a very long dial timeout so the parent cancel fires
 		// first.
@@ -4201,6 +4212,7 @@ func TestGetWorkspaceConn_DialErrorNotMisclassifiedAsTimeout(t *testing.T) {
 	dialErr := xerrors.New("authentication failed")
 	server := &Server{
 		db:                             db,
+		clock:                          quartz.NewReal(),
 		agentInactiveDisconnectTimeout: 30 * time.Second,
 		// Generous timeout so the dial error fires well before
 		// the timeout.
@@ -4227,4 +4239,159 @@ func TestGetWorkspaceConn_DialErrorNotMisclassifiedAsTimeout(t *testing.T) {
 	require.NotErrorIs(t, err, errChatDialTimeout)
 	// The original dial error should propagate.
 	require.ErrorContains(t, err, "authentication failed")
+}
+
+func TestGetWorkspaceConn_CacheHitHealthyAgent(t *testing.T) {
+	// When a cached connection exists and the agent is still
+	// healthy (LastConnectedAt near now), getWorkspaceConn
+	// should return the cached connection without error and
+	// without calling releaseConn.
+	t.Parallel()
+
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+
+	workspaceID := uuid.New()
+	agentID := uuid.New()
+	chat := database.Chat{
+		ID: uuid.New(),
+		WorkspaceID: uuid.NullUUID{
+			UUID:  workspaceID,
+			Valid: true,
+		},
+		AgentID: uuid.NullUUID{
+			UUID:  agentID,
+			Valid: true,
+		},
+	}
+
+	// Agent with a recent LastConnectedAt is healthy.
+	healthyAgent := database.WorkspaceAgent{
+		ID: agentID,
+		FirstConnectedAt: sql.NullTime{
+			Time:  time.Now().Add(-5 * time.Minute),
+			Valid: true,
+		},
+		LastConnectedAt: sql.NullTime{
+			Time:  time.Now(),
+			Valid: true,
+		},
+	}
+
+	db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), agentID).
+		Return(healthyAgent, nil).
+		Times(1)
+
+	cachedConn := agentconnmock.NewMockAgentConn(ctrl)
+	var releaseCalled bool
+
+	server := &Server{
+		db:                             db,
+		clock:                          quartz.NewReal(),
+		agentInactiveDisconnectTimeout: 30 * time.Second,
+		dialTimeout:                    defaultDialTimeout,
+	}
+	server.agentConnFn = func(context.Context, uuid.UUID) (workspacesdk.AgentConn, func(), error) {
+		return nil, nil, xerrors.New("should not be called")
+	}
+
+	chatStateMu := &sync.Mutex{}
+	currentChat := chat
+	workspaceCtx := turnWorkspaceContext{
+		server:      server,
+		chatStateMu: chatStateMu,
+		currentChat: &currentChat,
+		loadChatSnapshot: func(context.Context, uuid.UUID) (database.Chat, error) {
+			return database.Chat{}, nil
+		},
+	}
+	// Pre-populate cache to simulate a previously working
+	// connection.
+	workspaceCtx.agent = healthyAgent
+	workspaceCtx.agentLoaded = true
+	workspaceCtx.conn = cachedConn
+	workspaceCtx.releaseConn = func() { releaseCalled = true }
+	workspaceCtx.cachedWorkspaceID = chat.WorkspaceID
+
+	gotConn, err := workspaceCtx.getWorkspaceConn(ctx)
+	require.NoError(t, err)
+	require.Same(t, cachedConn, gotConn)
+	require.False(t, releaseCalled,
+		"releaseConn should not be called for a healthy cached connection")
+}
+
+func TestGetWorkspaceConn_CacheHitDBError(t *testing.T) {
+	// When a cached connection exists but GetWorkspaceAgentByID
+	// returns an error, getWorkspaceConn should fall through
+	// gracefully and return the cached connection.
+	t.Parallel()
+
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+
+	workspaceID := uuid.New()
+	agentID := uuid.New()
+	chat := database.Chat{
+		ID: uuid.New(),
+		WorkspaceID: uuid.NullUUID{
+			UUID:  workspaceID,
+			Valid: true,
+		},
+		AgentID: uuid.NullUUID{
+			UUID:  agentID,
+			Valid: true,
+		},
+	}
+
+	cachedAgent := database.WorkspaceAgent{
+		ID: agentID,
+		FirstConnectedAt: sql.NullTime{
+			Time:  time.Now().Add(-5 * time.Minute),
+			Valid: true,
+		},
+		LastConnectedAt: sql.NullTime{
+			Time:  time.Now(),
+			Valid: true,
+		},
+	}
+
+	// DB error on re-fetch.
+	db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), agentID).
+		Return(database.WorkspaceAgent{}, xerrors.New("connection reset")).
+		Times(1)
+
+	cachedConn := agentconnmock.NewMockAgentConn(ctrl)
+
+	server := &Server{
+		db:                             db,
+		clock:                          quartz.NewReal(),
+		agentInactiveDisconnectTimeout: 30 * time.Second,
+		dialTimeout:                    defaultDialTimeout,
+	}
+	server.agentConnFn = func(context.Context, uuid.UUID) (workspacesdk.AgentConn, func(), error) {
+		return nil, nil, xerrors.New("should not be called")
+	}
+
+	chatStateMu := &sync.Mutex{}
+	currentChat := chat
+	workspaceCtx := turnWorkspaceContext{
+		server:      server,
+		chatStateMu: chatStateMu,
+		currentChat: &currentChat,
+		loadChatSnapshot: func(context.Context, uuid.UUID) (database.Chat, error) {
+			return database.Chat{}, nil
+		},
+	}
+	// Pre-populate cache.
+	workspaceCtx.agent = cachedAgent
+	workspaceCtx.agentLoaded = true
+	workspaceCtx.conn = cachedConn
+	workspaceCtx.releaseConn = func() {}
+	workspaceCtx.cachedWorkspaceID = chat.WorkspaceID
+
+	gotConn, err := workspaceCtx.getWorkspaceConn(ctx)
+	require.NoError(t, err)
+	require.Same(t, cachedConn, gotConn)
 }

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -3704,9 +3704,9 @@ func TestSafeSweepIdleStreams_RecoversFromPanic(t *testing.T) {
 }
 
 func TestGetWorkspaceConn_DisconnectedAgentCacheMiss(t *testing.T) {
-	// Stage 1 red test: when ensureWorkspaceAgent returns a
-	// disconnected agent (cache miss), getWorkspaceConn should
-	// return errChatAgentDisconnected without attempting to dial.
+	// When ensureWorkspaceAgent returns a disconnected agent
+	// (cache miss), getWorkspaceConn should return
+	// errChatAgentDisconnected without attempting to dial.
 	t.Parallel()
 
 	ctx := context.Background()
@@ -3749,6 +3749,7 @@ func TestGetWorkspaceConn_DisconnectedAgentCacheMiss(t *testing.T) {
 	server := &Server{
 		db:                             db,
 		agentInactiveDisconnectTimeout: 30 * time.Second,
+		dialTimeout:                    defaultDialTimeout,
 	}
 	server.agentConnFn = func(context.Context, uuid.UUID) (workspacesdk.AgentConn, func(), error) {
 		dialCalled = true
@@ -3778,8 +3779,8 @@ func TestGetWorkspaceConn_DisconnectedAgentCacheMiss(t *testing.T) {
 }
 
 func TestGetWorkspaceConn_DisconnectedAgentCacheHit(t *testing.T) {
-	// Stage 1 red test: when a cached connection exists but the
-	// agent's status has become disconnected (time elapsed past
+	// When a cached connection exists but the agent's status
+	// has become disconnected (time elapsed past
 	// inactiveTimeout), getWorkspaceConn should detect this,
 	// release the cached connection, and return
 	// errChatAgentDisconnected.
@@ -3787,6 +3788,7 @@ func TestGetWorkspaceConn_DisconnectedAgentCacheHit(t *testing.T) {
 
 	ctx := context.Background()
 	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
 
 	workspaceID := uuid.New()
 	agentID := uuid.New()
@@ -3815,11 +3817,19 @@ func TestGetWorkspaceConn_DisconnectedAgentCacheHit(t *testing.T) {
 		},
 	}
 
+	// The production code re-fetches the agent row on cache hit
+	// to see the latest heartbeat timestamp.
+	db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), agentID).
+		Return(disconnectedAgent, nil).
+		Times(1)
+
 	cachedConn := agentconnmock.NewMockAgentConn(ctrl)
 	var releaseCalled bool
 
 	server := &Server{
+		db:                             db,
 		agentInactiveDisconnectTimeout: 30 * time.Second,
+		dialTimeout:                    defaultDialTimeout,
 	}
 	server.agentConnFn = func(context.Context, uuid.UUID) (workspacesdk.AgentConn, func(), error) {
 		return nil, nil, xerrors.New("should not be called")
@@ -3854,10 +3864,81 @@ func TestGetWorkspaceConn_DisconnectedAgentCacheHit(t *testing.T) {
 	require.Nil(t, workspaceCtx.conn)
 }
 
+func TestGetWorkspaceConn_TimedOutAgentCacheMiss(t *testing.T) {
+	// When ensureWorkspaceAgent returns an agent in the Timeout
+	// state (never connected, connection timeout exceeded),
+	// getWorkspaceConn should return errChatAgentDisconnected
+	// without attempting to dial.
+	t.Parallel()
+
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+
+	workspaceID := uuid.New()
+	agentID := uuid.New()
+	chat := database.Chat{
+		ID: uuid.New(),
+		WorkspaceID: uuid.NullUUID{
+			UUID:  workspaceID,
+			Valid: true,
+		},
+		AgentID: uuid.NullUUID{
+			UUID:  agentID,
+			Valid: true,
+		},
+	}
+
+	// Agent that never connected and exceeded its connection
+	// timeout. FirstConnectedAt is invalid, CreatedAt is old
+	// enough, and ConnectionTimeoutSeconds is set.
+	timedOutAgent := database.WorkspaceAgent{
+		ID:                       agentID,
+		CreatedAt:                time.Now().Add(-10 * time.Minute),
+		ConnectionTimeoutSeconds: 60,
+	}
+
+	db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), agentID).
+		Return(timedOutAgent, nil).
+		Times(1)
+
+	var dialCalled bool
+	server := &Server{
+		db:                             db,
+		agentInactiveDisconnectTimeout: 30 * time.Second,
+		dialTimeout:                    defaultDialTimeout,
+	}
+	server.agentConnFn = func(context.Context, uuid.UUID) (workspacesdk.AgentConn, func(), error) {
+		dialCalled = true
+		return nil, nil, xerrors.New("should not be called")
+	}
+
+	chatStateMu := &sync.Mutex{}
+	currentChat := chat
+	workspaceCtx := turnWorkspaceContext{
+		server:           server,
+		chatStateMu:      chatStateMu,
+		currentChat:      &currentChat,
+		loadChatSnapshot: func(context.Context, uuid.UUID) (database.Chat, error) { return database.Chat{}, nil },
+	}
+	defer workspaceCtx.close()
+
+	gotConn, err := workspaceCtx.getWorkspaceConn(ctx)
+	require.Nil(t, gotConn)
+	require.ErrorIs(t, err, errChatAgentDisconnected)
+	require.False(t, dialCalled, "dial should not be attempted for a timed-out agent")
+
+	// Cache should be cleared.
+	workspaceCtx.mu.Lock()
+	defer workspaceCtx.mu.Unlock()
+	require.False(t, workspaceCtx.agentLoaded)
+	require.Nil(t, workspaceCtx.conn)
+}
+
 func TestGetWorkspaceConn_ConnectingAgentProceeds(t *testing.T) {
-	// Stage 1 red test: a "connecting" agent (never connected,
-	// normal after fresh build) must NOT be blocked by the
-	// status check. The dial should proceed.
+	// A "connecting" agent (never connected, normal after
+	// fresh build) must NOT be blocked by the status check.
+	// The dial should proceed.
 	t.Parallel()
 
 	ctx := context.Background()
@@ -3893,7 +3974,7 @@ func TestGetWorkspaceConn_ConnectingAgentProceeds(t *testing.T) {
 	server := &Server{
 		db:                             db,
 		agentInactiveDisconnectTimeout: 30 * time.Second,
-		dialTimeout:                    30 * time.Second,
+		dialTimeout:                    defaultDialTimeout,
 	}
 	server.agentConnFn = func(_ context.Context, id uuid.UUID) (workspacesdk.AgentConn, func(), error) {
 		if id != agentID {
@@ -3918,8 +3999,8 @@ func TestGetWorkspaceConn_ConnectingAgentProceeds(t *testing.T) {
 }
 
 func TestGetWorkspaceConn_DialTimeout(t *testing.T) {
-	// Stage 2 red test: when dialWithLazyValidation blocks
-	// beyond the dial timeout, getWorkspaceConn should return
+	// When dialWithLazyValidation blocks beyond the dial
+	// timeout, getWorkspaceConn should return
 	// errChatDialTimeout instead of hanging indefinitely.
 	t.Parallel()
 
@@ -3985,10 +4066,10 @@ func TestGetWorkspaceConn_DialTimeout(t *testing.T) {
 }
 
 func TestGetWorkspaceConn_DialTimeoutParentCanceled(t *testing.T) {
-	// Stage 2 red test: when the parent context is canceled,
-	// the parent's error must propagate unchanged (not wrapped
-	// as a dial timeout). This is critical because the chatloop
-	// checks context.Cause(ctx) for ErrInterrupted.
+	// When the parent context is canceled, the parent's error
+	// must propagate unchanged (not wrapped as a dial timeout).
+	// This is critical because the chatloop checks
+	// context.Cause(ctx) for ErrInterrupted.
 	t.Parallel()
 
 	ctrl := gomock.NewController(t)
@@ -4065,6 +4146,7 @@ func TestGetWorkspaceConn_DialTimeoutParentCanceled(t *testing.T) {
 	require.NotErrorIs(t, err, errChatDialTimeout)
 	// The parent context's error should propagate.
 	require.Error(t, err)
+	require.ErrorIs(t, err, context.Canceled)
 }
 
 func TestGetWorkspaceConn_DialErrorNotMisclassifiedAsTimeout(t *testing.T) {
@@ -4122,7 +4204,7 @@ func TestGetWorkspaceConn_DialErrorNotMisclassifiedAsTimeout(t *testing.T) {
 		agentInactiveDisconnectTimeout: 30 * time.Second,
 		// Generous timeout so the dial error fires well before
 		// the timeout.
-		dialTimeout: 30 * time.Second,
+		dialTimeout: defaultDialTimeout,
 	}
 	server.agentConnFn = func(context.Context, uuid.UUID) (workspacesdk.AgentConn, func(), error) {
 		// Return an error immediately (not a timeout).

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -1111,9 +1111,11 @@ func TestPersistInstructionFilesIncludesAgentMetadata(t *testing.T) {
 	}, nil).AnyTimes()
 	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
 	server := &Server{
-		db:                       db,
-		logger:                   logger,
-		instructionLookupTimeout: 5 * time.Second,
+		db:                             db,
+		logger:                         logger,
+		instructionLookupTimeout:       5 * time.Second,
+		agentInactiveDisconnectTimeout: 30 * time.Second,
+		dialTimeout:                    30 * time.Second,
 		agentConnFn: func(context.Context, uuid.UUID) (workspacesdk.AgentConn, func(), error) {
 			return conn, func() {}, nil
 		},
@@ -1276,9 +1278,11 @@ func TestPersistInstructionFilesSentinelWithSkills(t *testing.T) {
 	}, nil).AnyTimes()
 	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
 	server := &Server{
-		db:                       db,
-		logger:                   logger,
-		instructionLookupTimeout: 5 * time.Second,
+		db:                             db,
+		logger:                         logger,
+		instructionLookupTimeout:       5 * time.Second,
+		agentInactiveDisconnectTimeout: 30 * time.Second,
+		dialTimeout:                    30 * time.Second,
 		agentConnFn: func(context.Context, uuid.UUID) (workspacesdk.AgentConn, func(), error) {
 			return conn, func() {}, nil
 		},
@@ -1361,9 +1365,11 @@ func TestPersistInstructionFilesSentinelNoSkillsClearsColumn(t *testing.T) {
 	}, nil).AnyTimes()
 	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
 	server := &Server{
-		db:                       db,
-		logger:                   logger,
-		instructionLookupTimeout: 5 * time.Second,
+		db:                             db,
+		logger:                         logger,
+		instructionLookupTimeout:       5 * time.Second,
+		agentInactiveDisconnectTimeout: 30 * time.Second,
+		dialTimeout:                    30 * time.Second,
 		agentConnFn: func(context.Context, uuid.UUID) (workspacesdk.AgentConn, func(), error) {
 			return conn, func() {}, nil
 		},
@@ -1589,7 +1595,11 @@ func TestTurnWorkspaceContextGetWorkspaceConnLazyValidationSwitchesWorkspaceAgen
 	conn.EXPECT().SetExtraHeaders(gomock.Any()).Times(1)
 
 	var dialed []uuid.UUID
-	server := &Server{db: db}
+	server := &Server{
+		db:                             db,
+		agentInactiveDisconnectTimeout: 30 * time.Second,
+		dialTimeout:                    30 * time.Second,
+	}
 	server.agentConnFn = func(_ context.Context, agentID uuid.UUID) (workspacesdk.AgentConn, func(), error) {
 		dialed = append(dialed, agentID)
 		if agentID == staleAgentID {
@@ -1649,7 +1659,11 @@ func TestTurnWorkspaceContextGetWorkspaceConnFastFailsWithoutCurrentAgent(t *tes
 		Return([]database.WorkspaceAgent{}, nil).
 		Times(1)
 
-	server := &Server{db: db}
+	server := &Server{
+		db:                             db,
+		agentInactiveDisconnectTimeout: 30 * time.Second,
+		dialTimeout:                    30 * time.Second,
+	}
 	server.agentConnFn = func(context.Context, uuid.UUID) (workspacesdk.AgentConn, func(), error) {
 		return nil, nil, xerrors.New("dial failed")
 	}
@@ -3687,4 +3701,448 @@ func TestSafeSweepIdleStreams_RecoversFromPanic(t *testing.T) {
 	require.NotPanics(t, func() {
 		server.safeSweepIdleStreams(context.Background())
 	}, "safeSweepIdleStreams must recover panics so the janitor loop keeps running")
+}
+
+func TestGetWorkspaceConn_DisconnectedAgentCacheMiss(t *testing.T) {
+	// Stage 1 red test: when ensureWorkspaceAgent returns a
+	// disconnected agent (cache miss), getWorkspaceConn should
+	// return errChatAgentDisconnected without attempting to dial.
+	t.Parallel()
+
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+
+	workspaceID := uuid.New()
+	agentID := uuid.New()
+	chat := database.Chat{
+		ID: uuid.New(),
+		WorkspaceID: uuid.NullUUID{
+			UUID:  workspaceID,
+			Valid: true,
+		},
+		AgentID: uuid.NullUUID{
+			UUID:  agentID,
+			Valid: true,
+		},
+	}
+
+	// Agent with LastConnectedAt far in the past triggers
+	// disconnected status.
+	disconnectedAgent := database.WorkspaceAgent{
+		ID: agentID,
+		FirstConnectedAt: sql.NullTime{
+			Time:  time.Now().Add(-10 * time.Minute),
+			Valid: true,
+		},
+		LastConnectedAt: sql.NullTime{
+			Time:  time.Now().Add(-10 * time.Minute),
+			Valid: true,
+		},
+	}
+
+	db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), agentID).
+		Return(disconnectedAgent, nil).
+		Times(1)
+
+	var dialCalled bool
+	server := &Server{
+		db:                             db,
+		agentInactiveDisconnectTimeout: 30 * time.Second,
+	}
+	server.agentConnFn = func(context.Context, uuid.UUID) (workspacesdk.AgentConn, func(), error) {
+		dialCalled = true
+		return nil, nil, xerrors.New("should not be called")
+	}
+
+	chatStateMu := &sync.Mutex{}
+	currentChat := chat
+	workspaceCtx := turnWorkspaceContext{
+		server:           server,
+		chatStateMu:      chatStateMu,
+		currentChat:      &currentChat,
+		loadChatSnapshot: func(context.Context, uuid.UUID) (database.Chat, error) { return database.Chat{}, nil },
+	}
+	defer workspaceCtx.close()
+
+	gotConn, err := workspaceCtx.getWorkspaceConn(ctx)
+	require.Nil(t, gotConn)
+	require.ErrorIs(t, err, errChatAgentDisconnected)
+	require.False(t, dialCalled, "dial should not be attempted for a disconnected agent")
+
+	// Cache should be cleared.
+	workspaceCtx.mu.Lock()
+	defer workspaceCtx.mu.Unlock()
+	require.False(t, workspaceCtx.agentLoaded)
+	require.Nil(t, workspaceCtx.conn)
+}
+
+func TestGetWorkspaceConn_DisconnectedAgentCacheHit(t *testing.T) {
+	// Stage 1 red test: when a cached connection exists but the
+	// agent's status has become disconnected (time elapsed past
+	// inactiveTimeout), getWorkspaceConn should detect this,
+	// release the cached connection, and return
+	// errChatAgentDisconnected.
+	t.Parallel()
+
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+
+	workspaceID := uuid.New()
+	agentID := uuid.New()
+	chat := database.Chat{
+		ID: uuid.New(),
+		WorkspaceID: uuid.NullUUID{
+			UUID:  workspaceID,
+			Valid: true,
+		},
+		AgentID: uuid.NullUUID{
+			UUID:  agentID,
+			Valid: true,
+		},
+	}
+
+	// Agent was connected but LastConnectedAt is now stale.
+	disconnectedAgent := database.WorkspaceAgent{
+		ID: agentID,
+		FirstConnectedAt: sql.NullTime{
+			Time:  time.Now().Add(-10 * time.Minute),
+			Valid: true,
+		},
+		LastConnectedAt: sql.NullTime{
+			Time:  time.Now().Add(-10 * time.Minute),
+			Valid: true,
+		},
+	}
+
+	cachedConn := agentconnmock.NewMockAgentConn(ctrl)
+	var releaseCalled bool
+
+	server := &Server{
+		agentInactiveDisconnectTimeout: 30 * time.Second,
+	}
+	server.agentConnFn = func(context.Context, uuid.UUID) (workspacesdk.AgentConn, func(), error) {
+		return nil, nil, xerrors.New("should not be called")
+	}
+
+	chatStateMu := &sync.Mutex{}
+	currentChat := chat
+	workspaceCtx := turnWorkspaceContext{
+		server:      server,
+		chatStateMu: chatStateMu,
+		currentChat: &currentChat,
+		loadChatSnapshot: func(context.Context, uuid.UUID) (database.Chat, error) {
+			return database.Chat{}, nil
+		},
+	}
+	// Pre-populate cache to simulate a previously working connection.
+	workspaceCtx.agent = disconnectedAgent
+	workspaceCtx.agentLoaded = true
+	workspaceCtx.conn = cachedConn
+	workspaceCtx.releaseConn = func() { releaseCalled = true }
+	workspaceCtx.cachedWorkspaceID = chat.WorkspaceID
+
+	gotConn, err := workspaceCtx.getWorkspaceConn(ctx)
+	require.Nil(t, gotConn)
+	require.ErrorIs(t, err, errChatAgentDisconnected)
+	require.True(t, releaseCalled, "stale connection should be released")
+
+	// Cache should be fully cleared.
+	workspaceCtx.mu.Lock()
+	defer workspaceCtx.mu.Unlock()
+	require.False(t, workspaceCtx.agentLoaded)
+	require.Nil(t, workspaceCtx.conn)
+}
+
+func TestGetWorkspaceConn_ConnectingAgentProceeds(t *testing.T) {
+	// Stage 1 red test: a "connecting" agent (never connected,
+	// normal after fresh build) must NOT be blocked by the
+	// status check. The dial should proceed.
+	t.Parallel()
+
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+
+	workspaceID := uuid.New()
+	agentID := uuid.New()
+	chat := database.Chat{
+		ID: uuid.New(),
+		WorkspaceID: uuid.NullUUID{
+			UUID:  workspaceID,
+			Valid: true,
+		},
+		AgentID: uuid.NullUUID{
+			UUID:  agentID,
+			Valid: true,
+		},
+	}
+
+	// Agent that has never connected: FirstConnectedAt is not valid.
+	connectingAgent := database.WorkspaceAgent{
+		ID: agentID,
+	}
+
+	db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), agentID).
+		Return(connectingAgent, nil).
+		Times(1)
+
+	conn := agentconnmock.NewMockAgentConn(ctrl)
+	conn.EXPECT().SetExtraHeaders(gomock.Any()).Times(1)
+
+	server := &Server{
+		db:                             db,
+		agentInactiveDisconnectTimeout: 30 * time.Second,
+		dialTimeout:                    30 * time.Second,
+	}
+	server.agentConnFn = func(_ context.Context, id uuid.UUID) (workspacesdk.AgentConn, func(), error) {
+		if id != agentID {
+			return nil, nil, xerrors.Errorf("unexpected agent ID %q", id)
+		}
+		return conn, func() {}, nil
+	}
+
+	chatStateMu := &sync.Mutex{}
+	currentChat := chat
+	workspaceCtx := turnWorkspaceContext{
+		server:           server,
+		chatStateMu:      chatStateMu,
+		currentChat:      &currentChat,
+		loadChatSnapshot: func(context.Context, uuid.UUID) (database.Chat, error) { return database.Chat{}, nil },
+	}
+	defer workspaceCtx.close()
+
+	gotConn, err := workspaceCtx.getWorkspaceConn(ctx)
+	require.NoError(t, err)
+	require.Same(t, conn, gotConn)
+}
+
+func TestGetWorkspaceConn_DialTimeout(t *testing.T) {
+	// Stage 2 red test: when dialWithLazyValidation blocks
+	// beyond the dial timeout, getWorkspaceConn should return
+	// errChatDialTimeout instead of hanging indefinitely.
+	t.Parallel()
+
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+
+	workspaceID := uuid.New()
+	agentID := uuid.New()
+	chat := database.Chat{
+		ID: uuid.New(),
+		WorkspaceID: uuid.NullUUID{
+			UUID:  workspaceID,
+			Valid: true,
+		},
+		AgentID: uuid.NullUUID{
+			UUID:  agentID,
+			Valid: true,
+		},
+	}
+
+	// Agent appears connected so the status check passes.
+	connectedAgent := database.WorkspaceAgent{
+		ID: agentID,
+		FirstConnectedAt: sql.NullTime{
+			Time:  time.Now().Add(-1 * time.Minute),
+			Valid: true,
+		},
+		LastConnectedAt: sql.NullTime{
+			Time:  time.Now(),
+			Valid: true,
+		},
+	}
+
+	db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), agentID).
+		Return(connectedAgent, nil).
+		Times(1)
+
+	server := &Server{
+		db:                             db,
+		agentInactiveDisconnectTimeout: 30 * time.Second,
+		dialTimeout:                    10 * time.Millisecond,
+	}
+	// Dial blocks forever (simulates unreachable agent).
+	server.agentConnFn = func(ctx context.Context, _ uuid.UUID) (workspacesdk.AgentConn, func(), error) {
+		<-ctx.Done()
+		return nil, nil, ctx.Err()
+	}
+
+	chatStateMu := &sync.Mutex{}
+	currentChat := chat
+	workspaceCtx := turnWorkspaceContext{
+		server:           server,
+		chatStateMu:      chatStateMu,
+		currentChat:      &currentChat,
+		loadChatSnapshot: func(context.Context, uuid.UUID) (database.Chat, error) { return database.Chat{}, nil },
+	}
+	defer workspaceCtx.close()
+
+	gotConn, err := workspaceCtx.getWorkspaceConn(ctx)
+	require.Nil(t, gotConn)
+	require.ErrorIs(t, err, errChatDialTimeout)
+}
+
+func TestGetWorkspaceConn_DialTimeoutParentCanceled(t *testing.T) {
+	// Stage 2 red test: when the parent context is canceled,
+	// the parent's error must propagate unchanged (not wrapped
+	// as a dial timeout). This is critical because the chatloop
+	// checks context.Cause(ctx) for ErrInterrupted.
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+
+	workspaceID := uuid.New()
+	agentID := uuid.New()
+	chat := database.Chat{
+		ID: uuid.New(),
+		WorkspaceID: uuid.NullUUID{
+			UUID:  workspaceID,
+			Valid: true,
+		},
+		AgentID: uuid.NullUUID{
+			UUID:  agentID,
+			Valid: true,
+		},
+	}
+
+	connectedAgent := database.WorkspaceAgent{
+		ID: agentID,
+		FirstConnectedAt: sql.NullTime{
+			Time:  time.Now().Add(-1 * time.Minute),
+			Valid: true,
+		},
+		LastConnectedAt: sql.NullTime{
+			Time:  time.Now(),
+			Valid: true,
+		},
+	}
+
+	db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), agentID).
+		Return(connectedAgent, nil).
+		Times(1)
+
+	parentErr := xerrors.New("parent canceled")
+	ctx, cancel := context.WithCancelCause(context.Background())
+
+	server := &Server{
+		db:                             db,
+		agentInactiveDisconnectTimeout: 30 * time.Second,
+		// Use a very long dial timeout so the parent cancel fires
+		// first.
+		dialTimeout: 10 * time.Minute,
+	}
+	// Signal when the dial goroutine has started so we can
+	// cancel the parent at the right time without time.Sleep.
+	dialStarted := make(chan struct{})
+	server.agentConnFn = func(ctx context.Context, _ uuid.UUID) (workspacesdk.AgentConn, func(), error) {
+		close(dialStarted)
+		<-ctx.Done()
+		return nil, nil, ctx.Err()
+	}
+
+	chatStateMu := &sync.Mutex{}
+	currentChat := chat
+	workspaceCtx := turnWorkspaceContext{
+		server:           server,
+		chatStateMu:      chatStateMu,
+		currentChat:      &currentChat,
+		loadChatSnapshot: func(context.Context, uuid.UUID) (database.Chat, error) { return database.Chat{}, nil },
+	}
+	defer workspaceCtx.close()
+
+	// Cancel the parent after the dial starts.
+	go func() {
+		<-dialStarted
+		cancel(parentErr)
+	}()
+
+	gotConn, err := workspaceCtx.getWorkspaceConn(ctx)
+	require.Nil(t, gotConn)
+	// The error must NOT be errChatDialTimeout.
+	require.NotErrorIs(t, err, errChatDialTimeout)
+	// The parent context's error should propagate.
+	require.Error(t, err)
+}
+
+func TestGetWorkspaceConn_DialErrorNotMisclassifiedAsTimeout(t *testing.T) {
+	// Regression test: a non-timeout dial error (e.g. auth
+	// failure) with the parent context still alive must NOT be
+	// converted to errChatDialTimeout. Before the fix,
+	// dialCancel() poisoned dialCtx.Err(), causing all errors
+	// to be misclassified.
+	t.Parallel()
+
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+
+	workspaceID := uuid.New()
+	agentID := uuid.New()
+	chat := database.Chat{
+		ID: uuid.New(),
+		WorkspaceID: uuid.NullUUID{
+			UUID:  workspaceID,
+			Valid: true,
+		},
+		AgentID: uuid.NullUUID{
+			UUID:  agentID,
+			Valid: true,
+		},
+	}
+
+	connectedAgent := database.WorkspaceAgent{
+		ID: agentID,
+		FirstConnectedAt: sql.NullTime{
+			Time:  time.Now().Add(-1 * time.Minute),
+			Valid: true,
+		},
+		LastConnectedAt: sql.NullTime{
+			Time:  time.Now(),
+			Valid: true,
+		},
+	}
+
+	db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), agentID).
+		Return(connectedAgent, nil).
+		Times(1)
+	// When the initial dial fails immediately, dialWithLazyValidation
+	// calls resolveFastFailure which validates the binding. Mock the
+	// validation to return the same agent, triggering a synchronous
+	// redial that also returns the error.
+	db.EXPECT().GetWorkspaceAgentsInLatestBuildByWorkspaceID(gomock.Any(), workspaceID).
+		Return([]database.WorkspaceAgent{connectedAgent}, nil).
+		AnyTimes()
+
+	dialErr := xerrors.New("authentication failed")
+	server := &Server{
+		db:                             db,
+		agentInactiveDisconnectTimeout: 30 * time.Second,
+		// Generous timeout so the dial error fires well before
+		// the timeout.
+		dialTimeout: 30 * time.Second,
+	}
+	server.agentConnFn = func(context.Context, uuid.UUID) (workspacesdk.AgentConn, func(), error) {
+		// Return an error immediately (not a timeout).
+		return nil, nil, dialErr
+	}
+
+	chatStateMu := &sync.Mutex{}
+	currentChat := chat
+	workspaceCtx := turnWorkspaceContext{
+		server:           server,
+		chatStateMu:      chatStateMu,
+		currentChat:      &currentChat,
+		loadChatSnapshot: func(context.Context, uuid.UUID) (database.Chat, error) { return database.Chat{}, nil },
+	}
+	defer workspaceCtx.close()
+
+	gotConn, err := workspaceCtx.getWorkspaceConn(ctx)
+	require.Nil(t, gotConn)
+	// Must NOT be misclassified as a dial timeout.
+	require.NotErrorIs(t, err, errChatDialTimeout)
+	// The original dial error should propagate.
+	require.ErrorContains(t, err, "authentication failed")
 }

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -3708,303 +3708,222 @@ func TestSafeSweepIdleStreams_RecoversFromPanic(t *testing.T) {
 	}, "safeSweepIdleStreams must recover panics so the janitor loop keeps running")
 }
 
-func TestGetWorkspaceConn_DisconnectedAgentCacheMiss(t *testing.T) {
-	// When ensureWorkspaceAgent returns a disconnected agent
-	// (cache miss), getWorkspaceConn should return
-	// errChatAgentDisconnected without attempting to dial.
+func TestGetWorkspaceConn_StatusCheck(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-	ctrl := gomock.NewController(t)
-	db := dbmock.NewMockStore(ctrl)
-
-	workspaceID := uuid.New()
-	agentID := uuid.New()
-	chat := database.Chat{
-		ID: uuid.New(),
-		WorkspaceID: uuid.NullUUID{
-			UUID:  workspaceID,
-			Valid: true,
-		},
-		AgentID: uuid.NullUUID{
-			UUID:  agentID,
-			Valid: true,
-		},
+	type testCase struct {
+		name              string
+		agent             database.WorkspaceAgent
+		cacheHit          bool
+		dbError           bool
+		wantErr           error
+		wantDialCalled    bool
+		wantReleaseCalled bool
 	}
 
-	// Agent with LastConnectedAt far in the past triggers
-	// disconnected status.
-	disconnectedAgent := database.WorkspaceAgent{
-		ID: agentID,
-		FirstConnectedAt: sql.NullTime{
-			Time:  time.Now().Add(-10 * time.Minute),
-			Valid: true,
+	tests := []testCase{
+		{
+			name: "DisconnectedAgentCacheMiss",
+			agent: database.WorkspaceAgent{
+				FirstConnectedAt: sql.NullTime{
+					Time:  time.Now().Add(-10 * time.Minute),
+					Valid: true,
+				},
+				LastConnectedAt: sql.NullTime{
+					Time:  time.Now().Add(-10 * time.Minute),
+					Valid: true,
+				},
+			},
+			wantErr: errChatAgentDisconnected,
 		},
-		LastConnectedAt: sql.NullTime{
-			Time:  time.Now().Add(-10 * time.Minute),
-			Valid: true,
+		{
+			name: "DisconnectedAgentCacheHit",
+			agent: database.WorkspaceAgent{
+				FirstConnectedAt: sql.NullTime{
+					Time:  time.Now().Add(-10 * time.Minute),
+					Valid: true,
+				},
+				LastConnectedAt: sql.NullTime{
+					Time:  time.Now().Add(-10 * time.Minute),
+					Valid: true,
+				},
+			},
+			cacheHit:          true,
+			wantErr:           errChatAgentDisconnected,
+			wantReleaseCalled: true,
 		},
-	}
-
-	db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), agentID).
-		Return(disconnectedAgent, nil).
-		Times(1)
-
-	var dialCalled bool
-	server := &Server{
-		db:                             db,
-		clock:                          quartz.NewReal(),
-		agentInactiveDisconnectTimeout: 30 * time.Second,
-		dialTimeout:                    defaultDialTimeout,
-	}
-	server.agentConnFn = func(context.Context, uuid.UUID) (workspacesdk.AgentConn, func(), error) {
-		dialCalled = true
-		return nil, nil, xerrors.New("should not be called")
-	}
-
-	chatStateMu := &sync.Mutex{}
-	currentChat := chat
-	workspaceCtx := turnWorkspaceContext{
-		server:           server,
-		chatStateMu:      chatStateMu,
-		currentChat:      &currentChat,
-		loadChatSnapshot: func(context.Context, uuid.UUID) (database.Chat, error) { return database.Chat{}, nil },
-	}
-	defer workspaceCtx.close()
-
-	gotConn, err := workspaceCtx.getWorkspaceConn(ctx)
-	require.Nil(t, gotConn)
-	require.ErrorIs(t, err, errChatAgentDisconnected)
-	require.False(t, dialCalled, "dial should not be attempted for a disconnected agent")
-
-	// Cache should be cleared.
-	workspaceCtx.mu.Lock()
-	defer workspaceCtx.mu.Unlock()
-	require.False(t, workspaceCtx.agentLoaded)
-	require.Nil(t, workspaceCtx.conn)
-}
-
-func TestGetWorkspaceConn_DisconnectedAgentCacheHit(t *testing.T) {
-	// When a cached connection exists but the agent's status
-	// has become disconnected (time elapsed past
-	// inactiveTimeout), getWorkspaceConn should detect this,
-	// release the cached connection, and return
-	// errChatAgentDisconnected.
-	t.Parallel()
-
-	ctx := context.Background()
-	ctrl := gomock.NewController(t)
-	db := dbmock.NewMockStore(ctrl)
-
-	workspaceID := uuid.New()
-	agentID := uuid.New()
-	chat := database.Chat{
-		ID: uuid.New(),
-		WorkspaceID: uuid.NullUUID{
-			UUID:  workspaceID,
-			Valid: true,
+		{
+			name: "TimedOutAgentCacheMiss",
+			agent: database.WorkspaceAgent{
+				CreatedAt:                time.Now().Add(-10 * time.Minute),
+				ConnectionTimeoutSeconds: 60,
+			},
+			wantErr: errChatAgentDisconnected,
 		},
-		AgentID: uuid.NullUUID{
-			UUID:  agentID,
-			Valid: true,
+		{
+			// A "connecting" agent (never connected, normal after
+			// fresh build) must NOT be blocked by the status check.
+			name:           "ConnectingAgentProceeds",
+			agent:          database.WorkspaceAgent{},
+			wantDialCalled: true,
+		},
+		{
+			name: "CacheHitHealthyAgent",
+			agent: database.WorkspaceAgent{
+				FirstConnectedAt: sql.NullTime{
+					Time:  time.Now().Add(-5 * time.Minute),
+					Valid: true,
+				},
+				LastConnectedAt: sql.NullTime{
+					Time:  time.Now(),
+					Valid: true,
+				},
+			},
+			cacheHit: true,
+		},
+		{
+			// When GetWorkspaceAgentByID returns an error on
+			// cache hit, the cached connection should be returned.
+			name: "CacheHitDBError",
+			agent: database.WorkspaceAgent{
+				FirstConnectedAt: sql.NullTime{
+					Time:  time.Now().Add(-5 * time.Minute),
+					Valid: true,
+				},
+				LastConnectedAt: sql.NullTime{
+					Time:  time.Now(),
+					Valid: true,
+				},
+			},
+			cacheHit: true,
+			dbError:  true,
 		},
 	}
 
-	// Agent was connected but LastConnectedAt is now stale.
-	disconnectedAgent := database.WorkspaceAgent{
-		ID: agentID,
-		FirstConnectedAt: sql.NullTime{
-			Time:  time.Now().Add(-10 * time.Minute),
-			Valid: true,
-		},
-		LastConnectedAt: sql.NullTime{
-			Time:  time.Now().Add(-10 * time.Minute),
-			Valid: true,
-		},
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			db := dbmock.NewMockStore(ctrl)
+
+			workspaceID := uuid.New()
+			agentID := uuid.New()
+			chat := database.Chat{
+				ID: uuid.New(),
+				WorkspaceID: uuid.NullUUID{
+					UUID:  workspaceID,
+					Valid: true,
+				},
+				AgentID: uuid.NullUUID{
+					UUID:  agentID,
+					Valid: true,
+				},
+			}
+
+			// Stamp the agent with the generated ID.
+			agent := tc.agent
+			agent.ID = agentID
+
+			// Set up the DB mock for GetWorkspaceAgentByID.
+			if tc.dbError {
+				db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), agentID).
+					Return(database.WorkspaceAgent{}, xerrors.New("connection reset")).
+					Times(1)
+			} else {
+				db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), agentID).
+					Return(agent, nil).
+					Times(1)
+			}
+
+			var dialCalled bool
+			var releaseCalled bool
+
+			// For ConnectingAgentProceeds the dial returns a real
+			// mock conn; for all others it should not be reached.
+			var dialConn *agentconnmock.MockAgentConn
+			if tc.wantDialCalled {
+				dialConn = agentconnmock.NewMockAgentConn(ctrl)
+				dialConn.EXPECT().SetExtraHeaders(gomock.Any()).Times(1)
+			}
+
+			server := &Server{
+				db:                             db,
+				logger:                         slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+				clock:                          quartz.NewReal(),
+				agentInactiveDisconnectTimeout: 30 * time.Second,
+				dialTimeout:                    defaultDialTimeout,
+			}
+			server.agentConnFn = func(_ context.Context, id uuid.UUID) (workspacesdk.AgentConn, func(), error) {
+				dialCalled = true
+				if dialConn != nil {
+					return dialConn, func() {}, nil
+				}
+				return nil, nil, xerrors.New("should not be called")
+			}
+
+			chatStateMu := &sync.Mutex{}
+			currentChat := chat
+			workspaceCtx := turnWorkspaceContext{
+				server:      server,
+				chatStateMu: chatStateMu,
+				currentChat: &currentChat,
+				loadChatSnapshot: func(context.Context, uuid.UUID) (database.Chat, error) {
+					return database.Chat{}, nil
+				},
+			}
+			defer workspaceCtx.close()
+
+			// For cache-hit tests, pre-populate the cached
+			// connection state.
+			var cachedConn *agentconnmock.MockAgentConn
+			if tc.cacheHit {
+				cachedConn = agentconnmock.NewMockAgentConn(ctrl)
+				workspaceCtx.agent = agent
+				workspaceCtx.agentLoaded = true
+				workspaceCtx.conn = cachedConn
+				workspaceCtx.releaseConn = func() { releaseCalled = true }
+				workspaceCtx.cachedWorkspaceID = chat.WorkspaceID
+			}
+
+			ctx := testutil.Context(t, testutil.WaitShort)
+			gotConn, err := workspaceCtx.getWorkspaceConn(ctx)
+
+			switch {
+			case tc.wantErr != nil:
+				require.Nil(t, gotConn)
+				require.ErrorIs(t, err, tc.wantErr)
+			case tc.cacheHit:
+				require.NoError(t, err)
+				require.Same(t, cachedConn, gotConn)
+			default:
+				// Cache-miss success (ConnectingAgentProceeds).
+				require.NoError(t, err)
+				require.Same(t, dialConn, gotConn)
+			}
+
+			require.Equal(t, tc.wantDialCalled, dialCalled, "dial called")
+			require.Equal(t, tc.wantReleaseCalled, releaseCalled, "release called")
+
+			// For error cases on cache-miss, the cache should be
+			// cleared.
+			if tc.wantErr != nil && !tc.cacheHit {
+				workspaceCtx.mu.Lock()
+				defer workspaceCtx.mu.Unlock()
+				require.False(t, workspaceCtx.agentLoaded)
+				require.Nil(t, workspaceCtx.conn)
+			}
+			// For cache-hit disconnect, the cache should also be
+			// cleared.
+			if tc.wantErr != nil && tc.cacheHit {
+				workspaceCtx.mu.Lock()
+				defer workspaceCtx.mu.Unlock()
+				require.False(t, workspaceCtx.agentLoaded)
+				require.Nil(t, workspaceCtx.conn)
+			}
+		})
 	}
-
-	// The production code re-fetches the agent row on cache hit
-	// to see the latest heartbeat timestamp.
-	db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), agentID).
-		Return(disconnectedAgent, nil).
-		Times(1)
-
-	cachedConn := agentconnmock.NewMockAgentConn(ctrl)
-	var releaseCalled bool
-
-	server := &Server{
-		db:                             db,
-		clock:                          quartz.NewReal(),
-		agentInactiveDisconnectTimeout: 30 * time.Second,
-		dialTimeout:                    defaultDialTimeout,
-	}
-	server.agentConnFn = func(context.Context, uuid.UUID) (workspacesdk.AgentConn, func(), error) {
-		return nil, nil, xerrors.New("should not be called")
-	}
-
-	chatStateMu := &sync.Mutex{}
-	currentChat := chat
-	workspaceCtx := turnWorkspaceContext{
-		server:      server,
-		chatStateMu: chatStateMu,
-		currentChat: &currentChat,
-		loadChatSnapshot: func(context.Context, uuid.UUID) (database.Chat, error) {
-			return database.Chat{}, nil
-		},
-	}
-	// Pre-populate cache to simulate a previously working connection.
-	workspaceCtx.agent = disconnectedAgent
-	workspaceCtx.agentLoaded = true
-	workspaceCtx.conn = cachedConn
-	workspaceCtx.releaseConn = func() { releaseCalled = true }
-	workspaceCtx.cachedWorkspaceID = chat.WorkspaceID
-
-	gotConn, err := workspaceCtx.getWorkspaceConn(ctx)
-	require.Nil(t, gotConn)
-	require.ErrorIs(t, err, errChatAgentDisconnected)
-	require.True(t, releaseCalled, "stale connection should be released")
-
-	// Cache should be fully cleared.
-	workspaceCtx.mu.Lock()
-	defer workspaceCtx.mu.Unlock()
-	require.False(t, workspaceCtx.agentLoaded)
-	require.Nil(t, workspaceCtx.conn)
-}
-
-func TestGetWorkspaceConn_TimedOutAgentCacheMiss(t *testing.T) {
-	// When ensureWorkspaceAgent returns an agent in the Timeout
-	// state (never connected, connection timeout exceeded),
-	// getWorkspaceConn should return errChatAgentDisconnected
-	// without attempting to dial.
-	t.Parallel()
-
-	ctx := context.Background()
-	ctrl := gomock.NewController(t)
-	db := dbmock.NewMockStore(ctrl)
-
-	workspaceID := uuid.New()
-	agentID := uuid.New()
-	chat := database.Chat{
-		ID: uuid.New(),
-		WorkspaceID: uuid.NullUUID{
-			UUID:  workspaceID,
-			Valid: true,
-		},
-		AgentID: uuid.NullUUID{
-			UUID:  agentID,
-			Valid: true,
-		},
-	}
-
-	// Agent that never connected and exceeded its connection
-	// timeout. FirstConnectedAt is invalid, CreatedAt is old
-	// enough, and ConnectionTimeoutSeconds is set.
-	timedOutAgent := database.WorkspaceAgent{
-		ID:                       agentID,
-		CreatedAt:                time.Now().Add(-10 * time.Minute),
-		ConnectionTimeoutSeconds: 60,
-	}
-
-	db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), agentID).
-		Return(timedOutAgent, nil).
-		Times(1)
-
-	var dialCalled bool
-	server := &Server{
-		db:                             db,
-		clock:                          quartz.NewReal(),
-		agentInactiveDisconnectTimeout: 30 * time.Second,
-		dialTimeout:                    defaultDialTimeout,
-	}
-	server.agentConnFn = func(context.Context, uuid.UUID) (workspacesdk.AgentConn, func(), error) {
-		dialCalled = true
-		return nil, nil, xerrors.New("should not be called")
-	}
-
-	chatStateMu := &sync.Mutex{}
-	currentChat := chat
-	workspaceCtx := turnWorkspaceContext{
-		server:           server,
-		chatStateMu:      chatStateMu,
-		currentChat:      &currentChat,
-		loadChatSnapshot: func(context.Context, uuid.UUID) (database.Chat, error) { return database.Chat{}, nil },
-	}
-	defer workspaceCtx.close()
-
-	gotConn, err := workspaceCtx.getWorkspaceConn(ctx)
-	require.Nil(t, gotConn)
-	require.ErrorIs(t, err, errChatAgentDisconnected)
-	require.False(t, dialCalled, "dial should not be attempted for a timed-out agent")
-
-	// Cache should be cleared.
-	workspaceCtx.mu.Lock()
-	defer workspaceCtx.mu.Unlock()
-	require.False(t, workspaceCtx.agentLoaded)
-	require.Nil(t, workspaceCtx.conn)
-}
-
-func TestGetWorkspaceConn_ConnectingAgentProceeds(t *testing.T) {
-	// A "connecting" agent (never connected, normal after
-	// fresh build) must NOT be blocked by the status check.
-	// The dial should proceed.
-	t.Parallel()
-
-	ctx := context.Background()
-	ctrl := gomock.NewController(t)
-	db := dbmock.NewMockStore(ctrl)
-
-	workspaceID := uuid.New()
-	agentID := uuid.New()
-	chat := database.Chat{
-		ID: uuid.New(),
-		WorkspaceID: uuid.NullUUID{
-			UUID:  workspaceID,
-			Valid: true,
-		},
-		AgentID: uuid.NullUUID{
-			UUID:  agentID,
-			Valid: true,
-		},
-	}
-
-	// Agent that has never connected: FirstConnectedAt is not valid.
-	connectingAgent := database.WorkspaceAgent{
-		ID: agentID,
-	}
-
-	db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), agentID).
-		Return(connectingAgent, nil).
-		Times(1)
-
-	conn := agentconnmock.NewMockAgentConn(ctrl)
-	conn.EXPECT().SetExtraHeaders(gomock.Any()).Times(1)
-
-	server := &Server{
-		db:                             db,
-		clock:                          quartz.NewReal(),
-		agentInactiveDisconnectTimeout: 30 * time.Second,
-		dialTimeout:                    defaultDialTimeout,
-	}
-	server.agentConnFn = func(_ context.Context, id uuid.UUID) (workspacesdk.AgentConn, func(), error) {
-		if id != agentID {
-			return nil, nil, xerrors.Errorf("unexpected agent ID %q", id)
-		}
-		return conn, func() {}, nil
-	}
-
-	chatStateMu := &sync.Mutex{}
-	currentChat := chat
-	workspaceCtx := turnWorkspaceContext{
-		server:           server,
-		chatStateMu:      chatStateMu,
-		currentChat:      &currentChat,
-		loadChatSnapshot: func(context.Context, uuid.UUID) (database.Chat, error) { return database.Chat{}, nil },
-	}
-	defer workspaceCtx.close()
-
-	gotConn, err := workspaceCtx.getWorkspaceConn(ctx)
-	require.NoError(t, err)
-	require.Same(t, conn, gotConn)
 }
 
 func TestGetWorkspaceConn_DialTimeout(t *testing.T) {
@@ -4013,7 +3932,6 @@ func TestGetWorkspaceConn_DialTimeout(t *testing.T) {
 	// errChatDialTimeout instead of hanging indefinitely.
 	t.Parallel()
 
-	ctx := context.Background()
 	ctrl := gomock.NewController(t)
 	db := dbmock.NewMockStore(ctrl)
 
@@ -4070,6 +3988,7 @@ func TestGetWorkspaceConn_DialTimeout(t *testing.T) {
 	}
 	defer workspaceCtx.close()
 
+	ctx := testutil.Context(t, testutil.WaitShort)
 	gotConn, err := workspaceCtx.getWorkspaceConn(ctx)
 	require.Nil(t, gotConn)
 	require.ErrorIs(t, err, errChatDialTimeout)
@@ -4116,7 +4035,7 @@ func TestGetWorkspaceConn_DialTimeoutParentCanceled(t *testing.T) {
 		Times(1)
 
 	parentErr := xerrors.New("parent canceled")
-	ctx, cancel := context.WithCancelCause(context.Background())
+	ctx, cancel := context.WithCancelCause(testutil.Context(t, testutil.WaitShort))
 
 	server := &Server{
 		db:                             db,
@@ -4168,7 +4087,6 @@ func TestGetWorkspaceConn_DialErrorNotMisclassifiedAsTimeout(t *testing.T) {
 	// to be misclassified.
 	t.Parallel()
 
-	ctx := context.Background()
 	ctrl := gomock.NewController(t)
 	db := dbmock.NewMockStore(ctrl)
 
@@ -4233,165 +4151,11 @@ func TestGetWorkspaceConn_DialErrorNotMisclassifiedAsTimeout(t *testing.T) {
 	}
 	defer workspaceCtx.close()
 
+	ctx := testutil.Context(t, testutil.WaitShort)
 	gotConn, err := workspaceCtx.getWorkspaceConn(ctx)
 	require.Nil(t, gotConn)
 	// Must NOT be misclassified as a dial timeout.
 	require.NotErrorIs(t, err, errChatDialTimeout)
 	// The original dial error should propagate.
 	require.ErrorContains(t, err, "authentication failed")
-}
-
-func TestGetWorkspaceConn_CacheHitHealthyAgent(t *testing.T) {
-	// When a cached connection exists and the agent is still
-	// healthy (LastConnectedAt near now), getWorkspaceConn
-	// should return the cached connection without error and
-	// without calling releaseConn.
-	t.Parallel()
-
-	ctx := context.Background()
-	ctrl := gomock.NewController(t)
-	db := dbmock.NewMockStore(ctrl)
-
-	workspaceID := uuid.New()
-	agentID := uuid.New()
-	chat := database.Chat{
-		ID: uuid.New(),
-		WorkspaceID: uuid.NullUUID{
-			UUID:  workspaceID,
-			Valid: true,
-		},
-		AgentID: uuid.NullUUID{
-			UUID:  agentID,
-			Valid: true,
-		},
-	}
-
-	// Agent with a recent LastConnectedAt is healthy.
-	healthyAgent := database.WorkspaceAgent{
-		ID: agentID,
-		FirstConnectedAt: sql.NullTime{
-			Time:  time.Now().Add(-5 * time.Minute),
-			Valid: true,
-		},
-		LastConnectedAt: sql.NullTime{
-			Time:  time.Now(),
-			Valid: true,
-		},
-	}
-
-	db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), agentID).
-		Return(healthyAgent, nil).
-		Times(1)
-
-	cachedConn := agentconnmock.NewMockAgentConn(ctrl)
-	var releaseCalled bool
-
-	server := &Server{
-		db:                             db,
-		clock:                          quartz.NewReal(),
-		agentInactiveDisconnectTimeout: 30 * time.Second,
-		dialTimeout:                    defaultDialTimeout,
-	}
-	server.agentConnFn = func(context.Context, uuid.UUID) (workspacesdk.AgentConn, func(), error) {
-		return nil, nil, xerrors.New("should not be called")
-	}
-
-	chatStateMu := &sync.Mutex{}
-	currentChat := chat
-	workspaceCtx := turnWorkspaceContext{
-		server:      server,
-		chatStateMu: chatStateMu,
-		currentChat: &currentChat,
-		loadChatSnapshot: func(context.Context, uuid.UUID) (database.Chat, error) {
-			return database.Chat{}, nil
-		},
-	}
-	// Pre-populate cache to simulate a previously working
-	// connection.
-	workspaceCtx.agent = healthyAgent
-	workspaceCtx.agentLoaded = true
-	workspaceCtx.conn = cachedConn
-	workspaceCtx.releaseConn = func() { releaseCalled = true }
-	workspaceCtx.cachedWorkspaceID = chat.WorkspaceID
-
-	gotConn, err := workspaceCtx.getWorkspaceConn(ctx)
-	require.NoError(t, err)
-	require.Same(t, cachedConn, gotConn)
-	require.False(t, releaseCalled,
-		"releaseConn should not be called for a healthy cached connection")
-}
-
-func TestGetWorkspaceConn_CacheHitDBError(t *testing.T) {
-	// When a cached connection exists but GetWorkspaceAgentByID
-	// returns an error, getWorkspaceConn should fall through
-	// gracefully and return the cached connection.
-	t.Parallel()
-
-	ctx := context.Background()
-	ctrl := gomock.NewController(t)
-	db := dbmock.NewMockStore(ctrl)
-
-	workspaceID := uuid.New()
-	agentID := uuid.New()
-	chat := database.Chat{
-		ID: uuid.New(),
-		WorkspaceID: uuid.NullUUID{
-			UUID:  workspaceID,
-			Valid: true,
-		},
-		AgentID: uuid.NullUUID{
-			UUID:  agentID,
-			Valid: true,
-		},
-	}
-
-	cachedAgent := database.WorkspaceAgent{
-		ID: agentID,
-		FirstConnectedAt: sql.NullTime{
-			Time:  time.Now().Add(-5 * time.Minute),
-			Valid: true,
-		},
-		LastConnectedAt: sql.NullTime{
-			Time:  time.Now(),
-			Valid: true,
-		},
-	}
-
-	// DB error on re-fetch.
-	db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), agentID).
-		Return(database.WorkspaceAgent{}, xerrors.New("connection reset")).
-		Times(1)
-
-	cachedConn := agentconnmock.NewMockAgentConn(ctrl)
-
-	server := &Server{
-		db:                             db,
-		clock:                          quartz.NewReal(),
-		agentInactiveDisconnectTimeout: 30 * time.Second,
-		dialTimeout:                    defaultDialTimeout,
-	}
-	server.agentConnFn = func(context.Context, uuid.UUID) (workspacesdk.AgentConn, func(), error) {
-		return nil, nil, xerrors.New("should not be called")
-	}
-
-	chatStateMu := &sync.Mutex{}
-	currentChat := chat
-	workspaceCtx := turnWorkspaceContext{
-		server:      server,
-		chatStateMu: chatStateMu,
-		currentChat: &currentChat,
-		loadChatSnapshot: func(context.Context, uuid.UUID) (database.Chat, error) {
-			return database.Chat{}, nil
-		},
-	}
-	// Pre-populate cache.
-	workspaceCtx.agent = cachedAgent
-	workspaceCtx.agentLoaded = true
-	workspaceCtx.conn = cachedConn
-	workspaceCtx.releaseConn = func() {}
-	workspaceCtx.cachedWorkspaceID = chat.WorkspaceID
-
-	gotConn, err := workspaceCtx.getWorkspaceConn(ctx)
-	require.NoError(t, err)
-	require.Same(t, cachedConn, gotConn)
 }

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -606,9 +606,11 @@ func TestPersistInstructionFilesIncludesAgentMetadata(t *testing.T) {
 	}, nil).AnyTimes()
 	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
 	server := &Server{
-		db:                       db,
-		logger:                   logger,
-		instructionLookupTimeout: 5 * time.Second,
+		db:                             db,
+		logger:                         logger,
+		instructionLookupTimeout:       5 * time.Second,
+		agentInactiveDisconnectTimeout: 30 * time.Second,
+		dialTimeout:                    30 * time.Second,
 		agentConnFn: func(context.Context, uuid.UUID) (workspacesdk.AgentConn, func(), error) {
 			return conn, func() {}, nil
 		},
@@ -771,9 +773,11 @@ func TestPersistInstructionFilesSentinelWithSkills(t *testing.T) {
 	}, nil).AnyTimes()
 	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
 	server := &Server{
-		db:                       db,
-		logger:                   logger,
-		instructionLookupTimeout: 5 * time.Second,
+		db:                             db,
+		logger:                         logger,
+		instructionLookupTimeout:       5 * time.Second,
+		agentInactiveDisconnectTimeout: 30 * time.Second,
+		dialTimeout:                    30 * time.Second,
 		agentConnFn: func(context.Context, uuid.UUID) (workspacesdk.AgentConn, func(), error) {
 			return conn, func() {}, nil
 		},
@@ -856,9 +860,11 @@ func TestPersistInstructionFilesSentinelNoSkillsClearsColumn(t *testing.T) {
 	}, nil).AnyTimes()
 	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
 	server := &Server{
-		db:                       db,
-		logger:                   logger,
-		instructionLookupTimeout: 5 * time.Second,
+		db:                             db,
+		logger:                         logger,
+		instructionLookupTimeout:       5 * time.Second,
+		agentInactiveDisconnectTimeout: 30 * time.Second,
+		dialTimeout:                    30 * time.Second,
 		agentConnFn: func(context.Context, uuid.UUID) (workspacesdk.AgentConn, func(), error) {
 			return conn, func() {}, nil
 		},
@@ -1084,7 +1090,11 @@ func TestTurnWorkspaceContextGetWorkspaceConnLazyValidationSwitchesWorkspaceAgen
 	conn.EXPECT().SetExtraHeaders(gomock.Any()).Times(1)
 
 	var dialed []uuid.UUID
-	server := &Server{db: db}
+	server := &Server{
+		db:                             db,
+		agentInactiveDisconnectTimeout: 30 * time.Second,
+		dialTimeout:                    30 * time.Second,
+	}
 	server.agentConnFn = func(_ context.Context, agentID uuid.UUID) (workspacesdk.AgentConn, func(), error) {
 		dialed = append(dialed, agentID)
 		if agentID == staleAgentID {
@@ -1144,7 +1154,11 @@ func TestTurnWorkspaceContextGetWorkspaceConnFastFailsWithoutCurrentAgent(t *tes
 		Return([]database.WorkspaceAgent{}, nil).
 		Times(1)
 
-	server := &Server{db: db}
+	server := &Server{
+		db:                             db,
+		agentInactiveDisconnectTimeout: 30 * time.Second,
+		dialTimeout:                    30 * time.Second,
+	}
 	server.agentConnFn = func(context.Context, uuid.UUID) (workspacesdk.AgentConn, func(), error) {
 		return nil, nil, xerrors.New("dial failed")
 	}
@@ -2798,4 +2812,448 @@ func TestHeartbeatTick_DBErrorDoesNotInterruptChats(t *testing.T) {
 	// returned early.
 	require.NoError(t, chatCtx.Err(),
 		"chat context should not be canceled on transient DB error")
+}
+
+func TestGetWorkspaceConn_DisconnectedAgentCacheMiss(t *testing.T) {
+	// Stage 1 red test: when ensureWorkspaceAgent returns a
+	// disconnected agent (cache miss), getWorkspaceConn should
+	// return errChatAgentDisconnected without attempting to dial.
+	t.Parallel()
+
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+
+	workspaceID := uuid.New()
+	agentID := uuid.New()
+	chat := database.Chat{
+		ID: uuid.New(),
+		WorkspaceID: uuid.NullUUID{
+			UUID:  workspaceID,
+			Valid: true,
+		},
+		AgentID: uuid.NullUUID{
+			UUID:  agentID,
+			Valid: true,
+		},
+	}
+
+	// Agent with LastConnectedAt far in the past triggers
+	// disconnected status.
+	disconnectedAgent := database.WorkspaceAgent{
+		ID: agentID,
+		FirstConnectedAt: sql.NullTime{
+			Time:  time.Now().Add(-10 * time.Minute),
+			Valid: true,
+		},
+		LastConnectedAt: sql.NullTime{
+			Time:  time.Now().Add(-10 * time.Minute),
+			Valid: true,
+		},
+	}
+
+	db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), agentID).
+		Return(disconnectedAgent, nil).
+		Times(1)
+
+	var dialCalled bool
+	server := &Server{
+		db:                             db,
+		agentInactiveDisconnectTimeout: 30 * time.Second,
+	}
+	server.agentConnFn = func(context.Context, uuid.UUID) (workspacesdk.AgentConn, func(), error) {
+		dialCalled = true
+		return nil, nil, xerrors.New("should not be called")
+	}
+
+	chatStateMu := &sync.Mutex{}
+	currentChat := chat
+	workspaceCtx := turnWorkspaceContext{
+		server:           server,
+		chatStateMu:      chatStateMu,
+		currentChat:      &currentChat,
+		loadChatSnapshot: func(context.Context, uuid.UUID) (database.Chat, error) { return database.Chat{}, nil },
+	}
+	defer workspaceCtx.close()
+
+	gotConn, err := workspaceCtx.getWorkspaceConn(ctx)
+	require.Nil(t, gotConn)
+	require.ErrorIs(t, err, errChatAgentDisconnected)
+	require.False(t, dialCalled, "dial should not be attempted for a disconnected agent")
+
+	// Cache should be cleared.
+	workspaceCtx.mu.Lock()
+	defer workspaceCtx.mu.Unlock()
+	require.False(t, workspaceCtx.agentLoaded)
+	require.Nil(t, workspaceCtx.conn)
+}
+
+func TestGetWorkspaceConn_DisconnectedAgentCacheHit(t *testing.T) {
+	// Stage 1 red test: when a cached connection exists but the
+	// agent's status has become disconnected (time elapsed past
+	// inactiveTimeout), getWorkspaceConn should detect this,
+	// release the cached connection, and return
+	// errChatAgentDisconnected.
+	t.Parallel()
+
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+
+	workspaceID := uuid.New()
+	agentID := uuid.New()
+	chat := database.Chat{
+		ID: uuid.New(),
+		WorkspaceID: uuid.NullUUID{
+			UUID:  workspaceID,
+			Valid: true,
+		},
+		AgentID: uuid.NullUUID{
+			UUID:  agentID,
+			Valid: true,
+		},
+	}
+
+	// Agent was connected but LastConnectedAt is now stale.
+	disconnectedAgent := database.WorkspaceAgent{
+		ID: agentID,
+		FirstConnectedAt: sql.NullTime{
+			Time:  time.Now().Add(-10 * time.Minute),
+			Valid: true,
+		},
+		LastConnectedAt: sql.NullTime{
+			Time:  time.Now().Add(-10 * time.Minute),
+			Valid: true,
+		},
+	}
+
+	cachedConn := agentconnmock.NewMockAgentConn(ctrl)
+	var releaseCalled bool
+
+	server := &Server{
+		agentInactiveDisconnectTimeout: 30 * time.Second,
+	}
+	server.agentConnFn = func(context.Context, uuid.UUID) (workspacesdk.AgentConn, func(), error) {
+		return nil, nil, xerrors.New("should not be called")
+	}
+
+	chatStateMu := &sync.Mutex{}
+	currentChat := chat
+	workspaceCtx := turnWorkspaceContext{
+		server:      server,
+		chatStateMu: chatStateMu,
+		currentChat: &currentChat,
+		loadChatSnapshot: func(context.Context, uuid.UUID) (database.Chat, error) {
+			return database.Chat{}, nil
+		},
+	}
+	// Pre-populate cache to simulate a previously working connection.
+	workspaceCtx.agent = disconnectedAgent
+	workspaceCtx.agentLoaded = true
+	workspaceCtx.conn = cachedConn
+	workspaceCtx.releaseConn = func() { releaseCalled = true }
+	workspaceCtx.cachedWorkspaceID = chat.WorkspaceID
+
+	gotConn, err := workspaceCtx.getWorkspaceConn(ctx)
+	require.Nil(t, gotConn)
+	require.ErrorIs(t, err, errChatAgentDisconnected)
+	require.True(t, releaseCalled, "stale connection should be released")
+
+	// Cache should be fully cleared.
+	workspaceCtx.mu.Lock()
+	defer workspaceCtx.mu.Unlock()
+	require.False(t, workspaceCtx.agentLoaded)
+	require.Nil(t, workspaceCtx.conn)
+}
+
+func TestGetWorkspaceConn_ConnectingAgentProceeds(t *testing.T) {
+	// Stage 1 red test: a "connecting" agent (never connected,
+	// normal after fresh build) must NOT be blocked by the
+	// status check. The dial should proceed.
+	t.Parallel()
+
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+
+	workspaceID := uuid.New()
+	agentID := uuid.New()
+	chat := database.Chat{
+		ID: uuid.New(),
+		WorkspaceID: uuid.NullUUID{
+			UUID:  workspaceID,
+			Valid: true,
+		},
+		AgentID: uuid.NullUUID{
+			UUID:  agentID,
+			Valid: true,
+		},
+	}
+
+	// Agent that has never connected: FirstConnectedAt is not valid.
+	connectingAgent := database.WorkspaceAgent{
+		ID: agentID,
+	}
+
+	db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), agentID).
+		Return(connectingAgent, nil).
+		Times(1)
+
+	conn := agentconnmock.NewMockAgentConn(ctrl)
+	conn.EXPECT().SetExtraHeaders(gomock.Any()).Times(1)
+
+	server := &Server{
+		db:                             db,
+		agentInactiveDisconnectTimeout: 30 * time.Second,
+		dialTimeout:                    30 * time.Second,
+	}
+	server.agentConnFn = func(_ context.Context, id uuid.UUID) (workspacesdk.AgentConn, func(), error) {
+		if id != agentID {
+			return nil, nil, xerrors.Errorf("unexpected agent ID %q", id)
+		}
+		return conn, func() {}, nil
+	}
+
+	chatStateMu := &sync.Mutex{}
+	currentChat := chat
+	workspaceCtx := turnWorkspaceContext{
+		server:           server,
+		chatStateMu:      chatStateMu,
+		currentChat:      &currentChat,
+		loadChatSnapshot: func(context.Context, uuid.UUID) (database.Chat, error) { return database.Chat{}, nil },
+	}
+	defer workspaceCtx.close()
+
+	gotConn, err := workspaceCtx.getWorkspaceConn(ctx)
+	require.NoError(t, err)
+	require.Same(t, conn, gotConn)
+}
+
+func TestGetWorkspaceConn_DialTimeout(t *testing.T) {
+	// Stage 2 red test: when dialWithLazyValidation blocks
+	// beyond the dial timeout, getWorkspaceConn should return
+	// errChatDialTimeout instead of hanging indefinitely.
+	t.Parallel()
+
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+
+	workspaceID := uuid.New()
+	agentID := uuid.New()
+	chat := database.Chat{
+		ID: uuid.New(),
+		WorkspaceID: uuid.NullUUID{
+			UUID:  workspaceID,
+			Valid: true,
+		},
+		AgentID: uuid.NullUUID{
+			UUID:  agentID,
+			Valid: true,
+		},
+	}
+
+	// Agent appears connected so the status check passes.
+	connectedAgent := database.WorkspaceAgent{
+		ID: agentID,
+		FirstConnectedAt: sql.NullTime{
+			Time:  time.Now().Add(-1 * time.Minute),
+			Valid: true,
+		},
+		LastConnectedAt: sql.NullTime{
+			Time:  time.Now(),
+			Valid: true,
+		},
+	}
+
+	db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), agentID).
+		Return(connectedAgent, nil).
+		Times(1)
+
+	server := &Server{
+		db:                             db,
+		agentInactiveDisconnectTimeout: 30 * time.Second,
+		dialTimeout:                    10 * time.Millisecond,
+	}
+	// Dial blocks forever (simulates unreachable agent).
+	server.agentConnFn = func(ctx context.Context, _ uuid.UUID) (workspacesdk.AgentConn, func(), error) {
+		<-ctx.Done()
+		return nil, nil, ctx.Err()
+	}
+
+	chatStateMu := &sync.Mutex{}
+	currentChat := chat
+	workspaceCtx := turnWorkspaceContext{
+		server:           server,
+		chatStateMu:      chatStateMu,
+		currentChat:      &currentChat,
+		loadChatSnapshot: func(context.Context, uuid.UUID) (database.Chat, error) { return database.Chat{}, nil },
+	}
+	defer workspaceCtx.close()
+
+	gotConn, err := workspaceCtx.getWorkspaceConn(ctx)
+	require.Nil(t, gotConn)
+	require.ErrorIs(t, err, errChatDialTimeout)
+}
+
+func TestGetWorkspaceConn_DialTimeoutParentCanceled(t *testing.T) {
+	// Stage 2 red test: when the parent context is canceled,
+	// the parent's error must propagate unchanged (not wrapped
+	// as a dial timeout). This is critical because the chatloop
+	// checks context.Cause(ctx) for ErrInterrupted.
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+
+	workspaceID := uuid.New()
+	agentID := uuid.New()
+	chat := database.Chat{
+		ID: uuid.New(),
+		WorkspaceID: uuid.NullUUID{
+			UUID:  workspaceID,
+			Valid: true,
+		},
+		AgentID: uuid.NullUUID{
+			UUID:  agentID,
+			Valid: true,
+		},
+	}
+
+	connectedAgent := database.WorkspaceAgent{
+		ID: agentID,
+		FirstConnectedAt: sql.NullTime{
+			Time:  time.Now().Add(-1 * time.Minute),
+			Valid: true,
+		},
+		LastConnectedAt: sql.NullTime{
+			Time:  time.Now(),
+			Valid: true,
+		},
+	}
+
+	db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), agentID).
+		Return(connectedAgent, nil).
+		Times(1)
+
+	parentErr := xerrors.New("parent canceled")
+	ctx, cancel := context.WithCancelCause(context.Background())
+
+	server := &Server{
+		db:                             db,
+		agentInactiveDisconnectTimeout: 30 * time.Second,
+		// Use a very long dial timeout so the parent cancel fires
+		// first.
+		dialTimeout: 10 * time.Minute,
+	}
+	// Signal when the dial goroutine has started so we can
+	// cancel the parent at the right time without time.Sleep.
+	dialStarted := make(chan struct{})
+	server.agentConnFn = func(ctx context.Context, _ uuid.UUID) (workspacesdk.AgentConn, func(), error) {
+		close(dialStarted)
+		<-ctx.Done()
+		return nil, nil, ctx.Err()
+	}
+
+	chatStateMu := &sync.Mutex{}
+	currentChat := chat
+	workspaceCtx := turnWorkspaceContext{
+		server:           server,
+		chatStateMu:      chatStateMu,
+		currentChat:      &currentChat,
+		loadChatSnapshot: func(context.Context, uuid.UUID) (database.Chat, error) { return database.Chat{}, nil },
+	}
+	defer workspaceCtx.close()
+
+	// Cancel the parent after the dial starts.
+	go func() {
+		<-dialStarted
+		cancel(parentErr)
+	}()
+
+	gotConn, err := workspaceCtx.getWorkspaceConn(ctx)
+	require.Nil(t, gotConn)
+	// The error must NOT be errChatDialTimeout.
+	require.NotErrorIs(t, err, errChatDialTimeout)
+	// The parent context's error should propagate.
+	require.Error(t, err)
+}
+
+func TestGetWorkspaceConn_DialErrorNotMisclassifiedAsTimeout(t *testing.T) {
+	// Regression test: a non-timeout dial error (e.g. auth
+	// failure) with the parent context still alive must NOT be
+	// converted to errChatDialTimeout. Before the fix,
+	// dialCancel() poisoned dialCtx.Err(), causing all errors
+	// to be misclassified.
+	t.Parallel()
+
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+
+	workspaceID := uuid.New()
+	agentID := uuid.New()
+	chat := database.Chat{
+		ID: uuid.New(),
+		WorkspaceID: uuid.NullUUID{
+			UUID:  workspaceID,
+			Valid: true,
+		},
+		AgentID: uuid.NullUUID{
+			UUID:  agentID,
+			Valid: true,
+		},
+	}
+
+	connectedAgent := database.WorkspaceAgent{
+		ID: agentID,
+		FirstConnectedAt: sql.NullTime{
+			Time:  time.Now().Add(-1 * time.Minute),
+			Valid: true,
+		},
+		LastConnectedAt: sql.NullTime{
+			Time:  time.Now(),
+			Valid: true,
+		},
+	}
+
+	db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), agentID).
+		Return(connectedAgent, nil).
+		Times(1)
+	// When the initial dial fails immediately, dialWithLazyValidation
+	// calls resolveFastFailure which validates the binding. Mock the
+	// validation to return the same agent, triggering a synchronous
+	// redial that also returns the error.
+	db.EXPECT().GetWorkspaceAgentsInLatestBuildByWorkspaceID(gomock.Any(), workspaceID).
+		Return([]database.WorkspaceAgent{connectedAgent}, nil).
+		AnyTimes()
+
+	dialErr := xerrors.New("authentication failed")
+	server := &Server{
+		db:                             db,
+		agentInactiveDisconnectTimeout: 30 * time.Second,
+		// Generous timeout so the dial error fires well before
+		// the timeout.
+		dialTimeout: 30 * time.Second,
+	}
+	server.agentConnFn = func(context.Context, uuid.UUID) (workspacesdk.AgentConn, func(), error) {
+		// Return an error immediately (not a timeout).
+		return nil, nil, dialErr
+	}
+
+	chatStateMu := &sync.Mutex{}
+	currentChat := chat
+	workspaceCtx := turnWorkspaceContext{
+		server:           server,
+		chatStateMu:      chatStateMu,
+		currentChat:      &currentChat,
+		loadChatSnapshot: func(context.Context, uuid.UUID) (database.Chat, error) { return database.Chat{}, nil },
+	}
+	defer workspaceCtx.close()
+
+	gotConn, err := workspaceCtx.getWorkspaceConn(ctx)
+	require.Nil(t, gotConn)
+	// Must NOT be misclassified as a dial timeout.
+	require.NotErrorIs(t, err, errChatDialTimeout)
+	// The original dial error should propagate.
+	require.ErrorContains(t, err, "authentication failed")
 }

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -2815,9 +2815,9 @@ func TestHeartbeatTick_DBErrorDoesNotInterruptChats(t *testing.T) {
 }
 
 func TestGetWorkspaceConn_DisconnectedAgentCacheMiss(t *testing.T) {
-	// Stage 1 red test: when ensureWorkspaceAgent returns a
-	// disconnected agent (cache miss), getWorkspaceConn should
-	// return errChatAgentDisconnected without attempting to dial.
+	// When ensureWorkspaceAgent returns a disconnected agent
+	// (cache miss), getWorkspaceConn should return
+	// errChatAgentDisconnected without attempting to dial.
 	t.Parallel()
 
 	ctx := context.Background()
@@ -2860,6 +2860,7 @@ func TestGetWorkspaceConn_DisconnectedAgentCacheMiss(t *testing.T) {
 	server := &Server{
 		db:                             db,
 		agentInactiveDisconnectTimeout: 30 * time.Second,
+		dialTimeout:                    defaultDialTimeout,
 	}
 	server.agentConnFn = func(context.Context, uuid.UUID) (workspacesdk.AgentConn, func(), error) {
 		dialCalled = true
@@ -2889,8 +2890,8 @@ func TestGetWorkspaceConn_DisconnectedAgentCacheMiss(t *testing.T) {
 }
 
 func TestGetWorkspaceConn_DisconnectedAgentCacheHit(t *testing.T) {
-	// Stage 1 red test: when a cached connection exists but the
-	// agent's status has become disconnected (time elapsed past
+	// When a cached connection exists but the agent's status
+	// has become disconnected (time elapsed past
 	// inactiveTimeout), getWorkspaceConn should detect this,
 	// release the cached connection, and return
 	// errChatAgentDisconnected.
@@ -2898,6 +2899,7 @@ func TestGetWorkspaceConn_DisconnectedAgentCacheHit(t *testing.T) {
 
 	ctx := context.Background()
 	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
 
 	workspaceID := uuid.New()
 	agentID := uuid.New()
@@ -2926,11 +2928,19 @@ func TestGetWorkspaceConn_DisconnectedAgentCacheHit(t *testing.T) {
 		},
 	}
 
+	// The production code re-fetches the agent row on cache hit
+	// to see the latest heartbeat timestamp.
+	db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), agentID).
+		Return(disconnectedAgent, nil).
+		Times(1)
+
 	cachedConn := agentconnmock.NewMockAgentConn(ctrl)
 	var releaseCalled bool
 
 	server := &Server{
+		db:                             db,
 		agentInactiveDisconnectTimeout: 30 * time.Second,
+		dialTimeout:                    defaultDialTimeout,
 	}
 	server.agentConnFn = func(context.Context, uuid.UUID) (workspacesdk.AgentConn, func(), error) {
 		return nil, nil, xerrors.New("should not be called")
@@ -2965,10 +2975,81 @@ func TestGetWorkspaceConn_DisconnectedAgentCacheHit(t *testing.T) {
 	require.Nil(t, workspaceCtx.conn)
 }
 
+func TestGetWorkspaceConn_TimedOutAgentCacheMiss(t *testing.T) {
+	// When ensureWorkspaceAgent returns an agent in the Timeout
+	// state (never connected, connection timeout exceeded),
+	// getWorkspaceConn should return errChatAgentDisconnected
+	// without attempting to dial.
+	t.Parallel()
+
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+
+	workspaceID := uuid.New()
+	agentID := uuid.New()
+	chat := database.Chat{
+		ID: uuid.New(),
+		WorkspaceID: uuid.NullUUID{
+			UUID:  workspaceID,
+			Valid: true,
+		},
+		AgentID: uuid.NullUUID{
+			UUID:  agentID,
+			Valid: true,
+		},
+	}
+
+	// Agent that never connected and exceeded its connection
+	// timeout. FirstConnectedAt is invalid, CreatedAt is old
+	// enough, and ConnectionTimeoutSeconds is set.
+	timedOutAgent := database.WorkspaceAgent{
+		ID:                       agentID,
+		CreatedAt:                time.Now().Add(-10 * time.Minute),
+		ConnectionTimeoutSeconds: 60,
+	}
+
+	db.EXPECT().GetWorkspaceAgentByID(gomock.Any(), agentID).
+		Return(timedOutAgent, nil).
+		Times(1)
+
+	var dialCalled bool
+	server := &Server{
+		db:                             db,
+		agentInactiveDisconnectTimeout: 30 * time.Second,
+		dialTimeout:                    defaultDialTimeout,
+	}
+	server.agentConnFn = func(context.Context, uuid.UUID) (workspacesdk.AgentConn, func(), error) {
+		dialCalled = true
+		return nil, nil, xerrors.New("should not be called")
+	}
+
+	chatStateMu := &sync.Mutex{}
+	currentChat := chat
+	workspaceCtx := turnWorkspaceContext{
+		server:           server,
+		chatStateMu:      chatStateMu,
+		currentChat:      &currentChat,
+		loadChatSnapshot: func(context.Context, uuid.UUID) (database.Chat, error) { return database.Chat{}, nil },
+	}
+	defer workspaceCtx.close()
+
+	gotConn, err := workspaceCtx.getWorkspaceConn(ctx)
+	require.Nil(t, gotConn)
+	require.ErrorIs(t, err, errChatAgentDisconnected)
+	require.False(t, dialCalled, "dial should not be attempted for a timed-out agent")
+
+	// Cache should be cleared.
+	workspaceCtx.mu.Lock()
+	defer workspaceCtx.mu.Unlock()
+	require.False(t, workspaceCtx.agentLoaded)
+	require.Nil(t, workspaceCtx.conn)
+}
+
 func TestGetWorkspaceConn_ConnectingAgentProceeds(t *testing.T) {
-	// Stage 1 red test: a "connecting" agent (never connected,
-	// normal after fresh build) must NOT be blocked by the
-	// status check. The dial should proceed.
+	// A "connecting" agent (never connected, normal after
+	// fresh build) must NOT be blocked by the status check.
+	// The dial should proceed.
 	t.Parallel()
 
 	ctx := context.Background()
@@ -3004,7 +3085,7 @@ func TestGetWorkspaceConn_ConnectingAgentProceeds(t *testing.T) {
 	server := &Server{
 		db:                             db,
 		agentInactiveDisconnectTimeout: 30 * time.Second,
-		dialTimeout:                    30 * time.Second,
+		dialTimeout:                    defaultDialTimeout,
 	}
 	server.agentConnFn = func(_ context.Context, id uuid.UUID) (workspacesdk.AgentConn, func(), error) {
 		if id != agentID {
@@ -3029,8 +3110,8 @@ func TestGetWorkspaceConn_ConnectingAgentProceeds(t *testing.T) {
 }
 
 func TestGetWorkspaceConn_DialTimeout(t *testing.T) {
-	// Stage 2 red test: when dialWithLazyValidation blocks
-	// beyond the dial timeout, getWorkspaceConn should return
+	// When dialWithLazyValidation blocks beyond the dial
+	// timeout, getWorkspaceConn should return
 	// errChatDialTimeout instead of hanging indefinitely.
 	t.Parallel()
 
@@ -3096,10 +3177,10 @@ func TestGetWorkspaceConn_DialTimeout(t *testing.T) {
 }
 
 func TestGetWorkspaceConn_DialTimeoutParentCanceled(t *testing.T) {
-	// Stage 2 red test: when the parent context is canceled,
-	// the parent's error must propagate unchanged (not wrapped
-	// as a dial timeout). This is critical because the chatloop
-	// checks context.Cause(ctx) for ErrInterrupted.
+	// When the parent context is canceled, the parent's error
+	// must propagate unchanged (not wrapped as a dial timeout).
+	// This is critical because the chatloop checks
+	// context.Cause(ctx) for ErrInterrupted.
 	t.Parallel()
 
 	ctrl := gomock.NewController(t)
@@ -3176,6 +3257,7 @@ func TestGetWorkspaceConn_DialTimeoutParentCanceled(t *testing.T) {
 	require.NotErrorIs(t, err, errChatDialTimeout)
 	// The parent context's error should propagate.
 	require.Error(t, err)
+	require.ErrorIs(t, err, context.Canceled)
 }
 
 func TestGetWorkspaceConn_DialErrorNotMisclassifiedAsTimeout(t *testing.T) {
@@ -3233,7 +3315,7 @@ func TestGetWorkspaceConn_DialErrorNotMisclassifiedAsTimeout(t *testing.T) {
 		agentInactiveDisconnectTimeout: 30 * time.Second,
 		// Generous timeout so the dial error fires well before
 		// the timeout.
-		dialTimeout: 30 * time.Second,
+		dialTimeout: defaultDialTimeout,
 	}
 	server.agentConnFn = func(context.Context, uuid.UUID) (workspacesdk.AgentConn, func(), error) {
 		// Return an error immediately (not a timeout).


### PR DESCRIPTION
## Problem

When a workspace agent disconnects but the workspace remains "running,"
`getWorkspaceConn` either hangs indefinitely on `AwaitReachable` (cache miss)
or returns a dead cached connection whose transport errors the LLM
misinterprets as transient (cache hit). Both paths leave the chat unusable
until stale recovery kicks in (~5 minutes) or the user clicks interrupt.

Closes https://linear.app/coder/issue/CODAGT-149

## Fix

Add two defenses in `getWorkspaceConn`:

1. **Status check** on every call (both cache-hit and cache-miss paths). On
   cache miss, the freshly fetched agent row is checked via `isAgentUnreachable`
   (timestamp arithmetic, zero cost). On cache hit, the agent row is re-fetched
   by PK to get fresh `LastConnectedAt` before checking. `disconnected` and
   `timeout` agents return a sentinel immediately; `connecting` agents proceed
   to dial normally. Uses the server's `quartz.Clock` for deterministic testing.

2. **Dial timeout** (30s, matching 8 other server-side `AgentConn` callers).
   Wraps `dialWithLazyValidation` in a `context.WithTimeoutCause`. Parent
   context cancellation propagates unchanged so the chatloop can still detect
   `ErrInterrupted`.

Both sentinels instruct the LLM that the agent is unreachable and the workspace
may need restarting from the dashboard. Neither suggests `start_workspace`
(which cannot recover a disconnected agent on a running workspace).

<details><summary>Implementation plan and decision log</summary>

Plan: `docs/plans/agent-disconnect-hang.md`
Research: `docs/plans/agent-disconnect-hang-research.md`

Key decisions:
- D1: Approaches A + B (status check + dial timeout).
- D2: Only `disconnected` and `timeout` trigger the error; `connecting` proceeds.
- D3: 30s dial timeout, injectable via `Server.dialTimeout` field for tests.
- D4: Two distinct error messages (disconnected vs timeout).
- D5: `start_workspace` behavior out of scope.

R1 amendments:
- Cache-hit re-fetches agent row (PK lookup) to avoid stale-timestamp false positives.
- `isAgentUnreachable` is a pure function to eliminate data race on concurrent tool dispatch.
- `context.WithTimeoutCause` replaces manual capture-before-cancel pattern.

R2 amendments:
- Merged two lock sections on cache-hit into one to eliminate TOCTOU.
- `isAgentUnreachable` accepts `time.Time` and uses server clock for testability.
- Added tests for cache-hit happy path and DB error fallthrough.

</details>

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻
