### PR TITLE
ci(.github/workflows/contrib): skip community label for dependabot

### DIFF
--- a/.github/workflows/contrib.yaml
+++ b/.github/workflows/contrib.yaml
@@ -69,6 +69,13 @@ jobs:
             // Use the org membership API as the source of truth.
             // See: https://github.com/actions/github-script/issues/643
             const author = context.payload.pull_request.user.login
+
+            // Dependabot is not a community contributor.
+            if (author === 'dependabot[bot]') {
+              console.log('Author "%s" is a bot, skipping.', author)
+              return
+            }
+
             try {
               await orgClient.rest.orgs.checkMembershipForUser({
                 org: context.repo.owner,


### PR DESCRIPTION
Dependabot PRs were not explicitly excluded from the community-label
job. Because `dependabot[bot]` is not an org member, the membership API
check would fail and the PR would be labeled as community.

Add an early return for the `dependabot[bot]` author before the org
membership lookup so dependabot PRs are never treated as community
contributions.

> Generated by Coder Agents