### PR TITLE
docs(docs/ai-coder/agents): correct chat statuses, watch events, auto-archive default, and add attach_file tool

### DIFF
--- a/docs/ai-coder/agents/architecture.md
+++ b/docs/ai-coder/agents/architecture.md
@@ -132,16 +132,16 @@ approach, discussing architecture) never provision or connect to a workspace.
 These tools execute inside the workspace via the workspace daemon's HTTP API.
 They traverse the same Tailnet tunnel used by web terminals and IDE connections.
 
-| Tool             | What it does                                                                |
-|------------------|-----------------------------------------------------------------------------|
-| `read_file`      | Reads file contents with line-number pagination.                            |
-| `write_file`     | Writes content to a file.                                                   |
-| `edit_files`     | Performs atomic search-and-replace edits across one or more files.          |
-| `execute`        | Runs a shell command, waiting for completion up to a timeout.               |
-| `process_output` | Retrieves output from a tracked process.                                    |
-| `process_list`   | Lists all tracked processes in the workspace.                               |
-| `process_signal` | Sends a signal (SIGTERM or SIGKILL) to a tracked process.                   |
-| `attach_file`    | Attaches a workspace file to the chat as a durable downloadable attachment. |
+| Tool             | What it does                                                                                                                                                                                                                                                                       |
+|------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `read_file`      | Reads file contents with line-number pagination.                                                                                                                                                                                                                                   |
+| `write_file`     | Writes content to a file.                                                                                                                                                                                                                                                          |
+| `edit_files`     | Performs atomic search-and-replace edits across one or more files.                                                                                                                                                                                                                 |
+| `execute`        | Runs a shell command, waiting for completion up to a timeout.                                                                                                                                                                                                                      |
+| `process_output` | Retrieves output from a tracked process.                                                                                                                                                                                                                                           |
+| `process_list`   | Lists all tracked processes in the workspace.                                                                                                                                                                                                                                      |
+| `process_signal` | Sends a signal (SIGTERM or SIGKILL) to a tracked process.                                                                                                                                                                                                                          |
+| `attach_file`    | Attach a workspace file to the current chat so the user can download it directly from the conversation. Use this when the user should receive an artifact such as a screenshot, log, patch, or document. Pass an absolute file path. The file must already exist in the workspace. |
 
 ### Platform tools
 

--- a/docs/ai-coder/agents/architecture.md
+++ b/docs/ai-coder/agents/architecture.md
@@ -132,15 +132,16 @@ approach, discussing architecture) never provision or connect to a workspace.
 These tools execute inside the workspace via the workspace daemon's HTTP API.
 They traverse the same Tailnet tunnel used by web terminals and IDE connections.
 
-| Tool             | What it does                                                       |
-|------------------|--------------------------------------------------------------------|
-| `read_file`      | Reads file contents with line-number pagination.                   |
-| `write_file`     | Writes content to a file.                                          |
-| `edit_files`     | Performs atomic search-and-replace edits across one or more files. |
-| `execute`        | Runs a shell command, waiting for completion up to a timeout.      |
-| `process_output` | Retrieves output from a tracked process.                           |
-| `process_list`   | Lists all tracked processes in the workspace.                      |
-| `process_signal` | Sends a signal (SIGTERM or SIGKILL) to a tracked process.          |
+| Tool             | What it does                                                                |
+|------------------|-----------------------------------------------------------------------------|
+| `read_file`      | Reads file contents with line-number pagination.                            |
+| `write_file`     | Writes content to a file.                                                   |
+| `edit_files`     | Performs atomic search-and-replace edits across one or more files.          |
+| `execute`        | Runs a shell command, waiting for completion up to a timeout.               |
+| `process_output` | Retrieves output from a tracked process.                                    |
+| `process_list`   | Lists all tracked processes in the workspace.                               |
+| `process_signal` | Sends a signal (SIGTERM or SIGKILL) to a tracked process.                   |
+| `attach_file`    | Attaches a workspace file to the chat as a durable downloadable attachment. |
 
 ### Platform tools
 

--- a/docs/ai-coder/agents/chats-api.md
+++ b/docs/ai-coder/agents/chats-api.md
@@ -334,10 +334,8 @@ The response contains an `id` you can reference as `file_id` in a
 `ChatInputPart` with `"type": "file"`. To retrieve a previously uploaded
 file, use `GET /api/experimental/chats/files/{file}`.
 
-Supported formats: PNG, JPEG, GIF, WebP, plus `text/plain`, `text/markdown`,
-`text/csv`, `application/json`, and `application/pdf` (up to 10 MB). The
-server validates actual file content regardless of the declared
-`Content-Type`.
+Supported formats: PNG, JPEG, GIF, WebP (up to 10 MB). The server
+validates actual file content regardless of the declared `Content-Type`.
 
 Files referenced in messages are automatically linked to the chat and
 appear in the `files` field on subsequent

--- a/docs/ai-coder/agents/chats-api.md
+++ b/docs/ai-coder/agents/chats-api.md
@@ -200,13 +200,14 @@ indicator without polling.
 
 Each event is a JSON object with `kind` and `chat` fields:
 
-| Kind                 | Description                      |
-|----------------------|----------------------------------|
-| `created`            | A new chat was created.          |
-| `status_change`      | A chat's status changed.         |
-| `title_change`       | A chat's title was updated.      |
-| `diff_status_change` | A chat's diff/PR status changed. |
-| `deleted`            | A chat was deleted.              |
+| Kind                 | Description                          |
+|----------------------|--------------------------------------|
+| `created`            | A new chat was created.              |
+| `status_change`      | A chat's status changed.             |
+| `title_change`       | A chat's title was updated.          |
+| `diff_status_change` | A chat's diff/PR status changed.     |
+| `action_required`    | A chat is waiting for a tool result. |
+| `deleted`            | A chat was deleted.                  |
 
 ### List chats
 
@@ -333,8 +334,10 @@ The response contains an `id` you can reference as `file_id` in a
 `ChatInputPart` with `"type": "file"`. To retrieve a previously uploaded
 file, use `GET /api/experimental/chats/files/{file}`.
 
-Supported formats: PNG, JPEG, GIF, WebP (up to 10 MB). The server
-validates actual file content regardless of the declared `Content-Type`.
+Supported formats: PNG, JPEG, GIF, WebP, plus `text/plain`, `text/markdown`,
+`text/csv`, `application/json`, and `application/pdf` (up to 10 MB). The
+server validates actual file content regardless of the declared
+`Content-Type`.
 
 Files referenced in messages are automatically linked to the chat and
 appear in the `files` field on subsequent
@@ -347,8 +350,6 @@ appear in the `files` field on subsequent
 | `waiting`         | Idle. Newly created, finished successfully, or interrupted.                  |
 | `pending`         | Queued for processing.                                                       |
 | `running`         | Agent is actively working.                                                   |
-| `paused`          | Agent is paused (for example, waiting for user input).                       |
-| `completed`       | Agent finished and the task is complete.                                     |
 | `error`           | Agent encountered an error.                                                  |
 | `requires_action` | Agent invoked a client-provided tool and needs the result before continuing. |
 
@@ -363,13 +364,13 @@ deployment-admin privileges.
 Chats whose newest non-deleted message is older than
 `auto_archive_days` are automatically archived by a background job.
 Pinned chats and chats belonging to a still-active thread are
-exempt. `0` disables the feature; the default is 90.
+exempt. `0` disables the feature, which is the default.
 
 ```sh
 # Read
 curl -H "Coder-Session-Token: $CODER_SESSION_TOKEN" \
   https://coder.example.com/api/experimental/chats/config/auto-archive-days
-# { "auto_archive_days": 90 }
+# { "auto_archive_days": 0 }
 
 # Update
 curl -X PUT -H "Coder-Session-Token: $CODER_SESSION_TOKEN" \

--- a/docs/ai-coder/agents/index.md
+++ b/docs/ai-coder/agents/index.md
@@ -244,6 +244,7 @@ tasks:
 | `process_output`                            | Retrieve output from a background process                                |
 | `process_list`                              | List all tracked processes in the workspace                              |
 | `process_signal`                            | Send a signal (terminate/kill) to a tracked process                      |
+| `attach_file`                               | Attach a workspace file to the chat as a durable downloadable attachment |
 | `spawn_agent` (`type=general` or `explore`) | Delegate a task to a sub-agent running in parallel                       |
 | `wait_agent`                                | Wait for a sub-agent to complete and collect its result                  |
 | `message_agent`                             | Send a follow-up message to a running sub-agent                          |


### PR DESCRIPTION
Linear: [CODAGT-157](https://linear.app/codercom/issue/CODAGT-157/ensure-docs-are-updated-for-beta).

Four small fixes in `docs/ai-coder/agents/` that surfaced during the Beta-rollout audit. Each is a doc-vs-code mismatch I verified against `main`. No behavior change.

## What changes

### 1. Drop `paused` and `completed` from the chat statuses table

`chats-api.md` lists both as user-visible chat states. They are defined in `codersdk/chats.go` (and in the database enum) but no production path on `main` ever transitions a chat into either status today. [PR #24264](https://github.com/coder/coder/pull/24264) (April 17) removed them from this table for that reason; [PR #24642](https://github.com/coder/coder/pull/24642) (April 24, auto-archive) unintentionally re-added them. This restores the corrected table.

```diff
 | `running`         | Agent is actively working.                                                   |
-| `paused`          | Agent is paused (for example, waiting for user input).                       |
-| `completed`       | Agent finished and the task is complete.                                     |
 | `error`           | Agent encountered an error.                                                  |
```

### 2. Add `action_required` to the watch event-kinds table

`ChatWatchEventKindActionRequired = "action_required"` (`codersdk/chats.go:1410`) is emitted when a chat enters the `requires_action` state, but the doc table had no row for it. Anyone driving UI off `GET /api/experimental/chats/watch` cannot use the event without it being documented.

```diff
+| `action_required`    | A chat is waiting for a tool result. |
 | `deleted`            | A chat was deleted.                  |
```

### 3. Correct the auto-archive default to `0` (disabled)

`DefaultChatAutoArchiveDays int32 = 0` in `codersdk/chats.go:801`. The doc said `90`, both in prose and in the curl-output example.

```diff
-exempt. `0` disables the feature; the default is 90.
+exempt. `0` disables the feature, which is the default.
 ...
-# { "auto_archive_days": 90 }
+# { "auto_archive_days": 0 }
```

`platform-controls/chat-auto-archive.md` was already correct on this point.

### 4. Add the `attach_file` built-in tool to the tool tables

Implemented in `coderd/x/chatd/chattool/attachfile.go:27` with the description “Attach a workspace file to the current chat so the user can download it directly from the conversation.” The tool is missing from both tool-list tables.

```diff
  | `process_signal`   ... |
+ | `attach_file`      ... |
  | `spawn_agent` ...      |
```

Added to `index.md` (Built-in tools) and `architecture.md` (Workspace tools).

## What was dropped from this PR

An earlier revision widened the file-uploads supported-formats line in `chats-api.md` to mention `text/plain`, `text/markdown`, `text/csv`, `application/json`, and `application/pdf` alongside the four image types, citing the server-side allowlist in `coderd/x/chatfiles/mime.go`. Per review, the chat UI is image-only end-to-end (file picker uses `accept="image/*"`, drag-drop filters with `f.type.startsWith("image/")`, native paste filters the same way). Widening the doc would imply a UX surface that does not exist, so the bullet was reverted to the original image-only wording. The server allowlist will be revisited as a separate change once a UI surface for non-image attachments lands.

## Files

- `docs/ai-coder/agents/chats-api.md` (3 of the 4 fixes)
- `docs/ai-coder/agents/index.md` (`attach_file` row)
- `docs/ai-coder/agents/architecture.md` (`attach_file` row)

The larger-than-expected `architecture.md` diff is the markdown table formatter re-padding column widths to accommodate the longer description in the new `attach_file` row. No content drift outside the new row.

## Validation

- `pnpm exec markdownlint-cli2 …` → 0 errors
- `pnpm exec markdown-table-formatter …` → stable (re-run produces no diff)
- `bash scripts/check_emdash.sh` → OK
- Cross-checked each claim against `main`:
  - `grep -n DefaultChatAutoArchiveDays codersdk/chats.go` → `const … int32 = 0`
  - `grep -n ChatWatchEventKindActionRequired codersdk/chats.go` → `"action_required"`
  - `grep -n attach_file coderd/x/chatd/chattool/attachfile.go` → tool registered
  - `grep -rn ChatStatusPaused\\|ChatStatusCompleted … | grep -v _test.go | grep -v models.go` → only enum-listing call sites; no production setter on `main`

## Proof

Docs-text change with no UI/UX impact. The visible-string diffs are above. If reviewers want rendered before/after, I can attach screenshots.

---

> Coder Agent generated this PR on @david-fraley's behalf.