### PR TITLE
fix(site/src/components/Chart): replace stale shadcn color classes with semantic tokens

### DIFF
--- a/site/src/components/Chart/Chart.tsx
+++ b/site/src/components/Chart/Chart.tsx
@@ -69,14 +69,14 @@ export const ChartContainer: React.FC<ChartContainerProps> = ({
 				data-chart={chartId}
 				className={cn(
 					"flex aspect-video justify-center text-xs",
-					"[&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground",
+					"[&_.recharts-cartesian-axis-tick_text]:fill-content-secondary",
 					"[&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50",
 					"[&_.recharts-curve.recharts-tooltip-cursor]:stroke-border",
 					"[&_.recharts-dot[stroke='#fff']]:stroke-transparent",
 					"[&_.recharts-layer]:outline-none",
 					"[&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border",
-					"[&_.recharts-radial-bar-background-sector]:fill-muted",
-					"[&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted",
+					"[&_.recharts-radial-bar-background-sector]:fill-surface-secondary",
+					"[&_.recharts-rectangle.recharts-tooltip-cursor]:fill-surface-secondary",
 					"[&_.recharts-reference-line_[stroke='#ccc']]:stroke-border",
 					"[&_.recharts-sector[stroke='#fff']]:stroke-transparent",
 					"[&_.recharts-sector]:outline-none",


### PR DESCRIPTION
Closing in favor of a fix in coder/blink where the /usage page lives.

---
*PR generated with Coder Agents*