### PR TITLE
feat(site/src/modules/resources): highlight log tabs with errors and badge hidden errors

### DIFF
--- a/site/src/modules/resources/AgentRow.stories.tsx
+++ b/site/src/modules/resources/AgentRow.stories.tsx
@@ -98,10 +98,10 @@ const installScriptLogSource: WorkspaceAgentLogSource = {
 	display_name: "Install Script",
 };
 
-const startupScriptLogSource: WorkspaceAgentLogSource = {
+const buildScriptLogSource: WorkspaceAgentLogSource = {
 	...M.MockWorkspaceAgentLogSource,
 	id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-	display_name: "Startup Script",
+	display_name: "Build Script",
 };
 
 const tabbedLogs = [
@@ -240,7 +240,7 @@ export const StartErrorWithTimings: Story = {
 		const canvas = within(canvasElement);
 
 		const scriptTab = await canvas.findByRole("tab", {
-			name: "Startup Script",
+			name: "Build Script",
 		});
 		await waitFor(() =>
 			expect(scriptTab).toHaveAttribute("data-state", "active"),
@@ -250,11 +250,18 @@ export const StartErrorWithTimings: Story = {
 		agent: {
 			...M.MockWorkspaceAgentStartError,
 			logs_length: 2,
-			log_sources: [startupScriptLogSource],
+			log_sources: [buildScriptLogSource],
+			scripts: [
+				{
+					...M.MockWorkspaceAgent.scripts[0],
+					display_name: "Build Script",
+					log_source_id: buildScriptLogSource.id,
+				},
+			],
 		},
 		agentScriptTimings: [
 			{
-				display_name: "Startup Script",
+				display_name: "Build Script",
 				exit_code: 1,
 				stage: "start",
 				status: "exit_failure",
@@ -273,15 +280,108 @@ export const StartErrorWithTimings: Story = {
 					{
 						id: 200,
 						level: "info",
-						output: "startup: preparing workspace",
+						output: "build: preparing workspace",
 						source_id: M.MockWorkspaceAgentLogSource.id,
 						created_at: fixedLogTimestamp,
 					},
 					{
 						id: 201,
 						level: "error",
-						output: "startup script: command not found",
-						source_id: startupScriptLogSource.id,
+						output: "build script: command not found",
+						source_id: buildScriptLogSource.id,
+						created_at: fixedLogTimestamp,
+					},
+				]),
+			},
+		],
+	},
+};
+
+export const MultipleFailedScripts: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		// buildScriptLogSource is first in log_sources, so it should be auto-selected.
+		const buildTab = await canvas.findByRole("tab", {
+			name: "Build Script",
+		});
+		await waitFor(() =>
+			expect(buildTab).toHaveAttribute("data-state", "active"),
+		);
+	},
+	args: {
+		agent: {
+			...M.MockWorkspaceAgentStartError,
+			logs_length: 4,
+			log_sources: [buildScriptLogSource, installScriptLogSource],
+			scripts: [
+				{
+					...M.MockWorkspaceAgent.scripts[0],
+					display_name: "Install Script",
+					log_source_id: installScriptLogSource.id,
+				},
+				{
+					...M.MockWorkspaceAgent.scripts[0],
+					id: "b2d3e4f5-a6b7-8901-cdef-234567890abc",
+					display_name: "Build Script",
+					log_source_id: buildScriptLogSource.id,
+				},
+			],
+		},
+		agentScriptTimings: [
+			{
+				display_name: "Install Script",
+				exit_code: 127,
+				stage: "start",
+				status: "exit_failure",
+				started_at: "2021-05-05T00:00:00.000Z",
+				ended_at: "2021-05-05T00:00:01.000Z",
+				workspace_agent_id: M.MockWorkspaceAgentStartError.id,
+				workspace_agent_name: M.MockWorkspaceAgentStartError.name,
+			},
+			{
+				display_name: "Build Script",
+				exit_code: 1,
+				stage: "start",
+				status: "exit_failure",
+				started_at: "2021-05-05T00:00:01.000Z",
+				ended_at: "2021-05-05T00:00:02.000Z",
+				workspace_agent_id: M.MockWorkspaceAgentStartError.id,
+				workspace_agent_name: M.MockWorkspaceAgentStartError.name,
+			},
+		],
+	},
+	parameters: {
+		webSocket: [
+			{
+				event: "message",
+				data: JSON.stringify([
+					{
+						id: 300,
+						level: "info",
+						output: "install: pnpm install",
+						source_id: installScriptLogSource.id,
+						created_at: fixedLogTimestamp,
+					},
+					{
+						id: 301,
+						level: "error",
+						output: "install script: command not found",
+						source_id: installScriptLogSource.id,
+						created_at: fixedLogTimestamp,
+					},
+					{
+						id: 302,
+						level: "info",
+						output: "build: preparing workspace",
+						source_id: buildScriptLogSource.id,
+						created_at: fixedLogTimestamp,
+					},
+					{
+						id: 303,
+						level: "error",
+						output: "build script: command not found",
+						source_id: buildScriptLogSource.id,
 						created_at: fixedLogTimestamp,
 					},
 				]),

--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -156,6 +156,19 @@ export const AgentRow: FC<AgentRowProps> = ({
 			t.stage === "start" &&
 			t.exit_code !== 0,
 	);
+	const failedLogSourceIds = new Set(
+		failedStartTimings
+			?.map((timing) => {
+				const script = agent.scripts.find(
+					(s) => s.display_name === timing.display_name,
+				);
+				return script?.log_source_id;
+			})
+			.filter(Boolean) ?? [],
+	);
+	const firstFailedLogSourceId = agent.log_sources.find((s) =>
+		failedLogSourceIds.has(s.id),
+	)?.id;
 	const { proxy } = useProxy();
 	const [showLogs, setShowLogs] = useState(
 		(["starting", "start_timeout"].includes(agent.lifecycle_state) ||
@@ -235,14 +248,16 @@ export const AgentRow: FC<AgentRowProps> = ({
 		agent,
 		Boolean(hasDevcontainerErrors || shouldShowWildcardWarning),
 	);
-	const failedStartupScriptSource = hasAgentIssues
-		? agent.log_sources.find(
-				(s) => s.display_name === STARTUP_SCRIPT_DISPLAY_NAME,
-			)
-		: undefined;
 	const [selectedLogTab, setSelectedLogTab] = useState(
-		failedStartupScriptSource?.id ?? "all",
+		firstFailedLogSourceId ?? "all",
 	);
+	const hasAutoSelectedFailedTab = useRef(false);
+	useEffect(() => {
+		if (!hasAutoSelectedFailedTab.current && firstFailedLogSourceId) {
+			hasAutoSelectedFailedTab.current = true;
+			setSelectedLogTab(firstFailedLogSourceId);
+		}
+	}, [firstFailedLogSourceId]);
 	const sourceLogTabs = agent.log_sources
 		.filter((logSource) => {
 			// Remove the logSources that have no entries.
@@ -265,6 +280,7 @@ export const AgentRow: FC<AgentRowProps> = ({
 			) : null,
 			title: logSource.display_name,
 			value: logSource.id,
+			hasError: failedLogSourceIds.has(logSource.id),
 		}));
 	const startupScriptLogTab = sourceLogTabs.find(
 		(tab) => tab.title === STARTUP_SCRIPT_DISPLAY_NAME,
@@ -276,6 +292,7 @@ export const AgentRow: FC<AgentRowProps> = ({
 		startIcon?: ReactNode;
 		title: string;
 		value: string;
+		hasError?: boolean;
 	}[] = [
 		{
 			title: "All Logs",
@@ -550,6 +567,9 @@ export const AgentRow: FC<AgentRowProps> = ({
 														<span className="whitespace-nowrap">
 															{tab.title}
 														</span>
+														{tab.hasError && (
+															<TriangleAlertIcon className="size-icon-xs text-content-warning shrink-0" />
+														)}
 													</TabsTrigger>
 												))}
 												{overflowLogTabs.length > 0 && (
@@ -567,7 +587,11 @@ export const AgentRow: FC<AgentRowProps> = ({
 																aria-label="More log tabs"
 																className="border-none py-4 bg-transparent text-inherit inline-flex items-center justify-center cursor-pointer transition-colors duration-150 ease-linear"
 															>
-																<EllipsisIcon className="size-icon-sm" />
+																{overflowLogTabs.some((t) => t.hasError) ? (
+																	<TriangleAlertIcon className="size-icon-xs text-content-warning" />
+																) : (
+																	<EllipsisIcon className="size-icon-sm" />
+																)}
 																<span className="sr-only">More log tabs</span>
 															</button>
 														</DropdownMenuTrigger>
@@ -586,6 +610,9 @@ export const AgentRow: FC<AgentRowProps> = ({
 																		<span className="whitespace-nowrap">
 																			{tab.title}
 																		</span>
+																		{tab.hasError && (
+																			<TriangleAlertIcon className="size-icon-xs text-content-warning shrink-0" />
+																		)}
 																	</DropdownMenuRadioItem>
 																))}
 															</DropdownMenuRadioGroup>

--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -512,7 +512,12 @@ export const AgentRow: FC<AgentRowProps> = ({
 						{healthIssues.length > 0 && (
 							<Badge variant="warning" size="xs" className="ml-1.5">
 								<TriangleAlertIcon />
-								<span>{healthIssues.length}</span>
+								{/*
+									If there are failed start timings, show that count instead
+									of the health issues count, since it correctly indicates
+									more than one issue instead of a generic "health issue"
+								*/}
+								<span>{failedStartTimings?.length || healthIssues.length}</span>
 							</Badge>
 						)}
 					</Button>


### PR DESCRIPTION
When an agent's startup scripts fail, the log tabs for the affected log sources now show a warning triangle icon. The overflow (three-dot) menu button is replaced with the warning triangle when any overflow tab has an error. This also changes the issue count ⚠️ badge to prefer the failed timings count to the count of overall health issues

> authored with Claude "Plan Mode" Code 🤖 

https://github.com/user-attachments/assets/effb492c-3f79-4bae-9b3b-ae910ffbe690
