### PR TITLE
fix: add /api prefix to chat swagger annotations

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -64,6 +64,87 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/experimental/chats": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "List chats",
+                "operationId": "list-chats",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Search query",
+                        "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by label as key:value. Repeat for multiple (AND logic).",
+                        "name": "label",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/codersdk.Chat"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "post": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Create chat",
+                "operationId": "create-chat",
+                "parameters": [
+                    {
+                        "description": "Create chat request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.CreateChatRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.Chat"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
         "/api/experimental/chats/config/retention-days": {
             "get": {
                 "produces": [
@@ -126,6 +207,94 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/experimental/chats/files": {
+            "post": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "consumes": [
+                    "image/png",
+                    "image/jpeg",
+                    "image/gif",
+                    "image/webp",
+                    "text/plain",
+                    "text/markdown",
+                    "text/csv",
+                    "application/json",
+                    "application/pdf"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Upload chat file",
+                "operationId": "upload-chat-file",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Organization ID",
+                        "name": "organization",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UploadChatFileResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/files/{file}": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "image/png",
+                    "image/jpeg",
+                    "image/gif",
+                    "image/webp",
+                    "text/plain",
+                    "text/markdown",
+                    "text/csv",
+                    "application/json",
+                    "application/pdf"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat file",
+                "operationId": "get-chat-file",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "File ID",
+                        "name": "file",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
         "/api/experimental/chats/insights/pull-requests": {
             "get": {
                 "produces": [
@@ -168,6 +337,502 @@ const docTemplate = `{
                 "x-apidocgen": {
                     "skip": true
                 }
+            }
+        },
+        "/api/experimental/chats/models": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "List chat models",
+                "operationId": "list-chat-models",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatModelsResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/watch": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Watch chat events for a user via WebSockets",
+                "operationId": "watch-chat-events-for-a-user-via-websockets",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatWatchEvent"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/{chat}": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat by ID",
+                "operationId": "get-chat-by-id",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.Chat"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "patch": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update chat",
+                "operationId": "update-chat",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Update chat request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateChatRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/{chat}/diff": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat diff contents",
+                "operationId": "get-chat-diff-contents",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatDiffContents"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/{chat}/interrupt": {
+            "post": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Interrupt chat",
+                "operationId": "interrupt-chat",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.Chat"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/{chat}/messages": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "List chat messages",
+                "operationId": "list-chat-messages",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Return messages with id \u003c before_id",
+                        "name": "before_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Return messages with id \u003e after_id",
+                        "name": "after_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size, 1 to 200. Defaults to 50.",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatMessagesResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "post": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Send chat message",
+                "operationId": "send-chat-message",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Create chat message request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.CreateChatMessageRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.CreateChatMessageResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/{chat}/messages/{message}": {
+            "patch": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Edit chat message",
+                "operationId": "edit-chat-message",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Message ID",
+                        "name": "message",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Edit chat message request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.EditChatMessageRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.EditChatMessageResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/{chat}/stream": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Stream chat events via WebSockets",
+                "operationId": "stream-chat-events-via-websockets",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatStreamEvent"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/{chat}/stream/desktop": {
+            "get": {
+                "description": "Raw binary WebSocket stream of the chat workspace desktop.\nExperimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/octet-stream"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Connect to chat workspace desktop via WebSockets",
+                "operationId": "connect-to-chat-workspace-desktop-via-websockets",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "101": {
+                        "description": "Switching Protocols"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/{chat}/stream/git": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Watch chat workspace git state via WebSockets",
+                "operationId": "watch-chat-workspace-git-state-via-websockets",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.WorkspaceAgentGitServerMessage"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/{chat}/title/regenerate": {
+            "post": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Regenerate chat title",
+                "operationId": "regenerate-chat-title",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.Chat"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
             }
         },
         "/api/experimental/watch-all-workspacebuilds": {
@@ -12211,671 +12876,6 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/codersdk.ServerSentEvent"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/experimental/chats": {
-            "get": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "List chats",
-                "operationId": "list-chats",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Search query",
-                        "name": "q",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filter by label as key:value. Repeat for multiple (AND logic).",
-                        "name": "label",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/codersdk.Chat"
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            },
-            "post": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Create chat",
-                "operationId": "create-chat",
-                "parameters": [
-                    {
-                        "description": "Create chat request",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.CreateChatRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.Chat"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/experimental/chats/files": {
-            "post": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "consumes": [
-                    "image/png",
-                    "image/jpeg",
-                    "image/gif",
-                    "image/webp",
-                    "text/plain",
-                    "text/markdown",
-                    "text/csv",
-                    "application/json",
-                    "application/pdf"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Upload chat file",
-                "operationId": "upload-chat-file",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Organization ID",
-                        "name": "organization",
-                        "in": "query",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UploadChatFileResponse"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/experimental/chats/files/{file}": {
-            "get": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "produces": [
-                    "image/png",
-                    "image/jpeg",
-                    "image/gif",
-                    "image/webp",
-                    "text/plain",
-                    "text/markdown",
-                    "text/csv",
-                    "application/json",
-                    "application/pdf"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Get chat file",
-                "operationId": "get-chat-file",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "File ID",
-                        "name": "file",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/experimental/chats/models": {
-            "get": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "List chat models",
-                "operationId": "list-chat-models",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatModelsResponse"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/experimental/chats/watch": {
-            "get": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Watch chat events for a user via WebSockets",
-                "operationId": "watch-chat-events-for-a-user-via-websockets",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatWatchEvent"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/experimental/chats/{chat}": {
-            "get": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Get chat by ID",
-                "operationId": "get-chat-by-id",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.Chat"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            },
-            "patch": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "consumes": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Update chat",
-                "operationId": "update-chat",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Update chat request",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.UpdateChatRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/experimental/chats/{chat}/diff": {
-            "get": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Get chat diff contents",
-                "operationId": "get-chat-diff-contents",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatDiffContents"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/experimental/chats/{chat}/interrupt": {
-            "post": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Interrupt chat",
-                "operationId": "interrupt-chat",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.Chat"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/experimental/chats/{chat}/messages": {
-            "get": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "List chat messages",
-                "operationId": "list-chat-messages",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Return messages with id \u003c before_id",
-                        "name": "before_id",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Return messages with id \u003e after_id",
-                        "name": "after_id",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page size, 1 to 200. Defaults to 50.",
-                        "name": "limit",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatMessagesResponse"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            },
-            "post": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Send chat message",
-                "operationId": "send-chat-message",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Create chat message request",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.CreateChatMessageRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.CreateChatMessageResponse"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/experimental/chats/{chat}/messages/{message}": {
-            "patch": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Edit chat message",
-                "operationId": "edit-chat-message",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Message ID",
-                        "name": "message",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Edit chat message request",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.EditChatMessageRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.EditChatMessageResponse"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/experimental/chats/{chat}/stream": {
-            "get": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Stream chat events via WebSockets",
-                "operationId": "stream-chat-events-via-websockets",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.ChatStreamEvent"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/experimental/chats/{chat}/stream/desktop": {
-            "get": {
-                "description": "Raw binary WebSocket stream of the chat workspace desktop.\nExperimental: this endpoint is subject to change.",
-                "produces": [
-                    "application/octet-stream"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Connect to chat workspace desktop via WebSockets",
-                "operationId": "connect-to-chat-workspace-desktop-via-websockets",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "101": {
-                        "description": "Switching Protocols"
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/experimental/chats/{chat}/stream/git": {
-            "get": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Watch chat workspace git state via WebSockets",
-                "operationId": "watch-chat-workspace-git-state-via-websockets",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.WorkspaceAgentGitServerMessage"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "CoderSessionToken": []
-                    }
-                ]
-            }
-        },
-        "/experimental/chats/{chat}/title/regenerate": {
-            "post": {
-                "description": "Experimental: this endpoint is subject to change.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Chats"
-                ],
-                "summary": "Regenerate chat title",
-                "operationId": "regenerate-chat-title",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "Chat ID",
-                        "name": "chat",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/codersdk.Chat"
                         }
                     }
                 },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -49,6 +49,77 @@
 				}
 			}
 		},
+		"/api/experimental/chats": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "List chats",
+				"operationId": "list-chats",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Search query",
+						"name": "q",
+						"in": "query"
+					},
+					{
+						"type": "string",
+						"description": "Filter by label as key:value. Repeat for multiple (AND logic).",
+						"name": "label",
+						"in": "query"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"type": "array",
+							"items": {
+								"$ref": "#/definitions/codersdk.Chat"
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"post": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Create chat",
+				"operationId": "create-chat",
+				"parameters": [
+					{
+						"description": "Create chat request",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.CreateChatRequest"
+						}
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "Created",
+						"schema": {
+							"$ref": "#/definitions/codersdk.Chat"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
 		"/api/experimental/chats/config/retention-days": {
 			"get": {
 				"produces": ["application/json"],
@@ -103,6 +174,88 @@
 				}
 			}
 		},
+		"/api/experimental/chats/files": {
+			"post": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"consumes": [
+					"image/png",
+					"image/jpeg",
+					"image/gif",
+					"image/webp",
+					"text/plain",
+					"text/markdown",
+					"text/csv",
+					"application/json",
+					"application/pdf"
+				],
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Upload chat file",
+				"operationId": "upload-chat-file",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Organization ID",
+						"name": "organization",
+						"in": "query",
+						"required": true
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "Created",
+						"schema": {
+							"$ref": "#/definitions/codersdk.UploadChatFileResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/files/{file}": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": [
+					"image/png",
+					"image/jpeg",
+					"image/gif",
+					"image/webp",
+					"text/plain",
+					"text/markdown",
+					"text/csv",
+					"application/json",
+					"application/pdf"
+				],
+				"tags": ["Chats"],
+				"summary": "Get chat file",
+				"operationId": "get-chat-file",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "File ID",
+						"name": "file",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
 		"/api/experimental/chats/insights/pull-requests": {
 			"get": {
 				"produces": ["application/json"],
@@ -141,6 +294,446 @@
 				"x-apidocgen": {
 					"skip": true
 				}
+			}
+		},
+		"/api/experimental/chats/models": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "List chat models",
+				"operationId": "list-chat-models",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatModelsResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/watch": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Watch chat events for a user via WebSockets",
+				"operationId": "watch-chat-events-for-a-user-via-websockets",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatWatchEvent"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/{chat}": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get chat by ID",
+				"operationId": "get-chat-by-id",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.Chat"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"patch": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"consumes": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update chat",
+				"operationId": "update-chat",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Update chat request",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateChatRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/{chat}/diff": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get chat diff contents",
+				"operationId": "get-chat-diff-contents",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatDiffContents"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/{chat}/interrupt": {
+			"post": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Interrupt chat",
+				"operationId": "interrupt-chat",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.Chat"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/{chat}/messages": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "List chat messages",
+				"operationId": "list-chat-messages",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "integer",
+						"description": "Return messages with id \u003c before_id",
+						"name": "before_id",
+						"in": "query"
+					},
+					{
+						"type": "integer",
+						"description": "Return messages with id \u003e after_id",
+						"name": "after_id",
+						"in": "query"
+					},
+					{
+						"type": "integer",
+						"description": "Page size, 1 to 200. Defaults to 50.",
+						"name": "limit",
+						"in": "query"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatMessagesResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"post": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Send chat message",
+				"operationId": "send-chat-message",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Create chat message request",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.CreateChatMessageRequest"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.CreateChatMessageResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/{chat}/messages/{message}": {
+			"patch": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Edit chat message",
+				"operationId": "edit-chat-message",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "integer",
+						"description": "Message ID",
+						"name": "message",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Edit chat message request",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.EditChatMessageRequest"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.EditChatMessageResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/{chat}/stream": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Stream chat events via WebSockets",
+				"operationId": "stream-chat-events-via-websockets",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatStreamEvent"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/{chat}/stream/desktop": {
+			"get": {
+				"description": "Raw binary WebSocket stream of the chat workspace desktop.\nExperimental: this endpoint is subject to change.",
+				"produces": ["application/octet-stream"],
+				"tags": ["Chats"],
+				"summary": "Connect to chat workspace desktop via WebSockets",
+				"operationId": "connect-to-chat-workspace-desktop-via-websockets",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"101": {
+						"description": "Switching Protocols"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/{chat}/stream/git": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Watch chat workspace git state via WebSockets",
+				"operationId": "watch-chat-workspace-git-state-via-websockets",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.WorkspaceAgentGitServerMessage"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/{chat}/title/regenerate": {
+			"post": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Regenerate chat title",
+				"operationId": "regenerate-chat-title",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.Chat"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
 			}
 		},
 		"/api/experimental/watch-all-workspacebuilds": {
@@ -10835,599 +11428,6 @@
 						"description": "OK",
 						"schema": {
 							"$ref": "#/definitions/codersdk.ServerSentEvent"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/experimental/chats": {
-			"get": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "List chats",
-				"operationId": "list-chats",
-				"parameters": [
-					{
-						"type": "string",
-						"description": "Search query",
-						"name": "q",
-						"in": "query"
-					},
-					{
-						"type": "string",
-						"description": "Filter by label as key:value. Repeat for multiple (AND logic).",
-						"name": "label",
-						"in": "query"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"type": "array",
-							"items": {
-								"$ref": "#/definitions/codersdk.Chat"
-							}
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			},
-			"post": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"consumes": ["application/json"],
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Create chat",
-				"operationId": "create-chat",
-				"parameters": [
-					{
-						"description": "Create chat request",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.CreateChatRequest"
-						}
-					}
-				],
-				"responses": {
-					"201": {
-						"description": "Created",
-						"schema": {
-							"$ref": "#/definitions/codersdk.Chat"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/experimental/chats/files": {
-			"post": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"consumes": [
-					"image/png",
-					"image/jpeg",
-					"image/gif",
-					"image/webp",
-					"text/plain",
-					"text/markdown",
-					"text/csv",
-					"application/json",
-					"application/pdf"
-				],
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Upload chat file",
-				"operationId": "upload-chat-file",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Organization ID",
-						"name": "organization",
-						"in": "query",
-						"required": true
-					}
-				],
-				"responses": {
-					"201": {
-						"description": "Created",
-						"schema": {
-							"$ref": "#/definitions/codersdk.UploadChatFileResponse"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/experimental/chats/files/{file}": {
-			"get": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"produces": [
-					"image/png",
-					"image/jpeg",
-					"image/gif",
-					"image/webp",
-					"text/plain",
-					"text/markdown",
-					"text/csv",
-					"application/json",
-					"application/pdf"
-				],
-				"tags": ["Chats"],
-				"summary": "Get chat file",
-				"operationId": "get-chat-file",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "File ID",
-						"name": "file",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK"
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/experimental/chats/models": {
-			"get": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "List chat models",
-				"operationId": "list-chat-models",
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatModelsResponse"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/experimental/chats/watch": {
-			"get": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Watch chat events for a user via WebSockets",
-				"operationId": "watch-chat-events-for-a-user-via-websockets",
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatWatchEvent"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/experimental/chats/{chat}": {
-			"get": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Get chat by ID",
-				"operationId": "get-chat-by-id",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.Chat"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			},
-			"patch": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"consumes": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Update chat",
-				"operationId": "update-chat",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					},
-					{
-						"description": "Update chat request",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.UpdateChatRequest"
-						}
-					}
-				],
-				"responses": {
-					"204": {
-						"description": "No Content"
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/experimental/chats/{chat}/diff": {
-			"get": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Get chat diff contents",
-				"operationId": "get-chat-diff-contents",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatDiffContents"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/experimental/chats/{chat}/interrupt": {
-			"post": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Interrupt chat",
-				"operationId": "interrupt-chat",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.Chat"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/experimental/chats/{chat}/messages": {
-			"get": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "List chat messages",
-				"operationId": "list-chat-messages",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "integer",
-						"description": "Return messages with id \u003c before_id",
-						"name": "before_id",
-						"in": "query"
-					},
-					{
-						"type": "integer",
-						"description": "Return messages with id \u003e after_id",
-						"name": "after_id",
-						"in": "query"
-					},
-					{
-						"type": "integer",
-						"description": "Page size, 1 to 200. Defaults to 50.",
-						"name": "limit",
-						"in": "query"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatMessagesResponse"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			},
-			"post": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"consumes": ["application/json"],
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Send chat message",
-				"operationId": "send-chat-message",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					},
-					{
-						"description": "Create chat message request",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.CreateChatMessageRequest"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.CreateChatMessageResponse"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/experimental/chats/{chat}/messages/{message}": {
-			"patch": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"consumes": ["application/json"],
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Edit chat message",
-				"operationId": "edit-chat-message",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "integer",
-						"description": "Message ID",
-						"name": "message",
-						"in": "path",
-						"required": true
-					},
-					{
-						"description": "Edit chat message request",
-						"name": "request",
-						"in": "body",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/codersdk.EditChatMessageRequest"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.EditChatMessageResponse"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/experimental/chats/{chat}/stream": {
-			"get": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Stream chat events via WebSockets",
-				"operationId": "stream-chat-events-via-websockets",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.ChatStreamEvent"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/experimental/chats/{chat}/stream/desktop": {
-			"get": {
-				"description": "Raw binary WebSocket stream of the chat workspace desktop.\nExperimental: this endpoint is subject to change.",
-				"produces": ["application/octet-stream"],
-				"tags": ["Chats"],
-				"summary": "Connect to chat workspace desktop via WebSockets",
-				"operationId": "connect-to-chat-workspace-desktop-via-websockets",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"101": {
-						"description": "Switching Protocols"
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/experimental/chats/{chat}/stream/git": {
-			"get": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Watch chat workspace git state via WebSockets",
-				"operationId": "watch-chat-workspace-git-state-via-websockets",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.WorkspaceAgentGitServerMessage"
-						}
-					}
-				},
-				"security": [
-					{
-						"CoderSessionToken": []
-					}
-				]
-			}
-		},
-		"/experimental/chats/{chat}/title/regenerate": {
-			"post": {
-				"description": "Experimental: this endpoint is subject to change.",
-				"produces": ["application/json"],
-				"tags": ["Chats"],
-				"summary": "Regenerate chat title",
-				"operationId": "regenerate-chat-title",
-				"parameters": [
-					{
-						"type": "string",
-						"format": "uuid",
-						"description": "Chat ID",
-						"name": "chat",
-						"in": "path",
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "OK",
-						"schema": {
-							"$ref": "#/definitions/codersdk.Chat"
 						}
 					}
 				},

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -168,7 +168,7 @@ func publishChatConfigEvent(logger slog.Logger, ps dbpubsub.Pubsub, kind pubsub.
 // @Tags Chats
 // @Produce json
 // @Success 200 {object} codersdk.ChatWatchEvent
-// @Router /experimental/chats/watch [get]
+// @Router /api/experimental/chats/watch [get]
 // @Description Experimental: this endpoint is subject to change.
 func (api *API) watchChats(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -234,7 +234,7 @@ func (api *API) watchChats(rw http.ResponseWriter, r *http.Request) {
 //  1. move aggregation to a SQL view with proper in-query authz so we
 //     can return a single row per workspace without this two-pass approach.
 //  2. Restore the below router annotation and un-skip docs gen
-//     <at>Router /experimental/chats/by-workspace [post]
+//     <at>Router /api/experimental/chats/by-workspace [post]
 //
 // @Summary Get latest chats by workspace IDs
 // @ID get-latest-chats-by-workspace-ids
@@ -315,7 +315,7 @@ func (api *API) chatsByWorkspace(rw http.ResponseWriter, r *http.Request) {
 // @Param q query string false "Search query"
 // @Param label query string false "Filter by label as key:value. Repeat for multiple (AND logic)."
 // @Success 200 {array} codersdk.Chat
-// @Router /experimental/chats [get]
+// @Router /api/experimental/chats [get]
 // @Description Experimental: this endpoint is subject to change.
 func (api *API) listChats(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -932,7 +932,7 @@ func (api *API) validateUserChatModelConfigAvailable(
 // @Produce json
 // @Param request body codersdk.CreateChatRequest true "Create chat request"
 // @Success 201 {object} codersdk.Chat
-// @Router /experimental/chats [post]
+// @Router /api/experimental/chats [post]
 // @Description Experimental: this endpoint is subject to change.
 func (api *API) postChats(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -1222,7 +1222,7 @@ func (api *API) postChats(rw http.ResponseWriter, r *http.Request) {
 // @Tags Chats
 // @Produce json
 // @Success 200 {object} codersdk.ChatModelsResponse
-// @Router /experimental/chats/models [get]
+// @Router /api/experimental/chats/models [get]
 // @Description Experimental: this endpoint is subject to change.
 func (api *API) listChatModels(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -1920,7 +1920,7 @@ func (api *API) deleteChatUsageLimitGroupOverride(rw http.ResponseWriter, r *htt
 // @Produce json
 // @Param chat path string true "Chat ID" format(uuid)
 // @Success 200 {object} codersdk.Chat
-// @Router /experimental/chats/{chat} [get]
+// @Router /api/experimental/chats/{chat} [get]
 // @Description Experimental: this endpoint is subject to change.
 //
 //nolint:revive // HTTP handler writes to ResponseWriter.
@@ -1997,7 +1997,7 @@ func (api *API) getChat(rw http.ResponseWriter, r *http.Request) {
 // @Param after_id query int false "Return messages with id > after_id"
 // @Param limit query int false "Page size, 1 to 200. Defaults to 50."
 // @Success 200 {object} codersdk.ChatMessagesResponse
-// @Router /experimental/chats/{chat}/messages [get]
+// @Router /api/experimental/chats/{chat}/messages [get]
 // @Description Experimental: this endpoint is subject to change.
 //
 //nolint:revive // HTTP handler writes to ResponseWriter.
@@ -2150,7 +2150,7 @@ func (api *API) authorizeChatWorkspaceExec(
 // @Produce json
 // @Param chat path string true "Chat ID" format(uuid)
 // @Success 200 {object} codersdk.WorkspaceAgentGitServerMessage
-// @Router /experimental/chats/{chat}/stream/git [get]
+// @Router /api/experimental/chats/{chat}/stream/git [get]
 // @Description Experimental: this endpoint is subject to change.
 //
 //nolint:revive // HTTP handler writes to ResponseWriter.
@@ -2305,7 +2305,7 @@ proxyLoop:
 // @Produce application/octet-stream
 // @Param chat path string true "Chat ID" format(uuid)
 // @Success 101
-// @Router /experimental/chats/{chat}/stream/desktop [get]
+// @Router /api/experimental/chats/{chat}/stream/desktop [get]
 // @Description Raw binary WebSocket stream of the chat workspace desktop.
 // @Description Experimental: this endpoint is subject to change.
 //
@@ -2497,7 +2497,7 @@ func (api *API) applyChatTitleUpdate(
 // @Param chat path string true "Chat ID" format(uuid)
 // @Param request body codersdk.UpdateChatRequest true "Update chat request"
 // @Success 204
-// @Router /experimental/chats/{chat} [patch]
+// @Router /api/experimental/chats/{chat} [patch]
 // @Description Experimental: this endpoint is subject to change.
 func (api *API) patchChat(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -2807,7 +2807,7 @@ func (api *API) writeChildUnarchiveGuard(
 // @Param chat path string true "Chat ID" format(uuid)
 // @Param request body codersdk.CreateChatMessageRequest true "Create chat message request"
 // @Success 200 {object} codersdk.CreateChatMessageResponse
-// @Router /experimental/chats/{chat}/messages [post]
+// @Router /api/experimental/chats/{chat}/messages [post]
 // @Description Experimental: this endpoint is subject to change.
 func (api *API) postChatMessages(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -3005,7 +3005,7 @@ func (api *API) postChatMessages(rw http.ResponseWriter, r *http.Request) {
 // @Param message path int true "Message ID"
 // @Param request body codersdk.EditChatMessageRequest true "Edit chat message request"
 // @Success 200 {object} codersdk.EditChatMessageResponse
-// @Router /experimental/chats/{chat}/messages/{message} [patch]
+// @Router /api/experimental/chats/{chat}/messages/{message} [patch]
 // @Description Experimental: this endpoint is subject to change.
 func (api *API) patchChatMessage(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -3263,7 +3263,7 @@ func (api *API) markChatAsRead(ctx context.Context, chatID uuid.UUID) {
 // @Produce json
 // @Param chat path string true "Chat ID" format(uuid)
 // @Success 200 {object} codersdk.ChatStreamEvent
-// @Router /experimental/chats/{chat}/stream [get]
+// @Router /api/experimental/chats/{chat}/stream [get]
 // @Description Experimental: this endpoint is subject to change.
 func (api *API) streamChat(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -3408,7 +3408,7 @@ func (api *API) streamChat(rw http.ResponseWriter, r *http.Request) {
 // @Param chat path string true "Chat ID" format(uuid)
 // @Produce json
 // @Success 200 {object} codersdk.Chat
-// @Router /experimental/chats/{chat}/interrupt [post]
+// @Router /api/experimental/chats/{chat}/interrupt [post]
 // @Description Experimental: this endpoint is subject to change.
 func (api *API) interruptChat(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -3450,7 +3450,7 @@ func (api *API) interruptChat(rw http.ResponseWriter, r *http.Request) {
 // @Produce json
 // @Param chat path string true "Chat ID" format(uuid)
 // @Success 200 {object} codersdk.Chat
-// @Router /experimental/chats/{chat}/title/regenerate [post]
+// @Router /api/experimental/chats/{chat}/title/regenerate [post]
 // @Description Experimental: this endpoint is subject to change.
 //
 //nolint:revive // HTTP handler writes to ResponseWriter.
@@ -3568,7 +3568,7 @@ func (api *API) proposeChatTitle(rw http.ResponseWriter, r *http.Request) {
 // @Produce json
 // @Param chat path string true "Chat ID" format(uuid)
 // @Success 200 {object} codersdk.ChatDiffContents
-// @Router /experimental/chats/{chat}/diff [get]
+// @Router /api/experimental/chats/{chat}/diff [get]
 // @Description Experimental: this endpoint is subject to change.
 //
 //nolint:revive // HTTP handler writes to ResponseWriter.
@@ -5772,7 +5772,7 @@ func (api *API) deleteUserChatCompactionThreshold(rw http.ResponseWriter, r *htt
 // @Produce json
 // @Param organization query string true "Organization ID" format(uuid)
 // @Success 201 {object} codersdk.UploadChatFileResponse
-// @Router /experimental/chats/files [post]
+// @Router /api/experimental/chats/files [post]
 // @Description Experimental: this endpoint is subject to change.
 func (api *API) postChatFile(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -5911,7 +5911,7 @@ func (api *API) postChatFile(rw http.ResponseWriter, r *http.Request) {
 // @Produce image/png,image/jpeg,image/gif,image/webp,text/plain,text/markdown,text/csv,application/json,application/pdf
 // @Param file path string true "File ID" format(uuid)
 // @Success 200
-// @Router /experimental/chats/files/{file} [get]
+// @Router /api/experimental/chats/files/{file} [get]
 // @Description Experimental: this endpoint is subject to change.
 func (api *API) chatFileByID(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()

--- a/docs/reference/api/chats.md
+++ b/docs/reference/api/chats.md
@@ -6,12 +6,12 @@
 
 ```shell
 # Example request using curl
-curl -X GET http://coder-server:8080/experimental/chats \
+curl -X GET http://coder-server:8080/api/experimental/chats \
   -H 'Accept: application/json' \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /experimental/chats`
+`GET /api/experimental/chats`
 
 Experimental: this endpoint is subject to change.
 
@@ -294,13 +294,13 @@ To perform this operation, you must be authenticated. [Learn more](authenticatio
 
 ```shell
 # Example request using curl
-curl -X POST http://coder-server:8080/experimental/chats \
+curl -X POST http://coder-server:8080/api/experimental/chats \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /experimental/chats`
+`POST /api/experimental/chats`
 
 Experimental: this endpoint is subject to change.
 
@@ -628,12 +628,12 @@ To perform this operation, you must be authenticated. [Learn more](authenticatio
 
 ```shell
 # Example request using curl
-curl -X POST http://coder-server:8080/experimental/chats/files?organization=497f6eca-6276-4993-bfeb-53cbbbba6f08 \
+curl -X POST http://coder-server:8080/api/experimental/chats/files?organization=497f6eca-6276-4993-bfeb-53cbbbba6f08 \
   -H 'Accept: application/json' \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /experimental/chats/files`
+`POST /api/experimental/chats/files`
 
 Experimental: this endpoint is subject to change.
 
@@ -667,11 +667,11 @@ To perform this operation, you must be authenticated. [Learn more](authenticatio
 
 ```shell
 # Example request using curl
-curl -X GET http://coder-server:8080/experimental/chats/files/{file} \
+curl -X GET http://coder-server:8080/api/experimental/chats/files/{file} \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /experimental/chats/files/{file}`
+`GET /api/experimental/chats/files/{file}`
 
 Experimental: this endpoint is subject to change.
 
@@ -695,12 +695,12 @@ To perform this operation, you must be authenticated. [Learn more](authenticatio
 
 ```shell
 # Example request using curl
-curl -X GET http://coder-server:8080/experimental/chats/models \
+curl -X GET http://coder-server:8080/api/experimental/chats/models \
   -H 'Accept: application/json' \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /experimental/chats/models`
+`GET /api/experimental/chats/models`
 
 Experimental: this endpoint is subject to change.
 
@@ -742,12 +742,12 @@ To perform this operation, you must be authenticated. [Learn more](authenticatio
 
 ```shell
 # Example request using curl
-curl -X GET http://coder-server:8080/experimental/chats/watch \
+curl -X GET http://coder-server:8080/api/experimental/chats/watch \
   -H 'Accept: application/json' \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /experimental/chats/watch`
+`GET /api/experimental/chats/watch`
 
 Experimental: this endpoint is subject to change.
 
@@ -912,12 +912,12 @@ To perform this operation, you must be authenticated. [Learn more](authenticatio
 
 ```shell
 # Example request using curl
-curl -X GET http://coder-server:8080/experimental/chats/{chat} \
+curl -X GET http://coder-server:8080/api/experimental/chats/{chat} \
   -H 'Accept: application/json' \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /experimental/chats/{chat}`
+`GET /api/experimental/chats/{chat}`
 
 Experimental: this endpoint is subject to change.
 
@@ -1205,12 +1205,12 @@ To perform this operation, you must be authenticated. [Learn more](authenticatio
 
 ```shell
 # Example request using curl
-curl -X PATCH http://coder-server:8080/experimental/chats/{chat} \
+curl -X PATCH http://coder-server:8080/api/experimental/chats/{chat} \
   -H 'Content-Type: application/json' \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PATCH /experimental/chats/{chat}`
+`PATCH /api/experimental/chats/{chat}`
 
 Experimental: this endpoint is subject to change.
 
@@ -1251,12 +1251,12 @@ To perform this operation, you must be authenticated. [Learn more](authenticatio
 
 ```shell
 # Example request using curl
-curl -X GET http://coder-server:8080/experimental/chats/{chat}/diff \
+curl -X GET http://coder-server:8080/api/experimental/chats/{chat}/diff \
   -H 'Accept: application/json' \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /experimental/chats/{chat}/diff`
+`GET /api/experimental/chats/{chat}/diff`
 
 Experimental: this endpoint is subject to change.
 
@@ -1295,12 +1295,12 @@ To perform this operation, you must be authenticated. [Learn more](authenticatio
 
 ```shell
 # Example request using curl
-curl -X POST http://coder-server:8080/experimental/chats/{chat}/interrupt \
+curl -X POST http://coder-server:8080/api/experimental/chats/{chat}/interrupt \
   -H 'Accept: application/json' \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /experimental/chats/{chat}/interrupt`
+`POST /api/experimental/chats/{chat}/interrupt`
 
 Experimental: this endpoint is subject to change.
 
@@ -1588,12 +1588,12 @@ To perform this operation, you must be authenticated. [Learn more](authenticatio
 
 ```shell
 # Example request using curl
-curl -X GET http://coder-server:8080/experimental/chats/{chat}/messages \
+curl -X GET http://coder-server:8080/api/experimental/chats/{chat}/messages \
   -H 'Accept: application/json' \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /experimental/chats/{chat}/messages`
+`GET /api/experimental/chats/{chat}/messages`
 
 Experimental: this endpoint is subject to change.
 
@@ -1771,13 +1771,13 @@ To perform this operation, you must be authenticated. [Learn more](authenticatio
 
 ```shell
 # Example request using curl
-curl -X POST http://coder-server:8080/experimental/chats/{chat}/messages \
+curl -X POST http://coder-server:8080/api/experimental/chats/{chat}/messages \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /experimental/chats/{chat}/messages`
+`POST /api/experimental/chats/{chat}/messages`
 
 Experimental: this endpoint is subject to change.
 
@@ -1976,13 +1976,13 @@ To perform this operation, you must be authenticated. [Learn more](authenticatio
 
 ```shell
 # Example request using curl
-curl -X PATCH http://coder-server:8080/experimental/chats/{chat}/messages/{message} \
+curl -X PATCH http://coder-server:8080/api/experimental/chats/{chat}/messages/{message} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`PATCH /experimental/chats/{chat}/messages/{message}`
+`PATCH /api/experimental/chats/{chat}/messages/{message}`
 
 Experimental: this endpoint is subject to change.
 
@@ -2112,12 +2112,12 @@ To perform this operation, you must be authenticated. [Learn more](authenticatio
 
 ```shell
 # Example request using curl
-curl -X GET http://coder-server:8080/experimental/chats/{chat}/stream \
+curl -X GET http://coder-server:8080/api/experimental/chats/{chat}/stream \
   -H 'Accept: application/json' \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /experimental/chats/{chat}/stream`
+`GET /api/experimental/chats/{chat}/stream`
 
 Experimental: this endpoint is subject to change.
 
@@ -2378,11 +2378,11 @@ To perform this operation, you must be authenticated. [Learn more](authenticatio
 
 ```shell
 # Example request using curl
-curl -X GET http://coder-server:8080/experimental/chats/{chat}/stream/desktop \
+curl -X GET http://coder-server:8080/api/experimental/chats/{chat}/stream/desktop \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /experimental/chats/{chat}/stream/desktop`
+`GET /api/experimental/chats/{chat}/stream/desktop`
 
 Raw binary WebSocket stream of the chat workspace desktop.
 Experimental: this endpoint is subject to change.
@@ -2407,12 +2407,12 @@ To perform this operation, you must be authenticated. [Learn more](authenticatio
 
 ```shell
 # Example request using curl
-curl -X GET http://coder-server:8080/experimental/chats/{chat}/stream/git \
+curl -X GET http://coder-server:8080/api/experimental/chats/{chat}/stream/git \
   -H 'Accept: application/json' \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`GET /experimental/chats/{chat}/stream/git`
+`GET /api/experimental/chats/{chat}/stream/git`
 
 Experimental: this endpoint is subject to change.
 
@@ -2457,12 +2457,12 @@ To perform this operation, you must be authenticated. [Learn more](authenticatio
 
 ```shell
 # Example request using curl
-curl -X POST http://coder-server:8080/experimental/chats/{chat}/title/regenerate \
+curl -X POST http://coder-server:8080/api/experimental/chats/{chat}/title/regenerate \
   -H 'Accept: application/json' \
   -H 'Coder-Session-Token: API_KEY'
 ```
 
-`POST /experimental/chats/{chat}/title/regenerate`
+`POST /api/experimental/chats/{chat}/title/regenerate`
 
 Experimental: this endpoint is subject to change.
 


### PR DESCRIPTION
Fixes API endpoints in exp_chats.go to ensure the API endpoints show up correctly.

> 🤖