### PR TITLE
feat: accept xhigh effort for Anthropic

### DIFF
--- a/coderd/x/chatd/chatprovider/chatprovider.go
+++ b/coderd/x/chatd/chatprovider/chatprovider.go
@@ -663,6 +663,7 @@ func ReasoningEffortFromChat(provider string, value *string) *string {
 			string(fantasyanthropic.EffortLow),
 			string(fantasyanthropic.EffortMedium),
 			string(fantasyanthropic.EffortHigh),
+			string(fantasyanthropic.EffortXHigh),
 			string(fantasyanthropic.EffortMax),
 		)
 	case fantasyopenrouter.Name:

--- a/coderd/x/chatd/chatprovider/chatprovider_test.go
+++ b/coderd/x/chatd/chatprovider/chatprovider_test.go
@@ -209,6 +209,12 @@ func TestReasoningEffortFromChat(t *testing.T) {
 			want:     ptr.Ref(string(fantasyanthropic.EffortMax)),
 		},
 		{
+			name:     "AnthropicXHighEffort",
+			provider: "anthropic",
+			input:    ptr.Ref("xhigh"),
+			want:     ptr.Ref(string(fantasyanthropic.EffortXHigh)),
+		},
+		{
 			name:     "OpenRouterEffort",
 			provider: "openrouter",
 			input:    ptr.Ref("medium"),

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -925,7 +925,7 @@ type ChatModelAnthropicThinkingOptions struct {
 type ChatModelAnthropicProviderOptions struct {
 	SendReasoning          *bool                              `json:"send_reasoning,omitempty" description:"Whether to include reasoning content in the response"`
 	Thinking               *ChatModelAnthropicThinkingOptions `json:"thinking,omitempty" description:"Configuration for extended thinking"`
-	Effort                 *string                            `json:"effort,omitempty" label:"Reasoning Effort" description:"Controls the level of reasoning effort" enum:"low,medium,high,max"`
+	Effort                 *string                            `json:"effort,omitempty" label:"Reasoning Effort" description:"Controls the level of reasoning effort" enum:"low,medium,high,xhigh,max"`
 	DisableParallelToolUse *bool                              `json:"disable_parallel_tool_use,omitempty" description:"Whether to disable parallel tool execution"`
 	WebSearchEnabled       *bool                              `json:"web_search_enabled,omitempty" description:"Enable Anthropic web search tool for grounding responses with real-time information"`
 	AllowedDomains         []string                           `json:"allowed_domains,omitempty" label:"Web Search: Allowed Domains" description:"Restrict web search to these domains (cannot be used with blocked_domains)"`

--- a/docs/ai-coder/agents/models.md
+++ b/docs/ai-coder/agents/models.md
@@ -160,10 +160,10 @@ fields appear dynamically in the admin UI when you select a provider.
 
 #### Anthropic
 
-| Option                 | Description                                             |
-|------------------------|---------------------------------------------------------|
-| Thinking Budget Tokens | Maximum tokens allocated for extended thinking.         |
-| Effort                 | Thinking effort level (`low`, `medium`, `high`, `max`). |
+| Option                 | Description                                                      |
+|------------------------|------------------------------------------------------------------|
+| Thinking Budget Tokens | Maximum tokens allocated for extended thinking.                  |
+| Effort                 | Thinking effort level (`low`, `medium`, `high`, `xhigh`, `max`). |
 
 #### OpenAI
 

--- a/go.mod
+++ b/go.mod
@@ -82,8 +82,9 @@ replace github.com/spf13/afero => github.com/aslilac/afero v0.0.0-20250403163713
 // 3) ibetitsmike/fantasy#4 — skip ephemeral replay items when store=false
 // 4) (anthropic-sdk-go) dannykopping's appendCompact performance fixes
 // 5) (anthropic-sdk-go) DirectEncoder to eliminate nested MarshalJSON allocation chain
-// See: https://github.com/coder/fantasy/commits/190272ce52f0
-replace charm.land/fantasy => github.com/coder/fantasy v0.0.0-20260415162245-190272ce52f0
+// 6) Anthropic EffortXHigh constant for Claude Opus 4.7
+// See: https://github.com/coder/fantasy/commits/959aa39579d2
+replace charm.land/fantasy => github.com/coder/fantasy v0.0.0-20260416152503-959aa39579d2
 
 // coder/coder uses a fork of charmbracelet's fork of the Anthropic Go SDK with some
 // additional performance improvements.

--- a/go.sum
+++ b/go.sum
@@ -324,8 +324,8 @@ github.com/coder/bubbletea v1.2.2-0.20241212190825-007a1cdb2c41 h1:SBN/DA63+ZHwu
 github.com/coder/bubbletea v1.2.2-0.20241212190825-007a1cdb2c41/go.mod h1:I9ULxr64UaOSUv7hcb3nX4kowodJCVS7vt7VVJk/kW4=
 github.com/coder/clistat v1.2.1 h1:P9/10njXMyj5cWzIU5wkRsSy5LVQH49+tcGMsAgWX0w=
 github.com/coder/clistat v1.2.1/go.mod h1:m7SC0uj88eEERgvF8Kn6+w6XF21BeSr+15f7GoLAw0A=
-github.com/coder/fantasy v0.0.0-20260415162245-190272ce52f0 h1:qv8PhuP2tbbR/CR3qnbLWwf+zn/nD+8LcQMWrktxZcQ=
-github.com/coder/fantasy v0.0.0-20260415162245-190272ce52f0/go.mod h1:wZ0e3lEPqrM0XiIdAUQLvMKCLYhc3gi96MRX2wjbX44=
+github.com/coder/fantasy v0.0.0-20260416152503-959aa39579d2 h1:bZoww6da3tFbiYHLgIZuRNTMgsiQDSgblDMSOSmmlzE=
+github.com/coder/fantasy v0.0.0-20260416152503-959aa39579d2/go.mod h1:wZ0e3lEPqrM0XiIdAUQLvMKCLYhc3gi96MRX2wjbX44=
 github.com/coder/flog v1.1.0 h1:kbAes1ai8fIS5OeV+QAnKBQE22ty1jRF/mcAwHpLBa4=
 github.com/coder/flog v1.1.0/go.mod h1:UQlQvrkJBvnRGo69Le8E24Tcl5SJleAAR7gYEHzAmdQ=
 github.com/coder/go-httpstat v0.0.0-20230801153223-321c88088322 h1:m0lPZjlQ7vdVpRBPKfYIFlmgevoTkBxB10wv6l2gOaU=

--- a/site/src/api/chatModelOptionsGenerated.json
+++ b/site/src/api/chatModelOptionsGenerated.json
@@ -109,7 +109,7 @@
 					"description": "Controls the level of reasoning effort",
 					"label": "Reasoning Effort",
 					"required": false,
-					"enum": ["low", "medium", "high", "max"],
+					"enum": ["low", "medium", "high", "xhigh", "max"],
 					"input_type": "select"
 				},
 				{

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/modelConfigFormLogic.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/modelConfigFormLogic.test.ts
@@ -753,6 +753,17 @@ describe("buildModelConfigFromForm", () => {
 			expect(anthropic.disable_parallel_tool_use).toBe(true);
 		});
 
+		it("accepts xhigh for Anthropic effort", () => {
+			const result = buildModelConfigFromForm(
+				"anthropic",
+				formWith({ anthropic: { effort: "xhigh" } }),
+			);
+			expect(result.fieldErrors).toEqual({});
+			const anthropic = result.modelConfig?.provider_options
+				?.anthropic as Record<string, unknown>;
+			expect(anthropic.effort).toBe("xhigh");
+		});
+
 		it("reports error for invalid Anthropic effort option", () => {
 			const result = buildModelConfigFromForm(
 				"anthropic",


### PR DESCRIPTION
Claude Opus 4.7 introduces an `xhigh` effort level between `high` and `max`. Wires it through the Anthropic provider options enum, the chat-config effort normalizer, and the generated chat model options schema that drives the admin UI.

Bumps `coder/fantasy` to pick up `EffortXHigh` (coder/fantasy#26).

Refs: https://www.anthropic.com/news/claude-opus-4-7

> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood