### PR TITLE
fix(site): remove clearStreamState from send path to prevent race

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -1352,11 +1352,14 @@ const AgentChatPage: FC = () => {
 			throw error;
 		}
 		// When the server accepts the message immediately (not
-		// queued), clear the stream and insert the user's message
-		// so it appears in the timeline without waiting for the
-		// WebSocket stream.
+		// queued), insert the user's message so it appears in
+		// the timeline without waiting for the WebSocket stream.
+		// Do not call clearStreamState here. The previous turn's
+		// state is already null by the time a non-queued send is
+		// possible, and clearing would wipe any stream content
+		// the WebSocket delivered while this REST call was in
+		// flight.
 		if (!response.queued) {
-			store.clearStreamState();
 			// Optimistically set status to "running" so the
 			// "Thinking..." indicator appears immediately.
 			// The server accepted the message (not queued),


### PR DESCRIPTION
`handleSend` calls `store.clearStreamState()` after `await sendMessage()`. With near-zero processing latency (since #23745 added `signalWake`), the WebSocket can deliver `status=running` and message parts before the REST response arrives. `clearStreamState` then wipes the accumulated stream content, causing a stuck "Thinking" indicator.

The call is always redundant for the previous turn: stream state is null by the time a non-queued send is possible (the durable message commit and `status=waiting` already cleared it via `needsStreamReset`).

The other two `clearStreamState` call sites in `AgentChatPage.tsx` (promote at L1108, edit at L1306) both run before their respective awaits, so they are not affected.

#24314 fixed the related Race 1 (stale pubsub pending) by removing `clearStreamState` from the status handler. #24659 adds backend defense-in-depth. This PR fixes the remaining Race 2.

Research: `docs/plans/chat-streaming-race-research.md` ("Race 2: REST response wipes in-progress stream")

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻