### PR TITLE
fix: use VSCode icons instead of ExternalLinkIcon on agent page workspace selector

### DIFF
--- a/site/src/pages/AgentsPage/components/WorkspacePill.tsx
+++ b/site/src/pages/AgentsPage/components/WorkspacePill.tsx
@@ -1,7 +1,6 @@
 import {
 	ChevronDownIcon,
 	CopyIcon,
-	ExternalLinkIcon,
 	LayoutGridIcon,
 	MonitorIcon,
 	SquareTerminalIcon,
@@ -26,6 +25,8 @@ import {
 	DropdownMenuTrigger,
 } from "#/components/DropdownMenu/DropdownMenu";
 import { ExternalImage } from "#/components/ExternalImage/ExternalImage";
+import { VSCodeIcon } from "#/components/Icons/VSCodeIcon";
+import { VSCodeInsidersIcon } from "#/components/Icons/VSCodeInsidersIcon";
 import {
 	Tooltip,
 	TooltipContent,
@@ -220,7 +221,11 @@ const VSCodeMenuItem: FC<{
 			onSelect={handleClick}
 			disabled={isGeneratingKey || !isRunning}
 		>
-			<ExternalLinkIcon className="size-3.5" />
+			{variant === "vscode" ? (
+				<VSCodeIcon className="size-3.5" />
+			) : (
+				<VSCodeInsidersIcon className="size-3.5" />
+			)}
 			{label}
 		</DropdownMenuItem>
 	);


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood

The VSCode button in the agent page workspace selector dropdown was using a generic `ExternalLinkIcon` from lucide-react instead of the proper VSCode/VSCode Insiders icons.

This replaces it with `VSCodeIcon` and `VSCodeInsidersIcon` (which already exist in the codebase and are used correctly in `VSCodeDesktopButton`), selecting the correct one based on the `variant` prop.