### PR TITLE
fix(site/src/pages/CoderCupPage): prevent codernauts lander from getting stuck on narrow pads

### DIFF
--- a/site/src/pages/CoderCupPage/LunarLander.tsx
+++ b/site/src/pages/CoderCupPage/LunarLander.tsx
@@ -1141,11 +1141,6 @@ function tryLanding(
 	const pad = findPadAt(x, pads);
 	if (!pad) return null;
 
-	// Direction: a lander moving upward is taking off, not landing. Without
-	// this check the lander can get stuck on narrow pads when one foot hangs
-	// over the edge onto the rising adjacent terrain: every tiny lift-off is
-	// immediately treated as a fresh landing because the lander's centre is
-	// still over the pad.
 	if (vy < 0) return null;
 
 	// Orientation: must be roughly upright.

--- a/site/src/pages/CoderCupPage/LunarLander.tsx
+++ b/site/src/pages/CoderCupPage/LunarLander.tsx
@@ -1141,6 +1141,13 @@ function tryLanding(
 	const pad = findPadAt(x, pads);
 	if (!pad) return null;
 
+	// Direction: a lander moving upward is taking off, not landing. Without
+	// this check the lander can get stuck on narrow pads when one foot hangs
+	// over the edge onto the rising adjacent terrain: every tiny lift-off is
+	// immediately treated as a fresh landing because the lander's centre is
+	// still over the pad.
+	if (vy < 0) return null;
+
 	// Orientation: must be roughly upright.
 	if (Math.abs(normalizeAngle(angle)) > LANDING_ANGLE_TOL) return null;
 


### PR DESCRIPTION
Reported bug: in the Codernauts game, landing on a pickup pad sometimes leaves the lander stuck. Pressing the main thruster (↓) burns fuel but the ship does not lift off.

## Problem

`tryLanding` in `LunarLander.tsx` only checks that the lander's centre x is over a pad, that it is roughly upright, and that its speed is below `LANDING_MAX_SPEED`. The direction of motion is never checked.

The four pickup pads are 6%, 2.5%, 5.5%, and 3.5% of the play area wide (roughly 60, 25, 55, 35 px). The lander's footprint is 22 px wide. On the narrowest pad the player has only ~1.5 px of off-centre tolerance before a foot hangs off the pad edge. Codernauts spawn at random x positions on the pad, so the player typically aims slightly off-centre to align with the codernaut they are picking up.

The terrain immediately adjacent to a pad slopes upward fast (control points outside pads are placed in the upper half of the screen versus the lower half for pads). Just 0.1 px past a pad edge the surface can already be ~0.4 px above pad level.

When the player presses ↓ to take off:

1. Frame N: thrust adds `vy ≈ -0.83`, position rises ~0.014 px, `landed = false`.
2. Frame N+1: thrust + gravity, position rises another ~0.025 px, then `landerHitsTerrain` fires because the off-pad foot is now below the rising adjacent surface.
3. `tryLanding` sees `findPadAt(landerX)` still returns the pad, low speed, upright angle, and reports a successful landing.
4. State is reset: `vy = 0`, `landerY = pad.y - 8`, `landed = true`.
5. Loop forever. Fuel keeps draining; the lander does not move.

## Fix

Reject re-landings while the lander is moving upward. A craft with negative `vy` is taking off, not landing.

```ts
if (vy < 0) return null;
```

This also defends against a related quirk where a fast upward arc whose centre passes over a pad would currently register as a landing while still ascending.

<details>
<summary>Investigation notes</summary>

Reproduced numerically by replaying the game's terrain generation and physics with a fixed seed:

- Centred and ±1 px landings on the 25 px pad take off normally.
- ±2 px off-centre landings re-land 60 times in 120 frames; the lander never escapes.
- Wider pads (35, 55, 60 px) take off normally for all tested offsets.

The station pad is always promoted from the widest pad (lines 220-224), so off-centre landings rarely place a foot off the station. The station also refills fuel, which masks the issue further if it ever does occur there.

The minimal `vy < 0` guard is preferred over alternatives such as requiring all foot collision points to be inside pad bounds, because:

- It is one line and self-contained inside `tryLanding`.
- It does not change the safe-touchdown criteria for legitimate descents.
- It also fixes upward-arc-through-pad false landings.

</details>

Generated by Coder Agents on behalf of @jaayden.
