### PR TITLE
fix: render non-typed parameter changes immediately

### DIFF
--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageViewExperimental.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceParametersPage/WorkspaceParametersPageViewExperimental.tsx
@@ -88,7 +88,14 @@ export const WorkspaceParametersPageViewExperimental: FC<
 			formInputs[parameter.name] = value;
 			sendMessage(formInputs);
 		},
-		500,
+		(parameter: PreviewParameter, _value: string) => {
+			// Return a debounce for string fields (those that involve typing) and
+			// zero debounce for all others (so the UI can react immediately).
+			return parameter.form_type === "input" ||
+				parameter.form_type === "textarea"
+				? 500
+				: 0;
+		},
 	);
 
 	const handleChange = async (


### PR DESCRIPTION
This was already done for the workspace creation page, but not the edit page, as it does not share the base form, so all I did was copy that fix into the edit page.

For reference: https://github.com/coder/coder/pull/23951

Closes https://linear.app/codercom/issue/DEVEX-235/update-parameters-page-is-missing-debounce-fix