### PR TITLE
fix: remove OIDC_TOKEN from secrets deny lsit

### DIFF
--- a/codersdk/usersecretvalidation.go
+++ b/codersdk/usersecretvalidation.go
@@ -114,12 +114,6 @@ var (
 		"XDG_DATA_HOME":   {},
 		"XDG_CACHE_HOME":  {},
 		"XDG_STATE_HOME":  {},
-
-		// OIDC token. The Coder agent injects a short-lived
-		// OIDC token for cloud auth flows (e.g. GCP workload
-		// identity). Overriding it could break provisioner and
-		// agent authentication.
-		"OIDC_TOKEN": {},
 	}
 
 	// aiGatewayReservedEnvNames are reserved only when AI Gateway

--- a/codersdk/usersecretvalidation_test.go
+++ b/codersdk/usersecretvalidation_test.go
@@ -88,9 +88,6 @@ func TestUserSecretEnvNameValid(t *testing.T) {
 		{name: "ReservedXDG_CACHE_HOME", input: "XDG_CACHE_HOME", opts: noAIGateway, wantErr: true, errMsg: "reserved"},
 		{name: "ReservedXDG_STATE_HOME", input: "XDG_STATE_HOME", opts: noAIGateway, wantErr: true, errMsg: "reserved"},
 
-		// Reserved system names — OIDC.
-		{name: "ReservedOIDC_TOKEN", input: "OIDC_TOKEN", opts: noAIGateway, wantErr: true, errMsg: "reserved"},
-
 		// AI Gateway vars — blocked when AI Gateway is enabled.
 		{name: "AIGateway/OPENAI_API_KEY/Enabled", input: "OPENAI_API_KEY", opts: withAIGateway, wantErr: true, errMsg: "AI Gateway"},
 		{name: "AIGateway/OPENAI_BASE_URL/Enabled", input: "OPENAI_BASE_URL", opts: withAIGateway, wantErr: true, errMsg: "AI Gateway"},


### PR DESCRIPTION
This was originally added because it was present in `env` output in dogfood, but it's specifically injected in the dogfood template so it doesn't make sense to deny across the board.