### PR TITLE
test(coderd/x/chatd): seed anthropic provider for computer_use tests

### DIFF
--- a/coderd/x/chatd/subagent_context_internal_test.go
+++ b/coderd/x/chatd/subagent_context_internal_test.go
@@ -472,12 +472,11 @@ func TestSpawnComputerUseAgentInheritsContext(t *testing.T) {
 
 	db, ps := dbtestutil.NewDB(t)
 	require.NoError(t, db.UpsertChatDesktopEnabled(chatdTestContext(t), true))
-	server := newInternalTestServer(t, db, ps, chatprovider.ProviderAPIKeys{
-		Anthropic: "test-anthropic-key",
-	})
+	server := newInternalTestServer(t, db, ps, chatprovider.ProviderAPIKeys{})
 
 	ctx := chatdTestContext(t)
 	parentChat := createParentChatWithInheritedContext(ctx, t, db, server)
+	insertEnabledAnthropicProvider(ctx, t, db, parentChat.OwnerID)
 
 	tools := server.subagentTools(ctx, func() database.Chat { return parentChat }, parentChat.LastModelConfigID)
 	tool := findToolByName(tools, spawnAgentToolName)

--- a/coderd/x/chatd/subagent_internal_test.go
+++ b/coderd/x/chatd/subagent_internal_test.go
@@ -147,6 +147,30 @@ func seedInternalChatDeps(
 	return user, org, model
 }
 
+// seedEnabledAnthropicProvider inserts an enabled Anthropic provider for
+// the current test user so computer_use flows keep Anthropic credentials
+// after provider-key pruning.
+func seedEnabledAnthropicProvider(
+	ctx context.Context,
+	t *testing.T,
+	db database.Store,
+	userID uuid.UUID,
+) {
+	t.Helper()
+
+	_, err := db.InsertChatProvider(ctx, database.InsertChatProviderParams{
+		Provider:             "anthropic",
+		DisplayName:          "Anthropic",
+		APIKey:               "test-anthropic-key",
+		BaseUrl:              "",
+		ApiKeyKeyID:          sql.NullString{},
+		CreatedBy:            uuid.NullUUID{UUID: userID, Valid: true},
+		Enabled:              true,
+		CentralApiKeyEnabled: true,
+	})
+	require.NoError(t, err)
+}
+
 func insertInternalChatModelConfig(
 	ctx context.Context,
 	t *testing.T,
@@ -991,6 +1015,9 @@ func TestSubagentLifecycleToolsIncludePersistedSubagentTypeAcrossVariants(t *tes
 
 			ctx := chatdTestContext(t)
 			user, org, model := seedInternalChatDeps(ctx, t, db)
+			if tt.variant == subagentTypeComputerUse {
+				seedEnabledAnthropicProvider(ctx, t, db, user.ID)
+			}
 			parentChat := createInternalParentChat(
 				ctx,
 				t,
@@ -1127,6 +1154,7 @@ func TestSpawnAgent_ComputerUseUsesComputerUseModelNotParent(t *testing.T) {
 
 	ctx := chatdTestContext(t)
 	user, org, model := seedInternalChatDeps(ctx, t, db)
+	seedEnabledAnthropicProvider(ctx, t, db, user.ID)
 	workspace, build, agent := seedWorkspaceBinding(t, db, user.ID)
 
 	require.Equal(t, "openai", model.Provider, "seed helper must create an OpenAI model")
@@ -1185,6 +1213,7 @@ func TestSpawnAgent_ComputerUseInheritsMCPServerIDs(t *testing.T) {
 
 	ctx := chatdTestContext(t)
 	user, org, model := seedInternalChatDeps(ctx, t, db)
+	seedEnabledAnthropicProvider(ctx, t, db, user.ID)
 
 	mcpCfg, err := db.InsertMCPServerConfig(ctx, database.InsertMCPServerConfigParams{
 		DisplayName:   "MCP Test",

--- a/coderd/x/chatd/subagent_internal_test.go
+++ b/coderd/x/chatd/subagent_internal_test.go
@@ -147,10 +147,10 @@ func seedInternalChatDeps(
 	return user, org, model
 }
 
-// seedEnabledAnthropicProvider inserts an enabled Anthropic provider for
+// insertEnabledAnthropicProvider inserts an enabled Anthropic provider for
 // the current test user so computer_use flows keep Anthropic credentials
 // after provider-key pruning.
-func seedEnabledAnthropicProvider(
+func insertEnabledAnthropicProvider(
 	ctx context.Context,
 	t *testing.T,
 	db database.Store,
@@ -169,6 +169,46 @@ func seedEnabledAnthropicProvider(
 		CentralApiKeyEnabled: true,
 	})
 	require.NoError(t, err)
+}
+
+func TestResolveUserProviderAPIKeys_PreservesAnthropicKeyFromDBProvider(t *testing.T) {
+	t.Parallel()
+
+	t.Run("PreservesDBProviderKeyWithoutFallback", func(t *testing.T) {
+		t.Parallel()
+
+		db, ps := dbtestutil.NewDB(t)
+		server := newInternalTestServer(t, db, ps, chatprovider.ProviderAPIKeys{})
+
+		ctx := chatdTestContext(t)
+		user, _, _ := seedInternalChatDeps(ctx, t, db)
+		insertEnabledAnthropicProvider(ctx, t, db, user.ID)
+
+		keys, err := server.resolveUserProviderAPIKeys(ctx, user.ID)
+		require.NoError(t, err)
+		require.Equal(t, "test-anthropic-key", keys.Anthropic)
+		require.Equal(t, "test-anthropic-key", keys.APIKey("anthropic"))
+		require.Equal(t, "test-anthropic-key", keys.ByProvider["anthropic"])
+	})
+
+	t.Run("PrunesFallbackKeyWithoutEnabledProvider", func(t *testing.T) {
+		t.Parallel()
+
+		db, ps := dbtestutil.NewDB(t)
+		server := newInternalTestServer(t, db, ps, chatprovider.ProviderAPIKeys{
+			Anthropic: "test-anthropic-key",
+		})
+
+		ctx := chatdTestContext(t)
+		user, _, _ := seedInternalChatDeps(ctx, t, db)
+
+		keys, err := server.resolveUserProviderAPIKeys(ctx, user.ID)
+		require.NoError(t, err)
+		require.Empty(t, keys.Anthropic)
+		require.Empty(t, keys.APIKey("anthropic"))
+		_, ok := keys.ByProvider["anthropic"]
+		require.False(t, ok)
+	})
 }
 
 func insertInternalChatModelConfig(
@@ -1007,16 +1047,12 @@ func TestSubagentLifecycleToolsIncludePersistedSubagentTypeAcrossVariants(t *tes
 				require.NoError(t, db.UpsertChatDesktopEnabled(chatdTestContext(t), true))
 			}
 
-			providerKeys := chatprovider.ProviderAPIKeys{}
-			if tt.variant == subagentTypeComputerUse {
-				providerKeys = chatprovider.ProviderAPIKeys{Anthropic: "test-anthropic-key"}
-			}
-			server := newInternalTestServer(t, db, ps, providerKeys)
+			server := newInternalTestServer(t, db, ps, chatprovider.ProviderAPIKeys{})
 
 			ctx := chatdTestContext(t)
 			user, org, model := seedInternalChatDeps(ctx, t, db)
 			if tt.variant == subagentTypeComputerUse {
-				seedEnabledAnthropicProvider(ctx, t, db, user.ID)
+				insertEnabledAnthropicProvider(ctx, t, db, user.ID)
 			}
 			parentChat := createInternalParentChat(
 				ctx,
@@ -1148,13 +1184,11 @@ func TestSpawnAgent_ComputerUseUsesComputerUseModelNotParent(t *testing.T) {
 
 	db, ps := dbtestutil.NewDB(t)
 	require.NoError(t, db.UpsertChatDesktopEnabled(chatdTestContext(t), true))
-	server := newInternalTestServer(t, db, ps, chatprovider.ProviderAPIKeys{
-		Anthropic: "test-anthropic-key",
-	})
+	server := newInternalTestServer(t, db, ps, chatprovider.ProviderAPIKeys{})
 
 	ctx := chatdTestContext(t)
 	user, org, model := seedInternalChatDeps(ctx, t, db)
-	seedEnabledAnthropicProvider(ctx, t, db, user.ID)
+	insertEnabledAnthropicProvider(ctx, t, db, user.ID)
 	workspace, build, agent := seedWorkspaceBinding(t, db, user.ID)
 
 	require.Equal(t, "openai", model.Provider, "seed helper must create an OpenAI model")
@@ -1207,13 +1241,11 @@ func TestSpawnAgent_ComputerUseInheritsMCPServerIDs(t *testing.T) {
 
 	db, ps := dbtestutil.NewDB(t)
 	require.NoError(t, db.UpsertChatDesktopEnabled(chatdTestContext(t), true))
-	server := newInternalTestServer(t, db, ps, chatprovider.ProviderAPIKeys{
-		Anthropic: "test-anthropic-key",
-	})
+	server := newInternalTestServer(t, db, ps, chatprovider.ProviderAPIKeys{})
 
 	ctx := chatdTestContext(t)
 	user, org, model := seedInternalChatDeps(ctx, t, db)
-	seedEnabledAnthropicProvider(ctx, t, db, user.ID)
+	insertEnabledAnthropicProvider(ctx, t, db, user.ID)
 
 	mcpCfg, err := db.InsertMCPServerConfig(ctx, database.InsertMCPServerConfigParams{
 		DisplayName:   "MCP Test",


### PR DESCRIPTION
`TestSubagentLifecycleToolsIncludePersistedSubagentTypeAcrossVariants/ComputerUse`
and two adjacent positive tests passed a static Anthropic key into
`newInternalTestServer`, but `seedInternalChatDeps` only inserts an OpenAI
provider. At runtime, `Server.resolveUserProviderAPIKeys` calls
`chatprovider.PruneDisabledProviderKeys`, which clears `keys.Anthropic`
because Anthropic is not in the enabled DB provider set, so the
`computer_use` execution path loses its key.

Add a focused test helper `seedEnabledAnthropicProvider` and use it only in
the positive tests that actually drive a `computer_use` spawn through the
runtime key-resolution path (the `computer_use` branch of
`TestSubagentLifecycleToolsIncludePersistedSubagentTypeAcrossVariants`,
`TestSpawnAgent_ComputerUseUsesComputerUseModelNotParent`, and
`TestSpawnAgent_ComputerUseInheritsMCPServerIDs`). `seedInternalChatDeps`
stays unchanged, so the negative availability tests continue to model the
"Anthropic unavailable" fixture. No production code is modified.

Closes https://github.com/coder/internal/issues/1486

> This PR was opened by Mux working on Mike's behalf.
