### PR TITLE
fix(site): apply message parts synchronously to prevent duplicate chat messages

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -3034,8 +3034,7 @@ describe("useChatStore", () => {
 });
 
 describe("thinking indicator event ordering", () => {
-	it("shows starting phase when message_part arrives before status:running in same batch", async () => {
-		vi.useFakeTimers({ shouldAdvanceTime: true });
+	it("applies message_part synchronously even when it arrives before status:running in same batch", async () => {
 		immediateAnimationFrame();
 
 		const chatID = "chat-thinking-parts-before-status";
@@ -3079,8 +3078,8 @@ describe("thinking indicator event ordering", () => {
 		});
 
 		// Server sends message_part BEFORE status:running in the same
-		// WebSocket frame. This is the event ordering that previously
-		// caused the "Thinking..." indicator to be skipped.
+		// WebSocket frame. Parts are now applied synchronously at the
+		// end of the batch, so stream state is populated immediately.
 		act(() => {
 			mockSocket.emitDataBatch([
 				{
@@ -3098,29 +3097,15 @@ describe("thinking indicator event ordering", () => {
 			]);
 		});
 
-		// After the batch, the status should be "running" but stream
-		// parts should NOT have been applied yet (deferred to
-		// setTimeout). This is the window where "Thinking..." shows.
+		// Status is running and stream state is populated in the
+		// same batch — no deferred timer needed.
 		await waitFor(() => {
 			expect(result.current.chatStatus).toBe("running");
-			expect(result.current.streamState).toBeNull();
-			expect(result.current.isAwaiting).toBe(true);
-		});
-
-		// Let the deferred parts flush fire (setTimeout 0).
-		await act(async () => {
-			vi.advanceTimersByTime(1);
-		});
-
-		// Now stream state should be populated.
-		await waitFor(() => {
 			expect(result.current.streamState).not.toBeNull();
 			expect(result.current.isAwaiting).toBe(false);
 		});
 	});
-
-	it("shows starting phase when status:running arrives before message_part in same batch", async () => {
-		vi.useFakeTimers({ shouldAdvanceTime: true });
+	it("applies message_part synchronously even when status:running arrives before it in same batch", async () => {
 		immediateAnimationFrame();
 
 		const chatID = "chat-thinking-status-before-parts";
@@ -3163,7 +3148,8 @@ describe("thinking indicator event ordering", () => {
 			expect(watchChat).toHaveBeenCalledWith(chatID, 1);
 		});
 
-		// Server sends status:running BEFORE message_part (the "good" order).
+		// Server sends status:running BEFORE message_part. Parts are
+		// now applied synchronously at the end of the batch.
 		act(() => {
 			mockSocket.emitDataBatch([
 				{
@@ -3181,24 +3167,14 @@ describe("thinking indicator event ordering", () => {
 			]);
 		});
 
-		// Same contract: status set, parts deferred.
+		// Status is running and stream state is populated in the
+		// same batch — no deferred timer needed.
 		await waitFor(() => {
 			expect(result.current.chatStatus).toBe("running");
-			expect(result.current.streamState).toBeNull();
-			expect(result.current.isAwaiting).toBe(true);
-		});
-
-		// Let the deferred parts flush fire.
-		await act(async () => {
-			vi.advanceTimersByTime(1);
-		});
-
-		await waitFor(() => {
 			expect(result.current.streamState).not.toBeNull();
 			expect(result.current.isAwaiting).toBe(false);
 		});
 	});
-
 	it("discards buffered parts when status transitions to pending", async () => {
 		vi.useFakeTimers({ shouldAdvanceTime: true });
 		immediateAnimationFrame();
@@ -3929,6 +3905,340 @@ describe("stream-to-durable transition (Bug 1)", () => {
 			(s) => s.hasStream && s.hasDurableAssistant,
 		);
 		expect(overlapping).toEqual([]);
+	});
+
+	it("cross-message race: no overlap when parts arrive in a separate WS message from the durable commit", async () => {
+		try {
+			vi.useFakeTimers({ shouldAdvanceTime: true });
+			immediateAnimationFrame();
+
+			const chatID = "chat-b1-cross-msg";
+			const userMsg = makeMessage(chatID, 1, "user", "hey");
+			const mockSocket = createMockSocket();
+			mockWatchChatReturn(mockSocket);
+
+			const queryClient = createTestQueryClient();
+			const wrapper = ({ children }: PropsWithChildren) => (
+				<QueryClientProvider client={queryClient}>
+					{children}
+				</QueryClientProvider>
+			);
+
+			const snapshots: Array<{
+				hasStream: boolean;
+				hasDurableAssistant: boolean;
+			}> = [];
+
+			const { result } = renderHook(
+				() => {
+					const { store } = useChatStore({
+						chatID,
+						chatMessages: [userMsg],
+						chatRecord: makeChat(chatID),
+						chatMessagesData: {
+							messages: [userMsg],
+							queued_messages: [],
+							has_more: false,
+						},
+						chatQueuedMessages: [],
+						setChatErrorReason: vi.fn(),
+						clearChatErrorReason: vi.fn(),
+					});
+					const streamState = useChatSelector(store, selectStreamState);
+					const messagesByID = useChatSelector(store, selectMessagesByID);
+					const hasDurableAssistant = Array.from(messagesByID.values()).some(
+						(m) => m.role === "assistant",
+					);
+
+					snapshots.push({
+						hasStream: streamState !== null,
+						hasDurableAssistant,
+					});
+
+					return { streamState, messagesByID };
+				},
+				{ wrapper },
+			);
+
+			await waitFor(() => {
+				expect(watchChat).toHaveBeenCalledWith(chatID, 1);
+			});
+
+			// WS message 1: streaming part arrives.
+			act(() => {
+				mockSocket.emitData({
+					type: "message_part",
+					chat_id: chatID,
+					message_part: {
+						role: "assistant",
+						part: { type: "text", text: "cross-msg" },
+					},
+				});
+			});
+
+			await waitFor(() => {
+				expect(result.current.streamState).not.toBeNull();
+			});
+
+			// Clear history before the critical transition.
+			snapshots.length = 0;
+
+			// Advance timer to flush any deferred work from old code.
+			await act(async () => {
+				vi.advanceTimersByTime(0);
+			});
+
+			// WS message 2: durable assistant commit arrives as a
+			// separate WebSocket message.
+			act(() => {
+				mockSocket.emitData({
+					type: "message",
+					chat_id: chatID,
+					message: makeMessage(chatID, 2, "assistant", "cross-msg"),
+				});
+			});
+
+			await waitFor(() => {
+				expect(result.current.messagesByID.has(2)).toBe(true);
+			});
+
+			const overlapping = snapshots.filter(
+				(s) => s.hasStream && s.hasDurableAssistant,
+			);
+			expect(overlapping).toEqual([]);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("parts are applied synchronously within the batch, not deferred", async () => {
+		immediateAnimationFrame();
+
+		const chatID = "chat-b1-sync-apply";
+		const userMsg = makeMessage(chatID, 1, "user", "prompt");
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createTestQueryClient();
+		const wrapper = ({ children }: PropsWithChildren) => (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+
+		const { result } = renderHook(
+			() => {
+				const { store } = useChatStore({
+					chatID,
+					chatMessages: [userMsg],
+					chatRecord: makeChat(chatID),
+					chatMessagesData: {
+						messages: [userMsg],
+						queued_messages: [],
+						has_more: false,
+					},
+					chatQueuedMessages: [],
+					setChatErrorReason: vi.fn(),
+					clearChatErrorReason: vi.fn(),
+				});
+				return {
+					streamState: useChatSelector(store, selectStreamState),
+				};
+			},
+			{ wrapper },
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, 1);
+		});
+
+		// Emit status=running then a message_part. The stream state
+		// should be available immediately after act() completes
+		// without needing any timer advancement.
+		act(() => {
+			mockSocket.emitData({
+				type: "status",
+				chat_id: chatID,
+				status: { status: "running" },
+			});
+			mockSocket.emitData({
+				type: "message_part",
+				chat_id: chatID,
+				message_part: {
+					role: "assistant",
+					part: { type: "text", text: "sync-check" },
+				},
+			});
+		});
+
+		// No timer advancement — parts should already be visible.
+		expect(result.current.streamState?.blocks).toEqual([
+			{ type: "response", text: "sync-check" },
+		]);
+	});
+
+	it("parts buffer is drained synchronously before stream reset in multi-turn", async () => {
+		immediateAnimationFrame();
+
+		const chatID = "chat-b1-multi-turn-batch";
+		const userMsg = makeMessage(chatID, 1, "user", "go");
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createTestQueryClient();
+		const wrapper = ({ children }: PropsWithChildren) => (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+
+		const { result } = renderHook(
+			() => {
+				const { store } = useChatStore({
+					chatID,
+					chatMessages: [userMsg],
+					chatRecord: makeChat(chatID),
+					chatMessagesData: {
+						messages: [userMsg],
+						queued_messages: [],
+						has_more: false,
+					},
+					chatQueuedMessages: [],
+					setChatErrorReason: vi.fn(),
+					clearChatErrorReason: vi.fn(),
+				});
+				return {
+					streamState: useChatSelector(store, selectStreamState),
+					orderedIDs: useChatSelector(store, selectOrderedMessageIDs),
+					messagesByID: useChatSelector(store, selectMessagesByID),
+				};
+			},
+			{ wrapper },
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, 1);
+		});
+
+		// Single WS message containing turn 1 part, turn 1 commit,
+		// and start of turn 2 — all in one batch.
+		act(() => {
+			mockSocket.emitDataBatch([
+				{
+					type: "message_part",
+					chat_id: chatID,
+					message_part: {
+						role: "assistant",
+						part: { type: "text", text: "turn1" },
+					},
+				},
+				{
+					type: "message",
+					chat_id: chatID,
+					message: makeMessage(chatID, 2, "assistant", "turn1"),
+				},
+				{
+					type: "message_part",
+					chat_id: chatID,
+					message_part: {
+						role: "assistant",
+						part: { type: "text", text: "turn2" },
+					},
+				},
+			]);
+		});
+
+		// Turn 1 must be committed as a durable message.
+		await waitFor(() => {
+			expect(result.current.orderedIDs).toContain(2);
+			expect(result.current.messagesByID.get(2)?.role).toBe("assistant");
+		});
+
+		// Stream state should contain only the turn 2 part.
+		expect(result.current.streamState?.blocks).toEqual([
+			{ type: "response", text: "turn2" },
+		]);
+	});
+
+	it("rapid multi-turn cycles across separate WS messages produce no overlap", async () => {
+		try {
+			vi.useFakeTimers({ shouldAdvanceTime: true });
+			immediateAnimationFrame();
+
+			const chatID = "chat-b1-rapid-turns";
+			const userMsg = makeMessage(chatID, 1, "user", "start");
+			const mockSocket = createMockSocket();
+			mockWatchChatReturn(mockSocket);
+
+			const queryClient = createTestQueryClient();
+			const wrapper = ({ children }: PropsWithChildren) => (
+				<QueryClientProvider client={queryClient}>
+					{children}
+				</QueryClientProvider>
+			);
+
+			const { result } = renderHook(
+				() => {
+					const { store } = useChatStore({
+						chatID,
+						chatMessages: [userMsg],
+						chatRecord: makeChat(chatID),
+						chatMessagesData: {
+							messages: [userMsg],
+							queued_messages: [],
+							has_more: false,
+						},
+						chatQueuedMessages: [],
+						setChatErrorReason: vi.fn(),
+						clearChatErrorReason: vi.fn(),
+					});
+					const streamState = useChatSelector(store, selectStreamState);
+					const messagesByID = useChatSelector(store, selectMessagesByID);
+					return { streamState, messagesByID };
+				},
+				{ wrapper },
+			);
+
+			await waitFor(() => {
+				expect(watchChat).toHaveBeenCalledWith(chatID, 1);
+			});
+
+			// Simulate 3 rapid turns: each turn streams a part in one
+			// WS message, then commits the durable message in the next.
+			// After each commit, stream state must be cleared for that
+			// turn so the committed content does not also appear in
+			// the streaming output.
+			for (let turn = 0; turn < 3; turn++) {
+				const msgID = 2 + turn;
+
+				act(() => {
+					mockSocket.emitData({
+						type: "message_part",
+						chat_id: chatID,
+						message_part: {
+							role: "assistant",
+							part: { type: "text", text: `turn-${turn}` },
+						},
+					});
+				});
+
+				// Flush deferred work between WS messages.
+				await act(async () => {
+					vi.advanceTimersByTime(0);
+				});
+
+				act(() => {
+					mockSocket.emitData({
+						type: "message",
+						chat_id: chatID,
+						message: makeMessage(chatID, msgID, "assistant", `turn-${turn}`),
+					});
+				});
+
+				await waitFor(() => {
+					expect(result.current.messagesByID.has(msgID)).toBe(true);
+					expect(result.current.streamState).toBeNull();
+				});
+			}
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 });
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -3105,6 +3105,7 @@ describe("thinking indicator event ordering", () => {
 			expect(result.current.isAwaiting).toBe(false);
 		});
 	});
+
 	it("applies message_part synchronously even when status:running arrives before it in same batch", async () => {
 		immediateAnimationFrame();
 
@@ -3175,6 +3176,7 @@ describe("thinking indicator event ordering", () => {
 			expect(result.current.isAwaiting).toBe(false);
 		});
 	});
+
 	it("discards buffered parts when status transitions to pending", async () => {
 		vi.useFakeTimers({ shouldAdvanceTime: true });
 		immediateAnimationFrame();

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -1168,7 +1168,7 @@ describe("useChatStore", () => {
 
 		// The old WebSocket was closed during effect cleanup.
 		expect(mockSocket1.close).toHaveBeenCalled();
-		// Stream state was reset — no stale stream data from chat-1.
+		// Stream state was reset so no stale stream data from chat-1.
 		expect(result.current.streamState).toBeNull();
 	});
 
@@ -1306,7 +1306,7 @@ describe("useChatStore", () => {
 			});
 		});
 
-		// Stream state should still be present — the mismatched event
+		// Stream state should still be present because the mismatched event
 		// was filtered and did not trigger a stream reset.
 		await waitFor(() => {
 			expect(result.current.streamState?.blocks).toEqual([
@@ -1390,10 +1390,10 @@ describe("useChatStore", () => {
 		});
 
 		// Emit a durable message followed by a message_part in the
-		// same batch. The message handler calls scheduleStreamReset
-		// (via rAF), and the subsequent message_part handler calls
-		// cancelScheduledStreamReset to prevent a flash. The final
-		// flushMessageParts re-populates stream state.
+		// same batch. The needsStreamReset flag clears stream state
+		// after the durable commit, but parts arriving after the
+		// message event in the same batch survive the reset and
+		// re-populate stream state for the next turn.
 		act(() => {
 			mockSocket.emitDataBatch([
 				{
@@ -1583,7 +1583,7 @@ describe("useChatStore", () => {
 		});
 
 		// After the switch, queued messages from chat-1 should NOT be
-		// visible — the store resets them on chatID change.
+		// visible since the store resets them on chatID change.
 		await waitFor(() => {
 			expect(watchChat).toHaveBeenCalledWith(chatID2, undefined);
 		});
@@ -1652,7 +1652,7 @@ describe("useChatStore", () => {
 			]);
 		});
 
-		// Stream state should be null — the status change cleared it,
+		// Stream state should be null because the status change cleared it,
 		// and the deferred applyMessageParts should not have
 		// re-populated it.
 		await waitFor(() => {
@@ -1929,7 +1929,7 @@ describe("useChatStore", () => {
 			});
 		});
 
-		// Transition to running — should clear retry state.
+		// Transition to running which should clear retry state.
 		act(() => {
 			mockSocket.emitData({
 				type: "status",
@@ -2089,7 +2089,7 @@ describe("useChatStore", () => {
 			);
 		});
 		// Main chat status should remain "running" from the initial
-		// chatRecord — the subagent status event must not change it.
+		// chatRecord so the subagent status event must not change it.
 		expect(result.current.chatStatus).toBe("running");
 	});
 
@@ -2423,7 +2423,7 @@ describe("useChatStore", () => {
 			timeout: 3_000,
 		});
 
-		// Second disconnect — reconnect after 2s.
+		// Second disconnect triggers reconnect after 2s.
 		const socket2 = sockets[1]!;
 		act(() => socket2.emitClose());
 
@@ -2661,7 +2661,7 @@ describe("useChatStore", () => {
 			expect(watchChat).toHaveBeenCalledWith(chatID, undefined);
 		});
 
-		// Transition to running — should call clearChatErrorReason.
+		// Transition to running which should call clearChatErrorReason.
 		act(() => {
 			mockSocket.emitData({
 				type: "status",
@@ -2737,7 +2737,7 @@ describe("useChatStore", () => {
 			},
 		});
 
-		// Messages 2 and 3 should be removed — replaceMessages should
+		// Messages 2 and 3 should be removed since replaceMessages should
 		// have been used instead of upsert because the store contained
 		// IDs not present in the fetched set.
 		await waitFor(() => {
@@ -3098,7 +3098,7 @@ describe("thinking indicator event ordering", () => {
 		});
 
 		// Status is running and stream state is populated in the
-		// same batch — no deferred timer needed.
+		// same batch with no deferred timer needed.
 		await waitFor(() => {
 			expect(result.current.chatStatus).toBe("running");
 			expect(result.current.streamState).not.toBeNull();
@@ -3168,7 +3168,7 @@ describe("thinking indicator event ordering", () => {
 		});
 
 		// Status is running and stream state is populated in the
-		// same batch — no deferred timer needed.
+		// same batch with no deferred timer needed.
 		await waitFor(() => {
 			expect(result.current.chatStatus).toBe("running");
 			expect(result.current.streamState).not.toBeNull();
@@ -3382,7 +3382,7 @@ describe("updateSidebarChat via stream events", () => {
 			});
 		});
 
-		// The per-chat WebSocket does not write updated_at — only the
+		// The per-chat WebSocket does not write updated_at so only the
 		// global chat-list WebSocket delivers the authoritative server
 		// timestamp. Verify it stays at the original value.
 		await waitFor(() => {
@@ -3914,6 +3914,7 @@ describe("stream-to-durable transition (Bug 1)", () => {
 
 			const chatID = "chat-b1-cross-msg";
 			const userMsg = makeMessage(chatID, 1, "user", "hey");
+			const turn1Msg = makeMessage(chatID, 2, "assistant", "turn1-done");
 			const mockSocket = createMockSocket();
 			mockWatchChatReturn(mockSocket);
 
@@ -3926,7 +3927,7 @@ describe("stream-to-durable transition (Bug 1)", () => {
 
 			const snapshots: Array<{
 				hasStream: boolean;
-				hasDurableAssistant: boolean;
+				hasTurn2Durable: boolean;
 			}> = [];
 
 			const { result } = renderHook(
@@ -3946,13 +3947,10 @@ describe("stream-to-durable transition (Bug 1)", () => {
 					});
 					const streamState = useChatSelector(store, selectStreamState);
 					const messagesByID = useChatSelector(store, selectMessagesByID);
-					const hasDurableAssistant = Array.from(messagesByID.values()).some(
-						(m) => m.role === "assistant",
-					);
 
 					snapshots.push({
 						hasStream: streamState !== null,
-						hasDurableAssistant,
+						hasTurn2Durable: messagesByID.has(3),
 					});
 
 					return { streamState, messagesByID };
@@ -3964,14 +3962,30 @@ describe("stream-to-durable transition (Bug 1)", () => {
 				expect(watchChat).toHaveBeenCalledWith(chatID, 1);
 			});
 
-			// WS message 1: streaming part arrives.
+			// Commit turn 1 as a durable message so it is fully settled.
+			act(() => {
+				mockSocket.emitData({
+					type: "message",
+					chat_id: chatID,
+					message: turn1Msg,
+				});
+			});
+
+			await waitFor(() => {
+				expect(result.current.messagesByID.has(2)).toBe(true);
+			});
+
+			// Clear snapshot history before the critical transition.
+			snapshots.length = 0;
+
+			// WS message 1: turn 2 streaming parts arrive.
 			act(() => {
 				mockSocket.emitData({
 					type: "message_part",
 					chat_id: chatID,
 					message_part: {
 						role: "assistant",
-						part: { type: "text", text: "cross-msg" },
+						part: { type: "text", text: "turn2-stream" },
 					},
 				});
 			});
@@ -3980,35 +3994,114 @@ describe("stream-to-durable transition (Bug 1)", () => {
 				expect(result.current.streamState).not.toBeNull();
 			});
 
-			// Clear history before the critical transition.
-			snapshots.length = 0;
-
-			// Advance timer to flush any deferred work from old code.
+			// Regression guard: advance timers to prove no deferred macrotask changes the outcome.
 			await act(async () => {
 				vi.advanceTimersByTime(0);
 			});
 
-			// WS message 2: durable assistant commit arrives as a
+			// WS message 2: durable commit for turn 2 arrives as a
 			// separate WebSocket message.
 			act(() => {
 				mockSocket.emitData({
 					type: "message",
 					chat_id: chatID,
-					message: makeMessage(chatID, 2, "assistant", "cross-msg"),
+					message: makeMessage(chatID, 3, "assistant", "turn2-stream"),
 				});
 			});
 
 			await waitFor(() => {
-				expect(result.current.messagesByID.has(2)).toBe(true);
+				expect(result.current.messagesByID.has(3)).toBe(true);
 			});
 
+			// With the old setTimeout(0) code, stream state from turn 2
+			// could coexist with the durable turn 2 message. Verify that
+			// no snapshot ever has both simultaneously.
 			const overlapping = snapshots.filter(
-				(s) => s.hasStream && s.hasDurableAssistant,
+				(s) => s.hasStream && s.hasTurn2Durable,
 			);
 			expect(overlapping).toEqual([]);
 		} finally {
 			vi.useRealTimers();
 		}
+	});
+
+	it("applies buffered parts before an error event in the same batch", async () => {
+		immediateAnimationFrame();
+
+		const chatID = "chat-b1-error-batch";
+		const userMsg = makeMessage(chatID, 1, "user", "prompt");
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createTestQueryClient();
+		const wrapper = ({ children }: PropsWithChildren) => (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+
+		const { result } = renderHook(
+			() => {
+				const { store } = useChatStore({
+					chatID,
+					chatMessages: [userMsg],
+					chatRecord: makeChat(chatID),
+					chatMessagesData: {
+						messages: [userMsg],
+						queued_messages: [],
+						has_more: false,
+					},
+					chatQueuedMessages: [],
+					setChatErrorReason: vi.fn(),
+					clearChatErrorReason: vi.fn(),
+				});
+				return {
+					streamState: useChatSelector(store, selectStreamState),
+					chatStatus: useChatSelector(store, selectChatStatus),
+				};
+			},
+			{ wrapper },
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, 1);
+		});
+
+		// Emit status=running, then a batch containing a message_part
+		// followed by an error. The part must be applied before the
+		// error so partial output is visible.
+		act(() => {
+			mockSocket.emitData({
+				type: "status",
+				chat_id: chatID,
+				status: { status: "running" },
+			});
+		});
+
+		act(() => {
+			mockSocket.emitDataBatch([
+				{
+					type: "message_part",
+					chat_id: chatID,
+					message_part: {
+						role: "assistant",
+						part: { type: "text", text: "partial output" },
+					},
+				},
+				{
+					type: "error",
+					chat_id: chatID,
+					error: { message: "provider failed", retryable: false },
+				},
+			]);
+		});
+
+		// Parts were applied before the error event.
+		expect(result.current.streamState).not.toBeNull();
+		expect(result.current.streamState?.blocks).toEqual([
+			{ type: "response", text: "partial output" },
+		]);
+
+		// The error event set chat status.
+		expect(result.current.chatStatus).toBe("error");
 	});
 
 	it("parts are applied synchronously within the batch, not deferred", async () => {
@@ -4069,7 +4162,7 @@ describe("stream-to-durable transition (Bug 1)", () => {
 			});
 		});
 
-		// No timer advancement — parts should already be visible.
+		// No timer advancement needed; parts should already be visible.
 		expect(result.current.streamState?.blocks).toEqual([
 			{ type: "response", text: "sync-check" },
 		]);
@@ -4117,7 +4210,7 @@ describe("stream-to-durable transition (Bug 1)", () => {
 		});
 
 		// Single WS message containing turn 1 part, turn 1 commit,
-		// and start of turn 2 — all in one batch.
+		// and start of turn 2, all in one batch.
 		act(() => {
 			mockSocket.emitDataBatch([
 				{
@@ -4218,7 +4311,7 @@ describe("stream-to-durable transition (Bug 1)", () => {
 					});
 				});
 
-				// Flush deferred work between WS messages.
+				// Regression guard: advance timers to prove no deferred macrotask changes the outcome.
 				await act(async () => {
 					vi.advanceTimersByTime(0);
 				});
@@ -4353,7 +4446,7 @@ describe("partsBuf cleanup on reconnect (Bug 2)", () => {
 
 describe("store/cache desync protection", () => {
 	it("does not wipe a message added via upsertDurableMessage when a genuine refetch follows", async () => {
-		// RED TEST: Simulates what handleSend does today — it calls
+		// RED TEST: Simulates what handleSend does today: it calls
 		// store.upsertDurableMessage without writing to the React
 		// Query cache. A subsequent rerender with new message refs
 		// (genuine refetch) should NOT wipe the store-only message.
@@ -4440,7 +4533,7 @@ describe("store/cache desync protection", () => {
 		});
 
 		// msg3 was added to the store AFTER the last sync. It
-		// should NOT be classified as stale — it's new, not
+		// should NOT be classified as stale because it's new, not
 		// something the server removed.
 		await waitFor(() => {
 			expect(result.current.orderedMessageIDs).toEqual([1, 2, 3]);
@@ -4518,7 +4611,7 @@ describe("store/cache desync protection", () => {
 		});
 
 		// msg2 and msg3 WERE in the previous sync data and are
-		// now absent — they are genuinely stale (edit truncation)
+		// now absent so they are genuinely stale (edit truncation)
 		// and should be removed.
 		await waitFor(() => {
 			expect(result.current.orderedMessageIDs).toEqual([1]);

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStore.test.tsx
@@ -1631,9 +1631,9 @@ describe("useChatStore", () => {
 		});
 
 		// Emit a batch with message_parts followed by a status change
-		// to "waiting". The status handler clears stream state
-		// synchronously, and the startTransition guard should prevent
-		// the deferred applyMessageParts from re-populating it.
+		// to "waiting". The status handler calls clearBufferedParts()
+		// which empties the buffer, so the synchronous end-of-batch
+		// application finds nothing to apply.
 		act(() => {
 			mockSocket.emitDataBatch([
 				{
@@ -1652,9 +1652,9 @@ describe("useChatStore", () => {
 			]);
 		});
 
-		// Stream state should be null because the status change cleared it,
-		// and the deferred applyMessageParts should not have
-		// re-populated it.
+		// Stream state should be null because the status change
+		// called clearBufferedParts() and clearStreamState(), and
+		// the synchronous end-of-batch flush found an empty buffer.
 		await waitFor(() => {
 			expect(result.current.streamState).toBeNull();
 		});
@@ -3249,6 +3249,81 @@ describe("thinking indicator event ordering", () => {
 		});
 
 		expect(result.current.streamState).toBeNull();
+	});
+
+	it("discards buffered parts when a retry event arrives", async () => {
+		immediateAnimationFrame();
+
+		const chatID = "chat-thinking-discard-retry";
+		const userMsg = makeMessage(chatID, 1, "user", "hello");
+		const mockSocket = createMockSocket();
+		mockWatchChatReturn(mockSocket);
+
+		const queryClient = createTestQueryClient();
+		const wrapper = ({ children }: PropsWithChildren) => (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+
+		const { result } = renderHook(
+			() => {
+				const { store } = useChatStore({
+					chatID,
+					chatMessages: [userMsg],
+					chatRecord: { ...makeChat(chatID), status: "running" },
+					chatMessagesData: {
+						messages: [userMsg],
+						queued_messages: [],
+						has_more: false,
+					},
+					chatQueuedMessages: [],
+					setChatErrorReason: vi.fn(),
+					clearChatErrorReason: vi.fn(),
+				});
+				return {
+					streamState: useChatSelector(store, selectStreamState),
+					retryState: useChatSelector(store, selectRetryState),
+				};
+			},
+			{ wrapper },
+		);
+
+		await waitFor(() => {
+			expect(watchChat).toHaveBeenCalledWith(chatID, 1);
+		});
+
+		// Server sends a message_part then immediately retries.
+		// The retry handler calls clearBufferedParts() and
+		// clearStreamState(), so the buffered parts must not
+		// leak through the end-of-batch synchronous flush.
+		act(() => {
+			mockSocket.emitDataBatch([
+				{
+					type: "message_part",
+					chat_id: chatID,
+					message_part: {
+						part: { type: "text", text: "partial before retry" },
+					},
+				},
+				{
+					type: "retry",
+					chat_id: chatID,
+					retry: {
+						attempt: 1,
+						error: "rate limited",
+						delay_ms: 5000,
+						retrying_at: "2026-01-01T00:00:05Z",
+					},
+				},
+			]);
+		});
+
+		// Stream state should be null (retry cleared it) and
+		// retry state should be populated.
+		await waitFor(() => {
+			expect(result.current.streamState).toBeNull();
+			expect(result.current.retryState).not.toBeNull();
+			expect(result.current.retryState?.attempt).toBe(1);
+		});
 	});
 });
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -331,45 +331,22 @@ export const useChatStore = (
 		// outside the utility) can bail out after cleanup.
 		let disposed = false;
 
-		// Parts buffer lives at the effect scope so it persists
-		// across WebSocket messages. A rAF-based flush coalesces
-		// parts from multiple WS messages into a single render,
-		// capping stream renders to once per animation frame.
+		// Parts buffer accumulates message_part events during
+		// the for-loop so they can be applied (or discarded)
+		// as a group at the end of the batch.
 		const partsBuf: TypesGen.ChatMessagePart[] = [];
-		let partsFlushTimer: ReturnType<typeof setTimeout> | null = null;
 
 		const shouldApplyMessagePart = (): boolean => {
 			const currentStatus = store.getSnapshot().chatStatus;
 			return currentStatus !== "pending" && currentStatus !== "waiting";
 		};
 
-		const schedulePartsFlush = () => {
-			if (partsFlushTimer !== null || partsBuf.length === 0) {
-				return;
-			}
-			partsFlushTimer = setTimeout(() => {
-				partsFlushTimer = null;
-				if (disposed || activeChatIDRef.current !== chatID) {
-					return;
-				}
-				const parts = partsBuf.splice(0);
-				if (parts.length === 0 || !shouldApplyMessagePart()) {
-					return;
-				}
-				store.applyMessageParts(parts);
-			}, 0);
-		};
-
-		// Immediate flush for non-message_part events that need
-		// the parts applied before they execute (e.g. a durable
-		// message commit right after the last part).
-		const flushMessageParts = () => {
+		// Apply buffered parts to the store immediately. Used
+		// before events that need stream state up-to-date (e.g.
+		// a durable message commit right after the last part).
+		const applyBufferedParts = () => {
 			if (partsBuf.length === 0) {
 				return;
-			}
-			if (partsFlushTimer !== null) {
-				clearTimeout(partsFlushTimer);
-				partsFlushTimer = null;
 			}
 			const parts = partsBuf.splice(0);
 			if (activeChatIDRef.current !== chatID || !shouldApplyMessagePart()) {
@@ -382,12 +359,8 @@ export const useChatStore = (
 		// stream state is about to be cleared (pending, waiting,
 		// retry) — flushing would re-populate the state that the
 		// event is about to clear.
-		const discardBufferedParts = () => {
+		const clearPartsBuf = () => {
 			partsBuf.length = 0;
-			if (partsFlushTimer !== null) {
-				clearTimeout(partsFlushTimer);
-				partsFlushTimer = null;
-			}
 		};
 
 		const handleMessage = (
@@ -444,7 +417,7 @@ export const useChatStore = (
 					// clears stream state which a flush would
 					// re-populate.
 					if (streamEvent.type === "message" || streamEvent.type === "error") {
-						flushMessageParts();
+						applyBufferedParts();
 					}
 
 					switch (streamEvent.type) {
@@ -496,7 +469,7 @@ export const useChatStore = (
 							store.clearRetryState();
 							store.setChatStatus(nextStatus);
 							if (nextStatus === "pending" || nextStatus === "waiting") {
-								discardBufferedParts();
+								clearPartsBuf();
 								store.clearStreamState();
 								store.clearRetryState();
 							}
@@ -533,7 +506,7 @@ export const useChatStore = (
 							}
 							const retry = streamEvent.retry;
 							if (retry) {
-								discardBufferedParts();
+								clearPartsBuf();
 								store.clearStreamState();
 								store.setRetryState(normalizeRetryState(retry));
 							}
@@ -544,10 +517,20 @@ export const useChatStore = (
 					}
 				}
 
-				// Schedule a coalesced flush for any remaining
-				// parts. If parts were already flushed by a
-				// non-message_part event above, this is a no-op.
-				schedulePartsFlush();
+				// Apply any remaining buffered parts synchronously,
+				// unless a stream reset is pending. When
+				// needsStreamReset is true, clearStreamState()
+				// will wipe stream state anyway, and any parts
+				// still in the buffer belong to the next turn —
+				// they must survive until after the reset.
+				if (
+					!needsStreamReset &&
+					partsBuf.length > 0 &&
+					shouldApplyMessagePart()
+				) {
+					const parts = partsBuf.splice(0);
+					store.applyMessageParts(parts);
+				}
 
 				// Bulk-upsert all collected durable messages in one
 				// pass: one Map copy + one sort instead of N each.
@@ -559,10 +542,7 @@ export const useChatStore = (
 				// Clear stream state atomically with the durable
 				// message commit so subscribers never see a
 				// snapshot where both the committed message and
-				// the streaming output coexist. Previously this
-				// was deferred to a requestAnimationFrame, which
-				// left a window where ConversationTimeline and
-				// LiveStreamTail rendered the same content.
+				// the streaming output coexist.
 				if (needsStreamReset) {
 					store.clearStreamState();
 					// If more message_part events arrived in this
@@ -571,10 +551,6 @@ export const useChatStore = (
 					// the stream transitions from the old turn to
 					// the new one without a flash.
 					if (partsBuf.length > 0) {
-						if (partsFlushTimer !== null) {
-							clearTimeout(partsFlushTimer);
-							partsFlushTimer = null;
-						}
 						const nextParts = partsBuf.splice(0);
 						if (shouldApplyMessagePart()) {
 							store.applyMessageParts(nextParts);
@@ -599,11 +575,9 @@ export const useChatStore = (
 				// stream.
 				store.resetTransportReplayState();
 				// Drain any message parts buffered from the
-				// previous socket. Without this, a pending
-				// flush timer could fire after reconnect and
-				// apply stale parts from the old connection
-				// into the fresh stream state.
-				discardBufferedParts();
+				// previous socket so stale parts from the old
+				// connection don't leak into the fresh stream.
+				clearPartsBuf();
 			},
 			onDisconnect(
 				reconnectState: import("#/utils/reconnectingWebSocket").ReconnectSchedule,
@@ -621,9 +595,6 @@ export const useChatStore = (
 		return () => {
 			disposed = true;
 			disposeSocket();
-			if (partsFlushTimer !== null) {
-				clearTimeout(partsFlushTimer);
-			}
 			activeChatIDRef.current = null;
 		};
 	}, [chatID, initialDataLoaded, queryClient, store]);

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -357,9 +357,9 @@ export const useChatStore = (
 
 		// Discard buffered parts without applying them. Used when
 		// stream state is about to be cleared (pending, waiting,
-		// retry) — flushing would re-populate the state that the
-		// event is about to clear.
-		const clearPartsBuf = () => {
+		// retry) because flushing would re-populate the state
+		// that the event is about to clear.
+		const clearBufferedParts = () => {
 			partsBuf.length = 0;
 		};
 
@@ -411,7 +411,7 @@ export const useChatStore = (
 					// commit durable state that must include all
 					// stream parts. `error` events should surface
 					// partial output. Other events (status, retry,
-					// queue_update) must NOT flush — status changes
+					// queue_update) must NOT flush because status changes
 					// need to be visible before parts so the
 					// "Thinking..." indicator can render, and retry
 					// clears stream state which a flush would
@@ -469,7 +469,7 @@ export const useChatStore = (
 							store.clearRetryState();
 							store.setChatStatus(nextStatus);
 							if (nextStatus === "pending" || nextStatus === "waiting") {
-								clearPartsBuf();
+								clearBufferedParts();
 								store.clearStreamState();
 								store.clearRetryState();
 							}
@@ -506,7 +506,7 @@ export const useChatStore = (
 							}
 							const retry = streamEvent.retry;
 							if (retry) {
-								clearPartsBuf();
+								clearBufferedParts();
 								store.clearStreamState();
 								store.setRetryState(normalizeRetryState(retry));
 							}
@@ -521,7 +521,7 @@ export const useChatStore = (
 				// unless a stream reset is pending. When
 				// needsStreamReset is true, clearStreamState()
 				// will wipe stream state anyway, and any parts
-				// still in the buffer belong to the next turn —
+				// still in the buffer belong to the next turn and
 				// they must survive until after the reset.
 				if (
 					!needsStreamReset &&
@@ -577,7 +577,7 @@ export const useChatStore = (
 				// Drain any message parts buffered from the
 				// previous socket so stale parts from the old
 				// connection don't leak into the fresh stream.
-				clearPartsBuf();
+				clearBufferedParts();
 			},
 			onDisconnect(
 				reconnectState: import("#/utils/reconnectingWebSocket").ReconnectSchedule,

--- a/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/useChatStore.ts
@@ -333,7 +333,8 @@ export const useChatStore = (
 
 		// Parts buffer accumulates message_part events during
 		// the for-loop so they can be applied (or discarded)
-		// as a group at the end of the batch.
+		// as a group when the next consuming event arrives or
+		// at the end of the batch.
 		const partsBuf: TypesGen.ChatMessagePart[] = [];
 
 		const shouldApplyMessagePart = (): boolean => {


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood

`schedulePartsFlush` used `setTimeout(0)` to defer applying `message_part` events to the store. This created a cross-macrotask race: stream state was populated in one task (when the timer fired) and the durable `message(assistant)` event arrived in the next task. Between those two tasks, both `ConversationTimeline` and `LiveStreamTail` rendered the same content.

PR #23924 fixed the same class of bug for the `requestAnimationFrame` variant but left the `setTimeout(0)` variant intact. The coalescing benefit of `setTimeout(0)` was negligible since `store.batch()` already coalesces mutations within a single `handleMessage` call.

Replace the deferred flush with synchronous application inside the batch. Parts accumulated during the event loop are now applied at the end of the batch, eliminating the async gap entirely.

- Remove `schedulePartsFlush` / `partsFlushTimer` infrastructure
- Rename `flushMessageParts` to `applyBufferedParts`, `discardBufferedParts` to `clearBufferedParts`
- Skip early parts flush when `needsStreamReset` is true (parts belong to next turn)
- Update thinking-indicator tests to reflect synchronous behavior
- Add 5 regression tests covering cross-message race, synchronous application, multi-turn drain, rapid multi-turn cycles, and error-after-part batches

<details><summary>Research</summary>

The chat UI renders messages through two independent components placed sequentially:
- `ConversationTimeline` reads `messagesByID` (durable/committed messages)
- `LiveStreamTail` reads `streamState` (in-progress streaming output)

The race occurs across two separate WebSocket `message` events:
1. WS message 1 contains `message_part` events, parts push to `partsBuf`, `setTimeout(0)` scheduled
2. Timer fires, `streamState` populated, `LiveStreamTail` renders
3. WS message 2 contains `message(assistant)`, durable message committed + `streamState` cleared

Between steps 2 and 3, both components show the same content. During rapid multi-turn tool-call cycles, the probability increases because the pattern repeats per turn.

### Approaches considered

**A: Remove setTimeout(0), apply parts synchronously (chosen).** Eliminates the cross-macrotask race entirely. Parts and durable messages are always processed in the same batch, so the stream-reset is atomic with both the parts application and the durable message commit. Mirrors PR #23924's rAF to synchronous approach.

**B: Use queueMicrotask instead of setTimeout(0).** Reduces but does not eliminate the window. The coalescing benefit is negligible, making this more complex for no meaningful gain.

**C: Deduplicate at the rendering layer.** Content comparison at render time is unreliable with tool calls, reasoning blocks, and sources. Treats the symptom, not the cause.

</details>

<details><summary>Implementation plan</summary>

**Decision:** Apply message parts synchronously inside the batch, remove deferred timer infrastructure entirely.

**Phase 1 (Red):** Write 5 failing tests: cross-message race (falsifiable via turn-2-specific tracking), synchronous application verification, multi-turn drain, rapid multi-turn cycles, and error-after-part batch.

**Phase 2 (Green):** Remove `schedulePartsFlush`/`partsFlushTimer`. Replace the deferred `schedulePartsFlush()` call with synchronous `store.applyMessageParts()`. Skip early flush when `needsStreamReset` is true so next-turn parts survive the reset. Simplify `discardBufferedParts` and `flushMessageParts` by removing timer cancellation.

**Phase 3 (Refactor):** Rename `flushMessageParts` to `applyBufferedParts` and `discardBufferedParts` to `clearBufferedParts`. Update stale comments referencing removed mechanisms. Replace em-dashes with rewording per codebase convention.

</details>