### PR TITLE
feat(site/src/pages/AgentsPage/components/ChatModelAdminPanel): add duplicate model action

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ChatModelAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ChatModelAdminPanel.tsx
@@ -1,4 +1,4 @@
-import { type FC, useState } from "react";
+import type { FC } from "react";
 
 import type * as TypesGen from "#/api/typesGenerated";
 import { Alert, AlertDescription, AlertTitle } from "#/components/Alert/Alert";
@@ -251,8 +251,6 @@ export const ChatModelAdminPanel: FC<ChatModelAdminPanelProps> = ({
 	isDeletingModel,
 	modelMutationError,
 }) => {
-	const [, setRequestedProvider] = useState<string | null>(null);
-
 	// ── Sorted model configs ───────────────────────────────────
 	const modelConfigs = (modelConfigsData ?? []).slice().sort((a, b) => {
 		const cmp = a.provider.localeCompare(b.provider);
@@ -290,14 +288,12 @@ export const ChatModelAdminPanel: FC<ChatModelAdminPanelProps> = ({
 						onCreateProvider={onCreateProvider}
 						onUpdateProvider={onUpdateProvider}
 						onDeleteProvider={onDeleteProvider}
-						onSelectedProviderChange={setRequestedProvider}
 					/>
 				) : (
 					<ModelsSection
 						sectionLabel={sectionLabel}
 						sectionDescription={sectionDescription}
 						providerStates={providerStates}
-						onSelectedProviderChange={setRequestedProvider}
 						modelConfigs={modelConfigs}
 						modelConfigsUnavailable={modelConfigsUnavailable}
 						isCreating={isCreatingModel}

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ChatModelAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ChatModelAdminPanel.tsx
@@ -251,9 +251,7 @@ export const ChatModelAdminPanel: FC<ChatModelAdminPanelProps> = ({
 	isDeletingModel,
 	modelMutationError,
 }) => {
-	const [requestedProvider, setRequestedProvider] = useState<string | null>(
-		null,
-	);
+	const [, setRequestedProvider] = useState<string | null>(null);
 
 	// ── Sorted model configs ───────────────────────────────────
 	const modelConfigs = (modelConfigsData ?? []).slice().sort((a, b) => {
@@ -268,20 +266,6 @@ export const ChatModelAdminPanel: FC<ChatModelAdminPanelProps> = ({
 		modelCatalogData,
 	);
 
-	// Derive the effective selected provider from user intent + available
-	// providers. This avoids a useEffect + setState cycle that would cause
-	// an extra render with a stale value.
-	const selectedProvider =
-		requestedProvider &&
-		providerStates.some((ps) => ps.provider === requestedProvider)
-			? requestedProvider
-			: (providerStates[0]?.provider ?? null);
-
-	const selectedProviderState = selectedProvider
-		? (providerStates.find((ps) => ps.provider === selectedProvider) ?? null)
-		: null;
-
-	// ── Derived state ──────────────────────────────────────────
 	const providerConfigsUnavailable = providerConfigsData === null;
 	const modelConfigsUnavailable = modelConfigsData === null;
 
@@ -313,8 +297,6 @@ export const ChatModelAdminPanel: FC<ChatModelAdminPanelProps> = ({
 						sectionLabel={sectionLabel}
 						sectionDescription={sectionDescription}
 						providerStates={providerStates}
-						selectedProvider={selectedProvider}
-						selectedProviderState={selectedProviderState}
 						onSelectedProviderChange={setRequestedProvider}
 						modelConfigs={modelConfigs}
 						modelConfigsUnavailable={modelConfigsUnavailable}

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelForm.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelForm.tsx
@@ -113,8 +113,6 @@ export const ModelForm: FC<ModelFormProps> = ({
 	const initialModel = editingModel ?? duplicateSourceModel;
 	const isEditing = Boolean(editingModel);
 	const isDuplicating = Boolean(duplicateSourceModel) && !isEditing;
-	const effectiveProvider = selectedProvider;
-	const effectiveProviderState = selectedProviderState;
 	const initialValues = {
 		...buildInitialModelFormValues(initialModel),
 		...(isDuplicating && { isDefault: false }),
@@ -125,9 +123,9 @@ export const ModelForm: FC<ModelFormProps> = ({
 	const [confirmingDelete, setConfirmingDelete] = useState(false);
 
 	const canManageModels = Boolean(
-		effectiveProviderState?.providerConfig &&
-			(effectiveProviderState.hasEffectiveAPIKey ||
-				effectiveProviderState.providerConfig.allow_user_api_key),
+		selectedProviderState?.providerConfig &&
+			(selectedProviderState.hasEffectiveAPIKey ||
+				selectedProviderState.providerConfig.allow_user_api_key),
 	);
 	const formTitle = isEditing
 		? "Edit Model"
@@ -155,7 +153,7 @@ export const ModelForm: FC<ModelFormProps> = ({
 			);
 
 			const buildResult = buildModelConfigFromForm(
-				effectiveProvider,
+				selectedProvider,
 				values.config,
 			);
 			if (Object.keys(buildResult.fieldErrors).length > 0) return;
@@ -192,11 +190,10 @@ export const ModelForm: FC<ModelFormProps> = ({
 
 				await onUpdateModel(editingModel.id, req);
 			} else {
-				if (!effectiveProvider || !effectiveProviderState?.providerConfig)
-					return;
+				if (!selectedProvider || !selectedProviderState?.providerConfig) return;
 
 				const req: TypesGen.CreateChatModelConfigRequest = {
-					provider: effectiveProvider,
+					provider: selectedProvider,
 					model: trimmedModel,
 					enabled: values.enabled,
 					is_default: values.isDefault,
@@ -225,7 +222,7 @@ export const ModelForm: FC<ModelFormProps> = ({
 	const getFieldHelpers = getFormHelpers(form);
 
 	const modelConfigFormBuildResult = buildModelConfigFromForm(
-		effectiveProvider,
+		selectedProvider,
 		form.values.config,
 	);
 
@@ -245,7 +242,7 @@ export const ModelForm: FC<ModelFormProps> = ({
 				Provider
 			</Label>
 			<Select
-				value={effectiveProvider ?? ""}
+				value={selectedProvider ?? ""}
 				onValueChange={onSelectedProviderChange}
 				disabled={isEditing || isDuplicating || providerStates.length === 0}
 			>
@@ -270,7 +267,7 @@ export const ModelForm: FC<ModelFormProps> = ({
 	);
 
 	// No provider selected or configs unavailable.
-	if (!effectiveProviderState || modelConfigsUnavailable) {
+	if (!selectedProviderState || modelConfigsUnavailable) {
 		return (
 			<div>
 				<BackButton onClick={onCancel} />
@@ -295,7 +292,7 @@ export const ModelForm: FC<ModelFormProps> = ({
 				<div className="space-y-3">
 					{providerSelect}
 					<p className="text-sm text-content-secondary">
-						{!effectiveProviderState.providerConfig
+						{!selectedProviderState.providerConfig
 							? "Create a managed provider config on the Providers tab before managing models."
 							: "Set an API key for this provider on the Providers tab before managing models."}
 					</p>
@@ -326,9 +323,9 @@ export const ModelForm: FC<ModelFormProps> = ({
 			</div>
 			{/* Header - editable display name */}
 			<div className="flex items-center gap-3">
-				{effectiveProviderState && (
+				{selectedProviderState && (
 					<ProviderIcon
-						provider={effectiveProviderState.provider}
+						provider={selectedProviderState.provider}
 						className="h-8 w-8"
 					/>
 				)}
@@ -507,7 +504,7 @@ export const ModelForm: FC<ModelFormProps> = ({
 						{showPricing && (
 							<div className="grid grid-cols-2 gap-3 pt-3 sm:grid-cols-4">
 								<PricingModelConfigFields
-									provider={effectiveProviderState.provider}
+									provider={selectedProviderState.provider}
 									form={form}
 									fieldErrors={modelConfigFormBuildResult.fieldErrors}
 									disabled={isSaving}
@@ -541,7 +538,7 @@ export const ModelForm: FC<ModelFormProps> = ({
 						{showProviderConfig && (
 							<div className="pt-3">
 								<ModelConfigFields
-									provider={effectiveProviderState.provider}
+									provider={selectedProviderState.provider}
 									form={form}
 									fieldErrors={modelConfigFormBuildResult.fieldErrors}
 									disabled={isSaving}
@@ -575,7 +572,7 @@ export const ModelForm: FC<ModelFormProps> = ({
 						{showAdvanced && (
 							<div className="grid grid-cols-2 gap-3 pt-3 sm:grid-cols-3">
 								<GeneralModelConfigFields
-									provider={effectiveProviderState.provider}
+									provider={selectedProviderState.provider}
 									form={form}
 									fieldErrors={modelConfigFormBuildResult.fieldErrors}
 									disabled={isSaving}

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelForm.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelForm.tsx
@@ -75,6 +75,7 @@ const validationSchema = Yup.object({
 interface ModelFormProps {
 	/** When set, the form is in "edit" mode for the given model. */
 	editingModel?: TypesGen.ChatModelConfig;
+	/** When set without editingModel, the form creates from this model. */
 	duplicateSourceModel?: TypesGen.ChatModelConfig;
 	providerStates: readonly ProviderState[];
 	selectedProvider: string | null;
@@ -112,16 +113,12 @@ export const ModelForm: FC<ModelFormProps> = ({
 	const initialModel = editingModel ?? duplicateSourceModel;
 	const isEditing = Boolean(editingModel);
 	const isDuplicating = Boolean(duplicateSourceModel) && !isEditing;
-	const effectiveProvider =
-		editingModel?.provider ??
-		duplicateSourceModel?.provider ??
-		selectedProvider;
-	const matchingProviderState = effectiveProvider
-		? providerStates.find((ps) => ps.provider === effectiveProvider)
-		: undefined;
-	const effectiveProviderState = effectiveProvider
-		? (matchingProviderState ?? null)
-		: selectedProviderState;
+	const effectiveProvider = selectedProvider;
+	const effectiveProviderState = selectedProviderState;
+	const initialValues = {
+		...buildInitialModelFormValues(initialModel),
+		...(isDuplicating && { isDefault: false }),
+	};
 	const [showAdvanced, setShowAdvanced] = useState(false);
 	const [showPricing, setShowPricing] = useState(false);
 	const [showProviderConfig, setShowProviderConfig] = useState(false);
@@ -142,7 +139,7 @@ export const ModelForm: FC<ModelFormProps> = ({
 		: undefined;
 
 	const form = useFormik<ModelFormValues>({
-		initialValues: buildInitialModelFormValues(initialModel),
+		initialValues,
 		validationSchema,
 		validateOnMount: true,
 		validateOnBlur: false,
@@ -234,7 +231,8 @@ export const ModelForm: FC<ModelFormProps> = ({
 
 	const hasFieldErrors =
 		Object.keys(modelConfigFormBuildResult.fieldErrors).length > 0;
-	const defaultModelDisableGuard = form.values.isDefault && form.values.enabled;
+	const defaultModelDisableGuard =
+		isEditing && form.values.isDefault && form.values.enabled;
 
 	// ── Provider select (shared across all form states) ───────
 
@@ -298,8 +296,8 @@ export const ModelForm: FC<ModelFormProps> = ({
 					{providerSelect}
 					<p className="text-sm text-content-secondary">
 						{!effectiveProviderState.providerConfig
-							? "Create a managed provider config on the Providers tab before adding models."
-							: "Set an API key for this provider on the Providers tab before adding models."}
+							? "Create a managed provider config on the Providers tab before managing models."
+							: "Set an API key for this provider on the Providers tab before managing models."}
 					</p>
 				</div>
 			</div>
@@ -369,9 +367,7 @@ export const ModelForm: FC<ModelFormProps> = ({
 						</TooltipTrigger>
 						<TooltipContent side="bottom">
 							{defaultModelDisableGuard
-								? isEditing
-									? "Default model cannot be disabled. Remove default status first."
-									: "A duplicated default model must stay enabled."
+								? "Default model cannot be disabled. Remove default status first."
 								: form.values.enabled
 									? "Disable this model. It will be hidden from users."
 									: "Enable this model. It will be visible to users."}

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelForm.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelForm.tsx
@@ -75,6 +75,7 @@ const validationSchema = Yup.object({
 interface ModelFormProps {
 	/** When set, the form is in "edit" mode for the given model. */
 	editingModel?: TypesGen.ChatModelConfig;
+	duplicateSourceModel?: TypesGen.ChatModelConfig;
 	providerStates: readonly ProviderState[];
 	selectedProvider: string | null;
 	selectedProviderState: ProviderState | null;
@@ -95,6 +96,7 @@ interface ModelFormProps {
 
 export const ModelForm: FC<ModelFormProps> = ({
 	editingModel,
+	duplicateSourceModel,
 	providerStates,
 	selectedProvider,
 	selectedProviderState,
@@ -107,21 +109,40 @@ export const ModelForm: FC<ModelFormProps> = ({
 	onCancel,
 	onDeleteModel,
 }) => {
+	const initialModel = editingModel ?? duplicateSourceModel;
 	const isEditing = Boolean(editingModel);
-	const isDefaultModel = isEditing && editingModel?.is_default === true;
+	const isDuplicating = Boolean(duplicateSourceModel) && !isEditing;
+	const effectiveProvider =
+		editingModel?.provider ??
+		duplicateSourceModel?.provider ??
+		selectedProvider;
+	const matchingProviderState = effectiveProvider
+		? providerStates.find((ps) => ps.provider === effectiveProvider)
+		: undefined;
+	const effectiveProviderState = effectiveProvider
+		? (matchingProviderState ?? null)
+		: selectedProviderState;
 	const [showAdvanced, setShowAdvanced] = useState(false);
 	const [showPricing, setShowPricing] = useState(false);
 	const [showProviderConfig, setShowProviderConfig] = useState(false);
 	const [confirmingDelete, setConfirmingDelete] = useState(false);
 
 	const canManageModels = Boolean(
-		selectedProviderState?.providerConfig &&
-			(selectedProviderState.hasEffectiveAPIKey ||
-				selectedProviderState.providerConfig.allow_user_api_key),
+		effectiveProviderState?.providerConfig &&
+			(effectiveProviderState.hasEffectiveAPIKey ||
+				effectiveProviderState.providerConfig.allow_user_api_key),
 	);
+	const formTitle = isEditing
+		? "Edit Model"
+		: isDuplicating
+			? "Duplicate Model"
+			: "Add Model";
+	const formDescription = isDuplicating
+		? "Review the copied settings, then save to create a new model."
+		: undefined;
 
 	const form = useFormik<ModelFormValues>({
-		initialValues: buildInitialModelFormValues(editingModel),
+		initialValues: buildInitialModelFormValues(initialModel),
 		validationSchema,
 		validateOnMount: true,
 		validateOnBlur: false,
@@ -137,7 +158,7 @@ export const ModelForm: FC<ModelFormProps> = ({
 			);
 
 			const buildResult = buildModelConfigFromForm(
-				selectedProviderState?.provider,
+				effectiveProvider,
 				values.config,
 			);
 			if (Object.keys(buildResult.fieldErrors).length > 0) return;
@@ -174,12 +195,14 @@ export const ModelForm: FC<ModelFormProps> = ({
 
 				await onUpdateModel(editingModel.id, req);
 			} else {
-				if (!selectedProviderState?.providerConfig) return;
+				if (!effectiveProvider || !effectiveProviderState?.providerConfig)
+					return;
 
 				const req: TypesGen.CreateChatModelConfigRequest = {
-					provider: selectedProviderState.provider,
+					provider: effectiveProvider,
 					model: trimmedModel,
-					enabled: true,
+					enabled: values.enabled,
+					is_default: values.isDefault,
 					...(parsedContextLimit !== null && {
 						context_limit: parsedContextLimit,
 					}),
@@ -188,9 +211,6 @@ export const ModelForm: FC<ModelFormProps> = ({
 					}),
 					...(trimmedDisplayName && {
 						display_name: trimmedDisplayName,
-					}),
-					...(values.isDefault && {
-						is_default: true,
 					}),
 					...(builtModelConfig && {
 						model_config: builtModelConfig,
@@ -208,13 +228,13 @@ export const ModelForm: FC<ModelFormProps> = ({
 	const getFieldHelpers = getFormHelpers(form);
 
 	const modelConfigFormBuildResult = buildModelConfigFromForm(
-		selectedProviderState?.provider,
+		effectiveProvider,
 		form.values.config,
 	);
 
 	const hasFieldErrors =
 		Object.keys(modelConfigFormBuildResult.fieldErrors).length > 0;
-	const defaultModelDisableGuard = isDefaultModel && form.values.enabled;
+	const defaultModelDisableGuard = form.values.isDefault && form.values.enabled;
 
 	// ── Provider select (shared across all form states) ───────
 
@@ -227,9 +247,9 @@ export const ModelForm: FC<ModelFormProps> = ({
 				Provider
 			</Label>
 			<Select
-				value={selectedProvider ?? ""}
+				value={effectiveProvider ?? ""}
 				onValueChange={onSelectedProviderChange}
-				disabled={isEditing || providerStates.length === 0}
+				disabled={isEditing || isDuplicating || providerStates.length === 0}
 			>
 				<SelectTrigger
 					id="providerSelect"
@@ -252,12 +272,12 @@ export const ModelForm: FC<ModelFormProps> = ({
 	);
 
 	// No provider selected or configs unavailable.
-	if (!selectedProviderState || modelConfigsUnavailable) {
+	if (!effectiveProviderState || modelConfigsUnavailable) {
 		return (
 			<div>
 				<BackButton onClick={onCancel} />
 				<h2 className="m-0 text-lg font-medium text-content-primary">
-					{isEditing ? "Edit Model" : "Add Model"}
+					{formTitle}
 				</h2>
 				<hr className="my-4 border-0 border-t border-solid border-border" />
 				<div className="space-y-3">{providerSelect}</div>
@@ -271,13 +291,13 @@ export const ModelForm: FC<ModelFormProps> = ({
 			<div>
 				<BackButton onClick={onCancel} />
 				<h2 className="m-0 text-lg font-medium text-content-primary">
-					Add Model
+					{formTitle}
 				</h2>
 				<hr className="my-4 border-0 border-t border-solid border-border" />
 				<div className="space-y-3">
 					{providerSelect}
 					<p className="text-sm text-content-secondary">
-						{!selectedProviderState.providerConfig
+						{!effectiveProviderState.providerConfig
 							? "Create a managed provider config on the Providers tab before adding models."
 							: "Set an API key for this provider on the Providers tab before adding models."}
 					</p>
@@ -295,11 +315,22 @@ export const ModelForm: FC<ModelFormProps> = ({
 	return (
 		<div className="flex min-h-full flex-col">
 			{/* Back */}
-			<BackButton onClick={onCancel} /> {/* Header - editable display name */}
+			<BackButton onClick={onCancel} />
+			<div className="mb-4">
+				<h2 className="m-0 text-lg font-medium text-content-primary">
+					{formTitle}
+				</h2>
+				{formDescription && (
+					<p className="m-0 mt-1 text-sm text-content-secondary">
+						{formDescription}
+					</p>
+				)}
+			</div>
+			{/* Header - editable display name */}
 			<div className="flex items-center gap-3">
-				{selectedProviderState && (
+				{effectiveProviderState && (
 					<ProviderIcon
-						provider={selectedProviderState.provider}
+						provider={effectiveProviderState.provider}
 						className="h-8 w-8"
 					/>
 				)}
@@ -309,10 +340,7 @@ export const ModelForm: FC<ModelFormProps> = ({
 							className="invisible col-start-1 row-start-1 whitespace-pre text-lg font-medium"
 							aria-hidden="true"
 						>
-							{form.values.displayName ||
-								(isEditing
-									? (editingModel?.model ?? "Model name")
-									: "Model name")}
+							{form.values.displayName || initialModel?.model || "Model name"}
 						</span>
 						<input
 							type="text"
@@ -320,14 +348,12 @@ export const ModelForm: FC<ModelFormProps> = ({
 							disabled={isSaving}
 							spellCheck={false}
 							className="col-start-1 row-start-1 m-0 min-w-0 border-0 bg-transparent p-0 text-lg font-medium text-content-primary outline-none placeholder:text-content-secondary focus:ring-0"
-							placeholder={
-								isEditing ? (editingModel?.model ?? "Model name") : "Model name"
-							}
+							placeholder={initialModel?.model ?? "Model name"}
 						/>
 					</div>
 					<PencilIcon className="h-3.5 w-3.5 shrink-0 text-content-secondary" />
 				</div>{" "}
-				{editingModel && (
+				{initialModel && (
 					<Tooltip>
 						<TooltipTrigger asChild>
 							<span className="ml-auto inline-flex">
@@ -343,7 +369,9 @@ export const ModelForm: FC<ModelFormProps> = ({
 						</TooltipTrigger>
 						<TooltipContent side="bottom">
 							{defaultModelDisableGuard
-								? "Default model cannot be disabled. Remove default status first."
+								? isEditing
+									? "Default model cannot be disabled. Remove default status first."
+									: "A duplicated default model must stay enabled."
 								: form.values.enabled
 									? "Disable this model. It will be hidden from users."
 									: "Enable this model. It will be visible to users."}
@@ -483,7 +511,7 @@ export const ModelForm: FC<ModelFormProps> = ({
 						{showPricing && (
 							<div className="grid grid-cols-2 gap-3 pt-3 sm:grid-cols-4">
 								<PricingModelConfigFields
-									provider={selectedProviderState.provider}
+									provider={effectiveProviderState.provider}
 									form={form}
 									fieldErrors={modelConfigFormBuildResult.fieldErrors}
 									disabled={isSaving}
@@ -517,7 +545,7 @@ export const ModelForm: FC<ModelFormProps> = ({
 						{showProviderConfig && (
 							<div className="pt-3">
 								<ModelConfigFields
-									provider={selectedProviderState.provider}
+									provider={effectiveProviderState.provider}
 									form={form}
 									fieldErrors={modelConfigFormBuildResult.fieldErrors}
 									disabled={isSaving}
@@ -551,7 +579,7 @@ export const ModelForm: FC<ModelFormProps> = ({
 						{showAdvanced && (
 							<div className="grid grid-cols-2 gap-3 pt-3 sm:grid-cols-3">
 								<GeneralModelConfigFields
-									provider={selectedProviderState.provider}
+									provider={effectiveProviderState.provider}
 									form={form}
 									fieldErrors={modelConfigFormBuildResult.fieldErrors}
 									disabled={isSaving}
@@ -633,7 +661,11 @@ export const ModelForm: FC<ModelFormProps> = ({
 							disabled={isSaving || !form.isValid || hasFieldErrors}
 						>
 							{isSaving && <Spinner className="h-4 w-4" loading />}{" "}
-							{isEditing ? "Save" : "Add model"}
+							{isEditing
+								? "Save"
+								: isDuplicating
+									? "Create duplicate"
+									: "Add model"}
 						</Button>
 					</div>
 				</div>

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelsSection.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelsSection.stories.tsx
@@ -71,39 +71,12 @@ const duplicateSourceModel: TypesGen.ChatModelConfig = {
 	},
 };
 
-type CreateModelHandler = (
-	req: TypesGen.CreateChatModelConfigRequest,
-) => Promise<unknown>;
-
-type UpdateModelHandler = (
-	modelConfigId: string,
-	req: TypesGen.UpdateChatModelConfigRequest,
-) => Promise<unknown>;
-
-type CreateModelMock = CreateModelHandler & {
-	mock: { calls: Array<[TypesGen.CreateChatModelConfigRequest]> };
-};
-
-type UpdateModelMock = UpdateModelHandler & {
-	mock: { calls: Array<[string, TypesGen.UpdateChatModelConfigRequest]> };
-};
-
-const isCreateModelMock = (
-	onCreateModel: CreateModelHandler,
-): onCreateModel is CreateModelMock => "mock" in onCreateModel;
-
-const isUpdateModelMock = (
-	onUpdateModel: UpdateModelHandler,
-): onUpdateModel is UpdateModelMock => "mock" in onUpdateModel;
-
 const meta: Meta<typeof ModelsSection> = {
 	title: "pages/AgentsPage/ChatModelAdminPanel/ModelsSection",
 	component: ModelsSection,
 	args: {
 		sectionLabel: "Models",
 		providerStates: [providerState],
-		selectedProvider: "openai",
-		selectedProviderState: providerState,
 		onSelectedProviderChange: fn(),
 		modelConfigs: [baseModelConfig],
 		modelConfigsUnavailable: false,
@@ -162,7 +135,7 @@ export const ShowsExplicitRowActions: Story = {
 		const canvas = within(canvasElement);
 		const user = userEvent.setup();
 		const rowButton = canvas.getByRole("button", {
-			name: "Edit model details: GPT-4.1",
+			name: "View model: GPT-4.1",
 		});
 		const starButton = canvas.getByRole("button", {
 			name: "Set as default model: GPT-4.1",
@@ -177,8 +150,6 @@ export const ShowsExplicitRowActions: Story = {
 		await expect(starButton).toBeVisible();
 		await expect(editButton).toBeVisible();
 		await expect(copyButton).toBeVisible();
-		expect(canvasElement.querySelector(".lucide-chevron-right")).toBeNull();
-
 		rowButton.focus();
 		await expect(rowButton).toHaveFocus();
 		await user.tab();
@@ -212,7 +183,9 @@ export const OpensDuplicateFormWithoutCreating: Story = {
 			"gpt-4.1-default",
 		);
 		expect(canvas.getByLabelText(/Context Limit/)).toHaveValue("200000");
-		expect(canvas.getByRole("switch", { name: "Enabled" })).toBeChecked();
+		const enabledSwitch = canvas.getByRole("switch", { name: "Enabled" });
+		expect(enabledSwitch).toBeChecked();
+		expect(enabledSwitch).toBeEnabled();
 
 		await userEvent.click(canvas.getByRole("button", { name: /Advanced/ }));
 		expect(canvas.getByLabelText(/Compression Threshold/)).toHaveValue("65");
@@ -280,38 +253,70 @@ export const SavesDuplicateAsCreateRequest: Story = {
 		await waitFor(() => expect(args.onCreateModel).toHaveBeenCalledTimes(1));
 		expect(args.onUpdateModel).not.toHaveBeenCalled();
 
-		if (!isCreateModelMock(args.onCreateModel)) {
-			throw new Error("Expected mocked create handler.");
-		}
-		const createReq = args.onCreateModel.mock.calls[0]?.[0];
+		const createModelMock = args.onCreateModel as ReturnType<typeof fn>;
+		const createReq = createModelMock.mock.calls[0]?.[0];
 		if (!createReq) {
 			throw new Error("Expected create request.");
 		}
-		expect(createReq).toEqual(
-			expect.objectContaining({
-				provider: "openai",
-				model: "gpt-4.1-copy",
-				display_name: "GPT-4.1 Copy",
-				enabled: true,
-				is_default: true,
-				context_limit: 200000,
-				compression_threshold: 65,
-			}),
-		);
-		expect(createReq.model_config).toEqual(
-			expect.objectContaining({
+		expect(createReq).toEqual({
+			provider: "openai",
+			model: "gpt-4.1-copy",
+			display_name: "GPT-4.1 Copy",
+			enabled: true,
+			is_default: false,
+			context_limit: 200000,
+			compression_threshold: 65,
+			model_config: {
 				max_output_tokens: 4096,
 				provider_options: {
-					openai: expect.objectContaining({
+					openai: {
 						max_tool_calls: 4,
 						reasoning_effort: "high",
-					}),
+					},
 				},
-			}),
+			},
+		});
+	},
+};
+
+export const SavesNonDefaultDuplicateWithEditableEnabled: Story = {
+	args: {
+		modelConfigs: [baseModelConfig],
+		onCreateModel: fn(async () => undefined),
+		onUpdateModel: fn(async () => undefined),
+	},
+	play: async ({ args, canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(
+			canvas.getByRole("button", { name: "Duplicate model: GPT-4.1" }),
 		);
-		expect("id" in createReq).toBe(false);
-		expect("created_at" in createReq).toBe(false);
-		expect("updated_at" in createReq).toBe(false);
+		await expect(canvas.findByText("Duplicate Model")).resolves.toBeVisible();
+
+		const enabledSwitch = canvas.getByRole("switch", { name: "Enabled" });
+		expect(enabledSwitch).toBeChecked();
+		expect(enabledSwitch).toBeEnabled();
+		await userEvent.click(enabledSwitch);
+
+		const modelInput = canvas.getByLabelText(/Model Identifier/);
+		await userEvent.clear(modelInput);
+		await userEvent.type(modelInput, "gpt-4.1-copy");
+		await userEvent.click(
+			canvas.getByRole("button", { name: "Create duplicate" }),
+		);
+
+		await waitFor(() => expect(args.onCreateModel).toHaveBeenCalledTimes(1));
+		expect(args.onUpdateModel).not.toHaveBeenCalled();
+
+		const createModelMock = args.onCreateModel as ReturnType<typeof fn>;
+		expect(createModelMock.mock.calls[0]?.[0]).toEqual({
+			provider: "openai",
+			model: "gpt-4.1-copy",
+			display_name: "GPT-4.1",
+			enabled: false,
+			is_default: false,
+			context_limit: 128000,
+			compression_threshold: 80,
+		});
 	},
 };
 
@@ -323,9 +328,7 @@ export const RowActionsDoNotOpenRowBody: Story = {
 	},
 	play: async ({ args, canvasElement }) => {
 		const canvas = within(canvasElement);
-		if (!isUpdateModelMock(args.onUpdateModel)) {
-			throw new Error("Expected mocked update handler.");
-		}
+		const updateModelMock = args.onUpdateModel as ReturnType<typeof fn>;
 
 		await userEvent.click(
 			canvas.getByRole("button", {
@@ -333,7 +336,7 @@ export const RowActionsDoNotOpenRowBody: Story = {
 			}),
 		);
 		await waitFor(() => expect(args.onUpdateModel).toHaveBeenCalledTimes(1));
-		expect(args.onUpdateModel.mock.calls[0]).toEqual([
+		expect(updateModelMock.mock.calls[0]).toEqual([
 			"model-config-id",
 			{ is_default: true },
 		]);

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelsSection.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelsSection.stories.tsx
@@ -31,6 +31,19 @@ const providerState: ProviderState = {
 	baseURL: "",
 };
 
+const providerStateWithoutAPIKey: ProviderState = {
+	...providerState,
+	providerConfig: {
+		...providerState.providerConfig!,
+		has_api_key: false,
+		central_api_key_enabled: false,
+		allow_user_api_key: false,
+	},
+	hasManagedAPIKey: false,
+	hasCatalogAPIKey: false,
+	hasEffectiveAPIKey: false,
+};
+
 const baseModelConfig: TypesGen.ChatModelConfig = {
 	id: "model-config-id",
 	provider: "openai",
@@ -42,6 +55,14 @@ const baseModelConfig: TypesGen.ChatModelConfig = {
 	compression_threshold: 80,
 	created_at: "2025-01-01T00:00:00Z",
 	updated_at: "2025-01-01T00:00:00Z",
+};
+
+const disabledModelConfig: TypesGen.ChatModelConfig = {
+	...baseModelConfig,
+	id: "disabled-model-config-id",
+	model: "gpt-4.1-disabled",
+	display_name: "GPT-4.1 Disabled",
+	enabled: false,
 };
 
 const defaultModelConfig: TypesGen.ChatModelConfig = {
@@ -77,7 +98,6 @@ const meta: Meta<typeof ModelsSection> = {
 	args: {
 		sectionLabel: "Models",
 		providerStates: [providerState],
-		onSelectedProviderChange: fn(),
 		modelConfigs: [baseModelConfig],
 		modelConfigsUnavailable: false,
 		isCreating: false,
@@ -135,7 +155,7 @@ export const ShowsExplicitRowActions: Story = {
 		const canvas = within(canvasElement);
 		const user = userEvent.setup();
 		const rowButton = canvas.getByRole("button", {
-			name: "View model: GPT-4.1",
+			name: "Open model: GPT-4.1",
 		});
 		const starButton = canvas.getByRole("button", {
 			name: "Set as default model: GPT-4.1",
@@ -317,6 +337,67 @@ export const SavesNonDefaultDuplicateWithEditableEnabled: Story = {
 			context_limit: 128000,
 			compression_threshold: 80,
 		});
+	},
+};
+
+export const SavesDisabledDuplicateWithEditableEnabled: Story = {
+	args: {
+		modelConfigs: [disabledModelConfig],
+		onCreateModel: fn(async () => undefined),
+		onUpdateModel: fn(async () => undefined),
+	},
+	play: async ({ args, canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(
+			canvas.getByRole("button", {
+				name: "Duplicate model: GPT-4.1 Disabled",
+			}),
+		);
+		await expect(canvas.findByText("Duplicate Model")).resolves.toBeVisible();
+
+		const enabledSwitch = canvas.getByRole("switch", { name: "Enabled" });
+		expect(enabledSwitch).not.toBeChecked();
+		expect(enabledSwitch).toBeEnabled();
+		await userEvent.click(enabledSwitch);
+
+		const modelInput = canvas.getByLabelText(/Model Identifier/);
+		await userEvent.clear(modelInput);
+		await userEvent.type(modelInput, "gpt-4.1-disabled-copy");
+		await userEvent.click(
+			canvas.getByRole("button", { name: "Create duplicate" }),
+		);
+
+		await waitFor(() => expect(args.onCreateModel).toHaveBeenCalledTimes(1));
+		const createModelMock = args.onCreateModel as ReturnType<typeof fn>;
+		expect(createModelMock.mock.calls[0]?.[0]).toEqual({
+			provider: "openai",
+			model: "gpt-4.1-disabled-copy",
+			display_name: "GPT-4.1 Disabled",
+			enabled: true,
+			is_default: false,
+			context_limit: 128000,
+			compression_threshold: 80,
+		});
+	},
+};
+
+export const DisablesDuplicateWhenProviderCannotManageModels: Story = {
+	args: {
+		providerStates: [providerStateWithoutAPIKey],
+		modelConfigs: [baseModelConfig],
+		onCreateModel: fn(async () => undefined),
+		onUpdateModel: fn(async () => undefined),
+	},
+	play: async ({ args, canvasElement }) => {
+		const canvas = within(canvasElement);
+		const duplicateButton = canvas.getByRole("button", {
+			name: "Duplicate model: GPT-4.1",
+		});
+
+		expect(duplicateButton).toHaveAttribute("aria-disabled", "true");
+		await userEvent.click(duplicateButton);
+		expect(canvas.queryByText("Duplicate Model")).not.toBeInTheDocument();
+		expect(args.onCreateModel).not.toHaveBeenCalled();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelsSection.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelsSection.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, fn, within } from "storybook/test";
+import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import type * as TypesGen from "#/api/typesGenerated";
 import { TooltipProvider } from "#/components/Tooltip/Tooltip";
 import type { ProviderState } from "./ChatModelAdminPanel";
@@ -43,6 +43,58 @@ const baseModelConfig: TypesGen.ChatModelConfig = {
 	created_at: "2025-01-01T00:00:00Z",
 	updated_at: "2025-01-01T00:00:00Z",
 };
+
+const defaultModelConfig: TypesGen.ChatModelConfig = {
+	...baseModelConfig,
+	id: "default-model-config-id",
+	model: "gpt-4o",
+	display_name: "GPT-4o",
+	is_default: true,
+};
+
+const duplicateSourceModel: TypesGen.ChatModelConfig = {
+	...baseModelConfig,
+	id: "duplicate-source-model-id",
+	model: "gpt-4.1-default",
+	display_name: "GPT-4.1 Default",
+	is_default: true,
+	context_limit: 200000,
+	compression_threshold: 65,
+	model_config: {
+		max_output_tokens: 4096,
+		provider_options: {
+			openai: {
+				max_tool_calls: 4,
+				reasoning_effort: "high",
+			},
+		},
+	},
+};
+
+type CreateModelHandler = (
+	req: TypesGen.CreateChatModelConfigRequest,
+) => Promise<unknown>;
+
+type UpdateModelHandler = (
+	modelConfigId: string,
+	req: TypesGen.UpdateChatModelConfigRequest,
+) => Promise<unknown>;
+
+type CreateModelMock = CreateModelHandler & {
+	mock: { calls: Array<[TypesGen.CreateChatModelConfigRequest]> };
+};
+
+type UpdateModelMock = UpdateModelHandler & {
+	mock: { calls: Array<[string, TypesGen.UpdateChatModelConfigRequest]> };
+};
+
+const isCreateModelMock = (
+	onCreateModel: CreateModelHandler,
+): onCreateModel is CreateModelMock => "mock" in onCreateModel;
+
+const isUpdateModelMock = (
+	onUpdateModel: UpdateModelHandler,
+): onUpdateModel is UpdateModelMock => "mock" in onUpdateModel;
 
 const meta: Meta<typeof ModelsSection> = {
 	title: "pages/AgentsPage/ChatModelAdminPanel/ModelsSection",
@@ -102,5 +154,209 @@ export const HidesPricingWarningForExplicitZeroPricing: Story = {
 		expect(
 			canvas.queryByText("Model pricing is not defined"),
 		).not.toBeInTheDocument();
+	},
+};
+
+export const ShowsExplicitRowActions: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const user = userEvent.setup();
+		const rowButton = canvas.getByRole("button", {
+			name: "Edit model details: GPT-4.1",
+		});
+		const starButton = canvas.getByRole("button", {
+			name: "Set as default model: GPT-4.1",
+		});
+		const editButton = canvas.getByRole("button", {
+			name: "Edit model: GPT-4.1",
+		});
+		const copyButton = canvas.getByRole("button", {
+			name: "Duplicate model: GPT-4.1",
+		});
+
+		await expect(starButton).toBeVisible();
+		await expect(editButton).toBeVisible();
+		await expect(copyButton).toBeVisible();
+		expect(canvasElement.querySelector(".lucide-chevron-right")).toBeNull();
+
+		rowButton.focus();
+		await expect(rowButton).toHaveFocus();
+		await user.tab();
+		await expect(starButton).toHaveFocus();
+		await user.tab();
+		await expect(editButton).toHaveFocus();
+		await user.tab();
+		await expect(copyButton).toHaveFocus();
+	},
+};
+
+export const OpensDuplicateFormWithoutCreating: Story = {
+	args: {
+		modelConfigs: [duplicateSourceModel],
+		onCreateModel: fn(async () => undefined),
+		onUpdateModel: fn(async () => undefined),
+	},
+	play: async ({ args, canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(
+			canvas.getByRole("button", {
+				name: "Duplicate model: GPT-4.1 Default",
+			}),
+		);
+
+		await expect(canvas.findByText("Duplicate Model")).resolves.toBeVisible();
+		expect(args.onCreateModel).not.toHaveBeenCalled();
+		expect(args.onUpdateModel).not.toHaveBeenCalled();
+		expect(canvas.getByDisplayValue("GPT-4.1 Default")).toBeVisible();
+		expect(canvas.getByLabelText(/Model Identifier/)).toHaveValue(
+			"gpt-4.1-default",
+		);
+		expect(canvas.getByLabelText(/Context Limit/)).toHaveValue("200000");
+		expect(canvas.getByRole("switch", { name: "Enabled" })).toBeChecked();
+
+		await userEvent.click(canvas.getByRole("button", { name: /Advanced/ }));
+		expect(canvas.getByLabelText(/Compression Threshold/)).toHaveValue("65");
+
+		await userEvent.click(
+			canvas.getByRole("button", { name: /Provider Configuration/ }),
+		);
+		expect(canvas.getByLabelText("Max Tool Calls")).toHaveValue("4");
+	},
+};
+
+export const AbandonsDuplicateWithoutSaving: Story = {
+	args: {
+		modelConfigs: [duplicateSourceModel],
+		onCreateModel: fn(async () => undefined),
+		onUpdateModel: fn(async () => undefined),
+	},
+	play: async ({ args, canvasElement }) => {
+		const canvas = within(canvasElement);
+		const copyButtonName = "Duplicate model: GPT-4.1 Default";
+
+		await userEvent.click(canvas.getByRole("button", { name: copyButtonName }));
+		await expect(canvas.findByText("Duplicate Model")).resolves.toBeVisible();
+		await userEvent.click(canvas.getByRole("button", { name: "Cancel" }));
+		await expect(
+			canvas.findByRole("button", { name: copyButtonName }),
+		).resolves.toBeVisible();
+
+		await userEvent.click(canvas.getByRole("button", { name: copyButtonName }));
+		await expect(canvas.findByText("Duplicate Model")).resolves.toBeVisible();
+		await userEvent.click(canvas.getByRole("button", { name: "Back" }));
+		await expect(
+			canvas.findByRole("button", { name: copyButtonName }),
+		).resolves.toBeVisible();
+		expect(args.onCreateModel).not.toHaveBeenCalled();
+		expect(args.onUpdateModel).not.toHaveBeenCalled();
+	},
+};
+
+export const SavesDuplicateAsCreateRequest: Story = {
+	args: {
+		modelConfigs: [duplicateSourceModel],
+		onCreateModel: fn(async () => undefined),
+		onUpdateModel: fn(async () => undefined),
+	},
+	play: async ({ args, canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(
+			canvas.getByRole("button", {
+				name: "Duplicate model: GPT-4.1 Default",
+			}),
+		);
+		await expect(canvas.findByText("Duplicate Model")).resolves.toBeVisible();
+
+		const modelInput = canvas.getByLabelText(/Model Identifier/);
+		await userEvent.clear(modelInput);
+		await userEvent.type(modelInput, "gpt-4.1-copy");
+		const displayNameInput = canvas.getByDisplayValue("GPT-4.1 Default");
+		await userEvent.clear(displayNameInput);
+		await userEvent.type(displayNameInput, "GPT-4.1 Copy");
+		await userEvent.click(
+			canvas.getByRole("button", { name: "Create duplicate" }),
+		);
+
+		await waitFor(() => expect(args.onCreateModel).toHaveBeenCalledTimes(1));
+		expect(args.onUpdateModel).not.toHaveBeenCalled();
+
+		if (!isCreateModelMock(args.onCreateModel)) {
+			throw new Error("Expected mocked create handler.");
+		}
+		const createReq = args.onCreateModel.mock.calls[0]?.[0];
+		if (!createReq) {
+			throw new Error("Expected create request.");
+		}
+		expect(createReq).toEqual(
+			expect.objectContaining({
+				provider: "openai",
+				model: "gpt-4.1-copy",
+				display_name: "GPT-4.1 Copy",
+				enabled: true,
+				is_default: true,
+				context_limit: 200000,
+				compression_threshold: 65,
+			}),
+		);
+		expect(createReq.model_config).toEqual(
+			expect.objectContaining({
+				max_output_tokens: 4096,
+				provider_options: {
+					openai: expect.objectContaining({
+						max_tool_calls: 4,
+						reasoning_effort: "high",
+					}),
+				},
+			}),
+		);
+		expect("id" in createReq).toBe(false);
+		expect("created_at" in createReq).toBe(false);
+		expect("updated_at" in createReq).toBe(false);
+	},
+};
+
+export const RowActionsDoNotOpenRowBody: Story = {
+	args: {
+		modelConfigs: [baseModelConfig, defaultModelConfig],
+		onCreateModel: fn(async () => undefined),
+		onUpdateModel: fn(async () => undefined),
+	},
+	play: async ({ args, canvasElement }) => {
+		const canvas = within(canvasElement);
+		if (!isUpdateModelMock(args.onUpdateModel)) {
+			throw new Error("Expected mocked update handler.");
+		}
+
+		await userEvent.click(
+			canvas.getByRole("button", {
+				name: "Set as default model: GPT-4.1",
+			}),
+		);
+		await waitFor(() => expect(args.onUpdateModel).toHaveBeenCalledTimes(1));
+		expect(args.onUpdateModel.mock.calls[0]).toEqual([
+			"model-config-id",
+			{ is_default: true },
+		]);
+		expect(canvas.queryByText("Edit Model")).not.toBeInTheDocument();
+
+		await userEvent.click(
+			canvas.getByRole("button", { name: "Default model: GPT-4o" }),
+		);
+		expect(args.onUpdateModel).toHaveBeenCalledTimes(1);
+		expect(canvas.queryByText("Edit Model")).not.toBeInTheDocument();
+
+		await userEvent.click(
+			canvas.getByRole("button", { name: "Duplicate model: GPT-4.1" }),
+		);
+		await expect(canvas.findByText("Duplicate Model")).resolves.toBeVisible();
+		expect(args.onCreateModel).not.toHaveBeenCalled();
+		expect(args.onUpdateModel).toHaveBeenCalledTimes(1);
+		expect(canvas.queryByText("Edit Model")).not.toBeInTheDocument();
+
+		await userEvent.click(canvas.getByRole("button", { name: "Back" }));
+		await userEvent.click(
+			await canvas.findByRole("button", { name: "Edit model: GPT-4.1" }),
+		);
+		await expect(canvas.findByText("Edit Model")).resolves.toBeVisible();
 	},
 };

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelsSection.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelsSection.stories.tsx
@@ -403,7 +403,7 @@ export const DisablesDuplicateWhenProviderCannotManageModels: Story = {
 
 export const RowActionsDoNotOpenRowBody: Story = {
 	args: {
-		modelConfigs: [baseModelConfig, defaultModelConfig],
+		modelConfigs: [baseModelConfig, defaultModelConfig, disabledModelConfig],
 		onCreateModel: fn(async () => undefined),
 		onUpdateModel: fn(async () => undefined),
 	},
@@ -426,6 +426,14 @@ export const RowActionsDoNotOpenRowBody: Story = {
 		await userEvent.click(
 			canvas.getByRole("button", { name: "Default model: GPT-4o" }),
 		);
+		expect(args.onUpdateModel).toHaveBeenCalledTimes(1);
+		expect(canvas.queryByText("Edit Model")).not.toBeInTheDocument();
+
+		const disabledStarButton = canvas.getByRole("button", {
+			name: "Set as default model: GPT-4.1 Disabled",
+		});
+		expect(disabledStarButton).toHaveAttribute("aria-disabled", "true");
+		await userEvent.click(disabledStarButton);
 		expect(args.onUpdateModel).toHaveBeenCalledTimes(1);
 		expect(canvas.queryByText("Edit Model")).not.toBeInTheDocument();
 

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelsSection.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelsSection.tsx
@@ -44,11 +44,18 @@ const clearModelViewParams = (params: URLSearchParams) => {
 	}
 };
 
+const canManageProviderModels = (providerState: ProviderState | undefined) => {
+	return Boolean(
+		providerState?.providerConfig &&
+			(providerState.hasEffectiveAPIKey ||
+				providerState.providerConfig.allow_user_api_key),
+	);
+};
+
 interface ModelsSectionProps {
 	sectionLabel?: string;
 	sectionDescription?: string;
 	providerStates: readonly ProviderState[];
-	onSelectedProviderChange: (provider: string) => void;
 	modelConfigs: readonly TypesGen.ChatModelConfig[];
 	modelConfigsUnavailable: boolean;
 	isCreating: boolean;
@@ -68,7 +75,6 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 	sectionLabel,
 	sectionDescription,
 	providerStates,
-	onSelectedProviderChange,
 	modelConfigs,
 	modelConfigsUnavailable,
 	isCreating,
@@ -179,7 +185,6 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 				selectedProvider={effectiveProvider}
 				selectedProviderState={effectiveProviderState}
 				onSelectedProviderChange={(provider) => {
-					onSelectedProviderChange(provider);
 					if (view.mode === "add") {
 						setModelViewParam("newModel", provider);
 					}
@@ -212,11 +217,7 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 
 	// Only show providers that have a deployment key configured or allow
 	// end users to bring their own key.
-	const addableProviders = providerStates.filter(
-		(ps) =>
-			ps.providerConfig &&
-			(ps.hasEffectiveAPIKey || ps.providerConfig.allow_user_api_key),
-	);
+	const addableProviders = providerStates.filter(canManageProviderModels);
 
 	const addButton = addableProviders.length > 0 && (
 		<DropdownMenu>
@@ -232,7 +233,6 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 					<DropdownMenuItem
 						key={ps.provider}
 						onClick={() => {
-							onSelectedProviderChange(ps.provider);
 							setModelViewParam("newModel", ps.provider);
 						}}
 						className="gap-2"
@@ -286,6 +286,11 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 							: `Set as default model: ${modelName}`;
 						const starUnavailable =
 							isUpdating || modelConfig.is_default || !modelConfig.enabled;
+						const providerState = providerStates.find(
+							(ps) => ps.provider === modelConfig.provider,
+						);
+						const duplicateUnavailable =
+							!canManageProviderModels(providerState);
 
 						return (
 							<div
@@ -298,7 +303,7 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 								<button
 									type="button"
 									onClick={() => setModelViewParam("model", modelConfig.id)}
-									aria-label={`View model: ${modelName}`}
+									aria-label={`Open model: ${modelName}`}
 									className="flex min-w-0 flex-1 cursor-pointer items-center gap-3.5 border-0 bg-transparent p-0 text-left"
 								>
 									<ProviderIcon
@@ -387,15 +392,25 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 												variant="subtle"
 												onClick={(event) => {
 													event.stopPropagation();
+													if (duplicateUnavailable) return;
 													setModelViewParam("duplicate", modelConfig.id);
 												}}
+												aria-disabled={duplicateUnavailable}
 												aria-label={`Duplicate model: ${modelName}`}
-												className="hover:bg-surface-secondary"
+												className={cn(
+													"hover:bg-surface-secondary",
+													duplicateUnavailable &&
+														"cursor-not-allowed text-content-secondary/40 hover:bg-transparent hover:text-content-secondary/40",
+												)}
 											>
 												<CopyIcon />
 											</Button>
 										</TooltipTrigger>
-										<TooltipContent side="top">Duplicate model</TooltipContent>
+										<TooltipContent side="top">
+											{duplicateUnavailable
+												? "Set an API key for this provider before duplicating models"
+												: "Duplicate model"}
+										</TooltipContent>
 									</Tooltip>
 								</div>
 							</div>

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelsSection.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelsSection.tsx
@@ -35,20 +35,19 @@ type ModelView =
 	| { mode: "edit"; model: TypesGen.ChatModelConfig }
 	| { mode: "duplicate"; sourceModel: TypesGen.ChatModelConfig };
 
-type ModelViewParam = "model" | "newModel" | "duplicate";
+const MODEL_VIEW_PARAMS = ["model", "newModel", "duplicate"] as const;
+type ModelViewParam = (typeof MODEL_VIEW_PARAMS)[number];
 
 const clearModelViewParams = (params: URLSearchParams) => {
-	params.delete("model");
-	params.delete("newModel");
-	params.delete("duplicate");
+	for (const param of MODEL_VIEW_PARAMS) {
+		params.delete(param);
+	}
 };
 
 interface ModelsSectionProps {
 	sectionLabel?: string;
 	sectionDescription?: string;
 	providerStates: readonly ProviderState[];
-	selectedProvider: string | null;
-	selectedProviderState: ProviderState | null;
 	onSelectedProviderChange: (provider: string) => void;
 	modelConfigs: readonly TypesGen.ChatModelConfig[];
 	modelConfigsUnavailable: boolean;
@@ -179,7 +178,12 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 				providerStates={providerStates}
 				selectedProvider={effectiveProvider}
 				selectedProviderState={effectiveProviderState}
-				onSelectedProviderChange={onSelectedProviderChange}
+				onSelectedProviderChange={(provider) => {
+					onSelectedProviderChange(provider);
+					if (view.mode === "add") {
+						setModelViewParam("newModel", provider);
+					}
+				}}
 				modelConfigsUnavailable={modelConfigsUnavailable}
 				isSaving={isCreating || isUpdating}
 				isDeleting={isDeleting}
@@ -294,7 +298,7 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 								<button
 									type="button"
 									onClick={() => setModelViewParam("model", modelConfig.id)}
-									aria-label={`Edit model details: ${modelName}`}
+									aria-label={`View model: ${modelName}`}
 									className="flex min-w-0 flex-1 cursor-pointer items-center gap-3.5 border-0 bg-transparent p-0 text-left"
 								>
 									<ProviderIcon
@@ -328,8 +332,9 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 								<div className="flex shrink-0 items-center gap-1">
 									<Tooltip>
 										<TooltipTrigger asChild>
-											<button
-												type="button"
+											<Button
+												size="icon"
+												variant="subtle"
 												onClick={(event) => {
 													event.stopPropagation();
 													handleSetDefault(modelConfig);
@@ -337,7 +342,7 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 												aria-disabled={starUnavailable}
 												aria-label={starLabel}
 												className={cn(
-													"flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-md border-0 bg-transparent p-0 text-content-secondary transition-colors hover:bg-surface-secondary hover:text-content-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-content-link",
+													"hover:bg-surface-secondary",
 													starUnavailable &&
 														"cursor-not-allowed text-content-secondary/40 hover:bg-transparent hover:text-content-secondary/40",
 													modelConfig.is_default && "text-content-primary",
@@ -345,11 +350,10 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 											>
 												<StarIcon
 													className={cn(
-														"h-4 w-4",
 														modelConfig.is_default && "fill-current",
 													)}
 												/>
-											</button>
+											</Button>
 										</TooltipTrigger>
 										<TooltipContent side="top">
 											{!modelConfig.enabled
@@ -361,33 +365,35 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 									</Tooltip>
 									<Tooltip>
 										<TooltipTrigger asChild>
-											<button
-												type="button"
+											<Button
+												size="icon"
+												variant="subtle"
 												onClick={(event) => {
 													event.stopPropagation();
 													setModelViewParam("model", modelConfig.id);
 												}}
 												aria-label={`Edit model: ${modelName}`}
-												className="flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-md border-0 bg-transparent p-0 text-content-secondary transition-colors hover:bg-surface-secondary hover:text-content-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-content-link"
+												className="hover:bg-surface-secondary"
 											>
-												<PencilIcon className="h-4 w-4" />
-											</button>
+												<PencilIcon />
+											</Button>
 										</TooltipTrigger>
 										<TooltipContent side="top">Edit model</TooltipContent>
 									</Tooltip>
 									<Tooltip>
 										<TooltipTrigger asChild>
-											<button
-												type="button"
+											<Button
+												size="icon"
+												variant="subtle"
 												onClick={(event) => {
 													event.stopPropagation();
 													setModelViewParam("duplicate", modelConfig.id);
 												}}
 												aria-label={`Duplicate model: ${modelName}`}
-												className="flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-md border-0 bg-transparent p-0 text-content-secondary transition-colors hover:bg-surface-secondary hover:text-content-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-content-link"
+												className="hover:bg-surface-secondary"
 											>
-												<CopyIcon className="h-4 w-4" />
-											</button>
+												<CopyIcon />
+											</Button>
 										</TooltipTrigger>
 										<TooltipContent side="top">Duplicate model</TooltipContent>
 									</Tooltip>

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelsSection.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelsSection.tsx
@@ -117,11 +117,18 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 		return { mode: "list" };
 	})();
 
-	const setModelViewParam = (param: ModelViewParam, value: string) => {
+	const setModelViewParam = (
+		param: ModelViewParam,
+		value: string,
+		options?: { replace?: boolean },
+	) => {
 		const nextParams = new URLSearchParams(searchParams);
 		clearModelViewParams(nextParams);
 		nextParams.set(param, value);
-		setSearchParams(nextParams, { state: { pushed: true } });
+		setSearchParams(nextParams, {
+			replace: options?.replace,
+			state: options?.replace ? location.state : { pushed: true },
+		});
 	};
 
 	// Clear model-related search params and return to the list.
@@ -186,7 +193,7 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 				selectedProviderState={effectiveProviderState}
 				onSelectedProviderChange={(provider) => {
 					if (view.mode === "add") {
-						setModelViewParam("newModel", provider);
+						setModelViewParam("newModel", provider, { replace: true });
 					}
 				}}
 				modelConfigsUnavailable={modelConfigsUnavailable}

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelsSection.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ModelsSection.tsx
@@ -1,8 +1,9 @@
 import {
 	ChevronDownIcon,
-	ChevronRightIcon,
-	PinIcon,
+	CopyIcon,
+	PencilIcon,
 	PlusIcon,
+	StarIcon,
 	TriangleAlertIcon,
 } from "lucide-react";
 import type { FC } from "react";
@@ -31,7 +32,16 @@ import { hasCustomPricing } from "./pricingFields";
 type ModelView =
 	| { mode: "list" }
 	| { mode: "add"; provider: string }
-	| { mode: "edit"; model: TypesGen.ChatModelConfig };
+	| { mode: "edit"; model: TypesGen.ChatModelConfig }
+	| { mode: "duplicate"; sourceModel: TypesGen.ChatModelConfig };
+
+type ModelViewParam = "model" | "newModel" | "duplicate";
+
+const clearModelViewParams = (params: URLSearchParams) => {
+	params.delete("model");
+	params.delete("newModel");
+	params.delete("duplicate");
+};
 
 interface ModelsSectionProps {
 	sectionLabel?: string;
@@ -59,8 +69,6 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 	sectionLabel,
 	sectionDescription,
 	providerStates,
-	selectedProvider,
-	selectedProviderState,
 	onSelectedProviderChange,
 	modelConfigs,
 	modelConfigsUnavailable,
@@ -90,6 +98,13 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 			const model = modelConfigs.find((m) => m.id === editModelId);
 			return model ? { mode: "edit", model } : { mode: "list" };
 		}
+		const duplicateModelId = searchParams.get("duplicate");
+		if (duplicateModelId) {
+			const sourceModel = modelConfigs.find((m) => m.id === duplicateModelId);
+			return sourceModel
+				? { mode: "duplicate", sourceModel }
+				: { mode: "list" };
+		}
 		const addProvider = searchParams.get("newModel");
 		if (addProvider) {
 			return { mode: "add", provider: addProvider };
@@ -97,12 +112,18 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 		return { mode: "list" };
 	})();
 
+	const setModelViewParam = (param: ModelViewParam, value: string) => {
+		const nextParams = new URLSearchParams(searchParams);
+		clearModelViewParams(nextParams);
+		nextParams.set(param, value);
+		setSearchParams(nextParams, { state: { pushed: true } });
+	};
+
 	// Clear model-related search params and return to the list.
 	const clearModelView = () => {
 		setSearchParams((prev) => {
 			const next = new URLSearchParams(prev);
-			next.delete("model");
-			next.delete("newModel");
+			clearModelViewParams(next);
 			return next;
 		});
 	};
@@ -118,8 +139,7 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 			setSearchParams(
 				(prev) => {
 					const next = new URLSearchParams(prev);
-					next.delete("model");
-					next.delete("newModel");
+					clearModelViewParams(next);
 					return next;
 				},
 				{ replace: true },
@@ -128,28 +148,34 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 	};
 
 	// When the form is open it takes over the full panel.
-	if (view.mode === "add" || view.mode === "edit") {
+	if (
+		view.mode === "add" ||
+		view.mode === "edit" ||
+		view.mode === "duplicate"
+	) {
 		const editingModel = view.mode === "edit" ? view.model : undefined;
-
-		const getEffectiveProvider = () => {
-			if (editingModel) {
-				return editingModel.provider;
-			}
-			if (view.mode === "add") {
-				return view.provider;
-			}
-			return selectedProvider;
-		};
-
-		const effectiveProvider = getEffectiveProvider();
-		const effectiveProviderState = effectiveProvider
-			? (providerStates.find((ps) => ps.provider === effectiveProvider) ?? null)
-			: selectedProviderState;
+		const duplicateSourceModel =
+			view.mode === "duplicate" ? view.sourceModel : undefined;
+		const effectiveProvider =
+			view.mode === "edit"
+				? view.model.provider
+				: view.mode === "duplicate"
+					? view.sourceModel.provider
+					: view.provider;
+		const effectiveProviderState =
+			providerStates.find((ps) => ps.provider === effectiveProvider) ?? null;
+		const formKey =
+			view.mode === "edit"
+				? `edit:${view.model.id}`
+				: view.mode === "duplicate"
+					? `duplicate:${view.sourceModel.id}`
+					: `add:${view.provider}`;
 
 		return (
 			<ModelForm
-				key={editingModel?.id ?? effectiveProvider ?? "new"}
+				key={formKey}
 				editingModel={editingModel}
+				duplicateSourceModel={duplicateSourceModel}
 				providerStates={providerStates}
 				selectedProvider={effectiveProvider}
 				selectedProviderState={effectiveProviderState}
@@ -203,10 +229,7 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 						key={ps.provider}
 						onClick={() => {
 							onSelectedProviderChange(ps.provider);
-							setSearchParams(
-								{ newModel: ps.provider },
-								{ state: { pushed: true } },
-							);
+							setModelViewParam("newModel", ps.provider);
 						}}
 						className="gap-2"
 					>
@@ -219,7 +242,7 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 	);
 
 	const handleSetDefault = (modelConfig: TypesGen.ChatModelConfig) => {
-		if (modelConfig.is_default || !modelConfig.enabled) return;
+		if (isUpdating || modelConfig.is_default || !modelConfig.enabled) return;
 		void onUpdateModel(modelConfig.id, { is_default: true });
 	};
 
@@ -253,6 +276,12 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 						const showPricingWarning = !hasCustomPricing(
 							modelConfig.model_config,
 						);
+						const modelName = modelConfig.display_name || modelConfig.model;
+						const starLabel = modelConfig.is_default
+							? `Default model: ${modelName}`
+							: `Set as default model: ${modelName}`;
+						const starUnavailable =
+							isUpdating || modelConfig.is_default || !modelConfig.enabled;
 
 						return (
 							<div
@@ -262,16 +291,11 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 									i > 0 && "border-0 border-t border-solid border-border/50",
 								)}
 							>
-								{/* Clickable row content */}
 								<button
 									type="button"
-									onClick={() =>
-										setSearchParams(
-											{ model: modelConfig.id },
-											{ state: { pushed: true } },
-										)
-									}
-									className="flex min-w-0 flex-1 cursor-pointer items-center gap-3.5 bg-transparent border-0 p-0 text-left"
+									onClick={() => setModelViewParam("model", modelConfig.id)}
+									aria-label={`Edit model details: ${modelName}`}
+									className="flex min-w-0 flex-1 cursor-pointer items-center gap-3.5 border-0 bg-transparent p-0 text-left"
 								>
 									<ProviderIcon
 										provider={modelConfig.provider}
@@ -286,7 +310,7 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 													: "text-content-primary",
 											)}
 										>
-											{modelConfig.display_name || modelConfig.model}
+											{modelName}
 										</span>
 										{showPricingWarning && (
 											<span className="mt-1 flex items-center gap-1 text-xs text-content-warning">
@@ -301,51 +325,73 @@ export const ModelsSection: FC<ModelsSectionProps> = ({
 										</Badge>
 									)}
 								</button>
-								{/* Pin for default */}
-								<Tooltip>
-									<TooltipTrigger asChild>
-										<button
-											type="button"
-											onClick={(e) => {
-												e.stopPropagation();
-												handleSetDefault(modelConfig);
-											}}
-											aria-disabled={
-												isUpdating ||
-												modelConfig.is_default ||
-												!modelConfig.enabled
-											}
-											aria-label={
-												modelConfig.is_default
-													? "Default model"
-													: "Set as default model"
-											}
-											className={cn(
-												"flex shrink-0 items-center justify-center bg-transparent border-0 p-0 transition-colors",
-												modelConfig.is_default
-													? "text-content-primary"
-													: !modelConfig.enabled
-														? "cursor-not-allowed text-content-secondary/30"
-														: "cursor-pointer text-content-secondary/30 hover:text-content-secondary",
-											)}
-										>
-											<PinIcon
+								<div className="flex shrink-0 items-center gap-1">
+									<Tooltip>
+										<TooltipTrigger asChild>
+											<button
+												type="button"
+												onClick={(event) => {
+													event.stopPropagation();
+													handleSetDefault(modelConfig);
+												}}
+												aria-disabled={starUnavailable}
+												aria-label={starLabel}
 												className={cn(
-													"h-4 w-4",
-													modelConfig.is_default && "fill-current",
+													"flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-md border-0 bg-transparent p-0 text-content-secondary transition-colors hover:bg-surface-secondary hover:text-content-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-content-link",
+													starUnavailable &&
+														"cursor-not-allowed text-content-secondary/40 hover:bg-transparent hover:text-content-secondary/40",
+													modelConfig.is_default && "text-content-primary",
 												)}
-											/>
-										</button>
-									</TooltipTrigger>
-									<TooltipContent side="left">
-										{!modelConfig.enabled
-											? "Cannot set a disabled model as default"
-											: modelConfig.is_default
-												? "Pinned as default for new conversations"
-												: "Pin as default for new conversations"}
-									</TooltipContent>
-								</Tooltip>
-								<ChevronRightIcon className="h-5 w-5 shrink-0 text-content-secondary" />
+											>
+												<StarIcon
+													className={cn(
+														"h-4 w-4",
+														modelConfig.is_default && "fill-current",
+													)}
+												/>
+											</button>
+										</TooltipTrigger>
+										<TooltipContent side="top">
+											{!modelConfig.enabled
+												? "Cannot set a disabled model as default"
+												: modelConfig.is_default
+													? "Default for new conversations"
+													: "Set as default for new conversations"}
+										</TooltipContent>
+									</Tooltip>
+									<Tooltip>
+										<TooltipTrigger asChild>
+											<button
+												type="button"
+												onClick={(event) => {
+													event.stopPropagation();
+													setModelViewParam("model", modelConfig.id);
+												}}
+												aria-label={`Edit model: ${modelName}`}
+												className="flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-md border-0 bg-transparent p-0 text-content-secondary transition-colors hover:bg-surface-secondary hover:text-content-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-content-link"
+											>
+												<PencilIcon className="h-4 w-4" />
+											</button>
+										</TooltipTrigger>
+										<TooltipContent side="top">Edit model</TooltipContent>
+									</Tooltip>
+									<Tooltip>
+										<TooltipTrigger asChild>
+											<button
+												type="button"
+												onClick={(event) => {
+													event.stopPropagation();
+													setModelViewParam("duplicate", modelConfig.id);
+												}}
+												aria-label={`Duplicate model: ${modelName}`}
+												className="flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-md border-0 bg-transparent p-0 text-content-secondary transition-colors hover:bg-surface-secondary hover:text-content-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-content-link"
+											>
+												<CopyIcon className="h-4 w-4" />
+											</button>
+										</TooltipTrigger>
+										<TooltipContent side="top">Duplicate model</TooltipContent>
+									</Tooltip>
+								</div>
 							</div>
 						);
 					})}

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ProvidersSection.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ProvidersSection.tsx
@@ -25,7 +25,6 @@ interface ProvidersSectionProps {
 		req: TypesGen.UpdateChatProviderConfigRequest,
 	) => Promise<unknown>;
 	onDeleteProvider: (providerConfigId: string) => Promise<void>;
-	onSelectedProviderChange: (provider: string) => void;
 }
 
 export const ProvidersSection: FC<ProvidersSectionProps> = ({
@@ -37,7 +36,6 @@ export const ProvidersSection: FC<ProvidersSectionProps> = ({
 	onCreateProvider,
 	onUpdateProvider,
 	onDeleteProvider,
-	onSelectedProviderChange,
 }) => {
 	const [searchParams, setSearchParams] = useSearchParams();
 	const navigate = useNavigate();
@@ -141,7 +139,6 @@ export const ProvidersSection: FC<ProvidersSectionProps> = ({
 						key={providerState.provider}
 						aria-label={providerState.label}
 						onClick={() => {
-							onSelectedProviderChange(providerState.provider);
 							setSearchParams(
 								{ provider: providerState.provider },
 								{ state: { pushed: true } },

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/modelConfigFormLogic.ts
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/modelConfigFormLogic.ts
@@ -221,18 +221,18 @@ export const extractModelConfigFormState = (
 // ── Build initial model form values ────────────────────────────
 
 export const buildInitialModelFormValues = (
-	editingModel?: TypesGen.ChatModelConfig,
+	sourceModel?: TypesGen.ChatModelConfig,
 ): ModelFormValues => ({
-	model: editingModel?.model ?? "",
-	displayName: editingModel?.display_name ?? "",
-	enabled: editingModel?.enabled ?? true,
-	contextLimit: editingModel ? String(editingModel.context_limit) : "",
-	compressionThreshold: editingModel
-		? String(editingModel.compression_threshold)
+	model: sourceModel?.model ?? "",
+	displayName: sourceModel?.display_name ?? "",
+	enabled: sourceModel?.enabled ?? true,
+	contextLimit: sourceModel ? String(sourceModel.context_limit) : "",
+	compressionThreshold: sourceModel
+		? String(sourceModel.compression_threshold)
 		: "",
-	isDefault: editingModel?.is_default ?? false,
-	config: editingModel
-		? extractModelConfigFormState(editingModel)
+	isDefault: sourceModel?.is_default ?? false,
+	config: sourceModel
+		? extractModelConfigFormState(sourceModel)
 		: structuredClone(emptyModelConfigFormState),
 });
 


### PR DESCRIPTION
> Mux is acting on Mike's behalf.

Adds explicit star, edit, and duplicate actions to each Agents model configuration row, replacing the chevron-only affordance.

Duplicate opens a prefilled create form backed by the existing create mutation when the provider can manage models. The form copies editable model fields and provider config while clearing default status so saving a duplicate does not change the current default model.
