### PR TITLE
fix(site): use theme-aware color for agent row tab bottom border

### DIFF
--- a/site/src/components/Tabs/Tabs.tsx
+++ b/site/src/components/Tabs/Tabs.tsx
@@ -37,7 +37,7 @@ const tabsListVariants = cva("flex flex-wrap items-center", {
 				"border-solid border-0 border-b gap-6",
 				"[&_[data-slot=tabs-trigger]]:text-content-secondary [&_[data-slot=tabs-trigger][data-state=active]]:text-content-primary",
 				"[&_[data-slot=tabs-trigger]]:border-0 [&_[data-slot=tabs-trigger]]:border-y [&_[data-slot=tabs-trigger]]:border-solid",
-				"[&_[data-slot=tabs-trigger]]:border-transparent [&_[data-slot=tabs-trigger][data-state=active]]:border-b-white",
+				"[&_[data-slot=tabs-trigger]]:border-transparent [&_[data-slot=tabs-trigger][data-state=active]]:border-b-content-primary",
 				"[&_[data-slot=tabs-trigger]:hover]:text-content-primary",
 				"[&_[data-slot=tabs-trigger]]:px-1",
 			),


### PR DESCRIPTION
noticed on the light theme that the bottom border on the Agent row is hardcoded white on white. switched this to an inverted border color so you can see the tab border on both themes

before:

<img width="859" height="185" alt="Screenshot 2026-04-27 at 10 50 24 AM" src="https://github.com/user-attachments/assets/aa81c9e2-3a11-456a-a5aa-84909982f5f7" />
<img width="875" height="207" alt="Screenshot 2026-04-27 at 10 50 37 AM" src="https://github.com/user-attachments/assets/2e6d5a4a-08a4-4c85-ba9b-d81f33059fa0" />


after:

<img width="537" height="209" alt="Screenshot 2026-04-27 at 10 52 47 AM" src="https://github.com/user-attachments/assets/6415a95d-e3b6-4f35-8819-b79ffe58ee59" />
<img width="543" height="222" alt="Screenshot 2026-04-27 at 10 52 29 AM" src="https://github.com/user-attachments/assets/6631544f-9f32-4dab-b443-e88a6c6bb0ea" />
