### PR TITLE
fix(coderd/x/chatd): do not chain OpenAI Responses from tool-calling anchors

### DIFF
--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -3286,6 +3286,30 @@ func userMessageContributesToChainMode(msg database.ChatMessage) bool {
 	return false
 }
 
+// assistantMessageHasToolCallParts reports whether a persisted
+// assistant row emitted any tool-call parts. Responses API chain
+// mode cannot safely target such a response: OpenAI's server-side
+// state for the referenced response still holds unanswered
+// function_call items, so a follow-up turn that sets
+// previous_response_id but strips the assistant/tool blocks from
+// the input gets rejected with HTTP 400
+// "No tool output found for function call call_...". Treat parse
+// errors as "has tool calls" so malformed rows never become a
+// chain anchor; the safe full-replay path picks them up via
+// chatprompt.injectMissingToolResults.
+func assistantMessageHasToolCallParts(msg database.ChatMessage) bool {
+	parts, err := chatprompt.ParseContent(msg)
+	if err != nil {
+		return true
+	}
+	for _, part := range parts {
+		if part.Type == codersdk.ChatMessagePartTypeToolCall {
+			return true
+		}
+	}
+	return false
+}
+
 // resolveChainMode scans DB messages from the end to count trailing user
 // messages for the current turn and detect whether the immediately
 // preceding assistant/tool block can chain from a provider response ID.
@@ -3304,6 +3328,18 @@ func resolveChainMode(messages []database.ChatMessage) chainModeInfo {
 	for ; i >= 0; i-- {
 		switch messages[i].Role {
 		case database.ChatMessageRoleAssistant:
+			// An assistant row whose response included tool calls
+			// cannot be used as the chain anchor: OpenAI requires a
+			// matching function_call_output for every unanswered
+			// function_call in the referenced response, but chain
+			// mode strips assistant and tool rows from the request
+			// input. Leave previousResponseID empty so the caller
+			// falls back to the full-history replay path that
+			// synthesizes interrupted tool results via
+			// chatprompt.injectMissingToolResults.
+			if assistantMessageHasToolCallParts(messages[i]) {
+				return info
+			}
 			if messages[i].ProviderResponseID.Valid &&
 				messages[i].ProviderResponseID.String != "" {
 				info.previousResponseID = messages[i].ProviderResponseID.String

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -2913,6 +2913,115 @@ func TestResolveChainModeIgnoresSkillOnlySentinelMessages(t *testing.T) {
 	require.Equal(t, 1, got.contributingTrailingUserCount)
 }
 
+// TestResolveChainMode_RefusesToolCallingAnchor guards against the
+// production OpenAI Responses API bug where chain mode latched onto
+// a tool-calling assistant as the previous_response_id anchor. When
+// the chained request strips assistant and tool rows, the input
+// lacks any function_call_output for the emitted function_call and
+// OpenAI returns HTTP 400 "No tool output found for function call
+// call_...". Refusing that anchor leaves previousResponseID empty
+// so the caller falls back to the safe full-replay path.
+func TestResolveChainMode_RefusesToolCallingAnchor(t *testing.T) {
+	t.Parallel()
+
+	modelConfigID := uuid.New()
+	toolCallAsst := chatMessageWithParts([]codersdk.ChatMessagePart{{
+		Type:       codersdk.ChatMessagePartTypeToolCall,
+		ToolName:   "list_templates",
+		ToolCallID: "call_pending_output",
+		Args:       json.RawMessage(`{}`),
+	}})
+	toolCallAsst.Role = database.ChatMessageRoleAssistant
+	toolCallAsst.ProviderResponseID = sql.NullString{String: "resp-tool-call", Valid: true}
+	toolCallAsst.ModelConfigID = uuid.NullUUID{UUID: modelConfigID, Valid: true}
+
+	toolResult := chatMessageWithParts([]codersdk.ChatMessagePart{{
+		Type:       codersdk.ChatMessagePartTypeToolResult,
+		ToolName:   "list_templates",
+		ToolCallID: "call_pending_output",
+		Result:     json.RawMessage(`{"templates":[]}`),
+	}})
+	toolResult.Role = database.ChatMessageRoleTool
+
+	followUp := chatMessageWithParts([]codersdk.ChatMessagePart{{
+		Type: codersdk.ChatMessagePartTypeText,
+		Text: "follow-up question",
+	}})
+	followUp.Role = database.ChatMessageRoleUser
+
+	got := resolveChainMode([]database.ChatMessage{toolCallAsst, toolResult, followUp})
+	require.Empty(t, got.previousResponseID,
+		"tool-calling assistant must not become the chain anchor")
+	require.Equal(t, uuid.Nil, got.modelConfigID,
+		"modelConfigID must remain unset when the anchor is refused")
+	require.Equal(t, 1, got.trailingUserCount)
+	require.Equal(t, 1, got.contributingTrailingUserCount)
+}
+
+// TestResolveChainMode_AcceptsTextOnlyAnchor confirms the normal
+// happy path still works: when the trailing assistant row is a
+// text-only step its provider_response_id becomes the chain anchor.
+func TestResolveChainMode_AcceptsTextOnlyAnchor(t *testing.T) {
+	t.Parallel()
+
+	modelConfigID := uuid.New()
+	textAsst := chatMessageWithParts([]codersdk.ChatMessagePart{
+		{
+			Type: codersdk.ChatMessagePartTypeReasoning,
+			Text: "some internal reasoning",
+		},
+		{
+			Type: codersdk.ChatMessagePartTypeText,
+			Text: "the final answer",
+		},
+	})
+	textAsst.Role = database.ChatMessageRoleAssistant
+	textAsst.ProviderResponseID = sql.NullString{String: "resp-text-answer", Valid: true}
+	textAsst.ModelConfigID = uuid.NullUUID{UUID: modelConfigID, Valid: true}
+
+	followUp := chatMessageWithParts([]codersdk.ChatMessagePart{{
+		Type: codersdk.ChatMessagePartTypeText,
+		Text: "follow-up question",
+	}})
+	followUp.Role = database.ChatMessageRoleUser
+
+	got := resolveChainMode([]database.ChatMessage{textAsst, followUp})
+	require.Equal(t, "resp-text-answer", got.previousResponseID,
+		"text-only assistant must be usable as the chain anchor")
+	require.Equal(t, modelConfigID, got.modelConfigID)
+	require.Equal(t, 1, got.trailingUserCount)
+	require.Equal(t, 1, got.contributingTrailingUserCount)
+}
+
+// TestResolveChainMode_ParseErrorTreatedAsToolCalling ensures that
+// malformed assistant content never becomes a chain anchor. If the
+// parser cannot decide whether a row has tool calls we must assume
+// the worst so the full-replay fallback picks it up safely instead
+// of letting OpenAI reject the chained request with HTTP 400.
+func TestResolveChainMode_ParseErrorTreatedAsToolCalling(t *testing.T) {
+	t.Parallel()
+
+	malformed := database.ChatMessage{
+		Role:               database.ChatMessageRoleAssistant,
+		Content:            pqtype.NullRawMessage{RawMessage: []byte(`{"not-a-parts-array":true}`), Valid: true},
+		ContentVersion:     1,
+		ProviderResponseID: sql.NullString{String: "resp-malformed", Valid: true},
+		ModelConfigID:      uuid.NullUUID{UUID: uuid.New(), Valid: true},
+	}
+
+	followUp := chatMessageWithParts([]codersdk.ChatMessagePart{{
+		Type: codersdk.ChatMessagePartTypeText,
+		Text: "follow-up question",
+	}})
+	followUp.Role = database.ChatMessageRoleUser
+
+	got := resolveChainMode([]database.ChatMessage{malformed, followUp})
+	require.Empty(t, got.previousResponseID,
+		"malformed assistant content must be treated as a tool-calling row and skipped")
+	require.Equal(t, uuid.Nil, got.modelConfigID,
+		"modelConfigID must remain unset when the anchor is refused")
+}
+
 func TestFilterPromptForChainModeKeepsContributingUsersAcrossSkippedSentinelTurns(t *testing.T) {
 	t.Parallel()
 

--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -8625,3 +8625,230 @@ func TestAcquireChatsSkipsArchivedPendingChat(t *testing.T) {
 	require.Len(t, acquired, 1, "only the non-archived chat should be acquired")
 	require.Equal(t, activeChat.ID, acquired[0].ID)
 }
+
+// TestProcessChat_ChainModeAfterToolCallReturnsError_BeforeFix is a
+// chattest-driven unit reproduction of the production OpenAI
+// Responses API chain-mode bug. The chatloop's
+// previous_response_id optimization picks the most recent
+// ProviderResponseID-bearing assistant row as the chain anchor. When
+// that row is a tool-calling step, OpenAI rejects the follow-up
+// with HTTP 400 "No tool output found for function call call_..."
+// because the chained input lacks the matching function_call_output.
+//
+// The test seeds the failure shape by running one tool-calling turn
+// and then soft-deleting the following text assistant + tool_result
+// rows, leaving the tool-calling assistant as the trailing row.
+// After the fix lands in resolveChainMode, a tool-calling anchor is
+// refused and the full-replay fallback path (which synthesizes
+// missing tool results) handles the turn cleanly. Before the fix,
+// the chattest server enforces the same contract as OpenAI and
+// rejects the chained request with HTTP 400.
+func TestProcessChat_ChainModeAfterToolCallReturnsError_BeforeFix(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	db, ps := dbtestutil.NewDB(t)
+
+	// callCount distinguishes turn 1 (tool call), tool-continuation
+	// (tool result → text), and turn 2 (follow-up that should be
+	// rejected by the contract validator before the fix).
+	var callCount atomic.Int32
+	const firstResponseID = "resp_turn1_toolcall"
+	openAIURL := chattest.NewOpenAI(t, func(req *chattest.OpenAIRequest) chattest.OpenAIResponse {
+		n := callCount.Add(1)
+		switch n {
+		case 1:
+			// Turn 1 step 1: emit a function_call that will be
+			// persisted with firstResponseID. The fake server
+			// registers this call as pending because the
+			// request has store=true.
+			return chattest.OpenAIResponse{
+				StreamingChunks: closedEmptyChunkChannel(),
+				FunctionCalls: []chattest.OpenAIResponsesFunctionCall{{
+					CallID:    "call_list_templates_1",
+					Name:      "list_templates",
+					Arguments: `{}`,
+				}},
+				ResponseID: firstResponseID,
+			}
+		case 2:
+			// Turn 1 step 2: chatloop replayed the history with
+			// the tool_result in input. Return a short text
+			// response to complete the turn. The response carries
+			// its own ID which the chatloop persists but the
+			// test will soft-delete it below.
+			return chattest.OpenAIResponse{
+				StreamingChunks: streamingTextChunks("done"),
+				ResponseID:      "resp_turn1_text",
+			}
+		default:
+			// Turn 2 (follow-up) will be rejected by
+			// validateChainModeContract before the handler
+			// runs. This path is still wired so the test
+			// fails loudly if the validator misses.
+			return chattest.OpenAIResponse{
+				StreamingChunks: streamingTextChunks("unexpected"),
+				ResponseID:      "resp_turn2_unexpected",
+			}
+		}
+	})
+
+	user, org, _ := seedChatDependenciesWithProvider(ctx, t, db, "openai", openAIURL)
+	storeEnabled := true
+	// gpt-4o is the smallest model that the chatprovider layer
+	// routes to the Responses API with store=true. Using the
+	// canonical production model (gpt-5.5) is unnecessary because
+	// the contract enforcement is driven by the chattest server,
+	// not by any model-specific fantasy behavior.
+	model := insertChatModelConfigWithCallConfig(
+		ctx, t, db, user.ID, "openai", "gpt-4o",
+		codersdk.ChatModelCallConfig{
+			ProviderOptions: &codersdk.ChatModelProviderOptions{
+				OpenAI: &codersdk.ChatModelOpenAIProviderOptions{
+					Store: &storeEnabled,
+				},
+			},
+		},
+	)
+
+	// Seed a template so list_templates has something to return.
+	// The actual result content is irrelevant; we only need the
+	// tool-call shape to be persisted with firstResponseID.
+	tv := dbgen.TemplateVersion(t, db, database.TemplateVersion{
+		OrganizationID: org.ID,
+		CreatedBy:      user.ID,
+	})
+	dbgen.Template(t, db, database.Template{
+		CreatedBy:       user.ID,
+		OrganizationID:  org.ID,
+		ActiveVersionID: tv.ID,
+	})
+
+	server := newActiveTestServer(t, db, ps)
+
+	// Create the chat with an initial user message that will
+	// trigger the list_templates tool call. The chatloop runs
+	// automatically because pending chats get acquired.
+	chat, err := server.CreateChat(ctx, chatd.CreateOptions{
+		OrganizationID: org.ID,
+		OwnerID:        user.ID,
+		Title:          "chain-mode-tool-call-repro",
+		ModelConfigID:  model.ID,
+		InitialUserContent: []codersdk.ChatMessagePart{
+			codersdk.ChatMessageText("List the available workspace templates."),
+		},
+	})
+	require.NoError(t, err)
+
+	// Wait for turn 1 to finish.
+	require.Eventually(t, func() bool {
+		got, getErr := db.GetChatByID(ctx, chat.ID)
+		if getErr != nil {
+			return false
+		}
+		return got.Status == database.ChatStatusWaiting ||
+			got.Status == database.ChatStatusError
+	}, testutil.WaitLong, testutil.IntervalFast)
+
+	chatData, err := db.GetChatByID(ctx, chat.ID)
+	require.NoError(t, err)
+	require.Equal(t, database.ChatStatusWaiting, chatData.Status,
+		"turn 1 should complete successfully; got error=%q", chatData.LastError.String)
+
+	// Locate the tool-calling assistant row and soft-delete
+	// everything after it so the trailing assistant row is the
+	// tool-calling one with firstResponseID as its
+	// provider_response_id. This mirrors the production failure
+	// shape for the chain-mode bug.
+	dbMsgs, err := db.GetChatMessagesByChatID(ctx, database.GetChatMessagesByChatIDParams{
+		ChatID:  chat.ID,
+		AfterID: 0,
+	})
+	require.NoError(t, err)
+	toolCallAsstIdx := -1
+	for i, msg := range dbMsgs {
+		if msg.Role != database.ChatMessageRoleAssistant {
+			continue
+		}
+		parts, parseErr := chatprompt.ParseContent(msg)
+		if parseErr != nil {
+			continue
+		}
+		for _, p := range parts {
+			if p.Type == codersdk.ChatMessagePartTypeToolCall &&
+				p.ToolName == "list_templates" {
+				toolCallAsstIdx = i
+				break
+			}
+		}
+		if toolCallAsstIdx >= 0 {
+			break
+		}
+	}
+	require.GreaterOrEqual(t, toolCallAsstIdx, 0,
+		"expected assistant row with list_templates tool call")
+	anchor := dbMsgs[toolCallAsstIdx]
+	require.True(t, anchor.ProviderResponseID.Valid,
+		"tool-calling anchor must have provider_response_id set")
+	require.Equal(t, firstResponseID, anchor.ProviderResponseID.String)
+
+	err = db.SoftDeleteChatMessagesAfterID(ctx, database.SoftDeleteChatMessagesAfterIDParams{
+		ChatID:  chat.ID,
+		AfterID: anchor.ID,
+	})
+	require.NoError(t, err)
+
+	// Follow-up user message. This is the scenario the fix
+	// addresses: chain mode must refuse to use a tool-calling
+	// response as the previous_response_id anchor.
+	_, err = server.SendMessage(ctx, chatd.SendMessageOptions{
+		ChatID:    chat.ID,
+		CreatedBy: user.ID,
+		Content: []codersdk.ChatMessagePart{
+			codersdk.ChatMessageText("And how about now?"),
+		},
+	})
+	require.NoError(t, err)
+
+	// With the fix: the chatloop refuses the tool-calling anchor,
+	// replays the full history with a synthesized
+	// function_call_output, and reaches waiting. Without the fix:
+	// the chattest contract rejects the chained request because
+	// the input is filtered down to system + new user and carries
+	// no function_call_output for call_list_templates_1.
+	require.Eventually(t, func() bool {
+		got, getErr := db.GetChatByID(ctx, chat.ID)
+		if getErr != nil {
+			return false
+		}
+		chatData = got
+		return got.Status == database.ChatStatusWaiting ||
+			got.Status == database.ChatStatusError
+	}, testutil.WaitLong, testutil.IntervalFast)
+
+	require.Equal(t, database.ChatStatusWaiting, chatData.Status,
+		"with the fix applied the follow-up should not fail "+
+			"(last_error=%q)", chatData.LastError.String)
+}
+
+// closedEmptyChunkChannel returns a closed channel so the streaming
+// writer emits no text deltas. The tests that use it only care
+// about items emitted before streaming begins (function_calls).
+func closedEmptyChunkChannel() chan chattest.OpenAIChunk {
+	ch := make(chan chattest.OpenAIChunk)
+	close(ch)
+	return ch
+}
+
+// streamingTextChunks returns a buffered channel preloaded with a
+// single text chunk whose channel is closed after the send, matching
+// the pattern used by chattest.OpenAIStreamingResponse.
+func streamingTextChunks(text string) chan chattest.OpenAIChunk {
+	chunks := chattest.OpenAITextChunks(text)
+	ch := make(chan chattest.OpenAIChunk, len(chunks))
+	for _, c := range chunks {
+		ch <- c
+	}
+	close(ch)
+	return ch
+}

--- a/coderd/x/chatd/chattest/openai.go
+++ b/coderd/x/chatd/chattest/openai.go
@@ -24,6 +24,7 @@ type OpenAIResponse struct {
 	Response        *OpenAICompletion
 	Reasoning       *OpenAIReasoningItem
 	WebSearch       *OpenAIWebSearchCall
+	FunctionCalls   []OpenAIResponsesFunctionCall
 	ResponseID      string         // If set, used as the response ID in streamed events; otherwise auto-generated.
 	Error           *ErrorResponse // If set, server returns this HTTP error instead of streaming/JSON.
 }
@@ -43,6 +44,26 @@ type OpenAIWebSearchCall struct {
 	Query string `json:"query,omitempty"`
 }
 
+// OpenAIResponsesFunctionCall configures a streamed function_call
+// output item for the Responses API test server. When the response
+// is stored (store=true) the test server remembers the emitted
+// call_id on the stored response so a follow-up request chained via
+// previous_response_id must include the matching
+// function_call_output in its input.
+type OpenAIResponsesFunctionCall struct {
+	// ItemID is the response item identifier ("fc_..."). Generated
+	// when empty.
+	ItemID string
+	// CallID is the function-call identifier ("call_...") that
+	// must be matched by a function_call_output on the next chained
+	// request. Generated when empty.
+	CallID string
+	// Name is the function name emitted to the client.
+	Name string
+	// Arguments is the JSON-encoded argument string.
+	Arguments string
+}
+
 // OpenAIRequest represents an OpenAI chat completion request.
 type OpenAIRequest struct {
 	*http.Request
@@ -50,9 +71,17 @@ type OpenAIRequest struct {
 	Messages           []OpenAIMessage `json:"messages"`
 	Stream             bool            `json:"stream,omitempty"`
 	Tools              []OpenAITool    `json:"tools,omitempty"`
-	Prompt             []interface{}   `json:"prompt,omitempty"` // For responses API
+	Prompt             []interface{}   `json:"prompt,omitempty"` // Legacy Responses API field alias; the real wire field is "input".
 	Store              *bool           `json:"store,omitempty"`
 	PreviousResponseID *string         `json:"previous_response_id,omitempty"`
+	// Input is the raw Responses API input array. Each element is
+	// an opaque JSON object (message / function_call /
+	// function_call_output / reasoning / etc.). The test server
+	// inspects it to enforce the chain-mode contract: follow-up
+	// requests that set previous_response_id to a response with
+	// unanswered function_calls must include the matching
+	// function_call_output items here.
+	Input []json.RawMessage `json:"input,omitempty"`
 	// TODO: encoding/json ignores inline tags. Add custom UnmarshalJSON to capture unknown keys.
 	Options map[string]interface{} `json:",inline"` //nolint:revive
 }
@@ -132,12 +161,29 @@ type OpenAICompletion struct {
 }
 
 // openAIServer is a test server that mocks the OpenAI API.
+// openAIResponsesStoredState tracks information about a single
+// response persisted on the fake Responses API server. It mirrors
+// the server-side behavior OpenAI uses when store=true: the server
+// remembers which function_call items a response emitted so that a
+// follow-up request chained via previous_response_id can be
+// validated against the expected function_call_output items.
+type openAIResponsesStoredState struct {
+	// pendingFunctionCalls is the set of function-call IDs that
+	// were emitted by the response and have not yet been answered
+	// by a function_call_output with the same call_id.
+	pendingFunctionCalls map[string]struct{}
+}
+
 type openAIServer struct {
 	mu      sync.Mutex
 	t       testing.TB
 	server  *httptest.Server
 	handler OpenAIHandler
 	request *OpenAIRequest
+	// storedResponses maps response IDs to their server-side state
+	// for the subset of requests that set store=true. Access is
+	// guarded by mu.
+	storedResponses map[string]*openAIResponsesStoredState
 }
 
 // OpenAI creates a fake OpenAI-compatible test server with a
@@ -168,8 +214,9 @@ func NewOpenAI(t testing.TB, handler OpenAIHandler) string {
 	t.Helper()
 
 	s := &openAIServer{
-		t:       t,
-		handler: handler,
+		t:               t,
+		handler:         handler,
+		storedResponses: make(map[string]*openAIResponsesStoredState),
 	}
 
 	mux := http.NewServeMux()
@@ -213,8 +260,121 @@ func (s *openAIServer) handleResponses(w http.ResponseWriter, r *http.Request) {
 	s.request = &req
 	s.mu.Unlock()
 
+	// Enforce the Responses API chain-mode contract: when a
+	// request sets previous_response_id to a stored response that
+	// emitted function_calls, the new request's input must
+	// include a function_call_output for each of those call IDs.
+	// OpenAI returns HTTP 400 with
+	//   "No tool output found for function call call_..."
+	// when this contract is violated.
+	if errResp := s.validateChainModeContract(&req); errResp != nil {
+		writeErrorResponse(s.t, w, errResp)
+		return
+	}
+
 	resp := s.handler(&req)
 	s.writeResponsesAPIResponse(w, &req, resp)
+}
+
+// validateChainModeContract checks whether a Responses API request
+// that chains via previous_response_id provides function_call_output
+// items for every unanswered function_call in the referenced
+// response. When a tool output is missing it returns an
+// ErrorResponse that mirrors the shape OpenAI serves in production.
+func (s *openAIServer) validateChainModeContract(req *OpenAIRequest) *ErrorResponse {
+	if req.PreviousResponseID == nil || *req.PreviousResponseID == "" {
+		return nil
+	}
+
+	s.mu.Lock()
+	stored, ok := s.storedResponses[*req.PreviousResponseID]
+	s.mu.Unlock()
+	if !ok || stored == nil || len(stored.pendingFunctionCalls) == 0 {
+		return nil
+	}
+
+	providedOutputs := functionCallOutputIDs(req.Input)
+	for callID := range stored.pendingFunctionCalls {
+		if _, provided := providedOutputs[callID]; !provided {
+			return &ErrorResponse{
+				StatusCode: http.StatusBadRequest,
+				Type:       "invalid_request_error",
+				Message:    fmt.Sprintf("No tool output found for function call %s.", callID),
+			}
+		}
+	}
+	return nil
+}
+
+// registerPendingFunctionCall records a function_call that was
+// emitted as part of the given response. Subsequent requests chained
+// to this response must provide a matching function_call_output or
+// the server will reject the chain per
+// openAIServer.validateChainModeContract. markFunctionCallAnswered
+// is called when a follow-up request satisfies the call.
+func (s *openAIServer) registerPendingFunctionCall(responseID, callID string) {
+	if responseID == "" || callID == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state, ok := s.storedResponses[responseID]
+	if !ok {
+		state = &openAIResponsesStoredState{
+			pendingFunctionCalls: make(map[string]struct{}),
+		}
+		s.storedResponses[responseID] = state
+	}
+	state.pendingFunctionCalls[callID] = struct{}{}
+}
+
+// markFunctionCallAnswered clears a function_call from the pending
+// set of a stored response when a follow-up request supplies the
+// matching function_call_output. OpenAI resolves this transitively
+// along the chain, so once an output is posted the call never
+// reappears as pending on subsequent turns.
+func (s *openAIServer) markFunctionCallAnswered(responseID, callID string) {
+	if responseID == "" || callID == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state, ok := s.storedResponses[responseID]
+	if !ok || state == nil {
+		return
+	}
+	delete(state.pendingFunctionCalls, callID)
+}
+
+// functionCallOutputIDs returns the set of call_id values carried by
+// function_call_output entries in the request input. The input is
+// heterogeneous so each item is decoded individually.
+func functionCallOutputIDs(input []json.RawMessage) map[string]struct{} {
+	if len(input) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{}, len(input))
+	for _, raw := range input {
+		var item struct {
+			Type   string `json:"type"`
+			CallID string `json:"call_id"`
+		}
+		if err := json.Unmarshal(raw, &item); err != nil {
+			continue
+		}
+		if item.Type != "function_call_output" || item.CallID == "" {
+			continue
+		}
+		out[item.CallID] = struct{}{}
+	}
+	return out
+}
+
+// storeEnabledForRequest reports whether the request opted into the
+// Responses API's store=true mode that causes OpenAI to persist the
+// emitted response server-side.
+func storeEnabledForRequest(req *OpenAIRequest) bool {
+	return req != nil && req.Store != nil && *req.Store
 }
 
 func (s *openAIServer) writeChatCompletionsResponse(w http.ResponseWriter, req *OpenAIRequest, resp OpenAIResponse) {
@@ -269,7 +429,7 @@ func (s *openAIServer) writeResponsesAPIResponse(w http.ResponseWriter, req *Ope
 		http.Error(w, "handler returned streaming response for non-streaming request", http.StatusInternalServerError)
 		return
 	case hasStreaming:
-		writeResponsesAPIStreaming(s.t, w, req.Request, resp)
+		s.writeResponsesAPIStreaming(w, req.Request, req, resp)
 	default:
 		s.writeResponsesAPINonStreaming(w, resp.Response)
 	}
@@ -362,7 +522,8 @@ func writeNamedSSEEvent(w http.ResponseWriter, eventType string, v interface{}) 
 	return err
 }
 
-func writeResponsesAPIStreaming(t testing.TB, w http.ResponseWriter, r *http.Request, resp OpenAIResponse) {
+func (s *openAIServer) writeResponsesAPIStreaming(w http.ResponseWriter, r *http.Request, req *OpenAIRequest, resp OpenAIResponse) {
+	t := s.t
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
@@ -537,6 +698,78 @@ func writeResponsesAPIStreaming(t testing.TB, w http.ResponseWriter, r *http.Req
 			return
 		}
 		textOffset++
+	}
+
+	// Emit any configured function_call items. When the
+	// referencing request set store=true, register them on the
+	// server's stored-responses map so a follow-up request with
+	// previous_response_id must include a matching
+	// function_call_output for each call.
+	for _, fc := range resp.FunctionCalls {
+		outputIndex := textOffset
+		itemID := fc.ItemID
+		if itemID == "" {
+			itemID = fmt.Sprintf("fc_%s", uuid.New().String()[:8])
+		}
+		callID := fc.CallID
+		if callID == "" {
+			callID = fmt.Sprintf("call_%s", uuid.New().String()[:12])
+		}
+		if !writeEvent("response.output_item.added", map[string]interface{}{
+			"output_index": outputIndex,
+			"item": map[string]interface{}{
+				"type":      "function_call",
+				"id":        itemID,
+				"status":    "in_progress",
+				"call_id":   callID,
+				"name":      fc.Name,
+				"arguments": "",
+			},
+		}) {
+			return
+		}
+		if fc.Arguments != "" {
+			if !writeEvent("response.function_call_arguments.delta", map[string]interface{}{
+				"item_id":      itemID,
+				"output_index": outputIndex,
+				"delta":        fc.Arguments,
+			}) {
+				return
+			}
+		}
+		if !writeEvent("response.function_call_arguments.done", map[string]interface{}{
+			"item_id":      itemID,
+			"output_index": outputIndex,
+			"arguments":    fc.Arguments,
+		}) {
+			return
+		}
+		if !writeEvent("response.output_item.done", map[string]interface{}{
+			"output_index": outputIndex,
+			"item": map[string]interface{}{
+				"type":      "function_call",
+				"id":        itemID,
+				"status":    "completed",
+				"call_id":   callID,
+				"name":      fc.Name,
+				"arguments": fc.Arguments,
+			},
+		}) {
+			return
+		}
+		if s != nil && storeEnabledForRequest(req) {
+			s.registerPendingFunctionCall(responseID, callID)
+		}
+		textOffset++
+	}
+
+	// When the follow-up request satisfies function_calls from a
+	// prior response, mark them answered so their stored state
+	// stops complaining on further chains.
+	if s != nil && req != nil && req.PreviousResponseID != nil && *req.PreviousResponseID != "" {
+		for callID := range functionCallOutputIDs(req.Input) {
+			s.markFunctionCallAnswered(*req.PreviousResponseID, callID)
+		}
 	}
 
 	for {

--- a/coderd/x/chatd/chattest/openai_test.go
+++ b/coderd/x/chatd/chattest/openai_test.go
@@ -1,7 +1,11 @@
 package chattest_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"io"
+	"net/http"
 	"sync/atomic"
 	"testing"
 
@@ -364,4 +368,179 @@ func TestOpenAI_NonStreaming_MismatchReturnsError_ResponsesAPI(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "streaming response for non-streaming request")
+}
+
+// TestOpenAI_ResponsesAPI_RejectsChainWithoutToolOutput verifies the
+// chattest OpenAI server enforces the Responses API chain-mode
+// contract: when a follow-up request sets previous_response_id to a
+// stored response whose output contained a function_call, the input
+// on the new request must include a matching function_call_output or
+// the server rejects with HTTP 400 mirroring OpenAI's production
+// error body.
+func TestOpenAI_ResponsesAPI_RejectsChainWithoutToolOutput(t *testing.T) {
+	t.Parallel()
+
+	const responseID = "resp_chainmode_test_1"
+	serverURL := chattest.NewOpenAI(t, func(req *chattest.OpenAIRequest) chattest.OpenAIResponse {
+		// First call: emit a function_call item that must be
+		// answered on the next request. The test server will
+		// remember the call because req.Store is true.
+		if req.PreviousResponseID == nil {
+			return chattest.OpenAIResponse{
+				StreamingChunks: emptyChunkChannel(),
+				FunctionCalls: []chattest.OpenAIResponsesFunctionCall{{
+					CallID:    "call_must_be_answered",
+					Name:      "list_templates",
+					Arguments: `{}`,
+				}},
+				ResponseID: responseID,
+			}
+		}
+		// The follow-up streamed body is irrelevant because the
+		// chain-mode validation fails before the handler emits
+		// anything, but we still need to return a valid response
+		// shape to keep the test server happy.
+		return chattest.OpenAIResponse{
+			StreamingChunks: emptyChunkChannel(),
+		}
+	})
+
+	// Turn 1: initial streaming request with store=true. This makes
+	// the fake server remember the emitted function_call.
+	turn1Body := mustMarshalJSON(t, map[string]any{
+		"model":  "gpt-5.5",
+		"stream": true,
+		"store":  true,
+		"input": []any{
+			map[string]any{
+				"role":    "user",
+				"content": "list templates please",
+			},
+		},
+	})
+	statusCode, body := postResponses(t, serverURL, turn1Body)
+	require.Equal(t, http.StatusOK, statusCode, "turn 1 should succeed")
+	require.Contains(t, body, "function_call",
+		"turn 1 should emit a function_call item")
+	require.Contains(t, body, "call_must_be_answered",
+		"turn 1 should emit the registered call_id")
+
+	// Turn 2: chain via previous_response_id but without a
+	// function_call_output for call_must_be_answered. The server
+	// must reject with HTTP 400 mirroring OpenAI's real error.
+	turn2Body := mustMarshalJSON(t, map[string]any{
+		"model":                "gpt-5.5",
+		"stream":               true,
+		"store":                true,
+		"previous_response_id": responseID,
+		"input": []any{
+			map[string]any{
+				"role":    "user",
+				"content": "follow-up without tool output",
+			},
+		},
+	})
+	statusCode, body = postResponses(t, serverURL, turn2Body)
+	require.Equal(t, http.StatusBadRequest, statusCode,
+		"turn 2 must be rejected with 400 when the chain anchor has "+
+			"unanswered function_calls")
+	require.Contains(t, body, "No tool output found for function call call_must_be_answered",
+		"error body should mirror OpenAI's production message")
+}
+
+// TestOpenAI_ResponsesAPI_AcceptsChainWithToolOutput confirms the
+// chattest server lets a chained follow-up through when the input
+// includes a function_call_output for every unanswered function_call
+// on the referenced response. This exercises the "happy path" side
+// of the contract so subtle regressions in the validator surface as
+// test failures rather than silent passes.
+func TestOpenAI_ResponsesAPI_AcceptsChainWithToolOutput(t *testing.T) {
+	t.Parallel()
+
+	const responseID = "resp_chainmode_test_2"
+	serverURL := chattest.NewOpenAI(t, func(req *chattest.OpenAIRequest) chattest.OpenAIResponse {
+		if req.PreviousResponseID == nil {
+			return chattest.OpenAIResponse{
+				StreamingChunks: emptyChunkChannel(),
+				FunctionCalls: []chattest.OpenAIResponsesFunctionCall{{
+					CallID:    "call_answered_on_next_turn",
+					Name:      "list_templates",
+					Arguments: `{}`,
+				}},
+				ResponseID: responseID,
+			}
+		}
+		return chattest.OpenAIResponse{
+			StreamingChunks: emptyChunkChannel(),
+		}
+	})
+
+	// Turn 1 sets up the outstanding call.
+	turn1Body := mustMarshalJSON(t, map[string]any{
+		"model":  "gpt-5.5",
+		"stream": true,
+		"store":  true,
+		"input": []any{
+			map[string]any{
+				"role":    "user",
+				"content": "list templates please",
+			},
+		},
+	})
+	statusCode, _ := postResponses(t, serverURL, turn1Body)
+	require.Equal(t, http.StatusOK, statusCode)
+
+	// Turn 2 provides the required function_call_output alongside
+	// the new user message. The server must accept this chain.
+	turn2Body := mustMarshalJSON(t, map[string]any{
+		"model":                "gpt-5.5",
+		"stream":               true,
+		"store":                true,
+		"previous_response_id": responseID,
+		"input": []any{
+			map[string]any{
+				"type":    "function_call_output",
+				"call_id": "call_answered_on_next_turn",
+				"output":  "{\"templates\":[]}",
+			},
+			map[string]any{
+				"role":    "user",
+				"content": "thanks",
+			},
+		},
+	})
+	statusCode, body := postResponses(t, serverURL, turn2Body)
+	require.Equal(t, http.StatusOK, statusCode,
+		"turn 2 should succeed once every function_call has a matching function_call_output (body=%s)", body)
+}
+
+func postResponses(t *testing.T, baseURL string, body []byte) (int, string) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, baseURL+"/responses", bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp.StatusCode, string(raw)
+}
+
+func mustMarshalJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	data, err := json.Marshal(v)
+	require.NoError(t, err)
+	return data
+}
+
+// emptyChunkChannel returns a closed channel so the streaming writer
+// exits immediately with no text deltas. The tests that use it only
+// care about header items emitted before streaming begins (function
+// calls, validation errors).
+func emptyChunkChannel() chan chattest.OpenAIChunk {
+	ch := make(chan chattest.OpenAIChunk)
+	close(ch)
+	return ch
 }


### PR DESCRIPTION
Users hit `OpenAI returned an unexpected error (HTTP 400). No tool output found for function call call_...` on follow-up turns when the model is an OpenAI Responses model with `store=true`, reasoning enabled, and the most recent `provider_response_id`-bearing assistant row contains tool-call parts.

`resolveChainMode` walked back from the trailing user, skipped tool rows, and took the first assistant row with a stored `provider_response_id` as the chain anchor. When that row's response still had unanswered `function_call` items, `filterPromptForChainMode` stripped the matching `function_call_output` from the input and OpenAI rejected the chained request. Refuse tool-calling rows as chain anchors so the safe full-replay path (which synthesizes missing tool results via `chatprompt.injectMissingToolResults`) handles the turn.

The `chattest` OpenAI Responses fake now mirrors OpenAI's real `store=true` contract: it tracks the `function_call` items emitted by each stored response and rejects a follow-up that sets `previous_response_id` without supplying the matching `function_call_output`. The rejection payload mirrors OpenAI's real HTTP 400 body so chatd-level tests can drive the failure mode without network. The fix was also verified live against `api.openai.com` with `gpt-5.5`, `Store=true`, reasoning, and a `list_templates` tool call.

Follows on from #23450 (introduced chain mode) and parallels #24706 (Anthropic provider-tool sanitization).

<details>
<summary>Test coverage</summary>

- Three `resolveChainMode` unit tests: refuses tool-call anchor, accepts text-only anchor, treats `ParseContent` errors as tool-calling for safety.
- `TestOpenAI_ResponsesAPI_RejectsChainWithoutToolOutput` and `...AcceptsChainWithToolOutput` pin the chattest contract directly.
- `TestProcessChat_ChainModeAfterToolCallReturnsError_BeforeFix` drives the chatd-level reproduction through the fake server.

</details>

<details>
<summary>Decision log</summary>

- **Why refuse the anchor instead of walking further back?** Chain mode drops everything between the anchor and the new user turn. Anchoring to an earlier text-only response would silently hide the tool-calling response (and its outputs) from the model.
- **Why treat `ParseContent` errors as tool-calling?** A malformed assistant row that we can't classify is safer to replay than to chain. The full-replay path is correct by construction; a 400 from OpenAI is not.

</details>

> Coder Agents acted on Kyle's behalf.