### PR TITLE
fix: grant AsAIBridged ResourceSystem.ActionCreate for UpsertAISeatState

### DIFF
--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -622,6 +622,7 @@ var (
 					},
 					rbac.ResourceApiKey.Type:               {policy.ActionRead}, // Validate API keys.
 					rbac.ResourceAibridgeInterception.Type: {policy.ActionCreate, policy.ActionRead, policy.ActionUpdate, policy.ActionDelete},
+					rbac.ResourceSystem.Type:               {policy.ActionCreate}, // Required for UpsertAISeatState.
 				}),
 				User:    []rbac.Permission{},
 				ByOrgID: map[string]rbac.OrgPermissions{},

--- a/enterprise/aiseats/tracker_test.go
+++ b/enterprise/aiseats/tracker_test.go
@@ -5,14 +5,19 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
+	"cdr.dev/slog/v3/sloggers/slogtest"
 	agplaiseats "github.com/coder/coder/v2/coderd/aiseats"
 	"github.com/coder/coder/v2/coderd/audit"
+	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/dbtime"
+	"github.com/coder/coder/v2/coderd/rbac"
 	enterpriseaiseats "github.com/coder/coder/v2/enterprise/aiseats"
 	"github.com/coder/coder/v2/testutil"
 	"github.com/coder/quartz"
@@ -35,6 +40,38 @@ func TestSeatTrackerDB(t *testing.T) {
 		count, err := db.GetActiveAISeatCount(ctx)
 		require.NoError(t, err)
 		require.EqualValues(t, 1, count)
+	})
+
+	// Regression test for coder/internal#1444: UpsertAISeatState must
+	// succeed when called through the AsAIBridged RBAC subject. The
+	// aibridged daemon context was missing ResourceSystem.ActionCreate,
+	// which caused the very first RecordUsage call per user to fail
+	// with "unauthorized: rbac: forbidden".
+	t.Run("AsAIBridgedRBAC", func(t *testing.T) {
+		t.Parallel()
+
+		rawDB, _ := dbtestutil.NewDB(t)
+		authz := rbac.NewStrictAuthorizer(prometheus.NewRegistry())
+		authzDB := dbauthz.New(rawDB, authz, slogtest.Make(t, nil), coderdtest.AccessControlStorePointer())
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		clock := quartz.NewMock(t)
+		tracker := enterpriseaiseats.New(authzDB, testutil.Logger(t), clock, nil)
+
+		// Insert a user directly in the raw DB so it exists for the
+		// foreign key reference.
+		user := dbgen.User(t, rawDB, database.User{Status: database.UserStatusActive})
+
+		// Call RecordUsage with the AIBridged context, mirroring the
+		// production call path in aibridgedserver.RecordInterception.
+		aibridgedCtx := dbauthz.AsAIBridged(ctx)
+		tracker.RecordUsage(aibridgedCtx, user.ID, agplaiseats.ReasonAIBridge("provider=test, model=test"))
+
+		// Verify the seat was actually recorded. A count of 0 means
+		// the upsert was silently rejected by RBAC.
+		count, err := rawDB.GetActiveAISeatCount(ctx)
+		require.NoError(t, err)
+		require.EqualValues(t, 1, count, "AI seat should be recorded when using AsAIBridged context")
 	})
 
 	t.Run("InactiveUsersExcluded", func(t *testing.T) {


### PR DESCRIPTION
## Problem

When a user connects to AI Bridge for the first time, `UpsertAISeatState` fails with `unauthorized: rbac: forbidden` because the `subjectAibridged` RBAC subject is missing `ResourceSystem.ActionCreate`.

`UpsertAISeatState` is called from two places via `SeatTracker.RecordUsage`:

1. **`enterprise/aibridgedserver/aibridgedserver.go`** — uses `AsAIBridged` context (broken)
2. **`coderd/provisionerdserver/provisionerdserver.go`** — uses `AsProvisionerd` context (works, because `subjectProvisionerd` has `ResourceSystem: {WildcardSymbol}`)

The error only surfaces on the first connection per user because the seat tracker throttles retries for 30 minutes after a failure (`failedThrottleInterval`), silencing subsequent attempts.

## Fix

Add `rbac.ResourceSystem.Type: {policy.ActionCreate}` to `subjectAibridged`. This is the minimal permission needed (principle of least privilege), matching how `subjectDBPurge` scopes `ResourceSystem` to a single action rather than using `WildcardSymbol`.

A regression test exercises the production call path: dbauthz-wrapped DB with a real authorizer and `AsAIBridged` context.

Fixes coder/internal#1444

> 🤖 Generated with [Coder Agents](https://coder.com/agents)