### PR TITLE
fix(site/e2e): wait for file upload before submitting create template form

### DIFF
--- a/site/e2e/helpers.ts
+++ b/site/e2e/helpers.ts
@@ -294,6 +294,13 @@ export const createTemplate = async (
 			mimeType: "application/x-tar",
 			name: "template.tar",
 		});
+		// setInputFiles triggers the upload API call through React's
+		// onChange handler, but the call is fire-and-forget (not awaited
+		// in the component chain). Wait for the upload to finish so
+		// uploadedFile.hash is available when the form submits.
+		await expect(
+			page.getByRole("button", { name: "Remove file" }),
+		).toBeVisible();
 	}
 
 	// If the organization picker is present on the page, select the default


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agent on behalf of Jake Howell

Fixes https://github.com/coder/internal/issues/1419

The `createTemplate` e2e helper clicks Save immediately after `setInputFiles`, but the file upload API call is fire-and-forget through the React component chain (`FileUpload.onChange` → `CreateTemplateForm.onUpload` → `UploadTemplateView.onUpload` — none of which `await` the returned promise up the chain).

If the upload mutation has not settled when the form submits, `uploadedFile` (`uploadFileMutation.data`) is still `undefined`, and the `uploadedFile!.hash` non-null assertion throws a `TypeError`. Formik silently swallows the rejected promise, so the page stays on `/templates/new` and the URL assertion times out.

The fix waits for the "Remove file" button to appear after `setInputFiles`. That button only renders when `!isPending && variables` — i.e. the upload mutation has succeeded and the hash is available.