### PR TITLE
fix(site): allow search by label in MultiSelectComboBox

### DIFF
--- a/site/src/components/MultiSelectCombobox/MultiSelectCombobox.stories.tsx
+++ b/site/src/components/MultiSelectCombobox/MultiSelectCombobox.stories.tsx
@@ -31,11 +31,43 @@ export const Default: Story = {};
 export const OpenCombobox: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await userEvent.click(canvas.getByPlaceholderText("Select organization"));
+		const input = canvas.getByPlaceholderText("Select organization");
+		await userEvent.click(input);
 
-		await waitFor(() =>
-			expect(canvas.getByText("My Organization")).toBeInTheDocument(),
-		);
+		// Both options should be visible initially.
+		await waitFor(() => {
+			expect(
+				canvas.getByRole("option", { name: "My Organization" }),
+			).toBeInTheDocument();
+			expect(
+				canvas.getByRole("option", { name: "My Organization 2" }),
+			).toBeInTheDocument();
+		});
+
+		// Type a display name to filter — this verifies cmdk filters
+		// by label rather than by the underlying UUID value.
+		await userEvent.type(input, "My Organization 2");
+
+		await waitFor(() => {
+			expect(
+				canvas.getByRole("option", { name: "My Organization 2" }),
+			).toBeInTheDocument();
+			expect(
+				canvas.queryByRole("option", { name: /^My Organization$/ }),
+			).not.toBeInTheDocument();
+		});
+
+		// Clear the search and confirm both options reappear.
+		await userEvent.clear(input);
+
+		await waitFor(() => {
+			expect(
+				canvas.getByRole("option", { name: "My Organization" }),
+			).toBeInTheDocument();
+			expect(
+				canvas.getByRole("option", { name: "My Organization 2" }),
+			).toBeInTheDocument();
+		});
 	},
 };
 

--- a/site/src/components/MultiSelectCombobox/MultiSelectCombobox.tsx
+++ b/site/src/components/MultiSelectCombobox/MultiSelectCombobox.tsx
@@ -642,6 +642,7 @@ export const MultiSelectCombobox: React.FC<MultiSelectComboboxProps> = ({
 													<CommandItem
 														key={option.value}
 														value={option.value}
+														keywords={[option.label]}
 														disabled={option.disable}
 														onMouseDown={(e) => {
 															e.preventDefault();

--- a/site/src/pages/AgentsPage/AgentSettingsTemplatesPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsTemplatesPageView.stories.tsx
@@ -60,6 +60,37 @@ export const TemplateAllowlist: Story = {
 			expect(saveBtn).toBeDisabled();
 		});
 
+		await step("search filters by display name", async () => {
+			const input = canvas.getByPlaceholderText("Select templates...");
+			await userEvent.click(input);
+
+			// Type a partial display name.
+			await userEvent.type(input, "Docker");
+
+			// The matching template should be visible.
+			await waitFor(() => {
+				expect(
+					canvas.getByRole("option", { name: "Docker Development" }),
+				).toBeVisible();
+			});
+
+			// A non-matching template should not be visible.
+			expect(
+				canvas.queryByRole("option", { name: "Kubernetes Production" }),
+			).not.toBeInTheDocument();
+
+			// Clear the search and verify the full list returns.
+			await userEvent.clear(input);
+			await waitFor(() => {
+				expect(
+					canvas.getByRole("option", { name: "Kubernetes Production" }),
+				).toBeVisible();
+			});
+
+			// Close dropdown by pressing Escape so the next step starts clean.
+			await userEvent.keyboard("{Escape}");
+		});
+
 		await step("select one template and save", async () => {
 			const input = canvas.getByPlaceholderText("Select templates...");
 			await userEvent.click(input);

--- a/site/src/pages/AgentsPage/AgentSettingsTemplatesPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsTemplatesPageView.stories.tsx
@@ -75,9 +75,11 @@ export const TemplateAllowlist: Story = {
 			});
 
 			// A non-matching template should not be visible.
-			expect(
-				canvas.queryByRole("option", { name: "Kubernetes Production" }),
-			).not.toBeInTheDocument();
+			await waitFor(() => {
+				expect(
+					canvas.queryByRole("option", { name: "Kubernetes Production" }),
+				).not.toBeInTheDocument();
+			});
 
 			// Clear the search and verify the full list returns.
 			await userEvent.clear(input);


### PR DESCRIPTION
Fixes https://linear.app/codercom/issue/CODAGT-103

- Add `keywords={[option.label]}` to `CommandItem` in `MultiSelectCombobox` so cmdk's default filter matches against the visible label text, not just the value (UUID)
- Extend `OpenCombobox` story with type-to-filter assertions
- Add "search filters by display name" step to `TemplateAllowlist` story

<details>
<summary>Root cause & decision log</summary>

`cmdk`'s default filter matches `CommandItem`'s `value` prop. `MultiSelectCombobox` was passing `option.value` (a UUID/ID) as `value` while rendering `option.label` (the display name) as children. Users type display names but the filter searched UUIDs — nothing ever matched.

`cmdk` supports a `keywords` prop on `CommandItem` that the built-in filter also searches. Adding `keywords={[option.label]}` is the minimal fix: it doesn't change the `value` identity semantics (used by `onSelect`), requires zero consumer changes, and fixes the same latent bug in `IdpGroupSyncForm`, `IdpOrgSyncPageView`, and `IdpRoleSyncForm`.
</details>

> 🤖