### PR TITLE
fix: avoid PTY for ssh command mode

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -1275,6 +1275,12 @@ func (e *exitError) Unwrap() error {
 	return e.err
 }
 
+// ExitCode returns the OS exit code that the CLI will use when this error is
+// returned from a command handler.
+func (e *exitError) ExitCode() int {
+	return e.code
+}
+
 // ExitError returns an error that will cause the CLI to exit with the given
 // exit code. If err is non-nil, it will be wrapped by the returned error.
 func ExitError(code int, err error) error {

--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -708,9 +708,12 @@ func (r *RootCmd) ssh() *serpent.Command {
 				if err != nil {
 					if exitErr := (&gossh.ExitError{}); errors.As(err, &exitErr) {
 						// Preserve the remote command's exit status as the CLI
-						// exit code instead of falling back to the default of 1
-						// for any non-zero exit.
-						return ExitError(exitErr.ExitStatus(), err)
+						// exit code, but clear the error since it's not useful
+						// beyond reporting status.
+						return ExitError(exitErr.ExitStatus(), nil)
+					}
+					if errors.Is(err, &gossh.ExitMissingError{}) {
+						return ExitError(255, xerrors.New("SSH connection ended unexpectedly"))
 					}
 					return xerrors.Errorf("run command: %w", err)
 				}

--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -634,6 +634,11 @@ func (r *RootCmd) ssh() *serpent.Command {
 				}
 			}
 
+			// Command mode must not request a PTY by default. A PTY
+			// interposes line discipline on the remote stdin which would
+			// prevent EOF from propagating to commands that read until
+			// EOF (e.g. `cat`, `wc`, `tar`). Interactive shell sessions
+			// always need a PTY, and command mode can opt in via --tty.
 			requestPTY := command == "" || tty
 			stdinFile, validIn := inv.Stdin.(*os.File)
 			stdoutFile, validOut := inv.Stdout.(*os.File)

--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -116,6 +116,7 @@ func retryWithInterval(ctx context.Context, logger slog.Logger, interval time.Du
 func (r *RootCmd) ssh() *serpent.Command {
 	var (
 		stdio               bool
+		tty                 bool
 		hostPrefix          string
 		hostnameSuffix      string
 		forceNewTunnel      bool
@@ -633,7 +634,7 @@ func (r *RootCmd) ssh() *serpent.Command {
 				}
 			}
 
-			requestPTY := command == ""
+			requestPTY := command == "" || tty
 			stdinFile, validIn := inv.Stdin.(*os.File)
 			stdoutFile, validOut := inv.Stdout.(*os.File)
 			if requestPTY && validIn && validOut && isatty.IsTerminal(stdinFile.Fd()) && isatty.IsTerminal(stdoutFile.Fd()) {
@@ -690,17 +691,19 @@ func (r *RootCmd) ssh() *serpent.Command {
 			sshSession.Stdout = inv.Stdout
 			sshSession.Stderr = inv.Stderr
 
-			if !requestPTY {
+			if requestPTY {
+				err = sshSession.RequestPty("xterm-256color", 128, 128, gossh.TerminalModes{})
+				if err != nil {
+					return xerrors.Errorf("request pty: %w", err)
+				}
+			}
+
+			if command != "" {
 				err := sshSession.Run(command)
 				if err != nil {
 					return xerrors.Errorf("run command: %w", err)
 				}
 			} else {
-				err = sshSession.RequestPty("xterm-256color", 128, 128, gossh.TerminalModes{})
-				if err != nil {
-					return xerrors.Errorf("request pty: %w", err)
-				}
-
 				err = sshSession.Shell()
 				if err != nil {
 					return xerrors.Errorf("start shell: %w", err)
@@ -751,6 +754,13 @@ func (r *RootCmd) ssh() *serpent.Command {
 			Env:         "CODER_SSH_STDIO",
 			Description: "Specifies whether to emit SSH output over stdin/stdout.",
 			Value:       serpent.BoolOf(&stdio),
+		},
+		{
+			Flag:          "tty",
+			FlagShorthand: "t",
+			Env:           "CODER_SSH_TTY",
+			Description:   "Request a pseudo-terminal for the SSH session. Interactive shell sessions request one by default; command sessions do not unless this flag is set.",
+			Value:         serpent.BoolOf(&tty),
 		},
 		{
 			Flag:        "ssh-host-prefix",

--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -633,9 +633,10 @@ func (r *RootCmd) ssh() *serpent.Command {
 				}
 			}
 
+			requestPTY := command == ""
 			stdinFile, validIn := inv.Stdin.(*os.File)
 			stdoutFile, validOut := inv.Stdout.(*os.File)
-			if validIn && validOut && isatty.IsTerminal(stdinFile.Fd()) && isatty.IsTerminal(stdoutFile.Fd()) {
+			if requestPTY && validIn && validOut && isatty.IsTerminal(stdinFile.Fd()) && isatty.IsTerminal(stdoutFile.Fd()) {
 				inState, err := pty.MakeInputRaw(stdinFile.Fd())
 				if err != nil {
 					return err
@@ -685,21 +686,21 @@ func (r *RootCmd) ssh() *serpent.Command {
 				}
 			}
 
-			err = sshSession.RequestPty("xterm-256color", 128, 128, gossh.TerminalModes{})
-			if err != nil {
-				return xerrors.Errorf("request pty: %w", err)
-			}
-
 			sshSession.Stdin = inv.Stdin
 			sshSession.Stdout = inv.Stdout
 			sshSession.Stderr = inv.Stderr
 
-			if command != "" {
+			if !requestPTY {
 				err := sshSession.Run(command)
 				if err != nil {
 					return xerrors.Errorf("run command: %w", err)
 				}
 			} else {
+				err = sshSession.RequestPty("xterm-256color", 128, 128, gossh.TerminalModes{})
+				if err != nil {
+					return xerrors.Errorf("request pty: %w", err)
+				}
+
 				err = sshSession.Shell()
 				if err != nil {
 					return xerrors.Errorf("start shell: %w", err)

--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -701,6 +701,12 @@ func (r *RootCmd) ssh() *serpent.Command {
 			if command != "" {
 				err := sshSession.Run(command)
 				if err != nil {
+					if exitErr := (&gossh.ExitError{}); errors.As(err, &exitErr) {
+						// Preserve the remote command's exit status as the CLI
+						// exit code instead of falling back to the default of 1
+						// for any non-zero exit.
+						return ExitError(exitErr.ExitStatus(), err)
+					}
 					return xerrors.Errorf("run command: %w", err)
 				}
 			} else {

--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -712,7 +712,7 @@ func (r *RootCmd) ssh() *serpent.Command {
 						// beyond reporting status.
 						return ExitError(exitErr.ExitStatus(), nil)
 					}
-					if errors.Is(err, &gossh.ExitMissingError{}) {
+					if missingErr := (&gossh.ExitMissingError{}); errors.As(err, &missingErr) {
 						return ExitError(255, xerrors.New("SSH connection ended unexpectedly"))
 					}
 					return xerrors.Errorf("run command: %w", err)
@@ -746,7 +746,7 @@ func (r *RootCmd) ssh() *serpent.Command {
 					// If the connection drops unexpectedly, we get an
 					// ExitMissingError but no other error details, so try to at
 					// least give the user a better message
-					if errors.Is(err, &gossh.ExitMissingError{}) {
+					if missingErr := (&gossh.ExitMissingError{}); errors.As(err, &missingErr) {
 						return ExitError(255, xerrors.New("SSH connection ended unexpectedly"))
 					}
 					return xerrors.Errorf("session ended: %w", err)

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -2371,7 +2371,7 @@ func TestSSH_CoderConnect(t *testing.T) {
 func TestSSH_OneShotCommandMode(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS == "windows" {
-		t.Skip("test and wc don't exist on Windows")
+		t.Skip("'test' shell command and wc are not available on Windows")
 	}
 
 	client, workspace, agentToken := setupWorkspaceForAgent(t)

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -2368,6 +2368,48 @@ func TestSSH_CoderConnect(t *testing.T) {
 	})
 }
 
+func TestSSH_OneShotCommandMode(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("test and wc don't exist on Windows")
+	}
+
+	client, workspace, agentToken := setupWorkspaceForAgent(t)
+	_ = agenttest.New(t, client.URL, agentToken)
+	coderdtest.AwaitWorkspaceAgents(t, client, workspace.ID)
+
+	t.Run("DoesNotRequestPTY", func(t *testing.T) {
+		t.Parallel()
+
+		output := new(bytes.Buffer)
+		inv, root := clitest.New(t, "ssh", workspace.Name, "test -t 0 && echo tty || echo not-tty")
+		clitest.SetupConfig(t, client, root)
+		inv.Stdout = output
+		inv.Stderr = io.Discard
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		err := inv.WithContext(ctx).Run()
+		require.NoError(t, err)
+		require.Equal(t, "not-tty", strings.TrimSpace(output.String()))
+	})
+
+	t.Run("ClosesStdinOnEOF", func(t *testing.T) {
+		t.Parallel()
+
+		output := new(bytes.Buffer)
+		inv, root := clitest.New(t, "ssh", workspace.Name, "wc -l")
+		clitest.SetupConfig(t, client, root)
+		inv.Stdin = strings.NewReader("a\nb\nc\n")
+		inv.Stdout = output
+		inv.Stderr = io.Discard
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		err := inv.WithContext(ctx).Run()
+		require.NoError(t, err)
+		require.Equal(t, "3", strings.TrimSpace(output.String()))
+	})
+}
+
 type fakeCoderConnectDialer struct{}
 
 func (*fakeCoderConnectDialer) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -2423,6 +2423,24 @@ func TestSSH_OneShotCommandMode(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "3", strings.TrimSpace(output.String()))
 	})
+
+	t.Run("PropagatesExitCode", func(t *testing.T) {
+		t.Parallel()
+
+		// Use a non-1 exit code so that we don't accidentally pass when the
+		// CLI falls back to the default exit code of 1 for any error.
+		inv, root := clitest.New(t, "ssh", workspace.Name, "exit 2")
+		clitest.SetupConfig(t, client, root)
+		inv.Stderr = io.Discard
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		err := inv.WithContext(ctx).Run()
+		require.Error(t, err)
+
+		var cliExitErr interface{ ExitCode() int }
+		require.ErrorAs(t, err, &cliExitErr)
+		require.Equal(t, 2, cliExitErr.ExitCode())
+	})
 }
 
 type fakeCoderConnectDialer struct{}

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -2393,6 +2393,21 @@ func TestSSH_OneShotCommandMode(t *testing.T) {
 		require.Equal(t, "not-tty", strings.TrimSpace(output.String()))
 	})
 
+	t.Run("RequestsPTYWithFlag", func(t *testing.T) {
+		t.Parallel()
+
+		output := new(bytes.Buffer)
+		inv, root := clitest.New(t, "ssh", "--tty", workspace.Name, "test -t 0 && echo tty || echo not-tty")
+		clitest.SetupConfig(t, client, root)
+		inv.Stdout = output
+		inv.Stderr = io.Discard
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		err := inv.WithContext(ctx).Run()
+		require.NoError(t, err)
+		require.Equal(t, "tty", strings.TrimSpace(output.String()))
+	})
+
 	t.Run("ClosesStdinOnEOF", func(t *testing.T) {
 		t.Parallel()
 

--- a/cli/ssh_test.go
+++ b/cli/ssh_test.go
@@ -2302,9 +2302,9 @@ func TestSSH_CoderConnect(t *testing.T) {
 
 			err := inv.WithContext(ctx).Run()
 			assert.Error(t, err)
-			var exitErr *ssh.ExitError
+			var exitErr interface{ ExitCode() int }
 			assert.True(t, errors.As(err, &exitErr))
-			assert.Equal(t, 1, exitErr.ExitStatus())
+			assert.Equal(t, 1, exitErr.ExitCode())
 		})
 	})
 

--- a/cli/testdata/coder_ssh_--help.golden
+++ b/cli/testdata/coder_ssh_--help.golden
@@ -67,6 +67,11 @@ OPTIONS:
       --stdio bool, $CODER_SSH_STDIO
           Specifies whether to emit SSH output over stdin/stdout.
 
+  -t, --tty bool, $CODER_SSH_TTY
+          Request a pseudo-terminal for the SSH session. Interactive shell
+          sessions request one by default; command sessions do not unless this
+          flag is set.
+
       --wait yes|no|auto, $CODER_SSH_WAIT (default: auto)
           Specifies whether or not to wait for the startup script to finish
           executing. Auto means that the agent startup script behavior

--- a/docs/reference/cli/ssh.md
+++ b/docs/reference/cli/ssh.md
@@ -30,6 +30,15 @@ This command does not have full parity with the standard SSH command. For users 
 
 Specifies whether to emit SSH output over stdin/stdout.
 
+### -t, --tty
+
+|             |                             |
+|-------------|-----------------------------|
+| Type        | <code>bool</code>           |
+| Environment | <code>$CODER_SSH_TTY</code> |
+
+Request a pseudo-terminal for the SSH session. Interactive shell sessions request one by default; command sessions do not unless this flag is set.
+
 ### --ssh-host-prefix
 
 |             |                                         |


### PR DESCRIPTION
`coder ssh <workspace> -- <cmd>` previously requested a PTY before running remote command sessions, which made command-mode stdin behave like a terminal and could prevent piped stdin EOF from reaching commands such as `wc -l`.

This changes command mode to run without requesting a PTY by default while preserving PTY allocation for interactive `coder ssh <workspace>` shell sessions. Command sessions that need a PTY can opt in with `--tty`/`-t` (`CODER_SSH_TTY`).

Fixes [https://github.com/coder/coder/issues/24861](<https://github.com/coder/coder/issues/24861>)

---

<details><summary>📋 Implementation Plan</summary>

# Implementation Plan: Fix `coder ssh` command-mode stdin EOF handling

## Summary

GitHub issue coder/coder#24861 is still valid in the current checkout. The root cause is that `cli/ssh.go` requests a PTY for every SSH session before it decides whether the session will run a remote command or start an interactive shell. A PTY is correct for interactive `coder ssh <workspace>`, but it changes stdin EOF semantics for non-interactive command mode. As a result, commands that read until EOF, such as `cat`, `wc -l`, or `tar`, can hang when used with piped stdin.

The core fix is to align command mode with OpenSSH defaults while keeping the change surgical:

* `coder ssh <workspace>` should continue to allocate a PTY for interactive shell use.
* Local raw terminal mode should be entered only for interactive shell use, not for command mode.
* `coder ssh <workspace> -- <cmd>` should not allocate a PTY by default.
* stdin, stdout, stderr, environment variables, agent forwarding, remote forwarding, container options, and exit status propagation should remain otherwise unchanged.

This plan intentionally avoids adding new user-facing PTY flags unless maintainers explicitly want them. The issue can be fixed at its core by making PTY and raw-mode decisions conditional and adding focused regression coverage.

## Verified repo evidence

Trusted read-only investigation found the following current structure:

* `cli/ssh.go`
  * `(r *RootCmd) ssh()` is the main CLI command implementation.
  * The command string is computed near `cli/ssh.go:216` as `strings.Join(inv.Args[1:], " ")`.
  * Terminal raw-mode setup currently happens around `cli/ssh.go:636-669` when both stdin and stdout are TTYs.
  * Environment and container-related `Setenv` calls happen around `cli/ssh.go:671-686`.
  * `sshSession.RequestPty("xterm-256color", 128, 128, gossh.TerminalModes{})` is currently called unconditionally around `cli/ssh.go:688-691`.
  * `sshSession.Stdin`, `Stdout`, and `Stderr` are assigned around `cli/ssh.go:693-695`.
  * The code chooses between `sshSession.Run(command)` and `sshSession.Shell()` only after the PTY request, around `cli/ssh.go:697-706`.
* `cli/ssh_test.go`
  * `setupWorkspaceForAgent` creates a test client, workspace, and agent token.
  * Existing tests use `agenttest.New` plus `coderdtest.AwaitWorkspaceAgents` for fake workspace agents.
  * Existing `TestSSH` subtests cover interactive shell behavior, `--stdio`, host key behavior, forwarding, and other SSH paths.
  * Current tests do not cover `coder ssh <workspace> -- <cmd>` with piped stdin that must close on EOF.
* `agent/agentssh/agentssh_test.go`
  * `TestSSHServer_ClosesStdin` covers agent-side stdin close behavior, but not the CLI command-mode path that currently requests a PTY.

## Goals

1. Fix the EOF hang at the source by avoiding PTY allocation for non-interactive command mode.
2. Preserve existing interactive terminal behavior for `coder ssh <workspace>`.
3. Preserve command exit status behavior, including non-zero statuses and missing exit statuses.
4. Add regression coverage that fails before the fix and passes after it.
5. Keep the implementation surgical and minimal.
6. Include dogfooding steps that exercise a real workspace with screenshots and a terminal recording for reviewer verification.

## Non-goals

* Do not add `-t`, `-T`, `--tty`, or `--no-tty` flags in this fix unless maintainers request explicit PTY control. Those flags would be useful but are not required to address the reported bug.
* Do not refactor the broader SSH command implementation.
* Do not change `--stdio` semantics.
* Do not change SSH agent forwarding, GPG forwarding, remote forwarding, or container execution behavior except where tests prove they depend on the corrected PTY behavior.

## Proposed behavior

<!-- linear:table-colwidths:200,200,200 -->
| Invocation | PTY default after fix | Rationale |
| -- | -- | -- |
| `coder ssh <workspace>` | Yes | Preserve current interactive shell behavior, including terminal control, resizing, control characters, and job control. |
| `coder ssh <workspace> -- <cmd>` | No | Remote command mode should receive normal stdin EOF and should match OpenSSH defaults. |
| `coder ssh --stdio <workspace>` | Preserve current behavior | This path is used as an SSH transport shim and must be verified separately before changing anything about it. |

Implementation decision for this PR: use a shared boolean such as `requestPTY := command == ""` for the actual SSH PTY request. Use `requestPTY && hasLocalTTY` for local raw-mode setup and window-size listener setup. This keeps the fix minimal and preserves the historical no-command shell PTY behavior even in tests or unusual non-TTY invocations. If maintainers require stricter OpenSSH fidelity, the follow-up decision is to define `requestPTY := command == "" && hasLocalTTY`, but that is a broader compatibility change than this bug requires.

## Implementation phases

### Phase 1: Add failing regression coverage first

Add a CLI-level test in `cli/ssh_test.go` that exercises command mode with piped stdin and EOF.

Recommended test shape:

1. Add a new `TestSSH` subtest named `CommandWithPipedStdinEOF` or equivalent.
2. Reuse existing helpers:
   * `setupWorkspaceForAgent(t)` to create the workspace and agent token.
   * `agenttest.New(t, client.URL, agentToken)` to start a fake agent.
   * `coderdtest.AwaitWorkspaceAgents(t, client, workspace.ID)` to wait for readiness.
   * Existing CLI invocation helpers from `clitest`.
3. Invoke the CLI as command mode, for example:

   ```sh
   coder ssh <workspace> -- wc -l
   ```
4. Connect test stdin to a finite reader containing:

   ```text
   a
   b
   c
   ```

   Prefer `strings.NewReader("a\nb\nc\n")` or `bytes.Buffer` if that reproduces the red failure. Use `io.Pipe` only if the CLI path needs explicit writer close semantics to exercise EOF.
5. Capture stdout and assert the command exits successfully and prints `3` with expected whitespace trimming.
6. Use a context timeout from existing test utilities so the pre-fix failure is a deterministic hang failure instead of an unbounded test run. Ensure cancellation and waits do not leak goroutines.
7. Add a direct no-PTY command-mode assertion if feasible:

   ```sh
   coder ssh <workspace> -- "test -t 0 && echo tty || echo not-tty"
   ```

   Expect `not-tty`. Because the CLI joins command arguments with `strings.Join`, pass complex remote commands as a single argument after the CLI `--` delimiter.
8. Add a second assertion or subcase for `cat` only if it adds coverage without making the test brittle. The minimum high-value test is `wc -l` because it proves EOF reached the remote process.
9. Keep any test identifiers unique to avoid parallel test conflicts, following existing repo patterns.

Expected red result before the implementation change:

* The new test should hang until its timeout or fail because the command does not observe stdin EOF when a PTY is allocated.

Test design details to be careful about:

* Avoid `time.Sleep`. Use context deadlines, existing test utilities, and channel completion signals.
* Assert the CLI returns within the timeout and fails with useful test diagnostics if it does not.
* Keep the regression test focused on command-mode stdin EOF. Do not combine it with unrelated forwarding or container assertions.
* Run the existing `--stdio` subtest after the fix. If `--stdio` does not bypass this session path, ensure it is excluded from new PTY/raw-mode behavior changes.

### Phase 2: Make PTY and raw-mode decisions conditional

Modify `cli/ssh.go` so command mode neither requests a remote PTY nor puts the local terminal into raw mode.

Current high-level flow:

```go
// Raw-mode setup.
// Environment setup.
RequestPty(...)
sshSession.Stdin = inv.Stdin
sshSession.Stdout = inv.Stdout
sshSession.Stderr = inv.Stderr
if command != "" {
    err := sshSession.Run(command)
} else {
    err = sshSession.Shell()
}
```

Target high-level flow:

```go
requestPTY := command == ""
// If --stdio reaches this same path, use command == "" && !stdio instead.

stdinFile, validIn := inv.Stdin.(*os.File)
stdoutFile, validOut := inv.Stdout.(*os.File)
hasLocalTTY := validIn && validOut &&
    isatty.IsTerminal(stdinFile.Fd()) &&
    isatty.IsTerminal(stdoutFile.Fd())

if requestPTY && hasLocalTTY {
    // Existing raw-mode and window-size listener setup.
}

// Existing environment setup.
sshSession.Stdin = inv.Stdin
sshSession.Stdout = inv.Stdout
sshSession.Stderr = inv.Stderr
if command != "" {
    err := sshSession.Run(command)
} else {
    if requestPTY {
        err = sshSession.RequestPty("xterm-256color", 128, 128, gossh.TerminalModes{})
        if err != nil {
            return xerrors.Errorf("request pty: %w", err)
        }
    }
    err = sshSession.Shell()
}
```

Preferred minimal implementation:

* Introduce a clearly named boolean, for example `requestPTY := command == ""`, near the existing terminal detection code.
* Reuse that boolean for both local raw-mode setup and remote PTY request so command mode cannot accidentally get one without the other.
* Move the existing `RequestPty` block into the interactive shell branch immediately before `sshSession.Shell()`.
* Gate the existing local raw-mode setup and window-size listener setup with `requestPTY && hasLocalTTY`.
* Do not change the existing error wrapping text unless needed.
* Keep `sshSession.Stdin`, `Stdout`, and `Stderr` assignments before the branch unless tests reveal the SSH library requires a different order. This keeps the diff small.
* Do not change existing environment setup. `Setenv` should continue to run before `Run` or `Shell`.
* Verify the `--stdio` path before finalizing the diff. If `--stdio` reaches the same session setup, explicitly exclude it from `requestPTY` and raw-mode behavior.

Compatibility choice:

* The recommended initial PR uses `requestPTY := command == ""` to preserve current no-command shell PTY behavior, including existing test assumptions.
* A stricter OpenSSH-compatible behavior would use `requestPTY := command == "" && hasLocalTTY`, which means no command plus non-TTY stdin/stdout would not request a PTY. That may be a worthwhile future change, but it is broader than this issue and should not be mixed into the minimal bug fix without maintainer agreement.

### Phase 3: Add exit-status regression coverage if not already present

Verify whether an existing `cli/ssh_test.go` test already proves command-mode exit status propagation. If not, add a small focused test or subcase.

Candidate checks:

```sh
coder ssh <workspace> -- false
```

Acceptance:

* The CLI exits with status `1`, not `0`, not a timeout, and not a generic SSH failure.

This is not the primary bug, so keep it small. If existing tests already cover this path well, reference them in the final implementation notes instead of adding duplicate coverage.

### Phase 4: Run focused validation and fix regressions

Run validation from narrow to broad:

1. Format touched Go files. The Makefile has both `fmt` and the Go-specific `fmt/go` target, so use the narrower Go target during iteration and the broader target before final handoff if needed.

   ```sh
   make fmt/go
   ```
2. Run the narrowest new regression test while iterating, using the exact subtest name chosen during implementation.

   ```sh
   go test ./cli -run 'TestSSH/CommandWithPipedStdinEOF' -count=1
   ```
3. Run the focused SSH test suite, including the existing `--stdio` subtest.

   ```sh
   make test RUN=TestSSH
   ```
4. If the implementation touches agent-side SSH behavior or shared helpers unexpectedly, run the related agent SSH test.

   ```sh
   make test RUN=TestSSHServer_ClosesStdin
   ```
5. Run lint.

   ```sh
   make lint
   ```
6. Run pre-commit checks before handing off or opening a PR.

   ```sh
   make pre-commit
   ```
7. If time and environment allow, run the full test suite.

   ```sh
   make test
   ```

## Dogfooding and reviewer evidence

Dogfooding should happen after automated tests pass. The goal is to prove the fix in a real CLI-to-workspace flow and produce evidence reviewers can inspect.

### Setup

1. Build the CLI using the repo workflow, not an ad hoc manual build.

   ```sh
   ./scripts/develop.sh
   ```

   If that workflow is not appropriate for this workspace, use the standard project build target:

   ```sh
   make build
   ```
2. Start or connect to a Coder deployment with a running workspace agent.
3. Ensure a test workspace is started and reachable.
4. Start a terminal recording before running commands. Use a local tool such as `asciinema`, macOS screen recording, or another available recorder.
5. Capture screenshots of the terminal before and after the command sequence. Attach the images for review with `attach_file` if working inside Mux.

### Manual command checks

Run these commands against a real workspace:

```sh
printf 'a\nb\nc\n' | timeout 5 coder ssh <workspace> -- wc -l
```

Expected:

```text
3
```

Run:

```sh
echo hello | timeout 5 coder ssh <workspace> -- cat
```

Expected:

```text
hello
```

Run:

```sh
coder ssh <workspace> -- "test -t 0 && echo tty || echo not-tty"
```

Expected:

```text
not-tty
```

Run:

```sh
timeout 5 coder ssh <workspace> -- false
echo "$?"
```

Expected:

```text
1
```

Run the interactive path:

```sh
coder ssh <workspace>
```

Expected:

* An interactive shell opens.
* Terminal input behaves normally.
* Window resizing still behaves normally.
* Exiting the shell returns cleanly.

Optional command-mode sanity checks:

```sh
coder ssh <workspace> -- echo ok
printf 'x' | timeout 5 coder ssh <workspace> -- "cat >/tmp/coder-ssh-eof-test && wc -c </tmp/coder-ssh-eof-test"
```

Expected:

* `echo ok` prints `ok` and exits `0`.
* The stdin byte-count check prints `1` and exits `0`.

### Expected compatibility change

Command mode will now expose non-PTY behavior by default. This is intended and is what makes stdin EOF propagation correct. Reviewers should expect these command-mode differences:

* `[ -t 0 ]` returns false.
* PTY-specific line discipline and CRLF translation do not apply.
* stdout and stderr may remain more faithfully separated than under a PTY.
* Commands that require a TTY, such as `top` or some `sudo` configurations, may not work in command mode until a future explicit `-t` or equivalent flag exists.

Interactive `coder ssh <workspace>` remains the supported path for PTY-requiring workflows in this fix.

### Evidence to attach

* Screenshot before dogfood showing the binary/version or git commit under test.
* Screenshot after dogfood showing all commands completed without timeout.
* Terminal recording showing the full sequence, including the interactive shell still working.
* If any command fails, preserve the output and stop to diagnose before claiming success.

## Acceptance criteria

Automated criteria:

* A CLI-level regression test proves `coder ssh <workspace> -- wc -l` or equivalent command-mode stdin EOF behavior.
* The regression test fails on the old unconditional-PTY behavior and passes after the fix.
* A direct command-mode no-PTY assertion proves `[ -t 0 ]` is false, if feasible in the test environment.
* Existing `TestSSH` coverage still passes.
* Formatting and linting pass.
* Exit status propagation is either covered by an existing test or by a new focused assertion.

Functional criteria:

* `printf 'a\nb\nc\n' | coder ssh <workspace> -- wc -l` prints `3` and exits `0`.
* `echo hello | coder ssh <workspace> -- cat` prints `hello` once and exits `0`.
* `coder ssh <workspace> -- "test -t 0 && echo tty || echo not-tty"` prints `not-tty`.
* `coder ssh <workspace> -- false` exits with status `1`.
* `coder ssh <workspace>` still opens an interactive PTY-backed shell.
* `--stdio` behavior remains unchanged.

Review criteria:

* The code diff is limited to `cli/ssh.go` and targeted tests in `cli/ssh_test.go`, unless investigation reveals a necessary helper change.
* The PR description explains the OpenSSH-compatible PTY default and mentions the dogfood evidence.
* No new unrelated refactors, formatting churn, or speculative flags are included.

## Risks and mitigations

<!-- linear:table-colwidths:200,200 -->
| Risk | Mitigation |
| -- | -- |
| Existing tests assume PTY allocation in command mode. | Treat failing tests as signal. Update only tests whose expectations are wrong under OpenSSH-compatible behavior. Do not weaken unrelated assertions. |
| Raw local terminal mode still runs for command mode when invoked from a TTY. | Gate raw-mode setup with `requestPTY && hasLocalTTY` in the initial fix, then dogfood command mode from a real terminal. |
| `--stdio` command execution relies on current PTY behavior. | Run the existing `--stdio` tests. If they fail, inspect before changing semantics because `--stdio` is a transport path and may need special handling. |
| Agent-side behavior is mistaken for CLI behavior. | Keep the new test at the CLI layer. Existing `agent/agentssh` EOF tests are useful but insufficient for this issue. |
| Manual workspace dogfood is unavailable. | Do not claim live dogfood success. Report automated validation plus the exact missing environment requirement. |

## Suggested final implementation notes

When the fix is complete, summarize it as:

* `coder ssh` now requests a PTY only for interactive shell sessions.
* Remote command sessions run without a PTY by default, so stdin EOF propagates to commands that read from stdin.
* Added regression coverage for command-mode piped stdin.
* Verified focused SSH tests, lint, and dogfood commands where environment allowed.

</details>

---

*Generated with* [`mux`](<https://github.com/coder/mux>) • Model: `openai:gpt-5.5` • Thinking: `xhigh`