### PR TITLE
fix: scan coder-preview:main instead of coder:latest

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -68,7 +68,7 @@ jobs:
       security-events: write
     runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-8' || 'ubuntu-latest' }}
     env:
-      IMAGE_REF: ghcr.io/coder/coder:latest
+      IMAGE_REF: ghcr.io/coder/coder-preview:main
       OSV_SCANNER_VERSION: v2.3.5
     steps:
       - name: Harden Runner
@@ -82,7 +82,7 @@ jobs:
             "https://github.com/google/osv-scanner/releases/download/${OSV_SCANNER_VERSION}/osv-scanner_linux_amd64"
           chmod +x /usr/local/bin/osv-scanner
 
-      - name: Pull released Coder image
+      - name: Pull latest Coder preview image
         run: docker pull "$IMAGE_REF"
 
       - name: Run OSV-Scanner vulnerability scanner


### PR DESCRIPTION
The OSV-Scanner job in the security workflow scanned `ghcr.io/coder/coder:latest`, which only updates on releases. Vulnerabilities fixed on main would not clear until the next release.

Switch to `ghcr.io/coder/coder-preview:main`, which is rebuilt on every commit to main, so scan results reflect the current state of the default branch.

> Generated with [Coder Agents](https://coder.com/agents)