### PR TITLE
feat(site): remove visible text from copy/download logs buttons

### DIFF
--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -46,6 +46,12 @@ import {
 	TabsTrigger,
 } from "#/components/Tabs/Tabs";
 import { useKebabMenu } from "#/components/Tabs/utils/useKebabMenu";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "#/components/Tooltip/Tooltip";
 import { useProxy } from "#/contexts/ProxyContext";
 import { useClipboard } from "#/hooks/useClipboard";
 import { useFeatureVisibility } from "#/modules/dashboard/useFeatureVisibility";
@@ -606,18 +612,29 @@ export const AgentRow: FC<AgentRowProps> = ({
 										<div
 											className={cn(
 												"h-12.5 shrink-0 flex items-center gap-2 pl-2 pr-3",
-												"border-solid border-0 border-b",
+												"border-solid border-0 border-b border-l",
 											)}
 										>
-											<Button
-												variant="subtle"
-												size="sm"
-												disabled={!hasSelectedLogs}
-												onClick={() => copyToClipboard(selectedLogsText)}
-											>
-												{showCopiedSuccess ? <CheckIcon /> : <CopyIcon />}
-												<span>Copy logs</span>
-											</Button>
+											<TooltipProvider>
+												<Tooltip>
+													<TooltipTrigger asChild>
+														<Button
+															variant="subtle"
+															size="sm"
+															className="min-w-0"
+															disabled={!hasSelectedLogs}
+															onClick={() => copyToClipboard(selectedLogsText)}
+														>
+															{showCopiedSuccess ? <CheckIcon /> : <CopyIcon />}
+														</Button>
+													</TooltipTrigger>
+													<TooltipContent>
+														{showCopiedSuccess
+															? "Copied!"
+															: "Copy selected logs"}
+													</TooltipContent>
+												</Tooltip>
+											</TooltipProvider>
 											<DownloadSelectedAgentLogsButton
 												agentName={agent.name}
 												logSets={downloadableLogSets}

--- a/site/src/modules/resources/DownloadSelectedAgentLogsButton.tsx
+++ b/site/src/modules/resources/DownloadSelectedAgentLogsButton.tsx
@@ -55,9 +55,16 @@ export const DownloadSelectedAgentLogsButton: FC<
 	return (
 		<DropdownMenu>
 			<DropdownMenuTrigger asChild>
-				<Button variant="subtle" size="sm" disabled={disabled || isDownloading}>
+				<Button
+					variant="subtle"
+					size="sm"
+					disabled={disabled || isDownloading}
+					className="min-w-0"
+				>
 					<DownloadIcon />
-					{isDownloading ? "Downloading..." : "Download logs"}
+					<span className="sr-only">
+						{isDownloading ? "Downloading..." : "Download logs"}
+					</span>
 					<ChevronDownIcon className="size-icon-sm" />
 				</Button>
 			</DropdownMenuTrigger>


### PR DESCRIPTION
The text from the AgentRow copy/download logs buttons were cramping actual log stream tabs. Design would like to hide this text:

1. The "Copy logs" text is now in a tooltip over the button
2. The "Download logs" text is now screen-reader only

https://github.com/user-attachments/assets/af883cae-67dc-4198-9fde-0ab5ea415360

