### PR TITLE
feat(enterprise/coderd): chat sharing org settings and role reconciliation

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -4703,6 +4703,86 @@ const docTemplate = `{
                 ]
             }
         },
+        "/organizations/{organization}/settings/chat-sharing": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Enterprise"
+                ],
+                "summary": "Get chat sharing settings for organization",
+                "operationId": "get-chat-sharing-settings-for-organization",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Organization ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatSharingSettings"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "patch": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Enterprise"
+                ],
+                "summary": "Update chat sharing settings for organization",
+                "operationId": "update-chat-sharing-settings-for-organization",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Organization ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Chat sharing settings",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateChatSharingSettingsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatSharingSettings"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
         "/organizations/{organization}/settings/idpsync/available-fields": {
             "get": {
                 "produces": [
@@ -14770,6 +14850,26 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.ChatSharingSettings": {
+            "type": "object",
+            "properties": {
+                "shareable_chat_owners": {
+                    "enum": [
+                        "none",
+                        "everyone",
+                        "service_accounts"
+                    ],
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/codersdk.ShareableChatOwners"
+                        }
+                    ]
+                },
+                "sharing_globally_disabled": {
+                    "type": "boolean"
+                }
+            }
+        },
         "codersdk.ConnectionLatency": {
             "type": "object",
             "properties": {
@@ -20003,6 +20103,19 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.ShareableChatOwners": {
+            "type": "string",
+            "enum": [
+                "none",
+                "everyone",
+                "service_accounts"
+            ],
+            "x-enum-varnames": [
+                "ShareableChatOwnersNone",
+                "ShareableChatOwnersEveryone",
+                "ShareableChatOwnersServiceAccounts"
+            ]
+        },
         "codersdk.ShareableWorkspaceOwners": {
             "type": "string",
             "enum": [
@@ -21329,6 +21442,23 @@ const docTemplate = `{
             "properties": {
                 "retention_days": {
                     "type": "integer"
+                }
+            }
+        },
+        "codersdk.UpdateChatSharingSettingsRequest": {
+            "type": "object",
+            "properties": {
+                "shareable_chat_owners": {
+                    "enum": [
+                        "none",
+                        "everyone",
+                        "service_accounts"
+                    ],
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/codersdk.ShareableChatOwners"
+                        }
+                    ]
                 }
             }
         },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -4176,6 +4176,76 @@
 				]
 			}
 		},
+		"/organizations/{organization}/settings/chat-sharing": {
+			"get": {
+				"produces": ["application/json"],
+				"tags": ["Enterprise"],
+				"summary": "Get chat sharing settings for organization",
+				"operationId": "get-chat-sharing-settings-for-organization",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Organization ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatSharingSettings"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"patch": {
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["Enterprise"],
+				"summary": "Update chat sharing settings for organization",
+				"operationId": "update-chat-sharing-settings-for-organization",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Organization ID",
+						"name": "organization",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Chat sharing settings",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateChatSharingSettingsRequest"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatSharingSettings"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
 		"/organizations/{organization}/settings/idpsync/available-fields": {
 			"get": {
 				"produces": ["application/json"],
@@ -13283,6 +13353,22 @@
 				}
 			}
 		},
+		"codersdk.ChatSharingSettings": {
+			"type": "object",
+			"properties": {
+				"shareable_chat_owners": {
+					"enum": ["none", "everyone", "service_accounts"],
+					"allOf": [
+						{
+							"$ref": "#/definitions/codersdk.ShareableChatOwners"
+						}
+					]
+				},
+				"sharing_globally_disabled": {
+					"type": "boolean"
+				}
+			}
+		},
 		"codersdk.ConnectionLatency": {
 			"type": "object",
 			"properties": {
@@ -18331,6 +18417,15 @@
 				}
 			}
 		},
+		"codersdk.ShareableChatOwners": {
+			"type": "string",
+			"enum": ["none", "everyone", "service_accounts"],
+			"x-enum-varnames": [
+				"ShareableChatOwnersNone",
+				"ShareableChatOwnersEveryone",
+				"ShareableChatOwnersServiceAccounts"
+			]
+		},
 		"codersdk.ShareableWorkspaceOwners": {
 			"type": "string",
 			"enum": ["none", "everyone", "service_accounts"],
@@ -19590,6 +19685,19 @@
 			"properties": {
 				"retention_days": {
 					"type": "integer"
+				}
+			}
+		},
+		"codersdk.UpdateChatSharingSettingsRequest": {
+			"type": "object",
+			"properties": {
+				"shareable_chat_owners": {
+					"enum": ["none", "everyone", "service_accounts"],
+					"allOf": [
+						{
+							"$ref": "#/definitions/codersdk.ShareableChatOwners"
+						}
+					]
 				}
 			}
 		},

--- a/docs/reference/api/enterprise.md
+++ b/docs/reference/api/enterprise.md
@@ -2385,6 +2385,92 @@ curl -X DELETE http://coder-server:8080/api/v2/organizations/{organization}/prov
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
+## Get chat sharing settings for organization
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/settings/chat-sharing \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /organizations/{organization}/settings/chat-sharing`
+
+### Parameters
+
+| Name           | In   | Type         | Required | Description     |
+|----------------|------|--------------|----------|-----------------|
+| `organization` | path | string(uuid) | true     | Organization ID |
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "shareable_chat_owners": "none",
+  "sharing_globally_disabled": true
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                 |
+|--------|---------------------------------------------------------|-------------|------------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.ChatSharingSettings](schemas.md#codersdkchatsharingsettings) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Update chat sharing settings for organization
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X PATCH http://coder-server:8080/api/v2/organizations/{organization}/settings/chat-sharing \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`PATCH /organizations/{organization}/settings/chat-sharing`
+
+> Body parameter
+
+```json
+{
+  "shareable_chat_owners": "none"
+}
+```
+
+### Parameters
+
+| Name           | In   | Type                                                                                             | Required | Description           |
+|----------------|------|--------------------------------------------------------------------------------------------------|----------|-----------------------|
+| `organization` | path | string(uuid)                                                                                     | true     | Organization ID       |
+| `body`         | body | [codersdk.UpdateChatSharingSettingsRequest](schemas.md#codersdkupdatechatsharingsettingsrequest) | true     | Chat sharing settings |
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "shareable_chat_owners": "none",
+  "sharing_globally_disabled": true
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                 |
+|--------|---------------------------------------------------------|-------------|------------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.ChatSharingSettings](schemas.md#codersdkchatsharingsettings) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
 ## Get the available organization idp sync claim fields
 
 ### Code samples

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -2102,6 +2102,28 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 |------------------|---------|----------|--------------|-------------|
 | `retention_days` | integer | false    |              |             |
 
+## codersdk.ChatSharingSettings
+
+```json
+{
+  "shareable_chat_owners": "none",
+  "sharing_globally_disabled": true
+}
+```
+
+### Properties
+
+| Name                        | Type                                                         | Required | Restrictions | Description |
+|-----------------------------|--------------------------------------------------------------|----------|--------------|-------------|
+| `shareable_chat_owners`     | [codersdk.ShareableChatOwners](#codersdkshareablechatowners) | false    |              |             |
+| `sharing_globally_disabled` | boolean                                                      | false    |              |             |
+
+#### Enumerated Values
+
+| Property                | Value(s)                               |
+|-------------------------|----------------------------------------|
+| `shareable_chat_owners` | `everyone`, `none`, `service_accounts` |
+
 ## codersdk.ConnectionLatency
 
 ```json
@@ -8945,6 +8967,20 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 | `max_token_lifetime`       | integer | false    |              |                                                                                                                                                                                        |
 | `refresh_default_duration` | integer | false    |              | Refresh default duration is the default lifetime for OAuth2 refresh tokens. This should generally be longer than access token lifetimes to allow refreshing after access token expiry. |
 
+## codersdk.ShareableChatOwners
+
+```json
+"none"
+```
+
+### Properties
+
+#### Enumerated Values
+
+| Value(s)                               |
+|----------------------------------------|
+| `everyone`, `none`, `service_accounts` |
+
 ## codersdk.ShareableWorkspaceOwners
 
 ```json
@@ -10444,6 +10480,26 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 | Name             | Type    | Required | Restrictions | Description |
 |------------------|---------|----------|--------------|-------------|
 | `retention_days` | integer | false    |              |             |
+
+## codersdk.UpdateChatSharingSettingsRequest
+
+```json
+{
+  "shareable_chat_owners": "none"
+}
+```
+
+### Properties
+
+| Name                    | Type                                                         | Required | Restrictions | Description |
+|-------------------------|--------------------------------------------------------------|----------|--------------|-------------|
+| `shareable_chat_owners` | [codersdk.ShareableChatOwners](#codersdkshareablechatowners) | false    |              |             |
+
+#### Enumerated Values
+
+| Property                | Value(s)                               |
+|-------------------------|----------------------------------------|
+| `shareable_chat_owners` | `everyone`, `none`, `service_accounts` |
 
 ## codersdk.UpdateCheckResponse
 

--- a/enterprise/coderd/chatsharing.go
+++ b/enterprise/coderd/chatsharing.go
@@ -1,0 +1,177 @@
+package coderd
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/coderd/audit"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
+	"github.com/coder/coder/v2/coderd/database/dbtime"
+	"github.com/coder/coder/v2/coderd/httpapi"
+	"github.com/coder/coder/v2/coderd/httpmw"
+	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
+	"github.com/coder/coder/v2/coderd/rbac/rolestore"
+	"github.com/coder/coder/v2/coderd/util/slice"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+// @Summary Get chat sharing settings for organization
+// @ID get-chat-sharing-settings-for-organization
+// @Security CoderSessionToken
+// @Produce json
+// @Tags Enterprise
+// @Param organization path string true "Organization ID" format(uuid)
+// @Success 200 {object} codersdk.ChatSharingSettings
+// @Router /organizations/{organization}/settings/chat-sharing [get]
+func (api *API) chatSharingSettings(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	org := httpmw.OrganizationParam(r)
+
+	if !api.Authorize(r, policy.ActionRead, org) {
+		httpapi.Forbidden(rw)
+		return
+	}
+
+	globallyDisabled := bool(api.DeploymentValues.DisableChatSharing)
+	owners := codersdk.ShareableChatOwners(org.ShareableChatOwners)
+	if globallyDisabled {
+		owners = codersdk.ShareableChatOwnersNone
+	}
+	httpapi.Write(ctx, rw, http.StatusOK, codersdk.ChatSharingSettings{
+		SharingGloballyDisabled: globallyDisabled,
+		ShareableChatOwners:     owners,
+	})
+}
+
+// @Summary Update chat sharing settings for organization
+// @ID update-chat-sharing-settings-for-organization
+// @Security CoderSessionToken
+// @Produce json
+// @Accept json
+// @Tags Enterprise
+// @Param organization path string true "Organization ID" format(uuid)
+// @Param request body codersdk.UpdateChatSharingSettingsRequest true "Chat sharing settings"
+// @Success 200 {object} codersdk.ChatSharingSettings
+// @Router /organizations/{organization}/settings/chat-sharing [patch]
+func (api *API) patchChatSharingSettings(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	org := httpmw.OrganizationParam(r)
+	auditor := *api.AGPL.Auditor.Load()
+	aReq, commitAudit := audit.InitRequest[database.Organization](rw, &audit.RequestParams{
+		Audit:          auditor,
+		Log:            api.Logger,
+		Request:        r,
+		Action:         database.AuditActionWrite,
+		OrganizationID: org.ID,
+	})
+	aReq.Old = org
+	defer commitAudit()
+
+	if !api.Authorize(r, policy.ActionUpdate, org) {
+		httpapi.Forbidden(rw)
+		return
+	}
+
+	var req codersdk.UpdateChatSharingSettingsRequest
+	if !httpapi.Read(ctx, rw, r, &req) {
+		return
+	}
+
+	allowedOwners := req.ShareableChatOwners
+	if allowedOwners == "" {
+		allowedOwners = codersdk.ShareableChatOwnersEveryone
+	}
+
+	if !database.ShareableChatOwners(allowedOwners).Valid() {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "Invalid shareable chat owners value.",
+			Validations: []codersdk.ValidationError{{
+				Field: "shareable_chat_owners",
+				Detail: fmt.Sprintf("invalid value %q, must be one of [%s]",
+					allowedOwners,
+					strings.Join(slice.ToStrings(database.AllShareableChatOwnersValues()), ", ")),
+			}},
+		})
+		return
+	}
+
+	err := api.Database.InTx(func(tx database.Store) error {
+		// nolint:gocritic // System context required to reconcile system roles; callers only need organization:update.
+		sysCtx := dbauthz.AsSystemRestricted(ctx)
+
+		// Serialize system-role reconciliation across coderd instances.
+		err := tx.AcquireLock(ctx, database.LockIDReconcileSystemRoles)
+		if err != nil {
+			return xerrors.Errorf("acquire system roles reconciliation lock: %w", err)
+		}
+
+		org, err = tx.UpdateOrganizationChatSharingSettings(ctx, database.UpdateOrganizationChatSharingSettingsParams{
+			ID:                  org.ID,
+			ShareableChatOwners: database.ShareableChatOwners(allowedOwners),
+			UpdatedAt:           dbtime.Now(),
+		})
+		if err != nil {
+			return xerrors.Errorf("update chat sharing settings for organization %s: %w",
+				org.ID, err)
+		}
+
+		roles, err := tx.CustomRoles(sysCtx, database.CustomRolesParams{
+			LookupRoles: []database.NameOrganizationPair{
+				{
+					Name:           rbac.RoleOrgMember(),
+					OrganizationID: org.ID,
+				},
+				{
+					Name:           rbac.RoleOrgServiceAccount(),
+					OrganizationID: org.ID,
+				},
+			},
+			OrganizationID:     org.ID,
+			ExcludeOrgRoles:    false,
+			IncludeSystemRoles: true,
+		})
+		if err != nil || len(roles) != 2 {
+			return xerrors.Errorf("get member and service-account roles for organization %s: %w",
+				org.ID, err)
+		}
+
+		for _, role := range roles {
+			_, _, err = rolestore.ReconcileSystemRole(sysCtx, tx, role, org)
+			if err != nil {
+				return xerrors.Errorf("reconcile %s role for organization %s: %w",
+					role.Name, org.ID, err)
+			}
+		}
+
+		// In service_accounts mode we retain ACLs on chats owned by service accounts.
+		if org.ShareableChatOwners != database.ShareableChatOwnersEveryone {
+			err = tx.DeleteChatACLsByOrganization(sysCtx, database.DeleteChatACLsByOrganizationParams{
+				OrganizationID:         org.ID,
+				ExcludeServiceAccounts: org.ShareableChatOwners == database.ShareableChatOwnersServiceAccounts,
+			})
+			if err != nil {
+				return xerrors.Errorf("delete chat ACLs for organization %s: %w",
+					org.ID, err)
+			}
+		}
+
+		return nil
+	}, nil)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Internal error updating chat sharing settings.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
+	aReq.New = org
+	httpapi.Write(ctx, rw, http.StatusOK, codersdk.ChatSharingSettings{
+		ShareableChatOwners: codersdk.ShareableChatOwners(org.ShareableChatOwners),
+	})
+}

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -433,6 +433,11 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 					r.Get("/", api.workspaceSharingSettings)
 					r.Patch("/", api.patchWorkspaceSharingSettings)
 				})
+				r.Route("/chat-sharing", func(r chi.Router) {
+					r.Use(httpmw.RequireExperimentWithDevBypass(api.AGPL.Experiments, codersdk.ExperimentAgents))
+					r.Get("/", api.chatSharingSettings)
+					r.Patch("/", api.patchChatSharingSettings)
+				})
 			})
 		})
 


### PR DESCRIPTION
## Stack

1. #24462 — Backend: REST API, RBAC, DB, kill switches
2. #24464 — Frontend: share UI with per-entry toggles, sidebar filter, read-only viewer
3. **This PR** — Enterprise: org-settings + role reconciliation

Pubsub-driven immediate ACL revocation was deferred (previously #24463, now closed). Revocation is eventual — applied on the next stream reconnect.

## What this adds

The enterprise handler for the per-organization chat-sharing kill switch:

- `GET /api/v2/organizations/{organization}/settings/chat-sharing` returns the current `ShareableChatOwners` setting plus the deployment-wide kill-switch state.
- `PATCH /api/v2/organizations/{organization}/settings/chat-sharing` updates the setting, reconciles org-member and service-account roles against the new mode, and (for non-`everyone` modes) clears affected chat ACLs via `DeleteChatACLsByOrganization`.
- Route gated on `ExperimentAgents`.

Without this PR in an enterprise deployment, the per-chat ACL feature from #24462 still works at the handler level. Only the org-level policy control is gated on this PR.

_This PR was created by Coder Agents on behalf of @DanielleMaywood._