### PR TITLE
feat(site): warn when viewing another user's chat

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -122,7 +122,7 @@ const mockModelConfigs: TypesGen.ChatModelConfig[] = [
 
 const baseChatFields = {
 	organization_id: "test-org-id",
-	owner_id: "owner-id",
+	owner_id: MockUserOwner.id,
 	workspace_id: mockWorkspace.id,
 	last_model_config_id: MODEL_CONFIG_ID,
 	mcp_server_ids: [],
@@ -1110,6 +1110,30 @@ export const Loading: Story = {
 			{ messages: [], queued_messages: [], has_more: false },
 			{ diffUrl: undefined },
 		),
+	},
+};
+
+export const AdminViewingOtherUserChat: Story = {
+	parameters: {
+		queries: buildQueries(
+			{
+				id: CHAT_ID,
+				...baseChatFields,
+				owner_id: "other-user-id",
+				title: "Other user's chat",
+				status: "completed",
+			},
+			{ messages: [], queued_messages: [], has_more: false },
+			{ diffUrl: undefined },
+		),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const banner = await canvas.findByRole("alert");
+		expect(banner).toBeVisible();
+		expect(banner).toHaveTextContent(
+			"This is not your chat. Prompting here will use the chat owner's identity.",
+		);
 	},
 };
 

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -19,7 +19,11 @@ import {
 } from "#/api/queries/chats";
 import { workspaceByIdKey } from "#/api/queries/workspaces";
 import type * as TypesGen from "#/api/typesGenerated";
-import { MockUserOwner, MockWorkspace } from "#/testHelpers/entities";
+import {
+	MockUserMember,
+	MockUserOwner,
+	MockWorkspace,
+} from "#/testHelpers/entities";
 import {
 	withAuthProvider,
 	withDashboardProvider,
@@ -1115,24 +1119,36 @@ export const Loading: Story = {
 
 export const AdminViewingOtherUserChat: Story = {
 	parameters: {
-		queries: buildQueries(
+		queries: [
+			...buildQueries(
+				{
+					id: CHAT_ID,
+					...baseChatFields,
+					owner_id: "other-user-id",
+					title: "Other user's chat",
+					status: "completed",
+				},
+				{ messages: [], queued_messages: [], has_more: false },
+				{ diffUrl: undefined },
+			),
 			{
-				id: CHAT_ID,
-				...baseChatFields,
-				owner_id: "other-user-id",
-				title: "Other user's chat",
-				status: "completed",
+				key: ["user", "other-user-id"],
+				data: {
+					...MockUserMember,
+					id: "other-user-id",
+					username: "OtherUser",
+				},
 			},
-			{ messages: [], queued_messages: [], has_more: false },
-			{ diffUrl: undefined },
-		),
+		],
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const banner = await canvas.findByRole("alert");
 		expect(banner).toBeVisible();
-		expect(banner).toHaveTextContent(
-			"This is not your chat. Prompting here will use the chat owner's identity.",
+		await waitFor(() =>
+			expect(banner).toHaveTextContent(
+				"This is not your chat. Prompting here will use @OtherUser's identity.",
+			),
 		);
 	},
 };

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -1103,7 +1103,9 @@ export const WithMessageHistory: Story = {
 			await canvas.findByText("Markdown rendering showcase"),
 		).toBeVisible();
 		await waitFor(() =>
-			expect(canvas.queryByRole("alert")).not.toBeInTheDocument(),
+			expect(
+				canvas.queryByText(/^This is not your chat/),
+			).not.toBeInTheDocument(),
 		);
 	},
 };
@@ -1152,13 +1154,37 @@ export const AdminViewingOtherUserChat: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		const banner = await canvas.findByRole("alert");
-		expect(banner).toBeVisible();
-		await waitFor(() =>
-			expect(banner).toHaveTextContent(
-				"This is not your chat. Prompting here will use @OtherUser's identity.",
-			),
+		const banner = await canvas.findByText(
+			"This is not your chat. Prompting here will use @OtherUser's identity.",
 		);
+		expect(banner).toBeVisible();
+		expect(banner).toHaveAttribute("role", "status");
+	},
+};
+
+export const ArchivedOtherUserChat: Story = {
+	parameters: {
+		queries: buildQueries(
+			{
+				id: CHAT_ID,
+				...baseChatFields,
+				archived: true,
+				owner_id: "other-user-id",
+				title: "Archived other user's chat",
+				status: "completed",
+			},
+			{ messages: [], queued_messages: [], has_more: false },
+			{ diffUrl: undefined },
+		),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			await canvas.findByText("This agent has been archived and is read-only."),
+		).toBeVisible();
+		expect(
+			canvas.queryByText(/^This is not your chat/),
+		).not.toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -1097,6 +1097,15 @@ export const WithMessageHistory: Story = {
 			{ diffUrl: undefined },
 		),
 	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			await canvas.findByText("Markdown rendering showcase"),
+		).toBeVisible();
+		await waitFor(() =>
+			expect(canvas.queryByRole("alert")).not.toBeInTheDocument(),
+		);
+	},
 };
 
 /** Skeleton placeholder when no query data is available yet. */

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -36,6 +36,7 @@ import {
 	userCompactionThresholds,
 } from "#/api/queries/chats";
 import { deploymentSSHConfig } from "#/api/queries/deployment";
+import { user as userQuery } from "#/api/queries/users";
 import {
 	workspaceById,
 	workspaceByIdKey,
@@ -646,7 +647,7 @@ const AgentChatPage: FC = () => {
 		scrollContainerRef,
 	} = useOutletContext<AgentsOutletContext>();
 	const queryClient = useQueryClient();
-	const { user } = useAuthenticated();
+	const { user: currentUser } = useAuthenticated();
 	const [selectedModel, setSelectedModel] = useState("");
 	const scrollToBottomRef = useRef<(() => void) | null>(null);
 	const chatInputRef = useRef<ChatMessageInputRef | null>(null);
@@ -798,9 +799,13 @@ const AgentChatPage: FC = () => {
 	const { proxy } = useProxy();
 
 	const chatRecord = chatQuery.data;
-	const isViewingNonOwnedChat = Boolean(
-		chatRecord?.owner_id && user.id !== chatRecord.owner_id,
-	);
+	const isArchived = chatRecord?.archived ?? false;
+	const isViewerNotOwner =
+		chatRecord !== undefined && currentUser.id !== chatRecord.owner_id;
+	const chatOwnerQuery = useQuery({
+		...userQuery(chatRecord?.owner_id ?? ""),
+		enabled: isViewerNotOwner && !isArchived,
+	});
 	const planModeEnabled = chatRecord?.plan_mode === "plan";
 
 	// Initialize MCP selection from chat record or defaults.
@@ -854,7 +859,6 @@ const AgentChatPage: FC = () => {
 					has_more: chatMessagesQuery.data?.pages.at(-1)?.has_more ?? false,
 				}
 			: undefined;
-	const isArchived = chatRecord?.archived ?? false;
 	const isRegenerateTitleDisabled = isArchived || isRegeneratingThisChat;
 	const chatLastModelConfigID = chatRecord?.last_model_config_id;
 
@@ -1461,7 +1465,9 @@ const AgentChatPage: FC = () => {
 			parentChat={parentChat}
 			persistedError={persistedError}
 			isArchived={isArchived}
-			isViewingNonOwnedChat={isViewingNonOwnedChat}
+			isViewerNotOwner={isViewerNotOwner}
+			chatOwnerId={chatQuery.data.owner_id}
+			chatOwnerUsername={chatOwnerQuery.data?.username}
 			workspace={workspace}
 			workspaceAgent={workspaceAgent}
 			chatBuildId={chatQuery.data?.build_id}

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -44,6 +44,7 @@ import {
 import type * as TypesGen from "#/api/typesGenerated";
 import type { ChatMessagePart } from "#/api/typesGenerated";
 import { useProxy } from "#/contexts/ProxyContext";
+import { useAuthenticated } from "#/hooks/useAuthenticated";
 import { isMobileViewport } from "#/utils/mobile";
 import { pageTitle } from "#/utils/page";
 import { rewriteLocalhostURL } from "#/utils/portForward";
@@ -645,6 +646,7 @@ const AgentChatPage: FC = () => {
 		scrollContainerRef,
 	} = useOutletContext<AgentsOutletContext>();
 	const queryClient = useQueryClient();
+	const { user } = useAuthenticated();
 	const [selectedModel, setSelectedModel] = useState("");
 	const scrollToBottomRef = useRef<(() => void) | null>(null);
 	const chatInputRef = useRef<ChatMessageInputRef | null>(null);
@@ -796,6 +798,9 @@ const AgentChatPage: FC = () => {
 	const { proxy } = useProxy();
 
 	const chatRecord = chatQuery.data;
+	const isViewingNonOwnedChat = Boolean(
+		chatRecord?.owner_id && user.id !== chatRecord.owner_id,
+	);
 	const planModeEnabled = chatRecord?.plan_mode === "plan";
 
 	// Initialize MCP selection from chat record or defaults.
@@ -1456,6 +1461,7 @@ const AgentChatPage: FC = () => {
 			parentChat={parentChat}
 			persistedError={persistedError}
 			isArchived={isArchived}
+			isViewingNonOwnedChat={isViewingNonOwnedChat}
 			workspace={workspace}
 			workspaceAgent={workspaceAgent}
 			chatBuildId={chatQuery.data?.build_id}

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -806,6 +806,15 @@ const AgentChatPage: FC = () => {
 		...userQuery(chatRecord?.owner_id ?? ""),
 		enabled: isViewerNotOwner && !isArchived,
 	});
+	const chatOwner =
+		isViewerNotOwner && chatRecord !== undefined
+			? {
+					id: chatRecord.owner_id,
+					...(chatOwnerQuery.data?.username
+						? { username: chatOwnerQuery.data.username }
+						: {}),
+				}
+			: undefined;
 	const planModeEnabled = chatRecord?.plan_mode === "plan";
 
 	// Initialize MCP selection from chat record or defaults.
@@ -1465,9 +1474,7 @@ const AgentChatPage: FC = () => {
 			parentChat={parentChat}
 			persistedError={persistedError}
 			isArchived={isArchived}
-			isViewerNotOwner={isViewerNotOwner}
-			chatOwnerId={chatQuery.data.owner_id}
-			chatOwnerUsername={chatOwnerQuery.data?.username}
+			chatOwner={chatOwner}
 			workspace={workspace}
 			workspaceAgent={workspaceAgent}
 			chatBuildId={chatQuery.data?.build_id}

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -247,6 +247,25 @@ export const AdminViewingOtherUserChat: Story = {
 	},
 };
 
+/** Shows the owner ID fallback while the owner profile is unavailable. */
+export const OtherUserChatOwnerFallback: Story = {
+	render: () => (
+		<StoryAgentChatPageView
+			isViewerNotOwner
+			chatOwnerId="other-user-id"
+			chatOwnerUsername={undefined}
+		/>
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const banner = canvas.getByRole("alert");
+		expect(banner).toBeVisible();
+		expect(banner).toHaveTextContent(
+			"This is not your chat. Prompting here will use owner other-user-id's identity.",
+		);
+	},
+};
+
 /** Archived chats stay read-only without the identity warning banner. */
 export const ArchivedOtherUserChat: Story = {
 	render: () => (

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -136,7 +136,9 @@ const StoryAgentChatPageView: FC<StoryProps> = ({ editing, ...overrides }) => {
 		persistedError: undefined as ChatDetailError | undefined,
 		parentChat: undefined as TypesGen.Chat | undefined,
 		isArchived: false,
-		isViewingNonOwnedChat: false,
+		isViewerNotOwner: false,
+		chatOwnerId: MockUserOwner.id,
+		chatOwnerUsername: MockUserOwner.username,
 		effectiveSelectedModel: defaultModelConfigID,
 		setSelectedModel: fn(),
 		modelOptions: defaultModelOptions,
@@ -215,6 +217,10 @@ type Story = StoryObj<typeof AgentChatPageView>;
 /** Basic conversation view with a chat title, workspace, and no archive. */
 export const Default: Story = {
 	render: () => <StoryAgentChatPageView />,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.queryByRole("alert")).not.toBeInTheDocument();
+	},
 };
 
 /** Archived agent displays the read-only banner below the top bar. */
@@ -222,16 +228,42 @@ export const Archived: Story = {
 	render: () => <StoryAgentChatPageView isArchived isInputDisabled />,
 };
 
-/** Admin viewing another user's chat sees identity warning copy. */
+/** Shows an identity warning banner when viewing a chat owned by another user. */
 export const AdminViewingOtherUserChat: Story = {
-	render: () => <StoryAgentChatPageView isViewingNonOwnedChat />,
+	render: () => (
+		<StoryAgentChatPageView
+			isViewerNotOwner
+			chatOwnerId="other-user-id"
+			chatOwnerUsername="OtherUser"
+		/>
+	),
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const banner = canvas.getByRole("alert");
 		expect(banner).toBeVisible();
 		expect(banner).toHaveTextContent(
-			"This is not your chat. Prompting here will use the chat owner's identity.",
+			"This is not your chat. Prompting here will use @OtherUser's identity.",
 		);
+	},
+};
+
+/** Archived chats stay read-only without the identity warning banner. */
+export const ArchivedOtherUserChat: Story = {
+	render: () => (
+		<StoryAgentChatPageView
+			isArchived
+			isViewerNotOwner
+			isInputDisabled
+			chatOwnerId="other-user-id"
+			chatOwnerUsername="OtherUser"
+		/>
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.queryByRole("alert")).not.toBeInTheDocument();
+		expect(
+			canvas.getByText("This agent has been archived and is read-only."),
+		).toBeVisible();
 	},
 };
 

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -136,9 +136,9 @@ const StoryAgentChatPageView: FC<StoryProps> = ({ editing, ...overrides }) => {
 		persistedError: undefined as ChatDetailError | undefined,
 		parentChat: undefined as TypesGen.Chat | undefined,
 		isArchived: false,
-		isViewerNotOwner: false,
-		chatOwnerId: MockUserOwner.id,
-		chatOwnerUsername: MockUserOwner.username,
+		chatOwner: undefined as ComponentProps<
+			typeof AgentChatPageView
+		>["chatOwner"],
 		effectiveSelectedModel: defaultModelConfigID,
 		setSelectedModel: fn(),
 		modelOptions: defaultModelOptions,
@@ -219,7 +219,9 @@ export const Default: Story = {
 	render: () => <StoryAgentChatPageView />,
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		expect(canvas.queryByRole("alert")).not.toBeInTheDocument();
+		expect(
+			canvas.queryByText(/^This is not your chat/),
+		).not.toBeInTheDocument();
 	},
 };
 
@@ -232,37 +234,29 @@ export const Archived: Story = {
 export const AdminViewingOtherUserChat: Story = {
 	render: () => (
 		<StoryAgentChatPageView
-			isViewerNotOwner
-			chatOwnerId="other-user-id"
-			chatOwnerUsername="OtherUser"
+			chatOwner={{ id: "other-user-id", username: "OtherUser" }}
 		/>
 	),
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		const banner = canvas.getByRole("alert");
-		expect(banner).toBeVisible();
-		expect(banner).toHaveTextContent(
+		const banner = canvas.getByText(
 			"This is not your chat. Prompting here will use @OtherUser's identity.",
 		);
+		expect(banner).toBeVisible();
+		expect(banner).toHaveAttribute("role", "status");
 	},
 };
 
 /** Shows the owner ID fallback while the owner profile is unavailable. */
 export const OtherUserChatOwnerFallback: Story = {
-	render: () => (
-		<StoryAgentChatPageView
-			isViewerNotOwner
-			chatOwnerId="other-user-id"
-			chatOwnerUsername={undefined}
-		/>
-	),
+	render: () => <StoryAgentChatPageView chatOwner={{ id: "other-user-id" }} />,
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		const banner = canvas.getByRole("alert");
-		expect(banner).toBeVisible();
-		expect(banner).toHaveTextContent(
+		const banner = canvas.getByText(
 			"This is not your chat. Prompting here will use owner other-user-id's identity.",
 		);
+		expect(banner).toBeVisible();
+		expect(banner).toHaveAttribute("role", "status");
 	},
 };
 
@@ -271,15 +265,15 @@ export const ArchivedOtherUserChat: Story = {
 	render: () => (
 		<StoryAgentChatPageView
 			isArchived
-			isViewerNotOwner
 			isInputDisabled
-			chatOwnerId="other-user-id"
-			chatOwnerUsername="OtherUser"
+			chatOwner={{ id: "other-user-id", username: "OtherUser" }}
 		/>
 	),
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		expect(canvas.queryByRole("alert")).not.toBeInTheDocument();
+		expect(
+			canvas.queryByText(/^This is not your chat/),
+		).not.toBeInTheDocument();
 		expect(
 			canvas.getByText("This agent has been archived and is read-only."),
 		).toBeVisible();

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -136,6 +136,7 @@ const StoryAgentChatPageView: FC<StoryProps> = ({ editing, ...overrides }) => {
 		persistedError: undefined as ChatDetailError | undefined,
 		parentChat: undefined as TypesGen.Chat | undefined,
 		isArchived: false,
+		isViewingNonOwnedChat: false,
 		effectiveSelectedModel: defaultModelConfigID,
 		setSelectedModel: fn(),
 		modelOptions: defaultModelOptions,
@@ -219,6 +220,19 @@ export const Default: Story = {
 /** Archived agent displays the read-only banner below the top bar. */
 export const Archived: Story = {
 	render: () => <StoryAgentChatPageView isArchived isInputDisabled />,
+};
+
+/** Admin viewing another user's chat sees identity warning copy. */
+export const AdminViewingOtherUserChat: Story = {
+	render: () => <StoryAgentChatPageView isViewingNonOwnedChat />,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const banner = canvas.getByRole("alert");
+		expect(banner).toBeVisible();
+		expect(banner).toHaveTextContent(
+			"This is not your chat. Prompting here will use the chat owner's identity.",
+		);
+	},
 };
 
 /** Shows the parent chat link in the top bar when a parent exists. */

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -87,7 +87,9 @@ interface AgentChatPageViewProps {
 	parentChat: TypesGen.Chat | undefined;
 	persistedError: ChatDetailError | undefined;
 	isArchived: boolean;
-	isViewingNonOwnedChat: boolean;
+	isViewerNotOwner: boolean;
+	chatOwnerId: string;
+	chatOwnerUsername?: string;
 	workspaceAgent?: TypesGen.WorkspaceAgent;
 	workspace?: TypesGen.Workspace;
 	chatBuildId?: string;
@@ -189,7 +191,9 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	parentChat,
 	persistedError,
 	isArchived,
-	isViewingNonOwnedChat,
+	isViewerNotOwner,
+	chatOwnerId,
+	chatOwnerUsername,
 	workspaceAgent,
 	workspace,
 	chatBuildId,
@@ -405,6 +409,10 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 		editing.editingMessageId !== null ||
 		editing.editingQueuedMessageID !== null;
 
+	const chatOwnerLabel = chatOwnerUsername
+		? `@${chatOwnerUsername}`
+		: `owner ${chatOwnerId}`;
+
 	const titleElement = (
 		<title>
 			{chatTitle ? pageTitle(chatTitle, "Agents") : pageTitle("Agents")}
@@ -455,14 +463,14 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 								isSidebarCollapsed={isSidebarCollapsed}
 								onToggleSidebarCollapsed={onToggleSidebarCollapsed}
 							/>
-							{isViewingNonOwnedChat && (
+							{isViewerNotOwner && !isArchived && (
 								<div
 									role="alert"
 									className="flex shrink-0 items-center gap-2 border-b border-border-warning bg-surface-orange px-4 py-2 text-xs text-content-primary"
 								>
 									<TriangleAlertIcon className="h-4 w-4 shrink-0 text-content-warning" />
-									This is not your chat. Prompting here will use the chat
-									owner's identity.
+									This is not your chat. Prompting here will use{" "}
+									{chatOwnerLabel}'s identity.
 								</div>
 							)}
 							{isArchived && (

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -1,4 +1,4 @@
-import { ArchiveIcon } from "lucide-react";
+import { ArchiveIcon, TriangleAlertIcon } from "lucide-react";
 
 import {
 	type FC,
@@ -87,6 +87,7 @@ interface AgentChatPageViewProps {
 	parentChat: TypesGen.Chat | undefined;
 	persistedError: ChatDetailError | undefined;
 	isArchived: boolean;
+	isViewingNonOwnedChat: boolean;
 	workspaceAgent?: TypesGen.WorkspaceAgent;
 	workspace?: TypesGen.Workspace;
 	chatBuildId?: string;
@@ -188,6 +189,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	parentChat,
 	persistedError,
 	isArchived,
+	isViewingNonOwnedChat,
 	workspaceAgent,
 	workspace,
 	chatBuildId,
@@ -453,6 +455,16 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 								isSidebarCollapsed={isSidebarCollapsed}
 								onToggleSidebarCollapsed={onToggleSidebarCollapsed}
 							/>
+							{isViewingNonOwnedChat && (
+								<div
+									role="alert"
+									className="flex shrink-0 items-center gap-2 border-b border-border-warning bg-surface-orange px-4 py-2 text-xs text-content-primary"
+								>
+									<TriangleAlertIcon className="h-4 w-4 shrink-0 text-content-warning" />
+									This is not your chat. Prompting here will use the chat
+									owner's identity.
+								</div>
+							)}
 							{isArchived && (
 								<div className="flex shrink-0 items-center gap-2 border-b border-border-default bg-surface-secondary px-4 py-2 text-xs text-content-secondary">
 									<ArchiveIcon className="h-4 w-4 shrink-0" />

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -412,6 +412,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	const chatOwnerLabel = chatOwnerUsername
 		? `@${chatOwnerUsername}`
 		: `owner ${chatOwnerId}`;
+	const chatOwnerWarning = `This is not your chat. Prompting here will use ${chatOwnerLabel}'s identity.`;
 
 	const titleElement = (
 		<title>
@@ -469,8 +470,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 									className="flex shrink-0 items-center gap-2 border-b border-border-warning bg-surface-orange px-4 py-2 text-xs text-content-primary"
 								>
 									<TriangleAlertIcon className="h-4 w-4 shrink-0 text-content-warning" />
-									This is not your chat. Prompting here will use{" "}
-									{chatOwnerLabel}'s identity.
+									{chatOwnerWarning}
 								</div>
 							)}
 							{isArchived && (

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -87,9 +87,7 @@ interface AgentChatPageViewProps {
 	parentChat: TypesGen.Chat | undefined;
 	persistedError: ChatDetailError | undefined;
 	isArchived: boolean;
-	isViewerNotOwner: boolean;
-	chatOwnerId: string;
-	chatOwnerUsername?: string;
+	chatOwner: { id: string; username?: string } | undefined;
 	workspaceAgent?: TypesGen.WorkspaceAgent;
 	workspace?: TypesGen.Workspace;
 	chatBuildId?: string;
@@ -191,9 +189,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	parentChat,
 	persistedError,
 	isArchived,
-	isViewerNotOwner,
-	chatOwnerId,
-	chatOwnerUsername,
+	chatOwner,
 	workspaceAgent,
 	workspace,
 	chatBuildId,
@@ -409,10 +405,16 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 		editing.editingMessageId !== null ||
 		editing.editingQueuedMessageID !== null;
 
-	const chatOwnerLabel = chatOwnerUsername
-		? `@${chatOwnerUsername}`
-		: `owner ${chatOwnerId}`;
-	const chatOwnerWarning = `This is not your chat. Prompting here will use ${chatOwnerLabel}'s identity.`;
+	const chatOwnerLabel =
+		chatOwner === undefined
+			? undefined
+			: chatOwner.username
+				? `@${chatOwner.username}`
+				: `owner ${chatOwner.id}`;
+	const chatOwnerWarning =
+		chatOwnerLabel === undefined
+			? undefined
+			: `This is not your chat. Prompting here will use ${chatOwnerLabel}'s identity.`;
 
 	const titleElement = (
 		<title>
@@ -464,9 +466,10 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 								isSidebarCollapsed={isSidebarCollapsed}
 								onToggleSidebarCollapsed={onToggleSidebarCollapsed}
 							/>
-							{isViewerNotOwner && !isArchived && (
+							{chatOwnerWarning && !isArchived && (
 								<div
-									role="alert"
+									role="status"
+									aria-live="polite"
 									className="flex shrink-0 items-center gap-2 border-b border-border-warning bg-surface-orange px-4 py-2 text-xs text-content-primary"
 								>
 									<TriangleAlertIcon className="h-4 w-4 shrink-0 text-content-warning" />


### PR DESCRIPTION
Shows a persistent warning banner when a user is viewing an active chat they do not own, clarifying that prompts will use the chat owner's identity. The banner resolves the owner username when available and falls back to the owner ID.

Adds Storybook coverage for owned chats, non-owned chats, archived non-owned chats, and the owner ID fallback state.

> Mux is acting on Mike's behalf.
