### PR TITLE
fix(site/src/pages/AgentsPage/components): keep ports submenu on screen on mobile

### DIFF
--- a/site/src/pages/AgentsPage/components/WorkspacePill.tsx
+++ b/site/src/pages/AgentsPage/components/WorkspacePill.tsx
@@ -258,7 +258,7 @@ const PortsSubMenuItem: FC<{
 				<NetworkIcon className="size-3.5" />
 				{totalCount !== undefined ? `Ports (${totalCount})` : "Ports"}
 			</DropdownMenuSubTrigger>
-			<DropdownMenuSubContent className="w-56 p-1 [&_[role=menuitem]]:text-xs [&_[role=menuitem]]:py-1 [&_svg]:!size-3.5">
+			<DropdownMenuSubContent className="mobile-full-width-dropdown mobile-full-width-dropdown-bottom w-56 p-1 [&_[role=menuitem]]:text-xs [&_[role=menuitem]]:py-1 [&_svg]:!size-3.5">
 				{/* Listening Ports header: only render when there are ports to list. */}
 				{privateListeningPorts.length > 0 && (
 					<div className="px-2 pb-1.5 pt-1">


### PR DESCRIPTION
## Problem

On the `/agents` page, the workspace pill dropdown has a `Ports (n)`
submenu. On mobile viewports the parent dropdown uses
`mobile-full-width-dropdown`, which pins it to the viewport width.
That leaves no horizontal room for the submenu, and Radix flipping
to `data-side=left` still pushes the 224px-wide submenu off-screen.

DOM measurement at a 390px viewport before the fix:
`x=-203, w=224` (i.e., starts 203px off the left edge).

## Fix

Apply the same `mobile-full-width-dropdown mobile-full-width-dropdown-bottom`
classes to the `Ports` submenu so it also fills the viewport on
mobile, matching the parent dropdown. Desktop keeps the existing
`w-56` width.

Verified at 1280, 768, 390, and 320 px:

| Viewport | Submenu side | Submenu x | Submenu width | On screen? |
| ---: | --- | ---: | ---: | --- |
| 1280 | right | 750 | 224 | yes |
| 768 | right | 494 | 224 | yes |
| 390 | left | 16 | 358 | yes |
| 320 | left | 16 | 288 | yes |

Before the fix, 390 reported `x=-203, w=224`.

`pnpm test:storybook src/pages/AgentsPage/components/WorkspacePill.stories.tsx`
passes (9/9). `make pre-commit` passes.

Coder Agents generated.
