### PR TITLE
feat: enable chat sharing

### DIFF
--- a/site/src/api/api.test.ts
+++ b/site/src/api/api.test.ts
@@ -426,4 +426,40 @@ describe("api.ts", () => {
 			);
 		});
 	});
+
+	describe("chat ACL endpoints", () => {
+		const chatId = "chat-1";
+		const chatACL: TypesGen.ChatACL = {
+			users: [],
+			groups: [],
+		};
+
+		it("gets a chat ACL", async () => {
+			vi.spyOn(axiosInstance, "get").mockResolvedValueOnce({
+				data: chatACL,
+			});
+
+			const result = await API.experimental.getChatACL(chatId);
+
+			expect(axiosInstance.get).toHaveBeenCalledWith(
+				`/api/experimental/chats/${chatId}/acl`,
+			);
+			expect(result).toStrictEqual(chatACL);
+		});
+
+		it("updates a chat ACL", async () => {
+			const request: TypesGen.UpdateChatACL = {
+				user_roles: { "user-1": "read" },
+			};
+
+			vi.spyOn(axiosInstance, "patch").mockResolvedValueOnce({});
+
+			await API.experimental.updateChatACL(chatId, request);
+
+			expect(axiosInstance.patch).toHaveBeenCalledWith(
+				`/api/experimental/chats/${chatId}/acl`,
+				request,
+			);
+		});
+	});
 });

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -183,7 +183,7 @@ export const watchChatDesktop = (chatId: string): WebSocket => {
 	const socket = createWebSocket(
 		`/api/experimental/chats/${chatId}/stream/desktop`,
 	);
-	// RFB is a binary protocol — noVNC expects arraybuffer, not blob.
+	// RFB is a binary protocol. noVNC expects arraybuffer, not blob.
 	socket.binaryType = "arraybuffer";
 	return socket;
 };
@@ -3165,6 +3165,20 @@ class ExperimentalApiMethods {
 		);
 		return response.data;
 	};
+	getChatACL = async (chatId: string): Promise<TypesGen.ChatACL> => {
+		const response = await this.axios.get<TypesGen.ChatACL>(
+			`/api/experimental/chats/${chatId}/acl`,
+		);
+		return response.data;
+	};
+
+	updateChatACL = async (
+		chatId: string,
+		req: TypesGen.UpdateChatACL,
+	): Promise<void> => {
+		await this.axios.patch(`/api/experimental/chats/${chatId}/acl`, req);
+	};
+
 	getChatMessages = async (
 		chatId: string,
 		opts?: { before_id?: number; after_id?: number; limit?: number },

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -183,7 +183,7 @@ export const watchChatDesktop = (chatId: string): WebSocket => {
 	const socket = createWebSocket(
 		`/api/experimental/chats/${chatId}/stream/desktop`,
 	);
-	// RFB is a binary protocol. noVNC expects arraybuffer, not blob.
+	// RFB is a binary protocol — noVNC expects arraybuffer, not blob.
 	socket.binaryType = "arraybuffer";
 	return socket;
 };

--- a/site/src/api/queries/chats.test.ts
+++ b/site/src/api/queries/chats.test.ts
@@ -11,6 +11,8 @@ import {
 	addChildToParentInCache,
 	archiveChat,
 	cancelChatListRefetches,
+	chatACL,
+	chatACLKey,
 	chatAdvisorConfig,
 	chatAdvisorConfigKey,
 	chatCostSummary,
@@ -36,6 +38,8 @@ import {
 	regenerateChatTitle,
 	removeChildFromParentInCache,
 	reorderPinnedChat,
+	setChatGroupRole,
+	setChatUserRole,
 	TERMINAL_RUN_STATUSES,
 	unarchiveChat,
 	unpinChat,
@@ -62,6 +66,8 @@ vi.mock("#/api/api", () => ({
 			regenerateChatTitle: vi.fn(),
 			getChatAdvisorConfig: vi.fn(),
 			updateChatAdvisorConfig: vi.fn(),
+			getChatACL: vi.fn(),
+			updateChatACL: vi.fn(),
 		},
 	},
 }));
@@ -367,7 +373,7 @@ describe("archiveChat optimistic update", () => {
 		// Verify the optimistic update took effect.
 		expect(readInfiniteChats(queryClient)?.[0].archived).toBe(true);
 
-		// Simulate an error — the onError handler invalidates the
+		// Simulate an error, the onError handler invalidates the
 		// cache so a re-fetch restores the correct state.
 		mutation.onError(new Error("server error"), chatId, context);
 
@@ -780,7 +786,7 @@ describe("chat cost query factories", () => {
 describe("mutation invalidation scope", () => {
 	// These tests assert the CORRECT (narrow) invalidation behaviour.
 	// Each mutation should only invalidate the queries it actually
-	// needs to refresh — not the entire ["chats"] prefix tree. The
+	// needs to refresh, not the entire ["chats"] prefix tree. The
 	// WebSocket stream already delivers real-time updates for
 	// messages, status changes, and sidebar ordering, so broad
 	// prefix invalidation causes a burst of redundant HTTP requests
@@ -1198,7 +1204,7 @@ describe("mutation invalidation scope", () => {
 		const queryClient = createTestQueryClient();
 		const chatId = "chat-1";
 
-		// Page 0 (newest): IDs 10–6. Page 1 (older): IDs 5–1.
+		// Page 0 (newest): IDs 10-6. Page 1 (older): IDs 5-1.
 		const page0 = [10, 9, 8, 7, 6].map((id) => makeMsg(chatId, id));
 		const page1 = [5, 4, 3, 2, 1].map((id) => makeMsg(chatId, id));
 		const optimisticMessage = buildOptimisticMessage(requireMessage(page0, 7));
@@ -1526,7 +1532,7 @@ describe("diff_status_change invalidation scope", () => {
 	// These tests verify the CORRECT invalidation pattern for
 	// diff_status_change WebSocket events. The handler should
 	// invalidate only the individual chat detail and diff-contents
-	// queries — NOT the chat list (sidebar) or messages.
+	// queries, NOT the chat list (sidebar) or messages.
 
 	it("exact chatKey invalidation does not cascade to messages or diff-contents", async () => {
 		const queryClient = createTestQueryClient();
@@ -1538,7 +1544,7 @@ describe("diff_status_change invalidation scope", () => {
 		queryClient.setQueryData(chatDiffContentsKey(chatId), { files: [] });
 		queryClient.setQueryData(chatsKey, [makeChat(chatId)]);
 
-		// This is what the fixed handler does — exact: true.
+		// This is what the fixed handler does, exact: true.
 		await queryClient.invalidateQueries({
 			queryKey: chatKey(chatId),
 			exact: true,
@@ -1577,7 +1583,7 @@ describe("diff_status_change invalidation scope", () => {
 		queryClient.setQueryData(chatMessagesKey(chatId), []);
 		queryClient.setQueryData(chatDiffContentsKey(chatId), { files: [] });
 
-		// This is what the OLD (broken) handler did — no exact: true.
+		// This is what the OLD broken handler did, no exact: true.
 		await queryClient.invalidateQueries({
 			queryKey: chatKey(chatId),
 		});
@@ -1693,7 +1699,7 @@ describe("cancelChatListRefetches", () => {
 
 		seedInfiniteChats(queryClient, [makeChat(chatId, { title: "original" })]);
 
-		// Start an in-flight refetch (no fetchMeta — simulates a
+		// Start an in-flight refetch, no fetchMeta simulates a
 		// regular invalidation or window-focus refetch).
 		const fetchDone = queryClient.prefetchQuery({
 			queryKey: infiniteChatsTestKey,
@@ -1756,7 +1762,7 @@ describe("cancelChatListRefetches", () => {
 		await cancelChatListRefetches(queryClient);
 		await fetchDone;
 
-		// The fetch was NOT cancelled — the new data landed.
+		// The fetch was NOT cancelled, the new data landed.
 		const title = readInfiniteChats(queryClient)?.find(
 			(c) => c.id === chatId,
 		)?.title;
@@ -1803,7 +1809,7 @@ describe("cancelChatListRefetches", () => {
 		const queryClient = createTestQueryClient();
 		const chatId = "chat-1";
 
-		// Do NOT seed the cache — simulate the very first fetch
+		// Do NOT seed the cache, simulate the very first fetch
 		// where no data exists yet.
 		const fetchDone = queryClient.prefetchQuery({
 			queryKey: infiniteChatsTestKey,
@@ -2501,5 +2507,58 @@ describe("TERMINAL_RUN_STATUSES", () => {
 				SUCCESS_STATUSES.has(status) || ERROR_STATUSES.has(status);
 			expect(classified).toBe(true);
 		}
+	});
+});
+
+describe("chat ACL query factories", () => {
+	it("builds the ACL query under the chat key hierarchy", async () => {
+		const chatId = "chat-1";
+		const acl: TypesGen.ChatACL = { users: [], groups: [] };
+		vi.mocked(API.experimental.getChatACL).mockResolvedValue(acl);
+
+		const query = chatACL(chatId);
+
+		expect(chatACLKey(chatId)).toEqual(["chats", chatId, "acl"]);
+		expect(query.queryKey).toEqual(chatACLKey(chatId));
+		await expect(query.queryFn()).resolves.toEqual(acl);
+		expect(API.experimental.getChatACL).toHaveBeenCalledWith(chatId);
+	});
+
+	it("sets one chat user role and invalidates the ACL", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		queryClient.setQueryData(chatACLKey(chatId), { users: [], groups: [] });
+		vi.mocked(API.experimental.updateChatACL).mockResolvedValue();
+
+		const mutation = setChatUserRole(queryClient);
+		const variables = { chatId, userId: "user-1", role: "read" as const };
+		await mutation.mutationFn(variables);
+		expect(API.experimental.updateChatACL).toHaveBeenCalledWith(chatId, {
+			user_roles: { "user-1": "read" },
+		});
+
+		await mutation.onSuccess?.(undefined, variables);
+		expect(queryClient.getQueryState(chatACLKey(chatId))?.isInvalidated).toBe(
+			true,
+		);
+	});
+
+	it("sets one chat group role and invalidates the ACL", async () => {
+		const queryClient = createTestQueryClient();
+		const chatId = "chat-1";
+		queryClient.setQueryData(chatACLKey(chatId), { users: [], groups: [] });
+		vi.mocked(API.experimental.updateChatACL).mockResolvedValue();
+
+		const mutation = setChatGroupRole(queryClient);
+		const variables = { chatId, groupId: "group-1", role: "" as const };
+		await mutation.mutationFn(variables);
+		expect(API.experimental.updateChatACL).toHaveBeenCalledWith(chatId, {
+			group_roles: { "group-1": "" },
+		});
+
+		await mutation.onSuccess?.(undefined, variables);
+		expect(queryClient.getQueryState(chatACLKey(chatId))?.isInvalidated).toBe(
+			true,
+		);
 	});
 });

--- a/site/src/api/queries/chats.test.ts
+++ b/site/src/api/queries/chats.test.ts
@@ -373,7 +373,7 @@ describe("archiveChat optimistic update", () => {
 		// Verify the optimistic update took effect.
 		expect(readInfiniteChats(queryClient)?.[0].archived).toBe(true);
 
-		// Simulate an error, the onError handler invalidates the
+		// Simulate an error — the onError handler invalidates the
 		// cache so a re-fetch restores the correct state.
 		mutation.onError(new Error("server error"), chatId, context);
 
@@ -786,7 +786,7 @@ describe("chat cost query factories", () => {
 describe("mutation invalidation scope", () => {
 	// These tests assert the CORRECT (narrow) invalidation behaviour.
 	// Each mutation should only invalidate the queries it actually
-	// needs to refresh, not the entire ["chats"] prefix tree. The
+	// needs to refresh — not the entire ["chats"] prefix tree. The
 	// WebSocket stream already delivers real-time updates for
 	// messages, status changes, and sidebar ordering, so broad
 	// prefix invalidation causes a burst of redundant HTTP requests
@@ -1204,7 +1204,7 @@ describe("mutation invalidation scope", () => {
 		const queryClient = createTestQueryClient();
 		const chatId = "chat-1";
 
-		// Page 0 (newest): IDs 10-6. Page 1 (older): IDs 5-1.
+		// Page 0 (newest): IDs 10–6. Page 1 (older): IDs 5–1.
 		const page0 = [10, 9, 8, 7, 6].map((id) => makeMsg(chatId, id));
 		const page1 = [5, 4, 3, 2, 1].map((id) => makeMsg(chatId, id));
 		const optimisticMessage = buildOptimisticMessage(requireMessage(page0, 7));
@@ -1532,7 +1532,7 @@ describe("diff_status_change invalidation scope", () => {
 	// These tests verify the CORRECT invalidation pattern for
 	// diff_status_change WebSocket events. The handler should
 	// invalidate only the individual chat detail and diff-contents
-	// queries, NOT the chat list (sidebar) or messages.
+	// queries — NOT the chat list (sidebar) or messages.
 
 	it("exact chatKey invalidation does not cascade to messages or diff-contents", async () => {
 		const queryClient = createTestQueryClient();
@@ -1544,7 +1544,7 @@ describe("diff_status_change invalidation scope", () => {
 		queryClient.setQueryData(chatDiffContentsKey(chatId), { files: [] });
 		queryClient.setQueryData(chatsKey, [makeChat(chatId)]);
 
-		// This is what the fixed handler does, exact: true.
+		// This is what the fixed handler does — exact: true.
 		await queryClient.invalidateQueries({
 			queryKey: chatKey(chatId),
 			exact: true,
@@ -1583,7 +1583,7 @@ describe("diff_status_change invalidation scope", () => {
 		queryClient.setQueryData(chatMessagesKey(chatId), []);
 		queryClient.setQueryData(chatDiffContentsKey(chatId), { files: [] });
 
-		// This is what the OLD broken handler did, no exact: true.
+		// This is what the OLD (broken) handler did — no exact: true.
 		await queryClient.invalidateQueries({
 			queryKey: chatKey(chatId),
 		});
@@ -1699,7 +1699,7 @@ describe("cancelChatListRefetches", () => {
 
 		seedInfiniteChats(queryClient, [makeChat(chatId, { title: "original" })]);
 
-		// Start an in-flight refetch, no fetchMeta simulates a
+		// Start an in-flight refetch (no fetchMeta — simulates a
 		// regular invalidation or window-focus refetch).
 		const fetchDone = queryClient.prefetchQuery({
 			queryKey: infiniteChatsTestKey,
@@ -1762,7 +1762,7 @@ describe("cancelChatListRefetches", () => {
 		await cancelChatListRefetches(queryClient);
 		await fetchDone;
 
-		// The fetch was NOT cancelled, the new data landed.
+		// The fetch was NOT cancelled — the new data landed.
 		const title = readInfiniteChats(queryClient)?.find(
 			(c) => c.id === chatId,
 		)?.title;
@@ -1809,7 +1809,7 @@ describe("cancelChatListRefetches", () => {
 		const queryClient = createTestQueryClient();
 		const chatId = "chat-1";
 
-		// Do NOT seed the cache, simulate the very first fetch
+		// Do NOT seed the cache — simulate the very first fetch
 		// where no data exists yet.
 		const fetchDone = queryClient.prefetchQuery({
 			queryKey: infiniteChatsTestKey,

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -1919,7 +1919,10 @@ export const setChatUserRole = (queryClient: QueryClient) => ({
 			user_roles: { [userId]: role },
 		}),
 	onSuccess: async (_data: unknown, { chatId }: SetChatUserRoleVariables) => {
-		await queryClient.invalidateQueries({ queryKey: chatACLKey(chatId) });
+		await queryClient.invalidateQueries({
+			queryKey: chatACLKey(chatId),
+			exact: true,
+		});
 	},
 });
 
@@ -1929,6 +1932,9 @@ export const setChatGroupRole = (queryClient: QueryClient) => ({
 			group_roles: { [groupId]: role },
 		}),
 	onSuccess: async (_data: unknown, { chatId }: SetChatGroupRoleVariables) => {
-		await queryClient.invalidateQueries({ queryKey: chatACLKey(chatId) });
+		await queryClient.invalidateQueries({
+			queryKey: chatACLKey(chatId),
+			exact: true,
+		});
 	},
 });

--- a/site/src/api/queries/chats.ts
+++ b/site/src/api/queries/chats.ts
@@ -23,6 +23,8 @@ export const chatMessagesKey = (chatId: string) =>
 export const chatPromptsKey = (chatId: string) =>
 	["chats", chatId, "prompts"] as const;
 
+export const chatACLKey = (chatId: string) => ["chats", chatId, "acl"] as const;
+
 export const chatsByWorkspaceKeyPrefix = [...chatsKey, "by-workspace"] as const;
 
 export const chatsByWorkspace = (workspaceIds: string[]) => {
@@ -539,6 +541,11 @@ export const infiniteChats = (opts?: { q?: string; archived?: boolean }) => {
 export const chat = (chatId: string) => ({
 	queryKey: chatKey(chatId),
 	queryFn: () => API.experimental.getChat(chatId),
+});
+
+export const chatACL = (chatId: string) => ({
+	queryKey: chatACLKey(chatId),
+	queryFn: () => API.experimental.getChatACL(chatId),
 });
 
 const MESSAGES_PAGE_SIZE = 50;
@@ -1891,5 +1898,37 @@ export const deleteMCPServerConfig = (queryClient: QueryClient) => ({
 	mutationFn: (id: string) => API.experimental.deleteMCPServerConfig(id),
 	onSuccess: async () => {
 		await invalidateMCPServerConfigQueries(queryClient);
+	},
+});
+
+type SetChatUserRoleVariables = {
+	chatId: string;
+	userId: string;
+	role: TypesGen.ChatRole;
+};
+
+type SetChatGroupRoleVariables = {
+	chatId: string;
+	groupId: string;
+	role: TypesGen.ChatRole;
+};
+
+export const setChatUserRole = (queryClient: QueryClient) => ({
+	mutationFn: ({ chatId, userId, role }: SetChatUserRoleVariables) =>
+		API.experimental.updateChatACL(chatId, {
+			user_roles: { [userId]: role },
+		}),
+	onSuccess: async (_data: unknown, { chatId }: SetChatUserRoleVariables) => {
+		await queryClient.invalidateQueries({ queryKey: chatACLKey(chatId) });
+	},
+});
+
+export const setChatGroupRole = (queryClient: QueryClient) => ({
+	mutationFn: ({ chatId, groupId, role }: SetChatGroupRoleVariables) =>
+		API.experimental.updateChatACL(chatId, {
+			group_roles: { [groupId]: role },
+		}),
+	onSuccess: async (_data: unknown, { chatId }: SetChatGroupRoleVariables) => {
+		await queryClient.invalidateQueries({ queryKey: chatACLKey(chatId) });
 	},
 });

--- a/site/src/components/Table/Table.tsx
+++ b/site/src/components/Table/Table.tsx
@@ -5,12 +5,17 @@
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "#/utils/cn";
 
-export const Table: React.FC<React.ComponentPropsWithRef<"table">> = ({
+type TableProps = React.ComponentPropsWithRef<"table"> & {
+	wrapperClassName?: string;
+};
+
+export const Table: React.FC<TableProps> = ({
 	className,
+	wrapperClassName,
 	...props
 }) => {
 	return (
-		<div className="relative w-full overflow-auto">
+		<div className={cn("relative w-full overflow-auto", wrapperClassName)}>
 			<table
 				className={cn(
 					"w-full caption-bottom text-xs font-medium text-content-secondary border-separate border-spacing-0",

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -825,7 +825,7 @@ export const WithMessageHistory: Story = {
 			},
 			{
 				messages: [
-					// Turn 1: user asks for a summary --
+					// Turn 1: user asks for a summary
 					{
 						id: 1,
 						chat_id: CHAT_ID,
@@ -838,7 +838,7 @@ export const WithMessageHistory: Story = {
 							},
 						],
 					},
-					// Turn 2: assistant with headings, lists, table, blockquote --
+					// Turn 2: assistant with headings, lists, table, blockquote
 					{
 						id: 2,
 						chat_id: CHAT_ID,
@@ -914,7 +914,7 @@ export const WithMessageHistory: Story = {
 							},
 						],
 					},
-					// Turn 3: user follow-up (long message) --
+					// Turn 3: user follow-up (long message)
 					{
 						id: 3,
 						chat_id: CHAT_ID,
@@ -953,7 +953,7 @@ export const WithMessageHistory: Story = {
 							},
 						],
 					},
-					// Turn 4: assistant with code, table, nested list, task list --
+					// Turn 4: assistant with code, table, nested list, task list
 					{
 						id: 4,
 						chat_id: CHAT_ID,
@@ -1027,7 +1027,7 @@ export const WithMessageHistory: Story = {
 							},
 						],
 					},
-					// Turn 5: user asks about middleware --
+					// Turn 5: user asks about middleware
 					{
 						id: 5,
 						chat_id: CHAT_ID,
@@ -1040,7 +1040,7 @@ export const WithMessageHistory: Story = {
 							},
 						],
 					},
-					// Turn 6: assistant with code, inline code, links, images, nested blockquote --
+					// Turn 6: assistant with code, inline code, links, images, nested blockquote
 					{
 						id: 6,
 						chat_id: CHAT_ID,
@@ -2130,7 +2130,7 @@ export const WithEveryTool: Story = {
 			},
 			{
 				messages: [
-					// Turn 1: user kicks off the task --
+					// Turn 1: user kicks off the task
 					{
 						id: 1,
 						chat_id: CHAT_ID,
@@ -2143,7 +2143,7 @@ export const WithEveryTool: Story = {
 							},
 						],
 					},
-					// Turn 2: previous assistant turn (completed) --
+					// Turn 2: previous assistant turn (completed)
 					//    Establishes that the agent already inspected and patched
 					//    a couple of files before the streaming turn begins.
 					{
@@ -2217,7 +2217,7 @@ export const WithEveryTool: Story = {
 							},
 						],
 					},
-					// Turn 3: user asks for a tool-by-tool tour --
+					// Turn 3: user asks for a tool-by-tool tour
 					{
 						id: 3,
 						chat_id: CHAT_ID,
@@ -2230,7 +2230,7 @@ export const WithEveryTool: Story = {
 							},
 						],
 					},
-					// Turn 4: assistant runs every tool exactly once --
+					// Turn 4: assistant runs every tool exactly once
 					EVERY_TOOL_ASSISTANT_TURN,
 				],
 				queued_messages: [],

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -8,6 +8,7 @@ import {
 	reactRouterParameters,
 } from "storybook-addon-remix-react-router";
 import { API } from "#/api/api";
+import { getAuthorizationKey } from "#/api/queries/authCheck";
 import {
 	chatDiffContentsKey,
 	chatKey,
@@ -21,7 +22,9 @@ import {
 import { workspaceByIdKey } from "#/api/queries/workspaces";
 import type * as TypesGen from "#/api/typesGenerated";
 import {
-	MockUserMember,
+	MockGroup,
+	MockOrganizationMember,
+	MockOrganizationMember2,
 	MockUserOwner,
 	MockWorkspace,
 } from "#/testHelpers/entities";
@@ -35,7 +38,7 @@ import AgentChatPage, { RIGHT_PANEL_OPEN_KEY } from "./AgentChatPage";
 import type { AgentsOutletContext } from "./AgentsPage";
 
 // ---------------------------------------------------------------------------
-// Layout wrapper – provides outlet context for the child route.
+// Layout wrapper, provides outlet context for the child route.
 // ---------------------------------------------------------------------------
 const AgentChatPageLayout: FC = () => {
 	const scrollContainerRef = useRef<HTMLDivElement | null>(null);
@@ -129,6 +132,7 @@ const baseChatFields = {
 	organization_id: "test-org-id",
 	owner_id: MockUserOwner.id,
 	owner_username: MockUserOwner.username,
+	owner_name: MockUserOwner.name,
 	workspace_id: mockWorkspace.id,
 	last_model_config_id: MODEL_CONFIG_ID,
 	mcp_server_ids: [],
@@ -185,6 +189,26 @@ const extractPromptsFromMessages = (
 	}
 	return prompts;
 };
+const buildChatAuthorizationQuery = (
+	chat: Pick<TypesGen.Chat, "owner_id" | "organization_id">,
+	key: string,
+	action: "share" | "update",
+	allowed: boolean,
+) => ({
+	key: getAuthorizationKey({
+		checks: {
+			[key]: {
+				object: {
+					resource_type: "chat",
+					owner_id: chat.owner_id,
+					organization_id: chat.organization_id,
+				},
+				action,
+			},
+		},
+	}),
+	data: { [key]: allowed },
+});
 
 /** Build `parameters.queries` entries for a given chat and messages. */
 const buildQueries = (
@@ -234,6 +258,12 @@ const buildQueries = (
 		{ key: chatModelsKey, data: mockModelCatalog },
 		{ key: chatModelConfigs().queryKey, data: mockModelConfigs },
 		{ key: mcpServerConfigsKey, data: [] },
+		buildChatAuthorizationQuery(
+			chat,
+			"canShareChat",
+			"share",
+			chat.owner_id === MockUserOwner.id && !chat.parent_chat_id,
+		),
 	];
 };
 
@@ -261,7 +291,7 @@ const EVERY_TOOL_ASSISTANT_TURN = {
 			text: "Here is a recap of every tool I have at my disposal, exercised against this workspace so each card type renders.",
 		},
 
-		// execute -- shell command output
+		// execute, shell command output
 		{
 			type: "tool-call",
 			tool_call_id: "every-execute",
@@ -281,7 +311,7 @@ const EVERY_TOOL_ASSISTANT_TURN = {
 			},
 		},
 
-		// process_output -- background process output
+		// process_output, background process output
 		{
 			type: "tool-call",
 			tool_call_id: "every-process-output",
@@ -302,7 +332,7 @@ const EVERY_TOOL_ASSISTANT_TURN = {
 			},
 		},
 
-		// process_signal -- signal sent to a background process
+		// process_signal, signal sent to a background process
 		{
 			type: "tool-call",
 			tool_call_id: "every-process-signal",
@@ -316,7 +346,7 @@ const EVERY_TOOL_ASSISTANT_TURN = {
 			result: { success: true, signal: "terminate" },
 		},
 
-		// read_file -- completed file read with content viewer
+		// read_file, completed file read with content viewer
 		{
 			type: "tool-call",
 			tool_call_id: "every-read-file",
@@ -338,7 +368,7 @@ const EVERY_TOOL_ASSISTANT_TURN = {
 			},
 		},
 
-		// write_file -- completed file write with diff viewer
+		// write_file, completed file write with diff viewer
 		{
 			type: "tool-call",
 			tool_call_id: "every-write-file",
@@ -362,7 +392,7 @@ const EVERY_TOOL_ASSISTANT_TURN = {
 			result: { content: "wrote 6 lines" },
 		},
 
-		// edit_files -- completed multi-file edit
+		// edit_files, completed multi-file edit
 		{
 			type: "tool-call",
 			tool_call_id: "every-edit-files",
@@ -388,7 +418,7 @@ const EVERY_TOOL_ASSISTANT_TURN = {
 			result: { applied: 1 },
 		},
 
-		// list_templates -- completed template listing
+		// list_templates, completed template listing
 		{
 			type: "tool-call",
 			tool_call_id: "every-list-templates",
@@ -417,7 +447,7 @@ const EVERY_TOOL_ASSISTANT_TURN = {
 			},
 		},
 
-		// read_template -- completed single-template read
+		// read_template, completed single-template read
 		{
 			type: "tool-call",
 			tool_call_id: "every-read-template",
@@ -433,7 +463,7 @@ const EVERY_TOOL_ASSISTANT_TURN = {
 			},
 		},
 
-		// read_skill -- completed skill load
+		// read_skill, completed skill load
 		{
 			type: "tool-call",
 			tool_call_id: "every-read-skill",
@@ -459,7 +489,7 @@ const EVERY_TOOL_ASSISTANT_TURN = {
 			},
 		},
 
-		// read_skill_file -- completed skill file fetch
+		// read_skill_file, completed skill file fetch
 		{
 			type: "tool-call",
 			tool_call_id: "every-read-skill-file",
@@ -479,7 +509,7 @@ const EVERY_TOOL_ASSISTANT_TURN = {
 			},
 		},
 
-		// chat_summarized -- compaction summary card
+		// chat_summarized, compaction summary card
 		{
 			type: "tool-call",
 			tool_call_id: "every-summarized",
@@ -499,7 +529,7 @@ const EVERY_TOOL_ASSISTANT_TURN = {
 			},
 		},
 
-		// ask_user_question -- completed clarification
+		// ask_user_question, completed clarification
 		{
 			type: "tool-call",
 			tool_call_id: "every-ask-user",
@@ -531,7 +561,7 @@ const EVERY_TOOL_ASSISTANT_TURN = {
 			result: { questions: [{ answer: "Incremental migrations" }] },
 		},
 
-		// propose_plan -- proposed plan with content
+		// propose_plan, proposed plan with content
 		{
 			type: "tool-call",
 			tool_call_id: "every-propose-plan",
@@ -555,7 +585,7 @@ const EVERY_TOOL_ASSISTANT_TURN = {
 			},
 		},
 
-		// computer -- screenshot tool result with text fallback
+		// computer, screenshot tool result with text fallback
 		{
 			type: "tool-call",
 			tool_call_id: "every-computer",
@@ -573,7 +603,7 @@ const EVERY_TOOL_ASSISTANT_TURN = {
 			},
 		},
 
-		// attach_file -- generic renderer with explicit attach label
+		// attach_file, generic renderer with explicit attach label
 		{
 			type: "tool-call",
 			tool_call_id: "every-attach-file",
@@ -587,7 +617,7 @@ const EVERY_TOOL_ASSISTANT_TURN = {
 			result: {},
 		},
 
-		// generic / MCP fallback -- unknown tool name with no server
+		// generic / MCP fallback, unknown tool name with no server
 		{
 			type: "tool-call",
 			tool_call_id: "every-generic",
@@ -676,7 +706,7 @@ const EVERY_TOOL_ASSISTANT_TURN = {
 			},
 		},
 
-		// message_agent -- send a follow-up to a subagent
+		// message_agent, send a follow-up to a subagent
 		{
 			type: "tool-call",
 			tool_call_id: "every-message-agent",
@@ -694,7 +724,7 @@ const EVERY_TOOL_ASSISTANT_TURN = {
 			},
 		},
 
-		// wait_agent -- wait for a subagent to finish
+		// wait_agent, wait for a subagent to finish
 		{
 			type: "tool-call",
 			tool_call_id: "every-wait-agent",
@@ -713,7 +743,7 @@ const EVERY_TOOL_ASSISTANT_TURN = {
 			},
 		},
 
-		// close_agent -- terminate a subagent
+		// close_agent, terminate a subagent
 		{
 			type: "tool-call",
 			tool_call_id: "every-close-agent",
@@ -795,7 +825,7 @@ export const WithMessageHistory: Story = {
 			},
 			{
 				messages: [
-					// -- Turn 1: user asks for a summary --
+					// Turn 1: user asks for a summary --
 					{
 						id: 1,
 						chat_id: CHAT_ID,
@@ -808,7 +838,7 @@ export const WithMessageHistory: Story = {
 							},
 						],
 					},
-					// -- Turn 2: assistant with headings, lists, table, blockquote --
+					// Turn 2: assistant with headings, lists, table, blockquote --
 					{
 						id: 2,
 						chat_id: CHAT_ID,
@@ -884,7 +914,7 @@ export const WithMessageHistory: Story = {
 							},
 						],
 					},
-					// -- Turn 3: user follow-up (long message) --
+					// Turn 3: user follow-up (long message) --
 					{
 						id: 3,
 						chat_id: CHAT_ID,
@@ -923,7 +953,7 @@ export const WithMessageHistory: Story = {
 							},
 						],
 					},
-					// -- Turn 4: assistant with code, table, nested list, task list --
+					// Turn 4: assistant with code, table, nested list, task list --
 					{
 						id: 4,
 						chat_id: CHAT_ID,
@@ -997,7 +1027,7 @@ export const WithMessageHistory: Story = {
 							},
 						],
 					},
-					// -- Turn 5: user asks about middleware --
+					// Turn 5: user asks about middleware --
 					{
 						id: 5,
 						chat_id: CHAT_ID,
@@ -1010,7 +1040,7 @@ export const WithMessageHistory: Story = {
 							},
 						],
 					},
-					// -- Turn 6: assistant with code, inline code, links, images, nested blockquote --
+					// Turn 6: assistant with code, inline code, links, images, nested blockquote --
 					{
 						id: 6,
 						chat_id: CHAT_ID,
@@ -1134,11 +1164,52 @@ export const WithMessageHistory: Story = {
 		expect(
 			await canvas.findByText("Markdown rendering showcase"),
 		).toBeVisible();
-		await waitFor(() =>
+		await waitFor(() => {
 			expect(
 				canvas.queryByText(/^This is not your chat/),
-			).not.toBeInTheDocument(),
-		);
+			).not.toBeInTheDocument();
+			expect(
+				canvas.queryByText(/^This chat is owned by/),
+			).not.toBeInTheDocument();
+		});
+	},
+};
+
+export const RootChatShareActionAvailable: Story = {
+	parameters: {
+		queries: buildQueries(
+			{
+				id: CHAT_ID,
+				...baseChatFields,
+				title: "Shareable root chat",
+				status: "completed",
+			},
+			{ messages: [], queued_messages: [], has_more: false },
+			{ diffUrl: undefined },
+		),
+	},
+	beforeEach: () => {
+		spyOn(API.experimental, "getChatACL").mockResolvedValue({
+			users: [],
+			groups: [],
+		});
+		spyOn(API.experimental, "updateChatACL").mockResolvedValue(undefined);
+		spyOn(API, "getOrganizationPaginatedMembers").mockResolvedValue({
+			members: [MockOrganizationMember, MockOrganizationMember2],
+			count: 2,
+		});
+		spyOn(API, "getGroupsByOrganization").mockResolvedValue([MockGroup]);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(canvas.getByLabelText("Share chat"));
+		const body = within(document.body);
+		await waitFor(() => {
+			expect(body.getByText("Chat Sharing")).toBeVisible();
+		});
+		await waitFor(() => {
+			expect(body.getByText("No shared members or groups yet")).toBeVisible();
+		});
 	},
 };
 
@@ -1168,29 +1239,77 @@ export const AdminViewingOtherUserChat: Story = {
 					id: CHAT_ID,
 					...baseChatFields,
 					owner_id: "other-user-id",
+					owner_username: "OtherUser",
+					owner_name: "Other User",
 					title: "Other user's chat",
 					status: "completed",
 				},
 				{ messages: [], queued_messages: [], has_more: false },
 				{ diffUrl: undefined },
 			),
-			{
-				key: ["user", "other-user-id"],
-				data: {
-					...MockUserMember,
-					id: "other-user-id",
-					username: "OtherUser",
+			buildChatAuthorizationQuery(
+				{
+					owner_id: "other-user-id",
+					organization_id: baseChatFields.organization_id,
 				},
-			},
+				"canUpdateChat",
+				"update",
+				true,
+			),
 		],
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const banner = await canvas.findByText(
-			"This is not your chat. Prompting here will use @OtherUser's identity.",
+			"This is not your chat. Prompting here will use Other User's identity.",
 		);
 		expect(banner).toBeVisible();
 		expect(banner).toHaveAttribute("role", "status");
+		expect(canvas.getByRole("textbox")).toHaveAttribute(
+			"aria-disabled",
+			"false",
+		);
+	},
+};
+
+export const SharedReadOnlyChat: Story = {
+	parameters: {
+		queries: [
+			...buildQueries(
+				{
+					id: CHAT_ID,
+					...baseChatFields,
+					owner_id: "other-user-id",
+					owner_username: "OtherUser",
+					owner_name: "Other User",
+					title: "Shared read-only chat",
+					status: "completed",
+				},
+				{ messages: [], queued_messages: [], has_more: false },
+				{ diffUrl: undefined },
+			),
+			buildChatAuthorizationQuery(
+				{
+					owner_id: "other-user-id",
+					organization_id: baseChatFields.organization_id,
+				},
+				"canUpdateChat",
+				"update",
+				false,
+			),
+		],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			await canvas.findByText(
+				"This chat is owned by Other User. You have read-only access.",
+			),
+		).toBeVisible();
+		expect(canvas.getByRole("textbox")).toHaveAttribute(
+			"aria-disabled",
+			"true",
+		);
 	},
 };
 
@@ -1202,6 +1321,8 @@ export const ArchivedOtherUserChat: Story = {
 				...baseChatFields,
 				archived: true,
 				owner_id: "other-user-id",
+				owner_username: "OtherUser",
+				owner_name: "Other User",
 				title: "Archived other user's chat",
 				status: "completed",
 			},
@@ -1216,6 +1337,9 @@ export const ArchivedOtherUserChat: Story = {
 		).toBeVisible();
 		expect(
 			canvas.queryByText(/^This is not your chat/),
+		).not.toBeInTheDocument();
+		expect(
+			canvas.queryByText(/^This chat is owned by/),
 		).not.toBeInTheDocument();
 	},
 };
@@ -1944,7 +2068,7 @@ export const SidebarWithSingleRepo: Story = {
 	},
 };
 /**
- * Streaming reasoning part via WebSocket — renders inline text.
+ * Streaming reasoning part via WebSocket, renders inline text.
  */
 export const StreamedReasoning: Story = {
 	parameters: {
@@ -2006,7 +2130,7 @@ export const WithEveryTool: Story = {
 			},
 			{
 				messages: [
-					// -- Turn 1: user kicks off the task --
+					// Turn 1: user kicks off the task --
 					{
 						id: 1,
 						chat_id: CHAT_ID,
@@ -2019,7 +2143,7 @@ export const WithEveryTool: Story = {
 							},
 						],
 					},
-					// -- Turn 2: previous assistant turn (completed) --
+					// Turn 2: previous assistant turn (completed) --
 					//    Establishes that the agent already inspected and patched
 					//    a couple of files before the streaming turn begins.
 					{
@@ -2093,7 +2217,7 @@ export const WithEveryTool: Story = {
 							},
 						],
 					},
-					// -- Turn 3: user asks for a tool-by-tool tour --
+					// Turn 3: user asks for a tool-by-tool tour --
 					{
 						id: 3,
 						chat_id: CHAT_ID,
@@ -2106,7 +2230,7 @@ export const WithEveryTool: Story = {
 							},
 						],
 					},
-					// -- Turn 4: assistant runs every tool exactly once --
+					// Turn 4: assistant runs every tool exactly once --
 					EVERY_TOOL_ASSISTANT_TURN,
 				],
 				queued_messages: [],

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -189,26 +189,41 @@ const extractPromptsFromMessages = (
 	}
 	return prompts;
 };
+type ChatAuthorizationFixture = {
+	action: "share" | "update";
+	allowed: boolean;
+};
+
 const buildChatAuthorizationQuery = (
 	chat: Pick<TypesGen.Chat, "owner_id" | "organization_id">,
-	key: string,
-	action: "share" | "update",
-	allowed: boolean,
-) => ({
-	key: getAuthorizationKey({
-		checks: {
-			[key]: {
-				object: {
-					resource_type: "chat",
-					owner_id: chat.owner_id,
-					organization_id: chat.organization_id,
-				},
-				action,
+	checks: Partial<
+		Record<"canShareChat" | "canUpdateChat", ChatAuthorizationFixture>
+	>,
+) => {
+	const authorizationChecks: TypesGen.AuthorizationRequest["checks"] = {};
+	const authorizationResponse: TypesGen.AuthorizationResponse = {};
+
+	for (const [key, check] of Object.entries(checks)) {
+		if (check === undefined) {
+			continue;
+		}
+
+		authorizationChecks[key] = {
+			object: {
+				resource_type: "chat",
+				owner_id: chat.owner_id,
+				organization_id: chat.organization_id,
 			},
-		},
-	}),
-	data: { [key]: allowed },
-});
+			action: check.action,
+		};
+		authorizationResponse[key] = check.allowed;
+	}
+
+	return {
+		key: getAuthorizationKey({ checks: authorizationChecks }),
+		data: authorizationResponse,
+	};
+};
 
 /** Build `parameters.queries` entries for a given chat and messages. */
 const buildQueries = (
@@ -258,12 +273,12 @@ const buildQueries = (
 		{ key: chatModelsKey, data: mockModelCatalog },
 		{ key: chatModelConfigs().queryKey, data: mockModelConfigs },
 		{ key: mcpServerConfigsKey, data: [] },
-		buildChatAuthorizationQuery(
-			chat,
-			"canShareChat",
-			"share",
-			chat.owner_id === MockUserOwner.id && !chat.parent_chat_id,
-		),
+		buildChatAuthorizationQuery(chat, {
+			canShareChat: {
+				action: "share",
+				allowed: chat.owner_id === MockUserOwner.id && !chat.parent_chat_id,
+			},
+		}),
 	];
 };
 
@@ -1252,9 +1267,10 @@ export const AdminViewingOtherUserChat: Story = {
 					owner_id: "other-user-id",
 					organization_id: baseChatFields.organization_id,
 				},
-				"canUpdateChat",
-				"update",
-				true,
+				{
+					canUpdateChat: { action: "update", allowed: true },
+					canShareChat: { action: "share", allowed: false },
+				},
 			),
 		],
 	},
@@ -1293,9 +1309,10 @@ export const SharedReadOnlyChat: Story = {
 					owner_id: "other-user-id",
 					organization_id: baseChatFields.organization_id,
 				},
-				"canUpdateChat",
-				"update",
-				false,
+				{
+					canUpdateChat: { action: "update", allowed: false },
+					canShareChat: { action: "share", allowed: false },
+				},
 			),
 		],
 	},

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -38,7 +38,7 @@ import AgentChatPage, { RIGHT_PANEL_OPEN_KEY } from "./AgentChatPage";
 import type { AgentsOutletContext } from "./AgentsPage";
 
 // ---------------------------------------------------------------------------
-// Layout wrapper, provides outlet context for the child route.
+// Layout wrapper – provides outlet context for the child route.
 // ---------------------------------------------------------------------------
 const AgentChatPageLayout: FC = () => {
 	const scrollContainerRef = useRef<HTMLDivElement | null>(null);
@@ -306,7 +306,7 @@ const EVERY_TOOL_ASSISTANT_TURN = {
 			text: "Here is a recap of every tool I have at my disposal, exercised against this workspace so each card type renders.",
 		},
 
-		// execute, shell command output
+		// execute -- shell command output
 		{
 			type: "tool-call",
 			tool_call_id: "every-execute",
@@ -326,7 +326,7 @@ const EVERY_TOOL_ASSISTANT_TURN = {
 			},
 		},
 
-		// process_output, background process output
+		// process_output -- background process output
 		{
 			type: "tool-call",
 			tool_call_id: "every-process-output",
@@ -347,7 +347,7 @@ const EVERY_TOOL_ASSISTANT_TURN = {
 			},
 		},
 
-		// process_signal, signal sent to a background process
+		// process_signal -- signal sent to a background process
 		{
 			type: "tool-call",
 			tool_call_id: "every-process-signal",
@@ -361,7 +361,7 @@ const EVERY_TOOL_ASSISTANT_TURN = {
 			result: { success: true, signal: "terminate" },
 		},
 
-		// read_file, completed file read with content viewer
+		// read_file -- completed file read with content viewer
 		{
 			type: "tool-call",
 			tool_call_id: "every-read-file",
@@ -383,7 +383,7 @@ const EVERY_TOOL_ASSISTANT_TURN = {
 			},
 		},
 
-		// write_file, completed file write with diff viewer
+		// write_file -- completed file write with diff viewer
 		{
 			type: "tool-call",
 			tool_call_id: "every-write-file",
@@ -407,7 +407,7 @@ const EVERY_TOOL_ASSISTANT_TURN = {
 			result: { content: "wrote 6 lines" },
 		},
 
-		// edit_files, completed multi-file edit
+		// edit_files -- completed multi-file edit
 		{
 			type: "tool-call",
 			tool_call_id: "every-edit-files",
@@ -433,7 +433,7 @@ const EVERY_TOOL_ASSISTANT_TURN = {
 			result: { applied: 1 },
 		},
 
-		// list_templates, completed template listing
+		// list_templates -- completed template listing
 		{
 			type: "tool-call",
 			tool_call_id: "every-list-templates",
@@ -462,7 +462,7 @@ const EVERY_TOOL_ASSISTANT_TURN = {
 			},
 		},
 
-		// read_template, completed single-template read
+		// read_template -- completed single-template read
 		{
 			type: "tool-call",
 			tool_call_id: "every-read-template",
@@ -478,7 +478,7 @@ const EVERY_TOOL_ASSISTANT_TURN = {
 			},
 		},
 
-		// read_skill, completed skill load
+		// read_skill -- completed skill load
 		{
 			type: "tool-call",
 			tool_call_id: "every-read-skill",
@@ -504,7 +504,7 @@ const EVERY_TOOL_ASSISTANT_TURN = {
 			},
 		},
 
-		// read_skill_file, completed skill file fetch
+		// read_skill_file -- completed skill file fetch
 		{
 			type: "tool-call",
 			tool_call_id: "every-read-skill-file",
@@ -524,7 +524,7 @@ const EVERY_TOOL_ASSISTANT_TURN = {
 			},
 		},
 
-		// chat_summarized, compaction summary card
+		// chat_summarized -- compaction summary card
 		{
 			type: "tool-call",
 			tool_call_id: "every-summarized",
@@ -544,7 +544,7 @@ const EVERY_TOOL_ASSISTANT_TURN = {
 			},
 		},
 
-		// ask_user_question, completed clarification
+		// ask_user_question -- completed clarification
 		{
 			type: "tool-call",
 			tool_call_id: "every-ask-user",
@@ -576,7 +576,7 @@ const EVERY_TOOL_ASSISTANT_TURN = {
 			result: { questions: [{ answer: "Incremental migrations" }] },
 		},
 
-		// propose_plan, proposed plan with content
+		// propose_plan -- proposed plan with content
 		{
 			type: "tool-call",
 			tool_call_id: "every-propose-plan",
@@ -600,7 +600,7 @@ const EVERY_TOOL_ASSISTANT_TURN = {
 			},
 		},
 
-		// computer, screenshot tool result with text fallback
+		// computer -- screenshot tool result with text fallback
 		{
 			type: "tool-call",
 			tool_call_id: "every-computer",
@@ -618,7 +618,7 @@ const EVERY_TOOL_ASSISTANT_TURN = {
 			},
 		},
 
-		// attach_file, generic renderer with explicit attach label
+		// attach_file -- generic renderer with explicit attach label
 		{
 			type: "tool-call",
 			tool_call_id: "every-attach-file",
@@ -632,7 +632,7 @@ const EVERY_TOOL_ASSISTANT_TURN = {
 			result: {},
 		},
 
-		// generic / MCP fallback, unknown tool name with no server
+		// generic / MCP fallback -- unknown tool name with no server
 		{
 			type: "tool-call",
 			tool_call_id: "every-generic",
@@ -721,7 +721,7 @@ const EVERY_TOOL_ASSISTANT_TURN = {
 			},
 		},
 
-		// message_agent, send a follow-up to a subagent
+		// message_agent -- send a follow-up to a subagent
 		{
 			type: "tool-call",
 			tool_call_id: "every-message-agent",
@@ -739,7 +739,7 @@ const EVERY_TOOL_ASSISTANT_TURN = {
 			},
 		},
 
-		// wait_agent, wait for a subagent to finish
+		// wait_agent -- wait for a subagent to finish
 		{
 			type: "tool-call",
 			tool_call_id: "every-wait-agent",
@@ -758,7 +758,7 @@ const EVERY_TOOL_ASSISTANT_TURN = {
 			},
 		},
 
-		// close_agent, terminate a subagent
+		// close_agent -- terminate a subagent
 		{
 			type: "tool-call",
 			tool_call_id: "every-close-agent",
@@ -840,7 +840,7 @@ export const WithMessageHistory: Story = {
 			},
 			{
 				messages: [
-					// Turn 1: user asks for a summary
+					// -- Turn 1: user asks for a summary --
 					{
 						id: 1,
 						chat_id: CHAT_ID,
@@ -853,7 +853,7 @@ export const WithMessageHistory: Story = {
 							},
 						],
 					},
-					// Turn 2: assistant with headings, lists, table, blockquote
+					// -- Turn 2: assistant with headings, lists, table, blockquote --
 					{
 						id: 2,
 						chat_id: CHAT_ID,
@@ -929,7 +929,7 @@ export const WithMessageHistory: Story = {
 							},
 						],
 					},
-					// Turn 3: user follow-up (long message)
+					// -- Turn 3: user follow-up (long message) --
 					{
 						id: 3,
 						chat_id: CHAT_ID,
@@ -968,7 +968,7 @@ export const WithMessageHistory: Story = {
 							},
 						],
 					},
-					// Turn 4: assistant with code, table, nested list, task list
+					// -- Turn 4: assistant with code, table, nested list, task list --
 					{
 						id: 4,
 						chat_id: CHAT_ID,
@@ -1042,7 +1042,7 @@ export const WithMessageHistory: Story = {
 							},
 						],
 					},
-					// Turn 5: user asks about middleware
+					// -- Turn 5: user asks about middleware --
 					{
 						id: 5,
 						chat_id: CHAT_ID,
@@ -1055,7 +1055,7 @@ export const WithMessageHistory: Story = {
 							},
 						],
 					},
-					// Turn 6: assistant with code, inline code, links, images, nested blockquote
+					// -- Turn 6: assistant with code, inline code, links, images, nested blockquote --
 					{
 						id: 6,
 						chat_id: CHAT_ID,
@@ -2085,7 +2085,7 @@ export const SidebarWithSingleRepo: Story = {
 	},
 };
 /**
- * Streaming reasoning part via WebSocket, renders inline text.
+ * Streaming reasoning part via WebSocket — renders inline text.
  */
 export const StreamedReasoning: Story = {
 	parameters: {
@@ -2147,7 +2147,7 @@ export const WithEveryTool: Story = {
 			},
 			{
 				messages: [
-					// Turn 1: user kicks off the task
+					// -- Turn 1: user kicks off the task --
 					{
 						id: 1,
 						chat_id: CHAT_ID,
@@ -2160,7 +2160,7 @@ export const WithEveryTool: Story = {
 							},
 						],
 					},
-					// Turn 2: previous assistant turn (completed)
+					// -- Turn 2: previous assistant turn (completed) --
 					//    Establishes that the agent already inspected and patched
 					//    a couple of files before the streaming turn begins.
 					{
@@ -2234,7 +2234,7 @@ export const WithEveryTool: Story = {
 							},
 						],
 					},
-					// Turn 3: user asks for a tool-by-tool tour
+					// -- Turn 3: user asks for a tool-by-tool tour --
 					{
 						id: 3,
 						chat_id: CHAT_ID,
@@ -2247,7 +2247,7 @@ export const WithEveryTool: Story = {
 							},
 						],
 					},
-					// Turn 4: assistant runs every tool exactly once
+					// -- Turn 4: assistant runs every tool exactly once --
 					EVERY_TOOL_ASSISTANT_TURN,
 				],
 				queued_messages: [],

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -861,6 +861,9 @@ const AgentChatPage: FC = () => {
 	const canUpdateOtherUserChat = Boolean(
 		canUpdateOtherUserChatQuery.data?.canUpdateChat,
 	);
+	const canUpdateOtherUserChatLoading =
+		canUpdateOtherUserChatQuery.isLoading ||
+		canUpdateOtherUserChatQuery.isFetching;
 	const isRootChat =
 		chatRecord !== undefined && getParentChatID(chatRecord) === undefined;
 	const canShareChatQuery = useQuery({
@@ -1125,7 +1128,8 @@ const AgentChatPage: FC = () => {
 		!hasModelOptions ||
 		isArchived ||
 		isChatSettingsPending ||
-		(isViewerNotOwner && !canUpdateOtherUserChat);
+		(isViewerNotOwner &&
+			(canUpdateOtherUserChatLoading || !canUpdateOtherUserChat));
 	const selectedWorkspaceId = chatQuery.data?.workspace_id ?? null;
 
 	const isWorkspaceLoading =
@@ -1576,6 +1580,7 @@ const AgentChatPage: FC = () => {
 			isArchived={isArchived}
 			chatOwner={chatOwner}
 			canUpdateOtherUserChat={canUpdateOtherUserChat}
+			canUpdateOtherUserChatLoading={canUpdateOtherUserChatLoading}
 			canShareChat={canShareChat}
 			workspace={workspace}
 			workspaceAgent={workspaceAgent}

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -843,46 +843,46 @@ const AgentChatPage: FC = () => {
 	const isArchived = chatRecord?.archived ?? false;
 	const isViewerNotOwner =
 		chatRecord !== undefined && currentUser.id !== chatRecord.owner_id;
-	const canUpdateOtherUserChatQuery = useQuery({
-		...checkAuthorization({
-			checks: {
-				canUpdateChat: {
-					object: {
-						resource_type: "chat",
-						owner_id: chatRecord?.owner_id ?? "",
-						organization_id: chatRecord?.organization_id ?? "",
-					},
-					action: "update",
-				},
-			},
-		}),
-		enabled: isViewerNotOwner && !isArchived && chatRecord !== undefined,
-	});
-	const canUpdateOtherUserChat = Boolean(
-		canUpdateOtherUserChatQuery.data?.canUpdateChat,
-	);
-	const canUpdateOtherUserChatLoading =
-		canUpdateOtherUserChatQuery.isLoading ||
-		canUpdateOtherUserChatQuery.isFetching;
 	const isRootChat =
 		chatRecord !== undefined && getParentChatID(chatRecord) === undefined;
-	const canShareChatQuery = useQuery({
-		...checkAuthorization({
-			checks: {
-				canShareChat: {
-					object: {
-						resource_type: "chat",
-						owner_id: chatRecord?.owner_id ?? "",
-						organization_id: chatRecord?.organization_id ?? "",
-					},
-					action: "share",
-				},
-			},
-		}),
-		enabled: isRootChat,
+	const shouldCheckCanUpdateOtherUserChat =
+		isViewerNotOwner && !isArchived && chatRecord !== undefined;
+	const shouldCheckCanShareChat = isRootChat;
+	const chatAuthorizationObject =
+		chatRecord !== undefined
+			? {
+					resource_type: "chat" as const,
+					owner_id: chatRecord.owner_id,
+					organization_id: chatRecord.organization_id,
+				}
+			: undefined;
+	const chatAuthorizationChecks: TypesGen.AuthorizationRequest["checks"] = {};
+	if (
+		chatAuthorizationObject !== undefined &&
+		shouldCheckCanUpdateOtherUserChat
+	) {
+		chatAuthorizationChecks.canUpdateChat = {
+			object: chatAuthorizationObject,
+			action: "update",
+		};
+	}
+	if (chatAuthorizationObject !== undefined && shouldCheckCanShareChat) {
+		chatAuthorizationChecks.canShareChat = {
+			object: chatAuthorizationObject,
+			action: "share",
+		};
+	}
+	const chatAuthorizationQuery = useQuery({
+		...checkAuthorization({ checks: chatAuthorizationChecks }),
+		enabled: Object.keys(chatAuthorizationChecks).length > 0,
 	});
+	const canUpdateOtherUserChat = Boolean(
+		chatAuthorizationQuery.data?.canUpdateChat,
+	);
+	const canUpdateOtherUserChatLoading =
+		shouldCheckCanUpdateOtherUserChat && chatAuthorizationQuery.isLoading;
 	const canShareChat =
-		isRootChat && Boolean(canShareChatQuery.data?.canShareChat);
+		isRootChat && Boolean(chatAuthorizationQuery.data?.canShareChat);
 	const chatOwner =
 		isViewerNotOwner && chatRecord?.owner_username
 			? {

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -15,6 +15,7 @@ import {
 	watchWorkspace,
 } from "#/api/api";
 import { getErrorMessage, isApiError } from "#/api/errors";
+import { checkAuthorization } from "#/api/queries/authCheck";
 import { buildOptimisticEditedMessage } from "#/api/queries/chatMessageEdits";
 import {
 	chat,
@@ -37,7 +38,7 @@ import {
 	userCompactionThresholds,
 } from "#/api/queries/chats";
 import { deploymentSSHConfig } from "#/api/queries/deployment";
-import { preferenceSettings, user as userQuery } from "#/api/queries/users";
+import { preferenceSettings } from "#/api/queries/users";
 import {
 	workspaceById,
 	workspaceByIdKey,
@@ -334,7 +335,7 @@ export function useConversationEditingState(deps: {
 		}
 	}, [editorInitialValue, inputValueRef]);
 
-	// -- History editing state --
+	// History editing state.
 	const [editingMessageId, setEditingMessageId] = useState<number | null>(null);
 	const [draftBeforeHistoryEdit, setDraftBeforeHistoryEdit] =
 		useState<ParsedDraft | null>(null);
@@ -385,7 +386,7 @@ export function useConversationEditingState(deps: {
 		setEditingFileBlocks([]);
 	};
 
-	// -- Queue editing state --
+	// Queue editing state.
 	const [editingQueuedMessageID, setEditingQueuedMessageID] = useState<
 		number | null
 	>(null);
@@ -522,7 +523,7 @@ export function useConversationEditingState(deps: {
 		serializedEditorStateRef.current = serializedEditorState;
 
 		// Don't overwrite the persisted draft while editing a
-		// history or queued message — the original draft (possibly
+		// history or queued message, the original draft (possibly
 		// containing file-reference chips) is saved in React state
 		// and should survive a cancel.
 		if (editingMessageId !== null || editingQueuedMessageID !== null) {
@@ -535,7 +536,7 @@ export function useConversationEditingState(deps: {
 				try {
 					localStorage.setItem(draftStorageKey, serializedEditorState);
 				} catch {
-					// QuotaExceededError — silently discard the draft.
+					// QuotaExceededError, silently discard the draft.
 				}
 			} else {
 				localStorage.removeItem(draftStorageKey);
@@ -842,17 +843,48 @@ const AgentChatPage: FC = () => {
 	const isArchived = chatRecord?.archived ?? false;
 	const isViewerNotOwner =
 		chatRecord !== undefined && currentUser.id !== chatRecord.owner_id;
-	const chatOwnerQuery = useQuery({
-		...userQuery(chatRecord?.owner_id ?? ""),
-		enabled: isViewerNotOwner && !isArchived,
+	const canUpdateOtherUserChatQuery = useQuery({
+		...checkAuthorization({
+			checks: {
+				canUpdateChat: {
+					object: {
+						resource_type: "chat",
+						owner_id: chatRecord?.owner_id ?? "",
+						organization_id: chatRecord?.organization_id ?? "",
+					},
+					action: "update",
+				},
+			},
+		}),
+		enabled: isViewerNotOwner && !isArchived && chatRecord !== undefined,
 	});
+	const canUpdateOtherUserChat = Boolean(
+		canUpdateOtherUserChatQuery.data?.canUpdateChat,
+	);
+	const isRootChat =
+		chatRecord !== undefined && getParentChatID(chatRecord) === undefined;
+	const canShareChatQuery = useQuery({
+		...checkAuthorization({
+			checks: {
+				canShareChat: {
+					object: {
+						resource_type: "chat",
+						owner_id: chatRecord?.owner_id ?? "",
+						organization_id: chatRecord?.organization_id ?? "",
+					},
+					action: "share",
+				},
+			},
+		}),
+		enabled: isRootChat,
+	});
+	const canShareChat =
+		isRootChat && Boolean(canShareChatQuery.data?.canShareChat);
 	const chatOwner =
-		isViewerNotOwner && chatRecord !== undefined
+		isViewerNotOwner && chatRecord?.owner_username
 			? {
-					id: chatRecord.owner_id,
-					...(chatOwnerQuery.data?.username
-						? { username: chatOwnerQuery.data.username }
-						: {}),
+					username: chatRecord.owner_username,
+					...(chatRecord.owner_name ? { name: chatRecord.owner_name } : {}),
 				}
 			: undefined;
 	const planModeEnabled = chatRecord?.plan_mode === "plan";
@@ -1090,7 +1122,10 @@ const AgentChatPage: FC = () => {
 	const isChatSettingsPending =
 		isUpdateChatPlanModePending || isUpdateChatWorkspacePending;
 	const isInputDisabled =
-		!hasModelOptions || isArchived || isChatSettingsPending;
+		!hasModelOptions ||
+		isArchived ||
+		isChatSettingsPending ||
+		(isViewerNotOwner && !canUpdateOtherUserChat);
 	const selectedWorkspaceId = chatQuery.data?.workspace_id ?? null;
 
 	const isWorkspaceLoading =
@@ -1540,6 +1575,8 @@ const AgentChatPage: FC = () => {
 			persistedError={persistedError}
 			isArchived={isArchived}
 			chatOwner={chatOwner}
+			canUpdateOtherUserChat={canUpdateOtherUserChat}
+			canShareChat={canShareChat}
 			workspace={workspace}
 			workspaceAgent={workspaceAgent}
 			chatBuildId={chatQuery.data?.build_id}
@@ -1605,7 +1642,7 @@ const AgentChatPage: FC = () => {
 
 // Keyed wrapper so that navigating between agents (changing the
 // :agentId param) fully remounts the component, resetting all
-// internal state — drafts, editing, queries — cleanly.
+// internal state, drafts, editing, and queries, cleanly.
 const KeyedAgentChatPage: FC = () => {
 	const { agentId } = useParams<{ agentId: string }>();
 	return <AgentChatPage key={agentId} />;

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -335,7 +335,7 @@ export function useConversationEditingState(deps: {
 		}
 	}, [editorInitialValue, inputValueRef]);
 
-	// History editing state.
+	// -- History editing state --
 	const [editingMessageId, setEditingMessageId] = useState<number | null>(null);
 	const [draftBeforeHistoryEdit, setDraftBeforeHistoryEdit] =
 		useState<ParsedDraft | null>(null);
@@ -386,7 +386,7 @@ export function useConversationEditingState(deps: {
 		setEditingFileBlocks([]);
 	};
 
-	// Queue editing state.
+	// -- Queue editing state --
 	const [editingQueuedMessageID, setEditingQueuedMessageID] = useState<
 		number | null
 	>(null);
@@ -523,7 +523,7 @@ export function useConversationEditingState(deps: {
 		serializedEditorStateRef.current = serializedEditorState;
 
 		// Don't overwrite the persisted draft while editing a
-		// history or queued message, the original draft (possibly
+		// history or queued message — the original draft (possibly
 		// containing file-reference chips) is saved in React state
 		// and should survive a cancel.
 		if (editingMessageId !== null || editingQueuedMessageID !== null) {
@@ -536,7 +536,7 @@ export function useConversationEditingState(deps: {
 				try {
 					localStorage.setItem(draftStorageKey, serializedEditorState);
 				} catch {
-					// QuotaExceededError, silently discard the draft.
+					// QuotaExceededError — silently discard the draft.
 				}
 			} else {
 				localStorage.removeItem(draftStorageKey);
@@ -1647,7 +1647,7 @@ const AgentChatPage: FC = () => {
 
 // Keyed wrapper so that navigating between agents (changing the
 // :agentId param) fully remounts the component, resetting all
-// internal state, drafts, editing, and queries, cleanly.
+// internal state — drafts, editing, queries — cleanly.
 const KeyedAgentChatPage: FC = () => {
 	const { agentId } = useParams<{ agentId: string }>();
 	return <AgentChatPage key={agentId} />;

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -6,6 +6,10 @@ import { API } from "#/api/api";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { ChatDiffStatus, ChatMessagePart } from "#/api/typesGenerated";
 import {
+	MockDefaultOrganization,
+	MockGroup,
+	MockOrganizationMember,
+	MockOrganizationMember2,
 	MockUserOwner,
 	MockWorkspace,
 	MockWorkspaceAgent,
@@ -53,6 +57,7 @@ const buildChat = (overrides: Partial<TypesGen.Chat> = {}): TypesGen.Chat => ({
 	organization_id: "test-org-id",
 	owner_id: "owner-1",
 	owner_username: "owner",
+	owner_name: "Owner",
 	title: "Help me refactor",
 	status: "completed",
 	last_model_config_id: defaultModelConfigID,
@@ -148,6 +153,7 @@ const StoryAgentChatPageView: FC<StoryProps> = ({ editing, ...overrides }) => {
 		modelSelectorPlaceholder: "Select a model",
 		hasModelOptions: true,
 		compressionThreshold: undefined as number | undefined,
+		canUpdateOtherUserChat: false,
 		isInputDisabled: false,
 		isSubmissionPending: false,
 		isInterruptPending: false,
@@ -182,6 +188,7 @@ const StoryAgentChatPageView: FC<StoryProps> = ({ editing, ...overrides }) => {
 		>["selectedMCPServerIds"],
 		onMCPSelectionChange: fn(),
 		onMCPAuthComplete: fn(),
+		canShareChat: false,
 		...overrides,
 		store,
 		messageCount: overrides.messageCount ?? messageCount,
@@ -233,33 +240,54 @@ export const Archived: Story = {
 	render: () => <StoryAgentChatPageView isArchived isInputDisabled />,
 };
 
-/** Shows an identity warning banner when viewing a chat owned by another user. */
 export const AdminViewingOtherUserChat: Story = {
 	render: () => (
 		<StoryAgentChatPageView
-			chatOwner={{ id: "other-user-id", username: "OtherUser" }}
+			canUpdateOtherUserChat
+			chatOwner={{ username: "OtherUser", name: "Other User" }}
 		/>
 	),
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const banner = canvas.getByText(
-			"This is not your chat. Prompting here will use @OtherUser's identity.",
+			"This is not your chat. Prompting here will use Other User's identity.",
 		);
 		expect(banner).toBeVisible();
 		expect(banner).toHaveAttribute("role", "status");
 	},
 };
 
-/** Shows the owner ID fallback while the owner profile is unavailable. */
-export const OtherUserChatOwnerFallback: Story = {
-	render: () => <StoryAgentChatPageView chatOwner={{ id: "other-user-id" }} />,
+export const OtherUserChatOwnerPending: Story = {
+	render: () => <StoryAgentChatPageView canUpdateOtherUserChat />,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			canvas.queryByText(/^This is not your chat/),
+		).not.toBeInTheDocument();
+		expect(canvas.queryByText(/other-user-id/)).not.toBeInTheDocument();
+	},
+};
+
+export const ReadOnlyOtherUserChatOwner: Story = {
+	render: () => (
+		<StoryAgentChatPageView chatOwner={{ username: "OtherUser" }} />
+	),
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const banner = canvas.getByText(
-			"This is not your chat. Prompting here will use owner other-user-id's identity.",
+			"This chat is owned by @OtherUser. You have read-only access.",
 		);
 		expect(banner).toBeVisible();
 		expect(banner).toHaveAttribute("role", "status");
+	},
+};
+
+export const ReadOnlyOtherUserChatOwnerPending: Story = {
+	render: () => <StoryAgentChatPageView />,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.queryByText(/^This chat is owned/)).not.toBeInTheDocument();
+		expect(canvas.queryByText(/other-user-id/)).not.toBeInTheDocument();
 	},
 };
 
@@ -269,7 +297,7 @@ export const ArchivedOtherUserChat: Story = {
 		<StoryAgentChatPageView
 			isArchived
 			isInputDisabled
-			chatOwner={{ id: "other-user-id", username: "OtherUser" }}
+			chatOwner={{ username: "OtherUser" }}
 		/>
 	),
 	play: async ({ canvasElement }) => {
@@ -435,7 +463,7 @@ export const SidebarCollapsed: Story = {
 	render: () => <StoryAgentChatPageView isSidebarCollapsed />,
 };
 
-/** No model options available — shows a disabled status message. */
+/** No model options available, shows a disabled status message. */
 export const NoModelOptions: Story = {
 	render: () => (
 		<StoryAgentChatPageView
@@ -623,7 +651,7 @@ export const Loading: Story = {
 	render: () => (
 		<AgentChatPageLoadingView
 			sendShortcut="enter"
-			titleElement={<title>Loading — Agents</title>}
+			titleElement={<title>Loading, Agents</title>}
 			isInputDisabled
 			effectiveSelectedModel={defaultModelConfigID}
 			setSelectedModel={fn()}
@@ -642,7 +670,7 @@ export const LoadingWithModelOptions: Story = {
 	render: () => (
 		<AgentChatPageLoadingView
 			sendShortcut="enter"
-			titleElement={<title>Loading — Agents</title>}
+			titleElement={<title>Loading, Agents</title>}
 			isInputDisabled={false}
 			effectiveSelectedModel={defaultModelConfigID}
 			setSelectedModel={fn()}
@@ -660,7 +688,7 @@ export const LoadingWithRightPanel: Story = {
 	render: () => (
 		<AgentChatPageLoadingView
 			sendShortcut="enter"
-			titleElement={<title>Loading — Agents</title>}
+			titleElement={<title>Loading, Agents</title>}
 			isInputDisabled
 			effectiveSelectedModel={defaultModelConfigID}
 			setSelectedModel={fn()}
@@ -679,7 +707,7 @@ export const LoadingSidebarCollapsed: Story = {
 	render: () => (
 		<AgentChatPageLoadingView
 			sendShortcut="enter"
-			titleElement={<title>Loading — Agents</title>}
+			titleElement={<title>Loading, Agents</title>}
 			isInputDisabled
 			effectiveSelectedModel={defaultModelConfigID}
 			setSelectedModel={fn()}
@@ -735,7 +763,7 @@ const editingMessages = [
 	buildMessage(5, "user", "That was terrible, try again"),
 ];
 
-/** Editing a message in the middle of the conversation — shows the warning
+/** Editing a message in the middle of the conversation, shows the warning
  *  border on the edited message, faded subsequent messages, and the editing
  *  banner + outline on the chat input. */
 export const EditingMessage: Story = {
@@ -758,7 +786,7 @@ export const EditingMessage: Story = {
 export const NotFound: Story = {
 	render: () => (
 		<AgentChatPageNotFoundView
-			titleElement={<title>Not Found — Agents</title>}
+			titleElement={<title>Not Found, Agents</title>}
 			isSidebarCollapsed={false}
 			onToggleSidebarCollapsed={fn()}
 		/>
@@ -769,7 +797,7 @@ export const NotFound: Story = {
 export const NotFoundSidebarCollapsed: Story = {
 	render: () => (
 		<AgentChatPageNotFoundView
-			titleElement={<title>Not Found — Agents</title>}
+			titleElement={<title>Not Found, Agents</title>}
 			isSidebarCollapsed
 			onToggleSidebarCollapsed={fn()}
 		/>
@@ -1400,5 +1428,37 @@ export const DoesNotPersistForArchivedChat: Story = {
 		});
 
 		expect(localStorage.getItem(sidebarTabStorageKey)).toBeNull();
+	},
+};
+
+export const ShareChatPopoverFromTopBar: Story = {
+	render: () => (
+		<StoryAgentChatPageView
+			canShareChat
+			organizationId={MockDefaultOrganization.id}
+		/>
+	),
+	beforeEach: () => {
+		spyOn(API.experimental, "getChatACL").mockResolvedValue({
+			users: [],
+			groups: [],
+		});
+		spyOn(API.experimental, "updateChatACL").mockResolvedValue(undefined);
+		spyOn(API, "getOrganizationPaginatedMembers").mockResolvedValue({
+			members: [MockOrganizationMember, MockOrganizationMember2],
+			count: 2,
+		});
+		spyOn(API, "getGroupsByOrganization").mockResolvedValue([MockGroup]);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await userEvent.click(canvas.getByLabelText("Share chat"));
+		const body = within(document.body);
+		await waitFor(() => {
+			expect(body.getByText("Chat Sharing")).toBeVisible();
+		});
+		await waitFor(() => {
+			expect(body.getByText("No shared members or groups yet")).toBeVisible();
+		});
 	},
 };

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -1453,6 +1453,44 @@ export const DoesNotPersistForArchivedChat: Story = {
 	},
 };
 
+export const ArchivedWithSharing: Story = {
+	render: () => (
+		<StoryAgentChatPageView
+			isArchived
+			isInputDisabled
+			canShareChat
+			organizationId={MockDefaultOrganization.id}
+		/>
+	),
+	beforeEach: () => {
+		spyOn(API.experimental, "getChatACL").mockResolvedValue({
+			users: [],
+			groups: [],
+		});
+		spyOn(API.experimental, "updateChatACL").mockResolvedValue(undefined);
+		spyOn(API, "getOrganizationPaginatedMembers").mockResolvedValue({
+			members: [MockOrganizationMember, MockOrganizationMember2],
+			count: 2,
+		});
+		spyOn(API, "getGroupsByOrganization").mockResolvedValue([MockGroup]);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			canvas.getByText("This agent has been archived and is read-only."),
+		).toBeVisible();
+
+		await userEvent.click(canvas.getByLabelText("Share chat"));
+		const body = within(document.body);
+		await waitFor(() => {
+			expect(body.getByText("Chat Sharing")).toBeVisible();
+		});
+		await waitFor(() => {
+			expect(body.getByText("No shared members or groups yet")).toBeVisible();
+		});
+	},
+};
+
 export const ShareChatPopoverFromTopBar: Story = {
 	render: () => (
 		<StoryAgentChatPageView

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -485,7 +485,7 @@ export const SidebarCollapsed: Story = {
 	render: () => <StoryAgentChatPageView isSidebarCollapsed />,
 };
 
-/** No model options available, shows a disabled status message. */
+/** No model options available — shows a disabled status message. */
 export const NoModelOptions: Story = {
 	render: () => (
 		<StoryAgentChatPageView
@@ -673,7 +673,7 @@ export const Loading: Story = {
 	render: () => (
 		<AgentChatPageLoadingView
 			sendShortcut="enter"
-			titleElement={<title>Loading, Agents</title>}
+			titleElement={<title>Loading — Agents</title>}
 			isInputDisabled
 			effectiveSelectedModel={defaultModelConfigID}
 			setSelectedModel={fn()}
@@ -692,7 +692,7 @@ export const LoadingWithModelOptions: Story = {
 	render: () => (
 		<AgentChatPageLoadingView
 			sendShortcut="enter"
-			titleElement={<title>Loading, Agents</title>}
+			titleElement={<title>Loading — Agents</title>}
 			isInputDisabled={false}
 			effectiveSelectedModel={defaultModelConfigID}
 			setSelectedModel={fn()}
@@ -710,7 +710,7 @@ export const LoadingWithRightPanel: Story = {
 	render: () => (
 		<AgentChatPageLoadingView
 			sendShortcut="enter"
-			titleElement={<title>Loading, Agents</title>}
+			titleElement={<title>Loading — Agents</title>}
 			isInputDisabled
 			effectiveSelectedModel={defaultModelConfigID}
 			setSelectedModel={fn()}
@@ -729,7 +729,7 @@ export const LoadingSidebarCollapsed: Story = {
 	render: () => (
 		<AgentChatPageLoadingView
 			sendShortcut="enter"
-			titleElement={<title>Loading, Agents</title>}
+			titleElement={<title>Loading — Agents</title>}
 			isInputDisabled
 			effectiveSelectedModel={defaultModelConfigID}
 			setSelectedModel={fn()}
@@ -785,7 +785,7 @@ const editingMessages = [
 	buildMessage(5, "user", "That was terrible, try again"),
 ];
 
-/** Editing a message in the middle of the conversation, shows the warning
+/** Editing a message in the middle of the conversation — shows the warning
  *  border on the edited message, faded subsequent messages, and the editing
  *  banner + outline on the chat input. */
 export const EditingMessage: Story = {
@@ -808,7 +808,7 @@ export const EditingMessage: Story = {
 export const NotFound: Story = {
 	render: () => (
 		<AgentChatPageNotFoundView
-			titleElement={<title>Not Found, Agents</title>}
+			titleElement={<title>Not Found — Agents</title>}
 			isSidebarCollapsed={false}
 			onToggleSidebarCollapsed={fn()}
 		/>
@@ -819,7 +819,7 @@ export const NotFound: Story = {
 export const NotFoundSidebarCollapsed: Story = {
 	render: () => (
 		<AgentChatPageNotFoundView
-			titleElement={<title>Not Found, Agents</title>}
+			titleElement={<title>Not Found — Agents</title>}
 			isSidebarCollapsed
 			onToggleSidebarCollapsed={fn()}
 		/>

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -154,6 +154,7 @@ const StoryAgentChatPageView: FC<StoryProps> = ({ editing, ...overrides }) => {
 		hasModelOptions: true,
 		compressionThreshold: undefined as number | undefined,
 		canUpdateOtherUserChat: false,
+		canUpdateOtherUserChatLoading: false,
 		isInputDisabled: false,
 		isSubmissionPending: false,
 		isInterruptPending: false,
@@ -258,13 +259,24 @@ export const AdminViewingOtherUserChat: Story = {
 };
 
 export const OtherUserChatOwnerPending: Story = {
-	render: () => <StoryAgentChatPageView canUpdateOtherUserChat />,
+	render: () => (
+		<StoryAgentChatPageView
+			canUpdateOtherUserChat
+			canUpdateOtherUserChatLoading
+			chatOwner={{ username: "OtherUser", name: "Other User" }}
+			isInputDisabled
+		/>
+	),
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		expect(
 			canvas.queryByText(/^This is not your chat/),
 		).not.toBeInTheDocument();
 		expect(canvas.queryByText(/other-user-id/)).not.toBeInTheDocument();
+		expect(canvas.getByLabelText("Chat message")).toHaveAttribute(
+			"aria-disabled",
+			"true",
+		);
 	},
 };
 
@@ -283,11 +295,21 @@ export const ReadOnlyOtherUserChatOwner: Story = {
 };
 
 export const ReadOnlyOtherUserChatOwnerPending: Story = {
-	render: () => <StoryAgentChatPageView />,
+	render: () => (
+		<StoryAgentChatPageView
+			chatOwner={{ username: "OtherUser" }}
+			canUpdateOtherUserChatLoading
+			isInputDisabled
+		/>
+	),
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		expect(canvas.queryByText(/^This chat is owned/)).not.toBeInTheDocument();
 		expect(canvas.queryByText(/other-user-id/)).not.toBeInTheDocument();
+		expect(canvas.getByLabelText("Chat message")).toHaveAttribute(
+			"aria-disabled",
+			"true",
+		);
 	},
 };
 

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -32,6 +32,7 @@ import { DesktopPanelContext } from "./components/ChatElements/tools/DesktopPane
 import type { PendingAttachment } from "./components/ChatPageContent";
 import { ChatPageInput, ChatPageTimeline } from "./components/ChatPageContent";
 import { ChatScrollContainer } from "./components/ChatScrollContainer";
+import { ChatSharingPopoverContent } from "./components/ChatSharingPopover";
 import { getEffectiveTabId } from "./components/ChatsSidebar/tabs/getEffectiveTabId";
 import { SidebarTabView } from "./components/ChatsSidebar/tabs/SidebarTabView";
 import { ChatTopBar } from "./components/ChatTopBar";
@@ -92,7 +93,9 @@ interface AgentChatPageViewProps {
 	parentChat: TypesGen.Chat | undefined;
 	persistedError: ChatDetailError | undefined;
 	isArchived: boolean;
-	chatOwner: { id: string; username?: string } | undefined;
+	chatOwner: Pick<TypesGen.MinimalUser, "name" | "username"> | undefined;
+	canUpdateOtherUserChat: boolean;
+	canShareChat: boolean;
 	workspaceAgent?: TypesGen.WorkspaceAgent;
 	workspace?: TypesGen.Workspace;
 	chatBuildId?: string;
@@ -197,6 +200,8 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	persistedError,
 	isArchived,
 	chatOwner,
+	canUpdateOtherUserChat,
+	canShareChat,
 	workspaceAgent,
 	workspace,
 	chatBuildId,
@@ -256,6 +261,8 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	lastInjectedContext,
 }) => {
 	const queryClient = useQueryClient();
+
+	const canOpenChatSharing = canShareChat && organizationId !== undefined;
 
 	// Wrap the git watcher refresh to also invalidate the cached
 	// remote/PR diff contents so the panel re-fetches from GitHub.
@@ -413,16 +420,16 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 		editing.editingMessageId !== null ||
 		editing.editingQueuedMessageID !== null;
 
+	const chatOwnerUsername = chatOwner?.username.trim();
 	const chatOwnerLabel =
-		chatOwner === undefined
-			? undefined
-			: chatOwner.username
-				? `@${chatOwner.username}`
-				: `owner ${chatOwner.id}`;
+		chatOwner?.name?.trim() ||
+		(chatOwnerUsername ? `@${chatOwnerUsername}` : undefined);
 	const chatOwnerWarning =
 		chatOwnerLabel === undefined
 			? undefined
-			: `This is not your chat. Prompting here will use ${chatOwnerLabel}'s identity.`;
+			: canUpdateOtherUserChat
+				? `This is not your chat. Prompting here will use ${chatOwnerLabel}'s identity.`
+				: `This chat is owned by ${chatOwnerLabel}. You have read-only access.`;
 
 	const titleElement = (
 		<title>
@@ -473,6 +480,17 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 								diffStatusData={diffStatusData}
 								isSidebarCollapsed={isSidebarCollapsed}
 								onToggleSidebarCollapsed={onToggleSidebarCollapsed}
+								chatSharingPopover={
+									canOpenChatSharing
+										? (open) => (
+												<ChatSharingPopoverContent
+													chatId={agentId}
+													organizationId={organizationId}
+													open={open}
+												/>
+											)
+										: undefined
+								}
 							/>
 							{chatOwnerWarning && !isArchived && (
 								<div

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -95,6 +95,7 @@ interface AgentChatPageViewProps {
 	isArchived: boolean;
 	chatOwner: Pick<TypesGen.MinimalUser, "name" | "username"> | undefined;
 	canUpdateOtherUserChat: boolean;
+	canUpdateOtherUserChatLoading: boolean;
 	canShareChat: boolean;
 	workspaceAgent?: TypesGen.WorkspaceAgent;
 	workspace?: TypesGen.Workspace;
@@ -201,6 +202,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	isArchived,
 	chatOwner,
 	canUpdateOtherUserChat,
+	canUpdateOtherUserChatLoading,
 	canShareChat,
 	workspaceAgent,
 	workspace,
@@ -425,7 +427,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 		chatOwner?.name?.trim() ||
 		(chatOwnerUsername ? `@${chatOwnerUsername}` : undefined);
 	const chatOwnerWarning =
-		chatOwnerLabel === undefined
+		isArchived || canUpdateOtherUserChatLoading || chatOwnerLabel === undefined
 			? undefined
 			: canUpdateOtherUserChat
 				? `This is not your chat. Prompting here will use ${chatOwnerLabel}'s identity.`
@@ -480,7 +482,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 								diffStatusData={diffStatusData}
 								isSidebarCollapsed={isSidebarCollapsed}
 								onToggleSidebarCollapsed={onToggleSidebarCollapsed}
-								chatSharingPopover={
+								renderChatSharingContent={
 									canOpenChatSharing
 										? (open) => (
 												<ChatSharingPopoverContent
@@ -492,7 +494,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 										: undefined
 								}
 							/>
-							{chatOwnerWarning && !isArchived && (
+							{chatOwnerWarning && (
 								<div
 									role="status"
 									aria-live="polite"

--- a/site/src/pages/AgentsPage/components/ChatSharingPopover.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatSharingPopover.stories.tsx
@@ -1,0 +1,341 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, spyOn, userEvent, waitFor, within } from "storybook/test";
+import { API } from "#/api/api";
+import type * as TypesGen from "#/api/typesGenerated";
+import {
+	MockDefaultOrganization,
+	MockGroup,
+	MockGroup2,
+	MockOrganizationMember,
+	MockOrganizationMember2,
+	MockUserMember,
+	MockUserOwner,
+} from "#/testHelpers/entities";
+import {
+	withAuthProvider,
+	withDashboardProvider,
+} from "#/testHelpers/storybook";
+import { ChatShareButton } from "./ChatSharingPopover";
+
+const chatId = "chat-1";
+const organizationId = MockDefaultOrganization.id;
+
+const currentChatUser: TypesGen.ChatUser = {
+	id: MockUserOwner.id,
+	username: MockUserOwner.username,
+	name: MockUserOwner.name,
+	avatar_url: MockUserOwner.avatar_url,
+	role: "read",
+};
+
+const chatUser: TypesGen.ChatUser = {
+	id: MockUserMember.id,
+	username: MockUserMember.username,
+	name: MockUserMember.name,
+	avatar_url: MockUserMember.avatar_url,
+	role: "read",
+};
+
+const chatGroup: TypesGen.ChatGroup = {
+	...MockGroup,
+	role: "read",
+};
+
+const emptyACL: TypesGen.ChatACL = { users: [], groups: [] };
+const populatedACL: TypesGen.ChatACL = {
+	users: [chatUser],
+	groups: [chatGroup],
+};
+
+const ignoreResizeObserverLoopError = () => {
+	const handleError = (event: ErrorEvent) => {
+		if (
+			event.message ===
+			"ResizeObserver loop completed with undelivered notifications."
+		) {
+			event.stopImmediatePropagation();
+			event.preventDefault();
+		}
+	};
+
+	window.addEventListener("error", handleError);
+	return () => window.removeEventListener("error", handleError);
+};
+
+type DialogRequestMocks = {
+	acl?: TypesGen.ChatACL;
+	aclError?: Error;
+	aclPending?: boolean;
+	updateError?: Error;
+};
+
+const mockDialogRequests = ({
+	acl = emptyACL,
+	aclError,
+	aclPending,
+	updateError,
+}: DialogRequestMocks = {}) => {
+	if (aclPending) {
+		spyOn(API.experimental, "getChatACL").mockReturnValue(
+			new Promise<TypesGen.ChatACL>(() => undefined),
+		);
+	} else if (aclError) {
+		spyOn(API.experimental, "getChatACL").mockRejectedValue(aclError);
+	} else {
+		spyOn(API.experimental, "getChatACL").mockResolvedValue(acl);
+	}
+	if (updateError) {
+		spyOn(API.experimental, "updateChatACL").mockRejectedValue(updateError);
+	} else {
+		spyOn(API.experimental, "updateChatACL").mockResolvedValue();
+	}
+	spyOn(API, "getOrganizationPaginatedMembers").mockResolvedValue({
+		members: [MockOrganizationMember, MockOrganizationMember2],
+		count: 2,
+	});
+	spyOn(API, "getGroupsByOrganization").mockResolvedValue([
+		MockGroup,
+		MockGroup2,
+	]);
+	return ignoreResizeObserverLoopError();
+};
+
+const openChatSharing = async (canvasElement: HTMLElement) => {
+	const canvas = within(canvasElement);
+	await userEvent.click(canvas.getByRole("button", { name: "Share" }));
+	const body = within(canvasElement.ownerDocument.body);
+	await body.findByText("Chat Sharing");
+	return body;
+};
+
+const addAutocompleteOption = async (
+	body: ReturnType<typeof within>,
+	query: string,
+	option: string | RegExp,
+) => {
+	await userEvent.click(
+		await body.findByRole("button", { name: "Search for user or group" }),
+	);
+	await userEvent.type(
+		body.getByPlaceholderText("Search for user or group"),
+		query,
+	);
+	await userEvent.click(await body.findByRole("option", { name: option }));
+	await userEvent.click(body.getByRole("button", { name: "Add member" }));
+};
+
+const meta: Meta<typeof ChatShareButton> = {
+	title: "pages/AgentsPage/ChatSharingPopover",
+	component: ChatShareButton,
+	decorators: [withAuthProvider, withDashboardProvider],
+	parameters: {
+		user: MockUserOwner,
+	},
+	args: {
+		chatId,
+		organizationId,
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof ChatShareButton>;
+
+export const EmptyACL: Story = {
+	beforeEach: () => mockDialogRequests(),
+	play: async ({ canvasElement }) => {
+		const body = await openChatSharing(canvasElement);
+		await waitFor(() => {
+			expect(body.getByText("No shared members or groups yet")).toBeVisible();
+			expect(
+				body.getByText("Add a member or group using the controls above."),
+			).toBeVisible();
+		});
+	},
+};
+
+export const PopulatedACL: Story = {
+	beforeEach: () => mockDialogRequests({ acl: populatedACL }),
+	play: async ({ canvasElement }) => {
+		const body = await openChatSharing(canvasElement);
+		await waitFor(() => {
+			expect(body.getByText(chatUser.username)).toBeInTheDocument();
+			expect(body.getByText(chatGroup.name)).toBeInTheDocument();
+			expect(body.getAllByText("Read").length).toBeGreaterThan(0);
+		});
+		expect(
+			body.queryByRole("button", {
+				name: new RegExp(`Remove ${chatUser.username}`, "i"),
+			}),
+		).not.toBeInTheDocument();
+		expect(
+			body.queryByRole("button", {
+				name: new RegExp(
+					`Remove ${chatGroup.display_name || chatGroup.name}`,
+					"i",
+				),
+			}),
+		).not.toBeInTheDocument();
+	},
+};
+
+export const CurrentUserHidden: Story = {
+	beforeEach: () =>
+		mockDialogRequests({
+			acl: {
+				users: [currentChatUser, chatUser],
+				groups: [],
+			},
+		}),
+	play: async ({ canvasElement }) => {
+		const body = await openChatSharing(canvasElement);
+		await waitFor(() => {
+			expect(
+				body.queryByText(currentChatUser.username),
+			).not.toBeInTheDocument();
+			expect(body.getByText(chatUser.username)).toBeVisible();
+		});
+	},
+};
+
+export const CurrentUserExcludedFromAutocomplete: Story = {
+	beforeEach: () => mockDialogRequests(),
+	play: async ({ canvasElement }) => {
+		const body = await openChatSharing(canvasElement);
+		const autocompleteButton = await body.findByRole("button", {
+			name: "Search for user or group",
+		});
+		await userEvent.click(autocompleteButton);
+		await userEvent.type(
+			body.getByPlaceholderText("Search for user or group"),
+			MockOrganizationMember.email,
+		);
+
+		await waitFor(() => {
+			expect(body.getByText("No users or groups found")).toBeVisible();
+			expect(
+				body.queryByRole("option", {
+					name: new RegExp(MockOrganizationMember.email, "i"),
+				}),
+			).not.toBeInTheDocument();
+		});
+	},
+};
+
+export const LoadingACL: Story = {
+	beforeEach: () => mockDialogRequests({ aclPending: true }),
+	play: async ({ canvasElement }) => {
+		const body = await openChatSharing(canvasElement);
+		await waitFor(() => {
+			expect(body.getByText("Loading chat sharing")).toBeInTheDocument();
+		});
+	},
+};
+
+export const ErrorACL: Story = {
+	beforeEach: () =>
+		mockDialogRequests({ aclError: new Error("Chat sharing is disabled") }),
+	play: async ({ canvasElement }) => {
+		const body = await openChatSharing(canvasElement);
+		await waitFor(() => {
+			expect(body.getByText("Chat sharing is disabled")).toBeInTheDocument();
+		});
+	},
+};
+
+export const AddUser: Story = {
+	beforeEach: () => mockDialogRequests(),
+	play: async ({ canvasElement }) => {
+		const body = await openChatSharing(canvasElement);
+		await addAutocompleteOption(
+			body,
+			MockOrganizationMember2.email,
+			new RegExp(MockOrganizationMember2.email, "i"),
+		);
+
+		await waitFor(() => {
+			expect(API.experimental.updateChatACL).toHaveBeenCalledWith(chatId, {
+				user_roles: { [MockUserMember.id]: "read" },
+			});
+		});
+	},
+};
+
+export const AddGroup: Story = {
+	beforeEach: () => mockDialogRequests(),
+	play: async ({ canvasElement }) => {
+		const body = await openChatSharing(canvasElement);
+		await addAutocompleteOption(
+			body,
+			MockGroup.name,
+			new RegExp(MockGroup.display_name || MockGroup.name, "i"),
+		);
+
+		await waitFor(() => {
+			expect(API.experimental.updateChatACL).toHaveBeenCalledWith(chatId, {
+				group_roles: { [MockGroup.id]: "read" },
+			});
+		});
+	},
+};
+
+export const RemoveUser: Story = {
+	beforeEach: () => mockDialogRequests({ acl: populatedACL }),
+	play: async ({ canvasElement }) => {
+		const body = await openChatSharing(canvasElement);
+		await waitFor(() => {
+			expect(body.getByText(chatUser.username)).toBeInTheDocument();
+		});
+		// Groups render before users, so the user row menu is the second one.
+		const menuButtons = await body.findAllByRole("button", {
+			name: "Open menu",
+		});
+		await userEvent.click(menuButtons[1]);
+		const removeItem = await body.findByRole("menuitem", { name: "Remove" });
+		await userEvent.click(removeItem);
+
+		await waitFor(() => {
+			expect(API.experimental.updateChatACL).toHaveBeenCalledWith(chatId, {
+				user_roles: { [chatUser.id]: "" },
+			});
+		});
+	},
+};
+
+export const RemoveGroup: Story = {
+	beforeEach: () => mockDialogRequests({ acl: populatedACL }),
+	play: async ({ canvasElement }) => {
+		const body = await openChatSharing(canvasElement);
+		await waitFor(() => {
+			expect(body.getByText(chatGroup.name)).toBeInTheDocument();
+		});
+		// Groups render before users, so the group row menu is the first one.
+		const menuButtons = await body.findAllByRole("button", {
+			name: "Open menu",
+		});
+		await userEvent.click(menuButtons[0]);
+		const removeItem = await body.findByRole("menuitem", { name: "Remove" });
+		await userEvent.click(removeItem);
+
+		await waitFor(() => {
+			expect(API.experimental.updateChatACL).toHaveBeenCalledWith(chatId, {
+				group_roles: { [chatGroup.id]: "" },
+			});
+		});
+	},
+};
+
+export const MutationError: Story = {
+	beforeEach: () =>
+		mockDialogRequests({ updateError: new Error("No share permission") }),
+	play: async ({ canvasElement }) => {
+		const body = await openChatSharing(canvasElement);
+		await addAutocompleteOption(
+			body,
+			MockOrganizationMember2.email,
+			new RegExp(MockOrganizationMember2.email, "i"),
+		);
+		await waitFor(() => {
+			expect(body.getByText("No share permission")).toBeInTheDocument();
+		});
+	},
+};

--- a/site/src/pages/AgentsPage/components/ChatSharingPopover.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatSharingPopover.stories.tsx
@@ -14,6 +14,7 @@ import {
 import {
 	withAuthProvider,
 	withDashboardProvider,
+	withToaster,
 } from "#/testHelpers/storybook";
 import { ChatShareButton } from "./ChatSharingPopover";
 
@@ -62,19 +63,17 @@ const ignoreResizeObserverLoopError = () => {
 	return () => window.removeEventListener("error", handleError);
 };
 
-type DialogRequestMocks = {
+type LookupRequestMocks = {
 	acl?: TypesGen.ChatACL;
 	aclError?: Error;
 	aclPending?: boolean;
-	updateError?: Error;
 };
 
-const mockDialogRequests = ({
+const mockLookupRequests = ({
 	acl = emptyACL,
 	aclError,
 	aclPending,
-	updateError,
-}: DialogRequestMocks = {}) => {
+}: LookupRequestMocks = {}) => {
 	if (aclPending) {
 		spyOn(API.experimental, "getChatACL").mockReturnValue(
 			new Promise<TypesGen.ChatACL>(() => undefined),
@@ -84,11 +83,7 @@ const mockDialogRequests = ({
 	} else {
 		spyOn(API.experimental, "getChatACL").mockResolvedValue(acl);
 	}
-	if (updateError) {
-		spyOn(API.experimental, "updateChatACL").mockRejectedValue(updateError);
-	} else {
-		spyOn(API.experimental, "updateChatACL").mockResolvedValue();
-	}
+
 	spyOn(API, "getOrganizationPaginatedMembers").mockResolvedValue({
 		members: [MockOrganizationMember, MockOrganizationMember2],
 		count: 2,
@@ -97,7 +92,27 @@ const mockDialogRequests = ({
 		MockGroup,
 		MockGroup2,
 	]);
+
 	return ignoreResizeObserverLoopError();
+};
+
+type DialogRequestMocks = LookupRequestMocks & {
+	updateError?: Error;
+};
+
+const mockDialogRequests = ({
+	updateError,
+	...lookupOptions
+}: DialogRequestMocks = {}) => {
+	const cleanup = mockLookupRequests(lookupOptions);
+
+	if (updateError) {
+		spyOn(API.experimental, "updateChatACL").mockRejectedValue(updateError);
+	} else {
+		spyOn(API.experimental, "updateChatACL").mockResolvedValue();
+	}
+
+	return cleanup;
 };
 
 const openChatSharing = async (canvasElement: HTMLElement) => {
@@ -108,14 +123,28 @@ const openChatSharing = async (canvasElement: HTMLElement) => {
 	return body;
 };
 
+const closeChatSharing = async (canvasElement: HTMLElement) => {
+	const canvas = within(canvasElement);
+	const body = within(canvasElement.ownerDocument.body);
+	await userEvent.click(canvas.getByRole("button", { name: "Share" }));
+	await waitFor(() => {
+		expect(body.queryByText("Chat Sharing")).not.toBeInTheDocument();
+	});
+};
+
 const addAutocompleteOption = async (
 	body: ReturnType<typeof within>,
-	query: string,
-	option: string | RegExp,
+	{
+		query,
+		option,
+		triggerName = "Search for user or group",
+	}: {
+		query: string;
+		option: string | RegExp;
+		triggerName?: string | RegExp;
+	},
 ) => {
-	await userEvent.click(
-		await body.findByRole("button", { name: "Search for user or group" }),
-	);
+	await userEvent.click(await body.findByRole("button", { name: triggerName }));
 	await userEvent.type(
 		body.getByPlaceholderText("Search for user or group"),
 		query,
@@ -162,19 +191,7 @@ export const PopulatedACL: Story = {
 			expect(body.getByText(chatGroup.name)).toBeInTheDocument();
 			expect(body.getAllByText("Read").length).toBeGreaterThan(0);
 		});
-		expect(
-			body.queryByRole("button", {
-				name: new RegExp(`Remove ${chatUser.username}`, "i"),
-			}),
-		).not.toBeInTheDocument();
-		expect(
-			body.queryByRole("button", {
-				name: new RegExp(
-					`Remove ${chatGroup.display_name || chatGroup.name}`,
-					"i",
-				),
-			}),
-		).not.toBeInTheDocument();
+		expect(body.getAllByRole("button", { name: "Open menu" })).toHaveLength(2);
 	},
 };
 
@@ -243,37 +260,43 @@ export const ErrorACL: Story = {
 };
 
 export const AddUser: Story = {
+	decorators: [withToaster],
 	beforeEach: () => mockDialogRequests(),
 	play: async ({ canvasElement }) => {
 		const body = await openChatSharing(canvasElement);
-		await addAutocompleteOption(
-			body,
-			MockOrganizationMember2.email,
-			new RegExp(MockOrganizationMember2.email, "i"),
-		);
+		await addAutocompleteOption(body, {
+			query: MockOrganizationMember2.email,
+			option: new RegExp(MockOrganizationMember2.email, "i"),
+		});
 
 		await waitFor(() => {
 			expect(API.experimental.updateChatACL).toHaveBeenCalledWith(chatId, {
 				user_roles: { [MockUserMember.id]: "read" },
 			});
 		});
+		await waitFor(() => {
+			expect(body.getByText("Member added to chat.")).toBeVisible();
+		});
 	},
 };
 
 export const AddGroup: Story = {
+	decorators: [withToaster],
 	beforeEach: () => mockDialogRequests(),
 	play: async ({ canvasElement }) => {
 		const body = await openChatSharing(canvasElement);
-		await addAutocompleteOption(
-			body,
-			MockGroup.name,
-			new RegExp(MockGroup.display_name || MockGroup.name, "i"),
-		);
+		await addAutocompleteOption(body, {
+			query: MockGroup.name,
+			option: new RegExp(MockGroup.display_name || MockGroup.name, "i"),
+		});
 
 		await waitFor(() => {
 			expect(API.experimental.updateChatACL).toHaveBeenCalledWith(chatId, {
 				group_roles: { [MockGroup.id]: "read" },
 			});
+		});
+		await waitFor(() => {
+			expect(body.getByText("Group added to chat.")).toBeVisible();
 		});
 	},
 };
@@ -329,13 +352,90 @@ export const MutationError: Story = {
 		mockDialogRequests({ updateError: new Error("No share permission") }),
 	play: async ({ canvasElement }) => {
 		const body = await openChatSharing(canvasElement);
-		await addAutocompleteOption(
-			body,
-			MockOrganizationMember2.email,
-			new RegExp(MockOrganizationMember2.email, "i"),
-		);
+		await addAutocompleteOption(body, {
+			query: MockOrganizationMember2.email,
+			option: new RegExp(MockOrganizationMember2.email, "i"),
+		});
 		await waitFor(() => {
 			expect(body.getByText("No share permission")).toBeInTheDocument();
+		});
+	},
+};
+
+export const MutationErrorClearsAcrossMemberTypes: Story = {
+	decorators: [withToaster],
+	beforeEach: () => {
+		const cleanup = mockLookupRequests();
+		spyOn(API.experimental, "updateChatACL")
+			.mockRejectedValueOnce(new Error("User add failed"))
+			.mockResolvedValue(undefined);
+		return cleanup;
+	},
+	play: async ({ canvasElement }) => {
+		const body = await openChatSharing(canvasElement);
+		await addAutocompleteOption(body, {
+			query: MockOrganizationMember2.email,
+			option: new RegExp(MockOrganizationMember2.email, "i"),
+		});
+		await waitFor(() => {
+			expect(body.getByText("User add failed")).toBeInTheDocument();
+		});
+
+		await userEvent.click(
+			body.getByRole("button", { name: "Clear selection" }),
+		);
+		await addAutocompleteOption(body, {
+			query: MockGroup.name,
+			option: new RegExp(MockGroup.display_name || MockGroup.name, "i"),
+		});
+
+		await waitFor(() => {
+			expect(API.experimental.updateChatACL).toHaveBeenNthCalledWith(
+				1,
+				chatId,
+				{
+					user_roles: { [MockUserMember.id]: "read" },
+				},
+			);
+			expect(API.experimental.updateChatACL).toHaveBeenNthCalledWith(
+				2,
+				chatId,
+				{
+					group_roles: { [MockGroup.id]: "read" },
+				},
+			);
+		});
+		await waitFor(() => {
+			expect(body.queryByText("User add failed")).not.toBeInTheDocument();
+			expect(body.getByText("Group added to chat.")).toBeVisible();
+		});
+	},
+};
+
+export const MutationErrorClearsWhenReopened: Story = {
+	beforeEach: () => {
+		const cleanup = mockLookupRequests();
+		spyOn(API.experimental, "updateChatACL").mockRejectedValue(
+			new Error("No share permission"),
+		);
+		return cleanup;
+	},
+	play: async ({ canvasElement }) => {
+		const body = await openChatSharing(canvasElement);
+		await addAutocompleteOption(body, {
+			query: MockOrganizationMember2.email,
+			option: new RegExp(MockOrganizationMember2.email, "i"),
+		});
+		await waitFor(() => {
+			expect(body.getByText("No share permission")).toBeInTheDocument();
+		});
+
+		await closeChatSharing(canvasElement);
+		const reopenedBody = await openChatSharing(canvasElement);
+		await waitFor(() => {
+			expect(
+				reopenedBody.queryByText("No share permission"),
+			).not.toBeInTheDocument();
 		});
 	},
 };

--- a/site/src/pages/AgentsPage/components/ChatSharingPopover.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatSharingPopover.stories.tsx
@@ -302,6 +302,7 @@ export const AddGroup: Story = {
 };
 
 export const RemoveUser: Story = {
+	decorators: [withToaster],
 	beforeEach: () => mockDialogRequests({ acl: populatedACL }),
 	play: async ({ canvasElement }) => {
 		const body = await openChatSharing(canvasElement);
@@ -321,10 +322,14 @@ export const RemoveUser: Story = {
 				user_roles: { [chatUser.id]: "" },
 			});
 		});
+		await waitFor(() => {
+			expect(body.getByText("Member removed from chat.")).toBeVisible();
+		});
 	},
 };
 
 export const RemoveGroup: Story = {
+	decorators: [withToaster],
 	beforeEach: () => mockDialogRequests({ acl: populatedACL }),
 	play: async ({ canvasElement }) => {
 		const body = await openChatSharing(canvasElement);
@@ -343,6 +348,9 @@ export const RemoveGroup: Story = {
 			expect(API.experimental.updateChatACL).toHaveBeenCalledWith(chatId, {
 				group_roles: { [chatGroup.id]: "" },
 			});
+		});
+		await waitFor(() => {
+			expect(body.getByText("Group removed from chat.")).toBeVisible();
 		});
 	},
 };

--- a/site/src/pages/AgentsPage/components/ChatSharingPopover.tsx
+++ b/site/src/pages/AgentsPage/components/ChatSharingPopover.tsx
@@ -1,5 +1,5 @@
 import { EllipsisVerticalIcon, Share2Icon } from "lucide-react";
-import { type FC, useEffect, useRef, useState } from "react";
+import { type FC, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
 import { toast } from "sonner";
 import {
@@ -94,7 +94,6 @@ export const ChatSharingPopoverContent: FC<ChatSharingPopoverContentProps> = ({
 	const queryClient = useQueryClient();
 	const [selectedOption, setSelectedOption] =
 		useState<UserOrGroupAutocompleteValue>(null);
-	const hasResetForOpenRef = useRef(false);
 
 	const aclQuery = useQuery({
 		...chatACL(chatId),
@@ -116,21 +115,6 @@ export const ChatSharingPopoverContent: FC<ChatSharingPopoverContentProps> = ({
 
 	const mutationError = userRoleError ?? groupRoleError;
 	const isMutating = isUserRolePending || isGroupRolePending;
-
-	useEffect(() => {
-		if (!open) {
-			hasResetForOpenRef.current = false;
-			return;
-		}
-
-		if (isMutating || hasResetForOpenRef.current) {
-			return;
-		}
-
-		resetUserRole();
-		resetGroupRole();
-		hasResetForOpenRef.current = true;
-	}, [open, isMutating, resetGroupRole, resetUserRole]);
 
 	const resetMutationErrors = () => {
 		resetUserRole();
@@ -332,9 +316,18 @@ export const ChatShareButton: FC<ChatShareButtonProps> = ({
 	organizationId,
 }) => {
 	const [open, setOpen] = useState(false);
+	const [contentGeneration, setContentGeneration] = useState(0);
+
+	const handleOpenChange = (nextOpen: boolean) => {
+		if (nextOpen) {
+			setContentGeneration((generation) => generation + 1);
+		}
+
+		setOpen(nextOpen);
+	};
 
 	return (
-		<Popover open={open} onOpenChange={setOpen}>
+		<Popover open={open} onOpenChange={handleOpenChange}>
 			<PopoverTrigger asChild>
 				<TopbarButton data-testid="chat-share-button">
 					<Share2Icon />
@@ -342,6 +335,7 @@ export const ChatShareButton: FC<ChatShareButtonProps> = ({
 				</TopbarButton>
 			</PopoverTrigger>
 			<ChatSharingPopoverContent
+				key={contentGeneration}
 				chatId={chatId}
 				organizationId={organizationId}
 				open={open}

--- a/site/src/pages/AgentsPage/components/ChatSharingPopover.tsx
+++ b/site/src/pages/AgentsPage/components/ChatSharingPopover.tsx
@@ -1,0 +1,307 @@
+import { EllipsisVerticalIcon, Share2Icon } from "lucide-react";
+import { type FC, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "react-query";
+import { toast } from "sonner";
+import {
+	chatACL,
+	setChatGroupRole,
+	setChatUserRole,
+} from "#/api/queries/chats";
+import type * as TypesGen from "#/api/typesGenerated";
+import { ErrorAlert } from "#/components/Alert/ErrorAlert";
+import { Avatar } from "#/components/Avatar/Avatar";
+import { AvatarData } from "#/components/Avatar/AvatarData";
+import { Button } from "#/components/Button/Button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "#/components/DropdownMenu/DropdownMenu";
+import { EmptyState } from "#/components/EmptyState/EmptyState";
+import { TopbarButton } from "#/components/FullPageLayout/Topbar";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "#/components/Popover/Popover";
+import { Spinner } from "#/components/Spinner/Spinner";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "#/components/Table/Table";
+import { useAuthenticated } from "#/hooks/useAuthenticated";
+import { getGroupSubtitle, isGroup } from "#/modules/groups";
+import {
+	UserOrGroupAutocomplete,
+	type UserOrGroupAutocompleteValue,
+} from "#/modules/workspaces/WorkspaceSharingForm/UserOrGroupAutocomplete";
+import { AddWorkspaceMemberForm } from "#/modules/workspaces/WorkspaceSharingForm/WorkspaceSharingForm";
+
+type ChatShareButtonProps = {
+	chatId: string;
+	organizationId: string;
+};
+
+type ChatSharingPopoverContentProps = ChatShareButtonProps & {
+	open: boolean;
+};
+
+type MemberRowMenuProps = {
+	disabled: boolean;
+	onRemove: () => void;
+};
+
+const ReadRoleBadge: FC = () => (
+	<span className="bg-surface-secondary rounded-md px-3 py-0.5 inline-block">
+		Read
+	</span>
+);
+
+const MemberRowMenu: FC<MemberRowMenuProps> = ({ disabled, onRemove }) => (
+	<DropdownMenu>
+		<DropdownMenuTrigger asChild>
+			<Button
+				size="icon-lg"
+				variant="subtle"
+				aria-label="Open menu"
+				disabled={disabled}
+			>
+				<EllipsisVerticalIcon aria-hidden="true" />
+				<span className="sr-only">Open menu</span>
+			</Button>
+		</DropdownMenuTrigger>
+		<DropdownMenuContent align="end">
+			<DropdownMenuItem
+				className="text-content-destructive focus:text-content-destructive"
+				onClick={onRemove}
+			>
+				Remove
+			</DropdownMenuItem>
+		</DropdownMenuContent>
+	</DropdownMenu>
+);
+
+export const ChatSharingPopoverContent: FC<ChatSharingPopoverContentProps> = ({
+	chatId,
+	organizationId,
+	open,
+}) => {
+	const { user: currentUser } = useAuthenticated();
+	const queryClient = useQueryClient();
+	const [selectedOption, setSelectedOption] =
+		useState<UserOrGroupAutocompleteValue>(null);
+
+	const aclQuery = useQuery({
+		...chatACL(chatId),
+		enabled: open,
+	});
+
+	const userRoleMutation = useMutation(setChatUserRole(queryClient));
+	const groupRoleMutation = useMutation(setChatGroupRole(queryClient));
+
+	const mutationError = userRoleMutation.error ?? groupRoleMutation.error;
+	const isMutating = userRoleMutation.isPending || groupRoleMutation.isPending;
+
+	const acl = aclQuery.data;
+	const users = (acl?.users ?? []).filter((user) => user.id !== currentUser.id);
+	const groups = acl?.groups ?? [];
+	const excludeFromAutocomplete = [...users, ...groups, currentUser];
+
+	const handleAddMember = () => {
+		if (!selectedOption) {
+			return;
+		}
+
+		const onSuccess = () => {
+			setSelectedOption(null);
+			toast.success("Member added to chat.");
+		};
+
+		if (!isGroup(selectedOption) && selectedOption.id === currentUser.id) {
+			return;
+		}
+
+		if (isGroup(selectedOption)) {
+			groupRoleMutation.mutate(
+				{
+					chatId,
+					groupId: selectedOption.id,
+					role: "read",
+				},
+				{ onSuccess },
+			);
+			return;
+		}
+
+		userRoleMutation.mutate(
+			{
+				chatId,
+				userId: selectedOption.id,
+				role: "read",
+			},
+			{ onSuccess },
+		);
+	};
+
+	const handleRemoveUser = (user: TypesGen.ChatUser) => {
+		userRoleMutation.mutate(
+			{ chatId, userId: user.id, role: "" },
+			{ onSuccess: () => toast.success("Member removed from chat.") },
+		);
+	};
+
+	const handleRemoveGroup = (group: TypesGen.ChatGroup) => {
+		groupRoleMutation.mutate(
+			{ chatId, groupId: group.id, role: "" },
+			{ onSuccess: () => toast.success("Group removed from chat.") },
+		);
+	};
+
+	const tableHeader = (
+		<TableHeader>
+			<TableRow>
+				<TableHead className="w-[50%] py-2">Member</TableHead>
+				<TableHead className="w-[40%] py-2">Role</TableHead>
+				<TableHead className="w-[10%] py-2" />
+			</TableRow>
+		</TableHeader>
+	);
+
+	const isEmpty = groups.length === 0 && users.length === 0;
+
+	const tableBody = (
+		<TableBody>
+			{isEmpty ? (
+				<TableRow>
+					<TableCell colSpan={999}>
+						<EmptyState
+							message="No shared members or groups yet"
+							description="Add a member or group using the controls above."
+							isCompact
+						/>
+					</TableCell>
+				</TableRow>
+			) : (
+				<>
+					{groups.map((group) => (
+						<TableRow key={group.id}>
+							<TableCell className="py-2 w-[50%]">
+								<AvatarData
+									title={group.display_name || group.name}
+									subtitle={getGroupSubtitle(group)}
+									src={group.avatar_url}
+									avatar={
+										<Avatar
+											src={group.avatar_url}
+											fallback={group.display_name || group.name}
+											variant="icon"
+										/>
+									}
+								/>
+							</TableCell>
+							<TableCell className="py-2 w-[40%]">
+								<ReadRoleBadge />
+							</TableCell>
+							<TableCell className="py-2 w-[10%]">
+								<MemberRowMenu
+									disabled={isMutating}
+									onRemove={() => handleRemoveGroup(group)}
+								/>
+							</TableCell>
+						</TableRow>
+					))}
+					{users.map((user) => (
+						<TableRow key={user.id}>
+							<TableCell className="py-2 w-[50%]">
+								<AvatarData
+									title={user.username}
+									subtitle={user.name}
+									src={user.avatar_url}
+								/>
+							</TableCell>
+							<TableCell className="py-2 w-[40%]">
+								<ReadRoleBadge />
+							</TableCell>
+							<TableCell className="py-2 w-[10%]">
+								<MemberRowMenu
+									disabled={isMutating}
+									onRemove={() => handleRemoveUser(user)}
+								/>
+							</TableCell>
+						</TableRow>
+					))}
+				</>
+			)}
+		</TableBody>
+	);
+
+	return (
+		<PopoverContent align="end" className="w-[580px] p-4">
+			<div className="flex items-center gap-2 mb-4">
+				<h3 className="text-lg font-semibold m-0">Chat Sharing</h3>
+			</div>
+
+			<div className="flex flex-col gap-4">
+				{mutationError && <ErrorAlert error={mutationError} />}
+				{aclQuery.error && <ErrorAlert error={aclQuery.error} />}
+
+				{aclQuery.isLoading ? (
+					<div role="status" className="flex flex-col items-center gap-4 py-8">
+						<Spinner loading />
+						<span>Loading chat sharing</span>
+					</div>
+				) : acl ? (
+					<>
+						<AddWorkspaceMemberForm
+							isLoading={isMutating}
+							disabled={!selectedOption}
+							onSubmit={handleAddMember}
+						>
+							<UserOrGroupAutocomplete
+								value={selectedOption}
+								onChange={setSelectedOption}
+								organizationId={organizationId}
+								exclude={excludeFromAutocomplete}
+							/>
+						</AddWorkspaceMemberForm>
+
+						<div>
+							<Table>{tableHeader}</Table>
+							<div className="max-h-60 overflow-y-auto">
+								<Table>{tableBody}</Table>
+							</div>
+						</div>
+					</>
+				) : null}
+			</div>
+		</PopoverContent>
+	);
+};
+
+export const ChatShareButton: FC<ChatShareButtonProps> = ({
+	chatId,
+	organizationId,
+}) => {
+	const [open, setOpen] = useState(false);
+
+	return (
+		<Popover open={open} onOpenChange={setOpen}>
+			<PopoverTrigger asChild>
+				<TopbarButton data-testid="chat-share-button">
+					<Share2Icon />
+					Share
+				</TopbarButton>
+			</PopoverTrigger>
+			<ChatSharingPopoverContent
+				chatId={chatId}
+				organizationId={organizationId}
+				open={open}
+			/>
+		</Popover>
+	);
+};

--- a/site/src/pages/AgentsPage/components/ChatSharingPopover.tsx
+++ b/site/src/pages/AgentsPage/components/ChatSharingPopover.tsx
@@ -1,5 +1,5 @@
 import { EllipsisVerticalIcon, Share2Icon } from "lucide-react";
-import { type FC, useState } from "react";
+import { type FC, useEffect, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
 import { toast } from "sonner";
 import {
@@ -72,7 +72,6 @@ const MemberRowMenu: FC<MemberRowMenuProps> = ({ disabled, onRemove }) => (
 				disabled={disabled}
 			>
 				<EllipsisVerticalIcon aria-hidden="true" />
-				<span className="sr-only">Open menu</span>
 			</Button>
 		</DropdownMenuTrigger>
 		<DropdownMenuContent align="end">
@@ -95,17 +94,48 @@ export const ChatSharingPopoverContent: FC<ChatSharingPopoverContentProps> = ({
 	const queryClient = useQueryClient();
 	const [selectedOption, setSelectedOption] =
 		useState<UserOrGroupAutocompleteValue>(null);
+	const hasResetForOpenRef = useRef(false);
 
 	const aclQuery = useQuery({
 		...chatACL(chatId),
 		enabled: open,
 	});
 
-	const userRoleMutation = useMutation(setChatUserRole(queryClient));
-	const groupRoleMutation = useMutation(setChatGroupRole(queryClient));
+	const {
+		error: userRoleError,
+		isPending: isUserRolePending,
+		mutate: mutateUserRole,
+		reset: resetUserRole,
+	} = useMutation(setChatUserRole(queryClient));
+	const {
+		error: groupRoleError,
+		isPending: isGroupRolePending,
+		mutate: mutateGroupRole,
+		reset: resetGroupRole,
+	} = useMutation(setChatGroupRole(queryClient));
 
-	const mutationError = userRoleMutation.error ?? groupRoleMutation.error;
-	const isMutating = userRoleMutation.isPending || groupRoleMutation.isPending;
+	const mutationError = userRoleError ?? groupRoleError;
+	const isMutating = isUserRolePending || isGroupRolePending;
+
+	useEffect(() => {
+		if (!open) {
+			hasResetForOpenRef.current = false;
+			return;
+		}
+
+		if (isMutating || hasResetForOpenRef.current) {
+			return;
+		}
+
+		resetUserRole();
+		resetGroupRole();
+		hasResetForOpenRef.current = true;
+	}, [open, isMutating, resetGroupRole, resetUserRole]);
+
+	const resetMutationErrors = () => {
+		resetUserRole();
+		resetGroupRole();
+	};
 
 	const acl = aclQuery.data;
 	const users = (acl?.users ?? []).filter((user) => user.id !== currentUser.id);
@@ -113,132 +143,73 @@ export const ChatSharingPopoverContent: FC<ChatSharingPopoverContentProps> = ({
 	const excludeFromAutocomplete = [...users, ...groups, currentUser];
 
 	const handleAddMember = () => {
-		if (!selectedOption) {
+		if (!selectedOption || isMutating) {
 			return;
 		}
-
-		const onSuccess = () => {
-			setSelectedOption(null);
-			toast.success("Member added to chat.");
-		};
 
 		if (!isGroup(selectedOption) && selectedOption.id === currentUser.id) {
 			return;
 		}
 
+		resetMutationErrors();
+
 		if (isGroup(selectedOption)) {
-			groupRoleMutation.mutate(
+			mutateGroupRole(
 				{
 					chatId,
 					groupId: selectedOption.id,
 					role: "read",
 				},
-				{ onSuccess },
+				{
+					onSuccess: () => {
+						setSelectedOption(null);
+						toast.success("Group added to chat.");
+					},
+				},
 			);
 			return;
 		}
 
-		userRoleMutation.mutate(
+		mutateUserRole(
 			{
 				chatId,
 				userId: selectedOption.id,
 				role: "read",
 			},
-			{ onSuccess },
+			{
+				onSuccess: () => {
+					setSelectedOption(null);
+					toast.success("Member added to chat.");
+				},
+			},
 		);
 	};
 
 	const handleRemoveUser = (user: TypesGen.ChatUser) => {
-		userRoleMutation.mutate(
+		if (isMutating) {
+			return;
+		}
+
+		resetMutationErrors();
+		mutateUserRole(
 			{ chatId, userId: user.id, role: "" },
 			{ onSuccess: () => toast.success("Member removed from chat.") },
 		);
 	};
 
 	const handleRemoveGroup = (group: TypesGen.ChatGroup) => {
-		groupRoleMutation.mutate(
+		if (isMutating) {
+			return;
+		}
+
+		resetMutationErrors();
+		mutateGroupRole(
 			{ chatId, groupId: group.id, role: "" },
 			{ onSuccess: () => toast.success("Group removed from chat.") },
 		);
 	};
 
-	const tableHeader = (
-		<TableHeader>
-			<TableRow>
-				<TableHead className="w-[50%] py-2">Member</TableHead>
-				<TableHead className="w-[40%] py-2">Role</TableHead>
-				<TableHead className="w-[10%] py-2" />
-			</TableRow>
-		</TableHeader>
-	);
-
 	const isEmpty = groups.length === 0 && users.length === 0;
-
-	const tableBody = (
-		<TableBody>
-			{isEmpty ? (
-				<TableRow>
-					<TableCell colSpan={999}>
-						<EmptyState
-							message="No shared members or groups yet"
-							description="Add a member or group using the controls above."
-							isCompact
-						/>
-					</TableCell>
-				</TableRow>
-			) : (
-				<>
-					{groups.map((group) => (
-						<TableRow key={group.id}>
-							<TableCell className="py-2 w-[50%]">
-								<AvatarData
-									title={group.display_name || group.name}
-									subtitle={getGroupSubtitle(group)}
-									src={group.avatar_url}
-									avatar={
-										<Avatar
-											src={group.avatar_url}
-											fallback={group.display_name || group.name}
-											variant="icon"
-										/>
-									}
-								/>
-							</TableCell>
-							<TableCell className="py-2 w-[40%]">
-								<ReadRoleBadge />
-							</TableCell>
-							<TableCell className="py-2 w-[10%]">
-								<MemberRowMenu
-									disabled={isMutating}
-									onRemove={() => handleRemoveGroup(group)}
-								/>
-							</TableCell>
-						</TableRow>
-					))}
-					{users.map((user) => (
-						<TableRow key={user.id}>
-							<TableCell className="py-2 w-[50%]">
-								<AvatarData
-									title={user.username}
-									subtitle={user.name}
-									src={user.avatar_url}
-								/>
-							</TableCell>
-							<TableCell className="py-2 w-[40%]">
-								<ReadRoleBadge />
-							</TableCell>
-							<TableCell className="py-2 w-[10%]">
-								<MemberRowMenu
-									disabled={isMutating}
-									onRemove={() => handleRemoveUser(user)}
-								/>
-							</TableCell>
-						</TableRow>
-					))}
-				</>
-			)}
-		</TableBody>
-	);
 
 	return (
 		<PopoverContent align="end" className="w-[580px] p-4">
@@ -270,12 +241,85 @@ export const ChatSharingPopoverContent: FC<ChatSharingPopoverContentProps> = ({
 							/>
 						</AddWorkspaceMemberForm>
 
-						<div>
-							<Table>{tableHeader}</Table>
-							<div className="max-h-60 overflow-y-auto">
-								<Table>{tableBody}</Table>
-							</div>
-						</div>
+						<Table
+							aria-label="Shared chat members and groups"
+							wrapperClassName="max-h-60 overflow-y-auto"
+						>
+							<TableHeader>
+								<TableRow>
+									<TableHead className="sticky top-0 z-10 w-[50%] bg-surface-primary py-2">
+										Member
+									</TableHead>
+									<TableHead className="sticky top-0 z-10 w-[40%] bg-surface-primary py-2">
+										Role
+									</TableHead>
+									<TableHead className="sticky top-0 z-10 w-[10%] bg-surface-primary py-2" />
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{isEmpty ? (
+									<TableRow>
+										<TableCell colSpan={3}>
+											<EmptyState
+												message="No shared members or groups yet"
+												description="Add a member or group using the controls above."
+												isCompact
+											/>
+										</TableCell>
+									</TableRow>
+								) : (
+									<>
+										{groups.map((group) => (
+											<TableRow key={group.id}>
+												<TableCell className="py-2 w-[50%]">
+													<AvatarData
+														title={group.display_name || group.name}
+														subtitle={getGroupSubtitle(group)}
+														src={group.avatar_url}
+														avatar={
+															<Avatar
+																src={group.avatar_url}
+																fallback={group.display_name || group.name}
+																variant="icon"
+															/>
+														}
+													/>
+												</TableCell>
+												<TableCell className="py-2 w-[40%]">
+													<ReadRoleBadge />
+												</TableCell>
+												<TableCell className="py-2 w-[10%]">
+													<MemberRowMenu
+														disabled={isMutating}
+														onRemove={() => handleRemoveGroup(group)}
+													/>
+												</TableCell>
+											</TableRow>
+										))}
+										{users.map((user) => (
+											<TableRow key={user.id}>
+												<TableCell className="py-2 w-[50%]">
+													<AvatarData
+														title={user.username}
+														subtitle={user.name}
+														src={user.avatar_url}
+													/>
+												</TableCell>
+												<TableCell className="py-2 w-[40%]">
+													<ReadRoleBadge />
+												</TableCell>
+												<TableCell className="py-2 w-[10%]">
+													<MemberRowMenu
+														disabled={isMutating}
+														onRemove={() => handleRemoveUser(user)}
+													/>
+												</TableCell>
+											</TableRow>
+										))}
+									</>
+								)}
+							</TableBody>
+						</Table>
 					</>
 				) : null}
 			</div>

--- a/site/src/pages/AgentsPage/components/ChatTopBar.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatTopBar.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
 import { useLocation } from "react-router";
 import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
@@ -283,7 +284,7 @@ export const PreservesArchivedFilterOnMobileBack: Story = {
 
 export const ShareChatButton: Story = {
 	args: {
-		chatSharingPopover: () => (
+		renderChatSharingContent: () => (
 			<PopoverContent align="end">Share chat</PopoverContent>
 		),
 	},
@@ -308,7 +309,7 @@ export const ShareChatButton: Story = {
 
 export const ShareChatButtonHiddenWithoutPermission: Story = {
 	args: {
-		chatSharingPopover: undefined,
+		renderChatSharingContent: undefined,
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -324,6 +325,61 @@ export const ShareChatButtonHiddenWithoutPermission: Story = {
 		expect(
 			body.queryByRole("menuitem", { name: "Share" }),
 		).not.toBeInTheDocument();
+	},
+};
+
+export const ShareChatButtonResetsWhenContentDisappears: Story = {
+	render: function Render(args) {
+		const [showShare, setShowShare] = useState(true);
+
+		return (
+			<div className="flex flex-col gap-3">
+				<div className="flex gap-2">
+					<button type="button" onClick={() => setShowShare(false)}>
+						Disable share
+					</button>
+					<button type="button" onClick={() => setShowShare(true)}>
+						Enable share
+					</button>
+				</div>
+				<ChatTopBar
+					{...args}
+					renderChatSharingContent={
+						showShare
+							? () => <PopoverContent align="end">Share chat</PopoverContent>
+							: undefined
+					}
+				/>
+			</div>
+		);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const body = within(document.body);
+
+		await userEvent.click(canvas.getByRole("button", { name: "Share chat" }));
+		expect(await body.findByText("Share chat")).toBeInTheDocument();
+
+		await userEvent.click(
+			canvas.getByRole("button", { name: "Disable share" }),
+		);
+		await waitFor(() => {
+			expect(
+				canvas.queryByRole("button", { name: "Share chat" }),
+			).not.toBeInTheDocument();
+			expect(body.queryByText("Share chat")).not.toBeInTheDocument();
+		});
+
+		await userEvent.click(canvas.getByRole("button", { name: "Enable share" }));
+		await waitFor(() => {
+			expect(
+				canvas.getByRole("button", { name: "Share chat" }),
+			).toBeInTheDocument();
+			expect(body.queryByText("Share chat")).not.toBeInTheDocument();
+		});
+
+		await userEvent.click(canvas.getByRole("button", { name: "Share chat" }));
+		expect(await body.findByText("Share chat")).toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatTopBar.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatTopBar.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useLocation } from "react-router";
 import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
+import { PopoverContent } from "#/components/Popover/Popover";
 import { ChatTopBar } from "./ChatTopBar";
 
 // Probe element rendered at /agents to verify search params are preserved
@@ -159,8 +160,8 @@ export const WithClosedPR: Story = {
 };
 
 // ---------------------------------------------------------------
-// Mobile viewport stories — constrain width to 390px so the
-// responsive md: breakpoint triggers the compact PR number.
+// Mobile viewport stories, constrained to 390px so the responsive
+// md: breakpoint triggers the compact PR number.
 // ---------------------------------------------------------------
 
 const mobileDecorator: Story["decorators"] = [
@@ -277,6 +278,52 @@ export const PreservesArchivedFilterOnMobileBack: Story = {
 				"?archived=archived",
 			);
 		});
+	},
+};
+
+export const ShareChatButton: Story = {
+	args: {
+		chatSharingPopover: () => (
+			<PopoverContent align="end">Share chat</PopoverContent>
+		),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.queryByText("Share")).not.toBeInTheDocument();
+		expect(
+			canvas.queryByRole("button", { name: "Share" }),
+		).not.toBeInTheDocument();
+
+		await userEvent.click(canvas.getByRole("button", { name: "Share chat" }));
+		const body = within(document.body);
+		expect(await body.findByText("Share chat")).toBeInTheDocument();
+
+		await userEvent.click(canvas.getByLabelText("Open agent actions"));
+		await body.findByText("Generate new title");
+		expect(
+			body.queryByRole("menuitem", { name: "Share" }),
+		).not.toBeInTheDocument();
+	},
+};
+
+export const ShareChatButtonHiddenWithoutPermission: Story = {
+	args: {
+		chatSharingPopover: undefined,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			canvas.queryByRole("button", { name: "Share chat" }),
+		).not.toBeInTheDocument();
+		expect(
+			canvas.queryByRole("button", { name: "Share" }),
+		).not.toBeInTheDocument();
+		await userEvent.click(canvas.getByLabelText("Open agent actions"));
+		const body = within(document.body);
+		await body.findByText("Generate new title");
+		expect(
+			body.queryByRole("menuitem", { name: "Share" }),
+		).not.toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatTopBar.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatTopBar.stories.tsx
@@ -161,8 +161,8 @@ export const WithClosedPR: Story = {
 };
 
 // ---------------------------------------------------------------
-// Mobile viewport stories, constrained to 390px so the responsive
-// md: breakpoint triggers the compact PR number.
+// Mobile viewport stories — constrain width to 390px so the
+// responsive md: breakpoint triggers the compact PR number.
 // ---------------------------------------------------------------
 
 const mobileDecorator: Story["decorators"] = [

--- a/site/src/pages/AgentsPage/components/ChatTopBar.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatTopBar.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { useState } from "react";
 import { useLocation } from "react-router";
 import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 import { reactRouterParameters } from "storybook-addon-remix-react-router";
@@ -325,61 +324,6 @@ export const ShareChatButtonHiddenWithoutPermission: Story = {
 		expect(
 			body.queryByRole("menuitem", { name: "Share" }),
 		).not.toBeInTheDocument();
-	},
-};
-
-export const ShareChatButtonResetsWhenContentDisappears: Story = {
-	render: function Render(args) {
-		const [showShare, setShowShare] = useState(true);
-
-		return (
-			<div className="flex flex-col gap-3">
-				<div className="flex gap-2">
-					<button type="button" onClick={() => setShowShare(false)}>
-						Disable share
-					</button>
-					<button type="button" onClick={() => setShowShare(true)}>
-						Enable share
-					</button>
-				</div>
-				<ChatTopBar
-					{...args}
-					renderChatSharingContent={
-						showShare
-							? () => <PopoverContent align="end">Share chat</PopoverContent>
-							: undefined
-					}
-				/>
-			</div>
-		);
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const body = within(document.body);
-
-		await userEvent.click(canvas.getByRole("button", { name: "Share chat" }));
-		expect(await body.findByText("Share chat")).toBeInTheDocument();
-
-		await userEvent.click(
-			canvas.getByRole("button", { name: "Disable share" }),
-		);
-		await waitFor(() => {
-			expect(
-				canvas.queryByRole("button", { name: "Share chat" }),
-			).not.toBeInTheDocument();
-			expect(body.queryByText("Share chat")).not.toBeInTheDocument();
-		});
-
-		await userEvent.click(canvas.getByRole("button", { name: "Enable share" }));
-		await waitFor(() => {
-			expect(
-				canvas.getByRole("button", { name: "Share chat" }),
-			).toBeInTheDocument();
-			expect(body.queryByText("Share chat")).not.toBeInTheDocument();
-		});
-
-		await userEvent.click(canvas.getByRole("button", { name: "Share chat" }));
-		expect(await body.findByText("Share chat")).toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatTopBar.tsx
+++ b/site/src/pages/AgentsPage/components/ChatTopBar.tsx
@@ -11,7 +11,7 @@ import {
 	Trash2Icon,
 	WandSparklesIcon,
 } from "lucide-react";
-import { type FC, type ReactNode, useState } from "react";
+import { type FC, Fragment, type ReactNode, useState } from "react";
 import { Link, useLocation } from "react-router";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { ChatDiffStatus } from "#/api/typesGenerated";
@@ -61,9 +61,18 @@ const ChatSharingTopBarButton: FC<ChatSharingTopBarButtonProps> = ({
 	renderChatSharingContent,
 }) => {
 	const [isChatSharingOpen, setIsChatSharingOpen] = useState(false);
+	const [contentGeneration, setContentGeneration] = useState(0);
+
+	const handleOpenChange = (nextOpen: boolean) => {
+		if (nextOpen) {
+			setContentGeneration((generation) => generation + 1);
+		}
+
+		setIsChatSharingOpen(nextOpen);
+	};
 
 	return (
-		<Popover open={isChatSharingOpen} onOpenChange={setIsChatSharingOpen}>
+		<Popover open={isChatSharingOpen} onOpenChange={handleOpenChange}>
 			<PopoverTrigger asChild>
 				<Button
 					variant="subtle"
@@ -74,7 +83,9 @@ const ChatSharingTopBarButton: FC<ChatSharingTopBarButtonProps> = ({
 					<Share2Icon className="h-4 w-4" />
 				</Button>
 			</PopoverTrigger>
-			{renderChatSharingContent(isChatSharingOpen)}
+			<Fragment key={contentGeneration}>
+				{renderChatSharingContent(isChatSharingOpen)}
+			</Fragment>
 		</Popover>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatTopBar.tsx
+++ b/site/src/pages/AgentsPage/components/ChatTopBar.tsx
@@ -7,10 +7,11 @@ import {
 	PanelLeftIcon,
 	PanelRightCloseIcon,
 	PanelRightOpenIcon,
+	Share2Icon,
 	Trash2Icon,
 	WandSparklesIcon,
 } from "lucide-react";
-import type { FC } from "react";
+import { type FC, type ReactNode, useState } from "react";
 import { Link, useLocation } from "react-router";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { ChatDiffStatus } from "#/api/typesGenerated";
@@ -22,6 +23,7 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "#/components/DropdownMenu/DropdownMenu";
+import { Popover, PopoverTrigger } from "#/components/Popover/Popover";
 import { Spinner } from "#/components/Spinner/Spinner";
 import { cn } from "#/utils/cn";
 import { parsePullRequestUrl } from "../utils/pullRequest";
@@ -48,6 +50,7 @@ type ChatTopBarProps = {
 	isSidebarCollapsed: boolean;
 	onToggleSidebarCollapsed: () => void;
 	diffStatusData?: ChatDiffStatus;
+	chatSharingPopover?: (open: boolean) => ReactNode;
 };
 
 export const ChatTopBar: FC<ChatTopBarProps> = ({
@@ -65,9 +68,11 @@ export const ChatTopBar: FC<ChatTopBarProps> = ({
 	isSidebarCollapsed,
 	onToggleSidebarCollapsed,
 	diffStatusData,
+	chatSharingPopover,
 }) => {
 	const { isEmbedded } = useEmbedContext();
 	const location = useLocation();
+	const [isChatSharingOpen, setIsChatSharingOpen] = useState(false);
 
 	const prUrl = diffStatusData?.url;
 	const prState = diffStatusData?.pull_request_state;
@@ -155,7 +160,7 @@ export const ChatTopBar: FC<ChatTopBarProps> = ({
 					</div>
 				)}
 			</div>
-			{/* PR link — mobile: icon + number; desktop: icon + title.
+			{/* PR link, mobile: icon + number; desktop: icon + title.
 			   Hidden on desktop when the sidebar panel is open
 			   (which already shows PR info). */}
 			{prUrl && hasPR && (
@@ -183,6 +188,21 @@ export const ChatTopBar: FC<ChatTopBarProps> = ({
 			)}
 			{/* Actions area */}
 			<div className="flex items-center gap-2">
+				{!isEmbedded && chatSharingPopover && (
+					<Popover open={isChatSharingOpen} onOpenChange={setIsChatSharingOpen}>
+						<PopoverTrigger asChild>
+							<Button
+								variant="subtle"
+								size="icon"
+								className="h-7 w-7 text-content-secondary hover:text-content-primary"
+								aria-label="Share chat"
+							>
+								<Share2Icon className="h-4 w-4" />
+							</Button>
+						</PopoverTrigger>
+						{chatSharingPopover(isChatSharingOpen)}
+					</Popover>
+				)}
 				{!isEmbedded && (
 					<DropdownMenu>
 						<DropdownMenuTrigger asChild>

--- a/site/src/pages/AgentsPage/components/ChatTopBar.tsx
+++ b/site/src/pages/AgentsPage/components/ChatTopBar.tsx
@@ -11,7 +11,7 @@ import {
 	Trash2Icon,
 	WandSparklesIcon,
 } from "lucide-react";
-import { type FC, type ReactNode, useEffect, useState } from "react";
+import { type FC, type ReactNode, useState } from "react";
 import { Link, useLocation } from "react-router";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { ChatDiffStatus } from "#/api/typesGenerated";
@@ -35,6 +35,10 @@ interface SidebarPanelState {
 	onToggleSidebar: () => void;
 }
 
+type ChatSharingTopBarButtonProps = {
+	renderChatSharingContent: (open: boolean) => ReactNode;
+};
+
 type ChatTopBarProps = {
 	chatTitle?: string;
 	parentChat?: TypesGen.Chat;
@@ -51,6 +55,28 @@ type ChatTopBarProps = {
 	onToggleSidebarCollapsed: () => void;
 	diffStatusData?: ChatDiffStatus;
 	renderChatSharingContent?: (open: boolean) => ReactNode;
+};
+
+const ChatSharingTopBarButton: FC<ChatSharingTopBarButtonProps> = ({
+	renderChatSharingContent,
+}) => {
+	const [isChatSharingOpen, setIsChatSharingOpen] = useState(false);
+
+	return (
+		<Popover open={isChatSharingOpen} onOpenChange={setIsChatSharingOpen}>
+			<PopoverTrigger asChild>
+				<Button
+					variant="subtle"
+					size="icon"
+					className="h-7 w-7 text-content-secondary hover:text-content-primary"
+					aria-label="Share chat"
+				>
+					<Share2Icon className="h-4 w-4" />
+				</Button>
+			</PopoverTrigger>
+			{renderChatSharingContent(isChatSharingOpen)}
+		</Popover>
+	);
 };
 
 export const ChatTopBar: FC<ChatTopBarProps> = ({
@@ -72,13 +98,6 @@ export const ChatTopBar: FC<ChatTopBarProps> = ({
 }) => {
 	const { isEmbedded } = useEmbedContext();
 	const location = useLocation();
-	const [isChatSharingOpen, setIsChatSharingOpen] = useState(false);
-
-	useEffect(() => {
-		if (!renderChatSharingContent || isEmbedded) {
-			setIsChatSharingOpen(false);
-		}
-	}, [renderChatSharingContent, isEmbedded]);
 
 	const prUrl = diffStatusData?.url;
 	const prState = diffStatusData?.pull_request_state;
@@ -195,19 +214,9 @@ export const ChatTopBar: FC<ChatTopBarProps> = ({
 			{/* Actions area */}
 			<div className="flex items-center gap-2">
 				{!isEmbedded && renderChatSharingContent && (
-					<Popover open={isChatSharingOpen} onOpenChange={setIsChatSharingOpen}>
-						<PopoverTrigger asChild>
-							<Button
-								variant="subtle"
-								size="icon"
-								className="h-7 w-7 text-content-secondary hover:text-content-primary"
-								aria-label="Share chat"
-							>
-								<Share2Icon className="h-4 w-4" />
-							</Button>
-						</PopoverTrigger>
-						{renderChatSharingContent(isChatSharingOpen)}
-					</Popover>
+					<ChatSharingTopBarButton
+						renderChatSharingContent={renderChatSharingContent}
+					/>
 				)}
 				{!isEmbedded && (
 					<DropdownMenu>

--- a/site/src/pages/AgentsPage/components/ChatTopBar.tsx
+++ b/site/src/pages/AgentsPage/components/ChatTopBar.tsx
@@ -11,7 +11,7 @@ import {
 	Trash2Icon,
 	WandSparklesIcon,
 } from "lucide-react";
-import { type FC, type ReactNode, useState } from "react";
+import { type FC, type ReactNode, useEffect, useState } from "react";
 import { Link, useLocation } from "react-router";
 import type * as TypesGen from "#/api/typesGenerated";
 import type { ChatDiffStatus } from "#/api/typesGenerated";
@@ -50,7 +50,7 @@ type ChatTopBarProps = {
 	isSidebarCollapsed: boolean;
 	onToggleSidebarCollapsed: () => void;
 	diffStatusData?: ChatDiffStatus;
-	chatSharingPopover?: (open: boolean) => ReactNode;
+	renderChatSharingContent?: (open: boolean) => ReactNode;
 };
 
 export const ChatTopBar: FC<ChatTopBarProps> = ({
@@ -68,11 +68,17 @@ export const ChatTopBar: FC<ChatTopBarProps> = ({
 	isSidebarCollapsed,
 	onToggleSidebarCollapsed,
 	diffStatusData,
-	chatSharingPopover,
+	renderChatSharingContent,
 }) => {
 	const { isEmbedded } = useEmbedContext();
 	const location = useLocation();
 	const [isChatSharingOpen, setIsChatSharingOpen] = useState(false);
+
+	useEffect(() => {
+		if (!renderChatSharingContent || isEmbedded) {
+			setIsChatSharingOpen(false);
+		}
+	}, [renderChatSharingContent, isEmbedded]);
 
 	const prUrl = diffStatusData?.url;
 	const prState = diffStatusData?.pull_request_state;
@@ -188,7 +194,7 @@ export const ChatTopBar: FC<ChatTopBarProps> = ({
 			)}
 			{/* Actions area */}
 			<div className="flex items-center gap-2">
-				{!isEmbedded && chatSharingPopover && (
+				{!isEmbedded && renderChatSharingContent && (
 					<Popover open={isChatSharingOpen} onOpenChange={setIsChatSharingOpen}>
 						<PopoverTrigger asChild>
 							<Button
@@ -200,7 +206,7 @@ export const ChatTopBar: FC<ChatTopBarProps> = ({
 								<Share2Icon className="h-4 w-4" />
 							</Button>
 						</PopoverTrigger>
-						{chatSharingPopover(isChatSharingOpen)}
+						{renderChatSharingContent(isChatSharingOpen)}
 					</Popover>
 				)}
 				{!isEmbedded && (

--- a/site/src/pages/AgentsPage/components/ChatTopBar.tsx
+++ b/site/src/pages/AgentsPage/components/ChatTopBar.tsx
@@ -166,7 +166,7 @@ export const ChatTopBar: FC<ChatTopBarProps> = ({
 					</div>
 				)}
 			</div>
-			{/* PR link, mobile: icon + number; desktop: icon + title.
+			{/* PR link — mobile: icon + number; desktop: icon + title.
 			   Hidden on desktop when the sidebar panel is open
 			   (which already shows PR info). */}
 			{prUrl && hasPR && (


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood

Depends on #24968.

Adds frontend chat sharing controls for experimental Coder Agents chats. Authorized users can open the chat actions menu on root chats, add users or groups with read-only access, remove existing ACL entries, and see shared or read-only chat ownership state in the agents UI.

<details><summary>Implementation plan</summary>

```md
$(sed 's/```/````/g' /home/coder/.coder/plans/PLAN-a34939be-00cb-4f5b-8de2-009e1473630e.md)
```

</details>
