### PR TITLE
fix: use findByRole in ProviderWithUserKeysOnly storybook to avoid race condition

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ChatModelAdminPanel.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ChatModelAdminPanel.stories.tsx
@@ -645,10 +645,10 @@ export const ProviderWithUserKeysOnly: Story = {
 		const body = within(canvasElement.ownerDocument.body);
 		await userEvent.click(await body.findByRole("button", { name: /Google/i }));
 		await expect(
-			body.getByRole("switch", { name: "Central API key" }),
+			await body.findByRole("switch", { name: "Central API key" }),
 		).not.toBeChecked();
 		await expect(
-			body.getByRole("switch", { name: "Allow user API keys" }),
+			await body.findByRole("switch", { name: "Allow user API keys" }),
 		).toBeChecked();
 		expect(body.queryByLabelText(/^API Key$/i)).not.toBeInTheDocument();
 		expect(


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood

The `ProviderWithUserKeysOnly` storybook play function used synchronous `getByRole` to query switch elements immediately after clicking the accordion button. The form may not have rendered yet at that point, causing the "Unable to find an accessible element with the role 'switch'" error intermittently.

Changed the two `body.getByRole("switch", ...)` calls to `await body.findByRole("switch", ...)` which retries until the element appears. This matches the pattern used by all other provider stories (`ProviderAccordionCards`, `ProviderWithUserAndCentralKeys`, `ProviderWithCentralFallback`, etc.).