### PR TITLE
fix(enterprise/coderd): accept "me" shortcut in swagger for quiet-hours

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -9367,8 +9367,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "format": "uuid",
-                        "description": "User ID",
+                        "description": "User ID, name, or me",
                         "name": "user",
                         "in": "path",
                         "required": true
@@ -9406,8 +9405,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "format": "uuid",
-                        "description": "User ID",
+                        "description": "User ID, name, or me",
                         "name": "user",
                         "in": "path",
                         "required": true

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -8300,8 +8300,7 @@
 				"parameters": [
 					{
 						"type": "string",
-						"format": "uuid",
-						"description": "User ID",
+						"description": "User ID, name, or me",
 						"name": "user",
 						"in": "path",
 						"required": true
@@ -8333,8 +8332,7 @@
 				"parameters": [
 					{
 						"type": "string",
-						"format": "uuid",
-						"description": "User ID",
+						"description": "User ID, name, or me",
 						"name": "user",
 						"in": "path",
 						"required": true

--- a/docs/reference/api/enterprise.md
+++ b/docs/reference/api/enterprise.md
@@ -4124,9 +4124,9 @@ curl -X GET http://coder-server:8080/api/v2/users/{user}/quiet-hours \
 
 ### Parameters
 
-| Name   | In   | Type         | Required | Description |
-|--------|------|--------------|----------|-------------|
-| `user` | path | string(uuid) | true     | User ID     |
+| Name   | In   | Type   | Required | Description          |
+|--------|------|--------|----------|----------------------|
+| `user` | path | string | true     | User ID, name, or me |
 
 ### Example responses
 
@@ -4193,7 +4193,7 @@ curl -X PUT http://coder-server:8080/api/v2/users/{user}/quiet-hours \
 
 | Name   | In   | Type                                                                                                   | Required | Description             |
 |--------|------|--------------------------------------------------------------------------------------------------------|----------|-------------------------|
-| `user` | path | string(uuid)                                                                                           | true     | User ID                 |
+| `user` | path | string                                                                                                 | true     | User ID, name, or me    |
 | `body` | body | [codersdk.UpdateUserQuietHoursScheduleRequest](schemas.md#codersdkupdateuserquiethoursschedulerequest) | true     | Update schedule request |
 
 ### Example responses

--- a/enterprise/coderd/users.go
+++ b/enterprise/coderd/users.go
@@ -41,7 +41,7 @@ func (api *API) autostopRequirementEnabledMW(next http.Handler) http.Handler {
 // @Security CoderSessionToken
 // @Produce json
 // @Tags Enterprise
-// @Param user path string true "User ID" format(uuid)
+// @Param user path string true "User ID, name, or me"
 // @Success 200 {array} codersdk.UserQuietHoursScheduleResponse
 // @Router /users/{user}/quiet-hours [get]
 func (api *API) userQuietHoursSchedule(rw http.ResponseWriter, r *http.Request) {
@@ -76,7 +76,7 @@ func (api *API) userQuietHoursSchedule(rw http.ResponseWriter, r *http.Request) 
 // @Accept json
 // @Produce json
 // @Tags Enterprise
-// @Param user path string true "User ID" format(uuid)
+// @Param user path string true "User ID, name, or me"
 // @Param request body codersdk.UpdateUserQuietHoursScheduleRequest true "Update schedule request"
 // @Success 200 {array} codersdk.UserQuietHoursScheduleResponse
 // @Router /users/{user}/quiet-hours [put]


### PR DESCRIPTION
Fixes #24473.

## Problem

The two `/users/{user}/quiet-hours` endpoints declared the `user` path
parameter with `format(uuid)`. Swagger UI honors that as a client-side
Guid validator, so typing `me` in the parameter input failed with:

> Please correct the following validation errors and try again.
>
> For 'user': Value must be a Guid.

No request was ever sent. The server itself accepts `me` (and usernames)
via `httpmw.UserParam`, exactly like every other user-scoped endpoint.
Those other endpoints already annotate the parameter as
`User ID, name, or me` with no `format(uuid)`.

## Fix

Match the existing convention in `enterprise/coderd/users.go` for both
the GET and PUT quiet-hours handlers, then regenerate `coderd/apidoc`
and `docs/reference/api/enterprise.md` via `make gen`.

```diff
-// @Param user path string true "User ID" format(uuid)
+// @Param user path string true "User ID, name, or me"
```

No behavior change; this is a swagger annotation fix.

## Proof

Loaded the regenerated `swagger.json` in Swagger UI, expanded
`GET /users/{user}/quiet-hours`, hit Try it out, typed `me`, and clicked
Execute.

### Before

![before](https://raw.githubusercontent.com/david-fraley/coder/dfraley/proof-24473-assets/before.png)

Client-side validation blocks the request: `For 'user': Value must be a
Guid.` Type label reads `string($uuid)`.

### After

![after](https://raw.githubusercontent.com/david-fraley/coder/dfraley/proof-24473-assets/after.png)

No validation error, request fires with `me` (the 404 in the screenshot
is from the local static file server used to render the spec, not from
the Coder API). Type label now reads `string` and the description shows
`User ID, name, or me`.

---

_Disclosure: this PR was opened by a Coder Agents bot on @david-fraley's behalf._