### PR TITLE
fix(coderd/x/chatd): wake after async chat-row UPDATEs commit

### DIFF
--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -8456,6 +8456,10 @@ func (p *Server) updateLastTurnSummary(
 	updatedChat := chat
 	updatedChat.LastTurnSummary = lastTurnSummary
 	p.publishChatPubsubEvent(updatedChat, codersdk.ChatWatchEventKindSummaryChange, nil)
+
+	// AcquireChats uses SKIP LOCKED; re-wake so a wake racing this
+	// UPDATE's row lock does not strand a freshly-pending chat.
+	p.signalWake()
 }
 
 func (p *Server) webpushConfigured() bool {

--- a/coderd/x/chatd/quickgen.go
+++ b/coderd/x/chatd/quickgen.go
@@ -262,6 +262,10 @@ func (p *Server) maybeGenerateChatTitle(
 		chat.Title = title
 		generatedTitle.Store(title)
 		p.publishChatPubsubEvent(chat, codersdk.ChatWatchEventKindTitleChange, nil)
+
+		// AcquireChats uses SKIP LOCKED; re-wake so a wake racing this
+		// UPDATE's row lock does not strand a freshly-pending chat.
+		p.signalWake()
 		return
 	}
 


### PR DESCRIPTION
Two async goroutines launched from `processChat` (`maybeGenerateChatTitle` and `maybeFinalizeTurnSummaryAndPush -> updateLastTurnSummary`) run autocommit `UPDATE`s on the chat row after `finishActiveChat` has set the chat to pending and `signalWake` has fired. If the row lock from one of those UPDATEs is held while `acquireLoop`'s `processOnce` runs, `AcquireChats`'s `FOR UPDATE SKIP LOCKED` skips the freshly-pending chat and returns no rows. The wake is consumed with no acquisition; the chat sits in pending until the next `acquireTicker` (1s default, `time.Hour` in the affected tests).

Fix: `signalWake` after each UPDATE commits.

Reproduces in CI under load. The `TestAutoPromoteQueuedMessageFallsBack*` flake reproduced locally on a 96-core box with 16 background `yes` processes, ~2 failures per 200 iterations. After this fix, 400 iterations under the same load are clean.

Disclosure: Coder Agents generated this change.

Closes https://github.com/coder/internal/issues/1500

<details>
<summary>Investigation log</summary>

Log from a failing run (chat `18725739`, owner `2ddc6784`):

```
19:59:16.503 publish chat:owner:2ddc6784...  len=594  StatusChange (auto-promote -> pending)
19:59:16.503 signalWake delivered                     finishActiveChat path
19:59:16.503 processOnce entry                        acquireLoop reads wake
19:59:16.503 removing queueSet chat:stream:18725739   controlCancel runs
19:59:16.504 publish chat:owner:2ddc6784...  len=598  SummaryChange UPDATE commits
19:59:16.504 processOnce acquired count=0             AcquireChats skipped the locked row
```

The `count=0` log lands between the StatusChange publish (chat is Pending) and the SummaryChange publish (the async UPDATE committing). The UPDATE held the row lock during the `AcquireChats` inner SELECT.

Isolation test: patched `processChat`'s deferred block to skip `maybeFinalizeTurnSummaryAndPush` entirely. Same stress, 200 + 400 iterations: zero failures. Confirms the post-finish summary UPDATE as the proximate cause. `UpdateChatTitleByID` is the same shape and gets the same treatment.

</details>
