### PR TITLE
test(codersdk/toolsdk): cover start without auto-bump

### DIFF
--- a/codersdk/toolsdk/toolsdk_test.go
+++ b/codersdk/toolsdk/toolsdk_test.go
@@ -354,20 +354,43 @@ func TestTools(t *testing.T) {
 			require.NoError(t, client.CancelWorkspaceBuild(ctx, result.ID, codersdk.CancelWorkspaceBuildParams{}))
 		})
 
-		t.Run("Start", func(t *testing.T) {
+		t.Run("Start_NoAutoBumpAcrossActiveVersionChange", func(t *testing.T) {
 			ctx := testutil.Context(t, testutil.WaitShort)
+			// Isolated fixture: move the template's active version
+			// forward without changing the workspace's previously built
+			// version, so the start request must choose between them.
+			noBumpBuild := dbfake.WorkspaceBuild(t, store, database.WorkspaceTable{
+				OrganizationID: owner.OrganizationID,
+				OwnerID:        member.ID,
+			}).Do()
+			previousVersionID := noBumpBuild.TemplateVersion.ID
+
+			newActiveVersion := dbfake.TemplateVersion(t, store).
+				// nolint:gocritic // This is in a test package and does not end up in the build
+				Seed(database.TemplateVersion{
+					OrganizationID: owner.OrganizationID,
+					CreatedBy:      owner.UserID,
+					TemplateID:     uuid.NullUUID{UUID: noBumpBuild.Template.ID, Valid: true},
+				}).Do()
+			require.NotEqual(t, previousVersionID, newActiveVersion.TemplateVersion.ID)
+
+			// Confirm v2 is now the template's active version. Without this the test
+			// would silently degrade to a tautology if dbfake.TemplateVersion's
+			// promote-by-default behavior ever changed: the contract being locked in
+			// is "do not auto-bump to the *currently active* version", which requires
+			// v2 to actually be active here.
+			template, err := store.GetTemplateByID(dbauthz.AsSystemRestricted(ctx), noBumpBuild.Template.ID)
+			require.NoError(t, err)
+			require.Equal(t, newActiveVersion.TemplateVersion.ID, template.ActiveVersionID)
+
 			tb, err := toolsdk.NewDeps(memberClient)
 			require.NoError(t, err)
 			result, err := testTool(t, toolsdk.CreateWorkspaceBuild, tb, toolsdk.CreateWorkspaceBuildArgs{
-				WorkspaceID: r.Workspace.ID.String(),
+				WorkspaceID: noBumpBuild.Workspace.ID.String(),
 				Transition:  "start",
 			})
-
 			require.NoError(t, err)
-			require.Equal(t, codersdk.WorkspaceTransitionStart, result.Transition)
-			require.Equal(t, r.Workspace.ID, result.WorkspaceID)
-			require.Equal(t, r.TemplateVersion.ID, result.TemplateVersionID)
-			require.Equal(t, codersdk.WorkspaceTransitionStart, result.Transition)
+			require.Equal(t, previousVersionID, result.TemplateVersionID)
 
 			// Important: cancel the build. We don't run any provisioners, so this
 			// will remain in the 'pending' state indefinitely.


### PR DESCRIPTION
Previously, the `CreateWorkspaceBuild` toolsdk tests only exercised a start where the workspace's prior template version was also the template's active version, so they did not prove that a plain start keeps using the previously built version.

Replace that tautological coverage with an isolated fixture that advances the template's active version and asserts a start without `TemplateVersionID` still reuses the prior build's version.
