### PR TITLE
fix(coderd/x/chatd): hoist system prompt fetch out of chat creation transaction (#24369)

### DIFF
--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -869,6 +869,10 @@ func (p *Server) CreateChat(ctx context.Context, opts CreateOptions) (database.C
 	if opts.Labels == nil {
 		opts.Labels = database.StringMap{}
 	}
+	// Resolve the deployment prompt before opening the transaction so
+	// chat creation does not hold one DB connection while waiting for
+	// another pool checkout.
+	deploymentPrompt := p.resolveDeploymentSystemPrompt(ctx)
 
 	var chat database.Chat
 	txErr := p.db.InTx(func(tx database.Store) error {
@@ -904,7 +908,6 @@ func (p *Server) CreateChat(ctx context.Context, opts CreateOptions) (database.C
 			return xerrors.Errorf("insert chat: %w", err)
 		}
 
-		deploymentPrompt := p.resolveDeploymentSystemPrompt(ctx)
 		userPrompt := SanitizePromptText(opts.SystemPrompt)
 		var workspaceAwareness string
 		if opts.WorkspaceID.Valid {


### PR DESCRIPTION
Partial backport of #24369 to `release/2.32`.

Only the `CreateChat` fix in `coderd/x/chatd/chatd.go` applies here — the second call site in `subagent.go` (`createChildSubagentChatWithOptions`) doesn't exist on this branch since the child-subagent-chat creation path was added after the branch cut. 

The fix hoists the `resolveDeploymentSystemPrompt` call out of the `InTx` closure so the transaction doesn't hold one DB connection while the helper tries to check out another via `p.db`. Under concurrent chat creation load this pattern can cause pool starvation.

This is not urgent enough to warrant an immediate patch release — the bug only manifests under high concurrent chat creation load. It should be fine to ride along with the next scheduled 2.32.x patch.
