### PR TITLE
fix(coderd): omit frame-ancestors CSP for embed routes

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -2036,16 +2036,20 @@ func New(options *Options) *API {
 	cspMW := httpmw.CSPHeaders(options.Telemetry.Enabled(), cspProxyHosts, additionalCSPHeaders)
 
 	// Embed routes (e.g. VS Code extension chat) are designed to be
-	// loaded inside iframes, so they need a relaxed frame-ancestors
-	// policy instead of the default 'self'. However, if the operator
-	// explicitly configured frame-ancestors via CODER_ADDITIONAL_CSP_POLICY,
+	// loaded inside iframes, so they must not include frame-ancestors
+	// in their CSP. The CSP wildcard '*' only matches network schemes
+	// (http, https, ws, wss) and cannot cover custom schemes like
+	// vscode-webview://, so the only way to allow all embedders is
+	// to omit the directive entirely. If the operator explicitly
+	// configured frame-ancestors via CODER_ADDITIONAL_CSP_POLICY,
 	// respect that setting.
+
 	embedCSPHeaders := make(map[httpmw.CSPFetchDirective][]string, len(additionalCSPHeaders))
 	for k, v := range additionalCSPHeaders {
 		embedCSPHeaders[k] = v
 	}
 	if _, ok := additionalCSPHeaders[httpmw.CSPFrameAncestors]; !ok {
-		embedCSPHeaders[httpmw.CSPFrameAncestors] = []string{"*"}
+		embedCSPHeaders[httpmw.CSPFrameAncestors] = []string{}
 	}
 	embedCSPMW := httpmw.CSPHeaders(options.Telemetry.Enabled(), cspProxyHosts, embedCSPHeaders)
 	embedHandler := embedCSPMW(compressHandler(httpmw.HSTS(api.SiteHandler, options.StrictTransportSecurityCfg)))

--- a/coderd/httpmw/csp.go
+++ b/coderd/httpmw/csp.go
@@ -145,8 +145,17 @@ func CSPHeaders(telemetry bool, proxyHosts func() []*proxyhealth.ProxyHost, stat
 			// Default to 'self' to prevent clickjacking unless
 			// explicitly overridden via staticAdditions (e.g. for
 			// embeddable routes).
-			if _, ok := cspSrcs[CSPFrameAncestors]; !ok {
+			//
+			// An explicit empty value means "omit frame-ancestors
+			// entirely", which is needed for embed routes where
+			// non-network-scheme parents (e.g. vscode-webview://)
+			// must be able to frame the page. The CSP wildcard '*'
+			// only matches network schemes (http, https, ws, wss)
+			// so it cannot cover custom schemes.
+			if vals, ok := cspSrcs[CSPFrameAncestors]; !ok {
 				cspSrcs[CSPFrameAncestors] = []string{"'self'"}
+			} else if len(vals) == 0 {
+				delete(cspSrcs, CSPFrameAncestors)
 			}
 
 			var csp strings.Builder

--- a/coderd/httpmw/csp_test.go
+++ b/coderd/httpmw/csp_test.go
@@ -40,14 +40,32 @@ func TestCSPFrameAncestors(t *testing.T) {
 		httpmw.CSPHeaders(false, func() []*proxyhealth.ProxyHost {
 			return nil
 		}, map[httpmw.CSPFetchDirective][]string{
-			httpmw.CSPFrameAncestors: {"*"},
+			httpmw.CSPFrameAncestors: {"https://example.com"},
 		})(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 			rw.WriteHeader(http.StatusOK)
 		})).ServeHTTP(rw, r)
 
 		csp := rw.Header().Get("Content-Security-Policy")
-		require.Contains(t, csp, "frame-ancestors *")
+		require.Contains(t, csp, "frame-ancestors https://example.com")
 		require.NotContains(t, csp, "frame-ancestors 'self'")
+	})
+
+	t.Run("OmitWhenEmpty", func(t *testing.T) {
+		t.Parallel()
+
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		rw := httptest.NewRecorder()
+
+		httpmw.CSPHeaders(false, func() []*proxyhealth.ProxyHost {
+			return nil
+		}, map[httpmw.CSPFetchDirective][]string{
+			httpmw.CSPFrameAncestors: {},
+		})(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			rw.WriteHeader(http.StatusOK)
+		})).ServeHTTP(rw, r)
+
+		csp := rw.Header().Get("Content-Security-Policy")
+		require.NotContains(t, csp, "frame-ancestors")
 	})
 }
 


### PR DESCRIPTION
## Problem

PR #24474 added `frame-ancestors 'self'` as the default CSP directive and set
`frame-ancestors *` for embed routes (`/agents/{agentId}/embed`). However,
per the CSP spec, the `*` wildcard in `frame-ancestors` only matches network
schemes (http, https, ws, wss). VSCode webviews use the `vscode-webview://`
scheme, which is not a network scheme, so `frame-ancestors *` blocks embedding.

This is a known limitation documented in:
- [electron/electron#26369](https://github.com/electron/electron/issues/26369)
- [community/discussions/13406](https://github.com/orgs/community/discussions/13406)

## Fix

Omit the `frame-ancestors` directive entirely from the embed route CSP instead
of setting it to `*`. When `frame-ancestors` is absent from CSP, the browser
does not enforce frame ancestor restrictions via CSP (`frame-ancestors` does
not fall back to `default-src`), allowing embedding from any origin/scheme
including `vscode-webview://`.

- Non-embed routes still have `frame-ancestors 'self'` for clickjacking protection.
- Operator `CODER_ADDITIONAL_CSP_POLICY` overrides are still respected.
- All other CSP protections (script-src, connect-src, etc.) remain intact.

## Changes

| File | Change |
|---|---|
| `coderd/httpmw/csp.go` | Support omitting `frame-ancestors` when an empty slice is passed via `staticAdditions` |
| `coderd/coderd.go` | Pass empty slice instead of `["*"]` for embed routes |
| `coderd/httpmw/csp_test.go` | Add `OmitWhenEmpty` test; update `OverrideViaStaticAdditions` to use a concrete origin |

<details><summary>Implementation notes (Coder Agents generated)</summary>

### Decision log

1. **Why not `frame-ancestors * vscode-webview://*`?** — The `frame-ancestors` source-list doesn't support arbitrary scheme wildcards. Only network schemes, hostnames, and `'self'` are valid sources.
2. **Why empty slice as sentinel?** — Minimal API surface change. An empty slice in `staticAdditions` for `CSPFrameAncestors` signals "omit entirely". The key exists (so the default `'self'` isn't applied), but the empty value triggers deletion before header construction.
3. **Security impact** — Embed routes are intentionally designed for iframe embedding (with postMessage auth bootstrap). Omitting `frame-ancestors` is equivalent to the pre-#24474 behavior for these specific routes only.

</details>

> 🤖 Generated by Coder Agents