### PR TITLE
fix: replay reasoning + web_search_call without orphan in chatd

### DIFF
--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -6166,6 +6166,10 @@ func (p *Server) runChat(
 	chatprompt.LogAnthropicProviderToolSanitization(
 		ctx, logger, "persisted_history_replay", model.Provider(), model.Model(), sanitizeStats,
 	)
+	prompt, openAISanitizeStats := chatprompt.SanitizeOpenAIOrphanToolMessages(model.Provider(), prompt)
+	chatprompt.LogOpenAIOrphanToolSanitization(
+		ctx, logger, "persisted_history_replay", model.Provider(), model.Model(), openAISanitizeStats,
+	)
 	subagentInstruction := ""
 	if !isRootChat {
 		subagentInstruction = defaultSubagentInstruction
@@ -6792,6 +6796,10 @@ func (p *Server) runChat(
 			reloadedPrompt, sanitizeStats := chatprompt.SanitizeAnthropicProviderToolCalls(model.Provider(), reloadedPrompt)
 			chatprompt.LogAnthropicProviderToolSanitization(
 				reloadCtx, logger, "reload_messages", model.Provider(), model.Model(), sanitizeStats,
+			)
+			reloadedPrompt, openAISanitizeStats := chatprompt.SanitizeOpenAIOrphanToolMessages(model.Provider(), reloadedPrompt)
+			chatprompt.LogOpenAIOrphanToolSanitization(
+				reloadCtx, logger, "reload_messages", model.Provider(), model.Model(), openAISanitizeStats,
 			)
 			// Re-derive instruction and skills from the reloaded
 			// messages so that any context added during the

--- a/coderd/x/chatd/chatloop/chatloop.go
+++ b/coderd/x/chatd/chatloop/chatloop.go
@@ -397,6 +397,12 @@ func Run(ctx context.Context, opts RunOptions) error {
 				slog.F("step_index", step),
 				slog.F("total_steps", totalSteps),
 			)
+			prepared, openAISanitizeStats := chatprompt.SanitizeOpenAIOrphanToolMessages(provider, prepared)
+			chatprompt.LogOpenAIOrphanToolSanitization(
+				ctx, opts.Logger, "pre_request", provider, modelName, openAISanitizeStats,
+				slog.F("step_index", step),
+				slog.F("total_steps", totalSteps),
+			)
 			if applyAnthropicCaching {
 				addAnthropicPromptCaching(prepared)
 			}

--- a/coderd/x/chatd/chatprompt/chatprompt.go
+++ b/coderd/x/chatd/chatprompt/chatprompt.go
@@ -12,7 +12,9 @@ import (
 
 	"charm.land/fantasy"
 	fantasyanthropic "charm.land/fantasy/providers/anthropic"
+	fantasyazure "charm.land/fantasy/providers/azure"
 	fantasyopenai "charm.land/fantasy/providers/openai"
+	fantasyopenaicompat "charm.land/fantasy/providers/openaicompat"
 	"github.com/google/uuid"
 	"github.com/sqlc-dev/pqtype"
 	"golang.org/x/xerrors"
@@ -170,8 +172,9 @@ func LogOpenAIOrphanToolSanitization(
 //	No tool output found for function call call_xxx.
 //
 // This is a defensive belt-and-suspenders complement to the fantasy
-// reasoning-replay fix in providers/openai. It is OpenAI-specific
-// and a no-op for other providers.
+// reasoning-replay fix in providers/openai. It runs for every
+// provider that routes through the same Responses API code path
+// (openai, azure, openai-compat) and is a no-op elsewhere.
 //
 // Returns the input slice unchanged when there is nothing to drop
 // (early return on the no-op path), matching
@@ -181,7 +184,7 @@ func SanitizeOpenAIOrphanToolMessages(
 	messages []fantasy.Message,
 ) ([]fantasy.Message, OpenAIOrphanToolSanitizationStats) {
 	var stats OpenAIOrphanToolSanitizationStats
-	if provider != fantasyopenai.Name || len(messages) == 0 {
+	if !isOpenAIResponsesProvider(provider) || len(messages) == 0 {
 		return messages, stats
 	}
 
@@ -232,6 +235,20 @@ func SanitizeOpenAIOrphanToolMessages(
 		out = append(out, msg)
 	}
 	return out, stats
+}
+
+// isOpenAIResponsesProvider reports whether the given provider name
+// uses the OpenAI Responses API. Azure OpenAI and openai-compat both
+// route through the same fantasy openai package and therefore hit the
+// same Responses API pairing rules. The sanitizer must run for all
+// of them, not just the canonical "openai" name.
+func isOpenAIResponsesProvider(provider string) bool {
+	switch provider {
+	case fantasyopenai.Name, fantasyazure.Name, fantasyopenaicompat.Name:
+		return true
+	default:
+		return false
+	}
 }
 
 // isReasoningOnlyAssistantMessage reports whether an assistant message

--- a/coderd/x/chatd/chatprompt/chatprompt.go
+++ b/coderd/x/chatd/chatprompt/chatprompt.go
@@ -12,6 +12,7 @@ import (
 
 	"charm.land/fantasy"
 	fantasyanthropic "charm.land/fantasy/providers/anthropic"
+	fantasyopenai "charm.land/fantasy/providers/openai"
 	"github.com/google/uuid"
 	"github.com/sqlc-dev/pqtype"
 	"golang.org/x/xerrors"
@@ -124,6 +125,123 @@ func SanitizeAnthropicProviderToolCalls(
 		return messages, stats
 	}
 	return out, stats
+}
+
+// OpenAIOrphanToolSanitizationStats summarizes how many
+// reasoning-only assistant messages and orphaned tool messages were
+// dropped by SanitizeOpenAIOrphanToolMessages.
+type OpenAIOrphanToolSanitizationStats struct {
+	DroppedAssistantMessages int
+	DroppedToolMessages      int
+}
+
+// LogOpenAIOrphanToolSanitization logs prompt changes made while
+// removing orphan tool messages that follow reasoning-only assistant
+// messages.
+func LogOpenAIOrphanToolSanitization(
+	ctx context.Context,
+	logger slog.Logger,
+	phase string,
+	provider string,
+	modelName string,
+	stats OpenAIOrphanToolSanitizationStats,
+	extra ...slog.Field,
+) {
+	if stats.DroppedAssistantMessages == 0 && stats.DroppedToolMessages == 0 {
+		return
+	}
+	fields := []slog.Field{
+		slog.F("phase", phase),
+		slog.F("provider", provider),
+		slog.F("model", modelName),
+		slog.F("dropped_assistant_messages", stats.DroppedAssistantMessages),
+		slog.F("dropped_tool_messages", stats.DroppedToolMessages),
+	}
+	fields = append(fields, extra...)
+	logger.Warn(ctx,
+		"dropped reasoning-only assistant + orphan tool messages",
+		fields...)
+}
+
+// SanitizeOpenAIOrphanToolMessages drops tool messages whose preceding
+// assistant message contains only reasoning content. The OpenAI
+// Responses API replay layer skips such messages when the reasoning
+// item lacks a stored ItemID, leaving any function_call_output
+// orphaned and producing:
+//
+//	No tool output found for function call call_xxx.
+//
+// This is a defensive belt-and-suspenders complement to the fantasy
+// reasoning-replay fix in providers/openai. It is OpenAI-specific
+// and a no-op for other providers.
+//
+// Returns the input slice unchanged when no edits are needed (zero-
+// copy fast path), matching SanitizeAnthropicProviderToolCalls.
+func SanitizeOpenAIOrphanToolMessages(
+	provider string,
+	messages []fantasy.Message,
+) ([]fantasy.Message, OpenAIOrphanToolSanitizationStats) {
+	var stats OpenAIOrphanToolSanitizationStats
+	if provider != fantasyopenai.Name || len(messages) == 0 {
+		return messages, stats
+	}
+
+	// Pre-scan: find indices to drop. Drop a tool message when the
+	// immediately preceding assistant message is reasoning-only, and
+	// drop that assistant message too.
+	drop := make([]bool, len(messages))
+	for i, msg := range messages {
+		if msg.Role != fantasy.MessageRoleTool {
+			continue
+		}
+		prev := i - 1
+		if prev < 0 || messages[prev].Role != fantasy.MessageRoleAssistant {
+			continue
+		}
+		if !isReasoningOnlyAssistantMessage(messages[prev]) {
+			continue
+		}
+		drop[i] = true
+		drop[prev] = true
+		stats.DroppedToolMessages++
+		stats.DroppedAssistantMessages++
+	}
+
+	if stats.DroppedToolMessages == 0 {
+		return messages, stats
+	}
+
+	out := make([]fantasy.Message, 0, len(messages))
+	for i, msg := range messages {
+		if drop[i] {
+			continue
+		}
+		out = appendSanitizedMessage(out, msg)
+	}
+	return out, stats
+}
+
+// isReasoningOnlyAssistantMessage reports whether an assistant message
+// has at least one reasoning part and no other part type that the
+// OpenAI Responses API treats as visible model content (text,
+// tool_call, tool_result, file).
+func isReasoningOnlyAssistantMessage(msg fantasy.Message) bool {
+	if msg.Role != fantasy.MessageRoleAssistant || len(msg.Content) == 0 {
+		return false
+	}
+	hasReasoning := false
+	for _, part := range msg.Content {
+		switch part.(type) {
+		case fantasy.ReasoningPart:
+			hasReasoning = true
+		case fantasy.TextPart,
+			fantasy.ToolCallPart,
+			fantasy.ToolResultPart,
+			fantasy.FilePart:
+			return false
+		}
+	}
+	return hasReasoning
 }
 
 func appendSanitizedMessage(out []fantasy.Message, msg fantasy.Message) []fantasy.Message {

--- a/coderd/x/chatd/chatprompt/chatprompt.go
+++ b/coderd/x/chatd/chatprompt/chatprompt.go
@@ -158,9 +158,7 @@ func LogOpenAIOrphanToolSanitization(
 		slog.F("dropped_tool_messages", stats.DroppedToolMessages),
 	}
 	fields = append(fields, extra...)
-	logger.Warn(ctx,
-		"dropped reasoning-only assistant + orphan tool messages",
-		fields...)
+	logger.Warn(ctx, "dropped reasoning-only assistant and orphan tool messages", fields...)
 }
 
 // SanitizeOpenAIOrphanToolMessages drops tool messages whose preceding
@@ -175,8 +173,9 @@ func LogOpenAIOrphanToolSanitization(
 // reasoning-replay fix in providers/openai. It is OpenAI-specific
 // and a no-op for other providers.
 //
-// Returns the input slice unchanged when no edits are needed (zero-
-// copy fast path), matching SanitizeAnthropicProviderToolCalls.
+// Returns the input slice unchanged when there is nothing to drop
+// (early return on the no-op path), matching
+// SanitizeAnthropicProviderToolCalls.
 func SanitizeOpenAIOrphanToolMessages(
 	provider string,
 	messages []fantasy.Message,
@@ -186,60 +185,75 @@ func SanitizeOpenAIOrphanToolMessages(
 		return messages, stats
 	}
 
-	// Pre-scan: find indices to drop. Drop a tool message when the
-	// immediately preceding assistant message is reasoning-only, and
-	// drop that assistant message too.
+	// Pre-scan: find indices to drop. When a reasoning-only assistant
+	// is found, drop it together with every contiguous tool message
+	// that follows. A function_call_output without its matching
+	// function_call (which lived on the dropped assistant turn) would
+	// otherwise reach OpenAI and trigger 'No tool output found'.
 	drop := make([]bool, len(messages))
 	for i, msg := range messages {
-		if msg.Role != fantasy.MessageRoleTool {
+		if msg.Role != fantasy.MessageRoleAssistant {
 			continue
 		}
-		prev := i - 1
-		if prev < 0 || messages[prev].Role != fantasy.MessageRoleAssistant {
+		if !isReasoningOnlyAssistantMessage(msg) {
 			continue
 		}
-		if !isReasoningOnlyAssistantMessage(messages[prev]) {
+		// Look ahead at the run of tool messages immediately
+		// following this assistant. If at least one exists, the
+		// orphan shape is present and we drop the whole pair.
+		j := i + 1
+		for j < len(messages) && messages[j].Role == fantasy.MessageRoleTool {
+			j++
+		}
+		if j == i+1 {
 			continue
 		}
 		drop[i] = true
-		drop[prev] = true
-		stats.DroppedToolMessages++
 		stats.DroppedAssistantMessages++
+		for k := i + 1; k < j; k++ {
+			drop[k] = true
+			stats.DroppedToolMessages++
+		}
 	}
 
-	if stats.DroppedToolMessages == 0 {
+	if stats.DroppedAssistantMessages == 0 {
 		return messages, stats
 	}
 
+	// Use a plain append (not appendSanitizedMessage) so we do not
+	// merge the two non-tool messages that bracket the dropped run
+	// into a single message. Merging would erase turn boundaries from
+	// the transcript sent to the model.
 	out := make([]fantasy.Message, 0, len(messages))
 	for i, msg := range messages {
 		if drop[i] {
 			continue
 		}
-		out = appendSanitizedMessage(out, msg)
+		out = append(out, msg)
 	}
 	return out, stats
 }
 
 // isReasoningOnlyAssistantMessage reports whether an assistant message
-// has at least one reasoning part and no other part type that the
-// OpenAI Responses API treats as visible model content (text,
-// tool_call, tool_result, file).
+// has at least one reasoning part and every other part is also
+// reasoning. Any non-reasoning part (text, tool call, tool result,
+// file, or unknown type added in a future fantasy release) makes the
+// message NOT reasoning-only so the sanitizer leaves it alone.
 func isReasoningOnlyAssistantMessage(msg fantasy.Message) bool {
 	if msg.Role != fantasy.MessageRoleAssistant || len(msg.Content) == 0 {
 		return false
 	}
 	hasReasoning := false
 	for _, part := range msg.Content {
-		switch part.(type) {
-		case fantasy.ReasoningPart:
+		// AsMessagePart normalizes value and pointer variants, so
+		// *fantasy.ReasoningPart matches too. Fall through to
+		// 'return false' on every non-reasoning part, including any
+		// type added later that this code does not enumerate.
+		if _, ok := fantasy.AsMessagePart[fantasy.ReasoningPart](part); ok {
 			hasReasoning = true
-		case fantasy.TextPart,
-			fantasy.ToolCallPart,
-			fantasy.ToolResultPart,
-			fantasy.FilePart:
-			return false
+			continue
 		}
+		return false
 	}
 	return hasReasoning
 }

--- a/coderd/x/chatd/chatprompt/chatprompt_test.go
+++ b/coderd/x/chatd/chatprompt/chatprompt_test.go
@@ -298,6 +298,159 @@ func TestSanitizeAnthropicProviderToolCalls(t *testing.T) {
 	}
 }
 
+func TestSanitizeOpenAIOrphanToolMessages(t *testing.T) {
+	t.Parallel()
+
+	reasoningPart := fantasy.ReasoningPart{Text: "thinking..."}
+	textPart := fantasy.TextPart{Text: "Here is the answer."}
+	toolCall := fantasy.ToolCallPart{
+		ToolCallID: "call_001",
+		ToolName:   "add",
+		Input:      `{"a":1}`,
+	}
+	toolResult := fantasy.ToolResultPart{
+		ToolCallID: "call_001",
+		Output:     fantasy.ToolResultOutputContentText{Text: "2"},
+	}
+
+	assistantReasoningOnly := fantasy.Message{
+		Role:    fantasy.MessageRoleAssistant,
+		Content: []fantasy.MessagePart{reasoningPart},
+	}
+	assistantWithText := fantasy.Message{
+		Role:    fantasy.MessageRoleAssistant,
+		Content: []fantasy.MessagePart{reasoningPart, textPart},
+	}
+	assistantWithToolCall := fantasy.Message{
+		Role:    fantasy.MessageRoleAssistant,
+		Content: []fantasy.MessagePart{reasoningPart, toolCall},
+	}
+	toolMessage := fantasy.Message{
+		Role:    fantasy.MessageRoleTool,
+		Content: []fantasy.MessagePart{toolResult},
+	}
+	userMessage := fantasy.Message{
+		Role:    fantasy.MessageRoleUser,
+		Content: []fantasy.MessagePart{fantasy.TextPart{Text: "hi"}},
+	}
+
+	testCases := []struct {
+		name            string
+		provider        string
+		messages        []fantasy.Message
+		want            []fantasy.Message
+		wantToolDropped int
+		wantAsstDropped int
+	}{
+		{
+			name:     "openai drops orphan tool after reasoning-only assistant",
+			provider: "openai",
+			messages: []fantasy.Message{
+				userMessage,
+				assistantReasoningOnly,
+				toolMessage,
+				userMessage,
+			},
+			want: []fantasy.Message{
+				// Adjacent user messages are merged by
+				// appendSanitizedMessage after the orphan tool and
+				// its reasoning-only assistant are dropped.
+				{
+					Role: fantasy.MessageRoleUser,
+					Content: []fantasy.MessagePart{
+						fantasy.TextPart{Text: "hi"},
+						fantasy.TextPart{Text: "hi"},
+					},
+				},
+			},
+			wantToolDropped: 1,
+			wantAsstDropped: 1,
+		},
+		{
+			name:     "openai keeps tool when assistant has text",
+			provider: "openai",
+			messages: []fantasy.Message{
+				userMessage,
+				assistantWithText,
+				toolMessage,
+				userMessage,
+			},
+			want: []fantasy.Message{
+				userMessage,
+				assistantWithText,
+				toolMessage,
+				userMessage,
+			},
+		},
+		{
+			name:     "openai keeps tool when assistant has tool_call",
+			provider: "openai",
+			messages: []fantasy.Message{
+				userMessage,
+				assistantWithToolCall,
+				toolMessage,
+				userMessage,
+			},
+			want: []fantasy.Message{
+				userMessage,
+				assistantWithToolCall,
+				toolMessage,
+				userMessage,
+			},
+		},
+		{
+			name:     "anthropic provider is a no-op even with orphan shape",
+			provider: "anthropic",
+			messages: []fantasy.Message{
+				userMessage,
+				assistantReasoningOnly,
+				toolMessage,
+				userMessage,
+			},
+			want: []fantasy.Message{
+				userMessage,
+				assistantReasoningOnly,
+				toolMessage,
+				userMessage,
+			},
+		},
+		{
+			name:     "openai with no orphan returns unchanged",
+			provider: "openai",
+			messages: []fantasy.Message{
+				userMessage,
+				assistantWithText,
+				userMessage,
+			},
+			want: []fantasy.Message{
+				userMessage,
+				assistantWithText,
+				userMessage,
+			},
+		},
+		{
+			name:     "openai empty input returns unchanged",
+			provider: "openai",
+			messages: nil,
+			want:     nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			sanitized, stats := chatprompt.SanitizeOpenAIOrphanToolMessages(
+				tc.provider,
+				tc.messages,
+			)
+			require.Equal(t, tc.wantToolDropped, stats.DroppedToolMessages)
+			require.Equal(t, tc.wantAsstDropped, stats.DroppedAssistantMessages)
+			require.Equal(t, tc.want, sanitized)
+		})
+	}
+}
+
 func TestConvertMessagesWithFiles_NormalizesAssistantToolCallInput(t *testing.T) {
 	t.Parallel()
 

--- a/coderd/x/chatd/chatprompt/chatprompt_test.go
+++ b/coderd/x/chatd/chatprompt/chatprompt_test.go
@@ -10,7 +10,9 @@ import (
 
 	"charm.land/fantasy"
 	fantasyanthropic "charm.land/fantasy/providers/anthropic"
+	fantasyazure "charm.land/fantasy/providers/azure"
 	fantasyopenai "charm.land/fantasy/providers/openai"
+	fantasyopenaicompat "charm.land/fantasy/providers/openaicompat"
 	"github.com/google/uuid"
 	"github.com/sqlc-dev/pqtype"
 	"github.com/stretchr/testify/assert"
@@ -410,6 +412,42 @@ func TestSanitizeOpenAIOrphanToolMessages(t *testing.T) {
 				toolMessage,
 				userMessage,
 			},
+		},
+		{
+			// Azure OpenAI uses the same fantasy openai code path,
+			// so it must hit the sanitizer too.
+			name:     "azure provider drops orphan tool after reasoning-only assistant",
+			provider: fantasyazure.Name,
+			messages: []fantasy.Message{
+				userMessage,
+				assistantReasoningOnly,
+				toolMessage,
+				userMessage,
+			},
+			want: []fantasy.Message{
+				userMessage,
+				userMessage,
+			},
+			wantToolDropped:      1,
+			wantAssistantDropped: 1,
+		},
+		{
+			// openai-compat backends that opt into WithUseResponsesAPI
+			// also need the sanitizer.
+			name:     "openai-compat provider drops orphan tool after reasoning-only assistant",
+			provider: fantasyopenaicompat.Name,
+			messages: []fantasy.Message{
+				userMessage,
+				assistantReasoningOnly,
+				toolMessage,
+				userMessage,
+			},
+			want: []fantasy.Message{
+				userMessage,
+				userMessage,
+			},
+			wantToolDropped:      1,
+			wantAssistantDropped: 1,
 		},
 		{
 			name:     "openai with no orphan returns unchanged",

--- a/coderd/x/chatd/chatprompt/chatprompt_test.go
+++ b/coderd/x/chatd/chatprompt/chatprompt_test.go
@@ -10,6 +10,7 @@ import (
 
 	"charm.land/fantasy"
 	fantasyanthropic "charm.land/fantasy/providers/anthropic"
+	fantasyopenai "charm.land/fantasy/providers/openai"
 	"github.com/google/uuid"
 	"github.com/sqlc-dev/pqtype"
 	"github.com/stretchr/testify/assert"
@@ -335,16 +336,16 @@ func TestSanitizeOpenAIOrphanToolMessages(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name            string
-		provider        string
-		messages        []fantasy.Message
-		want            []fantasy.Message
-		wantToolDropped int
-		wantAsstDropped int
+		name                 string
+		provider             string
+		messages             []fantasy.Message
+		want                 []fantasy.Message
+		wantToolDropped      int
+		wantAssistantDropped int
 	}{
 		{
 			name:     "openai drops orphan tool after reasoning-only assistant",
-			provider: "openai",
+			provider: fantasyopenai.Name,
 			messages: []fantasy.Message{
 				userMessage,
 				assistantReasoningOnly,
@@ -352,23 +353,19 @@ func TestSanitizeOpenAIOrphanToolMessages(t *testing.T) {
 				userMessage,
 			},
 			want: []fantasy.Message{
-				// Adjacent user messages are merged by
-				// appendSanitizedMessage after the orphan tool and
-				// its reasoning-only assistant are dropped.
-				{
-					Role: fantasy.MessageRoleUser,
-					Content: []fantasy.MessagePart{
-						fantasy.TextPart{Text: "hi"},
-						fantasy.TextPart{Text: "hi"},
-					},
-				},
+				// Turn boundaries between the two user messages are
+				// preserved (plain append, no same-role coalescing)
+				// after the reasoning-only assistant + its orphan
+				// tool message are dropped.
+				userMessage,
+				userMessage,
 			},
-			wantToolDropped: 1,
-			wantAsstDropped: 1,
+			wantToolDropped:      1,
+			wantAssistantDropped: 1,
 		},
 		{
 			name:     "openai keeps tool when assistant has text",
-			provider: "openai",
+			provider: fantasyopenai.Name,
 			messages: []fantasy.Message{
 				userMessage,
 				assistantWithText,
@@ -384,7 +381,7 @@ func TestSanitizeOpenAIOrphanToolMessages(t *testing.T) {
 		},
 		{
 			name:     "openai keeps tool when assistant has tool_call",
-			provider: "openai",
+			provider: fantasyopenai.Name,
 			messages: []fantasy.Message{
 				userMessage,
 				assistantWithToolCall,
@@ -400,7 +397,7 @@ func TestSanitizeOpenAIOrphanToolMessages(t *testing.T) {
 		},
 		{
 			name:     "anthropic provider is a no-op even with orphan shape",
-			provider: "anthropic",
+			provider: fantasyanthropic.Name,
 			messages: []fantasy.Message{
 				userMessage,
 				assistantReasoningOnly,
@@ -416,7 +413,7 @@ func TestSanitizeOpenAIOrphanToolMessages(t *testing.T) {
 		},
 		{
 			name:     "openai with no orphan returns unchanged",
-			provider: "openai",
+			provider: fantasyopenai.Name,
 			messages: []fantasy.Message{
 				userMessage,
 				assistantWithText,
@@ -430,9 +427,76 @@ func TestSanitizeOpenAIOrphanToolMessages(t *testing.T) {
 		},
 		{
 			name:     "openai empty input returns unchanged",
-			provider: "openai",
+			provider: fantasyopenai.Name,
 			messages: nil,
 			want:     nil,
+		},
+		{
+			// An assistant with empty content (e.g. a metadata-only
+			// stream that produced no parts) is NOT reasoning-only.
+			// The tool message after it must be left intact so the
+			// sanitizer cannot eat a legitimate tool result if the
+			// upstream stream produced an empty assistant message.
+			name:     "openai empty assistant before tool is left intact",
+			provider: fantasyopenai.Name,
+			messages: []fantasy.Message{
+				userMessage,
+				{Role: fantasy.MessageRoleAssistant, Content: nil},
+				toolMessage,
+				userMessage,
+			},
+			want: []fantasy.Message{
+				userMessage,
+				{Role: fantasy.MessageRoleAssistant, Content: nil},
+				toolMessage,
+				userMessage,
+			},
+		},
+		{
+			// Pointer-typed parts must be classified the same way as
+			// value-typed parts. Without fantasy.AsMessagePart the
+			// helper would silently treat a *ReasoningPart as 'not
+			// reasoning' and skip the drop.
+			name:     "openai pointer reasoning part is treated as reasoning",
+			provider: fantasyopenai.Name,
+			messages: []fantasy.Message{
+				userMessage,
+				{
+					Role: fantasy.MessageRoleAssistant,
+					Content: []fantasy.MessagePart{
+						&fantasy.ReasoningPart{Text: "thinking..."},
+					},
+				},
+				toolMessage,
+				userMessage,
+			},
+			want: []fantasy.Message{
+				userMessage,
+				userMessage,
+			},
+			wantToolDropped:      1,
+			wantAssistantDropped: 1,
+		},
+		{
+			// Multiple contiguous tool messages after a reasoning-
+			// only assistant must ALL be dropped, not just the
+			// immediate neighbor. Otherwise a later orphan tool
+			// message survives to OpenAI as 'No tool output found'.
+			name:     "openai drops contiguous tool run after reasoning-only assistant",
+			provider: fantasyopenai.Name,
+			messages: []fantasy.Message{
+				userMessage,
+				assistantReasoningOnly,
+				toolMessage,
+				toolMessage,
+				userMessage,
+			},
+			want: []fantasy.Message{
+				userMessage,
+				userMessage,
+			},
+			wantToolDropped:      2,
+			wantAssistantDropped: 1,
 		},
 	}
 
@@ -445,7 +509,7 @@ func TestSanitizeOpenAIOrphanToolMessages(t *testing.T) {
 				tc.messages,
 			)
 			require.Equal(t, tc.wantToolDropped, stats.DroppedToolMessages)
-			require.Equal(t, tc.wantAsstDropped, stats.DroppedAssistantMessages)
+			require.Equal(t, tc.wantAssistantDropped, stats.DroppedAssistantMessages)
 			require.Equal(t, tc.want, sanitized)
 		})
 	}

--- a/coderd/x/chatd/chattest/openai.go
+++ b/coderd/x/chatd/chattest/openai.go
@@ -51,6 +51,7 @@ type OpenAIRequest struct {
 	Stream             bool            `json:"stream,omitempty"`
 	Tools              []OpenAITool    `json:"tools,omitempty"`
 	Prompt             []interface{}   `json:"prompt,omitempty"` // For responses API
+	Input              []interface{}   `json:"input,omitempty"`  // For responses API
 	Store              *bool           `json:"store,omitempty"`
 	PreviousResponseID *string         `json:"previous_response_id,omitempty"`
 	// TODO: encoding/json ignores inline tags. Add custom UnmarshalJSON to capture unknown keys.

--- a/coderd/x/chatd/chattest/openai_responses_validation.go
+++ b/coderd/x/chatd/chattest/openai_responses_validation.go
@@ -94,6 +94,10 @@ func ValidateResponsesAPIInput(items []interface{}) *ErrorResponse {
 	return nil
 }
 
+// responsesInputKind tags items in the Responses API `input` array.
+// Message is a known kind but not enforced by the validator; it is
+// returned only so a future validation rule can reject malformed
+// messages without changing the classifier.
 type responsesInputKind int
 
 const (

--- a/coderd/x/chatd/chattest/openai_responses_validation.go
+++ b/coderd/x/chatd/chattest/openai_responses_validation.go
@@ -1,0 +1,149 @@
+package chattest
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// ValidateResponsesAPIInput inspects the Responses API `input` array and
+// returns a non-nil ErrorResponse mimicking the live OpenAI validation
+// rules that chatd needs to satisfy:
+//
+//  1. Any `item_reference` to a `web_search_call` (ID prefix `ws_`) MUST
+//     be immediately preceded by an `item_reference` to a `reasoning`
+//     item (ID prefix `rs_`). Live OpenAI rejects the request with:
+//     "Item 'ws_xxx' of type 'web_search_call' was provided without
+//     its required 'reasoning' item: 'rs_xxx'."
+//  2. Any `function_call` MUST be followed by a `function_call_output`
+//     with a matching `call_id`. Live OpenAI rejects with:
+//     "No tool output found for function call call_xxx."
+//
+// Item-reference shape is detected leniently. fantasy currently emits
+// item_reference entries with only an "id" field (the type field is
+// `omitzero` in the openai-go SDK), so the validator falls back to
+// treating any otherwise-bare item with a known ID prefix as a
+// reference of the inferred kind.
+//
+// Returns nil when the input passes validation. Mirrors the OpenAI
+// 400 error envelope. Caller decides whether to return the error.
+func ValidateResponsesAPIInput(items []interface{}) *ErrorResponse {
+	prevReasoningID := ""
+	functionCalls := make(map[string]bool)   // call_id -> seen function_call
+	functionOutputs := make(map[string]bool) // call_id -> seen function_call_output
+
+	for _, raw := range items {
+		item, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		switch classifyResponsesInputItem(item) {
+		case responsesInputKindItemReference:
+			id, _ := item["id"].(string)
+			switch {
+			case strings.HasPrefix(id, "ws_"):
+				if !strings.HasPrefix(prevReasoningID, "rs_") {
+					return &ErrorResponse{
+						StatusCode: http.StatusBadRequest,
+						Type:       "invalid_request_error",
+						Message: fmt.Sprintf(
+							"Item '%s' of type 'web_search_call' was "+
+								"provided without its required 'reasoning' "+
+								"item: 'rs_*'.",
+							id),
+					}
+				}
+				prevReasoningID = ""
+			case strings.HasPrefix(id, "rs_"):
+				prevReasoningID = id
+			default:
+				prevReasoningID = ""
+			}
+		case responsesInputKindFunctionCall:
+			callID, _ := item["call_id"].(string)
+			if callID == "" {
+				callID, _ = item["id"].(string)
+			}
+			if callID != "" {
+				functionCalls[callID] = true
+			}
+			prevReasoningID = ""
+		case responsesInputKindFunctionCallOutput:
+			callID, _ := item["call_id"].(string)
+			if callID != "" {
+				functionOutputs[callID] = true
+			}
+			prevReasoningID = ""
+		default:
+			prevReasoningID = ""
+		}
+	}
+
+	for callID := range functionCalls {
+		if !functionOutputs[callID] {
+			return &ErrorResponse{
+				StatusCode: http.StatusBadRequest,
+				Type:       "invalid_request_error",
+				Message: fmt.Sprintf(
+					"No tool output found for function call %s.", callID),
+			}
+		}
+	}
+
+	return nil
+}
+
+type responsesInputKind int
+
+const (
+	responsesInputKindUnknown responsesInputKind = iota
+	responsesInputKindMessage
+	responsesInputKindItemReference
+	responsesInputKindFunctionCall
+	responsesInputKindFunctionCallOutput
+)
+
+// classifyResponsesInputItem identifies the kind of Responses API input
+// item from its JSON shape. It first honors an explicit "type" field,
+// then falls back to shape-based heuristics for the openai-go SDK's
+// item_reference shape (only "id" set).
+func classifyResponsesInputItem(item map[string]interface{}) responsesInputKind {
+	if t, ok := item["type"].(string); ok && t != "" {
+		switch t {
+		case "item_reference":
+			return responsesInputKindItemReference
+		case "function_call":
+			return responsesInputKindFunctionCall
+		case "function_call_output":
+			return responsesInputKindFunctionCallOutput
+		case "message":
+			return responsesInputKindMessage
+		default:
+			return responsesInputKindUnknown
+		}
+	}
+	// Implicit message: EasyInputMessage shape with role and content.
+	if _, ok := item["role"]; ok {
+		return responsesInputKindMessage
+	}
+	// Implicit function_call_output: has call_id + output but no role.
+	if _, ok := item["call_id"]; ok {
+		if _, hasOutput := item["output"]; hasOutput {
+			return responsesInputKindFunctionCallOutput
+		}
+		return responsesInputKindFunctionCall
+	}
+	// Implicit item_reference: bare {id} (the openai-go SDK omits the
+	// type field as it is `omitzero`). Only treat as reference if the
+	// ID looks like an OpenAI item ID.
+	if id, ok := item["id"].(string); ok && id != "" {
+		if strings.HasPrefix(id, "ws_") ||
+			strings.HasPrefix(id, "rs_") ||
+			strings.HasPrefix(id, "msg_") ||
+			strings.HasPrefix(id, "fc_") {
+			return responsesInputKindItemReference
+		}
+	}
+	return responsesInputKindUnknown
+}

--- a/coderd/x/chatd/chattest/openai_responses_validation_test.go
+++ b/coderd/x/chatd/chattest/openai_responses_validation_test.go
@@ -12,7 +12,7 @@ import (
 func TestValidateResponsesAPIInput_Pass(t *testing.T) {
 	t.Parallel()
 
-	cases := []struct {
+	testCases := []struct {
 		name  string
 		items []interface{}
 	}{
@@ -74,7 +74,7 @@ func TestValidateResponsesAPIInput_Pass(t *testing.T) {
 		},
 	}
 
-	for _, tc := range cases {
+	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			require.Nil(t, chattest.ValidateResponsesAPIInput(tc.items))

--- a/coderd/x/chatd/chattest/openai_responses_validation_test.go
+++ b/coderd/x/chatd/chattest/openai_responses_validation_test.go
@@ -1,0 +1,153 @@
+package chattest_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/x/chatd/chattest"
+)
+
+func TestValidateResponsesAPIInput_Pass(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		items []interface{}
+	}{
+		{
+			name:  "empty",
+			items: nil,
+		},
+		{
+			name: "user only",
+			items: []interface{}{
+				map[string]interface{}{"type": "message", "role": "user"},
+			},
+		},
+		{
+			name: "reasoning then web_search reference",
+			items: []interface{}{
+				map[string]interface{}{"type": "message", "role": "user"},
+				map[string]interface{}{"type": "item_reference", "id": "rs_001"},
+				map[string]interface{}{"type": "item_reference", "id": "ws_001"},
+				map[string]interface{}{"type": "message", "role": "assistant"},
+			},
+		},
+		{
+			name: "function_call paired with function_call_output",
+			items: []interface{}{
+				map[string]interface{}{"type": "message", "role": "user"},
+				map[string]interface{}{
+					"type":      "function_call",
+					"call_id":   "call_001",
+					"name":      "add",
+					"arguments": `{"a":1}`,
+				},
+				map[string]interface{}{
+					"type":    "function_call_output",
+					"call_id": "call_001",
+					"output":  "2",
+				},
+			},
+		},
+		{
+			name: "reasoning reference standalone is allowed",
+			items: []interface{}{
+				map[string]interface{}{"type": "item_reference", "id": "rs_001"},
+				map[string]interface{}{"type": "message", "role": "assistant"},
+			},
+		},
+		{
+			// Fantasy emits item_reference entries with only "id"
+			// set because the openai-go SDK marks the type field
+			// as `omitzero`. The validator must still detect the
+			// pairing rule based on the bare-{id} shape.
+			name: "implicit item_reference shape (no type field)",
+			items: []interface{}{
+				map[string]interface{}{"role": "user", "content": "hi"},
+				map[string]interface{}{"id": "rs_001"},
+				map[string]interface{}{"id": "ws_001"},
+				map[string]interface{}{"role": "user", "content": "more"},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Nil(t, chattest.ValidateResponsesAPIInput(tc.items))
+		})
+	}
+}
+
+func TestValidateResponsesAPIInput_RejectsWebSearchWithoutReasoning(t *testing.T) {
+	t.Parallel()
+
+	items := []interface{}{
+		map[string]interface{}{"type": "message", "role": "user"},
+		map[string]interface{}{"type": "item_reference", "id": "ws_001"},
+		map[string]interface{}{"type": "message", "role": "assistant"},
+	}
+
+	err := chattest.ValidateResponsesAPIInput(items)
+	require.NotNil(t, err)
+	require.Equal(t, http.StatusBadRequest, err.StatusCode)
+	require.Contains(t, err.Message, "ws_001")
+	require.Contains(t, err.Message, "web_search_call")
+	require.Contains(t, err.Message, "reasoning")
+}
+
+func TestValidateResponsesAPIInput_RejectsImplicitWebSearchWithoutReasoning(t *testing.T) {
+	t.Parallel()
+
+	// Bare-{id} shape (no "type" field). Validator must still
+	// detect the orphan web_search_call.
+	items := []interface{}{
+		map[string]interface{}{"role": "user", "content": "hi"},
+		map[string]interface{}{"id": "ws_001"},
+		map[string]interface{}{"role": "user", "content": "more"},
+	}
+
+	err := chattest.ValidateResponsesAPIInput(items)
+	require.NotNil(t, err)
+	require.Equal(t, http.StatusBadRequest, err.StatusCode)
+	require.Contains(t, err.Message, "ws_001")
+}
+
+func TestValidateResponsesAPIInput_RejectsWebSearchAfterUnrelatedItem(t *testing.T) {
+	t.Parallel()
+
+	// reasoning preceded the web_search but a message intervenes.
+	items := []interface{}{
+		map[string]interface{}{"type": "item_reference", "id": "rs_001"},
+		map[string]interface{}{"type": "message", "role": "user"},
+		map[string]interface{}{"type": "item_reference", "id": "ws_001"},
+	}
+
+	err := chattest.ValidateResponsesAPIInput(items)
+	require.NotNil(t, err)
+	require.Equal(t, http.StatusBadRequest, err.StatusCode)
+}
+
+func TestValidateResponsesAPIInput_RejectsFunctionCallWithoutOutput(t *testing.T) {
+	t.Parallel()
+
+	items := []interface{}{
+		map[string]interface{}{"type": "message", "role": "user"},
+		map[string]interface{}{
+			"type":      "function_call",
+			"call_id":   "call_xyz",
+			"name":      "add",
+			"arguments": "{}",
+		},
+		map[string]interface{}{"type": "message", "role": "user"},
+	}
+
+	err := chattest.ValidateResponsesAPIInput(items)
+	require.NotNil(t, err)
+	require.Equal(t, http.StatusBadRequest, err.StatusCode)
+	require.Contains(t, err.Message, "call_xyz")
+	require.Contains(t, err.Message, "No tool output found")
+}

--- a/coderd/x/chatd/openai_reasoning_websearch_replay_test.go
+++ b/coderd/x/chatd/openai_reasoning_websearch_replay_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/util/ptr"
@@ -26,7 +27,7 @@ import (
 //	required 'reasoning' item: 'rs_xxx'.
 //
 // To force the replay path (rather than chain mode, which short-circuits
-// it via previous_response_id), turn 2 is dispatched against a different
+// it via previous_response_id), step 2 is dispatched against a different
 // model_config_id. chatd then sends the full prior history to the
 // provider and the fake server's ValidateResponsesAPIInput enforces the
 // same pairing rule as live OpenAI.
@@ -54,6 +55,7 @@ func runOpenAIReasoningWithWebSearchRoundTripTest(t *testing.T, store bool) {
 		mu                sync.Mutex
 		streamRequests    atomic.Int32
 		validationFailure error
+		step2InputItems   []interface{}
 	)
 	openAIURL := chattest.NewOpenAI(t, func(req *chattest.OpenAIRequest) chattest.OpenAIResponse {
 		if !req.Stream {
@@ -65,7 +67,7 @@ func runOpenAIReasoningWithWebSearchRoundTripTest(t *testing.T, store bool) {
 		if errResp := chattest.ValidateResponsesAPIInput(req.Input); errResp != nil {
 			mu.Lock()
 			if validationFailure == nil {
-				validationFailure = &openAIValidationError{message: errResp.Message}
+				validationFailure = xerrors.New(errResp.Message)
 			}
 			mu.Unlock()
 			return chattest.OpenAIResponse{Error: errResp}
@@ -73,7 +75,7 @@ func runOpenAIReasoningWithWebSearchRoundTripTest(t *testing.T, store bool) {
 
 		switch streamRequests.Add(1) {
 		case 1:
-			// Turn 1: emit reasoning + web_search_call + text.
+			// Step 1: emit reasoning + web_search_call + text.
 			return chattest.OpenAIResponse{
 				StreamingChunks: chattest.OpenAIStreamingResponse(
 					chattest.OpenAITextChunks("Here is what I found.")...,
@@ -87,7 +89,12 @@ func runOpenAIReasoningWithWebSearchRoundTripTest(t *testing.T, store bool) {
 				},
 			}
 		default:
-			// Turn 2: text-only response.
+			// Step 2: capture the input items so the test can
+			// assert that chain mode was actually disabled and
+			// fantasy replayed full history. Then emit text only.
+			mu.Lock()
+			step2InputItems = req.Input
+			mu.Unlock()
 			return chattest.OpenAIStreamingResponse(
 				chattest.OpenAITextChunks("Follow-up answer.")...,
 			)
@@ -111,24 +118,21 @@ func runOpenAIReasoningWithWebSearchRoundTripTest(t *testing.T, store bool) {
 
 	// gpt-5.5 is in fantasy's responsesReasoningModelIDs and routes
 	// through the Responses API. Two model configs are created so
-	// turn 2 can be sent against a different model_config_id, which
+	// step 2 can be sent against a different model_config_id, which
 	// disables chain mode and forces the full-history replay path
 	// where the reasoning + web_search pairing bug surfaces.
 	contextLimit := int64(200000)
-	isDefault := true
-	notDefault := false
-	reasoningSummary := "auto"
 	openAIOptions := &codersdk.ChatModelOpenAIProviderOptions{
 		Store:            ptr.Ref(store),
-		ReasoningSummary: &reasoningSummary,
+		ReasoningSummary: ptr.Ref("auto"),
 		WebSearchEnabled: ptr.Ref(true),
 	}
 	configA, err := expClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
 		Provider:     "openai",
 		Model:        "gpt-5.5",
-		DisplayName:  "gpt-5.5 (turn 1)",
+		DisplayName:  "gpt-5.5 (step 1)",
 		ContextLimit: &contextLimit,
-		IsDefault:    &isDefault,
+		IsDefault:    ptr.Ref(true),
 		ModelConfig: &codersdk.ChatModelCallConfig{
 			ProviderOptions: &codersdk.ChatModelProviderOptions{
 				OpenAI: openAIOptions,
@@ -139,9 +143,9 @@ func runOpenAIReasoningWithWebSearchRoundTripTest(t *testing.T, store bool) {
 	configB, err := expClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
 		Provider:     "openai",
 		Model:        "gpt-5.5",
-		DisplayName:  "gpt-5.5 (turn 2)",
+		DisplayName:  "gpt-5.5 (step 2)",
 		ContextLimit: &contextLimit,
-		IsDefault:    &notDefault,
+		IsDefault:    ptr.Ref(false),
 		ModelConfig: &codersdk.ChatModelCallConfig{
 			ProviderOptions: &codersdk.ChatModelProviderOptions{
 				OpenAI: openAIOptions,
@@ -151,8 +155,10 @@ func runOpenAIReasoningWithWebSearchRoundTripTest(t *testing.T, store bool) {
 	require.NoError(t, err)
 	require.NotEqual(t, configA.ID, configB.ID,
 		"two distinct model configs are required to disable chain mode")
+	require.NotEqual(t, configA.ID, configB.ID,
+		"two distinct model configs are required to disable chain mode")
 
-	// --- Turn 1: produce reasoning + web_search_call + text ---
+	// --- Step 1: produce reasoning + web_search_call + text ---
 	chat, err := expClient.CreateChat(ctx, codersdk.CreateChatRequest{
 		OrganizationID: user.OrganizationID,
 		ModelConfigID:  &configA.ID,
@@ -180,22 +186,22 @@ func runOpenAIReasoningWithWebSearchRoundTripTest(t *testing.T, store bool) {
 	require.NoError(t, err)
 	logMessages(t, chatMsgs.Messages)
 
-	// Turn 1's assistant message should contain reasoning,
+	// Step 1's assistant message should contain reasoning,
 	// tool-call, tool-result, and text parts.
 	assistantMsg := findAssistantWithText(t, chatMsgs.Messages)
 	require.NotNil(t, assistantMsg,
 		"expected an assistant message with text after step 1")
-	parts := partTypeSet(assistantMsg.Content)
-	require.Contains(t, parts, codersdk.ChatMessagePartTypeReasoning,
+	partTypes := partTypeSet(assistantMsg.Content)
+	require.Contains(t, partTypes, codersdk.ChatMessagePartTypeReasoning,
 		"assistant should contain reasoning parts")
-	require.Contains(t, parts, codersdk.ChatMessagePartTypeToolCall,
+	require.Contains(t, partTypes, codersdk.ChatMessagePartTypeToolCall,
 		"assistant should contain a web_search tool call")
-	require.Contains(t, parts, codersdk.ChatMessagePartTypeToolResult,
+	require.Contains(t, partTypes, codersdk.ChatMessagePartTypeToolResult,
 		"assistant should contain a web_search tool result")
-	require.Contains(t, parts, codersdk.ChatMessagePartTypeText,
+	require.Contains(t, partTypes, codersdk.ChatMessagePartTypeText,
 		"assistant should contain a text part")
 
-	// --- Turn 2: send a follow-up against configB so chain mode is
+	// --- Step 2: send a follow-up against configB so chain mode is
 	// disabled and chatd sends full history. Replay must satisfy
 	// OpenAI's pairing rules; otherwise the fake server returns 400
 	// and the chat lands in an Error state. ---
@@ -242,16 +248,22 @@ func runOpenAIReasoningWithWebSearchRoundTripTest(t *testing.T, store bool) {
 		"expected an assistant message with text after step 2")
 
 	// We expect exactly two streamed Responses API calls (one per
-	// turn). Anything else suggests the chatd retry path masked a
+	// step). Anything else suggests the chatd retry path masked a
 	// validation failure.
 	require.Equal(t, int32(2), streamRequests.Load(),
 		"expected exactly two streamed OpenAI responses")
-}
 
-type openAIValidationError struct {
-	message string
-}
-
-func (e *openAIValidationError) Error() string {
-	return e.message
+	// Confirm the test actually exercised the full-history replay
+	// path the bug surfaces on. Chain mode would have stripped the
+	// prior assistant turn and sent only system + new user input,
+	// hiding the reasoning + web_search_call pairing the fantasy
+	// fix targets. The presence of any historical item in step 2's
+	// input proves chain mode was disabled.
+	mu.Lock()
+	haveStep2 := step2InputItems
+	mu.Unlock()
+	require.NotEmpty(t, haveStep2, "step 2 must have captured input items")
+	require.Greater(t, len(haveStep2), 3,
+		"step 2 input should include the historical assistant turn,"+
+			" not just system + new user message; chain mode was not disabled")
 }

--- a/coderd/x/chatd/openai_reasoning_websearch_replay_test.go
+++ b/coderd/x/chatd/openai_reasoning_websearch_replay_test.go
@@ -1,0 +1,257 @@
+package chatd_test
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/coderd/util/ptr"
+	"github.com/coder/coder/v2/coderd/x/chatd/chattest"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/testutil"
+)
+
+// TestOpenAIReasoningWithWebSearchRoundTrip verifies that an OpenAI
+// Responses API turn that produces both a reasoning item and a
+// provider-executed web_search_call survives the persist, reload, and
+// replay cycle when Store is true and chain mode is not active.
+//
+// Live OpenAI rejects a follow-up turn that replays a web_search_call
+// (via item_reference) without its preceding reasoning item:
+//
+//	Item 'ws_xxx' of type 'web_search_call' was provided without its
+//	required 'reasoning' item: 'rs_xxx'.
+//
+// To force the replay path (rather than chain mode, which short-circuits
+// it via previous_response_id), turn 2 is dispatched against a different
+// model_config_id. chatd then sends the full prior history to the
+// provider and the fake server's ValidateResponsesAPIInput enforces the
+// same pairing rule as live OpenAI.
+func TestOpenAIReasoningWithWebSearchRoundTrip(t *testing.T) {
+	t.Parallel()
+	runOpenAIReasoningWithWebSearchRoundTripTest(t, true)
+}
+
+// TestOpenAIReasoningWithWebSearchRoundTripStoreFalse verifies the same
+// flow with Store=false, where reasoning items must NOT be replayed
+// (the IDs are ephemeral). This guards against accidentally emitting an
+// item_reference for an unstored reasoning item, which would produce
+// "Item not found" on real OpenAI.
+func TestOpenAIReasoningWithWebSearchRoundTripStoreFalse(t *testing.T) {
+	t.Parallel()
+	runOpenAIReasoningWithWebSearchRoundTripTest(t, false)
+}
+
+func runOpenAIReasoningWithWebSearchRoundTripTest(t *testing.T, store bool) {
+	t.Helper()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+
+	var (
+		mu                sync.Mutex
+		streamRequests    atomic.Int32
+		validationFailure error
+	)
+	openAIURL := chattest.NewOpenAI(t, func(req *chattest.OpenAIRequest) chattest.OpenAIResponse {
+		if !req.Stream {
+			return chattest.OpenAINonStreamingResponse(`{"title":"Reasoning + web search"}`)
+		}
+
+		// Validate the request input to mimic the live OpenAI 400.
+		// Any orphan web_search_call or function_call surfaces here.
+		if errResp := chattest.ValidateResponsesAPIInput(req.Input); errResp != nil {
+			mu.Lock()
+			if validationFailure == nil {
+				validationFailure = &openAIValidationError{message: errResp.Message}
+			}
+			mu.Unlock()
+			return chattest.OpenAIResponse{Error: errResp}
+		}
+
+		switch streamRequests.Add(1) {
+		case 1:
+			// Turn 1: emit reasoning + web_search_call + text.
+			return chattest.OpenAIResponse{
+				StreamingChunks: chattest.OpenAIStreamingResponse(
+					chattest.OpenAITextChunks("Here is what I found.")...,
+				).StreamingChunks,
+				Reasoning: &chattest.OpenAIReasoningItem{
+					Summary:          "thinking about the question",
+					EncryptedContent: "encrypted_data_here",
+				},
+				WebSearch: &chattest.OpenAIWebSearchCall{
+					Query: "latest AI news",
+				},
+			}
+		default:
+			// Turn 2: text-only response.
+			return chattest.OpenAIStreamingResponse(
+				chattest.OpenAITextChunks("Follow-up answer.")...,
+			)
+		}
+	})
+
+	deploymentValues := coderdtest.DeploymentValues(t)
+	deploymentValues.Experiments = []string{string(codersdk.ExperimentAgents)}
+	client := coderdtest.New(t, &coderdtest.Options{
+		DeploymentValues: deploymentValues,
+	})
+	user := coderdtest.CreateFirstUser(t, client)
+	expClient := codersdk.NewExperimentalClient(client)
+
+	_, err := expClient.CreateChatProvider(ctx, codersdk.CreateChatProviderConfigRequest{
+		Provider: "openai",
+		APIKey:   "test-api-key",
+		BaseURL:  openAIURL,
+	})
+	require.NoError(t, err)
+
+	// gpt-5.5 is in fantasy's responsesReasoningModelIDs and routes
+	// through the Responses API. Two model configs are created so
+	// turn 2 can be sent against a different model_config_id, which
+	// disables chain mode and forces the full-history replay path
+	// where the reasoning + web_search pairing bug surfaces.
+	contextLimit := int64(200000)
+	isDefault := true
+	notDefault := false
+	reasoningSummary := "auto"
+	openAIOptions := &codersdk.ChatModelOpenAIProviderOptions{
+		Store:            ptr.Ref(store),
+		ReasoningSummary: &reasoningSummary,
+		WebSearchEnabled: ptr.Ref(true),
+	}
+	configA, err := expClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+		Provider:     "openai",
+		Model:        "gpt-5.5",
+		DisplayName:  "gpt-5.5 (turn 1)",
+		ContextLimit: &contextLimit,
+		IsDefault:    &isDefault,
+		ModelConfig: &codersdk.ChatModelCallConfig{
+			ProviderOptions: &codersdk.ChatModelProviderOptions{
+				OpenAI: openAIOptions,
+			},
+		},
+	})
+	require.NoError(t, err)
+	configB, err := expClient.CreateChatModelConfig(ctx, codersdk.CreateChatModelConfigRequest{
+		Provider:     "openai",
+		Model:        "gpt-5.5",
+		DisplayName:  "gpt-5.5 (turn 2)",
+		ContextLimit: &contextLimit,
+		IsDefault:    &notDefault,
+		ModelConfig: &codersdk.ChatModelCallConfig{
+			ProviderOptions: &codersdk.ChatModelProviderOptions{
+				OpenAI: openAIOptions,
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotEqual(t, configA.ID, configB.ID,
+		"two distinct model configs are required to disable chain mode")
+
+	// --- Turn 1: produce reasoning + web_search_call + text ---
+	chat, err := expClient.CreateChat(ctx, codersdk.CreateChatRequest{
+		OrganizationID: user.OrganizationID,
+		ModelConfigID:  &configA.ID,
+		Content: []codersdk.ChatInputPart{
+			{
+				Type: codersdk.ChatInputPartTypeText,
+				Text: "What is the weather in San Francisco?",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	events, closer, err := expClient.StreamChat(ctx, chat.ID, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = closer.Close() })
+
+	waitForChatDone(ctx, t, events, "step 1")
+
+	chatData, err := expClient.GetChat(ctx, chat.ID)
+	require.NoError(t, err)
+	require.Equal(t, codersdk.ChatStatusWaiting, chatData.Status,
+		"chat should be in waiting status after step 1")
+
+	chatMsgs, err := expClient.GetChatMessages(ctx, chat.ID, nil)
+	require.NoError(t, err)
+	logMessages(t, chatMsgs.Messages)
+
+	// Turn 1's assistant message should contain reasoning,
+	// tool-call, tool-result, and text parts.
+	assistantMsg := findAssistantWithText(t, chatMsgs.Messages)
+	require.NotNil(t, assistantMsg,
+		"expected an assistant message with text after step 1")
+	parts := partTypeSet(assistantMsg.Content)
+	require.Contains(t, parts, codersdk.ChatMessagePartTypeReasoning,
+		"assistant should contain reasoning parts")
+	require.Contains(t, parts, codersdk.ChatMessagePartTypeToolCall,
+		"assistant should contain a web_search tool call")
+	require.Contains(t, parts, codersdk.ChatMessagePartTypeToolResult,
+		"assistant should contain a web_search tool result")
+	require.Contains(t, parts, codersdk.ChatMessagePartTypeText,
+		"assistant should contain a text part")
+
+	// --- Turn 2: send a follow-up against configB so chain mode is
+	// disabled and chatd sends full history. Replay must satisfy
+	// OpenAI's pairing rules; otherwise the fake server returns 400
+	// and the chat lands in an Error state. ---
+	_, err = expClient.CreateChatMessage(ctx, chat.ID,
+		codersdk.CreateChatMessageRequest{
+			ModelConfigID: &configB.ID,
+			Content: []codersdk.ChatInputPart{
+				{
+					Type: codersdk.ChatInputPartTypeText,
+					Text: "And Tokyo?",
+				},
+			},
+		})
+	require.NoError(t, err)
+
+	events2, closer2, err := expClient.StreamChat(ctx, chat.ID, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = closer2.Close() })
+
+	waitForChatDone(ctx, t, events2, "step 2")
+
+	chatData2, err := expClient.GetChat(ctx, chat.ID)
+	require.NoError(t, err)
+	chatMsgs2, err := expClient.GetChatMessages(ctx, chat.ID, nil)
+	require.NoError(t, err)
+	logMessages(t, chatMsgs2.Messages)
+
+	// If the replay is wrong, the fake server's validation failed
+	// and chatd surfaced the error; surface a clear assertion.
+	mu.Lock()
+	failure := validationFailure
+	mu.Unlock()
+	if failure != nil {
+		require.Failf(t,
+			"OpenAI Responses API input validation failed during replay",
+			"%s", failure.Error())
+	}
+
+	require.Equal(t, codersdk.ChatStatusWaiting, chatData2.Status,
+		"chat should be in waiting status after step 2")
+	require.Greater(t, len(chatMsgs2.Messages), len(chatMsgs.Messages),
+		"follow-up should have added more messages")
+	require.NotNil(t, findLastAssistantWithText(t, chatMsgs2.Messages),
+		"expected an assistant message with text after step 2")
+
+	// We expect exactly two streamed Responses API calls (one per
+	// turn). Anything else suggests the chatd retry path masked a
+	// validation failure.
+	require.Equal(t, int32(2), streamRequests.Load(),
+		"expected exactly two streamed OpenAI responses")
+}
+
+type openAIValidationError struct {
+	message string
+}
+
+func (e *openAIValidationError) Error() string {
+	return e.message
+}

--- a/go.mod
+++ b/go.mod
@@ -79,12 +79,15 @@ replace github.com/spf13/afero => github.com/aslilac/afero v0.0.0-20250403163713
 // Forked from coder/fantasy (coder_2_33) which adds:
 // 1) Anthropic computer use + thinking effort
 // 2) Go 1.25 downgrade for Windows CI compat
-// 3) ibetitsmike/fantasy#4 — skip ephemeral replay items when store=false
+// 3) ibetitsmike/fantasy#4, skip ephemeral replay items when store=false
 // 4) (anthropic-sdk-go) dannykopping's appendCompact performance fixes
 // 5) (anthropic-sdk-go) DirectEncoder to eliminate nested MarshalJSON allocation chain
 // 6) Anthropic EffortXHigh constant for Claude Opus 4.7
-// See: https://github.com/coder/fantasy/commits/5ab464a305f4
-replace charm.land/fantasy => github.com/coder/fantasy v0.0.0-20260424191546-5ab464a305f4
+// 7) coder/fantasy mike/fix-reasoning-replay-item-reference, emit
+//    item_reference for reasoning items when store=true so reasoning +
+//    web_search_call (and reasoning + function_call) replay correctly.
+// See: https://github.com/coder/fantasy/commits/56076b4533821cf35586eb7b7432576ba9bd9f7f
+replace charm.land/fantasy => github.com/coder/fantasy v0.0.0-20260425012031-56076b453382
 
 // coder/coder uses a fork of charmbracelet's fork of the Anthropic Go SDK with some
 // additional performance improvements.

--- a/go.sum
+++ b/go.sum
@@ -322,8 +322,8 @@ github.com/coder/bubbletea v1.2.2-0.20241212190825-007a1cdb2c41 h1:SBN/DA63+ZHwu
 github.com/coder/bubbletea v1.2.2-0.20241212190825-007a1cdb2c41/go.mod h1:I9ULxr64UaOSUv7hcb3nX4kowodJCVS7vt7VVJk/kW4=
 github.com/coder/clistat v1.2.1 h1:P9/10njXMyj5cWzIU5wkRsSy5LVQH49+tcGMsAgWX0w=
 github.com/coder/clistat v1.2.1/go.mod h1:m7SC0uj88eEERgvF8Kn6+w6XF21BeSr+15f7GoLAw0A=
-github.com/coder/fantasy v0.0.0-20260424191546-5ab464a305f4 h1:eL6f03ujlQiXs24FjAtdyD8TMbRiZtDWj6JdcSlMeUw=
-github.com/coder/fantasy v0.0.0-20260424191546-5ab464a305f4/go.mod h1:wZ0e3lEPqrM0XiIdAUQLvMKCLYhc3gi96MRX2wjbX44=
+github.com/coder/fantasy v0.0.0-20260425012031-56076b453382 h1:MENfeSUTqmbmrg1zyGR/EYnWo7C4yYSbPxkhAw+nLIg=
+github.com/coder/fantasy v0.0.0-20260425012031-56076b453382/go.mod h1:wZ0e3lEPqrM0XiIdAUQLvMKCLYhc3gi96MRX2wjbX44=
 github.com/coder/flog v1.1.0 h1:kbAes1ai8fIS5OeV+QAnKBQE22ty1jRF/mcAwHpLBa4=
 github.com/coder/flog v1.1.0/go.mod h1:UQlQvrkJBvnRGo69Le8E24Tcl5SJleAAR7gYEHzAmdQ=
 github.com/coder/go-httpstat v0.0.0-20230801153223-321c88088322 h1:m0lPZjlQ7vdVpRBPKfYIFlmgevoTkBxB10wv6l2gOaU=


### PR DESCRIPTION
*Disclaimer: opened by a Coder Agent on behalf of @ibetitsmike.*

Fixes the production OpenAI Responses API failure where a follow-up turn after a `reasoning + web_search_call` step is rejected with:

```
Item 'ws_xxx' of type 'web_search_call' was provided without its
required 'reasoning' item: 'rs_xxx'.
```

This trips on `gpt-5.5 xhigh` (and any reasoning model) when web search runs in step 1 and full-history replay (rather than chain mode) is used in step 2.

## Fix

- Bump the `charm.land/fantasy` replace pin to include coder/fantasy#30, which emits an `item_reference` for stored reasoning items so they pair with a following `web_search_call` (or `function_call`) on replay.
- Mirror live OpenAI's pairing rule in the `chattest` fake server via `ValidateResponsesAPIInput`. Cover both the orphan `web_search_call` (primary user-reported error) and orphan `function_call` (secondary failure mode).
- Add `TestOpenAIReasoningWithWebSearchRoundTrip` and the `Store=false` variant. The tests use two model configs to disable chain mode on step 2 and force the full-history replay path where the bug surfaces. Step 2's input is captured and asserted to contain the historical assistant turn so the test fails closed if chain-mode detection ever changes.
- Add a defensive `SanitizeOpenAIOrphanToolMessages` in `chatprompt`. It drops reasoning-only assistant messages together with any contiguous tool-message run that follows. Active for `openai`, `azure`, and `openai-compat` providers (all three route through the same Responses API). It runs at the prompt-build, reload, and chatloop pre-request boundaries to mirror `SanitizeAnthropicProviderToolCalls`.

This change supersedes closed #23402.

## Verification

- Manual red phase: with the unfixed pin, the new integration test fails reproducing the exact production error: `Item 'ws_xxx' of type 'web_search_call' was provided without its required 'reasoning' item: 'rs_*'`.
- Green phase: with the fixed pin, both `Store=true` and `Store=false` follow-up turns complete cleanly.
- `go test ./coderd/x/chatd/...` (full suite, race) passes.
- `make pre-commit` (gen / fmt / lint / build) passes.

<details>
<summary>Implementation plan and decision log</summary>

### Cycle A — coder/fantasy#30 (merged via this PR's pin)

Replaced fantasy's unconditional `continue` for `ContentTypeReasoning` with a `store`-gated `item_reference` emission using `GetReasoningMetadata`. Inline `OfReasoning` replay was intentionally avoided so #181's regression doesn't return.

### Cycle B — chatd integration test

The integration test had to defeat chain mode (which short-circuits replay via `previous_response_id`). Approach taken: create two model configs and dispatch step 2 against the second. `chainInfo.modelConfigID == modelConfig.ID` then fails and chatd sends full history through fantasy, where the bug surfaced. Step 2's input items are captured and asserted to contain the historical turn so the test fails closed if chain-mode detection changes.

`ValidateResponsesAPIInput` detects `item_reference` shape leniently because the openai-go SDK marks the `type` field as `omitzero`, so fantasy serializes references as bare `{id}`. The validator falls back to ID-prefix shape detection (`ws_`, `rs_`, `msg_`, `fc_`).

### Cycle C — defensive sanitizer

Sanitizer drops tool messages that follow reasoning-only assistant messages. It mirrors the Anthropic sanitizer pattern (zero-allocation no-op fast path, structured stats, warn-level log). It activates for `openai`, `azure`, and `openai-compat` providers via `isOpenAIResponsesProvider`. Wired at all three boundaries that currently invoke `SanitizeAnthropicProviderToolCalls`: prompt-build, reload, and chatloop pre-request.

### Decisions

- `item_reference` over inline `OfReasoning`: inline replay re-introduces the failure mode #181 fixed for plain reasoning replay.
- Defensive sanitizer kept despite Cycle A solving the primary failure mode: belt-and-suspenders against the residual `function_call_output` orphan when reasoning is stripped (e.g. missing `ItemID`).
- Two-model-configs test approach over a custom multi-step tool: smaller test surface, no synthetic tool stack, deterministic chain-mode bypass.
- `isReasoningOnlyAssistantMessage` uses `fantasy.AsMessagePart` (handles pointer + value variants) and falls back to `return false` for any unrecognized part type so a future fantasy MessagePart addition cannot silently cause data loss.
- Drop the entire contiguous tool-message run after a reasoning-only assistant, not just the immediate neighbor. Avoids leaving a later orphan tool message that would still trip the same OpenAI 400.
- Use plain `append` (not `appendSanitizedMessage`) so dropping the orphan pair does not collapse the two non-tool messages bracketing the run into one.

</details>

<details>
<summary>Deep-review pass</summary>

A multi-reviewer deep review (Test Auditor, Edge Case Analyst, Contract Auditor, Structural Analyst, Go Architect, Concurrency Reviewer, Performance Analyst, Duplication Checker, Modernization Reviewer, Style Reviewer) ran against the initial commit. All P2 and P3 structural findings were addressed:

- P2 (Structural Analyst, Edge Case Analyst, Contract Auditor): sanitizer didn't cover Azure / openai-compat. Fixed via `isOpenAIResponsesProvider`.
- P2 (Go Architect): sanitizer asymmetric with Anthropic at the chatloop pre-request boundary. Fixed.
- P3 (Test Auditor, Edge Case Analyst, Contract Auditor, Structural Analyst, Go Architect): type-switch failed open for unknown / pointer parts. Fixed via `fantasy.AsMessagePart` + invert predicate.
- P3 (Edge Case Analyst): sanitizer dropped only one tool message in a contiguous run. Fixed.
- P3 (Structural Analyst): user turns merged across the dropped run via `appendSanitizedMessage`. Fixed by switching to plain `append`.
- P3 (Structural Analyst): integration test depended on chain-mode internals without an assertion. Fixed via captured-input check.
- Multiple style nits applied (constants over literals, `ptr.Ref` consistency, `Step` over `Turn` terminology, drop unnecessary error wrapper).

Follow-up items called out by reviewers but not in scope here:

- ID-prefix sniffing in the validator is fragile against future openai-go SDK changes (Test Auditor Obs).
- `Prompt` field in `OpenAIRequest` is dead code from a prior PR (Structural Analyst Obs).
- Map-iteration order in unpaired-function-call validator is non-deterministic when multiple orphans exist (Edge Case Analyst, Performance Analyst Obs); fine for current tests.
- If a third provider needs a similar sanitizer, factor out the shared shape (Duplication Checker Obs).

</details>
