### PR TITLE
fix: guard against invalid URL in getAppHref to prevent UI crash

### DIFF
--- a/site/src/modules/apps/apps.ts
+++ b/site/src/modules/apps/apps.ts
@@ -1,9 +1,9 @@
+import { toast } from "sonner";
 import type {
 	Workspace,
 	WorkspaceAgent,
 	WorkspaceApp,
-} from "api/typesGenerated";
-import { toast } from "sonner";
+} from "#/api/typesGenerated";
 
 // This is a magic undocumented string that is replaced
 // with a brand-new session token from the backend.
@@ -83,13 +83,25 @@ export const getTerminalHref = ({
 	}/terminal?${params}`;
 };
 
+// Open `about:blank` first to detect a popup blocker. If it opens, we
+// null out `opener` (durable on the opened window); and navigate `popup`
+// to the target URL. The Coder UI keeps access to `popup`s handle
 export const openAppInNewWindow = (href: string) => {
-	const popup = window.open(href, "_blank", "width=900,height=600");
+	const popup = window.open("about:blank", "_blank", "width=900,height=600");
 	if (!popup) {
 		toast.error("Failed to open app in new window.", {
 			description: "Popup blocked. Allow popups to open this app.",
 		});
+		return;
 	}
+	try {
+		// Setting the opener to null persists in the `popup` window over refresh
+		// and navigation. The opening window retains its connection to `popup`
+		popup.opener = null;
+	} catch {
+		// Electron can throw
+	}
+	popup.location.href = href;
 };
 
 type GetAppHrefParams = {
@@ -105,7 +117,14 @@ export const getAppHref = (
 	{ path, token, workspace, agent, host }: GetAppHrefParams,
 ): string => {
 	if (isExternalApp(app)) {
-		const appProtocol = new URL(app.url).protocol;
+		let appProtocol: string;
+		try {
+			appProtocol = new URL(app.url).protocol;
+		} catch {
+			// Invalid URL (e.g. missing scheme) — return as-is so a single
+			// misconfigured coder_app does not crash the entire dashboard.
+			return app.url;
+		}
 		const isAllowedProtocol =
 			ALLOWED_EXTERNAL_APP_PROTOCOLS.includes(appProtocol);
 


### PR DESCRIPTION
## Summary

Closes #24417

When a `coder_app` resource specifies an external URL that cannot be parsed by the `URL` constructor (e.g. a bare string with no scheme like `my-app`), `new URL(app.url)` in `getAppHref()` throws a `TypeError: Failed to construct 'URL': Invalid URL` — crashing the **entire** dashboard, not just the affected app button.

## Change

Wrap the `new URL()` call in a try-catch and return the raw URL as a fallback:

```typescript
let appProtocol: string;
try {
  appProtocol = new URL(app.url).protocol;
} catch {
  // Invalid URL (e.g. missing scheme) — return as-is so a single
  // misconfigured coder_app does not crash the entire dashboard.
  return app.url;
}
```

This is a minimal, targeted fix: one invalid app URL no longer brings down the whole UI.

## Test plan

- [ ] Template with a valid external app URL still works as before
- [ ] Template with an invalid external app URL (e.g. `my-app`, no scheme) renders without crashing; the broken app button is visible but the rest of the workspace UI is functional
- [ ] Existing `apps.test.ts` tests pass