### PR TITLE
feat(site/src/pages/AgentsPage): show MCP settings and hide insights in sidebar

### DIFF
--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.stories.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.stories.tsx
@@ -166,20 +166,17 @@ export const CreateServer: Story = {
 		const nameInput = await body.findByLabelText(/Display Name/i);
 		await userEvent.type(nameInput, "Sentry");
 
-		// Collapsible sections start collapsed and the Enabled switch is
-		// edit-only. PencilIcon sits next to the editable name.
-		expect(
-			body.getByRole("button", { name: /Connection/i }),
-		).toBeInTheDocument();
-		expect(body.queryByLabelText(/^Slug$/i)).not.toBeInTheDocument();
+		// Required fields (slug, server URL) are always visible. Optional
+		// sections start collapsed and the Enabled switch is edit-only.
+		// PencilIcon sits next to the editable name.
+		expect(body.getByLabelText(/^Slug/i)).toBeInTheDocument();
+		expect(body.getByLabelText(/Server URL/i)).toBeInTheDocument();
+		expect(body.queryByLabelText(/Description/i)).not.toBeInTheDocument();
 		expect(
 			body.queryByRole("switch", { name: /Enabled/i }),
 		).not.toBeInTheDocument();
 		const nameRow = nameInput.closest("div")?.parentElement;
 		expect(nameRow?.querySelector("svg.lucide-pencil")).toBeTruthy();
-
-		// Expand Connection to reveal slug + server URL.
-		await userEvent.click(body.getByRole("button", { name: /Connection/i }));
 
 		// Slug should auto-populate from the display name.
 		await expect(body.getByLabelText(/^Slug/i)).toHaveValue("sentry");
@@ -220,7 +217,6 @@ export const CreateServerOAuth2: Story = {
 		);
 
 		await userEvent.type(await body.findByLabelText(/Display Name/i), "GitHub");
-		await userEvent.click(body.getByRole("button", { name: /Connection/i }));
 		await userEvent.type(
 			body.getByLabelText(/Server URL/i),
 			"https://api.githubcopilot.com/mcp/",
@@ -273,7 +269,6 @@ export const CreateServerAPIKey: Story = {
 		);
 
 		await userEvent.type(await body.findByLabelText(/Display Name/i), "Linear");
-		await userEvent.click(body.getByRole("button", { name: /Connection/i }));
 		await userEvent.type(
 			body.getByLabelText(/Server URL/i),
 			"https://mcp.linear.app/v1",
@@ -339,12 +334,14 @@ export const EditServer: Story = {
 		const nameInput = await body.findByLabelText(/Display Name/i);
 		expect(nameInput).toHaveValue("Sentry");
 
-		// Expand Connection to access slug, URL, and description.
-		await userEvent.click(body.getByRole("button", { name: /Connection/i }));
+		// Slug and Server URL are always visible.
 		expect(body.getByLabelText(/^Slug/i)).toHaveValue("sentry");
 		expect(body.getByLabelText(/Server URL/i)).toHaveValue(
 			"https://mcp.sentry.io/sse",
 		);
+
+		// Expand Details to reach the description field.
+		await userEvent.click(body.getByRole("button", { name: /Details/i }));
 
 		// Update the description.
 		const descField = body.getByLabelText(/Description/i);
@@ -595,7 +592,6 @@ export const CreateServerWithToolGovernance: Story = {
 			await body.findByLabelText(/Display Name/i),
 			"Restricted Server",
 		);
-		await userEvent.click(body.getByRole("button", { name: /Connection/i }));
 		await userEvent.type(
 			body.getByLabelText(/Server URL/i),
 			"https://mcp.example.com/v1",
@@ -641,7 +637,6 @@ export const CustomHeadersAuthType: Story = {
 			await body.findByLabelText(/Display Name/i),
 			"Custom API",
 		);
-		await userEvent.click(body.getByRole("button", { name: /Connection/i }));
 		await userEvent.type(
 			body.getByLabelText(/Server URL/i),
 			"https://mcp.example.com/v1",

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.stories.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.stories.tsx
@@ -8,16 +8,6 @@ import { MCPServerAdminPanel } from "./MCPServerAdminPanel";
 
 const now = "2026-03-19T12:00:00.000Z";
 
-// Expand a collapsible section in the form by its header label.
-// The section bodies start collapsed to mirror the Models panel, so stories
-// that interact with fields inside a section need to expand it first.
-const expandSection = async (
-	body: ReturnType<typeof within>,
-	name: RegExp | string,
-): Promise<void> => {
-	await userEvent.click(await body.findByRole("button", { name }));
-};
-
 const createServerConfig = (
 	overrides: Partial<TypesGen.MCPServerConfig> &
 		Pick<TypesGen.MCPServerConfig, "id" | "display_name" | "slug">,
@@ -91,21 +81,14 @@ export const EmptyState: Story = {
 		await expect(
 			await body.findByText(/No MCP servers configured yet/i),
 		).toBeInTheDocument();
-		await expect(
-			body.getAllByRole("button", { name: /Add Server/i })[0],
-		).toBeInTheDocument();
 
-		// Header action + empty-state CTA both render an Add button.
-		expect(body.getAllByRole("button", { name: /Add server/i })).toHaveLength(
-			2,
-		);
-		const emptyStateText = body.getByText(/No MCP servers configured yet/i);
-		const emptyStateContainer = emptyStateText.closest("div");
-		expect(emptyStateContainer).not.toBeNull();
+		// Both the section header and the empty state render a distinct
+		// Add button — the empty-state one is the primary CTA.
 		expect(
-			within(emptyStateContainer as HTMLElement).getByRole("button", {
-				name: /Add server/i,
-			}),
+			body.getByRole("button", { name: "Add server" }),
+		).toBeInTheDocument();
+		expect(
+			body.getByRole("button", { name: "Add your first server" }),
 		).toBeInTheDocument();
 	},
 };
@@ -176,7 +159,7 @@ export const CreateServer: Story = {
 
 		// Click Add Server.
 		await userEvent.click(
-			(await body.findAllByRole("button", { name: /Add server/i }))[0],
+			await body.findByRole("button", { name: /Add your first server/i }),
 		);
 
 		// Fill in the display name via the inline header input.
@@ -233,17 +216,19 @@ export const CreateServerOAuth2: Story = {
 		const body = within(canvasElement.ownerDocument.body);
 
 		await userEvent.click(
-			(await body.findAllByRole("button", { name: /Add server/i }))[0],
+			await body.findByRole("button", { name: /Add your first server/i }),
 		);
 
 		await userEvent.type(await body.findByLabelText(/Display Name/i), "GitHub");
-		await expandSection(body, /Connection/i);
+		await userEvent.click(body.getByRole("button", { name: /Connection/i }));
 		await userEvent.type(
 			body.getByLabelText(/Server URL/i),
 			"https://api.githubcopilot.com/mcp/",
 		);
 
-		await expandSection(body, /Authentication/i);
+		await userEvent.click(
+			body.getByRole("button", { name: /Authentication/i }),
+		);
 		// Select OAuth2 from the Radix Select dropdown.
 		await userEvent.click(body.getByLabelText(/Authentication/i));
 		await userEvent.click(await body.findByRole("option", { name: /OAuth2/i }));
@@ -284,17 +269,19 @@ export const CreateServerAPIKey: Story = {
 		const body = within(canvasElement.ownerDocument.body);
 
 		await userEvent.click(
-			(await body.findAllByRole("button", { name: /Add server/i }))[0],
+			await body.findByRole("button", { name: /Add your first server/i }),
 		);
 
 		await userEvent.type(await body.findByLabelText(/Display Name/i), "Linear");
-		await expandSection(body, /Connection/i);
+		await userEvent.click(body.getByRole("button", { name: /Connection/i }));
 		await userEvent.type(
 			body.getByLabelText(/Server URL/i),
 			"https://mcp.linear.app/v1",
 		);
 
-		await expandSection(body, /Authentication/i);
+		await userEvent.click(
+			body.getByRole("button", { name: /Authentication/i }),
+		);
 		// Select API Key from the Radix Select dropdown.
 		await userEvent.click(body.getByLabelText(/Authentication/i));
 		await userEvent.click(
@@ -353,7 +340,7 @@ export const EditServer: Story = {
 		expect(nameInput).toHaveValue("Sentry");
 
 		// Expand Connection to access slug, URL, and description.
-		await expandSection(body, /Connection/i);
+		await userEvent.click(body.getByRole("button", { name: /Connection/i }));
 		expect(body.getByLabelText(/^Slug/i)).toHaveValue("sentry");
 		expect(body.getByLabelText(/Server URL/i)).toHaveValue(
 			"https://mcp.sentry.io/sse",
@@ -404,7 +391,9 @@ export const EditServerWithOAuth2Secret: Story = {
 		await userEvent.click(await body.findByRole("button", { name: /GitHub/ }));
 
 		// Authentication section is collapsed by default.
-		await expandSection(body, /Authentication/i);
+		await userEvent.click(
+			body.getByRole("button", { name: /Authentication/i }),
+		);
 
 		// The OAuth2 fields should be visible.
 		const secretField = await body.findByLabelText(/Client Secret/i);
@@ -437,7 +426,9 @@ export const EditServerWithCustomHeaders: Story = {
 		);
 
 		// Authentication section is collapsed by default.
-		await expandSection(body, /Authentication/i);
+		await userEvent.click(
+			body.getByRole("button", { name: /Authentication/i }),
+		);
 
 		// Should show message about existing headers.
 		await expect(
@@ -573,7 +564,7 @@ export const BackToList: Story = {
 		const body = within(canvasElement.ownerDocument.body);
 
 		await userEvent.click(
-			(await body.findAllByRole("button", { name: /Add server/i }))[0],
+			await body.findByRole("button", { name: /^Add server$/i }),
 		);
 
 		// Click Back.
@@ -597,20 +588,20 @@ export const CreateServerWithToolGovernance: Story = {
 		const body = within(canvasElement.ownerDocument.body);
 
 		await userEvent.click(
-			(await body.findAllByRole("button", { name: /Add server/i }))[0],
+			await body.findByRole("button", { name: /Add your first server/i }),
 		);
 
 		await userEvent.type(
 			await body.findByLabelText(/Display Name/i),
 			"Restricted Server",
 		);
-		await expandSection(body, /Connection/i);
+		await userEvent.click(body.getByRole("button", { name: /Connection/i }));
 		await userEvent.type(
 			body.getByLabelText(/Server URL/i),
 			"https://mcp.example.com/v1",
 		);
 
-		await expandSection(body, /Behavior/i);
+		await userEvent.click(body.getByRole("button", { name: /Behavior/i }));
 		await userEvent.type(
 			body.getByLabelText(/Tool Allow List/i),
 			"search, read_file",
@@ -643,20 +634,22 @@ export const CustomHeadersAuthType: Story = {
 		const body = within(canvasElement.ownerDocument.body);
 
 		await userEvent.click(
-			(await body.findAllByRole("button", { name: /Add server/i }))[0],
+			await body.findByRole("button", { name: /Add your first server/i }),
 		);
 
 		await userEvent.type(
 			await body.findByLabelText(/Display Name/i),
 			"Custom API",
 		);
-		await expandSection(body, /Connection/i);
+		await userEvent.click(body.getByRole("button", { name: /Connection/i }));
 		await userEvent.type(
 			body.getByLabelText(/Server URL/i),
 			"https://mcp.example.com/v1",
 		);
 
-		await expandSection(body, /Authentication/i);
+		await userEvent.click(
+			body.getByRole("button", { name: /Authentication/i }),
+		);
 		// Select Custom Headers auth type.
 		await userEvent.click(body.getByLabelText(/Authentication/i));
 		await userEvent.click(

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.stories.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.stories.tsx
@@ -223,7 +223,7 @@ export const CreateServerOAuth2: Story = {
 		);
 
 		await userEvent.click(
-			body.getByRole("button", { name: /Authentication/i }),
+			await body.findByRole("button", { name: /Authentication/i }),
 		);
 		// Select OAuth2 from the Radix Select dropdown.
 		await userEvent.click(body.getByLabelText(/Authentication/i));
@@ -275,7 +275,7 @@ export const CreateServerAPIKey: Story = {
 		);
 
 		await userEvent.click(
-			body.getByRole("button", { name: /Authentication/i }),
+			await body.findByRole("button", { name: /Authentication/i }),
 		);
 		// Select API Key from the Radix Select dropdown.
 		await userEvent.click(body.getByLabelText(/Authentication/i));
@@ -389,7 +389,7 @@ export const EditServerWithOAuth2Secret: Story = {
 
 		// Authentication section is collapsed by default.
 		await userEvent.click(
-			body.getByRole("button", { name: /Authentication/i }),
+			await body.findByRole("button", { name: /Authentication/i }),
 		);
 
 		// The OAuth2 fields should be visible.
@@ -424,7 +424,7 @@ export const EditServerWithCustomHeaders: Story = {
 
 		// Authentication section is collapsed by default.
 		await userEvent.click(
-			body.getByRole("button", { name: /Authentication/i }),
+			await body.findByRole("button", { name: /Authentication/i }),
 		);
 
 		// Should show message about existing headers.
@@ -643,7 +643,7 @@ export const CustomHeadersAuthType: Story = {
 		);
 
 		await userEvent.click(
-			body.getByRole("button", { name: /Authentication/i }),
+			await body.findByRole("button", { name: /Authentication/i }),
 		);
 		// Select Custom Headers auth type.
 		await userEvent.click(body.getByLabelText(/Authentication/i));

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.stories.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.stories.tsx
@@ -83,7 +83,7 @@ export const EmptyState: Story = {
 		).toBeInTheDocument();
 
 		// Both the section header and the empty state render a distinct
-		// Add button — the empty-state one is the primary CTA.
+		// Add button, and the empty-state one is the primary CTA.
 		expect(
 			body.getByRole("button", { name: "Add server" }),
 		).toBeInTheDocument();
@@ -519,6 +519,31 @@ export const DeleteServerCancelled: Story = {
 };
 
 /** Confirm delete in dialog calls the API. */
+export const DirectEditWhileLoading: Story = {
+	parameters: {
+		reactRouter: reactRouterParameters({
+			location: {
+				path: "/agents/settings/mcp-servers",
+				searchParams: { server: "mcp-sentry" },
+			},
+			routing: { path: "/agents/settings/mcp-servers" },
+		}),
+	},
+	args: {
+		serversData: undefined,
+		isLoadingServers: true,
+	},
+	play: async ({ canvasElement }) => {
+		const body = within(canvasElement.ownerDocument.body);
+
+		await expect(await body.findByText(/^Loading$/i)).toBeInTheDocument();
+		expect(body.queryByLabelText(/Display Name/i)).not.toBeInTheDocument();
+		expect(
+			body.queryByRole("button", { name: /Save changes/i }),
+		).not.toBeInTheDocument();
+	},
+};
+
 export const DeleteServerConfirmed: Story = {
 	args: {
 		serversData: [

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.stories.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.stories.tsx
@@ -8,6 +8,16 @@ import { MCPServerAdminPanel } from "./MCPServerAdminPanel";
 
 const now = "2026-03-19T12:00:00.000Z";
 
+// Expand a collapsible section in the form by its header label.
+// The section bodies start collapsed to mirror the Models panel, so stories
+// that interact with fields inside a section need to expand it first.
+const expandSection = async (
+	body: ReturnType<typeof within>,
+	name: RegExp | string,
+): Promise<void> => {
+	await userEvent.click(await body.findByRole("button", { name }));
+};
+
 const createServerConfig = (
 	overrides: Partial<TypesGen.MCPServerConfig> &
 		Pick<TypesGen.MCPServerConfig, "id" | "display_name" | "slug">,
@@ -82,7 +92,20 @@ export const EmptyState: Story = {
 			await body.findByText(/No MCP servers configured yet/i),
 		).toBeInTheDocument();
 		await expect(
-			body.getByRole("button", { name: /Add Server/i }),
+			body.getAllByRole("button", { name: /Add Server/i })[0],
+		).toBeInTheDocument();
+
+		// Header action + empty-state CTA both render an Add button.
+		expect(body.getAllByRole("button", { name: /Add server/i })).toHaveLength(
+			2,
+		);
+		const emptyStateText = body.getByText(/No MCP servers configured yet/i);
+		const emptyStateContainer = emptyStateText.closest("div");
+		expect(emptyStateContainer).not.toBeNull();
+		expect(
+			within(emptyStateContainer as HTMLElement).getByRole("button", {
+				name: /Add server/i,
+			}),
 		).toBeInTheDocument();
 	},
 };
@@ -137,6 +160,9 @@ export const ServerList: Story = {
 		).toBeInTheDocument();
 		expect(body.getByRole("button", { name: /Linear/ })).toBeInTheDocument();
 		expect(body.getByRole("button", { name: /GitHub/ })).toBeInTheDocument();
+
+		// Disabled servers surface a warning badge next to the name.
+		expect(body.getByText(/^disabled$/i)).toBeInTheDocument();
 	},
 };
 
@@ -150,14 +176,29 @@ export const CreateServer: Story = {
 
 		// Click Add Server.
 		await userEvent.click(
-			await body.findByRole("button", { name: /Add Server/i }),
+			(await body.findAllByRole("button", { name: /Add server/i }))[0],
 		);
 
 		// Fill in the display name via the inline header input.
 		const nameInput = await body.findByLabelText(/Display Name/i);
 		await userEvent.type(nameInput, "Sentry");
 
-		// Slug should auto-populate.
+		// Collapsible sections start collapsed and the Enabled switch is
+		// edit-only. PencilIcon sits next to the editable name.
+		expect(
+			body.getByRole("button", { name: /Connection/i }),
+		).toBeInTheDocument();
+		expect(body.queryByLabelText(/^Slug$/i)).not.toBeInTheDocument();
+		expect(
+			body.queryByRole("switch", { name: /Enabled/i }),
+		).not.toBeInTheDocument();
+		const nameRow = nameInput.closest("div")?.parentElement;
+		expect(nameRow?.querySelector("svg.lucide-pencil")).toBeTruthy();
+
+		// Expand Connection to reveal slug + server URL.
+		await userEvent.click(body.getByRole("button", { name: /Connection/i }));
+
+		// Slug should auto-populate from the display name.
 		await expect(body.getByLabelText(/^Slug/i)).toHaveValue("sentry");
 
 		await userEvent.type(
@@ -192,15 +233,17 @@ export const CreateServerOAuth2: Story = {
 		const body = within(canvasElement.ownerDocument.body);
 
 		await userEvent.click(
-			await body.findByRole("button", { name: /Add Server/i }),
+			(await body.findAllByRole("button", { name: /Add server/i }))[0],
 		);
 
 		await userEvent.type(await body.findByLabelText(/Display Name/i), "GitHub");
+		await expandSection(body, /Connection/i);
 		await userEvent.type(
 			body.getByLabelText(/Server URL/i),
 			"https://api.githubcopilot.com/mcp/",
 		);
 
+		await expandSection(body, /Authentication/i);
 		// Select OAuth2 from the Radix Select dropdown.
 		await userEvent.click(body.getByLabelText(/Authentication/i));
 		await userEvent.click(await body.findByRole("option", { name: /OAuth2/i }));
@@ -241,15 +284,17 @@ export const CreateServerAPIKey: Story = {
 		const body = within(canvasElement.ownerDocument.body);
 
 		await userEvent.click(
-			await body.findByRole("button", { name: /Add Server/i }),
+			(await body.findAllByRole("button", { name: /Add server/i }))[0],
 		);
 
 		await userEvent.type(await body.findByLabelText(/Display Name/i), "Linear");
+		await expandSection(body, /Connection/i);
 		await userEvent.type(
 			body.getByLabelText(/Server URL/i),
 			"https://mcp.linear.app/v1",
 		);
 
+		await expandSection(body, /Authentication/i);
 		// Select API Key from the Radix Select dropdown.
 		await userEvent.click(body.getByLabelText(/Authentication/i));
 		await userEvent.click(
@@ -306,6 +351,9 @@ export const EditServer: Story = {
 		// The inline name input should be pre-populated.
 		const nameInput = await body.findByLabelText(/Display Name/i);
 		expect(nameInput).toHaveValue("Sentry");
+
+		// Expand Connection to access slug, URL, and description.
+		await expandSection(body, /Connection/i);
 		expect(body.getByLabelText(/^Slug/i)).toHaveValue("sentry");
 		expect(body.getByLabelText(/Server URL/i)).toHaveValue(
 			"https://mcp.sentry.io/sse",
@@ -355,6 +403,9 @@ export const EditServerWithOAuth2Secret: Story = {
 
 		await userEvent.click(await body.findByRole("button", { name: /GitHub/ }));
 
+		// Authentication section is collapsed by default.
+		await expandSection(body, /Authentication/i);
+
 		// The OAuth2 fields should be visible.
 		const secretField = await body.findByLabelText(/Client Secret/i);
 		expect(secretField).toHaveValue("••••••••••••••••");
@@ -384,6 +435,9 @@ export const EditServerWithCustomHeaders: Story = {
 		await userEvent.click(
 			await body.findByRole("button", { name: /Custom API/ }),
 		);
+
+		// Authentication section is collapsed by default.
+		await expandSection(body, /Authentication/i);
 
 		// Should show message about existing headers.
 		await expect(
@@ -519,7 +573,7 @@ export const BackToList: Story = {
 		const body = within(canvasElement.ownerDocument.body);
 
 		await userEvent.click(
-			await body.findByRole("button", { name: /Add Server/i }),
+			(await body.findAllByRole("button", { name: /Add server/i }))[0],
 		);
 
 		// Click Back.
@@ -543,18 +597,20 @@ export const CreateServerWithToolGovernance: Story = {
 		const body = within(canvasElement.ownerDocument.body);
 
 		await userEvent.click(
-			await body.findByRole("button", { name: /Add Server/i }),
+			(await body.findAllByRole("button", { name: /Add server/i }))[0],
 		);
 
 		await userEvent.type(
 			await body.findByLabelText(/Display Name/i),
 			"Restricted Server",
 		);
+		await expandSection(body, /Connection/i);
 		await userEvent.type(
 			body.getByLabelText(/Server URL/i),
 			"https://mcp.example.com/v1",
 		);
 
+		await expandSection(body, /Behavior/i);
 		await userEvent.type(
 			body.getByLabelText(/Tool Allow List/i),
 			"search, read_file",
@@ -587,18 +643,20 @@ export const CustomHeadersAuthType: Story = {
 		const body = within(canvasElement.ownerDocument.body);
 
 		await userEvent.click(
-			await body.findByRole("button", { name: /Add Server/i }),
+			(await body.findAllByRole("button", { name: /Add server/i }))[0],
 		);
 
 		await userEvent.type(
 			await body.findByLabelText(/Display Name/i),
 			"Custom API",
 		);
+		await expandSection(body, /Connection/i);
 		await userEvent.type(
 			body.getByLabelText(/Server URL/i),
 			"https://mcp.example.com/v1",
 		);
 
+		await expandSection(body, /Authentication/i);
 		// Select Custom Headers auth type.
 		await userEvent.click(body.getByLabelText(/Authentication/i));
 		await userEvent.click(

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.stories.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.stories.tsx
@@ -165,20 +165,17 @@ export const CreateServer: Story = {
 		const nameInput = await body.findByLabelText(/Display Name/i);
 		await userEvent.type(nameInput, "Sentry");
 
-		// Collapsible sections start collapsed and the Enabled switch is
-		// edit-only. PencilIcon sits next to the editable name.
-		expect(
-			body.getByRole("button", { name: /Connection/i }),
-		).toBeInTheDocument();
-		expect(body.queryByLabelText(/^Slug$/i)).not.toBeInTheDocument();
+		// Required fields (slug, server URL) are always visible. Optional
+		// sections start collapsed and the Enabled switch is edit-only.
+		// PencilIcon sits next to the editable name.
+		expect(body.getByLabelText(/^Slug/i)).toBeInTheDocument();
+		expect(body.getByLabelText(/Server URL/i)).toBeInTheDocument();
+		expect(body.queryByLabelText(/Description/i)).not.toBeInTheDocument();
 		expect(
 			body.queryByRole("switch", { name: /Enabled/i }),
 		).not.toBeInTheDocument();
 		const nameRow = nameInput.closest("div")?.parentElement;
 		expect(nameRow?.querySelector("svg.lucide-pencil")).toBeTruthy();
-
-		// Expand Connection to reveal slug + server URL.
-		await userEvent.click(body.getByRole("button", { name: /Connection/i }));
 
 		// Slug should auto-populate from the display name.
 		await expect(body.getByLabelText(/^Slug/i)).toHaveValue("sentry");
@@ -219,7 +216,6 @@ export const CreateServerOAuth2: Story = {
 		);
 
 		await userEvent.type(await body.findByLabelText(/Display Name/i), "GitHub");
-		await userEvent.click(body.getByRole("button", { name: /Connection/i }));
 		await userEvent.type(
 			body.getByLabelText(/Server URL/i),
 			"https://api.githubcopilot.com/mcp/",
@@ -272,7 +268,6 @@ export const CreateServerAPIKey: Story = {
 		);
 
 		await userEvent.type(await body.findByLabelText(/Display Name/i), "Linear");
-		await userEvent.click(body.getByRole("button", { name: /Connection/i }));
 		await userEvent.type(
 			body.getByLabelText(/Server URL/i),
 			"https://mcp.linear.app/v1",
@@ -338,12 +333,14 @@ export const EditServer: Story = {
 		const nameInput = await body.findByLabelText(/Display Name/i);
 		expect(nameInput).toHaveValue("Sentry");
 
-		// Expand Connection to access slug, URL, and description.
-		await userEvent.click(body.getByRole("button", { name: /Connection/i }));
+		// Slug and Server URL are always visible.
 		expect(body.getByLabelText(/^Slug/i)).toHaveValue("sentry");
 		expect(body.getByLabelText(/Server URL/i)).toHaveValue(
 			"https://mcp.sentry.io/sse",
 		);
+
+		// Expand Details to reach the description field.
+		await userEvent.click(body.getByRole("button", { name: /Details/i }));
 
 		// Update the description.
 		const descField = body.getByLabelText(/Description/i);
@@ -594,7 +591,6 @@ export const CreateServerWithToolGovernance: Story = {
 			await body.findByLabelText(/Display Name/i),
 			"Restricted Server",
 		);
-		await userEvent.click(body.getByRole("button", { name: /Connection/i }));
 		await userEvent.type(
 			body.getByLabelText(/Server URL/i),
 			"https://mcp.example.com/v1",
@@ -640,7 +636,6 @@ export const CustomHeadersAuthType: Story = {
 			await body.findByLabelText(/Display Name/i),
 			"Custom API",
 		);
-		await userEvent.click(body.getByRole("button", { name: /Connection/i }));
 		await userEvent.type(
 			body.getByLabelText(/Server URL/i),
 			"https://mcp.example.com/v1",

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.stories.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.stories.tsx
@@ -222,7 +222,7 @@ export const CreateServerOAuth2: Story = {
 		);
 
 		await userEvent.click(
-			body.getByRole("button", { name: /Authentication/i }),
+			await body.findByRole("button", { name: /Authentication/i }),
 		);
 		// Select OAuth2 from the Radix Select dropdown.
 		await userEvent.click(body.getByLabelText(/Authentication/i));
@@ -274,7 +274,7 @@ export const CreateServerAPIKey: Story = {
 		);
 
 		await userEvent.click(
-			body.getByRole("button", { name: /Authentication/i }),
+			await body.findByRole("button", { name: /Authentication/i }),
 		);
 		// Select API Key from the Radix Select dropdown.
 		await userEvent.click(body.getByLabelText(/Authentication/i));
@@ -388,7 +388,7 @@ export const EditServerWithOAuth2Secret: Story = {
 
 		// Authentication section is collapsed by default.
 		await userEvent.click(
-			body.getByRole("button", { name: /Authentication/i }),
+			await body.findByRole("button", { name: /Authentication/i }),
 		);
 
 		// The OAuth2 fields should be visible.
@@ -423,7 +423,7 @@ export const EditServerWithCustomHeaders: Story = {
 
 		// Authentication section is collapsed by default.
 		await userEvent.click(
-			body.getByRole("button", { name: /Authentication/i }),
+			await body.findByRole("button", { name: /Authentication/i }),
 		);
 
 		// Should show message about existing headers.
@@ -642,7 +642,7 @@ export const CustomHeadersAuthType: Story = {
 		);
 
 		await userEvent.click(
-			body.getByRole("button", { name: /Authentication/i }),
+			await body.findByRole("button", { name: /Authentication/i }),
 		);
 		// Select Custom Headers auth type.
 		await userEvent.click(body.getByLabelText(/Authentication/i));

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.stories.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.stories.tsx
@@ -8,6 +8,16 @@ import { MCPServerAdminPanel } from "./MCPServerAdminPanel";
 
 const now = "2026-03-19T12:00:00.000Z";
 
+// Expand a collapsible section in the form by its header label.
+// The section bodies start collapsed to mirror the Models panel, so stories
+// that interact with fields inside a section need to expand it first.
+const expandSection = async (
+	body: ReturnType<typeof within>,
+	name: RegExp | string,
+): Promise<void> => {
+	await userEvent.click(await body.findByRole("button", { name }));
+};
+
 const createServerConfig = (
 	overrides: Partial<TypesGen.MCPServerConfig> &
 		Pick<TypesGen.MCPServerConfig, "id" | "display_name" | "slug">,
@@ -81,7 +91,20 @@ export const EmptyState: Story = {
 			await body.findByText(/No MCP servers configured yet/i),
 		).toBeInTheDocument();
 		await expect(
-			body.getByRole("button", { name: /Add Server/i }),
+			body.getAllByRole("button", { name: /Add Server/i })[0],
+		).toBeInTheDocument();
+
+		// Header action + empty-state CTA both render an Add button.
+		expect(body.getAllByRole("button", { name: /Add server/i })).toHaveLength(
+			2,
+		);
+		const emptyStateText = body.getByText(/No MCP servers configured yet/i);
+		const emptyStateContainer = emptyStateText.closest("div");
+		expect(emptyStateContainer).not.toBeNull();
+		expect(
+			within(emptyStateContainer as HTMLElement).getByRole("button", {
+				name: /Add server/i,
+			}),
 		).toBeInTheDocument();
 	},
 };
@@ -136,6 +159,9 @@ export const ServerList: Story = {
 		).toBeInTheDocument();
 		expect(body.getByRole("button", { name: /Linear/ })).toBeInTheDocument();
 		expect(body.getByRole("button", { name: /GitHub/ })).toBeInTheDocument();
+
+		// Disabled servers surface a warning badge next to the name.
+		expect(body.getByText(/^disabled$/i)).toBeInTheDocument();
 	},
 };
 
@@ -149,14 +175,29 @@ export const CreateServer: Story = {
 
 		// Click Add Server.
 		await userEvent.click(
-			await body.findByRole("button", { name: /Add Server/i }),
+			(await body.findAllByRole("button", { name: /Add server/i }))[0],
 		);
 
 		// Fill in the display name via the inline header input.
 		const nameInput = await body.findByLabelText(/Display Name/i);
 		await userEvent.type(nameInput, "Sentry");
 
-		// Slug should auto-populate.
+		// Collapsible sections start collapsed and the Enabled switch is
+		// edit-only. PencilIcon sits next to the editable name.
+		expect(
+			body.getByRole("button", { name: /Connection/i }),
+		).toBeInTheDocument();
+		expect(body.queryByLabelText(/^Slug$/i)).not.toBeInTheDocument();
+		expect(
+			body.queryByRole("switch", { name: /Enabled/i }),
+		).not.toBeInTheDocument();
+		const nameRow = nameInput.closest("div")?.parentElement;
+		expect(nameRow?.querySelector("svg.lucide-pencil")).toBeTruthy();
+
+		// Expand Connection to reveal slug + server URL.
+		await userEvent.click(body.getByRole("button", { name: /Connection/i }));
+
+		// Slug should auto-populate from the display name.
 		await expect(body.getByLabelText(/^Slug/i)).toHaveValue("sentry");
 
 		await userEvent.type(
@@ -191,15 +232,17 @@ export const CreateServerOAuth2: Story = {
 		const body = within(canvasElement.ownerDocument.body);
 
 		await userEvent.click(
-			await body.findByRole("button", { name: /Add Server/i }),
+			(await body.findAllByRole("button", { name: /Add server/i }))[0],
 		);
 
 		await userEvent.type(await body.findByLabelText(/Display Name/i), "GitHub");
+		await expandSection(body, /Connection/i);
 		await userEvent.type(
 			body.getByLabelText(/Server URL/i),
 			"https://api.githubcopilot.com/mcp/",
 		);
 
+		await expandSection(body, /Authentication/i);
 		// Select OAuth2 from the Radix Select dropdown.
 		await userEvent.click(body.getByLabelText(/Authentication/i));
 		await userEvent.click(await body.findByRole("option", { name: /OAuth2/i }));
@@ -240,15 +283,17 @@ export const CreateServerAPIKey: Story = {
 		const body = within(canvasElement.ownerDocument.body);
 
 		await userEvent.click(
-			await body.findByRole("button", { name: /Add Server/i }),
+			(await body.findAllByRole("button", { name: /Add server/i }))[0],
 		);
 
 		await userEvent.type(await body.findByLabelText(/Display Name/i), "Linear");
+		await expandSection(body, /Connection/i);
 		await userEvent.type(
 			body.getByLabelText(/Server URL/i),
 			"https://mcp.linear.app/v1",
 		);
 
+		await expandSection(body, /Authentication/i);
 		// Select API Key from the Radix Select dropdown.
 		await userEvent.click(body.getByLabelText(/Authentication/i));
 		await userEvent.click(
@@ -305,6 +350,9 @@ export const EditServer: Story = {
 		// The inline name input should be pre-populated.
 		const nameInput = await body.findByLabelText(/Display Name/i);
 		expect(nameInput).toHaveValue("Sentry");
+
+		// Expand Connection to access slug, URL, and description.
+		await expandSection(body, /Connection/i);
 		expect(body.getByLabelText(/^Slug/i)).toHaveValue("sentry");
 		expect(body.getByLabelText(/Server URL/i)).toHaveValue(
 			"https://mcp.sentry.io/sse",
@@ -354,6 +402,9 @@ export const EditServerWithOAuth2Secret: Story = {
 
 		await userEvent.click(await body.findByRole("button", { name: /GitHub/ }));
 
+		// Authentication section is collapsed by default.
+		await expandSection(body, /Authentication/i);
+
 		// The OAuth2 fields should be visible.
 		const secretField = await body.findByLabelText(/Client Secret/i);
 		expect(secretField).toHaveValue("••••••••••••••••");
@@ -383,6 +434,9 @@ export const EditServerWithCustomHeaders: Story = {
 		await userEvent.click(
 			await body.findByRole("button", { name: /Custom API/ }),
 		);
+
+		// Authentication section is collapsed by default.
+		await expandSection(body, /Authentication/i);
 
 		// Should show message about existing headers.
 		await expect(
@@ -518,7 +572,7 @@ export const BackToList: Story = {
 		const body = within(canvasElement.ownerDocument.body);
 
 		await userEvent.click(
-			await body.findByRole("button", { name: /Add Server/i }),
+			(await body.findAllByRole("button", { name: /Add server/i }))[0],
 		);
 
 		// Click Back.
@@ -542,18 +596,20 @@ export const CreateServerWithToolGovernance: Story = {
 		const body = within(canvasElement.ownerDocument.body);
 
 		await userEvent.click(
-			await body.findByRole("button", { name: /Add Server/i }),
+			(await body.findAllByRole("button", { name: /Add server/i }))[0],
 		);
 
 		await userEvent.type(
 			await body.findByLabelText(/Display Name/i),
 			"Restricted Server",
 		);
+		await expandSection(body, /Connection/i);
 		await userEvent.type(
 			body.getByLabelText(/Server URL/i),
 			"https://mcp.example.com/v1",
 		);
 
+		await expandSection(body, /Behavior/i);
 		await userEvent.type(
 			body.getByLabelText(/Tool Allow List/i),
 			"search, read_file",
@@ -586,18 +642,20 @@ export const CustomHeadersAuthType: Story = {
 		const body = within(canvasElement.ownerDocument.body);
 
 		await userEvent.click(
-			await body.findByRole("button", { name: /Add Server/i }),
+			(await body.findAllByRole("button", { name: /Add server/i }))[0],
 		);
 
 		await userEvent.type(
 			await body.findByLabelText(/Display Name/i),
 			"Custom API",
 		);
+		await expandSection(body, /Connection/i);
 		await userEvent.type(
 			body.getByLabelText(/Server URL/i),
 			"https://mcp.example.com/v1",
 		);
 
+		await expandSection(body, /Authentication/i);
 		// Select Custom Headers auth type.
 		await userEvent.click(body.getByLabelText(/Authentication/i));
 		await userEvent.click(

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.stories.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.stories.tsx
@@ -8,16 +8,6 @@ import { MCPServerAdminPanel } from "./MCPServerAdminPanel";
 
 const now = "2026-03-19T12:00:00.000Z";
 
-// Expand a collapsible section in the form by its header label.
-// The section bodies start collapsed to mirror the Models panel, so stories
-// that interact with fields inside a section need to expand it first.
-const expandSection = async (
-	body: ReturnType<typeof within>,
-	name: RegExp | string,
-): Promise<void> => {
-	await userEvent.click(await body.findByRole("button", { name }));
-};
-
 const createServerConfig = (
 	overrides: Partial<TypesGen.MCPServerConfig> &
 		Pick<TypesGen.MCPServerConfig, "id" | "display_name" | "slug">,
@@ -90,21 +80,14 @@ export const EmptyState: Story = {
 		await expect(
 			await body.findByText(/No MCP servers configured yet/i),
 		).toBeInTheDocument();
-		await expect(
-			body.getAllByRole("button", { name: /Add Server/i })[0],
-		).toBeInTheDocument();
 
-		// Header action + empty-state CTA both render an Add button.
-		expect(body.getAllByRole("button", { name: /Add server/i })).toHaveLength(
-			2,
-		);
-		const emptyStateText = body.getByText(/No MCP servers configured yet/i);
-		const emptyStateContainer = emptyStateText.closest("div");
-		expect(emptyStateContainer).not.toBeNull();
+		// Both the section header and the empty state render a distinct
+		// Add button — the empty-state one is the primary CTA.
 		expect(
-			within(emptyStateContainer as HTMLElement).getByRole("button", {
-				name: /Add server/i,
-			}),
+			body.getByRole("button", { name: "Add server" }),
+		).toBeInTheDocument();
+		expect(
+			body.getByRole("button", { name: "Add your first server" }),
 		).toBeInTheDocument();
 	},
 };
@@ -175,7 +158,7 @@ export const CreateServer: Story = {
 
 		// Click Add Server.
 		await userEvent.click(
-			(await body.findAllByRole("button", { name: /Add server/i }))[0],
+			await body.findByRole("button", { name: /Add your first server/i }),
 		);
 
 		// Fill in the display name via the inline header input.
@@ -232,17 +215,19 @@ export const CreateServerOAuth2: Story = {
 		const body = within(canvasElement.ownerDocument.body);
 
 		await userEvent.click(
-			(await body.findAllByRole("button", { name: /Add server/i }))[0],
+			await body.findByRole("button", { name: /Add your first server/i }),
 		);
 
 		await userEvent.type(await body.findByLabelText(/Display Name/i), "GitHub");
-		await expandSection(body, /Connection/i);
+		await userEvent.click(body.getByRole("button", { name: /Connection/i }));
 		await userEvent.type(
 			body.getByLabelText(/Server URL/i),
 			"https://api.githubcopilot.com/mcp/",
 		);
 
-		await expandSection(body, /Authentication/i);
+		await userEvent.click(
+			body.getByRole("button", { name: /Authentication/i }),
+		);
 		// Select OAuth2 from the Radix Select dropdown.
 		await userEvent.click(body.getByLabelText(/Authentication/i));
 		await userEvent.click(await body.findByRole("option", { name: /OAuth2/i }));
@@ -283,17 +268,19 @@ export const CreateServerAPIKey: Story = {
 		const body = within(canvasElement.ownerDocument.body);
 
 		await userEvent.click(
-			(await body.findAllByRole("button", { name: /Add server/i }))[0],
+			await body.findByRole("button", { name: /Add your first server/i }),
 		);
 
 		await userEvent.type(await body.findByLabelText(/Display Name/i), "Linear");
-		await expandSection(body, /Connection/i);
+		await userEvent.click(body.getByRole("button", { name: /Connection/i }));
 		await userEvent.type(
 			body.getByLabelText(/Server URL/i),
 			"https://mcp.linear.app/v1",
 		);
 
-		await expandSection(body, /Authentication/i);
+		await userEvent.click(
+			body.getByRole("button", { name: /Authentication/i }),
+		);
 		// Select API Key from the Radix Select dropdown.
 		await userEvent.click(body.getByLabelText(/Authentication/i));
 		await userEvent.click(
@@ -352,7 +339,7 @@ export const EditServer: Story = {
 		expect(nameInput).toHaveValue("Sentry");
 
 		// Expand Connection to access slug, URL, and description.
-		await expandSection(body, /Connection/i);
+		await userEvent.click(body.getByRole("button", { name: /Connection/i }));
 		expect(body.getByLabelText(/^Slug/i)).toHaveValue("sentry");
 		expect(body.getByLabelText(/Server URL/i)).toHaveValue(
 			"https://mcp.sentry.io/sse",
@@ -403,7 +390,9 @@ export const EditServerWithOAuth2Secret: Story = {
 		await userEvent.click(await body.findByRole("button", { name: /GitHub/ }));
 
 		// Authentication section is collapsed by default.
-		await expandSection(body, /Authentication/i);
+		await userEvent.click(
+			body.getByRole("button", { name: /Authentication/i }),
+		);
 
 		// The OAuth2 fields should be visible.
 		const secretField = await body.findByLabelText(/Client Secret/i);
@@ -436,7 +425,9 @@ export const EditServerWithCustomHeaders: Story = {
 		);
 
 		// Authentication section is collapsed by default.
-		await expandSection(body, /Authentication/i);
+		await userEvent.click(
+			body.getByRole("button", { name: /Authentication/i }),
+		);
 
 		// Should show message about existing headers.
 		await expect(
@@ -572,7 +563,7 @@ export const BackToList: Story = {
 		const body = within(canvasElement.ownerDocument.body);
 
 		await userEvent.click(
-			(await body.findAllByRole("button", { name: /Add server/i }))[0],
+			await body.findByRole("button", { name: /^Add server$/i }),
 		);
 
 		// Click Back.
@@ -596,20 +587,20 @@ export const CreateServerWithToolGovernance: Story = {
 		const body = within(canvasElement.ownerDocument.body);
 
 		await userEvent.click(
-			(await body.findAllByRole("button", { name: /Add server/i }))[0],
+			await body.findByRole("button", { name: /Add your first server/i }),
 		);
 
 		await userEvent.type(
 			await body.findByLabelText(/Display Name/i),
 			"Restricted Server",
 		);
-		await expandSection(body, /Connection/i);
+		await userEvent.click(body.getByRole("button", { name: /Connection/i }));
 		await userEvent.type(
 			body.getByLabelText(/Server URL/i),
 			"https://mcp.example.com/v1",
 		);
 
-		await expandSection(body, /Behavior/i);
+		await userEvent.click(body.getByRole("button", { name: /Behavior/i }));
 		await userEvent.type(
 			body.getByLabelText(/Tool Allow List/i),
 			"search, read_file",
@@ -642,20 +633,22 @@ export const CustomHeadersAuthType: Story = {
 		const body = within(canvasElement.ownerDocument.body);
 
 		await userEvent.click(
-			(await body.findAllByRole("button", { name: /Add server/i }))[0],
+			await body.findByRole("button", { name: /Add your first server/i }),
 		);
 
 		await userEvent.type(
 			await body.findByLabelText(/Display Name/i),
 			"Custom API",
 		);
-		await expandSection(body, /Connection/i);
+		await userEvent.click(body.getByRole("button", { name: /Connection/i }));
 		await userEvent.type(
 			body.getByLabelText(/Server URL/i),
 			"https://mcp.example.com/v1",
 		);
 
-		await expandSection(body, /Authentication/i);
+		await userEvent.click(
+			body.getByRole("button", { name: /Authentication/i }),
+		);
 		// Select Custom Headers auth type.
 		await userEvent.click(body.getByLabelText(/Authentication/i));
 		await userEvent.click(

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
@@ -36,6 +36,7 @@ import {
 	InputGroupAddon,
 	InputGroupInput,
 } from "#/components/InputGroup/InputGroup";
+import { Label } from "#/components/Label/Label";
 import { Loader } from "#/components/Loader/Loader";
 import {
 	Popover,
@@ -963,7 +964,7 @@ const ServerForm: FC<ServerFormProps> = ({
 													<div>
 														<span>{opt.label}</span>
 														<span className="ml-1.5 text-content-secondary">
-															— {opt.description}
+															: {opt.description}
 														</span>
 													</div>
 												</SelectItem>
@@ -992,31 +993,31 @@ const ServerForm: FC<ServerFormProps> = ({
 									/>
 								</div>
 
-										<div className="flex items-start justify-between gap-4">
-											<div className="min-w-0 space-y-1">
-												<Label
-													htmlFor={`${formId}-allow-in-plan-mode`}
-												className="text-sm font-medium text-content-primary"
-											>
-													Allow all tools from this MCP server in root plan mode
-												</Label>
-											<p className="m-0 text-xs text-content-secondary">
-													When enabled, the root plan-mode agent can call these tools
-													during planning. Workspace MCP and plan-mode subagents remain
-													restricted.
-											</p>
-											</div>
-										<Switch
-												id={`${formId}-allow-in-plan-mode`}
-											checked={form.values.allowInPlanMode}
-												onCheckedChange={(v) => {
-													form.setFieldValue("allowInPlanMode", v);
-												}}
-											disabled={isDisabled}
-										/>
-										</div>
+								<div className="flex items-start justify-between gap-4">
+									<div className="min-w-0 space-y-1">
+										<Label
+											htmlFor={`${formId}-allow-in-plan-mode`}
+											className="text-sm font-medium text-content-primary"
+										>
+											Allow all tools from this MCP server in root plan mode
+										</Label>
+										<p className="m-0 text-xs text-content-secondary">
+											When enabled, the root plan-mode agent can call these
+											tools during planning. Workspace MCP and plan-mode
+											subagents remain restricted.
+										</p>
+									</div>
+									<Switch
+										id={`${formId}-allow-in-plan-mode`}
+										checked={form.values.allowInPlanMode}
+										onCheckedChange={(v) => {
+											form.setFieldValue("allowInPlanMode", v);
+										}}
+										disabled={isDisabled}
+									/>
+								</div>
 
-										<div className="grid items-start gap-4 sm:grid-cols-2">
+								<div className="grid items-start gap-4 sm:grid-cols-2">
 									<Field
 										label="Tool Allow List"
 										htmlFor={`${formId}-allow-list`}
@@ -1049,7 +1050,6 @@ const ServerForm: FC<ServerFormProps> = ({
 					</Collapsible>
 				</div>
 
-				{/* Footer — pushed to bottom, matches ProviderForm */}
 				<div className="mt-auto py-6">
 					<hr className="mb-4 border-0 border-t border-solid border-border" />
 					<div className="flex items-center justify-between">

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
@@ -561,28 +561,29 @@ const ServerForm: FC<ServerFormProps> = ({
 						</button>
 						{showAuth && (
 							<div className="space-y-4 pt-3">
-								<Select
-									value={form.values.authType}
-									onValueChange={(v) => {
-										form.setFieldValue("authType", v);
-									}}
-									disabled={isDisabled}
-								>
-									<SelectTrigger
-										id={`${formId}-auth`}
-										className="h-9 max-w-[240px] text-[13px]"
+								<Field label="Authentication method" htmlFor={`${formId}-auth`}>
+									<Select
+										value={form.values.authType}
+										onValueChange={(v) => {
+											form.setFieldValue("authType", v);
+										}}
+										disabled={isDisabled}
 									>
-										<SelectValue />
-									</SelectTrigger>
-									<SelectContent>
-										{AUTH_TYPE_OPTIONS.map((opt) => (
-											<SelectItem key={opt.value} value={opt.value}>
-												{opt.label}
-											</SelectItem>
-										))}
-									</SelectContent>
-								</Select>
-
+										<SelectTrigger
+											id={`${formId}-auth`}
+											className="h-9 max-w-[240px] text-[13px]"
+										>
+											<SelectValue />
+										</SelectTrigger>
+										<SelectContent>
+											{AUTH_TYPE_OPTIONS.map((opt) => (
+												<SelectItem key={opt.value} value={opt.value}>
+													{opt.label}
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+								</Field>
 								{form.values.authType === "oauth2" && (
 									<div className="space-y-4 rounded-lg border border-solid border-border/70 bg-surface-secondary/30 p-4">
 										<p className="m-0 text-xs text-content-secondary">

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
@@ -1,6 +1,7 @@
 import { useFormik } from "formik";
 import {
 	CheckCircleIcon,
+	ChevronDownIcon,
 	ChevronRightIcon,
 	CircleIcon,
 	PlusIcon,
@@ -290,6 +291,9 @@ const ServerForm: FC<ServerFormProps> = ({
 	const formId = useId();
 	const isEditing = server !== null;
 	const [confirmingDelete, setConfirmingDelete] = useState(false);
+	const [showConnection, setShowConnection] = useState(true);
+	const [showAuth, setShowAuth] = useState(true);
+	const [showBehavior, setShowBehavior] = useState(true);
 
 	const form = useFormik<MCPServerFormValues>({
 		initialValues: buildInitialValues(server),
@@ -452,390 +456,480 @@ const ServerForm: FC<ServerFormProps> = ({
 							disabled={isDisabled}
 						/>
 					</Field>
-					{/* ── Connection row: URL + transport side by side ── */}
-					<hr className="!my-0 border-0 border-t border-solid border-border" />
-					<div className="grid items-start gap-5 sm:grid-cols-[1fr_auto]">
-						<Field
-							label="Server URL"
-							htmlFor={`${formId}-url`}
-							required
-							description="The endpoint URL for this MCP server."
+					{/* ── Connection section ── */}
+					<div className="border-0 border-t border-solid border-border pt-4">
+						<button
+							type="button"
+							onClick={() => setShowConnection((v) => !v)}
+							className="flex w-full cursor-pointer items-start justify-between border-0 bg-transparent p-0 text-left transition-colors hover:text-content-primary"
 						>
-							<Input
-								id={`${formId}-url`}
-								className="h-9 text-[13px]"
-								{...form.getFieldProps("url")}
-								placeholder="https://mcp.example.com/sse"
-								disabled={isDisabled}
-							/>
-						</Field>
-
-						<Field label="Transport" htmlFor={`${formId}-transport`}>
-							<Select
-								value={form.values.transport}
-								onValueChange={(v) => {
-									form.setFieldValue("transport", v);
-								}}
-								disabled={isDisabled}
-							>
-								<SelectTrigger
-									id={`${formId}-transport`}
-									className="h-9 min-w-[160px] text-[13px]"
-								>
-									<SelectValue />
-								</SelectTrigger>
-								<SelectContent>
-									{TRANSPORT_OPTIONS.map((opt) => (
-										<SelectItem key={opt.value} value={opt.value}>
-											{opt.label}
-										</SelectItem>
-									))}
-								</SelectContent>
-							</Select>
-						</Field>
-					</div>
-					{/* ── Authentication ── */}
-					<hr className="!my-0 border-0 border-t border-solid border-border" />
-					<Field
-						label="Authentication"
-						htmlFor={`${formId}-auth`}
-						description="How users authenticate with this MCP server."
-					>
-						<Select
-							value={form.values.authType}
-							onValueChange={(v) => {
-								form.setFieldValue("authType", v);
-							}}
-							disabled={isDisabled}
-						>
-							<SelectTrigger
-								id={`${formId}-auth`}
-								className="h-9 max-w-[240px] text-[13px]"
-							>
-								<SelectValue />
-							</SelectTrigger>
-							<SelectContent>
-								{AUTH_TYPE_OPTIONS.map((opt) => (
-									<SelectItem key={opt.value} value={opt.value}>
-										{opt.label}
-									</SelectItem>
-								))}
-							</SelectContent>
-						</Select>
-					</Field>
-					{form.values.authType === "oauth2" && (
-						<div className="space-y-4 rounded-lg border border-border bg-surface-secondary/30 p-4">
-							<p className="m-0 text-xs text-content-secondary">
-								Register a client with the external MCP server's OAuth2 provider
-								and enter the credentials below. Coder will handle the per-user
-								authorization flow.
-							</p>
-							<div className="grid items-start gap-4 sm:grid-cols-2">
-								{" "}
-								<Field label="Client ID" htmlFor={`${formId}-oauth-id`}>
-									<Input
-										id={`${formId}-oauth-id`}
-										className="h-9 text-[13px]"
-										{...form.getFieldProps("oauth2ClientID")}
-										disabled={isDisabled}
-									/>
-								</Field>
-								<Field label="Client Secret" htmlFor={`${formId}-oauth-secret`}>
-									<Input
-										id={`${formId}-oauth-secret`}
-										className="h-9 font-mono text-[13px] [-webkit-text-security:disc]"
-										type="text"
-										autoComplete="off"
-										data-1p-ignore
-										data-lpignore="true"
-										data-form-type="other"
-										data-bwignore
-										value={form.values.oauth2ClientSecret}
-										onChange={(e) => {
-											form.setFieldValue("oauth2SecretTouched", true);
-											form.setFieldValue("oauth2ClientSecret", e.target.value);
-										}}
-										onFocus={() => {
-											if (
-												!form.values.oauth2SecretTouched &&
-												form.values.oauth2ClientSecret === SECRET_PLACEHOLDER
-											) {
-												form.setFieldValue("oauth2ClientSecret", "");
-												form.setFieldValue("oauth2SecretTouched", true);
-											}
-										}}
-										disabled={isDisabled}
-									/>
-								</Field>
+							<div>
+								<h3 className="m-0 text-sm font-medium text-content-primary">
+									Connection
+								</h3>
+								<p className="m-0 text-xs text-content-secondary">
+									Server endpoint and transport protocol.
+								</p>
 							</div>
-							<div className="grid items-start gap-4 sm:grid-cols-2">
-								<Field
-									label="Authorization URL"
-									htmlFor={`${formId}-oauth-auth-url`}
-								>
-									<Input
-										id={`${formId}-oauth-auth-url`}
-										className="h-9 text-[13px]"
-										{...form.getFieldProps("oauth2AuthURL")}
-										placeholder="https://provider.com/oauth2/authorize"
-										disabled={isDisabled}
-									/>
-								</Field>
-								<Field label="Token URL" htmlFor={`${formId}-oauth-token-url`}>
-									<Input
-										id={`${formId}-oauth-token-url`}
-										className="h-9 text-[13px]"
-										{...form.getFieldProps("oauth2TokenURL")}
-										placeholder="https://provider.com/oauth2/token"
-										disabled={isDisabled}
-									/>
-								</Field>
-							</div>
-							<Field label="Scopes" htmlFor={`${formId}-oauth-scopes`}>
-								<Input
-									id={`${formId}-oauth-scopes`}
-									className="h-9 text-[13px]"
-									{...form.getFieldProps("oauth2Scopes")}
-									placeholder="read write"
-									disabled={isDisabled}
-								/>
-							</Field>
-						</div>
-					)}
-					{form.values.authType === "api_key" && (
-						<div className="grid items-start gap-4 rounded-lg border border-border bg-surface-secondary/30 p-4 sm:grid-cols-2">
-							<Field label="Header Name" htmlFor={`${formId}-apikey-header`}>
-								<Input
-									id={`${formId}-apikey-header`}
-									className="h-9 text-[13px]"
-									{...form.getFieldProps("apiKeyHeader")}
-									placeholder="Authorization"
-									disabled={isDisabled}
-								/>
-							</Field>
-							<Field label="API Key" htmlFor={`${formId}-apikey-value`}>
-								<Input
-									id={`${formId}-apikey-value`}
-									className="h-9 font-mono text-[13px] [-webkit-text-security:disc]"
-									type="text"
-									autoComplete="off"
-									data-1p-ignore
-									data-lpignore="true"
-									data-form-type="other"
-									data-bwignore
-									value={form.values.apiKeyValue}
-									onChange={(e) => {
-										form.setFieldValue("apiKeyTouched", true);
-										form.setFieldValue("apiKeyValue", e.target.value);
-									}}
-									onFocus={() => {
-										if (
-											!form.values.apiKeyTouched &&
-											form.values.apiKeyValue === SECRET_PLACEHOLDER
-										) {
-											form.setFieldValue("apiKeyValue", "");
-											form.setFieldValue("apiKeyTouched", true);
-										}
-									}}
-									disabled={isDisabled}
-								/>
-							</Field>
-						</div>
-					)}
-					{form.values.authType === "custom_headers" && (
-						<div className="space-y-3 rounded-lg border border-border bg-surface-secondary/30 p-4">
-							{server?.has_custom_headers &&
-								!form.values.customHeadersTouched && (
-									<p className="m-0 text-xs text-content-secondary">
-										This server has custom headers configured. Add headers below
-										to replace them.
-									</p>
-								)}
-							{form.values.customHeaders.map((header, index) => (
-								<div key={index} className="flex items-start gap-2">
-									<div className="grid flex-1 items-start gap-2 sm:grid-cols-2">
-										<Input
-											className="h-9 text-[13px]"
-											value={header.key}
-											onChange={(e) => {
-												form.setFieldValue("customHeadersTouched", true);
-												const updated = [...form.values.customHeaders];
-												updated[index] = {
-													...updated[index],
-													key: e.target.value,
-												};
-												form.setFieldValue("customHeaders", updated);
-											}}
-											placeholder="Header name"
-											disabled={isDisabled}
-											aria-label={`Header ${index + 1} name`}
-										/>
-										<Input
-											className="h-9 font-mono text-[13px] [-webkit-text-security:disc]"
-											type="text"
-											autoComplete="off"
-											data-1p-ignore
-											data-lpignore="true"
-											data-form-type="other"
-											data-bwignore
-											value={header.value}
-											onChange={(e) => {
-												form.setFieldValue("customHeadersTouched", true);
-												const updated = [...form.values.customHeaders];
-												updated[index] = {
-													...updated[index],
-													value: e.target.value,
-												};
-												form.setFieldValue("customHeaders", updated);
-											}}
-											placeholder="Header value"
-											disabled={isDisabled}
-											aria-label={`Header ${index + 1} value`}
-										/>
-									</div>
-									<Button
-										variant="outline"
-										size="icon"
-										type="button"
-										className="mt-0 h-9 w-9 shrink-0"
-										onClick={() => {
-											form.setFieldValue("customHeadersTouched", true);
-											form.setFieldValue(
-												"customHeaders",
-												form.values.customHeaders.filter((_, i) => i !== index),
-											);
-										}}
-										disabled={isDisabled}
-										aria-label={`Remove header ${index + 1}`}
+							{showConnection ? (
+								<ChevronDownIcon className="mt-0.5 h-4 w-4 shrink-0 text-content-secondary" />
+							) : (
+								<ChevronRightIcon className="mt-0.5 h-4 w-4 shrink-0 text-content-secondary" />
+							)}
+						</button>
+						{showConnection && (
+							<div className="space-y-5 pt-3">
+								<div className="grid items-start gap-5 sm:grid-cols-[1fr_auto]">
+									<Field
+										label="Server URL"
+										htmlFor={`${formId}-url`}
+										required
+										description="The endpoint URL for this MCP server."
 									>
-										<XIcon className="h-4 w-4" />
-									</Button>
+										<Input
+											id={`${formId}-url`}
+											className="h-9 text-[13px]"
+											{...form.getFieldProps("url")}
+											placeholder="https://mcp.example.com/sse"
+											disabled={isDisabled}
+										/>
+									</Field>
+
+									<Field label="Transport" htmlFor={`${formId}-transport`}>
+										<Select
+											value={form.values.transport}
+											onValueChange={(v) => {
+												form.setFieldValue("transport", v);
+											}}
+											disabled={isDisabled}
+										>
+											<SelectTrigger
+												id={`${formId}-transport`}
+												className="h-9 min-w-[160px] text-[13px]"
+											>
+												<SelectValue />
+											</SelectTrigger>
+											<SelectContent>
+												{TRANSPORT_OPTIONS.map((opt) => (
+													<SelectItem key={opt.value} value={opt.value}>
+														{opt.label}
+													</SelectItem>
+												))}
+											</SelectContent>
+										</Select>
+									</Field>
 								</div>
-							))}
-							<Button
-								variant="outline"
-								size="sm"
-								type="button"
-								onClick={() => {
-									form.setFieldValue("customHeadersTouched", true);
-									form.setFieldValue("customHeaders", [
-										...form.values.customHeaders,
-										{ key: "", value: "" },
-									]);
-								}}
-								disabled={isDisabled}
-							>
-								<PlusIcon className="h-4 w-4" />
-								Add header
-							</Button>
-						</div>
-					)}
-					{/* ── Availability ── */}
-					<hr className="!my-0 border-0 border-t border-solid border-border" />
-					<Field
-						label="Availability"
-						htmlFor={`${formId}-availability`}
-						description="Controls how this server appears in new conversations."
-					>
-						<Select
-							value={form.values.availability}
-							onValueChange={(v) => {
-								form.setFieldValue("availability", v);
-							}}
-							disabled={isDisabled}
+							</div>
+						)}
+					</div>
+						{/* ── Authentication section ── */}
+					<div className="border-0 border-t border-solid border-border pt-4">
+						<button
+							type="button"
+								onClick={() => setShowAuth((v) => !v)}
+							className="flex w-full cursor-pointer items-start justify-between border-0 bg-transparent p-0 text-left transition-colors hover:text-content-primary"
 						>
-							<SelectTrigger
-								id={`${formId}-availability`}
-								className="h-9 text-[13px]"
-							>
-								<SelectValue />
-							</SelectTrigger>
-							<SelectContent>
-								{AVAILABILITY_OPTIONS.map((opt) => (
-									<SelectItem key={opt.value} value={opt.value}>
-										<div>
-											<span>{opt.label}</span>
-											<span className="ml-1.5 text-content-secondary">
-												— {opt.description}
-											</span>
+							<div>
+								<h3 className="m-0 text-sm font-medium text-content-primary">
+									Authentication
+								</h3>
+								<p className="m-0 text-xs text-content-secondary">
+									How users authenticate with this MCP server.
+								</p>
+							</div>
+							{showAuth ? (
+								<ChevronDownIcon className="mt-0.5 h-4 w-4 shrink-0 text-content-secondary" />
+							) : (
+								<ChevronRightIcon className="mt-0.5 h-4 w-4 shrink-0 text-content-secondary" />
+							)}
+						</button>
+						{showAuth && (
+							<div className="space-y-5 pt-3">
+								<Select
+									value={form.values.authType}
+									onValueChange={(v) => {
+										form.setFieldValue("authType", v);
+									}}
+									disabled={isDisabled}
+								>
+									<SelectTrigger
+										id={`${formId}-auth`}
+										className="h-9 max-w-[240px] text-[13px]"
+									>
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent>
+										{AUTH_TYPE_OPTIONS.map((opt) => (
+											<SelectItem key={opt.value} value={opt.value}>
+												{opt.label}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+
+								{form.values.authType === "oauth2" && (
+									<div className="space-y-4 rounded-lg border border-border bg-surface-secondary/30 p-4">
+										<p className="m-0 text-xs text-content-secondary">
+											Register a client with the external MCP server's OAuth2
+											provider and enter the credentials below. Coder will
+											handle the per-user authorization flow.
+										</p>
+										<div className="grid items-start gap-4 sm:grid-cols-2">
+											{" "}
+											<Field label="Client ID" htmlFor={`${formId}-oauth-id`}>
+												<Input
+													id={`${formId}-oauth-id`}
+													className="h-9 text-[13px]"
+													{...form.getFieldProps("oauth2ClientID")}
+													disabled={isDisabled}
+												/>
+											</Field>
+											<Field
+												label="Client Secret"
+												htmlFor={`${formId}-oauth-secret`}
+											>
+												<Input
+													id={`${formId}-oauth-secret`}
+													className="h-9 font-mono text-[13px] [-webkit-text-security:disc]"
+													type="text"
+													autoComplete="off"
+													data-1p-ignore
+													data-lpignore="true"
+													data-form-type="other"
+													data-bwignore
+													value={form.values.oauth2ClientSecret}
+													onChange={(e) => {
+														form.setFieldValue("oauth2SecretTouched", true);
+														form.setFieldValue(
+															"oauth2ClientSecret",
+															e.target.value,
+														);
+													}}
+													onFocus={() => {
+														if (
+															!form.values.oauth2SecretTouched &&
+															form.values.oauth2ClientSecret ===
+																SECRET_PLACEHOLDER
+														) {
+															form.setFieldValue("oauth2ClientSecret", "");
+															form.setFieldValue("oauth2SecretTouched", true);
+														}
+													}}
+													disabled={isDisabled}
+												/>
+											</Field>
 										</div>
-									</SelectItem>
-								))}
-							</SelectContent>
-						</Select>
-					</Field>{" "}
-					{/* ── Tool governance row ── */}
-					<hr className="!my-0 border-0 border-t border-solid border-border" />
-					<div className="flex items-start justify-between gap-4">
-						<div className="min-w-0 space-y-1">
-							<Label
-								htmlFor={`${formId}-model-intent`}
-								className="text-sm font-medium text-content-primary"
-							>
-								Model intent
-							</Label>
-							<p className="m-0 text-xs text-content-secondary">
-								Require the model to describe each tool call's purpose in
-								natural language, shown as a status label in the UI.
-							</p>
-						</div>
-						<Switch
-							id={`${formId}-model-intent`}
-							checked={form.values.modelIntent}
-							onCheckedChange={(v) => {
-								form.setFieldValue("modelIntent", v);
-							}}
-							disabled={isDisabled}
-						/>
+										<div className="grid items-start gap-4 sm:grid-cols-2">
+											<Field
+												label="Authorization URL"
+												htmlFor={`${formId}-oauth-auth-url`}
+											>
+												<Input
+													id={`${formId}-oauth-auth-url`}
+													className="h-9 text-[13px]"
+													{...form.getFieldProps("oauth2AuthURL")}
+													placeholder="https://provider.com/oauth2/authorize"
+													disabled={isDisabled}
+												/>
+											</Field>
+											<Field
+												label="Token URL"
+												htmlFor={`${formId}-oauth-token-url`}
+											>
+												<Input
+													id={`${formId}-oauth-token-url`}
+													className="h-9 text-[13px]"
+													{...form.getFieldProps("oauth2TokenURL")}
+													placeholder="https://provider.com/oauth2/token"
+													disabled={isDisabled}
+												/>
+											</Field>
+										</div>
+										<Field label="Scopes" htmlFor={`${formId}-oauth-scopes`}>
+											<Input
+												id={`${formId}-oauth-scopes`}
+												className="h-9 text-[13px]"
+												{...form.getFieldProps("oauth2Scopes")}
+												placeholder="read write"
+												disabled={isDisabled}
+											/>
+										</Field>
+									</div>
+								)}
+
+								{form.values.authType === "api_key" && (
+									<div className="grid items-start gap-4 rounded-lg border border-border bg-surface-secondary/30 p-4 sm:grid-cols-2">
+										<Field
+											label="Header Name"
+											htmlFor={`${formId}-apikey-header`}
+										>
+											<Input
+												id={`${formId}-apikey-header`}
+												className="h-9 text-[13px]"
+												{...form.getFieldProps("apiKeyHeader")}
+												placeholder="Authorization"
+												disabled={isDisabled}
+											/>
+										</Field>
+										<Field label="API Key" htmlFor={`${formId}-apikey-value`}>
+											<Input
+												id={`${formId}-apikey-value`}
+												className="h-9 font-mono text-[13px] [-webkit-text-security:disc]"
+												type="text"
+												autoComplete="off"
+												data-1p-ignore
+												data-lpignore="true"
+												data-form-type="other"
+												data-bwignore
+												value={form.values.apiKeyValue}
+												onChange={(e) => {
+													form.setFieldValue("apiKeyTouched", true);
+													form.setFieldValue("apiKeyValue", e.target.value);
+												}}
+												onFocus={() => {
+													if (
+														!form.values.apiKeyTouched &&
+														form.values.apiKeyValue === SECRET_PLACEHOLDER
+													) {
+														form.setFieldValue("apiKeyValue", "");
+														form.setFieldValue("apiKeyTouched", true);
+													}
+												}}
+												disabled={isDisabled}
+											/>
+										</Field>
+									</div>
+								)}
+
+								{form.values.authType === "custom_headers" && (
+									<div className="space-y-3 rounded-lg border border-border bg-surface-secondary/30 p-4">
+										{server?.has_custom_headers &&
+											!form.values.customHeadersTouched && (
+												<p className="m-0 text-xs text-content-secondary">
+													This server has custom headers configured. Add headers
+													below to replace them.
+												</p>
+											)}
+										{form.values.customHeaders.map((header, index) => (
+											<div key={index} className="flex items-start gap-2">
+												<div className="grid flex-1 items-start gap-2 sm:grid-cols-2">
+													<Input
+														className="h-9 text-[13px]"
+														value={header.key}
+														onChange={(e) => {
+															form.setFieldValue("customHeadersTouched", true);
+															const updated = [...form.values.customHeaders];
+															updated[index] = {
+																...updated[index],
+																key: e.target.value,
+															};
+															form.setFieldValue("customHeaders", updated);
+														}}
+														placeholder="Header name"
+														disabled={isDisabled}
+														aria-label={`Header ${index + 1} name`}
+													/>
+													<Input
+														className="h-9 font-mono text-[13px] [-webkit-text-security:disc]"
+														type="text"
+														autoComplete="off"
+														data-1p-ignore
+														data-lpignore="true"
+														data-form-type="other"
+														data-bwignore
+														value={header.value}
+														onChange={(e) => {
+															form.setFieldValue("customHeadersTouched", true);
+															const updated = [...form.values.customHeaders];
+															updated[index] = {
+																...updated[index],
+																value: e.target.value,
+															};
+															form.setFieldValue("customHeaders", updated);
+														}}
+														placeholder="Header value"
+														disabled={isDisabled}
+														aria-label={`Header ${index + 1} value`}
+													/>
+												</div>
+												<Button
+													variant="outline"
+													size="icon"
+													type="button"
+													className="mt-0 h-9 w-9 shrink-0"
+													onClick={() => {
+														form.setFieldValue("customHeadersTouched", true);
+														form.setFieldValue(
+															"customHeaders",
+															form.values.customHeaders.filter(
+																(_, i) => i !== index,
+															),
+														);
+													}}
+													disabled={isDisabled}
+													aria-label={`Remove header ${index + 1}`}
+												>
+													<XIcon className="h-4 w-4" />
+												</Button>
+											</div>
+										))}
+										<Button
+											variant="outline"
+											size="sm"
+											type="button"
+											onClick={() => {
+												form.setFieldValue("customHeadersTouched", true);
+												form.setFieldValue("customHeaders", [
+													...form.values.customHeaders,
+													{ key: "", value: "" },
+												]);
+											}}
+											disabled={isDisabled}
+										>
+											<PlusIcon className="h-4 w-4" />
+											Add header
+										</Button>
+									</div>
+								)}
+							</div>
+						)}
 					</div>
-					<div className="flex items-center justify-between">
-						<div>
-							<Label htmlFor={`${formId}-allow-in-plan-mode`}>
-								Allow all tools from this MCP server in root plan mode
-							</Label>
-							<p className="text-sm text-content-secondary">
-								When enabled, the root plan-mode agent can call these tools
-								during planning. Workspace MCP and plan-mode subagents remain
-								restricted.
-							</p>
-						</div>
-						<Switch
-							id={`${formId}-allow-in-plan-mode`}
-							checked={form.values.allowInPlanMode}
-							onCheckedChange={(v) => {
-								form.setFieldValue("allowInPlanMode", v);
-							}}
-							disabled={isDisabled}
-						/>
-					</div>
-					<div className="grid items-start gap-5 sm:grid-cols-2">
-						{" "}
-						<Field
-							label="Tool Allow List"
-							htmlFor={`${formId}-allow-list`}
-							description="Comma-separated. Empty = all allowed."
+					{/* ── Behavior section ── */}
+					<div className="border-0 border-t border-solid border-border pt-4">
+						<button
+							type="button"
+							onClick={() => setShowBehavior((v) => !v)}
+							className="flex w-full cursor-pointer items-start justify-between border-0 bg-transparent p-0 text-left transition-colors hover:text-content-primary"
 						>
-							<Input
-								id={`${formId}-allow-list`}
-								className="h-9 text-[13px]"
-								{...form.getFieldProps("toolAllowList")}
-								placeholder="tool1, tool2"
-								disabled={isDisabled}
-							/>
-						</Field>
-						<Field
-							label="Tool Deny List"
-							htmlFor={`${formId}-deny-list`}
-							description="Comma-separated names to block."
-						>
-							<Input
-								id={`${formId}-deny-list`}
-								className="h-9 text-[13px]"
-								{...form.getFieldProps("toolDenyList")}
-								placeholder="tool3, tool4"
-								disabled={isDisabled}
-							/>
-						</Field>
+							<div>
+								<h3 className="m-0 text-sm font-medium text-content-primary">
+									Behavior
+								</h3>
+								<p className="m-0 text-xs text-content-secondary">
+									Availability, model intent, and tool governance.
+								</p>
+							</div>
+							{showBehavior ? (
+								<ChevronDownIcon className="mt-0.5 h-4 w-4 shrink-0 text-content-secondary" />
+							) : (
+								<ChevronRightIcon className="mt-0.5 h-4 w-4 shrink-0 text-content-secondary" />
+							)}
+						</button>
+						{showBehavior && (
+							<div className="space-y-5 pt-3">
+								<div>
+									<Label
+										htmlFor={`${formId}-availability`}
+										className="mb-1 block text-sm font-medium text-content-primary"
+									>
+										Availability
+									</Label>
+									<Select
+										value={form.values.availability}
+										onValueChange={(v) => {
+											form.setFieldValue("availability", v);
+										}}
+										disabled={isDisabled}
+									>
+										<SelectTrigger
+											id={`${formId}-availability`}
+											className="h-9 text-[13px]"
+										>
+											<SelectValue />
+										</SelectTrigger>
+										<SelectContent>
+											{AVAILABILITY_OPTIONS.map((opt) => (
+												<SelectItem key={opt.value} value={opt.value}>
+													<div>
+														<span>{opt.label}</span>
+														<span className="ml-1.5 text-content-secondary">
+															— {opt.description}
+														</span>
+													</div>
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+								</div>
+
+								<div className="flex items-start justify-between gap-4">
+									<div className="min-w-0 space-y-1">
+										<Label
+											htmlFor={`${formId}-model-intent`}
+											className="text-sm font-medium text-content-primary"
+										>
+											Model intent
+										</Label>
+										<p className="m-0 text-xs text-content-secondary">
+											Require the model to describe each tool call's purpose in
+											natural language, shown as a status label in the UI.
+										</p>
+									</div>
+									<Switch
+										id={`${formId}-model-intent`}
+										checked={form.values.modelIntent}
+										onCheckedChange={(v) => {
+											form.setFieldValue("modelIntent", v);
+										}}
+										disabled={isDisabled}
+									/>
+								</div>
+
+								<div className="flex items-start justify-between gap-4">
+									<div className="min-w-0 space-y-1">
+										<Label
+											htmlFor={`${formId}-allow-in-plan-mode`}
+											className="text-sm font-medium text-content-primary"
+										>
+											Allow all tools from this MCP server in root plan mode
+										</Label>
+										<p className="m-0 text-xs text-content-secondary">
+											When enabled, the root plan-mode agent can call these tools
+											during planning. Workspace MCP and plan-mode subagents remain
+											restricted.
+										</p>
+									</div>
+									<Switch
+										id={`${formId}-allow-in-plan-mode`}
+										checked={form.values.allowInPlanMode}
+										onCheckedChange={(v) => {
+											form.setFieldValue("allowInPlanMode", v);
+										}}
+										disabled={isDisabled}
+									/>
+								</div>
+
+								<div className="grid items-start gap-5 sm:grid-cols-2">
+									{" "}
+									<Field
+										label="Tool Allow List"
+										htmlFor={`${formId}-allow-list`}
+										description="Comma-separated. Empty = all allowed."
+									>
+										<Input
+											id={`${formId}-allow-list`}
+											className="h-9 text-[13px]"
+											{...form.getFieldProps("toolAllowList")}
+											placeholder="tool1, tool2"
+											disabled={isDisabled}
+										/>
+									</Field>
+									<Field
+										label="Tool Deny List"
+										htmlFor={`${formId}-deny-list`}
+										description="Comma-separated names to block."
+									>
+										<Input
+											id={`${formId}-deny-list`}
+											className="h-9 text-[13px]"
+											{...form.getFieldProps("toolDenyList")}
+											placeholder="tool3, tool4"
+											disabled={isDisabled}
+										/>
+									</Field>
+								</div>
+							</div>
+						)}
 					</div>
 				</div>
 

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
@@ -17,7 +17,6 @@ import { Button } from "#/components/Button/Button";
 import { ExternalImage } from "#/components/ExternalImage/ExternalImage";
 import { IconField } from "#/components/IconField/IconField";
 import { Input } from "#/components/Input/Input";
-import { Label } from "#/components/Label/Label";
 import {
 	Select,
 	SelectContent,
@@ -549,7 +548,7 @@ const ServerForm: FC<ServerFormProps> = ({
 								</Select>
 
 								{form.values.authType === "oauth2" && (
-									<div className="space-y-4 rounded-lg border border-border bg-surface-secondary/30 p-4">
+									<div className="space-y-4 rounded-lg border border-solid border-border/70 bg-surface-secondary/30 p-4">
 										<p className="m-0 text-xs text-content-secondary">
 											Register a client with the external MCP server's OAuth2
 											provider and enter the credentials below. Coder will
@@ -639,7 +638,7 @@ const ServerForm: FC<ServerFormProps> = ({
 								)}
 
 								{form.values.authType === "api_key" && (
-									<div className="grid items-start gap-4 rounded-lg border border-border bg-surface-secondary/30 p-4 sm:grid-cols-2">
+									<div className="grid items-start gap-4 rounded-lg border border-solid border-border/70 bg-surface-secondary/30 p-4 sm:grid-cols-2">
 										<Field
 											label="Header Name"
 											htmlFor={`${formId}-apikey-header`}
@@ -683,7 +682,7 @@ const ServerForm: FC<ServerFormProps> = ({
 								)}
 
 								{form.values.authType === "custom_headers" && (
-									<div className="space-y-3 rounded-lg border border-border bg-surface-secondary/30 p-4">
+									<div className="space-y-3 rounded-lg border border-solid border-border/70 bg-surface-secondary/30 p-4">
 										{server?.has_custom_headers &&
 											!form.values.customHeadersTouched && (
 												<p className="m-0 text-xs text-content-secondary">
@@ -798,13 +797,7 @@ const ServerForm: FC<ServerFormProps> = ({
 						</button>
 						{showBehavior && (
 							<div className="space-y-5 pt-3">
-								<div>
-									<Label
-										htmlFor={`${formId}-availability`}
-										className="mb-1 block text-sm font-medium text-content-primary"
-									>
-										Availability
-									</Label>
+								<Field label="Availability" htmlFor={`${formId}-availability`}>
 									<Select
 										value={form.values.availability}
 										onValueChange={(v) => {
@@ -831,24 +824,21 @@ const ServerForm: FC<ServerFormProps> = ({
 											))}
 										</SelectContent>
 									</Select>
-								</div>
+								</Field>
 
 								<div className="flex items-start justify-between gap-4">
 									<div className="min-w-0 space-y-1">
-										<Label
-											htmlFor={`${formId}-model-intent`}
-											className="text-sm font-medium text-content-primary"
-										>
+										<p className="m-0 text-sm font-medium text-content-primary">
 											Model intent
-										</Label>
+										</p>
 										<p className="m-0 text-xs text-content-secondary">
 											Require the model to describe each tool call's purpose in
 											natural language, shown as a status label in the UI.
 										</p>
 									</div>
 									<Switch
-										id={`${formId}-model-intent`}
 										checked={form.values.modelIntent}
+										aria-label="Model intent"
 										onCheckedChange={(v) => {
 											form.setFieldValue("modelIntent", v);
 										}}
@@ -930,7 +920,14 @@ const ServerForm: FC<ServerFormProps> = ({
 								Delete
 							</Button>
 						) : (
-							<div />
+							<Button
+								variant="outline"
+								size="lg"
+								type="button"
+								onClick={onBack}
+							>
+								Cancel
+							</Button>
 						)}
 						<Button size="lg" type="submit" disabled={!canSubmit}>
 							{isSaving && <Spinner className="h-4 w-4" loading />}

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
@@ -4,15 +4,17 @@ import {
 	ChevronDownIcon,
 	ChevronRightIcon,
 	CircleIcon,
+	PencilIcon,
 	PlusIcon,
 	ServerIcon,
 	XIcon,
 } from "lucide-react";
 import { type FC, type ReactNode, useId, useState } from "react";
-import { useSearchParams } from "react-router";
+import { useLocation, useNavigate, useSearchParams } from "react-router";
 
 import type * as TypesGen from "#/api/typesGenerated";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
+import { Badge } from "#/components/Badge/Badge";
 import { Button } from "#/components/Button/Button";
 import { ExternalImage } from "#/components/ExternalImage/ExternalImage";
 import { IconField } from "#/components/IconField/IconField";
@@ -145,67 +147,84 @@ const ServerList: FC<ServerListProps> = ({
 	sectionLabel,
 	sectionDescription,
 	sectionBadge,
-}) => (
-	<>
-		<SectionHeader
-			label={sectionLabel ?? "MCP Servers"}
-			description={
-				sectionDescription ??
-				"Configure external MCP servers that provide additional tools for Coder Agents."
-			}
-			badge={sectionBadge}
-			action={
-				<Button size="sm" onClick={onAdd}>
-					<PlusIcon className="h-4 w-4" />
-					Add Server
-				</Button>
-			}
-		/>
+}) => {
+	const addButton = (
+		<Button size="sm" onClick={onAdd}>
+			<PlusIcon className="h-4 w-4" />
+			Add server
+		</Button>
+	);
 
-		{servers.length === 0 ? (
-			<div className="flex flex-col items-center justify-center gap-3 px-6 py-12 text-center">
-				<p className="m-0 text-sm text-content-secondary">
-					No MCP servers configured yet.
-				</p>
-			</div>
-		) : (
-			<div>
-				{servers.map((server, i) => (
-					<button
-						key={server.id}
-						type="button"
-						onClick={() => onSelect(server)}
-						aria-label={`${server.display_name} (${server.enabled ? "enabled" : "disabled"})`}
-						className={cn(
-							"flex w-full cursor-pointer items-center gap-3.5 bg-transparent border-0 p-0 px-3 py-3 text-left transition-colors hover:bg-surface-secondary/30",
-							i > 0 && "border-0 border-t border-solid border-border/50",
-						)}
-					>
-						<MCPServerIcon
-							iconUrl={server.icon_url}
-							name={server.display_name}
-							className="h-8 w-8"
-						/>
-						<div className="min-w-0 flex-1">
-							<span className="block truncate text-[15px] font-medium text-content-primary text-left">
-								{server.display_name}
-							</span>
-							<span className="block truncate text-xs text-content-secondary">
-								{server.url} · {authTypeLabel(server.auth_type)}
-							</span>
-						</div>
-						{server.enabled ? (
-							<CheckCircleIcon className="h-4 w-4 shrink-0 text-content-success" />
-						) : (
-							<CircleIcon className="h-4 w-4 shrink-0 text-content-secondary opacity-40" />
-						)}
-						<ChevronRightIcon className="h-5 w-5 shrink-0 text-content-secondary" />
-					</button>
-				))}
-			</div>
-		)}
-	</>
-);
+	return (
+		<>
+			<SectionHeader
+				label={sectionLabel ?? "MCP Servers"}
+				description={
+					sectionDescription ??
+					"Configure external MCP servers that provide additional tools for Coder Agents."
+				}
+				badge={sectionBadge}
+				action={addButton}
+			/>
+
+			{servers.length === 0 ? (
+				<div className="flex flex-col items-center justify-center gap-3 px-6 py-12 text-center">
+					<p className="m-0 text-sm text-content-secondary">
+						No MCP servers configured yet.
+					</p>
+					{addButton}
+				</div>
+			) : (
+				<div>
+					{servers.map((server, i) => (
+						<button
+							key={server.id}
+							type="button"
+							onClick={() => onSelect(server)}
+							aria-label={`${server.display_name} (${server.enabled ? "enabled" : "disabled"})`}
+							className={cn(
+								"flex w-full cursor-pointer items-center gap-3.5 bg-transparent border-0 p-0 px-3 py-3 text-left transition-colors hover:bg-surface-secondary/30",
+								i > 0 && "border-0 border-t border-solid border-border/50",
+							)}
+						>
+							<MCPServerIcon
+								iconUrl={server.icon_url}
+								name={server.display_name}
+								className="h-8 w-8 shrink-0"
+							/>
+							<div className="min-w-0 flex-1">
+								<span
+									className={cn(
+										"block truncate text-[15px] font-medium text-left",
+										server.enabled
+											? "text-content-primary"
+											: "text-content-secondary",
+									)}
+								>
+									{server.display_name}
+								</span>
+								<span className="block truncate text-xs text-content-secondary">
+									{server.url} · {authTypeLabel(server.auth_type)}
+								</span>
+							</div>
+							{!server.enabled && (
+								<Badge size="xs" variant="warning">
+									disabled
+								</Badge>
+							)}
+							{server.enabled ? (
+								<CheckCircleIcon className="h-4 w-4 shrink-0 text-content-success" />
+							) : (
+								<CircleIcon className="h-4 w-4 shrink-0 text-content-secondary opacity-40" />
+							)}
+							<ChevronRightIcon className="h-5 w-5 shrink-0 text-content-secondary" />
+						</button>
+					))}
+				</div>
+			)}
+		</>
+	);
+};
 
 // ── Server Form ────────────────────────────────────────────────
 
@@ -290,9 +309,9 @@ const ServerForm: FC<ServerFormProps> = ({
 	const formId = useId();
 	const isEditing = server !== null;
 	const [confirmingDelete, setConfirmingDelete] = useState(false);
-	const [showConnection, setShowConnection] = useState(true);
-	const [showAuth, setShowAuth] = useState(true);
-	const [showBehavior, setShowBehavior] = useState(true);
+	const [showConnection, setShowConnection] = useState(false);
+	const [showAuth, setShowAuth] = useState(false);
+	const [showBehavior, setShowBehavior] = useState(false);
 
 	const form = useFormik<MCPServerFormValues>({
 		initialValues: buildInitialValues(server),
@@ -361,46 +380,63 @@ const ServerForm: FC<ServerFormProps> = ({
 			<div className="flex items-center gap-3">
 				<MCPServerIcon
 					iconUrl={form.values.iconURL}
-					name={form.values.displayName || "New Server"}
+					name={form.values.displayName || "New server"}
 					className="h-8 w-8"
 				/>
-				<input
-					type="text"
-					value={form.values.displayName}
-					onChange={(e) => {
-						form.setFieldValue("displayName", e.target.value);
-						if (!form.values.slugTouched) {
-							form.setFieldValue("slug", slugify(e.target.value));
-						}
-					}}
-					disabled={isDisabled}
-					className="m-0 min-w-0 flex-1 border-0 bg-transparent p-0 text-lg font-medium text-content-primary outline-none placeholder:text-content-secondary focus:ring-0"
-					placeholder="Server display name"
-					aria-label="Display Name"
-				/>
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<span className="ml-auto inline-flex">
-							<Switch
-								checked={form.values.enabled}
-								onCheckedChange={(v) => {
-									form.setFieldValue("enabled", v);
-								}}
-								aria-label="Enabled"
-								disabled={isDisabled}
-							/>
+				<div className="inline-flex items-center gap-1">
+					<div className="relative inline-grid">
+						<span
+							className="invisible col-start-1 row-start-1 whitespace-pre text-lg font-medium"
+							aria-hidden="true"
+						>
+							{form.values.displayName || "Server display name"}
 						</span>
-					</TooltipTrigger>
-					<TooltipContent side="bottom">
-						{form.values.enabled ? "Disable" : "Enable"} this server
-					</TooltipContent>
-				</Tooltip>
+						<input
+							type="text"
+							value={form.values.displayName}
+							onChange={(e) => {
+								form.setFieldValue("displayName", e.target.value);
+								if (!form.values.slugTouched) {
+									form.setFieldValue("slug", slugify(e.target.value));
+								}
+							}}
+							disabled={isDisabled}
+							spellCheck={false}
+							className="col-start-1 row-start-1 m-0 min-w-0 border-0 bg-transparent p-0 text-lg font-medium text-content-primary outline-none placeholder:text-content-secondary focus:ring-0"
+							placeholder="Server display name"
+							aria-label="Display Name"
+						/>
+					</div>
+					<PencilIcon className="h-3.5 w-3.5 shrink-0 text-content-secondary" />
+				</div>
+				{isEditing && (
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<span className="ml-auto inline-flex">
+								<Switch
+									checked={form.values.enabled}
+									onCheckedChange={(v) => {
+										form.setFieldValue("enabled", v);
+									}}
+									aria-label="Enabled"
+									disabled={isDisabled}
+								/>
+							</span>
+						</TooltipTrigger>
+						<TooltipContent side="bottom">
+							{form.values.enabled
+								? "Disable this server. It will be hidden from agents."
+								: "Enable this server. It will be visible to agents."}
+						</TooltipContent>
+					</Tooltip>
+				)}
 			</div>
 			<hr className="my-4 border-0 border-t border-solid border-border" />
 			<form
 				id={formId}
 				onSubmit={form.handleSubmit}
 				className="flex flex-1 flex-col"
+				spellCheck={false}
 				autoComplete="off"
 			>
 				<div className="space-y-6">
@@ -426,8 +462,8 @@ const ServerForm: FC<ServerFormProps> = ({
 							)}
 						</button>
 						{showConnection && (
-							<div className="space-y-5 pt-3">
-								<div className="grid items-start gap-5 sm:grid-cols-2">
+							<div className="space-y-4 pt-3">
+								<div className="grid items-start gap-4 sm:grid-cols-2">
 									<Field label="Slug" htmlFor={`${formId}-slug`} required>
 										<Input
 											id={`${formId}-slug`}
@@ -524,7 +560,7 @@ const ServerForm: FC<ServerFormProps> = ({
 							)}
 						</button>
 						{showAuth && (
-							<div className="space-y-5 pt-3">
+							<div className="space-y-4 pt-3">
 								<Select
 									value={form.values.authType}
 									onValueChange={(v) => {
@@ -796,7 +832,7 @@ const ServerForm: FC<ServerFormProps> = ({
 							)}
 						</button>
 						{showBehavior && (
-							<div className="space-y-5 pt-3">
+							<div className="space-y-4 pt-3">
 								<Field label="Availability" htmlFor={`${formId}-availability`}>
 									<Select
 										value={form.values.availability}
@@ -846,31 +882,31 @@ const ServerForm: FC<ServerFormProps> = ({
 									/>
 								</div>
 
-								<div className="flex items-start justify-between gap-4">
-									<div className="min-w-0 space-y-1">
-										<Label
-											htmlFor={`${formId}-allow-in-plan-mode`}
+									<div className="flex items-start justify-between gap-4">
+										<div className="min-w-0 space-y-1">
+											<Label
+												htmlFor={`${formId}-allow-in-plan-mode`}
 											className="text-sm font-medium text-content-primary"
-										>
-											Allow all tools from this MCP server in root plan mode
-										</Label>
+											>
+												Allow all tools from this MCP server in root plan mode
+											</Label>
 										<p className="m-0 text-xs text-content-secondary">
-											When enabled, the root plan-mode agent can call these tools
+												When enabled, the root plan-mode agent can call these tools
 											during planning. Workspace MCP and plan-mode subagents remain
 											restricted.
-										</p>
-									</div>
+											</p>
+										</div>
 									<Switch
-										id={`${formId}-allow-in-plan-mode`}
+											id={`${formId}-allow-in-plan-mode`}
 										checked={form.values.allowInPlanMode}
 										onCheckedChange={(v) => {
-											form.setFieldValue("allowInPlanMode", v);
-										}}
+												form.setFieldValue("allowInPlanMode", v);
+											}}
 										disabled={isDisabled}
-									/>
-								</div>
+										/>
+									</div>
 
-								<div className="grid items-start gap-5 sm:grid-cols-2">
+									<div className="grid items-start gap-4 sm:grid-cols-2">
 									{" "}
 									<Field
 										label="Tool Allow List"
@@ -997,6 +1033,22 @@ export const MCPServerAdminPanel: FC<MCPServerAdminPanelProps> = ({
 }) => {
 	const [searchParams, setSearchParams] = useSearchParams();
 	const serverId = searchParams.get("server");
+	const navigate = useNavigate();
+	const location = useLocation();
+	// Whether the current form entry was pushed by an in-app click
+	// (as opposed to a direct-entry URL like a bookmark or shared link).
+	// When true, navigate(-1) is safe; otherwise we fall back to
+	// clearing params with replace to avoid leaving the app.
+	const canGoBack =
+		(location.state as { pushed?: boolean } | null)?.pushed === true;
+
+	const exitServerView = () => {
+		if (canGoBack) {
+			navigate(-1);
+		} else {
+			setSearchParams({}, { replace: true });
+		}
+	};
 
 	const servers = (serversData ?? [])
 		.slice()
@@ -1037,7 +1089,7 @@ export const MCPServerAdminPanel: FC<MCPServerAdminPanelProps> = ({
 				return;
 			}
 		}
-		setSearchParams({});
+		exitServerView();
 	};
 
 	const handleDelete = async (id: string) => {
@@ -1047,27 +1099,31 @@ export const MCPServerAdminPanel: FC<MCPServerAdminPanelProps> = ({
 			// Error surfaced via mutation error state.
 			return;
 		}
-		setSearchParams({});
+		exitServerView();
 	};
-
-	if (isLoadingServers) {
-		return (
-			<div className="flex items-center gap-1.5 text-xs text-content-secondary">
-				<Spinner className="h-4 w-4" loading />
-				Loading
-			</div>
-		);
-	}
 
 	return (
 		<div className={cn("flex min-h-full flex-col", className)}>
+			{isLoadingServers && (
+				<div className="flex items-center gap-1.5 text-xs text-content-secondary">
+					<Spinner className="h-4 w-4" loading />
+					Loading
+				</div>
+			)}
 			{/* Content */}
 			<div className="flex flex-1 flex-col gap-8">
 				{!isFormView ? (
 					<ServerList
 						servers={servers}
-						onSelect={(server) => setSearchParams({ server: server.id })}
-						onAdd={() => setSearchParams({ server: "new" })}
+						onSelect={(server) =>
+							setSearchParams(
+								{ server: server.id },
+								{ state: { pushed: true } },
+							)
+						}
+						onAdd={() =>
+							setSearchParams({ server: "new" }, { state: { pushed: true } })
+						}
 						sectionLabel={sectionLabel}
 						sectionDescription={sectionDescription}
 						sectionBadge={sectionBadge}
@@ -1080,7 +1136,7 @@ export const MCPServerAdminPanel: FC<MCPServerAdminPanelProps> = ({
 						isDeleting={isDeletingServer}
 						onSave={handleSave}
 						onDelete={handleDelete}
-						onBack={() => setSearchParams({})}
+						onBack={exitServerView}
 					/>
 				)}
 			</div>

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
@@ -149,16 +149,8 @@ const MCPServerIcon: FC<{
 
 // ── Icon picker ──────────────────────────────────────────────────
 
-// Lazy-loaded emoji picker keeps the main bundle lean. The emoji-mart
-// library takes several seconds on cold load, so we warm it up in an
-// sr-only node below while the form mounts.
 const EmojiPicker = lazy(() => import("#/components/IconField/EmojiPicker"));
 
-// A shadcn-styled icon picker that matches the surrounding form inputs.
-// Functionally equivalent to #/components/IconField/IconField (URL input +
-// preview + emoji/icon picker) but built on InputGroup + Popover instead
-// of the legacy MUI TextField wrapper, so it inherits the h-9 / border /
-// focus ring used everywhere else in this panel.
 interface IconPickerFieldProps {
 	id?: string;
 	value: string;
@@ -196,9 +188,7 @@ const IconPickerField: FC<IconPickerFieldProps> = ({
 						<ExternalImage
 							alt=""
 							src={value}
-							// Hide the broken-image glyph while the user is
-							// mid-typing a URL. Restore visibility only when a
-							// real bitmap loads.
+							// Hide the broken-image glyph while the URL is incomplete.
 							onError={(e) => {
 								e.currentTarget.style.display = "none";
 							}}
@@ -258,13 +248,6 @@ const ServerList: FC<ServerListProps> = ({
 	sectionDescription,
 	sectionBadge,
 }) => {
-	const addButton = (
-		<Button size="sm" onClick={onAdd}>
-			<PlusIcon className="h-4 w-4" />
-			Add server
-		</Button>
-	);
-
 	return (
 		<>
 			<SectionHeader
@@ -274,7 +257,12 @@ const ServerList: FC<ServerListProps> = ({
 					"Configure external MCP servers that provide additional tools for Coder Agents."
 				}
 				badge={sectionBadge}
-				action={addButton}
+				action={
+					<Button size="sm" onClick={onAdd}>
+						<PlusIcon className="h-4 w-4" />
+						Add server
+					</Button>
+				}
 			/>
 
 			{servers.length === 0 ? (
@@ -282,7 +270,10 @@ const ServerList: FC<ServerListProps> = ({
 					<p className="m-0 text-sm text-content-secondary">
 						No MCP servers configured yet.
 					</p>
-					{addButton}
+					<Button size="sm" onClick={onAdd} aria-label="Add your first server">
+						<PlusIcon className="h-4 w-4" />
+						Add your first server
+					</Button>
 				</div>
 			) : (
 				<div>
@@ -608,7 +599,7 @@ const ServerForm: FC<ServerFormProps> = ({
 										}}
 										disabled={isDisabled}
 									/>
-								</Field>{" "}
+								</Field>
 								<div className="grid items-start gap-4 sm:grid-cols-[1fr_auto]">
 									<Field label="Server URL" htmlFor={`${formId}-url`} required>
 										<Input
@@ -701,7 +692,6 @@ const ServerForm: FC<ServerFormProps> = ({
 											handle the per-user authorization flow.
 										</p>
 										<div className="grid items-start gap-4 sm:grid-cols-2">
-											{" "}
 											<Field label="Client ID" htmlFor={`${formId}-oauth-id`}>
 												<Input
 													id={`${formId}-oauth-id`}
@@ -992,32 +982,31 @@ const ServerForm: FC<ServerFormProps> = ({
 									/>
 								</div>
 
-									<div className="flex items-start justify-between gap-4">
-										<div className="min-w-0 space-y-1">
-											<Label
-												htmlFor={`${formId}-allow-in-plan-mode`}
-											className="text-sm font-medium text-content-primary"
+										<div className="flex items-start justify-between gap-4">
+											<div className="min-w-0 space-y-1">
+												<Label
+													htmlFor={`${formId}-allow-in-plan-mode`}
+												className="text-sm font-medium text-content-primary"
 											>
-												Allow all tools from this MCP server in root plan mode
-											</Label>
-										<p className="m-0 text-xs text-content-secondary">
-												When enabled, the root plan-mode agent can call these tools
-											during planning. Workspace MCP and plan-mode subagents remain
-											restricted.
+													Allow all tools from this MCP server in root plan mode
+												</Label>
+											<p className="m-0 text-xs text-content-secondary">
+													When enabled, the root plan-mode agent can call these tools
+													during planning. Workspace MCP and plan-mode subagents remain
+													restricted.
 											</p>
-										</div>
-									<Switch
-											id={`${formId}-allow-in-plan-mode`}
-										checked={form.values.allowInPlanMode}
-										onCheckedChange={(v) => {
-												form.setFieldValue("allowInPlanMode", v);
-											}}
-										disabled={isDisabled}
+											</div>
+										<Switch
+												id={`${formId}-allow-in-plan-mode`}
+											checked={form.values.allowInPlanMode}
+												onCheckedChange={(v) => {
+													form.setFieldValue("allowInPlanMode", v);
+												}}
+											disabled={isDisabled}
 										/>
-									</div>
+										</div>
 
-									<div className="grid items-start gap-4 sm:grid-cols-2">
-									{" "}
+										<div className="grid items-start gap-4 sm:grid-cols-2">
 									<Field
 										label="Tool Allow List"
 										htmlFor={`${formId}-allow-list`}
@@ -1090,7 +1079,7 @@ const ServerForm: FC<ServerFormProps> = ({
 					open={confirmingDelete}
 					onOpenChange={(open) => !open && setConfirmingDelete(false)}
 				/>
-			)}{" "}
+			)}
 		</div>
 	);
 };

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
@@ -454,6 +454,7 @@ const ServerForm: FC<ServerFormProps> = ({
 								</div>
 								<Field label="Icon">
 									<IconField
+										label=""
 										value={form.values.iconURL}
 										onChange={(e) => {
 											form.setFieldValue("iconURL", e.target.value);

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
@@ -24,6 +24,11 @@ import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { ChevronDownIcon as AnimatedChevronDownIcon } from "#/components/AnimatedIcons/ChevronDown";
 import { Badge } from "#/components/Badge/Badge";
 import { Button } from "#/components/Button/Button";
+import {
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+} from "#/components/Collapsible/Collapsible";
 import { ExternalImage } from "#/components/ExternalImage/ExternalImage";
 import { Input } from "#/components/Input/Input";
 import {
@@ -593,28 +598,29 @@ const ServerForm: FC<ServerFormProps> = ({
 					</div>
 
 					{/* ── Details section ── */}
-					<div className="border-0 border-t border-solid border-border pt-4">
-						<button
-							type="button"
-							onClick={() => setShowDetails((v) => !v)}
-							className="flex w-full cursor-pointer items-start justify-between border-0 bg-transparent p-0 text-left transition-colors hover:text-content-primary"
-						>
-							<div>
-								<h3 className="m-0 text-sm font-medium text-content-primary">
-									Details
-								</h3>
-								<p className="m-0 text-xs text-content-secondary">
-									Optional description and icon shown to users.
-								</p>
-							</div>
-							{showDetails ? (
-								<ChevronDownIcon className="mt-0.5 h-4 w-4 shrink-0 text-content-secondary" />
-							) : (
-								<ChevronRightIcon className="mt-0.5 h-4 w-4 shrink-0 text-content-secondary" />
-							)}
-						</button>
-						{showDetails && (
-							<div className="space-y-4 pt-3">
+					<Collapsible open={showDetails} onOpenChange={setShowDetails}>
+						<div className="border-0 border-t border-solid border-border pt-4">
+							<CollapsibleTrigger asChild>
+								<button
+									type="button"
+									className="flex w-full cursor-pointer items-start justify-between border-0 bg-transparent p-0 text-left transition-colors hover:text-content-primary"
+								>
+									<div>
+										<h3 className="m-0 text-sm font-medium text-content-primary">
+											Details
+										</h3>
+										<p className="m-0 text-xs text-content-secondary">
+											Optional description and icon shown to users.
+										</p>
+									</div>
+									{showDetails ? (
+										<ChevronDownIcon className="mt-0.5 h-4 w-4 shrink-0 text-content-secondary" />
+									) : (
+										<ChevronRightIcon className="mt-0.5 h-4 w-4 shrink-0 text-content-secondary" />
+									)}
+								</button>
+							</CollapsibleTrigger>
+							<CollapsibleContent className="space-y-4 pt-3">
 								<Field label="Description" htmlFor={`${formId}-desc`}>
 									<Input
 										id={`${formId}-desc`}
@@ -636,33 +642,34 @@ const ServerForm: FC<ServerFormProps> = ({
 										disabled={isDisabled}
 									/>
 								</Field>
-							</div>
-						)}
-					</div>
+							</CollapsibleContent>
+						</div>
+					</Collapsible>
 
 					{/* ── Authentication section ── */}
-					<div className="border-0 border-t border-solid border-border pt-4">
-						<button
-							type="button"
-								onClick={() => setShowAuth((v) => !v)}
-							className="flex w-full cursor-pointer items-start justify-between border-0 bg-transparent p-0 text-left transition-colors hover:text-content-primary"
-						>
-							<div>
-								<h3 className="m-0 text-sm font-medium text-content-primary">
-									Authentication
-								</h3>
-								<p className="m-0 text-xs text-content-secondary">
-									How users authenticate with this MCP server.
-								</p>
-							</div>
-							{showAuth ? (
-								<ChevronDownIcon className="mt-0.5 h-4 w-4 shrink-0 text-content-secondary" />
-							) : (
-								<ChevronRightIcon className="mt-0.5 h-4 w-4 shrink-0 text-content-secondary" />
-							)}
-						</button>
-						{showAuth && (
-							<div className="space-y-4 pt-3">
+					<Collapsible open={showAuth} onOpenChange={setShowAuth}>
+						<div className="border-0 border-t border-solid border-border pt-4">
+							<CollapsibleTrigger asChild>
+								<button
+									type="button"
+									className="flex w-full cursor-pointer items-start justify-between border-0 bg-transparent p-0 text-left transition-colors hover:text-content-primary"
+								>
+									<div>
+										<h3 className="m-0 text-sm font-medium text-content-primary">
+											Authentication
+										</h3>
+										<p className="m-0 text-xs text-content-secondary">
+											How users authenticate with this MCP server.
+										</p>
+									</div>
+									{showAuth ? (
+										<ChevronDownIcon className="mt-0.5 h-4 w-4 shrink-0 text-content-secondary" />
+									) : (
+										<ChevronRightIcon className="mt-0.5 h-4 w-4 shrink-0 text-content-secondary" />
+									)}
+								</button>
+							</CollapsibleTrigger>
+							<CollapsibleContent className="space-y-4 pt-3">
 								<Field label="Authentication method" htmlFor={`${formId}-auth`}>
 									<Select
 										value={form.values.authType}
@@ -909,32 +916,33 @@ const ServerForm: FC<ServerFormProps> = ({
 										</Button>
 									</div>
 								)}
-							</div>
-						)}
-					</div>
+							</CollapsibleContent>
+						</div>
+					</Collapsible>
 					{/* ── Behavior section ── */}
-					<div className="border-0 border-t border-solid border-border pt-4">
-						<button
-							type="button"
-							onClick={() => setShowBehavior((v) => !v)}
-							className="flex w-full cursor-pointer items-start justify-between border-0 bg-transparent p-0 text-left transition-colors hover:text-content-primary"
-						>
-							<div>
-								<h3 className="m-0 text-sm font-medium text-content-primary">
-									Behavior
-								</h3>
-								<p className="m-0 text-xs text-content-secondary">
-									Availability, model intent, and tool governance.
-								</p>
-							</div>
-							{showBehavior ? (
-								<ChevronDownIcon className="mt-0.5 h-4 w-4 shrink-0 text-content-secondary" />
-							) : (
-								<ChevronRightIcon className="mt-0.5 h-4 w-4 shrink-0 text-content-secondary" />
-							)}
-						</button>
-						{showBehavior && (
-							<div className="space-y-4 pt-3">
+					<Collapsible open={showBehavior} onOpenChange={setShowBehavior}>
+						<div className="border-0 border-t border-solid border-border pt-4">
+							<CollapsibleTrigger asChild>
+								<button
+									type="button"
+									className="flex w-full cursor-pointer items-start justify-between border-0 bg-transparent p-0 text-left transition-colors hover:text-content-primary"
+								>
+									<div>
+										<h3 className="m-0 text-sm font-medium text-content-primary">
+											Behavior
+										</h3>
+										<p className="m-0 text-xs text-content-secondary">
+											Availability, model intent, and tool governance.
+										</p>
+									</div>
+									{showBehavior ? (
+										<ChevronDownIcon className="mt-0.5 h-4 w-4 shrink-0 text-content-secondary" />
+									) : (
+										<ChevronRightIcon className="mt-0.5 h-4 w-4 shrink-0 text-content-secondary" />
+									)}
+								</button>
+							</CollapsibleTrigger>
+							<CollapsibleContent className="space-y-4 pt-3">
 								<Field label="Availability" htmlFor={`${formId}-availability`}>
 									<Select
 										value={form.values.availability}
@@ -1036,9 +1044,9 @@ const ServerForm: FC<ServerFormProps> = ({
 										/>
 									</Field>
 								</div>
-							</div>
-						)}
-					</div>
+							</CollapsibleContent>
+						</div>
+					</Collapsible>
 				</div>
 
 				{/* Footer — pushed to bottom, matches ProviderForm */}
@@ -1242,7 +1250,6 @@ export const MCPServerAdminPanel: FC<MCPServerAdminPanelProps> = ({
 				)}
 			</div>
 
-			{/* Errors — rendered at the bottom */}
 			{serversError && <ErrorAlert error={serversError} />}
 			{createError && <ErrorAlert error={createError} />}
 			{updateError && <ErrorAlert error={updateError} />}

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
@@ -9,16 +9,34 @@ import {
 	ServerIcon,
 	XIcon,
 } from "lucide-react";
-import { type FC, type ReactNode, useId, useState } from "react";
+import {
+	type FC,
+	lazy,
+	type ReactNode,
+	Suspense,
+	useId,
+	useState,
+} from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router";
 
 import type * as TypesGen from "#/api/typesGenerated";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
+import { ChevronDownIcon as AnimatedChevronDownIcon } from "#/components/AnimatedIcons/ChevronDown";
 import { Badge } from "#/components/Badge/Badge";
 import { Button } from "#/components/Button/Button";
 import { ExternalImage } from "#/components/ExternalImage/ExternalImage";
-import { IconField } from "#/components/IconField/IconField";
 import { Input } from "#/components/Input/Input";
+import {
+	InputGroup,
+	InputGroupAddon,
+	InputGroupInput,
+} from "#/components/InputGroup/InputGroup";
+import { Loader } from "#/components/Loader/Loader";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "#/components/Popover/Popover";
 import {
 	Select,
 	SelectContent,
@@ -126,6 +144,98 @@ const MCPServerIcon: FC<{
 		>
 			<ServerIcon className="h-3/5 w-3/5 text-content-secondary" />
 		</div>
+	);
+};
+
+// ── Icon picker ──────────────────────────────────────────────────
+
+// Lazy-loaded emoji picker keeps the main bundle lean. The emoji-mart
+// library takes several seconds on cold load, so we warm it up in an
+// sr-only node below while the form mounts.
+const EmojiPicker = lazy(() => import("#/components/IconField/EmojiPicker"));
+
+// A shadcn-styled icon picker that matches the surrounding form inputs.
+// Functionally equivalent to #/components/IconField/IconField (URL input +
+// preview + emoji/icon picker) but built on InputGroup + Popover instead
+// of the legacy MUI TextField wrapper, so it inherits the h-9 / border /
+// focus ring used everywhere else in this panel.
+interface IconPickerFieldProps {
+	id?: string;
+	value: string;
+	placeholder?: string;
+	disabled?: boolean;
+	onChange: (value: string) => void;
+	onPickEmoji: (value: string) => void;
+}
+
+const IconPickerField: FC<IconPickerFieldProps> = ({
+	id,
+	value,
+	placeholder,
+	disabled,
+	onChange,
+	onPickEmoji,
+}) => {
+	const [open, setOpen] = useState(false);
+	const hasIcon = value !== "";
+
+	return (
+		<InputGroup className="h-9">
+			<InputGroupInput
+				id={id}
+				value={value}
+				onChange={(e) => onChange(e.target.value)}
+				placeholder={placeholder}
+				disabled={disabled}
+				className="h-9 min-w-0 text-[13px] placeholder:text-content-disabled"
+				spellCheck={false}
+			/>
+			<InputGroupAddon align="inline-end" className="gap-1.5">
+				{hasIcon && (
+					<span className="flex h-5 w-5 items-center justify-center [&_img]:max-w-full [&_img]:object-contain">
+						<ExternalImage
+							alt=""
+							src={value}
+							// Hide the broken-image glyph while the user is
+							// mid-typing a URL. Restore visibility only when a
+							// real bitmap loads.
+							onError={(e) => {
+								e.currentTarget.style.display = "none";
+							}}
+							onLoad={(e) => {
+								e.currentTarget.style.display = "inline";
+							}}
+						/>
+					</span>
+				)}
+				<Popover open={open} onOpenChange={setOpen}>
+					<PopoverTrigger asChild>
+						<Button
+							type="button"
+							variant="subtle"
+							size="sm"
+							className="group h-7 gap-1"
+							disabled={disabled}
+							aria-label="Pick an emoji or icon"
+						>
+							Emoji
+							<AnimatedChevronDownIcon />
+						</Button>
+					</PopoverTrigger>
+					<PopoverContent side="bottom" align="end" className="w-min">
+						<Suspense fallback={<Loader />}>
+							<EmojiPicker
+								onEmojiSelect={(emoji) => {
+									const picked = emoji.src ?? `/emojis/${emoji.unified}.png`;
+									onPickEmoji(picked);
+									setOpen(false);
+								}}
+							/>
+						</Suspense>
+					</PopoverContent>
+				</Popover>
+			</InputGroupAddon>
+		</InputGroup>
 	);
 };
 
@@ -488,18 +598,17 @@ const ServerForm: FC<ServerFormProps> = ({
 									</Field>
 								</div>
 								<Field label="Icon">
-									<IconField
-										label=""
+									<IconPickerField
 										value={form.values.iconURL}
-										onChange={(e) => {
-											form.setFieldValue("iconURL", e.target.value);
+										onChange={(v) => {
+											form.setFieldValue("iconURL", v);
 										}}
-										onPickEmoji={(value) => {
-											form.setFieldValue("iconURL", value);
+										onPickEmoji={(v) => {
+											form.setFieldValue("iconURL", v);
 										}}
 										disabled={isDisabled}
 									/>
-								</Field>
+								</Field>{" "}
 								<div className="grid items-start gap-4 sm:grid-cols-[1fr_auto]">
 									<Field label="Server URL" htmlFor={`${formId}-url`} required>
 										<Input

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
@@ -452,16 +452,18 @@ const ServerForm: FC<ServerFormProps> = ({
 										/>
 									</Field>
 								</div>
-								<IconField
-									value={form.values.iconURL}
-									onChange={(e) => {
-										form.setFieldValue("iconURL", e.target.value);
-									}}
-									onPickEmoji={(value) => {
-										form.setFieldValue("iconURL", value);
-									}}
-									disabled={isDisabled}
-								/>
+								<Field label="Icon">
+									<IconField
+										value={form.values.iconURL}
+										onChange={(e) => {
+											form.setFieldValue("iconURL", e.target.value);
+										}}
+										onPickEmoji={(value) => {
+											form.setFieldValue("iconURL", value);
+										}}
+										disabled={isDisabled}
+									/>
+								</Field>
 								<div className="grid items-start gap-4 sm:grid-cols-[1fr_auto]">
 									<Field label="Server URL" htmlFor={`${formId}-url`} required>
 										<Input

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
@@ -405,57 +405,6 @@ const ServerForm: FC<ServerFormProps> = ({
 				autoComplete="off"
 			>
 				<div className="space-y-6">
-					{" "}
-					{/* ── Identity row: slug + description side by side ── */}
-					<div className="grid items-start gap-5 sm:grid-cols-2">
-						{" "}
-						<Field
-							label="Slug"
-							htmlFor={`${formId}-slug`}
-							required
-							description="URL-safe identifier."
-						>
-							<Input
-								id={`${formId}-slug`}
-								className="h-9 text-[13px]"
-								value={form.values.slug}
-								onChange={(e) => {
-									form.setFieldValue("slugTouched", true);
-									form.setFieldValue("slug", e.target.value);
-								}}
-								placeholder="e.g. sentry"
-								disabled={isDisabled}
-							/>
-						</Field>
-						<Field
-							label="Description"
-							htmlFor={`${formId}-desc`}
-							description="Brief summary of what this server provides."
-						>
-							<Input
-								id={`${formId}-desc`}
-								className="h-9 text-[13px]"
-								{...form.getFieldProps("description")}
-								placeholder="Optional description"
-								disabled={isDisabled}
-							/>
-						</Field>
-					</div>
-					<Field
-						label="Icon"
-						description="Pick an emoji or paste an image URL."
-					>
-						<IconField
-							value={form.values.iconURL}
-							onChange={(e) => {
-								form.setFieldValue("iconURL", e.target.value);
-							}}
-							onPickEmoji={(value) => {
-								form.setFieldValue("iconURL", value);
-							}}
-							disabled={isDisabled}
-						/>
-					</Field>
 					{/* ── Connection section ── */}
 					<div className="border-0 border-t border-solid border-border pt-4">
 						<button
@@ -468,7 +417,7 @@ const ServerForm: FC<ServerFormProps> = ({
 									Connection
 								</h3>
 								<p className="m-0 text-xs text-content-secondary">
-									Server endpoint and transport protocol.
+									Endpoint, identity, and transport settings.
 								</p>
 							</div>
 							{showConnection ? (
@@ -479,13 +428,44 @@ const ServerForm: FC<ServerFormProps> = ({
 						</button>
 						{showConnection && (
 							<div className="space-y-5 pt-3">
-								<div className="grid items-start gap-5 sm:grid-cols-[1fr_auto]">
-									<Field
-										label="Server URL"
-										htmlFor={`${formId}-url`}
-										required
-										description="The endpoint URL for this MCP server."
-									>
+								<div className="grid items-start gap-5 sm:grid-cols-2">
+									<Field label="Slug" htmlFor={`${formId}-slug`} required>
+										<Input
+											id={`${formId}-slug`}
+											className="h-9 text-[13px]"
+											value={form.values.slug}
+											onChange={(e) => {
+												form.setFieldValue("slugTouched", true);
+												form.setFieldValue("slug", e.target.value);
+											}}
+											placeholder="e.g. sentry"
+											disabled={isDisabled}
+										/>
+									</Field>
+									<Field label="Description" htmlFor={`${formId}-desc`}>
+										<Input
+											id={`${formId}-desc`}
+											className="h-9 text-[13px]"
+											{...form.getFieldProps("description")}
+											placeholder="Optional description"
+											disabled={isDisabled}
+										/>
+									</Field>
+								</div>
+								<Field label="Icon">
+									<IconField
+										value={form.values.iconURL}
+										onChange={(e) => {
+											form.setFieldValue("iconURL", e.target.value);
+										}}
+										onPickEmoji={(value) => {
+											form.setFieldValue("iconURL", value);
+										}}
+										disabled={isDisabled}
+									/>
+								</Field>
+								<div className="grid items-start gap-4 sm:grid-cols-[1fr_auto]">
+									<Field label="Server URL" htmlFor={`${formId}-url`} required>
 										<Input
 											id={`${formId}-url`}
 											className="h-9 text-[13px]"

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
@@ -410,7 +410,7 @@ const ServerForm: FC<ServerFormProps> = ({
 	const formId = useId();
 	const isEditing = server !== null;
 	const [confirmingDelete, setConfirmingDelete] = useState(false);
-	const [showConnection, setShowConnection] = useState(false);
+	const [showDetails, setShowDetails] = useState(false);
 	const [showAuth, setShowAuth] = useState(false);
 	const [showBehavior, setShowBehavior] = useState(false);
 
@@ -541,53 +541,89 @@ const ServerForm: FC<ServerFormProps> = ({
 				autoComplete="off"
 			>
 				<div className="space-y-6">
-					{/* ── Connection section ── */}
+					<div className="space-y-4">
+						<Field label="Slug" htmlFor={`${formId}-slug`} required>
+							<Input
+								id={`${formId}-slug`}
+								className="h-9 text-[13px]"
+								value={form.values.slug}
+								onChange={(e) => {
+									form.setFieldValue("slugTouched", true);
+									form.setFieldValue("slug", e.target.value);
+								}}
+								placeholder="e.g. sentry"
+								disabled={isDisabled}
+							/>
+						</Field>
+						<div className="grid items-start gap-4 sm:grid-cols-[1fr_auto]">
+							<Field label="Server URL" htmlFor={`${formId}-url`} required>
+								<Input
+									id={`${formId}-url`}
+									className="h-9 text-[13px]"
+									{...form.getFieldProps("url")}
+									placeholder="https://mcp.example.com/sse"
+									disabled={isDisabled}
+								/>
+							</Field>
+
+							<Field label="Transport" htmlFor={`${formId}-transport`}>
+								<Select
+									value={form.values.transport}
+									onValueChange={(v) => {
+										form.setFieldValue("transport", v);
+									}}
+									disabled={isDisabled}
+								>
+									<SelectTrigger
+										id={`${formId}-transport`}
+										className="h-9 min-w-[160px] text-[13px]"
+									>
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent>
+										{TRANSPORT_OPTIONS.map((opt) => (
+											<SelectItem key={opt.value} value={opt.value}>
+												{opt.label}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+							</Field>
+						</div>
+					</div>
+
+					{/* ── Details section ── */}
 					<div className="border-0 border-t border-solid border-border pt-4">
 						<button
 							type="button"
-							onClick={() => setShowConnection((v) => !v)}
+							onClick={() => setShowDetails((v) => !v)}
 							className="flex w-full cursor-pointer items-start justify-between border-0 bg-transparent p-0 text-left transition-colors hover:text-content-primary"
 						>
 							<div>
 								<h3 className="m-0 text-sm font-medium text-content-primary">
-									Connection
+									Details
 								</h3>
 								<p className="m-0 text-xs text-content-secondary">
-									Endpoint, identity, and transport settings.
+									Optional description and icon shown to users.
 								</p>
 							</div>
-							{showConnection ? (
+							{showDetails ? (
 								<ChevronDownIcon className="mt-0.5 h-4 w-4 shrink-0 text-content-secondary" />
 							) : (
 								<ChevronRightIcon className="mt-0.5 h-4 w-4 shrink-0 text-content-secondary" />
 							)}
 						</button>
-						{showConnection && (
+						{showDetails && (
 							<div className="space-y-4 pt-3">
-								<div className="grid items-start gap-4 sm:grid-cols-2">
-									<Field label="Slug" htmlFor={`${formId}-slug`} required>
-										<Input
-											id={`${formId}-slug`}
-											className="h-9 text-[13px]"
-											value={form.values.slug}
-											onChange={(e) => {
-												form.setFieldValue("slugTouched", true);
-												form.setFieldValue("slug", e.target.value);
-											}}
-											placeholder="e.g. sentry"
-											disabled={isDisabled}
-										/>
-									</Field>
-									<Field label="Description" htmlFor={`${formId}-desc`}>
-										<Input
-											id={`${formId}-desc`}
-											className="h-9 text-[13px]"
-											{...form.getFieldProps("description")}
-											placeholder="Optional description"
-											disabled={isDisabled}
-										/>
-									</Field>
-								</div>
+								<Field label="Description" htmlFor={`${formId}-desc`}>
+									<Input
+										id={`${formId}-desc`}
+										className="h-9 text-[13px]"
+										{...form.getFieldProps("description")}
+										placeholder="Optional description"
+										disabled={isDisabled}
+									/>
+								</Field>
 								<Field label="Icon">
 									<IconPickerField
 										value={form.values.iconURL}
@@ -600,45 +636,11 @@ const ServerForm: FC<ServerFormProps> = ({
 										disabled={isDisabled}
 									/>
 								</Field>
-								<div className="grid items-start gap-4 sm:grid-cols-[1fr_auto]">
-									<Field label="Server URL" htmlFor={`${formId}-url`} required>
-										<Input
-											id={`${formId}-url`}
-											className="h-9 text-[13px]"
-											{...form.getFieldProps("url")}
-											placeholder="https://mcp.example.com/sse"
-											disabled={isDisabled}
-										/>
-									</Field>
-
-									<Field label="Transport" htmlFor={`${formId}-transport`}>
-										<Select
-											value={form.values.transport}
-											onValueChange={(v) => {
-												form.setFieldValue("transport", v);
-											}}
-											disabled={isDisabled}
-										>
-											<SelectTrigger
-												id={`${formId}-transport`}
-												className="h-9 min-w-[160px] text-[13px]"
-											>
-												<SelectValue />
-											</SelectTrigger>
-											<SelectContent>
-												{TRANSPORT_OPTIONS.map((opt) => (
-													<SelectItem key={opt.value} value={opt.value}>
-														{opt.label}
-													</SelectItem>
-												))}
-											</SelectContent>
-										</Select>
-									</Field>
-								</div>
 							</div>
 						)}
 					</div>
-						{/* ── Authentication section ── */}
+
+					{/* ── Authentication section ── */}
 					<div className="border-0 border-t border-solid border-border pt-4">
 						<button
 							type="button"

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
@@ -1237,7 +1237,7 @@ export const MCPServerAdminPanel: FC<MCPServerAdminPanelProps> = ({
 						sectionDescription={sectionDescription}
 						sectionBadge={sectionBadge}
 					/>
-				) : (
+				) : isCreating || (!isLoadingServers && editingServer) ? (
 					<ServerForm
 						key={serverId}
 						server={isCreating ? null : editingServer}
@@ -1247,7 +1247,7 @@ export const MCPServerAdminPanel: FC<MCPServerAdminPanelProps> = ({
 						onDelete={handleDelete}
 						onBack={exitServerView}
 					/>
-				)}
+				) : null}
 			</div>
 
 			{serversError && <ErrorAlert error={serversError} />}

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
@@ -163,8 +163,10 @@ const ServerList: FC<ServerListProps> = ({
 		/>
 
 		{servers.length === 0 ? (
-			<div className="rounded-lg border border-dashed border-border bg-surface-primary p-6 text-center text-[13px] text-content-secondary">
-				No MCP servers configured yet. Add a server to get started.
+			<div className="flex flex-col items-center justify-center gap-3 px-6 py-12 text-center">
+				<p className="m-0 text-sm text-content-secondary">
+					No MCP servers configured yet.
+				</p>
 			</div>
 		) : (
 			<div>
@@ -873,6 +875,7 @@ const ServerForm: FC<ServerFormProps> = ({
 // ── Main Panel ─────────────────────────────────────────────────
 
 interface MCPServerAdminPanelProps {
+	className?: string;
 	sectionLabel?: string;
 	sectionDescription?: string;
 	sectionBadge?: ReactNode;
@@ -898,6 +901,7 @@ interface MCPServerAdminPanelProps {
 }
 
 export const MCPServerAdminPanel: FC<MCPServerAdminPanelProps> = ({
+	className,
 	sectionLabel,
 	sectionDescription,
 	sectionBadge,
@@ -970,32 +974,41 @@ export const MCPServerAdminPanel: FC<MCPServerAdminPanelProps> = ({
 	};
 
 	if (isLoadingServers) {
-		return <Spinner loading className="h-4 w-4" />;
+		return (
+			<div className="flex items-center gap-1.5 text-xs text-content-secondary">
+				<Spinner className="h-4 w-4" loading />
+				Loading
+			</div>
+		);
 	}
 
 	return (
-		<div className="flex min-h-full flex-col space-y-3">
-			{!isFormView ? (
-				<ServerList
-					servers={servers}
-					onSelect={(server) => setSearchParams({ server: server.id })}
-					onAdd={() => setSearchParams({ server: "new" })}
-					sectionLabel={sectionLabel}
-					sectionDescription={sectionDescription}
-					sectionBadge={sectionBadge}
-				/>
-			) : (
-				<ServerForm
-					key={serverId}
-					server={isCreating ? null : editingServer}
-					isSaving={isCreatingServer || isUpdatingServer}
-					isDeleting={isDeletingServer}
-					onSave={handleSave}
-					onDelete={handleDelete}
-					onBack={() => setSearchParams({})}
-				/>
-			)}
+		<div className={cn("flex min-h-full flex-col", className)}>
+			{/* Content */}
+			<div className="flex flex-1 flex-col gap-8">
+				{!isFormView ? (
+					<ServerList
+						servers={servers}
+						onSelect={(server) => setSearchParams({ server: server.id })}
+						onAdd={() => setSearchParams({ server: "new" })}
+						sectionLabel={sectionLabel}
+						sectionDescription={sectionDescription}
+						sectionBadge={sectionBadge}
+					/>
+				) : (
+					<ServerForm
+						key={serverId}
+						server={isCreating ? null : editingServer}
+						isSaving={isCreatingServer || isUpdatingServer}
+						isDeleting={isDeletingServer}
+						onSave={handleSave}
+						onDelete={handleDelete}
+						onBack={() => setSearchParams({})}
+					/>
+				)}
+			</div>
 
+			{/* Errors — rendered at the bottom */}
 			{serversError && <ErrorAlert error={serversError} />}
 			{createError && <ErrorAlert error={createError} />}
 			{updateError && <ErrorAlert error={updateError} />}

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
@@ -452,18 +452,16 @@ const ServerForm: FC<ServerFormProps> = ({
 										/>
 									</Field>
 								</div>
-								<Field label="Icon">
-									<IconField
-										value={form.values.iconURL}
-										onChange={(e) => {
-											form.setFieldValue("iconURL", e.target.value);
-										}}
-										onPickEmoji={(value) => {
-											form.setFieldValue("iconURL", value);
-										}}
-										disabled={isDisabled}
-									/>
-								</Field>
+								<IconField
+									value={form.values.iconURL}
+									onChange={(e) => {
+										form.setFieldValue("iconURL", e.target.value);
+									}}
+									onPickEmoji={(value) => {
+										form.setFieldValue("iconURL", value);
+									}}
+									disabled={isDisabled}
+								/>
 								<div className="grid items-start gap-4 sm:grid-cols-[1fr_auto]">
 									<Field label="Server URL" htmlFor={`${formId}-url`} required>
 										<Input

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
@@ -400,7 +400,7 @@ const ServerForm: FC<ServerFormProps> = ({
 				className="flex flex-1 flex-col"
 				autoComplete="off"
 			>
-				<div className="space-y-5">
+				<div className="space-y-6">
 					{" "}
 					{/* ── Identity row: slug + description side by side ── */}
 					<div className="grid items-start gap-5 sm:grid-cols-2">
@@ -453,7 +453,7 @@ const ServerForm: FC<ServerFormProps> = ({
 						/>
 					</Field>
 					{/* ── Connection row: URL + transport side by side ── */}
-					<hr className="!my-2 border-0 border-t border-solid border-border" />
+					<hr className="!my-0 border-0 border-t border-solid border-border" />
 					<div className="grid items-start gap-5 sm:grid-cols-[1fr_auto]">
 						<Field
 							label="Server URL"
@@ -495,7 +495,7 @@ const ServerForm: FC<ServerFormProps> = ({
 						</Field>
 					</div>
 					{/* ── Authentication ── */}
-					<hr className="!my-2 border-0 border-t border-solid border-border" />
+					<hr className="!my-0 border-0 border-t border-solid border-border" />
 					<Field
 						label="Authentication"
 						htmlFor={`${formId}-auth`}
@@ -731,7 +731,7 @@ const ServerForm: FC<ServerFormProps> = ({
 						</div>
 					)}
 					{/* ── Availability ── */}
-					<hr className="!my-2 border-0 border-t border-solid border-border" />
+					<hr className="!my-0 border-0 border-t border-solid border-border" />
 					<Field
 						label="Availability"
 						htmlFor={`${formId}-availability`}
@@ -765,11 +765,16 @@ const ServerForm: FC<ServerFormProps> = ({
 						</Select>
 					</Field>{" "}
 					{/* ── Tool governance row ── */}
-					<hr className="!my-2 border-0 border-t border-solid border-border" />
-					<div className="flex items-center justify-between">
-						<div>
-							<Label htmlFor={`${formId}-model-intent`}>Model intent</Label>
-							<p className="text-sm text-content-secondary">
+					<hr className="!my-0 border-0 border-t border-solid border-border" />
+					<div className="flex items-start justify-between gap-4">
+						<div className="min-w-0 space-y-1">
+							<Label
+								htmlFor={`${formId}-model-intent`}
+								className="text-sm font-medium text-content-primary"
+							>
+								Model intent
+							</Label>
+							<p className="m-0 text-xs text-content-secondary">
 								Require the model to describe each tool call's purpose in
 								natural language, shown as a status label in the UI.
 							</p>
@@ -835,7 +840,7 @@ const ServerForm: FC<ServerFormProps> = ({
 				</div>
 
 				{/* Footer — pushed to bottom, matches ProviderForm */}
-				<div className="mt-auto pt-6">
+				<div className="mt-auto py-6">
 					<hr className="mb-4 border-0 border-t border-solid border-border" />
 					<div className="flex items-center justify-between">
 						{isEditing ? (

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
@@ -9,16 +9,34 @@ import {
 	ServerIcon,
 	XIcon,
 } from "lucide-react";
-import { type FC, type ReactNode, useId, useState } from "react";
+import {
+	type FC,
+	lazy,
+	type ReactNode,
+	Suspense,
+	useId,
+	useState,
+} from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router";
 
 import type * as TypesGen from "#/api/typesGenerated";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
+import { ChevronDownIcon as AnimatedChevronDownIcon } from "#/components/AnimatedIcons/ChevronDown";
 import { Badge } from "#/components/Badge/Badge";
 import { Button } from "#/components/Button/Button";
 import { ExternalImage } from "#/components/ExternalImage/ExternalImage";
-import { IconField } from "#/components/IconField/IconField";
 import { Input } from "#/components/Input/Input";
+import {
+	InputGroup,
+	InputGroupAddon,
+	InputGroupInput,
+} from "#/components/InputGroup/InputGroup";
+import { Loader } from "#/components/Loader/Loader";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "#/components/Popover/Popover";
 import {
 	Select,
 	SelectContent,
@@ -126,6 +144,98 @@ const MCPServerIcon: FC<{
 		>
 			<ServerIcon className="h-3/5 w-3/5 text-content-secondary" />
 		</div>
+	);
+};
+
+// ── Icon picker ──────────────────────────────────────────────────
+
+// Lazy-loaded emoji picker keeps the main bundle lean. The emoji-mart
+// library takes several seconds on cold load, so we warm it up in an
+// sr-only node below while the form mounts.
+const EmojiPicker = lazy(() => import("#/components/IconField/EmojiPicker"));
+
+// A shadcn-styled icon picker that matches the surrounding form inputs.
+// Functionally equivalent to #/components/IconField/IconField (URL input +
+// preview + emoji/icon picker) but built on InputGroup + Popover instead
+// of the legacy MUI TextField wrapper, so it inherits the h-9 / border /
+// focus ring used everywhere else in this panel.
+interface IconPickerFieldProps {
+	id?: string;
+	value: string;
+	placeholder?: string;
+	disabled?: boolean;
+	onChange: (value: string) => void;
+	onPickEmoji: (value: string) => void;
+}
+
+const IconPickerField: FC<IconPickerFieldProps> = ({
+	id,
+	value,
+	placeholder,
+	disabled,
+	onChange,
+	onPickEmoji,
+}) => {
+	const [open, setOpen] = useState(false);
+	const hasIcon = value !== "";
+
+	return (
+		<InputGroup className="h-9">
+			<InputGroupInput
+				id={id}
+				value={value}
+				onChange={(e) => onChange(e.target.value)}
+				placeholder={placeholder}
+				disabled={disabled}
+				className="h-9 min-w-0 text-[13px] placeholder:text-content-disabled"
+				spellCheck={false}
+			/>
+			<InputGroupAddon align="inline-end" className="gap-1.5">
+				{hasIcon && (
+					<span className="flex h-5 w-5 items-center justify-center [&_img]:max-w-full [&_img]:object-contain">
+						<ExternalImage
+							alt=""
+							src={value}
+							// Hide the broken-image glyph while the user is
+							// mid-typing a URL. Restore visibility only when a
+							// real bitmap loads.
+							onError={(e) => {
+								e.currentTarget.style.display = "none";
+							}}
+							onLoad={(e) => {
+								e.currentTarget.style.display = "inline";
+							}}
+						/>
+					</span>
+				)}
+				<Popover open={open} onOpenChange={setOpen}>
+					<PopoverTrigger asChild>
+						<Button
+							type="button"
+							variant="subtle"
+							size="sm"
+							className="group h-7 gap-1"
+							disabled={disabled}
+							aria-label="Pick an emoji or icon"
+						>
+							Emoji
+							<AnimatedChevronDownIcon />
+						</Button>
+					</PopoverTrigger>
+					<PopoverContent side="bottom" align="end" className="w-min">
+						<Suspense fallback={<Loader />}>
+							<EmojiPicker
+								onEmojiSelect={(emoji) => {
+									const picked = emoji.src ?? `/emojis/${emoji.unified}.png`;
+									onPickEmoji(picked);
+									setOpen(false);
+								}}
+							/>
+						</Suspense>
+					</PopoverContent>
+				</Popover>
+			</InputGroupAddon>
+		</InputGroup>
 	);
 };
 
@@ -485,18 +595,17 @@ const ServerForm: FC<ServerFormProps> = ({
 									</Field>
 								</div>
 								<Field label="Icon">
-									<IconField
-										label=""
+									<IconPickerField
 										value={form.values.iconURL}
-										onChange={(e) => {
-											form.setFieldValue("iconURL", e.target.value);
+										onChange={(v) => {
+											form.setFieldValue("iconURL", v);
 										}}
-										onPickEmoji={(value) => {
-											form.setFieldValue("iconURL", value);
+										onPickEmoji={(v) => {
+											form.setFieldValue("iconURL", v);
 										}}
 										disabled={isDisabled}
 									/>
-								</Field>
+								</Field>{" "}
 								<div className="grid items-start gap-4 sm:grid-cols-[1fr_auto]">
 									<Field label="Server URL" htmlFor={`${formId}-url`} required>
 										<Input

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
@@ -163,8 +163,10 @@ const ServerList: FC<ServerListProps> = ({
 		/>
 
 		{servers.length === 0 ? (
-			<div className="rounded-lg border border-dashed border-border bg-surface-primary p-6 text-center text-[13px] text-content-secondary">
-				No MCP servers configured yet. Add a server to get started.
+			<div className="flex flex-col items-center justify-center gap-3 px-6 py-12 text-center">
+				<p className="m-0 text-sm text-content-secondary">
+					No MCP servers configured yet.
+				</p>
 			</div>
 		) : (
 			<div>
@@ -850,6 +852,7 @@ const ServerForm: FC<ServerFormProps> = ({
 // ── Main Panel ─────────────────────────────────────────────────
 
 interface MCPServerAdminPanelProps {
+	className?: string;
 	sectionLabel?: string;
 	sectionDescription?: string;
 	sectionBadge?: ReactNode;
@@ -875,6 +878,7 @@ interface MCPServerAdminPanelProps {
 }
 
 export const MCPServerAdminPanel: FC<MCPServerAdminPanelProps> = ({
+	className,
 	sectionLabel,
 	sectionDescription,
 	sectionBadge,
@@ -947,32 +951,41 @@ export const MCPServerAdminPanel: FC<MCPServerAdminPanelProps> = ({
 	};
 
 	if (isLoadingServers) {
-		return <Spinner loading className="h-4 w-4" />;
+		return (
+			<div className="flex items-center gap-1.5 text-xs text-content-secondary">
+				<Spinner className="h-4 w-4" loading />
+				Loading
+			</div>
+		);
 	}
 
 	return (
-		<div className="flex min-h-full flex-col space-y-3">
-			{!isFormView ? (
-				<ServerList
-					servers={servers}
-					onSelect={(server) => setSearchParams({ server: server.id })}
-					onAdd={() => setSearchParams({ server: "new" })}
-					sectionLabel={sectionLabel}
-					sectionDescription={sectionDescription}
-					sectionBadge={sectionBadge}
-				/>
-			) : (
-				<ServerForm
-					key={serverId}
-					server={isCreating ? null : editingServer}
-					isSaving={isCreatingServer || isUpdatingServer}
-					isDeleting={isDeletingServer}
-					onSave={handleSave}
-					onDelete={handleDelete}
-					onBack={() => setSearchParams({})}
-				/>
-			)}
+		<div className={cn("flex min-h-full flex-col", className)}>
+			{/* Content */}
+			<div className="flex flex-1 flex-col gap-8">
+				{!isFormView ? (
+					<ServerList
+						servers={servers}
+						onSelect={(server) => setSearchParams({ server: server.id })}
+						onAdd={() => setSearchParams({ server: "new" })}
+						sectionLabel={sectionLabel}
+						sectionDescription={sectionDescription}
+						sectionBadge={sectionBadge}
+					/>
+				) : (
+					<ServerForm
+						key={serverId}
+						server={isCreating ? null : editingServer}
+						isSaving={isCreatingServer || isUpdatingServer}
+						isDeleting={isDeletingServer}
+						onSave={handleSave}
+						onDelete={handleDelete}
+						onBack={() => setSearchParams({})}
+					/>
+				)}
+			</div>
 
+			{/* Errors — rendered at the bottom */}
 			{serversError && <ErrorAlert error={serversError} />}
 			{createError && <ErrorAlert error={createError} />}
 			{updateError && <ErrorAlert error={updateError} />}

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
@@ -17,7 +17,6 @@ import { Button } from "#/components/Button/Button";
 import { ExternalImage } from "#/components/ExternalImage/ExternalImage";
 import { IconField } from "#/components/IconField/IconField";
 import { Input } from "#/components/Input/Input";
-import { Label } from "#/components/Label/Label";
 import {
 	Select,
 	SelectContent,
@@ -546,7 +545,7 @@ const ServerForm: FC<ServerFormProps> = ({
 								</Select>
 
 								{form.values.authType === "oauth2" && (
-									<div className="space-y-4 rounded-lg border border-border bg-surface-secondary/30 p-4">
+									<div className="space-y-4 rounded-lg border border-solid border-border/70 bg-surface-secondary/30 p-4">
 										<p className="m-0 text-xs text-content-secondary">
 											Register a client with the external MCP server's OAuth2
 											provider and enter the credentials below. Coder will
@@ -636,7 +635,7 @@ const ServerForm: FC<ServerFormProps> = ({
 								)}
 
 								{form.values.authType === "api_key" && (
-									<div className="grid items-start gap-4 rounded-lg border border-border bg-surface-secondary/30 p-4 sm:grid-cols-2">
+									<div className="grid items-start gap-4 rounded-lg border border-solid border-border/70 bg-surface-secondary/30 p-4 sm:grid-cols-2">
 										<Field
 											label="Header Name"
 											htmlFor={`${formId}-apikey-header`}
@@ -680,7 +679,7 @@ const ServerForm: FC<ServerFormProps> = ({
 								)}
 
 								{form.values.authType === "custom_headers" && (
-									<div className="space-y-3 rounded-lg border border-border bg-surface-secondary/30 p-4">
+									<div className="space-y-3 rounded-lg border border-solid border-border/70 bg-surface-secondary/30 p-4">
 										{server?.has_custom_headers &&
 											!form.values.customHeadersTouched && (
 												<p className="m-0 text-xs text-content-secondary">
@@ -795,13 +794,7 @@ const ServerForm: FC<ServerFormProps> = ({
 						</button>
 						{showBehavior && (
 							<div className="space-y-5 pt-3">
-								<div>
-									<Label
-										htmlFor={`${formId}-availability`}
-										className="mb-1 block text-sm font-medium text-content-primary"
-									>
-										Availability
-									</Label>
+								<Field label="Availability" htmlFor={`${formId}-availability`}>
 									<Select
 										value={form.values.availability}
 										onValueChange={(v) => {
@@ -828,24 +821,21 @@ const ServerForm: FC<ServerFormProps> = ({
 											))}
 										</SelectContent>
 									</Select>
-								</div>
+								</Field>
 
 								<div className="flex items-start justify-between gap-4">
 									<div className="min-w-0 space-y-1">
-										<Label
-											htmlFor={`${formId}-model-intent`}
-											className="text-sm font-medium text-content-primary"
-										>
+										<p className="m-0 text-sm font-medium text-content-primary">
 											Model intent
-										</Label>
+										</p>
 										<p className="m-0 text-xs text-content-secondary">
 											Require the model to describe each tool call's purpose in
 											natural language, shown as a status label in the UI.
 										</p>
 									</div>
 									<Switch
-										id={`${formId}-model-intent`}
 										checked={form.values.modelIntent}
+										aria-label="Model intent"
 										onCheckedChange={(v) => {
 											form.setFieldValue("modelIntent", v);
 										}}
@@ -903,7 +893,14 @@ const ServerForm: FC<ServerFormProps> = ({
 								Delete
 							</Button>
 						) : (
-							<div />
+							<Button
+								variant="outline"
+								size="lg"
+								type="button"
+								onClick={onBack}
+							>
+								Cancel
+							</Button>
 						)}
 						<Button size="lg" type="submit" disabled={!canSubmit}>
 							{isSaving && <Spinner className="h-4 w-4" loading />}

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
@@ -4,15 +4,17 @@ import {
 	ChevronDownIcon,
 	ChevronRightIcon,
 	CircleIcon,
+	PencilIcon,
 	PlusIcon,
 	ServerIcon,
 	XIcon,
 } from "lucide-react";
 import { type FC, type ReactNode, useId, useState } from "react";
-import { useSearchParams } from "react-router";
+import { useLocation, useNavigate, useSearchParams } from "react-router";
 
 import type * as TypesGen from "#/api/typesGenerated";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
+import { Badge } from "#/components/Badge/Badge";
 import { Button } from "#/components/Button/Button";
 import { ExternalImage } from "#/components/ExternalImage/ExternalImage";
 import { IconField } from "#/components/IconField/IconField";
@@ -145,67 +147,84 @@ const ServerList: FC<ServerListProps> = ({
 	sectionLabel,
 	sectionDescription,
 	sectionBadge,
-}) => (
-	<>
-		<SectionHeader
-			label={sectionLabel ?? "MCP Servers"}
-			description={
-				sectionDescription ??
-				"Configure external MCP servers that provide additional tools for Coder Agents."
-			}
-			badge={sectionBadge}
-			action={
-				<Button size="sm" onClick={onAdd}>
-					<PlusIcon className="h-4 w-4" />
-					Add Server
-				</Button>
-			}
-		/>
+}) => {
+	const addButton = (
+		<Button size="sm" onClick={onAdd}>
+			<PlusIcon className="h-4 w-4" />
+			Add server
+		</Button>
+	);
 
-		{servers.length === 0 ? (
-			<div className="flex flex-col items-center justify-center gap-3 px-6 py-12 text-center">
-				<p className="m-0 text-sm text-content-secondary">
-					No MCP servers configured yet.
-				</p>
-			</div>
-		) : (
-			<div>
-				{servers.map((server, i) => (
-					<button
-						key={server.id}
-						type="button"
-						onClick={() => onSelect(server)}
-						aria-label={`${server.display_name} (${server.enabled ? "enabled" : "disabled"})`}
-						className={cn(
-							"flex w-full cursor-pointer items-center gap-3.5 bg-transparent border-0 p-0 px-3 py-3 text-left transition-colors hover:bg-surface-secondary/30",
-							i > 0 && "border-0 border-t border-solid border-border/50",
-						)}
-					>
-						<MCPServerIcon
-							iconUrl={server.icon_url}
-							name={server.display_name}
-							className="h-8 w-8"
-						/>
-						<div className="min-w-0 flex-1">
-							<span className="block truncate text-[15px] font-medium text-content-primary text-left">
-								{server.display_name}
-							</span>
-							<span className="block truncate text-xs text-content-secondary">
-								{server.url} · {authTypeLabel(server.auth_type)}
-							</span>
-						</div>
-						{server.enabled ? (
-							<CheckCircleIcon className="h-4 w-4 shrink-0 text-content-success" />
-						) : (
-							<CircleIcon className="h-4 w-4 shrink-0 text-content-secondary opacity-40" />
-						)}
-						<ChevronRightIcon className="h-5 w-5 shrink-0 text-content-secondary" />
-					</button>
-				))}
-			</div>
-		)}
-	</>
-);
+	return (
+		<>
+			<SectionHeader
+				label={sectionLabel ?? "MCP Servers"}
+				description={
+					sectionDescription ??
+					"Configure external MCP servers that provide additional tools for Coder Agents."
+				}
+				badge={sectionBadge}
+				action={addButton}
+			/>
+
+			{servers.length === 0 ? (
+				<div className="flex flex-col items-center justify-center gap-3 px-6 py-12 text-center">
+					<p className="m-0 text-sm text-content-secondary">
+						No MCP servers configured yet.
+					</p>
+					{addButton}
+				</div>
+			) : (
+				<div>
+					{servers.map((server, i) => (
+						<button
+							key={server.id}
+							type="button"
+							onClick={() => onSelect(server)}
+							aria-label={`${server.display_name} (${server.enabled ? "enabled" : "disabled"})`}
+							className={cn(
+								"flex w-full cursor-pointer items-center gap-3.5 bg-transparent border-0 p-0 px-3 py-3 text-left transition-colors hover:bg-surface-secondary/30",
+								i > 0 && "border-0 border-t border-solid border-border/50",
+							)}
+						>
+							<MCPServerIcon
+								iconUrl={server.icon_url}
+								name={server.display_name}
+								className="h-8 w-8 shrink-0"
+							/>
+							<div className="min-w-0 flex-1">
+								<span
+									className={cn(
+										"block truncate text-[15px] font-medium text-left",
+										server.enabled
+											? "text-content-primary"
+											: "text-content-secondary",
+									)}
+								>
+									{server.display_name}
+								</span>
+								<span className="block truncate text-xs text-content-secondary">
+									{server.url} · {authTypeLabel(server.auth_type)}
+								</span>
+							</div>
+							{!server.enabled && (
+								<Badge size="xs" variant="warning">
+									disabled
+								</Badge>
+							)}
+							{server.enabled ? (
+								<CheckCircleIcon className="h-4 w-4 shrink-0 text-content-success" />
+							) : (
+								<CircleIcon className="h-4 w-4 shrink-0 text-content-secondary opacity-40" />
+							)}
+							<ChevronRightIcon className="h-5 w-5 shrink-0 text-content-secondary" />
+						</button>
+					))}
+				</div>
+			)}
+		</>
+	);
+};
 
 // ── Server Form ────────────────────────────────────────────────
 
@@ -288,9 +307,9 @@ const ServerForm: FC<ServerFormProps> = ({
 	const formId = useId();
 	const isEditing = server !== null;
 	const [confirmingDelete, setConfirmingDelete] = useState(false);
-	const [showConnection, setShowConnection] = useState(true);
-	const [showAuth, setShowAuth] = useState(true);
-	const [showBehavior, setShowBehavior] = useState(true);
+	const [showConnection, setShowConnection] = useState(false);
+	const [showAuth, setShowAuth] = useState(false);
+	const [showBehavior, setShowBehavior] = useState(false);
 
 	const form = useFormik<MCPServerFormValues>({
 		initialValues: buildInitialValues(server),
@@ -358,46 +377,63 @@ const ServerForm: FC<ServerFormProps> = ({
 			<div className="flex items-center gap-3">
 				<MCPServerIcon
 					iconUrl={form.values.iconURL}
-					name={form.values.displayName || "New Server"}
+					name={form.values.displayName || "New server"}
 					className="h-8 w-8"
 				/>
-				<input
-					type="text"
-					value={form.values.displayName}
-					onChange={(e) => {
-						form.setFieldValue("displayName", e.target.value);
-						if (!form.values.slugTouched) {
-							form.setFieldValue("slug", slugify(e.target.value));
-						}
-					}}
-					disabled={isDisabled}
-					className="m-0 min-w-0 flex-1 border-0 bg-transparent p-0 text-lg font-medium text-content-primary outline-none placeholder:text-content-secondary focus:ring-0"
-					placeholder="Server display name"
-					aria-label="Display Name"
-				/>
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<span className="ml-auto inline-flex">
-							<Switch
-								checked={form.values.enabled}
-								onCheckedChange={(v) => {
-									form.setFieldValue("enabled", v);
-								}}
-								aria-label="Enabled"
-								disabled={isDisabled}
-							/>
+				<div className="inline-flex items-center gap-1">
+					<div className="relative inline-grid">
+						<span
+							className="invisible col-start-1 row-start-1 whitespace-pre text-lg font-medium"
+							aria-hidden="true"
+						>
+							{form.values.displayName || "Server display name"}
 						</span>
-					</TooltipTrigger>
-					<TooltipContent side="bottom">
-						{form.values.enabled ? "Disable" : "Enable"} this server
-					</TooltipContent>
-				</Tooltip>
+						<input
+							type="text"
+							value={form.values.displayName}
+							onChange={(e) => {
+								form.setFieldValue("displayName", e.target.value);
+								if (!form.values.slugTouched) {
+									form.setFieldValue("slug", slugify(e.target.value));
+								}
+							}}
+							disabled={isDisabled}
+							spellCheck={false}
+							className="col-start-1 row-start-1 m-0 min-w-0 border-0 bg-transparent p-0 text-lg font-medium text-content-primary outline-none placeholder:text-content-secondary focus:ring-0"
+							placeholder="Server display name"
+							aria-label="Display Name"
+						/>
+					</div>
+					<PencilIcon className="h-3.5 w-3.5 shrink-0 text-content-secondary" />
+				</div>
+				{isEditing && (
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<span className="ml-auto inline-flex">
+								<Switch
+									checked={form.values.enabled}
+									onCheckedChange={(v) => {
+										form.setFieldValue("enabled", v);
+									}}
+									aria-label="Enabled"
+									disabled={isDisabled}
+								/>
+							</span>
+						</TooltipTrigger>
+						<TooltipContent side="bottom">
+							{form.values.enabled
+								? "Disable this server. It will be hidden from agents."
+								: "Enable this server. It will be visible to agents."}
+						</TooltipContent>
+					</Tooltip>
+				)}
 			</div>
 			<hr className="my-4 border-0 border-t border-solid border-border" />
 			<form
 				id={formId}
 				onSubmit={form.handleSubmit}
 				className="flex flex-1 flex-col"
+				spellCheck={false}
 				autoComplete="off"
 			>
 				<div className="space-y-6">
@@ -423,8 +459,8 @@ const ServerForm: FC<ServerFormProps> = ({
 							)}
 						</button>
 						{showConnection && (
-							<div className="space-y-5 pt-3">
-								<div className="grid items-start gap-5 sm:grid-cols-2">
+							<div className="space-y-4 pt-3">
+								<div className="grid items-start gap-4 sm:grid-cols-2">
 									<Field label="Slug" htmlFor={`${formId}-slug`} required>
 										<Input
 											id={`${formId}-slug`}
@@ -521,7 +557,7 @@ const ServerForm: FC<ServerFormProps> = ({
 							)}
 						</button>
 						{showAuth && (
-							<div className="space-y-5 pt-3">
+							<div className="space-y-4 pt-3">
 								<Select
 									value={form.values.authType}
 									onValueChange={(v) => {
@@ -793,7 +829,7 @@ const ServerForm: FC<ServerFormProps> = ({
 							)}
 						</button>
 						{showBehavior && (
-							<div className="space-y-5 pt-3">
+							<div className="space-y-4 pt-3">
 								<Field label="Availability" htmlFor={`${formId}-availability`}>
 									<Select
 										value={form.values.availability}
@@ -843,7 +879,7 @@ const ServerForm: FC<ServerFormProps> = ({
 									/>
 								</div>
 
-								<div className="grid items-start gap-5 sm:grid-cols-2">
+								<div className="grid items-start gap-4 sm:grid-cols-2">
 									{" "}
 									<Field
 										label="Tool Allow List"
@@ -970,6 +1006,22 @@ export const MCPServerAdminPanel: FC<MCPServerAdminPanelProps> = ({
 }) => {
 	const [searchParams, setSearchParams] = useSearchParams();
 	const serverId = searchParams.get("server");
+	const navigate = useNavigate();
+	const location = useLocation();
+	// Whether the current form entry was pushed by an in-app click
+	// (as opposed to a direct-entry URL like a bookmark or shared link).
+	// When true, navigate(-1) is safe; otherwise we fall back to
+	// clearing params with replace to avoid leaving the app.
+	const canGoBack =
+		(location.state as { pushed?: boolean } | null)?.pushed === true;
+
+	const exitServerView = () => {
+		if (canGoBack) {
+			navigate(-1);
+		} else {
+			setSearchParams({}, { replace: true });
+		}
+	};
 
 	const servers = (serversData ?? [])
 		.slice()
@@ -1010,7 +1062,7 @@ export const MCPServerAdminPanel: FC<MCPServerAdminPanelProps> = ({
 				return;
 			}
 		}
-		setSearchParams({});
+		exitServerView();
 	};
 
 	const handleDelete = async (id: string) => {
@@ -1020,27 +1072,31 @@ export const MCPServerAdminPanel: FC<MCPServerAdminPanelProps> = ({
 			// Error surfaced via mutation error state.
 			return;
 		}
-		setSearchParams({});
+		exitServerView();
 	};
-
-	if (isLoadingServers) {
-		return (
-			<div className="flex items-center gap-1.5 text-xs text-content-secondary">
-				<Spinner className="h-4 w-4" loading />
-				Loading
-			</div>
-		);
-	}
 
 	return (
 		<div className={cn("flex min-h-full flex-col", className)}>
+			{isLoadingServers && (
+				<div className="flex items-center gap-1.5 text-xs text-content-secondary">
+					<Spinner className="h-4 w-4" loading />
+					Loading
+				</div>
+			)}
 			{/* Content */}
 			<div className="flex flex-1 flex-col gap-8">
 				{!isFormView ? (
 					<ServerList
 						servers={servers}
-						onSelect={(server) => setSearchParams({ server: server.id })}
-						onAdd={() => setSearchParams({ server: "new" })}
+						onSelect={(server) =>
+							setSearchParams(
+								{ server: server.id },
+								{ state: { pushed: true } },
+							)
+						}
+						onAdd={() =>
+							setSearchParams({ server: "new" }, { state: { pushed: true } })
+						}
 						sectionLabel={sectionLabel}
 						sectionDescription={sectionDescription}
 						sectionBadge={sectionBadge}
@@ -1053,7 +1109,7 @@ export const MCPServerAdminPanel: FC<MCPServerAdminPanelProps> = ({
 						isDeleting={isDeletingServer}
 						onSave={handleSave}
 						onDelete={handleDelete}
-						onBack={() => setSearchParams({})}
+						onBack={exitServerView}
 					/>
 				)}
 			</div>

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
@@ -1,6 +1,7 @@
 import { useFormik } from "formik";
 import {
 	CheckCircleIcon,
+	ChevronDownIcon,
 	ChevronRightIcon,
 	CircleIcon,
 	PlusIcon,
@@ -288,6 +289,9 @@ const ServerForm: FC<ServerFormProps> = ({
 	const formId = useId();
 	const isEditing = server !== null;
 	const [confirmingDelete, setConfirmingDelete] = useState(false);
+	const [showConnection, setShowConnection] = useState(true);
+	const [showAuth, setShowAuth] = useState(true);
+	const [showBehavior, setShowBehavior] = useState(true);
 
 	const form = useFormik<MCPServerFormValues>({
 		initialValues: buildInitialValues(server),
@@ -449,370 +453,456 @@ const ServerForm: FC<ServerFormProps> = ({
 							disabled={isDisabled}
 						/>
 					</Field>
-					{/* ── Connection row: URL + transport side by side ── */}
-					<hr className="!my-0 border-0 border-t border-solid border-border" />
-					<div className="grid items-start gap-5 sm:grid-cols-[1fr_auto]">
-						<Field
-							label="Server URL"
-							htmlFor={`${formId}-url`}
-							required
-							description="The endpoint URL for this MCP server."
+					{/* ── Connection section ── */}
+					<div className="border-0 border-t border-solid border-border pt-4">
+						<button
+							type="button"
+							onClick={() => setShowConnection((v) => !v)}
+							className="flex w-full cursor-pointer items-start justify-between border-0 bg-transparent p-0 text-left transition-colors hover:text-content-primary"
 						>
-							<Input
-								id={`${formId}-url`}
-								className="h-9 text-[13px]"
-								{...form.getFieldProps("url")}
-								placeholder="https://mcp.example.com/sse"
-								disabled={isDisabled}
-							/>
-						</Field>
-
-						<Field label="Transport" htmlFor={`${formId}-transport`}>
-							<Select
-								value={form.values.transport}
-								onValueChange={(v) => {
-									form.setFieldValue("transport", v);
-								}}
-								disabled={isDisabled}
-							>
-								<SelectTrigger
-									id={`${formId}-transport`}
-									className="h-9 min-w-[160px] text-[13px]"
-								>
-									<SelectValue />
-								</SelectTrigger>
-								<SelectContent>
-									{TRANSPORT_OPTIONS.map((opt) => (
-										<SelectItem key={opt.value} value={opt.value}>
-											{opt.label}
-										</SelectItem>
-									))}
-								</SelectContent>
-							</Select>
-						</Field>
-					</div>
-					{/* ── Authentication ── */}
-					<hr className="!my-0 border-0 border-t border-solid border-border" />
-					<Field
-						label="Authentication"
-						htmlFor={`${formId}-auth`}
-						description="How users authenticate with this MCP server."
-					>
-						<Select
-							value={form.values.authType}
-							onValueChange={(v) => {
-								form.setFieldValue("authType", v);
-							}}
-							disabled={isDisabled}
-						>
-							<SelectTrigger
-								id={`${formId}-auth`}
-								className="h-9 max-w-[240px] text-[13px]"
-							>
-								<SelectValue />
-							</SelectTrigger>
-							<SelectContent>
-								{AUTH_TYPE_OPTIONS.map((opt) => (
-									<SelectItem key={opt.value} value={opt.value}>
-										{opt.label}
-									</SelectItem>
-								))}
-							</SelectContent>
-						</Select>
-					</Field>
-					{form.values.authType === "oauth2" && (
-						<div className="space-y-4 rounded-lg border border-border bg-surface-secondary/30 p-4">
-							<p className="m-0 text-xs text-content-secondary">
-								Register a client with the external MCP server's OAuth2 provider
-								and enter the credentials below. Coder will handle the per-user
-								authorization flow.
-							</p>
-							<div className="grid items-start gap-4 sm:grid-cols-2">
-								{" "}
-								<Field label="Client ID" htmlFor={`${formId}-oauth-id`}>
-									<Input
-										id={`${formId}-oauth-id`}
-										className="h-9 text-[13px]"
-										{...form.getFieldProps("oauth2ClientID")}
-										disabled={isDisabled}
-									/>
-								</Field>
-								<Field label="Client Secret" htmlFor={`${formId}-oauth-secret`}>
-									<Input
-										id={`${formId}-oauth-secret`}
-										className="h-9 font-mono text-[13px] [-webkit-text-security:disc]"
-										type="text"
-										autoComplete="off"
-										data-1p-ignore
-										data-lpignore="true"
-										data-form-type="other"
-										data-bwignore
-										value={form.values.oauth2ClientSecret}
-										onChange={(e) => {
-											form.setFieldValue("oauth2SecretTouched", true);
-											form.setFieldValue("oauth2ClientSecret", e.target.value);
-										}}
-										onFocus={() => {
-											if (
-												!form.values.oauth2SecretTouched &&
-												form.values.oauth2ClientSecret === SECRET_PLACEHOLDER
-											) {
-												form.setFieldValue("oauth2ClientSecret", "");
-												form.setFieldValue("oauth2SecretTouched", true);
-											}
-										}}
-										disabled={isDisabled}
-									/>
-								</Field>
+							<div>
+								<h3 className="m-0 text-sm font-medium text-content-primary">
+									Connection
+								</h3>
+								<p className="m-0 text-xs text-content-secondary">
+									Server endpoint and transport protocol.
+								</p>
 							</div>
-							<div className="grid items-start gap-4 sm:grid-cols-2">
-								<Field
-									label="Authorization URL"
-									htmlFor={`${formId}-oauth-auth-url`}
-								>
-									<Input
-										id={`${formId}-oauth-auth-url`}
-										className="h-9 text-[13px]"
-										{...form.getFieldProps("oauth2AuthURL")}
-										placeholder="https://provider.com/oauth2/authorize"
-										disabled={isDisabled}
-									/>
-								</Field>
-								<Field label="Token URL" htmlFor={`${formId}-oauth-token-url`}>
-									<Input
-										id={`${formId}-oauth-token-url`}
-										className="h-9 text-[13px]"
-										{...form.getFieldProps("oauth2TokenURL")}
-										placeholder="https://provider.com/oauth2/token"
-										disabled={isDisabled}
-									/>
-								</Field>
-							</div>
-							<Field label="Scopes" htmlFor={`${formId}-oauth-scopes`}>
-								<Input
-									id={`${formId}-oauth-scopes`}
-									className="h-9 text-[13px]"
-									{...form.getFieldProps("oauth2Scopes")}
-									placeholder="read write"
-									disabled={isDisabled}
-								/>
-							</Field>
-						</div>
-					)}
-					{form.values.authType === "api_key" && (
-						<div className="grid items-start gap-4 rounded-lg border border-border bg-surface-secondary/30 p-4 sm:grid-cols-2">
-							<Field label="Header Name" htmlFor={`${formId}-apikey-header`}>
-								<Input
-									id={`${formId}-apikey-header`}
-									className="h-9 text-[13px]"
-									{...form.getFieldProps("apiKeyHeader")}
-									placeholder="Authorization"
-									disabled={isDisabled}
-								/>
-							</Field>
-							<Field label="API Key" htmlFor={`${formId}-apikey-value`}>
-								<Input
-									id={`${formId}-apikey-value`}
-									className="h-9 font-mono text-[13px] [-webkit-text-security:disc]"
-									type="text"
-									autoComplete="off"
-									data-1p-ignore
-									data-lpignore="true"
-									data-form-type="other"
-									data-bwignore
-									value={form.values.apiKeyValue}
-									onChange={(e) => {
-										form.setFieldValue("apiKeyTouched", true);
-										form.setFieldValue("apiKeyValue", e.target.value);
-									}}
-									onFocus={() => {
-										if (
-											!form.values.apiKeyTouched &&
-											form.values.apiKeyValue === SECRET_PLACEHOLDER
-										) {
-											form.setFieldValue("apiKeyValue", "");
-											form.setFieldValue("apiKeyTouched", true);
-										}
-									}}
-									disabled={isDisabled}
-								/>
-							</Field>
-						</div>
-					)}
-					{form.values.authType === "custom_headers" && (
-						<div className="space-y-3 rounded-lg border border-border bg-surface-secondary/30 p-4">
-							{server?.has_custom_headers &&
-								!form.values.customHeadersTouched && (
-									<p className="m-0 text-xs text-content-secondary">
-										This server has custom headers configured. Add headers below
-										to replace them.
-									</p>
-								)}
-							{form.values.customHeaders.map((header, index) => (
-								<div key={index} className="flex items-start gap-2">
-									<div className="grid flex-1 items-start gap-2 sm:grid-cols-2">
-										<Input
-											className="h-9 text-[13px]"
-											value={header.key}
-											onChange={(e) => {
-												form.setFieldValue("customHeadersTouched", true);
-												const updated = [...form.values.customHeaders];
-												updated[index] = {
-													...updated[index],
-													key: e.target.value,
-												};
-												form.setFieldValue("customHeaders", updated);
-											}}
-											placeholder="Header name"
-											disabled={isDisabled}
-											aria-label={`Header ${index + 1} name`}
-										/>
-										<Input
-											className="h-9 font-mono text-[13px] [-webkit-text-security:disc]"
-											type="text"
-											autoComplete="off"
-											data-1p-ignore
-											data-lpignore="true"
-											data-form-type="other"
-											data-bwignore
-											value={header.value}
-											onChange={(e) => {
-												form.setFieldValue("customHeadersTouched", true);
-												const updated = [...form.values.customHeaders];
-												updated[index] = {
-													...updated[index],
-													value: e.target.value,
-												};
-												form.setFieldValue("customHeaders", updated);
-											}}
-											placeholder="Header value"
-											disabled={isDisabled}
-											aria-label={`Header ${index + 1} value`}
-										/>
-									</div>
-									<Button
-										variant="outline"
-										size="icon"
-										type="button"
-										className="mt-0 h-9 w-9 shrink-0"
-										onClick={() => {
-											form.setFieldValue("customHeadersTouched", true);
-											form.setFieldValue(
-												"customHeaders",
-												form.values.customHeaders.filter((_, i) => i !== index),
-											);
-										}}
-										disabled={isDisabled}
-										aria-label={`Remove header ${index + 1}`}
+							{showConnection ? (
+								<ChevronDownIcon className="mt-0.5 h-4 w-4 shrink-0 text-content-secondary" />
+							) : (
+								<ChevronRightIcon className="mt-0.5 h-4 w-4 shrink-0 text-content-secondary" />
+							)}
+						</button>
+						{showConnection && (
+							<div className="space-y-5 pt-3">
+								<div className="grid items-start gap-5 sm:grid-cols-[1fr_auto]">
+									<Field
+										label="Server URL"
+										htmlFor={`${formId}-url`}
+										required
+										description="The endpoint URL for this MCP server."
 									>
-										<XIcon className="h-4 w-4" />
-									</Button>
+										<Input
+											id={`${formId}-url`}
+											className="h-9 text-[13px]"
+											{...form.getFieldProps("url")}
+											placeholder="https://mcp.example.com/sse"
+											disabled={isDisabled}
+										/>
+									</Field>
+
+									<Field label="Transport" htmlFor={`${formId}-transport`}>
+										<Select
+											value={form.values.transport}
+											onValueChange={(v) => {
+												form.setFieldValue("transport", v);
+											}}
+											disabled={isDisabled}
+										>
+											<SelectTrigger
+												id={`${formId}-transport`}
+												className="h-9 min-w-[160px] text-[13px]"
+											>
+												<SelectValue />
+											</SelectTrigger>
+											<SelectContent>
+												{TRANSPORT_OPTIONS.map((opt) => (
+													<SelectItem key={opt.value} value={opt.value}>
+														{opt.label}
+													</SelectItem>
+												))}
+											</SelectContent>
+										</Select>
+									</Field>
 								</div>
-							))}
-							<Button
-								variant="outline"
-								size="sm"
-								type="button"
-								onClick={() => {
-									form.setFieldValue("customHeadersTouched", true);
-									form.setFieldValue("customHeaders", [
-										...form.values.customHeaders,
-										{ key: "", value: "" },
-									]);
-								}}
-								disabled={isDisabled}
-							>
-								<PlusIcon className="h-4 w-4" />
-								Add header
-							</Button>
-						</div>
-					)}
-					{/* ── Availability ── */}
-					<hr className="!my-0 border-0 border-t border-solid border-border" />
-					<Field
-						label="Availability"
-						htmlFor={`${formId}-availability`}
-						description="Controls how this server appears in new conversations."
-					>
-						<Select
-							value={form.values.availability}
-							onValueChange={(v) => {
-								form.setFieldValue("availability", v);
-							}}
-							disabled={isDisabled}
-						>
-							<SelectTrigger
-								id={`${formId}-availability`}
-								className="h-9 text-[13px]"
-							>
-								<SelectValue />
-							</SelectTrigger>
-							<SelectContent>
-								{AVAILABILITY_OPTIONS.map((opt) => (
-									<SelectItem key={opt.value} value={opt.value}>
-										<div>
-											<span>{opt.label}</span>
-											<span className="ml-1.5 text-content-secondary">
-												— {opt.description}
-											</span>
-										</div>
-									</SelectItem>
-								))}
-							</SelectContent>
-						</Select>
-					</Field>{" "}
-					{/* ── Tool governance row ── */}
-					<hr className="!my-0 border-0 border-t border-solid border-border" />
-					<div className="flex items-start justify-between gap-4">
-						<div className="min-w-0 space-y-1">
-							<Label
-								htmlFor={`${formId}-model-intent`}
-								className="text-sm font-medium text-content-primary"
-							>
-								Model intent
-							</Label>
-							<p className="m-0 text-xs text-content-secondary">
-								Require the model to describe each tool call's purpose in
-								natural language, shown as a status label in the UI.
-							</p>
-						</div>
-						<Switch
-							id={`${formId}-model-intent`}
-							checked={form.values.modelIntent}
-							onCheckedChange={(v) => {
-								form.setFieldValue("modelIntent", v);
-							}}
-							disabled={isDisabled}
-						/>
+							</div>
+						)}
 					</div>
-					<div className="grid items-start gap-5 sm:grid-cols-2">
-						{" "}
-						<Field
-							label="Tool Allow List"
-							htmlFor={`${formId}-allow-list`}
-							description="Comma-separated. Empty = all allowed."
+					{/* ── Authentication section ── */}
+					<div className="border-0 border-t border-solid border-border pt-4">
+						<button
+							type="button"
+							onClick={() => setShowAuth((v) => !v)}
+							className="flex w-full cursor-pointer items-start justify-between border-0 bg-transparent p-0 text-left transition-colors hover:text-content-primary"
 						>
-							<Input
-								id={`${formId}-allow-list`}
-								className="h-9 text-[13px]"
-								{...form.getFieldProps("toolAllowList")}
-								placeholder="tool1, tool2"
-								disabled={isDisabled}
-							/>
-						</Field>
-						<Field
-							label="Tool Deny List"
-							htmlFor={`${formId}-deny-list`}
-							description="Comma-separated names to block."
+							<div>
+								<h3 className="m-0 text-sm font-medium text-content-primary">
+									Authentication
+								</h3>
+								<p className="m-0 text-xs text-content-secondary">
+									How users authenticate with this MCP server.
+								</p>
+							</div>
+							{showAuth ? (
+								<ChevronDownIcon className="mt-0.5 h-4 w-4 shrink-0 text-content-secondary" />
+							) : (
+								<ChevronRightIcon className="mt-0.5 h-4 w-4 shrink-0 text-content-secondary" />
+							)}
+						</button>
+						{showAuth && (
+							<div className="space-y-5 pt-3">
+								<Select
+									value={form.values.authType}
+									onValueChange={(v) => {
+										form.setFieldValue("authType", v);
+									}}
+									disabled={isDisabled}
+								>
+									<SelectTrigger
+										id={`${formId}-auth`}
+										className="h-9 max-w-[240px] text-[13px]"
+									>
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent>
+										{AUTH_TYPE_OPTIONS.map((opt) => (
+											<SelectItem key={opt.value} value={opt.value}>
+												{opt.label}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+
+								{form.values.authType === "oauth2" && (
+									<div className="space-y-4 rounded-lg border border-border bg-surface-secondary/30 p-4">
+										<p className="m-0 text-xs text-content-secondary">
+											Register a client with the external MCP server's OAuth2
+											provider and enter the credentials below. Coder will
+											handle the per-user authorization flow.
+										</p>
+										<div className="grid items-start gap-4 sm:grid-cols-2">
+											{" "}
+											<Field label="Client ID" htmlFor={`${formId}-oauth-id`}>
+												<Input
+													id={`${formId}-oauth-id`}
+													className="h-9 text-[13px]"
+													{...form.getFieldProps("oauth2ClientID")}
+													disabled={isDisabled}
+												/>
+											</Field>
+											<Field
+												label="Client Secret"
+												htmlFor={`${formId}-oauth-secret`}
+											>
+												<Input
+													id={`${formId}-oauth-secret`}
+													className="h-9 font-mono text-[13px] [-webkit-text-security:disc]"
+													type="text"
+													autoComplete="off"
+													data-1p-ignore
+													data-lpignore="true"
+													data-form-type="other"
+													data-bwignore
+													value={form.values.oauth2ClientSecret}
+													onChange={(e) => {
+														form.setFieldValue("oauth2SecretTouched", true);
+														form.setFieldValue(
+															"oauth2ClientSecret",
+															e.target.value,
+														);
+													}}
+													onFocus={() => {
+														if (
+															!form.values.oauth2SecretTouched &&
+															form.values.oauth2ClientSecret ===
+																SECRET_PLACEHOLDER
+														) {
+															form.setFieldValue("oauth2ClientSecret", "");
+															form.setFieldValue("oauth2SecretTouched", true);
+														}
+													}}
+													disabled={isDisabled}
+												/>
+											</Field>
+										</div>
+										<div className="grid items-start gap-4 sm:grid-cols-2">
+											<Field
+												label="Authorization URL"
+												htmlFor={`${formId}-oauth-auth-url`}
+											>
+												<Input
+													id={`${formId}-oauth-auth-url`}
+													className="h-9 text-[13px]"
+													{...form.getFieldProps("oauth2AuthURL")}
+													placeholder="https://provider.com/oauth2/authorize"
+													disabled={isDisabled}
+												/>
+											</Field>
+											<Field
+												label="Token URL"
+												htmlFor={`${formId}-oauth-token-url`}
+											>
+												<Input
+													id={`${formId}-oauth-token-url`}
+													className="h-9 text-[13px]"
+													{...form.getFieldProps("oauth2TokenURL")}
+													placeholder="https://provider.com/oauth2/token"
+													disabled={isDisabled}
+												/>
+											</Field>
+										</div>
+										<Field label="Scopes" htmlFor={`${formId}-oauth-scopes`}>
+											<Input
+												id={`${formId}-oauth-scopes`}
+												className="h-9 text-[13px]"
+												{...form.getFieldProps("oauth2Scopes")}
+												placeholder="read write"
+												disabled={isDisabled}
+											/>
+										</Field>
+									</div>
+								)}
+
+								{form.values.authType === "api_key" && (
+									<div className="grid items-start gap-4 rounded-lg border border-border bg-surface-secondary/30 p-4 sm:grid-cols-2">
+										<Field
+											label="Header Name"
+											htmlFor={`${formId}-apikey-header`}
+										>
+											<Input
+												id={`${formId}-apikey-header`}
+												className="h-9 text-[13px]"
+												{...form.getFieldProps("apiKeyHeader")}
+												placeholder="Authorization"
+												disabled={isDisabled}
+											/>
+										</Field>
+										<Field label="API Key" htmlFor={`${formId}-apikey-value`}>
+											<Input
+												id={`${formId}-apikey-value`}
+												className="h-9 font-mono text-[13px] [-webkit-text-security:disc]"
+												type="text"
+												autoComplete="off"
+												data-1p-ignore
+												data-lpignore="true"
+												data-form-type="other"
+												data-bwignore
+												value={form.values.apiKeyValue}
+												onChange={(e) => {
+													form.setFieldValue("apiKeyTouched", true);
+													form.setFieldValue("apiKeyValue", e.target.value);
+												}}
+												onFocus={() => {
+													if (
+														!form.values.apiKeyTouched &&
+														form.values.apiKeyValue === SECRET_PLACEHOLDER
+													) {
+														form.setFieldValue("apiKeyValue", "");
+														form.setFieldValue("apiKeyTouched", true);
+													}
+												}}
+												disabled={isDisabled}
+											/>
+										</Field>
+									</div>
+								)}
+
+								{form.values.authType === "custom_headers" && (
+									<div className="space-y-3 rounded-lg border border-border bg-surface-secondary/30 p-4">
+										{server?.has_custom_headers &&
+											!form.values.customHeadersTouched && (
+												<p className="m-0 text-xs text-content-secondary">
+													This server has custom headers configured. Add headers
+													below to replace them.
+												</p>
+											)}
+										{form.values.customHeaders.map((header, index) => (
+											<div key={index} className="flex items-start gap-2">
+												<div className="grid flex-1 items-start gap-2 sm:grid-cols-2">
+													<Input
+														className="h-9 text-[13px]"
+														value={header.key}
+														onChange={(e) => {
+															form.setFieldValue("customHeadersTouched", true);
+															const updated = [...form.values.customHeaders];
+															updated[index] = {
+																...updated[index],
+																key: e.target.value,
+															};
+															form.setFieldValue("customHeaders", updated);
+														}}
+														placeholder="Header name"
+														disabled={isDisabled}
+														aria-label={`Header ${index + 1} name`}
+													/>
+													<Input
+														className="h-9 font-mono text-[13px] [-webkit-text-security:disc]"
+														type="text"
+														autoComplete="off"
+														data-1p-ignore
+														data-lpignore="true"
+														data-form-type="other"
+														data-bwignore
+														value={header.value}
+														onChange={(e) => {
+															form.setFieldValue("customHeadersTouched", true);
+															const updated = [...form.values.customHeaders];
+															updated[index] = {
+																...updated[index],
+																value: e.target.value,
+															};
+															form.setFieldValue("customHeaders", updated);
+														}}
+														placeholder="Header value"
+														disabled={isDisabled}
+														aria-label={`Header ${index + 1} value`}
+													/>
+												</div>
+												<Button
+													variant="outline"
+													size="icon"
+													type="button"
+													className="mt-0 h-9 w-9 shrink-0"
+													onClick={() => {
+														form.setFieldValue("customHeadersTouched", true);
+														form.setFieldValue(
+															"customHeaders",
+															form.values.customHeaders.filter(
+																(_, i) => i !== index,
+															),
+														);
+													}}
+													disabled={isDisabled}
+													aria-label={`Remove header ${index + 1}`}
+												>
+													<XIcon className="h-4 w-4" />
+												</Button>
+											</div>
+										))}
+										<Button
+											variant="outline"
+											size="sm"
+											type="button"
+											onClick={() => {
+												form.setFieldValue("customHeadersTouched", true);
+												form.setFieldValue("customHeaders", [
+													...form.values.customHeaders,
+													{ key: "", value: "" },
+												]);
+											}}
+											disabled={isDisabled}
+										>
+											<PlusIcon className="h-4 w-4" />
+											Add header
+										</Button>
+									</div>
+								)}
+							</div>
+						)}
+					</div>
+					{/* ── Behavior section ── */}
+					<div className="border-0 border-t border-solid border-border pt-4">
+						<button
+							type="button"
+							onClick={() => setShowBehavior((v) => !v)}
+							className="flex w-full cursor-pointer items-start justify-between border-0 bg-transparent p-0 text-left transition-colors hover:text-content-primary"
 						>
-							<Input
-								id={`${formId}-deny-list`}
-								className="h-9 text-[13px]"
-								{...form.getFieldProps("toolDenyList")}
-								placeholder="tool3, tool4"
-								disabled={isDisabled}
-							/>
-						</Field>
+							<div>
+								<h3 className="m-0 text-sm font-medium text-content-primary">
+									Behavior
+								</h3>
+								<p className="m-0 text-xs text-content-secondary">
+									Availability, model intent, and tool governance.
+								</p>
+							</div>
+							{showBehavior ? (
+								<ChevronDownIcon className="mt-0.5 h-4 w-4 shrink-0 text-content-secondary" />
+							) : (
+								<ChevronRightIcon className="mt-0.5 h-4 w-4 shrink-0 text-content-secondary" />
+							)}
+						</button>
+						{showBehavior && (
+							<div className="space-y-5 pt-3">
+								<div>
+									<Label
+										htmlFor={`${formId}-availability`}
+										className="mb-1 block text-sm font-medium text-content-primary"
+									>
+										Availability
+									</Label>
+									<Select
+										value={form.values.availability}
+										onValueChange={(v) => {
+											form.setFieldValue("availability", v);
+										}}
+										disabled={isDisabled}
+									>
+										<SelectTrigger
+											id={`${formId}-availability`}
+											className="h-9 text-[13px]"
+										>
+											<SelectValue />
+										</SelectTrigger>
+										<SelectContent>
+											{AVAILABILITY_OPTIONS.map((opt) => (
+												<SelectItem key={opt.value} value={opt.value}>
+													<div>
+														<span>{opt.label}</span>
+														<span className="ml-1.5 text-content-secondary">
+															— {opt.description}
+														</span>
+													</div>
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+								</div>
+
+								<div className="flex items-start justify-between gap-4">
+									<div className="min-w-0 space-y-1">
+										<Label
+											htmlFor={`${formId}-model-intent`}
+											className="text-sm font-medium text-content-primary"
+										>
+											Model intent
+										</Label>
+										<p className="m-0 text-xs text-content-secondary">
+											Require the model to describe each tool call's purpose in
+											natural language, shown as a status label in the UI.
+										</p>
+									</div>
+									<Switch
+										id={`${formId}-model-intent`}
+										checked={form.values.modelIntent}
+										onCheckedChange={(v) => {
+											form.setFieldValue("modelIntent", v);
+										}}
+										disabled={isDisabled}
+									/>
+								</div>
+
+								<div className="grid items-start gap-5 sm:grid-cols-2">
+									{" "}
+									<Field
+										label="Tool Allow List"
+										htmlFor={`${formId}-allow-list`}
+										description="Comma-separated. Empty = all allowed."
+									>
+										<Input
+											id={`${formId}-allow-list`}
+											className="h-9 text-[13px]"
+											{...form.getFieldProps("toolAllowList")}
+											placeholder="tool1, tool2"
+											disabled={isDisabled}
+										/>
+									</Field>
+									<Field
+										label="Tool Deny List"
+										htmlFor={`${formId}-deny-list`}
+										description="Comma-separated names to block."
+									>
+										<Input
+											id={`${formId}-deny-list`}
+											className="h-9 text-[13px]"
+											{...form.getFieldProps("toolDenyList")}
+											placeholder="tool3, tool4"
+											disabled={isDisabled}
+										/>
+									</Field>
+								</div>
+							</div>
+						)}
 					</div>
 				</div>
 

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
@@ -558,28 +558,29 @@ const ServerForm: FC<ServerFormProps> = ({
 						</button>
 						{showAuth && (
 							<div className="space-y-4 pt-3">
-								<Select
-									value={form.values.authType}
-									onValueChange={(v) => {
-										form.setFieldValue("authType", v);
-									}}
-									disabled={isDisabled}
-								>
-									<SelectTrigger
-										id={`${formId}-auth`}
-										className="h-9 max-w-[240px] text-[13px]"
+								<Field label="Authentication method" htmlFor={`${formId}-auth`}>
+									<Select
+										value={form.values.authType}
+										onValueChange={(v) => {
+											form.setFieldValue("authType", v);
+										}}
+										disabled={isDisabled}
 									>
-										<SelectValue />
-									</SelectTrigger>
-									<SelectContent>
-										{AUTH_TYPE_OPTIONS.map((opt) => (
-											<SelectItem key={opt.value} value={opt.value}>
-												{opt.label}
-											</SelectItem>
-										))}
-									</SelectContent>
-								</Select>
-
+										<SelectTrigger
+											id={`${formId}-auth`}
+											className="h-9 max-w-[240px] text-[13px]"
+										>
+											<SelectValue />
+										</SelectTrigger>
+										<SelectContent>
+											{AUTH_TYPE_OPTIONS.map((opt) => (
+												<SelectItem key={opt.value} value={opt.value}>
+													{opt.label}
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+								</Field>
 								{form.values.authType === "oauth2" && (
 									<div className="space-y-4 rounded-lg border border-solid border-border/70 bg-surface-secondary/30 p-4">
 										<p className="m-0 text-xs text-content-secondary">

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
@@ -397,7 +397,7 @@ const ServerForm: FC<ServerFormProps> = ({
 				className="flex flex-1 flex-col"
 				autoComplete="off"
 			>
-				<div className="space-y-5">
+				<div className="space-y-6">
 					{" "}
 					{/* ── Identity row: slug + description side by side ── */}
 					<div className="grid items-start gap-5 sm:grid-cols-2">
@@ -450,7 +450,7 @@ const ServerForm: FC<ServerFormProps> = ({
 						/>
 					</Field>
 					{/* ── Connection row: URL + transport side by side ── */}
-					<hr className="!my-2 border-0 border-t border-solid border-border" />
+					<hr className="!my-0 border-0 border-t border-solid border-border" />
 					<div className="grid items-start gap-5 sm:grid-cols-[1fr_auto]">
 						<Field
 							label="Server URL"
@@ -492,7 +492,7 @@ const ServerForm: FC<ServerFormProps> = ({
 						</Field>
 					</div>
 					{/* ── Authentication ── */}
-					<hr className="!my-2 border-0 border-t border-solid border-border" />
+					<hr className="!my-0 border-0 border-t border-solid border-border" />
 					<Field
 						label="Authentication"
 						htmlFor={`${formId}-auth`}
@@ -728,7 +728,7 @@ const ServerForm: FC<ServerFormProps> = ({
 						</div>
 					)}
 					{/* ── Availability ── */}
-					<hr className="!my-2 border-0 border-t border-solid border-border" />
+					<hr className="!my-0 border-0 border-t border-solid border-border" />
 					<Field
 						label="Availability"
 						htmlFor={`${formId}-availability`}
@@ -762,11 +762,16 @@ const ServerForm: FC<ServerFormProps> = ({
 						</Select>
 					</Field>{" "}
 					{/* ── Tool governance row ── */}
-					<hr className="!my-2 border-0 border-t border-solid border-border" />
-					<div className="flex items-center justify-between">
-						<div>
-							<Label htmlFor={`${formId}-model-intent`}>Model intent</Label>
-							<p className="text-sm text-content-secondary">
+					<hr className="!my-0 border-0 border-t border-solid border-border" />
+					<div className="flex items-start justify-between gap-4">
+						<div className="min-w-0 space-y-1">
+							<Label
+								htmlFor={`${formId}-model-intent`}
+								className="text-sm font-medium text-content-primary"
+							>
+								Model intent
+							</Label>
+							<p className="m-0 text-xs text-content-secondary">
 								Require the model to describe each tool call's purpose in
 								natural language, shown as a status label in the UI.
 							</p>
@@ -812,7 +817,7 @@ const ServerForm: FC<ServerFormProps> = ({
 				</div>
 
 				{/* Footer — pushed to bottom, matches ProviderForm */}
-				<div className="mt-auto pt-6">
+				<div className="mt-auto py-6">
 					<hr className="mb-4 border-0 border-t border-solid border-border" />
 					<div className="flex items-center justify-between">
 						{isEditing ? (

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
@@ -449,18 +449,16 @@ const ServerForm: FC<ServerFormProps> = ({
 										/>
 									</Field>
 								</div>
-								<Field label="Icon">
-									<IconField
-										value={form.values.iconURL}
-										onChange={(e) => {
-											form.setFieldValue("iconURL", e.target.value);
-										}}
-										onPickEmoji={(value) => {
-											form.setFieldValue("iconURL", value);
-										}}
-										disabled={isDisabled}
-									/>
-								</Field>
+								<IconField
+									value={form.values.iconURL}
+									onChange={(e) => {
+										form.setFieldValue("iconURL", e.target.value);
+									}}
+									onPickEmoji={(value) => {
+										form.setFieldValue("iconURL", value);
+									}}
+									disabled={isDisabled}
+								/>
 								<div className="grid items-start gap-4 sm:grid-cols-[1fr_auto]">
 									<Field label="Server URL" htmlFor={`${formId}-url`} required>
 										<Input

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
@@ -449,16 +449,18 @@ const ServerForm: FC<ServerFormProps> = ({
 										/>
 									</Field>
 								</div>
-								<IconField
-									value={form.values.iconURL}
-									onChange={(e) => {
-										form.setFieldValue("iconURL", e.target.value);
-									}}
-									onPickEmoji={(value) => {
-										form.setFieldValue("iconURL", value);
-									}}
-									disabled={isDisabled}
-								/>
+								<Field label="Icon">
+									<IconField
+										value={form.values.iconURL}
+										onChange={(e) => {
+											form.setFieldValue("iconURL", e.target.value);
+										}}
+										onPickEmoji={(value) => {
+											form.setFieldValue("iconURL", value);
+										}}
+										disabled={isDisabled}
+									/>
+								</Field>
 								<div className="grid items-start gap-4 sm:grid-cols-[1fr_auto]">
 									<Field label="Server URL" htmlFor={`${formId}-url`} required>
 										<Input

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
@@ -408,7 +408,7 @@ const ServerForm: FC<ServerFormProps> = ({
 	const formId = useId();
 	const isEditing = server !== null;
 	const [confirmingDelete, setConfirmingDelete] = useState(false);
-	const [showConnection, setShowConnection] = useState(false);
+	const [showDetails, setShowDetails] = useState(false);
 	const [showAuth, setShowAuth] = useState(false);
 	const [showBehavior, setShowBehavior] = useState(false);
 
@@ -538,53 +538,89 @@ const ServerForm: FC<ServerFormProps> = ({
 				autoComplete="off"
 			>
 				<div className="space-y-6">
-					{/* ── Connection section ── */}
+					<div className="space-y-4">
+						<Field label="Slug" htmlFor={`${formId}-slug`} required>
+							<Input
+								id={`${formId}-slug`}
+								className="h-9 text-[13px]"
+								value={form.values.slug}
+								onChange={(e) => {
+									form.setFieldValue("slugTouched", true);
+									form.setFieldValue("slug", e.target.value);
+								}}
+								placeholder="e.g. sentry"
+								disabled={isDisabled}
+							/>
+						</Field>
+						<div className="grid items-start gap-4 sm:grid-cols-[1fr_auto]">
+							<Field label="Server URL" htmlFor={`${formId}-url`} required>
+								<Input
+									id={`${formId}-url`}
+									className="h-9 text-[13px]"
+									{...form.getFieldProps("url")}
+									placeholder="https://mcp.example.com/sse"
+									disabled={isDisabled}
+								/>
+							</Field>
+
+							<Field label="Transport" htmlFor={`${formId}-transport`}>
+								<Select
+									value={form.values.transport}
+									onValueChange={(v) => {
+										form.setFieldValue("transport", v);
+									}}
+									disabled={isDisabled}
+								>
+									<SelectTrigger
+										id={`${formId}-transport`}
+										className="h-9 min-w-[160px] text-[13px]"
+									>
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent>
+										{TRANSPORT_OPTIONS.map((opt) => (
+											<SelectItem key={opt.value} value={opt.value}>
+												{opt.label}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+							</Field>
+						</div>
+					</div>
+
+					{/* ── Details section ── */}
 					<div className="border-0 border-t border-solid border-border pt-4">
 						<button
 							type="button"
-							onClick={() => setShowConnection((v) => !v)}
+							onClick={() => setShowDetails((v) => !v)}
 							className="flex w-full cursor-pointer items-start justify-between border-0 bg-transparent p-0 text-left transition-colors hover:text-content-primary"
 						>
 							<div>
 								<h3 className="m-0 text-sm font-medium text-content-primary">
-									Connection
+									Details
 								</h3>
 								<p className="m-0 text-xs text-content-secondary">
-									Endpoint, identity, and transport settings.
+									Optional description and icon shown to users.
 								</p>
 							</div>
-							{showConnection ? (
+							{showDetails ? (
 								<ChevronDownIcon className="mt-0.5 h-4 w-4 shrink-0 text-content-secondary" />
 							) : (
 								<ChevronRightIcon className="mt-0.5 h-4 w-4 shrink-0 text-content-secondary" />
 							)}
 						</button>
-						{showConnection && (
+						{showDetails && (
 							<div className="space-y-4 pt-3">
-								<div className="grid items-start gap-4 sm:grid-cols-2">
-									<Field label="Slug" htmlFor={`${formId}-slug`} required>
-										<Input
-											id={`${formId}-slug`}
-											className="h-9 text-[13px]"
-											value={form.values.slug}
-											onChange={(e) => {
-												form.setFieldValue("slugTouched", true);
-												form.setFieldValue("slug", e.target.value);
-											}}
-											placeholder="e.g. sentry"
-											disabled={isDisabled}
-										/>
-									</Field>
-									<Field label="Description" htmlFor={`${formId}-desc`}>
-										<Input
-											id={`${formId}-desc`}
-											className="h-9 text-[13px]"
-											{...form.getFieldProps("description")}
-											placeholder="Optional description"
-											disabled={isDisabled}
-										/>
-									</Field>
-								</div>
+								<Field label="Description" htmlFor={`${formId}-desc`}>
+									<Input
+										id={`${formId}-desc`}
+										className="h-9 text-[13px]"
+										{...form.getFieldProps("description")}
+										placeholder="Optional description"
+										disabled={isDisabled}
+									/>
+								</Field>
 								<Field label="Icon">
 									<IconPickerField
 										value={form.values.iconURL}
@@ -597,44 +633,10 @@ const ServerForm: FC<ServerFormProps> = ({
 										disabled={isDisabled}
 									/>
 								</Field>
-								<div className="grid items-start gap-4 sm:grid-cols-[1fr_auto]">
-									<Field label="Server URL" htmlFor={`${formId}-url`} required>
-										<Input
-											id={`${formId}-url`}
-											className="h-9 text-[13px]"
-											{...form.getFieldProps("url")}
-											placeholder="https://mcp.example.com/sse"
-											disabled={isDisabled}
-										/>
-									</Field>
-
-									<Field label="Transport" htmlFor={`${formId}-transport`}>
-										<Select
-											value={form.values.transport}
-											onValueChange={(v) => {
-												form.setFieldValue("transport", v);
-											}}
-											disabled={isDisabled}
-										>
-											<SelectTrigger
-												id={`${formId}-transport`}
-												className="h-9 min-w-[160px] text-[13px]"
-											>
-												<SelectValue />
-											</SelectTrigger>
-											<SelectContent>
-												{TRANSPORT_OPTIONS.map((opt) => (
-													<SelectItem key={opt.value} value={opt.value}>
-														{opt.label}
-													</SelectItem>
-												))}
-											</SelectContent>
-										</Select>
-									</Field>
-								</div>
 							</div>
 						)}
 					</div>
+
 					{/* ── Authentication section ── */}
 					<div className="border-0 border-t border-solid border-border pt-4">
 						<button

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
@@ -149,16 +149,8 @@ const MCPServerIcon: FC<{
 
 // ── Icon picker ──────────────────────────────────────────────────
 
-// Lazy-loaded emoji picker keeps the main bundle lean. The emoji-mart
-// library takes several seconds on cold load, so we warm it up in an
-// sr-only node below while the form mounts.
 const EmojiPicker = lazy(() => import("#/components/IconField/EmojiPicker"));
 
-// A shadcn-styled icon picker that matches the surrounding form inputs.
-// Functionally equivalent to #/components/IconField/IconField (URL input +
-// preview + emoji/icon picker) but built on InputGroup + Popover instead
-// of the legacy MUI TextField wrapper, so it inherits the h-9 / border /
-// focus ring used everywhere else in this panel.
 interface IconPickerFieldProps {
 	id?: string;
 	value: string;
@@ -196,9 +188,7 @@ const IconPickerField: FC<IconPickerFieldProps> = ({
 						<ExternalImage
 							alt=""
 							src={value}
-							// Hide the broken-image glyph while the user is
-							// mid-typing a URL. Restore visibility only when a
-							// real bitmap loads.
+							// Hide the broken-image glyph while the URL is incomplete.
 							onError={(e) => {
 								e.currentTarget.style.display = "none";
 							}}
@@ -258,13 +248,6 @@ const ServerList: FC<ServerListProps> = ({
 	sectionDescription,
 	sectionBadge,
 }) => {
-	const addButton = (
-		<Button size="sm" onClick={onAdd}>
-			<PlusIcon className="h-4 w-4" />
-			Add server
-		</Button>
-	);
-
 	return (
 		<>
 			<SectionHeader
@@ -274,7 +257,12 @@ const ServerList: FC<ServerListProps> = ({
 					"Configure external MCP servers that provide additional tools for Coder Agents."
 				}
 				badge={sectionBadge}
-				action={addButton}
+				action={
+					<Button size="sm" onClick={onAdd}>
+						<PlusIcon className="h-4 w-4" />
+						Add server
+					</Button>
+				}
 			/>
 
 			{servers.length === 0 ? (
@@ -282,7 +270,10 @@ const ServerList: FC<ServerListProps> = ({
 					<p className="m-0 text-sm text-content-secondary">
 						No MCP servers configured yet.
 					</p>
-					{addButton}
+					<Button size="sm" onClick={onAdd} aria-label="Add your first server">
+						<PlusIcon className="h-4 w-4" />
+						Add your first server
+					</Button>
 				</div>
 			) : (
 				<div>
@@ -605,7 +596,7 @@ const ServerForm: FC<ServerFormProps> = ({
 										}}
 										disabled={isDisabled}
 									/>
-								</Field>{" "}
+								</Field>
 								<div className="grid items-start gap-4 sm:grid-cols-[1fr_auto]">
 									<Field label="Server URL" htmlFor={`${formId}-url`} required>
 										<Input
@@ -698,7 +689,6 @@ const ServerForm: FC<ServerFormProps> = ({
 											handle the per-user authorization flow.
 										</p>
 										<div className="grid items-start gap-4 sm:grid-cols-2">
-											{" "}
 											<Field label="Client ID" htmlFor={`${formId}-oauth-id`}>
 												<Input
 													id={`${formId}-oauth-id`}
@@ -990,7 +980,6 @@ const ServerForm: FC<ServerFormProps> = ({
 								</div>
 
 								<div className="grid items-start gap-4 sm:grid-cols-2">
-									{" "}
 									<Field
 										label="Tool Allow List"
 										htmlFor={`${formId}-allow-list`}
@@ -1063,7 +1052,7 @@ const ServerForm: FC<ServerFormProps> = ({
 					open={confirmingDelete}
 					onOpenChange={(open) => !open && setConfirmingDelete(false)}
 				/>
-			)}{" "}
+			)}
 		</div>
 	);
 };

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
@@ -402,57 +402,6 @@ const ServerForm: FC<ServerFormProps> = ({
 				autoComplete="off"
 			>
 				<div className="space-y-6">
-					{" "}
-					{/* ── Identity row: slug + description side by side ── */}
-					<div className="grid items-start gap-5 sm:grid-cols-2">
-						{" "}
-						<Field
-							label="Slug"
-							htmlFor={`${formId}-slug`}
-							required
-							description="URL-safe identifier."
-						>
-							<Input
-								id={`${formId}-slug`}
-								className="h-9 text-[13px]"
-								value={form.values.slug}
-								onChange={(e) => {
-									form.setFieldValue("slugTouched", true);
-									form.setFieldValue("slug", e.target.value);
-								}}
-								placeholder="e.g. sentry"
-								disabled={isDisabled}
-							/>
-						</Field>
-						<Field
-							label="Description"
-							htmlFor={`${formId}-desc`}
-							description="Brief summary of what this server provides."
-						>
-							<Input
-								id={`${formId}-desc`}
-								className="h-9 text-[13px]"
-								{...form.getFieldProps("description")}
-								placeholder="Optional description"
-								disabled={isDisabled}
-							/>
-						</Field>
-					</div>
-					<Field
-						label="Icon"
-						description="Pick an emoji or paste an image URL."
-					>
-						<IconField
-							value={form.values.iconURL}
-							onChange={(e) => {
-								form.setFieldValue("iconURL", e.target.value);
-							}}
-							onPickEmoji={(value) => {
-								form.setFieldValue("iconURL", value);
-							}}
-							disabled={isDisabled}
-						/>
-					</Field>
 					{/* ── Connection section ── */}
 					<div className="border-0 border-t border-solid border-border pt-4">
 						<button
@@ -465,7 +414,7 @@ const ServerForm: FC<ServerFormProps> = ({
 									Connection
 								</h3>
 								<p className="m-0 text-xs text-content-secondary">
-									Server endpoint and transport protocol.
+									Endpoint, identity, and transport settings.
 								</p>
 							</div>
 							{showConnection ? (
@@ -476,13 +425,44 @@ const ServerForm: FC<ServerFormProps> = ({
 						</button>
 						{showConnection && (
 							<div className="space-y-5 pt-3">
-								<div className="grid items-start gap-5 sm:grid-cols-[1fr_auto]">
-									<Field
-										label="Server URL"
-										htmlFor={`${formId}-url`}
-										required
-										description="The endpoint URL for this MCP server."
-									>
+								<div className="grid items-start gap-5 sm:grid-cols-2">
+									<Field label="Slug" htmlFor={`${formId}-slug`} required>
+										<Input
+											id={`${formId}-slug`}
+											className="h-9 text-[13px]"
+											value={form.values.slug}
+											onChange={(e) => {
+												form.setFieldValue("slugTouched", true);
+												form.setFieldValue("slug", e.target.value);
+											}}
+											placeholder="e.g. sentry"
+											disabled={isDisabled}
+										/>
+									</Field>
+									<Field label="Description" htmlFor={`${formId}-desc`}>
+										<Input
+											id={`${formId}-desc`}
+											className="h-9 text-[13px]"
+											{...form.getFieldProps("description")}
+											placeholder="Optional description"
+											disabled={isDisabled}
+										/>
+									</Field>
+								</div>
+								<Field label="Icon">
+									<IconField
+										value={form.values.iconURL}
+										onChange={(e) => {
+											form.setFieldValue("iconURL", e.target.value);
+										}}
+										onPickEmoji={(value) => {
+											form.setFieldValue("iconURL", value);
+										}}
+										disabled={isDisabled}
+									/>
+								</Field>
+								<div className="grid items-start gap-4 sm:grid-cols-[1fr_auto]">
+									<Field label="Server URL" htmlFor={`${formId}-url`} required>
 										<Input
 											id={`${formId}-url`}
 											className="h-9 text-[13px]"

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
@@ -451,6 +451,7 @@ const ServerForm: FC<ServerFormProps> = ({
 								</div>
 								<Field label="Icon">
 									<IconField
+										label=""
 										value={form.values.iconURL}
 										onChange={(e) => {
 											form.setFieldValue("iconURL", e.target.value);

--- a/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
@@ -46,7 +46,6 @@ import {
 	Trash2Icon,
 	UserIcon,
 	WalletIcon,
-	WandSparklesIcon,
 } from "lucide-react";
 import {
 	createContext,

--- a/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
@@ -39,6 +39,7 @@ import {
 	PauseIcon,
 	PinIcon,
 	PinOffIcon,
+	ServerIcon,
 	SettingsIcon,
 	ShieldIcon,
 	SquarePenIcon,
@@ -1360,18 +1361,18 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 									adminOnly
 								/>
 								<SettingsNavItem
-									icon={WalletIcon}
-									label="Spend"
-									active={sidebarView.section === "spend"}
-									to="/agents/settings/spend"
+									icon={ServerIcon}
+									label="MCP Servers"
+									active={sidebarView.section === "mcp-servers"}
+									to="/agents/settings/mcp-servers"
 									state={location.state}
 									adminOnly
 								/>
 								<SettingsNavItem
-									icon={WandSparklesIcon}
-									label="Insights"
-									active={sidebarView.section === "insights"}
-									to="/agents/settings/insights"
+									icon={WalletIcon}
+									label="Spend"
+									active={sidebarView.section === "spend"}
+									to="/agents/settings/spend"
 									state={location.state}
 									adminOnly
 								/>

--- a/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
@@ -38,6 +38,7 @@ import {
 	PauseIcon,
 	PinIcon,
 	PinOffIcon,
+	ServerIcon,
 	SettingsIcon,
 	ShieldIcon,
 	SquarePenIcon,
@@ -1302,18 +1303,18 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 									adminOnly
 								/>
 								<SettingsNavItem
-									icon={WalletIcon}
-									label="Spend"
-									active={sidebarView.section === "spend"}
-									to="/agents/settings/spend"
+									icon={ServerIcon}
+									label="MCP Servers"
+									active={sidebarView.section === "mcp-servers"}
+									to="/agents/settings/mcp-servers"
 									state={location.state}
 									adminOnly
 								/>
 								<SettingsNavItem
-									icon={WandSparklesIcon}
-									label="Insights"
-									active={sidebarView.section === "insights"}
-									to="/agents/settings/insights"
+									icon={WalletIcon}
+									label="Spend"
+									active={sidebarView.section === "spend"}
+									to="/agents/settings/spend"
 									state={location.state}
 									adminOnly
 								/>


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood

<img width="863" height="657" alt="image" src="https://github.com/user-attachments/assets/4bd0d97b-3a2e-4a48-9b68-b45c2c4c8e07" />


Closes CODAGT-160
Closes CODAGT-188

## Changes

**Sidebar navigation:**
- Added MCP Servers nav item to the agents settings sidebar (with `ServerIcon`)
- Removed the Insights nav item from the sidebar

**MCP settings page panel** (aligning with ChatModelAdminPanel):
- Loading state: inline spinner with "Loading" text label
- Outer wrapper: `cn()` for className merging, `flex-1 flex-col gap-8` content container
- Empty state: centered layout matching ModelsSection
- Error alerts: separated into dedicated bottom section

**MCP server form → collapsible sections (matching ModelForm):**

The flat form with `<hr>` separators is replaced by three collapsible sections using the same button+chevron pattern as the model form:

- **Connection** — Slug, Description, Icon, Server URL + Transport (identity fields moved here from top level)
- **Authentication** — Auth type selector + conditional panels (OAuth2, API Key, Custom Headers)
- **Behavior** — Availability, model intent toggle, tool allow/deny lists

The form now goes directly from the header (icon + editable name + enabled toggle) to collapsible sections with no top-level fields. Redundant Field descriptions are removed since section headers provide context.