### PR TITLE
feat(site): cycle prompt history with up/down arrows

### DIFF
--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -556,7 +556,6 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 								onCancelQueueEdit={editing.handleCancelQueueEdit}
 								isEditingHistoryMessage={editing.editingMessageId !== null}
 								onCancelHistoryEdit={editing.handleCancelHistoryEdit}
-								onEditUserMessage={editing.handleEditUserMessage}
 								editingFileBlocks={editing.editingFileBlocks}
 								mcpServers={mcpServers}
 								selectedMCPServerIds={selectedMCPServerIds}

--- a/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
@@ -44,7 +44,104 @@ const meta: Meta<typeof AgentChatInput> = {
 export default meta;
 type Story = StoryObj<typeof AgentChatInput>;
 
+const promptHistory = [
+	"Most recent prompt",
+	"Middle prompt",
+	"Oldest prompt",
+] as const;
+
+const getEditor = (canvasElement: HTMLElement) =>
+	within(canvasElement).getByTestId("chat-message-input");
+
+const expectEditorText = async (editor: HTMLElement, text: string) => {
+	await waitFor(() => {
+		expect(editor.textContent).toBe(text);
+	});
+};
+
 export const Default: Story = {};
+
+export const PromptHistoryCycling: Story = {
+	args: {
+		userPromptHistory: promptHistory,
+	},
+	play: async ({ canvasElement }) => {
+		const editor = getEditor(canvasElement);
+		await expectEditorText(editor, "");
+		await userEvent.click(editor);
+
+		await userEvent.keyboard("{ArrowUp}");
+		await expectEditorText(editor, "Most recent prompt");
+		await userEvent.keyboard("{ArrowUp}");
+		await expectEditorText(editor, "Middle prompt");
+		await userEvent.keyboard("{ArrowUp}");
+		await expectEditorText(editor, "Oldest prompt");
+		await userEvent.keyboard("{ArrowUp}");
+		await expectEditorText(editor, "Oldest prompt");
+
+		await userEvent.keyboard("{ArrowDown}");
+		await expectEditorText(editor, "Middle prompt");
+		await userEvent.keyboard("{ArrowDown}");
+		await expectEditorText(editor, "Most recent prompt");
+		await userEvent.keyboard("{ArrowDown}");
+		await expectEditorText(editor, "");
+
+		await userEvent.keyboard("{ArrowUp}");
+		await expectEditorText(editor, "Most recent prompt");
+		await userEvent.keyboard("{Escape}");
+		await expectEditorText(editor, "");
+	},
+};
+
+export const PromptHistoryCyclingExitsOnTyping: Story = {
+	args: {
+		userPromptHistory: promptHistory,
+	},
+	play: async ({ canvasElement }) => {
+		const editor = getEditor(canvasElement);
+		await expectEditorText(editor, "");
+		await userEvent.click(editor);
+
+		await userEvent.keyboard("{ArrowUp}");
+		await expectEditorText(editor, "Most recent prompt");
+		await userEvent.keyboard("!");
+		await expectEditorText(editor, "Most recent prompt!");
+		await userEvent.keyboard("{ArrowUp}");
+		await expectEditorText(editor, "Most recent prompt!");
+
+		await userEvent.keyboard("{Control>}a{/Control}{Backspace}");
+		await expectEditorText(editor, "");
+		await userEvent.keyboard("{ArrowUp}");
+		await expectEditorText(editor, "Most recent prompt");
+	},
+};
+
+export const NoPromptHistoryUpArrowIsNoOp: Story = {
+	args: {
+		userPromptHistory: [],
+	},
+	play: async ({ canvasElement }) => {
+		const editor = getEditor(canvasElement);
+		await expectEditorText(editor, "");
+		await userEvent.click(editor);
+		await userEvent.keyboard("{ArrowUp}");
+		await expectEditorText(editor, "");
+	},
+};
+
+export const PromptHistorySuppressedWhileEditingHistoryMessage: Story = {
+	args: {
+		isEditingHistoryMessage: true,
+		userPromptHistory: promptHistory,
+	},
+	play: async ({ canvasElement }) => {
+		const editor = getEditor(canvasElement);
+		await expectEditorText(editor, "");
+		await userEvent.click(editor);
+		await userEvent.keyboard("{ArrowUp}");
+		await expectEditorText(editor, "");
+	},
+};
 
 export const DisablesSendUntilInput: Story = {
 	play: async ({ canvasElement }) => {
@@ -576,7 +673,7 @@ const mcpDefaults = {
 
 // ── MCP stories ────────────────────────────────────────────────
 
-/** Input with multiple MCP servers selected — shows icon stack in toolbar. */
+/** Input with multiple MCP servers selected, shows icon stack in toolbar. */
 export const WithMCPServers: Story = {
 	args: {
 		...mcpDefaults,
@@ -585,7 +682,7 @@ export const WithMCPServers: Story = {
 	},
 };
 
-/** MCP server needing OAuth — shows Auth button instead of toggle. */
+/** MCP server needing OAuth, shows Auth button instead of toggle. */
 export const WithMCPNeedingAuth: Story = {
 	args: {
 		...mcpDefaults,
@@ -594,7 +691,7 @@ export const WithMCPNeedingAuth: Story = {
 	},
 };
 
-/** No MCP servers active — shows only "MCP" label with chevron. */
+/** No MCP servers active, shows only "MCP" label with chevron. */
 export const WithMCPNoneActive: Story = {
 	args: {
 		...mcpDefaults,
@@ -642,7 +739,10 @@ export const PlanFirstMenuItem: Story = {
 		const toggles = await body.findAllByRole("menuitemcheckbox", {
 			name: "Plan first",
 		});
-		const toggle = toggles.at(-1)!;
+		const toggle = toggles.at(-1);
+		if (!toggle) {
+			throw new Error("Expected Plan first menu item");
+		}
 		expect(toggle).toBeInTheDocument();
 	},
 };
@@ -708,7 +808,10 @@ export const PlanFirstCheckedState: Story = {
 		const toggles = await body.findAllByRole("menuitemcheckbox", {
 			name: "Plan first",
 		});
-		const toggle = toggles.at(-1)!;
+		const toggle = toggles.at(-1);
+		if (!toggle) {
+			throw new Error("Expected Plan first menu item");
+		}
 		expect(toggle).toHaveAttribute("aria-checked", "true");
 	},
 };
@@ -790,7 +893,7 @@ const pagerdutyMCP = makeMCPServer({
 	enabled: true,
 });
 
-/** Many tools with a workspace at 414px — forces overflow and "+N" pill. */
+/** Many tools with a workspace at 414px, forces overflow and "+N" pill. */
 export const OverflowBadges: Story = {
 	args: {
 		...mcpDefaults,
@@ -913,7 +1016,7 @@ export const ContextNearLimit: Story = {
 	},
 };
 
-/** Long workspace name at iPhone SE width — verifies truncation. */
+/** Long workspace name at iPhone SE width, verifies truncation. */
 export const LongWorkspaceNameMobile: Story = {
 	args: {
 		...mcpDefaults,

--- a/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
@@ -50,13 +50,6 @@ const promptHistory = [
 	"Oldest prompt",
 ] as const;
 
-// Realistic prompts used by the UAT walkthrough recording. Newest first.
-const uatPromptHistory = [
-	"Fix the dark-mode contrast on hover",
-	"Add a Storybook story for ChatTopBar",
-	"Refactor the auth flow",
-] as const;
-
 const getEditor = (canvasElement: HTMLElement) =>
 	within(canvasElement).getByTestId("chat-message-input");
 
@@ -67,14 +60,6 @@ const expectEditorText = async (editor: HTMLElement, text: string) => {
 };
 
 export const Default: Story = {};
-
-// Manual demo story used by the CODAGT-319 UAT recording.
-// No play function: this is intentionally interactive for human walkthrough.
-export const PromptHistoryDemo: Story = {
-	args: {
-		userPromptHistory: uatPromptHistory,
-	},
-};
 
 export const PromptHistoryCycling: Story = {
 	args: {
@@ -128,6 +113,8 @@ export const PromptHistoryCyclingExitsOnTyping: Story = {
 		await expectEditorText(editor, "");
 		await userEvent.keyboard("{ArrowUp}");
 		await expectEditorText(editor, "Most recent prompt");
+		await userEvent.keyboard("{ArrowDown}");
+		await expectEditorText(editor, "");
 	},
 };
 
@@ -147,6 +134,34 @@ export const NoPromptHistoryUpArrowIsNoOp: Story = {
 export const PromptHistorySuppressedWhileEditingHistoryMessage: Story = {
 	args: {
 		isEditingHistoryMessage: true,
+		userPromptHistory: promptHistory,
+	},
+	play: async ({ canvasElement }) => {
+		const editor = getEditor(canvasElement);
+		await expectEditorText(editor, "");
+		await userEvent.click(editor);
+		await userEvent.keyboard("{ArrowUp}");
+		await expectEditorText(editor, "");
+	},
+};
+
+export const PromptHistorySuppressedWhileDisabled: Story = {
+	args: {
+		isDisabled: true,
+		userPromptHistory: promptHistory,
+	},
+	play: async ({ canvasElement }) => {
+		const editor = getEditor(canvasElement);
+		await expectEditorText(editor, "");
+		await userEvent.click(editor);
+		await userEvent.keyboard("{ArrowUp}");
+		await expectEditorText(editor, "");
+	},
+};
+
+export const PromptHistorySuppressedWhileLoading: Story = {
+	args: {
+		isLoading: true,
 		userPromptHistory: promptHistory,
 	},
 	play: async ({ canvasElement }) => {
@@ -688,7 +703,7 @@ const mcpDefaults = {
 
 // ── MCP stories ────────────────────────────────────────────────
 
-/** Input with multiple MCP servers selected, shows icon stack in toolbar. */
+/** Input with multiple MCP servers selected — shows icon stack in toolbar. */
 export const WithMCPServers: Story = {
 	args: {
 		...mcpDefaults,
@@ -697,7 +712,7 @@ export const WithMCPServers: Story = {
 	},
 };
 
-/** MCP server needing OAuth, shows Auth button instead of toggle. */
+/** MCP server needing OAuth — shows Auth button instead of toggle. */
 export const WithMCPNeedingAuth: Story = {
 	args: {
 		...mcpDefaults,
@@ -706,7 +721,7 @@ export const WithMCPNeedingAuth: Story = {
 	},
 };
 
-/** No MCP servers active, shows only "MCP" label with chevron. */
+/** No MCP servers active — shows only "MCP" label with chevron. */
 export const WithMCPNoneActive: Story = {
 	args: {
 		...mcpDefaults,
@@ -754,10 +769,7 @@ export const PlanFirstMenuItem: Story = {
 		const toggles = await body.findAllByRole("menuitemcheckbox", {
 			name: "Plan first",
 		});
-		const toggle = toggles.at(-1);
-		if (!toggle) {
-			throw new Error("Expected Plan first menu item");
-		}
+		const toggle = toggles.at(-1)!;
 		expect(toggle).toBeInTheDocument();
 	},
 };
@@ -823,10 +835,7 @@ export const PlanFirstCheckedState: Story = {
 		const toggles = await body.findAllByRole("menuitemcheckbox", {
 			name: "Plan first",
 		});
-		const toggle = toggles.at(-1);
-		if (!toggle) {
-			throw new Error("Expected Plan first menu item");
-		}
+		const toggle = toggles.at(-1)!;
 		expect(toggle).toHaveAttribute("aria-checked", "true");
 	},
 };
@@ -908,7 +917,7 @@ const pagerdutyMCP = makeMCPServer({
 	enabled: true,
 });
 
-/** Many tools with a workspace at 414px, forces overflow and "+N" pill. */
+/** Many tools with a workspace at 414px — forces overflow and "+N" pill. */
 export const OverflowBadges: Story = {
 	args: {
 		...mcpDefaults,
@@ -1031,7 +1040,7 @@ export const ContextNearLimit: Story = {
 	},
 };
 
-/** Long workspace name at iPhone SE width, verifies truncation. */
+/** Long workspace name at iPhone SE width — verifies truncation. */
 export const LongWorkspaceNameMobile: Story = {
 	args: {
 		...mcpDefaults,

--- a/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.stories.tsx
@@ -50,6 +50,13 @@ const promptHistory = [
 	"Oldest prompt",
 ] as const;
 
+// Realistic prompts used by the UAT walkthrough recording. Newest first.
+const uatPromptHistory = [
+	"Fix the dark-mode contrast on hover",
+	"Add a Storybook story for ChatTopBar",
+	"Refactor the auth flow",
+] as const;
+
 const getEditor = (canvasElement: HTMLElement) =>
 	within(canvasElement).getByTestId("chat-message-input");
 
@@ -60,6 +67,14 @@ const expectEditorText = async (editor: HTMLElement, text: string) => {
 };
 
 export const Default: Story = {};
+
+// Manual demo story used by the CODAGT-319 UAT recording.
+// No play function: this is intentionally interactive for human walkthrough.
+export const PromptHistoryDemo: Story = {
+	args: {
+		userPromptHistory: uatPromptHistory,
+	},
+};
 
 export const PromptHistoryCycling: Story = {
 	args: {

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -383,6 +383,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 		setCycleSavedDraft(null);
 		cycleHistorySnapshotRef.current = null;
 		currentCycleValueRef.current = null;
+		// Keep in sync with resetPromptCycle above.
 	}, [remountKey]);
 
 	const speech = useSpeechRecognition();
@@ -613,14 +614,13 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 	const handleDrop = (e: React.DragEvent) => {
 		e.preventDefault();
 		setIsDragging(false);
-		resetPromptCycle();
 		if (!onAttach || !e.dataTransfer.files.length) return;
 		const attachable = Array.from(e.dataTransfer.files).filter(
 			isChatAttachmentFile,
 		);
-		if (attachable.length > 0) {
-			onAttach(attachable);
-		}
+		if (attachable.length === 0) return;
+		resetPromptCycle();
+		onAttach(attachable);
 	};
 
 	// Track whether the editor has content so we can gate the

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -641,9 +641,10 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 		// Lexical fires onChange synchronously from editor.setValue().
 		// While cycling, compare incoming content to currentCycleValueRef,
 		// the last value we applied. Different content means user input,
-		// so reset. Matching content is our own setValue echo, so keep cycling.
-		// This works because Lexical fires onChange once per editor.update()
-		// and React 19 flushes discrete-event state synchronously.
+		// so reset; matching content is our own setValue echo, so keep cycling.
+		// This works because React batches state updates within event handlers
+		// and commits them after the handler returns, so the synchronous onChange
+		// callback sees the pre-batch cycleIndex value, not the queued update.
 		if (cycleIndex !== null && content !== currentCycleValueRef.current) {
 			resetPromptCycle();
 		}

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -354,19 +354,14 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 	const [hasFileReferences, setHasFileReferences] = useState(false);
 	const [cycleIndex, setCycleIndex] = useState<number | null>(null);
 	const [cycleSavedDraft, setCycleSavedDraft] = useState<string | null>(null);
-	// While we're cycling, currentCycleValueRef holds the text we last
-	// programmatically applied via applyCycleValue. handleContentChange
-	// uses it to distinguish our own update echoing back (which should
-	// keep cycle mode alive) from real user input (which exits the
-	// cycle). Lexical's setEditorState fires several onChange events
-	// per setValue call, so we intentionally compare on every change
-	// rather than consuming a one-shot flag.
+	const cycleHistorySnapshotRef = useRef<readonly string[] | null>(null);
 	const currentCycleValueRef = useRef<string | null>(null);
 	const previousRemountKeyRef = useRef(remountKey);
 
 	const resetPromptCycle = () => {
 		setCycleIndex(null);
 		setCycleSavedDraft(null);
+		cycleHistorySnapshotRef.current = null;
 		currentCycleValueRef.current = null;
 	};
 
@@ -386,6 +381,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 		// callbacks but biome's react-hooks lint does not.
 		setCycleIndex(null);
 		setCycleSavedDraft(null);
+		cycleHistorySnapshotRef.current = null;
 		currentCycleValueRef.current = null;
 	}, [remountKey]);
 
@@ -406,6 +402,9 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 	}, [speech.transcript, speech.isRecording, preRecordingValue]);
 
 	// Forward a stable delegating handle to the parent-supplied inputRef.
+	// Delegates lazily to internalRef.current so methods see the current
+	// Lexical instance after a remount, not the orphaned ref captured at
+	// factory time.
 	useImperativeHandle(
 		inputRef,
 		() => ({
@@ -639,11 +638,12 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 		serializedEditorState: string,
 		hasRefs: boolean,
 	) => {
-		// While cycling, the editor's content fluctuates as Lexical fires
-		// multiple update events per setValue call. As long as the content
-		// matches the value we last applied, the change is our own update
-		// echoing back; anything else (typing, paste, drop, attach) is
-		// real user input and exits the cycle.
+		// Lexical fires onChange synchronously from editor.setValue().
+		// While cycling, compare incoming content to currentCycleValueRef,
+		// the last value we applied. Different content means user input,
+		// so reset. Matching content is our own setValue echo, so keep cycling.
+		// This works because Lexical fires onChange once per editor.update()
+		// and React 19 flushes discrete-event state synchronously.
 		if (cycleIndex !== null && content !== currentCycleValueRef.current) {
 			resetPromptCycle();
 		}
@@ -756,29 +756,27 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 		const savedDraft = cycleSavedDraft ?? "";
 		setCycleIndex(null);
 		setCycleSavedDraft(null);
+		cycleHistorySnapshotRef.current = null;
 		applyCycleValue(savedDraft);
 	};
 
 	const handleEditorKeyDown = (e: React.KeyboardEvent) => {
+		if (e.key === "Escape" && cycleIndex !== null) {
+			e.preventDefault();
+			e.stopPropagation();
+			restoreCycleDraft();
+			return;
+		}
+
+		// isStreaming is intentionally excluded. Cycling is allowed while
+		// streaming so the user can prepare the next prompt. Escape is
+		// cycle-aware so it does not accidentally interrupt streaming.
 		const isPromptCyclingSuppressed =
 			editingQueuedMessageID !== null ||
 			isEditingHistoryMessage ||
 			isDisabled ||
 			isLoading;
 		if (isPromptCyclingSuppressed) {
-			return;
-		}
-
-		if (e.key === "Escape") {
-			if (cycleIndex === null || isStreaming) {
-				return;
-			}
-			// Stop propagation so the outer composer Escape handler
-			// (interrupt streaming, cancel queue/history edit) doesn't
-			// also fire on the same keystroke.
-			e.preventDefault();
-			e.stopPropagation();
-			restoreCycleDraft();
 			return;
 		}
 
@@ -790,11 +788,13 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 			if (e.key !== "ArrowUp" || !isComposerEffectivelyEmpty) {
 				return;
 			}
-			const latestPrompt = userPromptHistory[0];
+			const cycleHistory = [...userPromptHistory];
+			const latestPrompt = cycleHistory[0];
 			if (latestPrompt === undefined) {
 				return;
 			}
 			e.preventDefault();
+			cycleHistorySnapshotRef.current = cycleHistory;
 			setCycleIndex(0);
 			setCycleSavedDraft(internalRef.current?.getValue() ?? "");
 			applyCycleValue(latestPrompt);
@@ -802,13 +802,14 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 		}
 
 		e.preventDefault();
+		const cycleHistory = cycleHistorySnapshotRef.current ?? userPromptHistory;
 		if (e.key === "ArrowDown") {
 			if (cycleIndex === 0) {
 				restoreCycleDraft();
 				return;
 			}
 			const nextIndex = cycleIndex - 1;
-			const nextPrompt = userPromptHistory[nextIndex];
+			const nextPrompt = cycleHistory[nextIndex];
 			if (nextPrompt === undefined) {
 				restoreCycleDraft();
 				return;
@@ -818,7 +819,8 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 			return;
 		}
 
-		const lastIndex = userPromptHistory.length - 1;
+		// ArrowUp: load an older prompt.
+		const lastIndex = cycleHistory.length - 1;
 		if (lastIndex < 0) {
 			restoreCycleDraft();
 			return;
@@ -827,7 +829,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 		if (nextIndex === cycleIndex) {
 			return;
 		}
-		const nextPrompt = userPromptHistory[nextIndex];
+		const nextPrompt = cycleHistory[nextIndex];
 		if (nextPrompt === undefined) {
 			restoreCycleDraft();
 			return;
@@ -952,7 +954,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 				{/* Warn about invisible Unicode in the message text.
 				 * Unlike the admin/user prompt textareas (which strip
 				 * invisible chars server-side on save), the chat input
-				 * is the user's free-form message, we don't silently
+				 * is the user's free-form message — we don't silently
 				 * mutate it. Instead we surface a warning so the user
 				 * can make an informed decision. This guards against
 				 * social engineering attacks where a user is tricked
@@ -1208,7 +1210,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 								)}
 							</span>
 						)}{" "}
-						{/* Badge row, all badges and the pill always
+						{/* Badge row — all badges and the pill always
 						 * render so the DOM structure never changes.
 						 * Overflow badges use invisible + order-1 to
 						 * hide and reorder via CSS. The pill is invisible
@@ -1241,7 +1243,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 									/>
 								);
 							})}
-							{/* Pill, always in the DOM so it permanently
+							{/* Pill — always in the DOM so it permanently
 							 * reserves layout space. Invisible when nothing
 							 * overflows. CSS order keeps it before order-1
 							 * (overflow) badges. */}

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -145,7 +145,8 @@ interface AgentChatInputProps {
 	// History editing state, owned by the parent.
 	isEditingHistoryMessage?: boolean;
 	onCancelHistoryEdit?: () => void;
-	onEditLastUserMessage?: () => void;
+	// Newest-first list of non-empty user prompts for local history cycling.
+	userPromptHistory?: readonly string[];
 
 	// Optional context-usage summary shown to the left of the send button.
 	// Pass `null` to render fallback values (e.g. when limit is unknown).
@@ -312,7 +313,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 	onCancelQueueEdit,
 	isEditingHistoryMessage = false,
 	onCancelHistoryEdit,
-	onEditLastUserMessage,
+	userPromptHistory = [],
 	contextUsage,
 	attachments = [],
 	onAttach,
@@ -351,6 +352,40 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 	const mcpPopupRef = useRef<Window | null>(null);
 
 	const [hasFileReferences, setHasFileReferences] = useState(false);
+	const [cycleIndex, setCycleIndex] = useState<number | null>(null);
+	const [cycleSavedDraft, setCycleSavedDraft] = useState<string | null>(null);
+	const isApplyingCycleValueRef = useRef(false);
+	const applyingCycleValueRef = useRef<string | null>(null);
+	const currentCycleValueRef = useRef<string | null>(null);
+	const previousRemountKeyRef = useRef(remountKey);
+
+	const resetPromptCycle = () => {
+		setCycleIndex(null);
+		setCycleSavedDraft(null);
+		isApplyingCycleValueRef.current = false;
+		applyingCycleValueRef.current = null;
+		currentCycleValueRef.current = null;
+	};
+
+	const applyCycleValue = (text: string) => {
+		const editor = internalRef.current;
+		if (!editor) return;
+		isApplyingCycleValueRef.current = true;
+		applyingCycleValueRef.current = text;
+		currentCycleValueRef.current = text;
+		editor.setValue(text);
+		editor.focus();
+	};
+
+	useEffect(() => {
+		if (previousRemountKeyRef.current === remountKey) return;
+		previousRemountKeyRef.current = remountKey;
+		setCycleIndex(null);
+		setCycleSavedDraft(null);
+		isApplyingCycleValueRef.current = false;
+		applyingCycleValueRef.current = null;
+		currentCycleValueRef.current = null;
+	}, [remountKey]);
 
 	const speech = useSpeechRecognition();
 	const [preRecordingValue, setPreRecordingValue] = useState<string>("");
@@ -368,9 +403,20 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 		}
 	}, [speech.transcript, speech.isRecording, preRecordingValue]);
 
-	// Forward the internal ref to the parent-supplied inputRef
-	// so both point to the same ChatMessageInputRef instance.
-	useImperativeHandle(inputRef, () => internalRef.current!, []);
+	// Forward a stable delegating handle to the parent-supplied inputRef.
+	useImperativeHandle(
+		inputRef,
+		() => ({
+			setValue: (text) => internalRef.current?.setValue(text),
+			insertText: (text) => internalRef.current?.insertText(text),
+			clear: () => internalRef.current?.clear(),
+			focus: () => internalRef.current?.focus(),
+			getValue: () => internalRef.current?.getValue() ?? "",
+			addFileReference: (ref) => internalRef.current?.addFileReference(ref),
+			getContentParts: () => internalRef.current?.getContentParts() ?? [],
+		}),
+		[],
+	);
 
 	// Listen for OAuth2 completion postMessage from popup.
 	useEffect(() => {
@@ -511,6 +557,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 
 	const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
 		if (e.target.files && onAttach) {
+			resetPromptCycle();
 			onAttach(Array.from(e.target.files));
 		}
 		// Reset so the same file can be selected again.
@@ -518,6 +565,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 	};
 
 	const handleFilePaste = (file: File) => {
+		resetPromptCycle();
 		onAttach?.([file]);
 	};
 
@@ -526,6 +574,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 		if (content === undefined) return;
 		const editor = internalRef.current;
 		if (!editor) return;
+		resetPromptCycle();
 		editor.insertText(content);
 		onRemoveAttachment?.(file);
 	};
@@ -563,6 +612,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 	const handleDrop = (e: React.DragEvent) => {
 		e.preventDefault();
 		setIsDragging(false);
+		resetPromptCycle();
 		if (!onAttach || !e.dataTransfer.files.length) return;
 		const attachable = Array.from(e.dataTransfer.files).filter(
 			isChatAttachmentFile,
@@ -587,6 +637,19 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 		serializedEditorState: string,
 		hasRefs: boolean,
 	) => {
+		let shouldResetCycle =
+			cycleIndex !== null && content !== currentCycleValueRef.current;
+		if (isApplyingCycleValueRef.current) {
+			shouldResetCycle =
+				content !== applyingCycleValueRef.current &&
+				cycleIndex !== null &&
+				content !== currentCycleValueRef.current;
+			isApplyingCycleValueRef.current = false;
+			applyingCycleValueRef.current = null;
+		}
+		if (shouldResetCycle) {
+			resetPromptCycle();
+		}
 		setHasContent(Boolean(content.trim()));
 		setHasFileReferences(hasRefs);
 		setInvisibleCharCount(countInvisibleCharacters(content));
@@ -650,6 +713,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 		}
 
 		onSend(text);
+		resetPromptCycle();
 		if (!isMobileViewport()) {
 			internalRef.current?.focus();
 		}
@@ -690,18 +754,84 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 			}
 		}
 	};
+	const restoreCycleDraft = () => {
+		const savedDraft = cycleSavedDraft ?? "";
+		setCycleIndex(null);
+		setCycleSavedDraft(null);
+		applyCycleValue(savedDraft);
+	};
+
 	const handleEditorKeyDown = (e: React.KeyboardEvent) => {
-		if (
-			e.key !== "ArrowUp" ||
+		const isPromptCyclingSuppressed =
 			editingQueuedMessageID !== null ||
 			isEditingHistoryMessage ||
-			!onEditLastUserMessage ||
-			!isComposerEffectivelyEmpty
-		) {
+			isDisabled ||
+			isLoading;
+		if (isPromptCyclingSuppressed) {
 			return;
 		}
+
+		if (e.key === "Escape") {
+			if (cycleIndex === null || isStreaming) {
+				return;
+			}
+			e.preventDefault();
+			restoreCycleDraft();
+			return;
+		}
+
+		if (e.key !== "ArrowUp" && e.key !== "ArrowDown") {
+			return;
+		}
+
+		if (cycleIndex === null) {
+			if (e.key !== "ArrowUp" || !isComposerEffectivelyEmpty) {
+				return;
+			}
+			const latestPrompt = userPromptHistory[0];
+			if (latestPrompt === undefined) {
+				return;
+			}
+			e.preventDefault();
+			setCycleIndex(0);
+			setCycleSavedDraft(internalRef.current?.getValue() ?? "");
+			applyCycleValue(latestPrompt);
+			return;
+		}
+
 		e.preventDefault();
-		onEditLastUserMessage();
+		if (e.key === "ArrowDown") {
+			if (cycleIndex === 0) {
+				restoreCycleDraft();
+				return;
+			}
+			const nextIndex = cycleIndex - 1;
+			const nextPrompt = userPromptHistory[nextIndex];
+			if (nextPrompt === undefined) {
+				restoreCycleDraft();
+				return;
+			}
+			setCycleIndex(nextIndex);
+			applyCycleValue(nextPrompt);
+			return;
+		}
+
+		const lastIndex = userPromptHistory.length - 1;
+		if (lastIndex < 0) {
+			restoreCycleDraft();
+			return;
+		}
+		const nextIndex = Math.min(cycleIndex + 1, lastIndex);
+		if (nextIndex === cycleIndex) {
+			return;
+		}
+		const nextPrompt = userPromptHistory[nextIndex];
+		if (nextPrompt === undefined) {
+			restoreCycleDraft();
+			return;
+		}
+		setCycleIndex(nextIndex);
+		applyCycleValue(nextPrompt);
 	};
 
 	const sendButtonLabel =
@@ -804,6 +934,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 				<ChatMessageInput
 					ref={internalRef}
 					onFilePaste={onAttach ? handleFilePaste : undefined}
+					onPaste={resetPromptCycle}
 					aria-label="Chat message"
 					className="min-h-[60px] sm:min-h-24 w-full resize-none bg-transparent px-3 py-2 font-sans text-[13px] leading-relaxed text-content-primary placeholder:text-content-secondary disabled:cursor-not-allowed disabled:opacity-70"
 					placeholder={placeholder}
@@ -819,7 +950,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 				{/* Warn about invisible Unicode in the message text.
 				 * Unlike the admin/user prompt textareas (which strip
 				 * invisible chars server-side on save), the chat input
-				 * is the user's free-form message — we don't silently
+				 * is the user's free-form message, we don't silently
 				 * mutate it. Instead we surface a warning so the user
 				 * can make an informed decision. This guards against
 				 * social engineering attacks where a user is tricked
@@ -903,6 +1034,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 											<button
 												type="button"
 												onClick={() => {
+													resetPromptCycle();
 													setPlusMenuOpen(false);
 													fileInputRef.current?.click();
 												}}
@@ -1074,7 +1206,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 								)}
 							</span>
 						)}{" "}
-						{/* Badge row — all badges and the pill always
+						{/* Badge row, all badges and the pill always
 						 * render so the DOM structure never changes.
 						 * Overflow badges use invisible + order-1 to
 						 * hide and reorder via CSS. The pill is invisible
@@ -1107,7 +1239,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 									/>
 								);
 							})}
-							{/* Pill — always in the DOM so it permanently
+							{/* Pill, always in the DOM so it permanently
 							 * reserves layout space. Invisible when nothing
 							 * overflows. CSS order keeps it before order-1
 							 * (overflow) badges. */}

--- a/site/src/pages/AgentsPage/components/AgentChatInput.tsx
+++ b/site/src/pages/AgentsPage/components/AgentChatInput.tsx
@@ -354,24 +354,25 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 	const [hasFileReferences, setHasFileReferences] = useState(false);
 	const [cycleIndex, setCycleIndex] = useState<number | null>(null);
 	const [cycleSavedDraft, setCycleSavedDraft] = useState<string | null>(null);
-	const isApplyingCycleValueRef = useRef(false);
-	const applyingCycleValueRef = useRef<string | null>(null);
+	// While we're cycling, currentCycleValueRef holds the text we last
+	// programmatically applied via applyCycleValue. handleContentChange
+	// uses it to distinguish our own update echoing back (which should
+	// keep cycle mode alive) from real user input (which exits the
+	// cycle). Lexical's setEditorState fires several onChange events
+	// per setValue call, so we intentionally compare on every change
+	// rather than consuming a one-shot flag.
 	const currentCycleValueRef = useRef<string | null>(null);
 	const previousRemountKeyRef = useRef(remountKey);
 
 	const resetPromptCycle = () => {
 		setCycleIndex(null);
 		setCycleSavedDraft(null);
-		isApplyingCycleValueRef.current = false;
-		applyingCycleValueRef.current = null;
 		currentCycleValueRef.current = null;
 	};
 
 	const applyCycleValue = (text: string) => {
 		const editor = internalRef.current;
 		if (!editor) return;
-		isApplyingCycleValueRef.current = true;
-		applyingCycleValueRef.current = text;
 		currentCycleValueRef.current = text;
 		editor.setValue(text);
 		editor.focus();
@@ -380,10 +381,11 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 	useEffect(() => {
 		if (previousRemountKeyRef.current === remountKey) return;
 		previousRemountKeyRef.current = remountKey;
+		// Inlined resetPromptCycle body. Calling resetPromptCycle directly
+		// would force it into the dep array; the React Compiler stabilises
+		// callbacks but biome's react-hooks lint does not.
 		setCycleIndex(null);
 		setCycleSavedDraft(null);
-		isApplyingCycleValueRef.current = false;
-		applyingCycleValueRef.current = null;
 		currentCycleValueRef.current = null;
 	}, [remountKey]);
 
@@ -637,17 +639,12 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 		serializedEditorState: string,
 		hasRefs: boolean,
 	) => {
-		let shouldResetCycle =
-			cycleIndex !== null && content !== currentCycleValueRef.current;
-		if (isApplyingCycleValueRef.current) {
-			shouldResetCycle =
-				content !== applyingCycleValueRef.current &&
-				cycleIndex !== null &&
-				content !== currentCycleValueRef.current;
-			isApplyingCycleValueRef.current = false;
-			applyingCycleValueRef.current = null;
-		}
-		if (shouldResetCycle) {
+		// While cycling, the editor's content fluctuates as Lexical fires
+		// multiple update events per setValue call. As long as the content
+		// matches the value we last applied, the change is our own update
+		// echoing back; anything else (typing, paste, drop, attach) is
+		// real user input and exits the cycle.
+		if (cycleIndex !== null && content !== currentCycleValueRef.current) {
 			resetPromptCycle();
 		}
 		setHasContent(Boolean(content.trim()));
@@ -719,6 +716,7 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 		}
 	};
 	const handleStartRecording = () => {
+		resetPromptCycle();
 		setPreRecordingValue(internalRef.current?.getValue()?.trim() ?? "");
 		speech.start();
 	};
@@ -775,7 +773,11 @@ export const AgentChatInput: FC<AgentChatInputProps> = ({
 			if (cycleIndex === null || isStreaming) {
 				return;
 			}
+			// Stop propagation so the outer composer Escape handler
+			// (interrupt streaming, cancel queue/history edit) doesn't
+			// also fire on the same keystroke.
 			e.preventDefault();
+			e.stopPropagation();
 			restoreCycleDraft();
 			return;
 		}

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -277,14 +277,18 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 			return message;
 		})
 		.filter(isChatMessage);
+	// Newest first. messages are in id-ascending order, so reverse
+	// iteration yields the most recent user prompts first. Store the
+	// original text untouched so cycling and re-sending reproduces what
+	// the user originally sent (boundary whitespace can be intentional).
 	const userPromptHistory: string[] = [];
 	for (let index = messages.length - 1; index >= 0; index--) {
 		const message = messages[index];
 		if (!message || message.role !== "user") {
 			continue;
 		}
-		const text = getEditableUserMessagePayload(message).text.trim();
-		if (text) {
+		const text = getEditableUserMessagePayload(message).text;
+		if (text.trim()) {
 			userPromptHistory.push(text);
 		}
 	}

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -283,7 +283,7 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 	// the user originally sent (boundary whitespace can be intentional).
 	const userPromptHistory: string[] = [];
 	for (let index = messages.length - 1; index >= 0; index--) {
-		const message = messages[index];
+		const message = messages.at(index);
 		if (!message || message.role !== "user") {
 			continue;
 		}

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -186,11 +186,6 @@ interface ChatPageInputProps {
 	onCancelQueueEdit: () => void;
 	isEditingHistoryMessage: boolean;
 	onCancelHistoryEdit: () => void;
-	onEditUserMessage: (
-		messageId: number,
-		text: string,
-		fileBlocks?: readonly TypesGen.ChatMessagePart[],
-	) => void;
 	// File parts from the message being edited, converted to
 	// File objects and pre-populated into attachments.
 	editingFileBlocks?: readonly TypesGen.ChatMessagePart[];
@@ -245,7 +240,6 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 	onCancelQueueEdit,
 	isEditingHistoryMessage,
 	onCancelHistoryEdit,
-	onEditUserMessage,
 	editingFileBlocks,
 	mcpServers,
 	selectedMCPServerIds,
@@ -283,23 +277,17 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 			return message;
 		})
 		.filter(isChatMessage);
-	let lastEditableUserMessage: TypesGen.ChatMessage | undefined;
-	for (let index = orderedMessageIDs.length - 1; index >= 0; index--) {
-		const message = messagesByID.get(orderedMessageIDs[index]);
-		if (message?.role === "user") {
-			lastEditableUserMessage = message;
-			break;
+	const userPromptHistory: string[] = [];
+	for (let index = messages.length - 1; index >= 0; index--) {
+		const message = messages[index];
+		if (!message || message.role !== "user") {
+			continue;
+		}
+		const text = getEditableUserMessagePayload(message).text.trim();
+		if (text) {
+			userPromptHistory.push(text);
 		}
 	}
-
-	const handleEditLastUserMessage = lastEditableUserMessage
-		? () => {
-				const { text, fileBlocks } = getEditableUserMessagePayload(
-					lastEditableUserMessage,
-				);
-				onEditUserMessage(lastEditableUserMessage.id, text, fileBlocks);
-			}
-		: undefined;
 
 	const rawUsage = getLatestContextUsage(messages);
 	const latestContextUsage = rawUsage
@@ -467,7 +455,7 @@ export const ChatPageInput: FC<ChatPageInputProps> = ({
 			onCancelQueueEdit={onCancelQueueEdit}
 			isEditingHistoryMessage={isEditingHistoryMessage}
 			onCancelHistoryEdit={onCancelHistoryEdit}
-			onEditLastUserMessage={handleEditLastUserMessage}
+			userPromptHistory={userPromptHistory}
 			isDisabled={isInputDisabled}
 			isLoading={isSendPending}
 			isStreaming={isStreaming}


### PR DESCRIPTION
Fixes [CODAGT-319](https://linear.app/codercom/issue/CODAGT-319/support-prompt-history-cycling-with-up-arrow).

Pressing the up-arrow key in the agent chat composer now cycles through prior user prompts in the chat (terminal/Discord/iTerm2 style). Down-arrow steps forward, Escape exits cycling and restores the in-progress draft. Cycling is non-destructive: the per-message hover **Edit** button is still the destructive truncate-and-edit path.

Replaces the previous up-arrow shortcut that immediately entered destructive history-edit mode (and which had a regression where the composer rendered as "editing" with an empty input box).

## Behaviour

- **Up** when composer is empty: snapshot the (empty) draft and load the most recent user prompt; subsequent **Up** presses load older prompts. Clamp at oldest, no wrap.
- **Up** while non-empty and not yet cycling: pass through (caret movement preserved).
- Once cycling, **Up / Down** are intercepted unconditionally because the cycle text fully replaces editor contents. Exit explicitly via Escape, by sending, or by typing.
- **Down** while cycling: load the next-newer prompt, or restore the saved draft when past newest.
- **Escape** while cycling: exit cycle and restore the saved draft. This also applies during streaming; the same keypress is stopped before it reaches the interrupt handler, and a second Escape interrupts as before.
- **Typing / paste / drop / attach / send / `remountKey` change**: exit cycle mode and clear the snapshot.
- Cycling is suppressed while `isEditingHistoryMessage`, `editingQueuedMessageID !== null`, or the input is `disabled` / `isLoading`.
- Empty `userPromptHistory` makes Up a no-op (no destructive fallback).

## Out of scope (filed as follow-ups if needed)

- Restoring file-reference chips / attachments on cycled messages — v1 cycles plain text only, matching the existing per-message destructive Edit's `text` payload.
- `^N` / `^P` keybindings (per Cian's note in the Linear thread).
- Per-user "enable/disable history cycling" preference (per Rowan's note).
- Cross-chat history; cycling is per-chat.

## Tests

New Storybook play functions in `AgentChatInput.stories.tsx`:

- `PromptHistoryCycling` — Up cycles older, clamps at oldest; Down returns to newer / draft; Escape restores draft.
- `PromptHistoryCyclingExitsOnTyping` — typing exits cycle mode; subsequent Up snapshots the fresh empty draft and Down restores it.
- `NoPromptHistoryUpArrowIsNoOp` — empty history → Up is a no-op.
- `PromptHistorySuppressedWhileEditingHistoryMessage` — cycling does not engage while history-editing.
- `PromptHistorySuppressedWhileDisabled` — cycling does not engage while disabled.
- `PromptHistorySuppressedWhileLoading` — cycling does not engage while loading.

## Implementation notes

Also rewrites `useImperativeHandle` to delegate to `internalRef.current` lazily on every call instead of capturing it eagerly at factory time. The old code crashed when methods were called after a remount because the captured ref was stale; the new wrapper sees the current Lexical instance. Behavior changes from throw-on-null to silent no-op, which matches every other consumer of `ChatMessageInputRef`.

Verified locally:

```
pnpm format
pnpm check
pnpm test:storybook src/pages/AgentsPage/components/AgentChatInput.stories.tsx         # 41 passed
pnpm lint
```

## Manual UAT

A 13-case manual UAT covering cycle entry/exit, clamping, draft restoration, no-history no-op, suppression while editing a history message, and the send-button enable state — all PASS. Spec lives at the deleted artifact branch; happy to re-attach if reviewers want it.

<details>
<summary>Implementation plan and decision log</summary>

The complete plan that drove this PR, including design alternatives considered and edge cases:

```md
# CODAGT-319 — Up-arrow prompt history cycling

## Goal
Pressing the up-arrow key in the agent chat composer should cycle through the
user's previously-sent prompts in the current chat, terminal/Discord/iTerm2
style. Down-arrow steps forward; Escape exits cycle mode and restores the
in-progress draft. Cycling is non-destructive — it only populates the
composer with text the user can choose to resend, edit, or discard.

## Today's behaviour (and the regression)
- `ChatMessageInput` is a Lexical-based plain-text editor used inside `AgentChatInput.tsx`.
- `AgentChatInput.tsx` already wires an `ArrowUp` handler. When the composer is empty and not already editing, it calls `onEditLastUserMessage`.
- `onEditLastUserMessage` puts the user into a destructive "edit history" mode that warns "Editing will delete all subsequent messages and restart the conversation here.".
- Danielle's regression report ("shows me as editing but the input box is empty") indicates the destructive flow has a bug in addition to being the wrong UX for the request. We're replacing that path on the up-arrow, not patching it. The destructive edit remains accessible via the per-message hover Edit button.

## Design

### Behaviour
- Up when composer is empty: snapshot the (empty) draft and load the most recent user prompt. Subsequent Up loads older prompts, clamping at oldest. No wrap.
- Up while non-empty and not yet cycling: pass through. Matches existing gating.
- Once cycling, Up/Down are intercepted unconditionally. Exit via Escape, send, or typing.
- Down while cycling: next-newer or restore draft past newest.
- Escape while cycling: restore draft. During streaming, stop propagation so the same keypress does not interrupt; a second Escape interrupts as before.
- Typing/paste/drop/attach/send: exit cycle.
- Suppressed while isEditingHistoryMessage, editingQueuedMessageID !== null, or disabled/isLoading.
- No history => Up is a no-op.

### State
Local to `AgentChatInput.tsx`:
- `cycleIndex: number | null` — null means not cycling. 0 = newest user prompt.
- `cycleSavedDraft: string | null` — text restored on dismiss.

No localStorage persistence — refresh is a clean exit signal and the chat already has history server-side.

### Wiring
- New prop `userPromptHistory: readonly string[]` on `AgentChatInput`, newest-first.
- Removed `onEditLastUserMessage` prop entirely (its single call-site is being replaced). Removed dead `onEditUserMessage` prop on `ChatPageInput` (no longer needed since the destructive last-message shortcut is gone; the destructive Edit button uses a separate prop chain through `ChatPageTimeline`).
- `ChatPageContent.tsx` derives `userPromptHistory` from existing message store, filtered to `role === "user"` with non-empty `getEditableUserMessagePayload(message).text.trim()`.

### Reset triggers
`cycleIndex` and `cycleSavedDraft` reset on:
1. New `remountKey` (chat change, edit start/cancel).
2. Successful send.
3. Paste, drop, file attach.
4. User typing (detected via `handleContentChange` by comparing the incoming content to `currentCycleValueRef`, the last value applied programmatically).

### Out of scope
- Chip/attachment cycling.
- ^N/^P (Cian's note).
- Per-user toggle (Rowan's note).
- Cross-chat history.
```

</details>

---
> [!NOTE]
> This PR was created on behalf of @ibetitsmike by Coder Agents.
