### PR TITLE
feat(coderd/x/chatd): make auto-titles keyword bags

### DIFF
--- a/coderd/x/chatd/quickgen.go
+++ b/coderd/x/chatd/quickgen.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"charm.land/fantasy"
 	"charm.land/fantasy/object"
@@ -29,13 +30,41 @@ import (
 	"github.com/coder/coder/v2/codersdk"
 )
 
-const titleGenerationPrompt = "Write a short title for the user's message. " +
-	"Populate the title field with the result. " +
-	"Return only the title text in 2-8 words. " +
-	"Do not answer the user or describe the title-writing task. " +
-	"Preserve specific identifiers such as PR numbers, repo names, file paths, function names, and error messages. " +
-	"If the message is short or vague, stay close to the user's wording instead of inventing context. " +
-	"Sentence case. No quotes, emoji, markdown, or trailing punctuation."
+// titleGenerationPrompt instructs the model to emit a keyword bag,
+// not a sentence. The first ~6 words of a chat title carry all the
+// visual scanability in the sidebar, so identifiers and domain
+// keywords must come first and generic framing verbs must be
+// dropped. renderManualTitlePrompt mirrors these rules for the
+// multi-turn manual-regeneration path; keep the two in sync when
+// editing either.
+const titleGenerationPrompt = "Write a short chat title as a bag of " +
+	"context-rich keywords, not a sentence. Populate the title field " +
+	"with the result.\n\n" +
+	"Rules:\n" +
+	"- 2-6 words. Fewer is better.\n" +
+	"- Lead with identifiers verbatim (issue keys, PR numbers, repo " +
+	"names, file paths, function names, error codes). Preserve their " +
+	"exact casing and punctuation.\n" +
+	"- After identifiers, add 1-3 keywords describing the subject or " +
+	"action. Prefer nouns and domain terms.\n" +
+	"- No filler: drop articles (a, an, the), conjunctions (and, or, " +
+	"but), and generic verbs (read, review, look, check, identify, " +
+	"find, fix, help, make, do, get, see, understand).\n" +
+	"- Not a sentence. No sentence case capitalization, no trailing " +
+	"punctuation, no quotes, no emoji, no markdown.\n" +
+	"- If the message is short or vague, stay close to the user's " +
+	"wording instead of inventing context.\n" +
+	"- Do not answer the user or describe the title-writing task.\n\n" +
+	"Examples:\n" +
+	"- User: \"Can you read FOOBAR-123 and identify a fix?\"\n" +
+	"  Title: FOOBAR-123 fix investigation\n" +
+	"- User: \"The frobulator in pkg/foo/bar.go keeps panicking on nil " +
+	"inputs\"\n" +
+	"  Title: pkg/foo/bar.go frobulator nil panic\n" +
+	"- User: \"help me understand how useEffect works in React\"\n" +
+	"  Title: React useEffect semantics\n" +
+	"- User: \"PR #4821 is failing CI on the windows runner\"\n" +
+	"  Title: PR #4821 windows CI failure"
 
 const (
 	// maxConversationContextRunes caps the conversation sample in manual
@@ -454,8 +483,14 @@ func validateGeneratedTitle(title string) error {
 	if title == "" {
 		return xerrors.New("generated title was empty")
 	}
-	if len(strings.Fields(title)) > 8 {
-		return xerrors.New("generated title exceeded 8 words")
+	// Rune count, not word count: the concept of a "word" is fuzzy
+	// across scripts (CJK has no spaces, agglutinative languages pack
+	// multiple tokens per "word"). 60 runes sits below the 80-rune
+	// truncation in normalizeTitleOutput so validation can actually
+	// fire and trigger the fallback-model retry cascade; truncation
+	// remains a last-resort safety net.
+	if utf8.RuneCountInString(title) > 60 {
+		return xerrors.New("generated title exceeded 60 runes")
 	}
 	return nil
 }
@@ -676,7 +711,8 @@ func renderManualTitlePrompt(
 		_, _ = prompt.WriteString(value)
 	}
 
-	write("Write a short title for this AI coding conversation.\n")
+	write("Write a short chat title as a bag of context-rich keywords, ")
+	write("not a sentence.\n")
 	write("Populate the title field with the result.\n\n")
 	write("Primary user objective:\n<primary_objective>\n")
 	write(firstUserText)
@@ -696,12 +732,21 @@ func renderManualTitlePrompt(
 	}
 
 	write("\n\nRequirements:\n")
-	write("- Return only the title text in 2-8 words.\n")
+	write("- 2-6 words. Fewer is better.\n")
 	write("- Populate the title field only.\n")
+	write("- Lead with identifiers verbatim (issue keys, PR numbers, ")
+	write("repo names, file paths, function names, error codes). ")
+	write("Preserve their exact casing and punctuation.\n")
+	write("- After identifiers, add 1-3 keywords describing the ")
+	write("subject or action. Prefer nouns and domain terms.\n")
+	write("- No filler: drop articles (a, an, the), conjunctions (and, ")
+	write("or, but), and generic verbs (read, review, look, check, ")
+	write("identify, find, fix, help, make, do, get, see, understand).\n")
+	write("- Not a sentence. No sentence case capitalization, no ")
+	write("trailing punctuation, no quotes, no emoji, no markdown.\n")
+	write("- If the conversation is short or vague, stay close to the ")
+	write("user's wording.\n")
 	write("- Do not answer the user or describe the title-writing task.\n")
-	write("- Preserve specific identifiers (PR numbers, repo names, file paths, function names, error messages).\n")
-	write("- If the conversation is short or vague, stay close to the user's wording.\n")
-	write("- Sentence case. No quotes, emoji, markdown, or trailing punctuation.\n")
 	return prompt.String()
 }
 

--- a/coderd/x/chatd/quickgen.go
+++ b/coderd/x/chatd/quickgen.go
@@ -45,6 +45,9 @@ const titleGenerationPrompt = "Write a short chat title as a bag of " +
 	"- Lead with identifiers verbatim (issue keys, PR numbers, repo " +
 	"names, file paths, function names, error codes). Preserve their " +
 	"exact casing and punctuation.\n" +
+	"- For deep file paths (more than ~3 segments), prefer the " +
+	"basename (e.g. WorkspaceSchedulePage.tsx) over the full path. " +
+	"Keep the full path only when disambiguation is necessary.\n" +
 	"- After identifiers, add 1-3 keywords describing the subject or " +
 	"action. Prefer nouns and domain terms.\n" +
 	"- No filler: drop articles (a, an, the), conjunctions (and, or, " +
@@ -57,7 +60,7 @@ const titleGenerationPrompt = "Write a short chat title as a bag of " +
 	"- Do not answer the user or describe the title-writing task.\n\n" +
 	"Examples:\n" +
 	"- User: \"Can you read FOOBAR-123 and identify a fix?\"\n" +
-	"  Title: FOOBAR-123 fix investigation\n" +
+	"  Title: FOOBAR-123 investigation\n" +
 	"- User: \"The frobulator in pkg/foo/bar.go keeps panicking on nil " +
 	"inputs\"\n" +
 	"  Title: pkg/foo/bar.go frobulator nil panic\n" +
@@ -75,6 +78,18 @@ const (
 	// recentTurnWindow is the number of most recent turns included
 	// alongside the first user turn in manual title context.
 	recentTurnWindow = 3
+	// maxGeneratedTitleRunes is the validator's hard ceiling on LLM
+	// title output. Sits below titleTruncationRunes so validation
+	// rejects overlong output before truncation silently clips it,
+	// giving the candidate-model fallback in maybeGenerateChatTitle a
+	// chance to try a different model. The error message in
+	// validateGeneratedTitle embeds the literal number for log
+	// grep-ability; keep them in sync.
+	maxGeneratedTitleRunes = 60
+	// titleTruncationRunes is the last-resort safety net in
+	// normalizeTitleOutput. Anything past this is clipped with no
+	// feedback to the caller.
+	titleTruncationRunes = 80
 )
 
 // preferredTitleModels are lightweight models used for title
@@ -485,11 +500,15 @@ func validateGeneratedTitle(title string) error {
 	}
 	// Rune count, not word count: the concept of a "word" is fuzzy
 	// across scripts (CJK has no spaces, agglutinative languages pack
-	// multiple tokens per "word"). 60 runes sits below the 80-rune
-	// truncation in normalizeTitleOutput so validation can actually
-	// fire and trigger the fallback-model retry cascade; truncation
-	// remains a last-resort safety net.
-	if utf8.RuneCountInString(title) > 60 {
+	// multiple tokens per "word"). maxGeneratedTitleRunes sits below
+	// titleTruncationRunes so validation rejects overlong output
+	// before normalizeTitleOutput silently clips it. A rejected title
+	// falls through to the next candidate model in
+	// maybeGenerateChatTitle's candidate loop; truncation remains a
+	// last-resort safety net if validation is ever skipped.
+	if utf8.RuneCountInString(title) > maxGeneratedTitleRunes {
+		// Error literal embeds the rune count so log searches stay
+		// stable; keep the number in sync with the constant above.
 		return xerrors.New("generated title exceeded 60 runes")
 	}
 	return nil
@@ -549,7 +568,7 @@ func normalizeTitleOutput(title string) string {
 	if title == "" {
 		return ""
 	}
-	return truncateRunes(title, 80)
+	return truncateRunes(title, titleTruncationRunes)
 }
 
 func fallbackChatTitle(message string) string {
@@ -737,6 +756,10 @@ func renderManualTitlePrompt(
 	write("- Lead with identifiers verbatim (issue keys, PR numbers, ")
 	write("repo names, file paths, function names, error codes). ")
 	write("Preserve their exact casing and punctuation.\n")
+	write("- For deep file paths (more than ~3 segments), prefer the ")
+	write("basename (e.g. WorkspaceSchedulePage.tsx) over the full ")
+	write("path. Keep the full path only when disambiguation is ")
+	write("necessary.\n")
 	write("- After identifiers, add 1-3 keywords describing the ")
 	write("subject or action. Prefer nouns and domain terms.\n")
 	write("- No filler: drop articles (a, an, the), conjunctions (and, ")

--- a/coderd/x/chatd/quickgen_test.go
+++ b/coderd/x/chatd/quickgen_test.go
@@ -337,6 +337,12 @@ func Test_renderManualTitlePrompt(t *testing.T) {
 			require.Contains(t, prompt, "Do not answer the user or describe the title-writing task")
 			require.Contains(t, prompt, "stay close to the user's wording")
 
+			// Mirror key rule assertions from the single-message prompt
+			// so silent drift between the two surfaces fails tests.
+			require.Contains(t, prompt, "No filler")
+			require.Contains(t, prompt, "basename")
+			require.Contains(t, prompt, "Lead with identifiers verbatim")
+
 			if tt.wantConversationSample {
 				require.Contains(t, prompt, "Conversation sample:")
 				require.Contains(t, prompt, tt.conversationBlock)
@@ -370,7 +376,14 @@ func Test_titleGenerationPrompt_UsesSlimRules(t *testing.T) {
 
 	// At least one few-shot example that mirrors the user's
 	// reference transformation, pinning the expected output shape.
-	require.Contains(t, titleGenerationPrompt, "FOOBAR-123")
+	// The example's title must not itself contain a banned filler
+	// verb (see "No filler" rule above) or the prompt contradicts
+	// itself.
+	require.Contains(t, titleGenerationPrompt, "FOOBAR-123 investigation")
+	require.NotContains(t, titleGenerationPrompt, "FOOBAR-123 fix investigation")
+
+	// Basename guidance for deep file paths.
+	require.Contains(t, titleGenerationPrompt, "basename")
 
 	// Preserved guidance.
 	require.Contains(t, titleGenerationPrompt, "stay close to the user's wording")
@@ -381,9 +394,11 @@ func Test_titleGenerationPrompt_UsesSlimRules(t *testing.T) {
 func Test_validateGeneratedTitle(t *testing.T) {
 	t.Parallel()
 
-	// 60 runes exactly. Use ASCII so len == rune count.
-	sixtyRunes := strings.Repeat("a", 60)
-	sixtyOneRunes := strings.Repeat("a", 61)
+	// Use the constant as the source of truth so the test tracks
+	// any future adjustment to the cap. ASCII keeps len == rune
+	// count for readability.
+	atCap := strings.Repeat("a", maxGeneratedTitleRunes)
+	overCap := strings.Repeat("a", maxGeneratedTitleRunes+1)
 
 	tests := []struct {
 		name      string
@@ -399,19 +414,19 @@ func Test_validateGeneratedTitle(t *testing.T) {
 		},
 		{
 			name:    "short title accepted",
-			title:   "FOOBAR-123 fix investigation",
+			title:   "FOOBAR-123 investigation",
 			wantErr: false,
 		},
 		{
-			name:    "sixty runes accepted",
-			title:   sixtyRunes,
+			name:    "at cap accepted",
+			title:   atCap,
 			wantErr: false,
 		},
 		{
-			name:      "sixty one runes rejected",
-			title:     sixtyOneRunes,
+			name:      "over cap rejected",
+			title:     overCap,
 			wantErr:   true,
-			errSubstr: "60",
+			errSubstr: "60 runes",
 		},
 		{
 			// Rune counting is script-agnostic: a short CJK title with

--- a/coderd/x/chatd/quickgen_test.go
+++ b/coderd/x/chatd/quickgen_test.go
@@ -331,7 +331,9 @@ func Test_renderManualTitlePrompt(t *testing.T) {
 
 			require.Contains(t, prompt, "Primary user objective:")
 			require.Contains(t, prompt, "Requirements:")
-			require.Contains(t, prompt, "- Return only the title text in 2-8 words.")
+			require.Contains(t, prompt, "- 2-6 words. Fewer is better.")
+			require.Contains(t, prompt, "bag of context-rich keywords")
+			require.NotContains(t, prompt, "2-8 words")
 			require.Contains(t, prompt, "Do not answer the user or describe the title-writing task")
 			require.Contains(t, prompt, "stay close to the user's wording")
 
@@ -357,10 +359,83 @@ func Test_renderManualTitlePrompt(t *testing.T) {
 func Test_titleGenerationPrompt_UsesSlimRules(t *testing.T) {
 	t.Parallel()
 
-	require.Contains(t, titleGenerationPrompt, "Return only the title text in 2-8 words")
-	require.Contains(t, titleGenerationPrompt, "Do not answer the user or describe the title-writing task")
+	// Keyword-bag framing and filler-word ban.
+	require.Contains(t, titleGenerationPrompt, "bag of context-rich keywords")
+	require.Contains(t, titleGenerationPrompt, "No filler")
+
+	// Tightened word cap (soft guidance to the model; validator
+	// enforces a rune cap separately).
+	require.Contains(t, titleGenerationPrompt, "2-6 words")
+	require.NotContains(t, titleGenerationPrompt, "2-8 words")
+
+	// At least one few-shot example that mirrors the user's
+	// reference transformation, pinning the expected output shape.
+	require.Contains(t, titleGenerationPrompt, "FOOBAR-123")
+
+	// Preserved guidance.
 	require.Contains(t, titleGenerationPrompt, "stay close to the user's wording")
+	require.Contains(t, titleGenerationPrompt, "Do not answer the user or describe the title-writing task")
 	require.NotContains(t, titleGenerationPrompt, "I am a title generator")
+}
+
+func Test_validateGeneratedTitle(t *testing.T) {
+	t.Parallel()
+
+	// 60 runes exactly. Use ASCII so len == rune count.
+	sixtyRunes := strings.Repeat("a", 60)
+	sixtyOneRunes := strings.Repeat("a", 61)
+
+	tests := []struct {
+		name      string
+		title     string
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:      "empty rejected",
+			title:     "",
+			wantErr:   true,
+			errSubstr: "empty",
+		},
+		{
+			name:    "short title accepted",
+			title:   "FOOBAR-123 fix investigation",
+			wantErr: false,
+		},
+		{
+			name:    "sixty runes accepted",
+			title:   sixtyRunes,
+			wantErr: false,
+		},
+		{
+			name:      "sixty one runes rejected",
+			title:     sixtyOneRunes,
+			wantErr:   true,
+			errSubstr: "60",
+		},
+		{
+			// Rune counting is script-agnostic: a short CJK title with
+			// no whitespace is fine even though strings.Fields would
+			// have treated it as a single word.
+			name:    "short CJK title accepted",
+			title:   "修复FOOBAR-123崩溃问题",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateGeneratedTitle(tt.title)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errSubstr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
 }
 
 func Test_generateManualTitle_UsesTimeout(t *testing.T) {


### PR DESCRIPTION
Auto-generated chat titles were sentence-shaped (`"Read FOOBAR-123 and identify a fix"`), pushing identifiers out of the scannable first-six-words window. This change reshapes them into keyword bags (`"FOOBAR-123 fix investigation"`).

## Changes

- Rewrite `titleGenerationPrompt`: keyword-bag framing, explicit filler-word ban, 2-6 word soft cap, four few-shot examples covering issue keys, file paths, camelCase identifiers, and PR numbers.
- Mirror the same rules in `renderManualTitlePrompt`'s `Requirements:` block (no examples there; conversation context already competes for tokens).
- `validateGeneratedTitle` now caps by rune count (60) instead of word count. The concept of a "word" is too fuzzy across scripts; rune count is objective.
- Add `Test_validateGeneratedTitle`; update existing prompt-assertion tests.

<details>
<summary>Decision log</summary>

- **Validator uses runes, not words.** CJK has no word separators; agglutinative languages pack multiple tokens per "word". Rune count is script-agnostic. The prompt still nudges the model toward `2-6 words` as soft guidance.
- **Validator ceiling 60 runes.** Below the existing 80-rune `truncateRunes` in `normalizeTitleOutput`, so validation can actually fire and trigger the fallback-model retry cascade; truncation stays as a last-resort safety net.
- **No i18n.** Project has no existing i18n layer. Prompt is English; filler-word enumeration is English. Validator behaves sanely across scripts by virtue of using runes.
- **Filler-word rejection stays at prompt level, not validator.** `fix` is sometimes the right keyword (`CI fix`); validator-level rejection would force a retry cascade across candidate models. Prompt + examples carry it.
- **Deterministic fallback paths (`fallbackChatTitle`, `subagentFallbackChatTitle`) left alone** per review: reshaping them is a separate change with its own tradeoffs.
- **`pushSummaryPrompt` unchanged**: notification bodies intentionally are sentences.

</details>

<details>
<summary>Implementation plan</summary>

Followed [TDD: red → green → refactor](https://www.conventionalcommits.org/). Phase 1 added failing tests for the new prompt content, validator behavior, and the updated `Requirements:` block. Phase 2 rewrote the prompts and validator. Phase 3 verified formatting, emdash lint, and full-package test run.

</details>

> 🤖 This PR was generated by Coder Agents on behalf of @johnstcn.