### PR TITLE
docs(docs/admin/infrastructure): add Governance Layer section to architecture page

### DIFF
--- a/docs/admin/infrastructure/architecture.md
+++ b/docs/admin/infrastructure/architecture.md
@@ -137,13 +137,12 @@ AI-powered development within Coder workspaces.
 
 ### AI Gateway
 
-AI Gateway is a centralized proxy between coding agents and LLM providers such
-as OpenAI and Anthropic. It handles authentication, authorization, and token
-management so that users authenticate through Coder instead of managing separate
-provider API keys. All prompts, completions, and tool invocations are recorded
+AI Gateway is a centralized gateway that sits between coding agents and LLM providers such
+as OpenAI and Anthropic. Users authenticate through Coder instead of managing separate
+provider API keys. All prompts, token usage, and tool invocations are recorded
 for compliance and cost tracking.
 
-Learn more: [AI Gateway Reference](../../ai-coder/ai-gateway/reference.md)
+Learn more: [AI Gateway](../../ai-coder/ai-gateway)
 
 ### Agent Firewall
 

--- a/docs/admin/infrastructure/architecture.md
+++ b/docs/admin/infrastructure/architecture.md
@@ -129,3 +129,27 @@ GitHub Container Registry) you can run your own container registry with Coder.
 
 To shorten the provisioning time, it is recommended to deploy registry mirrors
 in the same region as the workspace nodes.
+
+## Governance Layer
+
+The governance layer provides centralized oversight and policy enforcement for
+AI-powered development within Coder workspaces.
+
+### AI Gateway
+
+AI Gateway is a centralized proxy between coding agents and LLM providers such
+as OpenAI and Anthropic. It handles authentication, authorization, and token
+management so that users authenticate through Coder instead of managing separate
+provider API keys. All prompts, completions, and tool invocations are recorded
+for compliance and cost tracking.
+
+Learn more: [AI Gateway Reference](../../ai-coder/ai-gateway/reference.md)
+
+### Agent Firewall
+
+Agent Firewall is a process-level firewall that restricts and audits network
+access for AI agents running in workspaces. It enforces allowlist-based policies
+controlling which domains, HTTP methods, and URL paths agents can reach, while
+streaming audit logs to the Coder control plane for centralized monitoring.
+
+Learn more: [Agent Firewall](../../ai-coder/agent-firewall/index.md)


### PR DESCRIPTION
Adds a new "Governance Layer" section to the architecture page with short descriptions of AI Gateway and Agent Firewall, linking to their dedicated reference pages.

> Generated by Coder Agents