### PR TITLE
chore: deprecate /api/v2/aibridge/interceptions endpoint

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -122,6 +122,7 @@ const docTemplate = `{
                 ],
                 "summary": "List AI Bridge interceptions",
                 "operationId": "list-ai-bridge-interceptions",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -95,6 +95,7 @@
 				"tags": ["AI Bridge"],
 				"summary": "List AI Bridge interceptions",
 				"operationId": "list-ai-bridge-interceptions",
+				"deprecated": true,
 				"parameters": [
 					{
 						"type": "string",

--- a/codersdk/aibridge.go
+++ b/codersdk/aibridge.go
@@ -280,6 +280,9 @@ func (f AIBridgeListSessionsFilter) asRequestOption() RequestOption {
 
 // AIBridgeListInterceptions returns AI Bridge interceptions with the given
 // filter.
+//
+// Deprecated: Use AIBridgeListSessions instead, which provides richer
+// session-level aggregation including threads and agentic actions.
 func (c *Client) AIBridgeListInterceptions(ctx context.Context, filter AIBridgeListInterceptionsFilter) (AIBridgeListInterceptionsResponse, error) {
 	res, err := c.Request(ctx, http.MethodGet, "/api/v2/aibridge/interceptions", nil, filter.asRequestOption(), filter.Pagination.asRequestOption(), filter.Pagination.asRequestOption())
 	if err != nil {

--- a/enterprise/coderd/aibridge.go
+++ b/enterprise/coderd/aibridge.go
@@ -110,8 +110,6 @@ func aibridgeHandler(api *API, middlewares ...func(http.Handler) http.Handler) f
 // @Router /aibridge/interceptions [get]
 // @Deprecated Use /aibridge/sessions instead.
 func (api *API) aiBridgeListInterceptions(rw http.ResponseWriter, r *http.Request) {
-	rw.Header().Set("Deprecated", "true")
-
 	ctx := r.Context()
 	apiKey := httpmw.APIKey(r)
 

--- a/enterprise/coderd/aibridge.go
+++ b/enterprise/coderd/aibridge.go
@@ -92,7 +92,10 @@ func aibridgeHandler(api *API, middlewares ...func(http.Handler) http.Handler) f
 }
 
 // aiBridgeListInterceptions returns all AI Bridge interceptions a user can read.
-// Optional filters with query params
+// Optional filters with query params.
+//
+// Deprecated: Use /aibridge/sessions instead, which provides richer
+// session-level aggregation including threads and agentic actions.
 //
 // @Summary List AI Bridge interceptions
 // @ID list-ai-bridge-interceptions
@@ -105,7 +108,10 @@ func aibridgeHandler(api *API, middlewares ...func(http.Handler) http.Handler) f
 // @Param offset query int false "Offset pagination (cannot be used with after_id)"
 // @Success 200 {object} codersdk.AIBridgeListInterceptionsResponse
 // @Router /aibridge/interceptions [get]
+// @Deprecated Use /aibridge/sessions instead.
 func (api *API) aiBridgeListInterceptions(rw http.ResponseWriter, r *http.Request) {
+	rw.Header().Set("Deprecated", "true")
+
 	ctx := r.Context()
 	apiKey := httpmw.APIKey(r)
 


### PR DESCRIPTION
*Disclaimer: implemented by a Coder Agent using Claude Opus 4.6*

Marks the `GET /api/v2/aibridge/interceptions` endpoint as deprecated in favor of `/aibridge/sessions`, which provides richer session-level aggregation including threads and agentic actions.

Changes:
- Add `@Deprecated` Swagger annotation to the endpoint handler
- Add deprecation notice to the `codersdk.Client.AIBridgeListInterceptions` method
- Regenerated OpenAPI spec with `"deprecated": true` flag

The endpoint remains fully functional.

Fixes https://github.com/coder/internal/issues/1339