### PR TITLE
docs(install): add prominent quickstart callout for new users

### DIFF
--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -2,13 +2,16 @@
 
 A single CLI (`coder`) is used for both the Coder server and the client.
 
+> **New to Coder?** Follow the
+> [quickstart guide](../tutorials/quickstart.md) for a step-by-step walkthrough
+> that covers installation, creating your first template, and launching a
+> workspace.
+
 We support two release channels: mainline and stable - read the
 [Releases](./releases/index.md) page to learn more about which best suits your team.
 
-There are several ways to install Coder. Follow the steps on this page for a
-minimal installation of Coder, or for a step-by-step guide on how to install and
-configure your first Coder deployment, follow the
-[quickstart guide](../tutorials/quickstart.md).
+This page covers standalone installation methods. For a guided end-to-end
+setup, see the [quickstart guide](../tutorials/quickstart.md).
 
 ## Local/Individual Installs
 


### PR DESCRIPTION
Adds a prominent blockquote callout at the top of the install page directing new users to the quickstart guide. Simplifies the existing inline quickstart reference.

> [!IMPORTANT]
> **Do not merge until Wednesday.** Nick is working on quickstart improvements and we want those to land first.

Companion PR: coder/coder.com (CTA routing changes)

Ref: [DEVREL-18](https://linear.app/codercom/issue/DEVREL-18)

> Generated by Coder Agents