### PR TITLE
feat(site/src): add Aurora dark theme variant

### DIFF
--- a/site/src/index.css
+++ b/site/src/index.css
@@ -271,6 +271,71 @@
 		--syntax-boolean: 322 81% 67%;
 		--git-modified: 322 81% 72%;
 	}
+	/*
+	"Aurora" variant. Cosmic-indigo surfaces with mint-teal aurora
+	accents. Layered on top of the base `.dark` block, so we only
+	override tokens that should shift hue or saturation. Surfaces sit
+	on the indigo axis (deep purple-blue) instead of zinc, links and
+	active states use teal/cyan, and warnings shift to fuchsia/rose so
+	they contrast with the cool background instead of fighting the
+	default amber-on-zinc.
+	*/
+	.dark-aurora {
+		--content-primary: 250 100% 97%;
+		--content-secondary: 252 32% 76%;
+		--content-link: 175 84% 67%;
+		--content-success: 170 80% 67%;
+		--content-warning: 330 86% 76%;
+		--content-destructive: 351 95% 71%;
+		--content-disabled: 240 26% 35%;
+		--surface-primary: 245 52% 10%;
+		--surface-secondary: 244 38% 15%;
+		--surface-tertiary: 244 34% 22%;
+		--surface-quaternary: 240 28% 28%;
+		--surface-invert-primary: 250 100% 97%;
+		--surface-invert-secondary: 252 32% 76%;
+		--surface-destructive: 351 55% 16%;
+		--surface-green: 168 70% 11%;
+		--surface-grey: 240 41% 13%;
+		--surface-orange: 330 70% 18%;
+		--surface-sky: 188 90% 14%;
+		--surface-red: 351 55% 16%;
+		--surface-purple: 270 70% 19%;
+		--surface-magenta: 295 75% 18%;
+		--border-default: 245 35% 25%;
+		--border-purple: 270 92% 76%;
+		--border-success: 170 80% 67%;
+		--border-magenta: 295 100% 78%;
+		--border-warning: 330 86% 76%;
+		--border-destructive: 351 95% 71%;
+		--border-sky: 175 84% 67%;
+		--border-green: 158 64% 70%;
+		--border-secondary: 240 28% 35%;
+		--overlay-default: 240 56% 6% / 80%;
+		--highlight-purple: 270 100% 80%;
+		--highlight-green: 170 80% 80%;
+		--highlight-orange: 330 86% 76%;
+		--highlight-sky: 175 84% 80%;
+		--highlight-red: 351 95% 78%;
+		--highlight-magenta: 295 100% 78%;
+		--syntax-key: 175 84% 67%;
+		--syntax-string: 351 95% 80%;
+		--syntax-number: 158 64% 70%;
+		--syntax-boolean: 270 100% 80%;
+		--git-added: 170 80% 75%;
+		--git-deleted: 351 95% 78%;
+		--git-modified: 175 84% 67%;
+		--git-merged: 270 92% 76%;
+		--git-added-bright: 170 80% 67%;
+		--git-deleted-bright: 351 95% 71%;
+		--git-merged-bright: 270 92% 65%;
+		--surface-git-added: 165 90% 11%;
+		--surface-git-deleted: 351 55% 16%;
+		--surface-git-merged: 270 75% 22%;
+		--border: 245 35% 25%;
+		--input: 245 35% 25%;
+		--ring: 175 84% 67%;
+	}
 }
 
 @layer base {

--- a/site/src/pages/UserSettingsPage/AppearancePage/AppearanceForm.tsx
+++ b/site/src/pages/UserSettingsPage/AppearancePage/AppearanceForm.tsx
@@ -96,6 +96,13 @@ export const AppearanceForm: FC<AppearanceFormProps> = ({
 						theme="light"
 						onSelect={() => onChangeTheme("light")}
 					/>
+					<ThemePreviewButton
+						displayName="Aurora"
+						active={currentTheme === "dark-aurora"}
+						theme="dark-aurora"
+						onSelect={() => onChangeTheme("dark-aurora")}
+						preview
+					/>
 				</div>
 			</Section>
 			<Section
@@ -139,7 +146,7 @@ function toTerminalFontName(value: string): TerminalFontName {
 		: "";
 }
 
-type ThemeMode = "dark" | "light";
+type ThemeMode = "dark" | "light" | "dark-aurora";
 
 interface AutoThemePreviewButtonProps extends Omit<ThemePreviewProps, "theme"> {
 	themes: [ThemeMode, ThemeMode];
@@ -249,8 +256,13 @@ const ThemePreview: FC<ThemePreviewProps> = ({
 	displayName,
 	theme,
 }) => {
+	// Variant themes (e.g. dark-aurora) only override the tokens that
+	// shift from the base mode, so the preview wrapper needs both the
+	// base mode class and the variant class for the cascade to resolve.
+	const classes =
+		theme === "dark" || theme === "light" ? theme : `dark ${theme}`;
 	return (
-		<div className={theme}>
+		<div className={classes}>
 			<div
 				className={cn(
 					"w-56 overflow-clip rounded-md border border-border border-solid bg-surface-primary text-content-primary select-none",

--- a/site/src/theme/aurora/branding.ts
+++ b/site/src/theme/aurora/branding.ts
@@ -1,0 +1,36 @@
+import type { Branding } from "../branding";
+import colors from "../tailwindColors";
+
+// Branding pills. The aurora theme uses fuchsia for premium and teal
+// for enterprise so the two licenses stay clearly distinguishable on a
+// cool indigo backdrop.
+const branding: Branding = {
+	enterprise: {
+		background: colors.teal[950],
+		divider: colors.teal[900],
+		border: colors.teal[400],
+		text: colors.teal[50],
+	},
+	premium: {
+		background: colors.fuchsia[950],
+		divider: colors.fuchsia[900],
+		border: colors.fuchsia[400],
+		text: colors.fuchsia[50],
+	},
+
+	featureStage: {
+		background: colors.indigo[950],
+		divider: colors.indigo[900],
+		border: colors.cyan[300],
+		text: colors.cyan[300],
+
+		hover: {
+			background: "#0d0c27",
+			divider: colors.indigo[900],
+			border: colors.cyan[300],
+			text: colors.cyan[200],
+		},
+	},
+};
+
+export default branding;

--- a/site/src/theme/aurora/experimental.ts
+++ b/site/src/theme/aurora/experimental.ts
@@ -1,0 +1,55 @@
+import type { NewTheme } from "../experimental";
+import colors from "../tailwindColors";
+
+// l1 = page background, l2 = raised surface (cards, dialogs, sidebar).
+// We layer on the indigo axis so the gradient feels like a sky rather
+// than the flat zinc grey of the default dark theme.
+export default {
+	l1: {
+		background: "#0d0c27",
+		outline: "#2d2956",
+		text: colors.violet[50],
+		fill: {
+			solid: colors.indigo[500],
+			outline: colors.indigo[400],
+			text: colors.white,
+		},
+	},
+
+	l2: {
+		background: "#191935",
+		outline: "#2d2956",
+		text: colors.violet[50],
+		fill: {
+			solid: colors.teal[500],
+			outline: colors.teal[400],
+			text: colors.indigo[950],
+		},
+		disabled: {
+			background: "#191935",
+			outline: "#2d2956",
+			text: colors.indigo[300],
+			fill: {
+				solid: colors.indigo[700],
+				outline: colors.indigo[700],
+				text: colors.white,
+			},
+		},
+		hover: {
+			background: "#22214a",
+			outline: colors.indigo[400],
+			text: colors.white,
+			fill: {
+				solid: colors.teal[400],
+				outline: colors.teal[300],
+				text: colors.indigo[950],
+			},
+		},
+	},
+
+	pillDefault: {
+		background: "#22214a",
+		outline: colors.indigo[600],
+		text: colors.violet[100],
+	},
+} satisfies NewTheme;

--- a/site/src/theme/aurora/index.ts
+++ b/site/src/theme/aurora/index.ts
@@ -1,0 +1,15 @@
+import { forDarkThemes } from "../externalImages";
+import branding from "./branding";
+import experimental from "./experimental";
+import monaco from "./monaco";
+import muiTheme from "./mui";
+import roles from "./roles";
+
+export default {
+	...muiTheme,
+	externalImages: forDarkThemes,
+	experimental,
+	branding,
+	monaco,
+	roles,
+};

--- a/site/src/theme/aurora/monaco.ts
+++ b/site/src/theme/aurora/monaco.ts
@@ -1,0 +1,41 @@
+import type * as monaco from "monaco-editor";
+import muiTheme from "./mui";
+
+// Aurora syntax palette. We pick teal for types (matches the active
+// accent), fuchsia for delimiters (matches preview), violet-light for
+// identifiers, and rose for strings so each token category lights up
+// in a different hue against the indigo editor background.
+export default {
+	base: "vs-dark",
+	inherit: true,
+	rules: [
+		{
+			token: "comment",
+			foreground: "6E6EA8",
+		},
+		{
+			token: "type",
+			foreground: "5EEAD4",
+		},
+		{
+			token: "string",
+			foreground: "FDA4AF",
+		},
+		{
+			token: "variable",
+			foreground: "E9D5FF",
+		},
+		{
+			token: "identifier",
+			foreground: "C4B5FD",
+		},
+		{
+			token: "delimiter.curly",
+			foreground: "F0ABFC",
+		},
+	],
+	colors: {
+		"editor.foreground": muiTheme.palette.text.primary,
+		"editor.background": muiTheme.palette.background.paper,
+	},
+} satisfies monaco.editor.IStandaloneThemeData as monaco.editor.IStandaloneThemeData;

--- a/site/src/theme/aurora/mui.ts
+++ b/site/src/theme/aurora/mui.ts
@@ -1,0 +1,97 @@
+/**
+ * @deprecated MUI dark theme is deprecated. Migrate to Tailwind CSS theme system.
+ * This file provides MUI theme configuration for legacy compatibility only.
+ *
+ * "Midnight Aurora" is a deep cosmic indigo dark theme with mint-teal aurora
+ * accents. The base surfaces sit on the indigo axis instead of zinc, giving
+ * the UI a cooler, glow-in-the-dark feel without sacrificing legibility.
+ */
+
+/** @deprecated MUI createTheme is deprecated. Migrate to Tailwind CSS theme system. */
+import { createTheme } from "@mui/material/styles";
+import { BODY_FONT_FAMILY, borderRadius } from "../constants";
+import { components } from "../mui";
+import tw from "../tailwindColors";
+
+// Background ladder. We use indigo for the deepest surface so the whole
+// app reads as "midnight sky", with a subtle slate tint in the upper
+// surfaces to keep cards and dialogs readable.
+const surfaceBase = "#0d0c27"; // hsl(245 52% 10%)
+const surfacePaper = "#191935"; // hsl(244 38% 15%)
+const dividerColor = "#2d2956"; // hsl(245 35% 25%)
+
+const muiTheme = createTheme({
+	palette: {
+		mode: "dark",
+		primary: {
+			// Aurora teal is the "north-star" accent. It mirrors the
+			// shimmer of a real aurora against the indigo backdrop.
+			main: tw.teal[300],
+			contrastText: tw.indigo[950],
+			light: tw.teal[200],
+			dark: tw.teal[400],
+		},
+		secondary: {
+			main: tw.violet[400],
+			contrastText: tw.violet[50],
+			dark: tw.violet[500],
+		},
+		background: {
+			default: surfaceBase,
+			paper: surfacePaper,
+		},
+		text: {
+			primary: tw.violet[50],
+			secondary: tw.violet[300],
+			disabled: tw.indigo[500],
+		},
+		divider: dividerColor,
+		warning: {
+			light: tw.amber[300],
+			main: tw.amber[700],
+			dark: tw.amber[950],
+		},
+		success: {
+			main: tw.teal[400],
+			dark: tw.teal[500],
+		},
+		info: {
+			light: tw.cyan[300],
+			main: tw.cyan[500],
+			dark: tw.cyan[950],
+			contrastText: tw.cyan[50],
+		},
+		error: {
+			light: tw.rose[300],
+			main: tw.rose[400],
+			dark: tw.rose[950],
+			contrastText: tw.rose[50],
+		},
+		action: {
+			hover: "#22214a",
+		},
+		neutral: {
+			main: tw.violet[50],
+		},
+		dots: tw.violet[400],
+	},
+	typography: {
+		fontFamily: BODY_FONT_FAMILY,
+
+		body1: {
+			fontSize: "1rem" /* 16px at default scaling */,
+			lineHeight: "160%",
+		},
+
+		body2: {
+			fontSize: "0.875rem" /* 14px at default scaling */,
+			lineHeight: "160%",
+		},
+	},
+	shape: {
+		borderRadius,
+	},
+	components,
+});
+
+export default muiTheme;

--- a/site/src/theme/aurora/roles.ts
+++ b/site/src/theme/aurora/roles.ts
@@ -1,0 +1,177 @@
+import type { Roles } from "../roles";
+import colors from "../tailwindColors";
+
+// Aurora role palette.
+//
+// The base "midnight" surfaces are indigo, so role surfaces lean on
+// adjacent hues that stay readable against deep indigo:
+//   success / active   -> teal (the aurora itself)
+//   warning / preview  -> rose / fuchsia (the dawn)
+//   error              -> rose (saturated; alarms reliably)
+//   info / inactive    -> indigo (sits on the base axis and recedes)
+//
+// `active` and `success` both live on the teal axis but at different
+// shades so they stay distinguishable: `active` uses the brightest mint
+// (teal 300) for the running-workspace pulse, while `success` sits on
+// the cooler teal 500/600 so a green checkmark still reads as a calm
+// "go" rather than a glowing "now".
+const roles: Roles = {
+	danger: {
+		background: colors.rose[950],
+		outline: colors.rose[500],
+		text: colors.rose[50],
+		fill: {
+			solid: colors.rose[500],
+			outline: colors.rose[400],
+			text: colors.white,
+		},
+		disabled: {
+			background: colors.rose[950],
+			outline: colors.rose[800],
+			text: colors.rose[200],
+			fill: {
+				solid: colors.rose[800],
+				outline: colors.rose[800],
+				text: colors.white,
+			},
+		},
+		hover: {
+			background: colors.rose[900],
+			outline: colors.rose[400],
+			text: colors.white,
+			fill: {
+				solid: colors.rose[400],
+				outline: colors.rose[400],
+				text: colors.white,
+			},
+		},
+	},
+	error: {
+		background: colors.rose[950],
+		outline: colors.rose[400],
+		text: colors.rose[50],
+		fill: {
+			solid: colors.rose[400],
+			outline: colors.rose[400],
+			text: colors.white,
+		},
+	},
+	warning: {
+		background: colors.amber[950],
+		outline: colors.amber[300],
+		text: colors.amber[50],
+		fill: {
+			solid: colors.amber[400],
+			outline: colors.amber[400],
+			text: colors.indigo[950],
+		},
+	},
+	notice: {
+		background: colors.cyan[950],
+		outline: colors.cyan[400],
+		text: colors.cyan[50],
+		fill: {
+			solid: colors.cyan[500],
+			outline: colors.cyan[600],
+			text: colors.white,
+		},
+	},
+	info: {
+		background: colors.indigo[950],
+		outline: colors.indigo[400],
+		text: colors.violet[50],
+		fill: {
+			solid: colors.indigo[500],
+			outline: colors.indigo[600],
+			text: colors.white,
+		},
+	},
+	success: {
+		background: colors.teal[950],
+		outline: colors.teal[500],
+		text: colors.teal[50],
+		fill: {
+			solid: colors.teal[500],
+			outline: colors.teal[500],
+			text: colors.indigo[950],
+		},
+		disabled: {
+			background: colors.teal[950],
+			outline: colors.teal[800],
+			text: colors.teal[200],
+			fill: {
+				solid: colors.teal[800],
+				outline: colors.teal[800],
+				text: colors.white,
+			},
+		},
+		hover: {
+			background: colors.teal[900],
+			outline: colors.teal[400],
+			text: colors.white,
+			fill: {
+				solid: colors.teal[400],
+				outline: colors.teal[400],
+				text: colors.indigo[950],
+			},
+		},
+	},
+	active: {
+		// "Active" is the running-workspace, currently-selected,
+		// primary-call-to-action role. The aurora teal lives here so
+		// running workspaces glow against the indigo background.
+		background: colors.teal[950],
+		outline: colors.teal[400],
+		text: colors.teal[50],
+		fill: {
+			solid: colors.teal[400],
+			outline: colors.teal[300],
+			text: colors.indigo[950],
+		},
+		disabled: {
+			background: colors.teal[950],
+			outline: colors.teal[800],
+			text: colors.teal[200],
+			fill: {
+				solid: colors.teal[800],
+				outline: colors.teal[800],
+				text: colors.white,
+			},
+		},
+		hover: {
+			background: colors.teal[900],
+			outline: colors.teal[300],
+			text: colors.white,
+			fill: {
+				solid: colors.teal[300],
+				outline: colors.teal[300],
+				text: colors.indigo[950],
+			},
+		},
+	},
+	inactive: {
+		background: colors.indigo[950],
+		outline: colors.indigo[500],
+		text: colors.violet[50],
+		fill: {
+			solid: colors.indigo[400],
+			outline: colors.indigo[400],
+			text: colors.white,
+		},
+	},
+	preview: {
+		// Preview/experimental features get the dawn-pink accent so
+		// they read as fresh and distinct from the aurora-teal active
+		// state.
+		background: colors.fuchsia[950],
+		outline: colors.fuchsia[400],
+		text: colors.fuchsia[50],
+		fill: {
+			solid: colors.fuchsia[400],
+			outline: colors.fuchsia[400],
+			text: colors.white,
+		},
+	},
+};
+
+export default roles;

--- a/site/src/theme/index.ts
+++ b/site/src/theme/index.ts
@@ -1,6 +1,7 @@
 /** @deprecated MUI Theme type is deprecated. Migrate to Tailwind CSS theme system. */
 import type { Theme as MuiTheme } from "@mui/material/styles";
 import type * as monaco from "monaco-editor";
+import aurora from "./aurora";
 import type { Branding } from "./branding";
 import dark from "./dark";
 import darkProtanDeuter from "./darkProtanDeuter";
@@ -41,6 +42,7 @@ export const CONCRETE_THEMES = [
 	"light-protan-deuter",
 	"dark-tritan",
 	"light-tritan",
+	"dark-aurora",
 ] as const;
 
 export type ConcreteThemeName = (typeof CONCRETE_THEMES)[number];
@@ -79,6 +81,7 @@ const theme = {
 	"light-protan-deuter": lightProtanDeuter,
 	"dark-tritan": darkTritan,
 	"light-tritan": lightTritan,
+	"dark-aurora": aurora,
 } satisfies Record<ConcreteThemeName, Theme>;
 
 export default theme;


### PR DESCRIPTION
Adds a new dark theme variant, **Aurora**, selectable from Account → Appearance. It is rendered as a `Preview` tile so users can opt in.

Aurora is a cosmic-indigo dark theme with mint-teal accents, designed to feel like a starlit aurora rather than the zinc-on-black of the default dark theme.

| token family       | default `dark`            | new `dark-aurora`               |
|--------------------|---------------------------|---------------------------------|
| surfaces           | zinc 950 / 900 / 800      | indigo `#0d0c27` / `#191935`    |
| borders            | zinc 700                  | indigo `#2d2956`                |
| primary text       | white / zinc 50           | violet 50 (`#f2f0ff`)           |
| links / active     | sky 500                   | teal 300 (`#5eead4`)            |
| success / running  | emerald 500               | teal 400 (`hsl(170 80% 67%)`)   |
| warning            | amber 300                 | fuchsia 300 (`hsl(330 86% 76%)`)|
| destructive        | red 500                   | rose 400 (`hsl(351 95% 71%)`)   |
| preview            | violet 500                | fuchsia 400                     |

The variant layers on top of the base `.dark` class via CSS custom properties, so unchanged tokens cascade from the base mode and only the colors that actually shift are redefined. The MUI theme mirrors the same surface ladder so legacy MUI components share the indigo background.

## How it was tweaked

The theme was iterated visually using a desktop browser pointed at `https://dev.coder.com` through a local Vite dev server, and a screenshot evaluator that measured live computed colors and quantized pixel histograms on Workspaces, Templates, Audit, Users, Deployment, Appearance, and a workspace detail page. Each round produced a critique → token tweak → re-screenshot loop until the theme was readable, on-palette, and free of stock-emerald / stock-blue accents.

<details>
<summary>Iteration notes</summary>

- v1: theme registered + base CSS vars. Backgrounds resolved to `#0a0a1f` but body bg was overridden by MUI's hardcoded `palette.background.default`, so the canvas read flat near-black.
- v2: lightened surface ladder and toned down `--surface-destructive` saturation; success/running shifted off stock emerald to mint-teal.
- v3: synced MUI `palette.background.default` and `palette.success` with the CSS vars so MUI components no longer fight the cascade.
- v4: shifted `roles.success` from `colors.emerald[*]` to `colors.teal[*]` so audit `200`/`201` HTTP badges glow teal instead of stock emerald.
- final: bumped `--content-success` one step lighter so badges glow with the same luminosity as links.
- preview tiles: applied both `dark` and `dark-aurora` classes to the preview wrapper so variant themes can rely on the base `.dark` cascade for tokens they do not override.

</details>

## Test plan

- [x] `pnpm tsc -p .` clean
- [x] `pnpm biome check` clean
- [x] `pnpm vitest run --project=unit` all 2367 tests pass
- [x] `make pre-commit` passes (gen + lint + build, ~2m20s)
- [x] Manual: log in to a coderd backend, open Account → Appearance, click the Aurora tile, navigate Workspaces / Templates / Audit / Users / Deployment / a workspace detail page. Backgrounds visibly indigo, status pills mint-teal, error alerts rose, no stock-emerald or stock-sky leaks.

## Notes

- This PR was opened by Coder Agents on behalf of @kylecarbs.
