### PR TITLE
feat(scripts/develop): enable prometheus metrics by default

### DIFF
--- a/scripts/develop/main.go
+++ b/scripts/develop/main.go
@@ -946,7 +946,7 @@ func printBanner(ctx context.Context, logger slog.Logger, cfg *devConfig) {
 	}
 	line(
 		"",
-		"WebUI:",
+		"Web UI:",
 	)
 	for _, h := range ifaces {
 		line(indent(fmt.Sprintf("http://%s:%d", h, cfg.webPort)))
@@ -957,7 +957,7 @@ func printBanner(ctx context.Context, logger slog.Logger, cfg *devConfig) {
 			"Proxy:",
 		)
 		for _, h := range ifaces {
-			line(indent(fmt.Sprintf("Proxy:  http://%s:%d", h, cfg.proxyPort)))
+			line(indent(fmt.Sprintf("http://%s:%d", h, cfg.proxyPort)))
 		}
 	}
 	if cfg.prometheusPort != 0 {

--- a/scripts/develop/main.go
+++ b/scripts/develop/main.go
@@ -921,31 +921,60 @@ func printBanner(ctx context.Context, logger slog.Logger, cfg *devConfig) {
 	}
 	var b strings.Builder
 	w := 64
-	line := func(content string) {
-		_, _ = fmt.Fprintf(&b, "║ %-*s ║\n", w, content)
+	line := func(content ...string) {
+		for _, c := range content {
+			_, _ = fmt.Fprintf(&b, "║ %-*s ║\n", w, c)
+		}
+	}
+	indent := func(s string) string {
+		return "           " + s
 	}
 	divider := "╔" + strings.Repeat("═", w+2) + "╗"
 	bottom := "╚" + strings.Repeat("═", w+2) + "╝"
 
 	_, _ = fmt.Fprintln(&b)
 	_, _ = fmt.Fprintln(&b, divider)
-	line("")
-	line("           Coder is now running in development mode.")
-	line("")
+	line(
+		"",
+		indent("Coder is now running in development mode."),
+		"",
+		"API:",
+	)
+
 	for _, h := range ifaces {
-		line(fmt.Sprintf("API:    http://%s:%d", h, cfg.apiPort))
-		line(fmt.Sprintf("Web UI: http://%s:%d", h, cfg.webPort))
-		if cfg.useProxy {
-			line(fmt.Sprintf("Proxy:  http://%s:%d", h, cfg.proxyPort))
+		line(indent(fmt.Sprintf("http://%s:%d", h, cfg.apiPort)))
+	}
+	line(
+		"",
+		"WebUI:",
+	)
+	for _, h := range ifaces {
+		line(indent(fmt.Sprintf("http://%s:%d", h, cfg.webPort)))
+	}
+	if cfg.useProxy {
+		line(
+			"",
+			"Proxy:",
+		)
+		for _, h := range ifaces {
+			line(indent(fmt.Sprintf("Proxy:  http://%s:%d", h, cfg.proxyPort)))
 		}
 	}
 	if cfg.prometheusPort != 0 {
-		line(fmt.Sprintf("Metrics: http://127.0.0.1:%d", cfg.prometheusPort))
+		line(
+			"",
+			"Metrics:",
+		)
+		for _, h := range ifaces {
+			line(indent(fmt.Sprintf("http://%s:%d", h, cfg.prometheusPort)))
+		}
 	}
-	line("")
-	line("Use ./scripts/coder-dev.sh to talk to this instance!")
-	line(fmt.Sprintf("  alias cdr=%s/scripts/coder-dev.sh", cfg.projectRoot))
-	line("")
+	line(
+		"",
+		"Use ./scripts/coder-dev.sh to talk to this instance!",
+		fmt.Sprintf("  alias cdr=%s/scripts/coder-dev.sh", cfg.projectRoot),
+		"",
+	)
 	_, _ = fmt.Fprintln(&b, bottom)
 	logger.Info(ctx, b.String())
 }

--- a/scripts/develop/main.go
+++ b/scripts/develop/main.go
@@ -39,9 +39,11 @@ import (
 )
 
 const (
-	defaultAPIPort         = "3000"
-	defaultWebPort         = "8080"
-	defaultProxyPort       = "3010"
+	defaultAPIPort   = "3000"
+	defaultWebPort   = "8080"
+	defaultProxyPort = "3010"
+	// defaultPrometheusPort avoids 2112 (agent prometheus) and
+	// 2113 (agent debug) already bound inside Coder workspaces.
 	defaultPrometheusPort  = "2114"
 	defaultAccessURL       = "http://127.0.0.1:%d"
 	defaultPassword        = "SomeSecurePassword!"
@@ -215,8 +217,8 @@ func (c *devConfig) validate() error {
 			return xerrors.Errorf("%s must be between 1 and 65535", p.name)
 		}
 	}
-	if c.prometheusPort != 0 && (c.prometheusPort < 1 || c.prometheusPort > 65535) {
-		return xerrors.Errorf("--prometheus-port must be between 1 and 65535")
+	if c.prometheusPort < 0 || c.prometheusPort > 65535 {
+		return xerrors.Errorf("--prometheus-port must be 0 (disabled) or between 1 and 65535")
 	}
 	if c.apiPort == c.webPort {
 		return xerrors.Errorf("--port %d conflicts with frontend dev server", c.webPort)
@@ -936,9 +938,9 @@ func printBanner(ctx context.Context, logger slog.Logger, cfg *devConfig) {
 		if cfg.useProxy {
 			line(fmt.Sprintf("Proxy:  http://%s:%d", h, cfg.proxyPort))
 		}
-		if cfg.prometheusPort != 0 {
-			line(fmt.Sprintf("Prom:   http://%s:%d", h, cfg.prometheusPort))
-		}
+	}
+	if cfg.prometheusPort != 0 {
+		line(fmt.Sprintf("Metrics: http://127.0.0.1:%d", cfg.prometheusPort))
 	}
 	line("")
 	line("Use ./scripts/coder-dev.sh to talk to this instance!")

--- a/scripts/develop/main.go
+++ b/scripts/develop/main.go
@@ -544,7 +544,7 @@ func startServer(cfg *devConfig, group *procGroup) error {
 	if cfg.prometheusPort != 0 {
 		serverArgs = append(serverArgs,
 			"--prometheus-enable",
-			"--prometheus-address", fmt.Sprintf("127.0.0.1:%d", cfg.prometheusPort),
+			"--prometheus-address", fmt.Sprintf("0.0.0.0:%d", cfg.prometheusPort),
 			"--prometheus-collect-agent-stats",
 			"--prometheus-collect-db-metrics",
 		)

--- a/scripts/develop/main.go
+++ b/scripts/develop/main.go
@@ -42,6 +42,7 @@ const (
 	defaultAPIPort         = "3000"
 	defaultWebPort         = "8080"
 	defaultProxyPort       = "3010"
+	defaultPrometheusPort  = "2114"
 	defaultAccessURL       = "http://127.0.0.1:%d"
 	defaultPassword        = "SomeSecurePassword!"
 	defaultStarterTemplate = "docker"
@@ -76,6 +77,13 @@ func main() {
 				Default:     defaultProxyPort,
 				Description: "Workspace proxy port.",
 				Value:       serpent.Int64Of(&cfg.proxyPort),
+			},
+			{
+				Flag:        "prometheus-port",
+				Env:         "CODER_DEV_PROMETHEUS_PORT",
+				Default:     defaultPrometheusPort,
+				Description: "Prometheus metrics port. Set to 0 to disable.",
+				Value:       serpent.Int64Of(&cfg.prometheusPort),
 			},
 			{
 				Flag:        "agpl",
@@ -163,6 +171,7 @@ type devConfig struct {
 	apiPort         int64
 	webPort         int64
 	proxyPort       int64
+	prometheusPort  int64
 	agpl            bool
 	accessURL       string
 	password        string
@@ -206,6 +215,9 @@ func (c *devConfig) validate() error {
 			return xerrors.Errorf("%s must be between 1 and 65535", p.name)
 		}
 	}
+	if c.prometheusPort != 0 && (c.prometheusPort < 1 || c.prometheusPort > 65535) {
+		return xerrors.Errorf("--prometheus-port must be between 1 and 65535")
+	}
 	if c.apiPort == c.webPort {
 		return xerrors.Errorf("--port %d conflicts with frontend dev server", c.webPort)
 	}
@@ -214,6 +226,17 @@ func (c *devConfig) validate() error {
 	}
 	if c.useProxy && c.webPort == c.proxyPort {
 		return xerrors.Errorf("--web-port %d conflicts with --proxy-port", c.webPort)
+	}
+	if c.prometheusPort != 0 {
+		if c.prometheusPort == c.apiPort {
+			return xerrors.Errorf("--prometheus-port %d conflicts with API server", c.prometheusPort)
+		}
+		if c.prometheusPort == c.webPort {
+			return xerrors.Errorf("--prometheus-port %d conflicts with frontend dev server", c.prometheusPort)
+		}
+		if c.useProxy && c.prometheusPort == c.proxyPort {
+			return xerrors.Errorf("--prometheus-port %d conflicts with workspace proxy", c.prometheusPort)
+		}
 	}
 	return nil
 }
@@ -481,6 +504,9 @@ func preflight(ctx context.Context, logger slog.Logger, cfg *devConfig) error {
 	if cfg.useProxy && isPortBusy(ctx, cfg.proxyPort) {
 		return xerrors.Errorf("port %d is already in use (proxy)", cfg.proxyPort)
 	}
+	if cfg.prometheusPort != 0 && isPortBusy(ctx, cfg.prometheusPort) {
+		return xerrors.Errorf("port %d is already in use (prometheus)", cfg.prometheusPort)
+	}
 	return nil
 }
 
@@ -512,6 +538,14 @@ func startServer(cfg *devConfig, group *procGroup) error {
 		"--access-url", cfg.accessURL,
 		"--dangerous-allow-cors-requests=true",
 		"--enable-terraform-debug-mode",
+	}
+	if cfg.prometheusPort != 0 {
+		serverArgs = append(serverArgs,
+			"--prometheus-enable",
+			"--prometheus-address", fmt.Sprintf("127.0.0.1:%d", cfg.prometheusPort),
+			"--prometheus-collect-agent-stats",
+			"--prometheus-collect-db-metrics",
+		)
 	}
 	serverArgs = append(serverArgs, cfg.serverExtraArgs...)
 
@@ -901,6 +935,9 @@ func printBanner(ctx context.Context, logger slog.Logger, cfg *devConfig) {
 		line(fmt.Sprintf("Web UI: http://%s:%d", h, cfg.webPort))
 		if cfg.useProxy {
 			line(fmt.Sprintf("Proxy:  http://%s:%d", h, cfg.proxyPort))
+		}
+		if cfg.prometheusPort != 0 {
+			line(fmt.Sprintf("Prom:   http://%s:%d", h, cfg.prometheusPort))
 		}
 	}
 	line("")

--- a/scripts/develop/main_test.go
+++ b/scripts/develop/main_test.go
@@ -323,7 +323,7 @@ func TestDevConfigValidate(t *testing.T) {
 	t.Run("PrometheusPortValid", func(t *testing.T) {
 		t.Parallel()
 		cfg := base()
-		cfg.prometheusPort = 2114
+		cfg.prometheusPort = 9090
 		assert.NoError(t, cfg.validate())
 	})
 
@@ -333,7 +333,16 @@ func TestDevConfigValidate(t *testing.T) {
 		cfg.prometheusPort = 70000
 		err := cfg.validate()
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "--prometheus-port must be between 1 and 65535")
+		assert.Contains(t, err.Error(), "--prometheus-port must be 0 (disabled) or between 1 and 65535")
+	})
+
+	t.Run("PrometheusPortNegative", func(t *testing.T) {
+		t.Parallel()
+		cfg := base()
+		cfg.prometheusPort = -1
+		err := cfg.validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--prometheus-port must be 0 (disabled) or between 1 and 65535")
 	})
 
 	t.Run("PrometheusProxyConflictIgnoredNoProxy", func(t *testing.T) {

--- a/scripts/develop/main_test.go
+++ b/scripts/develop/main_test.go
@@ -171,10 +171,11 @@ func TestDevConfigValidate(t *testing.T) {
 
 	base := func() *devConfig {
 		return &devConfig{
-			apiPort:   3000,
-			webPort:   8080,
-			proxyPort: 3010,
-			password:  defaultPassword,
+			apiPort:        3000,
+			webPort:        8080,
+			proxyPort:      3010,
+			prometheusPort: 2114,
+			password:       defaultPassword,
 		}
 	}
 
@@ -281,6 +282,64 @@ func TestDevConfigValidate(t *testing.T) {
 		cfg := base()
 		cfg.webPort = 9000
 		cfg.proxyPort = 9000
+		assert.NoError(t, cfg.validate())
+	})
+
+	t.Run("PrometheusPortConflictWithAPI", func(t *testing.T) {
+		t.Parallel()
+		cfg := base()
+		cfg.prometheusPort = 3000
+		err := cfg.validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--prometheus-port 3000 conflicts with")
+	})
+
+	t.Run("PrometheusPortConflictWithWeb", func(t *testing.T) {
+		t.Parallel()
+		cfg := base()
+		cfg.prometheusPort = 8080
+		err := cfg.validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--prometheus-port 8080 conflicts with")
+	})
+
+	t.Run("PrometheusPortConflictWithProxy", func(t *testing.T) {
+		t.Parallel()
+		cfg := base()
+		cfg.prometheusPort = 3010
+		cfg.useProxy = true
+		err := cfg.validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--prometheus-port 3010 conflicts with")
+	})
+
+	t.Run("PrometheusPortZeroDisabled", func(t *testing.T) {
+		t.Parallel()
+		cfg := base()
+		cfg.prometheusPort = 0
+		assert.NoError(t, cfg.validate())
+	})
+
+	t.Run("PrometheusPortValid", func(t *testing.T) {
+		t.Parallel()
+		cfg := base()
+		cfg.prometheusPort = 2114
+		assert.NoError(t, cfg.validate())
+	})
+
+	t.Run("PrometheusPortTooHigh", func(t *testing.T) {
+		t.Parallel()
+		cfg := base()
+		cfg.prometheusPort = 70000
+		err := cfg.validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--prometheus-port must be between 1 and 65535")
+	})
+
+	t.Run("PrometheusProxyConflictIgnoredNoProxy", func(t *testing.T) {
+		t.Parallel()
+		cfg := base()
+		cfg.prometheusPort = 3010
 		assert.NoError(t, cfg.validate())
 	})
 }

--- a/scripts/develop/main_test.go
+++ b/scripts/develop/main_test.go
@@ -345,7 +345,7 @@ func TestDevConfigValidate(t *testing.T) {
 		assert.Contains(t, err.Error(), "--prometheus-port must be 0 (disabled) or between 1 and 65535")
 	})
 
-	t.Run("PrometheusProxyConflictIgnoredNoProxy", func(t *testing.T) {
+	t.Run("PrometheusProxyProxyConflictIgnoredWithoutProxy", func(t *testing.T) {
 		t.Parallel()
 		cfg := base()
 		cfg.prometheusPort = 3010


### PR DESCRIPTION
- Add `--prometheus-port` flag (default `2114`, `0` to disable)
- Pass `--prometheus-enable`, `--prometheus-address`, `--prometheus-collect-agent-stats`, and `--prometheus-collect-db-metrics` to `coder server`
- Port `2114` avoids conflicts with agent prometheus (`2112`) and agent debug (`2113`) in dogfood workspaces
- Add port validation and conflict checks
- Show Prometheus URL in dev banner + group by service
- Add 7 test cases for validation

<details>
<summary>Implementation plan & decisions</summary>

**Port choice:** `2114` was chosen because `2112` (agent prometheus) and `2113` (agent debug) are already bound inside Coder workspaces. `2114` is adjacent and easy to remember.

**Agent stats + DB metrics:** Enabled unconditionally when prometheus is on. No storage cost concern in local dev since nothing ships to a remote backend.

**Disable with `--prometheus-port=0`:** Follows the same opt-out pattern as `--proxy-port` requiring `--use-proxy`.

🧑‍💻 **Bind Prometheus to all interfaces:** for convenience.
</details>

> 🤖