### PR TITLE
feat: add Slack MCP integration

### DIFF
--- a/docs/ai-coder/agents/platform-controls/mcp-servers.md
+++ b/docs/ai-coder/agents/platform-controls/mcp-servers.md
@@ -10,9 +10,36 @@ This is an admin-only feature accessible at **Agents** > **Settings** >
 ## Add an MCP server
 
 1. Navigate to **Agents** > **Settings** > **MCP Servers**.
-1. Click **Add**.
+1. Click **Add server**, or click **Add Slack** to start from the Slack
+   preset.
 1. Fill in the configuration fields described below.
 1. Click **Save**.
+
+### Slack preset
+
+The Slack preset fills the hosted Slack MCP endpoint and OAuth2 URLs:
+
+| Field               | Value                                        |
+|---------------------|----------------------------------------------|
+| URL                 | `https://mcp.slack.com/mcp`                  |
+| Authorization URL   | `https://slack.com/oauth/v2_user/authorize`  |
+| Token URL           | `https://slack.com/api/oauth.v2.user.access` |
+| Transport           | `streamable_http`                            |
+| Authentication type | `oauth2`                                     |
+
+To finish setup:
+
+1. Create an internal Slack app or a Slack Marketplace app.
+1. Enable MCP for the Slack app.
+1. Copy the app's client ID and client secret into Coder.
+1. Save the preset-created server. Coder creates it disabled.
+1. Reopen the server, copy the OAuth callback URL, and add it as a Slack
+   redirect URL.
+1. Enable the server when the Slack app redirect URL is ready.
+
+The preset starts with read-focused Slack scopes. Add write scopes such as
+`chat:write`, `canvases:write`, or `reactions:write` if agents should take
+those actions.
 
 ### Identity
 
@@ -51,7 +78,7 @@ This is an admin-only feature accessible at **Agents** > **Settings** >
 Each MCP server uses one of five authentication modes. When you change the
 auth type, fields from the previous type are automatically cleared.
 
-Secrets are never returned in API responses — boolean flags indicate whether
+Secrets are never returned in API responses. Boolean flags indicate whether
 a value is set.
 
 ### None
@@ -64,7 +91,7 @@ authentication.
 Per-user authorization. The administrator configures the OAuth2 provider, and
 each user independently completes the authorization flow.
 
-**Manual configuration** — provide all three fields together:
+**Manual configuration**: provide all three fields together:
 
 | Field              | Description                 |
 |--------------------|-----------------------------|
@@ -79,12 +106,12 @@ Optional fields:
 | `oauth2_client_secret` | OAuth2 client secret.           |
 | `oauth2_scopes`        | Space-separated list of scopes. |
 
-**Auto-discovery** — leave `oauth2_client_id`, `oauth2_auth_url`, and
+**Auto-discovery**: leave `oauth2_client_id`, `oauth2_auth_url`, and
 `oauth2_token_url` empty. The server attempts discovery in this order:
 
-1. RFC 9728 — Protected Resource Metadata
-1. RFC 8414 — Authorization Server Metadata
-1. RFC 7591 — Dynamic Client Registration
+1. RFC 9728: Protected Resource Metadata
+1. RFC 8414: Authorization Server Metadata
+1. RFC 7591: Dynamic Client Registration
 
 Users connect through a popup that redirects through the OAuth2 provider.
 Tokens are stored per-user and refreshed automatically. Users can disconnect

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.stories.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.stories.tsx
@@ -201,6 +201,67 @@ export const CreateServer: Story = {
 	},
 };
 
+/** Open the Slack preset and create a disabled Slack MCP server. */
+export const CreateSlackPreset: Story = {
+	args: {
+		serversData: [],
+	},
+	play: async ({ canvasElement, args }) => {
+		const body = within(canvasElement.ownerDocument.body);
+
+		await userEvent.click(
+			await body.findByRole("button", { name: /Add Slack MCP/i }),
+		);
+
+		await expect(
+			await body.findByText(/Slack MCP preset/i),
+		).toBeInTheDocument();
+		expect(body.getByLabelText(/Display Name/i)).toHaveValue("Slack");
+		expect(body.getByLabelText(/^Slug/i)).toHaveValue("slack");
+		expect(body.getByLabelText(/Server URL/i)).toHaveValue(
+			"https://mcp.slack.com/mcp",
+		);
+		expect(body.getByLabelText(/Client ID/i)).toBeInTheDocument();
+		expect(body.getByLabelText(/Authorization URL/i)).toHaveValue(
+			"https://slack.com/oauth/v2_user/authorize",
+		);
+		expect(body.getByLabelText(/Token URL/i)).toHaveValue(
+			"https://slack.com/api/oauth.v2.user.access",
+		);
+		expect(body.getByLabelText(/^Scopes/i)).toHaveValue(
+			"search:read.public search:read.private search:read.mpim search:read.im search:read.files search:read.users channels:history groups:history mpim:history im:history canvases:read users:read users:read.email",
+		);
+
+		const createButton = body.getByRole("button", { name: /Create server/i });
+		expect(createButton).toBeDisabled();
+
+		await userEvent.type(body.getByLabelText(/Client ID/i), "123.abc");
+		await userEvent.type(body.getByLabelText(/Client Secret/i), "slack-secret");
+		await userEvent.click(createButton);
+
+		await waitFor(() => {
+			expect(args.onCreateServer).toHaveBeenCalledTimes(1);
+		});
+		expect(args.onCreateServer).toHaveBeenCalledWith(
+			expect.objectContaining({
+				display_name: "Slack",
+				slug: "slack",
+				icon_url: "/icon/slack.svg",
+				url: "https://mcp.slack.com/mcp",
+				transport: "streamable_http",
+				auth_type: "oauth2",
+				oauth2_client_id: "123.abc",
+				oauth2_client_secret: "slack-secret",
+				oauth2_auth_url: "https://slack.com/oauth/v2_user/authorize",
+				oauth2_token_url: "https://slack.com/api/oauth.v2.user.access",
+				oauth2_scopes: expect.stringContaining("search:read.public"),
+				availability: "default_off",
+				enabled: false,
+			}),
+		);
+	},
+};
+
 /** Open the create form and select OAuth2 auth type. */
 export const CreateServerOAuth2: Story = {
 	args: {
@@ -236,6 +297,14 @@ export const CreateServerOAuth2: Story = {
 		// Fill OAuth2 fields.
 		await userEvent.type(body.getByLabelText(/Client ID/i), "my-client-id");
 		await userEvent.type(body.getByLabelText(/Client Secret/i), "my-secret");
+		await userEvent.type(
+			body.getByLabelText(/Authorization URL/i),
+			"https://github.com/login/oauth/authorize",
+		);
+		await userEvent.type(
+			body.getByLabelText(/Token URL/i),
+			"https://github.com/login/oauth/access_token",
+		);
 
 		// Submit.
 		await userEvent.click(body.getByRole("button", { name: /Create server/i }));
@@ -248,6 +317,8 @@ export const CreateServerOAuth2: Story = {
 				auth_type: "oauth2",
 				oauth2_client_id: "my-client-id",
 				oauth2_client_secret: "my-secret",
+				oauth2_auth_url: "https://github.com/login/oauth/authorize",
+				oauth2_token_url: "https://github.com/login/oauth/access_token",
 			}),
 		);
 	},
@@ -359,7 +430,7 @@ export const EditServer: Story = {
 	},
 };
 
-/** Edit a server that has OAuth2 — secret field should show placeholder. */
+/** Edit a server that has OAuth2. Secret field should show placeholder. */
 export const EditServerWithOAuth2Secret: Story = {
 	args: {
 		serversData: [
@@ -393,6 +464,9 @@ export const EditServerWithOAuth2Secret: Story = {
 		const secretField = await body.findByLabelText(/Client Secret/i);
 		expect(secretField).toHaveValue("••••••••••••••••");
 		expect(body.getByLabelText(/Client ID/i)).toHaveValue("gh-client-id");
+		expect(body.getByLabelText(/OAuth callback URL/i)).toHaveValue(
+			`${location.origin}/api/experimental/mcp/servers/mcp-github/oauth2/callback`,
+		);
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
+++ b/site/src/pages/AgentsPage/components/MCPServerAdminPanel.tsx
@@ -12,6 +12,7 @@ import { type FC, lazy, Suspense, useId, useState } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router";
 
 import type * as TypesGen from "#/api/typesGenerated";
+import { Alert, AlertDescription, AlertTitle } from "#/components/Alert/Alert";
 import { ErrorAlert } from "#/components/Alert/ErrorAlert";
 import { ChevronDownIcon as AnimatedChevronDownIcon } from "#/components/AnimatedIcons/ChevronDown";
 import { Badge } from "#/components/Badge/Badge";
@@ -21,6 +22,7 @@ import {
 	CollapsibleContent,
 	CollapsibleTrigger,
 } from "#/components/Collapsible/Collapsible";
+import { CopyButton } from "#/components/CopyButton/CopyButton";
 import { ExternalImage } from "#/components/ExternalImage/ExternalImage";
 import { Input } from "#/components/Input/Input";
 import {
@@ -90,6 +92,49 @@ const AVAILABILITY_OPTIONS = [
 	},
 ] as const;
 
+const SLACK_MCP_READ_SCOPES = [
+	"search:read.public",
+	"search:read.private",
+	"search:read.mpim",
+	"search:read.im",
+	"search:read.files",
+	"search:read.users",
+	"channels:history",
+	"groups:history",
+	"mpim:history",
+	"im:history",
+	"canvases:read",
+	"users:read",
+	"users:read.email",
+].join(" ");
+
+const MCP_SERVER_PRESETS = [
+	{
+		id: "slack",
+		displayName: "Slack",
+		summary:
+			"Search Slack workspace data and read messages with Slack's hosted MCP server.",
+		buttonLabel: "Add Slack",
+		values: {
+			displayName: "Slack",
+			slug: "slack",
+			description:
+				"Search Slack workspace data and read messages with Slack's hosted MCP server.",
+			iconURL: "/icon/slack.svg",
+			url: "https://mcp.slack.com/mcp",
+			transport: "streamable_http",
+			authType: "oauth2",
+			oauth2AuthURL: "https://slack.com/oauth/v2_user/authorize",
+			oauth2TokenURL: "https://slack.com/api/oauth.v2.user.access",
+			oauth2Scopes: SLACK_MCP_READ_SCOPES,
+			availability: "default_off",
+			enabled: false,
+		},
+	},
+] as const;
+
+type MCPServerPreset = (typeof MCP_SERVER_PRESETS)[number];
+
 // ── Helpers ────────────────────────────────────────────────────
 
 const slugify = (value: string): string =>
@@ -110,6 +155,9 @@ const joinList = (arr: readonly string[] | undefined): string =>
 
 const authTypeLabel = (t: string) =>
 	AUTH_TYPE_OPTIONS.find((o) => o.value === t)?.label ?? t;
+
+const oauth2CallbackURL = (serverID: string): string =>
+	`${location.origin}/api/experimental/mcp/servers/${serverID}/oauth2/callback`;
 
 // ── Server icon ────────────────────────────────────────────────
 
@@ -234,6 +282,7 @@ interface ServerListProps {
 	servers: readonly TypesGen.MCPServerConfig[];
 	onSelect: (server: TypesGen.MCPServerConfig) => void;
 	onAdd: () => void;
+	onAddPreset: (presetID: MCPServerPreset["id"]) => void;
 	sectionLabel?: string;
 	sectionDescription?: string;
 }
@@ -242,6 +291,7 @@ const ServerList: FC<ServerListProps> = ({
 	servers,
 	onSelect,
 	onAdd,
+	onAddPreset,
 	sectionLabel,
 	sectionDescription,
 }) => {
@@ -254,10 +304,28 @@ const ServerList: FC<ServerListProps> = ({
 					"Configure external MCP servers that provide additional tools for Coder Agents."
 				}
 				action={
-					<Button size="sm" onClick={onAdd}>
-						<PlusIcon className="h-4 w-4" />
-						Add server
-					</Button>
+					<div className="flex items-center gap-2">
+						{MCP_SERVER_PRESETS.map((preset) => (
+							<Button
+								key={preset.id}
+								variant="outline"
+								size="sm"
+								onClick={() => onAddPreset(preset.id)}
+								title={preset.summary}
+							>
+								<MCPServerIcon
+									iconUrl={preset.values.iconURL}
+									name={preset.displayName}
+									className="h-4 w-4"
+								/>
+								{preset.buttonLabel}
+							</Button>
+						))}
+						<Button size="sm" onClick={onAdd}>
+							<PlusIcon className="h-4 w-4" />
+							Add server
+						</Button>
+					</div>
 				}
 			/>
 
@@ -266,10 +334,32 @@ const ServerList: FC<ServerListProps> = ({
 					<p className="m-0 text-sm text-content-secondary">
 						No MCP servers configured yet.
 					</p>
-					<Button size="sm" onClick={onAdd} aria-label="Add your first server">
-						<PlusIcon className="h-4 w-4" />
-						Add your first server
-					</Button>
+					<div className="flex flex-wrap items-center justify-center gap-2">
+						<Button
+							size="sm"
+							onClick={onAdd}
+							aria-label="Add your first server"
+						>
+							<PlusIcon className="h-4 w-4" />
+							Add your first server
+						</Button>
+						{MCP_SERVER_PRESETS.map((preset) => (
+							<Button
+								key={preset.id}
+								variant="outline"
+								size="sm"
+								onClick={() => onAddPreset(preset.id)}
+								title={preset.summary}
+							>
+								<MCPServerIcon
+									iconUrl={preset.values.iconURL}
+									name={preset.displayName}
+									className="h-4 w-4"
+								/>
+								Add {preset.displayName} MCP
+							</Button>
+						))}
+					</div>
 				</div>
 			) : (
 				<div>
@@ -355,36 +445,45 @@ interface MCPServerFormValues {
 
 const buildInitialValues = (
 	server: TypesGen.MCPServerConfig | null,
-): MCPServerFormValues => ({
-	displayName: server?.display_name ?? "",
-	slug: server?.slug ?? "",
-	slugTouched: false,
-	description: server?.description ?? "",
-	iconURL: server?.icon_url ?? "",
-	url: server?.url ?? "",
-	transport: server?.transport ?? "streamable_http",
-	authType: server?.auth_type ?? "none",
-	oauth2ClientID: server?.oauth2_client_id ?? "",
-	oauth2ClientSecret: server?.has_oauth2_secret ? SECRET_PLACEHOLDER : "",
-	oauth2SecretTouched: false,
-	oauth2AuthURL: server?.oauth2_auth_url ?? "",
-	oauth2TokenURL: server?.oauth2_token_url ?? "",
-	oauth2Scopes: server?.oauth2_scopes ?? "",
-	apiKeyHeader: server?.api_key_header ?? "",
-	apiKeyValue: server?.has_api_key ? SECRET_PLACEHOLDER : "",
-	apiKeyTouched: false,
-	availability: server?.availability ?? "default_off",
-	enabled: server?.enabled ?? true,
-	modelIntent: server?.model_intent ?? false,
-	allowInPlanMode: server?.allow_in_plan_mode ?? false,
-	toolAllowList: joinList(server?.tool_allow_list),
-	toolDenyList: joinList(server?.tool_deny_list),
-	customHeaders: [],
-	customHeadersTouched: false,
-});
+	preset?: MCPServerPreset,
+): MCPServerFormValues => {
+	const presetValues = server === null ? preset?.values : undefined;
+
+	return {
+		displayName: server?.display_name ?? presetValues?.displayName ?? "",
+		slug: server?.slug ?? presetValues?.slug ?? "",
+		slugTouched: false,
+		description: server?.description ?? presetValues?.description ?? "",
+		iconURL: server?.icon_url ?? presetValues?.iconURL ?? "",
+		url: server?.url ?? presetValues?.url ?? "",
+		transport:
+			server?.transport ?? presetValues?.transport ?? "streamable_http",
+		authType: server?.auth_type ?? presetValues?.authType ?? "none",
+		oauth2ClientID: server?.oauth2_client_id ?? "",
+		oauth2ClientSecret: server?.has_oauth2_secret ? SECRET_PLACEHOLDER : "",
+		oauth2SecretTouched: false,
+		oauth2AuthURL: server?.oauth2_auth_url ?? presetValues?.oauth2AuthURL ?? "",
+		oauth2TokenURL:
+			server?.oauth2_token_url ?? presetValues?.oauth2TokenURL ?? "",
+		oauth2Scopes: server?.oauth2_scopes ?? presetValues?.oauth2Scopes ?? "",
+		apiKeyHeader: server?.api_key_header ?? "",
+		apiKeyValue: server?.has_api_key ? SECRET_PLACEHOLDER : "",
+		apiKeyTouched: false,
+		availability:
+			server?.availability ?? presetValues?.availability ?? "default_off",
+		enabled: server?.enabled ?? presetValues?.enabled ?? true,
+		modelIntent: server?.model_intent ?? false,
+		allowInPlanMode: server?.allow_in_plan_mode ?? false,
+		toolAllowList: joinList(server?.tool_allow_list),
+		toolDenyList: joinList(server?.tool_deny_list),
+		customHeaders: [],
+		customHeadersTouched: false,
+	};
+};
 
 interface ServerFormProps {
 	server: TypesGen.MCPServerConfig | null;
+	preset?: MCPServerPreset;
 	isSaving: boolean;
 	isDeleting: boolean;
 	onSave: (
@@ -397,6 +496,7 @@ interface ServerFormProps {
 
 const ServerForm: FC<ServerFormProps> = ({
 	server,
+	preset,
 	isSaving,
 	isDeleting,
 	onSave,
@@ -406,12 +506,14 @@ const ServerForm: FC<ServerFormProps> = ({
 	const formId = useId();
 	const isEditing = server !== null;
 	const [confirmingDelete, setConfirmingDelete] = useState(false);
-	const [showDetails, setShowDetails] = useState(false);
-	const [showAuth, setShowAuth] = useState(false);
+	const [showDetails, setShowDetails] = useState(preset !== undefined);
+	const [showAuth, setShowAuth] = useState(
+		preset?.values.authType === "oauth2",
+	);
 	const [showBehavior, setShowBehavior] = useState(false);
 
 	const form = useFormik<MCPServerFormValues>({
-		initialValues: buildInitialValues(server),
+		initialValues: buildInitialValues(server, preset),
 		onSubmit: async (values) => {
 			const effectiveOAuth2Secret =
 				values.oauth2SecretTouched &&
@@ -463,10 +565,22 @@ const ServerForm: FC<ServerFormProps> = ({
 	});
 
 	const isDisabled = isSaving || isDeleting;
+	const callbackURL = server ? oauth2CallbackURL(server.id) : "";
+	const isSlackPreset = preset?.id === "slack";
+	const oauth2ManualFields = [
+		form.values.oauth2ClientID.trim(),
+		form.values.oauth2AuthURL.trim(),
+		form.values.oauth2TokenURL.trim(),
+	];
+	const hasPartialOAuth2ManualConfig =
+		form.values.authType === "oauth2" &&
+		oauth2ManualFields.some((value) => value !== "") &&
+		oauth2ManualFields.some((value) => value === "");
 	const canSubmit =
 		form.values.displayName.trim() !== "" &&
 		form.values.slug.trim() !== "" &&
 		form.values.url.trim() !== "" &&
+		!hasPartialOAuth2ManualConfig &&
 		!isDisabled;
 
 	return (
@@ -503,6 +617,16 @@ const ServerForm: FC<ServerFormProps> = ({
 				)}
 			</div>
 			<hr className="my-4 border-0 border-t border-solid border-border" />
+			{isSlackPreset && (
+				<Alert severity="info" className="mb-4">
+					<AlertTitle className="font-medium">Slack MCP preset</AlertTitle>
+					<AlertDescription>
+						Enter a Slack app client ID and secret. Coder creates the server
+						disabled so you can add its OAuth callback URL in Slack before users
+						connect.
+					</AlertDescription>
+				</Alert>
+			)}
 			<form
 				id={formId}
 				onSubmit={form.handleSubmit}
@@ -685,6 +809,30 @@ const ServerForm: FC<ServerFormProps> = ({
 											provider and enter the credentials below. Coder will
 											handle the per-user authorization flow.
 										</p>
+										{server && (
+											<Field
+												label="OAuth callback URL"
+												htmlFor={`${formId}-oauth-callback-url`}
+												description="Add this Redirect URL in the provider before users connect."
+											>
+												<InputGroup className="h-9">
+													<InputGroupInput
+														id={`${formId}-oauth-callback-url`}
+														value={callbackURL}
+														readOnly
+														className="h-9 min-w-0 font-mono text-[13px]"
+													/>
+													<InputGroupAddon align="inline-end">
+														<CopyButton
+															text={callbackURL}
+															label="Copy OAuth callback URL"
+															className="h-7 w-7"
+															disabled={isDisabled}
+														/>
+													</InputGroupAddon>
+												</InputGroup>
+											</Field>
+										)}
 										<div className="grid items-start gap-4 sm:grid-cols-2">
 											<Field label="Client ID" htmlFor={`${formId}-oauth-id`}>
 												<Input
@@ -755,7 +903,15 @@ const ServerForm: FC<ServerFormProps> = ({
 												/>
 											</Field>
 										</div>
-										<Field label="Scopes" htmlFor={`${formId}-oauth-scopes`}>
+										<Field
+											label="Scopes"
+											htmlFor={`${formId}-oauth-scopes`}
+											description={
+												isSlackPreset
+													? "Read-focused Slack scopes. Add write scopes when agents should post messages, write canvases, or add reactions."
+													: undefined
+											}
+										>
 											<Input
 												id={`${formId}-oauth-scopes`}
 												className="h-9 text-[13px]"
@@ -764,6 +920,12 @@ const ServerForm: FC<ServerFormProps> = ({
 												disabled={isDisabled}
 											/>
 										</Field>
+										{hasPartialOAuth2ManualConfig && (
+											<p className="m-0 text-xs text-content-destructive">
+												Provide Client ID, Authorization URL, and Token URL
+												together, or leave all three blank for auto-discovery.
+											</p>
+										)}
 									</div>
 								)}
 
@@ -1140,6 +1302,7 @@ export const MCPServerAdminPanel: FC<MCPServerAdminPanelProps> = ({
 }) => {
 	const [searchParams, setSearchParams] = useSearchParams();
 	const serverId = searchParams.get("server");
+	const presetID = searchParams.get("preset");
 	const navigate = useNavigate();
 	const location = useLocation();
 	// Whether the current form entry was pushed by an in-app click
@@ -1167,6 +1330,9 @@ export const MCPServerAdminPanel: FC<MCPServerAdminPanelProps> = ({
 			: null;
 	const isFormView = serverId !== null;
 	const isCreating = serverId === "new";
+	const activePreset = isCreating
+		? MCP_SERVER_PRESETS.find((preset) => preset.id === presetID)
+		: undefined;
 
 	const handleSave = async (
 		req: TypesGen.CreateMCPServerConfigRequest,
@@ -1231,13 +1397,20 @@ export const MCPServerAdminPanel: FC<MCPServerAdminPanelProps> = ({
 						onAdd={() =>
 							setSearchParams({ server: "new" }, { state: { pushed: true } })
 						}
+						onAddPreset={(presetID) =>
+							setSearchParams(
+								{ server: "new", preset: presetID },
+								{ state: { pushed: true } },
+							)
+						}
 						sectionLabel={sectionLabel}
 						sectionDescription={sectionDescription}
 					/>
 				) : isCreating || (!isLoadingServers && editingServer) ? (
 					<ServerForm
-						key={serverId}
+						key={`${serverId}:${activePreset?.id ?? "custom"}`}
 						server={isCreating ? null : editingServer}
+						preset={activePreset}
 						isSaving={isCreatingServer || isUpdatingServer}
 						isDeleting={isDeletingServer}
 						onSave={handleSave}


### PR DESCRIPTION
Adds a Slack preset to the MCP server admin UI so admins can create Slack MCP configs with the hosted endpoint, OAuth URLs, Slack icon, read-focused scopes, and disabled-by-default availability while they add the callback URL in Slack.

Also shows the OAuth callback URL for existing OAuth2 MCP servers and documents the Slack setup flow.

<details>
<summary>Implementation notes</summary>

- Used the existing generic MCP server CRUD and OAuth2 flow rather than adding backend seeding.
- Preset starts with read-focused Slack scopes. Admins can add write scopes as needed.
- Generated by Coder Agents.

</details>
