### PR TITLE
fix(site/src): preserve chat viewport across safari navigation

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { FC } from "react";
-import { useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Outlet } from "react-router";
 import { expect, spyOn, userEvent, waitFor, within } from "storybook/test";
 import {
@@ -57,11 +57,103 @@ const AgentChatPageLayout: FC = () => {
 							onToggleSidebarCollapsed: () => {},
 							onExpandSidebar: () => {},
 							onChatReady: () => {},
-							scrollContainerRef,
+							setScrollContainerElement: (element) => {
+								scrollContainerRef.current = element;
+							},
 						} satisfies AgentsOutletContext
 					}
 				/>
 			</div>
+		</div>
+	);
+};
+
+const MobileViewportChromeShiftLayout: FC = () => {
+	const [chromeHeight, setChromeHeight] = useState(0);
+
+	useEffect(() => {
+		const frame = requestAnimationFrame(() => {
+			setChromeHeight(48);
+		});
+		return () => cancelAnimationFrame(frame);
+	}, []);
+
+	return (
+		<div
+			data-testid="chat-story-frame"
+			style={{ height: "600px", display: "flex", flexDirection: "column" }}
+		>
+			<div style={{ minHeight: 0, display: "flex", flex: 1 }}>
+				<AgentChatPageLayout />
+			</div>
+			<div
+				data-testid="mobile-browser-chrome"
+				style={{ flexShrink: 0, height: `${chromeHeight}px` }}
+			/>
+		</div>
+	);
+};
+
+const MobileChatReadyChromeShiftLayout: FC = () => {
+	const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+	const [chromeHeight, setChromeHeight] = useState(0);
+	const readyFrameRef = useRef<number | null>(null);
+
+	useEffect(() => {
+		return () => {
+			if (readyFrameRef.current !== null) {
+				cancelAnimationFrame(readyFrameRef.current);
+			}
+		};
+	}, []);
+
+	const handleChatReady = () => {
+		if (readyFrameRef.current !== null) {
+			return;
+		}
+		readyFrameRef.current = requestAnimationFrame(() => {
+			readyFrameRef.current = null;
+			setChromeHeight(48);
+		});
+	};
+
+	return (
+		<div
+			data-testid="chat-story-frame"
+			style={{ height: "600px", display: "flex", flexDirection: "column" }}
+		>
+			<div style={{ minHeight: 0, display: "flex", flex: 1 }}>
+				<Outlet
+					context={
+						{
+							chatErrorReasons: {},
+							setChatErrorReason: () => {},
+							clearChatErrorReason: () => {},
+							requestArchiveAgent: () => {},
+							requestArchiveAndDeleteWorkspace: (
+								_chatId: string,
+								_workspaceId: string,
+							) => {},
+							requestUnarchiveAgent: () => {},
+							requestPinAgent: () => {},
+							requestUnpinAgent: () => {},
+							onRegenerateTitle: () => {},
+							regeneratingTitleChatIds: [],
+							isSidebarCollapsed: false,
+							onToggleSidebarCollapsed: () => {},
+							onExpandSidebar: () => {},
+							onChatReady: handleChatReady,
+							setScrollContainerElement: (element) => {
+								scrollContainerRef.current = element;
+							},
+						} satisfies AgentsOutletContext
+					}
+				/>
+			</div>
+			<div
+				data-testid="mobile-browser-chrome"
+				style={{ flexShrink: 0, height: `${chromeHeight}px` }}
+			/>
 		</div>
 	);
 };
@@ -201,6 +293,23 @@ const buildQueries = (
 	];
 };
 
+const buildLongConversation = (count: number): TypesGen.ChatMessage[] =>
+	Array.from({ length: count }, (_, index) => {
+		const id = index + 1;
+		return {
+			id,
+			chat_id: CHAT_ID,
+			created_at: new Date(Date.UTC(2026, 1, 18, 0, 0, id)).toISOString(),
+			role: id % 2 === 0 ? "assistant" : "user",
+			content: [
+				{
+					type: "text",
+					text: `${id % 2 === 0 ? "Assistant" : "User"} message ${id}. ${"More content. ".repeat(18)}`,
+				},
+			],
+		};
+	});
+
 // ---------------------------------------------------------------------------
 // Meta
 // ---------------------------------------------------------------------------
@@ -243,6 +352,309 @@ type Story = StoryObj<typeof AgentChatPageLayout>;
 // ---------------------------------------------------------------------------
 // Stories
 // ---------------------------------------------------------------------------
+
+/** Existing chats should open pinned to the latest message. */
+export const OpensExistingChatAtLatestMessage: Story = {
+	decorators: [
+		(Story) => (
+			<div
+				style={{ height: "600px", display: "flex", flexDirection: "column" }}
+			>
+				<Story />
+			</div>
+		),
+	],
+	parameters: {
+		queries: buildQueries(
+			{
+				id: CHAT_ID,
+				...baseChatFields,
+				title: "Existing long chat",
+				status: "completed",
+			},
+			{
+				messages: buildLongConversation(80),
+				queued_messages: [],
+				has_more: false,
+			},
+		),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scrollContainer = await waitFor(() =>
+			canvas.getByTestId("scroll-container"),
+		);
+		await waitFor(() => {
+			expect(scrollContainer.scrollHeight).toBeGreaterThan(
+				scrollContainer.clientHeight,
+			);
+		});
+		await waitFor(() => {
+			const distanceFromBottom =
+				scrollContainer.scrollHeight -
+				scrollContainer.scrollTop -
+				scrollContainer.clientHeight;
+			expect(distanceFromBottom).toBeLessThan(5);
+		});
+		await waitFor(() => {
+			expect(
+				canvas.queryByRole("button", { name: "Scroll to bottom" }),
+			).toBeNull();
+		});
+	},
+};
+
+/** Mobile chat opens at the latest message without auto-focusing the input. */
+export const MobileOpenDoesNotAutofocusInput: Story = {
+	decorators: [
+		(Story) => (
+			<div
+				style={{ height: "600px", display: "flex", flexDirection: "column" }}
+			>
+				<Story />
+			</div>
+		),
+	],
+	parameters: {
+		viewport: { defaultViewport: "mobile1" },
+		queries: buildQueries(
+			{
+				id: CHAT_ID,
+				...baseChatFields,
+				title: "Existing mobile chat",
+				status: "completed",
+			},
+			{
+				messages: buildLongConversation(80),
+				queued_messages: [],
+				has_more: false,
+			},
+		),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scrollContainer = await waitFor(() =>
+			canvas.getByTestId("scroll-container"),
+		);
+		const editor = await waitFor(() =>
+			canvas.getByTestId("chat-message-input"),
+		);
+		await waitFor(() => {
+			expect(scrollContainer.scrollHeight).toBeGreaterThan(
+				scrollContainer.clientHeight,
+			);
+		});
+		await waitFor(() => {
+			const distanceFromBottom =
+				scrollContainer.scrollHeight -
+				scrollContainer.scrollTop -
+				scrollContainer.clientHeight;
+			expect(distanceFromBottom).toBeLessThan(5);
+		});
+		expect(editor).not.toHaveFocus();
+		await waitFor(() => {
+			expect(
+				canvas.queryByRole("button", { name: "Scroll to bottom" }),
+			).toBeNull();
+		});
+	},
+};
+
+/** Revalidates the bottom pin one frame later for browsers with delayed layout. */
+export const MobileOpenRepinsAfterDeferredLayout: Story = {
+	decorators: [
+		(Story) => (
+			<div
+				style={{ height: "600px", display: "flex", flexDirection: "column" }}
+			>
+				<Story />
+			</div>
+		),
+	],
+	parameters: {
+		viewport: { defaultViewport: "mobile1" },
+		queries: buildQueries(
+			{
+				id: CHAT_ID,
+				...baseChatFields,
+				title: "Existing delayed-layout mobile chat",
+				status: "completed",
+			},
+			{
+				messages: buildLongConversation(80),
+				queued_messages: [],
+				has_more: false,
+			},
+		),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scrollContainer = await waitFor(() =>
+			canvas.getByTestId("scroll-container"),
+		);
+		await waitFor(() => {
+			expect(scrollContainer.scrollHeight).toBeGreaterThan(
+				scrollContainer.clientHeight,
+			);
+		});
+
+		const originalScrollHeight = Object.getOwnPropertyDescriptor(
+			Object.getPrototypeOf(scrollContainer),
+			"scrollHeight",
+		);
+		let spoofedScrollHeight = scrollContainer.clientHeight;
+		Object.defineProperty(scrollContainer, "scrollHeight", {
+			configurable: true,
+			get: () => spoofedScrollHeight,
+		});
+		try {
+			scrollContainer.scrollTop = 0;
+			scrollContainer.dispatchEvent(new Event("scroll"));
+			spoofedScrollHeight = scrollContainer.clientHeight;
+			for (let frame = 0; frame < 6; frame += 1) {
+				await new Promise<void>((resolve) =>
+					requestAnimationFrame(() => resolve()),
+				);
+			}
+			spoofedScrollHeight =
+				(originalScrollHeight?.get?.call(scrollContainer) as number) ??
+				scrollContainer.scrollHeight;
+			await waitFor(() => {
+				const distanceFromBottom =
+					scrollContainer.scrollHeight -
+					scrollContainer.scrollTop -
+					scrollContainer.clientHeight;
+				expect(distanceFromBottom).toBeLessThan(5);
+			});
+		} finally {
+			if (originalScrollHeight) {
+				Object.defineProperty(
+					scrollContainer,
+					"scrollHeight",
+					originalScrollHeight,
+				);
+			}
+		}
+	},
+};
+
+/** Late mobile browser chrome must not pull the transcript off bottom. */
+export const MobileOpenStaysPinnedAfterViewportChromeSettles: Story = {
+	render: () => <MobileViewportChromeShiftLayout />,
+	parameters: {
+		viewport: { defaultViewport: "mobile1" },
+		queries: buildQueries(
+			{
+				id: CHAT_ID,
+				...baseChatFields,
+				title: "Existing viewport-shift mobile chat",
+				status: "completed",
+			},
+			{
+				messages: buildLongConversation(80),
+				queued_messages: [],
+				has_more: false,
+			},
+		),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const storyFrame = await waitFor(() =>
+			canvas.getByTestId("chat-story-frame"),
+		);
+		const browserChrome = await waitFor(() =>
+			canvas.getByTestId("mobile-browser-chrome"),
+		);
+		const scrollContainer = await waitFor(() =>
+			canvas.getByTestId("scroll-container"),
+		);
+		await waitFor(() => {
+			expect(scrollContainer.scrollHeight).toBeGreaterThan(
+				scrollContainer.clientHeight,
+			);
+		});
+		await waitFor(() => {
+			expect(browserChrome).toHaveStyle({ height: "48px" });
+			expect(storyFrame.clientHeight).toBe(600);
+		});
+		await waitFor(() => {
+			const distanceFromBottom =
+				scrollContainer.scrollHeight -
+				scrollContainer.scrollTop -
+				scrollContainer.clientHeight;
+			expect(distanceFromBottom).toBeLessThan(5);
+		});
+		await waitFor(() => {
+			expect(
+				canvas.queryByRole("button", { name: "Scroll to bottom" }),
+			).toBeNull();
+		});
+	},
+};
+
+/** Layout changes after chat-ready must not pull mobile off bottom. */
+export const MobileOpenStaysPinnedAfterChatReadyViewportShift: Story = {
+	render: () => <MobileChatReadyChromeShiftLayout />,
+	parameters: {
+		viewport: { defaultViewport: "mobile1" },
+		reactRouter: reactRouterParameters({
+			location: {
+				path: `/agents/${CHAT_ID}`,
+				pathParams: { agentId: CHAT_ID },
+			},
+			routing: reactRouterOutlet(
+				{ path: "/agents/:agentId" },
+				<AgentChatPage />,
+			),
+		}),
+		queries: buildQueries(
+			{
+				id: CHAT_ID,
+				...baseChatFields,
+				title: "Existing chat-ready viewport-shift mobile chat",
+				status: "completed",
+			},
+			{
+				messages: buildLongConversation(80),
+				queued_messages: [],
+				has_more: false,
+			},
+		),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const storyFrame = await waitFor(() =>
+			canvas.getByTestId("chat-story-frame"),
+		);
+		const browserChrome = await waitFor(() =>
+			canvas.getByTestId("mobile-browser-chrome"),
+		);
+		const scrollContainer = await waitFor(() =>
+			canvas.getByTestId("scroll-container"),
+		);
+		await waitFor(() => {
+			expect(scrollContainer.scrollHeight).toBeGreaterThan(
+				scrollContainer.clientHeight,
+			);
+		});
+		await waitFor(() => {
+			expect(browserChrome).toHaveStyle({ height: "48px" });
+			expect(storyFrame.clientHeight).toBe(600);
+		});
+		await waitFor(() => {
+			const distanceFromBottom =
+				scrollContainer.scrollHeight -
+				scrollContainer.scrollTop -
+				scrollContainer.clientHeight;
+			expect(distanceFromBottom).toBeLessThan(5);
+		});
+		await waitFor(() => {
+			expect(
+				canvas.queryByRole("button", { name: "Scroll to bottom" }),
+			).toBeNull();
+		});
+	},
+};
 
 /** Multi-turn conversation with rich markdown rendering: headings, tables,
  *  ordered/unordered lists, nested lists, code blocks, blockquotes,

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -26,7 +26,10 @@ import {
 	withProxyProvider,
 	withWebSocket,
 } from "#/testHelpers/storybook";
-import AgentChatPage, { RIGHT_PANEL_OPEN_KEY } from "./AgentChatPage";
+import AgentChatPage, {
+	_resetChatFontsWarmForTesting,
+	RIGHT_PANEL_OPEN_KEY,
+} from "./AgentChatPage";
 import type { AgentsOutletContext } from "./AgentsPage";
 
 // ---------------------------------------------------------------------------
@@ -338,11 +341,15 @@ const meta: Meta<typeof AgentChatPageLayout> = {
 		}),
 	},
 	beforeEach: () => {
+		_resetChatFontsWarmForTesting();
 		localStorage.removeItem(RIGHT_PANEL_OPEN_KEY);
 		spyOn(API, "getApiKey").mockRejectedValue(new Error("missing API key"));
 		spyOn(API.experimental, "updateChat").mockResolvedValue();
 		spyOn(API.experimental, "getMCPServerConfigs").mockResolvedValue([]);
-		return () => localStorage.removeItem(RIGHT_PANEL_OPEN_KEY);
+		return () => {
+			_resetChatFontsWarmForTesting();
+			localStorage.removeItem(RIGHT_PANEL_OPEN_KEY);
+		};
 	},
 };
 
@@ -594,6 +601,36 @@ export const MobileOpenStaysPinnedAfterViewportChromeSettles: Story = {
 
 /** Layout changes after chat-ready must not pull mobile off bottom. */
 export const MobileOpenStaysPinnedAfterChatReadyViewportShift: Story = {
+	beforeEach: () => {
+		const originalFonts = document.fonts;
+		let resolveReady: (() => void) | null = null;
+		const ready = new Promise<void>((resolve) => {
+			resolveReady = resolve;
+		});
+		Object.defineProperty(document, "fonts", {
+			configurable: true,
+			value: {
+				...originalFonts,
+				status: "loading",
+				ready,
+			},
+		});
+		const releaseFrame = requestAnimationFrame(() => {
+			resolveReady?.();
+			Object.defineProperty(document, "fonts", {
+				configurable: true,
+				value: originalFonts,
+			});
+		});
+		return () => {
+			cancelAnimationFrame(releaseFrame);
+			resolveReady?.();
+			Object.defineProperty(document, "fonts", {
+				configurable: true,
+				value: originalFonts,
+			});
+		};
+	},
 	render: () => <MobileChatReadyChromeShiftLayout />,
 	parameters: {
 		viewport: { defaultViewport: "mobile1" },

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -548,6 +548,39 @@ type _UncoveredAgentFields = Omit<
 // to the excluded section of the Omit.
 const _agentFieldGuard: Record<keyof _UncoveredAgentFields, true> = {};
 
+const CHAT_TRANSCRIPT_FONT = '1rem "Geist Variable"';
+let areChatFontsWarm = false;
+let chatFontsWarmPromise: Promise<void> | null = null;
+
+const primeChatFonts = () => {
+	if (typeof document === "undefined") {
+		areChatFontsWarm = true;
+		return Promise.resolve();
+	}
+	if (areChatFontsWarm) {
+		return Promise.resolve();
+	}
+	if (!chatFontsWarmPromise) {
+		const fontLoad =
+			typeof document.fonts.load === "function"
+				? document.fonts.load(CHAT_TRANSCRIPT_FONT, "BESbswy")
+				: Promise.resolve();
+		chatFontsWarmPromise = fontLoad
+			.then(() => document.fonts.ready)
+			.catch(() => undefined)
+			.then(() => {
+				areChatFontsWarm = true;
+				chatFontsWarmPromise = null;
+			});
+	}
+	return chatFontsWarmPromise;
+};
+
+export const _resetChatFontsWarmForTesting = () => {
+	areChatFontsWarm = false;
+	chatFontsWarmPromise = null;
+};
+
 const AgentChatPage: FC = () => {
 	const { agentId } = useParams<{ agentId: string }>();
 	const {
@@ -566,6 +599,12 @@ const AgentChatPage: FC = () => {
 	} = useOutletContext<AgentsOutletContext>();
 	const queryClient = useQueryClient();
 	const [selectedModel, setSelectedModel] = useState("");
+	const [areChatFontsReady, setAreChatFontsReady] = useState(() => {
+		if (typeof document === "undefined") {
+			return true;
+		}
+		return areChatFontsWarm;
+	});
 	const scrollToBottomRef = useRef<(() => void) | null>(null);
 	const handleScrollToBottomChange = (scrollToBottom: (() => void) | null) => {
 		scrollToBottomRef.current = scrollToBottom;
@@ -578,6 +617,23 @@ const AgentChatPage: FC = () => {
 				).text
 			: "",
 	);
+
+	// Keep the skeleton visible until the transcript font is ready so
+	// the initial bottom pin does not target fallback text metrics.
+	useEffect(() => {
+		if (areChatFontsReady || typeof document === "undefined") {
+			return;
+		}
+		let cancelled = false;
+		void primeChatFonts().finally(() => {
+			if (!cancelled) {
+				setAreChatFontsReady(true);
+			}
+		});
+		return () => {
+			cancelled = true;
+		};
+	}, [areChatFontsReady]);
 
 	// Right panel open/closed state is owned here so the loading
 	// skeleton and the loaded view share the same layout, preventing
@@ -1095,9 +1151,10 @@ const AgentChatPage: FC = () => {
 	const chatReadyFiredRef = useRef<string | null>(null);
 	const storeMessageCount = useChatSelector(store, (s) => s.messagesByID.size);
 	const fetchedMessageCount = chatMessagesList?.length ?? 0;
-	useEffect(() => {
+	useLayoutEffect(() => {
 		if (
 			chatReadyFiredRef.current === agentId ||
+			!areChatFontsReady ||
 			!chatMessagesQuery.isSuccess ||
 			storeMessageCount < fetchedMessageCount
 		) {
@@ -1108,6 +1165,7 @@ const AgentChatPage: FC = () => {
 		onChatReady();
 		let settleFrame: number | null = null;
 		const frame = requestAnimationFrame(() => {
+			scrollToBottomRef.current?.();
 			settleFrame = requestAnimationFrame(() => {
 				scrollToBottomRef.current?.();
 			});
@@ -1119,6 +1177,7 @@ const AgentChatPage: FC = () => {
 			}
 		};
 	}, [
+		areChatFontsReady,
 		onChatReady,
 		storeMessageCount,
 		fetchedMessageCount,
@@ -1352,7 +1411,11 @@ const AgentChatPage: FC = () => {
 		});
 	};
 
-	if (chatQuery.isLoading || chatMessagesQuery.isLoading) {
+	if (
+		chatQuery.isLoading ||
+		chatMessagesQuery.isLoading ||
+		!areChatFontsReady
+	) {
 		return (
 			<AgentChatPageLoadingView
 				titleElement={titleElement}

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -562,11 +562,14 @@ const AgentChatPage: FC = () => {
 		isSidebarCollapsed,
 		onToggleSidebarCollapsed,
 		onChatReady,
-		scrollContainerRef,
+		setScrollContainerElement,
 	} = useOutletContext<AgentsOutletContext>();
 	const queryClient = useQueryClient();
 	const [selectedModel, setSelectedModel] = useState("");
 	const scrollToBottomRef = useRef<(() => void) | null>(null);
+	const handleScrollToBottomChange = (scrollToBottom: (() => void) | null) => {
+		scrollToBottomRef.current = scrollToBottom;
+	};
 	const chatInputRef = useRef<ChatMessageInputRef | null>(null);
 	const inputValueRef = useRef(
 		agentId
@@ -1086,7 +1089,9 @@ const AgentChatPage: FC = () => {
 	};
 
 	// Signal ready only after the store has synced fetched messages,
-	// so the DOM actually contains them when the parent scrolls.
+	// so the DOM contains the full transcript before we pin to the latest
+	// content. The scroll container mounts before the store hydration effect,
+	// so the mount-time bottom pin can otherwise run against an empty timeline.
 	const chatReadyFiredRef = useRef<string | null>(null);
 	const storeMessageCount = useChatSelector(store, (s) => s.messagesByID.size);
 	const fetchedMessageCount = chatMessagesList?.length ?? 0;
@@ -1099,7 +1104,11 @@ const AgentChatPage: FC = () => {
 			return;
 		}
 		chatReadyFiredRef.current = agentId ?? null;
-		onChatReady();
+		const frame = requestAnimationFrame(() => {
+			scrollToBottomRef.current?.();
+			onChatReady();
+		});
+		return () => cancelAnimationFrame(frame);
 	}, [
 		onChatReady,
 		storeMessageCount,
@@ -1417,8 +1426,8 @@ const AgentChatPage: FC = () => {
 			isRegeneratingTitle={isRegeneratingThisChat}
 			isRegenerateTitleDisabled={isRegenerateTitleDisabled}
 			urlTransform={urlTransform}
-			scrollContainerRef={scrollContainerRef}
-			scrollToBottomRef={scrollToBottomRef}
+			onScrollContainerChange={setScrollContainerElement}
+			onScrollToBottomChange={handleScrollToBottomChange}
 			hasMoreMessages={chatMessagesQuery.hasNextPage ?? false}
 			isFetchingMoreMessages={chatMessagesQuery.isFetchingNextPage}
 			onFetchMoreMessages={chatMessagesQuery.fetchNextPage}

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -1104,11 +1104,20 @@ const AgentChatPage: FC = () => {
 			return;
 		}
 		chatReadyFiredRef.current = agentId ?? null;
+		scrollToBottomRef.current?.();
+		onChatReady();
+		let settleFrame: number | null = null;
 		const frame = requestAnimationFrame(() => {
-			scrollToBottomRef.current?.();
-			onChatReady();
+			settleFrame = requestAnimationFrame(() => {
+				scrollToBottomRef.current?.();
+			});
 		});
-		return () => cancelAnimationFrame(frame);
+		return () => {
+			cancelAnimationFrame(frame);
+			if (settleFrame !== null) {
+				cancelAnimationFrame(settleFrame);
+			}
+		};
 	}, [
 		onChatReady,
 		storeMessageCount,

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -744,11 +744,9 @@ const waitForScrollOverflow = async (scrollContainer: HTMLElement) => {
 };
 
 const scrollAwayFromBottom = (scrollContainer: HTMLElement) => {
-	// Dispatch a wheel event first so the scroll handler treats
-	// this as user-initiated scrolling and disables follow mode.
-	// A bare scrollTop assignment fires a scroll event but the
-	// handler only re-pins (never disables autoScroll) unless
-	// a user-interaction event (wheel/touch/pointer) is active.
+	// Simulate a user scrolling upward. A bare scrollTop assignment is only a
+	// geometry change, which the container intentionally ignores while it is
+	// still following the live tail.
 	scrollContainer.dispatchEvent(
 		new WheelEvent("wheel", { bubbles: true, deltaY: -100 }),
 	);
@@ -1832,6 +1830,51 @@ export const CreateWorkspaceExpandDoesNotShiftViewport: Story = {
 
 const wheelDeferredStore = buildStoreWithMessages(buildLongConversation(30));
 const visibilityResetStore = buildStoreWithMessages(buildLongConversation(30));
+const jumpToBottomStreamingThinkingStore = (() => {
+	const store = buildStoreWithMessages(buildLongConversation(11), "running");
+	store.setStreamState({
+		blocks: [
+			{
+				type: "thinking",
+				text: "Jump reasoning step. ".repeat(2200),
+			},
+		],
+		toolCalls: {},
+		toolResults: {},
+		sources: [],
+	});
+	return store;
+})();
+const streamingThinkingTailStore = (() => {
+	const store = buildStoreWithMessages(buildLongConversation(11), "running");
+	store.setStreamState({
+		blocks: [
+			{
+				type: "thinking",
+				text: "Reasoning step. ".repeat(2200),
+			},
+		],
+		toolCalls: {},
+		toolResults: {},
+		sources: [],
+	});
+	return store;
+})();
+const loadWithStreamingThinkingStore = (() => {
+	const store = buildStoreWithMessages(buildLongConversation(11), "running");
+	store.setStreamState({
+		blocks: [
+			{
+				type: "thinking",
+				text: "Initial reasoning. ".repeat(2400),
+			},
+		],
+		toolCalls: {},
+		toolResults: {},
+		sources: [],
+	});
+	return store;
+})();
 
 /**
  * Backgrounding the page mid-gesture should clear stale touch state so
@@ -1978,6 +2021,183 @@ export const ScrollRepinnedAfterWheelDeferredAppend: Story = {
 		);
 
 		// Scroll-to-bottom button should not be visible.
+		expect(
+			canvas.queryByRole("button", { name: "Scroll to bottom" }),
+		).toBeNull();
+	},
+};
+
+/** Clicking Scroll to bottom during a large live thinking stream should re-arm
+ *  follow mode long enough for the continuing stream growth to settle at the
+ *  actual bottom. */
+export const ScrollToBottomSticksDuringStreamingThinking: Story = {
+	parameters: { chromatic: { disableSnapshot: true } },
+	decorators: scrollStoryDecorators,
+	render: () => <StoryAgentChatPageView store={streamingThinkingTailStore} />,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scrollContainer = canvas.getByTestId("scroll-container");
+
+		await waitForScrollOverflow(scrollContainer);
+		await waitFor(
+			() => {
+				const dist =
+					scrollContainer.scrollHeight -
+					scrollContainer.scrollTop -
+					scrollContainer.clientHeight;
+				expect(dist).toBeLessThan(5);
+			},
+			{ timeout: 2000 },
+		);
+
+		scrollAwayFromBottom(scrollContainer);
+		const button = await waitFor(() => {
+			const nextButton = canvas.getByRole("button", {
+				name: "Scroll to bottom",
+			});
+			expect(nextButton).toBeVisible();
+			return nextButton;
+		});
+
+		await userEvent.click(button);
+
+		streamingThinkingTailStore.setStreamState({
+			blocks: [
+				{
+					type: "thinking",
+					text: "Reasoning step. ".repeat(2600),
+				},
+			],
+			toolCalls: {},
+			toolResults: {},
+			sources: [],
+		});
+
+		await waitFor(
+			() => {
+				const dist =
+					scrollContainer.scrollHeight -
+					scrollContainer.scrollTop -
+					scrollContainer.clientHeight;
+				expect(dist).toBeLessThan(5);
+			},
+			{ timeout: 2000 },
+		);
+
+		await waitFor(() => {
+			expect(
+				canvas.queryByRole("button", { name: "Scroll to bottom" }),
+			).toBeNull();
+		});
+	},
+};
+
+const JumpToBottomHandleStory: FC = () => {
+	const jumpToBottomRef = useRef<(() => void) | null>(null);
+
+	return (
+		<>
+			<button type="button" onClick={() => jumpToBottomRef.current?.()}>
+				Jump to bottom
+			</button>
+			<StoryAgentChatPageView
+				store={jumpToBottomStreamingThinkingStore}
+				onScrollToBottomChange={(scrollToBottom) => {
+					jumpToBottomRef.current = scrollToBottom;
+				}}
+			/>
+		</>
+	);
+};
+
+/** Invoking the external jump-to-bottom handle during a large live thinking
+ *  stream should keep the viewport pinned while the stream continues to grow. */
+export const JumpToBottomHandleSticksDuringStreamingThinking: Story = {
+	parameters: { chromatic: { disableSnapshot: true } },
+	decorators: scrollStoryDecorators,
+	render: () => <JumpToBottomHandleStory />,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scrollContainer = canvas.getByTestId("scroll-container");
+
+		await waitForScrollOverflow(scrollContainer);
+		await waitFor(
+			() => {
+				const dist =
+					scrollContainer.scrollHeight -
+					scrollContainer.scrollTop -
+					scrollContainer.clientHeight;
+				expect(dist).toBeLessThan(5);
+			},
+			{ timeout: 2000 },
+		);
+
+		scrollAwayFromBottom(scrollContainer);
+		await waitFor(() => {
+			const nextButton = canvas.getByRole("button", {
+				name: "Scroll to bottom",
+			});
+			expect(nextButton).toBeVisible();
+		});
+
+		await userEvent.click(
+			canvas.getByRole("button", { name: "Jump to bottom" }),
+		);
+
+		jumpToBottomStreamingThinkingStore.setStreamState({
+			blocks: [
+				{
+					type: "thinking",
+					text: "Jump reasoning step. ".repeat(2600),
+				},
+			],
+			toolCalls: {},
+			toolResults: {},
+			sources: [],
+		});
+
+		await waitFor(
+			() => {
+				const dist =
+					scrollContainer.scrollHeight -
+					scrollContainer.scrollTop -
+					scrollContainer.clientHeight;
+				expect(dist).toBeLessThan(5);
+			},
+			{ timeout: 2000 },
+		);
+
+		await waitFor(() => {
+			expect(
+				canvas.queryByRole("button", { name: "Scroll to bottom" }),
+			).toBeNull();
+		});
+	},
+};
+
+/** Loading a running chat with a large live thinking tail should stay pinned
+ *  to the latest content instead of opening detached above bottom. */
+export const StreamingThinkingLoadStaysPinned: Story = {
+	parameters: { chromatic: { disableSnapshot: true } },
+	decorators: scrollStoryDecorators,
+	render: () => (
+		<StoryAgentChatPageView store={loadWithStreamingThinkingStore} />
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scrollContainer = canvas.getByTestId("scroll-container");
+
+		await waitForScrollOverflow(scrollContainer);
+		await waitFor(
+			() => {
+				const dist =
+					scrollContainer.scrollHeight -
+					scrollContainer.scrollTop -
+					scrollContainer.clientHeight;
+				expect(dist).toBeLessThan(5);
+			},
+			{ timeout: 2000 },
+		);
 		expect(
 			canvas.queryByRole("button", { name: "Scroll to bottom" }),
 		).toBeNull();

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -1,5 +1,5 @@
 import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
-import { type ComponentProps, type FC, useState } from "react";
+import { type ComponentProps, type FC, useRef, useState } from "react";
 import { expect, fn, spyOn, userEvent, waitFor, within } from "storybook/test";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
 import { API } from "#/api/api";
@@ -22,6 +22,7 @@ import {
 } from "./AgentChatPageView";
 import { createChatStore } from "./components/ChatConversation/chatStore";
 import type { ModelSelectorOption } from "./components/ChatElements";
+import { FOLLOW_THRESHOLD_PX } from "./components/chatViewportUtils";
 import type { ChatDetailError } from "./utils/usageLimitMessage";
 
 // ---------------------------------------------------------------------------
@@ -1253,9 +1254,79 @@ const touchGuardScrollStore = buildStoreWithMessages(buildLongConversation(30));
 const historyFetchGuardStore = buildStoreWithMessages(
 	buildLongConversation(30),
 );
+const initialDetachLockStore = buildStoreWithMessages(
+	buildLongConversation(30),
+);
+
+const InitialDetachLockStory: FC = () => {
+	const spoofedInitialScrollRef = useRef(false);
+
+	return (
+		<StoryAgentChatPageView
+			store={initialDetachLockStore}
+			onScrollContainerChange={(element) => {
+				if (!element || spoofedInitialScrollRef.current) {
+					return;
+				}
+				spoofedInitialScrollRef.current = true;
+				requestAnimationFrame(() => {
+					const detachedTop = Math.max(
+						0,
+						element.scrollHeight -
+							element.clientHeight -
+							(FOLLOW_THRESHOLD_PX + 24),
+					);
+					element.scrollTop = detachedTop;
+					element.dispatchEvent(new Event("scroll"));
+				});
+			}}
+		/>
+	);
+};
 
 /** During an active touch gesture, the container ResizeObserver must not
  *  snap scroll to bottom. This prevents the mobile URL bar resize jump. */
+/** A transient initial geometry mismatch must not detach the viewport. */
+export const InitialLayoutShiftDoesNotDetach: Story = {
+	parameters: { chromatic: { disableSnapshot: true } },
+	decorators: scrollStoryDecorators,
+	render: () => <InitialDetachLockStory />,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scrollContainer = canvas.getByTestId("scroll-container");
+
+		await waitForScrollOverflow(scrollContainer);
+
+		for (let frame = 0; frame < 4; frame += 1) {
+			await new Promise<void>((resolve) =>
+				requestAnimationFrame(() => resolve()),
+			);
+			expect(
+				canvas.queryByRole("button", { name: "Scroll to bottom" }),
+			).toBeNull();
+		}
+
+		await waitFor(
+			() => {
+				const dist =
+					scrollContainer.scrollHeight -
+					scrollContainer.scrollTop -
+					scrollContainer.clientHeight;
+				expect(dist).toBeLessThan(5);
+			},
+			{ timeout: 2000 },
+		);
+
+		scrollAwayFromBottom(scrollContainer);
+		await waitFor(() => {
+			const button = canvas.getByRole("button", {
+				name: "Scroll to bottom",
+			});
+			expect(button).toBeVisible();
+		});
+	},
+};
+
 export const ScrollNotJumpedDuringTouch: Story = {
 	parameters: { chromatic: { disableSnapshot: true } },
 	decorators: scrollStoryDecorators,

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -1,5 +1,5 @@
 import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
-import type { ComponentProps, FC } from "react";
+import { type ComponentProps, type FC, useState } from "react";
 import { expect, fn, spyOn, userEvent, waitFor, within } from "storybook/test";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
 import { API } from "#/api/api";
@@ -148,7 +148,8 @@ const StoryAgentChatPageView: FC<StoryProps> = ({ editing, ...overrides }) => {
 		handleUnarchiveAgentAction: fn(),
 		handleArchiveAndDeleteWorkspaceAction: fn(),
 		handleRegenerateTitle: fn(),
-		scrollContainerRef: { current: null },
+		onScrollContainerChange: fn(),
+		onScrollToBottomChange: fn(),
 		hasMoreMessages: false,
 		isFetchingMoreMessages: false,
 		onFetchMoreMessages: fn(),
@@ -557,7 +558,6 @@ const editingMessages = [
 	),
 	buildMessage(5, "user", "That was terrible, try again"),
 ];
-
 /** Editing a message in the middle of the conversation — shows the warning
  *  border on the edited message, faded subsequent messages, and the editing
  *  banner + outline on the chat input. */
@@ -571,6 +571,105 @@ export const EditingMessage: Story = {
 			}}
 		/>
 	),
+};
+
+/** Entering history edit mode should preserve the edited message position. */
+export const EditingHistoryPreservesViewportPosition: Story = {
+	parameters: { chromatic: { disableSnapshot: true } },
+	render: () => {
+		const [editingState, setEditingState] = useState({
+			editingMessageId: null as number | null,
+			editorInitialValue: "",
+			remountKey: 0,
+		});
+		return (
+			<div
+				style={{ height: "600px", display: "flex", flexDirection: "column" }}
+			>
+				<StoryAgentChatPageView
+					store={historyEditShiftStore}
+					editing={{
+						...editingState,
+						handleEditUserMessage: (messageId, text) => {
+							setEditingState((current) => ({
+								editingMessageId: messageId,
+								editorInitialValue: text,
+								remountKey: current.remountKey + 1,
+							}));
+						},
+						handleCancelHistoryEdit: () => {
+							setEditingState((current) => ({
+								editingMessageId: null,
+								editorInitialValue: "",
+								remountKey: current.remountKey + 1,
+							}));
+						},
+					}}
+				/>
+			</div>
+		);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scrollContainer = canvas.getByTestId("scroll-container");
+
+		await waitForScrollOverflow(scrollContainer);
+		await waitFor(
+			() => {
+				const dist =
+					scrollContainer.scrollHeight -
+					scrollContainer.scrollTop -
+					scrollContainer.clientHeight;
+				expect(dist).toBeLessThan(5);
+			},
+			{ timeout: 2000 },
+		);
+
+		scrollContainer.dispatchEvent(
+			new WheelEvent("wheel", { bubbles: true, deltaY: -50 }),
+		);
+		const targetAnchor = await waitFor(() => {
+			const anchor = canvasElement.querySelector<HTMLElement>(
+				"[data-chat-anchor-id='message-11']",
+			);
+			if (!anchor) {
+				throw new Error("Expected editable message anchor.");
+			}
+			return anchor;
+		});
+		scrollContainer.scrollTop = Math.max(0, targetAnchor.offsetTop - 180);
+		scrollContainer.dispatchEvent(new Event("scroll"));
+
+		const targetMessage = targetAnchor.nextElementSibling as HTMLElement | null;
+		if (!targetMessage) {
+			throw new Error("Expected editable message container.");
+		}
+		const editButton = await waitFor(() => {
+			const button = within(targetMessage).getByRole("button", {
+				name: "Edit message",
+			});
+			return button;
+		});
+		const offsetBeforeEdit =
+			targetAnchor.getBoundingClientRect().top -
+			scrollContainer.getBoundingClientRect().top;
+
+		await userEvent.click(editButton);
+
+		await waitFor(() => {
+			expect(
+				canvas.getByText(
+					"Editing will delete all subsequent messages and restart the conversation here.",
+				),
+			).toBeInTheDocument();
+		});
+		await waitFor(() => {
+			const offsetAfterEdit =
+				targetAnchor.getBoundingClientRect().top -
+				scrollContainer.getBoundingClientRect().top;
+			expect(Math.abs(offsetAfterEdit - offsetBeforeEdit)).toBeLessThan(8);
+		});
+	},
 };
 
 // ---------------------------------------------------------------------------
@@ -618,6 +717,8 @@ const buildLongConversation = (count: number): TypesGen.ChatMessage[] => {
 	}
 	return messages;
 };
+
+const historyEditShiftStore = buildStoreWithMessages(buildLongConversation(30));
 
 const scrollStoryDecorators: Decorator[] = [
 	(Story) => (
@@ -671,6 +772,93 @@ const getStoreMessages = (
 
 /** Scroll-to-bottom button appears after scrolling up in a long
  *  conversation, and clicking it returns to the bottom. */
+const smoothScrollFollowStore = buildStoreWithMessages(
+	buildLongConversation(40),
+);
+
+/** Clicking the button should keep follow mode during the trip back down. */
+export const ScrollToBottomButtonKeepsFollowingDuringSmoothScroll: Story = {
+	parameters: { chromatic: { disableSnapshot: true } },
+	decorators: scrollStoryDecorators,
+	render: () => <StoryAgentChatPageView store={smoothScrollFollowStore} />,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scrollContainer = canvas.getByTestId("scroll-container");
+
+		await waitForScrollOverflow(scrollContainer);
+		await waitFor(
+			() => {
+				const dist =
+					scrollContainer.scrollHeight -
+					scrollContainer.scrollTop -
+					scrollContainer.clientHeight;
+				expect(dist).toBeLessThan(5);
+			},
+			{ timeout: 2000 },
+		);
+
+		scrollAwayFromBottom(scrollContainer);
+		const button = await waitFor(() => {
+			const nextButton = canvas.getByRole("button", {
+				name: "Scroll to bottom",
+			});
+			expect(nextButton).toBeVisible();
+			return nextButton;
+		});
+
+		const originalScrollTo = scrollContainer.scrollTo.bind(scrollContainer);
+		scrollContainer.scrollTo = ((
+			options?: ScrollToOptions | number,
+			_y?: number,
+		) => {
+			if (
+				typeof options === "object" &&
+				options !== null &&
+				options.behavior === "smooth"
+			) {
+				const finalTop = Number(options.top ?? 0);
+				const intermediateTop = Math.max(
+					scrollContainer.scrollTop,
+					finalTop - 300,
+				);
+				scrollContainer.scrollTop = intermediateTop;
+				scrollContainer.dispatchEvent(new Event("scroll"));
+				requestAnimationFrame(() => {
+					scrollContainer.scrollTop = finalTop;
+					scrollContainer.dispatchEvent(new Event("scroll"));
+				});
+				return;
+			}
+			if (typeof options === "number") {
+				originalScrollTo({ top: options });
+				return;
+			}
+			originalScrollTo(options);
+		}) as typeof scrollContainer.scrollTo;
+
+		await userEvent.click(button);
+		const existing = getStoreMessages(smoothScrollFollowStore);
+		smoothScrollFollowStore.replaceMessages(
+			existing.concat([
+				buildMessage(41, "assistant", "Streaming tail. ".repeat(80)),
+			]),
+		);
+
+		await waitFor(() => {
+			const dist =
+				scrollContainer.scrollHeight -
+				scrollContainer.scrollTop -
+				scrollContainer.clientHeight;
+			expect(dist).toBeLessThan(5);
+		});
+		await waitFor(() => {
+			expect(
+				canvas.queryByRole("button", { name: "Scroll to bottom" }),
+			).toBeNull();
+		});
+	},
+};
+
 export const ScrollToBottomButton: Story = {
 	parameters: { chromatic: { disableSnapshot: true } },
 	decorators: scrollStoryDecorators,
@@ -739,6 +927,46 @@ export const ScrollToBottomButton: Story = {
 // it. Stories in a file execute sequentially, so there is no
 // cross-contamination.
 const preservedScrollStore = buildStoreWithMessages(buildLongConversation(30));
+const streamedTailCommitText = "Streaming tail content. ".repeat(900);
+
+const streamedTailCommitStore = (() => {
+	const store = buildStoreWithMessages(buildLongConversation(11), "running");
+	store.setStreamState({
+		blocks: [
+			{
+				type: "response",
+				text: streamedTailCommitText,
+			},
+		],
+		toolCalls: {},
+		toolResults: {},
+		sources: [],
+	});
+	return store;
+})();
+
+const interruptTransitionStore = (() => {
+	const store = buildStoreWithMessages(
+		[
+			buildMessage(1, "user", "Earlier prompt"),
+			buildMessage(2, "assistant", "Earlier response. ".repeat(40)),
+			buildMessage(3, "user", "Latest prompt awaiting interruption"),
+		],
+		"running",
+	);
+	store.setStreamState({
+		blocks: [
+			{
+				type: "response",
+				text: "Streaming tail content. ".repeat(900),
+			},
+		],
+		toolCalls: {},
+		toolResults: {},
+		sources: [],
+	});
+	return store;
+})();
 
 /** When scrolled away from bottom, new content preserves scroll position. */
 export const ScrollPositionPreservedOnNewContent: Story = {
@@ -821,6 +1049,131 @@ export const ScrollPositionPreservedOnNewContent: Story = {
 	},
 };
 
+/** Detached readers stay anchored when streamed output becomes durable. */
+export const TranslatesLiveTailAnchorWhenStreamCommits: Story = {
+	decorators: scrollStoryDecorators,
+	render: () => <StoryAgentChatPageView store={streamedTailCommitStore} />,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scrollContainer = canvas.getByTestId("scroll-container");
+
+		await waitForScrollOverflow(scrollContainer);
+		const liveTail = await waitFor(() => {
+			const nextTail = canvasElement.querySelector<HTMLElement>(
+				"[data-chat-anchor-id='live-stream-tail']",
+			);
+			if (!nextTail) {
+				throw new Error("Expected live stream tail anchor.");
+			}
+			return nextTail;
+		});
+
+		scrollAwayFromBottom(scrollContainer);
+		scrollContainer.scrollTop = Math.max(0, liveTail.offsetTop + 180);
+		scrollContainer.dispatchEvent(new Event("scroll"));
+
+		const liveTailOffsetBefore =
+			liveTail.getBoundingClientRect().top -
+			scrollContainer.getBoundingClientRect().top;
+		await waitFor(() => {
+			expect(
+				canvas.getByRole("button", { name: "Scroll to bottom" }),
+			).toBeVisible();
+		});
+
+		const existing = getStoreMessages(streamedTailCommitStore);
+		streamedTailCommitStore.batch(() => {
+			streamedTailCommitStore.replaceMessages(
+				existing.concat([
+					buildMessage(12, "assistant", streamedTailCommitText),
+				]),
+			);
+			streamedTailCommitStore.clearStreamState();
+			streamedTailCommitStore.setChatStatus("completed");
+		});
+
+		const committedAnchor = await waitFor(() => {
+			const nextAnchor = canvasElement.querySelector<HTMLElement>(
+				"[data-chat-anchor-id='message-12']",
+			);
+			if (!nextAnchor) {
+				throw new Error("Expected committed durable anchor.");
+			}
+			return nextAnchor;
+		});
+		await waitFor(() => {
+			expect(
+				canvasElement.querySelector("[data-chat-anchor-id='live-stream-tail']"),
+			).toBeNull();
+		});
+		await waitFor(() => {
+			const committedOffsetAfter =
+				committedAnchor.getBoundingClientRect().top -
+				scrollContainer.getBoundingClientRect().top;
+			expect(
+				Math.abs(committedOffsetAfter - liveTailOffsetBefore),
+			).toBeLessThan(8);
+		});
+	},
+};
+
+/** Interrupt transitions should keep the latest-user preview pinned. */
+export const InterruptTransitionKeepsLatestUserPinned: Story = {
+	decorators: scrollStoryDecorators,
+	render: () => <StoryAgentChatPageView store={interruptTransitionStore} />,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scrollContainer = canvas.getByTestId("scroll-container");
+
+		await waitForScrollOverflow(scrollContainer);
+		await waitFor(() => {
+			const dist =
+				scrollContainer.scrollHeight -
+				scrollContainer.scrollTop -
+				scrollContainer.clientHeight;
+			expect(dist).toBeLessThan(5);
+		});
+		await waitFor(() => {
+			expect(
+				canvas.getAllByText("Latest prompt awaiting interruption"),
+			).toHaveLength(2);
+		});
+		const latestPromptAnchor = await waitFor(() => {
+			const anchor = canvasElement.querySelector<HTMLElement>(
+				"[data-chat-anchor-id='message-3']",
+			);
+			if (!anchor) {
+				throw new Error("Expected latest prompt anchor.");
+			}
+			return anchor;
+		});
+		const anchorOffsetBefore =
+			latestPromptAnchor.getBoundingClientRect().top -
+			scrollContainer.getBoundingClientRect().top;
+		const scrollTopBefore = scrollContainer.scrollTop;
+
+		interruptTransitionStore.batch(() => {
+			interruptTransitionStore.clearStreamState();
+			interruptTransitionStore.setChatStatus("running");
+		});
+
+		await waitFor(() => {
+			expect(
+				canvas.getAllByText("Latest prompt awaiting interruption"),
+			).toHaveLength(2);
+		});
+		await waitFor(() => {
+			const anchorOffsetAfter =
+				latestPromptAnchor.getBoundingClientRect().top -
+				scrollContainer.getBoundingClientRect().top;
+			expect(Math.abs(anchorOffsetAfter - anchorOffsetBefore)).toBeLessThan(8);
+			expect(
+				Math.abs(scrollContainer.scrollTop - scrollTopBefore),
+			).toBeLessThan(8);
+		});
+	},
+};
+
 const pinnedScrollStore = buildStoreWithMessages(buildLongConversation(30));
 
 /** When at bottom, new content keeps the user pinned to bottom. */
@@ -897,6 +1250,9 @@ const dispatchTouchEvent = (
 };
 
 const touchGuardScrollStore = buildStoreWithMessages(buildLongConversation(30));
+const historyFetchGuardStore = buildStoreWithMessages(
+	buildLongConversation(30),
+);
 
 /** During an active touch gesture, the container ResizeObserver must not
  *  snap scroll to bottom. This prevents the mobile URL bar resize jump. */
@@ -924,6 +1280,15 @@ export const ScrollNotJumpedDuringTouch: Story = {
 		await new Promise<void>((resolve) =>
 			requestAnimationFrame(() => resolve()),
 		);
+
+		// A simple tap should not detach follow mode.
+		dispatchTouchEvent(scrollContainer, "touchstart", 1);
+		dispatchTouchEvent(scrollContainer, "touchend", 1);
+		await waitFor(() => {
+			expect(
+				canvas.queryByRole("button", { name: "Scroll to bottom" }),
+			).toBeNull();
+		});
 
 		// Simulate a multi-touch gesture starting with two fingers down.
 		dispatchTouchEvent(scrollContainer, "touchstart", 2);
@@ -1070,7 +1435,409 @@ export const ScrollNotJumpedDuringWheel: Story = {
 	},
 };
 
+const historyFetchGuardSpy = fn();
+const shortTranscriptHistoryFetchSpy = fn();
+
+/** Older history should load only after detaching and reaching the top sentinel. */
+export const HistoryFetchRequiresDetachment: Story = {
+	parameters: { chromatic: { disableSnapshot: true } },
+	decorators: scrollStoryDecorators,
+	render: () => {
+		historyFetchGuardSpy.mockClear();
+		return (
+			<StoryAgentChatPageView
+				store={historyFetchGuardStore}
+				hasMoreMessages
+				onFetchMoreMessages={historyFetchGuardSpy}
+			/>
+		);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scrollContainer = canvas.getByTestId("scroll-container");
+
+		await waitForScrollOverflow(scrollContainer);
+		await waitFor(
+			() => {
+				const dist =
+					scrollContainer.scrollHeight -
+					scrollContainer.scrollTop -
+					scrollContainer.clientHeight;
+				expect(dist).toBeLessThan(5);
+			},
+			{ timeout: 2000 },
+		);
+		expect(historyFetchGuardSpy).not.toHaveBeenCalled();
+
+		const maxScrollTop =
+			scrollContainer.scrollHeight - scrollContainer.clientHeight;
+		expect(maxScrollTop).toBeGreaterThan(700);
+		const detachedScrollTop = Math.min(maxScrollTop, 700);
+
+		scrollContainer.dispatchEvent(
+			new WheelEvent("wheel", { bubbles: true, deltaY: -50 }),
+		);
+		scrollContainer.scrollTop = detachedScrollTop;
+		scrollContainer.dispatchEvent(new Event("scroll"));
+
+		await waitFor(() => {
+			expect(
+				canvas.getByRole("button", { name: "Scroll to bottom" }),
+			).toBeVisible();
+		});
+		await new Promise<void>((resolve) =>
+			requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+		);
+		expect(historyFetchGuardSpy).not.toHaveBeenCalled();
+
+		scrollContainer.scrollTop = 0;
+		scrollContainer.dispatchEvent(new Event("scroll"));
+
+		await waitFor(() => {
+			expect(historyFetchGuardSpy).toHaveBeenCalledTimes(1);
+		});
+	},
+};
+
+/** Short transcripts should still fetch older history before the viewport can detach. */
+export const ShortTranscriptFetchesHistoryWhilePinned: Story = {
+	parameters: { chromatic: { disableSnapshot: true } },
+	decorators: scrollStoryDecorators,
+	render: () => {
+		shortTranscriptHistoryFetchSpy.mockClear();
+		return (
+			<StoryAgentChatPageView
+				store={buildStoreWithMessages([
+					buildMessage(1, "user", "Need the earlier context."),
+					buildMessage(2, "assistant", "Loading the most recent page."),
+				])}
+				hasMoreMessages
+				onFetchMoreMessages={shortTranscriptHistoryFetchSpy}
+			/>
+		);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scrollContainer = canvas.getByTestId("scroll-container");
+		await waitFor(() => {
+			expect(scrollContainer.scrollHeight).toBeLessThanOrEqual(
+				scrollContainer.clientHeight,
+			);
+		});
+		await waitFor(() => {
+			expect(shortTranscriptHistoryFetchSpy).toHaveBeenCalledTimes(1);
+		});
+	},
+};
+
+const chatSwitchMessages = (offset: number): TypesGen.ChatMessage[] => [
+	...buildLongConversation(12).map((message) => ({
+		...message,
+		id: message.id + offset,
+	})),
+];
+const firstChatSwitchStore = buildStoreWithMessages(chatSwitchMessages(0));
+const secondChatSwitchStore = buildStoreWithMessages(chatSwitchMessages(100));
+
+/** Switching chats should reset the viewport to the latest message. */
+export const SwitchingChatsPinsToLatest: Story = {
+	parameters: { chromatic: { disableSnapshot: true } },
+	decorators: scrollStoryDecorators,
+	render: () => {
+		const [activeChatId, setActiveChatId] = useState("chat-a");
+		const activeStore =
+			activeChatId === "chat-a" ? firstChatSwitchStore : secondChatSwitchStore;
+		return (
+			<>
+				<button type="button" onClick={() => setActiveChatId("chat-b")}>
+					Open second chat
+				</button>
+				<StoryAgentChatPageView
+					agentId={activeChatId}
+					chatTitle={activeChatId === "chat-a" ? "Chat A" : "Chat B"}
+					store={activeStore}
+				/>
+			</>
+		);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scrollContainer = canvas.getByTestId("scroll-container");
+
+		await waitForScrollOverflow(scrollContainer);
+		await waitFor(
+			() => {
+				const dist =
+					scrollContainer.scrollHeight -
+					scrollContainer.scrollTop -
+					scrollContainer.clientHeight;
+				expect(dist).toBeLessThan(5);
+			},
+			{ timeout: 2000 },
+		);
+
+		scrollAwayFromBottom(scrollContainer);
+		await waitFor(() => {
+			expect(
+				canvas.getByRole("button", { name: "Scroll to bottom" }),
+			).toBeVisible();
+		});
+
+		await userEvent.click(
+			canvas.getByRole("button", { name: "Open second chat" }),
+		);
+
+		const nextScrollContainer = await waitFor(() => {
+			const element = canvas.getByTestId("scroll-container");
+			expect(element).toBeInTheDocument();
+			return element;
+		});
+		await waitForScrollOverflow(nextScrollContainer);
+		await waitFor(() => {
+			const dist =
+				nextScrollContainer.scrollHeight -
+				nextScrollContainer.scrollTop -
+				nextScrollContainer.clientHeight;
+			expect(dist).toBeLessThan(5);
+		});
+		expect(
+			canvas.queryByRole("button", { name: "Scroll to bottom" }),
+		).toBeNull();
+	},
+};
+
+const createWorkspaceExpandBuildId = "c1b2c3d4-e5f6-7890-abcd-ef1234567890";
+const createWorkspaceExpandLogs: TypesGen.ProvisionerJobLog[] = [
+	{
+		id: 1,
+		created_at: "2026-02-18T00:00:00.000Z",
+		log_source: "provisioner",
+		log_level: "info",
+		stage: "Starting workspace",
+		output: "Initializing Terraform...",
+	},
+	{
+		id: 2,
+		created_at: "2026-02-18T00:00:01.000Z",
+		log_source: "provisioner",
+		log_level: "info",
+		stage: "Starting workspace",
+		output: "Downloading modules...",
+	},
+	{
+		id: 3,
+		created_at: "2026-02-18T00:00:02.000Z",
+		log_source: "provisioner",
+		log_level: "info",
+		stage: "Starting workspace",
+		output: "Apply complete! Resources: 2 added, 0 changed, 0 destroyed.",
+	},
+];
+const createWorkspaceExpandStore = buildStoreWithMessages([
+	buildMessage(1, "user", "Create a workspace for the refactor branch."),
+	buildMessage(2, "assistant", "I'll create the workspace now."),
+	buildMessage(3, "user", "Use the standard template."),
+	buildMessage(
+		4,
+		"assistant",
+		"Using the standard template and waiting for the build.",
+	),
+	{
+		id: 5,
+		chat_id: AGENT_ID,
+		created_at: "2026-02-18T00:05:00.000Z",
+		role: "assistant",
+		content: [
+			{ type: "text", text: "The workspace has been created." },
+			{
+				type: "tool-call",
+				tool_call_id: "tool-create-workspace-1",
+				tool_name: "create_workspace",
+				args: {
+					name: "coder",
+					template_id: "template-1",
+				},
+			},
+		],
+	},
+	{
+		id: 6,
+		chat_id: AGENT_ID,
+		created_at: "2026-02-18T00:05:01.000Z",
+		role: "tool",
+		content: [
+			{
+				type: "tool-result",
+				tool_call_id: "tool-create-workspace-1",
+				tool_name: "create_workspace",
+				result: {
+					created: "true",
+					owner_name: "owner",
+					workspace_name: "my-project",
+					build_id: createWorkspaceExpandBuildId,
+				},
+			},
+		],
+	},
+	...buildLongConversation(24).map((message) => ({
+		...message,
+		id: message.id + 6,
+	})),
+]);
+
+/** Expanding create-workspace logs must not move the outer chat viewport. */
+export const CreateWorkspaceExpandDoesNotShiftViewport: Story = {
+	parameters: {
+		chromatic: { disableSnapshot: true },
+		queries: [
+			{
+				key: ["workspaceBuilds", createWorkspaceExpandBuildId, "logs"],
+				data: createWorkspaceExpandLogs,
+			},
+		],
+	},
+	decorators: scrollStoryDecorators,
+	render: () => <StoryAgentChatPageView store={createWorkspaceExpandStore} />,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scrollContainer = canvas.getByTestId("scroll-container");
+
+		await waitForScrollOverflow(scrollContainer);
+		await waitFor(
+			() => {
+				const dist =
+					scrollContainer.scrollHeight -
+					scrollContainer.scrollTop -
+					scrollContainer.clientHeight;
+				expect(dist).toBeLessThan(5);
+			},
+			{ timeout: 2000 },
+		);
+
+		const expandButton = await waitFor(() => {
+			const button = canvas.getByRole("button", {
+				name: /Created my-project/i,
+			});
+			expect(button).toBeVisible();
+			return button;
+		});
+		scrollContainer.dispatchEvent(
+			new WheelEvent("wheel", { bubbles: true, deltaY: -50 }),
+		);
+		const scrollContainerTop = scrollContainer.getBoundingClientRect().top;
+		const headerOffset =
+			expandButton.getBoundingClientRect().top - scrollContainerTop;
+		scrollContainer.scrollTop += headerOffset - 24;
+		scrollContainer.dispatchEvent(new Event("scroll"));
+
+		await waitFor(() => {
+			const nextOffset =
+				expandButton.getBoundingClientRect().top -
+				scrollContainer.getBoundingClientRect().top;
+			expect(nextOffset).toBeGreaterThanOrEqual(0);
+			expect(nextOffset).toBeLessThan(64);
+		});
+
+		const scrollTopBeforeExpand = scrollContainer.scrollTop;
+		await userEvent.click(expandButton);
+
+		await waitFor(() => {
+			expect(canvas.getByText("Starting workspace")).toBeInTheDocument();
+		});
+		await new Promise<void>((resolve) =>
+			requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+		);
+		expect(scrollContainer.scrollTop).toBeCloseTo(scrollTopBeforeExpand, 0);
+
+		const logsViewport = canvasElement.querySelector<HTMLElement>(
+			"[data-testid='workspace-build-logs-scroll-area'] [data-radix-scroll-area-viewport]",
+		);
+		expect(logsViewport).not.toBeNull();
+		expect(
+			logsViewport!.scrollTop + logsViewport!.clientHeight,
+		).toBeGreaterThanOrEqual(logsViewport!.scrollHeight - 2);
+	},
+};
+
 const wheelDeferredStore = buildStoreWithMessages(buildLongConversation(30));
+const visibilityResetStore = buildStoreWithMessages(buildLongConversation(30));
+
+/**
+ * Backgrounding the page mid-gesture should clear stale touch state so
+ * later content can still pin to the latest message.
+ */
+export const VisibilityChangeClearsTouchGuard: Story = {
+	parameters: { chromatic: { disableSnapshot: true } },
+	decorators: scrollStoryDecorators,
+	render: () => {
+		visibilityResetStore.replaceMessages(buildLongConversation(30));
+		visibilityResetStore.clearStreamState();
+		visibilityResetStore.setChatStatus("completed");
+		return <StoryAgentChatPageView store={visibilityResetStore} />;
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scrollContainer = canvas.getByTestId("scroll-container");
+
+		await waitForScrollOverflow(scrollContainer);
+		await waitFor(
+			() => {
+				const dist =
+					scrollContainer.scrollHeight -
+					scrollContainer.scrollTop -
+					scrollContainer.clientHeight;
+				expect(dist).toBeLessThan(5);
+			},
+			{ timeout: 2000 },
+		);
+
+		dispatchTouchEvent(scrollContainer, "touchstart", 1);
+
+		const hiddenDescriptor = Object.getOwnPropertyDescriptor(
+			document,
+			"hidden",
+		);
+		try {
+			Object.defineProperty(document, "hidden", {
+				configurable: true,
+				value: true,
+			});
+			document.dispatchEvent(new Event("visibilitychange"));
+
+			const existing = getStoreMessages(visibilityResetStore);
+			const nextID = existing[existing.length - 1]?.id ?? 30;
+			visibilityResetStore.replaceMessages(
+				existing.concat([
+					buildMessage(
+						nextID + 1,
+						"assistant",
+						"Fresh streamed output after resume.",
+					),
+				]),
+			);
+
+			await waitFor(
+				() => {
+					const dist =
+						scrollContainer.scrollHeight -
+						scrollContainer.scrollTop -
+						scrollContainer.clientHeight;
+					expect(dist).toBeLessThan(5);
+				},
+				{ timeout: 2000 },
+			);
+		} finally {
+			Object.defineProperty(
+				document,
+				"hidden",
+				hiddenDescriptor ?? {
+					configurable: true,
+					value: false,
+				},
+			);
+		}
+	},
+};
 
 /**
  * Regression: when content grows during a wheel burst (so

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -1,12 +1,6 @@
 import { ArchiveIcon } from "lucide-react";
 
-import {
-	type FC,
-	type ReactNode,
-	type RefObject,
-	useRef,
-	useState,
-} from "react";
+import { type FC, type ReactNode, type RefObject, useState } from "react";
 import { useQueryClient } from "react-query";
 import type { UrlTransform } from "streamdown";
 import { chatDiffContentsKey } from "#/api/queries/chats";
@@ -147,9 +141,9 @@ interface AgentChatPageViewProps {
 	isRegeneratingTitle?: boolean;
 	isRegenerateTitleDisabled?: boolean;
 
-	// Scroll container ref.
-	scrollContainerRef: RefObject<HTMLDivElement | null>;
-	scrollToBottomRef?: RefObject<(() => void) | null>;
+	// Scroll container callbacks.
+	onScrollContainerChange?: (element: HTMLDivElement | null) => void;
+	onScrollToBottomChange?: (scrollToBottom: (() => void) | null) => void;
 
 	// Pagination for loading older messages.
 	hasMoreMessages: boolean;
@@ -219,8 +213,8 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	handleRegenerateTitle,
 	isRegeneratingTitle,
 	isRegenerateTitleDisabled,
-	scrollContainerRef,
-	scrollToBottomRef,
+	onScrollContainerChange,
+	onScrollToBottomChange,
 	hasMoreMessages,
 	isFetchingMoreMessages,
 	onFetchMoreMessages,
@@ -257,9 +251,6 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 		null,
 	);
 	const visualExpanded = dragVisualExpanded ?? isRightPanelExpanded;
-	const internalScrollToBottomRef = useRef<(() => void) | null>(null);
-	const effectiveScrollToBottomRef =
-		scrollToBottomRef ?? internalScrollToBottomRef;
 
 	// State for programmatically switching the sidebar tab (e.g. when
 	// the user clicks the inline desktop preview card).
@@ -376,8 +367,8 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 						</div>
 						<ChatScrollContainer
 							key={agentId}
-							scrollContainerRef={scrollContainerRef}
-							scrollToBottomRef={effectiveScrollToBottomRef}
+							onScrollContainerChange={onScrollContainerChange}
+							onScrollToBottomChange={onScrollToBottomChange}
 							isFetchingMoreMessages={isFetchingMoreMessages}
 							hasMoreMessages={hasMoreMessages}
 							onFetchMoreMessages={onFetchMoreMessages}

--- a/site/src/pages/AgentsPage/AgentEmbedPage.tsx
+++ b/site/src/pages/AgentsPage/AgentEmbedPage.tsx
@@ -227,7 +227,9 @@ const AgentEmbedPage: FC = () => {
 		onToggleSidebarCollapsed,
 		onExpandSidebar: () => {},
 		onChatReady,
-		scrollContainerRef,
+		setScrollContainerElement: (element) => {
+			scrollContainerRef.current = element;
+		},
 	};
 
 	// When signed out and not already bootstrapping, listen for the

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -342,7 +342,7 @@ const AgentsPage: FC = () => {
 					: undefined,
 			)
 		) {
-			navigate("/agents");
+			navigate("/agents", { preventScrollReset: true });
 		}
 	};
 
@@ -475,7 +475,7 @@ const AgentsPage: FC = () => {
 		if (!agentId) {
 			localStorage.removeItem(emptyInputStorageKey);
 		}
-		navigate("/agents");
+		navigate("/agents", { preventScrollReset: true });
 	};
 
 	useEffect(() => {

--- a/site/src/pages/AgentsPage/AgentsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageView.tsx
@@ -1,4 +1,4 @@
-import { type FC, type RefObject, useRef } from "react";
+import { type FC, useRef } from "react";
 import { Outlet, useLocation } from "react-router";
 import type * as TypesGen from "#/api/typesGenerated";
 import { cn } from "#/utils/cn";
@@ -30,8 +30,8 @@ export interface AgentsOutletContext {
 	onToggleSidebarCollapsed: () => void;
 	onExpandSidebar: () => void;
 	onChatReady: () => void;
-	/** Ref attached to the chat scroll container by AgentChatPage. */
-	scrollContainerRef: RefObject<HTMLDivElement | null>;
+	/** Callback attached to the chat scroll container by AgentChatPage. */
+	setScrollContainerElement: (element: HTMLDivElement | null) => void;
 }
 
 interface AgentsPageViewProps {
@@ -152,7 +152,9 @@ export const AgentsPageView: FC<AgentsPageViewProps> = ({
 		onToggleSidebarCollapsed,
 		onExpandSidebar,
 		onChatReady: () => {},
-		scrollContainerRef,
+		setScrollContainerElement: (element) => {
+			scrollContainerRef.current = element;
+		},
 	};
 
 	return (

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -303,6 +303,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 	folder,
 }) => {
 	const [chatFullWidth] = useChatFullWidth();
+	const shouldAutoFocus = !isMobileViewport();
 	const internalRef = useRef<ChatMessageInputRef>(null);
 	const [previewImage, setPreviewImage] = useState<string | null>(null);
 	const [previewText, setPreviewText] = useState<string | null>(null);
@@ -740,7 +741,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 					onKeyDown={handleEditorKeyDown}
 					onEnter={handleSubmit}
 					disabled={isDisabled || isLoading}
-					autoFocus
+					autoFocus={shouldAutoFocus}
 				/>
 				{/* Warn about invisible Unicode in the message text.
 				 * Unlike the admin/user prompt textareas (which strip

--- a/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
@@ -411,7 +411,8 @@ const RemoteImageBlock: FC<{
 	displayName: string;
 	onImageClick?: (src: string) => void;
 }> = ({ fileId, href, displayName, onImageClick }) => {
-	const { hasExpired, markExpired } = useExpiredFileIds();
+	const { hasExpired, markExpired, markProbing, clearProbing } =
+		useExpiredFileIds();
 	const isKnownExpired = fileId !== undefined && hasExpired(fileId);
 	const [failureState, setFailureState] = useState<AttachmentFailureState>(
 		() => (isKnownExpired ? { kind: "expired" } : { kind: "idle" }),
@@ -462,13 +463,16 @@ const RemoteImageBlock: FC<{
 						return;
 					}
 
-					const controller = probeRequest.start();
 					// Optimistically swap to the generic failure tile. The
-					// probe will either upgrade it to "expired" or fill in
-					// a detail; showing a tile without a label flash is
-					// preferable to leaving the broken-image icon up.
+					// shared probe will either upgrade it to "expired" or
+					// fill in a detail; showing a tile without a label flash
+					// is preferable to leaving the broken-image icon up.
 					setFailureState({ kind: "failed" });
+					if (!markProbing(fileId)) {
+						return;
+					}
 
+					const controller = probeRequest.start();
 					void probeAttachmentFailure(href, controller.signal)
 						.then((reason) => {
 							if (!probeRequest.clear(controller)) {
@@ -487,6 +491,9 @@ const RemoteImageBlock: FC<{
 								return;
 							}
 							setFailureState(attachmentFailureFromError(error));
+						})
+						.finally(() => {
+							clearProbing(fileId);
 						});
 				}}
 			/>

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -1048,36 +1048,165 @@ export const StickyUserMessageStructure: Story = {
 		]),
 	},
 	play: async ({ canvasElement }) => {
-		// Each user message should produce a data-user-sentinel
-		// marker that the push-up scroll logic relies on.
-		const sentinels = canvasElement.querySelectorAll("[data-user-sentinel]");
-		expect(sentinels.length).toBe(2);
-
-		// Each sentinel should be immediately followed by a sticky
-		// container (the user message itself).
-		for (const sentinel of sentinels) {
-			const container = sentinel.nextElementSibling;
-			expect(container).not.toBeNull();
-			const style = window.getComputedStyle(container!);
-			expect(style.position).toBe("sticky");
-		}
-
-		// Sentinels must appear in DOM order matching the message
-		// order so nextElementSibling traversal finds the correct
-		// next user message.
-		const allElements = Array.from(
-			canvasElement.querySelectorAll("[data-user-sentinel], [class*='sticky']"),
+		const anchors = Array.from(
+			canvasElement.querySelectorAll<HTMLElement>("[data-chat-anchor='true']"),
 		);
-		const sentinelIndices = Array.from(sentinels).map((s) =>
-			allElements.indexOf(s),
+		expect(canvasElement.querySelectorAll("[data-user-sentinel]")).toHaveLength(
+			0,
 		);
-		// Sentinels should be in ascending DOM order.
-		expect(sentinelIndices[0]).toBeLessThan(sentinelIndices[1]);
+		expect(anchors).toHaveLength(4);
+		expect(
+			new Set(anchors.map((anchor) => anchor.dataset.chatAnchorId)),
+		).toEqual(new Set(["message-1", "message-2", "message-3", "message-4"]));
 
-		// Both user messages should be visible.
+		const firstPromptAnchor = canvasElement.querySelector(
+			"[data-chat-anchor-id='message-1']",
+		);
+		const secondPromptAnchor = canvasElement.querySelector(
+			"[data-chat-anchor-id='message-3']",
+		);
+		expect(
+			firstPromptAnchor?.compareDocumentPosition(secondPromptAnchor!),
+		).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+
 		const canvas = within(canvasElement);
 		expect(canvas.getByText("First prompt")).toBeVisible();
 		expect(canvas.getByText("Second prompt")).toBeVisible();
+	},
+};
+
+export const LatestUserMessagePinnedPreviewDoesNotDuplicateActions: Story = {
+	args: {
+		...defaultArgs,
+		parsedMessages: buildMessages([
+			{
+				...baseMessage,
+				id: 1,
+				role: "user",
+				content: [{ type: "text", text: "Earlier prompt" }],
+			},
+			{
+				...baseMessage,
+				id: 2,
+				role: "assistant",
+				content: [{ type: "text", text: "Context block. ".repeat(160) }],
+			},
+			{
+				...baseMessage,
+				id: 3,
+				role: "user",
+				content: [{ type: "text", text: "Latest prompt" }],
+			},
+			{
+				...baseMessage,
+				id: 4,
+				role: "assistant",
+				content: [{ type: "text", text: "Follow-up response. ".repeat(180) }],
+			},
+		]),
+		onEditUserMessage: fn(),
+	},
+	decorators: [
+		(Story) => (
+			<div
+				data-testid="scroll-container"
+				style={{ maxHeight: "280px", overflowY: "auto" }}
+			>
+				<Story />
+			</div>
+		),
+	],
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scrollContainer = canvas.getByTestId("scroll-container");
+		const latestMessageAnchor = canvasElement.querySelector<HTMLElement>(
+			"[data-chat-anchor-id='message-3']",
+		);
+		expect(latestMessageAnchor).not.toBeNull();
+		const copyButtonsBefore = canvas.getAllByRole("button", {
+			name: "Copy message",
+		}).length;
+		const editButtonsBefore = canvas.getAllByRole("button", {
+			name: "Edit message",
+		}).length;
+
+		scrollContainer.scrollTop = latestMessageAnchor!.offsetTop + 16;
+		scrollContainer.dispatchEvent(new Event("scroll"));
+
+		await waitFor(() => {
+			expect(canvas.getAllByText("Latest prompt")).toHaveLength(2);
+		});
+		expect(
+			canvas.getAllByRole("button", { name: "Copy message" }),
+		).toHaveLength(copyButtonsBefore);
+		expect(
+			canvas.getAllByRole("button", { name: "Edit message" }),
+		).toHaveLength(editButtonsBefore);
+	},
+};
+
+export const LatestUserMessagePinnedPreview: Story = {
+	args: {
+		...defaultArgs,
+		parsedMessages: buildMessages([
+			{
+				...baseMessage,
+				id: 1,
+				role: "user",
+				content: [{ type: "text", text: "Earlier prompt" }],
+			},
+			{
+				...baseMessage,
+				id: 2,
+				role: "assistant",
+				content: [{ type: "text", text: "Context block. ".repeat(160) }],
+			},
+			{
+				...baseMessage,
+				id: 3,
+				role: "user",
+				content: [{ type: "text", text: "Latest prompt" }],
+			},
+			{
+				...baseMessage,
+				id: 4,
+				role: "assistant",
+				content: [{ type: "text", text: "Follow-up response. ".repeat(180) }],
+			},
+		]),
+	},
+	decorators: [
+		(Story) => (
+			<div
+				data-testid="scroll-container"
+				style={{ maxHeight: "280px", overflowY: "auto" }}
+			>
+				<Story />
+			</div>
+		),
+	],
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const scrollContainer = canvas.getByTestId("scroll-container");
+		const latestMessageAnchor = canvasElement.querySelector<HTMLElement>(
+			"[data-chat-anchor-id='message-3']",
+		);
+		expect(latestMessageAnchor).not.toBeNull();
+		expect(canvas.getAllByText("Latest prompt")).toHaveLength(1);
+
+		scrollContainer.scrollTop = latestMessageAnchor!.offsetTop + 16;
+		scrollContainer.dispatchEvent(new Event("scroll"));
+
+		await waitFor(() => {
+			expect(canvas.getAllByText("Latest prompt")).toHaveLength(2);
+		});
+
+		scrollContainer.scrollTop = 0;
+		scrollContainer.dispatchEvent(new Event("scroll"));
+
+		await waitFor(() => {
+			expect(canvas.getAllByText("Latest prompt")).toHaveLength(1);
+		});
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -1,12 +1,5 @@
 import { PencilIcon } from "lucide-react";
-import {
-	type FC,
-	Fragment,
-	memo,
-	useLayoutEffect,
-	useRef,
-	useState,
-} from "react";
+import { type FC, Fragment, memo, useEffect, useRef, useState } from "react";
 import type { UrlTransform } from "streamdown";
 import type * as TypesGen from "#/api/typesGenerated";
 import { Button } from "#/components/Button/Button";
@@ -27,6 +20,10 @@ import {
 } from "../ChatElements";
 import { WebSearchSources } from "../ChatElements/tools";
 import type { SubagentVariant } from "../ChatElements/tools/subagentDescriptor";
+import {
+	getPinnedPreviewMetrics,
+	PINNED_PREVIEW_MIN_HEIGHT_PX,
+} from "../chatViewportUtils";
 import { ImageLightbox } from "../ImageLightbox";
 import { TextPreviewDialog } from "../TextPreviewDialog";
 import {
@@ -537,6 +534,8 @@ const StickyUserMessage = memo<{
 	) => void;
 	editingMessageId?: number | null;
 	isAfterEditingMessage?: boolean;
+	latestUserMessageId?: number;
+	assistantBelowHeight: number;
 }>(
 	({
 		message,
@@ -544,176 +543,17 @@ const StickyUserMessage = memo<{
 		onEditUserMessage,
 		editingMessageId,
 		isAfterEditingMessage = false,
+		latestUserMessageId,
+		assistantBelowHeight,
 	}) => {
-		const [isStuck, setIsStuck] = useState(false);
-		const [isReady, setIsReady] = useState(false);
-		const [isTooTall, setIsTooTall] = useState(false);
-		const sentinelRef = useRef<HTMLDivElement>(null);
-		const containerRef = useRef<HTMLDivElement>(null);
-		const updateFnRef = useRef<(() => void) | null>(null);
-
-		// useLayoutEffect so isStuck and --clip-h are both resolved
-		// before the browser paints, avoiding a flash on load.
-		useLayoutEffect(() => {
-			const sentinel = sentinelRef.current;
-			if (!sentinel) return;
-			// Immediate check so the first paint is correct when the
-			// sentinel is already scrolled out of view.
-			const scroller = sentinel.closest(".overflow-y-auto");
-			if (scroller) {
-				const stuck =
-					sentinel.getBoundingClientRect().top <
-					scroller.getBoundingClientRect().top;
-				if (stuck) {
-					setIsStuck(true);
-				}
-			}
-			setIsReady(true);
-			const observer = new IntersectionObserver(
-				([entry]) => setIsStuck(!entry.isIntersecting),
-				{ threshold: 0 },
-			);
-			observer.observe(sentinel);
-			return () => observer.disconnect();
-		}, []);
-
-		// Sets a single CSS custom property (--clip-h) on the sticky
-		// container. All visual behaviour (max-height, mask fade) is
-		// driven by CSS using this variable.
-		useLayoutEffect(() => {
-			const sentinel = sentinelRef.current;
-			const container = containerRef.current;
-			if (!sentinel || !container) return;
-			const scroller = sentinel.closest(
-				".overflow-y-auto",
-			) as HTMLElement | null;
-			if (!scroller) return;
-
-			const MIN_HEIGHT = 72;
-			const STICKY_TOP = 8;
-
-			let scrollerTop = scroller.getBoundingClientRect().top;
-			let scrollerHeight = scroller.clientHeight;
-
-			const update = () => {
-				const fullHeight = container.offsetHeight;
-
-				// Skip sticky behavior for messages that take up
-				// most of the visible area — accounting for the
-				// chat input and some breathing room.
-				const tooTall = fullHeight > scrollerHeight * 0.75;
-				setIsTooTall(tooTall);
-				if (tooTall) {
-					container.style.setProperty("--clip-h", `${fullHeight}px`);
-					container.style.setProperty("--fade-opacity", "0");
-					container.style.top = `${STICKY_TOP}px`;
-
-					return;
-				}
-				const sentinelTop = sentinel.getBoundingClientRect().top;
-				const scrolledPast = scrollerTop - sentinelTop;
-
-				if (scrolledPast <= 0) {
-					// Always set a valid value so the overlay has the
-					// correct height immediately when isStuck flips.
-					container.style.setProperty("--clip-h", `${fullHeight}px`);
-					container.style.setProperty("--fade-opacity", "0");
-					container.style.top = `${STICKY_TOP}px`;
-
-					return;
-				}
-				const visible = Math.max(fullHeight - scrolledPast, MIN_HEIGHT);
-				container.style.setProperty("--clip-h", `${visible}px`);
-				// Only show the blur and gradient once the message
-				// is near its minimum compressed height. Ramp over
-				// the last 40px before MIN_HEIGHT so it doesn't pop.
-				const FADE_RANGE = 40;
-				const fade = Math.max(
-					0,
-					Math.min((MIN_HEIGHT + FADE_RANGE - visible) / FADE_RANGE, 1),
-				);
-				container.style.setProperty("--fade-opacity", String(fade));
-				// Push-up effect: when the next user message's sentinel
-				// approaches the bottom of this sticky container, shift
-				// this container upward so it slides out of view — the
-				// same visual as the old section-boundary behavior.
-				let nextSentinel: Element | null = sentinel.nextElementSibling;
-				while (nextSentinel) {
-					if (nextSentinel.hasAttribute("data-user-sentinel")) {
-						break;
-					}
-					nextSentinel = nextSentinel.nextElementSibling;
-				}
-				if (nextSentinel) {
-					const nextY = nextSentinel.getBoundingClientRect().top - scrollerTop;
-					container.style.top = `${Math.min(STICKY_TOP, nextY - visible + STICKY_TOP)}px`;
-				} else {
-					container.style.top = `${STICKY_TOP}px`;
-				}
-			};
-			updateFnRef.current = update;
-
-			const onResize = () => {
-				scrollerTop = scroller.getBoundingClientRect().top;
-				scrollerHeight = scroller.clientHeight;
-				update();
-			};
-
-			// Throttle to one update per animation frame so we don't
-			// do redundant work on high-refresh-rate displays.
-			let rafId: number | null = null;
-			const onScroll = () => {
-				if (rafId !== null) return;
-				rafId = requestAnimationFrame(() => {
-					rafId = null;
-					update();
-				});
-			};
-
-			// Re-run the visual update when the scrollable content height
-			// changes (e.g. streaming responses growing the transcript).
-			// In flex-col-reverse, scrollTop stays at 0 when pinned to
-			// bottom so no scroll event fires — but the content wrapper
-			// resizes and this observer catches that.
-			const contentEl = scroller.firstElementChild as HTMLElement | null;
-			let contentRafId: number | null = null;
-			const contentObserver = contentEl
-				? new ResizeObserver(() => {
-						if (contentRafId !== null) return;
-						contentRafId = requestAnimationFrame(() => {
-							contentRafId = null;
-							update();
-						});
-					})
-				: null;
-			contentObserver?.observe(contentEl!);
-
-			scroller.addEventListener("scroll", onScroll, { passive: true });
-			window.addEventListener("resize", onResize);
-			update();
-			// Set immediately — both --clip-h and --overlay-ready are
-			// applied before the browser paints since we're in a
-			// useLayoutEffect.
-			container.style.setProperty("--overlay-ready", "1");
-			return () => {
-				scroller.removeEventListener("scroll", onScroll);
-				window.removeEventListener("resize", onResize);
-				contentObserver?.disconnect();
-				container.style.removeProperty("--overlay-ready");
-				if (rafId !== null) cancelAnimationFrame(rafId);
-				if (contentRafId !== null) cancelAnimationFrame(contentRafId);
-			};
-		}, []);
-
-		// Re-run the height calculation synchronously whenever
-		// isStuck changes so --clip-h is correct on the same frame
-		// the overlay appears. Without this, the async
-		// IntersectionObserver + RAF-throttled scroll handler can
-		// leave a stale --clip-h for one paint.
-		// biome-ignore lint/correctness/useExhaustiveDependencies: isStuck is an intentional trigger
-		useLayoutEffect(() => {
-			updateFnRef.current?.();
-		}, [isStuck]);
+		const markerRef = useRef<HTMLDivElement>(null);
+		const messageRef = useRef<HTMLDivElement>(null);
+		const [previewMetrics, setPreviewMetrics] = useState(() =>
+			getPinnedPreviewMetrics({
+				messageHeight: 0,
+				scrolledPast: 0,
+			}),
+		);
 
 		const handleEditUserMessage = onEditUserMessage
 			? (
@@ -721,44 +561,131 @@ const StickyUserMessage = memo<{
 					text: string,
 					fileBlocks?: readonly TypesGen.ChatMessagePart[],
 				) => {
+					const markerElement = markerRef.current;
+					const scroller = markerElement?.closest(
+						"[data-testid='scroll-container']",
+					) as HTMLElement | null;
+					const offsetBeforeEdit =
+						markerElement && scroller
+							? markerElement.getBoundingClientRect().top -
+								scroller.getBoundingClientRect().top
+							: null;
 					onEditUserMessage(messageId, text, fileBlocks);
 					requestAnimationFrame(() => {
-						const sentinel = sentinelRef.current;
-						if (!sentinel) return;
-						const scroller = sentinel.closest(
-							".overflow-y-auto",
+						const nextMarkerElement = markerRef.current;
+						const nextScroller = nextMarkerElement?.closest(
+							"[data-testid='scroll-container']",
 						) as HTMLElement | null;
-						if (!scroller) return;
-						const offset =
-							sentinel.getBoundingClientRect().top -
-							scroller.getBoundingClientRect().top;
-						scroller.scrollBy({ top: offset, behavior: "smooth" });
+						if (
+							offsetBeforeEdit === null ||
+							!nextMarkerElement ||
+							!nextScroller
+						) {
+							return;
+						}
+						const offsetAfterEdit =
+							nextMarkerElement.getBoundingClientRect().top -
+							nextScroller.getBoundingClientRect().top;
+						const offsetDelta = offsetAfterEdit - offsetBeforeEdit;
+						if (Math.abs(offsetDelta) <= 1) {
+							return;
+						}
+						nextScroller.scrollBy({
+							top: offsetDelta,
+							behavior: "instant",
+						});
 					});
 				}
 			: undefined;
 
+		useEffect(() => {
+			const markerElement = markerRef.current;
+			const messageElement = messageRef.current;
+			const scroller = messageElement?.closest(
+				"[data-testid='scroll-container']",
+			) as HTMLElement | null;
+			if (!markerElement || !messageElement || !scroller) {
+				return;
+			}
+
+			if (
+				latestUserMessageId !== message.id ||
+				assistantBelowHeight < PINNED_PREVIEW_MIN_HEIGHT_PX
+			) {
+				setPreviewMetrics(
+					getPinnedPreviewMetrics({
+						messageHeight: messageElement.offsetHeight,
+						scrolledPast: 0,
+					}),
+				);
+				return;
+			}
+
+			const updatePinnedPreview = () => {
+				const scrolledPast =
+					scroller.getBoundingClientRect().top -
+					markerElement.getBoundingClientRect().top -
+					8;
+				setPreviewMetrics(
+					getPinnedPreviewMetrics({
+						messageHeight: messageElement.offsetHeight,
+						scrolledPast,
+					}),
+				);
+			};
+
+			let frameId: number | null = null;
+			const scheduleUpdate = () => {
+				if (frameId !== null) {
+					return;
+				}
+				frameId = requestAnimationFrame(() => {
+					frameId = null;
+					updatePinnedPreview();
+				});
+			};
+
+			const observer = new ResizeObserver(scheduleUpdate);
+			observer.observe(messageElement);
+			observer.observe(scroller);
+			scroller.addEventListener("scroll", scheduleUpdate, { passive: true });
+			scheduleUpdate();
+
+			return () => {
+				observer.disconnect();
+				scroller.removeEventListener("scroll", scheduleUpdate);
+				if (frameId !== null) {
+					cancelAnimationFrame(frameId);
+				}
+			};
+		}, [assistantBelowHeight, latestUserMessageId, message.id]);
+
+		const showOverlay = previewMetrics.active;
+
 		return (
 			<>
-				<div ref={sentinelRef} className="h-0" data-user-sentinel />
 				<div
-					ref={containerRef}
+					ref={markerRef}
+					data-chat-anchor="true"
+					data-chat-anchor-id={`message-${message.id}`}
+					className="pointer-events-none h-px"
+				/>
+				<div
+					ref={messageRef}
 					className={cn(
 						"relative px-3 -mx-3 -mt-2",
-						!isTooTall && "sticky z-10",
-						!isReady && "invisible",
-						isStuck && !isTooTall && "pointer-events-none",
+						showOverlay && "sticky top-2 z-10",
 					)}
 				>
-					{/* Flow element: always in the DOM to preserve
-				    scroll layout. Hidden when stuck so the
-				    clipped overlay takes over visually. */}
 					<div
+						inert={showOverlay ? true : undefined}
+						aria-hidden={showOverlay || undefined}
 						className={
-							isStuck && !isTooTall ? undefined : "pointer-events-auto"
+							showOverlay ? "pointer-events-none" : "pointer-events-auto"
 						}
 						style={
-							isStuck && !isTooTall
-								? { opacity: "calc(1 - var(--overlay-ready, 0))" }
+							showOverlay
+								? { opacity: 1 - previewMetrics.overlayOpacity }
 								: undefined
 						}
 					>
@@ -770,40 +697,22 @@ const StickyUserMessage = memo<{
 							isAfterEditingMessage={isAfterEditingMessage}
 						/>
 					</div>
-
-					{/* Overlay: absolutely positioned, matching the
-				    sticky container. max-height + mask are driven
-				    entirely by the --clip-h CSS variable which the
-				    scroll handler sets on the container. */}
-					{isStuck && !isTooTall && (
+					{showOverlay ? (
 						<div
-							className="absolute inset-0"
-							style={{
-								opacity: "var(--overlay-ready, 0)",
-								contain: "layout style",
-							}}
+							data-chat-anchor-ignore="true"
+							className="pointer-events-none absolute inset-x-0 top-0 z-10"
+							style={{ opacity: previewMetrics.overlayOpacity }}
 						>
-							{/* Blur layer: extends 48px beyond the
-						    clipped content so the frosted effect
-						    is visible around the bubble. Promoted
-						    to its own GPU layer via will-change. */}
 							<div
 								className="absolute inset-0 backdrop-blur-[1px] bg-surface-primary/15"
 								style={{
-									opacity: "var(--fade-opacity, 0)",
-									maxHeight: "calc(var(--clip-h, 100%) + 48px)",
-									willChange: "max-height, mask-image",
-									maskImage:
-										"linear-gradient(to bottom, black calc(var(--clip-h, 100%) + 24px), transparent calc(var(--clip-h, 100%) + 48px))",
-									WebkitMaskImage:
-										"linear-gradient(to bottom, black calc(var(--clip-h, 100%) + 24px), transparent calc(var(--clip-h, 100%) + 48px))",
+									opacity: previewMetrics.fadeOpacity,
+									maxHeight: `${previewMetrics.clipHeight + 48}px`,
+									maskImage: `linear-gradient(to bottom, black ${previewMetrics.clipHeight + 24}px, transparent ${previewMetrics.clipHeight + 48}px)`,
+									WebkitMaskImage: `linear-gradient(to bottom, black ${previewMetrics.clipHeight + 24}px, transparent ${previewMetrics.clipHeight + 48}px)`,
 								}}
 							/>
-							{/* Content layer: px-3 matches the sticky
-							    container's padding so the overlay aligns
-							    with the flow element. will-change promotes
-							    to GPU layer. */}
-							<div className="relative px-3 pointer-events-auto will-change-[max-height]">
+							<div className="relative px-3 pointer-events-auto">
 								<ChatMessageItem
 									message={message}
 									parsed={parsed}
@@ -814,7 +723,7 @@ const StickyUserMessage = memo<{
 								/>
 							</div>
 						</div>
-					)}
+					) : null}
 				</div>
 			</>
 		);
@@ -837,7 +746,7 @@ interface ConversationTimelineProps {
 	urlTransform?: UrlTransform;
 	mcpServers?: readonly TypesGen.MCPServerConfig[];
 	showDesktopPreviews?: boolean;
-	isTurnActive?: boolean;
+	hasLiveContentBelowLatestUser?: boolean;
 }
 
 export const ConversationTimeline = memo<ConversationTimelineProps>(
@@ -853,6 +762,7 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 		urlTransform,
 		mcpServers,
 		showDesktopPreviews,
+		hasLiveContentBelowLatestUser = false,
 	}) => {
 		if (parsedMessages.length === 0) {
 			return null;
@@ -910,6 +820,24 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 				? askUserQuestionResponseTextByToolId
 				: undefined;
 
+		const latestUserMessageId = [...parsedMessages]
+			.reverse()
+			.find((entry) => entry.message.role === "user")?.message.id;
+		const latestUserMessageIndex = latestUserMessageId
+			? parsedMessages.findIndex(
+					(entry) => entry.message.id === latestUserMessageId,
+				)
+			: -1;
+		let assistantBelowHeight = 0;
+		for (const entry of parsedMessages.slice(latestUserMessageIndex + 1)) {
+			if (entry.message.role === "assistant") {
+				assistantBelowHeight += 1;
+			}
+		}
+		if (hasLiveContentBelowLatestUser) {
+			assistantBelowHeight += 1;
+		}
+
 		return (
 			<ExpiredFileIdsProvider>
 				<div
@@ -926,6 +854,8 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 									onEditUserMessage={onEditUserMessage}
 									editingMessageId={editingMessageId}
 									isAfterEditingMessage={afterEditingMessageIds.has(message.id)}
+									latestUserMessageId={latestUserMessageId}
+									assistantBelowHeight={assistantBelowHeight * 120}
 								/>
 							);
 						}
@@ -934,28 +864,33 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 						const next = parsedMessages[msgIdx + 1];
 						const isLastInChain = !next || next.message.role === "user";
 						return (
-							<ChatMessageItem
+							<div
 								key={message.id}
-								message={message}
-								parsed={parsed}
-								onImplementPlan={onImplementPlan}
-								onSendAskUserQuestionResponse={onSendAskUserQuestionResponse}
-								isChatCompleted={isChatCompleted}
-								latestAskUserQuestionToolId={latestAskUserQuestionToolId}
-								askUserQuestionResponseTextByToolId={
-									historicalAskUserQuestionResponseTextByToolId
-								}
-								hasUserResponseAfterAskQuestion={
-									hasUserResponseAfterAskQuestion
-								}
-								urlTransform={urlTransform}
-								isAfterEditingMessage={afterEditingMessageIds.has(message.id)}
-								hideActions={!isLastInChain}
-								mcpServers={mcpServers}
-								subagentTitles={subagentTitles}
-								subagentVariants={subagentVariants}
-								showDesktopPreviews={showDesktopPreviews}
-							/>
+								data-chat-anchor="true"
+								data-chat-anchor-id={`message-${message.id}`}
+							>
+								<ChatMessageItem
+									message={message}
+									parsed={parsed}
+									onImplementPlan={onImplementPlan}
+									onSendAskUserQuestionResponse={onSendAskUserQuestionResponse}
+									isChatCompleted={isChatCompleted}
+									latestAskUserQuestionToolId={latestAskUserQuestionToolId}
+									askUserQuestionResponseTextByToolId={
+										historicalAskUserQuestionResponseTextByToolId
+									}
+									hasUserResponseAfterAskQuestion={
+										hasUserResponseAfterAskQuestion
+									}
+									urlTransform={urlTransform}
+									isAfterEditingMessage={afterEditingMessageIds.has(message.id)}
+									hideActions={!isLastInChain}
+									mcpServers={mcpServers}
+									subagentTitles={subagentTitles}
+									subagentVariants={subagentVariants}
+									showDesktopPreviews={showDesktopPreviews}
+								/>
+							</div>
 						);
 					})}
 				</div>

--- a/site/src/pages/AgentsPage/components/ChatConversation/ExpiredFileIdsContext.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ExpiredFileIdsContext.tsx
@@ -3,37 +3,58 @@ import {
 	type FC,
 	type PropsWithChildren,
 	useContext,
+	useRef,
 	useState,
 } from "react";
 
 type ExpiredFileIdsContextValue = {
 	hasExpired: (fileId: string) => boolean;
 	markExpired: (fileId: string) => void;
+	markProbing: (fileId: string) => boolean;
+	clearProbing: (fileId: string) => void;
 };
 
 const ExpiredFileIdsContext = createContext<ExpiredFileIdsContextValue>({
 	hasExpired: () => false,
 	markExpired: () => {},
+	markProbing: () => false,
+	clearProbing: () => {},
 });
 
 export const ExpiredFileIdsProvider: FC<PropsWithChildren> = ({ children }) => {
 	const [expiredFileIds, setExpiredFileIds] = useState<Set<string>>(
 		() => new Set(),
 	);
+	const expiredFileIdsRef = useRef(expiredFileIds);
+	const probingFileIdsRef = useRef<Set<string>>(new Set());
 
 	return (
 		<ExpiredFileIdsContext.Provider
 			value={{
-				hasExpired: (fileId) => expiredFileIds.has(fileId),
+				hasExpired: (fileId) => expiredFileIdsRef.current.has(fileId),
 				markExpired: (fileId) => {
-					setExpiredFileIds((previous) => {
-						if (previous.has(fileId)) {
-							return previous;
-						}
-						const next = new Set(previous);
-						next.add(fileId);
-						return next;
-					});
+					if (expiredFileIdsRef.current.has(fileId)) {
+						probingFileIdsRef.current.delete(fileId);
+						return;
+					}
+					const nextExpiredFileIds = new Set(expiredFileIdsRef.current);
+					nextExpiredFileIds.add(fileId);
+					expiredFileIdsRef.current = nextExpiredFileIds;
+					setExpiredFileIds(nextExpiredFileIds);
+					probingFileIdsRef.current.delete(fileId);
+				},
+				markProbing: (fileId) => {
+					if (
+						expiredFileIdsRef.current.has(fileId) ||
+						probingFileIdsRef.current.has(fileId)
+					) {
+						return false;
+					}
+					probingFileIdsRef.current.add(fileId);
+					return true;
+				},
+				clearProbing: (fileId) => {
+					probingFileIdsRef.current.delete(fileId);
 				},
 			}}
 		>

--- a/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { Link } from "react-router";
 import type { UrlTransform } from "streamdown";
 import type * as TypesGen from "#/api/typesGenerated";
@@ -5,6 +6,7 @@ import { Alert, AlertDescription } from "#/components/Alert/Alert";
 import { Button } from "#/components/Button/Button";
 import type { ChatDetailError } from "../../utils/usageLimitMessage";
 import type { SubagentVariant } from "../ChatElements/tools/subagentDescriptor";
+import { LIVE_STREAM_TAIL_ANCHOR_ID } from "../chatViewportUtils";
 import { ChatStatusCallout } from "./ChatStatusCallout";
 import {
 	selectIsAwaitingFirstStreamChunk,
@@ -29,6 +31,23 @@ const shouldRenderStreamingSection = (liveStatus: LiveStatusModel): boolean =>
 	liveStatus.hasAccumulatedOutput;
 
 type ChatStoreHandle = ReturnType<typeof useChatStore>["store"];
+
+type LatchedStreamState = {
+	contextKey: string;
+	streamState: StreamState;
+};
+
+const hasRenderableStreamState = (streamState: StreamState | null): boolean => {
+	if (!streamState) {
+		return false;
+	}
+	return (
+		streamState.blocks.length > 0 ||
+		Object.keys(streamState.toolCalls).length > 0 ||
+		Object.keys(streamState.toolResults).length > 0 ||
+		streamState.sources.length > 0
+	);
+};
 
 interface LiveStreamTailContentProps {
 	isTranscriptEmpty: boolean;
@@ -71,7 +90,11 @@ export const LiveStreamTailContent = ({
 	}
 
 	return (
-		<div className="flex flex-col gap-2">
+		<div
+			data-chat-anchor="true"
+			data-chat-anchor-id={LIVE_STREAM_TAIL_ANCHOR_ID}
+			className="flex flex-col gap-2"
+		>
 			{shouldRenderEmptyState && (
 				<div className="py-12 text-center text-content-secondary">
 					<p className="text-sm">Start a conversation with your agent.</p>
@@ -113,6 +136,7 @@ interface LiveStreamTailProps {
 	persistedError: ChatDetailError | undefined;
 	isTranscriptEmpty: boolean;
 	startingResetKey?: string;
+	tailContextKey: string;
 	subagentTitles: Map<string, string>;
 	subagentVariants?: Map<string, SubagentVariant>;
 	urlTransform?: UrlTransform;
@@ -124,6 +148,7 @@ export const LiveStreamTail = ({
 	persistedError,
 	isTranscriptEmpty,
 	startingResetKey,
+	tailContextKey,
 	subagentTitles,
 	subagentVariants,
 	urlTransform,
@@ -141,10 +166,8 @@ export const LiveStreamTail = ({
 		store,
 		selectSubagentStatusOverrides,
 	);
-	const streamTools = buildStreamTools(
-		streamState?.toolCalls,
-		streamState?.toolResults,
-	);
+	const [latchedStreamState, setLatchedStreamState] =
+		useState<LatchedStreamState | null>(null);
 	const liveStatus = deriveLiveStatus({
 		streamState,
 		retryState,
@@ -154,12 +177,47 @@ export const LiveStreamTail = ({
 		isAwaitingFirstStreamChunk,
 	});
 
+	useEffect(() => {
+		if (hasRenderableStreamState(streamState) && streamState) {
+			const nextStreamState = streamState;
+			setLatchedStreamState((current) => {
+				if (
+					current?.contextKey === tailContextKey &&
+					current.streamState === nextStreamState
+				) {
+					return current;
+				}
+				return { contextKey: tailContextKey, streamState: nextStreamState };
+			});
+			return;
+		}
+		if (latchedStreamState?.contextKey !== tailContextKey) {
+			setLatchedStreamState(null);
+		}
+	}, [latchedStreamState, streamState, tailContextKey]);
+
+	const effectiveStreamState =
+		streamState ??
+		(latchedStreamState?.contextKey === tailContextKey
+			? latchedStreamState.streamState
+			: null);
+	const streamTools = buildStreamTools(
+		effectiveStreamState?.toolCalls,
+		effectiveStreamState?.toolResults,
+	);
+	const effectiveLiveStatus =
+		effectiveStreamState && liveStatus.phase === "starting"
+			? { phase: "streaming" as const, hasAccumulatedOutput: true }
+			: effectiveStreamState && !liveStatus.hasAccumulatedOutput
+				? { ...liveStatus, hasAccumulatedOutput: true }
+				: liveStatus;
+
 	return (
 		<LiveStreamTailContent
 			isTranscriptEmpty={isTranscriptEmpty}
-			streamState={streamState}
+			streamState={effectiveStreamState}
 			streamTools={streamTools}
-			liveStatus={liveStatus}
+			liveStatus={effectiveLiveStatus}
 			startingResetKey={startingResetKey}
 			subagentTitles={subagentTitles}
 			subagentVariants={subagentVariants}

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/SubagentTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/SubagentTool.tsx
@@ -221,6 +221,7 @@ export const SubagentTool: React.FC<{
 					{chatId && (
 						<Link
 							to={`/agents/${chatId}`}
+							preventScrollReset
 							onClick={(e) => e.stopPropagation()}
 							className="ml-1 inline-flex align-middle text-content-secondary opacity-50 transition-opacity hover:opacity-100"
 							aria-label="View agent"

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/WorkspaceBuildLogSection.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/WorkspaceBuildLogSection.tsx
@@ -1,5 +1,5 @@
 import { LoaderIcon, TriangleAlertIcon } from "lucide-react";
-import { type FC, useEffect, useState } from "react";
+import { type FC, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useQuery } from "react-query";
 import { workspaceBuildLogs } from "#/api/queries/workspaceBuilds";
 import { workspaceById } from "#/api/queries/workspaces";
@@ -37,6 +37,7 @@ export const WorkspaceBuildLogSection: FC<WorkspaceBuildLogSectionProps> = ({
 	buildId,
 }) => {
 	const isRunning = status === "running";
+	const logsScrollAreaRef = useRef<HTMLDivElement>(null);
 
 	// Primary source: build ID from the chat binding, pushed via
 	// pubsub when create_workspace or start_workspace persists it.
@@ -104,6 +105,19 @@ export const WorkspaceBuildLogSection: FC<WorkspaceBuildLogSectionProps> = ({
 
 	const fetchFailed = !isRunning && completedLogsQuery.isError;
 
+	useLayoutEffect(() => {
+		if (!logs || logs.length === 0) {
+			return;
+		}
+		const viewport = logsScrollAreaRef.current?.querySelector<HTMLElement>(
+			"[data-radix-scroll-area-viewport]",
+		);
+		if (!viewport) {
+			return;
+		}
+		viewport.scrollTop = viewport.scrollHeight;
+	}, [logs]);
+
 	if (!effectiveBuildId) {
 		if (isRunning && workspaceId) {
 			return (
@@ -157,16 +171,19 @@ export const WorkspaceBuildLogSection: FC<WorkspaceBuildLogSectionProps> = ({
 	}
 
 	return (
-		<ScrollArea
-			className="mt-1.5 rounded-md border border-solid border-border-default text-2xs"
-			viewportClassName="max-h-64"
-			scrollBarClassName="w-1.5"
-		>
-			<WorkspaceBuildLogs
-				logs={logs}
-				sticky
-				className="border-0 rounded-none"
-			/>
-		</ScrollArea>
+		<div ref={logsScrollAreaRef} data-testid="workspace-build-logs-scroll-area">
+			<ScrollArea
+				className="mt-1.5 rounded-md border border-solid border-border-default text-2xs"
+				viewportClassName="max-h-64"
+				scrollBarClassName="w-1.5"
+			>
+				<WorkspaceBuildLogs
+					logs={logs}
+					sticky
+					disableAutoscroll
+					className="border-0 rounded-none"
+				/>
+			</ScrollArea>
+		</div>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -18,9 +18,13 @@ import { getLatestContextUsage } from "./ChatConversation/chatHelpers";
 import {
 	selectChatStatus,
 	selectHasStreamState,
+	selectIsAwaitingFirstStreamChunk,
 	selectMessagesByID,
 	selectOrderedMessageIDs,
 	selectQueuedMessages,
+	selectReconnectState,
+	selectRetryState,
+	selectStreamError,
 	useChatSelector,
 	type useChatStore,
 } from "./ChatConversation/chatStore";
@@ -71,7 +75,21 @@ export const ChatPageTimeline: FC<ChatPageTimelineProps> = ({
 	const orderedMessageIDs = useChatSelector(store, selectOrderedMessageIDs);
 	const chatStatus = useChatSelector(store, selectChatStatus);
 	const hasStream = useChatSelector(store, selectHasStreamState);
+	const isAwaitingFirstStreamChunk = useChatSelector(
+		store,
+		selectIsAwaitingFirstStreamChunk,
+	);
+	const retryState = useChatSelector(store, selectRetryState);
+	const reconnectState = useChatSelector(store, selectReconnectState);
+	const streamError = useChatSelector(store, selectStreamError);
 	const isChatCompleted = !hasStream && chatStatus !== "pending";
+	const hasLiveContentBelowLatestUser =
+		hasStream ||
+		isAwaitingFirstStreamChunk ||
+		retryState !== null ||
+		reconnectState !== null ||
+		streamError !== null ||
+		persistedError !== undefined;
 
 	const messages = orderedMessageIDs
 		.map((messageID) => {
@@ -89,6 +107,13 @@ export const ChatPageTimeline: FC<ChatPageTimelineProps> = ({
 	const parsedMessages = parseMessagesWithMergedTools(messages);
 	const { titles: subagentTitles, variants: subagentVariants } =
 		buildSubagentMaps(parsedMessages);
+	const latestDurableMessage =
+		orderedMessageIDs.length > 0
+			? messagesByID.get(orderedMessageIDs[orderedMessageIDs.length - 1])
+			: undefined;
+	const tailContextKey = latestDurableMessage
+		? `${latestDurableMessage.id}:${latestDurableMessage.role}`
+		: "empty";
 	const onRenderProfiler = useOnRenderProfiler();
 
 	return (
@@ -117,12 +142,14 @@ export const ChatPageTimeline: FC<ChatPageTimelineProps> = ({
 					urlTransform={urlTransform}
 					mcpServers={mcpServers}
 					showDesktopPreviews={false}
+					hasLiveContentBelowLatestUser={hasLiveContentBelowLatestUser}
 				/>
 				<LiveStreamTail
 					store={store}
 					persistedError={persistedError}
 					startingResetKey={chatID}
 					isTranscriptEmpty={parsedMessages.length === 0}
+					tailContextKey={tailContextKey}
 					subagentTitles={subagentTitles}
 					subagentVariants={subagentVariants}
 					urlTransform={urlTransform}

--- a/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
+++ b/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
@@ -134,10 +134,14 @@ function useChatViewportController({
 			cancelAnimationFrame(deferredPinFrameRef.current);
 			deferredPinFrameRef.current = null;
 		}
+	});
+
+	const cancelInitialFollowLock = useEffectEvent(() => {
 		if (initialFollowLockFrameRef.current !== null) {
 			cancelAnimationFrame(initialFollowLockFrameRef.current);
 			initialFollowLockFrameRef.current = null;
 		}
+		isInitialFollowLockRef.current = false;
 	});
 
 	const pinToLatest = useEffectEvent(() => {
@@ -248,10 +252,7 @@ function useChatViewportController({
 				cancelAnimationFrame(deferredPinFrameRef.current);
 				deferredPinFrameRef.current = null;
 			}
-			if (initialFollowLockFrameRef.current !== null) {
-				cancelAnimationFrame(initialFollowLockFrameRef.current);
-				initialFollowLockFrameRef.current = null;
-			}
+			cancelInitialFollowLock();
 		};
 	}, []);
 
@@ -326,6 +327,7 @@ function useChatViewportController({
 
 		const detachViewport = () => {
 			cancelDeferredPin();
+			cancelInitialFollowLock();
 			isProgrammaticScrollRef.current = false;
 			if (modeRef.current !== "detached") {
 				syncMode("detached");
@@ -442,10 +444,8 @@ function useChatViewportController({
 		if (modeRef.current === "following-latest") {
 			anchorRef.current = null;
 			isProgrammaticScrollRef.current = false;
+			cancelInitialFollowLock();
 			isInitialFollowLockRef.current = true;
-			if (initialFollowLockFrameRef.current !== null) {
-				cancelAnimationFrame(initialFollowLockFrameRef.current);
-			}
 			initialFollowLockFrameRef.current = requestAnimationFrame(() => {
 				initialFollowLockFrameRef.current = requestAnimationFrame(() => {
 					initialFollowLockFrameRef.current = null;

--- a/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
+++ b/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
@@ -18,7 +18,6 @@ import {
 	FOLLOW_THRESHOLD_PX,
 	findNearestScrollableAncestor,
 	getBottomGap,
-	getScrollMode,
 	resolveAnchorTarget,
 	restoreAnchorScrollTop,
 	type ScrollMode,
@@ -93,6 +92,7 @@ function useChatViewportController({
 	const initialFollowLockFrameRef = useRef<number | null>(null);
 	const isRestoringRef = useRef(false);
 	const isInitialFollowLockRef = useRef(true);
+	const isAwaitingDetachedAnchorRef = useRef(false);
 	const isPointerDownRef = useRef(false);
 	const isTouchActiveRef = useRef(false);
 	const activeTouchCountRef = useRef(0);
@@ -144,6 +144,22 @@ function useChatViewportController({
 		isInitialFollowLockRef.current = false;
 	});
 
+	const armInitialFollowLock = useEffectEvent((frames = 2) => {
+		cancelInitialFollowLock();
+		isInitialFollowLockRef.current = true;
+		const step = (remainingFrames: number) => {
+			initialFollowLockFrameRef.current = requestAnimationFrame(() => {
+				if (remainingFrames <= 1) {
+					initialFollowLockFrameRef.current = null;
+					isInitialFollowLockRef.current = false;
+					return;
+				}
+				step(remainingFrames - 1);
+			});
+		};
+		step(frames);
+	});
+
 	const pinToLatest = useEffectEvent(() => {
 		const container = scrollElementRef.current;
 		if (!container) {
@@ -180,7 +196,9 @@ function useChatViewportController({
 				return;
 			}
 			anchorRef.current = null;
+			isAwaitingDetachedAnchorRef.current = false;
 			syncMode("following-latest");
+			armInitialFollowLock();
 			if (behavior === "instant") {
 				isProgrammaticScrollRef.current = false;
 				scheduleDeferredPinToLatest(DEFERRED_PIN_FRAME_COUNT);
@@ -237,10 +255,16 @@ function useChatViewportController({
 			}
 			anchorRef.current = null;
 			isProgrammaticScrollRef.current = false;
+			isAwaitingDetachedAnchorRef.current = false;
 			pinToLatest();
 			return;
 		}
-		if (isInitialFollowLockRef.current) {
+		if (
+			isInitialFollowLockRef.current ||
+			isAwaitingDetachedAnchorRef.current ||
+			isPointerDownRef.current ||
+			isTouchActiveRef.current
+		) {
 			return;
 		}
 		restoreAnchor();
@@ -304,10 +328,13 @@ function useChatViewportController({
 			const movingDown = currentScrollTop > previousScrollTop;
 			const nextMode =
 				modeRef.current === "following-latest"
-					? getScrollMode(bottomGap, FOLLOW_THRESHOLD_PX)
+					? "following-latest"
 					: bottomGap <= 1 || (movingDown && bottomGap <= FOLLOW_THRESHOLD_PX)
 						? "following-latest"
 						: "detached";
+			// Detached mode now reflects explicit user intent. While we are already
+			// following the live tail, passive layout growth must not infer a detach
+			// transition just because the bottom gap briefly changes mid-stream.
 			if (isInitialFollowLockRef.current && nextMode === "detached") {
 				return;
 			}
@@ -316,8 +343,10 @@ function useChatViewportController({
 			}
 			if (nextMode === "detached") {
 				anchorRef.current = findAnchorSnapshot(scrollElement, contentElement);
+				isAwaitingDetachedAnchorRef.current = false;
 			} else {
 				anchorRef.current = null;
+				isAwaitingDetachedAnchorRef.current = false;
 			}
 		};
 
@@ -329,10 +358,11 @@ function useChatViewportController({
 			cancelDeferredPin();
 			cancelInitialFollowLock();
 			isProgrammaticScrollRef.current = false;
+			isAwaitingDetachedAnchorRef.current = true;
 			if (modeRef.current !== "detached") {
 				syncMode("detached");
 			}
-			anchorRef.current = findAnchorSnapshot(scrollElement, contentElement);
+			anchorRef.current = null;
 		};
 
 		const handleWheel = (event: WheelEvent) => {
@@ -444,14 +474,7 @@ function useChatViewportController({
 		if (modeRef.current === "following-latest") {
 			anchorRef.current = null;
 			isProgrammaticScrollRef.current = false;
-			cancelInitialFollowLock();
-			isInitialFollowLockRef.current = true;
-			initialFollowLockFrameRef.current = requestAnimationFrame(() => {
-				initialFollowLockFrameRef.current = requestAnimationFrame(() => {
-					initialFollowLockFrameRef.current = null;
-					isInitialFollowLockRef.current = false;
-				});
-			});
+			armInitialFollowLock();
 			scheduleDeferredPinToLatest(DEFERRED_PIN_FRAME_COUNT);
 		}
 
@@ -482,6 +505,7 @@ function useChatViewportController({
 				}
 				anchorRef.current = null;
 				isProgrammaticScrollRef.current = false;
+				armInitialFollowLock();
 				scheduleDeferredPinToLatest(DEFERRED_PIN_FRAME_COUNT);
 				return;
 			}

--- a/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
+++ b/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
@@ -134,6 +134,15 @@ function useChatViewportController({
 		}
 	});
 
+	const pinToLatest = useEffectEvent(() => {
+		const container = scrollElementRef.current;
+		if (!container) {
+			return;
+		}
+		container.scrollTop = container.scrollHeight;
+		previousScrollTopRef.current = container.scrollTop;
+	});
+
 	const scheduleDeferredPinToLatest = useEffectEvent((frames: number) => {
 		cancelDeferredPin();
 		const step = (remainingFrames: number) => {
@@ -142,8 +151,7 @@ function useChatViewportController({
 				deferredPinFrameRef.current = null;
 				return;
 			}
-			container.scrollTop = container.scrollHeight;
-			previousScrollTopRef.current = container.scrollTop;
+			pinToLatest();
 			if (remainingFrames <= 0) {
 				deferredPinFrameRef.current = null;
 				return;
@@ -210,6 +218,19 @@ function useChatViewportController({
 		requestAnimationFrame(() => {
 			isRestoringRef.current = false;
 		});
+	});
+
+	const syncViewportToCurrentMode = useEffectEvent(() => {
+		if (modeRef.current === "following-latest") {
+			if (isPointerDownRef.current || isTouchActiveRef.current) {
+				return;
+			}
+			anchorRef.current = null;
+			isProgrammaticScrollRef.current = false;
+			pinToLatest();
+			return;
+		}
+		restoreAnchor();
 	});
 
 	useEffect(() => {
@@ -386,6 +407,20 @@ function useChatViewportController({
 			return;
 		}
 
+		// WebKit can paint one frame of stale scroll geometry after transcript
+		// commits or parent layout shifts before ResizeObserver delivers. Apply
+		// the current scroll policy during layout so pinned and detached views do
+		// not visibly jump between React-driven commits.
+		syncViewportToCurrentMode();
+	});
+
+	useLayoutEffect(() => {
+		const scrollElement = scrollElementRef.current;
+		const contentElement = contentElementRef.current;
+		if (!scrollElement || !contentElement) {
+			return;
+		}
+
 		previousContentHeightRef.current =
 			contentElement.getBoundingClientRect().height;
 		if (modeRef.current === "following-latest") {
@@ -393,6 +428,20 @@ function useChatViewportController({
 			isProgrammaticScrollRef.current = false;
 			scheduleDeferredPinToLatest(DEFERRED_PIN_FRAME_COUNT);
 		}
+
+		const mutationObserver = new MutationObserver(() => {
+			// Reading the content box here forces WebKit to resolve layout before
+			// we decide whether to pin or restore, which avoids a one-frame gap
+			// after transcript mutations.
+			previousContentHeightRef.current =
+				contentElement.getBoundingClientRect().height;
+			syncViewportToCurrentMode();
+		});
+		mutationObserver.observe(contentElement, {
+			childList: true,
+			subtree: true,
+			characterData: true,
+		});
 
 		const resizeObserver = new ResizeObserver(() => {
 			const nextHeight = contentElement.getBoundingClientRect().height;
@@ -414,7 +463,10 @@ function useChatViewportController({
 		});
 		resizeObserver.observe(contentElement);
 		resizeObserver.observe(scrollElement);
-		return () => resizeObserver.disconnect();
+		return () => {
+			mutationObserver.disconnect();
+			resizeObserver.disconnect();
+		};
 	}, []);
 
 	useEffect(() => {

--- a/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
+++ b/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
@@ -2,7 +2,6 @@ import { ArrowDownIcon } from "lucide-react";
 import {
 	type FC,
 	type RefCallback,
-	type RefObject,
 	useEffect,
 	useEffectEvent,
 	useLayoutEffect,
@@ -11,440 +10,350 @@ import {
 } from "react";
 import { Button } from "#/components/Button/Button";
 import { cn } from "#/utils/cn";
+import {
+	type AnchorSnapshot,
+	CHAT_ANCHOR_SELECTOR,
+	CHAT_NON_ANCHOR_SELECTOR,
+	canElementScrollInDirection,
+	FOLLOW_THRESHOLD_PX,
+	findNearestScrollableAncestor,
+	getBottomGap,
+	getScrollMode,
+	resolveAnchorTarget,
+	restoreAnchorScrollTop,
+	type ScrollMode,
+} from "./chatViewportUtils";
 
-// ===========================================================================
-// useStickToBottom — scroll-lock hook
-// ===========================================================================
+const ANCHOR_SELECTOR = CHAT_ANCHOR_SELECTOR;
+const NON_ANCHOR_SELECTOR = CHAT_NON_ANCHOR_SELECTOR;
+const HISTORY_ROOT_MARGIN = "600px 0px 0px 0px";
+const DEFERRED_PIN_FRAME_COUNT = 8;
 
-/** Pixel threshold for "near bottom" detection. */
-const STICK_TO_BOTTOM_OFFSET_PX = 70;
-
-// ---------------------------------------------------------------------------
-// Mutable state (not tied to React render cycle)
-// ---------------------------------------------------------------------------
-
-interface InternalState {
-	scrollElement: HTMLElement | null;
-	contentElement: HTMLElement | null;
-	programmaticScrollCount: number;
-	resizeDifference: number;
-	lastScrollTop: number;
-	lastClientHeight: number;
-	escapedFromLock: boolean;
-	internalIsAtBottom: boolean;
-	resizeObserver: ResizeObserver | null;
-	viewportObserver: ResizeObserver | null;
-	previousContentHeight: number | undefined;
-	mouseDown: boolean;
-	suppressNextResize: boolean;
-	activeTouchCount: number;
-	pendingPrepend: { scrollHeight: number } | null;
-}
-
-/** The maximum scrollable offset for the container. */
-function maxScrollTop(s: InternalState): number {
-	if (!s.scrollElement) {
-		return 0;
-	}
-
-	return Math.max(
-		0,
-		s.scrollElement.scrollHeight - s.scrollElement.clientHeight,
-	);
-}
-
-/** Whether the scroll position is within the stick-to-bottom threshold. */
-function isNearBottom(s: InternalState): boolean {
-	if (!s.scrollElement) {
-		return false;
-	}
-
-	const distance = maxScrollTop(s) - s.scrollElement.scrollTop;
-
-	return distance <= STICK_TO_BOTTOM_OFFSET_PX;
-}
-
-/** Assign scrollTop and bump the programmatic-scroll counter so
- *  the next scroll event is not misread as a user-initiated scroll.
- *  Only bumps the counter when scrollTop actually changes, so no-op
- *  writes don't orphan a counter increment without a matching event. */
-function scrollTo(s: InternalState, value: number) {
-	if (!s.scrollElement) {
-		return;
-	}
-
-	const prev = s.scrollElement.scrollTop;
-	s.scrollElement.scrollTop = value;
-	if (s.scrollElement.scrollTop !== prev) {
-		s.programmaticScrollCount++;
-	}
-}
-
-// ---------------------------------------------------------------------------
-// Hook
-// ---------------------------------------------------------------------------
-
-interface StickToBottomInstance {
+interface ViewportController {
 	scrollRef: RefCallback<HTMLDivElement>;
 	contentRef: RefCallback<HTMLDivElement>;
-	/** Scroll to the bottom. Pass `"instant"` to jump; omit for smooth. */
+	topSentinelRef: RefCallback<HTMLDivElement>;
+	bottomSentinelRef: RefCallback<HTMLDivElement>;
 	scrollToBottom: (behavior?: ScrollBehavior) => void;
-	/** True when the view is locked to the bottom or physically near it. */
-	isAtBottom: boolean;
-	/** Tell the hook to skip the next content resize auto-pin. */
-	suppressNextResize: () => void;
-	/** Capture scrollHeight for prepend restoration. */
-	capturePrependSnapshot: () => void;
+	mode: ScrollMode;
 }
 
-function useStickToBottom(): StickToBottomInstance {
-	const [isAtBottom, setIsAtBottom] = useState(true);
-	const [nearBottom, setNearBottom] = useState(false);
+const isAnchorCandidate = (element: Element): element is HTMLElement => {
+	if (!(element instanceof HTMLElement)) {
+		return false;
+	}
+	if (element.closest(NON_ANCHOR_SELECTOR)) {
+		return false;
+	}
+	return element.dataset.chatAnchor === "true";
+};
 
-	const stateRef = useRef<InternalState>({
-		scrollElement: null,
-		contentElement: null,
-		programmaticScrollCount: 0,
-		resizeDifference: 0,
-		lastScrollTop: 0,
-		lastClientHeight: 0,
-		escapedFromLock: false,
-		internalIsAtBottom: true,
-		resizeObserver: null,
-		viewportObserver: null,
-		previousContentHeight: undefined,
-		mouseDown: false,
-		suppressNextResize: false,
-		activeTouchCount: 0,
-		pendingPrepend: null,
-	});
-
-	// Sync helpers — keep mutable state and React state in lockstep.
-	const syncIsAtBottom = (v: boolean) => {
-		stateRef.current.internalIsAtBottom = v;
-		setIsAtBottom(v);
-	};
-
-	const syncEscapedFromLock = (v: boolean) => {
-		stateRef.current.escapedFromLock = v;
-	};
-
-	// -----------------------------------------------------------------------
-	// scrollToBottom
-	// -----------------------------------------------------------------------
-
-	const scrollToBottom = (behavior?: ScrollBehavior) => {
-		const s = stateRef.current;
-		if (!s.scrollElement) return;
-
-		syncIsAtBottom(true);
-		syncEscapedFromLock(false);
-
-		const top = maxScrollTop(s);
-		if (behavior === "instant") {
-			scrollTo(s, top);
-		} else {
-			s.scrollElement.scrollTo({
-				top,
-				behavior: behavior ?? "smooth",
-			});
-			// Don't bump programmaticScrollCount for smooth scroll.
-			// Each animation frame naturally reads as a downward
-			// scroll (currentScrollTop > lastScrollTop), which
-			// correctly clears escapedFromLock.
+const findAnchorSnapshot = (
+	container: HTMLElement,
+	content: HTMLElement,
+): AnchorSnapshot | null => {
+	const containerTop = container.getBoundingClientRect().top;
+	const anchors = content.querySelectorAll(ANCHOR_SELECTOR);
+	for (const anchor of anchors) {
+		if (!isAnchorCandidate(anchor)) {
+			continue;
 		}
-	};
-
-	const suppressNextResize = () => {
-		stateRef.current.suppressNextResize = true;
-	};
-
-	const capturePrependSnapshot = () => {
-		const s = stateRef.current;
-		if (s.scrollElement) {
-			s.pendingPrepend = {
-				scrollHeight: s.scrollElement.scrollHeight,
+		const rect = anchor.getBoundingClientRect();
+		if (rect.bottom > containerTop + 1) {
+			return {
+				anchorId: anchor.dataset.chatAnchorId ?? "",
+				offsetTop: rect.top - containerTop,
 			};
 		}
-	};
+	}
+	return null;
+};
 
-	// -----------------------------------------------------------------------
-	// Event handlers
-	// -----------------------------------------------------------------------
+function useChatViewportController({
+	hasMoreMessages,
+	isFetchingMoreMessages,
+	onFetchMoreMessages,
+}: {
+	hasMoreMessages: boolean;
+	isFetchingMoreMessages: boolean;
+	onFetchMoreMessages: () => void;
+}): ViewportController {
+	const scrollElementRef = useRef<HTMLDivElement | null>(null);
+	const contentElementRef = useRef<HTMLDivElement | null>(null);
+	const topSentinelElementRef = useRef<HTMLDivElement | null>(null);
+	const bottomSentinelElementRef = useRef<HTMLDivElement | null>(null);
+	const [mode, setMode] = useState<ScrollMode>("following-latest");
 
-	const handleScroll = useEffectEvent((e: Event) => {
-		const s = stateRef.current;
-		const { scrollElement } = s;
-		if (e.target !== scrollElement || !scrollElement) return;
+	const modeRef = useRef<ScrollMode>("following-latest");
+	const anchorRef = useRef<AnchorSnapshot | null>(null);
+	const previousContentHeightRef = useRef<number | null>(null);
+	const previousScrollTopRef = useRef(0);
+	const isProgrammaticScrollRef = useRef(false);
+	const deferredPinFrameRef = useRef<number | null>(null);
+	const isRestoringRef = useRef(false);
+	const isPointerDownRef = useRef(false);
+	const isTouchActiveRef = useRef(false);
+	const activeTouchCountRef = useRef(0);
+	const isFetchingHistoryRef = useRef(false);
+	const topObserverRef = useRef<IntersectionObserver | null>(null);
 
-		const currentScrollTop = scrollElement.scrollTop;
-
-		// Detect viewport-size changes (e.g. Safari PWA toolbar
-		// settling, virtual keyboard, safe-area inset shifts).
-		// The browser may clamp scrollTop before the
-		// ResizeObserver fires, so this scroll event would look
-		// like an upward user scroll without this guard.
-		const currentClientHeight = scrollElement.clientHeight;
-		const viewportChanged = currentClientHeight !== s.lastClientHeight;
-		s.lastClientHeight = currentClientHeight;
-
-		// If this event was caused by a programmatic scrollTo,
-		// consume the counter and skip escape processing.
-		if (s.programmaticScrollCount > 0) {
-			s.programmaticScrollCount--;
-			s.lastScrollTop = currentScrollTop;
-			setNearBottom(isNearBottom(s));
+	const scrollRef: RefCallback<HTMLDivElement> = (element) => {
+		if (scrollElementRef.current === element) {
 			return;
 		}
-
-		const lastST = s.lastScrollTop;
-		s.lastScrollTop = currentScrollTop;
-
-		setNearBottom(isNearBottom(s));
-
-		// Synchronous escape logic — must run before any resize
-		// handler so they see up-to-date internalIsAtBottom.
-		// Skip when a content resize or viewport resize is in
-		// progress — the browser may fire scroll events during
-		// layout that aren’t user-initiated.
-		if (
-			s.resizeDifference === 0 &&
-			!viewportChanged &&
-			s.activeTouchCount === 0
-		) {
-			if (currentScrollTop < lastST) {
-				// If we believe we're at the bottom and the user
-				// hasn't escaped via wheel, touch, or scrollbar,
-				// this upward movement is browser-initiated (e.g.
-				// Safari scroll restoration, focus-driven scroll).
-				// Re-pin instead of escaping.
-				if (s.internalIsAtBottom && !s.escapedFromLock) {
-					scrollTo(s, maxScrollTop(s));
-				} else {
-					syncEscapedFromLock(true);
-					syncIsAtBottom(false);
-				}
-			} else if (currentScrollTop > lastST) {
-				syncEscapedFromLock(false);
-			}
-
-			if (!s.escapedFromLock && isNearBottom(s)) {
-				syncIsAtBottom(true);
-			}
+		scrollElementRef.current = element;
+	};
+	const contentRef: RefCallback<HTMLDivElement> = (element) => {
+		if (contentElementRef.current === element) {
+			return;
 		}
-		// Text-selection escape deferred — getSelection() needs
-		// post-layout DOM state to reflect the current drag.
-		setTimeout(() => {
-			if (s.resizeDifference !== 0) return;
-			if (s.mouseDown && s.scrollElement) {
-				const sel = window.getSelection();
-				if (sel && sel.rangeCount > 0) {
-					const ancestor = sel.getRangeAt(0).commonAncestorContainer;
-					const el =
-						ancestor instanceof HTMLElement ? ancestor : ancestor.parentElement;
-					if (
-						el &&
-						(s.scrollElement.contains(el) || el.contains(s.scrollElement))
-					) {
-						syncEscapedFromLock(true);
-						syncIsAtBottom(false);
-					}
-				}
-			}
-		}, 1);
+		contentElementRef.current = element;
+	};
+	const topSentinelRef: RefCallback<HTMLDivElement> = (element) => {
+		if (topSentinelElementRef.current === element) {
+			return;
+		}
+		topSentinelElementRef.current = element;
+	};
+	const bottomSentinelRef: RefCallback<HTMLDivElement> = (element) => {
+		if (bottomSentinelElementRef.current === element) {
+			return;
+		}
+		bottomSentinelElementRef.current = element;
+	};
+
+	const syncMode = useEffectEvent((nextMode: ScrollMode) => {
+		modeRef.current = nextMode;
+		setMode(nextMode);
 	});
 
-	const handleWheel = useEffectEvent((e: WheelEvent) => {
-		const s = stateRef.current;
-
-		// Walk up from target to find the nearest scrollable ancestor.
-		let el = e.target as HTMLElement | null;
-		while (el && el !== s.scrollElement) {
-			if (el.scrollHeight > el.clientHeight) {
-				const style = getComputedStyle(el);
-				if (
-					style.overflow === "scroll" ||
-					style.overflow === "auto" ||
-					style.overflowY === "scroll" ||
-					style.overflowY === "auto"
-				) {
-					break;
-				}
-			}
-			el = el.parentElement;
+	const cancelDeferredPin = useEffectEvent(() => {
+		if (deferredPinFrameRef.current !== null) {
+			cancelAnimationFrame(deferredPinFrameRef.current);
+			deferredPinFrameRef.current = null;
 		}
+	});
 
-		if (
-			el === s.scrollElement &&
-			e.deltaY < 0 &&
-			s.scrollElement &&
-			s.scrollElement.scrollHeight > s.scrollElement.clientHeight
-		) {
-			syncEscapedFromLock(true);
-			syncIsAtBottom(false);
-			// Cancel any in-progress smooth scroll so the animation
-			// doesn't override the user's escape intent.
-			s.scrollElement.scrollTo({
-				top: s.scrollElement.scrollTop,
-				behavior: "instant",
+	const scheduleDeferredPinToLatest = useEffectEvent((frames: number) => {
+		cancelDeferredPin();
+		const step = (remainingFrames: number) => {
+			const container = scrollElementRef.current;
+			if (!container || modeRef.current !== "following-latest") {
+				deferredPinFrameRef.current = null;
+				return;
+			}
+			container.scrollTop = container.scrollHeight;
+			previousScrollTopRef.current = container.scrollTop;
+			if (remainingFrames <= 0) {
+				deferredPinFrameRef.current = null;
+				return;
+			}
+			deferredPinFrameRef.current = requestAnimationFrame(() => {
+				step(remainingFrames - 1);
 			});
-		}
+		};
+		step(frames);
 	});
 
-	const handleContentResize = useEffectEvent(() => {
-		const s = stateRef.current;
-		if (!s.contentElement || !s.scrollElement) return;
-
-		const currentHeight = s.contentElement.getBoundingClientRect().height;
-		const previousHeight = s.previousContentHeight;
-		const difference =
-			previousHeight !== undefined ? currentHeight - previousHeight : 0;
-
-		s.resizeDifference = difference;
-
-		// Clamp browser overscroll.
-		const target = maxScrollTop(s);
-		if (s.scrollElement.scrollTop > target) {
-			scrollTo(s, target);
-		}
-
-		setNearBottom(isNearBottom(s));
-
-		// Skip auto-pin while touch contacts are active to
-		// prevent mobile URL bar resizes from fighting the
-		// user's finger.
-		if (s.activeTouchCount > 0) {
-			// No auto-pin during active touch.
-		} else if (s.pendingPrepend) {
-			// Prepend restoration: older messages were just added
-			// to the DOM. Adjust scrollTop by the height delta so
-			// the user's visual position stays the same.
-			const delta =
-				s.scrollElement.scrollHeight - s.pendingPrepend.scrollHeight;
-			if (delta > 0) {
-				const prev = s.scrollElement.scrollTop;
-				s.scrollElement.scrollTop = prev + delta;
-				if (s.scrollElement.scrollTop !== prev) {
-					s.programmaticScrollCount++;
-				}
+	const scrollToBottom = useEffectEvent(
+		(behavior: ScrollBehavior = "smooth") => {
+			const container = scrollElementRef.current;
+			if (!container) {
+				return;
 			}
-			s.pendingPrepend = null;
-		} else if (s.suppressNextResize) {
-			s.suppressNextResize = false;
-		} else if (difference >= 0) {
-			if (previousHeight === undefined) {
-				// First observation — jump to bottom instantly.
-				if (s.internalIsAtBottom) {
-					scrollTo(s, target);
-				}
-			} else {
-				// Check whether we were near the OLD bottom before
-				// this resize. We can't rely on internalIsAtBottom
-				// alone because scroll events fire during browser
-				// layout (before this ResizeObserver callback), and
-				// the handler may have disengaged the lock when it
-				// saw the scroll position was far from the new,
-				// taller bottom.
-				const prevMaxScroll = Math.max(
-					0,
-					previousHeight - s.scrollElement.clientHeight,
-				);
-				const wasAtBottom =
-					s.internalIsAtBottom ||
-					(!s.escapedFromLock &&
-						s.scrollElement.scrollTop >=
-							prevMaxScroll - STICK_TO_BOTTOM_OFFSET_PX);
-
-				if (wasAtBottom) {
-					scrollTo(s, target);
-					syncIsAtBottom(true);
-					syncEscapedFromLock(false);
-				}
+			anchorRef.current = null;
+			syncMode("following-latest");
+			if (behavior === "instant") {
+				isProgrammaticScrollRef.current = false;
+				scheduleDeferredPinToLatest(DEFERRED_PIN_FRAME_COUNT);
+				return;
 			}
-		} else if (isNearBottom(s)) {
-			// Content shrank and we ended up near bottom — re-engage.
-			syncEscapedFromLock(false);
-			syncIsAtBottom(true);
+			cancelDeferredPin();
+			isProgrammaticScrollRef.current = true;
+			container.scrollTo({ top: container.scrollHeight, behavior });
+		},
+	);
+
+	const restoreAnchor = useEffectEvent(() => {
+		const scrollElement = scrollElementRef.current;
+		const contentElement = contentElementRef.current;
+		if (!scrollElement || !contentElement) {
+			return;
 		}
-
-		s.previousContentHeight = currentHeight;
-
-		// Clear after rAF + setTimeout(1) so the scroll handler has
-		// a chance to see the resize flag before it resets.
-		const captured = s.resizeDifference;
+		const snapshot = anchorRef.current;
+		if (!snapshot?.anchorId) {
+			return;
+		}
+		const resolvedTarget = resolveAnchorTarget({
+			content: contentElement,
+			anchorId: snapshot.anchorId,
+		});
+		if (!resolvedTarget) {
+			return;
+		}
+		const { anchorId, element: anchor } = resolvedTarget;
+		if (anchorId !== snapshot.anchorId) {
+			anchorRef.current = { ...snapshot, anchorId };
+		}
+		const containerTop = scrollElement.getBoundingClientRect().top;
+		const nextScrollTop = restoreAnchorScrollTop({
+			currentScrollTop: scrollElement.scrollTop,
+			currentAnchorTop: anchor.getBoundingClientRect().top - containerTop,
+			targetOffsetTop: snapshot.offsetTop,
+		});
+		if (Math.abs(nextScrollTop - scrollElement.scrollTop) <= 1) {
+			return;
+		}
+		isRestoringRef.current = true;
+		scrollElement.scrollTop = nextScrollTop;
+		previousScrollTopRef.current = scrollElement.scrollTop;
 		requestAnimationFrame(() => {
-			setTimeout(() => {
-				if (s.resizeDifference === captured) {
-					s.resizeDifference = 0;
-				}
-			}, 1);
+			isRestoringRef.current = false;
 		});
 	});
 
-	// When the scroll container's viewport dimensions change (e.g.
-	// the top bar gains elements after async data loads), maxScrollTop
-	// shifts and we may no longer be at the bottom. Re-pin if locked
-	// or physically near the bottom. The near-bottom fallback handles
-	// the case where the browser clamped scrollTop before this
-	// observer fired, causing the synchronous escape logic in
-	// handleScroll to disengage the lock.
-	const handleViewportResize = useEffectEvent(() => {
-		const s = stateRef.current;
-		if (!s.scrollElement) return;
-		const maxST = maxScrollTop(s);
-		const near = isNearBottom(s);
-		if (s.activeTouchCount > 0 || (!s.internalIsAtBottom && !near)) {
+	useEffect(() => {
+		return () => {
+			if (deferredPinFrameRef.current !== null) {
+				cancelAnimationFrame(deferredPinFrameRef.current);
+				deferredPinFrameRef.current = null;
+			}
+		};
+	}, []);
+
+	useEffect(() => {
+		isFetchingHistoryRef.current = isFetchingMoreMessages;
+	}, [isFetchingMoreMessages]);
+
+	useEffect(() => {
+		const scrollElement = scrollElementRef.current;
+		const contentElement = contentElementRef.current;
+		if (!scrollElement || !contentElement) {
 			return;
 		}
 
-		scrollTo(s, maxST);
-		syncIsAtBottom(true);
-		syncEscapedFromLock(false);
-	});
+		const updateModeFromGeometry = () => {
+			if (isRestoringRef.current) {
+				return;
+			}
+			const bottomGap = getBottomGap({
+				scrollHeight: scrollElement.scrollHeight,
+				clientHeight: scrollElement.clientHeight,
+				scrollTop: scrollElement.scrollTop,
+			});
+			const previousScrollTop = previousScrollTopRef.current;
+			const currentScrollTop = scrollElement.scrollTop;
+			previousScrollTopRef.current = currentScrollTop;
 
-	const handleTouchStart = useEffectEvent((e: TouchEvent) => {
-		stateRef.current.activeTouchCount += Math.max(e.changedTouches.length, 1);
-		syncEscapedFromLock(true);
-		syncIsAtBottom(false);
-	});
+			if (isProgrammaticScrollRef.current) {
+				if (bottomGap <= 1) {
+					isProgrammaticScrollRef.current = false;
+				} else {
+					if (modeRef.current !== "following-latest") {
+						syncMode("following-latest");
+					}
+					anchorRef.current = null;
+					return;
+				}
+			}
 
-	const handleTouchEnd = useEffectEvent((e: TouchEvent) => {
-		const s = stateRef.current;
-		s.activeTouchCount = Math.max(
-			0,
-			s.activeTouchCount - Math.max(e.changedTouches.length, 1),
-		);
-	});
+			if (
+				isTouchActiveRef.current &&
+				modeRef.current === "following-latest" &&
+				currentScrollTop < previousScrollTop
+			) {
+				detachViewport();
+				return;
+			}
 
-	// -----------------------------------------------------------------------
-	// Ref callbacks
-	// -----------------------------------------------------------------------
+			const movingDown = currentScrollTop > previousScrollTop;
+			const nextMode =
+				modeRef.current === "following-latest"
+					? getScrollMode(bottomGap, FOLLOW_THRESHOLD_PX)
+					: bottomGap <= 1 || (movingDown && bottomGap <= FOLLOW_THRESHOLD_PX)
+						? "following-latest"
+						: "detached";
+			if (nextMode !== modeRef.current) {
+				syncMode(nextMode);
+			}
+			if (nextMode === "detached") {
+				anchorRef.current = findAnchorSnapshot(scrollElement, contentElement);
+			} else {
+				anchorRef.current = null;
+			}
+		};
 
-	const handlePointerDown = useEffectEvent((e: PointerEvent) => {
-		const s = stateRef.current;
-		// e.target === s.scrollElement is only true when clicking
-		// the scrollbar track/thumb, not content inside the container.
-		if (e.target === s.scrollElement) {
-			syncEscapedFromLock(true);
-			syncIsAtBottom(false);
-		}
-	});
+		const handleScroll = () => {
+			requestAnimationFrame(updateModeFromGeometry);
+		};
 
-	// Ref callbacks must have stable identity — React cycles them
-	// on identity change, which leaks event listeners. Store the
-	// element in state and let a useEffect manage listeners.
-	const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(
-		null,
-	);
+		const detachViewport = () => {
+			cancelDeferredPin();
+			isProgrammaticScrollRef.current = false;
+			if (modeRef.current !== "detached") {
+				syncMode("detached");
+			}
+			anchorRef.current = findAnchorSnapshot(scrollElement, contentElement);
+		};
 
-	useEffect(() => {
-		const s = stateRef.current;
-		s.scrollElement = scrollElement;
-		if (!scrollElement) return;
+		const handleWheel = (event: WheelEvent) => {
+			const nestedScroller = findNearestScrollableAncestor(
+				event.target,
+				scrollElement,
+			);
+			if (
+				nestedScroller &&
+				nestedScroller !== scrollElement &&
+				canElementScrollInDirection(nestedScroller, event.deltaY)
+			) {
+				return;
+			}
+			if (
+				event.deltaY < 0 ||
+				isPointerDownRef.current ||
+				isTouchActiveRef.current
+			) {
+				detachViewport();
+			}
+		};
 
-		s.lastClientHeight = scrollElement.clientHeight;
+		const handlePointerDown = (event: PointerEvent) => {
+			isPointerDownRef.current = event.target === scrollElement;
+			if (isPointerDownRef.current) {
+				detachViewport();
+			}
+		};
+
+		const handlePointerUp = () => {
+			isPointerDownRef.current = false;
+		};
+
+		const handleTouchStart = (event: TouchEvent) => {
+			cancelDeferredPin();
+			activeTouchCountRef.current += Math.max(1, event.changedTouches.length);
+			isTouchActiveRef.current = true;
+		};
+
+		const handleTouchEnd = (event: TouchEvent) => {
+			activeTouchCountRef.current = Math.max(
+				0,
+				activeTouchCountRef.current - Math.max(1, event.changedTouches.length),
+			);
+			isTouchActiveRef.current = activeTouchCountRef.current > 0;
+		};
+
+		const handleVisibilityChange = () => {
+			if (!document.hidden) {
+				return;
+			}
+			activeTouchCountRef.current = 0;
+			isTouchActiveRef.current = false;
+		};
+
 		scrollElement.addEventListener("scroll", handleScroll, { passive: true });
 		scrollElement.addEventListener("wheel", handleWheel, { passive: true });
+		scrollElement.addEventListener("pointerdown", handlePointerDown);
+		window.addEventListener("pointerup", handlePointerUp);
 		scrollElement.addEventListener("touchstart", handleTouchStart, {
 			passive: true,
 		});
@@ -454,133 +363,154 @@ function useStickToBottom(): StickToBottomInstance {
 		scrollElement.addEventListener("touchcancel", handleTouchEnd, {
 			passive: true,
 		});
-		scrollElement.addEventListener("pointerdown", handlePointerDown);
+		document.addEventListener("visibilitychange", handleVisibilityChange);
 
-		const vo = new ResizeObserver(handleViewportResize);
-		vo.observe(scrollElement);
-		s.viewportObserver = vo;
+		updateModeFromGeometry();
 
 		return () => {
-			scrollElement.removeEventListener("touchstart", handleTouchStart);
-			scrollElement.removeEventListener("touchend", handleTouchEnd);
-			scrollElement.removeEventListener("touchcancel", handleTouchEnd);
 			scrollElement.removeEventListener("scroll", handleScroll);
 			scrollElement.removeEventListener("wheel", handleWheel);
 			scrollElement.removeEventListener("pointerdown", handlePointerDown);
-			if (s.viewportObserver) {
-				s.viewportObserver.disconnect();
-				s.viewportObserver = null;
-			}
-		};
-	}, [scrollElement]);
-
-	const [contentElement, setContentElement] = useState<HTMLDivElement | null>(
-		null,
-	);
-
-	useEffect(() => {
-		const s = stateRef.current;
-		s.contentElement = contentElement;
-		if (!contentElement) return;
-
-		const ro = new ResizeObserver(handleContentResize);
-		ro.observe(contentElement);
-		s.resizeObserver = ro;
-
-		return () => {
-			ro.disconnect();
-			s.resizeObserver = null;
-		};
-	}, [contentElement]);
-
-	// -----------------------------------------------------------------------
-	// Mouse tracking (instance-scoped)
-	// -----------------------------------------------------------------------
-
-	useEffect(() => {
-		const s = stateRef.current;
-		const onDown = () => {
-			s.mouseDown = true;
-		};
-		const onUp = () => {
-			s.mouseDown = false;
-		};
-		document.addEventListener("mousedown", onDown);
-		document.addEventListener("mouseup", onUp);
-		document.addEventListener("click", onUp);
-		return () => {
-			document.removeEventListener("mousedown", onDown);
-			document.removeEventListener("mouseup", onUp);
-			document.removeEventListener("click", onUp);
-		};
-	}, []);
-
-	// Reset touch counter on tab switch. The browser may not
-	// fire touchend/touchcancel when the user switches away
-	// mid-gesture, leaving the counter positive and blocking
-	// resize observer pins permanently.
-	useEffect(() => {
-		const s = stateRef.current;
-		const handleVisibilityChange = () => {
-			if (document.hidden) {
-				s.activeTouchCount = 0;
-			}
-		};
-		document.addEventListener("visibilitychange", handleVisibilityChange);
-		return () => {
+			window.removeEventListener("pointerup", handlePointerUp);
+			scrollElement.removeEventListener("touchstart", handleTouchStart);
+			scrollElement.removeEventListener("touchend", handleTouchEnd);
+			scrollElement.removeEventListener("touchcancel", handleTouchEnd);
 			document.removeEventListener("visibilitychange", handleVisibilityChange);
 		};
 	}, []);
 
-	// Post-render consistency check. If we believe we're pinned
-	// to the bottom but the physical scroll position disagrees,
-	// correct it before the browser paints. This catches any
-	// race between ResizeObserver callbacks, browser scroll
-	// clamping, and React re-renders (e.g. Safari PWA viewport
-	// settling after navigation).
-	// Intentionally no deps — runs every render as a safety net.
 	useLayoutEffect(() => {
-		const s = stateRef.current;
-		if (!s.scrollElement || !s.internalIsAtBottom) return;
-		const target = maxScrollTop(s);
-		// 1px tolerance for sub-pixel rounding.
-		if (target - s.scrollElement.scrollTop > 1) {
-			scrollTo(s, target);
+		const scrollElement = scrollElementRef.current;
+		const contentElement = contentElementRef.current;
+		if (!scrollElement || !contentElement) {
+			return;
 		}
-	});
+
+		previousContentHeightRef.current =
+			contentElement.getBoundingClientRect().height;
+		if (modeRef.current === "following-latest") {
+			anchorRef.current = null;
+			isProgrammaticScrollRef.current = false;
+			scheduleDeferredPinToLatest(DEFERRED_PIN_FRAME_COUNT);
+		}
+
+		const resizeObserver = new ResizeObserver(() => {
+			const nextHeight = contentElement.getBoundingClientRect().height;
+			const previousHeight = previousContentHeightRef.current;
+			previousContentHeightRef.current = nextHeight;
+			if (previousHeight === null) {
+				return;
+			}
+			if (modeRef.current === "following-latest") {
+				if (isPointerDownRef.current || isTouchActiveRef.current) {
+					return;
+				}
+				anchorRef.current = null;
+				isProgrammaticScrollRef.current = false;
+				scheduleDeferredPinToLatest(DEFERRED_PIN_FRAME_COUNT);
+				return;
+			}
+			restoreAnchor();
+		});
+		resizeObserver.observe(contentElement);
+		resizeObserver.observe(scrollElement);
+		return () => resizeObserver.disconnect();
+	}, []);
+
+	useEffect(() => {
+		const scrollElement = scrollElementRef.current;
+		const topSentinelElement = topSentinelElementRef.current;
+		const contentElement = contentElementRef.current;
+		if (!scrollElement || !topSentinelElement || !hasMoreMessages) {
+			return;
+		}
+		const observer = new IntersectionObserver(
+			([entry]) => {
+				const canFetchWithoutDetaching =
+					scrollElement.scrollHeight <= scrollElement.clientHeight + 1;
+				if (
+					!entry?.isIntersecting ||
+					isFetchingHistoryRef.current ||
+					(modeRef.current !== "detached" && !canFetchWithoutDetaching)
+				) {
+					return;
+				}
+				if (contentElement && modeRef.current === "detached") {
+					anchorRef.current = findAnchorSnapshot(scrollElement, contentElement);
+				}
+				onFetchMoreMessages();
+			},
+			{
+				root: scrollElement,
+				rootMargin: HISTORY_ROOT_MARGIN,
+				threshold: 0.01,
+			},
+		);
+		observer.observe(topSentinelElement);
+		topObserverRef.current = observer;
+		return () => {
+			observer.disconnect();
+			topObserverRef.current = null;
+		};
+	}, [hasMoreMessages, onFetchMoreMessages]);
+
+	useEffect(() => {
+		const observer = topObserverRef.current;
+		const topSentinelElement = topSentinelElementRef.current;
+		if (isFetchingMoreMessages || !observer || !topSentinelElement) {
+			return;
+		}
+		observer.unobserve(topSentinelElement);
+		observer.observe(topSentinelElement);
+	}, [isFetchingMoreMessages]);
+
+	useEffect(() => {
+		const observer = topObserverRef.current;
+		const topSentinelElement = topSentinelElementRef.current;
+		if (
+			mode !== "detached" ||
+			!observer ||
+			!topSentinelElement ||
+			isFetchingMoreMessages
+		) {
+			return;
+		}
+		observer.unobserve(topSentinelElement);
+		observer.observe(topSentinelElement);
+	}, [isFetchingMoreMessages, mode]);
+
+	useLayoutEffect(() => {
+		const scrollElement = scrollElementRef.current;
+		const bottomSentinelElement = bottomSentinelElementRef.current;
+		if (!scrollElement || !bottomSentinelElement) {
+			return;
+		}
+		if (modeRef.current !== "following-latest") {
+			return;
+		}
+		scheduleDeferredPinToLatest(DEFERRED_PIN_FRAME_COUNT);
+	}, []);
 
 	return {
-		scrollRef: setScrollElement,
-		contentRef: setContentElement,
+		scrollRef,
+		contentRef,
+		topSentinelRef,
+		bottomSentinelRef,
 		scrollToBottom,
-		isAtBottom: isAtBottom || nearBottom,
-		suppressNextResize,
-		capturePrependSnapshot,
+		mode,
 	};
 }
 
-// ===========================================================================
-// ChatScrollContainer — the scroll-anchored wrapper for the chat transcript
-// ===========================================================================
-
-/**
- * Scroll container that keeps the transcript pinned to the bottom using
- * ResizeObserver-driven scroll tracking. Handles:
- * - Stick-to-bottom with automatic re-engagement when content grows.
- * - Loading older message pages via an IntersectionObserver sentinel.
- * - Scroll position restoration when older messages are prepended.
- * - A floating "Scroll to bottom" button when the user scrolls away.
- */
 const ChatScrollContainer: FC<{
-	scrollContainerRef: RefObject<HTMLDivElement | null>;
-	scrollToBottomRef: RefObject<(() => void) | null>;
+	onScrollContainerChange?: (element: HTMLDivElement | null) => void;
+	onScrollToBottomChange?: (scrollToBottom: (() => void) | null) => void;
 	isFetchingMoreMessages: boolean;
 	hasMoreMessages: boolean;
 	onFetchMoreMessages: () => void;
 	children: React.ReactNode;
 }> = ({
-	scrollContainerRef,
-	scrollToBottomRef,
+	onScrollContainerChange,
+	onScrollToBottomChange,
 	isFetchingMoreMessages,
 	hasMoreMessages,
 	onFetchMoreMessages,
@@ -589,118 +519,43 @@ const ChatScrollContainer: FC<{
 	const {
 		scrollRef,
 		contentRef,
+		topSentinelRef,
+		bottomSentinelRef,
 		scrollToBottom,
-		isAtBottom,
-		capturePrependSnapshot,
-	} = useStickToBottom();
+		mode,
+	} = useChatViewportController({
+		hasMoreMessages,
+		isFetchingMoreMessages,
+		onFetchMoreMessages,
+	});
 
-	// Merge our callback ref with the external RefObject so both
-	// point at the same DOM node, and expose scrollToBottom to the
-	// parent via its imperative ref.
-	const mergedScrollRef = (el: HTMLDivElement | null) => {
-		scrollRef(el);
-		scrollContainerRef.current = el;
-		scrollToBottomRef.current = el ? () => scrollToBottom("instant") : null;
+	const handleScrollContainerRef: RefCallback<HTMLDivElement> = (element) => {
+		scrollRef(element);
+		onScrollContainerChange?.(element);
+		onScrollToBottomChange?.(element ? () => scrollToBottom("instant") : null);
 	};
 
-	// -------------------------------------------------------------------
-	// Pagination sentinel (IntersectionObserver)
-	// -------------------------------------------------------------------
-
-	const sentinelRef = useRef<HTMLDivElement>(null);
-	const observerRef = useRef<IntersectionObserver | null>(null);
-	const isFetchingRef = useRef(isFetchingMoreMessages);
-	const hasFetchedRef = useRef(false);
-
-	const wasFetchingRef = useRef(false);
-
-	useLayoutEffect(() => {
-		const wasFetching = wasFetchingRef.current;
-		isFetchingRef.current = isFetchingMoreMessages;
-		wasFetchingRef.current = isFetchingMoreMessages;
-
-		if (!wasFetching && isFetchingMoreMessages) {
-			hasFetchedRef.current = true;
-			capturePrependSnapshot();
-		}
-		// Restoration happens in handleContentResize (via
-		// pendingPrepend) when the DOM actually reflects the
-		// prepended content — not here, because the store
-		// update may lag behind isFetchingMoreMessages.
-	}, [isFetchingMoreMessages, capturePrependSnapshot]);
-
-	useEffect(() => {
-		const sentinel = sentinelRef.current;
-		const container = scrollContainerRef.current;
-		if (!sentinel || !container) return;
-
-		const observer = new IntersectionObserver(
-			([entry]) => {
-				if (entry.isIntersecting && !isFetchingRef.current) {
-					onFetchMoreMessages();
-				}
-			},
-			{
-				root: container,
-				rootMargin: "600px 0px 0px 0px",
-				threshold: 0.01,
-			},
-		);
-		observerRef.current = observer;
-
-		// Defer observation via double-rAF so the initial bottom
-		// pin settles before the sentinel can trigger.
-		let deferInnerId: number | null = null;
-		const deferOuterId = requestAnimationFrame(() => {
-			deferInnerId = requestAnimationFrame(() => {
-				observer.observe(sentinel);
-			});
-		});
-		return () => {
-			cancelAnimationFrame(deferOuterId);
-			if (deferInnerId !== null) {
-				cancelAnimationFrame(deferInnerId);
-			}
-			observer.disconnect();
-			observerRef.current = null;
-		};
-	}, [scrollContainerRef, onFetchMoreMessages]);
-
-	// Re-observe the sentinel after a fetch completes so the
-	// IntersectionObserver fires again if it stayed visible.
-	useEffect(() => {
-		if (isFetchingMoreMessages) return;
-		if (!hasFetchedRef.current) return;
-
-		const sentinel = sentinelRef.current;
-		const observer = observerRef.current;
-		if (sentinel && observer) {
-			observer.unobserve(sentinel);
-			observer.observe(sentinel);
-		}
-	}, [isFetchingMoreMessages]);
-
-	// -------------------------------------------------------------------
-	// Render
-	// -------------------------------------------------------------------
-
-	const showButton = !isAtBottom;
+	const showButton = mode === "detached";
 
 	return (
 		<div className="relative flex min-h-0 flex-1 flex-col">
 			<div
-				ref={mergedScrollRef}
+				ref={handleScrollContainerRef}
 				data-testid="scroll-container"
 				className="flex min-h-0 flex-1 flex-col overflow-y-auto [overflow-anchor:none] [overscroll-behavior:contain] [scrollbar-gutter:stable] [scrollbar-width:thin] [scrollbar-color:hsl(var(--surface-quaternary))_transparent]"
 			>
 				<div ref={contentRef}>
-					{hasMoreMessages && (
-						<div ref={sentinelRef} className="h-px shrink-0" />
-					)}
+					{hasMoreMessages ? (
+						<div ref={topSentinelRef} className="h-px shrink-0" />
+					) : null}
 					{children}
+					<div ref={bottomSentinelRef} className="h-px shrink-0" />
 				</div>
 			</div>
-			<div className="pointer-events-none absolute inset-x-0 bottom-2 z-10 flex justify-center overflow-y-auto py-2 [scrollbar-gutter:stable] [scrollbar-width:thin]">
+			<div
+				data-chat-anchor-ignore="true"
+				className="pointer-events-none absolute inset-x-0 bottom-2 z-10 flex justify-center overflow-y-auto py-2 [scrollbar-gutter:stable] [scrollbar-width:thin]"
+			>
 				<Button
 					variant="outline"
 					size="icon"

--- a/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
+++ b/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
@@ -90,7 +90,9 @@ function useChatViewportController({
 	const previousScrollTopRef = useRef(0);
 	const isProgrammaticScrollRef = useRef(false);
 	const deferredPinFrameRef = useRef<number | null>(null);
+	const initialFollowLockFrameRef = useRef<number | null>(null);
 	const isRestoringRef = useRef(false);
+	const isInitialFollowLockRef = useRef(true);
 	const isPointerDownRef = useRef(false);
 	const isTouchActiveRef = useRef(false);
 	const activeTouchCountRef = useRef(0);
@@ -131,6 +133,10 @@ function useChatViewportController({
 		if (deferredPinFrameRef.current !== null) {
 			cancelAnimationFrame(deferredPinFrameRef.current);
 			deferredPinFrameRef.current = null;
+		}
+		if (initialFollowLockFrameRef.current !== null) {
+			cancelAnimationFrame(initialFollowLockFrameRef.current);
+			initialFollowLockFrameRef.current = null;
 		}
 	});
 
@@ -230,6 +236,9 @@ function useChatViewportController({
 			pinToLatest();
 			return;
 		}
+		if (isInitialFollowLockRef.current) {
+			return;
+		}
 		restoreAnchor();
 	});
 
@@ -238,6 +247,10 @@ function useChatViewportController({
 			if (deferredPinFrameRef.current !== null) {
 				cancelAnimationFrame(deferredPinFrameRef.current);
 				deferredPinFrameRef.current = null;
+			}
+			if (initialFollowLockFrameRef.current !== null) {
+				cancelAnimationFrame(initialFollowLockFrameRef.current);
+				initialFollowLockFrameRef.current = null;
 			}
 		};
 	}, []);
@@ -294,6 +307,9 @@ function useChatViewportController({
 					: bottomGap <= 1 || (movingDown && bottomGap <= FOLLOW_THRESHOLD_PX)
 						? "following-latest"
 						: "detached";
+			if (isInitialFollowLockRef.current && nextMode === "detached") {
+				return;
+			}
 			if (nextMode !== modeRef.current) {
 				syncMode(nextMode);
 			}
@@ -426,6 +442,16 @@ function useChatViewportController({
 		if (modeRef.current === "following-latest") {
 			anchorRef.current = null;
 			isProgrammaticScrollRef.current = false;
+			isInitialFollowLockRef.current = true;
+			if (initialFollowLockFrameRef.current !== null) {
+				cancelAnimationFrame(initialFollowLockFrameRef.current);
+			}
+			initialFollowLockFrameRef.current = requestAnimationFrame(() => {
+				initialFollowLockFrameRef.current = requestAnimationFrame(() => {
+					initialFollowLockFrameRef.current = null;
+					isInitialFollowLockRef.current = false;
+				});
+			});
 			scheduleDeferredPinToLatest(DEFERRED_PIN_FRAME_COUNT);
 		}
 

--- a/site/src/pages/AgentsPage/components/ChatTopBar.tsx
+++ b/site/src/pages/AgentsPage/components/ChatTopBar.tsx
@@ -121,7 +121,7 @@ export const ChatTopBar: FC<ChatTopBarProps> = ({
 									variant="subtle"
 									className="h-auto max-w-[16rem] rounded-sm px-1 py-0.5 text-sm text-content-secondary shadow-none hover:bg-transparent hover:text-content-primary"
 								>
-									<Link to={`/agents/${parentChat.id}`}>
+									<Link to={`/agents/${parentChat.id}`} preventScrollReset>
 										<span className="truncate">{parentChat.title}</span>
 									</Link>
 								</Button>

--- a/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
@@ -611,6 +611,7 @@ const ChatTreeNode: FC<ChatTreeNodeProps> = ({ chat, isChildNode }) => {
 						</div>
 						<NavLink
 							to={`/agents/${chat.id}`}
+							preventScrollReset
 							className="flex min-h-0 min-w-0 flex-1 items-start gap-2 rounded-[inherit] py-1 pr-0.5 text-inherit no-underline"
 						>
 							{({ isActive }) => (

--- a/site/src/pages/AgentsPage/components/chatViewportUtils.test.ts
+++ b/site/src/pages/AgentsPage/components/chatViewportUtils.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import {
+	canElementScrollInDirection,
+	FOLLOW_THRESHOLD_PX,
+	findNearestScrollableAncestor,
+	getBottomGap,
+	getPinnedPreviewMetrics,
+	getScrollMode,
+	LIVE_STREAM_TAIL_ANCHOR_ID,
+	PINNED_PREVIEW_MIN_HEIGHT_PX,
+	resolveAnchorTarget,
+	restoreAnchorScrollTop,
+} from "./chatViewportUtils";
+
+describe("chatViewportUtils", () => {
+	it("enters following mode when bottom gap is within threshold", () => {
+		expect(getScrollMode(FOLLOW_THRESHOLD_PX, FOLLOW_THRESHOLD_PX)).toBe(
+			"following-latest",
+		);
+	});
+
+	it("exits following mode when bottom gap exceeds threshold", () => {
+		expect(getScrollMode(FOLLOW_THRESHOLD_PX + 1)).toBe("detached");
+	});
+
+	it("restores anchor position after prepend-like layout growth", () => {
+		expect(
+			restoreAnchorScrollTop({
+				currentScrollTop: 700,
+				currentAnchorTop: 210,
+				targetOffsetTop: 110,
+			}),
+		).toBe(800);
+	});
+
+	it("preserves anchor position when content shrinks", () => {
+		expect(
+			restoreAnchorScrollTop({
+				currentScrollTop: 800,
+				currentAnchorTop: 110,
+				targetOffsetTop: 210,
+			}),
+		).toBe(700);
+	});
+
+	it("translates a live stream tail snapshot to the latest durable anchor", () => {
+		const content = document.createElement("div");
+		const durableOne = document.createElement("div");
+		durableOne.dataset.chatAnchor = "true";
+		durableOne.dataset.chatAnchorId = "message-1";
+		const durableTwo = document.createElement("div");
+		durableTwo.dataset.chatAnchor = "true";
+		durableTwo.dataset.chatAnchorId = "message-2";
+		content.append(durableOne, durableTwo);
+
+		expect(
+			resolveAnchorTarget({
+				content,
+				anchorId: LIVE_STREAM_TAIL_ANCHOR_ID,
+			}),
+		).toEqual({ anchorId: "message-2", element: durableTwo });
+	});
+
+	it("prefers the exact anchor match when the live stream tail is still mounted", () => {
+		const content = document.createElement("div");
+		const durable = document.createElement("div");
+		durable.dataset.chatAnchor = "true";
+		durable.dataset.chatAnchorId = "message-2";
+		const liveTail = document.createElement("div");
+		liveTail.dataset.chatAnchor = "true";
+		liveTail.dataset.chatAnchorId = LIVE_STREAM_TAIL_ANCHOR_ID;
+		content.append(durable, liveTail);
+
+		expect(
+			resolveAnchorTarget({
+				content,
+				anchorId: LIVE_STREAM_TAIL_ANCHOR_ID,
+			}),
+		).toEqual({
+			anchorId: LIVE_STREAM_TAIL_ANCHOR_ID,
+			element: liveTail,
+		});
+	});
+
+	it("reports boundary scrolling for nested scrollers", () => {
+		expect(
+			canElementScrollInDirection(
+				{ scrollTop: 0, clientHeight: 100, scrollHeight: 400 },
+				-30,
+			),
+		).toBe(false);
+		expect(
+			canElementScrollInDirection(
+				{ scrollTop: 50, clientHeight: 100, scrollHeight: 400 },
+				-30,
+			),
+		).toBe(true);
+		expect(
+			canElementScrollInDirection(
+				{ scrollTop: 300, clientHeight: 100, scrollHeight: 400 },
+				40,
+			),
+		).toBe(false);
+	});
+
+	it("finds the nearest scrollable ancestor before the chat viewport", () => {
+		const container = document.createElement("div");
+		const scrollable = document.createElement("div");
+		const child = document.createElement("div");
+		container.appendChild(scrollable);
+		scrollable.appendChild(child);
+		document.body.appendChild(container);
+
+		Object.defineProperty(scrollable, "clientHeight", {
+			configurable: true,
+			value: 100,
+		});
+		Object.defineProperty(scrollable, "scrollHeight", {
+			configurable: true,
+			value: 300,
+		});
+		scrollable.style.overflowY = "auto";
+
+		expect(findNearestScrollableAncestor(child, container)).toBe(scrollable);
+
+		container.remove();
+	});
+
+	it("calculates the visible bottom gap", () => {
+		expect(
+			getBottomGap({ scrollHeight: 1500, clientHeight: 500, scrollTop: 950 }),
+		).toBe(50);
+	});
+
+	it("keeps pinned preview inactive until the user message leaves the viewport", () => {
+		expect(
+			getPinnedPreviewMetrics({
+				messageHeight: 160,
+				scrolledPast: 0,
+			}),
+		).toEqual({
+			active: false,
+			clipHeight: 160,
+			fadeOpacity: 0,
+			overlayOpacity: 0,
+		});
+	});
+
+	it("clamps pinned preview height and increases fade as it compresses", () => {
+		const metrics = getPinnedPreviewMetrics({
+			messageHeight: 220,
+			scrolledPast: 180,
+		});
+		expect(metrics.active).toBe(true);
+		expect(metrics.clipHeight).toBe(PINNED_PREVIEW_MIN_HEIGHT_PX);
+		expect(metrics.fadeOpacity).toBeGreaterThan(0);
+		expect(metrics.overlayOpacity).toBe(1);
+	});
+});

--- a/site/src/pages/AgentsPage/components/chatViewportUtils.ts
+++ b/site/src/pages/AgentsPage/components/chatViewportUtils.ts
@@ -1,0 +1,165 @@
+export const FOLLOW_THRESHOLD_PX = 100;
+export const PINNED_PREVIEW_MIN_HEIGHT_PX = 72;
+export const CHAT_ANCHOR_SELECTOR = "[data-chat-anchor='true']";
+export const CHAT_NON_ANCHOR_SELECTOR = "[data-chat-anchor-ignore='true']";
+export const LIVE_STREAM_TAIL_ANCHOR_ID = "live-stream-tail";
+
+export type ScrollMode = "following-latest" | "detached";
+
+export interface AnchorSnapshot {
+	anchorId: string;
+	offsetTop: number;
+}
+
+interface ResolvedAnchorTarget {
+	anchorId: string;
+	element: HTMLElement;
+}
+
+export const getBottomGap = ({
+	scrollHeight,
+	clientHeight,
+	scrollTop,
+}: {
+	scrollHeight: number;
+	clientHeight: number;
+	scrollTop: number;
+}): number => Math.max(0, scrollHeight - clientHeight - scrollTop);
+
+export const getScrollMode = (
+	bottomGap: number,
+	threshold = FOLLOW_THRESHOLD_PX,
+): ScrollMode => (bottomGap <= threshold ? "following-latest" : "detached");
+
+export const restoreAnchorScrollTop = ({
+	currentScrollTop,
+	currentAnchorTop,
+	targetOffsetTop,
+}: {
+	currentScrollTop: number;
+	currentAnchorTop: number;
+	targetOffsetTop: number;
+}): number =>
+	Math.max(0, currentScrollTop + (currentAnchorTop - targetOffsetTop));
+
+export const resolveAnchorTarget = ({
+	content,
+	anchorId,
+}: {
+	content: ParentNode;
+	anchorId: string;
+}): ResolvedAnchorTarget | null => {
+	const exactMatch = content.querySelector<HTMLElement>(
+		`[data-chat-anchor-id='${CSS.escape(anchorId)}']`,
+	);
+	if (exactMatch) {
+		return { anchorId, element: exactMatch };
+	}
+	if (anchorId !== LIVE_STREAM_TAIL_ANCHOR_ID) {
+		return null;
+	}
+
+	// When streamed output commits into a durable assistant message, the
+	// transient tail unmounts before detached anchor restoration runs. Falling
+	// back to the last remaining durable anchor preserves the reader's place at
+	// the tail boundary instead of silently losing the snapshot.
+	const durableAnchors = Array.from(
+		content.querySelectorAll<HTMLElement>(CHAT_ANCHOR_SELECTOR),
+	).filter((anchor) => {
+		if (anchor.closest(CHAT_NON_ANCHOR_SELECTOR)) {
+			return false;
+		}
+		const nextAnchorId = anchor.dataset.chatAnchorId;
+		return Boolean(nextAnchorId) && nextAnchorId !== LIVE_STREAM_TAIL_ANCHOR_ID;
+	});
+	const replacement = durableAnchors.at(-1);
+	if (!replacement?.dataset.chatAnchorId) {
+		return null;
+	}
+	return {
+		anchorId: replacement.dataset.chatAnchorId,
+		element: replacement,
+	};
+};
+
+export const canElementScrollInDirection = (
+	element: Pick<HTMLElement, "scrollTop" | "scrollHeight" | "clientHeight">,
+	deltaY: number,
+): boolean => {
+	if (deltaY < 0) {
+		return element.scrollTop > 0;
+	}
+	if (deltaY > 0) {
+		return element.scrollTop + element.clientHeight < element.scrollHeight - 1;
+	}
+	return false;
+};
+
+const isVerticallyScrollable = (element: HTMLElement): boolean => {
+	if (element.scrollHeight <= element.clientHeight + 1) {
+		return false;
+	}
+
+	const style = getComputedStyle(element);
+	return (
+		style.overflowY === "auto" ||
+		style.overflowY === "scroll" ||
+		style.overflow === "auto" ||
+		style.overflow === "scroll"
+	);
+};
+
+export const findNearestScrollableAncestor = (
+	target: EventTarget | null,
+	container: HTMLElement,
+): HTMLElement | null => {
+	let element = target instanceof HTMLElement ? target : null;
+	while (element && element !== container) {
+		if (isVerticallyScrollable(element)) {
+			return element;
+		}
+		element = element.parentElement;
+	}
+	return null;
+};
+
+interface PinnedPreviewMetrics {
+	active: boolean;
+	clipHeight: number;
+	fadeOpacity: number;
+	overlayOpacity: number;
+}
+
+export const getPinnedPreviewMetrics = ({
+	messageHeight,
+	scrolledPast,
+	minimumHeight = PINNED_PREVIEW_MIN_HEIGHT_PX,
+}: {
+	messageHeight: number;
+	scrolledPast: number;
+	minimumHeight?: number;
+}): PinnedPreviewMetrics => {
+	if (scrolledPast <= 0 || messageHeight <= 0) {
+		return {
+			active: false,
+			clipHeight: messageHeight,
+			fadeOpacity: 0,
+			overlayOpacity: 0,
+		};
+	}
+
+	const clipHeight = Math.max(minimumHeight, messageHeight - scrolledPast);
+	const fadeRange = 40;
+	const fadeOpacity = Math.max(
+		0,
+		Math.min((minimumHeight + fadeRange - clipHeight) / fadeRange, 1),
+	);
+	const overlayOpacity = Math.max(0, Math.min(scrolledPast / 16, 1));
+
+	return {
+		active: true,
+		clipHeight,
+		fadeOpacity,
+		overlayOpacity,
+	};
+};

--- a/site/src/router.test.ts
+++ b/site/src/router.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { agentsScrollRestorationKey } from "./router";
+
+describe("agentsScrollRestorationKey", () => {
+	it("groups all /agents routes under one restoration key", () => {
+		expect(agentsScrollRestorationKey({ pathname: "/agents" })).toBe("/agents");
+		expect(agentsScrollRestorationKey({ pathname: "/agents/chat-123" })).toBe(
+			"/agents",
+		);
+		expect(
+			agentsScrollRestorationKey({ pathname: "/agents/chat-123/settings" }),
+		).toBe("/agents");
+	});
+
+	it("keeps non-agents routes isolated", () => {
+		expect(agentsScrollRestorationKey({ pathname: "/workspaces" })).toBe(
+			"/workspaces",
+		);
+		expect(agentsScrollRestorationKey({ pathname: "/login" })).toBe("/login");
+	});
+});

--- a/site/src/router.tsx
+++ b/site/src/router.tsx
@@ -413,11 +413,21 @@ const AIBridgeSessionThreadsPage = lazy(
 	() => import("./pages/AIBridgePage/SessionThreadsPage/SessionThreadsPage"),
 );
 
+export const agentsScrollRestorationKey = (location: { pathname: string }) => {
+	if (
+		location.pathname === "/agents" ||
+		location.pathname.startsWith("/agents/")
+	) {
+		return "/agents";
+	}
+	return location.pathname;
+};
+
 const GlobalLayout = () => {
 	return (
 		<Suspense fallback={<Loader fullscreen />}>
 			<Outlet />
-			<ScrollRestoration />
+			<ScrollRestoration getKey={agentsScrollRestorationKey} />
 		</Suspense>
 	);
 };


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood

Redesigns the Agents chat scroll system around explicit follow/detached viewport state, durable anchor restoration, and page-level open/navigation repinning so chat scrolling stays stable across streaming, history loading, expand/collapse, mobile viewport changes, and Safari navigation. This also fixes the newly reported interrupt/cancel jump by keeping live tail layout stable through transient stream-state transitions, restores history loading for short transcripts, and covers the new `/agents` scroll-restoration key with a unit test.

<details><summary>Implementation plan</summary>

# Agent chat scroll redesign plan

## Context

The current agent chat scrolling behavior has multiple coupled failures around
bottom following, prepending older messages, nested scrollable tool calls, and
height changes from collapsible content. Rather than patching the existing
logic, this work should replace the scroll system with a new viewport model
built around explicit invariants and a small state machine.

This plan intentionally treats the existing scroll behavior as replaceable.
Integration work should use the current page/component boundaries, but the new
scroll controller should not inherit the old algorithm.

## Requirements

The replacement must satisfy all of the following:

1. The first chat appears at the top of the viewport on initial load.
2. Messages flow downward, with the newest content at the bottom.
3. Older content loads lazily when scrolling upward.
4. When the viewport is within a ~100px window of the latest message, the chat
   auto-follows new content.
5. When the viewport is not near the latest message, new content and layout
   changes must preserve the exact visible position.
6. Loading older content must preserve the current viewport instead of jumping
   to newly loaded messages.
7. Scrolling through scrollable tool calls must not trap upward or downward
   scroll gestures.
8. Expanding or collapsing tool calls must not cause viewport jumps.
9. When scrolling down past the latest user message, and enough assistant
   content exists below it, that user message should progressively pin to the
   top with roughly the first 2-3 lines visible and a fade at the bottom.

## Acceptance criteria

The redesign is done when all of the following are true:

- Initial load places the first rendered chat item at the top of the viewport.
- Slow scrolling within the follow threshold does not snap unexpectedly to the
  absolute bottom unless the viewport is already in follow mode.
- Appended streamed content, including the live stream tail and transient
  streaming/status blocks rendered after the timeline, follows only while the
  user remains within the follow threshold.
- Detached reading preserves the same visible content during streaming,
  prepend loading, expand/collapse, tool-output growth, viewport resize, and
  other message height changes.
- Reaching the top sentinel triggers one fetch per in-flight pagination state
  and keeps the same content anchored in view after the prepend completes.
- Nested scrollable tool outputs hand scroll control back to the main viewport
  when they hit their own top or bottom boundary for both wheel and touch
  gestures.
- The pinned latest-user-message preview appears progressively, clamps to a
  preview height, fades at the bottom, and disappears when the original
  message is visible again.
- Existing external contracts remain intact or are deliberately replaced in the
  same change: the imperative `scrollToBottomRef`, the `data-testid="scroll-container"`
  hook, and CSS/DOM affordances relied on by chat stories and related UI.

## Proposed architecture

### 1. Replace the scroll container with a small viewport system

Build a new chat viewport stack instead of retrofitting the current container:

- `ChatViewport`: owns the scrollable element, top history sentinel, bottom
  follow sentinel, live-stream tail measurement, and the pinned-user-message
  overlay.
- `useChatViewportController`: owns scroll mode, anchor capture/restore,
  append/prepend behavior, and the imperative scroll-to-bottom API used by the
  page when sending/editing.
- `useBoundaryScrollHandoff`: coordinates wheel/touch handling for nested
  scrollable tool-call regions so the parent scroll resumes when the child hits
  its top or bottom boundary.
- `usePinnedLatestUserMessage`: computes when and how the latest user message
  should pin to the top after replacing the existing sticky-message mechanism.

Keep message rendering in `ConversationTimeline` and `LiveStreamTail`, but give
both the viewport system a stable way to identify and measure anchorable blocks.

### 2. Use explicit scroll modes instead of implicit heuristics

The viewport controller should track one of two modes:

- `FOLLOWING_LATEST`: bottom gap is within the follow threshold, so appended
  assistant content keeps the viewport attached to the bottom.
- `DETACHED`: the user has scrolled away from the bottom, so the controller
  preserves the current anchor instead of following new content.

Mode transitions should be driven by measured geometry only:

- Enter `FOLLOWING_LATEST` when `scrollHeight - clientHeight - scrollTop <=
  100px`.
- Leave `FOLLOWING_LATEST` as soon as the user scrolls farther away.
- Do not special-case slow scrolling; the mode should depend only on the bottom
  gap.

### 3. Preserve position using an anchor element, not raw scroll deltas

For every update that can change layout outside `FOLLOWING_LATEST`, preserve the
viewport using an anchor snapshot:

- Pick the first visible anchorable content block in the viewport.
- Record its stable ID and the pixel offset from the viewport top.
- After DOM updates, find the same element and restore `scrollTop` so the
  element returns to the same visual offset.
- Exclude non-content clones and control elements from anchor selection,
  including sentinels, scroll affordances, and any pinned/sticky overlay copy.

Use this anchor-restore flow for:

- prepending older pages;
- expanding or collapsing tool calls;
- streamed assistant growth while detached;
- image/tool output height changes;
- viewport resizes.

This keeps the user on the same visible content instead of chasing total scroll
height changes.

### 4. Separate append behavior from prepend behavior

Treat new content at the bottom and history loading at the top as different
operations.

#### Append behavior

- In `FOLLOWING_LATEST`, imperatively snap to the bottom after layout commits.
- In `DETACHED`, do not modify the visible range except through anchor restore.
- Streamed token updates should reuse the same rules as ordinary appends.

#### Prepend behavior

- Use a dedicated top sentinel placed above the first rendered message.
- When it intersects and more history is available, fetch the next older page.
- Capture the anchor before merging the new page into the timeline.
- Restore the anchor after render so the same content remains in view.
- Guard against duplicate fetches while a prepend is already in flight.

The sentinel should remain a simple fetch trigger only; it should not decide
where the viewport moves.

### 5. Handle nested scrollable tool calls with boundary handoff

The parent chat viewport should remain the primary scroller. For tool-call
regions that must stay internally scrollable:

- allow wheel/touch scrolling inside the child only while that child can still
  scroll in the gesture direction;
- once the child reaches its boundary, let the event continue to the parent
  viewport instead of trapping the user;
- avoid CSS or JS behavior that fully captures the wheel stream after the child
  is exhausted.

This should remove the "stuck scrolling up" behavior when traversing tool-call
outputs.

### 6. Implement pinned latest-user-message as an overlay, not as scroll logic

The pinned preview should be a separate visual layer driven by the latest user
message geometry.

- Identify the most recent user message that precedes the currently visible
  assistant run.
- Start pinning only after the original message begins leaving the viewport and
  enough assistant content exists below it.
- Render a top overlay copy that transitions from transparent/non-sticky to
  sticky/clamped as scroll progress increases.
- Clamp to roughly 2-3 lines and apply a bottom fade so the truncation is
  obvious.
- Remove the overlay once the original message would naturally be visible again.

Because the pinned preview is separate from the main scroll math, it should not
change anchor restoration or follow-mode behavior.

### 7. Keep the DOM contract simple and measurable

To make the controller reliable, ensure the rendered chat stack exposes stable
measurement points:

- wrap each top-level timeline message block in an element with a stable ID
  attribute;
- do the same for tool-call blocks that can expand or host internal scrolling;
- expose a stable anchor boundary for live-stream tail blocks rendered after the
  persisted timeline;
- keep the top sentinel outside the measured content items;
- keep the bottom follow marker at the end of the content stack;
- mark overlay clones and non-content controls as non-anchorable.

This avoids coupling the controller to message content internals.

## File-level plan

1. Replace `site/src/pages/AgentsPage/components/ChatScrollContainer.tsx`
   with a new, much smaller viewport shell that composes dedicated hooks rather
   than keeping all behavior in one file.
2. Add focused hooks under
   `site/src/pages/AgentsPage/components/` or a nearby `hooks/` directory for:
   - viewport mode and bottom-gap detection;
   - anchor capture/restore;
   - history sentinel loading;
   - nested scroll boundary handoff;
   - pinned latest-user-message overlay state;
   - the imperative `scrollToBottomRef` bridge.
3. Update `site/src/pages/AgentsPage/components/ChatPageContent.tsx` and the
   live-stream tail components so streaming output participates in follow-mode
   and detached anchor preservation.
4. Update `ConversationTimeline.tsx` to replace the existing sticky user-message
   mechanism with stable measurement anchors and the new pinned-preview contract
   without changing message ordering or parsing behavior.
5. Update relevant tool-call wrappers and shared scrollable tool primitives,
   especially collapsible outputs and Radix `ScrollArea`-based regions, so they
   register stable anchors and participate in boundary handoff.
6. Add or update Storybook stories for viewport-level behaviors using a page or
   container harness instead of relying only on timeline stories.

## Red phase

Define the behavior first with tests and stories.

### Pure logic tests

Add focused tests for the controller logic that do not require rendering the
entire page:

1. `FOLLOWING_LATEST` enters when bottom gap is at or below 100px.
2. `FOLLOWING_LATEST` exits immediately when the bottom gap exceeds 100px.
3. Anchor restoration returns the same element to the same viewport offset after
   a prepend.
4. Anchor restoration returns the same element to the same viewport offset after
   a collapse/expand height change.
5. Detached streaming in the live-stream tail preserves the same anchor offset
   while streamed blocks grow.
6. Boundary handoff allows parent scrolling when a nested scroller is already at
   its top or bottom for wheel and touch direction checks.
7. Anchor candidate selection excludes sentinels, overlay clones, and control
   elements.
8. Pinned-message progress stays off until the latest user message begins
   leaving the viewport and enough assistant content exists below it.
9. The imperative scroll-to-bottom bridge still scrolls to the latest content
   from send/edit flows.

### Storybook interaction coverage

Add or extend stories for these scenarios:

1. Initial load: first message sits at the top of the viewport.
2. Near-bottom auto-follow: streamed assistant growth, including the live tail,
   keeps the latest content visible.
3. Detached mode: while reading older content, new assistant output does not
   move the viewport.
4. History prepend: older messages load when the top sentinel is reached and
   the visible message remains fixed in place.
5. Collapsible tool call: opening and closing a large tool output preserves the
   viewport position.
6. Nested scrollable tool output: wheel-up, wheel-down, and touch scrolling
   transition smoothly between the child scroller and the parent viewport.
7. Imperative send/edit scroll: page-level actions still scroll to the latest
   content through `scrollToBottomRef`.
8. Pinned latest-user-message: the overlay appears progressively, stays clamped
   with a fade, and disappears when appropriate.

## Green phase

1. Create the new `ChatViewport` component and mount it in the agent chat page
   layout in place of the old scroll-specific container.
2. Implement the two-mode controller (`FOLLOWING_LATEST` / `DETACHED`) using
   bottom-gap measurement from the viewport element, while explicitly preserving
   current browser-specific resize and touch safety behavior where needed.
3. Implement anchor capture/restore around all layout-changing updates outside
   follow mode.
4. Wire top-sentinel pagination so history fetches use anchor restoration rather
   than scroll-height delta math.
5. Integrate boundary-handoff behavior at the actual nested scroller layer used
   by tool outputs, including Radix `ScrollArea` viewports.
6. Replace the existing sticky user-message mechanism with the new pinned
   latest-user-message overlay and its progressive clamp/fade behavior.
7. Keep the scroll-to-bottom affordance and imperative `scrollToBottomRef`
   bridge aligned with the new controller state, showing the affordance only
   when detached.

## Implementation sequencing

1. Land the pure controller utilities first so bottom-follow and
   anchor-preservation behavior can be tested outside the full page.
2. Add stable measurement IDs and live-tail anchor boundaries before switching
   the viewport shell so detached preservation can cover both persisted and
   streaming content from day one.
3. Switch `ChatScrollContainer` over to the new viewport/controller shell while
   preserving external contracts such as `scrollToBottomRef`, test IDs, and
   required CSS/DOM hooks.
4. Replace the existing sticky user-message mechanism as part of the viewport
   transition rather than running old and new pinning systems in parallel.
5. Add nested scroll boundary handoff for the actual tool-output scrollers after
   the base viewport behavior is stable.
6. Add the pinned latest-user-message overlay last so it remains a visual layer
   on top of a proven scroll model rather than becoming part of the core
   scrolling algorithm.

## Refactor phase

1. Reduce the new viewport code until each hook owns one responsibility only:
   mode detection, anchor restoration, history loading, nested scroll handoff,
   pinned preview state, or imperative scroll bridging.
2. Remove any leftover logic paths from the previous scroll container and the
   previous sticky user-message implementation so only one scroll model remains
   in production.
3. Simplify wrappers so measurement IDs and refs are attached at a single
   consistent boundary for every message, tool block, and live-tail block.
4. Revisit naming and small helper extraction only after the behavior is proven
   by tests and stories.

## Verification

### Automated

1. Run the targeted frontend test suite for the new pure logic tests.
2. Run Storybook interaction tests for the updated viewport/page harness stories
   and the affected timeline/live-tail stories.
3. Run the relevant lint/format checks for touched frontend files.

### Manual

Validate each requirement in the browser with realistic chat data:

1. Slow-scroll near the bottom without snapping unexpectedly.
2. Scroll upward through a long, internally scrollable tool output without
   getting trapped.
3. Trigger multiple lazy-history loads and confirm the viewport stays anchored.
4. Expand and collapse large tool-call sections mid-history and confirm no jump.
5. Stream assistant output while near the bottom and while detached, confirming
   the correct follow/preserve behavior in each case.
6. Scroll past the latest user message and confirm the pinned preview appears
   progressively, remains readable, and fades at the bottom.

## Risks and mitigations

- **Streaming updates can create many small height changes.** Mitigate by
  batching anchor restoration to animation-frame or layout-commit boundaries.
- **Unstable DOM keys will break anchor restoration.** Mitigate by using stable
  message/tool IDs rather than array indices.
- **Nested scrollers can behave differently across browsers.** Mitigate with
  Storybook interaction coverage, targeted manual testing in the supported
  browsers, and integration at the actual shared scroll viewport layer.
- **Pinned overlay can visually duplicate content at the wrong time.** Mitigate
  by replacing the old sticky implementation in the same transition, keying the
  new overlay off measured geometry, and hiding it whenever the source message
  is sufficiently visible in the viewport.
- **The live stream tail can bypass timeline-based anchoring.** Mitigate by
  making live-stream blocks first-class anchor candidates and covering detached
  streaming in tests and stories.
- **Browser resize, keyboard, and touch behavior may still require platform
  guards.** Mitigate by preserving proven browser-specific safeguards unless a
  replacement is validated in manual testing.


</details>
