### PR TITLE
feat: spawn heartbeat for agent connection during port-forward

### DIFF
--- a/cli/portforward.go
+++ b/cli/portforward.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"golang.org/x/xerrors"
 
@@ -193,6 +194,50 @@ func (r *RootCmd) portForward() *serpent.Command {
 			conn.AwaitReachable(ctx)
 			logger.Debug(ctx, "read to accept connections to forward")
 			_, _ = fmt.Fprintln(inv.Stderr, "Ready!")
+
+			// Watchdog: periodically verify the agent is still reachable. If
+			// the tailnet connection drops and does not recover (e.g. after a
+			// laptop sleep or network change), cancel the command context so
+			// the listeners close and the process exits instead of accepting
+			// connections into a dead backend. See coder/coder#10626.
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				const (
+					interval    = 5 * time.Second
+					timeout     = 10 * time.Second
+					maxFailures = 3
+				)
+				ticker := time.NewTicker(interval)
+				defer ticker.Stop()
+				failures := 0
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case <-ticker.C:
+					}
+					pingCtx, pingCancel := context.WithTimeout(ctx, timeout)
+					reachable := conn.AwaitReachable(pingCtx)
+					pingCancel()
+					if reachable {
+						failures = 0
+						continue
+					}
+					if ctx.Err() != nil {
+						return
+					}
+					failures++
+					logger.Warn(ctx, "workspace agent unreachable",
+						slog.F("failures", failures), slog.F("max_failures", maxFailures))
+					if failures >= maxFailures {
+						_, _ = fmt.Fprintln(inv.Stderr, "Workspace agent unreachable, closing port-forward")
+						cancel()
+						return
+					}
+				}
+			}()
+
 			wg.Wait()
 			return closeErr
 		},

--- a/cli/portforward.go
+++ b/cli/portforward.go
@@ -22,6 +22,7 @@ import (
 	"github.com/coder/coder/v2/cli/cliui"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
+	"github.com/coder/quartz"
 	"github.com/coder/serpent"
 )
 
@@ -170,6 +171,7 @@ func (r *RootCmd) portForward() *serpent.Command {
 			// Wait for the context to be canceled or for a signal and close
 			// all listeners.
 			var closeErr error
+			watchdogErr := make(chan error, 1)
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
@@ -180,7 +182,15 @@ func (r *RootCmd) portForward() *serpent.Command {
 				select {
 				case <-ctx.Done():
 					logger.Debug(ctx, "command context expired waiting for signal", slog.Error(ctx.Err()))
-					closeErr = ctx.Err()
+					// If the watchdog triggered the cancellation, use
+					// its error so callers can distinguish agent
+					// failure from user-initiated cancellation.
+					select {
+					case err := <-watchdogErr:
+						closeErr = err
+					default:
+						closeErr = ctx.Err()
+					}
 				case sig := <-sigs:
 					logger.Debug(ctx, "received signal", slog.F("signal", sig))
 					_, _ = fmt.Fprintln(inv.Stderr, "\nReceived signal, closing all listeners and active connections")
@@ -192,49 +202,23 @@ func (r *RootCmd) portForward() *serpent.Command {
 			}()
 
 			conn.AwaitReachable(ctx)
-			logger.Debug(ctx, "read to accept connections to forward")
+			logger.Debug(ctx, "ready to accept connections to forward")
 			_, _ = fmt.Fprintln(inv.Stderr, "Ready!")
 
-			// Watchdog: periodically verify the agent is still reachable. If
-			// the tailnet connection drops and does not recover (e.g. after a
-			// laptop sleep or network change), cancel the command context so
-			// the listeners close and the process exits instead of accepting
-			// connections into a dead backend. See coder/coder#10626.
+			// Watchdog: periodically ping the agent to verify it is
+			// still reachable. If the connection drops and does not
+			// recover (e.g. after a laptop sleep or network change),
+			// cancel the command so the listeners close and the
+			// process exits instead of forwarding into a dead
+			// backend. See coder/coder#10626.
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				const (
-					interval    = 5 * time.Second
-					timeout     = 10 * time.Second
-					maxFailures = 3
-				)
-				ticker := time.NewTicker(interval)
-				defer ticker.Stop()
-				failures := 0
-				for {
-					select {
-					case <-ctx.Done():
-						return
-					case <-ticker.C:
-					}
-					pingCtx, pingCancel := context.WithTimeout(ctx, timeout)
-					reachable := conn.AwaitReachable(pingCtx)
-					pingCancel()
-					if reachable {
-						failures = 0
-						continue
-					}
-					if ctx.Err() != nil {
-						return
-					}
-					failures++
-					logger.Warn(ctx, "workspace agent unreachable",
-						slog.F("failures", failures), slog.F("max_failures", maxFailures))
-					if failures >= maxFailures {
-						_, _ = fmt.Fprintln(inv.Stderr, "Workspace agent unreachable, closing port-forward")
-						cancel()
-						return
-					}
+				err := agentHeartbeat(ctx, conn, logger, quartz.NewReal(), watchdogInterval, watchdogTimeout, watchdogMaxFailures)
+				if err != nil {
+					_, _ = fmt.Fprintln(inv.Stderr, "Workspace agent unreachable, closing port-forward")
+					watchdogErr <- err
+					cancel()
 				}
 			}()
 
@@ -328,6 +312,66 @@ func listenAndPortForward(
 	}(spec)
 
 	return l, nil
+}
+
+const (
+	// watchdogInterval is how often the watchdog pings the agent.
+	watchdogInterval = 5 * time.Second
+	// watchdogTimeout is the per-ping timeout.
+	watchdogTimeout = 10 * time.Second
+	// watchdogMaxFailures is how many consecutive ping failures
+	// trigger a shutdown.
+	watchdogMaxFailures = 3
+)
+
+// agentHeartbeat periodically pings the workspace agent and returns
+// an error after maxFailures consecutive failures. It returns nil
+// when ctx is canceled for any other reason.
+func agentHeartbeat(
+	ctx context.Context,
+	conn workspacesdk.AgentConn,
+	logger slog.Logger,
+	clk quartz.Clock,
+	interval, timeout time.Duration,
+	maxFailures int,
+) error {
+	failures := 0
+	var lastErr error
+	w := clk.TickerFunc(ctx, interval, func() error {
+		pingCtx, pingCancel := context.WithTimeout(ctx, timeout)
+		_, _, _, err := conn.Ping(pingCtx)
+		pingCancel()
+		if err == nil {
+			failures = 0
+			return nil
+		}
+		// If the parent context was canceled, this isn't an agent
+		// reachability failure — just a normal shutdown.
+		if ctx.Err() != nil {
+			return nil
+		}
+		failures++
+		logger.Debug(ctx, "agent ping failed",
+			slog.F("failures", failures),
+			slog.F("max_failures", maxFailures),
+			slog.Error(err),
+		)
+		if failures >= maxFailures {
+			logger.Warn(ctx, "agent unreachable, shutting down",
+				slog.F("failures", failures),
+				slog.Error(err),
+			)
+			lastErr = err
+			return xerrors.Errorf("agent unreachable after %d consecutive failed pings: %w", maxFailures, err)
+		}
+		return nil
+	}, "agentHeartbeat")
+	err := w.Wait()
+	if lastErr != nil {
+		return err
+	}
+	// Context cancellation — normal shutdown.
+	return nil
 }
 
 type portForwardSpec struct {

--- a/cli/portforward_internal_test.go
+++ b/cli/portforward_internal_test.go
@@ -1,9 +1,20 @@
 package cli
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	ipnstate "tailscale.com/ipn/ipnstate"
+
+	"cdr.dev/slog/v3"
+	"cdr.dev/slog/v3/sloggers/slogtest"
+	"github.com/coder/coder/v2/codersdk/workspacesdk/agentconnmock"
+	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/quartz"
 )
 
 func Test_parsePortForwards(t *testing.T) {
@@ -114,4 +125,155 @@ func Test_parsePortForwards(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func Test_agentHeartbeat(t *testing.T) {
+	t.Parallel()
+
+	const (
+		interval    = 5 * time.Second
+		timeout     = 10 * time.Second
+		maxFailures = 3
+	)
+
+	// startHeartbeat launches agentHeartbeat in a goroutine and waits
+	// for the TickerFunc to be registered with the mock clock before
+	// returning. This ensures AdvanceNext will find the ticker.
+	startHeartbeat := func(
+		ctx context.Context,
+		mock *agentconnmock.MockAgentConn,
+		logger slog.Logger,
+		mClock *quartz.Mock,
+	) <-chan error {
+		trap := mClock.Trap().TickerFunc("agentHeartbeat")
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- agentHeartbeat(ctx, mock, logger, mClock, interval, timeout, maxFailures)
+		}()
+		trap.MustWait(ctx).Release(ctx)
+		trap.Close()
+		return errCh
+	}
+
+	t.Run("ReturnsErrAfterConsecutiveFailures", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mock := agentconnmock.NewMockAgentConn(ctrl)
+		logger := slogtest.Make(t, nil)
+		mClock := quartz.NewMock(t)
+
+		mock.EXPECT().
+			Ping(gomock.Any()).
+			Return(time.Duration(0), false, &ipnstate.PingResult{}, assert.AnError).
+			Times(maxFailures)
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		errCh := startHeartbeat(ctx, mock, logger, mClock)
+
+		for range maxFailures {
+			_, w := mClock.AdvanceNext()
+			w.MustWait(ctx)
+		}
+
+		err := testutil.TryReceive(ctx, t, errCh)
+		require.ErrorIs(t, err, assert.AnError)
+		require.Contains(t, err.Error(), "consecutive failed pings")
+	})
+
+	t.Run("ResetsCounterOnSuccess", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mock := agentconnmock.NewMockAgentConn(ctrl)
+		logger := slogtest.Make(t, nil)
+		mClock := quartz.NewMock(t)
+
+		// Fail twice, succeed once (resets counter), then fail three
+		// more times to trigger the error.
+		gomock.InOrder(
+			mock.EXPECT().Ping(gomock.Any()).
+				Return(time.Duration(0), false, &ipnstate.PingResult{}, assert.AnError).
+				Times(2),
+			mock.EXPECT().Ping(gomock.Any()).
+				Return(time.Millisecond, true, &ipnstate.PingResult{}, nil).
+				Times(1),
+			mock.EXPECT().Ping(gomock.Any()).
+				Return(time.Duration(0), false, &ipnstate.PingResult{}, assert.AnError).
+				Times(maxFailures),
+		)
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		errCh := startHeartbeat(ctx, mock, logger, mClock)
+
+		// 2 failures + 1 success + 3 failures = 6 ticks.
+		for range 2 + 1 + maxFailures {
+			_, w := mClock.AdvanceNext()
+			w.MustWait(ctx)
+		}
+
+		err := testutil.TryReceive(ctx, t, errCh)
+		require.ErrorIs(t, err, assert.AnError)
+		require.Contains(t, err.Error(), "consecutive failed pings")
+	})
+
+	t.Run("ReturnsNilOnContextCancel", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mock := agentconnmock.NewMockAgentConn(ctrl)
+		logger := slogtest.Make(t, nil)
+		mClock := quartz.NewMock(t)
+
+		testCtx := testutil.Context(t, testutil.WaitShort)
+		ctx, cancel := context.WithCancel(testCtx)
+
+		mock.EXPECT().
+			Ping(gomock.Any()).
+			Return(time.Millisecond, true, &ipnstate.PingResult{}, nil).
+			AnyTimes()
+
+		errCh := startHeartbeat(ctx, mock, logger, mClock)
+
+		// A few successful pings, then cancel.
+		for range 3 {
+			_, w := mClock.AdvanceNext()
+			w.MustWait(testCtx)
+		}
+		cancel()
+
+		err := testutil.TryReceive(testCtx, t, errCh)
+		require.NoError(t, err)
+	})
+
+	t.Run("ContextCancelDuringFailureIsNotError", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mock := agentconnmock.NewMockAgentConn(ctrl)
+		logger := slogtest.Make(t, nil)
+		mClock := quartz.NewMock(t)
+
+		testCtx := testutil.Context(t, testutil.WaitShort)
+		ctx, cancel := context.WithCancel(testCtx)
+
+		callCount := 0
+		mock.EXPECT().
+			Ping(gomock.Any()).
+			DoAndReturn(func(_ context.Context) (time.Duration, bool, *ipnstate.PingResult, error) {
+				callCount++
+				if callCount >= 2 {
+					cancel()
+				}
+				return time.Duration(0), false, &ipnstate.PingResult{}, assert.AnError
+			}).
+			AnyTimes()
+
+		errCh := startHeartbeat(ctx, mock, logger, mClock)
+
+		// Advance twice — second ping cancels the context.
+		for range 2 {
+			_, w := mClock.AdvanceNext()
+			w.MustWait(testCtx)
+		}
+
+		err := testutil.TryReceive(testCtx, t, errCh)
+		require.NoError(t, err)
+	})
 }


### PR DESCRIPTION
Taking over the changeset submitted by @zertosh in https://github.com/coder/coder/pull/24011