### PR TITLE
chore(provisioner/terraform): warn when agent dir breaks Desktop file sync

### DIFF
--- a/provisioner/terraform/provision.go
+++ b/provisioner/terraform/provision.go
@@ -269,6 +269,23 @@ func (s *server) Graph(
 		return provisionersdk.GraphError("convert state for graph: %s", err)
 	}
 
+	// Warn template authors if any agent sets dir to a non-$HOME
+	// value, because this breaks Coder Desktop file sync.
+	for _, resource := range state.Resources {
+		for _, agent := range resource.Agents {
+			if agent.Directory != "" && agent.Directory != "$HOME" && agent.Directory != "~" {
+				sess.ProvisionLog(
+					proto.LogLevel_WARN,
+					fmt.Sprintf(
+						"agent %q has 'dir' set to %q, which will break Coder Desktop file sync. "+
+							"Set 'dir' to a value that expands to the user's home directory or leave it unset.",
+						agent.Name, agent.Directory,
+					),
+				)
+			}
+		}
+	}
+
 	return &proto.GraphComplete{
 		Error:                 "",
 		Timings:               e.timings.aggregate(),


### PR DESCRIPTION
Emits a WARN-level build log when a `coder_agent` resource has `dir` set to a value other than `$HOME` or `~`, because this breaks Coder Desktop file sync.

Refs DEVEX-227

A companion change to the `coder_agent` Terraform provider docs is at [coder/terraform-provider-coder](https://github.com/coder/terraform-provider-coder) (to be submitted separately).

<details>
<summary>Implementation notes</summary>

The warning is emitted in `server.Graph()` after `ConvertState()` returns, which is the earliest point where agent attributes (including `Directory`) are available alongside the session's `ProvisionLog` sink. The check skips agents with an empty `dir` (the default) or values that expand to `$HOME`.

</details>

> Generated by Coder Agents