### PR TITLE
feat(coderd/x/chatd): add port forwarding URL templates to workspace-context

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -797,6 +797,8 @@ func New(options *Options) *API {
 			AgentConn:                      api.agentProvider.AgentConn,
 			AgentInactiveDisconnectTimeout: api.AgentInactiveDisconnectTimeout,
 			InstructionLookupTimeout:       options.ChatdInstructionLookupTimeout,
+			AccessURL:                      options.AccessURL,
+			AppHostname:                    options.AppHostname,
 			CreateWorkspace:                api.chatCreateWorkspace,
 			StartWorkspace:                 api.chatStartWorkspace,
 			Pubsub:                         options.Pubsub,

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"maps"
 	"net/http"
+	"net/url"
 	"slices"
 	"strconv"
 	"strings"
@@ -35,6 +36,7 @@ import (
 	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/coderd/util/xjson"
 	"github.com/coder/coder/v2/coderd/webpush"
+	"github.com/coder/coder/v2/coderd/workspaceapps/appurl"
 	"github.com/coder/coder/v2/coderd/workspacestats"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatadvisor"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatcost"
@@ -158,6 +160,8 @@ type Server struct {
 	agentInactiveDisconnectTimeout time.Duration
 	dialTimeout                    time.Duration
 	instructionLookupTimeout       time.Duration
+	accessURL                      *url.URL
+	appHostname                    string
 	createWorkspaceFn              chattool.CreateWorkspaceFn
 	startWorkspaceFn               chattool.StartWorkspaceFn
 	pubsub                         pubsub.Pubsub
@@ -465,6 +469,8 @@ type turnWorkspaceContext struct {
 	conn              workspacesdk.AgentConn
 	releaseConn       func()
 	cachedWorkspaceID uuid.NullUUID
+	workspaceName     string
+	ownerUsername     string
 }
 
 func (c *turnWorkspaceContext) close() {
@@ -479,6 +485,8 @@ func (c *turnWorkspaceContext) clearCachedWorkspaceState() {
 	c.conn = nil
 	c.releaseConn = nil
 	c.cachedWorkspaceID = uuid.NullUUID{}
+	c.workspaceName = ""
+	c.ownerUsername = ""
 	c.mu.Unlock()
 
 	if releaseConn != nil {
@@ -507,6 +515,35 @@ func (c *turnWorkspaceContext) selectWorkspace(chat database.Chat) {
 func (c *turnWorkspaceContext) currentWorkspaceMatches(expected uuid.NullUUID) (database.Chat, bool) {
 	chatSnapshot := c.currentChatSnapshot()
 	return chatSnapshot, nullUUIDEqual(chatSnapshot.WorkspaceID, expected)
+}
+
+// resolveWorkspaceMetadataLocked looks up the workspace name and
+// owner username for the current chat. These are cached on the
+// turnWorkspaceContext and used to build port forwarding URL
+// templates. Caller must hold c.mu.
+func (c *turnWorkspaceContext) resolveWorkspaceMetadataLocked(
+	ctx context.Context,
+	chat database.Chat,
+) {
+	if !chat.WorkspaceID.Valid {
+		return
+	}
+	//nolint:gocritic // System-level lookup for prompt metadata.
+	ws, err := c.server.db.GetWorkspaceByID(dbauthz.AsSystemRestricted(ctx), chat.WorkspaceID.UUID)
+	if err != nil {
+		c.server.logger.Debug(ctx, "failed to look up workspace name",
+			slog.F("chat_id", chat.ID), slog.Error(err))
+		return
+	}
+	//nolint:gocritic // Same as above; we need the owner username.
+	owner, err := c.server.db.GetUserByID(dbauthz.AsSystemRestricted(ctx), chat.OwnerID)
+	if err != nil {
+		c.server.logger.Debug(ctx, "failed to look up owner username",
+			slog.F("chat_id", chat.ID), slog.Error(err))
+		return
+	}
+	c.workspaceName = ws.Name
+	c.ownerUsername = owner.Username
 }
 
 func nullUUIDEqual(left, right uuid.NullUUID) bool {
@@ -594,6 +631,13 @@ func (c *turnWorkspaceContext) loadWorkspaceAgentLocked(
 
 		if !chatSnapshot.WorkspaceID.Valid {
 			return chatSnapshot, database.WorkspaceAgent{}, xerrors.New("no workspace is associated with this chat. Use the create_workspace tool to create one")
+		}
+
+		// Resolve workspace name and owner username for the
+		// app URL template. Best-effort; failures are not
+		// fatal since these are only used for prompt context.
+		if c.workspaceName == "" {
+			c.resolveWorkspaceMetadataLocked(ctx, chatSnapshot)
 		}
 
 		if chatSnapshot.AgentID.Valid {
@@ -3601,6 +3645,15 @@ type Config struct {
 	AgentConn                      AgentConnFunc
 	AgentInactiveDisconnectTimeout time.Duration
 	InstructionLookupTimeout       time.Duration
+
+	// AccessURL is the deployment's access URL, used to construct
+	// workspace app preview URLs in the workspace-context block.
+	AccessURL *url.URL
+	// AppHostname is the wildcard hostname pattern for subdomain
+	// apps, e.g. "*.apps.coder.com". When set alongside AccessURL,
+	// the workspace-context block includes a preview URL template
+	// so the agent knows how to link to forwarded ports.
+	AppHostname string
 	CreateWorkspace                chattool.CreateWorkspaceFn
 	StartWorkspace                 chattool.StartWorkspaceFn
 	Pubsub                         pubsub.Pubsub
@@ -3669,6 +3722,8 @@ func New(cfg Config) *Server {
 		agentInactiveDisconnectTimeout: cfg.AgentInactiveDisconnectTimeout,
 		dialTimeout:                    defaultDialTimeout,
 		instructionLookupTimeout:       instructionLookupTimeout,
+		accessURL:                      cfg.AccessURL,
+		appHostname:                    cfg.AppHostname,
 		createWorkspaceFn:              cfg.CreateWorkspace,
 		startWorkspaceFn:               cfg.StartWorkspace,
 		pubsub:                         cfg.Pubsub,
@@ -5842,6 +5897,8 @@ func (p *Server) appendRootChatTools(
 				ctx,
 				updatedChat,
 				opts.modelConfigID,
+				opts.workspaceCtx.workspaceName,
+				opts.workspaceCtx.ownerUsername,
 				opts.workspaceCtx.getWorkspaceAgent,
 				opts.workspaceCtx.getWorkspaceConn,
 			)
@@ -6273,6 +6330,8 @@ func (p *Server) runChat(
 				ctx,
 				chat,
 				modelConfig.ID,
+				workspaceCtx.workspaceName,
+				workspaceCtx.ownerUsername,
 				workspaceCtx.getWorkspaceAgent,
 				func(instructionCtx context.Context) (workspacesdk.AgentConn, error) {
 					if _, _, err := workspaceCtx.workspaceAgentIDForConn(instructionCtx); err != nil {
@@ -7555,6 +7614,7 @@ func contextFileAgentID(messages []database.ChatMessage) (uuid.UUID, bool) {
 func (p *Server) fetchWorkspaceContext(
 	ctx context.Context,
 	chat database.Chat,
+	workspaceName, ownerUsername string,
 	getWorkspaceAgent func(context.Context) (database.WorkspaceAgent, error),
 	getWorkspaceConn func(context.Context) (workspacesdk.AgentConn, error),
 ) (agent *database.WorkspaceAgent, agentParts []codersdk.ChatMessagePart, discoveredSkills []chattool.SkillMeta, workspaceConnOK bool) {
@@ -7607,6 +7667,10 @@ func (p *Server) fetchWorkspaceContext(
 	// directory — those are added here at the trust boundary.
 	agentID := uuid.NullUUID{UUID: loadedAgent.ID, Valid: true}
 
+	// Build the workspace app URL template so the agent can
+	// construct preview URLs for forwarded ports.
+	appURLTemplate := p.buildAppURLTemplate(loadedAgent.Name, workspaceName, ownerUsername)
+
 	for i := range agentParts {
 		agentParts[i].ContextFileAgentID = agentID
 		switch agentParts[i].Type {
@@ -7614,6 +7678,7 @@ func (p *Server) fetchWorkspaceContext(
 			agentParts[i].ContextFileContent = SanitizePromptText(agentParts[i].ContextFileContent)
 			agentParts[i].ContextFileOS = loadedAgent.OperatingSystem
 			agentParts[i].ContextFileDirectory = directory
+			agentParts[i].ContextFileAppURL = appURLTemplate
 		case codersdk.ChatMessagePartTypeSkill:
 			discoveredSkills = append(discoveredSkills, chattool.SkillMeta{
 				Name:        agentParts[i].SkillName,
@@ -7627,6 +7692,44 @@ func (p *Server) fetchWorkspaceContext(
 	return &loadedAgent, agentParts, discoveredSkills, workspaceConnOK
 }
 
+// buildAppURLTemplate constructs preview URL templates for
+// workspace app ports. The template uses {port} as a placeholder
+// so the agent can substitute actual port numbers. Returns an
+// empty string when the access URL is not configured or the
+// required metadata is missing.
+func (p *Server) buildAppURLTemplate(
+	agentName, workspaceName, ownerUsername string,
+) string {
+	if p.accessURL == nil || workspaceName == "" || ownerUsername == "" {
+		return ""
+	}
+
+	var lines []string
+
+	// Subdomain-based URL (when wildcard app hostname is configured).
+	if p.appHostname != "" {
+		appHost := appurl.SubdomainAppHost(p.appHostname, p.accessURL)
+		prefix := strings.Replace(
+			appHost,
+			"*",
+			fmt.Sprintf("{port}--%s--%s--%s", agentName, workspaceName, ownerUsername),
+			1,
+		)
+		lines = append(lines, fmt.Sprintf("%s://%s/", p.accessURL.Scheme, prefix))
+	} else {
+		// Path-based URL (fallback when no wildcard app hostname).
+		pathURL := fmt.Sprintf("%s/@%s/%s.%s/apps/{port}/",
+			p.accessURL.String(), ownerUsername, workspaceName, agentName)
+		lines = append(lines, pathURL)
+	}
+
+	// Coder Desktop URL.
+	lines = append(lines, fmt.Sprintf("http://%s.coder:{port}", workspaceName))
+
+	return strings.Join(lines, "\n")
+}
+
+
 // persistInstructionFiles fetches AGENTS.md instruction files and
 // skills from the workspace agent, persisting both as message
 // parts. This is called once when a workspace is first attached
@@ -7637,11 +7740,12 @@ func (p *Server) persistInstructionFiles(
 	ctx context.Context,
 	chat database.Chat,
 	modelConfigID uuid.UUID,
+	workspaceName, ownerUsername string,
 	getWorkspaceAgent func(context.Context) (database.WorkspaceAgent, error),
 	getWorkspaceConn func(context.Context) (workspacesdk.AgentConn, error),
 ) (instruction string, skills []chattool.SkillMeta, err error) {
 	agent, agentParts, discoveredSkills, workspaceConnOK := p.fetchWorkspaceContext(
-		ctx, chat, getWorkspaceAgent, getWorkspaceConn,
+		ctx, chat, workspaceName, ownerUsername, getWorkspaceAgent, getWorkspaceConn,
 	)
 	// Defensive guard: fetchWorkspaceContext returns nil when the
 	// chat has no valid workspace or the agent lookup fails. It's

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -1134,6 +1134,7 @@ func TestPersistInstructionFilesIncludesAgentMetadata(t *testing.T) {
 		ctx,
 		chat,
 		uuid.New(),
+		"", "",
 		workspaceCtx.getWorkspaceAgent,
 		workspaceCtx.getWorkspaceConn,
 	)
@@ -1165,6 +1166,7 @@ func TestPersistInstructionFilesSkipsSentinelWhenWorkspaceUnavailable(t *testing
 		ctx,
 		chat,
 		uuid.New(),
+		"", "",
 		func(context.Context) (database.WorkspaceAgent, error) {
 			return database.WorkspaceAgent{
 				ID:        uuid.New(),
@@ -1302,6 +1304,7 @@ func TestPersistInstructionFilesSentinelWithSkills(t *testing.T) {
 		ctx,
 		chat,
 		uuid.New(),
+		"", "",
 		workspaceCtx.getWorkspaceAgent,
 		workspaceCtx.getWorkspaceConn,
 	)
@@ -1390,6 +1393,7 @@ func TestPersistInstructionFilesSentinelNoSkillsClearsColumn(t *testing.T) {
 		ctx,
 		chat,
 		uuid.New(),
+		"", "",
 		workspaceCtx.getWorkspaceAgent,
 		workspaceCtx.getWorkspaceConn,
 	)

--- a/coderd/x/chatd/chatprompt/chatprompt.go
+++ b/coderd/x/chatd/chatprompt/chatprompt.go
@@ -1590,6 +1590,11 @@ func partsToMessageParts(
 				_, _ = sb.WriteString(part.ContextFileDirectory)
 				_, _ = sb.WriteString("\n")
 			}
+			if part.ContextFileAppURL != "" {
+				_, _ = sb.WriteString("\nPort forwarding URL templates (replace {port} with the port number):\n")
+				_, _ = sb.WriteString(part.ContextFileAppURL)
+				_, _ = sb.WriteString("\n")
+			}
 			source := part.ContextFilePath
 			if part.ContextFileTruncated {
 				source += " (truncated to 64KiB)"

--- a/coderd/x/chatd/instruction.go
+++ b/coderd/x/chatd/instruction.go
@@ -42,6 +42,17 @@ func formatSystemInstructions(
 		_, _ = b.WriteString(directory)
 		_, _ = b.WriteString("\n")
 	}
+	// Extract the app URL template from the first context-file
+	// part. All parts carry the same value since it is stamped
+	// uniformly in fetchWorkspaceContext.
+	for _, part := range parts {
+		if part.Type == codersdk.ChatMessagePartTypeContextFile && part.ContextFileAppURL != "" {
+			_, _ = b.WriteString("\nPort forwarding URL templates (replace {port} with the port number):\n")
+			_, _ = b.WriteString(part.ContextFileAppURL)
+			_, _ = b.WriteString("\n")
+			break
+		}
+	}
 	for _, part := range parts {
 		if part.Type != codersdk.ChatMessagePartTypeContextFile || part.ContextFileContent == "" {
 			continue

--- a/coderd/x/chatd/instruction_test.go
+++ b/coderd/x/chatd/instruction_test.go
@@ -234,6 +234,54 @@ func TestFormatSystemInstructions(t *testing.T) {
 		require.NotContains(t, got, "Source: /empty")
 		require.Contains(t, got, "Source: /real/AGENTS.md")
 	})
+
+	t.Run("PreviewURL", func(t *testing.T) {
+		t.Parallel()
+		got := formatSystemInstructions("linux", "/home/coder", []codersdk.ChatMessagePart{
+			{
+				Type:              codersdk.ChatMessagePartTypeContextFile,
+				ContextFileContent: "rules",
+				ContextFilePath:    "/home/coder/AGENTS.md",
+				ContextFileAppURL: "https://{port}--dev--my-ws--alice.apps.coder.com/\n" +
+					"http://my-ws.coder:{port}",
+			},
+		})
+		require.Contains(t, got, "Port forwarding URL templates")
+		require.Contains(t, got, "https://{port}--dev--my-ws--alice.apps.coder.com/")
+		require.Contains(t, got, "http://my-ws.coder:{port}")
+		// URL templates should appear before the Source lines.
+		urlIdx := strings.Index(got, "Port forwarding URL templates")
+		sourceIdx := strings.Index(got, "Source:")
+		require.Less(t, urlIdx, sourceIdx)
+	})
+
+	t.Run("PreviewURLPathBased", func(t *testing.T) {
+		t.Parallel()
+		got := formatSystemInstructions("linux", "/home/coder", []codersdk.ChatMessagePart{
+			{
+				Type:              codersdk.ChatMessagePartTypeContextFile,
+				ContextFileContent: "rules",
+				ContextFilePath:    "/home/coder/AGENTS.md",
+				ContextFileAppURL: "https://coder.example.com/@alice/my-ws.dev/apps/{port}/\n" +
+					"http://my-ws.coder:{port}",
+			},
+		})
+		require.Contains(t, got, "https://coder.example.com/@alice/my-ws.dev/apps/{port}/")
+		require.Contains(t, got, "http://my-ws.coder:{port}")
+		require.NotContains(t, got, "--dev--")
+	})
+
+	t.Run("PreviewURLOmittedWhenEmpty", func(t *testing.T) {
+		t.Parallel()
+		got := formatSystemInstructions("linux", "/home/coder", []codersdk.ChatMessagePart{
+			{
+				Type:              codersdk.ChatMessagePartTypeContextFile,
+				ContextFileContent: "rules",
+				ContextFilePath:    "/home/coder/AGENTS.md",
+			},
+		})
+		require.NotContains(t, got, "Port forwarding")
+	})
 }
 
 func TestInstructionFromContextFiles(t *testing.T) {

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -262,6 +262,11 @@ type ChatMessagePart struct {
 	// workspace agent. Internal only: same purpose as
 	// ContextFileOS.
 	ContextFileDirectory string `json:"context_file_directory,omitempty" typescript:"-"`
+	// ContextFileAppURL is the workspace app URL template with
+	// {port} as a placeholder for the port number. Internal
+	// only: included in the workspace-context block so the
+	// agent can construct preview URLs for forwarded ports.
+	ContextFileAppURL string `json:"context_file_app_url,omitempty" typescript:"-"`
 	// SkillName is the kebab-case name of a discovered skill
 	// from the workspace's .agents/skills/ directory.
 	SkillName string `json:"skill_name" variants:"skill"`
@@ -294,6 +299,7 @@ func (p *ChatMessagePart) StripInternal() {
 	p.ContextFileContent = ""
 	p.ContextFileOS = ""
 	p.ContextFileDirectory = ""
+	p.ContextFileAppURL = ""
 	p.SkillDir = ""
 	p.ContextFileSkillMetaFile = ""
 }


### PR DESCRIPTION
When a workspace is attached to a chat, the `<workspace-context>` block now includes port forwarding URL templates with `{port}` as a placeholder. This gives the agent correct URL formats instead of guessing or hallucinating link formats (e.g. `coder://` desktop protocol links).

Subdomain and path-based URLs are mutually exclusive: subdomain is used when the deployment has a wildcard app hostname, path-based is the fallback. Coder Desktop URLs are always included.

## Example output (with subdomain support)

```
<workspace-context>
Operating System: linux
Working Directory: /home/coder/project

Port forwarding URL templates (replace {port} with the port number):
https://{port}--dev--my-ws--alice.apps.coder.com/
http://my-ws.coder:{port}

Source: /home/coder/project/AGENTS.md
...
</workspace-context>
```

## Example output (without subdomain support)

```
<workspace-context>
Operating System: linux
Working Directory: /home/coder/project

Port forwarding URL templates (replace {port} with the port number):
https://coder.example.com/@alice/my-ws.dev/apps/{port}/
http://my-ws.coder:{port}

Source: /home/coder/project/AGENTS.md
...
</workspace-context>
```

## Changes

| File | Change |
|------|--------|
| `coderd/coderd.go` | Pass `AccessURL` and `AppHostname` to chatd config |
| `coderd/x/chatd/chatd.go` | Add fields to `Config`/`Server`; add `buildAppURLTemplate` with subdomain vs path-based logic |
| `coderd/x/chatd/instruction.go` | Emit URL templates in `formatSystemInstructions` |
| `coderd/x/chatd/chatprompt/chatprompt.go` | Emit URL templates in inline workspace-context renderer |
| `codersdk/chats.go` | Add `ContextFileAppURL` field; strip in `StripInternal()` |
| `coderd/x/chatd/instruction_test.go` | Tests for subdomain, path-based, and omitted cases |

> Generated by Coder Agents