### PR TITLE
feat: rebucket "Number of developers" onboarding options

### DIFF
--- a/cli/login.go
+++ b/cli/login.go
@@ -599,10 +599,22 @@ func promptTrialInfo(inv *serpent.Invocation, fieldName string) (string, error) 
 	return value, nil
 }
 
+// developerBuckets are the options offered for the "Number of developers"
+// prompt during first-user setup. Keep in sync with
+// site/src/pages/SetupPage/SetupPageView.tsx (numberOfDevelopersOptions).
+var developerBuckets = []string{
+	"1 - 50",
+	"51 - 100",
+	"101 - 200",
+	"201 - 500",
+	"501 - 1000",
+	"1001 - 2500",
+	"2500+",
+}
+
 func promptDevelopers(inv *serpent.Invocation) (string, error) {
-	options := []string{"1-100", "101-500", "501-1000", "1001-2500", "2500+"}
 	selection, err := cliui.Select(inv, cliui.SelectOptions{
-		Options:    options,
+		Options:    developerBuckets,
 		HideSearch: false,
 		Message:    "Select the number of developers:",
 	})

--- a/cli/login_internal_test.go
+++ b/cli/login_internal_test.go
@@ -1,0 +1,25 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDeveloperBuckets pins the set of options offered for the
+// "Number of developers" prompt. If this test fails, also update the
+// matching list in site/src/pages/SetupPage/SetupPageView.tsx
+// (numberOfDevelopersOptions) and coordinate with the licensor service owner,
+// since the same string is forwarded to v2-licensor.coder.com/trial.
+func TestDeveloperBuckets(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, []string{
+		"1 - 50",
+		"51 - 100",
+		"101 - 200",
+		"201 - 500",
+		"501 - 1000",
+		"1001 - 2500",
+		"2500+",
+	}, developerBuckets)
+}

--- a/site/src/pages/SetupPage/SetupPageView.stories.tsx
+++ b/site/src/pages/SetupPage/SetupPageView.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, waitFor, within } from "storybook/test";
 import { chromatic } from "#/testHelpers/chromatic";
 import { mockApiError } from "#/testHelpers/entities";
 import { SetupPageView } from "./SetupPageView";
@@ -44,5 +45,38 @@ export const TrialError: Story = {
 export const Loading: Story = {
 	args: {
 		isLoading: true,
+	},
+};
+
+// TrialOpen pins the "Number of developers" bucket list. If this assertion
+// changes, coordinate the new values with the licensor service owner, since
+// the selected bucket is forwarded verbatim to v2-licensor.coder.com/trial.
+export const TrialOpen: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		// Radix Select portals its listbox into document.body.
+		const body = within(canvasElement.ownerDocument.body);
+
+		// Reveal the trial fields by checking the Premium trial checkbox.
+		await userEvent.click(canvas.getByTestId("trial"));
+
+		// Open the "Number of developers" Select.
+		const trigger = await canvas.findByRole("combobox", {
+			name: "Number of developers",
+		});
+		await userEvent.click(trigger);
+
+		await waitFor(() => {
+			const options = body.getAllByRole("option");
+			expect(options.map((o) => o.textContent)).toEqual([
+				"1 - 50",
+				"51 - 100",
+				"101 - 200",
+				"201 - 500",
+				"501 - 1000",
+				"1001 - 2500",
+				"2500+",
+			]);
+		});
 	},
 };

--- a/site/src/pages/SetupPage/SetupPageView.tsx
+++ b/site/src/pages/SetupPage/SetupPageView.tsx
@@ -73,11 +73,14 @@ const validationSchema = Yup.object({
 	}),
 });
 
+// Keep in sync with cli/login.go (developerBuckets).
 const numberOfDevelopersOptions = [
-	"1-100",
-	"101-500",
-	"501-1000",
-	"1001-2500",
+	"1 - 50",
+	"51 - 100",
+	"101 - 200",
+	"201 - 500",
+	"501 - 1000",
+	"1001 - 2500",
 	"2500+",
 ];
 


### PR DESCRIPTION
## What

Split the "Number of developers" buckets on the first-user setup page into seven narrower ranges, with a space on each side of the hyphen.

| Before | After |
|---|---|
| `1-100` | `1 - 50` |
| `101-500` | `51 - 100` |
| `501-1000` | `101 - 200` |
| `1001-2500` | `201 - 500` |
| `2500+` | `501 - 1000` |
|  | `1001 - 2500` |
|  | `2500+` |

The bucket list is duplicated in two source-of-truth files (frontend form and CLI prompt); both now match, each with a keep-in-sync comment pointing at the other.

## Why

Finer segmentation of trial signups, particularly around the old `1-100` and `101-500` boundaries.

## Downstream / licensor (BigQuery)

The selected bucket is JSON-serialized and POSTed to `https://v2-licensor.coder.com/trial` by `enterprise/trialer/trialer.go`. **That licensor service is out of this repo.** If it ingests trial signups into BigQuery (or any exact-string bucket), the schema, allowlists, dashboards, and historical rollups need coordinated updates:

- **New exact values** will start arriving: `1 - 50`, `51 - 100`, `101 - 200`, `201 - 500`, `501 - 1000`, `1001 - 2500`. Note `501 - 1000` and `1001 - 2500` are also new strings (whitespace change).
- **Bucket splits at** `50` (inside the old `1-100`) and `200` (inside the old `101-500`). Any rollup that joins old and new values by exact string will undercount both sides of those two boundaries.
- `2500+` is unchanged.

Licensor-repo owner needs to (a) extend any enum or allowlist, (b) update dashboards grouped by `developers`, (c) decide a reconciliation rule for historical values.

## Out of scope (verified, no changes needed)

- API schema: `codersdk.CreateFirstUserTrialInfo.Developers` is already a free-form `string`; `coderd/apidoc/docs.go` and `docs/reference/api/{users,schemas}.md` already document it as `string`. No enum, no validation.
- Backend: `coderd/users.go` passes the value straight through; no database column, audit table, or converter involved.
- Fixture `coderdtest.TrialUserParams.Developers = "10-50"`: free-form sentinel not in the UI list, never asserted against the enum. Left unchanged.

## Tests

- `cli/login_internal_test.go` (new): `TestDeveloperBuckets` pins the exact 7-string slice.
- `site/src/pages/SetupPage/SetupPageView.stories.tsx`: new `TrialOpen` story whose `play` function ticks the trial checkbox, opens the Select, and asserts `getAllByRole("option")` returns the 7 labels in order.

Local runs:

- `go test ./cli/ -run '^(TestDeveloperBuckets|TestLogin)$'` passes.
- `pnpm exec vitest run --project=storybook src/pages/SetupPage/SetupPageView.stories.tsx` passes (6 tests including `TrialOpen`).
- `make pre-commit` via the installed hook passed in 84s.

<details>
<summary>Implementation plan (decision log)</summary>

- Extracted `developerBuckets` in `cli/login.go` so the list is directly assertable. Alternative was a ptytest-driven prompt test, rejected as more fragile.
- New test colocated in `cli/login_internal_test.go` (`package cli`) so it can access the unexported slice; matches existing `*_internal_test.go` convention in `cli/`.
- Did not introduce a shared `codersdk` constant for the bucket list. Frontend cannot import Go constants and threading through `typesGenerated.ts` is a bigger change than warranted. Mitigated with keep-in-sync comments at each site.

</details>

---

_This PR was authored by a Coder Agent on behalf of @david-fraley._