### PR TITLE
feat(site): show workspace quota failures in chats

### DIFF
--- a/site/src/modules/workspaces/WorkspaceBuildLogs/WorkspaceBuildLogs.tsx
+++ b/site/src/modules/workspaces/WorkspaceBuildLogs/WorkspaceBuildLogs.tsx
@@ -106,7 +106,7 @@ export const WorkspaceBuildLogs: FC<WorkspaceBuildLogsProps> = ({
 						</div>
 						{!isEmpty && (
 							<Logs
-								className="border-b-border"
+								className="min-h-0 border-b-border"
 								hideTimestamps={hideTimestamps}
 								lines={lines}
 							/>

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/CreateWorkspaceTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/CreateWorkspaceTool.tsx
@@ -30,7 +30,7 @@ export const CreateWorkspaceTool: React.FC<{
 	errorMessage?: string;
 	buildId?: string;
 	created?: boolean;
-	quotaTitle?: string;
+	labelOverride?: string;
 }> = ({
 	workspaceName,
 	resultJson,
@@ -39,7 +39,7 @@ export const CreateWorkspaceTool: React.FC<{
 	errorMessage,
 	buildId,
 	created = true,
-	quotaTitle,
+	labelOverride,
 }) => {
 	const isRunning = status === "running";
 	let rec: Record<string, unknown> | null = null;
@@ -58,8 +58,8 @@ export const CreateWorkspaceTool: React.FC<{
 
 	const label = isRunning
 		? "Creating workspace…"
-		: quotaTitle
-			? quotaTitle
+		: labelOverride
+			? labelOverride
 			: isError
 				? `Failed to create ${wsName || "workspace"}`
 				: created === false

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/CreateWorkspaceTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/CreateWorkspaceTool.tsx
@@ -30,7 +30,7 @@ export const CreateWorkspaceTool: React.FC<{
 	errorMessage?: string;
 	buildId?: string;
 	created?: boolean;
-	quotaFailure?: { title: string; message: string };
+	quotaTitle?: string;
 }> = ({
 	workspaceName,
 	resultJson,
@@ -39,7 +39,7 @@ export const CreateWorkspaceTool: React.FC<{
 	errorMessage,
 	buildId,
 	created = true,
-	quotaFailure,
+	quotaTitle,
 }) => {
 	const isRunning = status === "running";
 	let rec: Record<string, unknown> | null = null;
@@ -58,8 +58,8 @@ export const CreateWorkspaceTool: React.FC<{
 
 	const label = isRunning
 		? "Creating workspace…"
-		: quotaFailure
-			? quotaFailure.title
+		: quotaTitle
+			? quotaTitle
 			: isError
 				? `Failed to create ${wsName || "workspace"}`
 				: created === false

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/CreateWorkspaceTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/CreateWorkspaceTool.tsx
@@ -30,6 +30,7 @@ export const CreateWorkspaceTool: React.FC<{
 	errorMessage?: string;
 	buildId?: string;
 	created?: boolean;
+	quotaFailure?: { title: string; message: string };
 }> = ({
 	workspaceName,
 	resultJson,
@@ -38,6 +39,7 @@ export const CreateWorkspaceTool: React.FC<{
 	errorMessage,
 	buildId,
 	created = true,
+	quotaFailure,
 }) => {
 	const isRunning = status === "running";
 	let rec: Record<string, unknown> | null = null;
@@ -56,13 +58,15 @@ export const CreateWorkspaceTool: React.FC<{
 
 	const label = isRunning
 		? "Creating workspace…"
-		: isError
-			? `Failed to create ${wsName || "workspace"}`
-			: created === false
-				? `Workspace ${wsName} already exists`
-				: wsName
-					? `Created ${wsName}`
-					: "Created workspace";
+		: quotaFailure
+			? quotaFailure.title
+			: isError
+				? `Failed to create ${wsName || "workspace"}`
+				: created === false
+					? `Workspace ${wsName} already exists`
+					: wsName
+						? `Created ${wsName}`
+						: "Created workspace";
 
 	const hasBuildLogs = isRunning || Boolean(buildId);
 

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/StartWorkspaceTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/StartWorkspaceTool.tsx
@@ -16,6 +16,7 @@ interface StartWorkspaceToolProps {
 	isError: boolean;
 	errorMessage?: string;
 	noBuild?: boolean;
+	quotaFailure?: { title: string; message: string };
 }
 
 export const StartWorkspaceTool: FC<StartWorkspaceToolProps> = ({
@@ -25,16 +26,19 @@ export const StartWorkspaceTool: FC<StartWorkspaceToolProps> = ({
 	isError,
 	errorMessage,
 	noBuild,
+	quotaFailure,
 }) => {
 	const isRunning = status === "running";
 
 	const label = isRunning
 		? "Starting workspace…"
-		: isError
-			? `Failed to start ${workspaceName || "workspace"}`
-			: workspaceName
-				? `Started ${workspaceName}`
-				: "Started workspace";
+		: quotaFailure
+			? quotaFailure.title
+			: isError
+				? `Failed to start ${workspaceName || "workspace"}`
+				: workspaceName
+					? `Started ${workspaceName}`
+					: "Started workspace";
 
 	const header = (
 		<>

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/StartWorkspaceTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/StartWorkspaceTool.tsx
@@ -16,7 +16,7 @@ interface StartWorkspaceToolProps {
 	isError: boolean;
 	errorMessage?: string;
 	noBuild?: boolean;
-	quotaFailure?: { title: string; message: string };
+	quotaTitle?: string;
 }
 
 export const StartWorkspaceTool: FC<StartWorkspaceToolProps> = ({
@@ -26,14 +26,14 @@ export const StartWorkspaceTool: FC<StartWorkspaceToolProps> = ({
 	isError,
 	errorMessage,
 	noBuild,
-	quotaFailure,
+	quotaTitle,
 }) => {
 	const isRunning = status === "running";
 
 	const label = isRunning
 		? "Starting workspace…"
-		: quotaFailure
-			? quotaFailure.title
+		: quotaTitle
+			? quotaTitle
 			: isError
 				? `Failed to start ${workspaceName || "workspace"}`
 				: workspaceName

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/StartWorkspaceTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/StartWorkspaceTool.tsx
@@ -16,7 +16,7 @@ interface StartWorkspaceToolProps {
 	isError: boolean;
 	errorMessage?: string;
 	noBuild?: boolean;
-	quotaTitle?: string;
+	labelOverride?: string;
 }
 
 export const StartWorkspaceTool: FC<StartWorkspaceToolProps> = ({
@@ -26,14 +26,14 @@ export const StartWorkspaceTool: FC<StartWorkspaceToolProps> = ({
 	isError,
 	errorMessage,
 	noBuild,
-	quotaTitle,
+	labelOverride,
 }) => {
 	const isRunning = status === "running";
 
 	const label = isRunning
 		? "Starting workspace…"
-		: quotaTitle
-			? quotaTitle
+		: labelOverride
+			? labelOverride
 			: isError
 				? `Failed to start ${workspaceName || "workspace"}`
 				: workspaceName

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
@@ -1999,6 +1999,41 @@ export const StartWorkspaceBuildFailed: Story = {
 	},
 };
 
+export const StartWorkspaceQuotaReached: Story = {
+	args: {
+		name: "start_workspace",
+		status: "completed",
+		result: {
+			error_code: "INSUFFICIENT_QUOTA",
+			error: "workspace start build failed: insufficient quota",
+			title: "Workspace quota reached",
+			message:
+				"Coder could not start this workspace because your workspace quota is full.",
+			build_id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+			quota: {
+				credits_consumed: 40,
+				budget: 40,
+			},
+		},
+	},
+	parameters: {
+		queries: [
+			{
+				key: [
+					"workspaceBuilds",
+					"a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+					"logs",
+				],
+				data: [],
+			},
+		],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByText("Workspace quota reached")).toBeInTheDocument();
+	},
+};
+
 // ---------------------------------------------------------------------------
 // create_workspace stories
 // ---------------------------------------------------------------------------
@@ -2060,6 +2095,41 @@ export const CreateWorkspaceCompleted: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		expect(canvas.getByText("Created my-project")).toBeInTheDocument();
+	},
+};
+
+export const CreateWorkspaceQuotaReached: Story = {
+	args: {
+		name: "create_workspace",
+		status: "completed",
+		result: {
+			error_code: "INSUFFICIENT_QUOTA",
+			error: "workspace build failed: insufficient quota",
+			title: "Workspace quota reached",
+			message:
+				"Coder could not create this workspace because your workspace quota is full.",
+			build_id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+			quota: {
+				credits_consumed: 40,
+				budget: 40,
+			},
+		},
+	},
+	parameters: {
+		queries: [
+			{
+				key: [
+					"workspaceBuilds",
+					"a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+					"logs",
+				],
+				data: [],
+			},
+		],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByText("Workspace quota reached")).toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
@@ -168,6 +168,38 @@ const parseAskUserQuestions = (value: unknown): AskUserQuestion[] | null => {
 	return questions;
 };
 
+const insufficientQuotaErrorCode = "INSUFFICIENT_QUOTA";
+
+interface WorkspaceQuotaFailureDetails {
+	title: string;
+	message: string;
+}
+
+const parseWorkspaceQuotaFailure = (
+	rec: Record<string, unknown> | null,
+): WorkspaceQuotaFailureDetails | undefined => {
+	if (!rec || asString(rec.error_code) !== insufficientQuotaErrorCode) {
+		return undefined;
+	}
+
+	const quota = asRecord(rec.quota);
+	const creditsConsumed = quota
+		? asNumber(quota.credits_consumed, { parseString: true })
+		: undefined;
+	const budget = quota
+		? asNumber(quota.budget, { parseString: true })
+		: undefined;
+	const message =
+		creditsConsumed !== undefined && budget !== undefined
+			? `You're using ${creditsConsumed.toLocaleString("en-US")} of ${budget.toLocaleString("en-US")} workspace ${budget === 1 ? "credit" : "credits"}.`
+			: asString(rec.message).trim() ||
+				"Coder could not create this workspace because your workspace quota is full.";
+	return {
+		title: asString(rec.title).trim() || "Workspace quota reached",
+		message,
+	};
+};
+
 const parseAskUserQuestionResult = (
 	result: unknown,
 ): AskUserQuestion[] | null => {
@@ -430,6 +462,7 @@ const CreateWorkspaceRenderer: FC<ToolRendererProps> = ({
 	const resultJson = rec ? JSON.stringify(rec, null, 2) : "";
 	const hasErrorInResult = Boolean(rec?.error);
 	const created = rec?.created !== false;
+	const quotaFailure = parseWorkspaceQuotaFailure(rec);
 
 	return (
 		<CreateWorkspaceTool
@@ -437,9 +470,13 @@ const CreateWorkspaceRenderer: FC<ToolRendererProps> = ({
 			resultJson={resultJson}
 			status={status}
 			isError={isError || hasErrorInResult}
-			errorMessage={rec ? asString(rec.error || rec.reason) : undefined}
+			errorMessage={
+				quotaFailure?.message ??
+				(rec ? asString(rec.error || rec.reason) : undefined)
+			}
 			buildId={buildId}
 			created={created}
+			quotaFailure={quotaFailure}
 		/>
 	);
 };
@@ -967,6 +1004,7 @@ const StartWorkspaceRenderer: FC<ToolRendererProps> = ({
 	const buildId = rec ? asString(rec.build_id) : undefined;
 	const hasErrorInResult = Boolean(rec?.error);
 	const noBuild = Boolean(rec?.no_build);
+	const quotaFailure = parseWorkspaceQuotaFailure(rec);
 
 	return (
 		<StartWorkspaceTool
@@ -974,8 +1012,12 @@ const StartWorkspaceRenderer: FC<ToolRendererProps> = ({
 			buildId={buildId}
 			workspaceName={wsName}
 			isError={isError || hasErrorInResult}
-			errorMessage={rec ? asString(rec.error || rec.reason) : undefined}
+			errorMessage={
+				quotaFailure?.message ??
+				(rec ? asString(rec.error || rec.reason) : undefined)
+			}
 			noBuild={noBuild}
+			quotaFailure={quotaFailure}
 		/>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
@@ -452,7 +452,7 @@ const CreateWorkspaceRenderer: FC<ToolRendererProps> = ({
 			errorMessage={rec ? asString(rec.error || rec.reason) : undefined}
 			buildId={buildId}
 			created={created}
-			quotaTitle={quotaTitle}
+			labelOverride={quotaTitle}
 		/>
 	);
 };
@@ -990,7 +990,7 @@ const StartWorkspaceRenderer: FC<ToolRendererProps> = ({
 			isError={isError || hasErrorInResult}
 			errorMessage={rec ? asString(rec.error || rec.reason) : undefined}
 			noBuild={noBuild}
-			quotaTitle={quotaTitle}
+			labelOverride={quotaTitle}
 		/>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
@@ -170,34 +170,13 @@ const parseAskUserQuestions = (value: unknown): AskUserQuestion[] | null => {
 
 const insufficientQuotaErrorCode = "INSUFFICIENT_QUOTA";
 
-interface WorkspaceQuotaFailureDetails {
-	title: string;
-	message: string;
-}
-
-const parseWorkspaceQuotaFailure = (
+const getWorkspaceQuotaTitle = (
 	rec: Record<string, unknown> | null,
-): WorkspaceQuotaFailureDetails | undefined => {
+): string | undefined => {
 	if (!rec || asString(rec.error_code) !== insufficientQuotaErrorCode) {
 		return undefined;
 	}
-
-	const quota = asRecord(rec.quota);
-	const creditsConsumed = quota
-		? asNumber(quota.credits_consumed, { parseString: true })
-		: undefined;
-	const budget = quota
-		? asNumber(quota.budget, { parseString: true })
-		: undefined;
-	const message =
-		creditsConsumed !== undefined && budget !== undefined
-			? `You're using ${creditsConsumed.toLocaleString("en-US")} of ${budget.toLocaleString("en-US")} workspace ${budget === 1 ? "credit" : "credits"}.`
-			: asString(rec.message).trim() ||
-				"Coder could not create this workspace because your workspace quota is full.";
-	return {
-		title: asString(rec.title).trim() || "Workspace quota reached",
-		message,
-	};
+	return asString(rec.title).trim() || "Workspace quota reached";
 };
 
 const parseAskUserQuestionResult = (
@@ -462,7 +441,7 @@ const CreateWorkspaceRenderer: FC<ToolRendererProps> = ({
 	const resultJson = rec ? JSON.stringify(rec, null, 2) : "";
 	const hasErrorInResult = Boolean(rec?.error);
 	const created = rec?.created !== false;
-	const quotaFailure = parseWorkspaceQuotaFailure(rec);
+	const quotaTitle = getWorkspaceQuotaTitle(rec);
 
 	return (
 		<CreateWorkspaceTool
@@ -470,13 +449,10 @@ const CreateWorkspaceRenderer: FC<ToolRendererProps> = ({
 			resultJson={resultJson}
 			status={status}
 			isError={isError || hasErrorInResult}
-			errorMessage={
-				quotaFailure?.message ??
-				(rec ? asString(rec.error || rec.reason) : undefined)
-			}
+			errorMessage={rec ? asString(rec.error || rec.reason) : undefined}
 			buildId={buildId}
 			created={created}
-			quotaFailure={quotaFailure}
+			quotaTitle={quotaTitle}
 		/>
 	);
 };
@@ -1004,7 +980,7 @@ const StartWorkspaceRenderer: FC<ToolRendererProps> = ({
 	const buildId = rec ? asString(rec.build_id) : undefined;
 	const hasErrorInResult = Boolean(rec?.error);
 	const noBuild = Boolean(rec?.no_build);
-	const quotaFailure = parseWorkspaceQuotaFailure(rec);
+	const quotaTitle = getWorkspaceQuotaTitle(rec);
 
 	return (
 		<StartWorkspaceTool
@@ -1012,12 +988,9 @@ const StartWorkspaceRenderer: FC<ToolRendererProps> = ({
 			buildId={buildId}
 			workspaceName={wsName}
 			isError={isError || hasErrorInResult}
-			errorMessage={
-				quotaFailure?.message ??
-				(rec ? asString(rec.error || rec.reason) : undefined)
-			}
+			errorMessage={rec ? asString(rec.error || rec.reason) : undefined}
 			noBuild={noBuild}
-			quotaFailure={quotaFailure}
+			quotaTitle={quotaTitle}
 		/>
 	);
 };


### PR DESCRIPTION
Create and start workspace tool cards now recognize `INSUFFICIENT_QUOTA` results and use the server-provided quota failure title in the build-log dropdown. The existing warning icon and tooltip remain, while the assistant response remains the place for the detailed recovery guidance.

Adds Storybook coverage for quota-reached create and start workspace results.

https://github.com/coder/coder/pull/24956 added the necessary backend changes.
<img width="897" height="505" alt="image" src="https://github.com/user-attachments/assets/6cab8798-393d-429f-a3c3-a8ed50402d42" />



Closes CODAGT-20
