### PR TITLE
perf: cache message serialization to avoid O(N²) JSON encoding

### DIFF
--- a/coderd/x/chatd/chatloop/chatloop.go
+++ b/coderd/x/chatd/chatloop/chatloop.go
@@ -308,10 +308,16 @@ func Run(ctx context.Context, opts RunOptions) error {
 	tools := buildToolDefinitions(opts.Tools, opts.ActiveTools, opts.ProviderTools)
 	applyAnthropicCaching := shouldApplyAnthropicPromptCaching(opts.Model)
 
+	var msgCache *mapMessageCache
+	if applyAnthropicCaching {
+		msgCache = newMapMessageCache()
+	}
+
 	messages := opts.Messages
 	var lastUsage fantasy.Usage
 	var lastProviderMetadata fantasy.ProviderMetadata
 	needsFullHistoryReload := false
+
 	reloadFullHistory := func(stage string) error {
 		if opts.ReloadMessages == nil {
 			return nil
@@ -355,6 +361,11 @@ func Run(ctx context.Context, opts RunOptions) error {
 				addAnthropicPromptCaching(prepared)
 			}
 
+			providerOpts := opts.ProviderOptions
+			if msgCache != nil {
+				providerOpts = cloneProviderOptionsWithCache(opts.ProviderOptions, msgCache)
+			}
+
 			call := fantasy.Call{
 				Prompt:           prepared,
 				Tools:            tools,
@@ -364,9 +375,8 @@ func Run(ctx context.Context, opts RunOptions) error {
 				TopK:             opts.ModelConfig.TopK,
 				PresencePenalty:  opts.ModelConfig.PresencePenalty,
 				FrequencyPenalty: opts.ModelConfig.FrequencyPenalty,
-				ProviderOptions:  opts.ProviderOptions,
+				ProviderOptions:  providerOpts,
 			}
-
 			var result stepResult
 			err := chatretry.Retry(ctx, func(retryCtx context.Context) error {
 				attempt, streamErr := guardedStream(
@@ -591,6 +601,9 @@ func Run(ctx context.Context, opts RunOptions) error {
 					if err := reloadFullHistory("after compaction"); err != nil {
 						return err
 					}
+					if msgCache != nil {
+						msgCache.Clear()
+					}
 				}
 			}
 			if !result.shouldContinue {
@@ -646,6 +659,9 @@ func Run(ctx context.Context, opts RunOptions) error {
 				return xerrors.Errorf("reload messages after compaction: %w", reloadErr)
 			}
 			messages = reloaded
+			if msgCache != nil {
+				msgCache.Clear()
+			}
 			continue
 		}
 		break

--- a/coderd/x/chatd/chatloop/messagecache.go
+++ b/coderd/x/chatd/chatloop/messagecache.go
@@ -1,0 +1,74 @@
+package chatloop
+
+import (
+	"encoding/json"
+
+	"charm.land/fantasy"
+)
+
+const (
+	// MessageCacheProviderOptionsKey is the provider-options
+	// key used to pass a MessageCache through fantasy.Call.
+	MessageCacheProviderOptionsKey = "anthropic.message_cache"
+)
+
+// MessageCache caches serialized message JSON bytes keyed by
+// output message index. Implementations need not be safe for
+// concurrent use — the chat step loop is sequential.
+type MessageCache interface {
+	Get(index int) (json.RawMessage, bool)
+	Set(index int, data json.RawMessage)
+	Clear()
+}
+
+// mapMessageCache is a simple in-memory MessageCache backed by a map.
+type mapMessageCache struct {
+	entries map[int]json.RawMessage
+}
+
+func newMapMessageCache() *mapMessageCache {
+	return &mapMessageCache{entries: make(map[int]json.RawMessage)}
+}
+
+func (c *mapMessageCache) Get(index int) (json.RawMessage, bool) {
+	data, ok := c.entries[index]
+	return data, ok
+}
+
+func (c *mapMessageCache) Set(index int, data json.RawMessage) {
+	c.entries[index] = data
+}
+
+func (c *mapMessageCache) Clear() {
+	clear(c.entries)
+}
+
+// ProviderOptionsData interface methods allow mapMessageCache to
+// be stored in fantasy.ProviderOptions. The cache is never
+// serialized over the wire — these are stubs.
+
+func (*mapMessageCache) Options() {}
+
+func (*mapMessageCache) MarshalJSON() ([]byte, error) {
+	return []byte("null"), nil
+}
+
+func (*mapMessageCache) UnmarshalJSON([]byte) error {
+	return nil
+}
+
+// cloneProviderOptionsWithCache returns a shallow copy of base
+// with the message cache entry added. If base is nil a new map
+// is created.
+func cloneProviderOptionsWithCache(base fantasy.ProviderOptions, cache MessageCache) fantasy.ProviderOptions {
+	result := make(fantasy.ProviderOptions, len(base)+1)
+	for k, v := range base {
+		result[k] = v
+	}
+	mmc, ok := cache.(*mapMessageCache)
+	if !ok {
+		return base
+	}
+	result[MessageCacheProviderOptionsKey] = mmc
+	return result
+}

--- a/coderd/x/chatd/chatloop/messagecache_test.go
+++ b/coderd/x/chatd/chatloop/messagecache_test.go
@@ -1,0 +1,348 @@
+package chatloop //nolint:testpackage // Uses internal symbols.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+
+	"charm.land/fantasy"
+	fantasyanthropic "charm.land/fantasy/providers/anthropic"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/x/chatd/chattest"
+	"github.com/coder/coder/v2/testutil"
+)
+
+// extractMessageCache is a test helper that extracts the
+// MessageCache from a captured fantasy.Call's ProviderOptions.
+// Returns (cache, true) when the key is present and the value
+// satisfies the MessageCache interface.
+func extractMessageCache(t *testing.T, call fantasy.Call) (MessageCache, bool) {
+	t.Helper()
+	if call.ProviderOptions == nil {
+		return nil, false
+	}
+	v, ok := call.ProviderOptions[MessageCacheProviderOptionsKey]
+	if !ok {
+		return nil, false
+	}
+	mc, ok := v.(MessageCache)
+	require.True(t, ok, "cache entry should implement MessageCache")
+	return mc, true
+}
+
+// streamToolCall returns a StreamResponse that emits a single tool
+// call and finishes with FinishReasonToolCalls, causing the step
+// loop to continue.
+func streamToolCall(id string) fantasy.StreamResponse {
+	return streamFromParts([]fantasy.StreamPart{
+		{Type: fantasy.StreamPartTypeToolInputStart, ID: id, ToolCallName: "read_file"},
+		{Type: fantasy.StreamPartTypeToolInputDelta, ID: id, Delta: `{"path":"f.go"}`},
+		{Type: fantasy.StreamPartTypeToolInputEnd, ID: id},
+		{
+			Type:          fantasy.StreamPartTypeToolCall,
+			ID:            id,
+			ToolCallName:  "read_file",
+			ToolCallInput: `{"path":"f.go"}`,
+		},
+		{Type: fantasy.StreamPartTypeFinish, FinishReason: fantasy.FinishReasonToolCalls},
+	})
+}
+
+// streamTextStop returns a StreamResponse that emits a short text
+// block and finishes with FinishReasonStop, causing the step loop
+// to end.
+func streamTextStop(text string, usage fantasy.Usage) fantasy.StreamResponse {
+	return streamFromParts([]fantasy.StreamPart{
+		{Type: fantasy.StreamPartTypeTextStart, ID: "text"},
+		{Type: fantasy.StreamPartTypeTextDelta, ID: "text", Delta: text},
+		{Type: fantasy.StreamPartTypeTextEnd, ID: "text"},
+		{Type: fantasy.StreamPartTypeFinish, FinishReason: fantasy.FinishReasonStop, Usage: usage},
+	})
+}
+
+// callCapturingModel returns a FakeModel whose StreamFn records
+// each fantasy.Call and delegates to stepFn for the response.
+// The returned slice and counter are protected by the returned
+// mutex.
+type callCapture struct {
+	mu    sync.Mutex
+	calls []fantasy.Call
+	count int
+}
+
+func (c *callCapture) record(call fantasy.Call) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	step := c.count
+	c.count++
+	c.calls = append(c.calls, call)
+	return step
+}
+
+func TestChatLoop_MessageCachePassedToProvider(t *testing.T) {
+	t.Parallel()
+	ctx := testutil.Context(t, testutil.WaitShort)
+
+	var capture callCapture
+	model := &chattest.FakeModel{
+		ProviderName: fantasyanthropic.Name,
+		StreamFn: func(_ context.Context, call fantasy.Call) (fantasy.StreamResponse, error) {
+			step := capture.record(call)
+			if step == 0 {
+				return streamToolCall("tc-1"), nil
+			}
+			return streamTextStop("done", fantasy.Usage{}), nil
+		},
+	}
+
+	err := Run(ctx, RunOptions{
+		Model:                model,
+		Messages:             []fantasy.Message{textMessage(fantasy.MessageRoleUser, "hello")},
+		Tools:                []fantasy.AgentTool{newNoopTool("read_file")},
+		MaxSteps:             3,
+		ContextLimitFallback: 4096,
+		PersistStep:          func(_ context.Context, _ PersistedStep) error { return nil },
+	})
+	require.NoError(t, err)
+
+	capture.mu.Lock()
+	defer capture.mu.Unlock()
+
+	require.Equal(t, 2, capture.count, "expected 2 stream calls (tool-call + stop)")
+
+	// Both calls should carry the same MessageCache instance.
+	cache0, ok0 := extractMessageCache(t, capture.calls[0])
+	cache1, ok1 := extractMessageCache(t, capture.calls[1])
+	require.True(t, ok0, "step 0: cache should be present")
+	require.True(t, ok1, "step 1: cache should be present")
+	assert.Same(t, cache0, cache1, "same cache instance should be reused across steps")
+}
+
+func TestChatLoop_MessageCacheNotSetForNonAnthropic(t *testing.T) {
+	t.Parallel()
+	ctx := testutil.Context(t, testutil.WaitShort)
+
+	var capturedCall fantasy.Call
+	model := &chattest.FakeModel{
+		ProviderName: "openai",
+		StreamFn: func(_ context.Context, call fantasy.Call) (fantasy.StreamResponse, error) {
+			capturedCall = call
+			return streamTextStop("done", fantasy.Usage{}), nil
+		},
+	}
+
+	err := Run(ctx, RunOptions{
+		Model:                model,
+		Messages:             []fantasy.Message{textMessage(fantasy.MessageRoleUser, "hello")},
+		MaxSteps:             1,
+		ContextLimitFallback: 4096,
+		PersistStep:          func(_ context.Context, _ PersistedStep) error { return nil },
+	})
+	require.NoError(t, err)
+
+	_, ok := extractMessageCache(t, capturedCall)
+	require.False(t, ok, "non-Anthropic provider should not have a MessageCache")
+}
+
+func TestChatLoop_MessageCacheClearedOnCompaction(t *testing.T) {
+	t.Parallel()
+	ctx := testutil.Context(t, testutil.WaitShort)
+
+	var capture callCapture
+	model := &chattest.FakeModel{
+		ProviderName: fantasyanthropic.Name,
+		StreamFn: func(_ context.Context, call fantasy.Call) (fantasy.StreamResponse, error) {
+			step := capture.record(call)
+			if step == 0 {
+				// High usage triggers compaction (80/100 = 80% > 70%).
+				return streamTextStop("initial", fantasy.Usage{InputTokens: 80, TotalTokens: 85}), nil
+			}
+			return streamTextStop("after compaction", fantasy.Usage{InputTokens: 20, TotalTokens: 25}), nil
+		},
+		GenerateFn: func(_ context.Context, _ fantasy.Call) (*fantasy.Response, error) {
+			return &fantasy.Response{
+				Content: []fantasy.Content{fantasy.TextContent{Text: "compacted summary"}},
+			}, nil
+		},
+	}
+
+	err := Run(ctx, RunOptions{
+		Model:                model,
+		Messages:             []fantasy.Message{textMessage(fantasy.MessageRoleUser, "hello")},
+		MaxSteps:             3,
+		ContextLimitFallback: 100,
+		PersistStep:          func(_ context.Context, _ PersistedStep) error { return nil },
+		Compaction: &CompactionOptions{
+			ThresholdPercent: 70,
+			SummaryPrompt:    "summarize now",
+			Persist:          func(_ context.Context, _ CompactionResult) error { return nil },
+		},
+		ReloadMessages: func(_ context.Context) ([]fantasy.Message, error) {
+			return []fantasy.Message{
+				textMessage(fantasy.MessageRoleSystem, "compacted system"),
+				textMessage(fantasy.MessageRoleUser, "compacted user"),
+			}, nil
+		},
+	})
+	require.NoError(t, err)
+
+	capture.mu.Lock()
+	defer capture.mu.Unlock()
+
+	require.GreaterOrEqual(t, capture.count, 2, "expected at least 2 stream calls")
+
+	// Both steps should carry a MessageCache.
+	for i, call := range capture.calls {
+		_, ok := extractMessageCache(t, call)
+		require.True(t, ok, "step %d: cache should be present", i)
+	}
+
+	// The cache instance is the same object, but Clear() should
+	// have been called between steps. We verify indirectly: the
+	// cache is a *mapMessageCache and should have no stale entries
+	// from step 0 by the time step 1 completes (compaction
+	// replaced the message history).
+	mc, _ := extractMessageCache(t, capture.calls[0])
+	_ = mc // Cache was cleared; no stale entries survive.
+}
+
+// simulateProviderCachePopulation mimics the Anthropic provider's
+// toPrompt/applySerialisationCache logic: for each output message
+// that lacks a cache_control breakpoint, it checks the cache (hit)
+// or stores a placeholder (miss).
+func simulateProviderCachePopulation(t *testing.T, call fantasy.Call) (hits, misses int) {
+	t.Helper()
+	mc, ok := extractMessageCache(t, call)
+	if !ok {
+		return 0, 0
+	}
+	outIdx := 0
+	for _, msg := range call.Prompt {
+		if msg.Role == fantasy.MessageRoleSystem {
+			continue
+		}
+		if !hasAnthropicEphemeralCacheControl(msg) {
+			if _, cached := mc.Get(outIdx); cached {
+				hits++
+			} else {
+				mc.Set(outIdx, json.RawMessage(`{"simulated":true}`))
+				misses++
+			}
+		}
+		outIdx++
+	}
+	return hits, misses
+}
+
+func TestChatLoop_MessageCachePopulatedByProvider(t *testing.T) {
+	t.Parallel()
+	ctx := testutil.Context(t, testutil.WaitShort)
+
+	// 3-step conversation with enough initial messages so that
+	// addAnthropicPromptCaching leaves some without breakpoints.
+	//   Step 0: 4 msgs → 0 hits, 1 miss, 1 total
+	//   Step 1: 6 msgs → 1 hit, 2 misses, 3 total
+	//   Step 2: 8 msgs → 3 hits, 2 misses, 5 total
+
+	type stepStats struct{ hits, misses, total int }
+
+	var capture callCapture
+	var stats []stepStats
+
+	model := &chattest.FakeModel{
+		ProviderName: fantasyanthropic.Name,
+		StreamFn: func(_ context.Context, call fantasy.Call) (fantasy.StreamResponse, error) {
+			step := capture.record(call)
+			hits, misses := simulateProviderCachePopulation(t, call)
+			mmc := call.ProviderOptions[MessageCacheProviderOptionsKey].(*mapMessageCache)
+			capture.mu.Lock()
+			stats = append(stats, stepStats{hits, misses, len(mmc.entries)})
+			capture.mu.Unlock()
+
+			if step < 2 {
+				return streamToolCall(fmt.Sprintf("tc-%d", step)), nil
+			}
+			return streamTextStop("done", fantasy.Usage{}), nil
+		},
+	}
+
+	err := Run(ctx, RunOptions{
+		Model: model,
+		Messages: []fantasy.Message{
+			textMessage(fantasy.MessageRoleSystem, "system prompt"),
+			textMessage(fantasy.MessageRoleUser, "hello"),
+			textMessage(fantasy.MessageRoleAssistant, "thinking"),
+			textMessage(fantasy.MessageRoleUser, "continue"),
+		},
+		Tools:                []fantasy.AgentTool{newNoopTool("read_file")},
+		MaxSteps:             5,
+		ContextLimitFallback: 4096,
+		PersistStep:          func(_ context.Context, _ PersistedStep) error { return nil },
+	})
+	require.NoError(t, err)
+
+	capture.mu.Lock()
+	defer capture.mu.Unlock()
+
+	require.Equal(t, 3, capture.count)
+	require.Len(t, stats, 3)
+
+	assert.Equal(t, stepStats{0, 1, 1}, stats[0], "step 0")
+	assert.Equal(t, stepStats{1, 2, 3}, stats[1], "step 1")
+	assert.Equal(t, stepStats{3, 2, 5}, stats[2], "step 2")
+
+	// Same cache instance across all steps.
+	for i := 1; i < len(capture.calls); i++ {
+		c0 := capture.calls[0].ProviderOptions[MessageCacheProviderOptionsKey]
+		ci := capture.calls[i].ProviderOptions[MessageCacheProviderOptionsKey]
+		assert.Same(t, c0, ci, "cache instance should be same across steps 0 and %d", i)
+	}
+}
+
+func TestMapMessageCache_BasicOperations(t *testing.T) {
+	t.Parallel()
+
+	t.Run("SetAndGet", func(t *testing.T) {
+		t.Parallel()
+		cache := newMapMessageCache()
+		data := json.RawMessage(`{"role":"user","content":"hello"}`)
+		cache.Set(0, data)
+		got, ok := cache.Get(0)
+		require.True(t, ok)
+		require.Equal(t, data, got)
+	})
+
+	t.Run("GetMissing", func(t *testing.T) {
+		t.Parallel()
+		cache := newMapMessageCache()
+		_, ok := cache.Get(42)
+		require.False(t, ok)
+	})
+
+	t.Run("ClearEmptiesAll", func(t *testing.T) {
+		t.Parallel()
+		cache := newMapMessageCache()
+		cache.Set(0, json.RawMessage(`{"a":1}`))
+		cache.Set(1, json.RawMessage(`{"b":2}`))
+		cache.Set(2, json.RawMessage(`{"c":3}`))
+		cache.Clear()
+		for i := range 3 {
+			_, ok := cache.Get(i)
+			require.False(t, ok, "index %d should be cleared", i)
+		}
+	})
+
+	t.Run("SetOverwrites", func(t *testing.T) {
+		t.Parallel()
+		cache := newMapMessageCache()
+		cache.Set(0, json.RawMessage(`{"old":true}`))
+		cache.Set(0, json.RawMessage(`{"new":true}`))
+		got, ok := cache.Get(0)
+		require.True(t, ok)
+		require.Equal(t, json.RawMessage(`{"new":true}`), got)
+	})
+}

--- a/coderd/x/chatd/chatloop/messagecache_test.go
+++ b/coderd/x/chatd/chatloop/messagecache_test.go
@@ -3,8 +3,8 @@ package chatloop //nolint:testpackage // Uses internal symbols.
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"charm.land/fantasy"
@@ -64,10 +64,7 @@ func streamTextStop(text string, usage fantasy.Usage) fantasy.StreamResponse {
 	})
 }
 
-// callCapturingModel returns a FakeModel whose StreamFn records
-// each fantasy.Call and delegates to stepFn for the response.
-// The returned slice and counter are protected by the returned
-// mutex.
+// callCapture records fantasy.Calls made to a FakeModel's StreamFn.
 type callCapture struct {
 	mu    sync.Mutex
 	calls []fantasy.Call
@@ -210,67 +207,33 @@ func TestChatLoop_MessageCacheClearedOnCompaction(t *testing.T) {
 	_ = mc // Cache was cleared; no stale entries survive.
 }
 
-// simulateProviderCachePopulation mimics the Anthropic provider's
-// toPrompt/applySerialisationCache logic: for each output message
-// that lacks a cache_control breakpoint, it checks the cache (hit)
-// or stores a placeholder (miss).
-func simulateProviderCachePopulation(t *testing.T, call fantasy.Call) (hits, misses int) {
-	t.Helper()
-	mc, ok := extractMessageCache(t, call)
-	if !ok {
-		return 0, 0
-	}
-	outIdx := 0
-	for _, msg := range call.Prompt {
-		if msg.Role == fantasy.MessageRoleSystem {
-			continue
-		}
-		if !hasAnthropicEphemeralCacheControl(msg) {
-			if _, cached := mc.Get(outIdx); cached {
-				hits++
-			} else {
-				mc.Set(outIdx, json.RawMessage(`{"simulated":true}`))
-				misses++
-			}
-		}
-		outIdx++
-	}
-	return hits, misses
-}
-
+// TestChatLoop_MessageCachePopulatedByProvider uses a real fantasy
+// Anthropic provider backed by a mock HTTP server to verify that
+// the provider's toPrompt actually populates the cache. This test
+// fails when the fantasy dependency lacks MessageSerializationCache
+// support, since the cache entries will be empty.
 func TestChatLoop_MessageCachePopulatedByProvider(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.Context(t, testutil.WaitShort)
 
-	// 3-step conversation with enough initial messages so that
-	// addAnthropicPromptCaching leaves some without breakpoints.
-	//   Step 0: 4 msgs → 0 hits, 1 miss, 1 total
-	//   Step 1: 6 msgs → 1 hit, 2 misses, 3 total
-	//   Step 2: 8 msgs → 3 hits, 2 misses, 5 total
+	var requestCount atomic.Int32
+	serverURL := chattest.NewAnthropic(t, func(_ *chattest.AnthropicRequest) chattest.AnthropicResponse {
+		requestCount.Add(1)
+		return chattest.AnthropicStreamingResponse(
+			chattest.AnthropicTextChunks("done")...,
+		)
+	})
 
-	type stepStats struct{ hits, misses, total int }
+	provider, err := fantasyanthropic.New(
+		fantasyanthropic.WithAPIKey("test-key"),
+		fantasyanthropic.WithBaseURL(serverURL),
+	)
+	require.NoError(t, err)
 
-	var capture callCapture
-	var stats []stepStats
+	model, err := provider.LanguageModel(ctx, "claude-sonnet-4-20250514")
+	require.NoError(t, err)
 
-	model := &chattest.FakeModel{
-		ProviderName: fantasyanthropic.Name,
-		StreamFn: func(_ context.Context, call fantasy.Call) (fantasy.StreamResponse, error) {
-			step := capture.record(call)
-			hits, misses := simulateProviderCachePopulation(t, call)
-			mmc := call.ProviderOptions[MessageCacheProviderOptionsKey].(*mapMessageCache)
-			capture.mu.Lock()
-			stats = append(stats, stepStats{hits, misses, len(mmc.entries)})
-			capture.mu.Unlock()
-
-			if step < 2 {
-				return streamToolCall(fmt.Sprintf("tc-%d", step)), nil
-			}
-			return streamTextStop("done", fantasy.Usage{}), nil
-		},
-	}
-
-	err := Run(ctx, RunOptions{
+	err = Run(ctx, RunOptions{
 		Model: model,
 		Messages: []fantasy.Message{
 			textMessage(fantasy.MessageRoleSystem, "system prompt"),
@@ -278,29 +241,55 @@ func TestChatLoop_MessageCachePopulatedByProvider(t *testing.T) {
 			textMessage(fantasy.MessageRoleAssistant, "thinking"),
 			textMessage(fantasy.MessageRoleUser, "continue"),
 		},
-		Tools:                []fantasy.AgentTool{newNoopTool("read_file")},
-		MaxSteps:             5,
+		MaxSteps:             1,
+		ContextLimitFallback: 4096,
+		PersistStep:          func(_ context.Context, _ PersistedStep) error { return nil },
+	})
+	require.NoError(t, err)
+	require.Equal(t, int32(1), requestCount.Load(), "expected 1 API request")
+
+	// Run doesn't expose the cache directly, but we know
+	// applyAnthropicCaching is true (provider is "anthropic")
+	// so a cache was created. We need to inspect it.
+	//
+	// Since the cache is local to Run and not returned, we
+	// re-run with a wrapper model that captures the Call so we
+	// can inspect the cache after the provider has touched it.
+	var capturedCache *mapMessageCache
+	wrappedModel := &chattest.FakeModel{
+		ProviderName: fantasyanthropic.Name,
+		StreamFn: func(streamCtx context.Context, call fantasy.Call) (fantasy.StreamResponse, error) {
+			// Grab the cache before the real provider runs.
+			v := call.ProviderOptions[MessageCacheProviderOptionsKey]
+			//nolint:forcetypeassert // Test-only, panics are fine.
+			capturedCache = v.(*mapMessageCache)
+
+			// Delegate to the real provider so toPrompt runs
+			// and populates the cache.
+			return model.Stream(streamCtx, call)
+		},
+		ModelName: "claude-sonnet-4-20250514",
+	}
+
+	err = Run(ctx, RunOptions{
+		Model: wrappedModel,
+		Messages: []fantasy.Message{
+			textMessage(fantasy.MessageRoleSystem, "system prompt"),
+			textMessage(fantasy.MessageRoleUser, "hello"),
+			textMessage(fantasy.MessageRoleAssistant, "thinking"),
+			textMessage(fantasy.MessageRoleUser, "continue"),
+		},
+		MaxSteps:             1,
 		ContextLimitFallback: 4096,
 		PersistStep:          func(_ context.Context, _ PersistedStep) error { return nil },
 	})
 	require.NoError(t, err)
 
-	capture.mu.Lock()
-	defer capture.mu.Unlock()
-
-	require.Equal(t, 3, capture.count)
-	require.Len(t, stats, 3)
-
-	assert.Equal(t, stepStats{0, 1, 1}, stats[0], "step 0")
-	assert.Equal(t, stepStats{1, 2, 3}, stats[1], "step 1")
-	assert.Equal(t, stepStats{3, 2, 5}, stats[2], "step 2")
-
-	// Same cache instance across all steps.
-	for i := 1; i < len(capture.calls); i++ {
-		c0 := capture.calls[0].ProviderOptions[MessageCacheProviderOptionsKey]
-		ci := capture.calls[i].ProviderOptions[MessageCacheProviderOptionsKey]
-		assert.Same(t, c0, ci, "cache instance should be same across steps 0 and %d", i)
-	}
+	require.NotNil(t, capturedCache, "cache should have been created")
+	require.NotEmpty(t, capturedCache.entries,
+		"cache should have been populated by the fantasy Anthropic "+
+			"provider's toPrompt — if empty, the fantasy dependency "+
+			"likely lacks MessageSerializationCache support")
 }
 
 func TestMapMessageCache_BasicOperations(t *testing.T) {

--- a/coderd/x/chatd/chatloop/messagecache_test.go
+++ b/coderd/x/chatd/chatloop/messagecache_test.go
@@ -148,17 +148,39 @@ func TestChatLoop_MessageCacheNotSetForNonAnthropic(t *testing.T) {
 func TestChatLoop_MessageCacheClearedOnCompaction(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.Context(t, testutil.WaitShort)
-
 	var capture callCapture
+	// sentinelPlanted is set once we inject a marker entry into
+	// the cache during step 0. After compaction, Clear() should
+	// remove it before step 1 runs.
+	var sentinelPlanted atomic.Bool
 	model := &chattest.FakeModel{
 		ProviderName: fantasyanthropic.Name,
 		StreamFn: func(_ context.Context, call fantasy.Call) (fantasy.StreamResponse, error) {
 			step := capture.record(call)
-			if step == 0 {
+			mc, ok := extractMessageCache(t, call)
+			require.True(t, ok, "step %d: cache should be present", step)
+			mmc := mc.(*mapMessageCache)
+
+			switch step {
+			case 0:
+				// Plant a sentinel so we can detect whether
+				// Clear() runs before the next step.
+				mmc.Set(9999, json.RawMessage(`{"sentinel":true}`))
+				sentinelPlanted.Store(true)
 				// High usage triggers compaction (80/100 = 80% > 70%).
 				return streamTextStop("initial", fantasy.Usage{InputTokens: 80, TotalTokens: 85}), nil
+			default:
+				// After compaction + Clear(), the sentinel should
+				// be gone and the cache should be empty.
+				require.True(t, sentinelPlanted.Load(),
+					"sentinel should have been planted in step 0")
+				_, hasSentinel := mmc.Get(9999)
+				assert.False(t, hasSentinel,
+					"sentinel entry should have been cleared by compaction")
+				assert.Empty(t, mmc.entries,
+					"cache should be empty after compaction Clear()")
+				return streamTextStop("after compaction", fantasy.Usage{InputTokens: 20, TotalTokens: 25}), nil
 			}
-			return streamTextStop("after compaction", fantasy.Usage{InputTokens: 20, TotalTokens: 25}), nil
 		},
 		GenerateFn: func(_ context.Context, _ fantasy.Call) (*fantasy.Response, error) {
 			return &fantasy.Response{
@@ -189,22 +211,7 @@ func TestChatLoop_MessageCacheClearedOnCompaction(t *testing.T) {
 
 	capture.mu.Lock()
 	defer capture.mu.Unlock()
-
 	require.GreaterOrEqual(t, capture.count, 2, "expected at least 2 stream calls")
-
-	// Both steps should carry a MessageCache.
-	for i, call := range capture.calls {
-		_, ok := extractMessageCache(t, call)
-		require.True(t, ok, "step %d: cache should be present", i)
-	}
-
-	// The cache instance is the same object, but Clear() should
-	// have been called between steps. We verify indirectly: the
-	// cache is a *mapMessageCache and should have no stale entries
-	// from step 0 by the time step 1 completes (compaction
-	// replaced the message history).
-	mc, _ := extractMessageCache(t, capture.calls[0])
-	_ = mc // Cache was cleared; no stale entries survive.
 }
 
 // TestChatLoop_MessageCachePopulatedByProvider uses a real fantasy

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ChatModelAdminPanel.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ChatModelAdminPanel.stories.tsx
@@ -645,10 +645,10 @@ export const ProviderWithUserKeysOnly: Story = {
 		const body = within(canvasElement.ownerDocument.body);
 		await userEvent.click(await body.findByRole("button", { name: /Google/i }));
 		await expect(
-			body.getByRole("switch", { name: "Central API key" }),
+			await body.findByRole("switch", { name: "Central API key" }),
 		).not.toBeChecked();
 		await expect(
-			body.getByRole("switch", { name: "Allow user API keys" }),
+			await body.findByRole("switch", { name: "Allow user API keys" }),
 		).toBeChecked();
 		expect(body.queryByLabelText(/^API Key$/i)).not.toBeInTheDocument();
 		expect(


### PR DESCRIPTION
Each agentic loop step serializes the entire accumulated message history via the Anthropic SDK's recursive `MarshalJSON`. Step N serializes messages 1..N → total work is O(N²). Pprof showed 2+ GB in `bytes.growSlice` from this path.

This adds a per-run `MessageCache` that stores serialized `MessageParam` JSON bytes keyed by output index. The cache is passed to the fantasy Anthropic provider via `ProviderOptions`, where `applySerialisationCache` short-circuits `MarshalJSON` via `param.SetJSON` for previously-serialized messages.

- Messages with prompt caching breakpoints (last 2 + system) are excluded since their `cache_control` annotation changes every step
- Cache is cleared on compaction
- Cache is scoped to a single `Run()` invocation — no cross-replica or cross-run concerns
- Non-Anthropic providers are unaffected

**Depends on**: companion PR to [coder/fantasy](https://github.com/coder/fantasy) that adds `MessageSerializationCache` interface to the Anthropic provider and wires `toPrompt` to use it. Changes staged at `/home/coder/fantasy-local`.

<details><summary>Implementation notes</summary>

- `messagecache.go`: `MessageCache` interface, `mapMessageCache` concrete impl, `cloneProviderOptionsWithCache` helper
- `chatloop.go`: cache creation before step loop, injection into `ProviderOptions` per step, `Clear()` on both inline and post-run compaction paths
- Fantasy side: `provider_options.go` adds `MessageSerializationCache` interface + `GetMessageCache()`; `anthropic.go` extracts cache in `prepareParams`, passes to `toPrompt`, new `applySerialisationCache()` function handles hit/miss/skip logic per output `MessageParam`
- The `param.SetJSON` mechanism in the Anthropic SDK stores `json.RawMessage` bytes via `setMetadata`, causing `MarshalJSON` → `MarshalWithExtras` → `Overrides()` to short-circuit and return the cached bytes verbatim (the fork's `marshalerEncoder` skips `appendCompact`)

</details>

> 🤖