### PR TITLE
fix(site): style navbar version badge as a notch

### DIFF
--- a/site/src/modules/dashboard/Navbar/NavbarView.tsx
+++ b/site/src/modules/dashboard/Navbar/NavbarView.tsx
@@ -87,12 +87,12 @@ export const NavbarView: FC<NavbarViewProps> = ({
 					href={buildInfo.external_url}
 					target="_blank"
 					rel="noreferrer"
-					className="absolute top-1 left-1/2 -translate-x-1/2 no-underline z-10"
+					className="absolute top-0 left-1/2 -translate-x-1/2 no-underline z-10"
 				>
 					<Badge
 						variant={isRc ? "info" : "warning"}
 						size="sm"
-						className="font-mono"
+						className="font-mono rounded-t-none border-t-0"
 					>
 						{buildInfo.version}
 					</Badge>


### PR DESCRIPTION
- Pin version badge flush to viewport top (`top-0`)
- Remove top border (`border-t-0`) and top border-radius (`rounded-t-none`) for a "notch" appearance

<details><summary>Implementation notes</summary>

Two className changes in `NavbarView.tsx`:
1. Anchor: `top-1` → `top-0`
2. Badge: added `rounded-t-none border-t-0`

No component or behavioral changes. Existing Storybook stories (`DevelBuild`, `RcBuild`, `RcDevelBuild`) cover visual output.
</details>

> 🤖