### PR TITLE
fix: fix `image_type` options

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -121,20 +121,32 @@ data "coder_parameter" "repo_base_dir" {
   mutable     = true
 }
 
+locals {
+  image_tags = {
+    // Older style option values, where the option value was just supposed to
+    // be the exact name of the image on Docker hub. In practice, this is rather
+    // restrictive because the image_type parameter is immutable.
+    "codercom/oss-dogfood:latest"     = "codercom/oss-dogfood:latest"
+    "codercom/oss-dogfood-nix:latest" = "codercom/oss-dogfood-nix:latest"
+
+    "ubuntu-latest" = "codercom/oss-dogfood:26.04"
+  }
+}
+
 data "coder_parameter" "image_type" {
   type        = "string"
   name        = "Coder Image"
-  default     = "codercom/oss-dogfood:26.04"
+  default     = "ubuntu-latest"
   description = "The Docker image used to run your workspace."
   option {
     icon  = "/icon/coder.svg"
     name  = "Ubuntu 26.04"
-    value = "codercom/oss-dogfood:26.04"
+    value = "ubuntu-latest"
   }
   option {
     icon  = "/icon/coder.svg"
-    name  = "Ubuntu 22.04"
-    value = "codercom/oss-dogfood:22.04"
+    name  = "Ubuntu 22.04 (Legacy)"
+    value = "codercom/oss-dogfood:latest"
   }
   option {
     icon  = "/icon/nix.svg"
@@ -767,11 +779,11 @@ resource "docker_volume" "docker_volume" {
 }
 
 data "docker_registry_image" "dogfood" {
-  name = data.coder_parameter.image_type.value
+  name = local.image_tags[data.coder_parameter.image_type.value]
 }
 
 resource "docker_image" "dogfood" {
-  name = "${data.coder_parameter.image_type.value}@${data.docker_registry_image.dogfood.sha256_digest}"
+  name = "${local.image_tags[data.coder_parameter.image_type.value]}@${data.docker_registry_image.dogfood.sha256_digest}"
   pull_triggers = [
     data.docker_registry_image.dogfood.sha256_digest,
     sha1(join("", [for f in fileset(path.module, "files/*") : filesha1(f)])),

--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -136,7 +136,7 @@ locals {
 data "coder_parameter" "image_type" {
   type        = "string"
   name        = "Coder Image"
-  default     = "ubuntu-latest"
+  default     = "codercom/oss-dogfood:latest"
   description = "The Docker image used to run your workspace."
   option {
     icon  = "/icon/coder.svg"


### PR DESCRIPTION
Renaming the `image_type` value broke updating existing workspaces because `image_type` is immutable, which I forgot and didn't get caught in code review. I figured people would just be able to pick whether they wanted to test the new version or stick with the stable version when they updated.

So, we're leaving the current value everyone uses as Ubuntu 22.04 since they would not actually be able to roll back. We're also switching back to 22.04 as the default since the new image seems to have some issues from a bit of testing.