### PR TITLE
docs(docs/ai-coder): add deprecation notice to Coder Tasks pages

### DIFF
--- a/docs/ai-coder/agent-compatibility.md
+++ b/docs/ai-coder/agent-compatibility.md
@@ -1,5 +1,12 @@
 # Agent compatibility
 
+> [!WARNING]
+> Starting June 2, 2026, Coder Tasks will move to a 12-month Extended Support Release (ESR) for Premium customers.
+>
+> Tasks will be removed from new Coder releases beginning with v2.37 (September 1, 2026) and will only be available via the ESR during the support period.
+>
+> We recommend transitioning to [Coder Agents](./agents.md), the long-term replacement.
+
 Coder Tasks works with a range of AI coding agents, each with different levels
 of support for preserving conversation context across pause and resume cycles.
 This page covers which agents support resume, what session data they store,

--- a/docs/ai-coder/agent-compatibility.md
+++ b/docs/ai-coder/agent-compatibility.md
@@ -5,7 +5,7 @@
 >
 > Tasks will be removed from new Coder releases beginning with v2.37 (September 1, 2026) and will only be available via the ESR during the support period.
 >
-> We recommend transitioning to [Coder Agents](./agents.md), the long-term replacement.
+> We recommend transitioning to [Coder Agents](./agents/index.md), the long-term replacement.
 
 Coder Tasks works with a range of AI coding agents, each with different levels
 of support for preserving conversation context across pause and resume cycles.

--- a/docs/ai-coder/custom-agents.md
+++ b/docs/ai-coder/custom-agents.md
@@ -1,5 +1,12 @@
 # Custom Agents
 
+> [!WARNING]
+> Starting June 2, 2026, Coder Tasks will move to a 12-month Extended Support Release (ESR) for Premium customers.
+>
+> Tasks will be removed from new Coder releases beginning with v2.37 (September 1, 2026) and will only be available via the ESR during the support period.
+>
+> We recommend transitioning to [Coder Agents](./agents.md), the long-term replacement.
+
 Custom agents beyond the ones listed in the [Coder registry](https://registry.coder.com/modules?search=tag%3Aagent) can be used with Coder Tasks.
 
 ## Prerequisites

--- a/docs/ai-coder/custom-agents.md
+++ b/docs/ai-coder/custom-agents.md
@@ -5,7 +5,7 @@
 >
 > Tasks will be removed from new Coder releases beginning with v2.37 (September 1, 2026) and will only be available via the ESR during the support period.
 >
-> We recommend transitioning to [Coder Agents](./agents.md), the long-term replacement.
+> We recommend transitioning to [Coder Agents](./agents/index.md), the long-term replacement.
 
 Custom agents beyond the ones listed in the [Coder registry](https://registry.coder.com/modules?search=tag%3Aagent) can be used with Coder Tasks.
 

--- a/docs/ai-coder/github-to-tasks.md
+++ b/docs/ai-coder/github-to-tasks.md
@@ -1,5 +1,12 @@
 # Guide: Create a GitHub to Coder Tasks Workflow
 
+> [!WARNING]
+> Starting June 2, 2026, Coder Tasks will move to a 12-month Extended Support Release (ESR) for Premium customers.
+>
+> Tasks will be removed from new Coder releases beginning with v2.37 (September 1, 2026) and will only be available via the ESR during the support period.
+>
+> We recommend transitioning to [Coder Agents](./agents.md), the long-term replacement.
+
 ## Background
 
 Most software engineering organizations track and manage their codebase through GitHub, and use project management tools like Asana, Jira, or even GitHub's Projects to coordinate work. Across these systems, engineers are frequently performing the same repetitive workflows: triaging and addressing bugs, updating documentation, or implementing well-defined changes for example.

--- a/docs/ai-coder/github-to-tasks.md
+++ b/docs/ai-coder/github-to-tasks.md
@@ -5,7 +5,7 @@
 >
 > Tasks will be removed from new Coder releases beginning with v2.37 (September 1, 2026) and will only be available via the ESR during the support period.
 >
-> We recommend transitioning to [Coder Agents](./agents.md), the long-term replacement.
+> We recommend transitioning to [Coder Agents](./agents/index.md), the long-term replacement.
 
 ## Background
 

--- a/docs/ai-coder/tasks-core-principles.md
+++ b/docs/ai-coder/tasks-core-principles.md
@@ -1,5 +1,12 @@
 # Understanding Coder Tasks
 
+> [!WARNING]
+> Starting June 2, 2026, Coder Tasks will move to a 12-month Extended Support Release (ESR) for Premium customers.
+>
+> Tasks will be removed from new Coder releases beginning with v2.37 (September 1, 2026) and will only be available via the ESR during the support period.
+>
+> We recommend transitioning to [Coder Agents](./agents.md), the long-term replacement.
+
 ## What is a Task?
 
 Coder Tasks is Coder's platform for managing coding agents. With Coder Tasks, you can:

--- a/docs/ai-coder/tasks-core-principles.md
+++ b/docs/ai-coder/tasks-core-principles.md
@@ -5,7 +5,7 @@
 >
 > Tasks will be removed from new Coder releases beginning with v2.37 (September 1, 2026) and will only be available via the ESR during the support period.
 >
-> We recommend transitioning to [Coder Agents](./agents.md), the long-term replacement.
+> We recommend transitioning to [Coder Agents](./agents/index.md), the long-term replacement.
 
 ## What is a Task?
 

--- a/docs/ai-coder/tasks-lifecycle.md
+++ b/docs/ai-coder/tasks-lifecycle.md
@@ -5,7 +5,7 @@
 >
 > Tasks will be removed from new Coder releases beginning with v2.37 (September 1, 2026) and will only be available via the ESR during the support period.
 >
-> We recommend transitioning to [Coder Agents](./agents.md), the long-term replacement.
+> We recommend transitioning to [Coder Agents](./agents/index.md), the long-term replacement.
 
 Tasks can pause when idle and resume when you interact with them again.
 Pausing frees compute resources while preserving conversation context, so

--- a/docs/ai-coder/tasks-lifecycle.md
+++ b/docs/ai-coder/tasks-lifecycle.md
@@ -1,5 +1,12 @@
 # Task lifecycle
 
+> [!WARNING]
+> Starting June 2, 2026, Coder Tasks will move to a 12-month Extended Support Release (ESR) for Premium customers.
+>
+> Tasks will be removed from new Coder releases beginning with v2.37 (September 1, 2026) and will only be available via the ESR during the support period.
+>
+> We recommend transitioning to [Coder Agents](./agents.md), the long-term replacement.
+
 Tasks can pause when idle and resume when you interact with them again.
 Pausing frees compute resources while preserving conversation context, so
 the agent can pick up where it left off. This page covers how pause and

--- a/docs/ai-coder/tasks-migration.md
+++ b/docs/ai-coder/tasks-migration.md
@@ -1,5 +1,12 @@
 # Migrating Task Templates for Coder version 2.28.0
 
+> [!WARNING]
+> Starting June 2, 2026, Coder Tasks will move to a 12-month Extended Support Release (ESR) for Premium customers.
+>
+> Tasks will be removed from new Coder releases beginning with v2.37 (September 1, 2026) and will only be available via the ESR during the support period.
+>
+> We recommend transitioning to [Coder Agents](./agents.md), the long-term replacement.
+
 Prior to Coder version 2.28.0, the definition of a Coder task was different to the above. It required the following to be defined in the template:
 
 1. A Coder parameter specifically named `"AI Prompt"`,

--- a/docs/ai-coder/tasks-migration.md
+++ b/docs/ai-coder/tasks-migration.md
@@ -5,7 +5,7 @@
 >
 > Tasks will be removed from new Coder releases beginning with v2.37 (September 1, 2026) and will only be available via the ESR during the support period.
 >
-> We recommend transitioning to [Coder Agents](./agents.md), the long-term replacement.
+> We recommend transitioning to [Coder Agents](./agents/index.md), the long-term replacement.
 
 Prior to Coder version 2.28.0, the definition of a Coder task was different to the above. It required the following to be defined in the template:
 

--- a/docs/ai-coder/tasks.md
+++ b/docs/ai-coder/tasks.md
@@ -1,7 +1,11 @@
 # Coder Tasks
 
 > [!WARNING]
-> Beginning June 2026, Coder Tasks will be deprecated. Support for Tasks will be maintained on Coder's ESR release and through Coder v2.36. After v2.36, support for Tasks will only be on our 12-month ESR release for Coder Premium Customers.
+> Starting June 2, 2026, Coder Tasks will move to a 12-month Extended Support Release (ESR) for Premium customers.
+>
+> Tasks will be removed from new Coder releases beginning with v2.37 (September 1, 2026) and will only be available via the ESR during the support period.
+>
+> We recommend transitioning to [Coder Agents](./agents.md), the long-term replacement.
 
 Coder Tasks is an interface for running & managing coding agents such as Claude Code and Aider, powered by Coder workspaces.
 

--- a/docs/ai-coder/tasks.md
+++ b/docs/ai-coder/tasks.md
@@ -5,7 +5,7 @@
 >
 > Tasks will be removed from new Coder releases beginning with v2.37 (September 1, 2026) and will only be available via the ESR during the support period.
 >
-> We recommend transitioning to [Coder Agents](./agents.md), the long-term replacement.
+> We recommend transitioning to [Coder Agents](./agents/index.md), the long-term replacement.
 
 Coder Tasks is an interface for running & managing coding agents such as Claude Code and Aider, powered by Coder workspaces.
 

--- a/docs/ai-coder/tasks.md
+++ b/docs/ai-coder/tasks.md
@@ -1,5 +1,8 @@
 # Coder Tasks
 
+> [!WARNING]
+> Beginning June 2026, Coder Tasks will be deprecated. Support for Tasks will be maintained on Coder's ESR release and through Coder v2.36. After v2.36, support for Tasks will only be on our 12-month ESR release for Coder Premium Customers.
+
 Coder Tasks is an interface for running & managing coding agents such as Claude Code and Aider, powered by Coder workspaces.
 
 ![Tasks UI](../images/guides/ai-agents/tasks-ui.png)


### PR DESCRIPTION
Adds a deprecation warning callout to the top of the main Coder Tasks docs page (`docs/ai-coder/tasks.md`).

The message reads:

> Beginning June 2026, Coder Tasks will be deprecated. Support for Tasks will be maintained on Coder's ESR release and through Coder v2.36. After v2.36, support for Tasks will only be on our 12-month ESR release for Coder Premium Customers.

Uses the existing `> [!WARNING]` admonition pattern already used for deprecations elsewhere in the docs (e.g. `docs/ai-coder/ai-gateway/mcp.md`).

Linear: [CODAGT-157](https://linear.app/codercom/issue/CODAGT-157/ensure-docs-are-updated-for-beta)

---

_This PR was opened by Coder Agents on @davidfraley's behalf._