### PR TITLE
fix: bedrock anthropic system prompt must be string

### DIFF
--- a/coderd/x/chatd/chatprovider/chatprovider_test.go
+++ b/coderd/x/chatd/chatprovider/chatprovider_test.go
@@ -2,6 +2,7 @@ package chatprovider_test
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -923,6 +924,81 @@ func TestModelFromConfig_Bedrock(t *testing.T) {
 		require.Equal(t, "/model/"+modelID+"/invoke", got.Path)
 		require.Equal(t, "Bearer test-key", got.Authorization)
 		require.Equal(t, chatprovider.UserAgent(), got.UserAgent)
+	})
+
+	t.Run("CapturesSystemFieldShape", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitShort)
+
+		type requestCapture struct {
+			Body          string
+			BodyReadError error
+		}
+
+		requests := make(chan requestCapture, 1)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer r.Body.Close()
+
+			body, err := io.ReadAll(r.Body)
+			requests <- requestCapture{
+				Body:          string(body),
+				BodyReadError: err,
+			}
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(bedrockNonStreamingResponse())
+		}))
+		defer server.Close()
+
+		model, err := chatprovider.ModelFromConfig(
+			fantasybedrock.Name,
+			modelID,
+			chatprovider.ProviderAPIKeys{
+				ByProvider: map[string]string{
+					fantasybedrock.Name: "test-key",
+				},
+				BaseURLByProvider: map[string]string{
+					fantasybedrock.Name: server.URL,
+				},
+			},
+			chatprovider.UserAgent(),
+			nil,
+			nil,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, model)
+
+		_, err = model.Generate(ctx, fantasy.Call{
+			Prompt: []fantasy.Message{
+				{
+					Role: fantasy.MessageRoleSystem,
+					Content: []fantasy.MessagePart{
+						fantasy.TextPart{Text: "you are helpful"},
+					},
+				},
+				{
+					Role: fantasy.MessageRoleUser,
+					Content: []fantasy.MessagePart{
+						fantasy.TextPart{Text: "hello"},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		got := testutil.TryReceive(ctx, t, requests)
+		require.NoError(t, got.BodyReadError)
+
+		var payload map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal([]byte(got.Body), &payload))
+
+		systemField, ok := payload["system"]
+		require.True(t, ok, "expected top-level system field in request body: %s", got.Body)
+		t.Logf("Bedrock system field JSON: %s", systemField)
 	})
 
 	t.Run("NonBedrockStillRequiresAPIKey", func(t *testing.T) {

--- a/coderd/x/chatd/chatprovider/chatprovider_test.go
+++ b/coderd/x/chatd/chatprovider/chatprovider_test.go
@@ -999,6 +999,13 @@ func TestModelFromConfig_Bedrock(t *testing.T) {
 		systemField, ok := payload["system"]
 		require.True(t, ok, "expected top-level system field in request body: %s", got.Body)
 		t.Logf("Bedrock system field JSON: %s", systemField)
+
+		var systemValue any
+		require.NoError(t, json.Unmarshal(systemField, &systemValue))
+
+		systemText, ok := systemValue.(string)
+		require.True(t, ok, "expected system field to be a JSON string, got %T in request body: %s", systemValue, got.Body)
+		require.Equal(t, "you are helpful", systemText)
 	})
 
 	t.Run("NonBedrockStillRequiresAPIKey", func(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -83,8 +83,8 @@ replace github.com/spf13/afero => github.com/aslilac/afero v0.0.0-20250403163713
 // 4) (anthropic-sdk-go) dannykopping's appendCompact performance fixes
 // 5) (anthropic-sdk-go) DirectEncoder to eliminate nested MarshalJSON allocation chain
 // 6) Anthropic EffortXHigh constant for Claude Opus 4.7
-// See: https://github.com/coder/fantasy/commits/959aa39579d2
-replace charm.land/fantasy => github.com/coder/fantasy v0.0.0-20260416152503-959aa39579d2
+// See: https://github.com/coder/fantasy/commits/12c408489e35
+replace charm.land/fantasy => github.com/coder/fantasy v0.0.0-20260423190606-12c408489e35
 
 // coder/coder uses a fork of charmbracelet's fork of the Anthropic Go SDK with some
 // additional performance improvements.

--- a/go.sum
+++ b/go.sum
@@ -322,8 +322,8 @@ github.com/coder/bubbletea v1.2.2-0.20241212190825-007a1cdb2c41 h1:SBN/DA63+ZHwu
 github.com/coder/bubbletea v1.2.2-0.20241212190825-007a1cdb2c41/go.mod h1:I9ULxr64UaOSUv7hcb3nX4kowodJCVS7vt7VVJk/kW4=
 github.com/coder/clistat v1.2.1 h1:P9/10njXMyj5cWzIU5wkRsSy5LVQH49+tcGMsAgWX0w=
 github.com/coder/clistat v1.2.1/go.mod h1:m7SC0uj88eEERgvF8Kn6+w6XF21BeSr+15f7GoLAw0A=
-github.com/coder/fantasy v0.0.0-20260416152503-959aa39579d2 h1:bZoww6da3tFbiYHLgIZuRNTMgsiQDSgblDMSOSmmlzE=
-github.com/coder/fantasy v0.0.0-20260416152503-959aa39579d2/go.mod h1:wZ0e3lEPqrM0XiIdAUQLvMKCLYhc3gi96MRX2wjbX44=
+github.com/coder/fantasy v0.0.0-20260423190606-12c408489e35 h1:ccyKCj5TEvDAIWa2v42PSp0SVvxiegocxDy57UdbPRs=
+github.com/coder/fantasy v0.0.0-20260423190606-12c408489e35/go.mod h1:wZ0e3lEPqrM0XiIdAUQLvMKCLYhc3gi96MRX2wjbX44=
 github.com/coder/flog v1.1.0 h1:kbAes1ai8fIS5OeV+QAnKBQE22ty1jRF/mcAwHpLBa4=
 github.com/coder/flog v1.1.0/go.mod h1:UQlQvrkJBvnRGo69Le8E24Tcl5SJleAAR7gYEHzAmdQ=
 github.com/coder/go-httpstat v0.0.0-20230801153223-321c88088322 h1:m0lPZjlQ7vdVpRBPKfYIFlmgevoTkBxB10wv6l2gOaU=


### PR DESCRIPTION
> Mux working on behalf of Mike.

## Problem

Anthropic chat calls that go through the Bedrock provider were failing with 400 validationException on affected Bedrock paths. Captured wire shape on the way out:

```json
"system":[{"text":"you are helpful","type":"text"}]
```

Bedrock's Anthropic Messages schema expects `system` as a plain string.

## Fix

The actual fix lives in the fantasy fork: coder/fantasy#28 (branch `mike/bedrock-system-string`, targeting `coder_2_33`). This PR:

- Bumps `charm.land/fantasy` replace pin to the commit that contains the fix.
- Tightens the existing diagnostic test `TestModelFromConfig_Bedrock/CapturesSystemFieldShape` to assert `system` is a JSON string equal to `"you are helpful"`.

The diagnostic test landed in a separate commit first so the failing shape is visible in history without depending on the fantasy bump.

## Verification

```
go test ./coderd/x/chatd/chatprovider/ -run 'TestModelFromConfig_Bedrock' -count=1 -v
```

All subtests pass, including `CapturesSystemFieldShape` which logs:

```
Bedrock system field JSON: "you are helpful"
```

## Order of merge

coder/fantasy#28 needs to merge into `coder_2_33` first. Once that merges, this PR will be rebased to pin to the merge commit on `coder_2_33` rather than the PR branch tip.

## Out of scope

No changes to `chatprompt`, `chatloop`, `aibridge`, or any other non-Bedrock path.