### PR TITLE
feat(aibridge): add key pool with state tracking and walker

### DIFF
--- a/aibridge/keypool/keypool.go
+++ b/aibridge/keypool/keypool.go
@@ -1,0 +1,197 @@
+package keypool
+
+import (
+	"sync"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"github.com/coder/quartz"
+)
+
+// KeyState represents the current state of a key in the pool.
+type KeyState int
+
+const (
+	// KeyStateValid means the key is available for use.
+	KeyStateValid KeyState = iota
+	// KeyStateTemporary means the key is temporarily unavailable
+	// (e.g. rate-limited) and will recover after a cooldown.
+	KeyStateTemporary
+	// KeyStatePermanent means the key is permanently unavailable
+	// (e.g. revoked or unauthorized) until process restart.
+	KeyStatePermanent
+)
+
+// DefaultCooldown is applied when MarkTemporary is called with a
+// zero or negative cooldown duration.
+const DefaultCooldown = 60 * time.Second
+
+// keyEntry holds a key and its current state.
+type keyEntry struct {
+	key      string
+	state    KeyState
+	cooldown time.Time // Only meaningful when state == KeyStateTemporary.
+}
+
+// Pool manages a set of keys with state tracking and
+// automatic cooldown expiry. It is safe for concurrent use.
+type Pool struct {
+	mu      sync.RWMutex
+	entries []keyEntry
+	clock   quartz.Clock
+}
+
+// New creates a pool from the given keys. All keys start in the
+// valid state. Returns nil if keys is empty.
+func New(keys []string, clk quartz.Clock) *Pool {
+	if len(keys) == 0 {
+		return nil
+	}
+
+	entries := make([]keyEntry, len(keys))
+	for i, k := range keys {
+		entries[i] = keyEntry{key: k, state: KeyStateValid}
+	}
+
+	return &Pool{
+		entries: entries,
+		clock:   clk,
+	}
+}
+
+// Key is a handle to a specific key in the pool and provides
+// methods to read its value and update its state.
+type Key struct {
+	pool  *Pool
+	index int
+}
+
+// Value returns the key string.
+func (k *Key) Value() string {
+	return k.pool.entries[k.index].key
+}
+
+// State returns the current state of the key.
+func (k *Key) State() KeyState {
+	k.pool.mu.RLock()
+	defer k.pool.mu.RUnlock()
+
+	return k.pool.entries[k.index].state
+}
+
+// MarkValid transitions the key back to valid state. The call
+// is a no-op if the key is permanent or if the key is temporary
+// with an active cooldown.
+func (k *Key) MarkValid() {
+	k.pool.mu.Lock()
+	defer k.pool.mu.Unlock()
+
+	entry := &k.pool.entries[k.index]
+	switch entry.state {
+	case KeyStatePermanent:
+		return
+	case KeyStateTemporary:
+		// Ignore stale successes from concurrent requests
+		// that started before the key was rate-limited.
+		if k.pool.clock.Now().Before(entry.cooldown) {
+			return
+		}
+	}
+
+	entry.state = KeyStateValid
+}
+
+// MarkTemporary marks the key as temporarily unavailable with
+// the specified cooldown duration. If cooldown is zero or
+// negative, DefaultCooldown is used. If the key is already in
+// a permanent state, the call is a no-op.
+func (k *Key) MarkTemporary(cooldown time.Duration) {
+	k.pool.mu.Lock()
+	defer k.pool.mu.Unlock()
+
+	entry := &k.pool.entries[k.index]
+	if entry.state == KeyStatePermanent {
+		return
+	}
+
+	if cooldown <= 0 {
+		cooldown = DefaultCooldown
+	}
+
+	newDeadline := k.pool.clock.Now().Add(cooldown)
+
+	// Keep the longer cooldown when concurrent requests both
+	// mark the same key as rate-limited.
+	if entry.state == KeyStateTemporary && entry.cooldown.After(newDeadline) {
+		return
+	}
+
+	entry.state = KeyStateTemporary
+	entry.cooldown = newDeadline
+}
+
+// MarkPermanent marks the key as permanently unavailable. This
+// is a terminal state.
+func (k *Key) MarkPermanent() {
+	k.pool.mu.Lock()
+	defer k.pool.mu.Unlock()
+
+	k.pool.entries[k.index].state = KeyStatePermanent
+}
+
+// Walker traverses a Pool for a single request. Each request
+// creates its own walker so that it can independently iterate
+// through keys without interfering with other requests.
+type Walker struct {
+	pool *Pool
+	pos  int // Next index to consider.
+}
+
+// Walker creates a new Walker that follows a primary-with-fallback
+// strategy, starting from the first key in the pool. The walker
+// is not safe for concurrent use, it is intended for a single
+// request's failover loop.
+func (p *Pool) Walker() *Walker {
+	return &Walker{pool: p, pos: 0}
+}
+
+// ErrAllKeysExhausted is returned when the walker has visited
+// every key in the pool and none are available.
+var ErrAllKeysExhausted = xerrors.New("all keys exhausted")
+
+// Next returns a Key handle for the next available key. This is
+// a read-only operation; it does not modify the pool state.
+//
+// Returns ErrAllKeysExhausted when no more keys are available.
+func (w *Walker) Next() (*Key, error) {
+	p := w.pool
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	now := p.clock.Now()
+
+	for i := w.pos; i < len(p.entries); i++ {
+		entry := &p.entries[i]
+
+		switch entry.state {
+		case KeyStateValid:
+			// Key is available, use it.
+			w.pos = i + 1
+			return &Key{pool: p, index: i}, nil
+
+		case KeyStateTemporary:
+			// Cooldown expired, treat as available.
+			if now.After(entry.cooldown) {
+				w.pos = i + 1
+				return &Key{pool: p, index: i}, nil
+			}
+			// Still cooling down, skip.
+
+		case KeyStatePermanent:
+			// Permanently unavailable, skip.
+		}
+	}
+
+	return nil, ErrAllKeysExhausted
+}

--- a/aibridge/keypool/keypool.go
+++ b/aibridge/keypool/keypool.go
@@ -41,7 +41,7 @@ const defaultCooldown = 60 * time.Second
 // Key holds a key value and its runtime state.
 type Key struct {
 	value         string
-	isPermanent   bool
+	permanent     bool
 	cooldownUntil time.Time
 
 	mu    sync.RWMutex
@@ -86,12 +86,12 @@ func (k *Key) Value() string {
 }
 
 // State returns the current state of the key, derived from its
-// isPermanent flag and cooldown deadline.
+// permanent flag and cooldown deadline.
 func (k *Key) State() KeyState {
 	k.mu.RLock()
 	defer k.mu.RUnlock()
 
-	if k.isPermanent {
+	if k.permanent {
 		return KeyStatePermanent
 	}
 	// Cooldown still active: key is temporarily unavailable.
@@ -109,7 +109,7 @@ func (k *Key) MarkTemporary(cooldown time.Duration) bool {
 	defer k.mu.Unlock()
 
 	// Permanent is irreversible.
-	if k.isPermanent {
+	if k.permanent {
 		return false
 	}
 
@@ -138,11 +138,11 @@ func (k *Key) MarkPermanent() bool {
 	k.mu.Lock()
 	defer k.mu.Unlock()
 
-	if k.isPermanent {
+	if k.permanent {
 		return false
 	}
 
-	k.isPermanent = true
+	k.permanent = true
 	return true
 }
 

--- a/aibridge/keypool/keypool.go
+++ b/aibridge/keypool/keypool.go
@@ -180,5 +180,6 @@ func (w *Walker) Next() (*Key, error) {
 		return key, nil
 	}
 
+	// No keys available.
 	return nil, ErrAllKeysExhausted
 }

--- a/aibridge/keypool/keypool.go
+++ b/aibridge/keypool/keypool.go
@@ -102,38 +102,49 @@ func (k *Key) State() KeyState {
 	return KeyStateValid
 }
 
-// MarkTemporary marks the key as temporarily unavailable
-// with the specified cooldown duration.
-func (k *Key) MarkTemporary(cooldown time.Duration) {
+// MarkTemporary marks the key as temporarily unavailable with
+// the specified cooldown duration. Returns true if this call
+// transitions the key to temporary.
+func (k *Key) MarkTemporary(cooldown time.Duration) bool {
 	k.pool.mu.Lock()
 	defer k.pool.mu.Unlock()
 
 	// Permanent is irreversible.
 	if k.isPermanent {
-		return
+		return false
 	}
 
 	if cooldown <= 0 {
 		cooldown = defaultCooldown
 	}
 
-	newDeadline := k.pool.clock.Now().Add(cooldown)
+	now := k.pool.clock.Now()
+	// Used to detect the valid -> temporary transition.
+	inCooldown := k.cooldownUntil.After(now)
+	newDeadline := now.Add(cooldown)
 
 	// In case the key has a later expiry, keep it.
 	if k.cooldownUntil.After(newDeadline) {
-		return
+		return false
 	}
 
 	k.cooldownUntil = newDeadline
+	return !inCooldown
 }
 
 // MarkPermanent marks the key as permanently unavailable. This
-// is a terminal state.
-func (k *Key) MarkPermanent() {
+// is a terminal state. Returns true if this call transitions
+// the key to permanent.
+func (k *Key) MarkPermanent() bool {
 	k.pool.mu.Lock()
 	defer k.pool.mu.Unlock()
 
+	if k.isPermanent {
+		return false
+	}
+
 	k.isPermanent = true
+	return true
 }
 
 // Walker traverses a Pool for a single request. Each request

--- a/aibridge/keypool/keypool.go
+++ b/aibridge/keypool/keypool.go
@@ -103,13 +103,12 @@ func (k *Key) State() KeyState {
 }
 
 // MarkTemporary marks the key as temporarily unavailable
-// with the specified cooldown duration. If cooldown is zero
-// or negative, DefaultCooldown is used. If the key is
-// already permanent, the call is a no-op.
+// with the specified cooldown duration.
 func (k *Key) MarkTemporary(cooldown time.Duration) {
 	k.pool.mu.Lock()
 	defer k.pool.mu.Unlock()
 
+	// Permanent is irreversible.
 	if k.isPermanent {
 		return
 	}

--- a/aibridge/keypool/keypool.go
+++ b/aibridge/keypool/keypool.go
@@ -40,10 +40,10 @@ const defaultCooldown = 60 * time.Second
 
 // Key holds a key value and its runtime state.
 type Key struct {
-	pool        *Pool
-	value       string
-	isPermanent bool
-	expiresAt   time.Time
+	pool          *Pool
+	value         string
+	isPermanent   bool
+	cooldownUntil time.Time
 }
 
 // Pool manages a set of keys with state tracking and
@@ -96,7 +96,7 @@ func (k *Key) State() KeyState {
 		return KeyStatePermanent
 	}
 	// Cooldown still active: key is temporarily unavailable.
-	if k.pool.clock.Now().Before(k.expiresAt) {
+	if k.pool.clock.Now().Before(k.cooldownUntil) {
 		return KeyStateTemporary
 	}
 	return KeyStateValid
@@ -121,11 +121,11 @@ func (k *Key) MarkTemporary(cooldown time.Duration) {
 	newDeadline := k.pool.clock.Now().Add(cooldown)
 
 	// In case the key has a later expiry, keep it.
-	if k.expiresAt.After(newDeadline) {
+	if k.cooldownUntil.After(newDeadline) {
 		return
 	}
 
-	k.expiresAt = newDeadline
+	k.cooldownUntil = newDeadline
 }
 
 // MarkPermanent marks the key as permanently unavailable. This
@@ -173,7 +173,7 @@ func (w *Walker) Next() (*Key, error) {
 			continue
 		}
 		// Cooldown still active, skip.
-		if pool.clock.Now().Before(key.expiresAt) {
+		if pool.clock.Now().Before(key.cooldownUntil) {
 			continue
 		}
 		// Key is available.

--- a/aibridge/keypool/keypool.go
+++ b/aibridge/keypool/keypool.go
@@ -40,18 +40,18 @@ const defaultCooldown = 60 * time.Second
 
 // Key holds a key value and its runtime state.
 type Key struct {
-	pool          *Pool
 	value         string
 	isPermanent   bool
 	cooldownUntil time.Time
+
+	mu    sync.RWMutex
+	clock quartz.Clock
 }
 
 // Pool manages a set of keys with state tracking and
 // cooldown expiry. It is safe for concurrent use.
 type Pool struct {
-	mu    sync.RWMutex
-	keys  []Key
-	clock quartz.Clock
+	keys []Key
 }
 
 // New creates a pool from the given keys. All keys start in
@@ -62,8 +62,7 @@ func New(keys []string, clk quartz.Clock) (*Pool, error) {
 		return nil, ErrNoKeys
 	}
 	pool := &Pool{
-		keys:  make([]Key, len(keys)),
-		clock: clk,
+		keys: make([]Key, len(keys)),
 	}
 
 	seen := make(map[string]struct{}, len(keys))
@@ -73,7 +72,7 @@ func New(keys []string, clk quartz.Clock) (*Pool, error) {
 		}
 		seen[val] = struct{}{}
 		pool.keys[i] = Key{
-			pool:  pool,
+			clock: clk,
 			value: val,
 		}
 	}
@@ -89,14 +88,14 @@ func (k *Key) Value() string {
 // State returns the current state of the key, derived from its
 // isPermanent flag and cooldown deadline.
 func (k *Key) State() KeyState {
-	k.pool.mu.RLock()
-	defer k.pool.mu.RUnlock()
+	k.mu.RLock()
+	defer k.mu.RUnlock()
 
 	if k.isPermanent {
 		return KeyStatePermanent
 	}
 	// Cooldown still active: key is temporarily unavailable.
-	if k.pool.clock.Now().Before(k.cooldownUntil) {
+	if k.clock.Now().Before(k.cooldownUntil) {
 		return KeyStateTemporary
 	}
 	return KeyStateValid
@@ -106,8 +105,8 @@ func (k *Key) State() KeyState {
 // the specified cooldown duration. Returns true if this call
 // transitions the key to temporary.
 func (k *Key) MarkTemporary(cooldown time.Duration) bool {
-	k.pool.mu.Lock()
-	defer k.pool.mu.Unlock()
+	k.mu.Lock()
+	defer k.mu.Unlock()
 
 	// Permanent is irreversible.
 	if k.isPermanent {
@@ -118,7 +117,7 @@ func (k *Key) MarkTemporary(cooldown time.Duration) bool {
 		cooldown = defaultCooldown
 	}
 
-	now := k.pool.clock.Now()
+	now := k.clock.Now()
 	// Used to detect the valid -> temporary transition.
 	inCooldown := k.cooldownUntil.After(now)
 	newDeadline := now.Add(cooldown)
@@ -136,8 +135,8 @@ func (k *Key) MarkTemporary(cooldown time.Duration) bool {
 // is a terminal state. Returns true if this call transitions
 // the key to permanent.
 func (k *Key) MarkPermanent() bool {
-	k.pool.mu.Lock()
-	defer k.pool.mu.Unlock()
+	k.mu.Lock()
+	defer k.mu.Unlock()
 
 	if k.isPermanent {
 		return false
@@ -172,18 +171,10 @@ func (w *Walker) Next() (*Key, error) {
 	if pool == nil {
 		return nil, ErrAllKeysExhausted
 	}
-	pool.mu.RLock()
-	defer pool.mu.RUnlock()
 
 	for i := w.pos; i < len(pool.keys); i++ {
 		key := &pool.keys[i]
-
-		// Permanently unavailable, skip.
-		if key.isPermanent {
-			continue
-		}
-		// Cooldown still active, skip.
-		if pool.clock.Now().Before(key.cooldownUntil) {
+		if key.State() != KeyStateValid {
 			continue
 		}
 		// Key is available.

--- a/aibridge/keypool/keypool.go
+++ b/aibridge/keypool/keypool.go
@@ -156,7 +156,7 @@ type Walker struct {
 
 // Walker creates a new Walker that follows a primary-with-fallback
 // strategy, starting from the first key in the pool. The walker
-// is not safe for concurrent use, it is intended for a single
+// is not safe for concurrent use. It is intended for a single
 // request's failover loop.
 func (p *Pool) Walker() *Walker {
 	return &Walker{pool: p, pos: 0}

--- a/aibridge/keypool/keypool.go
+++ b/aibridge/keypool/keypool.go
@@ -9,6 +9,17 @@ import (
 	"github.com/coder/quartz"
 )
 
+var (
+	// ErrNoKeys is returned when the input is empty.
+	ErrNoKeys = xerrors.New("no keys provided")
+	// ErrDuplicateKey is returned when the input contains
+	// duplicate key values.
+	ErrDuplicateKey = xerrors.New("duplicate key")
+	// ErrAllKeysExhausted is returned when the walker has visited
+	// every key in the pool and none are available.
+	ErrAllKeysExhausted = xerrors.New("all keys exhausted")
+)
+
 // KeyState represents the current state of a key in the pool.
 type KeyState int
 
@@ -23,112 +34,98 @@ const (
 	KeyStatePermanent
 )
 
-// DefaultCooldown is applied when MarkTemporary is called with a
-// zero or negative cooldown duration.
-const DefaultCooldown = 60 * time.Second
+// defaultCooldown is applied when a key is marked temporary
+// with a zero or negative cooldown duration.
+const defaultCooldown = 60 * time.Second
 
-// keyEntry holds a key and its current state.
-type keyEntry struct {
-	key      string
-	state    KeyState
-	cooldown time.Time // Only meaningful when state == KeyStateTemporary.
+// Key holds a key value and its runtime state.
+type Key struct {
+	pool        *Pool
+	value       string
+	isPermanent bool
+	expiresAt   time.Time
 }
 
 // Pool manages a set of keys with state tracking and
-// automatic cooldown expiry. It is safe for concurrent use.
+// cooldown expiry. It is safe for concurrent use.
 type Pool struct {
-	mu      sync.RWMutex
-	entries []keyEntry
-	clock   quartz.Clock
+	mu    sync.RWMutex
+	keys  []Key
+	clock quartz.Clock
 }
 
-// New creates a pool from the given keys. All keys start in the
-// valid state. Returns nil if keys is empty.
-func New(keys []string, clk quartz.Clock) *Pool {
+// New creates a pool from the given keys. All keys start in
+// the valid state. Returns ErrNoKeys if keys is empty and
+// ErrDuplicateKey if any key appears more than once.
+func New(keys []string, clk quartz.Clock) (*Pool, error) {
 	if len(keys) == 0 {
-		return nil
+		return nil, ErrNoKeys
+	}
+	pool := &Pool{
+		keys:  make([]Key, len(keys)),
+		clock: clk,
 	}
 
-	entries := make([]keyEntry, len(keys))
-	for i, k := range keys {
-		entries[i] = keyEntry{key: k, state: KeyStateValid}
+	seen := make(map[string]struct{}, len(keys))
+	for i, val := range keys {
+		if _, exists := seen[val]; exists {
+			return nil, ErrDuplicateKey
+		}
+		seen[val] = struct{}{}
+		pool.keys[i] = Key{
+			pool:  pool,
+			value: val,
+		}
 	}
 
-	return &Pool{
-		entries: entries,
-		clock:   clk,
-	}
-}
-
-// Key is a handle to a specific key in the pool and provides
-// methods to read its value and update its state.
-type Key struct {
-	pool  *Pool
-	index int
+	return pool, nil
 }
 
 // Value returns the key string.
 func (k *Key) Value() string {
-	return k.pool.entries[k.index].key
+	return k.value
 }
 
-// State returns the current state of the key.
+// State returns the current state of the key, derived from its
+// isPermanent flag and cooldown deadline.
 func (k *Key) State() KeyState {
 	k.pool.mu.RLock()
 	defer k.pool.mu.RUnlock()
 
-	return k.pool.entries[k.index].state
-}
-
-// MarkValid transitions the key back to valid state. The call
-// is a no-op if the key is permanent or if the key is temporary
-// with an active cooldown.
-func (k *Key) MarkValid() {
-	k.pool.mu.Lock()
-	defer k.pool.mu.Unlock()
-
-	entry := &k.pool.entries[k.index]
-	switch entry.state {
-	case KeyStatePermanent:
-		return
-	case KeyStateTemporary:
-		// Ignore stale successes from concurrent requests
-		// that started before the key was rate-limited.
-		if k.pool.clock.Now().Before(entry.cooldown) {
-			return
-		}
+	if k.isPermanent {
+		return KeyStatePermanent
 	}
-
-	entry.state = KeyStateValid
+	// Cooldown still active: key is temporarily unavailable.
+	if k.pool.clock.Now().Before(k.expiresAt) {
+		return KeyStateTemporary
+	}
+	return KeyStateValid
 }
 
-// MarkTemporary marks the key as temporarily unavailable with
-// the specified cooldown duration. If cooldown is zero or
-// negative, DefaultCooldown is used. If the key is already in
-// a permanent state, the call is a no-op.
+// MarkTemporary marks the key as temporarily unavailable
+// with the specified cooldown duration. If cooldown is zero
+// or negative, DefaultCooldown is used. If the key is
+// already permanent, the call is a no-op.
 func (k *Key) MarkTemporary(cooldown time.Duration) {
 	k.pool.mu.Lock()
 	defer k.pool.mu.Unlock()
 
-	entry := &k.pool.entries[k.index]
-	if entry.state == KeyStatePermanent {
+	if k.isPermanent {
 		return
 	}
 
 	if cooldown <= 0 {
-		cooldown = DefaultCooldown
+		cooldown = defaultCooldown
 	}
 
 	newDeadline := k.pool.clock.Now().Add(cooldown)
 
-	// Keep the longer cooldown when concurrent requests both
-	// mark the same key as rate-limited.
-	if entry.state == KeyStateTemporary && entry.cooldown.After(newDeadline) {
+	// In case the key has a later expiry, keep it.
+	if k.expiresAt.After(newDeadline) {
 		return
 	}
 
-	entry.state = KeyStateTemporary
-	entry.cooldown = newDeadline
+	k.expiresAt = newDeadline
 }
 
 // MarkPermanent marks the key as permanently unavailable. This
@@ -137,7 +134,7 @@ func (k *Key) MarkPermanent() {
 	k.pool.mu.Lock()
 	defer k.pool.mu.Unlock()
 
-	k.pool.entries[k.index].state = KeyStatePermanent
+	k.isPermanent = true
 }
 
 // Walker traverses a Pool for a single request. Each request
@@ -156,41 +153,32 @@ func (p *Pool) Walker() *Walker {
 	return &Walker{pool: p, pos: 0}
 }
 
-// ErrAllKeysExhausted is returned when the walker has visited
-// every key in the pool and none are available.
-var ErrAllKeysExhausted = xerrors.New("all keys exhausted")
-
 // Next returns a Key handle for the next available key. This is
 // a read-only operation; it does not modify the pool state.
 //
 // Returns ErrAllKeysExhausted when no more keys are available.
 func (w *Walker) Next() (*Key, error) {
-	p := w.pool
-	p.mu.RLock()
-	defer p.mu.RUnlock()
+	pool := w.pool
+	if pool == nil {
+		return nil, ErrAllKeysExhausted
+	}
+	pool.mu.RLock()
+	defer pool.mu.RUnlock()
 
-	now := p.clock.Now()
+	for i := w.pos; i < len(pool.keys); i++ {
+		key := &pool.keys[i]
 
-	for i := w.pos; i < len(p.entries); i++ {
-		entry := &p.entries[i]
-
-		switch entry.state {
-		case KeyStateValid:
-			// Key is available, use it.
-			w.pos = i + 1
-			return &Key{pool: p, index: i}, nil
-
-		case KeyStateTemporary:
-			// Cooldown expired, treat as available.
-			if now.After(entry.cooldown) {
-				w.pos = i + 1
-				return &Key{pool: p, index: i}, nil
-			}
-			// Still cooling down, skip.
-
-		case KeyStatePermanent:
-			// Permanently unavailable, skip.
+		// Permanently unavailable, skip.
+		if key.isPermanent {
+			continue
 		}
+		// Cooldown still active, skip.
+		if pool.clock.Now().Before(key.expiresAt) {
+			continue
+		}
+		// Key is available.
+		w.pos = i + 1
+		return key, nil
 	}
 
 	return nil, ErrAllKeysExhausted

--- a/aibridge/keypool/keypool_test.go
+++ b/aibridge/keypool/keypool_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/coder/quartz"
 )
 
-func TestNew(t *testing.T) {
+func TestNewKeyPool(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {

--- a/aibridge/keypool/keypool_test.go
+++ b/aibridge/keypool/keypool_test.go
@@ -15,28 +15,32 @@ func TestNew(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name string
-		keys []string
+		name         string
+		keys         []string
+		expectedKeys []string
+		expectedErr  error
 	}{
-		{"nil_keys", nil},
-		{"empty_keys", []string{}},
-		{"single_key", []string{"key-0"}},
-		{"multiple_keys", []string{"key-0", "key-1", "key-2"}},
+		{"nil_keys", nil, nil, keypool.ErrNoKeys},
+		{"empty_keys", []string{}, nil, keypool.ErrNoKeys},
+		{"single_key", []string{"key-0"}, []string{"key-0"}, nil},
+		{"multiple_keys", []string{"key-0", "key-1", "key-2"}, []string{"key-0", "key-1", "key-2"}, nil},
+		{"duplicate_keys", []string{"key-0", "key-1", "key-0"}, nil, keypool.ErrDuplicateKey},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			pool := keypool.New(tc.keys, quartz.NewMock(t))
-			if len(tc.keys) == 0 {
-				assert.Nil(t, pool)
+			pool, err := keypool.New(tc.keys, quartz.NewMock(t))
+			if tc.expectedErr != nil {
+				require.ErrorIs(t, err, tc.expectedErr)
 				return
 			}
+			require.NoError(t, err)
 			require.NotNil(t, pool)
 
 			// Verify all keys are returned in order and valid.
 			walker := pool.Walker()
-			for _, expected := range tc.keys {
+			for _, expected := range tc.expectedKeys {
 				key, err := walker.Next()
 				require.NoError(t, err)
 				assert.Equal(t, expected, key.Value())
@@ -44,13 +48,13 @@ func TestNew(t *testing.T) {
 			}
 
 			// No more keys available.
-			_, err := walker.Next()
+			_, err = walker.Next()
 			require.ErrorIs(t, err, keypool.ErrAllKeysExhausted)
 		})
 	}
 }
 
-func TestMarkValid(t *testing.T) {
+func TestState(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -59,8 +63,8 @@ func TestMarkValid(t *testing.T) {
 		expectedState keypool.KeyState
 	}{
 		{
-			// valid -> valid: no-op, key stays available.
-			name: "valid_to_valid",
+			// Fresh key is valid.
+			name: "fresh_key_is_valid",
 			setup: func(t *testing.T, pool *keypool.Pool, _ *quartz.Mock) *keypool.Key {
 				key, err := pool.Walker().Next()
 				require.NoError(t, err)
@@ -69,24 +73,8 @@ func TestMarkValid(t *testing.T) {
 			expectedState: keypool.KeyStateValid,
 		},
 		{
-			// temporary -> valid: cooldown has expired, so
-			// MarkValid transitions the key back to valid.
-			name: "temporary_to_valid_cooldown_expired",
-			setup: func(t *testing.T, pool *keypool.Pool, clk *quartz.Mock) *keypool.Key {
-				key, err := pool.Walker().Next()
-				require.NoError(t, err)
-				key.MarkTemporary(30 * time.Second)
-				clk.Advance(31 * time.Second)
-				return key
-			},
-			expectedState: keypool.KeyStateValid,
-		},
-		{
-			// temporary -> temporary: cooldown is still active,
-			// so MarkValid is a no-op. This prevents a stale
-			// successful response from clearing a longer cooldown
-			// set by a concurrent request.
-			name: "temporary_with_active_cooldown_is_no_op",
+			// Active cooldown makes the key temporary.
+			name: "active_cooldown_is_temporary",
 			setup: func(t *testing.T, pool *keypool.Pool, _ *quartz.Mock) *keypool.Key {
 				key, err := pool.Walker().Next()
 				require.NoError(t, err)
@@ -96,11 +84,35 @@ func TestMarkValid(t *testing.T) {
 			expectedState: keypool.KeyStateTemporary,
 		},
 		{
-			// permanent -> permanent: no-op, permanent is irreversible.
-			name: "permanent_to_valid_is_no_op",
+			// Expired cooldown returns the key to valid.
+			name: "expired_cooldown_is_valid",
+			setup: func(t *testing.T, pool *keypool.Pool, clk *quartz.Mock) *keypool.Key {
+				key, err := pool.Walker().Next()
+				require.NoError(t, err)
+				key.MarkTemporary(30 * time.Second)
+				clk.Advance(35 * time.Second)
+				return key
+			},
+			expectedState: keypool.KeyStateValid,
+		},
+		{
+			// Permanent key is permanent.
+			name: "permanent_key",
 			setup: func(t *testing.T, pool *keypool.Pool, _ *quartz.Mock) *keypool.Key {
 				key, err := pool.Walker().Next()
 				require.NoError(t, err)
+				key.MarkPermanent()
+				return key
+			},
+			expectedState: keypool.KeyStatePermanent,
+		},
+		{
+			// Permanent takes precedence over active cooldown.
+			name: "permanent_with_cooldown_is_permanent",
+			setup: func(t *testing.T, pool *keypool.Pool, _ *quartz.Mock) *keypool.Key {
+				key, err := pool.Walker().Next()
+				require.NoError(t, err)
+				key.MarkTemporary(60 * time.Second)
 				key.MarkPermanent()
 				return key
 			},
@@ -112,10 +124,10 @@ func TestMarkValid(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			clk := quartz.NewMock(t)
-			pool := keypool.New([]string{"key-0", "key-1"}, clk)
+			pool, err := keypool.New([]string{"key-0"}, clk)
+			require.NoError(t, err)
 
 			key := tc.setup(t, pool, clk)
-			key.MarkValid()
 
 			assert.Equal(t, tc.expectedState, key.State())
 		})
@@ -186,7 +198,8 @@ func TestMarkTemporary(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			clk := quartz.NewMock(t)
-			pool := keypool.New([]string{"key-0", "key-1"}, clk)
+			pool, err := keypool.New([]string{"key-0", "key-1"}, clk)
+			require.NoError(t, err)
 
 			key := tc.setup(t, pool, clk)
 			key.MarkTemporary(tc.cooldown)
@@ -243,7 +256,8 @@ func TestMarkPermanent(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			clk := quartz.NewMock(t)
-			pool := keypool.New([]string{"key-0", "key-1"}, clk)
+			pool, err := keypool.New([]string{"key-0", "key-1"}, clk)
+			require.NoError(t, err)
 
 			key := tc.setup(t, pool)
 			key.MarkPermanent()
@@ -442,11 +456,12 @@ func TestWalkerNext(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			clk := quartz.NewMock(t)
-			pool := keypool.New(tc.keys, clk)
+			pool, err := keypool.New(tc.keys, clk)
+			require.NoError(t, err)
 
 			tc.setup(t, pool)
 
-			// Simulate time passing between setup (when keys are marked) and the walker walk.
+			// Simulate time passing between setup and the walk.
 			if tc.advance > 0 {
 				clk.Advance(tc.advance)
 			}
@@ -459,7 +474,7 @@ func TestWalkerNext(t *testing.T) {
 			}
 
 			// After all expected keys, the walker should be exhausted.
-			_, err := walker.Next()
+			_, err = walker.Next()
 			require.ErrorIs(t, err, keypool.ErrAllKeysExhausted)
 		})
 	}
@@ -473,7 +488,8 @@ func TestWalkerIndependence(t *testing.T) {
 	t.Parallel()
 
 	clk := quartz.NewMock(t)
-	pool := keypool.New([]string{"key-0", "key-1", "key-2"}, clk)
+	pool, err := keypool.New([]string{"key-0", "key-1", "key-2"}, clk)
+	require.NoError(t, err)
 
 	walker := pool.Walker()
 

--- a/aibridge/keypool/keypool_test.go
+++ b/aibridge/keypool/keypool_test.go
@@ -138,10 +138,11 @@ func TestMarkTemporary(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name          string
-		cooldown      time.Duration
-		setup         func(t *testing.T, pool *keypool.Pool, clk *quartz.Mock) *keypool.Key
-		expectedState keypool.KeyState
+		name               string
+		cooldown           time.Duration
+		setup              func(t *testing.T, pool *keypool.Pool, clk *quartz.Mock) *keypool.Key
+		expectedState      keypool.KeyState
+		expectedTransition bool
 	}{
 		{
 			// valid -> temporary: key becomes unavailable.
@@ -152,7 +153,8 @@ func TestMarkTemporary(t *testing.T) {
 				require.NoError(t, err)
 				return key
 			},
-			expectedState: keypool.KeyStateTemporary,
+			expectedState:      keypool.KeyStateTemporary,
+			expectedTransition: true,
 		},
 		{
 			// temporary -> temporary: new cooldown is longer,
@@ -165,7 +167,8 @@ func TestMarkTemporary(t *testing.T) {
 				key.MarkTemporary(10 * time.Second)
 				return key
 			},
-			expectedState: keypool.KeyStateTemporary,
+			expectedState:      keypool.KeyStateTemporary,
+			expectedTransition: false,
 		},
 		{
 			// temporary -> temporary: new cooldown is shorter,
@@ -178,7 +181,8 @@ func TestMarkTemporary(t *testing.T) {
 				key.MarkTemporary(60 * time.Second)
 				return key
 			},
-			expectedState: keypool.KeyStateTemporary,
+			expectedState:      keypool.KeyStateTemporary,
+			expectedTransition: false,
 		},
 		{
 			// permanent -> permanent: no-op, permanent is irreversible.
@@ -190,7 +194,8 @@ func TestMarkTemporary(t *testing.T) {
 				key.MarkPermanent()
 				return key
 			},
-			expectedState: keypool.KeyStatePermanent,
+			expectedState:      keypool.KeyStatePermanent,
+			expectedTransition: false,
 		},
 	}
 
@@ -202,9 +207,10 @@ func TestMarkTemporary(t *testing.T) {
 			require.NoError(t, err)
 
 			key := tc.setup(t, pool, clk)
-			key.MarkTemporary(tc.cooldown)
+			transition := key.MarkTemporary(tc.cooldown)
 
 			assert.Equal(t, tc.expectedState, key.State())
+			assert.Equal(t, tc.expectedTransition, transition)
 		})
 	}
 }
@@ -213,9 +219,10 @@ func TestMarkPermanent(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name          string
-		setup         func(t *testing.T, pool *keypool.Pool) *keypool.Key
-		expectedState keypool.KeyState
+		name               string
+		setup              func(t *testing.T, pool *keypool.Pool) *keypool.Key
+		expectedState      keypool.KeyState
+		expectedTransition bool
 	}{
 		{
 			// valid -> permanent: key becomes permanently unavailable.
@@ -225,7 +232,8 @@ func TestMarkPermanent(t *testing.T) {
 				require.NoError(t, err)
 				return key
 			},
-			expectedState: keypool.KeyStatePermanent,
+			expectedState:      keypool.KeyStatePermanent,
+			expectedTransition: true,
 		},
 		{
 			// temporary -> permanent: escalation from rate limit
@@ -237,7 +245,8 @@ func TestMarkPermanent(t *testing.T) {
 				key.MarkTemporary(60 * time.Second)
 				return key
 			},
-			expectedState: keypool.KeyStatePermanent,
+			expectedState:      keypool.KeyStatePermanent,
+			expectedTransition: true,
 		},
 		{
 			// permanent -> permanent: no-op, already permanent.
@@ -248,7 +257,8 @@ func TestMarkPermanent(t *testing.T) {
 				key.MarkPermanent()
 				return key
 			},
-			expectedState: keypool.KeyStatePermanent,
+			expectedState:      keypool.KeyStatePermanent,
+			expectedTransition: false,
 		},
 	}
 
@@ -260,9 +270,10 @@ func TestMarkPermanent(t *testing.T) {
 			require.NoError(t, err)
 
 			key := tc.setup(t, pool)
-			key.MarkPermanent()
+			transition := key.MarkPermanent()
 
 			assert.Equal(t, tc.expectedState, key.State())
+			assert.Equal(t, tc.expectedTransition, transition)
 		})
 	}
 }

--- a/aibridge/keypool/keypool_test.go
+++ b/aibridge/keypool/keypool_test.go
@@ -1,0 +1,506 @@
+package keypool_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/aibridge/keypool"
+	"github.com/coder/quartz"
+)
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		keys []string
+	}{
+		{"nil_keys", nil},
+		{"empty_keys", []string{}},
+		{"single_key", []string{"key-0"}},
+		{"multiple_keys", []string{"key-0", "key-1", "key-2"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			pool := keypool.New(tc.keys, quartz.NewMock(t))
+			if len(tc.keys) == 0 {
+				assert.Nil(t, pool)
+				return
+			}
+			require.NotNil(t, pool)
+
+			// Verify all keys are returned in order and valid.
+			walker := pool.Walker()
+			for _, expected := range tc.keys {
+				key, err := walker.Next()
+				require.NoError(t, err)
+				assert.Equal(t, expected, key.Value())
+				assert.Equal(t, keypool.KeyStateValid, key.State())
+			}
+
+			// No more keys available.
+			_, err := walker.Next()
+			require.ErrorIs(t, err, keypool.ErrAllKeysExhausted)
+		})
+	}
+}
+
+func TestMarkValid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		setup         func(t *testing.T, pool *keypool.Pool, clk *quartz.Mock) *keypool.Key
+		expectedState keypool.KeyState
+	}{
+		{
+			// valid -> valid: no-op, key stays available.
+			name: "valid_to_valid",
+			setup: func(t *testing.T, pool *keypool.Pool, _ *quartz.Mock) *keypool.Key {
+				key, err := pool.Walker().Next()
+				require.NoError(t, err)
+				return key
+			},
+			expectedState: keypool.KeyStateValid,
+		},
+		{
+			// temporary -> valid: cooldown has expired, so
+			// MarkValid transitions the key back to valid.
+			name: "temporary_to_valid_cooldown_expired",
+			setup: func(t *testing.T, pool *keypool.Pool, clk *quartz.Mock) *keypool.Key {
+				key, err := pool.Walker().Next()
+				require.NoError(t, err)
+				key.MarkTemporary(30 * time.Second)
+				clk.Advance(31 * time.Second)
+				return key
+			},
+			expectedState: keypool.KeyStateValid,
+		},
+		{
+			// temporary -> temporary: cooldown is still active,
+			// so MarkValid is a no-op. This prevents a stale
+			// successful response from clearing a longer cooldown
+			// set by a concurrent request.
+			name: "temporary_with_active_cooldown_is_no_op",
+			setup: func(t *testing.T, pool *keypool.Pool, _ *quartz.Mock) *keypool.Key {
+				key, err := pool.Walker().Next()
+				require.NoError(t, err)
+				key.MarkTemporary(60 * time.Second)
+				return key
+			},
+			expectedState: keypool.KeyStateTemporary,
+		},
+		{
+			// permanent -> permanent: no-op, permanent is irreversible.
+			name: "permanent_to_valid_is_no_op",
+			setup: func(t *testing.T, pool *keypool.Pool, _ *quartz.Mock) *keypool.Key {
+				key, err := pool.Walker().Next()
+				require.NoError(t, err)
+				key.MarkPermanent()
+				return key
+			},
+			expectedState: keypool.KeyStatePermanent,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			clk := quartz.NewMock(t)
+			pool := keypool.New([]string{"key-0", "key-1"}, clk)
+
+			key := tc.setup(t, pool, clk)
+			key.MarkValid()
+
+			assert.Equal(t, tc.expectedState, key.State())
+		})
+	}
+}
+
+func TestMarkTemporary(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		cooldown      time.Duration
+		setup         func(t *testing.T, pool *keypool.Pool, clk *quartz.Mock) *keypool.Key
+		expectedState keypool.KeyState
+	}{
+		{
+			// valid -> temporary: key becomes unavailable.
+			name:     "valid_to_temporary",
+			cooldown: 60 * time.Second,
+			setup: func(t *testing.T, pool *keypool.Pool, _ *quartz.Mock) *keypool.Key {
+				key, err := pool.Walker().Next()
+				require.NoError(t, err)
+				return key
+			},
+			expectedState: keypool.KeyStateTemporary,
+		},
+		{
+			// temporary -> temporary: new cooldown is longer,
+			// so the deadline is extended.
+			name:     "temporary_to_temporary_extends_cooldown",
+			cooldown: 60 * time.Second,
+			setup: func(t *testing.T, pool *keypool.Pool, _ *quartz.Mock) *keypool.Key {
+				key, err := pool.Walker().Next()
+				require.NoError(t, err)
+				key.MarkTemporary(10 * time.Second)
+				return key
+			},
+			expectedState: keypool.KeyStateTemporary,
+		},
+		{
+			// temporary -> temporary: new cooldown is shorter,
+			// so the existing longer deadline is preserved.
+			name:     "temporary_to_temporary_keeps_longer_cooldown",
+			cooldown: 10 * time.Second,
+			setup: func(t *testing.T, pool *keypool.Pool, _ *quartz.Mock) *keypool.Key {
+				key, err := pool.Walker().Next()
+				require.NoError(t, err)
+				key.MarkTemporary(60 * time.Second)
+				return key
+			},
+			expectedState: keypool.KeyStateTemporary,
+		},
+		{
+			// permanent -> permanent: no-op, permanent is irreversible.
+			name:     "permanent_to_temporary_is_no_op",
+			cooldown: 60 * time.Second,
+			setup: func(t *testing.T, pool *keypool.Pool, _ *quartz.Mock) *keypool.Key {
+				key, err := pool.Walker().Next()
+				require.NoError(t, err)
+				key.MarkPermanent()
+				return key
+			},
+			expectedState: keypool.KeyStatePermanent,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			clk := quartz.NewMock(t)
+			pool := keypool.New([]string{"key-0", "key-1"}, clk)
+
+			key := tc.setup(t, pool, clk)
+			key.MarkTemporary(tc.cooldown)
+
+			assert.Equal(t, tc.expectedState, key.State())
+		})
+	}
+}
+
+func TestMarkPermanent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		setup         func(t *testing.T, pool *keypool.Pool) *keypool.Key
+		expectedState keypool.KeyState
+	}{
+		{
+			// valid -> permanent: key becomes permanently unavailable.
+			name: "valid_to_permanent",
+			setup: func(t *testing.T, pool *keypool.Pool) *keypool.Key {
+				key, err := pool.Walker().Next()
+				require.NoError(t, err)
+				return key
+			},
+			expectedState: keypool.KeyStatePermanent,
+		},
+		{
+			// temporary -> permanent: escalation from rate limit
+			// to auth failure.
+			name: "temporary_to_permanent",
+			setup: func(t *testing.T, pool *keypool.Pool) *keypool.Key {
+				key, err := pool.Walker().Next()
+				require.NoError(t, err)
+				key.MarkTemporary(60 * time.Second)
+				return key
+			},
+			expectedState: keypool.KeyStatePermanent,
+		},
+		{
+			// permanent -> permanent: no-op, already permanent.
+			name: "permanent_to_permanent",
+			setup: func(t *testing.T, pool *keypool.Pool) *keypool.Key {
+				key, err := pool.Walker().Next()
+				require.NoError(t, err)
+				key.MarkPermanent()
+				return key
+			},
+			expectedState: keypool.KeyStatePermanent,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			clk := quartz.NewMock(t)
+			pool := keypool.New([]string{"key-0", "key-1"}, clk)
+
+			key := tc.setup(t, pool)
+			key.MarkPermanent()
+
+			assert.Equal(t, tc.expectedState, key.State())
+		})
+	}
+}
+
+func TestWalkerNext(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		keys        []string
+		setup       func(t *testing.T, pool *keypool.Pool)
+		advance     time.Duration
+		expectValid []string
+	}{
+		{
+			// Given: key-0: valid, key-1: valid, key-2: valid.
+			// Then: key-0: valid, key-1: valid, key-2: valid.
+			name:        "all_keys_valid",
+			keys:        []string{"key-0", "key-1", "key-2"},
+			setup:       func(_ *testing.T, _ *keypool.Pool) {},
+			expectValid: []string{"key-0", "key-1", "key-2"},
+		},
+		{
+			// Given: key-0: temporary, key-1: valid, key-2: valid.
+			// Then: key-0: temporary, key-1: valid, key-2: valid.
+			name: "skips_temporary_keys",
+			keys: []string{"key-0", "key-1", "key-2"},
+			setup: func(t *testing.T, pool *keypool.Pool) {
+				key, err := pool.Walker().Next()
+				require.NoError(t, err)
+				key.MarkTemporary(60 * time.Second)
+			},
+			expectValid: []string{"key-1", "key-2"},
+		},
+		{
+			// Given: key-0: permanent, key-1: permanent, key-2: valid.
+			// Then: key-0: permanent, key-1: permanent, key-2: valid.
+			name: "skips_permanent_keys",
+			keys: []string{"key-0", "key-1", "key-2"},
+			setup: func(t *testing.T, pool *keypool.Pool) {
+				walker := pool.Walker()
+				key0, err := walker.Next()
+				require.NoError(t, err)
+				key0.MarkPermanent()
+				key1, err := walker.Next()
+				require.NoError(t, err)
+				key1.MarkPermanent()
+			},
+			expectValid: []string{"key-2"},
+		},
+		{
+			// Given: key-0: temporary (30s), key-1: valid.
+			// When: 35s pass.
+			// Then: key-0: valid, key-1: valid.
+			name: "expired_temporary_is_available",
+			keys: []string{"key-0", "key-1"},
+			setup: func(t *testing.T, pool *keypool.Pool) {
+				key, err := pool.Walker().Next()
+				require.NoError(t, err)
+				key.MarkTemporary(30 * time.Second)
+			},
+			advance:     35 * time.Second,
+			expectValid: []string{"key-0", "key-1"},
+		},
+		{
+			// Given: key-0: temporary (zero, default 60s), key-1: valid.
+			// When: 50s pass.
+			// Then: key-0: temporary, key-1: valid.
+			name: "default_cooldown_not_expired",
+			keys: []string{"key-0", "key-1"},
+			setup: func(t *testing.T, pool *keypool.Pool) {
+				key, err := pool.Walker().Next()
+				require.NoError(t, err)
+				key.MarkTemporary(0)
+			},
+			advance:     50 * time.Second,
+			expectValid: []string{"key-1"},
+		},
+		{
+			// Given: key-0: temporary (zero, default 60s), key-1: valid.
+			// When: 65s pass.
+			// Then: key-0: valid, key-1: valid.
+			name: "default_cooldown_expired",
+			keys: []string{"key-0", "key-1"},
+			setup: func(t *testing.T, pool *keypool.Pool) {
+				key, err := pool.Walker().Next()
+				require.NoError(t, err)
+				key.MarkTemporary(0)
+			},
+			advance:     65 * time.Second,
+			expectValid: []string{"key-0", "key-1"},
+		},
+		{
+			// Given: key-0: temporary (negative, default 60s), key-1: valid.
+			// When: 65s pass.
+			// Then: key-0: valid, key-1: valid.
+			name: "negative_cooldown_uses_default",
+			keys: []string{"key-0", "key-1"},
+			setup: func(t *testing.T, pool *keypool.Pool) {
+				key, err := pool.Walker().Next()
+				require.NoError(t, err)
+				key.MarkTemporary(-10 * time.Second)
+			},
+			advance:     65 * time.Second,
+			expectValid: []string{"key-0", "key-1"},
+		},
+		{
+			// Given: key-0: temporary (60s), then marked again with shorter cooldown (10s).
+			// When: 15s pass (past 10s, but not 60s).
+			// Then: key-0: temporary.
+			name: "shorter_cooldown_preserves_longer_not_expired",
+			keys: []string{"key-0"},
+			setup: func(t *testing.T, pool *keypool.Pool) {
+				key, err := pool.Walker().Next()
+				require.NoError(t, err)
+				key.MarkTemporary(60 * time.Second)
+				key.MarkTemporary(10 * time.Second)
+			},
+			advance:     15 * time.Second,
+			expectValid: []string{},
+		},
+		{
+			// Given: key-0: temporary (60s), then marked again with shorter cooldown (10s).
+			// When: 65s pass (past the original 60s).
+			// Then: key-0: valid.
+			name: "shorter_cooldown_preserves_longer_expired",
+			keys: []string{"key-0"},
+			setup: func(t *testing.T, pool *keypool.Pool) {
+				key, err := pool.Walker().Next()
+				require.NoError(t, err)
+				key.MarkTemporary(60 * time.Second)
+				key.MarkTemporary(10 * time.Second)
+			},
+			advance:     65 * time.Second,
+			expectValid: []string{"key-0"},
+		},
+		{
+			// Given: key-0: temporary, key-1: temporary.
+			// Then: key-0: temporary, key-1: temporary.
+			name: "all_temporary_exhausted",
+			keys: []string{"key-0", "key-1"},
+			setup: func(t *testing.T, pool *keypool.Pool) {
+				walker := pool.Walker()
+				key0, err := walker.Next()
+				require.NoError(t, err)
+				key0.MarkTemporary(60 * time.Second)
+				key1, err := walker.Next()
+				require.NoError(t, err)
+				key1.MarkTemporary(60 * time.Second)
+			},
+			expectValid: []string{},
+		},
+		{
+			// Given: key-0: permanent, key-1: permanent.
+			// Then: key-0: permanent, key-1: permanent.
+			name: "all_permanent_exhausted",
+			keys: []string{"key-0", "key-1"},
+			setup: func(t *testing.T, pool *keypool.Pool) {
+				walker := pool.Walker()
+				key0, err := walker.Next()
+				require.NoError(t, err)
+				key0.MarkPermanent()
+				key1, err := walker.Next()
+				require.NoError(t, err)
+				key1.MarkPermanent()
+			},
+			expectValid: []string{},
+		},
+		{
+			// Given: key-0: permanent, key-1: temporary, key-2: permanent.
+			// Then: key-0: permanent, key-1: temporary, key-2: permanent.
+			name: "mixed_states_exhausted",
+			keys: []string{"key-0", "key-1", "key-2"},
+			setup: func(t *testing.T, pool *keypool.Pool) {
+				walker := pool.Walker()
+				key0, err := walker.Next()
+				require.NoError(t, err)
+				key0.MarkPermanent()
+				key1, err := walker.Next()
+				require.NoError(t, err)
+				key1.MarkTemporary(60 * time.Second)
+				key2, err := walker.Next()
+				require.NoError(t, err)
+				key2.MarkPermanent()
+			},
+			expectValid: []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			clk := quartz.NewMock(t)
+			pool := keypool.New(tc.keys, clk)
+
+			tc.setup(t, pool)
+
+			// Simulate time passing between setup (when keys are marked) and the walker walk.
+			if tc.advance > 0 {
+				clk.Advance(tc.advance)
+			}
+
+			walker := pool.Walker()
+			for _, expectedKey := range tc.expectValid {
+				key, err := walker.Next()
+				require.NoError(t, err)
+				assert.Equal(t, expectedKey, key.Value())
+			}
+
+			// After all expected keys, the walker should be exhausted.
+			_, err := walker.Next()
+			require.ErrorIs(t, err, keypool.ErrAllKeysExhausted)
+		})
+	}
+}
+
+// TestWalkerIndependence simulates two requests using the same
+// pool. The first request marks key-0 temporary and key-1
+// permanent, then gets key-2. The second request sees the
+// updated pool state and also gets key-2.
+func TestWalkerIndependence(t *testing.T) {
+	t.Parallel()
+
+	clk := quartz.NewMock(t)
+	pool := keypool.New([]string{"key-0", "key-1", "key-2"}, clk)
+
+	walker := pool.Walker()
+
+	// First attempt: get key-0.
+	key, err := walker.Next()
+	require.NoError(t, err)
+	assert.Equal(t, "key-0", key.Value())
+
+	// Simulate 429: mark key-0 temporary.
+	key.MarkTemporary(60 * time.Second)
+
+	// Second attempt: walker advances to key-1.
+	key, err = walker.Next()
+	require.NoError(t, err)
+	assert.Equal(t, "key-1", key.Value())
+
+	// Simulate 401: mark key-1 permanent.
+	key.MarkPermanent()
+
+	// Third attempt: walker advances to key-2.
+	key, err = walker.Next()
+	require.NoError(t, err)
+	assert.Equal(t, "key-2", key.Value())
+
+	// A new walker should skip key-0 (temporary) and key-1
+	// (permanent), and return key-2.
+	key2, err := pool.Walker().Next()
+	require.NoError(t, err)
+	assert.Equal(t, "key-2", key2.Value())
+}


### PR DESCRIPTION
## Description

Adds the `aibridge/keypool` package, a thread-safe key pool with per-key state tracking and cooldown expiry. This PR introduces the package only; wiring it into the aibridge providers and coder configuration will happen in upstream PRs.

## Changes

Each key is in one of three states: **Valid** (available), **Temporary** (rate-limited with cooldown expiry), or **Permanent** (revoked/unauthorized, terminal until restart). The state is derived from the key fields rather than stored explicitly: once a cooldown expires, the key is valid again without any external action.

A `Walker` provides per-request key traversal using a primary-with-fallback strategy: each request walks the pool from index 0, skipping unavailable keys, so the first key is always preferred when healthy. Walkers are independent, so concurrent requests traverse the pool without interfering with each other.

`MarkTemporary` preserves the longer cooldown when concurrent requests both mark the same key.

Relates to https://github.com/coder/internal/issues/1445

> [!NOTE]
> Initially generated by Coder Agents, modified and reviewed by @ssncferreira