### PR TITLE
fix(site/src/pages/AgentsPage): remove double border at top of RightPanel

### DIFF
--- a/site/src/pages/AgentsPage/components/RightPanel/RightPanel.tsx
+++ b/site/src/pages/AgentsPage/components/RightPanel/RightPanel.tsx
@@ -237,7 +237,7 @@ export const RightPanel = ({
 				visualExpanded
 					? "absolute inset-0 z-30 flex flex-col"
 					: visualOpen
-						? "fixed inset-0 z-30 flex flex-col bg-surface-primary lg:relative lg:inset-auto lg:z-auto lg:h-full lg:min-h-0 lg:border-l lg:border-solid lg:border-border-default lg:w-[var(--panel-width)] lg:min-w-[360px] lg:max-w-[70vw]"
+						? "fixed inset-0 z-30 flex flex-col bg-surface-primary lg:relative lg:inset-auto lg:z-auto lg:h-full lg:min-h-0 lg:border-0 lg:border-l lg:border-solid lg:border-border-default lg:w-[var(--panel-width)] lg:min-w-[360px] lg:max-w-[70vw]"
 						: "relative min-h-0 min-w-0 hidden",
 			)}
 		>


### PR DESCRIPTION
> [!NOTE]
> 🤖 Generated with [Coder Agents](https://coder.com) on behalf of Danielle Maywood

Tailwind preflight is disabled in this project (`preflight: false` in `tailwind.config.js`), so elements don't get the default `border-width: 0` reset. The RightPanel applied `lg:border-solid` (which sets `border-style: solid` on all four sides) together with `lg:border-l` (which only sets `border-left-width: 1px`). This left the top, right, and bottom sides with the browser's default `medium` border width, causing a visible border at the top of the panel.

Added `lg:border-0` before `lg:border-l` to explicitly zero all sides before setting the left border.