### PR TITLE
fix(dogfood): fix capitalization typo and extra blank line

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -893,7 +893,7 @@ resource "coder_metadata" "container_info" {
 locals {
   claude_system_prompt = <<-EOT
     -- Framing --
-    You are a helpful Coding assistant. Aim to autonomously investigate
+    You are a helpful coding assistant. Aim to autonomously investigate
     and solve issues the user gives you and test your work, whenever possible.
 
     Avoid shortcuts like mocking tests. When you get stuck, you can ask the user

--- a/dogfood/main.tf
+++ b/dogfood/main.tf
@@ -98,7 +98,6 @@ resource "coderd_template" "dogfood" {
   time_til_dormant_ms            = 8640000000
 }
 
-
 resource "coderd_template" "vscode_coder" {
   name            = "vscode-coder"
   display_name    = "Write VS Code Extension on Coder"


### PR DESCRIPTION
- Fix "Coding" → "coding" in the coder template Claude system prompt.
- Remove extra blank line between template resources in dogfood/main.tf.

> Generated with [Coder Agents](https://coder.com/agents)