### PR TITLE
fix(site): fix workspace unhealthy dialog stories

### DIFF
--- a/site/src/pages/WorkspacePage/WorkspaceNotifications/WorkspaceNotifications.stories.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceNotifications/WorkspaceNotifications.stories.tsx
@@ -55,10 +55,10 @@ export const Outdated: Story = {
 	},
 
 	play: async ({ step }) => {
-		await step("activate hover trigger", async () => {
-			await userEvent.hover(screen.getByTestId("info-notifications"));
+		await step("activate click trigger", async () => {
+			await userEvent.click(screen.getByTestId("info-notifications"));
 			await waitFor(() =>
-				expect(screen.getByRole("tooltip")).toHaveTextContent(
+				expect(screen.getByRole("dialog")).toHaveTextContent(
 					MockTemplateVersion.message,
 				),
 			);
@@ -73,10 +73,10 @@ export const OutdatedWithMarkdownMessage: Story = {
 	},
 
 	play: async ({ step }) => {
-		await step("activate hover trigger", async () => {
-			await userEvent.hover(screen.getByTestId("info-notifications"));
+		await step("activate click trigger", async () => {
+			await userEvent.click(screen.getByTestId("info-notifications"));
 			await waitFor(() =>
-				expect(screen.getByRole("tooltip")).toHaveTextContent(
+				expect(screen.getByRole("dialog")).toHaveTextContent(
 					/an update is available/i,
 				),
 			);
@@ -104,10 +104,10 @@ export const RequiresManualUpdate: Story = {
 	},
 
 	play: async ({ step }) => {
-		await step("activate hover trigger", async () => {
-			await userEvent.hover(screen.getByTestId("warning-notifications"));
+		await step("activate click trigger", async () => {
+			await userEvent.click(screen.getByTestId("warning-notifications"));
 			await waitFor(() =>
-				expect(screen.getByRole("tooltip")).toHaveTextContent(
+				expect(screen.getByRole("dialog")).toHaveTextContent(
 					/unable to automatically update/i,
 				),
 			);
@@ -153,9 +153,9 @@ export const StartupScriptFailed: Story = {
 
 	play: async ({ step }) => {
 		await step("shows startup script failure message", async () => {
-			await userEvent.hover(screen.getByTestId("warning-notifications"));
+			await userEvent.click(screen.getByTestId("warning-notifications"));
 			await waitFor(() =>
-				expect(screen.getByRole("tooltip")).toHaveTextContent(
+				expect(screen.getByRole("dialog")).toHaveTextContent(
 					/a startup script has failed/i,
 				),
 			);
@@ -178,10 +178,10 @@ export const AgentDisconnected: Story = {
 	},
 
 	play: async ({ step }) => {
-		await step("activate hover trigger", async () => {
-			await userEvent.hover(screen.getByTestId("warning-notifications"));
+		await step("activate click trigger", async () => {
+			await userEvent.click(screen.getByTestId("warning-notifications"));
 			await waitFor(() =>
-				expect(screen.getByRole("tooltip")).toHaveTextContent(
+				expect(screen.getByRole("dialog")).toHaveTextContent(
 					/one or more workspace agents need attention/i,
 				),
 			);
@@ -199,10 +199,10 @@ export const AgentTimeout: Story = {
 	},
 
 	play: async ({ step }) => {
-		await step("activate hover trigger", async () => {
-			await userEvent.hover(screen.getByTestId("warning-notifications"));
+		await step("activate click trigger", async () => {
+			await userEvent.click(screen.getByTestId("warning-notifications"));
 			await waitFor(() =>
-				expect(screen.getByRole("tooltip")).toHaveTextContent(
+				expect(screen.getByRole("dialog")).toHaveTextContent(
 					/one or more workspace agents need attention/i,
 				),
 			);
@@ -233,10 +233,10 @@ export const Dormant: Story = {
 	},
 
 	play: async ({ step }) => {
-		await step("activate hover trigger", async () => {
-			await userEvent.hover(screen.getByTestId("warning-notifications"));
+		await step("activate click trigger", async () => {
+			await userEvent.click(screen.getByTestId("warning-notifications"));
 			await waitFor(() =>
-				expect(screen.getByRole("tooltip")).toHaveTextContent(
+				expect(screen.getByRole("dialog")).toHaveTextContent(
 					/workspace is dormant/i,
 				),
 			);
@@ -273,10 +273,10 @@ export const PendingInQueue: Story = {
 	},
 
 	play: async ({ step }) => {
-		await step("activate hover trigger", async () => {
-			await userEvent.hover(await screen.findByTestId("info-notifications"));
+		await step("activate click trigger", async () => {
+			await userEvent.click(await screen.findByTestId("info-notifications"));
 			await waitFor(() =>
-				expect(screen.getByRole("tooltip")).toHaveTextContent(
+				expect(screen.getByRole("dialog")).toHaveTextContent(
 					/build is pending/i,
 				),
 			);
@@ -295,10 +295,10 @@ export const TemplateDeprecated: Story = {
 	},
 
 	play: async ({ step }) => {
-		await step("activate hover trigger", async () => {
-			await userEvent.hover(screen.getByTestId("warning-notifications"));
+		await step("activate click trigger", async () => {
+			await userEvent.click(screen.getByTestId("warning-notifications"));
 			await waitFor(() =>
-				expect(screen.getByRole("tooltip")).toHaveTextContent(
+				expect(screen.getByRole("dialog")).toHaveTextContent(
 					/deprecated template/i,
 				),
 			);


### PR DESCRIPTION
coder/coder#24536 changed the behavior of the ⚠️ from a tooltip (hover) to a popover (click). this is better for a11y, particularly keyboard navigation. this PR updates the storybook interaction tests to match

https://github.com/user-attachments/assets/94677b77-4925-4652-ae88-322ed087983b