### PR TITLE
feat: resize chat image attachments client-side for provider budgets

### DIFF
--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -4343,11 +4343,6 @@ func parseCompactionThresholdKey(key string) (uuid.UUID, error) {
 	return id, nil
 }
 
-const (
-	// maxChatFileSize is the maximum size of a chat file upload (10 MB).
-	maxChatFileSize = 10 << 20
-)
-
 //nolint:revive // get-return: revive assumes get* must be a getter, but this is an HTTP handler.
 func (api *API) getChatSystemPrompt(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -5832,14 +5827,14 @@ func (api *API) postChatFile(rw http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	r.Body = http.MaxBytesReader(rw, r.Body, maxChatFileSize)
+	r.Body = http.MaxBytesReader(rw, r.Body, codersdk.MaxChatFileSizeBytes)
 	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		var maxBytesErr *http.MaxBytesError
 		if errors.As(err, &maxBytesErr) {
 			httpapi.Write(ctx, rw, http.StatusRequestEntityTooLarge, codersdk.Response{
 				Message: "File too large.",
-				Detail:  fmt.Sprintf("Maximum file size is %d bytes.", maxChatFileSize),
+				Detail:  fmt.Sprintf("Maximum file size is %d bytes.", codersdk.MaxChatFileSizeBytes),
 			})
 			return
 		}

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -5161,42 +5161,55 @@ func (p *Server) subscribeChatControl(
 	return controlCancel
 }
 
-// anthropicMaxInlineImageBytes mirrors Anthropic's documented 5 MiB
-// cap on inline image parts. Enforced server-side as a safety net;
-// the browser also resizes proactively in useFileAttachments, so this
-// should only trigger for older clients or direct API callers.
-const anthropicMaxInlineImageBytes = 5 * 1024 * 1024 // 5_242_880
-
 // chatFileResolver returns a FileResolver that fetches chat file
 // content from the database by ID. The provider argument is used to
 // enforce per-provider payload limits (e.g. Anthropic's 5 MiB inline
-// image cap) so oversized attachments are rejected before any
-// upstream request is issued.
+// image cap, inherited by Bedrock-hosted Claude via chatprovider.
+// InlineImageByteCap) so oversized attachments are rejected before
+// any upstream request is issued.
+//
+// TODO(chat-images): when an oversize image lives in a historical
+// message, this aborts the whole prompt build and bricks the chat on
+// the affected provider. A follow-up should make the resolver skip
+// the offending file with a user-facing warning instead of failing
+// hard, so the conversation can still be continued.
 func (p *Server) chatFileResolver(provider string) chatprompt.FileResolver {
 	return func(ctx context.Context, ids []uuid.UUID) (map[uuid.UUID]chatprompt.FileData, error) {
 		files, err := p.db.GetChatFilesByIDs(ctx, ids)
 		if err != nil {
 			return nil, err
 		}
+		// Look up the provider-specific inline image cap once per
+		// invocation; skipped entirely for providers without a cap.
+		imageCap, hasImageCap := chatprovider.InlineImageByteCap(provider)
 		normalizedProvider := chatprovider.NormalizeProvider(provider)
 		result := make(map[uuid.UUID]chatprompt.FileData, len(files))
 		for _, f := range files {
-			if normalizedProvider == anthropic.Name &&
+			if hasImageCap &&
 				strings.HasPrefix(f.Mimetype, "image/") &&
-				len(f.Data) > anthropicMaxInlineImageBytes {
+				len(f.Data) >= imageCap {
 				// Pre-classify the error so the surfaced message
 				// points the user at the actionable cause rather
 				// than producing a generic upstream failure.
 				err := xerrors.Errorf(
-					"image attachment %q is %d bytes; Anthropic limits inline images to %d bytes",
-					f.Name, len(f.Data), anthropicMaxInlineImageBytes,
+					"image attachment %q is %d bytes; %s inline image limit is %d bytes",
+					f.Name, len(f.Data),
+					chatprovider.ProviderDisplayName(normalizedProvider),
+					imageCap,
 				)
 				return nil, chaterror.WithClassification(err, chaterror.ClassifiedError{
 					Kind:     chaterror.KindConfig,
-					Provider: anthropic.Name,
+					Provider: normalizedProvider,
+					// Kept client-agnostic on purpose: this backstop
+					// runs for older web clients and direct API
+					// callers that do not auto-resize, so a promise
+					// of "the app will resize it for you" would be a
+					// lie for exactly that audience. State the limit
+					// and let the caller decide how to shrink.
 					Message: fmt.Sprintf(
-						"Image attachment exceeds Anthropic's %d byte inline limit. Please remove or re-attach the image; the app will resize it for you.",
-						anthropicMaxInlineImageBytes,
+						"Image attachment exceeds %s's %d-byte inline image limit. Replace it with a smaller image.",
+						chatprovider.ProviderDisplayName(normalizedProvider),
+						imageCap,
 					),
 					Retryable: false,
 				})

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -19,6 +19,7 @@ import (
 
 	"charm.land/fantasy"
 	"charm.land/fantasy/providers/anthropic"
+	"github.com/dustin/go-humanize"
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/shopspring/decimal"
@@ -5161,55 +5162,46 @@ func (p *Server) subscribeChatControl(
 	return controlCancel
 }
 
-// chatFileResolver returns a FileResolver that fetches chat file
-// content from the database by ID. The provider argument is used to
-// enforce per-provider payload limits (e.g. Anthropic's 5 MiB inline
-// image cap, inherited by Bedrock-hosted Claude via chatprovider.
-// InlineImageByteCap) so oversized attachments are rejected before
-// any upstream request is issued.
+// Rejects oversize images on capped providers before any upstream
+// request is issued.
 //
-// TODO(chat-images): when an oversize image lives in a historical
-// message, this aborts the whole prompt build and bricks the chat on
-// the affected provider. A follow-up should make the resolver skip
-// the offending file with a user-facing warning instead of failing
-// hard, so the conversation can still be continued.
+// Gotcha: a historical oversize image bricks the chat on a capped
+// provider until the user switches providers back, starts a new
+// chat, or edits a message above the offending one (which truncates
+// the prompt forward). A future change should skip the file with a
+// user-facing warning, but that requires altering the FileResolver
+// contract.
 func (p *Server) chatFileResolver(provider string) chatprompt.FileResolver {
 	return func(ctx context.Context, ids []uuid.UUID) (map[uuid.UUID]chatprompt.FileData, error) {
 		files, err := p.db.GetChatFilesByIDs(ctx, ids)
 		if err != nil {
 			return nil, err
 		}
-		// Look up the provider-specific inline image cap once per
-		// invocation; skipped entirely for providers without a cap.
-		imageCap, hasImageCap := chatprovider.InlineImageByteCap(provider)
+		imageCap, hasImageCap := chatprovider.InlineImageCapBytes(provider)
 		normalizedProvider := chatprovider.NormalizeProvider(provider)
 		result := make(map[uuid.UUID]chatprompt.FileData, len(files))
 		for _, f := range files {
 			if hasImageCap &&
 				strings.HasPrefix(f.Mimetype, "image/") &&
 				len(f.Data) >= imageCap {
-				// Pre-classify the error so the surfaced message
-				// points the user at the actionable cause rather
-				// than producing a generic upstream failure.
 				err := xerrors.Errorf(
 					"image attachment %q is %d bytes; %s inline image limit is %d bytes",
 					f.Name, len(f.Data),
 					chatprovider.ProviderDisplayName(normalizedProvider),
 					imageCap,
 				)
+				// User-facing message stays client-agnostic since
+				// older web clients and direct API callers don't
+				// auto-resize; the wrapped error above keeps the
+				// exact byte count for operator logs.
 				return nil, chaterror.WithClassification(err, chaterror.ClassifiedError{
-					Kind:     chaterror.KindConfig,
+					Kind:     codersdk.ChatErrorKindConfig,
 					Provider: normalizedProvider,
-					// Kept client-agnostic on purpose: this backstop
-					// runs for older web clients and direct API
-					// callers that do not auto-resize, so a promise
-					// of "the app will resize it for you" would be a
-					// lie for exactly that audience. State the limit
-					// and let the caller decide how to shrink.
 					Message: fmt.Sprintf(
-						"Image attachment exceeds %s's %d-byte inline image limit. Replace it with a smaller image.",
+						"Image attachment exceeds %s's %s inline image limit. Replace it with a smaller image.",
 						chatprovider.ProviderDisplayName(normalizedProvider),
-						imageCap,
+						//nolint:gosec // imageCap is a small positive constant defined in chatprovider.
+						humanize.IBytes(uint64(imageCap)),
 					),
 					Retryable: false,
 				})

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -5161,16 +5161,46 @@ func (p *Server) subscribeChatControl(
 	return controlCancel
 }
 
+// anthropicMaxInlineImageBytes mirrors Anthropic's documented 5 MiB
+// cap on inline image parts. Enforced server-side as a safety net;
+// the browser also resizes proactively in useFileAttachments, so this
+// should only trigger for older clients or direct API callers.
+const anthropicMaxInlineImageBytes = 5 * 1024 * 1024 // 5_242_880
+
 // chatFileResolver returns a FileResolver that fetches chat file
-// content from the database by ID.
-func (p *Server) chatFileResolver() chatprompt.FileResolver {
+// content from the database by ID. The provider argument is used to
+// enforce per-provider payload limits (e.g. Anthropic's 5 MiB inline
+// image cap) so oversized attachments are rejected before any
+// upstream request is issued.
+func (p *Server) chatFileResolver(provider string) chatprompt.FileResolver {
 	return func(ctx context.Context, ids []uuid.UUID) (map[uuid.UUID]chatprompt.FileData, error) {
 		files, err := p.db.GetChatFilesByIDs(ctx, ids)
 		if err != nil {
 			return nil, err
 		}
+		normalizedProvider := chatprovider.NormalizeProvider(provider)
 		result := make(map[uuid.UUID]chatprompt.FileData, len(files))
 		for _, f := range files {
+			if normalizedProvider == anthropic.Name &&
+				strings.HasPrefix(f.Mimetype, "image/") &&
+				len(f.Data) > anthropicMaxInlineImageBytes {
+				// Pre-classify the error so the surfaced message
+				// points the user at the actionable cause rather
+				// than producing a generic upstream failure.
+				err := xerrors.Errorf(
+					"image attachment %q is %d bytes; Anthropic limits inline images to %d bytes",
+					f.Name, len(f.Data), anthropicMaxInlineImageBytes,
+				)
+				return nil, chaterror.WithClassification(err, chaterror.ClassifiedError{
+					Kind:     chaterror.KindConfig,
+					Provider: anthropic.Name,
+					Message: fmt.Sprintf(
+						"Image attachment exceeds Anthropic's %d byte inline limit. Please remove or re-attach the image; the app will resize it for you.",
+						anthropicMaxInlineImageBytes,
+					),
+					Retryable: false,
+				})
+			}
 			result[f.ID] = chatprompt.FileData{
 				Name:      f.Name,
 				Data:      f.Data,
@@ -6478,7 +6508,7 @@ func (p *Server) runChat(
 	var g2 errgroup.Group
 	g2.Go(func() error {
 		var err error
-		prompt, err = chatprompt.ConvertMessagesWithFiles(ctx, messages, p.chatFileResolver(), logger)
+		prompt, err = chatprompt.ConvertMessagesWithFiles(ctx, messages, p.chatFileResolver(modelConfig.Provider), logger)
 		if err != nil {
 			return xerrors.Errorf("build chat prompt: %w", err)
 		}
@@ -7263,7 +7293,7 @@ func (p *Server) runChat(
 			if compactionOptions != nil {
 				compactionOptions.HistoryTipMessageID = compactionHistoryTipMessageID
 			}
-			reloadedPrompt, err := chatprompt.ConvertMessagesWithFiles(reloadCtx, reloadedMsgs, p.chatFileResolver(), logger)
+			reloadedPrompt, err := chatprompt.ConvertMessagesWithFiles(reloadCtx, reloadedMsgs, p.chatFileResolver(modelConfig.Provider), logger)
 			if err != nil {
 				return nil, xerrors.Errorf("convert reloaded messages: %w", err)
 			}

--- a/coderd/x/chatd/chatfile_internal_test.go
+++ b/coderd/x/chatd/chatfile_internal_test.go
@@ -3,7 +3,7 @@ package chatd
 import (
 	"bytes"
 	"context"
-	"strings"
+	"strconv"
 	"testing"
 
 	"github.com/google/uuid"
@@ -14,76 +14,137 @@ import (
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbmock"
 	"github.com/coder/coder/v2/coderd/x/chatd/chaterror"
+	"github.com/coder/coder/v2/coderd/x/chatd/chatprovider"
 )
 
-// TestChatFileResolver_RejectsOversizedAnthropicImages verifies the
-// server-side safety net: even if an oversized image slips past the
-// browser's resize step, chatFileResolver refuses to forward it to
-// Anthropic. This prevents sending a request that Anthropic will
-// reject for exceeding its 5 MiB inline-image cap.
-func TestChatFileResolver_RejectsOversizedAnthropicImages(t *testing.T) {
+// inlineImageCapFor panics if the provider has no documented cap;
+// tests that call this must use a capped provider.
+func inlineImageCapFor(t *testing.T, provider string) int {
+	t.Helper()
+	imageCap, ok := chatprovider.InlineImageByteCap(provider)
+	require.Truef(t, ok, "expected provider %q to have an inline image cap", provider)
+	return imageCap
+}
+
+// TestChatFileResolver_RejectsOversizedImages verifies the server-side
+// safety net: even if an oversized image slips past the browser's
+// resize step, chatFileResolver refuses to forward it upstream. This
+// prevents sending a request that the provider's upstream API would
+// reject for exceeding its inline-image cap.
+func TestChatFileResolver_RejectsOversizedImages(t *testing.T) {
 	t.Parallel()
 
+	// Computed rather than hardcoded so the table doesn't silently
+	// rot if chatprovider ever retunes the cap.
+	anthropicCap := inlineImageCapFor(t, "anthropic")
+
 	tests := []struct {
-		name         string
-		provider     string
-		mimetype     string
-		size         int
-		expectReject bool
+		name             string
+		provider         string
+		mimetype         string
+		size             int
+		expectReject     bool
+		expectProviderID string // classified.Provider after normalization
 	}{
 		{
-			name:         "OversizedAnthropicPNG_Rejected",
-			provider:     "anthropic",
-			mimetype:     "image/png",
-			size:         anthropicMaxInlineImageBytes + 1,
-			expectReject: true,
+			name:             "OversizedAnthropicPNG_Rejected",
+			provider:         "anthropic",
+			mimetype:         "image/png",
+			size:             anthropicCap + 1,
+			expectReject:     true,
+			expectProviderID: "anthropic",
 		},
 		{
-			name:         "OversizedAnthropicJPEG_Rejected",
-			provider:     "anthropic",
-			mimetype:     "image/jpeg",
-			size:         anthropicMaxInlineImageBytes + 1024,
-			expectReject: true,
+			name:             "OversizedAnthropicJPEG_Rejected",
+			provider:         "anthropic",
+			mimetype:         "image/jpeg",
+			size:             anthropicCap + 1024,
+			expectReject:     true,
+			expectProviderID: "anthropic",
 		},
 		{
-			name:         "AtLimitAnthropicImage_Accepted",
-			provider:     "anthropic",
-			mimetype:     "image/png",
-			size:         anthropicMaxInlineImageBytes,
-			expectReject: false,
+			// Server uses >= for the boundary, so exactly-at-limit
+			// is also rejected. Anthropic's public docs phrase the
+			// limit as "5 MB maximum" without specifying inclusivity;
+			// rejecting strictly safer than letting the exact-limit
+			// file fail upstream with a generic error.
+			name:             "AtLimitAnthropicImage_Rejected",
+			provider:         "anthropic",
+			mimetype:         "image/png",
+			size:             anthropicCap,
+			expectReject:     true,
+			expectProviderID: "anthropic",
 		},
 		{
-			name:         "UndersizedAnthropicImage_Accepted",
-			provider:     "anthropic",
-			mimetype:     "image/png",
-			size:         1024,
-			expectReject: false,
+			name:             "JustUnderLimitAnthropicImage_Accepted",
+			provider:         "anthropic",
+			mimetype:         "image/png",
+			size:             anthropicCap - 1,
+			expectReject:     false,
+			expectProviderID: "anthropic",
 		},
 		{
-			name:         "OversizedOpenAIImage_Accepted",
-			provider:     "openai",
-			mimetype:     "image/png",
-			size:         anthropicMaxInlineImageBytes + 1,
-			expectReject: false,
+			name:             "UndersizedAnthropicImage_Accepted",
+			provider:         "anthropic",
+			mimetype:         "image/png",
+			size:             1024,
+			expectReject:     false,
+			expectProviderID: "anthropic",
 		},
 		{
-			name:         "OversizedAnthropicText_Accepted",
-			provider:     "anthropic",
-			mimetype:     "text/plain",
-			size:         anthropicMaxInlineImageBytes + 1,
-			expectReject: false,
+			// Bedrock reuses Anthropic's wire format and cap (see
+			// chatprovider.InlineImageByteCap); the same oversize
+			// image bound for Bedrock must be rejected.
+			name:             "OversizedBedrockPNG_Rejected",
+			provider:         "bedrock",
+			mimetype:         "image/png",
+			size:             anthropicCap + 1,
+			expectReject:     true,
+			expectProviderID: "bedrock",
 		},
 		{
-			name:         "ProviderCaseInsensitive_Rejected",
-			provider:     "Anthropic",
-			mimetype:     "image/png",
-			size:         anthropicMaxInlineImageBytes + 1,
-			expectReject: true,
+			name:             "OversizedOpenAIImage_Accepted",
+			provider:         "openai",
+			mimetype:         "image/png",
+			size:             anthropicCap + 1,
+			expectReject:     false,
+			expectProviderID: "openai",
+		},
+		{
+			name:             "OversizedAnthropicText_Accepted",
+			provider:         "anthropic",
+			mimetype:         "text/plain",
+			size:             anthropicCap + 1,
+			expectReject:     false,
+			expectProviderID: "anthropic",
+		},
+		{
+			name:             "ProviderMixedCase_Rejected",
+			provider:         "Anthropic",
+			mimetype:         "image/png",
+			size:             anthropicCap + 1,
+			expectReject:     true,
+			expectProviderID: "anthropic",
+		},
+		{
+			name:             "ProviderAllCaps_Rejected",
+			provider:         "ANTHROPIC",
+			mimetype:         "image/png",
+			size:             anthropicCap + 1,
+			expectReject:     true,
+			expectProviderID: "anthropic",
+		},
+		{
+			name:             "ProviderPaddedWhitespace_Rejected",
+			provider:         "  anthropic  ",
+			mimetype:         "image/png",
+			size:             anthropicCap + 1,
+			expectReject:     true,
+			expectProviderID: "anthropic",
 		},
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()
@@ -115,10 +176,17 @@ func TestChatFileResolver_RejectsOversizedAnthropicImages(t *testing.T) {
 				// generic provider failure.
 				classified := chaterror.Classify(err)
 				require.Equal(t, chaterror.KindConfig, classified.Kind)
-				require.Equal(t, "anthropic", classified.Provider)
+				require.Equal(t, tc.expectProviderID, classified.Provider)
 				require.False(t, classified.Retryable)
-				require.Contains(t, strings.ToLower(classified.Message), "anthropic")
-				require.Contains(t, classified.Message, "5242880")
+				// Surface should include the provider display name
+				// and the byte cap derived from the constant.
+				displayName := chatprovider.ProviderDisplayName(tc.expectProviderID)
+				require.Contains(t, classified.Message, displayName)
+				require.Contains(
+					t,
+					classified.Message,
+					strconv.Itoa(inlineImageCapFor(t, tc.expectProviderID)),
+				)
 				return
 			}
 			require.NoError(t, err)
@@ -129,8 +197,57 @@ func TestChatFileResolver_RejectsOversizedAnthropicImages(t *testing.T) {
 	}
 }
 
+// TestChatFileResolver_MultiFileFailsFastOnFirstOversized pins the
+// current "first bad file aborts the batch" contract. If this is
+// ever changed to collect all violations, this test should be
+// updated rather than silently dropped.
+func TestChatFileResolver_MultiFileFailsFastOnFirstOversized(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+	server := &Server{db: db}
+
+	anthropicCap := inlineImageCapFor(t, "anthropic")
+	okFileA := database.ChatFile{
+		ID:       uuid.New(),
+		Name:     "ok-a.png",
+		Mimetype: "image/png",
+		Data:     bytes.Repeat([]byte{0x00}, 1024),
+	}
+	oversized := database.ChatFile{
+		ID:       uuid.New(),
+		Name:     "too-big.png",
+		Mimetype: "image/png",
+		Data:     bytes.Repeat([]byte{0x00}, anthropicCap+1),
+	}
+	okFileB := database.ChatFile{
+		ID:       uuid.New(),
+		Name:     "ok-b.png",
+		Mimetype: "image/png",
+		Data:     bytes.Repeat([]byte{0x00}, 1024),
+	}
+	ids := []uuid.UUID{okFileA.ID, oversized.ID, okFileB.ID}
+
+	db.EXPECT().
+		GetChatFilesByIDs(gomock.Any(), ids).
+		Return([]database.ChatFile{okFileA, oversized, okFileB}, nil).
+		Times(1)
+
+	resolver := server.chatFileResolver("anthropic")
+	got, err := resolver(ctx, ids)
+	require.Error(t, err)
+	require.Nil(t, got)
+	classified := chaterror.Classify(err)
+	require.Equal(t, chaterror.KindConfig, classified.Kind)
+	// The error must identify the specific offending file so a user
+	// with several attachments knows which one to replace.
+	require.Contains(t, err.Error(), oversized.Name)
+}
+
 // TestChatFileResolver_PropagatesDBError confirms unrelated database
-// failures pass through unchanged (not masked by the Anthropic check).
+// failures pass through unchanged (not masked by the size check).
 func TestChatFileResolver_PropagatesDBError(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -150,4 +267,34 @@ func TestChatFileResolver_PropagatesDBError(t *testing.T) {
 	got, err := resolver(ctx, []uuid.UUID{fileID})
 	require.ErrorIs(t, err, sentinel)
 	require.Nil(t, got)
+}
+
+// TestChatFileResolver_UnknownProviderSkipsCapCheck confirms providers
+// without a documented inline cap are never rejected by the backstop.
+func TestChatFileResolver_UnknownProviderSkipsCapCheck(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+	server := &Server{db: db}
+
+	fileID := uuid.New()
+	row := database.ChatFile{
+		ID:       fileID,
+		Name:     "huge.png",
+		Mimetype: "image/png",
+		// Well above every documented cap; but without a matching
+		// provider the backstop must not fire.
+		Data: bytes.Repeat([]byte{0x00}, 50*1024*1024),
+	}
+	db.EXPECT().
+		GetChatFilesByIDs(gomock.Any(), []uuid.UUID{fileID}).
+		Return([]database.ChatFile{row}, nil).
+		Times(1)
+
+	resolver := server.chatFileResolver("openrouter")
+	got, err := resolver(ctx, []uuid.UUID{fileID})
+	require.NoError(t, err)
+	require.Contains(t, got, fileID)
 }

--- a/coderd/x/chatd/chatfile_internal_test.go
+++ b/coderd/x/chatd/chatfile_internal_test.go
@@ -1,11 +1,11 @@
 package chatd
 
 import (
-	"bytes"
 	"context"
 	"strconv"
 	"testing"
 
+	"github.com/dustin/go-humanize"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -15,27 +15,25 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbmock"
 	"github.com/coder/coder/v2/coderd/x/chatd/chaterror"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatprovider"
+	"github.com/coder/coder/v2/codersdk"
 )
 
-// inlineImageCapFor panics if the provider has no documented cap;
-// tests that call this must use a capped provider.
+// inlineImageCapFor returns the provider's inline image cap. Fails
+// the test if the provider has no documented cap.
 func inlineImageCapFor(t *testing.T, provider string) int {
 	t.Helper()
-	imageCap, ok := chatprovider.InlineImageByteCap(provider)
+	imageCap, ok := chatprovider.InlineImageCapBytes(provider)
 	require.Truef(t, ok, "expected provider %q to have an inline image cap", provider)
 	return imageCap
 }
 
-// TestChatFileResolver_RejectsOversizedImages verifies the server-side
-// safety net: even if an oversized image slips past the browser's
-// resize step, chatFileResolver refuses to forward it upstream. This
-// prevents sending a request that the provider's upstream API would
-// reject for exceeding its inline-image cap.
+// TestChatFileResolver_RejectsOversizedImages is the server-side
+// safety net for browser-side resize: oversize images that reach the
+// resolver are rejected before any upstream request.
 func TestChatFileResolver_RejectsOversizedImages(t *testing.T) {
 	t.Parallel()
 
-	// Computed rather than hardcoded so the table doesn't silently
-	// rot if chatprovider ever retunes the cap.
+	// Computed so the table tracks any future cap retune.
 	anthropicCap := inlineImageCapFor(t, "anthropic")
 
 	tests := []struct {
@@ -63,11 +61,9 @@ func TestChatFileResolver_RejectsOversizedImages(t *testing.T) {
 			expectProviderID: "anthropic",
 		},
 		{
-			// Server uses >= for the boundary, so exactly-at-limit
-			// is also rejected. Anthropic's public docs phrase the
-			// limit as "5 MB maximum" without specifying inclusivity;
-			// rejecting strictly safer than letting the exact-limit
-			// file fail upstream with a generic error.
+			// Boundary is >=: exactly-at-limit is rejected.
+			// Anthropic's docs say "5 MB maximum" without
+			// specifying inclusivity, so reject strictly.
 			name:             "AtLimitAnthropicImage_Rejected",
 			provider:         "anthropic",
 			mimetype:         "image/png",
@@ -92,9 +88,7 @@ func TestChatFileResolver_RejectsOversizedImages(t *testing.T) {
 			expectProviderID: "anthropic",
 		},
 		{
-			// Bedrock reuses Anthropic's wire format and cap (see
-			// chatprovider.InlineImageByteCap); the same oversize
-			// image bound for Bedrock must be rejected.
+			// Bedrock reuses Anthropic's cap.
 			name:             "OversizedBedrockPNG_Rejected",
 			provider:         "bedrock",
 			mimetype:         "image/png",
@@ -144,6 +138,17 @@ func TestChatFileResolver_RejectsOversizedImages(t *testing.T) {
 		},
 	}
 
+	// One shared backing buffer sliced per case. The resolver only
+	// reads len(f.Data), so shared backing is safe and avoids N×max
+	// allocations in parallel.
+	maxSize := 0
+	for _, tc := range tests {
+		if tc.size > maxSize {
+			maxSize = tc.size
+		}
+	}
+	sharedData := make([]byte, maxSize)
+
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -158,7 +163,7 @@ func TestChatFileResolver_RejectsOversizedImages(t *testing.T) {
 				ID:       fileID,
 				Name:     "attachment.png",
 				Mimetype: tc.mimetype,
-				Data:     bytes.Repeat([]byte{0x00}, tc.size),
+				Data:     sharedData[:tc.size],
 			}
 			db.EXPECT().
 				GetChatFilesByIDs(gomock.Any(), []uuid.UUID{fileID}).
@@ -171,22 +176,28 @@ func TestChatFileResolver_RejectsOversizedImages(t *testing.T) {
 			if tc.expectReject {
 				require.Error(t, err)
 				require.Nil(t, got)
-				// The error must carry a pre-built classification so
-				// the user sees an actionable message instead of a
-				// generic provider failure.
+				// Classification turns the generic upstream error
+				// into an actionable user-facing message.
 				classified := chaterror.Classify(err)
-				require.Equal(t, chaterror.KindConfig, classified.Kind)
+				require.Equal(t, codersdk.ChatErrorKindConfig, classified.Kind)
 				require.Equal(t, tc.expectProviderID, classified.Provider)
 				require.False(t, classified.Retryable)
-				// Surface should include the provider display name
-				// and the byte cap derived from the constant.
+				// User-facing message names the provider and shows
+				// the cap in human units; raw byte count stays in
+				// the wrapped developer error.
 				displayName := chatprovider.ProviderDisplayName(tc.expectProviderID)
 				require.Contains(t, classified.Message, displayName)
-				require.Contains(
+				imageCap := inlineImageCapFor(t, tc.expectProviderID)
+				//nolint:gosec // imageCap is a small positive constant defined in chatprovider.
+				require.Contains(t, classified.Message, humanize.IBytes(uint64(imageCap)))
+				require.NotContains(
 					t,
 					classified.Message,
-					strconv.Itoa(inlineImageCapFor(t, tc.expectProviderID)),
+					strconv.Itoa(imageCap),
+					"user-facing message should not include raw bytes",
 				)
+				// Wrapped error preserves exact bytes for logs.
+				require.Contains(t, err.Error(), strconv.Itoa(imageCap))
 				return
 			}
 			require.NoError(t, err)
@@ -198,9 +209,7 @@ func TestChatFileResolver_RejectsOversizedImages(t *testing.T) {
 }
 
 // TestChatFileResolver_MultiFileFailsFastOnFirstOversized pins the
-// current "first bad file aborts the batch" contract. If this is
-// ever changed to collect all violations, this test should be
-// updated rather than silently dropped.
+// "first bad file aborts the batch" contract.
 func TestChatFileResolver_MultiFileFailsFastOnFirstOversized(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -210,23 +219,25 @@ func TestChatFileResolver_MultiFileFailsFastOnFirstOversized(t *testing.T) {
 	server := &Server{db: db}
 
 	anthropicCap := inlineImageCapFor(t, "anthropic")
+	// Shared buffer; ok files take small prefixes.
+	buf := make([]byte, anthropicCap+1)
 	okFileA := database.ChatFile{
 		ID:       uuid.New(),
 		Name:     "ok-a.png",
 		Mimetype: "image/png",
-		Data:     bytes.Repeat([]byte{0x00}, 1024),
+		Data:     buf[:1024],
 	}
 	oversized := database.ChatFile{
 		ID:       uuid.New(),
 		Name:     "too-big.png",
 		Mimetype: "image/png",
-		Data:     bytes.Repeat([]byte{0x00}, anthropicCap+1),
+		Data:     buf,
 	}
 	okFileB := database.ChatFile{
 		ID:       uuid.New(),
 		Name:     "ok-b.png",
 		Mimetype: "image/png",
-		Data:     bytes.Repeat([]byte{0x00}, 1024),
+		Data:     buf[:1024],
 	}
 	ids := []uuid.UUID{okFileA.ID, oversized.ID, okFileB.ID}
 
@@ -240,7 +251,7 @@ func TestChatFileResolver_MultiFileFailsFastOnFirstOversized(t *testing.T) {
 	require.Error(t, err)
 	require.Nil(t, got)
 	classified := chaterror.Classify(err)
-	require.Equal(t, chaterror.KindConfig, classified.Kind)
+	require.Equal(t, codersdk.ChatErrorKindConfig, classified.Kind)
 	// The error must identify the specific offending file so a user
 	// with several attachments knows which one to replace.
 	require.Contains(t, err.Error(), oversized.Name)
@@ -280,13 +291,15 @@ func TestChatFileResolver_UnknownProviderSkipsCapCheck(t *testing.T) {
 	server := &Server{db: db}
 
 	fileID := uuid.New()
+	// Exactly 1 byte above the Anthropic cap is enough to prove
+	// the backstop is skipped for uncapped providers; no need to
+	// allocate tens of MiB in CI.
+	overAnyCap := inlineImageCapFor(t, "anthropic") + 1
 	row := database.ChatFile{
 		ID:       fileID,
 		Name:     "huge.png",
 		Mimetype: "image/png",
-		// Well above every documented cap; but without a matching
-		// provider the backstop must not fire.
-		Data: bytes.Repeat([]byte{0x00}, 50*1024*1024),
+		Data:     make([]byte, overAnyCap),
 	}
 	db.EXPECT().
 		GetChatFilesByIDs(gomock.Any(), []uuid.UUID{fileID}).

--- a/coderd/x/chatd/chatfile_internal_test.go
+++ b/coderd/x/chatd/chatfile_internal_test.go
@@ -1,0 +1,153 @@
+package chatd
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbmock"
+	"github.com/coder/coder/v2/coderd/x/chatd/chaterror"
+)
+
+// TestChatFileResolver_RejectsOversizedAnthropicImages verifies the
+// server-side safety net: even if an oversized image slips past the
+// browser's resize step, chatFileResolver refuses to forward it to
+// Anthropic. This prevents sending a request that Anthropic will
+// reject for exceeding its 5 MiB inline-image cap.
+func TestChatFileResolver_RejectsOversizedAnthropicImages(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		provider     string
+		mimetype     string
+		size         int
+		expectReject bool
+	}{
+		{
+			name:         "OversizedAnthropicPNG_Rejected",
+			provider:     "anthropic",
+			mimetype:     "image/png",
+			size:         anthropicMaxInlineImageBytes + 1,
+			expectReject: true,
+		},
+		{
+			name:         "OversizedAnthropicJPEG_Rejected",
+			provider:     "anthropic",
+			mimetype:     "image/jpeg",
+			size:         anthropicMaxInlineImageBytes + 1024,
+			expectReject: true,
+		},
+		{
+			name:         "AtLimitAnthropicImage_Accepted",
+			provider:     "anthropic",
+			mimetype:     "image/png",
+			size:         anthropicMaxInlineImageBytes,
+			expectReject: false,
+		},
+		{
+			name:         "UndersizedAnthropicImage_Accepted",
+			provider:     "anthropic",
+			mimetype:     "image/png",
+			size:         1024,
+			expectReject: false,
+		},
+		{
+			name:         "OversizedOpenAIImage_Accepted",
+			provider:     "openai",
+			mimetype:     "image/png",
+			size:         anthropicMaxInlineImageBytes + 1,
+			expectReject: false,
+		},
+		{
+			name:         "OversizedAnthropicText_Accepted",
+			provider:     "anthropic",
+			mimetype:     "text/plain",
+			size:         anthropicMaxInlineImageBytes + 1,
+			expectReject: false,
+		},
+		{
+			name:         "ProviderCaseInsensitive_Rejected",
+			provider:     "Anthropic",
+			mimetype:     "image/png",
+			size:         anthropicMaxInlineImageBytes + 1,
+			expectReject: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+
+			ctrl := gomock.NewController(t)
+			db := dbmock.NewMockStore(ctrl)
+			server := &Server{db: db}
+
+			fileID := uuid.New()
+			row := database.ChatFile{
+				ID:       fileID,
+				Name:     "attachment.png",
+				Mimetype: tc.mimetype,
+				Data:     bytes.Repeat([]byte{0x00}, tc.size),
+			}
+			db.EXPECT().
+				GetChatFilesByIDs(gomock.Any(), []uuid.UUID{fileID}).
+				Return([]database.ChatFile{row}, nil).
+				Times(1)
+
+			resolver := server.chatFileResolver(tc.provider)
+			got, err := resolver(ctx, []uuid.UUID{fileID})
+
+			if tc.expectReject {
+				require.Error(t, err)
+				require.Nil(t, got)
+				// The error must carry a pre-built classification so
+				// the user sees an actionable message instead of a
+				// generic provider failure.
+				classified := chaterror.Classify(err)
+				require.Equal(t, chaterror.KindConfig, classified.Kind)
+				require.Equal(t, "anthropic", classified.Provider)
+				require.False(t, classified.Retryable)
+				require.Contains(t, strings.ToLower(classified.Message), "anthropic")
+				require.Contains(t, classified.Message, "5242880")
+				return
+			}
+			require.NoError(t, err)
+			require.Contains(t, got, fileID)
+			require.Equal(t, row.Data, got[fileID].Data)
+			require.Equal(t, tc.mimetype, got[fileID].MediaType)
+		})
+	}
+}
+
+// TestChatFileResolver_PropagatesDBError confirms unrelated database
+// failures pass through unchanged (not masked by the Anthropic check).
+func TestChatFileResolver_PropagatesDBError(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+	server := &Server{db: db}
+
+	sentinel := xerrors.New("boom")
+	fileID := uuid.New()
+	db.EXPECT().
+		GetChatFilesByIDs(gomock.Any(), []uuid.UUID{fileID}).
+		Return(nil, sentinel).
+		Times(1)
+
+	resolver := server.chatFileResolver("anthropic")
+	got, err := resolver(ctx, []uuid.UUID{fileID})
+	require.ErrorIs(t, err, sentinel)
+	require.Nil(t, got)
+}

--- a/coderd/x/chatd/chatprovider/chatprovider.go
+++ b/coderd/x/chatd/chatprovider/chatprovider.go
@@ -83,24 +83,14 @@ func ProviderAllowsAmbientCredentials(provider string) bool {
 	return NormalizeProvider(provider) == fantasybedrock.Name
 }
 
-// anthropicInlineImageByteCap is Anthropic's documented 5 MiB
-// per-inline-image limit. Kept in sync with ANTHROPIC_IMAGE_BUDGET_BYTES
-// in site/src/pages/AgentsPage/hooks/useFileAttachments.ts.
-const anthropicInlineImageByteCap = 5 * 1024 * 1024
-
-// InlineImageByteCap returns the per-image byte cap that the given
-// provider's upstream API will accept for inline image parts, or
-// (0, false) when no documented cap applies.
-//
-// Bedrock is treated identically to Anthropic because fantasy's
-// bedrock provider is a thin wrapper around the anthropic client
-// (providers/bedrock/bedrock.go calls anthropic.New with
-// anthropic.WithBedrock()) and inherits the same Messages-format
-// per-part inline-image cap.
-func InlineImageByteCap(provider string) (int, bool) {
+// InlineImageCapBytes returns the per-image byte cap for inline
+// image parts, or (0, false) when no documented cap applies.
+// Bedrock shares Anthropic's cap because fantasy's bedrock provider
+// wraps the anthropic client.
+func InlineImageCapBytes(provider string) (int, bool) {
 	switch NormalizeProvider(provider) {
 	case fantasyanthropic.Name, fantasybedrock.Name:
-		return anthropicInlineImageByteCap, true
+		return codersdk.AnthropicInlineImageCapBytes, true
 	default:
 		return 0, false
 	}

--- a/coderd/x/chatd/chatprovider/chatprovider.go
+++ b/coderd/x/chatd/chatprovider/chatprovider.go
@@ -83,6 +83,29 @@ func ProviderAllowsAmbientCredentials(provider string) bool {
 	return NormalizeProvider(provider) == fantasybedrock.Name
 }
 
+// anthropicInlineImageByteCap is Anthropic's documented 5 MiB
+// per-inline-image limit. Kept in sync with ANTHROPIC_IMAGE_BUDGET_BYTES
+// in site/src/pages/AgentsPage/hooks/useFileAttachments.ts.
+const anthropicInlineImageByteCap = 5 * 1024 * 1024
+
+// InlineImageByteCap returns the per-image byte cap that the given
+// provider's upstream API will accept for inline image parts, or
+// (0, false) when no documented cap applies.
+//
+// Bedrock is treated identically to Anthropic because fantasy's
+// bedrock provider is a thin wrapper around the anthropic client
+// (providers/bedrock/bedrock.go calls anthropic.New with
+// anthropic.WithBedrock()) and inherits the same Messages-format
+// per-part inline-image cap.
+func InlineImageByteCap(provider string) (int, bool) {
+	switch NormalizeProvider(provider) {
+	case fantasyanthropic.Name, fantasybedrock.Name:
+		return anthropicInlineImageByteCap, true
+	default:
+		return 0, false
+	}
+}
+
 // ProviderAPIKeys contains API keys for provider calls.
 type ProviderAPIKeys struct {
 	OpenAI            string

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -33,6 +33,15 @@ const ChatCompactionThresholdKeyPrefix = "chat_compaction_threshold_pct:"
 // this limit than to lower it.
 const MaxChatFileIDs = 20
 
+// MaxChatFileSizeBytes is the upload-endpoint cap for chat
+// attachments.
+const MaxChatFileSizeBytes = 10 * 1024 * 1024
+
+// AnthropicInlineImageCapBytes is Anthropic's documented per-image
+// wire limit; the same cap applies to Bedrock-hosted Claude. Other
+// providers have no documented per-image cap.
+const AnthropicInlineImageCapBytes = 5 * 1024 * 1024
+
 // ChatAttachmentMediaType is a media type that is allowed for durable
 // chat file storage. The set is intentionally narrow; byte-level
 // classification and inline-render rules live alongside the enforcement

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -877,6 +877,14 @@ export const AgentSubsystems: AgentSubsystem[] = [
 	"exectrace",
 ];
 
+// From codersdk/chats.go
+/**
+ * AnthropicInlineImageCapBytes is Anthropic's documented per-image
+ * wire limit; the same cap applies to Bedrock-hosted Claude. Other
+ * providers have no documented per-image cap.
+ */
+export const AnthropicInlineImageCapBytes = 5242880;
+
 // From codersdk/deployment.go
 export interface AppHostResponse {
 	/**
@@ -4776,6 +4784,13 @@ export interface MatchedProvisioners {
  * this limit than to lower it.
  */
 export const MaxChatFileIDs = 20;
+
+// From codersdk/chats.go
+/**
+ * MaxChatFileSizeBytes is the upload-endpoint cap for chat
+ * attachments.
+ */
+export const MaxChatFileSizeBytes = 10485760;
 
 // From codersdk/usersecretvalidation.go
 /**

--- a/site/src/pages/AgentsPage/AgentsPage.test.ts
+++ b/site/src/pages/AgentsPage/AgentsPage.test.ts
@@ -605,3 +605,283 @@ describe("useFileAttachments persistence", () => {
 		unmount();
 	});
 });
+
+// Synthetic resize swaps the File without invoking the browser's
+// decoder, so these tests run in jsdom without resizeImage.ts fakes.
+describe("useFileAttachments processResizes", () => {
+	beforeEach(() => {
+		localStorage.clear();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	// Reported size > budget without actually allocating bytes.
+	const makeOversizeImage = (
+		name = "photo.png",
+		type = "image/png",
+		bytes = 6 * 1024 * 1024,
+	) => {
+		const file = new File([new Uint8Array(8)], name, { type });
+		Object.defineProperty(file, "size", { value: bytes });
+		return file;
+	};
+
+	it("marks oversize images as processing synchronously on attach", async () => {
+		const resize = await import("./utils/resizeImage");
+		// Never-resolving resize so "processing" stays observable.
+		vi.spyOn(resize, "resizeImageToMaxBytes").mockImplementation(
+			() => new Promise(() => undefined),
+		);
+
+		const { result, unmount } = renderHook(() =>
+			useFileAttachments("org-1", { provider: "anthropic" }),
+		);
+
+		const file = makeOversizeImage();
+
+		act(() => {
+			result.current.handleAttach([file]);
+		});
+
+		expect(result.current.attachments).toHaveLength(1);
+		expect(result.current.attachments[0]).toBe(file);
+		const state = result.current.uploadStates.get(file);
+		expect(state?.status).toBe("processing");
+		unmount();
+	});
+
+	it("swaps the original File for the resized replacement when resize succeeds", async () => {
+		const resize = await import("./utils/resizeImage");
+		const { API } = await import("#/api/api");
+		const replacement = new File([new Uint8Array(1024)], "photo.webp", {
+			type: "image/webp",
+		});
+		vi.spyOn(resize, "resizeImageToMaxBytes").mockResolvedValue(replacement);
+		vi.spyOn(API.experimental, "uploadChatFile").mockResolvedValue({
+			id: "file-id",
+		});
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response());
+
+		const { result, unmount } = renderHook(() =>
+			useFileAttachments("org-1", { provider: "anthropic" }),
+		);
+
+		const original = makeOversizeImage();
+
+		act(() => {
+			result.current.handleAttach([original]);
+		});
+
+		await vi.waitFor(() => {
+			expect(result.current.attachments[0]).toBe(replacement);
+		});
+
+		await vi.waitFor(() => {
+			expect(result.current.uploadStates.get(replacement)?.status).toBe(
+				"uploaded",
+			);
+		});
+		expect(result.current.uploadStates.get(original)).toBeUndefined();
+		unmount();
+	});
+
+	it("falls back to the original File when resize returns null", async () => {
+		const resize = await import("./utils/resizeImage");
+		const { API } = await import("#/api/api");
+		vi.spyOn(resize, "resizeImageToMaxBytes").mockResolvedValue(null);
+		vi.spyOn(API.experimental, "uploadChatFile").mockResolvedValue({
+			id: "file-id",
+		});
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response());
+
+		// 6 MiB on Anthropic + null resize forces the
+		// provider-budget-error path.
+		const { result, unmount } = renderHook(() =>
+			useFileAttachments("org-1", { provider: "anthropic" }),
+		);
+
+		const original = makeOversizeImage(
+			"photo.png",
+			"image/png",
+			6 * 1024 * 1024,
+		);
+
+		act(() => {
+			result.current.handleAttach([original]);
+		});
+
+		await vi.waitFor(() => {
+			const state = result.current.uploadStates.get(original);
+			expect(state?.status).toBe("error");
+			expect(state?.error).toMatch(/Anthropic/);
+			expect(state?.error).toMatch(/MiB/);
+		});
+		unmount();
+	});
+
+	it("freezes the provider snapshot at attach time so a mid-resize provider switch can't mislabel the error", async () => {
+		const resize = await import("./utils/resizeImage");
+		let releaseResize: (value: File | null) => void = () => undefined;
+		vi.spyOn(resize, "resizeImageToMaxBytes").mockImplementation(
+			() =>
+				new Promise<File | null>((resolve) => {
+					releaseResize = resolve;
+				}),
+		);
+
+		const { result, rerender, unmount } = renderHook(
+			({ provider }) => useFileAttachments("org-1", { provider }),
+			{ initialProps: { provider: "anthropic" } },
+		);
+
+		// Attach on Anthropic (5 MiB budget).
+		const original = makeOversizeImage(
+			"photo.gif",
+			"image/gif",
+			6 * 1024 * 1024,
+		);
+		act(() => {
+			result.current.handleAttach([original]);
+		});
+
+		// User switches to OpenAI (10 MiB budget) before the
+		// resize finishes. providerRef.current is now "openai".
+		rerender({ provider: "openai" });
+
+		// Resize gives up (animated GIF; falls back to original).
+		await act(async () => {
+			releaseResize(null);
+			await Promise.resolve();
+		});
+
+		// Error must name Anthropic (the provider whose budget
+		// rejected the file), not OpenAI (the live ref). The
+		// budget value in the error must match Anthropic's
+		// ~5 MiB, not OpenAI's ~10 MiB.
+		await vi.waitFor(() => {
+			const state = result.current.uploadStates.get(original);
+			expect(state?.status).toBe("error");
+			expect(state?.error).toMatch(/Anthropic/);
+			expect(state?.error).not.toMatch(/OpenAI/);
+			expect(state?.error).toMatch(/under 5\.0 MiB/);
+		});
+		unmount();
+	});
+
+	it("does not resurrect attachments removed while resize is in flight", async () => {
+		const resize = await import("./utils/resizeImage");
+		let releaseResize: (value: File | null) => void = () => undefined;
+		vi.spyOn(resize, "resizeImageToMaxBytes").mockImplementation(
+			() =>
+				new Promise<File | null>((resolve) => {
+					releaseResize = resolve;
+				}),
+		);
+
+		const { result, unmount } = renderHook(() =>
+			useFileAttachments("org-1", { provider: "anthropic" }),
+		);
+
+		const original = makeOversizeImage();
+
+		act(() => {
+			result.current.handleAttach([original]);
+		});
+		expect(result.current.attachments).toHaveLength(1);
+
+		// Remove the attachment while resize is still pending.
+		act(() => {
+			result.current.handleRemoveAttachment(original);
+		});
+		expect(result.current.attachments).toHaveLength(0);
+
+		// Resolve the pending resize with a swap; the hook must
+		// NOT resurrect the dismissed attachment.
+		const replacement = new File([new Uint8Array(512)], "photo.webp", {
+			type: "image/webp",
+		});
+		await act(async () => {
+			releaseResize(replacement);
+			await Promise.resolve();
+		});
+
+		expect(result.current.attachments).toHaveLength(0);
+		expect(result.current.uploadStates.get(replacement)).toBeUndefined();
+		unmount();
+	});
+
+	it("does not resurrect attachments after resetAttachments fires", async () => {
+		const resize = await import("./utils/resizeImage");
+		let releaseResize: (value: File | null) => void = () => undefined;
+		vi.spyOn(resize, "resizeImageToMaxBytes").mockImplementation(
+			() =>
+				new Promise<File | null>((resolve) => {
+					releaseResize = resolve;
+				}),
+		);
+
+		const { result, unmount } = renderHook(() =>
+			useFileAttachments("org-1", { provider: "anthropic" }),
+		);
+
+		const original = makeOversizeImage();
+
+		act(() => {
+			result.current.handleAttach([original]);
+		});
+		expect(result.current.attachments).toHaveLength(1);
+
+		// Simulate a chat-scope reset (e.g. ChatPageContent's
+		// editScopeRef effect when navigating between chats)
+		// while the resize is still pending.
+		act(() => {
+			result.current.resetAttachments();
+		});
+		expect(result.current.attachments).toHaveLength(0);
+
+		// Resolve the pending resize with a swap. The hook must
+		// not re-add the replacement to attachments or kick off
+		// an upload against the now-cleared scope.
+		const replacement = new File([new Uint8Array(512)], "photo.webp", {
+			type: "image/webp",
+		});
+		await act(async () => {
+			releaseResize(replacement);
+			await Promise.resolve();
+		});
+
+		expect(result.current.attachments).toHaveLength(0);
+		expect(result.current.uploadStates.get(replacement)).toBeUndefined();
+		expect(result.current.uploadStates.get(original)).toBeUndefined();
+		unmount();
+	});
+
+	it("gates the send-reachable isUploading state on processing", () => {
+		const resize = import("./utils/resizeImage");
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response());
+		// Never-resolving resize keeps the attachment in "processing".
+		void resize.then((m) =>
+			vi
+				.spyOn(m, "resizeImageToMaxBytes")
+				.mockImplementation(() => new Promise(() => undefined)),
+		);
+
+		const { result, unmount } = renderHook(() =>
+			useFileAttachments("org-1", { provider: "anthropic" }),
+		);
+
+		const file = makeOversizeImage();
+
+		act(() => {
+			result.current.handleAttach([file]);
+		});
+
+		// Upload state must be "processing" (not "uploaded" or
+		// undefined). The AgentChatInput send gate treats this the
+		// same as "uploading" and blocks dispatch.
+		expect(result.current.uploadStates.get(file)?.status).toBe("processing");
+		unmount();
+	});
+});

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -819,7 +819,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 				{/* Warn about invisible Unicode in the message text.
 				 * Unlike the admin/user prompt textareas (which strip
 				 * invisible chars server-side on save), the chat input
-				 * is the user's free-form message — we don't silently
+				 * is the user's free-form message; we don't silently
 				 * mutate it. Instead we surface a warning so the user
 				 * can make an informed decision. This guards against
 				 * social engineering attacks where a user is tricked
@@ -1074,7 +1074,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 								)}
 							</span>
 						)}{" "}
-						{/* Badge row — all badges and the pill always
+						{/* Badge row; all badges and the pill always
 						 * render so the DOM structure never changes.
 						 * Overflow badges use invisible + order-1 to
 						 * hide and reorder via CSS. The pill is invisible
@@ -1107,7 +1107,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 									/>
 								);
 							})}
-							{/* Pill — always in the DOM so it permanently
+							{/* Pill; always in the DOM so it permanently
 							 * reserves layout space. Invisible when nothing
 							 * overflows. CSS order keeps it before order-1
 							 * (overflow) badges. */}

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -22,6 +22,7 @@ import { useFileAttachments } from "../hooks/useFileAttachments";
 import { parseStoredDraft } from "../utils/draftStorage";
 import {
 	getModelSelectorPlaceholder,
+	getProviderForModelOption,
 	hasConfiguredModelsInCatalog,
 	hasUserFixableProviders,
 } from "../utils/modelOptions";
@@ -384,9 +385,7 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		resetAttachments,
 	} = useFileAttachments(organizationId || undefined, {
 		persist: true,
-		// Provider is read in a ref by the hook so resizing tracks
-		// the latest model selection without re-subscribing.
-		provider: modelOptions.find((o) => o.id === selectedModel)?.provider,
+		provider: getProviderForModelOption(modelOptions, selectedModel),
 	});
 
 	const handleSendWithAttachments = async (message: string) => {

--- a/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
+++ b/site/src/pages/AgentsPage/components/AgentCreateForm.tsx
@@ -382,7 +382,12 @@ export const AgentCreateForm: FC<AgentCreateFormProps> = ({
 		handleAttach,
 		handleRemoveAttachment,
 		resetAttachments,
-	} = useFileAttachments(organizationId || undefined, { persist: true });
+	} = useFileAttachments(organizationId || undefined, {
+		persist: true,
+		// Provider is read in a ref by the hook so resizing tracks
+		// the latest model selection without re-subscribing.
+		provider: modelOptions.find((o) => o.id === selectedModel)?.provider,
+	});
 
 	const handleSendWithAttachments = async (message: string) => {
 		const fileIds: string[] = [];

--- a/site/src/pages/AgentsPage/components/AttachmentPreview.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AttachmentPreview.stories.tsx
@@ -153,7 +153,7 @@ export const FileTooLarge: Story = {
 					file,
 					{
 						status: "error",
-						error: "File too large (12.4 MB). Maximum is 10 MB.",
+						error: "File too large (12.4 MiB). Maximum is 10 MiB.",
 					},
 				],
 			]),

--- a/site/src/pages/AgentsPage/components/AttachmentPreview.tsx
+++ b/site/src/pages/AgentsPage/components/AttachmentPreview.tsx
@@ -17,14 +17,19 @@ import {
 } from "../utils/fetchTextAttachment";
 
 export type UploadState = {
-	status: "pending" | "uploading" | "uploaded" | "error";
+	// "processing" covers any pre-upload client work (e.g. resize),
+	// so paste/drop handlers can commit the attachment synchronously
+	// without the send gate believing it is ready to dispatch.
+	status: "pending" | "processing" | "uploading" | "uploaded" | "error";
 	fileId?: string;
 	error?: string;
 	draftWarning?: string;
 };
 
 export const isUploadInProgress = (state: UploadState | undefined): boolean =>
-	state?.status === "pending" || state?.status === "uploading";
+	state?.status === "pending" ||
+	state?.status === "processing" ||
+	state?.status === "uploading";
 
 /** Renders an image thumbnail from a pre-created preview URL. */
 export const ImageThumbnail: FC<{
@@ -194,6 +199,7 @@ export const AttachmentPreview: FC<{
 								</button>
 							)}
 							{(uploadState?.status === "pending" ||
+								uploadState?.status === "processing" ||
 								uploadState?.status === "uploading") && (
 								<div className="absolute inset-0 flex items-center justify-center rounded-md bg-overlay">
 									<Spinner className="h-5 w-5 text-white" loading />

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -306,7 +306,9 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 	const latestContextUsage = rawUsage
 		? { ...rawUsage, compressionThreshold, lastInjectedContext }
 		: rawUsage;
-	const composeAttachments = useChatDraftAttachments(organizationId, chatId);
+	const composeAttachments = useChatDraftAttachments(organizationId, chatId, {
+		provider: getProviderForModelOption(modelOptions, selectedModel),
+	});
 	const editAttachments = useFileAttachments(organizationId, {
 		provider: getProviderForModelOption(modelOptions, selectedModel),
 	});

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -306,7 +306,11 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 		? { ...rawUsage, compressionThreshold, lastInjectedContext }
 		: rawUsage;
 	const composeAttachments = useChatDraftAttachments(organizationId, chatId);
-	const editAttachments = useFileAttachments(organizationId);
+	const editAttachments = useFileAttachments(organizationId, {
+		// Provider is read in a ref by the hook so resizing tracks
+		// the latest model selection without re-subscribing.
+		provider: modelOptions.find((o) => o.id === selectedModel)?.provider,
+	});
 	const {
 		setAttachments: setEditAttachments,
 		setPreviewUrls: setEditPreviewUrls,

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -7,6 +7,7 @@ import { useChatDraftAttachments } from "../hooks/useChatDraftAttachments";
 import { chatWidthClass, useChatFullWidth } from "../hooks/useChatFullWidth";
 import { useFileAttachments } from "../hooks/useFileAttachments";
 import { getChatFileURL } from "../utils/chatAttachments";
+import { getProviderForModelOption } from "../utils/modelOptions";
 import type { ChatDetailError } from "../utils/usageLimitMessage";
 import {
 	AgentChatInput,
@@ -307,9 +308,7 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 		: rawUsage;
 	const composeAttachments = useChatDraftAttachments(organizationId, chatId);
 	const editAttachments = useFileAttachments(organizationId, {
-		// Provider is read in a ref by the hook so resizing tracks
-		// the latest model selection without re-subscribing.
-		provider: modelOptions.find((o) => o.id === selectedModel)?.provider,
+		provider: getProviderForModelOption(modelOptions, selectedModel),
 	});
 	const {
 		setAttachments: setEditAttachments,

--- a/site/src/pages/AgentsPage/hooks/useChatDraftAttachments.test.ts
+++ b/site/src/pages/AgentsPage/hooks/useChatDraftAttachments.test.ts
@@ -370,7 +370,7 @@ describe("useChatDraftAttachments", () => {
 		expect(result.current.attachments).toHaveLength(1);
 		expect(result.current.uploadStates.get(file)).toMatchObject({
 			status: "error",
-			error: expect.stringContaining("Maximum is 10 MB"),
+			error: expect.stringContaining("Maximum is 10 MiB"),
 		});
 		expect(localStorage.getItem(storageKey)).toBeNull();
 		unmount();
@@ -522,5 +522,292 @@ describe("useChatDraftAttachments", () => {
 		expect(stored).toHaveLength(1);
 		expect(stored[0].clientId).toBe("good");
 		unmount();
+	});
+
+	describe("compose-path resize", () => {
+		const makeOversizeImage = () =>
+			new File([new Uint8Array(5 * 1024 * 1024 + 64 * 1024)], "photo.png", {
+				type: "image/png",
+				lastModified: 100,
+			});
+
+		it("commits the original synchronously with status: processing while resize is in flight", async () => {
+			const resize = await import("../utils/resizeImage");
+			vi.spyOn(resize, "resizeImageToMaxBytes").mockImplementation(
+				() => new Promise<File | null>(() => undefined),
+			);
+			const uploadSpy = vi.spyOn(API.experimental, "uploadChatFile");
+
+			const { result, unmount } = renderHook(() =>
+				useChatDraftAttachments(orgID, chatID, { provider: "anthropic" }),
+			);
+			const original = makeOversizeImage();
+
+			act(() => {
+				result.current.handleAttach([original]);
+			});
+
+			expect(result.current.attachments).toHaveLength(1);
+			expect(result.current.attachments[0]).toBe(original);
+			expect(result.current.uploadStates.get(original)).toMatchObject({
+				status: "processing",
+			});
+			// Registry entry is created post-resize.
+			expect(uploadSpy).not.toHaveBeenCalled();
+			expect(localStorage.getItem(storageKey)).toBeNull();
+			unmount();
+		});
+
+		it("swaps the original for a smaller resized File and starts the upload", async () => {
+			const upload = createDeferred<{ id: string }>();
+			const uploadSpy = vi
+				.spyOn(API.experimental, "uploadChatFile")
+				.mockReturnValue(upload.promise);
+			const resize = await import("../utils/resizeImage");
+			const replacement = new File(
+				[new Uint8Array(2 * 1024 * 1024)],
+				"photo.webp",
+				{ type: "image/webp", lastModified: 200 },
+			);
+			let releaseResize: (value: File | null) => void = () => undefined;
+			vi.spyOn(resize, "resizeImageToMaxBytes").mockImplementation(
+				() =>
+					new Promise<File | null>((resolveFn) => {
+						releaseResize = resolveFn;
+					}),
+			);
+
+			const { result, unmount } = renderHook(() =>
+				useChatDraftAttachments(orgID, chatID, { provider: "anthropic" }),
+			);
+			const original = makeOversizeImage();
+
+			act(() => {
+				result.current.handleAttach([original]);
+			});
+			expect(result.current.uploadStates.get(original)?.status).toBe(
+				"processing",
+			);
+
+			await act(async () => {
+				releaseResize(replacement);
+				await Promise.resolve();
+			});
+
+			await vi.waitFor(() => {
+				expect(result.current.attachments).toHaveLength(1);
+				expect(result.current.attachments[0]).toBe(replacement);
+			});
+			expect(result.current.uploadStates.get(original)).toBeUndefined();
+			expect(uploadSpy).toHaveBeenCalledTimes(1);
+			expect(uploadSpy).toHaveBeenCalledWith(replacement, orgID);
+
+			await act(async () => {
+				upload.resolve({ id: "file-resized" });
+			});
+			await vi.waitFor(() => {
+				expect(result.current.uploadStates.get(replacement)).toMatchObject({
+					status: "uploaded",
+					fileId: "file-resized",
+				});
+			});
+			unmount();
+		});
+
+		it("falls back to the original and surfaces a provider-budget error when resize returns null on Anthropic", async () => {
+			const uploadSpy = vi.spyOn(API.experimental, "uploadChatFile");
+			const resize = await import("../utils/resizeImage");
+			vi.spyOn(resize, "resizeImageToMaxBytes").mockResolvedValue(null);
+
+			const { result, unmount } = renderHook(() =>
+				useChatDraftAttachments(orgID, chatID, { provider: "anthropic" }),
+			);
+			const original = makeOversizeImage();
+
+			act(() => {
+				result.current.handleAttach([original]);
+			});
+			await vi.waitFor(() => {
+				const state = result.current.uploadStates.get(original);
+				expect(state?.status).toBe("error");
+				expect(state?.error).toMatch(/Anthropic/);
+				expect(state?.error).toMatch(/MiB/);
+			});
+
+			expect(uploadSpy).not.toHaveBeenCalled();
+			expect(localStorage.getItem(storageKey)).toBeNull();
+			unmount();
+		});
+
+		it("does not resurrect attachments removed while resize is in flight", async () => {
+			const uploadSpy = vi.spyOn(API.experimental, "uploadChatFile");
+			const resize = await import("../utils/resizeImage");
+			let releaseResize: (value: File | null) => void = () => undefined;
+			vi.spyOn(resize, "resizeImageToMaxBytes").mockImplementation(
+				() =>
+					new Promise<File | null>((resolveFn) => {
+						releaseResize = resolveFn;
+					}),
+			);
+
+			const { result, unmount } = renderHook(() =>
+				useChatDraftAttachments(orgID, chatID, { provider: "anthropic" }),
+			);
+			const original = makeOversizeImage();
+
+			act(() => {
+				result.current.handleAttach([original]);
+			});
+			expect(result.current.attachments).toHaveLength(1);
+
+			act(() => {
+				result.current.handleRemoveAttachment(original);
+			});
+			expect(result.current.attachments).toHaveLength(0);
+
+			const replacement = new File(
+				[new Uint8Array(1 * 1024 * 1024)],
+				"photo.webp",
+				{ type: "image/webp" },
+			);
+			await act(async () => {
+				releaseResize(replacement);
+				await Promise.resolve();
+			});
+
+			expect(result.current.attachments).toHaveLength(0);
+			expect(uploadSpy).not.toHaveBeenCalled();
+			expect(localStorage.getItem(storageKey)).toBeNull();
+			unmount();
+		});
+
+		it("does not resurrect attachments after resetAttachments fires", async () => {
+			const uploadSpy = vi.spyOn(API.experimental, "uploadChatFile");
+			const resize = await import("../utils/resizeImage");
+			let releaseResize: (value: File | null) => void = () => undefined;
+			vi.spyOn(resize, "resizeImageToMaxBytes").mockImplementation(
+				() =>
+					new Promise<File | null>((resolveFn) => {
+						releaseResize = resolveFn;
+					}),
+			);
+
+			const { result, unmount } = renderHook(() =>
+				useChatDraftAttachments(orgID, chatID, { provider: "anthropic" }),
+			);
+			const original = makeOversizeImage();
+
+			act(() => {
+				result.current.handleAttach([original]);
+			});
+			expect(result.current.attachments).toHaveLength(1);
+
+			act(() => {
+				result.current.resetAttachments();
+			});
+			expect(result.current.attachments).toHaveLength(0);
+
+			const replacement = new File(
+				[new Uint8Array(1 * 1024 * 1024)],
+				"photo.webp",
+				{ type: "image/webp" },
+			);
+			await act(async () => {
+				releaseResize(replacement);
+				await Promise.resolve();
+			});
+
+			expect(result.current.attachments).toHaveLength(0);
+			expect(uploadSpy).not.toHaveBeenCalled();
+			expect(localStorage.getItem(storageKey)).toBeNull();
+			unmount();
+		});
+
+		it("freezes the provider snapshot at attach time so a mid-resize provider switch can't mislabel the error", async () => {
+			const resize = await import("../utils/resizeImage");
+			let releaseResize: (value: File | null) => void = () => undefined;
+			vi.spyOn(resize, "resizeImageToMaxBytes").mockImplementation(
+				() =>
+					new Promise<File | null>((resolveFn) => {
+						releaseResize = resolveFn;
+					}),
+			);
+
+			const { result, rerender, unmount } = renderHook(
+				({ provider }) => useChatDraftAttachments(orgID, chatID, { provider }),
+				{ initialProps: { provider: "anthropic" } },
+			);
+
+			// Over Anthropic's 5 MiB but under OpenAI's 10 MiB.
+			const gif = new File([new Uint8Array(8)], "animated.gif", {
+				type: "image/gif",
+				lastModified: 400,
+			});
+			Object.defineProperty(gif, "size", { value: 6 * 1024 * 1024 });
+
+			act(() => {
+				result.current.handleAttach([gif]);
+			});
+
+			rerender({ provider: "openai" });
+
+			await act(async () => {
+				releaseResize(null);
+				await Promise.resolve();
+			});
+
+			// Error must name the provider whose budget rejected
+			// the file at attach time, not the live provider.
+			await vi.waitFor(() => {
+				const state = result.current.uploadStates.get(gif);
+				expect(state?.status).toBe("error");
+				expect(state?.error).toMatch(/Anthropic/);
+				expect(state?.error).not.toMatch(/OpenAI/);
+				expect(state?.error).toMatch(/under 5\.0 MiB/);
+			});
+			unmount();
+		});
+
+		it("uses the default 10 MiB budget for non-Anthropic providers (no resize for sub-10MiB images)", async () => {
+			const upload = createDeferred<{ id: string }>();
+			const uploadSpy = vi
+				.spyOn(API.experimental, "uploadChatFile")
+				.mockReturnValue(upload.promise);
+			const resize = await import("../utils/resizeImage");
+			const resizeSpy = vi
+				.spyOn(resize, "resizeImageToMaxBytes")
+				.mockResolvedValue(null);
+
+			const { result, unmount } = renderHook(() =>
+				useChatDraftAttachments(orgID, chatID, { provider: "openai" }),
+			);
+			// 7 MiB: over Anthropic's 5 MiB but under the default
+			// 10 MiB. OpenAI uploads directly without resize.
+			const file = new File([new Uint8Array(7 * 1024 * 1024)], "medium.png", {
+				type: "image/png",
+				lastModified: 300,
+			});
+
+			act(() => {
+				result.current.handleAttach([file]);
+			});
+
+			expect(resizeSpy).not.toHaveBeenCalled();
+			await vi.waitFor(() => {
+				expect(uploadSpy).toHaveBeenCalledTimes(1);
+				expect(uploadSpy).toHaveBeenCalledWith(file, orgID);
+			});
+
+			await act(async () => {
+				upload.resolve({ id: "file-direct" });
+			});
+			await vi.waitFor(() => {
+				expect(result.current.uploadStates.get(file)).toMatchObject({
+					status: "uploaded",
+					fileId: "file-direct",
+				});
+			});
+			unmount();
+		});
 	});
 });

--- a/site/src/pages/AgentsPage/hooks/useChatDraftAttachments.ts
+++ b/site/src/pages/AgentsPage/hooks/useChatDraftAttachments.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { API } from "#/api/api";
+import { MaxChatFileSizeBytes } from "#/api/typesGenerated";
 import type { UploadState } from "../components/AgentChatInput";
 import { getChatFileURL } from "../utils/chatAttachments";
 import {
@@ -13,9 +14,14 @@ import {
 import {
 	formatAgentAttachmentTooLargeError,
 	formatAgentAttachmentUploadError,
-	maxAgentAttachmentSize,
 	readAgentAttachmentText,
 } from "../utils/fileAttachmentLimits";
+import {
+	imageBudgetForProvider,
+	imageNeedsResize,
+	providerBudgetError,
+} from "../utils/imageBudget";
+import { resizeImageToMaxBytes } from "../utils/resizeImage";
 
 const maxTextPreviewSize = 1024 * 1024;
 
@@ -486,6 +492,7 @@ const queueTextContentReads = (
 export function useChatDraftAttachments(
 	organizationId: string | undefined,
 	chatId: string | undefined,
+	options?: { provider?: string },
 ) {
 	const [views, setViews] = useState(() =>
 		hydrateViews(organizationId, chatId),
@@ -493,6 +500,18 @@ export function useChatDraftAttachments(
 	const viewsRef = useRef(views);
 	const subscriptionsRef = useRef(new Map<string, () => void>());
 	const scopeRef = useRef(getDraftScopeKey(organizationId, chatId));
+	// providerRef lets event-driven handlers (paste/drop) see the
+	// latest model selection without rebuilding handleAttach. The
+	// effect-based write keeps React Compiler happy.
+	const provider = options?.provider;
+	const providerRef = useRef(provider);
+	useEffect(() => {
+		providerRef.current = provider;
+	}, [provider]);
+	// clientIds whose resize is in flight but the user removed the
+	// attachment (or the chat scope changed). processResize checks
+	// this before swapping in a replacement.
+	const abandonedResizesRef = useRef<Set<string>>(new Set());
 	const [subscriber] = useState<UploadRegistrySubscriber>(
 		() =>
 			function handleUploadRegistrySnapshot(snapshot: UploadRegistrySnapshot) {
@@ -518,6 +537,11 @@ export function useChatDraftAttachments(
 		const scopeKey = getDraftScopeKey(organizationId, chatId);
 		scopeRef.current = scopeKey;
 		unsubscribeAllEntries(subscriptionsRef);
+		// Abandon in-flight resizes from the previous scope so
+		// their callbacks don't register uploads in the new scope.
+		for (const view of viewsRef.current) {
+			abandonedResizesRef.current.add(view.clientId);
+		}
 		if (!organizationId || !chatId || !scopeKey) {
 			setViews([]);
 			return;
@@ -560,9 +584,145 @@ export function useChatDraftAttachments(
 		}
 	}, [organizationId, chatId, subscriber]);
 
+	// The view enters in "processing" status from handleAttach;
+	// processResize either swaps in the smaller file and registers
+	// the upload, or surfaces a too-large error.
+	const processResize = async (
+		clientId: string,
+		original: File,
+		budget: number,
+		// Pinned at attach time so a mid-resize provider switch
+		// can't mislabel the error with the new provider's name.
+		providerSnapshot: string | undefined,
+	) => {
+		let resized: File | null = null;
+		try {
+			resized = await resizeImageToMaxBytes(original, budget);
+		} catch {
+			resized = null;
+		}
+
+		if (abandonedResizesRef.current.has(clientId)) {
+			return;
+		}
+		if (!organizationId || !chatId) {
+			return;
+		}
+		const scopeKey = getDraftScopeKey(organizationId, chatId);
+		if (!scopeKey || scopeRef.current !== scopeKey) {
+			return;
+		}
+
+		const replacement = resized ?? original;
+		const replaced = replacement !== original;
+
+		// Resize failed entirely or couldn't shrink enough; show
+		// the too-large error instead of uploading and 413-ing.
+		if (replacement.size > MaxChatFileSizeBytes) {
+			setViews((prev) =>
+				prev.map((view) => {
+					if (view.clientId !== clientId) {
+						return view;
+					}
+					if (replaced) {
+						revokeBlobPreview(view);
+					}
+					const previewState = replaced
+						? computePreview(replacement, "error")
+						: {
+								previewUrl: view.previewUrl,
+								previewUrlKind: view.previewUrlKind,
+							};
+					return {
+						...view,
+						file: replacement,
+						status: "error",
+						error: formatAgentAttachmentTooLargeError(replacement.size),
+						previewUrl: previewState.previewUrl,
+						previewUrlKind: previewState.previewUrlKind,
+					};
+				}),
+			);
+			return;
+		}
+
+		// Replacement is still over the provider budget (e.g.
+		// animated GIF on Anthropic that we don't re-encode).
+		// Surface the error at attach time rather than letting
+		// the server backstop reject only at send time.
+		if (replacement.type.startsWith("image/") && replacement.size > budget) {
+			setViews((prev) =>
+				prev.map((view) => {
+					if (view.clientId !== clientId) {
+						return view;
+					}
+					if (replaced) {
+						revokeBlobPreview(view);
+					}
+					const previewState = replaced
+						? computePreview(replacement, "error")
+						: {
+								previewUrl: view.previewUrl,
+								previewUrlKind: view.previewUrlKind,
+							};
+					return {
+						...view,
+						file: replacement,
+						status: "error",
+						error: providerBudgetError(
+							providerSnapshot,
+							replacement.size,
+							budget,
+						),
+						previewUrl: previewState.previewUrl,
+						previewUrlKind: previewState.previewUrlKind,
+					};
+				}),
+			);
+			return;
+		}
+
+		// beginUpload below drives the view from pending to uploading
+		// via subscribers; we set "pending" here so the registry's
+		// initial snapshot doesn't overwrite our blob preview.
+		setViews((prev) =>
+			prev.map((view) => {
+				if (view.clientId !== clientId) {
+					return view;
+				}
+				if (!replaced) {
+					return { ...view, status: "pending" };
+				}
+				revokeBlobPreview(view);
+				const nextPreview = computePreview(replacement, "pending");
+				return {
+					...view,
+					file: replacement,
+					status: "pending",
+					previewUrl: nextPreview.previewUrl,
+					previewUrlKind: nextPreview.previewUrlKind,
+				};
+			}),
+		);
+
+		const entry = createRegistryEntry(
+			clientId,
+			organizationId,
+			chatId,
+			replacement,
+		);
+		subscribeToEntry(entry, subscriptionsRef, subscriber);
+		beginUpload(entry);
+	};
+
 	const handleAttach = (files: File[]) => {
 		const scopeKey = getDraftScopeKey(organizationId, chatId);
+		// Snapshot provider + budget so a mid-resize switch
+		// can't relabel the error with the new provider.
+		const providerSnapshot = providerRef.current;
+		const budget = imageBudgetForProvider(providerSnapshot);
 		const entriesToStart: UploadRegistryEntry[] = [];
+		const resizeJobs: Array<{ clientId: string; file: File }> = [];
 		const nextViews: DraftAttachmentView[] = [];
 		for (const file of files) {
 			const clientId = createClientId();
@@ -571,7 +731,11 @@ export function useChatDraftAttachments(
 				file,
 				status: "pending",
 			};
-			if (file.size > maxAgentAttachmentSize) {
+			const needsResize = imageNeedsResize(file, budget);
+			// Non-image files over the upload cap are rejected.
+			// Oversized images take the resize pipeline regardless;
+			// the post-resize check validates the result.
+			if (file.size > MaxChatFileSizeBytes && !needsResize) {
 				nextViews.push({
 					...baseView,
 					status: "error",
@@ -585,6 +749,18 @@ export function useChatDraftAttachments(
 					status: "error",
 					error: "Unable to upload: no chat context.",
 				});
+				continue;
+			}
+			if (needsResize) {
+				// Commit synchronously with "processing" so the
+				// send gate blocks dispatch until resize finishes.
+				const view = {
+					...baseView,
+					status: "processing" as const,
+					...computePreview(file, "processing"),
+				};
+				nextViews.push(view);
+				resizeJobs.push({ clientId, file });
 				continue;
 			}
 			const view = { ...baseView, ...computePreview(file, "pending") };
@@ -602,6 +778,11 @@ export function useChatDraftAttachments(
 			setViews,
 			() => scopeRef.current === scopeKey,
 		);
+		// processResize re-checks abandonment + scope before
+		// mutating state, so it's safe to fire-and-forget.
+		for (const job of resizeJobs) {
+			void processResize(job.clientId, job.file, budget, providerSnapshot);
+		}
 	};
 
 	const handleRemoveAttachment = (attachment: number | File) => {
@@ -613,6 +794,9 @@ export function useChatDraftAttachments(
 		if (!removed) {
 			return;
 		}
+		// In-flight resize would otherwise swap in a replacement
+		// after the clear below.
+		abandonedResizesRef.current.add(removed.clientId);
 		if (organizationId && chatId) {
 			removeChatDraftAttachmentRecord(organizationId, chatId, removed.clientId);
 		}
@@ -629,6 +813,12 @@ export function useChatDraftAttachments(
 	};
 
 	const resetAttachments = () => {
+		// Abandon all in-flight resizes so they don't swap a
+		// replacement back in (which would also re-call beginUpload
+		// against the now-stale scope).
+		for (const view of viewsRef.current) {
+			abandonedResizesRef.current.add(view.clientId);
+		}
 		if (!organizationId || !chatId) {
 			setViews([]);
 			return;

--- a/site/src/pages/AgentsPage/hooks/useFileAttachments.ts
+++ b/site/src/pages/AgentsPage/hooks/useFileAttachments.ts
@@ -3,17 +3,37 @@ import {
 	type SetStateAction,
 	useEffect,
 	useEffectEvent,
+	useRef,
 	useState,
 } from "react";
 import { API } from "#/api/api";
 import type { UploadState } from "../components/AgentChatInput";
 import { getChatFileURL } from "../utils/chatAttachments";
-import {
-	formatAgentAttachmentTooLargeError,
-	formatAgentAttachmentUploadError,
-	maxAgentAttachmentSize,
-	readAgentAttachmentText,
-} from "../utils/fileAttachmentLimits";
+import { formatAgentAttachmentUploadError } from "../utils/fileAttachmentLimits";
+import { resizeImageToMaxBytes } from "../utils/resizeImage";
+
+// Maximum bytes accepted by our upload endpoint (maxChatFileSize in
+// coderd/exp_chats.go). Non-image files over this limit surface as
+// an error; oversized images get resized down instead.
+const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
+
+// Default image budget keeps us safely under MAX_UPLOAD_BYTES after
+// any trailing encoder metadata. Images larger than this are
+// re-encoded before upload so we never have to reject them.
+const DEFAULT_IMAGE_BUDGET_BYTES = MAX_UPLOAD_BYTES - 16 * 1024;
+
+// Anthropic's documented inline image budget is 5 MiB (5,242,880
+// bytes). Stay slightly below to leave room for framing on the
+// wire. This is stricter than DEFAULT_IMAGE_BUDGET_BYTES, so the
+// Anthropic path uses it even though the upload endpoint itself
+// would accept more.
+const ANTHROPIC_IMAGE_BUDGET_BYTES = 5 * 1024 * 1024 - 16 * 1024;
+
+function imageBudgetForProvider(provider: string | undefined): number {
+	return provider === "anthropic"
+		? ANTHROPIC_IMAGE_BUDGET_BYTES
+		: DEFAULT_IMAGE_BUDGET_BYTES;
+}
 
 /** @internal Exported for testing. */
 export const persistedAttachmentsStorageKey = "agents.persisted-attachments";
@@ -173,9 +193,21 @@ interface UseFileAttachmentsReturn {
 
 export function useFileAttachments(
 	organizationId: string | undefined,
-	options?: { persist?: boolean },
+	options?: { persist?: boolean; provider?: string },
 ): UseFileAttachmentsReturn {
 	const persist = options?.persist ?? false;
+
+	// Provider is read inside async callbacks; keep it in a ref so
+	// the latest value is visible without rebuilding handleAttach
+	// whenever the user switches models. Writing the ref from an
+	// effect (rather than during render) keeps React Compiler happy
+	// while still ensuring subsequent event-driven calls see the
+	// newest value.
+	const provider = options?.provider;
+	const providerRef = useRef(provider);
+	useEffect(() => {
+		providerRef.current = provider;
+	}, [provider]);
 
 	// Restore previously uploaded attachments from localStorage
 	// when persistence is enabled. Computed once on first render.
@@ -257,10 +289,42 @@ export function useFileAttachments(
 	};
 
 	const handleAttach = (files: File[]) => {
-		setAttachments((prev) => [...prev, ...files]);
+		// handleAttach is fire-and-forget to callers (paste/drop
+		// handlers don't await). Delegate to an async worker so we
+		// can resize images before committing them to state when
+		// targeting Anthropic.
+		void processAttach(files);
+	};
+
+	const processAttach = async (files: File[]) => {
+		// Resize oversized images up front so that every File that
+		// enters attachment state is already within the applicable
+		// budget. Anthropic has a stricter 5 MiB inline cap; other
+		// providers just need to fit the server's 10 MiB upload
+		// limit. Non-image files are passed through unchanged; if
+		// they exceed MAX_UPLOAD_BYTES the check below still
+		// surfaces the existing too-large error.
+		const budget = imageBudgetForProvider(providerRef.current);
+		const processed = await Promise.all(
+			files.map(async (file) => {
+				if (!file.type.startsWith("image/")) return file;
+				if (file.size <= budget) return file;
+				let resized: File | null = null;
+				try {
+					resized = await resizeImageToMaxBytes(file, budget);
+				} catch {
+					// Never let a resize error swallow the attachment;
+					// the user can still attempt to upload the original.
+					resized = null;
+				}
+				return resized ?? file;
+			}),
+		);
+
+		setAttachments((prev) => [...prev, ...processed]);
 		setPreviewUrls((prev) => {
 			const next = new Map(prev);
-			for (const file of files) {
+			for (const file of processed) {
 				if (file.type !== "text/plain") {
 					next.set(file, URL.createObjectURL(file));
 				}
@@ -268,9 +332,14 @@ export function useFileAttachments(
 			return next;
 		});
 		// Read text content for preview, but skip oversized files.
-		for (const file of files) {
-			if (file.type === "text/plain" && file.size <= maxAgentAttachmentSize) {
-				void readAgentAttachmentText(file)
+		for (const file of processed) {
+			if (file.type === "text/plain" && file.size <= MAX_UPLOAD_BYTES) {
+				// Defensive: some test environments lack File.prototype.text().
+				const readText =
+					typeof file.text === "function"
+						? file.text()
+						: new Response(file).text();
+				void readText
 					.then((content) => {
 						setTextContents((prev) => {
 							const next = new Map(prev);
@@ -283,12 +352,12 @@ export function useFileAttachments(
 					});
 			}
 		}
-		for (const file of files) {
-			if (file.size > maxAgentAttachmentSize) {
+		for (const file of processed) {
+			if (file.size > MAX_UPLOAD_BYTES) {
 				setUploadStates((prev) =>
 					new Map(prev).set(file, {
 						status: "error" as const,
-						error: formatAgentAttachmentTooLargeError(file.size),
+						error: `File too large (${(file.size / 1024 / 1024).toFixed(1)} MB). Maximum is 10 MB.`,
 					}),
 				);
 			} else {

--- a/site/src/pages/AgentsPage/hooks/useFileAttachments.ts
+++ b/site/src/pages/AgentsPage/hooks/useFileAttachments.ts
@@ -7,48 +7,19 @@ import {
 	useState,
 } from "react";
 import { API } from "#/api/api";
+import { MaxChatFileSizeBytes } from "#/api/typesGenerated";
 import type { UploadState } from "../components/AgentChatInput";
 import { getChatFileURL } from "../utils/chatAttachments";
-import { formatAgentAttachmentUploadError } from "../utils/fileAttachmentLimits";
+import {
+	formatAgentAttachmentTooLargeError,
+	formatAgentAttachmentUploadError,
+} from "../utils/fileAttachmentLimits";
+import {
+	imageBudgetForProvider,
+	imageNeedsResize,
+	providerBudgetError,
+} from "../utils/imageBudget";
 import { resizeImageToMaxBytes } from "../utils/resizeImage";
-
-// Maximum bytes accepted by our upload endpoint (maxChatFileSize in
-// coderd/exp_chats.go). Non-image files over this limit surface as
-// an error; oversized images get resized down instead.
-const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
-
-// Default image budget keeps us safely under MAX_UPLOAD_BYTES after
-// any trailing encoder metadata. Images larger than this are
-// re-encoded before upload so we never have to reject them.
-const DEFAULT_IMAGE_BUDGET_BYTES = MAX_UPLOAD_BYTES - 16 * 1024;
-
-// Anthropic's documented inline image budget is 5 MiB (5,242,880
-// bytes). Stay slightly below to leave room for framing on the
-// wire. This is stricter than DEFAULT_IMAGE_BUDGET_BYTES, so the
-// Anthropic path uses it even though the upload endpoint itself
-// would accept more.
-//
-// Kept in sync with coderd/x/chatd/chatprovider/chatprovider.go
-// `anthropicInlineImageByteCap` (server-side backstop) — adjust the
-// byte values together if Anthropic ever revises the limit.
-const ANTHROPIC_IMAGE_BUDGET_BYTES = 5 * 1024 * 1024 - 16 * 1024;
-
-// Providers that inherit Anthropic's stricter 5 MiB inline image cap.
-// Must mirror chatprovider.InlineImageByteCap's coverage on the
-// server so both layers agree on which configurations need the
-// tighter budget. Bedrock is included because fantasy's bedrock
-// provider is a thin wrapper around the Anthropic client.
-const ANTHROPIC_STRICT_BUDGET_PROVIDERS: ReadonlySet<string> = new Set([
-	"anthropic",
-	"bedrock",
-]);
-
-function imageBudgetForProvider(provider: string | undefined): number {
-	if (provider && ANTHROPIC_STRICT_BUDGET_PROVIDERS.has(provider)) {
-		return ANTHROPIC_IMAGE_BUDGET_BYTES;
-	}
-	return DEFAULT_IMAGE_BUDGET_BYTES;
-}
 
 /** @internal Exported for testing. */
 export const persistedAttachmentsStorageKey = "agents.persisted-attachments";
@@ -78,10 +49,9 @@ function restorePersistedAttachments(currentOrgId: string): {
 	uploadStates: Map<File, UploadState>;
 	previewUrls: Map<File, string>;
 } {
-	// When the org ID is not yet known (e.g. still loading), skip
-	// restoration entirely so we don't accidentally prune valid
-	// entries. The initializer only runs once, so the caller must
-	// ensure the org ID is available before mounting the hook.
+	// Skip when org ID isn't loaded yet so we don't prune valid
+	// entries. The initializer runs once, so callers must wait for
+	// the org ID before mounting.
 	if (!currentOrgId) {
 		return {
 			attachments: [],
@@ -101,7 +71,6 @@ function restorePersistedAttachments(currentOrgId: string): {
 		const persisted: PersistedAttachment[] = JSON.parse(stored);
 		const matched = persisted.filter((p) => p.organizationId === currentOrgId);
 
-		// Prune entries that don't match the current org.
 		if (matched.length !== persisted.length) {
 			if (matched.length > 0) {
 				localStorage.setItem(
@@ -119,9 +88,8 @@ function restorePersistedAttachments(currentOrgId: string): {
 
 		for (const p of matched) {
 			if (!p.fileId || !p.fileName) continue;
-			// Synthetic File used as a Map key only. Its content is
-			// never read because the existing file_id is reused at
-			// send time.
+			// Synthetic File used as a Map key only; the existing
+			// file_id is reused at send time.
 			const file = new File([], p.fileName, {
 				type: p.fileType,
 				lastModified: p.lastModified,
@@ -212,20 +180,15 @@ export function useFileAttachments(
 ): UseFileAttachmentsReturn {
 	const persist = options?.persist ?? false;
 
-	// Provider is read inside async callbacks; keep it in a ref so
-	// the latest value is visible without rebuilding handleAttach
-	// whenever the user switches models. Writing the ref from an
-	// effect (rather than during render) keeps React Compiler happy
-	// while still ensuring subsequent event-driven calls see the
-	// newest value.
+	// providerRef lets event-driven handlers (paste/drop) see the
+	// latest model selection without rebuilding handleAttach. The
+	// effect-based write keeps React Compiler happy.
 	const provider = options?.provider;
 	const providerRef = useRef(provider);
 	useEffect(() => {
 		providerRef.current = provider;
 	}, [provider]);
 
-	// Restore previously uploaded attachments from localStorage
-	// when persistence is enabled. Computed once on first render.
 	const [restored] = useState(() =>
 		persist
 			? restorePersistedAttachments(organizationId ?? "")
@@ -284,11 +247,10 @@ export function useFileAttachments(
 				if (shouldPersist) {
 					addPersistedAttachment(file, result.id, organizationId!);
 				}
-				// Pre-warm the browser HTTP cache for images so the
-				// timeline can render them instantly after send. We
-				// intentionally skip text attachments because the
-				// composer already has the text content locally.
 				if (isImage) {
+					// Pre-warm the HTTP cache so the timeline can
+					// render the image instantly after send. Text
+					// content is already local in the composer.
 					void fetch(getChatFileURL(result.id));
 				}
 			} catch (err: unknown) {
@@ -303,45 +265,41 @@ export function useFileAttachments(
 		})();
 	};
 
-	// Track originals that were removed while their resize was still
-	// in flight. Writes happen in handleRemoveAttachment; reads in
-	// processResizes. A WeakSet lets dismissed File objects be GC'd
-	// without needing explicit cleanup.
+	// Files removed while their resize is in flight. processResizes
+	// checks this before swapping in a replacement so a dismissed
+	// file can't be resurrected. WeakSet lets entries get GC'd.
 	const abandonedResizesRef = useRef<WeakSet<File>>(new WeakSet());
 
+	type AttachItem = { file: File; needsResize: boolean };
+
 	const processResizes = async (
-		originals: File[],
-		needsResize: boolean[],
+		items: readonly AttachItem[],
 		budget: number,
+		// Pinned at attach time so a mid-resize provider switch
+		// can't mislabel the error with the new provider's name.
+		providerSnapshot: string | undefined,
 	) => {
-		// Resize images one at a time (module-level queue in
-		// resizeImageToMaxBytes already serializes decode work; this
-		// mirrors it so each swap is committed before the next
-		// starts, keeping UI transitions predictable).
-		for (let i = 0; i < originals.length; i++) {
-			if (!needsResize[i]) continue;
-			const original = originals[i];
+		// Sequential so each swap commits before the next starts;
+		// resizeImageToMaxBytes already serializes decode work.
+		for (const { file: original, needsResize } of items) {
+			if (!needsResize) continue;
 			let resized: File | null = null;
 			try {
 				resized = await resizeImageToMaxBytes(original, budget);
 			} catch {
-				// Never let a resize error swallow the attachment;
-				// we fall back to the original below.
 				resized = null;
 			}
 
-			// If the user removed this attachment while resize was
-			// in flight, skip state updates entirely so we don't
-			// resurrect a dismissed file.
+			// Skip if the user removed this attachment while
+			// resizing; updates here would resurrect it.
 			if (abandonedResizesRef.current.has(original)) {
 				continue;
 			}
 			const replacement = resized ?? original;
 			const replaced = replacement !== original;
 
-			// Functional updaters so a racing removal (e.g. unmount
-			// cleanup) leaves the state alone: if the original is no
-			// longer present, every updater below is a no-op.
+			// Functional updaters: if a racing removal cleared the
+			// original, every updater below becomes a no-op.
 			setAttachments((prev) => {
 				const idx = prev.indexOf(original);
 				if (idx === -1 || !replaced) return prev;
@@ -350,32 +308,52 @@ export function useFileAttachments(
 				return next;
 			});
 			setPreviewUrls((prev) => {
-				if (!prev.has(original)) return prev;
+				// Skip when no replacement happened so we don't
+				// revoke the original's still-in-use blob URL.
+				if (!prev.has(original) || !replaced) return prev;
 				const next = new Map(prev);
 				const oldUrl = next.get(original);
 				if (oldUrl?.startsWith("blob:")) URL.revokeObjectURL(oldUrl);
 				next.delete(original);
-				if (replaced && replacement.type !== "text/plain") {
+				if (replacement.type !== "text/plain") {
 					next.set(replacement, URL.createObjectURL(replacement));
 				}
 				return next;
 			});
 			setUploadStates((prev) => {
-				if (!prev.has(original)) return prev;
+				// Skip when no replacement: startUpload below
+				// overwrites "processing" with "uploading".
+				if (!prev.has(original) || !replaced) return prev;
 				const next = new Map(prev);
 				next.delete(original);
 				return next;
 			});
 
-			// If the replacement is still larger than the server
-			// cap (e.g. resize failed and the original was >10 MiB),
-			// surface the pre-existing too-large error instead of
+			// Resize failed and the original still exceeds the
+			// server cap; show the too-large error instead of
 			// kicking off an upload that will 413.
-			if (replacement.size > MAX_UPLOAD_BYTES) {
+			if (replacement.size > MaxChatFileSizeBytes) {
 				setUploadStates((prev) =>
 					new Map(prev).set(replacement, {
 						status: "error" as const,
-						error: `File too large (${(replacement.size / 1024 / 1024).toFixed(1)} MB). Maximum is 10 MB.`,
+						error: formatAgentAttachmentTooLargeError(replacement.size),
+					}),
+				);
+				continue;
+			}
+			// Replacement is still over the provider budget (e.g.
+			// animated GIF on Anthropic that we don't re-encode).
+			// Surface the error at attach time rather than letting
+			// the server backstop reject only at send time.
+			if (replacement.type.startsWith("image/") && replacement.size > budget) {
+				setUploadStates((prev) =>
+					new Map(prev).set(replacement, {
+						status: "error" as const,
+						error: providerBudgetError(
+							providerSnapshot,
+							replacement.size,
+							budget,
+						),
 					}),
 				);
 				continue;
@@ -385,20 +363,21 @@ export function useFileAttachments(
 	};
 
 	const handleAttach = (files: File[]) => {
-		// Commit originals to state synchronously so the composer
-		// reflects the paste/drop immediately and the send gate
-		// (via the "processing" UploadState) blocks dispatch until
-		// any async preprocessing finishes. The async worker below
-		// later swaps each entry for its resized File if needed.
-		const budget = imageBudgetForProvider(providerRef.current);
-		const needsResize = files.map(
-			(file) => file.type.startsWith("image/") && file.size > budget,
-		);
+		// Originals enter state with a "processing" status so the
+		// send gate blocks dispatch until processResizes finishes.
+		// Snapshot provider + budget so a mid-resize switch can't
+		// relabel the error with the new provider.
+		const providerSnapshot = providerRef.current;
+		const budget = imageBudgetForProvider(providerSnapshot);
+		const items: AttachItem[] = files.map((file) => ({
+			file,
+			needsResize: imageNeedsResize(file, budget),
+		}));
 
 		setAttachments((prev) => [...prev, ...files]);
 		setPreviewUrls((prev) => {
 			const next = new Map(prev);
-			for (const file of files) {
+			for (const { file } of items) {
 				if (file.type !== "text/plain") {
 					next.set(file, URL.createObjectURL(file));
 				}
@@ -407,24 +386,22 @@ export function useFileAttachments(
 		});
 		setUploadStates((prev) => {
 			const next = new Map(prev);
-			for (let i = 0; i < files.length; i++) {
-				const file = files[i];
-				if (file.size > MAX_UPLOAD_BYTES && !needsResize[i]) {
+			for (const { file, needsResize } of items) {
+				if (file.size > MaxChatFileSizeBytes && !needsResize) {
 					next.set(file, {
 						status: "error" as const,
-						error: `File too large (${(file.size / 1024 / 1024).toFixed(1)} MB). Maximum is 10 MB.`,
+						error: formatAgentAttachmentTooLargeError(file.size),
 					});
-				} else if (needsResize[i]) {
+				} else if (needsResize) {
 					next.set(file, { status: "processing" });
 				}
 			}
 			return next;
 		});
 
-		// Read text content for preview, but skip oversized files.
-		for (const file of files) {
-			if (file.type === "text/plain" && file.size <= MAX_UPLOAD_BYTES) {
-				// Defensive: some test environments lack File.prototype.text().
+		for (const { file } of items) {
+			if (file.type === "text/plain" && file.size <= MaxChatFileSizeBytes) {
+				// Some test environments lack File.prototype.text.
 				const readText =
 					typeof file.text === "function"
 						? file.text()
@@ -443,32 +420,27 @@ export function useFileAttachments(
 			}
 		}
 
-		// Start uploads for files that don't need resizing.
-		for (let i = 0; i < files.length; i++) {
-			const file = files[i];
-			if (needsResize[i]) continue;
-			if (file.size > MAX_UPLOAD_BYTES) continue; // already marked as error above
+		for (const { file, needsResize } of items) {
+			if (needsResize) continue;
+			if (file.size > MaxChatFileSizeBytes) continue; // already marked as error above
 			startUpload(file);
 		}
 
-		// Kick off async resize + swap for files that need it.
-		void processResizes(files, needsResize, budget);
+		void processResizes(items, budget, providerSnapshot);
 	};
 
 	const handleRemoveAttachment = (attachment: number | File) => {
-		// Resolve the file to remove and perform localStorage side
-		// effects before entering state updaters. React may call
-		// updaters more than once (StrictMode, React Compiler), so
-		// they must stay pure.
+		// Side effects (localStorage, abandonment) happen here;
+		// React may call updaters multiple times under StrictMode
+		// or React Compiler, so they must stay pure.
 		const idx =
 			typeof attachment === "number"
 				? attachment
 				: attachments.indexOf(attachment);
 		const removed = idx >= 0 ? attachments[idx] : undefined;
 		if (removed) {
-			// Mark this file as abandoned so an in-flight resize
-			// doesn't resurrect it by swapping in a replacement
-			// after the state updates below.
+			// In-flight resize would otherwise resurrect this file
+			// by swapping in a replacement after the clear below.
 			abandonedResizesRef.current.add(removed);
 		}
 		if (persist && removed) {
@@ -508,6 +480,12 @@ export function useFileAttachments(
 	};
 
 	const resetAttachments = () => {
+		// Abandon all in-flight resizes so they don't swap a
+		// replacement back in (which would also re-call startUpload
+		// against the now-stale scope).
+		for (const file of attachments) {
+			abandonedResizesRef.current.add(file);
+		}
 		for (const [, url] of previewUrls) {
 			if (url.startsWith("blob:")) URL.revokeObjectURL(url);
 		}
@@ -529,9 +507,9 @@ export function useFileAttachments(
 		handleRemoveAttachment,
 		startUpload,
 		resetAttachments,
-		// Raw setters exposed for ChatPageContent to pre-populate
-		// attachments from existing chat messages. These bypass
-		// localStorage persistence. Only use when persist is false.
+		// Raw setters bypass localStorage persistence; only use
+		// when persist is false (e.g. ChatPageContent pre-populating
+		// attachments from existing chat messages).
 		setAttachments,
 		setPreviewUrls,
 		setUploadStates,

--- a/site/src/pages/AgentsPage/hooks/useFileAttachments.ts
+++ b/site/src/pages/AgentsPage/hooks/useFileAttachments.ts
@@ -27,12 +27,27 @@ const DEFAULT_IMAGE_BUDGET_BYTES = MAX_UPLOAD_BYTES - 16 * 1024;
 // wire. This is stricter than DEFAULT_IMAGE_BUDGET_BYTES, so the
 // Anthropic path uses it even though the upload endpoint itself
 // would accept more.
+//
+// Kept in sync with coderd/x/chatd/chatprovider/chatprovider.go
+// `anthropicInlineImageByteCap` (server-side backstop) — adjust the
+// byte values together if Anthropic ever revises the limit.
 const ANTHROPIC_IMAGE_BUDGET_BYTES = 5 * 1024 * 1024 - 16 * 1024;
 
+// Providers that inherit Anthropic's stricter 5 MiB inline image cap.
+// Must mirror chatprovider.InlineImageByteCap's coverage on the
+// server so both layers agree on which configurations need the
+// tighter budget. Bedrock is included because fantasy's bedrock
+// provider is a thin wrapper around the Anthropic client.
+const ANTHROPIC_STRICT_BUDGET_PROVIDERS: ReadonlySet<string> = new Set([
+	"anthropic",
+	"bedrock",
+]);
+
 function imageBudgetForProvider(provider: string | undefined): number {
-	return provider === "anthropic"
-		? ANTHROPIC_IMAGE_BUDGET_BYTES
-		: DEFAULT_IMAGE_BUDGET_BYTES;
+	if (provider && ANTHROPIC_STRICT_BUDGET_PROVIDERS.has(provider)) {
+		return ANTHROPIC_IMAGE_BUDGET_BYTES;
+	}
+	return DEFAULT_IMAGE_BUDGET_BYTES;
 }
 
 /** @internal Exported for testing. */
@@ -288,51 +303,126 @@ export function useFileAttachments(
 		})();
 	};
 
-	const handleAttach = (files: File[]) => {
-		// handleAttach is fire-and-forget to callers (paste/drop
-		// handlers don't await). Delegate to an async worker so we
-		// can resize images before committing them to state when
-		// targeting Anthropic.
-		void processAttach(files);
+	// Track originals that were removed while their resize was still
+	// in flight. Writes happen in handleRemoveAttachment; reads in
+	// processResizes. A WeakSet lets dismissed File objects be GC'd
+	// without needing explicit cleanup.
+	const abandonedResizesRef = useRef<WeakSet<File>>(new WeakSet());
+
+	const processResizes = async (
+		originals: File[],
+		needsResize: boolean[],
+		budget: number,
+	) => {
+		// Resize images one at a time (module-level queue in
+		// resizeImageToMaxBytes already serializes decode work; this
+		// mirrors it so each swap is committed before the next
+		// starts, keeping UI transitions predictable).
+		for (let i = 0; i < originals.length; i++) {
+			if (!needsResize[i]) continue;
+			const original = originals[i];
+			let resized: File | null = null;
+			try {
+				resized = await resizeImageToMaxBytes(original, budget);
+			} catch {
+				// Never let a resize error swallow the attachment;
+				// we fall back to the original below.
+				resized = null;
+			}
+
+			// If the user removed this attachment while resize was
+			// in flight, skip state updates entirely so we don't
+			// resurrect a dismissed file.
+			if (abandonedResizesRef.current.has(original)) {
+				continue;
+			}
+			const replacement = resized ?? original;
+			const replaced = replacement !== original;
+
+			// Functional updaters so a racing removal (e.g. unmount
+			// cleanup) leaves the state alone: if the original is no
+			// longer present, every updater below is a no-op.
+			setAttachments((prev) => {
+				const idx = prev.indexOf(original);
+				if (idx === -1 || !replaced) return prev;
+				const next = prev.slice();
+				next[idx] = replacement;
+				return next;
+			});
+			setPreviewUrls((prev) => {
+				if (!prev.has(original)) return prev;
+				const next = new Map(prev);
+				const oldUrl = next.get(original);
+				if (oldUrl?.startsWith("blob:")) URL.revokeObjectURL(oldUrl);
+				next.delete(original);
+				if (replaced && replacement.type !== "text/plain") {
+					next.set(replacement, URL.createObjectURL(replacement));
+				}
+				return next;
+			});
+			setUploadStates((prev) => {
+				if (!prev.has(original)) return prev;
+				const next = new Map(prev);
+				next.delete(original);
+				return next;
+			});
+
+			// If the replacement is still larger than the server
+			// cap (e.g. resize failed and the original was >10 MiB),
+			// surface the pre-existing too-large error instead of
+			// kicking off an upload that will 413.
+			if (replacement.size > MAX_UPLOAD_BYTES) {
+				setUploadStates((prev) =>
+					new Map(prev).set(replacement, {
+						status: "error" as const,
+						error: `File too large (${(replacement.size / 1024 / 1024).toFixed(1)} MB). Maximum is 10 MB.`,
+					}),
+				);
+				continue;
+			}
+			startUpload(replacement);
+		}
 	};
 
-	const processAttach = async (files: File[]) => {
-		// Resize oversized images up front so that every File that
-		// enters attachment state is already within the applicable
-		// budget. Anthropic has a stricter 5 MiB inline cap; other
-		// providers just need to fit the server's 10 MiB upload
-		// limit. Non-image files are passed through unchanged; if
-		// they exceed MAX_UPLOAD_BYTES the check below still
-		// surfaces the existing too-large error.
+	const handleAttach = (files: File[]) => {
+		// Commit originals to state synchronously so the composer
+		// reflects the paste/drop immediately and the send gate
+		// (via the "processing" UploadState) blocks dispatch until
+		// any async preprocessing finishes. The async worker below
+		// later swaps each entry for its resized File if needed.
 		const budget = imageBudgetForProvider(providerRef.current);
-		const processed = await Promise.all(
-			files.map(async (file) => {
-				if (!file.type.startsWith("image/")) return file;
-				if (file.size <= budget) return file;
-				let resized: File | null = null;
-				try {
-					resized = await resizeImageToMaxBytes(file, budget);
-				} catch {
-					// Never let a resize error swallow the attachment;
-					// the user can still attempt to upload the original.
-					resized = null;
-				}
-				return resized ?? file;
-			}),
+		const needsResize = files.map(
+			(file) => file.type.startsWith("image/") && file.size > budget,
 		);
 
-		setAttachments((prev) => [...prev, ...processed]);
+		setAttachments((prev) => [...prev, ...files]);
 		setPreviewUrls((prev) => {
 			const next = new Map(prev);
-			for (const file of processed) {
+			for (const file of files) {
 				if (file.type !== "text/plain") {
 					next.set(file, URL.createObjectURL(file));
 				}
 			}
 			return next;
 		});
+		setUploadStates((prev) => {
+			const next = new Map(prev);
+			for (let i = 0; i < files.length; i++) {
+				const file = files[i];
+				if (file.size > MAX_UPLOAD_BYTES && !needsResize[i]) {
+					next.set(file, {
+						status: "error" as const,
+						error: `File too large (${(file.size / 1024 / 1024).toFixed(1)} MB). Maximum is 10 MB.`,
+					});
+				} else if (needsResize[i]) {
+					next.set(file, { status: "processing" });
+				}
+			}
+			return next;
+		});
+
 		// Read text content for preview, but skip oversized files.
-		for (const file of processed) {
+		for (const file of files) {
 			if (file.type === "text/plain" && file.size <= MAX_UPLOAD_BYTES) {
 				// Defensive: some test environments lack File.prototype.text().
 				const readText =
@@ -352,18 +442,17 @@ export function useFileAttachments(
 					});
 			}
 		}
-		for (const file of processed) {
-			if (file.size > MAX_UPLOAD_BYTES) {
-				setUploadStates((prev) =>
-					new Map(prev).set(file, {
-						status: "error" as const,
-						error: `File too large (${(file.size / 1024 / 1024).toFixed(1)} MB). Maximum is 10 MB.`,
-					}),
-				);
-			} else {
-				startUpload(file);
-			}
+
+		// Start uploads for files that don't need resizing.
+		for (let i = 0; i < files.length; i++) {
+			const file = files[i];
+			if (needsResize[i]) continue;
+			if (file.size > MAX_UPLOAD_BYTES) continue; // already marked as error above
+			startUpload(file);
 		}
+
+		// Kick off async resize + swap for files that need it.
+		void processResizes(files, needsResize, budget);
 	};
 
 	const handleRemoveAttachment = (attachment: number | File) => {
@@ -376,6 +465,12 @@ export function useFileAttachments(
 				? attachment
 				: attachments.indexOf(attachment);
 		const removed = idx >= 0 ? attachments[idx] : undefined;
+		if (removed) {
+			// Mark this file as abandoned so an in-flight resize
+			// doesn't resurrect it by swapping in a replacement
+			// after the state updates below.
+			abandonedResizesRef.current.add(removed);
+		}
 		if (persist && removed) {
 			const state = uploadStates.get(removed);
 			if (state?.status === "uploaded" && state.fileId) {

--- a/site/src/pages/AgentsPage/utils/fileAttachmentLimits.ts
+++ b/site/src/pages/AgentsPage/utils/fileAttachmentLimits.ts
@@ -1,9 +1,8 @@
 import { getErrorDetail, getErrorMessage } from "#/api/errors";
-
-export const maxAgentAttachmentSize = 10 * 1024 * 1024;
+import { MaxChatFileSizeBytes } from "#/api/typesGenerated";
 
 export const formatAgentAttachmentTooLargeError = (fileSize: number): string =>
-	`File too large (${(fileSize / 1024 / 1024).toFixed(1)} MB). Maximum is ${maxAgentAttachmentSize / 1024 / 1024} MB.`;
+	`File too large (${(fileSize / 1024 / 1024).toFixed(1)} MiB). Maximum is ${MaxChatFileSizeBytes / 1024 / 1024} MiB.`;
 
 export const formatAgentAttachmentUploadError = (error: unknown): string => {
 	const message = getErrorMessage(error, "Upload failed");

--- a/site/src/pages/AgentsPage/utils/imageBudget.test.ts
+++ b/site/src/pages/AgentsPage/utils/imageBudget.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { MaxChatFileSizeBytes } from "#/api/typesGenerated";
+import {
+	formatMiB,
+	imageBudgetForProvider,
+	imageNeedsResize,
+	providerBudgetError,
+} from "./imageBudget";
+
+const ANTHROPIC_BUDGET = 5 * 1024 * 1024 - 16 * 1024;
+const DEFAULT_BUDGET = MaxChatFileSizeBytes - 16 * 1024;
+
+describe("imageBudgetForProvider", () => {
+	it("returns the Anthropic budget for direct Anthropic", () => {
+		expect(imageBudgetForProvider("anthropic")).toBe(ANTHROPIC_BUDGET);
+	});
+
+	it("returns the Anthropic budget for Bedrock (Anthropic-compatible)", () => {
+		expect(imageBudgetForProvider("bedrock")).toBe(ANTHROPIC_BUDGET);
+	});
+
+	it("returns the default budget for OpenAI", () => {
+		expect(imageBudgetForProvider("openai")).toBe(DEFAULT_BUDGET);
+	});
+
+	it("returns the default budget for unknown providers", () => {
+		expect(imageBudgetForProvider("brand-new-provider")).toBe(DEFAULT_BUDGET);
+	});
+
+	it("returns the default budget when provider is undefined", () => {
+		expect(imageBudgetForProvider(undefined)).toBe(DEFAULT_BUDGET);
+	});
+
+	// Mirrors server-side chatprovider.NormalizeProvider so a
+	// caller passing a case/whitespace variant gets the strict
+	// budget instead of silently falling through to the default.
+	it.each([
+		"Anthropic",
+		"ANTHROPIC",
+		" anthropic ",
+		"\tanthropic\n",
+		"AnThRoPiC",
+	])("normalizes case/whitespace before matching strict providers (%s)", (input) => {
+		expect(imageBudgetForProvider(input)).toBe(ANTHROPIC_BUDGET);
+	});
+
+	it("normalizes Bedrock variants too", () => {
+		expect(imageBudgetForProvider("Bedrock")).toBe(ANTHROPIC_BUDGET);
+		expect(imageBudgetForProvider(" BEDROCK ")).toBe(ANTHROPIC_BUDGET);
+	});
+});
+
+describe("imageNeedsResize", () => {
+	const oversize = (type: string, bytes: number): File => {
+		const f = new File([new Uint8Array(8)], `f.${type.split("/")[1]}`, {
+			type,
+		});
+		Object.defineProperty(f, "size", { value: bytes });
+		return f;
+	};
+
+	it("returns true for an over-budget image", () => {
+		expect(
+			imageNeedsResize(oversize("image/png", 6 * 1024 * 1024), 5 * 1024 * 1024),
+		).toBe(true);
+	});
+
+	it("returns false for an under-budget image", () => {
+		expect(
+			imageNeedsResize(oversize("image/png", 1 * 1024 * 1024), 5 * 1024 * 1024),
+		).toBe(false);
+	});
+
+	it("returns false for non-image files even when oversized", () => {
+		expect(
+			imageNeedsResize(
+				oversize("text/plain", 6 * 1024 * 1024),
+				5 * 1024 * 1024,
+			),
+		).toBe(false);
+	});
+});
+
+describe("formatMiB", () => {
+	it("renders one decimal place", () => {
+		expect(formatMiB(5 * 1024 * 1024)).toBe("5.0");
+		expect(formatMiB(5 * 1024 * 1024 + 512 * 1024)).toBe("5.5");
+		expect(formatMiB(0)).toBe("0.0");
+	});
+});
+
+describe("providerBudgetError", () => {
+	it("uses the provider's display label and MiB units", () => {
+		const message = providerBudgetError(
+			"anthropic",
+			6 * 1024 * 1024,
+			ANTHROPIC_BUDGET,
+		);
+		expect(message).toMatch(/Anthropic/);
+		expect(message).toMatch(/6\.0 MiB/);
+		expect(message).toMatch(/5\.0 MiB/);
+	});
+
+	it("falls back to a generic label when provider is undefined", () => {
+		const message = providerBudgetError(
+			undefined,
+			6 * 1024 * 1024,
+			ANTHROPIC_BUDGET,
+		);
+		expect(message).toMatch(/this provider/);
+	});
+});

--- a/site/src/pages/AgentsPage/utils/imageBudget.ts
+++ b/site/src/pages/AgentsPage/utils/imageBudget.ts
@@ -1,0 +1,46 @@
+import {
+	AnthropicInlineImageCapBytes,
+	MaxChatFileSizeBytes,
+} from "#/api/typesGenerated";
+import { formatProviderLabel } from "./modelOptions";
+
+// Budgets sit below the wire limits to leave room for encoder framing
+// overhead, so a file at exactly the budget is still under the
+// server's hard cap.
+const FRAMING_MARGIN_BYTES = 16 * 1024;
+const DEFAULT_IMAGE_BUDGET_BYTES = MaxChatFileSizeBytes - FRAMING_MARGIN_BYTES;
+const ANTHROPIC_IMAGE_BUDGET_BYTES =
+	AnthropicInlineImageCapBytes - FRAMING_MARGIN_BYTES;
+
+// Must mirror chatprovider.InlineImageCapBytes on the server.
+const ANTHROPIC_STRICT_BUDGET_PROVIDERS: ReadonlySet<string> = new Set([
+	"anthropic",
+	"bedrock",
+]);
+
+// Inputs are normalized to match chatprovider.NormalizeProvider on
+// the server, so callers don't have to pre-normalize.
+export function imageBudgetForProvider(provider: string | undefined): number {
+	const normalized = provider?.trim().toLowerCase();
+	if (normalized && ANTHROPIC_STRICT_BUDGET_PROVIDERS.has(normalized)) {
+		return ANTHROPIC_IMAGE_BUDGET_BYTES;
+	}
+	return DEFAULT_IMAGE_BUDGET_BYTES;
+}
+
+export function formatMiB(bytes: number): string {
+	return (bytes / 1024 / 1024).toFixed(1);
+}
+
+export function providerBudgetError(
+	provider: string | undefined,
+	actualBytes: number,
+	budgetBytes: number,
+): string {
+	const label = provider ? formatProviderLabel(provider) : "this provider";
+	return `Image too large for ${label} (${formatMiB(actualBytes)} MiB). Inline images must be under ${formatMiB(budgetBytes)} MiB on this provider.`;
+}
+
+export function imageNeedsResize(file: File, budget: number): boolean {
+	return file.type.startsWith("image/") && file.size > budget;
+}

--- a/site/src/pages/AgentsPage/utils/modelOptions.ts
+++ b/site/src/pages/AgentsPage/utils/modelOptions.ts
@@ -210,6 +210,16 @@ export const getModelOptionsFromConfigs = (
 	});
 };
 
+// getProviderForModelOption returns the provider string for the
+// currently-selected model option, or undefined when the selection
+// is not (yet) in the options list. Extracted so resize/budget logic
+// has one place to resolve provider from the selector state.
+export const getProviderForModelOption = (
+	modelOptions: readonly ModelSelectorOption[],
+	selectedModel: string,
+): string | undefined =>
+	modelOptions.find((option) => option.id === selectedModel)?.provider;
+
 export const formatProviderLabel = (provider: string): string => {
 	const normalized = provider.trim().toLowerCase();
 	switch (normalized) {

--- a/site/src/pages/AgentsPage/utils/resizeImage.test.ts
+++ b/site/src/pages/AgentsPage/utils/resizeImage.test.ts
@@ -42,9 +42,8 @@ describe("resizeImageToMaxBytes", () => {
 	});
 
 	it("returns GIFs unchanged even when oversize", async () => {
-		// Animated GIFs can't be safely re-encoded via canvas
-		// (canvas flattens to a single frame), so resizeImageToMaxBytes
-		// is expected to bail early and hand back the original file.
+		// Canvas re-encoding flattens animation; we hand the
+		// original back instead.
 		const bytes = new Uint8Array(8 * 1024 * 1024);
 		const file = new File([bytes], "clip.gif", { type: "image/gif" });
 		const result = await resizeImageToMaxBytes(file, 1024 * 1024);
@@ -54,21 +53,43 @@ describe("resizeImageToMaxBytes", () => {
 	it("returns the original image unchanged when already under budget", async () => {
 		const bytes = new Uint8Array(1024);
 		const file = new File([bytes], "tiny.png", { type: "image/png" });
-		// Budget larger than file → no work required.
 		const result = await resizeImageToMaxBytes(file, 4096);
 		expect(result).toBe(file);
 	});
 
 	it("returns null for an unsupported image MIME that would need resizing", async () => {
-		// image/svg+xml and similar types are not in the resizable
-		// allowlist; when over budget, the helper refuses to touch
-		// them instead of silently producing garbage.
+		// Unsupported MIME + over budget: refuse rather than
+		// silently produce garbage.
 		const bytes = new Uint8Array(2 * 1024 * 1024);
 		const file = new File([bytes], "diagram.svg", {
 			type: "image/svg+xml",
 		});
 		const result = await resizeImageToMaxBytes(file, 1024 * 1024);
 		expect(result).toBeNull();
+	});
+
+	it("accepts image/jpg alias alongside image/jpeg", async () => {
+		// Pins the non-IANA `image/jpg` alias in RESIZABLE_MIME_TYPES.
+		// The under-budget passthrough is enough to prove acceptance;
+		// the over-budget case in the stubbed-decoder block proves
+		// the encode pipeline runs.
+		const under = new File([new Uint8Array(512)], "icon.jpg", {
+			type: "image/jpg",
+		});
+		const result = await resizeImageToMaxBytes(under, 4096);
+		expect(result).toBe(under);
+	});
+
+	it("returns an under-budget unsupported-MIME image unchanged", async () => {
+		// Under-budget unsupported MIMEs pass through; the contract
+		// is "give me something <= maxBytes" and we already have
+		// that.
+		const bytes = new Uint8Array(512);
+		const file = new File([bytes], "icon.bmp", {
+			type: "image/bmp",
+		});
+		const result = await resizeImageToMaxBytes(file, 4096);
+		expect(result).toBe(file);
 	});
 });
 
@@ -96,9 +117,16 @@ describe("resizeImageToMaxBytes with stubbed decoders", () => {
 			encodeCalls: [],
 		};
 
-		// Fake createImageBitmap: respects resizeWidth/Height the way
-		// the production code relies on (clamp-in-box, preserve
-		// aspect ratio), and records each call for assertions.
+		// Fake createImageBitmap matching the HTML spec output rules:
+		//   - both resize dims => stretch (no aspect-ratio preservation).
+		//   - only resizeWidth => width exact, height proportional.
+		//     UPSCALES if resizeWidth > source width.
+		//   - only resizeHeight => mirror of above.
+		//   - neither => source dimensions unchanged.
+		//
+		// Critical that the fake doesn't cap at source dimensions:
+		// real browsers follow the spec and upscale, so production
+		// code must handle that. A capped fake would mask the bug.
 		vi.stubGlobal(
 			"createImageBitmap",
 			vi.fn(
@@ -113,16 +141,25 @@ describe("resizeImageToMaxBytes with stubbed decoders", () => {
 					if (state.decodeThrows) {
 						throw new Error("decode boom");
 					}
-					let w = state.srcWidth;
-					let h = state.srcHeight;
-					const limit = Math.min(
-						options?.resizeWidth ?? Number.POSITIVE_INFINITY,
-						options?.resizeHeight ?? Number.POSITIVE_INFINITY,
-					);
-					if (Number.isFinite(limit) && limit > 0) {
-						const scale = Math.min(1, limit / w, limit / h);
-						w = Math.max(1, Math.round(w * scale));
-						h = Math.max(1, Math.round(h * scale));
+					const srcW = state.srcWidth;
+					const srcH = state.srcHeight;
+					const rW = options?.resizeWidth;
+					const rH = options?.resizeHeight;
+					let w: number;
+					let h: number;
+					if (rW !== undefined && rH !== undefined) {
+						// Spec: stretch-to-fit, no source clamp.
+						w = rW;
+						h = rH;
+					} else if (rW !== undefined) {
+						w = rW;
+						h = Math.max(1, Math.round((srcH * rW) / srcW));
+					} else if (rH !== undefined) {
+						h = rH;
+						w = Math.max(1, Math.round((srcW * rH) / srcH));
+					} else {
+						w = srcW;
+						h = srcH;
 					}
 					return {
 						width: w,
@@ -133,9 +170,36 @@ describe("resizeImageToMaxBytes with stubbed decoders", () => {
 			),
 		);
 
-		// Fake OffscreenCanvas whose convertToBlob returns a blob of
-		// size proportional to (width * height * quality) so the
-		// shrink loop observes convergence.
+		// Fake Image (for probeNaturalDimensions in production
+		// code). jsdom exposes `Image` but does not load blob URLs,
+		// so we stub it with a synthetic implementation that reports
+		// state.srcWidth/Height and fires onload on microtask.
+		class FakeImage {
+			onload: (() => void) | null = null;
+			onerror: (() => void) | null = null;
+			naturalWidth = 0;
+			naturalHeight = 0;
+			private _src = "";
+			get src() {
+				return this._src;
+			}
+			set src(url: string) {
+				this._src = url;
+				queueMicrotask(() => {
+					if (state.decodeThrows) {
+						this.onerror?.();
+						return;
+					}
+					this.naturalWidth = state.srcWidth;
+					this.naturalHeight = state.srcHeight;
+					this.onload?.();
+				});
+			}
+		}
+		vi.stubGlobal("Image", FakeImage);
+
+		// convertToBlob size scales with width*height*quality so
+		// the shrink loop converges.
 		class FakeOffscreenCanvas {
 			width: number;
 			height: number;
@@ -144,9 +208,6 @@ describe("resizeImageToMaxBytes with stubbed decoders", () => {
 				this.height = h;
 			}
 			getContext() {
-				// drawImage is called on whatever ctx we return; accept
-				// any args and return nothing — the test isn't
-				// inspecting pixel data.
 				return {
 					drawImage: () => undefined,
 				};
@@ -172,9 +233,7 @@ describe("resizeImageToMaxBytes with stubbed decoders", () => {
 	});
 
 	it("re-encodes an oversized image down to the requested byte budget", async () => {
-		// 4096² pixels × 0.5 bytes/pixel × 0.85 quality ≈ 7.1 MiB
-		// raw — well over budget, forcing at least a few shrink
-		// iterations before convergence.
+		// Forces at least a few shrink iterations before convergence.
 		const file = new File([new Uint8Array(6 * 1024 * 1024)], "big.png", {
 			type: "image/png",
 		});
@@ -185,60 +244,91 @@ describe("resizeImageToMaxBytes with stubbed decoders", () => {
 		expect(result.size).toBeLessThanOrEqual(budget);
 		expect(result.type).toBe("image/webp");
 		expect(result.name.endsWith(".webp")).toBe(true);
-		// Must have iterated the shrink loop at least once.
+
 		expect(state.encodeCalls.length).toBeGreaterThan(0);
 	});
 
-	it("passes resizeWidth/resizeHeight to the decoder so the bitmap cannot exceed the clamp", async () => {
-		// Source is far larger than MAX_INITIAL_DIMENSION on both
-		// axes. Without the resizeWidth/Height options the decoder
-		// would allocate a ~60000×40000 bitmap (~9.6 GB RGBA).
+	it("decoder never stretches non-square sources", async () => {
+		// 4:1 source with long axis above MAX_INITIAL_DIMENSION.
+		// If decodeToBitmap passes both resize dims, the spec
+		// would force 8192x8192 output and the ratio assertion
+		// would fail.
+		state.srcWidth = 16_000;
+		state.srcHeight = 4_000;
+		const file = new File([new Uint8Array(6 * 1024 * 1024)], "wide.png", {
+			type: "image/png",
+		});
+		await resizeImageToMaxBytes(file, 32 * 1024);
+		expect(state.encodeCalls.length).toBeGreaterThan(0);
+		const first = state.encodeCalls[0];
+		const ratio = first.width / first.height;
+		expect(ratio).toBeGreaterThanOrEqual(4 - 0.05);
+		expect(ratio).toBeLessThanOrEqual(4 + 0.05);
+		expect(first.width).toBeLessThanOrEqual(8192);
+		expect(first.height).toBeLessThanOrEqual(8192);
+	});
+
+	it("keeps the bitmap within MAX_INITIAL_DIMENSION on both axes for extreme portraits", async () => {
+		// Regression: passing resizeWidth: MAX on a 2000x60000
+		// source would upscale to 8192x245760, blowing past
+		// Chromium's ~268M pixel limit. Probe must pick
+		// resizeHeight only.
+		state.srcWidth = 2000;
+		state.srcHeight = 60_000;
+		const file = new File([new Uint8Array(6 * 1024 * 1024)], "tall.png", {
+			type: "image/png",
+		});
+		await resizeImageToMaxBytes(file, 64 * 1024);
+		for (const call of state.encodeCalls) {
+			expect(call.width).toBeLessThanOrEqual(8192);
+			expect(call.height).toBeLessThanOrEqual(8192);
+		}
+		const first = state.encodeCalls[0];
+		const sourceRatio = 2000 / 60_000;
+		const bitmapRatio = first.width / first.height;
+		expect(bitmapRatio).toBeGreaterThan(sourceRatio * 0.99);
+		expect(bitmapRatio).toBeLessThan(sourceRatio * 1.01);
+	});
+
+	it("stays within MAX_INITIAL_DIMENSION when source exceeds it on both axes", async () => {
 		state.srcWidth = 60_000;
 		state.srcHeight = 40_000;
 		const file = new File([new Uint8Array(6 * 1024 * 1024)], "huge.png", {
 			type: "image/png",
 		});
 		await resizeImageToMaxBytes(file, 256 * 1024);
-		// Every recorded encode must be within the 8192² clamp so we
-		// know the clamp is applied at decode time, not later.
 		for (const call of state.encodeCalls) {
 			expect(call.width).toBeLessThanOrEqual(8192);
 			expect(call.height).toBeLessThanOrEqual(8192);
 		}
 	});
 
-	it("preserves aspect ratio across the shrink loop", async () => {
-		state.srcWidth = 8000;
-		state.srcHeight = 2000; // 4:1 ratio
-		const file = new File([new Uint8Array(6 * 1024 * 1024)], "wide.png", {
+	it("skips createImageBitmap resize options entirely when source is already under clamp", async () => {
+		// Regression: passing resizeWidth: MAX on a 1920x1080
+		// source would upscale to 8192x4608 (spec: output width
+		// is exactly resizeWidth). Probe must skip resize options
+		// when the source already fits.
+		state.srcWidth = 1920;
+		state.srcHeight = 1080;
+		const file = new File([new Uint8Array(6 * 1024 * 1024)], "shot.png", {
 			type: "image/png",
 		});
-		await resizeImageToMaxBytes(file, 32 * 1024);
-		expect(state.encodeCalls.length).toBeGreaterThan(0);
-		for (const call of state.encodeCalls) {
-			// Allow ±1 px rounding across iterative Math.round calls.
-			const ratio = call.width / call.height;
-			expect(ratio).toBeGreaterThanOrEqual(4 - 0.05);
-			expect(ratio).toBeLessThanOrEqual(4 + 0.05);
-		}
+		await resizeImageToMaxBytes(file, 256 * 1024);
+		const first = state.encodeCalls[0];
+		expect(first.width).toBe(1920);
+		expect(first.height).toBe(1080);
 	});
 
 	it("tries the fallback quality pass when shrink iterations saturate", async () => {
-		// Use a source small enough that the fake will continue to
-		// overshoot even at 1×1 (we force this by choosing a
-		// ridiculously small budget); that exhausts the main loop
-		// and triggers the FALLBACK_QUALITY pass.
+		// Tiny source + unreachable 1-byte budget exhausts the main
+		// loop and forces FALLBACK_QUALITY (0.7).
 		state.srcWidth = 64;
 		state.srcHeight = 64;
 		const file = new File([new Uint8Array(1024 * 1024)], "tiny.png", {
 			type: "image/png",
 		});
 		const result = await resizeImageToMaxBytes(file, 1);
-		// The fake's minimum blob size is 64 bytes, so the budget of
-		// 1 byte is unreachable → null is the expected outcome.
 		expect(result).toBeNull();
-		// Last encode attempt should use FALLBACK_QUALITY (0.7), not
-		// the initial 0.85, proving the fallback ran.
 		const last = state.encodeCalls[state.encodeCalls.length - 1];
 		expect(last.quality).toBeCloseTo(0.7, 5);
 	});
@@ -252,10 +342,57 @@ describe("resizeImageToMaxBytes with stubbed decoders", () => {
 		expect(result).toBeNull();
 	});
 
+	it("fake createImageBitmap matches HTML spec output-dimension rules", async () => {
+		// Pins fake createImageBitmap behavior: stretch with both
+		// dims, proportional scale with one, including upscale
+		// when a resize dim exceeds the source. A fake that capped
+		// at source dimensions or scaled uniformly would mask real
+		// decoder bugs in production code.
+		state.srcWidth = 4000;
+		state.srcHeight = 1000;
+		const blob = new Blob([new Uint8Array(8)], { type: "image/png" });
+		const createBitmap = (
+			globalThis as unknown as {
+				createImageBitmap: (
+					blob: Blob,
+					opts?: { resizeWidth?: number; resizeHeight?: number },
+				) => Promise<ImageBitmap>;
+			}
+		).createImageBitmap;
+
+		// Stretch.
+		const stretched = await createBitmap(blob, {
+			resizeWidth: 800,
+			resizeHeight: 800,
+		});
+		expect(stretched.width).toBe(800);
+		expect(stretched.height).toBe(800);
+
+		// Downscale by width.
+		const downWidth = await createBitmap(blob, { resizeWidth: 800 });
+		expect(downWidth.width).toBe(800);
+		expect(downWidth.height).toBe(200);
+
+		// Downscale by height.
+		const downHeight = await createBitmap(blob, { resizeHeight: 200 });
+		expect(downHeight.height).toBe(200);
+		expect(downHeight.width).toBe(800);
+
+		// Upscale by width: spec allows; a capped fake would
+		// report (4000, 1000) and mask production decoder bugs.
+		const upWidth = await createBitmap(blob, { resizeWidth: 8000 });
+		expect(upWidth.width).toBe(8000);
+		expect(upWidth.height).toBe(2000);
+
+		// Natural.
+		const natural = await createBitmap(blob);
+		expect(natural.width).toBe(4000);
+		expect(natural.height).toBe(1000);
+	});
+
 	it("keeps the File type honest when the encoder falls back to PNG", async () => {
-		// Some browsers without WebP encode support silently return
-		// a PNG. The helper must reflect the actual type on the File
-		// rather than labelling a PNG as WebP.
+		// Some browsers without WebP encode return a PNG; the
+		// File's labelled type must match the actual content.
 		state.convertBlobType = "image/png";
 		const file = new File([new Uint8Array(2 * 1024 * 1024)], "photo.png", {
 			type: "image/png",
@@ -264,35 +401,41 @@ describe("resizeImageToMaxBytes with stubbed decoders", () => {
 		expect(result).not.toBeNull();
 		if (!result) return;
 		expect(result.type).toBe("image/png");
-		// Extension should not claim .webp for a PNG payload.
 		expect(result.name.endsWith(".webp")).toBe(false);
+	});
+
+	it("re-encodes an oversized image/jpg through the resize pipeline", async () => {
+		// Over-budget: ensures the image/jpg alias passes the
+		// allowlist gate and enters the encode pipeline. Removing
+		// the alias from RESIZABLE_MIME_TYPES would short-circuit
+		// to null here.
+		const file = new File([new Uint8Array(3 * 1024 * 1024)], "photo.jpg", {
+			type: "image/jpg",
+		});
+		const result = await resizeImageToMaxBytes(file, 512 * 1024);
+		expect(result).not.toBeNull();
+		expect(state.encodeCalls.length).toBeGreaterThan(0);
+		if (!result) return;
+		expect(result.size).toBeLessThanOrEqual(512 * 1024);
 	});
 });
 
 describeIfDecode("resizeImageToMaxBytes with real decoders", () => {
 	it("returns null (does not throw) for a corrupt image blob", async () => {
-		// Body is not a valid image; decode must fail cleanly and the
-		// caller must see `null` so it can fall back to the original.
-		// Gated on real decoders because the jsdom <img> fallback
-		// never fires onload/onerror and would hang forever.
+		// Real decoder only; jsdom <img> fallback never fires
+		// onload/onerror on a corrupt blob and would hang.
 		const bytes = new Uint8Array([0x00, 0x01, 0x02, 0x03]);
 		const file = new File([bytes], "broken.png", { type: "image/png" });
-		// Force the resize path by picking a budget smaller than the
-		// file so we don't hit the fast-path return.
 		const result = await resizeImageToMaxBytes(file, 1);
 		expect(result).toBeNull();
 	});
 
 	it("re-encodes a large PNG down to the requested byte budget", async () => {
-		// Synthesize a real PNG via OffscreenCanvas so the decode step
-		// has something to work on. 1024x1024 is large enough that the
-		// initial encode typically overshoots a 64 KiB budget,
-		// forcing the iterative shrink path.
 		const canvas = new OffscreenCanvas(1024, 1024);
 		const ctx = canvas.getContext("2d");
 		if (!ctx) throw new Error("no 2d ctx");
-		// Fill with a noise pattern so compression doesn't reduce it
-		// to a trivial byte count before shrinking kicks in.
+		// Noise pattern so compression doesn't trivialize the
+		// byte count before the shrink path runs.
 		const data = ctx.createImageData(1024, 1024);
 		for (let i = 0; i < data.data.length; i += 4) {
 			data.data[i] = (i * 13) & 0xff;
@@ -309,7 +452,6 @@ describeIfDecode("resizeImageToMaxBytes with real decoders", () => {
 		const budget = 64 * 1024;
 		const result = await resizeImageToMaxBytes(file, budget);
 		expect(result).not.toBeNull();
-		// Narrow after the null guard.
 		if (!result) return;
 		expect(result.size).toBeLessThan(budget);
 		expect(result.type).toBe("image/webp");

--- a/site/src/pages/AgentsPage/utils/resizeImage.test.ts
+++ b/site/src/pages/AgentsPage/utils/resizeImage.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { resizeImageToMaxBytes } from "./resizeImage";
+
+// jsdom (the default vitest environment) does not implement
+// createImageBitmap / OffscreenCanvas, so the re-encode codepaths
+// cannot run here. Tests that exercise them are gated behind this
+// flag and will be skipped in jsdom; the rest cover the pure-logic
+// fast paths and failure handling.
+const canDecodeImages =
+	typeof createImageBitmap === "function" &&
+	typeof OffscreenCanvas === "function";
+
+const describeIfDecode = canDecodeImages ? describe : describe.skip;
+
+describe("resizeImageToMaxBytes", () => {
+	it("returns non-image files unchanged", async () => {
+		const file = new File([new Uint8Array([1, 2, 3])], "notes.txt", {
+			type: "text/plain",
+		});
+		const result = await resizeImageToMaxBytes(file, 1024);
+		expect(result).toBe(file);
+	});
+
+	it("returns GIFs unchanged even when oversize", async () => {
+		// Animated GIFs can't be safely re-encoded via canvas
+		// (canvas flattens to a single frame), so resizeImageToMaxBytes
+		// is expected to bail early and hand back the original file.
+		const bytes = new Uint8Array(8 * 1024 * 1024);
+		const file = new File([bytes], "clip.gif", { type: "image/gif" });
+		const result = await resizeImageToMaxBytes(file, 1024 * 1024);
+		expect(result).toBe(file);
+	});
+
+	it("returns the original image unchanged when already under budget", async () => {
+		const bytes = new Uint8Array(1024);
+		const file = new File([bytes], "tiny.png", { type: "image/png" });
+		// Budget larger than file → no work required.
+		const result = await resizeImageToMaxBytes(file, 4096);
+		expect(result).toBe(file);
+	});
+
+	it("returns null for an unsupported image MIME that would need resizing", async () => {
+		// image/svg+xml and similar types are not in the resizable
+		// allowlist; when over budget, the helper refuses to touch
+		// them instead of silently producing garbage.
+		const bytes = new Uint8Array(2 * 1024 * 1024);
+		const file = new File([bytes], "diagram.svg", {
+			type: "image/svg+xml",
+		});
+		const result = await resizeImageToMaxBytes(file, 1024 * 1024);
+		expect(result).toBeNull();
+	});
+});
+
+describeIfDecode("resizeImageToMaxBytes with real decoders", () => {
+	it("returns null (does not throw) for a corrupt image blob", async () => {
+		// Body is not a valid image; decode must fail cleanly and the
+		// caller must see `null` so it can fall back to the original.
+		// Gated on real decoders because the jsdom <img> fallback
+		// never fires onload/onerror and would hang forever.
+		const bytes = new Uint8Array([0x00, 0x01, 0x02, 0x03]);
+		const file = new File([bytes], "broken.png", { type: "image/png" });
+		// Force the resize path by picking a budget smaller than the
+		// file so we don't hit the fast-path return.
+		const result = await resizeImageToMaxBytes(file, 1);
+		expect(result).toBeNull();
+	});
+
+	it("re-encodes a large PNG down to the requested byte budget", async () => {
+		// Synthesize a real PNG via OffscreenCanvas so the decode step
+		// has something to work on. 1024x1024 is large enough that the
+		// initial encode typically overshoots a 64 KiB budget,
+		// forcing the iterative shrink path.
+		const canvas = new OffscreenCanvas(1024, 1024);
+		const ctx = canvas.getContext("2d");
+		if (!ctx) throw new Error("no 2d ctx");
+		// Fill with a noise pattern so compression doesn't reduce it
+		// to a trivial byte count before shrinking kicks in.
+		const data = ctx.createImageData(1024, 1024);
+		for (let i = 0; i < data.data.length; i += 4) {
+			data.data[i] = (i * 13) & 0xff;
+			data.data[i + 1] = (i * 7) & 0xff;
+			data.data[i + 2] = (i * 19) & 0xff;
+			data.data[i + 3] = 0xff;
+		}
+		ctx.putImageData(data, 0, 0);
+		const sourceBlob = await canvas.convertToBlob({ type: "image/png" });
+		const file = new File([sourceBlob], "large.png", {
+			type: "image/png",
+		});
+
+		const budget = 64 * 1024;
+		const result = await resizeImageToMaxBytes(file, budget);
+		expect(result).not.toBeNull();
+		// Narrow after the null guard.
+		if (!result) return;
+		expect(result.size).toBeLessThan(budget);
+		expect(result.type).toBe("image/webp");
+		expect(result.name.endsWith(".webp")).toBe(true);
+	});
+});

--- a/site/src/pages/AgentsPage/utils/resizeImage.test.ts
+++ b/site/src/pages/AgentsPage/utils/resizeImage.test.ts
@@ -1,16 +1,36 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resizeImageToMaxBytes } from "./resizeImage";
 
 // jsdom (the default vitest environment) does not implement
 // createImageBitmap / OffscreenCanvas, so the re-encode codepaths
-// cannot run here. Tests that exercise them are gated behind this
-// flag and will be skipped in jsdom; the rest cover the pure-logic
-// fast paths and failure handling.
+// cannot run against real browser decoders. The "with stubbed
+// decoders" block below installs a deterministic fake so the shrink
+// loop runs in CI; the "with real decoders" block only runs when
+// actual browser APIs are available (e.g. a future Playwright-based
+// vitest project).
 const canDecodeImages =
 	typeof createImageBitmap === "function" &&
 	typeof OffscreenCanvas === "function";
 
 const describeIfDecode = canDecodeImages ? describe : describe.skip;
+
+// Minimum byte count the fake decoder reports for a blob at given
+// dimensions. Sized so the shrink loop runs a realistic number of
+// iterations within the module's MAX_SHRINK_ITERATIONS=8 budget.
+const FAKE_BYTES_PER_PIXEL = 0.5;
+
+// Returns a fake encoded blob whose size is proportional to (width
+// * height * quality) so the shrink loop can observe convergence.
+function fakeEncodedSize(
+	width: number,
+	height: number,
+	quality: number,
+): number {
+	return Math.max(
+		64,
+		Math.round(width * height * quality * FAKE_BYTES_PER_PIXEL),
+	);
+}
 
 describe("resizeImageToMaxBytes", () => {
 	it("returns non-image files unchanged", async () => {
@@ -49,6 +69,203 @@ describe("resizeImageToMaxBytes", () => {
 		});
 		const result = await resizeImageToMaxBytes(file, 1024 * 1024);
 		expect(result).toBeNull();
+	});
+});
+
+describe("resizeImageToMaxBytes with stubbed decoders", () => {
+	// Each test installs its own fakes; track per-test state on a
+	// shared object so the stubs can read the active configuration.
+	interface StubState {
+		srcWidth: number;
+		srcHeight: number;
+		decodeThrows: boolean;
+		convertBlobType: string;
+		decodeCalls: number;
+		encodeCalls: Array<{ width: number; height: number; quality: number }>;
+	}
+
+	let state: StubState;
+
+	beforeEach(() => {
+		state = {
+			srcWidth: 4096,
+			srcHeight: 4096,
+			decodeThrows: false,
+			convertBlobType: "image/webp",
+			decodeCalls: 0,
+			encodeCalls: [],
+		};
+
+		// Fake createImageBitmap: respects resizeWidth/Height the way
+		// the production code relies on (clamp-in-box, preserve
+		// aspect ratio), and records each call for assertions.
+		vi.stubGlobal(
+			"createImageBitmap",
+			vi.fn(
+				async (
+					_blob: Blob,
+					options?: {
+						resizeWidth?: number;
+						resizeHeight?: number;
+					},
+				) => {
+					state.decodeCalls++;
+					if (state.decodeThrows) {
+						throw new Error("decode boom");
+					}
+					let w = state.srcWidth;
+					let h = state.srcHeight;
+					const limit = Math.min(
+						options?.resizeWidth ?? Number.POSITIVE_INFINITY,
+						options?.resizeHeight ?? Number.POSITIVE_INFINITY,
+					);
+					if (Number.isFinite(limit) && limit > 0) {
+						const scale = Math.min(1, limit / w, limit / h);
+						w = Math.max(1, Math.round(w * scale));
+						h = Math.max(1, Math.round(h * scale));
+					}
+					return {
+						width: w,
+						height: h,
+						close: vi.fn(),
+					} as unknown as ImageBitmap;
+				},
+			),
+		);
+
+		// Fake OffscreenCanvas whose convertToBlob returns a blob of
+		// size proportional to (width * height * quality) so the
+		// shrink loop observes convergence.
+		class FakeOffscreenCanvas {
+			width: number;
+			height: number;
+			constructor(w: number, h: number) {
+				this.width = w;
+				this.height = h;
+			}
+			getContext() {
+				// drawImage is called on whatever ctx we return; accept
+				// any args and return nothing — the test isn't
+				// inspecting pixel data.
+				return {
+					drawImage: () => undefined,
+				};
+			}
+			async convertToBlob(opts?: { quality?: number }): Promise<Blob> {
+				const quality = opts?.quality ?? 1;
+				state.encodeCalls.push({
+					width: this.width,
+					height: this.height,
+					quality,
+				});
+				const size = fakeEncodedSize(this.width, this.height, quality);
+				return new Blob([new Uint8Array(size)], {
+					type: state.convertBlobType,
+				});
+			}
+		}
+		vi.stubGlobal("OffscreenCanvas", FakeOffscreenCanvas);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("re-encodes an oversized image down to the requested byte budget", async () => {
+		// 4096² pixels × 0.5 bytes/pixel × 0.85 quality ≈ 7.1 MiB
+		// raw — well over budget, forcing at least a few shrink
+		// iterations before convergence.
+		const file = new File([new Uint8Array(6 * 1024 * 1024)], "big.png", {
+			type: "image/png",
+		});
+		const budget = 512 * 1024;
+		const result = await resizeImageToMaxBytes(file, budget);
+		expect(result).not.toBeNull();
+		if (!result) return;
+		expect(result.size).toBeLessThanOrEqual(budget);
+		expect(result.type).toBe("image/webp");
+		expect(result.name.endsWith(".webp")).toBe(true);
+		// Must have iterated the shrink loop at least once.
+		expect(state.encodeCalls.length).toBeGreaterThan(0);
+	});
+
+	it("passes resizeWidth/resizeHeight to the decoder so the bitmap cannot exceed the clamp", async () => {
+		// Source is far larger than MAX_INITIAL_DIMENSION on both
+		// axes. Without the resizeWidth/Height options the decoder
+		// would allocate a ~60000×40000 bitmap (~9.6 GB RGBA).
+		state.srcWidth = 60_000;
+		state.srcHeight = 40_000;
+		const file = new File([new Uint8Array(6 * 1024 * 1024)], "huge.png", {
+			type: "image/png",
+		});
+		await resizeImageToMaxBytes(file, 256 * 1024);
+		// Every recorded encode must be within the 8192² clamp so we
+		// know the clamp is applied at decode time, not later.
+		for (const call of state.encodeCalls) {
+			expect(call.width).toBeLessThanOrEqual(8192);
+			expect(call.height).toBeLessThanOrEqual(8192);
+		}
+	});
+
+	it("preserves aspect ratio across the shrink loop", async () => {
+		state.srcWidth = 8000;
+		state.srcHeight = 2000; // 4:1 ratio
+		const file = new File([new Uint8Array(6 * 1024 * 1024)], "wide.png", {
+			type: "image/png",
+		});
+		await resizeImageToMaxBytes(file, 32 * 1024);
+		expect(state.encodeCalls.length).toBeGreaterThan(0);
+		for (const call of state.encodeCalls) {
+			// Allow ±1 px rounding across iterative Math.round calls.
+			const ratio = call.width / call.height;
+			expect(ratio).toBeGreaterThanOrEqual(4 - 0.05);
+			expect(ratio).toBeLessThanOrEqual(4 + 0.05);
+		}
+	});
+
+	it("tries the fallback quality pass when shrink iterations saturate", async () => {
+		// Use a source small enough that the fake will continue to
+		// overshoot even at 1×1 (we force this by choosing a
+		// ridiculously small budget); that exhausts the main loop
+		// and triggers the FALLBACK_QUALITY pass.
+		state.srcWidth = 64;
+		state.srcHeight = 64;
+		const file = new File([new Uint8Array(1024 * 1024)], "tiny.png", {
+			type: "image/png",
+		});
+		const result = await resizeImageToMaxBytes(file, 1);
+		// The fake's minimum blob size is 64 bytes, so the budget of
+		// 1 byte is unreachable → null is the expected outcome.
+		expect(result).toBeNull();
+		// Last encode attempt should use FALLBACK_QUALITY (0.7), not
+		// the initial 0.85, proving the fallback ran.
+		const last = state.encodeCalls[state.encodeCalls.length - 1];
+		expect(last.quality).toBeCloseTo(0.7, 5);
+	});
+
+	it("returns null (does not throw) when decode fails", async () => {
+		state.decodeThrows = true;
+		const file = new File([new Uint8Array(1024 * 1024)], "broken.png", {
+			type: "image/png",
+		});
+		const result = await resizeImageToMaxBytes(file, 4096);
+		expect(result).toBeNull();
+	});
+
+	it("keeps the File type honest when the encoder falls back to PNG", async () => {
+		// Some browsers without WebP encode support silently return
+		// a PNG. The helper must reflect the actual type on the File
+		// rather than labelling a PNG as WebP.
+		state.convertBlobType = "image/png";
+		const file = new File([new Uint8Array(2 * 1024 * 1024)], "photo.png", {
+			type: "image/png",
+		});
+		const result = await resizeImageToMaxBytes(file, 1024 * 1024);
+		expect(result).not.toBeNull();
+		if (!result) return;
+		expect(result.type).toBe("image/png");
+		// Extension should not claim .webp for a PNG payload.
+		expect(result.name.endsWith(".webp")).toBe(false);
 	});
 });
 

--- a/site/src/pages/AgentsPage/utils/resizeImage.ts
+++ b/site/src/pages/AgentsPage/utils/resizeImage.ts
@@ -1,21 +1,11 @@
 /**
- * Browser-side image resizing for provider-specific payload budgets.
- *
- * Motivation: Anthropic rejects inline images over 5,242,880 bytes
- * (5 MiB). Our upload endpoint otherwise accepts images up to 10 MiB,
- * so oversized images would reach the model and fail. Resizing on the
- * client avoids having the server decode attacker-controlled image
- * bytes (image-bomb DoS surface).
- *
- * This module is plain TS — no React — so it can be called from any
- * upload pipeline.
+ * Browser-side image re-encoding to a caller-supplied byte budget.
+ * Plain TS (no React) so it can be used by any upload pipeline.
  */
 
-// Formats we know how to safely re-encode. GIFs are intentionally
-// excluded: canvas re-encoding would flatten animation to a single
-// frame, which is worse than failing the budget check. `image/jpg`
-// is a non-IANA alias some OSes/uploaders emit for .jpg files; we
-// accept it as an alias for `image/jpeg`.
+// Formats we re-encode. GIFs are excluded so we don't flatten
+// animation; image/jpg is a non-IANA alias for image/jpeg some
+// OSes emit.
 const RESIZABLE_MIME_TYPES = new Set([
 	"image/png",
 	"image/jpeg",
@@ -23,48 +13,34 @@ const RESIZABLE_MIME_TYPES = new Set([
 	"image/webp",
 ]);
 
-// Canvas dimensions are clamped here because several browsers limit
-// the maximum decoded canvas area (Safari historically ~4096² on
-// mobile, Chrome ~16384 per side on desktop). 8192 is a safe
-// conservative lower bound that still preserves plenty of detail for
-// typical screenshots. Applied at the createImageBitmap boundary so
-// the raw decoded bitmap never exceeds the clamp — a low-byte image
-// with pathologically large pixel extent therefore cannot OOM the
-// tab on decode.
+// Per-axis clamp applied at decode so a low-byte image with
+// pathologically large pixel extent can't OOM the tab. 8192 stays
+// under Safari/Chrome canvas limits while preserving detail for
+// typical screenshots.
 const MAX_INITIAL_DIMENSION = 8192;
 
-// Maximum number of shrink iterations before we give up. Each
-// iteration multiplies dimensions by DIMENSION_STEP, so after N
-// iterations the image is ~DIMENSION_STEP^N of the original on each
-// axis. 8 iterations → ~17% of original dimensions → ~3% of original
-// pixels, which is plenty of headroom for any image that was only
-// modestly over budget.
+// 8 iterations × DIMENSION_STEP per axis gives ~3% of original
+// pixels, plenty of headroom for any modestly-oversize image.
 const MAX_SHRINK_ITERATIONS = 8;
 const DIMENSION_STEP = 0.8;
 
-// Initial and fallback WebP quality parameters. WebP at 0.85 is
-// visually near-lossless for screenshots; 0.7 is the hail-mary that
-// runs only if dimension shrinking alone didn't fit the budget.
+// 0.85 is near-lossless for screenshots; 0.7 is a hail-mary if
+// dimension shrinking alone didn't fit the budget.
 const INITIAL_QUALITY = 0.85;
 const FALLBACK_QUALITY = 0.7;
 
-// Timeout for the legacy <img>-based decode fallback. The fallback
-// is only used when createImageBitmap isn't available (very old
-// Safari, some embedded webviews, some test envs); capping it here
-// prevents a pathological blob that fires neither onload nor
-// onerror from wedging the module queue for the tab's lifetime.
+// Time-bound the legacy <img> decode fallback so a blob that fires
+// neither onload nor onerror can't wedge the module queue.
 const FALLBACK_DECODE_TIMEOUT_MS = 10_000;
 
-// Sequential queue so pasting or dropping many images doesn't spawn
-// many simultaneous decode pipelines. Each call waits for the
-// previous to finish before starting.
+// Sequential queue: pasting many images won't spawn parallel
+// decode pipelines.
 let queue: Promise<unknown> = Promise.resolve();
 
 function enqueue<T>(fn: () => Promise<T>): Promise<T> {
-	// Chain fn off both settlement branches so the next queued task
-	// runs regardless of whether the previous one resolved or
-	// rejected; the .catch below then detaches rejection from the
-	// shared tail so later calls don't inherit a poisoned promise.
+	// Chain off both settlement branches so the next task runs
+	// after a rejection too; the .catch below detaches rejection
+	// from the shared tail.
 	const next = queue.then(fn, fn);
 	queue = next.catch(() => undefined);
 	return next;
@@ -91,18 +67,18 @@ export async function resizeImageToMaxBytes(
 	if (!file.type.startsWith("image/")) {
 		return file;
 	}
-	// Animated formats — return as-is rather than silently producing
-	// a single-frame still.
+	// GIFs return as-is so we don't flatten animation.
 	if (file.type === "image/gif") {
 		return file;
 	}
-	// Fast path: already within budget in a format the server allows.
-	// Uses <= to match the caller's gate (useFileAttachments) and the
-	// server-side cap predicate, so a file at exactly `maxBytes` is
-	// consistently treated as "already fits".
-	if (file.size <= maxBytes && RESIZABLE_MIME_TYPES.has(file.type)) {
+	// Already under budget; return as-is regardless of MIME (the
+	// function's contract is "give me something <= maxBytes" and
+	// we already have that).
+	if (file.size <= maxBytes) {
 		return file;
 	}
+	// Over budget but unsupported MIME (e.g. image/bmp): refuse
+	// rather than silently produce a black canvas or wrong file.
 	if (!RESIZABLE_MIME_TYPES.has(file.type)) {
 		return null;
 	}
@@ -122,11 +98,9 @@ async function shrinkOnce(file: File, maxBytes: number): Promise<File | null> {
 	}
 
 	try {
-		// createImageBitmap with resizeWidth/resizeHeight has already
-		// clamped the bitmap to at most MAX_INITIAL_DIMENSION per
-		// axis (see decodeToBitmap), preserving aspect ratio. We can
-		// therefore start the shrink loop directly at the bitmap's
-		// reported dimensions without a separate manual clamp.
+		// decodeToBitmap already clamped to MAX_INITIAL_DIMENSION
+		// per axis, so we start the shrink loop from the bitmap's
+		// reported dimensions.
 		let width = bitmap.width;
 		let height = bitmap.height;
 		if (width <= 0 || height <= 0) {
@@ -146,9 +120,9 @@ async function shrinkOnce(file: File, maxBytes: number): Promise<File | null> {
 			height = Math.max(1, Math.round(height * DIMENSION_STEP));
 		}
 
-		// Last-ditch attempt at the smallest dimensions with a lower
-		// quality setting. Useful for mostly-photographic images where
-		// dimension shrinking alone saturated.
+		// Last-ditch attempt at the smallest dimensions with a
+		// lower quality, for photographic images where dimension
+		// shrinking alone saturated.
 		const fallbackBlob = await encodeWebP(
 			bitmap,
 			width,
@@ -167,22 +141,88 @@ async function shrinkOnce(file: File, maxBytes: number): Promise<File | null> {
 }
 
 async function decodeToBitmap(file: File): Promise<ImageBitmap | null> {
-	// createImageBitmap is the fastest path and avoids ever drawing
-	// through an <img> tag (which would require DOM attachment in
-	// some browsers). The resize* options clamp the decoded bitmap
-	// before it reaches memory, so a small file with pathological
-	// pixel extent cannot blow up RAM here.
-	if (typeof createImageBitmap === "function") {
+	// createImageBitmap's HTML-spec output rules:
+	//   - both resize dims => stretch (destroys aspect ratio).
+	//   - only resizeWidth => width is exact, height proportional.
+	//     Per spec this UPSCALES if resizeWidth > natural width.
+	//   - both omitted => source's natural size.
+	//
+	// Upscaling can blow past Chromium's ~268M-pixel decode limit
+	// (e.g. a 1080x5000 screenshot with resizeWidth: 8192 becomes
+	// ~310M pixels). Probe natural dimensions first to pick the
+	// smallest resize option that fits.
+	if (typeof createImageBitmap !== "function") {
+		return await decodeViaImgFallback(file);
+	}
+	const natural = await probeNaturalDimensions(file);
+	if (!natural) {
+		return await decodeViaImgFallback(file);
+	}
+	const { width, height } = natural;
+	if (width <= 0 || height <= 0) {
+		return null;
+	}
+	// Pick the smallest resize that fits MAX_INITIAL_DIMENSION
+	// without upscaling. Already-small sources pass no options.
+	const needsWidthClamp = width > MAX_INITIAL_DIMENSION;
+	const needsHeightClamp = height > MAX_INITIAL_DIMENSION;
+	if (!needsWidthClamp && !needsHeightClamp) {
+		return await createImageBitmap(file);
+	}
+	// Clamp the longer axis; the shorter axis scales with it.
+	if (width >= height) {
 		return await createImageBitmap(file, {
 			resizeWidth: MAX_INITIAL_DIMENSION,
-			resizeHeight: MAX_INITIAL_DIMENSION,
 			resizeQuality: "medium",
 		});
 	}
-	// Fallback: decode via <img> + Blob URL. Only reached on very
-	// old browsers and in some test environments. This path does
-	// not get the decode-time clamp, but it is intentionally
-	// time-bounded so a stuck decoder can't wedge the shared queue.
+	return await createImageBitmap(file, {
+		resizeHeight: MAX_INITIAL_DIMENSION,
+		resizeQuality: "medium",
+	});
+}
+
+// Reads natural dimensions via <img> without allocating a full
+// ImageBitmap. Returns null on decode/timeout failure.
+async function probeNaturalDimensions(
+	file: File,
+): Promise<{ width: number; height: number } | null> {
+	return await new Promise<{ width: number; height: number } | null>(
+		(resolve) => {
+			const url = URL.createObjectURL(file);
+			const img = new Image();
+			let settled = false;
+			const cleanup = () => {
+				settled = true;
+				URL.revokeObjectURL(url);
+			};
+			const timer = setTimeout(() => {
+				if (settled) return;
+				cleanup();
+				resolve(null);
+			}, FALLBACK_DECODE_TIMEOUT_MS);
+			img.onload = () => {
+				if (settled) return;
+				clearTimeout(timer);
+				cleanup();
+				resolve({ width: img.naturalWidth, height: img.naturalHeight });
+			};
+			img.onerror = () => {
+				if (settled) return;
+				clearTimeout(timer);
+				cleanup();
+				resolve(null);
+			};
+			img.src = url;
+		},
+	);
+}
+
+async function decodeViaImgFallback(file: File): Promise<ImageBitmap | null> {
+	// Decode via <img> + Blob URL. Reached only on browsers
+	// without createImageBitmap (very old Safari, embedded
+	// webviews); time-bounded so a stuck decoder can't wedge the
+	// queue. No decode-time clamp on this path.
 	return await new Promise<ImageBitmap | null>((resolve, reject) => {
 		const url = URL.createObjectURL(file);
 		const img = new Image();
@@ -200,9 +240,8 @@ async function decodeToBitmap(file: File): Promise<ImageBitmap | null> {
 			if (settled) return;
 			clearTimeout(timer);
 			cleanup();
-			// Best-effort cast: HTMLImageElement is acceptable as a
-			// CanvasImageSource and we only need width/height plus the
-			// drawable surface below.
+			// HTMLImageElement is a valid CanvasImageSource;
+			// width/height are all we need downstream.
 			resolve(img as unknown as ImageBitmap);
 		};
 		img.onerror = () => {
@@ -221,8 +260,8 @@ async function encodeWebP(
 	height: number,
 	quality: number,
 ): Promise<Blob | null> {
-	// Prefer OffscreenCanvas when available — its convertToBlob is
-	// fully async and does not require the canvas to be laid out.
+	// OffscreenCanvas's convertToBlob is fully async and doesn't
+	// need the canvas laid out.
 	if (typeof OffscreenCanvas === "function") {
 		const canvas = new OffscreenCanvas(width, height);
 		const ctx = canvas.getContext("2d");
@@ -237,8 +276,7 @@ async function encodeWebP(
 		}
 	}
 
-	// HTMLCanvasElement fallback for environments without
-	// OffscreenCanvas (older Safari, some embedded webviews).
+	// Fallback for environments without OffscreenCanvas.
 	const canvas = document.createElement("canvas");
 	canvas.width = width;
 	canvas.height = height;
@@ -253,18 +291,14 @@ async function encodeWebP(
 }
 
 function toWebPFile(original: File, blob: Blob): File {
-	// Replace the extension (if any) with .webp so the filename
-	// matches the new content type. Some web upload handlers and
-	// file-picker dialogs still key behavior off the extension even
-	// when the MIME type is correct, so keeping them consistent
-	// avoids surprises.
+	// Match the extension to the actual content type; some upload
+	// handlers still key behavior off the extension.
 	const dot = original.name.lastIndexOf(".");
 	const baseName = dot > 0 ? original.name.slice(0, dot) : original.name;
 	const webpName = `${baseName || "image"}.webp`;
-	// Prefer the blob's reported MIME type. canvas.toBlob/
-	// convertToBlob fall back to image/png on browsers without WebP
-	// encode support; trusting the browser's label keeps the File
-	// type honest instead of labelling a PNG as WebP.
+	// Use blob.type: canvas encoders fall back to PNG on browsers
+	// without WebP support; this keeps the File's labelled type
+	// matching its actual content.
 	const effectiveType = blob.type || "image/webp";
 	const effectiveName =
 		effectiveType === "image/webp" ? webpName : original.name;

--- a/site/src/pages/AgentsPage/utils/resizeImage.ts
+++ b/site/src/pages/AgentsPage/utils/resizeImage.ts
@@ -13,7 +13,9 @@
 
 // Formats we know how to safely re-encode. GIFs are intentionally
 // excluded: canvas re-encoding would flatten animation to a single
-// frame, which is worse than failing the budget check.
+// frame, which is worse than failing the budget check. `image/jpg`
+// is a non-IANA alias some OSes/uploaders emit for .jpg files; we
+// accept it as an alias for `image/jpeg`.
 const RESIZABLE_MIME_TYPES = new Set([
 	"image/png",
 	"image/jpeg",
@@ -25,7 +27,10 @@ const RESIZABLE_MIME_TYPES = new Set([
 // the maximum decoded canvas area (Safari historically ~4096² on
 // mobile, Chrome ~16384 per side on desktop). 8192 is a safe
 // conservative lower bound that still preserves plenty of detail for
-// typical screenshots.
+// typical screenshots. Applied at the createImageBitmap boundary so
+// the raw decoded bitmap never exceeds the clamp — a low-byte image
+// with pathologically large pixel extent therefore cannot OOM the
+// tab on decode.
 const MAX_INITIAL_DIMENSION = 8192;
 
 // Maximum number of shrink iterations before we give up. Each
@@ -43,24 +48,33 @@ const DIMENSION_STEP = 0.8;
 const INITIAL_QUALITY = 0.85;
 const FALLBACK_QUALITY = 0.7;
 
+// Timeout for the legacy <img>-based decode fallback. The fallback
+// is only used when createImageBitmap isn't available (very old
+// Safari, some embedded webviews, some test envs); capping it here
+// prevents a pathological blob that fires neither onload nor
+// onerror from wedging the module queue for the tab's lifetime.
+const FALLBACK_DECODE_TIMEOUT_MS = 10_000;
+
 // Sequential queue so pasting or dropping many images doesn't spawn
 // many simultaneous decode pipelines. Each call waits for the
 // previous to finish before starting.
 let queue: Promise<unknown> = Promise.resolve();
 
 function enqueue<T>(fn: () => Promise<T>): Promise<T> {
+	// Chain fn off both settlement branches so the next queued task
+	// runs regardless of whether the previous one resolved or
+	// rejected; the .catch below then detaches rejection from the
+	// shared tail so later calls don't inherit a poisoned promise.
 	const next = queue.then(fn, fn);
-	// Swallow rejection on the chain itself so later calls don't
-	// inherit it; the caller still sees the original rejection.
 	queue = next.catch(() => undefined);
 	return next;
 }
 
 /**
  * Re-encode `file` as WebP, iteratively shrinking until the output
- * is strictly smaller than `maxBytes`.
+ * is at or below `maxBytes`.
  *
- * - Returns the original `file` unchanged when it is already under
+ * - Returns the original `file` unchanged when it is already within
  *   the budget and its MIME type is in our resizable set (no need
  *   to pay the decode cost).
  * - Returns the original `file` unchanged for animated formats like
@@ -82,8 +96,11 @@ export async function resizeImageToMaxBytes(
 	if (file.type === "image/gif") {
 		return file;
 	}
-	// Fast path: already under budget in a format the server allows.
-	if (file.size < maxBytes && RESIZABLE_MIME_TYPES.has(file.type)) {
+	// Fast path: already within budget in a format the server allows.
+	// Uses <= to match the caller's gate (useFileAttachments) and the
+	// server-side cap predicate, so a file at exactly `maxBytes` is
+	// consistently treated as "already fits".
+	if (file.size <= maxBytes && RESIZABLE_MIME_TYPES.has(file.type)) {
 		return file;
 	}
 	if (!RESIZABLE_MIME_TYPES.has(file.type)) {
@@ -105,25 +122,20 @@ async function shrinkOnce(file: File, maxBytes: number): Promise<File | null> {
 	}
 
 	try {
-		let width = Math.min(bitmap.width, MAX_INITIAL_DIMENSION);
-		let height = Math.min(bitmap.height, MAX_INITIAL_DIMENSION);
+		// createImageBitmap with resizeWidth/resizeHeight has already
+		// clamped the bitmap to at most MAX_INITIAL_DIMENSION per
+		// axis (see decodeToBitmap), preserving aspect ratio. We can
+		// therefore start the shrink loop directly at the bitmap's
+		// reported dimensions without a separate manual clamp.
+		let width = bitmap.width;
+		let height = bitmap.height;
 		if (width <= 0 || height <= 0) {
 			return null;
-		}
-		// Preserve aspect ratio when the source exceeds the clamp.
-		const ratio = bitmap.width / bitmap.height;
-		if (bitmap.width > MAX_INITIAL_DIMENSION) {
-			width = MAX_INITIAL_DIMENSION;
-			height = Math.max(1, Math.round(MAX_INITIAL_DIMENSION / ratio));
-		}
-		if (bitmap.height > MAX_INITIAL_DIMENSION) {
-			height = MAX_INITIAL_DIMENSION;
-			width = Math.max(1, Math.round(MAX_INITIAL_DIMENSION * ratio));
 		}
 
 		for (let i = 0; i < MAX_SHRINK_ITERATIONS; i++) {
 			const blob = await encodeWebP(bitmap, width, height, INITIAL_QUALITY);
-			if (blob && blob.size < maxBytes) {
+			if (blob && blob.size <= maxBytes) {
 				return toWebPFile(file, blob);
 			}
 			// Guard against tiny images that can't shrink further.
@@ -143,7 +155,7 @@ async function shrinkOnce(file: File, maxBytes: number): Promise<File | null> {
 			height,
 			FALLBACK_QUALITY,
 		);
-		if (fallbackBlob && fallbackBlob.size < maxBytes) {
+		if (fallbackBlob && fallbackBlob.size <= maxBytes) {
 			return toWebPFile(file, fallbackBlob);
 		}
 		return null;
@@ -157,24 +169,46 @@ async function shrinkOnce(file: File, maxBytes: number): Promise<File | null> {
 async function decodeToBitmap(file: File): Promise<ImageBitmap | null> {
 	// createImageBitmap is the fastest path and avoids ever drawing
 	// through an <img> tag (which would require DOM attachment in
-	// some browsers).
+	// some browsers). The resize* options clamp the decoded bitmap
+	// before it reaches memory, so a small file with pathological
+	// pixel extent cannot blow up RAM here.
 	if (typeof createImageBitmap === "function") {
-		return await createImageBitmap(file);
+		return await createImageBitmap(file, {
+			resizeWidth: MAX_INITIAL_DIMENSION,
+			resizeHeight: MAX_INITIAL_DIMENSION,
+			resizeQuality: "medium",
+		});
 	}
 	// Fallback: decode via <img> + Blob URL. Only reached on very
-	// old browsers and in some test environments.
+	// old browsers and in some test environments. This path does
+	// not get the decode-time clamp, but it is intentionally
+	// time-bounded so a stuck decoder can't wedge the shared queue.
 	return await new Promise<ImageBitmap | null>((resolve, reject) => {
 		const url = URL.createObjectURL(file);
 		const img = new Image();
-		img.onload = () => {
+		let settled = false;
+		const cleanup = () => {
+			settled = true;
 			URL.revokeObjectURL(url);
+		};
+		const timer = setTimeout(() => {
+			if (settled) return;
+			cleanup();
+			reject(new Error("image decode timed out"));
+		}, FALLBACK_DECODE_TIMEOUT_MS);
+		img.onload = () => {
+			if (settled) return;
+			clearTimeout(timer);
+			cleanup();
 			// Best-effort cast: HTMLImageElement is acceptable as a
 			// CanvasImageSource and we only need width/height plus the
 			// drawable surface below.
 			resolve(img as unknown as ImageBitmap);
 		};
 		img.onerror = () => {
-			URL.revokeObjectURL(url);
+			if (settled) return;
+			clearTimeout(timer);
+			cleanup();
 			reject(new Error("image decode failed"));
 		};
 		img.src = url;
@@ -220,13 +254,22 @@ async function encodeWebP(
 
 function toWebPFile(original: File, blob: Blob): File {
 	// Replace the extension (if any) with .webp so the filename
-	// matches the new content type. File browsers sometimes key
-	// handling off the extension even when the MIME is correct.
+	// matches the new content type. Some web upload handlers and
+	// file-picker dialogs still key behavior off the extension even
+	// when the MIME type is correct, so keeping them consistent
+	// avoids surprises.
 	const dot = original.name.lastIndexOf(".");
 	const baseName = dot > 0 ? original.name.slice(0, dot) : original.name;
 	const webpName = `${baseName || "image"}.webp`;
-	return new File([blob], webpName, {
-		type: "image/webp",
+	// Prefer the blob's reported MIME type. canvas.toBlob/
+	// convertToBlob fall back to image/png on browsers without WebP
+	// encode support; trusting the browser's label keeps the File
+	// type honest instead of labelling a PNG as WebP.
+	const effectiveType = blob.type || "image/webp";
+	const effectiveName =
+		effectiveType === "image/webp" ? webpName : original.name;
+	return new File([blob], effectiveName, {
+		type: effectiveType,
 		lastModified: original.lastModified,
 	});
 }

--- a/site/src/pages/AgentsPage/utils/resizeImage.ts
+++ b/site/src/pages/AgentsPage/utils/resizeImage.ts
@@ -1,0 +1,232 @@
+/**
+ * Browser-side image resizing for provider-specific payload budgets.
+ *
+ * Motivation: Anthropic rejects inline images over 5,242,880 bytes
+ * (5 MiB). Our upload endpoint otherwise accepts images up to 10 MiB,
+ * so oversized images would reach the model and fail. Resizing on the
+ * client avoids having the server decode attacker-controlled image
+ * bytes (image-bomb DoS surface).
+ *
+ * This module is plain TS — no React — so it can be called from any
+ * upload pipeline.
+ */
+
+// Formats we know how to safely re-encode. GIFs are intentionally
+// excluded: canvas re-encoding would flatten animation to a single
+// frame, which is worse than failing the budget check.
+const RESIZABLE_MIME_TYPES = new Set([
+	"image/png",
+	"image/jpeg",
+	"image/jpg",
+	"image/webp",
+]);
+
+// Canvas dimensions are clamped here because several browsers limit
+// the maximum decoded canvas area (Safari historically ~4096² on
+// mobile, Chrome ~16384 per side on desktop). 8192 is a safe
+// conservative lower bound that still preserves plenty of detail for
+// typical screenshots.
+const MAX_INITIAL_DIMENSION = 8192;
+
+// Maximum number of shrink iterations before we give up. Each
+// iteration multiplies dimensions by DIMENSION_STEP, so after N
+// iterations the image is ~DIMENSION_STEP^N of the original on each
+// axis. 8 iterations → ~17% of original dimensions → ~3% of original
+// pixels, which is plenty of headroom for any image that was only
+// modestly over budget.
+const MAX_SHRINK_ITERATIONS = 8;
+const DIMENSION_STEP = 0.8;
+
+// Initial and fallback WebP quality parameters. WebP at 0.85 is
+// visually near-lossless for screenshots; 0.7 is the hail-mary that
+// runs only if dimension shrinking alone didn't fit the budget.
+const INITIAL_QUALITY = 0.85;
+const FALLBACK_QUALITY = 0.7;
+
+// Sequential queue so pasting or dropping many images doesn't spawn
+// many simultaneous decode pipelines. Each call waits for the
+// previous to finish before starting.
+let queue: Promise<unknown> = Promise.resolve();
+
+function enqueue<T>(fn: () => Promise<T>): Promise<T> {
+	const next = queue.then(fn, fn);
+	// Swallow rejection on the chain itself so later calls don't
+	// inherit it; the caller still sees the original rejection.
+	queue = next.catch(() => undefined);
+	return next;
+}
+
+/**
+ * Re-encode `file` as WebP, iteratively shrinking until the output
+ * is strictly smaller than `maxBytes`.
+ *
+ * - Returns the original `file` unchanged when it is already under
+ *   the budget and its MIME type is in our resizable set (no need
+ *   to pay the decode cost).
+ * - Returns the original `file` unchanged for animated formats like
+ *   GIF where canvas re-encoding would destroy the animation.
+ * - Returns a new `File` (WebP, renamed to `.webp`) when resizing
+ *   succeeded.
+ * - Returns `null` when the file cannot be decoded or no iteration
+ *   fit the budget; callers fall back to the original file.
+ */
+export async function resizeImageToMaxBytes(
+	file: File,
+	maxBytes: number,
+): Promise<File | null> {
+	if (!file.type.startsWith("image/")) {
+		return file;
+	}
+	// Animated formats — return as-is rather than silently producing
+	// a single-frame still.
+	if (file.type === "image/gif") {
+		return file;
+	}
+	// Fast path: already under budget in a format the server allows.
+	if (file.size < maxBytes && RESIZABLE_MIME_TYPES.has(file.type)) {
+		return file;
+	}
+	if (!RESIZABLE_MIME_TYPES.has(file.type)) {
+		return null;
+	}
+
+	return enqueue(() => shrinkOnce(file, maxBytes));
+}
+
+async function shrinkOnce(file: File, maxBytes: number): Promise<File | null> {
+	let bitmap: ImageBitmap | null = null;
+	try {
+		bitmap = await decodeToBitmap(file);
+	} catch {
+		return null;
+	}
+	if (!bitmap) {
+		return null;
+	}
+
+	try {
+		let width = Math.min(bitmap.width, MAX_INITIAL_DIMENSION);
+		let height = Math.min(bitmap.height, MAX_INITIAL_DIMENSION);
+		if (width <= 0 || height <= 0) {
+			return null;
+		}
+		// Preserve aspect ratio when the source exceeds the clamp.
+		const ratio = bitmap.width / bitmap.height;
+		if (bitmap.width > MAX_INITIAL_DIMENSION) {
+			width = MAX_INITIAL_DIMENSION;
+			height = Math.max(1, Math.round(MAX_INITIAL_DIMENSION / ratio));
+		}
+		if (bitmap.height > MAX_INITIAL_DIMENSION) {
+			height = MAX_INITIAL_DIMENSION;
+			width = Math.max(1, Math.round(MAX_INITIAL_DIMENSION * ratio));
+		}
+
+		for (let i = 0; i < MAX_SHRINK_ITERATIONS; i++) {
+			const blob = await encodeWebP(bitmap, width, height, INITIAL_QUALITY);
+			if (blob && blob.size < maxBytes) {
+				return toWebPFile(file, blob);
+			}
+			// Guard against tiny images that can't shrink further.
+			if (width <= 1 || height <= 1) {
+				break;
+			}
+			width = Math.max(1, Math.round(width * DIMENSION_STEP));
+			height = Math.max(1, Math.round(height * DIMENSION_STEP));
+		}
+
+		// Last-ditch attempt at the smallest dimensions with a lower
+		// quality setting. Useful for mostly-photographic images where
+		// dimension shrinking alone saturated.
+		const fallbackBlob = await encodeWebP(
+			bitmap,
+			width,
+			height,
+			FALLBACK_QUALITY,
+		);
+		if (fallbackBlob && fallbackBlob.size < maxBytes) {
+			return toWebPFile(file, fallbackBlob);
+		}
+		return null;
+	} catch {
+		return null;
+	} finally {
+		bitmap.close?.();
+	}
+}
+
+async function decodeToBitmap(file: File): Promise<ImageBitmap | null> {
+	// createImageBitmap is the fastest path and avoids ever drawing
+	// through an <img> tag (which would require DOM attachment in
+	// some browsers).
+	if (typeof createImageBitmap === "function") {
+		return await createImageBitmap(file);
+	}
+	// Fallback: decode via <img> + Blob URL. Only reached on very
+	// old browsers and in some test environments.
+	return await new Promise<ImageBitmap | null>((resolve, reject) => {
+		const url = URL.createObjectURL(file);
+		const img = new Image();
+		img.onload = () => {
+			URL.revokeObjectURL(url);
+			// Best-effort cast: HTMLImageElement is acceptable as a
+			// CanvasImageSource and we only need width/height plus the
+			// drawable surface below.
+			resolve(img as unknown as ImageBitmap);
+		};
+		img.onerror = () => {
+			URL.revokeObjectURL(url);
+			reject(new Error("image decode failed"));
+		};
+		img.src = url;
+	});
+}
+
+async function encodeWebP(
+	source: ImageBitmap,
+	width: number,
+	height: number,
+	quality: number,
+): Promise<Blob | null> {
+	// Prefer OffscreenCanvas when available — its convertToBlob is
+	// fully async and does not require the canvas to be laid out.
+	if (typeof OffscreenCanvas === "function") {
+		const canvas = new OffscreenCanvas(width, height);
+		const ctx = canvas.getContext("2d");
+		if (!ctx) {
+			return null;
+		}
+		ctx.drawImage(source, 0, 0, width, height);
+		try {
+			return await canvas.convertToBlob({ type: "image/webp", quality });
+		} catch {
+			return null;
+		}
+	}
+
+	// HTMLCanvasElement fallback for environments without
+	// OffscreenCanvas (older Safari, some embedded webviews).
+	const canvas = document.createElement("canvas");
+	canvas.width = width;
+	canvas.height = height;
+	const ctx = canvas.getContext("2d");
+	if (!ctx) {
+		return null;
+	}
+	ctx.drawImage(source as CanvasImageSource, 0, 0, width, height);
+	return await new Promise<Blob | null>((resolve) => {
+		canvas.toBlob((blob) => resolve(blob), "image/webp", quality);
+	});
+}
+
+function toWebPFile(original: File, blob: Blob): File {
+	// Replace the extension (if any) with .webp so the filename
+	// matches the new content type. File browsers sometimes key
+	// handling off the extension even when the MIME is correct.
+	const dot = original.name.lastIndexOf(".");
+	const baseName = dot > 0 ? original.name.slice(0, dot) : original.name;
+	const webpName = `${baseName || "image"}.webp`;
+	return new File([blob], webpName, {
+		type: "image/webp",
+		lastModified: original.lastModified,
+	});
+}


### PR DESCRIPTION
Anthropic rejects inline images over 5,242,880 bytes, but our upload
endpoint accepts images up to 10 MiB — so 5–10 MiB images were
reaching the provider and failing. This adds two layers of
protection: the browser resizes oversized images before upload, and
the server rejects any that still slip through before an upstream
request is issued.

Client-side resizing uses `createImageBitmap` with
`resizeWidth`/`resizeHeight` to clamp the decoded bitmap at decode
time, then iteratively shrinks on an `OffscreenCanvas` (falling back
to `HTMLCanvasElement`) until the output fits the applicable budget.
Anthropic (and Bedrock-hosted Claude — fantasy's bedrock provider is
a thin wrapper around the Anthropic client) uses a ~5 MiB budget;
other providers use a ~10 MiB budget to stay under the server cap.
Doing the resize in the browser avoids decoding attacker-controlled
image bytes in `coderd` (image-bomb DoS surface).

Server-side, `chatFileResolver` now takes a provider string and
looks up the inline-image cap via a new `chatprovider.InlineImageByteCap`
helper; oversized `image/*` files for capped providers are rejected
with a pre-classified `chaterror` before the SDK call. The backstop
fires for older clients, direct API callers, or any image that was
committed to the composer before the user switched to a stricter
provider.

Attachments commit to composer state synchronously with a new
`"processing"` `UploadState` so paste+Enter can't dispatch before
the resize finishes; the `"uploading"` send gate now covers both
states. Dismissed-while-resizing attachments are tracked in a
`WeakSet` so a late swap can't resurrect a removed file.

Closes CODAGT-215
