### PR TITLE
fix(site): clamp lander position on landing to keep feet on pad

### DIFF
--- a/site/src/pages/CoderCupPage/LunarLander.tsx
+++ b/site/src/pages/CoderCupPage/LunarLander.tsx
@@ -2137,6 +2137,14 @@ export const LunarLander: FC = () => {
 							landerAngle = 0;
 							thrusting = false;
 							landerY = pad.y - 8;
+							// Keep both feet (+-11px) on the pad so the
+							// lander cannot get stuck on the terrain slope
+							// at the pad edge on relaunch.
+							const footHalf = 11;
+							landerX = Math.max(
+								pad.x + footHalf,
+								Math.min(pad.x + pad.width - footHalf, landerX),
+							);
 							landedOnStation = pad.isStation;
 
 							if (pad.isStation) {


### PR DESCRIPTION
When the lander lands near the edge of a pad, its feet (+-11px from
center) can hang over the terrain slope. On relaunch the feet immediately
collide with the slope, trapping the lander in a land/relaunch loop.

Clamp `landerX` on touchdown so both feet stay within the pad bounds.

cc @DanielleMaywood for review

> [!NOTE]
> This PR was authored by Coder Agents.