### PR TITLE
fix: reduce re-registration interval to 5s to prevent replica staleness flapping

### DIFF
--- a/enterprise/wsproxy/wsproxysdk/wsproxysdk.go
+++ b/enterprise/wsproxy/wsproxysdk/wsproxysdk.go
@@ -314,7 +314,7 @@ func (l *RegisterWorkspaceProxyLoop) register(ctx context.Context) (RegisterWork
 // for the initial registration. Use Close() to stop.
 func (l *RegisterWorkspaceProxyLoop) Start(ctx context.Context) (RegisterWorkspaceProxyResponse, error) {
 	if l.opts.Interval == 0 {
-		l.opts.Interval = 15 * time.Second
+		l.opts.Interval = 5 * time.Second
 	}
 	if l.opts.MaxFailureCount == 0 {
 		l.opts.MaxFailureCount = 10

--- a/enterprise/wsproxy/wsproxysdk/wsproxysdk.go
+++ b/enterprise/wsproxy/wsproxysdk/wsproxysdk.go
@@ -313,6 +313,10 @@ func (l *RegisterWorkspaceProxyLoop) register(ctx context.Context) (RegisterWork
 // Start starts the proxy registration loop. The provided context is only used
 // for the initial registration. Use Close() to stop.
 func (l *RegisterWorkspaceProxyLoop) Start(ctx context.Context) (RegisterWorkspaceProxyResponse, error) {
+	// The primary's replicaManager marks replicas stale after
+	// 3 × UpdateInterval (default 15s). This must be well under
+	// that threshold so proxies get several heartbeat attempts
+	// before being excluded from the DERP mesh.
 	if l.opts.Interval == 0 {
 		l.opts.Interval = 5 * time.Second
 	}

--- a/enterprise/wsproxy/wsproxysdk/wsproxysdk.go
+++ b/enterprise/wsproxy/wsproxysdk/wsproxysdk.go
@@ -313,11 +313,10 @@ func (l *RegisterWorkspaceProxyLoop) register(ctx context.Context) (RegisterWork
 // Start starts the proxy registration loop. The provided context is only used
 // for the initial registration. Use Close() to stop.
 func (l *RegisterWorkspaceProxyLoop) Start(ctx context.Context) (RegisterWorkspaceProxyResponse, error) {
-	// The primary's replicaManager marks replicas stale after
-	// 3 × UpdateInterval (default 15s). This must be well under
-	// that threshold so proxies get several heartbeat attempts
-	// before being excluded from the DERP mesh.
+	// Workspace proxy re-registrations should be on the same interval as the rest of the replicasync.
+	// If they differ significantly it can cause problems with meshing.
 	if l.opts.Interval == 0 {
+		// Default to the same interval as the rest of the replicasync.
 		l.opts.Interval = 5 * time.Second
 	}
 	if l.opts.MaxFailureCount == 0 {


### PR DESCRIPTION
Workspace proxies re-register with the primary coderd every 15 seconds, which updates their replica row's updated_at timestamp in the database. The primary's replicaManager considers any replica not updated within 3 × 5s = 15s as stale and excludes it from queries.

So we basically get one shot at registering before being marked stale and breaking DERP meshing to this replica. Was causing some very confusing failures when scaletesting.