### PR TITLE
fix(cli): use app slug instead of raw command in terminal URLs

### DIFF
--- a/cli/open.go
+++ b/cli/open.go
@@ -645,7 +645,10 @@ func buildAppLinkURL(baseURL *url.URL, workspace codersdk.Workspace, agent coder
 		agent.Name,
 		url.PathEscape(app.Slug),
 	)
-	// The frontend leaves the returns a relative URL for the terminal, but we don't have that luxury.
+	// Pass the app slug instead of the raw command. The terminal
+	// page resolves the command from the workspace agent's app
+	// list, which lets it skip the confirmation dialog for
+	// trusted, admin-configured template apps.
 	if app.Command != "" {
 		u.Path = fmt.Sprintf(
 			"%s/@%s/%s.%s/terminal",
@@ -655,11 +658,8 @@ func buildAppLinkURL(baseURL *url.URL, workspace codersdk.Workspace, agent coder
 			agent.Name,
 		)
 		q := u.Query()
-		q.Set("command", app.Command)
+		q.Set("app", app.Slug)
 		u.RawQuery = q.Encode()
-		// encodeURIComponent replaces spaces with %20 but url.QueryEscape replaces them with +.
-		// We replace them with %20 to match the TypeScript implementation.
-		u.RawQuery = strings.ReplaceAll(u.RawQuery, "+", "%20")
 	}
 
 	if appsHost != "" && app.Subdomain && app.SubdomainName != "" {

--- a/cli/open.go
+++ b/cli/open.go
@@ -645,10 +645,6 @@ func buildAppLinkURL(baseURL *url.URL, workspace codersdk.Workspace, agent coder
 		agent.Name,
 		url.PathEscape(app.Slug),
 	)
-	// Pass the app slug instead of the raw command. The terminal
-	// page resolves the command from the workspace agent's app
-	// list, which lets it skip the confirmation dialog for
-	// trusted, admin-configured template apps.
 	if app.Command != "" {
 		u.Path = fmt.Sprintf(
 			"%s/@%s/%s.%s/terminal",

--- a/cli/open_internal_test.go
+++ b/cli/open_internal_test.go
@@ -114,9 +114,10 @@ func Test_buildAppLinkURL(t *testing.T) {
 				Name: "a-workspace-agent",
 			},
 			app: codersdk.WorkspaceApp{
+				Slug:    "my-terminal",
 				Command: "ls -la",
 			},
-			expectedLink: "https://coder.tld/@username/Test-Workspace.a-workspace-agent/terminal?command=ls%20-la",
+			expectedLink: "https://coder.tld/@username/Test-Workspace.a-workspace-agent/terminal?app=my-terminal",
 		},
 		{
 			name:    "with subdomain",


### PR DESCRIPTION
Came across this while trying to fix a customer issue. I'm not actually convinced this is the root problem, but it does seem like a nice small cleanup.