### PR TITLE
fix: stop tracking chat title in audit logs

### DIFF
--- a/coderd/audit/request.go
+++ b/coderd/audit/request.go
@@ -135,7 +135,7 @@ func ResourceTarget[T Auditable](tgt T) string {
 	case database.AiSeatState:
 		return "AI Seat"
 	case database.Chat:
-		return typed.Title
+		return typed.ID.String()[:8]
 	default:
 		panic(fmt.Sprintf("unknown resource %T for ResourceTarget", tgt))
 	}

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -272,10 +272,11 @@ func TestPostChats(t *testing.T) {
 		}
 		require.True(t, foundUserMessage)
 		require.True(t, mAudit.Contains(t, database.AuditLog{
-			Action:       database.AuditActionCreate,
-			ResourceType: database.ResourceTypeChat,
-			ResourceID:   chat.ID,
-			UserID:       member.ID,
+			Action:         database.AuditActionCreate,
+			ResourceType:   database.ResourceTypeChat,
+			ResourceID:     chat.ID,
+			ResourceTarget: chat.ID.String()[:8],
+			UserID:         member.ID,
 		}))
 	})
 
@@ -4564,10 +4565,11 @@ func TestArchiveChat(t *testing.T) {
 		require.True(t, archivedChats[0].Archived)
 
 		require.True(t, mAudit.Contains(t, database.AuditLog{
-			Action:       database.AuditActionWrite,
-			ResourceType: database.ResourceTypeChat,
-			ResourceID:   chatToArchive.ID,
-			UserID:       firstUser.UserID,
+			Action:         database.AuditActionWrite,
+			ResourceType:   database.ResourceTypeChat,
+			ResourceID:     chatToArchive.ID,
+			ResourceTarget: chatToArchive.ID.String()[:8],
+			UserID:         firstUser.UserID,
 		}))
 	})
 	t.Run("NotFound", func(t *testing.T) {

--- a/enterprise/audit/table.go
+++ b/enterprise/audit/table.go
@@ -386,7 +386,7 @@ var auditableResourcesTypes = map[any]map[string]Action{
 		"workspace_id":          ActionTrack,
 		"build_id":              ActionIgnore, // Internal lifecycle.
 		"agent_id":              ActionIgnore, // Internal lifecycle.
-		"title":                 ActionTrack,
+		"title":                 ActionSecret,
 		"status":                ActionIgnore, // Churns every message.
 		"worker_id":             ActionIgnore, // Internal.
 		"started_at":            ActionIgnore,


### PR DESCRIPTION
Chat titles can contain sensitive information (secrets, internal project names, etc.) and should not be visible in audit logs.

- Use truncated chat UUID (first 8 chars) as `resource_target` instead of the title
- Mark the `title` field as `ActionSecret` so diffs render as `••••••••`

<details><summary>Implementation notes</summary>

Two changes:
1. `coderd/audit/request.go`: `ResourceTarget` for Chat returns `typed.ID.String()[:8]` instead of `typed.Title`
2. `enterprise/audit/table.go`: Chat `title` field tracking changed from `ActionTrack` to `ActionSecret`

No frontend changes needed. The frontend already handles `secret: true` fields.

</details>

> 🤖