### PR TITLE
fix: resolve double border on `<WorkspaceTimings />`

### DIFF
--- a/site/src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.tsx
+++ b/site/src/modules/workspaces/WorkspaceTiming/WorkspaceTimings.tsx
@@ -99,7 +99,7 @@ export const WorkspaceTimings: FC<WorkspaceTimingsProps> = ({
 	};
 
 	return (
-		<div className="rounded-lg border-solid bg-surface-primary">
+		<div className="rounded-lg border border-solid bg-surface-primary">
 			<div className="flex items-center justify-between px-4 py-1.5 relative">
 				<Button
 					disabled={isLoading}


### PR DESCRIPTION
This pull-request ensures that we don't get a `2px` border on our `Workspace timeline` inside of the workspace pages border.

| Old | New |
| --- | --- |
| <img width="382" height="192" alt="PREVIEW_TIMELINE_OLD" src="https://github.com/user-attachments/assets/ccc1082d-f4d5-497e-8421-2b53ac8fcd5b" /> | <img width="382" height="195" alt="PREVIEW_TIMELINE_NEW" src="https://github.com/user-attachments/assets/4a6f800a-0f2f-449f-94e7-abc6a9b22bbf" /> |