### PR TITLE
docs(docs/ai-coder/agents): note OpenAI as a supported computer-use provider

### DIFF
--- a/docs/ai-coder/agents/architecture.md
+++ b/docs/ai-coder/agents/architecture.md
@@ -173,13 +173,13 @@ provider-native, and computer-use tools are not available.
 These tools manage sub-agents — child chats that work on independent tasks in
 parallel.
 
-| Tool                                        | What it does                                                                                                                                                                      |
-|---------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `spawn_agent` (`type=general` or `explore`) | Delegates a task to a sub-agent with its own context window.                                                                                                                      |
-| `wait_agent`                                | Waits for a sub-agent to finish and collects its result.                                                                                                                          |
-| `message_agent`                             | Sends a follow-up message to a running sub-agent.                                                                                                                                 |
-| `close_agent`                               | Stops a running sub-agent.                                                                                                                                                        |
-| `spawn_agent` (`type=computer_use`)         | Spawns a sub-agent with desktop interaction capabilities (screenshot, mouse, keyboard). Requires an Anthropic provider and the desktop feature to be enabled by an administrator. |
+| Tool                                        | What it does                                                                                                                                                                                |
+|---------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `spawn_agent` (`type=general` or `explore`) | Delegates a task to a sub-agent with its own context window.                                                                                                                                |
+| `wait_agent`                                | Waits for a sub-agent to finish and collects its result.                                                                                                                                    |
+| `message_agent`                             | Sends a follow-up message to a running sub-agent.                                                                                                                                           |
+| `close_agent`                               | Stops a running sub-agent.                                                                                                                                                                  |
+| `spawn_agent` (`type=computer_use`)         | Spawns a sub-agent with desktop interaction capabilities (screenshot, mouse, keyboard). Requires an Anthropic or OpenAI provider and the desktop feature to be enabled by an administrator. |
 
 ### Provider tools
 

--- a/docs/ai-coder/agents/index.md
+++ b/docs/ai-coder/agents/index.md
@@ -265,8 +265,8 @@ are only available to root chats. Sub-agents do not have access to these
 tools and cannot create workspaces or spawn further sub-agents.
 
 `spawn_agent` with `type=computer_use` additionally requires an
-Anthropic provider and the virtual desktop feature to be enabled by an
-administrator.
+Anthropic or OpenAI provider and the virtual desktop feature to be
+enabled by an administrator.
 `read_skill` and `read_skill_file` are available when the workspace contains
 skills in its `.agents/skills/` directory.
 

--- a/docs/ai-coder/agents/platform-controls/index.md
+++ b/docs/ai-coder/agents/platform-controls/index.md
@@ -116,8 +116,9 @@ It requires:
 
 - The [portabledesktop](https://registry.coder.com/modules/coder/portabledesktop)
   module to be installed in the workspace template.
-- An Anthropic provider to be configured (computer use is an Anthropic
-  capability).
+- An Anthropic or OpenAI provider to be configured. Administrators select
+  which provider agents use under the **Computer use provider** dropdown
+  next to the virtual desktop toggle. Anthropic is the default.
 
 ### Workspace autostop fallback
 


### PR DESCRIPTION
PR #24772 (merged 2026-05-04) added OpenAI alongside Anthropic for computer use, plus an admin selector under the virtual desktop toggle. Three places in the agents docs still said "Anthropic only" — this updates them.

No other content changes. Anthropic is still the default.

Fixes [CODAGT-310](https://linear.app/codercom/issue/CODAGT-310/enable-openai-computer-use-in-codercoder)

---

@nickvigilante — heads up, the kind of release-train drift we keep hitting:

- Feature is on `main`, so docs on `main` need to describe it.
- Feature is **not** in `release/2.33` and **not** in `v2.34.0-rc.0` (both cut before #24772 merged). It will ship in v2.34.
- `coder.com/docs` follows `main`, so once this lands, v2.33 users see "OpenAI is supported" and find no toggle.

Fwiw our [`doc-check` workflow](https://github.com/coder/coder/blob/main/.github/workflows/doc-check.yaml) would have caught this on #24772 — it's exactly what it's for. It [did trigger](https://github.com/coder/coder/actions/runs/25326759671) but the chat-create step errored out (curl exit 22) and nobody re-ran it, so the analysis never happened. Worth tightening that path so a transient API blip doesn't silently skip the check.

> Generated with [Coder Agents](https://coder.com/agents)