### PR TITLE
fix(site): reduce agents beta badge size from sm to xs

### DIFF
--- a/site/src/components/FeatureStageBadge/FeatureStageBadge.stories.tsx
+++ b/site/src/components/FeatureStageBadge/FeatureStageBadge.stories.tsx
@@ -12,6 +12,13 @@ const meta: Meta<typeof FeatureStageBadge> = {
 export default meta;
 type Story = StoryObj<typeof FeatureStageBadge>;
 
+export const ExtraSmallBeta: Story = {
+	args: {
+		size: "xs",
+		contentType: "beta",
+	},
+};
+
 export const SmallBeta: Story = {
 	args: {
 		size: "sm",

--- a/site/src/components/FeatureStageBadge/FeatureStageBadge.tsx
+++ b/site/src/components/FeatureStageBadge/FeatureStageBadge.tsx
@@ -21,7 +21,7 @@ type FeatureStageBadgeProps = Readonly<
 	Omit<HTMLAttributes<HTMLSpanElement>, "children"> & {
 		contentType: keyof typeof featureStageBadgeTypes;
 		labelText?: string;
-		size?: "sm" | "md";
+		size?: "xs" | "sm" | "md";
 	}
 >;
 
@@ -31,6 +31,7 @@ const badgeColorClasses = {
 } as const;
 
 const badgeSizeClasses = {
+	xs: "text-2xs font-normal px-1.5 py-0.5 h-[18px] rounded border-0",
 	sm: "text-xs font-medium px-2 py-1",
 	md: "text-base px-2 py-1",
 } as const;

--- a/site/src/pages/AgentsPage/components/AgentPageHeader.tsx
+++ b/site/src/pages/AgentsPage/components/AgentPageHeader.tsx
@@ -133,7 +133,7 @@ export const AgentPageHeader: FC<AgentPageHeaderProps> = ({
 					<NavLink to="/workspaces" className="inline-flex">
 						<ProductLogo className="size-6" />
 					</NavLink>
-					<FeatureStageBadge contentType="beta" size="sm" />
+					<FeatureStageBadge contentType="beta" size="xs" />
 				</div>
 			)}
 			{isSidebarCollapsed && (

--- a/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/AgentsSidebar.tsx
@@ -1085,7 +1085,7 @@ export const AgentsSidebar: FC<AgentsSidebarProps> = (props) => {
 							<NavLink to="/workspaces" className="inline-flex">
 								<ProductLogo className="size-6" />
 							</NavLink>
-							<FeatureStageBadge contentType="beta" size="sm" />
+							<FeatureStageBadge contentType="beta" size="xs" />
 						</div>
 						<div className="flex items-center gap-0.5 -mr-1.5">
 							<Button


### PR DESCRIPTION
Reduces the beta badge size in the Coder Agents UI from `sm` to `xs` for better visual balance with the logo.

## Changes

- Added `xs` size variant to `FeatureStageBadge`, styled to match the existing `Badge` component's `xs` variant (`text-2xs`, `h-[18px]`, `border-0`, `rounded`)
- Updated both usages in `AgentPageHeader` (mobile) and `AgentsSidebar` (desktop) from `size="sm"` to `size="xs"`
- Added `ExtraSmallBeta` Storybook story for the new size

> Generated by Coder Agents