### PR TITLE
fix: infer workspace from env in `coder support bundle`

### DIFF
--- a/cli/support.go
+++ b/cli/support.go
@@ -71,9 +71,9 @@ func (r *RootCmd) supportBundle() *serpent.Command {
 	var templateName string
 	var pprof bool
 	cmd := &serpent.Command{
-		Use:   "bundle <workspace> [<agent>]",
+		Use:   "bundle [<workspace>] [<agent>]",
 		Short: "Generate a support bundle to troubleshoot issues connecting to a workspace.",
-		Long:  `This command generates a file containing detailed troubleshooting information about the Coder deployment and workspace connections. You must specify a single workspace (and optionally an agent name).`,
+		Long:  `This command generates a file containing detailed troubleshooting information about the Coder deployment and workspace connections. You may specify a single workspace (and optionally an agent name). When run inside a workspace, the workspace and agent are inferred from the environment if not provided.`,
 		Middleware: serpent.Chain(
 			serpent.RequireRangeArgs(0, 2),
 		),
@@ -148,6 +148,38 @@ func (r *RootCmd) supportBundle() *serpent.Command {
 				agtID      uuid.UUID
 				templateID uuid.UUID
 			)
+
+			if len(inv.Args) == 0 {
+				// When running inside a workspace, infer the workspace
+				// and agent from environment variables set by the agent.
+				// Prefer CODER_WORKSPACE_ID for a direct UUID lookup;
+				// fall back to owner/name for older agents that do not
+				// set the ID variable.
+				if inv.Environ.Get("CODER") == "true" {
+					var wsArg string
+					if v := inv.Environ.Get("CODER_WORKSPACE_ID"); v != "" {
+						wsArg = v
+					} else {
+						wsOwner := inv.Environ.Get("CODER_WORKSPACE_OWNER_NAME")
+						wsName := inv.Environ.Get("CODER_WORKSPACE_NAME")
+						if wsOwner != "" && wsName != "" {
+							wsArg = wsOwner + "/" + wsName
+						}
+					}
+					agtName := inv.Environ.Get("CODER_WORKSPACE_AGENT_NAME")
+					if wsArg != "" {
+						cliLog.Info(inv.Context(), "detected workspace from environment",
+							slog.F("workspace_arg", wsArg),
+							slog.F("agent_name", agtName),
+						)
+						cliui.Info(inv.Stderr, "Detected workspace from environment: "+wsArg)
+						inv.Args = append(inv.Args, wsArg)
+						if agtName != "" {
+							inv.Args = append(inv.Args, agtName)
+						}
+					}
+				}
+			}
 
 			if len(inv.Args) == 0 {
 				cliLog.Warn(inv.Context(), "no workspace specified")

--- a/cli/support_test.go
+++ b/cli/support_test.go
@@ -118,6 +118,43 @@ func TestSupportBundle(t *testing.T) {
 		assertBundleContents(t, path, false, false, []string{secretValue})
 	})
 
+	t.Run("InferWorkspaceFromEnvByID", func(t *testing.T) {
+		t.Parallel()
+
+		d := t.TempDir()
+		path := filepath.Join(d, "bundle.zip")
+		// No workspace arg, but set env vars as if inside a workspace.
+		inv, root := clitest.New(t, "support", "bundle", "--output-file", path, "--yes")
+		inv.Environ.Set("CODER", "true")
+		inv.Environ.Set("CODER_WORKSPACE_ID", workspaceWithoutAgent.Workspace.ID.String())
+		inv.Environ.Set("CODER_WORKSPACE_AGENT_NAME", "dev")
+		//nolint: gocritic // requires owner privilege
+		clitest.SetupConfig(t, client, root)
+		err := inv.Run()
+		require.NoError(t, err)
+		// The workspace should be resolved, but there is no running agent.
+		assertBundleContents(t, path, true, false, []string{secretValue})
+	})
+
+	t.Run("InferWorkspaceFromEnvByName", func(t *testing.T) {
+		t.Parallel()
+
+		d := t.TempDir()
+		path := filepath.Join(d, "bundle.zip")
+		// No workspace arg and no CODER_WORKSPACE_ID; fall back to
+		// owner/name resolution for older agents.
+		inv, root := clitest.New(t, "support", "bundle", "--output-file", path, "--yes")
+		inv.Environ.Set("CODER", "true")
+		inv.Environ.Set("CODER_WORKSPACE_NAME", workspaceWithoutAgent.Workspace.Name)
+		inv.Environ.Set("CODER_WORKSPACE_OWNER_NAME", coderdtest.FirstUserParams.Username)
+		inv.Environ.Set("CODER_WORKSPACE_AGENT_NAME", "dev")
+		//nolint: gocritic // requires owner privilege
+		clitest.SetupConfig(t, client, root)
+		err := inv.Run()
+		require.NoError(t, err)
+		assertBundleContents(t, path, true, false, []string{secretValue})
+	})
+
 	t.Run("NoAgent", func(t *testing.T) {
 		t.Parallel()
 		d := t.TempDir()

--- a/cli/testdata/coder_support_bundle_--help.golden
+++ b/cli/testdata/coder_support_bundle_--help.golden
@@ -1,13 +1,14 @@
 coder v0.0.0-devel
 
 USAGE:
-  coder support bundle [flags] <workspace> [<agent>]
+  coder support bundle [flags] [<workspace>] [<agent>]
 
   Generate a support bundle to troubleshoot issues connecting to a workspace.
 
   This command generates a file containing detailed troubleshooting information
-  about the Coder deployment and workspace connections. You must specify a
-  single workspace (and optionally an agent name).
+  about the Coder deployment and workspace connections. You may specify a single
+  workspace (and optionally an agent name). When run inside a workspace, the
+  workspace and agent are inferred from the environment if not provided.
 
 OPTIONS:
   -O, --output-file string, $CODER_SUPPORT_BUNDLE_OUTPUT_FILE

--- a/docs/reference/cli/support_bundle.md
+++ b/docs/reference/cli/support_bundle.md
@@ -6,13 +6,13 @@ Generate a support bundle to troubleshoot issues connecting to a workspace.
 ## Usage
 
 ```console
-coder support bundle [flags] <workspace> [<agent>]
+coder support bundle [flags] [<workspace>] [<agent>]
 ```
 
 ## Description
 
 ```console
-This command generates a file containing detailed troubleshooting information about the Coder deployment and workspace connections. You must specify a single workspace (and optionally an agent name).
+This command generates a file containing detailed troubleshooting information about the Coder deployment and workspace connections. You may specify a single workspace (and optionally an agent name). When run inside a workspace, the workspace and agent are inferred from the environment if not provided.
 ```
 
 ## Options


### PR DESCRIPTION
When running `coder support bundle` inside a workspace without arguments, the command now infers the workspace and agent from the `CODER_WORKSPACE_NAME`, `CODER_WORKSPACE_OWNER_NAME`, and `CODER_WORKSPACE_AGENT_NAME` environment variables set by the workspace agent.

Previously, running without arguments inside a workspace produced an incomplete bundle with no workspace info, agent logs, or connection diagnostics, despite the environment having all the information needed to resolve the current workspace.

Also updates the usage string from `<workspace>` to `[<workspace>]` to reflect that the argument has always been optional.

Closes #24615

> [!NOTE]
> Generated by Coder Agents

<details>
<summary>Implementation notes</summary>

- Uses `inv.Environ.Get()` (testable via `inv.Environ.Set()`) rather than
  `os.Getenv` for the new env lookups, consistent with `cli/open.go`.
- The existing `os.LookupEnv("CODER")` warning on line 131 is left as-is
  to avoid unnecessary churn.
- When env vars are detected, args are injected as `owner/workspace` and
  the optional agent name, then the existing resolution logic runs
  unchanged.
- Falls through to the "no workspace specified" warning if env vars are
  missing or incomplete, so behavior is unchanged outside workspaces.

</details>