### PR TITLE
fix(site): fix OpensAdminSubPanelOnMobile story on mobile viewport

### DIFF
--- a/site/src/pages/AgentsPage/AgentsPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageView.stories.tsx
@@ -701,10 +701,17 @@ export const OpensAdminSubPanelOnMobile: Story = {
 	},
 	parameters: {
 		viewport: { defaultViewport: "mobile1" },
+		reactRouter: reactRouterParameters({
+			location: { path: "/agents/settings" },
+			routing: agentsRouting,
+		}),
 	},
-	play: async ({ canvasElement }) => {
-		await openSettingsView(canvasElement);
-		await userEvent.click(screen.getByRole("link", { name: "Manage Agents" }));
+	play: async () => {
+		// On mobile the sidebar gear icon is hidden, so start on the
+		// settings route directly and navigate to the admin sub-panel.
+		await userEvent.click(
+			await screen.findByRole("link", { name: "Manage Agents" }),
+		);
 
 		await expect(
 			await screen.findByRole("link", { name: "Providers" }),

--- a/site/src/pages/AgentsPage/AgentsPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageView.stories.tsx
@@ -707,8 +707,6 @@ export const OpensAdminSubPanelOnMobile: Story = {
 		}),
 	},
 	play: async () => {
-		// On mobile the sidebar gear icon is hidden, so start on the
-		// settings route directly and navigate to the admin sub-panel.
 		await userEvent.click(
 			await screen.findByRole("link", { name: "Manage Agents" }),
 		);


### PR DESCRIPTION
`OpensAdminSubPanelOnMobile` story has been failing due to not finding a role="link" with name "Settings". 

Agent investigated and claimed the Settings icon gets hidden in mobile view.
Suggested fix is to start the story directly at `/agents/settings`.

> Generated with [Coder Agents](https://coder.com/agents)