### PR TITLE
fix: reap idle chatd stream states on a timer

### DIFF
--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -100,6 +100,15 @@ const (
 	// snapshot the buffer before it is garbage-collected.
 	bufferRetainGracePeriod = 5 * time.Second
 
+	// streamJanitorInterval is how often sweepIdleStreams runs.
+	// Worst-case retention is bufferRetainGracePeriod +
+	// streamJanitorInterval. The janitor is the backstop for
+	// cleanupStreamIfIdle, which early-returns inside the grace
+	// window and does not reschedule; without this loop, a state
+	// whose last activity was a subscriber-detach inside grace
+	// would be pinned until the process exits.
+	streamJanitorInterval = 30 * time.Second
+
 	// DefaultMaxChatsPerAcquire is the maximum number of chats to
 	// acquire in a single processOnce call. Batching avoids
 	// waiting a full polling interval between acquisitions
@@ -2841,6 +2850,9 @@ func (p *Server) start(ctx context.Context) {
 	// Single heartbeat loop for all chats on this replica.
 	go p.heartbeatLoop(ctx)
 
+	// Reap idle stream states whose grace period has elapsed.
+	go p.streamJanitorLoop(ctx)
+
 	acquireTicker := p.clock.NewTicker(
 		p.pendingChatAcquireInterval,
 		"chatd",
@@ -3089,11 +3101,14 @@ func (p *Server) getOrCreateStreamState(chatID uuid.UUID) *chatStreamState {
 	return state
 }
 
-// cleanupStreamIfIdle removes the chat entry from the sync.Map
-// when there are no subscribers and the stream is not buffering.
-// When bufferRetainedAt is set, cleanup is deferred until the
-// grace period expires so cross-replica relay subscribers can
-// still snapshot the buffer.
+// cleanupStreamIfIdle removes the chat entry from the sync.Map when
+// there are no subscribers and the stream is not buffering. When
+// bufferRetainedAt is set, cleanup is deferred until the grace period
+// expires so cross-replica relay subscribers can still snapshot the
+// buffer. If the grace period has not yet elapsed, this function
+// returns without rescheduling — streamJanitorLoop is the backstop
+// that re-checks on a timer so entries do not linger after the grace
+// window ends.
 // The caller must hold state.mu.
 func (p *Server) cleanupStreamIfIdle(chatID uuid.UUID, state *chatStreamState) {
 	if state.buffering || len(state.subscribers) > 0 {
@@ -3108,6 +3123,50 @@ func (p *Server) cleanupStreamIfIdle(chatID uuid.UUID, state *chatStreamState) {
 	}
 	p.chatStreams.Delete(chatID)
 	p.workspaceMCPToolsCache.Delete(chatID)
+}
+
+// streamJanitorLoop periodically reaps idle chat stream states whose
+// grace period has expired. This is the backstop for
+// cleanupStreamIfIdle: that function early-returns inside the grace
+// window and does not reschedule, so without this loop a state that
+// last saw activity inside its grace window is pinned until the
+// process exits. A subscriber that detaches within grace is the most
+// common trigger for that pinning in practice — enterprise relay
+// drains (relayDrainTimeout = 200ms) always fire inside the 5s grace.
+func (p *Server) streamJanitorLoop(ctx context.Context) {
+	ticker := p.clock.NewTicker(streamJanitorInterval, "chatd", "stream-janitor")
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			p.sweepIdleStreams()
+		}
+	}
+}
+
+// sweepIdleStreams iterates chatStreams once and delegates each entry
+// to cleanupStreamIfIdle, which encodes the "is this state reapable"
+// predicate (not buffering, no subscribers, grace expired).
+//
+// sync.Map.Range + Delete is safe: Range may observe or miss
+// concurrent Deletes. A missed entry is reaped on the next tick.
+func (p *Server) sweepIdleStreams() {
+	p.chatStreams.Range(func(key, value any) bool {
+		chatID, ok := key.(uuid.UUID)
+		if !ok {
+			return true
+		}
+		state, ok := value.(*chatStreamState)
+		if !ok {
+			return true
+		}
+		state.mu.Lock()
+		p.cleanupStreamIfIdle(chatID, state)
+		state.mu.Unlock()
+		return true
+	})
 }
 
 // registerHeartbeat enrolls a chat in the centralized batch

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -3028,7 +3028,9 @@ func (p *Server) cacheDurableMessage(chatID uuid.UUID, event codersdk.ChatStream
 		if evicted := state.durableMessages[0]; evicted.Message != nil {
 			state.durableEvictedBefore = evicted.Message.ID
 		}
-		state.durableMessages[0] = codersdk.ChatStreamEvent{} // make the evictee GC-eligible
+		// Zero the dropped slot so the evicted *ChatMessage is
+		// GC-eligible; see publishToStream for the same pattern.
+		state.durableMessages[0] = codersdk.ChatStreamEvent{}
 		state.durableMessages = state.durableMessages[1:]
 	}
 	state.durableMessages = append(state.durableMessages, event)
@@ -3144,9 +3146,23 @@ func (p *Server) streamJanitorLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			p.sweepIdleStreams()
+			p.safeSweepIdleStreams(ctx)
 		}
 	}
+}
+
+// safeSweepIdleStreams runs sweepIdleStreams under a panic recovery
+// so an unexpected panic in the sweep cannot kill the janitor
+// goroutine and silently reintroduce the very leak it exists to
+// prevent. The next tick retries.
+func (p *Server) safeSweepIdleStreams(ctx context.Context) {
+	defer func() {
+		if r := recover(); r != nil {
+			p.logger.Error(ctx, "stream janitor sweep panicked, will retry next tick",
+				slog.F("panic", r))
+		}
+	}()
+	p.sweepIdleStreams()
 }
 
 // sweepIdleStreams iterates chatStreams once and delegates each entry

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -3103,7 +3103,7 @@ func (p *Server) getOrCreateStreamState(chatID uuid.UUID) *chatStreamState {
 // cleanupStreamIfIdle removes the chat entry from the sync.Map when
 // there are no subscribers, the stream is not buffering, and any
 // grace period for late-connecting relay subscribers has elapsed. If
-// the grace window is still open it returns without rescheduling —
+// the grace window is still open it returns without rescheduling.
 // streamJanitorLoop is the backstop that re-checks on a timer.
 //
 // The caller must hold state.mu. The state pointer may have been

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -102,11 +102,7 @@ const (
 
 	// streamJanitorInterval is how often sweepIdleStreams runs.
 	// Worst-case retention is bufferRetainGracePeriod +
-	// streamJanitorInterval. The janitor is the backstop for
-	// cleanupStreamIfIdle, which early-returns inside the grace
-	// window and does not reschedule; without this loop, a state
-	// whose last activity was a subscriber-detach inside grace
-	// would be pinned until the process exits.
+	// streamJanitorInterval.
 	streamJanitorInterval = 30 * time.Second
 
 	// DefaultMaxChatsPerAcquire is the maximum number of chats to
@@ -2850,7 +2846,6 @@ func (p *Server) start(ctx context.Context) {
 	// Single heartbeat loop for all chats on this replica.
 	go p.heartbeatLoop(ctx)
 
-	// Reap idle stream states whose grace period has elapsed.
 	go p.streamJanitorLoop(ctx)
 
 	acquireTicker := p.clock.NewTicker(
@@ -2975,13 +2970,9 @@ func (p *Server) publishToStream(chatID uuid.UUID, event codersdk.ChatStreamEven
 				state.bufferDropCount = 0
 				state.bufferLastWarnAt = now
 			}
-			// Clear the old slot before reslicing so its
-			// *ChatStreamMessagePart becomes GC-eligible. cap is often
-			// greater than len here (Go's growth policy over-allocates),
-			// so the subsequent append stays in place without
-			// reallocating — the dropped pointer would otherwise be
-			// pinned in the backing array until the buffer grew past
-			// its original capacity.
+			// Zero the dropped slot so its *ChatStreamMessagePart is
+			// GC-eligible; the later append reuses this slot in place
+			// whenever cap > len.
 			state.buffer[0] = codersdk.ChatStreamEvent{}
 			state.buffer = state.buffer[1:]
 		}
@@ -3110,20 +3101,15 @@ func (p *Server) getOrCreateStreamState(chatID uuid.UUID) *chatStreamState {
 }
 
 // cleanupStreamIfIdle removes the chat entry from the sync.Map when
-// there are no subscribers and the stream is not buffering. When
-// bufferRetainedAt is set, cleanup is deferred until the grace period
-// expires so cross-replica relay subscribers can still snapshot the
-// buffer. If the grace period has not yet elapsed, this function
-// returns without rescheduling — streamJanitorLoop is the backstop
-// that re-checks on a timer so entries do not linger after the grace
-// window ends.
+// there are no subscribers, the stream is not buffering, and any
+// grace period for late-connecting relay subscribers has elapsed. If
+// the grace window is still open it returns without rescheduling —
+// streamJanitorLoop is the backstop that re-checks on a timer.
 //
-// The caller must hold state.mu. Callers may pass a state pointer that
-// was obtained outside this lock (e.g. from sync.Map.Load or Range);
-// the map entry for chatID could have been replaced in the meantime
-// by a racing getOrCreateStreamState. We use CompareAndDelete so that
-// the map delete only takes effect if the current map entry is still
-// the same *chatStreamState the caller examined under its lock.
+// The caller must hold state.mu. The state pointer may have been
+// captured outside this lock (sync.Map.Load or Range); we use
+// CompareAndDelete so a stale pointer cannot evict a fresh entry
+// installed by a racing getOrCreateStreamState.
 func (p *Server) cleanupStreamIfIdle(chatID uuid.UUID, state *chatStreamState) {
 	if state.buffering || len(state.subscribers) > 0 {
 		return
@@ -3135,10 +3121,6 @@ func (p *Server) cleanupStreamIfIdle(chatID uuid.UUID, state *chatStreamState) {
 		p.clock.Now().Before(state.bufferRetainedAt.Add(bufferRetainGracePeriod)) {
 		return
 	}
-	// CompareAndDelete is a no-op when another goroutine has already
-	// replaced or deleted this entry. Without this guard, a janitor
-	// sweep holding a stale pointer could delete a freshly-installed
-	// state belonging to a new processChat run for the same chat.
 	if !p.chatStreams.CompareAndDelete(chatID, state) {
 		return
 	}
@@ -3146,13 +3128,10 @@ func (p *Server) cleanupStreamIfIdle(chatID uuid.UUID, state *chatStreamState) {
 }
 
 // streamJanitorLoop periodically reaps idle chat stream states whose
-// grace period has expired. This is the backstop for
-// cleanupStreamIfIdle: that function early-returns inside the grace
-// window and does not reschedule, so without this loop a state that
-// last saw activity inside its grace window is pinned until the
-// process exits. A subscriber that detaches within grace is the most
-// common trigger for that pinning in practice — enterprise relay
-// drains (relayDrainTimeout = 200ms) always fire inside the 5s grace.
+// grace period has expired. It is the backstop for the grace-window
+// early-return in cleanupStreamIfIdle; without it, a subscriber that
+// detaches inside grace (the common enterprise relay-drain case,
+// relayDrainTimeout = 200ms vs. 5s grace) pins the state forever.
 func (p *Server) streamJanitorLoop(ctx context.Context) {
 	ticker := p.clock.NewTicker(streamJanitorInterval, "chatd", "stream-janitor")
 	defer ticker.Stop()
@@ -3167,11 +3146,8 @@ func (p *Server) streamJanitorLoop(ctx context.Context) {
 }
 
 // sweepIdleStreams iterates chatStreams once and delegates each entry
-// to cleanupStreamIfIdle, which encodes the "is this state reapable"
-// predicate (not buffering, no subscribers, grace expired).
-//
-// sync.Map.Range + Delete is safe: Range may observe or miss
-// concurrent Deletes. A missed entry is reaped on the next tick.
+// to cleanupStreamIfIdle. Range may miss entries deleted concurrently;
+// any such entry is reaped on the next tick.
 func (p *Server) sweepIdleStreams() {
 	p.chatStreams.Range(func(key, value any) bool {
 		chatID, ok := key.(uuid.UUID)

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -3117,7 +3117,13 @@ func (p *Server) getOrCreateStreamState(chatID uuid.UUID) *chatStreamState {
 // returns without rescheduling — streamJanitorLoop is the backstop
 // that re-checks on a timer so entries do not linger after the grace
 // window ends.
-// The caller must hold state.mu.
+//
+// The caller must hold state.mu. Callers may pass a state pointer that
+// was obtained outside this lock (e.g. from sync.Map.Load or Range);
+// the map entry for chatID could have been replaced in the meantime
+// by a racing getOrCreateStreamState. We use CompareAndDelete so that
+// the map delete only takes effect if the current map entry is still
+// the same *chatStreamState the caller examined under its lock.
 func (p *Server) cleanupStreamIfIdle(chatID uuid.UUID, state *chatStreamState) {
 	if state.buffering || len(state.subscribers) > 0 {
 		return
@@ -3129,7 +3135,13 @@ func (p *Server) cleanupStreamIfIdle(chatID uuid.UUID, state *chatStreamState) {
 		p.clock.Now().Before(state.bufferRetainedAt.Add(bufferRetainGracePeriod)) {
 		return
 	}
-	p.chatStreams.Delete(chatID)
+	// CompareAndDelete is a no-op when another goroutine has already
+	// replaced or deleted this entry. Without this guard, a janitor
+	// sweep holding a stale pointer could delete a freshly-installed
+	// state belonging to a new processChat run for the same chat.
+	if !p.chatStreams.CompareAndDelete(chatID, state) {
+		return
+	}
 	p.workspaceMCPToolsCache.Delete(chatID)
 }
 

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"charm.land/fantasy"
@@ -3027,6 +3028,7 @@ func (p *Server) cacheDurableMessage(chatID uuid.UUID, event codersdk.ChatStream
 		if evicted := state.durableMessages[0]; evicted.Message != nil {
 			state.durableEvictedBefore = evicted.Message.ID
 		}
+		state.durableMessages[0] = codersdk.ChatStreamEvent{} // make the evictee GC-eligible
 		state.durableMessages = state.durableMessages[1:]
 	}
 	state.durableMessages = append(state.durableMessages, event)
@@ -3109,22 +3111,24 @@ func (p *Server) getOrCreateStreamState(chatID uuid.UUID) *chatStreamState {
 // The caller must hold state.mu. The state pointer may have been
 // captured outside this lock (sync.Map.Load or Range); we use
 // CompareAndDelete so a stale pointer cannot evict a fresh entry
-// installed by a racing getOrCreateStreamState.
-func (p *Server) cleanupStreamIfIdle(chatID uuid.UUID, state *chatStreamState) {
+// installed by a racing getOrCreateStreamState. Returns true
+// if the state was deleted, false otherwise.
+func (p *Server) cleanupStreamIfIdle(chatID uuid.UUID, state *chatStreamState) bool {
 	if state.buffering || len(state.subscribers) > 0 {
-		return
+		return false
 	}
 	// Keep stream state alive during the grace period so
 	// late-connecting relay subscribers can snapshot the
 	// buffer after the worker finishes processing.
 	if !state.bufferRetainedAt.IsZero() &&
 		p.clock.Now().Before(state.bufferRetainedAt.Add(bufferRetainGracePeriod)) {
-		return
+		return false
 	}
 	if !p.chatStreams.CompareAndDelete(chatID, state) {
-		return
+		return false
 	}
 	p.workspaceMCPToolsCache.Delete(chatID)
+	return true
 }
 
 // streamJanitorLoop periodically reaps idle chat stream states whose
@@ -3146,9 +3150,15 @@ func (p *Server) streamJanitorLoop(ctx context.Context) {
 }
 
 // sweepIdleStreams iterates chatStreams once and delegates each entry
-// to cleanupStreamIfIdle. Range may miss entries deleted concurrently;
-// any such entry is reaped on the next tick.
+// to cleanupStreamIfIdle. Range may skip entries that become reapable
+// concurrently. Any such entry is reaped on the next tick.
 func (p *Server) sweepIdleStreams() {
+	var reaped atomic.Int64
+	defer func() {
+		if count := reaped.Load(); count > 0 {
+			p.logger.Info(context.Background(), "reaped idle chat streams", slog.F("count", count))
+		}
+	}()
 	p.chatStreams.Range(func(key, value any) bool {
 		chatID, ok := key.(uuid.UUID)
 		if !ok {
@@ -3159,7 +3169,9 @@ func (p *Server) sweepIdleStreams() {
 			return true
 		}
 		state.mu.Lock()
-		p.cleanupStreamIfIdle(chatID, state)
+		if p.cleanupStreamIfIdle(chatID, state) {
+			reaped.Add(1)
+		}
 		state.mu.Unlock()
 		return true
 	})

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -3185,10 +3185,10 @@ func (p *Server) sweepIdleStreams() {
 			return true
 		}
 		state.mu.Lock()
+		defer state.mu.Unlock()
 		if p.cleanupStreamIfIdle(chatID, state) {
 			reaped.Add(1)
 		}
-		state.mu.Unlock()
 		return true
 	})
 }

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -2975,6 +2975,14 @@ func (p *Server) publishToStream(chatID uuid.UUID, event codersdk.ChatStreamEven
 				state.bufferDropCount = 0
 				state.bufferLastWarnAt = now
 			}
+			// Clear the old slot before reslicing so its
+			// *ChatStreamMessagePart becomes GC-eligible. cap is often
+			// greater than len here (Go's growth policy over-allocates),
+			// so the subsequent append stays in place without
+			// reallocating — the dropped pointer would otherwise be
+			// pinned in the backing array until the buffer grew past
+			// its original capacity.
+			state.buffer[0] = codersdk.ChatStreamEvent{}
 			state.buffer = state.buffer[1:]
 		}
 		state.buffer = append(state.buffer, event)

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -3184,11 +3184,14 @@ func (p *Server) sweepIdleStreams() {
 		if !ok {
 			return true
 		}
-		state.mu.Lock()
-		defer state.mu.Unlock()
-		if p.cleanupStreamIfIdle(chatID, state) {
-			reaped.Add(1)
-		}
+		// guard against any panic from cleanupStreamIfIdle locking state.mu for all time
+		func() {
+			state.mu.Lock()
+			defer state.mu.Unlock()
+			if p.cleanupStreamIfIdle(chatID, state) {
+				reaped.Add(1)
+			}
+		}()
 		return true
 	})
 }

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -3338,3 +3338,27 @@ func TestCleanupStreamIfIdle_StalePointerDoesNotDeleteFreshEntry(t *testing.T) {
 	require.Same(t, fresh, got,
 		"cleanup must not replace the fresh entry with the stale one")
 }
+
+// TestSafeSweepIdleStreams_RecoversFromPanic verifies that an
+// unexpected panic inside sweepIdleStreams is recovered rather than
+// killing the janitor goroutine. Without this guard, a panic would
+// silently reintroduce the very leak the janitor exists to prevent.
+func TestSafeSweepIdleStreams_RecoversFromPanic(t *testing.T) {
+	t.Parallel()
+
+	server := &Server{
+		logger: slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+		clock:  quartz.NewMock(t),
+	}
+
+	chatID := uuid.New()
+	// A nil *chatStreamState passes the type assertion in sweepIdleStreams
+	// but panics on state.mu.Lock with a nil-pointer deref. Any future
+	// panic source in the sweep would trigger the same recovery path.
+	var nilState *chatStreamState
+	server.chatStreams.Store(chatID, nilState)
+
+	require.NotPanics(t, func() {
+		server.safeSweepIdleStreams(context.Background())
+	}, "safeSweepIdleStreams must recover panics so the janitor loop keeps running")
+}

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -3046,3 +3046,200 @@ func TestHeartbeatTick_DBErrorDoesNotInterruptChats(t *testing.T) {
 	require.NoError(t, chatCtx.Err(),
 		"chat context should not be canceled on transient DB error")
 }
+
+// TestSubscribeCancelDuringGrace_ReapedBySweep exercises the OSS
+// single-replica trigger path for the retained-buffer leak:
+// a subscriber detaches within bufferRetainGracePeriod of chat
+// completion, so cleanupStreamIfIdle's grace-period early-return
+// fires. Before the janitor, nothing reschedules cleanup and the
+// state is pinned until process exit. sweepIdleStreams is the
+// backstop that re-checks on a timer.
+func TestSubscribeCancelDuringGrace_ReapedBySweep(t *testing.T) {
+	t.Parallel()
+
+	logger := slogtest.Make(t, nil)
+	mClock := quartz.NewMock(t)
+
+	server := &Server{
+		logger: logger,
+		clock:  mClock,
+	}
+
+	chatID := uuid.New()
+	start := mClock.Now()
+
+	// Mirror a just-finished chat: processing done, buffer retained
+	// for late-connecting relay subscribers, one message_part still
+	// buffered so the leak pins a non-trivial payload.
+	state := &chatStreamState{
+		buffering:        false,
+		bufferRetainedAt: start,
+		subscribers:      map[uuid.UUID]chan codersdk.ChatStreamEvent{},
+		buffer: []codersdk.ChatStreamEvent{{
+			Type: codersdk.ChatStreamEventTypeMessagePart,
+			MessagePart: &codersdk.ChatStreamMessagePart{
+				Role: codersdk.ChatMessageRoleAssistant,
+			},
+		}},
+	}
+	server.chatStreams.Store(chatID, state)
+
+	// Exercise the real subscribeToStream cancel path. This is the
+	// exact code path that leaks in prod: a WS subscriber detaches,
+	// cleanupStreamIfIdle runs, the grace-period check early-returns,
+	// and no future event or subscriber disconnect re-triggers it.
+	_, _, cancelSub := server.subscribeToStream(chatID)
+
+	// Advance within the grace window and detach.
+	mClock.Advance(bufferRetainGracePeriod / 2)
+	cancelSub()
+
+	// Characterization: the entry is still mapped because
+	// cleanupStreamIfIdle declined to act during grace. This
+	// assertion is true both before and after the janitor lands —
+	// cleanupStreamIfIdle's own behavior is unchanged.
+	_, ok := server.chatStreams.Load(chatID)
+	require.True(t, ok,
+		"entry should remain during grace window after subscriber detach")
+
+	// Advance past the grace window and sweep directly. Without the
+	// janitor, sweepIdleStreams does not exist; with it, the sweep
+	// observes grace expired + no subscribers + not buffering and
+	// reaps the entry.
+	mClock.Advance(bufferRetainGracePeriod)
+	server.sweepIdleStreams()
+
+	_, ok = server.chatStreams.Load(chatID)
+	require.False(t, ok,
+		"entry should be reaped after grace period expires and sweep runs")
+}
+
+// TestSweepIdleStreams_ReapsStaleRetainedBuffer verifies the
+// happy-path reap: a state with an expired grace period and no
+// subscribers is evicted.
+func TestSweepIdleStreams_ReapsStaleRetainedBuffer(t *testing.T) {
+	t.Parallel()
+
+	mClock := quartz.NewMock(t)
+	server := &Server{
+		logger: slogtest.Make(t, nil),
+		clock:  mClock,
+	}
+
+	chatID := uuid.New()
+	state := &chatStreamState{
+		buffering:        false,
+		bufferRetainedAt: mClock.Now(),
+		subscribers:      map[uuid.UUID]chan codersdk.ChatStreamEvent{},
+		buffer: []codersdk.ChatStreamEvent{{
+			Type:        codersdk.ChatStreamEventTypeMessagePart,
+			MessagePart: &codersdk.ChatStreamMessagePart{},
+		}},
+	}
+	server.chatStreams.Store(chatID, state)
+
+	mClock.Advance(bufferRetainGracePeriod + time.Second)
+	server.sweepIdleStreams()
+
+	_, ok := server.chatStreams.Load(chatID)
+	require.False(t, ok, "stale retained state should be reaped")
+}
+
+// TestSweepIdleStreams_DoesNotReapActiveBuffering guards against
+// reaping a state whose worker is still actively processing.
+func TestSweepIdleStreams_DoesNotReapActiveBuffering(t *testing.T) {
+	t.Parallel()
+
+	mClock := quartz.NewMock(t)
+	server := &Server{
+		logger: slogtest.Make(t, nil),
+		clock:  mClock,
+	}
+
+	chatID := uuid.New()
+	state := &chatStreamState{
+		buffering:   true,
+		subscribers: map[uuid.UUID]chan codersdk.ChatStreamEvent{},
+		buffer: []codersdk.ChatStreamEvent{{
+			Type:        codersdk.ChatStreamEventTypeMessagePart,
+			MessagePart: &codersdk.ChatStreamMessagePart{},
+		}},
+	}
+	server.chatStreams.Store(chatID, state)
+
+	mClock.Advance(time.Hour)
+	server.sweepIdleStreams()
+
+	_, ok := server.chatStreams.Load(chatID)
+	require.True(t, ok, "actively-buffering state must not be reaped")
+}
+
+// TestSweepIdleStreams_DoesNotReapWithSubscribers guards against
+// reaping a state that still has attached subscribers.
+func TestSweepIdleStreams_DoesNotReapWithSubscribers(t *testing.T) {
+	t.Parallel()
+
+	mClock := quartz.NewMock(t)
+	server := &Server{
+		logger: slogtest.Make(t, nil),
+		clock:  mClock,
+	}
+
+	chatID := uuid.New()
+	state := &chatStreamState{
+		buffering:        false,
+		bufferRetainedAt: mClock.Now(),
+		subscribers: map[uuid.UUID]chan codersdk.ChatStreamEvent{
+			uuid.New(): make(chan codersdk.ChatStreamEvent, 1),
+		},
+		buffer: []codersdk.ChatStreamEvent{{
+			Type:        codersdk.ChatStreamEventTypeMessagePart,
+			MessagePart: &codersdk.ChatStreamMessagePart{},
+		}},
+	}
+	server.chatStreams.Store(chatID, state)
+
+	mClock.Advance(bufferRetainGracePeriod + time.Second)
+	server.sweepIdleStreams()
+
+	_, ok := server.chatStreams.Load(chatID)
+	require.True(t, ok, "state with subscribers must not be reaped")
+}
+
+// TestSweepIdleStreams_DefersDuringGracePeriod verifies that a sweep
+// inside the grace window is a no-op, then the same state is reaped
+// once the window elapses.
+func TestSweepIdleStreams_DefersDuringGracePeriod(t *testing.T) {
+	t.Parallel()
+
+	mClock := quartz.NewMock(t)
+	server := &Server{
+		logger: slogtest.Make(t, nil),
+		clock:  mClock,
+	}
+
+	chatID := uuid.New()
+	start := mClock.Now()
+	state := &chatStreamState{
+		buffering:        false,
+		bufferRetainedAt: start,
+		subscribers:      map[uuid.UUID]chan codersdk.ChatStreamEvent{},
+		buffer: []codersdk.ChatStreamEvent{{
+			Type:        codersdk.ChatStreamEventTypeMessagePart,
+			MessagePart: &codersdk.ChatStreamMessagePart{},
+		}},
+	}
+	server.chatStreams.Store(chatID, state)
+
+	mClock.Advance(bufferRetainGracePeriod / 2)
+	server.sweepIdleStreams()
+
+	_, ok := server.chatStreams.Load(chatID)
+	require.True(t, ok, "sweep inside grace window must not reap")
+
+	mClock.Advance(bufferRetainGracePeriod)
+	server.sweepIdleStreams()
+
+	_, ok = server.chatStreams.Load(chatID)
+	require.False(t, ok, "sweep after grace window must reap")
+}

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -3047,13 +3047,10 @@ func TestHeartbeatTick_DBErrorDoesNotInterruptChats(t *testing.T) {
 		"chat context should not be canceled on transient DB error")
 }
 
-// TestSubscribeCancelDuringGrace_ReapedBySweep exercises the OSS
-// single-replica trigger path for the retained-buffer leak:
-// a subscriber detaches within bufferRetainGracePeriod of chat
-// completion, so cleanupStreamIfIdle's grace-period early-return
-// fires. Before the janitor, nothing reschedules cleanup and the
-// state is pinned until process exit. sweepIdleStreams is the
-// backstop that re-checks on a timer.
+// TestSubscribeCancelDuringGrace_ReapedBySweep verifies that a
+// subscriber detach inside bufferRetainGracePeriod (the OSS trigger
+// for the retained-buffer leak) leaves the state mapped, and the
+// next sweep past the grace window reaps it.
 func TestSubscribeCancelDuringGrace_ReapedBySweep(t *testing.T) {
 	t.Parallel()
 
@@ -3068,9 +3065,8 @@ func TestSubscribeCancelDuringGrace_ReapedBySweep(t *testing.T) {
 	chatID := uuid.New()
 	start := mClock.Now()
 
-	// Mirror a just-finished chat: processing done, buffer retained
-	// for late-connecting relay subscribers, one message_part still
-	// buffered so the leak pins a non-trivial payload.
+	// Just-finished chat: processing done, buffer retained for
+	// late-connecting relay subscribers.
 	state := &chatStreamState{
 		buffering:        false,
 		bufferRetainedAt: start,
@@ -3084,28 +3080,17 @@ func TestSubscribeCancelDuringGrace_ReapedBySweep(t *testing.T) {
 	}
 	server.chatStreams.Store(chatID, state)
 
-	// Exercise the real subscribeToStream cancel path. This is the
-	// exact code path that leaks in prod: a WS subscriber detaches,
-	// cleanupStreamIfIdle runs, the grace-period check early-returns,
-	// and no future event or subscriber disconnect re-triggers it.
+	// Real subscribeToStream cancel path: the WS subscriber detach
+	// that leaks in prod.
 	_, _, cancelSub := server.subscribeToStream(chatID)
 
-	// Advance within the grace window and detach.
 	mClock.Advance(bufferRetainGracePeriod / 2)
 	cancelSub()
 
-	// Characterization: the entry is still mapped because
-	// cleanupStreamIfIdle declined to act during grace. This
-	// assertion is true both before and after the janitor lands —
-	// cleanupStreamIfIdle's own behavior is unchanged.
 	_, ok := server.chatStreams.Load(chatID)
 	require.True(t, ok,
 		"entry should remain during grace window after subscriber detach")
 
-	// Advance past the grace window and sweep directly. Without the
-	// janitor, sweepIdleStreams does not exist; with it, the sweep
-	// observes grace expired + no subscribers + not buffering and
-	// reaps the entry.
 	mClock.Advance(bufferRetainGracePeriod)
 	server.sweepIdleStreams()
 
@@ -3114,9 +3099,8 @@ func TestSubscribeCancelDuringGrace_ReapedBySweep(t *testing.T) {
 		"entry should be reaped after grace period expires and sweep runs")
 }
 
-// TestSweepIdleStreams_ReapsStaleRetainedBuffer verifies the
-// happy-path reap: a state with an expired grace period and no
-// subscribers is evicted.
+// TestSweepIdleStreams_ReapsStaleRetainedBuffer: grace expired, no
+// subscribers, not buffering -> reaped.
 func TestSweepIdleStreams_ReapsStaleRetainedBuffer(t *testing.T) {
 	t.Parallel()
 
@@ -3145,8 +3129,8 @@ func TestSweepIdleStreams_ReapsStaleRetainedBuffer(t *testing.T) {
 	require.False(t, ok, "stale retained state should be reaped")
 }
 
-// TestSweepIdleStreams_DoesNotReapActiveBuffering guards against
-// reaping a state whose worker is still actively processing.
+// TestSweepIdleStreams_DoesNotReapActiveBuffering: buffering=true
+// blocks reap even long after any grace would have expired.
 func TestSweepIdleStreams_DoesNotReapActiveBuffering(t *testing.T) {
 	t.Parallel()
 
@@ -3174,8 +3158,8 @@ func TestSweepIdleStreams_DoesNotReapActiveBuffering(t *testing.T) {
 	require.True(t, ok, "actively-buffering state must not be reaped")
 }
 
-// TestSweepIdleStreams_DoesNotReapWithSubscribers guards against
-// reaping a state that still has attached subscribers.
+// TestSweepIdleStreams_DoesNotReapWithSubscribers: attached
+// subscribers block reap even when grace has expired.
 func TestSweepIdleStreams_DoesNotReapWithSubscribers(t *testing.T) {
 	t.Parallel()
 
@@ -3206,9 +3190,8 @@ func TestSweepIdleStreams_DoesNotReapWithSubscribers(t *testing.T) {
 	require.True(t, ok, "state with subscribers must not be reaped")
 }
 
-// TestSweepIdleStreams_DefersDuringGracePeriod verifies that a sweep
-// inside the grace window is a no-op, then the same state is reaped
-// once the window elapses.
+// TestSweepIdleStreams_DefersDuringGracePeriod: sweep inside grace
+// is a no-op; the next sweep past grace reaps.
 func TestSweepIdleStreams_DefersDuringGracePeriod(t *testing.T) {
 	t.Parallel()
 
@@ -3244,11 +3227,9 @@ func TestSweepIdleStreams_DefersDuringGracePeriod(t *testing.T) {
 	require.False(t, ok, "sweep after grace window must reap")
 }
 
-// TestPublishToStream_DropZeroesBackingSlot verifies that when
-// publishToStream evicts the oldest buffered event at capacity, the
-// dropped slot in the backing array is zeroed. Without that, the
-// dropped *ChatStreamMessagePart stays reachable via the backing
-// array until the buffer reallocates, pinning its payload.
+// TestPublishToStream_DropZeroesBackingSlot verifies that evicting
+// the oldest buffered event at capacity zeroes the dropped slot so
+// its *ChatStreamMessagePart becomes GC-eligible immediately.
 func TestPublishToStream_DropZeroesBackingSlot(t *testing.T) {
 	t.Parallel()
 
@@ -3260,10 +3241,8 @@ func TestPublishToStream_DropZeroesBackingSlot(t *testing.T) {
 
 	chatID := uuid.New()
 
-	// Overcap by one so the post-drop append fits in the original
-	// backing array. This matches the production case where Go's
-	// growth policy over-allocates and the drop-then-append
-	// sequence reuses memory in place.
+	// Over-allocate by one so the post-drop append fits in place and
+	// exercises the backing-array reuse this test is checking.
 	buf := make([]codersdk.ChatStreamEvent, maxStreamBufferSize, maxStreamBufferSize+1)
 	for i := range buf {
 		buf[i] = codersdk.ChatStreamEvent{
@@ -3271,9 +3250,8 @@ func TestPublishToStream_DropZeroesBackingSlot(t *testing.T) {
 			MessagePart: &codersdk.ChatStreamMessagePart{},
 		}
 	}
-	// Sentinel payload in slot 0 so we can distinguish a cleared
-	// slot from a slot that was merely overwritten by a later
-	// append.
+	// Sentinel in slot 0 distinguishes "slot was zeroed" from "slot
+	// was overwritten by a later append".
 	sentinel := &codersdk.ChatStreamMessagePart{
 		Role: codersdk.ChatMessageRoleAssistant,
 	}
@@ -3281,10 +3259,8 @@ func TestPublishToStream_DropZeroesBackingSlot(t *testing.T) {
 		Type:        codersdk.ChatStreamEventTypeMessagePart,
 		MessagePart: sentinel,
 	}
-	// origBacking is a stable alias over the full backing array.
-	// After publishToStream advances state.buffer by one slot, we
-	// reach through origBacking to observe what happened to the
-	// old slot 0.
+	// Alias over the full backing array so we can still observe slot
+	// 0 after publishToStream reslices state.buffer forward.
 	origBacking := buf[:cap(buf)]
 
 	state := &chatStreamState{
@@ -3306,27 +3282,20 @@ func TestPublishToStream_DropZeroesBackingSlot(t *testing.T) {
 		"dropped slot must be zero-valued so its *ChatStreamMessagePart "+
 			"is eligible for GC; got %+v", origBacking[0])
 
-	// Sanity-check that the test actually exercised the in-place
-	// append path the fix is designed for: the new event should
-	// have landed in the slot just past the original length, i.e.
-	// no reallocation happened. If Go's growth policy ever makes
-	// append reallocate here, this assertion fails loudly and the
-	// test author knows to revisit the setup.
+	// Sanity-check the in-place append path the fix targets: if Go's
+	// growth policy ever makes this append reallocate, this fails
+	// loudly so the test author revisits the setup.
 	require.Same(t, newPart, origBacking[len(origBacking)-1].MessagePart,
 		"append must have landed in the original backing array; the "+
 			"zero-out invariant only matters when cap > len")
 }
 
-// TestCleanupStreamIfIdle_StalePointerDoesNotDeleteFreshEntry guards
-// against a race where two callers of cleanupStreamIfIdle (e.g. the
-// janitor holding a Range-captured pointer and a fresh processChat
-// run that just reinstalled the state via getOrCreateStreamState) race
-// and the stale caller deletes the fresh map entry.
-//
-// Without CompareAndDelete in cleanupStreamIfIdle, the stale caller
-// wins the Delete and the fresh chat loses its stream state. With the
-// guard, the Delete is a no-op for the stale caller and the fresh
-// state stays mapped.
+// TestCleanupStreamIfIdle_StalePointerDoesNotDeleteFreshEntry covers
+// the race where a caller holds a pointer to a no-longer-mapped
+// state (e.g. a janitor Range callback racing a fresh
+// getOrCreateStreamState) and would otherwise evict the fresh entry.
+// With CompareAndDelete in cleanupStreamIfIdle the stale delete is
+// a no-op.
 func TestCleanupStreamIfIdle_StalePointerDoesNotDeleteFreshEntry(t *testing.T) {
 	t.Parallel()
 
@@ -3338,17 +3307,17 @@ func TestCleanupStreamIfIdle_StalePointerDoesNotDeleteFreshEntry(t *testing.T) {
 
 	chatID := uuid.New()
 
-	// Stale state: looks reapable (not buffering, no subscribers,
-	// grace expired).
+	// Stale pointer: reapable (not buffering, no subscribers, grace
+	// expired) but no longer the map's live entry.
 	stale := &chatStreamState{
 		buffering:        false,
 		bufferRetainedAt: mClock.Now(),
 		subscribers:      map[uuid.UUID]chan codersdk.ChatStreamEvent{},
 	}
 
-	// Fresh state: what getOrCreateStreamState would install after a
-	// racing processChat run started. Not reapable (actively
-	// buffering). Only this state is in the map.
+	// Fresh entry: the state getOrCreateStreamState would install
+	// after a racing processChat run. Actively buffering, so not
+	// reapable. Only this state is in the map.
 	fresh := &chatStreamState{
 		buffering:   true,
 		subscribers: map[uuid.UUID]chan codersdk.ChatStreamEvent{},
@@ -3357,9 +3326,8 @@ func TestCleanupStreamIfIdle_StalePointerDoesNotDeleteFreshEntry(t *testing.T) {
 
 	mClock.Advance(bufferRetainGracePeriod + time.Second)
 
-	// Caller holds the stale pointer and its lock; this mirrors the
-	// janitor's Range-callback path after the map entry has been
-	// replaced by another goroutine.
+	// Stale caller mirrors the janitor Range callback after the map
+	// entry has already been replaced.
 	stale.mu.Lock()
 	server.cleanupStreamIfIdle(chatID, stale)
 	stale.mu.Unlock()

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -3243,3 +3243,76 @@ func TestSweepIdleStreams_DefersDuringGracePeriod(t *testing.T) {
 	_, ok = server.chatStreams.Load(chatID)
 	require.False(t, ok, "sweep after grace window must reap")
 }
+
+// TestPublishToStream_DropZeroesBackingSlot verifies that when
+// publishToStream evicts the oldest buffered event at capacity, the
+// dropped slot in the backing array is zeroed. Without that, the
+// dropped *ChatStreamMessagePart stays reachable via the backing
+// array until the buffer reallocates, pinning its payload.
+func TestPublishToStream_DropZeroesBackingSlot(t *testing.T) {
+	t.Parallel()
+
+	mClock := quartz.NewMock(t)
+	server := &Server{
+		logger: slogtest.Make(t, nil),
+		clock:  mClock,
+	}
+
+	chatID := uuid.New()
+
+	// Overcap by one so the post-drop append fits in the original
+	// backing array. This matches the production case where Go's
+	// growth policy over-allocates and the drop-then-append
+	// sequence reuses memory in place.
+	buf := make([]codersdk.ChatStreamEvent, maxStreamBufferSize, maxStreamBufferSize+1)
+	for i := range buf {
+		buf[i] = codersdk.ChatStreamEvent{
+			Type:        codersdk.ChatStreamEventTypeMessagePart,
+			MessagePart: &codersdk.ChatStreamMessagePart{},
+		}
+	}
+	// Sentinel payload in slot 0 so we can distinguish a cleared
+	// slot from a slot that was merely overwritten by a later
+	// append.
+	sentinel := &codersdk.ChatStreamMessagePart{
+		Role: codersdk.ChatMessageRoleAssistant,
+	}
+	buf[0] = codersdk.ChatStreamEvent{
+		Type:        codersdk.ChatStreamEventTypeMessagePart,
+		MessagePart: sentinel,
+	}
+	// origBacking is a stable alias over the full backing array.
+	// After publishToStream advances state.buffer by one slot, we
+	// reach through origBacking to observe what happened to the
+	// old slot 0.
+	origBacking := buf[:cap(buf)]
+
+	state := &chatStreamState{
+		buffering:   true,
+		buffer:      buf,
+		subscribers: map[uuid.UUID]chan codersdk.ChatStreamEvent{},
+	}
+	server.chatStreams.Store(chatID, state)
+
+	newPart := &codersdk.ChatStreamMessagePart{
+		Role: codersdk.ChatMessageRoleAssistant,
+	}
+	server.publishToStream(chatID, codersdk.ChatStreamEvent{
+		Type:        codersdk.ChatStreamEventTypeMessagePart,
+		MessagePart: newPart,
+	})
+
+	require.Equal(t, codersdk.ChatStreamEvent{}, origBacking[0],
+		"dropped slot must be zero-valued so its *ChatStreamMessagePart "+
+			"is eligible for GC; got %+v", origBacking[0])
+
+	// Sanity-check that the test actually exercised the in-place
+	// append path the fix is designed for: the new event should
+	// have landed in the slot just past the original length, i.e.
+	// no reallocation happened. If Go's growth policy ever makes
+	// append reallocate here, this assertion fails loudly and the
+	// test author knows to revisit the setup.
+	require.Same(t, newPart, origBacking[len(origBacking)-1].MessagePart,
+		"append must have landed in the original backing array; the "+
+			"zero-out invariant only matters when cap > len")
+}

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -3316,3 +3316,57 @@ func TestPublishToStream_DropZeroesBackingSlot(t *testing.T) {
 		"append must have landed in the original backing array; the "+
 			"zero-out invariant only matters when cap > len")
 }
+
+// TestCleanupStreamIfIdle_StalePointerDoesNotDeleteFreshEntry guards
+// against a race where two callers of cleanupStreamIfIdle (e.g. the
+// janitor holding a Range-captured pointer and a fresh processChat
+// run that just reinstalled the state via getOrCreateStreamState) race
+// and the stale caller deletes the fresh map entry.
+//
+// Without CompareAndDelete in cleanupStreamIfIdle, the stale caller
+// wins the Delete and the fresh chat loses its stream state. With the
+// guard, the Delete is a no-op for the stale caller and the fresh
+// state stays mapped.
+func TestCleanupStreamIfIdle_StalePointerDoesNotDeleteFreshEntry(t *testing.T) {
+	t.Parallel()
+
+	mClock := quartz.NewMock(t)
+	server := &Server{
+		logger: slogtest.Make(t, nil),
+		clock:  mClock,
+	}
+
+	chatID := uuid.New()
+
+	// Stale state: looks reapable (not buffering, no subscribers,
+	// grace expired).
+	stale := &chatStreamState{
+		buffering:        false,
+		bufferRetainedAt: mClock.Now(),
+		subscribers:      map[uuid.UUID]chan codersdk.ChatStreamEvent{},
+	}
+
+	// Fresh state: what getOrCreateStreamState would install after a
+	// racing processChat run started. Not reapable (actively
+	// buffering). Only this state is in the map.
+	fresh := &chatStreamState{
+		buffering:   true,
+		subscribers: map[uuid.UUID]chan codersdk.ChatStreamEvent{},
+	}
+	server.chatStreams.Store(chatID, fresh)
+
+	mClock.Advance(bufferRetainGracePeriod + time.Second)
+
+	// Caller holds the stale pointer and its lock; this mirrors the
+	// janitor's Range-callback path after the map entry has been
+	// replaced by another goroutine.
+	stale.mu.Lock()
+	server.cleanupStreamIfIdle(chatID, stale)
+	stale.mu.Unlock()
+
+	got, ok := server.chatStreams.Load(chatID)
+	require.True(t, ok,
+		"fresh entry must remain mapped when cleanup is called with a stale pointer")
+	require.Same(t, fresh, got,
+		"cleanup must not replace the fresh entry with the stale one")
+}

--- a/enterprise/coderd/x/chatd/chatd_test.go
+++ b/enterprise/coderd/x/chatd/chatd_test.go
@@ -1426,25 +1426,18 @@ func TestSubscribeRelayDialCanceledOnFastCompletion(t *testing.T) {
 }
 
 // TestSubscribeRelayDrainWithinGraceLeavesBufferRetained characterizes
-// the multi-replica trigger for the retained-buffer leak: when an
-// enterprise relay drains after a worker finishes, the worker-side
-// subscriber-detach fires inside bufferRetainGracePeriod (5s) because
-// relayDrainTimeout is only 200ms. cleanupStreamIfIdle's grace-period
-// early-return blocks cleanup; without streamJanitorLoop as a timer-
-// driven backstop, the worker's chatStreamState stays mapped with its
-// full buffer until the process exits.
+// the multi-replica trigger for the retained-buffer leak: an enterprise
+// relay drain (relayDrainTimeout = 200ms) always fires inside the
+// worker's 5s grace window, so the worker-side subscriber-detach hits
+// cleanupStreamIfIdle's early-return and the buffer stays mapped.
+// streamJanitorLoop is the timer-driven backstop.
 //
-// This test asserts only the user-visible symptom — that a fresh
-// worker.Subscribe immediately after the relay drain still sees the
-// retained message_parts. The matching regression (that the janitor
-// reaps the state on a timer) is covered by the OSS unit tests in
-// coderd/x/chatd/chatd_internal_test.go, which can read chatStreams
-// directly.
-//
-// Behavioral observation is used here (not a chatStreams-size
-// assertion) because _test.go identifiers in coderd/x/chatd do not
-// link into enterprise/coderd/x/chatd's test binary, and we decline
-// to add a production-API accessor for memory-hygiene plumbing.
+// The assertion is behavioral (a fresh worker.Subscribe sees the
+// retained message_parts) rather than a chatStreams-size check because
+// _test.go identifiers in coderd/x/chatd do not link into the
+// enterprise test binary, and adding a production accessor for this
+// isn't justified. The matching reap assertion lives in the OSS unit
+// tests in coderd/x/chatd/chatd_internal_test.go.
 func TestSubscribeRelayDrainWithinGraceLeavesBufferRetained(t *testing.T) {
 	t.Parallel()
 
@@ -1474,11 +1467,9 @@ func TestSubscribeRelayDrainWithinGraceLeavesBufferRetained(t *testing.T) {
 		require.NoError(t, worker.Close())
 	})
 
-	// Subscriber dials through to the worker's Subscribe. When the
-	// subscriber cancels, the relay drain fires within 200ms and
-	// invokes the worker's subscribeToStream cancel func — inside
-	// the worker's 5s grace window — which triggers
-	// cleanupStreamIfIdle's early return.
+	// Subscriber dials through to the worker. On cancel the relay
+	// drain fires well inside the worker's 5s grace, exercising the
+	// cleanupStreamIfIdle early-return path.
 	subscriber := newTestServer(t, db, ps, subscriberID, func(
 		ctx context.Context,
 		chatID uuid.UUID,
@@ -1503,8 +1494,8 @@ func TestSubscribeRelayDrainWithinGraceLeavesBufferRetained(t *testing.T) {
 
 	chat := seedWaitingChat(ctx, t, db, org.ID, user, model, "relay-drain-characterization")
 
-	// Attach the subscriber before processing starts so the relay
-	// opens as soon as status=running arrives.
+	// Attach before processing so the relay opens as soon as
+	// status=running arrives.
 	_, events, subCancel, ok := subscriber.Subscribe(ctx, chat.ID, nil, 0)
 	require.True(t, ok)
 
@@ -1515,10 +1506,10 @@ func TestSubscribeRelayDrainWithinGraceLeavesBufferRetained(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Drain events until processing completes. We require at least
-	// one message_part and the committed assistant message so we
-	// know processChat's defer has flipped buffering=false and
-	// populated bufferRetainedAt before the subscriber detaches.
+	// Drain events until processing has clearly completed: we need
+	// the assistant message and at least one message_part so we know
+	// processChat's defer has flipped buffering=false and populated
+	// bufferRetainedAt before the subscriber detaches.
 	var committedAssistantMsgs int
 	var messagePartsSeen int
 	require.Eventually(t, func() bool {
@@ -1546,21 +1537,15 @@ func TestSubscribeRelayDrainWithinGraceLeavesBufferRetained(t *testing.T) {
 		return fromDB.Status == database.ChatStatusWaiting
 	}, testutil.WaitMedium, testutil.IntervalFast)
 
-	// Tear the subscriber down. The relay drain (200ms) fires well
-	// inside the worker's 5s bufferRetainGracePeriod, so the
-	// worker's cleanupStreamIfIdle early-returns and leaves the
-	// buffer retained.
+	// Tear the subscriber down inside the worker's grace window.
 	subCancel()
 
-	// Characterization: a fresh Subscribe on the worker still sees
-	// the retained message_parts in its initial snapshot. This is
-	// the leak: without streamJanitorLoop as a backstop, the
-	// retained state sits forever because nothing else will
-	// trigger cleanupStreamIfIdle after the grace window elapses.
-	// Eventually absorbs the short window until the worker observes
-	// the relay teardown. Note that the retry itself re-runs
-	// cleanupStreamIfIdle (via the returned cancel's defer) but
-	// still early-returns because grace has not expired.
+	// A fresh worker.Subscribe still sees the retained
+	// message_parts: the buffer was not reaped when the relay
+	// drained. Eventually absorbs the short window before the
+	// worker observes the teardown. The retry itself re-enters
+	// cleanupStreamIfIdle via its own cancel defer but still
+	// early-returns because grace is still open.
 	require.Eventually(t, func() bool {
 		snap, _, charCancel, ok := worker.Subscribe(ctx, chat.ID, nil, math.MaxInt64)
 		if !ok {

--- a/enterprise/coderd/x/chatd/chatd_test.go
+++ b/enterprise/coderd/x/chatd/chatd_test.go
@@ -1512,7 +1512,7 @@ func TestSubscribeRelayDrainWithinGraceLeavesBufferRetained(t *testing.T) {
 	// bufferRetainedAt before the subscriber detaches.
 	var committedAssistantMsgs int
 	var messagePartsSeen int
-	require.Eventually(t, func() bool {
+	testutil.Eventually(ctx, t, func(context.Context) bool {
 		select {
 		case event := <-events:
 			switch event.Type {
@@ -1527,15 +1527,15 @@ func TestSubscribeRelayDrainWithinGraceLeavesBufferRetained(t *testing.T) {
 		default:
 			return false
 		}
-	}, testutil.WaitLong, testutil.IntervalFast)
+	}, testutil.IntervalFast)
 
-	require.Eventually(t, func() bool {
+	testutil.Eventually(ctx, t, func(ctx context.Context) bool {
 		fromDB, dbErr := db.GetChatByID(ctx, chat.ID)
 		if dbErr != nil {
 			return false
 		}
 		return fromDB.Status == database.ChatStatusWaiting
-	}, testutil.WaitMedium, testutil.IntervalFast)
+	}, testutil.IntervalFast)
 
 	// Tear the subscriber down inside the worker's grace window.
 	subCancel()
@@ -1546,7 +1546,7 @@ func TestSubscribeRelayDrainWithinGraceLeavesBufferRetained(t *testing.T) {
 	// worker observes the teardown. The retry itself re-enters
 	// cleanupStreamIfIdle via its own cancel defer but still
 	// early-returns because grace is still open.
-	require.Eventually(t, func() bool {
+	testutil.Eventually(ctx, t, func(ctx context.Context) bool {
 		snap, _, charCancel, ok := worker.Subscribe(ctx, chat.ID, nil, math.MaxInt64)
 		if !ok {
 			return false
@@ -1558,7 +1558,7 @@ func TestSubscribeRelayDrainWithinGraceLeavesBufferRetained(t *testing.T) {
 			}
 		}
 		return false
-	}, testutil.WaitMedium, testutil.IntervalFast,
+	}, testutil.IntervalFast,
 		"retained buffer must still contain message_parts after the "+
 			"relay drains within grace — this confirms the multi-replica "+
 			"trigger path for the retained-buffer leak")

--- a/enterprise/coderd/x/chatd/chatd_test.go
+++ b/enterprise/coderd/x/chatd/chatd_test.go
@@ -1455,6 +1455,9 @@ func TestSubscribeRelayDrainWithinGraceLeavesBufferRetained(t *testing.T) {
 	})
 
 	workerLogger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	// Freeze the worker's clock so streamJanitorLoop cannot race the
+	// buffer-retained assertion on slow CI.
+	workerClock := quartz.NewMock(t)
 	worker := osschatd.New(osschatd.Config{
 		Logger:                     workerLogger,
 		Database:                   db,
@@ -1462,6 +1465,7 @@ func TestSubscribeRelayDrainWithinGraceLeavesBufferRetained(t *testing.T) {
 		Pubsub:                     ps,
 		PendingChatAcquireInterval: time.Hour,
 		InFlightChatStaleAfter:     testutil.WaitSuperLong,
+		Clock:                      workerClock,
 	})
 	t.Cleanup(func() {
 		require.NoError(t, worker.Close())

--- a/enterprise/coderd/x/chatd/chatd_test.go
+++ b/enterprise/coderd/x/chatd/chatd_test.go
@@ -1425,7 +1425,160 @@ func TestSubscribeRelayDialCanceledOnFastCompletion(t *testing.T) {
 			"worker completes before the relay is established")
 }
 
-// TestSubscribeRelayEstablishedMidStream demonstrates that when the
+// TestSubscribeRelayDrainWithinGraceLeavesBufferRetained characterizes
+// the multi-replica trigger for the retained-buffer leak: when an
+// enterprise relay drains after a worker finishes, the worker-side
+// subscriber-detach fires inside bufferRetainGracePeriod (5s) because
+// relayDrainTimeout is only 200ms. cleanupStreamIfIdle's grace-period
+// early-return blocks cleanup; without streamJanitorLoop as a timer-
+// driven backstop, the worker's chatStreamState stays mapped with its
+// full buffer until the process exits.
+//
+// This test asserts only the user-visible symptom — that a fresh
+// worker.Subscribe immediately after the relay drain still sees the
+// retained message_parts. The matching regression (that the janitor
+// reaps the state on a timer) is covered by the OSS unit tests in
+// coderd/x/chatd/chatd_internal_test.go, which can read chatStreams
+// directly.
+//
+// Behavioral observation is used here (not a chatStreams-size
+// assertion) because _test.go identifiers in coderd/x/chatd do not
+// link into enterprise/coderd/x/chatd's test binary, and we decline
+// to add a production-API accessor for memory-hygiene plumbing.
+func TestSubscribeRelayDrainWithinGraceLeavesBufferRetained(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+	workerID := uuid.New()
+	subscriberID := uuid.New()
+
+	openAIURL := chattest.NewOpenAI(t, func(req *chattest.OpenAIRequest) chattest.OpenAIResponse {
+		if !req.Stream {
+			return chattest.OpenAINonStreamingResponse("relay-drain-characterization")
+		}
+		return chattest.OpenAIStreamingResponse(
+			chattest.OpenAITextChunks("hello ", "from ", "worker")...,
+		)
+	})
+
+	workerLogger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	worker := osschatd.New(osschatd.Config{
+		Logger:                     workerLogger,
+		Database:                   db,
+		ReplicaID:                  workerID,
+		Pubsub:                     ps,
+		PendingChatAcquireInterval: time.Hour,
+		InFlightChatStaleAfter:     testutil.WaitSuperLong,
+	})
+	t.Cleanup(func() {
+		require.NoError(t, worker.Close())
+	})
+
+	// Subscriber dials through to the worker's Subscribe. When the
+	// subscriber cancels, the relay drain fires within 200ms and
+	// invokes the worker's subscribeToStream cancel func — inside
+	// the worker's 5s grace window — which triggers
+	// cleanupStreamIfIdle's early return.
+	subscriber := newTestServer(t, db, ps, subscriberID, func(
+		ctx context.Context,
+		chatID uuid.UUID,
+		targetWorkerID uuid.UUID,
+		requestHeader http.Header,
+	) (
+		[]codersdk.ChatStreamEvent,
+		<-chan codersdk.ChatStreamEvent,
+		func(),
+		error,
+	) {
+		snapshot, relayEvents, cancel, ok := worker.Subscribe(ctx, chatID, requestHeader, math.MaxInt64)
+		if !ok {
+			return nil, nil, nil, xerrors.New("worker subscribe failed")
+		}
+		return snapshot, relayEvents, cancel, nil
+	}, nil)
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	user, org, model := seedChatDependencies(ctx, t, db)
+	setOpenAIProviderBaseURL(ctx, t, db, openAIURL)
+
+	chat := seedWaitingChat(ctx, t, db, org.ID, user, model, "relay-drain-characterization")
+
+	// Attach the subscriber before processing starts so the relay
+	// opens as soon as status=running arrives.
+	_, events, subCancel, ok := subscriber.Subscribe(ctx, chat.ID, nil, 0)
+	require.True(t, ok)
+
+	_, err := worker.SendMessage(ctx, osschatd.SendMessageOptions{
+		ChatID:    chat.ID,
+		CreatedBy: user.ID,
+		Content:   []codersdk.ChatMessagePart{codersdk.ChatMessageText("hello")},
+	})
+	require.NoError(t, err)
+
+	// Drain events until processing completes. We require at least
+	// one message_part and the committed assistant message so we
+	// know processChat's defer has flipped buffering=false and
+	// populated bufferRetainedAt before the subscriber detaches.
+	var committedAssistantMsgs int
+	var messagePartsSeen int
+	require.Eventually(t, func() bool {
+		select {
+		case event := <-events:
+			switch event.Type {
+			case codersdk.ChatStreamEventTypeMessagePart:
+				messagePartsSeen++
+			case codersdk.ChatStreamEventTypeMessage:
+				if event.Message != nil && event.Message.Role == codersdk.ChatMessageRoleAssistant {
+					committedAssistantMsgs++
+				}
+			}
+			return committedAssistantMsgs > 0 && messagePartsSeen > 0
+		default:
+			return false
+		}
+	}, testutil.WaitLong, testutil.IntervalFast)
+
+	require.Eventually(t, func() bool {
+		fromDB, dbErr := db.GetChatByID(ctx, chat.ID)
+		if dbErr != nil {
+			return false
+		}
+		return fromDB.Status == database.ChatStatusWaiting
+	}, testutil.WaitMedium, testutil.IntervalFast)
+
+	// Tear the subscriber down. The relay drain (200ms) fires well
+	// inside the worker's 5s bufferRetainGracePeriod, so the
+	// worker's cleanupStreamIfIdle early-returns and leaves the
+	// buffer retained.
+	subCancel()
+
+	// Characterization: a fresh Subscribe on the worker still sees
+	// the retained message_parts in its initial snapshot. This is
+	// the leak: without streamJanitorLoop as a backstop, the
+	// retained state sits forever because nothing else will
+	// trigger cleanupStreamIfIdle after the grace window elapses.
+	// Eventually absorbs the short window until the worker observes
+	// the relay teardown. Note that the retry itself re-runs
+	// cleanupStreamIfIdle (via the returned cancel's defer) but
+	// still early-returns because grace has not expired.
+	require.Eventually(t, func() bool {
+		snap, _, charCancel, ok := worker.Subscribe(ctx, chat.ID, nil, math.MaxInt64)
+		if !ok {
+			return false
+		}
+		defer charCancel()
+		for _, e := range snap {
+			if e.Type == codersdk.ChatStreamEventTypeMessagePart {
+				return true
+			}
+		}
+		return false
+	}, testutil.WaitMedium, testutil.IntervalFast,
+		"retained buffer must still contain message_parts after the "+
+			"relay drains within grace — this confirms the multi-replica "+
+			"trigger path for the retained-buffer leak")
+}
+
 // relay is established while the worker is still streaming, the
 // subscriber receives buffered parts via the relay snapshot and live
 // parts through the relay channel.

--- a/enterprise/coderd/x/chatd/chatd_test.go
+++ b/enterprise/coderd/x/chatd/chatd_test.go
@@ -1547,11 +1547,11 @@ func TestSubscribeRelayDrainWithinGraceLeavesBufferRetained(t *testing.T) {
 	// cleanupStreamIfIdle via its own cancel defer but still
 	// early-returns because grace is still open.
 	testutil.Eventually(ctx, t, func(ctx context.Context) bool {
-		snap, _, charCancel, ok := worker.Subscribe(ctx, chat.ID, nil, math.MaxInt64)
+		snap, _, snapCancel, ok := worker.Subscribe(ctx, chat.ID, nil, math.MaxInt64)
 		if !ok {
 			return false
 		}
-		defer charCancel()
+		defer snapCancel()
 		for _, e := range snap {
 			if e.Type == codersdk.ChatStreamEventTypeMessagePart {
 				return true

--- a/enterprise/coderd/x/chatd/chatd_test.go
+++ b/enterprise/coderd/x/chatd/chatd_test.go
@@ -1560,10 +1560,10 @@ func TestSubscribeRelayDrainWithinGraceLeavesBufferRetained(t *testing.T) {
 		return false
 	}, testutil.IntervalFast,
 		"retained buffer must still contain message_parts after the "+
-			"relay drains within grace — this confirms the multi-replica "+
-			"trigger path for the retained-buffer leak")
+			"relay drains within grace")
 }
 
+// TestSubscribeRelayEstablishedMidStream demonstrates that when the
 // relay is established while the worker is still streaming, the
 // subscriber receives buffered parts via the relay snapshot and live
 // parts through the relay channel.


### PR DESCRIPTION
`cleanupStreamIfIdle` honours the retained-buffer grace window by early-returning when `clock.Now()` is still before `bufferRetainedAt + bufferRetainGracePeriod`, and nothing reschedules a later cleanup attempt. Subscribers that detach inside the grace window — notably the enterprise relay drain at 200 ms, 25× shorter than the 5 s grace — invoke cleanup, early-return, and strand `chatStreamState` in `p.chatStreams` until the process exits. A heap profile before an OOM showed 2.58 GB of live `*ChatStreamMessagePart` reachable only via these orphaned buffers.

Adds `streamJanitorLoop`, a timer-driven sweeper (30 s cadence) that reuses `cleanupStreamIfIdle` as the reapability predicate. Worst-case retention after this change is `bufferRetainGracePeriod + streamJanitorInterval` ≈ 35 s.

Separate commit zeros the dropped slot in `publishToStream`'s buffer-full path so the evicted `*ChatStreamMessagePart` is immediately GC-eligible instead of being pinned in the backing array until the buffer grows past its original capacity.

Regression tests (OSS):
- `TestSubscribeCancelDuringGrace_ReapedBySweep` — real `subscribeToStream` cancel path, verifies sweep reaps once grace expires.
- `TestSweepIdleStreams_*` (4 tests) — predicate branches.
- `TestPublishToStream_DropZeroesBackingSlot` — backing-slot zero-out with a sanity check that the in-place append path is actually exercised.

Characterization test (enterprise):
- `TestSubscribeRelayDrainWithinGraceLeavesBufferRetained` — multi-replica relay drain end-to-end via real `NewMultiReplicaSubscribeFn`; asserts the user-visible symptom (retained buffer still present after drain) via behavioral observation. See rationale in the test's doc comment.

<details>
<summary>Investigation & planning</summary>

- Heap-profile analysis: handoff doc identified 2.58 GB live `*ChatStreamMessagePart` reachable only via `state.buffer` in orphaned `chatStreamState` entries.
- Audit: zero existing tests assert on `chatStreams` shrinking; the 12 enterprise relay tests cover retention as a feature (buffer available to late subscribers) but not as a resource that eventually releases.
- Root cause identified as `cleanupStreamIfIdle`'s grace-period early-return with no reschedule. Enterprise relay drain (200 ms) systematically hits this path on every relayed chat.
- Multiple plan-refinement passes narrowed the enterprise test from a regression assertion (ruled out because it required a production-API internal accessor) to behavioral observation of the user-visible symptom.

</details>

Generated by a Coder agent.

> 🤖