### PR TITLE
fix(site): show cross-org workspaces as disabled in chat picker

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPage.test.ts
+++ b/site/src/pages/AgentsPage/AgentChatPage.test.ts
@@ -1,11 +1,9 @@
 import { act, renderHook } from "@testing-library/react";
 import { createRef } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type * as TypesGen from "#/api/typesGenerated";
 import {
 	clearPersistedSidebarTabId,
 	draftInputStorageKeyPrefix,
-	filterWorkspaceOptionsByOrganization,
 	getPersistedDraftInputValue,
 	getPersistedSidebarTabId,
 	lastActiveSidebarTabStorageKeyPrefix,
@@ -125,32 +123,6 @@ describe("waitForPendingChatSettingsSyncs", () => {
 
 		workspaceUpdate.reject(new Error("boom"));
 		await expect(waitPromise).rejects.toThrow("boom");
-	});
-});
-
-describe("filterWorkspaceOptionsByOrganization", () => {
-	const makeWorkspace = (id: string, organizationID: string) =>
-		({ id, organization_id: organizationID }) as TypesGen.Workspace;
-
-	it("returns only workspaces from the active chat organization", () => {
-		const workspaces = [
-			makeWorkspace("workspace-1", "org-a"),
-			makeWorkspace("workspace-2", "org-b"),
-			makeWorkspace("workspace-3", "org-a"),
-		];
-
-		expect(filterWorkspaceOptionsByOrganization(workspaces, "org-a")).toEqual([
-			workspaces[0],
-			workspaces[2],
-		]);
-	});
-
-	it("returns an empty list until the chat organization is known", () => {
-		const workspaces = [makeWorkspace("workspace-1", "org-a")];
-
-		expect(filterWorkspaceOptionsByOrganization(workspaces, undefined)).toEqual(
-			[],
-		);
 	});
 });
 

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -703,7 +703,6 @@ const AgentChatPage: FC = () => {
 	const mcpServersQuery = useQuery(mcpServerConfigs());
 	const workspacesQuery = useQuery(workspaces({ q: "owner:me", limit: 0 }));
 	const workspaceOptions = workspacesQuery.data?.workspaces ?? [];
-	const chatOrganizationId = chatQuery.data?.organization_id;
 	const desktopEnabled = desktopEnabledQuery.data?.enable_desktop ?? false;
 	const debugLoggingEnabled =
 		userDebugLoggingQuery.data?.debug_logging_enabled ?? false;
@@ -1473,7 +1472,6 @@ const AgentChatPage: FC = () => {
 			isSubmissionPending={isSubmissionPending}
 			isInterruptPending={isInterruptPending}
 			workspaceOptions={workspaceOptions}
-			chatOrganizationId={chatOrganizationId}
 			selectedWorkspaceId={selectedWorkspaceId}
 			onWorkspaceChange={handleWorkspaceChange}
 			isWorkspaceLoading={isWorkspaceLoading}

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -702,10 +702,8 @@ const AgentChatPage: FC = () => {
 	const userDebugLoggingQuery = useQuery(userChatDebugLogging());
 	const mcpServersQuery = useQuery(mcpServerConfigs());
 	const workspacesQuery = useQuery(workspaces({ q: "owner:me", limit: 0 }));
-	const workspaceOptions = filterWorkspaceOptionsByOrganization(
-		workspacesQuery.data?.workspaces ?? [],
-		chatQuery.data?.organization_id,
-	);
+	const workspaceOptions = workspacesQuery.data?.workspaces ?? [];
+	const chatOrganizationId = chatQuery.data?.organization_id;
 	const desktopEnabled = desktopEnabledQuery.data?.enable_desktop ?? false;
 	const debugLoggingEnabled =
 		userDebugLoggingQuery.data?.debug_logging_enabled ?? false;
@@ -1475,6 +1473,7 @@ const AgentChatPage: FC = () => {
 			isSubmissionPending={isSubmissionPending}
 			isInterruptPending={isInterruptPending}
 			workspaceOptions={workspaceOptions}
+			chatOrganizationId={chatOrganizationId}
 			selectedWorkspaceId={selectedWorkspaceId}
 			onWorkspaceChange={handleWorkspaceChange}
 			isWorkspaceLoading={isWorkspaceLoading}

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -515,6 +515,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 								onPlanModeToggle={onPlanModeToggle}
 								isModelCatalogLoading={isModelCatalogLoading}
 								workspaceOptions={workspaceOptions}
+								chatOrganizationId={organizationId}
 								selectedWorkspaceId={selectedWorkspaceId}
 								onWorkspaceChange={onWorkspaceChange}
 								isWorkspaceLoading={isWorkspaceLoading}

--- a/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
@@ -714,6 +714,7 @@ export const DetailPageWorkspacePicker: Story = {
 				id: "ws-detail",
 				name: "agents-workspace",
 				owner_name: "mike",
+				organization_id: "org-1",
 			},
 		],
 		selectedWorkspaceId: "ws-detail",
@@ -804,7 +805,12 @@ export const OverflowBadges: Story = {
 			pagerdutyMCP.id,
 		],
 		workspaceOptions: [
-			{ id: "ws-1", name: "my-long-workspace-name", owner_name: "admin" },
+			{
+				id: "ws-1",
+				name: "my-long-workspace-name",
+				owner_name: "admin",
+				organization_id: "org-1",
+			},
 		],
 		selectedWorkspaceId: "ws-1",
 		onWorkspaceChange: fn(),

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -1291,7 +1291,9 @@ const WorkspacePickerList: FC<WorkspacePickerListProps> = ({
 						if (isCrossOrg) {
 							return (
 								<Tooltip key={workspace.id}>
-									<TooltipTrigger asChild>{item}</TooltipTrigger>
+									<TooltipTrigger asChild>
+										<div>{item}</div>
+									</TooltipTrigger>
 									<TooltipContent side="right">
 										Chat and workspace must be in the same organization
 									</TooltipContent>

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -118,9 +118,13 @@ interface AgentChatInputProps {
 		id: string;
 		name: string;
 		owner_name: string;
+		organization_id: string;
 	}>;
 	selectedWorkspaceId?: string | null;
 	onWorkspaceChange?: (id: string | null) => void;
+	// Organization ID of the current chat. When set, workspaces from
+	// other organizations are shown as disabled in the picker.
+	chatOrganizationId?: string;
 	isWorkspaceLoading?: boolean;
 	// Queued user messages rendered above the textarea.
 	queuedMessages?: readonly ChatQueuedMessage[];
@@ -290,6 +294,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 	workspaceOptions,
 	selectedWorkspaceId,
 	onWorkspaceChange,
+	chatOrganizationId,
 	isWorkspaceLoading,
 	queuedMessages = [],
 	onDeleteQueuedMessage,
@@ -865,35 +870,15 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 											<span>Back</span>
 										</button>
 										<Separator className="my-1" />
-										<Command loop>
-											<CommandInput
-												placeholder="Search workspaces..."
-												className="text-xs"
-											/>
-											<CommandList>
-												<CommandEmpty className="text-xs">
-													No workspaces found
-												</CommandEmpty>
-												<CommandGroup>
-													{workspaceOptions?.map((workspace) => (
-														<CommandItem
-															className="text-xs font-normal"
-															key={workspace.id}
-															value={workspace.name}
-															onSelect={() => {
-																onWorkspaceChange?.(workspace.id);
-																setPlusMenuOpen(false);
-															}}
-														>
-															{workspace.name}
-															{selectedWorkspaceId === workspace.id && (
-																<CheckIcon className="ml-auto size-icon-sm shrink-0" />
-															)}
-														</CommandItem>
-													))}
-												</CommandGroup>
-											</CommandList>
-										</Command>
+										<WorkspacePickerList
+											workspaceOptions={workspaceOptions}
+											selectedWorkspaceId={selectedWorkspaceId}
+											chatOrganizationId={chatOrganizationId}
+											onSelect={(id) => {
+												onWorkspaceChange?.(id);
+												setPlusMenuOpen(false);
+											}}
+										/>
 									</div>
 								) : (
 									<>
@@ -966,36 +951,16 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 														sideOffset={8}
 														className="w-64 p-0"
 													>
-														<Command loop>
-															<CommandInput
-																placeholder="Search workspaces..."
-																className="text-xs"
-															/>
-															<CommandList>
-																<CommandEmpty className="text-xs">
-																	No workspaces found
-																</CommandEmpty>
-																<CommandGroup>
-																	{workspaceOptions.map((workspace) => (
-																		<CommandItem
-																			className="text-xs font-normal"
-																			key={workspace.id}
-																			value={workspace.name}
-																			onSelect={() => {
-																				onWorkspaceChange(workspace.id);
-																				setWorkspacePickerOpen(false);
-																				setPlusMenuOpen(false);
-																			}}
-																		>
-																			{workspace.name}
-																			{selectedWorkspaceId === workspace.id && (
-																				<CheckIcon className="ml-auto size-icon-sm shrink-0" />
-																			)}
-																		</CommandItem>
-																	))}
-																</CommandGroup>
-															</CommandList>
-														</Command>
+														<WorkspacePickerList
+															workspaceOptions={workspaceOptions}
+															selectedWorkspaceId={selectedWorkspaceId}
+															chatOrganizationId={chatOrganizationId}
+															onSelect={(id) => {
+																onWorkspaceChange(id);
+																setWorkspacePickerOpen(false);
+																setPlusMenuOpen(false);
+															}}
+														/>
 													</PopoverContent>
 												</Popover>
 											))}
@@ -1262,5 +1227,82 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 				/>
 			)}
 		</>
+	);
+};
+
+/**
+ * Shared workspace picker used by both the mobile and desktop
+ * "Attach workspace" menus. Workspaces from a different organization
+ * than the chat are rendered as disabled items with a tooltip.
+ */
+interface WorkspacePickerListProps {
+	workspaceOptions:
+		| ReadonlyArray<{
+				id: string;
+				name: string;
+				organization_id: string;
+		  }>
+		| undefined;
+	selectedWorkspaceId?: string | null;
+	chatOrganizationId?: string;
+	onSelect: (id: string) => void;
+}
+
+const WorkspacePickerList: FC<WorkspacePickerListProps> = ({
+	workspaceOptions,
+	selectedWorkspaceId,
+	chatOrganizationId,
+	onSelect,
+}) => {
+	return (
+		<Command loop>
+			<CommandInput placeholder="Search workspaces..." className="text-xs" />
+			<CommandList>
+				<CommandEmpty className="text-xs">No workspaces found</CommandEmpty>
+				<CommandGroup>
+					{workspaceOptions?.map((workspace) => {
+						const isCrossOrg =
+							!!chatOrganizationId &&
+							workspace.organization_id !== chatOrganizationId;
+
+						const item = (
+							<CommandItem
+								className={cn(
+									"text-xs font-normal",
+									isCrossOrg &&
+										"text-content-disabled cursor-not-allowed opacity-60",
+								)}
+								key={workspace.id}
+								value={workspace.name}
+								disabled={isCrossOrg}
+								onSelect={() => {
+									if (!isCrossOrg) {
+										onSelect(workspace.id);
+									}
+								}}
+							>
+								{workspace.name}
+								{selectedWorkspaceId === workspace.id && (
+									<CheckIcon className="ml-auto size-icon-sm shrink-0" />
+								)}
+							</CommandItem>
+						);
+
+						if (isCrossOrg) {
+							return (
+								<Tooltip key={workspace.id}>
+									<TooltipTrigger asChild>{item}</TooltipTrigger>
+									<TooltipContent side="right">
+										Chat and workspace must be in the same organization
+									</TooltipContent>
+								</Tooltip>
+							);
+						}
+
+						return item;
+					})}
+				</CommandGroup>
+			</CommandList>
+		</Command>
 	);
 };

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -1270,7 +1270,7 @@ const WorkspacePickerList: FC<WorkspacePickerListProps> = ({
 								className={cn(
 									"text-xs font-normal",
 									isCrossOrg &&
-										"text-content-disabled cursor-not-allowed opacity-60",
+										"cursor-not-allowed opacity-50 data-[disabled=true]:pointer-events-auto",
 								)}
 								key={workspace.id}
 								value={workspace.name}

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -1294,7 +1294,7 @@ const WorkspacePickerList: FC<WorkspacePickerListProps> = ({
 									<TooltipTrigger asChild>
 										<div>{item}</div>
 									</TooltipTrigger>
-									<TooltipContent side="right">
+									<TooltipContent side="top">
 										Chat and workspace must be in the same organization
 									</TooltipContent>
 								</Tooltip>

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -200,6 +200,7 @@ interface ChatPageInputProps {
 	onMCPAuthComplete?: (serverId: string) => void;
 	lastInjectedContext?: readonly TypesGen.ChatMessagePart[];
 	workspaceOptions: readonly TypesGen.Workspace[];
+	chatOrganizationId?: string;
 	selectedWorkspaceId: string | null;
 	onWorkspaceChange: (workspaceId: string | null) => void;
 	isWorkspaceLoading: boolean;
@@ -250,6 +251,7 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 	onMCPAuthComplete,
 	lastInjectedContext,
 	workspaceOptions,
+	chatOrganizationId,
 	selectedWorkspaceId,
 	onWorkspaceChange,
 	isWorkspaceLoading,
@@ -477,6 +479,7 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 			onPlanModeToggle={onPlanModeToggle}
 			isModelCatalogLoading={isModelCatalogLoading}
 			workspaceOptions={workspaceOptions}
+			chatOrganizationId={chatOrganizationId}
 			selectedWorkspaceId={selectedWorkspaceId}
 			onWorkspaceChange={onWorkspaceChange}
 			isWorkspaceLoading={isWorkspaceLoading}


### PR DESCRIPTION
# What does this solve?

When using Agents, I was trying to connect a chat I was using to my workspace. I was unable to find the workspace because it was in another organization as the chat. This was not made obvious, and I spent awhile looking through the docs on why a workspace might be unable to be attached.

This change makes all workspaces visible to the picker, with workspaces in other orgs disabled with a tooltip message saying why.

# What changed

All user workspaces now appear in the picker. Workspaces from a different organization are rendered as disabled (greyed out, not selectable) with a tooltip on hover: "Chat and workspace must be in the same organization."

**Changes:**
- Removed client-side `filterWorkspaceOptionsByOrganization` filtering; pass all workspaces to the picker instead
- Added `chatOrganizationId` prop threaded through `ChatPageContent` to `AgentChatInput`
- Extracted a shared `WorkspacePickerList` component (used by both mobile and desktop pickers) that marks cross-org workspaces as disabled with a tooltip
- Removed the now-unused `filterWorkspaceOptionsByOrganization` function and its tests

<details>
<summary>Generated by Coder Agents</summary>
This PR was generated by Coder's AI agent based on a user report that workspaces from other organizations were invisible in the chat workspace picker, with no explanation for their absence.
</details>

# Examples

### When in the `Coder` org

<img width="496" height="303" alt="Screenshot From 2026-05-04 14-17-10" src="https://github.com/user-attachments/assets/da76d78b-2778-441f-a2dd-fcb2ec6597d8" />

### When in my side org

<img width="496" height="303" alt="Screenshot From 2026-05-04 14-17-02" src="https://github.com/user-attachments/assets/e71dc96e-cdd5-4bfe-93b3-4a713cba434b" />

### On hover

[Screencast From 2026-05-04 14-28-23.webm](https://github.com/user-attachments/assets/6aee5756-6e07-4ff1-84b8-cda5d4563c87)

