### PR TITLE
ci: pass github.repository through env var

### DIFF
--- a/.github/workflows/docs-preview.yaml
+++ b/.github/workflows/docs-preview.yaml
@@ -28,6 +28,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           BRANCH: ${{ github.event.pull_request.head.ref }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
         run: |
           # URL-encode the branch name so slashes and special
           # characters don't break the preview URL.
@@ -35,7 +36,7 @@ jobs:
           url="https://coder.com/docs/@${encoded}"
 
           gh pr comment "${PR_NUMBER}" \
-            --repo "${{ github.repository }}" \
+            --repo "${REPO}" \
             --body "## Docs preview
           [:book: View docs preview](${url})
 


### PR DESCRIPTION
*Disclaimer: implemented by a Coder Agent using Claude Opus 4.*

---

Move `github.repository` from direct `${{ }}` interpolation in the `run:`
block to an `env:` var, consistent with how `BRANCH` and `PR_NUMBER` are
already handled. This eliminates a `zizmor` template-injection finding.

Follows up on #24283.