### PR TITLE
fix(site): clarify that Manage Agents settings are deployment-wide

### DIFF
--- a/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
@@ -1415,6 +1415,9 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 					</nav>
 				) : (
 					<nav className="flex flex-col gap-0.5 px-2 py-2">
+						<p className="px-2 pb-1 text-2xs text-content-tertiary">
+							These settings apply to all users across the deployment.
+						</p>
 						<SettingsNavItem
 							icon={BotIcon}
 							label="Agents"


### PR DESCRIPTION
The "Manage Agents" admin settings pages lacked any indication that they are deployment-wide. An admin could mistake them for personal settings.

Adds a small subtitle under the "Manage Agents" sidebar heading:

> These settings apply to all users across the deployment.

This is a single-line structural fix rather than modifying each page description individually.


<img width="324" height="482" alt="Screenshot From 2026-05-04 11-13-16" src="https://github.com/user-attachments/assets/8db5d56d-5fb8-4c49-b1ea-3e13c08b8824" />


**Generated by Coder Agents**
