### PR TITLE
feat(cli)!: allocate PTY only for interactive sessions

### DIFF
--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -135,6 +135,9 @@ func (r *RootCmd) ssh() *serpent.Command {
 
 		containerName string
 		containerUser string
+
+		tty   bool
+		noTTY bool
 	)
 	cmd := &serpent.Command{
 		Annotations: workspaceCommand,
@@ -206,6 +209,10 @@ func (r *RootCmd) ssh() *serpent.Command {
 			return completions
 		},
 		Handler: func(inv *serpent.Invocation) (retErr error) {
+			if tty && noTTY {
+				return xerrors.Errorf("cannot specify both --tty (-t) and --no-tty (-T)")
+			}
+
 			client, err := r.InitClient(inv)
 			if err != nil {
 				return err
@@ -633,9 +640,26 @@ func (r *RootCmd) ssh() *serpent.Command {
 				}
 			}
 
+			// Determine whether to allocate a remote PTY,
+			// following OpenSSH semantics:
+			//   -T (--no-tty): never allocate a PTY
+			//   -t (--tty):    always allocate a PTY
+			//   default:       allocate a PTY for login sessions when
+			//                  stdin is a TTY
 			stdinFile, validIn := inv.Stdin.(*os.File)
 			stdoutFile, validOut := inv.Stdout.(*os.File)
-			if validIn && validOut && isatty.IsTerminal(stdinFile.Fd()) && isatty.IsTerminal(stdoutFile.Fd()) {
+			stdinIsTerminal := validIn && isatty.IsTerminal(stdinFile.Fd())
+
+			var wantPTY bool
+			if noTTY {
+				wantPTY = false
+			} else if tty {
+				wantPTY = true
+			} else {
+				wantPTY = command == "" && stdinIsTerminal
+			}
+
+			if wantPTY && validIn && validOut && isatty.IsTerminal(stdinFile.Fd()) && isatty.IsTerminal(stdoutFile.Fd()) {
 				inState, err := pty.MakeInputRaw(stdinFile.Fd())
 				if err != nil {
 					return err
@@ -685,9 +709,11 @@ func (r *RootCmd) ssh() *serpent.Command {
 				}
 			}
 
-			err = sshSession.RequestPty("xterm-256color", 128, 128, gossh.TerminalModes{})
-			if err != nil {
-				return xerrors.Errorf("request pty: %w", err)
+			if wantPTY {
+				err = sshSession.RequestPty("xterm-256color", 128, 128, gossh.TerminalModes{})
+				if err != nil {
+					return xerrors.Errorf("request pty: %w", err)
+				}
 			}
 
 			sshSession.Stdin = inv.Stdin
@@ -709,7 +735,7 @@ func (r *RootCmd) ssh() *serpent.Command {
 				// shutdown of services.
 				defer cancel()
 
-				if validOut {
+				if wantPTY && validOut {
 					// Set initial window size.
 					width, height, err := term.GetSize(int(stdoutFile.Fd()))
 					if err == nil {
@@ -836,6 +862,20 @@ func (r *RootCmd) ssh() *serpent.Command {
 			Description: "Specifies the interval to update network information.",
 			Default:     "5s",
 			Value:       serpent.DurationOf(&networkInfoInterval),
+		},
+		{
+			Flag:          "tty",
+			FlagShorthand: "t",
+			Env:           "CODER_SSH_TTY",
+			Description:   "Force pseudo-terminal allocation. Similar to the -t flag in OpenSSH. A PTY is always allocated when this flag is set, even when running a command.",
+			Value:         serpent.BoolOf(&tty),
+		},
+		{
+			Flag:          "no-tty",
+			FlagShorthand: "T",
+			Env:           "CODER_SSH_NO_TTY",
+			Description:   "Disable pseudo-terminal allocation. Similar to the -T flag in OpenSSH. A PTY is never allocated when this flag is set. By default, a PTY is allocated when a shell is opened and not when a command is specified.",
+			Value:         serpent.BoolOf(&noTTY),
 		},
 		{
 			Flag:          "container",

--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -651,11 +651,12 @@ func (r *RootCmd) ssh() *serpent.Command {
 			stdinIsTerminal := validIn && isatty.IsTerminal(stdinFile.Fd())
 
 			var wantPTY bool
-			if noTTY {
+			switch {
+			case noTTY:
 				wantPTY = false
-			} else if tty {
+			case tty:
 				wantPTY = true
-			} else {
+			default:
 				wantPTY = command == "" && stdinIsTerminal
 			}
 

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -1809,6 +1809,119 @@ func TestSSH(t *testing.T) {
 			})
 		}
 	})
+
+	// Verify that running a command via SSH does not allocate a PTY by
+	// default, keeping stdout and stderr as separate streams (matching
+	// OpenSSH behavior).
+	t.Run("NoPTYByDefault", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("Test not supported on windows")
+		}
+		t.Parallel()
+
+		client, workspace, agentToken := setupWorkspaceForAgent(t)
+		_ = agenttest.New(t, client.URL, agentToken)
+		coderdtest.AwaitWorkspaceAgents(t, client, workspace.ID)
+
+		// Use -- to separate the command from the coder ssh flags.
+		inv, root := clitest.New(t, "ssh", workspace.Name, "--", "sh", "-c", "echo stdout-msg; echo stderr-msg >&2")
+		clitest.SetupConfig(t, client, root)
+
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		inv.Stdout = stdout
+		inv.Stderr = stderr
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		err := inv.WithContext(ctx).Run()
+		require.NoError(t, err)
+
+		assert.Contains(t, stdout.String(), "stdout-msg")
+		assert.NotContains(t, stdout.String(), "stderr-msg")
+		assert.Contains(t, stderr.String(), "stderr-msg")
+		assert.NotContains(t, stderr.String(), "stdout-msg")
+	})
+
+	// Verify that --tty (-t) forces PTY allocation even when running a
+	// command, causing stdout and stderr to be merged.
+	t.Run("TTYFlag", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("Test not supported on windows")
+		}
+		t.Parallel()
+
+		client, workspace, agentToken := setupWorkspaceForAgent(t)
+		_ = agenttest.New(t, client.URL, agentToken)
+		coderdtest.AwaitWorkspaceAgents(t, client, workspace.ID)
+
+		inv, root := clitest.New(t, "ssh", "--tty", workspace.Name, "--", "sh", "-c", "echo stdout-msg; echo stderr-msg >&2")
+		clitest.SetupConfig(t, client, root)
+
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		inv.Stdout = stdout
+		inv.Stderr = stderr
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		err := inv.WithContext(ctx).Run()
+		require.NoError(t, err)
+
+		// With a PTY, both stdout and stderr are merged into the
+		// stdout stream by the remote PTY device.
+		combined := stdout.String()
+		assert.Contains(t, combined, "stdout-msg")
+		assert.Contains(t, combined, "stderr-msg")
+	})
+
+	// Verify that --no-tty (-T) prevents PTY allocation even for
+	// interactive sessions.
+	t.Run("NoTTYFlag", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("Test not supported on windows")
+		}
+		t.Parallel()
+
+		client, workspace, agentToken := setupWorkspaceForAgent(t)
+		_ = agenttest.New(t, client.URL, agentToken)
+		coderdtest.AwaitWorkspaceAgents(t, client, workspace.ID)
+
+		// Run with --no-tty and a command to verify the flag works.
+		inv, root := clitest.New(t, "ssh", "--no-tty", workspace.Name, "--", "echo", "hello")
+		clitest.SetupConfig(t, client, root)
+
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		inv.Stdout = stdout
+		inv.Stderr = stderr
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		err := inv.WithContext(ctx).Run()
+		require.NoError(t, err)
+
+		assert.Contains(t, stdout.String(), "hello")
+	})
+
+	// Verify that --tty and --no-tty are mutually exclusive.
+	t.Run("ConflictingTTYFlags", func(t *testing.T) {
+		t.Parallel()
+
+		// No workspace setup needed — validation fails before any
+		// network call.
+		inv, _ := clitest.New(t, "ssh", "--tty", "--no-tty", "anyworkspace", "echo", "hello")
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
+		defer cancel()
+
+		err := inv.WithContext(ctx).Run()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot specify both")
+	})
 }
 
 //nolint:paralleltest // This test uses t.Setenv, parent test MUST NOT be parallel.

--- a/cli/testdata/coder_ssh_--help.golden
+++ b/cli/testdata/coder_ssh_--help.golden
@@ -50,6 +50,12 @@ OPTIONS:
       --network-info-interval duration (default: 5s)
           Specifies the interval to update network information.
 
+      --no-tty bool, $CODER_SSH_NO_TTY
+          Disable pseudo-terminal allocation. Similar to the -T flag in
+          OpenSSH. A PTY is never allocated when this flag is set. By default,
+          a PTY is allocated when a shell is opened and not when a command is
+          specified.
+
       --no-wait bool, $CODER_SSH_NO_WAIT
           Enter workspace immediately after the agent has connected. This is the
           default if the template has configured the agent startup script
@@ -66,6 +72,11 @@ OPTIONS:
 
       --stdio bool, $CODER_SSH_STDIO
           Specifies whether to emit SSH output over stdin/stdout.
+
+  -t, --tty bool, $CODER_SSH_TTY
+          Force pseudo-terminal allocation. Similar to the -t flag in OpenSSH.
+          A PTY is always allocated when this flag is set, even when running a
+          command.
 
       --wait yes|no|auto, $CODER_SSH_WAIT (default: auto)
           Specifies whether or not to wait for the startup script to finish


### PR DESCRIPTION
Previously, `coder ssh` always requested a remote PTY, which merged stdout and stderr through the PTY even for non-interactive commands. Now `coder ssh` follows OpenSSH semantics: a PTY is allocated only for login sessions when stdin is a TTY. Commands like `coder ssh <ws> -- ls` now keep stdout and stderr as separate streams.

Add `--tty`/`-t` to force PTY allocation and `--no-tty`/`-T` to disable it, matching OpenSSH's `-t` and `-T` flags.

By matching the same defaults as `ssh`, this is technically a breaking change. Whereas stdout and stderr were unconditionally merged before, with this change, stdout and stderr will remain separate streams when passing a command to `coder ssh`. 

### AI disclosure

I authored this PR using claude code

### Evidence that it works

I tested a local client build against our production coder instance and it works as expected.

<img width="2616" height="188" alt="CleanShot 2026-04-21 at 21 20 37@2x" src="https://github.com/user-attachments/assets/5f79f8cf-e36e-4a4b-816b-bb2559c58f56" />


As code snippet:

```console
➜  coder git:(ssh-tty-optional) ./build/coder-slim_2.33.0-rc.2-devel+1203f625b_darwin_arm64 ssh a -- 'echo hello on std out; echo hello on stderr >&2' >/dev/null
hello on stderr
➜  coder git:(ssh-tty-optional) ./build/coder-slim_2.33.0-rc.2-devel+1203f625b_darwin_arm64 ssh a -- 'echo hello on std out; echo hello on stderr >&2' 2>/dev/null
hello on std out
```
