### PR TITLE
test: skip TestSubscribeRelayEstablishedMidStream

### DIFF
--- a/enterprise/coderd/x/chatd/chatd_test.go
+++ b/enterprise/coderd/x/chatd/chatd_test.go
@@ -1435,6 +1435,8 @@ func TestSubscribeRelayDialCanceledOnFastCompletion(t *testing.T) {
 // condition where the relay is too slow.
 func TestSubscribeRelayEstablishedMidStream(t *testing.T) {
 	t.Parallel()
+	// TODO(hugodutka): Unskip when chatd is free of race conditions.
+	t.Skip("skipped due to inherent race condition; see https://github.com/coder/internal/issues/1455")
 
 	db, ps := dbtestutil.NewDB(t)
 	workerID := uuid.New()


### PR DESCRIPTION
Relates to https://github.com/coder/internal/issues/1455
From that issue:
> Going to skip this test until the underlying race in chatd is fixed. https://github.com/coder/coder/pull/24279 was a band-aid fix that I no longer think is valuable pursuing short term. Hugo is working on a RFC for a redesign of the system to prevent the class of race condition into the future.