### PR TITLE
fix(agent/x/agentmcp): surface MCP server connection failures and retry

### DIFF
--- a/agent/x/agentmcp/api.go
+++ b/agent/x/agentmcp/api.go
@@ -88,8 +88,11 @@ func (api *API) handleListTools(rw http.ResponseWriter, r *http.Request) {
 		tools = []workspacesdk.MCPToolInfo{}
 	}
 
+	failures := api.manager.Failures()
+
 	httpapi.Write(ctx, rw, http.StatusOK, workspacesdk.ListMCPToolsResponse{
-		Tools: tools,
+		Tools:    tools,
+		Failures: failures,
 	})
 }
 

--- a/agent/x/agentmcp/api_internal_test.go
+++ b/agent/x/agentmcp/api_internal_test.go
@@ -145,6 +145,49 @@ func TestHandleListTools_ReloadOnChange(t *testing.T) {
 	})
 }
 
+func TestHandleListTools_FailedServerSurfaced(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	dir := t.TempDir()
+
+	// Write a config that references a server with a bad command
+	// so it will fail to connect.
+	badEntry := mcpServerEntry{
+		Command: "/nonexistent-binary-that-does-not-exist",
+	}
+	configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{
+		"bad-server": badEntry,
+	})
+
+	m := NewManager(ctx, logger, agentexec.DefaultExecer, nil)
+	t.Cleanup(func() { _ = m.Close() })
+
+	err := m.Reload(ctx, []string{configPath})
+	require.NoError(t, err)
+
+	api := NewAPI(logger, m, func() []string {
+		return []string{configPath}
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/tools", nil)
+	rec := httptest.NewRecorder()
+	api.Routes().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp workspacesdk.ListMCPToolsResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+
+	// No tools should be returned since the server failed.
+	require.Empty(t, resp.Tools)
+
+	// Failures should be surfaced in the response.
+	require.Len(t, resp.Failures, 1)
+	assert.Equal(t, "bad-server", resp.Failures[0].ServerName)
+	assert.NotEmpty(t, resp.Failures[0].Error)
+}
+
 func TestHandleListTools_RefreshParam(t *testing.T) {
 	t.Parallel()
 

--- a/agent/x/agentmcp/manager.go
+++ b/agent/x/agentmcp/manager.go
@@ -71,9 +71,17 @@ type Manager struct {
 	closed    bool
 	servers   map[string]*serverEntry
 	tools     []workspacesdk.MCPToolInfo
+	failures  []workspacesdk.MCPServerFailure
 	snapshot  map[string]fileSnapshot
 	serverGen uint64
 	sf        tailscalesingleflight.Group[string, struct{}]
+
+	// failedConfigs tracks server configs whose last connection
+	// attempt failed. The retry loop uses this to periodically
+	// re-attempt connections without requiring a config-file
+	// change.
+	failedConfigs []ServerConfig
+	retryCancel   context.CancelFunc
 }
 
 // serverEntry pairs a server config with its connected client.
@@ -208,6 +216,13 @@ type connectedServer struct {
 	client *client.Client
 }
 
+// failedConnection records a server config whose connection
+// attempt failed, along with the error that caused it.
+type failedConnection struct {
+	config ServerConfig
+	err    error
+}
+
 // doReload reads MCP config files and performs a differential
 // reconnect. Unchanged servers keep their existing client; new or
 // changed servers get a fresh connection; removed servers are
@@ -225,9 +240,9 @@ func (m *Manager) doReload(ctx context.Context, mcpConfigFiles []string) error {
 		return err
 	}
 
-	connected := m.connectAll(ctx, diff.toConnect)
+	connected, connectFailures := m.connectAll(ctx, diff.toConnect)
 
-	replaced, err := m.installServers(wanted, diff, connected, snap)
+	replaced, err := m.installServers(wanted, diff, connected, connectFailures, snap)
 	if err != nil {
 		return err
 	}
@@ -332,11 +347,12 @@ func (m *Manager) classifyServers(wanted map[string]ServerConfig) (*serverDiff, 
 }
 
 // connectAll runs connectServer in parallel for the given configs.
-// Failed connects are logged and skipped.
-func (m *Manager) connectAll(ctx context.Context, toConnect []ServerConfig) []connectedServer {
+// Failed connects are logged, recorded, and skipped.
+func (m *Manager) connectAll(ctx context.Context, toConnect []ServerConfig) ([]connectedServer, []failedConnection) {
 	var (
 		mu        sync.Mutex
 		connected []connectedServer
+		failed    []failedConnection
 	)
 	var eg errgroup.Group
 	for _, cfg := range toConnect {
@@ -348,6 +364,12 @@ func (m *Manager) connectAll(ctx context.Context, toConnect []ServerConfig) []co
 					slog.F("transport", cfg.Transport),
 					slog.Error(err),
 				)
+				mu.Lock()
+				failed = append(failed, failedConnection{
+					config: cfg,
+					err:    err,
+				})
+				mu.Unlock()
 				return nil // Don't fail the group.
 			}
 			mu.Lock()
@@ -359,7 +381,7 @@ func (m *Manager) connectAll(ctx context.Context, toConnect []ServerConfig) []co
 		})
 	}
 	_ = eg.Wait()
-	return connected
+	return connected, failed
 }
 
 // installServers builds the new server map from diff.keep and the
@@ -370,6 +392,7 @@ func (m *Manager) installServers(
 	wanted map[string]ServerConfig,
 	diff *serverDiff,
 	connected []connectedServer,
+	connectFailures []failedConnection,
 	snap map[string]fileSnapshot,
 ) ([]*serverEntry, error) {
 	m.mu.Lock()
@@ -411,9 +434,37 @@ func (m *Manager) installServers(
 		}
 	}
 
+	// Record connection failures so they can be surfaced via
+	// the tools API and retried in the background.
+	var failures []workspacesdk.MCPServerFailure
+	var failedCfgs []ServerConfig
+	for _, fc := range connectFailures {
+		failures = append(failures, workspacesdk.MCPServerFailure{
+			ServerName: fc.config.Name,
+			Error:      fc.err.Error(),
+		})
+		failedCfgs = append(failedCfgs, fc.config)
+	}
+	m.failures = failures
+	m.failedConfigs = failedCfgs
+
 	m.servers = newServers
 	m.serverGen++
 	m.snapshot = snap
+
+	// Start a background retry loop for failed servers if there
+	// are any. Cancel any existing loop first so we don't leak
+	// goroutines after config changes.
+	if m.retryCancel != nil {
+		m.retryCancel()
+		m.retryCancel = nil
+	}
+	if len(failedCfgs) > 0 {
+		retryCtx, cancel := context.WithCancel(m.ctx)
+		m.retryCancel = cancel
+		go m.retryFailedServers(retryCtx, failedCfgs)
+	}
+
 	return replaced, nil
 }
 
@@ -442,6 +493,15 @@ func (m *Manager) Tools() []workspacesdk.MCPToolInfo {
 	defer m.mu.RUnlock()
 
 	return slices.Clone(m.tools)
+}
+
+// Failures returns the list of MCP servers that failed to
+// connect during the last reload. Thread-safe.
+func (m *Manager) Failures() []workspacesdk.MCPServerFailure {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return slices.Clone(m.failures)
 }
 
 // CallTool proxies a tool call to the appropriate MCP server.
@@ -572,6 +632,92 @@ func (m *Manager) RefreshTools(ctx context.Context) error {
 	return errors.Join(errs...)
 }
 
+// retryInterval is the base interval for retrying failed MCP
+// server connections. Each attempt doubles the interval up to
+// retryMaxInterval.
+const (
+	retryInterval    = 30 * time.Second
+	retryMaxInterval = 5 * time.Minute
+)
+
+// retryFailedServers periodically retries connecting to MCP
+// servers that failed during the initial connection. Servers
+// that connect successfully are installed into the server map
+// and their failures are cleared. The loop exits when all
+// servers connect or ctx is canceled.
+func (m *Manager) retryFailedServers(ctx context.Context, configs []ServerConfig) {
+	interval := retryInterval
+	remaining := slices.Clone(configs)
+
+	for len(remaining) > 0 {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(interval):
+		}
+
+		m.mu.RLock()
+		closed := m.closed
+		m.mu.RUnlock()
+		if closed {
+			return
+		}
+
+		var stillFailed []ServerConfig
+		var newFailures []workspacesdk.MCPServerFailure
+		for _, cfg := range remaining {
+			c, err := m.connectServer(ctx, cfg)
+			if err != nil {
+				m.logger.Warn(ctx, "mcp server retry failed",
+					slog.F("server", cfg.Name),
+					slog.Error(err),
+				)
+				stillFailed = append(stillFailed, cfg)
+				newFailures = append(newFailures, workspacesdk.MCPServerFailure{
+					ServerName: cfg.Name,
+					Error:      err.Error(),
+				})
+				continue
+			}
+
+			m.logger.Info(ctx, "mcp server connected on retry",
+				slog.F("server", cfg.Name),
+			)
+
+			m.mu.Lock()
+			m.servers[cfg.Name] = &serverEntry{
+				config: cfg,
+				client: c,
+			}
+			m.serverGen++
+			m.mu.Unlock()
+		}
+
+		// Update the failure list under the lock.
+		m.mu.Lock()
+		m.failures = newFailures
+		m.failedConfigs = stillFailed
+		m.mu.Unlock()
+
+		remaining = stillFailed
+
+		// Refresh tools to pick up newly connected servers.
+		if err := m.RefreshTools(ctx); err != nil {
+			m.logger.Warn(ctx, "failed to refresh tools after retry",
+				slog.Error(err),
+			)
+		}
+
+		// Exponential backoff capped at retryMaxInterval.
+		interval *= 2
+		if interval > retryMaxInterval {
+			interval = retryMaxInterval
+		}
+	}
+
+	m.logger.Info(ctx, "all previously failed mcp servers connected")
+}
+
 // Close terminates all MCP server connections and child
 // processes.
 func (m *Manager) Close() error {
@@ -579,6 +725,13 @@ func (m *Manager) Close() error {
 	defer m.mu.Unlock()
 
 	m.closed = true
+
+	// Cancel the retry loop before closing servers.
+	if m.retryCancel != nil {
+		m.retryCancel()
+		m.retryCancel = nil
+	}
+
 	var errs []error
 	for _, entry := range m.servers {
 		if err := entry.client.Close(); err != nil {
@@ -593,6 +746,8 @@ func (m *Manager) Close() error {
 	}
 	m.servers = make(map[string]*serverEntry)
 	m.tools = nil
+	m.failures = nil
+	m.failedConfigs = nil
 	return errors.Join(errs...)
 }
 

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -6239,6 +6239,7 @@ func (p *Server) runChat(
 		resolvedUserPrompt string
 		mcpTools           []fantasy.AgentTool
 		mcpCleanup         func()
+		mcpFailures        []mcpclient.ServerFailure
 		workspaceMCPTools  []fantasy.AgentTool
 		skills             []chattool.SkillMeta
 	)
@@ -6327,7 +6328,7 @@ func (p *Server) runChat(
 		g2.Go(func() error {
 			// Refresh expired OAuth2 tokens before connecting.
 			mcpTokens = p.refreshExpiredMCPTokens(ctx, logger, mcpConnectConfigs, mcpTokens)
-			mcpTools, mcpCleanup = mcpclient.ConnectAll(
+			mcpTools, mcpFailures, mcpCleanup = mcpclient.ConnectAll(
 				ctx, logger, mcpConnectConfigs, mcpTokens, chat.OwnerID, p.oidcTokenSource,
 			)
 			return nil
@@ -6435,6 +6436,17 @@ func (p *Server) runChat(
 	}
 	if mcpCleanup != nil {
 		defer mcpCleanup()
+	}
+
+	// Log MCP server connection failures so they appear in
+	// turn-level diagnostics. The failures are already logged
+	// individually during ConnectAll, but surfacing a summary
+	// here keeps the context close to the chat turn.
+	for _, f := range mcpFailures {
+		logger.Warn(ctx, "mcp server unavailable for chat turn",
+			slog.F("server_slug", f.ServerSlug),
+			slog.F("error", f.Error),
+		)
 	}
 
 	// Build a lookup from tool name to MCP server config ID

--- a/coderd/x/chatd/mcpclient/mcpclient.go
+++ b/coderd/x/chatd/mcpclient/mcpclient.go
@@ -61,12 +61,25 @@ type UserOIDCTokenSource interface {
 	OIDCAccessToken(ctx context.Context, userID uuid.UUID) (string, error)
 }
 
+// ServerFailure describes an MCP server that was configured but
+// failed to connect. Returned alongside tools from ConnectAll so
+// callers can surface connection problems to the user.
+type ServerFailure struct {
+	// ServerSlug is the admin-configured identifier for the
+	// MCP server.
+	ServerSlug string
+	// Error is the redacted connection failure message.
+	Error string
+}
+
 // ConnectAll connects to all configured MCP servers, discovers
 // their tools, and returns them as fantasy.AgentTool values.
 // Tools are sorted by their prefixed name so callers
 // receive a deterministic order. It skips servers that fail to
 // connect and logs warnings. The returned cleanup function
-// must be called to close all connections.
+// must be called to close all connections. Failed server
+// connections are reported in the returned ServerFailure slice
+// so callers can surface them to the user.
 func ConnectAll(
 	ctx context.Context,
 	logger slog.Logger,
@@ -74,7 +87,7 @@ func ConnectAll(
 	tokens []database.MCPServerUserToken,
 	userID uuid.UUID,
 	oidcSrc UserOIDCTokenSource,
-) ([]fantasy.AgentTool, func()) {
+) ([]fantasy.AgentTool, []ServerFailure, func()) {
 	// Index tokens by server config ID so auth header
 	// construction is O(1) per server.
 	tokensByConfigID := make(
@@ -85,9 +98,10 @@ func ConnectAll(
 	}
 
 	var (
-		mu      sync.Mutex
-		clients []*client.Client
-		tools   []fantasy.AgentTool
+		mu       sync.Mutex
+		clients  []*client.Client
+		tools    []fantasy.AgentTool
+		failures []ServerFailure
 	)
 
 	// Build cleanup eagerly so it always closes any clients
@@ -118,7 +132,13 @@ func ConnectAll(
 					slog.F("server_url", RedactURL(cfg.Url)),
 					slog.F("error", redactErrorURL(connectErr)),
 				)
-				// Connection failures are not propagated — the
+				mu.Lock()
+				failures = append(failures, ServerFailure{
+					ServerSlug: cfg.Slug,
+					Error:      redactErrorURL(connectErr),
+				})
+				mu.Unlock()
+				// Connection failures are not propagated; the
 				// LLM simply won't have this server's tools.
 				return nil
 			}
@@ -162,7 +182,7 @@ func ConnectAll(
 		)
 	})
 
-	return tools, cleanup
+	return tools, failures, cleanup
 }
 
 // connectOne establishes a connection to a single MCP server,

--- a/coderd/x/chatd/mcpclient/mcpclient_test.go
+++ b/coderd/x/chatd/mcpclient/mcpclient_test.go
@@ -96,7 +96,7 @@ func TestConnectAll_DiscoverTools(t *testing.T) {
 	ts := newTestMCPServer(t, echoTool(), greetTool())
 
 	cfg := makeConfig("myserver", ts.URL)
-	tools, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
+	tools, _, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
 	t.Cleanup(cleanup)
 
 	// Two tools should be discovered, namespaced with the server slug.
@@ -121,7 +121,7 @@ func TestConnectAll_CallTool(t *testing.T) {
 	ts := newTestMCPServer(t, echoTool())
 
 	cfg := makeConfig("srv", ts.URL)
-	tools, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
+	tools, _, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
 	t.Cleanup(cleanup)
 	require.Len(t, tools, 1)
 
@@ -147,7 +147,7 @@ func TestConnectAll_ToolAllowList(t *testing.T) {
 	// Only allow the "echo" tool.
 	cfg.ToolAllowList = []string{"echo"}
 
-	tools, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
+	tools, _, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
 	t.Cleanup(cleanup)
 
 	require.Len(t, tools, 1)
@@ -165,7 +165,7 @@ func TestConnectAll_ToolDenyList(t *testing.T) {
 	// Deny the "greet" tool, so only "echo" remains.
 	cfg.ToolDenyList = []string{"greet"}
 
-	tools, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
+	tools, _, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
 	t.Cleanup(cleanup)
 
 	require.Len(t, tools, 1)
@@ -179,10 +179,15 @@ func TestConnectAll_ConnectionFailure(t *testing.T) {
 
 	cfg := makeConfig("bad", "http://127.0.0.1:0/does-not-exist")
 
-	tools, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
+	tools, failures, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
 	t.Cleanup(cleanup)
 
 	assert.Empty(t, tools, "no tools should be returned for an unreachable server")
+
+	// The failure should be surfaced so callers can report it.
+	require.Len(t, failures, 1)
+	assert.Equal(t, "bad", failures[0].ServerSlug)
+	assert.NotEmpty(t, failures[0].Error)
 }
 
 func TestConnectAll_MultipleServers(t *testing.T) {
@@ -196,7 +201,7 @@ func TestConnectAll_MultipleServers(t *testing.T) {
 	cfg1 := makeConfig("alpha", ts1.URL)
 	cfg2 := makeConfig("beta", ts2.URL)
 
-	tools, cleanup := mcpclient.ConnectAll(
+	tools, _, cleanup := mcpclient.ConnectAll(
 		ctx, logger,
 		[]database.MCPServerConfig{cfg1, cfg2},
 		nil,
@@ -221,7 +226,7 @@ func TestConnectAll_NoToolsAfterFiltering(t *testing.T) {
 	cfg := makeConfig("filtered", ts.URL)
 	cfg.ToolAllowList = []string{"greet"}
 
-	tools, cleanup := mcpclient.ConnectAll(
+	tools, _, cleanup := mcpclient.ConnectAll(
 		ctx,
 		logger,
 		[]database.MCPServerConfig{cfg},
@@ -245,7 +250,7 @@ func TestConnectAll_DeterministicOrder(t *testing.T) {
 		ts2 := newTestMCPServer(t, makeTool("alpha"))
 		ts3 := newTestMCPServer(t, makeTool("middle"))
 
-		tools, cleanup := mcpclient.ConnectAll(
+		tools, _, cleanup := mcpclient.ConnectAll(
 			ctx,
 			logger,
 			[]database.MCPServerConfig{
@@ -275,7 +280,7 @@ func TestConnectAll_DeterministicOrder(t *testing.T) {
 		multi := newTestMCPServer(t, makeTool("zeta"), makeTool("beta"))
 		other := newTestMCPServer(t, makeTool("gamma"))
 
-		tools, cleanup := mcpclient.ConnectAll(
+		tools, _, cleanup := mcpclient.ConnectAll(
 			ctx,
 			logger,
 			[]database.MCPServerConfig{
@@ -311,7 +316,7 @@ func TestConnectAll_DeterministicOrder(t *testing.T) {
 		cfg2 := makeConfig("a__b", ts2.URL)
 		cfg2.ID = uuid.MustParse("00000000-0000-0000-0000-000000000001")
 
-		tools, cleanup := mcpclient.ConnectAll(
+		tools, _, cleanup := mcpclient.ConnectAll(
 			ctx,
 			logger,
 			[]database.MCPServerConfig{cfg1, cfg2},
@@ -376,7 +381,7 @@ func TestConnectAll_AuthHeaders(t *testing.T) {
 		TokenType:         "Bearer",
 	}
 
-	tools, cleanup := mcpclient.ConnectAll(
+	tools, _, cleanup := mcpclient.ConnectAll(
 		ctx, logger,
 		[]database.MCPServerConfig{cfg},
 		[]database.MCPServerUserToken{token},
@@ -435,7 +440,7 @@ func TestConnectAll_DisabledServer(t *testing.T) {
 	cfg := makeConfig("disabled", ts.URL)
 	cfg.Enabled = false
 
-	tools, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
+	tools, _, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
 	t.Cleanup(cleanup)
 	assert.Empty(t, tools)
 }
@@ -450,7 +455,7 @@ func TestConnectAll_CallToolInvalidInput(t *testing.T) {
 	ts := newTestMCPServer(t, echoTool())
 
 	cfg := makeConfig("srv", ts.URL)
-	tools, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
+	tools, _, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
 	t.Cleanup(cleanup)
 	require.Len(t, tools, 1)
 
@@ -475,7 +480,7 @@ func TestConnectAll_ToolInfoParameters(t *testing.T) {
 	ts := newTestMCPServer(t, echoTool())
 
 	cfg := makeConfig("srv", ts.URL)
-	tools, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
+	tools, _, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
 	t.Cleanup(cleanup)
 	require.Len(t, tools, 1)
 
@@ -517,7 +522,7 @@ func TestConnectAll_NilRequiredBecomesEmptySlice(t *testing.T) {
 
 	ts := newTestMCPServer(t, noRequiredTool)
 	cfg := makeConfig("srv", ts.URL)
-	tools, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
+	tools, _, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
 	t.Cleanup(cleanup)
 	require.Len(t, tools, 1)
 
@@ -567,7 +572,7 @@ func TestConnectAll_APIKeyAuth(t *testing.T) {
 	cfg.APIKeyHeader = "X-API-Key"
 	cfg.APIKeyValue = "secret-123"
 
-	tools, cleanup := mcpclient.ConnectAll(
+	tools, _, cleanup := mcpclient.ConnectAll(
 		ctx, logger, []database.MCPServerConfig{cfg}, nil,
 		uuid.Nil, nil,
 	)
@@ -624,7 +629,7 @@ func TestConnectAll_CustomHeadersAuth(t *testing.T) {
 	cfg.AuthType = "custom_headers"
 	cfg.CustomHeaders = `{"X-Custom-Auth":"custom-val"}`
 
-	tools, cleanup := mcpclient.ConnectAll(
+	tools, _, cleanup := mcpclient.ConnectAll(
 		ctx, logger, []database.MCPServerConfig{cfg}, nil,
 		uuid.Nil, nil,
 	)
@@ -661,7 +666,7 @@ func TestConnectAll_CustomHeadersInvalidJSON(t *testing.T) {
 	cfg.AuthType = "custom_headers"
 	cfg.CustomHeaders = "{not json}"
 
-	tools, cleanup := mcpclient.ConnectAll(
+	tools, _, cleanup := mcpclient.ConnectAll(
 		ctx, logger, []database.MCPServerConfig{cfg}, nil,
 		uuid.Nil, nil,
 	)
@@ -720,7 +725,7 @@ func TestConnectAll_UserOIDCAuth(t *testing.T) {
 	userID := uuid.New()
 	src := staticOIDCSource{token: "fake-oidc-token"}
 
-	tools, cleanup := mcpclient.ConnectAll(
+	tools, _, cleanup := mcpclient.ConnectAll(
 		ctx, logger, []database.MCPServerConfig{cfg}, nil,
 		userID, src,
 	)
@@ -779,7 +784,7 @@ func TestConnectAll_UserOIDCAuth_NoLink(t *testing.T) {
 	cfg.AuthType = "user_oidc"
 	src := staticOIDCSource{token: "", err: nil}
 
-	tools, cleanup := mcpclient.ConnectAll(
+	tools, _, cleanup := mcpclient.ConnectAll(
 		ctx, logger, []database.MCPServerConfig{cfg}, nil,
 		uuid.New(), src,
 	)
@@ -815,7 +820,7 @@ func TestConnectAll_UserOIDCAuth_NilSource(t *testing.T) {
 	cfg := makeConfig("oidc-nilsrc", ts.URL)
 	cfg.AuthType = "user_oidc"
 
-	tools, cleanup := mcpclient.ConnectAll(
+	tools, _, cleanup := mcpclient.ConnectAll(
 		ctx, logger, []database.MCPServerConfig{cfg}, nil,
 		uuid.New(), nil,
 	)
@@ -841,7 +846,7 @@ func TestConnectAll_ParallelConnections(t *testing.T) {
 	cfg2 := makeConfig("srv2", ts2.URL)
 	cfg3 := makeConfig("srv3", ts3.URL)
 
-	tools, cleanup := mcpclient.ConnectAll(
+	tools, _, cleanup := mcpclient.ConnectAll(
 		ctx, logger,
 		[]database.MCPServerConfig{cfg1, cfg2, cfg3},
 		nil,
@@ -906,7 +911,7 @@ func TestConnectAll_ExpiredToken(t *testing.T) {
 		Expiry:            sql.NullTime{Time: time.Now().Add(-1 * time.Hour), Valid: true},
 	}
 
-	tools, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, []database.MCPServerUserToken{token}, uuid.Nil, nil)
+	tools, _, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, []database.MCPServerUserToken{token}, uuid.Nil, nil)
 	t.Cleanup(cleanup)
 
 	// The server accepts any auth, so the tool is still discovered
@@ -939,7 +944,7 @@ func TestConnectAll_EmptyAccessToken(t *testing.T) {
 		TokenType:         "Bearer",
 	}
 
-	tools, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, []database.MCPServerUserToken{token}, uuid.Nil, nil)
+	tools, _, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, []database.MCPServerUserToken{token}, uuid.Nil, nil)
 	t.Cleanup(cleanup)
 
 	// Tool is still discovered (server doesn't require auth), but
@@ -969,7 +974,7 @@ func TestConnectAll_MCPToolIdentifier(t *testing.T) {
 		Enabled:     true,
 	}
 
-	tools, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
+	tools, _, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
 	t.Cleanup(cleanup)
 
 	require.Len(t, tools, 1)
@@ -1011,7 +1016,7 @@ func TestConnectAll_MCPToolIdentifier_MultipleServers(t *testing.T) {
 		Enabled:     true,
 	}
 
-	tools, cleanup := mcpclient.ConnectAll(
+	tools, _, cleanup := mcpclient.ConnectAll(
 		ctx, logger,
 		[]database.MCPServerConfig{cfg1, cfg2},
 		nil,
@@ -1072,7 +1077,7 @@ func TestConnectAll_EmbeddedResourceText(t *testing.T) {
 	t.Cleanup(ts.Close)
 
 	cfg := makeConfig("embed-txt", ts.URL)
-	tools, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
+	tools, _, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
 	t.Cleanup(cleanup)
 	require.Len(t, tools, 1)
 
@@ -1139,7 +1144,7 @@ func TestConnectAll_EmbeddedResourceBlob(t *testing.T) {
 			t.Cleanup(ts.Close)
 
 			cfg := makeConfig("embed-blob", ts.URL)
-			tools, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
+			tools, _, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
 			t.Cleanup(cleanup)
 			require.Len(t, tools, 1)
 
@@ -1219,7 +1224,7 @@ func TestConnectAll_ResourceLink(t *testing.T) {
 			t.Cleanup(ts.Close)
 
 			cfg := makeConfig("res-link", ts.URL)
-			tools, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
+			tools, _, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
 			t.Cleanup(cleanup)
 			require.Len(t, tools, 1)
 
@@ -1263,7 +1268,7 @@ func TestConnectAll_CallToolError(t *testing.T) {
 	t.Cleanup(ts.Close)
 
 	cfg := makeConfig("err-srv", ts.URL)
-	tools, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
+	tools, _, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
 	t.Cleanup(cleanup)
 	require.Len(t, tools, 1)
 
@@ -1287,7 +1292,7 @@ func TestModelIntent_Info_WrapsSchema(t *testing.T) {
 	cfg := makeConfig("intent-srv", ts.URL)
 	cfg.ModelIntent = true
 
-	tools, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
+	tools, _, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
 	t.Cleanup(cleanup)
 	require.Len(t, tools, 1)
 
@@ -1323,7 +1328,7 @@ func TestModelIntent_Info_NoWrapWhenDisabled(t *testing.T) {
 	cfg := makeConfig("no-intent", ts.URL)
 	cfg.ModelIntent = false
 
-	tools, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
+	tools, _, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
 	t.Cleanup(cleanup)
 	require.Len(t, tools, 1)
 
@@ -1346,7 +1351,7 @@ func TestModelIntent_Run_UnwrapsProperties(t *testing.T) {
 	cfg := makeConfig("unwrap-srv", ts.URL)
 	cfg.ModelIntent = true
 
-	tools, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
+	tools, _, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
 	t.Cleanup(cleanup)
 	require.Len(t, tools, 1)
 
@@ -1371,7 +1376,7 @@ func TestModelIntent_Run_UnwrapsFlat(t *testing.T) {
 	cfg := makeConfig("flat-srv", ts.URL)
 	cfg.ModelIntent = true
 
-	tools, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
+	tools, _, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
 	t.Cleanup(cleanup)
 	require.Len(t, tools, 1)
 
@@ -1396,7 +1401,7 @@ func TestModelIntent_Run_PassthroughWhenDisabled(t *testing.T) {
 	cfg := makeConfig("pass-srv", ts.URL)
 	cfg.ModelIntent = false
 
-	tools, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
+	tools, _, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
 	t.Cleanup(cleanup)
 	require.Len(t, tools, 1)
 
@@ -1421,7 +1426,7 @@ func TestModelIntent_Run_FallbackOnBadJSON(t *testing.T) {
 	cfg := makeConfig("bad-srv", ts.URL)
 	cfg.ModelIntent = true
 
-	tools, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
+	tools, _, cleanup := mcpclient.ConnectAll(ctx, logger, []database.MCPServerConfig{cfg}, nil, uuid.Nil, nil)
 	t.Cleanup(cleanup)
 	require.Len(t, tools, 1)
 

--- a/codersdk/workspacesdk/agentconn.go
+++ b/codersdk/workspacesdk/agentconn.go
@@ -1109,7 +1109,18 @@ type FileEditResult struct {
 // ListMCPToolsResponse is the response from the agent's
 // MCP tool discovery endpoint.
 type ListMCPToolsResponse struct {
-	Tools []MCPToolInfo `json:"tools"`
+	Tools    []MCPToolInfo      `json:"tools"`
+	Failures []MCPServerFailure `json:"failures,omitempty"`
+}
+
+// MCPServerFailure describes an MCP server that was configured
+// but failed to connect. Surfacing these lets callers distinguish
+// "no MCP servers configured" from "configured but failed."
+type MCPServerFailure struct {
+	// ServerName is the key from .mcp.json (e.g. "github").
+	ServerName string `json:"server_name"`
+	// Error is the human-readable connection failure message.
+	Error string `json:"error"`
 }
 
 // MCPToolInfo describes a single tool discovered from an MCP


### PR DESCRIPTION
Previously, when an MCP server configured in `.mcp.json` failed to connect, the failure was logged at `Warn` level and silently swallowed. The server's tools simply didn't appear in `ListMCPToolsResponse`, making it very difficult to debug why expected tools were missing. Failed servers were also not retried unless the config file changed on disk.

This change addresses both problems:

1. **Surface failures**: Adds `MCPServerFailure` type and `Failures` field to `ListMCPToolsResponse` so connection errors are visible to API callers. The chatd-side `ConnectAll` also returns `ServerFailure` values alongside tools.

2. **Retry failed servers**: The agent-side Manager now starts a background retry loop with exponential backoff (30s base, 5m cap) for servers that fail their initial connection. Successfully reconnected servers are installed into the server map and their tools become available without requiring a config-file touch.

Closes https://github.com/coder/coder/issues/24947

> 🤖 Generated with [Coder Agents](https://coder.com/docs/ai-coder/agents)

<details>
<summary>Changes by file</summary>

- `codersdk/workspacesdk/agentconn.go`: Added `MCPServerFailure` type and `Failures []MCPServerFailure` field to `ListMCPToolsResponse`.
- `agent/x/agentmcp/manager.go`: Track `failures` and `failedConfigs` in Manager. Updated `connectAll` to return failed connections. Updated `installServers` to record failures and start background retry. Added `Failures()` accessor and `retryFailedServers()` with exponential backoff.
- `agent/x/agentmcp/api.go`: Include failures in `handleListTools` response.
- `coderd/x/chatd/mcpclient/mcpclient.go`: Added `ServerFailure` type. Updated `ConnectAll` to return `[]ServerFailure` alongside tools.
- `coderd/x/chatd/chatd.go`: Handle new return value from `ConnectAll`, log failures per chat turn.
- Tests updated for new signatures; added `TestHandleListTools_FailedServerSurfaced` and updated `TestConnectAll_ConnectionFailure` to verify failures are returned.

</details>