### PR TITLE
fix(site): remove Request Logs from admin menu, redirect /aibridge to sessions

### DIFF
--- a/site/src/modules/dashboard/Navbar/DeploymentDropdown.tsx
+++ b/site/src/modules/dashboard/Navbar/DeploymentDropdown.tsx
@@ -92,14 +92,9 @@ const DeploymentDropdownContent: FC<DeploymentDropdownProps> = ({
 				</DropdownMenuItem>
 			)}
 			{canViewAIBridge && (
-				<>
-					<DropdownMenuItem asChild>
-						<Link to="/aibridge">AI Bridge Logs</Link>
-					</DropdownMenuItem>
-					<DropdownMenuItem asChild>
-						<Link to="/aibridge/sessions">AI Bridge Sessions</Link>
-					</DropdownMenuItem>
-				</>
+				<DropdownMenuItem asChild>
+					<Link to="/aibridge/sessions">AI Bridge Sessions</Link>
+				</DropdownMenuItem>
 			)}
 			{canViewHealth && (
 				<DropdownMenuItem asChild>

--- a/site/src/router.tsx
+++ b/site/src/router.tsx
@@ -662,7 +662,10 @@ export const router = createBrowserRouter(
 					</Route>
 
 					<Route path="/aibridge" element={<AIBridgeLayout />}>
-						<Route index element={<Navigate to="request-logs" replace />} />
+						<Route
+							index
+							element={<Navigate to="/aibridge/sessions" replace />}
+						/>
 						<Route path="request-logs" element={<AIBridgeRequestLogsPage />} />
 					</Route>
 


### PR DESCRIPTION
*Disclaimer: implemented by a Coder Agent using Claude Opus 4.6*

Remove the "AI Bridge Logs" menu item from the Admin settings dropdown, keeping only the "AI Bridge Sessions" link. The `/aibridge` index now redirects to `/aibridge/sessions` instead of `/aibridge/request-logs`.

The request-logs route and view remain accessible via direct URL (`/aibridge/request-logs`) for users who still need it.

Fixes https://linear.app/codercom/issue/AIGOV-205

<details><summary>Changes</summary>

- `DeploymentDropdown.tsx`: Removed "AI Bridge Logs" menu item; the `canViewAIBridge` block now only renders the "AI Bridge Sessions" link
- `router.tsx`: Changed `/aibridge` index redirect from `request-logs` to `/aibridge/sessions`
- All request-logs page files, route, and components are preserved for direct URL access

</details>