### PR TITLE
fix: correct SCIM/OAuth2/.well-known URLs in Swagger spec

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -24,7 +24,7 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
-        "/": {
+        "/api/v2/": {
             "get": {
                 "produces": [
                     "application/json"
@@ -84,7 +84,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/aibridge/clients": {
+        "/api/v2/aibridge/clients": {
             "get": {
                 "produces": [
                     "application/json"
@@ -112,7 +112,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/aibridge/interceptions": {
+        "/api/v2/aibridge/interceptions": {
             "get": {
                 "produces": [
                     "application/json"
@@ -164,7 +164,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/aibridge/models": {
+        "/api/v2/aibridge/models": {
             "get": {
                 "produces": [
                     "application/json"
@@ -192,7 +192,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/aibridge/sessions": {
+        "/api/v2/aibridge/sessions": {
             "get": {
                 "produces": [
                     "application/json"
@@ -243,7 +243,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/aibridge/sessions/{session_id}": {
+        "/api/v2/aibridge/sessions/{session_id}": {
             "get": {
                 "produces": [
                     "application/json"
@@ -295,7 +295,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/appearance": {
+        "/api/v2/appearance": {
             "get": {
                 "produces": [
                     "application/json"
@@ -357,7 +357,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/applications/auth-redirect": {
+        "/api/v2/applications/auth-redirect": {
             "get": {
                 "tags": [
                     "Applications"
@@ -384,7 +384,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/applications/host": {
+        "/api/v2/applications/host": {
             "get": {
                 "produces": [
                     "application/json"
@@ -410,7 +410,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/applications/reconnecting-pty-signed-token": {
+        "/api/v2/applications/reconnecting-pty-signed-token": {
             "post": {
                 "consumes": [
                     "application/json"
@@ -452,7 +452,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/audit": {
+        "/api/v2/audit": {
             "get": {
                 "produces": [
                     "application/json"
@@ -498,7 +498,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/audit/testgenerate": {
+        "/api/v2/audit/testgenerate": {
             "post": {
                 "consumes": [
                     "application/json"
@@ -534,7 +534,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/auth/scopes": {
+        "/api/v2/auth/scopes": {
             "get": {
                 "produces": [
                     "application/json"
@@ -554,7 +554,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/authcheck": {
+        "/api/v2/authcheck": {
             "post": {
                 "consumes": [
                     "application/json"
@@ -593,7 +593,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/buildinfo": {
+        "/api/v2/buildinfo": {
             "get": {
                 "produces": [
                     "application/json"
@@ -613,7 +613,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/chats/insights/pull-requests": {
+        "/api/v2/chats/insights/pull-requests": {
             "get": {
                 "produces": [
                     "application/json"
@@ -657,7 +657,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/connectionlog": {
+        "/api/v2/connectionlog": {
             "get": {
                 "produces": [
                     "application/json"
@@ -703,7 +703,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/csp/reports": {
+        "/api/v2/csp/reports": {
             "post": {
                 "consumes": [
                     "application/json"
@@ -736,7 +736,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/debug/coordinator": {
+        "/api/v2/debug/coordinator": {
             "get": {
                 "produces": [
                     "text/html"
@@ -758,7 +758,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/debug/derp/traffic": {
+        "/api/v2/debug/derp/traffic": {
             "get": {
                 "produces": [
                     "application/json"
@@ -789,7 +789,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/debug/expvar": {
+        "/api/v2/debug/expvar": {
             "get": {
                 "produces": [
                     "application/json"
@@ -818,7 +818,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/debug/health": {
+        "/api/v2/debug/health": {
             "get": {
                 "produces": [
                     "application/json"
@@ -851,7 +851,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/debug/health/settings": {
+        "/api/v2/debug/health/settings": {
             "get": {
                 "produces": [
                     "application/json"
@@ -913,7 +913,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/debug/metrics": {
+        "/api/v2/debug/metrics": {
             "get": {
                 "tags": [
                     "Debug"
@@ -935,7 +935,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/debug/pprof": {
+        "/api/v2/debug/pprof": {
             "get": {
                 "tags": [
                     "Debug"
@@ -957,7 +957,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/debug/pprof/cmdline": {
+        "/api/v2/debug/pprof/cmdline": {
             "get": {
                 "tags": [
                     "Debug"
@@ -979,7 +979,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/debug/pprof/profile": {
+        "/api/v2/debug/pprof/profile": {
             "get": {
                 "tags": [
                     "Debug"
@@ -1001,7 +1001,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/debug/pprof/symbol": {
+        "/api/v2/debug/pprof/symbol": {
             "get": {
                 "tags": [
                     "Debug"
@@ -1023,7 +1023,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/debug/pprof/trace": {
+        "/api/v2/debug/pprof/trace": {
             "get": {
                 "tags": [
                     "Debug"
@@ -1045,7 +1045,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/debug/profile": {
+        "/api/v2/debug/profile": {
             "post": {
                 "tags": [
                     "Debug"
@@ -1067,7 +1067,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/debug/tailnet": {
+        "/api/v2/debug/tailnet": {
             "get": {
                 "produces": [
                     "text/html"
@@ -1089,7 +1089,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/debug/ws": {
+        "/api/v2/debug/ws": {
             "get": {
                 "produces": [
                     "application/json"
@@ -1117,7 +1117,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/debug/{user}/debug-link": {
+        "/api/v2/debug/{user}/debug-link": {
             "get": {
                 "tags": [
                     "Agents"
@@ -1148,7 +1148,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/deployment/config": {
+        "/api/v2/deployment/config": {
             "get": {
                 "produces": [
                     "application/json"
@@ -1173,7 +1173,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/deployment/ssh": {
+        "/api/v2/deployment/ssh": {
             "get": {
                 "produces": [
                     "application/json"
@@ -1198,7 +1198,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/deployment/stats": {
+        "/api/v2/deployment/stats": {
             "get": {
                 "produces": [
                     "application/json"
@@ -1223,7 +1223,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/derp-map": {
+        "/api/v2/derp-map": {
             "get": {
                 "tags": [
                     "Agents"
@@ -1242,7 +1242,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/entitlements": {
+        "/api/v2/entitlements": {
             "get": {
                 "produces": [
                     "application/json"
@@ -1267,7 +1267,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/experimental/chats/config/retention-days": {
+        "/api/experimental/chats/config/retention-days": {
             "get": {
                 "produces": [
                     "application/json"
@@ -1329,7 +1329,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/experimental/watch-all-workspacebuilds": {
+        "/api/experimental/watch-all-workspacebuilds": {
             "get": {
                 "produces": [
                     "application/json"
@@ -1354,7 +1354,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/experiments": {
+        "/api/v2/experiments": {
             "get": {
                 "produces": [
                     "application/json"
@@ -1382,7 +1382,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/experiments/available": {
+        "/api/v2/experiments/available": {
             "get": {
                 "produces": [
                     "application/json"
@@ -1410,7 +1410,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/external-auth": {
+        "/api/v2/external-auth": {
             "get": {
                 "produces": [
                     "application/json"
@@ -1435,7 +1435,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/external-auth/{externalauth}": {
+        "/api/v2/external-auth/{externalauth}": {
             "get": {
                 "produces": [
                     "application/json"
@@ -1503,7 +1503,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/external-auth/{externalauth}/device": {
+        "/api/v2/external-auth/{externalauth}/device": {
             "get": {
                 "produces": [
                     "application/json"
@@ -1565,7 +1565,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/files": {
+        "/api/v2/files": {
             "post": {
                 "description": "Swagger notice: Swagger 2.0 doesn't support file upload with a ` + "`" + `content-type` + "`" + ` different than ` + "`" + `application/x-www-form-urlencoded` + "`" + `.",
                 "consumes": [
@@ -1617,7 +1617,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/files/{fileID}": {
+        "/api/v2/files/{fileID}": {
             "get": {
                 "tags": [
                     "Files"
@@ -1646,7 +1646,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/groups": {
+        "/api/v2/groups": {
             "get": {
                 "produces": [
                     "application/json"
@@ -1697,7 +1697,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/groups/{group}": {
+        "/api/v2/groups/{group}": {
             "get": {
                 "produces": [
                     "application/json"
@@ -1813,7 +1813,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/groups/{group}/members": {
+        "/api/v2/groups/{group}/members": {
             "get": {
                 "produces": [
                     "application/json"
@@ -1872,7 +1872,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/init-script/{os}/{arch}": {
+        "/api/v2/init-script/{os}/{arch}": {
             "get": {
                 "produces": [
                     "text/plain"
@@ -1905,7 +1905,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/insights/daus": {
+        "/api/v2/insights/daus": {
             "get": {
                 "produces": [
                     "application/json"
@@ -1939,7 +1939,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/insights/templates": {
+        "/api/v2/insights/templates": {
             "get": {
                 "produces": [
                     "application/json"
@@ -2003,7 +2003,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/insights/user-activity": {
+        "/api/v2/insights/user-activity": {
             "get": {
                 "produces": [
                     "application/json"
@@ -2056,7 +2056,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/insights/user-latency": {
+        "/api/v2/insights/user-latency": {
             "get": {
                 "produces": [
                     "application/json"
@@ -2109,7 +2109,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/insights/user-status-counts": {
+        "/api/v2/insights/user-status-counts": {
             "get": {
                 "produces": [
                     "application/json"
@@ -2148,7 +2148,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/licenses": {
+        "/api/v2/licenses": {
             "get": {
                 "produces": [
                     "application/json"
@@ -2213,7 +2213,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/licenses/refresh-entitlements": {
+        "/api/v2/licenses/refresh-entitlements": {
             "post": {
                 "produces": [
                     "application/json"
@@ -2238,7 +2238,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/licenses/{id}": {
+        "/api/v2/licenses/{id}": {
             "delete": {
                 "produces": [
                     "application/json"
@@ -2270,7 +2270,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/notifications/custom": {
+        "/api/v2/notifications/custom": {
             "post": {
                 "consumes": [
                     "application/json"
@@ -2324,7 +2324,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/notifications/dispatch-methods": {
+        "/api/v2/notifications/dispatch-methods": {
             "get": {
                 "produces": [
                     "application/json"
@@ -2352,7 +2352,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/notifications/inbox": {
+        "/api/v2/notifications/inbox": {
             "get": {
                 "produces": [
                     "application/json"
@@ -2404,7 +2404,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/notifications/inbox/mark-all-as-read": {
+        "/api/v2/notifications/inbox/mark-all-as-read": {
             "put": {
                 "tags": [
                     "Notifications"
@@ -2423,7 +2423,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/notifications/inbox/watch": {
+        "/api/v2/notifications/inbox/watch": {
             "get": {
                 "produces": [
                     "application/json"
@@ -2478,7 +2478,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/notifications/inbox/{id}/read-status": {
+        "/api/v2/notifications/inbox/{id}/read-status": {
             "put": {
                 "produces": [
                     "application/json"
@@ -2512,7 +2512,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/notifications/settings": {
+        "/api/v2/notifications/settings": {
             "get": {
                 "produces": [
                     "application/json"
@@ -2577,7 +2577,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/notifications/templates/custom": {
+        "/api/v2/notifications/templates/custom": {
             "get": {
                 "produces": [
                     "application/json"
@@ -2611,7 +2611,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/notifications/templates/system": {
+        "/api/v2/notifications/templates/system": {
             "get": {
                 "produces": [
                     "application/json"
@@ -2645,7 +2645,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/notifications/templates/{notification_template}/method": {
+        "/api/v2/notifications/templates/{notification_template}/method": {
             "put": {
                 "produces": [
                     "application/json"
@@ -2679,7 +2679,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/notifications/test": {
+        "/api/v2/notifications/test": {
             "post": {
                 "tags": [
                     "Notifications"
@@ -2698,7 +2698,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/oauth2-provider/apps": {
+        "/api/v2/oauth2-provider/apps": {
             "get": {
                 "produces": [
                     "application/json"
@@ -2771,7 +2771,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/oauth2-provider/apps/{app}": {
+        "/api/v2/oauth2-provider/apps/{app}": {
             "get": {
                 "produces": [
                     "application/json"
@@ -2875,7 +2875,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/oauth2-provider/apps/{app}/secrets": {
+        "/api/v2/oauth2-provider/apps/{app}/secrets": {
             "get": {
                 "produces": [
                     "application/json"
@@ -2947,7 +2947,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/oauth2-provider/apps/{app}/secrets/{secretID}": {
+        "/api/v2/oauth2-provider/apps/{app}/secrets/{secretID}": {
             "delete": {
                 "tags": [
                     "Enterprise"
@@ -3347,7 +3347,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/organizations": {
+        "/api/v2/organizations": {
             "get": {
                 "produces": [
                     "application/json"
@@ -3412,7 +3412,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/organizations/{organization}": {
+        "/api/v2/organizations/{organization}": {
             "get": {
                 "produces": [
                     "application/json"
@@ -3523,7 +3523,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/organizations/{organization}/groups": {
+        "/api/v2/organizations/{organization}/groups": {
             "get": {
                 "produces": [
                     "application/json"
@@ -3605,7 +3605,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/organizations/{organization}/groups/{groupName}": {
+        "/api/v2/organizations/{organization}/groups/{groupName}": {
             "get": {
                 "produces": [
                     "application/json"
@@ -3647,7 +3647,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/organizations/{organization}/groups/{groupName}/members": {
+        "/api/v2/organizations/{organization}/groups/{groupName}/members": {
             "get": {
                 "produces": [
                     "application/json"
@@ -3714,7 +3714,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/organizations/{organization}/members": {
+        "/api/v2/organizations/{organization}/members": {
             "get": {
                 "produces": [
                     "application/json"
@@ -3752,7 +3752,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/organizations/{organization}/members/roles": {
+        "/api/v2/organizations/{organization}/members/roles": {
             "get": {
                 "produces": [
                     "application/json"
@@ -3886,7 +3886,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/organizations/{organization}/members/roles/{roleName}": {
+        "/api/v2/organizations/{organization}/members/roles/{roleName}": {
             "delete": {
                 "produces": [
                     "application/json"
@@ -3931,7 +3931,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/organizations/{organization}/members/{user}": {
+        "/api/v2/organizations/{organization}/members/{user}": {
             "get": {
                 "produces": [
                     "application/json"
@@ -4044,7 +4044,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/organizations/{organization}/members/{user}/roles": {
+        "/api/v2/organizations/{organization}/members/{user}/roles": {
             "put": {
                 "consumes": [
                     "application/json"
@@ -4097,7 +4097,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/organizations/{organization}/members/{user}/workspace-quota": {
+        "/api/v2/organizations/{organization}/members/{user}/workspace-quota": {
             "get": {
                 "produces": [
                     "application/json"
@@ -4139,7 +4139,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/organizations/{organization}/members/{user}/workspaces": {
+        "/api/v2/organizations/{organization}/members/{user}/workspaces": {
             "post": {
                 "description": "Create a new workspace using a template. The request must\nspecify either the Template ID or the Template Version ID,\nnot both. If the Template ID is specified, the active version\nof the template will be used.",
                 "consumes": [
@@ -4195,7 +4195,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/organizations/{organization}/members/{user}/workspaces/available-users": {
+        "/api/v2/organizations/{organization}/members/{user}/workspaces/available-users": {
             "get": {
                 "produces": [
                     "application/json"
@@ -4258,7 +4258,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/organizations/{organization}/paginated-members": {
+        "/api/v2/organizations/{organization}/paginated-members": {
             "get": {
                 "produces": [
                     "application/json"
@@ -4320,7 +4320,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/organizations/{organization}/provisionerdaemons": {
+        "/api/v2/organizations/{organization}/provisionerdaemons": {
             "get": {
                 "produces": [
                     "application/json"
@@ -4402,7 +4402,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/organizations/{organization}/provisionerdaemons/serve": {
+        "/api/v2/organizations/{organization}/provisionerdaemons/serve": {
             "get": {
                 "tags": [
                     "Enterprise"
@@ -4431,7 +4431,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/organizations/{organization}/provisionerjobs": {
+        "/api/v2/organizations/{organization}/provisionerjobs": {
             "get": {
                 "produces": [
                     "application/json"
@@ -4520,7 +4520,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/organizations/{organization}/provisionerjobs/{job}": {
+        "/api/v2/organizations/{organization}/provisionerjobs/{job}": {
             "get": {
                 "produces": [
                     "application/json"
@@ -4563,7 +4563,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/organizations/{organization}/provisionerkeys": {
+        "/api/v2/organizations/{organization}/provisionerkeys": {
             "get": {
                 "produces": [
                     "application/json"
@@ -4632,7 +4632,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/organizations/{organization}/provisionerkeys/daemons": {
+        "/api/v2/organizations/{organization}/provisionerkeys/daemons": {
             "get": {
                 "produces": [
                     "application/json"
@@ -4669,7 +4669,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/organizations/{organization}/provisionerkeys/{provisionerkey}": {
+        "/api/v2/organizations/{organization}/provisionerkeys/{provisionerkey}": {
             "delete": {
                 "tags": [
                     "Enterprise"
@@ -4704,7 +4704,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/organizations/{organization}/settings/idpsync/available-fields": {
+        "/api/v2/organizations/{organization}/settings/idpsync/available-fields": {
             "get": {
                 "produces": [
                     "application/json"
@@ -4742,7 +4742,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/organizations/{organization}/settings/idpsync/field-values": {
+        "/api/v2/organizations/{organization}/settings/idpsync/field-values": {
             "get": {
                 "produces": [
                     "application/json"
@@ -4788,7 +4788,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/organizations/{organization}/settings/idpsync/groups": {
+        "/api/v2/organizations/{organization}/settings/idpsync/groups": {
             "get": {
                 "produces": [
                     "application/json"
@@ -4868,7 +4868,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/organizations/{organization}/settings/idpsync/groups/config": {
+        "/api/v2/organizations/{organization}/settings/idpsync/groups/config": {
             "patch": {
                 "consumes": [
                     "application/json"
@@ -4915,7 +4915,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/organizations/{organization}/settings/idpsync/groups/mapping": {
+        "/api/v2/organizations/{organization}/settings/idpsync/groups/mapping": {
             "patch": {
                 "consumes": [
                     "application/json"
@@ -4962,7 +4962,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/organizations/{organization}/settings/idpsync/roles": {
+        "/api/v2/organizations/{organization}/settings/idpsync/roles": {
             "get": {
                 "produces": [
                     "application/json"
@@ -5042,7 +5042,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/organizations/{organization}/settings/idpsync/roles/config": {
+        "/api/v2/organizations/{organization}/settings/idpsync/roles/config": {
             "patch": {
                 "consumes": [
                     "application/json"
@@ -5089,7 +5089,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/organizations/{organization}/settings/idpsync/roles/mapping": {
+        "/api/v2/organizations/{organization}/settings/idpsync/roles/mapping": {
             "patch": {
                 "consumes": [
                     "application/json"
@@ -5136,7 +5136,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/organizations/{organization}/settings/workspace-sharing": {
+        "/api/v2/organizations/{organization}/settings/workspace-sharing": {
             "get": {
                 "produces": [
                     "application/json"
@@ -5216,7 +5216,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/organizations/{organization}/templates": {
+        "/api/v2/organizations/{organization}/templates": {
             "get": {
                 "description": "Returns a list of templates for the specified organization.\nBy default, only non-deprecated templates are returned.\nTo include deprecated templates, specify ` + "`" + `deprecated:true` + "`" + ` in the search query.",
                 "produces": [
@@ -5299,7 +5299,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/organizations/{organization}/templates/examples": {
+        "/api/v2/organizations/{organization}/templates/examples": {
             "get": {
                 "produces": [
                     "application/json"
@@ -5338,7 +5338,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/organizations/{organization}/templates/{templatename}": {
+        "/api/v2/organizations/{organization}/templates/{templatename}": {
             "get": {
                 "produces": [
                     "application/json"
@@ -5380,7 +5380,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/organizations/{organization}/templates/{templatename}/versions/{templateversionname}": {
+        "/api/v2/organizations/{organization}/templates/{templatename}/versions/{templateversionname}": {
             "get": {
                 "produces": [
                     "application/json"
@@ -5429,7 +5429,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/organizations/{organization}/templates/{templatename}/versions/{templateversionname}/previous": {
+        "/api/v2/organizations/{organization}/templates/{templatename}/versions/{templateversionname}/previous": {
             "get": {
                 "produces": [
                     "application/json"
@@ -5481,7 +5481,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/organizations/{organization}/templateversions": {
+        "/api/v2/organizations/{organization}/templateversions": {
             "post": {
                 "consumes": [
                     "application/json"
@@ -5528,7 +5528,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/prebuilds/settings": {
+        "/api/v2/prebuilds/settings": {
             "get": {
                 "produces": [
                     "application/json"
@@ -5593,7 +5593,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/provisionerkeys/{provisionerkey}": {
+        "/api/v2/provisionerkeys/{provisionerkey}": {
             "get": {
                 "produces": [
                     "application/json"
@@ -5627,7 +5627,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/regions": {
+        "/api/v2/regions": {
             "get": {
                 "produces": [
                     "application/json"
@@ -5652,7 +5652,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/replicas": {
+        "/api/v2/replicas": {
             "get": {
                 "produces": [
                     "application/json"
@@ -5869,7 +5869,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/settings/idpsync/available-fields": {
+        "/api/v2/settings/idpsync/available-fields": {
             "get": {
                 "produces": [
                     "application/json"
@@ -5907,7 +5907,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/settings/idpsync/field-values": {
+        "/api/v2/settings/idpsync/field-values": {
             "get": {
                 "produces": [
                     "application/json"
@@ -5953,7 +5953,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/settings/idpsync/organization": {
+        "/api/v2/settings/idpsync/organization": {
             "get": {
                 "produces": [
                     "application/json"
@@ -6015,7 +6015,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/settings/idpsync/organization/config": {
+        "/api/v2/settings/idpsync/organization/config": {
             "patch": {
                 "consumes": [
                     "application/json"
@@ -6054,7 +6054,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/settings/idpsync/organization/mapping": {
+        "/api/v2/settings/idpsync/organization/mapping": {
             "patch": {
                 "consumes": [
                     "application/json"
@@ -6093,7 +6093,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/tailnet": {
+        "/api/v2/tailnet": {
             "get": {
                 "tags": [
                     "Agents"
@@ -6112,7 +6112,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/tasks": {
+        "/api/v2/tasks": {
             "get": {
                 "produces": [
                     "application/json"
@@ -6145,7 +6145,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/tasks/{user}": {
+        "/api/v2/tasks/{user}": {
             "post": {
                 "consumes": [
                     "application/json"
@@ -6191,7 +6191,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/tasks/{user}/{task}": {
+        "/api/v2/tasks/{user}/{task}": {
             "get": {
                 "produces": [
                     "application/json"
@@ -6265,7 +6265,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/tasks/{user}/{task}/input": {
+        "/api/v2/tasks/{user}/{task}/input": {
             "patch": {
                 "consumes": [
                     "application/json"
@@ -6312,7 +6312,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/tasks/{user}/{task}/logs": {
+        "/api/v2/tasks/{user}/{task}/logs": {
             "get": {
                 "produces": [
                     "application/json"
@@ -6353,7 +6353,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/tasks/{user}/{task}/pause": {
+        "/api/v2/tasks/{user}/{task}/pause": {
             "post": {
                 "produces": [
                     "application/json"
@@ -6395,7 +6395,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/tasks/{user}/{task}/resume": {
+        "/api/v2/tasks/{user}/{task}/resume": {
             "post": {
                 "produces": [
                     "application/json"
@@ -6437,7 +6437,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/tasks/{user}/{task}/send": {
+        "/api/v2/tasks/{user}/{task}/send": {
             "post": {
                 "consumes": [
                     "application/json"
@@ -6484,7 +6484,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/templates": {
+        "/api/v2/templates": {
             "get": {
                 "description": "Returns a list of templates.\nBy default, only non-deprecated templates are returned.\nTo include deprecated templates, specify ` + "`" + `deprecated:true` + "`" + ` in the search query.",
                 "produces": [
@@ -6513,7 +6513,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/templates/examples": {
+        "/api/v2/templates/examples": {
             "get": {
                 "produces": [
                     "application/json"
@@ -6541,7 +6541,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/templates/{template}": {
+        "/api/v2/templates/{template}": {
             "get": {
                 "produces": [
                     "application/json"
@@ -6654,7 +6654,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/templates/{template}/acl": {
+        "/api/v2/templates/{template}/acl": {
             "get": {
                 "produces": [
                     "application/json"
@@ -6734,7 +6734,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/templates/{template}/acl/available": {
+        "/api/v2/templates/{template}/acl/available": {
             "get": {
                 "produces": [
                     "application/json"
@@ -6772,7 +6772,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/templates/{template}/daus": {
+        "/api/v2/templates/{template}/daus": {
             "get": {
                 "produces": [
                     "application/json"
@@ -6807,7 +6807,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/templates/{template}/prebuilds/invalidate": {
+        "/api/v2/templates/{template}/prebuilds/invalidate": {
             "post": {
                 "produces": [
                     "application/json"
@@ -6842,7 +6842,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/templates/{template}/versions": {
+        "/api/v2/templates/{template}/versions": {
             "get": {
                 "produces": [
                     "application/json"
@@ -6950,7 +6950,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/templates/{template}/versions/archive": {
+        "/api/v2/templates/{template}/versions/archive": {
             "post": {
                 "consumes": [
                     "application/json"
@@ -6997,7 +6997,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/templates/{template}/versions/{templateversionname}": {
+        "/api/v2/templates/{template}/versions/{templateversionname}": {
             "get": {
                 "produces": [
                     "application/json"
@@ -7042,7 +7042,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/templateversions/{templateversion}": {
+        "/api/v2/templateversions/{templateversion}": {
             "get": {
                 "produces": [
                     "application/json"
@@ -7122,7 +7122,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/templateversions/{templateversion}/archive": {
+        "/api/v2/templateversions/{templateversion}/archive": {
             "post": {
                 "produces": [
                     "application/json"
@@ -7157,7 +7157,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/templateversions/{templateversion}/cancel": {
+        "/api/v2/templateversions/{templateversion}/cancel": {
             "patch": {
                 "produces": [
                     "application/json"
@@ -7192,7 +7192,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/templateversions/{templateversion}/dry-run": {
+        "/api/v2/templateversions/{templateversion}/dry-run": {
             "post": {
                 "consumes": [
                     "application/json"
@@ -7239,7 +7239,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/templateversions/{templateversion}/dry-run/{jobID}": {
+        "/api/v2/templateversions/{templateversion}/dry-run/{jobID}": {
             "get": {
                 "produces": [
                     "application/json"
@@ -7282,7 +7282,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/templateversions/{templateversion}/dry-run/{jobID}/cancel": {
+        "/api/v2/templateversions/{templateversion}/dry-run/{jobID}/cancel": {
             "patch": {
                 "produces": [
                     "application/json"
@@ -7325,7 +7325,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/templateversions/{templateversion}/dry-run/{jobID}/logs": {
+        "/api/v2/templateversions/{templateversion}/dry-run/{jobID}/logs": {
             "get": {
                 "produces": [
                     "application/json"
@@ -7399,7 +7399,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/templateversions/{templateversion}/dry-run/{jobID}/matched-provisioners": {
+        "/api/v2/templateversions/{templateversion}/dry-run/{jobID}/matched-provisioners": {
             "get": {
                 "produces": [
                     "application/json"
@@ -7442,7 +7442,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/templateversions/{templateversion}/dry-run/{jobID}/resources": {
+        "/api/v2/templateversions/{templateversion}/dry-run/{jobID}/resources": {
             "get": {
                 "produces": [
                     "application/json"
@@ -7488,7 +7488,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/templateversions/{templateversion}/dynamic-parameters": {
+        "/api/v2/templateversions/{templateversion}/dynamic-parameters": {
             "get": {
                 "tags": [
                     "Templates"
@@ -7517,7 +7517,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/templateversions/{templateversion}/dynamic-parameters/evaluate": {
+        "/api/v2/templateversions/{templateversion}/dynamic-parameters/evaluate": {
             "post": {
                 "consumes": [
                     "application/json"
@@ -7564,7 +7564,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/templateversions/{templateversion}/external-auth": {
+        "/api/v2/templateversions/{templateversion}/external-auth": {
             "get": {
                 "produces": [
                     "application/json"
@@ -7602,7 +7602,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/templateversions/{templateversion}/logs": {
+        "/api/v2/templateversions/{templateversion}/logs": {
             "get": {
                 "produces": [
                     "application/json"
@@ -7668,7 +7668,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/templateversions/{templateversion}/parameters": {
+        "/api/v2/templateversions/{templateversion}/parameters": {
             "get": {
                 "tags": [
                     "Templates"
@@ -7697,7 +7697,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/templateversions/{templateversion}/presets": {
+        "/api/v2/templateversions/{templateversion}/presets": {
             "get": {
                 "produces": [
                     "application/json"
@@ -7735,7 +7735,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/templateversions/{templateversion}/resources": {
+        "/api/v2/templateversions/{templateversion}/resources": {
             "get": {
                 "produces": [
                     "application/json"
@@ -7773,7 +7773,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/templateversions/{templateversion}/rich-parameters": {
+        "/api/v2/templateversions/{templateversion}/rich-parameters": {
             "get": {
                 "produces": [
                     "application/json"
@@ -7811,7 +7811,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/templateversions/{templateversion}/schema": {
+        "/api/v2/templateversions/{templateversion}/schema": {
             "get": {
                 "tags": [
                     "Templates"
@@ -7840,7 +7840,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/templateversions/{templateversion}/unarchive": {
+        "/api/v2/templateversions/{templateversion}/unarchive": {
             "post": {
                 "produces": [
                     "application/json"
@@ -7875,7 +7875,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/templateversions/{templateversion}/variables": {
+        "/api/v2/templateversions/{templateversion}/variables": {
             "get": {
                 "produces": [
                     "application/json"
@@ -7913,7 +7913,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/updatecheck": {
+        "/api/v2/updatecheck": {
             "get": {
                 "produces": [
                     "application/json"
@@ -7933,7 +7933,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/users": {
+        "/api/v2/users": {
             "get": {
                 "produces": [
                     "application/json"
@@ -8022,7 +8022,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/users/authmethods": {
+        "/api/v2/users/authmethods": {
             "get": {
                 "produces": [
                     "application/json"
@@ -8047,7 +8047,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/users/first": {
+        "/api/v2/users/first": {
             "get": {
                 "produces": [
                     "application/json"
@@ -8109,7 +8109,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/users/login": {
+        "/api/v2/users/login": {
             "post": {
                 "consumes": [
                     "application/json"
@@ -8143,7 +8143,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/users/logout": {
+        "/api/v2/users/logout": {
             "post": {
                 "produces": [
                     "application/json"
@@ -8168,7 +8168,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/users/oauth2/github/callback": {
+        "/api/v2/users/oauth2/github/callback": {
             "get": {
                 "tags": [
                     "Users"
@@ -8187,7 +8187,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/users/oauth2/github/device": {
+        "/api/v2/users/oauth2/github/device": {
             "get": {
                 "produces": [
                     "application/json"
@@ -8212,7 +8212,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/users/oidc-claims": {
+        "/api/v2/users/oidc-claims": {
             "get": {
                 "produces": [
                     "application/json"
@@ -8237,7 +8237,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/users/oidc/callback": {
+        "/api/v2/users/oidc/callback": {
             "get": {
                 "tags": [
                     "Users"
@@ -8256,7 +8256,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/users/otp/change-password": {
+        "/api/v2/users/otp/change-password": {
             "post": {
                 "consumes": [
                     "application/json"
@@ -8284,7 +8284,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/users/otp/request": {
+        "/api/v2/users/otp/request": {
             "post": {
                 "consumes": [
                     "application/json"
@@ -8312,7 +8312,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/users/roles": {
+        "/api/v2/users/roles": {
             "get": {
                 "produces": [
                     "application/json"
@@ -8340,7 +8340,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/users/validate-password": {
+        "/api/v2/users/validate-password": {
             "post": {
                 "consumes": [
                     "application/json"
@@ -8379,7 +8379,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/users/{user}": {
+        "/api/v2/users/{user}": {
             "get": {
                 "produces": [
                     "application/json"
@@ -8439,7 +8439,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/users/{user}/appearance": {
+        "/api/v2/users/{user}/appearance": {
             "get": {
                 "produces": [
                     "application/json"
@@ -8517,7 +8517,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/users/{user}/autofill-parameters": {
+        "/api/v2/users/{user}/autofill-parameters": {
             "get": {
                 "produces": [
                     "application/json"
@@ -8561,7 +8561,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/users/{user}/convert-login": {
+        "/api/v2/users/{user}/convert-login": {
             "post": {
                 "consumes": [
                     "application/json"
@@ -8607,7 +8607,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/users/{user}/gitsshkey": {
+        "/api/v2/users/{user}/gitsshkey": {
             "get": {
                 "produces": [
                     "application/json"
@@ -8673,7 +8673,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/users/{user}/keys": {
+        "/api/v2/users/{user}/keys": {
             "post": {
                 "produces": [
                     "application/json"
@@ -8707,7 +8707,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/users/{user}/keys/tokens": {
+        "/api/v2/users/{user}/keys/tokens": {
             "get": {
                 "produces": [
                     "application/json"
@@ -8794,7 +8794,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/users/{user}/keys/tokens/tokenconfig": {
+        "/api/v2/users/{user}/keys/tokens/tokenconfig": {
             "get": {
                 "produces": [
                     "application/json"
@@ -8828,7 +8828,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/users/{user}/keys/tokens/{keyname}": {
+        "/api/v2/users/{user}/keys/tokens/{keyname}": {
             "get": {
                 "produces": [
                     "application/json"
@@ -8870,7 +8870,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/users/{user}/keys/{keyid}": {
+        "/api/v2/users/{user}/keys/{keyid}": {
             "get": {
                 "produces": [
                     "application/json"
@@ -8946,7 +8946,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/users/{user}/keys/{keyid}/expire": {
+        "/api/v2/users/{user}/keys/{keyid}/expire": {
             "put": {
                 "tags": [
                     "Users"
@@ -8994,7 +8994,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/users/{user}/login-type": {
+        "/api/v2/users/{user}/login-type": {
             "get": {
                 "produces": [
                     "application/json"
@@ -9028,7 +9028,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/users/{user}/notifications/preferences": {
+        "/api/v2/users/{user}/notifications/preferences": {
             "get": {
                 "produces": [
                     "application/json"
@@ -9112,7 +9112,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/users/{user}/organizations": {
+        "/api/v2/users/{user}/organizations": {
             "get": {
                 "produces": [
                     "application/json"
@@ -9149,7 +9149,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/users/{user}/organizations/{organizationname}": {
+        "/api/v2/users/{user}/organizations/{organizationname}": {
             "get": {
                 "produces": [
                     "application/json"
@@ -9190,7 +9190,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/users/{user}/password": {
+        "/api/v2/users/{user}/password": {
             "put": {
                 "consumes": [
                     "application/json"
@@ -9230,7 +9230,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/users/{user}/preferences": {
+        "/api/v2/users/{user}/preferences": {
             "get": {
                 "produces": [
                     "application/json"
@@ -9308,7 +9308,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/users/{user}/profile": {
+        "/api/v2/users/{user}/profile": {
             "put": {
                 "consumes": [
                     "application/json"
@@ -9354,7 +9354,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/users/{user}/quiet-hours": {
+        "/api/v2/users/{user}/quiet-hours": {
             "get": {
                 "produces": [
                     "application/json"
@@ -9440,7 +9440,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/users/{user}/roles": {
+        "/api/v2/users/{user}/roles": {
             "get": {
                 "produces": [
                     "application/json"
@@ -9518,7 +9518,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/users/{user}/secrets": {
+        "/api/v2/users/{user}/secrets": {
             "get": {
                 "produces": [
                     "application/json"
@@ -9599,7 +9599,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/users/{user}/secrets/{name}": {
+        "/api/v2/users/{user}/secrets/{name}": {
             "get": {
                 "produces": [
                     "application/json"
@@ -9724,7 +9724,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/users/{user}/status/activate": {
+        "/api/v2/users/{user}/status/activate": {
             "put": {
                 "produces": [
                     "application/json"
@@ -9758,7 +9758,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/users/{user}/status/suspend": {
+        "/api/v2/users/{user}/status/suspend": {
             "put": {
                 "produces": [
                     "application/json"
@@ -9792,7 +9792,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/users/{user}/webpush/subscription": {
+        "/api/v2/users/{user}/webpush/subscription": {
             "post": {
                 "consumes": [
                     "application/json"
@@ -9876,7 +9876,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/users/{user}/webpush/test": {
+        "/api/v2/users/{user}/webpush/test": {
             "post": {
                 "tags": [
                     "Notifications"
@@ -9907,7 +9907,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/users/{user}/workspace/{workspacename}": {
+        "/api/v2/users/{user}/workspace/{workspacename}": {
             "get": {
                 "produces": [
                     "application/json"
@@ -9954,7 +9954,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/users/{user}/workspace/{workspacename}/builds/{buildnumber}": {
+        "/api/v2/users/{user}/workspace/{workspacename}/builds/{buildnumber}": {
             "get": {
                 "produces": [
                     "application/json"
@@ -10003,7 +10003,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/users/{user}/workspaces": {
+        "/api/v2/users/{user}/workspaces": {
             "post": {
                 "description": "Create a new workspace using a template. The request must\nspecify either the Template ID or the Template Version ID,\nnot both. If the Template ID is specified, the active version\nof the template will be used.",
                 "consumes": [
@@ -10050,7 +10050,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspace-quota/{user}": {
+        "/api/v2/workspace-quota/{user}": {
             "get": {
                 "produces": [
                     "application/json"
@@ -10085,7 +10085,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaceagents/aws-instance-identity": {
+        "/api/v2/workspaceagents/aws-instance-identity": {
             "post": {
                 "consumes": [
                     "application/json"
@@ -10124,7 +10124,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaceagents/azure-instance-identity": {
+        "/api/v2/workspaceagents/azure-instance-identity": {
             "post": {
                 "consumes": [
                     "application/json"
@@ -10163,7 +10163,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaceagents/connection": {
+        "/api/v2/workspaceagents/connection": {
             "get": {
                 "produces": [
                     "application/json"
@@ -10191,7 +10191,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/workspaceagents/google-instance-identity": {
+        "/api/v2/workspaceagents/google-instance-identity": {
             "post": {
                 "consumes": [
                     "application/json"
@@ -10230,7 +10230,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaceagents/me/app-status": {
+        "/api/v2/workspaceagents/me/app-status": {
             "patch": {
                 "consumes": [
                     "application/json"
@@ -10270,7 +10270,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaceagents/me/external-auth": {
+        "/api/v2/workspaceagents/me/external-auth": {
             "get": {
                 "produces": [
                     "application/json"
@@ -10317,7 +10317,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaceagents/me/gitauth": {
+        "/api/v2/workspaceagents/me/gitauth": {
             "get": {
                 "produces": [
                     "application/json"
@@ -10364,7 +10364,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaceagents/me/gitsshkey": {
+        "/api/v2/workspaceagents/me/gitsshkey": {
             "get": {
                 "produces": [
                     "application/json"
@@ -10389,7 +10389,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaceagents/me/log-source": {
+        "/api/v2/workspaceagents/me/log-source": {
             "post": {
                 "consumes": [
                     "application/json"
@@ -10428,7 +10428,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaceagents/me/logs": {
+        "/api/v2/workspaceagents/me/logs": {
             "patch": {
                 "consumes": [
                     "application/json"
@@ -10467,7 +10467,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaceagents/me/reinit": {
+        "/api/v2/workspaceagents/me/reinit": {
             "get": {
                 "produces": [
                     "application/json"
@@ -10506,7 +10506,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaceagents/me/rpc": {
+        "/api/v2/workspaceagents/me/rpc": {
             "get": {
                 "tags": [
                     "Agents"
@@ -10528,7 +10528,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/workspaceagents/me/tasks/{task}/log-snapshot": {
+        "/api/v2/workspaceagents/me/tasks/{task}/log-snapshot": {
             "post": {
                 "consumes": [
                     "application/json"
@@ -10579,7 +10579,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaceagents/{workspaceagent}": {
+        "/api/v2/workspaceagents/{workspaceagent}": {
             "get": {
                 "produces": [
                     "application/json"
@@ -10614,7 +10614,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaceagents/{workspaceagent}/connection": {
+        "/api/v2/workspaceagents/{workspaceagent}/connection": {
             "get": {
                 "produces": [
                     "application/json"
@@ -10649,7 +10649,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaceagents/{workspaceagent}/containers": {
+        "/api/v2/workspaceagents/{workspaceagent}/containers": {
             "get": {
                 "produces": [
                     "application/json"
@@ -10692,7 +10692,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaceagents/{workspaceagent}/containers/devcontainers/{devcontainer}": {
+        "/api/v2/workspaceagents/{workspaceagent}/containers/devcontainers/{devcontainer}": {
             "delete": {
                 "tags": [
                     "Agents"
@@ -10728,7 +10728,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaceagents/{workspaceagent}/containers/devcontainers/{devcontainer}/recreate": {
+        "/api/v2/workspaceagents/{workspaceagent}/containers/devcontainers/{devcontainer}/recreate": {
             "post": {
                 "produces": [
                     "application/json"
@@ -10770,7 +10770,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaceagents/{workspaceagent}/containers/watch": {
+        "/api/v2/workspaceagents/{workspaceagent}/containers/watch": {
             "get": {
                 "produces": [
                     "application/json"
@@ -10805,7 +10805,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaceagents/{workspaceagent}/coordinate": {
+        "/api/v2/workspaceagents/{workspaceagent}/coordinate": {
             "get": {
                 "tags": [
                     "Agents"
@@ -10834,7 +10834,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaceagents/{workspaceagent}/listening-ports": {
+        "/api/v2/workspaceagents/{workspaceagent}/listening-ports": {
             "get": {
                 "produces": [
                     "application/json"
@@ -10869,7 +10869,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaceagents/{workspaceagent}/logs": {
+        "/api/v2/workspaceagents/{workspaceagent}/logs": {
             "get": {
                 "produces": [
                     "application/json"
@@ -10941,7 +10941,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaceagents/{workspaceagent}/pty": {
+        "/api/v2/workspaceagents/{workspaceagent}/pty": {
             "get": {
                 "tags": [
                     "Agents"
@@ -10970,7 +10970,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaceagents/{workspaceagent}/startup-logs": {
+        "/api/v2/workspaceagents/{workspaceagent}/startup-logs": {
             "get": {
                 "produces": [
                     "application/json"
@@ -11032,7 +11032,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaceagents/{workspaceagent}/watch-metadata": {
+        "/api/v2/workspaceagents/{workspaceagent}/watch-metadata": {
             "get": {
                 "tags": [
                     "Agents"
@@ -11065,7 +11065,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/workspaceagents/{workspaceagent}/watch-metadata-ws": {
+        "/api/v2/workspaceagents/{workspaceagent}/watch-metadata-ws": {
             "get": {
                 "produces": [
                     "application/json"
@@ -11103,7 +11103,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/workspacebuilds/{workspacebuild}": {
+        "/api/v2/workspacebuilds/{workspacebuild}": {
             "get": {
                 "produces": [
                     "application/json"
@@ -11137,7 +11137,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspacebuilds/{workspacebuild}/cancel": {
+        "/api/v2/workspacebuilds/{workspacebuild}/cancel": {
             "patch": {
                 "produces": [
                     "application/json"
@@ -11181,7 +11181,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspacebuilds/{workspacebuild}/logs": {
+        "/api/v2/workspacebuilds/{workspacebuild}/logs": {
             "get": {
                 "produces": [
                     "application/json"
@@ -11246,7 +11246,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspacebuilds/{workspacebuild}/parameters": {
+        "/api/v2/workspacebuilds/{workspacebuild}/parameters": {
             "get": {
                 "produces": [
                     "application/json"
@@ -11283,7 +11283,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspacebuilds/{workspacebuild}/resources": {
+        "/api/v2/workspacebuilds/{workspacebuild}/resources": {
             "get": {
                 "produces": [
                     "application/json"
@@ -11321,7 +11321,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspacebuilds/{workspacebuild}/state": {
+        "/api/v2/workspacebuilds/{workspacebuild}/state": {
             "get": {
                 "produces": [
                     "application/json"
@@ -11394,7 +11394,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspacebuilds/{workspacebuild}/timings": {
+        "/api/v2/workspacebuilds/{workspacebuild}/timings": {
             "get": {
                 "produces": [
                     "application/json"
@@ -11429,7 +11429,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaceproxies": {
+        "/api/v2/workspaceproxies": {
             "get": {
                 "produces": [
                     "application/json"
@@ -11494,7 +11494,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaceproxies/me/app-stats": {
+        "/api/v2/workspaceproxies/me/app-stats": {
             "post": {
                 "consumes": [
                     "application/json"
@@ -11530,7 +11530,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/workspaceproxies/me/coordinate": {
+        "/api/v2/workspaceproxies/me/coordinate": {
             "get": {
                 "tags": [
                     "Enterprise"
@@ -11552,7 +11552,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/workspaceproxies/me/crypto-keys": {
+        "/api/v2/workspaceproxies/me/crypto-keys": {
             "get": {
                 "produces": [
                     "application/json"
@@ -11589,7 +11589,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/workspaceproxies/me/deregister": {
+        "/api/v2/workspaceproxies/me/deregister": {
             "post": {
                 "consumes": [
                     "application/json"
@@ -11625,7 +11625,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/workspaceproxies/me/issue-signed-app-token": {
+        "/api/v2/workspaceproxies/me/issue-signed-app-token": {
             "post": {
                 "consumes": [
                     "application/json"
@@ -11667,7 +11667,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/workspaceproxies/me/register": {
+        "/api/v2/workspaceproxies/me/register": {
             "post": {
                 "consumes": [
                     "application/json"
@@ -11709,7 +11709,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/workspaceproxies/{workspaceproxy}": {
+        "/api/v2/workspaceproxies/{workspaceproxy}": {
             "get": {
                 "produces": [
                     "application/json"
@@ -11822,7 +11822,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaces": {
+        "/api/v2/workspaces": {
             "get": {
                 "produces": [
                     "application/json"
@@ -11867,7 +11867,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaces/{workspace}": {
+        "/api/v2/workspaces/{workspace}": {
             "get": {
                 "produces": [
                     "application/json"
@@ -11947,7 +11947,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaces/{workspace}/acl": {
+        "/api/v2/workspaces/{workspace}/acl": {
             "get": {
                 "produces": [
                     "application/json"
@@ -12051,7 +12051,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaces/{workspace}/autostart": {
+        "/api/v2/workspaces/{workspace}/autostart": {
             "put": {
                 "consumes": [
                     "application/json"
@@ -12092,7 +12092,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaces/{workspace}/autoupdates": {
+        "/api/v2/workspaces/{workspace}/autoupdates": {
             "put": {
                 "consumes": [
                     "application/json"
@@ -12133,7 +12133,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaces/{workspace}/builds": {
+        "/api/v2/workspaces/{workspace}/builds": {
             "get": {
                 "produces": [
                     "application/json"
@@ -12242,7 +12242,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaces/{workspace}/dormant": {
+        "/api/v2/workspaces/{workspace}/dormant": {
             "put": {
                 "consumes": [
                     "application/json"
@@ -12289,7 +12289,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaces/{workspace}/extend": {
+        "/api/v2/workspaces/{workspace}/extend": {
             "put": {
                 "consumes": [
                     "application/json"
@@ -12336,7 +12336,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaces/{workspace}/external-agent/{agent}/credentials": {
+        "/api/v2/workspaces/{workspace}/external-agent/{agent}/credentials": {
             "get": {
                 "produces": [
                     "application/json"
@@ -12378,7 +12378,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaces/{workspace}/favorite": {
+        "/api/v2/workspaces/{workspace}/favorite": {
             "put": {
                 "tags": [
                     "Workspaces"
@@ -12434,7 +12434,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaces/{workspace}/port-share": {
+        "/api/v2/workspaces/{workspace}/port-share": {
             "get": {
                 "produces": [
                     "application/json"
@@ -12553,7 +12553,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaces/{workspace}/resolve-autostart": {
+        "/api/v2/workspaces/{workspace}/resolve-autostart": {
             "get": {
                 "produces": [
                     "application/json"
@@ -12588,7 +12588,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaces/{workspace}/timings": {
+        "/api/v2/workspaces/{workspace}/timings": {
             "get": {
                 "produces": [
                     "application/json"
@@ -12623,7 +12623,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaces/{workspace}/ttl": {
+        "/api/v2/workspaces/{workspace}/ttl": {
             "put": {
                 "consumes": [
                     "application/json"
@@ -12664,7 +12664,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaces/{workspace}/usage": {
+        "/api/v2/workspaces/{workspace}/usage": {
             "post": {
                 "consumes": [
                     "application/json"
@@ -12704,7 +12704,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaces/{workspace}/watch": {
+        "/api/v2/workspaces/{workspace}/watch": {
             "get": {
                 "produces": [
                     "text/event-stream"
@@ -12740,7 +12740,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/workspaces/{workspace}/watch-ws": {
+        "/api/v2/workspaces/{workspace}/watch-ws": {
             "get": {
                 "produces": [
                     "application/json"
@@ -25030,7 +25030,7 @@ const docTemplate = `{
 var SwaggerInfo = &swag.Spec{
 	Version:          "2.0",
 	Host:             "",
-	BasePath:         "/api/v2",
+	BasePath:         "/",
 	Schemes:          []string{},
 	Title:            "Coder API",
 	Description:      "Coderd is the service created by running coder server. It is a thin API that connects workspaces, provisioners and users. coderd stores its state in Postgres and is the only service that communicates with Postgres.",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -15,9 +15,9 @@
 		},
 		"version": "2.0"
 	},
-	"basePath": "/api/v2",
+	"basePath": "/",
 	"paths": {
-		"/": {
+		"/api/v2/": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["General"],
@@ -65,7 +65,7 @@
 				}
 			}
 		},
-		"/aibridge/clients": {
+		"/api/v2/aibridge/clients": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["AI Bridge"],
@@ -89,7 +89,7 @@
 				]
 			}
 		},
-		"/aibridge/interceptions": {
+		"/api/v2/aibridge/interceptions": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["AI Bridge"],
@@ -137,7 +137,7 @@
 				]
 			}
 		},
-		"/aibridge/models": {
+		"/api/v2/aibridge/models": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["AI Bridge"],
@@ -161,7 +161,7 @@
 				]
 			}
 		},
-		"/aibridge/sessions": {
+		"/api/v2/aibridge/sessions": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["AI Bridge"],
@@ -208,7 +208,7 @@
 				]
 			}
 		},
-		"/aibridge/sessions/{session_id}": {
+		"/api/v2/aibridge/sessions/{session_id}": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["AI Bridge"],
@@ -256,7 +256,7 @@
 				]
 			}
 		},
-		"/appearance": {
+		"/api/v2/appearance": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
@@ -308,7 +308,7 @@
 				]
 			}
 		},
-		"/applications/auth-redirect": {
+		"/api/v2/applications/auth-redirect": {
 			"get": {
 				"tags": ["Applications"],
 				"summary": "Redirect to URI with encrypted API key",
@@ -333,7 +333,7 @@
 				]
 			}
 		},
-		"/applications/host": {
+		"/api/v2/applications/host": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Applications"],
@@ -355,7 +355,7 @@
 				]
 			}
 		},
-		"/applications/reconnecting-pty-signed-token": {
+		"/api/v2/applications/reconnecting-pty-signed-token": {
 			"post": {
 				"consumes": ["application/json"],
 				"produces": ["application/json"],
@@ -391,7 +391,7 @@
 				}
 			}
 		},
-		"/audit": {
+		"/api/v2/audit": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Audit"],
@@ -433,7 +433,7 @@
 				]
 			}
 		},
-		"/audit/testgenerate": {
+		"/api/v2/audit/testgenerate": {
 			"post": {
 				"consumes": ["application/json"],
 				"tags": ["Audit"],
@@ -465,7 +465,7 @@
 				}
 			}
 		},
-		"/auth/scopes": {
+		"/api/v2/auth/scopes": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Authorization"],
@@ -481,7 +481,7 @@
 				}
 			}
 		},
-		"/authcheck": {
+		"/api/v2/authcheck": {
 			"post": {
 				"consumes": ["application/json"],
 				"produces": ["application/json"],
@@ -514,7 +514,7 @@
 				]
 			}
 		},
-		"/buildinfo": {
+		"/api/v2/buildinfo": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["General"],
@@ -530,7 +530,7 @@
 				}
 			}
 		},
-		"/chats/insights/pull-requests": {
+		"/api/v2/chats/insights/pull-requests": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Chats"],
@@ -570,7 +570,7 @@
 				}
 			}
 		},
-		"/connectionlog": {
+		"/api/v2/connectionlog": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
@@ -612,7 +612,7 @@
 				]
 			}
 		},
-		"/csp/reports": {
+		"/api/v2/csp/reports": {
 			"post": {
 				"consumes": ["application/json"],
 				"tags": ["General"],
@@ -641,7 +641,7 @@
 				]
 			}
 		},
-		"/debug/coordinator": {
+		"/api/v2/debug/coordinator": {
 			"get": {
 				"produces": ["text/html"],
 				"tags": ["Debug"],
@@ -659,7 +659,7 @@
 				]
 			}
 		},
-		"/debug/derp/traffic": {
+		"/api/v2/debug/derp/traffic": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Debug"],
@@ -686,7 +686,7 @@
 				}
 			}
 		},
-		"/debug/expvar": {
+		"/api/v2/debug/expvar": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Debug"],
@@ -711,7 +711,7 @@
 				}
 			}
 		},
-		"/debug/health": {
+		"/api/v2/debug/health": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Debug"],
@@ -740,7 +740,7 @@
 				]
 			}
 		},
-		"/debug/health/settings": {
+		"/api/v2/debug/health/settings": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Debug"],
@@ -792,7 +792,7 @@
 				]
 			}
 		},
-		"/debug/metrics": {
+		"/api/v2/debug/metrics": {
 			"get": {
 				"tags": ["Debug"],
 				"summary": "Debug metrics",
@@ -812,7 +812,7 @@
 				}
 			}
 		},
-		"/debug/pprof": {
+		"/api/v2/debug/pprof": {
 			"get": {
 				"tags": ["Debug"],
 				"summary": "Debug pprof index",
@@ -832,7 +832,7 @@
 				}
 			}
 		},
-		"/debug/pprof/cmdline": {
+		"/api/v2/debug/pprof/cmdline": {
 			"get": {
 				"tags": ["Debug"],
 				"summary": "Debug pprof cmdline",
@@ -852,7 +852,7 @@
 				}
 			}
 		},
-		"/debug/pprof/profile": {
+		"/api/v2/debug/pprof/profile": {
 			"get": {
 				"tags": ["Debug"],
 				"summary": "Debug pprof profile",
@@ -872,7 +872,7 @@
 				}
 			}
 		},
-		"/debug/pprof/symbol": {
+		"/api/v2/debug/pprof/symbol": {
 			"get": {
 				"tags": ["Debug"],
 				"summary": "Debug pprof symbol",
@@ -892,7 +892,7 @@
 				}
 			}
 		},
-		"/debug/pprof/trace": {
+		"/api/v2/debug/pprof/trace": {
 			"get": {
 				"tags": ["Debug"],
 				"summary": "Debug pprof trace",
@@ -912,7 +912,7 @@
 				}
 			}
 		},
-		"/debug/profile": {
+		"/api/v2/debug/profile": {
 			"post": {
 				"tags": ["Debug"],
 				"summary": "Collect debug profiles",
@@ -932,7 +932,7 @@
 				}
 			}
 		},
-		"/debug/tailnet": {
+		"/api/v2/debug/tailnet": {
 			"get": {
 				"produces": ["text/html"],
 				"tags": ["Debug"],
@@ -950,7 +950,7 @@
 				]
 			}
 		},
-		"/debug/ws": {
+		"/api/v2/debug/ws": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Debug"],
@@ -974,7 +974,7 @@
 				}
 			}
 		},
-		"/debug/{user}/debug-link": {
+		"/api/v2/debug/{user}/debug-link": {
 			"get": {
 				"tags": ["Agents"],
 				"summary": "Debug OIDC context for a user",
@@ -1003,7 +1003,7 @@
 				}
 			}
 		},
-		"/deployment/config": {
+		"/api/v2/deployment/config": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["General"],
@@ -1024,7 +1024,7 @@
 				]
 			}
 		},
-		"/deployment/ssh": {
+		"/api/v2/deployment/ssh": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["General"],
@@ -1045,7 +1045,7 @@
 				]
 			}
 		},
-		"/deployment/stats": {
+		"/api/v2/deployment/stats": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["General"],
@@ -1066,7 +1066,7 @@
 				]
 			}
 		},
-		"/derp-map": {
+		"/api/v2/derp-map": {
 			"get": {
 				"tags": ["Agents"],
 				"summary": "Get DERP map updates",
@@ -1083,7 +1083,7 @@
 				]
 			}
 		},
-		"/entitlements": {
+		"/api/v2/entitlements": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
@@ -1104,7 +1104,7 @@
 				]
 			}
 		},
-		"/experimental/chats/config/retention-days": {
+		"/api/experimental/chats/config/retention-days": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Chats"],
@@ -1158,7 +1158,7 @@
 				}
 			}
 		},
-		"/experimental/watch-all-workspacebuilds": {
+		"/api/experimental/watch-all-workspacebuilds": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Workspaces"],
@@ -1179,7 +1179,7 @@
 				}
 			}
 		},
-		"/experiments": {
+		"/api/v2/experiments": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["General"],
@@ -1203,7 +1203,7 @@
 				]
 			}
 		},
-		"/experiments/available": {
+		"/api/v2/experiments/available": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["General"],
@@ -1227,7 +1227,7 @@
 				]
 			}
 		},
-		"/external-auth": {
+		"/api/v2/external-auth": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Git"],
@@ -1248,7 +1248,7 @@
 				]
 			}
 		},
-		"/external-auth/{externalauth}": {
+		"/api/v2/external-auth/{externalauth}": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Git"],
@@ -1308,7 +1308,7 @@
 				]
 			}
 		},
-		"/external-auth/{externalauth}/device": {
+		"/api/v2/external-auth/{externalauth}/device": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Git"],
@@ -1364,7 +1364,7 @@
 				]
 			}
 		},
-		"/files": {
+		"/api/v2/files": {
 			"post": {
 				"description": "Swagger notice: Swagger 2.0 doesn't support file upload with a `content-type` different than `application/x-www-form-urlencoded`.",
 				"consumes": ["application/x-tar"],
@@ -1410,7 +1410,7 @@
 				]
 			}
 		},
-		"/files/{fileID}": {
+		"/api/v2/files/{fileID}": {
 			"get": {
 				"tags": ["Files"],
 				"summary": "Get file by ID",
@@ -1437,7 +1437,7 @@
 				]
 			}
 		},
-		"/groups": {
+		"/api/v2/groups": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
@@ -1484,7 +1484,7 @@
 				]
 			}
 		},
-		"/groups/{group}": {
+		"/api/v2/groups/{group}": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
@@ -1586,7 +1586,7 @@
 				]
 			}
 		},
-		"/groups/{group}/members": {
+		"/api/v2/groups/{group}/members": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
@@ -1641,7 +1641,7 @@
 				]
 			}
 		},
-		"/init-script/{os}/{arch}": {
+		"/api/v2/init-script/{os}/{arch}": {
 			"get": {
 				"produces": ["text/plain"],
 				"tags": ["InitScript"],
@@ -1670,7 +1670,7 @@
 				}
 			}
 		},
-		"/insights/daus": {
+		"/api/v2/insights/daus": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Insights"],
@@ -1700,7 +1700,7 @@
 				]
 			}
 		},
-		"/insights/templates": {
+		"/api/v2/insights/templates": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Insights"],
@@ -1757,7 +1757,7 @@
 				]
 			}
 		},
-		"/insights/user-activity": {
+		"/api/v2/insights/user-activity": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Insights"],
@@ -1806,7 +1806,7 @@
 				]
 			}
 		},
-		"/insights/user-latency": {
+		"/api/v2/insights/user-latency": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Insights"],
@@ -1855,7 +1855,7 @@
 				]
 			}
 		},
-		"/insights/user-status-counts": {
+		"/api/v2/insights/user-status-counts": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Insights"],
@@ -1890,7 +1890,7 @@
 				]
 			}
 		},
-		"/licenses": {
+		"/api/v2/licenses": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
@@ -1945,7 +1945,7 @@
 				]
 			}
 		},
-		"/licenses/refresh-entitlements": {
+		"/api/v2/licenses/refresh-entitlements": {
 			"post": {
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
@@ -1966,7 +1966,7 @@
 				]
 			}
 		},
-		"/licenses/{id}": {
+		"/api/v2/licenses/{id}": {
 			"delete": {
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
@@ -1994,7 +1994,7 @@
 				]
 			}
 		},
-		"/notifications/custom": {
+		"/api/v2/notifications/custom": {
 			"post": {
 				"consumes": ["application/json"],
 				"produces": ["application/json"],
@@ -2042,7 +2042,7 @@
 				]
 			}
 		},
-		"/notifications/dispatch-methods": {
+		"/api/v2/notifications/dispatch-methods": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Notifications"],
@@ -2066,7 +2066,7 @@
 				]
 			}
 		},
-		"/notifications/inbox": {
+		"/api/v2/notifications/inbox": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Notifications"],
@@ -2114,7 +2114,7 @@
 				]
 			}
 		},
-		"/notifications/inbox/mark-all-as-read": {
+		"/api/v2/notifications/inbox/mark-all-as-read": {
 			"put": {
 				"tags": ["Notifications"],
 				"summary": "Mark all unread notifications as read",
@@ -2131,7 +2131,7 @@
 				]
 			}
 		},
-		"/notifications/inbox/watch": {
+		"/api/v2/notifications/inbox/watch": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Notifications"],
@@ -2179,7 +2179,7 @@
 				]
 			}
 		},
-		"/notifications/inbox/{id}/read-status": {
+		"/api/v2/notifications/inbox/{id}/read-status": {
 			"put": {
 				"produces": ["application/json"],
 				"tags": ["Notifications"],
@@ -2209,7 +2209,7 @@
 				]
 			}
 		},
-		"/notifications/settings": {
+		"/api/v2/notifications/settings": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Notifications"],
@@ -2264,7 +2264,7 @@
 				]
 			}
 		},
-		"/notifications/templates/custom": {
+		"/api/v2/notifications/templates/custom": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Notifications"],
@@ -2294,7 +2294,7 @@
 				]
 			}
 		},
-		"/notifications/templates/system": {
+		"/api/v2/notifications/templates/system": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Notifications"],
@@ -2324,7 +2324,7 @@
 				]
 			}
 		},
-		"/notifications/templates/{notification_template}/method": {
+		"/api/v2/notifications/templates/{notification_template}/method": {
 			"put": {
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
@@ -2354,7 +2354,7 @@
 				]
 			}
 		},
-		"/notifications/test": {
+		"/api/v2/notifications/test": {
 			"post": {
 				"tags": ["Notifications"],
 				"summary": "Send a test notification",
@@ -2371,7 +2371,7 @@
 				]
 			}
 		},
-		"/oauth2-provider/apps": {
+		"/api/v2/oauth2-provider/apps": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
@@ -2434,7 +2434,7 @@
 				]
 			}
 		},
-		"/oauth2-provider/apps/{app}": {
+		"/api/v2/oauth2-provider/apps/{app}": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
@@ -2526,7 +2526,7 @@
 				]
 			}
 		},
-		"/oauth2-provider/apps/{app}/secrets": {
+		"/api/v2/oauth2-provider/apps/{app}/secrets": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
@@ -2590,7 +2590,7 @@
 				]
 			}
 		},
-		"/oauth2-provider/apps/{app}/secrets/{secretID}": {
+		"/api/v2/oauth2-provider/apps/{app}/secrets/{secretID}": {
 			"delete": {
 				"tags": ["Enterprise"],
 				"summary": "Delete OAuth2 application secret.",
@@ -2948,7 +2948,7 @@
 				]
 			}
 		},
-		"/organizations": {
+		"/api/v2/organizations": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Organizations"],
@@ -3003,7 +3003,7 @@
 				]
 			}
 		},
-		"/organizations/{organization}": {
+		"/api/v2/organizations/{organization}": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Organizations"],
@@ -3100,7 +3100,7 @@
 				]
 			}
 		},
-		"/organizations/{organization}/groups": {
+		"/api/v2/organizations/{organization}/groups": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
@@ -3172,7 +3172,7 @@
 				]
 			}
 		},
-		"/organizations/{organization}/groups/{groupName}": {
+		"/api/v2/organizations/{organization}/groups/{groupName}": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
@@ -3210,7 +3210,7 @@
 				]
 			}
 		},
-		"/organizations/{organization}/groups/{groupName}/members": {
+		"/api/v2/organizations/{organization}/groups/{groupName}/members": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
@@ -3273,7 +3273,7 @@
 				]
 			}
 		},
-		"/organizations/{organization}/members": {
+		"/api/v2/organizations/{organization}/members": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Members"],
@@ -3307,7 +3307,7 @@
 				]
 			}
 		},
-		"/organizations/{organization}/members/roles": {
+		"/api/v2/organizations/{organization}/members/roles": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Members"],
@@ -3425,7 +3425,7 @@
 				]
 			}
 		},
-		"/organizations/{organization}/members/roles/{roleName}": {
+		"/api/v2/organizations/{organization}/members/roles/{roleName}": {
 			"delete": {
 				"produces": ["application/json"],
 				"tags": ["Members"],
@@ -3466,7 +3466,7 @@
 				]
 			}
 		},
-		"/organizations/{organization}/members/{user}": {
+		"/api/v2/organizations/{organization}/members/{user}": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Members"],
@@ -3569,7 +3569,7 @@
 				]
 			}
 		},
-		"/organizations/{organization}/members/{user}/roles": {
+		"/api/v2/organizations/{organization}/members/{user}/roles": {
 			"put": {
 				"consumes": ["application/json"],
 				"produces": ["application/json"],
@@ -3616,7 +3616,7 @@
 				]
 			}
 		},
-		"/organizations/{organization}/members/{user}/workspace-quota": {
+		"/api/v2/organizations/{organization}/members/{user}/workspace-quota": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
@@ -3654,7 +3654,7 @@
 				]
 			}
 		},
-		"/organizations/{organization}/members/{user}/workspaces": {
+		"/api/v2/organizations/{organization}/members/{user}/workspaces": {
 			"post": {
 				"description": "Create a new workspace using a template. The request must\nspecify either the Template ID or the Template Version ID,\nnot both. If the Template ID is specified, the active version\nof the template will be used.",
 				"consumes": ["application/json"],
@@ -3704,7 +3704,7 @@
 				]
 			}
 		},
-		"/organizations/{organization}/members/{user}/workspaces/available-users": {
+		"/api/v2/organizations/{organization}/members/{user}/workspaces/available-users": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Workspaces"],
@@ -3763,7 +3763,7 @@
 				]
 			}
 		},
-		"/organizations/{organization}/paginated-members": {
+		"/api/v2/organizations/{organization}/paginated-members": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Members"],
@@ -3821,7 +3821,7 @@
 				]
 			}
 		},
-		"/organizations/{organization}/provisionerdaemons": {
+		"/api/v2/organizations/{organization}/provisionerdaemons": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Provisioning"],
@@ -3899,7 +3899,7 @@
 				]
 			}
 		},
-		"/organizations/{organization}/provisionerdaemons/serve": {
+		"/api/v2/organizations/{organization}/provisionerdaemons/serve": {
 			"get": {
 				"tags": ["Enterprise"],
 				"summary": "Serve provisioner daemon",
@@ -3926,7 +3926,7 @@
 				]
 			}
 		},
-		"/organizations/{organization}/provisionerjobs": {
+		"/api/v2/organizations/{organization}/provisionerjobs": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Organizations"],
@@ -4011,7 +4011,7 @@
 				]
 			}
 		},
-		"/organizations/{organization}/provisionerjobs/{job}": {
+		"/api/v2/organizations/{organization}/provisionerjobs/{job}": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Organizations"],
@@ -4050,7 +4050,7 @@
 				]
 			}
 		},
-		"/organizations/{organization}/provisionerkeys": {
+		"/api/v2/organizations/{organization}/provisionerkeys": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
@@ -4111,7 +4111,7 @@
 				]
 			}
 		},
-		"/organizations/{organization}/provisionerkeys/daemons": {
+		"/api/v2/organizations/{organization}/provisionerkeys/daemons": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
@@ -4144,7 +4144,7 @@
 				]
 			}
 		},
-		"/organizations/{organization}/provisionerkeys/{provisionerkey}": {
+		"/api/v2/organizations/{organization}/provisionerkeys/{provisionerkey}": {
 			"delete": {
 				"tags": ["Enterprise"],
 				"summary": "Delete provisioner key",
@@ -4177,7 +4177,7 @@
 				]
 			}
 		},
-		"/organizations/{organization}/settings/idpsync/available-fields": {
+		"/api/v2/organizations/{organization}/settings/idpsync/available-fields": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
@@ -4211,7 +4211,7 @@
 				]
 			}
 		},
-		"/organizations/{organization}/settings/idpsync/field-values": {
+		"/api/v2/organizations/{organization}/settings/idpsync/field-values": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
@@ -4253,7 +4253,7 @@
 				]
 			}
 		},
-		"/organizations/{organization}/settings/idpsync/groups": {
+		"/api/v2/organizations/{organization}/settings/idpsync/groups": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
@@ -4323,7 +4323,7 @@
 				]
 			}
 		},
-		"/organizations/{organization}/settings/idpsync/groups/config": {
+		"/api/v2/organizations/{organization}/settings/idpsync/groups/config": {
 			"patch": {
 				"consumes": ["application/json"],
 				"produces": ["application/json"],
@@ -4364,7 +4364,7 @@
 				]
 			}
 		},
-		"/organizations/{organization}/settings/idpsync/groups/mapping": {
+		"/api/v2/organizations/{organization}/settings/idpsync/groups/mapping": {
 			"patch": {
 				"consumes": ["application/json"],
 				"produces": ["application/json"],
@@ -4405,7 +4405,7 @@
 				]
 			}
 		},
-		"/organizations/{organization}/settings/idpsync/roles": {
+		"/api/v2/organizations/{organization}/settings/idpsync/roles": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
@@ -4475,7 +4475,7 @@
 				]
 			}
 		},
-		"/organizations/{organization}/settings/idpsync/roles/config": {
+		"/api/v2/organizations/{organization}/settings/idpsync/roles/config": {
 			"patch": {
 				"consumes": ["application/json"],
 				"produces": ["application/json"],
@@ -4516,7 +4516,7 @@
 				]
 			}
 		},
-		"/organizations/{organization}/settings/idpsync/roles/mapping": {
+		"/api/v2/organizations/{organization}/settings/idpsync/roles/mapping": {
 			"patch": {
 				"consumes": ["application/json"],
 				"produces": ["application/json"],
@@ -4557,7 +4557,7 @@
 				]
 			}
 		},
-		"/organizations/{organization}/settings/workspace-sharing": {
+		"/api/v2/organizations/{organization}/settings/workspace-sharing": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
@@ -4627,7 +4627,7 @@
 				]
 			}
 		},
-		"/organizations/{organization}/templates": {
+		"/api/v2/organizations/{organization}/templates": {
 			"get": {
 				"description": "Returns a list of templates for the specified organization.\nBy default, only non-deprecated templates are returned.\nTo include deprecated templates, specify `deprecated:true` in the search query.",
 				"produces": ["application/json"],
@@ -4700,7 +4700,7 @@
 				]
 			}
 		},
-		"/organizations/{organization}/templates/examples": {
+		"/api/v2/organizations/{organization}/templates/examples": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Templates"],
@@ -4735,7 +4735,7 @@
 				]
 			}
 		},
-		"/organizations/{organization}/templates/{templatename}": {
+		"/api/v2/organizations/{organization}/templates/{templatename}": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Templates"],
@@ -4773,7 +4773,7 @@
 				]
 			}
 		},
-		"/organizations/{organization}/templates/{templatename}/versions/{templateversionname}": {
+		"/api/v2/organizations/{organization}/templates/{templatename}/versions/{templateversionname}": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Templates"],
@@ -4818,7 +4818,7 @@
 				]
 			}
 		},
-		"/organizations/{organization}/templates/{templatename}/versions/{templateversionname}/previous": {
+		"/api/v2/organizations/{organization}/templates/{templatename}/versions/{templateversionname}/previous": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Templates"],
@@ -4866,7 +4866,7 @@
 				]
 			}
 		},
-		"/organizations/{organization}/templateversions": {
+		"/api/v2/organizations/{organization}/templateversions": {
 			"post": {
 				"consumes": ["application/json"],
 				"produces": ["application/json"],
@@ -4907,7 +4907,7 @@
 				]
 			}
 		},
-		"/prebuilds/settings": {
+		"/api/v2/prebuilds/settings": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Prebuilds"],
@@ -4962,7 +4962,7 @@
 				]
 			}
 		},
-		"/provisionerkeys/{provisionerkey}": {
+		"/api/v2/provisionerkeys/{provisionerkey}": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
@@ -4992,7 +4992,7 @@
 				]
 			}
 		},
-		"/regions": {
+		"/api/v2/regions": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["WorkspaceProxies"],
@@ -5013,7 +5013,7 @@
 				]
 			}
 		},
-		"/replicas": {
+		"/api/v2/replicas": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
@@ -5202,7 +5202,7 @@
 				]
 			}
 		},
-		"/settings/idpsync/available-fields": {
+		"/api/v2/settings/idpsync/available-fields": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
@@ -5236,7 +5236,7 @@
 				]
 			}
 		},
-		"/settings/idpsync/field-values": {
+		"/api/v2/settings/idpsync/field-values": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
@@ -5278,7 +5278,7 @@
 				]
 			}
 		},
-		"/settings/idpsync/organization": {
+		"/api/v2/settings/idpsync/organization": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
@@ -5330,7 +5330,7 @@
 				]
 			}
 		},
-		"/settings/idpsync/organization/config": {
+		"/api/v2/settings/idpsync/organization/config": {
 			"patch": {
 				"consumes": ["application/json"],
 				"produces": ["application/json"],
@@ -5363,7 +5363,7 @@
 				]
 			}
 		},
-		"/settings/idpsync/organization/mapping": {
+		"/api/v2/settings/idpsync/organization/mapping": {
 			"patch": {
 				"consumes": ["application/json"],
 				"produces": ["application/json"],
@@ -5396,7 +5396,7 @@
 				]
 			}
 		},
-		"/tailnet": {
+		"/api/v2/tailnet": {
 			"get": {
 				"tags": ["Agents"],
 				"summary": "User-scoped tailnet RPC connection",
@@ -5413,7 +5413,7 @@
 				]
 			}
 		},
-		"/tasks": {
+		"/api/v2/tasks": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Tasks"],
@@ -5442,7 +5442,7 @@
 				]
 			}
 		},
-		"/tasks/{user}": {
+		"/api/v2/tasks/{user}": {
 			"post": {
 				"consumes": ["application/json"],
 				"produces": ["application/json"],
@@ -5482,7 +5482,7 @@
 				]
 			}
 		},
-		"/tasks/{user}/{task}": {
+		"/api/v2/tasks/{user}/{task}": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Tasks"],
@@ -5550,7 +5550,7 @@
 				]
 			}
 		},
-		"/tasks/{user}/{task}/input": {
+		"/api/v2/tasks/{user}/{task}/input": {
 			"patch": {
 				"consumes": ["application/json"],
 				"tags": ["Tasks"],
@@ -5593,7 +5593,7 @@
 				]
 			}
 		},
-		"/tasks/{user}/{task}/logs": {
+		"/api/v2/tasks/{user}/{task}/logs": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Tasks"],
@@ -5630,7 +5630,7 @@
 				]
 			}
 		},
-		"/tasks/{user}/{task}/pause": {
+		"/api/v2/tasks/{user}/{task}/pause": {
 			"post": {
 				"produces": ["application/json"],
 				"tags": ["Tasks"],
@@ -5668,7 +5668,7 @@
 				]
 			}
 		},
-		"/tasks/{user}/{task}/resume": {
+		"/api/v2/tasks/{user}/{task}/resume": {
 			"post": {
 				"produces": ["application/json"],
 				"tags": ["Tasks"],
@@ -5706,7 +5706,7 @@
 				]
 			}
 		},
-		"/tasks/{user}/{task}/send": {
+		"/api/v2/tasks/{user}/{task}/send": {
 			"post": {
 				"consumes": ["application/json"],
 				"tags": ["Tasks"],
@@ -5749,7 +5749,7 @@
 				]
 			}
 		},
-		"/templates": {
+		"/api/v2/templates": {
 			"get": {
 				"description": "Returns a list of templates.\nBy default, only non-deprecated templates are returned.\nTo include deprecated templates, specify `deprecated:true` in the search query.",
 				"produces": ["application/json"],
@@ -5774,7 +5774,7 @@
 				]
 			}
 		},
-		"/templates/examples": {
+		"/api/v2/templates/examples": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Templates"],
@@ -5798,7 +5798,7 @@
 				]
 			}
 		},
-		"/templates/{template}": {
+		"/api/v2/templates/{template}": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Templates"],
@@ -5897,7 +5897,7 @@
 				]
 			}
 		},
-		"/templates/{template}/acl": {
+		"/api/v2/templates/{template}/acl": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
@@ -5967,7 +5967,7 @@
 				]
 			}
 		},
-		"/templates/{template}/acl/available": {
+		"/api/v2/templates/{template}/acl/available": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
@@ -6001,7 +6001,7 @@
 				]
 			}
 		},
-		"/templates/{template}/daus": {
+		"/api/v2/templates/{template}/daus": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Templates"],
@@ -6032,7 +6032,7 @@
 				]
 			}
 		},
-		"/templates/{template}/prebuilds/invalidate": {
+		"/api/v2/templates/{template}/prebuilds/invalidate": {
 			"post": {
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
@@ -6063,7 +6063,7 @@
 				]
 			}
 		},
-		"/templates/{template}/versions": {
+		"/api/v2/templates/{template}/versions": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Templates"],
@@ -6161,7 +6161,7 @@
 				]
 			}
 		},
-		"/templates/{template}/versions/archive": {
+		"/api/v2/templates/{template}/versions/archive": {
 			"post": {
 				"consumes": ["application/json"],
 				"produces": ["application/json"],
@@ -6202,7 +6202,7 @@
 				]
 			}
 		},
-		"/templates/{template}/versions/{templateversionname}": {
+		"/api/v2/templates/{template}/versions/{templateversionname}": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Templates"],
@@ -6243,7 +6243,7 @@
 				]
 			}
 		},
-		"/templateversions/{templateversion}": {
+		"/api/v2/templateversions/{templateversion}": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Templates"],
@@ -6313,7 +6313,7 @@
 				]
 			}
 		},
-		"/templateversions/{templateversion}/archive": {
+		"/api/v2/templateversions/{templateversion}/archive": {
 			"post": {
 				"produces": ["application/json"],
 				"tags": ["Templates"],
@@ -6344,7 +6344,7 @@
 				]
 			}
 		},
-		"/templateversions/{templateversion}/cancel": {
+		"/api/v2/templateversions/{templateversion}/cancel": {
 			"patch": {
 				"produces": ["application/json"],
 				"tags": ["Templates"],
@@ -6375,7 +6375,7 @@
 				]
 			}
 		},
-		"/templateversions/{templateversion}/dry-run": {
+		"/api/v2/templateversions/{templateversion}/dry-run": {
 			"post": {
 				"consumes": ["application/json"],
 				"produces": ["application/json"],
@@ -6416,7 +6416,7 @@
 				]
 			}
 		},
-		"/templateversions/{templateversion}/dry-run/{jobID}": {
+		"/api/v2/templateversions/{templateversion}/dry-run/{jobID}": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Templates"],
@@ -6455,7 +6455,7 @@
 				]
 			}
 		},
-		"/templateversions/{templateversion}/dry-run/{jobID}/cancel": {
+		"/api/v2/templateversions/{templateversion}/dry-run/{jobID}/cancel": {
 			"patch": {
 				"produces": ["application/json"],
 				"tags": ["Templates"],
@@ -6494,7 +6494,7 @@
 				]
 			}
 		},
-		"/templateversions/{templateversion}/dry-run/{jobID}/logs": {
+		"/api/v2/templateversions/{templateversion}/dry-run/{jobID}/logs": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Templates"],
@@ -6561,7 +6561,7 @@
 				]
 			}
 		},
-		"/templateversions/{templateversion}/dry-run/{jobID}/matched-provisioners": {
+		"/api/v2/templateversions/{templateversion}/dry-run/{jobID}/matched-provisioners": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Templates"],
@@ -6600,7 +6600,7 @@
 				]
 			}
 		},
-		"/templateversions/{templateversion}/dry-run/{jobID}/resources": {
+		"/api/v2/templateversions/{templateversion}/dry-run/{jobID}/resources": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Templates"],
@@ -6642,7 +6642,7 @@
 				]
 			}
 		},
-		"/templateversions/{templateversion}/dynamic-parameters": {
+		"/api/v2/templateversions/{templateversion}/dynamic-parameters": {
 			"get": {
 				"tags": ["Templates"],
 				"summary": "Open dynamic parameters WebSocket by template version",
@@ -6669,7 +6669,7 @@
 				]
 			}
 		},
-		"/templateversions/{templateversion}/dynamic-parameters/evaluate": {
+		"/api/v2/templateversions/{templateversion}/dynamic-parameters/evaluate": {
 			"post": {
 				"consumes": ["application/json"],
 				"produces": ["application/json"],
@@ -6710,7 +6710,7 @@
 				]
 			}
 		},
-		"/templateversions/{templateversion}/external-auth": {
+		"/api/v2/templateversions/{templateversion}/external-auth": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Templates"],
@@ -6744,7 +6744,7 @@
 				]
 			}
 		},
-		"/templateversions/{templateversion}/logs": {
+		"/api/v2/templateversions/{templateversion}/logs": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Templates"],
@@ -6803,7 +6803,7 @@
 				]
 			}
 		},
-		"/templateversions/{templateversion}/parameters": {
+		"/api/v2/templateversions/{templateversion}/parameters": {
 			"get": {
 				"tags": ["Templates"],
 				"summary": "Removed: Get parameters by template version",
@@ -6830,7 +6830,7 @@
 				]
 			}
 		},
-		"/templateversions/{templateversion}/presets": {
+		"/api/v2/templateversions/{templateversion}/presets": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Templates"],
@@ -6864,7 +6864,7 @@
 				]
 			}
 		},
-		"/templateversions/{templateversion}/resources": {
+		"/api/v2/templateversions/{templateversion}/resources": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Templates"],
@@ -6898,7 +6898,7 @@
 				]
 			}
 		},
-		"/templateversions/{templateversion}/rich-parameters": {
+		"/api/v2/templateversions/{templateversion}/rich-parameters": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Templates"],
@@ -6932,7 +6932,7 @@
 				]
 			}
 		},
-		"/templateversions/{templateversion}/schema": {
+		"/api/v2/templateversions/{templateversion}/schema": {
 			"get": {
 				"tags": ["Templates"],
 				"summary": "Removed: Get schema by template version",
@@ -6959,7 +6959,7 @@
 				]
 			}
 		},
-		"/templateversions/{templateversion}/unarchive": {
+		"/api/v2/templateversions/{templateversion}/unarchive": {
 			"post": {
 				"produces": ["application/json"],
 				"tags": ["Templates"],
@@ -6990,7 +6990,7 @@
 				]
 			}
 		},
-		"/templateversions/{templateversion}/variables": {
+		"/api/v2/templateversions/{templateversion}/variables": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Templates"],
@@ -7024,7 +7024,7 @@
 				]
 			}
 		},
-		"/updatecheck": {
+		"/api/v2/updatecheck": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["General"],
@@ -7040,7 +7040,7 @@
 				}
 			}
 		},
-		"/users": {
+		"/api/v2/users": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Users"],
@@ -7119,7 +7119,7 @@
 				]
 			}
 		},
-		"/users/authmethods": {
+		"/api/v2/users/authmethods": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Users"],
@@ -7140,7 +7140,7 @@
 				]
 			}
 		},
-		"/users/first": {
+		"/api/v2/users/first": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Users"],
@@ -7192,7 +7192,7 @@
 				]
 			}
 		},
-		"/users/login": {
+		"/api/v2/users/login": {
 			"post": {
 				"consumes": ["application/json"],
 				"produces": ["application/json"],
@@ -7220,7 +7220,7 @@
 				}
 			}
 		},
-		"/users/logout": {
+		"/api/v2/users/logout": {
 			"post": {
 				"produces": ["application/json"],
 				"tags": ["Users"],
@@ -7241,7 +7241,7 @@
 				]
 			}
 		},
-		"/users/oauth2/github/callback": {
+		"/api/v2/users/oauth2/github/callback": {
 			"get": {
 				"tags": ["Users"],
 				"summary": "OAuth 2.0 GitHub Callback",
@@ -7258,7 +7258,7 @@
 				]
 			}
 		},
-		"/users/oauth2/github/device": {
+		"/api/v2/users/oauth2/github/device": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Users"],
@@ -7279,7 +7279,7 @@
 				]
 			}
 		},
-		"/users/oidc-claims": {
+		"/api/v2/users/oidc-claims": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Users"],
@@ -7300,7 +7300,7 @@
 				]
 			}
 		},
-		"/users/oidc/callback": {
+		"/api/v2/users/oidc/callback": {
 			"get": {
 				"tags": ["Users"],
 				"summary": "OpenID Connect Callback",
@@ -7317,7 +7317,7 @@
 				]
 			}
 		},
-		"/users/otp/change-password": {
+		"/api/v2/users/otp/change-password": {
 			"post": {
 				"consumes": ["application/json"],
 				"tags": ["Authorization"],
@@ -7341,7 +7341,7 @@
 				}
 			}
 		},
-		"/users/otp/request": {
+		"/api/v2/users/otp/request": {
 			"post": {
 				"consumes": ["application/json"],
 				"tags": ["Authorization"],
@@ -7365,7 +7365,7 @@
 				}
 			}
 		},
-		"/users/roles": {
+		"/api/v2/users/roles": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Members"],
@@ -7389,7 +7389,7 @@
 				]
 			}
 		},
-		"/users/validate-password": {
+		"/api/v2/users/validate-password": {
 			"post": {
 				"consumes": ["application/json"],
 				"produces": ["application/json"],
@@ -7422,7 +7422,7 @@
 				]
 			}
 		},
-		"/users/{user}": {
+		"/api/v2/users/{user}": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Users"],
@@ -7476,7 +7476,7 @@
 				]
 			}
 		},
-		"/users/{user}/appearance": {
+		"/api/v2/users/{user}/appearance": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Users"],
@@ -7544,7 +7544,7 @@
 				]
 			}
 		},
-		"/users/{user}/autofill-parameters": {
+		"/api/v2/users/{user}/autofill-parameters": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Users"],
@@ -7584,7 +7584,7 @@
 				]
 			}
 		},
-		"/users/{user}/convert-login": {
+		"/api/v2/users/{user}/convert-login": {
 			"post": {
 				"consumes": ["application/json"],
 				"produces": ["application/json"],
@@ -7624,7 +7624,7 @@
 				]
 			}
 		},
-		"/users/{user}/gitsshkey": {
+		"/api/v2/users/{user}/gitsshkey": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Users"],
@@ -7682,7 +7682,7 @@
 				]
 			}
 		},
-		"/users/{user}/keys": {
+		"/api/v2/users/{user}/keys": {
 			"post": {
 				"produces": ["application/json"],
 				"tags": ["Users"],
@@ -7712,7 +7712,7 @@
 				]
 			}
 		},
-		"/users/{user}/keys/tokens": {
+		"/api/v2/users/{user}/keys/tokens": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Users"],
@@ -7789,7 +7789,7 @@
 				]
 			}
 		},
-		"/users/{user}/keys/tokens/tokenconfig": {
+		"/api/v2/users/{user}/keys/tokens/tokenconfig": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["General"],
@@ -7819,7 +7819,7 @@
 				]
 			}
 		},
-		"/users/{user}/keys/tokens/{keyname}": {
+		"/api/v2/users/{user}/keys/tokens/{keyname}": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Users"],
@@ -7857,7 +7857,7 @@
 				]
 			}
 		},
-		"/users/{user}/keys/{keyid}": {
+		"/api/v2/users/{user}/keys/{keyid}": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Users"],
@@ -7927,7 +7927,7 @@
 				]
 			}
 		},
-		"/users/{user}/keys/{keyid}/expire": {
+		"/api/v2/users/{user}/keys/{keyid}/expire": {
 			"put": {
 				"tags": ["Users"],
 				"summary": "Expire API key",
@@ -7973,7 +7973,7 @@
 				]
 			}
 		},
-		"/users/{user}/login-type": {
+		"/api/v2/users/{user}/login-type": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Users"],
@@ -8003,7 +8003,7 @@
 				]
 			}
 		},
-		"/users/{user}/notifications/preferences": {
+		"/api/v2/users/{user}/notifications/preferences": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Notifications"],
@@ -8077,7 +8077,7 @@
 				]
 			}
 		},
-		"/users/{user}/organizations": {
+		"/api/v2/users/{user}/organizations": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Users"],
@@ -8110,7 +8110,7 @@
 				]
 			}
 		},
-		"/users/{user}/organizations/{organizationname}": {
+		"/api/v2/users/{user}/organizations/{organizationname}": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Users"],
@@ -8147,7 +8147,7 @@
 				]
 			}
 		},
-		"/users/{user}/password": {
+		"/api/v2/users/{user}/password": {
 			"put": {
 				"consumes": ["application/json"],
 				"tags": ["Users"],
@@ -8183,7 +8183,7 @@
 				]
 			}
 		},
-		"/users/{user}/preferences": {
+		"/api/v2/users/{user}/preferences": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Users"],
@@ -8251,7 +8251,7 @@
 				]
 			}
 		},
-		"/users/{user}/profile": {
+		"/api/v2/users/{user}/profile": {
 			"put": {
 				"consumes": ["application/json"],
 				"produces": ["application/json"],
@@ -8291,7 +8291,7 @@
 				]
 			}
 		},
-		"/users/{user}/quiet-hours": {
+		"/api/v2/users/{user}/quiet-hours": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
@@ -8367,7 +8367,7 @@
 				]
 			}
 		},
-		"/users/{user}/roles": {
+		"/api/v2/users/{user}/roles": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Users"],
@@ -8435,7 +8435,7 @@
 				]
 			}
 		},
-		"/users/{user}/secrets": {
+		"/api/v2/users/{user}/secrets": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Secrets"],
@@ -8506,7 +8506,7 @@
 				]
 			}
 		},
-		"/users/{user}/secrets/{name}": {
+		"/api/v2/users/{user}/secrets/{name}": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Secrets"],
@@ -8619,7 +8619,7 @@
 				]
 			}
 		},
-		"/users/{user}/status/activate": {
+		"/api/v2/users/{user}/status/activate": {
 			"put": {
 				"produces": ["application/json"],
 				"tags": ["Users"],
@@ -8649,7 +8649,7 @@
 				]
 			}
 		},
-		"/users/{user}/status/suspend": {
+		"/api/v2/users/{user}/status/suspend": {
 			"put": {
 				"produces": ["application/json"],
 				"tags": ["Users"],
@@ -8679,7 +8679,7 @@
 				]
 			}
 		},
-		"/users/{user}/webpush/subscription": {
+		"/api/v2/users/{user}/webpush/subscription": {
 			"post": {
 				"consumes": ["application/json"],
 				"tags": ["Notifications"],
@@ -8755,7 +8755,7 @@
 				}
 			}
 		},
-		"/users/{user}/webpush/test": {
+		"/api/v2/users/{user}/webpush/test": {
 			"post": {
 				"tags": ["Notifications"],
 				"summary": "Send a test push notification",
@@ -8784,7 +8784,7 @@
 				}
 			}
 		},
-		"/users/{user}/workspace/{workspacename}": {
+		"/api/v2/users/{user}/workspace/{workspacename}": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Workspaces"],
@@ -8827,7 +8827,7 @@
 				]
 			}
 		},
-		"/users/{user}/workspace/{workspacename}/builds/{buildnumber}": {
+		"/api/v2/users/{user}/workspace/{workspacename}/builds/{buildnumber}": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Builds"],
@@ -8872,7 +8872,7 @@
 				]
 			}
 		},
-		"/users/{user}/workspaces": {
+		"/api/v2/users/{user}/workspaces": {
 			"post": {
 				"description": "Create a new workspace using a template. The request must\nspecify either the Template ID or the Template Version ID,\nnot both. If the Template ID is specified, the active version\nof the template will be used.",
 				"consumes": ["application/json"],
@@ -8913,7 +8913,7 @@
 				]
 			}
 		},
-		"/workspace-quota/{user}": {
+		"/api/v2/workspace-quota/{user}": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
@@ -8944,7 +8944,7 @@
 				]
 			}
 		},
-		"/workspaceagents/aws-instance-identity": {
+		"/api/v2/workspaceagents/aws-instance-identity": {
 			"post": {
 				"consumes": ["application/json"],
 				"produces": ["application/json"],
@@ -8977,7 +8977,7 @@
 				]
 			}
 		},
-		"/workspaceagents/azure-instance-identity": {
+		"/api/v2/workspaceagents/azure-instance-identity": {
 			"post": {
 				"consumes": ["application/json"],
 				"produces": ["application/json"],
@@ -9010,7 +9010,7 @@
 				]
 			}
 		},
-		"/workspaceagents/connection": {
+		"/api/v2/workspaceagents/connection": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Agents"],
@@ -9034,7 +9034,7 @@
 				}
 			}
 		},
-		"/workspaceagents/google-instance-identity": {
+		"/api/v2/workspaceagents/google-instance-identity": {
 			"post": {
 				"consumes": ["application/json"],
 				"produces": ["application/json"],
@@ -9067,7 +9067,7 @@
 				]
 			}
 		},
-		"/workspaceagents/me/app-status": {
+		"/api/v2/workspaceagents/me/app-status": {
 			"patch": {
 				"consumes": ["application/json"],
 				"produces": ["application/json"],
@@ -9101,7 +9101,7 @@
 				]
 			}
 		},
-		"/workspaceagents/me/external-auth": {
+		"/api/v2/workspaceagents/me/external-auth": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Agents"],
@@ -9144,7 +9144,7 @@
 				]
 			}
 		},
-		"/workspaceagents/me/gitauth": {
+		"/api/v2/workspaceagents/me/gitauth": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Agents"],
@@ -9187,7 +9187,7 @@
 				]
 			}
 		},
-		"/workspaceagents/me/gitsshkey": {
+		"/api/v2/workspaceagents/me/gitsshkey": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Agents"],
@@ -9208,7 +9208,7 @@
 				]
 			}
 		},
-		"/workspaceagents/me/log-source": {
+		"/api/v2/workspaceagents/me/log-source": {
 			"post": {
 				"consumes": ["application/json"],
 				"produces": ["application/json"],
@@ -9241,7 +9241,7 @@
 				]
 			}
 		},
-		"/workspaceagents/me/logs": {
+		"/api/v2/workspaceagents/me/logs": {
 			"patch": {
 				"consumes": ["application/json"],
 				"produces": ["application/json"],
@@ -9274,7 +9274,7 @@
 				]
 			}
 		},
-		"/workspaceagents/me/reinit": {
+		"/api/v2/workspaceagents/me/reinit": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Agents"],
@@ -9309,7 +9309,7 @@
 				]
 			}
 		},
-		"/workspaceagents/me/rpc": {
+		"/api/v2/workspaceagents/me/rpc": {
 			"get": {
 				"tags": ["Agents"],
 				"summary": "Workspace agent RPC API",
@@ -9329,7 +9329,7 @@
 				}
 			}
 		},
-		"/workspaceagents/me/tasks/{task}/log-snapshot": {
+		"/api/v2/workspaceagents/me/tasks/{task}/log-snapshot": {
 			"post": {
 				"consumes": ["application/json"],
 				"tags": ["Tasks"],
@@ -9374,7 +9374,7 @@
 				]
 			}
 		},
-		"/workspaceagents/{workspaceagent}": {
+		"/api/v2/workspaceagents/{workspaceagent}": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Agents"],
@@ -9405,7 +9405,7 @@
 				]
 			}
 		},
-		"/workspaceagents/{workspaceagent}/connection": {
+		"/api/v2/workspaceagents/{workspaceagent}/connection": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Agents"],
@@ -9436,7 +9436,7 @@
 				]
 			}
 		},
-		"/workspaceagents/{workspaceagent}/containers": {
+		"/api/v2/workspaceagents/{workspaceagent}/containers": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Agents"],
@@ -9475,7 +9475,7 @@
 				]
 			}
 		},
-		"/workspaceagents/{workspaceagent}/containers/devcontainers/{devcontainer}": {
+		"/api/v2/workspaceagents/{workspaceagent}/containers/devcontainers/{devcontainer}": {
 			"delete": {
 				"tags": ["Agents"],
 				"summary": "Delete devcontainer for workspace agent",
@@ -9509,7 +9509,7 @@
 				]
 			}
 		},
-		"/workspaceagents/{workspaceagent}/containers/devcontainers/{devcontainer}/recreate": {
+		"/api/v2/workspaceagents/{workspaceagent}/containers/devcontainers/{devcontainer}/recreate": {
 			"post": {
 				"produces": ["application/json"],
 				"tags": ["Agents"],
@@ -9547,7 +9547,7 @@
 				]
 			}
 		},
-		"/workspaceagents/{workspaceagent}/containers/watch": {
+		"/api/v2/workspaceagents/{workspaceagent}/containers/watch": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Agents"],
@@ -9578,7 +9578,7 @@
 				]
 			}
 		},
-		"/workspaceagents/{workspaceagent}/coordinate": {
+		"/api/v2/workspaceagents/{workspaceagent}/coordinate": {
 			"get": {
 				"tags": ["Agents"],
 				"summary": "Coordinate workspace agent",
@@ -9605,7 +9605,7 @@
 				]
 			}
 		},
-		"/workspaceagents/{workspaceagent}/listening-ports": {
+		"/api/v2/workspaceagents/{workspaceagent}/listening-ports": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Agents"],
@@ -9636,7 +9636,7 @@
 				]
 			}
 		},
-		"/workspaceagents/{workspaceagent}/logs": {
+		"/api/v2/workspaceagents/{workspaceagent}/logs": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Agents"],
@@ -9701,7 +9701,7 @@
 				]
 			}
 		},
-		"/workspaceagents/{workspaceagent}/pty": {
+		"/api/v2/workspaceagents/{workspaceagent}/pty": {
 			"get": {
 				"tags": ["Agents"],
 				"summary": "Open PTY to workspace agent",
@@ -9728,7 +9728,7 @@
 				]
 			}
 		},
-		"/workspaceagents/{workspaceagent}/startup-logs": {
+		"/api/v2/workspaceagents/{workspaceagent}/startup-logs": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Agents"],
@@ -9786,7 +9786,7 @@
 				]
 			}
 		},
-		"/workspaceagents/{workspaceagent}/watch-metadata": {
+		"/api/v2/workspaceagents/{workspaceagent}/watch-metadata": {
 			"get": {
 				"tags": ["Agents"],
 				"summary": "Watch for workspace agent metadata updates",
@@ -9817,7 +9817,7 @@
 				}
 			}
 		},
-		"/workspaceagents/{workspaceagent}/watch-metadata-ws": {
+		"/api/v2/workspaceagents/{workspaceagent}/watch-metadata-ws": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Agents"],
@@ -9851,7 +9851,7 @@
 				}
 			}
 		},
-		"/workspacebuilds/{workspacebuild}": {
+		"/api/v2/workspacebuilds/{workspacebuild}": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Builds"],
@@ -9881,7 +9881,7 @@
 				]
 			}
 		},
-		"/workspacebuilds/{workspacebuild}/cancel": {
+		"/api/v2/workspacebuilds/{workspacebuild}/cancel": {
 			"patch": {
 				"produces": ["application/json"],
 				"tags": ["Builds"],
@@ -9918,7 +9918,7 @@
 				]
 			}
 		},
-		"/workspacebuilds/{workspacebuild}/logs": {
+		"/api/v2/workspacebuilds/{workspacebuild}/logs": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Builds"],
@@ -9976,7 +9976,7 @@
 				]
 			}
 		},
-		"/workspacebuilds/{workspacebuild}/parameters": {
+		"/api/v2/workspacebuilds/{workspacebuild}/parameters": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Builds"],
@@ -10009,7 +10009,7 @@
 				]
 			}
 		},
-		"/workspacebuilds/{workspacebuild}/resources": {
+		"/api/v2/workspacebuilds/{workspacebuild}/resources": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Builds"],
@@ -10043,7 +10043,7 @@
 				]
 			}
 		},
-		"/workspacebuilds/{workspacebuild}/state": {
+		"/api/v2/workspacebuilds/{workspacebuild}/state": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Builds"],
@@ -10108,7 +10108,7 @@
 				]
 			}
 		},
-		"/workspacebuilds/{workspacebuild}/timings": {
+		"/api/v2/workspacebuilds/{workspacebuild}/timings": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Builds"],
@@ -10139,7 +10139,7 @@
 				]
 			}
 		},
-		"/workspaceproxies": {
+		"/api/v2/workspaceproxies": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
@@ -10194,7 +10194,7 @@
 				]
 			}
 		},
-		"/workspaceproxies/me/app-stats": {
+		"/api/v2/workspaceproxies/me/app-stats": {
 			"post": {
 				"consumes": ["application/json"],
 				"tags": ["Enterprise"],
@@ -10226,7 +10226,7 @@
 				}
 			}
 		},
-		"/workspaceproxies/me/coordinate": {
+		"/api/v2/workspaceproxies/me/coordinate": {
 			"get": {
 				"tags": ["Enterprise"],
 				"summary": "Workspace Proxy Coordinate",
@@ -10246,7 +10246,7 @@
 				}
 			}
 		},
-		"/workspaceproxies/me/crypto-keys": {
+		"/api/v2/workspaceproxies/me/crypto-keys": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
@@ -10279,7 +10279,7 @@
 				}
 			}
 		},
-		"/workspaceproxies/me/deregister": {
+		"/api/v2/workspaceproxies/me/deregister": {
 			"post": {
 				"consumes": ["application/json"],
 				"tags": ["Enterprise"],
@@ -10311,7 +10311,7 @@
 				}
 			}
 		},
-		"/workspaceproxies/me/issue-signed-app-token": {
+		"/api/v2/workspaceproxies/me/issue-signed-app-token": {
 			"post": {
 				"consumes": ["application/json"],
 				"produces": ["application/json"],
@@ -10347,7 +10347,7 @@
 				}
 			}
 		},
-		"/workspaceproxies/me/register": {
+		"/api/v2/workspaceproxies/me/register": {
 			"post": {
 				"consumes": ["application/json"],
 				"produces": ["application/json"],
@@ -10383,7 +10383,7 @@
 				}
 			}
 		},
-		"/workspaceproxies/{workspaceproxy}": {
+		"/api/v2/workspaceproxies/{workspaceproxy}": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
@@ -10482,7 +10482,7 @@
 				]
 			}
 		},
-		"/workspaces": {
+		"/api/v2/workspaces": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Workspaces"],
@@ -10523,7 +10523,7 @@
 				]
 			}
 		},
-		"/workspaces/{workspace}": {
+		"/api/v2/workspaces/{workspace}": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Workspaces"],
@@ -10595,7 +10595,7 @@
 				]
 			}
 		},
-		"/workspaces/{workspace}/acl": {
+		"/api/v2/workspaces/{workspace}/acl": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Workspaces"],
@@ -10687,7 +10687,7 @@
 				]
 			}
 		},
-		"/workspaces/{workspace}/autostart": {
+		"/api/v2/workspaces/{workspace}/autostart": {
 			"put": {
 				"consumes": ["application/json"],
 				"tags": ["Workspaces"],
@@ -10724,7 +10724,7 @@
 				]
 			}
 		},
-		"/workspaces/{workspace}/autoupdates": {
+		"/api/v2/workspaces/{workspace}/autoupdates": {
 			"put": {
 				"consumes": ["application/json"],
 				"tags": ["Workspaces"],
@@ -10761,7 +10761,7 @@
 				]
 			}
 		},
-		"/workspaces/{workspace}/builds": {
+		"/api/v2/workspaces/{workspace}/builds": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Builds"],
@@ -10860,7 +10860,7 @@
 				]
 			}
 		},
-		"/workspaces/{workspace}/dormant": {
+		"/api/v2/workspaces/{workspace}/dormant": {
 			"put": {
 				"consumes": ["application/json"],
 				"produces": ["application/json"],
@@ -10901,7 +10901,7 @@
 				]
 			}
 		},
-		"/workspaces/{workspace}/extend": {
+		"/api/v2/workspaces/{workspace}/extend": {
 			"put": {
 				"consumes": ["application/json"],
 				"produces": ["application/json"],
@@ -10942,7 +10942,7 @@
 				]
 			}
 		},
-		"/workspaces/{workspace}/external-agent/{agent}/credentials": {
+		"/api/v2/workspaces/{workspace}/external-agent/{agent}/credentials": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Enterprise"],
@@ -10980,7 +10980,7 @@
 				]
 			}
 		},
-		"/workspaces/{workspace}/favorite": {
+		"/api/v2/workspaces/{workspace}/favorite": {
 			"put": {
 				"tags": ["Workspaces"],
 				"summary": "Favorite workspace by ID.",
@@ -11032,7 +11032,7 @@
 				]
 			}
 		},
-		"/workspaces/{workspace}/port-share": {
+		"/api/v2/workspaces/{workspace}/port-share": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["PortSharing"],
@@ -11137,7 +11137,7 @@
 				]
 			}
 		},
-		"/workspaces/{workspace}/resolve-autostart": {
+		"/api/v2/workspaces/{workspace}/resolve-autostart": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Workspaces"],
@@ -11168,7 +11168,7 @@
 				]
 			}
 		},
-		"/workspaces/{workspace}/timings": {
+		"/api/v2/workspaces/{workspace}/timings": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Workspaces"],
@@ -11199,7 +11199,7 @@
 				]
 			}
 		},
-		"/workspaces/{workspace}/ttl": {
+		"/api/v2/workspaces/{workspace}/ttl": {
 			"put": {
 				"consumes": ["application/json"],
 				"tags": ["Workspaces"],
@@ -11236,7 +11236,7 @@
 				]
 			}
 		},
-		"/workspaces/{workspace}/usage": {
+		"/api/v2/workspaces/{workspace}/usage": {
 			"post": {
 				"consumes": ["application/json"],
 				"tags": ["Workspaces"],
@@ -11272,7 +11272,7 @@
 				]
 			}
 		},
-		"/workspaces/{workspace}/watch": {
+		"/api/v2/workspaces/{workspace}/watch": {
 			"get": {
 				"produces": ["text/event-stream"],
 				"tags": ["Workspaces"],
@@ -11304,7 +11304,7 @@
 				]
 			}
 		},
-		"/workspaces/{workspace}/watch-ws": {
+		"/api/v2/workspaces/{workspace}/watch-ws": {
 			"get": {
 				"produces": ["application/json"],
 				"tags": ["Workspaces"],

--- a/docs/reference/api/agents.md
+++ b/docs/reference/api/agents.md
@@ -10,7 +10,7 @@ curl -X GET http://coder-server:8080/api/v2/derp-map \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /derp-map`
+`GET /api/v2/derp-map`
 
 ### Responses
 
@@ -30,7 +30,7 @@ curl -X GET http://coder-server:8080/api/v2/tailnet \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /tailnet`
+`GET /api/v2/tailnet`
 
 ### Responses
 
@@ -52,7 +52,7 @@ curl -X POST http://coder-server:8080/api/v2/workspaceagents/aws-instance-identi
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /workspaceagents/aws-instance-identity`
+`POST /api/v2/workspaceagents/aws-instance-identity`
 
 > Body parameter
 
@@ -100,7 +100,7 @@ curl -X POST http://coder-server:8080/api/v2/workspaceagents/azure-instance-iden
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /workspaceagents/azure-instance-identity`
+`POST /api/v2/workspaceagents/azure-instance-identity`
 
 > Body parameter
 
@@ -148,7 +148,7 @@ curl -X POST http://coder-server:8080/api/v2/workspaceagents/google-instance-ide
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /workspaceagents/google-instance-identity`
+`POST /api/v2/workspaceagents/google-instance-identity`
 
 > Body parameter
 
@@ -195,7 +195,7 @@ curl -X PATCH http://coder-server:8080/api/v2/workspaceagents/me/app-status \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PATCH /workspaceagents/me/app-status`
+`PATCH /api/v2/workspaceagents/me/app-status`
 
 > Body parameter
 
@@ -252,7 +252,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaceagents/me/external-auth?mat
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /workspaceagents/me/external-auth`
+`GET /api/v2/workspaceagents/me/external-auth`
 
 ### Parameters
 
@@ -296,7 +296,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaceagents/me/gitauth?match=str
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /workspaceagents/me/gitauth`
+`GET /api/v2/workspaceagents/me/gitauth`
 
 ### Parameters
 
@@ -340,7 +340,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaceagents/me/gitsshkey \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /workspaceagents/me/gitsshkey`
+`GET /api/v2/workspaceagents/me/gitsshkey`
 
 ### Example responses
 
@@ -373,7 +373,7 @@ curl -X POST http://coder-server:8080/api/v2/workspaceagents/me/log-source \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /workspaceagents/me/log-source`
+`POST /api/v2/workspaceagents/me/log-source`
 
 > Body parameter
 
@@ -425,7 +425,7 @@ curl -X PATCH http://coder-server:8080/api/v2/workspaceagents/me/logs \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PATCH /workspaceagents/me/logs`
+`PATCH /api/v2/workspaceagents/me/logs`
 
 > Body parameter
 
@@ -484,7 +484,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaceagents/me/reinit \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /workspaceagents/me/reinit`
+`GET /api/v2/workspaceagents/me/reinit`
 
 ### Parameters
 
@@ -524,7 +524,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaceagents/{workspaceagent} \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /workspaceagents/{workspaceagent}`
+`GET /api/v2/workspaceagents/{workspaceagent}`
 
 ### Parameters
 
@@ -675,7 +675,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaceagents/{workspaceagent}/con
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /workspaceagents/{workspaceagent}/connection`
+`GET /api/v2/workspaceagents/{workspaceagent}/connection`
 
 ### Parameters
 
@@ -773,7 +773,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaceagents/{workspaceagent}/con
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /workspaceagents/{workspaceagent}/containers`
+`GET /api/v2/workspaceagents/{workspaceagent}/containers`
 
 ### Parameters
 
@@ -882,7 +882,7 @@ curl -X DELETE http://coder-server:8080/api/v2/workspaceagents/{workspaceagent}/
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`DELETE /workspaceagents/{workspaceagent}/containers/devcontainers/{devcontainer}`
+`DELETE /api/v2/workspaceagents/{workspaceagent}/containers/devcontainers/{devcontainer}`
 
 ### Parameters
 
@@ -910,7 +910,7 @@ curl -X POST http://coder-server:8080/api/v2/workspaceagents/{workspaceagent}/co
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /workspaceagents/{workspaceagent}/containers/devcontainers/{devcontainer}/recreate`
+`POST /api/v2/workspaceagents/{workspaceagent}/containers/devcontainers/{devcontainer}/recreate`
 
 ### Parameters
 
@@ -955,7 +955,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaceagents/{workspaceagent}/con
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /workspaceagents/{workspaceagent}/containers/watch`
+`GET /api/v2/workspaceagents/{workspaceagent}/containers/watch`
 
 ### Parameters
 
@@ -1063,7 +1063,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaceagents/{workspaceagent}/coo
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /workspaceagents/{workspaceagent}/coordinate`
+`GET /api/v2/workspaceagents/{workspaceagent}/coordinate`
 
 ### Parameters
 
@@ -1090,7 +1090,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaceagents/{workspaceagent}/lis
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /workspaceagents/{workspaceagent}/listening-ports`
+`GET /api/v2/workspaceagents/{workspaceagent}/listening-ports`
 
 ### Parameters
 
@@ -1133,7 +1133,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaceagents/{workspaceagent}/log
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /workspaceagents/{workspaceagent}/logs`
+`GET /api/v2/workspaceagents/{workspaceagent}/logs`
 
 ### Parameters
 
@@ -1205,7 +1205,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaceagents/{workspaceagent}/pty
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /workspaceagents/{workspaceagent}/pty`
+`GET /api/v2/workspaceagents/{workspaceagent}/pty`
 
 ### Parameters
 
@@ -1232,7 +1232,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaceagents/{workspaceagent}/sta
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /workspaceagents/{workspaceagent}/startup-logs`
+`GET /api/v2/workspaceagents/{workspaceagent}/startup-logs`
 
 ### Parameters
 

--- a/docs/reference/api/aibridge.md
+++ b/docs/reference/api/aibridge.md
@@ -11,7 +11,7 @@ curl -X GET http://coder-server:8080/api/v2/aibridge/clients \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /aibridge/clients`
+`GET /api/v2/aibridge/clients`
 
 ### Example responses
 
@@ -44,7 +44,7 @@ curl -X GET http://coder-server:8080/api/v2/aibridge/interceptions \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /aibridge/interceptions`
+`GET /api/v2/aibridge/interceptions`
 
 ### Parameters
 
@@ -152,7 +152,7 @@ curl -X GET http://coder-server:8080/api/v2/aibridge/models \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /aibridge/models`
+`GET /api/v2/aibridge/models`
 
 ### Example responses
 
@@ -185,7 +185,7 @@ curl -X GET http://coder-server:8080/api/v2/aibridge/sessions \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /aibridge/sessions`
+`GET /api/v2/aibridge/sessions`
 
 ### Parameters
 
@@ -258,7 +258,7 @@ curl -X GET http://coder-server:8080/api/v2/aibridge/sessions/{session_id} \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /aibridge/sessions/{session_id}`
+`GET /api/v2/aibridge/sessions/{session_id}`
 
 ### Parameters
 

--- a/docs/reference/api/applications.md
+++ b/docs/reference/api/applications.md
@@ -10,7 +10,7 @@ curl -X GET http://coder-server:8080/api/v2/applications/auth-redirect \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /applications/auth-redirect`
+`GET /api/v2/applications/auth-redirect`
 
 ### Parameters
 
@@ -37,7 +37,7 @@ curl -X GET http://coder-server:8080/api/v2/applications/host \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /applications/host`
+`GET /api/v2/applications/host`
 
 ### Example responses
 

--- a/docs/reference/api/audit.md
+++ b/docs/reference/api/audit.md
@@ -11,7 +11,7 @@ curl -X GET http://coder-server:8080/api/v2/audit?limit=0 \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /audit`
+`GET /api/v2/audit`
 
 ### Parameters
 

--- a/docs/reference/api/authorization.md
+++ b/docs/reference/api/authorization.md
@@ -10,7 +10,7 @@ curl -X GET http://coder-server:8080/api/v2/auth/scopes \
   -H 'Accept: application/json'
 ```
 
-`GET /auth/scopes`
+`GET /api/v2/auth/scopes`
 
 ### Example responses
 
@@ -42,7 +42,7 @@ curl -X POST http://coder-server:8080/api/v2/authcheck \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /authcheck`
+`POST /api/v2/authcheck`
 
 > Body parameter
 
@@ -109,7 +109,7 @@ curl -X POST http://coder-server:8080/api/v2/users/login \
   -H 'Accept: application/json'
 ```
 
-`POST /users/login`
+`POST /api/v2/users/login`
 
 > Body parameter
 
@@ -152,7 +152,7 @@ curl -X POST http://coder-server:8080/api/v2/users/otp/change-password \
   -H 'Content-Type: application/json'
 ```
 
-`POST /users/otp/change-password`
+`POST /api/v2/users/otp/change-password`
 
 > Body parameter
 
@@ -186,7 +186,7 @@ curl -X POST http://coder-server:8080/api/v2/users/otp/request \
   -H 'Content-Type: application/json'
 ```
 
-`POST /users/otp/request`
+`POST /api/v2/users/otp/request`
 
 > Body parameter
 
@@ -220,7 +220,7 @@ curl -X POST http://coder-server:8080/api/v2/users/validate-password \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /users/validate-password`
+`POST /api/v2/users/validate-password`
 
 > Body parameter
 
@@ -267,7 +267,7 @@ curl -X POST http://coder-server:8080/api/v2/users/{user}/convert-login \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /users/{user}/convert-login`
+`POST /api/v2/users/{user}/convert-login`
 
 > Body parameter
 

--- a/docs/reference/api/builds.md
+++ b/docs/reference/api/builds.md
@@ -11,7 +11,7 @@ curl -X GET http://coder-server:8080/api/v2/users/{user}/workspace/{workspacenam
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /users/{user}/workspace/{workspacename}/builds/{buildnumber}`
+`GET /api/v2/users/{user}/workspace/{workspacename}/builds/{buildnumber}`
 
 ### Parameters
 
@@ -256,7 +256,7 @@ curl -X GET http://coder-server:8080/api/v2/workspacebuilds/{workspacebuild} \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /workspacebuilds/{workspacebuild}`
+`GET /api/v2/workspacebuilds/{workspacebuild}`
 
 ### Parameters
 
@@ -499,7 +499,7 @@ curl -X PATCH http://coder-server:8080/api/v2/workspacebuilds/{workspacebuild}/c
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PATCH /workspacebuilds/{workspacebuild}/cancel`
+`PATCH /api/v2/workspacebuilds/{workspacebuild}/cancel`
 
 ### Parameters
 
@@ -550,7 +550,7 @@ curl -X GET http://coder-server:8080/api/v2/workspacebuilds/{workspacebuild}/log
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /workspacebuilds/{workspacebuild}/logs`
+`GET /api/v2/workspacebuilds/{workspacebuild}/logs`
 
 ### Parameters
 
@@ -625,7 +625,7 @@ curl -X GET http://coder-server:8080/api/v2/workspacebuilds/{workspacebuild}/par
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /workspacebuilds/{workspacebuild}/parameters`
+`GET /api/v2/workspacebuilds/{workspacebuild}/parameters`
 
 ### Parameters
 
@@ -675,7 +675,7 @@ curl -X GET http://coder-server:8080/api/v2/workspacebuilds/{workspacebuild}/res
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /workspacebuilds/{workspacebuild}/resources`
+`GET /api/v2/workspacebuilds/{workspacebuild}/resources`
 
 ### Parameters
 
@@ -971,7 +971,7 @@ curl -X GET http://coder-server:8080/api/v2/workspacebuilds/{workspacebuild}/sta
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /workspacebuilds/{workspacebuild}/state`
+`GET /api/v2/workspacebuilds/{workspacebuild}/state`
 
 ### Parameters
 
@@ -1214,7 +1214,7 @@ curl -X PUT http://coder-server:8080/api/v2/workspacebuilds/{workspacebuild}/sta
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PUT /workspacebuilds/{workspacebuild}/state`
+`PUT /api/v2/workspacebuilds/{workspacebuild}/state`
 
 > Body parameter
 
@@ -1252,7 +1252,7 @@ curl -X GET http://coder-server:8080/api/v2/workspacebuilds/{workspacebuild}/tim
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /workspacebuilds/{workspacebuild}/timings`
+`GET /api/v2/workspacebuilds/{workspacebuild}/timings`
 
 ### Parameters
 
@@ -1320,7 +1320,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaces/{workspace}/builds \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /workspaces/{workspace}/builds`
+`GET /api/v2/workspaces/{workspace}/builds`
 
 ### Parameters
 
@@ -1759,7 +1759,7 @@ curl -X POST http://coder-server:8080/api/v2/workspaces/{workspace}/builds \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /workspaces/{workspace}/builds`
+`POST /api/v2/workspaces/{workspace}/builds`
 
 > Body parameter
 

--- a/docs/reference/api/debug.md
+++ b/docs/reference/api/debug.md
@@ -10,7 +10,7 @@ curl -X GET http://coder-server:8080/api/v2/debug/coordinator \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /debug/coordinator`
+`GET /api/v2/debug/coordinator`
 
 ### Responses
 
@@ -31,7 +31,7 @@ curl -X GET http://coder-server:8080/api/v2/debug/health \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /debug/health`
+`GET /api/v2/debug/health`
 
 ### Parameters
 
@@ -434,7 +434,7 @@ curl -X GET http://coder-server:8080/api/v2/debug/health/settings \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /debug/health/settings`
+`GET /api/v2/debug/health/settings`
 
 ### Example responses
 
@@ -468,7 +468,7 @@ curl -X PUT http://coder-server:8080/api/v2/debug/health/settings \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PUT /debug/health/settings`
+`PUT /api/v2/debug/health/settings`
 
 > Body parameter
 
@@ -516,7 +516,7 @@ curl -X GET http://coder-server:8080/api/v2/debug/tailnet \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /debug/tailnet`
+`GET /api/v2/debug/tailnet`
 
 ### Responses
 

--- a/docs/reference/api/enterprise.md
+++ b/docs/reference/api/enterprise.md
@@ -6,7 +6,7 @@
 
 ```shell
 # Example request using curl
-curl -X GET http://coder-server:8080/api/v2/.well-known/oauth-authorization-server \
+curl -X GET http://coder-server:8080/.well-known/oauth-authorization-server \
   -H 'Accept: application/json'
 ```
 
@@ -53,7 +53,7 @@ curl -X GET http://coder-server:8080/api/v2/.well-known/oauth-authorization-serv
 
 ```shell
 # Example request using curl
-curl -X GET http://coder-server:8080/api/v2/.well-known/oauth-protected-resource \
+curl -X GET http://coder-server:8080/.well-known/oauth-protected-resource \
   -H 'Accept: application/json'
 ```
 
@@ -95,7 +95,7 @@ curl -X GET http://coder-server:8080/api/v2/appearance \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /appearance`
+`GET /api/v2/appearance`
 
 ### Example responses
 
@@ -149,7 +149,7 @@ curl -X PUT http://coder-server:8080/api/v2/appearance \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PUT /appearance`
+`PUT /api/v2/appearance`
 
 > Body parameter
 
@@ -220,7 +220,7 @@ curl -X GET http://coder-server:8080/api/v2/connectionlog?limit=0 \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /connectionlog`
+`GET /api/v2/connectionlog`
 
 ### Parameters
 
@@ -315,7 +315,7 @@ curl -X GET http://coder-server:8080/api/v2/entitlements \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /entitlements`
+`GET /api/v2/entitlements`
 
 ### Example responses
 
@@ -379,7 +379,7 @@ curl -X GET http://coder-server:8080/api/v2/groups?organization=string&has_membe
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /groups`
+`GET /api/v2/groups`
 
 ### Parameters
 
@@ -484,7 +484,7 @@ curl -X GET http://coder-server:8080/api/v2/groups/{group} \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /groups/{group}`
+`GET /api/v2/groups/{group}`
 
 ### Parameters
 
@@ -547,7 +547,7 @@ curl -X DELETE http://coder-server:8080/api/v2/groups/{group} \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`DELETE /groups/{group}`
+`DELETE /api/v2/groups/{group}`
 
 ### Parameters
 
@@ -610,7 +610,7 @@ curl -X PATCH http://coder-server:8080/api/v2/groups/{group} \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PATCH /groups/{group}`
+`PATCH /api/v2/groups/{group}`
 
 > Body parameter
 
@@ -690,7 +690,7 @@ curl -X GET http://coder-server:8080/api/v2/groups/{group}/members \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /groups/{group}/members`
+`GET /api/v2/groups/{group}/members`
 
 ### Parameters
 
@@ -747,7 +747,7 @@ curl -X GET http://coder-server:8080/api/v2/licenses \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /licenses`
+`GET /api/v2/licenses`
 
 ### Example responses
 
@@ -796,7 +796,7 @@ curl -X POST http://coder-server:8080/api/v2/licenses \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /licenses`
+`POST /api/v2/licenses`
 
 > Body parameter
 
@@ -844,7 +844,7 @@ curl -X POST http://coder-server:8080/api/v2/licenses/refresh-entitlements \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /licenses/refresh-entitlements`
+`POST /api/v2/licenses/refresh-entitlements`
 
 ### Example responses
 
@@ -881,7 +881,7 @@ curl -X DELETE http://coder-server:8080/api/v2/licenses/{id} \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`DELETE /licenses/{id}`
+`DELETE /api/v2/licenses/{id}`
 
 ### Parameters
 
@@ -907,7 +907,7 @@ curl -X PUT http://coder-server:8080/api/v2/notifications/templates/{notificatio
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PUT /notifications/templates/{notification_template}/method`
+`PUT /api/v2/notifications/templates/{notification_template}/method`
 
 ### Parameters
 
@@ -935,7 +935,7 @@ curl -X GET http://coder-server:8080/api/v2/oauth2-provider/apps \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /oauth2-provider/apps`
+`GET /api/v2/oauth2-provider/apps`
 
 ### Parameters
 
@@ -1001,7 +1001,7 @@ curl -X POST http://coder-server:8080/api/v2/oauth2-provider/apps \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /oauth2-provider/apps`
+`POST /api/v2/oauth2-provider/apps`
 
 > Body parameter
 
@@ -1057,7 +1057,7 @@ curl -X GET http://coder-server:8080/api/v2/oauth2-provider/apps/{app} \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /oauth2-provider/apps/{app}`
+`GET /api/v2/oauth2-provider/apps/{app}`
 
 ### Parameters
 
@@ -1104,7 +1104,7 @@ curl -X PUT http://coder-server:8080/api/v2/oauth2-provider/apps/{app} \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PUT /oauth2-provider/apps/{app}`
+`PUT /api/v2/oauth2-provider/apps/{app}`
 
 > Body parameter
 
@@ -1160,7 +1160,7 @@ curl -X DELETE http://coder-server:8080/api/v2/oauth2-provider/apps/{app} \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`DELETE /oauth2-provider/apps/{app}`
+`DELETE /api/v2/oauth2-provider/apps/{app}`
 
 ### Parameters
 
@@ -1187,7 +1187,7 @@ curl -X GET http://coder-server:8080/api/v2/oauth2-provider/apps/{app}/secrets \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /oauth2-provider/apps/{app}/secrets`
+`GET /api/v2/oauth2-provider/apps/{app}/secrets`
 
 ### Parameters
 
@@ -1239,7 +1239,7 @@ curl -X POST http://coder-server:8080/api/v2/oauth2-provider/apps/{app}/secrets 
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /oauth2-provider/apps/{app}/secrets`
+`POST /api/v2/oauth2-provider/apps/{app}/secrets`
 
 ### Parameters
 
@@ -1288,7 +1288,7 @@ curl -X DELETE http://coder-server:8080/api/v2/oauth2-provider/apps/{app}/secret
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`DELETE /oauth2-provider/apps/{app}/secrets/{secretID}`
+`DELETE /api/v2/oauth2-provider/apps/{app}/secrets/{secretID}`
 
 ### Parameters
 
@@ -1311,7 +1311,7 @@ To perform this operation, you must be authenticated. [Learn more](authenticatio
 
 ```shell
 # Example request using curl
-curl -X GET http://coder-server:8080/api/v2/oauth2/authorize?client_id=string&state=string&response_type=code \
+curl -X GET http://coder-server:8080/oauth2/authorize?client_id=string&state=string&response_type=code \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
@@ -1347,7 +1347,7 @@ To perform this operation, you must be authenticated. [Learn more](authenticatio
 
 ```shell
 # Example request using curl
-curl -X POST http://coder-server:8080/api/v2/oauth2/authorize?client_id=string&state=string&response_type=code \
+curl -X POST http://coder-server:8080/oauth2/authorize?client_id=string&state=string&response_type=code \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
@@ -1383,7 +1383,7 @@ To perform this operation, you must be authenticated. [Learn more](authenticatio
 
 ```shell
 # Example request using curl
-curl -X GET http://coder-server:8080/api/v2/oauth2/clients/{client_id} \
+curl -X GET http://coder-server:8080/oauth2/clients/{client_id} \
   -H 'Accept: application/json'
 ```
 
@@ -1444,7 +1444,7 @@ curl -X GET http://coder-server:8080/api/v2/oauth2/clients/{client_id} \
 
 ```shell
 # Example request using curl
-curl -X PUT http://coder-server:8080/api/v2/oauth2/clients/{client_id} \
+curl -X PUT http://coder-server:8080/oauth2/clients/{client_id} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json'
 ```
@@ -1538,7 +1538,7 @@ curl -X PUT http://coder-server:8080/api/v2/oauth2/clients/{client_id} \
 
 ```shell
 # Example request using curl
-curl -X DELETE http://coder-server:8080/api/v2/oauth2/clients/{client_id}
+curl -X DELETE http://coder-server:8080/oauth2/clients/{client_id}
 
 ```
 
@@ -1562,7 +1562,7 @@ curl -X DELETE http://coder-server:8080/api/v2/oauth2/clients/{client_id}
 
 ```shell
 # Example request using curl
-curl -X POST http://coder-server:8080/api/v2/oauth2/register \
+curl -X POST http://coder-server:8080/oauth2/register \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json'
 ```
@@ -1656,7 +1656,7 @@ curl -X POST http://coder-server:8080/api/v2/oauth2/register \
 
 ```shell
 # Example request using curl
-curl -X POST http://coder-server:8080/api/v2/oauth2/revoke \
+curl -X POST http://coder-server:8080/oauth2/revoke \
 
 ```
 
@@ -1692,7 +1692,7 @@ token_type_hint: string
 
 ```shell
 # Example request using curl
-curl -X POST http://coder-server:8080/api/v2/oauth2/tokens \
+curl -X POST http://coder-server:8080/oauth2/tokens \
   -H 'Accept: application/json'
 ```
 
@@ -1752,7 +1752,7 @@ grant_type: authorization_code
 
 ```shell
 # Example request using curl
-curl -X DELETE http://coder-server:8080/api/v2/oauth2/tokens?client_id=string \
+curl -X DELETE http://coder-server:8080/oauth2/tokens?client_id=string \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
@@ -1783,7 +1783,7 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/groups 
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /organizations/{organization}/groups`
+`GET /api/v2/organizations/{organization}/groups`
 
 ### Parameters
 
@@ -1887,7 +1887,7 @@ curl -X POST http://coder-server:8080/api/v2/organizations/{organization}/groups
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /organizations/{organization}/groups`
+`POST /api/v2/organizations/{organization}/groups`
 
 > Body parameter
 
@@ -1961,7 +1961,7 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/groups/
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /organizations/{organization}/groups/{groupName}`
+`GET /api/v2/organizations/{organization}/groups/{groupName}`
 
 ### Parameters
 
@@ -2024,7 +2024,7 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/groups/
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /organizations/{organization}/groups/{groupName}/members`
+`GET /api/v2/organizations/{organization}/groups/{groupName}/members`
 
 ### Parameters
 
@@ -2082,7 +2082,7 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/members
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /organizations/{organization}/members/{user}/workspace-quota`
+`GET /api/v2/organizations/{organization}/members/{user}/workspace-quota`
 
 ### Parameters
 
@@ -2120,7 +2120,7 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/provisi
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /organizations/{organization}/provisionerdaemons/serve`
+`GET /api/v2/organizations/{organization}/provisionerdaemons/serve`
 
 ### Parameters
 
@@ -2147,7 +2147,7 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/provisi
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /organizations/{organization}/provisionerkeys`
+`GET /api/v2/organizations/{organization}/provisionerkeys`
 
 ### Parameters
 
@@ -2207,7 +2207,7 @@ curl -X POST http://coder-server:8080/api/v2/organizations/{organization}/provis
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /organizations/{organization}/provisionerkeys`
+`POST /api/v2/organizations/{organization}/provisionerkeys`
 
 ### Parameters
 
@@ -2244,7 +2244,7 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/provisi
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /organizations/{organization}/provisionerkeys/daemons`
+`GET /api/v2/organizations/{organization}/provisionerkeys/daemons`
 
 ### Parameters
 
@@ -2368,7 +2368,7 @@ curl -X DELETE http://coder-server:8080/api/v2/organizations/{organization}/prov
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`DELETE /organizations/{organization}/provisionerkeys/{provisionerkey}`
+`DELETE /api/v2/organizations/{organization}/provisionerkeys/{provisionerkey}`
 
 ### Parameters
 
@@ -2396,7 +2396,7 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/setting
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /organizations/{organization}/settings/idpsync/available-fields`
+`GET /api/v2/organizations/{organization}/settings/idpsync/available-fields`
 
 ### Parameters
 
@@ -2435,7 +2435,7 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/setting
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /organizations/{organization}/settings/idpsync/field-values`
+`GET /api/v2/organizations/{organization}/settings/idpsync/field-values`
 
 ### Parameters
 
@@ -2475,7 +2475,7 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/setting
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /organizations/{organization}/settings/idpsync/groups`
+`GET /api/v2/organizations/{organization}/settings/idpsync/groups`
 
 ### Parameters
 
@@ -2527,7 +2527,7 @@ curl -X PATCH http://coder-server:8080/api/v2/organizations/{organization}/setti
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PATCH /organizations/{organization}/settings/idpsync/groups`
+`PATCH /api/v2/organizations/{organization}/settings/idpsync/groups`
 
 > Body parameter
 
@@ -2602,7 +2602,7 @@ curl -X PATCH http://coder-server:8080/api/v2/organizations/{organization}/setti
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PATCH /organizations/{organization}/settings/idpsync/groups/config`
+`PATCH /api/v2/organizations/{organization}/settings/idpsync/groups/config`
 
 > Body parameter
 
@@ -2665,7 +2665,7 @@ curl -X PATCH http://coder-server:8080/api/v2/organizations/{organization}/setti
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PATCH /organizations/{organization}/settings/idpsync/groups/mapping`
+`PATCH /api/v2/organizations/{organization}/settings/idpsync/groups/mapping`
 
 > Body parameter
 
@@ -2736,7 +2736,7 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/setting
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /organizations/{organization}/settings/idpsync/roles`
+`GET /api/v2/organizations/{organization}/settings/idpsync/roles`
 
 ### Parameters
 
@@ -2782,7 +2782,7 @@ curl -X PATCH http://coder-server:8080/api/v2/organizations/{organization}/setti
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PATCH /organizations/{organization}/settings/idpsync/roles`
+`PATCH /api/v2/organizations/{organization}/settings/idpsync/roles`
 
 > Body parameter
 
@@ -2845,7 +2845,7 @@ curl -X PATCH http://coder-server:8080/api/v2/organizations/{organization}/setti
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PATCH /organizations/{organization}/settings/idpsync/roles/config`
+`PATCH /api/v2/organizations/{organization}/settings/idpsync/roles/config`
 
 > Body parameter
 
@@ -2900,7 +2900,7 @@ curl -X PATCH http://coder-server:8080/api/v2/organizations/{organization}/setti
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PATCH /organizations/{organization}/settings/idpsync/roles/mapping`
+`PATCH /api/v2/organizations/{organization}/settings/idpsync/roles/mapping`
 
 > Body parameter
 
@@ -2965,7 +2965,7 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/setting
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /organizations/{organization}/settings/workspace-sharing`
+`GET /api/v2/organizations/{organization}/settings/workspace-sharing`
 
 ### Parameters
 
@@ -3005,7 +3005,7 @@ curl -X PATCH http://coder-server:8080/api/v2/organizations/{organization}/setti
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PATCH /organizations/{organization}/settings/workspace-sharing`
+`PATCH /api/v2/organizations/{organization}/settings/workspace-sharing`
 
 > Body parameter
 
@@ -3053,7 +3053,7 @@ curl -X GET http://coder-server:8080/api/v2/provisionerkeys/{provisionerkey} \
   -H 'Accept: application/json'
 ```
 
-`GET /provisionerkeys/{provisionerkey}`
+`GET /api/v2/provisionerkeys/{provisionerkey}`
 
 ### Parameters
 
@@ -3097,7 +3097,7 @@ curl -X GET http://coder-server:8080/api/v2/replicas \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /replicas`
+`GET /api/v2/replicas`
 
 ### Example responses
 
@@ -3146,7 +3146,7 @@ To perform this operation, you must be authenticated. [Learn more](authenticatio
 
 ```shell
 # Example request using curl
-curl -X GET http://coder-server:8080/api/v2/scim/v2/ServiceProviderConfig
+curl -X GET http://coder-server:8080/scim/v2/ServiceProviderConfig
 
 ```
 
@@ -3164,7 +3164,7 @@ curl -X GET http://coder-server:8080/api/v2/scim/v2/ServiceProviderConfig
 
 ```shell
 # Example request using curl
-curl -X GET http://coder-server:8080/api/v2/scim/v2/Users \
+curl -X GET http://coder-server:8080/scim/v2/Users \
   -H 'Authorizaiton: API_KEY'
 ```
 
@@ -3184,7 +3184,7 @@ To perform this operation, you must be authenticated. [Learn more](authenticatio
 
 ```shell
 # Example request using curl
-curl -X POST http://coder-server:8080/api/v2/scim/v2/Users \
+curl -X POST http://coder-server:8080/scim/v2/Users \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H 'Authorizaiton: API_KEY'
@@ -3276,7 +3276,7 @@ To perform this operation, you must be authenticated. [Learn more](authenticatio
 
 ```shell
 # Example request using curl
-curl -X GET http://coder-server:8080/api/v2/scim/v2/Users/{id} \
+curl -X GET http://coder-server:8080/scim/v2/Users/{id} \
   -H 'Authorizaiton: API_KEY'
 ```
 
@@ -3302,7 +3302,7 @@ To perform this operation, you must be authenticated. [Learn more](authenticatio
 
 ```shell
 # Example request using curl
-curl -X PUT http://coder-server:8080/api/v2/scim/v2/Users/{id} \
+curl -X PUT http://coder-server:8080/scim/v2/Users/{id} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/scim+json' \
   -H 'Authorizaiton: API_KEY'
@@ -3394,7 +3394,7 @@ To perform this operation, you must be authenticated. [Learn more](authenticatio
 
 ```shell
 # Example request using curl
-curl -X PATCH http://coder-server:8080/api/v2/scim/v2/Users/{id} \
+curl -X PATCH http://coder-server:8080/scim/v2/Users/{id} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/scim+json' \
   -H 'Authorizaiton: API_KEY'
@@ -3491,7 +3491,7 @@ curl -X GET http://coder-server:8080/api/v2/settings/idpsync/available-fields \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /settings/idpsync/available-fields`
+`GET /api/v2/settings/idpsync/available-fields`
 
 ### Parameters
 
@@ -3530,7 +3530,7 @@ curl -X GET http://coder-server:8080/api/v2/settings/idpsync/field-values?claimF
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /settings/idpsync/field-values`
+`GET /api/v2/settings/idpsync/field-values`
 
 ### Parameters
 
@@ -3570,7 +3570,7 @@ curl -X GET http://coder-server:8080/api/v2/settings/idpsync/organization \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /settings/idpsync/organization`
+`GET /api/v2/settings/idpsync/organization`
 
 ### Example responses
 
@@ -3611,7 +3611,7 @@ curl -X PATCH http://coder-server:8080/api/v2/settings/idpsync/organization \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PATCH /settings/idpsync/organization`
+`PATCH /api/v2/settings/idpsync/organization`
 
 > Body parameter
 
@@ -3675,7 +3675,7 @@ curl -X PATCH http://coder-server:8080/api/v2/settings/idpsync/organization/conf
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PATCH /settings/idpsync/organization/config`
+`PATCH /api/v2/settings/idpsync/organization/config`
 
 > Body parameter
 
@@ -3731,7 +3731,7 @@ curl -X PATCH http://coder-server:8080/api/v2/settings/idpsync/organization/mapp
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PATCH /settings/idpsync/organization/mapping`
+`PATCH /api/v2/settings/idpsync/organization/mapping`
 
 > Body parameter
 
@@ -3796,7 +3796,7 @@ curl -X GET http://coder-server:8080/api/v2/templates/{template}/acl \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /templates/{template}/acl`
+`GET /api/v2/templates/{template}/acl`
 
 ### Parameters
 
@@ -3892,7 +3892,7 @@ curl -X PATCH http://coder-server:8080/api/v2/templates/{template}/acl \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PATCH /templates/{template}/acl`
+`PATCH /api/v2/templates/{template}/acl`
 
 > Body parameter
 
@@ -3952,7 +3952,7 @@ curl -X GET http://coder-server:8080/api/v2/templates/{template}/acl/available \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /templates/{template}/acl/available`
+`GET /api/v2/templates/{template}/acl/available`
 
 ### Parameters
 
@@ -4077,7 +4077,7 @@ curl -X POST http://coder-server:8080/api/v2/templates/{template}/prebuilds/inva
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /templates/{template}/prebuilds/invalidate`
+`POST /api/v2/templates/{template}/prebuilds/invalidate`
 
 ### Parameters
 
@@ -4120,7 +4120,7 @@ curl -X GET http://coder-server:8080/api/v2/users/{user}/quiet-hours \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /users/{user}/quiet-hours`
+`GET /api/v2/users/{user}/quiet-hours`
 
 ### Parameters
 
@@ -4179,7 +4179,7 @@ curl -X PUT http://coder-server:8080/api/v2/users/{user}/quiet-hours \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PUT /users/{user}/quiet-hours`
+`PUT /api/v2/users/{user}/quiet-hours`
 
 > Body parameter
 
@@ -4246,7 +4246,7 @@ curl -X GET http://coder-server:8080/api/v2/workspace-quota/{user} \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /workspace-quota/{user}`
+`GET /api/v2/workspace-quota/{user}`
 
 ### Parameters
 
@@ -4284,7 +4284,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaceproxies \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /workspaceproxies`
+`GET /api/v2/workspaceproxies`
 
 ### Example responses
 
@@ -4380,7 +4380,7 @@ curl -X POST http://coder-server:8080/api/v2/workspaceproxies \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /workspaceproxies`
+`POST /api/v2/workspaceproxies`
 
 > Body parameter
 
@@ -4451,7 +4451,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaceproxies/{workspaceproxy} \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /workspaceproxies/{workspaceproxy}`
+`GET /api/v2/workspaceproxies/{workspaceproxy}`
 
 ### Parameters
 
@@ -4512,7 +4512,7 @@ curl -X DELETE http://coder-server:8080/api/v2/workspaceproxies/{workspaceproxy}
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`DELETE /workspaceproxies/{workspaceproxy}`
+`DELETE /api/v2/workspaceproxies/{workspaceproxy}`
 
 ### Parameters
 
@@ -4557,7 +4557,7 @@ curl -X PATCH http://coder-server:8080/api/v2/workspaceproxies/{workspaceproxy} 
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PATCH /workspaceproxies/{workspaceproxy}`
+`PATCH /api/v2/workspaceproxies/{workspaceproxy}`
 
 > Body parameter
 
@@ -4631,7 +4631,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaces/{workspace}/external-agen
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /workspaces/{workspace}/external-agent/{agent}/credentials`
+`GET /api/v2/workspaces/{workspace}/external-agent/{agent}/credentials`
 
 ### Parameters
 

--- a/docs/reference/api/files.md
+++ b/docs/reference/api/files.md
@@ -12,7 +12,7 @@ curl -X POST http://coder-server:8080/api/v2/files \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /files`
+`POST /api/v2/files`
 
 > Body parameter
 
@@ -58,7 +58,7 @@ curl -X GET http://coder-server:8080/api/v2/files/{fileID} \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /files/{fileID}`
+`GET /api/v2/files/{fileID}`
 
 ### Parameters
 

--- a/docs/reference/api/general.md
+++ b/docs/reference/api/general.md
@@ -10,7 +10,7 @@ curl -X GET http://coder-server:8080/api/v2/ \
   -H 'Accept: application/json'
 ```
 
-`GET /`
+`GET /api/v2/`
 
 ### Example responses
 
@@ -45,7 +45,7 @@ curl -X GET http://coder-server:8080/api/v2/buildinfo \
   -H 'Accept: application/json'
 ```
 
-`GET /buildinfo`
+`GET /api/v2/buildinfo`
 
 ### Example responses
 
@@ -83,7 +83,7 @@ curl -X POST http://coder-server:8080/api/v2/csp/reports \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /csp/reports`
+`POST /api/v2/csp/reports`
 
 > Body parameter
 
@@ -118,7 +118,7 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /deployment/config`
+`GET /api/v2/deployment/config`
 
 ### Example responses
 
@@ -687,7 +687,7 @@ curl -X GET http://coder-server:8080/api/v2/deployment/ssh \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /deployment/ssh`
+`GET /api/v2/deployment/ssh`
 
 ### Example responses
 
@@ -723,7 +723,7 @@ curl -X GET http://coder-server:8080/api/v2/deployment/stats \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /deployment/stats`
+`GET /api/v2/deployment/stats`
 
 ### Example responses
 
@@ -775,7 +775,7 @@ curl -X GET http://coder-server:8080/api/v2/experiments \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /experiments`
+`GET /api/v2/experiments`
 
 ### Example responses
 
@@ -814,7 +814,7 @@ curl -X GET http://coder-server:8080/api/v2/experiments/available \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /experiments/available`
+`GET /api/v2/experiments/available`
 
 ### Example responses
 
@@ -852,7 +852,7 @@ curl -X GET http://coder-server:8080/api/v2/updatecheck \
   -H 'Accept: application/json'
 ```
 
-`GET /updatecheck`
+`GET /api/v2/updatecheck`
 
 ### Example responses
 
@@ -883,7 +883,7 @@ curl -X GET http://coder-server:8080/api/v2/users/{user}/keys/tokens/tokenconfig
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /users/{user}/keys/tokens/tokenconfig`
+`GET /api/v2/users/{user}/keys/tokens/tokenconfig`
 
 ### Parameters
 

--- a/docs/reference/api/git.md
+++ b/docs/reference/api/git.md
@@ -11,7 +11,7 @@ curl -X GET http://coder-server:8080/api/v2/external-auth \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /external-auth`
+`GET /api/v2/external-auth`
 
 ### Example responses
 
@@ -48,7 +48,7 @@ curl -X GET http://coder-server:8080/api/v2/external-auth/{externalauth} \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /external-auth/{externalauth}`
+`GET /api/v2/external-auth/{externalauth}`
 
 ### Parameters
 
@@ -110,7 +110,7 @@ curl -X DELETE http://coder-server:8080/api/v2/external-auth/{externalauth} \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`DELETE /external-auth/{externalauth}`
+`DELETE /api/v2/external-auth/{externalauth}`
 
 ### Parameters
 
@@ -148,7 +148,7 @@ curl -X GET http://coder-server:8080/api/v2/external-auth/{externalauth}/device 
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /external-auth/{externalauth}/device`
+`GET /api/v2/external-auth/{externalauth}/device`
 
 ### Parameters
 
@@ -188,7 +188,7 @@ curl -X POST http://coder-server:8080/api/v2/external-auth/{externalauth}/device
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /external-auth/{externalauth}/device`
+`POST /api/v2/external-auth/{externalauth}/device`
 
 ### Parameters
 

--- a/docs/reference/api/initscript.md
+++ b/docs/reference/api/initscript.md
@@ -10,7 +10,7 @@ curl -X GET http://coder-server:8080/api/v2/init-script/{os}/{arch}
 
 ```
 
-`GET /init-script/{os}/{arch}`
+`GET /api/v2/init-script/{os}/{arch}`
 
 ### Parameters
 

--- a/docs/reference/api/insights.md
+++ b/docs/reference/api/insights.md
@@ -11,7 +11,7 @@ curl -X GET http://coder-server:8080/api/v2/insights/daus?tz_offset=0 \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /insights/daus`
+`GET /api/v2/insights/daus`
 
 ### Parameters
 
@@ -54,7 +54,7 @@ curl -X GET http://coder-server:8080/api/v2/insights/templates?start_time=2019-0
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /insights/templates`
+`GET /api/v2/insights/templates`
 
 ### Parameters
 
@@ -156,7 +156,7 @@ curl -X GET http://coder-server:8080/api/v2/insights/user-activity?start_time=20
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /insights/user-activity`
+`GET /api/v2/insights/user-activity`
 
 ### Parameters
 
@@ -212,7 +212,7 @@ curl -X GET http://coder-server:8080/api/v2/insights/user-latency?start_time=201
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /insights/user-latency`
+`GET /api/v2/insights/user-latency`
 
 ### Parameters
 
@@ -271,7 +271,7 @@ curl -X GET http://coder-server:8080/api/v2/insights/user-status-counts \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /insights/user-status-counts`
+`GET /api/v2/insights/user-status-counts`
 
 ### Parameters
 

--- a/docs/reference/api/members.md
+++ b/docs/reference/api/members.md
@@ -11,7 +11,7 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/members
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /organizations/{organization}/members`
+`GET /api/v2/organizations/{organization}/members`
 
 ### Parameters
 
@@ -113,7 +113,7 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/members
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /organizations/{organization}/members/roles`
+`GET /api/v2/organizations/{organization}/members/roles`
 
 ### Parameters
 
@@ -212,7 +212,7 @@ curl -X PUT http://coder-server:8080/api/v2/organizations/{organization}/members
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PUT /organizations/{organization}/members/roles`
+`PUT /api/v2/organizations/{organization}/members/roles`
 
 > Body parameter
 
@@ -345,7 +345,7 @@ curl -X POST http://coder-server:8080/api/v2/organizations/{organization}/member
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /organizations/{organization}/members/roles`
+`POST /api/v2/organizations/{organization}/members/roles`
 
 > Body parameter
 
@@ -477,7 +477,7 @@ curl -X DELETE http://coder-server:8080/api/v2/organizations/{organization}/memb
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`DELETE /organizations/{organization}/members/roles/{roleName}`
+`DELETE /api/v2/organizations/{organization}/members/roles/{roleName}`
 
 ### Parameters
 
@@ -572,7 +572,7 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/members
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /organizations/{organization}/members/{user}`
+`GET /api/v2/organizations/{organization}/members/{user}`
 
 ### Parameters
 
@@ -638,7 +638,7 @@ curl -X POST http://coder-server:8080/api/v2/organizations/{organization}/member
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /organizations/{organization}/members/{user}`
+`POST /api/v2/organizations/{organization}/members/{user}`
 
 ### Parameters
 
@@ -685,7 +685,7 @@ curl -X DELETE http://coder-server:8080/api/v2/organizations/{organization}/memb
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`DELETE /organizations/{organization}/members/{user}`
+`DELETE /api/v2/organizations/{organization}/members/{user}`
 
 ### Parameters
 
@@ -714,7 +714,7 @@ curl -X PUT http://coder-server:8080/api/v2/organizations/{organization}/members
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PUT /organizations/{organization}/members/{user}/roles`
+`PUT /api/v2/organizations/{organization}/members/{user}/roles`
 
 > Body parameter
 
@@ -773,7 +773,7 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/paginat
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /organizations/{organization}/paginated-members`
+`GET /api/v2/organizations/{organization}/paginated-members`
 
 ### Parameters
 
@@ -886,7 +886,7 @@ curl -X GET http://coder-server:8080/api/v2/users/roles \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /users/roles`
+`GET /api/v2/users/roles`
 
 ### Example responses
 

--- a/docs/reference/api/notifications.md
+++ b/docs/reference/api/notifications.md
@@ -12,7 +12,7 @@ curl -X POST http://coder-server:8080/api/v2/notifications/custom \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /notifications/custom`
+`POST /api/v2/notifications/custom`
 
 > Body parameter
 
@@ -70,7 +70,7 @@ curl -X GET http://coder-server:8080/api/v2/notifications/dispatch-methods \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /notifications/dispatch-methods`
+`GET /api/v2/notifications/dispatch-methods`
 
 ### Example responses
 
@@ -116,7 +116,7 @@ curl -X GET http://coder-server:8080/api/v2/notifications/inbox \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /notifications/inbox`
+`GET /api/v2/notifications/inbox`
 
 ### Parameters
 
@@ -176,7 +176,7 @@ curl -X PUT http://coder-server:8080/api/v2/notifications/inbox/mark-all-as-read
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PUT /notifications/inbox/mark-all-as-read`
+`PUT /api/v2/notifications/inbox/mark-all-as-read`
 
 ### Responses
 
@@ -197,7 +197,7 @@ curl -X GET http://coder-server:8080/api/v2/notifications/inbox/watch \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /notifications/inbox/watch`
+`GET /api/v2/notifications/inbox/watch`
 
 ### Parameters
 
@@ -262,7 +262,7 @@ curl -X PUT http://coder-server:8080/api/v2/notifications/inbox/{id}/read-status
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PUT /notifications/inbox/{id}/read-status`
+`PUT /api/v2/notifications/inbox/{id}/read-status`
 
 ### Parameters
 
@@ -306,7 +306,7 @@ curl -X GET http://coder-server:8080/api/v2/notifications/settings \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /notifications/settings`
+`GET /api/v2/notifications/settings`
 
 ### Example responses
 
@@ -338,7 +338,7 @@ curl -X PUT http://coder-server:8080/api/v2/notifications/settings \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PUT /notifications/settings`
+`PUT /api/v2/notifications/settings`
 
 > Body parameter
 
@@ -384,7 +384,7 @@ curl -X GET http://coder-server:8080/api/v2/notifications/templates/custom \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /notifications/templates/custom`
+`GET /api/v2/notifications/templates/custom`
 
 ### Example responses
 
@@ -443,7 +443,7 @@ curl -X GET http://coder-server:8080/api/v2/notifications/templates/system \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /notifications/templates/system`
+`GET /api/v2/notifications/templates/system`
 
 ### Example responses
 
@@ -501,7 +501,7 @@ curl -X POST http://coder-server:8080/api/v2/notifications/test \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /notifications/test`
+`POST /api/v2/notifications/test`
 
 ### Responses
 
@@ -522,7 +522,7 @@ curl -X GET http://coder-server:8080/api/v2/users/{user}/notifications/preferenc
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /users/{user}/notifications/preferences`
+`GET /api/v2/users/{user}/notifications/preferences`
 
 ### Parameters
 
@@ -575,7 +575,7 @@ curl -X PUT http://coder-server:8080/api/v2/users/{user}/notifications/preferenc
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PUT /users/{user}/notifications/preferences`
+`PUT /api/v2/users/{user}/notifications/preferences`
 
 > Body parameter
 

--- a/docs/reference/api/organizations.md
+++ b/docs/reference/api/organizations.md
@@ -11,7 +11,7 @@ curl -X GET http://coder-server:8080/api/v2/organizations \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /organizations`
+`GET /api/v2/organizations`
 
 ### Example responses
 
@@ -68,7 +68,7 @@ curl -X POST http://coder-server:8080/api/v2/organizations \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /organizations`
+`POST /api/v2/organizations`
 
 > Body parameter
 
@@ -123,7 +123,7 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization} \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /organizations/{organization}`
+`GET /api/v2/organizations/{organization}`
 
 ### Parameters
 
@@ -167,7 +167,7 @@ curl -X DELETE http://coder-server:8080/api/v2/organizations/{organization} \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`DELETE /organizations/{organization}`
+`DELETE /api/v2/organizations/{organization}`
 
 ### Parameters
 
@@ -212,7 +212,7 @@ curl -X PATCH http://coder-server:8080/api/v2/organizations/{organization} \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PATCH /organizations/{organization}`
+`PATCH /api/v2/organizations/{organization}`
 
 > Body parameter
 
@@ -268,7 +268,7 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/provisi
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /organizations/{organization}/provisionerjobs`
+`GET /api/v2/organizations/{organization}/provisionerjobs`
 
 ### Parameters
 
@@ -406,7 +406,7 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/provisi
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /organizations/{organization}/provisionerjobs/{job}`
+`GET /api/v2/organizations/{organization}/provisionerjobs/{job}`
 
 ### Parameters
 

--- a/docs/reference/api/portsharing.md
+++ b/docs/reference/api/portsharing.md
@@ -11,7 +11,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaces/{workspace}/port-share \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /workspaces/{workspace}/port-share`
+`GET /api/v2/workspaces/{workspace}/port-share`
 
 ### Parameters
 
@@ -57,7 +57,7 @@ curl -X POST http://coder-server:8080/api/v2/workspaces/{workspace}/port-share \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /workspaces/{workspace}/port-share`
+`POST /api/v2/workspaces/{workspace}/port-share`
 
 > Body parameter
 
@@ -110,7 +110,7 @@ curl -X DELETE http://coder-server:8080/api/v2/workspaces/{workspace}/port-share
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`DELETE /workspaces/{workspace}/port-share`
+`DELETE /api/v2/workspaces/{workspace}/port-share`
 
 > Body parameter
 

--- a/docs/reference/api/prebuilds.md
+++ b/docs/reference/api/prebuilds.md
@@ -11,7 +11,7 @@ curl -X GET http://coder-server:8080/api/v2/prebuilds/settings \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /prebuilds/settings`
+`GET /api/v2/prebuilds/settings`
 
 ### Example responses
 
@@ -43,7 +43,7 @@ curl -X PUT http://coder-server:8080/api/v2/prebuilds/settings \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PUT /prebuilds/settings`
+`PUT /api/v2/prebuilds/settings`
 
 > Body parameter
 

--- a/docs/reference/api/provisioning.md
+++ b/docs/reference/api/provisioning.md
@@ -11,7 +11,7 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/provisi
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /organizations/{organization}/provisionerdaemons`
+`GET /api/v2/organizations/{organization}/provisionerdaemons`
 
 ### Parameters
 

--- a/docs/reference/api/secrets.md
+++ b/docs/reference/api/secrets.md
@@ -11,7 +11,7 @@ curl -X GET http://coder-server:8080/api/v2/users/{user}/secrets \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /users/{user}/secrets`
+`GET /api/v2/users/{user}/secrets`
 
 ### Parameters
 
@@ -72,7 +72,7 @@ curl -X POST http://coder-server:8080/api/v2/users/{user}/secrets \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /users/{user}/secrets`
+`POST /api/v2/users/{user}/secrets`
 
 > Body parameter
 
@@ -128,7 +128,7 @@ curl -X GET http://coder-server:8080/api/v2/users/{user}/secrets/{name} \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /users/{user}/secrets/{name}`
+`GET /api/v2/users/{user}/secrets/{name}`
 
 ### Parameters
 
@@ -171,7 +171,7 @@ curl -X DELETE http://coder-server:8080/api/v2/users/{user}/secrets/{name} \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`DELETE /users/{user}/secrets/{name}`
+`DELETE /api/v2/users/{user}/secrets/{name}`
 
 ### Parameters
 
@@ -200,7 +200,7 @@ curl -X PATCH http://coder-server:8080/api/v2/users/{user}/secrets/{name} \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PATCH /users/{user}/secrets/{name}`
+`PATCH /api/v2/users/{user}/secrets/{name}`
 
 > Body parameter
 

--- a/docs/reference/api/tasks.md
+++ b/docs/reference/api/tasks.md
@@ -11,7 +11,7 @@ curl -X GET http://coder-server:8080/api/v2/tasks \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /tasks`
+`GET /api/v2/tasks`
 
 ### Parameters
 
@@ -95,7 +95,7 @@ curl -X POST http://coder-server:8080/api/v2/tasks/{user} \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /tasks/{user}`
+`POST /api/v2/tasks/{user}`
 
 > Body parameter
 
@@ -186,7 +186,7 @@ curl -X GET http://coder-server:8080/api/v2/tasks/{user}/{task} \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /tasks/{user}/{task}`
+`GET /api/v2/tasks/{user}/{task}`
 
 ### Parameters
 
@@ -264,7 +264,7 @@ curl -X DELETE http://coder-server:8080/api/v2/tasks/{user}/{task} \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`DELETE /tasks/{user}/{task}`
+`DELETE /api/v2/tasks/{user}/{task}`
 
 ### Parameters
 
@@ -292,7 +292,7 @@ curl -X PATCH http://coder-server:8080/api/v2/tasks/{user}/{task}/input \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PATCH /tasks/{user}/{task}/input`
+`PATCH /api/v2/tasks/{user}/{task}/input`
 
 > Body parameter
 
@@ -329,7 +329,7 @@ curl -X GET http://coder-server:8080/api/v2/tasks/{user}/{task}/logs \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /tasks/{user}/{task}/logs`
+`GET /api/v2/tasks/{user}/{task}/logs`
 
 ### Parameters
 
@@ -376,7 +376,7 @@ curl -X POST http://coder-server:8080/api/v2/tasks/{user}/{task}/pause \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /tasks/{user}/{task}/pause`
+`POST /api/v2/tasks/{user}/{task}/pause`
 
 ### Parameters
 
@@ -622,7 +622,7 @@ curl -X POST http://coder-server:8080/api/v2/tasks/{user}/{task}/resume \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /tasks/{user}/{task}/resume`
+`POST /api/v2/tasks/{user}/{task}/resume`
 
 ### Parameters
 
@@ -868,7 +868,7 @@ curl -X POST http://coder-server:8080/api/v2/tasks/{user}/{task}/send \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /tasks/{user}/{task}/send`
+`POST /api/v2/tasks/{user}/{task}/send`
 
 > Body parameter
 
@@ -905,7 +905,7 @@ curl -X POST http://coder-server:8080/api/v2/workspaceagents/me/tasks/{task}/log
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /workspaceagents/me/tasks/{task}/log-snapshot`
+`POST /api/v2/workspaceagents/me/tasks/{task}/log-snapshot`
 
 > Body parameter
 

--- a/docs/reference/api/templates.md
+++ b/docs/reference/api/templates.md
@@ -11,7 +11,7 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/templat
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /organizations/{organization}/templates`
+`GET /api/v2/organizations/{organization}/templates`
 
 Returns a list of templates for the specified organization.
 By default, only non-deprecated templates are returned.
@@ -165,7 +165,7 @@ curl -X POST http://coder-server:8080/api/v2/organizations/{organization}/templa
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /organizations/{organization}/templates`
+`POST /api/v2/organizations/{organization}/templates`
 
 > Body parameter
 
@@ -291,7 +291,7 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/templat
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /organizations/{organization}/templates/examples`
+`GET /api/v2/organizations/{organization}/templates/examples`
 
 ### Parameters
 
@@ -353,7 +353,7 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/templat
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /organizations/{organization}/templates/{templatename}`
+`GET /api/v2/organizations/{organization}/templates/{templatename}`
 
 ### Parameters
 
@@ -443,7 +443,7 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/templat
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /organizations/{organization}/templates/{templatename}/versions/{templateversionname}`
+`GET /api/v2/organizations/{organization}/templates/{templatename}/versions/{templateversionname}`
 
 ### Parameters
 
@@ -546,7 +546,7 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/templat
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /organizations/{organization}/templates/{templatename}/versions/{templateversionname}/previous`
+`GET /api/v2/organizations/{organization}/templates/{templatename}/versions/{templateversionname}/previous`
 
 ### Parameters
 
@@ -651,7 +651,7 @@ curl -X POST http://coder-server:8080/api/v2/organizations/{organization}/templa
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /organizations/{organization}/templateversions`
+`POST /api/v2/organizations/{organization}/templateversions`
 
 > Body parameter
 
@@ -777,7 +777,7 @@ curl -X GET http://coder-server:8080/api/v2/templates \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /templates`
+`GET /api/v2/templates`
 
 Returns a list of templates.
 By default, only non-deprecated templates are returned.
@@ -924,7 +924,7 @@ curl -X GET http://coder-server:8080/api/v2/templates/examples \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /templates/examples`
+`GET /api/v2/templates/examples`
 
 ### Example responses
 
@@ -980,7 +980,7 @@ curl -X GET http://coder-server:8080/api/v2/templates/{template} \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /templates/{template}`
+`GET /api/v2/templates/{template}`
 
 ### Parameters
 
@@ -1069,7 +1069,7 @@ curl -X DELETE http://coder-server:8080/api/v2/templates/{template} \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`DELETE /templates/{template}`
+`DELETE /api/v2/templates/{template}`
 
 ### Parameters
 
@@ -1114,7 +1114,7 @@ curl -X PATCH http://coder-server:8080/api/v2/templates/{template} \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PATCH /templates/{template}`
+`PATCH /api/v2/templates/{template}`
 
 > Body parameter
 
@@ -1243,7 +1243,7 @@ curl -X GET http://coder-server:8080/api/v2/templates/{template}/daus \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /templates/{template}/daus`
+`GET /api/v2/templates/{template}/daus`
 
 ### Parameters
 
@@ -1286,7 +1286,7 @@ curl -X GET http://coder-server:8080/api/v2/templates/{template}/versions \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /templates/{template}/versions`
+`GET /api/v2/templates/{template}/versions`
 
 ### Parameters
 
@@ -1465,7 +1465,7 @@ curl -X PATCH http://coder-server:8080/api/v2/templates/{template}/versions \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PATCH /templates/{template}/versions`
+`PATCH /api/v2/templates/{template}/versions`
 
 > Body parameter
 
@@ -1519,7 +1519,7 @@ curl -X POST http://coder-server:8080/api/v2/templates/{template}/versions/archi
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /templates/{template}/versions/archive`
+`POST /api/v2/templates/{template}/versions/archive`
 
 > Body parameter
 
@@ -1572,7 +1572,7 @@ curl -X GET http://coder-server:8080/api/v2/templates/{template}/versions/{templ
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /templates/{template}/versions/{templateversionname}`
+`GET /api/v2/templates/{template}/versions/{templateversionname}`
 
 ### Parameters
 
@@ -1747,7 +1747,7 @@ curl -X GET http://coder-server:8080/api/v2/templateversions/{templateversion} \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /templateversions/{templateversion}`
+`GET /api/v2/templateversions/{templateversion}`
 
 ### Parameters
 
@@ -1849,7 +1849,7 @@ curl -X PATCH http://coder-server:8080/api/v2/templateversions/{templateversion}
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PATCH /templateversions/{templateversion}`
+`PATCH /api/v2/templateversions/{templateversion}`
 
 > Body parameter
 
@@ -1960,7 +1960,7 @@ curl -X POST http://coder-server:8080/api/v2/templateversions/{templateversion}/
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /templateversions/{templateversion}/archive`
+`POST /api/v2/templateversions/{templateversion}/archive`
 
 ### Parameters
 
@@ -2004,7 +2004,7 @@ curl -X PATCH http://coder-server:8080/api/v2/templateversions/{templateversion}
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PATCH /templateversions/{templateversion}/cancel`
+`PATCH /api/v2/templateversions/{templateversion}/cancel`
 
 ### Parameters
 
@@ -2049,7 +2049,7 @@ curl -X POST http://coder-server:8080/api/v2/templateversions/{templateversion}/
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /templateversions/{templateversion}/dry-run`
+`POST /api/v2/templateversions/{templateversion}/dry-run`
 
 > Body parameter
 
@@ -2145,7 +2145,7 @@ curl -X GET http://coder-server:8080/api/v2/templateversions/{templateversion}/d
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /templateversions/{templateversion}/dry-run/{jobID}`
+`GET /api/v2/templateversions/{templateversion}/dry-run/{jobID}`
 
 ### Parameters
 
@@ -2221,7 +2221,7 @@ curl -X PATCH http://coder-server:8080/api/v2/templateversions/{templateversion}
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PATCH /templateversions/{templateversion}/dry-run/{jobID}/cancel`
+`PATCH /api/v2/templateversions/{templateversion}/dry-run/{jobID}/cancel`
 
 ### Parameters
 
@@ -2266,7 +2266,7 @@ curl -X GET http://coder-server:8080/api/v2/templateversions/{templateversion}/d
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /templateversions/{templateversion}/dry-run/{jobID}/logs`
+`GET /api/v2/templateversions/{templateversion}/dry-run/{jobID}/logs`
 
 ### Parameters
 
@@ -2342,7 +2342,7 @@ curl -X GET http://coder-server:8080/api/v2/templateversions/{templateversion}/d
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /templateversions/{templateversion}/dry-run/{jobID}/matched-provisioners`
+`GET /api/v2/templateversions/{templateversion}/dry-run/{jobID}/matched-provisioners`
 
 ### Parameters
 
@@ -2382,7 +2382,7 @@ curl -X GET http://coder-server:8080/api/v2/templateversions/{templateversion}/d
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /templateversions/{templateversion}/dry-run/{jobID}/resources`
+`GET /api/v2/templateversions/{templateversion}/dry-run/{jobID}/resources`
 
 ### Parameters
 
@@ -2678,7 +2678,7 @@ curl -X GET http://coder-server:8080/api/v2/templateversions/{templateversion}/d
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /templateversions/{templateversion}/dynamic-parameters`
+`GET /api/v2/templateversions/{templateversion}/dynamic-parameters`
 
 ### Parameters
 
@@ -2706,7 +2706,7 @@ curl -X POST http://coder-server:8080/api/v2/templateversions/{templateversion}/
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /templateversions/{templateversion}/dynamic-parameters/evaluate`
+`POST /api/v2/templateversions/{templateversion}/dynamic-parameters/evaluate`
 
 > Body parameter
 
@@ -2833,7 +2833,7 @@ curl -X GET http://coder-server:8080/api/v2/templateversions/{templateversion}/e
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /templateversions/{templateversion}/external-auth`
+`GET /api/v2/templateversions/{templateversion}/external-auth`
 
 ### Parameters
 
@@ -2893,7 +2893,7 @@ curl -X GET http://coder-server:8080/api/v2/templateversions/{templateversion}/l
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /templateversions/{templateversion}/logs`
+`GET /api/v2/templateversions/{templateversion}/logs`
 
 ### Parameters
 
@@ -2967,7 +2967,7 @@ curl -X GET http://coder-server:8080/api/v2/templateversions/{templateversion}/p
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /templateversions/{templateversion}/parameters`
+`GET /api/v2/templateversions/{templateversion}/parameters`
 
 ### Parameters
 
@@ -2994,7 +2994,7 @@ curl -X GET http://coder-server:8080/api/v2/templateversions/{templateversion}/p
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /templateversions/{templateversion}/presets`
+`GET /api/v2/templateversions/{templateversion}/presets`
 
 ### Parameters
 
@@ -3061,7 +3061,7 @@ curl -X GET http://coder-server:8080/api/v2/templateversions/{templateversion}/r
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /templateversions/{templateversion}/resources`
+`GET /api/v2/templateversions/{templateversion}/resources`
 
 ### Parameters
 
@@ -3357,7 +3357,7 @@ curl -X GET http://coder-server:8080/api/v2/templateversions/{templateversion}/r
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /templateversions/{templateversion}/rich-parameters`
+`GET /api/v2/templateversions/{templateversion}/rich-parameters`
 
 ### Parameters
 
@@ -3455,7 +3455,7 @@ curl -X GET http://coder-server:8080/api/v2/templateversions/{templateversion}/s
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /templateversions/{templateversion}/schema`
+`GET /api/v2/templateversions/{templateversion}/schema`
 
 ### Parameters
 
@@ -3482,7 +3482,7 @@ curl -X POST http://coder-server:8080/api/v2/templateversions/{templateversion}/
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /templateversions/{templateversion}/unarchive`
+`POST /api/v2/templateversions/{templateversion}/unarchive`
 
 ### Parameters
 
@@ -3526,7 +3526,7 @@ curl -X GET http://coder-server:8080/api/v2/templateversions/{templateversion}/v
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /templateversions/{templateversion}/variables`
+`GET /api/v2/templateversions/{templateversion}/variables`
 
 ### Parameters
 

--- a/docs/reference/api/users.md
+++ b/docs/reference/api/users.md
@@ -11,7 +11,7 @@ curl -X GET http://coder-server:8080/api/v2/users \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /users`
+`GET /api/v2/users`
 
 ### Parameters
 
@@ -79,7 +79,7 @@ curl -X POST http://coder-server:8080/api/v2/users \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /users`
+`POST /api/v2/users`
 
 > Body parameter
 
@@ -158,7 +158,7 @@ curl -X GET http://coder-server:8080/api/v2/users/authmethods \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /users/authmethods`
+`GET /api/v2/users/authmethods`
 
 ### Example responses
 
@@ -201,7 +201,7 @@ curl -X GET http://coder-server:8080/api/v2/users/first \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /users/first`
+`GET /api/v2/users/first`
 
 ### Example responses
 
@@ -240,7 +240,7 @@ curl -X POST http://coder-server:8080/api/v2/users/first \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /users/first`
+`POST /api/v2/users/first`
 
 > Body parameter
 
@@ -303,7 +303,7 @@ curl -X POST http://coder-server:8080/api/v2/users/logout \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /users/logout`
+`POST /api/v2/users/logout`
 
 ### Example responses
 
@@ -340,7 +340,7 @@ curl -X GET http://coder-server:8080/api/v2/users/oauth2/github/callback \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /users/oauth2/github/callback`
+`GET /api/v2/users/oauth2/github/callback`
 
 ### Responses
 
@@ -361,7 +361,7 @@ curl -X GET http://coder-server:8080/api/v2/users/oauth2/github/device \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /users/oauth2/github/device`
+`GET /api/v2/users/oauth2/github/device`
 
 ### Example responses
 
@@ -396,7 +396,7 @@ curl -X GET http://coder-server:8080/api/v2/users/oidc-claims \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /users/oidc-claims`
+`GET /api/v2/users/oidc-claims`
 
 ### Example responses
 
@@ -426,7 +426,7 @@ curl -X GET http://coder-server:8080/api/v2/users/oidc/callback \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /users/oidc/callback`
+`GET /api/v2/users/oidc/callback`
 
 ### Responses
 
@@ -447,7 +447,7 @@ curl -X GET http://coder-server:8080/api/v2/users/{user} \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /users/{user}`
+`GET /api/v2/users/{user}`
 
 ### Parameters
 
@@ -505,7 +505,7 @@ curl -X DELETE http://coder-server:8080/api/v2/users/{user} \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`DELETE /users/{user}`
+`DELETE /api/v2/users/{user}`
 
 ### Parameters
 
@@ -532,7 +532,7 @@ curl -X GET http://coder-server:8080/api/v2/users/{user}/appearance \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /users/{user}/appearance`
+`GET /api/v2/users/{user}/appearance`
 
 ### Parameters
 
@@ -571,7 +571,7 @@ curl -X PUT http://coder-server:8080/api/v2/users/{user}/appearance \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PUT /users/{user}/appearance`
+`PUT /api/v2/users/{user}/appearance`
 
 > Body parameter
 
@@ -619,7 +619,7 @@ curl -X GET http://coder-server:8080/api/v2/users/{user}/autofill-parameters?tem
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /users/{user}/autofill-parameters`
+`GET /api/v2/users/{user}/autofill-parameters`
 
 ### Parameters
 
@@ -670,7 +670,7 @@ curl -X GET http://coder-server:8080/api/v2/users/{user}/gitsshkey \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /users/{user}/gitsshkey`
+`GET /api/v2/users/{user}/gitsshkey`
 
 ### Parameters
 
@@ -710,7 +710,7 @@ curl -X PUT http://coder-server:8080/api/v2/users/{user}/gitsshkey \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PUT /users/{user}/gitsshkey`
+`PUT /api/v2/users/{user}/gitsshkey`
 
 ### Parameters
 
@@ -750,7 +750,7 @@ curl -X POST http://coder-server:8080/api/v2/users/{user}/keys \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /users/{user}/keys`
+`POST /api/v2/users/{user}/keys`
 
 ### Parameters
 
@@ -787,7 +787,7 @@ curl -X GET http://coder-server:8080/api/v2/users/{user}/keys/tokens \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /users/{user}/keys/tokens`
+`GET /api/v2/users/{user}/keys/tokens`
 
 ### Parameters
 
@@ -876,7 +876,7 @@ curl -X POST http://coder-server:8080/api/v2/users/{user}/keys/tokens \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /users/{user}/keys/tokens`
+`POST /api/v2/users/{user}/keys/tokens`
 
 > Body parameter
 
@@ -933,7 +933,7 @@ curl -X GET http://coder-server:8080/api/v2/users/{user}/keys/tokens/{keyname} \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /users/{user}/keys/tokens/{keyname}`
+`GET /api/v2/users/{user}/keys/tokens/{keyname}`
 
 ### Parameters
 
@@ -989,7 +989,7 @@ curl -X GET http://coder-server:8080/api/v2/users/{user}/keys/{keyid} \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /users/{user}/keys/{keyid}`
+`GET /api/v2/users/{user}/keys/{keyid}`
 
 ### Parameters
 
@@ -1044,7 +1044,7 @@ curl -X DELETE http://coder-server:8080/api/v2/users/{user}/keys/{keyid} \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`DELETE /users/{user}/keys/{keyid}`
+`DELETE /api/v2/users/{user}/keys/{keyid}`
 
 ### Parameters
 
@@ -1072,7 +1072,7 @@ curl -X PUT http://coder-server:8080/api/v2/users/{user}/keys/{keyid}/expire \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PUT /users/{user}/keys/{keyid}/expire`
+`PUT /api/v2/users/{user}/keys/{keyid}/expire`
 
 ### Parameters
 
@@ -1106,7 +1106,7 @@ curl -X GET http://coder-server:8080/api/v2/users/{user}/login-type \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /users/{user}/login-type`
+`GET /api/v2/users/{user}/login-type`
 
 ### Parameters
 
@@ -1143,7 +1143,7 @@ curl -X GET http://coder-server:8080/api/v2/users/{user}/organizations \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /users/{user}/organizations`
+`GET /api/v2/users/{user}/organizations`
 
 ### Parameters
 
@@ -1205,7 +1205,7 @@ curl -X GET http://coder-server:8080/api/v2/users/{user}/organizations/{organiza
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /users/{user}/organizations/{organizationname}`
+`GET /api/v2/users/{user}/organizations/{organizationname}`
 
 ### Parameters
 
@@ -1250,7 +1250,7 @@ curl -X PUT http://coder-server:8080/api/v2/users/{user}/password \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PUT /users/{user}/password`
+`PUT /api/v2/users/{user}/password`
 
 > Body parameter
 
@@ -1287,7 +1287,7 @@ curl -X GET http://coder-server:8080/api/v2/users/{user}/preferences \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /users/{user}/preferences`
+`GET /api/v2/users/{user}/preferences`
 
 ### Parameters
 
@@ -1326,7 +1326,7 @@ curl -X PUT http://coder-server:8080/api/v2/users/{user}/preferences \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PUT /users/{user}/preferences`
+`PUT /api/v2/users/{user}/preferences`
 
 > Body parameter
 
@@ -1375,7 +1375,7 @@ curl -X PUT http://coder-server:8080/api/v2/users/{user}/profile \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PUT /users/{user}/profile`
+`PUT /api/v2/users/{user}/profile`
 
 > Body parameter
 
@@ -1444,7 +1444,7 @@ curl -X GET http://coder-server:8080/api/v2/users/{user}/roles \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /users/{user}/roles`
+`GET /api/v2/users/{user}/roles`
 
 ### Parameters
 
@@ -1504,7 +1504,7 @@ curl -X PUT http://coder-server:8080/api/v2/users/{user}/roles \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PUT /users/{user}/roles`
+`PUT /api/v2/users/{user}/roles`
 
 > Body parameter
 
@@ -1574,7 +1574,7 @@ curl -X PUT http://coder-server:8080/api/v2/users/{user}/status/activate \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PUT /users/{user}/status/activate`
+`PUT /api/v2/users/{user}/status/activate`
 
 ### Parameters
 
@@ -1633,7 +1633,7 @@ curl -X PUT http://coder-server:8080/api/v2/users/{user}/status/suspend \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PUT /users/{user}/status/suspend`
+`PUT /api/v2/users/{user}/status/suspend`
 
 ### Parameters
 

--- a/docs/reference/api/workspaceproxies.md
+++ b/docs/reference/api/workspaceproxies.md
@@ -11,7 +11,7 @@ curl -X GET http://coder-server:8080/api/v2/regions \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /regions`
+`GET /api/v2/regions`
 
 ### Example responses
 

--- a/docs/reference/api/workspaces.md
+++ b/docs/reference/api/workspaces.md
@@ -12,7 +12,7 @@ curl -X POST http://coder-server:8080/api/v2/organizations/{organization}/member
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /organizations/{organization}/members/{user}/workspaces`
+`POST /api/v2/organizations/{organization}/members/{user}/workspaces`
 
 Create a new workspace using a template. The request must
 specify either the Template ID or the Template Version ID,
@@ -345,7 +345,7 @@ curl -X GET http://coder-server:8080/api/v2/organizations/{organization}/members
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /organizations/{organization}/members/{user}/workspaces/available-users`
+`GET /api/v2/organizations/{organization}/members/{user}/workspaces/available-users`
 
 ### Parameters
 
@@ -403,7 +403,7 @@ curl -X GET http://coder-server:8080/api/v2/users/{user}/workspace/{workspacenam
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /users/{user}/workspace/{workspacename}`
+`GET /api/v2/users/{user}/workspace/{workspacename}`
 
 ### Parameters
 
@@ -712,7 +712,7 @@ curl -X POST http://coder-server:8080/api/v2/users/{user}/workspaces \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /users/{user}/workspaces`
+`POST /api/v2/users/{user}/workspaces`
 
 Create a new workspace using a template. The request must
 specify either the Template ID or the Template Version ID,
@@ -1044,7 +1044,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaces \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /workspaces`
+`GET /api/v2/workspaces`
 
 ### Parameters
 
@@ -1340,7 +1340,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaces/{workspace} \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /workspaces/{workspace}`
+`GET /api/v2/workspaces/{workspace}`
 
 ### Parameters
 
@@ -1647,7 +1647,7 @@ curl -X PATCH http://coder-server:8080/api/v2/workspaces/{workspace} \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PATCH /workspaces/{workspace}`
+`PATCH /api/v2/workspaces/{workspace}`
 
 > Body parameter
 
@@ -1683,7 +1683,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaces/{workspace}/acl \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /workspaces/{workspace}/acl`
+`GET /api/v2/workspaces/{workspace}/acl`
 
 ### Parameters
 
@@ -1758,7 +1758,7 @@ curl -X DELETE http://coder-server:8080/api/v2/workspaces/{workspace}/acl \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`DELETE /workspaces/{workspace}/acl`
+`DELETE /api/v2/workspaces/{workspace}/acl`
 
 ### Parameters
 
@@ -1785,7 +1785,7 @@ curl -X PATCH http://coder-server:8080/api/v2/workspaces/{workspace}/acl \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PATCH /workspaces/{workspace}/acl`
+`PATCH /api/v2/workspaces/{workspace}/acl`
 
 > Body parameter
 
@@ -1828,7 +1828,7 @@ curl -X PUT http://coder-server:8080/api/v2/workspaces/{workspace}/autostart \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PUT /workspaces/{workspace}/autostart`
+`PUT /api/v2/workspaces/{workspace}/autostart`
 
 > Body parameter
 
@@ -1864,7 +1864,7 @@ curl -X PUT http://coder-server:8080/api/v2/workspaces/{workspace}/autoupdates \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PUT /workspaces/{workspace}/autoupdates`
+`PUT /api/v2/workspaces/{workspace}/autoupdates`
 
 > Body parameter
 
@@ -1901,7 +1901,7 @@ curl -X PUT http://coder-server:8080/api/v2/workspaces/{workspace}/dormant \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PUT /workspaces/{workspace}/dormant`
+`PUT /api/v2/workspaces/{workspace}/dormant`
 
 > Body parameter
 
@@ -2217,7 +2217,7 @@ curl -X PUT http://coder-server:8080/api/v2/workspaces/{workspace}/extend \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PUT /workspaces/{workspace}/extend`
+`PUT /api/v2/workspaces/{workspace}/extend`
 
 > Body parameter
 
@@ -2269,7 +2269,7 @@ curl -X PUT http://coder-server:8080/api/v2/workspaces/{workspace}/favorite \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PUT /workspaces/{workspace}/favorite`
+`PUT /api/v2/workspaces/{workspace}/favorite`
 
 ### Parameters
 
@@ -2295,7 +2295,7 @@ curl -X DELETE http://coder-server:8080/api/v2/workspaces/{workspace}/favorite \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`DELETE /workspaces/{workspace}/favorite`
+`DELETE /api/v2/workspaces/{workspace}/favorite`
 
 ### Parameters
 
@@ -2322,7 +2322,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaces/{workspace}/resolve-autos
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /workspaces/{workspace}/resolve-autostart`
+`GET /api/v2/workspaces/{workspace}/resolve-autostart`
 
 ### Parameters
 
@@ -2359,7 +2359,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaces/{workspace}/timings \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /workspaces/{workspace}/timings`
+`GET /api/v2/workspaces/{workspace}/timings`
 
 ### Parameters
 
@@ -2427,7 +2427,7 @@ curl -X PUT http://coder-server:8080/api/v2/workspaces/{workspace}/ttl \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PUT /workspaces/{workspace}/ttl`
+`PUT /api/v2/workspaces/{workspace}/ttl`
 
 > Body parameter
 
@@ -2463,7 +2463,7 @@ curl -X POST http://coder-server:8080/api/v2/workspaces/{workspace}/usage \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /workspaces/{workspace}/usage`
+`POST /api/v2/workspaces/{workspace}/usage`
 
 > Body parameter
 
@@ -2500,7 +2500,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaces/{workspace}/watch \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /workspaces/{workspace}/watch`
+`GET /api/v2/workspaces/{workspace}/watch`
 
 ### Parameters
 
@@ -2531,7 +2531,7 @@ curl -X GET http://coder-server:8080/api/v2/workspaces/{workspace}/watch-ws \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /workspaces/{workspace}/watch-ws`
+`GET /api/v2/workspaces/{workspace}/watch-ws`
 
 ### Parameters
 

--- a/scripts/apidocgen/swaginit/main.go
+++ b/scripts/apidocgen/swaginit/main.go
@@ -1,17 +1,67 @@
-// Package main wraps swag init with Strict mode enabled.
+// Package main wraps swag init with Strict mode enabled and rewrites
+// the generated swagger.json/docs.go so that paths mounted outside of
+// the default `/api/v2` prefix (such as SCIM, OAuth2 and `.well-known`
+// metadata endpoints) appear at their actual URLs in the spec.
 //
 // The upstream swag CLI (v1.16.2) does not expose a --strict
 // flag, so warnings about duplicate routes are silently
 // ignored. This wrapper calls the Go API directly with
 // Strict: true, turning those warnings into hard errors.
+//
+// In addition, swagger 2.0 prepends a single `basePath` to every path
+// in the spec.  Coder mounts most routes under `/api/v2`, but a small
+// number of routes are served from the root of the HTTP server
+// (e.g. `/scim/v2/...`, `/oauth2/...`, `/.well-known/...`,
+// `/api/experimental/...`).  Without post-processing, `swag` either
+// produces wrong "try it out" URLs in the Swagger UI for those routes
+// (when `@BasePath` is `/api/v2`) or forces every `@Router` annotation
+// in the codebase to be written as an absolute path (when `@BasePath`
+// is `/`).  We instead keep `@Router` annotations short in the source
+// and rewrite the generated spec here:
+//
+//   - `basePath` is set to `/`.
+//   - Paths that should remain at the root keep their original value.
+//   - All other paths are prefixed with `/api/v2`.
+//
+// This produces correct URLs for both the Swagger UI "try it out"
+// feature and the generated curl examples in `docs/reference/api`.
+//
+// See https://github.com/coder/coder/issues/24736.
 package main
 
 import (
+	"bytes"
+	"fmt"
 	"log"
 	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
 
 	"github.com/swaggo/swag/gen"
 )
+
+// apiV2BasePath is the base path that most Coder API routes are mounted under.
+const apiV2BasePath = "/api/v2"
+
+// rootMountedPathPrefixes are the path prefixes (in the generated
+// swagger.json) that are served from the root of the Coder HTTP
+// server, NOT from `/api/v2`.  Paths starting with any of these
+// prefixes will be left unmodified by the rewrite step; every other
+// path will be prefixed with `/api/v2`.
+//
+// Keep this list in sync with the route registrations in
+// `coderd/coderd.go` and `enterprise/coderd/coderd.go`.
+var rootMountedPathPrefixes = []string{
+	"/.well-known/",
+	"/oauth2/",
+	"/scim/",
+	"/api/experimental/",
+}
+
+// experimentalPathRewrite normalizes `@Router /experimental/...` (which
+// some annotations use) to the actual mount point `/api/experimental/...`.
+const experimentalPathRewrite = "/experimental/"
 
 func main() {
 	logger := log.New(os.Stdout, "", log.LstdFlags)
@@ -40,4 +90,118 @@ func main() {
 	if err != nil {
 		log.Fatalf("swag init failed: %v", err)
 	}
+
+	if err := rewriteSwagger(outputDir); err != nil {
+		log.Fatalf("rewrite swagger spec: %v", err)
+	}
+}
+
+// rewriteSwagger updates the generated `swagger.json` and `docs.go`
+// files in outputDir so that:
+//
+//   - The top-level `basePath` is `/`.
+//   - Paths mounted at the root of the HTTP server (see
+//     `rootMountedPathPrefixes`) keep their original value.
+//   - All other paths are prefixed with `/api/v2`.
+//
+// `docs.go` embeds the same JSON in a Go string literal, so we apply
+// the same set of rewrites to both files independently.
+func rewriteSwagger(outputDir string) error {
+	for _, name := range []string{"swagger.json", "docs.go"} {
+		path := filepath.Join(outputDir, name)
+		original, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", path, err)
+		}
+		rewritten, err := rewriteSpecBytes(original, name)
+		if err != nil {
+			return fmt.Errorf("rewrite %s: %w", path, err)
+		}
+		if err := os.WriteFile(path, rewritten, 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", path, err)
+		}
+	}
+	return nil
+}
+
+// pathKeyRegex matches a JSON path key as emitted by swag inside the
+// "paths" object of swagger.json/docs.go.  swag indents path keys with
+// exactly 8 spaces and follows the closing quote with `: {`.
+//
+// The capture group is the raw path string (without the surrounding
+// quotes).
+var pathKeyRegex = regexp.MustCompile(`(?m)^( {8})"(/[^"]*)": \{`)
+
+// basePathRegexJSON matches the `basePath` field in the swag-generated
+// swagger.json.  It always sits at indent 4, with one space after the
+// colon.
+var basePathRegexJSON = regexp.MustCompile(`(?m)^( {4})"basePath": "/api/v2",`)
+
+// basePathRegexDocsGo matches the `BasePath:` field of the SwaggerInfo
+// Go struct that swag emits at the bottom of docs.go.
+var basePathRegexDocsGo = regexp.MustCompile(`(?m)^(\tBasePath: +)"/api/v2",`)
+
+// rewriteSpecBytes applies path-key and basePath rewrites to the given
+// file contents.  `name` is used only to produce more descriptive
+// error messages and to skip the JSON-only basePath rewrite when
+// processing `docs.go`.
+func rewriteSpecBytes(in []byte, name string) ([]byte, error) {
+	// Sanity-check that swag's output still has the structure we
+	// expect.  We require the JSON file to declare basePath = /api/v2
+	// at the top level; if upstream swag changes its emitter we want
+	// to fail loudly rather than silently producing a wrong spec.
+	if name == "swagger.json" && !basePathRegexJSON.Match(in) {
+		return nil, fmt.Errorf(
+			"could not find expected basePath line in swagger.json. " +
+				"The swag generator output format may have changed; " +
+				"update scripts/apidocgen/swaginit/main.go.")
+	}
+
+	out := pathKeyRegex.ReplaceAllFunc(in, func(match []byte) []byte {
+		sub := pathKeyRegex.FindSubmatch(match)
+		indent := sub[1]
+		key := string(sub[2])
+		newKey := rewritePathKey(key)
+		if newKey == key {
+			return match
+		}
+		return []byte(fmt.Sprintf(`%s"%s": {`, indent, newKey))
+	})
+
+	// Rewrite the basePath fields so runtime consumers see the
+	// updated value too.  We only touch the JSON in swagger.json (the
+	// top-level `"basePath": "/api/v2"` field) and the Go literal in
+	// docs.go (`BasePath: "/api/v2"`).  The {{.BasePath}} template
+	// token in docs.go's docTemplate is filled at runtime from the
+	// SwaggerInfo struct, so updating the struct is sufficient.
+	out = basePathRegexJSON.ReplaceAll(out, []byte(`${1}"basePath": "/",`))
+	out = basePathRegexDocsGo.ReplaceAll(out, []byte(`${1}"/",`))
+
+	if !bytes.Contains(out, []byte(`"/api/v2/`)) && name == "swagger.json" {
+		return nil, fmt.Errorf(
+			"after rewrite, swagger.json contains no /api/v2/ paths. " +
+				"This is unexpected; the rewrite logic may be broken.")
+	}
+
+	return out, nil
+}
+
+// rewritePathKey applies the prefixing rules described on
+// `rewriteSwagger` to a single path key.
+func rewritePathKey(key string) string {
+	// `/experimental/...` is mounted at `/api/experimental/...` in
+	// chi.  Canonicalize before checking the root-mounted list so we
+	// don't accidentally double-prefix it.
+	if strings.HasPrefix(key, experimentalPathRewrite) {
+		key = "/api" + key
+	}
+	for _, prefix := range rootMountedPathPrefixes {
+		if strings.HasPrefix(key, prefix) || key == strings.TrimSuffix(prefix, "/") {
+			return key
+		}
+	}
+	if key == "/" {
+		return apiV2BasePath + "/"
+	}
+	return apiV2BasePath + key
 }

--- a/scripts/apidocgen/swaginit/main_test.go
+++ b/scripts/apidocgen/swaginit/main_test.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRewritePathKey(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// Root mounted paths must be left alone.
+		{
+			name: "scim path stays at root",
+			in:   "/scim/v2/Users",
+			want: "/scim/v2/Users",
+		},
+		{
+			name: "scim with id stays at root",
+			in:   "/scim/v2/Users/{id}",
+			want: "/scim/v2/Users/{id}",
+		},
+		{
+			name: "oauth2 path stays at root",
+			in:   "/oauth2/tokens",
+			want: "/oauth2/tokens",
+		},
+		{
+			name: "well-known path stays at root",
+			in:   "/.well-known/oauth-authorization-server",
+			want: "/.well-known/oauth-authorization-server",
+		},
+		{
+			name: "api/experimental path stays at root",
+			in:   "/api/experimental/watch-all-workspacebuilds",
+			want: "/api/experimental/watch-all-workspacebuilds",
+		},
+		// Annotations using `/experimental/...` are canonicalized to
+		// `/api/experimental/...`.
+		{
+			name: "experimental path canonicalized to api/experimental",
+			in:   "/experimental/chats/config/retention-days",
+			want: "/api/experimental/chats/config/retention-days",
+		},
+		// Everything else gets the /api/v2 prefix.
+		{
+			name: "regular endpoint gets api/v2 prefix",
+			in:   "/users",
+			want: "/api/v2/users",
+		},
+		{
+			name: "endpoint with template parameter gets api/v2 prefix",
+			in:   "/users/{user}",
+			want: "/api/v2/users/{user}",
+		},
+		{
+			name: "oauth2-provider is NOT root mounted",
+			in:   "/oauth2-provider/apps",
+			want: "/api/v2/oauth2-provider/apps",
+		},
+		{
+			name: "root path becomes /api/v2/",
+			in:   "/",
+			want: "/api/v2/",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := rewritePathKey(tc.in)
+			if got != tc.want {
+				t.Errorf("rewritePathKey(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRewriteSpecBytesPaths(t *testing.T) {
+	t.Parallel()
+
+	const input = `{
+    "swagger": "2.0",
+    "basePath": "/api/v2",
+    "paths": {
+        "/": {
+            "get": {}
+        },
+        "/users": {
+            "get": {}
+        },
+        "/scim/v2/Users": {
+            "get": {}
+        },
+        "/.well-known/oauth-authorization-server": {
+            "get": {}
+        },
+        "/oauth2/tokens": {
+            "post": {}
+        },
+        "/experimental/chats/config/retention-days": {
+            "get": {}
+        }
+    }
+}
+`
+
+	out, err := rewriteSpecBytes([]byte(input), "swagger.json")
+	if err != nil {
+		t.Fatalf("rewriteSpecBytes: %v", err)
+	}
+	got := string(out)
+
+	wantContains := []string{
+		`"basePath": "/",`,
+		`"/api/v2/": {`,
+		`"/api/v2/users": {`,
+		`"/scim/v2/Users": {`,
+		`"/.well-known/oauth-authorization-server": {`,
+		`"/oauth2/tokens": {`,
+		`"/api/experimental/chats/config/retention-days": {`,
+	}
+	for _, want := range wantContains {
+		if !strings.Contains(got, want) {
+			t.Errorf("rewritten spec missing %q.\nfull output:\n%s", want, got)
+		}
+	}
+
+	wantMissing := []string{
+		`"basePath": "/api/v2",`,
+		`"/api/v2/scim/`,
+		`"/api/v2/oauth2/`,
+		`"/api/v2/.well-known/`,
+		`"/api/v2/api/experimental/`,
+		`"/api/v2/experimental/`,
+		`"/experimental/chats/`,
+	}
+	for _, missing := range wantMissing {
+		if strings.Contains(got, missing) {
+			t.Errorf("rewritten spec unexpectedly contains %q.\nfull output:\n%s", missing, got)
+		}
+	}
+}
+
+func TestRewriteSpecBytesDocsGoBasePath(t *testing.T) {
+	t.Parallel()
+
+	// docs.go has both the docTemplate string and the SwaggerInfo
+	// struct's BasePath field.  We need the struct's BasePath field
+	// to be rewritten so the runtime SwaggerInfo reflects the new
+	// basePath; the docTemplate `"basePath": "{{.BasePath}}"` token
+	// is filled in at runtime from SwaggerInfo and must not be
+	// touched directly.
+	const input = "package apidoc\n" +
+		"const docTemplate = `{\n" +
+		"    \"basePath\": \"{{.BasePath}}\",\n" +
+		"    \"paths\": {\n" +
+		"        \"/users\": {}\n" +
+		"    }\n" +
+		"}`\n" +
+		"var SwaggerInfo = &swag.Spec{\n" +
+		"\tBasePath:         \"/api/v2\",\n" +
+		"}\n"
+
+	out, err := rewriteSpecBytes([]byte(input), "docs.go")
+	if err != nil {
+		t.Fatalf("rewriteSpecBytes: %v", err)
+	}
+	got := string(out)
+
+	if !strings.Contains(got, `BasePath:         "/",`) {
+		t.Errorf("expected SwaggerInfo BasePath to be rewritten, got:\n%s", got)
+	}
+	if !strings.Contains(got, `"basePath": "{{.BasePath}}"`) {
+		t.Errorf("expected docTemplate {{.BasePath}} token to be preserved, got:\n%s", got)
+	}
+	if !strings.Contains(got, `"/api/v2/users": {}`) {
+		t.Errorf("expected path keys to be rewritten in docTemplate, got:\n%s", got)
+	}
+}
+
+func TestRewriteSpecBytesRejectsUnexpectedBasePath(t *testing.T) {
+	t.Parallel()
+
+	const input = `{
+    "swagger": "2.0",
+    "basePath": "/somethingelse",
+    "paths": {
+        "/users": {}
+    }
+}
+`
+	_, err := rewriteSpecBytes([]byte(input), "swagger.json")
+	if err == nil {
+		t.Fatal("expected an error when basePath is not /api/v2")
+	}
+}


### PR DESCRIPTION
Fixes #24736.

## Problem

The Swagger UI was prepending the global `/api/v2` base path to every path in the spec, which produced wrong "try it out" URLs for routes that are actually mounted at the root of the HTTP server. For example, the SCIM `ServiceProviderConfig` endpoint was shown as `https://instance/api/v2/scim/v2/ServiceProviderConfig`, but the actual route is `https://instance/scim/v2/ServiceProviderConfig`.

The same mismatch produced wrong `curl` examples in the generated API reference docs (`docs/reference/api/enterprise.md`).

Affected route groups:
- `/scim/v2/...`
- `/oauth2/...` (OAuth2 provider linking endpoints, not `oauth2-provider`)
- `/.well-known/...`
- `/api/experimental/...`

## Approach

Rather than rewriting every `@Router` annotation in the codebase to be absolute (the approach taken in #24779, which touches ~80 source files), I post-process the spec generated by `swag init` so all paths get the correct prefix:

- `basePath` is set to `/`.
- Paths starting with `/scim/`, `/oauth2/`, `/.well-known/` or `/api/experimental/` keep their original value.
- All other paths are prefixed with `/api/v2`.
- Annotations using `/experimental/...` are normalized to the actual mount point `/api/experimental/...`.

This keeps `@Router` annotations short in the source and means future endpoints don't need to remember to prefix `/api/v2`.

## Files changed

Only two non-generated files:
- `scripts/apidocgen/swaginit/main.go` — adds the post-processing step
- `scripts/apidocgen/swaginit/main_test.go` — unit tests for the rewrite logic

The rest are regenerated outputs (`coderd/apidoc/{docs.go,swagger.json}` and `docs/reference/api/*.md`) produced by running `make gen`.

## Validation

- `go test ./scripts/apidocgen/swaginit/...` passes
- `go test -run TestSwagger ./coderd/...` passes
- `make coderd/apidoc/.gen` reproduces the committed output
- Verified against a running `coder server`:
  - `GET /swagger/doc.json` returns `"basePath": "/"`, `/scim/v2/...`, `/oauth2/...`, `/.well-known/...` paths are kept at root, all other paths are prefixed with `/api/v2`
  - The Swagger UI shows `/scim/v2/ServiceProviderConfig` (no `/api/v2` prefix) when the SCIM section is expanded
- Documentation curl examples in `docs/reference/api/enterprise.md` now use `http://coder-server:8080/scim/v2/...` instead of `http://coder-server:8080/api/v2/scim/v2/...`

### Proof

Docs change in `docs/reference/api/enterprise.md`:

```diff
  ## SCIM 2.0: Service Provider Config

  ### Code samples

  ```shell
  # Example request using curl
- curl -X GET http://coder-server:8080/api/v2/scim/v2/ServiceProviderConfig
+ curl -X GET http://coder-server:8080/scim/v2/ServiceProviderConfig
```

Swagger UI showing the corrected SCIM endpoint paths (no more `/api/v2/scim/v2/...`):

![Swagger UI SCIM section after fix](https://raw.githubusercontent.com/coder/coder/dfraley/scim-swagger-fix-screenshots/.github/screenshots/24736-overview.png)

![Swagger UI SCIM ServiceProviderConfig try it out](https://raw.githubusercontent.com/coder/coder/dfraley/scim-swagger-fix-screenshots/.github/screenshots/24736-tryout.png)

<details><summary>Why not change every <code>@Router</code> annotation?</summary>

#24779 takes the alternative approach of changing every `@Router` annotation in the codebase to use the full `/api/v2/...` path and setting `@BasePath /`. That works, but:

- It touches ~80 source files (~6,500 line diff) instead of ~2.
- Future endpoints have to remember to add the `/api/v2` prefix to their `@Router` or the spec will be wrong.
- The post-processing approach localizes all the routing knowledge to one file (`scripts/apidocgen/swaginit/main.go`) and explicitly documents which prefixes are root-mounted.
- If a new root-mounted prefix is added in `coderd/coderd.go`, the only change required is one line in the `rootMountedPathPrefixes` slice.

</details>

> 🤖 This PR was created with the help of Coder Agents on @david-fraley's behalf, and needs a human review.