### PR TITLE
refactor: add modern `DialogActions` component

### DIFF
--- a/site/.knip.jsonc
+++ b/site/.knip.jsonc
@@ -7,6 +7,7 @@
 		"./test/**/*.ts",
 		"./e2e/**/*.ts"
 	],
+	"tags": ["-lintignore"],
 	"ignore": [
 		"**/*Generated.ts",
 		"src/api/chatModelOptions.ts",

--- a/site/src/components/Dialog/Dialog.tsx
+++ b/site/src/components/Dialog/Dialog.tsx
@@ -108,6 +108,9 @@ export const DialogFooter: React.FC<React.ComponentPropsWithRef<"div">> = ({
 	);
 };
 
+/**
+ * @lintignore I'll be using this right away in another PR, just trying to break things up
+ */
 export interface DialogActionsProps {
 	/** Text to display in the confirm button */
 	confirmText?: React.ReactNode;
@@ -128,6 +131,7 @@ export interface DialogActionsProps {
 
 /**
  * Quickly handles most modals actions, some combination of a cancel and confirm button
+ * @lintignore I'll be using this right away in another PR, just trying to break things up
  */
 export const DialogActions: React.FC<DialogActionsProps> = ({
 	confirmText = "Confirm",

--- a/site/src/components/Dialog/Dialog.tsx
+++ b/site/src/components/Dialog/Dialog.tsx
@@ -4,6 +4,8 @@
  */
 import { cva, type VariantProps } from "class-variance-authority";
 import { Dialog as DialogPrimitive } from "radix-ui";
+import { Button } from "#/components/Button/Button";
+import { Spinner } from "#/components/Spinner/Spinner";
 import { cn } from "#/utils/cn";
 
 export const Dialog = DialogPrimitive.Root;
@@ -103,6 +105,68 @@ export const DialogFooter: React.FC<React.ComponentPropsWithRef<"div">> = ({
 			)}
 			{...props}
 		/>
+	);
+};
+
+export interface DialogActionsProps {
+	/** Text to display in the confirm button */
+	confirmText?: React.ReactNode;
+	/** Whether or not confirm is loading, also disables cancel when true */
+	confirmLoading?: boolean;
+	/** Whether or not the submit button is disabled */
+	confirmDisabled?: boolean;
+	/** Whether the confirm button triggers a destructive action or not */
+	confirmVariant?: React.ComponentProps<typeof Button>["variant"];
+	/** Called when confirm is clicked */
+	onConfirm?: () => void;
+
+	/** Text to display in the cancel button */
+	cancelText?: string;
+	/** Called when cancel is clicked */
+	onCancel?: () => void;
+}
+
+/**
+ * Quickly handles most modals actions, some combination of a cancel and confirm button
+ */
+export const DialogActions: React.FC<DialogActionsProps> = ({
+	confirmText = "Confirm",
+	confirmLoading = false,
+	confirmDisabled = false,
+	confirmVariant,
+	onConfirm,
+
+	cancelText = "Cancel",
+	onCancel,
+}) => {
+	return (
+		<>
+			{onCancel && (
+				<Button
+					disabled={confirmLoading}
+					onClick={(e) => {
+						e.stopPropagation();
+						onCancel();
+					}}
+					variant="outline"
+				>
+					{cancelText}
+				</Button>
+			)}
+
+			{onConfirm && (
+				<Button
+					variant={confirmVariant}
+					disabled={confirmLoading || confirmDisabled}
+					onClick={onConfirm}
+					data-testid="confirm-button"
+					type="submit"
+				>
+					<Spinner loading={confirmLoading} />
+					{confirmText}
+				</Button>
+			)}
+		</>
 	);
 };
 


### PR DESCRIPTION
We have a similar component for the MUI dialog style, so I took it, gave it a little polish, and put it next to our newer Dialog components. Breaking this out from a different refactor I've been working on because it's getting waaaay too big.