### PR TITLE
feat: add Explore mode as subagent-only modality

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1183,6 +1183,8 @@ func New(options *Options) *API {
 				r.Put("/system-prompt", api.putChatSystemPrompt)
 				r.Get("/plan-mode-instructions", api.getChatPlanModeInstructions)
 				r.Put("/plan-mode-instructions", api.putChatPlanModeInstructions)
+				r.Get("/explore-model-override", api.getChatExploreModelOverride)
+				r.Put("/explore-model-override", api.putChatExploreModelOverride)
 				r.Get("/desktop-enabled", api.getChatDesktopEnabled)
 				r.Put("/desktop-enabled", api.putChatDesktopEnabled)
 				r.Get("/user-prompt", api.getUserChatCustomPrompt)

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -706,7 +706,7 @@ var (
 				Site: rbac.Permissions(map[string][]policy.Action{
 					rbac.ResourceChat.Type:             {policy.ActionCreate, policy.ActionRead, policy.ActionUpdate, policy.ActionDelete},
 					rbac.ResourceWorkspace.Type:        {policy.ActionRead, policy.ActionUpdate},
-					rbac.ResourceDeploymentConfig.Type: {policy.ActionRead},
+					rbac.ResourceDeploymentConfig.Type: {policy.ActionRead, policy.ActionUpdate},
 					rbac.ResourceUser.Type:             {policy.ActionReadPersonal},
 				}),
 				User:    []rbac.Permission{},
@@ -833,7 +833,7 @@ func AsWorkspaceBuilder(ctx context.Context) context.Context {
 }
 
 // AsChatd returns a context with an actor scoped to the chat
-// daemon's background worker. It can manage chats and read
+// daemon's background worker. It can manage chats and access
 // workspaces and deployment config, but nothing else.
 func AsChatd(ctx context.Context) context.Context {
 	return As(ctx, subjectChatd)
@@ -2680,7 +2680,10 @@ func (q *querier) GetChatDiffStatusesByChatIDs(ctx context.Context, chatIDs []uu
 }
 
 func (q *querier) GetChatExploreModelOverride(ctx context.Context) (string, error) {
-	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceDeploymentConfig); err != nil {
+	// Uses ActionUpdate to match the admin-settings permission model
+	// used by adjacent chat-config endpoints (plan-mode instructions,
+	// system prompt, desktop enabled).
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceDeploymentConfig); err != nil {
 		return "", err
 	}
 	return q.db.GetChatExploreModelOverride(ctx)

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -2679,6 +2679,13 @@ func (q *querier) GetChatDiffStatusesByChatIDs(ctx context.Context, chatIDs []uu
 	return q.db.GetChatDiffStatusesByChatIDs(ctx, chatIDs)
 }
 
+func (q *querier) GetChatExploreModelOverride(ctx context.Context) (string, error) {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceDeploymentConfig); err != nil {
+		return "", err
+	}
+	return q.db.GetChatExploreModelOverride(ctx)
+}
+
 func (q *querier) GetChatFileByID(ctx context.Context, id uuid.UUID) (database.ChatFile, error) {
 	file, err := q.db.GetChatFileByID(ctx, id)
 	if err != nil {
@@ -7294,6 +7301,13 @@ func (q *querier) UpsertChatDiffStatusReference(ctx context.Context, arg databas
 		return database.ChatDiffStatus{}, err
 	}
 	return q.db.UpsertChatDiffStatusReference(ctx, arg)
+}
+
+func (q *querier) UpsertChatExploreModelOverride(ctx context.Context, value string) error {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceDeploymentConfig); err != nil {
+		return err
+	}
+	return q.db.UpsertChatExploreModelOverride(ctx, value)
 }
 
 func (q *querier) UpsertChatIncludeDefaultSystemPrompt(ctx context.Context, includeDefaultSystemPrompt bool) error {

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -706,7 +706,7 @@ var (
 				Site: rbac.Permissions(map[string][]policy.Action{
 					rbac.ResourceChat.Type:             {policy.ActionCreate, policy.ActionRead, policy.ActionUpdate, policy.ActionDelete},
 					rbac.ResourceWorkspace.Type:        {policy.ActionRead, policy.ActionUpdate},
-					rbac.ResourceDeploymentConfig.Type: {policy.ActionRead, policy.ActionUpdate},
+					rbac.ResourceDeploymentConfig.Type: {policy.ActionRead},
 					rbac.ResourceUser.Type:             {policy.ActionReadPersonal},
 				}),
 				User:    []rbac.Permission{},
@@ -2680,10 +2680,7 @@ func (q *querier) GetChatDiffStatusesByChatIDs(ctx context.Context, chatIDs []uu
 }
 
 func (q *querier) GetChatExploreModelOverride(ctx context.Context) (string, error) {
-	// Uses ActionUpdate to match the admin-settings permission model
-	// used by adjacent chat-config endpoints (plan-mode instructions,
-	// system prompt, desktop enabled).
-	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceDeploymentConfig); err != nil {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceDeploymentConfig); err != nil {
 		return "", err
 	}
 	return q.db.GetChatExploreModelOverride(ctx)

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -836,7 +836,7 @@ func (s *MethodTestSuite) TestChats() {
 	}))
 	s.Run("GetChatExploreModelOverride", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
 		dbm.EXPECT().GetChatExploreModelOverride(gomock.Any()).Return("", nil).AnyTimes()
-		check.Args().Asserts(rbac.ResourceDeploymentConfig, policy.ActionUpdate)
+		check.Args().Asserts(rbac.ResourceDeploymentConfig, policy.ActionRead)
 	}))
 	s.Run("GetChatPlanModeInstructions", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
 		dbm.EXPECT().GetChatPlanModeInstructions(gomock.Any()).Return("", nil).AnyTimes()
@@ -6107,16 +6107,14 @@ func TestAsChatd(t *testing.T) {
 			require.NoError(t, err, "workspace %s should be allowed", action)
 		}
 
-		// DeploymentConfig read + update.
-		for _, action := range []policy.Action{
-			policy.ActionRead, policy.ActionUpdate,
-		} {
-			err := auth.Authorize(ctx, actor, action, rbac.ResourceDeploymentConfig)
-			require.NoError(t, err, "deployment config %s should be allowed", action)
-		}
+		// DeploymentConfig reads are allowed, but writes are not.
+		err := auth.Authorize(ctx, actor, policy.ActionRead, rbac.ResourceDeploymentConfig)
+		require.NoError(t, err, "deployment config read should be allowed")
+		err = auth.Authorize(ctx, actor, policy.ActionUpdate, rbac.ResourceDeploymentConfig)
+		require.Error(t, err, "deployment config update should not be allowed")
 
 		// User read_personal (needed for GetUserChatCustomPrompt).
-		err := auth.Authorize(ctx, actor, policy.ActionReadPersonal, rbac.ResourceUser)
+		err = auth.Authorize(ctx, actor, policy.ActionReadPersonal, rbac.ResourceUser)
 		require.NoError(t, err, "user read_personal should be allowed")
 	})
 

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -836,7 +836,7 @@ func (s *MethodTestSuite) TestChats() {
 	}))
 	s.Run("GetChatExploreModelOverride", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
 		dbm.EXPECT().GetChatExploreModelOverride(gomock.Any()).Return("", nil).AnyTimes()
-		check.Args().Asserts(rbac.ResourceDeploymentConfig, policy.ActionRead)
+		check.Args().Asserts(rbac.ResourceDeploymentConfig, policy.ActionUpdate)
 	}))
 	s.Run("GetChatPlanModeInstructions", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
 		dbm.EXPECT().GetChatPlanModeInstructions(gomock.Any()).Return("", nil).AnyTimes()
@@ -6107,12 +6107,16 @@ func TestAsChatd(t *testing.T) {
 			require.NoError(t, err, "workspace %s should be allowed", action)
 		}
 
-		// DeploymentConfig read.
-		err := auth.Authorize(ctx, actor, policy.ActionRead, rbac.ResourceDeploymentConfig)
-		require.NoError(t, err, "deployment config read should be allowed")
+		// DeploymentConfig read + update.
+		for _, action := range []policy.Action{
+			policy.ActionRead, policy.ActionUpdate,
+		} {
+			err := auth.Authorize(ctx, actor, action, rbac.ResourceDeploymentConfig)
+			require.NoError(t, err, "deployment config %s should be allowed", action)
+		}
 
 		// User read_personal (needed for GetUserChatCustomPrompt).
-		err = auth.Authorize(ctx, actor, policy.ActionReadPersonal, rbac.ResourceUser)
+		err := auth.Authorize(ctx, actor, policy.ActionReadPersonal, rbac.ResourceUser)
 		require.NoError(t, err, "user read_personal should be allowed")
 	})
 

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -834,6 +834,10 @@ func (s *MethodTestSuite) TestChats() {
 		dbm.EXPECT().GetChatDesktopEnabled(gomock.Any()).Return(false, nil).AnyTimes()
 		check.Args().Asserts()
 	}))
+	s.Run("GetChatExploreModelOverride", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
+		dbm.EXPECT().GetChatExploreModelOverride(gomock.Any()).Return("", nil).AnyTimes()
+		check.Args().Asserts(rbac.ResourceDeploymentConfig, policy.ActionRead)
+	}))
 	s.Run("GetChatPlanModeInstructions", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
 		dbm.EXPECT().GetChatPlanModeInstructions(gomock.Any()).Return("", nil).AnyTimes()
 		check.Args().Asserts(rbac.ResourceDeploymentConfig, policy.ActionUpdate)
@@ -1134,6 +1138,10 @@ func (s *MethodTestSuite) TestChats() {
 	s.Run("UpsertChatDesktopEnabled", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
 		dbm.EXPECT().UpsertChatDesktopEnabled(gomock.Any(), false).Return(nil).AnyTimes()
 		check.Args(false).Asserts(rbac.ResourceDeploymentConfig, policy.ActionUpdate)
+	}))
+	s.Run("UpsertChatExploreModelOverride", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
+		dbm.EXPECT().UpsertChatExploreModelOverride(gomock.Any(), "").Return(nil).AnyTimes()
+		check.Args("").Asserts(rbac.ResourceDeploymentConfig, policy.ActionUpdate)
 	}))
 	s.Run("UpsertChatPlanModeInstructions", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
 		dbm.EXPECT().UpsertChatPlanModeInstructions(gomock.Any(), "").Return(nil).AnyTimes()

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -1208,6 +1208,14 @@ func (m queryMetricsStore) GetChatDiffStatusesByChatIDs(ctx context.Context, cha
 	return r0, r1
 }
 
+func (m queryMetricsStore) GetChatExploreModelOverride(ctx context.Context) (string, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetChatExploreModelOverride(ctx)
+	m.queryLatencies.WithLabelValues("GetChatExploreModelOverride").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetChatExploreModelOverride").Inc()
+	return r0, r1
+}
+
 func (m queryMetricsStore) GetChatFileByID(ctx context.Context, id uuid.UUID) (database.ChatFile, error) {
 	start := time.Now()
 	r0, r1 := m.s.GetChatFileByID(ctx, id)
@@ -5198,6 +5206,14 @@ func (m queryMetricsStore) UpsertChatDiffStatusReference(ctx context.Context, ar
 	m.queryLatencies.WithLabelValues("UpsertChatDiffStatusReference").Observe(time.Since(start).Seconds())
 	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "UpsertChatDiffStatusReference").Inc()
 	return r0, r1
+}
+
+func (m queryMetricsStore) UpsertChatExploreModelOverride(ctx context.Context, value string) error {
+	start := time.Now()
+	r0 := m.s.UpsertChatExploreModelOverride(ctx, value)
+	m.queryLatencies.WithLabelValues("UpsertChatExploreModelOverride").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "UpsertChatExploreModelOverride").Inc()
+	return r0
 }
 
 func (m queryMetricsStore) UpsertChatIncludeDefaultSystemPrompt(ctx context.Context, includeDefaultSystemPrompt bool) error {

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -2222,6 +2222,21 @@ func (mr *MockStoreMockRecorder) GetChatDiffStatusesByChatIDs(ctx, chatIds any) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChatDiffStatusesByChatIDs", reflect.TypeOf((*MockStore)(nil).GetChatDiffStatusesByChatIDs), ctx, chatIds)
 }
 
+// GetChatExploreModelOverride mocks base method.
+func (m *MockStore) GetChatExploreModelOverride(ctx context.Context) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetChatExploreModelOverride", ctx)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetChatExploreModelOverride indicates an expected call of GetChatExploreModelOverride.
+func (mr *MockStoreMockRecorder) GetChatExploreModelOverride(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChatExploreModelOverride", reflect.TypeOf((*MockStore)(nil).GetChatExploreModelOverride), ctx)
+}
+
 // GetChatFileByID mocks base method.
 func (m *MockStore) GetChatFileByID(ctx context.Context, id uuid.UUID) (database.ChatFile, error) {
 	m.ctrl.T.Helper()
@@ -9770,6 +9785,20 @@ func (m *MockStore) UpsertChatDiffStatusReference(ctx context.Context, arg datab
 func (mr *MockStoreMockRecorder) UpsertChatDiffStatusReference(ctx, arg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertChatDiffStatusReference", reflect.TypeOf((*MockStore)(nil).UpsertChatDiffStatusReference), ctx, arg)
+}
+
+// UpsertChatExploreModelOverride mocks base method.
+func (m *MockStore) UpsertChatExploreModelOverride(ctx context.Context, value string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpsertChatExploreModelOverride", ctx, value)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpsertChatExploreModelOverride indicates an expected call of UpsertChatExploreModelOverride.
+func (mr *MockStoreMockRecorder) UpsertChatExploreModelOverride(ctx, value any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertChatExploreModelOverride", reflect.TypeOf((*MockStore)(nil).UpsertChatExploreModelOverride), ctx, value)
 }
 
 // UpsertChatIncludeDefaultSystemPrompt mocks base method.

--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -289,7 +289,8 @@ CREATE TYPE chat_message_visibility AS ENUM (
 );
 
 CREATE TYPE chat_mode AS ENUM (
-    'computer_use'
+    'computer_use',
+    'explore'
 );
 
 CREATE TYPE chat_plan_mode AS ENUM (

--- a/coderd/database/migrations/000471_chat_explore_mode.down.sql
+++ b/coderd/database/migrations/000471_chat_explore_mode.down.sql
@@ -1,0 +1,2 @@
+-- No-op: enum values remain to avoid churn. Removing chat_mode enum values
+-- requires a create/cast/drop cycle which is intentionally omitted here.

--- a/coderd/database/migrations/000471_chat_explore_mode.up.sql
+++ b/coderd/database/migrations/000471_chat_explore_mode.up.sql
@@ -1,0 +1,1 @@
+ALTER TYPE chat_mode ADD VALUE IF NOT EXISTS 'explore';

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -1294,6 +1294,7 @@ type ChatMode string
 
 const (
 	ChatModeComputerUse ChatMode = "computer_use"
+	ChatModeExplore     ChatMode = "explore"
 )
 
 func (e *ChatMode) Scan(src interface{}) error {
@@ -1333,7 +1334,8 @@ func (ns NullChatMode) Value() (driver.Value, error) {
 
 func (e ChatMode) Valid() bool {
 	switch e {
-	case ChatModeComputerUse:
+	case ChatModeComputerUse,
+		ChatModeExplore:
 		return true
 	}
 	return false
@@ -1342,6 +1344,7 @@ func (e ChatMode) Valid() bool {
 func AllChatModeValues() []ChatMode {
 	return []ChatMode{
 		ChatModeComputerUse,
+		ChatModeExplore,
 	}
 }
 

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -282,6 +282,7 @@ type sqlcQuerier interface {
 	GetChatDesktopEnabled(ctx context.Context) (bool, error)
 	GetChatDiffStatusByChatID(ctx context.Context, chatID uuid.UUID) (ChatDiffStatus, error)
 	GetChatDiffStatusesByChatIDs(ctx context.Context, chatIds []uuid.UUID) ([]ChatDiffStatus, error)
+	GetChatExploreModelOverride(ctx context.Context) (string, error)
 	GetChatFileByID(ctx context.Context, id uuid.UUID) (ChatFile, error)
 	// GetChatFileMetadataByChatID returns lightweight file metadata for
 	// all files linked to a chat. The data column is excluded to avoid
@@ -1102,6 +1103,7 @@ type sqlcQuerier interface {
 	UpsertChatDesktopEnabled(ctx context.Context, enableDesktop bool) error
 	UpsertChatDiffStatus(ctx context.Context, arg UpsertChatDiffStatusParams) (ChatDiffStatus, error)
 	UpsertChatDiffStatusReference(ctx context.Context, arg UpsertChatDiffStatusReferenceParams) (ChatDiffStatus, error)
+	UpsertChatExploreModelOverride(ctx context.Context, value string) error
 	UpsertChatIncludeDefaultSystemPrompt(ctx context.Context, includeDefaultSystemPrompt bool) error
 	UpsertChatPlanModeInstructions(ctx context.Context, value string) error
 	UpsertChatRetentionDays(ctx context.Context, retentionDays int32) error

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -19954,6 +19954,18 @@ func (q *sqlQuerier) GetChatDesktopEnabled(ctx context.Context) (bool, error) {
 	return enable_desktop, err
 }
 
+const getChatExploreModelOverride = `-- name: GetChatExploreModelOverride :one
+SELECT
+	COALESCE((SELECT value FROM site_configs WHERE key = 'agents_chat_explore_model_override'), '') :: text AS model_config_id
+`
+
+func (q *sqlQuerier) GetChatExploreModelOverride(ctx context.Context) (string, error) {
+	row := q.db.QueryRowContext(ctx, getChatExploreModelOverride)
+	var model_config_id string
+	err := row.Scan(&model_config_id)
+	return model_config_id, err
+}
+
 const getChatIncludeDefaultSystemPrompt = `-- name: GetChatIncludeDefaultSystemPrompt :one
 SELECT
     COALESCE(
@@ -20308,6 +20320,16 @@ WHERE site_configs.key = 'agents_desktop_enabled'
 
 func (q *sqlQuerier) UpsertChatDesktopEnabled(ctx context.Context, enableDesktop bool) error {
 	_, err := q.db.ExecContext(ctx, upsertChatDesktopEnabled, enableDesktop)
+	return err
+}
+
+const upsertChatExploreModelOverride = `-- name: UpsertChatExploreModelOverride :exec
+INSERT INTO site_configs (key, value) VALUES ('agents_chat_explore_model_override', $1)
+ON CONFLICT (key) DO UPDATE SET value = $1 WHERE site_configs.key = 'agents_chat_explore_model_override'
+`
+
+func (q *sqlQuerier) UpsertChatExploreModelOverride(ctx context.Context, value string) error {
+	_, err := q.db.ExecContext(ctx, upsertChatExploreModelOverride, value)
 	return err
 }
 

--- a/coderd/database/queries/siteconfig.sql
+++ b/coderd/database/queries/siteconfig.sql
@@ -167,6 +167,14 @@ SELECT
 INSERT INTO site_configs (key, value) VALUES ('agents_chat_plan_mode_instructions', $1)
 ON CONFLICT (key) DO UPDATE SET value = $1 WHERE site_configs.key = 'agents_chat_plan_mode_instructions';
 
+-- name: GetChatExploreModelOverride :one
+SELECT
+	COALESCE((SELECT value FROM site_configs WHERE key = 'agents_chat_explore_model_override'), '') :: text AS model_config_id;
+
+-- name: UpsertChatExploreModelOverride :exec
+INSERT INTO site_configs (key, value) VALUES ('agents_chat_explore_model_override', $1)
+ON CONFLICT (key) DO UPDATE SET value = $1 WHERE site_configs.key = 'agents_chat_explore_model_override';
+
 -- name: GetChatDesktopEnabled :one
 SELECT
 	COALESCE((SELECT value = 'true' FROM site_configs WHERE key = 'agents_desktop_enabled'), false) :: boolean AS enable_desktop;

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -3480,8 +3480,7 @@ func (api *API) getChatExploreModelOverride(rw http.ResponseWriter, r *http.Requ
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
 func (api *API) putChatExploreModelOverride(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	if !api.Authorize(r, policy.ActionUpdate, rbac.ResourceDeploymentConfig) ||
-		!api.Authorize(r, policy.ActionRead, rbac.ResourceDeploymentConfig) {
+	if !api.Authorize(r, policy.ActionUpdate, rbac.ResourceDeploymentConfig) {
 		httpapi.Forbidden(rw)
 		return
 	}

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -391,6 +391,73 @@ func planModeToNullChatPlanMode(mode codersdk.ChatPlanMode) database.NullChatPla
 	}
 }
 
+func validateChatPlanMode(mode codersdk.ChatPlanMode) bool {
+	switch mode {
+	case "", codersdk.ChatPlanModePlan:
+		return true
+	default:
+		return false
+	}
+}
+
+func parseChatExploreModelOverride(raw string) (*uuid.UUID, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		//nolint:nilnil // Empty site-config value means the override is unset.
+		return nil, nil
+	}
+	modelConfigID, err := uuid.Parse(trimmed)
+	if err != nil {
+		return nil, xerrors.Errorf("parse explore model override: %w", err)
+	}
+	return &modelConfigID, nil
+}
+
+func formatChatExploreModelOverride(id *uuid.UUID) string {
+	if id == nil {
+		return ""
+	}
+	return id.String()
+}
+
+func validateChatExploreModelOverrideID(
+	ctx context.Context,
+	db database.Store,
+	id *uuid.UUID,
+) (int, *codersdk.Response) {
+	if id == nil {
+		return 0, nil
+	}
+	if *id == uuid.Nil {
+		return http.StatusBadRequest, &codersdk.Response{
+			Message: "Invalid model_config_id.",
+		}
+	}
+	_, err := db.GetEnabledChatModelConfigByID(ctx, *id)
+	if err == nil {
+		return 0, nil
+	}
+	if xerrors.Is(err, sql.ErrNoRows) {
+		return http.StatusBadRequest, &codersdk.Response{
+			Message: "Invalid model_config_id.",
+		}
+	}
+	return http.StatusInternalServerError, &codersdk.Response{
+		Message: "Internal error validating model config override.",
+		Detail:  err.Error(),
+	}
+}
+
+func (api *API) getChatExploreModelOverrideConfig(
+	ctx context.Context,
+) (*uuid.UUID, error) {
+	raw, err := api.Database.GetChatExploreModelOverride(ctx)
+	if err != nil {
+		return nil, xerrors.Errorf("get explore model override: %w", err)
+	}
+	return parseChatExploreModelOverride(raw)
+}
+
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
 func (api *API) postChats(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -469,10 +536,7 @@ func (api *API) postChats(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	switch req.PlanMode {
-	case codersdk.ChatPlanModePlan, "":
-		// Valid.
-	default:
+	if !validateChatPlanMode(req.PlanMode) {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Invalid plan_mode value.",
 		})
@@ -1776,10 +1840,7 @@ func (api *API) patchChat(rw http.ResponseWriter, r *http.Request) {
 
 	var planModeUpdate *database.NullChatPlanMode
 	if req.PlanMode != nil {
-		switch *req.PlanMode {
-		case codersdk.ChatPlanModePlan, "":
-			// Valid.
-		default:
+		if !validateChatPlanMode(*req.PlanMode) {
 			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 				Message: "Invalid plan_mode value.",
 			})
@@ -2047,10 +2108,7 @@ func (api *API) postChatMessages(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	if req.PlanMode != nil {
-		switch *req.PlanMode {
-		case codersdk.ChatPlanModePlan, "":
-			// Valid.
-		default:
+		if !validateChatPlanMode(*req.PlanMode) {
 			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 				Message: "Invalid plan_mode value.",
 			})
@@ -3387,6 +3445,61 @@ func (api *API) putChatPlanModeInstructions(rw http.ResponseWriter, r *http.Requ
 	if err := api.Database.UpsertChatPlanModeInstructions(ctx, sanitizedInstructions); err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Internal error updating plan mode instructions.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
+	rw.WriteHeader(http.StatusNoContent)
+}
+
+// EXPERIMENTAL: this endpoint is experimental and is subject to change.
+//
+//nolint:revive // get-return: revive assumes get* must be a getter, but this is an HTTP handler.
+func (api *API) getChatExploreModelOverride(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if !api.Authorize(r, policy.ActionRead, rbac.ResourceDeploymentConfig) {
+		httpapi.ResourceNotFound(rw)
+		return
+	}
+
+	modelConfigID, err := api.getChatExploreModelOverrideConfig(ctx)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Internal error fetching Explore model override.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
+	httpapi.Write(ctx, rw, http.StatusOK, codersdk.ChatExploreModelOverrideResponse{
+		ModelConfigID: modelConfigID,
+	})
+}
+
+// EXPERIMENTAL: this endpoint is experimental and is subject to change.
+func (api *API) putChatExploreModelOverride(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if !api.Authorize(r, policy.ActionUpdate, rbac.ResourceDeploymentConfig) ||
+		!api.Authorize(r, policy.ActionRead, rbac.ResourceDeploymentConfig) {
+		httpapi.Forbidden(rw)
+		return
+	}
+
+	var req codersdk.UpdateChatExploreModelOverrideRequest
+	if !httpapi.Read(ctx, rw, r, &req) {
+		return
+	}
+
+	status, resp := validateChatExploreModelOverrideID(ctx, api.Database, req.ModelConfigID)
+	if resp != nil {
+		httpapi.Write(ctx, rw, status, *resp)
+		return
+	}
+
+	if err := api.Database.UpsertChatExploreModelOverride(ctx, formatChatExploreModelOverride(req.ModelConfigID)); err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Internal error updating Explore model override.",
 			Detail:  err.Error(),
 		})
 		return

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -452,10 +452,10 @@ func validateChatExploreModelOverrideID(
 
 func (api *API) getChatExploreModelOverrideConfig(
 	ctx context.Context,
-) (*uuid.UUID, error) {
+) (*uuid.UUID, bool, error) {
 	raw, err := api.Database.GetChatExploreModelOverride(ctx)
 	if err != nil {
-		return nil, xerrors.Errorf("get explore model override: %w", err)
+		return nil, false, xerrors.Errorf("get explore model override: %w", err)
 	}
 	id, err := parseChatExploreModelOverride(raw)
 	if err != nil {
@@ -465,10 +465,9 @@ func (api *API) getChatExploreModelOverrideConfig(
 			slog.F("raw_value", raw),
 			slog.Error(err),
 		)
-		//nolint:nilnil // Malformed stored values are intentionally degraded to unset.
-		return nil, nil
+		return nil, true, nil
 	}
-	return id, nil
+	return id, false, nil
 }
 
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
@@ -3476,7 +3475,7 @@ func (api *API) getChatExploreModelOverride(rw http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	modelConfigID, err := api.getChatExploreModelOverrideConfig(ctx)
+	modelConfigID, hasMalformedOverride, err := api.getChatExploreModelOverrideConfig(ctx)
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Internal error fetching Explore model override.",
@@ -3486,7 +3485,8 @@ func (api *API) getChatExploreModelOverride(rw http.ResponseWriter, r *http.Requ
 	}
 
 	httpapi.Write(ctx, rw, http.StatusOK, codersdk.ChatExploreModelOverrideResponse{
-		ModelConfigID: modelConfigID,
+		ModelConfigID:        modelConfigID,
+		HasMalformedOverride: hasMalformedOverride,
 	})
 }
 

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -3471,7 +3471,7 @@ func (api *API) putChatPlanModeInstructions(rw http.ResponseWriter, r *http.Requ
 //nolint:revive // get-return: revive assumes get* must be a getter, but this is an HTTP handler.
 func (api *API) getChatExploreModelOverride(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	if !api.Authorize(r, policy.ActionRead, rbac.ResourceDeploymentConfig) {
+	if !api.Authorize(r, policy.ActionUpdate, rbac.ResourceDeploymentConfig) {
 		httpapi.ResourceNotFound(rw)
 		return
 	}

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -3471,7 +3471,7 @@ func (api *API) putChatPlanModeInstructions(rw http.ResponseWriter, r *http.Requ
 //nolint:revive // get-return: revive assumes get* must be a getter, but this is an HTTP handler.
 func (api *API) getChatExploreModelOverride(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	if !api.Authorize(r, policy.ActionUpdate, rbac.ResourceDeploymentConfig) {
+	if !api.Authorize(r, policy.ActionRead, rbac.ResourceDeploymentConfig) {
 		httpapi.ResourceNotFound(rw)
 		return
 	}

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -433,7 +433,9 @@ func validateChatExploreModelOverrideID(
 			Message: "Invalid model_config_id.",
 		}
 	}
-	_, err := db.GetEnabledChatModelConfigByID(ctx, *id)
+	//nolint:gocritic // Validation lookup uses system context to check model
+	// availability independently of the caller's read permissions.
+	_, err := db.GetEnabledChatModelConfigByID(dbauthz.AsSystemRestricted(ctx), *id)
 	if err == nil {
 		return 0, nil
 	}
@@ -455,7 +457,18 @@ func (api *API) getChatExploreModelOverrideConfig(
 	if err != nil {
 		return nil, xerrors.Errorf("get explore model override: %w", err)
 	}
-	return parseChatExploreModelOverride(raw)
+	id, err := parseChatExploreModelOverride(raw)
+	if err != nil {
+		// Degrade malformed values to unset so the admin settings page
+		// remains accessible and the bad value can be cleared.
+		api.Logger.Warn(ctx, "malformed explore model override in site config, treating as unset",
+			slog.F("raw_value", raw),
+			slog.Error(err),
+		)
+		//nolint:nilnil // Malformed stored values are intentionally degraded to unset.
+		return nil, nil
+	}
+	return id, nil
 }
 
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -8353,6 +8353,108 @@ func TestChatPlanModeInstructions(t *testing.T) {
 	})
 }
 
+//nolint:tparallel,paralleltest // Subtests share a single coderdtest instance.
+func TestChatExploreModelOverride(t *testing.T) {
+	t.Parallel()
+
+	adminClient, _ := newChatClientWithDatabase(t)
+	firstUser := coderdtest.CreateFirstUser(t, adminClient.Client)
+	defaultModel := createChatModelConfig(t, adminClient)
+	memberClientRaw, _ := coderdtest.CreateAnotherUser(t, adminClient.Client, firstUser.OrganizationID)
+	memberClient := codersdk.NewExperimentalClient(memberClientRaw)
+
+	createAdditionalModel := func(t *testing.T, model string, enabled bool) codersdk.ChatModelConfig {
+		t.Helper()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		contextLimit := int64(4096)
+		isDefault := false
+		modelConfig, err := adminClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+			Provider:     defaultModel.Provider,
+			Model:        model,
+			ContextLimit: &contextLimit,
+			IsDefault:    &isDefault,
+		})
+		require.NoError(t, err)
+		if enabled {
+			return modelConfig
+		}
+		updated, err := adminClient.UpdateChatModelConfig(ctx, modelConfig.ID, codersdk.UpdateChatModelConfigRequest{
+			Enabled: ptr.Ref(false),
+		})
+		require.NoError(t, err)
+		return updated
+	}
+
+	t.Run("DefaultGETReturnsEmpty", func(t *testing.T) {
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		resp, err := adminClient.GetChatExploreModelOverride(ctx)
+		require.NoError(t, err)
+		require.Nil(t, resp.ModelConfigID)
+	})
+
+	t.Run("AdminCanSetAndClear", func(t *testing.T) {
+		ctx := testutil.Context(t, testutil.WaitLong)
+		overrideModel := createAdditionalModel(t, "gpt-4.1-mini", true)
+
+		err := adminClient.UpdateChatExploreModelOverride(ctx, codersdk.UpdateChatExploreModelOverrideRequest{
+			ModelConfigID: &overrideModel.ID,
+		})
+		require.NoError(t, err)
+
+		resp, err := adminClient.GetChatExploreModelOverride(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, resp.ModelConfigID)
+		require.Equal(t, overrideModel.ID, *resp.ModelConfigID)
+
+		err = adminClient.UpdateChatExploreModelOverride(ctx, codersdk.UpdateChatExploreModelOverrideRequest{})
+		require.NoError(t, err)
+
+		resp, err = adminClient.GetChatExploreModelOverride(ctx)
+		require.NoError(t, err)
+		require.Nil(t, resp.ModelConfigID)
+	})
+
+	t.Run("DisabledModelReturns400", func(t *testing.T) {
+		ctx := testutil.Context(t, testutil.WaitLong)
+		disabledModel := createAdditionalModel(t, "gpt-4.1-disabled", false)
+
+		err := adminClient.UpdateChatExploreModelOverride(ctx, codersdk.UpdateChatExploreModelOverrideRequest{
+			ModelConfigID: &disabledModel.ID,
+		})
+		sdkErr := requireSDKError(t, err, http.StatusBadRequest)
+		require.Equal(t, "Invalid model_config_id.", sdkErr.Message)
+	})
+
+	t.Run("UnknownModelReturns400", func(t *testing.T) {
+		ctx := testutil.Context(t, testutil.WaitLong)
+		unknownModelID := uuid.New()
+
+		err := adminClient.UpdateChatExploreModelOverride(ctx, codersdk.UpdateChatExploreModelOverrideRequest{
+			ModelConfigID: &unknownModelID,
+		})
+		sdkErr := requireSDKError(t, err, http.StatusBadRequest)
+		require.Equal(t, "Invalid model_config_id.", sdkErr.Message)
+	})
+
+	t.Run("NonAdminGETReturns404", func(t *testing.T) {
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		_, err := memberClient.GetChatExploreModelOverride(ctx)
+		requireSDKError(t, err, http.StatusNotFound)
+	})
+
+	t.Run("NonAdminPUTReturns403", func(t *testing.T) {
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		err := memberClient.UpdateChatExploreModelOverride(ctx, codersdk.UpdateChatExploreModelOverrideRequest{
+			ModelConfigID: &defaultModel.ID,
+		})
+		requireSDKError(t, err, http.StatusForbidden)
+	})
+}
+
 func TestChatDesktopEnabled(t *testing.T) {
 	t.Parallel()
 

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -8357,7 +8357,7 @@ func TestChatPlanModeInstructions(t *testing.T) {
 func TestChatExploreModelOverride(t *testing.T) {
 	t.Parallel()
 
-	adminClient, _ := newChatClientWithDatabase(t)
+	adminClient, db := newChatClientWithDatabase(t)
 	firstUser := coderdtest.CreateFirstUser(t, adminClient.Client)
 	defaultModel := createChatModelConfig(t, adminClient)
 	memberClientRaw, _ := coderdtest.CreateAnotherUser(t, adminClient.Client, firstUser.OrganizationID)
@@ -8392,6 +8392,7 @@ func TestChatExploreModelOverride(t *testing.T) {
 		resp, err := adminClient.GetChatExploreModelOverride(ctx)
 		require.NoError(t, err)
 		require.Nil(t, resp.ModelConfigID)
+		require.False(t, resp.HasMalformedOverride)
 	})
 
 	t.Run("AdminCanSetAndClear", func(t *testing.T) {
@@ -8407,6 +8408,7 @@ func TestChatExploreModelOverride(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, resp.ModelConfigID)
 		require.Equal(t, overrideModel.ID, *resp.ModelConfigID)
+		require.False(t, resp.HasMalformedOverride)
 
 		err = adminClient.UpdateChatExploreModelOverride(ctx, codersdk.UpdateChatExploreModelOverrideRequest{})
 		require.NoError(t, err)
@@ -8414,6 +8416,29 @@ func TestChatExploreModelOverride(t *testing.T) {
 		resp, err = adminClient.GetChatExploreModelOverride(ctx)
 		require.NoError(t, err)
 		require.Nil(t, resp.ModelConfigID)
+		require.False(t, resp.HasMalformedOverride)
+	})
+
+	t.Run("MalformedStoredOverrideIsReportedAndCanBeCleared", func(t *testing.T) {
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		require.NoError(t, db.UpsertChatExploreModelOverride(
+			dbauthz.AsSystemRestricted(ctx),
+			"not-a-uuid",
+		))
+
+		resp, err := adminClient.GetChatExploreModelOverride(ctx)
+		require.NoError(t, err)
+		require.Nil(t, resp.ModelConfigID)
+		require.True(t, resp.HasMalformedOverride)
+
+		err = adminClient.UpdateChatExploreModelOverride(ctx, codersdk.UpdateChatExploreModelOverrideRequest{})
+		require.NoError(t, err)
+
+		resp, err = adminClient.GetChatExploreModelOverride(ctx)
+		require.NoError(t, err)
+		require.Nil(t, resp.ModelConfigID)
+		require.False(t, resp.HasMalformedOverride)
 	})
 
 	t.Run("DisabledModelReturns400", func(t *testing.T) {

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -4419,7 +4419,7 @@ func allowedPlanToolNames(
 		"start_workspace":          isRootChat,
 		"propose_plan":             isRootChat,
 		"spawn_agent":              isRootChat,
-		"spawn_explore_agent":      false,
+		"spawn_explore_agent":      isRootChat,
 		"wait_agent":               isRootChat,
 		"message_agent":            false,
 		"close_agent":              false,
@@ -4474,6 +4474,9 @@ func allowedExploreToolNames(allTools []fantasy.AgentTool) []string {
 	return toolNames
 }
 
+// allowedBehaviorToolNames applies behavior-specific precedence for
+// tool filtering: Explore mode wins over plan mode, and plan mode wins
+// over the default behavior that allows all tools.
 func allowedBehaviorToolNames(
 	allTools []fantasy.AgentTool,
 	planMode database.NullChatPlanMode,

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -4439,11 +4439,7 @@ func allowedPlanToolNames(
 	return toolNames
 }
 
-func allowedExploreToolNames(
-	allTools []fantasy.AgentTool,
-	parentChatID uuid.NullUUID,
-) []string {
-	_ = parentChatID
+func allowedExploreToolNames(allTools []fantasy.AgentTool) []string {
 	builtinExplorePolicy := map[string]bool{
 		"read_file":                true,
 		"write_file":               false,
@@ -4485,7 +4481,7 @@ func allowedBehaviorToolNames(
 	parentChatID uuid.NullUUID,
 ) []string {
 	if isExploreSubagentMode(chatMode) {
-		return allowedExploreToolNames(allTools, parentChatID)
+		return allowedExploreToolNames(allTools)
 	}
 	if planMode.Valid && planMode.ChatPlanMode == database.ChatPlanModePlan {
 		return allowedPlanToolNames(allTools, parentChatID)

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -4388,12 +4388,22 @@ type runChatResult struct {
 	PendingDynamicToolCalls []chatloop.PendingToolCall
 }
 
+func allToolNames(allTools []fantasy.AgentTool) []string {
+	toolNames := make([]string, 0, len(allTools))
+	for _, tool := range allTools {
+		toolNames = append(toolNames, tool.Info().Name)
+	}
+	return toolNames
+}
+
+func isExploreSubagentMode(mode database.NullChatMode) bool {
+	return mode.Valid && mode.ChatMode == database.ChatModeExplore
+}
+
 func allowedPlanToolNames(
 	allTools []fantasy.AgentTool,
-	mode database.NullChatPlanMode,
 	parentChatID uuid.NullUUID,
 ) []string {
-	isPlanModeTurn := mode.Valid && mode.ChatPlanMode == database.ChatPlanModePlan
 	isRootChat := !parentChatID.Valid
 	builtinPlanPolicy := map[string]bool{
 		"read_file":                true,
@@ -4409,6 +4419,7 @@ func allowedPlanToolNames(
 		"start_workspace":          isRootChat,
 		"propose_plan":             isRootChat,
 		"spawn_agent":              isRootChat,
+		"spawn_explore_agent":      false,
 		"wait_agent":               isRootChat,
 		"message_agent":            false,
 		"close_agent":              false,
@@ -4416,13 +4427,6 @@ func allowedPlanToolNames(
 		"read_skill":               true,
 		"read_skill_file":          true,
 		"ask_user_question":        isRootChat,
-	}
-	if !isPlanModeTurn {
-		toolNames := make([]string, 0, len(allTools))
-		for _, tool := range allTools {
-			toolNames = append(toolNames, tool.Info().Name)
-		}
-		return toolNames
 	}
 
 	toolNames := make([]string, 0, len(allTools))
@@ -4435,8 +4439,66 @@ func allowedPlanToolNames(
 	return toolNames
 }
 
-func stopAfterPlanTools(mode database.NullChatPlanMode, parentChatID uuid.NullUUID) map[string]struct{} {
-	if !mode.Valid || mode.ChatPlanMode != database.ChatPlanModePlan {
+func allowedExploreToolNames(
+	allTools []fantasy.AgentTool,
+	parentChatID uuid.NullUUID,
+) []string {
+	_ = parentChatID
+	builtinExplorePolicy := map[string]bool{
+		"read_file":                true,
+		"write_file":               false,
+		"edit_files":               false,
+		"execute":                  true,
+		"process_output":           true,
+		"process_list":             false,
+		"process_signal":           false,
+		"list_templates":           false,
+		"read_template":            false,
+		"create_workspace":         false,
+		"start_workspace":          false,
+		"propose_plan":             false,
+		"spawn_agent":              false,
+		"spawn_explore_agent":      false,
+		"wait_agent":               false,
+		"message_agent":            false,
+		"close_agent":              false,
+		"spawn_computer_use_agent": false,
+		"read_skill":               true,
+		"read_skill_file":          true,
+		"ask_user_question":        false,
+	}
+
+	toolNames := make([]string, 0, len(allTools))
+	for _, tool := range allTools {
+		name := tool.Info().Name
+		if builtinExplorePolicy[name] {
+			toolNames = append(toolNames, name)
+		}
+	}
+	return toolNames
+}
+
+func allowedBehaviorToolNames(
+	allTools []fantasy.AgentTool,
+	planMode database.NullChatPlanMode,
+	chatMode database.NullChatMode,
+	parentChatID uuid.NullUUID,
+) []string {
+	if isExploreSubagentMode(chatMode) {
+		return allowedExploreToolNames(allTools, parentChatID)
+	}
+	if planMode.Valid && planMode.ChatPlanMode == database.ChatPlanModePlan {
+		return allowedPlanToolNames(allTools, parentChatID)
+	}
+	return allToolNames(allTools)
+}
+
+func stopAfterBehaviorTools(
+	planMode database.NullChatPlanMode,
+	chatMode database.NullChatMode,
+	parentChatID uuid.NullUUID,
+) map[string]struct{} {
+	if isExploreSubagentMode(chatMode) || !planMode.Valid || planMode.ChatPlanMode != database.ChatPlanModePlan {
 		return nil
 	}
 	stopTools := map[string]struct{}{
@@ -4448,8 +4510,9 @@ func stopAfterPlanTools(mode database.NullChatPlanMode, parentChatID uuid.NullUU
 	return stopTools
 }
 
-type systemPromptPlanContext struct {
-	mode                 database.NullChatPlanMode
+type systemPromptBehaviorContext struct {
+	planMode             database.NullChatPlanMode
+	chatMode             database.NullChatMode
 	planModeInstructions string
 	isRootChat           bool
 }
@@ -4463,7 +4526,7 @@ func buildSystemPrompt(
 	instruction string,
 	skills []chattool.SkillMeta,
 	userPrompt string,
-	planContext systemPromptPlanContext,
+	behaviorContext systemPromptBehaviorContext,
 ) []fantasy.Message {
 	if subagentInstruction != "" {
 		prompt = chatprompt.InsertSystem(prompt, subagentInstruction)
@@ -4477,12 +4540,16 @@ func buildSystemPrompt(
 	if userPrompt != "" {
 		prompt = chatprompt.InsertSystem(prompt, userPrompt)
 	}
-	isPlanModeTurn := planContext.mode.Valid && planContext.mode.ChatPlanMode == database.ChatPlanModePlan
+	if isExploreSubagentMode(behaviorContext.chatMode) {
+		prompt = chatprompt.InsertSystem(prompt, ExploreSubagentOverlayPrompt)
+		return prompt
+	}
+	isPlanModeTurn := behaviorContext.planMode.Valid && behaviorContext.planMode.ChatPlanMode == database.ChatPlanModePlan
 	if isPlanModeTurn {
-		if planContext.isRootChat {
+		if behaviorContext.isRootChat {
 			prompt = chatprompt.InsertSystem(prompt, PlanningOverlayPrompt)
-			if planContext.planModeInstructions != "" {
-				prompt = chatprompt.InsertSystem(prompt, planContext.planModeInstructions)
+			if behaviorContext.planModeInstructions != "" {
+				prompt = chatprompt.InsertSystem(prompt, behaviorContext.planModeInstructions)
 			}
 		} else {
 			prompt = chatprompt.InsertSystem(prompt, PlanningSubagentOverlayPrompt)
@@ -4609,7 +4676,7 @@ func (p *Server) appendRootChatTools(
 
 	return append(tools, p.subagentTools(ctx, func() database.Chat {
 		return opts.chat
-	})...)
+	}, opts.modelConfigID)...)
 }
 
 func (p *Server) storePlanSnapshotFile(
@@ -4670,10 +4737,11 @@ func appendDynamicTools(
 	logger slog.Logger,
 	tools []fantasy.AgentTool,
 	raw pqtype.NullRawMessage,
-	mode database.NullChatPlanMode,
+	planMode database.NullChatPlanMode,
+	chatMode database.NullChatMode,
 	parentChatID uuid.NullUUID,
 ) ([]fantasy.AgentTool, map[string]bool, error) {
-	if mode.Valid && mode.ChatPlanMode == database.ChatPlanModePlan {
+	if isExploreSubagentMode(chatMode) || (planMode.Valid && planMode.ChatPlanMode == database.ChatPlanModePlan) {
 		return tools, nil, nil
 	}
 
@@ -4693,7 +4761,7 @@ func appendDynamicTools(
 	}
 
 	activeToolNames := make(map[string]struct{}, len(tools))
-	for _, name := range allowedPlanToolNames(tools, mode, parentChatID) {
+	for _, name := range allowedBehaviorToolNames(tools, planMode, chatMode, parentChatID) {
 		activeToolNames[name] = struct{}{}
 	}
 	for _, t := range tools {
@@ -4800,11 +4868,11 @@ func (p *Server) runChat(
 		return result, err
 	}
 
-	// Capture the current turn's mode from the chat plan mode so prompt
-	// and tool behavior can be resolved consistently for the rest of the
-	// turn.
+	// Capture the current turn's mode so prompt and tool behavior can
+	// be resolved consistently for the rest of the turn.
 	currentPlanMode := chat.PlanMode
 	isPlanModeTurn := currentPlanMode.Valid && currentPlanMode.ChatPlanMode == database.ChatPlanModePlan
+	isExploreSubagent := isExploreSubagentMode(chat.Mode)
 	planModeInstructions := p.loadPlanModeInstructions(ctx, currentPlanMode, logger)
 
 	chainInfo := resolveChainMode(messages)
@@ -5086,8 +5154,9 @@ func (p *Server) runChat(
 		instruction,
 		skills,
 		resolvedUserPrompt,
-		systemPromptPlanContext{
-			mode:                 currentPlanMode,
+		systemPromptBehaviorContext{
+			planMode:             currentPlanMode,
+			chatMode:             chat.Mode,
 			planModeInstructions: planModeInstructions,
 			isRootChat:           isRootChat,
 		},
@@ -5479,7 +5548,7 @@ func (p *Server) runChat(
 	// Append tools from external MCP servers. These appear
 	// after the built-in tools so the LLM sees them as
 	// additional capabilities.
-	if !isPlanModeTurn {
+	if !isPlanModeTurn && !isExploreSubagent {
 		tools = append(tools, mcpTools...)
 		tools = append(tools, workspaceMCPTools...)
 	}
@@ -5494,6 +5563,7 @@ func (p *Server) runChat(
 		tools,
 		chat.DynamicTools,
 		currentPlanMode,
+		chat.Mode,
 		chat.ParentChatID,
 	)
 	if err != nil {
@@ -5503,11 +5573,11 @@ func (p *Server) runChat(
 	// Build provider-native tools (e.g., web search) based on
 	// the model configuration.
 	var providerTools []chatloop.ProviderTool
-	if !isPlanModeTurn && callConfig.ProviderOptions != nil {
+	if !isPlanModeTurn && !isExploreSubagent && callConfig.ProviderOptions != nil {
 		providerTools = buildProviderTools(model.Provider(), callConfig.ProviderOptions)
 	}
 
-	if !isPlanModeTurn && isComputerUse {
+	if !isPlanModeTurn && !isExploreSubagent && isComputerUse {
 		desktopGeometry := workspacesdk.DefaultDesktopGeometry()
 		providerTools = append(providerTools, chatloop.ProviderTool{
 			Definition: chattool.ComputerUseProviderTool(
@@ -5548,8 +5618,8 @@ func (p *Server) runChat(
 		Model:            model,
 		Messages:         prompt,
 		Tools:            tools,
-		ActiveTools:      allowedPlanToolNames(tools, currentPlanMode, chat.ParentChatID),
-		StopAfterTools:   stopAfterPlanTools(currentPlanMode, chat.ParentChatID),
+		ActiveTools:      allowedBehaviorToolNames(tools, currentPlanMode, chat.Mode, chat.ParentChatID),
+		StopAfterTools:   stopAfterBehaviorTools(currentPlanMode, chat.Mode, chat.ParentChatID),
 		MaxSteps:         maxChatSteps,
 		Metrics:          p.metrics,
 		BuiltinToolNames: builtinToolNames,
@@ -5609,8 +5679,9 @@ func (p *Server) runChat(
 				reloadedInstruction,
 				reloadedSkills,
 				reloadUserPrompt,
-				systemPromptPlanContext{
-					mode:                 currentPlanMode,
+				systemPromptBehaviorContext{
+					planMode:             currentPlanMode,
+					chatMode:             chat.Mode,
 					planModeInstructions: planModeInstructions,
 					isRootChat:           isRootChat,
 				},

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -70,30 +70,7 @@ func TestAllowedPlanToolNames(t *testing.T) {
 		return tools
 	}
 
-	planMode := database.NullChatPlanMode{
-		ChatPlanMode: database.ChatPlanModePlan,
-		Valid:        true,
-	}
-
-	t.Run("NormalModeReturnsAllRegisteredTools", func(t *testing.T) {
-		t.Parallel()
-
-		got := allowedPlanToolNames(makeTools(
-			"read_file",
-			"propose_plan",
-			"custom_tool",
-			"execute",
-		), database.NullChatPlanMode{}, uuid.NullUUID{})
-
-		require.Equal(t, []string{
-			"read_file",
-			"propose_plan",
-			"custom_tool",
-			"execute",
-		}, got)
-	})
-
-	t.Run("PlanModeIncludesOnlyAllowlistedBuiltIns", func(t *testing.T) {
+	t.Run("RootPlanModeIncludesOnlyAllowlistedBuiltIns", func(t *testing.T) {
 		t.Parallel()
 
 		got := allowedPlanToolNames(makeTools(
@@ -110,6 +87,7 @@ func TestAllowedPlanToolNames(t *testing.T) {
 			"start_workspace",
 			"propose_plan",
 			"spawn_agent",
+			"spawn_explore_agent",
 			"wait_agent",
 			"message_agent",
 			"close_agent",
@@ -117,7 +95,7 @@ func TestAllowedPlanToolNames(t *testing.T) {
 			"read_skill",
 			"read_skill_file",
 			"ask_user_question",
-		), planMode, uuid.NullUUID{})
+		), uuid.NullUUID{})
 
 		require.Equal(t, []string{
 			"read_file",
@@ -138,7 +116,7 @@ func TestAllowedPlanToolNames(t *testing.T) {
 		}, got)
 	})
 
-	t.Run("PlanModeChildChatsAllowExplorationOnly", func(t *testing.T) {
+	t.Run("ChildPlanModeAllowsExplorationOnly", func(t *testing.T) {
 		t.Parallel()
 
 		got := allowedPlanToolNames(makeTools(
@@ -153,11 +131,12 @@ func TestAllowedPlanToolNames(t *testing.T) {
 			"start_workspace",
 			"propose_plan",
 			"spawn_agent",
+			"spawn_explore_agent",
 			"wait_agent",
 			"read_skill",
 			"read_skill_file",
 			"ask_user_question",
-		), planMode, uuid.NullUUID{UUID: uuid.New(), Valid: true})
+		), uuid.NullUUID{UUID: uuid.New(), Valid: true})
 
 		require.Equal(t, []string{
 			"read_file",
@@ -166,58 +145,116 @@ func TestAllowedPlanToolNames(t *testing.T) {
 			"read_skill",
 			"read_skill_file",
 		}, got)
-		require.NotContains(t, got, "write_file")
-		require.NotContains(t, got, "edit_files")
-		require.NotContains(t, got, "ask_user_question")
-		require.NotContains(t, got, "propose_plan")
-	})
-
-	t.Run("PlanModeStillExcludesDangerousTools", func(t *testing.T) {
-		t.Parallel()
-
-		got := allowedPlanToolNames(makeTools(
-			"execute",
-			"process_output",
-			"message_agent",
-			"spawn_computer_use_agent",
-			"propose_plan",
-		), planMode, uuid.NullUUID{})
-
-		require.Equal(t, []string{"execute", "process_output", "propose_plan"}, got)
-		require.NotContains(t, got, "message_agent")
-		require.NotContains(t, got, "spawn_computer_use_agent")
-	})
-
-	t.Run("PlanModeExcludesUnknownTools", func(t *testing.T) {
-		t.Parallel()
-
-		got := allowedPlanToolNames(makeTools(
-			"read_file",
-			"custom_tool",
-			"another_custom_tool",
-			"propose_plan",
-		), planMode, uuid.NullUUID{})
-
-		require.Equal(t, []string{
-			"read_file",
-			"propose_plan",
-		}, got)
-		require.NotContains(t, got, "custom_tool")
-		require.NotContains(t, got, "another_custom_tool")
 	})
 }
 
-func TestStopAfterPlanTools(t *testing.T) {
+func TestAllowedExploreToolNames(t *testing.T) {
+	t.Parallel()
+
+	makeTools := func(names ...string) []fantasy.AgentTool {
+		tools := make([]fantasy.AgentTool, 0, len(names))
+		for _, name := range names {
+			tools = append(tools, newTestAgentTool(name))
+		}
+		return tools
+	}
+
+	got := allowedExploreToolNames(makeTools(
+		"read_file",
+		"write_file",
+		"edit_files",
+		"execute",
+		"process_output",
+		"process_list",
+		"process_signal",
+		"spawn_agent",
+		"spawn_explore_agent",
+		"wait_agent",
+		"read_skill",
+		"read_skill_file",
+		"ask_user_question",
+	), uuid.NullUUID{UUID: uuid.New(), Valid: true})
+
+	require.Equal(t, []string{
+		"read_file",
+		"execute",
+		"process_output",
+		"read_skill",
+		"read_skill_file",
+	}, got)
+}
+
+func TestAllowedBehaviorToolNames(t *testing.T) {
+	t.Parallel()
+
+	makeTools := func(names ...string) []fantasy.AgentTool {
+		tools := make([]fantasy.AgentTool, 0, len(names))
+		for _, name := range names {
+			tools = append(tools, newTestAgentTool(name))
+		}
+		return tools
+	}
+
+	allTools := makeTools("read_file", "custom_tool", "spawn_explore_agent")
+	planMode := database.NullChatPlanMode{
+		ChatPlanMode: database.ChatPlanModePlan,
+		Valid:        true,
+	}
+	exploreMode := database.NullChatMode{
+		ChatMode: database.ChatModeExplore,
+		Valid:    true,
+	}
+
+	t.Run("DefaultModeReturnsAllTools", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, []string{"read_file", "custom_tool", "spawn_explore_agent"}, allowedBehaviorToolNames(
+			allTools,
+			database.NullChatPlanMode{},
+			database.NullChatMode{},
+			uuid.NullUUID{},
+		))
+	})
+
+	t.Run("PlanModeUsesPlanAllowlist", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, []string{"read_file"}, allowedBehaviorToolNames(
+			allTools,
+			planMode,
+			database.NullChatMode{},
+			uuid.NullUUID{},
+		))
+	})
+
+	t.Run("ExploreModeUsesExploreAllowlist", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, []string{"read_file"}, allowedBehaviorToolNames(
+			allTools,
+			database.NullChatPlanMode{},
+			exploreMode,
+			uuid.NullUUID{UUID: uuid.New(), Valid: true},
+		))
+	})
+}
+
+func TestStopAfterBehaviorTools(t *testing.T) {
 	t.Parallel()
 
 	planMode := database.NullChatPlanMode{
 		ChatPlanMode: database.ChatPlanModePlan,
 		Valid:        true,
 	}
+	exploreMode := database.NullChatMode{
+		ChatMode: database.ChatModeExplore,
+		Valid:    true,
+	}
 
-	t.Run("NormalModeReturnsNil", func(t *testing.T) {
+	t.Run("DefaultModeReturnsNil", func(t *testing.T) {
 		t.Parallel()
-		require.Nil(t, stopAfterPlanTools(database.NullChatPlanMode{}, uuid.NullUUID{}))
+		require.Nil(t, stopAfterBehaviorTools(
+			database.NullChatPlanMode{},
+			database.NullChatMode{},
+			uuid.NullUUID{},
+		))
 	})
 
 	t.Run("RootPlanModeIncludesClarificationTool", func(t *testing.T) {
@@ -225,14 +262,19 @@ func TestStopAfterPlanTools(t *testing.T) {
 		require.Equal(t, map[string]struct{}{
 			"propose_plan":      {},
 			"ask_user_question": {},
-		}, stopAfterPlanTools(planMode, uuid.NullUUID{}))
+		}, stopAfterBehaviorTools(planMode, database.NullChatMode{}, uuid.NullUUID{}))
 	})
 
 	t.Run("ChildPlanModeSkipsClarificationTool", func(t *testing.T) {
 		t.Parallel()
 		require.Equal(t, map[string]struct{}{
 			"propose_plan": {},
-		}, stopAfterPlanTools(planMode, uuid.NullUUID{UUID: uuid.New(), Valid: true}))
+		}, stopAfterBehaviorTools(planMode, database.NullChatMode{}, uuid.NullUUID{UUID: uuid.New(), Valid: true}))
+	})
+
+	t.Run("ExploreModeReturnsNil", func(t *testing.T) {
+		t.Parallel()
+		require.Nil(t, stopAfterBehaviorTools(planMode, exploreMode, uuid.NullUUID{}))
 	})
 }
 

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -109,6 +109,7 @@ func TestAllowedPlanToolNames(t *testing.T) {
 			"start_workspace",
 			"propose_plan",
 			"spawn_agent",
+			"spawn_explore_agent",
 			"wait_agent",
 			"read_skill",
 			"read_skill_file",
@@ -217,7 +218,7 @@ func TestAllowedBehaviorToolNames(t *testing.T) {
 
 	t.Run("PlanModeUsesPlanAllowlist", func(t *testing.T) {
 		t.Parallel()
-		require.Equal(t, []string{"read_file"}, allowedBehaviorToolNames(
+		require.Equal(t, []string{"read_file", "spawn_explore_agent"}, allowedBehaviorToolNames(
 			allTools,
 			planMode,
 			database.NullChatMode{},

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -173,7 +173,7 @@ func TestAllowedExploreToolNames(t *testing.T) {
 		"read_skill",
 		"read_skill_file",
 		"ask_user_question",
-	), uuid.NullUUID{UUID: uuid.New(), Valid: true})
+	))
 
 	require.Equal(t, []string{
 		"read_file",

--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -501,6 +501,160 @@ func TestPlanModeSubagentChatExcludesAskUserQuestion(t *testing.T) {
 	require.False(t, requestHasSystemSubstring(childRequests[0], "When the plan is ready, call propose_plan"))
 }
 
+func TestExploreSubagentIsReadOnly(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	deploymentValues := coderdtest.DeploymentValues(t)
+	deploymentValues.Experiments = []string{string(codersdk.ExperimentAgents)}
+	client, db := coderdtest.NewWithDatabase(t, &coderdtest.Options{
+		DeploymentValues:         deploymentValues,
+		IncludeProvisionerDaemon: true,
+	})
+	user := coderdtest.CreateFirstUser(t, client)
+	expClient := codersdk.NewExperimentalClient(client)
+
+	agentToken := uuid.NewString()
+	version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, &echo.Responses{
+		Parse:          echo.ParseComplete,
+		ProvisionPlan:  echo.PlanComplete,
+		ProvisionApply: echo.ApplyComplete,
+		ProvisionGraph: echo.ProvisionGraphWithAgent(agentToken),
+	})
+	coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+	template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
+	workspace := coderdtest.CreateWorkspace(t, client, template.ID, func(cwr *codersdk.CreateWorkspaceRequest) {
+		cwr.AutomaticUpdates = codersdk.AutomaticUpdatesNever
+	})
+	coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
+	_ = agenttest.New(t, client.URL, agentToken)
+	coderdtest.NewWorkspaceAgentWaiter(t, client, workspace.ID).Wait()
+
+	var toolsMu sync.Mutex
+	toolsByCall := make([][]string, 0, 2)
+	requestsByCall := make([]recordedOpenAIRequest, 0, 2)
+
+	var callCount atomic.Int32
+	openAIURL := chattest.NewOpenAI(t, func(req *chattest.OpenAIRequest) chattest.OpenAIResponse {
+		if !req.Stream {
+			return chattest.OpenAINonStreamingResponse("ok")
+		}
+
+		names := make([]string, 0, len(req.Tools))
+		for _, tool := range req.Tools {
+			names = append(names, tool.Function.Name)
+		}
+		toolsMu.Lock()
+		toolsByCall = append(toolsByCall, names)
+		requestsByCall = append(requestsByCall, recordOpenAIRequest(req))
+		toolsMu.Unlock()
+
+		if callCount.Add(1) == 1 {
+			return chattest.OpenAIStreamingResponse(
+				chattest.OpenAIToolCallChunk("spawn_explore_agent", `{"prompt":"investigate the codebase","title":"sub"}`),
+			)
+		}
+		return chattest.OpenAIStreamingResponse(
+			chattest.OpenAITextChunks("done")...,
+		)
+	})
+
+	_, err := expClient.CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
+		Provider: "openai-compat",
+		APIKey:   "test-api-key",
+		BaseURL:  openAIURL,
+	})
+	require.NoError(t, err)
+
+	contextLimit := int64(4096)
+	isDefault := true
+	_, err = expClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+		Provider:     "openai-compat",
+		Model:        "gpt-4o-mini",
+		ContextLimit: &contextLimit,
+		IsDefault:    &isDefault,
+	})
+	require.NoError(t, err)
+
+	_, err = expClient.CreateChat(ctx, codersdk.CreateChatRequest{
+		OrganizationID: user.OrganizationID,
+		WorkspaceID:    &workspace.ID,
+		Content: []codersdk.ChatInputPart{
+			{
+				Type: codersdk.ChatInputPartTypeText,
+				Text: "Spawn an Explore subagent to inspect the codebase.",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		toolsMu.Lock()
+		defer toolsMu.Unlock()
+
+		sawRoot := false
+		sawChild := false
+		for _, tools := range toolsByCall {
+			if slice.Contains(tools, "spawn_explore_agent") {
+				sawRoot = true
+				continue
+			}
+			sawChild = true
+		}
+		return sawRoot && sawChild
+	}, testutil.WaitLong, testutil.IntervalFast)
+
+	toolsMu.Lock()
+	recorded := append([][]string(nil), toolsByCall...)
+	recordedRequests := append([]recordedOpenAIRequest(nil), requestsByCall...)
+	toolsMu.Unlock()
+
+	require.GreaterOrEqual(t, len(recorded), 2,
+		"expected at least 2 streamed LLM calls (root + subagent)")
+	require.Len(t, recordedRequests, len(recorded))
+
+	var rootCalls, childCalls [][]string
+	var rootRequests, childRequests []recordedOpenAIRequest
+	for i, tools := range recorded {
+		if slice.Contains(tools, "spawn_explore_agent") {
+			rootCalls = append(rootCalls, tools)
+			rootRequests = append(rootRequests, recordedRequests[i])
+			continue
+		}
+		childCalls = append(childCalls, tools)
+		childRequests = append(childRequests, recordedRequests[i])
+	}
+
+	require.NotEmpty(t, rootCalls, "expected at least one root chat LLM call")
+	require.NotEmpty(t, childCalls, "expected at least one subagent LLM call")
+	require.NotEmpty(t, rootRequests, "expected at least one root prompt")
+	require.NotEmpty(t, childRequests, "expected at least one subagent prompt")
+	require.Contains(t, rootCalls[0], "spawn_agent")
+	require.Contains(t, rootCalls[0], "spawn_explore_agent")
+	require.Contains(t, rootCalls[0], "write_file")
+	require.Contains(t, rootCalls[0], "edit_files")
+	require.NotContains(t, childCalls[0], "write_file")
+	require.NotContains(t, childCalls[0], "edit_files")
+	require.NotContains(t, childCalls[0], "spawn_agent")
+	require.NotContains(t, childCalls[0], "spawn_explore_agent")
+	require.NotContains(t, childCalls[0], "wait_agent")
+	require.Contains(t, childCalls[0], "read_file")
+	require.Contains(t, childCalls[0], "execute")
+	require.Contains(t, childCalls[0], "process_output")
+	require.True(t, requestHasSystemSubstring(childRequests[0], "You are in Explore Mode as a delegated sub-agent."))
+	require.False(t, requestHasSystemSubstring(rootRequests[0], "You are in Explore Mode as a delegated sub-agent."))
+
+	allChats, err := db.GetChats(dbauthz.AsChatd(ctx), database.GetChatsParams{OwnerID: user.UserID})
+	require.NoError(t, err)
+	var exploreChildren []database.Chat
+	for _, candidate := range allChats {
+		if candidate.Chat.ParentChatID.Valid && candidate.Chat.Mode.Valid && candidate.Chat.Mode.ChatMode == database.ChatModeExplore {
+			exploreChildren = append(exploreChildren, candidate.Chat)
+		}
+	}
+	require.Len(t, exploreChildren, 1)
+}
+
 func TestInterruptChatClearsWorkerInDatabase(t *testing.T) {
 	t.Parallel()
 

--- a/coderd/x/chatd/prompt.go
+++ b/coderd/x/chatd/prompt.go
@@ -89,7 +89,7 @@ Propose a plan when:
 
 If no workspace is attached to this chat yet, create and start one first using create_workspace and start_workspace.
 Once a workspace is available:
-1. Use spawn_agent and wait_agent to research the codebase and gather context as needed.
+1. Use spawn_explore_agent and wait_agent to research the codebase and gather context as needed. Reserve spawn_agent for writable delegated work.
 2. Use write_file to create a Markdown plan file at the absolute
    chat-specific path from the <plan-file-path> block below when it is
    available.
@@ -125,4 +125,12 @@ const PlanningSubagentOverlayPrompt = `You are in Plan Mode as a delegated sub-a
 Every response must help the parent agent produce a plan.
 You may use read_file, execute, process_output, read_skill, and read_skill_file for exploration, including cloning repositories, searching code, and running inspection commands.
 Do not implement changes or intentionally modify workspace files.
+Return concise findings and recommendations to the parent agent.`
+
+// ExploreSubagentOverlayPrompt contains Explore-mode instructions for
+// delegated child chats.
+const ExploreSubagentOverlayPrompt = `You are in Explore Mode as a delegated sub-agent.
+Focus on discovery, code reading, and understanding the existing system.
+Use read_file, read_skill, execute, and process_output to inspect the workspace.
+Do not intentionally modify workspace files.
 Return concise findings and recommendations to the parent agent.`

--- a/coderd/x/chatd/recording_internal_test.go
+++ b/coderd/x/chatd/recording_internal_test.go
@@ -130,7 +130,7 @@ func invokeWaitAgentTool(
 	parentChat, err := db.GetChatByID(ctx, parentID)
 	require.NoError(t, err)
 
-	tools := server.subagentTools(ctx, func() database.Chat { return parentChat })
+	tools := server.subagentTools(ctx, func() database.Chat { return parentChat }, parentChat.LastModelConfigID)
 	tool := findToolByName(tools, "wait_agent")
 	require.NotNil(t, tool, "wait_agent tool must be present")
 
@@ -525,7 +525,7 @@ func TestWaitAgentTimeoutLeavesRecordingRunning(t *testing.T) {
 	parentChat, err := db.GetChatByID(ctx, child.ParentChatID.UUID)
 	require.NoError(t, err)
 
-	tools := server.subagentTools(ctx, func() database.Chat { return parentChat })
+	tools := server.subagentTools(ctx, func() database.Chat { return parentChat }, parentChat.LastModelConfigID)
 	tool := findToolByName(tools, "wait_agent")
 	require.NotNil(t, tool, "wait_agent tool must be present")
 

--- a/coderd/x/chatd/subagent.go
+++ b/coderd/x/chatd/subagent.go
@@ -229,6 +229,9 @@ func (p *Server) subagentTools(
 				if err != nil {
 					return fantasy.NewTextErrorResponse(err.Error()), nil
 				}
+				// Explore subagents operate independently of planning.
+				// Clear plan mode to prevent the child from inheriting
+				// parent planning behavior.
 				clearPlanMode := database.NullChatPlanMode{}
 				childChat, err := p.createChildSubagentChatWithOptions(
 					ctx,

--- a/coderd/x/chatd/subagent.go
+++ b/coderd/x/chatd/subagent.go
@@ -16,6 +16,7 @@ import (
 
 	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	coderdpubsub "github.com/coder/coder/v2/coderd/pubsub"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatprompt"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatprovider"
@@ -96,7 +97,51 @@ func (p *Server) isDesktopEnabled(ctx context.Context) bool {
 	return enabled
 }
 
-func (p *Server) subagentTools(ctx context.Context, currentChat func() database.Chat) []fantasy.AgentTool {
+func (p *Server) resolveExploreSubagentModelConfigID(
+	ctx context.Context,
+	fallback uuid.UUID,
+) (uuid.UUID, error) {
+	//nolint:gocritic // Chatd needs its scoped deployment-config read access here.
+	chatdCtx := dbauthz.AsChatd(ctx)
+	raw, err := p.db.GetChatExploreModelOverride(chatdCtx)
+	if err != nil {
+		return uuid.Nil, xerrors.Errorf("get Explore model override: %w", err)
+	}
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return fallback, nil
+	}
+	configuredModelConfigID, err := uuid.Parse(trimmed)
+	if err != nil {
+		p.logger.Warn(ctx,
+			"invalid Explore model override, falling back to current turn model",
+			slog.F("raw_model_config_id", trimmed),
+			slog.Error(err),
+		)
+		return fallback, nil
+	}
+	modelConfig, err := p.db.GetEnabledChatModelConfigByID(
+		chatdCtx,
+		configuredModelConfigID,
+	)
+	if err != nil {
+		if xerrors.Is(err, sql.ErrNoRows) {
+			p.logger.Warn(ctx,
+				"explore model override is unavailable, falling back to current turn model",
+				slog.F("model_config_id", configuredModelConfigID),
+			)
+			return fallback, nil
+		}
+		return uuid.Nil, xerrors.Errorf("get enabled chat model config by id: %w", err)
+	}
+	return modelConfig.ID, nil
+}
+
+func (p *Server) subagentTools(
+	ctx context.Context,
+	currentChat func() database.Chat,
+	currentModelConfigID uuid.UUID,
+) []fantasy.AgentTool {
 	var planMode database.NullChatPlanMode
 	if currentChat != nil {
 		planMode = currentChat().PlanMode
@@ -108,9 +153,9 @@ func (p *Server) subagentTools(ctx context.Context, currentChat func() database.
 		"(e.g. fixing a specific bug, writing a single module, " +
 		"running a migration). Do NOT use for simple or quick " +
 		"operations you can handle directly with execute, " +
-		"read_file, or write_file - for example, reading a group " +
-		"of files and outputting them verbatim does not need a " +
-		"subagent. Reserve subagents for tasks that require " +
+		"read_file, or write_file. For read-only investigation and " +
+		"codebase discovery, prefer spawn_explore_agent instead. " +
+		"Reserve writable subagents for tasks that require " +
 		"intellectual work such as code analysis, writing new " +
 		"code, or complex refactoring. Be careful when running " +
 		"parallel subagents: if two subagents modify the same " +
@@ -122,6 +167,7 @@ func (p *Server) subagentTools(ctx context.Context, currentChat func() database.
 	if planMode.Valid && planMode.ChatPlanMode == database.ChatPlanModePlan {
 		spawnAgentDescription += " During plan mode, spawned agents may use shell commands for exploration, such as cloning repositories, searching code, and running inspection commands, but they must not implement changes or intentionally modify workspace files."
 	}
+	spawnExploreAgentDescription := "Spawn a read-only delegated child agent for discovery, code reading, and system understanding. Use this when you need investigation, tracing, codebase research, or architecture discovery without intentionally modifying workspace files. The child agent cannot spawn its own subagents and has a restricted toolset focused on reading files and inspection commands. After spawning, use wait_agent to collect the result."
 
 	tools := []fantasy.AgentTool{
 		fantasy.NewAgentTool(
@@ -160,11 +206,62 @@ func (p *Server) subagentTools(ctx context.Context, currentChat func() database.
 			},
 		),
 		fantasy.NewAgentTool(
+			"spawn_explore_agent",
+			spawnExploreAgentDescription,
+			func(ctx context.Context, args spawnAgentArgs, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
+				if currentChat == nil {
+					return fantasy.NewTextErrorResponse("subagent callbacks are not configured"), nil
+				}
+
+				parent := currentChat()
+				if parent.ParentChatID.Valid {
+					return fantasy.NewTextErrorResponse("delegated chats cannot create child subagents"), nil
+				}
+
+				parent, err := p.db.GetChatByID(ctx, parent.ID)
+				if err != nil {
+					return fantasy.NewTextErrorResponse(err.Error()), nil
+				}
+				modelConfigID, err := p.resolveExploreSubagentModelConfigID(
+					ctx,
+					currentModelConfigID,
+				)
+				if err != nil {
+					return fantasy.NewTextErrorResponse(err.Error()), nil
+				}
+				clearPlanMode := database.NullChatPlanMode{}
+				childChat, err := p.createChildSubagentChatWithOptions(
+					ctx,
+					parent,
+					args.Prompt,
+					args.Title,
+					childSubagentChatOptions{
+						chatMode: database.NullChatMode{
+							ChatMode: database.ChatModeExplore,
+							Valid:    true,
+						},
+						modelConfigIDOverride: &modelConfigID,
+						planModeOverride:      &clearPlanMode,
+					},
+				)
+				if err != nil {
+					return fantasy.NewTextErrorResponse(err.Error()), nil
+				}
+
+				return toolJSONResponse(map[string]any{
+					"chat_id": childChat.ID.String(),
+					"title":   childChat.Title,
+					"status":  string(childChat.Status),
+				}), nil
+			},
+		),
+		fantasy.NewAgentTool(
 			"wait_agent",
 			"Wait until a spawned child agent finishes its task. "+
 				"Returns the agent's final response and status. "+
-				"Call this after spawn_agent to collect the result "+
-				"before continuing your own work.",
+				"Call this after spawn_agent, spawn_explore_agent, or "+
+				"spawn_computer_use_agent to collect the result before "+
+				"continuing your own work.",
 			func(ctx context.Context, args waitAgentArgs, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
 				if currentChat == nil {
 					return fantasy.NewTextErrorResponse("subagent callbacks are not configured"), nil
@@ -414,6 +511,7 @@ type childSubagentChatOptions struct {
 	chatMode              database.NullChatMode
 	systemPrompt          string
 	modelConfigIDOverride *uuid.UUID
+	planModeOverride      *database.NullChatPlanMode
 }
 
 func (p *Server) createChildSubagentChat(
@@ -459,6 +557,11 @@ func (p *Server) createChildSubagentChatWithOptions(
 		return database.Chat{}, xerrors.New("model config is required")
 	}
 
+	childPlanMode := parent.PlanMode
+	if opts.planModeOverride != nil {
+		childPlanMode = *opts.planModeOverride
+	}
+
 	mcpServerIDs := parent.MCPServerIDs
 	if mcpServerIDs == nil {
 		mcpServerIDs = []uuid.UUID{}
@@ -491,7 +594,7 @@ func (p *Server) createChildSubagentChatWithOptions(
 			LastModelConfigID: modelConfigID,
 			Title:             title,
 			Mode:              opts.chatMode,
-			PlanMode:          parent.PlanMode,
+			PlanMode:          childPlanMode,
 			ClientType:        parent.ClientType,
 			Status:            database.ChatStatusPending,
 			MCPServerIDs:      mcpServerIDs,

--- a/coderd/x/chatd/subagent.go
+++ b/coderd/x/chatd/subagent.go
@@ -99,6 +99,7 @@ func (p *Server) isDesktopEnabled(ctx context.Context) bool {
 
 func (p *Server) resolveExploreSubagentModelConfigID(
 	ctx context.Context,
+	ownerID uuid.UUID,
 	fallback uuid.UUID,
 ) (uuid.UUID, error) {
 	//nolint:gocritic // Chatd needs its scoped deployment-config read access here.
@@ -133,6 +134,25 @@ func (p *Server) resolveExploreSubagentModelConfigID(
 			return fallback, nil
 		}
 		return uuid.Nil, xerrors.Errorf("get enabled chat model config by id: %w", err)
+	}
+	providerName, _, err := chatprovider.ResolveModelWithProviderHint(
+		modelConfig.Model,
+		modelConfig.Provider,
+	)
+	if err != nil {
+		return uuid.Nil, xerrors.Errorf("resolve Explore model provider: %w", err)
+	}
+	providerKeys, err := p.resolveUserProviderAPIKeys(ctx, ownerID)
+	if err != nil {
+		return uuid.Nil, xerrors.Errorf("resolve provider API keys: %w", err)
+	}
+	if providerKeys.APIKey(providerName) == "" {
+		p.logger.Warn(ctx,
+			"explore model override credentials are unavailable, falling back to current turn model",
+			slog.F("model_config_id", configuredModelConfigID),
+			slog.F("provider", providerName),
+		)
+		return fallback, nil
 	}
 	return modelConfig.ID, nil
 }
@@ -224,6 +244,7 @@ func (p *Server) subagentTools(
 				}
 				modelConfigID, err := p.resolveExploreSubagentModelConfigID(
 					ctx,
+					parent.OwnerID,
 					currentModelConfigID,
 				)
 				if err != nil {

--- a/coderd/x/chatd/subagent_context_internal_test.go
+++ b/coderd/x/chatd/subagent_context_internal_test.go
@@ -479,7 +479,7 @@ func TestSpawnComputerUseAgentInheritsContext(t *testing.T) {
 	ctx := chatdTestContext(t)
 	parentChat := createParentChatWithInheritedContext(ctx, t, db, server)
 
-	tools := server.subagentTools(ctx, func() database.Chat { return parentChat })
+	tools := server.subagentTools(ctx, func() database.Chat { return parentChat }, parentChat.LastModelConfigID)
 	tool := findToolByName(tools, "spawn_computer_use_agent")
 	require.NotNil(t, tool)
 

--- a/coderd/x/chatd/subagent_internal_test.go
+++ b/coderd/x/chatd/subagent_internal_test.go
@@ -310,6 +310,38 @@ func createInternalParentChat(
 	return parentChat
 }
 
+func runSubagentTool(
+	ctx context.Context,
+	t *testing.T,
+	server *Server,
+	parentChat database.Chat,
+	currentModelConfigID uuid.UUID,
+	toolName string,
+	args spawnAgentArgs,
+) fantasy.ToolResponse {
+	t.Helper()
+
+	tools := server.subagentTools(
+		ctx,
+		func() database.Chat { return parentChat },
+		currentModelConfigID,
+	)
+	tool := findToolByName(tools, toolName)
+	require.NotNil(t, tool, "%s tool must be present", toolName)
+
+	input, err := json.Marshal(args)
+	require.NoError(t, err)
+
+	resp, err := tool.Run(ctx, fantasy.ToolCall{
+		ID:    uuid.NewString(),
+		Name:  toolName,
+		Input: string(input),
+	})
+	require.NoError(t, err)
+
+	return resp
+}
+
 func runSpawnAgentTool(
 	ctx context.Context,
 	t *testing.T,
@@ -318,22 +350,15 @@ func runSpawnAgentTool(
 	args spawnAgentArgs,
 ) fantasy.ToolResponse {
 	t.Helper()
-
-	tools := server.subagentTools(ctx, func() database.Chat { return parentChat })
-	tool := findToolByName(tools, "spawn_agent")
-	require.NotNil(t, tool, "spawn_agent tool must be present")
-
-	input, err := json.Marshal(args)
-	require.NoError(t, err)
-
-	resp, err := tool.Run(ctx, fantasy.ToolCall{
-		ID:    uuid.NewString(),
-		Name:  "spawn_agent",
-		Input: string(input),
-	})
-	require.NoError(t, err)
-
-	return resp
+	return runSubagentTool(
+		ctx,
+		t,
+		server,
+		parentChat,
+		parentChat.LastModelConfigID,
+		"spawn_agent",
+		args,
+	)
 }
 
 func requireSpawnAgentChildChatID(t *testing.T, resp fantasy.ToolResponse) uuid.UUID {
@@ -442,6 +467,108 @@ func TestCreateChildSubagentChat_OverrideWorksWhenParentHasNoModel(t *testing.T)
 	require.Equal(t, overrideModel.ID, childChat.LastModelConfigID)
 }
 
+func TestSpawnExploreAgent_UsesConfiguredModelOverride(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+	server := newInternalTestServer(t, db, ps, chatprovider.ProviderAPIKeys{})
+
+	ctx := chatdTestContext(t)
+	user, org, model := seedInternalChatDeps(ctx, t, db)
+	overrideModel := insertInternalChatModelConfig(
+		ctx, t, db, user.ID, "explore-override-"+uuid.NewString(), true,
+	)
+	require.NoError(t, db.UpsertChatExploreModelOverride(ctx, overrideModel.ID.String()))
+	parentChat := createInternalParentChat(
+		ctx, t, server, db, org.ID, user.ID, model.ID, "parent-explore-override",
+	)
+
+	resp := runSubagentTool(
+		ctx,
+		t,
+		server,
+		parentChat,
+		parentChat.LastModelConfigID,
+		"spawn_explore_agent",
+		spawnAgentArgs{Prompt: "investigate the codebase"},
+	)
+	childID := requireSpawnAgentChildChatID(t, resp)
+
+	childChat, err := db.GetChatByID(ctx, childID)
+	require.NoError(t, err)
+	require.Equal(t, overrideModel.ID, childChat.LastModelConfigID)
+	require.True(t, childChat.Mode.Valid)
+	require.Equal(t, database.ChatModeExplore, childChat.Mode.ChatMode)
+	require.False(t, childChat.PlanMode.Valid)
+}
+
+func TestSpawnExploreAgent_FallsBackToCurrentTurnModel(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+	server := newInternalTestServer(t, db, ps, chatprovider.ProviderAPIKeys{})
+
+	ctx := chatdTestContext(t)
+	user, org, parentModel := seedInternalChatDeps(ctx, t, db)
+	currentTurnModel := insertInternalChatModelConfig(
+		ctx, t, db, user.ID, "explore-current-turn-"+uuid.NewString(), true,
+	)
+	parentChat := createInternalParentChat(
+		ctx, t, server, db, org.ID, user.ID, parentModel.ID, "parent-explore-fallback",
+	)
+
+	resp := runSubagentTool(
+		ctx,
+		t,
+		server,
+		parentChat,
+		currentTurnModel.ID,
+		"spawn_explore_agent",
+		spawnAgentArgs{Prompt: "trace the request flow"},
+	)
+	childID := requireSpawnAgentChildChatID(t, resp)
+
+	childChat, err := db.GetChatByID(ctx, childID)
+	require.NoError(t, err)
+	require.Equal(t, currentTurnModel.ID, childChat.LastModelConfigID)
+	require.Equal(t, parentModel.ID, parentChat.LastModelConfigID)
+}
+
+func TestSpawnExploreAgent_FallsBackWhenOverrideIsUnavailable(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+	server := newInternalTestServer(t, db, ps, chatprovider.ProviderAPIKeys{})
+
+	ctx := chatdTestContext(t)
+	user, org, parentModel := seedInternalChatDeps(ctx, t, db)
+	currentTurnModel := insertInternalChatModelConfig(
+		ctx, t, db, user.ID, "explore-fallback-current-"+uuid.NewString(), true,
+	)
+	disabledModel := insertInternalChatModelConfig(
+		ctx, t, db, user.ID, "explore-disabled-"+uuid.NewString(), false,
+	)
+	require.NoError(t, db.UpsertChatExploreModelOverride(ctx, disabledModel.ID.String()))
+	parentChat := createInternalParentChat(
+		ctx, t, server, db, org.ID, user.ID, parentModel.ID, "parent-explore-disabled",
+	)
+
+	resp := runSubagentTool(
+		ctx,
+		t,
+		server,
+		parentChat,
+		currentTurnModel.ID,
+		"spawn_explore_agent",
+		spawnAgentArgs{Prompt: "inspect the service boundaries"},
+	)
+	childID := requireSpawnAgentChildChatID(t, resp)
+
+	childChat, err := db.GetChatByID(ctx, childID)
+	require.NoError(t, err)
+	require.Equal(t, currentTurnModel.ID, childChat.LastModelConfigID)
+}
+
 func TestSpawnComputerUseAgent_NoAnthropicProvider(t *testing.T) {
 	t.Parallel()
 
@@ -467,7 +594,7 @@ func TestSpawnComputerUseAgent_NoAnthropicProvider(t *testing.T) {
 	parentChat, err := db.GetChatByID(ctx, parent.ID)
 	require.NoError(t, err)
 
-	tools := server.subagentTools(ctx, func() database.Chat { return parentChat })
+	tools := server.subagentTools(ctx, func() database.Chat { return parentChat }, parentChat.LastModelConfigID)
 	tool := findToolByName(tools, "spawn_computer_use_agent")
 	assert.Nil(t, tool, "spawn_computer_use_agent tool must be omitted when Anthropic is not configured")
 }
@@ -520,7 +647,7 @@ func TestSpawnComputerUseAgent_NotAvailableForChildChats(t *testing.T) {
 		"child chat must have a parent")
 
 	// Get tools as if the child chat is the current chat.
-	tools := server.subagentTools(ctx, func() database.Chat { return childChat })
+	tools := server.subagentTools(ctx, func() database.Chat { return childChat }, childChat.LastModelConfigID)
 	tool := findToolByName(tools, "spawn_computer_use_agent")
 	require.NotNil(t, tool, "spawn_computer_use_agent tool must be present")
 
@@ -556,7 +683,7 @@ func TestSpawnComputerUseAgent_DesktopDisabled(t *testing.T) {
 	parentChat, err := db.GetChatByID(ctx, parent.ID)
 	require.NoError(t, err)
 
-	tools := server.subagentTools(ctx, func() database.Chat { return parentChat })
+	tools := server.subagentTools(ctx, func() database.Chat { return parentChat }, parentChat.LastModelConfigID)
 	tool := findToolByName(tools, "spawn_computer_use_agent")
 	assert.Nil(t, tool, "spawn_computer_use_agent tool must be omitted when desktop is disabled")
 }
@@ -603,7 +730,7 @@ func TestSpawnComputerUseAgent_UsesComputerUseModelNotParent(t *testing.T) {
 	parentChat, err := db.GetChatByID(ctx, parent.ID)
 	require.NoError(t, err)
 
-	tools := server.subagentTools(ctx, func() database.Chat { return parentChat })
+	tools := server.subagentTools(ctx, func() database.Chat { return parentChat }, parentChat.LastModelConfigID)
 	tool := findToolByName(tools, "spawn_computer_use_agent")
 	require.NotNil(t, tool)
 
@@ -768,7 +895,7 @@ func TestSpawnComputerUseAgent_InheritsMCPServerIDs(t *testing.T) {
 	require.NoError(t, err)
 
 	// Call spawn_computer_use_agent via the tool.
-	tools := server.subagentTools(ctx, func() database.Chat { return parentChat })
+	tools := server.subagentTools(ctx, func() database.Chat { return parentChat }, parentChat.LastModelConfigID)
 	tool := findToolByName(tools, "spawn_computer_use_agent")
 	require.NotNil(t, tool)
 

--- a/coderd/x/chatd/subagent_internal_test.go
+++ b/coderd/x/chatd/subagent_internal_test.go
@@ -534,6 +534,38 @@ func TestSpawnExploreAgent_FallsBackToCurrentTurnModel(t *testing.T) {
 	require.Equal(t, parentModel.ID, parentChat.LastModelConfigID)
 }
 
+func TestSpawnExploreAgent_FallsBackOnInvalidUUID(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+	server := newInternalTestServer(t, db, ps, chatprovider.ProviderAPIKeys{})
+
+	ctx := chatdTestContext(t)
+	user, org, parentModel := seedInternalChatDeps(ctx, t, db)
+	currentTurnModel := insertInternalChatModelConfig(
+		ctx, t, db, user.ID, "explore-invalid-override-"+uuid.NewString(), true,
+	)
+	require.NoError(t, db.UpsertChatExploreModelOverride(ctx, "not-a-uuid"))
+	parentChat := createInternalParentChat(
+		ctx, t, server, db, org.ID, user.ID, parentModel.ID, "parent-explore-invalid-override",
+	)
+
+	resp := runSubagentTool(
+		ctx,
+		t,
+		server,
+		parentChat,
+		currentTurnModel.ID,
+		"spawn_explore_agent",
+		spawnAgentArgs{Prompt: "inspect the handler flow"},
+	)
+	childID := requireSpawnAgentChildChatID(t, resp)
+
+	childChat, err := db.GetChatByID(ctx, childID)
+	require.NoError(t, err)
+	require.Equal(t, currentTurnModel.ID, childChat.LastModelConfigID)
+}
+
 func TestSpawnExploreAgent_FallsBackWhenOverrideIsUnavailable(t *testing.T) {
 	t.Parallel()
 

--- a/coderd/x/chatd/subagent_internal_test.go
+++ b/coderd/x/chatd/subagent_internal_test.go
@@ -601,6 +601,63 @@ func TestSpawnExploreAgent_FallsBackWhenOverrideIsUnavailable(t *testing.T) {
 	require.Equal(t, currentTurnModel.ID, childChat.LastModelConfigID)
 }
 
+func TestSpawnExploreAgent_FallsBackWhenOverrideCredentialsAreUnavailable(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+	server := newInternalTestServer(t, db, ps, chatprovider.ProviderAPIKeys{})
+
+	ctx := chatdTestContext(t)
+	user, org, parentModel := seedInternalChatDeps(ctx, t, db)
+	currentTurnModel := insertInternalChatModelConfig(
+		ctx, t, db, user.ID, "explore-missing-user-key-current-"+uuid.NewString(), true,
+	)
+	_, err := db.InsertChatProvider(ctx, database.InsertChatProviderParams{
+		Provider:                   "openai-compat",
+		DisplayName:                "OpenAI Compat",
+		APIKey:                     "",
+		BaseUrl:                    "",
+		CreatedBy:                  uuid.NullUUID{UUID: user.ID, Valid: true},
+		Enabled:                    true,
+		CentralApiKeyEnabled:       false,
+		AllowUserApiKey:            true,
+		AllowCentralApiKeyFallback: false,
+	})
+	require.NoError(t, err)
+	overrideModel, err := db.InsertChatModelConfig(ctx, database.InsertChatModelConfigParams{
+		Provider:             "openai-compat",
+		Model:                "gpt-4o-mini",
+		DisplayName:          "Explore Override Missing User Key",
+		CreatedBy:            uuid.NullUUID{UUID: user.ID, Valid: true},
+		UpdatedBy:            uuid.NullUUID{UUID: user.ID, Valid: true},
+		Enabled:              true,
+		IsDefault:            false,
+		ContextLimit:         128000,
+		CompressionThreshold: 70,
+		Options:              json.RawMessage(`{}`),
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.UpsertChatExploreModelOverride(ctx, overrideModel.ID.String()))
+	parentChat := createInternalParentChat(
+		ctx, t, server, db, org.ID, user.ID, parentModel.ID, "parent-explore-missing-user-key",
+	)
+
+	resp := runSubagentTool(
+		ctx,
+		t,
+		server,
+		parentChat,
+		currentTurnModel.ID,
+		"spawn_explore_agent",
+		spawnAgentArgs{Prompt: "inspect provider credential handling"},
+	)
+	childID := requireSpawnAgentChildChatID(t, resp)
+
+	childChat, err := db.GetChatByID(ctx, childID)
+	require.NoError(t, err)
+	require.Equal(t, currentTurnModel.ID, childChat.LastModelConfigID)
+}
+
 func TestSpawnComputerUseAgent_NoAnthropicProvider(t *testing.T) {
 	t.Parallel()
 

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -554,6 +554,18 @@ type UpdateChatPlanModeInstructionsRequest struct {
 	PlanModeInstructions string `json:"plan_mode_instructions"`
 }
 
+// ChatExploreModelOverrideResponse is the response body for the Explore
+// subagent model override configuration endpoint.
+type ChatExploreModelOverrideResponse struct {
+	ModelConfigID *uuid.UUID `json:"model_config_id,omitempty" format:"uuid"`
+}
+
+// UpdateChatExploreModelOverrideRequest is the request body for updating the
+// Explore subagent model override configuration endpoint.
+type UpdateChatExploreModelOverrideRequest struct {
+	ModelConfigID *uuid.UUID `json:"model_config_id,omitempty" format:"uuid"`
+}
+
 // UserChatCustomPrompt is the request and response body for the
 // user chat custom prompt configuration endpoint.
 type UserChatCustomPrompt struct {
@@ -1948,6 +1960,35 @@ func (c *ExperimentalClient) GetChatPlanModeInstructions(ctx context.Context) (C
 // UpdateChatPlanModeInstructions updates the deployment-wide plan mode instructions.
 func (c *ExperimentalClient) UpdateChatPlanModeInstructions(ctx context.Context, req UpdateChatPlanModeInstructionsRequest) error {
 	res, err := c.Request(ctx, http.MethodPut, "/api/experimental/chats/config/plan-mode-instructions", req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusNoContent {
+		return ReadBodyAsError(res)
+	}
+	return nil
+}
+
+// GetChatExploreModelOverride returns the deployment-wide Explore subagent
+// model override.
+func (c *ExperimentalClient) GetChatExploreModelOverride(ctx context.Context) (ChatExploreModelOverrideResponse, error) {
+	res, err := c.Request(ctx, http.MethodGet, "/api/experimental/chats/config/explore-model-override", nil)
+	if err != nil {
+		return ChatExploreModelOverrideResponse{}, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return ChatExploreModelOverrideResponse{}, ReadBodyAsError(res)
+	}
+	var resp ChatExploreModelOverrideResponse
+	return resp, json.NewDecoder(res.Body).Decode(&resp)
+}
+
+// UpdateChatExploreModelOverride updates the deployment-wide Explore subagent
+// model override.
+func (c *ExperimentalClient) UpdateChatExploreModelOverride(ctx context.Context, req UpdateChatExploreModelOverrideRequest) error {
+	res, err := c.Request(ctx, http.MethodPut, "/api/experimental/chats/config/explore-model-override", req)
 	if err != nil {
 		return err
 	}

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -558,6 +558,9 @@ type UpdateChatPlanModeInstructionsRequest struct {
 // subagent model override configuration endpoint.
 type ChatExploreModelOverrideResponse struct {
 	ModelConfigID *uuid.UUID `json:"model_config_id,omitempty" format:"uuid"`
+	// HasMalformedOverride reports whether the saved override is malformed and
+	// is currently being treated as unset.
+	HasMalformedOverride bool `json:"has_malformed_override"`
 }
 
 // UpdateChatExploreModelOverrideRequest is the request body for updating the

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -3276,6 +3276,24 @@ class ExperimentalApiMethods {
 		);
 	};
 
+	getChatExploreModelOverride =
+		async (): Promise<TypesGen.ChatExploreModelOverrideResponse> => {
+			const response =
+				await this.axios.get<TypesGen.ChatExploreModelOverrideResponse>(
+					"/api/experimental/chats/config/explore-model-override",
+				);
+			return response.data;
+		};
+
+	updateChatExploreModelOverride = async (
+		req: TypesGen.UpdateChatExploreModelOverrideRequest,
+	): Promise<void> => {
+		await this.axios.put(
+			"/api/experimental/chats/config/explore-model-override",
+			req,
+		);
+	};
+
 	getChatDesktopEnabled =
 		async (): Promise<TypesGen.ChatDesktopEnabledResponse> => {
 			const response =

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -922,6 +922,23 @@ export const updateChatPlanModeInstructions = (queryClient: QueryClient) => ({
 	},
 });
 
+const chatExploreModelOverrideKey = ["chat-explore-model-override"] as const;
+
+export const chatExploreModelOverride = () => ({
+	queryKey: chatExploreModelOverrideKey,
+	queryFn: () => API.experimental.getChatExploreModelOverride(),
+});
+
+export const updateChatExploreModelOverride = (queryClient: QueryClient) => ({
+	mutationFn: (req: TypesGen.UpdateChatExploreModelOverrideRequest) =>
+		API.experimental.updateChatExploreModelOverride(req),
+	onSuccess: async () => {
+		await queryClient.invalidateQueries({
+			queryKey: chatExploreModelOverrideKey,
+		});
+	},
+});
+
 const chatDesktopEnabledKey = ["chat-desktop-enabled"] as const;
 
 export const chatDesktopEnabled = () => ({

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1584,6 +1584,15 @@ export interface ChatDiffStatus {
 
 // From codersdk/chats.go
 /**
+ * ChatExploreModelOverrideResponse is the response body for the Explore
+ * subagent model override configuration endpoint.
+ */
+export interface ChatExploreModelOverrideResponse {
+	readonly model_config_id?: string;
+}
+
+// From codersdk/chats.go
+/**
  * ChatFileMetadata contains lightweight metadata about a file
  * associated with a chat, excluding the file content itself.
  */
@@ -7579,6 +7588,15 @@ export interface UpdateChatDebugLoggingAllowUsersRequest {
  */
 export interface UpdateChatDesktopEnabledRequest {
 	readonly enable_desktop: boolean;
+}
+
+// From codersdk/chats.go
+/**
+ * UpdateChatExploreModelOverrideRequest is the request body for updating the
+ * Explore subagent model override configuration endpoint.
+ */
+export interface UpdateChatExploreModelOverrideRequest {
+	readonly model_config_id?: string;
 }
 
 // From codersdk/chats.go

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -1589,6 +1589,11 @@ export interface ChatDiffStatus {
  */
 export interface ChatExploreModelOverrideResponse {
 	readonly model_config_id?: string;
+	/**
+	 * HasMalformedOverride reports whether the saved override is malformed and
+	 * is currently being treated as unset.
+	 */
+	readonly has_malformed_override: boolean;
 }
 
 // From codersdk/chats.go

--- a/site/src/pages/AgentsPage/AgentSettingsAgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsAgentsPage.tsx
@@ -1,0 +1,44 @@
+import type { FC } from "react";
+import { useMutation, useQuery, useQueryClient } from "react-query";
+import {
+	chatExploreModelOverride,
+	chatModelConfigs,
+	updateChatExploreModelOverride,
+} from "#/api/queries/chats";
+import { useAuthenticated } from "#/hooks/useAuthenticated";
+import { RequirePermission } from "#/modules/permissions/RequirePermission";
+import { AgentSettingsAgentsPageView } from "./AgentSettingsAgentsPageView";
+
+const AgentSettingsAgentsPage: FC = () => {
+	const { permissions } = useAuthenticated();
+	const queryClient = useQueryClient();
+
+	const exploreModelOverrideQuery = useQuery({
+		...chatExploreModelOverride(),
+		enabled: permissions.editDeploymentConfig,
+	});
+	const modelConfigsQuery = useQuery(chatModelConfigs());
+	const saveExploreModelOverrideMutation = useMutation(
+		updateChatExploreModelOverride(queryClient),
+	);
+
+	return (
+		<RequirePermission isFeatureVisible={permissions.editDeploymentConfig}>
+			<AgentSettingsAgentsPageView
+				exploreModelOverrideData={exploreModelOverrideQuery.data}
+				modelConfigsData={modelConfigsQuery.data}
+				modelConfigsError={modelConfigsQuery.error}
+				isLoadingModelConfigs={modelConfigsQuery.isLoading}
+				onSaveExploreModelOverride={saveExploreModelOverrideMutation.mutate}
+				isSavingExploreModelOverride={
+					saveExploreModelOverrideMutation.isPending
+				}
+				isSaveExploreModelOverrideError={
+					saveExploreModelOverrideMutation.isError
+				}
+			/>
+		</RequirePermission>
+	);
+};
+
+export default AgentSettingsAgentsPage;

--- a/site/src/pages/AgentsPage/AgentSettingsAgentsPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsAgentsPageView.stories.tsx
@@ -7,7 +7,9 @@ import {
 } from "./AgentSettingsAgentsPageView";
 
 const baseArgs: AgentSettingsAgentsPageViewProps = {
-	exploreModelOverrideData: {},
+	exploreModelOverrideData: {
+		has_malformed_override: false,
+	},
 	modelConfigsData: [],
 	modelConfigsError: undefined,
 	isLoadingModelConfigs: false,
@@ -29,6 +31,7 @@ export const ExploreModelOverrideSetting: Story = {
 	args: {
 		exploreModelOverrideData: {
 			model_config_id: "model-explore-1",
+			has_malformed_override: false,
 		},
 		modelConfigsData: [
 			{
@@ -89,8 +92,24 @@ export const ExploreModelOverrideSetting: Story = {
 
 export const ExploreModelOverrideAllowsExplicitClear: Story = {
 	args: {
-		exploreModelOverrideData: {},
-		modelConfigsData: [],
+		exploreModelOverrideData: {
+			model_config_id: "model-explore-clear",
+			has_malformed_override: false,
+		},
+		modelConfigsData: [
+			{
+				id: "model-explore-clear",
+				provider: "openai",
+				model: "gpt-4.1-mini",
+				display_name: "GPT 4.1 Mini",
+				enabled: true,
+				is_default: false,
+				context_limit: 1_000_000,
+				compression_threshold: 70,
+				created_at: "2026-03-12T12:00:00.000Z",
+				updated_at: "2026-03-12T12:00:00.000Z",
+			},
+		] as TypesGen.ChatModelConfig[],
 		onSaveExploreModelOverride: fn(),
 	},
 	play: async ({ canvasElement, args }) => {
@@ -102,7 +121,14 @@ export const ExploreModelOverrideAllowsExplicitClear: Story = {
 				"Expected Explore model clear button to live inside a form.",
 			);
 		}
+
+		const saveButton = within(form).getByRole("button", { name: "Save" });
 		await userEvent.click(clearButton);
+		expect(args.onSaveExploreModelOverride).not.toHaveBeenCalled();
+		await waitFor(() => {
+			expect(saveButton).toBeEnabled();
+		});
+		await userEvent.click(saveButton);
 		await waitFor(() => {
 			expect(args.onSaveExploreModelOverride).toHaveBeenCalledWith(
 				{},
@@ -111,10 +137,49 @@ export const ExploreModelOverrideAllowsExplicitClear: Story = {
 		});
 	},
 };
+
+export const ExploreModelOverrideClearsMalformedSavedValue: Story = {
+	args: {
+		exploreModelOverrideData: {
+			has_malformed_override: true,
+		},
+		modelConfigsData: [],
+		onSaveExploreModelOverride: fn(),
+	},
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		await canvas.findByText(
+			"The saved override is malformed and is being treated as unset. Click Save to clear it.",
+		);
+		const clearButton = await canvas.findByRole("button", { name: "Clear" });
+		const form = clearButton.closest("form");
+		if (!(form instanceof HTMLFormElement)) {
+			throw new Error(
+				"Expected Explore model clear button to live inside a form.",
+			);
+		}
+
+		const saveButton = within(form).getByRole("button", { name: "Save" });
+		await waitFor(() => {
+			expect(saveButton).toBeEnabled();
+		});
+		await userEvent.click(clearButton);
+		expect(args.onSaveExploreModelOverride).not.toHaveBeenCalled();
+		await userEvent.click(saveButton);
+		await waitFor(() => {
+			expect(args.onSaveExploreModelOverride).toHaveBeenCalledWith(
+				{},
+				expect.anything(),
+			);
+		});
+	},
+};
+
 export const ExploreModelOverrideFallsBackToModelName: Story = {
 	args: {
 		exploreModelOverrideData: {
 			model_config_id: "model-explore-empty-name",
+			has_malformed_override: false,
 		},
 		modelConfigsData: [
 			{

--- a/site/src/pages/AgentsPage/AgentSettingsAgentsPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsAgentsPageView.stories.tsx
@@ -87,6 +87,30 @@ export const ExploreModelOverrideSetting: Story = {
 	},
 };
 
+export const ExploreModelOverrideAllowsExplicitClear: Story = {
+	args: {
+		exploreModelOverrideData: {},
+		modelConfigsData: [],
+		onSaveExploreModelOverride: fn(),
+	},
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		const clearButton = await canvas.findByRole("button", { name: "Clear" });
+		const form = clearButton.closest("form");
+		if (!(form instanceof HTMLFormElement)) {
+			throw new Error(
+				"Expected Explore model clear button to live inside a form.",
+			);
+		}
+		await userEvent.click(clearButton);
+		await waitFor(() => {
+			expect(args.onSaveExploreModelOverride).toHaveBeenCalledWith(
+				{},
+				expect.anything(),
+			);
+		});
+	},
+};
 export const ExploreModelOverrideFallsBackToModelName: Story = {
 	args: {
 		exploreModelOverrideData: {

--- a/site/src/pages/AgentsPage/AgentSettingsAgentsPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsAgentsPageView.stories.tsx
@@ -1,0 +1,124 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, userEvent, waitFor, within } from "storybook/test";
+import type * as TypesGen from "#/api/typesGenerated";
+import {
+	AgentSettingsAgentsPageView,
+	type AgentSettingsAgentsPageViewProps,
+} from "./AgentSettingsAgentsPageView";
+
+const baseArgs: AgentSettingsAgentsPageViewProps = {
+	exploreModelOverrideData: {},
+	modelConfigsData: [],
+	modelConfigsError: undefined,
+	isLoadingModelConfigs: false,
+	onSaveExploreModelOverride: fn(),
+	isSavingExploreModelOverride: false,
+	isSaveExploreModelOverrideError: false,
+};
+
+const meta = {
+	title: "pages/AgentsPage/AgentSettingsAgentsPageView",
+	component: AgentSettingsAgentsPageView,
+	args: baseArgs,
+} satisfies Meta<typeof AgentSettingsAgentsPageView>;
+
+export default meta;
+type Story = StoryObj<typeof AgentSettingsAgentsPageView>;
+
+export const ExploreModelOverrideSetting: Story = {
+	args: {
+		exploreModelOverrideData: {
+			model_config_id: "model-explore-1",
+		},
+		modelConfigsData: [
+			{
+				id: "model-explore-1",
+				provider: "openai",
+				model: "gpt-4.1-mini",
+				display_name: "GPT 4.1 Mini",
+				enabled: true,
+				is_default: false,
+				context_limit: 1_000_000,
+				compression_threshold: 70,
+				created_at: "2026-03-12T12:00:00.000Z",
+				updated_at: "2026-03-12T12:00:00.000Z",
+			},
+			{
+				id: "model-explore-2",
+				provider: "anthropic",
+				model: "claude-sonnet-4",
+				display_name: "Claude Sonnet 4",
+				enabled: true,
+				is_default: false,
+				context_limit: 200_000,
+				compression_threshold: 70,
+				created_at: "2026-03-12T12:00:00.000Z",
+				updated_at: "2026-03-12T12:00:00.000Z",
+			},
+		] as TypesGen.ChatModelConfig[],
+	},
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		await canvas.findByText("Agents");
+		await canvas.findByText("Explore subagent model");
+		const trigger = canvas.getByRole("combobox", {
+			name: /gpt 4.1 mini/i,
+		});
+		await userEvent.click(trigger);
+		const body = within(canvasElement.ownerDocument.body);
+		await userEvent.click(
+			await body.findByRole("option", { name: "Claude Sonnet 4" }),
+		);
+		const form = trigger.closest("form");
+		if (!(form instanceof HTMLFormElement)) {
+			throw new Error("Expected Explore model selector to live inside a form.");
+		}
+		const saveButton = within(form).getByRole("button", { name: "Save" });
+		await waitFor(() => {
+			expect(saveButton).toBeEnabled();
+		});
+		await userEvent.click(saveButton);
+		await waitFor(() => {
+			expect(args.onSaveExploreModelOverride).toHaveBeenCalledWith(
+				{ model_config_id: "model-explore-2" },
+				expect.anything(),
+			);
+		});
+	},
+};
+
+export const ExploreModelOverrideFallsBackToModelName: Story = {
+	args: {
+		exploreModelOverrideData: {
+			model_config_id: "model-explore-empty-name",
+		},
+		modelConfigsData: [
+			{
+				id: "model-explore-empty-name",
+				provider: "anthropic",
+				model: "claude-sonnet-4-20250514",
+				display_name: "",
+				enabled: true,
+				is_default: false,
+				context_limit: 200_000,
+				compression_threshold: 70,
+				created_at: "2026-03-12T12:00:00.000Z",
+				updated_at: "2026-03-12T12:00:00.000Z",
+			},
+		] as TypesGen.ChatModelConfig[],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const trigger = await canvas.findByRole("combobox", {
+			name: /claude-sonnet-4-20250514/i,
+		});
+		expect(trigger).toHaveTextContent("claude-sonnet-4-20250514");
+		await userEvent.click(trigger);
+		const body = within(canvasElement.ownerDocument.body);
+		expect(
+			await body.findByRole("option", {
+				name: "claude-sonnet-4-20250514",
+			}),
+		).toBeInTheDocument();
+	},
+};

--- a/site/src/pages/AgentsPage/AgentSettingsAgentsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsAgentsPageView.tsx
@@ -1,0 +1,64 @@
+import type { FC } from "react";
+import type * as TypesGen from "#/api/typesGenerated";
+import { AdminBadge } from "./components/AdminBadge";
+import { ExploreModelOverrideSettings } from "./components/ExploreModelOverrideSettings";
+import { SectionHeader } from "./components/SectionHeader";
+
+interface MutationCallbacks {
+	onSuccess?: () => void;
+	onError?: () => void;
+}
+
+export interface AgentSettingsAgentsPageViewProps {
+	exploreModelOverrideData:
+		| TypesGen.ChatExploreModelOverrideResponse
+		| undefined;
+	modelConfigsData: TypesGen.ChatModelConfig[] | undefined;
+	modelConfigsError: unknown;
+	isLoadingModelConfigs: boolean;
+	onSaveExploreModelOverride: (
+		req: TypesGen.UpdateChatExploreModelOverrideRequest,
+		options?: MutationCallbacks,
+	) => void;
+	isSavingExploreModelOverride: boolean;
+	isSaveExploreModelOverrideError: boolean;
+}
+
+export const AgentSettingsAgentsPageView: FC<
+	AgentSettingsAgentsPageViewProps
+> = ({
+	exploreModelOverrideData,
+	modelConfigsData,
+	modelConfigsError,
+	isLoadingModelConfigs,
+	onSaveExploreModelOverride,
+	isSavingExploreModelOverride,
+	isSaveExploreModelOverrideError,
+}) => {
+	return (
+		<div className="flex flex-col gap-8">
+			<SectionHeader
+				label="Agents"
+				description="Configure defaults for delegated agents and other agent-specific capabilities."
+				badge={<AdminBadge />}
+			/>
+			<div className="flex flex-col gap-3">
+				<SectionHeader
+					label="Explore subagent model"
+					description="Optional deployment-wide model override for read-only Explore subagents."
+					level="section"
+				/>
+				<ExploreModelOverrideSettings
+					exploreModelOverrideData={exploreModelOverrideData}
+					modelConfigs={modelConfigsData ?? []}
+					modelConfigsError={modelConfigsError}
+					isLoadingModelConfigs={isLoadingModelConfigs}
+					onSaveExploreModelOverride={onSaveExploreModelOverride}
+					isSavingExploreModelOverride={isSavingExploreModelOverride}
+					isSaveExploreModelOverrideError={isSaveExploreModelOverrideError}
+					showHeader={false}
+				/>
+			</div>
+		</div>
+	);
+};

--- a/site/src/pages/AgentsPage/AgentSettingsBehaviorPage.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsBehaviorPage.tsx
@@ -2,7 +2,6 @@ import type { FC } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
 import {
 	chatDesktopEnabled,
-	chatExploreModelOverride,
 	chatModelConfigs,
 	chatPlanModeInstructions,
 	chatRetentionDays,
@@ -11,7 +10,6 @@ import {
 	chatWorkspaceTTL,
 	deleteUserCompactionThreshold,
 	updateChatDesktopEnabled,
-	updateChatExploreModelOverride,
 	updateChatPlanModeInstructions,
 	updateChatRetentionDays,
 	updateChatSystemPrompt,
@@ -40,14 +38,6 @@ const AgentSettingsBehaviorPage: FC = () => {
 	});
 	const savePlanModeInstructionsMutation = useMutation(
 		updateChatPlanModeInstructions(queryClient),
-	);
-
-	const exploreModelOverrideQuery = useQuery({
-		...chatExploreModelOverride(),
-		enabled: permissions.editDeploymentConfig,
-	});
-	const saveExploreModelOverrideMutation = useMutation(
-		updateChatExploreModelOverride(queryClient),
 	);
 
 	const userPromptQuery = useQuery(chatUserCustomPrompt());
@@ -97,7 +87,6 @@ const AgentSettingsBehaviorPage: FC = () => {
 			canSetSystemPrompt={permissions.editDeploymentConfig}
 			systemPromptData={systemPromptQuery.data}
 			planModeInstructionsData={planModeInstructionsQuery.data}
-			exploreModelOverrideData={exploreModelOverrideQuery.data}
 			userPromptData={userPromptQuery.data}
 			desktopEnabledData={desktopEnabledQuery.data}
 			workspaceTTLData={workspaceTTLQuery.data}
@@ -117,9 +106,6 @@ const AgentSettingsBehaviorPage: FC = () => {
 			onSavePlanModeInstructions={savePlanModeInstructionsMutation.mutate}
 			isSavingPlanModeInstructions={savePlanModeInstructionsMutation.isPending}
 			isSavePlanModeInstructionsError={savePlanModeInstructionsMutation.isError}
-			onSaveExploreModelOverride={saveExploreModelOverrideMutation.mutate}
-			isSavingExploreModelOverride={saveExploreModelOverrideMutation.isPending}
-			isSaveExploreModelOverrideError={saveExploreModelOverrideMutation.isError}
 			onSaveUserPrompt={saveUserPromptMutation.mutate}
 			isSavingUserPrompt={saveUserPromptMutation.isPending}
 			isSaveUserPromptError={saveUserPromptMutation.isError}

--- a/site/src/pages/AgentsPage/AgentSettingsBehaviorPage.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsBehaviorPage.tsx
@@ -2,6 +2,7 @@ import type { FC } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
 import {
 	chatDesktopEnabled,
+	chatExploreModelOverride,
 	chatModelConfigs,
 	chatPlanModeInstructions,
 	chatRetentionDays,
@@ -10,6 +11,7 @@ import {
 	chatWorkspaceTTL,
 	deleteUserCompactionThreshold,
 	updateChatDesktopEnabled,
+	updateChatExploreModelOverride,
 	updateChatPlanModeInstructions,
 	updateChatRetentionDays,
 	updateChatSystemPrompt,
@@ -38,6 +40,14 @@ const AgentSettingsBehaviorPage: FC = () => {
 	});
 	const savePlanModeInstructionsMutation = useMutation(
 		updateChatPlanModeInstructions(queryClient),
+	);
+
+	const exploreModelOverrideQuery = useQuery({
+		...chatExploreModelOverride(),
+		enabled: permissions.editDeploymentConfig,
+	});
+	const saveExploreModelOverrideMutation = useMutation(
+		updateChatExploreModelOverride(queryClient),
 	);
 
 	const userPromptQuery = useQuery(chatUserCustomPrompt());
@@ -87,6 +97,7 @@ const AgentSettingsBehaviorPage: FC = () => {
 			canSetSystemPrompt={permissions.editDeploymentConfig}
 			systemPromptData={systemPromptQuery.data}
 			planModeInstructionsData={planModeInstructionsQuery.data}
+			exploreModelOverrideData={exploreModelOverrideQuery.data}
 			userPromptData={userPromptQuery.data}
 			desktopEnabledData={desktopEnabledQuery.data}
 			workspaceTTLData={workspaceTTLQuery.data}
@@ -106,6 +117,9 @@ const AgentSettingsBehaviorPage: FC = () => {
 			onSavePlanModeInstructions={savePlanModeInstructionsMutation.mutate}
 			isSavingPlanModeInstructions={savePlanModeInstructionsMutation.isPending}
 			isSavePlanModeInstructionsError={savePlanModeInstructionsMutation.isError}
+			onSaveExploreModelOverride={saveExploreModelOverrideMutation.mutate}
+			isSavingExploreModelOverride={saveExploreModelOverrideMutation.isPending}
+			isSaveExploreModelOverrideError={saveExploreModelOverrideMutation.isError}
 			onSaveUserPrompt={saveUserPromptMutation.mutate}
 			isSavingUserPrompt={saveUserPromptMutation.isPending}
 			isSaveUserPromptError={saveUserPromptMutation.isError}

--- a/site/src/pages/AgentsPage/AgentSettingsBehaviorPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsBehaviorPageView.stories.tsx
@@ -18,7 +18,6 @@ const baseProps = {
 	planModeInstructionsData: {
 		plan_mode_instructions: "",
 	} as TypesGen.ChatPlanModeInstructionsResponse,
-	exploreModelOverrideData: {} as TypesGen.ChatExploreModelOverrideResponse,
 	userPromptData: { custom_prompt: "" } as TypesGen.UserChatCustomPrompt,
 	desktopEnabledData: {
 		enable_desktop: false,
@@ -28,6 +27,11 @@ const baseProps = {
 	} as TypesGen.ChatWorkspaceTTLResponse,
 	isWorkspaceTTLLoading: false,
 	isWorkspaceTTLLoadError: false,
+	retentionDaysData: {
+		retention_days: 30,
+	} as TypesGen.ChatRetentionDaysResponse,
+	isRetentionDaysLoading: false,
+	isRetentionDaysLoadError: false,
 	modelConfigsData: [] as TypesGen.ChatModelConfig[],
 	modelConfigsError: undefined as unknown,
 	isLoadingModelConfigs: false,
@@ -38,14 +42,14 @@ const baseProps = {
 	isSaveSystemPromptError: false,
 	isSavingPlanModeInstructions: false,
 	isSavePlanModeInstructionsError: false,
-	isSavingExploreModelOverride: false,
-	isSaveExploreModelOverrideError: false,
 	isSavingUserPrompt: false,
 	isSaveUserPromptError: false,
 	isSavingDesktopEnabled: false,
 	isSaveDesktopEnabledError: false,
 	isSavingWorkspaceTTL: false,
 	isSaveWorkspaceTTLError: false,
+	isSavingRetentionDays: false,
+	isSaveRetentionDaysError: false,
 };
 
 const meta = {
@@ -55,10 +59,10 @@ const meta = {
 		...baseProps,
 		onSaveSystemPrompt: fn(),
 		onSavePlanModeInstructions: fn(),
-		onSaveExploreModelOverride: fn(),
 		onSaveUserPrompt: fn(),
 		onSaveDesktopEnabled: fn(),
 		onSaveWorkspaceTTL: fn(),
+		onSaveRetentionDays: fn(),
 		onSaveThreshold: fn(),
 		onResetThreshold: fn(),
 	},
@@ -164,105 +168,6 @@ export const AdminWithDefaultToggleOff: Story = {
 		expect(
 			canvas.getByText(/only the additional instructions below are used/i),
 		).toBeInTheDocument();
-	},
-};
-
-export const ExploreModelOverrideSetting: Story = {
-	args: {
-		exploreModelOverrideData: {
-			model_config_id: "model-explore-1",
-		},
-		modelConfigsData: [
-			{
-				id: "model-explore-1",
-				provider: "openai",
-				model: "gpt-4.1-mini",
-				display_name: "GPT 4.1 Mini",
-				enabled: true,
-				is_default: false,
-				context_limit: 1_000_000,
-				compression_threshold: 70,
-				created_at: "2026-03-12T12:00:00.000Z",
-				updated_at: "2026-03-12T12:00:00.000Z",
-			},
-			{
-				id: "model-explore-2",
-				provider: "anthropic",
-				model: "claude-sonnet-4",
-				display_name: "Claude Sonnet 4",
-				enabled: true,
-				is_default: false,
-				context_limit: 200_000,
-				compression_threshold: 70,
-				created_at: "2026-03-12T12:00:00.000Z",
-				updated_at: "2026-03-12T12:00:00.000Z",
-			},
-		] as TypesGen.ChatModelConfig[],
-	},
-	play: async ({ canvasElement, args }) => {
-		const canvas = within(canvasElement);
-		await canvas.findByText("Explore subagent model");
-
-		const trigger = canvas.getByRole("combobox", {
-			name: /use chat default|gpt 4.1 mini/i,
-		});
-		await userEvent.click(trigger);
-		const body = within(canvasElement.ownerDocument.body);
-		await userEvent.click(
-			await body.findByRole("option", { name: "Claude Sonnet 4" }),
-		);
-
-		const form = trigger.closest("form");
-		if (!(form instanceof HTMLFormElement)) {
-			throw new Error("Expected Explore model selector to live inside a form.");
-		}
-		const saveButton = within(form).getByRole("button", { name: "Save" });
-		await waitFor(() => {
-			expect(saveButton).toBeEnabled();
-		});
-		await userEvent.click(saveButton);
-		await waitFor(() => {
-			expect(args.onSaveExploreModelOverride).toHaveBeenCalledWith(
-				{ model_config_id: "model-explore-2" },
-				expect.anything(),
-			);
-		});
-	},
-};
-
-export const ExploreModelOverrideFallsBackToModelName: Story = {
-	args: {
-		exploreModelOverrideData: {
-			model_config_id: "model-explore-empty-name",
-		},
-		modelConfigsData: [
-			{
-				id: "model-explore-empty-name",
-				provider: "anthropic",
-				model: "claude-sonnet-4-20250514",
-				display_name: "",
-				enabled: true,
-				is_default: false,
-				context_limit: 200_000,
-				compression_threshold: 70,
-				created_at: "2026-03-12T12:00:00.000Z",
-				updated_at: "2026-03-12T12:00:00.000Z",
-			},
-		] as TypesGen.ChatModelConfig[],
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const trigger = await canvas.findByRole("combobox", {
-			name: /claude-sonnet-4-20250514/i,
-		});
-		expect(trigger).toHaveTextContent("claude-sonnet-4-20250514");
-		await userEvent.click(trigger);
-		const body = within(canvasElement.ownerDocument.body);
-		expect(
-			await body.findByRole("option", {
-				name: "claude-sonnet-4-20250514",
-			}),
-		).toBeVisible();
 	},
 };
 

--- a/site/src/pages/AgentsPage/AgentSettingsBehaviorPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsBehaviorPageView.stories.tsx
@@ -18,6 +18,7 @@ const baseProps = {
 	planModeInstructionsData: {
 		plan_mode_instructions: "",
 	} as TypesGen.ChatPlanModeInstructionsResponse,
+	exploreModelOverrideData: {} as TypesGen.ChatExploreModelOverrideResponse,
 	userPromptData: { custom_prompt: "" } as TypesGen.UserChatCustomPrompt,
 	desktopEnabledData: {
 		enable_desktop: false,
@@ -37,6 +38,8 @@ const baseProps = {
 	isSaveSystemPromptError: false,
 	isSavingPlanModeInstructions: false,
 	isSavePlanModeInstructionsError: false,
+	isSavingExploreModelOverride: false,
+	isSaveExploreModelOverrideError: false,
 	isSavingUserPrompt: false,
 	isSaveUserPromptError: false,
 	isSavingDesktopEnabled: false,
@@ -52,6 +55,7 @@ const meta = {
 		...baseProps,
 		onSaveSystemPrompt: fn(),
 		onSavePlanModeInstructions: fn(),
+		onSaveExploreModelOverride: fn(),
 		onSaveUserPrompt: fn(),
 		onSaveDesktopEnabled: fn(),
 		onSaveWorkspaceTTL: fn(),
@@ -160,6 +164,65 @@ export const AdminWithDefaultToggleOff: Story = {
 		expect(
 			canvas.getByText(/only the additional instructions below are used/i),
 		).toBeInTheDocument();
+	},
+};
+
+export const ExploreModelOverrideSetting: Story = {
+	args: {
+		exploreModelOverrideData: {
+			model_config_id: "model-explore-1",
+		},
+		modelConfigsData: [
+			{
+				id: "model-explore-1",
+				provider: "openai",
+				model: "gpt-4.1-mini",
+				display_name: "GPT 4.1 Mini",
+				enabled: true,
+				is_default: false,
+				context_limit: 1_000_000,
+				compression_threshold: 70,
+				created_at: "2026-03-12T12:00:00.000Z",
+				updated_at: "2026-03-12T12:00:00.000Z",
+			},
+			{
+				id: "model-explore-2",
+				provider: "anthropic",
+				model: "claude-sonnet-4",
+				display_name: "Claude Sonnet 4",
+				enabled: true,
+				is_default: false,
+				context_limit: 200_000,
+				compression_threshold: 70,
+				created_at: "2026-03-12T12:00:00.000Z",
+				updated_at: "2026-03-12T12:00:00.000Z",
+			},
+		] as TypesGen.ChatModelConfig[],
+	},
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		await canvas.findByText("Explore subagent model");
+
+		const trigger = canvas.getByRole("combobox", {
+			name: /use chat default|gpt 4.1 mini/i,
+		});
+		await userEvent.click(trigger);
+		const body = within(canvasElement.ownerDocument.body);
+		await userEvent.click(
+			await body.findByRole("option", { name: "Claude Sonnet 4" }),
+		);
+
+		const saveButton = canvas.getByRole("button", { name: "Save" });
+		await waitFor(() => {
+			expect(saveButton).toBeEnabled();
+		});
+		await userEvent.click(saveButton);
+		await waitFor(() => {
+			expect(args.onSaveExploreModelOverride).toHaveBeenCalledWith(
+				{ model_config_id: "model-explore-2" },
+				expect.anything(),
+			);
+		});
 	},
 };
 

--- a/site/src/pages/AgentsPage/AgentSettingsBehaviorPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsBehaviorPageView.stories.tsx
@@ -212,7 +212,11 @@ export const ExploreModelOverrideSetting: Story = {
 			await body.findByRole("option", { name: "Claude Sonnet 4" }),
 		);
 
-		const saveButton = canvas.getByRole("button", { name: "Save" });
+		const form = trigger.closest("form");
+		if (!(form instanceof HTMLFormElement)) {
+			throw new Error("Expected Explore model selector to live inside a form.");
+		}
+		const saveButton = within(form).getByRole("button", { name: "Save" });
 		await waitFor(() => {
 			expect(saveButton).toBeEnabled();
 		});
@@ -223,6 +227,42 @@ export const ExploreModelOverrideSetting: Story = {
 				expect.anything(),
 			);
 		});
+	},
+};
+
+export const ExploreModelOverrideFallsBackToModelName: Story = {
+	args: {
+		exploreModelOverrideData: {
+			model_config_id: "model-explore-empty-name",
+		},
+		modelConfigsData: [
+			{
+				id: "model-explore-empty-name",
+				provider: "anthropic",
+				model: "claude-sonnet-4-20250514",
+				display_name: "",
+				enabled: true,
+				is_default: false,
+				context_limit: 200_000,
+				compression_threshold: 70,
+				created_at: "2026-03-12T12:00:00.000Z",
+				updated_at: "2026-03-12T12:00:00.000Z",
+			},
+		] as TypesGen.ChatModelConfig[],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const trigger = await canvas.findByRole("combobox", {
+			name: /claude-sonnet-4-20250514/i,
+		});
+		expect(trigger).toHaveTextContent("claude-sonnet-4-20250514");
+		await userEvent.click(trigger);
+		const body = within(canvasElement.ownerDocument.body);
+		expect(
+			await body.findByRole("option", {
+				name: "claude-sonnet-4-20250514",
+			}),
+		).toBeVisible();
 	},
 };
 

--- a/site/src/pages/AgentsPage/AgentSettingsBehaviorPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsBehaviorPageView.tsx
@@ -1,6 +1,7 @@
 import type { FC } from "react";
 import type * as TypesGen from "#/api/typesGenerated";
 import { ChatFullWidthSettings } from "./components/ChatFullWidthSettings";
+import { ExploreModelOverrideSettings } from "./components/ExploreModelOverrideSettings";
 import { PersonalInstructionsSettings } from "./components/PersonalInstructionsSettings";
 import { PlanModeInstructionsSettings } from "./components/PlanModeInstructionsSettings";
 import { RetentionPeriodSettings } from "./components/RetentionPeriodSettings";
@@ -22,6 +23,9 @@ interface AgentSettingsBehaviorPageViewProps {
 	systemPromptData: TypesGen.ChatSystemPromptResponse | undefined;
 	planModeInstructionsData:
 		| TypesGen.ChatPlanModeInstructionsResponse
+		| undefined;
+	exploreModelOverrideData:
+		| TypesGen.ChatExploreModelOverrideResponse
 		| undefined;
 	userPromptData: TypesGen.UserChatCustomPrompt | undefined;
 	desktopEnabledData: TypesGen.ChatDesktopEnabledResponse | undefined;
@@ -60,6 +64,13 @@ interface AgentSettingsBehaviorPageViewProps {
 	isSavingPlanModeInstructions: boolean;
 	isSavePlanModeInstructionsError: boolean;
 
+	onSaveExploreModelOverride: (
+		req: TypesGen.UpdateChatExploreModelOverrideRequest,
+		options?: MutationCallbacks,
+	) => void;
+	isSavingExploreModelOverride: boolean;
+	isSaveExploreModelOverrideError: boolean;
+
 	onSaveUserPrompt: (
 		req: TypesGen.UserChatCustomPrompt,
 		options?: MutationCallbacks,
@@ -95,6 +106,7 @@ export const AgentSettingsBehaviorPageView: FC<
 	canSetSystemPrompt,
 	systemPromptData,
 	planModeInstructionsData,
+	exploreModelOverrideData,
 	userPromptData,
 	desktopEnabledData,
 	workspaceTTLData,
@@ -117,6 +129,9 @@ export const AgentSettingsBehaviorPageView: FC<
 	onSavePlanModeInstructions,
 	isSavingPlanModeInstructions,
 	isSavePlanModeInstructionsError,
+	onSaveExploreModelOverride,
+	isSavingExploreModelOverride,
+	isSaveExploreModelOverrideError,
 	onSaveUserPrompt,
 	isSavingUserPrompt,
 	isSaveUserPromptError,
@@ -173,6 +188,15 @@ export const AgentSettingsBehaviorPageView: FC<
 						onSavePlanModeInstructions={onSavePlanModeInstructions}
 						isSavePlanModeInstructionsError={isSavePlanModeInstructionsError}
 						isAnyPromptSaving={isAnyPromptSaving}
+					/>
+					<ExploreModelOverrideSettings
+						exploreModelOverrideData={exploreModelOverrideData}
+						modelConfigs={modelConfigsData ?? []}
+						modelConfigsError={modelConfigsError}
+						isLoadingModelConfigs={isLoadingModelConfigs}
+						onSaveExploreModelOverride={onSaveExploreModelOverride}
+						isSavingExploreModelOverride={isSavingExploreModelOverride}
+						isSaveExploreModelOverrideError={isSaveExploreModelOverrideError}
 					/>
 					<VirtualDesktopSettings
 						desktopEnabledData={desktopEnabledData}

--- a/site/src/pages/AgentsPage/AgentSettingsBehaviorPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsBehaviorPageView.tsx
@@ -1,7 +1,6 @@
 import type { FC } from "react";
 import type * as TypesGen from "#/api/typesGenerated";
 import { ChatFullWidthSettings } from "./components/ChatFullWidthSettings";
-import { ExploreModelOverrideSettings } from "./components/ExploreModelOverrideSettings";
 import { PersonalInstructionsSettings } from "./components/PersonalInstructionsSettings";
 import { PlanModeInstructionsSettings } from "./components/PlanModeInstructionsSettings";
 import { RetentionPeriodSettings } from "./components/RetentionPeriodSettings";
@@ -23,9 +22,6 @@ interface AgentSettingsBehaviorPageViewProps {
 	systemPromptData: TypesGen.ChatSystemPromptResponse | undefined;
 	planModeInstructionsData:
 		| TypesGen.ChatPlanModeInstructionsResponse
-		| undefined;
-	exploreModelOverrideData:
-		| TypesGen.ChatExploreModelOverrideResponse
 		| undefined;
 	userPromptData: TypesGen.UserChatCustomPrompt | undefined;
 	desktopEnabledData: TypesGen.ChatDesktopEnabledResponse | undefined;
@@ -64,13 +60,6 @@ interface AgentSettingsBehaviorPageViewProps {
 	isSavingPlanModeInstructions: boolean;
 	isSavePlanModeInstructionsError: boolean;
 
-	onSaveExploreModelOverride: (
-		req: TypesGen.UpdateChatExploreModelOverrideRequest,
-		options?: MutationCallbacks,
-	) => void;
-	isSavingExploreModelOverride: boolean;
-	isSaveExploreModelOverrideError: boolean;
-
 	onSaveUserPrompt: (
 		req: TypesGen.UserChatCustomPrompt,
 		options?: MutationCallbacks,
@@ -106,7 +95,6 @@ export const AgentSettingsBehaviorPageView: FC<
 	canSetSystemPrompt,
 	systemPromptData,
 	planModeInstructionsData,
-	exploreModelOverrideData,
 	userPromptData,
 	desktopEnabledData,
 	workspaceTTLData,
@@ -129,9 +117,6 @@ export const AgentSettingsBehaviorPageView: FC<
 	onSavePlanModeInstructions,
 	isSavingPlanModeInstructions,
 	isSavePlanModeInstructionsError,
-	onSaveExploreModelOverride,
-	isSavingExploreModelOverride,
-	isSaveExploreModelOverrideError,
 	onSaveUserPrompt,
 	isSavingUserPrompt,
 	isSaveUserPromptError,
@@ -188,15 +173,6 @@ export const AgentSettingsBehaviorPageView: FC<
 						onSavePlanModeInstructions={onSavePlanModeInstructions}
 						isSavePlanModeInstructionsError={isSavePlanModeInstructionsError}
 						isAnyPromptSaving={isAnyPromptSaving}
-					/>
-					<ExploreModelOverrideSettings
-						exploreModelOverrideData={exploreModelOverrideData}
-						modelConfigs={modelConfigsData ?? []}
-						modelConfigsError={modelConfigsError}
-						isLoadingModelConfigs={isLoadingModelConfigs}
-						onSaveExploreModelOverride={onSaveExploreModelOverride}
-						isSavingExploreModelOverride={isSavingExploreModelOverride}
-						isSaveExploreModelOverrideError={isSaveExploreModelOverrideError}
 					/>
 					<VirtualDesktopSettings
 						desktopEnabledData={desktopEnabledData}

--- a/site/src/pages/AgentsPage/AgentsPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageView.stories.tsx
@@ -205,7 +205,7 @@ const BehaviorRouteElement = () => {
 
 const AgentsRouteElement = () => (
 	<AgentSettingsAgentsPageView
-		exploreModelOverrideData={{}}
+		exploreModelOverrideData={{ has_malformed_override: false }}
 		modelConfigsData={[]}
 		modelConfigsError={undefined}
 		isLoadingModelConfigs={false}

--- a/site/src/pages/AgentsPage/AgentsPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageView.stories.tsx
@@ -28,6 +28,7 @@ import {
 } from "#/testHelpers/storybook";
 import AgentAnalyticsPage from "./AgentAnalyticsPage";
 import AgentCreatePage from "./AgentCreatePage";
+import { AgentSettingsAgentsPageView } from "./AgentSettingsAgentsPageView";
 import { AgentSettingsBehaviorPageView } from "./AgentSettingsBehaviorPageView";
 import AgentSettingsPage from "./AgentSettingsPage";
 import AgentSettingsSpendPage from "./AgentSettingsSpendPage";
@@ -164,7 +165,6 @@ const BehaviorRouteElement = () => {
 			planModeInstructionsData={{
 				plan_mode_instructions: "",
 			}}
-			exploreModelOverrideData={{}}
 			userPromptData={{ custom_prompt: "" }}
 			desktopEnabledData={{ enable_desktop: false }}
 			workspaceTTLData={{ workspace_ttl_ms: 0 }}
@@ -182,9 +182,6 @@ const BehaviorRouteElement = () => {
 			onSavePlanModeInstructions={fn()}
 			isSavingPlanModeInstructions={false}
 			isSavePlanModeInstructionsError={false}
-			onSaveExploreModelOverride={fn()}
-			isSavingExploreModelOverride={false}
-			isSaveExploreModelOverrideError={false}
 			onSaveUserPrompt={fn()}
 			isSavingUserPrompt={false}
 			isSaveUserPromptError={false}
@@ -206,6 +203,18 @@ const BehaviorRouteElement = () => {
 	);
 };
 
+const AgentsRouteElement = () => (
+	<AgentSettingsAgentsPageView
+		exploreModelOverrideData={{}}
+		modelConfigsData={[]}
+		modelConfigsError={undefined}
+		isLoadingModelConfigs={false}
+		onSaveExploreModelOverride={fn()}
+		isSavingExploreModelOverride={false}
+		isSaveExploreModelOverrideError={false}
+	/>
+);
+
 const agentsRouting = {
 	path: "/agents",
 	useStoryElement: true,
@@ -216,6 +225,7 @@ const agentsRouting = {
 			children: [
 				{ index: true, element: <Navigate to="behavior" replace /> },
 				{ path: "behavior", element: <BehaviorRouteElement /> },
+				{ path: "agents", element: <AgentsRouteElement /> },
 				{ path: "spend", element: <AgentSettingsSpendPage now={fixedNow} /> },
 				{
 					path: "usage",

--- a/site/src/pages/AgentsPage/AgentsPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageView.stories.tsx
@@ -164,6 +164,7 @@ const BehaviorRouteElement = () => {
 			planModeInstructionsData={{
 				plan_mode_instructions: "",
 			}}
+			exploreModelOverrideData={{}}
 			userPromptData={{ custom_prompt: "" }}
 			desktopEnabledData={{ enable_desktop: false }}
 			workspaceTTLData={{ workspace_ttl_ms: 0 }}
@@ -181,6 +182,9 @@ const BehaviorRouteElement = () => {
 			onSavePlanModeInstructions={fn()}
 			isSavingPlanModeInstructions={false}
 			isSavePlanModeInstructionsError={false}
+			onSaveExploreModelOverride={fn()}
+			isSavingExploreModelOverride={false}
+			isSaveExploreModelOverrideError={false}
 			onSaveUserPrompt={fn()}
 			isSavingUserPrompt={false}
 			isSaveUserPromptError={false}

--- a/site/src/pages/AgentsPage/components/ChatConversation/messageParsing.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/messageParsing.ts
@@ -20,6 +20,7 @@ const appendText = (current: string, next: string): string => {
 
 const isSubagentToolName = (name: string): boolean =>
 	name === "spawn_agent" ||
+	name === "spawn_explore_agent" ||
 	name === "spawn_computer_use_agent" ||
 	name === "wait_agent" ||
 	name === "message_agent";
@@ -332,6 +333,7 @@ export const buildSubagentTitles = (
 		for (const tool of parsed.tools) {
 			if (
 				tool.name !== "spawn_agent" &&
+				tool.name !== "spawn_explore_agent" &&
 				tool.name !== "spawn_computer_use_agent"
 			) {
 				continue;

--- a/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.stories.tsx
@@ -83,6 +83,23 @@ export const CustomPlaceholder: Story = {
 	},
 };
 
+export const InputBorderTreatment: Story = {
+	args: {
+		value: "openai/gpt-4o-mini",
+		className:
+			"h-10 border border-border border-solid bg-transparent px-3 shadow-sm",
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const trigger = canvas.getByRole("combobox", { name: /gpt-4o mini/i });
+		const styles = getComputedStyle(trigger);
+
+		expect(styles.borderTopStyle).toBe("solid");
+		expect(styles.borderTopWidth).not.toBe("0px");
+		expect(styles.boxShadow).not.toBe("none");
+	},
+};
+
 export const Disabled: Story = {
 	args: {
 		disabled: true,

--- a/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.test.tsx
@@ -27,20 +27,3 @@ test("suppresses mouse-focus ring but keeps keyboard-focus ring on model selecto
 	expect(trigger.className).toContain("focus-visible:ring-2");
 	expect(trigger.className).not.toContain("focus-visible:ring-0");
 });
-
-test("allows callers to apply the regular input border treatment", () => {
-	render(
-		<ModelSelector
-			options={mockModelOptions}
-			value="gpt-4o-mini"
-			onValueChange={vi.fn()}
-			className="h-10 border border-border border-solid bg-transparent px-3 shadow-sm"
-		/>,
-	);
-
-	const trigger = screen.getByRole("combobox");
-
-	expect(trigger.className).toContain("border-solid");
-	expect(trigger.className).toContain("shadow-sm");
-	expect(trigger.className).not.toContain("border-none");
-});

--- a/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.test.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.test.tsx
@@ -27,3 +27,20 @@ test("suppresses mouse-focus ring but keeps keyboard-focus ring on model selecto
 	expect(trigger.className).toContain("focus-visible:ring-2");
 	expect(trigger.className).not.toContain("focus-visible:ring-0");
 });
+
+test("allows callers to apply the regular input border treatment", () => {
+	render(
+		<ModelSelector
+			options={mockModelOptions}
+			value="gpt-4o-mini"
+			onValueChange={vi.fn()}
+			className="h-10 border border-border border-solid bg-transparent px-3 shadow-sm"
+		/>,
+	);
+
+	const trigger = screen.getByRole("combobox");
+
+	expect(trigger.className).toContain("border-solid");
+	expect(trigger.className).toContain("shadow-sm");
+	expect(trigger.className).not.toContain("border-none");
+});

--- a/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.tsx
@@ -101,7 +101,7 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
 			<SelectTrigger
 				aria-label={selectedModel ? getOptionLabel(selectedModel) : placeholder}
 				className={cn(
-					"h-8 w-auto gap-1.5 border-none bg-transparent px-1 text-xs shadow-none transition-colors hover:bg-transparent hover:text-content-primary focus:ring-0 [&>svg]:transition-colors [&>svg]:hover:text-content-primary",
+					"h-8 w-auto gap-1.5 border-0 bg-transparent px-1 text-xs shadow-none transition-colors hover:bg-transparent hover:text-content-primary focus:ring-0 [&>svg]:transition-colors [&>svg]:hover:text-content-primary",
 					className,
 				)}
 			>

--- a/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/ModelSelector.tsx
@@ -54,6 +54,18 @@ const formatContextLimit = (tokens: number): string => {
 	return `${k}K context window`;
 };
 
+const getOptionLabel = (option: ModelSelectorOption): string => {
+	const displayName = option.displayName.trim();
+	if (displayName) {
+		return displayName;
+	}
+	const model = option.model.trim();
+	if (model) {
+		return model;
+	}
+	return option.id;
+};
+
 export const ModelSelector: FC<ModelSelectorProps> = ({
 	options,
 	value,
@@ -87,13 +99,14 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
 	return (
 		<Select value={value} onValueChange={onValueChange} disabled={isDisabled}>
 			<SelectTrigger
+				aria-label={selectedModel ? getOptionLabel(selectedModel) : placeholder}
 				className={cn(
 					"h-8 w-auto gap-1.5 border-none bg-transparent px-1 text-xs shadow-none transition-colors hover:bg-transparent hover:text-content-primary focus:ring-0 [&>svg]:transition-colors [&>svg]:hover:text-content-primary",
 					className,
 				)}
 			>
 				<SelectValue placeholder={placeholder}>
-					{selectedModel?.displayName ?? placeholder}
+					{selectedModel ? getOptionLabel(selectedModel) : placeholder}
 				</SelectValue>
 			</SelectTrigger>
 			<SelectContent
@@ -139,11 +152,11 @@ const ModelOptionItem: FC<ModelOptionItemProps> = ({
 	return (
 		<Tooltip>
 			<TooltipTrigger asChild>
-				<SelectItem value={option.id}>{option.displayName}</SelectItem>
+				<SelectItem value={option.id}>{getOptionLabel(option)}</SelectItem>
 			</TooltipTrigger>
 			<TooltipContent side="right" sideOffset={4} className="px-2.5 py-1.5">
 				<span className="block font-semibold text-content-primary leading-tight">
-					{option.displayName} via {providerLabel}
+					{getOptionLabel(option)} via {providerLabel}
 				</span>
 				{option.contextLimit != null && option.contextLimit > 0 && (
 					<span className="block text-content-secondary leading-tight">

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/SubagentTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/SubagentTool.tsx
@@ -33,6 +33,12 @@ const SUBAGENT_VERBS: Record<
 		error: "Failed to spawn ",
 		timeout: "Timed out spawning ",
 	},
+	spawn_explore_agent: {
+		completed: "Spawned ",
+		running: "Spawning ",
+		error: "Failed to spawn ",
+		timeout: "Timed out spawning ",
+	},
 	wait_agent: {
 		completed: "Waited for ",
 		running: "Waiting for ",

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
@@ -170,6 +170,30 @@ export const SubagentRunning: Story = {
 	},
 };
 
+export const ExploreSubagentRunning: Story = {
+	args: {
+		name: "spawn_explore_agent",
+		status: "running",
+		args: {
+			prompt: "Read the repository and summarize the auth flow.",
+		},
+		result: {
+			chat_id: "explore-chat-id",
+			status: "pending",
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByRole("link", { name: "View agent" })).toHaveAttribute(
+			"href",
+			"/agents/explore-chat-id",
+		);
+		expect(
+			canvas.getByRole("button", { name: /Spawning Explore agent/ }),
+		).toBeInTheDocument();
+	},
+};
+
 export const SubagentAwaitLinkCard: Story = {
 	args: {
 		name: "wait_agent",

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
@@ -463,7 +463,9 @@ const SubagentRenderer: FC<ToolRendererProps> = ({
 		(chatId && subagentTitles?.get(chatId)) ||
 		(name === "spawn_computer_use_agent"
 			? "Computer use sub-agent"
-			: "Sub-agent");
+			: name === "spawn_explore_agent"
+				? "Explore agent"
+				: "Sub-agent");
 	const subagentCompleted = isSubagentSuccessStatus(subagentStatus);
 	const subagentToolStatus = mapSubagentStatusToToolStatus(
 		subagentStatus,
@@ -887,6 +889,7 @@ const toolRenderers: Record<string, FC<ToolRendererProps>> = {
 	read_skill: ReadSkillRenderer,
 	read_skill_file: ReadSkillFileRenderer,
 	spawn_agent: SubagentRenderer,
+	spawn_explore_agent: SubagentRenderer,
 	wait_agent: SubagentRenderer,
 	message_agent: SubagentRenderer,
 	close_agent: SubagentRenderer,

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ToolIcon.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ToolIcon.tsx
@@ -82,6 +82,11 @@ export const ToolIcon: React.FC<{
 			return <FilePenIcon className={base} />;
 		case "create_workspace":
 			return <PlusCircleIcon className={base} />;
+		case "spawn_agent":
+		case "spawn_explore_agent":
+		case "wait_agent":
+		case "message_agent":
+		case "close_agent":
 		case "chat_summarized":
 			return <BotIcon className={base} />;
 		case "propose_plan":

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ToolLabel.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ToolLabel.tsx
@@ -156,6 +156,16 @@ export const ToolLabel: React.FC<{
 				</span>
 			);
 		}
+		case "spawn_explore_agent": {
+			const spawnTitle =
+				(parsedResult ? asString(parsedResult.title) : "") ||
+				(parsed ? asString(parsed.title) : "");
+			return (
+				<span className="truncate text-sm text-content-secondary">
+					{spawnTitle ? `Spawning ${spawnTitle}` : "Spawning Explore agent…"}
+				</span>
+			);
+		}
 		case "spawn_agent": {
 			const spawnTitle =
 				(parsedResult ? asString(parsedResult.title) : "") ||

--- a/site/src/pages/AgentsPage/components/ExploreModelOverrideSettings.tsx
+++ b/site/src/pages/AgentsPage/components/ExploreModelOverrideSettings.tsx
@@ -1,0 +1,161 @@
+import { useFormik } from "formik";
+import type { FC } from "react";
+import type * as TypesGen from "#/api/typesGenerated";
+import { Alert, AlertDescription } from "#/components/Alert/Alert";
+import { Button } from "#/components/Button/Button";
+import { AdminBadge } from "./AdminBadge";
+import type { ModelSelectorOption } from "./ChatElements/ModelSelector";
+import { ModelSelector } from "./ChatElements/ModelSelector";
+
+interface MutationCallbacks {
+	onSuccess?: () => void;
+	onError?: () => void;
+}
+
+interface ExploreModelOverrideSettingsProps {
+	exploreModelOverrideData:
+		| TypesGen.ChatExploreModelOverrideResponse
+		| undefined;
+	modelConfigs: readonly TypesGen.ChatModelConfig[];
+	modelConfigsError: unknown;
+	isLoadingModelConfigs: boolean;
+	onSaveExploreModelOverride: (
+		req: TypesGen.UpdateChatExploreModelOverrideRequest,
+		options?: MutationCallbacks,
+	) => void;
+	isSavingExploreModelOverride: boolean;
+	isSaveExploreModelOverrideError: boolean;
+}
+
+const toModelSelectorOption = (
+	modelConfig: TypesGen.ChatModelConfig,
+): ModelSelectorOption => ({
+	id: modelConfig.id,
+	provider: modelConfig.provider,
+	model: modelConfig.model,
+	displayName: modelConfig.display_name,
+	contextLimit: modelConfig.context_limit,
+});
+
+export const ExploreModelOverrideSettings: FC<
+	ExploreModelOverrideSettingsProps
+> = ({
+	exploreModelOverrideData,
+	modelConfigs,
+	modelConfigsError,
+	isLoadingModelConfigs,
+	onSaveExploreModelOverride,
+	isSavingExploreModelOverride,
+	isSaveExploreModelOverrideError,
+}) => {
+	const hasLoadedExploreModelOverride = exploreModelOverrideData !== undefined;
+	const enabledModelOptions = modelConfigs
+		.filter((modelConfig) => modelConfig.enabled)
+		.map(toModelSelectorOption);
+
+	const form = useFormik({
+		enableReinitialize: true,
+		initialValues: {
+			model_config_id: exploreModelOverrideData?.model_config_id ?? "",
+		},
+		onSubmit: (values, { resetForm }) => {
+			onSaveExploreModelOverride(
+				{
+					model_config_id: values.model_config_id || undefined,
+				},
+				{
+					onSuccess: () => {
+						resetForm({ values });
+					},
+				},
+			);
+		},
+	});
+
+	const isUnavailableSavedModel =
+		form.values.model_config_id !== "" &&
+		!enabledModelOptions.some(
+			(option) => option.id === form.values.model_config_id,
+		);
+	const isExploreModelOverrideDisabled =
+		isSavingExploreModelOverride ||
+		isLoadingModelConfigs ||
+		!hasLoadedExploreModelOverride;
+	const modelSelectorPlaceholder = isUnavailableSavedModel
+		? "Unavailable model"
+		: "Use chat default";
+
+	return (
+		<form className="space-y-2" onSubmit={form.handleSubmit}>
+			<div className="flex items-center gap-2">
+				<h3 className="m-0 text-[13px] font-semibold text-content-primary">
+					Explore subagent model
+				</h3>
+				<AdminBadge />
+			</div>
+			<p className="!mt-0.5 m-0 text-xs text-content-secondary">
+				Optional deployment-wide model override for read-only Explore subagents
+				spawned with <code>spawn_explore_agent</code>.
+			</p>
+			<div className="rounded-lg border border-border bg-surface-primary px-3 py-2">
+				<ModelSelector
+					options={enabledModelOptions}
+					value={form.values.model_config_id}
+					onValueChange={(value) =>
+						form.setFieldValue("model_config_id", value)
+					}
+					disabled={isExploreModelOverrideDisabled}
+					placeholder={modelSelectorPlaceholder}
+					emptyMessage={
+						isLoadingModelConfigs
+							? "Loading models..."
+							: "No enabled models found."
+					}
+					className="h-8 w-full justify-between px-0 text-sm"
+					contentClassName="min-w-[18rem]"
+				/>
+			</div>
+			{isUnavailableSavedModel && (
+				<Alert severity="warning">
+					<AlertDescription>
+						The saved model is no longer enabled and will be ignored until you
+						choose a new override.
+					</AlertDescription>
+				</Alert>
+			)}
+			{Boolean(modelConfigsError) && (
+				<p className="m-0 text-xs text-content-destructive">
+					Failed to load model configs.
+				</p>
+			)}
+			<div className="flex justify-end gap-2">
+				<Button
+					size="sm"
+					variant="outline"
+					type="button"
+					onClick={() => form.setFieldValue("model_config_id", "")}
+					disabled={
+						isExploreModelOverrideDisabled || !form.values.model_config_id
+					}
+				>
+					Clear
+				</Button>
+				<Button
+					size="sm"
+					type="submit"
+					disabled={
+						isExploreModelOverrideDisabled ||
+						!(form.dirty && hasLoadedExploreModelOverride)
+					}
+				>
+					Save
+				</Button>
+			</div>
+			{isSaveExploreModelOverrideError && (
+				<p className="m-0 text-xs text-content-destructive">
+					Failed to save Explore model override.
+				</p>
+			)}
+		</form>
+	);
+};

--- a/site/src/pages/AgentsPage/components/ExploreModelOverrideSettings.tsx
+++ b/site/src/pages/AgentsPage/components/ExploreModelOverrideSettings.tsx
@@ -139,10 +139,14 @@ export const ExploreModelOverrideSettings: FC<
 					size="sm"
 					variant="outline"
 					type="button"
-					onClick={() => form.setFieldValue("model_config_id", "")}
-					disabled={
-						isExploreModelOverrideDisabled || !form.values.model_config_id
-					}
+					onClick={() => {
+						if (form.values.model_config_id === "") {
+							void form.submitForm();
+							return;
+						}
+						form.setFieldValue("model_config_id", "");
+					}}
+					disabled={isExploreModelOverrideDisabled}
 				>
 					Clear
 				</Button>

--- a/site/src/pages/AgentsPage/components/ExploreModelOverrideSettings.tsx
+++ b/site/src/pages/AgentsPage/components/ExploreModelOverrideSettings.tsx
@@ -25,6 +25,7 @@ interface ExploreModelOverrideSettingsProps {
 	) => void;
 	isSavingExploreModelOverride: boolean;
 	isSaveExploreModelOverrideError: boolean;
+	showHeader?: boolean;
 }
 
 const toModelSelectorOption = (
@@ -47,6 +48,7 @@ export const ExploreModelOverrideSettings: FC<
 	onSaveExploreModelOverride,
 	isSavingExploreModelOverride,
 	isSaveExploreModelOverrideError,
+	showHeader = true,
 }) => {
 	const hasLoadedExploreModelOverride = exploreModelOverrideData !== undefined;
 	const enabledModelOptions = modelConfigs
@@ -87,16 +89,20 @@ export const ExploreModelOverrideSettings: FC<
 
 	return (
 		<form className="space-y-2" onSubmit={form.handleSubmit}>
-			<div className="flex items-center gap-2">
-				<h3 className="m-0 text-[13px] font-semibold text-content-primary">
-					Explore subagent model
-				</h3>
-				<AdminBadge />
-			</div>
-			<p className="!mt-0.5 m-0 text-xs text-content-secondary">
-				Optional deployment-wide model override for read-only Explore subagents
-				spawned with <code>spawn_explore_agent</code>.
-			</p>
+			{showHeader && (
+				<>
+					<div className="flex items-center gap-2">
+						<h3 className="m-0 text-[13px] font-semibold text-content-primary">
+							Explore subagent model
+						</h3>
+						<AdminBadge />
+					</div>
+					<p className="!mt-0.5 m-0 text-xs text-content-secondary">
+						Optional deployment-wide model override for read-only Explore
+						subagents spawned with <code>spawn_explore_agent</code>.
+					</p>
+				</>
+			)}
 			<div className="rounded-lg border border-border bg-surface-primary px-3 py-2">
 				<ModelSelector
 					options={enabledModelOptions}

--- a/site/src/pages/AgentsPage/components/ExploreModelOverrideSettings.tsx
+++ b/site/src/pages/AgentsPage/components/ExploreModelOverrideSettings.tsx
@@ -117,7 +117,7 @@ export const ExploreModelOverrideSettings: FC<
 							? "Loading models..."
 							: "No enabled models found."
 					}
-					className="h-8 w-full justify-between px-0 text-sm"
+					className="h-8 w-full justify-between rounded-md border border-border bg-surface-primary px-2.5 text-sm"
 					contentClassName="min-w-[18rem]"
 				/>
 			</div>

--- a/site/src/pages/AgentsPage/components/ExploreModelOverrideSettings.tsx
+++ b/site/src/pages/AgentsPage/components/ExploreModelOverrideSettings.tsx
@@ -79,13 +79,14 @@ export const ExploreModelOverrideSettings: FC<
 		!enabledModelOptions.some(
 			(option) => option.id === form.values.model_config_id,
 		);
+	const hasMalformedOverride =
+		exploreModelOverrideData?.has_malformed_override ?? false;
 	const isExploreModelOverrideDisabled =
 		isSavingExploreModelOverride ||
 		isLoadingModelConfigs ||
 		!hasLoadedExploreModelOverride;
-	const modelSelectorPlaceholder = isUnavailableSavedModel
-		? "Unavailable model"
-		: "Use chat default";
+	const canSaveExploreModelOverride =
+		hasLoadedExploreModelOverride && (form.dirty || hasMalformedOverride);
 
 	return (
 		<form className="space-y-2" onSubmit={form.handleSubmit}>
@@ -111,7 +112,9 @@ export const ExploreModelOverrideSettings: FC<
 						form.setFieldValue("model_config_id", value)
 					}
 					disabled={isExploreModelOverrideDisabled}
-					placeholder={modelSelectorPlaceholder}
+					placeholder={
+						isUnavailableSavedModel ? "Unavailable model" : "Use chat default"
+					}
 					emptyMessage={
 						isLoadingModelConfigs
 							? "Loading models..."
@@ -129,6 +132,14 @@ export const ExploreModelOverrideSettings: FC<
 					</AlertDescription>
 				</Alert>
 			)}
+			{hasMalformedOverride && (
+				<Alert severity="warning">
+					<AlertDescription>
+						The saved override is malformed and is being treated as unset. Click
+						Save to clear it.
+					</AlertDescription>
+				</Alert>
+			)}
 			{Boolean(modelConfigsError) && (
 				<p className="m-0 text-xs text-content-destructive">
 					Failed to load model configs.
@@ -140,10 +151,6 @@ export const ExploreModelOverrideSettings: FC<
 					variant="outline"
 					type="button"
 					onClick={() => {
-						if (form.values.model_config_id === "") {
-							void form.submitForm();
-							return;
-						}
 						form.setFieldValue("model_config_id", "");
 					}}
 					disabled={isExploreModelOverrideDisabled}
@@ -154,8 +161,7 @@ export const ExploreModelOverrideSettings: FC<
 					size="sm"
 					type="submit"
 					disabled={
-						isExploreModelOverrideDisabled ||
-						!(form.dirty && hasLoadedExploreModelOverride)
+						isExploreModelOverrideDisabled || !canSaveExploreModelOverride
 					}
 				>
 					Save

--- a/site/src/pages/AgentsPage/components/ExploreModelOverrideSettings.tsx
+++ b/site/src/pages/AgentsPage/components/ExploreModelOverrideSettings.tsx
@@ -117,7 +117,7 @@ export const ExploreModelOverrideSettings: FC<
 							? "Loading models..."
 							: "No enabled models found."
 					}
-					className="h-8 w-full justify-between rounded-md border border-border bg-surface-primary px-2.5 text-sm"
+					className="h-10 w-full justify-between rounded-md border border-border border-solid bg-transparent px-3 text-sm shadow-sm"
 					contentClassName="min-w-[18rem]"
 				/>
 			</div>

--- a/site/src/pages/AgentsPage/components/ExploreModelOverrideSettings.tsx
+++ b/site/src/pages/AgentsPage/components/ExploreModelOverrideSettings.tsx
@@ -33,7 +33,7 @@ const toModelSelectorOption = (
 	id: modelConfig.id,
 	provider: modelConfig.provider,
 	model: modelConfig.model,
-	displayName: modelConfig.display_name,
+	displayName: modelConfig.display_name.trim() || modelConfig.model,
 	contextLimit: modelConfig.context_limit,
 });
 

--- a/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
@@ -20,6 +20,7 @@ import {
 	AlertTriangleIcon,
 	ArchiveIcon,
 	ArchiveRestoreIcon,
+	BotIcon,
 	BoxesIcon,
 	CheckIcon,
 	ChevronDownIcon,
@@ -1277,6 +1278,14 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 						)}
 						{isAdmin && (
 							<>
+								<SettingsNavItem
+									icon={BotIcon}
+									label="Agents"
+									active={sidebarView.section === "agents"}
+									to="/agents/settings/agents"
+									state={location.state}
+									adminOnly
+								/>
 								<SettingsNavItem
 									icon={LayoutTemplateIcon}
 									label="Templates"

--- a/site/src/router.tsx
+++ b/site/src/router.tsx
@@ -360,6 +360,9 @@ const AgentSettingsPage = lazy(
 const AgentSettingsBehaviorPage = lazy(
 	() => import("./pages/AgentsPage/AgentSettingsBehaviorPage"),
 );
+const AgentSettingsAgentsPage = lazy(
+	() => import("./pages/AgentsPage/AgentSettingsAgentsPage"),
+);
 const AgentSettingsProvidersPage = lazy(
 	() => import("./pages/AgentsPage/AgentSettingsProvidersPage"),
 );
@@ -709,6 +712,7 @@ export const router = createBrowserRouter(
 					<Route path="settings" element={<AgentSettingsPage />}>
 						<Route index element={<AgentSettingsBehaviorPage />} />
 						<Route path="behavior" element={<AgentSettingsBehaviorPage />} />
+						<Route path="agents" element={<AgentSettingsAgentsPage />} />
 						<Route path="api-keys" element={<AgentSettingsAPIKeysPage />} />
 						<Route path="providers" element={<AgentSettingsProvidersPage />} />
 						<Route path="models" element={<AgentSettingsModelsPage />} />


### PR DESCRIPTION
> This PR was authored by Mux on behalf of Mike.

Introduce Explore mode, a read-only subagent modality for delegated
discovery and code investigation.

## What

Adds a `spawn_explore_agent` tool that creates child chats restricted to
read-only operations. An admin can optionally configure a deployment-wide
model override so Explore subagents use a model optimized for large context
or reasoning without changing the root chat's model.

### Backend

- New `ChatModeExplore` enum value (migration 000471).
- `spawn_explore_agent` tool definition with read-only allowlist:
  `read_file`, `execute`, `process_output`, `read_skill`, `read_skill_file`.
  Write tools, file editors, and nested subagent spawning are blocked.
- Deployment config storage for the Explore model override
  (`agents_chat_explore_model_override` in `site_configs`).
- Model resolution hierarchy: configured override, then current turn model,
  then global default. Silent fallback with warning log when the override
  becomes unavailable.
- RBAC: `AsChatd` for daemon reads, `ActionRead` and `ActionUpdate` on
  `ResourceDeploymentConfig` for admin API calls.
- Plan mode root chats can use `spawn_explore_agent` for read-only research,
  matching the planning prompt guidance.
- The Explore override config API now reports malformed saved overrides as
  "treated as unset" so admins can clear them explicitly.

### Frontend

- `ExploreModelOverrideSettings` component in admin agent behavior settings.
  Uses `ModelSelector`, handles unavailable model warnings, and supports
  explicit Save and Clear actions.
- Malformed saved overrides show a warning and require an explicit Save to
  clear, instead of Clear auto-submitting behind the scenes.

### Tests

- Integration: `TestExploreSubagentIsReadOnly` (full spawn flow, tool
  verification, prompt overlay, DB state).
- Unit: tool allowlist tests for explore, plan, and default modes.
- Internal: model override resolution with valid, invalid UUID, disabled, and
  unconfigured override scenarios.
- RBAC: `dbauthz_test.go` for `GetChatExploreModelOverride` and
  `UpsertChatExploreModelOverride`.
- API: admin set and clear, malformed stored override reporting, disabled
  model rejection, non-admin denial.
