### PR TITLE
docs: add early access user secrets guide

### DIFF
--- a/docs/admin/security/secrets.md
+++ b/docs/admin/security/secrets.md
@@ -5,9 +5,11 @@ more information about how to use secrets and other security tips, visit our
 guide to
 [security best practices](../../tutorials/best-practices/security-best-practices.md#secrets).
 
-This article explains how to use secrets in a workspace. To authenticate the
-workspace provisioner, see the
+This article explains template administrator approaches to using secrets in a
+workspace. To authenticate the workspace provisioner, see the
 <a href="../provisioners/index.md#authentication">provisioners documentation</a>.
+To manage personal secret values, see
+[User secrets](../../user-guides/user-secrets.md).
 
 ## Before you begin
 
@@ -42,51 +44,11 @@ Users can view their public key in their account settings:
 > SSH keys are never stored in Coder workspaces, and are fetched only when
 > SSH is invoked. The keys are held in-memory and never written to disk.
 
-## User Secrets
+## User secrets (beta)
 
-User secrets let each user store their own secret values in Coder and make
-them available in workspaces without adding those values to template code.
-They are a good fit for per-user credentials such as API keys, cloud
-credentials, or other values that should follow a user across workspaces.
-
-Use the CLI to create and manage user secrets:
-
-```sh
-# Create a secret from stdin and inject it into workspaces as an environment
-# variable.
-printf %s "$API_KEY" | coder secret create api-key \
-  --description "API key for workspace tools" \
-  --env API_KEY
-
-# Create a secret from stdin and inject it into a file in your workspace.
-printf %s "$TOOL_CONFIG_CONTENTS" | coder secret create tool-config \
-  --description "Tool configuration" \
-  --file ~/.config/tool/config.json
-
-# List all of your secrets.
-coder secret list
-
-# Show a single secret by name.
-coder secret list api-key
-
-# Delete a secret you no longer need.
-coder secret delete api-key
-```
-
-Use `--env` to inject a secret into your workspaces as an environment
-variable. Use `--file` to inject it as a file in the workspace. File
-paths must start with `~/` or `/`. Provide a secret value with `--value`,
-or non-interactive stdin (pipe or redirect). Stdin is read verbatim. This
-means `echo "$API_KEY" | ...` usually adds a trailing newline to the stored
-value. Prefer `printf %s "$API_KEY" | ...` or `echo -n "$API_KEY" | ...`
-when you do not want that newline.
-
-You can update a secret later with `coder secret update`, including rotating
-the value or clearing an injection target by passing an empty string. Use
-`coder secret delete` to remove a secret entirely. The secret value itself is
-never returned by the API or CLI list output. For full command details, see
-[`coder secret`](../../reference/cli/secret.md) and the
-[Secrets API reference](../../reference/api/secrets.md).
+User secrets are personal credentials that developers manage for their own
+workspaces. They are injected into all of their workspaces. See the
+[User secrets guide](../../user-guides/user-secrets.md).
 
 ## Dynamic Secrets
 

--- a/docs/admin/security/secrets.md
+++ b/docs/admin/security/secrets.md
@@ -8,7 +8,7 @@ guide to
 Use this guide to configure how templates make secrets available to Coder
 workspaces. To authenticate workspace provisioners with Coder, see the
 <a href="../provisioners/index.md#authentication">provisioners documentation</a>.
-For personal credentials that developers manage themselves, see
+For secret values that developers manage themselves, see
 [User secrets](../../user-guides/user-secrets.md).
 
 ## Before you begin
@@ -46,9 +46,8 @@ Users can view their public key in their account settings:
 
 ## User secrets (Early Access)
 
-User secrets are personal credentials that developers manage themselves. They
-are not configured in template code, and Coder injects them into all workspaces
-owned by that developer. See the
+User secrets are secret values that developers manage themselves. Coder injects
+them into all workspaces owned by that developer. See the
 [User secrets guide](../../user-guides/user-secrets.md).
 
 ## Dynamic Secrets

--- a/docs/admin/security/secrets.md
+++ b/docs/admin/security/secrets.md
@@ -44,7 +44,7 @@ Users can view their public key in their account settings:
 > SSH keys are never stored in Coder workspaces, and are fetched only when
 > SSH is invoked. The keys are held in-memory and never written to disk.
 
-## User secrets (beta)
+## User secrets (Early Access)
 
 User secrets are personal credentials that developers manage for their own
 workspaces. They are injected into all of their workspaces. See the

--- a/docs/admin/security/secrets.md
+++ b/docs/admin/security/secrets.md
@@ -46,10 +46,11 @@ Users can view their public key in their account settings:
 
 ## User secrets (Early Access)
 
-User secrets are secret values that developers manage themselves. At workspace
-start, they can override template-defined environment variables with the same
-name and replace files at matching paths. Template admins cannot currently
-configure or prevent this behavior. See the
+User secrets are developer-managed values that Coder applies at workspace start.
+If a user secret targets the same environment variable name or file path as a
+template-provided variable or file, the user secret is applied in that
+developer's workspace, matching their existing ability to customize their own
+workspace while keeping the value managed by Coder. See the
 [User secrets guide](../../user-guides/user-secrets.md).
 
 ## Dynamic Secrets

--- a/docs/admin/security/secrets.md
+++ b/docs/admin/security/secrets.md
@@ -5,10 +5,10 @@ more information about how to use secrets and other security tips, visit our
 guide to
 [security best practices](../../tutorials/best-practices/security-best-practices.md#secrets).
 
-This article explains template administrator approaches to using secrets in a
-workspace. To authenticate the workspace provisioner, see the
+Use this guide to configure how templates make secrets available to Coder
+workspaces. To authenticate workspace provisioners with Coder, see the
 <a href="../provisioners/index.md#authentication">provisioners documentation</a>.
-To manage personal secret values, see
+For personal credentials that developers manage themselves, see
 [User secrets](../../user-guides/user-secrets.md).
 
 ## Before you begin
@@ -46,8 +46,9 @@ Users can view their public key in their account settings:
 
 ## User secrets (Early Access)
 
-User secrets are personal credentials that developers manage for their own
-workspaces. They are injected into all of their workspaces. See the
+User secrets are personal credentials that developers manage themselves. They
+are not configured in template code, and Coder injects them into all workspaces
+owned by that developer. See the
 [User secrets guide](../../user-guides/user-secrets.md).
 
 ## Dynamic Secrets

--- a/docs/admin/security/secrets.md
+++ b/docs/admin/security/secrets.md
@@ -46,8 +46,10 @@ Users can view their public key in their account settings:
 
 ## User secrets (Early Access)
 
-User secrets are secret values that developers manage themselves. Coder injects
-them into all workspaces owned by that developer. See the
+User secrets are secret values that developers manage themselves. At workspace
+start, they can override template-defined environment variables with the same
+name and replace files at matching paths. Template admins cannot currently
+configure or prevent this behavior. See the
 [User secrets guide](../../user-guides/user-secrets.md).
 
 ## Dynamic Secrets

--- a/docs/admin/security/secrets.md
+++ b/docs/admin/security/secrets.md
@@ -46,12 +46,10 @@ Users can view their public key in their account settings:
 
 ## User secrets (Early Access)
 
-User secrets are developer-managed values that Coder applies at workspace start.
+User secrets are developer-managed values that Coder injects at workspace start.
 If a user secret targets the same environment variable name or file path as a
-template-provided variable or file, the user secret is applied in that
-developer's workspace, matching their existing ability to customize their own
-workspace while keeping the value managed by Coder. See the
-[User secrets guide](../../user-guides/user-secrets.md).
+template-provided variable or file, Coder injects the user secret into that
+workspace. See the [User secrets guide](../../user-guides/user-secrets.md).
 
 ## Dynamic Secrets
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -366,6 +366,13 @@
 					"description": "Personalize your environment with dotfiles",
 					"path": "./user-guides/workspace-dotfiles.md",
 					"icon_path": "./images/icons/art-pad.svg"
+				},
+				{
+					"title": "User secrets",
+					"description": "Store personal credentials in Coder and automatically inject them into workspaces",
+					"path": "./user-guides/user-secrets.md",
+					"icon_path": "./images/icons/secrets.svg",
+					"state": ["beta"]
 				}
 			]
 		},

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -372,7 +372,7 @@
 					"description": "Store personal credentials in Coder and automatically inject them into workspaces",
 					"path": "./user-guides/user-secrets.md",
 					"icon_path": "./images/icons/secrets.svg",
-					"state": ["beta"]
+					"state": ["early access"]
 				}
 			]
 		},

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -369,7 +369,7 @@
 				},
 				{
 					"title": "User secrets",
-					"description": "Store personal credentials in Coder and automatically inject them into workspaces",
+					"description": "Store secret values in Coder and automatically inject them into workspaces",
 					"path": "./user-guides/user-secrets.md",
 					"icon_path": "./images/icons/secrets.svg",
 					"state": ["early access"]

--- a/docs/user-guides/user-secrets.md
+++ b/docs/user-guides/user-secrets.md
@@ -1,31 +1,63 @@
 # User secrets (Early Access)
 
-User secrets let you store personal credentials in Coder and automatically
-inject them into your workspaces without adding those values to template code.
-They are a good fit for per-user credentials such as API keys, cloud
-credentials, or other values that should follow you across workspaces.
+User secrets let you store personal credentials in Coder and make them
+available in every workspace you own. Use them for values that belong to you,
+such as API keys, cloud credentials, or tool configuration that should not live
+in template code.
 
 > [!NOTE]
 > User secrets are in Early Access and may change. For more information, see
 > [feature stages](../install/releases/feature-stages.md#early-access-features).
 
-Use the CLI to create and manage user secrets. You can inject each secret as an
-environment variable, a file, or both.
+## How user secrets work
 
-## Environment variable secrets
+Coder workspaces are created from templates. Templates define the shared
+infrastructure, tools, and workspace configuration for a team or organization.
+User secrets sit outside templates: you create a secret once, choose how Coder
+should expose it, and Coder injects it into your workspaces.
 
-Use `--env` to inject a secret into your workspaces as an environment
-variable. The secret is available under the environment variable name you
-provide.
+Each user secret has:
+
+- A name, used to manage the secret with the CLI or API.
+- A value, which contains the sensitive content.
+- An optional description.
+- An optional environment variable target, file target, or both.
+
+A secret without an environment variable target or file target is stored, but is
+not injected into workspaces.
+
+User secrets apply to all workspaces that you own. Environment variable secrets
+are available to startup scripts and workspace sessions. File secrets are
+written before startup scripts run.
+
+Secret values are omitted from CLI and API output after you create or update
+them.
+
+> [!WARNING]
+> Anyone with shell or file access to a workspace can read secrets injected into
+> that workspace. Do not share a workspace that has injected secrets with users
+> who should not access those values.
+
+## Create a secret
+
+Use `coder secret create <name>` to create a user secret. For sensitive values,
+provide the value through non-interactive stdin with a pipe or redirect. This
+keeps the value out of your shell history and process arguments.
+
+### Create an environment variable secret
+
+Use `--env` to inject a secret into your workspaces as an environment variable.
+The secret is available under the environment variable name you provide. User
+secret environment variables take precedence over template-defined environment
+variables with the same name.
 
 ```sh
-coder secret create api-key \
-  --value "$API_KEY" \
+printf %s "$API_KEY" | coder secret create api-key \
   --description "API key for workspace tools" \
   --env API_KEY
 ```
 
-## File secrets
+### Create a file secret
 
 Use `--file` to inject a secret as a file in your workspaces. File paths must
 start with `~/` or `/`.
@@ -37,48 +69,56 @@ coder secret create tool-config \
   < ./tool-config.json
 ```
 
-You can also expose the same secret through both injection targets:
+Coder creates parent directories as needed. If the file already exists, Coder
+updates the contents and preserves the existing permissions.
+
+### Use both injection targets
+
+You can expose the same secret as both an environment variable and a file:
 
 ```sh
-coder secret create service-token \
-  --value "$TOKEN" \
+printf %s "$TOKEN" | coder secret create service-token \
   --description "Service token for workspace tools" \
   --env SERVICE_TOKEN \
   --file ~/.config/service/token
 ```
 
-## Secret values
+### Use `--value`
 
-Provide a secret value with `--value`, or non-interactive stdin (pipe or
-redirect). The examples above use `--value` for readability. For sensitive
-values, prefer stdin so the value does not appear in shell history or process
-arguments:
+You can also provide a secret value with `--value`:
 
 ```sh
 coder secret create api-key \
+  --value "$API_KEY" \
   --description "API key for workspace tools" \
-  --env API_KEY \
-  < ./api-key.txt
+  --env API_KEY
 ```
 
+For sensitive values, prefer stdin because `--value` can expose the secret in
+shell history or process arguments.
+
 Stdin is read verbatim. If the source file ends with a trailing newline, Coder
-stores that newline as part of the secret value.
+stores that newline as part of the secret value. Use `printf %s` when you do not
+want to store a trailing newline.
 
-## Update secrets
+## Update a secret
 
-Use `coder secret update` to rotate a secret value or change where it is
-injected. At least one of `--value`, `--description`, `--env`, or `--file` must
-be specified.
+Use `coder secret update` to update a secret value, description, environment
+variable target, or file target. At least one of `--value`, `--description`,
+`--env`, or `--file` must be specified.
 
 ```sh
-# Rotate a secret value.
-coder secret update api-key --value "$NEW_API_KEY"
+# Update a secret value.
+printf %s "$NEW_API_KEY" | coder secret update api-key
+
+# Change the environment variable target.
+coder secret update api-key --env NEW_API_KEY
 
 # Clear the file injection target while keeping the secret.
 coder secret update api-key --file ""
 ```
 
-## Manage secrets
+## List and delete secrets
 
 List, show, and delete your secrets with the `coder secret` CLI:
 
@@ -93,6 +133,8 @@ coder secret list api-key
 coder secret delete api-key
 ```
 
-The secret value itself is never returned by the API or CLI list output. For
-full command details, see [`coder secret`](../reference/cli/secret.md) and the
-[Secrets API reference](../reference/api/secrets.md).
+The list and show commands return secret metadata only. They never return the
+secret value.
+
+For full command details, see [`coder secret`](../reference/cli/secret.md) and
+the [Secrets API reference](../reference/api/secrets.md).

--- a/docs/user-guides/user-secrets.md
+++ b/docs/user-guides/user-secrets.md
@@ -1,4 +1,4 @@
-# User secrets (beta)
+# User secrets (Early Access)
 
 User secrets let you store personal credentials in Coder and automatically
 inject them into your workspaces without adding those values to template code.
@@ -6,8 +6,8 @@ They are a good fit for per-user credentials such as API keys, cloud
 credentials, or other values that should follow you across workspaces.
 
 > [!NOTE]
-> User secrets are in beta and may change. For more information, see
-> [feature stages](../install/releases/feature-stages.md#beta).
+> User secrets are in Early Access and may change. For more information, see
+> [feature stages](../install/releases/feature-stages.md#early-access-features).
 
 Use the CLI to create and manage user secrets. You can inject each secret as an
 environment variable, a file, or both.

--- a/docs/user-guides/user-secrets.md
+++ b/docs/user-guides/user-secrets.md
@@ -1,20 +1,13 @@
 # User secrets (Early Access)
 
-User secrets let you store personal credentials in Coder and make them
-available in every workspace you own. Use them for values that belong to you,
-such as API keys, cloud credentials, or tool configuration that should not live
-in template code.
+User secrets let you store secret values in Coder and make them available in
+every workspace you own.
 
 > [!NOTE]
 > User secrets are in Early Access and may change. For more information, see
 > [feature stages](../install/releases/feature-stages.md#early-access-features).
 
 ## How user secrets work
-
-Coder workspaces are created from templates. Templates define the shared
-infrastructure, tools, and workspace configuration for a team or organization.
-User secrets sit outside templates: you create a secret once, choose how Coder
-should expose it, and Coder injects it into your workspaces.
 
 Each user secret has:
 
@@ -52,7 +45,7 @@ secret environment variables take precedence over template-defined environment
 variables with the same name.
 
 ```sh
-printf %s "$API_KEY" | coder secret create api-key \
+echo -n "$API_KEY" | coder secret create api-key \
   --description "API key for workspace tools" \
   --env API_KEY
 ```
@@ -77,7 +70,7 @@ updates the contents and preserves the existing permissions.
 You can expose the same secret as both an environment variable and a file:
 
 ```sh
-printf %s "$TOKEN" | coder secret create service-token \
+echo -n "$TOKEN" | coder secret create service-token \
   --description "Service token for workspace tools" \
   --env SERVICE_TOKEN \
   --file ~/.config/service/token
@@ -98,8 +91,12 @@ For sensitive values, prefer stdin because `--value` can expose the secret in
 shell history or process arguments.
 
 Stdin is read verbatim. If the source file ends with a trailing newline, Coder
-stores that newline as part of the secret value. Use `printf %s` when you do not
-want to store a trailing newline.
+stores that newline as part of the secret value. Use `echo -n` when you do not
+want to store a trailing newline:
+
+```sh
+echo -n "$API_KEY" | coder secret create api-key --env API_KEY
+```
 
 ## Update a secret
 
@@ -109,7 +106,7 @@ variable target, or file target. At least one of `--value`, `--description`,
 
 ```sh
 # Update a secret value.
-printf %s "$NEW_API_KEY" | coder secret update api-key
+echo -n "$NEW_API_KEY" | coder secret update api-key
 
 # Change the environment variable target.
 coder secret update api-key --env NEW_API_KEY

--- a/docs/user-guides/user-secrets.md
+++ b/docs/user-guides/user-secrets.md
@@ -14,8 +14,8 @@ environment variable, a file, or both.
 
 ## Environment variable secrets
 
-Use `--env` when a tool expects a credential in an environment variable. The
-secret is available in your workspaces under the environment variable name you
+Use `--env` to inject a secret into your workspaces as an environment
+variable. The secret is available under the environment variable name you
 provide.
 
 ```sh
@@ -27,8 +27,8 @@ coder secret create api-key \
 
 ## File secrets
 
-Use `--file` when a tool expects a credential or config file on disk. File paths
-must start with `~/` or `/`.
+Use `--file` to inject a secret as a file in your workspaces. File paths must
+start with `~/` or `/`.
 
 ```sh
 coder secret create tool-config \
@@ -47,20 +47,7 @@ coder secret create service-token \
   --file ~/.config/service/token
 ```
 
-## Manage secrets
-
-List, show, and delete your secrets with the `coder secret` CLI:
-
-```sh
-# List all of your secrets.
-coder secret list
-
-# Show a single secret by name.
-coder secret list api-key
-
-# Delete a secret you no longer need.
-coder secret delete api-key
-```
+## Secret values
 
 Provide a secret value with `--value`, or non-interactive stdin (pipe or
 redirect). The examples above use `--value` for readability. For sensitive
@@ -76,6 +63,24 @@ coder secret create api-key \
 
 Stdin is read verbatim. If the source file ends with a trailing newline, Coder
 stores that newline as part of the secret value.
+
+## Manage secrets
+
+List, show, update, and delete your secrets with the `coder secret` CLI:
+
+```sh
+# List all of your secrets.
+coder secret list
+
+# Show a single secret by name.
+coder secret list api-key
+
+# Update a secret and clear its file injection target.
+coder secret update api-key --file ""
+
+# Delete a secret you no longer need.
+coder secret delete api-key
+```
 
 You can update a secret later with `coder secret update`, including rotating the
 value or clearing an injection target by passing an empty string. Use

--- a/docs/user-guides/user-secrets.md
+++ b/docs/user-guides/user-secrets.md
@@ -11,7 +11,7 @@ every workspace you own.
 
 Each user secret has:
 
-- A name, used to manage the secret with the CLI or API.
+- A name, used to manage the secret with the CLI or REST API.
 - A value, which contains the sensitive content.
 - An optional description.
 - An optional environment variable target, file target, or both.
@@ -19,12 +19,15 @@ Each user secret has:
 A secret without an environment variable target or file target is stored, but is
 not injected into workspaces.
 
-User secrets apply to all workspaces that you own. Environment variable secrets
-are available to startup scripts and workspace sessions. File secrets are
-written before startup scripts run.
+User secrets apply to all workspaces that you own. Coder loads user secrets when
+a workspace starts. If you create, update, or delete a secret while a workspace
+is running, restart the workspace before relying on that change.
 
-Secret values are omitted from CLI and API output after you create or update
-them.
+Environment variable secrets are available to startup scripts and workspace
+sessions. File secrets are written before startup scripts run.
+
+Secret values are omitted from CLI output and REST API responses after you
+create or update them.
 
 > [!WARNING]
 > Anyone with shell or file access to a workspace can read secrets injected into
@@ -129,6 +132,11 @@ coder secret list api-key
 # Delete a secret you no longer need.
 coder secret delete api-key
 ```
+
+Deleting a secret removes it from Coder and stops Coder from injecting it during
+future workspace starts. Deleting a secret does not remove the value from
+running processes or delete files that were already written in existing
+workspaces.
 
 The list and show commands return secret metadata only. They never return the
 secret value.

--- a/docs/user-guides/user-secrets.md
+++ b/docs/user-guides/user-secrets.md
@@ -1,0 +1,85 @@
+# User secrets (beta)
+
+User secrets let you store personal credentials in Coder and automatically
+inject them into your workspaces without adding those values to template code.
+They are a good fit for per-user credentials such as API keys, cloud
+credentials, or other values that should follow you across workspaces.
+
+> [!NOTE]
+> User secrets are in beta and may change. For more information, see
+> [feature stages](../install/releases/feature-stages.md#beta).
+
+Use the CLI to create and manage user secrets. You can inject each secret as an
+environment variable, a file, or both.
+
+## Environment variable secrets
+
+Use `--env` when a tool expects a credential in an environment variable. The
+secret is available in your workspaces under the environment variable name you
+provide.
+
+```sh
+coder secret create api-key \
+  --value "$API_KEY" \
+  --description "API key for workspace tools" \
+  --env API_KEY
+```
+
+## File secrets
+
+Use `--file` when a tool expects a credential or config file on disk. File paths
+must start with `~/` or `/`.
+
+```sh
+coder secret create tool-config \
+  --description "Tool configuration" \
+  --file ~/.config/tool/config.json \
+  < ./tool-config.json
+```
+
+You can also expose the same secret through both injection targets:
+
+```sh
+coder secret create service-token \
+  --value "$TOKEN" \
+  --description "Service token for workspace tools" \
+  --env SERVICE_TOKEN \
+  --file ~/.config/service/token
+```
+
+## Manage secrets
+
+List, show, and delete your secrets with the `coder secret` CLI:
+
+```sh
+# List all of your secrets.
+coder secret list
+
+# Show a single secret by name.
+coder secret list api-key
+
+# Delete a secret you no longer need.
+coder secret delete api-key
+```
+
+Provide a secret value with `--value`, or non-interactive stdin (pipe or
+redirect). The examples above use `--value` for readability. For sensitive
+values, prefer stdin so the value does not appear in shell history or process
+arguments:
+
+```sh
+coder secret create api-key \
+  --description "API key for workspace tools" \
+  --env API_KEY \
+  < ./api-key.txt
+```
+
+Stdin is read verbatim. If the source file ends with a trailing newline, Coder
+stores that newline as part of the secret value.
+
+You can update a secret later with `coder secret update`, including rotating the
+value or clearing an injection target by passing an empty string. Use
+`coder secret delete` to remove a secret entirely. The secret value itself is
+never returned by the API or CLI list output. For full command details, see
+[`coder secret`](../reference/cli/secret.md) and the
+[Secrets API reference](../reference/api/secrets.md).

--- a/docs/user-guides/user-secrets.md
+++ b/docs/user-guides/user-secrets.md
@@ -45,7 +45,7 @@ keeps the value out of your shell history and process arguments.
 Use `--env` to inject a secret into your workspaces as an environment variable.
 The secret is available under the environment variable name you provide. User
 secret environment variables take precedence over template-defined environment
-variables with the same name.
+variables with the same name, including variables set with `coder_env`.
 
 ```sh
 echo -n "$API_KEY" | coder secret create api-key \
@@ -65,8 +65,9 @@ coder secret create tool-config \
   < ./tool-config.json
 ```
 
-Coder creates parent directories as needed. If the file already exists, Coder
-updates the contents and preserves the existing permissions.
+Coder creates parent directories as needed. If the file already exists, including
+a file created by a template or image, Coder updates the contents and preserves
+the existing permissions.
 
 ### Create a secret with environment variable and file targets
 

--- a/docs/user-guides/user-secrets.md
+++ b/docs/user-guides/user-secrets.md
@@ -19,9 +19,9 @@ Each user secret has:
 A secret without an environment variable target or file target is stored, but is
 not injected into workspaces.
 
-User secrets apply to all workspaces that you own. Coder loads user secrets when
-a workspace starts. If you create, update, or delete a secret while a workspace
-is running, restart the workspace before relying on that change.
+User secrets apply to all workspaces that you own. Coder injects user secrets
+when a workspace starts. If you create, update, or delete a secret while a
+workspace is running, restart the workspace before relying on that change.
 
 Environment variable secrets are available to startup scripts and workspace
 sessions. File secrets are written before startup scripts run.
@@ -68,9 +68,9 @@ coder secret create tool-config \
 Coder creates parent directories as needed. If the file already exists, Coder
 updates the contents and preserves the existing permissions.
 
-### Use both injection targets
+### Create a secret with environment variable and file targets
 
-You can expose the same secret as both an environment variable and a file:
+You can inject the same secret as both an environment variable and a file:
 
 ```sh
 echo -n "$TOKEN" | coder secret create service-token \

--- a/docs/user-guides/user-secrets.md
+++ b/docs/user-guides/user-secrets.md
@@ -64,9 +64,23 @@ coder secret create api-key \
 Stdin is read verbatim. If the source file ends with a trailing newline, Coder
 stores that newline as part of the secret value.
 
+## Update secrets
+
+Use `coder secret update` to rotate a secret value or change where it is
+injected. At least one of `--value`, `--description`, `--env`, or `--file` must
+be specified.
+
+```sh
+# Rotate a secret value.
+coder secret update api-key --value "$NEW_API_KEY"
+
+# Clear the file injection target while keeping the secret.
+coder secret update api-key --file ""
+```
+
 ## Manage secrets
 
-List, show, update, and delete your secrets with the `coder secret` CLI:
+List, show, and delete your secrets with the `coder secret` CLI:
 
 ```sh
 # List all of your secrets.
@@ -75,16 +89,10 @@ coder secret list
 # Show a single secret by name.
 coder secret list api-key
 
-# Update a secret and clear its file injection target.
-coder secret update api-key --file ""
-
 # Delete a secret you no longer need.
 coder secret delete api-key
 ```
 
-You can update a secret later with `coder secret update`, including rotating the
-value or clearing an injection target by passing an empty string. Use
-`coder secret delete` to remove a secret entirely. The secret value itself is
-never returned by the API or CLI list output. For full command details, see
-[`coder secret`](../reference/cli/secret.md) and the
+The secret value itself is never returned by the API or CLI list output. For
+full command details, see [`coder secret`](../reference/cli/secret.md) and the
 [Secrets API reference](../reference/api/secrets.md).


### PR DESCRIPTION
## Summary
Move user secrets docs into User Guides because they describe developer-managed secret values. Mark the page as Early Access and keep the admin security page as a short cross-reference.

## Changes
- Add an Early Access User secrets page under User Guides.
- Keep the admin secrets page focused on template secret configuration and link to the user guide.
- Use stdin-first examples for secret values, including `echo -n` examples for values that should not store trailing newlines.
- Document environment variable, file, update, list, and delete workflows.
- Clarify when secret changes apply to workspaces and what deleting a secret does.
- Clarify how user secret injection interacts with template-defined environment variables and files.
- Add the page to docs navigation with Early Access state.

Preview: https://coder.com/docs/@docs-user-secrets-guide/user-guides/user-secrets

## Validation
- `make fmt/markdown FILE=docs/admin/security/secrets.md`
- `make fmt/markdown FILE=docs/user-guides/user-secrets.md`
- `make lint/markdown`
- `bash scripts/check_emdash.sh docs/admin/security/secrets.md docs/user-guides/user-secrets.md docs/manifest.json`
- `python3 -m json.tool docs/manifest.json`
- `git diff --check`
- `pre-commit-light` via git hook
- Focused staff technical writing review

> 🤖 This PR was created with the help of Coder Agents, and has been reviewed by my human.  🧑💻
