### PR TITLE
fix(coderd/x/chatd): fix flaky TestSpawnComputerUseAgentInheritsContext

### DIFF
--- a/coderd/x/chatd/subagent_context_internal_test.go
+++ b/coderd/x/chatd/subagent_context_internal_test.go
@@ -478,11 +478,10 @@ func TestSpawnComputerUseAgentInheritsContext(t *testing.T) {
 	parentChat := createParentChatWithInheritedContext(ctx, t, db, server)
 	insertEnabledAnthropicProvider(ctx, t, db, parentChat.OwnerID)
 	// The direct DB insert above bypasses the pubsub event that
-	// production uses to invalidate the provider cache. Without
-	// this, the background processing goroutine may have already
-	// cached the provider list (OpenAI only) before the Anthropic
-	// provider was inserted, causing isAnthropicConfigured to
-	// return false.
+	// production uses to invalidate the provider cache. Explicitly
+	// invalidate here so the background processing goroutine does
+	// not serve a stale provider list (OpenAI only) that was cached
+	// before the Anthropic provider was inserted.
 	server.configCache.InvalidateProviders()
 
 	tools := server.subagentTools(ctx, func() database.Chat { return parentChat }, parentChat.LastModelConfigID)

--- a/coderd/x/chatd/subagent_context_internal_test.go
+++ b/coderd/x/chatd/subagent_context_internal_test.go
@@ -477,6 +477,13 @@ func TestSpawnComputerUseAgentInheritsContext(t *testing.T) {
 	ctx := chatdTestContext(t)
 	parentChat := createParentChatWithInheritedContext(ctx, t, db, server)
 	insertEnabledAnthropicProvider(ctx, t, db, parentChat.OwnerID)
+	// The direct DB insert above bypasses the pubsub event that
+	// production uses to invalidate the provider cache. Without
+	// this, the background processing goroutine may have already
+	// cached the provider list (OpenAI only) before the Anthropic
+	// provider was inserted, causing isAnthropicConfigured to
+	// return false.
+	server.configCache.InvalidateProviders()
 
 	tools := server.subagentTools(ctx, func() database.Chat { return parentChat }, parentChat.LastModelConfigID)
 	tool := findToolByName(tools, spawnAgentToolName)


### PR DESCRIPTION
Fixes flaky `TestSpawnComputerUseAgentInheritsContext`.

- The test inserts an Anthropic provider directly into the DB after `CreateChat` has already been called
- The server's background goroutine may have already cached the provider list (OpenAI only) via `configCache.EnabledProviders()` with a 10s TTL
- The direct DB insert bypasses the pubsub event that production uses to invalidate the cache
- `isAnthropicConfigured()` returns the stale cached result, making `computer_use` appear unavailable
- Fix: call `server.configCache.InvalidateProviders()` after the insert, mirroring what production does via pubsub

CI failure: https://github.com/coder/coder/actions/runs/24829197096/job/72673070101?pr=24648

> 🤖