### PR TITLE
fix(site): handle invalid URLs in getAppHref without crashing

### DIFF
--- a/site/src/modules/apps/apps.test.ts
+++ b/site/src/modules/apps/apps.test.ts
@@ -117,6 +117,36 @@ describe("getAppHref", () => {
 		expect(href).toBe(externalApp.url);
 	});
 
+	it("returns the raw URL when external app URL is invalid", () => {
+		const externalApp = {
+			...MockWorkspaceApp,
+			external: true,
+			url: "my-app",
+		};
+		const href = getAppHref(externalApp, {
+			host: "*.apps-host.tld",
+			path: "/path-base",
+			agent: MockWorkspaceAgent,
+			workspace: MockWorkspace,
+		});
+		expect(href).toBe("my-app");
+	});
+
+	it("returns the raw URL when external app URL is an empty string", () => {
+		const externalApp = {
+			...MockWorkspaceApp,
+			external: true,
+			url: "",
+		};
+		const href = getAppHref(externalApp, {
+			host: "*.apps-host.tld",
+			path: "/path-base",
+			agent: MockWorkspaceAgent,
+			workspace: MockWorkspace,
+		});
+		expect(href).toBe("");
+	});
+
 	it("returns a path when app doesn't use a subdomain", () => {
 		const app = {
 			...MockWorkspaceApp,

--- a/site/src/modules/apps/apps.ts
+++ b/site/src/modules/apps/apps.ts
@@ -117,7 +117,15 @@ export const getAppHref = (
 	{ path, token, workspace, agent, host }: GetAppHrefParams,
 ): string => {
 	if (isExternalApp(app)) {
-		const appProtocol = new URL(app.url).protocol;
+		let appProtocol: string;
+		try {
+			appProtocol = new URL(app.url).protocol;
+		} catch {
+			// If the URL is invalid (e.g. a bare string with no
+			// scheme), return it as-is so one misconfigured app
+			// never crashes the entire dashboard.
+			return app.url;
+		}
 		const isAllowedProtocol =
 			ALLOWED_EXTERNAL_APP_PROTOCOLS.includes(appProtocol);
 


### PR DESCRIPTION
Fixes #24417

## Changes

When a template specifies an invalid URL (e.g. a bare string like `my-app`
with no scheme) on a `coder_app` resource with `external = true`, the call
to `new URL(app.url)` in `getAppHref()` throws a `TypeError`, crashing the
entire frontend UI.

This wraps the `new URL()` call in a try-catch and falls back to returning
the raw URL when parsing fails. A single misconfigured app no longer brings
down the whole dashboard.

### What changed

- **`site/src/modules/apps/apps.ts`**: Wrap `new URL(app.url).protocol` in
  try-catch; return `app.url` as-is on parse failure.
- **`site/src/modules/apps/apps.test.ts`**: Add two test cases covering
  invalid URL inputs (bare string, empty string).

> 🤖 Generated by Coder Agents