### PR TITLE
fix(site): add w-full to create workspace page container

### DIFF
--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
@@ -385,7 +385,7 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 					Go back
 				</button>
 			</div>
-			<div className="flex flex-col gap-6 max-w-screen-md mx-auto">
+			<div className="flex flex-col gap-6 w-full max-w-screen-md mx-auto">
 				<header className="flex flex-col items-start gap-3 mt-10">
 					<div className="flex items-center gap-2 justify-between w-full">
 						<span className="flex items-center gap-2">


### PR DESCRIPTION
## Fixes #19332

The "Create Workspace" page renders too narrow when a template has no parameters.

### Root cause

The container `<div>` on line 388 of `CreateWorkspacePageView.tsx` uses `max-w-screen-md mx-auto` but is missing `w-full`. In the parent flex-column layout (`DashboardLayout.tsx`), `mx-auto` overrides the default `align-items: stretch` behavior, causing the div to shrink to its content width. When parameters are absent, the only content is the workspace name input + submit button — resulting in a visibly narrow page.

### Fix

Added `w-full` to the container className:

```diff
- <div className="flex flex-col gap-6 max-w-screen-md mx-auto">
+ <div className="flex flex-col gap-6 w-full max-w-screen-md mx-auto">
```

This ensures `width: 100%`, capped at 768px by `max-w-screen-md`, centered by `mx-auto`. The width is now always `min(parent_width, 768px)` regardless of parameter presence.

### Why this approach

| Alternative | Why not |
|---|---|
| `min-w-*` | Could cause horizontal scrolling on narrow viewports |
| Fix in `DashboardLayout` | Over-scoped — shared by all pages |
| `w-full` (chosen) | Matches the established pattern used by every other centered page (`AgentSettingsPage`, `CreateOrganizationPageView`, `TaskPage`, etc.) |

All 16 existing unit tests pass.

<details><summary>Best-of-K selection process</summary>

Three independent agents implemented this fix. All three converged on the identical one-line change. Agent B (this PR) was selected for the most thorough analysis of alternatives.

</details>

> Generated by Coder Agents