### PR TITLE
fix(coderd/x/chatd): sanitize OpenAI Responses tool history

### DIFF
--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -3368,6 +3368,94 @@ func filterPromptForChainMode(
 	return filtered
 }
 
+func openAIResponsesRemoved(stats chatprompt.OpenAIResponsesSanitizationStats) bool {
+	return stats.RemovedToolCalls > 0 ||
+		stats.RemovedToolResults > 0 ||
+		stats.RemovedWebSearchCalls > 0 ||
+		stats.RemovedWebSearchResults > 0
+}
+
+func openAIResponsesRawRowsUnsafeForChainMode(
+	messages []database.ChatMessage,
+	info chainModeInfo,
+) (bool, error) {
+	if info.previousResponseID == "" || info.contributingTrailingUserCount <= 0 {
+		return false, nil
+	}
+
+	candidateEnd := len(messages) - 1
+	for ; candidateEnd >= 0; candidateEnd-- {
+		if messages[candidateEnd].Role != database.ChatMessageRoleUser {
+			break
+		}
+	}
+	if candidateEnd < 0 {
+		return false, nil
+	}
+
+	assistantIndex := -1
+scanCandidate:
+	for i := candidateEnd; i >= 0; i-- {
+		switch messages[i].Role {
+		case database.ChatMessageRoleAssistant:
+			if messages[i].ProviderResponseID.Valid &&
+				messages[i].ProviderResponseID.String != "" {
+				assistantIndex = i
+			}
+			break scanCandidate
+		case database.ChatMessageRoleTool:
+			continue
+		default:
+			return false, nil
+		}
+	}
+	if assistantIndex < 0 {
+		return false, nil
+	}
+
+	callMatched := map[string]bool{}
+	assistantParts, err := chatprompt.ParseContent(messages[assistantIndex])
+	if err != nil {
+		return false, xerrors.Errorf("parse chain assistant content: %w", err)
+	}
+	for _, part := range assistantParts {
+		if part.Type != codersdk.ChatMessagePartTypeToolCall || part.ProviderExecuted {
+			continue
+		}
+		if part.ToolCallID == "" {
+			return true, nil
+		}
+		callMatched[part.ToolCallID] = false
+	}
+	if len(callMatched) == 0 {
+		return false, nil
+	}
+
+	for i := assistantIndex + 1; i <= candidateEnd; i++ {
+		if messages[i].Role != database.ChatMessageRoleTool {
+			continue
+		}
+		parts, err := chatprompt.ParseContent(messages[i])
+		if err != nil {
+			return false, xerrors.Errorf("parse chain tool content: %w", err)
+		}
+		for _, part := range parts {
+			if part.Type != codersdk.ChatMessagePartTypeToolResult || part.ProviderExecuted {
+				continue
+			}
+			if _, ok := callMatched[part.ToolCallID]; ok {
+				callMatched[part.ToolCallID] = true
+			}
+		}
+	}
+	for _, matched := range callMatched {
+		if !matched {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // appendChatMessage appends a single message to the batch insert params.
 func appendChatMessage(
 	params *database.InsertChatMessagesParams,
@@ -6669,22 +6757,53 @@ func (p *Server) runChat(
 		model,
 		callConfig.ProviderOptions,
 	)
+	baseProviderOptions := providerOptions
 	// When the OpenAI Responses API has store=true, the provider
 	// retains conversation history server-side. For follow-up turns,
 	// we set previous_response_id and send only system instructions
 	// plus the new user input, avoiding redundant replay of prior
 	// assistant and tool messages that the provider already has.
-	chainModeActive := chatprovider.IsResponsesStoreEnabled(providerOptions) &&
+	wouldUseChainMode := chatprovider.IsResponsesStoreEnabled(providerOptions) &&
 		chainInfo.previousResponseID != "" &&
 		chainInfo.contributingTrailingUserCount > 0 &&
 		chainInfo.modelConfigID == modelConfig.ID &&
 		!isPlanModeTurn
-	if chainModeActive {
+	chainModeActive := false
+	sanitizedFullPrompt := prompt
+	if chatprovider.HasOpenAIResponsesProviderOptions(providerOptions) {
+		rawRowsUnsafe, err := openAIResponsesRawRowsUnsafeForChainMode(messages, chainInfo)
+		if err != nil {
+			return result, xerrors.Errorf("analyze OpenAI Responses chain rows: %w", err)
+		}
+		var openAIStats chatprompt.OpenAIResponsesSanitizationStats
+		sanitizedFullPrompt, openAIStats = chatprompt.SanitizeOpenAIResponsesMessages(prompt)
+		if rawRowsUnsafe {
+			openAIStats.UnsafeForChainMode = true
+		}
+		if openAIResponsesRemoved(openAIStats) || openAIStats.UnsafeForChainMode {
+			prompt = sanitizedFullPrompt
+			providerOptions = baseProviderOptions
+			if wouldUseChainMode {
+				openAIStats.DisabledChainMode = true
+			}
+			chatprompt.LogOpenAIResponsesSanitization(
+				ctx, logger, "request", model.Provider(), model.Model(), openAIStats,
+			)
+		} else if wouldUseChainMode {
+			providerOptions = chatprovider.CloneWithPreviousResponseID(
+				baseProviderOptions,
+				chainInfo.previousResponseID,
+			)
+			prompt = filterPromptForChainMode(prompt, chainInfo)
+			chainModeActive = true
+		}
+	} else if wouldUseChainMode {
 		providerOptions = chatprovider.CloneWithPreviousResponseID(
 			providerOptions,
 			chainInfo.previousResponseID,
 		)
 		prompt = filterPromptForChainMode(prompt, chainInfo)
+		chainModeActive = true
 	}
 	activeToolNames := activeToolNamesForTurn(
 		tools,
@@ -6740,6 +6859,29 @@ func (p *Server) runChat(
 		}
 	}()
 
+	var openAIResponsesChainFallbackMessages []fantasy.Message
+	var openAIResponsesChainFallbackProviderOptions fantasy.ProviderOptions
+	if chatprovider.HasOpenAIResponsesProviderOptions(providerOptions) {
+		sanitizedPrompt, openAIStats := chatprompt.SanitizeOpenAIResponsesMessages(prompt)
+		if openAIResponsesRemoved(openAIStats) {
+			if chainModeActive {
+				prompt = sanitizedFullPrompt
+				providerOptions = baseProviderOptions
+				chainModeActive = false
+				openAIStats.DisabledChainMode = true
+			} else {
+				prompt = sanitizedPrompt
+			}
+			chatprompt.LogOpenAIResponsesSanitization(
+				ctx, logger, "pre_request", model.Provider(), model.Model(), openAIStats,
+			)
+		}
+		if chainModeActive {
+			openAIResponsesChainFallbackMessages = sanitizedFullPrompt
+			openAIResponsesChainFallbackProviderOptions = baseProviderOptions
+		}
+	}
+
 	loopErr = chatloop.Run(ctx, chatloop.RunOptions{
 		Model:            model,
 		Messages:         prompt,
@@ -6751,9 +6893,11 @@ func (p *Server) runChat(
 		Logger:           loopLogger,
 		BuiltinToolNames: builtinToolNames,
 
-		ModelConfig:     callConfig,
-		ProviderOptions: providerOptions,
-		ProviderTools:   providerTools,
+		ModelConfig:                                 callConfig,
+		ProviderOptions:                             providerOptions,
+		OpenAIResponsesChainFallbackMessages:        openAIResponsesChainFallbackMessages,
+		OpenAIResponsesChainFallbackProviderOptions: openAIResponsesChainFallbackProviderOptions,
+		ProviderTools:                               providerTools,
 		// dynamicToolNames now contains only names that don't
 		// collide with built-in/MCP tools.
 		DynamicToolNames: dynamicToolNames,
@@ -6825,10 +6969,34 @@ func (p *Server) runChat(
 				},
 			)
 			reloadedPrompt = renderPlanPathPrompt(reloadedPrompt, resolvePlanPathBlock(reloadCtx))
+			reloadedChainInfo := resolveChainMode(reloadedMsgs)
+			if chatprovider.HasOpenAIResponsesProviderOptions(baseProviderOptions) {
+				rawRowsUnsafe, err := openAIResponsesRawRowsUnsafeForChainMode(
+					reloadedMsgs,
+					reloadedChainInfo,
+				)
+				if err != nil {
+					return nil, xerrors.Errorf("analyze reloaded OpenAI Responses chain rows: %w", err)
+				}
+				sanitizedReloadedPrompt, openAIStats := chatprompt.SanitizeOpenAIResponsesMessages(reloadedPrompt)
+				if rawRowsUnsafe {
+					openAIStats.UnsafeForChainMode = true
+				}
+				if openAIResponsesRemoved(openAIStats) || openAIStats.UnsafeForChainMode {
+					if chainModeActive {
+						chainModeActive = false
+						openAIStats.DisabledChainMode = true
+					}
+					chatprompt.LogOpenAIResponsesSanitization(
+						reloadCtx, logger, "reload_messages", model.Provider(), model.Model(), openAIStats,
+					)
+					return sanitizedReloadedPrompt, nil
+				}
+			}
 			if chainModeActive {
 				reloadedPrompt = filterPromptForChainMode(
 					reloadedPrompt,
-					chainInfo,
+					reloadedChainInfo,
 				)
 			}
 			return reloadedPrompt, nil

--- a/coderd/x/chatd/chatd_openai_responses_test.go
+++ b/coderd/x/chatd/chatd_openai_responses_test.go
@@ -1,0 +1,380 @@
+package chatd_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/coderd/x/chatd"
+	"github.com/coder/coder/v2/coderd/x/chatd/chatprompt"
+	"github.com/coder/coder/v2/coderd/x/chatd/chattest"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/testutil"
+)
+
+// These tests cover local tool-call chain safety only. A provider-executed
+// web-search replay fixture would require substantially more persisted
+// Responses setup, so it is intentionally left out of this focused coverage.
+func TestOpenAIResponsesUnsafeHistoryDisablesChainMode(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+	ctx := testutil.Context(t, testutil.WaitLong)
+	recorder := newOpenAIResponsesRequestRecorder()
+	openAIURL := chattest.NewOpenAI(t, func(req *chattest.OpenAIRequest) chattest.OpenAIResponse {
+		recorder.record(req)
+		if !req.Stream {
+			return chattest.OpenAINonStreamingResponse(`{"title":"OpenAI Responses unsafe chain test"}`)
+		}
+		return chattest.OpenAIStreamingResponse(
+			chattest.OpenAITextChunks("Unsafe chain fallback complete.")...,
+		)
+	})
+
+	user, org, _ := seedChatDependenciesWithProvider(ctx, t, db, "openai", openAIURL)
+	model := insertOpenAIResponsesStoreModel(ctx, t, db, user.ID)
+	chat := insertOpenAIResponsesChainChat(ctx, t, db, org.ID, user.ID, model.ID, "unsafe history")
+	insertOpenAIResponsesMessages(ctx, t, db, chat.ID, user.ID, model.ID, []openAIResponsesMessageSeed{
+		{
+			role: database.ChatMessageRoleUser,
+			parts: []codersdk.ChatMessagePart{
+				codersdk.ChatMessageText("initial user marker for unsafe chain"),
+			},
+		},
+		{
+			role:               database.ChatMessageRoleAssistant,
+			providerResponseID: "resp_unsafe",
+			parts: []codersdk.ChatMessagePart{
+				codersdk.ChatMessageText("previous assistant marker for unsafe chain"),
+				codersdk.ChatMessageToolCall("call_unsafe", "read_file", json.RawMessage(`{"path":"main.go"}`)),
+			},
+		},
+		{
+			role: database.ChatMessageRoleUser,
+			parts: []codersdk.ChatMessagePart{
+				codersdk.ChatMessageText("trailing user marker for unsafe chain"),
+			},
+		},
+	})
+
+	server := newActiveTestServer(t, db, ps)
+	chatResult := waitForTerminalChat(ctx, t, db, chat.ID)
+	chatd.WaitUntilIdleForTest(server)
+	if chatResult.Status == database.ChatStatusError {
+		require.FailNowf(t, "chat failed", "last_error=%q", chatResult.LastError.String)
+	}
+
+	streamed := recorder.streamingRequests()
+	require.NotEmpty(t, streamed)
+	first := streamed[0]
+	require.Nil(t, first.PreviousResponseID)
+	validateOpenAIResponsesPrompt(t, first.Prompt)
+	require.True(t, openAIResponsesPromptContainsString(first.Prompt, "initial user marker for unsafe chain"))
+	require.True(t, openAIResponsesPromptContainsString(first.Prompt, "previous assistant marker for unsafe chain"))
+}
+
+func TestOpenAIResponsesCleanHistoryPreservesChainMode(t *testing.T) {
+	t.Parallel()
+
+	db, ps := dbtestutil.NewDB(t)
+	ctx := testutil.Context(t, testutil.WaitLong)
+	recorder := newOpenAIResponsesRequestRecorder()
+	openAIURL := chattest.NewOpenAI(t, func(req *chattest.OpenAIRequest) chattest.OpenAIResponse {
+		recorder.record(req)
+		if !req.Stream {
+			return chattest.OpenAINonStreamingResponse(`{"title":"OpenAI Responses clean chain test"}`)
+		}
+		return chattest.OpenAIStreamingResponse(
+			chattest.OpenAITextChunks("Clean chain complete.")...,
+		)
+	})
+
+	user, org, _ := seedChatDependenciesWithProvider(ctx, t, db, "openai", openAIURL)
+	model := insertOpenAIResponsesStoreModel(ctx, t, db, user.ID)
+	chat := insertOpenAIResponsesChainChat(ctx, t, db, org.ID, user.ID, model.ID, "clean history")
+	insertOpenAIResponsesMessages(ctx, t, db, chat.ID, user.ID, model.ID, []openAIResponsesMessageSeed{
+		{
+			role: database.ChatMessageRoleUser,
+			parts: []codersdk.ChatMessagePart{
+				codersdk.ChatMessageText("initial user marker for clean chain"),
+			},
+		},
+		{
+			role:               database.ChatMessageRoleAssistant,
+			providerResponseID: "resp_clean",
+			parts: []codersdk.ChatMessagePart{
+				codersdk.ChatMessageText("previous assistant marker for clean chain"),
+			},
+		},
+		{
+			role: database.ChatMessageRoleUser,
+			parts: []codersdk.ChatMessagePart{
+				codersdk.ChatMessageText("trailing user marker for clean chain"),
+			},
+		},
+	})
+
+	server := newActiveTestServer(t, db, ps)
+	chatResult := waitForTerminalChat(ctx, t, db, chat.ID)
+	chatd.WaitUntilIdleForTest(server)
+	if chatResult.Status == database.ChatStatusError {
+		require.FailNowf(t, "chat failed", "last_error=%q", chatResult.LastError.String)
+	}
+
+	streamed := recorder.streamingRequests()
+	require.NotEmpty(t, streamed)
+	first := streamed[0]
+	require.NotNil(t, first.PreviousResponseID)
+	require.Equal(t, "resp_clean", *first.PreviousResponseID)
+	require.True(t, openAIResponsesPromptContainsString(first.Prompt, "trailing user marker for clean chain"))
+	require.False(t, openAIResponsesPromptContainsString(first.Prompt, "initial user marker for clean chain"))
+	require.False(t, openAIResponsesPromptContainsString(first.Prompt, "previous assistant marker for clean chain"))
+}
+
+type openAIResponsesRequestRecorder struct {
+	mu       sync.Mutex
+	requests []*chattest.OpenAIRequest
+}
+
+func newOpenAIResponsesRequestRecorder() *openAIResponsesRequestRecorder {
+	return &openAIResponsesRequestRecorder{}
+}
+
+func (r *openAIResponsesRequestRecorder) record(req *chattest.OpenAIRequest) {
+	var previousResponseID *string
+	if req.PreviousResponseID != nil {
+		value := *req.PreviousResponseID
+		previousResponseID = &value
+	}
+	var store *bool
+	if req.Store != nil {
+		value := *req.Store
+		store = &value
+	}
+	clone := &chattest.OpenAIRequest{
+		Model:              req.Model,
+		Messages:           append([]chattest.OpenAIMessage(nil), req.Messages...),
+		Stream:             req.Stream,
+		Tools:              append([]chattest.OpenAITool(nil), req.Tools...),
+		Prompt:             append([]interface{}(nil), req.Prompt...),
+		Store:              store,
+		PreviousResponseID: previousResponseID,
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.requests = append(r.requests, clone)
+}
+
+func (r *openAIResponsesRequestRecorder) streamingRequests() []*chattest.OpenAIRequest {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]*chattest.OpenAIRequest, 0, len(r.requests))
+	for _, req := range r.requests {
+		if req.Stream {
+			out = append(out, req)
+		}
+	}
+	return out
+}
+
+type openAIResponsesMessageSeed struct {
+	role               database.ChatMessageRole
+	parts              []codersdk.ChatMessagePart
+	providerResponseID string
+}
+
+func insertOpenAIResponsesStoreModel(
+	ctx context.Context,
+	t *testing.T,
+	db database.Store,
+	userID uuid.UUID,
+) database.ChatModelConfig {
+	t.Helper()
+	storeEnabled := true
+	return insertChatModelConfigWithCallConfig(
+		ctx,
+		t,
+		db,
+		userID,
+		"openai",
+		"gpt-4o",
+		codersdk.ChatModelCallConfig{
+			ProviderOptions: &codersdk.ChatModelProviderOptions{
+				OpenAI: &codersdk.ChatModelOpenAIProviderOptions{
+					Store: &storeEnabled,
+				},
+			},
+		},
+	)
+}
+
+func insertOpenAIResponsesChainChat(
+	ctx context.Context,
+	t *testing.T,
+	db database.Store,
+	organizationID uuid.UUID,
+	userID uuid.UUID,
+	modelConfigID uuid.UUID,
+	title string,
+) database.Chat {
+	t.Helper()
+	chat, err := db.InsertChat(ctx, database.InsertChatParams{
+		OrganizationID:    organizationID,
+		OwnerID:           userID,
+		LastModelConfigID: modelConfigID,
+		Title:             title,
+		Status:            database.ChatStatusPending,
+		ClientType:        database.ChatClientTypeApi,
+	})
+	require.NoError(t, err)
+	return chat
+}
+
+func insertOpenAIResponsesMessages(
+	ctx context.Context,
+	t *testing.T,
+	db database.Store,
+	chatID uuid.UUID,
+	userID uuid.UUID,
+	modelConfigID uuid.UUID,
+	seeds []openAIResponsesMessageSeed,
+) {
+	t.Helper()
+	params := database.InsertChatMessagesParams{
+		ChatID:              chatID,
+		CreatedBy:           make([]uuid.UUID, 0, len(seeds)),
+		ModelConfigID:       make([]uuid.UUID, 0, len(seeds)),
+		Role:                make([]database.ChatMessageRole, 0, len(seeds)),
+		Content:             make([]string, 0, len(seeds)),
+		ContentVersion:      make([]int16, 0, len(seeds)),
+		Visibility:          make([]database.ChatMessageVisibility, 0, len(seeds)),
+		InputTokens:         make([]int64, 0, len(seeds)),
+		OutputTokens:        make([]int64, 0, len(seeds)),
+		TotalTokens:         make([]int64, 0, len(seeds)),
+		ReasoningTokens:     make([]int64, 0, len(seeds)),
+		CacheCreationTokens: make([]int64, 0, len(seeds)),
+		CacheReadTokens:     make([]int64, 0, len(seeds)),
+		ContextLimit:        make([]int64, 0, len(seeds)),
+		Compressed:          make([]bool, 0, len(seeds)),
+		TotalCostMicros:     make([]int64, 0, len(seeds)),
+		RuntimeMs:           make([]int64, 0, len(seeds)),
+		ProviderResponseID:  make([]string, 0, len(seeds)),
+	}
+	for _, seed := range seeds {
+		content, err := chatprompt.MarshalParts(seed.parts)
+		require.NoError(t, err)
+		params.CreatedBy = append(params.CreatedBy, userID)
+		params.ModelConfigID = append(params.ModelConfigID, modelConfigID)
+		params.Role = append(params.Role, seed.role)
+		params.Content = append(params.Content, string(content.RawMessage))
+		params.ContentVersion = append(params.ContentVersion, chatprompt.CurrentContentVersion)
+		params.Visibility = append(params.Visibility, database.ChatMessageVisibilityBoth)
+		params.InputTokens = append(params.InputTokens, 0)
+		params.OutputTokens = append(params.OutputTokens, 0)
+		params.TotalTokens = append(params.TotalTokens, 0)
+		params.ReasoningTokens = append(params.ReasoningTokens, 0)
+		params.CacheCreationTokens = append(params.CacheCreationTokens, 0)
+		params.CacheReadTokens = append(params.CacheReadTokens, 0)
+		params.ContextLimit = append(params.ContextLimit, 0)
+		params.Compressed = append(params.Compressed, false)
+		params.TotalCostMicros = append(params.TotalCostMicros, 0)
+		params.RuntimeMs = append(params.RuntimeMs, 0)
+		params.ProviderResponseID = append(params.ProviderResponseID, seed.providerResponseID)
+	}
+	_, err := db.InsertChatMessages(ctx, params)
+	require.NoError(t, err)
+}
+
+func validateOpenAIResponsesPrompt(t *testing.T, prompt []interface{}) {
+	t.Helper()
+	calls := map[string]bool{}
+	outputs := map[string]bool{}
+
+	var walk func(any)
+	walk = func(value any) {
+		switch typed := value.(type) {
+		case map[string]interface{}:
+			if itemType, _ := typed["type"].(string); itemType != "" {
+				switch itemType {
+				case "web_search_call":
+					require.FailNow(t, "prompt contains web_search_call history")
+				case "function_call":
+					callID := openAIResponsesPromptCallID(typed)
+					require.NotEmpty(t, callID, "function_call item is missing a call ID")
+					if _, ok := calls[callID]; ok {
+						require.FailNowf(t, "duplicate function_call ID", "call_id=%q", callID)
+					}
+					if outputs[callID] {
+						require.FailNowf(t, "function_call_output appeared before call", "call_id=%q", callID)
+					}
+					calls[callID] = false
+				case "function_call_output":
+					callID := openAIResponsesPromptCallID(typed)
+					require.NotEmpty(t, callID, "function_call_output item is missing a call ID")
+					if outputs[callID] {
+						require.FailNowf(t, "duplicate function_call_output ID", "call_id=%q", callID)
+					}
+					if _, ok := calls[callID]; !ok {
+						require.FailNowf(t, "function_call_output without prior call", "call_id=%q", callID)
+					}
+					calls[callID] = true
+					outputs[callID] = true
+				}
+			}
+			for _, nested := range typed {
+				walk(nested)
+			}
+		case []interface{}:
+			for _, nested := range typed {
+				walk(nested)
+			}
+		}
+	}
+	walk(prompt)
+
+	for callID, matched := range calls {
+		if !matched {
+			require.FailNowf(t, "function_call without later output", "call_id=%q", callID)
+		}
+	}
+}
+
+func openAIResponsesPromptCallID(item map[string]interface{}) string {
+	if callID, _ := item["call_id"].(string); callID != "" {
+		return callID
+	}
+	id, _ := item["id"].(string)
+	return id
+}
+
+func openAIResponsesPromptContainsString(prompt []interface{}, want string) bool {
+	return openAIResponsesValueContainsString(prompt, want)
+}
+
+func openAIResponsesValueContainsString(value any, want string) bool {
+	switch typed := value.(type) {
+	case string:
+		return strings.Contains(typed, want)
+	case map[string]interface{}:
+		for _, nested := range typed {
+			if openAIResponsesValueContainsString(nested, want) {
+				return true
+			}
+		}
+	case []interface{}:
+		for _, nested := range typed {
+			if openAIResponsesValueContainsString(nested, want) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/coderd/x/chatd/chatloop/chatloop.go
+++ b/coderd/x/chatd/chatloop/chatloop.go
@@ -25,6 +25,7 @@ import (
 	"github.com/coder/coder/v2/coderd/x/chatd/chatdebug"
 	"github.com/coder/coder/v2/coderd/x/chatd/chaterror"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatprompt"
+	"github.com/coder/coder/v2/coderd/x/chatd/chatprovider"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatretry"
 	"github.com/coder/coder/v2/coderd/x/chatd/chattool"
 	"github.com/coder/coder/v2/codersdk"
@@ -136,6 +137,13 @@ type RunOptions struct {
 	// separate field because the conversion requires knowledge
 	// of the provider, which lives in chatd, not chatloop.
 	ProviderOptions fantasy.ProviderOptions
+
+	// OpenAIResponsesChainFallbackMessages is the sanitized full-history
+	// prompt used if a chain-mode request is still unsafe before send.
+	OpenAIResponsesChainFallbackMessages []fantasy.Message
+	// OpenAIResponsesChainFallbackProviderOptions are base provider
+	// options without PreviousResponseID for the fallback request.
+	OpenAIResponsesChainFallbackProviderOptions fantasy.ProviderOptions
 
 	// ProviderTools are provider-native tools (like web search
 	// and computer use) whose definitions are passed directly
@@ -397,6 +405,32 @@ func Run(ctx context.Context, opts RunOptions) error {
 				slog.F("step_index", step),
 				slog.F("total_steps", totalSteps),
 			)
+			if chatprovider.HasOpenAIResponsesProviderOptions(opts.ProviderOptions) {
+				sanitizedPrepared, openAIStats := chatprompt.SanitizeOpenAIResponsesMessages(prepared)
+				if openAIResponsesRemoved(openAIStats) {
+					if hasPreviousResponseID(opts.ProviderOptions) {
+						if len(opts.OpenAIResponsesChainFallbackMessages) == 0 ||
+							opts.OpenAIResponsesChainFallbackProviderOptions == nil {
+							return xerrors.New("OpenAI Responses chain fallback is required before sending sanitized prompt")
+						}
+						messages = opts.OpenAIResponsesChainFallbackMessages
+						prepared = make([]fantasy.Message, len(messages))
+						copy(prepared, messages)
+						opts.ProviderOptions = opts.OpenAIResponsesChainFallbackProviderOptions
+						if opts.DisableChainMode != nil {
+							opts.DisableChainMode()
+						}
+						openAIStats.DisabledChainMode = true
+					} else {
+						prepared = sanitizedPrepared
+					}
+					chatprompt.LogOpenAIResponsesSanitization(
+						ctx, opts.Logger, "pre_request", provider, modelName, openAIStats,
+						slog.F("step_index", step),
+						slog.F("total_steps", totalSteps),
+					)
+				}
+			}
 			if applyAnthropicCaching {
 				addAnthropicPromptCaching(prepared)
 			}
@@ -1581,6 +1615,13 @@ func addAnthropicPromptCaching(messages []fantasy.Message) {
 			messages[i].ProviderOptions = providerOption
 		}
 	}
+}
+
+func openAIResponsesRemoved(stats chatprompt.OpenAIResponsesSanitizationStats) bool {
+	return stats.RemovedToolCalls > 0 ||
+		stats.RemovedToolResults > 0 ||
+		stats.RemovedWebSearchCalls > 0 ||
+		stats.RemovedWebSearchResults > 0
 }
 
 // hasPreviousResponseID checks whether the provider options contain

--- a/coderd/x/chatd/chatprompt/sanitize_openai_responses.go
+++ b/coderd/x/chatd/chatprompt/sanitize_openai_responses.go
@@ -1,0 +1,246 @@
+package chatprompt
+
+import (
+	"context"
+
+	"charm.land/fantasy"
+
+	"cdr.dev/slog/v3"
+)
+
+// OpenAIResponsesSanitizationStats describes prompt-history changes made
+// for OpenAI Responses compatibility.
+type OpenAIResponsesSanitizationStats struct {
+	RemovedToolCalls        int
+	RemovedToolResults      int
+	RemovedWebSearchCalls   int
+	RemovedWebSearchResults int
+	DroppedMessages         int
+	DisabledChainMode       bool
+	UnsafeForChainMode      bool
+}
+
+// AnalyzeOpenAIResponsesMessages reports whether prompt history contains
+// tool-call shapes that are unsafe for OpenAI Responses chaining.
+func AnalyzeOpenAIResponsesMessages(messages []fantasy.Message) OpenAIResponsesSanitizationStats {
+	classification := classifyOpenAIResponsesMessages(messages)
+	return classification.stats
+}
+
+// SanitizeOpenAIResponsesMessages removes invalid OpenAI Responses tool-call
+// history while preserving valid content and same-role coalescing behavior.
+func SanitizeOpenAIResponsesMessages(messages []fantasy.Message) ([]fantasy.Message, OpenAIResponsesSanitizationStats) {
+	classification := classifyOpenAIResponsesMessages(messages)
+	if len(classification.remove) == 0 {
+		return messages, OpenAIResponsesSanitizationStats{}
+	}
+
+	stats := classification.stats
+	out := make([]fantasy.Message, 0, len(messages))
+	for messageIndex, msg := range messages {
+		changedMessage := false
+		var parts []fantasy.MessagePart
+		for partIndex, part := range msg.Content {
+			key := openAIResponsesPartKey{
+				messageIndex: messageIndex,
+				partIndex:    partIndex,
+			}
+			if _, remove := classification.remove[key]; remove {
+				if !changedMessage {
+					parts = make([]fantasy.MessagePart, 0, len(msg.Content)-1)
+					parts = append(parts, msg.Content[:partIndex]...)
+					changedMessage = true
+				}
+				continue
+			}
+			if changedMessage {
+				parts = append(parts, part)
+			}
+		}
+
+		if changedMessage {
+			if len(parts) == 0 {
+				stats.DroppedMessages++
+				continue
+			}
+			msg.Content = parts
+		}
+		out = appendSanitizedMessage(out, msg)
+	}
+	return out, stats
+}
+
+// LogOpenAIResponsesSanitization logs counts for prompt-history sanitization.
+func LogOpenAIResponsesSanitization(
+	ctx context.Context,
+	logger slog.Logger,
+	phase string,
+	provider string,
+	modelName string,
+	stats OpenAIResponsesSanitizationStats,
+	extra ...slog.Field,
+) {
+	hasRemoval := stats.RemovedToolCalls > 0 ||
+		stats.RemovedToolResults > 0 ||
+		stats.RemovedWebSearchCalls > 0 ||
+		stats.RemovedWebSearchResults > 0
+	if !hasRemoval && !stats.DisabledChainMode {
+		return
+	}
+
+	fields := []slog.Field{
+		slog.F("phase", phase),
+		slog.F("provider", provider),
+		slog.F("model", modelName),
+		slog.F("removed_tool_calls", stats.RemovedToolCalls),
+		slog.F("removed_tool_results", stats.RemovedToolResults),
+		slog.F("removed_web_search_calls", stats.RemovedWebSearchCalls),
+		slog.F("removed_web_search_results", stats.RemovedWebSearchResults),
+		slog.F("dropped_messages", stats.DroppedMessages),
+		slog.F("disabled_chain_mode", stats.DisabledChainMode),
+		slog.F("unsafe_for_chain_mode", stats.UnsafeForChainMode),
+	}
+	fields = append(fields, extra...)
+	logger.Warn(ctx, "sanitized OpenAI Responses prompt history", fields...)
+}
+
+type openAIResponsesPartKey struct {
+	messageIndex int
+	partIndex    int
+}
+
+type openAIResponsesOccurrence struct {
+	key       openAIResponsesPartKey
+	order     int
+	webSearch bool
+}
+
+type openAIResponsesToolHistory struct {
+	calls     []openAIResponsesOccurrence
+	results   []openAIResponsesOccurrence
+	webSearch bool
+}
+
+type openAIResponsesRemoval struct {
+	call      bool
+	webSearch bool
+}
+
+type openAIResponsesClassification struct {
+	remove map[openAIResponsesPartKey]openAIResponsesRemoval
+	stats  OpenAIResponsesSanitizationStats
+}
+
+func classifyOpenAIResponsesMessages(messages []fantasy.Message) openAIResponsesClassification {
+	classification := openAIResponsesClassification{}
+	histories := make(map[string]*openAIResponsesToolHistory)
+
+	order := 0
+	for messageIndex, msg := range messages {
+		for partIndex, part := range msg.Content {
+			key := openAIResponsesPartKey{
+				messageIndex: messageIndex,
+				partIndex:    partIndex,
+			}
+			if toolCall, ok := fantasy.AsMessagePart[fantasy.ToolCallPart](part); ok {
+				webSearch := isOpenAIResponsesWebSearchCall(toolCall)
+				if toolCall.ToolCallID == "" {
+					classification.removeToolCall(openAIResponsesOccurrence{key: key})
+					order++
+					continue
+				}
+				history := openAIResponsesHistoryForID(histories, toolCall.ToolCallID)
+				history.calls = append(history.calls, openAIResponsesOccurrence{
+					key:       key,
+					order:     order,
+					webSearch: webSearch,
+				})
+				if webSearch {
+					history.webSearch = true
+				}
+			} else if toolResult, ok := fantasy.AsMessagePart[fantasy.ToolResultPart](part); ok {
+				if toolResult.ToolCallID == "" {
+					classification.removeToolResult(openAIResponsesOccurrence{key: key})
+					order++
+					continue
+				}
+				history := openAIResponsesHistoryForID(histories, toolResult.ToolCallID)
+				history.results = append(history.results, openAIResponsesOccurrence{
+					key:   key,
+					order: order,
+				})
+			}
+			order++
+		}
+	}
+
+	for _, history := range histories {
+		invalid := history.webSearch || len(history.calls) != 1 || len(history.results) != 1
+		if !invalid && history.results[0].order < history.calls[0].order {
+			invalid = true
+		}
+		if !invalid {
+			continue
+		}
+
+		for _, call := range history.calls {
+			classification.removeToolCall(call)
+		}
+		for _, result := range history.results {
+			result.webSearch = history.webSearch
+			classification.removeToolResult(result)
+		}
+	}
+
+	return classification
+}
+
+func openAIResponsesHistoryForID(
+	histories map[string]*openAIResponsesToolHistory,
+	toolCallID string,
+) *openAIResponsesToolHistory {
+	history, ok := histories[toolCallID]
+	if ok {
+		return history
+	}
+	history = &openAIResponsesToolHistory{}
+	histories[toolCallID] = history
+	return history
+}
+
+func (c *openAIResponsesClassification) removeToolCall(occ openAIResponsesOccurrence) {
+	if c.remove == nil {
+		c.remove = make(map[openAIResponsesPartKey]openAIResponsesRemoval)
+	}
+	if _, ok := c.remove[occ.key]; ok {
+		return
+	}
+	c.remove[occ.key] = openAIResponsesRemoval{call: true, webSearch: occ.webSearch}
+	c.stats.RemovedToolCalls++
+	if occ.webSearch {
+		c.stats.RemovedWebSearchCalls++
+	}
+	c.stats.UnsafeForChainMode = true
+}
+
+func (c *openAIResponsesClassification) removeToolResult(occ openAIResponsesOccurrence) {
+	if c.remove == nil {
+		c.remove = make(map[openAIResponsesPartKey]openAIResponsesRemoval)
+	}
+	if _, ok := c.remove[occ.key]; ok {
+		return
+	}
+	c.remove[occ.key] = openAIResponsesRemoval{call: false, webSearch: occ.webSearch}
+	c.stats.RemovedToolResults++
+	if occ.webSearch {
+		c.stats.RemovedWebSearchResults++
+	}
+	c.stats.UnsafeForChainMode = true
+}
+
+func isOpenAIResponsesWebSearchCall(toolCall fantasy.ToolCallPart) bool {
+	if !toolCall.ProviderExecuted {
+		return false
+	}
+	return toolCall.ToolName == "web_search" || toolCall.ToolName == "web_search_preview"
+}

--- a/coderd/x/chatd/chatprompt/sanitize_openai_responses.go
+++ b/coderd/x/chatd/chatprompt/sanitize_openai_responses.go
@@ -84,7 +84,7 @@ func LogOpenAIResponsesSanitization(
 		stats.RemovedToolResults > 0 ||
 		stats.RemovedWebSearchCalls > 0 ||
 		stats.RemovedWebSearchResults > 0
-	if !hasRemoval && !stats.DisabledChainMode {
+	if !hasRemoval && !stats.DisabledChainMode && !stats.UnsafeForChainMode {
 		return
 	}
 

--- a/coderd/x/chatd/chatprompt/sanitize_openai_responses_test.go
+++ b/coderd/x/chatd/chatprompt/sanitize_openai_responses_test.go
@@ -556,7 +556,7 @@ func TestLogOpenAIResponsesSanitization(t *testing.T) {
 		require.Empty(t, sink.snapshotEntries())
 	})
 
-	t.Run("UnsafeOnlyDoesNotLog", func(t *testing.T) {
+	t.Run("UnsafeOnlyLogsApprovedFields", func(t *testing.T) {
 		t.Parallel()
 
 		sink := &openAIResponsesLogSink{}
@@ -571,7 +571,20 @@ func TestLogOpenAIResponsesSanitization(t *testing.T) {
 			chatprompt.OpenAIResponsesSanitizationStats{UnsafeForChainMode: true},
 		)
 
-		require.Empty(t, sink.snapshotEntries())
+		entries := sink.snapshotEntries()
+		require.Len(t, entries, 1)
+		require.Equal(t, map[string]any{
+			"phase":                      "prepare",
+			"provider":                   "openai",
+			"model":                      "gpt-4o-mini",
+			"removed_tool_calls":         0,
+			"removed_tool_results":       0,
+			"removed_web_search_calls":   0,
+			"removed_web_search_results": 0,
+			"dropped_messages":           0,
+			"disabled_chain_mode":        false,
+			"unsafe_for_chain_mode":      true,
+		}, openAIResponsesFieldsMap(entries[0].Fields))
 	})
 
 	t.Run("RemovalLogsApprovedFields", func(t *testing.T) {

--- a/coderd/x/chatd/chatprompt/sanitize_openai_responses_test.go
+++ b/coderd/x/chatd/chatprompt/sanitize_openai_responses_test.go
@@ -1,0 +1,673 @@
+package chatprompt_test
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"charm.land/fantasy"
+	fantasyopenai "charm.land/fantasy/providers/openai"
+	"github.com/stretchr/testify/require"
+
+	"cdr.dev/slog/v3"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/x/chatd/chatprompt"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+func TestSanitizeOpenAIResponsesMessages(t *testing.T) {
+	t.Parallel()
+
+	result := fantasy.ToolResultOutputContentText{Text: `{"ok":true}`}
+	textPart := fantasy.TextPart{Text: "keep text"}
+	validCall := fantasy.ToolCallPart{
+		ToolCallID: "call-valid",
+		ToolName:   "read_file",
+		Input:      `{"path":"main.go"}`,
+	}
+	validResult := fantasy.ToolResultPart{
+		ToolCallID: "call-valid",
+		Output:     result,
+	}
+	providerCall := fantasy.ToolCallPart{
+		ToolCallID:       "call-provider",
+		ToolName:         "code_interpreter",
+		Input:            `{"code":"print(1)"}`,
+		ProviderExecuted: true,
+	}
+	providerResult := fantasy.ToolResultPart{
+		ToolCallID:       "call-provider",
+		Output:           result,
+		ProviderExecuted: true,
+	}
+	orphanCall := fantasy.ToolCallPart{
+		ToolCallID: "call-orphan",
+		ToolName:   "read_file",
+		Input:      `{"path":"missing.go"}`,
+	}
+	orphanResult := fantasy.ToolResultPart{
+		ToolCallID: "call-orphan-result",
+		Output:     result,
+	}
+	webSearchCall := fantasy.ToolCallPart{
+		ToolCallID:       "call-web",
+		ToolName:         "web_search",
+		Input:            `{"query":"coder"}`,
+		ProviderExecuted: true,
+	}
+	webSearchResult := fantasy.ToolResultPart{
+		ToolCallID:       "call-web",
+		Output:           result,
+		ProviderExecuted: true,
+	}
+	webSearchPreviewCall := fantasy.ToolCallPart{
+		ToolCallID:       "call-web-preview",
+		ToolName:         "web_search_preview",
+		Input:            `{"query":"coder"}`,
+		ProviderExecuted: true,
+	}
+	webSearchPreviewResult := fantasy.ToolResultPart{
+		ToolCallID:       "call-web-preview",
+		Output:           result,
+		ProviderExecuted: true,
+	}
+
+	providerUser := "user-1"
+	partOptions := fantasy.ProviderOptions{
+		fantasyopenai.Name: &fantasyopenai.ResponsesProviderOptions{User: &providerUser},
+	}
+	reasoningPart := fantasy.ReasoningPart{
+		Text:            "keep reasoning",
+		ProviderOptions: partOptions,
+	}
+	filePart := fantasy.FilePart{
+		Filename:        "keep.txt",
+		Data:            []byte("keep file"),
+		MediaType:       "text/plain",
+		ProviderOptions: partOptions,
+	}
+
+	providerUserA := "user-a"
+	providerUserB := "user-b"
+	messageOptionsA := fantasy.ProviderOptions{
+		fantasyopenai.Name: &fantasyopenai.ResponsesProviderOptions{User: &providerUserA},
+	}
+	messageOptionsB := fantasy.ProviderOptions{
+		fantasyopenai.Name: &fantasyopenai.ResponsesProviderOptions{User: &providerUserB},
+	}
+
+	testCases := []struct {
+		name          string
+		messages      []fantasy.Message
+		want          []fantasy.Message
+		wantStats     chatprompt.OpenAIResponsesSanitizationStats
+		wantSameInput bool
+	}{
+		{
+			name: "KeepsValidLocalPair",
+			messages: []fantasy.Message{
+				{
+					Role:    fantasy.MessageRoleAssistant,
+					Content: []fantasy.MessagePart{validCall},
+				},
+				{
+					Role:    fantasy.MessageRoleTool,
+					Content: []fantasy.MessagePart{validResult},
+				},
+			},
+			want: []fantasy.Message{
+				{
+					Role:    fantasy.MessageRoleAssistant,
+					Content: []fantasy.MessagePart{validCall},
+				},
+				{
+					Role:    fantasy.MessageRoleTool,
+					Content: []fantasy.MessagePart{validResult},
+				},
+			},
+			wantSameInput: true,
+		},
+		{
+			name: "KeepsValidPairInSameAssistantMessage",
+			messages: []fantasy.Message{{
+				Role:    fantasy.MessageRoleAssistant,
+				Content: []fantasy.MessagePart{validCall, validResult},
+			}},
+			want: []fantasy.Message{{
+				Role:    fantasy.MessageRoleAssistant,
+				Content: []fantasy.MessagePart{validCall, validResult},
+			}},
+			wantSameInput: true,
+		},
+		{
+			name: "KeepsProviderExecutedNonWebPair",
+			messages: []fantasy.Message{{
+				Role:    fantasy.MessageRoleAssistant,
+				Content: []fantasy.MessagePart{providerCall, providerResult},
+			}},
+			want: []fantasy.Message{{
+				Role:    fantasy.MessageRoleAssistant,
+				Content: []fantasy.MessagePart{providerCall, providerResult},
+			}},
+			wantSameInput: true,
+		},
+		{
+			name: "DropsOrphanAssistantToolCall",
+			messages: []fantasy.Message{{
+				Role:    fantasy.MessageRoleAssistant,
+				Content: []fantasy.MessagePart{orphanCall},
+			}},
+			want: []fantasy.Message{},
+			wantStats: chatprompt.OpenAIResponsesSanitizationStats{
+				RemovedToolCalls:   1,
+				DroppedMessages:    1,
+				UnsafeForChainMode: true,
+			},
+		},
+		{
+			name: "DropsOrphanToolResult",
+			messages: []fantasy.Message{{
+				Role:    fantasy.MessageRoleTool,
+				Content: []fantasy.MessagePart{orphanResult},
+			}},
+			want: []fantasy.Message{},
+			wantStats: chatprompt.OpenAIResponsesSanitizationStats{
+				RemovedToolResults: 1,
+				DroppedMessages:    1,
+				UnsafeForChainMode: true,
+			},
+		},
+		{
+			name: "RemovesEmptyToolCallIDParts",
+			messages: []fantasy.Message{{
+				Role: fantasy.MessageRoleAssistant,
+				Content: []fantasy.MessagePart{
+					fantasy.ToolCallPart{ToolName: "read_file", Input: `{}`},
+					fantasy.ToolResultPart{Output: result},
+				},
+			}},
+			want: []fantasy.Message{},
+			wantStats: chatprompt.OpenAIResponsesSanitizationStats{
+				RemovedToolCalls:   1,
+				RemovedToolResults: 1,
+				DroppedMessages:    1,
+				UnsafeForChainMode: true,
+			},
+		},
+		{
+			name: "PreservesSurroundingContentAndOptions",
+			messages: []fantasy.Message{
+				{
+					Role: fantasy.MessageRoleAssistant,
+					Content: []fantasy.MessagePart{
+						textPart,
+						orphanCall,
+						reasoningPart,
+						filePart,
+						validCall,
+					},
+				},
+				{
+					Role:    fantasy.MessageRoleTool,
+					Content: []fantasy.MessagePart{validResult},
+				},
+			},
+			want: []fantasy.Message{
+				{
+					Role: fantasy.MessageRoleAssistant,
+					Content: []fantasy.MessagePart{
+						textPart,
+						reasoningPart,
+						filePart,
+						validCall,
+					},
+				},
+				{
+					Role:    fantasy.MessageRoleTool,
+					Content: []fantasy.MessagePart{validResult},
+				},
+			},
+			wantStats: chatprompt.OpenAIResponsesSanitizationStats{
+				RemovedToolCalls:   1,
+				UnsafeForChainMode: true,
+			},
+		},
+		{
+			name: "RemovesOnlyInvalidIDFromMixedMessage",
+			messages: []fantasy.Message{{
+				Role: fantasy.MessageRoleAssistant,
+				Content: []fantasy.MessagePart{
+					validCall,
+					orphanCall,
+					validResult,
+				},
+			}},
+			want: []fantasy.Message{{
+				Role: fantasy.MessageRoleAssistant,
+				Content: []fantasy.MessagePart{
+					validCall,
+					validResult,
+				},
+			}},
+			wantStats: chatprompt.OpenAIResponsesSanitizationStats{
+				RemovedToolCalls:   1,
+				UnsafeForChainMode: true,
+			},
+		},
+		{
+			name: "RemovesResultBeforeCall",
+			messages: []fantasy.Message{
+				{
+					Role:    fantasy.MessageRoleTool,
+					Content: []fantasy.MessagePart{validResult},
+				},
+				{
+					Role:    fantasy.MessageRoleAssistant,
+					Content: []fantasy.MessagePart{validCall},
+				},
+			},
+			want: []fantasy.Message{},
+			wantStats: chatprompt.OpenAIResponsesSanitizationStats{
+				RemovedToolCalls:   1,
+				RemovedToolResults: 1,
+				DroppedMessages:    2,
+				UnsafeForChainMode: true,
+			},
+		},
+		{
+			name: "DuplicateCallsRemoveEveryOccurrence",
+			messages: []fantasy.Message{{
+				Role: fantasy.MessageRoleAssistant,
+				Content: []fantasy.MessagePart{
+					validCall,
+					validCall,
+					validResult,
+				},
+			}},
+			want: []fantasy.Message{},
+			wantStats: chatprompt.OpenAIResponsesSanitizationStats{
+				RemovedToolCalls:   2,
+				RemovedToolResults: 1,
+				DroppedMessages:    1,
+				UnsafeForChainMode: true,
+			},
+		},
+		{
+			name: "DuplicateResultsRemoveEveryOccurrence",
+			messages: []fantasy.Message{{
+				Role: fantasy.MessageRoleAssistant,
+				Content: []fantasy.MessagePart{
+					validCall,
+					validResult,
+					validResult,
+				},
+			}},
+			want: []fantasy.Message{},
+			wantStats: chatprompt.OpenAIResponsesSanitizationStats{
+				RemovedToolCalls:   1,
+				RemovedToolResults: 2,
+				DroppedMessages:    1,
+				UnsafeForChainMode: true,
+			},
+		},
+		{
+			name: "RemovesWebSearchPair",
+			messages: []fantasy.Message{{
+				Role:    fantasy.MessageRoleAssistant,
+				Content: []fantasy.MessagePart{webSearchCall, webSearchResult},
+			}},
+			want: []fantasy.Message{},
+			wantStats: chatprompt.OpenAIResponsesSanitizationStats{
+				RemovedToolCalls:        1,
+				RemovedToolResults:      1,
+				RemovedWebSearchCalls:   1,
+				RemovedWebSearchResults: 1,
+				DroppedMessages:         1,
+				UnsafeForChainMode:      true,
+			},
+		},
+		{
+			name: "RemovesWebSearchPreviewPair",
+			messages: []fantasy.Message{{
+				Role:    fantasy.MessageRoleAssistant,
+				Content: []fantasy.MessagePart{webSearchPreviewCall, webSearchPreviewResult},
+			}},
+			want: []fantasy.Message{},
+			wantStats: chatprompt.OpenAIResponsesSanitizationStats{
+				RemovedToolCalls:        1,
+				RemovedToolResults:      1,
+				RemovedWebSearchCalls:   1,
+				RemovedWebSearchResults: 1,
+				DroppedMessages:         1,
+				UnsafeForChainMode:      true,
+			},
+		},
+		{
+			name: "CoalescesAdjacentSameRoleAfterDrop",
+			messages: []fantasy.Message{
+				{
+					Role:            fantasy.MessageRoleUser,
+					Content:         []fantasy.MessagePart{fantasy.TextPart{Text: "first"}},
+					ProviderOptions: messageOptionsA,
+				},
+				{
+					Role:    fantasy.MessageRoleAssistant,
+					Content: []fantasy.MessagePart{orphanCall},
+				},
+				{
+					Role:            fantasy.MessageRoleUser,
+					Content:         []fantasy.MessagePart{fantasy.TextPart{Text: "second"}},
+					ProviderOptions: messageOptionsB,
+				},
+			},
+			want: []fantasy.Message{{
+				Role: fantasy.MessageRoleUser,
+				Content: []fantasy.MessagePart{
+					fantasy.TextPart{Text: "first", ProviderOptions: messageOptionsA},
+					fantasy.TextPart{Text: "second", ProviderOptions: messageOptionsB},
+				},
+			}},
+			wantStats: chatprompt.OpenAIResponsesSanitizationStats{
+				RemovedToolCalls:   1,
+				DroppedMessages:    1,
+				UnsafeForChainMode: true,
+			},
+		},
+		{
+			name: "RemovesPointerFormToolCall",
+			messages: []fantasy.Message{{
+				Role: fantasy.MessageRoleAssistant,
+				Content: []fantasy.MessagePart{
+					textPart,
+					&fantasy.ToolCallPart{
+						ToolCallID: "call-pointer",
+						ToolName:   "read_file",
+						Input:      `{}`,
+					},
+				},
+			}},
+			want: []fantasy.Message{{
+				Role:    fantasy.MessageRoleAssistant,
+				Content: []fantasy.MessagePart{textPart},
+			}},
+			wantStats: chatprompt.OpenAIResponsesSanitizationStats{
+				RemovedToolCalls:   1,
+				UnsafeForChainMode: true,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, stats := chatprompt.SanitizeOpenAIResponsesMessages(tc.messages)
+
+			require.Equal(t, tc.wantStats, stats)
+			require.Equal(t, tc.want, got)
+			if tc.wantSameInput {
+				require.NotEmpty(t, got)
+				require.True(t, &got[0] == &tc.messages[0])
+			}
+		})
+	}
+}
+
+func TestAnalyzeOpenAIResponsesMessages(t *testing.T) {
+	t.Parallel()
+
+	result := fantasy.ToolResultOutputContentText{Text: `{"ok":true}`}
+	cleanMessages := []fantasy.Message{{
+		Role: fantasy.MessageRoleAssistant,
+		Content: []fantasy.MessagePart{
+			fantasy.ToolCallPart{ToolCallID: "call-clean", ToolName: "read_file", Input: `{}`},
+			fantasy.ToolResultPart{ToolCallID: "call-clean", Output: result},
+		},
+	}}
+
+	t.Run("CleanPromptReturnsZeroStats", func(t *testing.T) {
+		t.Parallel()
+
+		before := cloneOpenAIResponsesMessages(cleanMessages)
+		stats := chatprompt.AnalyzeOpenAIResponsesMessages(cleanMessages)
+
+		require.Equal(t, chatprompt.OpenAIResponsesSanitizationStats{}, stats)
+		require.Equal(t, before, cleanMessages)
+	})
+
+	t.Run("InvalidPairsAreUnsafeWithoutDroppedMessages", func(t *testing.T) {
+		t.Parallel()
+
+		messages := []fantasy.Message{{
+			Role: fantasy.MessageRoleAssistant,
+			Content: []fantasy.MessagePart{
+				fantasy.ToolCallPart{ToolCallID: "call-orphan", ToolName: "read_file", Input: `{}`},
+				fantasy.ToolResultPart{Output: result},
+			},
+		}}
+		before := cloneOpenAIResponsesMessages(messages)
+
+		stats := chatprompt.AnalyzeOpenAIResponsesMessages(messages)
+
+		require.Equal(t, chatprompt.OpenAIResponsesSanitizationStats{
+			RemovedToolCalls:   1,
+			RemovedToolResults: 1,
+			UnsafeForChainMode: true,
+		}, stats)
+		require.Equal(t, before, messages)
+	})
+
+	t.Run("WebSearchIsUnsafeWithoutDroppedMessages", func(t *testing.T) {
+		t.Parallel()
+
+		messages := []fantasy.Message{{
+			Role: fantasy.MessageRoleAssistant,
+			Content: []fantasy.MessagePart{
+				fantasy.ToolCallPart{
+					ToolCallID:       "call-web",
+					ToolName:         "web_search_preview",
+					Input:            `{}`,
+					ProviderExecuted: true,
+				},
+				fantasy.ToolResultPart{
+					ToolCallID:       "call-web",
+					Output:           result,
+					ProviderExecuted: true,
+				},
+			},
+		}}
+		before := cloneOpenAIResponsesMessages(messages)
+
+		stats := chatprompt.AnalyzeOpenAIResponsesMessages(messages)
+
+		require.Equal(t, chatprompt.OpenAIResponsesSanitizationStats{
+			RemovedToolCalls:        1,
+			RemovedToolResults:      1,
+			RemovedWebSearchCalls:   1,
+			RemovedWebSearchResults: 1,
+			UnsafeForChainMode:      true,
+		}, stats)
+		require.Equal(t, before, messages)
+	})
+}
+
+func TestSanitizeOpenAIResponsesMessages_ConvertedHistory(t *testing.T) {
+	t.Parallel()
+
+	t.Run("V1LocalToolPairStaysClean", func(t *testing.T) {
+		t.Parallel()
+
+		assistantContent, err := chatprompt.MarshalParts([]codersdk.ChatMessagePart{
+			codersdk.ChatMessageToolCall(
+				"call-v1",
+				"execute",
+				json.RawMessage(`{"command":"echo ok"}`),
+			),
+		})
+		require.NoError(t, err)
+		toolContent, err := chatprompt.MarshalParts([]codersdk.ChatMessagePart{
+			codersdk.ChatMessageToolResult(
+				"call-v1",
+				"execute",
+				json.RawMessage(`{"ok":true}`),
+				false,
+				false,
+			),
+		})
+		require.NoError(t, err)
+		prompt := convertMessagesWithoutFiles(t, []database.ChatMessage{
+			testMsgV1(codersdk.ChatMessageRoleAssistant, assistantContent),
+			testMsgV1(codersdk.ChatMessageRoleTool, toolContent),
+		})
+
+		got, stats := chatprompt.SanitizeOpenAIResponsesMessages(prompt)
+
+		require.Equal(t, chatprompt.OpenAIResponsesSanitizationStats{}, stats)
+		require.Equal(t, prompt, got)
+		require.NotEmpty(t, got)
+		require.True(t, &got[0] == &prompt[0])
+	})
+
+	t.Run("LegacyV0Skipped", func(t *testing.T) {
+		t.Parallel()
+		t.Skip("legacy V0 cannot cleanly represent provider executed OpenAI web search history")
+	})
+}
+
+func TestLogOpenAIResponsesSanitization(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ZeroStatsDoesNotLog", func(t *testing.T) {
+		t.Parallel()
+
+		sink := &openAIResponsesLogSink{}
+		logger := slog.Make(sink)
+
+		chatprompt.LogOpenAIResponsesSanitization(
+			context.Background(),
+			logger,
+			"prepare",
+			"openai",
+			"gpt-4o-mini",
+			chatprompt.OpenAIResponsesSanitizationStats{},
+		)
+
+		require.Empty(t, sink.snapshotEntries())
+	})
+
+	t.Run("UnsafeOnlyDoesNotLog", func(t *testing.T) {
+		t.Parallel()
+
+		sink := &openAIResponsesLogSink{}
+		logger := slog.Make(sink)
+
+		chatprompt.LogOpenAIResponsesSanitization(
+			context.Background(),
+			logger,
+			"prepare",
+			"openai",
+			"gpt-4o-mini",
+			chatprompt.OpenAIResponsesSanitizationStats{UnsafeForChainMode: true},
+		)
+
+		require.Empty(t, sink.snapshotEntries())
+	})
+
+	t.Run("RemovalLogsApprovedFields", func(t *testing.T) {
+		t.Parallel()
+
+		sink := &openAIResponsesLogSink{}
+		logger := slog.Make(sink)
+		stats := chatprompt.OpenAIResponsesSanitizationStats{
+			RemovedToolCalls:        2,
+			RemovedToolResults:      1,
+			RemovedWebSearchCalls:   1,
+			RemovedWebSearchResults: 1,
+			DroppedMessages:         1,
+			UnsafeForChainMode:      true,
+		}
+
+		chatprompt.LogOpenAIResponsesSanitization(
+			context.Background(),
+			logger,
+			"prepare",
+			"openai",
+			"gpt-4o-mini",
+			stats,
+			slog.F("extra_allowed", true),
+		)
+
+		entries := sink.snapshotEntries()
+		require.Len(t, entries, 1)
+		require.Equal(t, slog.LevelWarn, entries[0].Level)
+		require.Equal(t, "sanitized OpenAI Responses prompt history", entries[0].Message)
+		require.Equal(t, map[string]any{
+			"phase":                      "prepare",
+			"provider":                   "openai",
+			"model":                      "gpt-4o-mini",
+			"removed_tool_calls":         2,
+			"removed_tool_results":       1,
+			"removed_web_search_calls":   1,
+			"removed_web_search_results": 1,
+			"dropped_messages":           1,
+			"disabled_chain_mode":        false,
+			"unsafe_for_chain_mode":      true,
+			"extra_allowed":              true,
+		}, openAIResponsesFieldsMap(entries[0].Fields))
+	})
+
+	t.Run("DisabledChainModeLogsWithoutRemoval", func(t *testing.T) {
+		t.Parallel()
+
+		sink := &openAIResponsesLogSink{}
+		logger := slog.Make(sink)
+
+		chatprompt.LogOpenAIResponsesSanitization(
+			context.Background(),
+			logger,
+			"prepare",
+			"openai",
+			"gpt-4o-mini",
+			chatprompt.OpenAIResponsesSanitizationStats{DisabledChainMode: true},
+		)
+
+		require.Len(t, sink.snapshotEntries(), 1)
+	})
+}
+
+func cloneOpenAIResponsesMessages(messages []fantasy.Message) []fantasy.Message {
+	clone := make([]fantasy.Message, len(messages))
+	copy(clone, messages)
+	for i := range clone {
+		clone[i].Content = append([]fantasy.MessagePart(nil), messages[i].Content...)
+	}
+	return clone
+}
+
+type openAIResponsesLogSink struct {
+	mu      sync.Mutex
+	entries []slog.SinkEntry
+}
+
+func (s *openAIResponsesLogSink) LogEntry(_ context.Context, entry slog.SinkEntry) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.entries = append(s.entries, entry)
+}
+
+func (*openAIResponsesLogSink) Sync() {}
+
+func (s *openAIResponsesLogSink) snapshotEntries() []slog.SinkEntry {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]slog.SinkEntry(nil), s.entries...)
+}
+
+func openAIResponsesFieldsMap(fields []slog.Field) map[string]any {
+	result := make(map[string]any, len(fields))
+	for _, field := range fields {
+		result[field.Name] = field.Value
+	}
+	return result
+}

--- a/coderd/x/chatd/chatprovider/chatprovider.go
+++ b/coderd/x/chatd/chatprovider/chatprovider.go
@@ -1385,6 +1385,20 @@ func ProviderOptionsFromChatModelConfig(
 	return result
 }
 
+// HasOpenAIResponsesProviderOptions reports whether opts contains a
+// non-nil OpenAI Responses provider options entry.
+func HasOpenAIResponsesProviderOptions(opts fantasy.ProviderOptions) bool {
+	if opts == nil {
+		return false
+	}
+	raw, ok := opts[fantasyopenai.Name]
+	if !ok {
+		return false
+	}
+	respOpts, ok := raw.(*fantasyopenai.ResponsesProviderOptions)
+	return ok && respOpts != nil
+}
+
 // IsResponsesStoreEnabled checks if the OpenAI Responses provider
 // options are present and have Store set to true. When true, the
 // provider stores conversation history server-side, enabling

--- a/coderd/x/chatd/chatprovider/chatprovider_test.go
+++ b/coderd/x/chatd/chatprovider/chatprovider_test.go
@@ -1228,3 +1228,106 @@ func TestMergeMissingProviderOptions_OpenRouterNested(t *testing.T) {
 	require.Equal(t, []string{"int8"}, options.OpenRouter.Provider.Quantizations)
 	require.Equal(t, "latency", *options.OpenRouter.Provider.Sort)
 }
+
+func TestHasOpenAIResponsesProviderOptions(t *testing.T) {
+	t.Parallel()
+
+	var typedNil *fantasyopenai.ResponsesProviderOptions
+	testCases := []struct {
+		name string
+		opts fantasy.ProviderOptions
+		want bool
+	}{
+		{
+			name: "NilOptions",
+		},
+		{
+			name: "MissingOpenAIKey",
+			opts: fantasy.ProviderOptions{
+				fantasyanthropic.Name: &fantasyanthropic.ProviderOptions{},
+			},
+		},
+		{
+			name: "WrongOpenAIType",
+			opts: fantasy.ProviderOptions{
+				fantasyopenai.Name: &fantasyanthropic.ProviderOptions{},
+			},
+		},
+		{
+			name: "TypedNilResponsesOptions",
+			opts: fantasy.ProviderOptions{
+				fantasyopenai.Name: typedNil,
+			},
+		},
+		{
+			name: "ResponsesOptions",
+			opts: fantasy.ProviderOptions{
+				fantasyopenai.Name: &fantasyopenai.ResponsesProviderOptions{},
+			},
+			want: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := chatprovider.HasOpenAIResponsesProviderOptions(tc.opts)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestIsResponsesStoreEnabled(t *testing.T) {
+	t.Parallel()
+
+	storeTrue := true
+	storeFalse := false
+	testCases := []struct {
+		name string
+		opts fantasy.ProviderOptions
+		want bool
+	}{
+		{
+			name: "NilOptions",
+		},
+		{
+			name: "MissingOpenAIKey",
+			opts: fantasy.ProviderOptions{},
+		},
+		{
+			name: "WrongOpenAIType",
+			opts: fantasy.ProviderOptions{
+				fantasyopenai.Name: &fantasyanthropic.ProviderOptions{},
+			},
+		},
+		{
+			name: "NilStore",
+			opts: fantasy.ProviderOptions{
+				fantasyopenai.Name: &fantasyopenai.ResponsesProviderOptions{},
+			},
+		},
+		{
+			name: "StoreFalse",
+			opts: fantasy.ProviderOptions{
+				fantasyopenai.Name: &fantasyopenai.ResponsesProviderOptions{Store: &storeFalse},
+			},
+		},
+		{
+			name: "StoreTrue",
+			opts: fantasy.ProviderOptions{
+				fantasyopenai.Name: &fantasyopenai.ResponsesProviderOptions{Store: &storeTrue},
+			},
+			want: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := chatprovider.IsResponsesStoreEnabled(tc.opts)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/coderd/x/chatd/chattest/openai.go
+++ b/coderd/x/chatd/chattest/openai.go
@@ -50,7 +50,7 @@ type OpenAIRequest struct {
 	Messages           []OpenAIMessage `json:"messages"`
 	Stream             bool            `json:"stream,omitempty"`
 	Tools              []OpenAITool    `json:"tools,omitempty"`
-	Prompt             []interface{}   `json:"prompt,omitempty"` // For responses API
+	Prompt             []interface{}   `json:"input,omitempty"` // For responses API
 	Store              *bool           `json:"store,omitempty"`
 	PreviousResponseID *string         `json:"previous_response_id,omitempty"`
 	// TODO: encoding/json ignores inline tags. Add custom UnmarshalJSON to capture unknown keys.


### PR DESCRIPTION
> Mux opened this PR on behalf of Mike.

OpenAI Responses can reject replayed chat history when provider tool calls are orphaned, duplicated, ordered after their result, or when replayed web search lacks its original reasoning dependency.

This adds an OpenAI Responses prompt-history sanitizer for chatd, removes unsafe tool-call/tool-result history before provider requests, and disables `previous_response_id` chain mode for unsafe turns so bad server-side state is not reused. Clean histories still use chain mode.
