### PR TITLE
fix: prevent 'See all templates' from overlapping template list in New Workspace dropdown

### DIFF
--- a/site/src/components/OverflowY/OverflowY.tsx
+++ b/site/src/components/OverflowY/OverflowY.tsx
@@ -2,6 +2,7 @@
  * @file Provides reusable vertical overflow behavior.
  */
 import type { FC, ReactNode } from "react";
+import { cn } from "#/utils/cn";
 
 type OverflowYProps = {
 	children?: ReactNode;
@@ -12,6 +13,7 @@ type OverflowYProps = {
 
 export const OverflowY: FC<OverflowYProps> = ({
 	children,
+	className,
 	height,
 	maxHeight,
 	...attrs
@@ -27,7 +29,7 @@ export const OverflowY: FC<OverflowYProps> = ({
 
 	return (
 		<div
-			className="w-full overflow-y-auto shrink"
+			className={cn("w-full overflow-y-auto shrink", className)}
 			style={{
 				height: computedHeight,
 				maxHeight: computedMaxHeight,

--- a/site/src/pages/WorkspacesPage/WorkspacesButton.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesButton.tsx
@@ -63,7 +63,7 @@ export const WorkspacesButton: FC<WorkspacesButtonProps> = ({
 			</PopoverTrigger>
 			<PopoverContent
 				align="end"
-				className="bg-surface-secondary border-surface-quaternary w-[320px]"
+				className="bg-surface-secondary border-surface-quaternary w-[320px] overflow-hidden flex flex-col"
 			>
 				<MenuSearch
 					value={searchTerm}
@@ -73,7 +73,7 @@ export const WorkspacesButton: FC<WorkspacesButtonProps> = ({
 					aria-label="Template select for workspace"
 				/>
 
-				<OverflowY maxHeight={380} className="flex flex-col py-2">
+				<OverflowY maxHeight={380} className="flex flex-col py-2 min-h-0">
 					{templatesFetchStatus === "pending" ? (
 						<Loader size="sm" />
 					) : (


### PR DESCRIPTION
## Summary

Fixes the "See all templates" link overlapping template items in the New Workspace dropdown.

## Root cause

Two compounding issues:

1. **`OverflowY` className was being overwritten, not merged.** The component spread `...attrs` (which included the caller's `className`) onto the div, silently replacing its own base classes (`overflow-y-auto`, `shrink`, `w-full`). This meant the template list never scrolled independently.

2. **`PopoverContent` has `overflow-y-auto` in its base styles.** With the inner `OverflowY` not scrolling, the *entire popover* became the scroll container. The "See all templates" footer was part of that scrollable flow and overlapped template rows as the user scrolled.

## Fix

- **`OverflowY`**: Destructure `className` explicitly and merge it with the base classes using `cn()` so `overflow-y-auto` and `shrink` are always preserved.
- **`PopoverContent`**: Add `overflow-hidden flex flex-col` to make it a non-scrolling flex container. Only the `OverflowY` child scrolls.
- **`OverflowY` usage**: Add `min-h-0` so the flex child can shrink below its content size when the popover's available height is constrained.

## Screenshot
<img width="1460" height="1072" alt="image" src="https://github.com/user-attachments/assets/9b519f2d-9806-44ca-a354-12248de36952" />

> 🤖 Generated with [Coder Agents](https://coder.com/agents)