### PR TITLE
fix: check home directory for .mcp.json by default

### DIFF
--- a/agent/agentcontextconfig/api.go
+++ b/agent/agentcontextconfig/api.go
@@ -65,7 +65,7 @@ const (
 	DefaultInstructionsFile = "AGENTS.md"
 	DefaultSkillsDir        = ".agents/skills"
 	DefaultSkillMetaFile    = "SKILL.md"
-	DefaultMCPConfigFile    = ".mcp.json"
+	DefaultMCPConfigFile    = "~/.mcp.json,.mcp.json"
 )
 
 // Config holds the agent's context configuration.

--- a/agent/agentcontextconfig/api_test.go
+++ b/agent/agentcontextconfig/api_test.go
@@ -160,16 +160,33 @@ func setupConfigTestEnv(t *testing.T, overrides map[string]string) string {
 func TestResolve(t *testing.T) {
 	//nolint:paralleltest // Uses t.Setenv to mutate process-wide environment.
 	t.Run("Defaults", func(t *testing.T) {
-		setupConfigTestEnv(t, nil)
+		fakeHome := setupConfigTestEnv(t, nil)
 
 		workDir := platformAbsPath("work")
 		cfg, mcpFiles := agentcontextconfig.Resolve(workDir, agentcontextconfig.ReadEnvConfig())
 
 		// Parts is always non-nil.
 		require.NotNil(t, cfg.Parts)
-		// Default MCP config file is ".mcp.json" (relative),
-		// resolved against the working directory.
-		require.Equal(t, []string{filepath.Join(workDir, ".mcp.json")}, mcpFiles)
+		// Default MCP config includes both ~/.mcp.json (home) and
+		// .mcp.json (relative to working directory).
+		require.Equal(t, []string{
+			filepath.Join(fakeHome, ".mcp.json"),
+			filepath.Join(workDir, ".mcp.json"),
+		}, mcpFiles)
+	})
+
+	//nolint:paralleltest // Uses t.Setenv to mutate process-wide environment.
+	t.Run("DefaultsEmptyWorkDir", func(t *testing.T) {
+		fakeHome := setupConfigTestEnv(t, nil)
+
+		// When the working directory is empty (e.g. manifest.Directory
+		// unset), only the home-relative path resolves.
+		cfg, mcpFiles := agentcontextconfig.Resolve("", agentcontextconfig.ReadEnvConfig())
+
+		require.NotNil(t, cfg.Parts)
+		require.Equal(t, []string{
+			filepath.Join(fakeHome, ".mcp.json"),
+		}, mcpFiles)
 	})
 
 	//nolint:paralleltest // Uses t.Setenv to mutate process-wide environment.
@@ -464,6 +481,9 @@ func TestResolve(t *testing.T) {
 }
 
 func TestNewAPI_LazyDirectory(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+	t.Setenv("USERPROFILE", fakeHome)
 	t.Setenv(agentcontextconfig.EnvInstructionsDirs, "")
 	t.Setenv(agentcontextconfig.EnvInstructionsFile, "")
 	t.Setenv(agentcontextconfig.EnvSkillsDirs, "")
@@ -473,15 +493,17 @@ func TestNewAPI_LazyDirectory(t *testing.T) {
 	dir := ""
 	api := agentcontextconfig.NewAPI(func() string { return dir }, agentcontextconfig.ReadEnvConfig())
 
-	// Before directory is set, MCP paths resolve to nothing.
+	// Before directory is set, only the home-relative path resolves.
 	mcpFiles := api.MCPConfigFiles()
-	require.Empty(t, mcpFiles)
+	require.Equal(t, []string{filepath.Join(fakeHome, ".mcp.json")}, mcpFiles)
 
-	// After setting the directory, MCPConfigFiles() picks it up.
+	// After setting the directory, both home and workdir paths resolve.
 	dir = platformAbsPath("work")
 	mcpFiles = api.MCPConfigFiles()
-	require.NotEmpty(t, mcpFiles)
-	require.Equal(t, []string{filepath.Join(dir, ".mcp.json")}, mcpFiles)
+	require.Equal(t, []string{
+		filepath.Join(fakeHome, ".mcp.json"),
+		filepath.Join(dir, ".mcp.json"),
+	}, mcpFiles)
 }
 
 // TestClearEnvVars verifies that ClearEnvVars removes every

--- a/docs/ai-coder/agents/extending-agents.md
+++ b/docs/ai-coder/agents/extending-agents.md
@@ -79,16 +79,18 @@ directory.
 
 Workspace templates can expose custom
 [MCP](https://modelcontextprotocol.io/introduction) tools by placing a
-`.mcp.json` file in the workspace working directory. The agent discovers
-these tools automatically when it connects to a workspace and registers
-them alongside its built-in tools.
+`.mcp.json` file in the user's home directory or the workspace working
+directory. The agent discovers these tools automatically when it connects
+to a workspace and registers them alongside its built-in tools.
 
 ### Configuration
 
-Define MCP servers in `.mcp.json` at the workspace root. Each entry under
-`mcpServers` describes a server. The transport type is inferred from
-whether `command` or `url` is present, or you can set it explicitly with
-`type`:
+Define MCP servers in `~/.mcp.json` (home directory) or `.mcp.json`
+(workspace working directory). Both locations are checked by default —
+the home directory is checked first, then the working directory. Each
+entry under `mcpServers` describes a server. The transport type is inferred
+from whether `command` or `url` is present, or you can set it explicitly
+with `type`:
 
 ```json
 {


### PR DESCRIPTION
## Problem

When a workspace template does not set `directory` on its `coder_agent` resource, the agent's working directory falls back to a temp directory (e.g. `/tmp/coder.XXXXX`). The default MCP config path `.mcp.json` is relative, so it resolves to `<tempdir>/.mcp.json` — which doesn't exist. Users placing `.mcp.json` in their home directory (the conventional location) never get their MCP tools discovered.

## Root Cause

`DefaultMCPConfigFile` was set to `".mcp.json"` (a relative path). `ResolvePath` resolves relative paths against `manifest.Directory`, which comes from the template. When the template doesn't set a directory, the agent's CWD is a temp directory, and `~/.mcp.json` is never checked.

## Fix

Change the default from `".mcp.json"` to `"~/.mcp.json,.mcp.json"` (comma-separated). This means:

- `~/.mcp.json` — always resolves to the home directory (works regardless of template config)
- `.mcp.json` — additionally checks the working directory for project-specific configs (when set)

This matches the pattern already used by `DefaultInstructionsDir = "~/.coder"` which uses the `~/` prefix for home-relative resolution.

## Changes

- `agent/agentcontextconfig/api.go` — update `DefaultMCPConfigFile` constant
- `agent/agentcontextconfig/api_test.go` — update existing tests and add `DefaultsEmptyWorkDir` test case
- `docs/ai-coder/agents/extending-agents.md` — update docs to reflect both locations

<details><summary>Investigation & Decision Log</summary>

### How the bug was found

A workspace had `~/.mcp.json` configured with a Screeps MCP server. The server started fine (responds in <500ms), but no `screeps__*` tools appeared in the agent's tool set.

Tracing the code:
1. `agent.go` passes `manifest.Directory` as the working dir to `agentcontextconfig.NewAPI`
2. `manifest.Directory` was empty/temp for this template
3. `ResolvePath(".mcp.json", "/tmp/coder.XXXXX")` → `/tmp/coder.XXXXX/.mcp.json` (doesn't exist)
4. `ResolvePath(".mcp.json", "")` → `""` (skipped entirely)
5. MCP discovery finds no config → no tools

### Why `~/.mcp.json,.mcp.json`

- Home-first ensures the common case always works
- Comma-separated preserves project-specific override capability
- `ResolvePaths` already handles comma-separated lists and skips empty resolutions
- When `baseDir` is empty, the relative `.mcp.json` silently resolves to `""` and is skipped

</details>

> 🤖 Generated by [Coder Agents](https://coder.com/docs/ai-coder/agents)