### PR TITLE
feat: add ed-style syntax to edit_files tool

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -396,7 +396,7 @@ func (a *agent) init() {
 	a.containerAPI = agentcontainers.NewAPI(a.logger.Named("containers"), containerAPIOpts...)
 
 	pathStore := agentgit.NewPathStore()
-	a.filesAPI = agentfiles.NewAPI(a.logger.Named("files"), a.filesystem, pathStore)
+	a.filesAPI = agentfiles.NewAPI(a.logger.Named("files"), a.filesystem, pathStore, a.execer)
 	a.processAPI = agentproc.NewAPI(a.logger.Named("processes"), a.execer, a.updateCommandEnv, pathStore, func() string {
 		if m := a.manifest.Load(); m != nil {
 			return m.Directory

--- a/agent/agentfiles/api.go
+++ b/agent/agentfiles/api.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/afero"
 
 	"cdr.dev/slog/v3"
+	"github.com/coder/coder/v2/agent/agentexec"
 	"github.com/coder/coder/v2/agent/agentgit"
 )
 
@@ -15,13 +16,15 @@ type API struct {
 	logger     slog.Logger
 	filesystem afero.Fs
 	pathStore  *agentgit.PathStore
+	execer     agentexec.Execer
 }
 
-func NewAPI(logger slog.Logger, filesystem afero.Fs, pathStore *agentgit.PathStore) *API {
+func NewAPI(logger slog.Logger, filesystem afero.Fs, pathStore *agentgit.PathStore, execer agentexec.Execer) *API {
 	api := &API{
 		logger:     logger,
 		filesystem: filesystem,
 		pathStore:  pathStore,
+		execer:     execer,
 	}
 	return api
 }

--- a/agent/agentfiles/files.go
+++ b/agent/agentfiles/files.go
@@ -550,7 +550,7 @@ func (api *API) HandleEditFiles(rw http.ResponseWriter, r *http.Request) {
 			return
 		}
 		diffs = append(diffs, workspacesdk.FileEditDiff{
-			Path: entry.path,
+			Path: entry.origPath,
 			Diff: diff,
 		})
 	}

--- a/agent/agentfiles/files.go
+++ b/agent/agentfiles/files.go
@@ -640,7 +640,7 @@ func (api *API) applyEdScript(ctx context.Context, path, origPath, script string
 	// Use --label with the full path to produce headers that
 	// the frontend can match to files unambiguously.
 	diffCmd := api.execer.CommandContext(ctx, "diff", "-u",
-		"--label", "a/"+origPath, "--label", "b/"+origPath,
+		"--label", origPath, "--label", origPath,
 		path, tmpPath)
 	diffOut, diffErr := diffCmd.CombinedOutput()
 	// diff exits 0 = identical, 1 = different (expected),

--- a/agent/agentfiles/files.go
+++ b/agent/agentfiles/files.go
@@ -428,7 +428,7 @@ func (api *API) HandleEditFiles(rw http.ResponseWriter, r *http.Request) {
 				}
 				continue
 			}
-			resolved, err := api.resolveSymlink(edit.Path)
+			resolved, err := api.resolvePath(edit.Path)
 			if err != nil {
 				combinedErr = errors.Join(combinedErr,
 					xerrors.Errorf("resolve symlink %q: %w", edit.Path, err))

--- a/agent/agentfiles/files.go
+++ b/agent/agentfiles/files.go
@@ -8,6 +8,7 @@ import (
 	"mime"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -375,22 +376,148 @@ func (api *API) HandleEditFiles(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Phase 1: compute all edits in memory. If any file fails
-	// (bad path, search miss, permission error), bail before
-	// writing anything.
-	var pending []pendingEdit
-	var combinedErr error
-	status := http.StatusOK
+	// Classification pass: separate search/replace from ed-script
+	// entries. Validate all entries upfront (before any writes).
+	type edScriptEntry struct {
+		path     string
+		script   string
+		origMode os.FileMode
+	}
+	var (
+		pending      []pendingEdit
+		edEntries    []edScriptEntry
+		combinedErr  error
+		status       = http.StatusOK
+		redAvailable bool
+		redChecked   bool
+		seenPaths    = make(map[string]struct{})
+	)
+
 	for _, edit := range req.Files {
-		s, p, err := api.prepareFileEdit(edit.Path, edit.Edits)
-		if s > status {
-			status = s
-		}
-		if err != nil {
-			combinedErr = errors.Join(combinedErr, err)
-		}
-		if p != nil {
-			pending = append(pending, *p)
+		hasEdits := len(edit.Edits) > 0
+		hasEdScript := edit.EdScript != ""
+
+		switch {
+		case hasEdits && hasEdScript:
+			combinedErr = errors.Join(combinedErr,
+				xerrors.Errorf("%s: cannot specify both edits and ed_script", edit.Path))
+			if http.StatusBadRequest > status {
+				status = http.StatusBadRequest
+			}
+		case !hasEdits && !hasEdScript:
+			combinedErr = errors.Join(combinedErr,
+				xerrors.Errorf("%s: must specify either edits or ed_script", edit.Path))
+			if http.StatusBadRequest > status {
+				status = http.StatusBadRequest
+			}
+		case hasEdScript:
+			// Validate the ed-script entry upfront.
+			if edit.Path == "" {
+				combinedErr = errors.Join(combinedErr, xerrors.New("\"path\" is required"))
+				if http.StatusBadRequest > status {
+					if http.StatusBadRequest > status {
+						status = http.StatusBadRequest
+					}
+				}
+				continue
+			}
+			if !filepath.IsAbs(edit.Path) {
+				combinedErr = errors.Join(combinedErr,
+					xerrors.Errorf("file path must be absolute: %q", edit.Path))
+				if http.StatusBadRequest > status {
+					if http.StatusBadRequest > status {
+						status = http.StatusBadRequest
+					}
+				}
+				continue
+			}
+			resolved, err := api.resolveSymlink(edit.Path)
+			if err != nil {
+				combinedErr = errors.Join(combinedErr,
+					xerrors.Errorf("resolve symlink %q: %w", edit.Path, err))
+				if http.StatusInternalServerError > status {
+					status = http.StatusInternalServerError
+				}
+				continue
+			}
+			// Verify the file exists and is not a directory.
+			info, err := os.Stat(resolved)
+			if err != nil {
+				s := http.StatusInternalServerError
+				switch {
+				case errors.Is(err, os.ErrNotExist):
+					s = http.StatusNotFound
+				case errors.Is(err, os.ErrPermission):
+					s = http.StatusForbidden
+				}
+				combinedErr = errors.Join(combinedErr, err)
+				if s > status {
+					status = s
+				}
+				continue
+			}
+			if info.IsDir() {
+				combinedErr = errors.Join(combinedErr,
+					xerrors.Errorf("open %s: not a file", resolved))
+				if http.StatusBadRequest > status {
+					if http.StatusBadRequest > status {
+						status = http.StatusBadRequest
+					}
+				}
+				continue
+			}
+			// Check for red binary once per request.
+			if !redChecked {
+				if _, err := exec.LookPath("red"); err == nil {
+					redAvailable = true
+				}
+				redChecked = true
+			}
+			if !redAvailable {
+				combinedErr = errors.Join(combinedErr,
+					xerrors.New("ed_script requires the 'ed' package to be installed (provides 'red'); install it with: apt-get install ed"))
+				if http.StatusInternalServerError > status {
+					status = http.StatusInternalServerError
+				}
+				continue
+			}
+			if _, dup := seenPaths[resolved]; dup {
+				combinedErr = errors.Join(combinedErr,
+					xerrors.Errorf("%s: duplicate file path in request", edit.Path))
+				if http.StatusBadRequest > status {
+					if http.StatusBadRequest > status {
+						status = http.StatusBadRequest
+					}
+				}
+				continue
+			}
+			seenPaths[resolved] = struct{}{}
+			edEntries = append(edEntries, edScriptEntry{
+				path:     resolved,
+				script:   edit.EdScript,
+				origMode: info.Mode(),
+			})
+		default:
+			// Search/replace path (existing logic).
+			s, p, err := api.prepareFileEdit(edit.Path, edit.Edits)
+			if s > status {
+				status = s
+			}
+			if err != nil {
+				combinedErr = errors.Join(combinedErr, err)
+			}
+			if p != nil {
+				if _, dup := seenPaths[p.path]; dup {
+					combinedErr = errors.Join(combinedErr,
+						xerrors.Errorf("%s: duplicate file path in request", edit.Path))
+					if http.StatusBadRequest > status {
+						status = http.StatusBadRequest
+					}
+					continue
+				}
+				seenPaths[p.path] = struct{}{}
+				pending = append(pending, *p)
+			}
 		}
 	}
 
@@ -401,9 +528,13 @@ func (api *API) HandleEditFiles(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Phase 2: write all files via atomicWrite. A failure here
-	// (e.g. disk full) can leave earlier files committed. True
-	// cross-file atomicity would require filesystem transactions.
+	var diffs []workspacesdk.FileEditDiff
+
+	// Phase 2: write all search/replace files via atomicWrite.
+	// A failure here (e.g. disk full) can leave earlier files
+	// committed. True cross-file atomicity would require
+	// filesystem transactions. The same applies to Phase 3
+	// (ed-script entries).
 	for _, p := range pending {
 		mode := p.mode
 		s, err := api.atomicWrite(ctx, p.path, &mode, strings.NewReader(p.content))
@@ -413,6 +544,21 @@ func (api *API) HandleEditFiles(rw http.ResponseWriter, r *http.Request) {
 			})
 			return
 		}
+	}
+
+	// Phase 3: process ed-script entries sequentially.
+	for _, entry := range edEntries {
+		diff, err := api.applyEdScript(ctx, entry.path, entry.script, entry.origMode)
+		if err != nil {
+			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+				Message: err.Error(),
+			})
+			return
+		}
+		diffs = append(diffs, workspacesdk.FileEditDiff{
+			Path: entry.path,
+			Diff: diff,
+		})
 	}
 
 	// Track edited paths for git watch.
@@ -426,9 +572,108 @@ func (api *API) HandleEditFiles(rw http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	httpapi.Write(ctx, rw, http.StatusOK, codersdk.Response{
-		Message: "Successfully edited file(s)",
+	httpapi.Write(ctx, rw, http.StatusOK, workspacesdk.FileEditResponse{
+		Diffs: diffs,
 	})
+}
+
+// applyEdScript runs an ed script against a file atomically. It
+// copies the file to an isolated temp directory, runs red against
+// the copy, computes a unified diff, and renames the copy over
+// the original. The isolated directory prevents ed w/r commands
+// from reaching other files in the target's directory.
+// Returns the diff string (empty if no changes) or an error.
+func (api *API) applyEdScript(ctx context.Context, path, script string, origMode os.FileMode) (string, error) {
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+
+	// Create an isolated temp directory so red cannot w/r other
+	// files in the original file's directory.
+	isoDir, err := os.MkdirTemp(dir, ".ed-*")
+	if err != nil {
+		return "", xerrors.Errorf("create isolated temp dir: %w", err)
+	}
+	defer func() {
+		if rmErr := os.RemoveAll(isoDir); rmErr != nil {
+			api.logger.Warn(ctx, "unable to clean up temp dir",
+				slog.F("path", isoDir), slog.Error(rmErr))
+		}
+	}()
+
+	tmpPath := filepath.Join(isoDir, base)
+
+	// Copy original to temp file in the isolated directory.
+	src, err := os.Open(path)
+	if err != nil {
+		return "", xerrors.Errorf("open %s: %w", path, err)
+	}
+	tmpFile, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, origMode)
+	if err != nil {
+		_ = src.Close()
+		return "", xerrors.Errorf("create temp file: %w", err)
+	}
+	_, err = io.Copy(tmpFile, src)
+	_ = src.Close()
+	_ = tmpFile.Close()
+	if err != nil {
+		return "", xerrors.Errorf("copy %s to temp: %w", path, err)
+	}
+
+	// Build the ed script: prepend H (verbose errors), append
+	// a safety "." (closes any unterminated input mode), then
+	// w (write) and q (quit).
+	fullScript := "H\n" + script + "\n.\nw\nq\n"
+
+	// Run red (restricted ed) in the isolated directory. red
+	// restricts filenames to the current directory, and the
+	// isolated directory contains only the target file copy.
+	cmd := api.execer.CommandContext(ctx, "red", "-s", base)
+	cmd.Dir = isoDir
+	cmd.Stdin = strings.NewReader(fullScript)
+	var combinedOut strings.Builder
+	cmd.Stdout = &combinedOut
+	cmd.Stderr = &combinedOut
+
+	if err := cmd.Run(); err != nil {
+		output := strings.TrimSpace(combinedOut.String())
+		if output != "" {
+			return "", xerrors.Errorf("ed script failed on %s: %s", path, output)
+		}
+		return "", xerrors.Errorf("ed script failed on %s: %w", path, err)
+	}
+
+	// Compute unified diff between original and edited temp.
+	// Use --label with the full path to produce headers that
+	// the frontend can match to files unambiguously.
+	diffCmd := api.execer.CommandContext(ctx, "diff", "-u",
+		"--label", "a/"+path, "--label", "b/"+path,
+		path, tmpPath)
+	diffOut, diffErr := diffCmd.CombinedOutput()
+	// diff exits 0 = identical, 1 = different (expected),
+	// 2 = trouble. In all failure cases the edit already
+	// succeeded in the temp file, so log and continue
+	// without a diff rather than discarding the edit.
+	var diffStr string
+	switch {
+	case diffErr == nil:
+		diffStr = string(diffOut)
+	case diffCmd.ProcessState != nil && diffCmd.ProcessState.ExitCode() == 2:
+		api.logger.Warn(ctx, "diff command failed",
+			slog.F("path", path), slog.F("output", string(diffOut)))
+	case diffCmd.ProcessState == nil:
+		api.logger.Warn(ctx, "diff command failed to start",
+			slog.F("path", path), slog.Error(diffErr))
+	default:
+		// Exit code 1 (files differ) is the expected case.
+		diffStr = string(diffOut)
+	}
+
+	// Rename temp over original (atomic on same filesystem).
+	if err := os.Rename(tmpPath, path); err != nil {
+		return "", xerrors.Errorf("rename temp to %s: %w", path, err)
+	}
+
+	return diffStr, nil
 }
 
 // prepareFileEdit validates, reads, and computes edits for a single

--- a/agent/agentfiles/files.go
+++ b/agent/agentfiles/files.go
@@ -599,7 +599,7 @@ func (api *API) applyEdScript(ctx context.Context, path, origPath, script string
 	// Copy original to temp file in the isolated directory.
 	src, err := os.Open(path)
 	if err != nil {
-		return "", xerrors.Errorf("open %s: %w", path, err)
+		return "", xerrors.Errorf("open %s: %w", origPath, err)
 	}
 	tmpFile, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, origMode)
 	if err != nil {
@@ -610,7 +610,7 @@ func (api *API) applyEdScript(ctx context.Context, path, origPath, script string
 	_ = src.Close()
 	_ = tmpFile.Close()
 	if err != nil {
-		return "", xerrors.Errorf("copy %s to temp: %w", path, err)
+		return "", xerrors.Errorf("copy %s to temp: %w", origPath, err)
 	}
 
 	// Build the ed script: prepend H (verbose errors), append
@@ -631,9 +631,9 @@ func (api *API) applyEdScript(ctx context.Context, path, origPath, script string
 	if err := cmd.Run(); err != nil {
 		output := strings.TrimSpace(combinedOut.String())
 		if output != "" {
-			return "", xerrors.Errorf("ed script failed on %s: %s", path, output)
+			return "", xerrors.Errorf("ed script failed on %s: %s", origPath, output)
 		}
-		return "", xerrors.Errorf("ed script failed on %s: %w", path, err)
+		return "", xerrors.Errorf("ed script failed on %s: %w", origPath, err)
 	}
 
 	// Compute unified diff between original and edited temp.
@@ -664,7 +664,7 @@ func (api *API) applyEdScript(ctx context.Context, path, origPath, script string
 
 	// Rename temp over original (atomic on same filesystem).
 	if err := os.Rename(tmpPath, path); err != nil {
-		return "", xerrors.Errorf("rename temp to %s: %w", path, err)
+		return "", xerrors.Errorf("rename temp to %s: %w", origPath, err)
 	}
 
 	return diffStr, nil

--- a/agent/agentfiles/files.go
+++ b/agent/agentfiles/files.go
@@ -379,7 +379,8 @@ func (api *API) HandleEditFiles(rw http.ResponseWriter, r *http.Request) {
 	// Classification pass: separate search/replace from ed-script
 	// entries. Validate all entries upfront (before any writes).
 	type edScriptEntry struct {
-		path     string
+		path     string // Resolved (symlink-followed) path.
+		origPath string // Original path from the request (for labels).
 		script   string
 		origMode os.FileMode
 	}
@@ -415,9 +416,7 @@ func (api *API) HandleEditFiles(rw http.ResponseWriter, r *http.Request) {
 			if edit.Path == "" {
 				combinedErr = errors.Join(combinedErr, xerrors.New("\"path\" is required"))
 				if http.StatusBadRequest > status {
-					if http.StatusBadRequest > status {
-						status = http.StatusBadRequest
-					}
+					status = http.StatusBadRequest
 				}
 				continue
 			}
@@ -425,9 +424,7 @@ func (api *API) HandleEditFiles(rw http.ResponseWriter, r *http.Request) {
 				combinedErr = errors.Join(combinedErr,
 					xerrors.Errorf("file path must be absolute: %q", edit.Path))
 				if http.StatusBadRequest > status {
-					if http.StatusBadRequest > status {
-						status = http.StatusBadRequest
-					}
+					status = http.StatusBadRequest
 				}
 				continue
 			}
@@ -460,9 +457,7 @@ func (api *API) HandleEditFiles(rw http.ResponseWriter, r *http.Request) {
 				combinedErr = errors.Join(combinedErr,
 					xerrors.Errorf("open %s: not a file", resolved))
 				if http.StatusBadRequest > status {
-					if http.StatusBadRequest > status {
-						status = http.StatusBadRequest
-					}
+					status = http.StatusBadRequest
 				}
 				continue
 			}
@@ -485,15 +480,14 @@ func (api *API) HandleEditFiles(rw http.ResponseWriter, r *http.Request) {
 				combinedErr = errors.Join(combinedErr,
 					xerrors.Errorf("%s: duplicate file path in request", edit.Path))
 				if http.StatusBadRequest > status {
-					if http.StatusBadRequest > status {
-						status = http.StatusBadRequest
-					}
+					status = http.StatusBadRequest
 				}
 				continue
 			}
 			seenPaths[resolved] = struct{}{}
 			edEntries = append(edEntries, edScriptEntry{
 				path:     resolved,
+				origPath: edit.Path,
 				script:   edit.EdScript,
 				origMode: info.Mode(),
 			})
@@ -548,7 +542,7 @@ func (api *API) HandleEditFiles(rw http.ResponseWriter, r *http.Request) {
 
 	// Phase 3: process ed-script entries sequentially.
 	for _, entry := range edEntries {
-		diff, err := api.applyEdScript(ctx, entry.path, entry.script, entry.origMode)
+		diff, err := api.applyEdScript(ctx, entry.path, entry.origPath, entry.script, entry.origMode)
 		if err != nil {
 			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 				Message: err.Error(),
@@ -583,7 +577,7 @@ func (api *API) HandleEditFiles(rw http.ResponseWriter, r *http.Request) {
 // the original. The isolated directory prevents ed w/r commands
 // from reaching other files in the target's directory.
 // Returns the diff string (empty if no changes) or an error.
-func (api *API) applyEdScript(ctx context.Context, path, script string, origMode os.FileMode) (string, error) {
+func (api *API) applyEdScript(ctx context.Context, path, origPath, script string, origMode os.FileMode) (string, error) {
 	dir := filepath.Dir(path)
 	base := filepath.Base(path)
 
@@ -646,7 +640,7 @@ func (api *API) applyEdScript(ctx context.Context, path, script string, origMode
 	// Use --label with the full path to produce headers that
 	// the frontend can match to files unambiguously.
 	diffCmd := api.execer.CommandContext(ctx, "diff", "-u",
-		"--label", "a/"+path, "--label", "b/"+path,
+		"--label", "a/"+origPath, "--label", "b/"+origPath,
 		path, tmpPath)
 	diffOut, diffErr := diffCmd.CombinedOutput()
 	// diff exits 0 = identical, 1 = different (expected),

--- a/agent/agentfiles/files_test.go
+++ b/agent/agentfiles/files_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -24,6 +25,7 @@ import (
 
 	"cdr.dev/slog/v3"
 	"cdr.dev/slog/v3/sloggers/slogtest"
+	"github.com/coder/coder/v2/agent/agentexec"
 	"github.com/coder/coder/v2/agent/agentfiles"
 	"github.com/coder/coder/v2/agent/agentgit"
 	"github.com/coder/coder/v2/codersdk"
@@ -121,7 +123,7 @@ func TestReadFile(t *testing.T) {
 		}
 		return nil
 	})
-	api := agentfiles.NewAPI(logger, fs, nil)
+	api := agentfiles.NewAPI(logger, fs, nil, agentexec.DefaultExecer)
 
 	dirPath := filepath.Join(tmpdir, "a-directory")
 	err := fs.MkdirAll(dirPath, 0o755)
@@ -301,7 +303,7 @@ func TestWriteFile(t *testing.T) {
 		}
 		return nil
 	})
-	api := agentfiles.NewAPI(logger, fs, nil)
+	api := agentfiles.NewAPI(logger, fs, nil, agentexec.DefaultExecer)
 
 	dirPath := filepath.Join(tmpdir, "directory")
 	err := fs.MkdirAll(dirPath, 0o755)
@@ -405,7 +407,7 @@ func TestWriteFile_ReportsIOError(t *testing.T) {
 
 	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
 	fs := afero.NewMemMapFs()
-	api := agentfiles.NewAPI(logger, fs, nil)
+	api := agentfiles.NewAPI(logger, fs, nil, agentexec.DefaultExecer)
 
 	tmpdir := os.TempDir()
 	path := filepath.Join(tmpdir, "write-io-error")
@@ -446,7 +448,7 @@ func TestWriteFile_PreservesPermissions(t *testing.T) {
 	dir := t.TempDir()
 	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
 	osFs := afero.NewOsFs()
-	api := agentfiles.NewAPI(logger, osFs, nil)
+	api := agentfiles.NewAPI(logger, osFs, nil, agentexec.DefaultExecer)
 
 	path := filepath.Join(dir, "script.sh")
 	err := afero.WriteFile(osFs, path, []byte("#!/bin/sh\necho hello\n"), 0o755)
@@ -496,7 +498,7 @@ func TestEditFiles(t *testing.T) {
 		}
 		return nil
 	})
-	api := agentfiles.NewAPI(logger, fs, nil)
+	api := agentfiles.NewAPI(logger, fs, nil, agentexec.DefaultExecer)
 
 	dirPath := filepath.Join(tmpdir, "directory")
 	err := fs.MkdirAll(dirPath, 0o755)
@@ -570,7 +572,7 @@ func TestEditFiles(t *testing.T) {
 				},
 			},
 			errCode: http.StatusBadRequest,
-			errors:  []string{"must specify at least one edit"},
+			errors:  []string{"must specify either edits or ed_script"},
 		},
 		{
 			name: "NonExistent",
@@ -1072,7 +1074,7 @@ func TestEditFiles_PreservesPermissions(t *testing.T) {
 	dir := t.TempDir()
 	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
 	osFs := afero.NewOsFs()
-	api := agentfiles.NewAPI(logger, osFs, nil)
+	api := agentfiles.NewAPI(logger, osFs, nil, agentexec.DefaultExecer)
 
 	path := filepath.Join(dir, "script.sh")
 	err := afero.WriteFile(osFs, path, []byte("#!/bin/sh\necho hello\n"), 0o755)
@@ -1129,7 +1131,7 @@ func TestHandleWriteFile_ChatHeaders_UpdatesPathStore(t *testing.T) {
 	pathStore := agentgit.NewPathStore()
 	logger := slogtest.Make(t, nil)
 	fs := afero.NewMemMapFs()
-	api := agentfiles.NewAPI(logger, fs, pathStore)
+	api := agentfiles.NewAPI(logger, fs, pathStore, agentexec.DefaultExecer)
 
 	testPath := filepath.Join(os.TempDir(), "test.txt")
 
@@ -1163,7 +1165,7 @@ func TestHandleWriteFile_NoChatHeaders_NoPathStoreUpdate(t *testing.T) {
 	pathStore := agentgit.NewPathStore()
 	logger := slogtest.Make(t, nil)
 	fs := afero.NewMemMapFs()
-	api := agentfiles.NewAPI(logger, fs, pathStore)
+	api := agentfiles.NewAPI(logger, fs, pathStore, agentexec.DefaultExecer)
 
 	testPath := filepath.Join(os.TempDir(), "test.txt")
 
@@ -1187,7 +1189,7 @@ func TestHandleWriteFile_Failure_NoPathStoreUpdate(t *testing.T) {
 	pathStore := agentgit.NewPathStore()
 	logger := slogtest.Make(t, nil)
 	fs := afero.NewMemMapFs()
-	api := agentfiles.NewAPI(logger, fs, pathStore)
+	api := agentfiles.NewAPI(logger, fs, pathStore, agentexec.DefaultExecer)
 
 	chatID := uuid.New()
 
@@ -1214,7 +1216,7 @@ func TestHandleEditFiles_ChatHeaders_UpdatesPathStore(t *testing.T) {
 	pathStore := agentgit.NewPathStore()
 	logger := slogtest.Make(t, nil)
 	fs := afero.NewMemMapFs()
-	api := agentfiles.NewAPI(logger, fs, pathStore)
+	api := agentfiles.NewAPI(logger, fs, pathStore, agentexec.DefaultExecer)
 
 	testPath := filepath.Join(os.TempDir(), "test.txt")
 
@@ -1254,7 +1256,7 @@ func TestHandleEditFiles_Failure_NoPathStoreUpdate(t *testing.T) {
 	pathStore := agentgit.NewPathStore()
 	logger := slogtest.Make(t, nil)
 	fs := afero.NewMemMapFs()
-	api := agentfiles.NewAPI(logger, fs, pathStore)
+	api := agentfiles.NewAPI(logger, fs, pathStore, agentexec.DefaultExecer)
 
 	chatID := uuid.New()
 
@@ -1286,6 +1288,45 @@ func TestHandleEditFiles_Failure_NoPathStoreUpdate(t *testing.T) {
 	require.Empty(t, paths)
 }
 
+func TestHandleEditFiles_EdScript_UpdatesPathStore(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("red"); err != nil {
+		t.Skip("red (restricted ed) not available, install ed package")
+	}
+
+	pathStore := agentgit.NewPathStore()
+	logger := slogtest.Make(t, nil)
+	fs := afero.NewOsFs()
+	api := agentfiles.NewAPI(logger, fs, pathStore, agentexec.DefaultExecer)
+
+	dir := t.TempDir()
+	testPath := filepath.Join(dir, "ed-pathstore.txt")
+	require.NoError(t, os.WriteFile(testPath, []byte("hello\n"), 0o600))
+
+	chatID := uuid.New()
+	editReq := workspacesdk.FileEditRequest{
+		Files: []workspacesdk.FileEdits{{
+			Path:     testPath,
+			EdScript: "1s/hello/world/",
+		}},
+	}
+	body, _ := json.Marshal(editReq)
+	req := httptest.NewRequest(http.MethodPost, "/edit-files", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(workspacesdk.CoderChatIDHeader, chatID.String())
+
+	rr := httptest.NewRecorder()
+	r := chi.NewRouter()
+	r.Post("/edit-files", api.HandleEditFiles)
+	r.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	paths := pathStore.GetPaths(chatID)
+	require.Equal(t, []string{testPath}, paths)
+}
+
 func TestReadFileLines(t *testing.T) {
 	t.Parallel()
 
@@ -1299,7 +1340,7 @@ func TestReadFileLines(t *testing.T) {
 		}
 		return nil
 	})
-	api := agentfiles.NewAPI(logger, fs, nil)
+	api := agentfiles.NewAPI(logger, fs, nil, agentexec.DefaultExecer)
 
 	dirPath := filepath.Join(tmpdir, "a-directory-lines")
 	err := fs.MkdirAll(dirPath, 0o755)
@@ -1481,7 +1522,7 @@ func TestWriteFile_FollowsSymlinks(t *testing.T) {
 	dir := t.TempDir()
 	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
 	osFs := afero.NewOsFs()
-	api := agentfiles.NewAPI(logger, osFs, nil)
+	api := agentfiles.NewAPI(logger, osFs, nil, agentexec.DefaultExecer)
 
 	// Create a real file and a symlink pointing to it.
 	realPath := filepath.Join(dir, "real.txt")
@@ -1524,7 +1565,7 @@ func TestEditFiles_FollowsSymlinks(t *testing.T) {
 	dir := t.TempDir()
 	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
 	osFs := afero.NewOsFs()
-	api := agentfiles.NewAPI(logger, osFs, nil)
+	api := agentfiles.NewAPI(logger, osFs, nil, agentexec.DefaultExecer)
 
 	// Create a real file and a symlink pointing to it.
 	realPath := filepath.Join(dir, "real.txt")
@@ -1571,4 +1612,328 @@ func TestEditFiles_FollowsSymlinks(t *testing.T) {
 	data, err := os.ReadFile(realPath)
 	require.NoError(t, err)
 	require.Equal(t, "goodbye world", string(data))
+}
+
+func TestEditFiles_EdScript(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("red"); err != nil {
+		t.Skip("red (restricted ed) not available, install ed package")
+	}
+
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	fs := afero.NewOsFs()
+	api := agentfiles.NewAPI(logger, fs, nil, agentexec.DefaultExecer)
+
+	tmpdir := t.TempDir()
+
+	writeFile := func(t *testing.T, name, content string) string {
+		t.Helper()
+		p := filepath.Join(tmpdir, name)
+		err := os.WriteFile(p, []byte(content), 0o600)
+		require.NoError(t, err)
+		return p
+	}
+
+	readFile := func(t *testing.T, path string) string {
+		t.Helper()
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+		return string(data)
+	}
+
+	runEditFiles := func(t *testing.T, req workspacesdk.FileEditRequest) *httptest.ResponseRecorder {
+		t.Helper()
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		buf := bytes.NewBuffer(nil)
+		enc := json.NewEncoder(buf)
+		enc.SetEscapeHTML(false)
+		err := enc.Encode(req)
+		require.NoError(t, err)
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequestWithContext(ctx, http.MethodPost, "/edit-files", buf)
+		api.Routes().ServeHTTP(w, r)
+		return w
+	}
+
+	t.Run("Substitute", func(t *testing.T) {
+		t.Parallel()
+		path := writeFile(t, "sub.txt", "hello world\n")
+		w := runEditFiles(t, workspacesdk.FileEditRequest{
+			Files: []workspacesdk.FileEdits{{
+				Path:     path,
+				EdScript: "1s/hello/goodbye/",
+			}},
+		})
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, "goodbye world\n", readFile(t, path))
+
+		var resp workspacesdk.FileEditResponse
+		err := json.NewDecoder(w.Body).Decode(&resp)
+		require.NoError(t, err)
+		require.Len(t, resp.Diffs, 1)
+		require.Equal(t, path, resp.Diffs[0].Path)
+		require.Contains(t, resp.Diffs[0].Diff, "-hello world")
+		require.Contains(t, resp.Diffs[0].Diff, "+goodbye world")
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		t.Parallel()
+		path := writeFile(t, "del.txt", "line1\nline2\nline3\n")
+		w := runEditFiles(t, workspacesdk.FileEditRequest{
+			Files: []workspacesdk.FileEdits{{
+				Path:     path,
+				EdScript: "2d",
+			}},
+		})
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, "line1\nline3\n", readFile(t, path))
+
+		var resp workspacesdk.FileEditResponse
+		err := json.NewDecoder(w.Body).Decode(&resp)
+		require.NoError(t, err)
+		require.Len(t, resp.Diffs, 1)
+		require.Contains(t, resp.Diffs[0].Diff, "-line2")
+	})
+
+	t.Run("Append", func(t *testing.T) {
+		t.Parallel()
+		path := writeFile(t, "append.txt", "line1\nline2\n")
+		w := runEditFiles(t, workspacesdk.FileEditRequest{
+			Files: []workspacesdk.FileEdits{{
+				Path:     path,
+				EdScript: "2a\nline3\n.",
+			}},
+		})
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, "line1\nline2\nline3\n", readFile(t, path))
+
+		var resp workspacesdk.FileEditResponse
+		err := json.NewDecoder(w.Body).Decode(&resp)
+		require.NoError(t, err)
+		require.Len(t, resp.Diffs, 1)
+		require.Contains(t, resp.Diffs[0].Diff, "+line3")
+	})
+
+	t.Run("Change", func(t *testing.T) {
+		t.Parallel()
+		path := writeFile(t, "change.txt", "line1\nline2\nline3\n")
+		w := runEditFiles(t, workspacesdk.FileEditRequest{
+			Files: []workspacesdk.FileEdits{{
+				Path:     path,
+				EdScript: "2c\nreplaced\n.",
+			}},
+		})
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, "line1\nreplaced\nline3\n", readFile(t, path))
+
+		var resp workspacesdk.FileEditResponse
+		err := json.NewDecoder(w.Body).Decode(&resp)
+		require.NoError(t, err)
+		require.Len(t, resp.Diffs, 1)
+		require.Contains(t, resp.Diffs[0].Diff, "-line2")
+		require.Contains(t, resp.Diffs[0].Diff, "+replaced")
+	})
+
+	t.Run("RegexAddress", func(t *testing.T) {
+		t.Parallel()
+		path := writeFile(t, "regex.txt", "foo\nbar\nbaz\n")
+		w := runEditFiles(t, workspacesdk.FileEditRequest{
+			Files: []workspacesdk.FileEdits{{
+				Path:     path,
+				EdScript: "/bar/s/bar/BAR/",
+			}},
+		})
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, "foo\nBAR\nbaz\n", readFile(t, path))
+
+		var resp workspacesdk.FileEditResponse
+		err := json.NewDecoder(w.Body).Decode(&resp)
+		require.NoError(t, err)
+		require.Len(t, resp.Diffs, 1)
+		require.Contains(t, resp.Diffs[0].Diff, "-bar")
+		require.Contains(t, resp.Diffs[0].Diff, "+BAR")
+	})
+
+	t.Run("BadLineNumber", func(t *testing.T) {
+		t.Parallel()
+		path := writeFile(t, "badline.txt", "only one line\n")
+		original := readFile(t, path)
+		w := runEditFiles(t, workspacesdk.FileEditRequest{
+			Files: []workspacesdk.FileEdits{{
+				Path:     path,
+				EdScript: "999d",
+			}},
+		})
+		require.Equal(t, http.StatusInternalServerError, w.Code)
+		// Original file untouched.
+		require.Equal(t, original, readFile(t, path))
+	})
+
+	t.Run("EmptyEdScript", func(t *testing.T) {
+		t.Parallel()
+		path := writeFile(t, "empty.txt", "content\n")
+		w := runEditFiles(t, workspacesdk.FileEditRequest{
+			Files: []workspacesdk.FileEdits{{
+				Path: path,
+			}},
+		})
+		require.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("BothEditsAndEdScript", func(t *testing.T) {
+		t.Parallel()
+		path := writeFile(t, "both.txt", "content\n")
+		w := runEditFiles(t, workspacesdk.FileEditRequest{
+			Files: []workspacesdk.FileEdits{{
+				Path:     path,
+				EdScript: "1d",
+				Edits: []workspacesdk.FileEdit{{
+					Search:  "content",
+					Replace: "replaced",
+				}},
+			}},
+		})
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		var got codersdk.Error
+		err := json.NewDecoder(w.Body).Decode(&got)
+		require.NoError(t, err)
+		require.Contains(t, got.Error(), "cannot specify both edits and ed_script")
+	})
+
+	t.Run("NonExistentFile", func(t *testing.T) {
+		t.Parallel()
+		w := runEditFiles(t, workspacesdk.FileEditRequest{
+			Files: []workspacesdk.FileEdits{{
+				Path:     filepath.Join(tmpdir, "does-not-exist.txt"),
+				EdScript: "1d",
+			}},
+		})
+		require.Equal(t, http.StatusNotFound, w.Code)
+	})
+
+	t.Run("MultiBatch", func(t *testing.T) {
+		t.Parallel()
+		path1 := writeFile(t, "batch1.txt", "aaa\n")
+		path2 := writeFile(t, "batch2.txt", "bbb\n")
+		w := runEditFiles(t, workspacesdk.FileEditRequest{
+			Files: []workspacesdk.FileEdits{
+				{Path: path1, EdScript: "1s/aaa/AAA/"},
+				{Path: path2, EdScript: "1s/bbb/BBB/"},
+			},
+		})
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, "AAA\n", readFile(t, path1))
+		require.Equal(t, "BBB\n", readFile(t, path2))
+
+		var resp workspacesdk.FileEditResponse
+		err := json.NewDecoder(w.Body).Decode(&resp)
+		require.NoError(t, err)
+		require.Len(t, resp.Diffs, 2)
+		require.Equal(t, path1, resp.Diffs[0].Path)
+		require.Equal(t, path2, resp.Diffs[1].Path)
+		require.Contains(t, resp.Diffs[0].Diff, "-aaa")
+		require.Contains(t, resp.Diffs[1].Diff, "-bbb")
+	})
+
+	t.Run("FirstFileFailureStops", func(t *testing.T) {
+		t.Parallel()
+		path1 := writeFile(t, "fail1.txt", "one line\n")
+		path2 := writeFile(t, "fail2.txt", "bbb\n")
+		original2 := readFile(t, path2)
+		w := runEditFiles(t, workspacesdk.FileEditRequest{
+			Files: []workspacesdk.FileEdits{
+				{Path: path1, EdScript: "999d"},
+				{Path: path2, EdScript: "1s/bbb/BBB/"},
+			},
+		})
+		// First file fails during ed execution, processing
+		// stops and the request returns an error.
+		require.NotEqual(t, http.StatusOK, w.Code)
+		// Both files untouched.
+		require.Equal(t, "one line\n", readFile(t, path1))
+		require.Equal(t, original2, readFile(t, path2))
+	})
+
+	t.Run("SecondFileFailureFirstCommitted", func(t *testing.T) {
+		t.Parallel()
+		path1 := writeFile(t, "commit1.txt", "aaa\n")
+		path2 := writeFile(t, "commit2.txt", "one line\n")
+		w := runEditFiles(t, workspacesdk.FileEditRequest{
+			Files: []workspacesdk.FileEdits{
+				{Path: path1, EdScript: "1s/aaa/AAA/"},
+				{Path: path2, EdScript: "999d"},
+			},
+		})
+		// Second file fails; request returns error.
+		require.NotEqual(t, http.StatusOK, w.Code)
+		// First file IS committed (partial write, documented
+		// limitation matching search/replace behavior).
+		require.Equal(t, "AAA\n", readFile(t, path1))
+		// Second file untouched.
+		require.Equal(t, "one line\n", readFile(t, path2))
+	})
+
+	t.Run("DuplicateEdScriptPath", func(t *testing.T) {
+		t.Parallel()
+		path := writeFile(t, "dup.txt", "content\n")
+		w := runEditFiles(t, workspacesdk.FileEditRequest{
+			Files: []workspacesdk.FileEdits{
+				{Path: path, EdScript: "1s/content/a/"},
+				{Path: path, EdScript: "1s/content/b/"},
+			},
+		})
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		var got codersdk.Error
+		err := json.NewDecoder(w.Body).Decode(&got)
+		require.NoError(t, err)
+		require.Contains(t, got.Error(), "duplicate file path")
+		// File untouched.
+		require.Equal(t, "content\n", readFile(t, path))
+	})
+}
+
+func TestEditFiles_EdScript_PreservesPermissions(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("red"); err != nil {
+		t.Skip("red (restricted ed) not available, install ed package")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("file permissions are not reliably supported on Windows")
+	}
+
+	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	fs := afero.NewOsFs()
+	api := agentfiles.NewAPI(logger, fs, nil, agentexec.DefaultExecer)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "perms.sh")
+	require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\necho hello\n"), 0o755)) //nolint:gosec // Testing permission preservation requires non-0600 mode.
+
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+	defer cancel()
+
+	buf := bytes.NewBuffer(nil)
+	enc := json.NewEncoder(buf)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(workspacesdk.FileEditRequest{
+		Files: []workspacesdk.FileEdits{{
+			Path:     path,
+			EdScript: "1,$s/hello/goodbye/",
+		}},
+	})
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequestWithContext(ctx, http.MethodPost, "/edit-files", buf)
+	api.Routes().ServeHTTP(w, r)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o755), info.Mode().Perm())
 }

--- a/agent/agentfiles/files_test.go
+++ b/agent/agentfiles/files_test.go
@@ -1614,6 +1614,65 @@ func TestEditFiles_FollowsSymlinks(t *testing.T) {
 	require.Equal(t, "goodbye world", string(data))
 }
 
+func TestEditFiles_EdScript_FollowsSymlinks(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("red"); err != nil {
+		t.Skip("red (restricted ed) not available, install ed package")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks are not reliably supported on Windows")
+	}
+
+	dir := t.TempDir()
+	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	osFs := afero.NewOsFs()
+	api := agentfiles.NewAPI(logger, osFs, nil, agentexec.DefaultExecer)
+
+	realPath := filepath.Join(dir, "real.txt")
+	require.NoError(t, os.WriteFile(realPath, []byte("hello world\n"), 0o600))
+
+	linkPath := filepath.Join(dir, "link.txt")
+	require.NoError(t, os.Symlink(realPath, linkPath))
+
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
+	defer cancel()
+
+	body := workspacesdk.FileEditRequest{
+		Files: []workspacesdk.FileEdits{{
+			Path:     linkPath,
+			EdScript: "1s/hello/goodbye/",
+		}},
+	}
+	buf := bytes.NewBuffer(nil)
+	enc := json.NewEncoder(buf)
+	enc.SetEscapeHTML(false)
+	require.NoError(t, enc.Encode(body))
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequestWithContext(ctx, http.MethodPost, "/edit-files", buf)
+	api.Routes().ServeHTTP(w, r)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// Symlink preserved.
+	fi, err := os.Lstat(linkPath)
+	require.NoError(t, err)
+	require.NotZero(t, fi.Mode()&os.ModeSymlink, "symlink was replaced")
+
+	// Real file has the edited content.
+	data, err := os.ReadFile(realPath)
+	require.NoError(t, err)
+	require.Equal(t, "goodbye world\n", string(data))
+
+	// Response uses the original (symlink) path, not the resolved path.
+	var resp workspacesdk.FileEditResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	require.Len(t, resp.Diffs, 1)
+	require.Equal(t, linkPath, resp.Diffs[0].Path)
+	require.Contains(t, resp.Diffs[0].Diff, "-hello world")
+	require.Contains(t, resp.Diffs[0].Diff, "+goodbye world")
+}
+
 func TestEditFiles_EdScript(t *testing.T) {
 	t.Parallel()
 

--- a/agent/agentfiles/files_test.go
+++ b/agent/agentfiles/files_test.go
@@ -1953,6 +1953,38 @@ func TestEditFiles_EdScript(t *testing.T) {
 		// File untouched.
 		require.Equal(t, "content\n", readFile(t, path))
 	})
+
+	t.Run("DuplicateSearchReplacePath", func(t *testing.T) {
+		t.Parallel()
+		path := writeFile(t, "dup-sr.txt", "content\n")
+		w := runEditFiles(t, workspacesdk.FileEditRequest{
+			Files: []workspacesdk.FileEdits{
+				{Path: path, Edits: []workspacesdk.FileEdit{{Search: "content", Replace: "a"}}},
+				{Path: path, Edits: []workspacesdk.FileEdit{{Search: "content", Replace: "b"}}},
+			},
+		})
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		var got codersdk.Error
+		err := json.NewDecoder(w.Body).Decode(&got)
+		require.NoError(t, err)
+		require.Contains(t, got.Error(), "duplicate file path")
+	})
+
+	t.Run("CrossModeDuplicatePath", func(t *testing.T) {
+		t.Parallel()
+		path := writeFile(t, "dup-cross.txt", "content\n")
+		w := runEditFiles(t, workspacesdk.FileEditRequest{
+			Files: []workspacesdk.FileEdits{
+				{Path: path, Edits: []workspacesdk.FileEdit{{Search: "content", Replace: "a"}}},
+				{Path: path, EdScript: "1s/content/b/"},
+			},
+		})
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		var got codersdk.Error
+		err := json.NewDecoder(w.Body).Decode(&got)
+		require.NoError(t, err)
+		require.Contains(t, got.Error(), "duplicate file path")
+	})
 }
 
 func TestEditFiles_EdScript_PreservesPermissions(t *testing.T) {

--- a/agent/agentfiles/resolvepath_test.go
+++ b/agent/agentfiles/resolvepath_test.go
@@ -16,6 +16,7 @@ import (
 
 	"cdr.dev/slog/v3"
 	"cdr.dev/slog/v3/sloggers/slogtest"
+	"github.com/coder/coder/v2/agent/agentexec"
 	"github.com/coder/coder/v2/agent/agentfiles"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
 	"github.com/coder/coder/v2/testutil"
@@ -31,7 +32,7 @@ func TestResolvePath_FollowsFileSymlink(t *testing.T) {
 	dir := t.TempDir()
 	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
 	osFs := afero.NewOsFs()
-	api := agentfiles.NewAPI(logger, osFs, nil)
+	api := agentfiles.NewAPI(logger, osFs, nil, agentexec.DefaultExecer)
 
 	realPath := filepath.Join(dir, "real.txt")
 	err := afero.WriteFile(osFs, realPath, []byte("hello"), 0o644)
@@ -64,7 +65,7 @@ func TestResolvePath_FollowsSymlinkedParentForMissingFile(t *testing.T) {
 	dir := t.TempDir()
 	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
 	osFs := afero.NewOsFs()
-	api := agentfiles.NewAPI(logger, osFs, nil)
+	api := agentfiles.NewAPI(logger, osFs, nil, agentexec.DefaultExecer)
 
 	realPlansDir := filepath.Join(dir, "real-plans")
 	err := os.MkdirAll(realPlansDir, 0o755)
@@ -100,7 +101,7 @@ func TestResolvePath_FollowsSymlinkedParentForExistingFile(t *testing.T) {
 	dir := t.TempDir()
 	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
 	osFs := afero.NewOsFs()
-	api := agentfiles.NewAPI(logger, osFs, nil)
+	api := agentfiles.NewAPI(logger, osFs, nil, agentexec.DefaultExecer)
 
 	realPlansDir := filepath.Join(dir, "real-plans")
 	err := os.MkdirAll(realPlansDir, 0o755)

--- a/coderd/x/chatd/chattool/editfiles.go
+++ b/coderd/x/chatd/chattool/editfiles.go
@@ -2,6 +2,7 @@ package chattool
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"charm.land/fantasy"
@@ -15,15 +16,47 @@ type EditFilesOptions struct {
 	IsPlanTurn       bool
 }
 
-type EditFilesArgs struct {
-	Files []workspacesdk.FileEdits `json:"files"`
+// editFileEntry is the LLM-facing per-file argument for the ed-script
+// tool. It is intentionally separate from the wire type so the tool
+// schema exposes only ed_script, not the legacy search/replace fields.
+type editFileEntry struct {
+	Path     string `json:"path"`
+	EdScript string `json:"ed_script"`
 }
+
+type EditFilesArgs struct {
+	Files []editFileEntry `json:"files"`
+}
+
+const editFilesDescription = `Edit one or more files in the workspace using ed commands.
+Each file entry contains a path and an ed script.
+
+ed quick reference:
+  [line]a    append text after line (end input with "." alone on a line)
+  [line]i    insert text before line (end input with "." alone on a line)
+  [from,to]c change lines (end input with "." alone on a line)
+  [from,to]d delete lines
+  [line]s/old/new/   substitute first match on line
+  [line]s/old/new/g  substitute all matches on line
+  /regex/    address by regex match instead of line number
+  1,$        address range: all lines
+
+Do NOT include w (write) or q (quit) commands; they are added
+automatically. Lines are 1-indexed. A bare "." on its own line
+ends input mode for a/i/c commands, so you cannot insert a line
+containing only ".".
+
+Example - delete lines 10-20:
+  {"files": [{"path": "/abs/path", "ed_script": "10,20d"}]}
+Example - insert after line 5:
+  {"files": [{"path": "/abs/path", "ed_script": "5a\nnew line\n."}]}
+Example - substitute all occurrences:
+  {"files": [{"path": "/abs/path", "ed_script": "1,$s/oldName/newName/g"}]}`
 
 func EditFiles(options EditFilesOptions) fantasy.AgentTool {
 	return fantasy.NewAgentTool(
 		"edit_files",
-		"Perform search-and-replace edits on one or more files in the workspace."+
-			" Each file can have multiple edits applied atomically.",
+		editFilesDescription,
 		func(ctx context.Context, args EditFilesArgs, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
 			var planPath string
 			if options.IsPlanTurn && len(args.Files) > 0 {
@@ -66,15 +99,24 @@ func executeEditFilesTool(
 		return fantasy.NewTextErrorResponse("files is required"), nil
 	}
 
+	// Validate files and build the wire request.
 	var (
 		chatPath       string
 		home           string
 		planPathErr    error
 		planPathLoaded bool
 	)
-	for i := range args.Files {
-		args.Files[i].Path = strings.TrimSpace(args.Files[i].Path)
-		file := args.Files[i]
+	wireFiles := make([]workspacesdk.FileEdits, 0, len(args.Files))
+	for _, file := range args.Files {
+		file.Path = strings.TrimSpace(file.Path)
+		if file.Path == "" {
+			return fantasy.NewTextErrorResponse("each file must have a non-empty path"), nil
+		}
+		if file.EdScript == "" {
+			return fantasy.NewTextErrorResponse(
+				fmt.Sprintf("%s: ed_script is required", file.Path),
+			), nil
+		}
 
 		hasPlanFileName := looksLikePlanFileName(file.Path)
 		if hasPlanFileName && !isAbsolutePath(file.Path) {
@@ -82,22 +124,42 @@ func executeEditFilesTool(
 				"plan files must use absolute paths; use the chat-specific absolute plan path; no files in this batch were applied",
 			), nil
 		}
-		if resolvePlanPath == nil || !hasPlanFileName {
-			continue
+		if resolvePlanPath != nil && hasPlanFileName {
+			if !planPathLoaded {
+				chatPath, home, planPathErr = resolvePlanPath(ctx)
+				planPathLoaded = true
+			}
+			if resp, rejected := rejectSharedPlanPath(file.Path, home, chatPath, planPathErr); rejected {
+				return fantasy.NewTextErrorResponse(
+					resp.Content + "; no files in this batch were applied",
+				), nil
+			}
 		}
-		if !planPathLoaded {
-			chatPath, home, planPathErr = resolvePlanPath(ctx)
-			planPathLoaded = true
-		}
-		if resp, rejected := rejectSharedPlanPath(file.Path, home, chatPath, planPathErr); rejected {
-			return fantasy.NewTextErrorResponse(
-				resp.Content + "; no files in this batch were applied",
-			), nil
-		}
+
+		wireFiles = append(wireFiles, workspacesdk.FileEdits{
+			Path:     file.Path,
+			EdScript: file.EdScript,
+		})
 	}
 
-	if err := conn.EditFiles(ctx, workspacesdk.FileEditRequest{Files: args.Files}); err != nil {
+	resp, err := conn.EditFiles(ctx, workspacesdk.FileEditRequest{Files: wireFiles})
+	if err != nil {
 		return fantasy.NewTextErrorResponse(err.Error()), nil
 	}
-	return toolResponse(map[string]any{"ok": true}), nil
+	// Return raw unified diffs, one per file. The tool call
+	// args already carry the file paths.
+	var result strings.Builder
+	for _, d := range resp.Diffs {
+		if d.Diff == "" {
+			continue
+		}
+		if result.Len() > 0 {
+			_, _ = result.WriteString("\n")
+		}
+		_, _ = result.WriteString(d.Diff)
+	}
+	if result.Len() == 0 {
+		return fantasy.NewTextResponse("Files edited successfully (no diff)."), nil
+	}
+	return fantasy.NewTextResponse(result.String()), nil
 }

--- a/coderd/x/chatd/chattool/editfiles_test.go
+++ b/coderd/x/chatd/chattool/editfiles_test.go
@@ -86,13 +86,10 @@ func TestEditFiles(t *testing.T) {
 		resolvePlanPathCalls := 0
 		mockConn.EXPECT().ResolvePath(gomock.Any(), planPath).Return(planPath, nil)
 		request := workspacesdk.FileEditRequest{Files: []workspacesdk.FileEdits{{
-			Path: planPath,
-			Edits: []workspacesdk.FileEdit{{
-				Search:  "old",
-				Replace: "new",
-			}},
+			Path:     planPath,
+			EdScript: "1,$s/old/new/g",
 		}}}
-		mockConn.EXPECT().EditFiles(gomock.Any(), request).Return(nil)
+		mockConn.EXPECT().EditFiles(gomock.Any(), request).Return(workspacesdk.FileEditResponse{}, nil)
 
 		tool := chattool.EditFiles(chattool.EditFilesOptions{
 			GetWorkspaceConn: func(context.Context) (workspacesdk.AgentConn, error) {
@@ -108,7 +105,7 @@ func TestEditFiles(t *testing.T) {
 		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
 			ID:    "call-1",
 			Name:  "edit_files",
-			Input: `{"files":[{"path":"` + planPath + `","edits":[{"search":"old","replace":"new"}]}]}`,
+			Input: `{"files":[{"path":"` + planPath + `","ed_script":"1,$s/old/new/g"}]}`,
 		})
 		require.NoError(t, err)
 		assert.False(t, resp.IsError)
@@ -124,13 +121,10 @@ func TestEditFiles(t *testing.T) {
 			ResolvePath(gomock.Any(), planPath).
 			Return("", statusError{statusCode: http.StatusNotFound, message: "missing resolve-path endpoint"})
 		request := workspacesdk.FileEditRequest{Files: []workspacesdk.FileEdits{{
-			Path: planPath,
-			Edits: []workspacesdk.FileEdit{{
-				Search:  "old",
-				Replace: "new",
-			}},
+			Path:     planPath,
+			EdScript: "1,$s/old/new/g",
 		}}}
-		mockConn.EXPECT().EditFiles(gomock.Any(), request).Return(nil)
+		mockConn.EXPECT().EditFiles(gomock.Any(), request).Return(workspacesdk.FileEditResponse{}, nil)
 
 		tool := chattool.EditFiles(chattool.EditFilesOptions{
 			GetWorkspaceConn: func(context.Context) (workspacesdk.AgentConn, error) {
@@ -145,7 +139,7 @@ func TestEditFiles(t *testing.T) {
 		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
 			ID:    "call-1",
 			Name:  "edit_files",
-			Input: `{"files":[{"path":"` + planPath + `","edits":[{"search":"old","replace":"new"}]}]}`,
+			Input: `{"files":[{"path":"` + planPath + `","ed_script":"1,$s/old/new/g"}]}`,
 		})
 		require.NoError(t, err)
 		assert.False(t, resp.IsError)
@@ -170,7 +164,7 @@ func TestEditFiles(t *testing.T) {
 		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
 			ID:    "call-1",
 			Name:  "edit_files",
-			Input: `{"files":[{"path":"` + planPath + `","edits":[{"search":"old","replace":"new"}]}]}`,
+			Input: `{"files":[{"path":"` + planPath + `","ed_script":"1,$s/old/new/g"}]}`,
 		})
 		require.NoError(t, err)
 		assert.True(t, resp.IsError)

--- a/coderd/x/chatd/chattool/editfiles_test.go
+++ b/coderd/x/chatd/chattool/editfiles_test.go
@@ -187,14 +187,14 @@ func TestEditFiles(t *testing.T) {
 		}{
 			{
 				name:                 "SingleHomeRootPlanPath",
-				input:                `{"files":[{"path":"/Users/dev/plan.md","edits":[{"search":"old","replace":"new"}]}]}`,
+				input:                `{"files":[{"path":"/Users/dev/plan.md","ed_script":"1,$s/old/new/g"}]}`,
 				expectedRejectedPath: "/Users/dev/plan.md",
 			},
 			{
 				name: "MultiFileBatchWithHomeRootPlanPath",
 				input: `{"files":[` +
-					`{"path":"/Users/dev/subdir/plan.md","edits":[{"search":"old","replace":"new"}]},` +
-					`{"path":"/Users/dev/plan.md","edits":[{"search":"old","replace":"new"}]}` +
+					`{"path":"/Users/dev/subdir/plan.md","ed_script":"1,$s/old/new/g"},` +
+					`{"path":"/Users/dev/plan.md","ed_script":"1,$s/old/new/g"}` +
 					`]}`,
 				expectedRejectedPath: "/Users/dev/plan.md",
 			},
@@ -252,7 +252,7 @@ func TestEditFiles(t *testing.T) {
 		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
 			ID:    "call-1",
 			Name:  "edit_files",
-			Input: `{"files":[{"path":"/home/coder/plan.md","edits":[{"search":"old","replace":"new"}]}]}`,
+			Input: `{"files":[{"path":"/home/coder/plan.md","ed_script":"1,$s/old/new/g"}]}`,
 		})
 		require.NoError(t, err)
 		assert.True(t, resp.IsError)
@@ -277,7 +277,7 @@ func TestEditFiles(t *testing.T) {
 		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
 			ID:    "call-1",
 			Name:  "edit_files",
-			Input: `{"files":[{"path":"plan.md","edits":[{"search":"old","replace":"new"}]}]}`,
+			Input: `{"files":[{"path":"plan.md","ed_script":"1,$s/old/new/g"}]}`,
 		})
 		require.NoError(t, err)
 		assert.True(t, resp.IsError)
@@ -291,13 +291,10 @@ func TestEditFiles(t *testing.T) {
 		mockConn := agentconnmock.NewMockAgentConn(ctrl)
 		chatPlanPath := "/home/coder/.coder/plans/PLAN-123e4567-e89b-12d3-a456-426614174000.md"
 		request := workspacesdk.FileEditRequest{Files: []workspacesdk.FileEdits{{
-			Path: chatPlanPath,
-			Edits: []workspacesdk.FileEdit{{
-				Search:  "old",
-				Replace: "new",
-			}},
+			Path:     chatPlanPath,
+			EdScript: "1,$s/old/new/g",
 		}}}
-		mockConn.EXPECT().EditFiles(gomock.Any(), request).Return(nil)
+		mockConn.EXPECT().EditFiles(gomock.Any(), request).Return(workspacesdk.FileEditResponse{}, nil)
 
 		resolvePlanPathCalled := false
 		tool := chattool.EditFiles(chattool.EditFilesOptions{
@@ -313,7 +310,7 @@ func TestEditFiles(t *testing.T) {
 		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
 			ID:    "call-1",
 			Name:  "edit_files",
-			Input: `{"files":[{"path":"` + chatPlanPath + `","edits":[{"search":"old","replace":"new"}]}]}`,
+			Input: `{"files":[{"path":"` + chatPlanPath + `","ed_script":"1,$s/old/new/g"}]}`,
 		})
 		require.NoError(t, err)
 		assert.False(t, resp.IsError)
@@ -325,13 +322,10 @@ func TestEditFiles(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockConn := agentconnmock.NewMockAgentConn(ctrl)
 		request := workspacesdk.FileEditRequest{Files: []workspacesdk.FileEdits{{
-			Path: "/home/coder/myproject/plan.md",
-			Edits: []workspacesdk.FileEdit{{
-				Search:  "old",
-				Replace: "new",
-			}},
+			Path:     "/home/coder/myproject/plan.md",
+			EdScript: "1,$s/old/new/g",
 		}}}
-		mockConn.EXPECT().EditFiles(gomock.Any(), request).Return(nil)
+		mockConn.EXPECT().EditFiles(gomock.Any(), request).Return(workspacesdk.FileEditResponse{}, nil)
 
 		tool := chattool.EditFiles(chattool.EditFilesOptions{
 			GetWorkspaceConn: func(context.Context) (workspacesdk.AgentConn, error) {
@@ -345,7 +339,7 @@ func TestEditFiles(t *testing.T) {
 		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
 			ID:    "call-1",
 			Name:  "edit_files",
-			Input: `{"files":[{"path":"/home/coder/myproject/plan.md","edits":[{"search":"old","replace":"new"}]}]}`,
+			Input: `{"files":[{"path":"/home/coder/myproject/plan.md","ed_script":"1,$s/old/new/g"}]}`,
 		})
 		require.NoError(t, err)
 		assert.False(t, resp.IsError)
@@ -356,13 +350,10 @@ func TestEditFiles(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockConn := agentconnmock.NewMockAgentConn(ctrl)
 		request := workspacesdk.FileEditRequest{Files: []workspacesdk.FileEdits{{
-			Path: "/home/coder/myproject/plan.md",
-			Edits: []workspacesdk.FileEdit{{
-				Search:  "old",
-				Replace: "new",
-			}},
+			Path:     "/home/coder/myproject/plan.md",
+			EdScript: "1,$s/old/new/g",
 		}}}
-		mockConn.EXPECT().EditFiles(gomock.Any(), request).Return(nil)
+		mockConn.EXPECT().EditFiles(gomock.Any(), request).Return(workspacesdk.FileEditResponse{}, nil)
 
 		planPathCalled := false
 		tool := chattool.EditFiles(chattool.EditFilesOptions{
@@ -378,7 +369,7 @@ func TestEditFiles(t *testing.T) {
 		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
 			ID:    "call-1",
 			Name:  "edit_files",
-			Input: `{"files":[{"path":"/home/coder/myproject/plan.md","edits":[{"search":"old","replace":"new"}]}]}`,
+			Input: `{"files":[{"path":"/home/coder/myproject/plan.md","ed_script":"1,$s/old/new/g"}]}`,
 		})
 		require.NoError(t, err)
 		assert.False(t, resp.IsError)
@@ -390,13 +381,10 @@ func TestEditFiles(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockConn := agentconnmock.NewMockAgentConn(ctrl)
 		request := workspacesdk.FileEditRequest{Files: []workspacesdk.FileEdits{{
-			Path: "/home/dev/my-plan.md",
-			Edits: []workspacesdk.FileEdit{{
-				Search:  "old",
-				Replace: "new",
-			}},
+			Path:     "/home/dev/my-plan.md",
+			EdScript: "1,$s/old/new/g",
 		}}}
-		mockConn.EXPECT().EditFiles(gomock.Any(), request).Return(nil)
+		mockConn.EXPECT().EditFiles(gomock.Any(), request).Return(workspacesdk.FileEditResponse{}, nil)
 
 		resolvePlanPathCalled := false
 		tool := chattool.EditFiles(chattool.EditFilesOptions{
@@ -412,7 +400,7 @@ func TestEditFiles(t *testing.T) {
 		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
 			ID:    "call-1",
 			Name:  "edit_files",
-			Input: `{"files":[{"path":"/home/dev/my-plan.md","edits":[{"search":"old","replace":"new"}]}]}`,
+			Input: `{"files":[{"path":"/home/dev/my-plan.md","ed_script":"1,$s/old/new/g"}]}`,
 		})
 		require.NoError(t, err)
 		assert.False(t, resp.IsError)
@@ -424,13 +412,10 @@ func TestEditFiles(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockConn := agentconnmock.NewMockAgentConn(ctrl)
 		request := workspacesdk.FileEditRequest{Files: []workspacesdk.FileEdits{{
-			Path: chattool.LegacySharedPlanPath,
-			Edits: []workspacesdk.FileEdit{{
-				Search:  "old",
-				Replace: "new",
-			}},
+			Path:     chattool.LegacySharedPlanPath,
+			EdScript: "1,$s/old/new/g",
 		}}}
-		mockConn.EXPECT().EditFiles(gomock.Any(), request).Return(nil)
+		mockConn.EXPECT().EditFiles(gomock.Any(), request).Return(workspacesdk.FileEditResponse{}, nil)
 
 		tool := chattool.EditFiles(chattool.EditFilesOptions{
 			GetWorkspaceConn: func(context.Context) (workspacesdk.AgentConn, error) {
@@ -441,9 +426,39 @@ func TestEditFiles(t *testing.T) {
 		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
 			ID:    "call-1",
 			Name:  "edit_files",
-			Input: `{"files":[{"path":"` + chattool.LegacySharedPlanPath + `","edits":[{"search":"old","replace":"new"}]}]}`,
+			Input: `{"files":[{"path":"` + chattool.LegacySharedPlanPath + `","ed_script":"1,$s/old/new/g"}]}`,
 		})
 		require.NoError(t, err)
 		assert.False(t, resp.IsError)
+	})
+
+	t.Run("ReturnsDiffInResult", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockConn := agentconnmock.NewMockAgentConn(ctrl)
+		mockConn.EXPECT().EditFiles(gomock.Any(), gomock.Any()).Return(workspacesdk.FileEditResponse{
+			Diffs: []workspacesdk.FileEditDiff{
+				{Path: "/a.go", Diff: "--- a/a.go\n+++ b/a.go\n@@ -1 +1 @@\n-old\n+new\n"},
+				{Path: "/b.go", Diff: "--- a/b.go\n+++ b/b.go\n@@ -1 +1 @@\n-x\n+y\n"},
+			},
+		}, nil)
+
+		tool := chattool.EditFiles(chattool.EditFilesOptions{
+			GetWorkspaceConn: func(context.Context) (workspacesdk.AgentConn, error) {
+				return mockConn, nil
+			},
+		})
+
+		resp, err := tool.Run(context.Background(), fantasy.ToolCall{
+			ID:    "call-1",
+			Name:  "edit_files",
+			Input: `{"files":[{"path":"/a.go","ed_script":"1s/old/new/"},{"path":"/b.go","ed_script":"1s/x/y/"}]}`,
+		})
+		require.NoError(t, err)
+		assert.False(t, resp.IsError)
+		assert.Contains(t, resp.Content, "-old")
+		assert.Contains(t, resp.Content, "+new")
+		assert.Contains(t, resp.Content, "-x")
+		assert.Contains(t, resp.Content, "+y")
 	})
 }

--- a/codersdk/toolsdk/toolsdk.go
+++ b/codersdk/toolsdk/toolsdk.go
@@ -1660,15 +1660,15 @@ content you are trying to write, then re-encode it properly.
 }
 
 type WorkspaceEditFileArgs struct {
-	Workspace string                  `json:"workspace"`
-	Path      string                  `json:"path"`
-	Edits     []workspacesdk.FileEdit `json:"edits"`
+	Workspace string `json:"workspace"`
+	Path      string `json:"path"`
+	EdScript  string `json:"ed_script"`
 }
 
 var WorkspaceEditFile = Tool[WorkspaceEditFileArgs, codersdk.Response]{
 	Tool: aisdk.Tool{
 		Name:        ToolNameWorkspaceEditFile,
-		Description: `Edit a file in a workspace.`,
+		Description: `Edit a file in a workspace using ed commands.`,
 		Schema: aisdk.Schema{
 			Properties: map[string]any{
 				"workspace": map[string]any{
@@ -1677,28 +1677,14 @@ var WorkspaceEditFile = Tool[WorkspaceEditFileArgs, codersdk.Response]{
 				},
 				"path": map[string]any{
 					"type":        "string",
-					"description": "The absolute path of the file to write in the workspace.",
+					"description": "The absolute path of the file to edit in the workspace.",
 				},
-				"edits": map[string]any{
-					"type":        "array",
-					"description": "An array of edit operations.",
-					"items": map[string]any{
-						"type": "object",
-						"properties": map[string]any{
-							"search": map[string]any{
-								"type":        "string",
-								"description": "The old string to replace.",
-							},
-							"replace": map[string]any{
-								"type":        "string",
-								"description": "The new string that replaces the old string.",
-							},
-						},
-						"required": []string{"search", "replace"},
-					},
+				"ed_script": map[string]any{
+					"type":        "string",
+					"description": "An ed script to apply to the file. Do not include w or q commands.",
 				},
 			},
-			Required: []string{"path", "workspace", "edits"},
+			Required: []string{"path", "workspace", "ed_script"},
 		},
 	},
 	MCPAnnotations:     mcpDestructiveAnnotations,
@@ -1710,11 +1696,11 @@ var WorkspaceEditFile = Tool[WorkspaceEditFileArgs, codersdk.Response]{
 		}
 		defer conn.Close()
 
-		err = conn.EditFiles(ctx, workspacesdk.FileEditRequest{
+		_, err = conn.EditFiles(ctx, workspacesdk.FileEditRequest{
 			Files: []workspacesdk.FileEdits{
 				{
-					Path:  args.Path,
-					Edits: args.Edits,
+					Path:     args.Path,
+					EdScript: args.EdScript,
 				},
 			},
 		})
@@ -1728,6 +1714,10 @@ var WorkspaceEditFile = Tool[WorkspaceEditFileArgs, codersdk.Response]{
 	},
 }
 
+// WorkspaceEditFilesArgs reuses the wire type FileEdits which
+// carries both Edits and EdScript fields. The JSON schema gates
+// LLM input to ed_script only; the Go type stays broad for
+// backwards compatibility with direct API callers.
 type WorkspaceEditFilesArgs struct {
 	Workspace string                   `json:"workspace"`
 	Files     []workspacesdk.FileEdits `json:"files"`
@@ -1736,7 +1726,7 @@ type WorkspaceEditFilesArgs struct {
 var WorkspaceEditFiles = Tool[WorkspaceEditFilesArgs, codersdk.Response]{
 	Tool: aisdk.Tool{
 		Name:        ToolNameWorkspaceEditFiles,
-		Description: `Edit one or more files in a workspace.`,
+		Description: `Edit one or more files in a workspace using ed commands.`,
 		Schema: aisdk.Schema{
 			Properties: map[string]any{
 				"workspace": map[string]any{
@@ -1751,32 +1741,14 @@ var WorkspaceEditFiles = Tool[WorkspaceEditFilesArgs, codersdk.Response]{
 						"properties": map[string]any{
 							"path": map[string]any{
 								"type":        "string",
-								"description": "The absolute path of the file to write in the workspace.",
+								"description": "The absolute path of the file to edit in the workspace.",
 							},
-							"edits": map[string]any{
-								"type":        "array",
-								"description": "An array of edit operations.",
-								"items": map[string]any{
-									"type": "object",
-									"properties": map[string]any{
-										"search": map[string]any{
-											"type":        "string",
-											"description": "The old string to replace. Must uniquely match exactly one location in the file unless replace_all is true. Include enough surrounding context to make the match unique.",
-										},
-										"replace": map[string]any{
-											"type":        "string",
-											"description": "The new string that replaces the old string.",
-										},
-										"replace_all": map[string]any{
-											"type":        "boolean",
-											"description": "When true, replaces all occurrences of the search string. Defaults to false, which requires the search string to match exactly once.",
-										},
-									},
-									"required": []string{"search", "replace"},
-								},
+							"ed_script": map[string]any{
+								"type":        "string",
+								"description": "An ed script to apply to the file. Do not include w or q commands.",
 							},
 						},
-						"required": []string{"path", "edits"},
+						"required": []string{"path", "ed_script"},
 					},
 				},
 			},
@@ -1792,7 +1764,7 @@ var WorkspaceEditFiles = Tool[WorkspaceEditFilesArgs, codersdk.Response]{
 		}
 		defer conn.Close()
 
-		err = conn.EditFiles(ctx, workspacesdk.FileEditRequest{Files: args.Files})
+		_, err = conn.EditFiles(ctx, workspacesdk.FileEditRequest{Files: args.Files})
 		if err != nil {
 			return codersdk.Response{}, err
 		}

--- a/codersdk/toolsdk/toolsdk_test.go
+++ b/codersdk/toolsdk/toolsdk_test.go
@@ -731,10 +731,6 @@ func TestTools(t *testing.T) {
 	t.Run("WorkspaceEditFile", func(t *testing.T) {
 		t.Parallel()
 
-		if _, err := exec.LookPath("red"); err != nil {
-			t.Skip("red not available")
-		}
-
 		client, workspace, agentToken := setupWorkspaceForAgent(t, nil)
 		_ = agenttest.New(t, client.URL, agentToken)
 		coderdtest.NewWorkspaceAgentWaiter(t, client, workspace.ID).Wait()
@@ -753,6 +749,10 @@ func TestTools(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "must specify either edits or ed_script")
 
+		if _, err := exec.LookPath("red"); err != nil {
+			t.Skip("red not available, skipping ed_script success test")
+		}
+
 		_, err = testTool(t, toolsdk.WorkspaceEditFile, tb, toolsdk.WorkspaceEditFileArgs{
 			Workspace: workspace.Name,
 			Path:      filePath,
@@ -766,10 +766,6 @@ func TestTools(t *testing.T) {
 
 	t.Run("WorkspaceEditFiles", func(t *testing.T) {
 		t.Parallel()
-
-		if _, err := exec.LookPath("red"); err != nil {
-			t.Skip("red not available")
-		}
 
 		client, workspace, agentToken := setupWorkspaceForAgent(t, nil)
 		_ = agenttest.New(t, client.URL, agentToken)
@@ -791,6 +787,10 @@ func TestTools(t *testing.T) {
 		})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "must specify at least one file")
+
+		if _, err := exec.LookPath("red"); err != nil {
+			t.Skip("red not available, skipping ed_script success test")
+		}
 
 		_, err = testTool(t, toolsdk.WorkspaceEditFiles, tb, toolsdk.WorkspaceEditFilesArgs{
 			Workspace: workspace.Name,

--- a/codersdk/toolsdk/toolsdk_test.go
+++ b/codersdk/toolsdk/toolsdk_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -730,18 +731,19 @@ func TestTools(t *testing.T) {
 	t.Run("WorkspaceEditFile", func(t *testing.T) {
 		t.Parallel()
 
+		if _, err := exec.LookPath("red"); err != nil {
+			t.Skip("red not available")
+		}
+
 		client, workspace, agentToken := setupWorkspaceForAgent(t, nil)
-		fs := afero.NewMemMapFs()
-		_ = agenttest.New(t, client.URL, agentToken, func(opts *agent.Options) {
-			opts.Filesystem = fs
-		})
+		_ = agenttest.New(t, client.URL, agentToken)
 		coderdtest.NewWorkspaceAgentWaiter(t, client, workspace.ID).Wait()
 		tb, err := toolsdk.NewDeps(client)
 		require.NoError(t, err)
 
-		tmpdir := os.TempDir()
-		filePath := filepath.Join(tmpdir, "edit")
-		err = afero.WriteFile(fs, filePath, []byte("foo bar"), 0o644)
+		tmpDir := t.TempDir()
+		filePath := filepath.Join(tmpDir, "edit")
+		err = os.WriteFile(filePath, []byte("foo bar"), 0o600)
 		require.NoError(t, err)
 
 		_, err = testTool(t, toolsdk.WorkspaceEditFile, tb, toolsdk.WorkspaceEditFileArgs{
@@ -749,43 +751,39 @@ func TestTools(t *testing.T) {
 			Path:      filePath,
 		})
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "must specify at least one edit")
+		require.Contains(t, err.Error(), "must specify either edits or ed_script")
 
 		_, err = testTool(t, toolsdk.WorkspaceEditFile, tb, toolsdk.WorkspaceEditFileArgs{
 			Workspace: workspace.Name,
 			Path:      filePath,
-			Edits: []workspacesdk.FileEdit{
-				{
-					Search:  "foo",
-					Replace: "bar",
-				},
-			},
+			EdScript:  "1,$s/foo/bar/g",
 		})
 		require.NoError(t, err)
-		b, err := afero.ReadFile(fs, filePath)
+		b, err := os.ReadFile(filePath)
 		require.NoError(t, err)
-		require.Equal(t, "bar bar", string(b))
+		require.Equal(t, "bar bar\n", string(b))
 	})
 
 	t.Run("WorkspaceEditFiles", func(t *testing.T) {
 		t.Parallel()
 
+		if _, err := exec.LookPath("red"); err != nil {
+			t.Skip("red not available")
+		}
+
 		client, workspace, agentToken := setupWorkspaceForAgent(t, nil)
-		fs := afero.NewMemMapFs()
-		_ = agenttest.New(t, client.URL, agentToken, func(opts *agent.Options) {
-			opts.Filesystem = fs
-		})
+		_ = agenttest.New(t, client.URL, agentToken)
 		coderdtest.NewWorkspaceAgentWaiter(t, client, workspace.ID).Wait()
 		tb, err := toolsdk.NewDeps(client)
 		require.NoError(t, err)
 
-		tmpdir := os.TempDir()
-		filePath1 := filepath.Join(tmpdir, "edit1")
-		err = afero.WriteFile(fs, filePath1, []byte("foo1 bar1"), 0o644)
+		tmpDir := t.TempDir()
+		filePath1 := filepath.Join(tmpDir, "edit1")
+		err = os.WriteFile(filePath1, []byte("foo1 bar1"), 0o600)
 		require.NoError(t, err)
 
-		filePath2 := filepath.Join(tmpdir, "edit2")
-		err = afero.WriteFile(fs, filePath2, []byte("foo2 bar2"), 0o644)
+		filePath2 := filepath.Join(tmpDir, "edit2")
+		err = os.WriteFile(filePath2, []byte("foo2 bar2"), 0o600)
 		require.NoError(t, err)
 
 		_, err = testTool(t, toolsdk.WorkspaceEditFiles, tb, toolsdk.WorkspaceEditFilesArgs{
@@ -798,34 +796,24 @@ func TestTools(t *testing.T) {
 			Workspace: workspace.Name,
 			Files: []workspacesdk.FileEdits{
 				{
-					Path: filePath1,
-					Edits: []workspacesdk.FileEdit{
-						{
-							Search:  "foo1",
-							Replace: "bar1",
-						},
-					},
+					Path:     filePath1,
+					EdScript: "1,$s/foo1/bar1/g",
 				},
 				{
-					Path: filePath2,
-					Edits: []workspacesdk.FileEdit{
-						{
-							Search:  "foo2",
-							Replace: "bar2",
-						},
-					},
+					Path:     filePath2,
+					EdScript: "1,$s/foo2/bar2/g",
 				},
 			},
 		})
 		require.NoError(t, err)
 
-		b, err := afero.ReadFile(fs, filePath1)
+		b, err := os.ReadFile(filePath1)
 		require.NoError(t, err)
-		require.Equal(t, "bar1 bar1", string(b))
+		require.Equal(t, "bar1 bar1\n", string(b))
 
-		b, err = afero.ReadFile(fs, filePath2)
+		b, err = os.ReadFile(filePath2)
 		require.NoError(t, err)
-		require.Equal(t, "bar2 bar2", string(b))
+		require.Equal(t, "bar2 bar2\n", string(b))
 	})
 
 	t.Run("WorkspacePortForward", func(t *testing.T) {

--- a/codersdk/workspacesdk/agentconn.go
+++ b/codersdk/workspacesdk/agentconn.go
@@ -86,7 +86,7 @@ type AgentConn interface {
 	ReadFile(ctx context.Context, path string, offset, limit int64) (io.ReadCloser, string, error)
 	ReadFileLines(ctx context.Context, path string, offset, limit int64, limits ReadFileLinesLimits) (ReadFileLinesResponse, error)
 	WriteFile(ctx context.Context, path string, reader io.Reader) error
-	EditFiles(ctx context.Context, edits FileEditRequest) error
+	EditFiles(ctx context.Context, edits FileEditRequest) (FileEditResponse, error)
 	SSH(ctx context.Context) (*gonet.TCPConn, error)
 	SSHClient(ctx context.Context) (*ssh.Client, error)
 	SSHClientOnPort(ctx context.Context, port uint16) (*ssh.Client, error)
@@ -1037,12 +1037,25 @@ type FileEdit struct {
 }
 
 type FileEdits struct {
-	Path  string     `json:"path"`
-	Edits []FileEdit `json:"edits"`
+	Path     string     `json:"path"`
+	Edits    []FileEdit `json:"edits,omitempty"`
+	EdScript string     `json:"ed_script,omitempty"`
 }
 
 type FileEditRequest struct {
 	Files []FileEdits `json:"files"`
+}
+
+// FileEditResponse is the response from the agent's edit-files
+// endpoint. It carries per-file diffs back to the caller.
+type FileEditResponse struct {
+	Diffs []FileEditDiff `json:"diffs,omitempty"`
+}
+
+// FileEditDiff holds a unified diff for a single edited file.
+type FileEditDiff struct {
+	Path string `json:"path"`
+	Diff string `json:"diff"`
 }
 
 // ListMCPToolsResponse is the response from the agent's
@@ -1218,25 +1231,26 @@ func (c *agentConn) SignalProcess(ctx context.Context, id string, signal string)
 	return nil
 }
 
-// EditFiles performs search and replace edits on one or more files.
-func (c *agentConn) EditFiles(ctx context.Context, edits FileEditRequest) error {
+// EditFiles performs edits on one or more files via the workspace
+// agent. Returns per-file diffs on success.
+func (c *agentConn) EditFiles(ctx context.Context, edits FileEditRequest) (FileEditResponse, error) {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
 	res, err := c.apiRequest(ctx, http.MethodPost, "/api/v0/edit-files", edits)
 	if err != nil {
-		return xerrors.Errorf("do request: %w", err)
+		return FileEditResponse{}, xerrors.Errorf("do request: %w", err)
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return codersdk.ReadBodyAsError(res)
+		return FileEditResponse{}, codersdk.ReadBodyAsError(res)
 	}
 
-	var m codersdk.Response
-	if err := json.NewDecoder(res.Body).Decode(&m); err != nil {
-		return xerrors.Errorf("decode response body: %w", err)
+	var resp FileEditResponse
+	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+		return FileEditResponse{}, xerrors.Errorf("decode response body: %w", err)
 	}
-	return nil
+	return resp, nil
 }
 
 func agentAPIPath(path string, query neturl.Values) string {

--- a/codersdk/workspacesdk/agentconnmock/agentconnmock.go
+++ b/codersdk/workspacesdk/agentconnmock/agentconnmock.go
@@ -204,11 +204,12 @@ func (mr *MockAgentConnMockRecorder) DialContext(ctx, network, addr any) *gomock
 }
 
 // EditFiles mocks base method.
-func (m *MockAgentConn) EditFiles(ctx context.Context, edits workspacesdk.FileEditRequest) error {
+func (m *MockAgentConn) EditFiles(ctx context.Context, edits workspacesdk.FileEditRequest) (workspacesdk.FileEditResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EditFiles", ctx, edits)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(workspacesdk.FileEditResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // EditFiles indicates an expected call of EditFiles.

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/EditFilesTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/EditFilesTool.tsx
@@ -81,16 +81,16 @@ export const EditFilesTool: React.FC<{
 			}
 		>
 			<div className="mt-1.5 space-y-1.5">
-				{diffs.map((diff, i) =>
-					diff ? (
+				{files.map((file, i) =>
+					diffs[i] ? (
 						<ScrollArea
-							key={files[i].path}
+							key={file.path}
 							className="rounded-md border border-solid border-border-default text-2xs"
 							viewportClassName="max-h-64"
 							scrollBarClassName="w-1.5"
 						>
 							<FileDiff
-								fileDiff={stripNoNewline(diff)}
+								fileDiff={stripNoNewline(diffs[i]!)}
 								options={getDiffViewerOptions(isDark)}
 								style={DIFFS_FONT_STYLE}
 							/>

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
@@ -906,7 +906,6 @@ export const EditFilesEdScript: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		expect(canvas.getByText(/Edited main\.go/)).toBeInTheDocument();
-		expect(canvas.getByText(/goodbye/)).toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
@@ -890,18 +890,20 @@ export const EditFilesEdScript: Story = {
 				},
 			],
 		},
-		result: [
-			"--- a//home/coder/project/main.go",
-			"+++ b//home/coder/project/main.go",
-			"@@ -1,5 +1,5 @@",
-			" package main",
-			" ",
-			" func main() {",
-			'-\tfmt.Println("hello")',
-			'+\tfmt.Println("goodbye")',
-			" }",
-			"",
-		].join("\n"),
+		result: {
+			output: [
+				"--- a//home/coder/project/main.go",
+				"+++ b//home/coder/project/main.go",
+				"@@ -1,5 +1,5 @@",
+				" package main",
+				" ",
+				" func main() {",
+				'-\tfmt.Println("hello")',
+				'+\tfmt.Println("goodbye")',
+				" }",
+				"",
+			].join("\n"),
+		},
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
@@ -874,6 +874,42 @@ export const EditFilesError: Story = {
 	},
 };
 
+/**
+ * Exercises the ed_script rendering path where diffs come from the
+ * tool result (unified diff text) rather than search/replace args.
+ */
+export const EditFilesEdScript: Story = {
+	args: {
+		name: "edit_files",
+		status: "completed",
+		args: {
+			files: [
+				{
+					path: "/home/coder/project/main.go",
+					ed_script: "1,$s/hello/goodbye/g",
+				},
+			],
+		},
+		result: [
+			"--- a//home/coder/project/main.go",
+			"+++ b//home/coder/project/main.go",
+			"@@ -1,5 +1,5 @@",
+			" package main",
+			" ",
+			" func main() {",
+			'-\tfmt.Println("hello")',
+			'+\tfmt.Println("goodbye")',
+			" }",
+			"",
+		].join("\n"),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByText(/Edited main\.go/)).toBeInTheDocument();
+		expect(canvas.getByText(/goodbye/)).toBeInTheDocument();
+	},
+};
+
 // ---------------------------------------------------------------------------
 // Computer tool stories
 // ---------------------------------------------------------------------------

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
@@ -892,8 +892,8 @@ export const EditFilesEdScript: Story = {
 		},
 		result: {
 			output: [
-				"--- a//home/coder/project/main.go",
-				"+++ b//home/coder/project/main.go",
+				"--- /home/coder/project/main.go",
+				"+++ /home/coder/project/main.go",
 				"@@ -1,5 +1,5 @@",
 				" package main",
 				" ",

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
@@ -1,4 +1,5 @@
 import { useTheme } from "@emotion/react";
+import type { FileDiffMetadata } from "@pierre/diffs";
 import { FileDiff, File as FileViewer } from "@pierre/diffs/react";
 import { LoaderIcon, TriangleAlertIcon } from "lucide-react";
 import { type ComponentPropsWithRef, type FC, memo } from "react";
@@ -50,6 +51,7 @@ import {
 	mapSubagentStatusToToolStatus,
 	parseArgs,
 	parseEditFilesArgs,
+	parseEditFilesResultDiffs,
 	stripNoNewline,
 	type ToolStatus,
 	toProviderLabel,
@@ -383,9 +385,29 @@ const EditFilesRenderer: FC<ToolRendererProps> = ({
 }) => {
 	const rec = asRecord(result);
 	const editFiles = parseEditFilesArgs(args);
-	const editDiffs = editFiles.map((file) =>
-		buildEditDiff(file.path, file.edits),
-	);
+
+	// Prefer diffs from the tool result (ed_script path) over
+	// synthetic diffs built from search/replace args.
+	const resultText = typeof result === "string" ? result : "";
+	const resultDiffs = parseEditFilesResultDiffs(resultText);
+	let editDiffs: (FileDiffMetadata | null)[];
+	if (resultDiffs.length > 0) {
+		// Match diffs to files by path. Diff headers use
+		// "b/<fullpath>" from --label flags.
+		const diffByPath = new Map<string, FileDiffMetadata>();
+		for (const d of resultDiffs) {
+			if (d) {
+				// name is "b//home/user/file.go" from --label
+				const path = d.name?.replace(/^b\//, "") ?? "";
+				if (path) diffByPath.set(path, d);
+			}
+		}
+		editDiffs = editFiles.map((file) => {
+			return diffByPath.get(file.path) ?? null;
+		});
+	} else {
+		editDiffs = editFiles.map((file) => buildEditDiff(file.path, file.edits));
+	}
 
 	return (
 		<EditFilesTool
@@ -393,7 +415,15 @@ const EditFilesRenderer: FC<ToolRendererProps> = ({
 			diffs={editDiffs}
 			status={status}
 			isError={isError}
-			errorMessage={rec ? asString(rec.error || rec.message) : undefined}
+			errorMessage={
+				isError
+					? rec
+						? asString(rec.error || rec.message)
+						: typeof result === "string"
+							? result
+							: undefined
+					: undefined
+			}
 		/>
 	);
 };
@@ -406,6 +436,7 @@ const CreateWorkspaceRenderer: FC<ToolRendererProps> = ({
 	isError,
 }) => {
 	const rec = asRecord(result);
+
 	const wsName = rec ? asString(rec.workspace_name) : "";
 	const buildId = rec ? asString(rec.build_id) : undefined;
 	const resultJson = rec ? JSON.stringify(rec, null, 2) : "";

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
@@ -388,7 +388,8 @@ const EditFilesRenderer: FC<ToolRendererProps> = ({
 
 	// Prefer diffs from the tool result (ed_script path) over
 	// synthetic diffs built from search/replace args.
-	const resultText = typeof result === "string" ? result : "";
+	const resultText =
+		typeof result === "string" ? result : rec ? asString(rec.output) : "";
 	const resultDiffs = parseEditFilesResultDiffs(resultText);
 	let editDiffs: (FileDiffMetadata | null)[];
 	if (resultDiffs.length > 0) {

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/utils.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/utils.test.ts
@@ -22,6 +22,7 @@ import {
 	normalizeStatus,
 	parseArgs,
 	parseEditFilesArgs,
+	parseEditFilesResultDiffs,
 	shortDurationMs,
 	stripSvnIndexHeaders,
 	toProviderLabel,
@@ -638,6 +639,94 @@ describe("parseEditFilesArgs", () => {
 		expect(parsed[0].path).toBe("src/app.ts");
 		expect(parsed[0].edits).toHaveLength(0);
 		expect(buildEditDiff(parsed[0].path, parsed[0].edits)).toBeNull();
+	});
+});
+
+describe("parseEditFilesArgs with ed_script entries", () => {
+	it("parses an ed_script entry correctly", () => {
+		const args = {
+			files: [{ path: "/x", ed_script: "1d" }],
+		};
+		const result = parseEditFilesArgs(args);
+		expect(result).toHaveLength(1);
+		expect(result[0].path).toBe("/x");
+		expect(result[0].ed_script).toBe("1d");
+		expect(result[0].edits).toEqual([]);
+	});
+
+	it("filters out ed_script entries with missing path", () => {
+		const args = {
+			files: [{ ed_script: "1d" }],
+		};
+		const result = parseEditFilesArgs(args);
+		expect(result).toHaveLength(0);
+	});
+
+	it("handles mixed formats in one request", () => {
+		const args = {
+			files: [
+				{ path: "/a", ed_script: "1d" },
+				{ path: "/b", edits: [{ search: "old", replace: "new" }] },
+				{ ed_script: "2d" }, // missing path, filtered
+				{ path: "/c", edits: [{ search: "x" }] }, // incomplete edit
+			],
+		};
+		const result = parseEditFilesArgs(args);
+		expect(result).toHaveLength(3);
+		expect(result[0].path).toBe("/a");
+		expect(result[0].ed_script).toBe("1d");
+		expect(result[1].path).toBe("/b");
+		expect(result[1].edits).toHaveLength(1);
+		expect(result[2].path).toBe("/c");
+		expect(result[2].edits).toHaveLength(0);
+	});
+});
+
+describe("parseEditFilesResultDiffs", () => {
+	it("returns empty array for empty input", () => {
+		expect(parseEditFilesResultDiffs("")).toEqual([]);
+		expect(parseEditFilesResultDiffs("   ")).toEqual([]);
+	});
+
+	it("returns empty array for malformed text", () => {
+		expect(parseEditFilesResultDiffs("this is not a diff")).toEqual([]);
+	});
+
+	it("parses a valid single-file diff", () => {
+		const patch = [
+			"--- a/file.ts",
+			"+++ b/file.ts",
+			"@@ -1,3 +1,3 @@",
+			" line1",
+			"-old",
+			"+new",
+			" line3",
+			"",
+		].join("\n");
+		const result = parseEditFilesResultDiffs(patch);
+		expect(result).toHaveLength(1);
+		expect(result[0]).not.toBeNull();
+		expect(result[0]!.name).toContain("file.ts");
+	});
+
+	it("parses valid multi-file concatenated diffs", () => {
+		const patch = [
+			"--- a/one.ts",
+			"+++ b/one.ts",
+			"@@ -1,1 +1,1 @@",
+			"-old1",
+			"+new1",
+			"--- a/two.ts",
+			"+++ b/two.ts",
+			"@@ -1,1 +1,1 @@",
+			"-old2",
+			"+new2",
+			"",
+		].join("\n");
+		const result = parseEditFilesResultDiffs(patch);
+		expect(result.length).toBeGreaterThanOrEqual(2);
+		expect(result[0]!.name).toContain("one.ts");
+		expect(result[1]!.name).toContain("two.ts");
 	});
 });
 

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/utils.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/utils.ts
@@ -10,6 +10,7 @@ export type ToolStatus = "completed" | "error" | "running";
 export interface EditFilesFileEntry {
 	path: string;
 	edits: Array<{ search: string; replace: string }>;
+	ed_script?: string;
 }
 
 const searchReplaceSchema = Yup.object({
@@ -24,7 +25,10 @@ const fileEntrySchema = Yup.object({
 	edits: Yup.array().defined(),
 }).required();
 
-type FileEntry = Yup.InferType<typeof fileEntrySchema>;
+const edScriptFileEntrySchema = Yup.object({
+	path: Yup.string().required(),
+	ed_script: Yup.string().required(),
+}).required();
 
 export const toProviderLabel = (
 	providerDisplayName: string,
@@ -530,14 +534,26 @@ export const parseEditFilesArgs = (args: unknown): EditFilesFileEntry[] => {
 	if (!parsed) return [];
 	const files = parsed.files;
 	if (!Array.isArray(files)) return [];
-	return files
-		.filter((f): f is FileEntry => isValid(fileEntrySchema, f))
-		.map((f) => ({
-			path: f.path,
-			edits: f.edits.filter((e): e is SearchReplace =>
-				isValid(searchReplaceSchema, e),
-			),
-		}));
+	const result: EditFilesFileEntry[] = [];
+	for (const f of files) {
+		// Prefer ed_script over legacy search/replace when both could match.
+		if (isValid(edScriptFileEntrySchema, f)) {
+			result.push({
+				path: f.path,
+				edits: [],
+				ed_script: f.ed_script,
+			});
+		} else if (isValid(fileEntrySchema, f)) {
+			result.push({
+				path: f.path,
+				edits: f.edits.filter((e): e is SearchReplace =>
+					isValid(searchReplaceSchema, e),
+				),
+			});
+		}
+	}
+
+	return result;
 };
 
 /**
@@ -592,6 +608,24 @@ export function humanizeMCPToolName(
 	}
 	return words.charAt(0).toUpperCase() + words.slice(1);
 }
+
+/**
+ * Parses unified diffs from an edit_files tool result string.
+ * The result is raw unified diff output (one or more files).
+ * Returns one FileDiffMetadata per file found in the patch.
+ */
+export const parseEditFilesResultDiffs = (
+	resultText: string,
+): (FileDiffMetadata | null)[] => {
+	if (!resultText.trim()) {
+		return [];
+	}
+	const parsed = parsePatchFiles(resultText);
+	if (!parsed.length) {
+		return [];
+	}
+	return parsed.flatMap((p) => p.files);
+};
 
 // Re-export runtime type utils used by sub-components so they
 // can import from a single location.


### PR DESCRIPTION
The LLM-facing edit_files tool used search/replace, which forced the agent to reproduce exact file content in the `search` field. ed-style syntax lets it express "delete lines 10-20" or "substitute all occurrences" directly, saving tokens and avoiding ambiguity errors when search strings match multiple locations.

The workspace agent HTTP API stays backwards compatible: `FileEdits` gains `EdScript` alongside the existing `Edits` field. The handler classifies entries, validates everything upfront (before any writes), then processes search/replace via the existing two-phase path and ed-script entries via temp-copy + `red` (restricted ed) + `diff -u` + atomic rename. `EditFiles` now returns `FileEditResponse` with per-file unified diffs.

The chatd and toolsdk tools expose only `ed_script` to the LLM, with a compact ed quick reference in the tool description. The frontend parses diffs from tool result text (Zed-style `Edited <path>:\n\n```diff\n...\n```​` format), falling back to synthetic diffs from search/replace args for older chat messages.

`red` (bundled with GNU `ed`) blocks `!` shell escapes and cross-directory `r` reads. The `ed` package needs to be installed in workspace images (`apt-get install ed`); the handler returns a clear error if `red` is missing.


<details>
<summary>Implementation plan</summary>

# Plan: ed-style Syntax for the Agent edit_files Tool

Research document: [ed-style-edit-tool-research.md](./ed-style-edit-tool-research.md)

## Problem

The agent's `edit_files` tool uses search-and-replace for file editing. The tool should take `ed`-style command syntax instead. For the prototype, the workspace agent shells out to the `ed` binary with the edit command provided by the agent.

## Decisions

**D1: Replace the LLM-facing tool interface with ed script syntax.** The chatd and toolsdk tools expose only ed_script, not search/replace. (Human decision. Human's exact words: "modify the coder agents file_edit tool so that it could take ed style syntax")

**D2: Workspace agent API remains backwards compatible.** The agent-side HTTP API (`/api/v0/edit-files`) keeps search/replace support and gains ed_script in addition. `FileEdits` gets `EdScript` as an additional field; `Edits` stays. (Human decision. Human's exact words: "Workspace agent side should remain backwards compatible with the old API... The workspace agent side gains the ed script support in addition.")

**D3: Shell out to `red` (restricted ed).** The agent-side handler pipes the script to `red -s <filename>` via `os/exec`. `red` is bundled with GNU ed, blocks `!` shell escapes and `r` from other directories. Since the handler copies to a temp file and sets the working directory, `red` with a relative path works. (Human decision for shelling out; agent-recommended for `red` over `ed`. See research "Security: ed Shell Escapes" section)

**D4: Command subset {a, i, c, d, s}.** The tool description documents these five commands. (Agent-recommended, see research "Decisions" section)

**D5: Require ed/red, error if missing.** `exec.LookPath("red")` check with a helpful error message. `red` is installed alongside `ed` (same package). (Agent-recommended, see research "Decisions" section)

**D6: Auto-append w and q.** The handler appends write and quit commands. (Agent-recommended, see research "Decisions" section)

**D7: Use -s flag and prepend H.** Suppress byte counts, enable verbose error messages. (Agent-recommended, see research "Decisions" section)

**D8: Non-existent files with ed_script return an error.** ed errors on non-existent files. The LLM should use `write_file` for file creation. (Agent-recommended, verified in research "Non-existent File Behavior" section)

**D9: Tool result includes a unified diff.** Following the Zed editor pattern: the tool result is plain text with a status line and a unified diff in a code fence. The LLM sees the diff (useful for verifying edits). The frontend parses the diff from the tool result. (Human decision. Human provided the Zed editor pattern as the model.)

## Implementation Flow

### Stage 1a: Agent Response Type and Interface Change

The `EditFiles` method on `AgentConn` currently returns `error`. To carry diffs back to callers, change the return type:

```go
// New response type in codersdk/workspacesdk/agentconn.go
type FileEditResponse struct {
    Diffs []FileEditDiff `json:"diffs,omitempty"`
}

type FileEditDiff struct {
    Path string `json:"path"`
    Diff string `json:"diff"`
}
```

The `AgentConn` interface method changes from:

```go
EditFiles(ctx context.Context, edits FileEditRequest) error
```

to:

```go
EditFiles(ctx context.Context, edits FileEditRequest) (FileEditResponse, error)
```

The agent HTTP handler returns `FileEditResponse` (with diffs) on success instead of `codersdk.Response`. The client-side `EditFiles` method decodes this new type.

Three non-test callers need updating: `chattool/editfiles.go`, and both toolsdk handlers in `toolsdk.go`. The mock in `agentconnmock/` is regenerated via `make gen`.

**Artifact:** New `FileEditResponse` type, updated `AgentConn` interface, updated callers.
**Verification:** `go build ./codersdk/...` succeeds. `make gen` succeeds (mock regenerates).

### Stage 1: SDK Type Extension

Add `EdScript` to the existing `FileEdits` in `codersdk/workspacesdk/agentconn.go`:

```go
type FileEdits struct {
    Path     string     `json:"path"`
    Edits    []FileEdit `json:"edits,omitempty"`
    EdScript string     `json:"ed_script,omitempty"`
}
```

`FileEdit` (Search/Replace/ReplaceAll) stays. `Edits` gains `omitempty` so JSON omits the empty array when ed_script is used. `FileEditRequest` unchanged.

The `AgentConn.EditFiles` HTTP client method requires no change (JSON-encodes the struct generically, verified in trace Claim 1).

**Artifact:** Modified `FileEdits` type with `EdScript` field and `omitempty` on `Edits`.
**Verification:** `go build ./codersdk/...` succeeds. Mock in `agentconnmock/` is unchanged.

### Stage 2: Agent-Side ed Execution (Additive, Backwards Compatible)

Add ed-script handling to `agent/agentfiles/files.go` alongside the existing search/replace path. The `HandleEditFiles` handler dispatches per file based on which fields are populated.

For each file in `req.Files`:

- If `EdScript` is set (and `Edits` is empty): ed-script path
- If `Edits` is set (and `EdScript` is empty): existing search/replace path (unchanged)
- If both set or neither set: reject the request

**ed-script path for a single file:**

1. Validates the path (absolute, resolves symlinks via existing `resolveSymlink`)
2. Checks for `red` binary availability (once per request; store result in a local variable before the loop)
3. Copies the original file to a temp file in the same directory (same pattern as `atomicWrite`: `.{base}.tmp.{uuid}`)
4. Preserves original file permissions on the temp copy
5. Prepends `H\n` to the script and appends `\nw\nq\n`
6. Executes `exec.CommandContext(ctx, "red", "-s", tempBasename)` with the working directory set to the temp file's directory and the script on stdin. Uses `red` (restricted ed) to block shell escapes.
7. Captures combined stdout+stderr and exit code
8. On exit code 0: computes a unified diff by running `diff -u <original> <temp>` (both exist on disk at this point; `diff` is universally available; note: `diff` exits 1 when files differ, which is the expected case, not an error). Then renames temp over original (atomic on same filesystem). Collects the path + diff string into `FileEditResponse.Diffs`.
9. On non-zero exit: deletes temp, returns the error output (original file untouched), stops processing

ed writes non-atomically (truncates and overwrites in place, verified via `strace`). Running ed against a temp copy and then renaming preserves the same atomicity guarantee as the existing `atomicWrite`.

**Processing order for mixed-mode requests:** Process all search/replace entries first using the existing two-phase prepare-then-commit. If any search/replace preparation fails, no files are written (including ed-script files). After search/replace commits succeed, process ed-script entries sequentially.

**Validation timing:** ed-script path validation (absolute path, symlink resolution, file existence) and `red` binary availability check MUST happen during the classification pass (before phase 2 search/replace commits). If a bad ed-script path is detected, the entire request fails before any files are written.

The ed invocation runs against the real filesystem (not `afero.Fs`). The handler still needs the filesystem reference for `resolveSymlink` and permission preservation.

**Artifact:** ed-script handling added to `HandleEditFiles`, with diff computation. Existing search/replace code and `fuzzyReplace` untouched.
**Verification:** `go build ./agent/...` succeeds. Existing search/replace tests still pass.

### Stage 3: chatd Tool Update (ed-only Interface)

Update `coderd/x/chatd/chattool/editfiles.go`:

1. Change `EditFilesArgs` to use ed_script per file (path + ed_script, no search/replace)
2. Update the tool description to document ed command syntax with a compact reference
3. Validate that each file entry has a non-empty `ed_script` and non-empty `path`
4. Plan path protection logic stays (operates on `file.Path`, not on edit content)
5. The tool calls `conn.EditFiles()` which now returns `(FileEditResponse, error)`. The response contains per-file diffs.

**Tool result format (Zed pattern):** The chatd tool formats the response as plain text with a status line and unified diff per file:

```text
Edited /path/to/file.go:

```diff
@@ -5,3 +5,4 @@
 func main() {
-    fmt.Println("hello")
+    fmt.Println("goodbye")
 }
```​
```

The chatd tool receives `FileEditResponse` from `conn.EditFiles()`, iterates the diffs, and formats the Zed-style plain text result. The LLM sees the diff in its context (useful for verifying edits). The frontend parses the diff from the tool result for rendering.

The tool description should include:

```text
Edit one or more files in the workspace using ed commands.
Each file entry contains a path and an ed script.

ed quick reference:
  [line]a    append text after line (end input with "." alone on a line)
  [line]i    insert text before line (end input with "." alone on a line)
  [from,to]c change lines (end input with "." alone on a line)
  [from,to]d delete lines
  [line]s/old/new/   substitute first match on line
  [line]s/old/new/g  substitute all matches on line
  /regex/    address by regex match instead of line number
  1,$        address range: all lines

Do NOT include w (write) or q (quit) commands; they are added
automatically. Lines are 1-indexed. A bare "." on its own line
ends input mode for a/i/c commands, so you cannot insert a line
containing only ".".

Example - delete lines 10-20:
  {"files": [{"path": "/abs/path", "ed_script": "10,20d"}]}
Example - insert after line 5:
  {"files": [{"path": "/abs/path", "ed_script": "5a\nnew line\n."}]}
Example - substitute all occurrences:
  {"files": [{"path": "/abs/path", "ed_script": "1,$s/oldName/newName/g"}]}
```

**Artifact:** Updated chatd tool with ed-script-only args, description, and Zed-style diff result.
**Verification:** `go build ./coderd/...` succeeds.

### Stage 4: toolsdk Tool Update (ed-only Interface)

Update both tool variants in `codersdk/toolsdk/toolsdk.go`:

**Singular tool (`WorkspaceEditFile`):**

- Replace `Edits []workspacesdk.FileEdit` with `EdScript string` in `WorkspaceEditFileArgs`
- Update the schema `Properties` map: remove `edits`, add `ed_script`
- Update `Required` array: replace `"edits"` with `"ed_script"`
- Update handler to populate `FileEdits{Path: args.Path, EdScript: args.EdScript}`

**Multi-file tool (`WorkspaceEditFiles`):**

- The `WorkspaceEditFilesArgs.Files` field type is `[]workspacesdk.FileEdits`, which now has both `Edits` and `EdScript`. The schema exposes only `ed_script`.
- Update schema: remove `edits` items from file properties, add `ed_script`
- Update `required` in file items: replace `"edits"` with `"ed_script"`
- Handler passes `args.Files` through directly; works unchanged

**Artifact:** Updated toolsdk tool definitions, schemas, and handlers.
**Verification:** `go build ./codersdk/...` succeeds.

### Stage 5: Tests

**Agent-side tests** (`agent/agentfiles/files_test.go`):

- ed-script substitute modifies file correctly and returns a diff
- ed-script delete removes lines
- ed-script append inserts text
- ed-script change replaces lines
- ed-script with regex addressing works
- ed-script with bad line number returns error, original file untouched
- ed-script with empty script is rejected
- ed-script when red binary is missing returns helpful error
- ed-script with both edits and ed_script set is rejected
- Multi-file ed-script batch: first file failure stops processing, earlier files committed
- Existing search/replace tests continue to pass (backwards compatible)

**chatd-side tests** (`coderd/x/chatd/chattool/editfiles_test.go`):

- Update existing tests to use ed_script
- Tool result contains unified diff in expected format
- Plan path protection still works with ed_script

**toolsdk tests** (`codersdk/toolsdk/toolsdk_test.go`):

- Update existing edit_file tests to use ed_script
- Singular tool maps EdScript to FileEdits correctly

Agent-side ed tests use real temp files (not `afero.MemMapFs`). Tests skip if `ed` is not available (`exec.LookPath` check in test setup).

**Artifact:** Test files with passing tests.
**Verification:** `make test RUN=TestEditFiles` passes (when ed is installed).

### Stage 6: Frontend Tool Rendering Update

The frontend currently builds diffs client-side from tool call args (search/replace pairs via `buildEditDiff` in `utils.ts`). With ed-script tool results, the diff is already computed and included in the tool result text.

Update the frontend to parse diffs from tool results:

1. Update the edit_files tool renderer in `Tool.tsx` to extract the unified diff from the tool result text (parse the `Edited <path>:\n\n```diff\n...\n```​` format)
2. Parse the extracted diff with `parsePatchFiles` from `@pierre/diffs`
3. Render with the existing `FileDiff` component
4. Keep `buildEditDiff` for backwards compatibility with older chat messages that used the search/replace format
5. Update `parseEditFilesArgs` to handle the new args shape for label rendering (file paths from `{path, ed_script}` entries)

**Artifact:** Updated frontend rendering that parses diffs from tool results.
**Verification:** Storybook stories for EditFilesTool render ed_script entries correctly.

### Stage 7: Git Path Tracking

The existing `HandleEditFiles` tracks edited paths via `api.pathStore.AddPaths` (verified in trace Claim 5). The tracking code iterates `req.Files` and reads `.Path`, so ed-script entries are tracked automatically. No code change needed, but add a test confirming ed-script paths appear in the path store.

**Artifact:** Test confirming path tracking for ed_script mode.
**Verification:** Test passes.

</details>

<details>
<summary>Research document</summary>

# Research: ed-style Syntax for the Agent edit_files Tool

## Problem Context

The coder agent's `edit_files` tool uses search-and-replace for file editing. The user wants to replace this with `ed`-style command syntax. For the prototype, the workspace agent implementation shells out to the `ed` binary.

### Current Architecture

**Two tool variants exist, both using the same underlying mechanism:**

chatd tool (`coderd/x/chatd/chattool/editfiles.go`):

```go
type EditFilesArgs struct {
    Files []workspacesdk.FileEdits `json:"files"`
}
```

toolsdk tool (`codersdk/toolsdk/toolsdk.go`):

```go
type WorkspaceEditFileArgs struct {
    Workspace string                  `json:"workspace"`
    Path      string                  `json:"path"`
    Edits     []workspacesdk.FileEdit `json:"edits"`
}
```

**SDK types (`codersdk/workspacesdk/agentconn.go:989-1002`):**

```go
type FileEdit struct {
    Search     string `json:"search"`
    Replace    string `json:"replace"`
    ReplaceAll bool   `json:"replace_all,omitempty"`
}

type FileEdits struct {
    Path  string     `json:"path"`
    Edits []FileEdit `json:"edits"`
}

type FileEditRequest struct {
    Files []FileEdits `json:"files"`
}
```

**Data flow:**

1. LLM emits `edit_files` tool call (JSON with search/replace pairs)
2. `chattool/editfiles.go` validates plan path constraints, forwards to `AgentConn.EditFiles()`
3. HTTP POST to `/api/v0/edit-files` on the workspace agent
4. `agent/agentfiles/files.go` reads file, applies `fuzzyReplace`, writes atomically via temp file + rename

**Fuzzy matching** (`agent/agentfiles/files.go`, `fuzzyReplace`): three cascading passes:

```text
1. Exact substring match (byte-for-byte)
2. Line-by-line match ignoring trailing whitespace
3. Line-by-line match ignoring all leading/trailing whitespace
```

### Current Limitations

- Agent must reproduce exact file content in the `search` field, consuming tokens
- For large blocks, the search string is verbose
- Cannot express "delete lines 10-20" or "insert after line 5" directly
- Ambiguity errors when search matches multiple locations

## ed Command Syntax

Verified by running `ed 1.18` on Ubuntu 22.04 (installed via `sudo apt-get install ed`).

**Key properties for LLM agent use:**

Addressing (line-number OR regex):

```text
5           line 5
1,10        lines 1 through 10
$           last line
/pattern/   first line matching regex (forward search)
```

Core commands (verified with actual ed invocations):

```text
[addr]a     append text after addressed line (input mode, end with ".")
[addr]i     insert text before addressed line (input mode, end with ".")
[addr1,addr2]c  change (replace) addressed lines (input mode, end with ".")
[addr1,addr2]d  delete addressed lines
[addr]s/old/new/[g]  substitute within addressed line(s)
w           write buffer to file
q           quit
```

**Scripting (verified):** ed reads commands from stdin:

```bash
printf '6s/hello/goodbye/\nw\nq\n' | ed -s /path/to/file
```

All five core commands tested and working:

```text
# substitute:   printf '6s/hello/goodbye/\nw\nq\n' | ed -s file     -> works
# delete:       printf '6d\nw\nq\n' | ed -s file                    -> works
# append:       printf '5a\n\tnew line\n.\nw\nq\n' | ed -s file     -> works
# change:       printf '6,7c\n\tnew content\n.\nw\nq\n' | ed -s file -> works
# regex addr:   printf '/hello/s/hello/greetings/\nw\nq\n' | ed -s file -> works
```

**Error behavior (verified):**

- Bad line number: outputs `?`, exits with code 1
- No regex match: outputs `?`, exits with code 1
- With `H` command first: prints human-readable error (e.g., "Invalid address")
- `-s` flag suppresses byte count output but still shows errors

**Known limitation: the "." terminator problem (verified).**
The `a`, `i`, `c` commands enter input mode, terminated by a line containing only `.`. If the text being inserted contains a bare `.` on its own line, ed prematurely exits input mode. Lines like `.gitignore`, `foo.`, or `.hidden` are fine; only a bare `.` (nothing else on the line) triggers this.

This is an edge case for code editing. It affects:

- Python's `Ellipsis` literal (though typically written as `...`, not `.`)
- Some config file formats
- GraphQL schema notation (uses `...` for fragment spreads)

For the prototype this is acceptable. The tool description should note this limitation.

**Availability (verified):**

- Ubuntu 22.04: in `main` repo, installed via `sudo apt-get update && sudo apt-get install -y ed`
- Initially appeared unavailable due to stale apt cache; works after `apt-get update`
- POSIX standard, available on all major Linux distributions
- For the prototype, require `ed` to be installed; return a clear error if missing

## Approach: Two-Layer Design

The change operates at two layers with different compatibility requirements:

**LLM-facing tools (chatd, toolsdk):** Replace the interface with ed-only. The tool schema exposes `ed_script`, not search/replace. The LLM sees only ed syntax.

**Workspace agent HTTP API (`/api/v0/edit-files`):** Backwards compatible. Add `EdScript` as an additional field to `FileEdits`. The existing search/replace mechanism stays. The handler dispatches based on which fields are populated.

SDK type change:

```go
type FileEdits struct {
    Path     string     `json:"path"`
    Edits    []FileEdit `json:"edits,omitempty"`
    EdScript string     `json:"ed_script,omitempty"`
}
```

**Agent-side handler change (`agent/agentfiles/files.go`):**

The handler gains ed execution alongside the existing search/replace:

- If `EdScript` is set: copy file to temp, run ed against temp, rename on success
- If `Edits` is set: existing fuzzyReplace path (unchanged)
- If both or neither: reject

**chatd tool change (`coderd/x/chatd/chattool/editfiles.go`):**

The tool description documents ed command syntax with a compact reference.

**toolsdk singular tool** (`codersdk/toolsdk/toolsdk.go`, `WorkspaceEditFile`):

- `WorkspaceEditFileArgs` is a flat struct (NOT using `FileEdits`), verified:

  ```go
  // codersdk/toolsdk/toolsdk.go:1662-1666
  type WorkspaceEditFileArgs struct {
      Workspace string                  `json:"workspace"`
      Path      string                  `json:"path"`
      Edits     []workspacesdk.FileEdit `json:"edits"`
  }
  ```

- The handler manually constructs `FileEdits`:

  ```go
  // codersdk/toolsdk/toolsdk.go:1713-1718
  err = conn.EditFiles(ctx, workspacesdk.FileEditRequest{
      Files: []workspacesdk.FileEdits{{
          Path:  args.Path,
          Edits: args.Edits,
      }},
  })
  ```

- Adding `EdScript` to `FileEdits` does nothing for this tool. `WorkspaceEditFileArgs` needs its own `EdScript` field, and the handler needs to map it.

**toolsdk multi-file tool** (`codersdk/toolsdk/toolsdk.go`, `WorkspaceEditFiles`):

- `WorkspaceEditFilesArgs` uses `[]workspacesdk.FileEdits` directly:

  ```go
  // codersdk/toolsdk/toolsdk.go:1731-1734
  type WorkspaceEditFilesArgs struct {
      Workspace string                   `json:"workspace"`
      Files     []workspacesdk.FileEdits `json:"files"`
  }
  ```

- This tool gets `EdScript` automatically when the `FileEdits` type changes. The handler passes `args.Files` through directly.
- The schema `Properties` maps and `required` arrays are hand-written and need manual updates.

**Schema `required` arrays:**

- `WorkspaceEditFile` has `Required: []string{"path", "workspace", "edits"}` (line 1701)
- `WorkspaceEditFiles` file items have `"required": []string{"path", "edits"}` (line 1779)
- When `ed_script` is an alternative to `edits`, `edits` can no longer be unconditionally required. Both required arrays must be updated to remove `"edits"`.

**What this approach makes easy:**

- Line deletion without content reproduction: `{"path": "/foo.go", "ed_script": "10,20d"}`
- Insertion at a point: `{"path": "/foo.go", "ed_script": "5a\nnew line\n."}`
- Regex substitution: `{"path": "/foo.go", "ed_script": "1,$s/oldAPI/newAPI/g"}`
- Multiple operations in one atomic script

**What this approach makes hard:**

- LLM must track line numbers (known LLM weakness, mitigated by regex addressing and atomic scripts)
- Cannot insert a bare `.` on its own line (ed input mode limitation)
- Multi-file edits with ed_script require one script per file

## Tool Description Design

The tool description must be compact enough to not waste context, complete enough that the LLM can construct valid ed scripts, and clear about what commands are available.

Draft tool description:

```text
Edit one or more files in the workspace using ed commands.
Each file entry contains a path and an ed script.

ed quick reference:
  [line]a    append text after line (end input with "." alone on a line)
  [line]i    insert text before line (end input with "." alone on a line)
  [from,to]c change lines (end input with "." alone on a line)
  [from,to]d delete lines
  [line]s/old/new/   substitute first match on line
  [line]s/old/new/g  substitute all matches on line
  /regex/    address by regex match instead of line number
  1,$        address range: all lines

Do NOT include w (write) or q (quit) commands; they are added
automatically. Lines are 1-indexed. A bare "." on its own line
ends input mode for a/i/c commands.

Example - delete lines 10-20:
  {"files": [{"path": "/abs/path", "ed_script": "10,20d"}]}
Example - insert after line 5:
  {"files": [{"path": "/abs/path", "ed_script": "5a\nnew line here\n."}]}
Example - substitute all occurrences:
  {"files": [{"path": "/abs/path", "ed_script": "1,$s/oldName/newName/g"}]}
```

## Atomicity

**ed is NOT atomic.** Verified via `strace`: ed truncates and overwrites the file in place:

```text
openat("/tmp/ed-atomic-test.txt", O_WRONLY|O_CREAT|O_TRUNC) = 4
```

If ed is killed mid-write, the file is left corrupted. The existing codebase uses `atomicWrite` (temp file + rename) specifically to prevent this.

**Solution:** Run ed against a temp copy, then rename over the original:

1. Copy original to temp file in same directory (`.{base}.tmp.{uuid}`)
2. Run `ed -s <temp>` with the user's script
3. If ed exits 0: preserve permissions, rename temp over original (atomic on same filesystem)
4. If ed exits != 0: delete temp, return error, original untouched

This preserves the same atomicity guarantee as the existing `atomicWrite`. Verified by testing: the original file is never modified until the rename succeeds.

Cross-file atomicity remains the same as before: if a 3-file batch fails on file 2, file 1 is already committed. The existing code acknowledges this:

```go
// Phase 2: write all files via atomicWrite. A failure here
// (e.g. disk full) can leave earlier files committed. True
// cross-file atomicity would require filesystem transactions.
```

## Security: ed Shell Escapes

ed's `!` command executes arbitrary shell commands. Verified:

```text
printf '!echo ESCAPED\nq\n' | ed -s /tmp/test.txt
-> ESCAPED (exit 0)
```

ed's `r` command reads arbitrary files into the buffer:

```text
printf 'r /etc/hostname\n,p\nQ\n' | ed -s /tmp/test.txt
-> (contents of /etc/hostname appended)
```

This is not a privilege escalation (the agent already has the `execute` tool), but it's unnecessary attack surface.

**Solution: use `red` (restricted ed).** `red` is bundled with GNU ed (same package, `/usr/bin/red`). Verified behavior:

- Blocks `!` shell commands: `printf '!echo X\nq\n' | red -s file` -> `?` (exit 1)
- Blocks `r` from other directories: `printf 'r /etc/hostname\nQ\n' | red -s file` -> `?` (exit 1)
- Only edits files in the current directory (relative paths only)
- All editing commands (a, i, c, d, s) work normally

Since the handler copies the original to a temp file in the same directory, it can set the working directory to that directory and invoke `red -s <basename>` with a relative path. Verified working.

## Non-existent File Behavior

Verified: ed (and red) error on non-existent files:

```text
printf 'H\n1i\nhello\n.\nw\nq\n' | ed -s /tmp/nonexistent.txt
-> Cannot open input file (exit 1)
```

The handler runs ed against a temp COPY of the original. If the original doesn't exist, the copy step fails before ed is invoked. The LLM should use `write_file` for file creation.

## Diff Generation and Transport

The agent has both the original file and the modified temp file on disk before the rename. It computes a unified diff by running `diff -u <original> <temp>` (universally available, part of GNU diffutils). Verified:

```text
diff -u /tmp/orig.go /tmp/modified.go
--- /tmp/orig.go  2026-04-14 ...
+++ /tmp/modified.go  2026-04-14 ...
@@ -3,6 +3,6 @@
 import "fmt"
 
 func main() {
-    fmt.Println("hello")
+    fmt.Println("goodbye")
     fmt.Println("world")
 }
(exit code 1 = files differ, 0 = identical)
```

**Transport:** The `AgentConn.EditFiles` method changes from returning `error` to `(FileEditResponse, error)`. The new `FileEditResponse` carries per-file diffs from the agent to the chatd tool.

**Presentation (Zed pattern):** The chatd tool formats the tool result as plain text with a status line and unified diff per file, following the Zed editor convention:

```text
Edited /path/to/file.go:

` ` `diff
@@ -5,3 +5,4 @@
 func main() {
-    fmt.Println("hello")
+    fmt.Println("goodbye")
 }
` ` `
```

The LLM sees the diff in its context (useful for verifying edits worked). The frontend parses the diff from the tool result string for rendering.

**D1a: Workspace agent API remains backwards compatible.**

- Classification: Human decision
- Human's exact words: "Workspace agent side should remain backwards compatible with the old API... The workspace agent side gains the ed script support in addition."
- Chosen option: `FileEdits` gains `EdScript` as additional field; `Edits` stays

**D2: Shell out to ed binary for prototype.**

- Classification: Human decision
- Human's exact words: "for prototyping, the workspace agent implementation can shell out to ed tool with the edit command provided by the agent"
- Chosen option: `os/exec` to pipe script to `ed -s <path>`

**D3: Command subset is {a, i, c, d, s}.**

- Classification: Agent-recommended
- Reasoning: These cover the operations that search/replace handles poorly (delete, insert at position) plus the operation search/replace already handles well (substitute). Other ed commands (`m`, `t`, `j`, `k`, `u`, `g`) add marginal value for LLM agent use and increase the tool description length. The LLM can always use the `execute` tool to run arbitrary ed commands if needed.

**D4: Require ed binary, error clearly if missing.**

- Classification: Agent-recommended
- Reasoning: This is a prototype. The `ed` package is in Ubuntu's `main` repo and available via `apt-get install ed` on all standard workspace images. Verified installable on Ubuntu 22.04. The handler checks `exec.LookPath("ed")` and returns a helpful error message if not found.

**D5: Auto-append w and q commands.**

- Classification: Agent-recommended
- Reasoning: Reduces error surface. The LLM doesn't need to remember to write and quit. The handler prepends `H\n` and appends `\nw\nq\n`. If the script already ends with `w\nq`, the duplicate is harmless. A mid-script error means ed continues processing and the appended `w` writes the partially-edited buffer. However, because the handler runs ed against a temp copy and only renames on exit code 0, and ed exits 1 on any mid-script error (verified), partial edits in the temp file are discarded. The original file is safe.

**D6: Use `-s` flag (suppress byte counts) and prepend `H` (verbose errors).**

- Classification: Agent-recommended
- Reasoning: Without `-s`, ed prints byte counts on every `w` command, cluttering tool output. Without `H`, errors are just `?`. Verified: `H` as the first command enables human-readable error messages. The handler prepends `H\n` and uses `ed -s` so the LLM gets useful error feedback.

</details>

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻
