### PR TITLE
fix(site): reduce agents beta badge size to xs

### DIFF
--- a/site/src/components/FeatureStageBadge/FeatureStageBadge.stories.tsx
+++ b/site/src/components/FeatureStageBadge/FeatureStageBadge.stories.tsx
@@ -12,6 +12,13 @@ const meta: Meta<typeof FeatureStageBadge> = {
 export default meta;
 type Story = StoryObj<typeof FeatureStageBadge>;
 
+export const ExtraSmallBeta: Story = {
+	args: {
+		size: "xs",
+		contentType: "beta",
+	},
+};
+
 export const SmallBeta: Story = {
 	args: {
 		size: "sm",
@@ -23,6 +30,13 @@ export const MediumBeta: Story = {
 	args: {
 		size: "md",
 		contentType: "beta",
+	},
+};
+
+export const ExtraSmallEarlyAccess: Story = {
+	args: {
+		size: "xs",
+		contentType: "early_access",
 	},
 };
 

--- a/site/src/components/FeatureStageBadge/FeatureStageBadge.tsx
+++ b/site/src/components/FeatureStageBadge/FeatureStageBadge.tsx
@@ -21,7 +21,7 @@ type FeatureStageBadgeProps = Readonly<
 	Omit<HTMLAttributes<HTMLSpanElement>, "children"> & {
 		contentType: keyof typeof featureStageBadgeTypes;
 		labelText?: string;
-		size?: "sm" | "md";
+		size?: "xs" | "sm" | "md";
 	}
 >;
 
@@ -31,6 +31,7 @@ const badgeColorClasses = {
 } as const;
 
 const badgeSizeClasses = {
+	xs: "text-2xs font-medium px-1.5 py-0.5",
 	sm: "text-xs font-medium px-2 py-1",
 	md: "text-base px-2 py-1",
 } as const;

--- a/site/src/pages/AgentsPage/components/AgentPageHeader.tsx
+++ b/site/src/pages/AgentsPage/components/AgentPageHeader.tsx
@@ -133,7 +133,7 @@ export const AgentPageHeader: FC<AgentPageHeaderProps> = ({
 					<NavLink to="/workspaces" className="inline-flex">
 						<ProductLogo className="size-6" />
 					</NavLink>
-					<FeatureStageBadge contentType="beta" size="sm" />
+					<FeatureStageBadge contentType="beta" size="xs" />
 				</div>
 			)}
 			{isSidebarCollapsed && (

--- a/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
@@ -1091,7 +1091,7 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 							<NavLink to="/workspaces" className="inline-flex">
 								<ProductLogo className="size-6" />
 							</NavLink>
-							<FeatureStageBadge contentType="beta" size="sm" />
+							<FeatureStageBadge contentType="beta" size="xs" />
 						</div>
 						<div className="flex items-center gap-0.5 -mr-1.5">
 							<Button


### PR DESCRIPTION
Reduces the Coder Agents "beta" badge from `sm` to a new `xs` size variant.

## Changes

- **`FeatureStageBadge`**: Added `xs` size (`text-2xs`, `px-1.5`, `py-0.5`) to the component's size options.
- **`AgentPageHeader`** and **`AgentsSidebar`**: Updated both usages from `size="sm"` to `size="xs"`.
- **Storybook**: Added `ExtraSmallBeta` and `ExtraSmallEarlyAccess` stories.

| Size | Text | Padding |
|------|------|---------|
| `xs` (new) | `text-2xs` (10px) | `px-1.5 py-0.5` |
| `sm` | `text-xs` (12px) | `px-2 py-1` |
| `md` | `text-base` (16px) | `px-2 py-1` |

> Generated by Coder Agents