### PR TITLE
fix: rebuild modeloptionsgen when codersdk changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,9 @@ _gen/bin/metricsdocgen-scanner: $(wildcard scripts/metricsdocgen/scanner/*.go) |
 	@mkdir -p _gen/bin
 	go build -o $@ ./scripts/metricsdocgen/scanner
 
-_gen/bin/modeloptionsgen: $(wildcard scripts/modeloptionsgen/*.go) | _gen
+# modeloptionsgen reflects over codersdk chat model types, so it must
+# rebuild when those struct tags change.
+_gen/bin/modeloptionsgen: $(wildcard scripts/modeloptionsgen/*.go) $(wildcard codersdk/*.go) | _gen
 	@mkdir -p _gen/bin
 	go build -o $@ ./scripts/modeloptionsgen
 

--- a/Makefile
+++ b/Makefile
@@ -151,8 +151,6 @@ _gen/bin/metricsdocgen-scanner: $(wildcard scripts/metricsdocgen/scanner/*.go) |
 	@mkdir -p _gen/bin
 	go build -o $@ ./scripts/metricsdocgen/scanner
 
-# modeloptionsgen reflects over codersdk chat model types, so it must
-# rebuild when those struct tags change.
 _gen/bin/modeloptionsgen: $(wildcard scripts/modeloptionsgen/*.go) $(wildcard codersdk/*.go) | _gen
 	@mkdir -p _gen/bin
 	go build -o $@ ./scripts/modeloptionsgen


### PR DESCRIPTION
`_gen/bin/modeloptionsgen` reflects over `codersdk` struct tags, but reflection doesn't read source — Go struct tags are compile-time string literals folded into the type descriptor and emitted into the binary's `.rodata` section. `reflect.TypeOf(...).Field(i).Tag.Get("enum")` reads from that baked-in table; the generator cannot consult `codersdk/chats.go` on disk even if it wanted to.

That means the binary has to be rebuilt whenever those tags change. The existing Makefile rule only depends on `scripts/modeloptionsgen/*.go`, and the JSON target lists the binary as an order-only prereq, so `make gen` happily runs the stale binary after edits to `codersdk/chats.go` and writes outdated enum values.

Fix: add `$(wildcard codersdk/*.go)` to the binary's prereqs, matching `clidocgen`. The whole-package wildcard is deliberate — a narrower prereq would break if someone splits `chats.go`. Cost is negligible: Go's per-package build cache means unrelated edits recompile one package and re-link, and the JSON target's own prereqs are unchanged so it doesn't regenerate.