### PR TITLE
fix: allow "me" shortcut in swagger user parameter validation

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -9367,8 +9367,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "format": "uuid",
-                        "description": "User ID",
+                        "description": "User ID, name, or me",
                         "name": "user",
                         "in": "path",
                         "required": true
@@ -9406,8 +9405,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "format": "uuid",
-                        "description": "User ID",
+                        "description": "User ID, name, or me",
                         "name": "user",
                         "in": "path",
                         "required": true

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -8300,8 +8300,7 @@
 				"parameters": [
 					{
 						"type": "string",
-						"format": "uuid",
-						"description": "User ID",
+						"description": "User ID, name, or me",
 						"name": "user",
 						"in": "path",
 						"required": true
@@ -8333,8 +8332,7 @@
 				"parameters": [
 					{
 						"type": "string",
-						"format": "uuid",
-						"description": "User ID",
+						"description": "User ID, name, or me",
 						"name": "user",
 						"in": "path",
 						"required": true

--- a/docs/reference/api/enterprise.md
+++ b/docs/reference/api/enterprise.md
@@ -4124,9 +4124,9 @@ curl -X GET http://coder-server:8080/api/v2/users/{user}/quiet-hours \
 
 ### Parameters
 
-| Name   | In   | Type         | Required | Description |
-|--------|------|--------------|----------|-------------|
-| `user` | path | string(uuid) | true     | User ID     |
+| Name   | In   | Type   | Required | Description          |
+|--------|------|--------|----------|----------------------|
+| `user` | path | string | true     | User ID, name, or me |
 
 ### Example responses
 
@@ -4193,7 +4193,7 @@ curl -X PUT http://coder-server:8080/api/v2/users/{user}/quiet-hours \
 
 | Name   | In   | Type                                                                                                   | Required | Description             |
 |--------|------|--------------------------------------------------------------------------------------------------------|----------|-------------------------|
-| `user` | path | string(uuid)                                                                                           | true     | User ID                 |
+| `user` | path | string                                                                                                 | true     | User ID, name, or me    |
 | `body` | body | [codersdk.UpdateUserQuietHoursScheduleRequest](schemas.md#codersdkupdateuserquiethoursschedulerequest) | true     | Update schedule request |
 
 ### Example responses

--- a/enterprise/coderd/users.go
+++ b/enterprise/coderd/users.go
@@ -41,7 +41,7 @@ func (api *API) autostopRequirementEnabledMW(next http.Handler) http.Handler {
 // @Security CoderSessionToken
 // @Produce json
 // @Tags Enterprise
-// @Param user path string true "User ID" format(uuid)
+// @Param user path string true "User ID, name, or me"
 // @Success 200 {array} codersdk.UserQuietHoursScheduleResponse
 // @Router /users/{user}/quiet-hours [get]
 func (api *API) userQuietHoursSchedule(rw http.ResponseWriter, r *http.Request) {
@@ -76,7 +76,7 @@ func (api *API) userQuietHoursSchedule(rw http.ResponseWriter, r *http.Request) 
 // @Accept json
 // @Produce json
 // @Tags Enterprise
-// @Param user path string true "User ID" format(uuid)
+// @Param user path string true "User ID, name, or me"
 // @Param request body codersdk.UpdateUserQuietHoursScheduleRequest true "Update schedule request"
 // @Success 200 {array} codersdk.UserQuietHoursScheduleResponse
 // @Router /users/{user}/quiet-hours [put]


### PR DESCRIPTION
Closes #24473

The two quiet-hours endpoints in `enterprise/coderd/users.go` had `format(uuid)` on their `@Param user` swagger annotations. Swagger UI validates this client-side, rejecting "me" as not a valid UUID before any request is sent.

All other `{user}` endpoints use plain `string` without `format(uuid)`. This removes the format constraint and updates the description to `"User ID, name, or me"` to match convention.

**Changes:**
- `enterprise/coderd/users.go`: removed `format(uuid)` from both `@Param user` annotations
- `coderd/apidoc/docs.go`, `coderd/apidoc/swagger.json`, `docs/reference/api/enterprise.md`: regenerated via `make gen`

> 🤖 Generated by Coder Agents

<details><summary>Review notes</summary>

- These were the only two {user} params with format(uuid) in the codebase
- 7 other non-user endpoints have similar format(uuid) on name-accepting params (out of scope)
- Generated files produced by make gen, not hand-edited

</details>