### PR TITLE
refactor: remove unnecessary typeof window checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -358,7 +358,6 @@ These files may be gitignored, read manually if not auto-loaded.
 2. **OAuth2 errors** → Return RFC-compliant format
 3. **Race conditions** → Use unique test identifiers
 4. **Missing newlines** → Ensure files end with newline
-5. **SSR/Node checks in site/** → Remove `typeof window`, `typeof document`, etc.; Coder is a pure SPA
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -358,6 +358,7 @@ These files may be gitignored, read manually if not auto-loaded.
 2. **OAuth2 errors** → Return RFC-compliant format
 3. **Race conditions** → Use unique test identifiers
 4. **Missing newlines** → Ensure files end with newline
+5. **SSR/Node checks in site/** → Remove `typeof window`, `typeof document`, etc.; Coder is a pure SPA
 
 ---
 

--- a/site/AGENTS.md
+++ b/site/AGENTS.md
@@ -73,6 +73,7 @@ When investigating or editing TypeScript/React code, always use the TypeScript l
   directly. Do not prefix them with `window.` (e.g., write
   `location.href`, not `window.location.href`). They are globally
   available in every browser context.
+- Do not use `typeof window`, `typeof document`, or similar runtime checks for browser globals. Coder is a pure SPA—these globals are always available.
 - Always use react-query for data fetching. Do not attempt to manage any
   data life cycle manually. Do not ever call an `API` function directly
   within a component.
@@ -300,3 +301,4 @@ When investigating or editing TypeScript/React code, always use the TypeScript l
   internally (e.g., `new Date()`, `Date.now()`). This makes the
   component deterministic and testable in Storybook without mocking
   globals.
+

--- a/site/AGENTS.md
+++ b/site/AGENTS.md
@@ -301,4 +301,3 @@ When investigating or editing TypeScript/React code, always use the TypeScript l
   internally (e.g., `new Date()`, `Date.now()`). This makes the
   component deterministic and testable in Storybook without mocking
   globals.
-

--- a/site/AGENTS.md
+++ b/site/AGENTS.md
@@ -73,7 +73,7 @@ When investigating or editing TypeScript/React code, always use the TypeScript l
   directly. Do not prefix them with `window.` (e.g., write
   `location.href`, not `window.location.href`). They are globally
   available in every browser context.
-- Do not use `typeof window`, `typeof document`, or similar runtime checks for browser globals. Coder is a pure SPA—these globals are always available.
+- Do not use `typeof window`, `typeof document`, or similar runtime checks for browser globals. Coder is a pure SPA so these globals are always available.
 - Always use react-query for data fetching. Do not attempt to manage any
   data life cycle manually. Do not ever call an `API` function directly
   within a component.

--- a/site/src/contexts/DiffsWorkerPoolProvider.tsx
+++ b/site/src/contexts/DiffsWorkerPoolProvider.tsx
@@ -22,8 +22,7 @@ const getPoolSize = (): number => {
 	return Math.min(Math.max(1, cores - 1), 3);
 };
 
-const hasWorkerSupport = (): boolean =>
-	typeof window !== "undefined" && typeof Worker !== "undefined";
+const hasWorkerSupport = (): boolean => typeof Worker !== "undefined";
 
 export const DiffsWorkerPoolProvider: FC<DiffsWorkerPoolProviderProps> = ({
 	children,

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -345,7 +345,7 @@ export function useConversationEditingState(deps: {
 		: null;
 	const [{ editorInitialValue, initialEditorState }, setDraftState] = useState(
 		() => {
-			if (typeof window === "undefined" || !draftStorageKey) {
+			if (!draftStorageKey) {
 				return { editorInitialValue: "", initialEditorState: undefined };
 			}
 			const draft = parseStoredDraft(localStorage.getItem(draftStorageKey));

--- a/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
@@ -95,7 +95,7 @@ export const MobileEnterInsertsNewline: Story = {
 	},
 	play: async ({ canvasElement, args }) => {
 		const originalMatchMedia = window.matchMedia;
-		window.matchMedia = ((query: string) =>
+		window.matchMedia = (query: string) =>
 			({
 				matches: query === "(max-width: 639px)",
 				media: query,
@@ -105,7 +105,7 @@ export const MobileEnterInsertsNewline: Story = {
 				dispatchEvent: () => true,
 				addListener: () => undefined,
 				removeListener: () => undefined,
-			}) as MediaQueryList) as typeof window.matchMedia;
+			}) as MediaQueryList;
 
 		try {
 			const canvas = within(canvasElement);

--- a/site/src/pages/AgentsPage/components/AgentPageHeader.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentPageHeader.stories.tsx
@@ -51,7 +51,7 @@ const createMatchMediaController = (initialDesktop: boolean) => {
 		}
 	};
 
-	const matchMedia = ((query: string): MediaQueryList => {
+	const matchMedia = (query: string): MediaQueryList => {
 		const isDesktopQuery = /\(\s*min-width\s*:\s*640px\s*\)/.test(query);
 		return {
 			matches: isDesktopQuery ? desktop : false,
@@ -94,7 +94,7 @@ const createMatchMediaController = (initialDesktop: boolean) => {
 				}
 			},
 		};
-	}) as typeof window.matchMedia;
+	};
 
 	return {
 		matchMedia,

--- a/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx
@@ -106,7 +106,7 @@ export const WorkspaceReadyPage: FC<WorkspaceReadyPageProps> = ({
 	const favicon = getFaviconByStatus(workspace.latest_build);
 	const [faviconTheme, setFaviconTheme] = useState<"light" | "dark">("dark");
 	useEffect(() => {
-		if (typeof window === "undefined" || !window.matchMedia) {
+		if (!window.matchMedia) {
 			return;
 		}
 

--- a/site/src/testHelpers/storybook.tsx
+++ b/site/src/testHelpers/storybook.tsx
@@ -145,7 +145,7 @@ export const withWebSocket = (Story: FC, { parameters }: StoryContext) => {
 		removeEventListener(_type: string, _callback: CallbackFn) {}
 
 		close() {}
-	} as unknown as typeof window.WebSocket;
+	} as unknown as typeof WebSocket;
 
 	return <Story />;
 };

--- a/site/src/utils/mobile.ts
+++ b/site/src/utils/mobile.ts
@@ -5,9 +5,6 @@
  * virtual keyboard to pop up unexpectedly.
  */
 export const isMobileViewport = (): boolean => {
-	if (typeof window === "undefined" || !window.matchMedia) {
-		return false;
-	}
 	return window.matchMedia("(max-width: 639px)").matches;
 };
 
@@ -20,8 +17,5 @@ export const isMobileViewport = (): boolean => {
  * mobile branch instead of the desktop flyout branch.
  */
 export const isBelowMdViewport = (): boolean => {
-	if (typeof window === "undefined" || !window.matchMedia) {
-		return false;
-	}
 	return window.matchMedia("(max-width: 767px)").matches;
 };


### PR DESCRIPTION
## Summary

Removes all `typeof window !== "undefined"` checks from the site/ directory. These checks are unnecessary for a single-page application that always runs in a browser context.

## Changes

- Removed 7 `typeof window !== "undefined"` checks
- Files modified:
  - `site/src/contexts/DiffsWorkerPoolProvider.tsx`
  - `site/src/pages/AgentsPage/AgentChatPage.tsx`
  - `site/src/pages/WorkspacePage/WorkspaceReadyPage.tsx`
  - `site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx`
  - `site/src/pages/AgentsPage/components/AgentPageHeader.stories.tsx`
  - `site/src/testHelpers/storybook.tsx`
  - `site/src/utils/mobile.ts`

## Rationale

These checks appear to be copy-pasted from isomorphic/universal JavaScript patterns where code runs in both Node.js and browser environments. Since Coder's frontend is a pure SPA, `window` is always defined at runtime.