### PR TITLE
refactor: use terraform provider methods for user secret env var names

### DIFF
--- a/provisioner/terraform/provision.go
+++ b/provisioner/terraform/provision.go
@@ -2,7 +2,6 @@ package terraform
 
 import (
 	"context"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -419,14 +418,14 @@ func provisionEnv(
 
 	for _, secret := range userSecrets {
 		if secret.EnvName != "" {
-			env = append(env, fmt.Sprintf("CODER_SECRET_ENV_%s=%s", secret.EnvName, string(secret.Value)))
+			env = append(env, provider.SecretEnvEnvironmentVariable(secret.EnvName)+"="+string(secret.Value))
 		}
 		if secret.FilePath != "" {
 			// Environment variables are used to communicate the file path a
 			// secret should be written to. The hex encoding is done because
 			// file paths contain slashes, tildes, and dots that are illegal
 			// in environment variable names.
-			env = append(env, fmt.Sprintf("CODER_SECRET_FILE_%s=%s", hex.EncodeToString([]byte(secret.FilePath)), string(secret.Value)))
+			env = append(env, provider.SecretFileEnvironmentVariable(secret.FilePath)+"="+string(secret.Value))
 		}
 	}
 


### PR DESCRIPTION
The original PR that plumbed secrets to the terraform provider landed before updating terraform-provider-coder to a version that codified the environment variable API contract. This change uses the exported functions from terraform-coder-provider to ensure the contract is defined in one place.