### PR TITLE
fix(coderd): add frame-ancestors CSP directive to prevent clickjacking

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -2028,12 +2028,16 @@ func New(options *Options) *API {
 
 	// Embed routes (e.g. VS Code extension chat) are designed to be
 	// loaded inside iframes, so they need a relaxed frame-ancestors
-	// policy instead of the default 'self'.
+	// policy instead of the default 'self'. However, if the operator
+	// explicitly configured frame-ancestors via CODER_ADDITIONAL_CSP_POLICY,
+	// respect that setting.
 	embedCSPHeaders := make(map[httpmw.CSPFetchDirective][]string, len(additionalCSPHeaders))
 	for k, v := range additionalCSPHeaders {
 		embedCSPHeaders[k] = v
 	}
-	embedCSPHeaders[httpmw.CSPFrameAncestors] = []string{"*"}
+	if _, ok := additionalCSPHeaders[httpmw.CSPFrameAncestors]; !ok {
+		embedCSPHeaders[httpmw.CSPFrameAncestors] = []string{"*"}
+	}
 	embedCSPMW := httpmw.CSPHeaders(options.Telemetry.Enabled(), cspProxyHosts, embedCSPHeaders)
 	embedHandler := embedCSPMW(compressHandler(httpmw.HSTS(api.SiteHandler, options.StrictTransportSecurityCfg)))
 	r.Get("/agents/{agentId}/embed", embedHandler.ServeHTTP)

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -2002,29 +2002,42 @@ func New(options *Options) *API {
 
 	// Add CSP headers to all static assets and pages. CSP headers only affect
 	// browsers, so these don't make sense on api routes.
-	cspMW := httpmw.CSPHeaders(
-		options.Telemetry.Enabled(), func() []*proxyhealth.ProxyHost {
-			if api.DeploymentValues.Dangerous.AllowAllCors {
-				// In this mode, allow all external requests.
-				return []*proxyhealth.ProxyHost{
-					{
-						Host:    "*",
-						AppHost: "*",
-					},
-				}
-			}
-			// Always add the primary, since the app host may be on a sub-domain.
-			proxies := []*proxyhealth.ProxyHost{
+	cspProxyHosts := func() []*proxyhealth.ProxyHost {
+		if api.DeploymentValues.Dangerous.AllowAllCors {
+			// In this mode, allow all external requests.
+			return []*proxyhealth.ProxyHost{
 				{
-					Host:    api.AccessURL.Host,
-					AppHost: appurl.ConvertAppHostForCSP(api.AccessURL.Host, api.AppHostname),
+					Host:    "*",
+					AppHost: "*",
 				},
 			}
-			if f := api.WorkspaceProxyHostsFn.Load(); f != nil {
-				proxies = append(proxies, (*f)()...)
-			}
-			return proxies
-		}, additionalCSPHeaders)
+		}
+		// Always add the primary, since the app host may be on a sub-domain.
+		proxies := []*proxyhealth.ProxyHost{
+			{
+				Host:    api.AccessURL.Host,
+				AppHost: appurl.ConvertAppHostForCSP(api.AccessURL.Host, api.AppHostname),
+			},
+		}
+		if f := api.WorkspaceProxyHostsFn.Load(); f != nil {
+			proxies = append(proxies, (*f)()...)
+		}
+		return proxies
+	}
+	cspMW := httpmw.CSPHeaders(options.Telemetry.Enabled(), cspProxyHosts, additionalCSPHeaders)
+
+	// Embed routes (e.g. VS Code extension chat) are designed to be
+	// loaded inside iframes, so they need a relaxed frame-ancestors
+	// policy instead of the default 'self'.
+	embedCSPHeaders := make(map[httpmw.CSPFetchDirective][]string, len(additionalCSPHeaders))
+	for k, v := range additionalCSPHeaders {
+		embedCSPHeaders[k] = v
+	}
+	embedCSPHeaders[httpmw.CSPFrameAncestors] = []string{"*"}
+	embedCSPMW := httpmw.CSPHeaders(options.Telemetry.Enabled(), cspProxyHosts, embedCSPHeaders)
+	embedHandler := embedCSPMW(compressHandler(httpmw.HSTS(api.SiteHandler, options.StrictTransportSecurityCfg)))
+	r.Get("/agents/{agentId}/embed", embedHandler.ServeHTTP)
+	r.Get("/agents/{agentId}/embed/*", embedHandler.ServeHTTP)
 
 	// Static file handler must be wrapped with HSTS handler if the
 	// StrictTransportSecurityAge is set. We only need to set this header on

--- a/coderd/httpmw/csp.go
+++ b/coderd/httpmw/csp.go
@@ -142,6 +142,13 @@ func CSPHeaders(telemetry bool, proxyHosts func() []*proxyhealth.ProxyHost, stat
 				cspSrcs.Append(directive, values...)
 			}
 
+			// Default to 'self' to prevent clickjacking unless
+			// explicitly overridden via staticAdditions (e.g. for
+			// embeddable routes).
+			if _, ok := cspSrcs[CSPFrameAncestors]; !ok {
+				cspSrcs[CSPFrameAncestors] = []string{"'self'"}
+			}
+
 			var csp strings.Builder
 			for src, vals := range cspSrcs {
 				_, _ = fmt.Fprintf(&csp, "%s %s; ", src, strings.Join(vals, " "))

--- a/coderd/httpmw/csp_test.go
+++ b/coderd/httpmw/csp_test.go
@@ -12,6 +12,45 @@ import (
 	"github.com/coder/coder/v2/coderd/proxyhealth"
 )
 
+func TestCSPFrameAncestors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("DefaultSelf", func(t *testing.T) {
+		t.Parallel()
+
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		rw := httptest.NewRecorder()
+
+		httpmw.CSPHeaders(false, func() []*proxyhealth.ProxyHost {
+			return nil
+		}, nil)(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			rw.WriteHeader(http.StatusOK)
+		})).ServeHTTP(rw, r)
+
+		csp := rw.Header().Get("Content-Security-Policy")
+		require.Contains(t, csp, "frame-ancestors 'self'")
+	})
+
+	t.Run("OverrideViaStaticAdditions", func(t *testing.T) {
+		t.Parallel()
+
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		rw := httptest.NewRecorder()
+
+		httpmw.CSPHeaders(false, func() []*proxyhealth.ProxyHost {
+			return nil
+		}, map[httpmw.CSPFetchDirective][]string{
+			httpmw.CSPFrameAncestors: {"*"},
+		})(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			rw.WriteHeader(http.StatusOK)
+		})).ServeHTTP(rw, r)
+
+		csp := rw.Header().Get("Content-Security-Policy")
+		require.Contains(t, csp, "frame-ancestors *")
+		require.NotContains(t, csp, "frame-ancestors 'self'")
+	})
+}
+
 func TestCSP(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The Coder dashboard CSP headers did not include a `frame-ancestors`
directive, allowing any external site to embed dashboard pages in an iframe
for clickjacking attacks. Only the OAuth2 consent page had hardcoded
protection (`frame-ancestors 'none'` + `X-Frame-Options: DENY`).

This change adds `frame-ancestors 'self'` as the default for all pages
served through the CSP middleware, and registers agent embed routes
(`/agents/{id}/embed`) with `frame-ancestors *` so the VS Code extension
iframe continues to work. Deployments that already set `frame-ancestors`
via `CODER_ADDITIONAL_CSP_POLICY` keep their custom value — the default
only applies when no override is present.

<details><summary>Implementation notes</summary>

- `coderd/httpmw/csp.go`: After the `staticAdditions` loop, set
  `frame-ancestors 'self'` only if no entry already exists. This lets
  `staticAdditions` (including the deployment-level
  `CODER_ADDITIONAL_CSP_POLICY`) override the default.
- `coderd/coderd.go`: Extract proxy-hosts closure into a shared
  `cspProxyHosts` variable. Create a second CSP middleware instance for
  embed routes with `frame-ancestors *`, and register
  `/agents/{agentId}/embed` + `/agents/{agentId}/embed/*` before the
  `r.NotFound` catch-all.
- `coderd/httpmw/csp_test.go`: Two new subtests — default `'self'` and
  override via `staticAdditions`.
</details>

> 🤖 Generated by Coder Agents