### PR TITLE
feat(coderd): add server-side workspace restart API endpoint

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -12034,6 +12034,52 @@ const docTemplate = `{
                 ]
             }
         },
+        "/api/v2/workspaces/{workspace}/restart": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Workspaces"
+                ],
+                "summary": "Restart workspace",
+                "operationId": "restart-workspace",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Workspace ID",
+                        "name": "workspace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Restart workspace request",
+                        "name": "request",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.RestartWorkspaceRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.WorkspaceBuild"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
         "/api/v2/workspaces/{workspace}/timings": {
             "get": {
                 "produces": [
@@ -19839,6 +19885,34 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/codersdk.ValidationError"
                     }
+                }
+            }
+        },
+        "codersdk.RestartWorkspaceRequest": {
+            "type": "object",
+            "properties": {
+                "log_level": {
+                    "description": "LogLevel changes the default logging verbosity of a provider\n(\"info\" if empty).",
+                    "enum": [
+                        "debug"
+                    ],
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/codersdk.ProvisionerLogLevel"
+                        }
+                    ]
+                },
+                "rich_parameter_values": {
+                    "description": "RichParameterValues are optional parameter values applied to both\nthe stop and start builds.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/codersdk.WorkspaceBuildParameter"
+                    }
+                },
+                "template_version_id": {
+                    "description": "TemplateVersionID is the target template version for the start build.\nIf omitted, the workspace will be started with the same template\nversion as the last build.",
+                    "type": "string",
+                    "format": "uuid"
                 }
             }
         },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -10678,6 +10678,46 @@
 				]
 			}
 		},
+		"/api/v2/workspaces/{workspace}/restart": {
+			"post": {
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["Workspaces"],
+				"summary": "Restart workspace",
+				"operationId": "restart-workspace",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Workspace ID",
+						"name": "workspace",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Restart workspace request",
+						"name": "request",
+						"in": "body",
+						"schema": {
+							"$ref": "#/definitions/codersdk.RestartWorkspaceRequest"
+						}
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "Created",
+						"schema": {
+							"$ref": "#/definitions/codersdk.WorkspaceBuild"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
 		"/api/v2/workspaces/{workspace}/timings": {
 			"get": {
 				"produces": ["application/json"],
@@ -18171,6 +18211,32 @@
 					"items": {
 						"$ref": "#/definitions/codersdk.ValidationError"
 					}
+				}
+			}
+		},
+		"codersdk.RestartWorkspaceRequest": {
+			"type": "object",
+			"properties": {
+				"log_level": {
+					"description": "LogLevel changes the default logging verbosity of a provider\n(\"info\" if empty).",
+					"enum": ["debug"],
+					"allOf": [
+						{
+							"$ref": "#/definitions/codersdk.ProvisionerLogLevel"
+						}
+					]
+				},
+				"rich_parameter_values": {
+					"description": "RichParameterValues are optional parameter values applied to both\nthe stop and start builds.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/codersdk.WorkspaceBuildParameter"
+					}
+				},
+				"template_version_id": {
+					"description": "TemplateVersionID is the target template version for the start build.\nIf omitted, the workspace will be started with the same template\nversion as the last build.",
+					"type": "string",
+					"format": "uuid"
 				}
 			}
 		},

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1763,6 +1763,7 @@ func New(options *Options) *API {
 					r.Delete("/", api.deleteWorkspaceAgentPortShare)
 				})
 				r.Get("/timings", api.workspaceTimings)
+				r.Post("/restart", api.restartWorkspace)
 				r.Route("/acl", func(r chi.Router) {
 					r.Get("/", api.workspaceACL)
 					r.Patch("/", api.patchWorkspaceACL)

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -2285,6 +2285,192 @@ func (api *API) workspaceTimings(rw http.ResponseWriter, r *http.Request) {
 	httpapi.Write(ctx, rw, http.StatusOK, timings)
 }
 
+// @Summary Restart workspace
+// @ID restart-workspace
+// @Security CoderSessionToken
+// @Accept json
+// @Produce json
+// @Tags Workspaces
+// @Param workspace path string true "Workspace ID" format(uuid)
+// @Param request body codersdk.RestartWorkspaceRequest false "Restart workspace request"
+// @Success 201 {object} codersdk.WorkspaceBuild
+// @Router /api/v2/workspaces/{workspace}/restart [post]
+func (api *API) restartWorkspace(rw http.ResponseWriter, r *http.Request) {
+	var (
+		ctx       = r.Context()
+		apiKey    = httpmw.APIKey(r)
+		workspace = httpmw.WorkspaceParam(r)
+	)
+
+	var req codersdk.RestartWorkspaceRequest
+	if r.ContentLength > 0 {
+		if !httpapi.Read(ctx, rw, r, &req) {
+			return
+		}
+	}
+
+	// Disallow restart of deleted workspaces.
+	if workspace.Deleted {
+		httpapi.Write(ctx, rw, http.StatusConflict, codersdk.Response{
+			Message: "Cannot restart a deleted workspace.",
+			Detail:  "This workspace has been deleted and cannot be modified.",
+		})
+		return
+	}
+
+	authorize := func(action policy.Action, object rbac.Objecter) bool {
+		return api.Authorize(r, action, object)
+	}
+	baggage := audit.WorkspaceBuildBaggageFromRequest(r)
+
+	// Create the stop build.
+	stopBuildReq := codersdk.CreateWorkspaceBuildRequest{
+		Transition:          codersdk.WorkspaceTransitionStop,
+		RichParameterValues: req.RichParameterValues,
+		LogLevel:            req.LogLevel,
+	}
+	stopBuild, err := api.postWorkspaceBuildsInternal(ctx, apiKey, workspace, stopBuildReq, authorize, baggage)
+	if err != nil {
+		httperror.WriteWorkspaceBuildError(ctx, rw, err)
+		return
+	}
+
+	// Prepare the start build request. The background goroutine will
+	// issue it once the stop build completes.
+	startBuildReq := codersdk.CreateWorkspaceBuildRequest{
+		Transition:          codersdk.WorkspaceTransitionStart,
+		TemplateVersionID:   req.TemplateVersionID,
+		RichParameterValues: req.RichParameterValues,
+		LogLevel:            req.LogLevel,
+	}
+
+	go api.completeWorkspaceRestart(workspace, apiKey, stopBuild.ID, startBuildReq, baggage)
+
+	httpapi.Write(ctx, rw, http.StatusCreated, stopBuild)
+}
+
+// completeWorkspaceRestart waits for a stop build to finish and then
+// creates a start build. It is meant to run in a background goroutine
+// so that clients do not need to stick around to complete the restart.
+func (api *API) completeWorkspaceRestart(
+	workspace database.Workspace,
+	apiKey database.APIKey,
+	stopBuildID uuid.UUID,
+	startReq codersdk.CreateWorkspaceBuildRequest,
+	baggage audit.WorkspaceBuildBaggage,
+) {
+	// Use the server lifecycle context with a generous timeout to prevent
+	// leaked goroutines.
+	ctx, cancel := context.WithTimeout(api.ctx, 30*time.Minute)
+	defer cancel()
+
+	log := api.Logger.With(
+		slog.F("workspace_id", workspace.ID),
+		slog.F("stop_build_id", stopBuildID),
+		slog.F("initiator_id", apiKey.UserID),
+	)
+
+	// Subscribe to workspace events so we are notified when the build
+	// state changes. Subscribe before checking the current state to
+	// avoid a race where the build completes between our check and
+	// the subscription.
+	events := make(chan struct{}, 1)
+	sub, err := api.Pubsub.SubscribeWithErr(
+		wspubsub.WorkspaceEventChannel(workspace.OwnerID),
+		wspubsub.HandleWorkspaceEvent(
+			func(_ context.Context, event wspubsub.WorkspaceEvent, err error) {
+				if err != nil {
+					return
+				}
+				if event.WorkspaceID != workspace.ID {
+					return
+				}
+				if event.Kind != wspubsub.WorkspaceEventKindStateChange {
+					return
+				}
+				select {
+				case events <- struct{}{}:
+				default:
+				}
+			},
+		),
+	)
+	if err != nil {
+		log.Error(ctx, "restart: failed to subscribe to workspace events", slog.Error(err))
+		return
+	}
+	defer sub()
+
+	// Poll-and-wait loop until the stop build reaches a terminal state.
+	for {
+		// nolint:gocritic // The restart background task needs to read
+		// build/job state regardless of the original user's permissions.
+		// Authorization was already verified when the stop build was created.
+		sysCtx := dbauthz.AsSystemRestricted(ctx)
+
+		build, err := api.Database.GetWorkspaceBuildByID(sysCtx, stopBuildID)
+		if err != nil {
+			log.Error(ctx, "restart: failed to get stop build", slog.Error(err))
+			return
+		}
+
+		job, err := api.Database.GetProvisionerJobByID(sysCtx, build.JobID)
+		if err != nil {
+			log.Error(ctx, "restart: failed to get provisioner job", slog.Error(err))
+			return
+		}
+
+		switch job.JobStatus {
+		case database.ProvisionerJobStatusSucceeded:
+			// Stop completed, proceed to start.
+		case database.ProvisionerJobStatusFailed:
+			log.Warn(ctx, "restart: stop build failed, aborting restart")
+			return
+		case database.ProvisionerJobStatusCanceled:
+			log.Warn(ctx, "restart: stop build was canceled, aborting restart")
+			return
+		default:
+			// Still in progress; wait for the next event.
+			select {
+			case <-ctx.Done():
+				log.Warn(ctx, "restart: timed out waiting for stop build to complete")
+				return
+			case <-events:
+				continue
+			}
+		}
+
+		// The stop build succeeded. Create the start build.
+		log.Info(ctx, "restart: stop build completed, creating start build")
+
+		// Re-fetch the workspace because its state changed after the
+		// stop build.
+		updatedWorkspace, err := api.Database.GetWorkspaceByID(sysCtx, workspace.ID)
+		if err != nil {
+			log.Error(ctx, "restart: failed to re-fetch workspace", slog.Error(err))
+			return
+		}
+
+		_, err = api.postWorkspaceBuildsInternal(
+			sysCtx,
+			apiKey,
+			updatedWorkspace,
+			startReq,
+			// Authorization was already checked when the stop build was
+			// created. Allow the start unconditionally.
+			func(_ policy.Action, _ rbac.Objecter) bool { return true },
+			baggage,
+		)
+		if err != nil {
+			log.Error(ctx, "restart: failed to create start build", slog.Error(err))
+			return
+		}
+
+		log.Info(ctx, "restart: start build created successfully")
+		return
+	}
+}
+
 // @Summary Get workspace ACLs
 // @ID get-workspace-acls
 // @Security CoderSessionToken

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -6247,3 +6247,79 @@ func mustSchedule(t *testing.T, s string) *cron.Schedule {
 	require.NoError(t, err)
 	return sched
 }
+
+func TestRestartWorkspace(t *testing.T) {
+	t.Parallel()
+
+	t.Run("OK", func(t *testing.T) {
+		t.Parallel()
+
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+		user := coderdtest.CreateFirstUser(t, client)
+		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
+		coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
+		workspace := coderdtest.CreateWorkspace(t, client, template.ID)
+		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		// Verify the workspace is running.
+		workspace, err := client.Workspace(ctx, workspace.ID)
+		require.NoError(t, err)
+		require.Equal(t, codersdk.WorkspaceStatusRunning, workspace.LatestBuild.Status)
+
+		// Call the restart endpoint.
+		stopBuild, err := client.RestartWorkspace(ctx, workspace.ID, codersdk.RestartWorkspaceRequest{})
+		require.NoError(t, err)
+		require.Equal(t, codersdk.WorkspaceTransitionStop, stopBuild.Transition)
+
+		// Wait for the stop build to complete.
+		stopBuild = coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, stopBuild.ID)
+		require.Equal(t, codersdk.ProvisionerJobSucceeded, stopBuild.Job.Status)
+
+		// The background goroutine should have created a start build.
+		// Wait for the workspace to come back to running.
+		require.Eventually(t, func() bool {
+			workspace, err = client.Workspace(ctx, workspace.ID)
+			if err != nil {
+				return false
+			}
+			// The latest build should be a start transition with a terminal
+			// status.
+			if workspace.LatestBuild.Transition != codersdk.WorkspaceTransitionStart {
+				return false
+			}
+			return workspace.LatestBuild.Job.Status == codersdk.ProvisionerJobSucceeded
+		}, testutil.WaitLong, testutil.IntervalMedium)
+
+		require.Equal(t, codersdk.WorkspaceStatusRunning, workspace.LatestBuild.Status)
+	})
+
+	t.Run("DeletedWorkspace", func(t *testing.T) {
+		t.Parallel()
+
+		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+		user := coderdtest.CreateFirstUser(t, client)
+		version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
+		coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+		template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
+		workspace := coderdtest.CreateWorkspace(t, client, template.ID)
+		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		// Delete the workspace first.
+		build := coderdtest.CreateWorkspaceBuild(t, client, workspace, database.WorkspaceTransitionDelete)
+		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, build.ID)
+
+		// Attempt restart should fail with Conflict.
+		_, err := client.RestartWorkspace(ctx, workspace.ID, codersdk.RestartWorkspaceRequest{})
+		require.Error(t, err)
+		var sdkErr *codersdk.Error
+		require.ErrorAs(t, err, &sdkErr)
+		require.Equal(t, http.StatusConflict, sdkErr.StatusCode())
+	})
+}

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -398,6 +398,39 @@ func (c *Client) PostWorkspaceUsage(ctx context.Context, id uuid.UUID) error {
 	return nil
 }
 
+// RestartWorkspaceRequest is a request to restart a workspace.
+// The server handles the full stop->start sequence so the client
+// does not need to wait for the stop to complete before issuing
+// the start.
+type RestartWorkspaceRequest struct {
+	// TemplateVersionID is the target template version for the start build.
+	// If omitted, the workspace will be started with the same template
+	// version as the last build.
+	TemplateVersionID uuid.UUID `json:"template_version_id,omitempty" format:"uuid"`
+	// RichParameterValues are optional parameter values applied to both
+	// the stop and start builds.
+	RichParameterValues []WorkspaceBuildParameter `json:"rich_parameter_values,omitempty"`
+	// LogLevel changes the default logging verbosity of a provider
+	// ("info" if empty).
+	LogLevel ProvisionerLogLevel `json:"log_level,omitempty" validate:"omitempty,oneof=debug"`
+}
+
+// RestartWorkspace creates a stop build and then automatically creates a
+// start build once the stop completes. The returned build is the initial
+// stop build.
+func (c *Client) RestartWorkspace(ctx context.Context, id uuid.UUID, req RestartWorkspaceRequest) (WorkspaceBuild, error) {
+	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/v2/workspaces/%s/restart", id), req)
+	if err != nil {
+		return WorkspaceBuild{}, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusCreated {
+		return WorkspaceBuild{}, ReadBodyAsError(res)
+	}
+	var build WorkspaceBuild
+	return build, json.NewDecoder(res.Body).Decode(&build)
+}
+
 // UpdateWorkspaceUsageWithBodyContext periodically posts workspace usage for the workspace
 // with the given id and app name in the background.
 // The caller is responsible for calling the returned function to stop the background

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -8538,6 +8538,35 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 | `message`     | string                                                        | false    |              | Message is an actionable message that depicts actions the request took. These messages should be fully formed sentences with proper punctuation. Examples: - "A user has been created." - "Failed to create a user."               |
 | `validations` | array of [codersdk.ValidationError](#codersdkvalidationerror) | false    |              | Validations are form field-specific friendly error messages. They will be shown on a form field in the UI. These can also be used to add additional context if there is a set of errors in the primary 'Message'.                  |
 
+## codersdk.RestartWorkspaceRequest
+
+```json
+{
+  "log_level": "debug",
+  "rich_parameter_values": [
+    {
+      "name": "string",
+      "value": "string"
+    }
+  ],
+  "template_version_id": "0ba39c92-1f1b-4c32-aa3e-9925d7713eb1"
+}
+```
+
+### Properties
+
+| Name                    | Type                                                                          | Required | Restrictions | Description                                                                                                                                                         |
+|-------------------------|-------------------------------------------------------------------------------|----------|--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `log_level`             | [codersdk.ProvisionerLogLevel](#codersdkprovisionerloglevel)                  | false    |              | Log level changes the default logging verbosity of a provider ("info" if empty).                                                                                    |
+| `rich_parameter_values` | array of [codersdk.WorkspaceBuildParameter](#codersdkworkspacebuildparameter) | false    |              | Rich parameter values are optional parameter values applied to both the stop and start builds.                                                                      |
+| `template_version_id`   | string                                                                        | false    |              | Template version ID is the target template version for the start build. If omitted, the workspace will be started with the same template version as the last build. |
+
+#### Enumerated Values
+
+| Property    | Value(s) |
+|-------------|----------|
+| `log_level` | `debug`  |
+
 ## codersdk.ResumeTaskResponse
 
 ```json

--- a/docs/reference/api/workspaces.md
+++ b/docs/reference/api/workspaces.md
@@ -2348,6 +2348,266 @@ curl -X GET http://coder-server:8080/api/v2/workspaces/{workspace}/resolve-autos
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
+## Restart workspace
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X POST http://coder-server:8080/api/v2/workspaces/{workspace}/restart \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`POST /api/v2/workspaces/{workspace}/restart`
+
+> Body parameter
+
+```json
+{
+  "log_level": "debug",
+  "rich_parameter_values": [
+    {
+      "name": "string",
+      "value": "string"
+    }
+  ],
+  "template_version_id": "0ba39c92-1f1b-4c32-aa3e-9925d7713eb1"
+}
+```
+
+### Parameters
+
+| Name        | In   | Type                                                                           | Required | Description               |
+|-------------|------|--------------------------------------------------------------------------------|----------|---------------------------|
+| `workspace` | path | string(uuid)                                                                   | true     | Workspace ID              |
+| `body`      | body | [codersdk.RestartWorkspaceRequest](schemas.md#codersdkrestartworkspacerequest) | false    | Restart workspace request |
+
+### Example responses
+
+> 201 Response
+
+```json
+{
+  "build_number": 0,
+  "created_at": "2019-08-24T14:15:22Z",
+  "daily_cost": 0,
+  "deadline": "2019-08-24T14:15:22Z",
+  "has_ai_task": true,
+  "has_external_agent": true,
+  "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+  "initiator_id": "06588898-9a84-4b35-ba8f-f9cbd64946f3",
+  "initiator_name": "string",
+  "job": {
+    "available_workers": [
+      "497f6eca-6276-4993-bfeb-53cbbbba6f08"
+    ],
+    "canceled_at": "2019-08-24T14:15:22Z",
+    "completed_at": "2019-08-24T14:15:22Z",
+    "created_at": "2019-08-24T14:15:22Z",
+    "error": "string",
+    "error_code": "REQUIRED_TEMPLATE_VARIABLES",
+    "file_id": "8a0cfb4f-ddc9-436d-91bb-75133c583767",
+    "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+    "initiator_id": "06588898-9a84-4b35-ba8f-f9cbd64946f3",
+    "input": {
+      "error": "string",
+      "template_version_id": "0ba39c92-1f1b-4c32-aa3e-9925d7713eb1",
+      "workspace_build_id": "badaf2eb-96c5-4050-9f1d-db2d39ca5478"
+    },
+    "logs_overflowed": true,
+    "metadata": {
+      "template_display_name": "string",
+      "template_icon": "string",
+      "template_id": "c6d67e98-83ea-49f0-8812-e4abae2b68bc",
+      "template_name": "string",
+      "template_version_name": "string",
+      "workspace_build_transition": "start",
+      "workspace_id": "0967198e-ec7b-4c6b-b4d3-f71244cadbe9",
+      "workspace_name": "string"
+    },
+    "organization_id": "7c60d51f-b44e-4682-87d6-449835ea4de6",
+    "queue_position": 0,
+    "queue_size": 0,
+    "started_at": "2019-08-24T14:15:22Z",
+    "status": "pending",
+    "tags": {
+      "property1": "string",
+      "property2": "string"
+    },
+    "type": "template_version_import",
+    "worker_id": "ae5fa6f7-c55b-40c1-b40a-b36ac467652b",
+    "worker_name": "string"
+  },
+  "matched_provisioners": {
+    "available": 0,
+    "count": 0,
+    "most_recently_seen": "2019-08-24T14:15:22Z"
+  },
+  "max_deadline": "2019-08-24T14:15:22Z",
+  "reason": "initiator",
+  "resources": [
+    {
+      "agents": [
+        {
+          "api_version": "string",
+          "apps": [
+            {
+              "command": "string",
+              "display_name": "string",
+              "external": true,
+              "group": "string",
+              "health": "disabled",
+              "healthcheck": {
+                "interval": 0,
+                "threshold": 0,
+                "url": "string"
+              },
+              "hidden": true,
+              "icon": "string",
+              "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+              "open_in": "slim-window",
+              "sharing_level": "owner",
+              "slug": "string",
+              "statuses": [
+                {
+                  "agent_id": "2b1e3b65-2c04-4fa2-a2d7-467901e98978",
+                  "app_id": "affd1d10-9538-4fc8-9e0b-4594a28c1335",
+                  "created_at": "2019-08-24T14:15:22Z",
+                  "icon": "string",
+                  "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+                  "message": "string",
+                  "needs_user_attention": true,
+                  "state": "working",
+                  "uri": "string",
+                  "workspace_id": "0967198e-ec7b-4c6b-b4d3-f71244cadbe9"
+                }
+              ],
+              "subdomain": true,
+              "subdomain_name": "string",
+              "tooltip": "string",
+              "url": "string"
+            }
+          ],
+          "architecture": "string",
+          "connection_timeout_seconds": 0,
+          "created_at": "2019-08-24T14:15:22Z",
+          "directory": "string",
+          "disconnected_at": "2019-08-24T14:15:22Z",
+          "display_apps": [
+            "vscode"
+          ],
+          "environment_variables": {
+            "property1": "string",
+            "property2": "string"
+          },
+          "expanded_directory": "string",
+          "first_connected_at": "2019-08-24T14:15:22Z",
+          "health": {
+            "healthy": false,
+            "reason": "agent has lost connection"
+          },
+          "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+          "instance_id": "string",
+          "last_connected_at": "2019-08-24T14:15:22Z",
+          "latency": {
+            "property1": {
+              "latency_ms": 0,
+              "preferred": true
+            },
+            "property2": {
+              "latency_ms": 0,
+              "preferred": true
+            }
+          },
+          "lifecycle_state": "created",
+          "log_sources": [
+            {
+              "created_at": "2019-08-24T14:15:22Z",
+              "display_name": "string",
+              "icon": "string",
+              "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+              "workspace_agent_id": "7ad2e618-fea7-4c1a-b70a-f501566a72f1"
+            }
+          ],
+          "logs_length": 0,
+          "logs_overflowed": true,
+          "name": "string",
+          "operating_system": "string",
+          "parent_id": {
+            "uuid": "string",
+            "valid": true
+          },
+          "ready_at": "2019-08-24T14:15:22Z",
+          "resource_id": "4d5215ed-38bb-48ed-879a-fdb9ca58522f",
+          "scripts": [
+            {
+              "cron": "string",
+              "display_name": "string",
+              "exit_code": 0,
+              "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+              "log_path": "string",
+              "log_source_id": "4197ab25-95cf-4b91-9c78-f7f2af5d353a",
+              "run_on_start": true,
+              "run_on_stop": true,
+              "script": "string",
+              "start_blocks_login": true,
+              "status": "ok",
+              "timeout": 0
+            }
+          ],
+          "started_at": "2019-08-24T14:15:22Z",
+          "startup_script_behavior": "blocking",
+          "status": "connecting",
+          "subsystems": [
+            "envbox"
+          ],
+          "troubleshooting_url": "string",
+          "updated_at": "2019-08-24T14:15:22Z",
+          "version": "string"
+        }
+      ],
+      "created_at": "2019-08-24T14:15:22Z",
+      "daily_cost": 0,
+      "hide": true,
+      "icon": "string",
+      "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+      "job_id": "453bd7d7-5355-4d6d-a38e-d9e7eb218c3f",
+      "metadata": [
+        {
+          "key": "string",
+          "sensitive": true,
+          "value": "string"
+        }
+      ],
+      "name": "string",
+      "type": "string",
+      "workspace_transition": "start"
+    }
+  ],
+  "status": "pending",
+  "template_version_id": "0ba39c92-1f1b-4c32-aa3e-9925d7713eb1",
+  "template_version_name": "string",
+  "template_version_preset_id": "512a53a7-30da-446e-a1fc-713c630baff1",
+  "transition": "start",
+  "updated_at": "2019-08-24T14:15:22Z",
+  "workspace_id": "0967198e-ec7b-4c6b-b4d3-f71244cadbe9",
+  "workspace_name": "string",
+  "workspace_owner_avatar_url": "string",
+  "workspace_owner_id": "e7078695-5279-4c86-8774-3ac2367a2fc7",
+  "workspace_owner_name": "string"
+}
+```
+
+### Responses
+
+| Status | Meaning                                                      | Description | Schema                                                       |
+|--------|--------------------------------------------------------------|-------------|--------------------------------------------------------------|
+| 201    | [Created](https://tools.ietf.org/html/rfc7231#section-6.3.2) | Created     | [codersdk.WorkspaceBuild](schemas.md#codersdkworkspacebuild) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
 ## Get workspace timings by ID
 
 ### Code samples

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -6559,6 +6559,32 @@ export interface Response {
 	readonly validations?: readonly ValidationError[];
 }
 
+// From codersdk/workspaces.go
+/**
+ * RestartWorkspaceRequest is a request to restart a workspace.
+ * The server handles the full stop->start sequence so the client
+ * does not need to wait for the stop to complete before issuing
+ * the start.
+ */
+export interface RestartWorkspaceRequest {
+	/**
+	 * TemplateVersionID is the target template version for the start build.
+	 * If omitted, the workspace will be started with the same template
+	 * version as the last build.
+	 */
+	readonly template_version_id?: string;
+	/**
+	 * RichParameterValues are optional parameter values applied to both
+	 * the stop and start builds.
+	 */
+	readonly rich_parameter_values?: readonly WorkspaceBuildParameter[];
+	/**
+	 * LogLevel changes the default logging verbosity of a provider
+	 * ("info" if empty).
+	 */
+	readonly log_level?: ProvisionerLogLevel;
+}
+
 // From codersdk/aitasks.go
 /**
  * ResumeTaskResponse represents the response from resuming a task.


### PR DESCRIPTION
Previously, restarting a workspace required the client to issue a stop build, wait for it to complete, and then issue a start build. If the client disconnected between those steps (e.g. page reload, network loss, CLI interruption), the workspace would remain stopped.

Adds `POST /api/v2/workspaces/{workspace}/restart` that handles the full stop->start sequence server-side. The endpoint creates a stop build immediately and returns it, then a background goroutine watches for completion via pubsub and automatically creates the start build. If the stop build fails or is canceled, the restart is aborted.

Closes https://github.com/coder/coder/issues/5800

<details><summary>Implementation details</summary>

- New `RestartWorkspaceRequest` SDK type accepts optional `template_version_id`, `rich_parameter_values`, and `log_level`.
- The background goroutine subscribes to the owner-scoped workspace event channel before checking build state to avoid races.
- Uses `dbauthz.AsSystemRestricted` in the goroutine since authorization was already validated when the stop build was created.
- A 30-minute timeout prevents leaked goroutines.
- Does not change CLI behavior; the CLI can adopt this endpoint in a follow-up.

</details>

> Generated with [Coder Agents](https://coder.com/agents)