### PR TITLE
docs: Testing `tf` vs. `hcl` on Terraform code blocks

### DIFF
--- a/docs/admin/templates/extending-templates/resource-metadata.md
+++ b/docs/admin/templates/extending-templates/resource-metadata.md
@@ -63,7 +63,7 @@ Some resources don't need to be exposed in the dashboard's UI. This helps keep
 the workspace view clean for developers. To hide a resource, use the `hide`
 attribute:
 
-```tf
+```hcl
 resource "coder_metadata" "hide_serviceaccount" {
   count = data.coder_workspace.me.start_count
   resource_id = kubernetes_service_account.user_data.id


### PR DESCRIPTION
The syntax highlighting when using `tf` looks somewhat bland. I wonder if changing the formatting to HCL has any impact.

<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->
