### PR TITLE
docs: move copilot provider config from clients to setup

### DIFF
--- a/docs/ai-coder/ai-gateway/clients/copilot.md
+++ b/docs/ai-coder/ai-gateway/clients/copilot.md
@@ -12,32 +12,7 @@ For general information about GitHub Copilot, see the [GitHub Copilot documentat
 For general client configuration requirements, see [AI Gateway Proxy Client Configuration](../ai-gateway-proxy/setup.md#client-configuration).
 The sections below cover Copilot-specific setup for each client.
 
-## Provider configuration
-
-Configure a `copilot` provider using the
-[indexed provider format](../setup.md#multiple-instances-of-the-same-provider).
-Copilot providers use OAuth app installations for authentication rather than
-static API keys.
-
-```sh
-# GitHub Copilot (Individual)
-export CODER_AIBRIDGE_PROVIDER_0_TYPE=copilot
-export CODER_AIBRIDGE_PROVIDER_0_NAME=copilot
-
-# GitHub Copilot Business
-export CODER_AIBRIDGE_PROVIDER_1_TYPE=copilot
-export CODER_AIBRIDGE_PROVIDER_1_NAME=copilot-business
-export CODER_AIBRIDGE_PROVIDER_1_BASE_URL=https://api.business.githubcopilot.com
-
-# GitHub Copilot Enterprise
-export CODER_AIBRIDGE_PROVIDER_2_TYPE=copilot
-export CODER_AIBRIDGE_PROVIDER_2_NAME=copilot-enterprise
-export CODER_AIBRIDGE_PROVIDER_2_BASE_URL=https://api.enterprise.githubcopilot.com
-```
-
-The default base URL targets the individual Copilot API
-(`api.individual.githubcopilot.com`). Override `BASE_URL` for Business or
-Enterprise tiers as shown above.
+For provider configuration (admin), see [GitHub Copilot provider setup](../setup.md#github-copilot).
 
 ## Copilot CLI
 

--- a/docs/ai-coder/ai-gateway/setup.md
+++ b/docs/ai-coder/ai-gateway/setup.md
@@ -95,11 +95,32 @@ proxy between AI Gateway and AWS Bedrock.
 ### GitHub Copilot
 
 Configure a `copilot` provider using the
-[indexed provider format](#multiple-instances-of-the-same-provider) with
-separate instances for Individual, Business, and Enterprise tiers.
+[indexed provider format](#multiple-instances-of-the-same-provider).
+Copilot providers use OAuth app installations for authentication rather than
+static API keys.
 
-See [GitHub Copilot — Provider configuration](./clients/copilot.md#provider-configuration)
-for full setup instructions.
+```sh
+# GitHub Copilot (Individual)
+export CODER_AIBRIDGE_PROVIDER_0_TYPE=copilot
+export CODER_AIBRIDGE_PROVIDER_0_NAME=copilot
+
+# GitHub Copilot Business
+export CODER_AIBRIDGE_PROVIDER_1_TYPE=copilot
+export CODER_AIBRIDGE_PROVIDER_1_NAME=copilot-business
+export CODER_AIBRIDGE_PROVIDER_1_BASE_URL=https://api.business.githubcopilot.com
+
+# GitHub Copilot Enterprise
+export CODER_AIBRIDGE_PROVIDER_2_TYPE=copilot
+export CODER_AIBRIDGE_PROVIDER_2_NAME=copilot-enterprise
+export CODER_AIBRIDGE_PROVIDER_2_BASE_URL=https://api.enterprise.githubcopilot.com
+```
+
+The default base URL targets the individual Copilot API
+(`api.individual.githubcopilot.com`). Override `BASE_URL` for Business or
+Enterprise tiers as shown above.
+
+For client-side setup (proxy, certificates, IDE configuration), see
+[GitHub Copilot client configuration](./clients/copilot.md).
 
 ### ChatGPT
 

--- a/docs/ai-coder/ai-gateway/setup.md
+++ b/docs/ai-coder/ai-gateway/setup.md
@@ -116,8 +116,8 @@ export CODER_AIBRIDGE_PROVIDER_2_BASE_URL=https://api.enterprise.githubcopilot.c
 ```
 
 The default base URL targets the individual Copilot API
-(`api.individual.githubcopilot.com`). Override `BASE_URL` for Business or
-Enterprise tiers as shown above.
+(`api.individual.githubcopilot.com`). Override `CODER_AIBRIDGE_PROVIDER_<N>_BASE_URL`
+for Business or Enterprise tiers as shown above.
 
 For client-side setup (proxy, certificates, IDE configuration), see
 [GitHub Copilot client configuration](./clients/copilot.md).


### PR DESCRIPTION
The `## Provider configuration` section in the Copilot client page contained server-side admin configuration (`CODER_AIBRIDGE_PROVIDER_*` env vars) that belongs in `setup.md` alongside the other provider tabs (OpenAI, Anthropic, Bedrock, ChatGPT).

The clients section is meant for end users and template admins to configure clients with already-configured providers — not for provider setup itself.

## Changes

- Moved the Copilot provider configuration into the `### GitHub Copilot` tab in `setup.md` (inline, consistent with other providers)
- Removed `## Provider configuration` from `clients/copilot.md`
- Added a link in `copilot.md` pointing to `setup.md#github-copilot` for provider setup
- Added a link in `setup.md` pointing back to `clients/copilot.md` for client-side setup

> 🤖 This PR was created with the help of Coder Agents, and needs a human review.  🧑💻