### PR TITLE
test: pin DateRangePicker calendar today to caller-supplied clock

### DIFF
--- a/site/src/components/DateRangePicker/DateRangePicker.tsx
+++ b/site/src/components/DateRangePicker/DateRangePicker.tsx
@@ -246,6 +246,7 @@ export const DateRangePicker: FC<DateRangePickerProps> = ({
 								onSelect={handleCalendarSelect}
 								numberOfMonths={2}
 								disabled={{ after: currentTime }}
+								today={currentTime}
 							/>
 						</div>
 


### PR DESCRIPTION
The `DateRangePicker` accepts a `now` prop that stories and tests use to pin preset ranges and future-date disabling to a deterministic clock, but it never forwarded that value to the underlying `Calendar`. `react-day-picker` then computed its own `today` from wall-clock time, which drives both the "today" highlight modifier and the initial visible month — causing stories like `TemplateInsightsControls:Day` to _flake_ as real time advanced.

Thread `currentTime` into `react-day-picker`'s `today` prop. When `now` is omitted (production usage), `currentTime` falls back to `new Date()`, which matches `react-day-picker`'s existing default, so there is no runtime behavior change.
