### PR TITLE
fix(site): improve disabled text contrast for WCAG AA compliance

### DIFF
--- a/site/src/components/Input/Input.tsx
+++ b/site/src/components/Input/Input.tsx
@@ -17,7 +17,7 @@ export const Input: FC<InputProps> = ({ className, type, ...props }) => {
 				file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-content-primary
 				placeholder:text-content-secondary
 				focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-content-link
-				disabled:cursor-not-allowed disabled:opacity-50 md:text-sm text-inherit
+				disabled:cursor-not-allowed disabled:text-content-disabled md:text-sm text-inherit
 				aria-[invalid=true]:border-border-destructive
 				`,
 				className,

--- a/site/src/components/InputGroup/InputGroup.tsx
+++ b/site/src/components/InputGroup/InputGroup.tsx
@@ -18,7 +18,7 @@ export const InputGroup: React.FC<React.ComponentProps<"div">> = ({
 				// Invalid state
 				"has-[input[aria-invalid=true]]:border-border-destructive",
 				// Disabled state
-				"has-[input:disabled]:opacity-50 has-[input:disabled]:cursor-not-allowed",
+				"has-[input:disabled]:text-content-disabled has-[input:disabled]:cursor-not-allowed",
 				className,
 			)}
 			{...props}
@@ -27,7 +27,7 @@ export const InputGroup: React.FC<React.ComponentProps<"div">> = ({
 };
 
 const inputGroupAddonVariants = cva(
-	"text-content-secondary h-auto gap-2 text-sm font-medium flex cursor-text items-center justify-center select-none group-has-[input:disabled]/input-group:opacity-50 [&>svg:not([class*='size-'])]:size-4",
+	"text-content-secondary h-auto gap-2 text-sm font-medium flex cursor-text items-center justify-center select-none group-has-[input:disabled]/input-group:text-content-disabled [&>svg:not([class*='size-'])]:size-4",
 	{
 		variants: {
 			align: {

--- a/site/src/components/Select/Select.tsx
+++ b/site/src/components/Select/Select.tsx
@@ -31,7 +31,7 @@ export const SelectTrigger: React.FC<SelectTriggerProps> = ({
 			`flex h-10 w-full font-medium items-center justify-between whitespace-nowrap rounded-md
 			border border-border border-solid bg-transparent px-3 py-2 text-sm shadow-sm
 			ring-offset-background text-content-secondary placeholder:text-content-secondary
-			disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1
+			disabled:cursor-not-allowed disabled:text-content-disabled [&>span]:line-clamp-1
 			focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-content-link group`,
 			className,
 		)}

--- a/site/src/components/Textarea/Textarea.tsx
+++ b/site/src/components/Textarea/Textarea.tsx
@@ -14,7 +14,7 @@ export const Textarea: React.FC<React.ComponentPropsWithRef<"textarea">> = ({
 				`flex min-h-[60px] w-full px-3 py-2 text-sm shadow-sm text-content-primary
 				rounded-md border border-border bg-transparent placeholder:text-content-secondary
 				focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-content-link
-				disabled:cursor-not-allowed disabled:opacity-50 disabled:text-content-disabled md:text-sm`,
+				disabled:cursor-not-allowed disabled:text-content-disabled md:text-sm`,
 				className,
 			)}
 			{...props}

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -22,7 +22,13 @@
 		--content-secondary: 240 5% 34%;
 		--content-link: 221 83% 53%;
 		--content-invert: 0 0% 98%;
-		--content-disabled: 240 5% 65%;
+		/*
+		 * Disabled text must remain readable since disabled parameters
+		 * display informational values. WCAG 2.1 SC 1.4.3 exempts
+		 * inactive components, but we target 4.5:1 anyway for usability.
+		 * 46% lightness ≈ 4.96:1 contrast against white (#fff).
+		 */
+		--content-disabled: 240 5% 46%;
 		--content-success: 142 72% 29%;
 		--content-warning: 27 96% 61%;
 		--content-destructive: 0 84% 60%;
@@ -95,7 +101,11 @@
 		--content-secondary: 240 5% 65%;
 		--content-link: 213 94% 68%;
 		--content-invert: 240 10% 4%;
-		--content-disabled: 240 5% 26%;
+		/*
+		 * 50% lightness ≈ 4.63:1 contrast against the dark surface
+		 * (hsl 240 10% 4%). See light-mode comment for rationale.
+		 */
+		--content-disabled: 240 5% 50%;
 		--content-success: 142 76% 36%;
 		--content-warning: 31 97% 72%;
 		--content-destructive: 0 91% 71%;


### PR DESCRIPTION
## Fixes #18683

Disabled text on dynamic parameters (and all disabled inputs) was nearly invisible — especially in dark mode.

### Root cause

Two compounding issues:

1. **`--content-disabled` CSS token too dark in dark mode** — `hsl(240 5% 26%)` gave only ~1.88:1 contrast against the dark background. Light mode was also poor at ~2.5:1. WCAG AA requires 4.5:1.
2. **`disabled:opacity-50` further halved contrast** — Input, Textarea, SelectTrigger, and InputGroup all applied a blanket 50% opacity on disabled state (standard shadcn pattern), which compounded the already-poor contrast. Textarea was double-penalized with *both* `opacity-50` and `text-content-disabled`.

### Fix (5 files)

**1. `index.css` — Per-theme `--content-disabled` values tuned for WCAG AA:**

| Mode | Old | New | Contrast ratio |
|---|---|---|---|
| Dark | `240 5% 26%` | `240 5% 50%` | **4.63:1** ✅ |
| Light | `240 5% 65%` | `240 5% 46%` | **4.96:1** ✅ |

Added CSS comments documenting WCAG rationale and computed contrast ratios.

**2. Input, Textarea, Select — Replace `disabled:opacity-50` with explicit text color:**

`disabled:opacity-50` → `disabled:text-content-disabled` so text readability is controlled independently of element dimming.

**3. InputGroup — Same fix** (not in the original plan — caught by the implementation agent as having the same pattern).

**4. Textarea — Remove redundant `disabled:opacity-50`** that double-penalized disabled text.

### Risk assessment

- Pure CSS changes — no logic affected
- `content-disabled` token audited across all 50+ usages — none regresses
- The change makes disabled text *more* readable everywhere, not just parameters
- WCAG 2.1 SC 1.4.3 technically exempts inactive components, but we target 4.5:1 anyway for usability
- All 38 DynamicParameter tests pass

<details><summary>Best-of-K selection process</summary>

Three independent agents implemented this fix:
- **Agent A**: 4 files, per-theme values (dark 50%, light 45%). Clean.
- **Agent B**: 4 files, per-theme values (dark 50%, light 46%). Thorough contrast math.
- **Agent C** (this PR): 5 files (also caught InputGroup), per-theme values (dark 50%, light 46%), added WCAG comments in CSS. Most comprehensive.

Agent C was selected for catching the InputGroup oversight and adding documentation.

</details>

> Generated by Coder Agents