### PR TITLE
feat: exclude aibridge/fixtures directory from scripts/check_emdash.sh

### DIFF
--- a/scripts/check_emdash.sh
+++ b/scripts/check_emdash.sh
@@ -20,20 +20,14 @@ emdash=$'\xE2\x80\x94'
 endash=$'\xE2\x80\x93'
 pattern="${emdash}|${endash}"
 
-# Path prefixes excluded from the check. These contain captured upstream
-# content where emdash/endash come from the provider.
-exclude_prefixes=(
-	"aibridge/fixtures/"
+# Git exclude_pathspecs excluded from the check. Used in both ls-files and diff comparison.
+exclude_pathspecs=(
+	":(exclude)aibridge/fixtures/**/*.txtar"
 )
 
 scan_all_files() {
-	local pathspecs=()
-	local prefix
-	for prefix in "${exclude_prefixes[@]}"; do
-		pathspecs+=(":(exclude)${prefix}**")
-	done
 	local output
-	output=$(git ls-files -z -- "${pathspecs[@]}" | xargs -0 grep -IEn "$pattern" 2>/dev/null || true)
+	output=$(git ls-files -z -- "${exclude_pathspecs[@]}" | xargs -0 grep -IEn "$pattern" 2>/dev/null || true)
 	if [[ -n "$output" ]]; then
 		echo "$output"
 		found=1
@@ -69,7 +63,7 @@ else
 		fi
 
 		found=0
-		if ! diff_output=$(git diff "$base" -U0 -- . 2>&1); then
+		if ! diff_output=$(git diff "$base" -U0 -- . "${exclude_pathspecs[@]}" 2>&1); then
 			echo "ERROR: git diff against $base failed:"
 			echo "$diff_output"
 			exit 1
@@ -83,17 +77,9 @@ else
 		# Parse the diff to check only added lines for emdash/endash.
 		current_file=""
 		current_line=0
-		file_excluded=0
 		while IFS= read -r diff_line; do
 			if [[ "$diff_line" =~ ^\+\+\+\ b/(.*) ]]; then
 				current_file="${BASH_REMATCH[1]}"
-				file_excluded=0
-				for prefix in "${exclude_prefixes[@]}"; do
-					if [[ "$current_file" == "$prefix"* ]]; then
-						file_excluded=1
-						break
-					fi
-				done
 			fi
 			# Anchored to hunk header structure to avoid matching
 			# digits from trailing function context.
@@ -102,7 +88,7 @@ else
 				continue
 			fi
 			if [[ "$diff_line" =~ ^\+ ]] && [[ ! "$diff_line" =~ ^\+\+\+\ [ab/] ]]; then
-				if [[ "$file_excluded" -eq 0 ]] && echo "$diff_line" | grep -Eq "$pattern"; then
+				if echo "$diff_line" | grep -Eq "$pattern"; then
 					echo "${current_file}:${current_line}:${diff_line:1}"
 					found=1
 				fi

--- a/scripts/check_emdash.sh
+++ b/scripts/check_emdash.sh
@@ -20,9 +20,20 @@ emdash=$'\xE2\x80\x94'
 endash=$'\xE2\x80\x93'
 pattern="${emdash}|${endash}"
 
+# Path prefixes excluded from the check. These contain captured upstream
+# content where emdash/endash come from the provider.
+exclude_prefixes=(
+	"aibridge/fixtures/"
+)
+
 scan_all_files() {
+	local pathspecs=()
+	local prefix
+	for prefix in "${exclude_prefixes[@]}"; do
+		pathspecs+=(":(exclude)${prefix}**")
+	done
 	local output
-	output=$(git ls-files -z | xargs -0 grep -IEn "$pattern" 2>/dev/null || true)
+	output=$(git ls-files -z -- "${pathspecs[@]}" | xargs -0 grep -IEn "$pattern" 2>/dev/null || true)
 	if [[ -n "$output" ]]; then
 		echo "$output"
 		found=1
@@ -72,9 +83,17 @@ else
 		# Parse the diff to check only added lines for emdash/endash.
 		current_file=""
 		current_line=0
+		file_excluded=0
 		while IFS= read -r diff_line; do
 			if [[ "$diff_line" =~ ^\+\+\+\ b/(.*) ]]; then
 				current_file="${BASH_REMATCH[1]}"
+				file_excluded=0
+				for prefix in "${exclude_prefixes[@]}"; do
+					if [[ "$current_file" == "$prefix"* ]]; then
+						file_excluded=1
+						break
+					fi
+				done
 			fi
 			# Anchored to hunk header structure to avoid matching
 			# digits from trailing function context.
@@ -83,7 +102,7 @@ else
 				continue
 			fi
 			if [[ "$diff_line" =~ ^\+ ]] && [[ ! "$diff_line" =~ ^\+\+\+\ [ab/] ]]; then
-				if echo "$diff_line" | grep -Eq "$pattern"; then
+				if [[ "$file_excluded" -eq 0 ]] && echo "$diff_line" | grep -Eq "$pattern"; then
 					echo "${current_file}:${current_line}:${diff_line:1}"
 					found=1
 				fi


### PR DESCRIPTION
<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->

Adds exception to emdash check to exclude `/aibridge/fixtures` directory.