### PR TITLE
fix: fix flaky TestExpAgentsE2E/ExistingChatHistory

### DIFF
--- a/cli/exp_agents_e2e_helpers_test.go
+++ b/cli/exp_agents_e2e_helpers_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/coder/coder/v2/cli/clitest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/coderd/x/chatd/chattest"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/pty/ptytest"
 	"github.com/coder/coder/v2/testutil"
@@ -26,6 +27,19 @@ func setupExpAgentsBackend(t *testing.T) (*codersdk.Client, *codersdk.Experiment
 	values := coderdtest.DeploymentValues(t)
 	values.Experiments = []string{string(codersdk.ExperimentAgents)}
 
+	// Use a mock OpenAI server so chatd does not hit the real API
+	// with a fake key. Without this, seedChat triggers background
+	// processing that fails with an auth error, injecting noise
+	// into the TUI output and causing flaky PTY expects.
+	// The non-streaming handler returns unparseable title JSON so
+	// the original seed-based chat title is preserved.
+	openAIURL := chattest.NewOpenAI(t, func(req *chattest.OpenAIRequest) chattest.OpenAIResponse {
+		if req.Stream {
+			return chattest.OpenAIStreamingResponse(chattest.OpenAITextChunks("ok")...)
+		}
+		return chattest.OpenAINonStreamingResponse("ok")
+	})
+
 	client := coderdtest.New(t, &coderdtest.Options{
 		DeploymentValues: values,
 	})
@@ -37,6 +51,7 @@ func setupExpAgentsBackend(t *testing.T) (*codersdk.Client, *codersdk.Experiment
 	_, err := expClient.CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
 		Provider: "openai",
 		APIKey:   "test-api-key",
+		BaseURL:  openAIURL,
 	})
 	require.NoError(t, err)
 

--- a/cli/exp_agents_e2e_test.go
+++ b/cli/exp_agents_e2e_test.go
@@ -77,8 +77,16 @@ func TestExpAgentsE2E(t *testing.T) {
 		chat := seedChat(t, ctx, expClient, orgID, "direct open seed")
 		session := startExpAgentsSession(t, ctx, client, chat.ID.String())
 
-		session.expect(ctx, "direct open seed")
-		session.expect(ctx, "esc")
+		// Match the short chat ID in the header. The mock's title
+		// generation may have already replaced the seed text, so
+		// the short ID is the only stable identifier.
+		shortID := chat.ID.String()[:8]
+		session.expect(ctx, shortID)
+		// Wait for the full chat view render including the help
+		// row. In the initial render the help row (containing
+		// "esc back") follows the header in the byte stream, so
+		// this expect succeeds without consuming text out of order.
+		session.expect(ctx, "esc back")
 		session.esc()
 		session.expect(ctx, "enter: open")
 		session.quit()

--- a/testutil/goleak.go
+++ b/testutil/goleak.go
@@ -21,4 +21,8 @@ var GoleakOptions []goleak.Option = []goleak.Option{
 	// The go-winio library starts a process-level I/O completion port
 	// goroutine via sync.Once that is never terminated.
 	goleak.IgnoreAnyFunction("github.com/Microsoft/go-winio.ioCompletionProcessor"),
+	// Bubble Tea cursor blink goroutine waits on an internal timer
+	// (~530ms) and cannot be canceled. When a TUI test exits faster
+	// than the blink interval the goroutine is still pending.
+	goleak.IgnoreTopFunction("github.com/charmbracelet/bubbles/cursor.(*Model).BlinkCmd.func1"),
 }


### PR DESCRIPTION
Fixes https://linear.app/codercom/issue/ENG-2509

## Changes

Three root causes for the flake, all addressed:

1. **Mock OpenAI server**: `seedChat` triggers the chatd processor which
   hit the real OpenAI API with a fake key (`test-api-key`), producing an
   auth error that rendered an `error` banner in the TUI and polluted PTY
   output. Added a `chattest.NewOpenAI` mock so processing completes
   cleanly.

2. **Stable header match**: The PTY expect for `"direct open seed"` was
   racy because the mock's title generation could replace the seed text
   before the TUI rendered. Changed to match the chat's short ID
   (first 8 hex chars), which is always present in the header.

3. **Correct expect ordering**: The PTY expect for `"esc"` after
   matching the header was racy because Bubble Tea's incremental
   rendering emitted the help row (containing `"esc back"`) before
   updating the header in the byte stream, so the first match consumed
   the `"esc"` text. Changed to match `"esc back"` after the short ID,
   which works in the initial full render where the help row follows the
   header.

Also added Bubble Tea's cursor `BlinkCmd` goroutine to the global goleak
exceptions. The timer (~530ms) cannot be canceled and outlives fast TUI
tests.

<details><summary>Root cause analysis</summary>

The `ExistingChatHistory` test opens the TUI directly in the chat view
(by passing the chat ID as an argument). Bubble Tea renders the full
screen once, then uses cursor-positioning (ANSI escape sequences) for
incremental updates. In the terminal byte stream:

1. Initial full render: `header` → `separator` → `viewport` →
   `statusBar` → `composer` → `helpRow` (contains `"esc back"`)
2. Chat data loads → incremental update repositions cursor to overwrite
   just the header with `"direct open seed (shortID)"`
3. `ExpectMatch("direct open seed")` scans forward, consuming
   `"esc back"` which appeared earlier in the byte stream
4. `ExpectMatch("esc")` then only sees the error banner text from the
   failed API call, and eventually times out

The `ListAndNavigate` test doesn't flake because `session.enter()`
triggers a full screen re-render that emits `"esc back"` fresh.
</details>

---

> Generated by Coder Agents