### PR TITLE
fix: avoid VT input mode for secret input on Windows

### DIFF
--- a/cli/cliui/prompt.go
+++ b/cli/cliui/prompt.go
@@ -269,9 +269,10 @@ func readSecretRunes(reader *bufio.Reader, w io.Writer) (string, error) {
 			}
 			switch next {
 			case '[':
-				// CSI sequence: ESC [ <params> <final_byte>.
-				// Parameters are bytes in 0x20-0x3F; the final
-				// byte is in the 0x40-0x7E range.
+				// CSI sequence: ESC [ <params> <intermediates> <final_byte>.
+				// Parameter bytes are 0x30-0x3F, intermediate bytes
+				// are 0x20-0x2F, and the final byte is 0x40-0x7E.
+				// We simply scan until the final byte.
 				for {
 					c, _, err := reader.ReadRune()
 					if err != nil {

--- a/cli/cliui/prompt.go
+++ b/cli/cliui/prompt.go
@@ -211,7 +211,7 @@ func readUntil(r io.Reader, delim byte) (string, error) {
 // masking each character with an asterisk.
 func readSecretInput(f *os.File, w io.Writer) (string, error) {
 	// Put terminal into raw mode (no echo, no line buffering).
-	oldState, err := pty.MakeInputRaw(f.Fd())
+	oldState, err := pty.MakeInputRawNoVT(f.Fd())
 	if err != nil {
 		return "", err
 	}
@@ -219,7 +219,15 @@ func readSecretInput(f *os.File, w io.Writer) (string, error) {
 		_ = pty.RestoreTerminal(f.Fd(), oldState)
 	}()
 
-	reader := bufio.NewReader(f)
+	return readSecretRunes(bufio.NewReader(f), w)
+}
+
+// readSecretRunes reads runes one at a time from reader, writing a
+// '*' to w for every printable character. It handles Enter (finish),
+// Ctrl+C (cancel), Backspace (erase), and ANSI escape sequences
+// (discard). The caller is responsible for putting the terminal into
+// raw mode before calling this function.
+func readSecretRunes(reader *bufio.Reader, w io.Writer) (string, error) {
 	var runes []rune
 
 	for {
@@ -248,6 +256,42 @@ func readSecretInput(f *os.File, w io.Writer) (string, error) {
 					return "", err
 				}
 				runes = runes[:len(runes)-1]
+			}
+
+		case r == '\x1b':
+			// ESC starts an ANSI escape sequence (e.g. bracketed-
+			// paste markers ESC[200~ / ESC[201~, cursor keys, or
+			// function keys). Consume and discard the full sequence
+			// so it does not pollute the secret input.
+			next, _, err := reader.ReadRune()
+			if err != nil {
+				return "", err
+			}
+			switch next {
+			case '[':
+				// CSI sequence: ESC [ <params> <final_byte>.
+				// Parameters are bytes in 0x20-0x3F; the final
+				// byte is in the 0x40-0x7E range.
+				for {
+					c, _, err := reader.ReadRune()
+					if err != nil {
+						return "", err
+					}
+					if c >= 0x40 && c <= 0x7E {
+						break
+					}
+				}
+			case 'O':
+				// SS3 / application-mode sequence: ESC O <final>.
+				// Consume the final byte so function/cursor key
+				// sequences do not leak into the input.
+				if _, _, err := reader.ReadRune(); err != nil {
+					return "", err
+				}
+			default:
+				// Unrecognized sequence — put the character back
+				// so it isn't silently swallowed.
+				_ = reader.UnreadRune()
 			}
 
 		default:

--- a/cli/cliui/prompt_internal_test.go
+++ b/cli/cliui/prompt_internal_test.go
@@ -1,0 +1,214 @@
+package cliui
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadSecretRunes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("PlainInput", func(t *testing.T) {
+		t.Parallel()
+		input := "hello\r"
+		reader := bufio.NewReader(strings.NewReader(input))
+		var out bytes.Buffer
+
+		result, err := readSecretRunes(reader, &out)
+		require.NoError(t, err)
+		assert.Equal(t, "hello", result)
+		assert.Equal(t, "*****\r\n", out.String())
+	})
+
+	t.Run("BracketedPaste", func(t *testing.T) {
+		t.Parallel()
+		// Simulates: ESC[200~ token123 ESC[201~ Enter
+		input := "\x1b[200~token123\x1b[201~\r"
+		reader := bufio.NewReader(strings.NewReader(input))
+		var out bytes.Buffer
+
+		result, err := readSecretRunes(reader, &out)
+		require.NoError(t, err)
+		assert.Equal(t, "token123", result)
+		assert.Equal(t, "********\r\n", out.String())
+	})
+
+	t.Run("ArrowKeysIgnored", func(t *testing.T) {
+		t.Parallel()
+		// Type "ab", press Up arrow (ESC[A), type "cd", Enter.
+		input := "ab\x1b[Acd\r"
+		reader := bufio.NewReader(strings.NewReader(input))
+		var out bytes.Buffer
+
+		result, err := readSecretRunes(reader, &out)
+		require.NoError(t, err)
+		assert.Equal(t, "abcd", result)
+		assert.Equal(t, "****\r\n", out.String())
+	})
+
+	t.Run("FunctionKeyIgnored", func(t *testing.T) {
+		t.Parallel()
+		// Type "x", press F5 (ESC[15~), type "y", Enter.
+		input := "x\x1b[15~y\r"
+		reader := bufio.NewReader(strings.NewReader(input))
+		var out bytes.Buffer
+
+		result, err := readSecretRunes(reader, &out)
+		require.NoError(t, err)
+		assert.Equal(t, "xy", result)
+		assert.Equal(t, "**\r\n", out.String())
+	})
+
+	t.Run("EscOSequenceIgnored", func(t *testing.T) {
+		t.Parallel()
+		// ESC O P (F1 in application-mode) between typed chars.
+		input := "a\x1bOPb\r"
+		reader := bufio.NewReader(strings.NewReader(input))
+		var out bytes.Buffer
+
+		result, err := readSecretRunes(reader, &out)
+		require.NoError(t, err)
+		// The full SS3 sequence (ESC O P) should be discarded.
+		assert.Equal(t, "ab", result)
+		assert.Equal(t, "**\r\n", out.String())
+	})
+
+	t.Run("Backspace", func(t *testing.T) {
+		t.Parallel()
+		// Type "abc", backspace, type "d", Enter.
+		input := "abc\x7fd\r"
+		reader := bufio.NewReader(strings.NewReader(input))
+		var out bytes.Buffer
+
+		result, err := readSecretRunes(reader, &out)
+		require.NoError(t, err)
+		assert.Equal(t, "abd", result)
+	})
+
+	t.Run("BackspaceBS", func(t *testing.T) {
+		t.Parallel()
+		// Same but with \b (0x08) instead of DEL (0x7F).
+		input := "abc\bd\r"
+		reader := bufio.NewReader(strings.NewReader(input))
+		var out bytes.Buffer
+
+		result, err := readSecretRunes(reader, &out)
+		require.NoError(t, err)
+		assert.Equal(t, "abd", result)
+	})
+
+	t.Run("CtrlC", func(t *testing.T) {
+		t.Parallel()
+		input := "abc\x03"
+		reader := bufio.NewReader(strings.NewReader(input))
+		var out bytes.Buffer
+
+		_, err := readSecretRunes(reader, &out)
+		assert.ErrorIs(t, err, ErrCanceled)
+	})
+
+	t.Run("UTF8", func(t *testing.T) {
+		t.Parallel()
+		input := "和製漢字\r"
+		reader := bufio.NewReader(strings.NewReader(input))
+		var out bytes.Buffer
+
+		result, err := readSecretRunes(reader, &out)
+		require.NoError(t, err)
+		assert.Equal(t, "和製漢字", result)
+		assert.Equal(t, "****\r\n", out.String())
+	})
+
+	t.Run("NewlineTerminator", func(t *testing.T) {
+		t.Parallel()
+		input := "test\n"
+		reader := bufio.NewReader(strings.NewReader(input))
+		var out bytes.Buffer
+
+		result, err := readSecretRunes(reader, &out)
+		require.NoError(t, err)
+		assert.Equal(t, "test", result)
+	})
+
+	t.Run("ControlCharsIgnored", func(t *testing.T) {
+		t.Parallel()
+		// Tab (0x09) and other control chars should be silently
+		// dropped without being appended to the result.
+		input := "a\tb\x01c\r"
+		reader := bufio.NewReader(strings.NewReader(input))
+		var out bytes.Buffer
+
+		result, err := readSecretRunes(reader, &out)
+		require.NoError(t, err)
+		assert.Equal(t, "abc", result)
+		assert.Equal(t, "***\r\n", out.String())
+	})
+
+	t.Run("EmptyInput", func(t *testing.T) {
+		t.Parallel()
+		input := "\r"
+		reader := bufio.NewReader(strings.NewReader(input))
+		var out bytes.Buffer
+
+		result, err := readSecretRunes(reader, &out)
+		require.NoError(t, err)
+		assert.Equal(t, "", result)
+	})
+
+	t.Run("EOF", func(t *testing.T) {
+		t.Parallel()
+		// EOF without a newline should return an error.
+		input := "abc"
+		reader := bufio.NewReader(strings.NewReader(input))
+		var out bytes.Buffer
+
+		_, err := readSecretRunes(reader, &out)
+		assert.ErrorIs(t, err, io.EOF)
+	})
+
+	t.Run("MultipleBracketedPastes", func(t *testing.T) {
+		t.Parallel()
+		// Two bracketed pastes back to back (unlikely but
+		// defensive).
+		input := "\x1b[200~abc\x1b[201~\x1b[200~def\x1b[201~\r"
+		reader := bufio.NewReader(strings.NewReader(input))
+		var out bytes.Buffer
+
+		result, err := readSecretRunes(reader, &out)
+		require.NoError(t, err)
+		assert.Equal(t, "abcdef", result)
+	})
+
+	t.Run("BareEsc", func(t *testing.T) {
+		t.Parallel()
+		// A bare ESC followed by a normal printable character
+		// (not '[' or 'O') should discard only the ESC and keep
+		// the following character.
+		input := "a\x1bxb\r"
+		reader := bufio.NewReader(strings.NewReader(input))
+		var out bytes.Buffer
+
+		result, err := readSecretRunes(reader, &out)
+		require.NoError(t, err)
+		assert.Equal(t, "axb", result)
+		assert.Equal(t, "***\r\n", out.String())
+	})
+
+	t.Run("BackspaceOnEmpty", func(t *testing.T) {
+		t.Parallel()
+		// Backspace when buffer is empty should be a no-op.
+		input := "\x7f\x7fabc\r"
+		reader := bufio.NewReader(strings.NewReader(input))
+		var out bytes.Buffer
+
+		result, err := readSecretRunes(reader, &out)
+		require.NoError(t, err)
+		assert.Equal(t, "abc", result)
+	})
+}

--- a/pty/terminal.go
+++ b/pty/terminal.go
@@ -14,6 +14,18 @@ func MakeInputRaw(fd uintptr) (*TerminalState, error) {
 	return makeInputRaw(fd)
 }
 
+// MakeInputRawNoVT puts the terminal into raw mode but, unlike
+// MakeInputRaw, does NOT enable VT input processing on Windows.
+// This avoids problems with pasted text being wrapped in ANSI
+// escape sequences (e.g. bracketed-paste markers) that would
+// corrupt password or token input. On non-Windows platforms the
+// behavior is identical to MakeInputRaw.
+//
+//nolint:revive
+func MakeInputRawNoVT(fd uintptr) (*TerminalState, error) {
+	return makeInputRawNoVT(fd)
+}
+
 // MakeOutputRaw does nothing on non-Windows platforms. On Windows it sets
 // special terminal modes that enable VT100 emulation as well as setting the
 // same modes that term.MakeRaw sets.

--- a/pty/terminal_other.go
+++ b/pty/terminal_other.go
@@ -19,6 +19,11 @@ func makeInputRaw(fd uintptr) (*TerminalState, error) {
 }
 
 //nolint:revive
+func makeInputRawNoVT(fd uintptr) (*TerminalState, error) {
+	return makeInputRaw(fd)
+}
+
+//nolint:revive
 func makeOutputRaw(_ uintptr) (*TerminalState, error) {
 	// Does nothing. makeInputRaw does enough for both input and output.
 	return &TerminalState{

--- a/pty/terminal_windows.go
+++ b/pty/terminal_windows.go
@@ -48,6 +48,29 @@ func makeInputRaw(handle uintptr) (*TerminalState, error) {
 }
 
 //nolint:revive
+func makeInputRawNoVT(handle uintptr) (*TerminalState, error) {
+	var prevState uint32
+	if err := windows.GetConsoleMode(windows.Handle(handle), &prevState); err != nil {
+		return nil, err
+	}
+
+	// Clear echo, line-input, processed-input, and VT-input flags
+	// so we get immediate, unechoed character input. We explicitly
+	// clear ENABLE_VIRTUAL_TERMINAL_INPUT even if the caller or a
+	// previous program already enabled it — that flag causes the
+	// console to deliver ANSI escape sequences (including
+	// bracketed-paste markers) which corrupt secret/password input.
+	raw := prevState &^ (windows.ENABLE_ECHO_INPUT | windows.ENABLE_PROCESSED_INPUT | windows.ENABLE_LINE_INPUT | windows.ENABLE_PROCESSED_OUTPUT | windows.ENABLE_VIRTUAL_TERMINAL_INPUT)
+
+	if err := windows.SetConsoleMode(windows.Handle(handle), raw); err != nil {
+		return nil, err
+	}
+	return &TerminalState{
+		state: terminalState(prevState),
+	}, nil
+}
+
+//nolint:revive
 func makeOutputRaw(handle uintptr) (*TerminalState, error) {
 	prevState, err := makeRaw(windows.Handle(handle), false)
 	if err != nil {

--- a/pty/terminal_windows.go
+++ b/pty/terminal_windows.go
@@ -60,7 +60,7 @@ func makeInputRawNoVT(handle uintptr) (*TerminalState, error) {
 	// previous program already enabled it — that flag causes the
 	// console to deliver ANSI escape sequences (including
 	// bracketed-paste markers) which corrupt secret/password input.
-	raw := prevState &^ (windows.ENABLE_ECHO_INPUT | windows.ENABLE_PROCESSED_INPUT | windows.ENABLE_LINE_INPUT | windows.ENABLE_PROCESSED_OUTPUT | windows.ENABLE_VIRTUAL_TERMINAL_INPUT)
+	raw := prevState &^ (windows.ENABLE_ECHO_INPUT | windows.ENABLE_PROCESSED_INPUT | windows.ENABLE_LINE_INPUT | windows.ENABLE_VIRTUAL_TERMINAL_INPUT)
 
 	if err := windows.SetConsoleMode(windows.Handle(handle), raw); err != nil {
 		return nil, err


### PR DESCRIPTION
## Problem

On Windows, `readSecretInput` calls `MakeInputRaw`, which enables `ENABLE_VIRTUAL_TERMINAL_INPUT` on the console input handle. This tells the console to deliver all input as VT/ANSI escape sequences.

When the terminal is in bracketed paste mode — common with PowerShell (PSReadLine emits `\e[?2004h`), bash ≥4.4, and zsh — pasting a token wraps it in `ESC[200~` / `ESC[201~` markers. `readSecretInput` drops the ESC bytes (control characters) but keeps `[200~` and `[201~` as printable characters, corrupting the token into `[200~REAL_TOKEN[201~`. The API rejects this every time.

## Fix

- Add `MakeInputRawNoVT` to the `pty` package: raw mode without `ENABLE_VIRTUAL_TERMINAL_INPUT`. On non-Windows this delegates to `MakeInputRaw` (no behavioral difference).
- `readSecretInput` now uses `MakeInputRawNoVT` instead of `MakeInputRaw`. Existing callers in `cli/ssh.go` and `cli/exp_rpty.go` still use `MakeInputRaw` — they need VT input for full interactive terminal sessions.
- Defense-in-depth: `readSecretRunes` now detects ESC and consumes the full ANSI escape sequence (CSI or two-char) so stray sequences are discarded on any platform.
- Extracted `readSecretRunes` from `readSecretInput` for testability; added 15 unit tests covering bracketed paste, arrow keys, function keys, backspace (both `\x7F` and `\b`), Ctrl+C, UTF-8, and edge cases.

> [!NOTE]
> This PR was authored by Coder Agents.

<details><summary>Implementation context</summary>

The root cause is the interaction between two independent flags:

1. **Terminal-level**: bracketed paste mode (`\e[?2004h`), enabled by the parent shell
2. **Console-level**: `ENABLE_VIRTUAL_TERMINAL_INPUT`, enabled by our `MakeInputRaw`

When both are active, the console passes bracketed paste escape sequences through to `ReadFile`. Password/token input does not need VT sequences (only printable chars, Enter, Backspace, Ctrl+C), so disabling VT input for this use case is the correct fix.

</details>