### PR TITLE
refactor: remove unused tailnet connIO stats fields

### DIFF
--- a/enterprise/tailnet/connio.go
+++ b/enterprise/tailnet/connio.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"slices"
 	"sync"
-	"sync/atomic"
-	"time"
 
 	"github.com/google/uuid"
 	"golang.org/x/xerrors"
@@ -39,10 +37,7 @@ type connIO struct {
 	// latest is the most recent, unfiltered snapshot of the mappings we know about
 	latest []mapping
 
-	name       string
-	start      int64
-	lastWrite  int64
-	overwrites int64
+	name string
 }
 
 func newConnIO(coordContext context.Context,
@@ -58,7 +53,6 @@ func newConnIO(coordContext context.Context,
 	auth agpl.CoordinateeAuth,
 ) *connIO {
 	peerCtx, cancel := context.WithCancel(peerCtx)
-	now := time.Now().Unix()
 	c := &connIO{
 		id:        id,
 		coordCtx:  coordContext,
@@ -72,8 +66,6 @@ func newConnIO(coordContext context.Context,
 		rfhs:      rfhs,
 		auth:      auth,
 		name:      name,
-		start:     now,
-		lastWrite: now,
 	}
 	go c.recvLoop()
 	c.logger.Info(coordContext, "serving connection")
@@ -254,7 +246,6 @@ func (c *connIO) UniqueID() uuid.UUID {
 }
 
 func (c *connIO) Enqueue(resp *proto.CoordinateResponse) error {
-	atomic.StoreInt64(&c.lastWrite, time.Now().Unix())
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.closed {
@@ -273,14 +264,6 @@ func (c *connIO) Enqueue(resp *proto.CoordinateResponse) error {
 
 func (c *connIO) Name() string {
 	return c.name
-}
-
-func (c *connIO) Stats() (start int64, lastWrite int64) {
-	return c.start, atomic.LoadInt64(&c.lastWrite)
-}
-
-func (c *connIO) Overwrites() int64 {
-	return atomic.LoadInt64(&c.overwrites)
 }
 
 // CoordinatorClose is used by the coordinator when closing a Queue. It

--- a/enterprise/tailnet/pgcoord.go
+++ b/enterprise/tailnet/pgcoord.go
@@ -7,7 +7,6 @@ import (
 	"slices"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -916,8 +915,6 @@ func (q *querier) newConn(c *connIO) {
 	dup, ok := q.mappers[mk]
 	if ok {
 		q.logger.Debug(q.ctx, "duplicate mapper found; closing old connection", slog.F("peer_id", dup.c.UniqueID()))
-		// overwrite and close the old one
-		atomic.StoreInt64(&c.overwrites, dup.c.Overwrites()+1)
 		err := dup.c.CoordinatorClose()
 		if err != nil {
 			q.logger.Error(q.ctx, "failed to close duplicate mapper", slog.F("peer_id", dup.c.UniqueID()), slog.Error(err))


### PR DESCRIPTION
Drop start, lastWrite, and overwrites fields on connIO along with the Stats() and Overwrites() methods. They have had no readers since 52901e121 which rewrote the PG coordinator's debug page to query the database directly.

Found on inspection while auditing atomic usage in coder/coder.
