### PR TITLE
feat(site/src/pages/AgentsPage): render markdown attachments in preview popup

### DIFF
--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -149,7 +149,11 @@ interface AgentChatInputProps {
 	uploadStates?: Map<File, UploadState>;
 	previewUrls?: Map<File, string>;
 	textContents?: Map<File, string>;
-	onTextPreview?: (content: string, fileName: string) => void;
+	onTextPreview?: (
+		content: string,
+		fileName: string,
+		mediaType?: string,
+	) => void;
 	// MCP Server picker.
 	mcpServers?: readonly TypesGen.MCPServerConfig[];
 	selectedMCPServerIds?: readonly string[];
@@ -326,6 +330,9 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 	const [previewTextFileName, setPreviewTextFileName] = useState<string | null>(
 		null,
 	);
+	const [previewTextMediaType, setPreviewTextMediaType] = useState<
+		string | null
+	>(null);
 	const [plusMenuOpen, setPlusMenuOpen] = useState(false);
 	const [plusMenuView, setPlusMenuView] = useState<"main" | "workspace">(
 		"main",
@@ -514,12 +521,17 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 		onRemoveAttachment?.(file);
 	};
 
-	const handleTextPreview = (content: string, fileName: string) => {
+	const handleTextPreview = (
+		content: string,
+		fileName: string,
+		mediaType?: string,
+	) => {
 		if (onTextPreview) {
-			onTextPreview(content, fileName);
+			onTextPreview(content, fileName, mediaType);
 		} else {
 			setPreviewText(content);
 			setPreviewTextFileName(fileName);
+			setPreviewTextMediaType(mediaType ?? null);
 		}
 	};
 
@@ -1255,9 +1267,11 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 				<TextPreviewDialog
 					content={previewText}
 					fileName={previewTextFileName ?? undefined}
+					mediaType={previewTextMediaType ?? undefined}
 					onClose={() => {
 						setPreviewText(null);
 						setPreviewTextFileName(null);
+						setPreviewTextMediaType(null);
 					}}
 				/>
 			)}

--- a/site/src/pages/AgentsPage/components/AttachmentPreview.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AttachmentPreview.stories.tsx
@@ -206,6 +206,7 @@ export const TextAttachment: Story = {
 		expect(args.onTextPreview).toHaveBeenCalledWith(
 			"This is the pasted text content.\nIt has multiple lines.\nAnd should be displayed in a readable card format.",
 			"clipboard.txt",
+			"text/plain",
 		);
 	},
 };

--- a/site/src/pages/AgentsPage/components/AttachmentPreview.tsx
+++ b/site/src/pages/AgentsPage/components/AttachmentPreview.tsx
@@ -52,7 +52,11 @@ export const AttachmentPreview: FC<{
 	previewUrls?: Map<File, string>;
 	onPreview?: (url: string) => void;
 	textContents?: Map<File, string>;
-	onTextPreview?: (content: string, fileName: string) => void;
+	onTextPreview?: (
+		content: string,
+		fileName: string,
+		mediaType?: string,
+	) => void;
 	onInlineText?: (file: File, content?: string) => void;
 }> = ({
 	attachments,
@@ -157,7 +161,7 @@ export const AttachmentPreview: FC<{
 											textFileId,
 										);
 										if (nextContent !== undefined) {
-											onTextPreview?.(nextContent, file.name);
+											onTextPreview?.(nextContent, file.name, file.type);
 										}
 									}}
 								>

--- a/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
@@ -32,6 +32,7 @@ import type { RenderBlock } from "./types";
 export type PreviewTextAttachment = {
 	content: string;
 	fileName?: string;
+	mediaType?: string;
 };
 
 type FileAttachmentBlock = Extract<RenderBlock, { type: "file" }>;
@@ -278,6 +279,7 @@ const InlineTextAttachmentButton: FC<{
 const RemoteTextAttachmentButton: FC<{
 	fileId: string;
 	fileName?: string;
+	mediaType?: string;
 	frameHref?: string | null;
 	downloadName: string;
 	onPreview?: (attachment: PreviewTextAttachment) => void | Promise<void>;
@@ -285,6 +287,7 @@ const RemoteTextAttachmentButton: FC<{
 }> = ({
 	fileId,
 	fileName,
+	mediaType,
 	frameHref,
 	downloadName,
 	onPreview,
@@ -337,7 +340,7 @@ const RemoteTextAttachmentButton: FC<{
 					return;
 				}
 				if (content !== null) {
-					void onPreview?.({ content, fileName });
+					void onPreview?.({ content, fileName, mediaType });
 					return;
 				}
 
@@ -372,7 +375,7 @@ const RemoteTextAttachmentButton: FC<{
 					return;
 				}
 				setContent(result.content);
-				void onPreview?.({ content: result.content, fileName });
+				void onPreview?.({ content: result.content, fileName, mediaType });
 			}}
 		/>
 	);
@@ -560,6 +563,7 @@ export const AttachmentBlock: FC<{
 				<RemoteTextAttachmentButton
 					fileId={block.file_id}
 					fileName={displayName}
+					mediaType={block.media_type}
 					frameHref={framePreview ? href : undefined}
 					downloadName={downloadName}
 					onPreview={onTextFileClick}
@@ -578,7 +582,11 @@ export const AttachmentBlock: FC<{
 				isPlaceholder={!revealedInlineText}
 				onPreview={() => {
 					setRevealedInlineText(true);
-					void onTextFileClick?.({ content, fileName: displayName });
+					void onTextFileClick?.({
+						content,
+						fileName: displayName,
+						mediaType: block.media_type,
+					});
 				}}
 			/>
 		);

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -639,6 +639,7 @@ const ChatMessageItem = memo<{
 					<TextPreviewDialog
 						content={previewText.content}
 						fileName={previewText.fileName}
+						mediaType={previewText.mediaType}
 						onClose={() => setPreviewText(null)}
 					/>
 				)}

--- a/site/src/pages/AgentsPage/components/TextPreviewDialog.stories.tsx
+++ b/site/src/pages/AgentsPage/components/TextPreviewDialog.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, within } from "storybook/test";
+import { expect, waitFor, within } from "storybook/test";
 import { TextPreviewDialog } from "./TextPreviewDialog";
 
 const meta: Meta<typeof TextPreviewDialog> = {
@@ -55,5 +55,141 @@ export const NoFileName: Story = {
 		const body = within(canvasElement.ownerDocument.body);
 		const dialog = await body.findByRole("dialog");
 		expect(within(dialog).getByText("Pasted text")).toBeInTheDocument();
+	},
+};
+
+const sampleMarkdown = `# Auth split runbook
+
+This document captures the rollout plan for the upcoming auth split.
+
+## Goals
+
+1. Move OAuth2 endpoints under \`coderd/oauth2/\`.
+2. Keep external auth providers behind their existing routes.
+3. Avoid downtime for in-flight tokens.
+
+> Reviewers should pay close attention to the migration order, since
+> dropping the legacy table before backfilling will lose tokens.
+
+## Checklist
+
+- [x] Draft the migration in \`coderd/database/migrations/\`.
+- [x] Update [the SDK types](https://example.com/sdk).
+- [ ] Coordinate with the deployments team.
+
+## Rollout window
+
+| Phase | Date       | Owner   |
+| ----- | ---------- | ------- |
+| Beta  | 2025-07-15 | @kyle   |
+| GA    | 2025-08-01 | @ammar  |
+
+## Sample query
+
+\`\`\`sql
+SELECT id, user_id, provider
+FROM oauth2_tokens
+WHERE provider = 'github';
+\`\`\`
+
+Inline guidance: prefer \`AsSystemRestricted\` over \`AsSystem\`.
+`;
+
+/** Markdown attachments should render with the same formatter we use for
+ * chat messages, so headings, lists, tables, and fenced code all look
+ * native instead of appearing as a raw monospaced dump. */
+export const MarkdownByExtension: Story = {
+	args: {
+		content: sampleMarkdown,
+		fileName: "AUTH_SPLIT.md",
+		onClose: () => {},
+	},
+	play: async ({ canvasElement }) => {
+		const body = within(canvasElement.ownerDocument.body);
+		const dialog = await body.findByRole("dialog");
+		// The heading should render as a real <h1>, not raw "# Auth split…".
+		const heading = await within(dialog).findByRole("heading", {
+			name: /Auth split runbook/i,
+			level: 1,
+		});
+		expect(heading).toBeInTheDocument();
+		// Inline link from the markdown should be a real anchor.
+		const link = within(dialog).getByRole("link", {
+			name: /the SDK types/i,
+		});
+		expect(link).toHaveAttribute("href", "https://example.com/sdk");
+		// The verbatim "# " heading prefix must not appear as text — that
+		// would mean we fell back to the plain <pre> renderer.
+		expect(dialog.textContent ?? "").not.toContain("# Auth split runbook");
+	},
+};
+
+/** Equivalent to MarkdownByExtension but driven entirely by the explicit
+ * media type so we cover the case where a file lacks a `.md` suffix but
+ * the upload pipeline still tagged it as `text/markdown`. */
+export const MarkdownByMediaType: Story = {
+	args: {
+		content: sampleMarkdown,
+		fileName: "runbook",
+		mediaType: "text/markdown",
+		onClose: () => {},
+	},
+	play: async ({ canvasElement }) => {
+		const body = within(canvasElement.ownerDocument.body);
+		const dialog = await body.findByRole("dialog");
+		const heading = await within(dialog).findByRole("heading", {
+			name: /Auth split runbook/i,
+			level: 1,
+		});
+		expect(heading).toBeInTheDocument();
+	},
+};
+
+/** When the file looks like markdown but the body is just plain prose, the
+ * Markdown renderer should still produce a clean paragraph rather than a
+ * monospaced block. */
+export const MarkdownProseOnly: Story = {
+	args: {
+		content:
+			"Just a short paragraph of prose with **bold** and _italic_ runs and an inline `code` token.",
+		fileName: "notes.md",
+		onClose: () => {},
+	},
+	play: async ({ canvasElement }) => {
+		const body = within(canvasElement.ownerDocument.body);
+		const dialog = await body.findByRole("dialog");
+		await waitFor(() => {
+			// The markdown renderer schedules updates via useTransition,
+			// so wait for the inline formatting nodes to appear before
+			// asserting on them. Streamdown renders bold as a styled
+			// <span data-streamdown="strong"> rather than a literal
+			// <strong> element.
+			const strong = dialog.querySelector('[data-streamdown="strong"]');
+			expect(strong?.textContent).toBe("bold");
+		});
+		const em = dialog.querySelector("em");
+		expect(em?.textContent).toBe("italic");
+		// Inline code should render in a <code> element.
+		const code = dialog.querySelector("code");
+		expect(code?.textContent).toBe("code");
+		// Raw markdown markers should not be visible as text.
+		expect(dialog.textContent ?? "").not.toContain("**bold**");
+	},
+};
+
+/** Plain `.txt` files should keep the existing monospaced rendering so we
+ * don't regress the original code-style preview. */
+export const PlainTextStaysMonospaced: Story = {
+	args: {
+		content: "function add(a, b) {\n  return a + b;\n}\n",
+		fileName: "snippet.txt",
+		onClose: () => {},
+	},
+	play: async ({ canvasElement }) => {
+		const body = within(canvasElement.ownerDocument.body);
+		const dialog = await body.findByRole("dialog");
+		const pre = dialog.querySelector("pre");
+		expect(pre).not.toBeNull();
+		expect(pre?.textContent).toContain("function add(a, b)");
 	},
 };

--- a/site/src/pages/AgentsPage/components/TextPreviewDialog.stories.tsx
+++ b/site/src/pages/AgentsPage/components/TextPreviewDialog.stories.tsx
@@ -118,7 +118,7 @@ export const MarkdownByExtension: Story = {
 			name: /the SDK types/i,
 		});
 		expect(link).toHaveAttribute("href", "https://example.com/sdk");
-		// The verbatim "# " heading prefix must not appear as text — that
+		// The verbatim "# " heading prefix must not appear as text. That
 		// would mean we fell back to the plain <pre> renderer.
 		expect(dialog.textContent ?? "").not.toContain("# Auth split runbook");
 	},

--- a/site/src/pages/AgentsPage/components/TextPreviewDialog.tsx
+++ b/site/src/pages/AgentsPage/components/TextPreviewDialog.tsx
@@ -1,17 +1,43 @@
 import type { FC } from "react";
 import { Dialog, DialogContent, DialogTitle } from "#/components/Dialog/Dialog";
+import { Response } from "./ChatElements/Response";
 
 interface TextPreviewDialogProps {
 	content: string;
 	fileName?: string;
+	/** Explicit media type for the attachment, if known. */
+	mediaType?: string;
 	onClose: () => void;
 }
+
+/**
+ * Returns true when the attachment should render as Markdown rather than as
+ * a monospaced code block. We trust an explicit `text/markdown` media type
+ * when available and otherwise fall back to the file extension, which is
+ * how attached `.md` files arrive from the OS file picker.
+ */
+const isMarkdownPreview = (
+	fileName: string | undefined,
+	mediaType: string | undefined,
+): boolean => {
+	if (mediaType === "text/markdown") {
+		return true;
+	}
+	if (!fileName) {
+		return false;
+	}
+	const lower = fileName.toLowerCase();
+	return lower.endsWith(".md") || lower.endsWith(".markdown");
+};
 
 export const TextPreviewDialog: FC<TextPreviewDialogProps> = ({
 	content,
 	fileName,
+	mediaType,
 	onClose,
 }) => {
+	const renderAsMarkdown = isMarkdownPreview(fileName, mediaType);
+
 	return (
 		<Dialog open onOpenChange={(open) => !open && onClose()}>
 			<DialogContent
@@ -22,9 +48,16 @@ export const TextPreviewDialog: FC<TextPreviewDialogProps> = ({
 					{fileName ?? "Pasted text"}
 				</DialogTitle>
 				<div className="overflow-auto p-4 max-h-[calc(85vh-3rem)]">
-					<pre className="whitespace-pre-wrap break-words text-sm text-content-primary font-mono m-0">
-						{content}
-					</pre>
+					{renderAsMarkdown ? (
+						// Reuse the same Markdown renderer used for chat messages
+						// so attached markdown previews look consistent with the
+						// rest of the conversation.
+						<Response className="max-w-3xl">{content}</Response>
+					) : (
+						<pre className="whitespace-pre-wrap break-words text-sm text-content-primary font-mono m-0">
+							{content}
+						</pre>
+					)}
 				</div>
 			</DialogContent>
 		</Dialog>


### PR DESCRIPTION
Markdown attachments on `/agents` now render through the same `Response` component used for chat messages instead of falling back to a monospaced `<pre>` block. The popup detects markdown via an explicit `text/markdown` media type and falls back to the `.md`/`.markdown` filename extension when no media type is available.

`PreviewTextAttachment` and `TextPreviewDialog` gain an optional `mediaType` so that callers (`AttachmentBlock` for already-sent messages and `AttachmentPreview` for live drafts) can plumb the upload metadata through. Plain `.txt` and unrecognized text attachments keep the existing monospaced rendering.

## Demo

![Markdown attachment preview demo](https://raw.githubusercontent.com/coder/coder/kylecarbs/preview-assets-md-attachments/markdown-attachment-preview.gif)

## Screenshots

| Markdown rendering | Plain text rendering |
| --- | --- |
| ![Markdown by extension](https://raw.githubusercontent.com/coder/coder/kylecarbs/preview-assets-md-attachments/markdown-by-extension.png) | ![Plain text stays monospaced](https://raw.githubusercontent.com/coder/coder/kylecarbs/preview-assets-md-attachments/plain-text-stays-monospaced.png) |

Light theme also verified:

![Markdown by extension (light)](https://raw.githubusercontent.com/coder/coder/kylecarbs/preview-assets-md-attachments/markdown-by-extension-light.png)

<details>
<summary>Coverage details</summary>

New stories in `TextPreviewDialog.stories.tsx` cover:

- `MarkdownByExtension` — `.md` filename, headings/lists/tables/fenced code render natively.
- `MarkdownByMediaType` — explicit `text/markdown` mediaType wins even without a `.md` suffix.
- `MarkdownProseOnly` — inline `**bold**`, `_italic_`, and `` `code` `` render via streamdown.
- `PlainTextStaysMonospaced` — `.txt` content stays inside `<pre>` so existing previews don't regress.

Manual verification (desktop, Chromium, dark + light): all four stories above plus the existing `Default`, `LongContent`, and `NoFileName` stories pass.
</details>

_Coder Agents generated PR._