### PR TITLE
fix: prevent chatd test races and deduplicate expired-image probes

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -2218,7 +2218,7 @@ func (a *agent) Close() error {
 	}
 
 	if err := a.mcpManager.Close(); err != nil {
-		a.logger.Error(a.hardCtx, "mcp manager close", slog.Error(err))
+		a.logger.Warn(a.hardCtx, "mcp manager close", slog.Error(err))
 	}
 
 	if a.boundaryLogProxy != nil {

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -180,6 +180,11 @@ type Server struct {
 	maxChatsPerAcquire         int32
 	inFlightChatStaleAfter     time.Duration
 	chatHeartbeatInterval      time.Duration
+	// noAutoAcquire mirrors Config.NoAutoAcquire. When true the start()
+	// loop drains wakeCh and acquireTicker events without calling
+	// processOnce, making the server passive with respect to chat
+	// acquisition.
+	noAutoAcquire bool
 
 	// heartbeatMu guards heartbeatRegistry.
 	heartbeatMu sync.Mutex
@@ -3571,10 +3576,17 @@ type Config struct {
 	Pubsub                         pubsub.Pubsub
 	ProviderAPIKeys                chatprovider.ProviderAPIKeys
 	AlwaysEnableDebugLogs          bool
-	WebpushDispatcher              webpush.Dispatcher
-	UsageTracker                   *workspacestats.UsageTracker
-	Clock                          quartz.Clock
-	PrometheusRegistry             prometheus.Registerer
+	// NoAutoAcquire disables automatic chat acquisition in response to
+	// signalWake() and the periodic acquire ticker. When true, the server
+	// runs its heartbeat and stale-recovery loops but never calls
+	// processOnce on its own. Use this in tests that want a truly passive
+	// server so that CreateChat (and other operations that call
+	// signalWake) cannot race with the test's own DB reads.
+	NoAutoAcquire      bool
+	WebpushDispatcher  webpush.Dispatcher
+	UsageTracker       *workspacestats.UsageTracker
+	Clock              quartz.Clock
+	PrometheusRegistry prometheus.Registerer
 }
 
 // New creates a new chat processor. The processor polls for pending
@@ -3652,6 +3664,7 @@ func New(cfg Config) *Server {
 		maxChatsPerAcquire:         maxChatsPerAcquire,
 		inFlightChatStaleAfter:     inFlightChatStaleAfter,
 		chatHeartbeatInterval:      chatHeartbeatInterval,
+		noAutoAcquire:              cfg.NoAutoAcquire,
 		usageTracker:               cfg.UsageTracker,
 		clock:                      clk,
 		recordingSem:               make(chan struct{}, maxConcurrentRecordingUploads),
@@ -3738,9 +3751,13 @@ func (p *Server) start(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-acquireTicker.C:
-			p.processOnce(ctx)
+			if !p.noAutoAcquire {
+				p.processOnce(ctx)
+			}
 		case <-p.wakeCh:
-			p.processOnce(ctx)
+			if !p.noAutoAcquire {
+				p.processOnce(ctx)
+			}
 		case <-staleTicker.C:
 			p.recoverStaleChats(ctx)
 			if debugSvc := p.existingDebugService(); debugSvc != nil {

--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -2082,7 +2082,7 @@ func TestSendMessageInterruptBehaviorQueuesAndInterruptsWhenBusy(t *testing.T) {
 	t.Parallel()
 
 	db, ps := dbtestutil.NewDB(t)
-	replica := newTestServer(t, db, ps, uuid.New())
+	replica := newWakeTestServer(t, db, ps, uuid.New())
 
 	ctx := testutil.Context(t, testutil.WaitLong)
 	user, org, model := seedChatDependencies(ctx, t, db)
@@ -2234,9 +2234,9 @@ func TestEditMessageUpdatesAndTruncatesAndClearsQueue(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, queued, 0)
 
-	// The wake channel may trigger immediate processing after EditMessage,
-	// transitioning the chat from pending to running then error before we
-	// read the DB. Wait for any in-flight processing to settle.
+	// With a passive server (NoAutoAcquire), EditMessage sets the chat to
+	// Pending but no background processing runs. WaitUntilIdleForTest is a
+	// no-op here; the Eventually immediately satisfies Status != Running.
 	// Note: WaitUntilIdleForTest must be called from the test goroutine
 	// (not inside require.Eventually) to avoid a WaitGroup Add/Wait race.
 	chatd.WaitUntilIdleForTest(replica)
@@ -2433,7 +2433,7 @@ func TestPromoteQueuedAllowsAlreadyQueuedMessageWhenUsageLimitReached(t *testing
 	t.Parallel()
 
 	db, ps := dbtestutil.NewDB(t)
-	replica := newTestServer(t, db, ps, uuid.New())
+	replica := newWakeTestServer(t, db, ps, uuid.New())
 
 	ctx := testutil.Context(t, testutil.WaitLong)
 	user, org, model := seedChatDependencies(ctx, t, db)
@@ -4787,7 +4787,7 @@ func TestSubscribeNoPubsubNoDuplicateMessageParts(t *testing.T) {
 
 	// Use nil pubsub to force the no-pubsub path.
 	db, _ := dbtestutil.NewDB(t)
-	replica := newTestServer(t, db, nil, uuid.New())
+	replica := newWakeTestServer(t, db, nil, uuid.New())
 
 	ctx := testutil.Context(t, testutil.WaitLong)
 	user, org, model := seedChatDependencies(ctx, t, db)
@@ -5739,6 +5739,36 @@ func newTestServer(
 		ReplicaID:                  replicaID,
 		Pubsub:                     ps,
 		PendingChatAcquireInterval: testutil.WaitLong,
+		NoAutoAcquire:              true,
+	})
+	t.Cleanup(func() {
+		require.NoError(t, server.Close())
+	})
+	return server
+}
+
+// newWakeTestServer creates a test server that responds to signalWake()
+// events but uses a very long acquire ticker so it does not poll
+// aggressively. Use this instead of newTestServer when the test
+// deliberately needs background chat processing to run exactly once
+// in response to a wake signal (e.g. after CreateChat) before the
+// test inspects state. For fully passive servers use newTestServer;
+// for aggressively polling servers use newActiveTestServer.
+func newWakeTestServer(
+	t *testing.T,
+	db database.Store,
+	ps dbpubsub.Pubsub,
+	replicaID uuid.UUID,
+) *chatd.Server {
+	t.Helper()
+
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	server := chatd.New(chatd.Config{
+		Logger:                     logger,
+		Database:                   db,
+		ReplicaID:                  replicaID,
+		Pubsub:                     ps,
+		PendingChatAcquireInterval: testutil.WaitLong,
 	})
 	t.Cleanup(func() {
 		require.NoError(t, server.Close())
@@ -5767,6 +5797,7 @@ func newDebugEnabledTestServer(
 		Pubsub:                     ps,
 		PendingChatAcquireInterval: testutil.WaitLong,
 		AlwaysEnableDebugLogs:      true,
+		NoAutoAcquire:              true,
 	})
 	t.Cleanup(func() {
 		require.NoError(t, server.Close())

--- a/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
@@ -411,7 +411,8 @@ const RemoteImageBlock: FC<{
 	displayName: string;
 	onImageClick?: (src: string) => void;
 }> = ({ fileId, href, displayName, onImageClick }) => {
-	const { hasExpired, markExpired } = useExpiredFileIds();
+	const { hasExpired, markExpired, isPending, markPending } =
+		useExpiredFileIds();
 	const isKnownExpired = fileId !== undefined && hasExpired(fileId);
 	const [failureState, setFailureState] = useState<AttachmentFailureState>(
 		() => (isKnownExpired ? { kind: "expired" } : { kind: "idle" }),
@@ -461,7 +462,15 @@ const RemoteImageBlock: FC<{
 						setFailureState({ kind: "expired" });
 						return;
 					}
+					// Another block already started a probe for this file.
+					// Fall back to the generic failure tile; markExpired will
+					// propagate via context if the probe resolves as expired.
+					if (isPending(fileId)) {
+						setFailureState({ kind: "failed" });
+						return;
+					}
 
+					markPending(fileId);
 					const controller = probeRequest.start();
 					// Optimistically swap to the generic failure tile. The
 					// probe will either upgrade it to "expired" or fill in

--- a/site/src/pages/AgentsPage/components/ChatConversation/ExpiredFileIdsContext.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ExpiredFileIdsContext.tsx
@@ -3,23 +3,35 @@ import {
 	type FC,
 	type PropsWithChildren,
 	useContext,
+	useRef,
 	useState,
 } from "react";
 
 type ExpiredFileIdsContextValue = {
 	hasExpired: (fileId: string) => boolean;
 	markExpired: (fileId: string) => void;
+	// isPending and markPending track in-flight probes so that when the same
+	// file ID appears in multiple blocks, only the first onError handler starts
+	// a network probe. The others fall through to the optimistic "failed" tile
+	// and will be upgraded to "expired" if markExpired is later called.
+	isPending: (fileId: string) => boolean;
+	markPending: (fileId: string) => void;
 };
 
 const ExpiredFileIdsContext = createContext<ExpiredFileIdsContextValue>({
 	hasExpired: () => false,
 	markExpired: () => {},
+	isPending: () => false,
+	markPending: () => {},
 });
 
 export const ExpiredFileIdsProvider: FC<PropsWithChildren> = ({ children }) => {
 	const [expiredFileIds, setExpiredFileIds] = useState<Set<string>>(
 		() => new Set(),
 	);
+	// Use a ref so pending-state changes don't trigger re-renders; we only
+	// need re-renders when expiredFileIds changes.
+	const pendingProbeFileIds = useRef<Set<string>>(new Set());
 
 	return (
 		<ExpiredFileIdsContext.Provider
@@ -34,6 +46,10 @@ export const ExpiredFileIdsProvider: FC<PropsWithChildren> = ({ children }) => {
 						next.add(fileId);
 						return next;
 					});
+				},
+				isPending: (fileId) => pendingProbeFileIds.current.has(fileId),
+				markPending: (fileId) => {
+					pendingProbeFileIds.current.add(fileId);
 				},
 			}}
 		>


### PR DESCRIPTION
Two independent test reliability fixes.

**chatd**: `TestEditMessageRejectsArchivedChat` and related tests were flaky because `newTestServer` started a `Server` that auto-acquired and processed work via its internal ticker and wake channel. Concurrent test activity could trigger processing during unrelated tests, causing spurious failures. A new `NoAutoAcquire` config option prevents the server from self-scheduling in tests; tests that need wake-driven behavior opt in via `newWakeTestServer`. Also downgrades the MCP manager close error from `Error` to `Warn` so slog-based tests (`Test_TaskLogs_Golden`) do not fail when agents are killed at test teardown.

**site**: When the same file ID appears in multiple `RemoteImageBlock` components and both images fail to load simultaneously, each block independently called `probeAttachmentFailure`. `ExpiredFileIdsContext` now tracks in-flight probes in a ref so a second block for the same file ID skips its probe and falls through to the generic failure tile, which is upgraded to "expired" when `markExpired` fires from the first probe.

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻