### PR TITLE
docs(docs/admin/users/oidc-auth): note SCIM 2.0 support is not guaranteed

### DIFF
--- a/docs/admin/users/oidc-auth/index.md
+++ b/docs/admin/users/oidc-auth/index.md
@@ -140,6 +140,16 @@ CODER_DISABLE_PASSWORD_AUTH=true
 > SCIM is a Premium feature.
 > [Learn more](https://coder.com/pricing#compare-plans).
 
+> [!IMPORTANT]
+> Coder's SCIM 2.0 implementation is not a fully certified or guaranteed
+> implementation of the [SCIM 2.0 specification](https://datatracker.ietf.org/doc/html/rfc7644).
+> It is intended to cover common user provisioning and deprovisioning flows
+> with the major identity providers (Okta, Microsoft Entra ID, etc.). Specific
+> attributes, endpoints, or behaviors required by your IdP may not be
+> supported, and compatibility may change between releases. If you depend on
+> a specific SCIM behavior, [contact us](https://coder.com/contact) before
+> rolling it out broadly.
+
 Coder supports user provisioning and deprovisioning via SCIM 2.0 with header
 authentication. Upon deactivation, users are
 [suspended](../index.md#suspend-a-user) and are not deleted.

--- a/docs/admin/users/oidc-auth/index.md
+++ b/docs/admin/users/oidc-auth/index.md
@@ -148,7 +148,9 @@ CODER_DISABLE_PASSWORD_AUTH=true
 > attributes, endpoints, or behaviors required by your IdP may not be
 > supported, and compatibility may change between releases. If you depend on
 > a specific SCIM behavior, [contact us](https://coder.com/contact) before
-> rolling it out broadly.
+> rolling it out broadly. See
+> [coder/coder#15830](https://github.com/coder/coder/issues/15830) for
+> tracked gaps and ongoing work.
 
 Coder supports user provisioning and deprovisioning via SCIM 2.0 with header
 authentication. Upon deactivation, users are

--- a/docs/admin/users/oidc-auth/index.md
+++ b/docs/admin/users/oidc-auth/index.md
@@ -136,11 +136,10 @@ CODER_DISABLE_PASSWORD_AUTH=true
 
 ## SCIM
 
-> [!NOTE]
-> SCIM is a Premium feature.
-> [Learn more](https://coder.com/pricing#compare-plans).
-
 > [!IMPORTANT]
+> SCIM is a Premium feature
+> ([learn more](https://coder.com/pricing#compare-plans)).
+>
 > Coder's SCIM 2.0 implementation is not a fully certified or guaranteed
 > implementation of the [SCIM 2.0 specification](https://datatracker.ietf.org/doc/html/rfc7644).
 > It is intended to cover common user provisioning and deprovisioning flows


### PR DESCRIPTION
Adds an `[!IMPORTANT]` callout under the SCIM heading in the OIDC auth docs noting that Coder's SCIM 2.0 implementation is not a fully certified or guaranteed implementation of the spec. It covers common provisioning/deprovisioning flows with major IdPs (Okta, Entra ID, etc.) but specific attributes, endpoints, or behaviors may not be supported and may change between releases.

This matches what we say in conversations with prospects and avoids setting an expectation we can't always meet. Background: #15830 (current implementation is an MVP scoped to Okta cloud; `PATCH` is not RFC 7644 compliant; user updates only change status, not groups/orgs/roles).

Companion PR: coder/coder.com#738 removes the SCIM row from the pricing comparison.

> Generated with [Coder Agents](https://coder.com/agents)