### PR TITLE
docs(docs/ai-coder): clarify MCP tools injection deprecation timeline

### DIFF
--- a/docs/ai-coder/ai-gateway/mcp.md
+++ b/docs/ai-coder/ai-gateway/mcp.md
@@ -1,9 +1,10 @@
 # MCP
 
 > [!WARNING]
-> Injected MCP in AI Gateway is deprecated. 
+> Injected MCP in AI Gateway is deprecated.
 > It remains functional and will not be removed until
->  the new implementation is released. Only critical security-related patches will be made. 
+> the new implementation is released. Only critical
+> security-related patches will be made.
 
 [Model Context Protocol (MCP)](https://modelcontextprotocol.io/docs/getting-started/intro) is a mechanism for connecting AI applications to external systems.
 

--- a/docs/ai-coder/ai-gateway/mcp.md
+++ b/docs/ai-coder/ai-gateway/mcp.md
@@ -1,9 +1,9 @@
 # MCP
 
 > [!WARNING]
-> Injected MCP in AI Gateway is deprecated. However, this feature will
-> remain functional and will not be removed until the new implementation
-> is released.
+> Injected MCP in AI Gateway is deprecated. 
+> It remains functional and will not be removed until
+>  the new implementation is released. Only critical security-related patches will be made. 
 
 [Model Context Protocol (MCP)](https://modelcontextprotocol.io/docs/getting-started/intro) is a mechanism for connecting AI applications to external systems.
 

--- a/docs/ai-coder/ai-gateway/mcp.md
+++ b/docs/ai-coder/ai-gateway/mcp.md
@@ -1,7 +1,10 @@
 # MCP
 
 > [!WARNING]
-> Injected MCP in AI Gateway is deprecated and will be removed in a future release.
+> Injected MCP in AI Gateway is deprecated. This feature will remain
+> functional and will not be removed until
+> [MCP Gateway](https://coder.com/docs/ai-coder/ai-gateway), its
+> replacement, is released.
 
 [Model Context Protocol (MCP)](https://modelcontextprotocol.io/docs/getting-started/intro) is a mechanism for connecting AI applications to external systems.
 

--- a/docs/ai-coder/ai-gateway/mcp.md
+++ b/docs/ai-coder/ai-gateway/mcp.md
@@ -1,10 +1,9 @@
 # MCP
 
 > [!WARNING]
-> Injected MCP in AI Gateway is deprecated. This feature will remain
-> functional and will not be removed until
-> [MCP Gateway](https://coder.com/docs/ai-coder/ai-gateway), its
-> replacement, is released.
+> Injected MCP in AI Gateway is deprecated. However, this feature will
+> remain functional and will not be removed until the new implementation
+> is released.
 
 [Model Context Protocol (MCP)](https://modelcontextprotocol.io/docs/getting-started/intro) is a mechanism for connecting AI applications to external systems.
 


### PR DESCRIPTION
The deprecation notice on the [MCP Tools Injection](https://coder.com/docs/ai-coder/ai-gateway/mcp) page currently states the feature "will be removed in a future release," which may cause concern for users relying on it today.

This updates the warning to clarify that the feature will remain functional and will not be removed until its replacement, MCP Gateway, is released.

> [!NOTE]
> Generated by Coder Agents