### PR TITLE
docs: clarify copilot plans in provider config

### DIFF
--- a/docs/ai-coder/ai-gateway/setup.md
+++ b/docs/ai-coder/ai-gateway/setup.md
@@ -94,8 +94,10 @@ proxy between AI Gateway and AWS Bedrock.
 
 ### GitHub Copilot
 
-Configure a `copilot` provider using the
-[indexed provider format](#multiple-instances-of-the-same-provider).
+GitHub Copilot offers three plans — Individual, Business, and Enterprise —
+each with its own API endpoint. Configure one or more `copilot` providers
+using the [indexed provider format](#multiple-instances-of-the-same-provider)
+depending on which plans your organization uses.
 Copilot providers use OAuth app installations for authentication rather than
 static API keys.
 


### PR DESCRIPTION
Follow-up to #24382.

Addresses [review feedback](https://github.com/coder/coder/pull/24382#discussion_r3093020060): clarify that GitHub Copilot has three plans (Individual, Business, Enterprise) and that admins should configure one or more depending on which plans their organization uses.

> 🤖 This PR was created with the help of Coder Agents, and needs a human review.  🧑💻