### PR TITLE
feat(site): add Charm Crush client icon to AI Bridge UI

### DIFF
--- a/site/src/pages/AIBridgePage/RequestLogsPage/icons/AIBridgeClientIcon.tsx
+++ b/site/src/pages/AIBridgePage/RequestLogsPage/icons/AIBridgeClientIcon.tsx
@@ -71,6 +71,13 @@ export const AIBridgeClientIcon = ({
 					className={cn(iconClassName, className)}
 				/>
 			);
+		case "Charm Crush":
+			return (
+				<ExternalImage
+					src="/icon/charm-crush.svg"
+					className={cn(iconClassName, className)}
+				/>
+			);
 		case "GitHub Copilot (VS Code)":
 		case "GitHub Copilot (CLI)":
 			return (

--- a/site/src/theme/icons.json
+++ b/site/src/theme/icons.json
@@ -23,6 +23,7 @@
 	"azure.svg",
 	"bitbucket.svg",
 	"centos.svg",
+	"charm-crush.svg",
 	"claude.svg",
 	"clion.svg",
 	"code-insiders.svg",

--- a/site/static/icon/charm-crush.svg
+++ b/site/static/icon/charm-crush.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <text x="64" y="96" font-size="96" text-anchor="middle">💘</text>
+</svg>

--- a/site/static/icon/charm-crush.svg
+++ b/site/static/icon/charm-crush.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
-  <text x="64" y="96" font-size="96" text-anchor="middle">💘</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256">
+  <text x="128" y="192" font-size="192" text-anchor="middle">💘</text>
 </svg>


### PR DESCRIPTION
*Disclaimer: implemented by a Coder Agent using Claude Opus 4.6*

Follow-up to https://github.com/coder/coder/pull/24630 which added backend Charm Crush client detection.

## Summary

Adds a `"Charm Crush"` case to the `AIBridgeClientIcon` switch so the client filter and request logs show an icon instead of the generic question mark fallback.

Uses a 💘 emoji-based SVG as a placeholder, matching Crush's branding. Replace with an official brand SVG when one becomes available from the Charm team.

## Changes

- `site/static/icon/charm-crush.svg`: new emoji-based placeholder icon.
- `site/src/pages/AIBridgePage/RequestLogsPage/icons/AIBridgeClientIcon.tsx`: added `"Charm Crush"` case.