### PR TITLE
feat(site): add /mux dashboard page

### DIFF
--- a/site/src/modules/dashboard/Navbar/NavbarView.tsx
+++ b/site/src/modules/dashboard/Navbar/NavbarView.tsx
@@ -207,6 +207,14 @@ const NavItems: FC<NavItemsProps> = ({ className, user, canCreateChat }) => {
 			</NavLink>
 			<TasksNavItem user={user} />
 			<AgentsNavItem canCreateChat={canCreateChat} />
+			<NavLink
+				className={({ isActive }) => {
+					return cn(linkStyles.default, { [linkStyles.active]: isActive });
+				}}
+				to="/mux"
+			>
+				Mux
+			</NavLink>
 		</nav>
 	);
 };

--- a/site/src/pages/MuxPage/MuxIframe.tsx
+++ b/site/src/pages/MuxPage/MuxIframe.tsx
@@ -1,0 +1,208 @@
+import { ExternalLinkIcon } from "lucide-react";
+import type { FC } from "react";
+import { Link as RouterLink } from "react-router";
+import type { Workspace } from "#/api/typesGenerated";
+import { Alert, AlertDescription, AlertTitle } from "#/components/Alert/Alert";
+import { Button } from "#/components/Button/Button";
+import { Link } from "#/components/Link/Link";
+import { Spinner } from "#/components/Spinner/Spinner";
+import { useProxy } from "#/contexts/ProxyContext";
+import { useAppLink } from "#/modules/apps/useAppLink";
+import type { MuxAppCandidate } from "./muxApps";
+
+type MuxIframeProps = {
+	workspace: Workspace;
+	candidate: MuxAppCandidate;
+};
+
+export const MuxIframe: FC<MuxIframeProps> = ({ workspace, candidate }) => {
+	const { agent, app } = candidate;
+	const link = useAppLink(app, { agent, workspace });
+	const proxy = useProxy();
+	const workspacePath = `/@${workspace.owner_name}/${workspace.name}`;
+	const shouldDisplayWildcardWarning =
+		app.subdomain && !proxy.proxy?.preferredWildcardHostname;
+
+	return (
+		<div className="flex h-full min-h-0 flex-col bg-surface-primary">
+			<div className="flex flex-col gap-3 border-0 border-b border-solid border-border px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+				<div className="min-w-0">
+					<p className="m-0 truncate text-sm font-medium text-content-primary">
+						{workspace.owner_name}/{workspace.name}
+					</p>
+					<p className="m-0 truncate text-xs text-content-secondary">
+						{app.display_name ?? app.slug} on agent {agent.name}
+					</p>
+				</div>
+				<Link
+					href={link.href}
+					target="_blank"
+					rel="noreferrer"
+					onClick={link.onClick}
+					className="w-fit"
+				>
+					Open in new tab
+				</Link>
+			</div>
+
+			<div className="min-h-0 flex-1">
+				{workspace.latest_build.status === "stopped" ? (
+					<StoppedWorkspace workspacePath={workspacePath} />
+				) : shouldDisplayWildcardWarning ? (
+					<MissingWildcardHostnameWarning />
+				) : app.health === "healthy" || app.health === "disabled" ? (
+					<MuxAppFrame src={link.href} title={link.label} />
+				) : app.health === "initializing" ? (
+					<InitializingMuxApp />
+				) : app.health === "unhealthy" ? (
+					<UnhealthyMuxApp
+						workspacePath={workspacePath}
+						healthcheckUrl={app.healthcheck?.url}
+					/>
+				) : (
+					<UnknownHealthState />
+				)}
+			</div>
+		</div>
+	);
+};
+
+type MuxAppFrameProps = {
+	src: string;
+	title: string;
+};
+
+const MuxAppFrame: FC<MuxAppFrameProps> = ({ src, title }) => {
+	return (
+		<iframe
+			data-testid="mux-iframe"
+			src={src}
+			title={title}
+			loading="eager"
+			allow="clipboard-read; clipboard-write"
+			className="h-full w-full border-0"
+		/>
+	);
+};
+
+type StoppedWorkspaceProps = {
+	workspacePath: string;
+};
+
+const StoppedWorkspace: FC<StoppedWorkspaceProps> = ({ workspacePath }) => {
+	return (
+		<div className="flex h-full flex-col items-center justify-center gap-4 p-6 text-center">
+			<div>
+				<h2 className="m-0 text-xl font-medium text-content-primary">
+					Start this workspace to use Mux
+				</h2>
+				<p className="m-0 mt-2 max-w-md text-sm text-content-secondary">
+					Mux is available in this workspace, but the workspace is stopped.
+					Start it from the workspace page before opening the embedded app.
+				</p>
+			</div>
+			<div className="flex flex-wrap items-center justify-center gap-3">
+				<Button asChild>
+					<RouterLink to={workspacePath}>Start workspace</RouterLink>
+				</Button>
+				<Link href={workspacePath} showExternalIcon={false}>
+					Open workspace
+				</Link>
+			</div>
+		</div>
+	);
+};
+
+const MissingWildcardHostnameWarning: FC = () => {
+	return (
+		<div className="flex h-full items-center justify-center p-6">
+			<Alert severity="warning" prominent className="max-w-2xl">
+				<AlertTitle>
+					Workspace app wildcard hostname is not configured
+				</AlertTitle>
+				<AlertDescription>
+					This Mux app uses subdomains, but this deployment does not have a
+					preferred wildcard hostname configured. Configure a wildcard hostname
+					for workspace apps, then refresh this page.
+				</AlertDescription>
+			</Alert>
+		</div>
+	);
+};
+
+const InitializingMuxApp: FC = () => {
+	return (
+		<div
+			role="status"
+			aria-live="polite"
+			className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center"
+		>
+			<Spinner loading />
+			<div>
+				<h2 className="m-0 text-xl font-medium text-content-primary">
+					Mux is starting
+				</h2>
+				<p className="m-0 mt-2 text-sm text-content-secondary">
+					Waiting for the Mux app healthcheck to pass.
+				</p>
+			</div>
+		</div>
+	);
+};
+
+type UnhealthyMuxAppProps = {
+	workspacePath: string;
+	healthcheckUrl?: string;
+};
+
+const UnhealthyMuxApp: FC<UnhealthyMuxAppProps> = ({
+	workspacePath,
+	healthcheckUrl,
+}) => {
+	return (
+		<div className="flex h-full items-center justify-center p-6">
+			<Alert
+				severity="error"
+				prominent
+				className="max-w-2xl"
+				actions={
+					<Button asChild size="sm" variant="outline">
+						<RouterLink to={workspacePath}>
+							<ExternalLinkIcon aria-hidden="true" />
+							Open workspace logs
+						</RouterLink>
+					</Button>
+				}
+			>
+				<AlertTitle>Mux app healthcheck is failing</AlertTitle>
+				<AlertDescription>
+					The Mux app is reporting an unhealthy state. Check the workspace logs
+					and verify the Mux app healthcheck.
+					{healthcheckUrl ? (
+						<span className="mt-2 block">
+							Healthcheck URL:{" "}
+							<code className="select-all rounded-sm bg-surface-tertiary px-1 py-0.5 font-mono text-content-primary">
+								{healthcheckUrl}
+							</code>
+							.
+						</span>
+					) : null}
+				</AlertDescription>
+			</Alert>
+		</div>
+	);
+};
+
+const UnknownHealthState: FC = () => {
+	return (
+		<div className="flex h-full items-center justify-center p-6">
+			<Alert severity="error" prominent className="max-w-2xl">
+				<AlertTitle>Mux app health state is unknown</AlertTitle>
+				<AlertDescription>
+					Refresh this page or open the app in a new tab after the workspace
+					finishes reporting app health.
+				</AlertDescription>
+			</Alert>
+		</div>
+	);
+};

--- a/site/src/pages/MuxPage/MuxIframe.tsx
+++ b/site/src/pages/MuxPage/MuxIframe.tsx
@@ -7,6 +7,7 @@ import { Button } from "#/components/Button/Button";
 import { Link } from "#/components/Link/Link";
 import { Spinner } from "#/components/Spinner/Spinner";
 import { useProxy } from "#/contexts/ProxyContext";
+import { getAppHref } from "#/modules/apps/apps";
 import { useAppLink } from "#/modules/apps/useAppLink";
 import type { MuxAppCandidate } from "./muxApps";
 
@@ -19,6 +20,12 @@ export const MuxIframe: FC<MuxIframeProps> = ({ workspace, candidate }) => {
 	const { agent, app } = candidate;
 	const link = useAppLink(app, { agent, workspace });
 	const proxy = useProxy();
+	// In production, the app's preferred mode is used for isolation. In dev,
+	// the frontend can be on a different origin than the backend, so force
+	// path-app mode so the Vite dev proxy can strip CSP frame-ancestors.
+	const src = import.meta.env.DEV
+		? getAppHref(app, { agent, workspace, path: "", host: "" })
+		: link.href;
 	const workspacePath = `/@${workspace.owner_name}/${workspace.name}`;
 	const shouldDisplayWildcardWarning =
 		app.subdomain && !proxy.proxy?.preferredWildcardHostname;
@@ -51,7 +58,7 @@ export const MuxIframe: FC<MuxIframeProps> = ({ workspace, candidate }) => {
 				) : shouldDisplayWildcardWarning ? (
 					<MissingWildcardHostnameWarning />
 				) : app.health === "healthy" || app.health === "disabled" ? (
-					<MuxAppFrame src={link.href} title={link.label} />
+					<MuxAppFrame src={src} title={link.label} />
 				) : app.health === "initializing" ? (
 					<InitializingMuxApp />
 				) : app.health === "unhealthy" ? (

--- a/site/src/pages/MuxPage/MuxPage.stories.tsx
+++ b/site/src/pages/MuxPage/MuxPage.stories.tsx
@@ -24,6 +24,15 @@ import {
 import MuxPage from "./MuxPage";
 import { getMuxCandidatesFromWorkspace, pickPreferredMuxApp } from "./muxApps";
 
+const muxRouteParameters = (searchParams?: Record<string, string>) =>
+	reactRouterParameters({
+		location: { path: "/mux", searchParams },
+		routing: { path: "/mux" },
+	});
+
+const routeWithWorkspace = (workspace: Workspace) =>
+	muxRouteParameters({ workspace: workspace.id });
+
 const meta = {
 	title: "pages/MuxPage/MuxPage",
 	component: MuxPage,
@@ -34,10 +43,7 @@ const meta = {
 		permissions: {
 			viewDeploymentConfig: false,
 		},
-		reactRouter: reactRouterParameters({
-			location: { path: "/mux" },
-			routing: { path: "/mux" },
-		}),
+		reactRouter: muxRouteParameters(),
 	},
 } satisfies Meta<typeof MuxPage>;
 
@@ -136,6 +142,13 @@ const secondHealthyWorkspace = workspaceWithApps({
 	apps: [muxApp({ id: "mux-beta", display_name: "Mux Beta" })],
 });
 
+const stoppedWorkspace = workspaceWithApps({
+	id: "workspace-stopped",
+	name: "stopped",
+	status: "stopped",
+	apps: [muxApp({ id: "mux-stopped" })],
+});
+
 export const LoadingWorkspaces: Story = {
 	beforeEach: () => {
 		spyOn(API, "getWorkspaces").mockImplementation(() => new Promise(() => {}));
@@ -188,25 +201,59 @@ export const MultipleMuxCandidates: Story = {
 		const body = within(canvasElement.ownerDocument.body);
 		const user = userEvent.setup();
 
-		await step("Select the first workspace", async () => {
+		await step("Show launcher until a workspace is selected", async () => {
+			const launchButton = await canvas.findByRole("button", {
+				name: /^launch$/i,
+			});
+			expect(launchButton).toBeDisabled();
+			expect(await canvas.findByText("Select a workspace")).toBeVisible();
+		});
+
+		await step("Select the first workspace and launch", async () => {
 			await user.click(
 				await canvas.findByRole("button", { name: /select workspace/i }),
 			);
 			await user.click(await body.findByText(healthyWorkspace.name));
 
+			const launchButton = await canvas.findByRole("button", {
+				name: /^launch$/i,
+			});
+			expect(launchButton).toBeEnabled();
+			expect(
+				await canvas.findByRole("button", { name: /select workspace/i }),
+			).toHaveTextContent(`${MockUserOwner.username}/${healthyWorkspace.name}`);
+
+			await user.click(launchButton);
+
 			const frame = await canvas.findByTestId("mux-iframe");
 			expect(frame).toHaveAttribute("title", "Mux Alpha");
 			expect(frame).toHaveAttribute("src", expectedMuxHref(healthyWorkspace));
 			expect(
-				await canvas.findByRole("button", { name: /select workspace/i }),
-			).toHaveTextContent(`${MockUserOwner.username}/${healthyWorkspace.name}`);
+				await canvas.findByRole("button", { name: /change workspace/i }),
+			).toBeVisible();
+			expect(
+				await canvas.findByRole("link", { name: /open in new tab/i }),
+			).toHaveAttribute("href", expectedMuxHref(healthyWorkspace));
+			expect(
+				canvas.queryByRole("button", { name: /select workspace/i }),
+			).not.toBeInTheDocument();
 		});
 
-		await step("Select the second workspace", async () => {
+		await step("Change workspace and launch the second workspace", async () => {
+			await user.click(
+				await canvas.findByRole("button", { name: /change workspace/i }),
+			);
+			expect(
+				await canvas.findByRole("button", { name: /^launch$/i }),
+			).toBeDisabled();
+
 			await user.click(
 				await canvas.findByRole("button", { name: /select workspace/i }),
 			);
 			await user.click(await body.findByText(secondHealthyWorkspace.name));
+			await user.click(
+				await canvas.findByRole("button", { name: /^launch$/i }),
+			);
 
 			await waitFor(() => {
 				const frame = canvas.getByTestId("mux-iframe");
@@ -215,17 +262,21 @@ export const MultipleMuxCandidates: Story = {
 					"src",
 					expectedMuxHref(secondHealthyWorkspace),
 				);
-				expect(
-					canvas.getByRole("button", { name: /select workspace/i }),
-				).toHaveTextContent(
-					`${MockUserOwner.username}/${secondHealthyWorkspace.name}`,
-				);
 			});
 		});
 	},
 };
 
 export const MultipleMuxAppsPreferDefaultSlug: Story = {
+	parameters: {
+		reactRouter: routeWithWorkspace(
+			workspaceWithApps({
+				id: "workspace-multiple-apps",
+				name: "multiple-apps",
+				apps: [muxApp()],
+			}),
+		),
+	},
 	beforeEach: () => {
 		mockWorkspaces([
 			workspaceWithApps({
@@ -257,7 +308,10 @@ export const MultipleMuxAppsPreferDefaultSlug: Story = {
 	},
 };
 
-export const SelectedRunningHealthyMuxApp: Story = {
+export const Launched: Story = {
+	parameters: {
+		reactRouter: routeWithWorkspace(healthyWorkspace),
+	},
 	beforeEach: () => {
 		mockWorkspaces([healthyWorkspace]);
 	},
@@ -271,35 +325,50 @@ export const SelectedRunningHealthyMuxApp: Story = {
 		expect(frame).toHaveAttribute("title", "Mux Alpha");
 		expect(frame).toHaveAttribute("src", expectedMuxHref(healthyWorkspace));
 		expect(openLink).toHaveAttribute("href", expectedMuxHref(healthyWorkspace));
+		expect(
+			await canvas.findByRole("button", { name: /change workspace/i }),
+		).toBeVisible();
+		expect(
+			canvas.queryByRole("button", { name: /select workspace/i }),
+		).not.toBeInTheDocument();
+		expect(canvas.queryByText(/open the mux app/i)).not.toBeInTheDocument();
 	},
 };
 
 export const SelectedStoppedWorkspace: Story = {
 	beforeEach: () => {
-		mockWorkspaces([
-			workspaceWithApps({
-				id: "workspace-stopped",
-				name: "stopped",
-				status: "stopped",
-				apps: [muxApp({ id: "mux-stopped" })],
-			}),
-		]);
+		mockWorkspaces([stoppedWorkspace]);
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		const startLink = await canvas.findByRole("link", {
-			name: /start workspace/i,
+		const body = within(canvasElement.ownerDocument.body);
+		const user = userEvent.setup();
+
+		await user.click(
+			await canvas.findByRole("button", { name: /select workspace/i }),
+		);
+		await user.click(await body.findByText(stoppedWorkspace.name));
+
+		const workspaceLink = await canvas.findByRole("link", {
+			name: /open workspace/i,
 		});
 
-		expect(startLink).toHaveAttribute(
+		expect(workspaceLink).toHaveAttribute(
 			"href",
 			`/@${MockUserOwner.username}/stopped`,
 		);
 		expect(canvas.queryByTestId("mux-iframe")).not.toBeInTheDocument();
+		expect(
+			canvas.queryByRole("button", { name: /^launch$/i }),
+		).not.toBeInTheDocument();
+		expect(await canvas.findByText("Start workspace to launch")).toBeVisible();
 	},
 };
 
 export const MuxAppInitializing: Story = {
+	parameters: {
+		reactRouter: muxRouteParameters({ workspace: "workspace-initializing" }),
+	},
 	beforeEach: () => {
 		mockWorkspaces([
 			workspaceWithApps({
@@ -319,6 +388,9 @@ export const MuxAppInitializing: Story = {
 };
 
 export const MuxAppUnhealthy: Story = {
+	parameters: {
+		reactRouter: muxRouteParameters({ workspace: "workspace-unhealthy" }),
+	},
 	beforeEach: () => {
 		mockWorkspaces([
 			workspaceWithApps({
@@ -350,6 +422,9 @@ export const MuxAppUnhealthy: Story = {
 };
 
 export const SubdomainMissingWildcardHostname: Story = {
+	parameters: {
+		reactRouter: muxRouteParameters({ workspace: "workspace-subdomain" }),
+	},
 	beforeEach: () => {
 		mockWorkspaces([
 			workspaceWithApps({

--- a/site/src/pages/MuxPage/MuxPage.stories.tsx
+++ b/site/src/pages/MuxPage/MuxPage.stories.tsx
@@ -1,0 +1,377 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, spyOn, userEvent, waitFor, within } from "storybook/test";
+import { reactRouterParameters } from "storybook-addon-remix-react-router";
+import { API } from "#/api/api";
+import type {
+	Workspace,
+	WorkspaceAgent,
+	WorkspaceApp,
+	WorkspaceStatus,
+} from "#/api/typesGenerated";
+import {
+	MockStoppedWorkspace,
+	MockUserOwner,
+	MockWorkspace,
+	MockWorkspaceAgent,
+	MockWorkspaceApp,
+	MockWorkspaceResource,
+} from "#/testHelpers/entities";
+import {
+	withAuthProvider,
+	withDashboardProvider,
+	withProxyProvider,
+} from "#/testHelpers/storybook";
+import MuxPage from "./MuxPage";
+import { getMuxCandidatesFromWorkspace, pickPreferredMuxApp } from "./muxApps";
+
+const meta = {
+	title: "pages/MuxPage/MuxPage",
+	component: MuxPage,
+	decorators: [withAuthProvider, withDashboardProvider, withProxyProvider()],
+	parameters: {
+		layout: "fullscreen",
+		user: MockUserOwner,
+		permissions: {
+			viewDeploymentConfig: false,
+		},
+		reactRouter: reactRouterParameters({
+			location: { path: "/mux" },
+			routing: { path: "/mux" },
+		}),
+	},
+} satisfies Meta<typeof MuxPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const muxApp = (overrides: Partial<WorkspaceApp> = {}): WorkspaceApp => ({
+	...MockWorkspaceApp,
+	id: "mux-app",
+	slug: "mux",
+	display_name: "Mux",
+	icon: "/icon/mux.svg",
+	health: "healthy",
+	open_in: "tab",
+	...overrides,
+});
+
+type MakeWorkspaceOptions = {
+	id: string;
+	name: string;
+	apps: readonly WorkspaceApp[];
+	status?: WorkspaceStatus;
+};
+
+const workspaceWithApps = ({
+	id,
+	name,
+	apps,
+	status = "running",
+}: MakeWorkspaceOptions): Workspace => {
+	const baseWorkspace =
+		status === "stopped" ? MockStoppedWorkspace : MockWorkspace;
+	const agent: WorkspaceAgent = {
+		...MockWorkspaceAgent,
+		id: `${id}-agent`,
+		name: "main",
+		apps,
+	};
+
+	return {
+		...baseWorkspace,
+		id,
+		name,
+		owner_name: MockUserOwner.username,
+		latest_build: {
+			...baseWorkspace.latest_build,
+			status,
+			workspace_id: id,
+			workspace_name: name,
+			workspace_owner_name: MockUserOwner.username,
+			resources: [
+				{
+					...MockWorkspaceResource,
+					id: `${id}-resource`,
+					agents: [agent],
+				},
+			],
+		},
+	};
+};
+
+const getPreferredMuxCandidate = (workspace: Workspace) => {
+	const candidate = pickPreferredMuxApp(
+		getMuxCandidatesFromWorkspace(workspace),
+	);
+	if (!candidate) {
+		throw new Error(`Workspace ${workspace.name} does not have a Mux app.`);
+	}
+	return candidate;
+};
+
+const expectedMuxHref = (workspace: Workspace) => {
+	const { agent, app } = getPreferredMuxCandidate(workspace);
+	return `/@${workspace.owner_name}/${workspace.name}.${agent.name}/apps/${encodeURIComponent(app.slug)}/`;
+};
+
+const mockWorkspaces = (
+	workspaces: readonly Workspace[],
+	count = workspaces.length,
+) => {
+	spyOn(API, "getWorkspaces").mockResolvedValue({
+		workspaces,
+		count,
+	});
+};
+
+const healthyWorkspace = workspaceWithApps({
+	id: "workspace-alpha",
+	name: "alpha",
+	apps: [muxApp({ id: "mux-alpha", display_name: "Mux Alpha" })],
+});
+
+const secondHealthyWorkspace = workspaceWithApps({
+	id: "workspace-beta",
+	name: "beta",
+	apps: [muxApp({ id: "mux-beta", display_name: "Mux Beta" })],
+});
+
+export const LoadingWorkspaces: Story = {
+	beforeEach: () => {
+		spyOn(API, "getWorkspaces").mockImplementation(() => new Promise(() => {}));
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(await canvas.findByRole("status")).toHaveTextContent(/loading/i);
+	},
+};
+
+export const EmptyNoWorkspaces: Story = {
+	beforeEach: () => {
+		mockWorkspaces([], 0);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(await canvas.findByText("No workspaces yet")).toBeVisible();
+	},
+};
+
+export const EmptyNoMuxWorkspaces: Story = {
+	beforeEach: () => {
+		mockWorkspaces([
+			workspaceWithApps({
+				id: "workspace-no-mux",
+				name: "no-mux",
+				apps: [
+					{
+						...MockWorkspaceApp,
+						id: "code-app",
+						slug: "code",
+						icon: "/icon/code.svg",
+					},
+				],
+			}),
+		]);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(await canvas.findByText("No Mux workspaces found")).toBeVisible();
+	},
+};
+
+export const MultipleMuxCandidates: Story = {
+	beforeEach: () => {
+		mockWorkspaces([healthyWorkspace, secondHealthyWorkspace]);
+	},
+	play: async ({ canvasElement, step }) => {
+		const canvas = within(canvasElement);
+		const body = within(canvasElement.ownerDocument.body);
+		const user = userEvent.setup();
+
+		await step("Select the first workspace", async () => {
+			await user.click(
+				await canvas.findByRole("button", { name: /select workspace/i }),
+			);
+			await user.click(await body.findByText(healthyWorkspace.name));
+
+			const frame = await canvas.findByTestId("mux-iframe");
+			expect(frame).toHaveAttribute("title", "Mux Alpha");
+			expect(frame).toHaveAttribute("src", expectedMuxHref(healthyWorkspace));
+			expect(
+				await canvas.findByRole("button", { name: /select workspace/i }),
+			).toHaveTextContent(`${MockUserOwner.username}/${healthyWorkspace.name}`);
+		});
+
+		await step("Select the second workspace", async () => {
+			await user.click(
+				await canvas.findByRole("button", { name: /select workspace/i }),
+			);
+			await user.click(await body.findByText(secondHealthyWorkspace.name));
+
+			await waitFor(() => {
+				const frame = canvas.getByTestId("mux-iframe");
+				expect(frame).toHaveAttribute("title", "Mux Beta");
+				expect(frame).toHaveAttribute(
+					"src",
+					expectedMuxHref(secondHealthyWorkspace),
+				);
+				expect(
+					canvas.getByRole("button", { name: /select workspace/i }),
+				).toHaveTextContent(
+					`${MockUserOwner.username}/${secondHealthyWorkspace.name}`,
+				);
+			});
+		});
+	},
+};
+
+export const MultipleMuxAppsPreferDefaultSlug: Story = {
+	beforeEach: () => {
+		mockWorkspaces([
+			workspaceWithApps({
+				id: "workspace-multiple-apps",
+				name: "multiple-apps",
+				apps: [
+					muxApp({
+						id: "z-mux",
+						slug: "z-mux",
+						display_name: "Z Mux",
+					}),
+					muxApp({
+						id: "default-mux",
+						slug: "mux",
+						display_name: "Preferred Mux",
+					}),
+				],
+			}),
+		]);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const frame = await canvas.findByTestId("mux-iframe");
+		expect(frame).toHaveAttribute("title", "Preferred Mux");
+		expect(frame).toHaveAttribute(
+			"src",
+			`/@${MockUserOwner.username}/multiple-apps.main/apps/mux/`,
+		);
+	},
+};
+
+export const SelectedRunningHealthyMuxApp: Story = {
+	beforeEach: () => {
+		mockWorkspaces([healthyWorkspace]);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const frame = await canvas.findByTestId("mux-iframe");
+		const openLink = await canvas.findByRole("link", {
+			name: /open in new tab/i,
+		});
+
+		expect(frame).toHaveAttribute("title", "Mux Alpha");
+		expect(frame).toHaveAttribute("src", expectedMuxHref(healthyWorkspace));
+		expect(openLink).toHaveAttribute("href", expectedMuxHref(healthyWorkspace));
+	},
+};
+
+export const SelectedStoppedWorkspace: Story = {
+	beforeEach: () => {
+		mockWorkspaces([
+			workspaceWithApps({
+				id: "workspace-stopped",
+				name: "stopped",
+				status: "stopped",
+				apps: [muxApp({ id: "mux-stopped" })],
+			}),
+		]);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const startLink = await canvas.findByRole("link", {
+			name: /start workspace/i,
+		});
+
+		expect(startLink).toHaveAttribute(
+			"href",
+			`/@${MockUserOwner.username}/stopped`,
+		);
+		expect(canvas.queryByTestId("mux-iframe")).not.toBeInTheDocument();
+	},
+};
+
+export const MuxAppInitializing: Story = {
+	beforeEach: () => {
+		mockWorkspaces([
+			workspaceWithApps({
+				id: "workspace-initializing",
+				name: "initializing",
+				apps: [muxApp({ id: "mux-initializing", health: "initializing" })],
+			}),
+		]);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(await canvas.findByText("Mux is starting")).toBeVisible();
+		expect(canvas.getByRole("status")).toHaveTextContent(
+			/healthcheck to pass/i,
+		);
+	},
+};
+
+export const MuxAppUnhealthy: Story = {
+	beforeEach: () => {
+		mockWorkspaces([
+			workspaceWithApps({
+				id: "workspace-unhealthy",
+				name: "unhealthy",
+				apps: [
+					muxApp({
+						id: "mux-unhealthy",
+						health: "unhealthy",
+						healthcheck: {
+							url: "http://localhost:3000/healthz",
+							interval: 10,
+							threshold: 3,
+						},
+					}),
+				],
+			}),
+		]);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			await canvas.findByText("Mux app healthcheck is failing"),
+		).toBeVisible();
+		expect(
+			await canvas.findByRole("link", { name: /open workspace logs/i }),
+		).toHaveAttribute("href", `/@${MockUserOwner.username}/unhealthy`);
+	},
+};
+
+export const SubdomainMissingWildcardHostname: Story = {
+	beforeEach: () => {
+		mockWorkspaces([
+			workspaceWithApps({
+				id: "workspace-subdomain",
+				name: "subdomain",
+				apps: [
+					muxApp({
+						id: "mux-subdomain",
+						subdomain: true,
+						subdomain_name: "mux--main--subdomain--admin",
+					}),
+				],
+			}),
+		]);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			await canvas.findByText(
+				"Workspace app wildcard hostname is not configured",
+			),
+		).toBeVisible();
+		expect(canvas.queryByTestId("mux-iframe")).not.toBeInTheDocument();
+	},
+};

--- a/site/src/pages/MuxPage/MuxPage.tsx
+++ b/site/src/pages/MuxPage/MuxPage.tsx
@@ -1,0 +1,162 @@
+import { type FC, useCallback, useEffect, useMemo } from "react";
+import { useQuery } from "react-query";
+import { useSearchParams } from "react-router";
+import { workspaces } from "#/api/queries/workspaces";
+import type { Workspace } from "#/api/typesGenerated";
+import { ACTIVE_BUILD_STATUSES } from "#/modules/workspaces/status";
+import { MuxPageView } from "./MuxPageView";
+import {
+	filterMuxWorkspaces,
+	getMuxCandidatesFromWorkspace,
+	pickPreferredMuxApp,
+} from "./muxApps";
+
+const ACTIVE_MUX_REFRESH_INTERVAL = 5_000;
+const IDLE_MUX_REFRESH_INTERVAL = 30_000;
+const WORKSPACES_REQUEST = { q: "owner:me", limit: 0 } as const;
+
+const MuxPage: FC = () => {
+	const [searchParams, setSearchParams] = useSearchParams();
+	const searchParamsKey = searchParams.toString();
+	const selectedWorkspaceId = searchParams.get("workspace");
+	const workspacesQueryOptions = workspaces(WORKSPACES_REQUEST);
+	const workspacesQuery = useQuery({
+		...workspacesQueryOptions,
+		refetchInterval: ({ state }) => {
+			if (state.error) {
+				return false;
+			}
+
+			if (!state.data) {
+				return ACTIVE_MUX_REFRESH_INTERVAL;
+			}
+
+			const muxCapableWorkspaces = getMuxCapableWorkspaces(
+				state.data.workspaces,
+			);
+			const hasActiveBuild = muxCapableWorkspaces.some((workspace) =>
+				ACTIVE_BUILD_STATUSES.includes(workspace.latest_build.status),
+			);
+			if (hasActiveBuild) {
+				return ACTIVE_MUX_REFRESH_INTERVAL;
+			}
+
+			const muxWorkspaces = filterMuxWorkspaces(state.data.workspaces);
+			const selectedWorkspace = getSelectedWorkspace(
+				muxWorkspaces,
+				selectedWorkspaceId,
+			);
+			const selectedMuxCandidate = selectedWorkspace
+				? pickPreferredMuxApp(getMuxCandidatesFromWorkspace(selectedWorkspace))
+				: undefined;
+
+			return selectedMuxCandidate?.app.health === "initializing"
+				? ACTIVE_MUX_REFRESH_INTERVAL
+				: IDLE_MUX_REFRESH_INTERVAL;
+		},
+		refetchOnWindowFocus: "always",
+	});
+
+	const muxWorkspaces = useMemo(
+		() => filterMuxWorkspaces(workspacesQuery.data?.workspaces ?? []),
+		[workspacesQuery.data?.workspaces],
+	);
+
+	useEffect(() => {
+		if (!workspacesQuery.data) {
+			return;
+		}
+
+		const selectedParamIsValid =
+			selectedWorkspaceId !== null &&
+			muxWorkspaces.some((workspace) => workspace.id === selectedWorkspaceId);
+		const onlyMuxWorkspace =
+			muxWorkspaces.length === 1 ? muxWorkspaces[0] : undefined;
+
+		if (onlyMuxWorkspace && selectedWorkspaceId !== onlyMuxWorkspace.id) {
+			const nextParams = new URLSearchParams(searchParamsKey);
+			nextParams.set("workspace", onlyMuxWorkspace.id);
+			setSearchParams(nextParams, { replace: true });
+			return;
+		}
+
+		if (selectedWorkspaceId !== null && !selectedParamIsValid) {
+			const nextParams = new URLSearchParams(searchParamsKey);
+			nextParams.delete("workspace");
+			setSearchParams(nextParams, { replace: true });
+		}
+	}, [
+		muxWorkspaces,
+		searchParamsKey,
+		selectedWorkspaceId,
+		setSearchParams,
+		workspacesQuery.data,
+	]);
+
+	const selectedWorkspace = useMemo(
+		() => getSelectedWorkspace(muxWorkspaces, selectedWorkspaceId),
+		[muxWorkspaces, selectedWorkspaceId],
+	);
+	const selectedMuxCandidate = useMemo(() => {
+		if (!selectedWorkspace) {
+			return undefined;
+		}
+
+		return pickPreferredMuxApp(
+			getMuxCandidatesFromWorkspace(selectedWorkspace),
+		);
+	}, [selectedWorkspace]);
+
+	const handleSelectWorkspace = useCallback(
+		(workspaceId: string | undefined) => {
+			const nextParams = new URLSearchParams(searchParamsKey);
+			if (workspaceId) {
+				nextParams.set("workspace", workspaceId);
+			} else {
+				nextParams.delete("workspace");
+			}
+
+			setSearchParams(nextParams);
+		},
+		[searchParamsKey, setSearchParams],
+	);
+
+	return (
+		<MuxPageView
+			isLoading={workspacesQuery.isLoading}
+			error={workspacesQuery.error}
+			ownedWorkspaceCount={workspacesQuery.data?.count}
+			muxWorkspaces={muxWorkspaces}
+			selectedWorkspace={selectedWorkspace}
+			selectedMuxCandidate={selectedMuxCandidate}
+			onSelectWorkspace={handleSelectWorkspace}
+		/>
+	);
+};
+
+const getSelectedWorkspace = (
+	muxWorkspaces: readonly Workspace[],
+	selectedWorkspaceId: string | null,
+): Workspace | undefined => {
+	if (!selectedWorkspaceId) {
+		return undefined;
+	}
+
+	return muxWorkspaces.find(
+		(workspace) => workspace.id === selectedWorkspaceId,
+	);
+};
+
+const getMuxCapableWorkspaces = (
+	workspaces: readonly Workspace[],
+): Workspace[] => {
+	return workspaces.filter((workspace) => {
+		return (
+			workspace.dormant_at === null &&
+			!workspace.is_prebuild &&
+			getMuxCandidatesFromWorkspace(workspace).length > 0
+		);
+	});
+};
+
+export default MuxPage;

--- a/site/src/pages/MuxPage/MuxPage.tsx
+++ b/site/src/pages/MuxPage/MuxPage.tsx
@@ -1,4 +1,4 @@
-import { type FC, useCallback, useEffect, useMemo } from "react";
+import { type FC, useCallback, useEffect, useMemo, useState } from "react";
 import { useQuery } from "react-query";
 import { useSearchParams } from "react-router";
 import { workspaces } from "#/api/queries/workspaces";
@@ -18,7 +18,10 @@ const WORKSPACES_REQUEST = { q: "owner:me", limit: 0 } as const;
 const MuxPage: FC = () => {
 	const [searchParams, setSearchParams] = useSearchParams();
 	const searchParamsKey = searchParams.toString();
-	const selectedWorkspaceId = searchParams.get("workspace");
+	const launchedWorkspaceId = searchParams.get("workspace");
+	const [launcherWorkspaceId, setLauncherWorkspaceId] = useState<
+		string | undefined
+	>();
 	const workspacesQueryOptions = workspaces(WORKSPACES_REQUEST);
 	const workspacesQuery = useQuery({
 		...workspacesQueryOptions,
@@ -42,15 +45,15 @@ const MuxPage: FC = () => {
 			}
 
 			const muxWorkspaces = filterMuxWorkspaces(state.data.workspaces);
-			const selectedWorkspace = getSelectedWorkspace(
+			const launchedWorkspace = getSelectedWorkspace(
 				muxWorkspaces,
-				selectedWorkspaceId,
+				launchedWorkspaceId,
 			);
-			const selectedMuxCandidate = selectedWorkspace
-				? pickPreferredMuxApp(getMuxCandidatesFromWorkspace(selectedWorkspace))
+			const launchedMuxCandidate = launchedWorkspace
+				? pickPreferredMuxApp(getMuxCandidatesFromWorkspace(launchedWorkspace))
 				: undefined;
 
-			return selectedMuxCandidate?.app.health === "initializing"
+			return launchedMuxCandidate?.app.health === "initializing"
 				? ACTIVE_MUX_REFRESH_INTERVAL
 				: IDLE_MUX_REFRESH_INTERVAL;
 		},
@@ -67,20 +70,11 @@ const MuxPage: FC = () => {
 			return;
 		}
 
-		const selectedParamIsValid =
-			selectedWorkspaceId !== null &&
-			muxWorkspaces.some((workspace) => workspace.id === selectedWorkspaceId);
-		const onlyMuxWorkspace =
-			muxWorkspaces.length === 1 ? muxWorkspaces[0] : undefined;
+		const launchedParamIsValid =
+			launchedWorkspaceId !== null &&
+			muxWorkspaces.some((workspace) => workspace.id === launchedWorkspaceId);
 
-		if (onlyMuxWorkspace && selectedWorkspaceId !== onlyMuxWorkspace.id) {
-			const nextParams = new URLSearchParams(searchParamsKey);
-			nextParams.set("workspace", onlyMuxWorkspace.id);
-			setSearchParams(nextParams, { replace: true });
-			return;
-		}
-
-		if (selectedWorkspaceId !== null && !selectedParamIsValid) {
+		if (launchedWorkspaceId !== null && !launchedParamIsValid) {
 			const nextParams = new URLSearchParams(searchParamsKey);
 			nextParams.delete("workspace");
 			setSearchParams(nextParams, { replace: true });
@@ -88,38 +82,92 @@ const MuxPage: FC = () => {
 	}, [
 		muxWorkspaces,
 		searchParamsKey,
-		selectedWorkspaceId,
+		launchedWorkspaceId,
 		setSearchParams,
 		workspacesQuery.data,
 	]);
 
-	const selectedWorkspace = useMemo(
-		() => getSelectedWorkspace(muxWorkspaces, selectedWorkspaceId),
-		[muxWorkspaces, selectedWorkspaceId],
+	useEffect(() => {
+		if (!workspacesQuery.data || !launcherWorkspaceId) {
+			return;
+		}
+
+		const launcherSelectionIsValid = muxWorkspaces.some(
+			(workspace) => workspace.id === launcherWorkspaceId,
+		);
+		if (!launcherSelectionIsValid) {
+			setLauncherWorkspaceId(undefined);
+		}
+	}, [launcherWorkspaceId, muxWorkspaces, workspacesQuery.data]);
+
+	const launchedWorkspace = useMemo(
+		() => getSelectedWorkspace(muxWorkspaces, launchedWorkspaceId),
+		[muxWorkspaces, launchedWorkspaceId],
 	);
-	const selectedMuxCandidate = useMemo(() => {
-		if (!selectedWorkspace) {
+	const launchedMuxCandidate = useMemo(() => {
+		if (!launchedWorkspace) {
 			return undefined;
 		}
 
 		return pickPreferredMuxApp(
-			getMuxCandidatesFromWorkspace(selectedWorkspace),
+			getMuxCandidatesFromWorkspace(launchedWorkspace),
 		);
-	}, [selectedWorkspace]);
+	}, [launchedWorkspace]);
+	const isLaunched =
+		launchedWorkspaceId !== null &&
+		launchedWorkspace !== undefined &&
+		launchedWorkspace.latest_build.status !== "stopped" &&
+		launchedMuxCandidate !== undefined;
+
+	const launcherSelectedWorkspaceId =
+		launcherWorkspaceId ??
+		(isLaunched ? undefined : (launchedWorkspaceId ?? undefined));
+	const launcherWorkspace = useMemo(
+		() => getSelectedWorkspace(muxWorkspaces, launcherSelectedWorkspaceId),
+		[muxWorkspaces, launcherSelectedWorkspaceId],
+	);
+	const launcherMuxCandidate = useMemo(() => {
+		if (!launcherWorkspace) {
+			return undefined;
+		}
+
+		return pickPreferredMuxApp(
+			getMuxCandidatesFromWorkspace(launcherWorkspace),
+		);
+	}, [launcherWorkspace]);
 
 	const handleSelectWorkspace = useCallback(
 		(workspaceId: string | undefined) => {
-			const nextParams = new URLSearchParams(searchParamsKey);
-			if (workspaceId) {
-				nextParams.set("workspace", workspaceId);
-			} else {
-				nextParams.delete("workspace");
+			setLauncherWorkspaceId(workspaceId);
+
+			if (launchedWorkspaceId === null) {
+				return;
 			}
 
+			const nextParams = new URLSearchParams(searchParamsKey);
+			nextParams.delete("workspace");
 			setSearchParams(nextParams);
 		},
-		[searchParamsKey, setSearchParams],
+		[launchedWorkspaceId, searchParamsKey, setSearchParams],
 	);
+
+	const handleLaunchWorkspace = useCallback(() => {
+		if (!launcherSelectedWorkspaceId) {
+			return;
+		}
+
+		const nextParams = new URLSearchParams(searchParamsKey);
+		nextParams.set("workspace", launcherSelectedWorkspaceId);
+		setSearchParams(nextParams);
+	}, [launcherSelectedWorkspaceId, searchParamsKey, setSearchParams]);
+
+	const handleChangeWorkspace = useCallback(() => {
+		setLauncherWorkspaceId(undefined);
+
+		const nextParams = new URLSearchParams(searchParamsKey);
+		nextParams.delete("workspace");
+		setSearchParams(nextParams);
+	}, [searchParamsKey, setSearchParams]);
 
 	return (
 		<MuxPageView
@@ -127,16 +175,21 @@ const MuxPage: FC = () => {
 			error={workspacesQuery.error}
 			ownedWorkspaceCount={workspacesQuery.data?.count}
 			muxWorkspaces={muxWorkspaces}
-			selectedWorkspace={selectedWorkspace}
-			selectedMuxCandidate={selectedMuxCandidate}
+			selectedWorkspace={isLaunched ? launchedWorkspace : launcherWorkspace}
+			selectedMuxCandidate={
+				isLaunched ? launchedMuxCandidate : launcherMuxCandidate
+			}
+			isLaunched={isLaunched}
 			onSelectWorkspace={handleSelectWorkspace}
+			onLaunchWorkspace={handleLaunchWorkspace}
+			onChangeWorkspace={handleChangeWorkspace}
 		/>
 	);
 };
 
 const getSelectedWorkspace = (
 	muxWorkspaces: readonly Workspace[],
-	selectedWorkspaceId: string | null,
+	selectedWorkspaceId: string | null | undefined,
 ): Workspace | undefined => {
 	if (!selectedWorkspaceId) {
 		return undefined;

--- a/site/src/pages/MuxPage/MuxPageView.tsx
+++ b/site/src/pages/MuxPage/MuxPageView.tsx
@@ -1,0 +1,199 @@
+import type { FC } from "react";
+import type { Workspace } from "#/api/typesGenerated";
+import { Alert, AlertDescription, AlertTitle } from "#/components/Alert/Alert";
+import { ErrorAlert } from "#/components/Alert/ErrorAlert";
+import {
+	Combobox,
+	ComboboxButton,
+	ComboboxContent,
+	ComboboxEmpty,
+	ComboboxInput,
+	ComboboxItem,
+	ComboboxList,
+	ComboboxTrigger,
+} from "#/components/Combobox/Combobox";
+import { EmptyState } from "#/components/EmptyState/EmptyState";
+import { Loader } from "#/components/Loader/Loader";
+import { Margins } from "#/components/Margins/Margins";
+import {
+	PageHeader,
+	PageHeaderSubtitle,
+	PageHeaderTitle,
+} from "#/components/PageHeader/PageHeader";
+import { DashboardFullPage } from "#/modules/dashboard/DashboardLayout";
+import { pageTitle } from "#/utils/page";
+import { MuxIframe } from "./MuxIframe";
+import type { MuxAppCandidate } from "./muxApps";
+
+type MuxPageViewProps = {
+	isLoading: boolean;
+	error: unknown;
+	ownedWorkspaceCount: number | undefined;
+	muxWorkspaces: readonly Workspace[];
+	selectedWorkspace: Workspace | undefined;
+	selectedMuxCandidate: MuxAppCandidate | undefined;
+	onSelectWorkspace: (workspaceId: string | undefined) => void;
+};
+
+export const MuxPageView: FC<MuxPageViewProps> = ({
+	isLoading,
+	error,
+	ownedWorkspaceCount,
+	muxWorkspaces,
+	selectedWorkspace,
+	selectedMuxCandidate,
+	onSelectWorkspace,
+}) => {
+	const selectedOption = selectedWorkspace
+		? {
+				label: `${selectedWorkspace.owner_name}/${selectedWorkspace.name}`,
+				value: selectedWorkspace.id,
+			}
+		: undefined;
+	const resolvedPageTitle = selectedWorkspace
+		? pageTitle(`Mux - ${selectedWorkspace.name}`)
+		: pageTitle("Mux");
+
+	return (
+		<DashboardFullPage>
+			<title>{resolvedPageTitle}</title>
+			<Margins className="flex min-h-0 flex-1 flex-col pb-6">
+				<PageHeader className="shrink-0">
+					<PageHeaderTitle>Mux</PageHeaderTitle>
+					<PageHeaderSubtitle>
+						Open the Mux app from one of your workspaces.
+					</PageHeaderSubtitle>
+				</PageHeader>
+
+				{isLoading ? (
+					<Loader label="Loading workspaces" />
+				) : error ? (
+					<ErrorAlert error={error} />
+				) : muxWorkspaces.length === 0 ? (
+					<MuxEmptyState ownedWorkspaceCount={ownedWorkspaceCount} />
+				) : (
+					<>
+						<div className="mb-4 flex shrink-0 flex-col gap-2 sm:max-w-md">
+							<span
+								id="mux-workspace-select-label"
+								className="text-sm font-medium text-content-primary"
+							>
+								Select workspace
+							</span>
+							<Combobox
+								value={selectedWorkspace?.id}
+								onValueChange={onSelectWorkspace}
+							>
+								<ComboboxTrigger asChild>
+									<ComboboxButton
+										aria-labelledby="mux-workspace-select-label"
+										placeholder="Choose a workspace"
+										selectedOption={selectedOption}
+										width={384}
+									/>
+								</ComboboxTrigger>
+								<ComboboxContent align="start" className="w-96 max-w-[90vw]">
+									<ComboboxInput placeholder="Search workspaces" />
+									<ComboboxList>
+										<ComboboxEmpty>No workspaces found.</ComboboxEmpty>
+										{muxWorkspaces.map((workspace) => (
+											<WorkspaceOption
+												key={workspace.id}
+												workspace={workspace}
+											/>
+										))}
+									</ComboboxList>
+								</ComboboxContent>
+							</Combobox>
+						</div>
+
+						<section
+							aria-label="Mux app"
+							className="min-h-0 flex-1 overflow-hidden rounded-lg border border-solid border-border"
+						>
+							{selectedWorkspace && selectedMuxCandidate ? (
+								<MuxIframe
+									workspace={selectedWorkspace}
+									candidate={selectedMuxCandidate}
+								/>
+							) : selectedWorkspace ? (
+								<MissingSelectedApp />
+							) : (
+								<EmptyState
+									isCompact
+									className="h-full"
+									message="Choose a workspace"
+									description="Select a workspace above to open its Mux app."
+								/>
+							)}
+						</section>
+					</>
+				)}
+			</Margins>
+		</DashboardFullPage>
+	);
+};
+
+type WorkspaceOptionProps = {
+	workspace: Workspace;
+};
+
+const WorkspaceOption: FC<WorkspaceOptionProps> = ({ workspace }) => {
+	const statusHint =
+		workspace.latest_build.status === "stopped"
+			? "Stopped, start required"
+			: "Running";
+
+	return (
+		<ComboboxItem
+			value={workspace.id}
+			keywords={[workspace.name, workspace.owner_name, statusHint]}
+			className="items-start gap-3 px-4 py-3"
+		>
+			<div className="min-w-0 flex-1">
+				<p className="m-0 truncate text-sm font-medium text-content-primary">
+					{workspace.name}
+				</p>
+				<p className="m-0 truncate text-xs text-content-secondary">
+					{workspace.owner_name}, {statusHint}
+				</p>
+			</div>
+		</ComboboxItem>
+	);
+};
+
+type MuxEmptyStateProps = {
+	ownedWorkspaceCount: number | undefined;
+};
+
+const MuxEmptyState: FC<MuxEmptyStateProps> = ({ ownedWorkspaceCount }) => {
+	if (ownedWorkspaceCount === 0) {
+		return (
+			<EmptyState
+				message="No workspaces yet"
+				description="Create a workspace with the Mux app configured, then return here to open it."
+			/>
+		);
+	}
+
+	return (
+		<EmptyState
+			message="No Mux workspaces found"
+			description="Your workspaces do not currently expose a Mux app. Add the Mux app to a workspace template and start the workspace."
+		/>
+	);
+};
+
+const MissingSelectedApp: FC = () => {
+	return (
+		<div className="flex h-full items-center justify-center p-6">
+			<Alert severity="error" prominent className="max-w-2xl">
+				<AlertTitle>Mux app was not found</AlertTitle>
+				<AlertDescription>
+					The selected workspace no longer exposes a Mux app. Choose another
+					workspace or refresh the page.
+				</AlertDescription>
+			</Alert>
+		</div>
+	);
+};

--- a/site/src/pages/MuxPage/MuxPageView.tsx
+++ b/site/src/pages/MuxPage/MuxPageView.tsx
@@ -1,7 +1,9 @@
-import type { FC } from "react";
+import type { FC, ReactNode } from "react";
+import { Link as RouterLink } from "react-router";
 import type { Workspace } from "#/api/typesGenerated";
 import { Alert, AlertDescription, AlertTitle } from "#/components/Alert/Alert";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
+import { Button } from "#/components/Button/Button";
 import {
 	Combobox,
 	ComboboxButton,
@@ -13,13 +15,10 @@ import {
 	ComboboxTrigger,
 } from "#/components/Combobox/Combobox";
 import { EmptyState } from "#/components/EmptyState/EmptyState";
+import { Link } from "#/components/Link/Link";
 import { Loader } from "#/components/Loader/Loader";
 import { Margins } from "#/components/Margins/Margins";
-import {
-	PageHeader,
-	PageHeaderSubtitle,
-	PageHeaderTitle,
-} from "#/components/PageHeader/PageHeader";
+import { useAppLink } from "#/modules/apps/useAppLink";
 import { DashboardFullPage } from "#/modules/dashboard/DashboardLayout";
 import { pageTitle } from "#/utils/page";
 import { MuxIframe } from "./MuxIframe";
@@ -32,7 +31,10 @@ type MuxPageViewProps = {
 	muxWorkspaces: readonly Workspace[];
 	selectedWorkspace: Workspace | undefined;
 	selectedMuxCandidate: MuxAppCandidate | undefined;
+	isLaunched: boolean;
 	onSelectWorkspace: (workspaceId: string | undefined) => void;
+	onLaunchWorkspace: () => void;
+	onChangeWorkspace: () => void;
 };
 
 export const MuxPageView: FC<MuxPageViewProps> = ({
@@ -42,6 +44,147 @@ export const MuxPageView: FC<MuxPageViewProps> = ({
 	muxWorkspaces,
 	selectedWorkspace,
 	selectedMuxCandidate,
+	isLaunched,
+	onSelectWorkspace,
+	onLaunchWorkspace,
+	onChangeWorkspace,
+}) => {
+	const resolvedPageTitle = selectedWorkspace
+		? pageTitle(`Mux - ${selectedWorkspace.name}`)
+		: pageTitle("Mux");
+
+	return (
+		<DashboardFullPage>
+			<title>{resolvedPageTitle}</title>
+			{isLoading ? (
+				<MuxCenteredPanel>
+					<Loader label="Loading workspaces" />
+				</MuxCenteredPanel>
+			) : error ? (
+				<MuxCenteredPanel>
+					<ErrorAlert error={error} />
+				</MuxCenteredPanel>
+			) : muxWorkspaces.length === 0 ? (
+				<MuxCenteredPanel>
+					<MuxEmptyState ownedWorkspaceCount={ownedWorkspaceCount} />
+				</MuxCenteredPanel>
+			) : isLaunched ? (
+				<MuxLaunchedView
+					selectedWorkspace={selectedWorkspace}
+					selectedMuxCandidate={selectedMuxCandidate}
+					onChangeWorkspace={onChangeWorkspace}
+				/>
+			) : (
+				<MuxLauncher
+					muxWorkspaces={muxWorkspaces}
+					selectedWorkspace={selectedWorkspace}
+					selectedMuxCandidate={selectedMuxCandidate}
+					onSelectWorkspace={onSelectWorkspace}
+					onLaunchWorkspace={onLaunchWorkspace}
+				/>
+			)}
+		</DashboardFullPage>
+	);
+};
+
+type MuxCenteredPanelProps = {
+	children: ReactNode;
+};
+
+const MuxCenteredPanel: FC<MuxCenteredPanelProps> = ({ children }) => {
+	return (
+		<Margins className="flex min-h-0 flex-1 items-center justify-center py-10">
+			<div className="w-full max-w-md rounded-lg border border-solid border-border bg-surface-primary p-6 shadow-sm">
+				{children}
+			</div>
+		</Margins>
+	);
+};
+
+type MuxLauncherProps = {
+	muxWorkspaces: readonly Workspace[];
+	selectedWorkspace: Workspace | undefined;
+	selectedMuxCandidate: MuxAppCandidate | undefined;
+	onSelectWorkspace: (workspaceId: string | undefined) => void;
+	onLaunchWorkspace: () => void;
+};
+
+const MuxLauncher: FC<MuxLauncherProps> = ({
+	muxWorkspaces,
+	selectedWorkspace,
+	selectedMuxCandidate,
+	onSelectWorkspace,
+	onLaunchWorkspace,
+}) => {
+	const canLaunch =
+		selectedWorkspace?.latest_build.status === "running" &&
+		selectedMuxCandidate !== undefined;
+	const workspacePath = selectedWorkspace
+		? `/@${selectedWorkspace.owner_name}/${selectedWorkspace.name}`
+		: undefined;
+	const helperLabel = !selectedWorkspace
+		? "Select a workspace"
+		: selectedWorkspace.latest_build.status === "stopped"
+			? "Start workspace to launch"
+			: selectedMuxCandidate === undefined
+				? "Mux app unavailable"
+				: undefined;
+
+	return (
+		<MuxCenteredPanel>
+			<div className="flex flex-col items-center text-center">
+				<h1 className="m-0 text-3xl font-medium text-content-primary">Mux</h1>
+				<p className="m-0 mt-2 max-w-sm text-sm text-content-secondary">
+					Open the Mux app from one of your workspaces.
+				</p>
+
+				<div className="mt-6 flex w-full max-w-sm flex-col items-stretch gap-4 text-left">
+					<WorkspaceSelect
+						muxWorkspaces={muxWorkspaces}
+						selectedWorkspace={selectedWorkspace}
+						onSelectWorkspace={onSelectWorkspace}
+					/>
+
+					<div className="flex flex-col gap-2 text-center">
+						{selectedWorkspace?.latest_build.status === "stopped" &&
+						workspacePath ? (
+							<Button asChild className="w-full">
+								<RouterLink to={workspacePath}>Open workspace</RouterLink>
+							</Button>
+						) : (
+							<Button
+								className="w-full"
+								disabled={!canLaunch}
+								onClick={onLaunchWorkspace}
+								aria-describedby={helperLabel ? "mux-launch-helper" : undefined}
+							>
+								Launch
+							</Button>
+						)}
+						{helperLabel ? (
+							<p
+								id="mux-launch-helper"
+								className="m-0 text-xs text-content-secondary"
+							>
+								{helperLabel}
+							</p>
+						) : null}
+					</div>
+				</div>
+			</div>
+		</MuxCenteredPanel>
+	);
+};
+
+type WorkspaceSelectProps = {
+	muxWorkspaces: readonly Workspace[];
+	selectedWorkspace: Workspace | undefined;
+	onSelectWorkspace: (workspaceId: string | undefined) => void;
+};
+
+const WorkspaceSelect: FC<WorkspaceSelectProps> = ({
+	muxWorkspaces,
+	selectedWorkspace,
 	onSelectWorkspace,
 }) => {
 	const selectedOption = selectedWorkspace
@@ -50,87 +193,115 @@ export const MuxPageView: FC<MuxPageViewProps> = ({
 				value: selectedWorkspace.id,
 			}
 		: undefined;
-	const resolvedPageTitle = selectedWorkspace
-		? pageTitle(`Mux - ${selectedWorkspace.name}`)
-		: pageTitle("Mux");
 
 	return (
-		<DashboardFullPage>
-			<title>{resolvedPageTitle}</title>
-			<Margins className="flex min-h-0 flex-1 flex-col pb-6">
-				<PageHeader className="shrink-0">
-					<PageHeaderTitle>Mux</PageHeaderTitle>
-					<PageHeaderSubtitle>
-						Open the Mux app from one of your workspaces.
-					</PageHeaderSubtitle>
-				</PageHeader>
+		<div className="flex w-full flex-col gap-2">
+			<span
+				id="mux-workspace-select-label"
+				className="text-sm font-medium text-content-primary"
+			>
+				Select workspace
+			</span>
+			<div className="flex w-full">
+				<Combobox
+					value={selectedWorkspace?.id}
+					onValueChange={onSelectWorkspace}
+				>
+					<ComboboxTrigger asChild>
+						<ComboboxButton
+							aria-labelledby="mux-workspace-select-label"
+							placeholder="Choose a workspace"
+							selectedOption={selectedOption}
+							width={320}
+						/>
+					</ComboboxTrigger>
+					<ComboboxContent align="center" className="w-80 max-w-[90vw]">
+						<ComboboxInput placeholder="Search workspaces" />
+						<ComboboxList>
+							<ComboboxEmpty>No workspaces found.</ComboboxEmpty>
+							{muxWorkspaces.map((workspace) => (
+								<WorkspaceOption key={workspace.id} workspace={workspace} />
+							))}
+						</ComboboxList>
+					</ComboboxContent>
+				</Combobox>
+			</div>
+		</div>
+	);
+};
 
-				{isLoading ? (
-					<Loader label="Loading workspaces" />
-				) : error ? (
-					<ErrorAlert error={error} />
-				) : muxWorkspaces.length === 0 ? (
-					<MuxEmptyState ownedWorkspaceCount={ownedWorkspaceCount} />
-				) : (
-					<>
-						<div className="mb-4 flex shrink-0 flex-col gap-2 sm:max-w-md">
-							<span
-								id="mux-workspace-select-label"
-								className="text-sm font-medium text-content-primary"
-							>
-								Select workspace
-							</span>
-							<Combobox
-								value={selectedWorkspace?.id}
-								onValueChange={onSelectWorkspace}
-							>
-								<ComboboxTrigger asChild>
-									<ComboboxButton
-										aria-labelledby="mux-workspace-select-label"
-										placeholder="Choose a workspace"
-										selectedOption={selectedOption}
-										width={384}
-									/>
-								</ComboboxTrigger>
-								<ComboboxContent align="start" className="w-96 max-w-[90vw]">
-									<ComboboxInput placeholder="Search workspaces" />
-									<ComboboxList>
-										<ComboboxEmpty>No workspaces found.</ComboboxEmpty>
-										{muxWorkspaces.map((workspace) => (
-											<WorkspaceOption
-												key={workspace.id}
-												workspace={workspace}
-											/>
-										))}
-									</ComboboxList>
-								</ComboboxContent>
-							</Combobox>
-						</div>
+type MuxLaunchedViewProps = {
+	selectedWorkspace: Workspace | undefined;
+	selectedMuxCandidate: MuxAppCandidate | undefined;
+	onChangeWorkspace: () => void;
+};
 
-						<section
-							aria-label="Mux app"
-							className="min-h-0 flex-1 overflow-hidden rounded-lg border border-solid border-border"
-						>
-							{selectedWorkspace && selectedMuxCandidate ? (
-								<MuxIframe
-									workspace={selectedWorkspace}
-									candidate={selectedMuxCandidate}
-								/>
-							) : selectedWorkspace ? (
-								<MissingSelectedApp />
-							) : (
-								<EmptyState
-									isCompact
-									className="h-full"
-									message="Choose a workspace"
-									description="Select a workspace above to open its Mux app."
-								/>
-							)}
-						</section>
-					</>
-				)}
-			</Margins>
-		</DashboardFullPage>
+const MuxLaunchedView: FC<MuxLaunchedViewProps> = ({
+	selectedWorkspace,
+	selectedMuxCandidate,
+	onChangeWorkspace,
+}) => {
+	return (
+		<section
+			aria-label="Mux app"
+			className="relative min-h-0 flex-1 overflow-hidden bg-surface-primary [&>div>div:first-child]:hidden"
+		>
+			{selectedWorkspace && selectedMuxCandidate ? (
+				<>
+					<MuxIframe
+						workspace={selectedWorkspace}
+						candidate={selectedMuxCandidate}
+					/>
+					<MuxLaunchedControls
+						workspace={selectedWorkspace}
+						candidate={selectedMuxCandidate}
+						onChangeWorkspace={onChangeWorkspace}
+					/>
+				</>
+			) : selectedWorkspace ? (
+				<MissingSelectedApp />
+			) : (
+				<EmptyState
+					isCompact
+					className="h-full"
+					message="Choose a workspace"
+					description="Select a workspace to open its Mux app."
+				/>
+			)}
+		</section>
+	);
+};
+
+type MuxLaunchedControlsProps = {
+	workspace: Workspace;
+	candidate: MuxAppCandidate;
+	onChangeWorkspace: () => void;
+};
+
+const MuxLaunchedControls: FC<MuxLaunchedControlsProps> = ({
+	workspace,
+	candidate,
+	onChangeWorkspace,
+}) => {
+	const { agent, app } = candidate;
+	const link = useAppLink(app, { agent, workspace });
+
+	return (
+		<div className="absolute right-3 top-3 z-10 flex items-center gap-2 rounded-md border border-solid border-border bg-surface-primary p-1 shadow-sm">
+			<Button variant="subtle" size="sm" onClick={onChangeWorkspace}>
+				Change workspace
+			</Button>
+			<Link
+				href={link.href}
+				target="_blank"
+				rel="noreferrer"
+				onClick={link.onClick}
+				size="sm"
+				className="px-1"
+			>
+				Open in new tab
+			</Link>
+		</div>
 	);
 };
 
@@ -170,6 +341,7 @@ const MuxEmptyState: FC<MuxEmptyStateProps> = ({ ownedWorkspaceCount }) => {
 	if (ownedWorkspaceCount === 0) {
 		return (
 			<EmptyState
+				isCompact
 				message="No workspaces yet"
 				description="Create a workspace with the Mux app configured, then return here to open it."
 			/>
@@ -178,6 +350,7 @@ const MuxEmptyState: FC<MuxEmptyStateProps> = ({ ownedWorkspaceCount }) => {
 
 	return (
 		<EmptyState
+			isCompact
 			message="No Mux workspaces found"
 			description="Your workspaces do not currently expose a Mux app. Add the Mux app to a workspace template and start the workspace."
 		/>

--- a/site/src/pages/MuxPage/muxApps.test.ts
+++ b/site/src/pages/MuxPage/muxApps.test.ts
@@ -1,0 +1,126 @@
+import type { Workspace, WorkspaceApp } from "#/api/typesGenerated";
+import {
+	MockPrebuiltWorkspace,
+	MockStoppedWorkspace,
+	MockWorkspace,
+	MockWorkspaceAgent,
+	MockWorkspaceApp,
+	MockWorkspaceResource,
+} from "#/testHelpers/entities";
+import {
+	filterMuxWorkspaces,
+	getMuxCandidatesFromWorkspace,
+	pickPreferredMuxApp,
+} from "./muxApps";
+
+const muxApp = (overrides: Partial<WorkspaceApp> = {}): WorkspaceApp => ({
+	...MockWorkspaceApp,
+	id: "mux-app",
+	slug: "mux",
+	display_name: "Mux",
+	icon: "/icon/mux.svg",
+	health: "healthy",
+	open_in: "tab",
+	...overrides,
+});
+
+const workspaceWithApps = (
+	workspace: Workspace,
+	apps: readonly WorkspaceApp[],
+): Workspace => ({
+	...workspace,
+	latest_build: {
+		...workspace.latest_build,
+		resources: [
+			{
+				...MockWorkspaceResource,
+				agents: [
+					{
+						...MockWorkspaceAgent,
+						apps,
+					},
+				],
+			},
+		],
+	},
+});
+
+describe("filterMuxWorkspaces", () => {
+	it("includes a running workspace with the default Mux app", () => {
+		const workspace = workspaceWithApps(MockWorkspace, [muxApp()]);
+
+		expect(filterMuxWorkspaces([workspace])).toEqual([workspace]);
+	});
+
+	it("includes a stopped workspace with the default Mux app", () => {
+		const workspace = workspaceWithApps(MockStoppedWorkspace, [muxApp()]);
+
+		expect(filterMuxWorkspaces([workspace])).toEqual([workspace]);
+	});
+
+	it("excludes dormant workspaces", () => {
+		const workspace = workspaceWithApps(
+			{
+				...MockWorkspace,
+				dormant_at: "2024-01-01T00:00:00.000Z",
+			},
+			[muxApp()],
+		);
+
+		expect(filterMuxWorkspaces([workspace])).toEqual([]);
+	});
+
+	it("excludes prebuild workspaces", () => {
+		const workspace = workspaceWithApps(MockPrebuiltWorkspace, [muxApp()]);
+
+		expect(filterMuxWorkspaces([workspace])).toEqual([]);
+	});
+
+	it("excludes workspaces with only non-Mux apps", () => {
+		const workspace = workspaceWithApps(MockWorkspace, [
+			{
+				...MockWorkspaceApp,
+				slug: "not-mux",
+				icon: "/icon/code.svg",
+			},
+		]);
+
+		expect(filterMuxWorkspaces([workspace])).toEqual([]);
+	});
+
+	it("includes a workspace with a custom slug and the Mux icon", () => {
+		const workspace = workspaceWithApps(MockWorkspace, [
+			muxApp({ id: "custom", slug: "custom-mux" }),
+		]);
+
+		expect(filterMuxWorkspaces([workspace])).toEqual([workspace]);
+	});
+});
+
+describe("pickPreferredMuxApp", () => {
+	it("prefers an app with the mux slug", () => {
+		const workspace = workspaceWithApps(MockWorkspace, [
+			muxApp({ id: "z-mux", slug: "z-mux" }),
+			muxApp({ id: "default-mux", slug: "mux" }),
+		]);
+
+		const preferred = pickPreferredMuxApp(
+			getMuxCandidatesFromWorkspace(workspace),
+		);
+
+		expect(preferred?.app.id).toBe("default-mux");
+	});
+
+	it("sorts custom Mux apps by slug when no default app exists", () => {
+		const workspace = workspaceWithApps(MockWorkspace, [
+			muxApp({ id: "z-mux", slug: "z-mux" }),
+			muxApp({ id: "a-mux", slug: "a-mux" }),
+		]);
+
+		const preferred = pickPreferredMuxApp(
+			getMuxCandidatesFromWorkspace(workspace),
+		);
+
+		expect(preferred?.app.id).toBe("a-mux");
+	});
+});

--- a/site/src/pages/MuxPage/muxApps.ts
+++ b/site/src/pages/MuxPage/muxApps.ts
@@ -1,0 +1,59 @@
+import type {
+	Workspace,
+	WorkspaceAgent,
+	WorkspaceApp,
+} from "#/api/typesGenerated";
+
+export type MuxAppCandidate = {
+	agent: WorkspaceAgent;
+	app: WorkspaceApp;
+};
+
+const isMuxApp = (app: WorkspaceApp): boolean => {
+	return app.slug === "mux" || app.icon === "/icon/mux.svg";
+};
+
+export const getMuxCandidatesFromWorkspace = (
+	workspace: Workspace,
+): MuxAppCandidate[] => {
+	const candidates: MuxAppCandidate[] = [];
+
+	for (const resource of workspace.latest_build.resources) {
+		for (const agent of resource.agents ?? []) {
+			for (const app of agent.apps) {
+				if (isMuxApp(app)) {
+					candidates.push({ agent, app });
+				}
+			}
+		}
+	}
+
+	return candidates;
+};
+
+export const pickPreferredMuxApp = (
+	candidates: readonly MuxAppCandidate[],
+): MuxAppCandidate | undefined => {
+	return (
+		candidates.find(({ app }) => app.slug === "mux") ??
+		candidates
+			.toSorted((left, right) => left.app.slug.localeCompare(right.app.slug))
+			.at(0)
+	);
+};
+
+export const filterMuxWorkspaces = (
+	workspaces: readonly Workspace[],
+): Workspace[] => {
+	return workspaces.filter((workspace) => {
+		const status = workspace.latest_build.status;
+		const isRunnableMuxWorkspace = status === "running" || status === "stopped";
+
+		return (
+			isRunnableMuxWorkspace &&
+			workspace.dormant_at === null &&
+			!workspace.is_prebuild &&
+			getMuxCandidatesFromWorkspace(workspace).length > 0
+		);
+	});
+};

--- a/site/src/router.tsx
+++ b/site/src/router.tsx
@@ -95,6 +95,7 @@ const WorkspaceSharingPage = lazy(
 			"./pages/WorkspaceSettingsPage/WorkspaceSharingPage/WorkspaceSharingPage"
 		),
 );
+const MuxPage = lazy(() => import("./pages/MuxPage/MuxPage"));
 const TerminalPage = lazy(() => import("./pages/TerminalPage/TerminalPage"));
 const TemplatePermissionsPage = lazy(
 	() =>
@@ -538,6 +539,8 @@ export const router = createBrowserRouter(
 					<Route path="/audit" element={<AuditPage />} />
 
 					<Route path="/connectionlog" element={<ConnectionLogPage />} />
+
+					<Route path="/mux" element={<MuxPage />} />
 
 					<Route path="/tasks" element={<TasksPage />} />
 

--- a/site/vite.config.mts
+++ b/site/vite.config.mts
@@ -4,7 +4,7 @@ import { storybookTest } from "@storybook/addon-vitest/vitest-plugin";
 import react, { reactCompilerPreset } from "@vitejs/plugin-react";
 import { playwright } from "@vitest/browser-playwright";
 import { visualizer } from "rollup-plugin-visualizer";
-import type { PluginOption } from "vite";
+import type { PluginOption, ProxyOptions } from "vite";
 import checker from "vite-plugin-checker";
 import { defineConfig } from "vitest/config";
 
@@ -26,6 +26,24 @@ const plugins: PluginOption[] = [
 		typescript: true,
 	}),
 ];
+
+type ProxyServer = Parameters<NonNullable<ProxyOptions["configure"]>>[0];
+
+// Dev-only convenience for remote CODER_HOST sessions. Stripping CSP
+// frame-ancestors lets path-app iframes render through the Vite dev server
+// when the backend is a remote deployment like dev.coder.com. Production
+// builds are unaffected.
+const stripDevIframeHeaders = (proxy: ProxyServer) => {
+	proxy.on("proxyRes", (proxyRes) => {
+		if (process.env.NODE_ENV === "production") {
+			return;
+		}
+
+		delete proxyRes.headers["content-security-policy"];
+		delete proxyRes.headers["content-security-policy-report-only"];
+		delete proxyRes.headers["x-frame-options"];
+	});
+};
 
 if (process.env.STATS !== undefined) {
 	plugins.push(
@@ -108,6 +126,7 @@ export default defineConfig({
 						target: process.env.CODER_HOST || "http://localhost:3000",
 						secure: process.env.NODE_ENV === "production",
 						configure: (proxy) => {
+							stripDevIframeHeaders(proxy);
 							if (process.env.CODER_SESSION_TOKEN) {
 								proxy.on("proxyReq", (proxyReq) => {
 									proxyReq.setHeader(
@@ -137,6 +156,23 @@ export default defineConfig({
 									console.error(error);
 								});
 							});
+						},
+					},
+					"/@": {
+						ws: true,
+						changeOrigin: true,
+						target: process.env.CODER_HOST || "http://localhost:3000",
+						secure: process.env.NODE_ENV === "production",
+						configure: (proxy) => {
+							stripDevIframeHeaders(proxy);
+							if (process.env.CODER_SESSION_TOKEN) {
+								proxy.on("proxyReq", (proxyReq) => {
+									proxyReq.setHeader(
+										"Coder-Session-Token",
+										process.env.CODER_SESSION_TOKEN!,
+									);
+								});
+							}
 						},
 					},
 					"/swagger": {

--- a/site/vite.config.mts
+++ b/site/vite.config.mts
@@ -158,7 +158,10 @@ export default defineConfig({
 							});
 						},
 					},
-					"/@": {
+					// Only proxy Coder path-app and terminal URLs. This avoids
+					// colliding with Vite internals like /@vite/*,
+					// /@react-refresh, /@id/*, and /@fs/*.
+					"^/@[^/]+/[^/]+/(apps|terminal)(/|$)": {
 						ws: true,
 						changeOrigin: true,
 						target: process.env.CODER_HOST || "http://localhost:3000",

--- a/site/vite.config.mts
+++ b/site/vite.config.mts
@@ -4,7 +4,7 @@ import { storybookTest } from "@storybook/addon-vitest/vitest-plugin";
 import react, { reactCompilerPreset } from "@vitejs/plugin-react";
 import { playwright } from "@vitest/browser-playwright";
 import { visualizer } from "rollup-plugin-visualizer";
-import type { PluginOption, ProxyOptions } from "vite";
+import type { Plugin, PluginOption, ProxyOptions } from "vite";
 import checker from "vite-plugin-checker";
 import { defineConfig } from "vitest/config";
 
@@ -19,7 +19,57 @@ compilerPreset.rolldown.filter = {
 	id: { include: [/src\/pages\/AgentsPage\//] },
 };
 
+// Path-app iframe HTML can point to root-absolute assets like /main.js
+// because the upstream app expects a subdomain. In dev, rewrite those
+// requests under the referring path-app base before Vite serves the SPA.
+const coderPathAppAssetRewrite = (): Plugin => ({
+	name: "coder-path-app-asset-rewrite",
+	configureServer(server) {
+		if (process.env.NODE_ENV === "production") {
+			return;
+		}
+
+		server.middlewares.use((req, _res, next) => {
+			const referer = req.headers.referer;
+			if (!referer || !req.url) {
+				return next();
+			}
+
+			let refPath: string;
+			try {
+				refPath = new URL(referer).pathname;
+			} catch {
+				return next();
+			}
+
+			const match = refPath.match(/^(\/@[^/]+\/[^/]+\/apps\/[^/]+\/)/);
+			if (!match) {
+				return next();
+			}
+			const prefix = match[1];
+			const url = req.url;
+
+			if (
+				url.startsWith("/@") ||
+				url.startsWith("/src/") ||
+				url.startsWith("/node_modules/") ||
+				url.startsWith("/api/") ||
+				url.startsWith("/healthz") ||
+				url.startsWith("/swagger") ||
+				url.startsWith("/serviceWorker.js") ||
+				url.startsWith(prefix)
+			) {
+				return next();
+			}
+
+			req.url = prefix + url.replace(/^\//, "");
+			next();
+		});
+	},
+});
+
 const plugins: PluginOption[] = [
+	coderPathAppAssetRewrite(),
 	react(),
 	babel({ presets: [compilerPreset] }),
 	checker({


### PR DESCRIPTION
Adds a new `/mux` dashboard page that lets a user pick one of their workspaces and embed its [Mux](https://github.com/coder/mux) app in an iframe filling the page below the Coder Navbar. Adds a corresponding "Mux" entry in the main desktop nav after "Agents".

## What's in the diff

- New page at `site/src/pages/MuxPage/`. Centered launcher card with a workspace picker; on Launch the iframe fills the full content area. Selection syncs to `?workspace=<id>` so refresh and shareable links work. A "Change workspace" affordance returns to the launcher; "Open in new tab" stays available.
- Detection is runtime-only: a workspace is treated as Mux-capable when its latest build exposes a `coder_app` whose `slug === "mux"` or `icon === "/icon/mux.svg"` (matches the [registry Mux module](https://registry.coder.com/modules/coder/mux) defaults). Stopped workspaces appear in the picker but show an "Open workspace" link instead of attempting to iframe.
- Mux nav link added unconditionally in `NavbarView.tsx`, immediately after `AgentsNavItem`. Mobile menu unchanged (it does not render top-level nav links).
- Storybook stories with play-function coverage for loading, empty, multi-candidate selection, deterministic preferred-app picking, healthy launched state, stopped-workspace CTA, initializing, unhealthy, and missing-wildcard-host warning. Pure-helper unit tests for `muxApps.ts`.

## Dev-server convenience for remote-CODER_HOST testing

Three commits add a `vite dev`-only path so contributors running `CODER_HOST=https://dev.coder.com pnpm --dir site dev` can verify the iframe locally:

- `vite.config.mts` proxies `^/@<owner>/<ws>.<agent>/(apps|terminal)` to `CODER_HOST`, forwards `CODER_SESSION_TOKEN` when set, and strips `content-security-policy`, `content-security-policy-report-only`, and `x-frame-options` from proxied responses so path-app iframes render against a remote backend.
- A small middleware rewrites root-absolute asset requests under the path-app prefix using the `Referer` header. This is needed because some apps (Mux included) emit `<script src="/main-<hash>.js">` assuming subdomain-root deployment.
- `MuxIframe.tsx` forces path-app mode for the iframe `src` under `import.meta.env.DEV` only. Production keeps the app's preferred URL (typically subdomain) so isolation guarantees are unchanged.

These are inert in production: `vite.config.mts` is dev-server tooling and is not bundled by `vite build`. The `import.meta.env.DEV` branch is statically replaced with `false` and tree-shaken in production builds. No backend changes; no CORS changes; the existing `--dangerous-allow-cors-requests` deployment flag is referenced only in commit messages, not used.

## Known limitation

Embedding Mux through a path-app URL (which is what dev mode uses, and what some operator setups will use in prod) requires the Mux app itself to handle a non-root path prefix in its asset and websocket URLs. The current Mux build assumes subdomain-root deployment and stalls on "Loading Mux..." in path-app mode. This is a Mux-side issue, not a Coder-side issue; subdomain mode (the registry module's default) works as intended.

> This PR was opened by Mux on behalf of Mike.
