### PR TITLE
fix(.github/workflows): upgrade github-script to v9 in community-label job

### DIFF
--- a/.github/workflows/contrib.yaml
+++ b/.github/workflows/contrib.yaml
@@ -40,7 +40,7 @@ jobs:
           app-id: ${{ vars.ORG_MEMBERSHIP_APP_ID }}
           private-key: ${{ secrets.ORG_MEMBERSHIP_APP_PRIVATE_KEY }}
       - name: Add community label
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           APP_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
@@ -49,7 +49,6 @@ jobs:
           # token is scoped to members: read only and used via a
           # separate Octokit client for the membership check.
           script: |
-            const { getOctokit } = require("@actions/github")
             const orgClient = getOctokit(process.env.APP_TOKEN)
 
             const params = {


### PR DESCRIPTION
The `community-label` job in the contrib workflow fails with:

```
Error: Cannot find module '@actions/github'
```

`require("@actions/github")` does not work inside the bundled `actions/github-script` v8 dist — the package is compiled into `dist/index.js` and is not resolvable by Node's module loader at runtime.

`actions/github-script` v9 exposes `getOctokit` as an injected script parameter, so the `require` call is no longer needed.

Failing run: https://github.com/coder/coder/actions/runs/24566113706/job/71826621724

> 🤖 Generated by Coder Agents