### PR TITLE
fix: handle invalid external app URL in getAppHref

### DIFF
--- a/site/src/modules/apps/apps.ts
+++ b/site/src/modules/apps/apps.ts
@@ -117,7 +117,12 @@ export const getAppHref = (
 	{ path, token, workspace, agent, host }: GetAppHrefParams,
 ): string => {
 	if (isExternalApp(app)) {
-		const appProtocol = new URL(app.url).protocol;
+		let appProtocol: string;
+		try {
+			appProtocol = new URL(app.url).protocol;
+		} catch {
+			return app.url;
+		}
 		const isAllowedProtocol =
 			ALLOWED_EXTERNAL_APP_PROTOCOLS.includes(appProtocol);
 


### PR DESCRIPTION
## Summary

Wraps the `new URL(app.url)` call in `getAppHref()` with a try-catch to prevent the entire frontend from crashing when a `coder_app` resource specifies an invalid URL (e.g., a bare string like `my-app` with no scheme).

## Problem

When a template has an external `coder_app` with an invalid URL (no scheme, protocol-relative, empty string), the `URL` constructor throws a `TypeError: Failed to construct 'URL': Invalid URL`. This crashes the entire frontend UI since the error is unhandled.

## Changes

- Added a try-catch around `new URL(app.url).protocol` in `getAppHref()`
- On parse failure, returns the raw `app.url` so the UI doesn't crash
- The app still renders, just without protocol-based token injection (which wouldn't work anyway for an invalid URL)

## Testing

- External apps with valid URLs: unchanged behavior
- External apps with invalid URLs (e.g., `my-app`, empty string): returns the raw URL instead of crashing

Fixes #24417