### PR TITLE
fix(site/src/pages/AgentsPage): add copy buttons to raw attempts

### DIFF
--- a/site/src/pages/AgentsPage/components/RightPanel/DebugPanel/DebugAttemptAccordion.tsx
+++ b/site/src/pages/AgentsPage/components/RightPanel/DebugPanel/DebugAttemptAccordion.tsx
@@ -9,7 +9,7 @@ import {
 import { cn } from "#/utils/cn";
 import { DATE_FORMAT, formatDateTime, humanDuration } from "#/utils/time";
 import {
-	DebugCodeBlock,
+	CopyableCodeBlock,
 	DebugDataSection,
 	EmptyHelper,
 } from "./DebugPanelPrimitives";
@@ -28,9 +28,10 @@ interface DebugAttemptAccordionProps {
 interface JsonBlockProps {
 	value: unknown;
 	fallbackCopy: string;
+	copyLabel: string;
 }
 
-const JsonBlock: FC<JsonBlockProps> = ({ value, fallbackCopy }) => {
+const JsonBlock: FC<JsonBlockProps> = ({ value, fallbackCopy, copyLabel }) => {
 	if (
 		value === null ||
 		value === undefined ||
@@ -40,11 +41,9 @@ const JsonBlock: FC<JsonBlockProps> = ({ value, fallbackCopy }) => {
 		return <EmptyHelper message={fallbackCopy} />;
 	}
 
-	if (typeof value === "string") {
-		return <DebugCodeBlock code={value} />;
-	}
+	const code = typeof value === "string" ? value : safeJsonStringify(value);
 
-	return <DebugCodeBlock code={safeJsonStringify(value)} />;
+	return <CopyableCodeBlock code={code} label={copyLabel} />;
 };
 
 const getAttemptTimingLabel = (attempt: NormalizedAttempt): string => {
@@ -79,7 +78,7 @@ export const DebugAttemptAccordion: FC<DebugAttemptAccordionProps> = ({
 					Unable to parse raw attempts. Showing the original payload exactly as
 					it was captured.
 				</p>
-				<DebugCodeBlock code={rawFallback} />
+				<CopyableCodeBlock code={rawFallback} label="Copy raw attempts JSON" />
 			</div>
 		);
 	}
@@ -162,18 +161,21 @@ export const DebugAttemptAccordion: FC<DebugAttemptAccordionProps> = ({
 									<JsonBlock
 										value={attempt.raw_request}
 										fallbackCopy="No raw request captured."
+										copyLabel="Copy raw request JSON"
 									/>
 								</DebugDataSection>
 								<DebugDataSection title="Raw response">
 									<JsonBlock
 										value={attempt.raw_response}
 										fallbackCopy="No raw response captured."
+										copyLabel="Copy raw response JSON"
 									/>
 								</DebugDataSection>
 								<DebugDataSection title="Error">
 									<JsonBlock
 										value={attempt.error}
 										fallbackCopy="No error captured."
+										copyLabel="Copy raw attempt error"
 									/>
 								</DebugDataSection>
 							</div>

--- a/site/src/pages/AgentsPage/components/RightPanel/DebugPanel/DebugAttemptAccordion.tsx
+++ b/site/src/pages/AgentsPage/components/RightPanel/DebugPanel/DebugAttemptAccordion.tsx
@@ -27,21 +27,21 @@ interface DebugAttemptAccordionProps {
 
 interface JsonBlockProps {
 	value: unknown;
-	fallbackCopy: string;
+	emptyMessage: string;
 	copyLabel: string;
 }
 
-const JsonBlock: FC<JsonBlockProps> = ({ value, fallbackCopy, copyLabel }) => {
+const JsonBlock: FC<JsonBlockProps> = ({ value, emptyMessage, copyLabel }) => {
 	if (
 		value === null ||
 		value === undefined ||
 		(typeof value === "string" && value.length === 0) ||
 		(typeof value === "object" && Object.keys(value as object).length === 0)
 	) {
-		return <EmptyHelper message={fallbackCopy} />;
+		return <EmptyHelper message={emptyMessage} />;
 	}
 
-	const code = typeof value === "string" ? value : safeJsonStringify(value);
+	const code = safeJsonStringify(value);
 
 	return <CopyableCodeBlock code={code} label={copyLabel} />;
 };
@@ -78,7 +78,7 @@ export const DebugAttemptAccordion: FC<DebugAttemptAccordionProps> = ({
 					Unable to parse raw attempts. Showing the original payload exactly as
 					it was captured.
 				</p>
-				<CopyableCodeBlock code={rawFallback} label="Copy raw attempts JSON" />
+				<CopyableCodeBlock code={rawFallback} label="Copy raw attempts" />
 			</div>
 		);
 	}
@@ -160,21 +160,21 @@ export const DebugAttemptAccordion: FC<DebugAttemptAccordionProps> = ({
 								<DebugDataSection title="Raw request">
 									<JsonBlock
 										value={attempt.raw_request}
-										fallbackCopy="No raw request captured."
+										emptyMessage="No raw request captured."
 										copyLabel="Copy raw request JSON"
 									/>
 								</DebugDataSection>
 								<DebugDataSection title="Raw response">
 									<JsonBlock
 										value={attempt.raw_response}
-										fallbackCopy="No raw response captured."
+										emptyMessage="No raw response captured."
 										copyLabel="Copy raw response JSON"
 									/>
 								</DebugDataSection>
 								<DebugDataSection title="Error">
 									<JsonBlock
 										value={attempt.error}
-										fallbackCopy="No error captured."
+										emptyMessage="No error captured."
 										copyLabel="Copy raw attempt error"
 									/>
 								</DebugDataSection>

--- a/site/src/pages/AgentsPage/components/RightPanel/DebugPanel/DebugPanel.stories.tsx
+++ b/site/src/pages/AgentsPage/components/RightPanel/DebugPanel/DebugPanel.stories.tsx
@@ -786,6 +786,19 @@ export const MultiStepRunWithRetries: Story = {
 			expect(canvas.getByText(/Attempt 2/)).toBeVisible();
 			expect(canvas.getByText(/Attempt 3/)).toBeVisible();
 		});
+
+		await user.click(canvas.getByRole("button", { name: /Attempt 1/i }));
+		await waitFor(() => {
+			expect(
+				canvas.getByRole("button", { name: /Copy raw request JSON/i }),
+			).toBeVisible();
+			expect(
+				canvas.getByRole("button", { name: /Copy raw response JSON/i }),
+			).toBeVisible();
+			expect(
+				canvas.getByRole("button", { name: /Copy raw attempt error/i }),
+			).toBeVisible();
+		});
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/RightPanel/DebugPanel/DebugPanelPrimitives.tsx
+++ b/site/src/pages/AgentsPage/components/RightPanel/DebugPanel/DebugPanelPrimitives.tsx
@@ -33,10 +33,7 @@ interface DebugCodeBlockProps {
 	className?: string;
 }
 
-export const DebugCodeBlock: FC<DebugCodeBlockProps> = ({
-	code,
-	className,
-}) => {
+const DebugCodeBlock: FC<DebugCodeBlockProps> = ({ code, className }) => {
 	return (
 		<pre
 			className={cn(


### PR DESCRIPTION
Raw attempt details in the chat debug panel rendered plain code blocks, so raw request, raw response, and attempt error payloads were missing the copy affordance used by nearby body sections.

This reuses the existing copyable code block treatment for raw attempt payloads, including the raw-attempt fallback path, and covers the affordance in the debug panel Storybook interaction.

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.5` • Thinking: `xhigh`_
