### PR TITLE
fix(site/src/pages/AgentsPage): use h-dvh on root to fix mobile keyboard layout

### DIFF
--- a/site/src/pages/AgentsPage/AgentsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageView.tsx
@@ -156,7 +156,7 @@ export const AgentsPageView: FC<AgentsPageViewProps> = ({
 	};
 
 	return (
-		<div className="flex h-full min-h-0 flex-col overflow-hidden bg-surface-primary md:flex-row">
+		<div className="flex h-dvh min-h-0 flex-col overflow-hidden bg-surface-primary md:flex-row">
 			<title>{pageTitle("Agents")}</title>
 			<div
 				className={cn(


### PR DESCRIPTION
## Summary

On iOS, the virtual keyboard does **not** shrink the layout viewport. `h-full` (= 100% of the layout viewport) therefore keeps the root div at the full device height even after the keyboard appears. The browser then auto-scrolls the page to bring the focused chat input into view, which pushes the oldest/first messages above the visible fold.

Replacing `h-full` with `h-dvh` (100% dynamic viewport height) fixes this. `dvh` tracks the **visual** viewport, which shrinks when the keyboard opens on both iOS and Android. The container fits naturally in the remaining visible area, the input sits at the bottom above the keyboard, and no browser scroll adjustment is needed.

On desktop and Android Chrome the change is effectively transparent: `dvh` equals `svh`/`lvh` when no keyboard is present, and Android already resizes the layout viewport on keyboard open.

## Change

```diff
- <div className="flex h-full min-h-0 flex-col overflow-hidden bg-surface-primary md:flex-row">
+ <div className="flex h-dvh min-h-0 flex-col overflow-hidden bg-surface-primary md:flex-row">
```

`h-dvh` is a Tailwind v3.3+ built-in (`height: 100dvh`). The project uses Tailwind v3.4.18, so no extra configuration is needed.

---

*Generated by Coder Agents.*