### PR TITLE
fix: resolve `<ChatTopBar />` `fmt` issue

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatTopBar.tsx
+++ b/site/src/pages/AgentsPage/components/ChatTopBar.tsx
@@ -190,20 +190,16 @@ export const ChatTopBar: FC<ChatTopBarProps> = ({
 							align="end"
 							className="[&_[role=menuitem]]:text-[13px]"
 						>
-							{!isArchived && (
+							{!isArchived && onRegenerateTitle && (
 								<>
-									{onRegenerateTitle && (
-										<>
-											<DropdownMenuItem
-												disabled={isRegenerateTitleDisabled}
-												onSelect={onRegenerateTitle}
-											>
-												<WandSparklesIcon className="h-3.5 w-3.5" />
-												Generate new title
-											</DropdownMenuItem>
-											<DropdownMenuSeparator />
-										</>
-									)}
+									<DropdownMenuItem
+										disabled={isRegenerateTitleDisabled}
+										onSelect={onRegenerateTitle}
+									>
+										<WandSparklesIcon className="h-3.5 w-3.5" />
+										Generate new title
+									</DropdownMenuItem>
+									<DropdownMenuSeparator />
 								</>
 							)}
 							{isArchived ? (


### PR DESCRIPTION
Noticed in #24514, this was throwing an error in CI.

```
$ biome lint --error-on-warnings .
src/pages/AgentsPage/components/ChatTopBar.tsx:194:9 lint/complexity/noUselessFragments  FIXABLE  ━━━━━━━━━━

  ℹ This fragment is unnecessary.
  
    192 │                                             >
    193 │                                             {!isArchived && (
  > 194 │                                             <>
        │                                             ^^
  > 195 │                                             {onRegenerateTitle && (
         ...
  > 206 │                                             )}
  > 207 │                                             </>
        │                                             ^^^
    208 │                                             )}
    209 │                                             {isArchived ? (
  
  ℹ A fragment is redundant if it contains only one child, or if it is the child of a html element, and is not a keyed fragment.
  
  ℹ Unsafe fix: Remove the Fragment
  
    192 192 │               >
    193 193 │                 {!isArchived && (
    194     │ - → → → → → → → → <>
    195     │ - → → → → → → → → → {onRegenerateTitle·&&·(
        194 │ + → → → → → → → → onRegenerateTitle·&&·(
    196 195 │                       <>
    197 196 │                         <DropdownMenuItem
    ······· │ 
    204 203 │                         <DropdownMenuSeparator />
    205 204 │                       </>
    206     │ - → → → → → → → → → )}
    207     │ - → → → → → → → → </>
        205 │ + → → → → → → → → → )
    208 206 │                 )}
    209 207 │                 {isArchived ? (
  

```