### PR TITLE
fix(Makefile): rebuild helper binaries when inputs change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,20 +104,45 @@ CLIDOCGEN_INPUTS := \
 	scripts/clidocgen/command.tpl \
 	$(CLIDOC_SRC_FILES)
 
+# Helper binaries that import repo packages need their compile-time inputs on
+# the binary target. Most generated outputs keep these binaries as order-only
+# prereqs, so stale binaries otherwise survive source changes.
+RBAC_GO_FILES := \
+	$(wildcard coderd/rbac/*.go) \
+	$(wildcard coderd/rbac/policy/*.go)
+
+DBDUMP_INPUTS := \
+	$(wildcard coderd/database/migrations/*.go) \
+	$(wildcard coderd/database/migrations/*.sql)
+
+# Exclude generated RBAC files to avoid cycles with typegen outputs. The
+# output rules still order generated RBAC prerequisites where needed.
+TYPEGEN_RBAC_GO_FILES := \
+	$(filter-out coderd/rbac/%_gen.go,$(wildcard coderd/rbac/*.go)) \
+	$(wildcard coderd/rbac/policy/*.go)
+
+TYPEGEN_INPUTS := \
+	$(wildcard scripts/typegen/*.go) \
+	$(wildcard scripts/typegen/*.gotmpl) \
+	$(wildcard scripts/typegen/*.tstmpl) \
+	$(TYPEGEN_RBAC_GO_FILES) \
+	$(wildcard coderd/util/strings/*.go) \
+	codersdk/countries.go
+
 # Helper binary targets. Built with go build -o to avoid caching
 # link-stage executables in GOCACHE. Each binary is a real Make
 # target so parallel -j builds serialize correctly instead of
 # racing on the same output path.
 
-_gen/bin/apitypings: $(wildcard scripts/apitypings/*.go) | _gen
+_gen/bin/apitypings: $(wildcard scripts/apitypings/*.go) $(wildcard codersdk/*.go) | _gen
 	@mkdir -p _gen/bin
 	go build -o $@ ./scripts/apitypings
 
-_gen/bin/auditdocgen: $(wildcard scripts/auditdocgen/*.go) | _gen
+_gen/bin/auditdocgen: $(wildcard scripts/auditdocgen/*.go) $(wildcard enterprise/audit/*.go) | _gen
 	@mkdir -p _gen/bin
 	go build -o $@ ./scripts/auditdocgen
 
-_gen/bin/check-scopes: $(wildcard scripts/check-scopes/*.go) | _gen
+_gen/bin/check-scopes: $(wildcard scripts/check-scopes/*.go) $(RBAC_GO_FILES) | _gen
 	@mkdir -p _gen/bin
 	go build -o $@ ./scripts/check-scopes
 
@@ -127,7 +152,7 @@ _gen/bin/clidocgen: $(CLIDOCGEN_INPUTS) | _gen
 	@mkdir -p _gen/bin
 	go build -o $@ ./scripts/clidocgen
 
-_gen/bin/dbdump: $(wildcard coderd/database/gen/dump/*.go) | _gen
+_gen/bin/dbdump: $(wildcard coderd/database/gen/dump/*.go) $(DBDUMP_INPUTS) | _gen
 	@mkdir -p _gen/bin
 	go build -o $@ ./coderd/database/gen/dump
 
@@ -139,7 +164,7 @@ _gen/bin/gensite: $(wildcard scripts/gensite/*.go) | _gen
 	@mkdir -p _gen/bin
 	go build -o $@ ./scripts/gensite
 
-_gen/bin/apikeyscopesgen: $(wildcard scripts/apikeyscopesgen/*.go) | _gen
+_gen/bin/apikeyscopesgen: $(wildcard scripts/apikeyscopesgen/*.go) $(RBAC_GO_FILES) | _gen
 	@mkdir -p _gen/bin
 	go build -o $@ ./scripts/apikeyscopesgen
 
@@ -155,7 +180,7 @@ _gen/bin/modeloptionsgen: $(wildcard scripts/modeloptionsgen/*.go) $(wildcard co
 	@mkdir -p _gen/bin
 	go build -o $@ ./scripts/modeloptionsgen
 
-_gen/bin/typegen: $(wildcard scripts/typegen/*.go) | _gen
+_gen/bin/typegen: $(TYPEGEN_INPUTS) | _gen
 	@mkdir -p _gen/bin
 	go build -o $@ ./scripts/typegen
 
@@ -1031,7 +1056,7 @@ gen/mark-fresh:
 
 # Runs migrations to output a dump of the database schema after migrations are
 # applied.
-coderd/database/dump.sql: coderd/database/gen/dump/main.go $(wildcard coderd/database/migrations/*.sql) | _gen/bin/dbdump
+coderd/database/dump.sql: coderd/database/gen/dump/main.go $(DBDUMP_INPUTS) | _gen/bin/dbdump
 	_gen/bin/dbdump
 	touch "$@"
 
@@ -1149,7 +1174,10 @@ enterprise/aibridged/proto/aibridged.pb.go: enterprise/aibridged/proto/aibridged
 		--go-drpc_opt=paths=source_relative \
 		./enterprise/aibridged/proto/aibridged.proto
 
-site/src/api/typesGenerated.ts: site/node_modules/.installed $(wildcard scripts/apitypings/*) $(shell find ./codersdk $(FIND_EXCLUSIONS) -type f -name '*.go') | _gen _gen/bin/apitypings
+site/src/api/typesGenerated.ts: site/node_modules/.installed $(wildcard scripts/apitypings/*) \
+		$(shell find ./codersdk $(FIND_EXCLUSIONS) -type f -name '*.go') \
+		$(wildcard coderd/healthcheck/health/*.go) \
+		$(wildcard codersdk/healthsdk/*.go) | _gen _gen/bin/apitypings
 	$(call atomic_write,_gen/bin/apitypings,./scripts/biome_format.sh)
 
 site/e2e/provisionerGenerated.ts: site/node_modules/.installed provisionerd/proto/provisionerd.pb.go provisionersdk/proto/provisioner.pb.go


### PR DESCRIPTION
## Summary

This fixes the stale helper-binary class of generator bugs in the Makefile by adding the repo packages and embedded files that are compiled into each affected `_gen/bin/*` helper as real prerequisites of the helper binary target.

The concrete issue that prompted this was an audit docs regeneration after a rebase. `docs/admin/security/audit-logs.md` depends on `enterprise/audit/table.go`, so the docs target reran, but `_gen/bin/auditdocgen` was only an order-only prerequisite and its own rule only depended on `scripts/auditdocgen/*.go`. Because the stale local `auditdocgen` binary had been compiled before `UserSecret` was added to `enterprise/audit/table.go`, it regenerated the audit docs without the `UserSecret` row even though the source table still contained it.

This is the same failure mode I recently fixed for `_gen/bin/clidocgen` in #24302 and `_gen/bin/modeloptionsgen` in #24543. Those fixes made the binaries depend on the package sources and embedded template files whose compile-time data they read at runtime, rather than relying on output targets to mention those files. This PR applies that pattern to the other high-value helper binaries with the same risk.

## Changes

- Rebuild `_gen/bin/auditdocgen` when `enterprise/audit/*.go` changes, so audit docs are generated from the current `AuditableResources` and `AuditActionMap` data.
- Rebuild `_gen/bin/apitypings` when `codersdk/*.go` changes, and make `typesGenerated.ts` rerun when the health packages it emits change.
- Rebuild `_gen/bin/check-scopes` and `_gen/bin/apikeyscopesgen` when RBAC or policy sources change.
- Rebuild `_gen/bin/dbdump` when migration Go or SQL files change, since the migrations package embeds SQL into the binary.
- Rebuild `_gen/bin/typegen` when its Go sources, embedded templates, RBAC/policy inputs, string helper, or country data change. Generated RBAC files are deliberately excluded from the typegen binary input set to avoid cycles with typegen outputs.

## Why this covers the class

Most generated output targets keep helper binaries as order-only prerequisites. That is fine for avoiding unnecessary output churn, but it means the helper binary target must be the cache boundary and must list everything baked into the compiled binary. The affected helpers import repo packages that expose maps, constants, struct tags, embedded templates, or embedded SQL. Without those files on the binary rule, Make can rerun an output target with an old executable and write semantically stale generated content.

The fix keeps the existing order-only output structure and instead makes each binary rule track its compile-time inputs directly. That matches the previous clidocgen and modeloptionsgen fixes while avoiding a broad `$(GO_SRC_FILES)` dependency for helpers that only need a small set of packages.


> Written by Mux, reviewed by a human