### PR TITLE
fix(site/e2e): backport verifyParameters flake fixes to 2.29

### DIFF
--- a/site/e2e/helpers.ts
+++ b/site/e2e/helpers.ts
@@ -169,53 +169,83 @@ export const verifyParameters = async (
 	expectedBuildParameters: WorkspaceBuildParameter[],
 ) => {
 	const user = currentUser(page);
+	// Use networkidle to ensure all API responses (workspace data, build
+	// parameters) are settled before verifying values. Using domcontentloaded
+	// can cause the form to render with stale React Query cache data.
 	await page.goto(`/@${user.username}/${workspaceName}/settings/parameters`, {
-		waitUntil: "domcontentloaded",
+		waitUntil: "networkidle",
 	});
 
-	for (const buildParameter of expectedBuildParameters) {
-		const richParameter = richParameters.find(
-			(richParam) => richParam.name === buildParameter.name,
-		);
-		if (!richParameter) {
-			throw new Error(
-				"build parameter is expected to be present in rich parameter schema",
-			);
-		}
-
-		const parameterLabel = page.getByTestId(
-			`parameter-field-${richParameter.displayName}`,
-		);
-		await expect(parameterLabel).toBeVisible();
-
-		if (richParameter.options.length > 0) {
-			const parameterValue = parameterLabel.getByLabel(buildParameter.value);
-			const value = await parameterValue.isChecked();
-			expect(value).toBe(true);
-			continue;
-		}
-
-		switch (richParameter.type) {
-			case "bool":
-				{
-					const parameterField = parameterLabel.locator("input");
-					const value = await parameterField.isChecked();
-					expect(value.toString()).toEqual(buildParameter.value);
+	await Promise.all(
+		expectedBuildParameters.map(
+			async (buildParameter: WorkspaceBuildParameter) => {
+				const richParameter = richParameters.find(
+					(richParam) => richParam.name === buildParameter.name,
+				);
+				if (!richParameter) {
+					throw new Error(
+						"build parameter is expected to be present in rich parameter schema",
+					);
 				}
-				break;
-			case "string":
-			case "number":
-				{
-					const parameterField = parameterLabel.locator("input");
-					const value = await parameterField.inputValue();
-					expect(value).toEqual(buildParameter.value);
+
+				const parameterLabel = page.getByTestId(
+					`parameter-field-${richParameter.displayName}`,
+				);
+
+				await expect(parameterLabel).toBeVisible({
+					timeout: 10_000,
+				});
+
+				if (richParameter.options.length > 0) {
+					const parameterValue = parameterLabel.getByLabel(
+						buildParameter.value,
+					);
+					const value = await parameterValue.isChecked();
+					expect(value).toBe(true);
+					return;
 				}
-				break;
-			default:
-				// Some types like `list(string)` are not tested
-				throw new Error("not implemented yet");
-		}
-	}
+
+				switch (richParameter.type) {
+					case "bool":
+						{
+							// Use auto-retrying assertions to avoid capturing
+							// a stale default value before data hydration
+							// completes.
+							const parameterField = parameterLabel.locator("input");
+							if (buildParameter.value === "true") {
+								await expect(parameterField).toBeChecked({
+									timeout: 15_000,
+								});
+							} else if (buildParameter.value === "false") {
+								await expect(parameterField).not.toBeChecked({
+									timeout: 15_000,
+								});
+							} else {
+								throw new Error(
+									`Invalid boolean build parameter value: ${buildParameter.value}`,
+								);
+							}
+						}
+						break;
+					case "string":
+					case "number":
+						{
+							const parameterField = parameterLabel.locator("input").first();
+							// Dynamic parameters can hydrate after initial render with
+							// stale or empty values. Retry with a longer timeout to
+							// allow the page to settle.
+							await expect(parameterField).toHaveValue(buildParameter.value, {
+								timeout: 15_000,
+							});
+						}
+						break;
+					default:
+						// Some types like `list(string)` are not tested
+						throw new Error("not implemented yet");
+				}
+			},
+		),
+	);
 };
 
 /**


### PR DESCRIPTION
Backports three incremental fixes to `verifyParameters` in `site/e2e/helpers.ts` from `main` to `release/2.29`. These fix a consistent e2e flake in `create workspace and overwrite default parameters` that blocks [#24769](https://github.com/coder/coder/pull/24769).

## Root cause

`verifyParameters` navigated with `waitUntil: "domcontentloaded"`, so the form rendered with the default parameter value (`"abc"`) from the React Query cache before the actual build parameter value (`"AAAAA"`) arrived from the API. The one-shot `inputValue()` + `toEqual()` assertion captured the stale value.

## Fixes included

| Commit | PR | Fix |
|---|---|---|
| `8bb80b0` | [#22413](https://github.com/coder/coder/pull/22413) | Switch `waitUntil` to `"networkidle"`, replace one-shot assertions with auto-retrying `toHaveValue()` (15s timeout) |
| `b73f216` | [#22557](https://github.com/coder/coder/pull/22557) | Run parameter assertions in parallel with `Promise.all` |
| `13703fb` | [#23315](https://github.com/coder/coder/pull/23315) | Replace one-shot `isChecked()` for bool params with auto-retrying `toBeChecked()` / `not.toBeChecked()` (15s timeout) |

The combined change brings `verifyParameters` in line with `main`.

> Generated by Coder Agents