### PR TITLE
fix: infer workspace claim time from build history for /agents delete dialog

### DIFF
--- a/coderd/database/constants.go
+++ b/coderd/database/constants.go
@@ -1,5 +1,12 @@
 package database
 
-import "github.com/google/uuid"
+import (
+	"github.com/google/uuid"
 
-var PrebuildsSystemUserID = uuid.MustParse("c42fdf75-3097-471c-8c33-fb52454d81c0")
+	"github.com/coder/coder/v2/codersdk"
+)
+
+// PrebuildsSystemUserID mirrors codersdk.PrebuildsSystemUserID, parsed
+// for use as a uuid.UUID. Both must agree; tests pin the value to the
+// codersdk constant so the two cannot drift.
+var PrebuildsSystemUserID = uuid.MustParse(codersdk.PrebuildsSystemUserID)

--- a/codersdk/prebuilds.go
+++ b/codersdk/prebuilds.go
@@ -6,6 +6,13 @@ import (
 	"net/http"
 )
 
+// PrebuildsSystemUserID is the UUID of the Coder prebuilds system
+// user. Prebuilt workspaces are owned by this user until they are
+// claimed; build #1 of a claimed workspace remains attributed to
+// this user as the initiator forever, which is how callers can
+// recognize a prebuild claim after the fact.
+const PrebuildsSystemUserID = "c42fdf75-3097-471c-8c33-fb52454d81c0"
+
 type PrebuildsSettings struct {
 	ReconciliationPaused bool `json:"reconciliation_paused"`
 }

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -5916,6 +5916,16 @@ export interface PrebuildsSettings {
 	readonly reconciliation_paused: boolean;
 }
 
+// From codersdk/prebuilds.go
+/**
+ * PrebuildsSystemUserID is the UUID of the Coder prebuilds system
+ * user. Prebuilt workspaces are owned by this user until they are
+ * claimed; build #1 of a claimed workspace remains attributed to
+ * this user as the initiator forever, which is how callers can
+ * recognize a prebuild claim after the fact.
+ */
+export const PrebuildsSystemUserID = "c42fdf75-3097-471c-8c33-fb52454d81c0";
+
 // From codersdk/presets.go
 export interface Preset {
 	readonly ID: string;

--- a/site/src/pages/AgentsPage/AgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentsPage.tsx
@@ -340,6 +340,19 @@ const AgentsPage: FC = () => {
 		try {
 			const action = await resolveArchiveAndDeleteAction(
 				() => queryClient.fetchQuery(workspaceById(workspaceId)),
+				// We only need build_number 1 and 2 to recognise a
+				// prebuild claim. The default page is newest-first; the
+				// resolver degrades safely ("confirm") if those builds
+				// aren't in the returned slice.
+				() =>
+					queryClient.fetchQuery({
+						queryKey: [
+							"workspaceBuilds",
+							workspaceId,
+							"archive-and-delete-resolver",
+						],
+						queryFn: () => API.getWorkspaceBuilds(workspaceId),
+					}),
 				() =>
 					readInfiniteChatsCache(queryClient)?.find((c) => c.id === chatId)
 						?.created_at,

--- a/site/src/pages/AgentsPage/utils/agentWorkspaceUtils.test.ts
+++ b/site/src/pages/AgentsPage/utils/agentWorkspaceUtils.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { PrebuildsSystemUserID } from "#/api/typesGenerated";
 import {
 	archiveChatAndDeleteWorkspace,
 	isWorkspaceAutoCreated,
@@ -8,7 +9,6 @@ import {
 	workspaceAcquiredAt,
 } from "./agentWorkspaceUtils";
 
-const PREBUILDS_USER = "c42fdf75-3097-471c-8c33-fb52454d81c0";
 const REAL_USER = "11111111-2222-3333-4444-555555555555";
 
 describe("workspaceAcquiredAt", () => {
@@ -43,7 +43,7 @@ describe("workspaceAcquiredAt", () => {
 			},
 			{
 				build_number: 1,
-				initiator_id: PREBUILDS_USER,
+				initiator_id: PrebuildsSystemUserID,
 				created_at: "2026-01-01T08:00:01Z",
 			},
 		];
@@ -55,7 +55,7 @@ describe("workspaceAcquiredAt", () => {
 		const builds = [
 			{
 				build_number: 1,
-				initiator_id: PREBUILDS_USER,
+				initiator_id: PrebuildsSystemUserID,
 				created_at: "2026-01-01T08:00:01Z",
 			},
 		];
@@ -87,7 +87,7 @@ describe("workspaceAcquiredAt", () => {
 			},
 			{
 				build_number: 1,
-				initiator_id: PREBUILDS_USER,
+				initiator_id: PrebuildsSystemUserID,
 				created_at: "2026-01-01T08:00:01Z",
 			},
 		];
@@ -149,7 +149,7 @@ describe("isWorkspaceAutoCreated", () => {
 				},
 				{
 					build_number: 1,
-					initiator_id: PREBUILDS_USER,
+					initiator_id: PrebuildsSystemUserID,
 					created_at: "2026-01-01T08:00:01Z",
 				},
 			],
@@ -167,7 +167,7 @@ describe("isWorkspaceAutoCreated", () => {
 				},
 				{
 					build_number: 1,
-					initiator_id: PREBUILDS_USER,
+					initiator_id: PrebuildsSystemUserID,
 					created_at: "2026-01-01T08:00:01Z",
 				},
 			],
@@ -180,7 +180,7 @@ describe("isWorkspaceAutoCreated", () => {
 			builds: [
 				{
 					build_number: 1,
-					initiator_id: PREBUILDS_USER,
+					initiator_id: PrebuildsSystemUserID,
 					created_at: "2026-01-01T08:00:01Z",
 				},
 			],
@@ -431,7 +431,7 @@ describe("resolveArchiveAndDeleteAction", () => {
 				},
 				{
 					build_number: 1,
-					initiator_id: PREBUILDS_USER,
+					initiator_id: PrebuildsSystemUserID,
 					created_at: "2025-12-15T00:00:00Z",
 				},
 			],
@@ -449,7 +449,7 @@ describe("resolveArchiveAndDeleteAction", () => {
 				},
 				{
 					build_number: 1,
-					initiator_id: PREBUILDS_USER,
+					initiator_id: PrebuildsSystemUserID,
 					created_at: "2025-12-15T00:00:00Z",
 				},
 			],

--- a/site/src/pages/AgentsPage/utils/agentWorkspaceUtils.test.ts
+++ b/site/src/pages/AgentsPage/utils/agentWorkspaceUtils.test.ts
@@ -5,42 +5,200 @@ import {
 	isWorkspaceNotFound,
 	resolveArchiveAndDeleteAction,
 	shouldNavigateAfterArchive,
+	workspaceAcquiredAt,
 } from "./agentWorkspaceUtils";
+
+const PREBUILDS_USER = "c42fdf75-3097-471c-8c33-fb52454d81c0";
+const REAL_USER = "11111111-2222-3333-4444-555555555555";
+
+describe("workspaceAcquiredAt", () => {
+	it("returns workspace.created_at when no builds exist", () => {
+		const ws = { created_at: "2026-01-01T00:00:00Z" };
+		expect(workspaceAcquiredAt(ws, [])).toBe("2026-01-01T00:00:00Z");
+	});
+
+	it("returns workspace.created_at when build #1 was initiated by a real user", () => {
+		const ws = { created_at: "2026-01-01T00:00:00Z" };
+		const builds = [
+			{
+				build_number: 1,
+				initiator_id: REAL_USER,
+				created_at: "2026-01-01T00:00:01Z",
+			},
+		];
+		expect(workspaceAcquiredAt(ws, builds)).toBe("2026-01-01T00:00:00Z");
+	});
+
+	it("returns build #2 created_at when build #1 was initiated by the prebuilds user", () => {
+		// Workspace.created_at predates the chat (the prebuild was
+		// provisioned long before the chat existed), but build #2 is
+		// the claim and that's the moment the chat acquired the
+		// workspace.
+		const ws = { created_at: "2026-01-01T08:00:00Z" };
+		const builds = [
+			{
+				build_number: 2,
+				initiator_id: REAL_USER,
+				created_at: "2026-01-01T12:00:05Z",
+			},
+			{
+				build_number: 1,
+				initiator_id: PREBUILDS_USER,
+				created_at: "2026-01-01T08:00:01Z",
+			},
+		];
+		expect(workspaceAcquiredAt(ws, builds)).toBe("2026-01-01T12:00:05Z");
+	});
+
+	it("returns null when prebuild has no claim build yet", () => {
+		const ws = { created_at: "2026-01-01T08:00:00Z" };
+		const builds = [
+			{
+				build_number: 1,
+				initiator_id: PREBUILDS_USER,
+				created_at: "2026-01-01T08:00:01Z",
+			},
+		];
+		expect(workspaceAcquiredAt(ws, builds)).toBeNull();
+	});
+
+	it("ignores extra builds beyond #1 and #2", () => {
+		const ws = { created_at: "2026-01-01T08:00:00Z" };
+		const builds = [
+			{
+				build_number: 5,
+				initiator_id: REAL_USER,
+				created_at: "2026-02-01T00:00:00Z",
+			},
+			{
+				build_number: 4,
+				initiator_id: REAL_USER,
+				created_at: "2026-01-15T00:00:00Z",
+			},
+			{
+				build_number: 3,
+				initiator_id: REAL_USER,
+				created_at: "2026-01-10T00:00:00Z",
+			},
+			{
+				build_number: 2,
+				initiator_id: REAL_USER,
+				created_at: "2026-01-01T12:00:05Z",
+			},
+			{
+				build_number: 1,
+				initiator_id: PREBUILDS_USER,
+				created_at: "2026-01-01T08:00:01Z",
+			},
+		];
+		expect(workspaceAcquiredAt(ws, builds)).toBe("2026-01-01T12:00:05Z");
+	});
+});
 
 describe("isWorkspaceAutoCreated", () => {
 	it.each([
 		{
-			name: "workspace created after chat",
-			workspace: "2026-01-01T00:00:05Z",
+			name: "from-scratch workspace created after chat",
+			workspace: { created_at: "2026-01-01T00:00:05Z" },
+			builds: [
+				{
+					build_number: 1,
+					initiator_id: REAL_USER,
+					created_at: "2026-01-01T00:00:05Z",
+				},
+			],
 			chat: "2026-01-01T00:00:00Z",
 			expected: true,
 		},
 		{
-			name: "workspace created at same time as chat",
-			workspace: "2026-01-01T12:00:00Z",
+			name: "from-scratch workspace created at same time as chat",
+			workspace: { created_at: "2026-01-01T12:00:00Z" },
+			builds: [
+				{
+					build_number: 1,
+					initiator_id: REAL_USER,
+					created_at: "2026-01-01T12:00:00Z",
+				},
+			],
 			chat: "2026-01-01T12:00:00Z",
 			expected: true,
 		},
 		{
-			name: "workspace created before chat",
-			workspace: "2026-01-01T11:59:59Z",
+			name: "from-scratch workspace created before chat",
+			workspace: { created_at: "2026-01-01T11:59:59Z" },
+			builds: [
+				{
+					build_number: 1,
+					initiator_id: REAL_USER,
+					created_at: "2026-01-01T11:59:59Z",
+				},
+			],
+			chat: "2026-01-01T12:00:00Z",
+			expected: false,
+		},
+		// Prebuild claim cases: workspace.created_at predates the
+		// chat, but build #2 (the claim) happened after the chat.
+		{
+			name: "prebuild claimed after chat",
+			workspace: { created_at: "2026-01-01T08:00:00Z" },
+			builds: [
+				{
+					build_number: 2,
+					initiator_id: REAL_USER,
+					created_at: "2026-01-01T12:00:05Z",
+				},
+				{
+					build_number: 1,
+					initiator_id: PREBUILDS_USER,
+					created_at: "2026-01-01T08:00:01Z",
+				},
+			],
+			chat: "2026-01-01T12:00:00Z",
+			expected: true,
+		},
+		{
+			name: "prebuild claimed before chat",
+			workspace: { created_at: "2026-01-01T08:00:00Z" },
+			builds: [
+				{
+					build_number: 2,
+					initiator_id: REAL_USER,
+					created_at: "2026-01-01T11:00:00Z",
+				},
+				{
+					build_number: 1,
+					initiator_id: PREBUILDS_USER,
+					created_at: "2026-01-01T08:00:01Z",
+				},
+			],
 			chat: "2026-01-01T12:00:00Z",
 			expected: false,
 		},
 		{
-			name: "sub-second precision difference",
-			workspace: "2026-01-01T00:00:00.001Z",
-			chat: "2026-01-01T00:00:00.000Z",
-			expected: true,
-		},
-		{
-			name: "workspace predates chat by days",
-			workspace: "2026-03-10T10:00:00Z",
-			chat: "2026-03-15T10:00:00Z",
+			name: "unclaimed prebuild treated as not auto-created",
+			workspace: { created_at: "2026-01-01T08:00:00Z" },
+			builds: [
+				{
+					build_number: 1,
+					initiator_id: PREBUILDS_USER,
+					created_at: "2026-01-01T08:00:01Z",
+				},
+			],
+			chat: "2026-01-01T12:00:00Z",
 			expected: false,
 		},
-	])("$name → $expected", ({ workspace, chat, expected }) => {
-		expect(isWorkspaceAutoCreated(workspace, chat)).toBe(expected);
+		{
+			// Defensive: build history empty. Fall back to
+			// workspace.created_at so we still allow the proceed
+			// path in the common case rather than blocking on data.
+			name: "no builds, falls back to workspace.created_at",
+			workspace: { created_at: "2026-01-01T12:00:05Z" },
+			builds: [],
+			chat: "2026-01-01T12:00:00Z",
+			expected: true,
+		},
+	])("$name → $expected", ({ workspace, builds, chat, expected }) => {
+		expect(isWorkspaceAutoCreated(workspace, builds, chat)).toBe(expected);
 	});
 });
 
@@ -221,29 +379,101 @@ describe("archiveChatAndDeleteWorkspace", () => {
 describe("resolveArchiveAndDeleteAction", () => {
 	it.each([
 		{
-			name: "auto-created workspace → proceed",
-			workspaceCreatedAt: "2026-01-01T00:00:05Z",
+			name: "from-scratch workspace created after chat → proceed",
+			workspace: { created_at: "2026-01-01T00:00:05Z" },
+			builds: [
+				{
+					build_number: 1,
+					initiator_id: REAL_USER,
+					created_at: "2026-01-01T00:00:05Z",
+				},
+			],
 			chatCreatedAt: "2026-01-01T00:00:00Z",
 			expected: "proceed",
 		},
 		{
 			name: "workspace predates chat → confirm",
-			workspaceCreatedAt: "2025-12-01T00:00:00Z",
+			workspace: { created_at: "2025-12-01T00:00:00Z" },
+			builds: [
+				{
+					build_number: 1,
+					initiator_id: REAL_USER,
+					created_at: "2025-12-01T00:00:00Z",
+				},
+			],
 			chatCreatedAt: "2026-01-01T00:00:00Z",
 			expected: "confirm",
 		},
 		{
 			name: "chat not found in cache → confirm",
-			workspaceCreatedAt: "2026-01-01T00:00:05Z",
+			workspace: { created_at: "2026-01-01T00:00:05Z" },
+			builds: [
+				{
+					build_number: 1,
+					initiator_id: REAL_USER,
+					created_at: "2026-01-01T00:00:05Z",
+				},
+			],
 			chatCreatedAt: undefined,
 			expected: "confirm",
 		},
-	])("$name", async ({ workspaceCreatedAt, chatCreatedAt, expected }) => {
+		{
+			// The bug this PR fixes: workspace.created_at predates
+			// the chat (the prebuild was provisioned earlier) but
+			// build #2 is the claim and happened after the chat.
+			name: "prebuild claimed after chat → proceed",
+			workspace: { created_at: "2025-12-15T00:00:00Z" },
+			builds: [
+				{
+					build_number: 2,
+					initiator_id: REAL_USER,
+					created_at: "2026-01-01T00:00:05Z",
+				},
+				{
+					build_number: 1,
+					initiator_id: PREBUILDS_USER,
+					created_at: "2025-12-15T00:00:00Z",
+				},
+			],
+			chatCreatedAt: "2026-01-01T00:00:00Z",
+			expected: "proceed",
+		},
+		{
+			name: "prebuild claimed before chat → confirm",
+			workspace: { created_at: "2025-12-15T00:00:00Z" },
+			builds: [
+				{
+					build_number: 2,
+					initiator_id: REAL_USER,
+					created_at: "2025-12-31T00:00:00Z",
+				},
+				{
+					build_number: 1,
+					initiator_id: PREBUILDS_USER,
+					created_at: "2025-12-15T00:00:00Z",
+				},
+			],
+			chatCreatedAt: "2026-01-01T00:00:00Z",
+			expected: "confirm",
+		},
+	])("$name", async ({ workspace, builds, chatCreatedAt, expected }) => {
 		const result = await resolveArchiveAndDeleteAction(
-			async () => ({ created_at: workspaceCreatedAt }),
+			async () => workspace,
+			async () => builds,
 			() => chatCreatedAt,
 		);
 		expect(result).toBe(expected);
+	});
+
+	it("does not fetch builds when the chat is not in the cache", async () => {
+		const fetchBuilds = vi.fn(async () => []);
+		const result = await resolveArchiveAndDeleteAction(
+			async () => ({ created_at: "2026-01-01T00:00:00Z" }),
+			fetchBuilds,
+			() => undefined,
+		);
+		expect(result).toBe("confirm");
+		expect(fetchBuilds).not.toHaveBeenCalled();
 	});
 
 	it("propagates non-404-or-410 workspace fetch errors", async () => {
@@ -260,6 +490,7 @@ describe("resolveArchiveAndDeleteAction", () => {
 				async () => {
 					throw error;
 				},
+				async () => [],
 				() => "2026-01-01T00:00:00Z",
 			),
 		).rejects.toBe(error);
@@ -279,6 +510,7 @@ describe("resolveArchiveAndDeleteAction", () => {
 				async () => {
 					throw error;
 				},
+				async () => [],
 				() => "2026-01-01T00:00:00Z",
 			),
 		).resolves.toBe("archive-only");
@@ -298,9 +530,50 @@ describe("resolveArchiveAndDeleteAction", () => {
 				async () => {
 					throw error;
 				},
+				async () => [],
 				() => "2026-01-01T00:00:00Z",
 			),
 		).resolves.toBe("archive-only");
+	});
+
+	it("returns archive-only when the builds fetch returns 404", async () => {
+		const error = {
+			isAxiosError: true,
+			response: {
+				status: 404,
+				data: { message: "Workspace not found" },
+			},
+		};
+
+		await expect(
+			resolveArchiveAndDeleteAction(
+				async () => ({ created_at: "2026-01-01T00:00:00Z" }),
+				async () => {
+					throw error;
+				},
+				() => "2026-01-01T00:00:00Z",
+			),
+		).resolves.toBe("archive-only");
+	});
+
+	it("propagates non-404-or-410 builds fetch errors", async () => {
+		const error = {
+			isAxiosError: true,
+			response: {
+				status: 500,
+				data: { message: "Internal server error" },
+			},
+		};
+
+		await expect(
+			resolveArchiveAndDeleteAction(
+				async () => ({ created_at: "2026-01-01T00:00:00Z" }),
+				async () => {
+					throw error;
+				},
+				() => "2026-01-01T00:00:00Z",
+			),
+		).rejects.toBe(error);
 	});
 });
 

--- a/site/src/pages/AgentsPage/utils/agentWorkspaceUtils.ts
+++ b/site/src/pages/AgentsPage/utils/agentWorkspaceUtils.ts
@@ -1,15 +1,8 @@
 import { isAxiosError } from "axios";
-import type { WorkspaceBuild } from "#/api/typesGenerated";
-
-// The hard-coded UUID of the Coder prebuilds system user. Prebuilt
-// workspaces are owned by this user until claim. Build #1 of a
-// claimed workspace is permanently attributed to this user as the
-// initiator, which is how we recognize prebuild claims after the
-// fact.
-//
-// This UUID is stable and lives in coderd/database/constants.go on
-// the backend. If it ever changes, both sides must move in lockstep.
-const PREBUILDS_SYSTEM_USER_ID = "c42fdf75-3097-471c-8c33-fb52454d81c0";
+import {
+	PrebuildsSystemUserID,
+	type WorkspaceBuild,
+} from "#/api/typesGenerated";
 
 /**
  * Returns the moment a workspace's identity transferred to its
@@ -43,7 +36,7 @@ export function workspaceAcquiredAt(
 	if (!build1) {
 		return workspace.created_at;
 	}
-	if (build1.initiator_id !== PREBUILDS_SYSTEM_USER_ID) {
+	if (build1.initiator_id !== PrebuildsSystemUserID) {
 		return workspace.created_at;
 	}
 	const build2 = builds.find((b) => b.build_number === 2);

--- a/site/src/pages/AgentsPage/utils/agentWorkspaceUtils.ts
+++ b/site/src/pages/AgentsPage/utils/agentWorkspaceUtils.ts
@@ -1,17 +1,77 @@
 import { isAxiosError } from "axios";
+import type { WorkspaceBuild } from "#/api/typesGenerated";
+
+// The hard-coded UUID of the Coder prebuilds system user. Prebuilt
+// workspaces are owned by this user until claim. Build #1 of a
+// claimed workspace is permanently attributed to this user as the
+// initiator, which is how we recognize prebuild claims after the
+// fact.
+//
+// This UUID is stable and lives in coderd/database/constants.go on
+// the backend. If it ever changes, both sides must move in lockstep.
+const PREBUILDS_SYSTEM_USER_ID = "c42fdf75-3097-471c-8c33-fb52454d81c0";
 
 /**
- * Determines whether a workspace was auto-created by a chat.
- * Workspaces created at or after the chat's creation time are
- * considered auto-created (the chat provisioned them). Pre-existing
- * workspaces that were manually associated need a confirmation
- * dialog before deletion.
+ * Returns the moment a workspace's identity transferred to its
+ * current owner.
+ *
+ * For workspaces created from scratch, this is `workspace.created_at`:
+ * build #1 already belongs to the current owner.
+ *
+ * For workspaces claimed from a prebuild, this is the start time of
+ * build #2 (the claim build). `workspace.created_at` for those
+ * workspaces reflects when the prebuild was provisioned, often well
+ * before the chat that claimed it existed, which is why the original
+ * `created_at` heuristic misfired the deletion confirmation dialog.
+ *
+ * Returns `null` when the result cannot be determined, for example
+ * an unclaimed prebuild (build #1 by prebuilds system user, no build
+ * #2). Callers should treat `null` as "force the confirmation
+ * dialog"; the deletion path is destructive and should err on the
+ * side of asking.
+ */
+export function workspaceAcquiredAt(
+	workspace: { created_at: string },
+	builds: readonly Pick<
+		WorkspaceBuild,
+		"build_number" | "initiator_id" | "created_at"
+	>[],
+): string | null {
+	const build1 = builds.find((b) => b.build_number === 1);
+	// No history at all (shouldn't happen for an existing workspace);
+	// fall back to created_at rather than blocking on missing data.
+	if (!build1) {
+		return workspace.created_at;
+	}
+	if (build1.initiator_id !== PREBUILDS_SYSTEM_USER_ID) {
+		return workspace.created_at;
+	}
+	const build2 = builds.find((b) => b.build_number === 2);
+	return build2 ? build2.created_at : null;
+}
+
+/**
+ * Determines whether a workspace was auto-created by a chat. A
+ * workspace is "auto-created" if the chat acquired it (via creation
+ * from scratch or by claiming a prebuild) at or after the chat's own
+ * creation time.
+ *
+ * Pre-existing workspaces that were manually associated with the
+ * chat need a confirmation dialog before deletion.
  */
 export function isWorkspaceAutoCreated(
-	workspaceCreatedAt: string,
+	workspace: { created_at: string },
+	builds: readonly Pick<
+		WorkspaceBuild,
+		"build_number" | "initiator_id" | "created_at"
+	>[],
 	chatCreatedAt: string,
 ): boolean {
-	return new Date(workspaceCreatedAt) >= new Date(chatCreatedAt);
+	const acquiredAt = workspaceAcquiredAt(workspace, builds);
+	if (acquiredAt === null) {
+		return false;
+	}
+	return new Date(acquiredAt) >= new Date(chatCreatedAt);
 }
 
 /**
@@ -78,14 +138,18 @@ export function shouldNavigateAfterArchive(
 /**
  * Resolves whether an archive-and-delete action should proceed
  * immediately or require user confirmation. Fetches the workspace
- * to compare its creation time against the chat's. Auto-created
- * workspaces (provisioned by the chat) skip the confirmation
- * dialog; pre-existing workspaces require the user to type the
- * workspace name.
+ * and its build history to determine when the workspace was
+ * acquired (claim time for prebuilts, creation time otherwise) and
+ * compares against the chat's creation time. Auto-created
+ * workspaces (provisioned or claimed by the chat) skip the
+ * confirmation dialog; pre-existing workspaces require the user to
+ * type the workspace name.
  *
  * @param fetchWorkspace - Retrieves the workspace (e.g. via
- *   `queryClient.fetchQuery`). The result must include
- *   `created_at`.
+ *   `queryClient.fetchQuery`). The result must include `created_at`.
+ * @param fetchBuilds - Retrieves the workspace's build history. The
+ *   first call only needs build_number 1 and 2, but callers will
+ *   typically pass the full list.
  * @param getChatCreatedAt - Returns the chat's `created_at`
  *   timestamp, or `undefined` if the chat is not in the cache.
  * @returns `"proceed"` to skip the dialog, `"archive-only"` to archive
@@ -94,6 +158,12 @@ export function shouldNavigateAfterArchive(
  */
 export async function resolveArchiveAndDeleteAction(
 	fetchWorkspace: () => Promise<{ created_at: string }>,
+	fetchBuilds: () => Promise<
+		readonly Pick<
+			WorkspaceBuild,
+			"build_number" | "initiator_id" | "created_at"
+		>[]
+	>,
 	getChatCreatedAt: () => string | undefined,
 ): Promise<"proceed" | "confirm" | "archive-only"> {
 	let workspace: { created_at: string };
@@ -106,10 +176,22 @@ export async function resolveArchiveAndDeleteAction(
 		throw error;
 	}
 	const chatCreatedAt = getChatCreatedAt();
-	if (
-		chatCreatedAt &&
-		isWorkspaceAutoCreated(workspace.created_at, chatCreatedAt)
-	) {
+	if (!chatCreatedAt) {
+		return "confirm";
+	}
+	let builds: readonly Pick<
+		WorkspaceBuild,
+		"build_number" | "initiator_id" | "created_at"
+	>[];
+	try {
+		builds = await fetchBuilds();
+	} catch (error) {
+		if (isWorkspaceNotFound(error)) {
+			return "archive-only";
+		}
+		throw error;
+	}
+	if (isWorkspaceAutoCreated(workspace, builds, chatCreatedAt)) {
 		return "proceed";
 	}
 	return "confirm";


### PR DESCRIPTION
Closes [CODAGT-317](https://linear.app/codercom/issue/CODAGT-317/pr-workspaces-sometimes-require-name-confirmation-to-delete).

## Problem

The `/agents` archive-and-delete molly-guard (typing the workspace name) was firing for chats that had clearly created their own workspace. The heuristic in `resolveArchiveAndDeleteAction` decides whether confirmation is needed by comparing the workspace's `created_at` against the chat's `created_at`:

```ts
return new Date(workspaceCreatedAt) >= new Date(chatCreatedAt);
```

That assumption breaks for **prebuilt workspaces**. `ClaimPrebuiltWorkspace` rewrites `owner_id`, `name`, `updated_at`, `last_used_at`, etc., but **never touches `created_at`**, which still reflects when the prebuild was provisioned by the reconciler, often hours before the chat exists. Result: every prebuild-claimed workspace looks pre-existing, so the molly-guard fires.

Concrete example from a real chat:

| Field | Value |
|---|---|
| `chat.created_at` | `2026-05-07T15:12:23Z` |
| `workspace.created_at` (provision) | `2026-05-07T14:22:24Z` |
| `latest_build.created_at` (claim) | `2026-05-07T15:19:09Z` |

`14:22:24 < 15:12:23` so `isWorkspaceAutoCreated` returned false even though the chat issued the claim.

## Fix (frontend-only)

Derive the moment a workspace was acquired from existing build history rather than relying on `workspace.created_at`:

- Build #1 initiator = prebuilds system user → workspace was a prebuild → use `build_2.created_at` (the claim build) as the acquisition time.
- Build #1 initiator = real user → workspace was created from scratch → use `workspace.created_at` (unchanged behavior).
- Unclaimed prebuild or no build history → return `null` (force confirmation; safe degradation for a destructive flow).

The resolver fetches the build list via the existing `getWorkspaceBuilds` endpoint when the dialog might fire. No new column, no migration, no schema change. Works retroactively for all existing claimed prebuilds; no backfill needed.

The prebuilds system user UUID is exposed via `codersdk.PrebuildsSystemUserID` and typegen'd to `typesGenerated.ts`. `coderd/database.PrebuildsSystemUserID` parses that constant via `uuid.MustParse` so the two cannot drift; if the codersdk literal ever changes, package init fails fast.

## History

The first draft of this PR added a `workspaces.claimed_at` column populated by `ClaimPrebuiltWorkspace`. After review feedback from @johnstcn pointing out that the same fact is already implicit in build history, I pivoted to the frontend-only approach. Subsequent review notes consolidated the prebuilds system user UUID into a single typegen'd constant.

## Why not the other open PRs

- **#25055** (`chatKey` cache fallback) only fixes a different cache-miss path; it explicitly notes it does not address `created_at < chat.created_at`.
- **#25053** (`chats.workspace_auto_created` boolean) puts the truth on the wrong side of the schema: "this workspace was claimed at time T" is a property of the workspace, not the chat. The MCP plumbing it adds is also unnecessary now that the same answer is available from build history.

## Test plan

- `pnpm vitest run --project=unit src/pages/AgentsPage/utils/agentWorkspaceUtils.test.ts` — 40/40 pass; new cases cover prebuild claim before/after chat, unclaimed prebuild, missing-build-history fallback, and the fetch-skip when the chat is not in cache.
- `pnpm lint:types`, `pnpm check`, `make pre-commit`.

<details>
<summary>Disclosure</summary>

Opened on behalf of @kylecarbs by [Coder Agents](https://coder.com/coder-agents).
</details>