### PR TITLE
docs: add Claude Desktop and ChatGPT Desktop to AI Gateway client docs

### DIFF
--- a/docs/ai-coder/ai-gateway/clients/claude-desktop.md
+++ b/docs/ai-coder/ai-gateway/clients/claude-desktop.md
@@ -1,77 +1,78 @@
 # Claude Desktop
 
-Claude Desktop (Cowork and Code tabs) can route all model inference through
-AI Gateway using its third-party inference mode. This mode is configured via
-the built-in setup UI or through MDM for fleet-wide deployment.
+Claude Desktop's Code tab runs the Claude Code engine and makes API calls to
+`api.anthropic.com`. [AI Gateway Proxy](../ai-gateway-proxy/index.md)
+intercepts this traffic transparently, so users keep their normal Anthropic
+login, conversation history, and the full Claude Desktop experience (Chat,
+Cowork, and Code tabs) while AI Gateway provides governance and observability.
 
-> [!NOTE]
-> Cowork on third-party platforms is a
-> [Research Preview](https://claude.com/docs/cowork/3p/overview).
-> Features and configuration keys may change.
+To use Claude Desktop with AI Gateway, make sure AI Gateway Proxy is
+configured. See [AI Gateway Proxy Setup](../ai-gateway-proxy/setup.md) for
+instructions.
+
+For general client configuration requirements, see
+[AI Gateway Proxy Client Configuration](../ai-gateway-proxy/setup.md#client-configuration).
 
 ## Prerequisites
 
 - Claude Desktop installed ([download](https://claude.com/download))
-- A **[Coder API token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)** for authentication with AI Gateway
+- [AI Gateway Proxy](../ai-gateway-proxy/setup.md) enabled on your Coder
+  deployment
+- A **[Coder API token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)**
+  for authentication with AI Gateway
 
-## Centralized API Key
+## Proxy configuration
 
-### Single-machine setup (Developer Mode)
+Claude Desktop respects system proxy settings. Configure the proxy so that
+traffic to `api.anthropic.com` is routed through AI Gateway Proxy.
 
-1. Open Claude Desktop (you do not need to sign in).
-1. Go to **Help** > **Troubleshooting** > **Enable Developer Mode**.
-1. Go to **Developer** > **Configure Third-Party Inference**.
-1. In the **Connection** section, configure:
-   - **Inference provider**: Select **Gateway (Anthropic-compatible)**.
-   - **Gateway base URL**: Enter
-     `https://coder.example.com/api/v2/aibridge/anthropic`.
-   - **Gateway auth scheme**: Leave as **bearer**.
-   - **Gateway API key**: Enter your
-     **[Coder API token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)**.
-1. In the **Models** section, add the models you want to use
-   (for example `claude-sonnet-4-6`, `claude-opus-4-7`).
-1. Click **Apply locally**, then quit and reopen Claude Desktop.
-1. On the sign-in screen, choose **Continue with Gateway**.
+### Environment variable
 
-### MDM deployment
-
-For fleet-wide rollout, distribute a managed configuration profile via
-Jamf, Intune, or Group Policy. The key fields are:
-
-```json
-{
-  "inferenceProvider": "gateway",
-  "inferenceGatewayBaseUrl": "https://coder.example.com/api/v2/aibridge/anthropic",
-  "inferenceGatewayApiKey": "<coder-api-token>",
-  "inferenceGatewayAuthScheme": "bearer",
-  "inferenceModels": ["claude-sonnet-4-6", "claude-opus-4-7", "claude-haiku-4-5"]
-}
+```bash
+export HTTPS_PROXY="https://coder:<your-coder-api-token>@<proxy-host>:8888"
 ```
 
-Replace `coder.example.com` with your Coder deployment URL.
+Replace `<proxy-host>` with your AI Gateway Proxy hostname.
 
-You can export a ready-to-deploy profile from the setup UI:
+> [!NOTE]
+> If [TLS is not enabled](../ai-gateway-proxy/setup.md#proxy-tls-configuration)
+> on the proxy, replace `https://` with `http://` in the proxy URL.
 
-- **macOS**: Click **Export** to save a `.mobileconfig` file for Jamf or
-  Kandji.
-- **Windows**: Click **Export** to save a `.reg` file for Intune or Group
-  Policy.
+### System proxy (alternative)
 
-When the app launches and finds a managed configuration, it enters
-third-party mode automatically without requiring users to sign in.
+You can also configure the proxy at the OS level so Claude Desktop picks it
+up automatically:
 
-## Limitations
+- **macOS**: System Settings > Network > your connection > Details > Proxies.
+- **Windows**: Settings > Network & Internet > Proxy > Manual proxy setup.
 
-- **BYOK is not supported.** Claude Desktop's gateway mode sends a single
-  credential (`inferenceGatewayApiKey`) on every request. There is no
-  built-in mechanism to separate the gateway authentication token from a
-  personal provider API key, so Bring Your Own Key mode is not available
-  through this client.
-- **Claude Code CLI configuration is separate.** Claude Desktop and the
-  Claude Code CLI read their own configuration independently. If you also
-  use Claude Code in the terminal, configure it separately with
-  [environment variables](./claude-code.md).
+Enter the proxy host, port, and credentials (username: `coder`, password:
+your Coder API token).
+
+## CA certificate trust
+
+Claude Desktop must trust the AI Gateway Proxy CA certificate. Add the
+certificate to your operating system's trust store.
+
+See [Trusting the CA certificate](../ai-gateway-proxy/setup.md#trusting-the-ca-certificate)
+for how to download the certificate, and
+[System trust store](../ai-gateway-proxy/setup.md#system-trust-store) for
+platform-specific instructions.
+
+When [TLS is enabled](../ai-gateway-proxy/setup.md#proxy-tls-configuration)
+on the proxy, add the TLS certificate to the system trust store as well.
+
+## Claude Code CLI
+
+Claude Desktop and the Claude Code CLI read their own configuration
+independently. If you also use Claude Code in the terminal, you can either:
+
+- Configure the CLI to use AI Gateway Proxy with the same `HTTPS_PROXY`
+  and CA certificate settings described above.
+- Configure the CLI to use AI Gateway directly with
+  [environment variables](./claude-code.md), which does not require the
+  proxy.
 
 **References:**
-[Cowork on third-party platforms](https://claude.com/docs/cowork/3p/overview),
-[Install and configure](https://support.claude.com/en/articles/14680741-install-and-configure-claude-cowork-with-third-party-platforms)
+[Claude Desktop documentation](https://code.claude.com/docs/en/desktop),
+[AI Gateway Proxy Setup](../ai-gateway-proxy/setup.md)

--- a/docs/ai-coder/ai-gateway/clients/claude-desktop.md
+++ b/docs/ai-coder/ai-gateway/clients/claude-desktop.md
@@ -30,6 +30,9 @@ Claude Desktop is an Electron app that does not read shell profile files
 (`~/.zshrc`, `~/.bashrc`). You must set the `HTTPS_PROXY` environment
 variable in a way that the desktop application can see it.
 
+Developer Mode is **not** required. The proxy operates at the OS network
+level, so no in-app configuration is needed.
+
 > [!NOTE]
 > If [TLS is not enabled](../ai-gateway-proxy/setup.md#proxy-tls-configuration)
 > on the proxy, replace `https://` with `http://` in the proxy URL.

--- a/docs/ai-coder/ai-gateway/clients/claude-desktop.md
+++ b/docs/ai-coder/ai-gateway/clients/claude-desktop.md
@@ -1,17 +1,20 @@
 # Claude Desktop
 
-Claude Desktop's Code tab runs the Claude Code engine and makes API calls to
-`api.anthropic.com`. [AI Gateway Proxy](../ai-gateway-proxy/index.md)
-intercepts this traffic transparently, so users keep their normal Anthropic
-login, conversation history, and the full Claude Desktop experience (Chat,
-Cowork, and Code tabs) while AI Gateway provides governance and observability.
+The Code tab in Claude Desktop runs the Claude Code engine and makes API
+calls to `api.anthropic.com`.
+[AI Gateway Proxy](../ai-gateway-proxy/index.md) intercepts this traffic
+transparently, so users keep their normal Anthropic login and conversation
+history while AI Gateway provides governance and observability.
 
 To use Claude Desktop with AI Gateway, make sure AI Gateway Proxy is
 configured. See [AI Gateway Proxy Setup](../ai-gateway-proxy/setup.md) for
 instructions.
 
-For general client configuration requirements, see
-[AI Gateway Proxy Client Configuration](../ai-gateway-proxy/setup.md#client-configuration).
+> [!NOTE]
+> Only the **Code tab** is supported. The Cowork tab runs inside an
+> isolated VM that does not inherit proxy settings. Proxy support for
+> Cowork is tracked in
+> [anthropics/claude-code#45994](https://github.com/anthropics/claude-code/issues/45994).
 
 ## Prerequisites
 
@@ -23,36 +26,77 @@ For general client configuration requirements, see
 
 ## Proxy configuration
 
-Claude Desktop respects system proxy settings. Configure the proxy so that
-traffic to `api.anthropic.com` is routed through AI Gateway Proxy.
-
-### Environment variable
-
-```bash
-export HTTPS_PROXY="https://coder:<your-coder-api-token>@<proxy-host>:8888"
-```
-
-Replace `<proxy-host>` with your AI Gateway Proxy hostname.
+Claude Desktop is an Electron app that does not read shell profile files
+(`~/.zshrc`, `~/.bashrc`). You must set the `HTTPS_PROXY` environment
+variable in a way that the desktop application can see it.
 
 > [!NOTE]
 > If [TLS is not enabled](../ai-gateway-proxy/setup.md#proxy-tls-configuration)
 > on the proxy, replace `https://` with `http://` in the proxy URL.
 
-### System proxy (alternative)
+Replace `<proxy-host>` with your AI Gateway Proxy hostname and
+`<your-coder-api-token>` with your Coder API token in the examples below.
 
-You can also configure the proxy at the OS level so Claude Desktop picks it
-up automatically:
+<div class="tabs">
 
-- **macOS**: System Settings > Network > your connection > Details > Proxies.
-- **Windows**: Settings > Network & Internet > Proxy > Manual proxy setup.
+### macOS
 
-Enter the proxy host, port, and credentials (username: `coder`, password:
-your Coder API token).
+Use `launchctl setenv` to inject the variable into the GUI application
+environment. This only affects applications launched after the command
+runs, so quit and reopen Claude Desktop afterwards.
+
+```sh
+launchctl setenv HTTPS_PROXY "https://coder:<your-coder-api-token>@<proxy-host>:8888"
+```
+
+To persist across reboots, add the command to a login script or
+LaunchAgent.
+
+To remove the proxy setting:
+
+```sh
+launchctl unsetenv HTTPS_PROXY
+```
+
+### Windows
+
+Set a user-level environment variable so the desktop application picks it
+up on next launch. Open PowerShell and run:
+
+```powershell
+[Environment]::SetEnvironmentVariable(
+  "HTTPS_PROXY",
+  "https://coder:<your-coder-api-token>@<proxy-host>:8888",
+  "User"
+)
+```
+
+Quit and reopen Claude Desktop for the change to take effect.
+
+To remove the proxy setting:
+
+```powershell
+[Environment]::SetEnvironmentVariable("HTTPS_PROXY", $null, "User")
+```
+
+### Linux
+
+Set the variable before launching Claude Desktop from the terminal:
+
+```sh
+HTTPS_PROXY="https://coder:<your-coder-api-token>@<proxy-host>:8888" claude-desktop
+```
+
+For `.desktop` file launchers, add the variable to the `Exec` line or
+create a wrapper script that exports it before starting the application.
+
+</div>
 
 ## CA certificate trust
 
 Claude Desktop must trust the AI Gateway Proxy CA certificate. Add the
-certificate to your operating system's trust store.
+certificate to your operating system's trust store so the Electron app
+picks it up automatically.
 
 See [Trusting the CA certificate](../ai-gateway-proxy/setup.md#trusting-the-ca-certificate)
 for how to download the certificate, and
@@ -75,4 +119,5 @@ independently. If you also use Claude Code in the terminal, you can either:
 
 **References:**
 [Claude Desktop documentation](https://code.claude.com/docs/en/desktop),
-[AI Gateway Proxy Setup](../ai-gateway-proxy/setup.md)
+[AI Gateway Proxy Setup](../ai-gateway-proxy/setup.md),
+[Claude Code network configuration](https://code.claude.com/docs/en/network-config)

--- a/docs/ai-coder/ai-gateway/clients/claude-desktop.md
+++ b/docs/ai-coder/ai-gateway/clients/claude-desktop.md
@@ -1,0 +1,77 @@
+# Claude Desktop
+
+Claude Desktop (Cowork and Code tabs) can route all model inference through
+AI Gateway using its third-party inference mode. This mode is configured via
+the built-in setup UI or through MDM for fleet-wide deployment.
+
+> [!NOTE]
+> Cowork on third-party platforms is a
+> [Research Preview](https://claude.com/docs/cowork/3p/overview).
+> Features and configuration keys may change.
+
+## Prerequisites
+
+- Claude Desktop installed ([download](https://claude.com/download))
+- A **[Coder API token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)** for authentication with AI Gateway
+
+## Centralized API Key
+
+### Single-machine setup (Developer Mode)
+
+1. Open Claude Desktop (you do not need to sign in).
+1. Go to **Help** > **Troubleshooting** > **Enable Developer Mode**.
+1. Go to **Developer** > **Configure Third-Party Inference**.
+1. In the **Connection** section, configure:
+   - **Inference provider**: Select **Gateway (Anthropic-compatible)**.
+   - **Gateway base URL**: Enter
+     `https://coder.example.com/api/v2/aibridge/anthropic`.
+   - **Gateway auth scheme**: Leave as **bearer**.
+   - **Gateway API key**: Enter your
+     **[Coder API token](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)**.
+1. In the **Models** section, add the models you want to use
+   (for example `claude-sonnet-4-6`, `claude-opus-4-7`).
+1. Click **Apply locally**, then quit and reopen Claude Desktop.
+1. On the sign-in screen, choose **Continue with Gateway**.
+
+### MDM deployment
+
+For fleet-wide rollout, distribute a managed configuration profile via
+Jamf, Intune, or Group Policy. The key fields are:
+
+```json
+{
+  "inferenceProvider": "gateway",
+  "inferenceGatewayBaseUrl": "https://coder.example.com/api/v2/aibridge/anthropic",
+  "inferenceGatewayApiKey": "<coder-api-token>",
+  "inferenceGatewayAuthScheme": "bearer",
+  "inferenceModels": ["claude-sonnet-4-6", "claude-opus-4-7", "claude-haiku-4-5"]
+}
+```
+
+Replace `coder.example.com` with your Coder deployment URL.
+
+You can export a ready-to-deploy profile from the setup UI:
+
+- **macOS**: Click **Export** to save a `.mobileconfig` file for Jamf or
+  Kandji.
+- **Windows**: Click **Export** to save a `.reg` file for Intune or Group
+  Policy.
+
+When the app launches and finds a managed configuration, it enters
+third-party mode automatically without requiring users to sign in.
+
+## Limitations
+
+- **BYOK is not supported.** Claude Desktop's gateway mode sends a single
+  credential (`inferenceGatewayApiKey`) on every request. There is no
+  built-in mechanism to separate the gateway authentication token from a
+  personal provider API key, so Bring Your Own Key mode is not available
+  through this client.
+- **Claude Code CLI configuration is separate.** Claude Desktop and the
+  Claude Code CLI read their own configuration independently. If you also
+  use Claude Code in the terminal, configure it separately with
+  [environment variables](./claude-code.md).
+
+**References:**
+[Cowork on third-party platforms](https://claude.com/docs/cowork/3p/overview),
+[Install and configure](https://support.claude.com/en/articles/14680741-install-and-configure-claude-cowork-with-third-party-platforms)

--- a/docs/ai-coder/ai-gateway/clients/index.md
+++ b/docs/ai-coder/ai-gateway/clients/index.md
@@ -85,26 +85,28 @@ When disabled, BYOK requests are rejected with a `403 Forbidden` response and on
 
 The table below shows tested AI clients and their compatibility with AI Gateway.
 
-| Client                           | OpenAI | Anthropic | BYOK | Notes                                                                                                                                                  |
-|----------------------------------|--------|-----------|------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [Mux](./mux.md)                  | ✅      | ✅         | -    |                                                                                                                                                        |
-| [Claude Code](./claude-code.md)  | -      | ✅         | ✅    |                                                                                                                                                        |
-| [Codex CLI](./codex.md)          | ✅      | -         | ✅    |                                                                                                                                                        |
-| [OpenCode](./opencode.md)        | ✅      | ✅         | ✅    |                                                                                                                                                        |
-| [Factory](./factory.md)          | ✅      | ✅         | ✅    |                                                                                                                                                        |
-| [Cline](./cline.md)              | ✅      | ✅         | ✅    |                                                                                                                                                        |
-| [Kilo Code](./kilo-code.md)      | ✅      | ✅         | ❌    |                                                                                                                                                        |
-| [Roo Code](./roo-code.md)        | ✅      | ✅         | ✅    |                                                                                                                                                        |
-| [VS Code](./vscode.md)           | ✅      | ❌         | ❌    | Only supports Custom Base URL for OpenAI.                                                                                                              |
-| [JetBrains IDEs](./jetbrains.md) | ✅      | ❌         | ❌    | Works in Chat mode via [third-party model configuration](https://www.jetbrains.com/help/ai-assistant/use-custom-models.html#provide-your-own-api-key). |
-| [Zed](./zed.md)                  | ✅      | ✅         | ❌    |                                                                                                                                                        |
-| [GitHub Copilot](./copilot.md)   | ⚙️     | -         | -    | Requires [AI Gateway Proxy](../ai-gateway-proxy/index.md). Uses per-user GitHub tokens.                                                                |
-| WindSurf                         | ❌      | ❌         | ❌    | No option to override base URL.                                                                                                                        |
-| Cursor                           | ❌      | ❌         | ❌    | Override for OpenAI broken ([upstream issue](https://forum.cursor.com/t/requests-are-sent-to-incorrect-endpoint-when-using-base-url-override/144894)). |
-| Sourcegraph Amp                  | ❌      | ❌         | ❌    | No option to override base URL.                                                                                                                        |
-| Kiro                             | ❌      | ❌         | ❌    | No option to override base URL.                                                                                                                        |
-| Gemini CLI                       | ❌      | ❌         | ❌    | No Gemini API support. Upvote [this issue](https://github.com/coder/coder/issues/24804).                                                               |
-| Antigravity                      | ❌      | ❌         | ❌    | No option to override base URL.                                                                                                                        |
+| Client                                | OpenAI | Anthropic | BYOK | Notes                                                                                                                                                  |
+|---------------------------------------|--------|-----------|------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [Mux](./mux.md)                       | ✅      | ✅         | -    |                                                                                                                                                        |
+| [Claude Code](./claude-code.md)       | -      | ✅         | ✅    |                                                                                                                                                        |
+| [Claude Desktop](./claude-desktop.md) | ⚙️     | ⚙️        | ✅    | Requires [AI Gateway Proxy](../ai-gateway-proxy/index.md). Users keep their Anthropic login.                                                           |
+| [Codex CLI](./codex.md)               | ✅      | -         | ✅    |                                                                                                                                                        |
+| [OpenCode](./opencode.md)             | ✅      | ✅         | ✅    |                                                                                                                                                        |
+| [Factory](./factory.md)               | ✅      | ✅         | ✅    |                                                                                                                                                        |
+| [Cline](./cline.md)                   | ✅      | ✅         | ✅    |                                                                                                                                                        |
+| [Kilo Code](./kilo-code.md)           | ✅      | ✅         | ❌    |                                                                                                                                                        |
+| [Roo Code](./roo-code.md)             | ✅      | ✅         | ✅    |                                                                                                                                                        |
+| [VS Code](./vscode.md)                | ✅      | ❌         | ❌    | Only supports Custom Base URL for OpenAI.                                                                                                              |
+| [JetBrains IDEs](./jetbrains.md)      | ✅      | ❌         | ❌    | Works in Chat mode via [third-party model configuration](https://www.jetbrains.com/help/ai-assistant/use-custom-models.html#provide-your-own-api-key). |
+| [Zed](./zed.md)                       | ✅      | ✅         | ❌    |                                                                                                                                                        |
+| [GitHub Copilot](./copilot.md)        | ⚙️     | -         | -    | Requires [AI Gateway Proxy](../ai-gateway-proxy/index.md). Uses per-user GitHub tokens.                                                                |
+| WindSurf                              | ❌      | ❌         | ❌    | No option to override base URL.                                                                                                                        |
+| Cursor                                | ❌      | ❌         | ❌    | Override for OpenAI broken ([upstream issue](https://forum.cursor.com/t/requests-are-sent-to-incorrect-endpoint-when-using-base-url-override/144894)). |
+| Sourcegraph Amp                       | ❌      | ❌         | ❌    | No option to override base URL.                                                                                                                        |
+| Kiro                                  | ❌      | ❌         | ❌    | No option to override base URL.                                                                                                                        |
+| Gemini CLI                            | ❌      | ❌         | ❌    | No Gemini API support. Upvote [this issue](https://github.com/coder/coder/issues/24804).                                                               |
+| Antigravity                           | ❌      | ❌         | ❌    | No option to override base URL.                                                                                                                        |
+| ChatGPT Desktop                       | ❌      | ❌         | ❌    | No option to override base URL.                                                                                                                        |
 |
 
 *Legend: ✅ supported, ⚙️ requires AI Gateway Proxy, ❌ not supported, - not applicable.*

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1099,6 +1099,11 @@
 											"path": "./ai-coder/ai-gateway/clients/claude-code.md"
 										},
 										{
+											"title": "Claude Desktop",
+											"description": "Configure Claude Desktop to use AI Gateway",
+											"path": "./ai-coder/ai-gateway/clients/claude-desktop.md"
+										},
+										{
 											"title": "Codex",
 											"description": "Configure Codex to use AI Gateway",
 											"path": "./ai-coder/ai-gateway/clients/codex.md"


### PR DESCRIPTION
Adds a new AI Gateway client configuration page for Claude Desktop using the AI Gateway Proxy approach. The proxy intercepts traffic to `api.anthropic.com` transparently, so users keep their normal Anthropic login, conversation history, and all Claude Desktop features (Chat, Cowork, and Code tabs) while AI Gateway provides governance and observability.

Also adds ChatGPT Desktop to the compatibility table as unsupported (no option to override base URL).

<details><summary>Changes</summary>

- New file: `docs/ai-coder/ai-gateway/clients/claude-desktop.md` with proxy configuration (env var and system proxy), CA certificate trust, and CLI cross-reference.
- Updated `docs/ai-coder/ai-gateway/clients/index.md` compatibility table: Claude Desktop requires AI Gateway Proxy, supports BYOK. ChatGPT Desktop unsupported.
- Updated `docs/manifest.json` to add Claude Desktop to the navigation.

</details>

> Generated by Coder Agents