### PR TITLE
fix(Makefile): map arm64 to aarch64 for typos binary download

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -781,6 +781,10 @@ TYPOS_VERSION := $(shell grep -oP 'crate-ci/typos@\S+\s+\#\s+v\K[0-9.]+' .github
 
 # Map uname values to typos release asset names.
 TYPOS_ARCH := $(shell uname -m)
+# typos release assets use aarch64, but macOS ARM reports arm64 via uname -m.
+ifeq ($(TYPOS_ARCH),arm64)
+TYPOS_ARCH := aarch64
+endif
 ifeq ($(shell uname -s),Darwin)
 TYPOS_OS := apple-darwin
 else


### PR DESCRIPTION
macOS ARM reports arm64 via uname -m, but typos GitHub release assets use aarch64 in their filenames. The mismatch produces a 404, so the build/typos-$(VERSION) target fails silently and Apple Silicon users fall back to whatever typos binary their environment provides, such as the one from nix. That binary may be a different version than the one pinned in CI, creating a skew where local lint/typos rejects strings that CI accepts.

<!--

If you have used AI to produce some or all of this PR, please ensure you have read our [AI Contribution guidelines](https://coder.com/docs/about/contributing/AI_CONTRIBUTING) before submitting.

-->
