### PR TITLE
fix: isolate test HTTP clients

### DIFF
--- a/cli/agent_test.go
+++ b/cli/agent_test.go
@@ -111,7 +111,7 @@ func TestWorkspaceAgent(t *testing.T) {
 		t.Cleanup(func() {
 			_ = provisionerCloser.Close()
 		})
-		client := codersdk.New(serverURL)
+		client := codersdk.New(serverURL, codersdk.WithHTTPClient(coderdtest.NewIsolatedHTTPClient(serverURL)))
 		t.Cleanup(func() {
 			cancelFunc()
 			_ = provisionerCloser.Close()

--- a/cli/root_test.go
+++ b/cli/root_test.go
@@ -217,7 +217,7 @@ func TestDERPHeaders(t *testing.T) {
 	t.Cleanup(func() {
 		_ = provisionerCloser.Close()
 	})
-	client := codersdk.New(serverURL)
+	client := codersdk.New(serverURL, codersdk.WithHTTPClient(coderdtest.NewIsolatedHTTPClient(serverURL)))
 	t.Cleanup(func() {
 		cancelFunc()
 		_ = provisionerCloser.Close()

--- a/cli/templateedit_test.go
+++ b/cli/templateedit_test.go
@@ -384,7 +384,7 @@ func TestTemplateEdit(t *testing.T) {
 			// Create a new client that uses the proxy server.
 			proxyURL, err := url.Parse(proxy.URL)
 			require.NoError(t, err)
-			proxyClient := codersdk.New(proxyURL)
+			proxyClient := codersdk.New(proxyURL, codersdk.WithHTTPClient(coderdtest.NewIsolatedHTTPClient(proxyURL)))
 			proxyClient.SetSessionToken(templateAdmin.SessionToken())
 			t.Cleanup(proxyClient.HTTPClient.CloseIdleConnections)
 
@@ -515,7 +515,7 @@ func TestTemplateEdit(t *testing.T) {
 			// Create a new client that uses the proxy server.
 			proxyURL, err := url.Parse(proxy.URL)
 			require.NoError(t, err)
-			proxyClient := codersdk.New(proxyURL)
+			proxyClient := codersdk.New(proxyURL, codersdk.WithHTTPClient(coderdtest.NewIsolatedHTTPClient(proxyURL)))
 			proxyClient.SetSessionToken(templateAdmin.SessionToken())
 			t.Cleanup(proxyClient.HTTPClient.CloseIdleConnections)
 
@@ -659,7 +659,7 @@ func TestTemplateEdit(t *testing.T) {
 			// Create a new client that uses the proxy server.
 			proxyURL, err := url.Parse(proxy.URL)
 			require.NoError(t, err)
-			proxyClient := codersdk.New(proxyURL)
+			proxyClient := codersdk.New(proxyURL, codersdk.WithHTTPClient(coderdtest.NewIsolatedHTTPClient(proxyURL)))
 			proxyClient.SetSessionToken(templateAdmin.SessionToken())
 			t.Cleanup(proxyClient.HTTPClient.CloseIdleConnections)
 
@@ -771,7 +771,7 @@ func TestTemplateEdit(t *testing.T) {
 			// Create a new client that uses the proxy server.
 			proxyURL, err := url.Parse(proxy.URL)
 			require.NoError(t, err)
-			proxyClient := codersdk.New(proxyURL)
+			proxyClient := codersdk.New(proxyURL, codersdk.WithHTTPClient(coderdtest.NewIsolatedHTTPClient(proxyURL)))
 			proxyClient.SetSessionToken(templateAdmin.SessionToken())
 			t.Cleanup(proxyClient.HTTPClient.CloseIdleConnections)
 

--- a/coderd/coderd_test.go
+++ b/coderd/coderd_test.go
@@ -184,7 +184,7 @@ func TestDERPForceWebSockets(t *testing.T) {
 		_ = provisionerCloser.Close()
 	})
 
-	client := codersdk.New(serverURL)
+	client := codersdk.New(serverURL, codersdk.WithHTTPClient(coderdtest.NewIsolatedHTTPClient(serverURL)))
 	t.Cleanup(func() {
 		client.HTTPClient.CloseIdleConnections()
 	})

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -669,7 +669,7 @@ func NewWithAPI(t testing.TB, options *Options) (*codersdk.Client, io.Closer, *c
 	if options.IncludeProvisionerDaemon {
 		provisionerCloser = NewTaggedProvisionerDaemon(t, coderAPI, defaultTestDaemonName, options.ProvisionerDaemonTags, coderd.MemoryProvisionerWithVersionOverride(options.ProvisionerDaemonVersion))
 	}
-	client := codersdk.New(serverURL)
+	client := codersdk.New(serverURL, codersdk.WithHTTPClient(newHTTPClient(serverURL)))
 	t.Cleanup(func() {
 		cancelFunc()
 		_ = provisionerCloser.Close()
@@ -677,6 +677,42 @@ func NewWithAPI(t testing.TB, options *Options) (*codersdk.Client, io.Closer, *c
 		client.HTTPClient.CloseIdleConnections()
 	})
 	return client, provisionerCloser, coderAPI
+}
+
+// newHTTPClient gives each coderdtest server an isolated transport.
+// Closing idle connections at test cleanup must not close http.DefaultTransport
+// while another parallel test is using it.
+func newHTTPClient(serverURL *url.URL) *http.Client {
+	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return &http.Client{Transport: http.DefaultTransport}
+	}
+	transport := defaultTransport.Clone()
+	if serverURL != nil && serverURL.Scheme == "https" {
+		if transport.TLSClientConfig != nil {
+			transport.TLSClientConfig = transport.TLSClientConfig.Clone()
+		} else {
+			transport.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12}
+		}
+		if transport.TLSClientConfig.MinVersion == 0 {
+			transport.TLSClientConfig.MinVersion = tls.VersionTLS12
+		}
+		//nolint:gosec // The coderdtest server uses test-only TLS certificates.
+		transport.TLSClientConfig.InsecureSkipVerify = true
+	}
+	return &http.Client{Transport: transport}
+}
+
+// newHTTPClientWithTransportFrom returns a fresh client that shares the base
+// transport without sharing mutable per-client state like CheckRedirect.
+func newHTTPClientWithTransportFrom(base *http.Client) *http.Client {
+	if base == nil {
+		return &http.Client{}
+	}
+	return &http.Client{
+		Transport: base.Transport,
+		Timeout:   base.Timeout,
+	}
 }
 
 // ProvisionerdCloser wraps a provisioner daemon as an io.Closer that can be called multiple times
@@ -937,10 +973,11 @@ func createAnotherUserRetry(t testing.TB, client *codersdk.Client, organizationI
 		require.NoError(t, err)
 	}
 
-	other := codersdk.New(client.URL, codersdk.WithSessionToken(sessionToken))
-	t.Cleanup(func() {
-		other.HTTPClient.CloseIdleConnections()
-	})
+	other := codersdk.New(
+		client.URL,
+		codersdk.WithSessionToken(sessionToken),
+		codersdk.WithHTTPClient(newHTTPClientWithTransportFrom(client.HTTPClient)),
+	)
 
 	if len(roles) > 0 {
 		// Find the roles for the org vs the site wide roles

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -708,6 +708,11 @@ func newHTTPClientWithTransportFrom(base *http.Client) *http.Client {
 	if base == nil {
 		return NewIsolatedHTTPClient(nil)
 	}
+	if base.Transport == nil {
+		client := NewIsolatedHTTPClient(nil)
+		client.Timeout = base.Timeout
+		return client
+	}
 	return &http.Client{
 		Transport: base.Transport,
 		Timeout:   base.Timeout,

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -706,7 +706,7 @@ func NewIsolatedHTTPClient(serverURL *url.URL) *http.Client {
 // transport without sharing mutable per-client state like CheckRedirect.
 func newHTTPClientWithTransportFrom(base *http.Client) *http.Client {
 	if base == nil {
-		return &http.Client{}
+		return NewIsolatedHTTPClient(nil)
 	}
 	return &http.Client{
 		Transport: base.Transport,

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -669,7 +669,7 @@ func NewWithAPI(t testing.TB, options *Options) (*codersdk.Client, io.Closer, *c
 	if options.IncludeProvisionerDaemon {
 		provisionerCloser = NewTaggedProvisionerDaemon(t, coderAPI, defaultTestDaemonName, options.ProvisionerDaemonTags, coderd.MemoryProvisionerWithVersionOverride(options.ProvisionerDaemonVersion))
 	}
-	client := codersdk.New(serverURL, codersdk.WithHTTPClient(newHTTPClient(serverURL)))
+	client := codersdk.New(serverURL, codersdk.WithHTTPClient(NewIsolatedHTTPClient(serverURL)))
 	t.Cleanup(func() {
 		cancelFunc()
 		_ = provisionerCloser.Close()
@@ -679,27 +679,26 @@ func NewWithAPI(t testing.TB, options *Options) (*codersdk.Client, io.Closer, *c
 	return client, provisionerCloser, coderAPI
 }
 
-// newHTTPClient gives each coderdtest server an isolated transport.
+// NewIsolatedHTTPClient returns a test client with its own transport.
 // Closing idle connections at test cleanup must not close http.DefaultTransport
 // while another parallel test is using it.
-func newHTTPClient(serverURL *url.URL) *http.Client {
-	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
-	if !ok {
-		return &http.Client{Transport: http.DefaultTransport}
+func NewIsolatedHTTPClient(serverURL *url.URL) *http.Client {
+	transport := &http.Transport{Proxy: http.ProxyFromEnvironment}
+	if defaultTransport, ok := http.DefaultTransport.(*http.Transport); ok {
+		transport = defaultTransport.Clone()
 	}
-	transport := defaultTransport.Clone()
-	if serverURL != nil && serverURL.Scheme == "https" {
-		if transport.TLSClientConfig != nil {
-			transport.TLSClientConfig = transport.TLSClientConfig.Clone()
-		} else {
-			transport.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12}
-		}
-		if transport.TLSClientConfig.MinVersion == 0 {
-			transport.TLSClientConfig.MinVersion = tls.VersionTLS12
-		}
-		//nolint:gosec // The coderdtest server uses test-only TLS certificates.
-		transport.TLSClientConfig.InsecureSkipVerify = true
+	if serverURL == nil || serverURL.Scheme != "https" {
+		transport.TLSClientConfig = nil
+		return &http.Client{Transport: transport}
 	}
+	if transport.TLSClientConfig == nil {
+		transport.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12}
+	}
+	if transport.TLSClientConfig.MinVersion == 0 {
+		transport.TLSClientConfig.MinVersion = tls.VersionTLS12
+	}
+	//nolint:gosec // The coderdtest server uses test-only TLS certificates.
+	transport.TLSClientConfig.InsecureSkipVerify = true
 	return &http.Client{Transport: transport}
 }
 

--- a/coderd/coderdtest/httpclient_test.go
+++ b/coderd/coderdtest/httpclient_test.go
@@ -55,14 +55,14 @@ func TestCreateAnotherUserHTTPClient(t *testing.T) {
 
 	client := coderdtest.New(t, nil)
 	first := coderdtest.CreateFirstUser(t, client)
+	client.HTTPClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+
 	other, _ := coderdtest.CreateAnotherUser(t, client, first.OrganizationID)
 
 	require.NotSame(t, client.HTTPClient, other.HTTPClient)
 	require.Same(t, client.HTTPClient.Transport, other.HTTPClient.Transport)
-
-	client.HTTPClient.CheckRedirect = func(*http.Request, []*http.Request) error {
-		return http.ErrUseLastResponse
-	}
 	require.Nil(t, other.HTTPClient.CheckRedirect)
 }
 

--- a/coderd/coderdtest/httpclient_test.go
+++ b/coderd/coderdtest/httpclient_test.go
@@ -36,6 +36,18 @@ func TestNewIsolatedHTTPSClient(t *testing.T) {
 	require.Equal(t, uint16(tls.VersionTLS12), transport.TLSClientConfig.MinVersion)
 }
 
+func TestNewIsolatedHTTPClientNilURL(t *testing.T) {
+	t.Parallel()
+
+	client := coderdtest.NewIsolatedHTTPClient(nil)
+	require.NotNil(t, client.Transport)
+	require.NotSame(t, http.DefaultTransport, client.Transport)
+
+	transport, ok := client.Transport.(*http.Transport)
+	require.True(t, ok)
+	require.Nil(t, transport.TLSClientConfig)
+}
+
 func TestCreateAnotherUserHTTPClient(t *testing.T) {
 	t.Parallel()
 

--- a/coderd/coderdtest/httpclient_test.go
+++ b/coderd/coderdtest/httpclient_test.go
@@ -4,10 +4,12 @@ import (
 	"crypto/tls"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/testutil"
 )
 
@@ -62,4 +64,23 @@ func TestCreateAnotherUserHTTPClient(t *testing.T) {
 		return http.ErrUseLastResponse
 	}
 	require.Nil(t, other.HTTPClient.CheckRedirect)
+}
+
+func TestCreateAnotherUserHTTPClientDefaultTransport(t *testing.T) {
+	t.Parallel()
+
+	client := coderdtest.New(t, nil)
+	first := coderdtest.CreateFirstUser(t, client)
+	base := codersdk.New(
+		client.URL,
+		codersdk.WithSessionToken(client.SessionToken()),
+		codersdk.WithHTTPClient(&http.Client{Timeout: time.Second}),
+	)
+
+	other, _ := coderdtest.CreateAnotherUser(t, base, first.OrganizationID)
+
+	require.NotSame(t, base.HTTPClient, other.HTTPClient)
+	require.NotNil(t, other.HTTPClient.Transport)
+	require.NotSame(t, http.DefaultTransport, other.HTTPClient.Transport)
+	require.Equal(t, base.HTTPClient.Timeout, other.HTTPClient.Timeout)
 }

--- a/coderd/coderdtest/httpclient_test.go
+++ b/coderd/coderdtest/httpclient_test.go
@@ -1,0 +1,57 @@
+package coderdtest_test
+
+import (
+	"crypto/tls"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/testutil"
+)
+
+func TestCoderdtestNewHTTPClient(t *testing.T) {
+	t.Parallel()
+
+	client := coderdtest.New(t, nil)
+	require.NotNil(t, client.HTTPClient.Transport)
+	require.NotSame(t, http.DefaultTransport, client.HTTPClient.Transport)
+
+	transport, ok := client.HTTPClient.Transport.(*http.Transport)
+	require.True(t, ok)
+	if transport.TLSClientConfig != nil {
+		require.False(t, transport.TLSClientConfig.InsecureSkipVerify)
+	}
+}
+
+func TestCoderdtestNewHTTPSClient(t *testing.T) {
+	t.Parallel()
+
+	client := coderdtest.New(t, &coderdtest.Options{
+		TLSCertificates: []tls.Certificate{
+			testutil.GenerateTLSCertificate(t, "localhost"),
+		},
+	})
+	transport, ok := client.HTTPClient.Transport.(*http.Transport)
+	require.True(t, ok)
+	require.NotNil(t, transport.TLSClientConfig)
+	require.True(t, transport.TLSClientConfig.InsecureSkipVerify)
+	require.Equal(t, uint16(tls.VersionTLS12), transport.TLSClientConfig.MinVersion)
+}
+
+func TestCreateAnotherUserHTTPClient(t *testing.T) {
+	t.Parallel()
+
+	client := coderdtest.New(t, nil)
+	first := coderdtest.CreateFirstUser(t, client)
+	other, _ := coderdtest.CreateAnotherUser(t, client, first.OrganizationID)
+
+	require.NotSame(t, client.HTTPClient, other.HTTPClient)
+	require.Same(t, client.HTTPClient.Transport, other.HTTPClient.Transport)
+
+	client.HTTPClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	require.Nil(t, other.HTTPClient.CheckRedirect)
+}

--- a/coderd/coderdtest/httpclient_test.go
+++ b/coderd/coderdtest/httpclient_test.go
@@ -3,37 +3,33 @@ package coderdtest_test
 import (
 	"crypto/tls"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/coderd/coderdtest"
-	"github.com/coder/coder/v2/testutil"
 )
 
-func TestCoderdtestNewHTTPClient(t *testing.T) {
+func TestNewIsolatedHTTPClient(t *testing.T) {
 	t.Parallel()
 
-	client := coderdtest.New(t, nil)
-	require.NotNil(t, client.HTTPClient.Transport)
-	require.NotSame(t, http.DefaultTransport, client.HTTPClient.Transport)
+	client := coderdtest.NewIsolatedHTTPClient(mustParseURL(t, "http://example.com"))
+	require.NotNil(t, client.Transport)
+	require.NotSame(t, http.DefaultTransport, client.Transport)
 
-	transport, ok := client.HTTPClient.Transport.(*http.Transport)
+	transport, ok := client.Transport.(*http.Transport)
 	require.True(t, ok)
-	if transport.TLSClientConfig != nil {
-		require.False(t, transport.TLSClientConfig.InsecureSkipVerify)
-	}
+	require.Nil(t, transport.TLSClientConfig)
 }
 
-func TestCoderdtestNewHTTPSClient(t *testing.T) {
+func TestNewIsolatedHTTPSClient(t *testing.T) {
 	t.Parallel()
 
-	client := coderdtest.New(t, &coderdtest.Options{
-		TLSCertificates: []tls.Certificate{
-			testutil.GenerateTLSCertificate(t, "localhost"),
-		},
-	})
-	transport, ok := client.HTTPClient.Transport.(*http.Transport)
+	client := coderdtest.NewIsolatedHTTPClient(mustParseURL(t, "https://example.com"))
+	require.NotSame(t, http.DefaultTransport, client.Transport)
+
+	transport, ok := client.Transport.(*http.Transport)
 	require.True(t, ok)
 	require.NotNil(t, transport.TLSClientConfig)
 	require.True(t, transport.TLSClientConfig.InsecureSkipVerify)
@@ -54,4 +50,12 @@ func TestCreateAnotherUserHTTPClient(t *testing.T) {
 		return http.ErrUseLastResponse
 	}
 	require.Nil(t, other.HTTPClient.CheckRedirect)
+}
+
+func mustParseURL(t *testing.T, rawURL string) *url.URL {
+	t.Helper()
+
+	parsed, err := url.Parse(rawURL)
+	require.NoError(t, err)
+	return parsed
 }

--- a/coderd/coderdtest/httpclient_test.go
+++ b/coderd/coderdtest/httpclient_test.go
@@ -3,18 +3,18 @@ package coderdtest_test
 import (
 	"crypto/tls"
 	"net/http"
-	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/testutil"
 )
 
 func TestNewIsolatedHTTPClient(t *testing.T) {
 	t.Parallel()
 
-	client := coderdtest.NewIsolatedHTTPClient(mustParseURL(t, "http://example.com"))
+	client := coderdtest.NewIsolatedHTTPClient(testutil.MustURL(t, "http://example.com"))
 	require.NotNil(t, client.Transport)
 	require.NotSame(t, http.DefaultTransport, client.Transport)
 
@@ -26,7 +26,7 @@ func TestNewIsolatedHTTPClient(t *testing.T) {
 func TestNewIsolatedHTTPSClient(t *testing.T) {
 	t.Parallel()
 
-	client := coderdtest.NewIsolatedHTTPClient(mustParseURL(t, "https://example.com"))
+	client := coderdtest.NewIsolatedHTTPClient(testutil.MustURL(t, "https://example.com"))
 	require.NotSame(t, http.DefaultTransport, client.Transport)
 
 	transport, ok := client.Transport.(*http.Transport)
@@ -62,12 +62,4 @@ func TestCreateAnotherUserHTTPClient(t *testing.T) {
 		return http.ErrUseLastResponse
 	}
 	require.Nil(t, other.HTTPClient.CheckRedirect)
-}
-
-func mustParseURL(t *testing.T, rawURL string) *url.URL {
-	t.Helper()
-
-	parsed, err := url.Parse(rawURL)
-	require.NoError(t, err)
-	return parsed
 }

--- a/coderd/workspaces_scoped_test.go
+++ b/coderd/workspaces_scoped_test.go
@@ -63,7 +63,11 @@ func TestCompositeWorkspaceScopes(t *testing.T) {
 		})
 		require.NoError(t, err, "creating scoped token")
 
-		scoped := codersdk.New(adminClient.URL, codersdk.WithSessionToken(resp.Key))
+		scoped := codersdk.New(
+			adminClient.URL,
+			codersdk.WithSessionToken(resp.Key),
+			codersdk.WithHTTPClient(coderdtest.NewIsolatedHTTPClient(adminClient.URL)),
+		)
 		t.Cleanup(func() { scoped.HTTPClient.CloseIdleConnections() })
 		return scoped
 	}

--- a/enterprise/cli/boundary_test.go
+++ b/enterprise/cli/boundary_test.go
@@ -118,7 +118,7 @@ func TestBoundaryLicenseVerification(t *testing.T) {
 
 		proxyURL, err := url.Parse(proxy.URL)
 		require.NoError(t, err)
-		proxyClient := codersdk.New(proxyURL)
+		proxyClient := codersdk.New(proxyURL, codersdk.WithHTTPClient(coderdtest.NewIsolatedHTTPClient(proxyURL)))
 		proxyClient.SetSessionToken(client.SessionToken())
 		t.Cleanup(proxyClient.HTTPClient.CloseIdleConnections)
 
@@ -182,7 +182,7 @@ func TestBoundaryLicenseVerification(t *testing.T) {
 
 		proxyURL, err := url.Parse(proxy.URL)
 		require.NoError(t, err)
-		proxyClient := codersdk.New(proxyURL)
+		proxyClient := codersdk.New(proxyURL, codersdk.WithHTTPClient(coderdtest.NewIsolatedHTTPClient(proxyURL)))
 		proxyClient.SetSessionToken(client.SessionToken())
 		t.Cleanup(proxyClient.HTTPClient.CloseIdleConnections)
 
@@ -219,7 +219,7 @@ func TestBoundaryLicenseVerification(t *testing.T) {
 
 		proxyURL, err := url.Parse(proxy.URL)
 		require.NoError(t, err)
-		proxyClient := codersdk.New(proxyURL)
+		proxyClient := codersdk.New(proxyURL, codersdk.WithHTTPClient(coderdtest.NewIsolatedHTTPClient(proxyURL)))
 		proxyClient.SetSessionToken(client.SessionToken())
 		t.Cleanup(proxyClient.HTTPClient.CloseIdleConnections)
 
@@ -286,7 +286,7 @@ func TestBoundaryChildProcessSkipsCheck(t *testing.T) {
 
 	proxyURL, err := url.Parse(proxy.URL)
 	require.NoError(t, err)
-	proxyClient := codersdk.New(proxyURL)
+	proxyClient := codersdk.New(proxyURL, codersdk.WithHTTPClient(coderdtest.NewIsolatedHTTPClient(proxyURL)))
 	proxyClient.SetSessionToken(client.SessionToken())
 	t.Cleanup(proxyClient.HTTPClient.CloseIdleConnections)
 


### PR DESCRIPTION
Parallel tests could share `http.DefaultTransport` through ad hoc `codersdk.New` clients. When one test cleaned up with `CloseIdleConnections`, another in-flight request could fail with `http: CloseIdleConnections called`, as seen in ENG-2179.

Add a coderdtest helper for isolated test HTTP clients, use it in coderdtest and sibling test sites that close idle SDK connections, and keep `CreateAnotherUser` from sharing mutable `http.Client` fields such as `CheckRedirect`.

Closes https://github.com/coder/internal/issues/1395

<details>
<summary>Coder Agents notes</summary>

Generated by Coder Agents for Linear ENG-2179.

Local validation run before opening and after review follow-up:

- `go test ./coderd/coderdtest`
- `go test ./coderd -run '^TestOAuth2ProviderResourceIndicators$' -count=20 -parallel=16`
- `go test ./coderd -run '^TestOIDCOauthLoginWithExisting$'`
- `go test ./coderd/coderdtest ./coderd ./cli ./enterprise/cli -run 'TestNewIsolatedHTTPClient|TestNewIsolatedHTTPSClient|TestCreateAnotherUserHTTPClient|TestDERPForceWebSockets|TestCompositeWorkspaceScopes|TestOAuth2ProviderResourceIndicators|TestDERPHeaders|TestWorkspaceAgent/Headers&DERPHeaders|TestTemplateEdit/AllowAdvancedScheduling|TestTemplateEdit/AllowUserScheduling|TestBoundary' -count=1`
- `make lint`

</details>
