### PR TITLE
fix(site): fix flaky CreateWorkspacePage tests

### DIFF
--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.test.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.test.tsx
@@ -255,15 +255,13 @@ describe("CreateWorkspacePage", () => {
 				diagnostics: [],
 			};
 
-			act(() => {
-				mockPublisher.publishMessage(
-					new MessageEvent("message", { data: JSON.stringify(response1) }),
-				);
+			mockPublisher.publishMessage(
+				new MessageEvent("message", { data: JSON.stringify(response1) }),
+			);
 
-				mockPublisher.publishMessage(
-					new MessageEvent("message", { data: JSON.stringify(response2) }),
-				);
-			});
+			mockPublisher.publishMessage(
+				new MessageEvent("message", { data: JSON.stringify(response2) }),
+			);
 
 			await waitFor(() => {
 				expect(screen.queryByText("CPU Count")).toBeInTheDocument();

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.test.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.test.tsx
@@ -267,13 +267,15 @@ describe("CreateWorkspacePage", () => {
 				diagnostics: [],
 			};
 
-			mockPublisher.publishMessage(
-				new MessageEvent("message", { data: JSON.stringify(response1) }),
-			);
+			await act(async () => {
+				mockPublisher.publishMessage(
+					new MessageEvent("message", { data: JSON.stringify(response1) }),
+				);
 
-			mockPublisher.publishMessage(
-				new MessageEvent("message", { data: JSON.stringify(response2) }),
-			);
+				mockPublisher.publishMessage(
+					new MessageEvent("message", { data: JSON.stringify(response2) }),
+				);
+			});
 
 			await waitFor(() => {
 				expect(screen.queryByText("CPU Count")).toBeInTheDocument();

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.test.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.test.tsx
@@ -147,19 +147,13 @@ describe("CreateWorkspacePage", () => {
 
 			vi.useFakeTimers({ shouldAdvanceTime: true });
 
-			await waitFor(async () => {
-				await userEvent.click(instanceTypeSelect);
+			await userEvent.click(instanceTypeSelect);
+
+			const mediumOption = await screen.findByRole("option", {
+				name: /t3\.medium/i,
 			});
 
-			let mediumOption: Element | null = null;
-			await waitFor(() => {
-				mediumOption = screen.queryByRole("option", { name: /t3\.medium/i });
-				expect(mediumOption).toBeTruthy();
-			});
-
-			await waitFor(async () => {
-				await userEvent.click(mediumOption!);
-			});
+			await userEvent.click(mediumOption);
 
 			await act(async () => {
 				await vi.runAllTimersAsync();
@@ -261,7 +255,7 @@ describe("CreateWorkspacePage", () => {
 				diagnostics: [],
 			};
 
-			await waitFor(() => {
+			act(() => {
 				mockPublisher.publishMessage(
 					new MessageEvent("message", { data: JSON.stringify(response1) }),
 				);
@@ -271,8 +265,10 @@ describe("CreateWorkspacePage", () => {
 				);
 			});
 
-			expect(screen.queryByText("CPU Count")).toBeInTheDocument();
-			expect(screen.queryByText("Instance Type")).not.toBeInTheDocument();
+			await waitFor(() => {
+				expect(screen.queryByText("CPU Count")).toBeInTheDocument();
+				expect(screen.queryByText("Instance Type")).not.toBeInTheDocument();
+			});
 		});
 	});
 
@@ -381,10 +377,8 @@ describe("CreateWorkspacePage", () => {
 			const numberInput = screen.getByDisplayValue("50");
 			expect(numberInput).toBeInTheDocument();
 
-			await waitFor(async () => {
-				await userEvent.clear(numberInput);
-				await userEvent.type(numberInput, "200");
-			});
+			await userEvent.clear(numberInput);
+			await userEvent.type(numberInput, "200");
 
 			await waitFor(() => {
 				expect(screen.getByDisplayValue("200")).toBeInTheDocument();
@@ -509,17 +503,13 @@ describe("CreateWorkspacePage", () => {
 			const nameInput = screen.getByRole("textbox", {
 				name: /workspace name/i,
 			});
-			await waitFor(async () => {
-				await userEvent.clear(nameInput);
-				await userEvent.type(nameInput, "my-test-workspace");
-			});
+			await userEvent.clear(nameInput);
+			await userEvent.type(nameInput, "my-test-workspace");
 
 			const createButton = screen.getByRole("button", {
 				name: /create workspace/i,
 			});
-			await waitFor(async () => {
-				await userEvent.click(createButton);
-			});
+			await userEvent.click(createButton);
 
 			await waitFor(() => {
 				expect(API.createWorkspace).toHaveBeenCalledWith(
@@ -597,18 +587,13 @@ describe("CreateWorkspacePage", () => {
 				name: /workspace name/i,
 			});
 
-			await waitFor(async () => {
-				await userEvent.clear(nameInput);
-				await userEvent.type(nameInput, "my-test-workspace");
-			});
+			await userEvent.clear(nameInput);
+			await userEvent.type(nameInput, "my-test-workspace");
 
-			// Submit form
 			const createButton = screen.getByRole("button", {
 				name: /create workspace/i,
 			});
-			await waitFor(async () => {
-				await userEvent.click(createButton);
-			});
+			await userEvent.click(createButton);
 
 			await waitFor(() => {
 				expect(router.state.location.pathname).toBe(

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.test.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.test.tsx
@@ -182,8 +182,14 @@ describe("CreateWorkspacePage", () => {
 			renderCreateWorkspacePage();
 
 			await waitFor(() => {
-				expect(mockPublisher).toBeDefined();
+				expect(API.templateVersionDynamicParameters).toHaveBeenCalled();
+			});
+
+			await act(async () => {
 				mockPublisher.publishError(new Event("Connection failed"));
+			});
+
+			await waitFor(() => {
 				const alert = screen.getByRole("alert");
 				expect(
 					within(alert).getByRole("heading", { name: /connection failed/i }),
@@ -207,8 +213,14 @@ describe("CreateWorkspacePage", () => {
 			renderCreateWorkspacePage();
 
 			await waitFor(() => {
-				expect(mockPublisher).toBeDefined();
+				expect(API.templateVersionDynamicParameters).toHaveBeenCalled();
+			});
+
+			await act(async () => {
 				mockPublisher.publishClose(new Event("close") as CloseEvent);
+			});
+
+			await waitFor(() => {
 				const alert = screen.getByRole("alert");
 				expect(
 					within(alert).getByRole("heading", {


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood

Fixes coder/internal#1472 and fixes coder/internal#1473.

Three flaky/smelly patterns in `CreateWorkspacePage.test.tsx`:

**Redundant `waitFor` around `userEvent` (internal#1472)**

Most removed `waitFor` blocks wrapped only `userEvent.clear`/`type`/`click`
with no assertion — `waitFor` resolves on the first pass when the callback
doesn't throw, so these weren't causing retries, just clutter. Cleaning
them up matches testing-library best practice (await `userEvent` directly).

**`waitFor` polling with inner side effects (internal#1472)**

In one block, `queryByRole` + `expect(...).toBeTruthy()` polled for an
async-appearing option — the retries were real, and replacing with
`findByRole` is the idiomatic fix.

**Synchronous assertion after `waitFor` side effects (internal#1473)**

The "only parameters from latest response" test published WebSocket
messages inside `waitFor` then asserted synchronously, before React
flushed the updates. Fixed by publishing bare and asserting inside a
trailing `waitFor`, which flushes pending state updates on each retry.

**Sibling WebSocket tests (DEREM-2)**

Caught in review: the `handles WebSocket error` and `handles WebSocket
close` tests had the real retry-and-re-fire pattern (vacuous
`toBeDefined` guard + throwing DOM assertions inside `waitFor`). Fixed
by waiting for the API mock to be invoked, publishing inside `act()`,
and asserting inside a trailing `waitFor`.
