### PR TITLE
test: add missing ClientType to InsertChat test params

### DIFF
--- a/coderd/x/chatd/chattool/startworkspace_test.go
+++ b/coderd/x/chatd/chattool/startworkspace_test.go
@@ -431,6 +431,7 @@ func TestStartWorkspace(t *testing.T) {
 		chat, err := db.InsertChat(ctx, database.InsertChatParams{
 			OrganizationID:    org.ID,
 			Status:            database.ChatStatusWaiting,
+			ClientType:        database.ChatClientTypeUi,
 			OwnerID:           user.ID,
 			WorkspaceID:       uuid.NullUUID{UUID: ws.ID, Valid: true},
 			LastModelConfigID: modelCfg.ID,
@@ -495,6 +496,7 @@ func TestStartWorkspace(t *testing.T) {
 		chat, err := db.InsertChat(ctx, database.InsertChatParams{
 			OrganizationID:    org.ID,
 			Status:            database.ChatStatusWaiting,
+			ClientType:        database.ChatClientTypeUi,
 			OwnerID:           user.ID,
 			WorkspaceID:       uuid.NullUUID{UUID: ws.ID, Valid: true},
 			LastModelConfigID: modelCfg.ID,


### PR DESCRIPTION
Two `InsertChatParams` blocks in `startworkspace_test.go` were missing the `ClientType` field. Since the `chat_client_type` enum column is `NOT NULL`, Postgres rejects the Go zero value (`""`), causing `TestStartWorkspace` subtests `StoppedWorkspaceReportsAutoUpdate` and `ManualUpdateRequired` to fail with:

```
pq: invalid input value for enum chat_client_type: ""
```

This broke on main because my PR (#24342, adding `client_type` to chats) had its CI pass before Dean's PR (which added these two test cases) was merged. Dean's PR merged first, adding `InsertChat` calls without `ClientType` — which was correct at the time since the field didn't exist yet. Then my PR merged after, making `ClientType` required but not touching Dean's new test blocks. 

Closes https://github.com/coder/internal/issues/1471