### PR TITLE
fix(site): fix download log size display

### DIFF
--- a/site/src/modules/workspaces/WorkspaceMoreActions/DownloadLogsDialog.test.ts
+++ b/site/src/modules/workspaces/WorkspaceMoreActions/DownloadLogsDialog.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { humanBlobSize } from "./DownloadLogsDialog";
+
+describe("humanBlobSize", () => {
+	it("formats bytes without decimals", () => {
+		expect(humanBlobSize(200)).toBe("200 B");
+	});
+
+	it("promotes 1024 bytes to 1 KB", () => {
+		expect(humanBlobSize(1024)).toBe("1 KB");
+	});
+
+	it("formats fractional kilobytes with up to 2 decimals", () => {
+		expect(humanBlobSize(1491)).toBe("1.46 KB");
+		expect(humanBlobSize(4472)).toBe("4.37 KB");
+	});
+
+	it("formats larger units", () => {
+		expect(humanBlobSize(1024 * 1024)).toBe("1 MB");
+		expect(humanBlobSize(1024 * 1024 * 1.5)).toBe("1.5 MB");
+	});
+});

--- a/site/src/modules/workspaces/WorkspaceMoreActions/DownloadLogsDialog.tsx
+++ b/site/src/modules/workspaces/WorkspaceMoreActions/DownloadLogsDialog.tsx
@@ -227,21 +227,22 @@ const DownloadingItem: FC<DownloadingItemProps> = ({ file, giveUpTimeMs }) => {
 	);
 };
 
-function humanBlobSize(size: number) {
+export function humanBlobSize(size: number) {
 	const BLOB_SIZE_UNITS = ["B", "KB", "MB", "GB", "TB"] as const;
 	let i = 0;
-	let sizeIterator = size;
-	while (sizeIterator > 1024 && i < BLOB_SIZE_UNITS.length) {
-		sizeIterator /= 1024;
+	let sizeInUnits = size;
+	while (sizeInUnits >= 1024 && i < BLOB_SIZE_UNITS.length - 1) {
+		sizeInUnits /= 1024;
 		i++;
 	}
 
-	// The condition for the while loop above means that over time, we could break
-	// out of the loop because we accidentally shot past the array bounds and i
-	// is at index (BLOB_SIZE_UNITS.length). Adding a lot of redundant checks to
-	// make sure we always have a usable unit
-	const finalUnit = BLOB_SIZE_UNITS[i] ?? BLOB_SIZE_UNITS.at(-1) ?? "TB";
-	return `${size.toFixed(2)} ${finalUnit}`;
+	const finalUnit = BLOB_SIZE_UNITS[i];
+
+	// Round to 2 decimals and omit trailing zeros for whole numbers.
+	const formattedSize = new Intl.NumberFormat("en-US", {
+		maximumFractionDigits: 2,
+	}).format(sizeInUnits);
+	return `${formattedSize} ${finalUnit}`;
 }
 
 type FileNameInfo = Readonly<{


### PR DESCRIPTION
Previously, the workspace "Download logs" dialog formatted the original byte
count with the promoted unit, so sizes above 1 KiB could be shown incorrectly,
for example `4472 KB` instead of `4.37 KB`. Exact 1024-byte files also stayed
in bytes.

Update `humanBlobSize` to format the scaled value correctly, promote `1024 B`
to `1 KB`, and omit trailing `.00` for whole numbers. Export the helper and add
a focused regression test covering bytes, the KiB boundary, fractional KiB, and
MiB cases.

<table>
  <tr>
    <td><strong>Before</strong></td>
    <td><strong>After</strong></td>
  </tr>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/b5d2af8e-85a6-46b9-896a-c359ed09371f" width="250" alt="Before" />
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/4a556985-37f6-4a16-969e-c60baf85c143" width="250" alt="After" />
    </td>
  </tr>
</table>