### PR TITLE
docs(docs/ai-coder/agents): note minimum Coder version 2.33.1

### DIFF
--- a/docs/ai-coder/agents/getting-started.md
+++ b/docs/ai-coder/agents/getting-started.md
@@ -6,6 +6,7 @@ Agents, preparing your deployment, and running your first Coder Agent.
 > [!NOTE]
 > Coder Agents is in Beta. APIs, behavior, and configuration may change
 > between releases without notice; pin a release before broad rollout.
+> Use Coder version 2.33.1 or greater.
 
 ## Prerequisites
 

--- a/docs/ai-coder/agents/getting-started.md
+++ b/docs/ai-coder/agents/getting-started.md
@@ -6,7 +6,7 @@ Agents, preparing your deployment, and running your first Coder Agent.
 > [!NOTE]
 > Coder Agents is in Beta. APIs, behavior, and configuration may change
 > between releases without notice; pin a release before broad rollout.
-> Use Coder version 2.33.1 or greater.
+> Use **Coder version 2.33.1 or greater**.
 
 ## Prerequisites
 


### PR DESCRIPTION
Adds a minimum version note to the Coder Agents getting started page so users know to run Coder 2.33.1 or greater.

---

PR generated with Coder Agents