### PR TITLE
fix: move OnChatUpdated call after agent is ready in create/start workspace

### DIFF
--- a/coderd/x/chatd/chattool/createworkspace.go
+++ b/coderd/x/chatd/chattool/createworkspace.go
@@ -251,14 +251,6 @@ func CreateWorkspace(organizationID uuid.UUID, db database.Store, options Create
 				}
 			}
 
-			// The agent is now online — re-fire so callers can
-			// load instruction files from the running agent.
-			if options.OnChatUpdated != nil {
-				if latest, err := db.GetChatByID(ctx, options.ChatID); err == nil {
-					options.OnChatUpdated(latest)
-				}
-			}
-
 			result := map[string]any{
 				"created":        true,
 				"workspace_name": workspace.FullName(),
@@ -288,6 +280,19 @@ func CreateWorkspace(organizationID uuid.UUID, db database.Store, options Create
 				agentStatus := waitForAgentReady(ctx, db, workspaceAgentID, options.AgentConnFn)
 				for k, v := range agentStatus {
 					result[k] = v
+				}
+			}
+
+			// Re-fire after the agent is fully ready so callers
+			// can load instruction files (AGENTS.md) from the
+			// running agent. This must happen after
+			// waitForAgentReady — firing earlier (e.g. right
+			// after waitForBuild) races with the agent startup
+			// and the connection usually times out before the
+			// agent is reachable.
+			if options.OnChatUpdated != nil {
+				if latest, err := db.GetChatByID(ctx, options.ChatID); err == nil {
+					options.OnChatUpdated(latest)
 				}
 			}
 

--- a/coderd/x/chatd/chattool/startworkspace.go
+++ b/coderd/x/chatd/chattool/startworkspace.go
@@ -134,14 +134,17 @@ func StartWorkspace(options StartWorkspaceOptions) fantasy.AgentTool {
 						build.ID,
 					)), nil
 				}
-				// The agent is now online — re-fire so callers can
-				// load instruction files from the running agent.
+				resp, respErr := waitForAgentAndRespond(ctx, options.DB, options.AgentConnFn, ws, build.ID)
+				// Re-fire after the agent is fully ready so
+				// callers can load instruction files (AGENTS.md).
+				// This must happen after waitForAgentAndRespond —
+				// firing earlier races with agent startup.
 				if options.OnChatUpdated != nil {
 					if latest, err := options.DB.GetChatByID(ctx, options.ChatID); err == nil {
 						options.OnChatUpdated(latest)
 					}
 				}
-				return waitForAgentAndRespond(ctx, options.DB, options.AgentConnFn, ws, build.ID)
+				return resp, respErr
 			case database.ProvisionerJobStatusSucceeded:
 				// If the latest successful build is a start
 				// transition, the workspace should be running.
@@ -197,15 +200,17 @@ func StartWorkspace(options StartWorkspaceOptions) fantasy.AgentTool {
 				)), nil
 			}
 
-			// The agent is now online — re-fire so callers can
-			// load instruction files from the running agent.
+			resp, respErr := waitForAgentAndRespond(ctx, options.DB, options.AgentConnFn, ws, startBuild.ID)
+			// Re-fire after the agent is fully ready so
+			// callers can load instruction files (AGENTS.md).
+			// This must happen after waitForAgentAndRespond —
+			// firing earlier races with agent startup.
 			if options.OnChatUpdated != nil {
 				if latest, err := options.DB.GetChatByID(ctx, options.ChatID); err == nil {
 					options.OnChatUpdated(latest)
 				}
 			}
-
-			return waitForAgentAndRespond(ctx, options.DB, options.AgentConnFn, ws, startBuild.ID)
+			return resp, respErr
 		})
 }
 


### PR DESCRIPTION
## Problem

The `OnChatUpdated` callback — which triggers AGENTS.md injection via `persistInstructionFiles` — was firing after `waitForBuild` completed but **before** the workspace agent was fully ready. At that point the agent process has not connected to coderd yet, so the 5-second connection timeout in `fetchWorkspaceContext` would fail. The `instruction` variable stays empty and AGENTS.md is never injected into the prompt for the remainder of the turn.

This affects both `create_workspace` (new workspace from scratch) and `start_workspace` (restarting a stopped workspace).

## Root Cause

The sequence was:
1. `waitForBuild` — polls until Terraform provisioning succeeds
2. `OnChatUpdated` → `persistInstructionFiles` → tries `getWorkspaceConn` → **times out** (agent not connected yet)
3. `waitForAgentReady` — waits for agent to connect and startup scripts to finish
4. Tool returns — **no retry** of `OnChatUpdated`

Step 2 races with agent startup. The `homeInstructionLookupTimeout` is only 5 seconds, which is not enough time for the agent to boot, download the coder binary, and establish a DRPC connection.

## Fix

Move the `OnChatUpdated` call from after `waitForBuild` to after the agent is fully ready:
- `create_workspace`: after `waitForAgentReady`
- `start_workspace`: after `waitForAgentAndRespond` (both the in-progress-build path and the fresh-start path)

The earlier `OnChatUpdated` call (after `UpdateChatWorkspaceBinding`) is preserved — it is needed for the frontend to start streaming build logs.

> 🤖 Generated with [Coder Agents](https://coder.com/agents)