### PR TITLE
fix(site/src/pages/TemplateVersionEditorPage): make Create Workspace button a link

### DIFF
--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.stories.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.stories.tsx
@@ -35,7 +35,7 @@ const meta: Meta<typeof TemplateVersionEditor> = {
 		onPublish: action("onPublish"),
 		onConfirmPublish: action("onConfirmPublish"),
 		onCancelPublish: action("onCancelPublish"),
-		onCreateWorkspace: action("onCreateWorkspace"),
+		createWorkspaceUrl: "/templates/default/test-template/workspace",
 		onSubmitMissingVariableValues: action("onSubmitMissingVariableValues"),
 		onCancelSubmitMissingVariableValues: action(
 			"onCancelSubmitMissingVariableValues",

--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditor.tsx
@@ -89,7 +89,7 @@ interface TemplateVersionEditorProps {
 	onCancelPublish: () => void;
 	publishingError?: unknown;
 	publishedVersion?: TemplateVersion;
-	onCreateWorkspace: () => void;
+	createWorkspaceUrl: string | undefined;
 	isAskingPublishParameters: boolean;
 	isPromptingMissingVariables: boolean;
 	isPublishing: boolean;
@@ -117,7 +117,7 @@ export const TemplateVersionEditor: FC<TemplateVersionEditorProps> = ({
 	isPublishing,
 	publishingError,
 	publishedVersion,
-	onCreateWorkspace,
+	createWorkspaceUrl,
 	buildLogs,
 	resources,
 	isPromptingMissingVariables,
@@ -307,8 +307,10 @@ export const TemplateVersionEditor: FC<TemplateVersionEditorProps> = ({
 								prominent
 								dismissible
 								actions={
-									<Button size="sm" onClick={onCreateWorkspace}>
-										Create a workspace
+									<Button asChild size="sm">
+										<RouterLink to={createWorkspaceUrl ?? ""}>
+											Create a workspace
+										</RouterLink>
 									</Button>
 								}
 							>

--- a/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditorPage.tsx
+++ b/site/src/pages/TemplateVersionEditorPage/TemplateVersionEditorPage.tsx
@@ -187,18 +187,16 @@ const TemplateVersionEditorPage: FC = () => {
 					isPublishing={publishVersionMutation.isPending}
 					publishingError={publishVersionMutation.error}
 					publishedVersion={lastSuccessfulPublishedVersion}
-					onCreateWorkspace={() => {
+					createWorkspaceUrl={(() => {
 						const params = new URLSearchParams();
 						const publishedVersion = lastSuccessfulPublishedVersion;
 						if (publishedVersion) {
 							params.set("version", publishedVersion.id);
 						}
-						navigate(
-							`${getLink(
-								linkToTemplate(organizationName, templateName),
-							)}/workspace?${params.toString()}`,
-						);
-					}}
+						return `${getLink(
+							linkToTemplate(organizationName, templateName),
+						)}/workspace?${params.toString()}`;
+					})()}
 					isBuilding={
 						createTemplateVersionMutation.isPending ||
 						uploadFileMutation.isPending ||


### PR DESCRIPTION
The "Create a workspace" button in the template publish success banner used an `onClick` handler with `navigate()`, rendering a plain `<button>`. Users could not right-click to open in a new tab.

Changed the prop from `onCreateWorkspace` callback to `createWorkspaceUrl` string and switched to `<Button asChild>` + `<RouterLink>`, rendering a proper `<a>` element that supports standard link interactions (right-click, middle-click, Ctrl+click).

Fixes https://github.com/coder/coder/issues/24802

> _This PR was authored by Coder Agents on behalf of @35C4n0r._