### PR TITLE
feat(.agents/skills/deep-review): add GitHub bridge scripts

### DIFF
--- a/.agents/skills/deep-review/SKILL.md
+++ b/.agents/skills/deep-review/SKILL.md
@@ -39,37 +39,27 @@ export REVIEW_DIR="/tmp/deep-review/$(date +%s)"
 mkdir -p "$REVIEW_DIR"
 ```
 
-**Re-review detection.** Check if you or a previous agent session already reviewed this PR:
+**Re-review detection.** Fetch the full PR context using the fetch script:
 
 ```sh
-gh pr view {number} --json reviews --jq '.reviews[] | select(.body | test("P[0-4]|\\*\\*Obs\\*\\*|\\*\\*Nit\\*\\*")) | .submittedAt' | head -1
+.agents/skills/deep-review/scripts/fetch-pr-context.sh \
+  --pr {number} --output "$REVIEW_DIR/pr-context.json"
 ```
 
-If a prior agent review exists, you must produce a prior-findings classification table before proceeding. This is not optional — the table is an input to step 3 (reviewer prompts). Without it, reviewers will re-discover resolved findings.
+Read `$REVIEW_DIR/pr-context.json` to detect prior agent reviews: scan `reviews[].body` for P0–P4/Obs/Nit patterns. The script skips resolved threads, so findings from a prior round that were addressed simply don't appear in the output.
 
-1. Read every author response since the last review (inline replies, PR comments, commit messages).
-2. Diff the branch to see what changed since the last review.
-3. Engage with any author questions before re-raising findings.
-4. Write `$REVIEW_DIR/prior-findings.md` with this format:
+Unresolved threads from prior agent reviews *are* the carry-forward findings. Author replies are threaded under them via `in_reply_to_id`. Classify each unresolved thread as:
 
-```markdown
-# Prior findings from round {N}
+- **Contested**: unresolved thread with an author reply. The author disagreed or raised a constraint — engage with their argument before re-raising.
+- **No response**: unresolved thread without an author reply.
 
-| Finding | Author response | Status |
-|---------|----------------|--------|
-| P1 `file.go:42` wire-format break | Acknowledged, pushed fix in abc123 | Resolved |
-| P2 `handler.go:15` missing auth check | "Middleware handles this" — see comment | Contested |
-| P3 `db.go:88` naming | Agreed, will fix | Acknowledged |
+Only **Contested** and **No response** findings carry forward to the new review. Resolved threads (addressed findings) are excluded by the script and must not be re-raised.
+
+Save the diff once for all reviewers:
+
+```sh
+gh pr diff {number} > "$REVIEW_DIR/pr.diff"
 ```
-
-Classify each finding as:
-
-- **Resolved**: author pushed a code fix. Verify the fix addresses the finding's specific concern — not just that code changed in the relevant area. Check that the fix doesn't introduce new issues.
-- **Acknowledged**: author agreed but deferred.
-- **Contested**: author disagreed or raised a constraint. Write their argument in the table.
-- **No response**: author didn't address it.
-
-Only **Contested** and **No response** findings carry forward to the new review. Resolved and Acknowledged findings must not be re-raised.
 
 **Scope the diff.** Get the file list from the diff, PR, or user. Skim for intent and note which layers are touched (frontend, backend, database, auth, concurrency, tests, docs).
 
@@ -120,9 +110,9 @@ Tier 2 file filters:
 
 ## 3. Spawn reviewers
 
-Each reviewer writes findings to `$REVIEW_DIR/{role-name}.md` where `{role-name}` is the kebab-cased role name (e.g. `test-auditor`, `go-architect`). For Modernization Reviewer instances, qualify with the language: `modernization-reviewer-go.md`, `modernization-reviewer-ts.md`, `modernization-reviewer-react.md`. The orchestrator does not read reviewer findings from the subagent return text — it reads the files in step 4.
+Each reviewer writes findings to `$REVIEW_DIR/{role-name}.json` where `{role-name}` is the kebab-cased role name (e.g. `test-auditor`, `go-architect`). For Modernization Reviewer instances, qualify with the language: `modernization-reviewer-go.json`, `modernization-reviewer-ts.json`, `modernization-reviewer-react.json`. The orchestrator does not read reviewer findings from the subagent return text — it reads the files in step 4.
 
-Spawn all Tier 1 and Tier 2 reviewers in parallel. Give each reviewer a reference (PR number, branch name), not the diff content. The reviewer fetches the diff itself. Reviewers are read-only — no worktrees needed.
+Spawn all Tier 1 and Tier 2 reviewers in parallel. Reviewers read the shared diff from `$REVIEW_DIR/pr.diff` and use `add-finding.sh` to produce structured JSON output. Reviewers are read-only — no worktrees needed.
 
 **Tier 1 prompt:**
 
@@ -135,8 +125,9 @@ You are the {Role Name} reviewer. Read your methodology in
 Follow the review instructions in
 `.agents/skills/deep-review/structural-reviewer-prompt.md`.
 
-Review: {PR number / branch / commit range}.
-Output file: {REVIEW_DIR}/{role-name}.md
+Review PR #{number}.
+Diff file: {REVIEW_DIR}/pr.diff
+Output file: {REVIEW_DIR}/{role-name}.json
 ```
 
 **Tier 2 prompt:**
@@ -150,9 +141,10 @@ You are the {Role Name} reviewer. Read your methodology in
 Follow the review instructions in
 `.agents/skills/deep-review/nit-reviewer-prompt.md`.
 
-Review: {PR number / branch / commit range}.
+Review PR #{number}.
+Diff file: {REVIEW_DIR}/pr.diff
 File scope: {filter from step 2}.
-Output file: {REVIEW_DIR}/{role-name}.md
+Output file: {REVIEW_DIR}/{role-name}.json
 ```
 
 For Modernization Reviewer instances, add the language reference after the methodology line:
@@ -163,21 +155,30 @@ For Modernization Reviewer instances, add the language reference after the metho
 
 For re-reviews, append to both Tier 1 and Tier 2 prompts:
 
-> Prior findings and author responses are in {REVIEW_DIR}/prior-findings.md. Read it before reviewing. Do not re-raise Resolved or Acknowledged findings.
+> Unresolved threads from prior agent reviews are in {REVIEW_DIR}/pr-context.json under `review_comments`. Scan for P0–P4/Obs/Nit patterns in comment bodies. Threads with author replies (check `in_reply_to_id` chains) are contested — engage with the author's argument. Threads without replies had no response. Do not re-raise findings whose threads were resolved (they are already excluded from the file).
 
 ## 4. Cross-check findings
 
 ### 4a. Read findings from files
 
-Read each reviewer's output file from `$REVIEW_DIR/` one at a time. One file per read — do not batch multiple reviewer files in parallel. Batching causes reviewer voices to blend in the context window, leading to misattribution (grabbing phrasing from one reviewer and attributing it to another).
+Compile all reviewer output into a single inventory:
 
-For each file:
+```sh
+.agents/skills/deep-review/scripts/compile-findings.sh \
+  --dir "$REVIEW_DIR" --output "$REVIEW_DIR/findings.json"
+```
+
+The orchestrator reads `findings.json` for cross-check work. Convergent findings are pre-identified and max severity is pre-computed. The orchestrator still does all the intellectual cross-check work in step 4b.
+
+The orchestrator should still read each reviewer's JSON file individually during cross-check (step 4b) when it needs the full evidence text. `findings.json` gives the inventory and convergence map; the individual files remain the source of record for quoting. Read one reviewer file at a time — do not batch multiple reviewer files in parallel. Batching causes reviewer voices to blend in the context window, leading to misattribution (grabbing phrasing from one reviewer and attributing it to another).
+
+For each reviewer file:
 
 1. Read the file.
 2. List each finding with its severity, location, and one-line summary.
 3. Note the reviewer's exact evidence line for each finding.
 
-If a file says "No findings," record that and move on. If a file is missing (reviewer crashed or timed out), note the gap and proceed — do not stall or silently drop the reviewer's perspective.
+If a file is an empty array (`[]`), record "No findings" and move on. If a file is missing (reviewer crashed or timed out), note the gap and proceed — do not stall or silently drop the reviewer's perspective.
 
 After reading all files, you have a finding inventory. Proceed to cross-check.
 
@@ -295,51 +296,47 @@ P3 findings and observations can be one-liners. Group multiple nits on the same 
 
 For P0 or P1 findings, add a note in the review body: "This review contains findings that may need attention before merge."
 
-**Posting via GitHub API.**
+**Posting via `post-review.sh`.**
 
-The `gh api` endpoint for posting reviews routes through GraphQL by default. Field names differ from the REST API docs:
-
-- Use `position` (diff-relative line number), not `line` + `side`. `side` is not a valid field in the GraphQL schema.
-- `subject_type: "file"` is not recognized. Pin file-level comments to `position: 1` instead.
-- Use `-X POST` with `--input` to force REST API routing.
-
-To compute positions: save the PR diff to a file, then count lines from the first `@@` hunk header of each file's diff section. For new files, position = line number + 1 (the hunk header is position 1, first content line is position 2).
-
-```sh
-gh pr diff {number} > /tmp/pr.diff
-```
-
-Submit:
-
-```sh
-gh api -X POST \
-  repos/{owner}/{repo}/pulls/{number}/reviews \
-  --input review.json
-```
-
-Where `review.json`:
+The orchestrator builds a review JSON matching the `post-review.sh` input schema, using source file line numbers (not diff positions):
 
 ```json
 {
-    "event": "COMMENT",
-    "body": "Summary of what's good and what to look at.\n1 P2, 1 P3 across 2 inline comments.",
-    "comments": [
-        {
-            "path": "file.go",
-            "position": 42,
-            "body": "**P1** Finding... *(Reviewer Role)*\n\n> Evidence..."
-        },
-        {
-            "path": "other.go",
-            "position": 1,
-            "body": "**P2** Cross-file finding... *(Reviewer Role)*\n\n> Evidence..."
-        }
-    ]
+  "event": "COMMENT",
+  "body": "Review summary...",
+  "comments": [
+    {
+      "path": "file.go",
+      "line": 42,
+      "body": "**P1** Finding... *(Reviewer Role)*\n\n> Evidence..."
+    }
+  ],
+  "replies": [
+    {
+      "in_reply_to_id": 456,
+      "body": "Response to existing comment..."
+    }
+  ],
+  "resolve_thread_ids": ["thread-ids-for-resolved-findings"]
 }
 ```
+
+Then post:
+
+```sh
+.agents/skills/deep-review/scripts/post-review.sh \
+  --pr {number} --input "$REVIEW_DIR/review.json" \
+  --diff "$REVIEW_DIR/pr.diff"
+```
+
+- `comments[].line` uses source file line numbers — the script handles diff position computation internally.
+- `replies` are for responding to existing review threads (e.g. answering author questions or acknowledging contested findings).
+- `resolve_thread_ids` resolves prior review threads for findings that are now addressed. Thread IDs come from `pr-context.json` review comments' `thread_id` field. Use this during re-reviews to close threads for findings the author has fixed.
 
 **Tone guidance.** Frame design concerns as questions: "Could we use X instead?" — be direct only for correctness issues. Hedge design, not bugs. Build concrete scenarios to make concerns tangible. When uncertain, say so. See `.claude/docs/PR_STYLE_GUIDE.md` for PR conventions.
 
 ## Follow-up
 
 After posting the review, monitor the PR for author responses. If the author pushes fixes or responds to findings, consider running a re-review (this skill, starting from step 1 with the re-review detection path). Allow time for the author to address multiple findings before re-reviewing — don't trigger on each individual response.
+
+During re-reviews, the orchestrator should resolve threads for findings that are now addressed by including their `thread_id` values in `resolve_thread_ids`. This keeps the PR conversation clean — resolved findings are collapsed on GitHub and excluded from future `fetch-pr-context.sh` output.

--- a/.agents/skills/deep-review/nit-reviewer-prompt.md
+++ b/.agents/skills/deep-review/nit-reviewer-prompt.md
@@ -1,30 +1,29 @@
-Get the diff for the review target specified in your prompt, filtered to the file scope specified, then review it.
-
-- **PR:** `gh pr diff {number} -- {file filter from prompt}`
-- **Branch:** `git diff origin/main...{branch} -- {file filter from prompt}`
-- **Commit range:** `git diff {base}..{tip} -- {file filter from prompt}`
+Read the diff from the file path specified in your prompt, filtered to the file scope specified. To filter, extract only the relevant sections from the diff file. For example: `awk '/^diff --git.*\.go /,/^diff --git/' "$diff_file"` or similar approaches for your file scope.
 
 If the filtered diff is empty, say so in one line and stop.
 
-You are a nit reviewer. Your job is to catch what the linter doesn’t: naming, style, commenting, and language-level improvements. You are not looking for bugs or architecture issues — those are handled by other reviewers.
+You are a nit reviewer. Your job is to catch what the linter doesn't: naming, style, commenting, and language-level improvements. You are not looking for bugs or architecture issues — those are handled by other reviewers.
 
-Write all findings to the output file specified in your prompt. Create the directory if it doesn’t exist. The file is your deliverable — the orchestrator reads it, not your chat output. Your final message should just confirm the file path and how many findings you wrote (or that you found nothing).
+Write all findings to the output file specified in your prompt (a `.json` file). The file is your deliverable — the orchestrator reads it, not your chat output. Your final message should confirm the output file path and how many findings you wrote (or that you found nothing).
 
-Use this structure in the file:
+For each finding, call `add-finding.sh`:
 
----
-
-**Nit** `file.go:42` — One-sentence finding.
-
-Why it matters: brief explanation. If there’s an obvious fix, mention it.
-
----
+```sh
+.agents/skills/deep-review/scripts/add-finding.sh \
+  --output "{output file from prompt}" \
+  --severity Nit \
+  --file "file.go" \
+  --line 42 \
+  --summary "One-sentence nit" \
+  --evidence "Why it matters: brief explanation. If there's an obvious fix, mention it." \
+  --reviewer "{role-name}"
+```
 
 Rules:
 
-- Use **Nit** for all findings. Don’t use P0-P4 severity; that scale is for structural reviewers.
-- Findings MUST reference specific lines or names. Vague style observations aren’t findings.
-- Don’t flag things the linter already catches (formatting, import order, missing error checks).
-- Don’t suggest changes that are purely subjective with no practical benefit.
+- Use **Nit** for all findings. Don't use P0-P4 severity; that scale is for structural reviewers.
+- Findings MUST reference specific lines or names. Vague style observations aren't findings.
+- Don't flag things the linter already catches (formatting, import order, missing error checks).
+- Don't suggest changes that are purely subjective with no practical benefit.
 - For comment quality standards (confidence threshold, avoiding speculation, verifying claims), see `.claude/skills/code-review/SKILL.md` Comment Standards section.
-- If you find nothing, write a single line to the output file: "No findings."
+- If you find nothing, write an empty array to the output file: `echo '[]' > "{output file}"`.

--- a/.agents/skills/deep-review/scripts/add-finding.sh
+++ b/.agents/skills/deep-review/scripts/add-finding.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+
+# This script appends a structured JSON finding to a reviewer's output
+# file. It handles JSON construction, escaping, and field validation so
+# reviewer sub-agents can focus on content rather than formatting.
+#
+# Usage: ./add-finding.sh --output <path> --severity <P0|P1|P2|P3|P4|Obs|Nit> \
+#          --file <path> --line <number> --summary <text> --evidence <text> \
+#          --reviewer <role-name>
+
+set -euo pipefail
+# shellcheck source=scripts/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/../../../../scripts/lib.sh"
+
+dependencies jq
+
+output=""
+severity=""
+file=""
+line=""
+summary=""
+evidence=""
+reviewer=""
+
+args="$(getopt -o "" -l output:,severity:,file:,line:,summary:,evidence:,reviewer: -- "$@")"
+eval set -- "$args"
+while true; do
+	case "$1" in
+	--output)
+		output="$2"
+		shift 2
+		;;
+	--severity)
+		severity="$2"
+		shift 2
+		;;
+	--file)
+		file="$2"
+		shift 2
+		;;
+	--line)
+		line="$2"
+		shift 2
+		;;
+	--summary)
+		summary="$2"
+		shift 2
+		;;
+	--evidence)
+		evidence="$2"
+		shift 2
+		;;
+	--reviewer)
+		reviewer="$2"
+		shift 2
+		;;
+	--)
+		shift
+		break
+		;;
+	*)
+		error "Unrecognized option: $1"
+		;;
+	esac
+done
+
+# Validate severity against the allowed set.
+case "$severity" in
+P0 | P1 | P2 | P3 | P4 | Obs | Nit) ;;
+"")
+	error "--severity is a required parameter"
+	;;
+*)
+	error "Invalid --severity '$severity', must be one of: P0, P1, P2, P3, P4, Obs, Nit"
+	;;
+esac
+
+# Validate required fields.
+if [[ -z "$output" ]]; then
+	error "--output is a required parameter"
+fi
+if [[ -z "$reviewer" ]]; then
+	error "--reviewer is a required parameter"
+fi
+if [[ -z "$summary" ]]; then
+	error "--summary is a required parameter"
+fi
+
+# Severity-specific required fields.
+case "$severity" in
+P0 | P1 | P2 | P3 | P4)
+	if [[ -z "$file" ]]; then
+		error "--file is required for severity $severity"
+	fi
+	if [[ -z "$line" ]]; then
+		error "--line is required for severity $severity"
+	fi
+	if [[ -z "$evidence" ]]; then
+		error "--evidence is required for severity $severity"
+	fi
+	;;
+Nit)
+	if [[ -z "$file" ]]; then
+		error "--file is required for severity Nit"
+	fi
+	;;
+Obs)
+	# Only --summary and --reviewer are required for observations.
+	;;
+esac
+
+# Initialize the output file if it doesn't exist.
+if [[ ! -f "$output" ]]; then
+	echo '[]' >"$output"
+fi
+
+# Build jq arguments. Use --argjson for line so it becomes a number
+# (or null), and --arg for strings. Null-valued optional fields are
+# passed as jq null via --argjson.
+jq_args=(
+	--arg sev "$severity"
+	--arg summary "$summary"
+	--arg reviewer "$reviewer"
+)
+
+if [[ -n "$file" ]]; then
+	jq_args+=(--arg file "$file")
+else
+	jq_args+=(--argjson file "null")
+fi
+
+if [[ -n "$line" ]]; then
+	jq_args+=(--argjson line "$line")
+else
+	jq_args+=(--argjson line "null")
+fi
+
+if [[ -n "$evidence" ]]; then
+	jq_args+=(--arg evidence "$evidence")
+else
+	jq_args+=(--argjson evidence "null")
+fi
+
+tmp="$(mktemp)"
+jq "${jq_args[@]}" \
+	'. += [{ severity: $sev, file: $file, line: $line, summary: $summary, evidence: $evidence, reviewer: $reviewer }]' \
+	"$output" >"$tmp" && mv "$tmp" "$output"

--- a/.agents/skills/deep-review/scripts/compile-findings.sh
+++ b/.agents/skills/deep-review/scripts/compile-findings.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+
+# This script reads all reviewer JSON files from a review directory,
+# deduplicates findings at the same location, identifies convergence
+# (multiple reviewers at the same file+line), computes max severity,
+# and outputs a consolidated findings inventory.
+#
+# Usage: ./compile-findings.sh --dir <review-dir> [--output <path>]
+
+set -euo pipefail
+# shellcheck source=scripts/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/../../../../scripts/lib.sh"
+
+dependencies jq
+
+dir=""
+output=""
+
+args="$(getopt -o "" -l dir:,output: -- "$@")"
+eval set -- "$args"
+while true; do
+	case "$1" in
+	--dir)
+		dir="$2"
+		shift 2
+		;;
+	--output)
+		output="$2"
+		shift 2
+		;;
+	--)
+		shift
+		break
+		;;
+	*)
+		error "Unexpected argument: $1"
+		;;
+	esac
+done
+
+if [[ -z "$dir" ]]; then
+	error "--dir is required"
+fi
+
+if [[ ! -d "$dir" ]]; then
+	error "Directory does not exist: $dir"
+fi
+
+# Collect all findings from JSON array files in the directory.
+all_findings="[]"
+for f in "$dir"/*.json; do
+	[[ -f "$f" ]] || continue
+
+	# Skip files that aren't valid JSON or aren't arrays.
+	file_type="$(jq -r 'type' "$f" 2>/dev/null)" || continue
+	if [[ "$file_type" != "array" ]]; then
+		log "Skipping non-array JSON file: $f"
+		continue
+	fi
+
+	# Skip empty arrays.
+	count="$(jq 'length' "$f")"
+	if [[ "$count" -eq 0 ]]; then
+		log "Skipping empty array: $f"
+		continue
+	fi
+
+	all_findings="$(echo "$all_findings" | jq --slurpfile new "$f" '. + $new[0]')"
+done
+
+# Process all findings with jq: group, compute severity, detect
+# convergence, and produce final output.
+result="$(echo "$all_findings" | jq '
+# Severity ordering: lower number = higher severity.
+def sev_rank:
+	if . == "P0" then 0
+	elif . == "P1" then 1
+	elif . == "P2" then 2
+	elif . == "P3" then 3
+	elif . == "P4" then 4
+	elif . == "Obs" then 5
+	elif . == "Nit" then 6
+	else 99
+	end;
+
+def rank_to_sev:
+	if . == 0 then "P0"
+	elif . == 1 then "P1"
+	elif . == 2 then "P2"
+	elif . == 3 then "P3"
+	elif . == 4 then "P4"
+	elif . == 5 then "Obs"
+	elif . == 6 then "Nit"
+	else "Unknown"
+	end;
+
+# Group findings by file+line. Findings without file or line get
+# unique keys so they are never grouped together.
+def group_key:
+	if (.file // "") == "" or (.line // null) == null then
+		"__ungrouped__\(.)| " + (. | @json | @base64)
+	else
+		"\(.file):\(.line)"
+	end;
+
+# Build grouped findings.
+(group_by(group_key)) |
+map(
+	. as $group |
+	# Compute max severity (lowest rank number).
+	($group | map(.severity | sev_rank) | min) as $max_rank |
+	($max_rank | rank_to_sev) as $max_sev |
+	# Pick summary from the reviewer with max severity (first match).
+	($group | map(select((.severity | sev_rank) == $max_rank)) | .[0].summary) as $top_summary |
+	# Build reviewer list.
+	($group | map({
+		role: .reviewer,
+		severity: .severity,
+		summary: .summary,
+		evidence: .evidence
+	})) as $reviewers |
+	# Convergent if 2+ distinct reviewers.
+	([$reviewers[].role] | unique | length >= 2) as $convergent |
+	{
+		file: $group[0].file,
+		line: $group[0].line,
+		summary: $top_summary,
+		reviewers: $reviewers,
+		max_severity: $max_sev,
+		convergent: $convergent
+	}
+) as $findings |
+
+# Compute stats.
+{
+	findings: $findings,
+	stats: {
+		total_findings: ($findings | length),
+		by_severity: (
+			{"P0": 0, "P1": 0, "P2": 0, "P3": 0, "P4": 0, "Obs": 0, "Nit": 0} as $init |
+			reduce $findings[] as $f ($init;
+				.[$f.max_severity] += 1
+			)
+		),
+		convergent_count: ([$findings[] | select(.convergent)] | length),
+		reviewers_reporting: ([$findings[].reviewers[].role] | unique)
+	}
+}
+')"
+
+if [[ -n "$output" ]]; then
+	mkdir -p "$(dirname "$output")"
+	echo "$result" >"$output"
+	log "Findings written to $output"
+else
+	echo "$result"
+fi

--- a/.agents/skills/deep-review/scripts/diff-position-map.sh
+++ b/.agents/skills/deep-review/scripts/diff-position-map.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+
+# This script parses a unified diff and produces a JSON mapping of
+# {file, line} → diff_position suitable for posting GitHub PR review
+# comments.
+#
+# Usage:
+#   cat diff.patch | ./diff-position-map.sh
+#   ./diff-position-map.sh --diff path/to/diff
+#   ./diff-position-map.sh --diff path/to/diff --file coderd/handler.go
+
+set -euo pipefail
+# shellcheck source=scripts/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/../../../../scripts/lib.sh"
+
+dependencies jq
+
+diff_path=""
+file_filter=""
+
+args="$(getopt -o "" -l diff:,file: -- "$@")"
+eval set -- "$args"
+while true; do
+	case "$1" in
+	--diff)
+		diff_path="$2"
+		shift 2
+		;;
+	--file)
+		file_filter="$2"
+		shift 2
+		;;
+	--)
+		shift
+		break
+		;;
+	*)
+		error "Unexpected argument: $1"
+		;;
+	esac
+done
+
+# Awk script that emits file\tline\tposition rows from unified diff.
+# Uses only POSIX awk features (no gawk-specific match() with arrays).
+# shellcheck disable=SC2016
+awk_script='
+/^diff --git / {
+	# Extract the new-side path (b/...).
+	n = split($0, parts, " ")
+	raw = parts[n]
+	# Strip leading "b/".
+	file = substr(raw, 3)
+	file_position = 0
+	in_file = 0
+	next
+}
+
+/^@@/ {
+	if (!in_file) {
+		in_file = 1
+		file_position = 1
+	} else {
+		file_position++
+	}
+	# Parse +start from the @@ header.
+	# Find the field that starts with + and extract the number.
+	for (i = 1; i <= NF; i++) {
+		if ($i ~ /^\+[0-9]/) {
+			val = $i
+			sub(/^\+/, "", val)
+			sub(/,.*/, "", val)
+			new_line = val + 0
+			break
+		}
+	}
+	next
+}
+
+# Skip lines before the first hunk header (e.g. ---/+++ lines).
+!in_file { next }
+
+/^\\ No newline at end of file/ {
+	file_position++
+	next
+}
+
+/^\+/ {
+	file_position++
+	print file "\t" new_line "\t" file_position
+	new_line++
+	next
+}
+
+/^-/ {
+	file_position++
+	next
+}
+
+/^ / {
+	file_position++
+	print file "\t" new_line "\t" file_position
+	new_line++
+	next
+}
+'
+
+# Assemble nested JSON from the TSV rows.
+jq_script='
+[inputs | split("\t") | {file: .[0], line: .[1], pos: .[2]}]
+| group_by(.file)
+| map({key: .[0].file, value: (map({key: .line, value: (.pos | tonumber)}) | from_entries)})
+| from_entries
+'
+
+if [[ -n "$diff_path" ]]; then
+	diff_input() { cat "$diff_path"; }
+else
+	diff_input() { cat; }
+fi
+
+if [[ -n "$file_filter" ]]; then
+	diff_input | awk "$awk_script" | awk -F'\t' -v f="$file_filter" '$1 == f' | jq -Rn "$jq_script"
+else
+	diff_input | awk "$awk_script" | jq -Rn "$jq_script"
+fi

--- a/.agents/skills/deep-review/scripts/fetch-pr-context.sh
+++ b/.agents/skills/deep-review/scripts/fetch-pr-context.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+
+# Fetch all PR context (metadata, reviews, inline comments, issue comments,
+# commits) into a single structured JSON file. Resolved inline review
+# threads are excluded from the output.
+#
+# Usage: ./fetch-pr-context.sh --pr <number> [--repo <owner/repo>] [--output <path>]
+
+set -euo pipefail
+# shellcheck source=scripts/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/../../../../scripts/lib.sh"
+
+dependencies gh jq
+
+pr=""
+repo=""
+output=""
+
+args="$(getopt -o "" -l pr:,repo:,output: -- "$@")"
+eval set -- "$args"
+while true; do
+	case "$1" in
+	--pr)
+		pr="$2"
+		shift 2
+		;;
+	--repo)
+		repo="$2"
+		shift 2
+		;;
+	--output)
+		output="$2"
+		shift 2
+		;;
+	--)
+		shift
+		break
+		;;
+	*)
+		error "Unrecognized option: $1"
+		;;
+	esac
+done
+
+if [[ -z "$pr" ]]; then
+	error "--pr is a required parameter"
+fi
+
+# Infer repo from the current git context if not provided.
+if [[ -z "$repo" ]]; then
+	repo="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+	log "Inferred repo: $repo"
+fi
+
+# Split repo into owner and reponame for GraphQL queries.
+owner="${repo%%/*}"
+reponame="${repo##*/}"
+
+log "Fetching PR #$pr from $repo..."
+
+# 1. Fetch PR metadata.
+log "  Fetching PR metadata..."
+pr_json="$(gh pr view "$pr" --repo "$repo" \
+	--json number,title,body,author,state,baseRefName,headRefName,url,headRefOid,baseRefOid)"
+pr_json="$(echo "$pr_json" | jq '{
+	number: .number,
+	title: .title,
+	body: .body,
+	author: .author.login,
+	state: .state,
+	base_sha: .baseRefOid,
+	head_sha: .headRefOid,
+	base_ref: .baseRefName,
+	head_ref: .headRefName,
+	url: .url
+}')"
+
+# 2. Fetch reviews.
+log "  Fetching reviews..."
+reviews_json="$(gh pr view "$pr" --repo "$repo" --json reviews | jq '[
+	.reviews[] | {
+		id: .id,
+		author: .author.login,
+		state: .state,
+		body: .body,
+		submitted_at: .submittedAt
+	}
+]')"
+
+# 3. Fetch issue comments.
+log "  Fetching issue comments..."
+issue_comments_json="$(gh pr view "$pr" --repo "$repo" --json comments | jq '[
+	.comments[] | {
+		id: .id,
+		author: .author.login,
+		body: .body,
+		created_at: .createdAt,
+		updated_at: .updatedAt
+	}
+]')"
+
+# 4. Fetch inline review comments (paginated via gh api).
+log "  Fetching inline review comments..."
+review_comments_raw="$(gh api --paginate "repos/$repo/pulls/$pr/comments" | jq '[
+	.[] | {
+		id: .id,
+		node_id: .node_id,
+		review_id: .pull_request_review_id,
+		author: .user.login,
+		path: .path,
+		line: .line,
+		side: .side,
+		start_line: .start_line,
+		body: .body,
+		in_reply_to_id: .in_reply_to_id,
+		created_at: .created_at,
+		updated_at: .updated_at
+	}
+]')"
+
+# 5. Fetch resolved thread status via GraphQL with pagination.
+log "  Fetching review thread resolution status..."
+all_threads="[]"
+has_next_page="true"
+cursor="null"
+
+while [[ "$has_next_page" == "true" ]]; do
+	if [[ "$cursor" == "null" ]]; then
+		after_clause=""
+	else
+		after_clause=", after: $cursor"
+	fi
+
+	graphql_result="$(gh api graphql -f query="
+		query {
+			repository(owner: \"$owner\", name: \"$reponame\") {
+				pullRequest(number: $pr) {
+					reviewThreads(first: 100${after_clause}) {
+						pageInfo { hasNextPage endCursor }
+						nodes {
+							id
+							isResolved
+							comments(first: 1) {
+								nodes { databaseId }
+							}
+						}
+					}
+				}
+			}
+		}
+	")"
+
+	page_threads="$(echo "$graphql_result" | jq '.data.repository.pullRequest.reviewThreads.nodes')"
+	all_threads="$(jq -n --argjson a "$all_threads" --argjson b "$page_threads" '$a + $b')"
+
+	has_next_page="$(echo "$graphql_result" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')"
+	cursor="$(echo "$graphql_result" | jq '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor')"
+done
+
+# 6. Build resolved set and thread ID mapping from GraphQL results.
+#    resolved_set: root comment databaseId values where isResolved == true
+#    thread_map: root comment databaseId → thread GraphQL node ID
+resolved_set="$(echo "$all_threads" | jq '[
+	.[] | select(.isResolved == true) | .comments.nodes[0].databaseId
+] | map(select(. != null))')"
+
+thread_map="$(echo "$all_threads" | jq '[
+	.[] | {
+		key: (.comments.nodes[0].databaseId | tostring),
+		value: .id
+	} | select(.key != "null")
+] | from_entries')"
+
+# 7. Filter inline review comments — exclude resolved threads.
+#    Also add thread_id to each surviving comment.
+log "  Filtering resolved threads..."
+review_comments_json="$(jq -n \
+	--argjson comments "$review_comments_raw" \
+	--argjson resolved "$resolved_set" \
+	--argjson thread_map "$thread_map" '
+	# Build a set from the resolved array for O(1) lookup.
+	($resolved | [.[] | tostring] | INDEX(.[]; .)) as $resolved_set |
+	[
+		$comments[] |
+		# Determine root comment ID for this comment.
+		(if .in_reply_to_id == null then .id else .in_reply_to_id end) as $root_id |
+		# Skip if the root comment is in the resolved set.
+		select(($root_id | tostring) as $rid | $resolved_set[$rid] == null) |
+		# Add thread_id from the thread map.
+		. + { thread_id: ($thread_map[$root_id | tostring] // null) }
+	]
+')"
+
+# 8. Fetch commits.
+log "  Fetching commits..."
+commits_json="$(gh pr view "$pr" --repo "$repo" --json commits | jq '[
+	.commits[] | {
+		sha: .oid,
+		message: .messageHeadline,
+		author: .authors[0].login,
+		date: .committedDate
+	}
+]')"
+
+# 9. Assemble final JSON.
+log "  Assembling output..."
+final_json="$(jq -n \
+	--argjson pr "$pr_json" \
+	--argjson reviews "$reviews_json" \
+	--argjson review_comments "$review_comments_json" \
+	--argjson issue_comments "$issue_comments_json" \
+	--argjson commits "$commits_json" \
+	'{
+		pr: $pr,
+		reviews: $reviews,
+		review_comments: $review_comments,
+		issue_comments: $issue_comments,
+		commits: $commits
+	}')"
+
+# 10. Write output.
+if [[ -n "$output" ]]; then
+	echo "$final_json" >"$output"
+	log "Output written to $output"
+else
+	echo "$final_json"
+fi

--- a/.agents/skills/deep-review/scripts/post-review.sh
+++ b/.agents/skills/deep-review/scripts/post-review.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+
+# This script posts a structured review to a GitHub PR. It accepts a
+# JSON file describing the review body, inline comments (with source
+# file line numbers — not diff positions), replies to existing comments,
+# and thread IDs to resolve. Diff position computation is handled
+# internally via diff-position-map.sh.
+#
+# Usage:
+#   ./post-review.sh --pr 1234 --input review.json [--repo owner/repo] \
+#       [--diff pr.diff] [--dry-run]
+
+set -euo pipefail
+# shellcheck source=scripts/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/../../../../scripts/lib.sh"
+
+dependencies gh jq
+
+pr=""
+repo=""
+input=""
+diff_file=""
+dry_run=0
+
+args="$(getopt -o "" -l pr:,repo:,input:,diff:,dry-run -- "$@")"
+eval set -- "$args"
+while true; do
+	case "$1" in
+	--pr)
+		pr="$2"
+		shift 2
+		;;
+	--repo)
+		repo="$2"
+		shift 2
+		;;
+	--input)
+		input="$2"
+		shift 2
+		;;
+	--diff)
+		diff_file="$2"
+		shift 2
+		;;
+	--dry-run)
+		dry_run=1
+		shift
+		;;
+	--)
+		shift
+		break
+		;;
+	*)
+		error "Unexpected argument: $1"
+		;;
+	esac
+done
+
+if [[ -z "$pr" ]]; then
+	error "--pr is required"
+fi
+if [[ -z "$input" ]]; then
+	error "--input is required"
+fi
+if [[ ! -f "$input" ]]; then
+	error "Input file does not exist: $input"
+fi
+
+# Infer repo if not provided.
+if [[ -z "$repo" ]]; then
+	repo="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+fi
+
+# Validate input JSON.
+event="$(jq -r '.event // empty' "$input")"
+if [[ -z "$event" ]]; then
+	error "Input JSON must contain an 'event' field"
+fi
+if [[ "$event" != "COMMENT" ]]; then
+	error "Only 'COMMENT' event is supported (got '$event')"
+fi
+
+body="$(jq -r '.body // empty' "$input")"
+if [[ -z "$body" ]]; then
+	error "Input JSON must contain a non-empty 'body' field"
+fi
+
+# Set up temp directory for intermediate files.
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+# Get the diff.
+if [[ -z "$diff_file" ]]; then
+	diff_file="$tmpdir/pr.diff"
+	gh pr diff "$pr" --repo "$repo" >"$diff_file"
+fi
+
+# Compute the position map via sibling script.
+SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
+position_map="$("$SCRIPT_DIR/diff-position-map.sh" --diff "$diff_file")"
+
+# Extract comments array (default to empty).
+comments="$(jq -c '.comments // []' "$input")"
+num_comments="$(echo "$comments" | jq 'length')"
+
+# Build the review comments array with positions.
+review_comments="[]"
+for ((i = 0; i < num_comments; i++)); do
+	path="$(echo "$comments" | jq -r ".[$i].path")"
+	line="$(echo "$comments" | jq -r ".[$i].line")"
+	comment_body="$(echo "$comments" | jq -r ".[$i].body")"
+
+	# Look up position from the map.
+	position="$(echo "$position_map" | jq --arg path "$path" --arg line "$line" '.[$path][$line] // empty')"
+
+	if [[ -n "$position" ]]; then
+		# Position found — add as inline comment.
+		review_comments="$(echo "$review_comments" | jq \
+			--arg path "$path" \
+			--argjson position "$position" \
+			--arg body "$comment_body" \
+			'. + [{"path": $path, "position": $position, "body": $body}]')"
+	else
+		# Line not in diff — fall back to file-level comment at position 1.
+		log "WARNING: Line $line of $path not found in diff, falling back to file-level comment"
+		fallback_body="[Line $line] $comment_body"
+		review_comments="$(echo "$review_comments" | jq \
+			--arg path "$path" \
+			--arg body "$fallback_body" \
+			'. + [{"path": $path, "position": 1, "body": $body}]')"
+	fi
+done
+
+# Build the review payload.
+if [[ "$(echo "$review_comments" | jq 'length')" -gt 0 ]]; then
+	jq -n \
+		--arg event "$event" \
+		--arg body "$body" \
+		--argjson comments "$review_comments" \
+		'{"event": $event, "body": $body, "comments": $comments}' \
+		>"$tmpdir/review_payload.json"
+else
+	jq -n \
+		--arg event "$event" \
+		--arg body "$body" \
+		'{"event": $event, "body": $body}' \
+		>"$tmpdir/review_payload.json"
+fi
+
+# Extract replies and resolve_thread_ids (default to empty arrays).
+replies="$(jq -c '.replies // []' "$input")"
+num_replies="$(echo "$replies" | jq 'length')"
+
+resolve_thread_ids="$(jq -c '.resolve_thread_ids // []' "$input")"
+num_resolve="$(echo "$resolve_thread_ids" | jq 'length')"
+
+if [[ "$dry_run" == 1 ]]; then
+	# Print the review payload as compact JSON (one line).
+	jq -c . "$tmpdir/review_payload.json"
+
+	# Print each reply as a separate compact JSON object.
+	for ((i = 0; i < num_replies; i++)); do
+		reply_id="$(echo "$replies" | jq ".[$i].in_reply_to_id")"
+		reply_body="$(echo "$replies" | jq -r ".[$i].body")"
+		jq -cn \
+			--arg action "reply" \
+			--argjson in_reply_to_id "$reply_id" \
+			--arg body "$reply_body" \
+			'{"action": $action, "in_reply_to_id": $in_reply_to_id, "body": $body}'
+	done
+
+	# Print each thread resolution as compact JSON.
+	for ((i = 0; i < num_resolve; i++)); do
+		thread_id="$(echo "$resolve_thread_ids" | jq -r ".[$i]")"
+		jq -cn \
+			--arg action "resolve_thread" \
+			--arg thread_id "$thread_id" \
+			'{"action": $action, "thread_id": $thread_id}'
+	done
+
+	exit 0
+fi
+
+# Post the review.
+gh api -X POST "repos/$repo/pulls/$pr/reviews" --input "$tmpdir/review_payload.json"
+
+# Post replies.
+for ((i = 0; i < num_replies; i++)); do
+	reply_id="$(echo "$replies" | jq ".[$i].in_reply_to_id")"
+	reply_body="$(echo "$replies" | jq -r ".[$i].body")"
+	gh api -X POST "repos/$repo/pulls/$pr/comments" \
+		-f "body=$reply_body" -F "in_reply_to=$reply_id"
+done
+
+# Resolve threads via GraphQL.
+for ((i = 0; i < num_resolve; i++)); do
+	thread_id="$(echo "$resolve_thread_ids" | jq -r ".[$i]")"
+	# shellcheck disable=SC2016
+	gh api graphql -f query='mutation($id: ID!) {
+		resolveReviewThread(input: {threadId: $id}) {
+			thread { isResolved }
+		}
+	}' -f id="$thread_id"
+done

--- a/.agents/skills/deep-review/scripts/test-add-finding.bats
+++ b/.agents/skills/deep-review/scripts/test-add-finding.bats
@@ -1,0 +1,154 @@
+#!/usr/bin/env bats
+
+# Tests for add-finding.sh
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+ADD_FINDING="$SCRIPT_DIR/add-finding.sh"
+
+setup() {
+	TEST_TMPDIR="$(mktemp -d)"
+	OUTPUT="$TEST_TMPDIR/findings.json"
+}
+
+teardown() {
+	rm -rf "$TEST_TMPDIR"
+}
+
+@test "first finding creates valid JSON array" {
+	run "$ADD_FINDING" \
+		--output "$OUTPUT" \
+		--severity P2 \
+		--file "coderd/handler.go" \
+		--line 42 \
+		--summary "Test passes by coincidence" \
+		--evidence "The assertion checks length > 0 but the slice is always non-empty" \
+		--reviewer "test-auditor"
+	[ "$status" -eq 0 ]
+	# Output file must be valid JSON.
+	jq . "$OUTPUT" >/dev/null
+	# Must be an array with one element.
+	count="$(jq 'length' "$OUTPUT")"
+	[ "$count" -eq 1 ]
+	# Verify fields.
+	[ "$(jq -r '.[0].severity' "$OUTPUT")" = "P2" ]
+	[ "$(jq -r '.[0].file' "$OUTPUT")" = "coderd/handler.go" ]
+	[ "$(jq '.[0].line' "$OUTPUT")" = "42" ]
+	[ "$(jq -r '.[0].reviewer' "$OUTPUT")" = "test-auditor" ]
+}
+
+@test "second finding appends to existing array" {
+	"$ADD_FINDING" \
+		--output "$OUTPUT" \
+		--severity P1 \
+		--file "coderd/a.go" \
+		--line 10 \
+		--summary "First finding" \
+		--evidence "Evidence one" \
+		--reviewer "security-reviewer"
+
+	"$ADD_FINDING" \
+		--output "$OUTPUT" \
+		--severity P3 \
+		--file "coderd/b.go" \
+		--line 20 \
+		--summary "Second finding" \
+		--evidence "Evidence two" \
+		--reviewer "structural-reviewer"
+
+	count="$(jq 'length' "$OUTPUT")"
+	[ "$count" -eq 2 ]
+	[ "$(jq -r '.[0].summary' "$OUTPUT")" = "First finding" ]
+	[ "$(jq -r '.[1].summary' "$OUTPUT")" = "Second finding" ]
+}
+
+@test "validates severity — rejects invalid values" {
+	run "$ADD_FINDING" \
+		--output "$OUTPUT" \
+		--severity INVALID \
+		--file "coderd/handler.go" \
+		--line 42 \
+		--summary "Bad severity" \
+		--evidence "Evidence" \
+		--reviewer "test-auditor"
+	[ "$status" -ne 0 ]
+}
+
+@test "handles multi-line evidence with special characters" {
+	evidence=$'Line one with "quotes"\nLine two with \\backslashes\\\nLine three with $dollars and {braces}'
+	run "$ADD_FINDING" \
+		--output "$OUTPUT" \
+		--severity P2 \
+		--file "coderd/handler.go" \
+		--line 42 \
+		--summary "Special chars test" \
+		--evidence "$evidence" \
+		--reviewer "test-auditor"
+	[ "$status" -eq 0 ]
+	# Output must be valid JSON.
+	jq . "$OUTPUT" >/dev/null
+	# Evidence must be preserved (jq -r renders it back).
+	got="$(jq -r '.[0].evidence' "$OUTPUT")"
+	[ "$got" = "$evidence" ]
+}
+
+@test "observation — severity is Obs, no line required" {
+	run "$ADD_FINDING" \
+		--output "$OUTPUT" \
+		--severity Obs \
+		--summary "General observation about architecture" \
+		--reviewer "structural-reviewer"
+	[ "$status" -eq 0 ]
+	jq . "$OUTPUT" >/dev/null
+	count="$(jq 'length' "$OUTPUT")"
+	[ "$count" -eq 1 ]
+	[ "$(jq '.[0].file' "$OUTPUT")" = "null" ]
+	[ "$(jq '.[0].line' "$OUTPUT")" = "null" ]
+	[ "$(jq '.[0].evidence' "$OUTPUT")" = "null" ]
+	[ "$(jq -r '.[0].severity' "$OUTPUT")" = "Obs" ]
+}
+
+@test "nit — severity is Nit" {
+	run "$ADD_FINDING" \
+		--output "$OUTPUT" \
+		--severity Nit \
+		--file "coderd/handler.go" \
+		--summary "Nit about naming" \
+		--reviewer "structural-reviewer"
+	[ "$status" -eq 0 ]
+	jq . "$OUTPUT" >/dev/null
+	count="$(jq 'length' "$OUTPUT")"
+	[ "$count" -eq 1 ]
+	[ "$(jq -r '.[0].file' "$OUTPUT")" = "coderd/handler.go" ]
+	[ "$(jq '.[0].line' "$OUTPUT")" = "null" ]
+	[ "$(jq '.[0].evidence' "$OUTPUT")" = "null" ]
+	[ "$(jq -r '.[0].severity' "$OUTPUT")" = "Nit" ]
+}
+
+@test "missing required flags exits non-zero" {
+	# Omit --summary, which is required for all severities.
+	run "$ADD_FINDING" \
+		--output "$OUTPUT" \
+		--severity P2 \
+		--file "coderd/handler.go" \
+		--line 42 \
+		--evidence "Some evidence" \
+		--reviewer "test-auditor"
+	[ "$status" -ne 0 ]
+}
+
+@test "output file is always valid JSON after each call" {
+	for i in 1 2 3; do
+		"$ADD_FINDING" \
+			--output "$OUTPUT" \
+			--severity P2 \
+			--file "coderd/handler.go" \
+			--line "$i" \
+			--summary "Finding number $i" \
+			--evidence "Evidence $i" \
+			--reviewer "test-auditor"
+		# Must be valid JSON after every call.
+		jq . "$OUTPUT" >/dev/null
+	done
+	count="$(jq 'length' "$OUTPUT")"
+	[ "$count" -eq 3 ]
+}

--- a/.agents/skills/deep-review/scripts/test-compile-findings.bats
+++ b/.agents/skills/deep-review/scripts/test-compile-findings.bats
@@ -1,0 +1,315 @@
+#!/usr/bin/env bats
+
+# Tests for compile-findings.sh
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+COMPILE_FINDINGS="$SCRIPT_DIR/compile-findings.sh"
+
+setup() {
+	TEST_DIR="$(mktemp -d)"
+}
+
+teardown() {
+	rm -rf "$TEST_DIR"
+}
+
+@test "reads all reviewer JSON files from directory" {
+	cat >"$TEST_DIR/test-auditor.json" <<'EOF'
+[
+  {
+    "severity": "P2",
+    "file": "coderd/handler.go",
+    "line": 42,
+    "summary": "Test passes by coincidence",
+    "evidence": "The assertion checks length > 0",
+    "reviewer": "test-auditor"
+  }
+]
+EOF
+	cat >"$TEST_DIR/contract-auditor.json" <<'EOF'
+[
+  {
+    "severity": "P3",
+    "file": "coderd/routes.go",
+    "line": 10,
+    "summary": "Missing error check",
+    "evidence": "The error is ignored",
+    "reviewer": "contract-auditor"
+  }
+]
+EOF
+
+	run "$COMPILE_FINDINGS" --dir "$TEST_DIR"
+	[ "$status" -eq 0 ]
+	total="$(echo "$output" | jq '.stats.total_findings')"
+	[ "$total" -eq 2 ]
+	reviewers="$(echo "$output" | jq '.stats.reviewers_reporting | length')"
+	[ "$reviewers" -eq 2 ]
+}
+
+@test "deduplicates findings at exact same file:line with same severity" {
+	cat >"$TEST_DIR/auditor-a.json" <<'EOF'
+[
+  {
+    "severity": "P2",
+    "file": "coderd/handler.go",
+    "line": 42,
+    "summary": "Finding from A",
+    "evidence": "Evidence A",
+    "reviewer": "auditor-a"
+  }
+]
+EOF
+	cat >"$TEST_DIR/auditor-b.json" <<'EOF'
+[
+  {
+    "severity": "P2",
+    "file": "coderd/handler.go",
+    "line": 42,
+    "summary": "Finding from B",
+    "evidence": "Evidence B",
+    "reviewer": "auditor-b"
+  }
+]
+EOF
+
+	run "$COMPILE_FINDINGS" --dir "$TEST_DIR"
+	[ "$status" -eq 0 ]
+	# Same file:line should be grouped into one finding.
+	total="$(echo "$output" | jq '.stats.total_findings')"
+	[ "$total" -eq 1 ]
+	# Both reviewers should be listed.
+	reviewer_count="$(echo "$output" | jq '.findings[0].reviewers | length')"
+	[ "$reviewer_count" -eq 2 ]
+}
+
+@test "convergent findings — same file:line, different reviewers — grouped" {
+	cat >"$TEST_DIR/test-auditor.json" <<'EOF'
+[
+  {
+    "severity": "P2",
+    "file": "coderd/handler.go",
+    "line": 42,
+    "summary": "Test passes by coincidence",
+    "evidence": "The assertion checks...",
+    "reviewer": "test-auditor"
+  }
+]
+EOF
+	cat >"$TEST_DIR/contract-auditor.json" <<'EOF'
+[
+  {
+    "severity": "P1",
+    "file": "coderd/handler.go",
+    "line": 42,
+    "summary": "Contract violation",
+    "evidence": "The contract requires...",
+    "reviewer": "contract-auditor"
+  }
+]
+EOF
+
+	run "$COMPILE_FINDINGS" --dir "$TEST_DIR"
+	[ "$status" -eq 0 ]
+	total="$(echo "$output" | jq '.stats.total_findings')"
+	[ "$total" -eq 1 ]
+	convergent="$(echo "$output" | jq '.findings[0].convergent')"
+	[ "$convergent" = "true" ]
+	reviewer_count="$(echo "$output" | jq '.findings[0].reviewers | length')"
+	[ "$reviewer_count" -eq 2 ]
+}
+
+@test "max severity computed across convergent findings" {
+	cat >"$TEST_DIR/reviewer-a.json" <<'EOF'
+[
+  {
+    "severity": "P2",
+    "file": "coderd/handler.go",
+    "line": 42,
+    "summary": "Minor issue",
+    "evidence": "Some evidence",
+    "reviewer": "reviewer-a"
+  }
+]
+EOF
+	cat >"$TEST_DIR/reviewer-b.json" <<'EOF'
+[
+  {
+    "severity": "P1",
+    "file": "coderd/handler.go",
+    "line": 42,
+    "summary": "Serious issue",
+    "evidence": "More evidence",
+    "reviewer": "reviewer-b"
+  }
+]
+EOF
+
+	run "$COMPILE_FINDINGS" --dir "$TEST_DIR"
+	[ "$status" -eq 0 ]
+	max_sev="$(echo "$output" | jq -r '.findings[0].max_severity')"
+	[ "$max_sev" = "P1" ]
+	# The finding-level summary should come from the P1 reviewer.
+	summary="$(echo "$output" | jq -r '.findings[0].summary')"
+	[ "$summary" = "Serious issue" ]
+}
+
+@test "preserves individual reviewer severity in attribution" {
+	cat >"$TEST_DIR/reviewer-a.json" <<'EOF'
+[
+  {
+    "severity": "P2",
+    "file": "coderd/handler.go",
+    "line": 42,
+    "summary": "Minor issue",
+    "evidence": "Some evidence",
+    "reviewer": "reviewer-a"
+  }
+]
+EOF
+	cat >"$TEST_DIR/reviewer-b.json" <<'EOF'
+[
+  {
+    "severity": "P1",
+    "file": "coderd/handler.go",
+    "line": 42,
+    "summary": "Serious issue",
+    "evidence": "More evidence",
+    "reviewer": "reviewer-b"
+  }
+]
+EOF
+
+	run "$COMPILE_FINDINGS" --dir "$TEST_DIR"
+	[ "$status" -eq 0 ]
+	# Check individual reviewer severities are preserved.
+	sev_a="$(echo "$output" | jq -r '.findings[0].reviewers[] | select(.role == "reviewer-a") | .severity')"
+	[ "$sev_a" = "P2" ]
+	sev_b="$(echo "$output" | jq -r '.findings[0].reviewers[] | select(.role == "reviewer-b") | .severity')"
+	[ "$sev_b" = "P1" ]
+}
+
+@test "handles mixed P-level, Obs, and Nit findings" {
+	cat >"$TEST_DIR/reviewer.json" <<'EOF'
+[
+  {
+    "severity": "P1",
+    "file": "a.go",
+    "line": 1,
+    "summary": "P1 finding",
+    "evidence": "ev",
+    "reviewer": "r1"
+  },
+  {
+    "severity": "P2",
+    "file": "b.go",
+    "line": 2,
+    "summary": "P2 finding",
+    "evidence": "ev",
+    "reviewer": "r1"
+  },
+  {
+    "severity": "P2",
+    "file": "c.go",
+    "line": 3,
+    "summary": "Another P2",
+    "evidence": "ev",
+    "reviewer": "r1"
+  },
+  {
+    "severity": "Obs",
+    "file": "d.go",
+    "line": 4,
+    "summary": "Observation",
+    "evidence": "ev",
+    "reviewer": "r1"
+  },
+  {
+    "severity": "Nit",
+    "file": "e.go",
+    "line": 5,
+    "summary": "Nitpick",
+    "evidence": "ev",
+    "reviewer": "r1"
+  },
+  {
+    "severity": "Nit",
+    "file": "f.go",
+    "line": 6,
+    "summary": "Another nit",
+    "evidence": "ev",
+    "reviewer": "r1"
+  }
+]
+EOF
+
+	run "$COMPILE_FINDINGS" --dir "$TEST_DIR"
+	[ "$status" -eq 0 ]
+	total="$(echo "$output" | jq '.stats.total_findings')"
+	[ "$total" -eq 6 ]
+	p0="$(echo "$output" | jq '.stats.by_severity.P0')"
+	[ "$p0" -eq 0 ]
+	p1="$(echo "$output" | jq '.stats.by_severity.P1')"
+	[ "$p1" -eq 1 ]
+	p2="$(echo "$output" | jq '.stats.by_severity.P2')"
+	[ "$p2" -eq 2 ]
+	p3="$(echo "$output" | jq '.stats.by_severity.P3')"
+	[ "$p3" -eq 0 ]
+	p4="$(echo "$output" | jq '.stats.by_severity.P4')"
+	[ "$p4" -eq 0 ]
+	obs="$(echo "$output" | jq '.stats.by_severity.Obs')"
+	[ "$obs" -eq 1 ]
+	nit="$(echo "$output" | jq '.stats.by_severity.Nit')"
+	[ "$nit" -eq 2 ]
+}
+
+@test "empty reviewer files (no findings) are skipped" {
+	cat >"$TEST_DIR/empty-reviewer.json" <<'EOF'
+[]
+EOF
+	cat >"$TEST_DIR/real-reviewer.json" <<'EOF'
+[
+  {
+    "severity": "P3",
+    "file": "x.go",
+    "line": 1,
+    "summary": "Real finding",
+    "evidence": "ev",
+    "reviewer": "real"
+  }
+]
+EOF
+
+	run bash -c '"$1" --dir "$2" 2>/dev/null' _ "$COMPILE_FINDINGS" "$TEST_DIR"
+	[ "$status" -eq 0 ]
+	total="$(echo "$output" | jq '.stats.total_findings')"
+	[ "$total" -eq 1 ]
+	# Only the real reviewer should appear.
+	reviewers="$(echo "$output" | jq -r '.stats.reviewers_reporting[]')"
+	[ "$reviewers" = "real" ]
+}
+
+@test "skips non-array JSON files" {
+	cat >"$TEST_DIR/pr-context.json" <<'EOF'
+{"pr": {"title": "Test PR", "number": 123}}
+EOF
+	cat >"$TEST_DIR/real-reviewer.json" <<'EOF'
+[
+  {
+    "severity": "P2",
+    "file": "y.go",
+    "line": 5,
+    "summary": "A finding",
+    "evidence": "ev",
+    "reviewer": "auditor"
+  }
+]
+EOF
+
+	run bash -c '"$1" --dir "$2" 2>/dev/null' _ "$COMPILE_FINDINGS" "$TEST_DIR"
+	[ "$status" -eq 0 ]
+	total="$(echo "$output" | jq '.stats.total_findings')"
+	[ "$total" -eq 1 ]
+	file="$(echo "$output" | jq -r '.findings[0].file')"
+	[ "$file" = "y.go" ]
+}

--- a/.agents/skills/deep-review/scripts/test-diff-position-map.bats
+++ b/.agents/skills/deep-review/scripts/test-diff-position-map.bats
@@ -1,0 +1,242 @@
+#!/usr/bin/env bats
+
+# Tests for diff-position-map.sh
+
+setup() {
+	SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+	SCRIPT="$SCRIPT_DIR/diff-position-map.sh"
+}
+
+@test "single file, single hunk" {
+	diff_input='diff --git a/main.go b/main.go
+index 1111111..2222222 100644
+--- a/main.go
++++ b/main.go
+@@ -10,4 +10,6 @@ package main
+ context line 10
+ context line 11
++added line 12
++added line 13
+ context line 12 old
+ context line 13 old'
+
+	result="$(echo "$diff_input" | "$SCRIPT")"
+
+	# @@ header = position 1
+	# context 10 = position 2
+	# context 11 = position 3
+	# +added 12  = position 4
+	# +added 13  = position 5
+	# context (now 14) = position 6
+	# context (now 15) = position 7
+	[ "$(echo "$result" | jq -r '.["main.go"]["12"]')" = "4" ]
+	[ "$(echo "$result" | jq -r '.["main.go"]["13"]')" = "5" ]
+	# Context lines also get mapped.
+	[ "$(echo "$result" | jq -r '.["main.go"]["10"]')" = "2" ]
+	[ "$(echo "$result" | jq -r '.["main.go"]["11"]')" = "3" ]
+}
+
+@test "single file, multiple hunks — position continues across hunks" {
+	diff_input='diff --git a/file.go b/file.go
+index 1111111..2222222 100644
+--- a/file.go
++++ b/file.go
+@@ -1,3 +1,4 @@
+ line 1
++added line 2
+ line 2 old
+ line 3 old
+@@ -20,3 +21,4 @@ some function
+ line 21
++added line 22
+ line 22 old
+ line 23 old'
+
+	result="$(echo "$diff_input" | "$SCRIPT")"
+
+	# First hunk:
+	# @@ = position 1
+	# context 1 = position 2
+	# +added 2  = position 3
+	# context 3 = position 4
+	# context 4 = position 5
+	[ "$(echo "$result" | jq -r '.["file.go"]["2"]')" = "3" ]
+
+	# Second hunk:
+	# @@ = position 6 (continues from 5)
+	# context 21 = position 7
+	# +added 22  = position 8
+	# context 23 = position 9
+	# context 24 = position 10
+	[ "$(echo "$result" | jq -r '.["file.go"]["22"]')" = "8" ]
+	# Verify positions didn't reset.
+	[ "$(echo "$result" | jq -r '.["file.go"]["21"]')" = "7" ]
+}
+
+@test "multiple files — separate position namespaces" {
+	diff_input='diff --git a/a.go b/a.go
+index 1111111..2222222 100644
+--- a/a.go
++++ b/a.go
+@@ -1,2 +1,3 @@
+ line 1
++added line 2
+ line 2 old
+diff --git a/b.go b/b.go
+index 3333333..4444444 100644
+--- a/b.go
++++ b/b.go
+@@ -5,2 +5,3 @@ package b
+ line 5
++added line 6
+ line 6 old'
+
+	result="$(echo "$diff_input" | "$SCRIPT")"
+
+	# a.go: @@ pos=1, ctx 1 pos=2, +added 2 pos=3, ctx 3 pos=4
+	[ "$(echo "$result" | jq -r '.["a.go"]["2"]')" = "3" ]
+
+	# b.go: position resets for new file.
+	# @@ pos=1, ctx 5 pos=2, +added 6 pos=3, ctx 7 pos=4
+	[ "$(echo "$result" | jq -r '.["b.go"]["6"]')" = "3" ]
+
+	# Verify both files exist.
+	[ "$(echo "$result" | jq 'keys | length')" = "2" ]
+}
+
+@test "new file (all additions)" {
+	diff_input='diff --git a/new.go b/new.go
+new file mode 100644
+index 0000000..1234567
+--- /dev/null
++++ b/new.go
+@@ -0,0 +1,3 @@
++package new
++
++func init() {}'
+
+	result="$(echo "$diff_input" | "$SCRIPT")"
+
+	# @@ = position 1
+	# +package new = position 2 (line 1)
+	# +(blank)     = position 3 (line 2)
+	# +func init   = position 4 (line 3)
+	[ "$(echo "$result" | jq -r '.["new.go"]["1"]')" = "2" ]
+	[ "$(echo "$result" | jq -r '.["new.go"]["2"]')" = "3" ]
+	[ "$(echo "$result" | jq -r '.["new.go"]["3"]')" = "4" ]
+}
+
+@test "deleted file — no new-side mappings" {
+	diff_input='diff --git a/old.go b/old.go
+deleted file mode 100644
+index 1234567..0000000
+--- a/old.go
++++ /dev/null
+@@ -1,3 +0,0 @@
+-package old
+-
+-func gone() {}'
+
+	result="$(echo "$diff_input" | "$SCRIPT")"
+
+	# No new-side lines, so old.go should have no entries (or not appear).
+	[ "$(echo "$result" | jq 'if .["old.go"] then .["old.go"] | length else 0 end')" = "0" ]
+}
+
+@test "context lines increment position and produce new-side mappings" {
+	diff_input='diff --git a/ctx.go b/ctx.go
+index 1111111..2222222 100644
+--- a/ctx.go
++++ b/ctx.go
+@@ -5,5 +5,5 @@ package ctx
+ alpha
+ beta
+-old gamma
++new gamma
+ delta
+ epsilon'
+
+	result="$(echo "$diff_input" | "$SCRIPT")"
+
+	# @@ = position 1
+	# ctx alpha (5) = position 2
+	# ctx beta  (6) = position 3
+	# -old gamma    = position 4 (no mapping)
+	# +new gamma(7) = position 5
+	# ctx delta (8) = position 6
+	# ctx epsilon(9)= position 7
+	[ "$(echo "$result" | jq -r '.["ctx.go"]["5"]')" = "2" ]
+	[ "$(echo "$result" | jq -r '.["ctx.go"]["6"]')" = "3" ]
+	[ "$(echo "$result" | jq -r '.["ctx.go"]["7"]')" = "5" ]
+	[ "$(echo "$result" | jq -r '.["ctx.go"]["8"]')" = "6" ]
+	[ "$(echo "$result" | jq -r '.["ctx.go"]["9"]')" = "7" ]
+}
+
+@test "mixed add/delete/context — line numbers track correctly" {
+	diff_input='diff --git a/mix.go b/mix.go
+index 1111111..2222222 100644
+--- a/mix.go
++++ b/mix.go
+@@ -1,7 +1,7 @@
+ line one
+-removed A
+-removed B
++added A
++added B
++added C
+ line four
+-removed D
+ line five'
+
+	result="$(echo "$diff_input" | "$SCRIPT")"
+
+	# @@ = position 1
+	# ctx "line one" new=1 = position 2
+	# -removed A            = position 3
+	# -removed B            = position 4
+	# +added A     new=2    = position 5
+	# +added B     new=3    = position 6
+	# +added C     new=4    = position 7
+	# ctx "line four" new=5 = position 8
+	# -removed D            = position 9
+	# ctx "line five" new=6 = position 10
+	[ "$(echo "$result" | jq -r '.["mix.go"]["1"]')" = "2" ]
+	[ "$(echo "$result" | jq -r '.["mix.go"]["2"]')" = "5" ]
+	[ "$(echo "$result" | jq -r '.["mix.go"]["3"]')" = "6" ]
+	[ "$(echo "$result" | jq -r '.["mix.go"]["4"]')" = "7" ]
+	[ "$(echo "$result" | jq -r '.["mix.go"]["5"]')" = "8" ]
+	[ "$(echo "$result" | jq -r '.["mix.go"]["6"]')" = "10" ]
+	# No mapping for deleted lines — check there's no "line 0" weirdness.
+	[ "$(echo "$result" | jq -r '.["mix.go"] | length')" = "6" ]
+}
+
+@test "--file filter outputs only requested file" {
+	diff_input='diff --git a/keep.go b/keep.go
+index 1111111..2222222 100644
+--- a/keep.go
++++ b/keep.go
+@@ -1,2 +1,3 @@
+ line 1
++added line 2
+ line 2 old
+diff --git a/skip.go b/skip.go
+index 3333333..4444444 100644
+--- a/skip.go
++++ b/skip.go
+@@ -1,2 +1,3 @@
+ line 1
++added line 2
+ line 2 old'
+
+	result="$(echo "$diff_input" | "$SCRIPT" --file keep.go)"
+
+	# Only keep.go should appear.
+	[ "$(echo "$result" | jq 'keys | length')" = "1" ]
+	[ "$(echo "$result" | jq 'keys[0]')" = '"keep.go"' ]
+	[ "$(echo "$result" | jq -r '.["keep.go"]["2"]')" = "3" ]
+}
+
+@test "empty diff produces empty object" {
+	result="$(echo "" | "$SCRIPT")"
+	[ "$result" = "{}" ]
+}

--- a/.agents/skills/deep-review/scripts/test-fetch-pr-context.bats
+++ b/.agents/skills/deep-review/scripts/test-fetch-pr-context.bats
@@ -1,0 +1,100 @@
+#!/usr/bin/env bats
+
+# Integration tests for fetch-pr-context.sh.
+# These tests require network access and run against real PRs from
+# coder/coder.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+FETCH_SCRIPT="$SCRIPT_DIR/fetch-pr-context.sh"
+
+# PR 24310: merged, 8 reviews, 7 commits, 3 resolved threads (all
+# review comments filtered out). Good for resolved-thread filtering.
+# PR 24300: open, 10 reviews, 7 commits, 9 unresolved threads with
+# replies, 1 issue comment. Good for general structure and threading.
+TEST_REPO="coder/coder"
+
+setup() {
+	TEST_TMPDIR="$(mktemp -d)"
+	# Cache directory shared across tests in a single bats run. We
+	# fetch each PR at most once and reuse the cached JSON.
+	CACHE_DIR="${BATS_TMPDIR}/fetch-pr-cache"
+	mkdir -p "$CACHE_DIR"
+}
+
+teardown() {
+	rm -rf "$TEST_TMPDIR"
+}
+
+# Helper: fetch a PR once, caching the result. Subsequent calls for
+# the same PR reuse the cached file.
+fetch_cached() {
+	local pr="$1"
+	local cached="$CACHE_DIR/pr-${pr}.json"
+	if [[ ! -f "$cached" ]]; then
+		"$FETCH_SCRIPT" --pr "$pr" --repo "$TEST_REPO" --output "$cached"
+	fi
+	echo "$cached"
+}
+
+@test "output has all required top-level keys" {
+	local cached
+	cached="$(fetch_cached 24300)"
+	result="$(jq 'has("pr") and has("reviews") and has("review_comments") and has("issue_comments") and has("commits")' "$cached")"
+	[ "$result" = "true" ]
+}
+
+@test "PR metadata fields are non-null" {
+	local cached
+	cached="$(fetch_cached 24300)"
+	[ "$(jq '.pr.number != null' "$cached")" = "true" ]
+	[ "$(jq '.pr.title != null' "$cached")" = "true" ]
+	[ "$(jq '.pr.author != null' "$cached")" = "true" ]
+	[ "$(jq '.pr.url != null' "$cached")" = "true" ]
+	[ "$(jq '.pr.base_sha != null' "$cached")" = "true" ]
+	[ "$(jq '.pr.head_sha != null' "$cached")" = "true" ]
+	[ "$(jq '.pr.base_ref != null' "$cached")" = "true" ]
+	[ "$(jq '.pr.head_ref != null' "$cached")" = "true" ]
+	[ "$(jq '.pr.state != null' "$cached")" = "true" ]
+}
+
+@test "resolved threads are excluded from review_comments" {
+	# PR 24310 has 3 review threads, ALL resolved. After filtering
+	# the output should contain zero review comments.
+	local cached
+	cached="$(fetch_cached 24310)"
+	count="$(jq '.review_comments | length' "$cached")"
+	[ "$count" -eq 0 ]
+	# Sanity: the PR should still have reviews and commits to prove
+	# the fetch actually worked.
+	[ "$(jq '.reviews | length' "$cached")" -gt 0 ]
+	[ "$(jq '.commits | length' "$cached")" -gt 0 ]
+}
+
+@test "threading preserved — in_reply_to_id links exist" {
+	# PR 24300 has unresolved threads with reply comments.
+	local cached
+	cached="$(fetch_cached 24300)"
+	total="$(jq '.review_comments | length' "$cached")"
+	replies="$(jq '[.review_comments[] | select(.in_reply_to_id != null)] | length' "$cached")"
+	# The PR should have some comments overall.
+	[ "$total" -gt 0 ]
+	# At least one reply should be present.
+	[ "$replies" -gt 0 ]
+}
+
+@test "--output flag writes to specified file" {
+	local outfile="$TEST_TMPDIR/out.json"
+	run "$FETCH_SCRIPT" --pr 24300 --repo "$TEST_REPO" --output "$outfile"
+	[ "$status" -eq 0 ]
+	[ -f "$outfile" ]
+	# Must be valid JSON.
+	jq . "$outfile" >/dev/null
+	# Must have all top-level keys.
+	result="$(jq 'has("pr") and has("reviews") and has("review_comments") and has("issue_comments") and has("commits")' "$outfile")"
+	[ "$result" = "true" ]
+}
+
+@test "invalid PR number exits non-zero" {
+	run "$FETCH_SCRIPT" --pr 999999999 --repo "$TEST_REPO"
+	[ "$status" -ne 0 ]
+}

--- a/.agents/skills/deep-review/scripts/test-fetch-pr-context.bats
+++ b/.agents/skills/deep-review/scripts/test-fetch-pr-context.bats
@@ -1,100 +1,304 @@
 #!/usr/bin/env bats
 
-# Integration tests for fetch-pr-context.sh.
-# These tests require network access and run against real PRs from
-# coder/coder.
+# Tests for fetch-pr-context.sh using mocked gh responses.
+# No network access required — all gh calls are intercepted by a
+# stub script that returns known JSON fixtures.
 
 SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
 FETCH_SCRIPT="$SCRIPT_DIR/fetch-pr-context.sh"
 
-# PR 24310: merged, 8 reviews, 7 commits, 3 resolved threads (all
-# review comments filtered out). Good for resolved-thread filtering.
-# PR 24300: open, 10 reviews, 7 commits, 9 unresolved threads with
-# replies, 1 issue comment. Good for general structure and threading.
-TEST_REPO="coder/coder"
-
 setup() {
 	TEST_TMPDIR="$(mktemp -d)"
-	# Cache directory shared across tests in a single bats run. We
-	# fetch each PR at most once and reuse the cached JSON.
-	CACHE_DIR="${BATS_TMPDIR}/fetch-pr-cache"
-	mkdir -p "$CACHE_DIR"
+	MOCK_BIN="$TEST_TMPDIR/bin"
+	mkdir -p "$MOCK_BIN"
+
+	# Create the gh stub. It inspects arguments to decide which
+	# fixture to return.
+	cat > "$MOCK_BIN/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Join all arguments for pattern matching.
+args="$*"
+
+# gh pr view ... --json number,title,...
+if [[ "$args" == *"pr view"* && "$args" == *"--json"* ]]; then
+	# Extract the --json fields to decide which fixture to return.
+	json_fields="${args##*--json }"
+	json_fields="${json_fields%% *}"
+
+	if [[ "$json_fields" == *"number,title"* ]]; then
+		# PR metadata.
+		cat <<'EOF'
+{
+  "number": 42,
+  "title": "fix: improve widget handling",
+  "body": "This PR fixes widget handling.",
+  "author": {"login": "testuser"},
+  "state": "OPEN",
+  "baseRefName": "main",
+  "headRefName": "fix-widgets",
+  "url": "https://github.com/test/repo/pull/42",
+  "headRefOid": "abc123def456",
+  "baseRefOid": "000111222333"
+}
+EOF
+	elif [[ "$json_fields" == *"reviews"* ]]; then
+		cat <<'EOF'
+{
+  "reviews": [
+    {
+      "id": "R_100",
+      "author": {"login": "reviewer1"},
+      "state": "COMMENTED",
+      "body": "Looks good, one P2 finding.",
+      "submittedAt": "2025-01-15T10:00:00Z"
+    },
+    {
+      "id": "R_101",
+      "author": {"login": "reviewer2"},
+      "state": "APPROVED",
+      "body": "",
+      "submittedAt": "2025-01-15T11:00:00Z"
+    }
+  ]
+}
+EOF
+	elif [[ "$json_fields" == *"comments"* ]]; then
+		cat <<'EOF'
+{
+  "comments": [
+    {
+      "id": "IC_200",
+      "author": {"login": "testuser"},
+      "body": "Thanks for the review!",
+      "createdAt": "2025-01-15T12:00:00Z",
+      "updatedAt": "2025-01-15T12:00:00Z"
+    }
+  ]
+}
+EOF
+	elif [[ "$json_fields" == *"commits"* ]]; then
+		cat <<'EOF'
+{
+  "commits": [
+    {
+      "oid": "abc123",
+      "messageHeadline": "fix: improve widget handling",
+      "authors": [{"login": "testuser"}],
+      "committedDate": "2025-01-14T09:00:00Z"
+    },
+    {
+      "oid": "def456",
+      "messageHeadline": "fix: address review feedback",
+      "authors": [{"login": "testuser"}],
+      "committedDate": "2025-01-15T14:00:00Z"
+    }
+  ]
+}
+EOF
+	fi
+	exit 0
+fi
+
+# gh api --paginate repos/.../pulls/.../comments
+if [[ "$args" == *"api"* && "$args" == *"/comments"* && "$args" != *"graphql"* ]]; then
+	cat <<'EOF'
+[
+  {
+    "id": 300,
+    "node_id": "PRRC_300",
+    "pull_request_review_id": 100,
+    "user": {"login": "reviewer1"},
+    "path": "widget.go",
+    "line": 42,
+    "side": "RIGHT",
+    "start_line": null,
+    "body": "**P2** Missing nil check",
+    "in_reply_to_id": null,
+    "created_at": "2025-01-15T10:01:00Z",
+    "updated_at": "2025-01-15T10:01:00Z"
+  },
+  {
+    "id": 301,
+    "node_id": "PRRC_301",
+    "pull_request_review_id": 100,
+    "user": {"login": "testuser"},
+    "path": "widget.go",
+    "line": 42,
+    "side": "RIGHT",
+    "start_line": null,
+    "body": "Good catch, will fix.",
+    "in_reply_to_id": 300,
+    "created_at": "2025-01-15T12:30:00Z",
+    "updated_at": "2025-01-15T12:30:00Z"
+  },
+  {
+    "id": 400,
+    "node_id": "PRRC_400",
+    "pull_request_review_id": 100,
+    "user": {"login": "reviewer1"},
+    "path": "handler.go",
+    "line": 10,
+    "side": "RIGHT",
+    "start_line": null,
+    "body": "**P3** Consider renaming this",
+    "in_reply_to_id": null,
+    "created_at": "2025-01-15T10:02:00Z",
+    "updated_at": "2025-01-15T10:02:00Z"
+  }
+]
+EOF
+	exit 0
+fi
+
+# gh api graphql — review threads
+if [[ "$args" == *"api"* && "$args" == *"graphql"* ]]; then
+	cat <<'EOF'
+{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "reviewThreads": {
+          "pageInfo": {"hasNextPage": false, "endCursor": null},
+          "nodes": [
+            {
+              "id": "PRT_thread_300",
+              "isResolved": false,
+              "comments": {"nodes": [{"databaseId": 300}]}
+            },
+            {
+              "id": "PRT_thread_400",
+              "isResolved": true,
+              "comments": {"nodes": [{"databaseId": 400}]}
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+EOF
+	exit 0
+fi
+
+# gh repo view (for repo inference — shouldn't be called in tests
+# since we always pass --repo, but just in case).
+if [[ "$args" == *"repo view"* ]]; then
+	echo '{"nameWithOwner": "test/repo"}'
+	exit 0
+fi
+
+echo "gh stub: unrecognized call: $args" >&2
+exit 1
+STUB
+	chmod +x "$MOCK_BIN/gh"
+
+	# Prepend mock bin to PATH so fetch-pr-context.sh picks it up.
+	export PATH="$MOCK_BIN:$PATH"
 }
 
 teardown() {
 	rm -rf "$TEST_TMPDIR"
 }
 
-# Helper: fetch a PR once, caching the result. Subsequent calls for
-# the same PR reuse the cached file.
-fetch_cached() {
-	local pr="$1"
-	local cached="$CACHE_DIR/pr-${pr}.json"
-	if [[ ! -f "$cached" ]]; then
-		"$FETCH_SCRIPT" --pr "$pr" --repo "$TEST_REPO" --output "$cached"
-	fi
-	echo "$cached"
-}
-
 @test "output has all required top-level keys" {
-	local cached
-	cached="$(fetch_cached 24300)"
-	result="$(jq 'has("pr") and has("reviews") and has("review_comments") and has("issue_comments") and has("commits")' "$cached")"
+	run "$FETCH_SCRIPT" --pr 42 --repo "test/repo" --output "$TEST_TMPDIR/out.json"
+	[ "$status" -eq 0 ]
+	result="$(jq 'has("pr") and has("reviews") and has("review_comments") and has("issue_comments") and has("commits")' "$TEST_TMPDIR/out.json")"
 	[ "$result" = "true" ]
 }
 
 @test "PR metadata fields are non-null" {
-	local cached
-	cached="$(fetch_cached 24300)"
-	[ "$(jq '.pr.number != null' "$cached")" = "true" ]
-	[ "$(jq '.pr.title != null' "$cached")" = "true" ]
-	[ "$(jq '.pr.author != null' "$cached")" = "true" ]
-	[ "$(jq '.pr.url != null' "$cached")" = "true" ]
-	[ "$(jq '.pr.base_sha != null' "$cached")" = "true" ]
-	[ "$(jq '.pr.head_sha != null' "$cached")" = "true" ]
-	[ "$(jq '.pr.base_ref != null' "$cached")" = "true" ]
-	[ "$(jq '.pr.head_ref != null' "$cached")" = "true" ]
-	[ "$(jq '.pr.state != null' "$cached")" = "true" ]
+	"$FETCH_SCRIPT" --pr 42 --repo "test/repo" --output "$TEST_TMPDIR/out.json"
+	[ "$(jq '.pr.number != null' "$TEST_TMPDIR/out.json")" = "true" ]
+	[ "$(jq '.pr.title != null' "$TEST_TMPDIR/out.json")" = "true" ]
+	[ "$(jq '.pr.author != null' "$TEST_TMPDIR/out.json")" = "true" ]
+	[ "$(jq '.pr.url != null' "$TEST_TMPDIR/out.json")" = "true" ]
+	[ "$(jq '.pr.base_sha != null' "$TEST_TMPDIR/out.json")" = "true" ]
+	[ "$(jq '.pr.head_sha != null' "$TEST_TMPDIR/out.json")" = "true" ]
+	[ "$(jq '.pr.base_ref != null' "$TEST_TMPDIR/out.json")" = "true" ]
+	[ "$(jq '.pr.head_ref != null' "$TEST_TMPDIR/out.json")" = "true" ]
+	[ "$(jq '.pr.state != null' "$TEST_TMPDIR/out.json")" = "true" ]
+}
+
+@test "PR metadata values are correctly mapped" {
+	"$FETCH_SCRIPT" --pr 42 --repo "test/repo" --output "$TEST_TMPDIR/out.json"
+	[ "$(jq -r '.pr.number' "$TEST_TMPDIR/out.json")" = "42" ]
+	[ "$(jq -r '.pr.title' "$TEST_TMPDIR/out.json")" = "fix: improve widget handling" ]
+	[ "$(jq -r '.pr.author' "$TEST_TMPDIR/out.json")" = "testuser" ]
+	[ "$(jq -r '.pr.head_ref' "$TEST_TMPDIR/out.json")" = "fix-widgets" ]
+	[ "$(jq -r '.pr.base_ref' "$TEST_TMPDIR/out.json")" = "main" ]
 }
 
 @test "resolved threads are excluded from review_comments" {
-	# PR 24310 has 3 review threads, ALL resolved. After filtering
-	# the output should contain zero review comments.
-	local cached
-	cached="$(fetch_cached 24310)"
-	count="$(jq '.review_comments | length' "$cached")"
-	[ "$count" -eq 0 ]
-	# Sanity: the PR should still have reviews and commits to prove
-	# the fetch actually worked.
-	[ "$(jq '.reviews | length' "$cached")" -gt 0 ]
-	[ "$(jq '.commits | length' "$cached")" -gt 0 ]
+	"$FETCH_SCRIPT" --pr 42 --repo "test/repo" --output "$TEST_TMPDIR/out.json"
+	# Comment 400 (handler.go:10) is in a resolved thread — should be excluded.
+	count_400="$(jq '[.review_comments[] | select(.id == 400)] | length' "$TEST_TMPDIR/out.json")"
+	[ "$count_400" -eq 0 ]
+	# Comments 300 and 301 (unresolved thread) should survive.
+	count_unresolved="$(jq '[.review_comments[] | select(.id == 300 or .id == 301)] | length' "$TEST_TMPDIR/out.json")"
+	[ "$count_unresolved" -eq 2 ]
 }
 
-@test "threading preserved — in_reply_to_id links exist" {
-	# PR 24300 has unresolved threads with reply comments.
-	local cached
-	cached="$(fetch_cached 24300)"
-	total="$(jq '.review_comments | length' "$cached")"
-	replies="$(jq '[.review_comments[] | select(.in_reply_to_id != null)] | length' "$cached")"
-	# The PR should have some comments overall.
-	[ "$total" -gt 0 ]
-	# At least one reply should be present.
-	[ "$replies" -gt 0 ]
+@test "threading preserved — in_reply_to_id links exist for replies" {
+	"$FETCH_SCRIPT" --pr 42 --repo "test/repo" --output "$TEST_TMPDIR/out.json"
+	# Comment 301 replies to 300.
+	reply_to="$(jq '.review_comments[] | select(.id == 301) | .in_reply_to_id' "$TEST_TMPDIR/out.json")"
+	[ "$reply_to" = "300" ]
+	# Comment 300 is a root (null in_reply_to_id).
+	root="$(jq '.review_comments[] | select(.id == 300) | .in_reply_to_id' "$TEST_TMPDIR/out.json")"
+	[ "$root" = "null" ]
+}
+
+@test "thread_id is populated from GraphQL data" {
+	"$FETCH_SCRIPT" --pr 42 --repo "test/repo" --output "$TEST_TMPDIR/out.json"
+	# Comment 300 is root of thread PRT_thread_300.
+	thread_id="$(jq -r '.review_comments[] | select(.id == 300) | .thread_id' "$TEST_TMPDIR/out.json")"
+	[ "$thread_id" = "PRT_thread_300" ]
+	# Comment 301 replies to 300, so should also get PRT_thread_300.
+	thread_id_reply="$(jq -r '.review_comments[] | select(.id == 301) | .thread_id' "$TEST_TMPDIR/out.json")"
+	[ "$thread_id_reply" = "PRT_thread_300" ]
+}
+
+@test "reviews are correctly shaped" {
+	"$FETCH_SCRIPT" --pr 42 --repo "test/repo" --output "$TEST_TMPDIR/out.json"
+	[ "$(jq '.reviews | length' "$TEST_TMPDIR/out.json")" = "2" ]
+	[ "$(jq -r '.reviews[0].author' "$TEST_TMPDIR/out.json")" = "reviewer1" ]
+	[ "$(jq -r '.reviews[0].state' "$TEST_TMPDIR/out.json")" = "COMMENTED" ]
+	[ "$(jq -r '.reviews[1].state' "$TEST_TMPDIR/out.json")" = "APPROVED" ]
+}
+
+@test "issue comments are correctly shaped" {
+	"$FETCH_SCRIPT" --pr 42 --repo "test/repo" --output "$TEST_TMPDIR/out.json"
+	[ "$(jq '.issue_comments | length' "$TEST_TMPDIR/out.json")" = "1" ]
+	[ "$(jq -r '.issue_comments[0].author' "$TEST_TMPDIR/out.json")" = "testuser" ]
+	[ "$(jq -r '.issue_comments[0].body' "$TEST_TMPDIR/out.json")" = "Thanks for the review!" ]
+}
+
+@test "commits are correctly shaped" {
+	"$FETCH_SCRIPT" --pr 42 --repo "test/repo" --output "$TEST_TMPDIR/out.json"
+	[ "$(jq '.commits | length' "$TEST_TMPDIR/out.json")" = "2" ]
+	[ "$(jq -r '.commits[0].sha' "$TEST_TMPDIR/out.json")" = "abc123" ]
+	[ "$(jq -r '.commits[0].author' "$TEST_TMPDIR/out.json")" = "testuser" ]
 }
 
 @test "--output flag writes to specified file" {
-	local outfile="$TEST_TMPDIR/out.json"
-	run "$FETCH_SCRIPT" --pr 24300 --repo "$TEST_REPO" --output "$outfile"
+	outfile="$TEST_TMPDIR/specific-output.json"
+	run "$FETCH_SCRIPT" --pr 42 --repo "test/repo" --output "$outfile"
 	[ "$status" -eq 0 ]
 	[ -f "$outfile" ]
-	# Must be valid JSON.
+	# Must be valid JSON with correct structure.
 	jq . "$outfile" >/dev/null
-	# Must have all top-level keys.
-	result="$(jq 'has("pr") and has("reviews") and has("review_comments") and has("issue_comments") and has("commits")' "$outfile")"
+	result="$(jq 'has("pr") and has("reviews")' "$outfile")"
 	[ "$result" = "true" ]
 }
 
-@test "invalid PR number exits non-zero" {
-	run "$FETCH_SCRIPT" --pr 999999999 --repo "$TEST_REPO"
-	[ "$status" -ne 0 ]
+@test "stdout output when --output is not provided" {
+	run bash -c "'$FETCH_SCRIPT' --pr 42 --repo 'test/repo' 2>/dev/null"
+	[ "$status" -eq 0 ]
+	# Output should be valid JSON.
+	echo "$output" | jq . >/dev/null
+	result="$(echo "$output" | jq 'has("pr")')"
+	[ "$result" = "true" ]
 }

--- a/.agents/skills/deep-review/scripts/test-post-review.bats
+++ b/.agents/skills/deep-review/scripts/test-post-review.bats
@@ -1,0 +1,219 @@
+#!/usr/bin/env bats
+
+# Tests for post-review.sh
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+POST_REVIEW="$SCRIPT_DIR/post-review.sh"
+
+# A simple diff used across multiple tests.
+# Positions:
+#   @@ header       = position 1
+#   " package main" = position 2 (line 1)
+#   " "             = position 3 (line 2)
+#   " func hello()" = position 4 (line 3)
+#   "+    fmt..."   = position 5 (line 4)
+#   "     return"   = position 6 (line 5)
+#   " }"            = position 7 (line 6)
+DIFF='diff --git a/test.go b/test.go
+--- a/test.go
++++ b/test.go
+@@ -1,5 +1,6 @@
+ package main
+ 
+ func hello() {
++    fmt.Println("hello")
+     return
+ }'
+
+setup() {
+	TEST_TMPDIR="$(mktemp -d)"
+	DIFF_FILE="$TEST_TMPDIR/pr.diff"
+	echo "$DIFF" >"$DIFF_FILE"
+}
+
+teardown() {
+	rm -rf "$TEST_TMPDIR"
+}
+
+@test "--dry-run outputs valid JSON with computed positions" {
+	cat >"$TEST_TMPDIR/input.json" <<'EOF'
+{
+  "event": "COMMENT",
+  "body": "Review summary",
+  "comments": [
+    {
+      "path": "test.go",
+      "line": 4,
+      "body": "**P1** This line is suspicious."
+    }
+  ]
+}
+EOF
+
+	run "$POST_REVIEW" --pr 1 --repo owner/repo --input "$TEST_TMPDIR/input.json" \
+		--diff "$DIFF_FILE" --dry-run
+	[ "$status" -eq 0 ]
+
+	# First line of output is the review payload — must be valid JSON.
+	payload="$(echo "$output" | head -n1)"
+	echo "$payload" | jq . >/dev/null
+
+	# Must have a position field (not line).
+	[ "$(echo "$payload" | jq '.comments[0].position')" != "null" ]
+	[ "$(echo "$payload" | jq '.comments[0].line // empty')" = "" ]
+}
+
+@test "line-to-position translation matches expected value" {
+	# Line 4 in our diff is the added line "+    fmt.Println..."
+	# which is at position 5.
+	cat >"$TEST_TMPDIR/input.json" <<'EOF'
+{
+  "event": "COMMENT",
+  "body": "Checking positions",
+  "comments": [
+    {
+      "path": "test.go",
+      "line": 4,
+      "body": "Comment on the added line."
+    }
+  ]
+}
+EOF
+
+	run "$POST_REVIEW" --pr 1 --repo owner/repo --input "$TEST_TMPDIR/input.json" \
+		--diff "$DIFF_FILE" --dry-run
+	[ "$status" -eq 0 ]
+
+	payload="$(echo "$output" | head -n1)"
+	[ "$(echo "$payload" | jq '.comments[0].position')" = "5" ]
+}
+
+@test "unmappable line falls back to file-level comment" {
+	cat >"$TEST_TMPDIR/input.json" <<'EOF'
+{
+  "event": "COMMENT",
+  "body": "Fallback test",
+  "comments": [
+    {
+      "path": "test.go",
+      "line": 999,
+      "body": "This line is way out of range."
+    }
+  ]
+}
+EOF
+
+	run "$POST_REVIEW" --pr 1 --repo owner/repo --input "$TEST_TMPDIR/input.json" \
+		--diff "$DIFF_FILE" --dry-run
+	[ "$status" -eq 0 ]
+
+	# The output may contain a WARNING line on stderr (captured by bats).
+	# Extract the first line that starts with '{' to get the JSON payload.
+	payload="$(echo "$output" | grep '^{'  | head -n1)"
+
+	# Position should be 1 (fallback).
+	[ "$(echo "$payload" | jq '.comments[0].position')" = "1" ]
+
+	# Body should be prefixed with [Line 999].
+	body="$(echo "$payload" | jq -r '.comments[0].body')"
+	[[ "$body" == "[Line 999] "* ]]
+}
+
+@test "replies are separated from review comments in output" {
+	cat >"$TEST_TMPDIR/input.json" <<'EOF'
+{
+  "event": "COMMENT",
+  "body": "Review with replies",
+  "comments": [
+    {
+      "path": "test.go",
+      "line": 4,
+      "body": "Inline comment."
+    }
+  ],
+  "replies": [
+    {
+      "in_reply_to_id": 456,
+      "body": "Reply to existing comment."
+    }
+  ]
+}
+EOF
+
+	run "$POST_REVIEW" --pr 1 --repo owner/repo --input "$TEST_TMPDIR/input.json" \
+		--diff "$DIFF_FILE" --dry-run
+	[ "$status" -eq 0 ]
+
+	# First line is the review payload.
+	review="$(echo "$output" | head -n1)"
+	[ "$(echo "$review" | jq -r '.event')" = "COMMENT" ]
+	[ "$(echo "$review" | jq '.comments | length')" = "1" ]
+
+	# Second line is the reply action.
+	reply="$(echo "$output" | sed -n '2p')"
+	[ "$(echo "$reply" | jq -r '.action')" = "reply" ]
+	[ "$(echo "$reply" | jq '.in_reply_to_id')" = "456" ]
+	[ "$(echo "$reply" | jq -r '.body')" = "Reply to existing comment." ]
+}
+
+@test "missing required fields exits non-zero" {
+	# Missing body.
+	cat >"$TEST_TMPDIR/input.json" <<'EOF'
+{
+  "event": "COMMENT",
+  "comments": []
+}
+EOF
+
+	run "$POST_REVIEW" --pr 1 --repo owner/repo --input "$TEST_TMPDIR/input.json" \
+		--diff "$DIFF_FILE" --dry-run
+	[ "$status" -ne 0 ]
+}
+
+@test "empty comments array posts review body only" {
+	cat >"$TEST_TMPDIR/input.json" <<'EOF'
+{
+  "event": "COMMENT",
+  "body": "All good, no inline comments.",
+  "comments": []
+}
+EOF
+
+	run "$POST_REVIEW" --pr 1 --repo owner/repo --input "$TEST_TMPDIR/input.json" \
+		--diff "$DIFF_FILE" --dry-run
+	[ "$status" -eq 0 ]
+
+	payload="$(echo "$output" | head -n1)"
+	echo "$payload" | jq . >/dev/null
+
+	# Review body is present.
+	[ "$(echo "$payload" | jq -r '.body')" = "All good, no inline comments." ]
+
+	# No comments key in the payload.
+	[ "$(echo "$payload" | jq 'has("comments")')" = "false" ]
+}
+
+@test "resolve_thread_ids included in --dry-run output" {
+	cat >"$TEST_TMPDIR/input.json" <<'EOF'
+{
+  "event": "COMMENT",
+  "body": "Resolving threads.",
+  "resolve_thread_ids": ["thread-node-id-1", "thread-node-id-2"]
+}
+EOF
+
+	run "$POST_REVIEW" --pr 1 --repo owner/repo --input "$TEST_TMPDIR/input.json" \
+		--diff "$DIFF_FILE" --dry-run
+	[ "$status" -eq 0 ]
+
+	# First line is the review payload.
+	# Lines 2 and 3 should be resolve_thread actions.
+	resolve1="$(echo "$output" | sed -n '2p')"
+	resolve2="$(echo "$output" | sed -n '3p')"
+
+	[ "$(echo "$resolve1" | jq -r '.action')" = "resolve_thread" ]
+	[ "$(echo "$resolve1" | jq -r '.thread_id')" = "thread-node-id-1" ]
+
+	[ "$(echo "$resolve2" | jq -r '.action')" = "resolve_thread" ]
+	[ "$(echo "$resolve2" | jq -r '.thread_id')" = "thread-node-id-2" ]
+}

--- a/.agents/skills/deep-review/structural-reviewer-prompt.md
+++ b/.agents/skills/deep-review/structural-reviewer-prompt.md
@@ -1,47 +1,49 @@
-Get the diff for the review target specified in your prompt, then review it.
+Read the diff from the file path specified in your prompt (the orchestrator saves it before launching you). Then review it.
 
-Write all findings to the output file specified in your prompt. Create the directory if it doesn’t exist. The file is your deliverable — the orchestrator reads it, not your chat output. Your final message should just confirm the file path and how many findings it contains (or that you found nothing).
+Write all findings to the output file specified in your prompt (a `.json` file). The file is your deliverable — the orchestrator reads it, not your chat output. Your final message should confirm the output file path and how many findings it contains (or that you found nothing).
 
-- **PR:** `gh pr diff {number}`
-- **Branch:** `git diff origin/main...{branch}`
-- **Commit range:** `git diff {base}..{tip}`
+For each finding, call `add-finding.sh`:
+
+```sh
+.agents/skills/deep-review/scripts/add-finding.sh \
+  --output "{output file from prompt}" \
+  --severity P2 \
+  --file "coderd/handler.go" \
+  --line 42 \
+  --summary "One-sentence finding" \
+  --evidence "Evidence: what you see in the code, and what goes wrong." \
+  --reviewer "{role-name}"
+```
+
+For observations:
+
+```sh
+.agents/skills/deep-review/scripts/add-finding.sh \
+  --output "{output file from prompt}" \
+  --severity Obs \
+  --file "file.go" \
+  --line 42 \
+  --summary "One-sentence observation" \
+  --evidence "Why it matters: brief explanation." \
+  --reviewer "{role-name}"
+```
 
 You can report two kinds of things:
 
 **Findings** — concrete problems with evidence.
 
-**Observations** — things that work but are fragile, work by coincidence, or are worth knowing about for future changes. These aren’t bugs, they’re context. Mark them with `Obs`.
-
-Use this structure in the file for each finding:
-
----
-
-**P{n}** `file.go:42` — One-sentence finding.
-
-Evidence: what you see in the code, and what goes wrong.
-
----
-
-For observations:
-
----
-
-**Obs** `file.go:42` — One-sentence observation.
-
-Why it matters: brief explanation.
-
----
+**Observations** — things that work but are fragile, work by coincidence, or are worth knowing about for future changes. These aren't bugs, they're context. Mark them with `Obs`.
 
 Rules:
 
 - **Severity**: P0 (blocks merge), P1 (should fix before merge), P2 (consider fixing), P3 (minor), P4 (out of scope, cosmetic).
-- Severity comes from **consequences**, not mechanism. “setState on unmounted component” is a mechanism. “Dialog opens in wrong view” is a consequence. “Attacker can upload active content” is a consequence. “Removing this check has no test to catch it” is a consequence. Rate the consequence, whether it’s a UX bug, a security gap, or a silent regression.
+- Severity comes from **consequences**, not mechanism. "setState on unmounted component" is a mechanism. "Dialog opens in wrong view" is a consequence. "Attacker can upload active content" is a consequence. "Removing this check has no test to catch it" is a consequence. Rate the consequence, whether it's a UX bug, a security gap, or a silent regression.
 - When a finding involves async code (fetch, await, setTimeout), trace the full execution chain past the async boundary. What renders, what callbacks fire, what state changes? Rate based on what happens at the END of the chain, not the start.
 - Findings MUST have evidence. An assertion without evidence is an opinion.
-- Evidence should be specific (file paths, line numbers, scenarios) but concise. Write it like you’re explaining to a colleague, not building a legal case.
-- For each finding, include your practical judgment: is this worth fixing now, or is the current tradeoff acceptable? If there’s an obvious fix, mention it briefly.
-- Observations don’t need evidence, just a clear explanation of why someone should know about this.
+- Evidence should be specific (file paths, line numbers, scenarios) but concise. Write it like you're explaining to a colleague, not building a legal case.
+- For each finding, include your practical judgment: is this worth fixing now, or is the current tradeoff acceptable? If there's an obvious fix, mention it briefly.
+- Observations don't need evidence, just a clear explanation of why someone should know about this.
 - Check the surrounding code for existing conventions. Flag when the change introduces a new pattern where an existing one would work (new file vs. extending existing, new naming scheme vs. established prefix, etc.).
 - Note what the change does well. Good patterns are worth calling out so they get repeated.
 - For comment quality standards (confidence threshold, avoiding speculation, verifying claims), see `.claude/skills/code-review/SKILL.md` Comment Standards section.
-- If you find nothing, write a single line to the output file: “No findings.”
+- If you find nothing, write an empty array to the output file: `echo '[]' > "{output file}"`.


### PR DESCRIPTION
Five bash scripts that decouple the deep-review skill from raw GitHub API mechanics.

## New scripts

- **`fetch-pr-context.sh`** — Fetches PR metadata, reviews, inline comments, issue comments, and commits into structured JSON. Resolved threads excluded via GraphQL.
- **`post-review.sh`** — Posts reviews from structured JSON using source line numbers. Handles diff position computation internally. Supports thread resolution.
- **`diff-position-map.sh`** — Parses unified diffs into `{file, line} → position` maps.
- **`add-finding.sh`** — Helper for reviewer sub-agents to produce structured JSON findings.
- **`compile-findings.sh`** — Merges reviewer findings, detects convergence, computes max severity.

## SKILL.md and prompt changes

- Step 1: `fetch-pr-context.sh` replaces ad-hoc `gh`/`jq` for re-review detection. Shared diff saved once for all reviewers.
- Step 3: Reviewer prompts use `add-finding.sh` for structured JSON output, read shared diff.
- Step 4a: `compile-findings.sh` replaces manual markdown parsing.
- Step 5: `post-review.sh` replaces manual diff position math and `gh api` construction.
- Re-review flow uses GitHub thread resolution state as tracking mechanism.

## Testing

38 bats tests (32 offline, 6 integration against real coder/coder PRs).

<details><summary>Implementation plan / decision log</summary>

### Key decisions

- **bash + gh + jq** over Go: these are glue scripts calling APIs and reshaping JSON. No build step, no deps beyond what's already available.
- **Source line numbers in input, diff positions computed internally**: callers never deal with position math.
- **Resolved threads as re-review tracking**: `fetch-pr-context.sh` skips resolved threads. Unresolved threads carry forward. `post-review.sh` resolves threads via GraphQL mutations. No cross-session state needed.
- **Structured reviewer output via `add-finding.sh`**: reviewers call a script instead of hand-writing JSON. `compile-findings.sh` mechanically groups and computes max severity. Cross-check judgment stays with the orchestrator.
- **Shared diff**: orchestrator saves diff once, passes path to all reviewers. Eliminates N redundant `gh pr diff` calls.

### What stays unchanged

- Cross-check judgment logic (steps 4b–4c) — consequence chains, contradictions, quoting discipline
- Reviewer role definitions in `roles/`
- Severity scales, tone guidance, review body format

</details>

> 🤖