### PR TITLE
docs(coderd/x/chatd): improve edit_files tool description

### DIFF
--- a/coderd/x/chatd/chattool/editfiles.go
+++ b/coderd/x/chatd/chattool/editfiles.go
@@ -22,8 +22,12 @@ type EditFilesArgs struct {
 func EditFiles(options EditFilesOptions) fantasy.AgentTool {
 	return fantasy.NewAgentTool(
 		"edit_files",
-		"Perform search-and-replace edits on one or more files in the workspace."+
-			" Each file can have multiple edits applied atomically.",
+		"Perform search-and-replace edits on one or more files. Matching"+
+			" is fuzzy (tolerates whitespace and indentation differences) and"+
+			" preserves the file's existing indentation and line endings."+
+			" Errors if search matches zero locations, or more than one unless"+
+			" replace_all is set. All edits in a batch are validated before any"+
+			" file is written.",
 		func(ctx context.Context, args EditFilesArgs, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
 			var planPath string
 			if options.IsPlanTurn && len(args.Files) > 0 {


### PR DESCRIPTION
The tool description didn't document matching semantics, so callers assume naive exact-match. The new description (~45 words) adds: fuzzy whitespace/indentation matching, error on ambiguous matches, and atomic batch validation.

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻