### PR TITLE
fix: record debug runs for proposed chat titles

### DIFF
--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -2236,7 +2236,7 @@ var ErrManualTitleRegenerationInProgress = xerrors.New(
 	"manual title regeneration already in progress",
 )
 
-type manualTitleResult struct {
+type manualTitleCandidateResult struct {
 	title       string
 	modelConfig database.ChatModelConfig
 	usage       fantasy.Usage
@@ -2490,14 +2490,17 @@ func (p *Server) recordManualTitleGenerationFailure(
 	return generationErr
 }
 
+// generateManualTitleCandidate performs only model generation and returns the
+// candidate plus accounting metadata. Endpoint-specific commit paths are
+// responsible for recording usage and deciding whether to persist the title.
 func (p *Server) generateManualTitleCandidate(
 	ctx context.Context,
 	store database.Store,
 	chat database.Chat,
 	keys chatprovider.ProviderAPIKeys,
-) (manualTitleResult, error) {
+) (manualTitleCandidateResult, error) {
 	if limitErr := p.checkUsageLimit(ctx, store, chat.OwnerID, uuid.NullUUID{UUID: chat.OrganizationID, Valid: true}); limitErr != nil {
-		return manualTitleResult{}, limitErr
+		return manualTitleCandidateResult{}, limitErr
 	}
 
 	headMessages, err := store.GetChatMessagesByChatIDAscPaginated(
@@ -2509,7 +2512,7 @@ func (p *Server) generateManualTitleCandidate(
 		},
 	)
 	if err != nil {
-		return manualTitleResult{}, xerrors.Errorf("get head chat messages: %w", err)
+		return manualTitleCandidateResult{}, xerrors.Errorf("get head chat messages: %w", err)
 	}
 	tailMessages, err := store.GetChatMessagesByChatIDDescPaginated(
 		ctx,
@@ -2520,15 +2523,15 @@ func (p *Server) generateManualTitleCandidate(
 		},
 	)
 	if err != nil {
-		return manualTitleResult{}, xerrors.Errorf("get tail chat messages: %w", err)
+		return manualTitleCandidateResult{}, xerrors.Errorf("get tail chat messages: %w", err)
 	}
 	messages := mergeManualTitleMessages(headMessages, tailMessages)
 	if len(messages) == 0 {
-		return manualTitleResult{}, nil
+		return manualTitleCandidateResult{}, nil
 	}
 
 	model, modelConfig, err := p.resolveManualTitleModel(ctx, store, chat, keys)
-	result := manualTitleResult{
+	result := manualTitleCandidateResult{
 		modelConfig: modelConfig,
 		hasMessages: true,
 	}

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -2236,6 +2236,13 @@ var ErrManualTitleRegenerationInProgress = xerrors.New(
 	"manual title regeneration already in progress",
 )
 
+type manualTitleResult struct {
+	title       string
+	modelConfig database.ChatModelConfig
+	usage       fantasy.Usage
+	hasMessages bool
+}
+
 type manualTitleGenerationError struct {
 	cause       error
 	modelConfig database.ChatModelConfig
@@ -2483,16 +2490,14 @@ func (p *Server) recordManualTitleGenerationFailure(
 	return generationErr
 }
 
-//nolint:revive // flag-parameter: enableDebug toggles optional debug capture on a shared code path; splitting would duplicate message fetch and model resolution.
-func (p *Server) fetchAndGenerateManualTitle(
+func (p *Server) generateManualTitleCandidate(
 	ctx context.Context,
 	store database.Store,
 	chat database.Chat,
 	keys chatprovider.ProviderAPIKeys,
-	enableDebug bool,
-) (title string, modelConfig database.ChatModelConfig, usage fantasy.Usage, hasMessages bool, err error) {
+) (manualTitleResult, error) {
 	if limitErr := p.checkUsageLimit(ctx, store, chat.OwnerID, uuid.NullUUID{UUID: chat.OrganizationID, Valid: true}); limitErr != nil {
-		return "", database.ChatModelConfig{}, fantasy.Usage{}, false, limitErr
+		return manualTitleResult{}, limitErr
 	}
 
 	headMessages, err := store.GetChatMessagesByChatIDAscPaginated(
@@ -2504,7 +2509,7 @@ func (p *Server) fetchAndGenerateManualTitle(
 		},
 	)
 	if err != nil {
-		return "", database.ChatModelConfig{}, fantasy.Usage{}, false, xerrors.Errorf("get head chat messages: %w", err)
+		return manualTitleResult{}, xerrors.Errorf("get head chat messages: %w", err)
 	}
 	tailMessages, err := store.GetChatMessagesByChatIDDescPaginated(
 		ctx,
@@ -2515,50 +2520,54 @@ func (p *Server) fetchAndGenerateManualTitle(
 		},
 	)
 	if err != nil {
-		return "", database.ChatModelConfig{}, fantasy.Usage{}, false, xerrors.Errorf("get tail chat messages: %w", err)
+		return manualTitleResult{}, xerrors.Errorf("get tail chat messages: %w", err)
 	}
 	messages := mergeManualTitleMessages(headMessages, tailMessages)
 	if len(messages) == 0 {
-		return "", database.ChatModelConfig{}, fantasy.Usage{}, false, nil
+		return manualTitleResult{}, nil
 	}
 
 	model, modelConfig, err := p.resolveManualTitleModel(ctx, store, chat, keys)
+	result := manualTitleResult{
+		modelConfig: modelConfig,
+		hasMessages: true,
+	}
 	if err != nil {
-		return "", database.ChatModelConfig{}, fantasy.Usage{}, true, err
+		return result, err
 	}
 
 	titleCtx := ctx
 	titleModel := model
 	finishDebugRun := func(error) {}
-	if enableDebug {
-		if debugSvc := p.debugService(); debugSvc != nil && debugSvc.IsEnabled(ctx, chat.ID, chat.OwnerID) {
-			titleCtx, titleModel, finishDebugRun = p.prepareManualTitleDebugRun(
-				ctx,
-				debugSvc,
-				chat,
-				modelConfig,
-				keys,
-				messages,
-				model,
-			)
-		}
+	if debugSvc := p.debugService(); debugSvc != nil && debugSvc.IsEnabled(ctx, chat.ID, chat.OwnerID) {
+		titleCtx, titleModel, finishDebugRun = p.prepareManualTitleDebugRun(
+			ctx,
+			debugSvc,
+			chat,
+			modelConfig,
+			keys,
+			messages,
+			model,
+		)
 	}
 
-	title, usage, err = generateManualTitle(titleCtx, messages, titleModel)
+	title, usage, err := generateManualTitle(titleCtx, messages, titleModel)
 	finishDebugRun(err)
+	result.title = title
+	result.usage = usage
 	if err != nil {
 		wrappedErr := xerrors.Errorf("generate manual title: %w", err)
 		if usage == (fantasy.Usage{}) {
-			return "", modelConfig, fantasy.Usage{}, true, wrappedErr
+			return result, wrappedErr
 		}
-		return "", modelConfig, usage, true, &manualTitleGenerationError{
+		return result, &manualTitleGenerationError{
 			cause:       wrappedErr,
 			modelConfig: modelConfig,
 			usage:       usage,
 		}
 	}
 
-	return title, modelConfig, usage, true, nil
+	return result, nil
 }
 
 func (p *Server) proposeChatTitleWithStore(
@@ -2567,11 +2576,11 @@ func (p *Server) proposeChatTitleWithStore(
 	chat database.Chat,
 	keys chatprovider.ProviderAPIKeys,
 ) (string, error) {
-	title, modelConfig, usage, hasMessages, err := p.fetchAndGenerateManualTitle(ctx, store, chat, keys, false)
+	result, err := p.generateManualTitleCandidate(ctx, store, chat, keys)
 	if err != nil {
 		return "", err
 	}
-	if !hasMessages {
+	if !result.hasMessages {
 		return "", nil
 	}
 
@@ -2581,13 +2590,13 @@ func (p *Server) proposeChatTitleWithStore(
 		recordCtx,
 		store,
 		chat,
-		modelConfig,
-		usage,
+		result.modelConfig,
+		result.usage,
 		"",
 	); recordErr != nil {
 		return "", xerrors.Errorf("record manual title usage: %w", recordErr)
 	}
-	return title, nil
+	return result.title, nil
 }
 
 func (p *Server) regenerateChatTitleWithStore(
@@ -2596,11 +2605,11 @@ func (p *Server) regenerateChatTitleWithStore(
 	chat database.Chat,
 	keys chatprovider.ProviderAPIKeys,
 ) (database.Chat, error) {
-	title, modelConfig, usage, hasMessages, err := p.fetchAndGenerateManualTitle(ctx, store, chat, keys, true)
+	result, err := p.generateManualTitleCandidate(ctx, store, chat, keys)
 	if err != nil {
 		return database.Chat{}, err
 	}
-	if !hasMessages {
+	if !result.hasMessages {
 		return chat, nil
 	}
 
@@ -2611,12 +2620,12 @@ func (p *Server) regenerateChatTitleWithStore(
 		recordCtx,
 		store,
 		chat,
-		modelConfig,
-		usage,
-		title,
+		result.modelConfig,
+		result.usage,
+		result.title,
 	)
 	if recordErr != nil {
-		if title != "" {
+		if result.title != "" {
 			return database.Chat{}, xerrors.Errorf("record manual title usage and update chat title: %w", recordErr)
 		}
 		return database.Chat{}, xerrors.Errorf("record manual title usage: %w", recordErr)

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -4847,12 +4847,14 @@ func TestAutoPromote_InsertFailureSkipsStatusUpdate(t *testing.T) {
 		heartbeatRegistry:     make(map[uuid.UUID]*heartbeatEntry),
 	}
 
-	// Block model resolution until the control subscriber fires.
+	// Block model resolution until the running status has been
+	// published. Returning ErrInterrupted makes processChat enter the
+	// waiting-state auto-promotion path deterministically.
 	modelBlocked := make(chan struct{})
 	db.EXPECT().GetChatModelConfigByID(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(ctx context.Context, _ uuid.UUID) (database.ChatModelConfig, error) {
+		func(context.Context, uuid.UUID) (database.ChatModelConfig, error) {
 			<-modelBlocked
-			return database.ChatModelConfig{}, xerrors.New("no model")
+			return database.ChatModelConfig{}, chatloop.ErrInterrupted
 		},
 	).AnyTimes()
 	db.EXPECT().GetEnabledChatProviders(gomock.Any()).Return(nil, nil).AnyTimes()
@@ -4914,15 +4916,6 @@ func TestAutoPromote_InsertFailureSkipsStatusUpdate(t *testing.T) {
 		t.Fatal("timed out waiting for running status")
 	}
 
-	// Publish an interrupt so processChat exits runChat.
-	interruptMsg, err := json.Marshal(coderdpubsub.ChatStreamNotifyMessage{
-		Status: string(database.ChatStatusWaiting),
-	})
-	require.NoError(t, err)
-	err = ps.Publish(coderdpubsub.ChatStreamNotifyChannel(chatID), interruptMsg)
-	require.NoError(t, err)
-
-	// Unblock model resolution so runChat can exit.
 	close(modelBlocked)
 
 	select {

--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -5859,6 +5859,116 @@ func newActiveTestServer(
 	return server
 }
 
+func TestProposeChatTitle_DebugRun(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                    string
+		alwaysEnableDebugLogs   bool
+		wantTitleGenerationRuns int
+	}{
+		{
+			name:                    "Enabled",
+			alwaysEnableDebugLogs:   true,
+			wantTitleGenerationRuns: 1,
+		},
+		{
+			name:                    "Disabled",
+			alwaysEnableDebugLogs:   false,
+			wantTitleGenerationRuns: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := testutil.Context(t, testutil.WaitLong)
+			db, ps := dbtestutil.NewDB(t)
+			wantTitle := "Debug proposal title"
+			openAIURL := chattest.NewOpenAI(t, func(req *chattest.OpenAIRequest) chattest.OpenAIResponse {
+				require.False(t, req.Stream)
+				return chattest.OpenAINonStreamingResponse(
+					"{\"title\":\"" + wantTitle + "\"}",
+				)
+			})
+			user, org, model := seedChatDependenciesWithProvider(
+				ctx,
+				t,
+				db,
+				"openai",
+				openAIURL,
+			)
+			server := chatd.New(chatd.Config{
+				Logger:                     slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+				Database:                   db,
+				ReplicaID:                  uuid.New(),
+				Pubsub:                     ps,
+				PendingChatAcquireInterval: testutil.WaitLong,
+				AlwaysEnableDebugLogs:      tt.alwaysEnableDebugLogs,
+			})
+			t.Cleanup(func() {
+				require.NoError(t, server.Close())
+			})
+
+			chat, err := db.InsertChat(ctx, database.InsertChatParams{
+				OrganizationID:    org.ID,
+				Status:            database.ChatStatusCompleted,
+				ClientType:        database.ChatClientTypeUi,
+				OwnerID:           user.ID,
+				Title:             "original title",
+				LastModelConfigID: model.ID,
+			})
+			require.NoError(t, err)
+			content, err := chatprompt.MarshalParts([]codersdk.ChatMessagePart{
+				codersdk.ChatMessageText("summarize debug title generation"),
+			})
+			require.NoError(t, err)
+			messages, err := db.InsertChatMessages(ctx, database.InsertChatMessagesParams{
+				ChatID:              chat.ID,
+				CreatedBy:           []uuid.UUID{user.ID},
+				ModelConfigID:       []uuid.UUID{model.ID},
+				Role:                []database.ChatMessageRole{database.ChatMessageRoleUser},
+				Content:             []string{string(content.RawMessage)},
+				ContentVersion:      []int16{chatprompt.CurrentContentVersion},
+				Visibility:          []database.ChatMessageVisibility{database.ChatMessageVisibilityBoth},
+				InputTokens:         []int64{0},
+				OutputTokens:        []int64{0},
+				TotalTokens:         []int64{0},
+				ReasoningTokens:     []int64{0},
+				CacheCreationTokens: []int64{0},
+				CacheReadTokens:     []int64{0},
+				ContextLimit:        []int64{model.ContextLimit},
+				Compressed:          []bool{false},
+				TotalCostMicros:     []int64{0},
+				RuntimeMs:           []int64{0},
+				ProviderResponseID:  []string{""},
+			})
+			require.NoError(t, err)
+			require.Len(t, messages, 1)
+
+			gotTitle, err := server.ProposeChatTitle(ctx, chat)
+			require.NoError(t, err)
+			require.Equal(t, wantTitle, gotTitle)
+
+			runs, err := db.GetChatDebugRunsByChatID(ctx, database.GetChatDebugRunsByChatIDParams{
+				ChatID:   chat.ID,
+				LimitVal: 100,
+			})
+			require.NoError(t, err)
+			require.Len(t, runs, tt.wantTitleGenerationRuns)
+			if tt.wantTitleGenerationRuns == 0 {
+				return
+			}
+			require.Equal(t, string(codersdk.ChatDebugRunKindTitleGeneration), runs[0].Kind)
+			require.Equal(t, string(codersdk.ChatDebugStatusCompleted), runs[0].Status)
+			require.True(t, runs[0].FinishedAt.Valid)
+			require.True(t, runs[0].HistoryTipMessageID.Valid)
+			require.Equal(t, messages[0].ID, runs[0].HistoryTipMessageID.Int64)
+		})
+	}
+}
+
 func seedChatDependencies(
 	ctx context.Context,
 	t *testing.T,

--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -6184,14 +6184,14 @@ func insertUserTextMessage(
 	userID uuid.UUID,
 	modelConfigID uuid.UUID,
 	text string,
-	contextLimits ...int64,
+	contextLimit ...int64,
 ) []database.ChatMessage {
 	t.Helper()
-	require.LessOrEqual(t, len(contextLimits), 1)
+	require.LessOrEqual(t, len(contextLimit), 1)
 
-	contextLimit := int64(0)
-	if len(contextLimits) == 1 {
-		contextLimit = contextLimits[0]
+	contextLimitValue := int64(0)
+	if len(contextLimit) == 1 {
+		contextLimitValue = contextLimit[0]
 	}
 	content, err := chatprompt.MarshalParts([]codersdk.ChatMessagePart{codersdk.ChatMessageText(text)})
 	require.NoError(t, err)
@@ -6210,7 +6210,7 @@ func insertUserTextMessage(
 		ReasoningTokens:     []int64{0},
 		CacheCreationTokens: []int64{0},
 		CacheReadTokens:     []int64{0},
-		ContextLimit:        []int64{contextLimit},
+		ContextLimit:        []int64{contextLimitValue},
 		Compressed:          []bool{false},
 		TotalCostMicros:     []int64{0},
 		RuntimeMs:           []int64{0},

--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -5862,20 +5862,47 @@ func newActiveTestServer(
 func TestProposeChatTitle_DebugRun(t *testing.T) {
 	t.Parallel()
 
+	wantTitle := "Debug proposal title"
 	tests := []struct {
 		name                    string
 		alwaysEnableDebugLogs   bool
+		response                func() chattest.OpenAIResponse
+		wantErr                 bool
+		wantTitle               string
 		wantTitleGenerationRuns int
+		wantDebugStatus         codersdk.ChatDebugStatus
 	}{
 		{
-			name:                    "Enabled",
-			alwaysEnableDebugLogs:   true,
+			name:                  "Enabled",
+			alwaysEnableDebugLogs: true,
+			response: func() chattest.OpenAIResponse {
+				return chattest.OpenAINonStreamingResponse(
+					"{\"title\":\"" + wantTitle + "\"}",
+				)
+			},
+			wantTitle:               wantTitle,
 			wantTitleGenerationRuns: 1,
+			wantDebugStatus:         codersdk.ChatDebugStatusCompleted,
 		},
 		{
-			name:                    "Disabled",
-			alwaysEnableDebugLogs:   false,
-			wantTitleGenerationRuns: 0,
+			name:                  "Disabled",
+			alwaysEnableDebugLogs: false,
+			response: func() chattest.OpenAIResponse {
+				return chattest.OpenAINonStreamingResponse(
+					"{\"title\":\"" + wantTitle + "\"}",
+				)
+			},
+			wantTitle: wantTitle,
+		},
+		{
+			name:                  "GenerationErrorFinalizesDebugRun",
+			alwaysEnableDebugLogs: true,
+			response: func() chattest.OpenAIResponse {
+				return chattest.OpenAINonStreamingResponse("not json")
+			},
+			wantErr:                 true,
+			wantTitleGenerationRuns: 1,
+			wantDebugStatus:         codersdk.ChatDebugStatusError,
 		},
 	}
 
@@ -5884,13 +5911,10 @@ func TestProposeChatTitle_DebugRun(t *testing.T) {
 			t.Parallel()
 
 			ctx := testutil.Context(t, testutil.WaitLong)
-			db, ps := dbtestutil.NewDB(t)
-			wantTitle := "Debug proposal title"
+			db, ps, rawDB := dbtestutil.NewDBWithSQLDB(t)
 			openAIURL := chattest.NewOpenAI(t, func(req *chattest.OpenAIRequest) chattest.OpenAIResponse {
 				require.False(t, req.Stream)
-				return chattest.OpenAINonStreamingResponse(
-					"{\"title\":\"" + wantTitle + "\"}",
-				)
+				return tt.response()
 			})
 			user, org, model := seedChatDependenciesWithProvider(
 				ctx,
@@ -5920,36 +5944,25 @@ func TestProposeChatTitle_DebugRun(t *testing.T) {
 				LastModelConfigID: model.ID,
 			})
 			require.NoError(t, err)
-			content, err := chatprompt.MarshalParts([]codersdk.ChatMessagePart{
-				codersdk.ChatMessageText("summarize debug title generation"),
-			})
-			require.NoError(t, err)
-			messages, err := db.InsertChatMessages(ctx, database.InsertChatMessagesParams{
-				ChatID:              chat.ID,
-				CreatedBy:           []uuid.UUID{user.ID},
-				ModelConfigID:       []uuid.UUID{model.ID},
-				Role:                []database.ChatMessageRole{database.ChatMessageRoleUser},
-				Content:             []string{string(content.RawMessage)},
-				ContentVersion:      []int16{chatprompt.CurrentContentVersion},
-				Visibility:          []database.ChatMessageVisibility{database.ChatMessageVisibilityBoth},
-				InputTokens:         []int64{0},
-				OutputTokens:        []int64{0},
-				TotalTokens:         []int64{0},
-				ReasoningTokens:     []int64{0},
-				CacheCreationTokens: []int64{0},
-				CacheReadTokens:     []int64{0},
-				ContextLimit:        []int64{model.ContextLimit},
-				Compressed:          []bool{false},
-				TotalCostMicros:     []int64{0},
-				RuntimeMs:           []int64{0},
-				ProviderResponseID:  []string{""},
-			})
-			require.NoError(t, err)
+			messages := insertUserTextMessage(
+				ctx,
+				t,
+				db,
+				chat.ID,
+				user.ID,
+				model.ID,
+				"summarize debug title generation",
+				model.ContextLimit,
+			)
 			require.Len(t, messages, 1)
 
 			gotTitle, err := server.ProposeChatTitle(ctx, chat)
-			require.NoError(t, err)
-			require.Equal(t, wantTitle, gotTitle)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.wantTitle, gotTitle)
+			}
 
 			runs, err := db.GetChatDebugRunsByChatID(ctx, database.GetChatDebugRunsByChatIDParams{
 				ChatID:   chat.ID,
@@ -5957,14 +5970,23 @@ func TestProposeChatTitle_DebugRun(t *testing.T) {
 			})
 			require.NoError(t, err)
 			require.Len(t, runs, tt.wantTitleGenerationRuns)
-			if tt.wantTitleGenerationRuns == 0 {
-				return
+			if tt.wantTitleGenerationRuns > 0 {
+				require.Equal(t, string(codersdk.ChatDebugRunKindTitleGeneration), runs[0].Kind)
+				require.Equal(t, string(tt.wantDebugStatus), runs[0].Status)
+				require.True(t, runs[0].FinishedAt.Valid)
+				require.True(t, runs[0].HistoryTipMessageID.Valid)
+				require.Equal(t, messages[0].ID, runs[0].HistoryTipMessageID.Int64)
 			}
-			require.Equal(t, string(codersdk.ChatDebugRunKindTitleGeneration), runs[0].Kind)
-			require.Equal(t, string(codersdk.ChatDebugStatusCompleted), runs[0].Status)
-			require.True(t, runs[0].FinishedAt.Valid)
-			require.True(t, runs[0].HistoryTipMessageID.Valid)
-			require.Equal(t, messages[0].ID, runs[0].HistoryTipMessageID.Int64)
+			if !tt.wantErr {
+				var usageMessages int
+				err = rawDB.QueryRowContext(
+					ctx,
+					`SELECT count(*) FROM chat_messages WHERE chat_id = $1 AND visibility = 'model' AND deleted = true`,
+					chat.ID,
+				).Scan(&usageMessages)
+				require.NoError(t, err)
+				require.Equal(t, 1, usageMessages)
+			}
 		})
 	}
 }
@@ -6162,13 +6184,19 @@ func insertUserTextMessage(
 	userID uuid.UUID,
 	modelConfigID uuid.UUID,
 	text string,
-) {
+	contextLimits ...int64,
+) []database.ChatMessage {
 	t.Helper()
+	require.LessOrEqual(t, len(contextLimits), 1)
 
+	contextLimit := int64(0)
+	if len(contextLimits) == 1 {
+		contextLimit = contextLimits[0]
+	}
 	content, err := chatprompt.MarshalParts([]codersdk.ChatMessagePart{codersdk.ChatMessageText(text)})
 	require.NoError(t, err)
 
-	_, err = db.InsertChatMessages(ctx, database.InsertChatMessagesParams{
+	messages, err := db.InsertChatMessages(ctx, database.InsertChatMessagesParams{
 		ChatID:              chatID,
 		CreatedBy:           []uuid.UUID{userID},
 		ModelConfigID:       []uuid.UUID{modelConfigID},
@@ -6182,13 +6210,14 @@ func insertUserTextMessage(
 		ReasoningTokens:     []int64{0},
 		CacheCreationTokens: []int64{0},
 		CacheReadTokens:     []int64{0},
-		ContextLimit:        []int64{0},
+		ContextLimit:        []int64{contextLimit},
 		Compressed:          []bool{false},
 		TotalCostMicros:     []int64{0},
 		RuntimeMs:           []int64{0},
 		ProviderResponseID:  []string{""},
 	})
 	require.NoError(t, err)
+	return messages
 }
 
 // seedWorkspaceWithAgent creates a full workspace chain with a connected

--- a/site/src/api/queries/chats.test.ts
+++ b/site/src/api/queries/chats.test.ts
@@ -30,6 +30,7 @@ import {
 	paginatedChatCostUsers,
 	pinChat,
 	promoteChatQueuedMessage,
+	proposeChatTitle,
 	regenerateChatTitle,
 	removeChildFromParentInCache,
 	reorderPinnedChat,
@@ -54,6 +55,7 @@ vi.mock("#/api/api", () => ({
 			editChatMessage: vi.fn(),
 			interruptChat: vi.fn(),
 			promoteChatQueuedMessage: vi.fn(),
+			proposeChatTitle: vi.fn(),
 			regenerateChatTitle: vi.fn(),
 		},
 	},
@@ -1292,6 +1294,39 @@ describe("mutation invalidation scope", () => {
 			).not.toBe(true);
 		}
 	});
+
+	for (const { label, error } of [
+		{ label: "success", error: undefined },
+		{ label: "failure", error: new Error("proposal failed") },
+	]) {
+		it(`proposeChatTitle invalidates debug runs on ${label} without touching unrelated queries`, async () => {
+			const queryClient = createTestQueryClient();
+			const chatId = "chat-1";
+			seedAllActiveQueries(queryClient, chatId);
+
+			const mutation = proposeChatTitle(queryClient);
+			await mutation.onSettled(undefined, error, chatId);
+
+			expect(
+				queryClient.getQueryState(chatDebugRunsKey(chatId))?.isInvalidated,
+				"chatDebugRunsKey should be invalidated",
+			).toBe(true);
+
+			for (const { label, key } of [
+				{ label: "flat chats", key: chatsKey },
+				{ label: "infinite chats", key: [...chatsKey, { archived: false }] },
+				{ label: "chat detail", key: chatKey(chatId) },
+				{ label: "messages", key: chatMessagesKey(chatId) },
+				...unrelatedKeys(chatId),
+			]) {
+				const state = queryClient.getQueryState(key);
+				expect(
+					state?.isInvalidated,
+					`${label} should NOT be invalidated by proposeChatTitle`,
+				).not.toBe(true);
+			}
+		});
+	}
 
 	it("createChat invalidates only sidebar queries on success", async () => {
 		const queryClient = createTestQueryClient();

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -1005,12 +1005,12 @@ export const regenerateChatTitle = (queryClient: QueryClient) => ({
 export const proposeChatTitle = (queryClient: QueryClient) => ({
 	mutationFn: (chatId: string) => API.experimental.proposeChatTitle(chatId),
 
-	onSettled: async (
+	onSettled: (
 		_data: { title: string } | undefined,
 		_error: unknown,
 		chatId: string,
 	) => {
-		await invalidateChatDebugRuns(queryClient, chatId);
+		void invalidateChatDebugRuns(queryClient, chatId);
 	},
 });
 

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -1002,6 +1002,18 @@ export const regenerateChatTitle = (queryClient: QueryClient) => ({
 	},
 });
 
+export const proposeChatTitle = (queryClient: QueryClient) => ({
+	mutationFn: (chatId: string) => API.experimental.proposeChatTitle(chatId),
+
+	onSettled: async (
+		_data: { title: string } | undefined,
+		_error: unknown,
+		chatId: string,
+	) => {
+		await invalidateChatDebugRuns(queryClient, chatId);
+	},
+});
+
 type UpdateChatTitleVariables = {
 	chatId: string;
 	title: string;

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -23,6 +23,7 @@ import {
 	mergeWatchedChatIntoCaches,
 	pinChat,
 	prependToInfiniteChatsCache,
+	proposeChatTitle,
 	readInfiniteChatsCache,
 	regenerateChatTitle,
 	removeChildFromParentInCache,
@@ -252,6 +253,7 @@ const AgentsPage: FC = () => {
 			toast.error(getErrorMessage(error, "Failed to rename chat."));
 		},
 	});
+	const proposeTitleMutation = useMutation(proposeChatTitle(queryClient));
 	const regeneratingTitleChatIdsRef = useRef<ReadonlySet<string>>(new Set());
 	const [regeneratingTitleChatIds, setRegeneratingTitleChatIds] = useState<
 		readonly string[]
@@ -438,7 +440,7 @@ const AgentsPage: FC = () => {
 		return promise;
 	};
 	const requestProposeTitle = async (chatId: string): Promise<string> => {
-		const result = await API.experimental.proposeChatTitle(chatId);
+		const result = await proposeTitleMutation.mutateAsync(chatId);
 		return result.title;
 	};
 	const requestRenameTitle = async (chatId: string, title: string) => {

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -247,13 +247,13 @@ const AgentsPage: FC = () => {
 			toast.error(getErrorMessage(error, "Failed to generate new title."));
 		},
 	});
+	const proposeTitleMutation = useMutation(proposeChatTitle(queryClient));
 	const renameTitleMutation = useMutation({
 		...updateChatTitle(queryClient),
 		onError: (error: unknown) => {
 			toast.error(getErrorMessage(error, "Failed to rename chat."));
 		},
 	});
-	const proposeTitleMutation = useMutation(proposeChatTitle(queryClient));
 	const regeneratingTitleChatIdsRef = useRef<ReadonlySet<string>>(new Set());
 	const [regeneratingTitleChatIds, setRegeneratingTitleChatIds] = useState<
 		readonly string[]


### PR DESCRIPTION
## Summary

- Share manual chat title candidate generation between title proposal and regeneration.
- Capture title-generation debug runs for proposed titles when chat debug logging is enabled.
- Invalidate chat debug runs from the rename-dialog Generate flow on success and failure without blocking title proposal UX.
- Stabilize the auto-promote interrupt test that failed in CI while validating this PR.

## Testing

- `go test ./coderd/x/chatd -run TestAutoPromote_InsertFailureSkipsStatusUpdate -count=20`
- `go test ./coderd/x/chatd -run 'TestAutoPromote_InsertFailureSkipsStatusUpdate|TestRegenerateChatTitle_PersistsAndBroadcasts|TestProposeChatTitle_DebugRun' -count=1`
- `go test ./coderd -run 'TestProposeChatTitle|TestRegenerateChatTitle' -count=1`
- `pnpm -C site test -- src/api/queries/chats.test.ts`
- `pnpm -C site exec biome format --write src/api/queries/chats.ts src/api/queries/chats.test.ts src/pages/AgentsPage/AgentsPage.tsx`
- `pnpm -C site exec biome check --error-on-warnings src/api/queries/chats.ts src/api/queries/chats.test.ts src/pages/AgentsPage/AgentsPage.tsx`
- `pnpm -C site run lint:types`
- `make fmt`
- `make lint`

---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: Unify manual chat title proposal and regeneration

## Goal

Refactor manual chat title generation so the UI rename-dialog **Generate** flow
and the direct **Regenerate title** flow share the same internal generation
path, while preserving their different commit behavior:

- `propose` generates a candidate title, records usage, returns the candidate,
  and does not persist the title.
- `regenerate` generates a candidate title through the same path, records usage,
  persists the generated title, publishes the title-change event when needed,
  and returns the updated chat.

This should fix the current debug-panel gap where `/title/propose` bypasses
manual title debug capture even though it performs the same model generation as
`/title/regenerate`.

## Evidence gathered

- Frontend rename dialog Generate calls `onPropose(chat.id)` in
  `site/src/pages/AgentsPage/components/Sidebar/RenameChatDialog.tsx`.
- `site/src/pages/AgentsPage/AgentsPage.tsx` implements that as
  `API.experimental.proposeChatTitle(chatId)` via `requestProposeTitle`.
- `site/src/api/api.ts` maps proposal to
  `/api/experimental/chats/${chatId}/title/propose` and regeneration to
  `/api/experimental/chats/${chatId}/title/regenerate`.
- Backend HTTP handlers live in `coderd/exp_chats.go`:
  - `proposeChatTitle` calls `api.chatDaemon.ProposeChatTitle`.
  - `regenerateChatTitle` calls `api.chatDaemon.RegenerateChatTitle`.
- In `coderd/x/chatd/chatd.go`, both internal paths already share
  `fetchAndGenerateManualTitle`, but with different debug behavior:
  - `proposeChatTitleWithStore` calls
    `fetchAndGenerateManualTitle(ctx, store, chat, keys, false)`.
  - `regenerateChatTitleWithStore` calls
    `fetchAndGenerateManualTitle(ctx, store, chat, keys, true)`.
- `fetchAndGenerateManualTitle` only calls `prepareManualTitleDebugRun` when
  `enableDebug` is true, so `/title/propose` never creates or finalizes a
  `title_generation` debug run.
- `regenerateChatTitle` frontend cache logic already invalidates chat debug runs
  in `site/src/api/queries/chats.ts`; `proposeChatTitle` currently bypasses that
  mutation/query invalidation path.

## Design direction

Use one shared lower-level generation helper, not a public-method call chain.
`RegenerateChatTitle` should not literally call `ProposeChatTitle`, because the
public propose method already handles locking, usage recording, failure
accounting, and returns only a string. Calling it directly from regenerate would
risk double accounting, lock-boundary issues, and loss of model/usage metadata.

Instead, split the backend flow into two explicit phases:

1. **Generate candidate**: shared by propose and regenerate.
2. **Commit result**: endpoint-specific behavior.

## Backend implementation plan

### 1. Introduce a small result type

In `coderd/x/chatd/chatd.go`, add an internal result type near the manual title
helpers:

```go
type manualTitleResult struct {
	title       string
	modelConfig database.ChatModelConfig
	usage       fantasy.Usage
	hasMessages bool
}
```

Keep the type unexported and narrowly scoped to the manual title helpers.

### 2. Replace the boolean-gated helper with a shared candidate generator

Refactor `fetchAndGenerateManualTitle` into a helper with intent in the name,
for example:

```go
func (p *Server) generateManualTitleCandidate(
	ctx context.Context,
	store database.Store,
	chat database.Chat,
	keys chatprovider.ProviderAPIKeys,
) (manualTitleResult, error)
```

This helper should keep the existing behavior from `fetchAndGenerateManualTitle`:

- Check usage limits with `p.checkUsageLimit`.
- Fetch head and tail messages using the existing manual title message window.
- Merge messages with `mergeManualTitleMessages`.
- Return `hasMessages=false` when there are no messages.
- Resolve the manual title model with `p.resolveManualTitleModel`.
- Prepare debug recording when the debug service is enabled.
- Call `generateManualTitle`.
- Call `finishDebugRun(err)` exactly once after generation, using the original
  generation error before wrapping and before usage or persistence work.
- Wrap generation failures as `generate manual title: %w`.
- Preserve `manualTitleGenerationError` behavior when usage is available, so
  failure accounting through `recordManualTitleGenerationFailure` still works.
- Do not call `recordManualTitleUsage`; usage recording belongs only in the
  endpoint-specific commit path.

Remove the endpoint-controlled `enableDebug` boolean. The only debug gate should
be the existing runtime policy:

```go
if debugSvc := p.debugService(); debugSvc != nil &&
	debugSvc.IsEnabled(ctx, chat.ID, chat.OwnerID) {
	// prepareManualTitleDebugRun(...)
}
```

This makes proposal and regeneration consistent while still respecting global,
admin, and user debug-log settings.

### 3. Keep `proposeChatTitleWithStore` as the non-persisting commit path

Update `proposeChatTitleWithStore` to call `generateManualTitleCandidate` and
then record usage without updating the title:

```go
result, err := p.generateManualTitleCandidate(ctx, store, chat, keys)
if err != nil {
	return "", err
}
if !result.hasMessages {
	return "", nil
}

_, recordErr := recordManualTitleUsage(
	recordCtx,
	store,
	chat,
	result.modelConfig,
	result.usage,
	"",
)
```

Preserve the existing response behavior: return only `result.title` and do not
persist the title or bump `updated_at`.

### 4. Keep `regenerateChatTitleWithStore` as the persisting commit path

Update `regenerateChatTitleWithStore` to call the same candidate helper and then
record usage while updating the title:

```go
result, err := p.generateManualTitleCandidate(ctx, store, chat, keys)
if err != nil {
	return database.Chat{}, err
}
if !result.hasMessages {
	return chat, nil
}

updatedChat, recordErr := recordManualTitleUsage(
	recordCtx,
	store,
	chat,
	result.modelConfig,
	result.usage,
	result.title,
)
```

Preserve existing behavior:

- Return the original chat when there are no messages.
- Return the same error strings for record/update failures where possible.
- Publish `codersdk.ChatWatchEventKindTitleChange` only when the persisted title
  differs from the previous title.
- Return the updated chat.

### 5. Preserve outer locking and failure accounting

Do not move manual title locks out of the public methods unless tests reveal a
specific need. Preserve current boundaries:

- `ProposeChatTitle` resolves keys, acquires/releases the manual title lock,
  delegates to `proposeChatTitleWithStore`, and uses
  `recordManualTitleGenerationFailure` on errors.
- `RegenerateChatTitle` resolves keys, acquires/releases the manual title lock,
  delegates to `regenerateChatTitleWithStore`, and uses existing failure
  handling.

This avoids changing concurrency semantics while still unifying generation.

## Frontend implementation plan

### 1. Add a query-aware proposal mutation

In `site/src/api/queries/chats.ts`, add a mutation helper for proposal, or route
`requestProposeTitle` through equivalent query logic:

- Mutation function: `API.experimental.proposeChatTitle(chatId)`.
- On settle, for both success and failure: invalidate `chatDebugRunsKey(chatId)`
  via the existing `invalidateChatDebugRuns` helper. Failed title generations are
  often the runs users need to inspect.
- Avoid invalidating unrelated chat queries unless the current UX needs it,
  because proposal does not persist title changes.

### 2. Use the proposal mutation from `AgentsPage`

In `site/src/pages/AgentsPage/AgentsPage.tsx`, replace the direct
`API.experimental.proposeChatTitle(chatId)` call with the query-aware mutation.
Keep the return value as `result.title` so the rename dialog behavior does not
change.

## Tests

### Backend tests

Update or add tests near the existing chat title tests:

- `coderd/exp_chats_test.go`
  - Keep `TestProposeChatTitle/DoesNotPersistTitleOrBumpUpdatedAt` passing.
  - Add coverage that proposal still returns a generated title when model
    generation succeeds, if practical with existing helpers.
- `coderd/x/chatd/chatd_internal_test.go`
  - Add or update a focused test that `ProposeChatTitle` creates/finalizes a
    `title_generation` debug run when debug logging is enabled.
  - Add disabled-debug coverage proving `ProposeChatTitle` does not create a
    debug run when debug logging is disabled.
  - Keep regeneration tests proving it persists the title and broadcasts
    `ChatWatchEventKindTitleChange`.
  - Add failure coverage if existing test utilities make it straightforward:
    generation failure should finalize the debug run with failure status and
    preserve `recordManualTitleGenerationFailure` behavior.
- Guard against double accounting by asserting the manual title usage recording
  path runs once per successful proposal or regeneration in mock-based tests.

### Frontend tests

Update `site/src/api/queries/chats.test.ts`:

- Add a `proposeChatTitle` cache invalidation test mirroring the existing
  `regenerateChatTitle invalidates debug runs so the title_generation run
  surfaces immediately` test.
- Confirm unrelated query keys are not invalidated by proposal.

Update Storybook interaction coverage only if UI behavior changes. The current
rename dialog UI should remain unchanged, so existing stories should still pass.

## Validation commands

Run focused checks first:

```sh
make test RUN='TestProposeChatTitle|TestRegenerateChatTitle'
make test RUN='TestRegenerateChatTitle_PersistsAndBroadcasts|TestProposeChatTitle'
```

Run frontend checks scoped to the touched query tests. Use the repository's
existing package scripts after confirming the exact command in `package.json` or
site scripts, for example the relevant `pnpm`/Vitest invocation for
`site/src/api/queries/chats.test.ts`.

Then run required broader validation for touched code:

```sh
make fmt
make lint
```

If Go or generated API types change, run the repository-required generation step
before linting. This refactor should not require database or SDK generation if
no API contracts change.

## Dogfooding and quality gates

### Backend quality gates

After backend tests pass:

1. Start the development environment with the repository-supported command:

   ```sh
   ./scripts/develop.sh
   ```

2. Enable chat debug logging for the test user or deployment.
3. Create or open an agent chat with existing messages.
4. Use the rename dialog's Generate button.
5. Confirm the proposed title appears in the input and the persisted chat title
   has not changed yet.
6. Open the debug panel and confirm a new `title_generation` run appears.
7. Save the proposed title and confirm this save does not create a second title
   generation run.
8. Use the direct Regenerate title action.
9. Confirm exactly one additional `title_generation` run appears and the visible
   chat title updates.

### Visual evidence for reviewers

Use `agent-browser` or equivalent browser automation during dogfooding and
capture:

- Screenshot before clicking Generate in the rename dialog.
- Screenshot after the generated title appears in the input.
- Screenshot of the debug panel showing the proposal `title_generation` run.
- Screenshot after direct Regenerate updates the visible title.
- A short screen recording covering Generate, debug-panel verification, Save,
  and direct Regenerate.

Attach screenshots and recording to the final implementation summary or PR notes
if a PR is requested.

## Advisor review incorporated

Advisor review agreed with the shared generation helper and separate commit
paths, with these refinements incorporated into this plan:

- Finalize debug runs immediately after model generation with the original
  generation error, before wrapping and before usage or persistence work.
- Treat debug runs as model-call observability; later usage-recording or title
  persistence failures should not retroactively change generation status.
- Add disabled-debug test coverage for `/title/propose` after removing the
  endpoint-level `enableDebug` bypass.
- Invalidate proposal debug runs on both success and failure.
- Keep generation pure: no usage recording inside the shared candidate helper.
- Preserve existing failure accounting behavior instead of broadening it as part
  of this refactor.

## Acceptance criteria

- Proposal and regeneration share one internal manual title generation helper.
- There is no endpoint-level `enableDebug=false` bypass for manual title model
  calls.
- `/title/propose` records and finalizes debug runs when chat debug logging is
  enabled.
- `/title/regenerate` continues to record and finalize debug runs when chat debug
  logging is enabled.
- `/title/propose` does not persist the generated title or bump `updated_at`.
- `/title/regenerate` persists the generated title and publishes a title-change
  event only when the title changes.
- Manual title usage is recorded exactly once for each successful proposal or
  regeneration.
- Generation failures preserve the existing client-facing error behavior and
  failure accounting.
- The rename-dialog Generate flow invalidates chat debug runs so the debug panel
  can show the new run without a full page reload.

## Risks and mitigations

- **Risk: accidental title persistence from proposal.** Keep proposal commit code
  passing an empty title to `recordManualTitleUsage`; keep/update the existing
  `DoesNotPersistTitleOrBumpUpdatedAt` test.
- **Risk: double usage recording.** Keep generation pure with respect to usage
  persistence; only commit helpers should call `recordManualTitleUsage`.
- **Risk: lock semantics change.** Do not move the public lock acquire/release
  boundaries in this refactor.
- **Risk: debug runs created when disabled.** Keep `debugSvc.IsEnabled` as the
  only debug capture gate and test both enabled and disabled behavior where
  practical.
- **Risk: debug panel still does not refresh.** Add frontend invalidation for the
  proposal flow, not just backend debug run creation.
- **Risk: debug run status may not match the whole HTTP request status.** Debug
  runs represent model-generation status, not later usage-recording or
  title-persistence status. Preserve current semantics by finalizing immediately
  after generation with the original generation error.
- **Risk: increased debug data from proposal clicks.** Enabling debug capture for
  `/title/propose` means rename-dialog Generate can store title-generation
  prompts and responses when debug logging is enabled. This is desired for
  observability and consistent with regeneration, but proposal may be clicked
  more often than direct regeneration.


</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.5` • Thinking: `xhigh`_
