### PR TITLE
fix: remove last import of `@mui/material/SvgIcon`

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -99,7 +99,7 @@
 							// "@mui/material/Snackbar": "Use components/GlobalSnackbar instead.",
 							// "@mui/material/Stack": "Use Tailwind flex utilities instead (e.g., <div className='flex flex-col gap-4'>).",
 							// "@mui/material/styles": "Use Tailwind CSS instead.",
-							// "@mui/material/SvgIcon": "Use lucide-react icons instead.",
+							"@mui/material/SvgIcon": "Use lucide-react icons instead.",
 							"@mui/material/Switch": "Use shadcn/ui Switch component instead.",
 							"@mui/material/Table": "Import from components/Table/Table instead.",
 							"@mui/material/TableRow": "Import from components/Table/Table instead.",

--- a/site/src/modules/dashboard/Navbar/SupportIcon.tsx
+++ b/site/src/modules/dashboard/Navbar/SupportIcon.tsx
@@ -1,6 +1,5 @@
-import type { SvgIconProps } from "@mui/material/SvgIcon";
 import { BookOpenTextIcon, BugIcon, MessageSquareIcon } from "lucide-react";
-import type { FC } from "react";
+import type { ComponentProps, FC } from "react";
 import { ExternalImage } from "#/components/ExternalImage/ExternalImage";
 
 interface SupportIconProps {
@@ -23,7 +22,7 @@ export const SupportIcon: FC<SupportIconProps> = ({ icon, className }) => {
 	}
 };
 
-const GithubStar: FC<SvgIconProps> = (props) => (
+const GithubStar: FC<ComponentProps<"svg">> = (props) => (
 	<svg
 		aria-hidden="true"
 		height="16"

--- a/site/vite.config.mts
+++ b/site/vite.config.mts
@@ -202,7 +202,6 @@ export default defineConfig({
 			"@mui/material/Skeleton",
 			"@mui/material/Snackbar",
 			"@mui/material/Stack",
-			"@mui/material/SvgIcon",
 			"@mui/material/TableRow",
 			"@mui/material/TextField",
 			"@mui/material/ToggleButton",


### PR DESCRIPTION
This pull-request finds the last place we make use of `@mui/material/SvgIcon` and removes it 🙂 Therefore, another MUI import we no longer need. 