### PR TITLE
fix(enterprise/coderd/x/chatd): trim overlapping relay reconnect snapshot

### DIFF
--- a/enterprise/coderd/x/chatd/chatd.go
+++ b/enterprise/coderd/x/chatd/chatd.go
@@ -297,8 +297,9 @@ func NewMultiReplicaSubscribeFn(
 			}
 			closeRelay(workerID != recentRelayWorkerID)
 			// Create a per-dial context so this goroutine is
-			// canceled if closeRelay() or openRelayAsync() is
-			// called again before the dial completes.
+			// canceled if closeRelay(clearRecentHistory) or
+			// openRelayAsync() is called again before the dial
+			// completes.
 			var dialCtx context.Context
 			dialCtx, dialCancel = context.WithCancel(ctx)
 			expectedWorkerID = workerID
@@ -386,7 +387,7 @@ func NewMultiReplicaSubscribeFn(
 			case <-ctx.Done():
 			}
 		}
-		forwardRelayPart := func(event codersdk.ChatStreamEvent) bool {
+		forwardAndRecordRelayPart := func(event codersdk.ChatStreamEvent) bool {
 			if event.Type != codersdk.ChatStreamEventTypeMessagePart {
 				return true
 			}
@@ -400,7 +401,7 @@ func NewMultiReplicaSubscribeFn(
 		}
 		forwardRelaySnapshot := func(snapshot []codersdk.ChatStreamEvent) bool {
 			for _, event := range snapshot {
-				if !forwardRelayPart(event) {
+				if !forwardAndRecordRelayPart(event) {
 					return false
 				}
 			}
@@ -414,7 +415,7 @@ func NewMultiReplicaSubscribeFn(
 			// Forward any initial relay snapshot parts
 			// collected synchronously above.
 			for _, event := range initialRelaySnapshot {
-				if !forwardRelayPart(event) {
+				if !forwardAndRecordRelayPart(event) {
 					return
 				}
 			}
@@ -629,7 +630,7 @@ func NewMultiReplicaSubscribeFn(
 						scheduleRelayReconnect(delay)
 						continue
 					}
-					if !forwardRelayPart(event) {
+					if !forwardAndRecordRelayPart(event) {
 						return
 					}
 				}
@@ -644,6 +645,14 @@ func NewMultiReplicaSubscribeFn(
 	}
 }
 
+// trimRelaySnapshotOverlap finds the largest suffix of recent that
+// exactly matches a prefix of snapshot, then returns snapshot with
+// that prefix removed. If no match is found, or if more than one
+// overlap size matches, it returns the full snapshot. The
+// overlapMatches == 1 guard is the safety property of reconnect
+// dedup and must not be simplified away: repeated payloads can make
+// the boundary ambiguous, and in that case we prefer duplicate
+// delivery over silently dropping real output.
 func trimRelaySnapshotOverlap(
 	recent []codersdk.ChatStreamEvent,
 	snapshot []codersdk.ChatStreamEvent,
@@ -653,7 +662,7 @@ func trimRelaySnapshotOverlap(
 	limit := min(len(recent), len(snapshot))
 	for size := 1; size <= limit; size++ {
 		matched := true
-		for i := 0; i < size; i++ {
+		for i := range size {
 			recentEvent := recent[len(recent)-size+i]
 			snapshotEvent := snapshot[i]
 			if recentEvent.Type != codersdk.ChatStreamEventTypeMessagePart ||
@@ -674,6 +683,9 @@ func trimRelaySnapshotOverlap(
 	return snapshot[overlap:]
 }
 
+// appendRecentRelayPart appends one relay message part to the
+// bounded sliding-window buffer used for reconnect dedup, keeping at
+// most relaySnapshotCap recent entries.
 func appendRecentRelayPart(
 	recent []codersdk.ChatStreamEvent,
 	event codersdk.ChatStreamEvent,
@@ -689,6 +701,14 @@ func appendRecentRelayPart(
 	return recent[:relaySnapshotCap]
 }
 
+// relayMessagePartEqual reports whether two streamed message parts
+// are safe to treat as identical for reconnect dedup. It
+// intentionally uses reflect.DeepEqual for a conservative
+// comparison. That is safe today because both sides come from JSON
+// and neither carries a monotonic time.Time reading. Audit this
+// helper before adding fields populated with time.Now() or
+// re-encoded json.RawMessage values, because either could silently
+// disable dedup even when the logical payloads still match.
 func relayMessagePartEqual(
 	left *codersdk.ChatStreamMessagePart,
 	right *codersdk.ChatStreamMessagePart,

--- a/enterprise/coderd/x/chatd/chatd.go
+++ b/enterprise/coderd/x/chatd/chatd.go
@@ -240,7 +240,10 @@ func NewMultiReplicaSubscribeFn(
 		var drainTimerCh <-chan time.Time
 
 		// Helper to close relay and stop any pending reconnect
-		// timer.
+		// timer. clearRecentHistory controls whether the
+		// per-subscription relay history used to dedupe replayed
+		// message parts is reset, or preserved across
+		// same-worker transient reconnects.
 		closeRelay := func(clearRecentHistory bool) {
 			// Cancel any in-flight dial goroutine first.
 			if dialCancel != nil {

--- a/enterprise/coderd/x/chatd/chatd.go
+++ b/enterprise/coderd/x/chatd/chatd.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"net/http"
 	"net/url"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -43,6 +44,10 @@ const (
 	// which isn't compatible with quartz.Clock determinism in tests.
 	relayRetryFloor = 500 * time.Millisecond // first retry matches old fixed delay
 	relayRetryCeil  = 15 * time.Second       // cap stall before tear-down
+	// relaySnapshotCap bounds both the initial relay snapshot
+	// drain and the per-subscription recent-history buffer used
+	// to trim reconnect overlap.
+	relaySnapshotCap = 100
 	// After this many reconnect retries the relay leg is torn down.
 	// Total dial attempts = 1 initial dial + relayMaxRetries.
 	relayMaxRetries = 6
@@ -157,6 +162,8 @@ func NewMultiReplicaSubscribeFn(
 
 		var relayCancel func()
 		var relayParts <-chan codersdk.ChatStreamEvent
+		recentRelayParts := make([]codersdk.ChatStreamEvent, 0, relaySnapshotCap)
+		var recentRelayWorkerID uuid.UUID
 
 		// If the chat is currently running on a different worker
 		// and we have a remote parts provider, open an initial
@@ -171,6 +178,7 @@ func NewMultiReplicaSubscribeFn(
 			if err == nil {
 				relayCancel = cancel
 				relayParts = parts
+				recentRelayWorkerID = params.Chat.WorkerID.UUID
 				// Collect relay message_parts to forward at the
 				// start of the merge goroutine.
 				for _, event := range snapshot {
@@ -190,12 +198,13 @@ func NewMultiReplicaSubscribeFn(
 		mergedEvents := make(chan codersdk.ChatStreamEvent, 128)
 		// Channel for async relay establishment.
 		type relayResult struct {
+			snapshot []codersdk.ChatStreamEvent
 			parts    <-chan codersdk.ChatStreamEvent
 			cancel   func()
-			workerID uuid.UUID // the worker this dial targeted
+			workerID uuid.UUID // the worker this dial targeted.
 			// err and parts are mutually exclusive: success sets
-			// parts; failure sets err (unwrap to *RelayDialError
-			// for classification).
+			// snapshot and parts; failure sets err (unwrap to
+			// *RelayDialError for classification).
 			err error
 		}
 		relayReadyCh := make(chan relayResult, 4)
@@ -232,7 +241,7 @@ func NewMultiReplicaSubscribeFn(
 
 		// Helper to close relay and stop any pending reconnect
 		// timer.
-		closeRelay := func() {
+		closeRelay := func(clearRecentHistory bool) {
 			// Cancel any in-flight dial goroutine first.
 			if dialCancel != nil {
 				dialCancel()
@@ -267,6 +276,10 @@ func NewMultiReplicaSubscribeFn(
 				drainTimerCh = nil
 			}
 			drainAndClose = false
+			if clearRecentHistory {
+				recentRelayParts = recentRelayParts[:0]
+				recentRelayWorkerID = uuid.Nil
+			}
 		}
 
 		// openRelayAsync dials the remote replica in a background
@@ -282,7 +295,7 @@ func NewMultiReplicaSubscribeFn(
 			if workerID != expectedWorkerID {
 				retryState.reset()
 			}
-			closeRelay()
+			closeRelay(workerID != recentRelayWorkerID)
 			// Create a per-dial context so this goroutine is
 			// canceled if closeRelay() or openRelayAsync() is
 			// called again before the dial completes.
@@ -319,51 +332,25 @@ func NewMultiReplicaSubscribeFn(
 					}
 					return
 				}
-				// Discard stale dials so we don't start a
-				// wrappedParts goroutine on a canceled connection.
+				// Discard stale dials so we don't start using a
+				// canceled connection.
 				if dialCtx.Err() != nil {
 					cancel()
 					return
 				}
-				// Wrap the relay channel so snapshot parts
-				// are delivered through the same channel as
-				// live parts. This goroutine only forwards
-				// events - it does not own the relay
-				// lifecycle. When dialCtx is canceled it
-				// simply returns, closing wrappedParts via
-				// its defer. The cancel() is called by
-				// whoever canceled dialCtx (closeRelay or
-				// the send-fallback select below).
-				wrappedParts := make(chan codersdk.ChatStreamEvent, 128)
-				go func() {
-					defer close(wrappedParts)
-					for _, event := range snapshot {
-						if event.Type == codersdk.ChatStreamEventTypeMessagePart {
-							select {
-							case wrappedParts <- event:
-							case <-dialCtx.Done():
-								return
-							}
-						}
+				relaySnapshot := make([]codersdk.ChatStreamEvent, 0, len(snapshot))
+				for _, event := range snapshot {
+					if event.Type == codersdk.ChatStreamEventTypeMessagePart {
+						relaySnapshot = append(relaySnapshot, event)
 					}
-					for {
-						select {
-						case event, ok := <-parts:
-							if !ok {
-								return
-							}
-							select {
-							case wrappedParts <- event:
-							case <-dialCtx.Done():
-								return
-							}
-						case <-dialCtx.Done():
-							return
-						}
-					}
-				}()
+				}
 				select {
-				case relayReadyCh <- relayResult{parts: wrappedParts, cancel: cancel, workerID: workerID}:
+				case relayReadyCh <- relayResult{
+					snapshot: relaySnapshot,
+					parts:    parts,
+					cancel:   cancel,
+					workerID: workerID,
+				}:
 				case <-dialCtx.Done():
 					cancel()
 				}
@@ -399,18 +386,36 @@ func NewMultiReplicaSubscribeFn(
 			case <-ctx.Done():
 			}
 		}
+		forwardRelayPart := func(event codersdk.ChatStreamEvent) bool {
+			if event.Type != codersdk.ChatStreamEventTypeMessagePart {
+				return true
+			}
+			select {
+			case <-ctx.Done():
+				return false
+			case mergedEvents <- event:
+				recentRelayParts = appendRecentRelayPart(recentRelayParts, event)
+				return true
+			}
+		}
+		forwardRelaySnapshot := func(snapshot []codersdk.ChatStreamEvent) bool {
+			for _, event := range snapshot {
+				if !forwardRelayPart(event) {
+					return false
+				}
+			}
+			return true
+		}
 		statusNotifications := params.StatusNotifications
 		go func() {
 			defer close(mergedEvents)
-			defer closeRelay()
+			defer closeRelay(true)
 
 			// Forward any initial relay snapshot parts
 			// collected synchronously above.
 			for _, event := range initialRelaySnapshot {
-				select {
-				case <-ctx.Done():
+				if !forwardRelayPart(event) {
 					return
-				case mergedEvents <- event:
 				}
 			}
 
@@ -429,16 +434,17 @@ func NewMultiReplicaSubscribeFn(
 						continue
 					}
 					// A nil parts channel signals the dial
-					// failed - classify the error to decide
-					// whether to schedule a backoff retry, emit a
-					// terminal error and tear the relay leg down
-					// (unrecoverable / cap reached), or simply
-					// drop the stale drain.
+					// failed. Classify the error to decide
+					// whether to schedule a backoff retry,
+					// emit a terminal error and tear the
+					// relay leg down (unrecoverable / cap
+					// reached), or tear down a stale drain.
 					if result.parts == nil {
 						if drainAndClose {
-							// Dial failed and we were only
-							// waiting to drain - nothing to do.
-							drainAndClose = false
+							// Dial failed while we were waiting to
+							// drain a relay that is no longer remote.
+							// Clear the dedupe state with the relay.
+							closeRelay(true)
 							continue
 						}
 						var dialErr *RelayDialError
@@ -501,20 +507,34 @@ func NewMultiReplicaSubscribeFn(
 						if dbErr == nil && currentChat.Status == database.ChatStatusRunning &&
 							currentChat.WorkerID.Valid &&
 							currentChat.WorkerID.UUID != params.WorkerID {
-							// A new worker picked up the chat;
-							// discard the stale relay and let
+							// A new worker picked up the chat.
+							// Discard the stale relay and let
 							// openRelayAsync handle the new one.
-							closeRelay()
-						} else {
-							// Chat is still idle - drain the
-							// buffered snapshot before closing.
-							if drainTimer != nil {
-								drainTimer.Stop()
-							}
-							drainTimer = cfg.clock().NewTimer(relayDrainTimeout, "drain")
-							drainTimerCh = drainTimer.C
-							drainAndClose = false
+							closeRelay(true)
+							continue
 						}
+						// Chat is still idle. Drain the
+						// buffered snapshot before closing.
+						if drainTimer != nil {
+							drainTimer.Stop()
+						}
+						drainTimer = cfg.clock().NewTimer(relayDrainTimeout, "drain")
+						drainTimerCh = drainTimer.C
+						drainAndClose = false
+					}
+
+					relaySnapshot := result.snapshot
+					if result.workerID == recentRelayWorkerID {
+						// Do not suppress the whole reconnect
+						// snapshot. Parts emitted while the
+						// relay was down only exist in the
+						// worker buffer, so we trim only the
+						// proven-overlapping prefix.
+						relaySnapshot = trimRelaySnapshotOverlap(recentRelayParts, relaySnapshot)
+					}
+					recentRelayWorkerID = result.workerID
+					if !forwardRelaySnapshot(relaySnapshot) {
+						return
 					}
 				case <-reconnectCh:
 					reconnectCh = nil
@@ -552,6 +572,8 @@ func NewMultiReplicaSubscribeFn(
 					if currentChat.Status == database.ChatStatusRunning &&
 						currentChat.WorkerID.Valid && currentChat.WorkerID.UUID != params.WorkerID {
 						openRelayAsync(currentChat.WorkerID.UUID)
+					} else {
+						closeRelay(true)
 					}
 				case sn, ok := <-statusNotifications:
 					if !ok {
@@ -576,13 +598,13 @@ func NewMultiReplicaSubscribeFn(
 							drainTimer = cfg.clock().NewTimer(relayDrainTimeout, "drain")
 							drainTimerCh = drainTimer.C
 						default:
-							closeRelay()
+							closeRelay(true)
 						}
 					}
 				case <-drainTimerCh:
 					drainTimerCh = nil
 					drainTimer = nil
-					closeRelay()
+					closeRelay(true)
 				case event, ok := <-relayPartsCh:
 					if !ok {
 						if relayCancel != nil {
@@ -607,14 +629,8 @@ func NewMultiReplicaSubscribeFn(
 						scheduleRelayReconnect(delay)
 						continue
 					}
-					// Only forward message_part events from
-					// relay.
-					if event.Type == codersdk.ChatStreamEventTypeMessagePart {
-						select {
-						case <-ctx.Done():
-							return
-						case mergedEvents <- event:
-						}
+					if !forwardRelayPart(event) {
+						return
 					}
 				}
 			}
@@ -623,9 +639,64 @@ func NewMultiReplicaSubscribeFn(
 		// Cleanup is driven by ctx cancellation: the merge
 		// goroutine owns all relay state (reconnectTimer,
 		// relayCancel, dialCancel, etc.) and tears it down
-		// via defer closeRelay() when ctx is done.
+		// via defer closeRelay(true) when ctx is done.
 		return mergedEvents
 	}
+}
+
+func trimRelaySnapshotOverlap(
+	recent []codersdk.ChatStreamEvent,
+	snapshot []codersdk.ChatStreamEvent,
+) []codersdk.ChatStreamEvent {
+	overlap := 0
+	overlapMatches := 0
+	limit := min(len(recent), len(snapshot))
+	for size := 1; size <= limit; size++ {
+		matched := true
+		for i := 0; i < size; i++ {
+			recentEvent := recent[len(recent)-size+i]
+			snapshotEvent := snapshot[i]
+			if recentEvent.Type != codersdk.ChatStreamEventTypeMessagePart ||
+				snapshotEvent.Type != codersdk.ChatStreamEventTypeMessagePart ||
+				!relayMessagePartEqual(recentEvent.MessagePart, snapshotEvent.MessagePart) {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			overlapMatches++
+			overlap = size
+		}
+	}
+	if overlap == 0 || overlapMatches != 1 {
+		return snapshot
+	}
+	return snapshot[overlap:]
+}
+
+func appendRecentRelayPart(
+	recent []codersdk.ChatStreamEvent,
+	event codersdk.ChatStreamEvent,
+) []codersdk.ChatStreamEvent {
+	if event.Type != codersdk.ChatStreamEventTypeMessagePart {
+		return recent
+	}
+	recent = append(recent, event)
+	if len(recent) <= relaySnapshotCap {
+		return recent
+	}
+	copy(recent, recent[len(recent)-relaySnapshotCap:])
+	return recent[:relaySnapshotCap]
+}
+
+func relayMessagePartEqual(
+	left *codersdk.ChatStreamMessagePart,
+	right *codersdk.ChatStreamMessagePart,
+) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return left.Role == right.Role && reflect.DeepEqual(left.Part, right.Part)
 }
 
 // relayRetryState drives the retry policy for the relay reconnect
@@ -741,7 +812,7 @@ func dialRelay(
 	// large message_part batches don't trip the default 32 KiB cap.
 	conn.SetReadLimit(1 << 22)
 
-	snapshot = make([]codersdk.ChatStreamEvent, 0, 100)
+	snapshot = make([]codersdk.ChatStreamEvent, 0, relaySnapshotCap)
 
 	// sourceEvents is the flattened batch→event channel. A small
 	// goroutine reads batches off the websocket and fans them out;

--- a/enterprise/coderd/x/chatd/chatd_internal_test.go
+++ b/enterprise/coderd/x/chatd/chatd_internal_test.go
@@ -174,6 +174,17 @@ func TestRelayMessagePartEqual(t *testing.T) {
 			want:  true,
 		},
 		{
+			name: "different roles compare not equal",
+			left: &codersdk.ChatStreamMessagePart{
+				Role: "user",
+				Part: codersdk.ChatMessageText("same"),
+			},
+			right: &codersdk.ChatStreamMessagePart{
+				Role: "assistant",
+				Part: codersdk.ChatMessageText("same"),
+			},
+		},
+		{
 			name:  "different payloads compare not equal",
 			left:  testRelayMessagePart("left"),
 			right: testRelayMessagePart("right"),

--- a/enterprise/coderd/x/chatd/chatd_internal_test.go
+++ b/enterprise/coderd/x/chatd/chatd_internal_test.go
@@ -1,0 +1,189 @@
+package chatd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/codersdk"
+)
+
+func testRelayTextEvent(text string) codersdk.ChatStreamEvent {
+	return codersdk.ChatStreamEvent{
+		Type: codersdk.ChatStreamEventTypeMessagePart,
+		MessagePart: &codersdk.ChatStreamMessagePart{
+			Role: "assistant",
+			Part: codersdk.ChatMessageText(text),
+		},
+	}
+}
+
+func testRelayTextEvents(texts ...string) []codersdk.ChatStreamEvent {
+	events := make([]codersdk.ChatStreamEvent, 0, len(texts))
+	for _, text := range texts {
+		events = append(events, testRelayTextEvent(text))
+	}
+	return events
+}
+
+func testRelayTexts(events []codersdk.ChatStreamEvent) []string {
+	texts := make([]string, 0, len(events))
+	for _, event := range events {
+		if event.Type == codersdk.ChatStreamEventTypeMessagePart &&
+			event.MessagePart != nil {
+			texts = append(texts, event.MessagePart.Part.Text)
+		}
+	}
+	return texts
+}
+
+func testRelayMessagePart(text string) *codersdk.ChatStreamMessagePart {
+	return &codersdk.ChatStreamMessagePart{
+		Role: "assistant",
+		Part: codersdk.ChatMessageText(text),
+	}
+}
+
+func TestTrimRelaySnapshotOverlap(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		recent   []codersdk.ChatStreamEvent
+		snapshot []codersdk.ChatStreamEvent
+		want     []string
+	}{
+		{
+			name:     "empty recent returns full snapshot",
+			snapshot: testRelayTextEvents("a", "b"),
+			want:     []string{"a", "b"},
+		},
+		{
+			name:   "empty snapshot stays empty",
+			recent: testRelayTextEvents("a"),
+			want:   []string{},
+		},
+		{
+			name: "both empty stay empty",
+			want: []string{},
+		},
+		{
+			name:     "single element exact match trims one part",
+			recent:   testRelayTextEvents("a"),
+			snapshot: testRelayTextEvents("a", "b"),
+			want:     []string{"b"},
+		},
+		{
+			name:     "full overlap trims the whole snapshot",
+			recent:   testRelayTextEvents("a", "b"),
+			snapshot: testRelayTextEvents("a", "b"),
+			want:     []string{},
+		},
+		{
+			name:     "ambiguous overlap falls back to full snapshot",
+			recent:   testRelayTextEvents("a", "b", "a"),
+			snapshot: testRelayTextEvents("a", "b", "a", "c"),
+			want:     []string{"a", "b", "a", "c"},
+		},
+		{
+			name:     "unambiguous overlap trims matching prefix",
+			recent:   testRelayTextEvents("x", "a", "b"),
+			snapshot: testRelayTextEvents("a", "b", "c"),
+			want:     []string{"c"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := trimRelaySnapshotOverlap(tt.recent, tt.snapshot)
+			require.Equal(t, tt.want, testRelayTexts(got))
+		})
+	}
+}
+
+func TestAppendRecentRelayPart(t *testing.T) {
+	t.Parallel()
+
+	recentAtCap := make([]codersdk.ChatStreamEvent, 0, relaySnapshotCap)
+	wantAtCap := make([]string, 0, relaySnapshotCap)
+	for i := range relaySnapshotCap {
+		recentAtCap = append(recentAtCap, testRelayTextEvent(fmt.Sprintf("part-%03d", i)))
+		if i > 0 {
+			wantAtCap = append(wantAtCap, fmt.Sprintf("part-%03d", i))
+		}
+	}
+	wantAtCap = append(wantAtCap, fmt.Sprintf("part-%03d", relaySnapshotCap))
+
+	tests := []struct {
+		name   string
+		recent []codersdk.ChatStreamEvent
+		event  codersdk.ChatStreamEvent
+		want   []string
+	}{
+		{
+			name:   "append under cap preserves order",
+			recent: testRelayTextEvents("a", "b"),
+			event:  testRelayTextEvent("c"),
+			want:   []string{"a", "b", "c"},
+		},
+		{
+			name:   "append at cap keeps most recent entries",
+			recent: recentAtCap,
+			event:  testRelayTextEvent(fmt.Sprintf("part-%03d", relaySnapshotCap)),
+			want:   wantAtCap,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			recent := append([]codersdk.ChatStreamEvent(nil), tt.recent...)
+			got := appendRecentRelayPart(recent, tt.event)
+			require.Equal(t, tt.want, testRelayTexts(got))
+		})
+	}
+}
+
+func TestRelayMessagePartEqual(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		left  *codersdk.ChatStreamMessagePart
+		right *codersdk.ChatStreamMessagePart
+		want  bool
+	}{
+		{
+			name: "both nil are equal",
+			want: true,
+		},
+		{
+			name:  "left nil is not equal",
+			right: testRelayMessagePart("a"),
+		},
+		{
+			name: "right nil is not equal",
+			left: testRelayMessagePart("a"),
+		},
+		{
+			name:  "identical payloads compare equal",
+			left:  testRelayMessagePart("same"),
+			right: testRelayMessagePart("same"),
+			want:  true,
+		},
+		{
+			name:  "different payloads compare not equal",
+			left:  testRelayMessagePart("left"),
+			right: testRelayMessagePart("right"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, relayMessagePartEqual(tt.left, tt.right))
+		})
+	}
+}

--- a/enterprise/coderd/x/chatd/chatd_internal_test.go
+++ b/enterprise/coderd/x/chatd/chatd_internal_test.go
@@ -129,6 +129,12 @@ func TestAppendRecentRelayPart(t *testing.T) {
 			want:   []string{"a", "b", "c"},
 		},
 		{
+			name:   "non-message-part event is ignored",
+			recent: testRelayTextEvents("a", "b"),
+			event:  codersdk.ChatStreamEvent{Type: codersdk.ChatStreamEventTypeStatus},
+			want:   []string{"a", "b"},
+		},
+		{
 			name:   "append at cap keeps most recent entries",
 			recent: recentAtCap,
 			event:  testRelayTextEvent(fmt.Sprintf("part-%03d", relaySnapshotCap)),

--- a/enterprise/coderd/x/chatd/chatd_test.go
+++ b/enterprise/coderd/x/chatd/chatd_test.go
@@ -330,7 +330,7 @@ func requireNoRelayTexts(
 		default:
 			return false
 		}
-	}, testutil.WaitShort, testutil.IntervalFast)
+	}, 2*time.Second, testutil.IntervalFast)
 }
 
 func advanceRelayReconnect(
@@ -378,7 +378,7 @@ func TestSubscribeRelayReconnectsOnDrop(t *testing.T) {
 					Part: codersdk.ChatMessageText("second-relay"),
 				},
 			}
-			// Don't close — keep alive so the subscriber stays connected.
+			// Don't close, keep alive so the subscriber stays connected.
 		}
 		return nil, ch, func() {}, nil
 	}
@@ -632,6 +632,46 @@ func TestSubscribeRelayReconnectRepeatedPayloadsFallBackToFullSnapshot(t *testin
 		return callCount.Load() == 2
 	}, testutil.WaitShort, testutil.IntervalFast)
 	requireRelayTexts(t, events, "dup", "dup", "new-tail")
+}
+
+func TestSubscribeRelayReconnectDedupsAcrossThreeCycles(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+	workerID := uuid.New()
+	subscriberID := uuid.New()
+	dialer, callCount := newScriptedRelayDialer([]relayDialScript{
+		{workerID: workerID, snapshot: []string{"cycle-a", "cycle-b"}, closeLive: true},
+		{workerID: workerID, snapshot: []string{"cycle-b", "cycle-c"}, closeLive: true},
+		{workerID: workerID, snapshot: []string{"cycle-b", "cycle-c", "cycle-d"}},
+	})
+
+	mclk := quartz.NewMock(t)
+	trapReconnect := mclk.Trap().NewTimer("reconnect")
+	defer trapReconnect.Close()
+
+	subscriber := newTestServer(t, db, ps, subscriberID, dialer, mclk)
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	user, org, model := seedChatDependencies(ctx, t, db)
+	chat := seedRemoteRunningChat(ctx, t, db, org.ID, user, model, workerID, "relay-three-cycles")
+
+	_, events, cancel, ok := subscriber.Subscribe(ctx, chat.ID, nil, 0)
+	require.True(t, ok)
+	t.Cleanup(cancel)
+
+	requireRelayTexts(t, events, "cycle-a", "cycle-b")
+	advanceRelayReconnect(ctx, t, mclk, trapReconnect)
+	require.Eventually(t, func() bool {
+		return callCount.Load() == 2
+	}, testutil.WaitShort, testutil.IntervalFast)
+	requireRelayTexts(t, events, "cycle-c")
+	advanceRelayReconnect(ctx, t, mclk, trapReconnect)
+	require.Eventually(t, func() bool {
+		return callCount.Load() == 3
+	}, testutil.WaitShort, testutil.IntervalFast)
+	requireRelayTexts(t, events, "cycle-d")
+	requireNoRelayTexts(t, events)
 }
 
 func TestSubscribeRelayAsyncDoesNotBlock(t *testing.T) {
@@ -967,7 +1007,7 @@ func TestSubscribeRelayStaleDialDiscardedAfterInterrupt(t *testing.T) {
 				return nil, nil, nil, ctx.Err()
 			}
 			// If we get here after being released (not canceled),
-			// return a stale part — this should be discarded.
+			// return a stale part. This should be discarded.
 			ch <- codersdk.ChatStreamEvent{
 				Type: codersdk.ChatStreamEventTypeMessagePart,
 				MessagePart: &codersdk.ChatStreamMessagePart{
@@ -998,7 +1038,7 @@ func TestSubscribeRelayStaleDialDiscardedAfterInterrupt(t *testing.T) {
 	// relay.
 	chat := seedWaitingChat(ctx, t, db, org.ID, user, model, "stale-dial-test")
 
-	// Subscribe while chat is in "waiting" state — no relay opened.
+	// Subscribe while chat is in "waiting" state, no relay opened.
 	_, events, cancel, ok := subscriber.Subscribe(ctx, chat.ID, nil, 0)
 	require.True(t, ok)
 	t.Cleanup(cancel)
@@ -1092,7 +1132,7 @@ func TestSubscribeRelayStaleDialDiscardedAfterInterrupt(t *testing.T) {
 			if event.Type == codersdk.ChatStreamEventTypeMessagePart &&
 				event.MessagePart != nil &&
 				event.MessagePart.Part.Text == "stale-part" {
-				t.Fatal("received stale part from old worker — relay did not cancel in-flight dial")
+				t.Fatal("received stale part from old worker, relay did not cancel in-flight dial")
 			}
 			return false
 		default:
@@ -1478,7 +1518,7 @@ func TestSubscribeRunningLocalWorkerClosesRelay(t *testing.T) {
 	require.NoError(t, err)
 
 	// Give the system time to process the notification. No additional
-	// dial should happen — only the initial synchronous one.
+	// dial should happen, only the initial synchronous one.
 	require.Never(t, func() bool {
 		return int(callCount.Load()) > 1
 	}, 2*time.Second, testutil.IntervalFast)
@@ -1489,7 +1529,7 @@ func TestSubscribeRunningLocalWorkerClosesRelay(t *testing.T) {
 
 // TestSubscribeRelayMultipleReconnects verifies that the reconnect
 // loop handles multiple consecutive relay drops, proving it is
-// robust across repeated iterations — not just the single reconnect
+// robust across repeated iterations, not just the single reconnect
 // already covered by TestSubscribeRelayReconnectsOnDrop.
 func TestSubscribeRelayMultipleReconnects(t *testing.T) {
 	t.Parallel()

--- a/enterprise/coderd/x/chatd/chatd_test.go
+++ b/enterprise/coderd/x/chatd/chatd_test.go
@@ -209,6 +209,142 @@ func setOpenAIProviderBaseURL(
 	require.NoError(t, err)
 }
 
+type relayDialScript struct {
+	workerID  uuid.UUID
+	snapshot  []string
+	live      []string
+	closeLive bool
+}
+
+func relayTextEvent(text string) codersdk.ChatStreamEvent {
+	return codersdk.ChatStreamEvent{
+		Type: codersdk.ChatStreamEventTypeMessagePart,
+		MessagePart: &codersdk.ChatStreamMessagePart{
+			Role: "assistant",
+			Part: codersdk.ChatMessageText(text),
+		},
+	}
+}
+
+func relaySnapshotEvents(texts ...string) []codersdk.ChatStreamEvent {
+	events := make([]codersdk.ChatStreamEvent, 0, len(texts))
+	for _, text := range texts {
+		events = append(events, relayTextEvent(text))
+	}
+	return events
+}
+
+func newScriptedRelayDialer(
+	scripts []relayDialScript,
+) (
+	func(
+		ctx context.Context,
+		chatID uuid.UUID,
+		workerID uuid.UUID,
+		requestHeader http.Header,
+	) (
+		[]codersdk.ChatStreamEvent,
+		<-chan codersdk.ChatStreamEvent,
+		func(),
+		error,
+	),
+	*atomic.Int32,
+) {
+	var callCount atomic.Int32
+	return func(
+		_ context.Context,
+		_ uuid.UUID,
+		workerID uuid.UUID,
+		_ http.Header,
+	) (
+		[]codersdk.ChatStreamEvent,
+		<-chan codersdk.ChatStreamEvent,
+		func(),
+		error,
+	) {
+		idx := int(callCount.Add(1)) - 1
+		if idx >= len(scripts) {
+			return nil, nil, nil, xerrors.Errorf(
+				"unexpected relay dial %d for worker %s",
+				idx+1,
+				workerID,
+			)
+		}
+		script := scripts[idx]
+		if script.workerID != uuid.Nil && script.workerID != workerID {
+			return nil, nil, nil, xerrors.Errorf(
+				"unexpected relay target %s on dial %d",
+				workerID,
+				idx+1,
+			)
+		}
+		live := make(chan codersdk.ChatStreamEvent, len(script.live))
+		for _, text := range script.live {
+			live <- relayTextEvent(text)
+		}
+		if script.closeLive {
+			close(live)
+		}
+		return relaySnapshotEvents(script.snapshot...), live, func() {}, nil
+	}, &callCount
+}
+
+func requireRelayTexts(
+	t *testing.T,
+	events <-chan codersdk.ChatStreamEvent,
+	want ...string,
+) {
+	t.Helper()
+	got := make([]string, 0, len(want))
+	require.Eventually(t, func() bool {
+		select {
+		case event, ok := <-events:
+			if !ok {
+				return false
+			}
+			if event.Type == codersdk.ChatStreamEventTypeMessagePart &&
+				event.MessagePart != nil {
+				got = append(got, event.MessagePart.Part.Text)
+			}
+			return len(got) >= len(want)
+		default:
+			return false
+		}
+	}, testutil.WaitMedium, testutil.IntervalFast)
+	require.Equal(t, want, got)
+}
+
+func requireNoRelayTexts(
+	t *testing.T,
+	events <-chan codersdk.ChatStreamEvent,
+) {
+	t.Helper()
+	require.Never(t, func() bool {
+		select {
+		case event, ok := <-events:
+			if !ok {
+				return false
+			}
+			return event.Type == codersdk.ChatStreamEventTypeMessagePart &&
+				event.MessagePart != nil
+		default:
+			return false
+		}
+	}, testutil.WaitShort, testutil.IntervalFast)
+}
+
+func advanceRelayReconnect(
+	ctx context.Context,
+	t *testing.T,
+	mclk *quartz.Mock,
+	trapReconnect *quartz.Trap,
+) {
+	t.Helper()
+	call := trapReconnect.MustWait(ctx)
+	call.MustRelease(ctx)
+	mclk.Advance(call.Duration).MustWait(ctx)
+}
+
 func TestSubscribeRelayReconnectsOnDrop(t *testing.T) {
 	t.Parallel()
 
@@ -301,6 +437,201 @@ func TestSubscribeRelayReconnectsOnDrop(t *testing.T) {
 	}, testutil.WaitMedium, testutil.IntervalFast)
 
 	require.GreaterOrEqual(t, int(callCount.Load()), 2)
+}
+
+func TestSubscribeRelayReconnectDedupsIdenticalSnapshot(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+	workerID := uuid.New()
+	subscriberID := uuid.New()
+	dialer, callCount := newScriptedRelayDialer([]relayDialScript{
+		{workerID: workerID, snapshot: []string{"snap-one", "snap-two"}, closeLive: true},
+		{workerID: workerID, snapshot: []string{"snap-one", "snap-two"}},
+	})
+
+	mclk := quartz.NewMock(t)
+	trapReconnect := mclk.Trap().NewTimer("reconnect")
+	defer trapReconnect.Close()
+
+	subscriber := newTestServer(t, db, ps, subscriberID, dialer, mclk)
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	user, org, model := seedChatDependencies(ctx, t, db)
+	chat := seedRemoteRunningChat(ctx, t, db, org.ID, user, model, workerID, "relay-dedup-identical")
+
+	_, events, cancel, ok := subscriber.Subscribe(ctx, chat.ID, nil, 0)
+	require.True(t, ok)
+	t.Cleanup(cancel)
+
+	requireRelayTexts(t, events, "snap-one", "snap-two")
+	advanceRelayReconnect(ctx, t, mclk, trapReconnect)
+	require.Eventually(t, func() bool {
+		return callCount.Load() == 2
+	}, testutil.WaitShort, testutil.IntervalFast)
+	requireNoRelayTexts(t, events)
+}
+
+func TestSubscribeRelayReconnectTrimsOverlapPlusNewSuffix(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+	workerID := uuid.New()
+	subscriberID := uuid.New()
+	dialer, callCount := newScriptedRelayDialer([]relayDialScript{
+		{workerID: workerID, snapshot: []string{"snap-one"}, live: []string{"seen-live"}, closeLive: true},
+		{workerID: workerID, snapshot: []string{"seen-live", "new-tail"}},
+	})
+
+	mclk := quartz.NewMock(t)
+	trapReconnect := mclk.Trap().NewTimer("reconnect")
+	defer trapReconnect.Close()
+
+	subscriber := newTestServer(t, db, ps, subscriberID, dialer, mclk)
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	user, org, model := seedChatDependencies(ctx, t, db)
+	chat := seedRemoteRunningChat(ctx, t, db, org.ID, user, model, workerID, "relay-overlap-new-suffix")
+
+	_, events, cancel, ok := subscriber.Subscribe(ctx, chat.ID, nil, 0)
+	require.True(t, ok)
+	t.Cleanup(cancel)
+
+	requireRelayTexts(t, events, "snap-one", "seen-live")
+	advanceRelayReconnect(ctx, t, mclk, trapReconnect)
+	require.Eventually(t, func() bool {
+		return callCount.Load() == 2
+	}, testutil.WaitShort, testutil.IntervalFast)
+	requireRelayTexts(t, events, "new-tail")
+}
+
+func TestSubscribeRelayWorkerChangeResetsDedup(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+	workerA := uuid.New()
+	workerB := uuid.New()
+	subscriberID := uuid.New()
+	dialer, callCount := newScriptedRelayDialer([]relayDialScript{
+		{workerID: workerA, snapshot: []string{"shared-one", "shared-two"}},
+		{workerID: workerB, snapshot: []string{"shared-one", "shared-two"}},
+	})
+
+	subscriber := newTestServer(t, db, ps, subscriberID, dialer, nil)
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	user, org, model := seedChatDependencies(ctx, t, db)
+	chat := seedRemoteRunningChat(ctx, t, db, org.ID, user, model, workerA, "relay-worker-change")
+
+	_, events, cancel, ok := subscriber.Subscribe(ctx, chat.ID, nil, 0)
+	require.True(t, ok)
+	t.Cleanup(cancel)
+
+	requireRelayTexts(t, events, "shared-one", "shared-two")
+	setChatRunningAndPublish(ctx, t, db, ps, chat.ID, workerB)
+	require.Eventually(t, func() bool {
+		return callCount.Load() == 2
+	}, testutil.WaitMedium, testutil.IntervalFast)
+	requireRelayTexts(t, events, "shared-one", "shared-two")
+}
+
+func TestSubscribeRelayReconnectMismatchFallsBackToFullSnapshot(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+	workerID := uuid.New()
+	subscriberID := uuid.New()
+	dialer, callCount := newScriptedRelayDialer([]relayDialScript{
+		{workerID: workerID, snapshot: []string{"seen-one", "seen-two"}, closeLive: true},
+		{workerID: workerID, snapshot: []string{"different-one", "seen-two"}},
+	})
+
+	mclk := quartz.NewMock(t)
+	trapReconnect := mclk.Trap().NewTimer("reconnect")
+	defer trapReconnect.Close()
+
+	subscriber := newTestServer(t, db, ps, subscriberID, dialer, mclk)
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	user, org, model := seedChatDependencies(ctx, t, db)
+	chat := seedRemoteRunningChat(ctx, t, db, org.ID, user, model, workerID, "relay-mismatch-fallback")
+
+	_, events, cancel, ok := subscriber.Subscribe(ctx, chat.ID, nil, 0)
+	require.True(t, ok)
+	t.Cleanup(cancel)
+
+	requireRelayTexts(t, events, "seen-one", "seen-two")
+	advanceRelayReconnect(ctx, t, mclk, trapReconnect)
+	require.Eventually(t, func() bool {
+		return callCount.Load() == 2
+	}, testutil.WaitShort, testutil.IntervalFast)
+	requireRelayTexts(t, events, "different-one", "seen-two")
+}
+
+func TestSubscribeRelayInitialSnapshotSeedsDedup(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+	workerID := uuid.New()
+	subscriberID := uuid.New()
+	dialer, callCount := newScriptedRelayDialer([]relayDialScript{
+		{workerID: workerID, snapshot: []string{"seed-one", "seed-two"}, closeLive: true},
+		{workerID: workerID, snapshot: []string{"seed-one", "seed-two", "new-tail"}},
+	})
+
+	mclk := quartz.NewMock(t)
+	trapReconnect := mclk.Trap().NewTimer("reconnect")
+	defer trapReconnect.Close()
+
+	subscriber := newTestServer(t, db, ps, subscriberID, dialer, mclk)
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	user, org, model := seedChatDependencies(ctx, t, db)
+	chat := seedRemoteRunningChat(ctx, t, db, org.ID, user, model, workerID, "relay-initial-snapshot-dedup")
+
+	_, events, cancel, ok := subscriber.Subscribe(ctx, chat.ID, nil, 0)
+	require.True(t, ok)
+	t.Cleanup(cancel)
+
+	requireRelayTexts(t, events, "seed-one", "seed-two")
+	advanceRelayReconnect(ctx, t, mclk, trapReconnect)
+	require.Eventually(t, func() bool {
+		return callCount.Load() == 2
+	}, testutil.WaitShort, testutil.IntervalFast)
+	requireRelayTexts(t, events, "new-tail")
+}
+
+func TestSubscribeRelayReconnectRepeatedPayloadsFallBackToFullSnapshot(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+	workerID := uuid.New()
+	subscriberID := uuid.New()
+	dialer, callCount := newScriptedRelayDialer([]relayDialScript{
+		{workerID: workerID, snapshot: []string{"dup", "dup"}, closeLive: true},
+		{workerID: workerID, snapshot: []string{"dup", "dup", "new-tail"}},
+	})
+
+	mclk := quartz.NewMock(t)
+	trapReconnect := mclk.Trap().NewTimer("reconnect")
+	defer trapReconnect.Close()
+
+	subscriber := newTestServer(t, db, ps, subscriberID, dialer, mclk)
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	user, org, model := seedChatDependencies(ctx, t, db)
+	chat := seedRemoteRunningChat(ctx, t, db, org.ID, user, model, workerID, "relay-repeated-payloads")
+
+	_, events, cancel, ok := subscriber.Subscribe(ctx, chat.ID, nil, 0)
+	require.True(t, ok)
+	t.Cleanup(cancel)
+
+	requireRelayTexts(t, events, "dup", "dup")
+	advanceRelayReconnect(ctx, t, mclk, trapReconnect)
+	require.Eventually(t, func() bool {
+		return callCount.Load() == 2
+	}, testutil.WaitShort, testutil.IntervalFast)
+	requireRelayTexts(t, events, "dup", "dup", "new-tail")
 }
 
 func TestSubscribeRelayAsyncDoesNotBlock(t *testing.T) {

--- a/enterprise/coderd/x/chatd/chatd_test.go
+++ b/enterprise/coderd/x/chatd/chatd_test.go
@@ -716,6 +716,99 @@ func TestSubscribeRelayReconnectClearsDedupWhenChatStopsRemote(t *testing.T) {
 	requireRelayTexts(t, events, "stale-one", "stale-two", "new-run")
 }
 
+func TestSubscribeRelayDrainFailureClearsDedupWhenChatStopsRemote(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+	workerID := uuid.New()
+	subscriberID := uuid.New()
+	secondDialStarted := make(chan struct{})
+	releaseSecondDial := make(chan struct{})
+	var callCount atomic.Int32
+
+	provider := func(ctx context.Context, _ uuid.UUID, worker uuid.UUID, _ http.Header) (
+		[]codersdk.ChatStreamEvent,
+		<-chan codersdk.ChatStreamEvent,
+		func(),
+		error,
+	) {
+		require.Equal(t, workerID, worker)
+		switch call := callCount.Add(1); call {
+		case 1:
+			live := make(chan codersdk.ChatStreamEvent)
+			close(live)
+			return relaySnapshotEvents("stale-one", "stale-two"), live, func() {}, nil
+		case 2:
+			close(secondDialStarted)
+			select {
+			case <-releaseSecondDial:
+				return nil, nil, nil, xerrors.New("drain dial failed")
+			case <-ctx.Done():
+				return nil, nil, nil, ctx.Err()
+			}
+		case 3:
+			live := make(chan codersdk.ChatStreamEvent)
+			return relaySnapshotEvents("stale-one", "stale-two", "new-run"), live, func() {}, nil
+		default:
+			return nil, nil, nil, xerrors.Errorf("unexpected relay dial %d", call)
+		}
+	}
+
+	mclk := quartz.NewMock(t)
+	trapReconnect := mclk.Trap().NewTimer("reconnect")
+	defer trapReconnect.Close()
+
+	subscriber := newTestServer(t, db, ps, subscriberID, provider, mclk)
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	user, org, model := seedChatDependencies(ctx, t, db)
+	chat := seedRemoteRunningChat(ctx, t, db, org.ID, user, model, workerID, "relay-clear-on-drain-failure")
+
+	_, events, cancel, ok := subscriber.Subscribe(ctx, chat.ID, nil, 0)
+	require.True(t, ok)
+	t.Cleanup(cancel)
+
+	requireRelayTexts(t, events, "stale-one", "stale-two")
+	advanceRelayReconnect(ctx, t, mclk, trapReconnect)
+
+	select {
+	case <-secondDialStarted:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for second relay dial")
+	}
+
+	_, err := db.UpdateChatStatus(ctx, database.UpdateChatStatusParams{
+		ID:     chat.ID,
+		Status: database.ChatStatusWaiting,
+	})
+	require.NoError(t, err)
+	waitingPayload, err := json.Marshal(coderdpubsub.ChatStreamNotifyMessage{
+		Status: string(database.ChatStatusWaiting),
+	})
+	require.NoError(t, err)
+	err = ps.Publish(coderdpubsub.ChatStreamNotifyChannel(chat.ID), waitingPayload)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		select {
+		case event := <-events:
+			return event.Type == codersdk.ChatStreamEventTypeStatus &&
+				event.Status != nil &&
+				event.Status.Status == codersdk.ChatStatusWaiting
+		default:
+			return false
+		}
+	}, testutil.WaitMedium, testutil.IntervalFast)
+
+	close(releaseSecondDial)
+	requireNoRelayTexts(t, events)
+
+	setChatRunningAndPublish(ctx, t, db, ps, chat.ID, workerID)
+	require.Eventually(t, func() bool {
+		return callCount.Load() == 3
+	}, testutil.WaitShort, testutil.IntervalFast)
+	requireRelayTexts(t, events, "stale-one", "stale-two", "new-run")
+}
+
 func TestSubscribeRelayAsyncDoesNotBlock(t *testing.T) {
 	t.Parallel()
 

--- a/enterprise/coderd/x/chatd/chatd_test.go
+++ b/enterprise/coderd/x/chatd/chatd_test.go
@@ -674,6 +674,48 @@ func TestSubscribeRelayReconnectDedupsAcrossThreeCycles(t *testing.T) {
 	requireNoRelayTexts(t, events)
 }
 
+func TestSubscribeRelayReconnectClearsDedupWhenChatStopsRemote(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+	workerID := uuid.New()
+	subscriberID := uuid.New()
+	dialer, callCount := newScriptedRelayDialer([]relayDialScript{
+		{workerID: workerID, snapshot: []string{"stale-one", "stale-two"}, closeLive: true},
+		{workerID: workerID, snapshot: []string{"stale-one", "stale-two", "new-run"}},
+	})
+
+	mclk := quartz.NewMock(t)
+	trapReconnect := mclk.Trap().NewTimer("reconnect")
+	defer trapReconnect.Close()
+
+	subscriber := newTestServer(t, db, ps, subscriberID, dialer, mclk)
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	user, org, model := seedChatDependencies(ctx, t, db)
+	chat := seedRemoteRunningChat(ctx, t, db, org.ID, user, model, workerID, "relay-clear-on-idle")
+
+	_, events, cancel, ok := subscriber.Subscribe(ctx, chat.ID, nil, 0)
+	require.True(t, ok)
+	t.Cleanup(cancel)
+
+	requireRelayTexts(t, events, "stale-one", "stale-two")
+	_, err := db.UpdateChatStatus(ctx, database.UpdateChatStatusParams{
+		ID:     chat.ID,
+		Status: database.ChatStatusWaiting,
+	})
+	require.NoError(t, err)
+
+	advanceRelayReconnect(ctx, t, mclk, trapReconnect)
+	requireNoRelayTexts(t, events)
+
+	setChatRunningAndPublish(ctx, t, db, ps, chat.ID, workerID)
+	require.Eventually(t, func() bool {
+		return callCount.Load() == 2
+	}, testutil.WaitShort, testutil.IntervalFast)
+	requireRelayTexts(t, events, "stale-one", "stale-two", "new-run")
+}
+
 func TestSubscribeRelayAsyncDoesNotBlock(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
On enterprise multi-replica setups, `message_part` events for in-flight
chat output live only in the worker replica's memory. Cross-replica
subscribers recover them through the enterprise relay (`dialRelay` +
`NewMultiReplicaSubscribeFn`), not via DB replay. When the relay leg
drops and reconnects inside one still-active subscription, the new
relay snapshot can overlap parts already forwarded to the subscriber,
producing duplicate output in the client.

This change adds per-subscription recent-history tracking of relay
`message_part` events actually forwarded downstream. On a reconnect
snapshot, we compute the largest proven exact-payload overlap against
the recent-forwarded tail, drop only that overlapping prefix, and
forward the remaining suffix plus the live relay stream. If overlap
cannot be proven (no match, or repeated identical payloads make it
ambiguous), we forward the full snapshot to avoid dropping real output.
Dedupe state resets when the relay worker changes or the relay leg is
fully torn down, but persists across same-worker transient reconnects.

No changes to OSS chatd, SDK, CLI, site, or websocket framing.

> Mux is acting on Mike's behalf.