### PR TITLE
feat: validate coder_secret requirements in dynamic parameters

### DIFF
--- a/coderd/autobuild/lifecycle_executor.go
+++ b/coderd/autobuild/lifecycle_executor.go
@@ -343,6 +343,7 @@ func (e *Executor) runOnce(t time.Time) Stats {
 							SetLastWorkspaceBuildJobInTx(&latestJob).
 							Experiments(e.experiments).
 							Reason(reason).
+							Logger(log.Named("wsbuilder")).
 							BuildMetrics(e.workspaceBuilderMetrics)
 						log.Debug(e.ctx, "auto building workspace", slog.F("transition", nextTransition))
 						if nextTransition == database.WorkspaceTransitionStart &&

--- a/coderd/dynamicparameters/render.go
+++ b/coderd/dynamicparameters/render.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"io/fs"
-	"log/slog"
+	stdslog "log/slog"
 	"sync"
 	"time"
 
@@ -13,6 +13,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 	"golang.org/x/xerrors"
 
+	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/apiversion"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
@@ -34,11 +35,48 @@ type Renderer interface {
 
 var ErrTemplateVersionNotReady = xerrors.New("template version job not finished")
 
+// Diagnostic extra codes for secret-requirement validation. The
+// frontend keys off these strings.
+const (
+	DiagCodeMissingSecret             = "missing_secret"
+	DiagCodeOwnerSecretsFetchFailed   = "owner_secrets_fetch_failed"
+	DiagCodeSecretValidationForbidden = "secret_validation_forbidden"
+)
+
+// IsSecretRequirementDiagnostic reports whether d was emitted by the
+// secret-requirement check.
+func IsSecretRequirementDiagnostic(d *hcl.Diagnostic) bool {
+	extra, ok := d.Extra.(previewtypes.DiagnosticExtra)
+	if !ok {
+		return false
+	}
+	switch extra.Code {
+	case DiagCodeMissingSecret, DiagCodeOwnerSecretsFetchFailed, DiagCodeSecretValidationForbidden:
+		return true
+	}
+	return false
+}
+
+func filterSecretDiagnostics(diags hcl.Diagnostics) hcl.Diagnostics {
+	if len(diags) == 0 {
+		return diags
+	}
+	out := make(hcl.Diagnostics, 0, len(diags))
+	for _, d := range diags {
+		if IsSecretRequirementDiagnostic(d) {
+			continue
+		}
+		out = append(out, d)
+	}
+	return out
+}
+
 // loader is used to load the necessary coder objects for rendering a template
 // version's parameters. The output is a Renderer, which is the object that uses
 // the cached objects to render the template version's parameters.
 type loader struct {
 	templateVersionID uuid.UUID
+	logger            slog.Logger
 
 	// cache of objects
 	templateVersion        *database.TemplateVersion
@@ -87,6 +125,13 @@ func WithTerraformValues(values database.TemplateVersionTerraformValue) func(r *
 		if values.TemplateVersionID == r.templateVersionID {
 			r.terraformValues = &values
 		}
+	}
+}
+
+// WithLogger sets the logger used by the renderer.
+func WithLogger(logger slog.Logger) func(r *loader) {
+	return func(r *loader) {
+		r.logger = logger
 	}
 }
 
@@ -203,13 +248,14 @@ func (r *loader) dynamicRenderer(ctx context.Context, db database.Store, cache *
 
 	closeFiles = false // Caller will have to call close
 	return &dynamicRenderer{
-		data:            r,
-		templateFS:      templateFS,
-		db:              db,
-		ownerErrors:     make(map[uuid.UUID]error),
-		ownerSecretsErr: make(map[uuid.UUID]error),
-		close:           cache.Close,
-		tfvarValues:     tfVarValues,
+		data:              r,
+		templateFS:        templateFS,
+		db:                db,
+		logger:            r.logger,
+		ownerErrors:       make(map[uuid.UUID]error),
+		ownerSecretErrors: make(map[uuid.UUID]error),
+		close:             cache.Close,
+		tfvarValues:       tfVarValues,
 	}, nil
 }
 
@@ -217,13 +263,13 @@ type dynamicRenderer struct {
 	db         database.Store
 	data       *loader
 	templateFS fs.FS
+	logger     slog.Logger
 
 	ownerErrors  map[uuid.UUID]error
 	currentOwner *previewtypes.WorkspaceOwner
 
-	// ownerSecretsErr caches NotAuthorized denials per owner. Successes
-	// and transient errors are not cached; see getOwnerSecrets.
-	ownerSecretsErr map[uuid.UUID]error
+	// ownerSecretErrors caches NotAuthorized denials per owner.
+	ownerSecretErrors map[uuid.UUID]error
 
 	tfvarValues map[string]cty.Value
 
@@ -260,7 +306,7 @@ func (r *dynamicRenderer) Render(ctx context.Context, ownerID uuid.UUID, values 
 		// Do not emit parser logs to coderd output logs.
 		// TODO: Returning this logs in the output would benefit the caller.
 		//  Unsure how large the logs can be, so for now we just discard them.
-		Logger: slog.New(slog.DiscardHandler),
+		Logger: stdslog.New(stdslog.DiscardHandler),
 	}
 
 	output, diags := preview.Preview(ctx, input, r.templateFS)
@@ -268,9 +314,8 @@ func (r *dynamicRenderer) Render(ctx context.Context, ownerID uuid.UUID, values 
 		return nil, diags
 	}
 
-	// Secret requirements may change across renders because coder_secret
-	// blocks can be conditional on parameter values (e.g.
-	// count = var.x ? 1 : 0), so this check has to run every render.
+	// coder_secret blocks can be conditional on parameter values, so
+	// this must run every render.
 	if len(output.SecretRequirements) > 0 {
 		diags = diags.Extend(r.checkSecretRequirements(ctx, ownerID, output.SecretRequirements))
 	}
@@ -280,35 +325,35 @@ func (r *dynamicRenderer) Render(ctx context.Context, ownerID uuid.UUID, values 
 
 // checkSecretRequirements emits missing_secret diagnostics for unmet
 // SecretRequirements. Callers without user_secret:read on the owner get
-// a single secret_validation_forbidden warning, preventing enumeration
-// of the target's secret names via diagnostic presence.
+// a single secret_validation_forbidden warning instead, to avoid
+// leaking the target's secret names via diagnostic presence.
 //
-// TODO: wsbuilder reuses this renderer under the caller's context, so
-// cross-user builds pass the warning through. Authoritative build-time
-// enforcement is tracked as a follow-up.
+// TODO: add authoritative build-time enforcement so
+// cross-user builds don't fall back to a warning.
 func (r *dynamicRenderer) checkSecretRequirements(ctx context.Context, ownerID uuid.UUID, reqs []previewtypes.SecretRequirement) hcl.Diagnostics {
 	secrets, err := r.getOwnerSecrets(ctx, ownerID)
 	if err != nil {
 		if dbauthz.IsNotAuthorizedError(err) {
-			// Warning, not error: the caller can still create the workspace;
-			// the build will simply fail later if required secrets are not
-			// set. Using warning severity also keeps the Create Workspace
-			// button enabled (which checks for error-severity diagnostics).
+			// Warning keeps the Create Workspace button enabled.
 			return hcl.Diagnostics{{
 				Severity: hcl.DiagWarning,
 				Summary:  "Cannot validate secret requirements",
 				Detail:   "You are not permitted to read secret metadata for this user. The workspace may fail to build if required secrets are not set.",
 				Extra: previewtypes.DiagnosticExtra{
-					Code: "secret_validation_forbidden",
+					Code: DiagCodeSecretValidationForbidden,
 				},
 			}}
 		}
+		r.logger.Warn(ctx, "failed to fetch owner secrets for secret-requirement validation",
+			slog.F("owner_id", ownerID),
+			slog.Error(err),
+		)
 		return hcl.Diagnostics{{
 			Severity: hcl.DiagError,
 			Summary:  "Failed to fetch owner secrets",
-			Detail:   "The create workspace page cannot validate template secret requirements. Please try again.",
+			Detail:   "Could not validate template secret requirements. Please try again.",
 			Extra: previewtypes.DiagnosticExtra{
-				Code: "owner_secrets_fetch_failed",
+				Code: DiagCodeOwnerSecretsFetchFailed,
 			},
 		}}
 	}
@@ -326,6 +371,10 @@ func (r *dynamicRenderer) checkSecretRequirements(ctx context.Context, ownerID u
 
 	var diags hcl.Diagnostics
 	for _, req := range reqs {
+		// Defensive: SecretFromBlock should reject this upstream.
+		if req.Env == "" && req.File == "" {
+			continue
+		}
 		satisfied := false
 		switch {
 		case req.Env != "":
@@ -341,7 +390,7 @@ func (r *dynamicRenderer) checkSecretRequirements(ctx context.Context, ownerID u
 			Summary:  "Missing required secret",
 			Detail:   req.HelpMessage,
 			Extra: previewtypes.DiagnosticExtra{
-				Code: "missing_secret",
+				Code: DiagCodeMissingSecret,
 			},
 		})
 	}
@@ -362,19 +411,17 @@ func (r *dynamicRenderer) getWorkspaceOwnerData(ctx context.Context, ownerID uui
 	return nil
 }
 
-// getOwnerSecrets returns the owner's user-secret metadata under the
-// caller's auth context. Non-owners get NotAuthorizedError (only the
-// owner holds user_secret:read). Only NotAuthorized denials are cached;
-// successes and transient errors re-fetch so `coder secret create`
-// guidance is picked up without a page reload.
+// getOwnerSecrets fetches the owner's secrets under the caller's auth
+// context. Only NotAuthorized denials are cached; successes re-fetch so
+// newly-created secrets are picked up on the next render.
 func (r *dynamicRenderer) getOwnerSecrets(ctx context.Context, ownerID uuid.UUID) ([]database.ListUserSecretsRow, error) {
-	if err, cached := r.ownerSecretsErr[ownerID]; cached {
+	if err, cached := r.ownerSecretErrors[ownerID]; cached {
 		return nil, err
 	}
 	rows, err := r.db.ListUserSecrets(ctx, ownerID)
 	if err != nil {
 		if dbauthz.IsNotAuthorizedError(err) {
-			r.ownerSecretsErr[ownerID] = err
+			r.ownerSecretErrors[ownerID] = err
 		}
 		return nil, err
 	}

--- a/coderd/dynamicparameters/render.go
+++ b/coderd/dynamicparameters/render.go
@@ -57,7 +57,7 @@ func IsSecretRequirementDiagnostic(d *hcl.Diagnostic) bool {
 	return false
 }
 
-func filterSecretDiagnostics(diags hcl.Diagnostics) hcl.Diagnostics {
+func FilterSecretDiagnostics(diags hcl.Diagnostics) hcl.Diagnostics {
 	if len(diags) == 0 {
 		return diags
 	}
@@ -328,7 +328,7 @@ func (r *dynamicRenderer) Render(ctx context.Context, ownerID uuid.UUID, values 
 // a single secret_validation_forbidden warning instead, to avoid
 // leaking the target's secret names via diagnostic presence.
 //
-// TODO: add authoritative build-time enforcement so
+// TODO (PLAT-147): add authoritative build-time enforcement so
 // cross-user builds don't fall back to a warning.
 func (r *dynamicRenderer) checkSecretRequirements(ctx context.Context, ownerID uuid.UUID, reqs []previewtypes.SecretRequirement) hcl.Diagnostics {
 	secrets, err := r.getOwnerSecrets(ctx, ownerID)

--- a/coderd/dynamicparameters/render.go
+++ b/coderd/dynamicparameters/render.go
@@ -203,12 +203,13 @@ func (r *loader) dynamicRenderer(ctx context.Context, db database.Store, cache *
 
 	closeFiles = false // Caller will have to call close
 	return &dynamicRenderer{
-		data:        r,
-		templateFS:  templateFS,
-		db:          db,
-		ownerErrors: make(map[uuid.UUID]error),
-		close:       cache.Close,
-		tfvarValues: tfVarValues,
+		data:            r,
+		templateFS:      templateFS,
+		db:              db,
+		ownerErrors:     make(map[uuid.UUID]error),
+		ownerSecretsErr: make(map[uuid.UUID]error),
+		close:           cache.Close,
+		tfvarValues:     tfVarValues,
 	}, nil
 }
 
@@ -219,7 +220,12 @@ type dynamicRenderer struct {
 
 	ownerErrors  map[uuid.UUID]error
 	currentOwner *previewtypes.WorkspaceOwner
-	tfvarValues  map[string]cty.Value
+
+	// ownerSecretsErr caches NotAuthorized denials per owner. Successes
+	// and transient errors are not cached; see getOwnerSecrets.
+	ownerSecretsErr map[uuid.UUID]error
+
+	tfvarValues map[string]cty.Value
 
 	once  sync.Once
 	close func()
@@ -257,7 +263,89 @@ func (r *dynamicRenderer) Render(ctx context.Context, ownerID uuid.UUID, values 
 		Logger: slog.New(slog.DiscardHandler),
 	}
 
-	return preview.Preview(ctx, input, r.templateFS)
+	output, diags := preview.Preview(ctx, input, r.templateFS)
+	if output == nil {
+		return nil, diags
+	}
+
+	// Secret requirements may change across renders because coder_secret
+	// blocks can be conditional on parameter values (e.g.
+	// count = var.x ? 1 : 0), so this check has to run every render.
+	if len(output.SecretRequirements) > 0 {
+		diags = diags.Extend(r.checkSecretRequirements(ctx, ownerID, output.SecretRequirements))
+	}
+
+	return output, diags
+}
+
+// checkSecretRequirements emits missing_secret diagnostics for unmet
+// SecretRequirements. Callers without user_secret:read on the owner get
+// a single secret_validation_forbidden warning, preventing enumeration
+// of the target's secret names via diagnostic presence.
+//
+// TODO: wsbuilder reuses this renderer under the caller's context, so
+// cross-user builds pass the warning through. Authoritative build-time
+// enforcement is tracked as a follow-up.
+func (r *dynamicRenderer) checkSecretRequirements(ctx context.Context, ownerID uuid.UUID, reqs []previewtypes.SecretRequirement) hcl.Diagnostics {
+	secrets, err := r.getOwnerSecrets(ctx, ownerID)
+	if err != nil {
+		if dbauthz.IsNotAuthorizedError(err) {
+			// Warning, not error: the caller can still create the workspace;
+			// the build will simply fail later if required secrets are not
+			// set. Using warning severity also keeps the Create Workspace
+			// button enabled (which checks for error-severity diagnostics).
+			return hcl.Diagnostics{{
+				Severity: hcl.DiagWarning,
+				Summary:  "Cannot validate secret requirements",
+				Detail:   "You are not permitted to read secret metadata for this user. The workspace may fail to build if required secrets are not set.",
+				Extra: previewtypes.DiagnosticExtra{
+					Code: "secret_validation_forbidden",
+				},
+			}}
+		}
+		return hcl.Diagnostics{{
+			Severity: hcl.DiagError,
+			Summary:  "Failed to fetch owner secrets",
+			Detail:   "The create workspace page cannot validate template secret requirements. Please try again.",
+			Extra: previewtypes.DiagnosticExtra{
+				Code: "owner_secrets_fetch_failed",
+			},
+		}}
+	}
+
+	envSet := make(map[string]struct{}, len(secrets))
+	fileSet := make(map[string]struct{}, len(secrets))
+	for _, s := range secrets {
+		if s.EnvName != "" {
+			envSet[s.EnvName] = struct{}{}
+		}
+		if s.FilePath != "" {
+			fileSet[s.FilePath] = struct{}{}
+		}
+	}
+
+	var diags hcl.Diagnostics
+	for _, req := range reqs {
+		satisfied := false
+		switch {
+		case req.Env != "":
+			_, satisfied = envSet[req.Env]
+		case req.File != "":
+			_, satisfied = fileSet[req.File]
+		}
+		if satisfied {
+			continue
+		}
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Missing required secret",
+			Detail:   req.HelpMessage,
+			Extra: previewtypes.DiagnosticExtra{
+				Code: "missing_secret",
+			},
+		})
+	}
+	return diags
 }
 
 func (r *dynamicRenderer) getWorkspaceOwnerData(ctx context.Context, ownerID uuid.UUID) error {
@@ -272,6 +360,25 @@ func (r *dynamicRenderer) getWorkspaceOwnerData(ctx context.Context, ownerID uui
 
 	r.currentOwner = owner
 	return nil
+}
+
+// getOwnerSecrets returns the owner's user-secret metadata under the
+// caller's auth context. Non-owners get NotAuthorizedError (only the
+// owner holds user_secret:read). Only NotAuthorized denials are cached;
+// successes and transient errors re-fetch so `coder secret create`
+// guidance is picked up without a page reload.
+func (r *dynamicRenderer) getOwnerSecrets(ctx context.Context, ownerID uuid.UUID) ([]database.ListUserSecretsRow, error) {
+	if err, cached := r.ownerSecretsErr[ownerID]; cached {
+		return nil, err
+	}
+	rows, err := r.db.ListUserSecrets(ctx, ownerID)
+	if err != nil {
+		if dbauthz.IsNotAuthorizedError(err) {
+			r.ownerSecretsErr[ownerID] = err
+		}
+		return nil, err
+	}
+	return rows, nil
 }
 
 func (r *dynamicRenderer) Close() {

--- a/coderd/dynamicparameters/render_internal_test.go
+++ b/coderd/dynamicparameters/render_internal_test.go
@@ -1,0 +1,296 @@
+package dynamicparameters
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
+	"github.com/coder/coder/v2/coderd/database/dbgen"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	previewtypes "github.com/coder/preview/types"
+)
+
+// newTestRenderer constructs a dynamicRenderer pointing at a testdata
+// fixture on disk. The caller is responsible for seeding the organization
+// and a member row so that WorkspaceOwner lookups succeed.
+func newTestRenderer(t *testing.T, db database.Store, orgID uuid.UUID, fixture string) *dynamicRenderer {
+	t.Helper()
+	return &dynamicRenderer{
+		db:              db,
+		templateFS:      os.DirFS(filepath.Join("testdata", fixture)),
+		ownerErrors:     make(map[uuid.UUID]error),
+		ownerSecretsErr: make(map[uuid.UUID]error),
+		data: &loader{
+			templateVersion: &database.TemplateVersion{
+				OrganizationID: orgID,
+			},
+			terraformValues: &database.TemplateVersionTerraformValue{},
+		},
+		close: func() {},
+	}
+}
+
+// seedOwner creates a user and an organization member, which is what
+// WorkspaceOwner requires to resolve the owner.
+func seedOwner(t *testing.T, db database.Store, orgID uuid.UUID) database.User {
+	t.Helper()
+	u := dbgen.User(t, db, database.User{})
+	dbgen.OrganizationMember(t, db, database.OrganizationMember{
+		OrganizationID: orgID,
+		UserID:         u.ID,
+	})
+	return u
+}
+
+func TestDynamicRender_MissingSecretRequirement(t *testing.T) {
+	t.Parallel()
+
+	db, _ := dbtestutil.NewDB(t)
+	ctx := context.Background()
+	org := dbgen.Organization(t, db, database.Organization{})
+	owner := seedOwner(t, db, org.ID)
+
+	renderer := newTestRenderer(t, db, org.ID, "secret_required")
+	defer renderer.Close()
+
+	// Owner has no secrets; the GITHUB_TOKEN requirement is unmet.
+	out, diags := renderer.Render(ctx, owner.ID, nil)
+	require.NotNil(t, out)
+	requireMissingSecret(t, diags, "Add a GitHub PAT with env=GITHUB_TOKEN")
+
+	// Mimic the user following the diagnostic's "coder secret create"
+	// guidance in another tab, then coming back. The SAME renderer (i.e.
+	// the same websocket session) must pick up the new secret on the next
+	// render without needing a page reload; otherwise the Create Workspace
+	// button stays disabled against a stale cached secret list and the
+	// recovery UX silently breaks.
+	_ = dbgen.UserSecret(t, db, database.UserSecret{
+		UserID:  owner.ID,
+		Name:    "github_token",
+		EnvName: "GITHUB_TOKEN",
+	})
+
+	_, diags2 := renderer.Render(ctx, owner.ID, nil)
+	requireNoMissingSecret(t, diags2)
+}
+
+func TestDynamicRender_ConditionalSecretRequirement(t *testing.T) {
+	t.Parallel()
+
+	db, _ := dbtestutil.NewDB(t)
+	ctx := context.Background()
+	org := dbgen.Organization(t, db, database.Organization{})
+	owner := seedOwner(t, db, org.ID)
+
+	renderer := newTestRenderer(t, db, org.ID, "secret_conditional")
+	defer renderer.Close()
+
+	// use_github=false keeps the coder_secret block inactive, so nothing
+	// to validate.
+	_, diags := renderer.Render(ctx, owner.ID, map[string]string{"use_github": "false"})
+	requireNoMissingSecret(t, diags)
+
+	// Flipping the parameter activates the block and surfaces the
+	// unsatisfied requirement.
+	_, diags = renderer.Render(ctx, owner.ID, map[string]string{"use_github": "true"})
+	requireMissingSecret(t, diags, "Add a GitHub PAT")
+}
+
+func TestDynamicRender_SingleSecretSatisfiesEnvAndFile(t *testing.T) {
+	t.Parallel()
+
+	db, _ := dbtestutil.NewDB(t)
+	ctx := context.Background()
+	org := dbgen.Organization(t, db, database.Organization{})
+	owner := seedOwner(t, db, org.ID)
+
+	// One user_secrets row with BOTH env_name and file_path populated.
+	// Per the User Secrets RFC a single secret must satisfy both an env
+	// and a file requirement simultaneously.
+	_ = dbgen.UserSecret(t, db, database.UserSecret{
+		UserID:   owner.ID,
+		Name:     "combined",
+		EnvName:  "GITHUB_TOKEN",
+		FilePath: "~/.ssh/id_rsa",
+	})
+
+	renderer := newTestRenderer(t, db, org.ID, "secret_env_and_file")
+	defer renderer.Close()
+
+	_, diags := renderer.Render(ctx, owner.ID, nil)
+	requireNoMissingSecret(t, diags)
+}
+
+func TestDynamicRender_OwnerSwitch(t *testing.T) {
+	t.Parallel()
+
+	db, _ := dbtestutil.NewDB(t)
+	ctx := context.Background()
+	org := dbgen.Organization(t, db, database.Organization{})
+
+	// Owner A satisfies the requirement; owner B does not.
+	ownerA := seedOwner(t, db, org.ID)
+	ownerB := seedOwner(t, db, org.ID)
+	_ = dbgen.UserSecret(t, db, database.UserSecret{
+		UserID:  ownerA.ID,
+		Name:    "gh",
+		EnvName: "GITHUB_TOKEN",
+	})
+
+	renderer := newTestRenderer(t, db, org.ID, "secret_required")
+	defer renderer.Close()
+
+	_, diags := renderer.Render(ctx, ownerA.ID, nil)
+	requireNoMissingSecret(t, diags)
+
+	// The cache must not serve owner A's rows to owner B.
+	_, diags = renderer.Render(ctx, ownerB.ID, nil)
+	requireMissingSecret(t, diags, "")
+}
+
+// countingStore wraps a database.Store and counts ListUserSecrets calls
+// per user so we can assert the owner-keyed cache behavior.
+type countingStore struct {
+	database.Store
+	mu    sync.Mutex
+	calls map[uuid.UUID]int
+}
+
+func (c *countingStore) ListUserSecrets(ctx context.Context, userID uuid.UUID) ([]database.ListUserSecretsRow, error) {
+	c.mu.Lock()
+	if c.calls == nil {
+		c.calls = map[uuid.UUID]int{}
+	}
+	c.calls[userID]++
+	c.mu.Unlock()
+	return c.Store.ListUserSecrets(ctx, userID)
+}
+
+func (c *countingStore) callsFor(id uuid.UUID) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.calls[id]
+}
+
+// TestDynamicRender_NotAuthorizedIsCached asserts that NotAuthorized
+// denials are cached per-owner for the renderer lifetime: repeated
+// renders for a denied owner hit ListUserSecrets at most once.
+func TestDynamicRender_NotAuthorizedIsCached(t *testing.T) {
+	t.Parallel()
+
+	inner, _ := dbtestutil.NewDB(t)
+	// Compose: outer countingStore sees every ListUserSecrets invocation;
+	// inner secretAuthDenyingStore makes each one return NotAuthorized.
+	db := &countingStore{Store: secretAuthDenyingStore{Store: inner}}
+	ctx := context.Background()
+	org := dbgen.Organization(t, db, database.Organization{})
+	owner := seedOwner(t, db, org.ID)
+
+	renderer := newTestRenderer(t, db, org.ID, "secret_required")
+	defer renderer.Close()
+
+	for range 3 {
+		_, _ = renderer.Render(ctx, owner.ID, nil)
+	}
+	require.Equal(t, 1, db.callsFor(owner.ID),
+		"NotAuthorized must be cached; expected one ListUserSecrets call across multiple renders")
+}
+
+// secretAuthDenyingStore wraps database.Store and makes ListUserSecrets
+// return dbauthz.NotAuthorizedError, simulating a caller that lacks
+// user_secret:read on the target owner. This is the exact condition a
+// template admin rendering for another user hits, per the User Secrets
+// RFC's owner-only RBAC model.
+type secretAuthDenyingStore struct {
+	database.Store
+}
+
+func (secretAuthDenyingStore) ListUserSecrets(_ context.Context, _ uuid.UUID) ([]database.ListUserSecretsRow, error) {
+	return nil, dbauthz.NotAuthorizedError{}
+}
+
+// TestDynamicRender_NonOwnerCannotLeakSecretRequirements is the
+// regression test for the information-leak vector where a non-owner
+// (e.g. a template admin) could enumerate a target user's secret
+// env_names and file_paths by watching for missing_secret diagnostics
+// across crafted templates. The fix is to keep the ListUserSecrets call
+// inside the caller's own authorization context; this test pins it.
+func TestDynamicRender_NonOwnerCannotLeakSecretRequirements(t *testing.T) {
+	t.Parallel()
+
+	inner, _ := dbtestutil.NewDB(t)
+	db := secretAuthDenyingStore{Store: inner}
+	ctx := context.Background()
+	org := dbgen.Organization(t, db, database.Organization{})
+	owner := seedOwner(t, db, org.ID)
+
+	// Seed a secret that DOES match the template's requirement. Under the
+	// buggy behavior (elevated system actor) this would satisfy the
+	// requirement and emit no missing_secret diagnostic, while under the
+	// correct behavior the non-owner never sees the list at all.
+	_ = dbgen.UserSecret(t, db, database.UserSecret{
+		UserID:  owner.ID,
+		Name:    "gh",
+		EnvName: "GITHUB_TOKEN",
+	})
+
+	renderer := newTestRenderer(t, db, org.ID, "secret_required")
+	defer renderer.Close()
+
+	_, diags := renderer.Render(ctx, owner.ID, nil)
+
+	// 1. Never emit missing_secret for a non-owner, regardless of whether
+	//    the target satisfies the requirement. This is the leak being
+	//    prevented: the presence/absence of missing_secret must not be
+	//    observable by callers who lack user_secret:read on the target.
+	requireNoMissingSecret(t, diags)
+
+	// 2. Surface a visible warning so the admin understands the feature
+	//    is not running for this target, rather than silently succeeding.
+	var sawWarn bool
+	for _, d := range diags {
+		extra, ok := d.Extra.(previewtypes.DiagnosticExtra)
+		if !ok {
+			continue
+		}
+		if extra.Code == "secret_validation_forbidden" {
+			require.Equal(t, hcl.DiagWarning, d.Severity,
+				"secret_validation_forbidden must be a warning so it does not disable the Create Workspace button")
+			sawWarn = true
+		}
+	}
+	require.True(t, sawWarn,
+		"expected secret_validation_forbidden warning when caller lacks user_secret:read")
+}
+
+func requireMissingSecret(t *testing.T, diags hcl.Diagnostics, wantDetail string) {
+	t.Helper()
+	for _, d := range diags {
+		extra, ok := d.Extra.(previewtypes.DiagnosticExtra)
+		if !ok || extra.Code != "missing_secret" {
+			continue
+		}
+		if wantDetail != "" {
+			require.Contains(t, d.Detail, wantDetail)
+		}
+		return
+	}
+	t.Fatalf("expected a missing_secret diagnostic; got %v", diags)
+}
+
+func requireNoMissingSecret(t *testing.T, diags hcl.Diagnostics) {
+	t.Helper()
+	for _, d := range diags {
+		if extra, ok := d.Extra.(previewtypes.DiagnosticExtra); ok && extra.Code == "missing_secret" {
+			t.Fatalf("unexpected missing_secret diagnostic: %s", d.Detail)
+		}
+	}
+}

--- a/coderd/dynamicparameters/render_internal_test.go
+++ b/coderd/dynamicparameters/render_internal_test.go
@@ -18,16 +18,15 @@ import (
 	previewtypes "github.com/coder/preview/types"
 )
 
-// newTestRenderer constructs a dynamicRenderer pointing at a testdata
-// fixture on disk. The caller is responsible for seeding the organization
-// and a member row so that WorkspaceOwner lookups succeed.
+// newTestRenderer builds a dynamicRenderer backed by the given testdata
+// fixture. The caller must seed an org and member row.
 func newTestRenderer(t *testing.T, db database.Store, orgID uuid.UUID, fixture string) *dynamicRenderer {
 	t.Helper()
 	return &dynamicRenderer{
-		db:              db,
-		templateFS:      os.DirFS(filepath.Join("testdata", fixture)),
-		ownerErrors:     make(map[uuid.UUID]error),
-		ownerSecretsErr: make(map[uuid.UUID]error),
+		db:                db,
+		templateFS:        os.DirFS(filepath.Join("testdata", fixture)),
+		ownerErrors:       make(map[uuid.UUID]error),
+		ownerSecretErrors: make(map[uuid.UUID]error),
 		data: &loader{
 			templateVersion: &database.TemplateVersion{
 				OrganizationID: orgID,
@@ -38,8 +37,7 @@ func newTestRenderer(t *testing.T, db database.Store, orgID uuid.UUID, fixture s
 	}
 }
 
-// seedOwner creates a user and an organization member, which is what
-// WorkspaceOwner requires to resolve the owner.
+// seedOwner creates a user and org member so WorkspaceOwner resolves.
 func seedOwner(t *testing.T, db database.Store, orgID uuid.UUID) database.User {
 	t.Helper()
 	u := dbgen.User(t, db, database.User{})
@@ -54,7 +52,7 @@ func TestDynamicRender_MissingSecretRequirement(t *testing.T) {
 	t.Parallel()
 
 	db, _ := dbtestutil.NewDB(t)
-	ctx := context.Background()
+	ctx := t.Context()
 	org := dbgen.Organization(t, db, database.Organization{})
 	owner := seedOwner(t, db, org.ID)
 
@@ -66,12 +64,8 @@ func TestDynamicRender_MissingSecretRequirement(t *testing.T) {
 	require.NotNil(t, out)
 	requireMissingSecret(t, diags, "Add a GitHub PAT with env=GITHUB_TOKEN")
 
-	// Mimic the user following the diagnostic's "coder secret create"
-	// guidance in another tab, then coming back. The SAME renderer (i.e.
-	// the same websocket session) must pick up the new secret on the next
-	// render without needing a page reload; otherwise the Create Workspace
-	// button stays disabled against a stale cached secret list and the
-	// recovery UX silently breaks.
+	// The same renderer must pick up a newly-created secret on the
+	// next render, without a reload.
 	_ = dbgen.UserSecret(t, db, database.UserSecret{
 		UserID:  owner.ID,
 		Name:    "github_token",
@@ -86,20 +80,18 @@ func TestDynamicRender_ConditionalSecretRequirement(t *testing.T) {
 	t.Parallel()
 
 	db, _ := dbtestutil.NewDB(t)
-	ctx := context.Background()
+	ctx := t.Context()
 	org := dbgen.Organization(t, db, database.Organization{})
 	owner := seedOwner(t, db, org.ID)
 
 	renderer := newTestRenderer(t, db, org.ID, "secret_conditional")
 	defer renderer.Close()
 
-	// use_github=false keeps the coder_secret block inactive, so nothing
-	// to validate.
+	// Block inactive: no validation.
 	_, diags := renderer.Render(ctx, owner.ID, map[string]string{"use_github": "false"})
 	requireNoMissingSecret(t, diags)
 
-	// Flipping the parameter activates the block and surfaces the
-	// unsatisfied requirement.
+	// Block active: requirement surfaces.
 	_, diags = renderer.Render(ctx, owner.ID, map[string]string{"use_github": "true"})
 	requireMissingSecret(t, diags, "Add a GitHub PAT")
 }
@@ -108,13 +100,12 @@ func TestDynamicRender_SingleSecretSatisfiesEnvAndFile(t *testing.T) {
 	t.Parallel()
 
 	db, _ := dbtestutil.NewDB(t)
-	ctx := context.Background()
+	ctx := t.Context()
 	org := dbgen.Organization(t, db, database.Organization{})
 	owner := seedOwner(t, db, org.ID)
 
-	// One user_secrets row with BOTH env_name and file_path populated.
-	// Per the User Secrets RFC a single secret must satisfy both an env
-	// and a file requirement simultaneously.
+	// One row must satisfy both an env and a file requirement: the
+	// check builds independent envSet and fileSet maps.
 	_ = dbgen.UserSecret(t, db, database.UserSecret{
 		UserID:   owner.ID,
 		Name:     "combined",
@@ -129,11 +120,41 @@ func TestDynamicRender_SingleSecretSatisfiesEnvAndFile(t *testing.T) {
 	requireNoMissingSecret(t, diags)
 }
 
+func TestDynamicRender_PartialEnvAndFileSatisfaction(t *testing.T) {
+	t.Parallel()
+
+	db, _ := dbtestutil.NewDB(t)
+	ctx := t.Context()
+	org := dbgen.Organization(t, db, database.Organization{})
+	owner := seedOwner(t, db, org.ID)
+
+	// Env-only secret against an env+file requirement: only the file
+	// requirement should fail.
+	_ = dbgen.UserSecret(t, db, database.UserSecret{
+		UserID:  owner.ID,
+		Name:    "env_only",
+		EnvName: "GITHUB_TOKEN",
+	})
+
+	renderer := newTestRenderer(t, db, org.ID, "secret_env_and_file")
+	defer renderer.Close()
+
+	_, diags := renderer.Render(ctx, owner.ID, nil)
+	var missing []*hcl.Diagnostic
+	for _, d := range diags {
+		if extra, ok := d.Extra.(previewtypes.DiagnosticExtra); ok && extra.Code == DiagCodeMissingSecret {
+			missing = append(missing, d)
+		}
+	}
+	require.Len(t, missing, 1, "only the file requirement should be unmet; env was satisfied by the seeded secret")
+	require.Contains(t, missing[0].Detail, "needs file")
+}
+
 func TestDynamicRender_OwnerSwitch(t *testing.T) {
 	t.Parallel()
 
 	db, _ := dbtestutil.NewDB(t)
-	ctx := context.Background()
+	ctx := t.Context()
 	org := dbgen.Organization(t, db, database.Organization{})
 
 	// Owner A satisfies the requirement; owner B does not.
@@ -156,8 +177,7 @@ func TestDynamicRender_OwnerSwitch(t *testing.T) {
 	requireMissingSecret(t, diags, "")
 }
 
-// countingStore wraps a database.Store and counts ListUserSecrets calls
-// per user so we can assert the owner-keyed cache behavior.
+// countingStore counts ListUserSecrets calls per user.
 type countingStore struct {
 	database.Store
 	mu    sync.Mutex
@@ -180,17 +200,14 @@ func (c *countingStore) callsFor(id uuid.UUID) int {
 	return c.calls[id]
 }
 
-// TestDynamicRender_NotAuthorizedIsCached asserts that NotAuthorized
-// denials are cached per-owner for the renderer lifetime: repeated
-// renders for a denied owner hit ListUserSecrets at most once.
+// TestDynamicRender_NotAuthorizedIsCached pins that NotAuthorized
+// denials hit ListUserSecrets at most once per owner.
 func TestDynamicRender_NotAuthorizedIsCached(t *testing.T) {
 	t.Parallel()
 
 	inner, _ := dbtestutil.NewDB(t)
-	// Compose: outer countingStore sees every ListUserSecrets invocation;
-	// inner secretAuthDenyingStore makes each one return NotAuthorized.
 	db := &countingStore{Store: secretAuthDenyingStore{Store: inner}}
-	ctx := context.Background()
+	ctx := t.Context()
 	org := dbgen.Organization(t, db, database.Organization{})
 	owner := seedOwner(t, db, org.ID)
 
@@ -201,14 +218,11 @@ func TestDynamicRender_NotAuthorizedIsCached(t *testing.T) {
 		_, _ = renderer.Render(ctx, owner.ID, nil)
 	}
 	require.Equal(t, 1, db.callsFor(owner.ID),
-		"NotAuthorized must be cached; expected one ListUserSecrets call across multiple renders")
+		"NotAuthorized must be cached across renders")
 }
 
-// secretAuthDenyingStore wraps database.Store and makes ListUserSecrets
-// return dbauthz.NotAuthorizedError, simulating a caller that lacks
-// user_secret:read on the target owner. This is the exact condition a
-// template admin rendering for another user hits, per the User Secrets
-// RFC's owner-only RBAC model.
+// secretAuthDenyingStore makes ListUserSecrets return NotAuthorized,
+// simulating a non-owner caller.
 type secretAuthDenyingStore struct {
 	database.Store
 }
@@ -217,25 +231,19 @@ func (secretAuthDenyingStore) ListUserSecrets(_ context.Context, _ uuid.UUID) ([
 	return nil, dbauthz.NotAuthorizedError{}
 }
 
-// TestDynamicRender_NonOwnerCannotLeakSecretRequirements is the
-// regression test for the information-leak vector where a non-owner
-// (e.g. a template admin) could enumerate a target user's secret
-// env_names and file_paths by watching for missing_secret diagnostics
-// across crafted templates. The fix is to keep the ListUserSecrets call
-// inside the caller's own authorization context; this test pins it.
+// TestDynamicRender_NonOwnerCannotLeakSecretRequirements guards against
+// a non-owner enumerating secret names via missing_secret diagnostics.
 func TestDynamicRender_NonOwnerCannotLeakSecretRequirements(t *testing.T) {
 	t.Parallel()
 
 	inner, _ := dbtestutil.NewDB(t)
 	db := secretAuthDenyingStore{Store: inner}
-	ctx := context.Background()
+	ctx := t.Context()
 	org := dbgen.Organization(t, db, database.Organization{})
 	owner := seedOwner(t, db, org.ID)
 
-	// Seed a secret that DOES match the template's requirement. Under the
-	// buggy behavior (elevated system actor) this would satisfy the
-	// requirement and emit no missing_secret diagnostic, while under the
-	// correct behavior the non-owner never sees the list at all.
+	// Secret matches the requirement; a non-owner must still never
+	// see it.
 	_ = dbgen.UserSecret(t, db, database.UserSecret{
 		UserID:  owner.ID,
 		Name:    "gh",
@@ -247,37 +255,36 @@ func TestDynamicRender_NonOwnerCannotLeakSecretRequirements(t *testing.T) {
 
 	_, diags := renderer.Render(ctx, owner.ID, nil)
 
-	// 1. Never emit missing_secret for a non-owner, regardless of whether
-	//    the target satisfies the requirement. This is the leak being
-	//    prevented: the presence/absence of missing_secret must not be
-	//    observable by callers who lack user_secret:read on the target.
+	// No missing_secret diagnostic for a non-owner, regardless of
+	// whether the target satisfies the requirement.
 	requireNoMissingSecret(t, diags)
 
-	// 2. Surface a visible warning so the admin understands the feature
-	//    is not running for this target, rather than silently succeeding.
+	// Surface a warning so the admin knows validation didn't run.
 	var sawWarn bool
 	for _, d := range diags {
 		extra, ok := d.Extra.(previewtypes.DiagnosticExtra)
 		if !ok {
 			continue
 		}
-		if extra.Code == "secret_validation_forbidden" {
+		if extra.Code == DiagCodeSecretValidationForbidden {
 			require.Equal(t, hcl.DiagWarning, d.Severity,
-				"secret_validation_forbidden must be a warning so it does not disable the Create Workspace button")
+				"secret_validation_forbidden must be a warning")
 			sawWarn = true
 		}
 	}
-	require.True(t, sawWarn,
-		"expected secret_validation_forbidden warning when caller lacks user_secret:read")
+	require.True(t, sawWarn, "expected secret_validation_forbidden warning")
 }
 
 func requireMissingSecret(t *testing.T, diags hcl.Diagnostics, wantDetail string) {
 	t.Helper()
 	for _, d := range diags {
 		extra, ok := d.Extra.(previewtypes.DiagnosticExtra)
-		if !ok || extra.Code != "missing_secret" {
+		if !ok || extra.Code != DiagCodeMissingSecret {
 			continue
 		}
+		// The Create Workspace button disables only on error severity.
+		require.Equal(t, hcl.DiagError, d.Severity,
+			"missing_secret must be error severity")
 		if wantDetail != "" {
 			require.Contains(t, d.Detail, wantDetail)
 		}
@@ -289,7 +296,7 @@ func requireMissingSecret(t *testing.T, diags hcl.Diagnostics, wantDetail string
 func requireNoMissingSecret(t *testing.T, diags hcl.Diagnostics) {
 	t.Helper()
 	for _, d := range diags {
-		if extra, ok := d.Extra.(previewtypes.DiagnosticExtra); ok && extra.Code == "missing_secret" {
+		if extra, ok := d.Extra.(previewtypes.DiagnosticExtra); ok && extra.Code == DiagCodeMissingSecret {
 			t.Fatalf("unexpected missing_secret diagnostic: %s", d.Detail)
 		}
 	}

--- a/coderd/dynamicparameters/resolver.go
+++ b/coderd/dynamicparameters/resolver.go
@@ -27,6 +27,22 @@ type parameterValue struct {
 	Source parameterValueSource
 }
 
+// ResolveOption configures optional behavior for ResolveParameters.
+type ResolveOption func(*resolveOptions)
+
+type resolveOptions struct {
+	skipSecretRequirements bool
+}
+
+// SkipSecretRequirements drops secret-requirement diagnostics from the
+// renderer output. Callers must pass this for non-start transitions so
+// an unsatisfied coder_secret doesn't block stop or delete.
+func SkipSecretRequirements() ResolveOption {
+	return func(o *resolveOptions) {
+		o.skipSecretRequirements = true
+	}
+}
+
 //nolint:revive // firstbuild is a control flag to turn on immutable validation
 func ResolveParameters(
 	ctx context.Context,
@@ -36,7 +52,12 @@ func ResolveParameters(
 	previousValues []database.WorkspaceBuildParameter,
 	buildValues []codersdk.WorkspaceBuildParameter,
 	presetValues []database.TemplateVersionPresetParameter,
+	opts ...ResolveOption,
 ) (map[string]string, error) {
+	o := resolveOptions{}
+	for _, opt := range opts {
+		opt(&o)
+	}
 	previousValuesMap := slice.ToMapFunc(previousValues, func(p database.WorkspaceBuildParameter) (string, string) {
 		return p.Name, p.Value
 	})
@@ -71,6 +92,9 @@ func ResolveParameters(
 	// This is how the form should look to the user on their workspace settings page.
 	// This is the original form truth that our validations should initially be based on.
 	output, diags := renderer.Render(ctx, ownerID, previousValuesMap)
+	// Baseline diagnostics reflect the previous build, not the user's
+	// new inputs. The final render below enforces secret requirements.
+	diags = filterSecretDiagnostics(diags)
 	if diags.HasErrors() {
 		// Top level diagnostics should break the build. Previous values (and new) should
 		// always be valid. If there is a case where this is not true, then this has to
@@ -99,6 +123,9 @@ func ResolveParameters(
 	// This is the final set of values that will be used. Any errors at this stage
 	// are fatal. Additional validation for immutability has to be done manually.
 	output, diags = renderer.Render(ctx, ownerID, values.ValuesMap())
+	if o.skipSecretRequirements {
+		diags = filterSecretDiagnostics(diags)
+	}
 	if diags.HasErrors() {
 		return nil, parameterValidationError(diags)
 	}

--- a/coderd/dynamicparameters/resolver.go
+++ b/coderd/dynamicparameters/resolver.go
@@ -94,7 +94,7 @@ func ResolveParameters(
 	output, diags := renderer.Render(ctx, ownerID, previousValuesMap)
 	// Baseline diagnostics reflect the previous build, not the user's
 	// new inputs. The final render below enforces secret requirements.
-	diags = filterSecretDiagnostics(diags)
+	diags = FilterSecretDiagnostics(diags)
 	if diags.HasErrors() {
 		// Top level diagnostics should break the build. Previous values (and new) should
 		// always be valid. If there is a case where this is not true, then this has to
@@ -124,7 +124,7 @@ func ResolveParameters(
 	// are fatal. Additional validation for immutability has to be done manually.
 	output, diags = renderer.Render(ctx, ownerID, values.ValuesMap())
 	if o.skipSecretRequirements {
-		diags = filterSecretDiagnostics(diags)
+		diags = FilterSecretDiagnostics(diags)
 	}
 	if diags.HasErrors() {
 		return nil, parameterValidationError(diags)

--- a/coderd/dynamicparameters/resolver_test.go
+++ b/coderd/dynamicparameters/resolver_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/hcl/v2"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
@@ -143,9 +144,9 @@ func TestResolveParameters(t *testing.T) {
 			{name: "decreasing/decrease allowed", monotonic: "decreasing", prev: "10", cur: "5"},
 			{name: "decreasing/same allowed", monotonic: "decreasing", prev: "5", cur: "5"},
 			{name: "decreasing/increase rejected", monotonic: "decreasing", prev: "5", cur: "10", expectErr: "must be equal or lower than previous value"},
-			// First build — not enforced
+			// First build, not enforced
 			{name: "increasing/first build", monotonic: "increasing", cur: "1", firstBuild: true},
-			// No previous value — not enforced
+			// No previous value, not enforced
 			{name: "increasing/no previous", monotonic: "increasing", cur: "5"},
 		}
 
@@ -205,4 +206,121 @@ func TestResolveParameters(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("BaselineSecretDiagnosticsDoNotBlockDeactivatingRequirement", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		render := rendermock.NewMockRenderer(ctrl)
+		ownerID := uuid.New()
+
+		gomock.InOrder(
+			render.EXPECT().
+				Render(gomock.Any(), ownerID, map[string]string{"use_github": "true"}).
+				Return(&preview.Output{
+					Parameters: []previewtypes.Parameter{stringParameter("use_github", "true")},
+				}, hcl.Diagnostics{secretDiagnostic(dynamicparameters.DiagCodeMissingSecret)}),
+			render.EXPECT().
+				Render(gomock.Any(), ownerID, map[string]string{"use_github": "false"}).
+				Return(&preview.Output{
+					Parameters: []previewtypes.Parameter{stringParameter("use_github", "false")},
+				}, nil),
+		)
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		values, err := dynamicparameters.ResolveParameters(ctx, ownerID, render, false,
+			[]database.WorkspaceBuildParameter{{Name: "use_github", Value: "true"}},
+			[]codersdk.WorkspaceBuildParameter{{Name: "use_github", Value: "false"}},
+			[]database.TemplateVersionPresetParameter{},
+		)
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{"use_github": "false"}, values)
+	})
+
+	t.Run("SkipSecretRequirementsDropsFinalSecretDiagnostics", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		render := rendermock.NewMockRenderer(ctrl)
+		ownerID := uuid.New()
+
+		gomock.InOrder(
+			render.EXPECT().
+				Render(gomock.Any(), ownerID, map[string]string{"use_github": "true"}).
+				Return(&preview.Output{
+					Parameters: []previewtypes.Parameter{stringParameter("use_github", "true")},
+				}, nil),
+			render.EXPECT().
+				Render(gomock.Any(), ownerID, map[string]string{"use_github": "true"}).
+				Return(&preview.Output{
+					Parameters: []previewtypes.Parameter{stringParameter("use_github", "true")},
+				}, hcl.Diagnostics{secretDiagnostic(dynamicparameters.DiagCodeMissingSecret)}),
+		)
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		values, err := dynamicparameters.ResolveParameters(ctx, ownerID, render, false,
+			[]database.WorkspaceBuildParameter{{Name: "use_github", Value: "true"}},
+			nil,
+			nil,
+			dynamicparameters.SkipSecretRequirements(),
+		)
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{"use_github": "true"}, values)
+	})
+
+	t.Run("FinalSecretDiagnosticsBlockByDefault", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		render := rendermock.NewMockRenderer(ctrl)
+		ownerID := uuid.New()
+
+		gomock.InOrder(
+			render.EXPECT().
+				Render(gomock.Any(), ownerID, map[string]string{"use_github": "true"}).
+				Return(&preview.Output{
+					Parameters: []previewtypes.Parameter{stringParameter("use_github", "true")},
+				}, nil),
+			render.EXPECT().
+				Render(gomock.Any(), ownerID, map[string]string{"use_github": "true"}).
+				Return(&preview.Output{
+					Parameters: []previewtypes.Parameter{stringParameter("use_github", "true")},
+				}, hcl.Diagnostics{secretDiagnostic(dynamicparameters.DiagCodeMissingSecret)}),
+		)
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		_, err := dynamicparameters.ResolveParameters(ctx, ownerID, render, false,
+			[]database.WorkspaceBuildParameter{{Name: "use_github", Value: "true"}},
+			nil,
+			nil,
+		)
+		require.Error(t, err)
+		resp, ok := httperror.IsResponder(err)
+		require.True(t, ok)
+		_, respErr := resp.Response()
+		require.Contains(t, respErr.Detail, "Secret requirement diagnostic")
+	})
+}
+
+func stringParameter(name string, value string) previewtypes.Parameter {
+	return previewtypes.Parameter{
+		ParameterData: previewtypes.ParameterData{
+			Name:         name,
+			Type:         previewtypes.ParameterTypeString,
+			FormType:     provider.ParameterFormTypeInput,
+			Mutable:      true,
+			DefaultValue: previewtypes.StringLiteral(value),
+		},
+		Value: previewtypes.StringLiteral(value),
+	}
+}
+
+func secretDiagnostic(code string) *hcl.Diagnostic {
+	return &hcl.Diagnostic{
+		Severity: hcl.DiagError,
+		Summary:  "Secret requirement diagnostic",
+		Extra: previewtypes.DiagnosticExtra{
+			Code: code,
+		},
+	}
 }

--- a/coderd/dynamicparameters/testdata/secret_conditional/main.tf
+++ b/coderd/dynamicparameters/testdata/secret_conditional/main.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    coder = {
+      source = "coder/coder"
+    }
+  }
+}
+
+data "coder_parameter" "use_github" {
+  name    = "use_github"
+  type    = "bool"
+  default = "false"
+  mutable = true
+}
+
+data "coder_secret" "gh" {
+  count        = data.coder_parameter.use_github.value == "true" ? 1 : 0
+  env          = "GITHUB_TOKEN"
+  help_message = "Add a GitHub PAT"
+}

--- a/coderd/dynamicparameters/testdata/secret_env_and_file/main.tf
+++ b/coderd/dynamicparameters/testdata/secret_env_and_file/main.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    coder = {
+      source = "coder/coder"
+    }
+  }
+}
+
+data "coder_secret" "env_req" {
+  env          = "GITHUB_TOKEN"
+  help_message = "needs env"
+}
+
+data "coder_secret" "file_req" {
+  file         = "~/.ssh/id_rsa"
+  help_message = "needs file"
+}

--- a/coderd/dynamicparameters/testdata/secret_required/main.tf
+++ b/coderd/dynamicparameters/testdata/secret_required/main.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    coder = {
+      source = "coder/coder"
+    }
+  }
+}
+
+data "coder_secret" "gh" {
+  env          = "GITHUB_TOKEN"
+  help_message = "Add a GitHub PAT with env=GITHUB_TOKEN"
+}

--- a/coderd/parameters.go
+++ b/coderd/parameters.go
@@ -82,6 +82,7 @@ func (api *API) templateVersionDynamicParameters(listen bool, initial codersdk.D
 
 		renderer, err := dynamicparameters.Prepare(ctx, api.Database, api.FileCache, templateVersion.ID,
 			dynamicparameters.WithTemplateVersion(templateVersion),
+			dynamicparameters.WithLogger(api.Logger.Named("dynamicparameters")),
 		)
 		if err != nil {
 			if httpapi.Is404Error(err) {

--- a/coderd/parameters_test.go
+++ b/coderd/parameters_test.go
@@ -386,6 +386,27 @@ func TestDynamicParametersWithTerraformValues(t *testing.T) {
 		coderdtest.AssertParameter(t, "variable_values", preview.Parameters).
 			Exists().Value("austin")
 	})
+
+	t.Run("MissingSecret", func(t *testing.T) {
+		t.Parallel()
+
+		dynamicParametersTerraformSource, err := os.ReadFile("testdata/parameters/secret_required/main.tf")
+		require.NoError(t, err)
+
+		setup := setupDynamicParamsTest(t, setupDynamicParamsTestParams{
+			provisionerDaemonVersion: provProto.CurrentVersion.String(),
+			mainTF:                   dynamicParametersTerraformSource,
+		})
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		previews := setup.stream.Chan()
+
+		preview := testutil.RequireReceive(ctx, t, previews)
+		require.Equal(t, -1, preview.ID)
+		require.Len(t, preview.Diagnostics, 1)
+		require.Equal(t, "missing_secret", preview.Diagnostics[0].Extra.Code)
+		require.Contains(t, preview.Diagnostics[0].Detail, "GITHUB_TOKEN")
+	})
 }
 
 type setupDynamicParamsTestParams struct {

--- a/coderd/parameters_test.go
+++ b/coderd/parameters_test.go
@@ -410,6 +410,59 @@ func TestDynamicParametersWithTerraformValues(t *testing.T) {
 		// Error severity drives the Create Workspace button disable.
 		require.Equal(t, codersdk.DiagnosticSeverityError, preview.Diagnostics[0].Severity)
 	})
+
+	// Regression test for PLAT-100: a workspace whose template has an
+	// unsatisfied coder_secret requirement must still be stoppable and
+	// deletable. Start remains blocked.
+	t.Run("SecretRequirementDoesNotBlockStopOrDelete", func(t *testing.T) {
+		t.Parallel()
+
+		dynamicParametersTerraformSource, err := os.ReadFile("testdata/parameters/secret_required/main.tf")
+		require.NoError(t, err)
+
+		setup := setupDynamicParamsTest(t, setupDynamicParamsTestParams{
+			provisionerDaemonVersion: provProto.CurrentVersion.String(),
+			mainTF:                   dynamicParametersTerraformSource,
+		})
+		_ = setup.stream.Close(websocket.StatusGoingAway)
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		// Owner must satisfy the coder_secret requirement to create
+		// the workspace; delete it later to provoke the bug scenario.
+		_, err = setup.client.CreateUserSecret(ctx, codersdk.Me, codersdk.CreateUserSecretRequest{
+			Name:    "github-token",
+			Value:   "ghp_test",
+			EnvName: "GITHUB_TOKEN",
+		})
+		require.NoError(t, err)
+
+		wrk := coderdtest.CreateWorkspace(t, setup.client, setup.template.ID)
+		coderdtest.AwaitWorkspaceBuildJobCompleted(t, setup.client, wrk.LatestBuild.ID)
+
+		require.NoError(t, setup.client.DeleteUserSecret(ctx, codersdk.Me, "github-token"))
+
+		// Start on the now-unsatisfied requirement must still fail;
+		// otherwise we've over-filtered the diagnostic.
+		_, err = setup.client.CreateWorkspaceBuild(ctx, wrk.ID, codersdk.CreateWorkspaceBuildRequest{
+			Transition: codersdk.WorkspaceTransitionStart,
+		})
+		require.Error(t, err, "start must still reject unsatisfied secret requirement")
+
+		// Stop must succeed despite the unsatisfied requirement.
+		stop, err := setup.client.CreateWorkspaceBuild(ctx, wrk.ID, codersdk.CreateWorkspaceBuildRequest{
+			Transition: codersdk.WorkspaceTransitionStop,
+		})
+		require.NoError(t, err)
+		coderdtest.AwaitWorkspaceBuildJobCompleted(t, setup.client, stop.ID)
+
+		// Delete must succeed despite the unsatisfied requirement.
+		del, err := setup.client.CreateWorkspaceBuild(ctx, wrk.ID, codersdk.CreateWorkspaceBuildRequest{
+			Transition: codersdk.WorkspaceTransitionDelete,
+		})
+		require.NoError(t, err)
+		coderdtest.AwaitWorkspaceBuildJobCompleted(t, setup.client, del.ID)
+	})
 }
 
 type setupDynamicParamsTestParams struct {

--- a/coderd/parameters_test.go
+++ b/coderd/parameters_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/pubsub"
+	"github.com/coder/coder/v2/coderd/dynamicparameters"
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/wsjson"
@@ -404,8 +405,10 @@ func TestDynamicParametersWithTerraformValues(t *testing.T) {
 		preview := testutil.RequireReceive(ctx, t, previews)
 		require.Equal(t, -1, preview.ID)
 		require.Len(t, preview.Diagnostics, 1)
-		require.Equal(t, "missing_secret", preview.Diagnostics[0].Extra.Code)
+		require.Equal(t, dynamicparameters.DiagCodeMissingSecret, preview.Diagnostics[0].Extra.Code)
 		require.Contains(t, preview.Diagnostics[0].Detail, "GITHUB_TOKEN")
+		// Error severity drives the Create Workspace button disable.
+		require.Equal(t, codersdk.DiagnosticSeverityError, preview.Diagnostics[0].Severity)
 	})
 }
 

--- a/coderd/testdata/parameters/secret_required/main.tf
+++ b/coderd/testdata/parameters/secret_required/main.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    coder = {
+      source = "coder/coder"
+    }
+  }
+}
+
+data "coder_secret" "gh" {
+  env          = "GITHUB_TOKEN"
+  help_message = "Add a GitHub PAT with env=GITHUB_TOKEN"
+}

--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -383,6 +383,7 @@ func (api *API) postWorkspaceBuildsInternal(
 		DeploymentValues(api.Options.DeploymentValues).
 		Experiments(api.Experiments).
 		TemplateVersionPresetID(createBuild.TemplateVersionPresetID).
+		Logger(api.Logger.Named("wsbuilder")).
 		BuildMetrics(api.WorkspaceBuilderMetrics)
 
 	if (transition == database.WorkspaceTransitionStart || transition == database.WorkspaceTransitionStop) && createBuild.Reason != "" {

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -794,6 +794,7 @@ func createWorkspace(
 			Experiments(api.Experiments).
 			DeploymentValues(api.DeploymentValues).
 			RichParameterValues(req.RichParameterValues).
+			Logger(api.Logger.Named("wsbuilder")).
 			BuildMetrics(api.WorkspaceBuilderMetrics)
 		if req.TemplateVersionID != uuid.Nil {
 			builder = builder.VersionID(req.TemplateVersionID)

--- a/coderd/wsbuilder/wsbuilder.go
+++ b/coderd/wsbuilder/wsbuilder.go
@@ -1139,6 +1139,10 @@ func (b *Builder) getDynamicProvisionerTags() (map[string]string, error) {
 	}
 
 	output, diags := render.Render(b.ctx, b.workspace.OwnerID, vals)
+	// Don't let missing secrets block stop or delete on the tags path.
+	if b.trans != database.WorkspaceTransitionStart {
+		diags = dynamicparameters.FilterSecretDiagnostics(diags)
+	}
 	tagErr := dynamicparameters.CheckTags(output, diags)
 	if tagErr != nil {
 		return nil, BuildError{http.StatusBadRequest, "workspace tags validation failed", tagErr}

--- a/coderd/wsbuilder/wsbuilder.go
+++ b/coderd/wsbuilder/wsbuilder.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sqlc-dev/pqtype"
 	"golang.org/x/xerrors"
 
+	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/coderd/audit"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/db2sdk"
@@ -59,6 +60,7 @@ type Builder struct {
 	deploymentValues *codersdk.DeploymentValues
 	experiments      codersdk.Experiments
 	usageChecker     UsageChecker
+	logger           slog.Logger
 
 	richParameterValues     []codersdk.WorkspaceBuildParameter
 	initiator               uuid.UUID
@@ -192,6 +194,12 @@ func (b Builder) Experiments(exp codersdk.Experiments) Builder {
 	cpy := make(codersdk.Experiments, len(exp))
 	copy(cpy, exp)
 	b.experiments = cpy
+	return b
+}
+
+func (b Builder) Logger(log slog.Logger) Builder {
+	// nolint: revive
+	b.logger = log
 	return b
 }
 
@@ -759,6 +767,7 @@ func (b *Builder) getDynamicParameterRenderer() (dynamicparameters.Renderer, err
 		dynamicparameters.WithProvisionerJob(*job),
 		dynamicparameters.WithTerraformValues(*tfVals),
 		dynamicparameters.WithTemplateVariableValues(variableValues),
+		dynamicparameters.WithLogger(b.logger.Named("dynamicparameters")),
 	)
 	if err != nil {
 		return nil, xerrors.Errorf("get template version renderer: %w", err)
@@ -884,10 +893,16 @@ func (b *Builder) getDynamicParameters() (names, values []string, err error) {
 		return nil, nil, BuildError{http.StatusInternalServerError, "failed to check if first build", err}
 	}
 
+	// Don't let missing secrets block stop or delete.
+	var resolveOpts []dynamicparameters.ResolveOption
+	if b.trans != database.WorkspaceTransitionStart {
+		resolveOpts = append(resolveOpts, dynamicparameters.SkipSecretRequirements())
+	}
 	buildValues, err := dynamicparameters.ResolveParameters(b.ctx, b.workspace.OwnerID, render, firstBuild,
 		lastBuildParameters,
 		b.richParameterValues,
-		presetParameterValues)
+		presetParameterValues,
+		resolveOpts...)
 	if err != nil {
 		return nil, nil, BuildError{http.StatusBadRequest, "resolve parameters", err}
 	}

--- a/go.mod
+++ b/go.mod
@@ -502,7 +502,7 @@ require (
 	github.com/coder/aibridge v1.1.3-0.20260420072253-d474d6813420
 	github.com/coder/aisdk-go v0.0.9
 	github.com/coder/boundary v0.8.4-0.20260304164748-566aeea939ab
-	github.com/coder/preview v1.0.8
+	github.com/coder/preview v1.0.9-0.20260422211932-5e77eadfa551
 	github.com/danieljoos/wincred v1.2.3
 	github.com/dgraph-io/ristretto/v2 v2.4.0
 	github.com/elazarl/goproxy v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -340,8 +340,8 @@ github.com/coder/pq v1.10.5-0.20250807075151-6ad9b0a25151 h1:YAxwg3lraGNRwoQ18H7
 github.com/coder/pq v1.10.5-0.20250807075151-6ad9b0a25151/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/coder/pretty v0.0.0-20230908205945-e89ba86370e0 h1:3A0ES21Ke+FxEM8CXx9n47SZOKOpgSE1bbJzlE4qPVs=
 github.com/coder/pretty v0.0.0-20230908205945-e89ba86370e0/go.mod h1:5UuS2Ts+nTToAMeOjNlnHFkPahrtDkmpydBen/3wgZc=
-github.com/coder/preview v1.0.8 h1:RqejfDTplczgSiNqsrQTH7g2qV0p5FGZHTkc/psWZfM=
-github.com/coder/preview v1.0.8/go.mod h1:BvAfITWREXP08NIOasaAJ2hi2TWFWc6Y0CSPKEPsMzk=
+github.com/coder/preview v1.0.9-0.20260422211932-5e77eadfa551 h1:Z5uwJ5fVZO8pTq6HtfFc+4mMNtYgoY7MsuwZS2ZzwIE=
+github.com/coder/preview v1.0.9-0.20260422211932-5e77eadfa551/go.mod h1:3+ponddy+zyv07w6mU3QPaSiAQQ06l8i2aHbWBvpJhU=
 github.com/coder/quartz v0.3.0 h1:bUoSEJ77NBfKtUqv6CPSC0AS8dsjqAqqAv7bN02m1mg=
 github.com/coder/quartz v0.3.0/go.mod h1:BgE7DOj/8NfvRgvKw0jPLDQH/2Lya2kxcTaNJ8X0rZk=
 github.com/coder/retry v1.5.1 h1:iWu8YnD8YqHs3XwqrqsjoBTAVqT9ml6z9ViJ2wlMiqc=

--- a/site/src/modules/workspaces/DynamicParameter/DynamicParameter.stories.tsx
+++ b/site/src/modules/workspaces/DynamicParameter/DynamicParameter.stories.tsx
@@ -308,8 +308,34 @@ export const MissingSecretDiagnostic: StoryObj<typeof Diagnostics> = {
 		// stay stable across versioned builds (`/@vX.Y.Z/`).
 		await expect(link).toHaveAttribute(
 			"href",
-			expect.stringContaining("/reference/cli/secret-create"),
+			expect.stringContaining("/reference/cli/secret_create"),
 		);
 		await expect(link).toHaveAttribute("target", "_blank");
 	},
 };
+
+// Warning variant for callers lacking user_secret:read on the owner.
+const secretValidationForbiddenDiagnostic: FriendlyDiagnostic = {
+	severity: "warning",
+	summary: "Cannot validate secret requirements",
+	detail:
+		"You are not permitted to read secret metadata for this user. The workspace may fail to build if required secrets are not set.",
+	extra: { code: "secret_validation_forbidden" },
+};
+
+export const SecretValidationForbiddenDiagnostic: StoryObj<typeof Diagnostics> =
+	{
+		render: () => (
+			<Diagnostics diagnostics={[secretValidationForbiddenDiagnostic]} />
+		),
+		play: async ({ canvasElement }) => {
+			const canvas = within(canvasElement);
+			await expect(
+				canvas.getByText("Cannot validate secret requirements"),
+			).toBeVisible();
+			// No CLI-recovery link for the warning variant.
+			await expect(
+				canvas.queryByRole("link", { name: /coder secret create/i }),
+			).toBeNull();
+		},
+	};

--- a/site/src/modules/workspaces/DynamicParameter/DynamicParameter.stories.tsx
+++ b/site/src/modules/workspaces/DynamicParameter/DynamicParameter.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, within } from "storybook/test";
+import type { FriendlyDiagnostic } from "#/api/typesGenerated";
 import { MockPreviewParameter } from "#/testHelpers/entities";
-import { DynamicParameter } from "./DynamicParameter";
+import { Diagnostics, DynamicParameter } from "./DynamicParameter";
 
 const meta: Meta<typeof DynamicParameter> = {
 	title: "modules/workspaces/DynamicParameter",
@@ -277,5 +279,37 @@ export const MaskedTextArea: Story = {
 				mask_input: true,
 			},
 		},
+	},
+};
+
+// Covers the top-level Diagnostics specialization for missing_secret.
+// The <Diagnostics> component is rendered directly here because missing
+// secret diagnostics surface at the page level, not on individual
+// parameters (see CreateWorkspacePageView).
+const missingSecretDiagnostic: FriendlyDiagnostic = {
+	severity: "error",
+	summary: "Missing required secret",
+	detail: "Add an SSH deploy key with file=~/.ssh/id_deploy",
+	extra: { code: "missing_secret" },
+};
+
+export const MissingSecretDiagnostic: StoryObj<typeof Diagnostics> = {
+	render: () => <Diagnostics diagnostics={[missingSecretDiagnostic]} />,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(
+			canvas.getByText("Add an SSH deploy key with file=~/.ssh/id_deploy"),
+		).toBeVisible();
+		const link = canvas.getByRole("link", {
+			name: /coder secret create/i,
+		});
+		// The link target goes through the docs() helper, which resolves to
+		// the coder.com docs URL at runtime. Assert on the path suffix to
+		// stay stable across versioned builds (`/@vX.Y.Z/`).
+		await expect(link).toHaveAttribute(
+			"href",
+			expect.stringContaining("/reference/cli/secret-create"),
+		);
+		await expect(link).toHaveAttribute("target", "_blank");
 	},
 };

--- a/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
+++ b/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
@@ -951,17 +951,12 @@ export const Diagnostics: FC<DiagnosticsProps> = ({ diagnostics }) => {
 							<p className="m-0">{diagnostic.summary}</p>
 							{diagnostic.detail && <p className="m-0">{diagnostic.detail}</p>}
 							{diagnostic.extra?.code === "missing_secret" && (
-								// TODO(PLAT-100): when the user-secrets settings page
-								// lands, swap this external CLI-docs link for a
-								// <RouterLink to="/settings/secrets"> so recovery is a
-								// single click without leaving the app. Opening in a
-								// new tab here because the create-workspace form has
-								// pending parameter state that same-tab navigation
-								// would discard.
+								// TODO(PLAT-102): swap for a RouterLink to
+								// /settings/secrets once that page lands.
 								<p className="m-0">
 									Create this secret with the{" "}
 									<Link
-										href={docs("/reference/cli/secret-create")}
+										href={docs("/reference/cli/secret_create")}
 										target="_blank"
 										rel="noreferrer"
 									>

--- a/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
+++ b/site/src/modules/workspaces/DynamicParameter/DynamicParameter.tsx
@@ -22,6 +22,7 @@ import { Checkbox } from "#/components/Checkbox/Checkbox";
 import { ExternalImage } from "#/components/ExternalImage/ExternalImage";
 import { Input } from "#/components/Input/Input";
 import { Label } from "#/components/Label/Label";
+import { Link } from "#/components/Link/Link";
 import { MemoizedMarkdown } from "#/components/Markdown/Markdown";
 import {
 	MultiSelectCombobox,
@@ -47,6 +48,7 @@ import {
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
 import { cn } from "#/utils/cn";
+import { docs } from "#/utils/docs";
 import type { AutofillBuildParameter } from "#/utils/richParameters";
 
 interface DynamicParameterProps {
@@ -948,6 +950,26 @@ export const Diagnostics: FC<DiagnosticsProps> = ({ diagnostics }) => {
 						<div className="flex flex-col gap-3">
 							<p className="m-0">{diagnostic.summary}</p>
 							{diagnostic.detail && <p className="m-0">{diagnostic.detail}</p>}
+							{diagnostic.extra?.code === "missing_secret" && (
+								// TODO(PLAT-100): when the user-secrets settings page
+								// lands, swap this external CLI-docs link for a
+								// <RouterLink to="/settings/secrets"> so recovery is a
+								// single click without leaving the app. Opening in a
+								// new tab here because the create-workspace form has
+								// pending parameter state that same-tab navigation
+								// would discard.
+								<p className="m-0">
+									Create this secret with the{" "}
+									<Link
+										href={docs("/reference/cli/secret-create")}
+										target="_blank"
+										rel="noreferrer"
+									>
+										coder secret create
+									</Link>{" "}
+									CLI command.
+								</p>
+							)}
 						</div>
 					</div>
 				</div>

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.stories.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.stories.tsx
@@ -356,3 +356,36 @@ export const WithPresets: Story = {
 		parameters: [parameterInput, parameterDropdown],
 	},
 };
+
+export const MissingSecretRequirement: Story = {
+	args: {
+		...WithParameters.args,
+		diagnostics: [
+			{
+				severity: "error",
+				summary: "Missing required secret",
+				detail: "Add an SSH deploy key with file=~/.ssh/id_deploy",
+				extra: { code: "missing_secret" },
+			},
+		],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const createBtn = canvas.getByRole("button", {
+			name: /create workspace/i,
+		});
+		await expect(createBtn).toBeDisabled();
+		await expect(
+			canvas.getByText("Add an SSH deploy key with file=~/.ssh/id_deploy"),
+		).toBeVisible();
+		const link = canvas.getByRole("link", { name: /coder secret create/i });
+		// The link goes through docs(), which resolves to the coder.com docs
+		// URL at runtime. Match on the path suffix so versioned builds
+		// (`/@vX.Y.Z/`) don't break the assertion.
+		await expect(link).toHaveAttribute(
+			"href",
+			expect.stringContaining("/reference/cli/secret-create"),
+		);
+		await expect(link).toHaveAttribute("target", "_blank");
+	},
+};

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.stories.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.stories.tsx
@@ -384,7 +384,7 @@ export const MissingSecretRequirement: Story = {
 		// (`/@vX.Y.Z/`) don't break the assertion.
 		await expect(link).toHaveAttribute(
 			"href",
-			expect.stringContaining("/reference/cli/secret-create"),
+			expect.stringContaining("/reference/cli/secret_create"),
 		);
 		await expect(link).toHaveAttribute("target", "_blank");
 	},


### PR DESCRIPTION
Integrates `coder_secret` requirements from the preview renderer into dynamic parameter evaluation. Missing owner secrets now surface as dynamic parameter diagnostics, with UI guidance for `coder secret create`; callers without secret read access get a non-blocking validation warning.

Workspace starts enforce missing secrets, while stop and delete transitions filter those diagnostics so unmet secret requirements do not prevent cleanup.

[Refs PLAT-100](https://linear.app/codercom/issue/PLAT-100/integrate-secret-requirements-into-dynamic-parameters-coderpreview)