### PR TITLE
fix(Makefile): run storybook tests after Go tests in pre-push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -881,8 +881,15 @@ pre-push:
 	$(MAKE) --no-print-directory -j$(PARALLEL_JOBS) MAKE_TIMED=1 MAKE_LOGDIR=$$logdir \
 		test \
 		test-js \
-		test-storybook \
 		site/out/index.html
+	# Storybook tests run after Go tests and the site build to avoid
+	# CPU starvation. Rolldown's tokio workers in Vite's transform
+	# pipeline stall when competing with Go compilation and the
+	# production build, causing browser import() calls to hang
+	# indefinitely (vitest has no import-phase timeout).
+	echo "test storybook:"
+	$(MAKE) --no-print-directory MAKE_TIMED=1 MAKE_LOGDIR=$$logdir \
+		test-storybook
 	rm -rf $$logdir
 	echo "$(GREEN)✓ pre-push passed$(RESET) ($$(( $$(date +%s) - $$start ))s)"
 .PHONY: pre-push


### PR DESCRIPTION
Rolldown's tokio workers stall when competing with Go compilation and the production site build for CPU, causing Vite transform requests to hang. Vitest browser mode has no import-phase timeout, so a stalled browser `import()` blocks the run indefinitely.

Work-around: run storybook tests after the parallel Go/JS/build targets finish.

<details>
<summary>Diagnostic evidence</summary>

- **Isolated:** 393 files, ~110s, no stalls.
- **With Go tests only:** 393 files, ~119s, no stalls.
- **All four targets parallel (old):** file(s) stuck at `(0 test)` after 7+ min. Vitest sleeping in `ep_poll`, 68 CLOSE-WAIT sockets, one ESTAB request Vite never serves. Example victim: `Breadcrumb.stories.tsx` (trivial static component).
- 168 tokio-rt-worker threads from Rolldown visible in `/proc/<pid>/task/`.
- `ss -tnp` shows the stuck file's module request sitting ESTAB in Vite's socket table.

</details>

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻