### PR TITLE
feat(coderd/x/chatd): reshape auto-title prompt as noun phrase

### DIFF
--- a/coderd/x/chatd/quickgen.go
+++ b/coderd/x/chatd/quickgen.go
@@ -29,13 +29,64 @@ import (
 	"github.com/coder/coder/v2/codersdk"
 )
 
-const titleGenerationPrompt = "Write a short title for the user's message. " +
-	"Populate the title field with the result. " +
-	"Return only the title text in 2-8 words. " +
-	"Do not answer the user or describe the title-writing task. " +
-	"Preserve specific identifiers such as PR numbers, repo names, file paths, function names, and error messages. " +
-	"If the message is short or vague, stay close to the user's wording instead of inventing context. " +
-	"Sentence case. No quotes, emoji, markdown, or trailing punctuation."
+// titleGenerationPrompt shapes auto-generated chat titles as a
+// lead identifier followed by a short noun phrase, not a sentence.
+// The first ~30 characters of a title are what the sidebar shows,
+// so the most distinctive tokens must come first. The negative
+// example on PR #4821 is load-bearing: earlier iterations tried
+// to enumerate banned verbs ("fix", "help", "check", ...) but the
+// model kept inventing similar ones ("investigate", "wire up",
+// "click handler"). A single NOT example catches the class.
+// renderManualTitlePrompt mirrors these rules inline for the
+// multi-turn manual-regeneration path; keep the two in sync when
+// editing either.
+const titleGenerationPrompt = "Write a short chat title. The title appears " +
+	"in a sidebar where only the first ~30 characters are visible, " +
+	"so the most distinctive tokens must come first.\n\n" +
+	"Format:\n" +
+	"- One or more identifiers, followed by a short noun phrase. " +
+	"Not a sentence. Not a list of disconnected tokens.\n" +
+	"- Target 3-5 words total (including identifiers). Go shorter " +
+	"when identifiers carry most of the meaning.\n\n" +
+	"Identifiers to lead with (verbatim, preserving casing and " +
+	"punctuation): issue keys, PR numbers, repo names, file paths, " +
+	"function names, error codes.\n\n" +
+	"For paths with 3 or more segments, use just the basename. " +
+	"Keep the path prefix only if the basename alone would be " +
+	"ambiguous (e.g. index.ts, main.go).\n\n" +
+	"Casing:\n" +
+	"- Lowercase descriptive words.\n" +
+	"- Preserve exact casing for identifiers, proper nouns " +
+	"(Windows, React, Anthropic), and acronyms (CI, SQL, MCP).\n\n" +
+	"Vocabulary:\n" +
+	"- Drop words that describe the act of working on the task " +
+	"(\"read X\", \"look at X\", \"help with Y\", \"investigate Z\").\n" +
+	"- Keep words that name the technical subject (\"nil panic\", " +
+	"\"token refresh\", \"cache miss\").\n" +
+	"- No articles, no conjunctions, no trailing punctuation, no " +
+	"quotes, no emoji, no markdown.\n\n" +
+	"If the user's message is short or vague, use their own words. " +
+	"Do not invent abstraction nouns.\n\n" +
+	"Do not answer the user or describe the title-writing task.\n\n" +
+	"Examples:\n" +
+	"- User: \"Can you read FOOBAR-123 and identify a fix?\"\n" +
+	"  Title: FOOBAR-123 fix\n" +
+	"- User: \"The frobulator in pkg/foo/bar.go keeps panicking on " +
+	"nil inputs\"\n" +
+	"  Title: pkg/foo/bar.go frobulator nil panic\n" +
+	"- User: \"coderd/database/queries/workspaces.sql " +
+	"GetWorkspaceByID is slow\"\n" +
+	"  Title: workspaces.sql GetWorkspaceByID slow\n" +
+	"- User: \"disengage plan mode from Planning badge\"\n" +
+	"  Title: Planning badge disengage\n" +
+	"  (NOT: Planning badge click handler, \"click handler\" " +
+	"invents a word.)\n" +
+	"- User: \"help me understand how useEffect works in React\"\n" +
+	"  Title: React useEffect behavior\n" +
+	"- User: \"PR #4821 is failing CI on the Windows runner\"\n" +
+	"  Title: PR #4821 Windows CI failure\n" +
+	"- User: \"why is my workspace slow\"\n" +
+	"  Title: slow workspace"
 
 const (
 	// maxConversationContextRunes caps the conversation sample in manual

--- a/coderd/x/chatd/quickgen_test.go
+++ b/coderd/x/chatd/quickgen_test.go
@@ -354,12 +354,56 @@ func Test_renderManualTitlePrompt(t *testing.T) {
 	}
 }
 
-func Test_titleGenerationPrompt_UsesSlimRules(t *testing.T) {
+func Test_titleGenerationPrompt_UsesNounPhraseRules(t *testing.T) {
 	t.Parallel()
 
-	require.Contains(t, titleGenerationPrompt, "Return only the title text in 2-8 words")
+	// Framing: noun phrase, not a sentence, not a disconnected
+	// keyword bag. The sidebar-scanability rationale is what
+	// motivates "distinctive tokens first" and should appear
+	// verbatim so future edits don't accidentally drop it.
+	require.Contains(t, titleGenerationPrompt, "first ~30 characters are visible")
+	require.Contains(t, titleGenerationPrompt, "Not a sentence. Not a list of disconnected tokens.")
+
+	// Target word count is a soft range, not a hard cap. The
+	// validator enforces length separately by rune count.
+	require.Contains(t, titleGenerationPrompt, "Target 3-5 words total")
+
+	// Path rule is explicitly "paths" (not "file paths") so it
+	// also applies to directory paths.
+	require.Contains(t, titleGenerationPrompt, "For paths with 3 or more segments")
+
+	// Casing rule preserves proper nouns and acronyms rather
+	// than forcing sentence case, which conflicts with leading
+	// identifiers like ECONNREFUSED or PR numbers.
+	require.Contains(t, titleGenerationPrompt, "Preserve exact casing for identifiers, proper nouns")
+	require.NotContains(t, titleGenerationPrompt, "Sentence case")
+
+	// Vocabulary guidance is stated as a principle (act-of-
+	// working verbs vs. technical-subject verbs), not as an
+	// enumerated banned-word list. The previous enumeration
+	// was incomplete and the model kept inventing similar
+	// words that weren't on the list.
+	require.Contains(t, titleGenerationPrompt, "Drop words that describe the act of working on the task")
+	require.Contains(t, titleGenerationPrompt, "Keep words that name the technical subject")
+
+	// Anti-invention rule anchors on a negative example; the
+	// enumerated banned-verbs list that used to carry this
+	// rule must be gone.
+	require.Contains(t, titleGenerationPrompt, "Do not invent abstraction nouns")
+	require.Contains(t, titleGenerationPrompt, "Title: Planning badge disengage")
+	require.Contains(t, titleGenerationPrompt, "NOT: Planning badge click handler")
+	require.NotContains(t, titleGenerationPrompt, "generic verbs (read, review")
+
+	// FOOBAR-123 example uses the user's word ("fix") rather
+	// than an invented abstraction ("investigation"); swapping
+	// back would re-introduce the self-contradiction that the
+	// anti-invention rule is meant to prevent.
+	require.Contains(t, titleGenerationPrompt, "Title: FOOBAR-123 fix")
+	require.NotContains(t, titleGenerationPrompt, "Title: FOOBAR-123 investigation")
+
+	// Preserved guidance from the previous prompt.
+	require.Contains(t, titleGenerationPrompt, "use their own words")
 	require.Contains(t, titleGenerationPrompt, "Do not answer the user or describe the title-writing task")
-	require.Contains(t, titleGenerationPrompt, "stay close to the user's wording")
 	require.NotContains(t, titleGenerationPrompt, "I am a title generator")
 }
 


### PR DESCRIPTION
Modfies title generation prompt to hopefully produce better titles.

Here's the baseline (main) versus modified run against a handful of inputs collected from recent commits:

```
==== anthropic/claude-haiku-4-5 :: main (baseline) ====
INPUT                             GENERATED TITLE
--------------------------------  ------------------------------------------------
PR #24638 (subagent entitlements)  PR #24638 snapshot explore subagent entitlements
PR #24678 (storybook mobile)      OpensAdminSubPanelOnMobile storybook story broken
PR #24633 (archived chats)        Reject API operations on archived chats coderd
PR #24674 (highlight-orange)      Warning badge color change to highlight-orange
PR #24651 (plan mode disengage)   Wire Planning badge click to disengage plan mode
PR #24652 (MCP display name)      MCP server display name field requirement
PR #24671 (flaky desktop test)    Investigate flaky test StopRecording_WithThumbnail
PR #24566 (null assistant msg)    Action bar hides after null assistant message
PR #24609 (relay drain flake)     Fix relay drain test flakiness
PR #24640 (lima incus example)    Lima incus example template minimum viable
short vague prompt                Workspace performance issues
error code prompt                 ECONNREFUSED on agent port 13337
deep file path                    GetWorkspaceByID returning stale rows under load

==== anthropic/claude-haiku-4-5 :: swapped (negative example) ====
INPUT                             GENERATED TITLE
--------------------------------  ------------------------------------------------
PR #24638 (subagent entitlements)  PR #24638 snapshot explore subagent entitlements
PR #24678 (storybook mobile)      OpensAdminSubPanelOnMobile storybook story broken
PR #24633 (archived chats)        archived chat API rejection placement
PR #24674 (highlight-orange)      warning badge highlight-orange color
PR #24651 (plan mode disengage)   Planning badge disengage plan mode
PR #24652 (MCP display name)      MCP server display name required field
PR #24671 (flaky desktop test)    TestPortableDesktop_StopRecording_WithThumbnail flaky
PR #24566 (null assistant msg)    action bar hides on null assistant message
PR #24609 (relay drain flake)     enterprise/coderd/x/chatd relay drain test deflake
PR #24640 (lima incus example)    lima incus example template
short vague prompt                slow workspace
error code prompt                 agent ECONNREFUSED port 13337
deep file path                    workspaces.sql GetWorkspaceByID stale rows

==== openai/gpt-4o-mini :: main (baseline) ====
INPUT                             GENERATED TITLE
--------------------------------  ------------------------------------------------
PR #24638 (subagent entitlements)  Understanding snapshot explore subagent tool entitlements in PR #24638
PR #24678 (storybook mobile)      OpensAdminSubPanelOnMobile storybook issue
PR #24633 (archived chats)        API operation checks on archived chats
PR #24674 (highlight-orange)      Change warning badge color to highlight-orange
PR #24651 (plan mode disengage)   Disengage plan mode in AgentsPage
PR #24652 (MCP display name)      MCP server display name validation requirement
PR #24671 (flaky desktop test)    Flaky test: TestPortableDesktop_StopRecording_WithThumbnail
PR #24566 (null assistant msg)    Action bar hides after null response
PR #24609 (relay drain flake)     Deflake relay drain test in chatd
PR #24640 (lima incus example)    Add lima incus example to examples directory
short vague prompt                Why is my workspace slow
error code prompt                 ECONNREFUSED on port 13337 after restart
deep file path                    GetWorkspaceByID returning stale rows

==== openai/gpt-4o-mini :: swapped (negative example) ====
INPUT                             GENERATED TITLE
--------------------------------  ------------------------------------------------
PR #24638 (subagent entitlements)  PR #24638 snapshot explore subagent tool entitlements
PR #24678 (storybook mobile)      site/src/pages/admin OpensAdminSubPanelOnMobile broken
PR #24633 (archived chats)        coderd API operations archived chats check
PR #24674 (highlight-orange)      warning badge highlight-orange color
PR #24651 (plan mode disengage)   AgentsPage Planning badge disengage
PR #24652 (MCP display name)      MCP server display name required field
PR #24671 (flaky desktop test)    TestPortableDesktop_StopRecording_WithThumbnail flakiness
PR #24566 (null assistant msg)    null-returning assistant action bar issue
PR #24609 (relay drain flake)     enterprise/coderd/x/chatd relay drain test deflake
PR #24640 (lima incus example)    examples directory lima incus
short vague prompt                slow workspace
error code prompt                 ECONNREFUSED agent port 13337
deep file path                    workspaces.sql GetWorkspaceByID stale rows
```

> 🤖 I let an LLM drive most of the prompt engineering here.