### PR TITLE
refactor(site/src/components): migrate dialog wrapper foundations

### DIFF
--- a/site/src/components/Dialogs/ConfirmDialog/ConfirmDialog.stories.tsx
+++ b/site/src/components/Dialogs/ConfirmDialog/ConfirmDialog.stories.tsx
@@ -1,13 +1,13 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { action } from "storybook/actions";
+import { expect, fn, userEvent, within } from "storybook/test";
 import { ConfirmDialog } from "./ConfirmDialog";
 
 const meta: Meta<typeof ConfirmDialog> = {
 	title: "components/Dialogs/ConfirmDialog",
 	component: ConfirmDialog,
 	args: {
-		onClose: action("onClose"),
-		onConfirm: action("onConfirm"),
+		onClose: fn(),
+		onConfirm: fn(),
 		open: true,
 		title: "Confirm Dialog",
 	},
@@ -22,6 +22,23 @@ export const Example: Story = {
 		hideCancel: false,
 		type: "delete",
 	},
+	play: async ({ canvasElement, args }) => {
+		const user = userEvent.setup();
+		const body = within(canvasElement.ownerDocument.body);
+
+		expect(
+			body.getByRole("heading", { name: "Confirm Dialog" }),
+		).toBeInTheDocument();
+		expect(
+			body.getByText("Do you really want to delete me?"),
+		).toBeInTheDocument();
+
+		await user.click(body.getByRole("button", { name: "Cancel" }));
+		expect(args.onClose).toHaveBeenCalled();
+
+		await user.click(body.getByRole("button", { name: "Delete" }));
+		expect(args.onConfirm).toHaveBeenCalled();
+	},
 };
 
 export const InfoDialog: Story = {
@@ -29,6 +46,14 @@ export const InfoDialog: Story = {
 		description: "Information is cool!",
 		hideCancel: true,
 		type: "info",
+	},
+	play: async ({ canvasElement }) => {
+		const body = within(canvasElement.ownerDocument.body);
+
+		expect(body.getByRole("button", { name: "OK" })).toBeInTheDocument();
+		expect(
+			body.queryByRole("button", { name: "Cancel" }),
+		).not.toBeInTheDocument();
 	},
 };
 
@@ -59,8 +84,15 @@ export const SuccessDialogWithCancel: Story = {
 export const SuccessDialogLoading: Story = {
 	args: {
 		description: "I am successful.",
-		hideCancel: true,
+		hideCancel: false,
 		type: "success",
 		confirmLoading: true,
+	},
+	play: async ({ canvasElement }) => {
+		const body = within(canvasElement.ownerDocument.body);
+
+		expect(body.getByRole("button", { name: "Cancel" })).toBeDisabled();
+		expect(body.getByRole("button", { name: /OK/ })).toBeDisabled();
+		expect(body.getByTitle("Loading spinner")).toBeInTheDocument();
 	},
 };

--- a/site/src/components/Dialogs/ConfirmDialog/ConfirmDialog.tsx
+++ b/site/src/components/Dialogs/ConfirmDialog/ConfirmDialog.tsx
@@ -1,11 +1,15 @@
-import type { Interpolation, Theme } from "@emotion/react";
-import DialogActions from "@mui/material/DialogActions";
 import type { FC, ReactNode } from "react";
 import {
 	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogTitle,
+} from "#/components/Dialog/Dialog";
+import {
 	DialogActionButtons,
 	type DialogActionButtonsProps,
-} from "../Dialog";
+} from "../DialogActionButtons";
 import type { ConfirmDialogType } from "../types";
 
 interface ConfirmDialogTypeConfig {
@@ -52,48 +56,6 @@ export interface ConfirmDialogProps
 	readonly title: string;
 }
 
-const styles = {
-	dialogWrapper: (theme) => ({
-		"& .MuiPaper-root": {
-			background: theme.palette.background.paper,
-			border: `1px solid ${theme.palette.divider}`,
-			width: "100%",
-			maxWidth: 440,
-		},
-		"& .MuiDialogActions-spacing": {
-			padding: "0 40px 40px",
-		},
-	}),
-	dialogContent: (theme) => ({
-		color: theme.palette.text.secondary,
-		padding: "40px 40px 20px",
-	}),
-	dialogTitle: (theme) => ({
-		margin: 0,
-		marginBottom: 16,
-		color: theme.palette.text.primary,
-		fontWeight: 400,
-		fontSize: 20,
-	}),
-	dialogDescription: (theme) => ({
-		color: theme.palette.text.secondary,
-		lineHeight: "160%",
-		fontSize: 16,
-
-		"& strong": {
-			color: theme.palette.text.primary,
-		},
-
-		"& p:not(.MuiFormHelperText-root)": {
-			margin: 0,
-		},
-
-		"& > p": {
-			margin: "8px 0",
-		},
-	}),
-} satisfies Record<string, Interpolation<Theme>>;
-
 /**
  * Quick-use version of the Dialog component with slightly alternative styles,
  * great to use for dialogs that don't have any interaction beyond yes / no.
@@ -112,34 +74,42 @@ export const ConfirmDialog: FC<ConfirmDialogProps> = ({
 	type = "info",
 }) => {
 	const defaults = CONFIRM_DIALOG_DEFAULTS[type];
-
-	if (typeof hideCancel === "undefined") {
-		hideCancel = defaults.hideCancel;
-	}
+	const resolvedHideCancel = hideCancel ?? defaults.hideCancel;
 
 	return (
 		<Dialog
-			css={styles.dialogWrapper}
-			onClose={onClose}
 			open={open}
-			data-testid="dialog"
+			onOpenChange={(nextOpen) => {
+				if (!nextOpen) {
+					onClose();
+				}
+			}}
 		>
-			<div css={styles.dialogContent}>
-				<h3 css={styles.dialogTitle}>{title}</h3>
-				{description && <div css={styles.dialogDescription}>{description}</div>}
-			</div>
+			<DialogContent className="max-w-[440px] gap-0 p-0" data-testid="dialog">
+				<div className="px-10 pb-5 pt-10">
+					<DialogTitle className="mb-4 font-normal">{title}</DialogTitle>
+					{description && (
+						<DialogDescription
+							asChild
+							className="text-base font-normal leading-[160%] text-content-secondary [&>p]:my-2 [&_p:not(.MuiFormHelperText-root)]:m-0 [&_strong]:text-content-primary"
+						>
+							<div>{description}</div>
+						</DialogDescription>
+					)}
+				</div>
 
-			<DialogActions>
-				<DialogActionButtons
-					cancelText={cancelText}
-					confirmLoading={confirmLoading}
-					confirmText={confirmText || defaults.confirmText}
-					disabled={disabled}
-					onCancel={!hideCancel ? onClose : undefined}
-					onConfirm={onConfirm || onClose}
-					type={type}
-				/>
-			</DialogActions>
+				<DialogFooter className="px-10 pb-10">
+					<DialogActionButtons
+						cancelText={cancelText}
+						confirmLoading={confirmLoading}
+						confirmText={confirmText || defaults.confirmText}
+						disabled={disabled}
+						onCancel={!resolvedHideCancel ? onClose : undefined}
+						onConfirm={onConfirm || onClose}
+						type={type}
+					/>
+				</DialogFooter>
+			</DialogContent>
 		</Dialog>
 	);
 };

--- a/site/src/components/Dialogs/DeleteDialog/DeleteDialog.test.tsx
+++ b/site/src/components/Dialogs/DeleteDialog/DeleteDialog.test.tsx
@@ -7,14 +7,9 @@ import { DeleteDialog } from "./DeleteDialog";
 const inputTestId = "delete-dialog-name-confirmation";
 
 async function fillInputField(inputElement: HTMLElement, text: string) {
-	// 2023-10-06 - There's something wonky with MUI's ConfirmDialog that causes
-	// its state to update after a typing event gets  fired, and React Testing
-	// Library isn't able to catch it, making React DOM freak out because an
-	// "unexpected" state change happened. It won't fail the test, but it makes
-	// the console look really scary because it'll spit out a big warning message.
-	// Tried everything under the sun to catch the state changes the proper way,
-	// but the only way to get around it for now might be to manually make React
-	// DOM aware of the changes
+	// 2023-10-06: MUI's TextField can update state after a typing event fires,
+	// and React Testing Library is not able to catch it. Manually wrapping the
+	// event keeps React DOM aware of the changes.
 	return act(() => userEvent.type(inputElement, text));
 }
 

--- a/site/src/components/Dialogs/Dialog.tsx
+++ b/site/src/components/Dialogs/Dialog.tsx
@@ -1,67 +1,6 @@
 import MuiDialog, { type DialogProps } from "@mui/material/Dialog";
-import type { FC, ReactNode } from "react";
-import { Button } from "#/components/Button/Button";
-import { Spinner } from "#/components/Spinner/Spinner";
-import type { ConfirmDialogType } from "./types";
 
-export interface DialogActionButtonsProps {
-	/** Text to display in the cancel button */
-	cancelText?: string;
-	/** Text to display in the confirm button */
-	confirmText?: ReactNode;
-	/** Whether or not confirm is loading, also disables cancel when true */
-	confirmLoading?: boolean;
-	/** Whether or not the submit button is disabled */
-	disabled?: boolean;
-	/** Called when cancel is clicked */
-	onCancel?: () => void;
-	/** Called when confirm is clicked */
-	onConfirm?: () => void;
-	type?: ConfirmDialogType;
-}
-
-/**
- * Quickly handles most modals actions, some combination of a cancel and confirm button
- */
-export const DialogActionButtons: FC<DialogActionButtonsProps> = ({
-	cancelText = "Cancel",
-	confirmText = "Confirm",
-	confirmLoading = false,
-	disabled = false,
-	onCancel,
-	onConfirm,
-	type = "info",
-}) => {
-	return (
-		<>
-			{onCancel && (
-				<Button
-					disabled={confirmLoading}
-					onClick={(e) => {
-						e.stopPropagation();
-						onCancel();
-					}}
-					variant="outline"
-				>
-					{cancelText}
-				</Button>
-			)}
-
-			{onConfirm && (
-				<Button
-					variant={type === "delete" ? "destructive" : undefined}
-					disabled={confirmLoading || disabled}
-					onClick={onConfirm}
-					data-testid="confirm-button"
-					type="submit"
-				>
-					<Spinner loading={confirmLoading} />
-					{confirmText}
-				</Button>
-			)}
-		</>
-	);
-};
+export * from "./DialogActionButtons";
 
 /**
  * Re-export of MUI's Dialog component, for convenience.

--- a/site/src/components/Dialogs/DialogActionButtons.tsx
+++ b/site/src/components/Dialogs/DialogActionButtons.tsx
@@ -1,0 +1,63 @@
+import type { FC, ReactNode } from "react";
+import { Button } from "#/components/Button/Button";
+import { Spinner } from "#/components/Spinner/Spinner";
+import type { ConfirmDialogType } from "./types";
+
+export interface DialogActionButtonsProps {
+	/** Text to display in the cancel button. */
+	cancelText?: string;
+	/** Text to display in the confirm button. */
+	confirmText?: ReactNode;
+	/** Whether confirm is loading, also disables cancel when true. */
+	confirmLoading?: boolean;
+	/** Whether the submit button is disabled. */
+	disabled?: boolean;
+	/** Called when cancel is clicked. */
+	onCancel?: () => void;
+	/** Called when confirm is clicked. */
+	onConfirm?: () => void;
+	type?: ConfirmDialogType;
+}
+
+/**
+ * Quickly handles modal actions with a cancel button, a confirm button, or both.
+ */
+export const DialogActionButtons: FC<DialogActionButtonsProps> = ({
+	cancelText = "Cancel",
+	confirmText = "Confirm",
+	confirmLoading = false,
+	disabled = false,
+	onCancel,
+	onConfirm,
+	type = "info",
+}) => {
+	return (
+		<>
+			{onCancel && (
+				<Button
+					disabled={confirmLoading}
+					onClick={(e) => {
+						e.stopPropagation();
+						onCancel();
+					}}
+					variant="outline"
+				>
+					{cancelText}
+				</Button>
+			)}
+
+			{onConfirm && (
+				<Button
+					variant={type === "delete" ? "destructive" : undefined}
+					disabled={confirmLoading || disabled}
+					onClick={onConfirm}
+					data-testid="confirm-button"
+					type="submit"
+				>
+					<Spinner loading={confirmLoading} />
+					{confirmText}
+				</Button>
+			)}
+		</>
+	);
+};

--- a/site/src/components/MIGRATION.md
+++ b/site/src/components/MIGRATION.md
@@ -61,11 +61,11 @@ points for MUI replacement work.
 | `TextField`                            | `FormField` for form-backed labeled inputs, or `Input` for bare inputs      | `FormField` already wires label, helper text, errors, and accessible descriptions.  |
 | `Link`                                 | `#/components/Link/Link`                                                    | Use `asChild` when composing with router links or another anchor-like child.        |
 | `Select` plus `MenuItem`               | `Select`, `SelectTrigger`, `SelectValue`, `SelectContent`, and `SelectItem` | This is the default closed-list replacement for finite options.                     |
-| `MenuItem` in action menus             | Menu primitives in a later slice                                            | Do not map action-menu items to `SelectItem`. Slice 1 documents the direction only. |
+| `MenuItem` in action menus             | `DropdownMenu` primitives                                                   | Do not map action-menu items to `SelectItem`. Use action-menu primitives instead.  |
 | `FormControlLabel`                     | `Checkbox` or `Switch` plus `Label`                                         | Keep explicit `id` and `htmlFor` wiring so the label activates the control.         |
 | `Checkbox`                             | `#/components/Checkbox/Checkbox`                                            | Use controlled state when indeterminate behavior is required.                       |
 | `CircularProgress`                     | `#/components/Spinner/Spinner`                                              | Use `loading` when wrapping fallback children.                                      |
-| `DialogActions`                        | `DialogFooter` when dialog wrappers are migrated                            | Existing dialog wrappers remain slice 2 scope.                                      |
+| `DialogActions`                        | `DialogFooter`                                                              | `ConfirmDialog` uses this mapping. New custom dialogs should use Radix primitives. |
 | `sx`, MUI `styled`, and MUI `useTheme` | Tailwind classes, design tokens, and CVA variants                           | Emotion cleanup remains final-cleanup scope.                                        |
 
 ## Examples
@@ -154,7 +154,7 @@ import { Spinner } from "#/components/Spinner/Spinner";
 
 ### DialogActions
 
-Use `DialogFooter` when dialog wrappers are migrated in slice 2.
+Use `DialogFooter` for action rows in Radix dialogs.
 
 ```tsx
 import { DialogFooter } from "#/components/Dialog/Dialog";
@@ -164,6 +164,25 @@ import { DialogFooter } from "#/components/Dialog/Dialog";
   <Button>Save</Button>
 </DialogFooter>;
 ```
+
+## Shared dialog wrappers
+
+`#/components/Dialogs/ConfirmDialog` is Radix-backed and remains the preferred
+shared wrapper for confirmation, deletion, success, and informational dialogs.
+It keeps the existing confirmation button behavior and uses `DialogFooter` for
+its action row.
+
+New custom dialogs should import primitives from `#/components/Dialog/Dialog`.
+Do not start new code from `#/components/Dialogs/Dialog`; that file is a
+temporary MUI compatibility shim for feature dialogs and type-only consumers
+that still rely on MUI `Dialog` behavior or `DialogProps`.
+
+## Menu wrapper findings
+
+Use `DropdownMenu` primitives for action menus. No reused shared MUI action-menu
+wrapper was migrated in slice 2. `SelectMenu` is deferred because it has no
+production callsites outside its own story. `DurationField` is deferred because
+it is form-field scope.
 
 ## Select versus Combobox
 
@@ -178,8 +197,12 @@ experience.
 
 ## Deferred work
 
-- Dialog and menu wrapper migrations are slice 2 scope.
-- Existing MUI callsite replacement is later slice scope.
+- `#/components/Dialogs/Dialog` remains a temporary MUI compatibility shim for
+  feature dialogs and type-only consumers that still need MUI `Dialog` props.
+- `SelectMenu` remains deferred until it has production callsites or a later
+  slice needs it as part of a broader menu migration.
+- `DurationField` and other form-field MUI usage remain form-field slice scope.
+- Existing feature callsite replacement is later slice scope.
 - MUI provider, theme, package, and Emotion cleanup remain final-cleanup scope.
 - Add new primitives only when a later slice proves the existing component
   inventory cannot cover the target migration.

--- a/site/src/components/MIGRATION.md
+++ b/site/src/components/MIGRATION.md
@@ -56,17 +56,17 @@ points for MUI replacement work.
 
 ## Canonical mapping
 
-| MUI component or API                   | Replacement pattern                                                         | Notes                                                                               |
-|----------------------------------------|-----------------------------------------------------------------------------|-------------------------------------------------------------------------------------|
-| `TextField`                            | `FormField` for form-backed labeled inputs, or `Input` for bare inputs      | `FormField` already wires label, helper text, errors, and accessible descriptions.  |
-| `Link`                                 | `#/components/Link/Link`                                                    | Use `asChild` when composing with router links or another anchor-like child.        |
-| `Select` plus `MenuItem`               | `Select`, `SelectTrigger`, `SelectValue`, `SelectContent`, and `SelectItem` | This is the default closed-list replacement for finite options.                     |
+| MUI component or API                   | Replacement pattern                                                         | Notes                                                                              |
+|----------------------------------------|-----------------------------------------------------------------------------|------------------------------------------------------------------------------------|
+| `TextField`                            | `FormField` for form-backed labeled inputs, or `Input` for bare inputs      | `FormField` already wires label, helper text, errors, and accessible descriptions. |
+| `Link`                                 | `#/components/Link/Link`                                                    | Use `asChild` when composing with router links or another anchor-like child.       |
+| `Select` plus `MenuItem`               | `Select`, `SelectTrigger`, `SelectValue`, `SelectContent`, and `SelectItem` | This is the default closed-list replacement for finite options.                    |
 | `MenuItem` in action menus             | `DropdownMenu` primitives                                                   | Do not map action-menu items to `SelectItem`. Use action-menu primitives instead.  |
-| `FormControlLabel`                     | `Checkbox` or `Switch` plus `Label`                                         | Keep explicit `id` and `htmlFor` wiring so the label activates the control.         |
-| `Checkbox`                             | `#/components/Checkbox/Checkbox`                                            | Use controlled state when indeterminate behavior is required.                       |
-| `CircularProgress`                     | `#/components/Spinner/Spinner`                                              | Use `loading` when wrapping fallback children.                                      |
+| `FormControlLabel`                     | `Checkbox` or `Switch` plus `Label`                                         | Keep explicit `id` and `htmlFor` wiring so the label activates the control.        |
+| `Checkbox`                             | `#/components/Checkbox/Checkbox`                                            | Use controlled state when indeterminate behavior is required.                      |
+| `CircularProgress`                     | `#/components/Spinner/Spinner`                                              | Use `loading` when wrapping fallback children.                                     |
 | `DialogActions`                        | `DialogFooter`                                                              | `ConfirmDialog` uses this mapping. New custom dialogs should use Radix primitives. |
-| `sx`, MUI `styled`, and MUI `useTheme` | Tailwind classes, design tokens, and CVA variants                           | Emotion cleanup remains final-cleanup scope.                                        |
+| `sx`, MUI `styled`, and MUI `useTheme` | Tailwind classes, design tokens, and CVA variants                           | Emotion cleanup remains final-cleanup scope.                                       |
 
 ## Examples
 


### PR DESCRIPTION
## Summary

Slice 2 of the UI migration, stacked on #24741, migrates the shared confirmation dialog foundation from the legacy MUI dialog shim to the existing Radix dialog primitives.

- Migrates `ConfirmDialog` to `#/components/Dialog/Dialog` primitives.
- Extracts `DialogActionButtons` into a shared MUI-free helper while preserving the old `#/components/Dialogs/Dialog` export path.
- Adds Storybook play coverage for the Radix-backed confirmation dialog and keeps `DeleteDialog` coverage working through the wrapper migration.
- Documents the dialog and menu wrapper audit in `site/src/components/MIGRATION.md`.

## Scope

### Migrated

- `site/src/components/Dialogs/ConfirmDialog/ConfirmDialog.tsx`
  - Uses Radix `Dialog`, `DialogContent`, `DialogTitle`, `DialogDescription`, and `DialogFooter`.
  - Preserves the existing public props, default confirm text, loading behavior, disabled behavior, cancel behavior, confirm fallback, and `data-testid="confirm-button"`.
- `site/src/components/Dialogs/DialogActionButtons.tsx`
  - Moves action button logic out of the legacy MUI dialog shim.
  - Keeps legacy imports working through `site/src/components/Dialogs/Dialog.tsx`.

### Audited and deferred

- `site/src/components/Dialogs/Dialog.tsx` remains a temporary MUI compatibility shim for out-of-scope feature dialogs and `DialogProps` consumers.
- `site/src/components/Dialogs/DeleteDialog/DeleteDialog.tsx` now inherits the Radix dialog shell through `ConfirmDialog`, but its MUI `TextField` remains deferred to form-field slices.
- `site/src/components/SelectMenu/SelectMenu.tsx` is deferred because it has no production callsites outside its own story.
- `site/src/components/DurationField/DurationField.tsx` is deferred because it is form-field scope.
- Direct feature dialog and menu callsites under pages and modules are deferred to later feature slices.
- Emotion cleanup remains deferred to the final cleanup slice.

## Counts

- Final `@mui/*` import file count under `site/`: 77.
- Final `@mui/*` import statement count under `site/`: 146.
- Import count delta for this slice: 78 to 77 files, 147 to 146 statements.
- Final changed-line count against `ui-migration/01-replacement-primitives`: 332.

Remaining shared component dialog and menu MUI imports are intentional in this slice:

- `DurationField`, form-field scope.
- `SelectMenu`, deferred because it has no production callsites.
- `Dialogs/Dialog.tsx`, temporary compatibility shim.

## Validation

- `cd site && pnpm format`, passed.
- `cd site && pnpm lint`, passed.
- `cd site && pnpm test`, passed, 151 files and 1923 tests. Vitest emitted its existing close-timeout warning after success.
- `cd site && pnpm test:storybook src/components/Dialogs/ConfirmDialog/ConfirmDialog.stories.tsx`, passed, 6 tests. Vitest emitted its existing close-timeout warning after success.
- `cd site && pnpm test:storybook src/components/Dialogs/DeleteDialog/DeleteDialog.stories.tsx`, passed, 4 tests. Vitest emitted its existing close-timeout warning after success.
- `cd site && pnpm storybook:ci`, passed.
- `pnpm exec markdown-table-formatter --check site/src/components/MIGRATION.md`, passed.
- `make pre-commit`, passed.
