### PR TITLE
fix(coderd/x/chatd): wait long enough for cold-start workspace MCP discovery

### DIFF
--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -66,18 +66,9 @@ const (
 	planPathLookupTimeout        = 5 * time.Second
 	instructionCacheTTL          = 5 * time.Minute
 	workspaceDialValidationDelay = 5 * time.Second
-	// workspaceMCPDiscoveryTimeout bounds the per-turn HTTP call
-	// that asks the workspace agent for its MCP tools. The DB
-	// lookup and the dial that precede the call use the parent
-	// chat-turn context (the dial has its own internal
-	// dialTimeout), so this constant scopes only ListMCPTools.
-	// It must be greater than agent/x/agentmcp.connectTimeout
-	// (30s as of this writing) plus a small buffer so a
-	// cold-start agent has time to finish its first MCP reload
-	// before chatd gives up. The agent constant is unexported,
-	// so this comment is the only contract between the two
-	// values. If agentmcp.connectTimeout changes, bump this
-	// value to match.
+	// Must exceed agent/x/agentmcp.connectTimeout (30s) so a
+	// cold-start agent's first MCP reload can settle before
+	// chatd gives up.
 	workspaceMCPDiscoveryTimeout = 35 * time.Second
 	turnSummaryWriteTimeout      = 5 * time.Second
 	// defaultDialTimeout matches the timeout used by ~8 other
@@ -6576,12 +6567,7 @@ func (p *Server) runChat(
 				}
 			} // Cache miss, agent changed, or no cache: validate
 			// that the workspace still has a live agent before
-			// attempting a dial. The DB lookup and the dial run
-			// under the parent chat-turn context; the dial has
-			// its own internal dialTimeout. Only ListMCPTools is
-			// wrapped in workspaceMCPDiscoveryTimeout because
-			// that is the call that must outlast the agent's
-			// per-server connectTimeout on a cold reload.
+			// attempting a dial.
 			_, _, agentErr = workspaceCtx.workspaceAgentIDForConn(ctx)
 			if agentErr != nil {
 				if xerrors.Is(agentErr, errChatHasNoWorkspaceAgent) {

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -66,14 +66,17 @@ const (
 	planPathLookupTimeout        = 5 * time.Second
 	instructionCacheTTL          = 5 * time.Minute
 	workspaceDialValidationDelay = 5 * time.Second
-	// workspaceMCPDiscoveryTimeout bounds the per-turn dial that
-	// asks the workspace agent for its MCP tools. It must be
-	// greater than agent/x/agentmcp.connectTimeout (30s as of
-	// this writing) plus a small buffer so a cold-start agent
-	// has time to finish its first MCP reload before chatd gives
-	// up. The two constants live in different packages, so this
-	// comment is the contract; do not import the agent constant
-	// at runtime. If agentmcp.connectTimeout changes, bump this
+	// workspaceMCPDiscoveryTimeout bounds the per-turn HTTP call
+	// that asks the workspace agent for its MCP tools. The DB
+	// lookup and the dial that precede the call use the parent
+	// chat-turn context (the dial has its own internal
+	// dialTimeout), so this constant scopes only ListMCPTools.
+	// It must be greater than agent/x/agentmcp.connectTimeout
+	// (30s as of this writing) plus a small buffer so a
+	// cold-start agent has time to finish its first MCP reload
+	// before chatd gives up. The agent constant is unexported,
+	// so this comment is the only contract between the two
+	// values. If agentmcp.connectTimeout changes, bump this
 	// value to match.
 	workspaceMCPDiscoveryTimeout = 35 * time.Second
 	turnSummaryWriteTimeout      = 5 * time.Second
@@ -6573,14 +6576,13 @@ func (p *Server) runChat(
 				}
 			} // Cache miss, agent changed, or no cache: validate
 			// that the workspace still has a live agent before
-			// attempting a dial.
-			workspaceMCPCtx, cancel := context.WithTimeout(
-				ctx,
-				workspaceMCPDiscoveryTimeout,
-			)
-			defer cancel()
-
-			_, _, agentErr = workspaceCtx.workspaceAgentIDForConn(workspaceMCPCtx)
+			// attempting a dial. The DB lookup and the dial run
+			// under the parent chat-turn context; the dial has
+			// its own internal dialTimeout. Only ListMCPTools is
+			// wrapped in workspaceMCPDiscoveryTimeout because
+			// that is the call that must outlast the agent's
+			// per-server connectTimeout on a cold reload.
+			_, _, agentErr = workspaceCtx.workspaceAgentIDForConn(ctx)
 			if agentErr != nil {
 				if xerrors.Is(agentErr, errChatHasNoWorkspaceAgent) {
 					p.workspaceMCPToolsCache.Delete(chat.ID)
@@ -6592,13 +6594,15 @@ func (p *Server) runChat(
 			}
 
 			// List workspace MCP tools via the agent conn.
-			conn, connErr := workspaceCtx.getWorkspaceConn(workspaceMCPCtx)
+			conn, connErr := workspaceCtx.getWorkspaceConn(ctx)
 			if connErr != nil {
 				logger.Warn(ctx, "failed to get workspace conn for MCP tools",
 					slog.Error(connErr))
 				return nil
 			}
-			toolsResp, listErr := conn.ListMCPTools(workspaceMCPCtx)
+			listCtx, cancel := context.WithTimeout(ctx, workspaceMCPDiscoveryTimeout)
+			defer cancel()
+			toolsResp, listErr := conn.ListMCPTools(listCtx)
 			if listErr != nil {
 				logger.Warn(ctx, "failed to list workspace MCP tools",
 					slog.Error(listErr))
@@ -6610,7 +6614,7 @@ func (p *Server) runChat(
 			// caching an empty list would hide tools
 			// permanently.
 			if len(toolsResp.Tools) > 0 {
-				if agent, agentErr := workspaceCtx.getWorkspaceAgent(workspaceMCPCtx); agentErr == nil {
+				if agent, agentErr := workspaceCtx.getWorkspaceAgent(ctx); agentErr == nil {
 					p.workspaceMCPToolsCache.Store(chat.ID, &cachedWorkspaceMCPTools{
 						agentID: agent.ID,
 						tools:   toolsResp.Tools,

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -66,7 +66,16 @@ const (
 	planPathLookupTimeout        = 5 * time.Second
 	instructionCacheTTL          = 5 * time.Minute
 	workspaceDialValidationDelay = 5 * time.Second
-	workspaceMCPDiscoveryTimeout = 5 * time.Second
+	// workspaceMCPDiscoveryTimeout bounds the per-turn dial that
+	// asks the workspace agent for its MCP tools. It must be
+	// greater than agent/x/agentmcp.connectTimeout (30s as of
+	// this writing) plus a small buffer so a cold-start agent
+	// has time to finish its first MCP reload before chatd gives
+	// up. The two constants live in different packages, so this
+	// comment is the contract; do not import the agent constant
+	// at runtime. If agentmcp.connectTimeout changes, bump this
+	// value to match.
+	workspaceMCPDiscoveryTimeout = 35 * time.Second
 	turnSummaryWriteTimeout      = 5 * time.Second
 	// defaultDialTimeout matches the timeout used by ~8 other
 	// server-side AgentConn callers.

--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -11158,6 +11158,25 @@ func TestRecoverStaleChatsWaitingPropagatesSynthError(t *testing.T) {
 	}
 }
 
+// TestWorkspaceMCPDiscoveryTimeoutExceedsAgentConnectTimeout encodes
+// the cross-package contract that workspaceMCPDiscoveryTimeout must
+// be greater than agent/x/agentmcp.connectTimeout (30s as of this
+// writing) so a cold-start agent finishes its first MCP reload before
+// chatd's per-turn dial gives up. agentmcp.connectTimeout is
+// unexported, so this test asserts the lower bound directly. If
+// connectTimeout ever changes, both this lower bound and the comment
+// on workspaceMCPDiscoveryTimeout must be updated together.
+func TestWorkspaceMCPDiscoveryTimeoutExceedsAgentConnectTimeout(t *testing.T) {
+	t.Parallel()
+
+	// 31s = agentmcp.connectTimeout (30s) + a 1s minimum buffer.
+	// The production constant is 35s; this lower bound exists to
+	// catch a future tightening that would re-introduce the cold
+	// start race documented on the constant itself.
+	require.GreaterOrEqual(t, chatd.WorkspaceMCPDiscoveryTimeout, 31*time.Second,
+		"workspaceMCPDiscoveryTimeout must exceed agent/x/agentmcp.connectTimeout (30s) plus a small buffer")
+}
+
 // TestRunChat_WorkspaceMCPDiscoveryWaitsForSlowAgent verifies that
 // chatd's per-turn workspace MCP discovery waits long enough for a
 // cold-start agent to finish its first MCP reload. The agent's
@@ -11170,9 +11189,11 @@ func TestRecoverStaleChatsWaitingPropagatesSynthError(t *testing.T) {
 func TestRunChat_WorkspaceMCPDiscoveryWaitsForSlowAgent(t *testing.T) {
 	t.Parallel()
 
-	// slowAgentMCPListDelay must be greater than the old 5s
-	// workspaceMCPDiscoveryTimeout and less than the new bound.
-	// Any value in that band proves the constant bump.
+	// slowAgentMCPListDelay must be smaller than
+	// workspaceMCPDiscoveryTimeout so the mock returns before
+	// chatd gives up, but large enough that any reasonable
+	// regression in the chatd timeout (back below the agent's
+	// connectTimeout) makes the test fail.
 	const slowAgentMCPListDelay = 7 * time.Second
 
 	db, ps := dbtestutil.NewDB(t)
@@ -11219,8 +11240,8 @@ func TestRunChat_WorkspaceMCPDiscoveryWaitsForSlowAgent(t *testing.T) {
 		Return(workspacesdk.ContextConfigResponse{}, xerrors.New("not supported")).AnyTimes()
 	// Block ListMCPTools to simulate a cold-start agent whose
 	// first MCP reload has not finished yet. Honor caller-side
-	// cancellation so the goroutine exits when chatd's per-turn
-	// context is canceled by the old 5s timeout.
+	// cancellation so the goroutine exits cleanly if the parent
+	// context is canceled.
 	mockConn.EXPECT().ListMCPTools(gomock.Any()).
 		DoAndReturn(func(ctx context.Context) (workspacesdk.ListMCPToolsResponse, error) {
 			select {

--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -11157,3 +11157,115 @@ func TestRecoverStaleChatsWaitingPropagatesSynthError(t *testing.T) {
 		}
 	}
 }
+
+// TestRunChat_WorkspaceMCPDiscoveryWaitsForSlowAgent verifies that
+// chatd's per-turn workspace MCP discovery waits long enough for a
+// cold-start agent to finish its first MCP reload. The agent's
+// per-server connectTimeout (in agent/x/agentmcp) is 30s, so a
+// chatd timeout shorter than that can abandon a legitimate cold
+// reload and surface an empty tool list to the LLM. The mocked
+// ListMCPTools blocks for slowAgentMCPListDelay before returning a
+// non-empty list. The test passes only when
+// workspaceMCPDiscoveryTimeout exceeds slowAgentMCPListDelay.
+func TestRunChat_WorkspaceMCPDiscoveryWaitsForSlowAgent(t *testing.T) {
+	t.Parallel()
+
+	// slowAgentMCPListDelay must be greater than the old 5s
+	// workspaceMCPDiscoveryTimeout and less than the new bound.
+	// Any value in that band proves the constant bump.
+	const slowAgentMCPListDelay = 7 * time.Second
+
+	db, ps := dbtestutil.NewDB(t)
+	ctx := testutil.Context(t, testutil.WaitLong)
+
+	var (
+		requestsMu sync.Mutex
+		requests   []recordedOpenAIRequest
+	)
+	openAIURL := chattest.NewOpenAI(t, func(req *chattest.OpenAIRequest) chattest.OpenAIResponse {
+		if !req.Stream {
+			return chattest.OpenAINonStreamingResponse("title")
+		}
+
+		requestsMu.Lock()
+		requests = append(requests, recordOpenAIRequest(req))
+		requestsMu.Unlock()
+
+		return chattest.OpenAIStreamingResponse(
+			chattest.OpenAITextChunks("done")...,
+		)
+	})
+
+	user, org, model := seedChatDependenciesWithProvider(t, db, "openai-compat", openAIURL)
+	ws, dbAgent := seedWorkspaceWithAgent(t, db, user.ID)
+
+	workspaceToolName := "workspace-slow-mcp__echo"
+	workspaceToolsResp := workspacesdk.ListMCPToolsResponse{
+		Tools: []workspacesdk.MCPToolInfo{{
+			ServerName:  "workspace-slow-mcp",
+			Name:        workspaceToolName,
+			Description: "Slow workspace echo tool",
+			Schema: map[string]any{
+				"input": map[string]any{"type": "string"},
+			},
+			Required: []string{"input"},
+		}},
+	}
+
+	ctrl := gomock.NewController(t)
+	mockConn := agentconnmock.NewMockAgentConn(ctrl)
+	mockConn.EXPECT().SetExtraHeaders(gomock.Any()).AnyTimes()
+	mockConn.EXPECT().ContextConfig(gomock.Any()).
+		Return(workspacesdk.ContextConfigResponse{}, xerrors.New("not supported")).AnyTimes()
+	// Block ListMCPTools to simulate a cold-start agent whose
+	// first MCP reload has not finished yet. Honor caller-side
+	// cancellation so the goroutine exits when chatd's per-turn
+	// context is canceled by the old 5s timeout.
+	mockConn.EXPECT().ListMCPTools(gomock.Any()).
+		DoAndReturn(func(ctx context.Context) (workspacesdk.ListMCPToolsResponse, error) {
+			select {
+			case <-time.After(slowAgentMCPListDelay):
+				return workspaceToolsResp, nil
+			case <-ctx.Done():
+				return workspacesdk.ListMCPToolsResponse{}, ctx.Err()
+			}
+		}).AnyTimes()
+	mockConn.EXPECT().LS(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(workspacesdk.LSResponse{}, nil).AnyTimes()
+	mockConn.EXPECT().ReadFile(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(io.NopCloser(strings.NewReader("")), "", nil).AnyTimes()
+
+	server := newActiveTestServer(t, db, ps, func(cfg *chatd.Config) {
+		cfg.AgentConn = func(_ context.Context, agentID uuid.UUID) (workspacesdk.AgentConn, func(), error) {
+			require.Equal(t, dbAgent.ID, agentID)
+			return mockConn, func() {}, nil
+		}
+	})
+
+	chat, err := server.CreateChat(ctx, chatd.CreateOptions{
+		OrganizationID: org.ID,
+		OwnerID:        user.ID,
+		Title:          "workspace-mcp-slow-agent",
+		ModelConfigID:  model.ID,
+		WorkspaceID:    uuid.NullUUID{UUID: ws.ID, Valid: true},
+		InitialUserContent: []codersdk.ChatMessagePart{
+			codersdk.ChatMessageText("List the workspace MCP tools."),
+		},
+	})
+	require.NoError(t, err)
+
+	chatResult := waitForTerminalChat(ctx, t, db, chat.ID)
+	if chatResult.Status == database.ChatStatusError {
+		require.FailNowf(t, "chat failed", "last_error=%q",
+			chatLastErrorMessage(chatResult.LastError))
+	}
+	require.Equal(t, database.ChatStatusWaiting, chatResult.Status)
+
+	requestsMu.Lock()
+	recorded := append([]recordedOpenAIRequest(nil), requests...)
+	requestsMu.Unlock()
+	require.Len(t, recorded, 1, "expected exactly one streamed model call")
+	require.Contains(t, recorded[0].Tools, workspaceToolName,
+		"workspace MCP tool should reach the LLM once chatd's discovery "+
+			"timeout exceeds the agent's MCP reload time")
+}

--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -11158,14 +11158,6 @@ func TestRecoverStaleChatsWaitingPropagatesSynthError(t *testing.T) {
 	}
 }
 
-func TestWorkspaceMCPDiscoveryTimeoutExceedsAgentConnectTimeout(t *testing.T) {
-	t.Parallel()
-	// agentmcp.connectTimeout is 30s and unexported; the +1s
-	// pins the lower bound so a future tightening fails here
-	// instead of silently reintroducing the cold-start race.
-	require.Greater(t, chatd.WorkspaceMCPDiscoveryTimeout, 31*time.Second)
-}
-
 // Regression for the cold-start race: chatd must wait long enough
 // for ListMCPTools to return after the agent's MCP reload settles.
 func TestRunChat_WorkspaceMCPDiscoveryWaitsForSlowAgent(t *testing.T) {

--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -11158,42 +11158,19 @@ func TestRecoverStaleChatsWaitingPropagatesSynthError(t *testing.T) {
 	}
 }
 
-// TestWorkspaceMCPDiscoveryTimeoutExceedsAgentConnectTimeout encodes
-// the cross-package contract that workspaceMCPDiscoveryTimeout must
-// be greater than agent/x/agentmcp.connectTimeout (30s as of this
-// writing) so a cold-start agent finishes its first MCP reload before
-// chatd's per-turn dial gives up. agentmcp.connectTimeout is
-// unexported, so this test asserts the lower bound directly. If
-// connectTimeout ever changes, both this lower bound and the comment
-// on workspaceMCPDiscoveryTimeout must be updated together.
 func TestWorkspaceMCPDiscoveryTimeoutExceedsAgentConnectTimeout(t *testing.T) {
 	t.Parallel()
-
-	// 31s = agentmcp.connectTimeout (30s) + a 1s minimum buffer.
-	// The production constant is 35s; this lower bound exists to
-	// catch a future tightening that would re-introduce the cold
-	// start race documented on the constant itself.
-	require.GreaterOrEqual(t, chatd.WorkspaceMCPDiscoveryTimeout, 31*time.Second,
-		"workspaceMCPDiscoveryTimeout must exceed agent/x/agentmcp.connectTimeout (30s) plus a small buffer")
+	// agentmcp.connectTimeout is 30s and unexported; the +1s
+	// pins the lower bound so a future tightening fails here
+	// instead of silently reintroducing the cold-start race.
+	require.Greater(t, chatd.WorkspaceMCPDiscoveryTimeout, 31*time.Second)
 }
 
-// TestRunChat_WorkspaceMCPDiscoveryWaitsForSlowAgent verifies that
-// chatd's per-turn workspace MCP discovery waits long enough for a
-// cold-start agent to finish its first MCP reload. The agent's
-// per-server connectTimeout (in agent/x/agentmcp) is 30s, so a
-// chatd timeout shorter than that can abandon a legitimate cold
-// reload and surface an empty tool list to the LLM. The mocked
-// ListMCPTools blocks for slowAgentMCPListDelay before returning a
-// non-empty list. The test passes only when
-// workspaceMCPDiscoveryTimeout exceeds slowAgentMCPListDelay.
+// Regression for the cold-start race: chatd must wait long enough
+// for ListMCPTools to return after the agent's MCP reload settles.
 func TestRunChat_WorkspaceMCPDiscoveryWaitsForSlowAgent(t *testing.T) {
 	t.Parallel()
 
-	// slowAgentMCPListDelay must be smaller than
-	// workspaceMCPDiscoveryTimeout so the mock returns before
-	// chatd gives up, but large enough that any reasonable
-	// regression in the chatd timeout (back below the agent's
-	// connectTimeout) makes the test fail.
 	const slowAgentMCPListDelay = 7 * time.Second
 
 	db, ps := dbtestutil.NewDB(t)
@@ -11238,10 +11215,7 @@ func TestRunChat_WorkspaceMCPDiscoveryWaitsForSlowAgent(t *testing.T) {
 	mockConn.EXPECT().SetExtraHeaders(gomock.Any()).AnyTimes()
 	mockConn.EXPECT().ContextConfig(gomock.Any()).
 		Return(workspacesdk.ContextConfigResponse{}, xerrors.New("not supported")).AnyTimes()
-	// Block ListMCPTools to simulate a cold-start agent whose
-	// first MCP reload has not finished yet. Honor caller-side
-	// cancellation so the goroutine exits cleanly if the parent
-	// context is canceled.
+	// Honor ctx so the goroutine exits if chatd cancels.
 	mockConn.EXPECT().ListMCPTools(gomock.Any()).
 		DoAndReturn(func(ctx context.Context) (workspacesdk.ListMCPToolsResponse, error) {
 			select {

--- a/coderd/x/chatd/export_test.go
+++ b/coderd/x/chatd/export_test.go
@@ -18,10 +18,6 @@ func WaitUntilIdleForTest(server *Server) {
 	server.drainInflight()
 }
 
-// WorkspaceMCPDiscoveryTimeout exposes workspaceMCPDiscoveryTimeout
-// for tests in chatd_test.
-const WorkspaceMCPDiscoveryTimeout = workspaceMCPDiscoveryTimeout
-
 // FinishActiveChatForTest exposes the unexported cleanup TX so tests
 // can drive the post-run state machine deterministically. Returns the
 // resulting chat, the promoted message (if any), the synthetic

--- a/coderd/x/chatd/export_test.go
+++ b/coderd/x/chatd/export_test.go
@@ -18,6 +18,11 @@ func WaitUntilIdleForTest(server *Server) {
 	server.drainInflight()
 }
 
+// WorkspaceMCPDiscoveryTimeout exposes the unexported constant so tests
+// in the chatd_test package can encode the cross-package invariant that
+// this value exceeds agent/x/agentmcp.connectTimeout.
+const WorkspaceMCPDiscoveryTimeout = workspaceMCPDiscoveryTimeout
+
 // FinishActiveChatForTest exposes the unexported cleanup TX so tests
 // can drive the post-run state machine deterministically. Returns the
 // resulting chat, the promoted message (if any), the synthetic

--- a/coderd/x/chatd/export_test.go
+++ b/coderd/x/chatd/export_test.go
@@ -18,9 +18,8 @@ func WaitUntilIdleForTest(server *Server) {
 	server.drainInflight()
 }
 
-// WorkspaceMCPDiscoveryTimeout exposes the unexported constant so tests
-// in the chatd_test package can encode the cross-package invariant that
-// this value exceeds agent/x/agentmcp.connectTimeout.
+// WorkspaceMCPDiscoveryTimeout exposes workspaceMCPDiscoveryTimeout
+// for tests in chatd_test.
 const WorkspaceMCPDiscoveryTimeout = workspaceMCPDiscoveryTimeout
 
 // FinishActiveChatForTest exposes the unexported cleanup TX so tests


### PR DESCRIPTION
# Why

`workspaceMCPDiscoveryTimeout` was 5 seconds. The agent's per-server
`agentmcp.connectTimeout` is 30 seconds. Any cold-start fetch where
a reload is in flight (the common case on a fresh workspace)
guarantees the chatd dial cancels before the reload settles. The
result is logged by the agent as `mcp reload canceled by caller`
and surfaced to chatd as a 200 with an empty tool list.

# What changes

Bump `workspaceMCPDiscoveryTimeout` to 35 seconds and scope it to
exactly the call that races the agent's `connectTimeout`:

- `workspaceMCPCtx` previously wrapped the DB lookup, the dial, and
  the `ListMCPTools` call as a single 5-second chain. Now only
  `ListMCPTools` runs under `workspaceMCPDiscoveryTimeout`. The DB
  lookup uses the parent chat-turn ctx; `getWorkspaceConn` already
  has its own internal `dialTimeout` (30s).
- The constant's comment documents the contract: must exceed
  `agent/x/agentmcp.connectTimeout`. The agent constant is
  unexported, so the comment is the only link between the two.

The MCP discovery goroutine runs concurrently with prompt resolution
inside `g2` in `runChat`, so the longer wait does not bound
user-visible latency in the steady state.

# Tests

`TestRunChat_WorkspaceMCPDiscoveryWaitsForSlowAgent` mocks
`ListMCPTools` to block for 7 seconds and asserts the workspace MCP
tool name reaches the LLM tool list. Fails at the pre-fix 5s
constant; passes at 35s.

# Companion change

The agent-side fix that makes the handler actually wait for a settled
reload is in PR #25034. This PR is independent. The reviewer
suggested adding a back-reference comment on
`agent/x/agentmcp.connectTimeout` so the contract becomes
bidirectional; that comment belongs in PR #25034 because that PR
already owns the file.

<details>
<summary>Reviewer-flagged future work</summary>

`g2` in `runChat` is a plain `errgroup.Group`, not
`errgroup.WithContext`. The MCP discovery goroutine always returns
nil (errors are logged and swallowed), so a peer's failure does
not short-circuit it. With the timeout at 35s instead of 5s, the
worst-case dead-wait window after a peer error is 7x longer.
Converting the group to share a cancel signal requires auditing
every `g2.Go` caller for early-cancel safety; out of scope for
this constant tweak. Tracked separately.

</details>

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻
