### PR TITLE
feat: support AWS SDK default credential chain for Bedrock authentication

### DIFF
--- a/docs/ai-coder/ai-gateway/setup.md
+++ b/docs/ai-coder/ai-gateway/setup.md
@@ -55,7 +55,9 @@ Set the following when routing [Amazon Bedrock](https://coder.com/docs/reference
 
 **Required:**
 
-- `CODER_AIBRIDGE_BEDROCK_REGION` or `--aibridge-bedrock-region`
+- `CODER_AIBRIDGE_BEDROCK_REGION` or `--aibridge-bedrock-region`.
+Alternatively, set `CODER_AIBRIDGE_BEDROCK_BASE_URL` or `--aibridge-bedrock-base-url` to a full URL (e.g., when routing through a proxy between AI Gateway and AWS Bedrock or using a non-standard endpoint that doesn't follow the `https://bedrock-runtime.<region>.amazonaws.com` format).
+If both are set, `CODER_AIBRIDGE_BEDROCK_BASE_URL` takes precedence.
 - `CODER_AIBRIDGE_BEDROCK_MODEL` or `--aibridge-bedrock-model`
 - `CODER_AIBRIDGE_BEDROCK_SMALL_FAST_MODEL` or `--aibridge-bedrock-small-fast-model`
 
@@ -63,11 +65,6 @@ Set the following when routing [Amazon Bedrock](https://coder.com/docs/reference
 
 - `CODER_AIBRIDGE_BEDROCK_ACCESS_KEY` or `--aibridge-bedrock-access-key`
 - `CODER_AIBRIDGE_BEDROCK_ACCESS_KEY_SECRET` or `--aibridge-bedrock-access-key-secret`
-
-> [!NOTE]
-> `CODER_AIBRIDGE_BEDROCK_BASE_URL` or `--aibridge-bedrock-base-url` may be used instead of `CODER_AIBRIDGE_BEDROCK_REGION`/`--aibridge-bedrock-region`
-> if you would like to specify a URL which does not follow the form of `https://bedrock-runtime.<region>.amazonaws.com` - for example if using a
-> proxy between AI Gateway and AWS Bedrock.
 
 #### Authentication
 

--- a/docs/ai-coder/ai-gateway/setup.md
+++ b/docs/ai-coder/ai-gateway/setup.md
@@ -53,18 +53,43 @@ Anthropic does not allow [API keys](https://console.anthropic.com/settings/keys)
 
 Set the following when routing [Amazon Bedrock](https://coder.com/docs/reference/cli/server#--aibridge-bedrock-region) traffic through AI Gateway:
 
+**Required:**
+
 - `CODER_AIBRIDGE_BEDROCK_REGION` or `--aibridge-bedrock-region`
-- `CODER_AIBRIDGE_BEDROCK_ACCESS_KEY` or `--aibridge-bedrock-access-key`
-- `CODER_AIBRIDGE_BEDROCK_ACCESS_KEY_SECRET` or `--aibridge-bedrock-access-key-secret`
 - `CODER_AIBRIDGE_BEDROCK_MODEL` or `--aibridge-bedrock-model`
 - `CODER_AIBRIDGE_BEDROCK_SMALL_FAST_MODEL` or `--aibridge-bedrock-small-fast-model`
 
+**Optional:**
+
+- `CODER_AIBRIDGE_BEDROCK_ACCESS_KEY` or `--aibridge-bedrock-access-key`
+- `CODER_AIBRIDGE_BEDROCK_ACCESS_KEY_SECRET` or `--aibridge-bedrock-access-key-secret`
+
 > [!NOTE]
 > `CODER_AIBRIDGE_BEDROCK_BASE_URL` or `--aibridge-bedrock-base-url` may be used instead of `CODER_AIBRIDGE_BEDROCK_REGION`/`--aibridge-bedrock-region`
-if you would like to specify a URL which does not follow the form of `https://bedrock-runtime.<region>.amazonaws.com` - for example if using a
-proxy between AI Gateway and AWS Bedrock.
+> if you would like to specify a URL which does not follow the form of `https://bedrock-runtime.<region>.amazonaws.com` - for example if using a
+> proxy between AI Gateway and AWS Bedrock.
 
-#### Obtaining Bedrock credentials
+#### Authentication
+
+AI Gateway supports two credential configuration paths:
+
+##### AWS SDK default credential chain (recommended)
+
+When no credentials are set in AI Gateway config, the AWS SDK resolves them automatically from the environment.
+This includes IAM Roles (instance profiles, IRSA, ECS task roles), shared config files, environment variables, SSO, and more.
+
+**IAM Roles are the recommended approach** when AI Gateway runs on AWS infrastructure.
+Attach an IAM Role with Bedrock permissions to the compute running AI Gateway (EC2 instance, EKS pod via IRSA, or ECS task), no credentials need to be configured in AI Gateway itself.
+
+The IAM Role must have permission to invoke the Bedrock models configured for AI Gateway (`bedrock:InvokeModel` and `bedrock:InvokeModelWithResponseStream`).
+See [Amazon Bedrock identity-based policy examples](https://docs.aws.amazon.com/bedrock/latest/userguide/security_iam_id-based-policy-examples.html) for policy examples,
+and [AWS IAM role creation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-service.html) for general guidance on attaching roles to AWS services.
+
+This aligns with [AWS best practices](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html) for using temporary credentials instead of long-lived access keys.
+
+##### Static credentials
+
+For deployments when explicit credentials are preferred, provide an access key and secret for an IAM User:
 
 1. **Choose a region** where you want to use Bedrock.
 

--- a/enterprise/cli/aibridged.go
+++ b/enterprise/cli/aibridged.go
@@ -159,7 +159,11 @@ func bedrockConfigFromProvider(p codersdk.AIBridgeProviderConfig) *aibridge.AWSB
 }
 
 func getBedrockConfig(cfg codersdk.AIBridgeBedrockConfig) *aibridge.AWSBedrockConfig {
-	if cfg.Region.String() == "" && cfg.BaseURL.String() == "" && cfg.AccessKey.String() == "" && cfg.AccessKeySecret.String() == "" {
+	// Bedrock is considered disabled when no region or base URL is configured.
+	// Static credentials are optional. When not provided, the AWS SDK default
+	// credential chain resolves credentials (environment variables, shared config,
+	// IAM roles, etc.).
+	if cfg.Region.String() == "" && cfg.BaseURL.String() == "" {
 		return nil
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -504,7 +504,7 @@ require (
 	github.com/aymanbagabas/go-udiff v0.4.1
 	github.com/brianvoe/gofakeit/v7 v7.14.0
 	github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225
-	github.com/coder/aibridge v1.1.3-0.20260417133125-bb7fced4621a
+	github.com/coder/aibridge v1.1.3-0.20260420072253-d474d6813420
 	github.com/coder/aisdk-go v0.0.9
 	github.com/coder/boundary v0.8.4-0.20260304164748-566aeea939ab
 	github.com/coder/preview v1.0.8

--- a/go.mod
+++ b/go.mod
@@ -504,7 +504,7 @@ require (
 	github.com/aymanbagabas/go-udiff v0.4.1
 	github.com/brianvoe/gofakeit/v7 v7.14.0
 	github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225
-	github.com/coder/aibridge v1.1.2
+	github.com/coder/aibridge v1.1.3-0.20260417133125-bb7fced4621a
 	github.com/coder/aisdk-go v0.0.9
 	github.com/coder/boundary v0.8.4-0.20260304164748-566aeea939ab
 	github.com/coder/preview v1.0.8

--- a/go.mod
+++ b/go.mod
@@ -498,7 +498,7 @@ require (
 	github.com/anthropics/anthropic-sdk-go v1.19.0
 	github.com/brianvoe/gofakeit/v7 v7.14.0
 	github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225
-	github.com/coder/aibridge v1.1.2
+	github.com/coder/aibridge v1.1.3-0.20260417133125-bb7fced4621a
 	github.com/coder/aisdk-go v0.0.9
 	github.com/coder/boundary v0.8.4-0.20260304164748-566aeea939ab
 	github.com/coder/preview v1.0.8

--- a/go.sum
+++ b/go.sum
@@ -312,8 +312,8 @@ github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 h1:aBangftG7EVZoUb69Os
 github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2/go.mod h1:qwXFYgsP6T7XnJtbKlf1HP8AjxZZyzxMmc+Lq5GjlU4=
 github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225 h1:tRIViZ5JRmzdOEo5wUWngaGEFBG8OaE1o2GIHN5ujJ8=
 github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225/go.mod h1:rNLVpYgEVeu1Zk29K64z6Od8RBP9DwqCu9OfCzh8MR4=
-github.com/coder/aibridge v1.1.3-0.20260417133125-bb7fced4621a h1:/DTviqLGz01034h/HpuUqLqZiIrHj+jZKUEOHj/UdEk=
-github.com/coder/aibridge v1.1.3-0.20260417133125-bb7fced4621a/go.mod h1:k2/JzBF/jW2h4xKYyXXy9gbD7qaf0kKvfXxwA2JCYxE=
+github.com/coder/aibridge v1.1.3-0.20260420072253-d474d6813420 h1:vSgHLbHvty3Y9DXAKZimP/GXKI23o52PlTC+EJYh6tM=
+github.com/coder/aibridge v1.1.3-0.20260420072253-d474d6813420/go.mod h1:k2/JzBF/jW2h4xKYyXXy9gbD7qaf0kKvfXxwA2JCYxE=
 github.com/coder/aisdk-go v0.0.9 h1:Vzo/k2qwVGLTR10ESDeP2Ecek1SdPfZlEjtTfMveiVo=
 github.com/coder/aisdk-go v0.0.9/go.mod h1:KF6/Vkono0FJJOtWtveh5j7yfNrSctVTpwgweYWSp5M=
 github.com/coder/anthropic-sdk-go v0.0.0-20260415160422-a31d7d0e7067 h1:v1RAkUO21u0QH6UlUueSHMbgFf++BZZW41Rj6LM2eWo=

--- a/go.sum
+++ b/go.sum
@@ -312,8 +312,8 @@ github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 h1:aBangftG7EVZoUb69Os
 github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2/go.mod h1:qwXFYgsP6T7XnJtbKlf1HP8AjxZZyzxMmc+Lq5GjlU4=
 github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225 h1:tRIViZ5JRmzdOEo5wUWngaGEFBG8OaE1o2GIHN5ujJ8=
 github.com/coder/agentapi-sdk-go v0.0.0-20250505131810-560d1d88d225/go.mod h1:rNLVpYgEVeu1Zk29K64z6Od8RBP9DwqCu9OfCzh8MR4=
-github.com/coder/aibridge v1.1.2 h1:DLz0B7j9qzGj/nVQUbWDluux2c/y7+a7xGgc+63uOUM=
-github.com/coder/aibridge v1.1.2/go.mod h1:k2/JzBF/jW2h4xKYyXXy9gbD7qaf0kKvfXxwA2JCYxE=
+github.com/coder/aibridge v1.1.3-0.20260417133125-bb7fced4621a h1:/DTviqLGz01034h/HpuUqLqZiIrHj+jZKUEOHj/UdEk=
+github.com/coder/aibridge v1.1.3-0.20260417133125-bb7fced4621a/go.mod h1:k2/JzBF/jW2h4xKYyXXy9gbD7qaf0kKvfXxwA2JCYxE=
 github.com/coder/aisdk-go v0.0.9 h1:Vzo/k2qwVGLTR10ESDeP2Ecek1SdPfZlEjtTfMveiVo=
 github.com/coder/aisdk-go v0.0.9/go.mod h1:KF6/Vkono0FJJOtWtveh5j7yfNrSctVTpwgweYWSp5M=
 github.com/coder/anthropic-sdk-go v0.0.0-20260415160422-a31d7d0e7067 h1:v1RAkUO21u0QH6UlUueSHMbgFf++BZZW41Rj6LM2eWo=


### PR DESCRIPTION
## Description

Makes AWS Bedrock credentials optional. When `AccessKey` and `AccessKeySecret` are not set, AI Bridge falls back to the AWS SDK default credential chain, which supports IAM Roles (instance profiles, IRSA, ECS task roles), SSO, shared credentials files, and environment variables.

This allows AI Bridge to authenticate with AWS Bedrock using:
- Permanent credentials (access key + secret) as before
- IAM Roles, shared config files, environment variables, SSO, etc, via the SDK default credential chain

Depends on: https://github.com/coder/aibridge/pull/265
Related to: https://github.com/coder/aibridge/issues/144 
Related to: https://linear.app/codercom/issue/AIGOV-67

_Disclaimer: initially produced by Claude Opus 4.6, modified and reviewed by @ssncferreira ._