### PR TITLE
fix(site): sync rename dialog state in template editor

### DIFF
--- a/site/src/pages/TemplateVersionEditorPage/FileDialog.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/FileDialog.tsx
@@ -136,6 +136,17 @@ export const RenameFileDialog: FC<RenameFileDialogProps> = ({
 }) => {
 	const [pathValue, setPathValue] = useState(filename);
 	const [error, setError] = useState<string>();
+	const [prevFilename, setPrevFilename] = useState(filename);
+
+	// Sync pathValue with the filename prop when a new file is selected
+	// for renaming. useState alone only captures the initial value on
+	// mount, so reopening the dialog for a different file would show a
+	// stale (or empty) path without this adjustment.
+	if (filename !== prevFilename) {
+		setPrevFilename(filename);
+		setPathValue(filename);
+		setError(undefined);
+	}
 	const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
 		setPathValue(event.target.value);
 	};


### PR DESCRIPTION
The rename dialog in the template files editor never showed the current filename in the input field. `RenameFileDialog` stays mounted for the lifetime of the editor, so `useState(filename)` only captured the initial empty value and never updated when a different file was selected for renaming.

Track the previous `filename` prop and reset `pathValue` during render when it changes.

> [!NOTE]
> Generated by Coder Agents