### PR TITLE
fix(site): remove "Tasks on Docker" as featured template

### DIFF
--- a/site/src/pages/CreateTemplateGalleryPage/StarterTemplates.tsx
+++ b/site/src/pages/CreateTemplateGalleryPage/StarterTemplates.tsx
@@ -22,9 +22,9 @@ const selectTags = (starterTemplatesByTag: StarterTemplatesByTag) => {
 };
 
 const sortVisibleTemplates = (templates: TemplateExample[]) => {
-	// The tasks-docker template should be first, as it's the easiest way to
-	// get started with Coder. The docker template should be second.
-	const featuredTemplateIds = ["tasks-docker", "docker"];
+	// The docker template should be first, as it's the easiest way to get
+	// started with Coder.
+	const featuredTemplateIds = ["docker"];
 
 	const featuredTemplates: TemplateExample[] = [];
 	for (const id of featuredTemplateIds) {

--- a/site/src/pages/TemplatesPage/EmptyTemplates.tsx
+++ b/site/src/pages/TemplatesPage/EmptyTemplates.tsx
@@ -10,7 +10,6 @@ import { docs } from "#/utils/docs";
 
 // Those are from https://github.com/coder/coder/tree/main/examples/templates
 const featuredExampleIds = [
-	"tasks-docker",
 	"docker",
 	"kubernetes",
 	"aws-linux",


### PR DESCRIPTION
Removes "Tasks on Docker" from the featured/prioritized template lists in the templates empty state and the starter templates gallery. Docker remains as the primary featured starter template.

Fixes https://linear.app/codercom/issue/DEVREL-20

> Generated with [Coder Agents](https://coder.com/agents)