### PR TITLE
refactor(site): replace deprecated Stack in Sidebar

### DIFF
--- a/site/src/components/Sidebar/Sidebar.tsx
+++ b/site/src/components/Sidebar/Sidebar.tsx
@@ -1,6 +1,5 @@
 import type { ElementType, FC, ReactNode } from "react";
 import { Link, NavLink } from "react-router";
-import { Stack } from "#/components/Stack/Stack";
 import { cn } from "#/utils/cn";
 
 interface SidebarProps {
@@ -31,7 +30,7 @@ export const SidebarHeader: FC<SidebarHeaderProps> = ({
 	linkTo,
 }) => {
 	return (
-		<Stack direction="row" spacing={1} className="mb-4">
+		<div className="flex flex-row gap-2 mb-4">
 			{avatar}
 			<div className="overflow-hidden flex flex-col">
 				{linkTo ? (
@@ -45,7 +44,7 @@ export const SidebarHeader: FC<SidebarHeaderProps> = ({
 					{subtitle}
 				</span>
 			</div>
-		</Stack>
+		</div>
 	);
 };
 
@@ -100,10 +99,10 @@ export const SidebarNavItem: FC<SidebarNavItemProps> = ({
 				)
 			}
 		>
-			<Stack alignItems="center" spacing={1.5} direction="row">
+			<div className="flex flex-row items-center gap-3">
 				<Icon className="size-4" />
 				{children}
-			</Stack>
+			</div>
 		</NavLink>
 	);
 };


### PR DESCRIPTION
Replace the deprecated `Stack` component (emotion CSS-in-JS) with plain Tailwind flex utilities in the shared Sidebar components.

> Generated with [Coder Agents](https://coder.com/agents)