### PR TITLE
fix(cli): fix flaky TestExpAgentsE2E/ExistingChatHistory

### DIFF
--- a/cli/exp_agents_e2e_test.go
+++ b/cli/exp_agents_e2e_test.go
@@ -77,8 +77,14 @@ func TestExpAgentsE2E(t *testing.T) {
 		chat := seedChat(t, ctx, expClient, orgID, "direct open seed")
 		session := startExpAgentsSession(t, ctx, client, chat.ID.String())
 
+		// The initial render contains both the chat title/content
+		// and the status bar in a single frame. Their relative
+		// order in the PTY byte stream depends on async title
+		// generation, so matching them with separate sequential
+		// expects is racy. Instead, just confirm the seed text is
+		// visible (proving we are in the chat view), then verify
+		// esc navigates back to the list.
 		session.expect(ctx, "direct open seed")
-		session.expect(ctx, "esc")
 		session.esc()
 		session.expect(ctx, "enter: open")
 		session.quit()


### PR DESCRIPTION
- Remove racy sequential `expect("esc")` after `expect("direct open seed")`
- Both strings appear in the same initial PTY render; their byte-stream order depends on async title generation timing
- The seed text alone proves we are in the chat view; pressing esc + expecting `enter: open` confirms list navigation

> 🤖