### PR TITLE
fix(coderd/x/chatd): prefer devcontainer sub-agent over host agent in chat

### DIFF
--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -50,6 +50,7 @@ import (
 	"github.com/coder/coder/v2/coderd/workspaceapps"
 	"github.com/coder/coder/v2/coderd/wsbuilder"
 	"github.com/coder/coder/v2/coderd/x/chatd"
+	"github.com/coder/coder/v2/coderd/x/chatd/agentselect"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatprovider"
 	"github.com/coder/coder/v2/coderd/x/gitsync"
 	"github.com/coder/coder/v2/codersdk"
@@ -1500,6 +1501,26 @@ func (api *API) getChatMessages(rw http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// pickChatAgentForWatch returns the agent the chat should talk to. It
+// prefers the agent pinned on the chat record (set by chatd when the
+// chat first resolves its workspace agent) and falls back to
+// agentselect.FindChatAgent so devcontainer sub-agents are preferred
+// over the host agent.
+func pickChatAgentForWatch(
+	chat database.Chat,
+	agents []database.WorkspaceAgent,
+) (database.WorkspaceAgent, error) {
+	if chat.AgentID.Valid {
+		for _, a := range agents {
+			if a.ID == chat.AgentID.UUID {
+				return a, nil
+			}
+		}
+		// Pinned agent is no longer in the latest build; fall through.
+	}
+	return agentselect.FindChatAgent(agents)
+}
+
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
 //
 //nolint:revive // HTTP handler writes to ResponseWriter.
@@ -1532,10 +1553,19 @@ func (api *API) watchChatGit(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	selectedAgent, err := pickChatAgentForWatch(chat, agents)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Failed to select workspace agent for chat.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
 	apiAgent, err := db2sdk.WorkspaceAgent(
 		api.DERPMap(),
 		*api.TailnetCoordinator.Load(),
-		agents[0],
+		selectedAgent,
 		nil,
 		nil,
 		nil,
@@ -1559,7 +1589,7 @@ func (api *API) watchChatGit(rw http.ResponseWriter, r *http.Request) {
 	dialCtx, dialCancel := context.WithTimeout(ctx, 30*time.Second)
 	defer dialCancel()
 
-	agentConn, release, err := api.agentProvider.AgentConn(dialCtx, agents[0].ID)
+	agentConn, release, err := api.agentProvider.AgentConn(dialCtx, selectedAgent.ID)
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Internal error dialing workspace agent.",
@@ -1693,10 +1723,19 @@ func (api *API) watchChatDesktop(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	selectedAgent, err := pickChatAgentForWatch(chat, agents)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Failed to select workspace agent for chat.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
 	apiAgent, err := db2sdk.WorkspaceAgent(
 		api.DERPMap(),
 		*api.TailnetCoordinator.Load(),
-		agents[0],
+		selectedAgent,
 		nil,
 		nil,
 		nil,
@@ -1720,7 +1759,7 @@ func (api *API) watchChatDesktop(rw http.ResponseWriter, r *http.Request) {
 	dialCtx, dialCancel := context.WithTimeout(ctx, 30*time.Second)
 	defer dialCancel()
 
-	agentConn, release, err := api.agentProvider.AgentConn(dialCtx, agents[0].ID)
+	agentConn, release, err := api.agentProvider.AgentConn(dialCtx, selectedAgent.ID)
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
 			Message: "Failed to dial workspace agent.",

--- a/coderd/x/chatd/agentselect/agentselect.go
+++ b/coderd/x/chatd/agentselect/agentselect.go
@@ -21,32 +21,38 @@ func IsChatAgent(name string) bool {
 
 // FindChatAgent picks the best workspace agent for a chat session from the
 // provided candidates. It applies these rules in order:
-//  1. Filter to root agents only (ParentID is null).
-//  2. Sort stably and deterministically by DisplayOrder ASC, then Name ASC
-//     (case-insensitive), then Name ASC, then ID ASC.
-//  3. If exactly one root agent name ends with Suffix (case-insensitive),
-//     return it.
-//  4. If zero root agents match the suffix, return the first root agent after
-//     sorting (deterministic fallback).
-//  5. If more than one root agent matches the suffix, return an error with an
-//     actionable message.
-//  6. If no root agents exist at all, return an error.
+//  1. Split candidates into sub-agents (ParentID valid) and root agents
+//     (ParentID null). Devcontainer sub-agents are preferred because they
+//     host the actual dev environment; the outer root agent only runs the
+//     devcontainer runtime.
+//  2. Sort each slice stably and deterministically by DisplayOrder ASC, then
+//     Name ASC (case-insensitive), then Name ASC, then ID ASC.
+//  3. If exactly one agent — sub or root — has a name ending in Suffix
+//     (case-insensitive), return it. An explicit suffix match always wins
+//     over the sub-agent preference so operators can pin a specific agent.
+//  4. If no agent matches the suffix and at least one sub-agent exists,
+//     return the first sub-agent after sorting.
+//  5. Otherwise return the first root agent after sorting.
+//  6. If more than one agent matches the suffix, return an error.
+//  7. If no agents exist at all, return an error.
 func FindChatAgent(
 	agents []database.WorkspaceAgent,
 ) (database.WorkspaceAgent, error) {
+	subAgents := make([]database.WorkspaceAgent, 0, len(agents))
 	rootAgents := make([]database.WorkspaceAgent, 0, len(agents))
 	matchingAgents := make([]database.WorkspaceAgent, 0, 1)
 	for _, agent := range agents {
 		if agent.ParentID.Valid {
-			continue
+			subAgents = append(subAgents, agent)
+		} else {
+			rootAgents = append(rootAgents, agent)
 		}
-		rootAgents = append(rootAgents, agent)
 		if IsChatAgent(agent.Name) {
 			matchingAgents = append(matchingAgents, agent)
 		}
 	}
 
-	if len(rootAgents) == 0 {
+	if len(subAgents) == 0 && len(rootAgents) == 0 {
 		return database.WorkspaceAgent{}, xerrors.New(
 			"no eligible workspace agents found",
 		)
@@ -64,11 +70,15 @@ func FindChatAgent(
 		}
 		return cmp.Compare(a.ID.String(), b.ID.String())
 	}
+	slices.SortStableFunc(subAgents, compareAgents)
 	slices.SortStableFunc(rootAgents, compareAgents)
 	slices.SortStableFunc(matchingAgents, compareAgents)
 
 	switch len(matchingAgents) {
 	case 0:
+		if len(subAgents) > 0 {
+			return subAgents[0], nil
+		}
 		return rootAgents[0], nil
 	case 1:
 		return matchingAgents[0], nil

--- a/coderd/x/chatd/agentselect/agentselect_test.go
+++ b/coderd/x/chatd/agentselect/agentselect_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/coderd/database"
-	"github.com/coder/coder/v2/coderd/x/chatd/internal/agentselect"
+	"github.com/coder/coder/v2/coderd/x/chatd/agentselect"
 )
 
 func TestFindChatAgent(t *testing.T) {
@@ -108,36 +108,64 @@ func TestFindChatAgent(t *testing.T) {
 			},
 		},
 		{
-			name: "ChildAgentSuffixIgnored",
+			name: "SubAgentPreferredOverRoot",
 			agents: []database.WorkspaceAgent{
-				newRootAgent("alpha", 1),
-				newChildAgent("child-coderd-chat", 0),
-				newRootAgent("bravo", 0),
+				newRootAgent("host", 0),
+				newChildAgent("devcontainer", 1),
 			},
-			wantIndex: 2,
+			wantIndex: 1,
 		},
 		{
-			name: "ChildAgentSuffixIgnoredWithRootMatch",
+			name: "SubAgentSuffixMatchWins",
 			agents: []database.WorkspaceAgent{
 				newRootAgent("alpha", 0),
-				newChildAgent("child-coderd-chat", 1),
-				newRootAgent("root-coderd-chat", 2),
+				newChildAgent("dev-coderd-chat", 1),
 			},
-			wantIndex: 2,
+			wantIndex: 1,
+		},
+		{
+			name: "RootSuffixMatchWinsOverSubAgent",
+			agents: []database.WorkspaceAgent{
+				newChildAgent("alpha", 1),
+				newRootAgent("dev-coderd-chat", 0),
+			},
+			wantIndex: 1,
+		},
+		{
+			name: "MultipleSubAgentsSortedDeterministically",
+			agents: []database.WorkspaceAgent{
+				newChildAgent("zeta", 0),
+				newChildAgent("alpha", 0),
+			},
+			wantIndex: 1,
+		},
+		{
+			name: "OnlySubAgents",
+			agents: []database.WorkspaceAgent{
+				newChildAgent("zeta", 0),
+				newChildAgent("alpha", 0),
+			},
+			wantIndex: 1,
+		},
+		{
+			name: "MultipleSuffixMatchesAcrossRootAndSubAgentError",
+			agents: []database.WorkspaceAgent{
+				newRootAgent("alpha-coderd-chat", 0),
+				newChildAgent("beta-coderd-chat", 1),
+			},
+			wantErrContains: []string{
+				fmt.Sprintf(
+					"multiple agents match the chat suffix %q",
+					agentselect.Suffix,
+				),
+				"alpha-coderd-chat",
+				"beta-coderd-chat",
+				"only one agent should use this suffix",
+			},
 		},
 		{
 			name:   "EmptyAgentList",
 			agents: []database.WorkspaceAgent{},
-			wantErrContains: []string{
-				"no eligible workspace agents found",
-			},
-		},
-		{
-			name: "OnlyChildAgents",
-			agents: []database.WorkspaceAgent{
-				newChildAgent("alpha", 0),
-				newChildAgent("beta-coderd-chat", 1),
-			},
 			wantErrContains: []string{
 				"no eligible workspace agents found",
 			},

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -42,7 +42,7 @@ import (
 	"github.com/coder/coder/v2/coderd/x/chatd/chatprovider"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatretry"
 	"github.com/coder/coder/v2/coderd/x/chatd/chattool"
-	"github.com/coder/coder/v2/coderd/x/chatd/internal/agentselect"
+	"github.com/coder/coder/v2/coderd/x/chatd/agentselect"
 	"github.com/coder/coder/v2/coderd/x/chatd/mcpclient"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"

--- a/coderd/x/chatd/chattool/createworkspace.go
+++ b/coderd/x/chatd/chattool/createworkspace.go
@@ -16,7 +16,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
 	"github.com/coder/coder/v2/coderd/util/namesgenerator"
-	"github.com/coder/coder/v2/coderd/x/chatd/internal/agentselect"
+	"github.com/coder/coder/v2/coderd/x/chatd/agentselect"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
 )

--- a/coderd/x/chatd/chattool/startworkspace.go
+++ b/coderd/x/chatd/chattool/startworkspace.go
@@ -11,7 +11,7 @@ import (
 	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/httpapi/httperror"
-	"github.com/coder/coder/v2/coderd/x/chatd/internal/agentselect"
+	"github.com/coder/coder/v2/coderd/x/chatd/agentselect"
 	"github.com/coder/coder/v2/codersdk"
 )
 


### PR DESCRIPTION
Fixes #23547

## Problem

The `/agents` AI chat always talked to `agents[0]` from `GetWorkspaceAgentsInLatestBuildByWorkspaceID`. In workspaces with devcontainers, that is the **host** agent rather than the sub-agent where the actual dev environment lives, so chat tool calls ran on the host instead of inside the devcontainer.

Two separate places contributed:

1. `agentselect.FindChatAgent` (the helper used by `chatd`, `chattool/createworkspace.go`, `chattool/startworkspace.go`) explicitly **filtered out** every sub-agent (`ParentID.Valid`), so even when the helper was used it could never return a devcontainer sub-agent.
2. The two experimental watch endpoints in `coderd/exp_chats.go` (`watchChatGit`, `watchChatDesktop`) bypassed the helper entirely and used `agents[0]` directly, also ignoring any `chat.AgentID` previously pinned by `chatd`.

## Fix (Option 1 from the issue — "prefer sub-agents automatically")

### `agentselect.FindChatAgent`

New rules, in order:
1. Split candidates into sub-agents and root agents; sort each deterministically (unchanged sort key).
2. If exactly one agent — sub or root — has the `-coderd-chat` suffix, return it. A unique suffix match still wins, so operators can pin a specific agent by name.
3. No suffix match and ≥1 sub-agent → return the first sub-agent.
4. Otherwise return the first root agent.
5. Multiple suffix matches → existing error.
6. No agents at all → existing error.

This means `chatd`, `createworkspace`, and `startworkspace` all automatically start preferring devcontainer sub-agents once they wait for the sub-agent to come online.

### `coderd/exp_chats.go`

Introduce `pickChatAgentForWatch(chat, agents)`:
- If `chat.AgentID` is set and still present in the latest build, return that agent (honors the pin that `chatd` already persists).
- Otherwise fall through to `agentselect.FindChatAgent`.

Use it from both `watchChatGit` and `watchChatDesktop` in place of the two `agents[0]` references per handler.

### Package move

`agentselect` was under `coderd/x/chatd/internal/`, so `coderd/exp_chats.go` (package `coderd`) could not import it. Moved to `coderd/x/chatd/agentselect/`. Three existing importers updated (`chatd.go`, `chattool/createworkspace.go`, `chattool/startworkspace.go`).

## What this does not change

- No schema, SDK, or HTTP API changes.
- `codersdk.Chat.AgentID` is already surfaced and `getWorkspaceAgent` in `site/src/pages/AgentsPage/components/ChatConversation/chatHelpers.ts` already prefers it, so no frontend change is needed to light this up.
- The issue listed four other, bigger options (per-chat agent pinning UI, workspace default agent, mid-session agent switching). Those are deliberately out of scope — this PR goes for the least-invasive approach that makes the common case correct.

## Testing

- `go test ./coderd/x/chatd/agentselect/...` — passes. Added 6 new sub-cases covering sub-agent preference, cross-agent suffix matching, and the `only sub-agents` case; removed three cases that asserted the old (incorrect) behavior.
- `go build ./coderd/... ./coderd/x/chatd/...` — passes.

<details><summary>Implementation notes (Coder Agents generated)</summary>

- `agentselect.FindChatAgent` was previously documented as "root agents only". The doc comment was rewritten to describe the new sub-agent-first rule.
- No existing callers of `FindChatAgent` had to change their error handling — the error cases and fallback-to-`agents[0]` paths in `createworkspace.go` / `startworkspace.go` continue to work.
- `pickChatAgentForWatch` lives in `exp_chats.go` rather than `agentselect` because it depends on `database.Chat`, which would pull `database` into `agentselect` and fight the existing package shape.
- Did not touch the frontend because `getWorkspaceAgent` already picks the agent by `chat.agent_id`, so the backend fix is self-propagating.

> This PR was authored by Coder Agents.
</details>