### PR TITLE
chore: pin Docker 27 on dogfood Ubuntu 26.04 image

### DIFF
--- a/dogfood/coder/ubuntu-26.04/Dockerfile
+++ b/dogfood/coder/ubuntu-26.04/Dockerfile
@@ -183,6 +183,15 @@ RUN sed -i 's|http://archive.ubuntu.com/ubuntu/|http://mirrors.edge.kernel.org/u
 	zip \
 	zsh \
 	zstd && \
+	# Keep Docker's engine, CLI, runtime, and plugins on the versions selected by
+	# the apt pins copied above. Future apt operations in this image should not
+	# upgrade Docker 27 or containerd.io 1.7.23 out from under sysbox / DinD.
+	apt-mark hold \
+		containerd.io \
+		docker-buildx-plugin \
+		docker-ce \
+		docker-ce-cli \
+		docker-compose-plugin && \
 	# Delete package cache to avoid consuming space in layer
 	apt-get clean && \
 	# Configure FIPS-compliant policies

--- a/dogfood/coder/ubuntu-26.04/files/etc/apt/preferences.d/containerd
+++ b/dogfood/coder/ubuntu-26.04/files/etc/apt/preferences.d/containerd
@@ -1,6 +1,0 @@
-# Ref: https://github.com/nestybox/sysbox/issues/879
-# We need to pin containerd to a specific version to avoid breaking
-# Docker-in-Docker.
-Package: containerd.io
-Pin: version 1.7.23-1
-Pin-Priority: 1001

--- a/dogfood/coder/ubuntu-26.04/files/etc/apt/preferences.d/docker
+++ b/dogfood/coder/ubuntu-26.04/files/etc/apt/preferences.d/docker
@@ -1,23 +1,35 @@
-# Ignore all packages from this repository by default
+# Ignore all packages from this repository by default.
 Package: *
 Pin: origin download.docker.com
 Pin-Priority: 1
 
-# Docker Community Edition
-# We need to pin docker-ce to a specific version because containerd is pinned
-# to an older version. Newer major versions of docker-ce require a version of
-# containerd.io greater than our pinned version.
+# Docker Community Edition.
+# We need to pin docker-ce to Docker 27 because containerd is pinned to an
+# older version for sysbox / Docker-in-Docker compatibility. Docker 28 and newer
+# require containerd.io >= 1.7.27, but sysbox currently needs 1.7.23.
 Package: docker-ce
-Pin: origin download.docker.com
-Pin: version 5:29.*
-Pin-Priority: 500
+Pin: version 5:27.*
+Pin-Priority: 1001
 
-# Docker command-line tool
+# Docker command-line tool.
+# Keep the CLI on the same major line as the engine. docker-ce only depends on
+# docker-ce-cli without an exact version constraint, so leaving this unpinned can
+# cause apt to pair a Docker 27 engine with a newer CLI.
 Package: docker-ce-cli
-Pin: origin download.docker.com
-Pin-Priority: 500
+Pin: version 5:27.*
+Pin-Priority: 1001
 
-# containerd runtime
+# containerd runtime.
+# Ref: https://github.com/nestybox/sysbox/issues/879
+# We need to pin containerd to this specific version to avoid breaking
+# Docker-in-Docker. Keep this pin in the Docker preferences file so the Docker
+# engine and runtime constraints are maintained together.
 Package: containerd.io
+Pin: version 1.7.23-1
+Pin-Priority: 1001
+
+# Allow Docker plugins from Docker's repository, but keep the repository ignored
+# globally so unpinned Docker packages do not unexpectedly upgrade.
+Package: docker-buildx-plugin docker-compose-plugin
 Pin: origin download.docker.com
 Pin-Priority: 500

--- a/dogfood/coder/ubuntu-26.04/files/etc/apt/sources.list.d/docker.list
+++ b/dogfood/coder/ubuntu-26.04/files/etc/apt/sources.list.d/docker.list
@@ -1,1 +1,6 @@
-deb [signed-by=/usr/share/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu resolute stable
+# Intentionally use Docker's Ubuntu 22.04 (jammy) repository on this Ubuntu
+# 26.04 image. Docker's resolute repo no longer carries the Docker 27 packages
+# we need, and Docker 28+ requires containerd.io >= 1.7.27. We pin
+# containerd.io to 1.7.23 for sysbox / Docker-in-Docker compatibility, so the
+# older jammy repo is required until that constraint is removed.
+deb [signed-by=/usr/share/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu jammy stable


### PR DESCRIPTION
## Summary

- switch the Ubuntu 26.04 dogfood image to Docker's jammy apt repository so Docker 27 remains available
- pin `docker-ce` and `docker-ce-cli` to the Docker 27 line and keep `containerd.io` pinned to `1.7.23-1`
- fold the containerd pin into the Docker preferences file, remove the duplicate containerd preferences file, and hold the installed Docker packages in the image

## Notes

Docker 28+ requires `containerd.io >= 1.7.27`, but sysbox / Docker-in-Docker currently requires `containerd.io=1.7.23-1`, so the image needs the older Docker 27 packages from the jammy repo.

## Testing

- Not run locally; verified the branch diff only.