### PR TITLE
fix(site): close terminal window on command confirmation cancel

### DIFF
--- a/site/src/pages/TerminalPage/TerminalPage.test.tsx
+++ b/site/src/pages/TerminalPage/TerminalPage.test.tsx
@@ -238,17 +238,15 @@ describe("TerminalPage", () => {
 		expect(resizeReq.width).toBeGreaterThan(0);
 	});
 
-	it("removes command param on cancel", async () => {
-		createWorkspaceTerminalWebSocket();
+	it("closes window on cancel", async () => {
+		const closeSpy = vi.spyOn(window, "close").mockImplementation(() => {});
 		renderTerminalRaw(
 			`/${MockUserOwner.username}/${MockWorkspace.name}/terminal?command=echo+hello`,
 		);
 		await userEvent.click(
 			await screen.findByRole("button", { name: "Cancel" }),
 		);
-		await waitFor(() =>
-			expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
-		);
+		expect(closeSpy).toHaveBeenCalled();
 	});
 
 	it("skips confirmation dialog for trusted app commands", async () => {

--- a/site/src/pages/TerminalPage/TerminalPage.tsx
+++ b/site/src/pages/TerminalPage/TerminalPage.tsx
@@ -213,8 +213,7 @@ const TerminalPage: FC = () => {
 						setCommandConfirmed(true);
 					}}
 					onDeny={() => {
-						searchParams.delete("command");
-						navigate({ search: searchParams.toString() }, { replace: true });
+						window.close();
 					}}
 				/>
 			)}


### PR DESCRIPTION
Follow-up to #24650.

Canceling the terminal command confirmation dialog now calls
`window.close()` instead of stripping the `?command=` query parameter
and opening a plain terminal. The terminal always opens in a new tab,
so closing it is the expected UX when the user declines.

> 🤖 Generated by Coder Agents