### PR TITLE
fix(site): improve info icon styles in audit and connection log rows

### DIFF
--- a/site/src/pages/AuditPage/AuditLogRow/AuditLogRow.tsx
+++ b/site/src/pages/AuditPage/AuditLogRow/AuditLogRow.tsx
@@ -131,7 +131,7 @@ export const AuditLogRow: FC<AuditLogRowProps> = ({
 										{showOrgDetails ? (
 											<Tooltip>
 												<TooltipTrigger asChild>
-													<InfoIcon className="text-content-link" />
+													<InfoIcon className="size-icon-sm text-content-link" />
 												</TooltipTrigger>
 												<TooltipContent side="bottom">
 													<div className="flex flex-col gap-2">

--- a/site/src/pages/AuditPage/AuditLogRow/AuditLogRow.tsx
+++ b/site/src/pages/AuditPage/AuditLogRow/AuditLogRow.tsx
@@ -131,7 +131,7 @@ export const AuditLogRow: FC<AuditLogRowProps> = ({
 										{showOrgDetails ? (
 											<Tooltip>
 												<TooltipTrigger asChild>
-													<InfoIcon className="size-icon-sm text-content-link" />
+													<InfoIcon className="size-icon-sm text-content-secondary" />
 												</TooltipTrigger>
 												<TooltipContent side="bottom">
 													<div className="flex flex-col gap-2">

--- a/site/src/pages/ConnectionLogPage/ConnectionLogRow/ConnectionLogRow.tsx
+++ b/site/src/pages/ConnectionLogPage/ConnectionLogRow/ConnectionLogRow.tsx
@@ -72,7 +72,7 @@ export const ConnectionLogRow: FC<ConnectionLogRowProps> = ({
 								)}
 								<Tooltip>
 									<TooltipTrigger asChild>
-										<InfoIcon className="size-icon-sm text-content-link" />
+										<InfoIcon className="size-icon-sm text-content-secondary" />
 									</TooltipTrigger>
 									<TooltipContent side="bottom">
 										<div className="flex flex-col gap-2">

--- a/site/src/pages/ConnectionLogPage/ConnectionLogRow/ConnectionLogRow.tsx
+++ b/site/src/pages/ConnectionLogPage/ConnectionLogRow/ConnectionLogRow.tsx
@@ -72,7 +72,7 @@ export const ConnectionLogRow: FC<ConnectionLogRowProps> = ({
 								)}
 								<Tooltip>
 									<TooltipTrigger asChild>
-										<InfoIcon className="text-content-link" />
+										<InfoIcon className="size-icon-sm text-content-link" />
 									</TooltipTrigger>
 									<TooltipContent side="bottom">
 										<div className="flex flex-col gap-2">


### PR DESCRIPTION
The Lucide `InfoIcon` shown next to multi-org audit log rows (and the
connection log rows that copied the same pattern) had no size class, so it
rendered at Lucide's 24px default and dwarfed the surrounding text.

Apply `size-icon-sm` to bring it in line with adjacent UI.

> Made on behalf of @aslilac with Coder Agents.