### PR TITLE
fix(scripts): fix Windows version format for RC builds (#23542)

### DIFF
--- a/scripts/build_go.sh
+++ b/scripts/build_go.sh
@@ -238,7 +238,7 @@ if [[ "$windows_resources" == 1 ]] && [[ "$os" == "windows" ]]; then
 	# Remove any trailing data after a "+" or "-".
 	version_windows=$version
 	version_windows="${version_windows%+*}"
-	version_windows="${version_windows%-*}"
+	version_windows="${version_windows%%-*}"
 	# If there wasn't any extra data, add a .0 to the version. Otherwise, add
 	# a .1 to the version to signify that this is not a release build so it can
 	# be distinguished from a release build.


### PR DESCRIPTION
Backport of https://github.com/coder/coder/pull/23542

Original PR: #23542 — fix(scripts): fix Windows version format for RC builds
Merge commit: 7f75670f8d9695c0024aab836748d7d46cc25f76
Requested by: @f0ssel

---

> [!NOTE]
> This PR was created by Coder Agents.