### PR TITLE
fix(site/src/pages/AgentsPage/components): disable chat scroll anchoring

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
+++ b/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
@@ -139,7 +139,7 @@ const ChatScrollContainer: FC<{
 				ref={setScrollContainer}
 				data-testid="scroll-container"
 				aria-busy={isFetchingMoreMessages || undefined}
-				className="flex min-h-0 flex-1 flex-col-reverse overflow-y-auto [scrollbar-gutter:stable] [scrollbar-width:thin] [scrollbar-color:hsl(var(--surface-quaternary))_transparent]"
+				className="flex min-h-0 flex-1 flex-col-reverse overflow-y-auto [overflow-anchor:none] [scrollbar-gutter:stable] [scrollbar-width:thin] [scrollbar-color:hsl(var(--surface-quaternary))_transparent]"
 			>
 				<div aria-hidden className="flex-1 basis-0" />
 				<InfiniteScroll


### PR DESCRIPTION
Safari exhibits visible scroll jumpiness in the Coder Agents chat viewport, especially during streaming responses, history loads, and message height changes. Browser scroll anchoring fights the app's bottom-pinning logic inside the reversed `flex-col-reverse` viewport that wraps the inverse `react-infinite-scroll-component`.

Disable browser scroll anchoring on the chat scroll viewport with `[overflow-anchor:none]`. The app already owns bottom pinning, so removing the browser's anchor selection prevents Safari from shifting `scrollTop` while content updates.