### PR TITLE
docs: add guide for using AI Gateway without workspaces

### DIFF
--- a/docs/ai-coder/ai-gateway/clients/index.md
+++ b/docs/ai-coder/ai-gateway/clients/index.md
@@ -133,7 +133,8 @@ resource "coder_agent" "dev" {
 
 AI tools running outside of a Coder workspace, such as local IDE extensions
 or desktop applications, can also connect to AI Gateway. Users authenticate
-with a long-lived Coder API token instead of a workspace session token.
+with a long-lived Coder API token instead of the workspace owner's session
+token.
 
 For a step-by-step walkthrough covering both admin and user setup, see
 [Using AI Gateway Without Workspaces](../external-clients.md).

--- a/docs/ai-coder/ai-gateway/clients/index.md
+++ b/docs/ai-coder/ai-gateway/clients/index.md
@@ -131,11 +131,12 @@ resource "coder_agent" "dev" {
 
 ## External and Desktop Clients
 
-You can also configure AI tools running outside of a Coder workspace, such as local IDE extensions or desktop applications, to connect to AI Gateway.
+AI tools running outside of a Coder workspace, such as local IDE extensions
+or desktop applications, can also connect to AI Gateway. Users authenticate
+with a long-lived Coder API token instead of a workspace session token.
 
-The configuration is the same: point the tool to the AI Gateway [base URL](#base-urls) and use a Coder API key for authentication.
-
-Users can generate a long-lived API key from the Coder UI or CLI. Follow the instructions at [Sessions and API tokens](../../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself) to create one.
+For a step-by-step walkthrough covering both admin and user setup, see
+[Using AI Gateway Without Workspaces](../external-clients.md).
 
 ## All Supported Clients
 

--- a/docs/ai-coder/ai-gateway/external-clients.md
+++ b/docs/ai-coder/ai-gateway/external-clients.md
@@ -3,10 +3,10 @@
 AI Gateway does not require users to work inside Coder workspaces. AI coding
 tools running on a developer's local machine (IDE extensions, CLI tools,
 desktop applications) can route traffic through AI Gateway as long as the
-tool [supports AI Gateway](./clients/index.md#compatibility) and the user
+tool [supports AI Gateway](https://coder.com/docs/ai-coder/ai-gateway/clients#compatibility) and the user
 can authenticate with a Coder API token. Not every client supports
 customizing the API base URL; see the
-[compatibility table](./clients/index.md#compatibility) for the current list.
+[compatibility table](https://coder.com/docs/ai-coder/ai-gateway/clients#compatibility) for the current list.
 
 This page describes what administrators need to set up and what end users
 need to do to connect their local tools.

--- a/docs/ai-coder/ai-gateway/external-clients.md
+++ b/docs/ai-coder/ai-gateway/external-clients.md
@@ -13,31 +13,13 @@ need to do to connect their local tools.
 
 ## Admin setup
 
-### 1. Enable AI Gateway
+### Prerequisites
 
-AI Gateway must be enabled on the Coder deployment. See [Setup](./setup.md)
-for full instructions.
+Before sharing AI Gateway with external users, complete the
+[AI Gateway setup](./setup.md): enable the feature flag and configure at
+least one upstream provider.
 
-```sh
-coder server --aibridge-enabled=true
-```
-
-### 2. Configure upstream providers
-
-Configure at least one upstream LLM provider so AI Gateway has somewhere to
-forward requests. See
-[Configure Providers](./setup.md#configure-providers) for the full list of
-options.
-
-```sh
-# Example: Anthropic
-export CODER_AIBRIDGE_ANTHROPIC_KEY="sk-ant-..."
-
-# Example: OpenAI
-export CODER_AIBRIDGE_OPENAI_KEY="sk-..."
-```
-
-### 3. Create Coder accounts for external users
+### 1. Create Coder accounts for external users
 
 Every request to AI Gateway is authenticated with a Coder API token, so each
 external user must have a Coder account. Users do not need workspace
@@ -45,9 +27,9 @@ permissions; they only need the ability to generate an API token.
 
 #### Users without individual Coder accounts
 
-Some organizations have developers who need AI Gateway access but should not
-have full Coder accounts (for example, contractors or teams that do not use
-Coder workspaces at all). In this case, an admin can create a
+Some organizations have developers who need AI Gateway access but do not
+have individual Coder accounts (for example, contractors or teams that do
+not use Coder workspaces). In this case, an admin can create a
 [service account](../../admin/users/headless-auth.md) and distribute its
 API token to those users.
 
@@ -55,42 +37,15 @@ API token to those users.
 > Using a shared service account token is a temporary workaround.
 > A dedicated authentication-only account tier is planned to give each
 > external user their own identity for auditing and access control.
-> Until then, a service account provides a practical path for teams
-> that need AI Gateway governance without individual Coder logins.
-
-To create a service account and generate a token for it:
-
-```sh
-# Create the service account (requires User Admin role or above).
-coder users create \
-  --username="ai-gateway-external" \
-  --service-account
-
-# Generate a long-lived API token for the service account.
-coder tokens create \
-  --name=ai-gateway \
-  --lifetime=2160h \
-  --user="ai-gateway-external"
-```
-
-Distribute the resulting token to the external users along with the
-connection details from the next step.
 
 When every user shares a single token, AI Gateway audit logs attribute
-all traffic to the service account rather than to individual developers.
-There are two ways to get per-user attribution:
+all traffic to the service account. To get per-user attribution, generate
+a separate named token for each developer or create a dedicated service
+account per user or group. See
+[Headless Authentication](../../admin/users/headless-auth.md) for details
+on creating service accounts and generating tokens.
 
-- **One token per user from the same service account.** Generate a
-  separate named token for each developer (`--name=alice`,
-  `--name=bob`, etc.). Each token is logged as a distinct API key,
-  so audit records can be traced back to an individual even though
-  they all belong to the same account.
-- **One service account per user or group.** Create a dedicated
-  service account for each developer or team. This provides a
-  distinct user identity in audit logs but requires more accounts
-  to manage.
-
-### 4. Share connection details
+### 2. Share connection details
 
 Provide users with the following information:
 
@@ -101,7 +56,7 @@ Provide users with the following information:
 - **How to generate an API token**: link users to the Coder dashboard or
   provide the CLI command (see below).
 
-### 5. Optional: disable BYOK
+### 3. Optional: disable BYOK
 
 By default AI Gateway allows users to bring their own LLM API keys. To
 require all traffic to use the centralized org key, disable BYOK:
@@ -114,30 +69,14 @@ coder server --aibridge-allow-byok=false
 
 ### 1. Generate a long-lived API token
 
-Create a token from the Coder dashboard or CLI. This token authenticates
-you with AI Gateway and does not require a workspace. If you do not have
-a Coder account, ask your admin to provision a
+Create a Coder API token to authenticate with AI Gateway. If you do not
+have a Coder account, ask your admin to provision a
 [service account](#users-without-individual-coder-accounts) and provide
 you with a token.
 
-<div class="tabs">
-
-#### Dashboard
-
-1. Navigate to `https://coder.example.com/settings/account`.
-1. Open the **Tokens** page in the sidebar.
-1. Click **Create token**, give it a name, and save the value.
-
-#### CLI
-
-```sh
-coder tokens create --name=ai-gateway --lifetime=720h
-```
-
-</div>
-
-See [Sessions and API tokens](../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)
-for more details on token management.
+See
+[Sessions and API tokens](../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)
+for instructions on creating tokens via the dashboard or CLI.
 
 ### 2. Configure your AI tool
 

--- a/docs/ai-coder/ai-gateway/external-clients.md
+++ b/docs/ai-coder/ai-gateway/external-clients.md
@@ -59,11 +59,9 @@ Provide users with the following information:
 ### 3. Optional: disable BYOK
 
 By default AI Gateway allows users to bring their own LLM API keys. To
-require all traffic to use the centralized org key, disable BYOK:
-
-```sh
-coder server --aibridge-allow-byok=false
-```
+require all traffic to use the centralized org key, disable BYOK. See
+[Enabling or disabling BYOK](./clients/index.md#enabling-or-disabling-byok)
+for the server flag.
 
 ## User setup
 
@@ -81,53 +79,19 @@ for instructions on creating tokens via the dashboard or CLI.
 ### 2. Configure your AI tool
 
 Point your tool at the AI Gateway base URL and set the Coder API token as
-the authentication credential. The exact settings vary by tool.
+the authentication credential. The general pattern is:
 
-<div class="tabs">
+1. Set the base URL to the appropriate AI Gateway endpoint.
+2. Set the API key or auth token to your Coder API token.
 
-#### Claude Code
+The exact variable names and configuration format differ by tool. See
+[Client Configuration](./clients/index.md) for base URLs and
+authentication details, and individual client pages for tool-specific
+instructions:
 
-```bash
-export ANTHROPIC_BASE_URL="https://coder.example.com/api/v2/aibridge/anthropic"
-export ANTHROPIC_AUTH_TOKEN="<your-coder-api-token>"
-```
-
-#### Codex CLI
-
-In `~/.codex/config.toml`:
-
-```toml
-model_provider = "aibridge"
-
-[model_providers.aibridge]
-name = "AI Bridge"
-base_url = "https://coder.example.com/api/v2/aibridge/openai/v1"
-env_key = "OPENAI_API_KEY"
-wire_api = "responses"
-```
-
-Then set the environment variable:
-
-```bash
-export OPENAI_API_KEY="<your-coder-api-token>"
-```
-
-#### Other tools
-
-For tools not listed here, the general pattern is:
-
-1. Set the base URL to `https://coder.example.com/api/v2/aibridge/openai/v1`
-   (OpenAI-compatible) or
-   `https://coder.example.com/api/v2/aibridge/anthropic`
-   (Anthropic-compatible).
-2. Set the API key to your Coder API token.
-
-See the [individual client pages](./clients/index.md#all-supported-clients)
-for tool-specific instructions.
-
-</div>
-
-Replace `coder.example.com` with your Coder deployment URL in all examples.
+- [Claude Code](./clients/claude-code.md)
+- [Codex CLI](./clients/codex.md)
+- [All supported clients](./clients/index.md#all-supported-clients)
 
 ### 3. Verify the connection
 

--- a/docs/ai-coder/ai-gateway/external-clients.md
+++ b/docs/ai-coder/ai-gateway/external-clients.md
@@ -112,7 +112,10 @@ coder server --aibridge-allow-byok=false
 ### 1. Generate a long-lived API token
 
 Create a token from the Coder dashboard or CLI. This token authenticates
-you with AI Gateway and does not require a workspace.
+you with AI Gateway and does not require a workspace. If you do not have
+a Coder account, ask your admin to provision a
+[service account](#users-without-individual-coder-accounts) and provide
+you with a token.
 
 <div class="tabs">
 

--- a/docs/ai-coder/ai-gateway/external-clients.md
+++ b/docs/ai-coder/ai-gateway/external-clients.md
@@ -40,6 +40,44 @@ Every request to AI Gateway is authenticated with a Coder API token, so each
 external user must have a Coder account. Users do not need workspace
 permissions; they only need the ability to generate an API token.
 
+#### Users without individual Coder accounts
+
+Some organizations have developers who need AI Gateway access but should not
+have full Coder accounts (for example, contractors or teams that do not use
+Coder workspaces at all). In this case, an admin can create a
+[service account](../../admin/users/headless-auth.md) and distribute its
+API token to those users.
+
+> [!NOTE]
+> Using a shared service account token is a temporary workaround.
+> A dedicated authentication-only account tier is planned to give each
+> external user their own identity for auditing and access control.
+> Until then, a service account provides a practical path for teams
+> that need AI Gateway governance without individual Coder logins.
+
+To create a service account and generate a token for it:
+
+```sh
+# Create the service account (requires User Admin role or above).
+coder users create \
+  --username="ai-gateway-external" \
+  --service-account
+
+# Generate a long-lived API token for the service account.
+coder tokens create \
+  --name=ai-gateway \
+  --lifetime=2160h \
+  --user="ai-gateway-external"
+```
+
+Distribute the resulting token to the external users along with the
+connection details from the next step.
+
+Because all users share one identity, AI Gateway audit logs attribute
+traffic to the service account rather than to individual developers.
+If per-user attribution matters, create a separate service account
+for each user or group.
+
 ### 4. Share connection details
 
 Provide users with the following information:

--- a/docs/ai-coder/ai-gateway/external-clients.md
+++ b/docs/ai-coder/ai-gateway/external-clients.md
@@ -1,0 +1,146 @@
+# Using AI Gateway Without Workspaces
+
+AI Gateway does not require users to work inside Coder workspaces. Any AI
+coding tool running on a developer's local machine (IDE extensions, CLI tools,
+desktop applications) can route traffic through AI Gateway as long as the user
+can authenticate with a Coder API token.
+
+This page describes what administrators need to set up and what end users
+need to do to connect their local tools.
+
+## Admin setup
+
+### 1. Enable AI Gateway
+
+AI Gateway must be enabled on the Coder deployment. See [Setup](./setup.md)
+for full instructions.
+
+```sh
+coder server --aibridge-enabled=true
+```
+
+### 2. Configure upstream providers
+
+Configure at least one upstream LLM provider so AI Gateway has somewhere to
+forward requests. See
+[Configure Providers](./setup.md#configure-providers) for the full list of
+options.
+
+```sh
+# Example: Anthropic
+export CODER_AIBRIDGE_ANTHROPIC_KEY="sk-ant-..."
+
+# Example: OpenAI
+export CODER_AIBRIDGE_OPENAI_KEY="sk-..."
+```
+
+### 3. Create Coder accounts for external users
+
+Every request to AI Gateway is authenticated with a Coder API token, so each
+external user must have a Coder account. Users do not need workspace
+permissions; they only need the ability to generate an API token.
+
+### 4. Share connection details
+
+Provide users with the following information:
+
+- **Coder deployment URL**: for example `https://coder.example.com`
+- **AI Gateway base URLs**:
+  - OpenAI-compatible: `https://coder.example.com/api/v2/aibridge/openai/v1`
+  - Anthropic-compatible: `https://coder.example.com/api/v2/aibridge/anthropic`
+- **How to generate an API token**: link users to the Coder dashboard or
+  provide the CLI command (see below).
+
+### 5. Optional: disable BYOK
+
+By default AI Gateway allows users to bring their own LLM API keys. To
+require all traffic to use the centralized org key, disable BYOK:
+
+```sh
+coder server --aibridge-allow-byok=false
+```
+
+## User setup
+
+### 1. Generate a long-lived API token
+
+Create a token from the Coder dashboard or CLI. This token authenticates
+you with AI Gateway and does not require a workspace.
+
+<div class="tabs">
+
+#### Dashboard
+
+1. Navigate to `https://coder.example.com/settings/account`.
+1. Open the **Tokens** page in the sidebar.
+1. Click **Create token**, give it a name, and save the value.
+
+#### CLI
+
+```sh
+coder tokens create --name=ai-gateway --lifetime=720h
+```
+
+</div>
+
+See [Sessions and API tokens](../../admin/users/sessions-tokens.md#generate-a-long-lived-api-token-on-behalf-of-yourself)
+for more details on token management.
+
+### 2. Configure your AI tool
+
+Point your tool at the AI Gateway base URL and set the Coder API token as
+the authentication credential. The exact settings vary by tool.
+
+<div class="tabs">
+
+#### Claude Code
+
+```bash
+export ANTHROPIC_BASE_URL="https://coder.example.com/api/v2/aibridge/anthropic"
+export ANTHROPIC_AUTH_TOKEN="<your-coder-api-token>"
+```
+
+#### Codex CLI
+
+In `~/.codex/config.toml`:
+
+```toml
+model_provider = "aibridge"
+
+[model_providers.aibridge]
+name = "AI Bridge"
+base_url = "https://coder.example.com/api/v2/aibridge/openai/v1"
+env_key = "OPENAI_API_KEY"
+wire_api = "responses"
+```
+
+Then set the environment variable:
+
+```bash
+export OPENAI_API_KEY="<your-coder-api-token>"
+```
+
+#### Other tools
+
+For tools not listed here, the general pattern is:
+
+1. Set the base URL to `https://coder.example.com/api/v2/aibridge/openai/v1`
+   (OpenAI-compatible) or
+   `https://coder.example.com/api/v2/aibridge/anthropic`
+   (Anthropic-compatible).
+2. Set the API key to your Coder API token.
+
+See the [individual client pages](./clients/index.md#all-supported-clients)
+for tool-specific instructions.
+
+</div>
+
+Replace `coder.example.com` with your Coder deployment URL in all examples.
+
+### 3. Verify the connection
+
+Run a request through your tool. If authentication succeeds, the request
+appears in the [AI Gateway audit log](./audit.md). If you receive a `401`
+error, confirm your API token is valid. If you receive a `403`, BYOK may
+be disabled and the tool may be sending a personal LLM key instead of the
+Coder token.

--- a/docs/ai-coder/ai-gateway/external-clients.md
+++ b/docs/ai-coder/ai-gateway/external-clients.md
@@ -3,7 +3,7 @@
 AI Gateway does not require users to work inside Coder workspaces. AI coding
 tools running on a developer's local machine (IDE extensions, CLI tools,
 desktop applications) can route traffic through AI Gateway as long as the
-tool [supports AI Gateway](https://coder.com/docs/ai-coder/ai-gateway/clients#compatibility) and the user
+tool supports AI Gateway and the user
 can authenticate with a Coder API token. Not every client supports
 customizing the API base URL; see the
 [compatibility table](https://coder.com/docs/ai-coder/ai-gateway/clients#compatibility) for the current list.

--- a/docs/ai-coder/ai-gateway/external-clients.md
+++ b/docs/ai-coder/ai-gateway/external-clients.md
@@ -1,9 +1,12 @@
 # Using AI Gateway Without Workspaces
 
-AI Gateway does not require users to work inside Coder workspaces. Any AI
-coding tool running on a developer's local machine (IDE extensions, CLI tools,
-desktop applications) can route traffic through AI Gateway as long as the user
-can authenticate with a Coder API token.
+AI Gateway does not require users to work inside Coder workspaces. AI coding
+tools running on a developer's local machine (IDE extensions, CLI tools,
+desktop applications) can route traffic through AI Gateway as long as the
+tool [supports AI Gateway](./clients/index.md#compatibility) and the user
+can authenticate with a Coder API token. Not every client supports
+customizing the API base URL; see the
+[compatibility table](./clients/index.md#compatibility) for the current list.
 
 This page describes what administrators need to set up and what end users
 need to do to connect their local tools.

--- a/docs/ai-coder/ai-gateway/external-clients.md
+++ b/docs/ai-coder/ai-gateway/external-clients.md
@@ -73,10 +73,19 @@ coder tokens create \
 Distribute the resulting token to the external users along with the
 connection details from the next step.
 
-Because all users share one identity, AI Gateway audit logs attribute
-traffic to the service account rather than to individual developers.
-If per-user attribution matters, create a separate service account
-for each user or group.
+When every user shares a single token, AI Gateway audit logs attribute
+all traffic to the service account rather than to individual developers.
+There are two ways to get per-user attribution:
+
+- **One token per user from the same service account.** Generate a
+  separate named token for each developer (`--name=alice`,
+  `--name=bob`, etc.). Each token is logged as a distinct API key,
+  so audit records can be traced back to an individual even though
+  they all belong to the same account.
+- **One service account per user or group.** Create a dedicated
+  service account for each developer or team. This provides a
+  distinct user identity in audit logs but requires more accounts
+  to manage.
 
 ### 4. Share connection details
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1156,6 +1156,11 @@
 									]
 								},
 								{
+									"title": "Using AI Gateway Without Workspaces",
+									"description": "Connect local IDE extensions and desktop applications to AI Gateway",
+									"path": "./ai-coder/ai-gateway/external-clients.md"
+								},
+								{
 									"title": "MCP Tools Injection",
 									"description": "How to configure MCP servers for tools injection through AI Gateway",
 									"path": "./ai-coder/ai-gateway/mcp.md",


### PR DESCRIPTION
Adds a dedicated page documenting how to connect local AI coding tools to AI Gateway when users are not working inside Coder workspaces. The existing docs covered this in three sentences; the new page provides an end-to-end walkthrough split by audience.

**Admin setup**: enable AI Gateway, configure upstream providers, create Coder accounts for external users, share connection details, optionally disable BYOK.

**User setup**: generate a long-lived API token (dashboard or CLI), configure their tool with the base URL and token (tabbed examples for Claude Code, Codex CLI, and a generic pattern), verify the connection.

**Service account workaround**: for users who do not have individual Coder accounts, admins can create a service account and distribute its API token. This is documented as a temporary workaround; a dedicated authentication-only account tier is planned to replace it.

The previous "External and Desktop Clients" section in `clients/index.md` is replaced with a cross-reference to the new page.

> Generated by Coder Agents