### PR TITLE
feat: trust Coder-Authorization header from upstream auth gateways

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -641,6 +641,8 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 			externalAuthHeaderConfig, err := httpmw.ParseExternalAuthHeaderConfig(
 				vals.Dangerous.AllowExternalAuthHeader.Value(),
 				vals.Dangerous.ExternalAuthHeaderTrustedOrigins.Value(),
+				vals.Dangerous.AllowExternalAuthHeaderAutoCreateUsers.Value(),
+				vals.Dangerous.ExternalAuthHeaderAutoCreateDefaultRoles.Value(),
 			)
 			if err != nil {
 				return xerrors.Errorf("parse external auth header config: %w", err)

--- a/cli/server.go
+++ b/cli/server.go
@@ -638,6 +638,21 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 				return xerrors.Errorf("parse real ip config: %w", err)
 			}
 
+			externalAuthHeaderConfig, err := httpmw.ParseExternalAuthHeaderConfig(
+				vals.Dangerous.AllowExternalAuthHeader.Value(),
+				vals.Dangerous.ExternalAuthHeaderTrustedOrigins.Value(),
+			)
+			if err != nil {
+				return xerrors.Errorf("parse external auth header config: %w", err)
+			}
+			if externalAuthHeaderConfig.Enabled && len(externalAuthHeaderConfig.TrustedOrigins) == 0 {
+				cliui.Warnf(inv.Stderr,
+					"%s is set but no trusted origins are configured; the %s header will be ignored.\n",
+					pretty.Sprint(cliui.DefaultStyles.Field, "--dangerous-allow-external-auth-header"),
+					httpmw.ExternalAuthHeaderName,
+				)
+			}
+
 			configSSHOptions, err := vals.SSHConfig.ParseOptions()
 			if err != nil {
 				return xerrors.Errorf("parse ssh config options %q: %w", vals.SSHConfig.SSHConfigOptions.String(), err)
@@ -664,6 +679,7 @@ func (r *RootCmd) Server(newAPI func(context.Context, *coderd.Options) (*coderd.
 				GoogleTokenValidator:        googleTokenValidator,
 				ExternalAuthConfigs:         nil,
 				RealIPConfig:                realIPConfig,
+				ExternalAuthHeaderConfig:    externalAuthHeaderConfig,
 				SSHKeygenAlgorithm:          sshKeygenAlgorithm,
 				TracerProvider:              tracerProvider,
 				Telemetry:                   telemetry.NewNoop(),

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -868,6 +868,16 @@ Configure how workspace prebuilds behave.
           How often to reconcile workspace prebuilds state.
 
 ⚠️ DANGEROUS OPTIONS: 
+      --dangerous-allow-external-auth-header bool, $CODER_DANGEROUS_ALLOW_EXTERNAL_AUTH_HEADER
+          Trust the Coder-Authorization header for user identity assertions when
+          the request originates from a CIDR listed in
+          --dangerous-external-auth-header-trusted-origins. This is intended for
+          deployments that sit behind an authenticating reverse proxy (e.g. an
+          Envoy authn plugin). MISCONFIGURING THIS IS A FULL-IMPERSONATION
+          FOOTGUN. The header has the form 'Coder-Authorization: Basic
+          Username=alice' or 'Coder-Authorization: Basic
+          UserEmail=alice@example.com'. See the docs for the full threat model.
+
       --dangerous-allow-path-app-sharing bool, $CODER_DANGEROUS_ALLOW_PATH_APP_SHARING
           Allow workspace apps that are not served from subdomains to be shared.
           Path-based app sharing is DISABLED by default for security purposes.
@@ -883,6 +893,14 @@ Configure how workspace prebuilds behave.
           risk when the workspace serves malicious JavaScript. Path-based apps
           can be disabled entirely with --disable-path-apps for further
           security.
+
+      --dangerous-external-auth-header-trusted-origins string-array, $CODER_DANGEROUS_EXTERNAL_AUTH_HEADER_TRUSTED_ORIGINS
+          CIDR networks whose source addresses may assert user identity via the
+          Coder-Authorization header. Required for
+          --dangerous-allow-external-auth-header to have any effect; an empty
+          list silently disables the feature. Bind Coder to localhost or use
+          mTLS at the proxy boundary; never list a network containing untrusted
+          clients.
 
 ENTERPRISE OPTIONS: 
 These options are only available in the Enterprise Edition.

--- a/cli/testdata/coder_server_--help.golden
+++ b/cli/testdata/coder_server_--help.golden
@@ -894,6 +894,21 @@ Configure how workspace prebuilds behave.
           can be disabled entirely with --disable-path-apps for further
           security.
 
+      --dangerous-allow-external-auth-header-auto-create-users bool, $CODER_DANGEROUS_ALLOW_EXTERNAL_AUTH_HEADER_AUTO_CREATE_USERS
+          Provision Coder users on the fly when the Coder-Authorization header
+          asserts an unknown user. Requires
+          --dangerous-allow-external-auth-header. The header must include
+          UserEmail; Username defaults to the local part of the email. New users
+          are placed in the default organization with the roles specified by
+          --dangerous-external-auth-header-auto-create-default-roles (or the
+          Roles= field on the header, which wins when present).
+
+      --dangerous-external-auth-header-auto-create-default-roles string-array, $CODER_DANGEROUS_EXTERNAL_AUTH_HEADER_AUTO_CREATE_DEFAULT_ROLES
+          Site roles assigned to users auto-created via the Coder-Authorization
+          header when the header itself does not carry a Roles= field. Defaults
+          to a plain member with no extra roles. Valid values include member,
+          owner, auditor, user-admin, and template-admin.
+
       --dangerous-external-auth-header-trusted-origins string-array, $CODER_DANGEROUS_EXTERNAL_AUTH_HEADER_TRUSTED_ORIGINS
           CIDR networks whose source addresses may assert user identity via the
           Coder-Authorization header. Required for

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -476,6 +476,20 @@ dangerous:
   # untrusted clients.
   # (default: <unset>, type: string-array)
   externalAuthHeaderTrustedOrigins: []
+  # Provision Coder users on the fly when the Coder-Authorization header asserts an
+  # unknown user. Requires --dangerous-allow-external-auth-header. The header must
+  # include UserEmail; Username defaults to the local part of the email. New users
+  # are placed in the default organization with the roles specified by
+  # --dangerous-external-auth-header-auto-create-default-roles (or the Roles= field
+  # on the header, which wins when present).
+  # (default: <unset>, type: bool)
+  allowExternalAuthHeaderAutoCreateUsers: false
+  # Site roles assigned to users auto-created via the Coder-Authorization header
+  # when the header itself does not carry a Roles= field. Defaults to a plain member
+  # with no extra roles. Valid values include member, owner, auditor, user-admin,
+  # and template-admin.
+  # (default: <unset>, type: string-array)
+  externalAuthHeaderAutoCreateDefaultRoles: []
 # Enable one or more experiments. These are not ready for production. Separate
 # multiple experiments with commas, or enter '*' to opt-in to all available
 # experiments.

--- a/cli/testdata/server-config.yaml.golden
+++ b/cli/testdata/server-config.yaml.golden
@@ -459,6 +459,23 @@ provisioning:
   # Time to force cancel provisioning tasks that are stuck.
   # (default: 10m0s, type: duration)
   forceCancelInterval: 10m0s
+dangerous:
+  # Trust the Coder-Authorization header for user identity assertions when the
+  # request originates from a CIDR listed in
+  # --dangerous-external-auth-header-trusted-origins. This is intended for
+  # deployments that sit behind an authenticating reverse proxy (e.g. an Envoy authn
+  # plugin). MISCONFIGURING THIS IS A FULL-IMPERSONATION FOOTGUN. The header has the
+  # form 'Coder-Authorization: Basic Username=alice' or 'Coder-Authorization: Basic
+  # UserEmail=alice@example.com'. See the docs for the full threat model.
+  # (default: <unset>, type: bool)
+  allowExternalAuthHeader: false
+  # CIDR networks whose source addresses may assert user identity via the
+  # Coder-Authorization header. Required for --dangerous-allow-external-auth-header
+  # to have any effect; an empty list silently disables the feature. Bind Coder to
+  # localhost or use mTLS at the proxy boundary; never list a network containing
+  # untrusted clients.
+  # (default: <unset>, type: string-array)
+  externalAuthHeaderTrustedOrigins: []
 # Enable one or more experiments. These are not ready for production. Separate
 # multiple experiments with commas, or enter '*' to opt-in to all available
 # experiments.

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -17528,11 +17528,20 @@ const docTemplate = `{
                 "allow_all_cors": {
                     "type": "boolean"
                 },
+                "allow_external_auth_header": {
+                    "type": "boolean"
+                },
                 "allow_path_app_sharing": {
                     "type": "boolean"
                 },
                 "allow_path_app_site_owner_access": {
                     "type": "boolean"
+                },
+                "external_auth_header_trusted_origins": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },

--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -17531,11 +17531,20 @@ const docTemplate = `{
                 "allow_external_auth_header": {
                     "type": "boolean"
                 },
+                "allow_external_auth_header_auto_create_users": {
+                    "type": "boolean"
+                },
                 "allow_path_app_sharing": {
                     "type": "boolean"
                 },
                 "allow_path_app_site_owner_access": {
                     "type": "boolean"
+                },
+                "external_auth_header_auto_create_default_roles": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "external_auth_header_trusted_origins": {
                     "type": "array",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -15890,11 +15890,20 @@
 				"allow_external_auth_header": {
 					"type": "boolean"
 				},
+				"allow_external_auth_header_auto_create_users": {
+					"type": "boolean"
+				},
 				"allow_path_app_sharing": {
 					"type": "boolean"
 				},
 				"allow_path_app_site_owner_access": {
 					"type": "boolean"
+				},
+				"external_auth_header_auto_create_default_roles": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
 				},
 				"external_auth_header_trusted_origins": {
 					"type": "array",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -15887,11 +15887,20 @@
 				"allow_all_cors": {
 					"type": "boolean"
 				},
+				"allow_external_auth_header": {
+					"type": "boolean"
+				},
 				"allow_path_app_sharing": {
 					"type": "boolean"
 				},
 				"allow_path_app_site_owner_access": {
 					"type": "boolean"
+				},
+				"external_auth_header_trusted_origins": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
 				}
 			}
 		},

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -902,6 +902,20 @@ func New(options *Options) *API {
 		APIKeyEncryptionKeycache: options.AppEncryptionKeyCache,
 	})
 
+	// We attach the CreateUser callback to the deployment's external
+	// auth header config here so subsequent middleware wrappers share
+	// the wired value. The underlying helper needs *API to reach the
+	// audit chain, default org lookup, and notifications; httpmw
+	// cannot import coderd, so we route the call through a closure.
+	// Mutating options.ExternalAuthHeaderConfig in place also lets
+	// enterprise.New reuse the wired callback when it builds its own
+	// middleware against the shared *Options.
+	if options.ExternalAuthHeaderConfig.Enabled &&
+		options.ExternalAuthHeaderConfig.AllowAutoCreateUsers &&
+		options.ExternalAuthHeaderConfig.CreateUser == nil {
+		options.ExternalAuthHeaderConfig.CreateUser = api.createExternalAuthHeaderUser
+	}
+
 	apiKeyMiddleware := httpmw.ExtractAPIKeyMW(httpmw.ExtractAPIKeyConfig{
 		DB:                            options.Database,
 		ActivateDormantUser:           ActivateDormantUser(options.Logger, &api.Auditor, options.Database),

--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -182,6 +182,7 @@ type Options struct {
 	TracerProvider                 trace.TracerProvider
 	ExternalAuthConfigs            []*externalauth.Config
 	RealIPConfig                   *httpmw.RealIPConfig
+	ExternalAuthHeaderConfig       httpmw.ExternalAuthHeaderConfig
 	TrialGenerator                 func(ctx context.Context, body codersdk.LicensorTrialRequest) error
 	// RefreshEntitlements is used to set correct entitlements after creating first user and generating trial license.
 	RefreshEntitlements func(ctx context.Context) error
@@ -912,6 +913,7 @@ func New(options *Options) *API {
 		PostAuthAdditionalHeadersFunc: options.PostAuthAdditionalHeadersFunc,
 		Logger:                        options.Logger,
 		AccessURL:                     options.AccessURL,
+		ExternalAuthHeader:            options.ExternalAuthHeaderConfig,
 	})
 	// Same as above but it redirects to the login page.
 	apiKeyMiddlewareRedirect := httpmw.ExtractAPIKeyMW(httpmw.ExtractAPIKeyConfig{
@@ -924,6 +926,7 @@ func New(options *Options) *API {
 		PostAuthAdditionalHeadersFunc: options.PostAuthAdditionalHeadersFunc,
 		Logger:                        options.Logger,
 		AccessURL:                     options.AccessURL,
+		ExternalAuthHeader:            options.ExternalAuthHeaderConfig,
 	})
 	// Same as the first but it's optional.
 	apiKeyMiddlewareOptional := httpmw.ExtractAPIKeyMW(httpmw.ExtractAPIKeyConfig{
@@ -936,6 +939,7 @@ func New(options *Options) *API {
 		PostAuthAdditionalHeadersFunc: options.PostAuthAdditionalHeadersFunc,
 		Logger:                        options.Logger,
 		AccessURL:                     options.AccessURL,
+		ExternalAuthHeader:            options.ExternalAuthHeaderConfig,
 	})
 
 	workspaceAgentInfo := httpmw.ExtractWorkspaceAgentAndLatestBuild(httpmw.ExtractWorkspaceAgentAndLatestBuildConfig{
@@ -983,6 +987,7 @@ func New(options *Options) *API {
 			OAuth2Configs:               oauthConfigs,
 			DisableSessionExpiryRefresh: options.DeploymentValues.Sessions.DisableExpiryRefresh.Value(),
 			Logger:                      options.Logger,
+			ExternalAuthHeader:          options.ExternalAuthHeaderConfig,
 		}),
 		httpmw.HTTPRoute, // NB: prometheusMW depends on this middleware.
 		prometheusMW,

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -121,6 +121,7 @@ type Options struct {
 	AzureCertificates              x509.VerifyOptions
 	GithubOAuth2Config             *coderd.GithubOAuth2Config
 	RealIPConfig                   *httpmw.RealIPConfig
+	ExternalAuthHeaderConfig       httpmw.ExternalAuthHeaderConfig
 	OIDCConfig                     *coderd.OIDCConfig
 	GoogleTokenValidator           *idtoken.Validator
 	SSHKeygenAlgorithm             gitsshkey.Algorithm
@@ -601,6 +602,7 @@ func NewOptions(t testing.TB, options *Options) (func(http.Handler), context.Can
 			AzureCertificates:                  options.AzureCertificates,
 			GithubOAuth2Config:                 options.GithubOAuth2Config,
 			RealIPConfig:                       options.RealIPConfig,
+			ExternalAuthHeaderConfig:           options.ExternalAuthHeaderConfig,
 			OIDCConfig:                         options.OIDCConfig,
 			GoogleTokenValidator:               options.GoogleTokenValidator,
 			SSHKeygenAlgorithm:                 options.SSHKeygenAlgorithm,

--- a/coderd/external_auth_header_user.go
+++ b/coderd/external_auth_header_user.go
@@ -1,0 +1,94 @@
+package coderd
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"golang.org/x/xerrors"
+
+	"cdr.dev/slog/v3"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
+	"github.com/coder/coder/v2/coderd/httpmw"
+	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/coderd/util/ptr"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+// createExternalAuthHeaderUser provisions a Coder user asserted by the
+// Coder-Authorization header (see httpmw.ExternalAuthHeaderConfig).
+// It is wired as the CreateUser callback in coderd.New so the httpmw
+// package can request a user create without importing coderd.
+//
+// The flow mirrors the OIDC auto-create path in oauthLogin: look up
+// the default organization, validate every role, then defer to
+// (*API).CreateUser which handles InTx semantics, SSH key generation,
+// org membership, and admin notifications.
+//
+// SECURITY: callers must have already validated that the asserting
+// request came from a trusted origin. This method does not re-check
+// that.
+func (api *API) createExternalAuthHeaderUser(ctx context.Context, params httpmw.ExternalAuthHeaderCreateUserParams) (database.User, error) {
+	if params.Email == "" {
+		return database.User{}, xerrors.New("UserEmail is required to auto-create users")
+	}
+	if params.Username == "" {
+		return database.User{}, xerrors.New("Username could not be derived; supply Username= in the header or use an email with a valid local part")
+	}
+
+	roles, err := validateExternalAuthHeaderRoles(params.Roles)
+	if err != nil {
+		return database.User{}, err
+	}
+
+	//nolint:gocritic // System needs to read the default organization
+	// for any unauthenticated identity assertion.
+	defaultOrg, err := api.Database.GetDefaultOrganization(dbauthz.AsSystemRestricted(ctx))
+	if err != nil {
+		return database.User{}, xerrors.Errorf("fetch default organization: %w", err)
+	}
+
+	//nolint:gocritic // System creates the user on behalf of the gateway.
+	user, err := api.CreateUser(dbauthz.AsSystemRestricted(ctx), api.Database, CreateUserRequest{
+		CreateUserRequestWithOrgs: codersdk.CreateUserRequestWithOrgs{
+			Email:           params.Email,
+			Username:        params.Username,
+			Name:            params.Name,
+			OrganizationIDs: []uuid.UUID{defaultOrg.ID},
+			UserStatus:      ptr.Ref(codersdk.UserStatusActive),
+		},
+		LoginType:          database.LoginTypeNone,
+		accountCreatorName: "external-auth-header",
+		RBACRoles:          roles,
+	})
+	if err != nil {
+		return database.User{}, xerrors.Errorf("create user: %w", err)
+	}
+	api.Logger.Info(ctx, "auto-created user via external authentication header",
+		slog.F("user_id", user.ID),
+		slog.F("username", user.Username),
+		slog.F("email", user.Email),
+		slog.F("roles", roles),
+	)
+	return user, nil
+}
+
+// validateExternalAuthHeaderRoles ensures every role supplied by the
+// gateway (either via the header's Roles= field or the deployment's
+// default-role list) is a real built-in role. Custom roles are
+// rejected because they may not exist until the operator creates
+// them; we prefer a clear error over silently dropping unrecognized
+// names.
+func validateExternalAuthHeaderRoles(roles []string) ([]string, error) {
+	if len(roles) == 0 {
+		return nil, nil
+	}
+	out := make([]string, 0, len(roles))
+	for _, r := range roles {
+		if _, err := rbac.RoleByName(rbac.RoleIdentifier{Name: r}); err != nil {
+			return nil, xerrors.Errorf("invalid role %q: %w", r, err)
+		}
+		out = append(out, r)
+	}
+	return out, nil
+}

--- a/coderd/external_auth_header_user_test.go
+++ b/coderd/external_auth_header_user_test.go
@@ -1,0 +1,146 @@
+package coderd_test
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/coderdtest"
+	"github.com/coder/coder/v2/coderd/httpmw"
+	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/testutil"
+)
+
+// TestExternalAuthHeaderAutoCreateE2E exercises the auto-create code
+// path end to end through coderdtest. It verifies that an unknown
+// user asserted via the Coder-Authorization header is provisioned,
+// receives the configured default roles, and can immediately access
+// authenticated routes.
+func TestExternalAuthHeaderAutoCreateE2E(t *testing.T) {
+	t.Parallel()
+
+	dv := coderdtest.DeploymentValues(t)
+	dv.Dangerous.AllowExternalAuthHeader = true
+	dv.Dangerous.AllowExternalAuthHeaderAutoCreateUsers = true
+
+	client := coderdtest.New(t, &coderdtest.Options{
+		DeploymentValues:         dv,
+		ExternalAuthHeaderConfig: trustedExternalAuthHeaderConfig(t, []string{codersdk.RoleAuditor}),
+	})
+	// CreateFirstUser is required so the default org and an admin
+	// exist; the auto-created user will be added to that org.
+	_ = coderdtest.CreateFirstUser(t, client)
+
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitMedium)
+	defer cancel()
+
+	resp := doExternalAuthHeaderRequest(ctx, t, client.URL.String(),
+		"Basic UserEmail=external-newcomer@example.com, Name=External Newcomer")
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode, "auto-create + auth should succeed")
+
+	// Resolve the freshly-created user to verify roles, status, and
+	// login type ended up correct.
+	created, err := client.User(ctx, "external-newcomer")
+	require.NoError(t, err)
+	require.Equal(t, "external-newcomer@example.com", created.Email)
+	require.Equal(t, codersdk.UserStatusActive, created.Status)
+	require.Equal(t, codersdk.LoginTypeNone, created.LoginType)
+	require.Contains(t, roleNames(created.Roles), codersdk.RoleAuditor)
+}
+
+// TestExternalAuthHeaderAutoCreateHeaderRolesWin verifies that the
+// header's Roles= field overrides the deployment default-role list.
+func TestExternalAuthHeaderAutoCreateHeaderRolesWin(t *testing.T) {
+	t.Parallel()
+
+	dv := coderdtest.DeploymentValues(t)
+	dv.Dangerous.AllowExternalAuthHeader = true
+	dv.Dangerous.AllowExternalAuthHeaderAutoCreateUsers = true
+
+	client := coderdtest.New(t, &coderdtest.Options{
+		DeploymentValues:         dv,
+		ExternalAuthHeaderConfig: trustedExternalAuthHeaderConfig(t, []string{codersdk.RoleAuditor}),
+	})
+	_ = coderdtest.CreateFirstUser(t, client)
+
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitMedium)
+	defer cancel()
+
+	resp := doExternalAuthHeaderRequest(ctx, t, client.URL.String(),
+		"Basic UserEmail=role-override@example.com, Roles=user-admin")
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	created, err := client.User(ctx, "role-override")
+	require.NoError(t, err)
+	roles := roleNames(created.Roles)
+	require.Contains(t, roles, codersdk.RoleUserAdmin)
+	require.NotContains(t, roles, codersdk.RoleAuditor)
+}
+
+// TestExternalAuthHeaderAutoCreateInvalidRoleRejected ensures the
+// helper refuses unknown role names rather than silently dropping
+// them, matching the conservative posture for a dangerous flag.
+func TestExternalAuthHeaderAutoCreateInvalidRoleRejected(t *testing.T) {
+	t.Parallel()
+
+	dv := coderdtest.DeploymentValues(t)
+	dv.Dangerous.AllowExternalAuthHeader = true
+	dv.Dangerous.AllowExternalAuthHeaderAutoCreateUsers = true
+
+	client := coderdtest.New(t, &coderdtest.Options{
+		DeploymentValues:         dv,
+		ExternalAuthHeaderConfig: trustedExternalAuthHeaderConfig(t, nil),
+	})
+	_ = coderdtest.CreateFirstUser(t, client)
+
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitMedium)
+	defer cancel()
+
+	resp := doExternalAuthHeaderRequest(ctx, t, client.URL.String(),
+		"Basic UserEmail=bogus-role@example.com, Roles=not-a-real-role")
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+// trustedExternalAuthHeaderConfig returns a ready-to-use config that
+// trusts the httptest loopback range so test requests are accepted.
+func trustedExternalAuthHeaderConfig(t *testing.T, defaultRoles []string) httpmw.ExternalAuthHeaderConfig {
+	t.Helper()
+	_, trustedNet, err := net.ParseCIDR("127.0.0.0/8")
+	require.NoError(t, err)
+	return httpmw.ExternalAuthHeaderConfig{
+		Enabled:                true,
+		TrustedOrigins:         []*net.IPNet{trustedNet},
+		AllowAutoCreateUsers:   true,
+		AutoCreateDefaultRoles: defaultRoles,
+	}
+}
+
+// doExternalAuthHeaderRequest issues a GET to /api/v2/users/me with
+// only the Coder-Authorization header set. It bypasses the codersdk
+// client because the client would attach a session cookie.
+func doExternalAuthHeaderRequest(ctx context.Context, t *testing.T, baseURL, headerValue string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/api/v2/users/me", nil)
+	require.NoError(t, err)
+	req.Header.Set(httpmw.ExternalAuthHeaderName, headerValue)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	return resp
+}
+
+// roleNames flattens a list of codersdk.SlimRole into just the names
+// for membership assertions.
+func roleNames(roles []codersdk.SlimRole) []string {
+	out := make([]string, 0, len(roles))
+	for _, r := range roles {
+		out = append(out, r.Name)
+	}
+	return out
+}

--- a/coderd/httpmw/apikey.go
+++ b/coderd/httpmw/apikey.go
@@ -47,6 +47,11 @@ type ValidateAPIKeyConfig struct {
 	// from the request. Nil uses the default (cookie/header).
 	SessionTokenFunc func(*http.Request) string
 	Logger           slog.Logger
+
+	// ExternalAuthHeader configures trust of the Coder-Authorization
+	// header used by external authentication gateways. Defaults to
+	// disabled. See ExternalAuthHeaderConfig for the threat model.
+	ExternalAuthHeader ExternalAuthHeaderConfig
 }
 
 // ValidateAPIKeyResult is the outcome of successful validation.
@@ -169,6 +174,11 @@ type ExtractAPIKeyConfig struct {
 
 	// Logger is used for logging middleware operations.
 	Logger slog.Logger
+
+	// ExternalAuthHeader configures trust of the Coder-Authorization
+	// header used by external authentication gateways. Defaults to
+	// disabled. See ExternalAuthHeaderConfig for the threat model.
+	ExternalAuthHeader ExternalAuthHeaderConfig
 }
 
 // ExtractAPIKeyMW calls ExtractAPIKey with the given config on each request,
@@ -248,6 +258,16 @@ func PrecheckAPIKey(cfg ValidateAPIKeyConfig) func(http.Handler) http.Handler {
 //
 // Returns (result, nil) on success or (nil, error) on failure.
 func ValidateAPIKey(ctx context.Context, cfg ValidateAPIKeyConfig, r *http.Request) (*ValidateAPIKeyResult, *ValidateAPIKeyError) {
+	// External authentication gateways assert user identity via the
+	// Coder-Authorization header. When trusted, that assertion
+	// short-circuits all token-based validation: no secret hash check,
+	// no OAuth refresh, no DB updates. The synthesized APIKey lives
+	// only in this request's context. See ExternalAuthHeaderConfig
+	// for the threat model.
+	if result, valErr, ok := validateExternalAuthHeader(ctx, cfg.ExternalAuthHeader, cfg.DB, cfg.Logger, r); ok {
+		return result, valErr
+	}
+
 	key, valErr := apiKeyFromRequestValidate(ctx, cfg.DB, cfg.SessionTokenFunc, r)
 	if valErr != nil {
 		return nil, valErr
@@ -640,6 +660,7 @@ func ExtractAPIKey(rw http.ResponseWriter, r *http.Request, cfg ExtractAPIKeyCon
 			DisableSessionExpiryRefresh: cfg.DisableSessionExpiryRefresh,
 			SessionTokenFunc:            cfg.SessionTokenFunc,
 			Logger:                      cfg.Logger,
+			ExternalAuthHeader:          cfg.ExternalAuthHeader,
 		}, r)
 		if valErr != nil {
 			if valErr.Hard {

--- a/coderd/httpmw/external_auth_header.go
+++ b/coderd/httpmw/external_auth_header.go
@@ -1,0 +1,292 @@
+package httpmw
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+
+	"golang.org/x/xerrors"
+
+	"cdr.dev/slog/v3"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+// ExternalAuthHeaderName is the request header used by external
+// authentication gateways to assert the authenticated user. See
+// ExternalAuthHeaderConfig for the threat model.
+const ExternalAuthHeaderName = "Coder-Authorization"
+
+// ExternalAuthHeaderConfig configures trust of the
+// Coder-Authorization header used by external authentication gateways.
+//
+// When Enabled is true and the request originates from an address in
+// TrustedOrigins, the middleware accepts the gateway's user identity
+// assertion in lieu of a Coder session token. The header has the
+// format:
+//
+//	Coder-Authorization: Basic Username=alice
+//	Coder-Authorization: Basic UserEmail=alice@example.com
+//
+// Exactly one of Username or UserEmail must be supplied. Other fields
+// are accepted and ignored for forward compatibility.
+//
+// SECURITY: this header is fully trusted on trusted origins. A
+// misconfigured deployment that lists a network containing untrusted
+// clients will allow those clients to impersonate any user. Use only
+// when Coder is bound to localhost or sits behind an authenticating
+// reverse proxy on a network you control. Implements the design
+// proposed in https://github.com/coder/coder/issues/8889.
+type ExternalAuthHeaderConfig struct {
+	// Enabled gates the entire feature. When false, the header is
+	// ignored everywhere and callers fall back to normal session-token
+	// authentication.
+	Enabled bool
+
+	// TrustedOrigins is the list of CIDR ranges whose source addresses
+	// may assert user identity via the header. An empty list with
+	// Enabled=true is a misconfiguration: the header will never be
+	// honored.
+	TrustedOrigins []*net.IPNet
+}
+
+// externalAuthHeader holds the parsed contents of a
+// Coder-Authorization: Basic header.
+type externalAuthHeader struct {
+	Username string
+	Email    string
+}
+
+// hasIdentity returns true if the parsed header carries a usable
+// user identity field.
+func (h externalAuthHeader) hasIdentity() bool {
+	return h.Username != "" || h.Email != ""
+}
+
+// errNoExternalAuthHeader signals that the Coder-Authorization header
+// is absent. Callers fall back to normal session-token authentication
+// in that case.
+var errNoExternalAuthHeader = xerrors.New("no external auth header")
+
+// parseExternalAuthHeader parses a Coder-Authorization header value.
+// Currently only the Basic scheme is supported; future schemes (e.g.
+// signed JWTs) can be added without breaking callers.
+//
+// The Basic scheme uses comma-separated Field=Value pairs:
+//
+//	Basic Username=alice
+//	Basic UserEmail=alice@example.com, TokenName=ignored
+//
+// Unknown fields are ignored. Missing or empty values for known
+// fields are treated as not set. The function returns
+// errNoExternalAuthHeader when value is empty so callers can
+// distinguish "not present" from "malformed".
+func parseExternalAuthHeader(value string) (externalAuthHeader, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return externalAuthHeader{}, errNoExternalAuthHeader
+	}
+
+	scheme, rest, ok := strings.Cut(value, " ")
+	if !ok {
+		return externalAuthHeader{}, xerrors.Errorf("missing scheme in %s header", ExternalAuthHeaderName)
+	}
+	if !strings.EqualFold(scheme, "Basic") {
+		return externalAuthHeader{}, xerrors.Errorf("unsupported %s scheme %q", ExternalAuthHeaderName, scheme)
+	}
+
+	var parsed externalAuthHeader
+	for _, pair := range strings.Split(rest, ",") {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			continue
+		}
+		key, val, ok := strings.Cut(pair, "=")
+		if !ok {
+			return externalAuthHeader{}, xerrors.Errorf("malformed field %q in %s header (expected Key=Value)", pair, ExternalAuthHeaderName)
+		}
+		key = strings.TrimSpace(key)
+		val = strings.TrimSpace(val)
+		switch strings.ToLower(key) {
+		case "username":
+			parsed.Username = val
+		case "useremail":
+			parsed.Email = val
+		default:
+			// Ignore unknown fields. The original proposal lists
+			// ActiveSession and TokenName, which we accept and
+			// ignore so deployments that already send them keep
+			// working as we add support over time.
+		}
+	}
+
+	if !parsed.hasIdentity() {
+		return externalAuthHeader{}, xerrors.Errorf("%s header must include Username or UserEmail", ExternalAuthHeaderName)
+	}
+
+	return parsed, nil
+}
+
+// ParseExternalAuthHeaderConfig builds an ExternalAuthHeaderConfig
+// from the deployment values. trustedOrigins is a list of CIDR
+// strings; an empty list with enabled=true is allowed but logs a
+// warning at construction time (the feature is silently disabled
+// because no origin can match).
+func ParseExternalAuthHeaderConfig(enabled bool, trustedOrigins []string) (ExternalAuthHeaderConfig, error) {
+	cfg := ExternalAuthHeaderConfig{Enabled: enabled}
+	for _, origin := range trustedOrigins {
+		origin = strings.TrimSpace(origin)
+		if origin == "" {
+			continue
+		}
+		_, network, err := net.ParseCIDR(origin)
+		if err != nil {
+			return ExternalAuthHeaderConfig{}, xerrors.Errorf("parse external auth header trusted origin %q: %w", origin, err)
+		}
+		cfg.TrustedOrigins = append(cfg.TrustedOrigins, network)
+	}
+	return cfg, nil
+}
+
+// originAllowed returns true if the request's source address is
+// inside one of the trusted CIDR ranges. An empty range list never
+// matches.
+func (c ExternalAuthHeaderConfig) originAllowed(remoteAddr string) bool {
+	if len(c.TrustedOrigins) == 0 {
+		return false
+	}
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		// RemoteAddr is sometimes a bare IP (e.g. in tests) without
+		// a port. Try the value as-is.
+		host = remoteAddr
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	for _, network := range c.TrustedOrigins {
+		if network.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// validateExternalAuthHeader inspects the Coder-Authorization header
+// and, when accepted, returns a successful ValidateAPIKeyResult with
+// a synthesized in-memory APIKey. The synthesized key is never
+// persisted: it exists only to satisfy downstream middleware that
+// expects a database.APIKey shape.
+//
+// Returns (nil, nil, false) when the feature is disabled, the header
+// is absent, or the request did not come from a trusted origin. In
+// those cases callers fall through to normal session-token
+// authentication.
+//
+// Returns (nil, *ValidateAPIKeyError, true) when the header is
+// present but cannot be honored (malformed, user not found, etc.).
+// The error is hard so the caller surfaces it even on optional-auth
+// routes; otherwise an attacker on a trusted origin could mask a
+// failed impersonation by simply omitting cookies.
+func validateExternalAuthHeader(
+	ctx context.Context,
+	cfg ExternalAuthHeaderConfig,
+	db database.Store,
+	logger slog.Logger,
+	r *http.Request,
+) (*ValidateAPIKeyResult, *ValidateAPIKeyError, bool) {
+	if !cfg.Enabled {
+		return nil, nil, false
+	}
+	raw := r.Header.Get(ExternalAuthHeaderName)
+	if raw == "" {
+		return nil, nil, false
+	}
+
+	if !cfg.originAllowed(r.RemoteAddr) {
+		// Header was set but the origin is untrusted. Log loudly
+		// and fall through to normal auth so we don't pretend the
+		// header is gospel from an arbitrary network.
+		logger.Warn(ctx, "ignoring external auth header from untrusted origin",
+			slog.F("remote_addr", r.RemoteAddr),
+		)
+		return nil, nil, false
+	}
+
+	parsed, err := parseExternalAuthHeader(raw)
+	if err != nil {
+		if errors.Is(err, errNoExternalAuthHeader) {
+			return nil, nil, false
+		}
+		return nil, &ValidateAPIKeyError{
+			Code: http.StatusBadRequest,
+			Response: codersdk.Response{
+				Message: SignedOutErrorMessage,
+				Detail:  fmt.Sprintf("Invalid %s header: %s", ExternalAuthHeaderName, err.Error()),
+			},
+			Hard: true,
+		}, true
+	}
+
+	// nolint:gocritic // System needs to look up the asserted user
+	// regardless of the caller's RBAC.
+	user, err := db.GetUserByEmailOrUsername(dbauthz.AsSystemRestricted(ctx), database.GetUserByEmailOrUsernameParams{
+		Username: parsed.Username,
+		Email:    parsed.Email,
+	})
+	if err != nil {
+		// We treat all lookup failures (no rows, permission
+		// errors, real DB errors) as a hard 401 rather than
+		// leaking which case occurred. The Detail field carries
+		// enough context for an operator to diagnose, while the
+		// Message remains the standard signed-out copy.
+		return nil, &ValidateAPIKeyError{
+			Code: http.StatusUnauthorized,
+			Response: codersdk.Response{
+				Message: SignedOutErrorMessage,
+				Detail:  fmt.Sprintf("%s header user lookup failed: %s", ExternalAuthHeaderName, err.Error()),
+			},
+			Hard: true,
+		}, true
+	}
+
+	// The shared GetUserByEmailOrUsername query already filters
+	// out deleted=true rows. Status is then enforced by the
+	// route-specific check in ExtractAPIKey via the returned
+	// UserStatus, matching the cookie-based flow.
+
+	// Build a synthetic in-memory APIKey. The values that matter
+	// downstream are UserID (ratelimit, RBAC actor lookup),
+	// LoginType (skips OAuth refresh), and Scopes (RBAC scope set).
+	// ID/HashedSecret/ExpiresAt are set to non-empty placeholders
+	// so accidental DB writes would be obvious.
+	key := database.APIKey{
+		ID:        "external",
+		UserID:    user.ID,
+		LoginType: database.LoginTypeNone,
+		Scopes:    database.APIKeyScopes{database.ApiKeyScopeCoderAll},
+	}
+
+	actor, userStatus, err := UserRBACSubject(ctx, db, user.ID, key.ScopeSet())
+	if err != nil {
+		return nil, &ValidateAPIKeyError{
+			Code: http.StatusInternalServerError,
+			Response: codersdk.Response{
+				Message: internalErrorMessage,
+				Detail:  fmt.Sprintf("fetch %s header user roles: %s", ExternalAuthHeaderName, err.Error()),
+			},
+			Hard: true,
+		}, true
+	}
+
+	return &ValidateAPIKeyResult{
+		Key:        key,
+		Subject:    actor,
+		UserStatus: userStatus,
+	}, nil, true
+}

--- a/coderd/httpmw/external_auth_header.go
+++ b/coderd/httpmw/external_auth_header.go
@@ -2,6 +2,7 @@ package httpmw
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"net"
@@ -13,6 +14,7 @@ import (
 	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
+	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/codersdk"
 )
 
@@ -20,6 +22,25 @@ import (
 // authentication gateways to assert the authenticated user. See
 // ExternalAuthHeaderConfig for the threat model.
 const ExternalAuthHeaderName = "Coder-Authorization"
+
+// ExternalAuthHeaderCreateUserParams carries the user identity asserted
+// by the Coder-Authorization header to a deployment-supplied callback
+// that creates the Coder user on first sight. Auto-creation is gated
+// behind ExternalAuthHeaderConfig.AllowAutoCreateUsers.
+type ExternalAuthHeaderCreateUserParams struct {
+	// Username and Email are read from the header. Email is required;
+	// the header parser rejects auto-create attempts without it.
+	Username string
+	Email    string
+	// Name is the user's full name. Optional. Mirrors the OIDC flow,
+	// which also accepts a real-name claim.
+	Name string
+	// Roles is the deployment-effective role list for the new user.
+	// It comes from the header's Roles= field if present, otherwise
+	// the config's AutoCreateDefaultRoles. The callback validates
+	// and assigns these.
+	Roles []string
+}
 
 // ExternalAuthHeaderConfig configures trust of the
 // Coder-Authorization header used by external authentication gateways.
@@ -31,9 +52,12 @@ const ExternalAuthHeaderName = "Coder-Authorization"
 //
 //	Coder-Authorization: Basic Username=alice
 //	Coder-Authorization: Basic UserEmail=alice@example.com
+//	Coder-Authorization: Basic Username=alice, UserEmail=alice@example.com, Roles=member
 //
-// Exactly one of Username or UserEmail must be supplied. Other fields
-// are accepted and ignored for forward compatibility.
+// At least one of Username or UserEmail must be supplied. Auto-creation
+// additionally requires UserEmail (and Username, derived from the local
+// part if absent). Other fields are accepted and ignored for forward
+// compatibility.
 //
 // SECURITY: this header is fully trusted on trusted origins. A
 // misconfigured deployment that lists a network containing untrusted
@@ -52,6 +76,28 @@ type ExternalAuthHeaderConfig struct {
 	// Enabled=true is a misconfiguration: the header will never be
 	// honored.
 	TrustedOrigins []*net.IPNet
+
+	// AllowAutoCreateUsers controls whether a header that names a
+	// previously unknown user causes that user to be provisioned on
+	// the fly. When false (the default), an unknown user fails the
+	// request with a 401. Auto-creation requires a non-empty Email
+	// in the header or a deployment that synthesizes one.
+	AllowAutoCreateUsers bool
+
+	// AutoCreateDefaultRoles is the role list assigned to a freshly
+	// created user when the header does not carry a Roles= field.
+	// Nil or empty means a plain member with no extra site roles.
+	AutoCreateDefaultRoles []string
+
+	// CreateUser is the deployment-supplied callback that performs the
+	// actual user creation. It runs only when AllowAutoCreateUsers is
+	// true and the looked-up user is missing. nil disables auto-create
+	// even if AllowAutoCreateUsers is true.
+	//
+	// Wired by coderd.New so the callback has access to the full user
+	// creation path (default org, SSH keypair generation, audit, and
+	// notifications), without httpmw importing coderd.
+	CreateUser func(context.Context, ExternalAuthHeaderCreateUserParams) (database.User, error)
 }
 
 // externalAuthHeader holds the parsed contents of a
@@ -59,6 +105,8 @@ type ExternalAuthHeaderConfig struct {
 type externalAuthHeader struct {
 	Username string
 	Email    string
+	Name     string
+	Roles    []string
 }
 
 // hasIdentity returns true if the parsed header carries a usable
@@ -79,10 +127,10 @@ var errNoExternalAuthHeader = xerrors.New("no external auth header")
 // The Basic scheme uses comma-separated Field=Value pairs:
 //
 //	Basic Username=alice
-//	Basic UserEmail=alice@example.com, TokenName=ignored
+//	Basic UserEmail=alice@example.com, Roles=member
+//	Basic Username=alice, UserEmail=alice@example.com, Name=Alice Liddell, Roles=member,auditor
 //
-// Unknown fields are ignored. Missing or empty values for known
-// fields are treated as not set. The function returns
+// Unknown fields are accepted and ignored. The function returns
 // errNoExternalAuthHeader when value is empty so callers can
 // distinguish "not present" from "malformed".
 func parseExternalAuthHeader(value string) (externalAuthHeader, error) {
@@ -100,7 +148,22 @@ func parseExternalAuthHeader(value string) (externalAuthHeader, error) {
 	}
 
 	var parsed externalAuthHeader
-	for _, pair := range strings.Split(rest, ",") {
+	// The Roles field is itself comma-separated, but the outer
+	// header is also comma-separated. We parse left-to-right and
+	// only treat Roles= specially: once we see it, the rest of the
+	// header is the role list. This matches the issue's example
+	// "Roles=member,auditor" without forcing the gateway to quote
+	// or escape commas.
+	remaining := rest
+	for remaining != "" {
+		var pair string
+		if i := strings.IndexByte(remaining, ','); i >= 0 {
+			pair = remaining[:i]
+			remaining = remaining[i+1:]
+		} else {
+			pair = remaining
+			remaining = ""
+		}
 		pair = strings.TrimSpace(pair)
 		if pair == "" {
 			continue
@@ -116,6 +179,24 @@ func parseExternalAuthHeader(value string) (externalAuthHeader, error) {
 			parsed.Username = val
 		case "useremail":
 			parsed.Email = val
+		case "name":
+			parsed.Name = val
+		case "roles":
+			// Roles consumes the rest of the header as a single
+			// comma-separated list, so a value like
+			// "Roles=member,auditor" is preserved.
+			full := val
+			if remaining != "" {
+				full = full + "," + remaining
+				remaining = ""
+			}
+			for _, role := range strings.Split(full, ",") {
+				role = strings.TrimSpace(role)
+				if role == "" {
+					continue
+				}
+				parsed.Roles = append(parsed.Roles, role)
+			}
 		default:
 			// Ignore unknown fields. The original proposal lists
 			// ActiveSession and TokenName, which we accept and
@@ -136,8 +217,16 @@ func parseExternalAuthHeader(value string) (externalAuthHeader, error) {
 // strings; an empty list with enabled=true is allowed but logs a
 // warning at construction time (the feature is silently disabled
 // because no origin can match).
-func ParseExternalAuthHeaderConfig(enabled bool, trustedOrigins []string) (ExternalAuthHeaderConfig, error) {
-	cfg := ExternalAuthHeaderConfig{Enabled: enabled}
+//
+// The CreateUser callback must be set separately by coderd.New so
+// that this parser stays free of import cycles with the user-creation
+// machinery.
+func ParseExternalAuthHeaderConfig(enabled bool, trustedOrigins []string, allowAutoCreate bool, autoCreateDefaultRoles []string) (ExternalAuthHeaderConfig, error) {
+	cfg := ExternalAuthHeaderConfig{
+		Enabled:                enabled,
+		AllowAutoCreateUsers:   allowAutoCreate,
+		AutoCreateDefaultRoles: append([]string(nil), autoCreateDefaultRoles...),
+	}
 	for _, origin := range trustedOrigins {
 		origin = strings.TrimSpace(origin)
 		if origin == "" {
@@ -239,10 +328,26 @@ func validateExternalAuthHeader(
 		Username: parsed.Username,
 		Email:    parsed.Email,
 	})
-	if err != nil {
-		// We treat all lookup failures (no rows, permission
-		// errors, real DB errors) as a hard 401 rather than
-		// leaking which case occurred. The Detail field carries
+	switch {
+	case err == nil:
+		// Found, fall through to RBAC resolution below.
+	case errors.Is(err, sql.ErrNoRows) && cfg.AllowAutoCreateUsers && cfg.CreateUser != nil:
+		// Unknown user, auto-create is enabled, callback wired.
+		user, err = autoCreateExternalAuthHeaderUser(ctx, cfg, parsed)
+		if err != nil {
+			return nil, &ValidateAPIKeyError{
+				Code: http.StatusUnauthorized,
+				Response: codersdk.Response{
+					Message: SignedOutErrorMessage,
+					Detail:  fmt.Sprintf("%s header user auto-create failed: %s", ExternalAuthHeaderName, err.Error()),
+				},
+				Hard: true,
+			}, true
+		}
+	default:
+		// We treat all lookup failures (no rows without auto-create,
+		// permission errors, real DB errors) as a hard 401 rather
+		// than leaking which case occurred. The Detail field carries
 		// enough context for an operator to diagnose, while the
 		// Message remains the standard signed-out copy.
 		return nil, &ValidateAPIKeyError{
@@ -270,6 +375,11 @@ func validateExternalAuthHeader(
 		UserID:    user.ID,
 		LoginType: database.LoginTypeNone,
 		Scopes:    database.APIKeyScopes{database.ApiKeyScopeCoderAll},
+		// AllowList must contain at least the wildcard element so
+		// IntersectAllowLists doesn't fail closed for a key with no
+		// stored row. The synthesized session has no DB-level
+		// resource scoping; it inherits the user's full RBAC.
+		AllowList: database.AllowList{rbac.AllowListAll()},
 	}
 
 	actor, userStatus, err := UserRBACSubject(ctx, db, user.ID, key.ScopeSet())
@@ -289,4 +399,50 @@ func validateExternalAuthHeader(
 		Subject:    actor,
 		UserStatus: userStatus,
 	}, nil, true
+}
+
+// autoCreateExternalAuthHeaderUser materializes a previously unknown
+// user asserted by the Coder-Authorization header. The header must
+// supply an email; auto-create cannot synthesize one because Coder
+// users own a real email address. Username defaults to the local
+// part of the email when the header omits it.
+//
+// Role assignment precedence (issue #8889): the header's Roles= field
+// wins; otherwise AutoCreateDefaultRoles from the deployment config.
+// A nil/empty result hands a plain member to the underlying
+// CreateUser callback.
+func autoCreateExternalAuthHeaderUser(
+	ctx context.Context,
+	cfg ExternalAuthHeaderConfig,
+	parsed externalAuthHeader,
+) (database.User, error) {
+	email := parsed.Email
+	if email == "" {
+		return database.User{}, xerrors.Errorf("UserEmail is required to auto-create a user via the %s header", ExternalAuthHeaderName)
+	}
+	username := parsed.Username
+	if username == "" {
+		// Derive a username from the email's local part. The
+		// downstream codersdk.NameValid check still applies in
+		// the CreateUser callback, so an invalid derivation
+		// surfaces as a clear "invalid username" error rather
+		// than silently corrupting the row.
+		if at := strings.IndexByte(email, '@'); at > 0 {
+			username = email[:at]
+		} else {
+			username = email
+		}
+	}
+
+	roles := parsed.Roles
+	if len(roles) == 0 {
+		roles = cfg.AutoCreateDefaultRoles
+	}
+
+	return cfg.CreateUser(ctx, ExternalAuthHeaderCreateUserParams{
+		Username: username,
+		Email:    email,
+		Name:     parsed.Name,
+		Roles:    roles,
+	})
 }

--- a/coderd/httpmw/external_auth_header_test.go
+++ b/coderd/httpmw/external_auth_header_test.go
@@ -1,0 +1,300 @@
+package httpmw_test
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/database/dbauthz"
+	"github.com/coder/coder/v2/coderd/database/dbgen"
+	"github.com/coder/coder/v2/coderd/database/dbtestutil"
+	"github.com/coder/coder/v2/coderd/httpapi"
+	"github.com/coder/coder/v2/coderd/httpmw"
+	"github.com/coder/coder/v2/codersdk"
+)
+
+// trustedLoopbackCIDR is the CIDR used by the tests to mark
+// httptest.NewRequest's default 192.0.2.1 RemoteAddr as a trusted
+// origin.
+const trustedLoopbackCIDR = "192.0.2.0/24"
+
+func parseCIDR(t *testing.T, cidr string) *net.IPNet {
+	t.Helper()
+	_, network, err := net.ParseCIDR(cidr)
+	require.NoError(t, err)
+	return network
+}
+
+func mustExternalAuthConfig(t *testing.T, enabled bool, origins ...string) httpmw.ExternalAuthHeaderConfig {
+	t.Helper()
+	cfg, err := httpmw.ParseExternalAuthHeaderConfig(enabled, origins)
+	require.NoError(t, err)
+	return cfg
+}
+
+// successHandlerWritingActor mirrors successHandler in apikey_test
+// but additionally writes the dbauthz actor's friendly name (the
+// asserted user's username) so tests can confirm impersonation.
+func successHandlerWritingActor(t *testing.T) http.HandlerFunc {
+	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		actor, ok := dbauthz.ActorFromContext(r.Context())
+		require.True(t, ok, "expected dbauthz actor")
+		httpapi.Write(context.Background(), rw, http.StatusOK, codersdk.Response{
+			Message: actor.FriendlyName,
+		})
+	})
+}
+
+func TestExternalAuthHeader(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Username", func(t *testing.T) {
+		t.Parallel()
+		db, _ := dbtestutil.NewDB(t)
+		user := dbgen.User(t, db, database.User{Username: "alice"})
+
+		r := httptest.NewRequest("GET", "/", nil)
+		r.Header.Set(httpmw.ExternalAuthHeaderName, "Basic Username=alice")
+		rw := httptest.NewRecorder()
+
+		httpmw.ExtractAPIKeyMW(httpmw.ExtractAPIKeyConfig{
+			DB:                 db,
+			ExternalAuthHeader: mustExternalAuthConfig(t, true, trustedLoopbackCIDR),
+		})(successHandlerWritingActor(t)).ServeHTTP(rw, r)
+
+		res := rw.Result()
+		defer res.Body.Close()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+		var resp codersdk.Response
+		require.NoError(t, json.NewDecoder(res.Body).Decode(&resp))
+		require.Equal(t, user.Username, resp.Message)
+	})
+
+	t.Run("Email", func(t *testing.T) {
+		t.Parallel()
+		db, _ := dbtestutil.NewDB(t)
+		user := dbgen.User(t, db, database.User{Username: "bob", Email: "bob@example.com"})
+
+		r := httptest.NewRequest("GET", "/", nil)
+		r.Header.Set(httpmw.ExternalAuthHeaderName, "Basic UserEmail=bob@example.com")
+		rw := httptest.NewRecorder()
+
+		httpmw.ExtractAPIKeyMW(httpmw.ExtractAPIKeyConfig{
+			DB:                 db,
+			ExternalAuthHeader: mustExternalAuthConfig(t, true, trustedLoopbackCIDR),
+		})(successHandlerWritingActor(t)).ServeHTTP(rw, r)
+
+		res := rw.Result()
+		defer res.Body.Close()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+		var resp codersdk.Response
+		require.NoError(t, json.NewDecoder(res.Body).Decode(&resp))
+		require.Equal(t, user.Username, resp.Message)
+	})
+
+	t.Run("UntrustedOriginIgnored", func(t *testing.T) {
+		t.Parallel()
+		db, _ := dbtestutil.NewDB(t)
+		dbgen.User(t, db, database.User{Username: "alice"})
+
+		r := httptest.NewRequest("GET", "/", nil)
+		r.Header.Set(httpmw.ExternalAuthHeaderName, "Basic Username=alice")
+		// Explicitly set an origin that is NOT in the trusted CIDR.
+		r.RemoteAddr = "203.0.113.5:1234"
+		rw := httptest.NewRecorder()
+
+		httpmw.ExtractAPIKeyMW(httpmw.ExtractAPIKeyConfig{
+			DB:                 db,
+			ExternalAuthHeader: mustExternalAuthConfig(t, true, trustedLoopbackCIDR),
+		})(successHandlerWritingActor(t)).ServeHTTP(rw, r)
+
+		res := rw.Result()
+		defer res.Body.Close()
+		// The header was ignored, so the request fell through to the
+		// normal session-token flow with no token, producing a 401.
+		require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+	})
+
+	t.Run("DisabledIgnoresHeader", func(t *testing.T) {
+		t.Parallel()
+		db, _ := dbtestutil.NewDB(t)
+		dbgen.User(t, db, database.User{Username: "alice"})
+
+		r := httptest.NewRequest("GET", "/", nil)
+		r.Header.Set(httpmw.ExternalAuthHeaderName, "Basic Username=alice")
+		rw := httptest.NewRecorder()
+
+		// Enabled=false: feature off, header ignored, falls through
+		// to no-token 401.
+		httpmw.ExtractAPIKeyMW(httpmw.ExtractAPIKeyConfig{
+			DB: db,
+			ExternalAuthHeader: httpmw.ExternalAuthHeaderConfig{
+				Enabled: false,
+				TrustedOrigins: []*net.IPNet{
+					parseCIDR(t, trustedLoopbackCIDR),
+				},
+			},
+		})(successHandlerWritingActor(t)).ServeHTTP(rw, r)
+
+		res := rw.Result()
+		defer res.Body.Close()
+		require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+	})
+
+	t.Run("EmptyTrustedOriginsSilentlyDisables", func(t *testing.T) {
+		t.Parallel()
+		db, _ := dbtestutil.NewDB(t)
+		dbgen.User(t, db, database.User{Username: "alice"})
+
+		r := httptest.NewRequest("GET", "/", nil)
+		r.Header.Set(httpmw.ExternalAuthHeaderName, "Basic Username=alice")
+		rw := httptest.NewRecorder()
+
+		httpmw.ExtractAPIKeyMW(httpmw.ExtractAPIKeyConfig{
+			DB:                 db,
+			ExternalAuthHeader: mustExternalAuthConfig(t, true /* no origins */),
+		})(successHandlerWritingActor(t)).ServeHTTP(rw, r)
+
+		res := rw.Result()
+		defer res.Body.Close()
+		require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+	})
+
+	t.Run("UnknownUserHardFail", func(t *testing.T) {
+		t.Parallel()
+		db, _ := dbtestutil.NewDB(t)
+
+		r := httptest.NewRequest("GET", "/", nil)
+		r.Header.Set(httpmw.ExternalAuthHeaderName, "Basic Username=ghost")
+		rw := httptest.NewRecorder()
+
+		httpmw.ExtractAPIKeyMW(httpmw.ExtractAPIKeyConfig{
+			DB:                 db,
+			ExternalAuthHeader: mustExternalAuthConfig(t, true, trustedLoopbackCIDR),
+			Optional:           true, // Hard error must surface even on optional routes.
+		})(successHandlerWritingActor(t)).ServeHTTP(rw, r)
+
+		res := rw.Result()
+		defer res.Body.Close()
+		require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+	})
+
+	t.Run("MalformedHeaderHardFail", func(t *testing.T) {
+		t.Parallel()
+		db, _ := dbtestutil.NewDB(t)
+
+		cases := []string{
+			"Basic",                 // No fields at all.
+			"Basic GarbageOnlyKey",  // Field without =.
+			"Bearer Username=alice", // Wrong scheme.
+			"Basic TokenName=tok",   // No identity field.
+		}
+		for _, header := range cases {
+			r := httptest.NewRequest("GET", "/", nil)
+			r.Header.Set(httpmw.ExternalAuthHeaderName, header)
+			rw := httptest.NewRecorder()
+
+			httpmw.ExtractAPIKeyMW(httpmw.ExtractAPIKeyConfig{
+				DB:                 db,
+				ExternalAuthHeader: mustExternalAuthConfig(t, true, trustedLoopbackCIDR),
+			})(successHandlerWritingActor(t)).ServeHTTP(rw, r)
+
+			res := rw.Result()
+			res.Body.Close()
+			assert.NotEqual(t, http.StatusOK, res.StatusCode, "header %q should be rejected", header)
+		}
+	})
+
+	t.Run("DeletedUserNotFound", func(t *testing.T) {
+		t.Parallel()
+		db, _ := dbtestutil.NewDB(t)
+		user := dbgen.User(t, db, database.User{Username: "ghost"})
+
+		// Soft-delete the user. GetUserByEmailOrUsername filters
+		// out deleted=true rows so the lookup will fail just like
+		// for a missing user.
+		ctx := dbauthz.AsSystemRestricted(context.Background())
+		err := db.UpdateUserDeletedByID(ctx, user.ID)
+		require.NoError(t, err)
+
+		r := httptest.NewRequest("GET", "/", nil)
+		r.Header.Set(httpmw.ExternalAuthHeaderName, "Basic Username=ghost")
+		rw := httptest.NewRecorder()
+
+		httpmw.ExtractAPIKeyMW(httpmw.ExtractAPIKeyConfig{
+			DB:                 db,
+			ExternalAuthHeader: mustExternalAuthConfig(t, true, trustedLoopbackCIDR),
+		})(successHandlerWritingActor(t)).ServeHTTP(rw, r)
+
+		res := rw.Result()
+		defer res.Body.Close()
+		require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+	})
+
+	t.Run("NoDBWritesForSyntheticKey", func(t *testing.T) {
+		t.Parallel()
+		db, _ := dbtestutil.NewDB(t)
+		user := dbgen.User(t, db, database.User{Username: "alice"})
+
+		// Snapshot how many keys exist before the request.
+		ctx := dbauthz.AsSystemRestricted(context.Background())
+		beforeKeys, err := db.GetAPIKeysByUserID(ctx, database.GetAPIKeysByUserIDParams{
+			LoginType: database.LoginTypeNone,
+			UserID:    user.ID,
+		})
+		require.NoError(t, err)
+
+		r := httptest.NewRequest("GET", "/", nil)
+		r.Header.Set(httpmw.ExternalAuthHeaderName, "Basic Username=alice")
+		rw := httptest.NewRecorder()
+
+		httpmw.ExtractAPIKeyMW(httpmw.ExtractAPIKeyConfig{
+			DB:                 db,
+			ExternalAuthHeader: mustExternalAuthConfig(t, true, trustedLoopbackCIDR),
+		})(successHandlerWritingActor(t)).ServeHTTP(rw, r)
+
+		res := rw.Result()
+		res.Body.Close()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		afterKeys, err := db.GetAPIKeysByUserID(ctx, database.GetAPIKeysByUserIDParams{
+			LoginType: database.LoginTypeNone,
+			UserID:    user.ID,
+		})
+		require.NoError(t, err)
+		require.Len(t, afterKeys, len(beforeKeys),
+			"synthesized api key must not be persisted")
+	})
+}
+
+func TestParseExternalAuthHeaderConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Valid", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := httpmw.ParseExternalAuthHeaderConfig(true, []string{"127.0.0.0/8", "10.0.0.0/8"})
+		require.NoError(t, err)
+		require.True(t, cfg.Enabled)
+		require.Len(t, cfg.TrustedOrigins, 2)
+	})
+
+	t.Run("InvalidCIDR", func(t *testing.T) {
+		t.Parallel()
+		_, err := httpmw.ParseExternalAuthHeaderConfig(true, []string{"not-a-cidr"})
+		require.Error(t, err)
+	})
+
+	t.Run("EmptyEntriesSkipped", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := httpmw.ParseExternalAuthHeaderConfig(true, []string{"", "127.0.0.0/8", "  "})
+		require.NoError(t, err)
+		require.Len(t, cfg.TrustedOrigins, 1)
+	})
+}

--- a/coderd/httpmw/external_auth_header_test.go
+++ b/coderd/httpmw/external_auth_header_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
 
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
@@ -34,7 +35,7 @@ func parseCIDR(t *testing.T, cidr string) *net.IPNet {
 
 func mustExternalAuthConfig(t *testing.T, enabled bool, origins ...string) httpmw.ExternalAuthHeaderConfig {
 	t.Helper()
-	cfg, err := httpmw.ParseExternalAuthHeaderConfig(enabled, origins)
+	cfg, err := httpmw.ParseExternalAuthHeaderConfig(enabled, origins, false, nil)
 	require.NoError(t, err)
 	return cfg
 }
@@ -272,14 +273,136 @@ func TestExternalAuthHeader(t *testing.T) {
 		require.Len(t, afterKeys, len(beforeKeys),
 			"synthesized api key must not be persisted")
 	})
+
+	t.Run("AutoCreateInvokesCallback", func(t *testing.T) {
+		t.Parallel()
+		db, _ := dbtestutil.NewDB(t)
+
+		var called bool
+		var gotParams httpmw.ExternalAuthHeaderCreateUserParams
+		cfg := mustExternalAuthConfig(t, true, trustedLoopbackCIDR)
+		cfg.AllowAutoCreateUsers = true
+		cfg.AutoCreateDefaultRoles = []string{"member"}
+		cfg.CreateUser = func(ctx context.Context, params httpmw.ExternalAuthHeaderCreateUserParams) (database.User, error) {
+			called = true
+			gotParams = params
+			return dbgen.User(t, db, database.User{
+				Username: params.Username,
+				Email:    params.Email,
+			}), nil
+		}
+
+		r := httptest.NewRequest("GET", "/", nil)
+		r.Header.Set(httpmw.ExternalAuthHeaderName, "Basic UserEmail=carol@example.com, Name=Carol Danvers, Roles=auditor")
+		rw := httptest.NewRecorder()
+
+		httpmw.ExtractAPIKeyMW(httpmw.ExtractAPIKeyConfig{
+			DB:                 db,
+			ExternalAuthHeader: cfg,
+		})(successHandlerWritingActor(t)).ServeHTTP(rw, r)
+
+		res := rw.Result()
+		res.Body.Close()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+		require.True(t, called, "CreateUser callback should run for unknown user")
+		require.Equal(t, "carol@example.com", gotParams.Email)
+		require.Equal(t, "carol", gotParams.Username, "username should default to email local part")
+		require.Equal(t, "Carol Danvers", gotParams.Name)
+		require.Equal(t, []string{"auditor"}, gotParams.Roles, "header Roles= must win over default")
+	})
+
+	t.Run("AutoCreateUsesDefaultRolesWhenHeaderOmitsThem", func(t *testing.T) {
+		t.Parallel()
+		db, _ := dbtestutil.NewDB(t)
+
+		var gotRoles []string
+		cfg := mustExternalAuthConfig(t, true, trustedLoopbackCIDR)
+		cfg.AllowAutoCreateUsers = true
+		cfg.AutoCreateDefaultRoles = []string{"member", "auditor"}
+		cfg.CreateUser = func(ctx context.Context, params httpmw.ExternalAuthHeaderCreateUserParams) (database.User, error) {
+			gotRoles = params.Roles
+			return dbgen.User(t, db, database.User{
+				Username: params.Username,
+				Email:    params.Email,
+			}), nil
+		}
+
+		r := httptest.NewRequest("GET", "/", nil)
+		r.Header.Set(httpmw.ExternalAuthHeaderName, "Basic Username=dave, UserEmail=dave@example.com")
+		rw := httptest.NewRecorder()
+
+		httpmw.ExtractAPIKeyMW(httpmw.ExtractAPIKeyConfig{
+			DB:                 db,
+			ExternalAuthHeader: cfg,
+		})(successHandlerWritingActor(t)).ServeHTTP(rw, r)
+
+		res := rw.Result()
+		res.Body.Close()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+		require.Equal(t, []string{"member", "auditor"}, gotRoles)
+	})
+
+	t.Run("AutoCreateDisabledKeepsUnknownUser401", func(t *testing.T) {
+		t.Parallel()
+		db, _ := dbtestutil.NewDB(t)
+
+		cfg := mustExternalAuthConfig(t, true, trustedLoopbackCIDR)
+		require.False(t, cfg.AllowAutoCreateUsers)
+		cfg.CreateUser = func(context.Context, httpmw.ExternalAuthHeaderCreateUserParams) (database.User, error) {
+			t.Fatal("CreateUser must not run when AllowAutoCreateUsers is false")
+			return database.User{}, nil
+		}
+
+		r := httptest.NewRequest("GET", "/", nil)
+		r.Header.Set(httpmw.ExternalAuthHeaderName, "Basic UserEmail=eve@example.com")
+		rw := httptest.NewRecorder()
+
+		httpmw.ExtractAPIKeyMW(httpmw.ExtractAPIKeyConfig{
+			DB:                 db,
+			ExternalAuthHeader: cfg,
+		})(successHandlerWritingActor(t)).ServeHTTP(rw, r)
+
+		res := rw.Result()
+		res.Body.Close()
+		require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+	})
+
+	t.Run("AutoCreatePropagatesCallbackError", func(t *testing.T) {
+		t.Parallel()
+		db, _ := dbtestutil.NewDB(t)
+
+		cfg := mustExternalAuthConfig(t, true, trustedLoopbackCIDR)
+		cfg.AllowAutoCreateUsers = true
+		cfg.CreateUser = func(context.Context, httpmw.ExternalAuthHeaderCreateUserParams) (database.User, error) {
+			return database.User{}, errStubCreateFailed
+		}
+
+		r := httptest.NewRequest("GET", "/", nil)
+		r.Header.Set(httpmw.ExternalAuthHeaderName, "Basic Username=greta, UserEmail=greta@example.com")
+		rw := httptest.NewRecorder()
+
+		httpmw.ExtractAPIKeyMW(httpmw.ExtractAPIKeyConfig{
+			DB:                 db,
+			ExternalAuthHeader: cfg,
+		})(successHandlerWritingActor(t)).ServeHTTP(rw, r)
+
+		res := rw.Result()
+		res.Body.Close()
+		require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+	})
 }
+
+// errStubCreateFailed is a sentinel returned by the test stub
+// CreateUser callback when the test wants to simulate a creation
+// failure.
+var errStubCreateFailed = xerrors.New("create failed")
 
 func TestParseExternalAuthHeaderConfig(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Valid", func(t *testing.T) {
 		t.Parallel()
-		cfg, err := httpmw.ParseExternalAuthHeaderConfig(true, []string{"127.0.0.0/8", "10.0.0.0/8"})
+		cfg, err := httpmw.ParseExternalAuthHeaderConfig(true, []string{"127.0.0.0/8", "10.0.0.0/8"}, false, nil)
 		require.NoError(t, err)
 		require.True(t, cfg.Enabled)
 		require.Len(t, cfg.TrustedOrigins, 2)
@@ -287,14 +410,26 @@ func TestParseExternalAuthHeaderConfig(t *testing.T) {
 
 	t.Run("InvalidCIDR", func(t *testing.T) {
 		t.Parallel()
-		_, err := httpmw.ParseExternalAuthHeaderConfig(true, []string{"not-a-cidr"})
+		_, err := httpmw.ParseExternalAuthHeaderConfig(true, []string{"not-a-cidr"}, false, nil)
 		require.Error(t, err)
 	})
 
 	t.Run("EmptyEntriesSkipped", func(t *testing.T) {
 		t.Parallel()
-		cfg, err := httpmw.ParseExternalAuthHeaderConfig(true, []string{"", "127.0.0.0/8", "  "})
+		cfg, err := httpmw.ParseExternalAuthHeaderConfig(true, []string{"", "127.0.0.0/8", "  "}, false, nil)
 		require.NoError(t, err)
 		require.Len(t, cfg.TrustedOrigins, 1)
+	})
+
+	t.Run("AutoCreateDefaultsCopied", func(t *testing.T) {
+		t.Parallel()
+		defaults := []string{"member", "auditor"}
+		cfg, err := httpmw.ParseExternalAuthHeaderConfig(true, []string{"127.0.0.0/8"}, true, defaults)
+		require.NoError(t, err)
+		require.True(t, cfg.AllowAutoCreateUsers)
+		require.Equal(t, defaults, cfg.AutoCreateDefaultRoles)
+		// Mutating the input must not change the stored value.
+		defaults[0] = "owner"
+		require.Equal(t, "member", cfg.AutoCreateDefaultRoles[0])
 	})
 }

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -1026,9 +1026,11 @@ type LoggingConfig struct {
 }
 
 type DangerousConfig struct {
-	AllowPathAppSharing         serpent.Bool `json:"allow_path_app_sharing" typescript:",notnull"`
-	AllowPathAppSiteOwnerAccess serpent.Bool `json:"allow_path_app_site_owner_access" typescript:",notnull"`
-	AllowAllCors                serpent.Bool `json:"allow_all_cors" typescript:",notnull"`
+	AllowPathAppSharing              serpent.Bool        `json:"allow_path_app_sharing" typescript:",notnull"`
+	AllowPathAppSiteOwnerAccess      serpent.Bool        `json:"allow_path_app_site_owner_access" typescript:",notnull"`
+	AllowAllCors                     serpent.Bool        `json:"allow_all_cors" typescript:",notnull"`
+	AllowExternalAuthHeader          serpent.Bool        `json:"allow_external_auth_header" typescript:",notnull"`
+	ExternalAuthHeaderTrustedOrigins serpent.StringArray `json:"external_auth_header_trusted_origins,omitempty" typescript:",notnull"`
 }
 
 type UserQuietHoursScheduleConfig struct {
@@ -2748,6 +2750,26 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 			Env:         "CODER_DANGEROUS_ALLOW_PATH_APP_SITE_OWNER_ACCESS",
 
 			Value: &c.Dangerous.AllowPathAppSiteOwnerAccess,
+			Group: &deploymentGroupDangerous,
+		},
+		{
+			Name:        "DANGEROUS: Allow External Authentication Header",
+			Description: "Trust the Coder-Authorization header for user identity assertions when the request originates from a CIDR listed in --dangerous-external-auth-header-trusted-origins. This is intended for deployments that sit behind an authenticating reverse proxy (e.g. an Envoy authn plugin). MISCONFIGURING THIS IS A FULL-IMPERSONATION FOOTGUN. The header has the form 'Coder-Authorization: Basic Username=alice' or 'Coder-Authorization: Basic UserEmail=alice@example.com'. See the docs for the full threat model.",
+			Flag:        "dangerous-allow-external-auth-header",
+			Env:         "CODER_DANGEROUS_ALLOW_EXTERNAL_AUTH_HEADER",
+			YAML:        "allowExternalAuthHeader",
+
+			Value: &c.Dangerous.AllowExternalAuthHeader,
+			Group: &deploymentGroupDangerous,
+		},
+		{
+			Name:        "DANGEROUS: External Authentication Header Trusted Origins",
+			Description: "CIDR networks whose source addresses may assert user identity via the Coder-Authorization header. Required for --dangerous-allow-external-auth-header to have any effect; an empty list silently disables the feature. Bind Coder to localhost or use mTLS at the proxy boundary; never list a network containing untrusted clients.",
+			Flag:        "dangerous-external-auth-header-trusted-origins",
+			Env:         "CODER_DANGEROUS_EXTERNAL_AUTH_HEADER_TRUSTED_ORIGINS",
+			YAML:        "externalAuthHeaderTrustedOrigins",
+
+			Value: &c.Dangerous.ExternalAuthHeaderTrustedOrigins,
 			Group: &deploymentGroupDangerous,
 		},
 		// Misc. settings

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -1026,11 +1026,13 @@ type LoggingConfig struct {
 }
 
 type DangerousConfig struct {
-	AllowPathAppSharing              serpent.Bool        `json:"allow_path_app_sharing" typescript:",notnull"`
-	AllowPathAppSiteOwnerAccess      serpent.Bool        `json:"allow_path_app_site_owner_access" typescript:",notnull"`
-	AllowAllCors                     serpent.Bool        `json:"allow_all_cors" typescript:",notnull"`
-	AllowExternalAuthHeader          serpent.Bool        `json:"allow_external_auth_header" typescript:",notnull"`
-	ExternalAuthHeaderTrustedOrigins serpent.StringArray `json:"external_auth_header_trusted_origins,omitempty" typescript:",notnull"`
+	AllowPathAppSharing                      serpent.Bool        `json:"allow_path_app_sharing" typescript:",notnull"`
+	AllowPathAppSiteOwnerAccess              serpent.Bool        `json:"allow_path_app_site_owner_access" typescript:",notnull"`
+	AllowAllCors                             serpent.Bool        `json:"allow_all_cors" typescript:",notnull"`
+	AllowExternalAuthHeader                  serpent.Bool        `json:"allow_external_auth_header" typescript:",notnull"`
+	ExternalAuthHeaderTrustedOrigins         serpent.StringArray `json:"external_auth_header_trusted_origins,omitempty" typescript:",notnull"`
+	AllowExternalAuthHeaderAutoCreateUsers   serpent.Bool        `json:"allow_external_auth_header_auto_create_users" typescript:",notnull"`
+	ExternalAuthHeaderAutoCreateDefaultRoles serpent.StringArray `json:"external_auth_header_auto_create_default_roles,omitempty" typescript:",notnull"`
 }
 
 type UserQuietHoursScheduleConfig struct {
@@ -2770,6 +2772,26 @@ func (c *DeploymentValues) Options() serpent.OptionSet {
 			YAML:        "externalAuthHeaderTrustedOrigins",
 
 			Value: &c.Dangerous.ExternalAuthHeaderTrustedOrigins,
+			Group: &deploymentGroupDangerous,
+		},
+		{
+			Name:        "DANGEROUS: Auto-create users from the External Authentication Header",
+			Description: "Provision Coder users on the fly when the Coder-Authorization header asserts an unknown user. Requires --dangerous-allow-external-auth-header. The header must include UserEmail; Username defaults to the local part of the email. New users are placed in the default organization with the roles specified by --dangerous-external-auth-header-auto-create-default-roles (or the Roles= field on the header, which wins when present).",
+			Flag:        "dangerous-allow-external-auth-header-auto-create-users",
+			Env:         "CODER_DANGEROUS_ALLOW_EXTERNAL_AUTH_HEADER_AUTO_CREATE_USERS",
+			YAML:        "allowExternalAuthHeaderAutoCreateUsers",
+
+			Value: &c.Dangerous.AllowExternalAuthHeaderAutoCreateUsers,
+			Group: &deploymentGroupDangerous,
+		},
+		{
+			Name:        "DANGEROUS: External Authentication Header Auto-create Default Roles",
+			Description: "Site roles assigned to users auto-created via the Coder-Authorization header when the header itself does not carry a Roles= field. Defaults to a plain member with no extra roles. Valid values include member, owner, auditor, user-admin, and template-admin.",
+			Flag:        "dangerous-external-auth-header-auto-create-default-roles",
+			Env:         "CODER_DANGEROUS_EXTERNAL_AUTH_HEADER_AUTO_CREATE_DEFAULT_ROLES",
+			YAML:        "externalAuthHeaderAutoCreateDefaultRoles",
+
+			Value: &c.Dangerous.ExternalAuthHeaderAutoCreateDefaultRoles,
 			Group: &deploymentGroupDangerous,
 		},
 		// Misc. settings

--- a/docs/admin/security/external-auth-header.md
+++ b/docs/admin/security/external-auth-header.md
@@ -59,8 +59,30 @@ Never list a network that contains untrusted clients. The proxy is
 responsible for stripping any inbound `Coder-Authorization` header
 before it is allowed to set its own. Coder does not strip it for you.
 
-User auto-creation is intentionally not supported. Provision users
-ahead of time using SCIM, the API, or `coder users create`.
+## User auto-creation
+
+When `--dangerous-allow-external-auth-header-auto-create-users` is
+also enabled, Coder provisions a previously unknown user on the fly.
+The header MUST include a `UserEmail`; the username defaults to the
+local part of the email when not supplied. The new user is placed in
+the default organization with login type `none`.
+
+Role assignment, in priority order:
+
+1. The header's `Roles=` field. The value is a comma-separated list:
+   `Coder-Authorization: Basic UserEmail=alice@example.com, Roles=member,auditor`.
+   Role names that do not exist on the deployment cause auto-creation
+   to fail with a 401 rather than silently dropping them.
+2. The deployment's
+   `--dangerous-external-auth-header-auto-create-default-roles`
+   list.
+3. Empty: the user is a plain member of the default organization
+   with no additional site roles.
+
+Auto-creation is off by default and is intended for steady-state
+provisioning from a trusted identity-aware proxy. For bulk
+provisioning or attribute mapping, prefer
+[SCIM](../users/headless-auth.md) or the [users API](../../reference/api/users.md).
 
 ## Configuration
 
@@ -77,6 +99,17 @@ Or via environment:
 ```sh
 CODER_DANGEROUS_ALLOW_EXTERNAL_AUTH_HEADER=true
 CODER_DANGEROUS_EXTERNAL_AUTH_HEADER_TRUSTED_ORIGINS=127.0.0.0/8,::1/128
+```
+
+To also auto-create unknown users (see above), enable both
+auto-create flags:
+
+```sh
+coder server \
+  --dangerous-allow-external-auth-header \
+  --dangerous-external-auth-header-trusted-origins=127.0.0.0/8,::1/128 \
+  --dangerous-allow-external-auth-header-auto-create-users \
+  --dangerous-external-auth-header-auto-create-default-roles=member
 ```
 
 Setting `--dangerous-allow-external-auth-header` without trusted

--- a/docs/admin/security/external-auth-header.md
+++ b/docs/admin/security/external-auth-header.md
@@ -1,0 +1,122 @@
+# External authentication header
+
+> [!CAUTION]
+> Misconfiguring this feature is a full-impersonation footgun. Read the
+> threat model before enabling it. See
+> [issue #8889](https://github.com/coder/coder/issues/8889) for the
+> original design discussion.
+
+Coder can trust an upstream authentication gateway that sits in front
+of `coder server` to assert the authenticated user via a request
+header. This is intended for deployments where every request flows
+through an identity-aware reverse proxy (for example, Envoy with a
+custom external authorization plugin) and Coder runs on a private
+network.
+
+## How it works
+
+When the feature is enabled, Coder accepts the `Coder-Authorization`
+header on requests that originate from a configured CIDR allowlist.
+The header asserts the user identity that Coder should run the
+request as:
+
+```http
+Coder-Authorization: Basic Username=alice
+Coder-Authorization: Basic UserEmail=alice@example.com
+```
+
+Either `Username` or `UserEmail` must be present. Other fields are
+accepted and ignored for forward compatibility. The header value is
+case-insensitive on field names and tolerant of whitespace.
+
+When Coder accepts the assertion, it:
+
+1. Looks up the user via `GetUserByEmailOrUsername` (deleted users
+   are not found).
+2. Builds an in-memory API key bound to that user. The key is never
+   persisted, no session token is issued, and the user's existing
+   sessions are not touched.
+3. Loads the user's roles, groups, and status, and runs the request
+   under that authorization context.
+
+If the header is absent, malformed, or the request did not come from
+a trusted origin, Coder falls back to the normal session-token flow.
+
+## Threat model
+
+Coder fully trusts the header on trusted origins. Anyone who can
+deliver a request with a `Coder-Authorization` header from one of
+those origins can impersonate any user.
+
+Run Coder behind a hardened reverse proxy and pick exactly one of:
+
+- Bind `coder server` to `localhost` and run the proxy on the same
+  host. Trust `127.0.0.1/32` and `::1/128`.
+- Use mTLS between the proxy and Coder over a private network and
+  trust the proxy's network range.
+
+Never list a network that contains untrusted clients. The proxy is
+responsible for stripping any inbound `Coder-Authorization` header
+before it is allowed to set its own. Coder does not strip it for you.
+
+User auto-creation is intentionally not supported. Provision users
+ahead of time using SCIM, the API, or `coder users create`.
+
+## Configuration
+
+Two flags on `coder server` enable the feature. Both are required:
+
+```sh
+coder server \
+  --dangerous-allow-external-auth-header \
+  --dangerous-external-auth-header-trusted-origins=127.0.0.0/8,::1/128
+```
+
+Or via environment:
+
+```sh
+CODER_DANGEROUS_ALLOW_EXTERNAL_AUTH_HEADER=true
+CODER_DANGEROUS_EXTERNAL_AUTH_HEADER_TRUSTED_ORIGINS=127.0.0.0/8,::1/128
+```
+
+Setting `--dangerous-allow-external-auth-header` without trusted
+origins is a no-op: Coder logs a warning at startup and the header
+will never be honored.
+
+## Example: Envoy with external authorization
+
+The proxy must be configured to set the header itself, not forward
+one supplied by the client. A minimal Envoy `ext_authz` filter that
+populates the header from an upstream identity decision looks like:
+
+```yaml
+http_filters:
+  - name: envoy.filters.http.ext_authz
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+      transport_api_version: V3
+      grpc_service:
+        envoy_grpc:
+          cluster_name: ext-authz
+      authorization_response:
+        allowed_upstream_headers:
+          patterns:
+            - exact: coder-authorization
+```
+
+The `ext-authz` service authenticates the user (cookie, SAML, OIDC,
+mTLS, etc.) and responds with a `Coder-Authorization: Basic
+Username=...` header that Envoy then injects into the upstream
+request. Coder, bound to `localhost` and trusting `127.0.0.0/8`,
+accepts the assertion.
+
+## Limitations
+
+- Only the `Basic` scheme is supported today. Future schemes may add
+  signed assertions (HMAC, JWT) for deployments that cannot rely on
+  network-level trust alone.
+- The `ActiveSession` and `TokenName` fields from the original
+  proposal are accepted and ignored.
+- The header bypasses Coder's own session refresh and OAuth refresh
+  paths. The proxy is responsible for keeping the upstream session
+  alive.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -956,6 +956,11 @@
 							"description": "Encrypt the database to prevent unauthorized access",
 							"path": "./admin/security/database-encryption.md",
 							"state": ["premium"]
+						},
+						{
+							"title": "External Authentication Header",
+							"description": "Trust an upstream authentication gateway via the Coder-Authorization header",
+							"path": "./admin/security/external-auth-header.md"
 						}
 					]
 				},

--- a/docs/reference/api/general.md
+++ b/docs/reference/api/general.md
@@ -240,8 +240,12 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
     "dangerous": {
       "allow_all_cors": true,
       "allow_external_auth_header": true,
+      "allow_external_auth_header_auto_create_users": true,
       "allow_path_app_sharing": true,
       "allow_path_app_site_owner_access": true,
+      "external_auth_header_auto_create_default_roles": [
+        "string"
+      ],
       "external_auth_header_trusted_origins": [
         "string"
       ]

--- a/docs/reference/api/general.md
+++ b/docs/reference/api/general.md
@@ -239,8 +239,12 @@ curl -X GET http://coder-server:8080/api/v2/deployment/config \
     },
     "dangerous": {
       "allow_all_cors": true,
+      "allow_external_auth_header": true,
       "allow_path_app_sharing": true,
-      "allow_path_app_site_owner_access": true
+      "allow_path_app_site_owner_access": true,
+      "external_auth_header_trusted_origins": [
+        "string"
+      ]
     },
     "derp": {
       "config": {

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -5126,18 +5126,24 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 ```json
 {
   "allow_all_cors": true,
+  "allow_external_auth_header": true,
   "allow_path_app_sharing": true,
-  "allow_path_app_site_owner_access": true
+  "allow_path_app_site_owner_access": true,
+  "external_auth_header_trusted_origins": [
+    "string"
+  ]
 }
 ```
 
 ### Properties
 
-| Name                               | Type    | Required | Restrictions | Description |
-|------------------------------------|---------|----------|--------------|-------------|
-| `allow_all_cors`                   | boolean | false    |              |             |
-| `allow_path_app_sharing`           | boolean | false    |              |             |
-| `allow_path_app_site_owner_access` | boolean | false    |              |             |
+| Name                                   | Type            | Required | Restrictions | Description |
+|----------------------------------------|-----------------|----------|--------------|-------------|
+| `allow_all_cors`                       | boolean         | false    |              |             |
+| `allow_external_auth_header`           | boolean         | false    |              |             |
+| `allow_path_app_sharing`               | boolean         | false    |              |             |
+| `allow_path_app_site_owner_access`     | boolean         | false    |              |             |
+| `external_auth_header_trusted_origins` | array of string | false    |              |             |
 
 ## codersdk.DeleteExternalAuthByIDResponse
 
@@ -5302,8 +5308,12 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
     },
     "dangerous": {
       "allow_all_cors": true,
+      "allow_external_auth_header": true,
       "allow_path_app_sharing": true,
-      "allow_path_app_site_owner_access": true
+      "allow_path_app_site_owner_access": true,
+      "external_auth_header_trusted_origins": [
+        "string"
+      ]
     },
     "derp": {
       "config": {
@@ -5893,8 +5903,12 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
   },
   "dangerous": {
     "allow_all_cors": true,
+    "allow_external_auth_header": true,
     "allow_path_app_sharing": true,
-    "allow_path_app_site_owner_access": true
+    "allow_path_app_site_owner_access": true,
+    "external_auth_header_trusted_origins": [
+      "string"
+    ]
   },
   "derp": {
     "config": {

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -5127,8 +5127,12 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 {
   "allow_all_cors": true,
   "allow_external_auth_header": true,
+  "allow_external_auth_header_auto_create_users": true,
   "allow_path_app_sharing": true,
   "allow_path_app_site_owner_access": true,
+  "external_auth_header_auto_create_default_roles": [
+    "string"
+  ],
   "external_auth_header_trusted_origins": [
     "string"
   ]
@@ -5137,13 +5141,15 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 
 ### Properties
 
-| Name                                   | Type            | Required | Restrictions | Description |
-|----------------------------------------|-----------------|----------|--------------|-------------|
-| `allow_all_cors`                       | boolean         | false    |              |             |
-| `allow_external_auth_header`           | boolean         | false    |              |             |
-| `allow_path_app_sharing`               | boolean         | false    |              |             |
-| `allow_path_app_site_owner_access`     | boolean         | false    |              |             |
-| `external_auth_header_trusted_origins` | array of string | false    |              |             |
+| Name                                             | Type            | Required | Restrictions | Description |
+|--------------------------------------------------|-----------------|----------|--------------|-------------|
+| `allow_all_cors`                                 | boolean         | false    |              |             |
+| `allow_external_auth_header`                     | boolean         | false    |              |             |
+| `allow_external_auth_header_auto_create_users`   | boolean         | false    |              |             |
+| `allow_path_app_sharing`                         | boolean         | false    |              |             |
+| `allow_path_app_site_owner_access`               | boolean         | false    |              |             |
+| `external_auth_header_auto_create_default_roles` | array of string | false    |              |             |
+| `external_auth_header_trusted_origins`           | array of string | false    |              |             |
 
 ## codersdk.DeleteExternalAuthByIDResponse
 
@@ -5309,8 +5315,12 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
     "dangerous": {
       "allow_all_cors": true,
       "allow_external_auth_header": true,
+      "allow_external_auth_header_auto_create_users": true,
       "allow_path_app_sharing": true,
       "allow_path_app_site_owner_access": true,
+      "external_auth_header_auto_create_default_roles": [
+        "string"
+      ],
       "external_auth_header_trusted_origins": [
         "string"
       ]
@@ -5904,8 +5914,12 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
   "dangerous": {
     "allow_all_cors": true,
     "allow_external_auth_header": true,
+    "allow_external_auth_header_auto_create_users": true,
     "allow_path_app_sharing": true,
     "allow_path_app_site_owner_access": true,
+    "external_auth_header_auto_create_default_roles": [
+      "string"
+    ],
     "external_auth_header_trusted_origins": [
       "string"
     ]

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -889,6 +889,26 @@ Allow workspace apps that are not served from subdomains to be shared. Path-base
 
 Allow site-owners to access workspace apps from workspaces they do not own. Owners cannot access path-based apps they do not own by default. Path-based apps can make requests to the Coder API and pose a security risk when the workspace serves malicious JavaScript. Path-based apps can be disabled entirely with --disable-path-apps for further security.
 
+### --dangerous-allow-external-auth-header
+
+|             |                                                          |
+|-------------|----------------------------------------------------------|
+| Type        | <code>bool</code>                                        |
+| Environment | <code>$CODER_DANGEROUS_ALLOW_EXTERNAL_AUTH_HEADER</code> |
+| YAML        | <code>dangerous.allowExternalAuthHeader</code>           |
+
+Trust the Coder-Authorization header for user identity assertions when the request originates from a CIDR listed in --dangerous-external-auth-header-trusted-origins. This is intended for deployments that sit behind an authenticating reverse proxy (e.g. an Envoy authn plugin). MISCONFIGURING THIS IS A FULL-IMPERSONATION FOOTGUN. The header has the form 'Coder-Authorization: Basic Username=alice' or 'Coder-Authorization: Basic UserEmail=alice@example.com'. See the docs for the full threat model.
+
+### --dangerous-external-auth-header-trusted-origins
+
+|             |                                                                    |
+|-------------|--------------------------------------------------------------------|
+| Type        | <code>string-array</code>                                          |
+| Environment | <code>$CODER_DANGEROUS_EXTERNAL_AUTH_HEADER_TRUSTED_ORIGINS</code> |
+| YAML        | <code>dangerous.externalAuthHeaderTrustedOrigins</code>            |
+
+CIDR networks whose source addresses may assert user identity via the Coder-Authorization header. Required for --dangerous-allow-external-auth-header to have any effect; an empty list silently disables the feature. Bind Coder to localhost or use mTLS at the proxy boundary; never list a network containing untrusted clients.
+
 ### --experiments
 
 |             |                                 |

--- a/docs/reference/cli/server.md
+++ b/docs/reference/cli/server.md
@@ -909,6 +909,26 @@ Trust the Coder-Authorization header for user identity assertions when the reque
 
 CIDR networks whose source addresses may assert user identity via the Coder-Authorization header. Required for --dangerous-allow-external-auth-header to have any effect; an empty list silently disables the feature. Bind Coder to localhost or use mTLS at the proxy boundary; never list a network containing untrusted clients.
 
+### --dangerous-allow-external-auth-header-auto-create-users
+
+|             |                                                                            |
+|-------------|----------------------------------------------------------------------------|
+| Type        | <code>bool</code>                                                          |
+| Environment | <code>$CODER_DANGEROUS_ALLOW_EXTERNAL_AUTH_HEADER_AUTO_CREATE_USERS</code> |
+| YAML        | <code>dangerous.allowExternalAuthHeaderAutoCreateUsers</code>              |
+
+Provision Coder users on the fly when the Coder-Authorization header asserts an unknown user. Requires --dangerous-allow-external-auth-header. The header must include UserEmail; Username defaults to the local part of the email. New users are placed in the default organization with the roles specified by --dangerous-external-auth-header-auto-create-default-roles (or the Roles= field on the header, which wins when present).
+
+### --dangerous-external-auth-header-auto-create-default-roles
+
+|             |                                                                              |
+|-------------|------------------------------------------------------------------------------|
+| Type        | <code>string-array</code>                                                    |
+| Environment | <code>$CODER_DANGEROUS_EXTERNAL_AUTH_HEADER_AUTO_CREATE_DEFAULT_ROLES</code> |
+| YAML        | <code>dangerous.externalAuthHeaderAutoCreateDefaultRoles</code>              |
+
+Site roles assigned to users auto-created via the Coder-Authorization header when the header itself does not carry a Roles= field. Defaults to a plain member with no extra roles. Valid values include member, owner, auditor, user-admin, and template-admin.
+
 ### --experiments
 
 |             |                                 |

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -869,6 +869,16 @@ Configure how workspace prebuilds behave.
           How often to reconcile workspace prebuilds state.
 
 ⚠️ DANGEROUS OPTIONS: 
+      --dangerous-allow-external-auth-header bool, $CODER_DANGEROUS_ALLOW_EXTERNAL_AUTH_HEADER
+          Trust the Coder-Authorization header for user identity assertions when
+          the request originates from a CIDR listed in
+          --dangerous-external-auth-header-trusted-origins. This is intended for
+          deployments that sit behind an authenticating reverse proxy (e.g. an
+          Envoy authn plugin). MISCONFIGURING THIS IS A FULL-IMPERSONATION
+          FOOTGUN. The header has the form 'Coder-Authorization: Basic
+          Username=alice' or 'Coder-Authorization: Basic
+          UserEmail=alice@example.com'. See the docs for the full threat model.
+
       --dangerous-allow-path-app-sharing bool, $CODER_DANGEROUS_ALLOW_PATH_APP_SHARING
           Allow workspace apps that are not served from subdomains to be shared.
           Path-based app sharing is DISABLED by default for security purposes.
@@ -884,6 +894,14 @@ Configure how workspace prebuilds behave.
           risk when the workspace serves malicious JavaScript. Path-based apps
           can be disabled entirely with --disable-path-apps for further
           security.
+
+      --dangerous-external-auth-header-trusted-origins string-array, $CODER_DANGEROUS_EXTERNAL_AUTH_HEADER_TRUSTED_ORIGINS
+          CIDR networks whose source addresses may assert user identity via the
+          Coder-Authorization header. Required for
+          --dangerous-allow-external-auth-header to have any effect; an empty
+          list silently disables the feature. Bind Coder to localhost or use
+          mTLS at the proxy boundary; never list a network containing untrusted
+          clients.
 
 ENTERPRISE OPTIONS: 
 These options are only available in the Enterprise Edition.

--- a/enterprise/cli/testdata/coder_server_--help.golden
+++ b/enterprise/cli/testdata/coder_server_--help.golden
@@ -895,6 +895,21 @@ Configure how workspace prebuilds behave.
           can be disabled entirely with --disable-path-apps for further
           security.
 
+      --dangerous-allow-external-auth-header-auto-create-users bool, $CODER_DANGEROUS_ALLOW_EXTERNAL_AUTH_HEADER_AUTO_CREATE_USERS
+          Provision Coder users on the fly when the Coder-Authorization header
+          asserts an unknown user. Requires
+          --dangerous-allow-external-auth-header. The header must include
+          UserEmail; Username defaults to the local part of the email. New users
+          are placed in the default organization with the roles specified by
+          --dangerous-external-auth-header-auto-create-default-roles (or the
+          Roles= field on the header, which wins when present).
+
+      --dangerous-external-auth-header-auto-create-default-roles string-array, $CODER_DANGEROUS_EXTERNAL_AUTH_HEADER_AUTO_CREATE_DEFAULT_ROLES
+          Site roles assigned to users auto-created via the Coder-Authorization
+          header when the header itself does not carry a Roles= field. Defaults
+          to a plain member with no extra roles. Valid values include member,
+          owner, auditor, user-admin, and template-admin.
+
       --dangerous-external-auth-header-trusted-origins string-array, $CODER_DANGEROUS_EXTERNAL_AUTH_HEADER_TRUSTED_ORIGINS
           CIDR networks whose source addresses may assert user identity via the
           Coder-Authorization header. Required for

--- a/enterprise/coderd/coderd.go
+++ b/enterprise/coderd/coderd.go
@@ -270,6 +270,7 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 		Optional:                      false,
 		SessionTokenFunc:              nil, // Default behavior
 		PostAuthAdditionalHeadersFunc: options.PostAuthAdditionalHeadersFunc,
+		ExternalAuthHeader:            options.ExternalAuthHeaderConfig,
 	})
 	apiKeyMiddlewareOptional := httpmw.ExtractAPIKeyMW(httpmw.ExtractAPIKeyConfig{
 		DB:                            options.Database,
@@ -279,6 +280,7 @@ func New(ctx context.Context, options *Options) (_ *API, err error) {
 		Optional:                      true,
 		SessionTokenFunc:              nil, // Default behavior
 		PostAuthAdditionalHeadersFunc: options.PostAuthAdditionalHeadersFunc,
+		ExternalAuthHeader:            options.ExternalAuthHeaderConfig,
 	})
 
 	deploymentID, err := options.Database.GetDeploymentID(ctx)

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -3568,6 +3568,8 @@ export interface DangerousConfig {
 	readonly allow_path_app_sharing: boolean;
 	readonly allow_path_app_site_owner_access: boolean;
 	readonly allow_all_cors: boolean;
+	readonly allow_external_auth_header: boolean;
+	readonly external_auth_header_trusted_origins?: string;
 }
 
 // From codersdk/database.go

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -3570,6 +3570,8 @@ export interface DangerousConfig {
 	readonly allow_all_cors: boolean;
 	readonly allow_external_auth_header: boolean;
 	readonly external_auth_header_trusted_origins?: string;
+	readonly allow_external_auth_header_auto_create_users: boolean;
+	readonly external_auth_header_auto_create_default_roles?: string;
 }
 
 // From codersdk/database.go


### PR DESCRIPTION
Closes #8889.

Adds the `Coder-Authorization` header path proposed in the issue, with the auto-create-users behavior the original requester asked for. An upstream authenticating reverse proxy (e.g. Envoy) on a trusted origin can assert user identity to Coder:

```
Coder-Authorization: Basic Username=alice
Coder-Authorization: Basic UserEmail=alice@example.com
Coder-Authorization: Basic Username=alice, UserEmail=alice@example.com, Name=Alice Liddell, Roles=member,auditor
```

Four dangerous flags gate the feature:

- `--dangerous-allow-external-auth-header` — turn the parser on.
- `--dangerous-external-auth-header-trusted-origins=CIDR,…` — mandatory allowlist; an empty list silently disables the feature.
- `--dangerous-allow-external-auth-header-auto-create-users` — opt in to on-demand provisioning of unknown users.
- `--dangerous-external-auth-header-auto-create-default-roles=member,…` — site roles assigned when the header omits `Roles=`.

When the header is accepted, Coder either looks up the asserted user (default) or, with auto-create enabled, provisions them through `api.CreateUser` with `LoginTypeNone` in the default organization (same path the OIDC auto-create flow uses). The synthesized session is an in-memory `APIKey` — no DB writes, no OAuth refresh.

Documented in `docs/admin/security/external-auth-header.md` (threat model, configuration, Envoy `ext_authz` example).

<details>
<summary>Implementation plan and decision log</summary>

### Design decisions (locked with @kylecarbs before implementing)

- **Scheme**: `Basic` header, JWT deferred. Matches @coryb's original need; signed-JWT schemes (`HMAC-SHA256`, `Bearer`) can be added to the same parser later.
- **OSS**, not Enterprise. Sits next to `--proxy-trusted-headers`, which is already OSS.
- **Mandatory trusted-origins CIDR allowlist.** Without it, anyone who can reach the listener can impersonate any user. An empty list with the flag set is a no-op and logs a warning at startup.
- **Auto-create users** (added in the follow-up commit after a review of the issue thread): opt-in via a second dangerous flag, mirroring the OIDC auto-create path. Reuses `api.CreateUser`, default organization, SSH-key generation, audit, and notifications. `LoginTypeNone` so the OAuth refresh path is skipped.
- **Role precedence**: header `Roles=` wins, then deployment default-role list, then empty. Unknown role names fail closed with a 401.
- **Synthesize the session in-memory.** No DB lookup of an existing API key, no DB writes per request. The synthesized `APIKey` short-circuits at the top of `ValidateAPIKey` so OAuth refresh and `LastUsed` updates are skipped.

### Where the change lives

- `coderd/httpmw/external_auth_header.go` (new): parser, config, `ParseExternalAuthHeaderConfig`, `validateExternalAuthHeader`, `autoCreateExternalAuthHeaderUser` (calls the deployment callback).
- `coderd/external_auth_header_user.go` (new): `(*API).createExternalAuthHeaderUser` and role validation. Wired as the `CreateUser` callback in `coderd.New` so `httpmw` stays free of an import cycle while enterprise.New inherits the wired callback via the shared `*Options`.
- `coderd/external_auth_header_user_test.go` (new): end-to-end coderdtest exercising auto-create, header-roles-win precedence, and invalid-role rejection.
- `coderd/httpmw/external_auth_header_test.go`: existing 9 subtests plus 4 new auto-create subtests covering callback invocation, default-role fallback, disabled-flag enforcement, and propagation of callback errors.
- `coderd/httpmw/apikey.go`: `ExternalAuthHeader` on `ValidateAPIKeyConfig`/`ExtractAPIKeyConfig`, short-circuit at the top of `ValidateAPIKey`, plumbing through the precheck path.
- `cli/server.go`, `coderd/coderd.go`, `coderd/coderdtest/coderdtest.go`, `enterprise/coderd/coderd.go`: deployment-value plumbing.
- `codersdk/deployment.go`: four new `DangerousConfig` fields with serpent options.
- `docs/admin/security/external-auth-header.md` + `docs/manifest.json`: docs page with threat model, auto-create role precedence, and Envoy example.
- Regenerated CLI / API / TypeScript fixtures.

### Bug fix surfaced by the e2e tests

The synthesized in-memory `APIKey` needed an explicit `AllowList{rbac.AllowListAll()}`. `IntersectAllowLists` treats an empty DB list as fail-closed and was blocking the auditor role from reading `/api/v2/users/me`. Caught only when the e2e test exercised a real authenticated route rather than a no-op handler.

### Out of scope (deliberate)

- Signed JWT mode (HMAC-SHA256, JWKS). Parser is structured so a new scheme is additive.
- `ActiveSession` and `TokenName` field semantics. Both are accepted and ignored for forward compatibility (matches the issue's later clarification that these are optional).
- Workspace-app session integration.
- Audit log entries for the synthesized session (auto-create itself goes through `api.CreateUser`, which already emits the user-create audit event).

</details>

This PR was opened by a Coder agent on behalf of @kylecarbs.