### PR TITLE
fix(site): fall back to username when initiator name is empty in AI Bridge pages

### DIFF
--- a/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.tsx
+++ b/site/src/pages/AIBridgePage/ListSessionsPage/ListSessionsRow.tsx
@@ -56,7 +56,7 @@ export const ListSessionsRow: FC<ListSessionsRowProps> = ({
 							className="flex-shrink-0"
 						/>
 						<div className="font-normal truncate min-w-0 flex-1 overflow-hidden">
-							{session.initiator.name ?? session.initiator.username}
+							{session.initiator.name || session.initiator.username}
 						</div>
 					</div>
 				</div>

--- a/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsRow/RequestLogsRow.tsx
+++ b/site/src/pages/AIBridgePage/RequestLogsPage/RequestLogsRow/RequestLogsRow.tsx
@@ -160,7 +160,7 @@ export const RequestLogsRow: FC<RequestLogsRowProps> = ({ interception }) => {
 								className="flex-shrink-0"
 							/>
 							<div className="font-medium truncate min-w-0 flex-1 overflow-hidden">
-								{interception.initiator.name ?? interception.initiator.username}
+								{interception.initiator.name || interception.initiator.username}
 							</div>
 						</div>
 					</div>
@@ -270,7 +270,7 @@ export const RequestLogsRow: FC<RequestLogsRowProps> = ({ interception }) => {
 										className="flex-shrink-0"
 									/>
 									<span className="truncate min-w-0 w-full">
-										{interception.initiator.name ??
+										{interception.initiator.name ||
 											interception.initiator.username}
 									</span>
 								</dd>

--- a/site/src/pages/AIBridgePage/SessionThreadsPage/SessionSummaryTable.stories.tsx
+++ b/site/src/pages/AIBridgePage/SessionThreadsPage/SessionSummaryTable.stories.tsx
@@ -56,3 +56,13 @@ export const LargeTokenCounts: Story = {
 		outputTokens: 32_000,
 	},
 };
+
+export const EmptyInitiatorName: Story = {
+	args: {
+		...Default.args,
+		initiator: {
+			...MockSession.initiator,
+			name: "",
+		},
+	},
+};

--- a/site/src/pages/AIBridgePage/SessionThreadsPage/SessionSummaryTable.tsx
+++ b/site/src/pages/AIBridgePage/SessionThreadsPage/SessionSummaryTable.tsx
@@ -36,6 +36,8 @@ export const SessionSummaryTable = ({
 	toolCallCount,
 	tokenUsageMetadata,
 }: SessionSummaryTableProps) => {
+	const initiatorDisplayName = initiator.name || initiator.username;
+
 	const durationInMs =
 		endTime !== undefined
 			? new Date(endTime).getTime() - new Date(startTime).getTime()
@@ -88,10 +90,10 @@ export const SessionSummaryTable = ({
 					<Avatar
 						size="sm"
 						src={initiator.avatar_url}
-						fallback={initiator.name}
+						fallback={initiatorDisplayName}
 					/>
-					<span className="truncate min-w-0" title={initiator.name}>
-						{initiator.name}
+					<span className="truncate min-w-0" title={initiatorDisplayName}>
+						{initiatorDisplayName}
 					</span>
 				</dd>
 			</div>

--- a/site/src/pages/AIBridgePage/SessionThreadsPage/SessionTimeline/SessionTimeline.tsx
+++ b/site/src/pages/AIBridgePage/SessionThreadsPage/SessionTimeline/SessionTimeline.tsx
@@ -288,7 +288,7 @@ const ThreadItem: FC<ThreadItemProps> = ({ thread, initiator }) => {
 				<div className="flex flex-row items-center gap-1">
 					<Avatar
 						src={initiator.avatar_url}
-						fallback={initiator.name ?? initiator.username}
+						fallback={initiator.name || initiator.username}
 						size="sm"
 						className="flex-shrink-0"
 					/>


### PR DESCRIPTION
*Disclaimer: implemented by a Coder Agent using Claude Opus 4.6*

## Problem

The initiator field in AI Bridge session pages shows an empty avatar and no display name when the user's human-readable name is not set (the "Name" field in Account settings is optional).

## Root cause

Two issues across the AI Bridge UI components:

1. **`SessionSummaryTable`** used `initiator.name` directly with no fallback to `username` at all.
2. **`ListSessionsRow`**, **`RequestLogsRow`**, and **`SessionTimeline`** used the nullish coalescing operator (`??`) which only catches `null`/`undefined`, not empty strings (`""`).

## Fix

- `SessionSummaryTable`: compute `initiatorDisplayName = initiator.name || initiator.username` and use it for the avatar fallback, title, and display text.
- All other occurrences: replace `??` with `||` so empty strings also fall back to `username`.
- Added an `EmptyInitiatorName` story to `SessionSummaryTable.stories.tsx` for visual regression coverage.

## Files changed

| File | Change |
|------|--------|
| `SessionSummaryTable.tsx` | Add username fallback for avatar and display name |
| `SessionSummaryTable.stories.tsx` | Add `EmptyInitiatorName` story |
| `ListSessionsRow.tsx` | `??` -> `||` for name display |
| `RequestLogsRow.tsx` | `??` -> `||` in both collapsed and expanded views |
| `SessionTimeline.tsx` | `??` -> `||` for avatar fallback |