### PR TITLE
feat: refresh dynamic parameters on secret changes

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -16172,7 +16172,7 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "id": {
-                    "description": "ID identifies the request. The response contains the same\nID so that the client can match it to the request.",
+                    "description": "ID identifies the request for response ordering. Websocket response\nIDs are monotonically increasing and may exceed the request ID when\nserver-side events trigger additional renders.",
                     "type": "integer"
                 },
                 "inputs": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -14636,7 +14636,7 @@
 			"type": "object",
 			"properties": {
 				"id": {
-					"description": "ID identifies the request. The response contains the same\nID so that the client can match it to the request.",
+					"description": "ID identifies the request for response ordering. Websocket response\nIDs are monotonically increasing and may exceed the request ID when\nserver-side events trigger additional renders.",
 					"type": "integer"
 				},
 				"inputs": {

--- a/coderd/parameters.go
+++ b/coderd/parameters.go
@@ -122,16 +122,7 @@ func (*API) handleParameterEvaluate(rw http.ResponseWriter, r *http.Request, ini
 	ctx := r.Context()
 
 	// Send an initial form state, computed without any user input.
-	result, diagnostics := render.Render(ctx, initial.OwnerID, initial.Inputs, dynamicparameters.IncludeSecretRequirements())
-	response := codersdk.DynamicParametersResponse{
-		ID:          0,
-		Diagnostics: db2sdk.HCLDiagnostics(diagnostics),
-	}
-	if result.Output != nil {
-		response.Parameters = slice.List(result.Output.Parameters, db2sdk.PreviewParameter)
-	}
-	response.SecretRequirements = result.SecretRequirements
-
+	response := renderDynamicParametersResponse(ctx, render, 0, initial.OwnerID, initial.Inputs)
 	httpapi.Write(ctx, rw, http.StatusOK, response)
 }
 
@@ -156,75 +147,21 @@ func (api *API) handleParameterWebsocket(rw http.ResponseWriter, r *http.Request
 		api.Logger,
 	)
 
-	sendRender := func(id int, ownerID uuid.UUID, inputs map[string]string) bool {
-		result, diagnostics := render.Render(ctx, ownerID, inputs, dynamicparameters.IncludeSecretRequirements())
-		response := codersdk.DynamicParametersResponse{
-			ID:          id,
-			Diagnostics: db2sdk.HCLDiagnostics(diagnostics),
-		}
-		if result.Output != nil {
-			response.Parameters = slice.List(result.Output.Parameters, db2sdk.PreviewParameter)
-		}
-		response.SecretRequirements = result.SecretRequirements
-		if err := stream.Send(response); err != nil {
-			stream.Drop()
-			return false
-		}
-		return true
-	}
-
 	secretEvents := make(chan struct{}, 1)
-	var (
-		cancelSecretEvents func()
-		subscribedOwnerID  uuid.UUID
-	)
-	subscribeSecretEvents := func(ownerID uuid.UUID) {
-		if ownerID == subscribedOwnerID {
-			return
-		}
-		if cancelSecretEvents != nil {
-			cancelSecretEvents()
-			cancelSecretEvents = nil
-			// A canceled callback may have already queued one event.
-			select {
-			case <-secretEvents:
-			default:
-			}
-		}
-		// Websocket authorization uses the actor snapshot from connection
-		// creation, matching the rest of the websocket handlers.
-		if !api.canSubscribeUserSecretEvents(ctx, ownerID) {
-			subscribedOwnerID = ownerID
-			return
-		}
-		subscribedOwnerID = ownerID
-		cancel, err := api.Pubsub.Subscribe(usersecretspubsub.Channel(ownerID), func(context.Context, []byte) {
-			select {
-			case secretEvents <- struct{}{}:
-			default:
-			}
-		})
-		if err != nil {
-			// Leave the owner unset so transient pubsub failures can be
-			// retried on the next update for this owner.
-			subscribedOwnerID = uuid.Nil
-			api.Logger.Warn(ctx, "failed to subscribe to user secret events",
-				slog.F("user_id", ownerID),
-				slog.Error(err),
-			)
-			return
-		}
-		cancelSecretEvents = cancel
+	secretSubscriber := &parameterSecretEventSubscriber{
+		api:    api,
+		events: secretEvents,
 	}
-	subscribeSecretEvents(initial.OwnerID)
-	defer func() {
-		if cancelSecretEvents != nil {
-			cancelSecretEvents()
-		}
-	}()
+	secretSubscriber.EnsureOwner(ctx, initial.OwnerID)
+	defer secretSubscriber.Close()
+
+	sender := dynamicParametersResponseSender{
+		stream: stream,
+		render: render,
+	}
 
 	// Send an initial form state, computed without any user input.
-	if !sendRender(-1, initial.OwnerID, initial.Inputs) {
+	if !sender.Send(ctx, -1, initial.OwnerID, initial.Inputs) {
 		return
 	}
 
@@ -241,7 +178,7 @@ func (api *API) handleParameterWebsocket(rw http.ResponseWriter, r *http.Request
 			return
 		case <-secretEvents:
 			lastResponseID = nextDynamicParametersResponseID(lastResponseID, lastResponseID+1)
-			if !sendRender(lastResponseID, ownerID, inputs) {
+			if !sender.Send(ctx, lastResponseID, ownerID, inputs) {
 				return
 			}
 		case update, ok := <-updates:
@@ -258,13 +195,107 @@ func (api *API) handleParameterWebsocket(rw http.ResponseWriter, r *http.Request
 
 			ownerID = update.OwnerID
 			inputs = update.Inputs
-			subscribeSecretEvents(ownerID)
+			secretSubscriber.EnsureOwner(ctx, ownerID)
 			responseID := nextDynamicParametersResponseID(lastResponseID, update.ID)
 			lastResponseID = responseID
-			if !sendRender(responseID, ownerID, inputs) {
+			if !sender.Send(ctx, responseID, ownerID, inputs) {
 				return
 			}
 		}
+	}
+}
+
+func renderDynamicParametersResponse(
+	ctx context.Context,
+	render dynamicparameters.Renderer,
+	id int,
+	ownerID uuid.UUID,
+	inputs map[string]string,
+) codersdk.DynamicParametersResponse {
+	result, diagnostics := render.Render(ctx, ownerID, inputs, dynamicparameters.IncludeSecretRequirements())
+	response := codersdk.DynamicParametersResponse{
+		ID:          id,
+		Diagnostics: db2sdk.HCLDiagnostics(diagnostics),
+	}
+	if result.Output != nil {
+		response.Parameters = slice.List(result.Output.Parameters, db2sdk.PreviewParameter)
+	}
+	response.SecretRequirements = result.SecretRequirements
+	return response
+}
+
+type dynamicParametersResponseSender struct {
+	stream *wsjson.Stream[codersdk.DynamicParametersRequest, codersdk.DynamicParametersResponse]
+	render dynamicparameters.Renderer
+}
+
+func (s dynamicParametersResponseSender) Send(
+	ctx context.Context,
+	id int,
+	ownerID uuid.UUID,
+	inputs map[string]string,
+) bool {
+	response := renderDynamicParametersResponse(ctx, s.render, id, ownerID, inputs)
+	if err := s.stream.Send(response); err != nil {
+		s.stream.Drop()
+		return false
+	}
+	return true
+}
+
+type parameterSecretEventSubscriber struct {
+	api    *API
+	events chan struct{}
+
+	cancel  func()
+	ownerID uuid.UUID
+}
+
+func (s *parameterSecretEventSubscriber) EnsureOwner(ctx context.Context, ownerID uuid.UUID) {
+	if ownerID == s.ownerID {
+		return
+	}
+	if s.cancel != nil {
+		s.Close()
+		// A canceled callback may have already queued one event.
+		select {
+		case <-s.events:
+		default:
+		}
+	}
+	// Websocket authorization uses the actor snapshot from connection
+	// creation, matching the rest of the websocket handlers.
+	if !s.api.canSubscribeUserSecretEvents(ctx, ownerID) {
+		s.ownerID = ownerID
+		return
+	}
+	s.ownerID = ownerID
+	cancel, err := s.api.Pubsub.Subscribe(usersecretspubsub.Channel(ownerID), s.notify)
+	if err != nil {
+		// Leave the owner unset so transient pubsub failures can be
+		// retried on the next update for this owner.
+		s.ownerID = uuid.Nil
+		s.api.Logger.Warn(ctx, "failed to subscribe to user secret events",
+			slog.F("user_id", ownerID),
+			slog.Error(err),
+		)
+		return
+	}
+	s.cancel = cancel
+}
+
+func (s *parameterSecretEventSubscriber) Close() {
+	if s.cancel == nil {
+		return
+	}
+	s.cancel()
+	s.cancel = nil
+}
+
+func (s *parameterSecretEventSubscriber) notify(context.Context, []byte) {
+	select {
+	case s.events <- struct{}{}:
+	default:
 	}
 }
 

--- a/coderd/parameters.go
+++ b/coderd/parameters.go
@@ -8,10 +8,15 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/xerrors"
 
+	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/coderd/database/db2sdk"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/dynamicparameters"
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/httpmw"
+	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
+	"github.com/coder/coder/v2/coderd/usersecretspubsub"
 	"github.com/coder/coder/v2/coderd/util/slice"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/wsjson"
@@ -151,31 +156,94 @@ func (api *API) handleParameterWebsocket(rw http.ResponseWriter, r *http.Request
 		api.Logger,
 	)
 
+	sendRender := func(id int, ownerID uuid.UUID, inputs map[string]string) bool {
+		result, diagnostics := render.Render(ctx, ownerID, inputs, dynamicparameters.IncludeSecretRequirements())
+		response := codersdk.DynamicParametersResponse{
+			ID:          id,
+			Diagnostics: db2sdk.HCLDiagnostics(diagnostics),
+		}
+		if result.Output != nil {
+			response.Parameters = slice.List(result.Output.Parameters, db2sdk.PreviewParameter)
+		}
+		response.SecretRequirements = result.SecretRequirements
+		if err := stream.Send(response); err != nil {
+			stream.Drop()
+			return false
+		}
+		return true
+	}
+
+	secretEvents := make(chan struct{}, 1)
+	var (
+		cancelSecretEvents func()
+		subscribedOwnerID  uuid.UUID
+	)
+	subscribeSecretEvents := func(ownerID uuid.UUID) {
+		if ownerID == subscribedOwnerID {
+			return
+		}
+		if cancelSecretEvents != nil {
+			cancelSecretEvents()
+			cancelSecretEvents = nil
+			// A canceled callback may have already queued one event.
+			select {
+			case <-secretEvents:
+			default:
+			}
+		}
+		// Websocket authorization uses the actor snapshot from connection
+		// creation, matching the rest of the websocket handlers.
+		if !api.canSubscribeUserSecretEvents(ctx, ownerID) {
+			subscribedOwnerID = ownerID
+			return
+		}
+		subscribedOwnerID = ownerID
+		cancel, err := api.Pubsub.Subscribe(usersecretspubsub.Channel(ownerID), func(context.Context, []byte) {
+			select {
+			case secretEvents <- struct{}{}:
+			default:
+			}
+		})
+		if err != nil {
+			// Leave the owner unset so transient pubsub failures can be
+			// retried on the next update for this owner.
+			subscribedOwnerID = uuid.Nil
+			api.Logger.Warn(ctx, "failed to subscribe to user secret events",
+				slog.F("user_id", ownerID),
+				slog.Error(err),
+			)
+			return
+		}
+		cancelSecretEvents = cancel
+	}
+	subscribeSecretEvents(initial.OwnerID)
+	defer func() {
+		if cancelSecretEvents != nil {
+			cancelSecretEvents()
+		}
+	}()
+
 	// Send an initial form state, computed without any user input.
-	result, diagnostics := render.Render(ctx, initial.OwnerID, initial.Inputs, dynamicparameters.IncludeSecretRequirements())
-	response := codersdk.DynamicParametersResponse{
-		ID:          -1, // Always start with -1.
-		Diagnostics: db2sdk.HCLDiagnostics(diagnostics),
-	}
-	if result.Output != nil {
-		response.Parameters = slice.List(result.Output.Parameters, db2sdk.PreviewParameter)
-	}
-	response.SecretRequirements = result.SecretRequirements
-	err = stream.Send(response)
-	if err != nil {
-		stream.Drop()
+	if !sendRender(-1, initial.OwnerID, initial.Inputs) {
 		return
 	}
 
-	// As the user types into the form, reprocess the state using their input,
-	// and respond with updates.
+	// As the user types into the form or updates secrets in another client,
+	// reprocess the state using their input and respond with updates.
 	updates := stream.Chan()
 	ownerID := initial.OwnerID
+	inputs := initial.Inputs
+	lastResponseID := -1
 	for {
 		select {
 		case <-ctx.Done():
 			stream.Close(websocket.StatusGoingAway)
 			return
+		case <-secretEvents:
+			lastResponseID = nextDynamicParametersResponseID(lastResponseID, lastResponseID+1)
+			if !sendRender(lastResponseID, ownerID, inputs) {
+				return
+			}
 		case update, ok := <-updates:
 			if !ok {
 				// The connection has been closed, so there is no one to write to
@@ -189,21 +257,34 @@ func (api *API) handleParameterWebsocket(rw http.ResponseWriter, r *http.Request
 			}
 
 			ownerID = update.OwnerID
-
-			result, diagnostics := render.Render(ctx, update.OwnerID, update.Inputs, dynamicparameters.IncludeSecretRequirements())
-			response := codersdk.DynamicParametersResponse{
-				ID:          update.ID,
-				Diagnostics: db2sdk.HCLDiagnostics(diagnostics),
-			}
-			if result.Output != nil {
-				response.Parameters = slice.List(result.Output.Parameters, db2sdk.PreviewParameter)
-			}
-			response.SecretRequirements = result.SecretRequirements
-			err = stream.Send(response)
-			if err != nil {
-				stream.Drop()
+			inputs = update.Inputs
+			subscribeSecretEvents(ownerID)
+			responseID := nextDynamicParametersResponseID(lastResponseID, update.ID)
+			lastResponseID = responseID
+			if !sendRender(responseID, ownerID, inputs) {
 				return
 			}
 		}
 	}
+}
+
+func nextDynamicParametersResponseID(lastResponseID int, requestID int) int {
+	if requestID <= lastResponseID {
+		return lastResponseID + 1
+	}
+	return requestID
+}
+
+func (api *API) canSubscribeUserSecretEvents(ctx context.Context, ownerID uuid.UUID) bool {
+	roles, ok := dbauthz.ActorFromContext(ctx)
+	if !ok {
+		api.Logger.Error(ctx, "no authorization actor for user secret event subscription")
+		return false
+	}
+	return api.HTTPAuth.Authorizer.Authorize(
+		ctx,
+		roles,
+		policy.ActionRead,
+		rbac.ResourceUserSecret.WithOwner(ownerID.String()),
+	) == nil
 }

--- a/coderd/parameters.go
+++ b/coderd/parameters.go
@@ -23,6 +23,8 @@ import (
 	"github.com/coder/websocket"
 )
 
+const initialDynamicParametersResponseID = -1
+
 // @Summary Evaluate dynamic parameters for template version
 // @ID evaluate-dynamic-parameters-for-template-version
 // @Security CoderSessionToken
@@ -68,7 +70,7 @@ func (api *API) templateVersionDynamicParametersWebsocket(rw http.ResponseWriter
 	}
 
 	api.templateVersionDynamicParameters(true, codersdk.DynamicParametersRequest{
-		ID:      -1,
+		ID:      initialDynamicParametersResponseID,
 		Inputs:  map[string]string{},
 		OwnerID: userID,
 	})(rw, r)
@@ -147,12 +149,12 @@ func (api *API) handleParameterWebsocket(rw http.ResponseWriter, r *http.Request
 		api.Logger,
 	)
 
-	secretEvents := make(chan struct{}, 1)
+	secretEvents := make(chan uuid.UUID, 1)
 	secretSubscriber := &parameterSecretEventSubscriber{
 		api:    api,
 		events: secretEvents,
 	}
-	secretSubscriber.EnsureOwner(ctx, initial.OwnerID)
+	secretSubscriber.UpdateOwnerSubscription(ctx, initial.OwnerID)
 	defer secretSubscriber.Close()
 
 	sender := dynamicParametersResponseSender{
@@ -161,7 +163,7 @@ func (api *API) handleParameterWebsocket(rw http.ResponseWriter, r *http.Request
 	}
 
 	// Send an initial form state, computed without any user input.
-	if !sender.Send(ctx, -1, initial.OwnerID, initial.Inputs) {
+	if !sender.Send(ctx, initialDynamicParametersResponseID, initial.OwnerID, initial.Inputs) {
 		return
 	}
 
@@ -170,13 +172,16 @@ func (api *API) handleParameterWebsocket(rw http.ResponseWriter, r *http.Request
 	updates := stream.Chan()
 	ownerID := initial.OwnerID
 	inputs := initial.Inputs
-	lastResponseID := -1
+	lastResponseID := initialDynamicParametersResponseID
 	for {
 		select {
 		case <-ctx.Done():
 			stream.Close(websocket.StatusGoingAway)
 			return
-		case <-secretEvents:
+		case eventOwnerID := <-secretEvents:
+			if eventOwnerID != ownerID {
+				continue
+			}
 			lastResponseID = nextDynamicParametersResponseID(lastResponseID, lastResponseID+1)
 			if !sender.Send(ctx, lastResponseID, ownerID, inputs) {
 				return
@@ -195,7 +200,7 @@ func (api *API) handleParameterWebsocket(rw http.ResponseWriter, r *http.Request
 
 			ownerID = update.OwnerID
 			inputs = update.Inputs
-			secretSubscriber.EnsureOwner(ctx, ownerID)
+			secretSubscriber.UpdateOwnerSubscription(ctx, ownerID)
 			responseID := nextDynamicParametersResponseID(lastResponseID, update.ID)
 			lastResponseID = responseID
 			if !sender.Send(ctx, responseID, ownerID, inputs) {
@@ -245,23 +250,22 @@ func (s dynamicParametersResponseSender) Send(
 
 type parameterSecretEventSubscriber struct {
 	api    *API
-	events chan struct{}
+	events chan uuid.UUID
 
 	cancel  func()
 	ownerID uuid.UUID
 }
 
-func (s *parameterSecretEventSubscriber) EnsureOwner(ctx context.Context, ownerID uuid.UUID) {
+// UpdateOwnerSubscription switches the pubsub subscription to the owner's
+// user secret channel. Dynamic parameters can render for a workspace owner
+// other than the connected user, so owner changes must update the channel
+// that drives secret requirement refreshes.
+func (s *parameterSecretEventSubscriber) UpdateOwnerSubscription(ctx context.Context, ownerID uuid.UUID) {
 	if ownerID == s.ownerID {
 		return
 	}
 	if s.cancel != nil {
 		s.Close()
-		// A canceled callback may have already queued one event.
-		select {
-		case <-s.events:
-		default:
-		}
 	}
 	// Websocket authorization uses the actor snapshot from connection
 	// creation, matching the rest of the websocket handlers.
@@ -270,7 +274,10 @@ func (s *parameterSecretEventSubscriber) EnsureOwner(ctx context.Context, ownerI
 		return
 	}
 	s.ownerID = ownerID
-	cancel, err := s.api.Pubsub.Subscribe(usersecretspubsub.Channel(ownerID), s.notify)
+	subscribedOwnerID := ownerID
+	cancel, err := s.api.Pubsub.Subscribe(usersecretspubsub.Channel(ownerID), func(context.Context, []byte) {
+		s.notify(subscribedOwnerID)
+	})
 	if err != nil {
 		// Leave the owner unset so transient pubsub failures can be
 		// retried on the next update for this owner.
@@ -292,9 +299,9 @@ func (s *parameterSecretEventSubscriber) Close() {
 	s.cancel = nil
 }
 
-func (s *parameterSecretEventSubscriber) notify(context.Context, []byte) {
+func (s *parameterSecretEventSubscriber) notify(ownerID uuid.UUID) {
 	select {
-	case s.events <- struct{}{}:
+	case s.events <- ownerID:
 	default:
 	}
 }

--- a/coderd/parameters_internal_test.go
+++ b/coderd/parameters_internal_test.go
@@ -1,0 +1,148 @@
+package coderd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
+
+	"cdr.dev/slog/v3"
+	"cdr.dev/slog/v3/sloggers/slogtest"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
+	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/rbac/policy"
+	"github.com/coder/coder/v2/testutil"
+)
+
+func TestNextDynamicParametersResponseID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		lastResponseID int
+		requestID      int
+		want           int
+	}{
+		{
+			name:           "request ID advances response ID",
+			lastResponseID: 1,
+			requestID:      4,
+			want:           4,
+		},
+		{
+			name:           "request ID collision advances response ID",
+			lastResponseID: 4,
+			requestID:      4,
+			want:           5,
+		},
+		{
+			name:           "stale request ID advances response ID",
+			lastResponseID: 4,
+			requestID:      2,
+			want:           5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := nextDynamicParametersResponseID(tt.lastResponseID, tt.requestID)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCanSubscribeUserSecretEventsRequiresSecretRead(t *testing.T) {
+	t.Parallel()
+
+	ownerID := uuid.New()
+	actor := rbac.Subject{ID: uuid.NewString()}
+
+	t.Run("allowed", func(t *testing.T) {
+		t.Parallel()
+
+		auth := &recordingAuthorizer{}
+		api := &API{
+			Options: &Options{
+				Logger: testutil.Logger(t),
+			},
+			HTTPAuth: &HTTPAuthorizer{
+				Authorizer: auth,
+				Logger:     testutil.Logger(t),
+			},
+		}
+		ctx := dbauthz.As(t.Context(), actor) //nolint:gocritic // Testing authorization from the request context.
+
+		require.True(t, api.canSubscribeUserSecretEvents(ctx, ownerID))
+		require.Len(t, auth.calls, 1)
+		require.Equal(t, actor, auth.calls[0].Actor)
+		require.Equal(t, policy.ActionRead, auth.calls[0].Action)
+		require.Equal(t, rbac.ResourceUserSecret.Type, auth.calls[0].Object.Type)
+		require.Equal(t, ownerID.String(), auth.calls[0].Object.Owner)
+	})
+
+	t.Run("denied", func(t *testing.T) {
+		t.Parallel()
+
+		auth := &recordingAuthorizer{err: xerrors.New("denied")}
+		api := &API{
+			Options: &Options{
+				Logger: testutil.Logger(t),
+			},
+			HTTPAuth: &HTTPAuthorizer{
+				Authorizer: auth,
+				Logger:     testutil.Logger(t),
+			},
+		}
+		ctx := dbauthz.As(t.Context(), actor) //nolint:gocritic // Testing authorization from the request context.
+
+		require.False(t, api.canSubscribeUserSecretEvents(ctx, ownerID))
+		require.Len(t, auth.calls, 1)
+	})
+
+	t.Run("no actor", func(t *testing.T) {
+		t.Parallel()
+
+		auth := &recordingAuthorizer{}
+		logger := slogtest.Make(t, &slogtest.Options{
+			IgnoredErrorIs: []error{},
+			IgnoreErrorFn: func(entry slog.SinkEntry) bool {
+				return entry.Message == "no authorization actor for user secret event subscription"
+			},
+		})
+		api := &API{
+			Options: &Options{
+				Logger: logger,
+			},
+			HTTPAuth: &HTTPAuthorizer{
+				Authorizer: auth,
+				Logger:     logger,
+			},
+		}
+
+		require.False(t, api.canSubscribeUserSecretEvents(context.Background(), ownerID))
+		require.Empty(t, auth.calls)
+	})
+}
+
+type recordingAuthorizer struct {
+	err   error
+	calls []rbac.AuthCall
+}
+
+func (a *recordingAuthorizer) Authorize(_ context.Context, subject rbac.Subject, action policy.Action, object rbac.Object) error {
+	a.calls = append(a.calls, rbac.AuthCall{
+		Actor:  subject,
+		Action: action,
+		Object: object,
+	})
+	return a.err
+}
+
+func (*recordingAuthorizer) Prepare(context.Context, rbac.Subject, policy.Action, string) (rbac.PreparedAuthorized, error) {
+	//nolint:nilnil // Prepare is unused by these tests.
+	return nil, nil
+}

--- a/coderd/parameters_test.go
+++ b/coderd/parameters_test.go
@@ -414,6 +414,183 @@ func TestDynamicParametersWithTerraformValues(t *testing.T) {
 		}}, preview.SecretRequirements)
 	})
 
+	t.Run("SecretRequirementPushesOnSecretChange", func(t *testing.T) {
+		t.Parallel()
+
+		dynamicParametersTerraformSource, err := os.ReadFile("testdata/parameters/secret_required/main.tf")
+		require.NoError(t, err)
+
+		setup := setupDynamicParamsTest(t, setupDynamicParamsTestParams{
+			provisionerDaemonVersion: provProto.CurrentVersion.String(),
+			mainTF:                   dynamicParametersTerraformSource,
+		})
+
+		ctx := testutil.Context(t, testutil.WaitMedium)
+		previews := setup.stream.Chan()
+
+		preview := testutil.RequireReceive(ctx, t, previews)
+		require.Equal(t, -1, preview.ID)
+		require.Len(t, preview.SecretRequirements, 1)
+		require.False(t, preview.SecretRequirements[0].Satisfied)
+
+		_, err = setup.dynamicParamsClient.CreateUserSecret(ctx, codersdk.Me, codersdk.CreateUserSecretRequest{
+			Name:    "github-token",
+			Value:   "ghp_test",
+			EnvName: "GITHUB_TOKEN",
+		})
+		require.NoError(t, err)
+
+		preview = testutil.RequireReceive(ctx, t, previews)
+		require.Equal(t, 0, preview.ID)
+		require.Len(t, preview.SecretRequirements, 1)
+		require.True(t, preview.SecretRequirements[0].Satisfied)
+
+		err = setup.dynamicParamsClient.DeleteUserSecret(ctx, codersdk.Me, "github-token")
+		require.NoError(t, err)
+
+		preview = testutil.RequireReceive(ctx, t, previews)
+		require.Equal(t, 1, preview.ID)
+		require.Len(t, preview.SecretRequirements, 1)
+		require.False(t, preview.SecretRequirements[0].Satisfied)
+
+		_, err = setup.dynamicParamsClient.CreateUserSecret(ctx, codersdk.Me, codersdk.CreateUserSecretRequest{
+			Name:    "github-token",
+			Value:   "ghp_test",
+			EnvName: "GITHUB_TOKEN",
+		})
+		require.NoError(t, err)
+
+		preview = testutil.RequireReceive(ctx, t, previews)
+		require.Equal(t, 2, preview.ID)
+		require.Len(t, preview.SecretRequirements, 1)
+		require.True(t, preview.SecretRequirements[0].Satisfied)
+
+		otherEnvName := "OTHER_GITHUB_TOKEN"
+		_, err = setup.dynamicParamsClient.UpdateUserSecret(ctx, codersdk.Me, "github-token", codersdk.UpdateUserSecretRequest{
+			EnvName: &otherEnvName,
+		})
+		require.NoError(t, err)
+
+		preview = testutil.RequireReceive(ctx, t, previews)
+		require.Equal(t, 3, preview.ID)
+		require.Len(t, preview.SecretRequirements, 1)
+		require.False(t, preview.SecretRequirements[0].Satisfied)
+	})
+
+	t.Run("SecretRequirementPushesAfterOwnerSwitch", func(t *testing.T) {
+		t.Parallel()
+
+		dynamicParametersTerraformSource, err := os.ReadFile("testdata/parameters/secret_required/main.tf")
+		require.NoError(t, err)
+
+		setup := setupDynamicParamsTest(t, setupDynamicParamsTestParams{
+			// No production role grants cross-user user_secret:read today,
+			// so use an allow-all authorizer for lifecycle coverage.
+			authorizer:               &coderdtest.FakeAuthorizer{},
+			provisionerDaemonVersion: provProto.CurrentVersion.String(),
+			mainTF:                   dynamicParametersTerraformSource,
+		})
+
+		ctx := testutil.Context(t, testutil.WaitMedium)
+		previews := setup.stream.Chan()
+		targetClient, target := coderdtest.CreateAnotherUser(t, setup.client, setup.template.OrganizationID)
+
+		preview := testutil.RequireReceive(ctx, t, previews)
+		require.Equal(t, -1, preview.ID)
+		require.Len(t, preview.SecretRequirements, 1)
+		require.False(t, preview.SecretRequirements[0].Satisfied)
+
+		err = setup.stream.Send(codersdk.DynamicParametersRequest{
+			ID:      0,
+			Inputs:  map[string]string{},
+			OwnerID: target.ID,
+		})
+		require.NoError(t, err)
+
+		preview = testutil.RequireReceive(ctx, t, previews)
+		require.Equal(t, 0, preview.ID)
+		require.Len(t, preview.SecretRequirements, 1)
+		require.False(t, preview.SecretRequirements[0].Satisfied)
+
+		_, err = targetClient.CreateUserSecret(ctx, codersdk.Me, codersdk.CreateUserSecretRequest{
+			Name:    "github-token",
+			Value:   "ghp_target",
+			EnvName: "GITHUB_TOKEN",
+		})
+		require.NoError(t, err)
+
+		preview = testutil.RequireReceive(ctx, t, previews)
+		require.Equal(t, 1, preview.ID)
+		require.Len(t, preview.SecretRequirements, 1)
+		require.True(t, preview.SecretRequirements[0].Satisfied)
+
+		_, err = setup.dynamicParamsClient.CreateUserSecret(ctx, codersdk.Me, codersdk.CreateUserSecretRequest{
+			Name:    "github-token",
+			Value:   "ghp_initial",
+			EnvName: "GITHUB_TOKEN",
+		})
+		require.NoError(t, err)
+
+		require.Never(t, func() bool {
+			select {
+			case <-previews:
+				return true
+			default:
+				return false
+			}
+		}, testutil.WaitShort/5, testutil.IntervalFast)
+	})
+
+	t.Run("SecretRequirementDoesNotSubscribeWhenOwnerUnauthorized", func(t *testing.T) {
+		t.Parallel()
+
+		dynamicParametersTerraformSource, err := os.ReadFile("testdata/parameters/secret_required/main.tf")
+		require.NoError(t, err)
+
+		setup := setupDynamicParamsTest(t, setupDynamicParamsTestParams{
+			provisionerDaemonVersion: provProto.CurrentVersion.String(),
+			mainTF:                   dynamicParametersTerraformSource,
+		})
+
+		ctx := testutil.Context(t, testutil.WaitMedium)
+		previews := setup.stream.Chan()
+		targetClient, target := coderdtest.CreateAnotherUser(t, setup.client, setup.template.OrganizationID)
+
+		preview := testutil.RequireReceive(ctx, t, previews)
+		require.Equal(t, -1, preview.ID)
+		require.Len(t, preview.SecretRequirements, 1)
+		require.False(t, preview.SecretRequirements[0].Satisfied)
+
+		err = setup.stream.Send(codersdk.DynamicParametersRequest{
+			ID:      0,
+			Inputs:  map[string]string{},
+			OwnerID: target.ID,
+		})
+		require.NoError(t, err)
+
+		preview = testutil.RequireReceive(ctx, t, previews)
+		require.Equal(t, 0, preview.ID)
+		require.Empty(t, preview.SecretRequirements)
+		require.Len(t, preview.Diagnostics, 1)
+		require.Equal(t, dynamicparameters.DiagCodeSecretValidationForbidden, preview.Diagnostics[0].Extra.Code)
+
+		_, err = targetClient.CreateUserSecret(ctx, codersdk.Me, codersdk.CreateUserSecretRequest{
+			Name:    "github-token",
+			Value:   "ghp_target",
+			EnvName: "GITHUB_TOKEN",
+		})
+		require.NoError(t, err)
+
+		require.Never(t, func() bool {
+			select {
+			case <-previews:
+				return true
+			default:
+				return false
+			}
+		}, testutil.WaitShort/5, testutil.IntervalFast)
+	})
+
 	// Regression test for PLAT-100: a workspace whose template has an
 	// unsatisfied coder_secret requirement must still be stoppable and
 	// deletable. Start remains blocked.
@@ -475,6 +652,7 @@ func TestDynamicParametersWithTerraformValues(t *testing.T) {
 type setupDynamicParamsTestParams struct {
 	db                       database.Store
 	ps                       pubsub.Pubsub
+	authorizer               rbac.Authorizer
 	provisionerDaemonVersion string
 	mainTF                   []byte
 	modulesArchive           []byte
@@ -486,16 +664,18 @@ type setupDynamicParamsTestParams struct {
 }
 
 type dynamicParamsTest struct {
-	client   *codersdk.Client
-	api      *coderd.API
-	stream   *wsjson.Stream[codersdk.DynamicParametersResponse, codersdk.DynamicParametersRequest]
-	template codersdk.Template
+	client              *codersdk.Client
+	dynamicParamsClient *codersdk.Client
+	api                 *coderd.API
+	stream              *wsjson.Stream[codersdk.DynamicParametersResponse, codersdk.DynamicParametersRequest]
+	template            codersdk.Template
 }
 
 func setupDynamicParamsTest(t *testing.T, args setupDynamicParamsTestParams) dynamicParamsTest {
 	ownerClient, _, api := coderdtest.NewWithAPI(t, &coderdtest.Options{
 		Database:                 args.db,
 		Pubsub:                   args.ps,
+		Authorizer:               args.authorizer,
 		IncludeProvisionerDaemon: true,
 		ProvisionerDaemonVersion: args.provisionerDaemonVersion,
 	})
@@ -530,10 +710,11 @@ func setupDynamicParamsTest(t *testing.T, args setupDynamicParamsTestParams) dyn
 	})
 
 	return dynamicParamsTest{
-		client:   ownerClient,
-		api:      api,
-		stream:   stream,
-		template: tpl,
+		client:              ownerClient,
+		dynamicParamsClient: templateAdmin,
+		api:                 api,
+		stream:              stream,
+		template:            tpl,
 	}
 }
 

--- a/coderd/usersecrets.go
+++ b/coderd/usersecrets.go
@@ -1,6 +1,7 @@
 package coderd
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"net/http"
@@ -9,11 +10,13 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/xerrors"
 
+	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/coderd/audit"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/db2sdk"
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/coderd/httpmw"
+	"github.com/coder/coder/v2/coderd/usersecretspubsub"
 	"github.com/coder/coder/v2/codersdk"
 )
 
@@ -105,6 +108,14 @@ func (api *API) postUserSecret(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	aReq.New = secret
+
+	api.publishUserSecretEvent(ctx, usersecretspubsub.Event{
+		Kind:     usersecretspubsub.EventKindCreated,
+		UserID:   secret.UserID,
+		Name:     secret.Name,
+		EnvName:  secret.EnvName,
+		FilePath: secret.FilePath,
+	})
 
 	httpapi.Write(ctx, rw, http.StatusCreated, db2sdk.UserSecretFromFull(secret))
 }
@@ -303,6 +314,14 @@ func (api *API) patchUserSecret(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	api.publishUserSecretEvent(ctx, usersecretspubsub.Event{
+		Kind:     usersecretspubsub.EventKindUpdated,
+		UserID:   secret.UserID,
+		Name:     secret.Name,
+		EnvName:  secret.EnvName,
+		FilePath: secret.FilePath,
+	})
+
 	httpapi.Write(ctx, rw, http.StatusOK, db2sdk.UserSecretFromFull(secret))
 }
 
@@ -346,5 +365,22 @@ func (api *API) deleteUserSecret(rw http.ResponseWriter, r *http.Request) {
 	}
 	aReq.Old = deleted
 
+	api.publishUserSecretEvent(ctx, usersecretspubsub.Event{
+		Kind:   usersecretspubsub.EventKindDeleted,
+		UserID: user.ID,
+		Name:   name,
+	})
+
 	rw.WriteHeader(http.StatusNoContent)
+}
+
+func (api *API) publishUserSecretEvent(ctx context.Context, event usersecretspubsub.Event) {
+	if err := usersecretspubsub.Publish(api.Pubsub, event); err != nil {
+		api.Logger.Warn(ctx, "failed to publish user secret event",
+			slog.F("user_id", event.UserID),
+			slog.F("secret_name", event.Name),
+			slog.F("event_kind", event.Kind),
+			slog.Error(err),
+		)
+	}
 }

--- a/coderd/usersecretspubsub/usersecretspubsub.go
+++ b/coderd/usersecretspubsub/usersecretspubsub.go
@@ -1,0 +1,42 @@
+package usersecretspubsub
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+	"golang.org/x/xerrors"
+
+	"github.com/coder/coder/v2/coderd/database/pubsub"
+)
+
+type EventKind string
+
+const (
+	EventKindCreated EventKind = "created"
+	EventKindUpdated EventKind = "updated"
+	EventKindDeleted EventKind = "deleted"
+)
+
+type Event struct {
+	Kind     EventKind `json:"kind"`
+	UserID   uuid.UUID `json:"user_id" format:"uuid"`
+	Name     string    `json:"name"`
+	EnvName  string    `json:"env_name,omitempty"`
+	FilePath string    `json:"file_path,omitempty"`
+}
+
+func Channel(userID uuid.UUID) string {
+	return fmt.Sprintf("user_secrets:%s", userID)
+}
+
+func Publish(ps pubsub.Publisher, event Event) error {
+	msg, err := json.Marshal(event)
+	if err != nil {
+		return xerrors.Errorf("marshal user secret event: %w", err)
+	}
+	if err := ps.Publish(Channel(event.UserID), msg); err != nil {
+		return xerrors.Errorf("publish user secret event: %w", err)
+	}
+	return nil
+}

--- a/codersdk/parameters.go
+++ b/codersdk/parameters.go
@@ -162,8 +162,9 @@ type PreviewParameterValidation struct {
 }
 
 type DynamicParametersRequest struct {
-	// ID identifies the request. The response contains the same
-	// ID so that the client can match it to the request.
+	// ID identifies the request for response ordering. Websocket response
+	// IDs are monotonically increasing and may exceed the request ID when
+	// server-side events trigger additional renders.
 	ID     int               `json:"id"`
 	Inputs map[string]string `json:"inputs"`
 	// OwnerID if uuid.Nil, it defaults to `codersdk.Me`

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -4478,12 +4478,12 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 
 ### Properties
 
-| Name               | Type    | Required | Restrictions | Description                                                                                                  |
-|--------------------|---------|----------|--------------|--------------------------------------------------------------------------------------------------------------|
-| `id`               | integer | false    |              | ID identifies the request. The response contains the same ID so that the client can match it to the request. |
-| `inputs`           | object  | false    |              |                                                                                                              |
-| » `[any property]` | string  | false    |              |                                                                                                              |
-| `owner_id`         | string  | false    |              | Owner ID if uuid.Nil, it defaults to `codersdk.Me`                                                           |
+| Name               | Type    | Required | Restrictions | Description                                                                                                                                                                            |
+|--------------------|---------|----------|--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `id`               | integer | false    |              | ID identifies the request for response ordering. Websocket response IDs are monotonically increasing and may exceed the request ID when server-side events trigger additional renders. |
+| `inputs`           | object  | false    |              |                                                                                                                                                                                        |
+| » `[any property]` | string  | false    |              |                                                                                                                                                                                        |
+| `owner_id`         | string  | false    |              | Owner ID if uuid.Nil, it defaults to `codersdk.Me`                                                                                                                                     |
 
 ## codersdk.DynamicParametersResponse
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -3657,8 +3657,9 @@ export const DisplayApps: DisplayApp[] = [
 // From codersdk/parameters.go
 export interface DynamicParametersRequest {
 	/**
-	 * ID identifies the request. The response contains the same
-	 * ID so that the client can match it to the request.
+	 * ID identifies the request for response ordering. Websocket response
+	 * IDs are monotonically increasing and may exceed the request ID when
+	 * server-side events trigger additional renders.
 	 */
 	readonly id: number;
 	readonly inputs: Record<string, string>;


### PR DESCRIPTION
Publishes user secret create, update, and delete events and subscribes dynamic parameter websockets to authorized owner secret changes.

Secret changes trigger fresh renders with monotonic response IDs, with backend tests covering subscription authorization and websocket refresh behavior.
