### PR TITLE
chore(dogfood): add CODER_AGENT_EXP_MCP_CONFIG_FILES env var

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -501,6 +501,7 @@ resource "coder_agent" "dev" {
   env = merge(
     {
       OIDC_TOKEN : data.coder_workspace_owner.me.oidc_access_token,
+      CODER_AGENT_EXP_MCP_CONFIG_FILES : "~/.mcp.json,.mcp.json",
     },
     data.coder_parameter.use_ai_bridge.value ? {
       ANTHROPIC_BASE_URL : "https://dev.coder.com/api/v2/aibridge/anthropic",


### PR DESCRIPTION
The Coder agent resolves `.mcp.json` relative to its manifest `Directory`,
which is `~/coder` in the dogfood template. A global `~/.mcp.json` is
invisible without explicitly listing it. Setting the env var to
`~/.mcp.json,.mcp.json` lets the agent discover both a global config
and the project-local one. Multiple files are merged; first wins on
name conflicts; missing files silently skipped.

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻