### PR TITLE
fix(site): ignore empty file path segments in template file tree

### DIFF
--- a/site/src/utils/templateVersion.test.ts
+++ b/site/src/utils/templateVersion.test.ts
@@ -1,0 +1,25 @@
+import { TarReader, TarWriter } from "./tar";
+import { createTemplateVersionFileTree } from "./templateVersion";
+
+test("createTemplateVersionFileTree ignores empty path segments", async () => {
+	const writer = new TarWriter();
+	writer.addFolder("files/etc/apt/");
+	writer.addFile(
+		"files/etc/apt/sources.list",
+		"deb http://example.com stable main",
+	);
+
+	const tarFile = await writer.write();
+	const reader = new TarReader();
+	await reader.readFile(tarFile);
+
+	expect(createTemplateVersionFileTree(reader)).toEqual({
+		files: {
+			etc: {
+				apt: {
+					"sources.list": "deb http://example.com stable main",
+				},
+			},
+		},
+	});
+});

--- a/site/src/utils/templateVersion.ts
+++ b/site/src/utils/templateVersion.ts
@@ -30,7 +30,7 @@ export const createTemplateVersionFileTree = (
 	for (const file of tarReader.fileInfo) {
 		fileTree = set(
 			fileTree,
-			file.name.split("/"),
+			file.name.split("/").filter((part) => part !== ""),
 			file.type === TarFileTypeCodes.Dir
 				? {}
 				: (tarReader.getTextFile(file.name) as string),


### PR DESCRIPTION
This fixes empty folders appearing in the template editor file tree when tar entries include trailing or repeated path separators.

The file tree builder now ignores empty path segments before inserting tar entries, with unit coverage for a trailing slash directory path.

Generated by Coder Agents.
