### PR TITLE
fix(dogfood/coder): set CODER_AGENT_EXP_MCP_CONFIG_FILES on container, not agent env

### DIFF
--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -508,7 +508,6 @@ resource "coder_agent" "dev" {
   env = merge(
     {
       OIDC_TOKEN : data.coder_workspace_owner.me.oidc_access_token,
-      CODER_AGENT_EXP_MCP_CONFIG_FILES : "~/.mcp.json,.mcp.json",
     },
     data.coder_parameter.enable_ai_gateway.value ? {
       ANTHROPIC_BASE_URL : "https://dev.coder.com/api/v2/aibridge/anthropic",
@@ -840,6 +839,10 @@ resource "docker_container" "workspace" {
     "CODER_PROC_OOM_SCORE=10",
     "CODER_PROC_NICE_SCORE=1",
     "CODER_AGENT_DEVCONTAINERS_ENABLE=1",
+    # Set on the container so the agent process reads it directly.
+    # coder_agent.env vars are injected into subprocesses, not the
+    # agent itself.
+    "CODER_AGENT_EXP_MCP_CONFIG_FILES=~/.mcp.json,.mcp.json",
   ]
   host {
     host = "host.docker.internal"

--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -839,7 +839,6 @@ resource "docker_container" "workspace" {
     "CODER_PROC_OOM_SCORE=10",
     "CODER_PROC_NICE_SCORE=1",
     "CODER_AGENT_DEVCONTAINERS_ENABLE=1",
-    # Set on the container so the agent process reads it directly.
     "CODER_AGENT_EXP_MCP_CONFIG_FILES=~/.mcp.json,.mcp.json",
   ]
   host {

--- a/dogfood/coder/main.tf
+++ b/dogfood/coder/main.tf
@@ -840,8 +840,6 @@ resource "docker_container" "workspace" {
     "CODER_PROC_NICE_SCORE=1",
     "CODER_AGENT_DEVCONTAINERS_ENABLE=1",
     # Set on the container so the agent process reads it directly.
-    # coder_agent.env vars are injected into subprocesses, not the
-    # agent itself.
     "CODER_AGENT_EXP_MCP_CONFIG_FILES=~/.mcp.json,.mcp.json",
   ]
   host {


### PR DESCRIPTION
`coder_agent.env` vars are injected into agent subprocesses (shells, scripts, MCP servers), not into the agent process itself. The agent reads `CODER_AGENT_EXP_MCP_CONFIG_FILES` from its own OS environment, so the previous placement was a no-op for the agent and the configured paths were never applied.

Set it on `docker_container.workspace.env` so the agent process inherits it from the container.

> Generated by Coder Agents.
