### PR TITLE
refactor(coderd/x/chatd/chattool): consolidate plan-path validation

### DIFF
--- a/coderd/x/chatd/chattool/editfiles.go
+++ b/coderd/x/chatd/chattool/editfiles.go
@@ -66,32 +66,11 @@ func executeEditFilesTool(
 		return fantasy.NewTextErrorResponse("files is required"), nil
 	}
 
-	var (
-		chatPath       string
-		home           string
-		planPathErr    error
-		planPathLoaded bool
-	)
 	for i := range args.Files {
 		args.Files[i].Path = strings.TrimSpace(args.Files[i].Path)
-		file := args.Files[i]
-
-		hasPlanFileName := looksLikePlanFileName(file.Path)
-		if hasPlanFileName && !isAbsolutePath(file.Path) {
+		if resp, rejected := validatePlanPath(ctx, args.Files[i].Path, resolvePlanPath); rejected {
 			return fantasy.NewTextErrorResponse(
-				"plan files must use absolute paths; use the chat-specific absolute plan path; no files in this batch were applied",
-			), nil
-		}
-		if resolvePlanPath == nil || !hasPlanFileName {
-			continue
-		}
-		if !planPathLoaded {
-			chatPath, home, planPathErr = resolvePlanPath(ctx)
-			planPathLoaded = true
-		}
-		if resp, rejected := rejectSharedPlanPath(file.Path, home, chatPath, planPathErr); rejected {
-			return fantasy.NewTextErrorResponse(
-				resp.Content + "; no files in this batch were applied",
+				resp.Content+"; no files in this batch were applied",
 			), nil
 		}
 	}

--- a/coderd/x/chatd/chattool/editfiles_test.go
+++ b/coderd/x/chatd/chattool/editfiles_test.go
@@ -188,14 +188,16 @@ func TestEditFiles(t *testing.T) {
 		t.Parallel()
 
 		tests := []struct {
-			name                 string
-			input                string
-			expectedRejectedPath string
+			name                  string
+			input                 string
+			expectedRejectedPath  string
+			expectedResolverCalls int
 		}{
 			{
-				name:                 "SingleHomeRootPlanPath",
-				input:                `{"files":[{"path":"/Users/dev/plan.md","edits":[{"search":"old","replace":"new"}]}]}`,
-				expectedRejectedPath: "/Users/dev/plan.md",
+				name:                  "SingleHomeRootPlanPath",
+				input:                 `{"files":[{"path":"/Users/dev/plan.md","edits":[{"search":"old","replace":"new"}]}]}`,
+				expectedRejectedPath:  "/Users/dev/plan.md",
+				expectedResolverCalls: 1,
 			},
 			{
 				name: "MultiFileBatchWithHomeRootPlanPath",
@@ -203,7 +205,8 @@ func TestEditFiles(t *testing.T) {
 					`{"path":"/Users/dev/subdir/plan.md","edits":[{"search":"old","replace":"new"}]},` +
 					`{"path":"/Users/dev/plan.md","edits":[{"search":"old","replace":"new"}]}` +
 					`]}`,
-				expectedRejectedPath: "/Users/dev/plan.md",
+				expectedRejectedPath:  "/Users/dev/plan.md",
+				expectedResolverCalls: 2,
 			},
 		}
 
@@ -230,7 +233,7 @@ func TestEditFiles(t *testing.T) {
 				})
 				require.NoError(t, err)
 				assert.True(t, resp.IsError)
-				assert.Equal(t, 1, resolvePlanPathCalls)
+				assert.Equal(t, testCase.expectedResolverCalls, resolvePlanPathCalls)
 				assert.Equal(
 					t,
 					editFilesBatchRejectedMessage(sharedPlanPathResolvedMessage(

--- a/coderd/x/chatd/chattool/planpath.go
+++ b/coderd/x/chatd/chattool/planpath.go
@@ -5,6 +5,8 @@ import (
 	"path"
 	"strings"
 
+	"charm.land/fantasy"
+
 	"github.com/google/uuid"
 	"golang.org/x/xerrors"
 
@@ -71,6 +73,32 @@ func resolvePlanTurnPath(
 	}
 
 	return planPath, nil
+}
+
+// validatePlanPath checks whether requestedPath targets a plan
+// file and, if so, enforces that it uses an absolute,
+// chat-specific path rather than a relative or shared home-root
+// path. Returns a rejection response and true when the path is
+// invalid. Non-plan file paths pass through without validation.
+func validatePlanPath(
+	ctx context.Context,
+	requestedPath string,
+	resolvePlanPath func(context.Context) (chatPath string, home string, err error),
+) (fantasy.ToolResponse, bool) {
+	if !looksLikePlanFileName(requestedPath) {
+		return fantasy.ToolResponse{}, false
+	}
+	if !isAbsolutePath(requestedPath) {
+		return fantasy.NewTextErrorResponse(
+			"plan files must use absolute paths; " +
+				"use the chat-specific absolute plan path",
+		), true
+	}
+	if resolvePlanPath == nil {
+		return fantasy.ToolResponse{}, false
+	}
+	chatPath, home, err := resolvePlanPath(ctx)
+	return rejectSharedPlanPath(requestedPath, home, chatPath, err)
 }
 
 // chatd consumes agent-normalized POSIX paths. Workspace agents are

--- a/coderd/x/chatd/chattool/proposeplan.go
+++ b/coderd/x/chatd/chattool/proposeplan.go
@@ -81,18 +81,8 @@ func executeProposePlanTool(
 		return fantasy.NewTextErrorResponse("path must end with .md"), nil
 	}
 
-	hasPlanFileName := looksLikePlanFileName(requestedPath)
-	if hasPlanFileName && !isAbsolutePath(requestedPath) {
-		return fantasy.NewTextErrorResponse(
-			"plan files must use absolute paths; use the chat-specific absolute plan path",
-		), nil
-	}
-
-	if resolvePlanPath != nil && hasPlanFileName {
-		chatPath, home, err := resolvePlanPath(ctx)
-		if resp, rejected := rejectSharedPlanPath(requestedPath, home, chatPath, err); rejected {
-			return resp, nil
-		}
+	if resp, rejected := validatePlanPath(ctx, requestedPath, resolvePlanPath); rejected {
+		return resp, nil
 	}
 
 	rc, _, err := conn.ReadFile(ctx, requestedPath, 0, maxProposePlanSize+1)

--- a/coderd/x/chatd/chattool/writefile.go
+++ b/coderd/x/chatd/chattool/writefile.go
@@ -65,18 +65,8 @@ func executeWriteFileTool(
 		return fantasy.NewTextErrorResponse("path is required"), nil
 	}
 
-	hasPlanFileName := looksLikePlanFileName(requestedPath)
-	if hasPlanFileName && !isAbsolutePath(requestedPath) {
-		return fantasy.NewTextErrorResponse(
-			"plan files must use absolute paths; use the chat-specific absolute plan path",
-		), nil
-	}
-
-	if resolvePlanPath != nil && hasPlanFileName {
-		chatPath, home, err := resolvePlanPath(ctx)
-		if resp, rejected := rejectSharedPlanPath(requestedPath, home, chatPath, err); rejected {
-			return resp, nil
-		}
+	if resp, rejected := validatePlanPath(ctx, requestedPath, resolvePlanPath); rejected {
+		return resp, nil
 	}
 
 	if err := conn.WriteFile(ctx, requestedPath, strings.NewReader(args.Content)); err != nil {


### PR DESCRIPTION
Closes #24290

Plan-path validation (legacy path rejection, relative path rejection, plan path resolution) was duplicated across `writefile.go`, `editfiles.go`, and `proposeplan.go`. This extracts a shared `validatePlanPath` helper in `planpath.go`.

**Changes:**
- New `planpath.go`: shared `validatePlanPath(ctx, path, resolvePlanPath)` helper
- `writefile.go`: 12-line inline block replaced with 3-line call
- `proposeplan.go`: identical replacement
- `editfiles.go`: batch loop replaced with per-file `validatePlanPath` call
- `editfiles_test.go`: updated resolver call count expectation (1 to 2)

**Trade-off:** the `editfiles` handler no longer caches the resolver result across batch entries. The resolver is now called once per plan-named file instead of once per batch. This simplifies the code at negligible cost since batches with multiple plan-named files don't occur in practice.

Net: 45 insertions, 55 deletions. No behavioral change.

> 🤖 Generated by Coder Agents

<details><summary>Review notes</summary>

- All existing tests pass
- Error messages are preserved exactly
- The resolver caching trade-off is intentional and documented above

</details>