### PR TITLE
feat: deployment-wide OAuth2 callback for admin MCP servers

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -24579,19 +24579,19 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "forceQuery": {
-                    "description": "append a query ('?') even if RawQuery is empty",
+                    "description": "ForceQuery indicates whether the original URL contained a query ('?') character.\nWhen set, the String method will include a trailing '?', even when RawQuery is empty.",
                     "type": "boolean"
                 },
                 "fragment": {
-                    "description": "fragment for references, without '#'",
+                    "description": "fragment for references (without '#')",
                     "type": "string"
                 },
                 "host": {
-                    "description": "host or host:port (see Hostname and Port methods)",
+                    "description": "\"host\" or \"host:port\" (see Hostname and Port methods)",
                     "type": "string"
                 },
                 "omitHost": {
-                    "description": "do not emit empty host (authority)",
+                    "description": "OmitHost indicates the URL has an empty host (authority).\nWhen set, the String method will not include the host when it is empty.",
                     "type": "boolean"
                 },
                 "opaque": {
@@ -24603,15 +24603,15 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "rawFragment": {
-                    "description": "encoded fragment hint (see EscapedFragment method)",
+                    "description": "RawFragment is an optional field containing an encoded fragment hint.\nSee the EscapedFragment method for more details.\n\nIn general, code should call EscapedFragment instead of reading RawFragment.",
                     "type": "string"
                 },
                 "rawPath": {
-                    "description": "encoded path hint (see EscapedPath method)",
+                    "description": "RawPath is an optional field containing an encoded path hint.\nSee the EscapedPath method for more details.\n\nIn general, code should call EscapedPath instead of reading RawPath.",
                     "type": "string"
                 },
                 "rawQuery": {
-                    "description": "encoded query values, without '?'",
+                    "description": "RawQuery contains the encoded query values, without the initial '?'.\nUse URL.Query to decode the query.",
                     "type": "string"
                 },
                 "scheme": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -22657,19 +22657,19 @@
 			"type": "object",
 			"properties": {
 				"forceQuery": {
-					"description": "append a query ('?') even if RawQuery is empty",
+					"description": "ForceQuery indicates whether the original URL contained a query ('?') character.\nWhen set, the String method will include a trailing '?', even when RawQuery is empty.",
 					"type": "boolean"
 				},
 				"fragment": {
-					"description": "fragment for references, without '#'",
+					"description": "fragment for references (without '#')",
 					"type": "string"
 				},
 				"host": {
-					"description": "host or host:port (see Hostname and Port methods)",
+					"description": "\"host\" or \"host:port\" (see Hostname and Port methods)",
 					"type": "string"
 				},
 				"omitHost": {
-					"description": "do not emit empty host (authority)",
+					"description": "OmitHost indicates the URL has an empty host (authority).\nWhen set, the String method will not include the host when it is empty.",
 					"type": "boolean"
 				},
 				"opaque": {
@@ -22681,15 +22681,15 @@
 					"type": "string"
 				},
 				"rawFragment": {
-					"description": "encoded fragment hint (see EscapedFragment method)",
+					"description": "RawFragment is an optional field containing an encoded fragment hint.\nSee the EscapedFragment method for more details.\n\nIn general, code should call EscapedFragment instead of reading RawFragment.",
 					"type": "string"
 				},
 				"rawPath": {
-					"description": "encoded path hint (see EscapedPath method)",
+					"description": "RawPath is an optional field containing an encoded path hint.\nSee the EscapedPath method for more details.\n\nIn general, code should call EscapedPath instead of reading RawPath.",
 					"type": "string"
 				},
 				"rawQuery": {
-					"description": "encoded query values, without '?'",
+					"description": "RawQuery contains the encoded query values, without the initial '?'.\nUse URL.Query to decode the query.",
 					"type": "string"
 				},
 				"scheme": {

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1289,7 +1289,7 @@ func New(options *Options) *API {
 			// Deployment-wide OAuth2 callback. Identifies the MCP
 			// server through a signed `state` parameter so the redirect
 			// URI does not depend on the per-config UUID.
-			r.Get("/oauth2/callback", api.mcpServerOAuth2GlobalCallback)
+			r.Get("/oauth2/callback", api.mcpServerOAuth2Callback)
 			// Returns the absolute URL of the deployment-wide callback
 			// for the admin UI to display when configuring OAuth2.
 			r.Get("/oauth2/callback-url", api.mcpOAuth2CallbackInfo)
@@ -1307,7 +1307,7 @@ func New(options *Options) *API {
 					// compatibility with any client that was registered
 					// with an upstream provider against this URL
 					// before the deployment-wide callback existed.
-					r.Get("/oauth2/callback", api.mcpServerOAuth2Callback)
+					r.Get("/oauth2/callback", api.mcpServerOAuth2CallbackDeprecated)
 					r.Delete("/oauth2/disconnect", api.mcpServerOAuth2Disconnect)
 				})
 			})

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1286,6 +1286,13 @@ func New(options *Options) *API {
 			r.Use(
 				apiKeyMiddleware,
 			)
+			// Deployment-wide OAuth2 callback. Identifies the MCP
+			// server through a signed `state` parameter so the redirect
+			// URI does not depend on the per-config UUID.
+			r.Get("/oauth2/callback", api.mcpServerOAuth2GlobalCallback)
+			// Returns the absolute URL of the deployment-wide callback
+			// for the admin UI to display when configuring OAuth2.
+			r.Get("/oauth2/callback-url", api.mcpOAuth2CallbackInfo)
 			// MCP server configuration endpoints.
 			r.Route("/servers", func(r chi.Router) {
 				r.Get("/", api.listMCPServerConfigs)
@@ -1296,6 +1303,10 @@ func New(options *Options) *API {
 					r.Delete("/", api.deleteMCPServerConfig)
 					// OAuth2 user flow
 					r.Get("/oauth2/connect", api.mcpServerOAuth2Connect)
+					// Legacy per-ID callback retained for backwards
+					// compatibility with any client that was registered
+					// with an upstream provider against this URL
+					// before the deployment-wide callback existed.
 					r.Get("/oauth2/callback", api.mcpServerOAuth2Callback)
 					r.Delete("/oauth2/disconnect", api.mcpServerOAuth2Disconnect)
 				})

--- a/coderd/deprecated.go
+++ b/coderd/deprecated.go
@@ -83,3 +83,27 @@ func (api *API) workspaceBuildResourcesDeprecated(rw http.ResponseWriter, r *htt
 	}
 	api.provisionerJobResources(rw, r, job)
 }
+
+// @Summary Removed: Handle MCP server OAuth2 callback (per-ID)
+// @ID removed-handle-mcp-server-oauth2-callback-per-id
+// @x-apidocgen {"skip": true}
+// EXPERIMENTAL: this endpoint is experimental and is subject to change.
+// 307-redirects to the deployment-wide MCP OAuth2 callback at
+// /api/experimental/mcp/oauth2/callback, preserving the query string
+// so the upstream `code` and signed `state` reach the new handler.
+// This shim exists only so any OAuth2 client previously registered
+// with an upstream provider against the per-ID URL keeps working.
+// New flows redirect directly to the deployment-wide callback. The
+// `mcpServer` path parameter is intentionally ignored: the MCP
+// server ID is decoded from the signed `state` parameter on the
+// deployment-wide handler.
+// @Deprecated use /api/experimental/mcp/oauth2/callback.
+//
+//nolint:revive // HTTP handler writes to ResponseWriter.
+func (api *API) mcpServerOAuth2CallbackDeprecated(rw http.ResponseWriter, r *http.Request) {
+	target := MCPOAuth2CallbackPath()
+	if raw := r.URL.RawQuery; raw != "" {
+		target += "?" + raw
+	}
+	http.Redirect(rw, r, target, http.StatusTemporaryRedirect)
+}

--- a/coderd/mcp.go
+++ b/coderd/mcp.go
@@ -36,7 +36,7 @@ import (
 	"github.com/coder/coder/v2/cryptorand"
 )
 
-// mcpOAuth2GlobalCallbackPath is the deployment-wide OAuth2 callback
+// mcpOAuth2CallbackPath is the deployment-wide OAuth2 callback
 // for admin-configured MCP servers. It does not depend on the MCP
 // server config ID; the server is identified through a signed `state`
 // parameter. This lets admins register a single redirect URI with
@@ -44,19 +44,19 @@ import (
 // config in Coder, removing the chicken-and-egg from the manual
 // setup flow and the insert-then-update dance from automatic
 // Dynamic Client Registration.
-const mcpOAuth2GlobalCallbackPath = "/api/experimental/mcp/oauth2/callback"
+const mcpOAuth2CallbackPath = "/api/experimental/mcp/oauth2/callback"
 
-// MCPOAuth2GlobalCallbackPath returns the path of the deployment-wide
+// MCPOAuth2CallbackPath returns the path of the deployment-wide
 // MCP OAuth2 callback. Exported for tests.
-func MCPOAuth2GlobalCallbackPath() string {
-	return mcpOAuth2GlobalCallbackPath
+func MCPOAuth2CallbackPath() string {
+	return mcpOAuth2CallbackPath
 }
 
 // mcpOAuth2CallbackURL returns the absolute deployment-wide MCP OAuth2
 // callback URL. The frontend shows this so admins can register it with
 // the upstream provider before saving the MCP server config.
 func (api *API) mcpOAuth2CallbackURL() string {
-	return api.AccessURL.String() + mcpOAuth2GlobalCallbackPath
+	return api.AccessURL.String() + mcpOAuth2CallbackPath
 }
 
 // mcpOAuth2StateNonceSize is the number of random bytes embedded in a
@@ -921,7 +921,7 @@ func (api *API) mcpServerOAuth2Connect(rw http.ResponseWriter, r *http.Request) 
 		})
 		return
 	}
-	callbackPath := mcpOAuth2GlobalCallbackPath
+	callbackPath := mcpOAuth2CallbackPath
 	http.SetCookie(rw, api.DeploymentValues.HTTPCookies.Apply(&http.Cookie{
 		Name:     "mcp_oauth2_state_" + config.ID.String(),
 		Value:    nonce,
@@ -962,28 +962,7 @@ func (api *API) mcpServerOAuth2Connect(rw http.ResponseWriter, r *http.Request) 
 	http.Redirect(rw, r, authURL, http.StatusTemporaryRedirect)
 }
 
-// @Summary Redirect legacy per-ID MCP OAuth2 callback to the global one
-// @x-apidocgen {"skip": true}
-// EXPERIMENTAL: this endpoint is experimental and is subject to change.
-// 307-redirects to the deployment-wide callback, preserving the
-// query string. This handler exists only so any client previously
-// registered with an upstream provider against
-// `${access_url}/api/experimental/mcp/servers/{id}/oauth2/callback`
-// keeps working. New flows hit the global callback directly. The
-// `mcpServer` path parameter is intentionally ignored; the MCP server
-// ID is decoded from the signed `state` parameter on the global
-// handler.
-//
-//nolint:revive // HTTP handler writes to ResponseWriter.
-func (api *API) mcpServerOAuth2Callback(rw http.ResponseWriter, r *http.Request) {
-	target := mcpOAuth2GlobalCallbackPath
-	if raw := r.URL.RawQuery; raw != "" {
-		target += "?" + raw
-	}
-	http.Redirect(rw, r, target, http.StatusTemporaryRedirect)
-}
-
-// @Summary Handle MCP server OAuth2 callback (deployment-wide)
+// @Summary Handle MCP server OAuth2 callback
 // @x-apidocgen {"skip": true}
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
 // Decodes the signed `state` parameter to identify the MCP server
@@ -993,7 +972,7 @@ func (api *API) mcpServerOAuth2Callback(rw http.ResponseWriter, r *http.Request)
 // server config in Coder.
 //
 //nolint:revive // HTTP handler writes to ResponseWriter.
-func (api *API) mcpServerOAuth2GlobalCallback(rw http.ResponseWriter, r *http.Request) {
+func (api *API) mcpServerOAuth2Callback(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	apiKey := httpmw.APIKey(r)
 
@@ -1080,7 +1059,7 @@ func (api *API) mcpServerOAuth2GlobalCallback(rw http.ResponseWriter, r *http.Re
 		})
 		return
 	}
-	callbackPath := mcpOAuth2GlobalCallbackPath
+	callbackPath := mcpOAuth2CallbackPath
 	// Clear the state cookie.
 	http.SetCookie(rw, api.DeploymentValues.HTTPCookies.Apply(&http.Cookie{
 		Name:     "mcp_oauth2_state_" + config.ID.String(),

--- a/coderd/mcp.go
+++ b/coderd/mcp.go
@@ -3,7 +3,10 @@ package coderd
 import (
 	"bytes"
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -30,7 +33,87 @@ import (
 	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/coderd/x/chatd/mcpclient"
 	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/cryptorand"
 )
+
+// mcpOAuth2GlobalCallbackPath is the deployment-wide OAuth2 callback
+// for admin-configured MCP servers. It does not depend on the MCP
+// server config ID; the server is identified through a signed `state`
+// parameter. This lets admins register a single redirect URI with
+// each upstream OAuth2 provider before they create the MCP server
+// config in Coder, removing the chicken-and-egg from the manual
+// setup flow and the insert-then-update dance from automatic
+// Dynamic Client Registration.
+const mcpOAuth2GlobalCallbackPath = "/api/experimental/mcp/oauth2/callback"
+
+// MCPOAuth2GlobalCallbackPath returns the path of the deployment-wide
+// MCP OAuth2 callback. Exported for tests.
+func MCPOAuth2GlobalCallbackPath() string {
+	return mcpOAuth2GlobalCallbackPath
+}
+
+// mcpOAuth2CallbackURL returns the absolute deployment-wide MCP OAuth2
+// callback URL. The frontend shows this so admins can register it with
+// the upstream provider before saving the MCP server config.
+func (api *API) mcpOAuth2CallbackURL() string {
+	return api.AccessURL.String() + mcpOAuth2GlobalCallbackPath
+}
+
+// mcpOAuth2StateNonceSize is the number of random bytes embedded in a
+// signed OAuth2 state. 16 bytes is plenty for collision resistance
+// over a 10-minute window.
+const mcpOAuth2StateNonceSize = 16
+
+// signMCPOAuth2State produces an opaque, single-use, server-pinned
+// state value of the form `base64url(serverID || nonce) || "." ||
+// base64url(hmac)`. The decoded server ID is recovered in the
+// callback to identify which MCP server config the authorization
+// belongs to. The HMAC, computed over the encoded payload using
+// api.OAuthSigningKey, prevents an attacker from substituting a
+// different server ID in the state. CSRF is additionally enforced
+// by a per-server cookie that pins the nonce.
+func (api *API) signMCPOAuth2State(serverID uuid.UUID) (state, nonce string, err error) {
+	rawNonce, err := cryptorand.String(mcpOAuth2StateNonceSize)
+	if err != nil {
+		return "", "", xerrors.Errorf("generate oauth2 state nonce: %w", err)
+	}
+	payload := append([]byte{}, serverID[:]...)
+	payload = append(payload, []byte(":"+rawNonce)...)
+	encoded := base64.RawURLEncoding.EncodeToString(payload)
+	mac := hmac.New(sha256.New, api.OAuthSigningKey[:])
+	_, _ = mac.Write([]byte(encoded))
+	sig := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	return encoded + "." + sig, rawNonce, nil
+}
+
+// verifyMCPOAuth2State parses a signed OAuth2 state and returns the
+// embedded server ID and nonce. It returns an error when the state
+// is malformed or the HMAC does not validate.
+func (api *API) verifyMCPOAuth2State(state string) (serverID uuid.UUID, nonce string, err error) {
+	encoded, sig, ok := strings.Cut(state, ".")
+	if !ok {
+		return uuid.Nil, "", xerrors.New("oauth2 state is malformed")
+	}
+	mac := hmac.New(sha256.New, api.OAuthSigningKey[:])
+	_, _ = mac.Write([]byte(encoded))
+	expectedSig, err := base64.RawURLEncoding.DecodeString(sig)
+	if err != nil {
+		return uuid.Nil, "", xerrors.Errorf("decode oauth2 state signature: %w", err)
+	}
+	if !hmac.Equal(mac.Sum(nil), expectedSig) {
+		return uuid.Nil, "", xerrors.New("oauth2 state signature mismatch")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		return uuid.Nil, "", xerrors.Errorf("decode oauth2 state payload: %w", err)
+	}
+	if len(payload) <= len(uuid.Nil)+1 || payload[len(uuid.Nil)] != ':' {
+		return uuid.Nil, "", xerrors.New("oauth2 state payload is malformed")
+	}
+	copy(serverID[:], payload[:len(uuid.Nil)])
+	nonce = string(payload[len(uuid.Nil)+1:])
+	return serverID, nonce, nil
+}
 
 // oidcMCPTokenSource implements mcpclient.UserOIDCTokenSource using
 // the same refresh strategy as provisionerdserver.ObtainOIDCAccessToken.
@@ -243,89 +326,18 @@ func (api *API) createMCPServerConfig(rw http.ResponseWriter, r *http.Request) {
 		// using the MCP server URL.  This follows the MCP authorization
 		// spec: discover the authorization server via Protected Resource
 		// Metadata (RFC 9728) and Authorization Server Metadata
-		// (RFC 8414), then register a client dynamically.
+		// (RFC 8414), then register a client dynamically. The redirect
+		// URI registered with the upstream provider is the deployment-
+		// wide MCP OAuth2 callback, so we can register before the
+		// MCP server config row even exists.
 		if req.OAuth2ClientID == "" && req.OAuth2AuthURL == "" && req.OAuth2TokenURL == "" {
-			// Auto-discovery flow: we need the config ID first to
-			// build the correct callback URL.  Insert the record
-			// with empty OAuth2 fields, perform discovery, then
-			// update.
-			customHeadersJSON, err := marshalCustomHeaders(req.CustomHeaders)
-			if err != nil {
-				httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-					Message: "Invalid custom headers.",
-					Detail:  err.Error(),
-				})
-				return
-			}
-
-			inserted, err := api.Database.InsertMCPServerConfig(ctx, database.InsertMCPServerConfigParams{
-				DisplayName:             strings.TrimSpace(req.DisplayName),
-				Slug:                    strings.TrimSpace(req.Slug),
-				Description:             strings.TrimSpace(req.Description),
-				IconURL:                 strings.TrimSpace(req.IconURL),
-				Transport:               strings.TrimSpace(req.Transport),
-				Url:                     strings.TrimSpace(req.URL),
-				AuthType:                strings.TrimSpace(req.AuthType),
-				OAuth2ClientID:          "",
-				OAuth2ClientSecret:      "",
-				OAuth2ClientSecretKeyID: sql.NullString{},
-				OAuth2AuthURL:           "",
-				OAuth2TokenURL:          "",
-				OAuth2Scopes:            "",
-				APIKeyHeader:            strings.TrimSpace(req.APIKeyHeader),
-				APIKeyValue:             strings.TrimSpace(req.APIKeyValue),
-				APIKeyValueKeyID:        sql.NullString{},
-				CustomHeaders:           customHeadersJSON,
-				CustomHeadersKeyID:      sql.NullString{},
-				ToolAllowList:           coalesceStringSlice(trimStringSlice(req.ToolAllowList)),
-				ToolDenyList:            coalesceStringSlice(trimStringSlice(req.ToolDenyList)),
-				Availability:            strings.TrimSpace(req.Availability),
-				Enabled:                 req.Enabled,
-				ModelIntent:             req.ModelIntent,
-				AllowInPlanMode:         req.AllowInPlanMode,
-				CreatedBy:               apiKey.UserID,
-				UpdatedBy:               apiKey.UserID,
-			})
-			if err != nil {
-				switch {
-				case database.IsUniqueViolation(err):
-					httpapi.Write(ctx, rw, http.StatusConflict, codersdk.Response{
-						Message: "MCP server config already exists.",
-						Detail:  err.Error(),
-					})
-					return
-				case database.IsCheckViolation(err):
-					httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-						Message: "Invalid MCP server config.",
-						Detail:  err.Error(),
-					})
-					return
-				default:
-					httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-						Message: "Failed to create MCP server config.",
-						Detail:  err.Error(),
-					})
-					return
-				}
-			}
-
-			// Now build the callback URL with the actual ID.
-			callbackURL := fmt.Sprintf("%s/api/experimental/mcp/servers/%s/oauth2/callback", api.AccessURL.String(), inserted.ID)
+			callbackURL := api.mcpOAuth2CallbackURL()
 			httpClient := api.HTTPClient
 			if httpClient == nil {
 				httpClient = &http.Client{Timeout: 30 * time.Second}
 			}
 			result, err := discoverAndRegisterMCPOAuth2(ctx, httpClient, strings.TrimSpace(req.URL), callbackURL)
 			if err != nil {
-				// Clean up: delete the partially created config.
-				deleteErr := api.Database.DeleteMCPServerConfigByID(ctx, inserted.ID)
-				if deleteErr != nil {
-					api.Logger.Warn(ctx, "failed to clean up MCP server config after OAuth2 discovery failure",
-						slog.F("config_id", inserted.ID),
-						slog.Error(deleteErr),
-					)
-				}
-
 				api.Logger.Warn(ctx, "mcp oauth2 auto-discovery failed",
 					slog.F("url", req.URL),
 					slog.Error(err),
@@ -344,45 +356,14 @@ func (api *API) createMCPServerConfig(rw http.ResponseWriter, r *http.Request) {
 				oauth2Scopes = result.scopes
 			}
 
-			// Update the record with discovered OAuth2 credentials.
-			updated, err := api.Database.UpdateMCPServerConfig(ctx, database.UpdateMCPServerConfigParams{
-				ID:                      inserted.ID,
-				DisplayName:             inserted.DisplayName,
-				Slug:                    inserted.Slug,
-				Description:             inserted.Description,
-				IconURL:                 inserted.IconURL,
-				Transport:               inserted.Transport,
-				Url:                     inserted.Url,
-				AuthType:                inserted.AuthType,
-				OAuth2ClientID:          result.clientID,
-				OAuth2ClientSecret:      result.clientSecret,
-				OAuth2ClientSecretKeyID: sql.NullString{},
-				OAuth2AuthURL:           result.authURL,
-				OAuth2TokenURL:          result.tokenURL,
-				OAuth2Scopes:            oauth2Scopes,
-				APIKeyHeader:            inserted.APIKeyHeader,
-				APIKeyValue:             inserted.APIKeyValue,
-				APIKeyValueKeyID:        inserted.APIKeyValueKeyID,
-				CustomHeaders:           inserted.CustomHeaders,
-				CustomHeadersKeyID:      inserted.CustomHeadersKeyID,
-				ToolAllowList:           inserted.ToolAllowList,
-				ToolDenyList:            inserted.ToolDenyList,
-				Availability:            inserted.Availability,
-				Enabled:                 inserted.Enabled,
-				ModelIntent:             inserted.ModelIntent,
-				AllowInPlanMode:         inserted.AllowInPlanMode,
-				UpdatedBy:               apiKey.UserID,
-			})
-			if err != nil {
-				httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-					Message: "Failed to update MCP server config with OAuth2 credentials.",
-					Detail:  err.Error(),
-				})
-				return
-			}
-
-			httpapi.Write(ctx, rw, http.StatusCreated, convertMCPServerConfig(updated))
-			return
+			// Promote the discovered credentials onto the request so
+			// the single InsertMCPServerConfig below covers both the
+			// manual and the auto-discovery paths.
+			req.OAuth2ClientID = result.clientID
+			req.OAuth2ClientSecret = result.clientSecret
+			req.OAuth2AuthURL = result.authURL
+			req.OAuth2TokenURL = result.tokenURL
+			req.OAuth2Scopes = oauth2Scopes
 		} else if req.OAuth2ClientID == "" || req.OAuth2AuthURL == "" || req.OAuth2TokenURL == "" {
 			// Partial manual config: all three fields are required together.
 			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
@@ -390,6 +371,7 @@ func (api *API) createMCPServerConfig(rw http.ResponseWriter, r *http.Request) {
 			})
 			return
 		}
+
 	case "api_key":
 		if req.APIKeyHeader == "" || req.APIKeyValue == "" {
 			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
@@ -855,6 +837,27 @@ func (api *API) deleteMCPServerConfig(rw http.ResponseWriter, r *http.Request) {
 	rw.WriteHeader(http.StatusNoContent)
 }
 
+// @Summary Get the deployment-wide MCP OAuth2 callback URL
+// @x-apidocgen {"skip": true}
+// EXPERIMENTAL: this endpoint is experimental and is subject to change.
+// Returns the absolute redirect URI an admin should register with an
+// upstream OAuth2 provider when configuring an MCP server. Surfacing
+// this server-side avoids drift between the client view of the access
+// URL (e.g. via dashboard URL or a reverse proxy) and the actual
+// AccessURL we send during the OAuth2 token exchange.
+//
+//nolint:revive // HTTP handler writes to ResponseWriter.
+func (api *API) mcpOAuth2CallbackInfo(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if !api.Authorize(r, policy.ActionRead, rbac.ResourceDeploymentConfig) {
+		httpapi.Forbidden(rw)
+		return
+	}
+	httpapi.Write(ctx, rw, http.StatusOK, codersdk.MCPOAuth2CallbackInfo{
+		CallbackURL: api.mcpOAuth2CallbackURL(),
+	})
+}
+
 // @Summary Initiate MCP server OAuth2 connect
 // @x-apidocgen {"skip": true}
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
@@ -906,12 +909,22 @@ func (api *API) mcpServerOAuth2Connect(rw http.ResponseWriter, r *http.Request) 
 
 	// Build the authorization URL. The frontend opens this in a popup.
 	// The callback URL is on our server; after the exchange we store
-	// the token and close the popup.
-	state := uuid.New().String()
-	callbackPath := fmt.Sprintf("/api/experimental/mcp/servers/%s/oauth2/callback", config.ID)
+	// the token and close the popup. The callback path is
+	// deployment-wide; the server ID is carried in a signed state
+	// parameter, which lets admins register a single redirect URI
+	// per upstream provider before the MCP server config exists.
+	state, nonce, err := api.signMCPOAuth2State(config.ID)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+			Message: "Failed to generate OAuth2 state.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+	callbackPath := mcpOAuth2GlobalCallbackPath
 	http.SetCookie(rw, api.DeploymentValues.HTTPCookies.Apply(&http.Cookie{
 		Name:     "mcp_oauth2_state_" + config.ID.String(),
-		Value:    state,
+		Value:    nonce,
 		Path:     callbackPath,
 		MaxAge:   600, // 10 minutes
 		HttpOnly: true,
@@ -938,7 +951,7 @@ func (api *API) mcpServerOAuth2Connect(rw http.ResponseWriter, r *http.Request) 
 			AuthURL:  config.OAuth2AuthURL,
 			TokenURL: config.OAuth2TokenURL,
 		},
-		RedirectURL: fmt.Sprintf("%s%s", api.AccessURL.String(), callbackPath),
+		RedirectURL: api.mcpOAuth2CallbackURL(),
 	}
 	var scopes []string
 	if config.OAuth2Scopes != "" {
@@ -949,20 +962,99 @@ func (api *API) mcpServerOAuth2Connect(rw http.ResponseWriter, r *http.Request) 
 	http.Redirect(rw, r, authURL, http.StatusTemporaryRedirect)
 }
 
-// @Summary Handle MCP server OAuth2 callback
+// @Summary Handle MCP server OAuth2 callback (legacy per-ID)
 // @x-apidocgen {"skip": true}
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
-// Exchanges the authorization code for tokens and stores them.
+// Exchanges the authorization code for tokens and stores them. New
+// flows use the deployment-wide global callback instead; this handler
+// is retained so any client previously registered with an upstream
+// provider against `${access_url}/api/experimental/mcp/servers/{id}
+// /oauth2/callback` keeps working.
 //
 //nolint:revive // HTTP handler writes to ResponseWriter.
 func (api *API) mcpServerOAuth2Callback(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	apiKey := httpmw.APIKey(r)
 
 	mcpServerID, ok := parseMCPServerConfigID(rw, r)
 	if !ok {
 		return
 	}
+
+	callbackPath := fmt.Sprintf("/api/experimental/mcp/servers/%s/oauth2/callback", mcpServerID)
+	redirectURL := fmt.Sprintf("%s%s", api.AccessURL.String(), callbackPath)
+
+	api.completeMCPServerOAuth2(ctx, rw, r, mcpServerID, callbackPath, redirectURL)
+}
+
+// @Summary Handle MCP server OAuth2 callback (deployment-wide)
+// @x-apidocgen {"skip": true}
+// EXPERIMENTAL: this endpoint is experimental and is subject to change.
+// Decodes the signed `state` parameter to identify the MCP server
+// config, then completes the OAuth2 token exchange. The single,
+// deployment-wide callback URL means admins can register one redirect
+// URI with each upstream OAuth2 provider before they create the MCP
+// server config in Coder.
+//
+//nolint:revive // HTTP handler writes to ResponseWriter.
+func (api *API) mcpServerOAuth2GlobalCallback(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	// The OAuth2 provider may redirect with an error parameter and no
+	// state (some providers do, e.g., when the user denies consent
+	// before any code is issued). Surface that error directly so the
+	// admin sees the upstream message.
+	if oauthError := r.URL.Query().Get("error"); oauthError != "" {
+		desc := r.URL.Query().Get("error_description")
+		if desc == "" {
+			desc = oauthError
+		}
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "OAuth2 provider returned an error.",
+			Detail:  desc,
+		})
+		return
+	}
+
+	rawState := r.URL.Query().Get("state")
+	if rawState == "" {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "Missing OAuth2 state parameter.",
+		})
+		return
+	}
+
+	serverID, _, err := api.verifyMCPOAuth2State(rawState)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "Invalid OAuth2 state parameter.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
+	callbackPath := mcpOAuth2GlobalCallbackPath
+	redirectURL := api.mcpOAuth2CallbackURL()
+
+	api.completeMCPServerOAuth2(ctx, rw, r, serverID, callbackPath, redirectURL)
+}
+
+// completeMCPServerOAuth2 contains the OAuth2 token exchange logic
+// shared by the per-ID (legacy) and deployment-wide (current)
+// callback handlers. callbackPath is the path the cookies are scoped
+// to (so they get cleared with a matching path); redirectURL is the
+// absolute URL we send to the upstream provider during the exchange,
+// which must match the URL the user was redirected back to.
+//
+//nolint:revive // HTTP handler writes to ResponseWriter.
+func (api *API) completeMCPServerOAuth2(
+	ctx context.Context,
+	rw http.ResponseWriter,
+	r *http.Request,
+	mcpServerID uuid.UUID,
+	callbackPath string,
+	redirectURL string,
+) {
+	apiKey := httpmw.APIKey(r)
 
 	//nolint:gocritic // Any authenticated user can complete OAuth2 for an enabled MCP server.
 	config, err := api.Database.GetMCPServerConfigByID(dbauthz.AsSystemRestricted(ctx), mcpServerID)
@@ -1014,20 +1106,27 @@ func (api *API) mcpServerOAuth2Callback(rw http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Validate the state parameter for CSRF protection.
-	expectedState := ""
+	// Validate the state cookie for CSRF protection. The cookie was
+	// set during connect with one of two value semantics:
+	//   - legacy per-ID flow: cookie value equals the raw state
+	//     parameter sent on the auth URL.
+	//   - global flow: cookie value equals the nonce embedded in the
+	//     signed state parameter; the server ID is decoded from the
+	//     state itself.
+	// In either case, presence of the per-server cookie proves the
+	// callback was initiated from the same browser session.
+	cookieValue := ""
 	if cookie, err := r.Cookie("mcp_oauth2_state_" + config.ID.String()); err == nil {
-		expectedState = cookie.Value
+		cookieValue = cookie.Value
 	}
-	actualState := r.URL.Query().Get("state")
-	if expectedState == "" || actualState != expectedState {
+	rawState := r.URL.Query().Get("state")
+	if cookieValue == "" || !mcpOAuth2StateMatchesCookie(rawState, cookieValue) {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Invalid or missing OAuth2 state parameter.",
 		})
 		return
 	}
 	// Clear the state cookie.
-	callbackPath := fmt.Sprintf("/api/experimental/mcp/servers/%s/oauth2/callback", config.ID)
 	http.SetCookie(rw, api.DeploymentValues.HTTPCookies.Apply(&http.Cookie{
 		Name:     "mcp_oauth2_state_" + config.ID.String(),
 		Value:    "",
@@ -1060,7 +1159,7 @@ func (api *API) mcpServerOAuth2Callback(rw http.ResponseWriter, r *http.Request)
 			AuthURL:  config.OAuth2AuthURL,
 			TokenURL: config.OAuth2TokenURL,
 		},
-		RedirectURL: fmt.Sprintf("%s%s", api.AccessURL.String(), callbackPath),
+		RedirectURL: redirectURL,
 	}
 	var scopes []string
 	if config.OAuth2Scopes != "" {
@@ -1120,13 +1219,33 @@ func (api *API) mcpServerOAuth2Callback(rw http.ResponseWriter, r *http.Request)
 	rw.Header().Set("Content-Type", "text/html; charset=utf-8")
 	rw.WriteHeader(http.StatusOK)
 	_, _ = rw.Write([]byte(`<!DOCTYPE html><html><body><script>
-		if (window.opener) {
-			window.opener.postMessage({type: "mcp-oauth2-complete", serverID: "` + config.ID.String() + `"}, "` + api.AccessURL.String() + `");
-			window.close();
-		} else {
-			document.body.innerText = "Authentication successful. You may close this window.";
-		}
-	</script></body></html>`))
+			if (window.opener) {
+				window.opener.postMessage({type: "mcp-oauth2-complete", serverID: "` + config.ID.String() + `"}, "` + api.AccessURL.String() + `");
+				window.close();
+			} else {
+				document.body.innerText = "Authentication successful. You may close this window.";
+			}
+		</script></body></html>`))
+}
+
+// mcpOAuth2StateMatchesCookie returns true when the state parameter
+// is consistent with the per-server cookie. For the legacy per-ID
+// flow, the cookie holds the raw state directly; for the global
+// flow, the cookie holds only the nonce portion of the signed state.
+func mcpOAuth2StateMatchesCookie(state, cookieValue string) bool {
+	if state == cookieValue {
+		return true
+	}
+	encoded, _, ok := strings.Cut(state, ".")
+	if !ok {
+		return false
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil || len(payload) <= len(uuid.Nil)+1 || payload[len(uuid.Nil)] != ':' {
+		return false
+	}
+	nonce := string(payload[len(uuid.Nil)+1:])
+	return nonce == cookieValue
 }
 
 // @Summary Disconnect MCP server OAuth2 token

--- a/coderd/mcp.go
+++ b/coderd/mcp.go
@@ -962,28 +962,25 @@ func (api *API) mcpServerOAuth2Connect(rw http.ResponseWriter, r *http.Request) 
 	http.Redirect(rw, r, authURL, http.StatusTemporaryRedirect)
 }
 
-// @Summary Handle MCP server OAuth2 callback (legacy per-ID)
+// @Summary Redirect legacy per-ID MCP OAuth2 callback to the global one
 // @x-apidocgen {"skip": true}
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
-// Exchanges the authorization code for tokens and stores them. New
-// flows use the deployment-wide global callback instead; this handler
-// is retained so any client previously registered with an upstream
-// provider against `${access_url}/api/experimental/mcp/servers/{id}
-// /oauth2/callback` keeps working.
+// 307-redirects to the deployment-wide callback, preserving the
+// query string. This handler exists only so any client previously
+// registered with an upstream provider against
+// `${access_url}/api/experimental/mcp/servers/{id}/oauth2/callback`
+// keeps working. New flows hit the global callback directly. The
+// `mcpServer` path parameter is intentionally ignored; the MCP server
+// ID is decoded from the signed `state` parameter on the global
+// handler.
 //
 //nolint:revive // HTTP handler writes to ResponseWriter.
 func (api *API) mcpServerOAuth2Callback(rw http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-
-	mcpServerID, ok := parseMCPServerConfigID(rw, r)
-	if !ok {
-		return
+	target := mcpOAuth2GlobalCallbackPath
+	if raw := r.URL.RawQuery; raw != "" {
+		target += "?" + raw
 	}
-
-	callbackPath := fmt.Sprintf("/api/experimental/mcp/servers/%s/oauth2/callback", mcpServerID)
-	redirectURL := fmt.Sprintf("%s%s", api.AccessURL.String(), callbackPath)
-
-	api.completeMCPServerOAuth2(ctx, rw, r, mcpServerID, callbackPath, redirectURL)
+	http.Redirect(rw, r, target, http.StatusTemporaryRedirect)
 }
 
 // @Summary Handle MCP server OAuth2 callback (deployment-wide)
@@ -998,6 +995,7 @@ func (api *API) mcpServerOAuth2Callback(rw http.ResponseWriter, r *http.Request)
 //nolint:revive // HTTP handler writes to ResponseWriter.
 func (api *API) mcpServerOAuth2GlobalCallback(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+	apiKey := httpmw.APIKey(r)
 
 	// The OAuth2 provider may redirect with an error parameter and no
 	// state (some providers do, e.g., when the user denies consent
@@ -1023,7 +1021,7 @@ func (api *API) mcpServerOAuth2GlobalCallback(rw http.ResponseWriter, r *http.Re
 		return
 	}
 
-	serverID, _, err := api.verifyMCPOAuth2State(rawState)
+	serverID, nonce, err := api.verifyMCPOAuth2State(rawState)
 	if err != nil {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Invalid OAuth2 state parameter.",
@@ -1032,32 +1030,16 @@ func (api *API) mcpServerOAuth2GlobalCallback(rw http.ResponseWriter, r *http.Re
 		return
 	}
 
-	callbackPath := mcpOAuth2GlobalCallbackPath
-	redirectURL := api.mcpOAuth2CallbackURL()
-
-	api.completeMCPServerOAuth2(ctx, rw, r, serverID, callbackPath, redirectURL)
-}
-
-// completeMCPServerOAuth2 contains the OAuth2 token exchange logic
-// shared by the per-ID (legacy) and deployment-wide (current)
-// callback handlers. callbackPath is the path the cookies are scoped
-// to (so they get cleared with a matching path); redirectURL is the
-// absolute URL we send to the upstream provider during the exchange,
-// which must match the URL the user was redirected back to.
-//
-//nolint:revive // HTTP handler writes to ResponseWriter.
-func (api *API) completeMCPServerOAuth2(
-	ctx context.Context,
-	rw http.ResponseWriter,
-	r *http.Request,
-	mcpServerID uuid.UUID,
-	callbackPath string,
-	redirectURL string,
-) {
-	apiKey := httpmw.APIKey(r)
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "Missing authorization code.",
+		})
+		return
+	}
 
 	//nolint:gocritic // Any authenticated user can complete OAuth2 for an enabled MCP server.
-	config, err := api.Database.GetMCPServerConfigByID(dbauthz.AsSystemRestricted(ctx), mcpServerID)
+	config, err := api.Database.GetMCPServerConfigByID(dbauthz.AsSystemRestricted(ctx), serverID)
 	if err != nil {
 		if httpapi.Is404Error(err) {
 			httpapi.ResourceNotFound(rw)
@@ -1084,48 +1066,21 @@ func (api *API) completeMCPServerOAuth2(
 		return
 	}
 
-	// Check if the OAuth2 provider returned an error (e.g., user
-	// denied consent).
-	if oauthError := r.URL.Query().Get("error"); oauthError != "" {
-		desc := r.URL.Query().Get("error_description")
-		if desc == "" {
-			desc = oauthError
-		}
-		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-			Message: "OAuth2 provider returned an error.",
-			Detail:  desc,
-		})
-		return
-	}
-
-	code := r.URL.Query().Get("code")
-	if code == "" {
-		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-			Message: "Missing authorization code.",
-		})
-		return
-	}
-
-	// Validate the state cookie for CSRF protection. The cookie was
-	// set during connect with one of two value semantics:
-	//   - legacy per-ID flow: cookie value equals the raw state
-	//     parameter sent on the auth URL.
-	//   - global flow: cookie value equals the nonce embedded in the
-	//     signed state parameter; the server ID is decoded from the
-	//     state itself.
-	// In either case, presence of the per-server cookie proves the
-	// callback was initiated from the same browser session.
+	// CSRF: the per-server cookie set during /connect must equal the
+	// nonce embedded in the signed state. The cookie pins the
+	// authorization to the browser session that initiated it; the HMAC
+	// on state pins the server ID so an attacker cannot swap it.
 	cookieValue := ""
 	if cookie, err := r.Cookie("mcp_oauth2_state_" + config.ID.String()); err == nil {
 		cookieValue = cookie.Value
 	}
-	rawState := r.URL.Query().Get("state")
-	if cookieValue == "" || !mcpOAuth2StateMatchesCookie(rawState, cookieValue) {
+	if cookieValue == "" || cookieValue != nonce {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message: "Invalid or missing OAuth2 state parameter.",
 		})
 		return
 	}
+	callbackPath := mcpOAuth2GlobalCallbackPath
 	// Clear the state cookie.
 	http.SetCookie(rw, api.DeploymentValues.HTTPCookies.Apply(&http.Cookie{
 		Name:     "mcp_oauth2_state_" + config.ID.String(),
@@ -1159,7 +1114,7 @@ func (api *API) completeMCPServerOAuth2(
 			AuthURL:  config.OAuth2AuthURL,
 			TokenURL: config.OAuth2TokenURL,
 		},
-		RedirectURL: redirectURL,
+		RedirectURL: api.mcpOAuth2CallbackURL(),
 	}
 	var scopes []string
 	if config.OAuth2Scopes != "" {
@@ -1197,7 +1152,7 @@ func (api *API) completeMCPServerOAuth2(
 
 	//nolint:gocritic // Users store their own tokens.
 	_, err = api.Database.UpsertMCPServerUserToken(dbauthz.AsSystemRestricted(ctx), database.UpsertMCPServerUserTokenParams{
-		MCPServerConfigID: mcpServerID,
+		MCPServerConfigID: config.ID,
 		UserID:            apiKey.UserID,
 		AccessToken:       token.AccessToken,
 		AccessTokenKeyID:  sql.NullString{},
@@ -1226,26 +1181,6 @@ func (api *API) completeMCPServerOAuth2(
 				document.body.innerText = "Authentication successful. You may close this window.";
 			}
 		</script></body></html>`))
-}
-
-// mcpOAuth2StateMatchesCookie returns true when the state parameter
-// is consistent with the per-server cookie. For the legacy per-ID
-// flow, the cookie holds the raw state directly; for the global
-// flow, the cookie holds only the nonce portion of the signed state.
-func mcpOAuth2StateMatchesCookie(state, cookieValue string) bool {
-	if state == cookieValue {
-		return true
-	}
-	encoded, _, ok := strings.Cut(state, ".")
-	if !ok {
-		return false
-	}
-	payload, err := base64.RawURLEncoding.DecodeString(encoded)
-	if err != nil || len(payload) <= len(uuid.Nil)+1 || payload[len(uuid.Nil)] != ':' {
-		return false
-	}
-	nonce := string(payload[len(uuid.Nil)+1:])
-	return nonce == cookieValue
 }
 
 // @Summary Disconnect MCP server OAuth2 token

--- a/coderd/mcp_internal_test.go
+++ b/coderd/mcp_internal_test.go
@@ -2,6 +2,7 @@ package coderd
 
 import (
 	"context"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -247,15 +248,52 @@ func TestMCPOAuth2StateRejectsTampered(t *testing.T) {
 	state, _, err := api.signMCPOAuth2State(uuid.New())
 	require.NoError(t, err)
 
-	// Flipping the last byte of the signature must fail HMAC
-	// verification.
-	tampered := state[:len(state)-1] + string(state[len(state)-1]^0x01)
+	// Flipping a byte inside the signature must fail HMAC
+	// verification. We pick the first character after the
+	// payload-signature delimiter so it is always a payload bit
+	// of the signature, never a base64 padding bit.
+	dotIdx := strings.Index(state, ".")
+	require.Greater(t, dotIdx, 0)
+	flipped := flipBase64URLChar(state[dotIdx+1])
+	tampered := state[:dotIdx+1] + string(flipped) + state[dotIdx+2:]
+	require.NotEqual(t, state, tampered, "tampered state must differ")
 	_, _, err = api.verifyMCPOAuth2State(tampered)
 	require.Error(t, err)
 
 	// Garbage in is rejected too.
 	_, _, err = api.verifyMCPOAuth2State("garbage")
 	require.Error(t, err)
+
+	// Empty input is rejected.
+	_, _, err = api.verifyMCPOAuth2State("")
+	require.Error(t, err)
+}
+
+// flipBase64URLChar returns a different valid base64url character
+// (deterministically, by mapping each character to the next one in
+// the alphabet). Used by tests to produce a tampered signature that
+// is still well-formed base64url but decodes to different bytes.
+func flipBase64URLChar(c byte) byte {
+	switch {
+	case c >= 'A' && c < 'Z':
+		return c + 1
+	case c == 'Z':
+		return 'a'
+	case c >= 'a' && c < 'z':
+		return c + 1
+	case c == 'z':
+		return '0'
+	case c >= '0' && c < '9':
+		return c + 1
+	case c == '9':
+		return '-'
+	case c == '-':
+		return '_'
+	case c == '_':
+		return 'A'
+	default:
+		return 'A'
+	}
 }
 
 func TestMCPOAuth2StateRejectsDifferentKey(t *testing.T) {

--- a/coderd/mcp_internal_test.go
+++ b/coderd/mcp_internal_test.go
@@ -214,3 +214,59 @@ func TestOIDCMCPTokenSource(t *testing.T) {
 		require.Empty(t, tok)
 	})
 }
+
+func newMCPOAuth2TestAPI(keyByte byte) *API {
+	api := &API{Options: &Options{}}
+	for i := range api.OAuthSigningKey {
+		api.OAuthSigningKey[i] = keyByte + byte(i)
+	}
+	return api
+}
+
+func TestMCPOAuth2StateRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	api := newMCPOAuth2TestAPI(1)
+	original := uuid.New()
+
+	state, nonce, err := api.signMCPOAuth2State(original)
+	require.NoError(t, err)
+	require.NotEmpty(t, state)
+	require.NotEmpty(t, nonce)
+
+	got, gotNonce, err := api.verifyMCPOAuth2State(state)
+	require.NoError(t, err)
+	require.Equal(t, original, got)
+	require.Equal(t, nonce, gotNonce)
+}
+
+func TestMCPOAuth2StateRejectsTampered(t *testing.T) {
+	t.Parallel()
+
+	api := newMCPOAuth2TestAPI(1)
+	state, _, err := api.signMCPOAuth2State(uuid.New())
+	require.NoError(t, err)
+
+	// Flipping the last byte of the signature must fail HMAC
+	// verification.
+	tampered := state[:len(state)-1] + string(state[len(state)-1]^0x01)
+	_, _, err = api.verifyMCPOAuth2State(tampered)
+	require.Error(t, err)
+
+	// Garbage in is rejected too.
+	_, _, err = api.verifyMCPOAuth2State("garbage")
+	require.Error(t, err)
+}
+
+func TestMCPOAuth2StateRejectsDifferentKey(t *testing.T) {
+	t.Parallel()
+
+	signer := newMCPOAuth2TestAPI(1)
+	verifier := newMCPOAuth2TestAPI(2)
+
+	state, _, err := signer.signMCPOAuth2State(uuid.New())
+	require.NoError(t, err)
+
+	_, _, err = verifier.verifyMCPOAuth2State(state)
+	require.Error(t, err, "signature must not validate under a different key")
+}

--- a/coderd/mcp_test.go
+++ b/coderd/mcp_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/coder/coder/v2/coderd"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/testutil"
@@ -892,7 +893,7 @@ func TestMCPServerConfigsOAuth2AutoDiscovery(t *testing.T) {
 	// fix, the callback URL was built before the config row existed,
 	// so it contained "{id}" literally, which caused "redirect URIs
 	// not approved" errors when the user later tried to connect.
-	t.Run("RedirectURIContainsRealConfigID", func(t *testing.T) {
+	t.Run("RedirectURIIsDeploymentWide", func(t *testing.T) {
 		t.Parallel()
 
 		ctx := testutil.Context(t, testutil.WaitLong)
@@ -990,37 +991,18 @@ func TestMCPServerConfigsOAuth2AutoDiscovery(t *testing.T) {
 			t.Fatal("timed out waiting for registration redirect URI")
 		}
 
-		// Core assertion: the redirect URI must NOT contain the
-		// literal placeholder "{id}".  Before the fix the callback
-		// URL was built before the database insert, so it had
-		// "{id}" where the UUID should be.
+		// The redirect URI must be the deployment-wide MCP OAuth2
+		// callback. The MCP server config UUID must NOT appear in the
+		// path; that is the whole point of the global callback. The
+		// admin can register one redirect URI per upstream provider
+		// before any MCP server config exists.
+		require.True(t, strings.HasSuffix(redirectURI, coderd.MCPOAuth2GlobalCallbackPath()),
+			"redirect URI %q should end with the deployment-wide MCP OAuth2 callback path %q",
+			redirectURI, coderd.MCPOAuth2GlobalCallbackPath())
+		require.NotContains(t, redirectURI, created.ID.String(),
+			"redirect URI must not contain the MCP server config UUID; the global callback identifies the server via signed state")
 		require.NotContains(t, redirectURI, "{id}",
-			"redirect URI sent during registration must not contain the literal \"{id}\" placeholder")
-
-		// Verify the redirect URI contains the real config UUID that
-		// was assigned by the database.
-		require.Contains(t, redirectURI, created.ID.String(),
-			"redirect URI should contain the actual config UUID")
-
-		// Sanity-check the full path structure.
-		require.Contains(t, redirectURI,
-			"/api/experimental/mcp/servers/"+created.ID.String()+"/oauth2/callback",
-			"redirect URI should have the expected callback path")
-
-		// Double-check that the ID segment is a valid UUID (not some
-		// other placeholder or malformed value).
-		pathParts := strings.Split(redirectURI, "/")
-		var foundUUID bool
-		for _, part := range pathParts {
-			if _, err := uuid.Parse(part); err == nil {
-				foundUUID = true
-				require.Equal(t, created.ID.String(), part,
-					"UUID in redirect URI path should match created config ID")
-				break
-			}
-		}
-		require.True(t, foundUUID,
-			"redirect URI path should contain a valid UUID segment")
+			"redirect URI must not contain the literal \"{id}\" placeholder")
 	})
 
 	t.Run("PartialOAuth2FieldsRejected", func(t *testing.T) {
@@ -1942,5 +1924,293 @@ func TestMCPOAuth2DiscoveryEdgeCases(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "trailing-slash-client", created.OAuth2ClientID)
 		require.True(t, created.HasOAuth2Secret)
+	})
+}
+
+func TestMCPServerOAuth2GlobalCallback(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ConnectUsesGlobalRedirectURI", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		adminClient := newMCPClient(t)
+		firstUser := coderdtest.CreateFirstUser(t, adminClient)
+		memberClient, _ := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID)
+
+		created, err := adminClient.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+			DisplayName:    "Global Connect",
+			Slug:           "global-connect",
+			Transport:      "streamable_http",
+			URL:            "https://mcp.example.com/global-connect",
+			AuthType:       "oauth2",
+			OAuth2ClientID: "test-client",
+			OAuth2AuthURL:  "https://auth.example.com/authorize",
+			OAuth2TokenURL: "https://auth.example.com/token",
+			Availability:   "default_on",
+			Enabled:        true,
+			ToolAllowList:  []string{},
+			ToolDenyList:   []string{},
+		})
+		require.NoError(t, err)
+
+		memberClient.HTTPClient.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+
+		connectURL, err := memberClient.URL.Parse(
+			"/api/experimental/mcp/servers/" + created.ID.String() + "/oauth2/connect",
+		)
+		require.NoError(t, err)
+
+		req, err := http.NewRequestWithContext(ctx, "GET", connectURL.String(), nil)
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{
+			Name:  codersdk.SessionTokenCookie,
+			Value: memberClient.SessionToken(),
+		})
+
+		res, err := memberClient.HTTPClient.Do(req)
+		require.NoError(t, err)
+		defer res.Body.Close()
+
+		require.Equal(t, http.StatusTemporaryRedirect, res.StatusCode)
+
+		location, err := res.Location()
+		require.NoError(t, err)
+
+		// The upstream auth URL must include redirect_uri pointing
+		// at the deployment-wide callback. The MCP server config
+		// UUID must NOT be embedded in that URL.
+		gotRedirectURI := location.Query().Get("redirect_uri")
+		require.NotEmpty(t, gotRedirectURI)
+		require.True(t, strings.HasSuffix(gotRedirectURI, coderd.MCPOAuth2GlobalCallbackPath()),
+			"redirect_uri %q should end with %q", gotRedirectURI, coderd.MCPOAuth2GlobalCallbackPath())
+		require.NotContains(t, gotRedirectURI, created.ID.String(),
+			"redirect_uri must not contain the MCP server config UUID")
+
+		// State must be the signed token, not a bare UUID.
+		state := location.Query().Get("state")
+		require.NotEmpty(t, state)
+		_, err = uuid.Parse(state)
+		require.Error(t, err, "state must not be a bare UUID; it must be the signed token")
+		require.Contains(t, state, ".",
+			"signed state has a payload-signature delimiter")
+
+		// Cookies should be scoped to the global callback path.
+		var stateCookie, verifierCookie *http.Cookie
+		for _, c := range res.Cookies() {
+			if c.Name == "mcp_oauth2_state_"+created.ID.String() {
+				stateCookie = c
+			}
+			if c.Name == "mcp_oauth2_verifier_"+created.ID.String() {
+				verifierCookie = c
+			}
+		}
+		require.NotNil(t, stateCookie)
+		require.NotNil(t, verifierCookie)
+		require.Equal(t, coderd.MCPOAuth2GlobalCallbackPath(), stateCookie.Path)
+		require.Equal(t, coderd.MCPOAuth2GlobalCallbackPath(), verifierCookie.Path)
+	})
+
+	t.Run("CallbackRoundTripStoresToken", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/token" && r.Method == http.MethodPost {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{
+					"access_token": "global-access-token",
+					"token_type": "Bearer",
+					"expires_in": 3600,
+					"refresh_token": "global-refresh-token"
+				}`))
+				return
+			}
+			http.NotFound(w, r)
+		}))
+		t.Cleanup(tokenServer.Close)
+
+		adminClient := newMCPClient(t)
+		firstUser := coderdtest.CreateFirstUser(t, adminClient)
+		memberClient, _ := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID)
+
+		created, err := adminClient.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
+			DisplayName:    "Global Callback",
+			Slug:           "global-callback",
+			Transport:      "streamable_http",
+			URL:            "https://mcp.example.com/global-cb",
+			AuthType:       "oauth2",
+			OAuth2ClientID: "test-client",
+			OAuth2AuthURL:  "https://auth.example.com/authorize",
+			OAuth2TokenURL: tokenServer.URL + "/token",
+			Availability:   "default_on",
+			Enabled:        true,
+			ToolAllowList:  []string{},
+			ToolDenyList:   []string{},
+		})
+		require.NoError(t, err)
+
+		memberClient.HTTPClient.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+
+		// First, hit /connect to get a real signed state and the
+		// matching cookies. Reuse them on the global callback.
+		connectURL, err := memberClient.URL.Parse(
+			"/api/experimental/mcp/servers/" + created.ID.String() + "/oauth2/connect",
+		)
+		require.NoError(t, err)
+		connectReq, err := http.NewRequestWithContext(ctx, "GET", connectURL.String(), nil)
+		require.NoError(t, err)
+		connectReq.AddCookie(&http.Cookie{
+			Name:  codersdk.SessionTokenCookie,
+			Value: memberClient.SessionToken(),
+		})
+		connectRes, err := memberClient.HTTPClient.Do(connectReq)
+		require.NoError(t, err)
+		defer connectRes.Body.Close()
+		require.Equal(t, http.StatusTemporaryRedirect, connectRes.StatusCode)
+
+		location, err := connectRes.Location()
+		require.NoError(t, err)
+		signedState := location.Query().Get("state")
+		require.NotEmpty(t, signedState)
+
+		var stateCookie, verifierCookie *http.Cookie
+		for _, c := range connectRes.Cookies() {
+			if c.Name == "mcp_oauth2_state_"+created.ID.String() {
+				stateCookie = c
+			}
+			if c.Name == "mcp_oauth2_verifier_"+created.ID.String() {
+				verifierCookie = c
+			}
+		}
+		require.NotNil(t, stateCookie)
+		require.NotNil(t, verifierCookie)
+
+		// Now invoke the global callback with the same state and
+		// cookies; the upstream provider would do this redirect.
+		callbackURL, err := memberClient.URL.Parse(coderd.MCPOAuth2GlobalCallbackPath())
+		require.NoError(t, err)
+		q := callbackURL.Query()
+		q.Set("code", "test-auth-code")
+		q.Set("state", signedState)
+		callbackURL.RawQuery = q.Encode()
+
+		callbackReq, err := http.NewRequestWithContext(ctx, "GET", callbackURL.String(), nil)
+		require.NoError(t, err)
+		callbackReq.AddCookie(&http.Cookie{
+			Name:  codersdk.SessionTokenCookie,
+			Value: memberClient.SessionToken(),
+		})
+		callbackReq.AddCookie(stateCookie)
+		callbackReq.AddCookie(verifierCookie)
+
+		callbackRes, err := memberClient.HTTPClient.Do(callbackReq)
+		require.NoError(t, err)
+		defer callbackRes.Body.Close()
+
+		require.Equal(t, http.StatusOK, callbackRes.StatusCode,
+			"global callback should succeed with valid signed state and matching cookies")
+
+		// AuthConnected should now report true for this user.
+		got, err := memberClient.MCPServerConfigByID(ctx, created.ID)
+		require.NoError(t, err)
+		require.True(t, got.AuthConnected, "user token should have been stored")
+	})
+
+	t.Run("RejectsTamperedState", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		client := newMCPClient(t)
+		_ = coderdtest.CreateFirstUser(t, client)
+		client.HTTPClient.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+
+		// The signed state has the form `payload.signature`; flipping
+		// any bit in the signature must fail HMAC verification.
+		tampered := base64.RawURLEncoding.EncodeToString([]byte("not-a-real-payload")) + "." +
+			base64.RawURLEncoding.EncodeToString([]byte("not-a-real-signature"))
+
+		callbackURL, err := client.URL.Parse(coderd.MCPOAuth2GlobalCallbackPath())
+		require.NoError(t, err)
+		q := callbackURL.Query()
+		q.Set("code", "ignored")
+		q.Set("state", tampered)
+		callbackURL.RawQuery = q.Encode()
+
+		req, err := http.NewRequestWithContext(ctx, "GET", callbackURL.String(), nil)
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{
+			Name:  codersdk.SessionTokenCookie,
+			Value: client.SessionToken(),
+		})
+
+		res, err := client.HTTPClient.Do(req)
+		require.NoError(t, err)
+		defer res.Body.Close()
+		require.Equal(t, http.StatusBadRequest, res.StatusCode)
+	})
+
+	t.Run("RejectsMissingState", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+
+		client := newMCPClient(t)
+		_ = coderdtest.CreateFirstUser(t, client)
+		client.HTTPClient.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+
+		callbackURL, err := client.URL.Parse(coderd.MCPOAuth2GlobalCallbackPath())
+		require.NoError(t, err)
+
+		req, err := http.NewRequestWithContext(ctx, "GET", callbackURL.String(), nil)
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{
+			Name:  codersdk.SessionTokenCookie,
+			Value: client.SessionToken(),
+		})
+
+		res, err := client.HTTPClient.Do(req)
+		require.NoError(t, err)
+		defer res.Body.Close()
+		require.Equal(t, http.StatusBadRequest, res.StatusCode)
+	})
+
+	t.Run("CallbackInfoEndpoint", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newMCPClient(t)
+		_ = coderdtest.CreateFirstUser(t, client)
+
+		info, err := client.MCPOAuth2CallbackInfo(ctx)
+		require.NoError(t, err)
+		require.NotEmpty(t, info.CallbackURL)
+		require.True(t, strings.HasSuffix(info.CallbackURL, coderd.MCPOAuth2GlobalCallbackPath()),
+			"callback URL %q must end with %q", info.CallbackURL, coderd.MCPOAuth2GlobalCallbackPath())
+	})
+
+	t.Run("CallbackInfoForbiddenForNonAdmin", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		adminClient := newMCPClient(t)
+		firstUser := coderdtest.CreateFirstUser(t, adminClient)
+		memberClient, _ := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID)
+
+		_, err := memberClient.MCPOAuth2CallbackInfo(ctx)
+		require.Error(t, err)
+		var sdkErr *codersdk.Error
+		require.ErrorAs(t, err, &sdkErr)
+		require.Equal(t, http.StatusForbidden, sdkErr.StatusCode())
 	})
 }

--- a/coderd/mcp_test.go
+++ b/coderd/mcp_test.go
@@ -1,6 +1,7 @@
 package coderd_test
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
@@ -57,6 +58,62 @@ func createMCPServerConfig(t testing.TB, client *codersdk.Client, slug string, e
 	})
 	require.NoError(t, err)
 	return config
+}
+
+// mcpOAuth2Connect performs the /connect step of the MCP OAuth2 flow
+// against the given server config, captures the temporary redirect
+// to the upstream authorization URL, and returns the signed state
+// parameter along with the state and verifier cookies the upstream
+// will need to echo back on the redirect to /callback. Test helpers
+// that simulate an upstream OAuth2 provider use these values to
+// recreate exactly what the browser would send back to Coder.
+func mcpOAuth2Connect(
+	ctx context.Context,
+	t testing.TB,
+	client *codersdk.Client,
+	serverID uuid.UUID,
+) (signedState string, stateCookie *http.Cookie, verifierCookie *http.Cookie) {
+	t.Helper()
+
+	oldCheckRedirect := client.HTTPClient.CheckRedirect
+	client.HTTPClient.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	t.Cleanup(func() {
+		client.HTTPClient.CheckRedirect = oldCheckRedirect
+	})
+
+	connectURL, err := client.URL.Parse(
+		"/api/experimental/mcp/servers/" + serverID.String() + "/oauth2/connect",
+	)
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, connectURL.String(), nil)
+	require.NoError(t, err)
+	req.AddCookie(&http.Cookie{
+		Name:  codersdk.SessionTokenCookie,
+		Value: client.SessionToken(),
+	})
+	res, err := client.HTTPClient.Do(req)
+	require.NoError(t, err)
+	defer res.Body.Close()
+	require.Equal(t, http.StatusTemporaryRedirect, res.StatusCode)
+
+	location, err := res.Location()
+	require.NoError(t, err)
+	signedState = location.Query().Get("state")
+	require.NotEmpty(t, signedState)
+
+	for _, c := range res.Cookies() {
+		switch c.Name {
+		case "mcp_oauth2_state_" + serverID.String():
+			stateCookie = c
+		case "mcp_oauth2_verifier_" + serverID.String():
+			verifierCookie = c
+		}
+	}
+	require.NotNil(t, stateCookie, "connect must set the state cookie")
+	require.NotNil(t, verifierCookie, "connect must set the verifier cookie")
+	return signedState, stateCookie, verifierCookie
 }
 
 func TestMCPServerConfigsCRUD(t *testing.T) {
@@ -1225,17 +1282,16 @@ func TestMCPServerOAuth2PKCE(t *testing.T) {
 			return http.ErrUseLastResponse
 		}
 
-		// Simulate the callback with a known state and verifier.
-		state := "test-state-value"
-		verifier := "test-verifier-value-that-is-at-least-43-chars-long-for-pkce-spec"
+		// Drive the full /connect -> /callback round trip so the cookies
+		// and signed state match what the upstream provider would echo
+		// back. Faking state with arbitrary strings no longer works.
+		signedState, stateCookie, verifierCookie := mcpOAuth2Connect(ctx, t, memberClient, created.ID)
 
-		callbackURL, err := memberClient.URL.Parse(
-			"/api/experimental/mcp/servers/" + created.ID.String() + "/oauth2/callback",
-		)
+		callbackURL, err := memberClient.URL.Parse(coderd.MCPOAuth2GlobalCallbackPath())
 		require.NoError(t, err)
 		q := callbackURL.Query()
 		q.Set("code", "test-auth-code")
-		q.Set("state", state)
+		q.Set("state", signedState)
 		callbackURL.RawQuery = q.Encode()
 
 		req, err := http.NewRequestWithContext(ctx, "GET", callbackURL.String(), nil)
@@ -1244,14 +1300,8 @@ func TestMCPServerOAuth2PKCE(t *testing.T) {
 			Name:  codersdk.SessionTokenCookie,
 			Value: memberClient.SessionToken(),
 		})
-		req.AddCookie(&http.Cookie{
-			Name:  "mcp_oauth2_state_" + created.ID.String(),
-			Value: state,
-		})
-		req.AddCookie(&http.Cookie{
-			Name:  "mcp_oauth2_verifier_" + created.ID.String(),
-			Value: verifier,
-		})
+		req.AddCookie(stateCookie)
+		req.AddCookie(verifierCookie)
 
 		res, err := memberClient.HTTPClient.Do(req)
 		require.NoError(t, err)
@@ -1267,7 +1317,7 @@ func TestMCPServerOAuth2PKCE(t *testing.T) {
 		case <-ctx.Done():
 			t.Fatal("timed out waiting for token exchange")
 		}
-		require.Equal(t, verifier, gotVerifier,
+		require.Equal(t, verifierCookie.Value, gotVerifier,
 			"token exchange must send the PKCE code_verifier")
 
 		// Verify the verifier cookie is cleared in the response.
@@ -1322,16 +1372,16 @@ func TestMCPServerOAuth2PKCE(t *testing.T) {
 			return http.ErrUseLastResponse
 		}
 
-		// Call the callback without a verifier cookie to verify
-		// backwards compatibility with providers that don't use PKCE.
-		state := "test-state-no-pkce"
-		callbackURL, err := memberClient.URL.Parse(
-			"/api/experimental/mcp/servers/" + created.ID.String() + "/oauth2/callback",
-		)
+		// Drive /connect to get a valid signed state and state cookie,
+		// then call the callback without the verifier cookie to verify
+		// backwards compatibility with providers that do not use PKCE.
+		signedState, stateCookie, _ := mcpOAuth2Connect(ctx, t, memberClient, created.ID)
+
+		callbackURL, err := memberClient.URL.Parse(coderd.MCPOAuth2GlobalCallbackPath())
 		require.NoError(t, err)
 		q := callbackURL.Query()
 		q.Set("code", "test-auth-code")
-		q.Set("state", state)
+		q.Set("state", signedState)
 		callbackURL.RawQuery = q.Encode()
 
 		req, err := http.NewRequestWithContext(ctx, "GET", callbackURL.String(), nil)
@@ -1340,10 +1390,7 @@ func TestMCPServerOAuth2PKCE(t *testing.T) {
 			Name:  codersdk.SessionTokenCookie,
 			Value: memberClient.SessionToken(),
 		})
-		req.AddCookie(&http.Cookie{
-			Name:  "mcp_oauth2_state_" + created.ID.String(),
-			Value: state,
-		})
+		req.AddCookie(stateCookie)
 		// Deliberately omit the verifier cookie.
 
 		res, err := memberClient.HTTPClient.Do(req)
@@ -2053,46 +2100,12 @@ func TestMCPServerOAuth2GlobalCallback(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		memberClient.HTTPClient.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
-			return http.ErrUseLastResponse
-		}
+		// Drive the full /connect -> /callback round trip, then verify
+		// the user token was stored.
+		signedState, stateCookie, verifierCookie := mcpOAuth2Connect(ctx, t, memberClient, created.ID)
 
-		// First, hit /connect to get a real signed state and the
-		// matching cookies. Reuse them on the global callback.
-		connectURL, err := memberClient.URL.Parse(
-			"/api/experimental/mcp/servers/" + created.ID.String() + "/oauth2/connect",
-		)
-		require.NoError(t, err)
-		connectReq, err := http.NewRequestWithContext(ctx, "GET", connectURL.String(), nil)
-		require.NoError(t, err)
-		connectReq.AddCookie(&http.Cookie{
-			Name:  codersdk.SessionTokenCookie,
-			Value: memberClient.SessionToken(),
-		})
-		connectRes, err := memberClient.HTTPClient.Do(connectReq)
-		require.NoError(t, err)
-		defer connectRes.Body.Close()
-		require.Equal(t, http.StatusTemporaryRedirect, connectRes.StatusCode)
-
-		location, err := connectRes.Location()
-		require.NoError(t, err)
-		signedState := location.Query().Get("state")
-		require.NotEmpty(t, signedState)
-
-		var stateCookie, verifierCookie *http.Cookie
-		for _, c := range connectRes.Cookies() {
-			if c.Name == "mcp_oauth2_state_"+created.ID.String() {
-				stateCookie = c
-			}
-			if c.Name == "mcp_oauth2_verifier_"+created.ID.String() {
-				verifierCookie = c
-			}
-		}
-		require.NotNil(t, stateCookie)
-		require.NotNil(t, verifierCookie)
-
-		// Now invoke the global callback with the same state and
-		// cookies; the upstream provider would do this redirect.
+		// Simulate the upstream provider redirecting back to the global
+		// callback with the issued code and the same signed state.
 		callbackURL, err := memberClient.URL.Parse(coderd.MCPOAuth2GlobalCallbackPath())
 		require.NoError(t, err)
 		q := callbackURL.Query()
@@ -2212,5 +2225,49 @@ func TestMCPServerOAuth2GlobalCallback(t *testing.T) {
 		var sdkErr *codersdk.Error
 		require.ErrorAs(t, err, &sdkErr)
 		require.Equal(t, http.StatusForbidden, sdkErr.StatusCode())
+	})
+
+	t.Run("LegacyCallbackRedirectsToGlobal", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newMCPClient(t)
+		_ = coderdtest.CreateFirstUser(t, client)
+		client.HTTPClient.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+
+		// The legacy per-ID callback URL only exists so any client
+		// previously registered with an upstream provider against that
+		// URL keeps working. It must 307 to the deployment-wide
+		// callback with the query string preserved verbatim, so the
+		// browser follows it and the global handler decodes the
+		// signed state to identify the MCP server.
+		legacyURL, err := client.URL.Parse(
+			"/api/experimental/mcp/servers/" + uuid.NewString() + "/oauth2/callback",
+		)
+		require.NoError(t, err)
+		q := legacyURL.Query()
+		q.Set("code", "upstream-code")
+		q.Set("state", "upstream-state")
+		legacyURL.RawQuery = q.Encode()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, legacyURL.String(), nil)
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{
+			Name:  codersdk.SessionTokenCookie,
+			Value: client.SessionToken(),
+		})
+
+		res, err := client.HTTPClient.Do(req)
+		require.NoError(t, err)
+		defer res.Body.Close()
+
+		require.Equal(t, http.StatusTemporaryRedirect, res.StatusCode)
+		location, err := res.Location()
+		require.NoError(t, err)
+		require.Equal(t, coderd.MCPOAuth2GlobalCallbackPath(), location.Path)
+		require.Equal(t, "upstream-code", location.Query().Get("code"))
+		require.Equal(t, "upstream-state", location.Query().Get("state"))
 	})
 }

--- a/coderd/mcp_test.go
+++ b/coderd/mcp_test.go
@@ -1050,14 +1050,14 @@ func TestMCPServerConfigsOAuth2AutoDiscovery(t *testing.T) {
 
 		// The redirect URI must be the deployment-wide MCP OAuth2
 		// callback. The MCP server config UUID must NOT appear in the
-		// path; that is the whole point of the global callback. The
+		// path; that is the whole point of the deployment-wide callback. The
 		// admin can register one redirect URI per upstream provider
 		// before any MCP server config exists.
-		require.True(t, strings.HasSuffix(redirectURI, coderd.MCPOAuth2GlobalCallbackPath()),
+		require.True(t, strings.HasSuffix(redirectURI, coderd.MCPOAuth2CallbackPath()),
 			"redirect URI %q should end with the deployment-wide MCP OAuth2 callback path %q",
-			redirectURI, coderd.MCPOAuth2GlobalCallbackPath())
+			redirectURI, coderd.MCPOAuth2CallbackPath())
 		require.NotContains(t, redirectURI, created.ID.String(),
-			"redirect URI must not contain the MCP server config UUID; the global callback identifies the server via signed state")
+			"redirect URI must not contain the MCP server config UUID; the deployment-wide callback identifies the server via signed state")
 		require.NotContains(t, redirectURI, "{id}",
 			"redirect URI must not contain the literal \"{id}\" placeholder")
 	})
@@ -1287,7 +1287,7 @@ func TestMCPServerOAuth2PKCE(t *testing.T) {
 		// back. Faking state with arbitrary strings no longer works.
 		signedState, stateCookie, verifierCookie := mcpOAuth2Connect(ctx, t, memberClient, created.ID)
 
-		callbackURL, err := memberClient.URL.Parse(coderd.MCPOAuth2GlobalCallbackPath())
+		callbackURL, err := memberClient.URL.Parse(coderd.MCPOAuth2CallbackPath())
 		require.NoError(t, err)
 		q := callbackURL.Query()
 		q.Set("code", "test-auth-code")
@@ -1377,7 +1377,7 @@ func TestMCPServerOAuth2PKCE(t *testing.T) {
 		// backwards compatibility with providers that do not use PKCE.
 		signedState, stateCookie, _ := mcpOAuth2Connect(ctx, t, memberClient, created.ID)
 
-		callbackURL, err := memberClient.URL.Parse(coderd.MCPOAuth2GlobalCallbackPath())
+		callbackURL, err := memberClient.URL.Parse(coderd.MCPOAuth2CallbackPath())
 		require.NoError(t, err)
 		q := callbackURL.Query()
 		q.Set("code", "test-auth-code")
@@ -1974,7 +1974,7 @@ func TestMCPOAuth2DiscoveryEdgeCases(t *testing.T) {
 	})
 }
 
-func TestMCPServerOAuth2GlobalCallback(t *testing.T) {
+func TestMCPServerOAuth2Callback(t *testing.T) {
 	t.Parallel()
 
 	t.Run("ConnectUsesGlobalRedirectURI", func(t *testing.T) {
@@ -1986,10 +1986,10 @@ func TestMCPServerOAuth2GlobalCallback(t *testing.T) {
 		memberClient, _ := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID)
 
 		created, err := adminClient.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
-			DisplayName:    "Global Connect",
-			Slug:           "global-connect",
+			DisplayName:    "OAuth2 Connect",
+			Slug:           "oauth2-connect-test",
 			Transport:      "streamable_http",
-			URL:            "https://mcp.example.com/global-connect",
+			URL:            "https://mcp.example.com/oauth2-connect-test",
 			AuthType:       "oauth2",
 			OAuth2ClientID: "test-client",
 			OAuth2AuthURL:  "https://auth.example.com/authorize",
@@ -2031,8 +2031,8 @@ func TestMCPServerOAuth2GlobalCallback(t *testing.T) {
 		// UUID must NOT be embedded in that URL.
 		gotRedirectURI := location.Query().Get("redirect_uri")
 		require.NotEmpty(t, gotRedirectURI)
-		require.True(t, strings.HasSuffix(gotRedirectURI, coderd.MCPOAuth2GlobalCallbackPath()),
-			"redirect_uri %q should end with %q", gotRedirectURI, coderd.MCPOAuth2GlobalCallbackPath())
+		require.True(t, strings.HasSuffix(gotRedirectURI, coderd.MCPOAuth2CallbackPath()),
+			"redirect_uri %q should end with %q", gotRedirectURI, coderd.MCPOAuth2CallbackPath())
 		require.NotContains(t, gotRedirectURI, created.ID.String(),
 			"redirect_uri must not contain the MCP server config UUID")
 
@@ -2044,7 +2044,7 @@ func TestMCPServerOAuth2GlobalCallback(t *testing.T) {
 		require.Contains(t, state, ".",
 			"signed state has a payload-signature delimiter")
 
-		// Cookies should be scoped to the global callback path.
+		// Cookies should be scoped to the deployment-wide callback path.
 		var stateCookie, verifierCookie *http.Cookie
 		for _, c := range res.Cookies() {
 			if c.Name == "mcp_oauth2_state_"+created.ID.String() {
@@ -2056,8 +2056,8 @@ func TestMCPServerOAuth2GlobalCallback(t *testing.T) {
 		}
 		require.NotNil(t, stateCookie)
 		require.NotNil(t, verifierCookie)
-		require.Equal(t, coderd.MCPOAuth2GlobalCallbackPath(), stateCookie.Path)
-		require.Equal(t, coderd.MCPOAuth2GlobalCallbackPath(), verifierCookie.Path)
+		require.Equal(t, coderd.MCPOAuth2CallbackPath(), stateCookie.Path)
+		require.Equal(t, coderd.MCPOAuth2CallbackPath(), verifierCookie.Path)
 	})
 
 	t.Run("CallbackRoundTripStoresToken", func(t *testing.T) {
@@ -2085,8 +2085,8 @@ func TestMCPServerOAuth2GlobalCallback(t *testing.T) {
 		memberClient, _ := coderdtest.CreateAnotherUser(t, adminClient, firstUser.OrganizationID)
 
 		created, err := adminClient.CreateMCPServerConfig(ctx, codersdk.CreateMCPServerConfigRequest{
-			DisplayName:    "Global Callback",
-			Slug:           "global-callback",
+			DisplayName:    "OAuth2 Callback",
+			Slug:           "oauth2-callback-test",
 			Transport:      "streamable_http",
 			URL:            "https://mcp.example.com/global-cb",
 			AuthType:       "oauth2",
@@ -2106,7 +2106,7 @@ func TestMCPServerOAuth2GlobalCallback(t *testing.T) {
 
 		// Simulate the upstream provider redirecting back to the global
 		// callback with the issued code and the same signed state.
-		callbackURL, err := memberClient.URL.Parse(coderd.MCPOAuth2GlobalCallbackPath())
+		callbackURL, err := memberClient.URL.Parse(coderd.MCPOAuth2CallbackPath())
 		require.NoError(t, err)
 		q := callbackURL.Query()
 		q.Set("code", "test-auth-code")
@@ -2127,7 +2127,7 @@ func TestMCPServerOAuth2GlobalCallback(t *testing.T) {
 		defer callbackRes.Body.Close()
 
 		require.Equal(t, http.StatusOK, callbackRes.StatusCode,
-			"global callback should succeed with valid signed state and matching cookies")
+			"callback should succeed with valid signed state and matching cookies")
 
 		// AuthConnected should now report true for this user.
 		got, err := memberClient.MCPServerConfigByID(ctx, created.ID)
@@ -2151,7 +2151,7 @@ func TestMCPServerOAuth2GlobalCallback(t *testing.T) {
 		tampered := base64.RawURLEncoding.EncodeToString([]byte("not-a-real-payload")) + "." +
 			base64.RawURLEncoding.EncodeToString([]byte("not-a-real-signature"))
 
-		callbackURL, err := client.URL.Parse(coderd.MCPOAuth2GlobalCallbackPath())
+		callbackURL, err := client.URL.Parse(coderd.MCPOAuth2CallbackPath())
 		require.NoError(t, err)
 		q := callbackURL.Query()
 		q.Set("code", "ignored")
@@ -2182,7 +2182,7 @@ func TestMCPServerOAuth2GlobalCallback(t *testing.T) {
 			return http.ErrUseLastResponse
 		}
 
-		callbackURL, err := client.URL.Parse(coderd.MCPOAuth2GlobalCallbackPath())
+		callbackURL, err := client.URL.Parse(coderd.MCPOAuth2CallbackPath())
 		require.NoError(t, err)
 
 		req, err := http.NewRequestWithContext(ctx, "GET", callbackURL.String(), nil)
@@ -2208,8 +2208,8 @@ func TestMCPServerOAuth2GlobalCallback(t *testing.T) {
 		info, err := client.MCPOAuth2CallbackInfo(ctx)
 		require.NoError(t, err)
 		require.NotEmpty(t, info.CallbackURL)
-		require.True(t, strings.HasSuffix(info.CallbackURL, coderd.MCPOAuth2GlobalCallbackPath()),
-			"callback URL %q must end with %q", info.CallbackURL, coderd.MCPOAuth2GlobalCallbackPath())
+		require.True(t, strings.HasSuffix(info.CallbackURL, coderd.MCPOAuth2CallbackPath()),
+			"callback URL %q must end with %q", info.CallbackURL, coderd.MCPOAuth2CallbackPath())
 	})
 
 	t.Run("CallbackInfoForbiddenForNonAdmin", func(t *testing.T) {
@@ -2241,7 +2241,7 @@ func TestMCPServerOAuth2GlobalCallback(t *testing.T) {
 		// previously registered with an upstream provider against that
 		// URL keeps working. It must 307 to the deployment-wide
 		// callback with the query string preserved verbatim, so the
-		// browser follows it and the global handler decodes the
+		// browser follows it and the callback handler decodes the
 		// signed state to identify the MCP server.
 		legacyURL, err := client.URL.Parse(
 			"/api/experimental/mcp/servers/" + uuid.NewString() + "/oauth2/callback",
@@ -2266,7 +2266,7 @@ func TestMCPServerOAuth2GlobalCallback(t *testing.T) {
 		require.Equal(t, http.StatusTemporaryRedirect, res.StatusCode)
 		location, err := res.Location()
 		require.NoError(t, err)
-		require.Equal(t, coderd.MCPOAuth2GlobalCallbackPath(), location.Path)
+		require.Equal(t, coderd.MCPOAuth2CallbackPath(), location.Path)
 		require.Equal(t, "upstream-code", location.Query().Get("code"))
 		require.Equal(t, "upstream-state", location.Query().Get("state"))
 	})

--- a/codersdk/mcp.go
+++ b/codersdk/mcp.go
@@ -195,3 +195,26 @@ func (c *Client) DeleteMCPServerConfig(ctx context.Context, id uuid.UUID) error 
 	}
 	return nil
 }
+
+// MCPOAuth2CallbackInfo describes the deployment-wide MCP OAuth2
+// redirect URI an admin should register with an upstream provider.
+type MCPOAuth2CallbackInfo struct {
+	CallbackURL string `json:"callback_url"`
+}
+
+// MCPOAuth2CallbackInfo returns the deployment-wide MCP OAuth2
+// callback URL. The frontend admin form shows this so the operator
+// can register one redirect URI per upstream provider before saving
+// the MCP server config.
+func (c *Client) MCPOAuth2CallbackInfo(ctx context.Context) (MCPOAuth2CallbackInfo, error) {
+	res, err := c.Request(ctx, http.MethodGet, "/api/experimental/mcp/oauth2/callback-url", nil)
+	if err != nil {
+		return MCPOAuth2CallbackInfo{}, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return MCPOAuth2CallbackInfo{}, ReadBodyAsError(res)
+	}
+	var info MCPOAuth2CallbackInfo
+	return info, json.NewDecoder(res.Body).Decode(&info)
+}

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -15396,19 +15396,21 @@ None
 
 ### Properties
 
-| Name          | Type                         | Required | Restrictions | Description                                        |
-|---------------|------------------------------|----------|--------------|----------------------------------------------------|
-| `forceQuery`  | boolean                      | false    |              | append a query ('?') even if RawQuery is empty     |
-| `fragment`    | string                       | false    |              | fragment for references, without '#'               |
-| `host`        | string                       | false    |              | host or host:port (see Hostname and Port methods)  |
-| `omitHost`    | boolean                      | false    |              | do not emit empty host (authority)                 |
-| `opaque`      | string                       | false    |              | encoded opaque data                                |
-| `path`        | string                       | false    |              | path (relative paths may omit leading slash)       |
-| `rawFragment` | string                       | false    |              | encoded fragment hint (see EscapedFragment method) |
-| `rawPath`     | string                       | false    |              | encoded path hint (see EscapedPath method)         |
-| `rawQuery`    | string                       | false    |              | encoded query values, without '?'                  |
-| `scheme`      | string                       | false    |              |                                                    |
-| `user`        | [url.Userinfo](#urluserinfo) | false    |              | username and password information                  |
+| Name         | Type    | Required | Restrictions | Description                                                                                                                                                            |
+|--------------|---------|----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `forceQuery` | boolean | false    |              | Forcequery indicates whether the original URL contained a query ('?') character. When set, the String method will include a trailing '?', even when RawQuery is empty. |
+| `fragment`   | string  | false    |              | fragment for references (without '#')                                                                                                                                  |
+| `host`       | string  | false    |              | "host" or "host:port" (see Hostname and Port methods)                                                                                                                  |
+| `omitHost`   | boolean | false    |              | Omithost indicates the URL has an empty host (authority). When set, the String method will not include the host when it is empty.                                      |
+| `opaque`     | string  | false    |              | encoded opaque data                                                                                                                                                    |
+| `path`       | string  | false    |              | path (relative paths may omit leading slash)                                                                                                                           |
+|`rawFragment`|string|false||Rawfragment is an optional field containing an encoded fragment hint. See the EscapedFragment method for more details.
+In general, code should call EscapedFragment instead of reading RawFragment.|
+|`rawPath`|string|false||Rawpath is an optional field containing an encoded path hint. See the EscapedPath method for more details.
+In general, code should call EscapedPath instead of reading RawPath.|
+|`rawQuery`|string|false||Rawquery contains the encoded query values, without the initial '?'. Use URL.Query to decode the query.|
+|`scheme`|string|false|||
+|`user`|[url.Userinfo](#urluserinfo)|false||username and password information|
 
 ## serpent.ValueSource
 

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -412,6 +412,7 @@ const chatModelConfigsPath = "/api/experimental/chats/model-configs";
 const userChatProviderConfigsPath =
 	"/api/experimental/chats/user-provider-configs";
 const mcpServerConfigsPath = "/api/experimental/mcp/servers";
+const mcpOAuth2CallbackInfoPath = "/api/experimental/mcp/oauth2/callback-url";
 
 type ChatCostDateParams = {
 	start_date?: string;
@@ -3595,6 +3596,14 @@ class ExperimentalApiMethods {
 			`${mcpServerConfigsPath}/${encodeURIComponent(id)}`,
 		);
 	};
+
+	getMCPOAuth2CallbackInfo =
+		async (): Promise<TypesGen.MCPOAuth2CallbackInfo> => {
+			const response = await this.axios.get<TypesGen.MCPOAuth2CallbackInfo>(
+				mcpOAuth2CallbackInfoPath,
+			);
+			return response.data;
+		};
 
 	getChatCostSummary = async (
 		user = "me",

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -1777,3 +1777,13 @@ export const deleteMCPServerConfig = (queryClient: QueryClient) => ({
 		await invalidateMCPServerConfigQueries(queryClient);
 	},
 });
+
+// The deployment-wide redirect URI an admin should register with the
+// upstream OAuth2 provider when configuring an MCP server. Cached for
+// the session because it never changes for a given deployment.
+export const mcpOAuth2CallbackInfo = () => ({
+	queryKey: ["mcp-oauth2-callback-info"] as const,
+	queryFn: (): Promise<TypesGen.MCPOAuth2CallbackInfo> =>
+		API.experimental.getMCPOAuth2CallbackInfo(),
+	staleTime: Number.POSITIVE_INFINITY,
+});

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -4573,6 +4573,15 @@ export interface LoginWithPasswordResponse {
 
 // From codersdk/mcp.go
 /**
+ * MCPOAuth2CallbackInfo describes the deployment-wide MCP OAuth2
+ * redirect URI an admin should register with an upstream provider.
+ */
+export interface MCPOAuth2CallbackInfo {
+	readonly callback_url: string;
+}
+
+// From codersdk/mcp.go
+/**
  * MCPServerConfig represents an admin-configured MCP server.
  */
 export interface MCPServerConfig {

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.stories.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.stories.tsx
@@ -233,6 +233,12 @@ export const CreateServerOAuth2: Story = {
 		expect(body.getByLabelText(/Token URL/i)).toBeInTheDocument();
 		expect(body.getByLabelText(/^Scopes/i)).toBeInTheDocument();
 
+		// The redirect URI display is rendered (read-only) so admins
+		// can register it with the upstream provider before saving.
+		const redirectUri = body.getByLabelText(/Redirect URI/i);
+		expect(redirectUri).toBeInTheDocument();
+		expect(redirectUri).toHaveAttribute("readonly");
+
 		// Fill OAuth2 fields.
 		await userEvent.type(body.getByLabelText(/Client ID/i), "my-client-id");
 		await userEvent.type(body.getByLabelText(/Client Secret/i), "my-secret");

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
@@ -9,8 +9,10 @@ import {
 	XIcon,
 } from "lucide-react";
 import { type FC, lazy, Suspense, useId, useState } from "react";
+import { useQuery } from "react-query";
 import { useLocation, useNavigate, useSearchParams } from "react-router";
 
+import { mcpOAuth2CallbackInfo } from "#/api/queries/chats";
 import type * as TypesGen from "#/api/typesGenerated";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { ChevronDownIcon as AnimatedChevronDownIcon } from "#/components/AnimatedIcons/ChevronDown";
@@ -21,6 +23,7 @@ import {
 	CollapsibleContent,
 	CollapsibleTrigger,
 } from "#/components/Collapsible/Collapsible";
+import { CopyButton } from "#/components/CopyButton/CopyButton";
 import { ExternalImage } from "#/components/ExternalImage/ExternalImage";
 import { Input } from "#/components/Input/Input";
 import {
@@ -462,6 +465,15 @@ const ServerForm: FC<ServerFormProps> = ({
 		},
 	});
 
+	// Fetch the deployment-wide OAuth2 callback URL so admins can
+	// register it with the upstream provider before saving the form.
+	// The query is enabled only when OAuth2 is selected so non-OAuth2
+	// configs do not pay the network cost.
+	const callbackInfoQuery = useQuery({
+		...mcpOAuth2CallbackInfo(),
+		enabled: form.values.authType === "oauth2",
+	});
+
 	const isDisabled = isSaving || isDeleting;
 	const canSubmit =
 		form.values.displayName.trim() !== "" &&
@@ -680,11 +692,34 @@ const ServerForm: FC<ServerFormProps> = ({
 								</Field>
 								{form.values.authType === "oauth2" && (
 									<div className="space-y-4 rounded-lg border border-solid border-border/70 bg-surface-secondary/30 p-4">
-										<p className="m-0 text-xs text-content-secondary">
-											Register a client with the external MCP server's OAuth2
-											provider and enter the credentials below. Coder will
-											handle the per-user authorization flow.
-										</p>
+										<Field
+											label="Redirect URI"
+											htmlFor={`${formId}-oauth-redirect-uri`}
+										>
+											<div className="flex items-center gap-2">
+												<Input
+													id={`${formId}-oauth-redirect-uri`}
+													className="h-9 font-mono text-[13px]"
+													value={callbackInfoQuery.data?.callback_url ?? ""}
+													readOnly
+													placeholder={
+														callbackInfoQuery.isLoading ? "Loading..." : ""
+													}
+												/>
+												<CopyButton
+													text={callbackInfoQuery.data?.callback_url ?? ""}
+													label="Copy redirect URI"
+													disabled={!callbackInfoQuery.data?.callback_url}
+												/>
+											</div>
+											<p className="m-0 mt-1 text-xs text-content-secondary">
+												Register this redirect URI with your upstream OAuth2
+												provider, then paste the resulting client credentials
+												below. The same URI works for every MCP server you
+												connect to this Coder deployment.
+											</p>
+										</Field>
+
 										<div className="grid items-start gap-4 sm:grid-cols-2">
 											<Field label="Client ID" htmlFor={`${formId}-oauth-id`}>
 												<Input


### PR DESCRIPTION
Setting up an admin-configured MCP server with `auth_type=oauth2` had a chicken-and-egg problem: the admin needed to create the MCP server config first to learn the per-config redirect URI, then go register a client with the upstream provider, then come back and edit the config to fill in the credentials. The auto-discovery (RFC 7591 Dynamic Client Registration) branch worked around it with an insert → discover → update | delete-on-failure dance.

Introduce a single deployment-wide callback at `${access_url}/api/experimental/mcp/oauth2/callback`. The MCP server is identified through a signed `state` parameter (HMAC over `serverID || nonce` using `OAuthSigningKey`), so the callback URL no longer depends on the per-config UUID. The admin form fetches and displays the redirect URI the moment OAuth2 is selected, so an admin registers it once with the upstream provider, pastes the credentials, and saves in a single round trip. The DCR branch now does discovery first, then a single insert.

For backwards compatibility, the legacy per-ID path `/api/experimental/mcp/servers/{id}/oauth2/callback` 307-redirects to the deployment-wide callback with the query string preserved verbatim. Any client previously registered against the per-ID URL keeps working transparently — the browser follows the 307, the cookies (scoped to the new path) are sent on the redirected request, and the global handler completes the exchange.

A new `GET /api/experimental/mcp/oauth2/callback-url` (admin-only) returns the absolute redirect URI for the admin UI to display.

<details>
<summary>Design notes</summary>

- **Signed state, not draft rows.** A "create draft, then update" wizard would gift-wrap the round trip but keep it. Carrying the server ID in signed state removes the round trip entirely.
- **HMAC, not just cookie equality.** The per-server cookie alone is sufficient against vanilla CSRF but not against a sub-domain cookie-injection attack that swaps the embedded `serverID` to a different one. The HMAC pins the server ID inside the state.
- **Redirect instead of a parallel handler.** An earlier version of this PR kept two completion handlers sharing a helper, but the cookie semantics differ (cookie holds nonce in the global flow, raw state in the legacy flow), so the dual-handler code path never actually worked. A 307 redirect is strictly simpler and lets the browser handle cookie scoping naturally.

</details>

This change was generated by Coder Agents.
