### PR TITLE
fix(site): scope template workspace count query to organization

### DIFF
--- a/site/src/pages/TemplatePage/TemplatePageHeader.tsx
+++ b/site/src/pages/TemplatePage/TemplatePageHeader.tsx
@@ -67,7 +67,7 @@ const TemplateMenu: FC<TemplateMenuProps> = ({
 	);
 	const navigate = useNavigate();
 	const getLink = useLinks();
-	const queryText = `template:${templateName}`;
+	const queryText = `organization:${organizationName} template:${templateName}`;
 	const workspaceCountQuery = useQuery({
 		...workspaces({ q: queryText }),
 		select: (res) => res.count,


### PR DESCRIPTION
Fixes an issue where `TemplateMenu` queried workspace count across the wrong scope, causing false “workspaces exist” warnings. Now scoped to the correct organization.

<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->
