### PR TITLE
feat: add AIProvider types and client methods

### DIFF
--- a/codersdk/aiproviders.go
+++ b/codersdk/aiproviders.go
@@ -1,6 +1,7 @@
 package codersdk
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -8,6 +9,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"golang.org/x/xerrors"
 )
 
 // AIProviderType identifies the protocol Coder uses to communicate
@@ -19,32 +21,115 @@ const (
 	AIProviderTypeAnthropic AIProviderType = "anthropic"
 )
 
-// AIProviderSettings holds type-specific provider settings that do
-// not fit the generic API key + base URL pattern. Fields are only
-// meaningful for specific provider types.
+// AIProviderSettings is the discriminated container for type-specific
+// provider settings stored in ai_providers.settings. Providers that
+// need no type-specific configuration (current OpenAI and standard
+// Anthropic flows) leave every field nil; the wire form for those
+// providers is JSON null.
 //
-// Bedrock-targeted Anthropic providers authenticate via the AWS
-// credentials stored on this struct, not via an entry in
-// ai_provider_keys.
+// On the wire, settings serialize as a JSON object that always carries
+// _type and _version discriminator keys alongside the type-specific
+// fields. The custom (Un)MarshalJSON implementations on this type
+// handle the routing automatically; callers should never marshal the
+// concrete settings struct directly.
 type AIProviderSettings struct {
-	// BedrockRegion is the AWS region used to construct the Bedrock
-	// endpoint URL when BaseURL is not set on the parent provider.
-	// Only meaningful when Type is AIProviderTypeAnthropic.
-	BedrockRegion string `json:"bedrock_region,omitempty"`
-	// BedrockModel is the AWS Bedrock model identifier used for
-	// primary requests. Only meaningful when Type is
+	// Bedrock, when set, indicates this provider authenticates against
+	// AWS Bedrock instead of api.anthropic.com. Only meaningful for
 	// AIProviderTypeAnthropic.
-	BedrockModel string `json:"bedrock_model,omitempty"`
-	// BedrockSmallFastModel is the AWS Bedrock model identifier used
-	// for background tasks (e.g. Claude Code's haiku-class model).
-	// Only meaningful when Type is AIProviderTypeAnthropic.
-	BedrockSmallFastModel string `json:"bedrock_small_fast_model,omitempty"`
-	// BedrockAccessKey is the AWS access key ID used to authenticate
-	// against Bedrock. Write-only.
-	BedrockAccessKey string `json:"bedrock_access_key,omitempty"`
-	// BedrockAccessKeySecret is the AWS secret access key paired with
-	// BedrockAccessKey. Write-only.
-	BedrockAccessKeySecret string `json:"bedrock_access_key_secret,omitempty"`
+	Bedrock *AIProviderBedrockSettings `json:"-"`
+}
+
+// IsZero reports whether the settings carry no type-specific data.
+func (s AIProviderSettings) IsZero() bool {
+	return s.Bedrock == nil
+}
+
+// MarshalJSON emits the discriminated wire form. Empty settings encode
+// as JSON null so the column round-trips cleanly through SQL NULL.
+func (s AIProviderSettings) MarshalJSON() ([]byte, error) {
+	switch {
+	case s.Bedrock != nil:
+		return marshalSettings(*s.Bedrock)
+	default:
+		return []byte("null"), nil
+	}
+}
+
+// UnmarshalJSON inspects the _type discriminator and routes to the
+// concrete settings struct that matches it.
+func (s *AIProviderSettings) UnmarshalJSON(data []byte) error {
+	*s = AIProviderSettings{}
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return nil
+	}
+	var header aiProviderSettingsHeader
+	if err := json.Unmarshal(data, &header); err != nil {
+		return xerrors.Errorf("decode settings header: %w", err)
+	}
+	if header.Type == "" {
+		return xerrors.New("settings missing _type discriminator")
+	}
+	switch header.Type {
+	case AIProviderSettingsTypeBedrock:
+		// TODO: handle multiple versions; this will be implemented
+		// once needed.
+		if header.Version != AIProviderBedrockSettingsVersion {
+			return xerrors.Errorf("unsupported %q settings version %d (expected %d)",
+				header.Type, header.Version, AIProviderBedrockSettingsVersion)
+		}
+		var b AIProviderBedrockSettings
+		if err := json.Unmarshal(data, &b); err != nil {
+			return xerrors.Errorf("decode bedrock settings: %w", err)
+		}
+		s.Bedrock = &b
+		return nil
+	default:
+		return xerrors.Errorf("unknown settings type %q", header.Type)
+	}
+}
+
+// aiProviderSettingsHeader is the discriminator-only view of an
+// encoded settings blob.
+type aiProviderSettingsHeader struct {
+	Type    string `json:"_type"`
+	Version int    `json:"_version"`
+}
+
+// settingsTyped is implemented by concrete settings structs so that
+// marshalSettings can inject the discriminator without type-asserting
+// against every variant.
+type settingsTyped interface {
+	settingsType() string
+	settingsVersion() int
+}
+
+// marshalSettings encodes a concrete settings struct and merges the
+// _type and _version discriminator keys at the top level of the
+// resulting JSON object.
+func marshalSettings(s settingsTyped) ([]byte, error) {
+	raw, err := json.Marshal(s)
+	if err != nil {
+		return nil, err
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil, err
+	}
+	if m == nil {
+		m = make(map[string]json.RawMessage)
+	}
+	typeRaw, err := json.Marshal(s.settingsType())
+	if err != nil {
+		return nil, err
+	}
+	versRaw, err := json.Marshal(s.settingsVersion())
+	if err != nil {
+		return nil, err
+	}
+	m["_type"] = typeRaw
+	m["_version"] = versRaw
+	return json.Marshal(m)
 }
 
 // AIProvider represents an AI provider configuration row as returned
@@ -74,7 +159,7 @@ type CreateAIProviderRequest struct {
 	DisplayName string             `json:"display_name,omitempty"`
 	Enabled     bool               `json:"enabled"`
 	BaseURL     string             `json:"base_url"`
-	Settings    AIProviderSettings `json:"settings,omitempty"`
+	Settings    AIProviderSettings `json:"settings,omitzero"`
 }
 
 // UpdateAIProviderRequest is the payload for partially updating an

--- a/codersdk/aiproviders.go
+++ b/codersdk/aiproviders.go
@@ -1,0 +1,153 @@
+package codersdk
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// AIProviderType identifies the protocol Coder uses to communicate
+// with an upstream AI provider.
+type AIProviderType string
+
+const (
+	AIProviderTypeOpenAI    AIProviderType = "openai"
+	AIProviderTypeAnthropic AIProviderType = "anthropic"
+)
+
+// AIProviderSettings holds type-specific provider settings that do
+// not fit the generic API key + base URL pattern. Fields are only
+// meaningful for specific provider types.
+type AIProviderSettings struct {
+	// BedrockRegion is the AWS region used to construct the Bedrock
+	// endpoint URL when BaseURL is not set on the parent provider.
+	// Only meaningful when Type is AIProviderTypeAnthropic.
+	BedrockRegion string `json:"bedrock_region,omitempty"`
+	// BedrockModel is the AWS Bedrock model identifier used for
+	// primary requests. Only meaningful when Type is
+	// AIProviderTypeAnthropic.
+	BedrockModel string `json:"bedrock_model,omitempty"`
+	// BedrockSmallFastModel is the AWS Bedrock model identifier used
+	// for background tasks (e.g. Claude Code's haiku-class model).
+	// Only meaningful when Type is AIProviderTypeAnthropic.
+	BedrockSmallFastModel string `json:"bedrock_small_fast_model,omitempty"`
+}
+
+// AIProvider represents an AI Bridge provider configuration row as
+// returned by the API. APIKey and BedrockAccessKeySecret are write-
+// only and never included in responses.
+type AIProvider struct {
+	ID          uuid.UUID          `json:"id" format:"uuid"`
+	Type        AIProviderType     `json:"type"`
+	Name        string             `json:"name"`
+	DisplayName string             `json:"display_name"`
+	Enabled     bool               `json:"enabled"`
+	BaseURL     string             `json:"base_url"`
+	Settings    AIProviderSettings `json:"settings"`
+	CreatedAt   time.Time          `json:"created_at" format:"date-time"`
+	UpdatedAt   time.Time          `json:"updated_at" format:"date-time"`
+}
+
+// CreateAIProviderRequest is the payload for creating a new AI
+// provider. Name, Type, and BaseURL are required.
+type CreateAIProviderRequest struct {
+	Type        AIProviderType     `json:"type"`
+	Name        string             `json:"name"`
+	DisplayName string             `json:"display_name,omitempty"`
+	Enabled     bool               `json:"enabled"`
+	BaseURL     string             `json:"base_url"`
+	APIKey      string             `json:"api_key,omitempty"`
+	Settings    AIProviderSettings `json:"settings,omitempty"`
+	// BedrockAccessKeySecret is the AWS secret access key paired with
+	// APIKey (used as the access key) when configuring an Anthropic
+	// provider that targets AWS Bedrock. Write-only.
+	BedrockAccessKeySecret string `json:"bedrock_access_key_secret,omitempty"`
+}
+
+// UpdateAIProviderRequest is the payload for partially updating an
+// AI provider. At least one field must be non-nil. Pointer fields
+// distinguish "not sent" (nil) from "set to empty/zero" (a pointer
+// to the zero value).
+type UpdateAIProviderRequest struct {
+	DisplayName            *string             `json:"display_name,omitempty"`
+	Enabled                *bool               `json:"enabled,omitempty"`
+	BaseURL                *string             `json:"base_url,omitempty"`
+	APIKey                 *string             `json:"api_key,omitempty"`
+	Settings               *AIProviderSettings `json:"settings,omitempty"`
+	BedrockAccessKeySecret *string             `json:"bedrock_access_key_secret,omitempty"`
+}
+
+// AIProviders lists all (non-deleted) AI providers.
+func (c *Client) AIProviders(ctx context.Context) ([]AIProvider, error) {
+	res, err := c.Request(ctx, http.MethodGet, "/api/v2/aibridge/providers", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return nil, ReadBodyAsError(res)
+	}
+	var providers []AIProvider
+	return providers, json.NewDecoder(res.Body).Decode(&providers)
+}
+
+// AIProvider fetches a single AI provider by ID or name.
+func (c *Client) AIProvider(ctx context.Context, idOrName string) (AIProvider, error) {
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/v2/aibridge/providers/%s", idOrName), nil)
+	if err != nil {
+		return AIProvider{}, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return AIProvider{}, ReadBodyAsError(res)
+	}
+	var provider AIProvider
+	return provider, json.NewDecoder(res.Body).Decode(&provider)
+}
+
+// CreateAIProvider creates a new AI provider.
+func (c *Client) CreateAIProvider(ctx context.Context, req CreateAIProviderRequest) (AIProvider, error) {
+	res, err := c.Request(ctx, http.MethodPost, "/api/v2/aibridge/providers", req)
+	if err != nil {
+		return AIProvider{}, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusCreated {
+		return AIProvider{}, ReadBodyAsError(res)
+	}
+	var provider AIProvider
+	return provider, json.NewDecoder(res.Body).Decode(&provider)
+}
+
+// UpdateAIProvider partially updates an AI provider identified by
+// ID or name.
+func (c *Client) UpdateAIProvider(ctx context.Context, idOrName string, req UpdateAIProviderRequest) (AIProvider, error) {
+	res, err := c.Request(ctx, http.MethodPatch, fmt.Sprintf("/api/v2/aibridge/providers/%s", idOrName), req)
+	if err != nil {
+		return AIProvider{}, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return AIProvider{}, ReadBodyAsError(res)
+	}
+	var provider AIProvider
+	return provider, json.NewDecoder(res.Body).Decode(&provider)
+}
+
+// DeleteAIProvider soft-deletes an AI provider identified by ID or
+// name. The row is preserved for audit/FK history.
+func (c *Client) DeleteAIProvider(ctx context.Context, idOrName string) error {
+	res, err := c.Request(ctx, http.MethodDelete, fmt.Sprintf("/api/v2/aibridge/providers/%s", idOrName), nil)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusNoContent {
+		return ReadBodyAsError(res)
+	}
+	return nil
+}

--- a/codersdk/aiproviders.go
+++ b/codersdk/aiproviders.go
@@ -22,6 +22,10 @@ const (
 // AIProviderSettings holds type-specific provider settings that do
 // not fit the generic API key + base URL pattern. Fields are only
 // meaningful for specific provider types.
+//
+// Bedrock-targeted Anthropic providers authenticate via the AWS
+// credentials stored on this struct, not via an entry in
+// ai_provider_keys.
 type AIProviderSettings struct {
 	// BedrockRegion is the AWS region used to construct the Bedrock
 	// endpoint URL when BaseURL is not set on the parent provider.
@@ -35,11 +39,18 @@ type AIProviderSettings struct {
 	// for background tasks (e.g. Claude Code's haiku-class model).
 	// Only meaningful when Type is AIProviderTypeAnthropic.
 	BedrockSmallFastModel string `json:"bedrock_small_fast_model,omitempty"`
+	// BedrockAccessKey is the AWS access key ID used to authenticate
+	// against Bedrock. Write-only.
+	BedrockAccessKey string `json:"bedrock_access_key,omitempty"`
+	// BedrockAccessKeySecret is the AWS secret access key paired with
+	// BedrockAccessKey. Write-only.
+	BedrockAccessKeySecret string `json:"bedrock_access_key_secret,omitempty"`
 }
 
-// AIProvider represents an AI Bridge provider configuration row as
-// returned by the API. APIKey and BedrockAccessKeySecret are write-
-// only and never included in responses.
+// AIProvider represents an AI provider configuration row as returned
+// by the API. API keys are stored in a separate ai_provider_keys
+// table and managed via the keys sub-endpoints; secret fields on
+// Settings are never included in responses.
 type AIProvider struct {
 	ID          uuid.UUID          `json:"id" format:"uuid"`
 	Type        AIProviderType     `json:"type"`
@@ -53,19 +64,17 @@ type AIProvider struct {
 }
 
 // CreateAIProviderRequest is the payload for creating a new AI
-// provider. Name, Type, and BaseURL are required.
+// provider. Name, Type, and BaseURL are required. API keys for
+// OpenAI/Anthropic providers are added via the keys sub-endpoint
+// after the provider is created; Bedrock providers carry their
+// credentials in Settings and do not use the keys sub-endpoint.
 type CreateAIProviderRequest struct {
 	Type        AIProviderType     `json:"type"`
 	Name        string             `json:"name"`
 	DisplayName string             `json:"display_name,omitempty"`
 	Enabled     bool               `json:"enabled"`
 	BaseURL     string             `json:"base_url"`
-	APIKey      string             `json:"api_key,omitempty"`
 	Settings    AIProviderSettings `json:"settings,omitempty"`
-	// BedrockAccessKeySecret is the AWS secret access key paired with
-	// APIKey (used as the access key) when configuring an Anthropic
-	// provider that targets AWS Bedrock. Write-only.
-	BedrockAccessKeySecret string `json:"bedrock_access_key_secret,omitempty"`
 }
 
 // UpdateAIProviderRequest is the payload for partially updating an
@@ -73,17 +82,33 @@ type CreateAIProviderRequest struct {
 // distinguish "not sent" (nil) from "set to empty/zero" (a pointer
 // to the zero value).
 type UpdateAIProviderRequest struct {
-	DisplayName            *string             `json:"display_name,omitempty"`
-	Enabled                *bool               `json:"enabled,omitempty"`
-	BaseURL                *string             `json:"base_url,omitempty"`
-	APIKey                 *string             `json:"api_key,omitempty"`
-	Settings               *AIProviderSettings `json:"settings,omitempty"`
-	BedrockAccessKeySecret *string             `json:"bedrock_access_key_secret,omitempty"`
+	DisplayName *string             `json:"display_name,omitempty"`
+	Enabled     *bool               `json:"enabled,omitempty"`
+	BaseURL     *string             `json:"base_url,omitempty"`
+	Settings    *AIProviderSettings `json:"settings,omitempty"`
+}
+
+// AIProviderKey represents a single API key registered against an
+// AI provider, as returned by the API. The plaintext APIKey is
+// write-only and never included in responses.
+type AIProviderKey struct {
+	ID         uuid.UUID `json:"id" format:"uuid"`
+	ProviderID uuid.UUID `json:"provider_id" format:"uuid"`
+	CreatedAt  time.Time `json:"created_at" format:"date-time"`
+	UpdatedAt  time.Time `json:"updated_at" format:"date-time"`
+}
+
+// CreateAIProviderKeyRequest is the payload for adding an API key to
+// an AI provider. Only meaningful for openai and anthropic providers;
+// Bedrock providers reject this call because they use the access
+// credentials stored in Settings.
+type CreateAIProviderKeyRequest struct {
+	APIKey string `json:"api_key"`
 }
 
 // AIProviders lists all (non-deleted) AI providers.
 func (c *Client) AIProviders(ctx context.Context) ([]AIProvider, error) {
-	res, err := c.Request(ctx, http.MethodGet, "/api/v2/aibridge/providers", nil)
+	res, err := c.Request(ctx, http.MethodGet, "/api/v2/ai/providers", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +122,7 @@ func (c *Client) AIProviders(ctx context.Context) ([]AIProvider, error) {
 
 // AIProvider fetches a single AI provider by ID or name.
 func (c *Client) AIProvider(ctx context.Context, idOrName string) (AIProvider, error) {
-	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/v2/aibridge/providers/%s", idOrName), nil)
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/v2/ai/providers/%s", idOrName), nil)
 	if err != nil {
 		return AIProvider{}, err
 	}
@@ -111,7 +136,7 @@ func (c *Client) AIProvider(ctx context.Context, idOrName string) (AIProvider, e
 
 // CreateAIProvider creates a new AI provider.
 func (c *Client) CreateAIProvider(ctx context.Context, req CreateAIProviderRequest) (AIProvider, error) {
-	res, err := c.Request(ctx, http.MethodPost, "/api/v2/aibridge/providers", req)
+	res, err := c.Request(ctx, http.MethodPost, "/api/v2/ai/providers", req)
 	if err != nil {
 		return AIProvider{}, err
 	}
@@ -126,7 +151,7 @@ func (c *Client) CreateAIProvider(ctx context.Context, req CreateAIProviderReque
 // UpdateAIProvider partially updates an AI provider identified by
 // ID or name.
 func (c *Client) UpdateAIProvider(ctx context.Context, idOrName string, req UpdateAIProviderRequest) (AIProvider, error) {
-	res, err := c.Request(ctx, http.MethodPatch, fmt.Sprintf("/api/v2/aibridge/providers/%s", idOrName), req)
+	res, err := c.Request(ctx, http.MethodPatch, fmt.Sprintf("/api/v2/ai/providers/%s", idOrName), req)
 	if err != nil {
 		return AIProvider{}, err
 	}
@@ -141,7 +166,35 @@ func (c *Client) UpdateAIProvider(ctx context.Context, idOrName string, req Upda
 // DeleteAIProvider soft-deletes an AI provider identified by ID or
 // name. The row is preserved for audit/FK history.
 func (c *Client) DeleteAIProvider(ctx context.Context, idOrName string) error {
-	res, err := c.Request(ctx, http.MethodDelete, fmt.Sprintf("/api/v2/aibridge/providers/%s", idOrName), nil)
+	res, err := c.Request(ctx, http.MethodDelete, fmt.Sprintf("/api/v2/ai/providers/%s", idOrName), nil)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusNoContent {
+		return ReadBodyAsError(res)
+	}
+	return nil
+}
+
+// CreateAIProviderKey registers a new API key against an AI
+// provider identified by ID or name.
+func (c *Client) CreateAIProviderKey(ctx context.Context, idOrName string, req CreateAIProviderKeyRequest) (AIProviderKey, error) {
+	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/v2/ai/providers/%s/keys", idOrName), req)
+	if err != nil {
+		return AIProviderKey{}, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusCreated {
+		return AIProviderKey{}, ReadBodyAsError(res)
+	}
+	var key AIProviderKey
+	return key, json.NewDecoder(res.Body).Decode(&key)
+}
+
+// DeleteAIProviderKey removes a single API key from an AI provider.
+func (c *Client) DeleteAIProviderKey(ctx context.Context, idOrName string, keyID uuid.UUID) error {
+	res, err := c.Request(ctx, http.MethodDelete, fmt.Sprintf("/api/v2/ai/providers/%s/keys/%s", idOrName, keyID), nil)
 	if err != nil {
 		return err
 	}

--- a/codersdk/aiproviders_bedrock.go
+++ b/codersdk/aiproviders_bedrock.go
@@ -1,0 +1,38 @@
+package codersdk
+
+// AIProviderSettingsTypeBedrock is the _type discriminator value for
+// AIProviderBedrockSettings.
+const AIProviderSettingsTypeBedrock = "bedrock"
+
+// AIProviderBedrockSettingsVersion is the current schema version of
+// AIProviderBedrockSettings.
+const AIProviderBedrockSettingsVersion = 1
+
+// AIProviderBedrockSettings configures providers that authenticate
+// against AWS Bedrock. AccessKey and AccessKeySecret are write-only:
+// servers strip them from GET and list responses.
+type AIProviderBedrockSettings struct {
+	// Region is the AWS region used to construct the Bedrock endpoint
+	// URL when BaseURL is not set on the parent provider.
+	Region string `json:"region,omitempty"`
+	// Model is the AWS Bedrock model identifier used for primary
+	// requests.
+	Model string `json:"model,omitempty"`
+	// SmallFastModel is the AWS Bedrock model identifier used for
+	// background tasks (e.g. Claude Code's haiku-class model).
+	SmallFastModel string `json:"small_fast_model,omitempty"`
+	// AccessKey is the AWS access key ID used to authenticate against
+	// Bedrock. Write-only.
+	AccessKey string `json:"access_key,omitempty"`
+	// AccessKeySecret is the AWS secret access key paired with
+	// AccessKey. Write-only.
+	AccessKeySecret string `json:"access_key_secret,omitempty"`
+}
+
+func (AIProviderBedrockSettings) settingsType() string {
+	return AIProviderSettingsTypeBedrock
+}
+
+func (AIProviderBedrockSettings) settingsVersion() int {
+	return AIProviderBedrockSettingsVersion
+}

--- a/codersdk/aiproviders_test.go
+++ b/codersdk/aiproviders_test.go
@@ -1,0 +1,160 @@
+package codersdk_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/codersdk"
+)
+
+func TestAIProviderSettings_Marshal(t *testing.T) {
+	t.Parallel()
+
+	t.Run("EmptyEmitsNull", func(t *testing.T) {
+		t.Parallel()
+		got, err := json.Marshal(codersdk.AIProviderSettings{})
+		require.NoError(t, err)
+		require.Equal(t, "null", string(got))
+	})
+
+	t.Run("BedrockEmitsDiscriminator", func(t *testing.T) {
+		t.Parallel()
+		got, err := json.Marshal(codersdk.AIProviderSettings{
+			Bedrock: &codersdk.AIProviderBedrockSettings{
+				Region:          "us-east-1",
+				Model:           "anthropic.claude-3-5-sonnet",
+				SmallFastModel:  "anthropic.claude-3-5-haiku",
+				AccessKey:       "AKIA-test", //nolint:gosec // fixture
+				AccessKeySecret: "secret",
+			},
+		})
+		require.NoError(t, err)
+
+		// Decode back into a plain map so we can assert the wire
+		// keys without coupling to JSON field ordering.
+		var raw map[string]any
+		require.NoError(t, json.Unmarshal(got, &raw))
+		require.Equal(t, codersdk.AIProviderSettingsTypeBedrock, raw["_type"])
+		require.EqualValues(t, codersdk.AIProviderBedrockSettingsVersion, raw["_version"])
+		require.Equal(t, "us-east-1", raw["region"])
+		require.Equal(t, "anthropic.claude-3-5-sonnet", raw["model"])
+		require.Equal(t, "anthropic.claude-3-5-haiku", raw["small_fast_model"])
+		require.Equal(t, "AKIA-test", raw["access_key"])
+		require.Equal(t, "secret", raw["access_key_secret"])
+	})
+
+	t.Run("BedrockOmitsEmptyFields", func(t *testing.T) {
+		t.Parallel()
+		got, err := json.Marshal(codersdk.AIProviderSettings{
+			Bedrock: &codersdk.AIProviderBedrockSettings{Region: "us-east-1"},
+		})
+		require.NoError(t, err)
+		require.Contains(t, string(got), `"region":"us-east-1"`)
+		require.NotContains(t, string(got), "model")
+		require.NotContains(t, string(got), "access_key")
+	})
+}
+
+func TestAIProviderSettings_Unmarshal(t *testing.T) {
+	t.Parallel()
+
+	t.Run("EmptyInputZeroes", func(t *testing.T) {
+		t.Parallel()
+		// encoding/json never invokes UnmarshalJSON with an empty
+		// payload, but the method must still tolerate it for callers
+		// (e.g. row decoders) that hand it raw column bytes.
+		var s codersdk.AIProviderSettings
+		require.NoError(t, s.UnmarshalJSON(nil))
+		require.True(t, s.IsZero())
+		require.NoError(t, s.UnmarshalJSON([]byte("")))
+		require.True(t, s.IsZero())
+	})
+
+	t.Run("NullZeroes", func(t *testing.T) {
+		t.Parallel()
+		var s codersdk.AIProviderSettings
+		require.NoError(t, json.Unmarshal([]byte(`null`), &s))
+		require.True(t, s.IsZero())
+	})
+
+	t.Run("BedrockSupportedVersion", func(t *testing.T) {
+		t.Parallel()
+		var s codersdk.AIProviderSettings
+		require.NoError(t, json.Unmarshal([]byte(`{
+			"_type":    "bedrock",
+			"_version": 1,
+			"region":   "us-east-1",
+			"model":    "anthropic.claude-3-5-sonnet"
+		}`), &s))
+		require.NotNil(t, s.Bedrock)
+		require.Equal(t, "us-east-1", s.Bedrock.Region)
+		require.Equal(t, "anthropic.claude-3-5-sonnet", s.Bedrock.Model)
+	})
+
+	t.Run("MissingTypeDiscriminator", func(t *testing.T) {
+		t.Parallel()
+		var s codersdk.AIProviderSettings
+		err := json.Unmarshal([]byte(`{"_version":1,"region":"us-east-1"}`), &s)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "_type")
+	})
+
+	t.Run("UnsupportedVersion", func(t *testing.T) {
+		t.Parallel()
+		var s codersdk.AIProviderSettings
+		err := json.Unmarshal([]byte(`{"_type":"bedrock","_version":99}`), &s)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "version")
+	})
+
+	t.Run("UnknownType", func(t *testing.T) {
+		t.Parallel()
+		var s codersdk.AIProviderSettings
+		err := json.Unmarshal([]byte(`{"_type":"copilot","_version":1}`), &s)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unknown")
+	})
+
+	t.Run("MalformedHeader", func(t *testing.T) {
+		t.Parallel()
+		var s codersdk.AIProviderSettings
+		err := json.Unmarshal([]byte(`{"_type": 1}`), &s)
+		require.Error(t, err)
+	})
+
+	t.Run("ResetsBetweenCalls", func(t *testing.T) {
+		t.Parallel()
+		// A non-zero value passed to Unmarshal should be reset when
+		// the payload decodes to null, so callers can reuse the
+		// variable without leaking stale state.
+		s := codersdk.AIProviderSettings{
+			Bedrock: &codersdk.AIProviderBedrockSettings{Region: "us-east-1"},
+		}
+		require.NoError(t, json.Unmarshal([]byte(`null`), &s))
+		require.True(t, s.IsZero())
+	})
+}
+
+func TestAIProviderSettings_Roundtrip(t *testing.T) {
+	t.Parallel()
+	orig := codersdk.AIProviderSettings{
+		Bedrock: &codersdk.AIProviderBedrockSettings{
+			Region:          "us-west-2",
+			Model:           "anthropic.claude-sonnet-4-5",
+			SmallFastModel:  "anthropic.claude-haiku-4-5",
+			AccessKey:       "AKIA-roundtrip", //nolint:gosec // fixture
+			AccessKeySecret: "secret-roundtrip",
+		},
+	}
+	encoded, err := json.Marshal(orig)
+	require.NoError(t, err)
+	// Sanity: discriminator is part of the on-wire shape.
+	require.True(t, strings.Contains(string(encoded), `"_type":"bedrock"`))
+
+	var got codersdk.AIProviderSettings
+	require.NoError(t, json.Unmarshal(encoded, &got))
+	require.Equal(t, orig, got)
+}

--- a/codersdk/aiproviders_test.go
+++ b/codersdk/aiproviders_test.go
@@ -98,31 +98,32 @@ func TestAIProviderSettings_Unmarshal(t *testing.T) {
 		t.Parallel()
 		var s codersdk.AIProviderSettings
 		err := json.Unmarshal([]byte(`{"_version":1,"region":"us-east-1"}`), &s)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "_type")
+		require.ErrorContains(t, err, "missing _type discriminator")
 	})
 
 	t.Run("UnsupportedVersion", func(t *testing.T) {
 		t.Parallel()
 		var s codersdk.AIProviderSettings
 		err := json.Unmarshal([]byte(`{"_type":"bedrock","_version":99}`), &s)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "version")
+		require.ErrorContains(t, err, `unsupported "bedrock" settings version 99`)
+		require.ErrorContains(t, err, "expected 1")
 	})
 
 	t.Run("UnknownType", func(t *testing.T) {
 		t.Parallel()
 		var s codersdk.AIProviderSettings
 		err := json.Unmarshal([]byte(`{"_type":"copilot","_version":1}`), &s)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "unknown")
+		require.ErrorContains(t, err, `unknown settings type "copilot"`)
 	})
 
 	t.Run("MalformedHeader", func(t *testing.T) {
 		t.Parallel()
+		// _type must be a string; passing a number triggers the
+		// header decode path before any discriminator routing.
 		var s codersdk.AIProviderSettings
 		err := json.Unmarshal([]byte(`{"_type": 1}`), &s)
-		require.Error(t, err)
+		require.ErrorContains(t, err, "decode settings header")
+		require.ErrorContains(t, err, "_type")
 	})
 
 	t.Run("ResetsBetweenCalls", func(t *testing.T) {

--- a/codersdk/aiproviders_test.go
+++ b/codersdk/aiproviders_test.go
@@ -17,7 +17,7 @@ func TestAIProviderSettings_Marshal(t *testing.T) {
 		t.Parallel()
 		got, err := json.Marshal(codersdk.AIProviderSettings{})
 		require.NoError(t, err)
-		require.Equal(t, "null", string(got))
+		require.JSONEq(t, `null`, string(got))
 	})
 
 	t.Run("BedrockEmitsDiscriminator", func(t *testing.T) {
@@ -32,18 +32,15 @@ func TestAIProviderSettings_Marshal(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-
-		// Decode back into a plain map so we can assert the wire
-		// keys without coupling to JSON field ordering.
-		var raw map[string]any
-		require.NoError(t, json.Unmarshal(got, &raw))
-		require.Equal(t, codersdk.AIProviderSettingsTypeBedrock, raw["_type"])
-		require.EqualValues(t, codersdk.AIProviderBedrockSettingsVersion, raw["_version"])
-		require.Equal(t, "us-east-1", raw["region"])
-		require.Equal(t, "anthropic.claude-3-5-sonnet", raw["model"])
-		require.Equal(t, "anthropic.claude-3-5-haiku", raw["small_fast_model"])
-		require.Equal(t, "AKIA-test", raw["access_key"])
-		require.Equal(t, "secret", raw["access_key_secret"])
+		require.JSONEq(t, `{
+			"_type": "bedrock",
+			"_version": 1,
+			"region": "us-east-1",
+			"model": "anthropic.claude-3-5-sonnet",
+			"small_fast_model": "anthropic.claude-3-5-haiku",
+			"access_key": "AKIA-test",
+			"access_key_secret": "secret"
+		}`, string(got))
 	})
 
 	t.Run("BedrockOmitsEmptyFields", func(t *testing.T) {
@@ -52,9 +49,11 @@ func TestAIProviderSettings_Marshal(t *testing.T) {
 			Bedrock: &codersdk.AIProviderBedrockSettings{Region: "us-east-1"},
 		})
 		require.NoError(t, err)
-		require.Contains(t, string(got), `"region":"us-east-1"`)
-		require.NotContains(t, string(got), "model")
-		require.NotContains(t, string(got), "access_key")
+		require.JSONEq(t, `{
+			"_type": "bedrock",
+			"_version": 1,
+			"region": "us-east-1"
+		}`, string(got))
 	})
 }
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -317,6 +317,47 @@ export interface AIProvider {
 	readonly updated_at: string;
 }
 
+// From codersdk/aiproviders_bedrock.go
+/**
+ * AIProviderBedrockSettings configures providers that authenticate
+ * against AWS Bedrock. AccessKey and AccessKeySecret are write-only:
+ * servers strip them from GET and list responses.
+ */
+export interface AIProviderBedrockSettings {
+	/**
+	 * Region is the AWS region used to construct the Bedrock endpoint
+	 * URL when BaseURL is not set on the parent provider.
+	 */
+	readonly region?: string;
+	/**
+	 * Model is the AWS Bedrock model identifier used for primary
+	 * requests.
+	 */
+	readonly model?: string;
+	/**
+	 * SmallFastModel is the AWS Bedrock model identifier used for
+	 * background tasks (e.g. Claude Code's haiku-class model).
+	 */
+	readonly small_fast_model?: string;
+	/**
+	 * AccessKey is the AWS access key ID used to authenticate against
+	 * Bedrock. Write-only.
+	 */
+	readonly access_key?: string;
+	/**
+	 * AccessKeySecret is the AWS secret access key paired with
+	 * AccessKey. Write-only.
+	 */
+	readonly access_key_secret?: string;
+}
+
+// From codersdk/aiproviders_bedrock.go
+/**
+ * AIProviderBedrockSettingsVersion is the current schema version of
+ * AIProviderBedrockSettings.
+ */
+export const AIProviderBedrockSettingsVersion = 1;
+
 // From codersdk/deployment.go
 /**
  * AIProviderConfig represents a single AI provider instance,

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -298,6 +298,24 @@ export interface AIConfig {
 	readonly chat?: ChatConfig;
 }
 
+// From codersdk/aiproviders.go
+/**
+ * AIProvider represents an AI Bridge provider configuration row as
+ * returned by the API. APIKey and BedrockAccessKeySecret are write-
+ * only and never included in responses.
+ */
+export interface AIProvider {
+	readonly id: string;
+	readonly type: AIProviderType;
+	readonly name: string;
+	readonly display_name: string;
+	readonly enabled: boolean;
+	readonly base_url: string;
+	readonly settings: AIProviderSettings;
+	readonly created_at: string;
+	readonly updated_at: string;
+}
+
 // From codersdk/deployment.go
 /**
  * AIProviderConfig represents a single AI provider instance,
@@ -326,6 +344,40 @@ export interface AIProviderConfig {
 	readonly bedrock_model?: string;
 	readonly bedrock_small_fast_model?: string;
 }
+
+// From codersdk/aiproviders.go
+/**
+ * AIProviderSettings is the discriminated container for type-specific
+ * provider settings stored in ai_providers.settings. Providers that
+ * need no type-specific configuration (current OpenAI and standard
+ * Anthropic flows) leave every field nil; the wire form for those
+ * providers is JSON null.
+ */
+export interface AIProviderSettings {
+	/**
+	 * BedrockRegion is the AWS region used to construct the Bedrock
+	 * endpoint URL when BaseURL is not set on the parent provider.
+	 * Only meaningful when Type is AIProviderTypeAnthropic.
+	 */
+	readonly bedrock_region?: string;
+	/**
+	 * BedrockModel is the AWS Bedrock model identifier used for
+	 * primary requests. Only meaningful when Type is
+	 * AIProviderTypeAnthropic.
+	 */
+	readonly bedrock_model?: string;
+	/**
+	 * BedrockSmallFastModel is the AWS Bedrock model identifier used
+	 * for background tasks (e.g. Claude Code's haiku-class model).
+	 * Only meaningful when Type is AIProviderTypeAnthropic.
+	 */
+	readonly bedrock_small_fast_model?: string;
+}
+
+// From codersdk/aiproviders.go
+export type AIProviderType = "anthropic" | "openai";
+
+export const AIProviderTypes: AIProviderType[] = ["anthropic", "openai"];
 
 // From codersdk/allowlist.go
 /**
@@ -2976,6 +3028,27 @@ export interface ConvertLoginRequest {
 	 */
 	readonly to_type: LoginType;
 	readonly password: string;
+}
+
+// From codersdk/aiproviders.go
+/**
+ * CreateAIProviderRequest is the payload for creating a new AI
+ * provider. Name, Type, and BaseURL are required.
+ */
+export interface CreateAIProviderRequest {
+	readonly type: AIProviderType;
+	readonly name: string;
+	readonly display_name?: string;
+	readonly enabled: boolean;
+	readonly base_url: string;
+	readonly api_key?: string;
+	readonly settings?: AIProviderSettings;
+	/**
+	 * BedrockAccessKeySecret is the AWS secret access key paired with
+	 * APIKey (used as the access key) when configuring an Anthropic
+	 * provider that targets AWS Bedrock. Write-only.
+	 */
+	readonly bedrock_access_key_secret?: string;
 }
 
 // From codersdk/chats.go
@@ -8042,6 +8115,22 @@ export interface TraceConfig {
 export interface TransitionStats {
 	readonly P50: number | null;
 	readonly P95: number | null;
+}
+
+// From codersdk/aiproviders.go
+/**
+ * UpdateAIProviderRequest is the payload for partially updating an
+ * AI provider. At least one field must be non-nil. Pointer fields
+ * distinguish "not sent" (nil) from "set to empty/zero" (a pointer
+ * to the zero value).
+ */
+export interface UpdateAIProviderRequest {
+	readonly display_name?: string;
+	readonly enabled?: boolean;
+	readonly base_url?: string;
+	readonly api_key?: string;
+	readonly settings?: AIProviderSettings;
+	readonly bedrock_access_key_secret?: string;
 }
 
 // From codersdk/templates.go

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -300,9 +300,10 @@ export interface AIConfig {
 
 // From codersdk/aiproviders.go
 /**
- * AIProvider represents an AI Bridge provider configuration row as
- * returned by the API. APIKey and BedrockAccessKeySecret are write-
- * only and never included in responses.
+ * AIProvider represents an AI provider configuration row as returned
+ * by the API. API keys are stored in a separate ai_provider_keys
+ * table and managed via the keys sub-endpoints; secret fields on
+ * Settings are never included in responses.
  */
 export interface AIProvider {
 	readonly id: string;
@@ -347,32 +348,39 @@ export interface AIProviderConfig {
 
 // From codersdk/aiproviders.go
 /**
+ * AIProviderKey represents a single API key registered against an
+ * AI provider, as returned by the API. The plaintext APIKey is
+ * write-only and never included in responses.
+ */
+export interface AIProviderKey {
+	readonly id: string;
+	readonly provider_id: string;
+	readonly created_at: string;
+	readonly updated_at: string;
+}
+
+// From codersdk/aiproviders.go
+/**
  * AIProviderSettings is the discriminated container for type-specific
  * provider settings stored in ai_providers.settings. Providers that
  * need no type-specific configuration (current OpenAI and standard
  * Anthropic flows) leave every field nil; the wire form for those
  * providers is JSON null.
+ *
+ * On the wire, settings serialize as a JSON object that always carries
+ * _type and _version discriminator keys alongside the type-specific
+ * fields. The custom (Un)MarshalJSON implementations on this type
+ * handle the routing automatically; callers should never marshal the
+ * concrete settings struct directly.
  */
-export interface AIProviderSettings {
-	/**
-	 * BedrockRegion is the AWS region used to construct the Bedrock
-	 * endpoint URL when BaseURL is not set on the parent provider.
-	 * Only meaningful when Type is AIProviderTypeAnthropic.
-	 */
-	readonly bedrock_region?: string;
-	/**
-	 * BedrockModel is the AWS Bedrock model identifier used for
-	 * primary requests. Only meaningful when Type is
-	 * AIProviderTypeAnthropic.
-	 */
-	readonly bedrock_model?: string;
-	/**
-	 * BedrockSmallFastModel is the AWS Bedrock model identifier used
-	 * for background tasks (e.g. Claude Code's haiku-class model).
-	 * Only meaningful when Type is AIProviderTypeAnthropic.
-	 */
-	readonly bedrock_small_fast_model?: string;
-}
+export interface AIProviderSettings {}
+
+// From codersdk/aiproviders_bedrock.go
+/**
+ * AIProviderSettingsTypeBedrock is the _type discriminator value for
+ * AIProviderBedrockSettings.
+ */
+export const AIProviderSettingsTypeBedrock = "bedrock";
 
 // From codersdk/aiproviders.go
 export type AIProviderType = "anthropic" | "openai";
@@ -3032,8 +3040,22 @@ export interface ConvertLoginRequest {
 
 // From codersdk/aiproviders.go
 /**
+ * CreateAIProviderKeyRequest is the payload for adding an API key to
+ * an AI provider. Only meaningful for openai and anthropic providers;
+ * Bedrock providers reject this call because they use the access
+ * credentials stored in Settings.
+ */
+export interface CreateAIProviderKeyRequest {
+	readonly api_key: string;
+}
+
+// From codersdk/aiproviders.go
+/**
  * CreateAIProviderRequest is the payload for creating a new AI
- * provider. Name, Type, and BaseURL are required.
+ * provider. Name, Type, and BaseURL are required. API keys for
+ * OpenAI/Anthropic providers are added via the keys sub-endpoint
+ * after the provider is created; Bedrock providers carry their
+ * credentials in Settings and do not use the keys sub-endpoint.
  */
 export interface CreateAIProviderRequest {
 	readonly type: AIProviderType;
@@ -3041,14 +3063,7 @@ export interface CreateAIProviderRequest {
 	readonly display_name?: string;
 	readonly enabled: boolean;
 	readonly base_url: string;
-	readonly api_key?: string;
 	readonly settings?: AIProviderSettings;
-	/**
-	 * BedrockAccessKeySecret is the AWS secret access key paired with
-	 * APIKey (used as the access key) when configuring an Anthropic
-	 * provider that targets AWS Bedrock. Write-only.
-	 */
-	readonly bedrock_access_key_secret?: string;
 }
 
 // From codersdk/chats.go
@@ -8128,9 +8143,7 @@ export interface UpdateAIProviderRequest {
 	readonly display_name?: string;
 	readonly enabled?: boolean;
 	readonly base_url?: string;
-	readonly api_key?: string;
 	readonly settings?: AIProviderSettings;
-	readonly bedrock_access_key_secret?: string;
 }
 
 // From codersdk/templates.go


### PR DESCRIPTION
*Disclaimer: implemented by a Coder Agent using Claude Opus 4.7*

Part of the implementation of [RFC: Common AI Provider Configs](https://www.notion.so/coderhq/RFC-Common-AI-Provider-Configs-34bd579be59280ed958feffb82024797) (AIGOV-201).

Adds the `codersdk` types and client methods for runtime AI provider management. AI Bridge is the initial consumer but the data model is provider-generic — other Coder features (Agents, Chat, etc.) can read the same rows over time.

## What's in this PR

- `AIProvider`, `AIProviderType`, `AIProviderSettings`, `AIProviderBedrockSettings`
- `CreateAIProviderRequest`, `UpdateAIProviderRequest`
- `AIProviderKey`, `CreateAIProviderKeyRequest`
- `Client.AIProviders`, `AIProvider`, `CreateAIProvider`, `UpdateAIProvider`, `DeleteAIProvider`
- `Client.CreateAIProviderKey`, `DeleteAIProviderKey` (no list method — keys are write-managed)

`AIProviderSettings` is a discriminated, versioned container: the JSON wire form carries `_type` and `_version` keys alongside the type-specific fields. Only providers that need custom configuration get a struct (just `Bedrock` for now); other types store SQL `NULL`.

Bedrock `access_key` / `access_key_secret` are write-only and never appear in responses. HTTP handlers are in a follow-up PR.

`TestAIProviderSettings_Marshal` / `_Unmarshal` / `_Roundtrip` cover the discriminator routing: null encode/decode, missing/unknown `_type`, unsupported version, bedrock encode and decode, malformed headers, and the reset-between-calls invariant.

## Notes

- `biome.jsonc` adds a `noEmptyInterface` exemption for `typesGenerated.ts`. `AIProviderSettings.Bedrock` is `json:"-"` (custom marshal handles the discriminator), so the generator emits an empty interface and Biome flags it; suppress at the generated-file level rather than restructure the wrapper.