### PR TITLE
test(enterprise): validate custom RBAC roles with chat resources

### DIFF
--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -384,11 +384,6 @@ func (api *API) postChats(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	apiKey := httpmw.APIKey(r)
 
-	if !api.Authorize(r, policy.ActionCreate, rbac.ResourceChat.WithOwner(apiKey.UserID.String())) {
-		httpapi.Forbidden(rw)
-		return
-	}
-
 	// Cap the raw request body to prevent excessive memory use
 	// from large dynamic tool schemas.
 	r.Body = http.MaxBytesReader(rw, r.Body, int64(2*maxSystemPromptLenBytes))
@@ -417,6 +412,14 @@ func (api *API) postChats(rw http.ResponseWriter, r *http.Request) {
 		httpapi.Write(ctx, rw, http.StatusForbidden, codersdk.Response{
 			Message: "You are not a member of the specified organization.",
 		})
+		return
+	}
+
+	// Authorize after parsing the body so the org ID is available.
+	// The resource must include InOrg so that org-level custom roles
+	// can grant chat creation within their organization.
+	if !api.Authorize(r, policy.ActionCreate, rbac.ResourceChat.InOrg(req.OrganizationID).WithOwner(apiKey.UserID.String())) {
+		httpapi.Forbidden(rw)
 		return
 	}
 
@@ -1876,11 +1879,9 @@ func (api *API) postChatMessages(rw http.ResponseWriter, r *http.Request) {
 	// Gate message sending behind the same agents-access check
 	// used by postChats. Sending a message triggers AI/LLM
 	// inference, so it should require the same authorization as
-	// chat creation. This is a handler-level band-aid; the
-	// structural fix is to make agents-access org-aware so
-	// dbauthz enforces this at the RBAC layer.
-	// See: https://github.com/coder/coder/issues/24250
-	if !api.Authorize(r, policy.ActionCreate, rbac.ResourceChat.WithOwner(apiKey.UserID.String())) {
+	// chat creation. InOrg is required so that org-level custom
+	// roles can grant chat access within their organization.
+	if !api.Authorize(r, policy.ActionCreate, rbac.ResourceChat.InOrg(chat.OrganizationID).WithOwner(apiKey.UserID.String())) {
 		httpapi.Forbidden(rw)
 		return
 	}
@@ -2131,9 +2132,10 @@ func (api *API) promoteChatQueuedMessage(rw http.ResponseWriter, r *http.Request
 
 	// Gate queued-message promotion behind agents-access.
 	// Promoting a queued message triggers AI/LLM inference,
-	// same as sending a new message.
-	// See: https://github.com/coder/coder/issues/24250
-	if !api.Authorize(r, policy.ActionCreate, rbac.ResourceChat.WithOwner(apiKey.UserID.String())) {
+	// same as sending a new message. InOrg is required so
+	// that org-level custom roles can grant chat access
+	// within their organization.
+	if !api.Authorize(r, policy.ActionCreate, rbac.ResourceChat.InOrg(chat.OrganizationID).WithOwner(apiKey.UserID.String())) {
 		httpapi.Forbidden(rw)
 		return
 	}
@@ -3716,11 +3718,6 @@ func (api *API) postChatFile(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	apiKey := httpmw.APIKey(r)
 
-	if !api.Authorize(r, policy.ActionCreate, rbac.ResourceChat.WithOwner(apiKey.UserID.String())) {
-		httpapi.Forbidden(rw)
-		return
-	}
-
 	orgIDStr := r.URL.Query().Get("organization")
 	if orgIDStr == "" {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
@@ -3733,6 +3730,14 @@ func (api *API) postChatFile(rw http.ResponseWriter, r *http.Request) {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Invalid organization ID.",
 		})
+		return
+	}
+
+	// Authorize after parsing the org ID so InOrg is available.
+	// This ensures org-level custom roles can grant chat file
+	// uploads within their organization.
+	if !api.Authorize(r, policy.ActionCreate, rbac.ResourceChat.InOrg(orgID).WithOwner(apiKey.UserID.String())) {
+		httpapi.Forbidden(rw)
 		return
 	}
 
@@ -5857,9 +5862,10 @@ func (api *API) postChatToolResults(rw http.ResponseWriter, r *http.Request) {
 
 	// Gate tool-result submission behind agents-access.
 	// Submitting tool results resumes AI/LLM inference on
-	// a chat in requires_action state.
-	// See: https://github.com/coder/coder/issues/24250
-	if !api.Authorize(r, policy.ActionCreate, rbac.ResourceChat.WithOwner(apiKey.UserID.String())) {
+	// a chat in requires_action state. InOrg is required so
+	// that org-level custom roles can grant chat access
+	// within their organization.
+	if !api.Authorize(r, policy.ActionCreate, rbac.ResourceChat.InOrg(chat.OrganizationID).WithOwner(apiKey.UserID.String())) {
 		httpapi.Forbidden(rw)
 		return
 	}

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -384,6 +384,11 @@ func (api *API) postChats(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	apiKey := httpmw.APIKey(r)
 
+	if !api.Authorize(r, policy.ActionCreate, rbac.ResourceChat.WithOwner(apiKey.UserID.String())) {
+		httpapi.Forbidden(rw)
+		return
+	}
+
 	// Cap the raw request body to prevent excessive memory use
 	// from large dynamic tool schemas.
 	r.Body = http.MaxBytesReader(rw, r.Body, int64(2*maxSystemPromptLenBytes))
@@ -412,14 +417,6 @@ func (api *API) postChats(rw http.ResponseWriter, r *http.Request) {
 		httpapi.Write(ctx, rw, http.StatusForbidden, codersdk.Response{
 			Message: "You are not a member of the specified organization.",
 		})
-		return
-	}
-
-	// Authorize after parsing the body so the org ID is available.
-	// The resource must include InOrg so that org-level custom roles
-	// can grant chat creation within their organization.
-	if !api.Authorize(r, policy.ActionCreate, rbac.ResourceChat.InOrg(req.OrganizationID).WithOwner(apiKey.UserID.String())) {
-		httpapi.Forbidden(rw)
 		return
 	}
 
@@ -1879,9 +1876,11 @@ func (api *API) postChatMessages(rw http.ResponseWriter, r *http.Request) {
 	// Gate message sending behind the same agents-access check
 	// used by postChats. Sending a message triggers AI/LLM
 	// inference, so it should require the same authorization as
-	// chat creation. InOrg is required so that org-level custom
-	// roles can grant chat access within their organization.
-	if !api.Authorize(r, policy.ActionCreate, rbac.ResourceChat.InOrg(chat.OrganizationID).WithOwner(apiKey.UserID.String())) {
+	// chat creation. This is a handler-level band-aid; the
+	// structural fix is to make agents-access org-aware so
+	// dbauthz enforces this at the RBAC layer.
+	// See: https://github.com/coder/coder/issues/24250
+	if !api.Authorize(r, policy.ActionCreate, rbac.ResourceChat.WithOwner(apiKey.UserID.String())) {
 		httpapi.Forbidden(rw)
 		return
 	}
@@ -2132,10 +2131,9 @@ func (api *API) promoteChatQueuedMessage(rw http.ResponseWriter, r *http.Request
 
 	// Gate queued-message promotion behind agents-access.
 	// Promoting a queued message triggers AI/LLM inference,
-	// same as sending a new message. InOrg is required so
-	// that org-level custom roles can grant chat access
-	// within their organization.
-	if !api.Authorize(r, policy.ActionCreate, rbac.ResourceChat.InOrg(chat.OrganizationID).WithOwner(apiKey.UserID.String())) {
+	// same as sending a new message.
+	// See: https://github.com/coder/coder/issues/24250
+	if !api.Authorize(r, policy.ActionCreate, rbac.ResourceChat.WithOwner(apiKey.UserID.String())) {
 		httpapi.Forbidden(rw)
 		return
 	}
@@ -3718,6 +3716,11 @@ func (api *API) postChatFile(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	apiKey := httpmw.APIKey(r)
 
+	if !api.Authorize(r, policy.ActionCreate, rbac.ResourceChat.WithOwner(apiKey.UserID.String())) {
+		httpapi.Forbidden(rw)
+		return
+	}
+
 	orgIDStr := r.URL.Query().Get("organization")
 	if orgIDStr == "" {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
@@ -3730,14 +3733,6 @@ func (api *API) postChatFile(rw http.ResponseWriter, r *http.Request) {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Invalid organization ID.",
 		})
-		return
-	}
-
-	// Authorize after parsing the org ID so InOrg is available.
-	// This ensures org-level custom roles can grant chat file
-	// uploads within their organization.
-	if !api.Authorize(r, policy.ActionCreate, rbac.ResourceChat.InOrg(orgID).WithOwner(apiKey.UserID.String())) {
-		httpapi.Forbidden(rw)
 		return
 	}
 
@@ -5862,10 +5857,9 @@ func (api *API) postChatToolResults(rw http.ResponseWriter, r *http.Request) {
 
 	// Gate tool-result submission behind agents-access.
 	// Submitting tool results resumes AI/LLM inference on
-	// a chat in requires_action state. InOrg is required so
-	// that org-level custom roles can grant chat access
-	// within their organization.
-	if !api.Authorize(r, policy.ActionCreate, rbac.ResourceChat.InOrg(chat.OrganizationID).WithOwner(apiKey.UserID.String())) {
+	// a chat in requires_action state.
+	// See: https://github.com/coder/coder/issues/24250
+	if !api.Authorize(r, policy.ActionCreate, rbac.ResourceChat.WithOwner(apiKey.UserID.String())) {
 		httpapi.Forbidden(rw)
 		return
 	}

--- a/enterprise/coderd/exp_chats_custom_role_test.go
+++ b/enterprise/coderd/exp_chats_custom_role_test.go
@@ -21,11 +21,10 @@ import (
 //
 // Key RBAC facts for context:
 //   - Chat objects are org-scoped: ResourceChat.WithID(id).WithOwner(ownerID).InOrg(orgID)
-//   - The postChats handler checks ActionCreate on ResourceChat.WithOwner(userID) (no InOrg),
-//     meaning org-level permissions alone cannot satisfy the create check. Users need either
-//     the built-in agents-access role (user-level create) or a site-level wildcard (owner).
+//   - The postChats handler checks ActionCreate on ResourceChat.InOrg(orgID).WithOwner(userID),
+//     so org-level custom role permissions can satisfy the create check.
 //   - Read/update checks go through dbauthz on the actual chat object (which IS org-scoped),
-//     so org-level custom role permissions DO apply for reads and updates on existing chats.
+//     so org-level custom role permissions apply for reads and updates on existing chats.
 //   - The listChats handler hardcodes OwnerID to the calling user, so cross-user visibility
 //     must be tested via GetChat, not ListChats.
 func TestCustomRoleChatAccess(t *testing.T) {
@@ -95,8 +94,8 @@ func TestCustomRoleChatAccess(t *testing.T) {
 	}
 
 	// FullCRUD: A custom role granting read+update on chat combined with
-	// agents-access (for create) should allow the member to create their
-	// own chats AND read/update another user's chat via org-level perms.
+	// agents-access should allow the member to create their own chats AND
+	// read/update another user's chat via org-level perms.
 	t.Run("FullCRUD", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
@@ -115,7 +114,11 @@ func TestCustomRoleChatAccess(t *testing.T) {
 		_, err := s.ownerClient.CreateOrganizationRole(ctx, role)
 		require.NoError(t, err)
 
-		// Create a member with the custom role AND agents-access (for chat creation).
+		// Create a member with the custom role AND agents-access.
+		// agents-access is still needed for chat creation because
+		// downstream dbauthz checks (e.g. GetDefaultChatModelConfig)
+		// use un-org-scoped ResourceChat checks that only match
+		// user-level permissions.
 		memberRaw, _ := coderdtest.CreateAnotherUser(
 			t, s.ownerClient, s.firstUser.OrganizationID,
 			rbac.RoleIdentifier{Name: role.Name, OrganizationID: s.firstUser.OrganizationID},
@@ -123,7 +126,7 @@ func TestCustomRoleChatAccess(t *testing.T) {
 		)
 		memberExp := codersdk.NewExperimentalClient(memberRaw)
 
-		// 1. Member can create their own chat (via agents-access user-level create).
+		// 1. Member can create their own chat.
 		memberChat, err := memberExp.CreateChat(ctx, codersdk.CreateChatRequest{
 			OrganizationID: s.firstUser.OrganizationID,
 			Content: []codersdk.ChatInputPart{

--- a/enterprise/coderd/exp_chats_custom_role_test.go
+++ b/enterprise/coderd/exp_chats_custom_role_test.go
@@ -1,0 +1,269 @@
+package coderd_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/util/ptr"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/enterprise/coderd/coderdenttest"
+	"github.com/coder/coder/v2/enterprise/coderd/license"
+	"github.com/coder/coder/v2/testutil"
+)
+
+// TestCustomRoleChatAccess validates that custom organization roles with
+// chat permissions allow users to access chat resources across user
+// boundaries within the same org.
+//
+// Key RBAC facts for context:
+//   - Chat objects are org-scoped: ResourceChat.WithID(id).WithOwner(ownerID).InOrg(orgID)
+//   - The postChats handler checks ActionCreate on ResourceChat.WithOwner(userID) (no InOrg),
+//     meaning org-level permissions alone cannot satisfy the create check. Users need either
+//     the built-in agents-access role (user-level create) or a site-level wildcard (owner).
+//   - Read/update checks go through dbauthz on the actual chat object (which IS org-scoped),
+//     so org-level custom role permissions DO apply for reads and updates on existing chats.
+//   - The listChats handler hardcodes OwnerID to the calling user, so cross-user visibility
+//     must be tested via GetChat, not ListChats.
+func TestCustomRoleChatAccess(t *testing.T) {
+	t.Parallel()
+
+	// setupTest creates an enterprise server with custom roles + agents
+	// experiment, a chat provider/model config, and an owner-created chat.
+	type testSetup struct {
+		ownerClient *codersdk.Client
+		ownerExp    *codersdk.ExperimentalClient
+		firstUser   codersdk.CreateFirstUserResponse
+		ownerChat   codersdk.Chat
+	}
+
+	setupTest := func(t *testing.T) testSetup {
+		t.Helper()
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		dv := coderdtest.DeploymentValues(t)
+		dv.Experiments = []string{string(codersdk.ExperimentAgents)}
+
+		client, firstUser := coderdenttest.New(t, &coderdenttest.Options{
+			Options: &coderdtest.Options{
+				DeploymentValues: dv,
+			},
+			LicenseOptions: &coderdenttest.LicenseOptions{
+				Features: license.Features{
+					codersdk.FeatureCustomRoles: 1,
+				},
+			},
+		})
+		expClient := codersdk.NewExperimentalClient(client)
+
+		// Create a chat provider and model config so chats can be created.
+		provider, err := expClient.CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
+			Provider:    "openai",
+			DisplayName: "OpenAI",
+			APIKey:      "test-key",
+			BaseURL:     "https://example.com",
+		})
+		require.NoError(t, err)
+		_, err = expClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+			Provider:             provider.Provider,
+			Model:                "gpt-4o-mini",
+			DisplayName:          "Test Model",
+			IsDefault:            ptr.Ref(true),
+			ContextLimit:         ptr.Ref(int64(1000)),
+			CompressionThreshold: ptr.Ref(int32(70)),
+		})
+		require.NoError(t, err)
+
+		// Owner creates a chat that subtests use to verify cross-user access.
+		ownerChat, err := expClient.CreateChat(ctx, codersdk.CreateChatRequest{
+			OrganizationID: firstUser.OrganizationID,
+			Content: []codersdk.ChatInputPart{
+				{Type: codersdk.ChatInputPartTypeText, Text: "hello from owner"},
+			},
+		})
+		require.NoError(t, err)
+
+		return testSetup{
+			ownerClient: client,
+			ownerExp:    expClient,
+			firstUser:   firstUser,
+			ownerChat:   ownerChat,
+		}
+	}
+
+	// FullCRUD: A custom role granting read+update on chat combined with
+	// agents-access (for create) should allow the member to create their
+	// own chats AND read/update another user's chat via org-level perms.
+	t.Run("FullCRUD", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		s := setupTest(t)
+
+		// Create custom role with read+update chat permissions at org level.
+		role := codersdk.Role{
+			Name:           "chat-read-update",
+			DisplayName:    "Chat Read Update",
+			OrganizationID: s.firstUser.OrganizationID.String(),
+			OrganizationPermissions: codersdk.CreatePermissions(map[codersdk.RBACResource][]codersdk.RBACAction{
+				codersdk.ResourceChat: {codersdk.ActionRead, codersdk.ActionUpdate},
+			}),
+		}
+		//nolint:gocritic // owner is required to create custom roles
+		_, err := s.ownerClient.CreateOrganizationRole(ctx, role)
+		require.NoError(t, err)
+
+		// Create a member with the custom role AND agents-access (for chat creation).
+		memberRaw, _ := coderdtest.CreateAnotherUser(
+			t, s.ownerClient, s.firstUser.OrganizationID,
+			rbac.RoleIdentifier{Name: role.Name, OrganizationID: s.firstUser.OrganizationID},
+			rbac.RoleAgentsAccess(),
+		)
+		memberExp := codersdk.NewExperimentalClient(memberRaw)
+
+		// 1. Member can create their own chat (via agents-access user-level create).
+		memberChat, err := memberExp.CreateChat(ctx, codersdk.CreateChatRequest{
+			OrganizationID: s.firstUser.OrganizationID,
+			Content: []codersdk.ChatInputPart{
+				{Type: codersdk.ChatInputPartTypeText, Text: "hello from member"},
+			},
+		})
+		require.NoError(t, err, "member with agents-access should create chats")
+
+		// 2. Member can list their own chats.
+		chats, err := memberExp.ListChats(ctx, nil)
+		require.NoError(t, err)
+		var foundOwn bool
+		for _, c := range chats {
+			if c.ID == memberChat.ID {
+				foundOwn = true
+			}
+		}
+		require.True(t, foundOwn, "member should see own chat in list")
+
+		// 3. Member can read their own chat.
+		gotChat, err := memberExp.GetChat(ctx, memberChat.ID)
+		require.NoError(t, err)
+		require.Equal(t, memberChat.ID, gotChat.ID)
+
+		// 4. Member can read the OWNER's chat (cross-user via org-level read).
+		gotOwnerChat, err := memberExp.GetChat(ctx, s.ownerChat.ID)
+		require.NoError(t, err, "custom org-level read should grant access to owner's chat")
+		require.Equal(t, s.ownerChat.ID, gotOwnerChat.ID)
+
+		// 5. Member can read the owner's chat messages.
+		messages, err := memberExp.GetChatMessages(ctx, s.ownerChat.ID, nil)
+		require.NoError(t, err, "custom org-level read should grant access to owner's messages")
+		require.NotEmpty(t, messages.Messages)
+
+		// 6. Member can archive the owner's chat (cross-user via org-level update).
+		err = memberExp.UpdateChat(ctx, s.ownerChat.ID, codersdk.UpdateChatRequest{
+			Archived: ptr.Ref(true),
+		})
+		require.NoError(t, err, "custom org-level update should allow archiving owner's chat")
+	})
+
+	// ReadOtherUsersChat: A custom role granting ONLY read on chat
+	// should allow the member to view another user's chat but not modify it.
+	t.Run("ReadOtherUsersChat", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		s := setupTest(t)
+
+		// Create custom role with read-only chat permission at org level.
+		role := codersdk.Role{
+			Name:           "chat-read-only",
+			DisplayName:    "Chat Read Only",
+			OrganizationID: s.firstUser.OrganizationID.String(),
+			OrganizationPermissions: codersdk.CreatePermissions(map[codersdk.RBACResource][]codersdk.RBACAction{
+				codersdk.ResourceChat: {codersdk.ActionRead},
+			}),
+		}
+		//nolint:gocritic // owner is required to create custom roles
+		_, err := s.ownerClient.CreateOrganizationRole(ctx, role)
+		require.NoError(t, err)
+
+		// Create a member with the custom role AND agents-access.
+		// agents-access grants user-level chat create/read/update/delete
+		// on own resources. The custom role adds org-level read on ALL
+		// chats in the org.
+		memberRaw, _ := coderdtest.CreateAnotherUser(
+			t, s.ownerClient, s.firstUser.OrganizationID,
+			rbac.RoleIdentifier{Name: role.Name, OrganizationID: s.firstUser.OrganizationID},
+			rbac.RoleAgentsAccess(),
+		)
+		memberExp := codersdk.NewExperimentalClient(memberRaw)
+
+		// 1. Member can read the owner's chat (via custom org-level read).
+		gotChat, err := memberExp.GetChat(ctx, s.ownerChat.ID)
+		require.NoError(t, err, "custom org-level read should grant access to owner's chat")
+		require.Equal(t, s.ownerChat.ID, gotChat.ID)
+
+		// 2. Member can read the owner's chat messages.
+		messages, err := memberExp.GetChatMessages(ctx, s.ownerChat.ID, nil)
+		require.NoError(t, err, "custom org-level read should grant access to owner's messages")
+		require.NotEmpty(t, messages.Messages)
+
+		// 3. Member CANNOT update (archive) the owner's chat — no org-level update.
+		// The ChatParam middleware successfully loads the chat (member has
+		// org-level read), but the subsequent ArchiveChatByID call fails
+		// in dbauthz because the member lacks update permission. The
+		// handler currently returns 500 for this case.
+		err = memberExp.UpdateChat(ctx, s.ownerChat.ID, codersdk.UpdateChatRequest{
+			Archived: ptr.Ref(true),
+		})
+		require.Error(t, err, "member without org-level update should not archive owner's chat")
+		var apiErr *codersdk.Error
+		require.ErrorAs(t, err, &apiErr)
+		require.True(t, apiErr.StatusCode() == http.StatusInternalServerError || apiErr.StatusCode() == http.StatusNotFound,
+			"expected 500 or 404, got %d", apiErr.StatusCode())
+	})
+
+	// NoOrgPermissions: A member with agents-access but NO custom org role
+	// should not be able to access another user's chat. This is the baseline
+	// control proving the custom role is what enables cross-user access.
+	t.Run("NoOrgPermissions", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitLong)
+		s := setupTest(t)
+
+		// Create a member with agents-access only (no custom org role).
+		memberRaw, _ := coderdtest.CreateAnotherUser(
+			t, s.ownerClient, s.firstUser.OrganizationID,
+			rbac.RoleAgentsAccess(),
+		)
+		memberExp := codersdk.NewExperimentalClient(memberRaw)
+
+		// 1. Member can create their own chat (via agents-access).
+		_, err := memberExp.CreateChat(ctx, codersdk.CreateChatRequest{
+			OrganizationID: s.firstUser.OrganizationID,
+			Content: []codersdk.ChatInputPart{
+				{Type: codersdk.ChatInputPartTypeText, Text: "hello from member"},
+			},
+		})
+		require.NoError(t, err, "member with agents-access can create own chats")
+
+		// 2. Member CANNOT read the owner's chat — no org-level read.
+		_, err = memberExp.GetChat(ctx, s.ownerChat.ID)
+		require.Error(t, err, "member without org-level read should not access owner's chat")
+		var apiErr *codersdk.Error
+		require.ErrorAs(t, err, &apiErr)
+		require.Equal(t, http.StatusNotFound, apiErr.StatusCode())
+
+		// 3. Member CANNOT read the owner's chat messages.
+		_, err = memberExp.GetChatMessages(ctx, s.ownerChat.ID, nil)
+		require.Error(t, err, "member without org-level read should not read owner's messages")
+		require.ErrorAs(t, err, &apiErr)
+		require.Equal(t, http.StatusNotFound, apiErr.StatusCode())
+
+		// 4. Member CANNOT update the owner's chat.
+		err = memberExp.UpdateChat(ctx, s.ownerChat.ID, codersdk.UpdateChatRequest{
+			Archived: ptr.Ref(true),
+		})
+		require.Error(t, err, "member without org-level update should not archive owner's chat")
+		require.ErrorAs(t, err, &apiErr)
+		require.Equal(t, http.StatusNotFound, apiErr.StatusCode())
+	})
+}


### PR DESCRIPTION
Adds `TestCustomRoleChatAccess` with three subtests validating custom org roles with chat permissions:
- **FullCRUD**: Custom role with `read+update` + `agents-access` grants cross-user chat access
- **ReadOtherUsersChat**: Custom role with `read` only allows viewing but not modifying other users' chats
- **NoOrgPermissions**: Baseline control proving agents-access alone cannot access other users' chats

During implementation, discovered that all five `ActionCreate` checks on `ResourceChat` in `exp_chats.go` use `WithOwner(userID)` without `.InOrg(orgID)`. This means org-level custom roles cannot grant chat creation — `agents-access` is the sole gate. This is currently intentional (pending #24250) but means custom roles currently only work for cross-user read/update, not create.

Relates to #24250.

> :robot: