### PR TITLE
chore(docs): remove misleading chat forking reference

### DIFF
--- a/docs/ai-coder/agents/index.md
+++ b/docs/ai-coder/agents/index.md
@@ -118,9 +118,6 @@ workspace is stopped, deleted, or rebuilt, the full conversation history
 survives. The agent can resume work by creating a new workspace with the same
 template and continuing from the last known state, such as a git branch.
 
-Users can also fork a chat at any point to explore a different direction while
-preserving the original conversation.
-
 ### Message queuing
 
 Users can send follow-up messages while the agent is actively working. Messages


### PR DESCRIPTION
Removes the claim that users can fork a chat to explore a different direction — this is not a supported feature and the reference is misleading.

---

*PR generated with Coder Agents*