### PR TITLE
ci: add build provenance attestation for release binaries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -488,6 +488,22 @@ jobs:
           subject-digest: ${{ steps.docker_digests.outputs.latest_digest }}
           push-to-registry: true
 
+      - name: GitHub Attestation for release binaries
+        id: attest_binaries
+        if: ${{ !inputs.dry_run }}
+        continue-on-error: true
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-path: |
+            ./build/*.tar.gz
+            ./build/*.zip
+            ./build/*.deb
+            ./build/*.rpm
+            ./build/*.apk
+            ./build/*_installer.exe
+            ./build/*_helm_*.tgz
+            ./build/provisioner_helm_*.tgz
+
       # Report attestation failures but don't fail the workflow
       - name: Check attestation status
         if: ${{ !inputs.dry_run }}
@@ -500,6 +516,9 @@ jobs:
           fi
           if [[ "${{ steps.attest_latest.outcome }}" == "failure" && "${{ steps.attest_latest.conclusion }}" != "skipped" ]]; then
             echo "::warning::GitHub attestation for latest image failed"
+          fi
+          if [[ "${{ steps.attest_binaries.outcome }}" == "failure" && "${{ steps.attest_binaries.conclusion }}" != "skipped" ]]; then
+            echo "::warning::GitHub attestation for release binaries failed"
           fi
 
       - name: Generate offline docs


### PR DESCRIPTION
## Problem

The release workflow attests Docker container images (via `actions/attest` and `cosign`), but binary release assets (`.tar.gz`, `.zip`, `.deb`, `.rpm`, `.apk`, `.exe`) have no supply-chain provenance attestation. Enterprise customers in air-gapped environments who rely on these binaries cannot cryptographically verify *where* and *how* they were built.

## Fix

Add a GitHub Attestation step using `actions/attest@v4.1.0` (same pinned version already in the workflow) to generate SLSA build provenance for all binary release artifacts.

## Changes

- Add `GitHub Attestation for release binaries` step after Docker attestations, covering `*.tar.gz`, `*.zip`, `*.deb`, `*.rpm`, `*.apk`, and `*_installer.exe`
- Update `Check attestation status` step to report binary attestation failures
- Uses `continue-on-error: true` to match the existing Docker attestation pattern — failures warn but don't block the release

## Verification

After this ships, users can verify any release binary with:

```bash
gh attestation verify coder_<version>_linux_amd64.tar.gz --owner coder
```

> [!NOTE]
> The workflow already has the required `id-token: write` and `attestations: write` permissions. No new secrets or permissions needed.

> 🤖 This PR was created with the help of Coder Agents, and needs a human review.  🧑💻