### PR TITLE
docs: add git providers and PR Insights pages for Coder Agents

### DIFF
--- a/docs/admin/external-auth/index.md
+++ b/docs/admin/external-auth/index.md
@@ -244,7 +244,14 @@ CODER_EXTERNAL_AUTH_0_CLIENT_SECRET=xxxxxxx
 CODER_EXTERNAL_AUTH_0_VALIDATE_URL="https://github.example.com/api/v3/user"
 CODER_EXTERNAL_AUTH_0_AUTH_URL="https://github.example.com/login/oauth/authorize"
 CODER_EXTERNAL_AUTH_0_TOKEN_URL="https://github.example.com/login/oauth/access_token"
+CODER_EXTERNAL_AUTH_0_API_BASE_URL="https://github.example.com/api/v3"
 ```
+
+`API_BASE_URL` is required for features like
+[PR Insights](../../ai-coder/agents/platform-controls/pr-insights.md) that use
+the GitHub API to fetch repository and pull request metadata. Without it, Coder
+defaults to `https://api.github.com` and cannot match URLs from your GitHub
+Enterprise instance.
 
 When configuring your GitHub Enterprise OAuth application, set the
 [authorization callback URL](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/about-the-user-authorization-callback-url)

--- a/docs/admin/external-auth/index.md
+++ b/docs/admin/external-auth/index.md
@@ -244,14 +244,7 @@ CODER_EXTERNAL_AUTH_0_CLIENT_SECRET=xxxxxxx
 CODER_EXTERNAL_AUTH_0_VALIDATE_URL="https://github.example.com/api/v3/user"
 CODER_EXTERNAL_AUTH_0_AUTH_URL="https://github.example.com/login/oauth/authorize"
 CODER_EXTERNAL_AUTH_0_TOKEN_URL="https://github.example.com/login/oauth/access_token"
-CODER_EXTERNAL_AUTH_0_API_BASE_URL="https://github.example.com/api/v3"
 ```
-
-`API_BASE_URL` is required for features like
-[PR Insights](../../ai-coder/agents/platform-controls/pr-insights.md) that use
-the GitHub API to fetch repository and pull request metadata. Without it, Coder
-defaults to `https://api.github.com` and cannot match URLs from your GitHub
-Enterprise instance.
 
 When configuring your GitHub Enterprise OAuth application, set the
 [authorization callback URL](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/about-the-user-authorization-callback-url)

--- a/docs/ai-coder/agents/platform-controls/git-providers.md
+++ b/docs/ai-coder/agents/platform-controls/git-providers.md
@@ -1,9 +1,10 @@
 # Git Providers
 
-Coder Agents extends your existing
+Coder Agents leverages your existing
 [external authentication](../../../admin/external-auth/index.md) configuration
-to power the in-chat diff viewer and [PR Insights](./pr-insights.md). These
-features use the GitHub API to fetch diffs, PR status, and review metadata.
+to power the in-chat diff viewer and [PR Insights](./pr-insights.md).
+Self-hosted GitHub Enterprise deployments require one additional setting
+(`API_BASE_URL`) for these features to work.
 
 > [!NOTE]
 > Only `github` type external auth providers are supported today.

--- a/docs/ai-coder/agents/platform-controls/git-providers.md
+++ b/docs/ai-coder/agents/platform-controls/git-providers.md
@@ -1,54 +1,19 @@
 # Git Providers
 
-Coder Agents uses your existing
+Coder Agents extends your existing
 [external authentication](../../../admin/external-auth/index.md) configuration
-to interact with git hosting providers. External auth handles clone, push, and
-credential flows. The git provider integration documented here extends that
-foundation to support Coder Agents features that need richer access to your
-git host's API — specifically the in-chat diff viewer and
-[PR Insights](./pr-insights.md).
+to power the in-chat diff viewer and [PR Insights](./pr-insights.md). These
+features use the GitHub API to fetch diffs, PR status, and review metadata.
 
 > [!NOTE]
-> Only `github` type external auth providers are supported for git provider
-> features today.
-
-## What the git provider enables
-
-When a `github` type external auth provider is fully configured, Coder Agents
-can:
-
-- **Show diffs in the chat UI** — the agent resolves the working branch and
-  remote origin, then fetches the diff from the GitHub API and displays it
-  inline in the conversation.
-- **Track PR analytics** — a background worker fetches PR metadata (status,
-  review state, merge outcome, diff stats) and surfaces it in the
-  [PR Insights](./pr-insights.md) dashboard.
-
-Both features rely on the same underlying mechanism: Coder resolves the git
-remote origin against your external auth configs, builds host-specific URL
-patterns from the provider's API base URL, and uses the matched provider to
-make API calls.
+> Only `github` type external auth providers are supported today.
 
 ## GitHub Enterprise configuration
 
-For public `github.com`, the default configuration from
-[external authentication](../../../admin/external-auth/index.md) is
-sufficient — no additional settings are needed.
+For public `github.com`, no additional configuration is needed.
 
-For self-hosted GitHub Enterprise (GHE) deployments, you must set
-`CODER_EXTERNAL_AUTH_X_API_BASE_URL` in addition to the standard external
-auth variables documented in the
-[GitHub Enterprise](../../../admin/external-auth/index.md#github-enterprise)
-section.
-
-Without `API_BASE_URL`, Coder defaults to `https://api.github.com`. Standard
-auth operations (clone, push, token refresh) still work because they use
-`AUTH_URL` and `TOKEN_URL` directly. However, the git provider builds its
-URL-matching patterns from the API base URL. When the default points to
-`github.com`, Coder cannot match repository origins or PR URLs from your GHE
-instance, and both the diff viewer and PR Insights silently return no data.
-
-### Example
+For self-hosted GitHub Enterprise, add `API_BASE_URL` to your
+[existing configuration](../../../admin/external-auth/index.md#github-enterprise):
 
 ```env
 CODER_EXTERNAL_AUTH_0_ID="primary-github"
@@ -62,33 +27,28 @@ CODER_EXTERNAL_AUTH_0_API_BASE_URL="https://github.example.com/api/v3"
 CODER_EXTERNAL_AUTH_0_REGEX=github\.example\.com
 ```
 
-The key addition compared to the base
-[GitHub Enterprise](../../../admin/external-auth/index.md#github-enterprise)
-configuration is `API_BASE_URL`. This tells Coder to build URL patterns for
-your GHE host and to direct API calls there when fetching diffs and PR
-metadata.
+Without `API_BASE_URL`, Coder defaults to `https://api.github.com`. Clone
+and push still work (they use `AUTH_URL` and `TOKEN_URL` directly), but
+the diff viewer and PR Insights silently fail because Coder builds its
+URL-matching patterns from the API base URL.
 
 > [!NOTE]
 > If you have both a `github.com` and a GHE external auth config, only the
-> GHE config needs `API_BASE_URL`. The `github.com` default is already
-> correct.
+> GHE config needs `API_BASE_URL`.
 
 ## Troubleshooting
 
-### Diffs and PR data not appearing on GHE
+### Diffs or PR data not appearing on GHE
 
-The most common cause is a missing `API_BASE_URL`. Add it to your GHE
-external auth config and restart Coder. The diff viewer and PR Insights
-should start working within a couple of minutes.
+Add `API_BASE_URL` to your GHE external auth config and restart Coder.
+Data should appear within a couple of minutes.
 
 ### Users not seeing diffs
 
-The user who owns the chat must have linked their account through the
-relevant external auth provider. Without a linked token, Coder cannot
-make API calls on their behalf.
+The chat owner must have linked their account through the relevant external
+auth provider.
 
 ### Checking logs
 
-Look for gitsync warnings in Coder logs such as `no provider for origin` or
-`resolve token` errors. These indicate that the remote origin did not match
-any configured external auth provider, or that no valid token was available.
+Look for gitsync warnings such as `no provider for origin` or
+`resolve token` errors.

--- a/docs/ai-coder/agents/platform-controls/git-providers.md
+++ b/docs/ai-coder/agents/platform-controls/git-providers.md
@@ -1,0 +1,94 @@
+# Git Providers
+
+Coder Agents uses your existing
+[external authentication](../../../admin/external-auth/index.md) configuration
+to interact with git hosting providers. External auth handles clone, push, and
+credential flows. The git provider integration documented here extends that
+foundation to support Coder Agents features that need richer access to your
+git host's API — specifically the in-chat diff viewer and
+[PR Insights](./pr-insights.md).
+
+> [!NOTE]
+> Only `github` type external auth providers are supported for git provider
+> features today.
+
+## What the git provider enables
+
+When a `github` type external auth provider is fully configured, Coder Agents
+can:
+
+- **Show diffs in the chat UI** — the agent resolves the working branch and
+  remote origin, then fetches the diff from the GitHub API and displays it
+  inline in the conversation.
+- **Track PR analytics** — a background worker fetches PR metadata (status,
+  review state, merge outcome, diff stats) and surfaces it in the
+  [PR Insights](./pr-insights.md) dashboard.
+
+Both features rely on the same underlying mechanism: Coder resolves the git
+remote origin against your external auth configs, builds host-specific URL
+patterns from the provider's API base URL, and uses the matched provider to
+make API calls.
+
+## GitHub Enterprise configuration
+
+For public `github.com`, the default configuration from
+[external authentication](../../../admin/external-auth/index.md) is
+sufficient — no additional settings are needed.
+
+For self-hosted GitHub Enterprise (GHE) deployments, you must set
+`CODER_EXTERNAL_AUTH_X_API_BASE_URL` in addition to the standard external
+auth variables documented in the
+[GitHub Enterprise](../../../admin/external-auth/index.md#github-enterprise)
+section.
+
+Without `API_BASE_URL`, Coder defaults to `https://api.github.com`. Standard
+auth operations (clone, push, token refresh) still work because they use
+`AUTH_URL` and `TOKEN_URL` directly. However, the git provider builds its
+URL-matching patterns from the API base URL. When the default points to
+`github.com`, Coder cannot match repository origins or PR URLs from your GHE
+instance, and both the diff viewer and PR Insights silently return no data.
+
+### Example
+
+```env
+CODER_EXTERNAL_AUTH_0_ID="primary-github"
+CODER_EXTERNAL_AUTH_0_TYPE=github
+CODER_EXTERNAL_AUTH_0_CLIENT_ID=xxxxxx
+CODER_EXTERNAL_AUTH_0_CLIENT_SECRET=xxxxxxx
+CODER_EXTERNAL_AUTH_0_AUTH_URL="https://github.example.com/login/oauth/authorize"
+CODER_EXTERNAL_AUTH_0_TOKEN_URL="https://github.example.com/login/oauth/access_token"
+CODER_EXTERNAL_AUTH_0_VALIDATE_URL="https://github.example.com/api/v3/user"
+CODER_EXTERNAL_AUTH_0_API_BASE_URL="https://github.example.com/api/v3"
+CODER_EXTERNAL_AUTH_0_REGEX=github\.example\.com
+```
+
+The key addition compared to the base
+[GitHub Enterprise](../../../admin/external-auth/index.md#github-enterprise)
+configuration is `API_BASE_URL`. This tells Coder to build URL patterns for
+your GHE host and to direct API calls there when fetching diffs and PR
+metadata.
+
+> [!NOTE]
+> If you have both a `github.com` and a GHE external auth config, only the
+> GHE config needs `API_BASE_URL`. The `github.com` default is already
+> correct.
+
+## Troubleshooting
+
+### Diffs and PR data not appearing on GHE
+
+The most common cause is a missing `API_BASE_URL`. Add it to your GHE
+external auth config and restart Coder. The diff viewer and PR Insights
+should start working within a couple of minutes.
+
+### Users not seeing diffs
+
+The user who owns the chat must have linked their account through the
+relevant external auth provider. Without a linked token, Coder cannot
+make API calls on their behalf.
+
+### Checking logs
+
+Look for gitsync warnings in Coder logs such as `no provider for origin` or
+`resolve token` errors. These indicate that the remote origin did not match
+any configured external auth provider, or that no valid token was available.

--- a/docs/ai-coder/agents/platform-controls/index.md
+++ b/docs/ai-coder/agents/platform-controls/index.md
@@ -140,7 +140,7 @@ See [Spend Management](./usage-insights.md) for details.
 ### Git providers
 
 Coder Agents leverages your existing
-[external authentication](../../admin/external-auth/index.md) configuration to
+[external authentication](../../../admin/external-auth/index.md) configuration to
 power the in-chat diff viewer and PR Insights. Self-hosted GitHub Enterprise
 deployments require additional configuration for these features.
 

--- a/docs/ai-coder/agents/platform-controls/index.md
+++ b/docs/ai-coder/agents/platform-controls/index.md
@@ -137,6 +137,16 @@ breakdowns.
 
 See [Spend Management](./usage-insights.md) for details.
 
+### PR Insights
+
+PR Insights tracks pull requests created by Coder Agents and surfaces
+analytics on PR activity, merge rates, and cost efficiency. The system
+automatically fetches PR metadata from configured GitHub external auth
+providers.
+
+See [PR Insights](./pr-insights.md) for configuration details, including
+requirements for GitHub Enterprise deployments.
+
 ### Data retention
 
 Administrators can configure a retention period for archived conversations.

--- a/docs/ai-coder/agents/platform-controls/index.md
+++ b/docs/ai-coder/agents/platform-controls/index.md
@@ -139,11 +139,10 @@ See [Spend Management](./usage-insights.md) for details.
 
 ### Git providers
 
-Coder Agents extends your existing
+Coder Agents leverages your existing
 [external authentication](../../admin/external-auth/index.md) configuration to
-support features that need richer access to your git host's API — the in-chat
-diff viewer and PR Insights. For self-hosted GitHub Enterprise deployments,
-additional configuration is required.
+power the in-chat diff viewer and PR Insights. Self-hosted GitHub Enterprise
+deployments require additional configuration for these features.
 
 See [Git Providers](./git-providers.md) for details.
 

--- a/docs/ai-coder/agents/platform-controls/index.md
+++ b/docs/ai-coder/agents/platform-controls/index.md
@@ -137,15 +137,22 @@ breakdowns.
 
 See [Spend Management](./usage-insights.md) for details.
 
+### Git providers
+
+Coder Agents extends your existing
+[external authentication](../../admin/external-auth/index.md) configuration to
+support features that need richer access to your git host's API — the in-chat
+diff viewer and PR Insights. For self-hosted GitHub Enterprise deployments,
+additional configuration is required.
+
+See [Git Providers](./git-providers.md) for details.
+
 ### PR Insights
 
 PR Insights tracks pull requests created by Coder Agents and surfaces
-analytics on PR activity, merge rates, and cost efficiency. The system
-automatically fetches PR metadata from configured GitHub external auth
-providers.
+analytics on PR activity, merge rates, and cost efficiency.
 
-See [PR Insights](./pr-insights.md) for configuration details, including
-requirements for GitHub Enterprise deployments.
+See [PR Insights](./pr-insights.md) for requirements and dashboard details.
 
 ### Data retention
 

--- a/docs/ai-coder/agents/platform-controls/pr-insights.md
+++ b/docs/ai-coder/agents/platform-controls/pr-insights.md
@@ -1,7 +1,9 @@
 # PR Insights
 
 PR Insights tracks pull requests created by Coder Agents and surfaces
-analytics on PR activity, merge rates, and cost efficiency.
+analytics on PR activity, merge rates, and cost efficiency. The dashboard
+(under **Agents** > **Insights** > **PR Insights**) shows merge rates,
+cost per merged PR, per-model breakdowns, and individual PR status.
 
 ## How it works
 
@@ -64,51 +66,6 @@ CODER_EXTERNAL_AUTH_0_REGEX=github\.example\.com
 > [!NOTE]
 > Public `github.com` configurations do not need `API_BASE_URL` — the
 > default (`https://api.github.com`) is already correct.
-
-## Dashboard
-
-Navigate to **Agents** > **Insights** > **PR Insights**.
-
-### Summary view
-
-Period-over-period comparison cards:
-
-- **Total PRs created** — count of PRs opened during the selected period.
-- **Total PRs merged** — count of PRs merged during the selected period.
-- **Merge rate** — percentage of created PRs that were merged.
-- **Cost per merged PR** — total agent spend divided by merged PR count.
-- **Approval rate** — percentage of PRs that received an approving review.
-
-### Per-model breakdown
-
-Table showing per-model stats:
-
-| Column           | Description                                   |
-|------------------|-----------------------------------------------|
-| Model            | LLM model used by the agent                   |
-| Total PRs        | Number of PRs created using this model        |
-| Merge rate       | Percentage of PRs merged for this model       |
-| Cost per merged  | Average agent cost per merged PR              |
-| Additions        | Total lines added across PRs for this model   |
-| Deletions        | Total lines removed across PRs for this model |
-
-### Recent PRs
-
-Table of individual PRs:
-
-| Column        | Description                                    |
-|---------------|------------------------------------------------|
-| PR            | PR number with link to the pull request        |
-| State         | Current state: open, merged, or closed         |
-| Additions     | Lines added                                    |
-| Deletions     | Lines removed                                  |
-| Review status | Approval state from reviewers                  |
-| Chat          | Link to the associated agent chat              |
-| Cost          | Agent spend attributed to this PR              |
-
-### Time series
-
-Daily chart of PRs created, merged, and closed over the selected period.
 
 ## Troubleshooting
 

--- a/docs/ai-coder/agents/platform-controls/pr-insights.md
+++ b/docs/ai-coder/agents/platform-controls/pr-insights.md
@@ -1,0 +1,131 @@
+# PR Insights
+
+PR Insights tracks pull requests created by Coder Agents and surfaces
+analytics on PR activity, merge rates, and cost efficiency.
+
+## How it works
+
+A background worker monitors active agent chats for git activity. When an
+agent pushes a branch or creates a pull request, the worker resolves the git
+remote origin against configured external auth providers.
+
+The worker uses the matched provider's API to fetch PR metadata: status, diff
+stats, review state, and merge outcome.
+
+> [!NOTE]
+> Only `github` type external auth providers are supported for PR Insights
+> today.
+
+## Requirements
+
+For PR data to appear in analytics, all of the following must be true:
+
+1. **External auth is configured for your git host** — The external auth
+   config must have `type` set to `github` with a regex matching your
+   repository URLs. See
+   [External Authentication](../../../admin/external-auth/index.md).
+
+1. **Users have linked their external auth** — The user who ran the agent
+   task must have authenticated with the relevant external auth provider.
+   Without a linked token, the worker cannot fetch PR data and retries on a
+   backoff schedule.
+
+1. **The agent reported a git reference** — The agent must push to a branch
+   with a configured remote origin. If no branch or remote origin is
+   reported, the worker skips the chat.
+
+## GitHub Enterprise configuration
+
+For self-hosted GitHub Enterprise (GHE) deployments, you must set
+`CODER_EXTERNAL_AUTH_X_API_BASE_URL` in addition to the standard external
+auth variables.
+
+Without this, Coder defaults to `https://api.github.com` as the API
+endpoint. Auth operations like clone and push still work because they use the
+`AUTH_URL` and `TOKEN_URL` you configured. However, PR Insights builds its
+URL-matching patterns from the API base URL. When the default points to
+`github.com`, the worker cannot match PR URLs or repository origins from your
+GHE instance, and PR data silently fails to appear.
+
+Example configuration for GHE:
+
+```env
+CODER_EXTERNAL_AUTH_0_ID="primary-github"
+CODER_EXTERNAL_AUTH_0_TYPE=github
+CODER_EXTERNAL_AUTH_0_CLIENT_ID=xxxxxx
+CODER_EXTERNAL_AUTH_0_CLIENT_SECRET=xxxxxxx
+CODER_EXTERNAL_AUTH_0_AUTH_URL="https://github.example.com/login/oauth/authorize"
+CODER_EXTERNAL_AUTH_0_TOKEN_URL="https://github.example.com/login/oauth/access_token"
+CODER_EXTERNAL_AUTH_0_VALIDATE_URL="https://github.example.com/api/v3/user"
+CODER_EXTERNAL_AUTH_0_API_BASE_URL="https://github.example.com/api/v3"
+CODER_EXTERNAL_AUTH_0_REGEX=github\.example\.com
+```
+
+> [!NOTE]
+> Public `github.com` configurations do not need `API_BASE_URL` — the
+> default (`https://api.github.com`) is already correct.
+
+## Dashboard
+
+Navigate to **Agents** > **Insights** > **PR Insights**.
+
+### Summary view
+
+Period-over-period comparison cards:
+
+- **Total PRs created** — count of PRs opened during the selected period.
+- **Total PRs merged** — count of PRs merged during the selected period.
+- **Merge rate** — percentage of created PRs that were merged.
+- **Cost per merged PR** — total agent spend divided by merged PR count.
+- **Approval rate** — percentage of PRs that received an approving review.
+
+### Per-model breakdown
+
+Table showing per-model stats:
+
+| Column           | Description                                   |
+|------------------|-----------------------------------------------|
+| Model            | LLM model used by the agent                   |
+| Total PRs        | Number of PRs created using this model        |
+| Merge rate       | Percentage of PRs merged for this model       |
+| Cost per merged  | Average agent cost per merged PR              |
+| Additions        | Total lines added across PRs for this model   |
+| Deletions        | Total lines removed across PRs for this model |
+
+### Recent PRs
+
+Table of individual PRs:
+
+| Column        | Description                                    |
+|---------------|------------------------------------------------|
+| PR            | PR number with link to the pull request        |
+| State         | Current state: open, merged, or closed         |
+| Additions     | Lines added                                    |
+| Deletions     | Lines removed                                  |
+| Review status | Approval state from reviewers                  |
+| Chat          | Link to the associated agent chat              |
+| Cost          | Agent spend attributed to this PR              |
+
+### Time series
+
+Daily chart of PRs created, merged, and closed over the selected period.
+
+## Troubleshooting
+
+### PRs not appearing
+
+Check that `API_BASE_URL` is set for GHE deployments. Verify the user has
+linked their external auth. Check Coder logs for gitsync warnings like
+`no provider for origin` or token resolution errors.
+
+### Only github.com PRs appear
+
+If you have multiple external auth configs (e.g., `github.com` + GHE),
+ensure the GHE config has `API_BASE_URL` set. The `github.com` config works
+without it because the default is already correct.
+
+### PR data delayed
+
+The gitsync worker polls on a ~10 second interval. New PRs typically appear
+within a couple of minutes. If a token refresh fails, the worker backs off
+for 10 minutes before retrying.

--- a/docs/ai-coder/agents/platform-controls/pr-insights.md
+++ b/docs/ai-coder/agents/platform-controls/pr-insights.md
@@ -36,44 +36,17 @@ For PR data to appear in analytics, all of the following must be true:
    with a configured remote origin. If no branch or remote origin is
    reported, the worker skips the chat.
 
-## GitHub Enterprise configuration
-
-For self-hosted GitHub Enterprise (GHE) deployments, you must set
-`CODER_EXTERNAL_AUTH_X_API_BASE_URL` in addition to the standard external
-auth variables.
-
-Without this, Coder defaults to `https://api.github.com` as the API
-endpoint. Auth operations like clone and push still work because they use the
-`AUTH_URL` and `TOKEN_URL` you configured. However, PR Insights builds its
-URL-matching patterns from the API base URL. When the default points to
-`github.com`, the worker cannot match PR URLs or repository origins from your
-GHE instance, and PR data silently fails to appear.
-
-Example configuration for GHE:
-
-```env
-CODER_EXTERNAL_AUTH_0_ID="primary-github"
-CODER_EXTERNAL_AUTH_0_TYPE=github
-CODER_EXTERNAL_AUTH_0_CLIENT_ID=xxxxxx
-CODER_EXTERNAL_AUTH_0_CLIENT_SECRET=xxxxxxx
-CODER_EXTERNAL_AUTH_0_AUTH_URL="https://github.example.com/login/oauth/authorize"
-CODER_EXTERNAL_AUTH_0_TOKEN_URL="https://github.example.com/login/oauth/access_token"
-CODER_EXTERNAL_AUTH_0_VALIDATE_URL="https://github.example.com/api/v3/user"
-CODER_EXTERNAL_AUTH_0_API_BASE_URL="https://github.example.com/api/v3"
-CODER_EXTERNAL_AUTH_0_REGEX=github\.example\.com
-```
-
-> [!NOTE]
-> Public `github.com` configurations do not need `API_BASE_URL` — the
-> default (`https://api.github.com`) is already correct.
+For self-hosted GitHub Enterprise deployments, additional configuration is
+required. See [Git Providers](./git-providers.md#github-enterprise-configuration).
 
 ## Troubleshooting
 
 ### PRs not appearing
 
-Check that `API_BASE_URL` is set for GHE deployments. Verify the user has
-linked their external auth. Check Coder logs for gitsync warnings like
-`no provider for origin` or token resolution errors.
+Verify the user has linked their external auth. Check Coder logs for gitsync
+warnings like `no provider for origin` or token resolution errors. For GitHub
+Enterprise, confirm that `API_BASE_URL` is set — see
+[Git Providers](./git-providers.md#troubleshooting).
 
 ### Only github.com PRs appear
 
@@ -83,6 +56,6 @@ without it because the default is already correct.
 
 ### PR data delayed
 
-The gitsync worker polls on a ~10 second interval. New PRs typically appear
-within a couple of minutes. If a token refresh fails, the worker backs off
-for 10 minutes before retrying.
+The background worker polls on a ~10 second interval. New PRs typically
+appear within a couple of minutes. If a token refresh fails, the worker
+backs off for 10 minutes before retrying.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1245,16 +1245,16 @@
 									"path": "./ai-coder/agents/platform-controls/mcp-servers.md",
 									"state": ["early access"]
 								},
-								{
-									"title": "Spend Management",
-									"description": "Spend limits and cost tracking for Coder Agents",
-									"path": "./ai-coder/agents/platform-controls/usage-insights.md",
-									"state": ["early access"]
-								},
 									{
-										"title": "Data Retention",
-										"description": "Automatic cleanup of old conversation data",
-										"path": "./ai-coder/agents/platform-controls/chat-retention.md",
+										"title": "Spend Management",
+										"description": "Spend limits and cost tracking for Coder Agents",
+										"path": "./ai-coder/agents/platform-controls/usage-insights.md",
+										"state": ["early access"]
+									},
+									{
+										"title": "Git Providers",
+										"description": "Git provider configuration for the diff viewer and PR Insights",
+										"path": "./ai-coder/agents/platform-controls/git-providers.md",
 										"state": ["early access"]
 									},
 									{
@@ -1262,8 +1262,13 @@
 										"description": "Pull request analytics for Coder Agents",
 										"path": "./ai-coder/agents/platform-controls/pr-insights.md",
 										"state": ["early access"]
-									}
-								]						},
+									},
+									{
+										"title": "Data Retention",
+										"description": "Automatic cleanup of old conversation data",
+										"path": "./ai-coder/agents/platform-controls/chat-retention.md",
+										"state": ["early access"]
+									}								]						},
 						{
 							"title": "Extending Agents",
 							"description": "Add custom skills and MCP tools to agent workspaces",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1251,14 +1251,19 @@
 									"path": "./ai-coder/agents/platform-controls/usage-insights.md",
 									"state": ["early access"]
 								},
-								{
-									"title": "Data Retention",
-									"description": "Automatic cleanup of old conversation data",
-									"path": "./ai-coder/agents/platform-controls/chat-retention.md",
-									"state": ["early access"]
-								}
-							]
-						},
+									{
+										"title": "Data Retention",
+										"description": "Automatic cleanup of old conversation data",
+										"path": "./ai-coder/agents/platform-controls/chat-retention.md",
+										"state": ["early access"]
+									},
+									{
+										"title": "PR Insights",
+										"description": "Pull request analytics for Coder Agents",
+										"path": "./ai-coder/agents/platform-controls/pr-insights.md",
+										"state": ["early access"]
+									}
+								]						},
 						{
 							"title": "Extending Agents",
 							"description": "Add custom skills and MCP tools to agent workspaces",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1245,30 +1245,32 @@
 									"path": "./ai-coder/agents/platform-controls/mcp-servers.md",
 									"state": ["early access"]
 								},
-									{
-										"title": "Spend Management",
-										"description": "Spend limits and cost tracking for Coder Agents",
-										"path": "./ai-coder/agents/platform-controls/usage-insights.md",
-										"state": ["early access"]
-									},
-									{
-										"title": "Git Providers",
-										"description": "Git provider configuration for the diff viewer and PR Insights",
-										"path": "./ai-coder/agents/platform-controls/git-providers.md",
-										"state": ["early access"]
-									},
-									{
-										"title": "PR Insights",
-										"description": "Pull request analytics for Coder Agents",
-										"path": "./ai-coder/agents/platform-controls/pr-insights.md",
-										"state": ["early access"]
-									},
-									{
-										"title": "Data Retention",
-										"description": "Automatic cleanup of old conversation data",
-										"path": "./ai-coder/agents/platform-controls/chat-retention.md",
-										"state": ["early access"]
-									}								]						},
+								{
+									"title": "Spend Management",
+									"description": "Spend limits and cost tracking for Coder Agents",
+									"path": "./ai-coder/agents/platform-controls/usage-insights.md",
+									"state": ["early access"]
+								},
+								{
+									"title": "Git Providers",
+									"description": "Git provider configuration for the diff viewer and PR Insights",
+									"path": "./ai-coder/agents/platform-controls/git-providers.md",
+									"state": ["early access"]
+								},
+								{
+									"title": "PR Insights",
+									"description": "Pull request analytics for Coder Agents",
+									"path": "./ai-coder/agents/platform-controls/pr-insights.md",
+									"state": ["early access"]
+								},
+								{
+									"title": "Data Retention",
+									"description": "Automatic cleanup of old conversation data",
+									"path": "./ai-coder/agents/platform-controls/chat-retention.md",
+									"state": ["early access"]
+								}
+							]
+						},
 						{
 							"title": "Extending Agents",
 							"description": "Add custom skills and MCP tools to agent workspaces",


### PR DESCRIPTION
Adds two new documentation pages under platform controls for Coder Agents:

- **Git Providers** (`git-providers.md`) — documents the `API_BASE_URL` configuration required for self-hosted GitHub Enterprise deployments. Positions it as an extension of the existing [external auth](https://coder.com/docs/admin/external-auth) setup to support Coder Agents features that need richer git host API access: the in-chat diff viewer and PR Insights.
- **PR Insights** (`pr-insights.md`) — documents the PR analytics dashboard, requirements for PR data to appear, and troubleshooting. Links to git-providers for GHE setup.

Also updates the platform controls index and docs manifest.

---

> PR generated with Coder Agents