### PR TITLE
fix(scripts/releaser): use last stable release as changelog base for .0 releases

### DIFF
--- a/scripts/releaser/release.go
+++ b/scripts/releaser/release.go
@@ -546,7 +546,6 @@ func runRelease(ctx context.Context, inv *serpent.Invocation, executor ReleaseEx
 		var lastStable *version
 		for _, t := range allTags {
 			if t.Pre == "" && t.Major == newVersion.Major && t.Minor < newVersion.Minor {
-				v := t
 				lastStable = &t
 				break
 			}

--- a/scripts/releaser/release.go
+++ b/scripts/releaser/release.go
@@ -547,7 +547,7 @@ func runRelease(ctx context.Context, inv *serpent.Invocation, executor ReleaseEx
 		for _, t := range allTags {
 			if t.Pre == "" && t.Major == newVersion.Major && t.Minor < newVersion.Minor {
 				v := t
-				lastStable = &v
+				lastStable = &t
 				break
 			}
 		}

--- a/scripts/releaser/release.go
+++ b/scripts/releaser/release.go
@@ -536,6 +536,29 @@ func runRelease(ctx context.Context, inv *serpent.Invocation, executor ReleaseEx
 	}
 	fmt.Fprintln(w)
 
+	// --- Adjust changelog base for initial releases ---
+	// When the new version is a .0 release (e.g. v2.33.0) and
+	// prevVersion is an RC (e.g. v2.33.0-rc.3), the release
+	// notes should show all changes since the last stable
+	// release in the previous minor series (e.g. v2.32.X),
+	// not just the delta from the last RC.
+	if !onMain && newVersion.Patch == 0 && !newVersion.IsRC() && prevVersion != nil && prevVersion.IsRC() {
+		var lastStable *version
+		for _, t := range allTags {
+			if t.Pre == "" && t.Major == newVersion.Major && t.Minor < newVersion.Minor {
+				v := t
+				lastStable = &v
+				break
+			}
+		}
+		if lastStable != nil {
+			infof(w, "Changelog base: %s (last stable release before %s series).", lastStable, newVersion)
+			prevVersion = lastStable
+		} else {
+			warnf(w, "No previous stable release found; changelog will diff from RC %s.", prevVersion)
+		}
+	}
+
 	// --- Generate release notes ---
 	infof(w, "Generating release notes...")
 


### PR DESCRIPTION
When releasing a `.0` version (e.g. `v2.33.0`) from a release branch, the release notes diff was comparing against the most recent RC (e.g. `v2.33.0-rc.3`) instead of the last stable release from the previous minor series (e.g. `v2.32.X`).

## The bug

`prevVersion` is set to the latest tag matching the branch's `major.minor` from merged tags. For a `.0` release, this is the latest RC (e.g. `v2.33.0-rc.3`). The commit range for release notes then becomes `v2.33.0-rc.3..HEAD` instead of `v2.32.X..HEAD`, so the notes only show the delta from the last RC rather than all changes since the previous real release. The compare link also points to `v2.33.0-rc.3...v2.33.0`.

## The fix

After all semver sanity checks have run (so version suggestion and validation are unaffected), when the new version is a `.0` release and `prevVersion` is an RC, override `prevVersion` with the last stable release from the previous minor series. This makes both the commit range and compare link use the correct base (e.g. `v2.32.X..HEAD` and `v2.32.X...v2.33.0`).

> Generated with [Coder Agents](https://coder.com/agents)