### PR TITLE
feat: add credits display to workspace topbar with quota warning

### DIFF
--- a/examples/templates/docker/main.tf
+++ b/examples/templates/docker/main.tf
@@ -209,3 +209,8 @@ resource "docker_container" "workspace" {
     value = data.coder_workspace.me.name
   }
 }
+
+resource "coder_metadata" "workspace_cost" {
+  resource_id = coder_agent.main.id
+  daily_cost  = 1
+}

--- a/site/src/pages/WorkspacePage/WorkspaceTopbar.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceTopbar.tsx
@@ -172,34 +172,34 @@ export const WorkspaceTopbar: FC<WorkspaceProps> = ({
 								? `See affected workspaces for ${orgDisplayName}`
 								: "See affected workspaces"
 						}
-						>
+					>
+						<TopbarData>
 							<TopbarIcon>
 								<CircleDollarSign
 									className="size-icon-sm"
 									aria-label="Daily usage"
 								/>
 							</TopbarIcon>
-								<TopbarData>
-									<span>
-										{workspace.latest_build.daily_cost}{" "}
-																			<span className="text-content-secondary">
-										{workspace.latest_build.daily_cost === 1
-											? "credit"
-											: "credits"}{" "}
-										(
-										<span
-							className={cn({
-								"text-content-warning":
-									quota.credits_consumed >= quota.budget * 0.85,
-								})}									>
-											{quota.credits_consumed}
-											</span>
-												{" "} of {quota.budget} total)
-									</span>
+							<span>
+								{workspace.latest_build.daily_cost}{" "}
+								<span className="text-content-secondary">
+									{workspace.latest_build.daily_cost === 1
+										? "credit"
+										: "credits"}{" "}
+									(
+									<span
+										className={cn({
+											"text-content-warning":
+												quota.credits_consumed >= quota.budget * 0.85,
+										})}
+									>
+										{quota.credits_consumed}
+									</span>{" "}
+									of {quota.budget} total)
 								</span>
-							</TopbarData>
-						</Link>
-
+							</span>
+						</TopbarData>
+					</Link>
 				)}
 
 				{shouldDisplayDormantData && (

--- a/site/src/pages/WorkspacePage/WorkspaceTopbar.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceTopbar.tsx
@@ -30,6 +30,7 @@ import {
 import { useDashboard } from "#/modules/dashboard/useDashboard";
 import { linkToTemplate, useLinks } from "#/modules/navigation";
 import { WorkspaceStatusIndicator } from "#/modules/workspaces/WorkspaceStatusIndicator/WorkspaceStatusIndicator";
+import { cn } from "#/utils/cn";
 import { displayDormantDeletion } from "#/utils/dormant";
 import { formatDate } from "#/utils/time";
 import type { WorkspacePermissions } from "../../modules/workspaces/permissions";
@@ -171,22 +172,34 @@ export const WorkspaceTopbar: FC<WorkspaceProps> = ({
 								? `See affected workspaces for ${orgDisplayName}`
 								: "See affected workspaces"
 						}
-					>
-						<TopbarData>
+						>
 							<TopbarIcon>
 								<CircleDollarSign
 									className="size-icon-sm"
 									aria-label="Daily usage"
 								/>
 							</TopbarIcon>
+								<TopbarData>
+									<span>
+										{workspace.latest_build.daily_cost}{" "}
+																			<span className="text-content-secondary">
+										{workspace.latest_build.daily_cost === 1
+											? "credit"
+											: "credits"}{" "}
+										(
+										<span
+							className={cn({
+								"text-content-warning":
+									quota.credits_consumed >= quota.budget * 0.85,
+								})}									>
+											{quota.credits_consumed}
+											</span>
+												{" "} of {quota.budget} total)
+									</span>
+								</span>
+							</TopbarData>
+						</Link>
 
-							<span>
-								{workspace.latest_build.daily_cost}{" "}
-								<span className="text-content-secondary">credits of</span>{" "}
-								{quota.budget}
-							</span>
-						</TopbarData>
-					</Link>
 				)}
 
 				{shouldDisplayDormantData && (


### PR DESCRIPTION
Adds a credits display to the workspace topbar showing daily cost and quota usage with a warning indicator when approaching the budget limit (>= 85%).

The topbar now displays: "1 credit (9 of 10 total)" with:
- Daily cost from `workspace.latest_build.daily_cost`
- Consumed and budget quota from the `workspaceQuota()` hook
- Automatic singularization ("1 credit" vs "2 credits")
- Warning color (`text-content-warning`) when quota >= 85% of budget

Updates the Docker template with cost metadata.