### PR TITLE
fix: regenerate API docs for ChatErrorKind

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -15679,7 +15679,11 @@ const docTemplate = `{
                 },
                 "kind": {
                     "description": "Kind classifies the error for consistent client rendering.",
-                    "type": "string"
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/codersdk.ChatErrorKind"
+                        }
+                    ]
                 },
                 "message": {
                     "description": "Message is the normalized, user-facing error message.",
@@ -15698,6 +15702,29 @@ const docTemplate = `{
                     "type": "integer"
                 }
             }
+        },
+        "codersdk.ChatErrorKind": {
+            "type": "string",
+            "enum": [
+                "generic",
+                "overloaded",
+                "rate_limit",
+                "timeout",
+                "startup_timeout",
+                "auth",
+                "config",
+                "usage_limit"
+            ],
+            "x-enum-varnames": [
+                "ChatErrorKindGeneric",
+                "ChatErrorKindOverloaded",
+                "ChatErrorKindRateLimit",
+                "ChatErrorKindTimeout",
+                "ChatErrorKindStartupTimeout",
+                "ChatErrorKindAuth",
+                "ChatErrorKindConfig",
+                "ChatErrorKindUsageLimit"
+            ]
         },
         "codersdk.ChatFileMetadata": {
             "type": "object",
@@ -16266,7 +16293,11 @@ const docTemplate = `{
                 },
                 "kind": {
                     "description": "Kind classifies the retry reason for consistent client rendering.",
-                    "type": "string"
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/codersdk.ChatErrorKind"
+                        }
+                    ]
                 },
                 "provider": {
                     "description": "Provider identifies the upstream model provider when known.",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -14108,7 +14108,11 @@
 				},
 				"kind": {
 					"description": "Kind classifies the error for consistent client rendering.",
-					"type": "string"
+					"allOf": [
+						{
+							"$ref": "#/definitions/codersdk.ChatErrorKind"
+						}
+					]
 				},
 				"message": {
 					"description": "Message is the normalized, user-facing error message.",
@@ -14127,6 +14131,29 @@
 					"type": "integer"
 				}
 			}
+		},
+		"codersdk.ChatErrorKind": {
+			"type": "string",
+			"enum": [
+				"generic",
+				"overloaded",
+				"rate_limit",
+				"timeout",
+				"startup_timeout",
+				"auth",
+				"config",
+				"usage_limit"
+			],
+			"x-enum-varnames": [
+				"ChatErrorKindGeneric",
+				"ChatErrorKindOverloaded",
+				"ChatErrorKindRateLimit",
+				"ChatErrorKindTimeout",
+				"ChatErrorKindStartupTimeout",
+				"ChatErrorKindAuth",
+				"ChatErrorKindConfig",
+				"ChatErrorKindUsageLimit"
+			]
 		},
 		"codersdk.ChatFileMetadata": {
 			"type": "object",
@@ -14678,7 +14705,11 @@
 				},
 				"kind": {
 					"description": "Kind classifies the retry reason for consistent client rendering.",
-					"type": "string"
+					"allOf": [
+						{
+							"$ref": "#/definitions/codersdk.ChatErrorKind"
+						}
+					]
 				},
 				"provider": {
 					"description": "Provider identifies the upstream model provider when known.",

--- a/docs/reference/api/chats.md
+++ b/docs/reference/api/chats.md
@@ -76,7 +76,7 @@ Experimental: this endpoint is subject to change.
     },
     "last_error": {
       "detail": "string",
-      "kind": "string",
+      "kind": "generic",
       "message": "string",
       "provider": "string",
       "retryable": true,
@@ -212,7 +212,7 @@ Status Code **200**
 | `»» [any property]`               | string                                                                 | false    |              |                                                                                                                                                                                                                                                                            |
 | `» last_error`                    | [codersdk.ChatError](schemas.md#codersdkchaterror)                     | false    |              |                                                                                                                                                                                                                                                                            |
 | `»» detail`                       | string                                                                 | false    |              | Detail is optional provider-specific context shown alongside the normalized error message when available.                                                                                                                                                                  |
-| `»» kind`                         | string                                                                 | false    |              | Kind classifies the error for consistent client rendering.                                                                                                                                                                                                                 |
+| `»» kind`                         | [codersdk.ChatErrorKind](schemas.md#codersdkchaterrorkind)             | false    |              | Kind classifies the error for consistent client rendering.                                                                                                                                                                                                                 |
 | `»» message`                      | string                                                                 | false    |              | Message is the normalized, user-facing error message.                                                                                                                                                                                                                      |
 | `»» provider`                     | string                                                                 | false    |              | Provider identifies the upstream model provider when known.                                                                                                                                                                                                                |
 | `»» retryable`                    | boolean                                                                | false    |              | Retryable reports whether the underlying error is transient.                                                                                                                                                                                                               |
@@ -279,6 +279,7 @@ Status Code **200**
 | Property      | Value(s)                                                                                                     |
 |---------------|--------------------------------------------------------------------------------------------------------------|
 | `client_type` | `api`, `ui`                                                                                                  |
+| `kind`        | `auth`, `config`, `generic`, `overloaded`, `rate_limit`, `startup_timeout`, `timeout`, `usage_limit`         |
 | `type`        | `context-file`, `file`, `file-reference`, `reasoning`, `skill`, `source`, `text`, `tool-call`, `tool-result` |
 | `plan_mode`   | `plan`                                                                                                       |
 | `status`      | `completed`, `error`, `paused`, `pending`, `requires_action`, `running`, `waiting`                           |
@@ -403,7 +404,7 @@ Experimental: this endpoint is subject to change.
       },
       "last_error": {
         "detail": "string",
-        "kind": "string",
+        "kind": "generic",
         "message": "string",
         "provider": "string",
         "retryable": true,
@@ -526,7 +527,7 @@ Experimental: this endpoint is subject to change.
   },
   "last_error": {
     "detail": "string",
-    "kind": "string",
+    "kind": "generic",
     "message": "string",
     "provider": "string",
     "retryable": true,
@@ -800,7 +801,7 @@ Experimental: this endpoint is subject to change.
     },
     "last_error": {
       "detail": "string",
-      "kind": "string",
+      "kind": "generic",
       "message": "string",
       "provider": "string",
       "retryable": true,
@@ -977,7 +978,7 @@ Experimental: this endpoint is subject to change.
       },
       "last_error": {
         "detail": "string",
-        "kind": "string",
+        "kind": "generic",
         "message": "string",
         "provider": "string",
         "retryable": true,
@@ -1100,7 +1101,7 @@ Experimental: this endpoint is subject to change.
   },
   "last_error": {
     "detail": "string",
-    "kind": "string",
+    "kind": "generic",
     "message": "string",
     "provider": "string",
     "retryable": true,
@@ -1358,7 +1359,7 @@ Experimental: this endpoint is subject to change.
       },
       "last_error": {
         "detail": "string",
-        "kind": "string",
+        "kind": "generic",
         "message": "string",
         "provider": "string",
         "retryable": true,
@@ -1481,7 +1482,7 @@ Experimental: this endpoint is subject to change.
   },
   "last_error": {
     "detail": "string",
-    "kind": "string",
+    "kind": "generic",
     "message": "string",
     "provider": "string",
     "retryable": true,
@@ -2135,7 +2136,7 @@ Experimental: this endpoint is subject to change.
   "chat_id": "efc9fe20-a1e5-4a8c-9c48-f1b30c1e4f86",
   "error": {
     "detail": "string",
-    "kind": "string",
+    "kind": "generic",
     "message": "string",
     "provider": "string",
     "retryable": true,
@@ -2342,7 +2343,7 @@ Experimental: this endpoint is subject to change.
     "attempt": 0,
     "delay_ms": 0,
     "error": "string",
-    "kind": "string",
+    "kind": "generic",
     "provider": "string",
     "retrying_at": "2019-08-24T14:15:22Z",
     "status_code": 0
@@ -2518,7 +2519,7 @@ Experimental: this endpoint is subject to change.
       },
       "last_error": {
         "detail": "string",
-        "kind": "string",
+        "kind": "generic",
         "message": "string",
         "provider": "string",
         "retryable": true,
@@ -2641,7 +2642,7 @@ Experimental: this endpoint is subject to change.
   },
   "last_error": {
     "detail": "string",
-    "kind": "string",
+    "kind": "generic",
     "message": "string",
     "provider": "string",
     "retryable": true,

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -2133,7 +2133,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
       },
       "last_error": {
         "detail": "string",
-        "kind": "string",
+        "kind": "generic",
         "message": "string",
         "provider": "string",
         "retryable": true,
@@ -2256,7 +2256,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
   },
   "last_error": {
     "detail": "string",
-    "kind": "string",
+    "kind": "generic",
     "message": "string",
     "provider": "string",
     "retryable": true,
@@ -2494,7 +2494,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 ```json
 {
   "detail": "string",
-  "kind": "string",
+  "kind": "generic",
   "message": "string",
   "provider": "string",
   "retryable": true,
@@ -2504,14 +2504,28 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 ### Properties
 
-| Name          | Type    | Required | Restrictions | Description                                                                                               |
-|---------------|---------|----------|--------------|-----------------------------------------------------------------------------------------------------------|
-| `detail`      | string  | false    |              | Detail is optional provider-specific context shown alongside the normalized error message when available. |
-| `kind`        | string  | false    |              | Kind classifies the error for consistent client rendering.                                                |
-| `message`     | string  | false    |              | Message is the normalized, user-facing error message.                                                     |
-| `provider`    | string  | false    |              | Provider identifies the upstream model provider when known.                                               |
-| `retryable`   | boolean | false    |              | Retryable reports whether the underlying error is transient.                                              |
-| `status_code` | integer | false    |              | Status code is the best-effort upstream HTTP status code.                                                 |
+| Name          | Type                                             | Required | Restrictions | Description                                                                                               |
+|---------------|--------------------------------------------------|----------|--------------|-----------------------------------------------------------------------------------------------------------|
+| `detail`      | string                                           | false    |              | Detail is optional provider-specific context shown alongside the normalized error message when available. |
+| `kind`        | [codersdk.ChatErrorKind](#codersdkchaterrorkind) | false    |              | Kind classifies the error for consistent client rendering.                                                |
+| `message`     | string                                           | false    |              | Message is the normalized, user-facing error message.                                                     |
+| `provider`    | string                                           | false    |              | Provider identifies the upstream model provider when known.                                               |
+| `retryable`   | boolean                                          | false    |              | Retryable reports whether the underlying error is transient.                                              |
+| `status_code` | integer                                          | false    |              | Status code is the best-effort upstream HTTP status code.                                                 |
+
+## codersdk.ChatErrorKind
+
+```json
+"generic"
+```
+
+### Properties
+
+#### Enumerated Values
+
+| Value(s)                                                                                             |
+|------------------------------------------------------------------------------------------------------|
+| `auth`, `config`, `generic`, `overloaded`, `rate_limit`, `startup_timeout`, `timeout`, `usage_limit` |
 
 ## codersdk.ChatFileMetadata
 
@@ -3226,7 +3240,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
   "chat_id": "efc9fe20-a1e5-4a8c-9c48-f1b30c1e4f86",
   "error": {
     "detail": "string",
-    "kind": "string",
+    "kind": "generic",
     "message": "string",
     "provider": "string",
     "retryable": true,
@@ -3433,7 +3447,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
     "attempt": 0,
     "delay_ms": 0,
     "error": "string",
-    "kind": "string",
+    "kind": "generic",
     "provider": "string",
     "retrying_at": "2019-08-24T14:15:22Z",
     "status_code": 0
@@ -3550,7 +3564,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
   "attempt": 0,
   "delay_ms": 0,
   "error": "string",
-  "kind": "string",
+  "kind": "generic",
   "provider": "string",
   "retrying_at": "2019-08-24T14:15:22Z",
   "status_code": 0
@@ -3559,15 +3573,15 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 
 ### Properties
 
-| Name          | Type    | Required | Restrictions | Description                                                       |
-|---------------|---------|----------|--------------|-------------------------------------------------------------------|
-| `attempt`     | integer | false    |              | Attempt is the 1-indexed retry attempt number.                    |
-| `delay_ms`    | integer | false    |              | Delay ms is the backoff delay in milliseconds before the retry.   |
-| `error`       | string  | false    |              | Error is the normalized error message from the failed attempt.    |
-| `kind`        | string  | false    |              | Kind classifies the retry reason for consistent client rendering. |
-| `provider`    | string  | false    |              | Provider identifies the upstream model provider when known.       |
-| `retrying_at` | string  | false    |              | Retrying at is the timestamp when the retry will be attempted.    |
-| `status_code` | integer | false    |              | Status code is the best-effort upstream HTTP status code.         |
+| Name          | Type                                             | Required | Restrictions | Description                                                       |
+|---------------|--------------------------------------------------|----------|--------------|-------------------------------------------------------------------|
+| `attempt`     | integer                                          | false    |              | Attempt is the 1-indexed retry attempt number.                    |
+| `delay_ms`    | integer                                          | false    |              | Delay ms is the backoff delay in milliseconds before the retry.   |
+| `error`       | string                                           | false    |              | Error is the normalized error message from the failed attempt.    |
+| `kind`        | [codersdk.ChatErrorKind](#codersdkchaterrorkind) | false    |              | Kind classifies the retry reason for consistent client rendering. |
+| `provider`    | string                                           | false    |              | Provider identifies the upstream model provider when known.       |
+| `retrying_at` | string                                           | false    |              | Retrying at is the timestamp when the retry will be attempted.    |
+| `status_code` | integer                                          | false    |              | Status code is the best-effort upstream HTTP status code.         |
 
 ## codersdk.ChatStreamStatus
 
@@ -3653,7 +3667,7 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
     },
     "last_error": {
       "detail": "string",
-      "kind": "string",
+      "kind": "generic",
       "message": "string",
       "provider": "string",
       "retryable": true,


### PR DESCRIPTION
Follow-up to #24955 (`refactor: move chat error kinds into codersdk`), which moved `ChatErrorKind` into `codersdk` but did not refresh the generated apidoc artifacts. As a result, `make gen` was producing a dirty tree on `main`.

This PR is the output of running `make gen -B` on a clean checkout of `main`. Only generated files are touched:

- `coderd/apidoc/docs.go`
- `coderd/apidoc/swagger.json`
- `docs/reference/api/chats.md`
- `docs/reference/api/schemas.md`

The diff adds the `codersdk.ChatErrorKind` schema and replaces the previously-untyped `kind: string` fields on `codersdk.ChatError` and `codersdk.ChatRetryEvent` with references to the new enum.
