### PR TITLE
docs: document terminal command confirmation dialog

### DIFF
--- a/docs/user-guides/workspace-access/web-terminal.md
+++ b/docs/user-guides/workspace-access/web-terminal.md
@@ -159,7 +159,15 @@ You can open a terminal with a specific command by adding a query parameter:
 https://coder.example.com/@user/workspace/terminal?command=htop
 ```
 
-This will execute `htop` immediately when the terminal opens.
+When a `?command=` parameter is present, a confirmation dialog is shown before
+the command executes. The user must click **Run command** to proceed or
+**Cancel** to close the terminal window. This prevents external links from
+silently executing arbitrary commands in a workspace.
+
+Template-configured apps that use the `command` attribute in
+[`coder_app`](https://registry.terraform.io/providers/coder/coder/latest/docs/resources/app)
+are trusted and bypass the confirmation dialog. These apps use the `?app=`
+parameter internally, which resolves the command from the agent's app list.
 
 ### Container Selection
 


### PR DESCRIPTION
Documents the breaking change from #24650 and #24765 in the
[Custom Commands](https://coder.com/docs/user-guides/workspace-access/web-terminal#custom-commands) section.

- `?command=` URLs now show a confirmation dialog before executing.
- Template-configured `coder_app` commands bypass the dialog via `?app=`.

> 🤖 Generated by Coder Agents