### PR TITLE
refactor(site/src/components): migrate shared form fields to Radix primitives

### DIFF
--- a/site/src/components/Dialogs/DeleteDialog/DeleteDialog.tsx
+++ b/site/src/components/Dialogs/DeleteDialog/DeleteDialog.tsx
@@ -1,6 +1,7 @@
 import type { Interpolation, Theme } from "@emotion/react";
-import TextField from "@mui/material/TextField";
 import { type FC, type FormEvent, useId, useState } from "react";
+import { Input } from "../../Input/Input";
+import { Label } from "../../Label/Label";
 import { Stack } from "../../Stack/Stack";
 import { ConfirmDialog } from "../ConfirmDialog/ConfirmDialog";
 
@@ -47,7 +48,12 @@ export const DeleteDialog: FC<DeleteDialogProps> = ({
 
 	const hasError = !deletionConfirmed && userConfirmationText.length > 0;
 	const displayErrorMessage = hasError && !isFocused;
-	const inputColor = hasError ? "error" : "primary";
+	const confirmationInputId = `${hookId}-confirm`;
+	const confirmationErrorId = `${confirmationInputId}-error`;
+	const confirmationLabel = label ?? `Name of the ${entity} to delete`;
+	const errorMessage = displayErrorMessage
+		? `${userConfirmationText} does not match the name of this ${entity}`
+		: undefined;
 
 	return (
 		<ConfirmDialog
@@ -75,30 +81,36 @@ export const DeleteDialog: FC<DeleteDialogProps> = ({
 					</Stack>
 
 					<form onSubmit={onSubmit}>
-						<TextField
-							fullWidth
-							autoFocus
-							className="mt-6"
-							name="confirmation"
-							autoComplete="off"
-							id={`${hookId}-confirm`}
-							placeholder={name}
-							value={userConfirmationText}
-							onChange={(event) => setUserConfirmationText(event.target.value)}
-							onFocus={() => setIsFocused(true)}
-							onBlur={() => setIsFocused(false)}
-							label={label ?? `Name of the ${entity} to delete`}
-							color={inputColor}
-							error={displayErrorMessage}
-							helperText={
-								displayErrorMessage &&
-								`${userConfirmationText} does not match the name of this ${entity}`
-							}
-							InputProps={{ color: inputColor }}
-							inputProps={{
-								"data-testid": "delete-dialog-name-confirmation",
-							}}
-						/>
+						<div className="mt-6 flex flex-col gap-2">
+							<Label htmlFor={confirmationInputId}>{confirmationLabel}</Label>
+							<Input
+								autoFocus
+								name="confirmation"
+								autoComplete="off"
+								id={confirmationInputId}
+								placeholder={name}
+								value={userConfirmationText}
+								onChange={(event) =>
+									setUserConfirmationText(event.target.value)
+								}
+								onFocus={() => setIsFocused(true)}
+								onBlur={() => setIsFocused(false)}
+								aria-invalid={displayErrorMessage}
+								aria-describedby={
+									errorMessage ? confirmationErrorId : undefined
+								}
+								data-testid="delete-dialog-name-confirmation"
+								className="text-content-primary"
+							/>
+							{errorMessage && (
+								<span
+									id={confirmationErrorId}
+									className="text-xs text-content-destructive"
+								>
+									{errorMessage}
+								</span>
+							)}
+						</div>
 					</form>
 				</>
 			}

--- a/site/src/components/DurationField/DurationField.tsx
+++ b/site/src/components/DurationField/DurationField.tsx
@@ -1,9 +1,21 @@
-import FormHelperText from "@mui/material/FormHelperText";
-import MenuItem from "@mui/material/MenuItem";
-import Select from "@mui/material/Select";
-import TextField, { type TextFieldProps } from "@mui/material/TextField";
-import { ChevronDownIcon } from "lucide-react";
-import { type FC, useEffect, useReducer } from "react";
+import {
+	type FC,
+	type InputHTMLAttributes,
+	type ReactNode,
+	useEffect,
+	useId,
+	useReducer,
+} from "react";
+import { Input } from "#/components/Input/Input";
+import { Label } from "#/components/Label/Label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "#/components/Select/Select";
+import { cn } from "#/utils/cn";
 import {
 	durationInDays,
 	durationInHours,
@@ -11,9 +23,17 @@ import {
 	type TimeUnit,
 } from "#/utils/time";
 
-type DurationFieldProps = Omit<TextFieldProps, "value" | "onChange"> & {
+type DurationFieldProps = Omit<
+	InputHTMLAttributes<HTMLInputElement>,
+	"onChange" | "value"
+> & {
 	valueMs: number;
 	onChange: (value: number) => void;
+	label?: ReactNode;
+	helperText?: ReactNode;
+	error?: boolean;
+	fullWidth?: boolean;
+	value?: InputHTMLAttributes<HTMLInputElement>["value"];
 };
 
 type State = {
@@ -64,8 +84,22 @@ export const DurationField: FC<DurationFieldProps> = (props) => {
 		valueMs: parentValueMs,
 		onChange,
 		helperText,
-		...textFieldProps
+		error,
+		label,
+		fullWidth: _fullWidth,
+		value: _value,
+		id,
+		className,
+		disabled,
+		inputMode,
+		step,
+		"aria-describedby": ariaDescribedBy,
+		...inputProps
 	} = props;
+	const generatedId = useId();
+	const inputId = id ?? generatedId;
+	const helperTextId = helperText ? `${inputId}-helper-text` : undefined;
+	const describedBy = [ariaDescribedBy, helperTextId].filter(Boolean).join(" ");
 	const [state, dispatch] = useReducer(reducer, initState(parentValueMs));
 	const currentDurationMs = durationInMs(state.durationFieldValue, state.unit);
 
@@ -75,12 +109,52 @@ export const DurationField: FC<DurationFieldProps> = (props) => {
 		}
 	}, [currentDurationMs, parentValueMs]);
 
+	const handleUnitChange = (value: string) => {
+		if (!isTimeUnit(value)) {
+			return;
+		}
+
+		const unit = value;
+		dispatch({
+			type: "CHANGE_TIME_UNIT",
+			unit,
+		});
+
+		// Calculate the new duration in ms after changing the unit.
+		// Important: When changing from hours to days, we need to round up to
+		// nearest day but keep the millisecond value consistent for the parent
+		// component.
+		let newDurationMs: number;
+		if (unit === "hours") {
+			// When switching to hours, use the current milliseconds to get exact
+			// hours.
+			newDurationMs = currentDurationMs;
+		} else {
+			// When switching to days, round up to the nearest day.
+			const daysValue = Math.ceil(durationInDays(currentDurationMs));
+			newDurationMs = daysToDuration(daysValue);
+		}
+
+		// Notify parent component if the value has changed.
+		if (newDurationMs !== parentValueMs) {
+			onChange(newDurationMs);
+		}
+	};
+
 	return (
 		<div>
+			{label && (
+				<Label htmlFor={inputId} className="mb-2 block">
+					{label}
+				</Label>
+			)}
+
 			<div className="flex gap-2">
-				<TextField
-					{...textFieldProps}
-					fullWidth
+				<Input
+					{...inputProps}
+					id={inputId}
+					className={cn("min-w-0 flex-1", className)}
+					disabled={disabled}
 					value={state.durationFieldValue}
 					onChange={(e) => {
 						const durationFieldValue = intMask(e.currentTarget.value);
@@ -98,49 +172,40 @@ export const DurationField: FC<DurationFieldProps> = (props) => {
 							onChange(newDurationInMs);
 						}
 					}}
-					inputProps={{
-						step: 1,
-					}}
+					step={step ?? 1}
+					inputMode={inputMode ?? "numeric"}
+					aria-invalid={error || undefined}
+					aria-describedby={describedBy || undefined}
 				/>
 				<Select
-					disabled={props.disabled}
-					css={{ width: 120, "& .MuiSelect-icon": { padding: 2 } }}
+					disabled={disabled}
 					value={state.unit}
-					onChange={(e) => {
-						const unit = e.target.value as TimeUnit;
-						dispatch({
-							type: "CHANGE_TIME_UNIT",
-							unit,
-						});
-
-						// Calculate the new duration in ms after changing the unit
-						// Important: When changing from hours to days, we need to round up to nearest day
-						// but keep the millisecond value consistent for the parent component
-						let newDurationMs: number;
-						if (unit === "hours") {
-							// When switching to hours, use the current milliseconds to get exact hours
-							newDurationMs = currentDurationMs;
-						} else {
-							// When switching to days, round up to the nearest day
-							const daysValue = Math.ceil(durationInDays(currentDurationMs));
-							newDurationMs = daysToDuration(daysValue);
-						}
-
-						// Notify parent component if the value has changed
-						if (newDurationMs !== parentValueMs) {
-							onChange(newDurationMs);
-						}
-					}}
-					inputProps={{ "aria-label": "Time unit" }}
-					IconComponent={ChevronDownIcon}
+					onValueChange={handleUnitChange}
 				>
-					<MenuItem value="hours">Hours</MenuItem>
-					<MenuItem value="days">Days</MenuItem>
+					<SelectTrigger
+						disabled={disabled}
+						aria-label="Time unit"
+						className="w-[120px] shrink-0"
+					>
+						<SelectValue />
+					</SelectTrigger>
+					<SelectContent>
+						<SelectItem value="hours">Hours</SelectItem>
+						<SelectItem value="days">Days</SelectItem>
+					</SelectContent>
 				</Select>
 			</div>
 
 			{helperText && (
-				<FormHelperText error={props.error}>{helperText}</FormHelperText>
+				<p
+					id={helperTextId}
+					className={cn(
+						"mt-2 text-xs",
+						error ? "text-content-destructive" : "text-content-secondary",
+					)}
+				>
+					{helperText}
+				</p>
 			)}
 		</div>
 	);
@@ -181,4 +246,8 @@ function hoursToDuration(hours: number): number {
 
 function daysToDuration(days: number): number {
 	return days * 24 * hoursToDuration(1);
+}
+
+function isTimeUnit(value: string): value is TimeUnit {
+	return value === "hours" || value === "days";
 }

--- a/site/src/components/Form/Form.stories.tsx
+++ b/site/src/components/Form/Form.stories.tsx
@@ -1,5 +1,6 @@
-import TextField from "@mui/material/TextField";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Input } from "#/components/Input/Input";
+import { Label } from "#/components/Label/Label";
 import { Form, FormFields, FormSection } from "./Form";
 
 const meta: Meta<typeof Form> = {
@@ -12,8 +13,14 @@ const meta: Meta<typeof Form> = {
 				description="The name of the workspace and its owner. Only admins can create workspaces for other users."
 			>
 				<FormFields>
-					<TextField label="Workspace Name" />
-					<TextField label="Owner" />
+					<div className="flex flex-col gap-2">
+						<Label htmlFor="form-story-workspace-name">Workspace Name</Label>
+						<Input id="form-story-workspace-name" name="workspaceName" />
+					</div>
+					<div className="flex flex-col gap-2">
+						<Label htmlFor="form-story-owner">Owner</Label>
+						<Input id="form-story-owner" name="owner" />
+					</div>
 				</FormFields>
 			</FormSection>
 		),

--- a/site/src/components/FullPageForm/FullPageForm.stories.tsx
+++ b/site/src/components/FullPageForm/FullPageForm.stories.tsx
@@ -1,8 +1,9 @@
-import TextField from "@mui/material/TextField";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { FC } from "react";
 import { Button } from "#/components/Button/Button";
 import { FormFooter } from "#/components/Form/Form";
+import { Input } from "#/components/Input/Input";
+import { Label } from "#/components/Label/Label";
 import { Stack } from "../Stack/Stack";
 import { FullPageForm, type FullPageFormProps } from "./FullPageForm";
 
@@ -14,8 +15,14 @@ const Template: FC<FullPageFormProps> = (props) => (
 			}}
 		>
 			<Stack>
-				<TextField fullWidth label="Field 1" name="field1" />
-				<TextField fullWidth label="Field 2" name="field2" />
+				<div className="flex flex-col gap-2">
+					<Label htmlFor="full-page-form-story-field-1">Field 1</Label>
+					<Input id="full-page-form-story-field-1" name="field1" />
+				</div>
+				<div className="flex flex-col gap-2">
+					<Label htmlFor="full-page-form-story-field-2">Field 2</Label>
+					<Input id="full-page-form-story-field-2" name="field2" />
+				</div>
 				<FormFooter>
 					<Button variant="outline">Cancel</Button>
 					<Button type="submit">Save</Button>

--- a/site/src/components/IconField/IconField.tsx
+++ b/site/src/components/IconField/IconField.tsx
@@ -1,95 +1,153 @@
 import { css, Global, useTheme } from "@emotion/react";
-import InputAdornment from "@mui/material/InputAdornment";
-import TextField, { type TextFieldProps } from "@mui/material/TextField";
-import { type FC, lazy, Suspense, useState } from "react";
+import {
+	type ChangeEventHandler,
+	type FC,
+	type FocusEventHandler,
+	lazy,
+	type ReactNode,
+	Suspense,
+	useId,
+	useState,
+} from "react";
 import { ChevronDownIcon } from "#/components/AnimatedIcons/ChevronDown";
 import { Button } from "#/components/Button/Button";
 import { ExternalImage } from "#/components/ExternalImage/ExternalImage";
+import { Input } from "#/components/Input/Input";
+import { Label } from "#/components/Label/Label";
 import { Loader } from "#/components/Loader/Loader";
 import {
 	Popover,
 	PopoverContent,
 	PopoverTrigger,
 } from "#/components/Popover/Popover";
+import { cn } from "#/utils/cn";
 
-type IconFieldProps = TextFieldProps & {
+type IconFieldProps = {
+	value?: string | number;
+	onChange?: ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement>;
+	onBlur?: FocusEventHandler<HTMLInputElement | HTMLTextAreaElement>;
+	name?: string;
+	id?: string;
+	disabled?: boolean;
+	fullWidth?: boolean;
+	label?: ReactNode;
+	error?: boolean;
+	helperText?: ReactNode;
+	className?: string;
 	onPickEmoji: (value: string) => void;
 };
 
 const EmojiPicker = lazy(() => import("./EmojiPicker"));
 
 export const IconField: FC<IconFieldProps> = ({
+	className,
+	disabled,
+	error,
+	fullWidth = true,
+	helperText,
+	id,
+	label = "Icon",
+	name,
+	onBlur,
+	onChange,
 	onPickEmoji,
-	...textFieldProps
+	value,
 }) => {
-	if (
-		typeof textFieldProps.value !== "string" &&
-		typeof textFieldProps.value !== "undefined"
-	) {
-		throw new Error(`Invalid icon value "${typeof textFieldProps.value}"`);
+	if (typeof value !== "string" && typeof value !== "undefined") {
+		throw new Error(`Invalid icon value "${typeof value}"`);
 	}
 
 	const theme = useTheme();
-	const hasIcon = textFieldProps.value && textFieldProps.value !== "";
+	const generatedId = useId();
+	const inputId = id ?? generatedId;
+	const helperTextId = helperText ? `${inputId}-helper-text` : undefined;
+	const hasIcon = value !== undefined && value !== "";
 	const [open, setOpen] = useState(false);
 
 	return (
-		<div className="flex items-center gap-2">
-			<TextField
-				fullWidth
-				label="Icon"
-				{...textFieldProps}
-				InputProps={{
-					endAdornment: hasIcon ? (
-						<InputAdornment
-							position="end"
-							className="w-6 h-6 flex items-center justify-center [&_img]:max-w-full [&_img]:object-contain"
-						>
-							<ExternalImage
-								alt=""
-								src={textFieldProps.value}
-								// This prevent browser to display the ugly error icon if the
-								// image path is wrong or user didn't finish typing the url
-								onError={(e) => {
-									e.currentTarget.style.display = "none";
-								}}
-								onLoad={(e) => {
-									e.currentTarget.style.display = "inline";
+		<div
+			className={cn("flex flex-col gap-2", fullWidth && "w-full", className)}
+		>
+			<Label htmlFor={inputId}>{label}</Label>
+			<div className="flex items-center gap-2">
+				<div className={cn("relative", fullWidth && "w-full")}>
+					<Input
+						id={inputId}
+						name={name}
+						value={value}
+						onChange={onChange}
+						onBlur={onBlur}
+						disabled={disabled}
+						aria-invalid={error || undefined}
+						aria-describedby={helperTextId}
+						className={cn(!fullWidth && "w-auto", hasIcon && "pr-12")}
+					/>
+					{hasIcon && (
+						<div className="pointer-events-none absolute inset-y-0 right-3 flex items-center">
+							<div className="w-6 h-6 flex items-center justify-center [&_img]:max-w-full [&_img]:object-contain">
+								<ExternalImage
+									alt=""
+									src={value}
+									// This prevent browser to display the ugly error icon if the
+									// image path is wrong or user didn't finish typing the url
+									onError={(e) => {
+										e.currentTarget.style.display = "none";
+									}}
+									onLoad={(e) => {
+										e.currentTarget.style.display = "inline";
+									}}
+								/>
+							</div>
+						</div>
+					)}
+				</div>
+
+				<Global
+					styles={css`
+						em-emoji-picker {
+							--rgb-background: ${theme.palette.background.paper};
+							--rgb-input: ${theme.palette.primary.main};
+							--rgb-color: ${theme.palette.text.primary};
+						}
+					`}
+				/>
+				<Popover open={open} onOpenChange={setOpen}>
+					<PopoverTrigger asChild>
+						<Button variant="outline" size="lg" className="group flex-shrink-0">
+							Emoji
+							<ChevronDownIcon />
+						</Button>
+					</PopoverTrigger>
+					<PopoverContent
+						id="emoji"
+						side="bottom"
+						align="end"
+						className="w-min"
+					>
+						<Suspense fallback={<Loader />}>
+							<EmojiPicker
+								onEmojiSelect={(emoji) => {
+									const value = emoji.src ?? `/emojis/${emoji.unified}.png`;
+									onPickEmoji(value);
+									setOpen(false);
 								}}
 							/>
-						</InputAdornment>
-					) : undefined,
-				}}
-			/>
+						</Suspense>
+					</PopoverContent>
+				</Popover>
+			</div>
 
-			<Global
-				styles={css`
-					em-emoji-picker {
-						--rgb-background: ${theme.palette.background.paper};
-						--rgb-input: ${theme.palette.primary.main};
-						--rgb-color: ${theme.palette.text.primary};
-					}
-				`}
-			/>
-			<Popover open={open} onOpenChange={setOpen}>
-				<PopoverTrigger asChild>
-					<Button variant="outline" size="lg" className="group flex-shrink-0">
-						Emoji
-						<ChevronDownIcon />
-					</Button>
-				</PopoverTrigger>
-				<PopoverContent id="emoji" side="bottom" align="end" className="w-min">
-					<Suspense fallback={<Loader />}>
-						<EmojiPicker
-							onEmojiSelect={(emoji) => {
-								const value = emoji.src ?? `/emojis/${emoji.unified}.png`;
-								onPickEmoji(value);
-								setOpen(false);
-							}}
-						/>
-					</Suspense>
-				</PopoverContent>
-			</Popover>
+			{helperText && (
+				<p
+					id={helperTextId}
+					className={cn(
+						"m-0 text-xs",
+						error ? "text-content-destructive" : "text-content-secondary",
+					)}
+				>
+					{helperText}
+				</p>
+			)}
 
 			{/*
       - This component takes a long time to load (easily several seconds), so we


### PR DESCRIPTION
## Slice 3 of 15 · MUI → Radix/shadcn migration

Stacks on #24747 (slice 2). Migrates **basic MUI form-field callsites in shared form components** under `site/src/components/` to the existing Radix/shadcn primitives documented in `MIGRATION.md` (added in #24741).

### Files migrated (5)

| File | Migration |
|---|---|
| `site/src/components/Dialogs/DeleteDialog/DeleteDialog.tsx` | `TextField` → `Label` + `Input`; preserved `autoFocus`, accessibility wiring (`htmlFor`, `aria-invalid`, `aria-describedby`), and `data-testid="delete-dialog-name-confirmation"` |
| `site/src/components/DurationField/DurationField.tsx` | `TextField` + `Select` + `MenuItem` + `FormHelperText` → shared `Input` + Radix `Select` family + semantic helper `<p>`; reducer, integer mask, hours/days conversion preserved; removed Emotion `css` prop |
| `site/src/components/IconField/IconField.tsx` | `TextField` + `InputAdornment` → shared `Input` with custom end-slot adornment; emoji picker behavior unchanged; 6 production callsites typecheck unmodified |
| `site/src/components/Form/Form.stories.tsx` | Story demos: `TextField` → `Label` + `Input` |
| `site/src/components/FullPageForm/FullPageForm.stories.tsx` | Story demos: `TextField` → `Label` + `Input` |

### Files explicitly deferred

- `site/src/components/RichParameterInput/RichParameterInput.tsx` — slice 4 owns this (high-risk, 458 LOC, 6 MUI imports).
- `site/src/components/SelectMenu/SelectMenu.tsx` — `MenuItem` is in an action menu (not a closed-list select); deferred to a later wave.
- All feature-page form callsites (template, workspace, deployment, organization) — slices 5–13.
- MUI provider/theme/Emotion cleanup — slice 15.

### `@mui/*` import counts

| | Before | After | Δ |
|---|---|---|---|
| Files importing `@mui/*` | 77 | 72 | −5 |
| `@mui/*` import statements | 146 | 137 | −9 |

### Validation

- `pnpm check` — pass (1639 files, 0 fixes)
- `pnpm lint` — pass (0 errors, 0 diagnostics; `tsc -p .`, dpdm, check-compiler, knip)
- `pnpm test` — pass (151 files, 1923/1923 tests)
- `pnpm test:storybook` on the 5 migrated stories — pass (15/15)
- `make pre-commit` — pass

Pre-existing warnings observed during validation but **not introduced by this slice**: `@mui/x-tree-view` Storybook warm-up, Vitest 4 close-timeout notice (exit 0), jsdom canvas warning in unrelated tests.

### Notes

- Component public APIs preserved; no caller-visible behavior changes.
- Chromatic visual diffs will be reported by CI; baselines may need acceptance.
- Emotion cleanup deferred to final-cleanup slice (15).

### PR stack

1. #24741 — Replacement primitives + migration rules (foundation, docs)
2. #24747 — Dialog & menu foundations (`ConfirmDialog` migrated)
3. **This PR** — Shared form-field migrations
4. *(coming next)* — `RichParameterInput`
