### PR TITLE
fix(site): truncate long workspace name in chat input toolbar

### DIFF
--- a/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useEffect, useRef } from "react";
 import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import type * as TypesGen from "#/api/typesGenerated";
+import { MockWorkspace, MockWorkspaceAgent } from "#/testHelpers/entities";
 import {
 	AgentChatInput,
 	type AgentContextUsage,
@@ -726,5 +727,43 @@ export const ContextNearLimit: Story = {
 				},
 			] as TypesGen.ChatMessagePart[],
 		},
+	},
+};
+
+/** Long workspace name at iPhone SE width — verifies truncation. */
+export const LongWorkspaceNameMobile: Story = {
+	args: {
+		...mcpDefaults,
+		mcpServers: [githubMCPConnected],
+		selectedMCPServerIds: [githubMCPConnected.id],
+		workspace: {
+			...MockWorkspace,
+			name: "my-super-extremely-long-workspace-name-that-overflows",
+		},
+		workspaceAgent: MockWorkspaceAgent,
+		chatId: "test-chat-id",
+	},
+	parameters: {
+		viewport: { defaultViewport: "mobile1" },
+		chromatic: { viewports: [375] },
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		// The workspace pill button should be present.
+		const pill = await canvas.findByRole("button", {
+			name: /workspace menu/,
+		});
+		await waitFor(() => {
+			expect(pill).toBeVisible();
+		});
+		// The toolbar row should not cause horizontal overflow.
+		const toolbar = pill.closest(
+			".flex.items-center.justify-between",
+		) as HTMLElement;
+		if (toolbar?.parentElement) {
+			expect(toolbar.scrollWidth).toBeLessThanOrEqual(
+				toolbar.parentElement.clientWidth,
+			);
+		}
 	},
 };

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -193,7 +193,7 @@ const ToolBadge: FC<{
 						)}
 					>
 						{badge.statusIcon}
-						{badge.name}
+						<span className="truncate">{badge.name}</span>
 					</Link>
 				</TooltipTrigger>
 				<TooltipContent>{badge.statusLabel}</TooltipContent>
@@ -205,7 +205,7 @@ const ToolBadge: FC<{
 		return (
 			<span className={badgeCls}>
 				<MonitorIcon className="size-3" />
-				{badge.name}
+				<span className="truncate">{badge.name}</span>
 				{onRemoveWorkspace && (
 					<button
 						type="button"

--- a/site/src/pages/AgentsPage/components/WorkspacePill.tsx
+++ b/site/src/pages/AgentsPage/components/WorkspacePill.tsx
@@ -92,17 +92,18 @@ export const WorkspacePill: FC<WorkspacePillProps> = ({
 							type="button"
 							aria-label={`${workspace.name} workspace menu`}
 							className={cn(
-								"inline-flex shrink-0 items-center gap-1 rounded-full bg-surface-secondary px-2 py-0.5 text-xs font-medium text-content-secondary",
+								"inline-flex min-w-0 max-w-[200px] items-center gap-1 rounded-full bg-surface-secondary px-2 py-0.5 text-xs font-medium text-content-secondary",
 								"cursor-pointer border-0 transition-colors hover:bg-surface-tertiary hover:text-content-primary",
 							)}
 						>
-							<StatusIcon type={effectiveType} /> {workspace.name}
+							<StatusIcon type={effectiveType} />
+							<span className="truncate">{workspace.name}</span>
 							{/* The menu opens upward (side="top"), so the chevron
 							   points away from the menu when closed (default) and
 							   toward it when open (rotate-180). */}
 							<ChevronDownIcon
 								className={cn(
-									"size-3 opacity-60 transition-transform",
+									"size-3 shrink-0 opacity-60 transition-transform",
 									open && "rotate-180",
 								)}
 							/>


### PR DESCRIPTION
On narrow viewports (iPhone), a long workspace name in the agents chat input toolbar caused horizontal overflow. The `WorkspacePill` button used `shrink-0` which prevented it from shrinking, and the workspace name had no truncation.

## Changes

**`WorkspacePill.tsx`** — the main fix:
- Replace `shrink-0` with `min-w-0 max-w-[200px]` so the pill can shrink in its flex container and is capped at a reasonable max width.
- Wrap `{workspace.name}` in `<span className="truncate">` so long names show an ellipsis.
- Add `shrink-0` to `ChevronDownIcon` so it always stays visible.

**`AgentChatInput.tsx`** — consistency for `ToolBadge`:
- Wrap `{badge.name}` in `<span className="truncate">` for `attached-workspace` and `workspace` badge kinds.

**`AgentChatInput.stories.tsx`** — regression story:
- Add `LongWorkspaceNameMobile` story at iPhone SE (375px) viewport with a very long workspace name + connected GitHub MCP server. Play function asserts the pill is visible and the toolbar doesn't overflow.

<details>
<summary>Visually verified in Storybook</summary>

- **LongWorkspaceNameMobile**: Name truncates with ellipsis, no overflow, chevron visible.
- **OverflowBadges**: +N pill still works correctly alongside the truncated workspace pill.
- **WithMCPServers**: No visual regression.
</details>

> 🤖 Generated by Coder Agents