### PR TITLE
fix(site): deduplicate expired-attachment probes for repeated file IDs

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
@@ -26,7 +26,7 @@ import {
 	formatTextAttachmentPreview,
 } from "../../utils/fetchTextAttachment";
 import { ImageThumbnail } from "../AgentChatInput";
-import { useExpiredFileIds } from "./ExpiredFileIdsContext";
+import { useFileProbes } from "./FileProbeContext";
 import type { RenderBlock } from "./types";
 
 export type PreviewTextAttachment = {
@@ -290,7 +290,7 @@ const RemoteTextAttachmentButton: FC<{
 	onPreview,
 	showStatus = false,
 }) => {
-	const { hasExpired, markExpired } = useExpiredFileIds();
+	const { hasExpired, markExpired } = useFileProbes();
 	const isKnownExpired = hasExpired(fileId);
 	const [content, setContent] = useState<string | null>(null);
 	const [isLoading, setIsLoading] = useState(false);
@@ -411,8 +411,15 @@ const RemoteImageBlock: FC<{
 	displayName: string;
 	onImageClick?: (src: string) => void;
 }> = ({ fileId, href, displayName, onImageClick }) => {
-	const { hasExpired, markExpired, isPending, markPending, clearPending } =
-		useExpiredFileIds();
+	const {
+		hasExpired,
+		markExpired,
+		isPending,
+		markPending,
+		clearPending,
+		getProbeResult,
+		setProbeResult,
+	} = useFileProbes();
 	const isKnownExpired = fileId !== undefined && hasExpired(fileId);
 	const [failureState, setFailureState] = useState<AttachmentFailureState>(
 		() => (isKnownExpired ? { kind: "expired" } : { kind: "idle" }),
@@ -427,10 +434,12 @@ const RemoteImageBlock: FC<{
 			/>
 		);
 	}
-	if (failureState.kind !== "idle") {
+	const sharedResult = fileId ? getProbeResult(fileId) : undefined;
+	const effectiveFailure = sharedResult ?? failureState;
+	if (effectiveFailure.kind !== "idle") {
 		return (
 			<AttachmentFallbackTile
-				state={failureState}
+				state={effectiveFailure}
 				labels={imageAttachmentFailureLabels}
 			/>
 		);
@@ -462,9 +471,7 @@ const RemoteImageBlock: FC<{
 						setFailureState({ kind: "expired" });
 						return;
 					}
-					// Another block already started a probe for this file.
-					// Fall back to the generic failure tile; markExpired will
-					// propagate via context if the probe resolves as expired.
+					// Dedup: skip probe, context will propagate the result.
 					if (isPending(fileId)) {
 						setFailureState({ kind: "failed" });
 						return;
@@ -481,23 +488,26 @@ const RemoteImageBlock: FC<{
 					void probeAttachmentFailure(href, controller.signal)
 						.then((reason) => {
 							clearPending(fileId);
-							if (!probeRequest.clear(controller)) {
-								return;
-							}
+							// Context writes stay above the clear() guard so
+							// siblings get the result even if this block unmounted.
 							if (reason.kind === "expired") {
 								markExpired(fileId);
 							}
-							setFailureState(reason);
+							setProbeResult(fileId, reason);
+							if (probeRequest.clear(controller)) {
+								setFailureState(reason);
+							}
 						})
 						.catch((error) => {
 							clearPending(fileId);
-							if (!probeRequest.clear(controller)) {
-								return;
-							}
 							if (isAbortError(error)) {
 								return;
 							}
-							setFailureState(attachmentFailureFromError(error));
+							const failure = attachmentFailureFromError(error);
+							setProbeResult(fileId, failure);
+							if (probeRequest.clear(controller)) {
+								setFailureState(failure);
+							}
 						});
 				}}
 			/>

--- a/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
@@ -411,7 +411,8 @@ const RemoteImageBlock: FC<{
 	displayName: string;
 	onImageClick?: (src: string) => void;
 }> = ({ fileId, href, displayName, onImageClick }) => {
-	const { hasExpired, markExpired } = useExpiredFileIds();
+	const { hasExpired, markExpired, isPending, markPending, clearPending } =
+		useExpiredFileIds();
 	const isKnownExpired = fileId !== undefined && hasExpired(fileId);
 	const [failureState, setFailureState] = useState<AttachmentFailureState>(
 		() => (isKnownExpired ? { kind: "expired" } : { kind: "idle" }),
@@ -461,7 +462,15 @@ const RemoteImageBlock: FC<{
 						setFailureState({ kind: "expired" });
 						return;
 					}
+					// Another block already started a probe for this file.
+					// Fall back to the generic failure tile; markExpired will
+					// propagate via context if the probe resolves as expired.
+					if (isPending(fileId)) {
+						setFailureState({ kind: "failed" });
+						return;
+					}
 
+					markPending(fileId);
 					const controller = probeRequest.start();
 					// Optimistically swap to the generic failure tile. The
 					// probe will either upgrade it to "expired" or fill in
@@ -471,6 +480,7 @@ const RemoteImageBlock: FC<{
 
 					void probeAttachmentFailure(href, controller.signal)
 						.then((reason) => {
+							clearPending(fileId);
 							if (!probeRequest.clear(controller)) {
 								return;
 							}
@@ -480,6 +490,7 @@ const RemoteImageBlock: FC<{
 							setFailureState(reason);
 						})
 						.catch((error) => {
+							clearPending(fileId);
 							if (!probeRequest.clear(controller)) {
 								return;
 							}

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -474,6 +474,17 @@ export const UserMessageWithRepeatedFailedImage: Story = {
 		expect(
 			canvas.queryByRole("button", { name: "View Attached image" }),
 		).not.toBeInTheDocument();
+
+		const tiles = await waitFor(() => {
+			const t = canvas.getAllByRole("img", { name: "Image failed to load" });
+			for (const tile of t) {
+				expect(tile).toHaveAttribute("data-state");
+			}
+			return t;
+		});
+		for (const tile of tiles) {
+			await hoverAndExpectTooltip(tile, FAILED_ATTACHMENT_API_MESSAGE);
+		}
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -432,12 +432,45 @@ export const UserMessageWithRepeatedExpiredImage: Story = {
 		const images = canvas.getAllByRole("img", { name: "Attached image" });
 		expect(images).toHaveLength(2);
 		fireEvent.error(images[0]);
+		fireEvent.error(images[1]);
 		await waitFor(() =>
 			expect(
 				canvas.getAllByRole("img", { name: "Image expired" }),
 			).toHaveLength(2),
 		);
 		expect(getAttachmentFetchCount("storybook-expired-image")).toBe(1);
+		expect(
+			canvas.queryByRole("button", { name: "View Attached image" }),
+		).not.toBeInTheDocument();
+	},
+};
+
+/** Duplicate file IDs with a non-expired probe reuse the first result. */
+export const UserMessageWithRepeatedFailedImage: Story = {
+	args: buildStoryArgs(
+		buildUserMessage({
+			id: 1,
+			text: "First reference to the failed upload",
+			files: [buildImageAttachmentPart("storybook-failed-image")],
+		}),
+		buildUserMessage({
+			id: 2,
+			text: "Second reference to the same failed upload",
+			files: [buildImageAttachmentPart("storybook-failed-image")],
+		}),
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const images = canvas.getAllByRole("img", { name: "Attached image" });
+		expect(images).toHaveLength(2);
+		fireEvent.error(images[0]);
+		fireEvent.error(images[1]);
+		await waitFor(() =>
+			expect(
+				canvas.getAllByRole("img", { name: "Image failed to load" }),
+			).toHaveLength(2),
+		);
+		expect(getAttachmentFetchCount("storybook-failed-image")).toBe(1);
 		expect(
 			canvas.queryByRole("button", { name: "View Attached image" }),
 		).not.toBeInTheDocument();

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -44,7 +44,7 @@ import {
 	AttachmentBlock,
 	type PreviewTextAttachment,
 } from "./AttachmentBlocks";
-import { ExpiredFileIdsProvider } from "./ExpiredFileIdsContext";
+import { FileProbeProvider } from "./FileProbeContext";
 import { deriveMessageDisplayState } from "./messageHelpers";
 import { getEditableUserMessagePayload } from "./messageParsing";
 import { useSmoothStreamingText } from "./SmoothText";
@@ -1045,7 +1045,7 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 				: undefined;
 
 		return (
-			<ExpiredFileIdsProvider>
+			<FileProbeProvider>
 				<div
 					data-testid="conversation-timeline"
 					className="flex flex-col gap-2"
@@ -1093,7 +1093,7 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 						);
 					})}
 				</div>
-			</ExpiredFileIdsProvider>
+			</FileProbeProvider>
 		);
 	},
 );

--- a/site/src/pages/AgentsPage/components/ChatConversation/ExpiredFileIdsContext.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ExpiredFileIdsContext.tsx
@@ -3,23 +3,37 @@ import {
 	type FC,
 	type PropsWithChildren,
 	useContext,
+	useRef,
 	useState,
 } from "react";
 
 type ExpiredFileIdsContextValue = {
 	hasExpired: (fileId: string) => boolean;
 	markExpired: (fileId: string) => void;
+	// isPending and markPending track in-flight probes so that when the same
+	// file ID appears in multiple blocks, only the first onError handler starts
+	// a network probe. The others fall through to the optimistic "failed" tile
+	// and will be upgraded to "expired" if markExpired is later called.
+	isPending: (fileId: string) => boolean;
+	markPending: (fileId: string) => void;
+	clearPending: (fileId: string) => void;
 };
 
 const ExpiredFileIdsContext = createContext<ExpiredFileIdsContextValue>({
 	hasExpired: () => false,
 	markExpired: () => {},
+	isPending: () => false,
+	markPending: () => {},
+	clearPending: () => {},
 });
 
 export const ExpiredFileIdsProvider: FC<PropsWithChildren> = ({ children }) => {
 	const [expiredFileIds, setExpiredFileIds] = useState<Set<string>>(
 		() => new Set(),
 	);
+	// Use a ref so pending-state changes don't trigger re-renders; we only
+	// need re-renders when expiredFileIds changes.
+	const pendingProbeFileIds = useRef<Set<string>>(new Set());
 
 	return (
 		<ExpiredFileIdsContext.Provider
@@ -34,6 +48,13 @@ export const ExpiredFileIdsProvider: FC<PropsWithChildren> = ({ children }) => {
 						next.add(fileId);
 						return next;
 					});
+				},
+				isPending: (fileId) => pendingProbeFileIds.current.has(fileId),
+				markPending: (fileId) => {
+					pendingProbeFileIds.current.add(fileId);
+				},
+				clearPending: (fileId) => {
+					pendingProbeFileIds.current.delete(fileId);
 				},
 			}}
 		>

--- a/site/src/pages/AgentsPage/components/ChatConversation/FileProbeContext.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/FileProbeContext.tsx
@@ -6,37 +6,41 @@ import {
 	useRef,
 	useState,
 } from "react";
+import type { AttachmentFailure } from "../../utils/chatAttachments";
 
-type ExpiredFileIdsContextValue = {
+type FileProbeContextValue = {
 	hasExpired: (fileId: string) => boolean;
 	markExpired: (fileId: string) => void;
-	// isPending and markPending track in-flight probes so that when the same
-	// file ID appears in multiple blocks, only the first onError handler starts
-	// a network probe. The others fall through to the optimistic "failed" tile
-	// and will be upgraded to "expired" if markExpired is later called.
 	isPending: (fileId: string) => boolean;
 	markPending: (fileId: string) => void;
 	clearPending: (fileId: string) => void;
+	getProbeResult: (fileId: string) => AttachmentFailure | undefined;
+	setProbeResult: (fileId: string, result: AttachmentFailure) => void;
 };
 
-const ExpiredFileIdsContext = createContext<ExpiredFileIdsContextValue>({
+const FileProbeContext = createContext<FileProbeContextValue>({
 	hasExpired: () => false,
 	markExpired: () => {},
 	isPending: () => false,
 	markPending: () => {},
 	clearPending: () => {},
+	getProbeResult: () => undefined,
+	setProbeResult: () => {},
 });
 
-export const ExpiredFileIdsProvider: FC<PropsWithChildren> = ({ children }) => {
+export const FileProbeProvider: FC<PropsWithChildren> = ({ children }) => {
 	const [expiredFileIds, setExpiredFileIds] = useState<Set<string>>(
 		() => new Set(),
 	);
-	// Use a ref so pending-state changes don't trigger re-renders; we only
-	// need re-renders when expiredFileIds changes.
+	// Ref, not state: must be readable synchronously by the second
+	// onError handler before React re-renders.
 	const pendingProbeFileIds = useRef<Set<string>>(new Set());
+	const [probeResults, setProbeResults] = useState<
+		Map<string, AttachmentFailure>
+	>(() => new Map());
 
 	return (
-		<ExpiredFileIdsContext.Provider
+		<FileProbeContext.Provider
 			value={{
 				hasExpired: (fileId) => expiredFileIds.has(fileId),
 				markExpired: (fileId) => {
@@ -56,11 +60,19 @@ export const ExpiredFileIdsProvider: FC<PropsWithChildren> = ({ children }) => {
 				clearPending: (fileId) => {
 					pendingProbeFileIds.current.delete(fileId);
 				},
+				getProbeResult: (fileId) => probeResults.get(fileId),
+				setProbeResult: (fileId, result) => {
+					setProbeResults((prev) => {
+						const next = new Map(prev);
+						next.set(fileId, result);
+						return next;
+					});
+				},
 			}}
 		>
 			{children}
-		</ExpiredFileIdsContext.Provider>
+		</FileProbeContext.Provider>
 	);
 };
 
-export const useExpiredFileIds = () => useContext(ExpiredFileIdsContext);
+export const useFileProbes = () => useContext(FileProbeContext);


### PR DESCRIPTION
## Problem

The `UserMessageWithRepeatedExpiredImage` storybook test
(introduced in 353e5226) asserts that when two `RemoteImageBlock`
components reference the same expired file ID, only one `fetch`
probe fires. On `main` the assertion `toBe(1)` gets `2`.

### Root cause

Both `RemoteImageBlock` instances render `<img>` elements with a
broken URL. Chromium fires native `error` events on both before
the first probe's async `fetch` resolves and calls `markExpired`.
Each handler independently checks `hasExpired(fileId)`, sees
`false`, and starts its own probe.

### Fix

`ExpiredFileIdsContext` now tracks in-flight probes via a
`useRef<Set<string>>` (`isPending`/`markPending`/`clearPending`).
Before starting a probe, `RemoteImageBlock.onError` checks
`isPending(fileId)`. If true, it skips the probe and falls through
to the generic failure tile.

Resolved probe outcomes are stored in context state (`probeResults`
map) so all duplicate blocks for the same file ID re-render and
pick up the full result, including API error detail for tooltips.
This covers both expired (via `markExpired`) and non-expired
failures (via `setProbeResult`).

Pending entries are cleared when the probe settles (both `.then`
and `.catch`) so transient failures do not permanently block
re-probes for the same file ID.

A ref is used for pending tracking (not state) because the set
must be readable synchronously by the second handler before any
re-render, and pending transitions do not need to trigger
re-renders themselves.

> 🤖 Generated with [Coder Agents](https://coder.com/agents)
