### PR TITLE
ci: add permissions section to backport.yaml

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -21,6 +21,8 @@ on:
       - closed
       - labeled
 
+permissions: {}
+
 # Prevent duplicate runs for the same PR when both 'closed' and 'labeled'
 # fire in quick succession.
 concurrency:


### PR DESCRIPTION
Add an empty permissions section to the backport workflow to stop Openssf from complaining about a missing top-level permissions block. 