### PR TITLE
docs: document /api/experimental/chats config and provider routes

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -145,6 +145,544 @@ const docTemplate = `{
                 ]
             }
         },
+        "/api/experimental/chats/config/advisor": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat advisor config",
+                "operationId": "get-chat-advisor-config",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.AdvisorConfig"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "put": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update chat advisor config",
+                "operationId": "update-chat-advisor-config",
+                "parameters": [
+                    {
+                        "description": "Request body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateAdvisorConfigRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/config/auto-archive-days": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat auto archive days",
+                "operationId": "get-chat-auto-archive-days",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatAutoArchiveDaysResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "put": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update chat auto archive days",
+                "operationId": "update-chat-auto-archive-days",
+                "parameters": [
+                    {
+                        "description": "Request body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateChatAutoArchiveDaysRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/config/computer-use-provider": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat computer use provider",
+                "operationId": "get-chat-computer-use-provider",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatComputerUseProviderResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "put": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update chat computer use provider",
+                "operationId": "update-chat-computer-use-provider",
+                "parameters": [
+                    {
+                        "description": "Request body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateChatComputerUseProviderRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/config/debug-logging": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat debug logging",
+                "operationId": "get-chat-debug-logging",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatDebugLoggingAdminSettings"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "put": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update chat debug logging",
+                "operationId": "update-chat-debug-logging",
+                "parameters": [
+                    {
+                        "description": "Request body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateChatDebugLoggingAllowUsersRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/config/debug-retention-days": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat debug retention days",
+                "operationId": "get-chat-debug-retention-days",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatDebugRetentionDaysResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "put": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update chat debug retention days",
+                "operationId": "update-chat-debug-retention-days",
+                "parameters": [
+                    {
+                        "description": "Request body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateChatDebugRetentionDaysRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/config/desktop-enabled": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat desktop enabled",
+                "operationId": "get-chat-desktop-enabled",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatDesktopEnabledResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "put": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update chat desktop enabled",
+                "operationId": "update-chat-desktop-enabled",
+                "parameters": [
+                    {
+                        "description": "Request body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateChatDesktopEnabledRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/config/model-override/{context}": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat model override",
+                "operationId": "get-chat-model-override",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Override context",
+                        "name": "context",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatModelOverrideResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "put": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update chat model override",
+                "operationId": "update-chat-model-override",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Override context",
+                        "name": "context",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateChatModelOverrideRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/config/personal-model-overrides": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat personal model overrides admin settings",
+                "operationId": "get-chat-personal-model-overrides-admin-settings",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatPersonalModelOverridesAdminSettings"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "put": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update chat personal model overrides admin settings",
+                "operationId": "update-chat-personal-model-overrides-admin-settings",
+                "parameters": [
+                    {
+                        "description": "Request body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateChatPersonalModelOverridesAdminSettingsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/config/plan-mode-instructions": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat plan mode instructions",
+                "operationId": "get-chat-plan-mode-instructions",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatPlanModeInstructionsResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "put": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update chat plan mode instructions",
+                "operationId": "update-chat-plan-mode-instructions",
+                "parameters": [
+                    {
+                        "description": "Request body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateChatPlanModeInstructionsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
         "/api/experimental/chats/config/retention-days": {
             "get": {
                 "produces": [
@@ -205,6 +743,369 @@ const docTemplate = `{
                 "x-apidocgen": {
                     "skip": true
                 }
+            }
+        },
+        "/api/experimental/chats/config/system-prompt": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat system prompt",
+                "operationId": "get-chat-system-prompt",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatSystemPromptResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "put": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update chat system prompt",
+                "operationId": "update-chat-system-prompt",
+                "parameters": [
+                    {
+                        "description": "Request body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateChatSystemPromptRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/config/template-allowlist": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat template allowlist",
+                "operationId": "get-chat-template-allowlist",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatTemplateAllowlist"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "put": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update chat template allowlist",
+                "operationId": "update-chat-template-allowlist",
+                "parameters": [
+                    {
+                        "description": "Request body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatTemplateAllowlist"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/config/user-debug-logging": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get user chat debug logging",
+                "operationId": "get-user-chat-debug-logging",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UserChatDebugLoggingSettings"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "put": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update user chat debug logging",
+                "operationId": "update-user-chat-debug-logging",
+                "parameters": [
+                    {
+                        "description": "Request body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateUserChatDebugLoggingRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/config/user-personal-model-overrides": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get user chat personal model overrides",
+                "operationId": "get-user-chat-personal-model-overrides",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UserChatPersonalModelOverridesResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/config/user-personal-model-overrides/{context}": {
+            "put": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update user chat personal model override",
+                "operationId": "update-user-chat-personal-model-override",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Override context",
+                        "name": "context",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateUserChatPersonalModelOverrideRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/config/user-prompt": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get user chat custom prompt",
+                "operationId": "get-user-chat-custom-prompt",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UserChatCustomPrompt"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "put": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update user chat custom prompt",
+                "operationId": "update-user-chat-custom-prompt",
+                "parameters": [
+                    {
+                        "description": "Request body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UserChatCustomPrompt"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UserChatCustomPrompt"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/config/workspace-ttl": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat workspace TTL",
+                "operationId": "get-chat-workspace-ttl",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatWorkspaceTTLResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "put": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update chat workspace TTL",
+                "operationId": "update-chat-workspace-ttl",
+                "parameters": [
+                    {
+                        "description": "Request body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateChatWorkspaceTTLRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
             }
         },
         "/api/experimental/chats/files": {
@@ -339,6 +1240,149 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/experimental/chats/model-configs": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "List chat model configs",
+                "operationId": "list-chat-model-configs",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/codersdk.ChatModelConfig"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "post": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Create chat model config",
+                "operationId": "create-chat-model-config",
+                "parameters": [
+                    {
+                        "description": "Request body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.CreateChatModelConfigRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatModelConfig"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/model-configs/{modelConfig}": {
+            "delete": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Delete chat model config",
+                "operationId": "delete-chat-model-config",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Model config ID",
+                        "name": "modelConfig",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "patch": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update chat model config",
+                "operationId": "update-chat-model-config",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Model config ID",
+                        "name": "modelConfig",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateChatModelConfigRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatModelConfig"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
         "/api/experimental/chats/models": {
             "get": {
                 "description": "Experimental: this endpoint is subject to change.",
@@ -356,6 +1400,254 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/codersdk.ChatModelsResponse"
                         }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/providers": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "List chat providers",
+                "operationId": "list-chat-providers",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/codersdk.ChatProviderConfig"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "post": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Create chat provider",
+                "operationId": "create-chat-provider",
+                "parameters": [
+                    {
+                        "description": "Request body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.CreateChatProviderConfigRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatProviderConfig"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/providers/{providerConfig}": {
+            "delete": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Delete chat provider",
+                "operationId": "delete-chat-provider",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Provider config ID",
+                        "name": "providerConfig",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "patch": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Update chat provider",
+                "operationId": "update-chat-provider",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Provider config ID",
+                        "name": "providerConfig",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UpdateChatProviderConfigRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatProviderConfig"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/user-provider-configs": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "List user chat provider configs",
+                "operationId": "list-user-chat-provider-configs",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/codersdk.UserChatProviderConfig"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/user-provider-configs/{providerConfig}": {
+            "put": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Upsert user chat provider key",
+                "operationId": "upsert-user-chat-provider-key",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Provider config ID",
+                        "name": "providerConfig",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.CreateUserChatProviderKeyRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.UserChatProviderConfig"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            },
+            "delete": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Delete user chat provider key",
+                "operationId": "delete-user-chat-provider-key",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Provider config ID",
+                        "name": "providerConfig",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
                     }
                 },
                 "security": [
@@ -458,6 +1750,89 @@ const docTemplate = `{
                 "responses": {
                     "204": {
                         "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/{chat}/debug/runs": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat debug runs",
+                "operationId": "get-chat-debug-runs",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/codersdk.ChatDebugRunSummary"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/{chat}/debug/runs/{debugRun}": {
+            "get": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Get chat debug run",
+                "operationId": "get-chat-debug-run",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Debug run ID",
+                        "name": "debugRun",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ChatDebugRun"
+                        }
                     }
                 },
                 "security": [
@@ -694,6 +2069,80 @@ const docTemplate = `{
                 ]
             }
         },
+        "/api/experimental/chats/{chat}/queue/{queuedMessage}": {
+            "delete": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Delete chat queued message",
+                "operationId": "delete-chat-queued-message",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Queued message ID",
+                        "name": "queuedMessage",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/{chat}/queue/{queuedMessage}/promote": {
+            "post": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Promote chat queued message",
+                "operationId": "promote-chat-queued-message",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Queued message ID",
+                        "name": "queuedMessage",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
         "/api/experimental/chats/{chat}/stream": {
             "get": {
                 "description": "Experimental: this endpoint is subject to change.",
@@ -799,6 +2248,42 @@ const docTemplate = `{
                 ]
             }
         },
+        "/api/experimental/chats/{chat}/title/propose": {
+            "post": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Propose chat title",
+                "operationId": "propose-chat-title",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.ProposeChatTitleResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
         "/api/experimental/chats/{chat}/title/regenerate": {
             "post": {
                 "description": "Experimental: this endpoint is subject to change.",
@@ -826,6 +2311,48 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/codersdk.Chat"
                         }
+                    }
+                },
+                "security": [
+                    {
+                        "CoderSessionToken": []
+                    }
+                ]
+            }
+        },
+        "/api/experimental/chats/{chat}/tool-results": {
+            "post": {
+                "description": "Experimental: this endpoint is subject to change.",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chats"
+                ],
+                "summary": "Submit chat tool results",
+                "operationId": "submit-chat-tool-results",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Chat ID",
+                        "name": "chat",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.SubmitToolResultsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
                     }
                 },
                 "security": [
@@ -14900,6 +16427,28 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.AdvisorConfig": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "description": "Enabled toggles the advisor runtime. When false, advisor is not\nattached to new chats.",
+                    "type": "boolean"
+                },
+                "max_output_tokens": {
+                    "description": "MaxOutputTokens caps the advisor model response tokens. 0 means\nuse the runtime default.",
+                    "type": "integer"
+                },
+                "max_uses_per_run": {
+                    "description": "MaxUsesPerRun caps how many times the advisor can be invoked per\nchat run. 0 means unlimited.",
+                    "type": "integer"
+                },
+                "model_config_id": {
+                    "description": "ModelConfigID selects a specific chat model config to power the\nadvisor. uuid.Nil means reuse the outer chat model. The runtime\nmust fall back to the outer chat model when this ID cannot be\nresolved (e.g. the referenced model config was soft-deleted or\nits provider was disabled after the admin saved this config).",
+                    "type": "string",
+                    "format": "uuid"
+                }
+            }
+        },
         "codersdk.AgentConnectionTiming": {
             "type": "object",
             "properties": {
@@ -15564,6 +17113,14 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.ChatAutoArchiveDaysResponse": {
+            "type": "object",
+            "properties": {
+                "auto_archive_days": {
+                    "type": "integer"
+                }
+            }
+        },
         "codersdk.ChatBusyBehavior": {
             "type": "string",
             "enum": [
@@ -15586,6 +17143,14 @@ const docTemplate = `{
                 "ChatClientTypeAPI"
             ]
         },
+        "codersdk.ChatComputerUseProviderResponse": {
+            "type": "object",
+            "properties": {
+                "provider": {
+                    "type": "string"
+                }
+            }
+        },
         "codersdk.ChatConfig": {
             "type": "object",
             "properties": {
@@ -15593,6 +17158,251 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "debug_logging_enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "codersdk.ChatDebugLoggingAdminSettings": {
+            "type": "object",
+            "properties": {
+                "allow_users": {
+                    "type": "boolean"
+                },
+                "forced_by_deployment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "codersdk.ChatDebugRetentionDaysResponse": {
+            "type": "object",
+            "properties": {
+                "debug_retention_days": {
+                    "type": "integer"
+                }
+            }
+        },
+        "codersdk.ChatDebugRun": {
+            "type": "object",
+            "properties": {
+                "chat_id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "finished_at": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "history_tip_message_id": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "kind": {
+                    "$ref": "#/definitions/codersdk.ChatDebugRunKind"
+                },
+                "model": {
+                    "type": "string"
+                },
+                "model_config_id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "parent_chat_id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "root_chat_id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "started_at": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "status": {
+                    "$ref": "#/definitions/codersdk.ChatDebugStatus"
+                },
+                "steps": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/codersdk.ChatDebugStep"
+                    }
+                },
+                "summary": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "trigger_message_id": {
+                    "type": "integer"
+                },
+                "updated_at": {
+                    "type": "string",
+                    "format": "date-time"
+                }
+            }
+        },
+        "codersdk.ChatDebugRunKind": {
+            "type": "string",
+            "enum": [
+                "chat_turn",
+                "title_generation",
+                "quickgen",
+                "compaction"
+            ],
+            "x-enum-varnames": [
+                "ChatDebugRunKindChatTurn",
+                "ChatDebugRunKindTitleGeneration",
+                "ChatDebugRunKindQuickgen",
+                "ChatDebugRunKindCompaction"
+            ]
+        },
+        "codersdk.ChatDebugRunSummary": {
+            "type": "object",
+            "properties": {
+                "chat_id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "finished_at": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "kind": {
+                    "$ref": "#/definitions/codersdk.ChatDebugRunKind"
+                },
+                "model": {
+                    "type": "string"
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "started_at": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "status": {
+                    "$ref": "#/definitions/codersdk.ChatDebugStatus"
+                },
+                "summary": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "updated_at": {
+                    "type": "string",
+                    "format": "date-time"
+                }
+            }
+        },
+        "codersdk.ChatDebugStatus": {
+            "type": "string",
+            "enum": [
+                "in_progress",
+                "completed",
+                "error",
+                "interrupted"
+            ],
+            "x-enum-varnames": [
+                "ChatDebugStatusInProgress",
+                "ChatDebugStatusCompleted",
+                "ChatDebugStatusError",
+                "ChatDebugStatusInterrupted"
+            ]
+        },
+        "codersdk.ChatDebugStep": {
+            "type": "object",
+            "properties": {
+                "assistant_message_id": {
+                    "type": "integer"
+                },
+                "attempts": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": {}
+                    }
+                },
+                "chat_id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "error": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "finished_at": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "history_tip_message_id": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "normalized_request": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "normalized_response": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "operation": {
+                    "$ref": "#/definitions/codersdk.ChatDebugStepOperation"
+                },
+                "run_id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "started_at": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "status": {
+                    "$ref": "#/definitions/codersdk.ChatDebugStatus"
+                },
+                "step_number": {
+                    "type": "integer"
+                },
+                "updated_at": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "usage": {
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            }
+        },
+        "codersdk.ChatDebugStepOperation": {
+            "type": "string",
+            "enum": [
+                "stream",
+                "generate"
+            ],
+            "x-enum-varnames": [
+                "ChatDebugStepOperationStream",
+                "ChatDebugStepOperationGenerate"
+            ]
+        },
+        "codersdk.ChatDesktopEnabledResponse": {
+            "type": "object",
+            "properties": {
+                "enable_desktop": {
                     "type": "boolean"
                 }
             }
@@ -16105,6 +17915,360 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.ChatModelAnthropicProviderOptions": {
+            "type": "object",
+            "properties": {
+                "allowed_domains": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "blocked_domains": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "disable_parallel_tool_use": {
+                    "type": "boolean"
+                },
+                "effort": {
+                    "type": "string"
+                },
+                "send_reasoning": {
+                    "type": "boolean"
+                },
+                "thinking": {
+                    "$ref": "#/definitions/codersdk.ChatModelAnthropicThinkingOptions"
+                },
+                "web_search_enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "codersdk.ChatModelAnthropicThinkingOptions": {
+            "type": "object",
+            "properties": {
+                "budget_tokens": {
+                    "type": "integer"
+                }
+            }
+        },
+        "codersdk.ChatModelCallConfig": {
+            "type": "object",
+            "properties": {
+                "cost": {
+                    "$ref": "#/definitions/codersdk.ModelCostConfig"
+                },
+                "frequency_penalty": {
+                    "type": "number"
+                },
+                "max_output_tokens": {
+                    "type": "integer"
+                },
+                "presence_penalty": {
+                    "type": "number"
+                },
+                "provider_options": {
+                    "$ref": "#/definitions/codersdk.ChatModelProviderOptions"
+                },
+                "temperature": {
+                    "type": "number"
+                },
+                "top_k": {
+                    "type": "integer"
+                },
+                "top_p": {
+                    "type": "number"
+                }
+            }
+        },
+        "codersdk.ChatModelConfig": {
+            "type": "object",
+            "properties": {
+                "compression_threshold": {
+                    "type": "integer"
+                },
+                "context_limit": {
+                    "type": "integer"
+                },
+                "created_at": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "is_default": {
+                    "type": "boolean"
+                },
+                "model": {
+                    "type": "string"
+                },
+                "model_config": {
+                    "$ref": "#/definitions/codersdk.ChatModelCallConfig"
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string",
+                    "format": "date-time"
+                }
+            }
+        },
+        "codersdk.ChatModelGoogleProviderOptions": {
+            "type": "object",
+            "properties": {
+                "cached_content": {
+                    "type": "string"
+                },
+                "safety_settings": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/codersdk.ChatModelGoogleSafetySetting"
+                    }
+                },
+                "thinking_config": {
+                    "$ref": "#/definitions/codersdk.ChatModelGoogleThinkingConfig"
+                },
+                "threshold": {
+                    "type": "string"
+                },
+                "web_search_enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "codersdk.ChatModelGoogleSafetySetting": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "type": "string"
+                },
+                "threshold": {
+                    "type": "string"
+                }
+            }
+        },
+        "codersdk.ChatModelGoogleThinkingConfig": {
+            "type": "object",
+            "properties": {
+                "include_thoughts": {
+                    "type": "boolean"
+                },
+                "thinking_budget": {
+                    "type": "integer"
+                }
+            }
+        },
+        "codersdk.ChatModelOpenAICompatProviderOptions": {
+            "type": "object",
+            "properties": {
+                "reasoning_effort": {
+                    "type": "string"
+                },
+                "user": {
+                    "type": "string"
+                }
+            }
+        },
+        "codersdk.ChatModelOpenAIProviderOptions": {
+            "type": "object",
+            "properties": {
+                "allowed_domains": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "include": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "instructions": {
+                    "type": "string"
+                },
+                "log_probs": {
+                    "type": "boolean"
+                },
+                "logit_bias": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                },
+                "max_completion_tokens": {
+                    "type": "integer"
+                },
+                "max_tool_calls": {
+                    "type": "integer"
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "parallel_tool_calls": {
+                    "type": "boolean"
+                },
+                "prediction": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "prompt_cache_key": {
+                    "type": "string"
+                },
+                "reasoning_effort": {
+                    "type": "string"
+                },
+                "reasoning_summary": {
+                    "type": "string"
+                },
+                "safety_identifier": {
+                    "type": "string"
+                },
+                "search_context_size": {
+                    "type": "string"
+                },
+                "service_tier": {
+                    "type": "string"
+                },
+                "store": {
+                    "type": "boolean"
+                },
+                "strict_json_schema": {
+                    "type": "boolean"
+                },
+                "structured_outputs": {
+                    "type": "boolean"
+                },
+                "text_verbosity": {
+                    "type": "string"
+                },
+                "top_log_probs": {
+                    "type": "integer"
+                },
+                "user": {
+                    "type": "string"
+                },
+                "web_search_enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "codersdk.ChatModelOpenRouterProvider": {
+            "type": "object",
+            "properties": {
+                "allow_fallbacks": {
+                    "type": "boolean"
+                },
+                "data_collection": {
+                    "type": "string"
+                },
+                "ignore": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "only": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "order": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "quantizations": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "require_parameters": {
+                    "type": "boolean"
+                },
+                "sort": {
+                    "type": "string"
+                }
+            }
+        },
+        "codersdk.ChatModelOpenRouterProviderOptions": {
+            "type": "object",
+            "properties": {
+                "extra_body": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "include_usage": {
+                    "type": "boolean"
+                },
+                "log_probs": {
+                    "type": "boolean"
+                },
+                "logit_bias": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                },
+                "parallel_tool_calls": {
+                    "type": "boolean"
+                },
+                "provider": {
+                    "$ref": "#/definitions/codersdk.ChatModelOpenRouterProvider"
+                },
+                "reasoning": {
+                    "$ref": "#/definitions/codersdk.ChatModelReasoningOptions"
+                },
+                "user": {
+                    "type": "string"
+                }
+            }
+        },
+        "codersdk.ChatModelOverrideContext": {
+            "type": "string",
+            "enum": [
+                "general",
+                "explore",
+                "title_generation"
+            ],
+            "x-enum-varnames": [
+                "ChatModelOverrideContextGeneral",
+                "ChatModelOverrideContextExplore",
+                "ChatModelOverrideContextTitleGeneration"
+            ]
+        },
+        "codersdk.ChatModelOverrideResponse": {
+            "type": "object",
+            "properties": {
+                "context": {
+                    "$ref": "#/definitions/codersdk.ChatModelOverrideContext"
+                },
+                "is_malformed": {
+                    "type": "boolean"
+                },
+                "model_config_id": {
+                    "type": "string"
+                }
+            }
+        },
         "codersdk.ChatModelProvider": {
             "type": "object",
             "properties": {
@@ -16125,6 +18289,29 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.ChatModelProviderOptions": {
+            "type": "object",
+            "properties": {
+                "anthropic": {
+                    "$ref": "#/definitions/codersdk.ChatModelAnthropicProviderOptions"
+                },
+                "google": {
+                    "$ref": "#/definitions/codersdk.ChatModelGoogleProviderOptions"
+                },
+                "openai": {
+                    "$ref": "#/definitions/codersdk.ChatModelOpenAIProviderOptions"
+                },
+                "openaicompat": {
+                    "$ref": "#/definitions/codersdk.ChatModelOpenAICompatProviderOptions"
+                },
+                "openrouter": {
+                    "$ref": "#/definitions/codersdk.ChatModelOpenRouterProviderOptions"
+                },
+                "vercel": {
+                    "$ref": "#/definitions/codersdk.ChatModelVercelProviderOptions"
+                }
+            }
+        },
         "codersdk.ChatModelProviderUnavailableReason": {
             "type": "string",
             "enum": [
@@ -16138,6 +18325,74 @@ const docTemplate = `{
                 "ChatModelProviderUnavailableReasonUserAPIKeyRequired"
             ]
         },
+        "codersdk.ChatModelReasoningOptions": {
+            "type": "object",
+            "properties": {
+                "effort": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "exclude": {
+                    "type": "boolean"
+                },
+                "max_tokens": {
+                    "type": "integer"
+                }
+            }
+        },
+        "codersdk.ChatModelVercelGatewayProviderOptions": {
+            "type": "object",
+            "properties": {
+                "models": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "order": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "codersdk.ChatModelVercelProviderOptions": {
+            "type": "object",
+            "properties": {
+                "extra_body": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "logit_bias": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                },
+                "logprobs": {
+                    "type": "boolean"
+                },
+                "parallel_tool_calls": {
+                    "type": "boolean"
+                },
+                "providerOptions": {
+                    "$ref": "#/definitions/codersdk.ChatModelVercelGatewayProviderOptions"
+                },
+                "reasoning": {
+                    "$ref": "#/definitions/codersdk.ChatModelReasoningOptions"
+                },
+                "top_logprobs": {
+                    "type": "integer"
+                },
+                "user": {
+                    "type": "string"
+                }
+            }
+        },
         "codersdk.ChatModelsResponse": {
             "type": "object",
             "properties": {
@@ -16149,6 +18404,71 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.ChatPersonalModelOverride": {
+            "type": "object",
+            "properties": {
+                "context": {
+                    "$ref": "#/definitions/codersdk.ChatPersonalModelOverrideContext"
+                },
+                "is_malformed": {
+                    "type": "boolean"
+                },
+                "is_set": {
+                    "type": "boolean"
+                },
+                "mode": {
+                    "$ref": "#/definitions/codersdk.ChatPersonalModelOverrideMode"
+                },
+                "model_config_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "codersdk.ChatPersonalModelOverrideContext": {
+            "type": "string",
+            "enum": [
+                "root",
+                "general",
+                "explore"
+            ],
+            "x-enum-varnames": [
+                "ChatPersonalModelOverrideContextRoot",
+                "ChatPersonalModelOverrideContextGeneral",
+                "ChatPersonalModelOverrideContextExplore"
+            ]
+        },
+        "codersdk.ChatPersonalModelOverrideDeploymentDefaults": {
+            "type": "object",
+            "properties": {
+                "explore": {
+                    "$ref": "#/definitions/codersdk.ChatModelOverrideResponse"
+                },
+                "general": {
+                    "$ref": "#/definitions/codersdk.ChatModelOverrideResponse"
+                }
+            }
+        },
+        "codersdk.ChatPersonalModelOverrideMode": {
+            "type": "string",
+            "enum": [
+                "deployment_default",
+                "chat_default",
+                "model"
+            ],
+            "x-enum-varnames": [
+                "ChatPersonalModelOverrideModeDeploymentDefault",
+                "ChatPersonalModelOverrideModeChatDefault",
+                "ChatPersonalModelOverrideModeModel"
+            ]
+        },
+        "codersdk.ChatPersonalModelOverridesAdminSettings": {
+            "type": "object",
+            "properties": {
+                "allow_users": {
+                    "type": "boolean"
+                }
+            }
+        },
         "codersdk.ChatPlanMode": {
             "type": "string",
             "enum": [
@@ -16156,6 +18476,71 @@ const docTemplate = `{
             ],
             "x-enum-varnames": [
                 "ChatPlanModePlan"
+            ]
+        },
+        "codersdk.ChatPlanModeInstructionsResponse": {
+            "type": "object",
+            "properties": {
+                "plan_mode_instructions": {
+                    "type": "string"
+                }
+            }
+        },
+        "codersdk.ChatProviderConfig": {
+            "type": "object",
+            "properties": {
+                "allow_central_api_key_fallback": {
+                    "type": "boolean"
+                },
+                "allow_user_api_key": {
+                    "type": "boolean"
+                },
+                "base_url": {
+                    "type": "string"
+                },
+                "central_api_key_enabled": {
+                    "type": "boolean"
+                },
+                "created_at": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "has_api_key": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "source": {
+                    "$ref": "#/definitions/codersdk.ChatProviderConfigSource"
+                },
+                "updated_at": {
+                    "type": "string",
+                    "format": "date-time"
+                }
+            }
+        },
+        "codersdk.ChatProviderConfigSource": {
+            "type": "string",
+            "enum": [
+                "database",
+                "env_preset",
+                "supported"
+            ],
+            "x-enum-varnames": [
+                "ChatProviderConfigSourceDatabase",
+                "ChatProviderConfigSourceEnvPreset",
+                "ChatProviderConfigSourceSupported"
             ]
         },
         "codersdk.ChatQueuedMessage": {
@@ -16352,6 +18737,31 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.ChatSystemPromptResponse": {
+            "type": "object",
+            "properties": {
+                "default_system_prompt": {
+                    "type": "string"
+                },
+                "include_default_system_prompt": {
+                    "type": "boolean"
+                },
+                "system_prompt": {
+                    "type": "string"
+                }
+            }
+        },
+        "codersdk.ChatTemplateAllowlist": {
+            "type": "object",
+            "properties": {
+                "template_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "codersdk.ChatWatchEvent": {
             "type": "object",
             "properties": {
@@ -16389,6 +18799,15 @@ const docTemplate = `{
                 "ChatWatchEventKindDiffStatusChange",
                 "ChatWatchEventKindActionRequired"
             ]
+        },
+        "codersdk.ChatWorkspaceTTLResponse": {
+            "type": "object",
+            "properties": {
+                "workspace_ttl_ms": {
+                    "description": "WorkspaceTTLMillis is the workspace TTL in milliseconds.\nZero means disabled, so the template's own autostop setting applies.",
+                    "type": "integer"
+                }
+            }
         },
         "codersdk.ConnectionLatency": {
             "type": "object",
@@ -16617,6 +19036,64 @@ const docTemplate = `{
                     "items": {
                         "type": "string"
                     }
+                }
+            }
+        },
+        "codersdk.CreateChatModelConfigRequest": {
+            "type": "object",
+            "properties": {
+                "compression_threshold": {
+                    "type": "integer"
+                },
+                "context_limit": {
+                    "type": "integer"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "is_default": {
+                    "type": "boolean"
+                },
+                "model": {
+                    "type": "string"
+                },
+                "model_config": {
+                    "$ref": "#/definitions/codersdk.ChatModelCallConfig"
+                },
+                "provider": {
+                    "type": "string"
+                }
+            }
+        },
+        "codersdk.CreateChatProviderConfigRequest": {
+            "type": "object",
+            "properties": {
+                "allow_central_api_key_fallback": {
+                    "type": "boolean"
+                },
+                "allow_user_api_key": {
+                    "type": "boolean"
+                },
+                "api_key": {
+                    "type": "string"
+                },
+                "base_url": {
+                    "type": "string"
+                },
+                "central_api_key_enabled": {
+                    "type": "boolean"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "provider": {
+                    "type": "string"
                 }
             }
         },
@@ -17102,6 +19579,14 @@ const docTemplate = `{
                     }
                 },
                 "token_name": {
+                    "type": "string"
+                }
+            }
+        },
+        "codersdk.CreateUserChatProviderKeyRequest": {
+            "type": "object",
+            "properties": {
+                "api_key": {
                     "type": "string"
                 }
             }
@@ -18909,6 +21394,23 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.ModelCostConfig": {
+            "type": "object",
+            "properties": {
+                "cache_read_price_per_million_tokens": {
+                    "type": "number"
+                },
+                "cache_write_price_per_million_tokens": {
+                    "type": "number"
+                },
+                "input_price_per_million_tokens": {
+                    "type": "number"
+                },
+                "output_price_per_million_tokens": {
+                    "type": "number"
+                }
+            }
+        },
         "codersdk.NotificationMethodsResponse": {
             "type": "object",
             "properties": {
@@ -20686,6 +23188,14 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.ProposeChatTitleResponse": {
+            "type": "object",
+            "properties": {
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
         "codersdk.ProvisionerConfig": {
             "type": "object",
             "properties": {
@@ -21890,6 +24400,17 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.SubmitToolResultsRequest": {
+            "type": "object",
+            "properties": {
+                "results": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/codersdk.ToolResult"
+                    }
+                }
+            }
+        },
         "codersdk.SupportConfig": {
             "type": "object",
             "properties": {
@@ -23080,6 +25601,23 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.ToolResult": {
+            "type": "object",
+            "properties": {
+                "is_error": {
+                    "type": "boolean"
+                },
+                "output": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "tool_call_id": {
+                    "type": "string"
+                }
+            }
+        },
         "codersdk.TraceConfig": {
             "type": "object",
             "properties": {
@@ -23122,6 +25660,28 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.UpdateAdvisorConfigRequest": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "description": "Enabled toggles the advisor runtime. When false, advisor is not\nattached to new chats.",
+                    "type": "boolean"
+                },
+                "max_output_tokens": {
+                    "description": "MaxOutputTokens caps the advisor model response tokens. 0 means\nuse the runtime default.",
+                    "type": "integer"
+                },
+                "max_uses_per_run": {
+                    "description": "MaxUsesPerRun caps how many times the advisor can be invoked per\nchat run. 0 means unlimited.",
+                    "type": "integer"
+                },
+                "model_config_id": {
+                    "description": "ModelConfigID selects a specific chat model config to power the\nadvisor. uuid.Nil means reuse the outer chat model. The runtime\nmust fall back to the outer chat model when this ID cannot be\nresolved (e.g. the referenced model config was soft-deleted or\nits provider was disabled after the admin saved this config).",
+                    "type": "string",
+                    "format": "uuid"
+                }
+            }
+        },
         "codersdk.UpdateAppearanceConfig": {
             "type": "object",
             "properties": {
@@ -23144,6 +25704,125 @@ const docTemplate = `{
                             "$ref": "#/definitions/codersdk.BannerConfig"
                         }
                     ]
+                }
+            }
+        },
+        "codersdk.UpdateChatAutoArchiveDaysRequest": {
+            "type": "object",
+            "properties": {
+                "auto_archive_days": {
+                    "type": "integer"
+                }
+            }
+        },
+        "codersdk.UpdateChatComputerUseProviderRequest": {
+            "type": "object",
+            "properties": {
+                "provider": {
+                    "type": "string"
+                }
+            }
+        },
+        "codersdk.UpdateChatDebugLoggingAllowUsersRequest": {
+            "type": "object",
+            "properties": {
+                "allow_users": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "codersdk.UpdateChatDebugRetentionDaysRequest": {
+            "type": "object",
+            "properties": {
+                "debug_retention_days": {
+                    "type": "integer"
+                }
+            }
+        },
+        "codersdk.UpdateChatDesktopEnabledRequest": {
+            "type": "object",
+            "properties": {
+                "enable_desktop": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "codersdk.UpdateChatModelConfigRequest": {
+            "type": "object",
+            "properties": {
+                "compression_threshold": {
+                    "type": "integer"
+                },
+                "context_limit": {
+                    "type": "integer"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "is_default": {
+                    "type": "boolean"
+                },
+                "model": {
+                    "type": "string"
+                },
+                "model_config": {
+                    "$ref": "#/definitions/codersdk.ChatModelCallConfig"
+                },
+                "provider": {
+                    "type": "string"
+                }
+            }
+        },
+        "codersdk.UpdateChatModelOverrideRequest": {
+            "type": "object",
+            "properties": {
+                "model_config_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "codersdk.UpdateChatPersonalModelOverridesAdminSettingsRequest": {
+            "type": "object",
+            "properties": {
+                "allow_users": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "codersdk.UpdateChatPlanModeInstructionsRequest": {
+            "type": "object",
+            "properties": {
+                "plan_mode_instructions": {
+                    "type": "string"
+                }
+            }
+        },
+        "codersdk.UpdateChatProviderConfigRequest": {
+            "type": "object",
+            "properties": {
+                "allow_central_api_key_fallback": {
+                    "type": "boolean"
+                },
+                "allow_user_api_key": {
+                    "type": "boolean"
+                },
+                "api_key": {
+                    "type": "string"
+                },
+                "base_url": {
+                    "type": "string"
+                },
+                "central_api_key_enabled": {
+                    "type": "boolean"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
                 }
             }
         },
@@ -23184,6 +25863,26 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "retention_days": {
+                    "type": "integer"
+                }
+            }
+        },
+        "codersdk.UpdateChatSystemPromptRequest": {
+            "type": "object",
+            "properties": {
+                "include_default_system_prompt": {
+                    "type": "boolean"
+                },
+                "system_prompt": {
+                    "type": "string"
+                }
+            }
+        },
+        "codersdk.UpdateChatWorkspaceTTLRequest": {
+            "type": "object",
+            "properties": {
+                "workspace_ttl_ms": {
+                    "description": "WorkspaceTTLMillis is the workspace TTL in milliseconds.\nZero means disabled, so the template's own autostop setting applies.",
                     "type": "integer"
                 }
             }
@@ -23366,6 +26065,25 @@ const docTemplate = `{
                     "$ref": "#/definitions/codersdk.TerminalFontName"
                 },
                 "theme_preference": {
+                    "type": "string"
+                }
+            }
+        },
+        "codersdk.UpdateUserChatDebugLoggingRequest": {
+            "type": "object",
+            "properties": {
+                "debug_logging_enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "codersdk.UpdateUserChatPersonalModelOverrideRequest": {
+            "type": "object",
+            "properties": {
+                "mode": {
+                    "$ref": "#/definitions/codersdk.ChatPersonalModelOverrideMode"
+                },
+                "model_config_id": {
                     "type": "string"
                 }
             }
@@ -23786,6 +26504,69 @@ const docTemplate = `{
                 },
                 "theme_preference": {
                     "type": "string"
+                }
+            }
+        },
+        "codersdk.UserChatCustomPrompt": {
+            "type": "object",
+            "properties": {
+                "custom_prompt": {
+                    "type": "string"
+                }
+            }
+        },
+        "codersdk.UserChatDebugLoggingSettings": {
+            "type": "object",
+            "properties": {
+                "debug_logging_enabled": {
+                    "type": "boolean"
+                },
+                "forced_by_deployment": {
+                    "type": "boolean"
+                },
+                "user_toggle_allowed": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "codersdk.UserChatPersonalModelOverridesResponse": {
+            "type": "object",
+            "properties": {
+                "deployment_defaults": {
+                    "$ref": "#/definitions/codersdk.ChatPersonalModelOverrideDeploymentDefaults"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "explore": {
+                    "$ref": "#/definitions/codersdk.ChatPersonalModelOverride"
+                },
+                "general": {
+                    "$ref": "#/definitions/codersdk.ChatPersonalModelOverride"
+                },
+                "root": {
+                    "$ref": "#/definitions/codersdk.ChatPersonalModelOverride"
+                }
+            }
+        },
+        "codersdk.UserChatProviderConfig": {
+            "type": "object",
+            "properties": {
+                "display_name": {
+                    "type": "string"
+                },
+                "has_central_api_key_fallback": {
+                    "type": "boolean"
+                },
+                "has_user_api_key": {
+                    "type": "boolean"
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "provider_id": {
+                    "type": "string",
+                    "format": "uuid"
                 }
             }
         },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -120,6 +120,472 @@
 				]
 			}
 		},
+		"/api/experimental/chats/config/advisor": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get chat advisor config",
+				"operationId": "get-chat-advisor-config",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.AdvisorConfig"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"put": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"consumes": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update chat advisor config",
+				"operationId": "update-chat-advisor-config",
+				"parameters": [
+					{
+						"description": "Request body",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateAdvisorConfigRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/config/auto-archive-days": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get chat auto archive days",
+				"operationId": "get-chat-auto-archive-days",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatAutoArchiveDaysResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"put": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"consumes": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update chat auto archive days",
+				"operationId": "update-chat-auto-archive-days",
+				"parameters": [
+					{
+						"description": "Request body",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateChatAutoArchiveDaysRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/config/computer-use-provider": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get chat computer use provider",
+				"operationId": "get-chat-computer-use-provider",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatComputerUseProviderResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"put": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"consumes": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update chat computer use provider",
+				"operationId": "update-chat-computer-use-provider",
+				"parameters": [
+					{
+						"description": "Request body",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateChatComputerUseProviderRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/config/debug-logging": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get chat debug logging",
+				"operationId": "get-chat-debug-logging",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatDebugLoggingAdminSettings"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"put": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"consumes": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update chat debug logging",
+				"operationId": "update-chat-debug-logging",
+				"parameters": [
+					{
+						"description": "Request body",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateChatDebugLoggingAllowUsersRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/config/debug-retention-days": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get chat debug retention days",
+				"operationId": "get-chat-debug-retention-days",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatDebugRetentionDaysResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"put": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"consumes": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update chat debug retention days",
+				"operationId": "update-chat-debug-retention-days",
+				"parameters": [
+					{
+						"description": "Request body",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateChatDebugRetentionDaysRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/config/desktop-enabled": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get chat desktop enabled",
+				"operationId": "get-chat-desktop-enabled",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatDesktopEnabledResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"put": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"consumes": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update chat desktop enabled",
+				"operationId": "update-chat-desktop-enabled",
+				"parameters": [
+					{
+						"description": "Request body",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateChatDesktopEnabledRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/config/model-override/{context}": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get chat model override",
+				"operationId": "get-chat-model-override",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Override context",
+						"name": "context",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatModelOverrideResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"put": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"consumes": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update chat model override",
+				"operationId": "update-chat-model-override",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Override context",
+						"name": "context",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Request body",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateChatModelOverrideRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/config/personal-model-overrides": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get chat personal model overrides admin settings",
+				"operationId": "get-chat-personal-model-overrides-admin-settings",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatPersonalModelOverridesAdminSettings"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"put": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"consumes": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update chat personal model overrides admin settings",
+				"operationId": "update-chat-personal-model-overrides-admin-settings",
+				"parameters": [
+					{
+						"description": "Request body",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateChatPersonalModelOverridesAdminSettingsRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/config/plan-mode-instructions": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get chat plan mode instructions",
+				"operationId": "get-chat-plan-mode-instructions",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatPlanModeInstructionsResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"put": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"consumes": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update chat plan mode instructions",
+				"operationId": "update-chat-plan-mode-instructions",
+				"parameters": [
+					{
+						"description": "Request body",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateChatPlanModeInstructionsRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
 		"/api/experimental/chats/config/retention-days": {
 			"get": {
 				"produces": ["application/json"],
@@ -172,6 +638,319 @@
 				"x-apidocgen": {
 					"skip": true
 				}
+			}
+		},
+		"/api/experimental/chats/config/system-prompt": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get chat system prompt",
+				"operationId": "get-chat-system-prompt",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatSystemPromptResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"put": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"consumes": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update chat system prompt",
+				"operationId": "update-chat-system-prompt",
+				"parameters": [
+					{
+						"description": "Request body",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateChatSystemPromptRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/config/template-allowlist": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get chat template allowlist",
+				"operationId": "get-chat-template-allowlist",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatTemplateAllowlist"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"put": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"consumes": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update chat template allowlist",
+				"operationId": "update-chat-template-allowlist",
+				"parameters": [
+					{
+						"description": "Request body",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatTemplateAllowlist"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/config/user-debug-logging": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get user chat debug logging",
+				"operationId": "get-user-chat-debug-logging",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.UserChatDebugLoggingSettings"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"put": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"consumes": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update user chat debug logging",
+				"operationId": "update-user-chat-debug-logging",
+				"parameters": [
+					{
+						"description": "Request body",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateUserChatDebugLoggingRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/config/user-personal-model-overrides": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get user chat personal model overrides",
+				"operationId": "get-user-chat-personal-model-overrides",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.UserChatPersonalModelOverridesResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/config/user-personal-model-overrides/{context}": {
+			"put": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"consumes": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update user chat personal model override",
+				"operationId": "update-user-chat-personal-model-override",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "Override context",
+						"name": "context",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Request body",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateUserChatPersonalModelOverrideRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/config/user-prompt": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get user chat custom prompt",
+				"operationId": "get-user-chat-custom-prompt",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.UserChatCustomPrompt"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"put": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update user chat custom prompt",
+				"operationId": "update-user-chat-custom-prompt",
+				"parameters": [
+					{
+						"description": "Request body",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UserChatCustomPrompt"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.UserChatCustomPrompt"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/config/workspace-ttl": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get chat workspace TTL",
+				"operationId": "get-chat-workspace-ttl",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatWorkspaceTTLResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"put": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"consumes": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update chat workspace TTL",
+				"operationId": "update-chat-workspace-ttl",
+				"parameters": [
+					{
+						"description": "Request body",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateChatWorkspaceTTLRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
 			}
 		},
 		"/api/experimental/chats/files": {
@@ -296,6 +1075,131 @@
 				}
 			}
 		},
+		"/api/experimental/chats/model-configs": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "List chat model configs",
+				"operationId": "list-chat-model-configs",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"type": "array",
+							"items": {
+								"$ref": "#/definitions/codersdk.ChatModelConfig"
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"post": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Create chat model config",
+				"operationId": "create-chat-model-config",
+				"parameters": [
+					{
+						"description": "Request body",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.CreateChatModelConfigRequest"
+						}
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "Created",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatModelConfig"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/model-configs/{modelConfig}": {
+			"delete": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"tags": ["Chats"],
+				"summary": "Delete chat model config",
+				"operationId": "delete-chat-model-config",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Model config ID",
+						"name": "modelConfig",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"patch": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update chat model config",
+				"operationId": "update-chat-model-config",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Model config ID",
+						"name": "modelConfig",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Request body",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateChatModelConfigRequest"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatModelConfig"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
 		"/api/experimental/chats/models": {
 			"get": {
 				"description": "Experimental: this endpoint is subject to change.",
@@ -309,6 +1213,224 @@
 						"schema": {
 							"$ref": "#/definitions/codersdk.ChatModelsResponse"
 						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/providers": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "List chat providers",
+				"operationId": "list-chat-providers",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"type": "array",
+							"items": {
+								"$ref": "#/definitions/codersdk.ChatProviderConfig"
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"post": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Create chat provider",
+				"operationId": "create-chat-provider",
+				"parameters": [
+					{
+						"description": "Request body",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.CreateChatProviderConfigRequest"
+						}
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "Created",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatProviderConfig"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/providers/{providerConfig}": {
+			"delete": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"tags": ["Chats"],
+				"summary": "Delete chat provider",
+				"operationId": "delete-chat-provider",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Provider config ID",
+						"name": "providerConfig",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"patch": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Update chat provider",
+				"operationId": "update-chat-provider",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Provider config ID",
+						"name": "providerConfig",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Request body",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.UpdateChatProviderConfigRequest"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatProviderConfig"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/user-provider-configs": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "List user chat provider configs",
+				"operationId": "list-user-chat-provider-configs",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"type": "array",
+							"items": {
+								"$ref": "#/definitions/codersdk.UserChatProviderConfig"
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/user-provider-configs/{providerConfig}": {
+			"put": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"consumes": ["application/json"],
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Upsert user chat provider key",
+				"operationId": "upsert-user-chat-provider-key",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Provider config ID",
+						"name": "providerConfig",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Request body",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.CreateUserChatProviderKeyRequest"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.UserChatProviderConfig"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			},
+			"delete": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"tags": ["Chats"],
+				"summary": "Delete user chat provider key",
+				"operationId": "delete-user-chat-provider-key",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Provider config ID",
+						"name": "providerConfig",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
 					}
 				},
 				"security": [
@@ -399,6 +1521,81 @@
 				"responses": {
 					"204": {
 						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/{chat}/debug/runs": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get chat debug runs",
+				"operationId": "get-chat-debug-runs",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"type": "array",
+							"items": {
+								"$ref": "#/definitions/codersdk.ChatDebugRunSummary"
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/{chat}/debug/runs/{debugRun}": {
+			"get": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Get chat debug run",
+				"operationId": "get-chat-debug-run",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Debug run ID",
+						"name": "debugRun",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ChatDebugRun"
+						}
 					}
 				},
 				"security": [
@@ -611,6 +1808,76 @@
 				]
 			}
 		},
+		"/api/experimental/chats/{chat}/queue/{queuedMessage}": {
+			"delete": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"tags": ["Chats"],
+				"summary": "Delete chat queued message",
+				"operationId": "delete-chat-queued-message",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "integer",
+						"description": "Queued message ID",
+						"name": "queuedMessage",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/{chat}/queue/{queuedMessage}/promote": {
+			"post": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"tags": ["Chats"],
+				"summary": "Promote chat queued message",
+				"operationId": "promote-chat-queued-message",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "integer",
+						"description": "Queued message ID",
+						"name": "queuedMessage",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
 		"/api/experimental/chats/{chat}/stream": {
 			"get": {
 				"description": "Experimental: this endpoint is subject to change.",
@@ -704,6 +1971,38 @@
 				]
 			}
 		},
+		"/api/experimental/chats/{chat}/title/propose": {
+			"post": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"produces": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Propose chat title",
+				"operationId": "propose-chat-title",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/codersdk.ProposeChatTitleResponse"
+						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
 		"/api/experimental/chats/{chat}/title/regenerate": {
 			"post": {
 				"description": "Experimental: this endpoint is subject to change.",
@@ -727,6 +2026,44 @@
 						"schema": {
 							"$ref": "#/definitions/codersdk.Chat"
 						}
+					}
+				},
+				"security": [
+					{
+						"CoderSessionToken": []
+					}
+				]
+			}
+		},
+		"/api/experimental/chats/{chat}/tool-results": {
+			"post": {
+				"description": "Experimental: this endpoint is subject to change.",
+				"consumes": ["application/json"],
+				"tags": ["Chats"],
+				"summary": "Submit chat tool results",
+				"operationId": "submit-chat-tool-results",
+				"parameters": [
+					{
+						"type": "string",
+						"format": "uuid",
+						"description": "Chat ID",
+						"name": "chat",
+						"in": "path",
+						"required": true
+					},
+					{
+						"description": "Request body",
+						"name": "request",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/codersdk.SubmitToolResultsRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "No Content"
 					}
 				},
 				"security": [
@@ -13366,6 +14703,28 @@
 				}
 			}
 		},
+		"codersdk.AdvisorConfig": {
+			"type": "object",
+			"properties": {
+				"enabled": {
+					"description": "Enabled toggles the advisor runtime. When false, advisor is not\nattached to new chats.",
+					"type": "boolean"
+				},
+				"max_output_tokens": {
+					"description": "MaxOutputTokens caps the advisor model response tokens. 0 means\nuse the runtime default.",
+					"type": "integer"
+				},
+				"max_uses_per_run": {
+					"description": "MaxUsesPerRun caps how many times the advisor can be invoked per\nchat run. 0 means unlimited.",
+					"type": "integer"
+				},
+				"model_config_id": {
+					"description": "ModelConfigID selects a specific chat model config to power the\nadvisor. uuid.Nil means reuse the outer chat model. The runtime\nmust fall back to the outer chat model when this ID cannot be\nresolved (e.g. the referenced model config was soft-deleted or\nits provider was disabled after the admin saved this config).",
+					"type": "string",
+					"format": "uuid"
+				}
+			}
+		},
 		"codersdk.AgentConnectionTiming": {
 			"type": "object",
 			"properties": {
@@ -14001,6 +15360,14 @@
 				}
 			}
 		},
+		"codersdk.ChatAutoArchiveDaysResponse": {
+			"type": "object",
+			"properties": {
+				"auto_archive_days": {
+					"type": "integer"
+				}
+			}
+		},
 		"codersdk.ChatBusyBehavior": {
 			"type": "string",
 			"enum": ["queue", "interrupt"],
@@ -14011,6 +15378,14 @@
 			"enum": ["ui", "api"],
 			"x-enum-varnames": ["ChatClientTypeUI", "ChatClientTypeAPI"]
 		},
+		"codersdk.ChatComputerUseProviderResponse": {
+			"type": "object",
+			"properties": {
+				"provider": {
+					"type": "string"
+				}
+			}
+		},
 		"codersdk.ChatConfig": {
 			"type": "object",
 			"properties": {
@@ -14018,6 +15393,238 @@
 					"type": "integer"
 				},
 				"debug_logging_enabled": {
+					"type": "boolean"
+				}
+			}
+		},
+		"codersdk.ChatDebugLoggingAdminSettings": {
+			"type": "object",
+			"properties": {
+				"allow_users": {
+					"type": "boolean"
+				},
+				"forced_by_deployment": {
+					"type": "boolean"
+				}
+			}
+		},
+		"codersdk.ChatDebugRetentionDaysResponse": {
+			"type": "object",
+			"properties": {
+				"debug_retention_days": {
+					"type": "integer"
+				}
+			}
+		},
+		"codersdk.ChatDebugRun": {
+			"type": "object",
+			"properties": {
+				"chat_id": {
+					"type": "string",
+					"format": "uuid"
+				},
+				"finished_at": {
+					"type": "string",
+					"format": "date-time"
+				},
+				"history_tip_message_id": {
+					"type": "integer"
+				},
+				"id": {
+					"type": "string",
+					"format": "uuid"
+				},
+				"kind": {
+					"$ref": "#/definitions/codersdk.ChatDebugRunKind"
+				},
+				"model": {
+					"type": "string"
+				},
+				"model_config_id": {
+					"type": "string",
+					"format": "uuid"
+				},
+				"parent_chat_id": {
+					"type": "string",
+					"format": "uuid"
+				},
+				"provider": {
+					"type": "string"
+				},
+				"root_chat_id": {
+					"type": "string",
+					"format": "uuid"
+				},
+				"started_at": {
+					"type": "string",
+					"format": "date-time"
+				},
+				"status": {
+					"$ref": "#/definitions/codersdk.ChatDebugStatus"
+				},
+				"steps": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/codersdk.ChatDebugStep"
+					}
+				},
+				"summary": {
+					"type": "object",
+					"additionalProperties": {}
+				},
+				"trigger_message_id": {
+					"type": "integer"
+				},
+				"updated_at": {
+					"type": "string",
+					"format": "date-time"
+				}
+			}
+		},
+		"codersdk.ChatDebugRunKind": {
+			"type": "string",
+			"enum": ["chat_turn", "title_generation", "quickgen", "compaction"],
+			"x-enum-varnames": [
+				"ChatDebugRunKindChatTurn",
+				"ChatDebugRunKindTitleGeneration",
+				"ChatDebugRunKindQuickgen",
+				"ChatDebugRunKindCompaction"
+			]
+		},
+		"codersdk.ChatDebugRunSummary": {
+			"type": "object",
+			"properties": {
+				"chat_id": {
+					"type": "string",
+					"format": "uuid"
+				},
+				"finished_at": {
+					"type": "string",
+					"format": "date-time"
+				},
+				"id": {
+					"type": "string",
+					"format": "uuid"
+				},
+				"kind": {
+					"$ref": "#/definitions/codersdk.ChatDebugRunKind"
+				},
+				"model": {
+					"type": "string"
+				},
+				"provider": {
+					"type": "string"
+				},
+				"started_at": {
+					"type": "string",
+					"format": "date-time"
+				},
+				"status": {
+					"$ref": "#/definitions/codersdk.ChatDebugStatus"
+				},
+				"summary": {
+					"type": "object",
+					"additionalProperties": {}
+				},
+				"updated_at": {
+					"type": "string",
+					"format": "date-time"
+				}
+			}
+		},
+		"codersdk.ChatDebugStatus": {
+			"type": "string",
+			"enum": ["in_progress", "completed", "error", "interrupted"],
+			"x-enum-varnames": [
+				"ChatDebugStatusInProgress",
+				"ChatDebugStatusCompleted",
+				"ChatDebugStatusError",
+				"ChatDebugStatusInterrupted"
+			]
+		},
+		"codersdk.ChatDebugStep": {
+			"type": "object",
+			"properties": {
+				"assistant_message_id": {
+					"type": "integer"
+				},
+				"attempts": {
+					"type": "array",
+					"items": {
+						"type": "object",
+						"additionalProperties": {}
+					}
+				},
+				"chat_id": {
+					"type": "string",
+					"format": "uuid"
+				},
+				"error": {
+					"type": "object",
+					"additionalProperties": {}
+				},
+				"finished_at": {
+					"type": "string",
+					"format": "date-time"
+				},
+				"history_tip_message_id": {
+					"type": "integer"
+				},
+				"id": {
+					"type": "string",
+					"format": "uuid"
+				},
+				"metadata": {
+					"type": "object",
+					"additionalProperties": {}
+				},
+				"normalized_request": {
+					"type": "object",
+					"additionalProperties": {}
+				},
+				"normalized_response": {
+					"type": "object",
+					"additionalProperties": {}
+				},
+				"operation": {
+					"$ref": "#/definitions/codersdk.ChatDebugStepOperation"
+				},
+				"run_id": {
+					"type": "string",
+					"format": "uuid"
+				},
+				"started_at": {
+					"type": "string",
+					"format": "date-time"
+				},
+				"status": {
+					"$ref": "#/definitions/codersdk.ChatDebugStatus"
+				},
+				"step_number": {
+					"type": "integer"
+				},
+				"updated_at": {
+					"type": "string",
+					"format": "date-time"
+				},
+				"usage": {
+					"type": "object",
+					"additionalProperties": {}
+				}
+			}
+		},
+		"codersdk.ChatDebugStepOperation": {
+			"type": "string",
+			"enum": ["stream", "generate"],
+			"x-enum-varnames": [
+				"ChatDebugStepOperationStream",
+				"ChatDebugStepOperationGenerate"
+			]
+		},
+		"codersdk.ChatDesktopEnabledResponse": {
+			"type": "object",
+			"properties": {
+				"enable_desktop": {
 					"type": "boolean"
 				}
 			}
@@ -14521,6 +16128,356 @@
 				}
 			}
 		},
+		"codersdk.ChatModelAnthropicProviderOptions": {
+			"type": "object",
+			"properties": {
+				"allowed_domains": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"blocked_domains": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"disable_parallel_tool_use": {
+					"type": "boolean"
+				},
+				"effort": {
+					"type": "string"
+				},
+				"send_reasoning": {
+					"type": "boolean"
+				},
+				"thinking": {
+					"$ref": "#/definitions/codersdk.ChatModelAnthropicThinkingOptions"
+				},
+				"web_search_enabled": {
+					"type": "boolean"
+				}
+			}
+		},
+		"codersdk.ChatModelAnthropicThinkingOptions": {
+			"type": "object",
+			"properties": {
+				"budget_tokens": {
+					"type": "integer"
+				}
+			}
+		},
+		"codersdk.ChatModelCallConfig": {
+			"type": "object",
+			"properties": {
+				"cost": {
+					"$ref": "#/definitions/codersdk.ModelCostConfig"
+				},
+				"frequency_penalty": {
+					"type": "number"
+				},
+				"max_output_tokens": {
+					"type": "integer"
+				},
+				"presence_penalty": {
+					"type": "number"
+				},
+				"provider_options": {
+					"$ref": "#/definitions/codersdk.ChatModelProviderOptions"
+				},
+				"temperature": {
+					"type": "number"
+				},
+				"top_k": {
+					"type": "integer"
+				},
+				"top_p": {
+					"type": "number"
+				}
+			}
+		},
+		"codersdk.ChatModelConfig": {
+			"type": "object",
+			"properties": {
+				"compression_threshold": {
+					"type": "integer"
+				},
+				"context_limit": {
+					"type": "integer"
+				},
+				"created_at": {
+					"type": "string",
+					"format": "date-time"
+				},
+				"display_name": {
+					"type": "string"
+				},
+				"enabled": {
+					"type": "boolean"
+				},
+				"id": {
+					"type": "string",
+					"format": "uuid"
+				},
+				"is_default": {
+					"type": "boolean"
+				},
+				"model": {
+					"type": "string"
+				},
+				"model_config": {
+					"$ref": "#/definitions/codersdk.ChatModelCallConfig"
+				},
+				"provider": {
+					"type": "string"
+				},
+				"updated_at": {
+					"type": "string",
+					"format": "date-time"
+				}
+			}
+		},
+		"codersdk.ChatModelGoogleProviderOptions": {
+			"type": "object",
+			"properties": {
+				"cached_content": {
+					"type": "string"
+				},
+				"safety_settings": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/codersdk.ChatModelGoogleSafetySetting"
+					}
+				},
+				"thinking_config": {
+					"$ref": "#/definitions/codersdk.ChatModelGoogleThinkingConfig"
+				},
+				"threshold": {
+					"type": "string"
+				},
+				"web_search_enabled": {
+					"type": "boolean"
+				}
+			}
+		},
+		"codersdk.ChatModelGoogleSafetySetting": {
+			"type": "object",
+			"properties": {
+				"category": {
+					"type": "string"
+				},
+				"threshold": {
+					"type": "string"
+				}
+			}
+		},
+		"codersdk.ChatModelGoogleThinkingConfig": {
+			"type": "object",
+			"properties": {
+				"include_thoughts": {
+					"type": "boolean"
+				},
+				"thinking_budget": {
+					"type": "integer"
+				}
+			}
+		},
+		"codersdk.ChatModelOpenAICompatProviderOptions": {
+			"type": "object",
+			"properties": {
+				"reasoning_effort": {
+					"type": "string"
+				},
+				"user": {
+					"type": "string"
+				}
+			}
+		},
+		"codersdk.ChatModelOpenAIProviderOptions": {
+			"type": "object",
+			"properties": {
+				"allowed_domains": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"include": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"instructions": {
+					"type": "string"
+				},
+				"log_probs": {
+					"type": "boolean"
+				},
+				"logit_bias": {
+					"type": "object",
+					"additionalProperties": {
+						"type": "integer",
+						"format": "int64"
+					}
+				},
+				"max_completion_tokens": {
+					"type": "integer"
+				},
+				"max_tool_calls": {
+					"type": "integer"
+				},
+				"metadata": {
+					"type": "object",
+					"additionalProperties": {}
+				},
+				"parallel_tool_calls": {
+					"type": "boolean"
+				},
+				"prediction": {
+					"type": "object",
+					"additionalProperties": {}
+				},
+				"prompt_cache_key": {
+					"type": "string"
+				},
+				"reasoning_effort": {
+					"type": "string"
+				},
+				"reasoning_summary": {
+					"type": "string"
+				},
+				"safety_identifier": {
+					"type": "string"
+				},
+				"search_context_size": {
+					"type": "string"
+				},
+				"service_tier": {
+					"type": "string"
+				},
+				"store": {
+					"type": "boolean"
+				},
+				"strict_json_schema": {
+					"type": "boolean"
+				},
+				"structured_outputs": {
+					"type": "boolean"
+				},
+				"text_verbosity": {
+					"type": "string"
+				},
+				"top_log_probs": {
+					"type": "integer"
+				},
+				"user": {
+					"type": "string"
+				},
+				"web_search_enabled": {
+					"type": "boolean"
+				}
+			}
+		},
+		"codersdk.ChatModelOpenRouterProvider": {
+			"type": "object",
+			"properties": {
+				"allow_fallbacks": {
+					"type": "boolean"
+				},
+				"data_collection": {
+					"type": "string"
+				},
+				"ignore": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"only": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"order": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"quantizations": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"require_parameters": {
+					"type": "boolean"
+				},
+				"sort": {
+					"type": "string"
+				}
+			}
+		},
+		"codersdk.ChatModelOpenRouterProviderOptions": {
+			"type": "object",
+			"properties": {
+				"extra_body": {
+					"type": "object",
+					"additionalProperties": {}
+				},
+				"include_usage": {
+					"type": "boolean"
+				},
+				"log_probs": {
+					"type": "boolean"
+				},
+				"logit_bias": {
+					"type": "object",
+					"additionalProperties": {
+						"type": "integer",
+						"format": "int64"
+					}
+				},
+				"parallel_tool_calls": {
+					"type": "boolean"
+				},
+				"provider": {
+					"$ref": "#/definitions/codersdk.ChatModelOpenRouterProvider"
+				},
+				"reasoning": {
+					"$ref": "#/definitions/codersdk.ChatModelReasoningOptions"
+				},
+				"user": {
+					"type": "string"
+				}
+			}
+		},
+		"codersdk.ChatModelOverrideContext": {
+			"type": "string",
+			"enum": ["general", "explore", "title_generation"],
+			"x-enum-varnames": [
+				"ChatModelOverrideContextGeneral",
+				"ChatModelOverrideContextExplore",
+				"ChatModelOverrideContextTitleGeneration"
+			]
+		},
+		"codersdk.ChatModelOverrideResponse": {
+			"type": "object",
+			"properties": {
+				"context": {
+					"$ref": "#/definitions/codersdk.ChatModelOverrideContext"
+				},
+				"is_malformed": {
+					"type": "boolean"
+				},
+				"model_config_id": {
+					"type": "string"
+				}
+			}
+		},
 		"codersdk.ChatModelProvider": {
 			"type": "object",
 			"properties": {
@@ -14541,6 +16498,29 @@
 				}
 			}
 		},
+		"codersdk.ChatModelProviderOptions": {
+			"type": "object",
+			"properties": {
+				"anthropic": {
+					"$ref": "#/definitions/codersdk.ChatModelAnthropicProviderOptions"
+				},
+				"google": {
+					"$ref": "#/definitions/codersdk.ChatModelGoogleProviderOptions"
+				},
+				"openai": {
+					"$ref": "#/definitions/codersdk.ChatModelOpenAIProviderOptions"
+				},
+				"openaicompat": {
+					"$ref": "#/definitions/codersdk.ChatModelOpenAICompatProviderOptions"
+				},
+				"openrouter": {
+					"$ref": "#/definitions/codersdk.ChatModelOpenRouterProviderOptions"
+				},
+				"vercel": {
+					"$ref": "#/definitions/codersdk.ChatModelVercelProviderOptions"
+				}
+			}
+		},
 		"codersdk.ChatModelProviderUnavailableReason": {
 			"type": "string",
 			"enum": ["missing_api_key", "fetch_failed", "user_api_key_required"],
@@ -14549,6 +16529,74 @@
 				"ChatModelProviderUnavailableFetchFailed",
 				"ChatModelProviderUnavailableReasonUserAPIKeyRequired"
 			]
+		},
+		"codersdk.ChatModelReasoningOptions": {
+			"type": "object",
+			"properties": {
+				"effort": {
+					"type": "string"
+				},
+				"enabled": {
+					"type": "boolean"
+				},
+				"exclude": {
+					"type": "boolean"
+				},
+				"max_tokens": {
+					"type": "integer"
+				}
+			}
+		},
+		"codersdk.ChatModelVercelGatewayProviderOptions": {
+			"type": "object",
+			"properties": {
+				"models": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"order": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				}
+			}
+		},
+		"codersdk.ChatModelVercelProviderOptions": {
+			"type": "object",
+			"properties": {
+				"extra_body": {
+					"type": "object",
+					"additionalProperties": {}
+				},
+				"logit_bias": {
+					"type": "object",
+					"additionalProperties": {
+						"type": "integer",
+						"format": "int64"
+					}
+				},
+				"logprobs": {
+					"type": "boolean"
+				},
+				"parallel_tool_calls": {
+					"type": "boolean"
+				},
+				"providerOptions": {
+					"$ref": "#/definitions/codersdk.ChatModelVercelGatewayProviderOptions"
+				},
+				"reasoning": {
+					"$ref": "#/definitions/codersdk.ChatModelReasoningOptions"
+				},
+				"top_logprobs": {
+					"type": "integer"
+				},
+				"user": {
+					"type": "string"
+				}
+			}
 		},
 		"codersdk.ChatModelsResponse": {
 			"type": "object",
@@ -14561,10 +16609,128 @@
 				}
 			}
 		},
+		"codersdk.ChatPersonalModelOverride": {
+			"type": "object",
+			"properties": {
+				"context": {
+					"$ref": "#/definitions/codersdk.ChatPersonalModelOverrideContext"
+				},
+				"is_malformed": {
+					"type": "boolean"
+				},
+				"is_set": {
+					"type": "boolean"
+				},
+				"mode": {
+					"$ref": "#/definitions/codersdk.ChatPersonalModelOverrideMode"
+				},
+				"model_config_id": {
+					"type": "string"
+				}
+			}
+		},
+		"codersdk.ChatPersonalModelOverrideContext": {
+			"type": "string",
+			"enum": ["root", "general", "explore"],
+			"x-enum-varnames": [
+				"ChatPersonalModelOverrideContextRoot",
+				"ChatPersonalModelOverrideContextGeneral",
+				"ChatPersonalModelOverrideContextExplore"
+			]
+		},
+		"codersdk.ChatPersonalModelOverrideDeploymentDefaults": {
+			"type": "object",
+			"properties": {
+				"explore": {
+					"$ref": "#/definitions/codersdk.ChatModelOverrideResponse"
+				},
+				"general": {
+					"$ref": "#/definitions/codersdk.ChatModelOverrideResponse"
+				}
+			}
+		},
+		"codersdk.ChatPersonalModelOverrideMode": {
+			"type": "string",
+			"enum": ["deployment_default", "chat_default", "model"],
+			"x-enum-varnames": [
+				"ChatPersonalModelOverrideModeDeploymentDefault",
+				"ChatPersonalModelOverrideModeChatDefault",
+				"ChatPersonalModelOverrideModeModel"
+			]
+		},
+		"codersdk.ChatPersonalModelOverridesAdminSettings": {
+			"type": "object",
+			"properties": {
+				"allow_users": {
+					"type": "boolean"
+				}
+			}
+		},
 		"codersdk.ChatPlanMode": {
 			"type": "string",
 			"enum": ["plan"],
 			"x-enum-varnames": ["ChatPlanModePlan"]
+		},
+		"codersdk.ChatPlanModeInstructionsResponse": {
+			"type": "object",
+			"properties": {
+				"plan_mode_instructions": {
+					"type": "string"
+				}
+			}
+		},
+		"codersdk.ChatProviderConfig": {
+			"type": "object",
+			"properties": {
+				"allow_central_api_key_fallback": {
+					"type": "boolean"
+				},
+				"allow_user_api_key": {
+					"type": "boolean"
+				},
+				"base_url": {
+					"type": "string"
+				},
+				"central_api_key_enabled": {
+					"type": "boolean"
+				},
+				"created_at": {
+					"type": "string",
+					"format": "date-time"
+				},
+				"display_name": {
+					"type": "string"
+				},
+				"enabled": {
+					"type": "boolean"
+				},
+				"has_api_key": {
+					"type": "boolean"
+				},
+				"id": {
+					"type": "string",
+					"format": "uuid"
+				},
+				"provider": {
+					"type": "string"
+				},
+				"source": {
+					"$ref": "#/definitions/codersdk.ChatProviderConfigSource"
+				},
+				"updated_at": {
+					"type": "string",
+					"format": "date-time"
+				}
+			}
+		},
+		"codersdk.ChatProviderConfigSource": {
+			"type": "string",
+			"enum": ["database", "env_preset", "supported"],
+			"x-enum-varnames": [
+				"ChatProviderConfigSourceDatabase",
+				"ChatProviderConfigSourceEnvPreset",
+				"ChatProviderConfigSourceSupported"
+			]
 		},
 		"codersdk.ChatQueuedMessage": {
 			"type": "object",
@@ -14760,6 +16926,31 @@
 				}
 			}
 		},
+		"codersdk.ChatSystemPromptResponse": {
+			"type": "object",
+			"properties": {
+				"default_system_prompt": {
+					"type": "string"
+				},
+				"include_default_system_prompt": {
+					"type": "boolean"
+				},
+				"system_prompt": {
+					"type": "string"
+				}
+			}
+		},
+		"codersdk.ChatTemplateAllowlist": {
+			"type": "object",
+			"properties": {
+				"template_ids": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				}
+			}
+		},
 		"codersdk.ChatWatchEvent": {
 			"type": "object",
 			"properties": {
@@ -14797,6 +16988,15 @@
 				"ChatWatchEventKindDiffStatusChange",
 				"ChatWatchEventKindActionRequired"
 			]
+		},
+		"codersdk.ChatWorkspaceTTLResponse": {
+			"type": "object",
+			"properties": {
+				"workspace_ttl_ms": {
+					"description": "WorkspaceTTLMillis is the workspace TTL in milliseconds.\nZero means disabled, so the template's own autostop setting applies.",
+					"type": "integer"
+				}
+			}
 		},
 		"codersdk.ConnectionLatency": {
 			"type": "object",
@@ -15019,6 +17219,64 @@
 					"items": {
 						"type": "string"
 					}
+				}
+			}
+		},
+		"codersdk.CreateChatModelConfigRequest": {
+			"type": "object",
+			"properties": {
+				"compression_threshold": {
+					"type": "integer"
+				},
+				"context_limit": {
+					"type": "integer"
+				},
+				"display_name": {
+					"type": "string"
+				},
+				"enabled": {
+					"type": "boolean"
+				},
+				"is_default": {
+					"type": "boolean"
+				},
+				"model": {
+					"type": "string"
+				},
+				"model_config": {
+					"$ref": "#/definitions/codersdk.ChatModelCallConfig"
+				},
+				"provider": {
+					"type": "string"
+				}
+			}
+		},
+		"codersdk.CreateChatProviderConfigRequest": {
+			"type": "object",
+			"properties": {
+				"allow_central_api_key_fallback": {
+					"type": "boolean"
+				},
+				"allow_user_api_key": {
+					"type": "boolean"
+				},
+				"api_key": {
+					"type": "string"
+				},
+				"base_url": {
+					"type": "string"
+				},
+				"central_api_key_enabled": {
+					"type": "boolean"
+				},
+				"display_name": {
+					"type": "string"
+				},
+				"enabled": {
+					"type": "boolean"
+				},
+				"provider": {
+					"type": "string"
 				}
 			}
 		},
@@ -15475,6 +17733,14 @@
 					}
 				},
 				"token_name": {
+					"type": "string"
+				}
+			}
+		},
+		"codersdk.CreateUserChatProviderKeyRequest": {
+			"type": "object",
+			"properties": {
+				"api_key": {
 					"type": "string"
 				}
 			}
@@ -17203,6 +19469,23 @@
 				},
 				"username": {
 					"type": "string"
+				}
+			}
+		},
+		"codersdk.ModelCostConfig": {
+			"type": "object",
+			"properties": {
+				"cache_read_price_per_million_tokens": {
+					"type": "number"
+				},
+				"cache_write_price_per_million_tokens": {
+					"type": "number"
+				},
+				"input_price_per_million_tokens": {
+					"type": "number"
+				},
+				"output_price_per_million_tokens": {
+					"type": "number"
 				}
 			}
 		},
@@ -18952,6 +21235,14 @@
 				}
 			}
 		},
+		"codersdk.ProposeChatTitleResponse": {
+			"type": "object",
+			"properties": {
+				"title": {
+					"type": "string"
+				}
+			}
+		},
 		"codersdk.ProvisionerConfig": {
 			"type": "object",
 			"properties": {
@@ -20097,6 +22388,17 @@
 				}
 			}
 		},
+		"codersdk.SubmitToolResultsRequest": {
+			"type": "object",
+			"properties": {
+				"results": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/codersdk.ToolResult"
+					}
+				}
+			}
+		},
 		"codersdk.SupportConfig": {
 			"type": "object",
 			"properties": {
@@ -21227,6 +23529,23 @@
 				}
 			}
 		},
+		"codersdk.ToolResult": {
+			"type": "object",
+			"properties": {
+				"is_error": {
+					"type": "boolean"
+				},
+				"output": {
+					"type": "array",
+					"items": {
+						"type": "integer"
+					}
+				},
+				"tool_call_id": {
+					"type": "string"
+				}
+			}
+		},
 		"codersdk.TraceConfig": {
 			"type": "object",
 			"properties": {
@@ -21267,6 +23586,28 @@
 				}
 			}
 		},
+		"codersdk.UpdateAdvisorConfigRequest": {
+			"type": "object",
+			"properties": {
+				"enabled": {
+					"description": "Enabled toggles the advisor runtime. When false, advisor is not\nattached to new chats.",
+					"type": "boolean"
+				},
+				"max_output_tokens": {
+					"description": "MaxOutputTokens caps the advisor model response tokens. 0 means\nuse the runtime default.",
+					"type": "integer"
+				},
+				"max_uses_per_run": {
+					"description": "MaxUsesPerRun caps how many times the advisor can be invoked per\nchat run. 0 means unlimited.",
+					"type": "integer"
+				},
+				"model_config_id": {
+					"description": "ModelConfigID selects a specific chat model config to power the\nadvisor. uuid.Nil means reuse the outer chat model. The runtime\nmust fall back to the outer chat model when this ID cannot be\nresolved (e.g. the referenced model config was soft-deleted or\nits provider was disabled after the admin saved this config).",
+					"type": "string",
+					"format": "uuid"
+				}
+			}
+		},
 		"codersdk.UpdateAppearanceConfig": {
 			"type": "object",
 			"properties": {
@@ -21289,6 +23630,125 @@
 							"$ref": "#/definitions/codersdk.BannerConfig"
 						}
 					]
+				}
+			}
+		},
+		"codersdk.UpdateChatAutoArchiveDaysRequest": {
+			"type": "object",
+			"properties": {
+				"auto_archive_days": {
+					"type": "integer"
+				}
+			}
+		},
+		"codersdk.UpdateChatComputerUseProviderRequest": {
+			"type": "object",
+			"properties": {
+				"provider": {
+					"type": "string"
+				}
+			}
+		},
+		"codersdk.UpdateChatDebugLoggingAllowUsersRequest": {
+			"type": "object",
+			"properties": {
+				"allow_users": {
+					"type": "boolean"
+				}
+			}
+		},
+		"codersdk.UpdateChatDebugRetentionDaysRequest": {
+			"type": "object",
+			"properties": {
+				"debug_retention_days": {
+					"type": "integer"
+				}
+			}
+		},
+		"codersdk.UpdateChatDesktopEnabledRequest": {
+			"type": "object",
+			"properties": {
+				"enable_desktop": {
+					"type": "boolean"
+				}
+			}
+		},
+		"codersdk.UpdateChatModelConfigRequest": {
+			"type": "object",
+			"properties": {
+				"compression_threshold": {
+					"type": "integer"
+				},
+				"context_limit": {
+					"type": "integer"
+				},
+				"display_name": {
+					"type": "string"
+				},
+				"enabled": {
+					"type": "boolean"
+				},
+				"is_default": {
+					"type": "boolean"
+				},
+				"model": {
+					"type": "string"
+				},
+				"model_config": {
+					"$ref": "#/definitions/codersdk.ChatModelCallConfig"
+				},
+				"provider": {
+					"type": "string"
+				}
+			}
+		},
+		"codersdk.UpdateChatModelOverrideRequest": {
+			"type": "object",
+			"properties": {
+				"model_config_id": {
+					"type": "string"
+				}
+			}
+		},
+		"codersdk.UpdateChatPersonalModelOverridesAdminSettingsRequest": {
+			"type": "object",
+			"properties": {
+				"allow_users": {
+					"type": "boolean"
+				}
+			}
+		},
+		"codersdk.UpdateChatPlanModeInstructionsRequest": {
+			"type": "object",
+			"properties": {
+				"plan_mode_instructions": {
+					"type": "string"
+				}
+			}
+		},
+		"codersdk.UpdateChatProviderConfigRequest": {
+			"type": "object",
+			"properties": {
+				"allow_central_api_key_fallback": {
+					"type": "boolean"
+				},
+				"allow_user_api_key": {
+					"type": "boolean"
+				},
+				"api_key": {
+					"type": "string"
+				},
+				"base_url": {
+					"type": "string"
+				},
+				"central_api_key_enabled": {
+					"type": "boolean"
+				},
+				"display_name": {
+					"type": "string"
+				},
+				"enabled": {
+					"type": "boolean"
 				}
 			}
 		},
@@ -21329,6 +23789,26 @@
 			"type": "object",
 			"properties": {
 				"retention_days": {
+					"type": "integer"
+				}
+			}
+		},
+		"codersdk.UpdateChatSystemPromptRequest": {
+			"type": "object",
+			"properties": {
+				"include_default_system_prompt": {
+					"type": "boolean"
+				},
+				"system_prompt": {
+					"type": "string"
+				}
+			}
+		},
+		"codersdk.UpdateChatWorkspaceTTLRequest": {
+			"type": "object",
+			"properties": {
+				"workspace_ttl_ms": {
+					"description": "WorkspaceTTLMillis is the workspace TTL in milliseconds.\nZero means disabled, so the template's own autostop setting applies.",
 					"type": "integer"
 				}
 			}
@@ -21508,6 +23988,25 @@
 					"$ref": "#/definitions/codersdk.TerminalFontName"
 				},
 				"theme_preference": {
+					"type": "string"
+				}
+			}
+		},
+		"codersdk.UpdateUserChatDebugLoggingRequest": {
+			"type": "object",
+			"properties": {
+				"debug_logging_enabled": {
+					"type": "boolean"
+				}
+			}
+		},
+		"codersdk.UpdateUserChatPersonalModelOverrideRequest": {
+			"type": "object",
+			"properties": {
+				"mode": {
+					"$ref": "#/definitions/codersdk.ChatPersonalModelOverrideMode"
+				},
+				"model_config_id": {
 					"type": "string"
 				}
 			}
@@ -21897,6 +24396,69 @@
 				},
 				"theme_preference": {
 					"type": "string"
+				}
+			}
+		},
+		"codersdk.UserChatCustomPrompt": {
+			"type": "object",
+			"properties": {
+				"custom_prompt": {
+					"type": "string"
+				}
+			}
+		},
+		"codersdk.UserChatDebugLoggingSettings": {
+			"type": "object",
+			"properties": {
+				"debug_logging_enabled": {
+					"type": "boolean"
+				},
+				"forced_by_deployment": {
+					"type": "boolean"
+				},
+				"user_toggle_allowed": {
+					"type": "boolean"
+				}
+			}
+		},
+		"codersdk.UserChatPersonalModelOverridesResponse": {
+			"type": "object",
+			"properties": {
+				"deployment_defaults": {
+					"$ref": "#/definitions/codersdk.ChatPersonalModelOverrideDeploymentDefaults"
+				},
+				"enabled": {
+					"type": "boolean"
+				},
+				"explore": {
+					"$ref": "#/definitions/codersdk.ChatPersonalModelOverride"
+				},
+				"general": {
+					"$ref": "#/definitions/codersdk.ChatPersonalModelOverride"
+				},
+				"root": {
+					"$ref": "#/definitions/codersdk.ChatPersonalModelOverride"
+				}
+			}
+		},
+		"codersdk.UserChatProviderConfig": {
+			"type": "object",
+			"properties": {
+				"display_name": {
+					"type": "string"
+				},
+				"has_central_api_key_fallback": {
+					"type": "boolean"
+				},
+				"has_user_api_key": {
+					"type": "boolean"
+				},
+				"provider": {
+					"type": "string"
+				},
+				"provider_id": {
+					"type": "string",
+					"format": "uuid"
 				}
 			}
 		},

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -3111,6 +3111,16 @@ func (api *API) patchChatMessage(rw http.ResponseWriter, r *http.Request) {
 }
 
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
+//
+// @Summary Delete chat queued message
+// @ID delete-chat-queued-message
+// @Security CoderSessionToken
+// @Tags Chats
+// @Param chat path string true "Chat ID" format(uuid)
+// @Param queuedMessage path integer true "Queued message ID"
+// @Success 204
+// @Router /api/experimental/chats/{chat}/queue/{queuedMessage} [delete]
+// @Description Experimental: this endpoint is subject to change.
 func (api *API) deleteChatQueuedMessage(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	chat := httpmw.ChatParam(r)
@@ -3146,6 +3156,16 @@ func (api *API) deleteChatQueuedMessage(rw http.ResponseWriter, r *http.Request)
 }
 
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
+//
+// @Summary Promote chat queued message
+// @ID promote-chat-queued-message
+// @Security CoderSessionToken
+// @Tags Chats
+// @Param chat path string true "Chat ID" format(uuid)
+// @Param queuedMessage path integer true "Queued message ID"
+// @Success 204
+// @Router /api/experimental/chats/{chat}/queue/{queuedMessage}/promote [post]
+// @Description Experimental: this endpoint is subject to change.
 func (api *API) promoteChatQueuedMessage(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	apiKey := httpmw.APIKey(r)
@@ -3506,6 +3526,16 @@ func (api *API) regenerateChatTitle(rw http.ResponseWriter, r *http.Request) {
 	httpapi.Write(ctx, rw, http.StatusOK, db2sdk.Chat(updatedChat, nil, nil))
 }
 
+// @Summary Propose chat title
+// @ID propose-chat-title
+// @Security CoderSessionToken
+// @Tags Chats
+// @Produce json
+// @Param chat path string true "Chat ID" format(uuid)
+// @Success 200 {object} codersdk.ProposeChatTitleResponse
+// @Router /api/experimental/chats/{chat}/title/propose [post]
+// @Description Experimental: this endpoint is subject to change.
+//
 //nolint:revive // HTTP handler writes to ResponseWriter.
 func (api *API) proposeChatTitle(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -4343,6 +4373,15 @@ func parseCompactionThresholdKey(key string) (uuid.UUID, error) {
 	return id, nil
 }
 
+// @Summary Get chat system prompt
+// @ID get-chat-system-prompt
+// @Security CoderSessionToken
+// @Tags Chats
+// @Produce json
+// @Success 200 {object} codersdk.ChatSystemPromptResponse
+// @Router /api/experimental/chats/config/system-prompt [get]
+// @Description Experimental: this endpoint is subject to change.
+//
 //nolint:revive // get-return: revive assumes get* must be a getter, but this is an HTTP handler.
 func (api *API) getChatSystemPrompt(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -4365,6 +4404,15 @@ func (api *API) getChatSystemPrompt(rw http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// @Summary Update chat system prompt
+// @ID update-chat-system-prompt
+// @Security CoderSessionToken
+// @Tags Chats
+// @Accept json
+// @Param request body codersdk.UpdateChatSystemPromptRequest true "Request body"
+// @Success 204
+// @Router /api/experimental/chats/config/system-prompt [put]
+// @Description Experimental: this endpoint is subject to change.
 func (api *API) putChatSystemPrompt(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	if !api.Authorize(r, policy.ActionUpdate, rbac.ResourceDeploymentConfig) {
@@ -4414,6 +4462,15 @@ func (api *API) putChatSystemPrompt(rw http.ResponseWriter, r *http.Request) {
 
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
 //
+// @Summary Get chat plan mode instructions
+// @ID get-chat-plan-mode-instructions
+// @Security CoderSessionToken
+// @Tags Chats
+// @Produce json
+// @Success 200 {object} codersdk.ChatPlanModeInstructionsResponse
+// @Router /api/experimental/chats/config/plan-mode-instructions [get]
+// @Description Experimental: this endpoint is subject to change.
+//
 //nolint:revive // get-return: revive assumes get* must be a getter, but this is an HTTP handler.
 func (api *API) getChatPlanModeInstructions(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -4437,6 +4494,16 @@ func (api *API) getChatPlanModeInstructions(rw http.ResponseWriter, r *http.Requ
 }
 
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
+//
+// @Summary Update chat plan mode instructions
+// @ID update-chat-plan-mode-instructions
+// @Security CoderSessionToken
+// @Tags Chats
+// @Accept json
+// @Param request body codersdk.UpdateChatPlanModeInstructionsRequest true "Request body"
+// @Success 204
+// @Router /api/experimental/chats/config/plan-mode-instructions [put]
+// @Description Experimental: this endpoint is subject to change.
 func (api *API) putChatPlanModeInstructions(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	if !api.Authorize(r, policy.ActionUpdate, rbac.ResourceDeploymentConfig) {
@@ -4505,6 +4572,16 @@ func readChatModelOverrideContext(
 
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
 //
+// @Summary Get chat model override
+// @ID get-chat-model-override
+// @Security CoderSessionToken
+// @Tags Chats
+// @Produce json
+// @Param context path string true "Override context"
+// @Success 200 {object} codersdk.ChatModelOverrideResponse
+// @Router /api/experimental/chats/config/model-override/{context} [get]
+// @Description Experimental: this endpoint is subject to change.
+//
 //nolint:revive // get-return: revive assumes get* must be a getter, but this is an HTTP handler.
 func (api *API) getChatModelOverride(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -4539,6 +4616,17 @@ func (api *API) getChatModelOverride(rw http.ResponseWriter, r *http.Request) {
 }
 
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
+//
+// @Summary Update chat model override
+// @ID update-chat-model-override
+// @Security CoderSessionToken
+// @Tags Chats
+// @Accept json
+// @Param context path string true "Override context"
+// @Param request body codersdk.UpdateChatModelOverrideRequest true "Request body"
+// @Success 204
+// @Router /api/experimental/chats/config/model-override/{context} [put]
+// @Description Experimental: this endpoint is subject to change.
 func (api *API) putChatModelOverride(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	if !api.Authorize(r, policy.ActionUpdate, rbac.ResourceDeploymentConfig) {
@@ -4608,6 +4696,15 @@ func readChatPersonalModelOverrideContext(
 
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
 //
+// @Summary Get chat personal model overrides admin settings
+// @ID get-chat-personal-model-overrides-admin-settings
+// @Security CoderSessionToken
+// @Tags Chats
+// @Produce json
+// @Success 200 {object} codersdk.ChatPersonalModelOverridesAdminSettings
+// @Router /api/experimental/chats/config/personal-model-overrides [get]
+// @Description Experimental: this endpoint is subject to change.
+//
 //nolint:revive // get-return: revive assumes get* must be a getter, but this is an HTTP handler.
 func (api *API) getChatPersonalModelOverridesAdminSettings(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -4630,6 +4727,16 @@ func (api *API) getChatPersonalModelOverridesAdminSettings(rw http.ResponseWrite
 }
 
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
+//
+// @Summary Update chat personal model overrides admin settings
+// @ID update-chat-personal-model-overrides-admin-settings
+// @Security CoderSessionToken
+// @Tags Chats
+// @Accept json
+// @Param request body codersdk.UpdateChatPersonalModelOverridesAdminSettingsRequest true "Request body"
+// @Success 204
+// @Router /api/experimental/chats/config/personal-model-overrides [put]
+// @Description Experimental: this endpoint is subject to change.
 func (api *API) putChatPersonalModelOverridesAdminSettings(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	if !api.Authorize(r, policy.ActionUpdate, rbac.ResourceDeploymentConfig) {
@@ -4652,6 +4759,15 @@ func (api *API) putChatPersonalModelOverridesAdminSettings(rw http.ResponseWrite
 }
 
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
+//
+// @Summary Get user chat personal model overrides
+// @ID get-user-chat-personal-model-overrides
+// @Security CoderSessionToken
+// @Tags Chats
+// @Produce json
+// @Success 200 {object} codersdk.UserChatPersonalModelOverridesResponse
+// @Router /api/experimental/chats/config/user-personal-model-overrides [get]
+// @Description Experimental: this endpoint is subject to change.
 //
 //nolint:revive // get-return: revive assumes get* must be a getter, but this is an HTTP handler.
 func (api *API) getUserChatPersonalModelOverrides(rw http.ResponseWriter, r *http.Request) {
@@ -4718,6 +4834,17 @@ func (api *API) getUserChatPersonalModelOverrides(rw http.ResponseWriter, r *htt
 }
 
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
+//
+// @Summary Update user chat personal model override
+// @ID update-user-chat-personal-model-override
+// @Security CoderSessionToken
+// @Tags Chats
+// @Accept json
+// @Param context path string true "Override context"
+// @Param request body codersdk.UpdateUserChatPersonalModelOverrideRequest true "Request body"
+// @Success 204
+// @Router /api/experimental/chats/config/user-personal-model-overrides/{context} [put]
+// @Description Experimental: this endpoint is subject to change.
 func (api *API) putUserChatPersonalModelOverride(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	apiKey := httpmw.APIKey(r)
@@ -4820,6 +4947,15 @@ func (api *API) putUserChatPersonalModelOverride(rw http.ResponseWriter, r *http
 
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
 //
+// @Summary Get chat desktop enabled
+// @ID get-chat-desktop-enabled
+// @Security CoderSessionToken
+// @Tags Chats
+// @Produce json
+// @Success 200 {object} codersdk.ChatDesktopEnabledResponse
+// @Router /api/experimental/chats/config/desktop-enabled [get]
+// @Description Experimental: this endpoint is subject to change.
+//
 //nolint:revive // get-return: revive assumes get* must be a getter, but this is an HTTP handler.
 func (api *API) getChatDesktopEnabled(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -4837,6 +4973,16 @@ func (api *API) getChatDesktopEnabled(rw http.ResponseWriter, r *http.Request) {
 }
 
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
+//
+// @Summary Update chat desktop enabled
+// @ID update-chat-desktop-enabled
+// @Security CoderSessionToken
+// @Tags Chats
+// @Accept json
+// @Param request body codersdk.UpdateChatDesktopEnabledRequest true "Request body"
+// @Success 204
+// @Router /api/experimental/chats/config/desktop-enabled [put]
+// @Description Experimental: this endpoint is subject to change.
 func (api *API) putChatDesktopEnabled(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	if !api.Authorize(r, policy.ActionUpdate, rbac.ResourceDeploymentConfig) {
@@ -4863,6 +5009,15 @@ func (api *API) putChatDesktopEnabled(rw http.ResponseWriter, r *http.Request) {
 
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
 //
+// @Summary Get chat computer use provider
+// @ID get-chat-computer-use-provider
+// @Security CoderSessionToken
+// @Tags Chats
+// @Produce json
+// @Success 200 {object} codersdk.ChatComputerUseProviderResponse
+// @Router /api/experimental/chats/config/computer-use-provider [get]
+// @Description Experimental: this endpoint is subject to change.
+//
 //nolint:revive // get-return: revive assumes get* must be a getter, but this is an HTTP handler.
 func (api *API) getChatComputerUseProvider(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -4880,6 +5035,16 @@ func (api *API) getChatComputerUseProvider(rw http.ResponseWriter, r *http.Reque
 }
 
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
+//
+// @Summary Update chat computer use provider
+// @ID update-chat-computer-use-provider
+// @Security CoderSessionToken
+// @Tags Chats
+// @Accept json
+// @Param request body codersdk.UpdateChatComputerUseProviderRequest true "Request body"
+// @Success 204
+// @Router /api/experimental/chats/config/computer-use-provider [put]
+// @Description Experimental: this endpoint is subject to change.
 func (api *API) putChatComputerUseProvider(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	if !api.Authorize(r, policy.ActionUpdate, rbac.ResourceDeploymentConfig) {
@@ -4919,6 +5084,15 @@ func (api *API) deploymentChatDebugLoggingEnabled() bool {
 
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
 //
+// @Summary Get chat debug logging
+// @ID get-chat-debug-logging
+// @Security CoderSessionToken
+// @Tags Chats
+// @Produce json
+// @Success 200 {object} codersdk.ChatDebugLoggingAdminSettings
+// @Router /api/experimental/chats/config/debug-logging [get]
+// @Description Experimental: this endpoint is subject to change.
+//
 //nolint:revive // get-return: revive assumes get* must be a getter, but this is an HTTP handler.
 func (api *API) getChatDebugLogging(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -4942,6 +5116,16 @@ func (api *API) getChatDebugLogging(rw http.ResponseWriter, r *http.Request) {
 }
 
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
+//
+// @Summary Update chat debug logging
+// @ID update-chat-debug-logging
+// @Security CoderSessionToken
+// @Tags Chats
+// @Accept json
+// @Param request body codersdk.UpdateChatDebugLoggingAllowUsersRequest true "Request body"
+// @Success 204
+// @Router /api/experimental/chats/config/debug-logging [put]
+// @Description Experimental: this endpoint is subject to change.
 func (api *API) putChatDebugLogging(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	if !api.Authorize(r, policy.ActionUpdate, rbac.ResourceDeploymentConfig) {
@@ -4964,6 +5148,15 @@ func (api *API) putChatDebugLogging(rw http.ResponseWriter, r *http.Request) {
 }
 
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
+//
+// @Summary Get user chat debug logging
+// @ID get-user-chat-debug-logging
+// @Security CoderSessionToken
+// @Tags Chats
+// @Produce json
+// @Success 200 {object} codersdk.UserChatDebugLoggingSettings
+// @Router /api/experimental/chats/config/user-debug-logging [get]
+// @Description Experimental: this endpoint is subject to change.
 //
 //nolint:revive // get-return: revive assumes get* must be a getter, but this is an HTTP handler.
 func (api *API) getUserChatDebugLogging(rw http.ResponseWriter, r *http.Request) {
@@ -5005,6 +5198,16 @@ func (api *API) getUserChatDebugLogging(rw http.ResponseWriter, r *http.Request)
 }
 
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
+//
+// @Summary Update user chat debug logging
+// @ID update-user-chat-debug-logging
+// @Security CoderSessionToken
+// @Tags Chats
+// @Accept json
+// @Param request body codersdk.UpdateUserChatDebugLoggingRequest true "Request body"
+// @Success 204
+// @Router /api/experimental/chats/config/user-debug-logging [put]
+// @Description Experimental: this endpoint is subject to change.
 func (api *API) putUserChatDebugLogging(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	apiKey := httpmw.APIKey(r)
@@ -5049,6 +5252,15 @@ func (api *API) putUserChatDebugLogging(rw http.ResponseWriter, r *http.Request)
 
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
 //
+// @Summary Get chat advisor config
+// @ID get-chat-advisor-config
+// @Security CoderSessionToken
+// @Tags Chats
+// @Produce json
+// @Success 200 {object} codersdk.AdvisorConfig
+// @Router /api/experimental/chats/config/advisor [get]
+// @Description Experimental: this endpoint is subject to change.
+//
 //nolint:revive // get-return: revive assumes get* must be a getter, but this is an HTTP handler.
 func (api *API) getChatAdvisorConfig(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -5076,6 +5288,16 @@ func (api *API) getChatAdvisorConfig(rw http.ResponseWriter, r *http.Request) {
 }
 
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
+//
+// @Summary Update chat advisor config
+// @ID update-chat-advisor-config
+// @Security CoderSessionToken
+// @Tags Chats
+// @Accept json
+// @Param request body codersdk.UpdateAdvisorConfigRequest true "Request body"
+// @Success 204
+// @Router /api/experimental/chats/config/advisor [put]
+// @Description Experimental: this endpoint is subject to change.
 func (api *API) putChatAdvisorConfig(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	if !api.Authorize(r, policy.ActionUpdate, rbac.ResourceDeploymentConfig) {
@@ -5143,6 +5365,15 @@ func (api *API) putChatAdvisorConfig(rw http.ResponseWriter, r *http.Request) {
 
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
 //
+// @Summary Get chat workspace TTL
+// @ID get-chat-workspace-ttl
+// @Security CoderSessionToken
+// @Tags Chats
+// @Produce json
+// @Success 200 {object} codersdk.ChatWorkspaceTTLResponse
+// @Router /api/experimental/chats/config/workspace-ttl [get]
+// @Description Experimental: this endpoint is subject to change.
+//
 //nolint:revive // get-return: revive assumes get* must be a getter, but this is an HTTP handler.
 func (api *API) getChatWorkspaceTTL(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -5174,6 +5405,16 @@ func (api *API) getChatWorkspaceTTL(rw http.ResponseWriter, r *http.Request) {
 }
 
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
+//
+// @Summary Update chat workspace TTL
+// @ID update-chat-workspace-ttl
+// @Security CoderSessionToken
+// @Tags Chats
+// @Accept json
+// @Param request body codersdk.UpdateChatWorkspaceTTLRequest true "Request body"
+// @Success 204
+// @Router /api/experimental/chats/config/workspace-ttl [put]
+// @Description Experimental: this endpoint is subject to change.
 func (api *API) putChatWorkspaceTTL(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	if !api.Authorize(r, policy.ActionUpdate, rbac.ResourceDeploymentConfig) {
@@ -5293,6 +5534,15 @@ func (api *API) putChatRetentionDays(rw http.ResponseWriter, r *http.Request) {
 // getChatDebugRetentionDays returns the deployment-wide chat debug run
 // retention window. Any authenticated user can read it; writes require admin.
 //
+// @Summary Get chat debug retention days
+// @ID get-chat-debug-retention-days
+// @Security CoderSessionToken
+// @Tags Chats
+// @Produce json
+// @Success 200 {object} codersdk.ChatDebugRetentionDaysResponse
+// @Router /api/experimental/chats/config/debug-retention-days [get]
+// @Description Experimental: this endpoint is subject to change.
+//
 //nolint:revive // get-return: revive assumes get* must be a getter, but this is an HTTP handler.
 func (api *API) getChatDebugRetentionDays(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -5315,6 +5565,16 @@ const chatDebugRetentionDaysMaximum = 3650 // ~10 years
 
 // putChatDebugRetentionDays updates the deployment-wide chat debug run
 // retention window. Admin-only.
+//
+// @Summary Update chat debug retention days
+// @ID update-chat-debug-retention-days
+// @Security CoderSessionToken
+// @Tags Chats
+// @Accept json
+// @Param request body codersdk.UpdateChatDebugRetentionDaysRequest true "Request body"
+// @Success 204
+// @Router /api/experimental/chats/config/debug-retention-days [put]
+// @Description Experimental: this endpoint is subject to change.
 func (api *API) putChatDebugRetentionDays(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	if !api.Authorize(r, policy.ActionUpdate, rbac.ResourceDeploymentConfig) {
@@ -5345,6 +5605,15 @@ func (api *API) putChatDebugRetentionDays(rw http.ResponseWriter, r *http.Reques
 // window. Any authenticated user can read it (same as retention
 // days); writes require admin.
 //
+// @Summary Get chat auto archive days
+// @ID get-chat-auto-archive-days
+// @Security CoderSessionToken
+// @Tags Chats
+// @Produce json
+// @Success 200 {object} codersdk.ChatAutoArchiveDaysResponse
+// @Router /api/experimental/chats/config/auto-archive-days [get]
+// @Description Experimental: this endpoint is subject to change.
+//
 //nolint:revive // get-return: revive assumes get* must be a getter, but this is an HTTP handler.
 func (api *API) getChatAutoArchiveDays(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -5367,6 +5636,16 @@ const autoArchiveDaysMaximum = 3650 // ~10 years
 
 // putChatAutoArchiveDays updates the deployment-wide auto-archive
 // window. Admin-only; documented in docs/ai-coder/agents/chats-api.md.
+//
+// @Summary Update chat auto archive days
+// @ID update-chat-auto-archive-days
+// @Security CoderSessionToken
+// @Tags Chats
+// @Accept json
+// @Param request body codersdk.UpdateChatAutoArchiveDaysRequest true "Request body"
+// @Success 204
+// @Router /api/experimental/chats/config/auto-archive-days [put]
+// @Description Experimental: this endpoint is subject to change.
 func (api *API) putChatAutoArchiveDays(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	if !api.Authorize(r, policy.ActionUpdate, rbac.ResourceDeploymentConfig) {
@@ -5394,6 +5673,15 @@ func (api *API) putChatAutoArchiveDays(rw http.ResponseWriter, r *http.Request) 
 }
 
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
+//
+// @Summary Get chat template allowlist
+// @ID get-chat-template-allowlist
+// @Security CoderSessionToken
+// @Tags Chats
+// @Produce json
+// @Success 200 {object} codersdk.ChatTemplateAllowlist
+// @Router /api/experimental/chats/config/template-allowlist [get]
+// @Description Experimental: this endpoint is subject to change.
 //
 //nolint:revive // get-return: revive assumes get* must be a getter, but this is an HTTP handler.
 func (api *API) getChatTemplateAllowlist(rw http.ResponseWriter, r *http.Request) {
@@ -5429,6 +5717,16 @@ func (api *API) getChatTemplateAllowlist(rw http.ResponseWriter, r *http.Request
 }
 
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
+//
+// @Summary Update chat template allowlist
+// @ID update-chat-template-allowlist
+// @Security CoderSessionToken
+// @Tags Chats
+// @Accept json
+// @Param request body codersdk.ChatTemplateAllowlist true "Request body"
+// @Success 204
+// @Router /api/experimental/chats/config/template-allowlist [put]
+// @Description Experimental: this endpoint is subject to change.
 func (api *API) putChatTemplateAllowlist(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	if !api.Authorize(r, policy.ActionUpdate, rbac.ResourceDeploymentConfig) {
@@ -5529,6 +5827,15 @@ func (api *API) putChatTemplateAllowlist(rw http.ResponseWriter, r *http.Request
 
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
 //
+// @Summary Get user chat custom prompt
+// @ID get-user-chat-custom-prompt
+// @Security CoderSessionToken
+// @Tags Chats
+// @Produce json
+// @Success 200 {object} codersdk.UserChatCustomPrompt
+// @Router /api/experimental/chats/config/user-prompt [get]
+// @Description Experimental: this endpoint is subject to change.
+//
 //nolint:revive // get-return: revive assumes get* must be a getter, but this is an HTTP handler.
 func (api *API) getUserChatCustomPrompt(rw http.ResponseWriter, r *http.Request) {
 	var (
@@ -5555,6 +5862,17 @@ func (api *API) getUserChatCustomPrompt(rw http.ResponseWriter, r *http.Request)
 }
 
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
+//
+// @Summary Update user chat custom prompt
+// @ID update-user-chat-custom-prompt
+// @Security CoderSessionToken
+// @Tags Chats
+// @Accept json
+// @Produce json
+// @Param request body codersdk.UserChatCustomPrompt true "Request body"
+// @Success 200 {object} codersdk.UserChatCustomPrompt
+// @Router /api/experimental/chats/config/user-prompt [put]
+// @Description Experimental: this endpoint is subject to change.
 func (api *API) putUserChatCustomPrompt(rw http.ResponseWriter, r *http.Request) {
 	var (
 		ctx    = r.Context()
@@ -6240,6 +6558,16 @@ func convertChatMessages(messages []database.ChatMessage) []codersdk.ChatMessage
 	return result
 }
 
+// EXPERIMENTAL: this endpoint is experimental and is subject to change.
+//
+// @Summary List chat providers
+// @ID list-chat-providers
+// @Security CoderSessionToken
+// @Tags Chats
+// @Produce json
+// @Success 200 {array} codersdk.ChatProviderConfig
+// @Router /api/experimental/chats/providers [get]
+// @Description Experimental: this endpoint is subject to change.
 func (api *API) listChatProviders(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	//nolint:gocritic // System context required to read enabled chat providers.
@@ -6358,6 +6686,18 @@ func (api *API) listChatProviders(rw http.ResponseWriter, r *http.Request) {
 	httpapi.Write(ctx, rw, http.StatusOK, resp)
 }
 
+// EXPERIMENTAL: this endpoint is experimental and is subject to change.
+//
+// @Summary Create chat provider
+// @ID create-chat-provider
+// @Security CoderSessionToken
+// @Tags Chats
+// @Accept json
+// @Produce json
+// @Param request body codersdk.CreateChatProviderConfigRequest true "Request body"
+// @Success 201 {object} codersdk.ChatProviderConfig
+// @Router /api/experimental/chats/providers [post]
+// @Description Experimental: this endpoint is subject to change.
 func (api *API) createChatProvider(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	apiKey := httpmw.APIKey(r)
@@ -6492,6 +6832,19 @@ func (api *API) createChatProvider(rw http.ResponseWriter, r *http.Request) {
 	)
 }
 
+// EXPERIMENTAL: this endpoint is experimental and is subject to change.
+//
+// @Summary Update chat provider
+// @ID update-chat-provider
+// @Security CoderSessionToken
+// @Tags Chats
+// @Accept json
+// @Produce json
+// @Param providerConfig path string true "Provider config ID" format(uuid)
+// @Param request body codersdk.UpdateChatProviderConfigRequest true "Request body"
+// @Success 200 {object} codersdk.ChatProviderConfig
+// @Router /api/experimental/chats/providers/{providerConfig} [patch]
+// @Description Experimental: this endpoint is subject to change.
 func (api *API) updateChatProvider(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	var (
@@ -6639,6 +6992,16 @@ func (api *API) updateChatProvider(rw http.ResponseWriter, r *http.Request) {
 	)
 }
 
+// EXPERIMENTAL: this endpoint is experimental and is subject to change.
+//
+// @Summary Delete chat provider
+// @ID delete-chat-provider
+// @Security CoderSessionToken
+// @Tags Chats
+// @Param providerConfig path string true "Provider config ID" format(uuid)
+// @Success 204
+// @Router /api/experimental/chats/providers/{providerConfig} [delete]
+// @Description Experimental: this endpoint is subject to change.
 func (api *API) deleteChatProvider(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	if !api.Authorize(r, policy.ActionUpdate, rbac.ResourceDeploymentConfig) {
@@ -6688,6 +7051,16 @@ func (api *API) deleteChatProvider(rw http.ResponseWriter, r *http.Request) {
 	rw.WriteHeader(http.StatusNoContent)
 }
 
+// EXPERIMENTAL: this endpoint is experimental and is subject to change.
+//
+// @Summary List user chat provider configs
+// @ID list-user-chat-provider-configs
+// @Security CoderSessionToken
+// @Tags Chats
+// @Produce json
+// @Success 200 {array} codersdk.UserChatProviderConfig
+// @Router /api/experimental/chats/user-provider-configs [get]
+// @Description Experimental: this endpoint is subject to change.
 func (api *API) listUserChatProviderConfigs(rw http.ResponseWriter, r *http.Request) {
 	var (
 		ctx    = r.Context()
@@ -6741,6 +7114,19 @@ func (api *API) listUserChatProviderConfigs(rw http.ResponseWriter, r *http.Requ
 	httpapi.Write(ctx, rw, http.StatusOK, resp)
 }
 
+// EXPERIMENTAL: this endpoint is experimental and is subject to change.
+//
+// @Summary Upsert user chat provider key
+// @ID upsert-user-chat-provider-key
+// @Security CoderSessionToken
+// @Tags Chats
+// @Accept json
+// @Produce json
+// @Param providerConfig path string true "Provider config ID" format(uuid)
+// @Param request body codersdk.CreateUserChatProviderKeyRequest true "Request body"
+// @Success 200 {object} codersdk.UserChatProviderConfig
+// @Router /api/experimental/chats/user-provider-configs/{providerConfig} [put]
+// @Description Experimental: this endpoint is subject to change.
 func (api *API) upsertUserChatProviderKey(rw http.ResponseWriter, r *http.Request) {
 	var (
 		ctx    = r.Context()
@@ -6826,6 +7212,16 @@ func (api *API) upsertUserChatProviderKey(rw http.ResponseWriter, r *http.Reques
 	)
 }
 
+// EXPERIMENTAL: this endpoint is experimental and is subject to change.
+//
+// @Summary Delete user chat provider key
+// @ID delete-user-chat-provider-key
+// @Security CoderSessionToken
+// @Tags Chats
+// @Param providerConfig path string true "Provider config ID" format(uuid)
+// @Success 204
+// @Router /api/experimental/chats/user-provider-configs/{providerConfig} [delete]
+// @Description Experimental: this endpoint is subject to change.
 func (api *API) deleteUserChatProviderKey(rw http.ResponseWriter, r *http.Request) {
 	var (
 		ctx    = r.Context()
@@ -6851,6 +7247,16 @@ func (api *API) deleteUserChatProviderKey(rw http.ResponseWriter, r *http.Reques
 	rw.WriteHeader(http.StatusNoContent)
 }
 
+// EXPERIMENTAL: this endpoint is experimental and is subject to change.
+//
+// @Summary List chat model configs
+// @ID list-chat-model-configs
+// @Security CoderSessionToken
+// @Tags Chats
+// @Produce json
+// @Success 200 {array} codersdk.ChatModelConfig
+// @Router /api/experimental/chats/model-configs [get]
+// @Description Experimental: this endpoint is subject to change.
 func (api *API) listChatModelConfigs(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
@@ -6883,6 +7289,18 @@ func (api *API) listChatModelConfigs(rw http.ResponseWriter, r *http.Request) {
 	httpapi.Write(ctx, rw, http.StatusOK, resp)
 }
 
+// EXPERIMENTAL: this endpoint is experimental and is subject to change.
+//
+// @Summary Create chat model config
+// @ID create-chat-model-config
+// @Security CoderSessionToken
+// @Tags Chats
+// @Accept json
+// @Produce json
+// @Param request body codersdk.CreateChatModelConfigRequest true "Request body"
+// @Success 201 {object} codersdk.ChatModelConfig
+// @Router /api/experimental/chats/model-configs [post]
+// @Description Experimental: this endpoint is subject to change.
 func (api *API) createChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	apiKey := httpmw.APIKey(r)
@@ -7036,6 +7454,19 @@ func (api *API) createChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 	httpapi.Write(ctx, rw, http.StatusCreated, convertChatModelConfig(inserted))
 }
 
+// EXPERIMENTAL: this endpoint is experimental and is subject to change.
+//
+// @Summary Update chat model config
+// @ID update-chat-model-config
+// @Security CoderSessionToken
+// @Tags Chats
+// @Accept json
+// @Produce json
+// @Param modelConfig path string true "Model config ID" format(uuid)
+// @Param request body codersdk.UpdateChatModelConfigRequest true "Request body"
+// @Success 200 {object} codersdk.ChatModelConfig
+// @Router /api/experimental/chats/model-configs/{modelConfig} [patch]
+// @Description Experimental: this endpoint is subject to change.
 func (api *API) updateChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	apiKey := httpmw.APIKey(r)
@@ -7223,6 +7654,16 @@ func (api *API) updateChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 	httpapi.Write(ctx, rw, http.StatusOK, convertChatModelConfig(updated))
 }
 
+// EXPERIMENTAL: this endpoint is experimental and is subject to change.
+//
+// @Summary Delete chat model config
+// @ID delete-chat-model-config
+// @Security CoderSessionToken
+// @Tags Chats
+// @Param modelConfig path string true "Model config ID" format(uuid)
+// @Success 204
+// @Router /api/experimental/chats/model-configs/{modelConfig} [delete]
+// @Description Experimental: this endpoint is subject to change.
 func (api *API) deleteChatModelConfig(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	if !api.Authorize(r, policy.ActionUpdate, rbac.ResourceDeploymentConfig) {
@@ -7974,6 +8415,17 @@ func (api *API) prInsights(rw http.ResponseWriter, r *http.Request) {
 
 // EXPERIMENTAL: this endpoint is experimental and is subject to change.
 //
+// @Summary Submit chat tool results
+// @ID submit-chat-tool-results
+// @Security CoderSessionToken
+// @Tags Chats
+// @Accept json
+// @Param chat path string true "Chat ID" format(uuid)
+// @Param request body codersdk.SubmitToolResultsRequest true "Request body"
+// @Success 204
+// @Router /api/experimental/chats/{chat}/tool-results [post]
+// @Description Experimental: this endpoint is subject to change.
+//
 //nolint:revive // HTTP handler writes to ResponseWriter.
 func (api *API) postChatToolResults(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -8076,6 +8528,16 @@ func (api *API) postChatToolResults(rw http.ResponseWriter, r *http.Request) {
 // getChatDebugRuns returns a list of debug run summaries for a chat.
 // EXPERIMENTAL
 //
+// @Summary Get chat debug runs
+// @ID get-chat-debug-runs
+// @Security CoderSessionToken
+// @Tags Chats
+// @Produce json
+// @Param chat path string true "Chat ID" format(uuid)
+// @Success 200 {array} codersdk.ChatDebugRunSummary
+// @Router /api/experimental/chats/{chat}/debug/runs [get]
+// @Description Experimental: this endpoint is subject to change.
+//
 //nolint:revive // get-return: revive assumes get* must be a getter, but this is an HTTP handler.
 func (api *API) getChatDebugRuns(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -8111,6 +8573,17 @@ func (api *API) getChatDebugRuns(rw http.ResponseWriter, r *http.Request) {
 
 // getChatDebugRun returns a single debug run with its steps.
 // EXPERIMENTAL
+//
+// @Summary Get chat debug run
+// @ID get-chat-debug-run
+// @Security CoderSessionToken
+// @Tags Chats
+// @Produce json
+// @Param chat path string true "Chat ID" format(uuid)
+// @Param debugRun path string true "Debug run ID" format(uuid)
+// @Success 200 {object} codersdk.ChatDebugRun
+// @Router /api/experimental/chats/{chat}/debug/runs/{debugRun} [get]
+// @Description Experimental: this endpoint is subject to change.
 //
 //nolint:revive // get-return: revive assumes get* must be a getter, but this is an HTTP handler.
 func (api *API) getChatDebugRun(rw http.ResponseWriter, r *http.Request) {

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -944,7 +944,7 @@ type ChatDebugStep struct {
 }
 
 // DefaultChatWorkspaceTTL is the default TTL for chat workspaces.
-// Zero means disabled — the template's own autostop setting applies.
+// Zero means disabled, so the template's own autostop setting applies.
 const DefaultChatWorkspaceTTL = 0
 
 // DefaultChatAutoArchiveDays is the default auto-archive window, in
@@ -961,7 +961,7 @@ const DefaultChatDebugRetentionDays int32 = 30
 // workspace TTL setting.
 type ChatWorkspaceTTLResponse struct {
 	// WorkspaceTTLMillis is the workspace TTL in milliseconds.
-	// Zero means disabled — the template's own autostop setting applies.
+	// Zero means disabled, so the template's own autostop setting applies.
 	WorkspaceTTLMillis int64 `json:"workspace_ttl_ms"`
 }
 
@@ -969,7 +969,7 @@ type ChatWorkspaceTTLResponse struct {
 // workspace TTL setting.
 type UpdateChatWorkspaceTTLRequest struct {
 	// WorkspaceTTLMillis is the workspace TTL in milliseconds.
-	// Zero means disabled — the template's own autostop setting applies.
+	// Zero means disabled, so the template's own autostop setting applies.
 	WorkspaceTTLMillis int64 `json:"workspace_ttl_ms"`
 }
 

--- a/docs/reference/api/chats.md
+++ b/docs/reference/api/chats.md
@@ -622,6 +622,1127 @@ Experimental: this endpoint is subject to change.
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
+## Get chat advisor config
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/experimental/chats/config/advisor \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /api/experimental/chats/config/advisor`
+
+Experimental: this endpoint is subject to change.
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "enabled": true,
+  "max_output_tokens": 0,
+  "max_uses_per_run": 0,
+  "model_config_id": "f5fb4d91-62ca-4377-9ee6-5d43ba00d205"
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                     |
+|--------|---------------------------------------------------------|-------------|------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.AdvisorConfig](schemas.md#codersdkadvisorconfig) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Update chat advisor config
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X PUT http://coder-server:8080/api/experimental/chats/config/advisor \
+  -H 'Content-Type: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`PUT /api/experimental/chats/config/advisor`
+
+Experimental: this endpoint is subject to change.
+
+> Body parameter
+
+```json
+{
+  "enabled": true,
+  "max_output_tokens": 0,
+  "max_uses_per_run": 0,
+  "model_config_id": "f5fb4d91-62ca-4377-9ee6-5d43ba00d205"
+}
+```
+
+### Parameters
+
+| Name   | In   | Type                                                                                 | Required | Description  |
+|--------|------|--------------------------------------------------------------------------------------|----------|--------------|
+| `body` | body | [codersdk.UpdateAdvisorConfigRequest](schemas.md#codersdkupdateadvisorconfigrequest) | true     | Request body |
+
+### Responses
+
+| Status | Meaning                                                         | Description | Schema |
+|--------|-----------------------------------------------------------------|-------------|--------|
+| 204    | [No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5) | No Content  |        |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Get chat auto archive days
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/experimental/chats/config/auto-archive-days \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /api/experimental/chats/config/auto-archive-days`
+
+Experimental: this endpoint is subject to change.
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "auto_archive_days": 0
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                                 |
+|--------|---------------------------------------------------------|-------------|----------------------------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.ChatAutoArchiveDaysResponse](schemas.md#codersdkchatautoarchivedaysresponse) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Update chat auto archive days
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X PUT http://coder-server:8080/api/experimental/chats/config/auto-archive-days \
+  -H 'Content-Type: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`PUT /api/experimental/chats/config/auto-archive-days`
+
+Experimental: this endpoint is subject to change.
+
+> Body parameter
+
+```json
+{
+  "auto_archive_days": 0
+}
+```
+
+### Parameters
+
+| Name   | In   | Type                                                                                             | Required | Description  |
+|--------|------|--------------------------------------------------------------------------------------------------|----------|--------------|
+| `body` | body | [codersdk.UpdateChatAutoArchiveDaysRequest](schemas.md#codersdkupdatechatautoarchivedaysrequest) | true     | Request body |
+
+### Responses
+
+| Status | Meaning                                                         | Description | Schema |
+|--------|-----------------------------------------------------------------|-------------|--------|
+| 204    | [No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5) | No Content  |        |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Get chat computer use provider
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/experimental/chats/config/computer-use-provider \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /api/experimental/chats/config/computer-use-provider`
+
+Experimental: this endpoint is subject to change.
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "provider": "string"
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                                         |
+|--------|---------------------------------------------------------|-------------|------------------------------------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.ChatComputerUseProviderResponse](schemas.md#codersdkchatcomputeruseproviderresponse) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Update chat computer use provider
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X PUT http://coder-server:8080/api/experimental/chats/config/computer-use-provider \
+  -H 'Content-Type: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`PUT /api/experimental/chats/config/computer-use-provider`
+
+Experimental: this endpoint is subject to change.
+
+> Body parameter
+
+```json
+{
+  "provider": "string"
+}
+```
+
+### Parameters
+
+| Name   | In   | Type                                                                                                     | Required | Description  |
+|--------|------|----------------------------------------------------------------------------------------------------------|----------|--------------|
+| `body` | body | [codersdk.UpdateChatComputerUseProviderRequest](schemas.md#codersdkupdatechatcomputeruseproviderrequest) | true     | Request body |
+
+### Responses
+
+| Status | Meaning                                                         | Description | Schema |
+|--------|-----------------------------------------------------------------|-------------|--------|
+| 204    | [No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5) | No Content  |        |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Get chat debug logging
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/experimental/chats/config/debug-logging \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /api/experimental/chats/config/debug-logging`
+
+Experimental: this endpoint is subject to change.
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "allow_users": true,
+  "forced_by_deployment": true
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                                     |
+|--------|---------------------------------------------------------|-------------|--------------------------------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.ChatDebugLoggingAdminSettings](schemas.md#codersdkchatdebugloggingadminsettings) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Update chat debug logging
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X PUT http://coder-server:8080/api/experimental/chats/config/debug-logging \
+  -H 'Content-Type: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`PUT /api/experimental/chats/config/debug-logging`
+
+Experimental: this endpoint is subject to change.
+
+> Body parameter
+
+```json
+{
+  "allow_users": true
+}
+```
+
+### Parameters
+
+| Name   | In   | Type                                                                                                           | Required | Description  |
+|--------|------|----------------------------------------------------------------------------------------------------------------|----------|--------------|
+| `body` | body | [codersdk.UpdateChatDebugLoggingAllowUsersRequest](schemas.md#codersdkupdatechatdebugloggingallowusersrequest) | true     | Request body |
+
+### Responses
+
+| Status | Meaning                                                         | Description | Schema |
+|--------|-----------------------------------------------------------------|-------------|--------|
+| 204    | [No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5) | No Content  |        |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Get chat debug retention days
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/experimental/chats/config/debug-retention-days \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /api/experimental/chats/config/debug-retention-days`
+
+Experimental: this endpoint is subject to change.
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "debug_retention_days": 0
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                                       |
+|--------|---------------------------------------------------------|-------------|----------------------------------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.ChatDebugRetentionDaysResponse](schemas.md#codersdkchatdebugretentiondaysresponse) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Update chat debug retention days
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X PUT http://coder-server:8080/api/experimental/chats/config/debug-retention-days \
+  -H 'Content-Type: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`PUT /api/experimental/chats/config/debug-retention-days`
+
+Experimental: this endpoint is subject to change.
+
+> Body parameter
+
+```json
+{
+  "debug_retention_days": 0
+}
+```
+
+### Parameters
+
+| Name   | In   | Type                                                                                                   | Required | Description  |
+|--------|------|--------------------------------------------------------------------------------------------------------|----------|--------------|
+| `body` | body | [codersdk.UpdateChatDebugRetentionDaysRequest](schemas.md#codersdkupdatechatdebugretentiondaysrequest) | true     | Request body |
+
+### Responses
+
+| Status | Meaning                                                         | Description | Schema |
+|--------|-----------------------------------------------------------------|-------------|--------|
+| 204    | [No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5) | No Content  |        |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Get chat desktop enabled
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/experimental/chats/config/desktop-enabled \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /api/experimental/chats/config/desktop-enabled`
+
+Experimental: this endpoint is subject to change.
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "enable_desktop": true
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                               |
+|--------|---------------------------------------------------------|-------------|--------------------------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.ChatDesktopEnabledResponse](schemas.md#codersdkchatdesktopenabledresponse) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Update chat desktop enabled
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X PUT http://coder-server:8080/api/experimental/chats/config/desktop-enabled \
+  -H 'Content-Type: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`PUT /api/experimental/chats/config/desktop-enabled`
+
+Experimental: this endpoint is subject to change.
+
+> Body parameter
+
+```json
+{
+  "enable_desktop": true
+}
+```
+
+### Parameters
+
+| Name   | In   | Type                                                                                           | Required | Description  |
+|--------|------|------------------------------------------------------------------------------------------------|----------|--------------|
+| `body` | body | [codersdk.UpdateChatDesktopEnabledRequest](schemas.md#codersdkupdatechatdesktopenabledrequest) | true     | Request body |
+
+### Responses
+
+| Status | Meaning                                                         | Description | Schema |
+|--------|-----------------------------------------------------------------|-------------|--------|
+| 204    | [No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5) | No Content  |        |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Get chat model override
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/experimental/chats/config/model-override/{context} \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /api/experimental/chats/config/model-override/{context}`
+
+Experimental: this endpoint is subject to change.
+
+### Parameters
+
+| Name      | In   | Type   | Required | Description      |
+|-----------|------|--------|----------|------------------|
+| `context` | path | string | true     | Override context |
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "context": "general",
+  "is_malformed": true,
+  "model_config_id": "string"
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                             |
+|--------|---------------------------------------------------------|-------------|------------------------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.ChatModelOverrideResponse](schemas.md#codersdkchatmodeloverrideresponse) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Update chat model override
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X PUT http://coder-server:8080/api/experimental/chats/config/model-override/{context} \
+  -H 'Content-Type: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`PUT /api/experimental/chats/config/model-override/{context}`
+
+Experimental: this endpoint is subject to change.
+
+> Body parameter
+
+```json
+{
+  "model_config_id": "string"
+}
+```
+
+### Parameters
+
+| Name      | In   | Type                                                                                         | Required | Description      |
+|-----------|------|----------------------------------------------------------------------------------------------|----------|------------------|
+| `context` | path | string                                                                                       | true     | Override context |
+| `body`    | body | [codersdk.UpdateChatModelOverrideRequest](schemas.md#codersdkupdatechatmodeloverriderequest) | true     | Request body     |
+
+### Responses
+
+| Status | Meaning                                                         | Description | Schema |
+|--------|-----------------------------------------------------------------|-------------|--------|
+| 204    | [No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5) | No Content  |        |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Get chat personal model overrides admin settings
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/experimental/chats/config/personal-model-overrides \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /api/experimental/chats/config/personal-model-overrides`
+
+Experimental: this endpoint is subject to change.
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "allow_users": true
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                                                         |
+|--------|---------------------------------------------------------|-------------|----------------------------------------------------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.ChatPersonalModelOverridesAdminSettings](schemas.md#codersdkchatpersonalmodeloverridesadminsettings) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Update chat personal model overrides admin settings
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X PUT http://coder-server:8080/api/experimental/chats/config/personal-model-overrides \
+  -H 'Content-Type: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`PUT /api/experimental/chats/config/personal-model-overrides`
+
+Experimental: this endpoint is subject to change.
+
+> Body parameter
+
+```json
+{
+  "allow_users": true
+}
+```
+
+### Parameters
+
+| Name   | In   | Type                                                                                                                                     | Required | Description  |
+|--------|------|------------------------------------------------------------------------------------------------------------------------------------------|----------|--------------|
+| `body` | body | [codersdk.UpdateChatPersonalModelOverridesAdminSettingsRequest](schemas.md#codersdkupdatechatpersonalmodeloverridesadminsettingsrequest) | true     | Request body |
+
+### Responses
+
+| Status | Meaning                                                         | Description | Schema |
+|--------|-----------------------------------------------------------------|-------------|--------|
+| 204    | [No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5) | No Content  |        |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Get chat plan mode instructions
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/experimental/chats/config/plan-mode-instructions \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /api/experimental/chats/config/plan-mode-instructions`
+
+Experimental: this endpoint is subject to change.
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "plan_mode_instructions": "string"
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                                           |
+|--------|---------------------------------------------------------|-------------|--------------------------------------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.ChatPlanModeInstructionsResponse](schemas.md#codersdkchatplanmodeinstructionsresponse) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Update chat plan mode instructions
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X PUT http://coder-server:8080/api/experimental/chats/config/plan-mode-instructions \
+  -H 'Content-Type: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`PUT /api/experimental/chats/config/plan-mode-instructions`
+
+Experimental: this endpoint is subject to change.
+
+> Body parameter
+
+```json
+{
+  "plan_mode_instructions": "string"
+}
+```
+
+### Parameters
+
+| Name   | In   | Type                                                                                                       | Required | Description  |
+|--------|------|------------------------------------------------------------------------------------------------------------|----------|--------------|
+| `body` | body | [codersdk.UpdateChatPlanModeInstructionsRequest](schemas.md#codersdkupdatechatplanmodeinstructionsrequest) | true     | Request body |
+
+### Responses
+
+| Status | Meaning                                                         | Description | Schema |
+|--------|-----------------------------------------------------------------|-------------|--------|
+| 204    | [No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5) | No Content  |        |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Get chat system prompt
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/experimental/chats/config/system-prompt \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /api/experimental/chats/config/system-prompt`
+
+Experimental: this endpoint is subject to change.
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "default_system_prompt": "string",
+  "include_default_system_prompt": true,
+  "system_prompt": "string"
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                           |
+|--------|---------------------------------------------------------|-------------|----------------------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.ChatSystemPromptResponse](schemas.md#codersdkchatsystempromptresponse) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Update chat system prompt
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X PUT http://coder-server:8080/api/experimental/chats/config/system-prompt \
+  -H 'Content-Type: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`PUT /api/experimental/chats/config/system-prompt`
+
+Experimental: this endpoint is subject to change.
+
+> Body parameter
+
+```json
+{
+  "include_default_system_prompt": true,
+  "system_prompt": "string"
+}
+```
+
+### Parameters
+
+| Name   | In   | Type                                                                                       | Required | Description  |
+|--------|------|--------------------------------------------------------------------------------------------|----------|--------------|
+| `body` | body | [codersdk.UpdateChatSystemPromptRequest](schemas.md#codersdkupdatechatsystempromptrequest) | true     | Request body |
+
+### Responses
+
+| Status | Meaning                                                         | Description | Schema |
+|--------|-----------------------------------------------------------------|-------------|--------|
+| 204    | [No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5) | No Content  |        |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Get chat template allowlist
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/experimental/chats/config/template-allowlist \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /api/experimental/chats/config/template-allowlist`
+
+Experimental: this endpoint is subject to change.
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "template_ids": [
+    "string"
+  ]
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                     |
+|--------|---------------------------------------------------------|-------------|----------------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.ChatTemplateAllowlist](schemas.md#codersdkchattemplateallowlist) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Update chat template allowlist
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X PUT http://coder-server:8080/api/experimental/chats/config/template-allowlist \
+  -H 'Content-Type: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`PUT /api/experimental/chats/config/template-allowlist`
+
+Experimental: this endpoint is subject to change.
+
+> Body parameter
+
+```json
+{
+  "template_ids": [
+    "string"
+  ]
+}
+```
+
+### Parameters
+
+| Name   | In   | Type                                                                       | Required | Description  |
+|--------|------|----------------------------------------------------------------------------|----------|--------------|
+| `body` | body | [codersdk.ChatTemplateAllowlist](schemas.md#codersdkchattemplateallowlist) | true     | Request body |
+
+### Responses
+
+| Status | Meaning                                                         | Description | Schema |
+|--------|-----------------------------------------------------------------|-------------|--------|
+| 204    | [No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5) | No Content  |        |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Get user chat debug logging
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/experimental/chats/config/user-debug-logging \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /api/experimental/chats/config/user-debug-logging`
+
+Experimental: this endpoint is subject to change.
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "debug_logging_enabled": true,
+  "forced_by_deployment": true,
+  "user_toggle_allowed": true
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                                   |
+|--------|---------------------------------------------------------|-------------|------------------------------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.UserChatDebugLoggingSettings](schemas.md#codersdkuserchatdebugloggingsettings) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Update user chat debug logging
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X PUT http://coder-server:8080/api/experimental/chats/config/user-debug-logging \
+  -H 'Content-Type: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`PUT /api/experimental/chats/config/user-debug-logging`
+
+Experimental: this endpoint is subject to change.
+
+> Body parameter
+
+```json
+{
+  "debug_logging_enabled": true
+}
+```
+
+### Parameters
+
+| Name   | In   | Type                                                                                               | Required | Description  |
+|--------|------|----------------------------------------------------------------------------------------------------|----------|--------------|
+| `body` | body | [codersdk.UpdateUserChatDebugLoggingRequest](schemas.md#codersdkupdateuserchatdebugloggingrequest) | true     | Request body |
+
+### Responses
+
+| Status | Meaning                                                         | Description | Schema |
+|--------|-----------------------------------------------------------------|-------------|--------|
+| 204    | [No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5) | No Content  |        |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Get user chat personal model overrides
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/experimental/chats/config/user-personal-model-overrides \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /api/experimental/chats/config/user-personal-model-overrides`
+
+Experimental: this endpoint is subject to change.
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "deployment_defaults": {
+    "explore": {
+      "context": "general",
+      "is_malformed": true,
+      "model_config_id": "string"
+    },
+    "general": {
+      "context": "general",
+      "is_malformed": true,
+      "model_config_id": "string"
+    }
+  },
+  "enabled": true,
+  "explore": {
+    "context": "root",
+    "is_malformed": true,
+    "is_set": true,
+    "mode": "deployment_default",
+    "model_config_id": "string"
+  },
+  "general": {
+    "context": "root",
+    "is_malformed": true,
+    "is_set": true,
+    "mode": "deployment_default",
+    "model_config_id": "string"
+  },
+  "root": {
+    "context": "root",
+    "is_malformed": true,
+    "is_set": true,
+    "mode": "deployment_default",
+    "model_config_id": "string"
+  }
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                                                       |
+|--------|---------------------------------------------------------|-------------|--------------------------------------------------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.UserChatPersonalModelOverridesResponse](schemas.md#codersdkuserchatpersonalmodeloverridesresponse) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Update user chat personal model override
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X PUT http://coder-server:8080/api/experimental/chats/config/user-personal-model-overrides/{context} \
+  -H 'Content-Type: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`PUT /api/experimental/chats/config/user-personal-model-overrides/{context}`
+
+Experimental: this endpoint is subject to change.
+
+> Body parameter
+
+```json
+{
+  "mode": "deployment_default",
+  "model_config_id": "string"
+}
+```
+
+### Parameters
+
+| Name      | In   | Type                                                                                                                 | Required | Description      |
+|-----------|------|----------------------------------------------------------------------------------------------------------------------|----------|------------------|
+| `context` | path | string                                                                                                               | true     | Override context |
+| `body`    | body | [codersdk.UpdateUserChatPersonalModelOverrideRequest](schemas.md#codersdkupdateuserchatpersonalmodeloverriderequest) | true     | Request body     |
+
+### Responses
+
+| Status | Meaning                                                         | Description | Schema |
+|--------|-----------------------------------------------------------------|-------------|--------|
+| 204    | [No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5) | No Content  |        |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Get user chat custom prompt
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/experimental/chats/config/user-prompt \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /api/experimental/chats/config/user-prompt`
+
+Experimental: this endpoint is subject to change.
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "custom_prompt": "string"
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                   |
+|--------|---------------------------------------------------------|-------------|--------------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.UserChatCustomPrompt](schemas.md#codersdkuserchatcustomprompt) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Update user chat custom prompt
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X PUT http://coder-server:8080/api/experimental/chats/config/user-prompt \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`PUT /api/experimental/chats/config/user-prompt`
+
+Experimental: this endpoint is subject to change.
+
+> Body parameter
+
+```json
+{
+  "custom_prompt": "string"
+}
+```
+
+### Parameters
+
+| Name   | In   | Type                                                                     | Required | Description  |
+|--------|------|--------------------------------------------------------------------------|----------|--------------|
+| `body` | body | [codersdk.UserChatCustomPrompt](schemas.md#codersdkuserchatcustomprompt) | true     | Request body |
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "custom_prompt": "string"
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                   |
+|--------|---------------------------------------------------------|-------------|--------------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.UserChatCustomPrompt](schemas.md#codersdkuserchatcustomprompt) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Get chat workspace TTL
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/experimental/chats/config/workspace-ttl \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /api/experimental/chats/config/workspace-ttl`
+
+Experimental: this endpoint is subject to change.
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "workspace_ttl_ms": 0
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                           |
+|--------|---------------------------------------------------------|-------------|----------------------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.ChatWorkspaceTTLResponse](schemas.md#codersdkchatworkspacettlresponse) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Update chat workspace TTL
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X PUT http://coder-server:8080/api/experimental/chats/config/workspace-ttl \
+  -H 'Content-Type: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`PUT /api/experimental/chats/config/workspace-ttl`
+
+Experimental: this endpoint is subject to change.
+
+> Body parameter
+
+```json
+{
+  "workspace_ttl_ms": 0
+}
+```
+
+### Parameters
+
+| Name   | In   | Type                                                                                       | Required | Description  |
+|--------|------|--------------------------------------------------------------------------------------------|----------|--------------|
+| `body` | body | [codersdk.UpdateChatWorkspaceTTLRequest](schemas.md#codersdkupdatechatworkspacettlrequest) | true     | Request body |
+
+### Responses
+
+| Status | Meaning                                                         | Description | Schema |
+|--------|-----------------------------------------------------------------|-------------|--------|
+| 204    | [No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5) | No Content  |        |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
 ## Upload chat file
 
 ### Code samples
@@ -689,6 +1810,1091 @@ Experimental: this endpoint is subject to change.
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
+## List chat model configs
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/experimental/chats/model-configs \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /api/experimental/chats/model-configs`
+
+Experimental: this endpoint is subject to change.
+
+### Example responses
+
+> 200 Response
+
+```json
+[
+  {
+    "compression_threshold": 0,
+    "context_limit": 0,
+    "created_at": "2019-08-24T14:15:22Z",
+    "display_name": "string",
+    "enabled": true,
+    "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+    "is_default": true,
+    "model": "string",
+    "model_config": {
+      "cost": {
+        "cache_read_price_per_million_tokens": 0,
+        "cache_write_price_per_million_tokens": 0,
+        "input_price_per_million_tokens": 0,
+        "output_price_per_million_tokens": 0
+      },
+      "frequency_penalty": 0,
+      "max_output_tokens": 0,
+      "presence_penalty": 0,
+      "provider_options": {
+        "anthropic": {
+          "allowed_domains": [
+            "string"
+          ],
+          "blocked_domains": [
+            "string"
+          ],
+          "disable_parallel_tool_use": true,
+          "effort": "string",
+          "send_reasoning": true,
+          "thinking": {
+            "budget_tokens": 0
+          },
+          "web_search_enabled": true
+        },
+        "google": {
+          "cached_content": "string",
+          "safety_settings": [
+            {
+              "category": "string",
+              "threshold": "string"
+            }
+          ],
+          "thinking_config": {
+            "include_thoughts": true,
+            "thinking_budget": 0
+          },
+          "threshold": "string",
+          "web_search_enabled": true
+        },
+        "openai": {
+          "allowed_domains": [
+            "string"
+          ],
+          "include": [
+            "string"
+          ],
+          "instructions": "string",
+          "log_probs": true,
+          "logit_bias": {
+            "property1": 0,
+            "property2": 0
+          },
+          "max_completion_tokens": 0,
+          "max_tool_calls": 0,
+          "metadata": {
+            "property1": null,
+            "property2": null
+          },
+          "parallel_tool_calls": true,
+          "prediction": {
+            "property1": null,
+            "property2": null
+          },
+          "prompt_cache_key": "string",
+          "reasoning_effort": "string",
+          "reasoning_summary": "string",
+          "safety_identifier": "string",
+          "search_context_size": "string",
+          "service_tier": "string",
+          "store": true,
+          "strict_json_schema": true,
+          "structured_outputs": true,
+          "text_verbosity": "string",
+          "top_log_probs": 0,
+          "user": "string",
+          "web_search_enabled": true
+        },
+        "openaicompat": {
+          "reasoning_effort": "string",
+          "user": "string"
+        },
+        "openrouter": {
+          "extra_body": {
+            "property1": null,
+            "property2": null
+          },
+          "include_usage": true,
+          "log_probs": true,
+          "logit_bias": {
+            "property1": 0,
+            "property2": 0
+          },
+          "parallel_tool_calls": true,
+          "provider": {
+            "allow_fallbacks": true,
+            "data_collection": "string",
+            "ignore": [
+              "string"
+            ],
+            "only": [
+              "string"
+            ],
+            "order": [
+              "string"
+            ],
+            "quantizations": [
+              "string"
+            ],
+            "require_parameters": true,
+            "sort": "string"
+          },
+          "reasoning": {
+            "effort": "string",
+            "enabled": true,
+            "exclude": true,
+            "max_tokens": 0
+          },
+          "user": "string"
+        },
+        "vercel": {
+          "extra_body": {
+            "property1": null,
+            "property2": null
+          },
+          "logit_bias": {
+            "property1": 0,
+            "property2": 0
+          },
+          "logprobs": true,
+          "parallel_tool_calls": true,
+          "providerOptions": {
+            "models": [
+              "string"
+            ],
+            "order": [
+              "string"
+            ]
+          },
+          "reasoning": {
+            "effort": "string",
+            "enabled": true,
+            "exclude": true,
+            "max_tokens": 0
+          },
+          "top_logprobs": 0,
+          "user": "string"
+        }
+      },
+      "temperature": 0,
+      "top_k": 0,
+      "top_p": 0
+    },
+    "provider": "string",
+    "updated_at": "2019-08-24T14:15:22Z"
+  }
+]
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                  |
+|--------|---------------------------------------------------------|-------------|-------------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | array of [codersdk.ChatModelConfig](schemas.md#codersdkchatmodelconfig) |
+
+<h3 id="list-chat-model-configs-responseschema">Response Schema</h3>
+
+Status Code **200**
+
+| Name                                       | Type                                                                                                       | Required | Restrictions | Description |
+|--------------------------------------------|------------------------------------------------------------------------------------------------------------|----------|--------------|-------------|
+| `[array item]`                             | array                                                                                                      | false    |              |             |
+| `» compression_threshold`                  | integer                                                                                                    | false    |              |             |
+| `» context_limit`                          | integer                                                                                                    | false    |              |             |
+| `» created_at`                             | string(date-time)                                                                                          | false    |              |             |
+| `» display_name`                           | string                                                                                                     | false    |              |             |
+| `» enabled`                                | boolean                                                                                                    | false    |              |             |
+| `» id`                                     | string(uuid)                                                                                               | false    |              |             |
+| `» is_default`                             | boolean                                                                                                    | false    |              |             |
+| `» model`                                  | string                                                                                                     | false    |              |             |
+| `» model_config`                           | [codersdk.ChatModelCallConfig](schemas.md#codersdkchatmodelcallconfig)                                     | false    |              |             |
+| `»» cost`                                  | [codersdk.ModelCostConfig](schemas.md#codersdkmodelcostconfig)                                             | false    |              |             |
+| `»»» cache_read_price_per_million_tokens`  | number                                                                                                     | false    |              |             |
+| `»»» cache_write_price_per_million_tokens` | number                                                                                                     | false    |              |             |
+| `»»» input_price_per_million_tokens`       | number                                                                                                     | false    |              |             |
+| `»»» output_price_per_million_tokens`      | number                                                                                                     | false    |              |             |
+| `»» frequency_penalty`                     | number                                                                                                     | false    |              |             |
+| `»» max_output_tokens`                     | integer                                                                                                    | false    |              |             |
+| `»» presence_penalty`                      | number                                                                                                     | false    |              |             |
+| `»» provider_options`                      | [codersdk.ChatModelProviderOptions](schemas.md#codersdkchatmodelprovideroptions)                           | false    |              |             |
+| `»»» anthropic`                            | [codersdk.ChatModelAnthropicProviderOptions](schemas.md#codersdkchatmodelanthropicprovideroptions)         | false    |              |             |
+| `»»»» allowed_domains`                     | array                                                                                                      | false    |              |             |
+| `»»»» blocked_domains`                     | array                                                                                                      | false    |              |             |
+| `»»»» disable_parallel_tool_use`           | boolean                                                                                                    | false    |              |             |
+| `»»»» effort`                              | string                                                                                                     | false    |              |             |
+| `»»»» send_reasoning`                      | boolean                                                                                                    | false    |              |             |
+| `»»»» thinking`                            | [codersdk.ChatModelAnthropicThinkingOptions](schemas.md#codersdkchatmodelanthropicthinkingoptions)         | false    |              |             |
+| `»»»»» budget_tokens`                      | integer                                                                                                    | false    |              |             |
+| `»»»» web_search_enabled`                  | boolean                                                                                                    | false    |              |             |
+| `»»» google`                               | [codersdk.ChatModelGoogleProviderOptions](schemas.md#codersdkchatmodelgoogleprovideroptions)               | false    |              |             |
+| `»»»» cached_content`                      | string                                                                                                     | false    |              |             |
+| `»»»» safety_settings`                     | array                                                                                                      | false    |              |             |
+| `»»»»» category`                           | string                                                                                                     | false    |              |             |
+| `»»»»» threshold`                          | string                                                                                                     | false    |              |             |
+| `»»»» thinking_config`                     | [codersdk.ChatModelGoogleThinkingConfig](schemas.md#codersdkchatmodelgooglethinkingconfig)                 | false    |              |             |
+| `»»»»» include_thoughts`                   | boolean                                                                                                    | false    |              |             |
+| `»»»»» thinking_budget`                    | integer                                                                                                    | false    |              |             |
+| `»»»» threshold`                           | string                                                                                                     | false    |              |             |
+| `»»»» web_search_enabled`                  | boolean                                                                                                    | false    |              |             |
+| `»»» openai`                               | [codersdk.ChatModelOpenAIProviderOptions](schemas.md#codersdkchatmodelopenaiprovideroptions)               | false    |              |             |
+| `»»»» allowed_domains`                     | array                                                                                                      | false    |              |             |
+| `»»»» include`                             | array                                                                                                      | false    |              |             |
+| `»»»» instructions`                        | string                                                                                                     | false    |              |             |
+| `»»»» log_probs`                           | boolean                                                                                                    | false    |              |             |
+| `»»»» logit_bias`                          | object                                                                                                     | false    |              |             |
+| `»»»»» [any property]`                     | integer(int64)                                                                                             | false    |              |             |
+| `»»»» max_completion_tokens`               | integer                                                                                                    | false    |              |             |
+| `»»»» max_tool_calls`                      | integer                                                                                                    | false    |              |             |
+| `»»»» metadata`                            | object                                                                                                     | false    |              |             |
+| `»»»»» [any property]`                     | any                                                                                                        | false    |              |             |
+| `»»»» parallel_tool_calls`                 | boolean                                                                                                    | false    |              |             |
+| `»»»» prediction`                          | object                                                                                                     | false    |              |             |
+| `»»»»» [any property]`                     | any                                                                                                        | false    |              |             |
+| `»»»» prompt_cache_key`                    | string                                                                                                     | false    |              |             |
+| `»»»» reasoning_effort`                    | string                                                                                                     | false    |              |             |
+| `»»»» reasoning_summary`                   | string                                                                                                     | false    |              |             |
+| `»»»» safety_identifier`                   | string                                                                                                     | false    |              |             |
+| `»»»» search_context_size`                 | string                                                                                                     | false    |              |             |
+| `»»»» service_tier`                        | string                                                                                                     | false    |              |             |
+| `»»»» store`                               | boolean                                                                                                    | false    |              |             |
+| `»»»» strict_json_schema`                  | boolean                                                                                                    | false    |              |             |
+| `»»»» structured_outputs`                  | boolean                                                                                                    | false    |              |             |
+| `»»»» text_verbosity`                      | string                                                                                                     | false    |              |             |
+| `»»»» top_log_probs`                       | integer                                                                                                    | false    |              |             |
+| `»»»» user`                                | string                                                                                                     | false    |              |             |
+| `»»»» web_search_enabled`                  | boolean                                                                                                    | false    |              |             |
+| `»»» openaicompat`                         | [codersdk.ChatModelOpenAICompatProviderOptions](schemas.md#codersdkchatmodelopenaicompatprovideroptions)   | false    |              |             |
+| `»»»» reasoning_effort`                    | string                                                                                                     | false    |              |             |
+| `»»»» user`                                | string                                                                                                     | false    |              |             |
+| `»»» openrouter`                           | [codersdk.ChatModelOpenRouterProviderOptions](schemas.md#codersdkchatmodelopenrouterprovideroptions)       | false    |              |             |
+| `»»»» extra_body`                          | object                                                                                                     | false    |              |             |
+| `»»»»» [any property]`                     | any                                                                                                        | false    |              |             |
+| `»»»» include_usage`                       | boolean                                                                                                    | false    |              |             |
+| `»»»» log_probs`                           | boolean                                                                                                    | false    |              |             |
+| `»»»» logit_bias`                          | object                                                                                                     | false    |              |             |
+| `»»»»» [any property]`                     | integer(int64)                                                                                             | false    |              |             |
+| `»»»» parallel_tool_calls`                 | boolean                                                                                                    | false    |              |             |
+| `»»»» provider`                            | [codersdk.ChatModelOpenRouterProvider](schemas.md#codersdkchatmodelopenrouterprovider)                     | false    |              |             |
+| `»»»»» allow_fallbacks`                    | boolean                                                                                                    | false    |              |             |
+| `»»»»» data_collection`                    | string                                                                                                     | false    |              |             |
+| `»»»»» ignore`                             | array                                                                                                      | false    |              |             |
+| `»»»»» only`                               | array                                                                                                      | false    |              |             |
+| `»»»»» order`                              | array                                                                                                      | false    |              |             |
+| `»»»»» quantizations`                      | array                                                                                                      | false    |              |             |
+| `»»»»» require_parameters`                 | boolean                                                                                                    | false    |              |             |
+| `»»»»» sort`                               | string                                                                                                     | false    |              |             |
+| `»»»» reasoning`                           | [codersdk.ChatModelReasoningOptions](schemas.md#codersdkchatmodelreasoningoptions)                         | false    |              |             |
+| `»»»»» effort`                             | string                                                                                                     | false    |              |             |
+| `»»»»» enabled`                            | boolean                                                                                                    | false    |              |             |
+| `»»»»» exclude`                            | boolean                                                                                                    | false    |              |             |
+| `»»»»» max_tokens`                         | integer                                                                                                    | false    |              |             |
+| `»»»» user`                                | string                                                                                                     | false    |              |             |
+| `»»» vercel`                               | [codersdk.ChatModelVercelProviderOptions](schemas.md#codersdkchatmodelvercelprovideroptions)               | false    |              |             |
+| `»»»» extra_body`                          | object                                                                                                     | false    |              |             |
+| `»»»»» [any property]`                     | any                                                                                                        | false    |              |             |
+| `»»»» logit_bias`                          | object                                                                                                     | false    |              |             |
+| `»»»»» [any property]`                     | integer(int64)                                                                                             | false    |              |             |
+| `»»»» logprobs`                            | boolean                                                                                                    | false    |              |             |
+| `»»»» parallel_tool_calls`                 | boolean                                                                                                    | false    |              |             |
+| `»»»» providerOptions`                     | [codersdk.ChatModelVercelGatewayProviderOptions](schemas.md#codersdkchatmodelvercelgatewayprovideroptions) | false    |              |             |
+| `»»»»» models`                             | array                                                                                                      | false    |              |             |
+| `»»»»» order`                              | array                                                                                                      | false    |              |             |
+| `»»»» reasoning`                           | [codersdk.ChatModelReasoningOptions](schemas.md#codersdkchatmodelreasoningoptions)                         | false    |              |             |
+| `»»»» top_logprobs`                        | integer                                                                                                    | false    |              |             |
+| `»»»» user`                                | string                                                                                                     | false    |              |             |
+| `»» temperature`                           | number                                                                                                     | false    |              |             |
+| `»» top_k`                                 | integer                                                                                                    | false    |              |             |
+| `»» top_p`                                 | number                                                                                                     | false    |              |             |
+| `» provider`                               | string                                                                                                     | false    |              |             |
+| `» updated_at`                             | string(date-time)                                                                                          | false    |              |             |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Create chat model config
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X POST http://coder-server:8080/api/experimental/chats/model-configs \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`POST /api/experimental/chats/model-configs`
+
+Experimental: this endpoint is subject to change.
+
+> Body parameter
+
+```json
+{
+  "compression_threshold": 0,
+  "context_limit": 0,
+  "display_name": "string",
+  "enabled": true,
+  "is_default": true,
+  "model": "string",
+  "model_config": {
+    "cost": {
+      "cache_read_price_per_million_tokens": 0,
+      "cache_write_price_per_million_tokens": 0,
+      "input_price_per_million_tokens": 0,
+      "output_price_per_million_tokens": 0
+    },
+    "frequency_penalty": 0,
+    "max_output_tokens": 0,
+    "presence_penalty": 0,
+    "provider_options": {
+      "anthropic": {
+        "allowed_domains": [
+          "string"
+        ],
+        "blocked_domains": [
+          "string"
+        ],
+        "disable_parallel_tool_use": true,
+        "effort": "string",
+        "send_reasoning": true,
+        "thinking": {
+          "budget_tokens": 0
+        },
+        "web_search_enabled": true
+      },
+      "google": {
+        "cached_content": "string",
+        "safety_settings": [
+          {
+            "category": "string",
+            "threshold": "string"
+          }
+        ],
+        "thinking_config": {
+          "include_thoughts": true,
+          "thinking_budget": 0
+        },
+        "threshold": "string",
+        "web_search_enabled": true
+      },
+      "openai": {
+        "allowed_domains": [
+          "string"
+        ],
+        "include": [
+          "string"
+        ],
+        "instructions": "string",
+        "log_probs": true,
+        "logit_bias": {
+          "property1": 0,
+          "property2": 0
+        },
+        "max_completion_tokens": 0,
+        "max_tool_calls": 0,
+        "metadata": {
+          "property1": null,
+          "property2": null
+        },
+        "parallel_tool_calls": true,
+        "prediction": {
+          "property1": null,
+          "property2": null
+        },
+        "prompt_cache_key": "string",
+        "reasoning_effort": "string",
+        "reasoning_summary": "string",
+        "safety_identifier": "string",
+        "search_context_size": "string",
+        "service_tier": "string",
+        "store": true,
+        "strict_json_schema": true,
+        "structured_outputs": true,
+        "text_verbosity": "string",
+        "top_log_probs": 0,
+        "user": "string",
+        "web_search_enabled": true
+      },
+      "openaicompat": {
+        "reasoning_effort": "string",
+        "user": "string"
+      },
+      "openrouter": {
+        "extra_body": {
+          "property1": null,
+          "property2": null
+        },
+        "include_usage": true,
+        "log_probs": true,
+        "logit_bias": {
+          "property1": 0,
+          "property2": 0
+        },
+        "parallel_tool_calls": true,
+        "provider": {
+          "allow_fallbacks": true,
+          "data_collection": "string",
+          "ignore": [
+            "string"
+          ],
+          "only": [
+            "string"
+          ],
+          "order": [
+            "string"
+          ],
+          "quantizations": [
+            "string"
+          ],
+          "require_parameters": true,
+          "sort": "string"
+        },
+        "reasoning": {
+          "effort": "string",
+          "enabled": true,
+          "exclude": true,
+          "max_tokens": 0
+        },
+        "user": "string"
+      },
+      "vercel": {
+        "extra_body": {
+          "property1": null,
+          "property2": null
+        },
+        "logit_bias": {
+          "property1": 0,
+          "property2": 0
+        },
+        "logprobs": true,
+        "parallel_tool_calls": true,
+        "providerOptions": {
+          "models": [
+            "string"
+          ],
+          "order": [
+            "string"
+          ]
+        },
+        "reasoning": {
+          "effort": "string",
+          "enabled": true,
+          "exclude": true,
+          "max_tokens": 0
+        },
+        "top_logprobs": 0,
+        "user": "string"
+      }
+    },
+    "temperature": 0,
+    "top_k": 0,
+    "top_p": 0
+  },
+  "provider": "string"
+}
+```
+
+### Parameters
+
+| Name   | In   | Type                                                                                     | Required | Description  |
+|--------|------|------------------------------------------------------------------------------------------|----------|--------------|
+| `body` | body | [codersdk.CreateChatModelConfigRequest](schemas.md#codersdkcreatechatmodelconfigrequest) | true     | Request body |
+
+### Example responses
+
+> 201 Response
+
+```json
+{
+  "compression_threshold": 0,
+  "context_limit": 0,
+  "created_at": "2019-08-24T14:15:22Z",
+  "display_name": "string",
+  "enabled": true,
+  "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+  "is_default": true,
+  "model": "string",
+  "model_config": {
+    "cost": {
+      "cache_read_price_per_million_tokens": 0,
+      "cache_write_price_per_million_tokens": 0,
+      "input_price_per_million_tokens": 0,
+      "output_price_per_million_tokens": 0
+    },
+    "frequency_penalty": 0,
+    "max_output_tokens": 0,
+    "presence_penalty": 0,
+    "provider_options": {
+      "anthropic": {
+        "allowed_domains": [
+          "string"
+        ],
+        "blocked_domains": [
+          "string"
+        ],
+        "disable_parallel_tool_use": true,
+        "effort": "string",
+        "send_reasoning": true,
+        "thinking": {
+          "budget_tokens": 0
+        },
+        "web_search_enabled": true
+      },
+      "google": {
+        "cached_content": "string",
+        "safety_settings": [
+          {
+            "category": "string",
+            "threshold": "string"
+          }
+        ],
+        "thinking_config": {
+          "include_thoughts": true,
+          "thinking_budget": 0
+        },
+        "threshold": "string",
+        "web_search_enabled": true
+      },
+      "openai": {
+        "allowed_domains": [
+          "string"
+        ],
+        "include": [
+          "string"
+        ],
+        "instructions": "string",
+        "log_probs": true,
+        "logit_bias": {
+          "property1": 0,
+          "property2": 0
+        },
+        "max_completion_tokens": 0,
+        "max_tool_calls": 0,
+        "metadata": {
+          "property1": null,
+          "property2": null
+        },
+        "parallel_tool_calls": true,
+        "prediction": {
+          "property1": null,
+          "property2": null
+        },
+        "prompt_cache_key": "string",
+        "reasoning_effort": "string",
+        "reasoning_summary": "string",
+        "safety_identifier": "string",
+        "search_context_size": "string",
+        "service_tier": "string",
+        "store": true,
+        "strict_json_schema": true,
+        "structured_outputs": true,
+        "text_verbosity": "string",
+        "top_log_probs": 0,
+        "user": "string",
+        "web_search_enabled": true
+      },
+      "openaicompat": {
+        "reasoning_effort": "string",
+        "user": "string"
+      },
+      "openrouter": {
+        "extra_body": {
+          "property1": null,
+          "property2": null
+        },
+        "include_usage": true,
+        "log_probs": true,
+        "logit_bias": {
+          "property1": 0,
+          "property2": 0
+        },
+        "parallel_tool_calls": true,
+        "provider": {
+          "allow_fallbacks": true,
+          "data_collection": "string",
+          "ignore": [
+            "string"
+          ],
+          "only": [
+            "string"
+          ],
+          "order": [
+            "string"
+          ],
+          "quantizations": [
+            "string"
+          ],
+          "require_parameters": true,
+          "sort": "string"
+        },
+        "reasoning": {
+          "effort": "string",
+          "enabled": true,
+          "exclude": true,
+          "max_tokens": 0
+        },
+        "user": "string"
+      },
+      "vercel": {
+        "extra_body": {
+          "property1": null,
+          "property2": null
+        },
+        "logit_bias": {
+          "property1": 0,
+          "property2": 0
+        },
+        "logprobs": true,
+        "parallel_tool_calls": true,
+        "providerOptions": {
+          "models": [
+            "string"
+          ],
+          "order": [
+            "string"
+          ]
+        },
+        "reasoning": {
+          "effort": "string",
+          "enabled": true,
+          "exclude": true,
+          "max_tokens": 0
+        },
+        "top_logprobs": 0,
+        "user": "string"
+      }
+    },
+    "temperature": 0,
+    "top_k": 0,
+    "top_p": 0
+  },
+  "provider": "string",
+  "updated_at": "2019-08-24T14:15:22Z"
+}
+```
+
+### Responses
+
+| Status | Meaning                                                      | Description | Schema                                                         |
+|--------|--------------------------------------------------------------|-------------|----------------------------------------------------------------|
+| 201    | [Created](https://tools.ietf.org/html/rfc7231#section-6.3.2) | Created     | [codersdk.ChatModelConfig](schemas.md#codersdkchatmodelconfig) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Delete chat model config
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X DELETE http://coder-server:8080/api/experimental/chats/model-configs/{modelConfig} \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`DELETE /api/experimental/chats/model-configs/{modelConfig}`
+
+Experimental: this endpoint is subject to change.
+
+### Parameters
+
+| Name          | In   | Type         | Required | Description     |
+|---------------|------|--------------|----------|-----------------|
+| `modelConfig` | path | string(uuid) | true     | Model config ID |
+
+### Responses
+
+| Status | Meaning                                                         | Description | Schema |
+|--------|-----------------------------------------------------------------|-------------|--------|
+| 204    | [No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5) | No Content  |        |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Update chat model config
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X PATCH http://coder-server:8080/api/experimental/chats/model-configs/{modelConfig} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`PATCH /api/experimental/chats/model-configs/{modelConfig}`
+
+Experimental: this endpoint is subject to change.
+
+> Body parameter
+
+```json
+{
+  "compression_threshold": 0,
+  "context_limit": 0,
+  "display_name": "string",
+  "enabled": true,
+  "is_default": true,
+  "model": "string",
+  "model_config": {
+    "cost": {
+      "cache_read_price_per_million_tokens": 0,
+      "cache_write_price_per_million_tokens": 0,
+      "input_price_per_million_tokens": 0,
+      "output_price_per_million_tokens": 0
+    },
+    "frequency_penalty": 0,
+    "max_output_tokens": 0,
+    "presence_penalty": 0,
+    "provider_options": {
+      "anthropic": {
+        "allowed_domains": [
+          "string"
+        ],
+        "blocked_domains": [
+          "string"
+        ],
+        "disable_parallel_tool_use": true,
+        "effort": "string",
+        "send_reasoning": true,
+        "thinking": {
+          "budget_tokens": 0
+        },
+        "web_search_enabled": true
+      },
+      "google": {
+        "cached_content": "string",
+        "safety_settings": [
+          {
+            "category": "string",
+            "threshold": "string"
+          }
+        ],
+        "thinking_config": {
+          "include_thoughts": true,
+          "thinking_budget": 0
+        },
+        "threshold": "string",
+        "web_search_enabled": true
+      },
+      "openai": {
+        "allowed_domains": [
+          "string"
+        ],
+        "include": [
+          "string"
+        ],
+        "instructions": "string",
+        "log_probs": true,
+        "logit_bias": {
+          "property1": 0,
+          "property2": 0
+        },
+        "max_completion_tokens": 0,
+        "max_tool_calls": 0,
+        "metadata": {
+          "property1": null,
+          "property2": null
+        },
+        "parallel_tool_calls": true,
+        "prediction": {
+          "property1": null,
+          "property2": null
+        },
+        "prompt_cache_key": "string",
+        "reasoning_effort": "string",
+        "reasoning_summary": "string",
+        "safety_identifier": "string",
+        "search_context_size": "string",
+        "service_tier": "string",
+        "store": true,
+        "strict_json_schema": true,
+        "structured_outputs": true,
+        "text_verbosity": "string",
+        "top_log_probs": 0,
+        "user": "string",
+        "web_search_enabled": true
+      },
+      "openaicompat": {
+        "reasoning_effort": "string",
+        "user": "string"
+      },
+      "openrouter": {
+        "extra_body": {
+          "property1": null,
+          "property2": null
+        },
+        "include_usage": true,
+        "log_probs": true,
+        "logit_bias": {
+          "property1": 0,
+          "property2": 0
+        },
+        "parallel_tool_calls": true,
+        "provider": {
+          "allow_fallbacks": true,
+          "data_collection": "string",
+          "ignore": [
+            "string"
+          ],
+          "only": [
+            "string"
+          ],
+          "order": [
+            "string"
+          ],
+          "quantizations": [
+            "string"
+          ],
+          "require_parameters": true,
+          "sort": "string"
+        },
+        "reasoning": {
+          "effort": "string",
+          "enabled": true,
+          "exclude": true,
+          "max_tokens": 0
+        },
+        "user": "string"
+      },
+      "vercel": {
+        "extra_body": {
+          "property1": null,
+          "property2": null
+        },
+        "logit_bias": {
+          "property1": 0,
+          "property2": 0
+        },
+        "logprobs": true,
+        "parallel_tool_calls": true,
+        "providerOptions": {
+          "models": [
+            "string"
+          ],
+          "order": [
+            "string"
+          ]
+        },
+        "reasoning": {
+          "effort": "string",
+          "enabled": true,
+          "exclude": true,
+          "max_tokens": 0
+        },
+        "top_logprobs": 0,
+        "user": "string"
+      }
+    },
+    "temperature": 0,
+    "top_k": 0,
+    "top_p": 0
+  },
+  "provider": "string"
+}
+```
+
+### Parameters
+
+| Name          | In   | Type                                                                                     | Required | Description     |
+|---------------|------|------------------------------------------------------------------------------------------|----------|-----------------|
+| `modelConfig` | path | string(uuid)                                                                             | true     | Model config ID |
+| `body`        | body | [codersdk.UpdateChatModelConfigRequest](schemas.md#codersdkupdatechatmodelconfigrequest) | true     | Request body    |
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "compression_threshold": 0,
+  "context_limit": 0,
+  "created_at": "2019-08-24T14:15:22Z",
+  "display_name": "string",
+  "enabled": true,
+  "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+  "is_default": true,
+  "model": "string",
+  "model_config": {
+    "cost": {
+      "cache_read_price_per_million_tokens": 0,
+      "cache_write_price_per_million_tokens": 0,
+      "input_price_per_million_tokens": 0,
+      "output_price_per_million_tokens": 0
+    },
+    "frequency_penalty": 0,
+    "max_output_tokens": 0,
+    "presence_penalty": 0,
+    "provider_options": {
+      "anthropic": {
+        "allowed_domains": [
+          "string"
+        ],
+        "blocked_domains": [
+          "string"
+        ],
+        "disable_parallel_tool_use": true,
+        "effort": "string",
+        "send_reasoning": true,
+        "thinking": {
+          "budget_tokens": 0
+        },
+        "web_search_enabled": true
+      },
+      "google": {
+        "cached_content": "string",
+        "safety_settings": [
+          {
+            "category": "string",
+            "threshold": "string"
+          }
+        ],
+        "thinking_config": {
+          "include_thoughts": true,
+          "thinking_budget": 0
+        },
+        "threshold": "string",
+        "web_search_enabled": true
+      },
+      "openai": {
+        "allowed_domains": [
+          "string"
+        ],
+        "include": [
+          "string"
+        ],
+        "instructions": "string",
+        "log_probs": true,
+        "logit_bias": {
+          "property1": 0,
+          "property2": 0
+        },
+        "max_completion_tokens": 0,
+        "max_tool_calls": 0,
+        "metadata": {
+          "property1": null,
+          "property2": null
+        },
+        "parallel_tool_calls": true,
+        "prediction": {
+          "property1": null,
+          "property2": null
+        },
+        "prompt_cache_key": "string",
+        "reasoning_effort": "string",
+        "reasoning_summary": "string",
+        "safety_identifier": "string",
+        "search_context_size": "string",
+        "service_tier": "string",
+        "store": true,
+        "strict_json_schema": true,
+        "structured_outputs": true,
+        "text_verbosity": "string",
+        "top_log_probs": 0,
+        "user": "string",
+        "web_search_enabled": true
+      },
+      "openaicompat": {
+        "reasoning_effort": "string",
+        "user": "string"
+      },
+      "openrouter": {
+        "extra_body": {
+          "property1": null,
+          "property2": null
+        },
+        "include_usage": true,
+        "log_probs": true,
+        "logit_bias": {
+          "property1": 0,
+          "property2": 0
+        },
+        "parallel_tool_calls": true,
+        "provider": {
+          "allow_fallbacks": true,
+          "data_collection": "string",
+          "ignore": [
+            "string"
+          ],
+          "only": [
+            "string"
+          ],
+          "order": [
+            "string"
+          ],
+          "quantizations": [
+            "string"
+          ],
+          "require_parameters": true,
+          "sort": "string"
+        },
+        "reasoning": {
+          "effort": "string",
+          "enabled": true,
+          "exclude": true,
+          "max_tokens": 0
+        },
+        "user": "string"
+      },
+      "vercel": {
+        "extra_body": {
+          "property1": null,
+          "property2": null
+        },
+        "logit_bias": {
+          "property1": 0,
+          "property2": 0
+        },
+        "logprobs": true,
+        "parallel_tool_calls": true,
+        "providerOptions": {
+          "models": [
+            "string"
+          ],
+          "order": [
+            "string"
+          ]
+        },
+        "reasoning": {
+          "effort": "string",
+          "enabled": true,
+          "exclude": true,
+          "max_tokens": 0
+        },
+        "top_logprobs": 0,
+        "user": "string"
+      }
+    },
+    "temperature": 0,
+    "top_k": 0,
+    "top_p": 0
+  },
+  "provider": "string",
+  "updated_at": "2019-08-24T14:15:22Z"
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                         |
+|--------|---------------------------------------------------------|-------------|----------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.ChatModelConfig](schemas.md#codersdkchatmodelconfig) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
 ## List chat models
 
 ### Code samples
@@ -733,6 +2939,371 @@ Experimental: this endpoint is subject to change.
 | Status | Meaning                                                 | Description | Schema                                                               |
 |--------|---------------------------------------------------------|-------------|----------------------------------------------------------------------|
 | 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.ChatModelsResponse](schemas.md#codersdkchatmodelsresponse) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## List chat providers
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/experimental/chats/providers \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /api/experimental/chats/providers`
+
+Experimental: this endpoint is subject to change.
+
+### Example responses
+
+> 200 Response
+
+```json
+[
+  {
+    "allow_central_api_key_fallback": true,
+    "allow_user_api_key": true,
+    "base_url": "string",
+    "central_api_key_enabled": true,
+    "created_at": "2019-08-24T14:15:22Z",
+    "display_name": "string",
+    "enabled": true,
+    "has_api_key": true,
+    "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+    "provider": "string",
+    "source": "database",
+    "updated_at": "2019-08-24T14:15:22Z"
+  }
+]
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                        |
+|--------|---------------------------------------------------------|-------------|-------------------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | array of [codersdk.ChatProviderConfig](schemas.md#codersdkchatproviderconfig) |
+
+<h3 id="list-chat-providers-responseschema">Response Schema</h3>
+
+Status Code **200**
+
+| Name                               | Type                                                                             | Required | Restrictions | Description |
+|------------------------------------|----------------------------------------------------------------------------------|----------|--------------|-------------|
+| `[array item]`                     | array                                                                            | false    |              |             |
+| `» allow_central_api_key_fallback` | boolean                                                                          | false    |              |             |
+| `» allow_user_api_key`             | boolean                                                                          | false    |              |             |
+| `» base_url`                       | string                                                                           | false    |              |             |
+| `» central_api_key_enabled`        | boolean                                                                          | false    |              |             |
+| `» created_at`                     | string(date-time)                                                                | false    |              |             |
+| `» display_name`                   | string                                                                           | false    |              |             |
+| `» enabled`                        | boolean                                                                          | false    |              |             |
+| `» has_api_key`                    | boolean                                                                          | false    |              |             |
+| `» id`                             | string(uuid)                                                                     | false    |              |             |
+| `» provider`                       | string                                                                           | false    |              |             |
+| `» source`                         | [codersdk.ChatProviderConfigSource](schemas.md#codersdkchatproviderconfigsource) | false    |              |             |
+| `» updated_at`                     | string(date-time)                                                                | false    |              |             |
+
+#### Enumerated Values
+
+| Property | Value(s)                              |
+|----------|---------------------------------------|
+| `source` | `database`, `env_preset`, `supported` |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Create chat provider
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X POST http://coder-server:8080/api/experimental/chats/providers \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`POST /api/experimental/chats/providers`
+
+Experimental: this endpoint is subject to change.
+
+> Body parameter
+
+```json
+{
+  "allow_central_api_key_fallback": true,
+  "allow_user_api_key": true,
+  "api_key": "string",
+  "base_url": "string",
+  "central_api_key_enabled": true,
+  "display_name": "string",
+  "enabled": true,
+  "provider": "string"
+}
+```
+
+### Parameters
+
+| Name   | In   | Type                                                                                           | Required | Description  |
+|--------|------|------------------------------------------------------------------------------------------------|----------|--------------|
+| `body` | body | [codersdk.CreateChatProviderConfigRequest](schemas.md#codersdkcreatechatproviderconfigrequest) | true     | Request body |
+
+### Example responses
+
+> 201 Response
+
+```json
+{
+  "allow_central_api_key_fallback": true,
+  "allow_user_api_key": true,
+  "base_url": "string",
+  "central_api_key_enabled": true,
+  "created_at": "2019-08-24T14:15:22Z",
+  "display_name": "string",
+  "enabled": true,
+  "has_api_key": true,
+  "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+  "provider": "string",
+  "source": "database",
+  "updated_at": "2019-08-24T14:15:22Z"
+}
+```
+
+### Responses
+
+| Status | Meaning                                                      | Description | Schema                                                               |
+|--------|--------------------------------------------------------------|-------------|----------------------------------------------------------------------|
+| 201    | [Created](https://tools.ietf.org/html/rfc7231#section-6.3.2) | Created     | [codersdk.ChatProviderConfig](schemas.md#codersdkchatproviderconfig) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Delete chat provider
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X DELETE http://coder-server:8080/api/experimental/chats/providers/{providerConfig} \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`DELETE /api/experimental/chats/providers/{providerConfig}`
+
+Experimental: this endpoint is subject to change.
+
+### Parameters
+
+| Name             | In   | Type         | Required | Description        |
+|------------------|------|--------------|----------|--------------------|
+| `providerConfig` | path | string(uuid) | true     | Provider config ID |
+
+### Responses
+
+| Status | Meaning                                                         | Description | Schema |
+|--------|-----------------------------------------------------------------|-------------|--------|
+| 204    | [No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5) | No Content  |        |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Update chat provider
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X PATCH http://coder-server:8080/api/experimental/chats/providers/{providerConfig} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`PATCH /api/experimental/chats/providers/{providerConfig}`
+
+Experimental: this endpoint is subject to change.
+
+> Body parameter
+
+```json
+{
+  "allow_central_api_key_fallback": true,
+  "allow_user_api_key": true,
+  "api_key": "string",
+  "base_url": "string",
+  "central_api_key_enabled": true,
+  "display_name": "string",
+  "enabled": true
+}
+```
+
+### Parameters
+
+| Name             | In   | Type                                                                                           | Required | Description        |
+|------------------|------|------------------------------------------------------------------------------------------------|----------|--------------------|
+| `providerConfig` | path | string(uuid)                                                                                   | true     | Provider config ID |
+| `body`           | body | [codersdk.UpdateChatProviderConfigRequest](schemas.md#codersdkupdatechatproviderconfigrequest) | true     | Request body       |
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "allow_central_api_key_fallback": true,
+  "allow_user_api_key": true,
+  "base_url": "string",
+  "central_api_key_enabled": true,
+  "created_at": "2019-08-24T14:15:22Z",
+  "display_name": "string",
+  "enabled": true,
+  "has_api_key": true,
+  "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+  "provider": "string",
+  "source": "database",
+  "updated_at": "2019-08-24T14:15:22Z"
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                               |
+|--------|---------------------------------------------------------|-------------|----------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.ChatProviderConfig](schemas.md#codersdkchatproviderconfig) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## List user chat provider configs
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/experimental/chats/user-provider-configs \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /api/experimental/chats/user-provider-configs`
+
+Experimental: this endpoint is subject to change.
+
+### Example responses
+
+> 200 Response
+
+```json
+[
+  {
+    "display_name": "string",
+    "has_central_api_key_fallback": true,
+    "has_user_api_key": true,
+    "provider": "string",
+    "provider_id": "fe3d49af-4061-436b-ae60-f7044f252a44"
+  }
+]
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                                |
+|--------|---------------------------------------------------------|-------------|---------------------------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | array of [codersdk.UserChatProviderConfig](schemas.md#codersdkuserchatproviderconfig) |
+
+<h3 id="list-user-chat-provider-configs-responseschema">Response Schema</h3>
+
+Status Code **200**
+
+| Name                             | Type         | Required | Restrictions | Description |
+|----------------------------------|--------------|----------|--------------|-------------|
+| `[array item]`                   | array        | false    |              |             |
+| `» display_name`                 | string       | false    |              |             |
+| `» has_central_api_key_fallback` | boolean      | false    |              |             |
+| `» has_user_api_key`             | boolean      | false    |              |             |
+| `» provider`                     | string       | false    |              |             |
+| `» provider_id`                  | string(uuid) | false    |              |             |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Upsert user chat provider key
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X PUT http://coder-server:8080/api/experimental/chats/user-provider-configs/{providerConfig} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`PUT /api/experimental/chats/user-provider-configs/{providerConfig}`
+
+Experimental: this endpoint is subject to change.
+
+> Body parameter
+
+```json
+{
+  "api_key": "string"
+}
+```
+
+### Parameters
+
+| Name             | In   | Type                                                                                             | Required | Description        |
+|------------------|------|--------------------------------------------------------------------------------------------------|----------|--------------------|
+| `providerConfig` | path | string(uuid)                                                                                     | true     | Provider config ID |
+| `body`           | body | [codersdk.CreateUserChatProviderKeyRequest](schemas.md#codersdkcreateuserchatproviderkeyrequest) | true     | Request body       |
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "display_name": "string",
+  "has_central_api_key_fallback": true,
+  "has_user_api_key": true,
+  "provider": "string",
+  "provider_id": "fe3d49af-4061-436b-ae60-f7044f252a44"
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                       |
+|--------|---------------------------------------------------------|-------------|------------------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.UserChatProviderConfig](schemas.md#codersdkuserchatproviderconfig) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Delete user chat provider key
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X DELETE http://coder-server:8080/api/experimental/chats/user-provider-configs/{providerConfig} \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`DELETE /api/experimental/chats/user-provider-configs/{providerConfig}`
+
+Experimental: this endpoint is subject to change.
+
+### Parameters
+
+| Name             | In   | Type         | Required | Description        |
+|------------------|------|--------------|----------|--------------------|
+| `providerConfig` | path | string(uuid) | true     | Provider config ID |
+
+### Responses
+
+| Status | Meaning                                                         | Description | Schema |
+|--------|-----------------------------------------------------------------|-------------|--------|
+| 204    | [No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5) | No Content  |        |
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
@@ -1242,6 +3813,183 @@ Experimental: this endpoint is subject to change.
 | Status | Meaning                                                         | Description | Schema |
 |--------|-----------------------------------------------------------------|-------------|--------|
 | 204    | [No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5) | No Content  |        |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Get chat debug runs
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/experimental/chats/{chat}/debug/runs \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /api/experimental/chats/{chat}/debug/runs`
+
+Experimental: this endpoint is subject to change.
+
+### Parameters
+
+| Name   | In   | Type         | Required | Description |
+|--------|------|--------------|----------|-------------|
+| `chat` | path | string(uuid) | true     | Chat ID     |
+
+### Example responses
+
+> 200 Response
+
+```json
+[
+  {
+    "chat_id": "efc9fe20-a1e5-4a8c-9c48-f1b30c1e4f86",
+    "finished_at": "2019-08-24T14:15:22Z",
+    "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+    "kind": "chat_turn",
+    "model": "string",
+    "provider": "string",
+    "started_at": "2019-08-24T14:15:22Z",
+    "status": "in_progress",
+    "summary": {
+      "property1": null,
+      "property2": null
+    },
+    "updated_at": "2019-08-24T14:15:22Z"
+  }
+]
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                          |
+|--------|---------------------------------------------------------|-------------|---------------------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | array of [codersdk.ChatDebugRunSummary](schemas.md#codersdkchatdebugrunsummary) |
+
+<h3 id="get-chat-debug-runs-responseschema">Response Schema</h3>
+
+Status Code **200**
+
+| Name                | Type                                                             | Required | Restrictions | Description |
+|---------------------|------------------------------------------------------------------|----------|--------------|-------------|
+| `[array item]`      | array                                                            | false    |              |             |
+| `» chat_id`         | string(uuid)                                                     | false    |              |             |
+| `» finished_at`     | string(date-time)                                                | false    |              |             |
+| `» id`              | string(uuid)                                                     | false    |              |             |
+| `» kind`            | [codersdk.ChatDebugRunKind](schemas.md#codersdkchatdebugrunkind) | false    |              |             |
+| `» model`           | string                                                           | false    |              |             |
+| `» provider`        | string                                                           | false    |              |             |
+| `» started_at`      | string(date-time)                                                | false    |              |             |
+| `» status`          | [codersdk.ChatDebugStatus](schemas.md#codersdkchatdebugstatus)   | false    |              |             |
+| `» summary`         | object                                                           | false    |              |             |
+| `»» [any property]` | any                                                              | false    |              |             |
+| `» updated_at`      | string(date-time)                                                | false    |              |             |
+
+#### Enumerated Values
+
+| Property | Value(s)                                                  |
+|----------|-----------------------------------------------------------|
+| `kind`   | `chat_turn`, `compaction`, `quickgen`, `title_generation` |
+| `status` | `completed`, `error`, `in_progress`, `interrupted`        |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Get chat debug run
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X GET http://coder-server:8080/api/experimental/chats/{chat}/debug/runs/{debugRun} \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`GET /api/experimental/chats/{chat}/debug/runs/{debugRun}`
+
+Experimental: this endpoint is subject to change.
+
+### Parameters
+
+| Name       | In   | Type         | Required | Description  |
+|------------|------|--------------|----------|--------------|
+| `chat`     | path | string(uuid) | true     | Chat ID      |
+| `debugRun` | path | string(uuid) | true     | Debug run ID |
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "chat_id": "efc9fe20-a1e5-4a8c-9c48-f1b30c1e4f86",
+  "finished_at": "2019-08-24T14:15:22Z",
+  "history_tip_message_id": 0,
+  "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+  "kind": "chat_turn",
+  "model": "string",
+  "model_config_id": "f5fb4d91-62ca-4377-9ee6-5d43ba00d205",
+  "parent_chat_id": "c3609ee6-3b11-4a93-b9ae-e4fabcc99359",
+  "provider": "string",
+  "root_chat_id": "2898031c-fdce-4e3e-8c53-4481dd42fcd7",
+  "started_at": "2019-08-24T14:15:22Z",
+  "status": "in_progress",
+  "steps": [
+    {
+      "assistant_message_id": 0,
+      "attempts": [
+        {
+          "property1": null,
+          "property2": null
+        }
+      ],
+      "chat_id": "efc9fe20-a1e5-4a8c-9c48-f1b30c1e4f86",
+      "error": {
+        "property1": null,
+        "property2": null
+      },
+      "finished_at": "2019-08-24T14:15:22Z",
+      "history_tip_message_id": 0,
+      "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+      "metadata": {
+        "property1": null,
+        "property2": null
+      },
+      "normalized_request": {
+        "property1": null,
+        "property2": null
+      },
+      "normalized_response": {
+        "property1": null,
+        "property2": null
+      },
+      "operation": "stream",
+      "run_id": "dded282c-8ebd-44cf-8ba5-9a234973d1ec",
+      "started_at": "2019-08-24T14:15:22Z",
+      "status": "in_progress",
+      "step_number": 0,
+      "updated_at": "2019-08-24T14:15:22Z",
+      "usage": {
+        "property1": null,
+        "property2": null
+      }
+    }
+  ],
+  "summary": {
+    "property1": null,
+    "property2": null
+  },
+  "trigger_message_id": 0,
+  "updated_at": "2019-08-24T14:15:22Z"
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                   |
+|--------|---------------------------------------------------------|-------------|----------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.ChatDebugRun](schemas.md#codersdkchatdebugrun) |
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
@@ -2106,6 +4854,64 @@ Experimental: this endpoint is subject to change.
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
+## Delete chat queued message
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X DELETE http://coder-server:8080/api/experimental/chats/{chat}/queue/{queuedMessage} \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`DELETE /api/experimental/chats/{chat}/queue/{queuedMessage}`
+
+Experimental: this endpoint is subject to change.
+
+### Parameters
+
+| Name            | In   | Type         | Required | Description       |
+|-----------------|------|--------------|----------|-------------------|
+| `chat`          | path | string(uuid) | true     | Chat ID           |
+| `queuedMessage` | path | integer      | true     | Queued message ID |
+
+### Responses
+
+| Status | Meaning                                                         | Description | Schema |
+|--------|-----------------------------------------------------------------|-------------|--------|
+| 204    | [No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5) | No Content  |        |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Promote chat queued message
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X POST http://coder-server:8080/api/experimental/chats/{chat}/queue/{queuedMessage}/promote \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`POST /api/experimental/chats/{chat}/queue/{queuedMessage}/promote`
+
+Experimental: this endpoint is subject to change.
+
+### Parameters
+
+| Name            | In   | Type         | Required | Description       |
+|-----------------|------|--------------|----------|-------------------|
+| `chat`          | path | string(uuid) | true     | Chat ID           |
+| `queuedMessage` | path | integer      | true     | Queued message ID |
+
+### Responses
+
+| Status | Meaning                                                         | Description | Schema |
+|--------|-----------------------------------------------------------------|-------------|--------|
+| 204    | [No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5) | No Content  |        |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
 ## Stream chat events via WebSockets
 
 ### Code samples
@@ -2451,6 +5257,45 @@ Experimental: this endpoint is subject to change.
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).
 
+## Propose chat title
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X POST http://coder-server:8080/api/experimental/chats/{chat}/title/propose \
+  -H 'Accept: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`POST /api/experimental/chats/{chat}/title/propose`
+
+Experimental: this endpoint is subject to change.
+
+### Parameters
+
+| Name   | In   | Type         | Required | Description |
+|--------|------|--------------|----------|-------------|
+| `chat` | path | string(uuid) | true     | Chat ID     |
+
+### Example responses
+
+> 200 Response
+
+```json
+{
+  "title": "string"
+}
+```
+
+### Responses
+
+| Status | Meaning                                                 | Description | Schema                                                                           |
+|--------|---------------------------------------------------------|-------------|----------------------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.ProposeChatTitleResponse](schemas.md#codersdkproposechattitleresponse) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
 ## Regenerate chat title
 
 ### Code samples
@@ -2741,5 +5586,51 @@ Experimental: this endpoint is subject to change.
 | Status | Meaning                                                 | Description | Schema                                   |
 |--------|---------------------------------------------------------|-------------|------------------------------------------|
 | 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.Chat](schemas.md#codersdkchat) |
+
+To perform this operation, you must be authenticated. [Learn more](authentication.md).
+
+## Submit chat tool results
+
+### Code samples
+
+```shell
+# Example request using curl
+curl -X POST http://coder-server:8080/api/experimental/chats/{chat}/tool-results \
+  -H 'Content-Type: application/json' \
+  -H 'Coder-Session-Token: API_KEY'
+```
+
+`POST /api/experimental/chats/{chat}/tool-results`
+
+Experimental: this endpoint is subject to change.
+
+> Body parameter
+
+```json
+{
+  "results": [
+    {
+      "is_error": true,
+      "output": [
+        0
+      ],
+      "tool_call_id": "string"
+    }
+  ]
+}
+```
+
+### Parameters
+
+| Name   | In   | Type                                                                             | Required | Description  |
+|--------|------|----------------------------------------------------------------------------------|----------|--------------|
+| `chat` | path | string(uuid)                                                                     | true     | Chat ID      |
+| `body` | body | [codersdk.SubmitToolResultsRequest](schemas.md#codersdksubmittoolresultsrequest) | true     | Request body |
+
+### Responses
+
+| Status | Meaning                                                         | Description | Schema |
+|--------|-----------------------------------------------------------------|-------------|--------|
+| 204    | [No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5) | No Content  |        |
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -1409,6 +1409,26 @@
 |-----------|--------|----------|--------------|-------------|
 | `license` | string | true     |              |             |
 
+## codersdk.AdvisorConfig
+
+```json
+{
+  "enabled": true,
+  "max_output_tokens": 0,
+  "max_uses_per_run": 0,
+  "model_config_id": "f5fb4d91-62ca-4377-9ee6-5d43ba00d205"
+}
+```
+
+### Properties
+
+| Name                | Type    | Required | Restrictions | Description                                                                                                                                                                                                                                                                                                                  |
+|---------------------|---------|----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `enabled`           | boolean | false    |              | Enabled toggles the advisor runtime. When false, advisor is not attached to new chats.                                                                                                                                                                                                                                       |
+| `max_output_tokens` | integer | false    |              | Max output tokens caps the advisor model response tokens. 0 means use the runtime default.                                                                                                                                                                                                                                   |
+| `max_uses_per_run`  | integer | false    |              | Max uses per run caps how many times the advisor can be invoked per chat run. 0 means unlimited.                                                                                                                                                                                                                             |
+| `model_config_id`   | string  | false    |              | Model config ID selects a specific chat model config to power the advisor. uuid.Nil means reuse the outer chat model. The runtime must fall back to the outer chat model when this ID cannot be resolved (e.g. the referenced model config was soft-deleted or its provider was disabled after the admin saved this config). |
+
 ## codersdk.AgentConnectionTiming
 
 ```json
@@ -2388,6 +2408,20 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `warnings`              | array of string                                                 | false    |              |                                                                                                                                                                                                                                                                            |
 | `workspace_id`          | string                                                          | false    |              |                                                                                                                                                                                                                                                                            |
 
+## codersdk.ChatAutoArchiveDaysResponse
+
+```json
+{
+  "auto_archive_days": 0
+}
+```
+
+### Properties
+
+| Name                | Type    | Required | Restrictions | Description |
+|---------------------|---------|----------|--------------|-------------|
+| `auto_archive_days` | integer | false    |              |             |
+
 ## codersdk.ChatBusyBehavior
 
 ```json
@@ -2416,6 +2450,20 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 |-------------|
 | `api`, `ui` |
 
+## codersdk.ChatComputerUseProviderResponse
+
+```json
+{
+  "provider": "string"
+}
+```
+
+### Properties
+
+| Name       | Type   | Required | Restrictions | Description |
+|------------|--------|----------|--------------|-------------|
+| `provider` | string | false    |              |             |
+
 ## codersdk.ChatConfig
 
 ```json
@@ -2431,6 +2479,288 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 |-------------------------|---------|----------|--------------|-------------|
 | `acquire_batch_size`    | integer | false    |              |             |
 | `debug_logging_enabled` | boolean | false    |              |             |
+
+## codersdk.ChatDebugLoggingAdminSettings
+
+```json
+{
+  "allow_users": true,
+  "forced_by_deployment": true
+}
+```
+
+### Properties
+
+| Name                   | Type    | Required | Restrictions | Description |
+|------------------------|---------|----------|--------------|-------------|
+| `allow_users`          | boolean | false    |              |             |
+| `forced_by_deployment` | boolean | false    |              |             |
+
+## codersdk.ChatDebugRetentionDaysResponse
+
+```json
+{
+  "debug_retention_days": 0
+}
+```
+
+### Properties
+
+| Name                   | Type    | Required | Restrictions | Description |
+|------------------------|---------|----------|--------------|-------------|
+| `debug_retention_days` | integer | false    |              |             |
+
+## codersdk.ChatDebugRun
+
+```json
+{
+  "chat_id": "efc9fe20-a1e5-4a8c-9c48-f1b30c1e4f86",
+  "finished_at": "2019-08-24T14:15:22Z",
+  "history_tip_message_id": 0,
+  "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+  "kind": "chat_turn",
+  "model": "string",
+  "model_config_id": "f5fb4d91-62ca-4377-9ee6-5d43ba00d205",
+  "parent_chat_id": "c3609ee6-3b11-4a93-b9ae-e4fabcc99359",
+  "provider": "string",
+  "root_chat_id": "2898031c-fdce-4e3e-8c53-4481dd42fcd7",
+  "started_at": "2019-08-24T14:15:22Z",
+  "status": "in_progress",
+  "steps": [
+    {
+      "assistant_message_id": 0,
+      "attempts": [
+        {
+          "property1": null,
+          "property2": null
+        }
+      ],
+      "chat_id": "efc9fe20-a1e5-4a8c-9c48-f1b30c1e4f86",
+      "error": {
+        "property1": null,
+        "property2": null
+      },
+      "finished_at": "2019-08-24T14:15:22Z",
+      "history_tip_message_id": 0,
+      "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+      "metadata": {
+        "property1": null,
+        "property2": null
+      },
+      "normalized_request": {
+        "property1": null,
+        "property2": null
+      },
+      "normalized_response": {
+        "property1": null,
+        "property2": null
+      },
+      "operation": "stream",
+      "run_id": "dded282c-8ebd-44cf-8ba5-9a234973d1ec",
+      "started_at": "2019-08-24T14:15:22Z",
+      "status": "in_progress",
+      "step_number": 0,
+      "updated_at": "2019-08-24T14:15:22Z",
+      "usage": {
+        "property1": null,
+        "property2": null
+      }
+    }
+  ],
+  "summary": {
+    "property1": null,
+    "property2": null
+  },
+  "trigger_message_id": 0,
+  "updated_at": "2019-08-24T14:15:22Z"
+}
+```
+
+### Properties
+
+| Name                     | Type                                                      | Required | Restrictions | Description |
+|--------------------------|-----------------------------------------------------------|----------|--------------|-------------|
+| `chat_id`                | string                                                    | false    |              |             |
+| `finished_at`            | string                                                    | false    |              |             |
+| `history_tip_message_id` | integer                                                   | false    |              |             |
+| `id`                     | string                                                    | false    |              |             |
+| `kind`                   | [codersdk.ChatDebugRunKind](#codersdkchatdebugrunkind)    | false    |              |             |
+| `model`                  | string                                                    | false    |              |             |
+| `model_config_id`        | string                                                    | false    |              |             |
+| `parent_chat_id`         | string                                                    | false    |              |             |
+| `provider`               | string                                                    | false    |              |             |
+| `root_chat_id`           | string                                                    | false    |              |             |
+| `started_at`             | string                                                    | false    |              |             |
+| `status`                 | [codersdk.ChatDebugStatus](#codersdkchatdebugstatus)      | false    |              |             |
+| `steps`                  | array of [codersdk.ChatDebugStep](#codersdkchatdebugstep) | false    |              |             |
+| `summary`                | object                                                    | false    |              |             |
+| » `[any property]`       | any                                                       | false    |              |             |
+| `trigger_message_id`     | integer                                                   | false    |              |             |
+| `updated_at`             | string                                                    | false    |              |             |
+
+## codersdk.ChatDebugRunKind
+
+```json
+"chat_turn"
+```
+
+### Properties
+
+#### Enumerated Values
+
+| Value(s)                                                  |
+|-----------------------------------------------------------|
+| `chat_turn`, `compaction`, `quickgen`, `title_generation` |
+
+## codersdk.ChatDebugRunSummary
+
+```json
+{
+  "chat_id": "efc9fe20-a1e5-4a8c-9c48-f1b30c1e4f86",
+  "finished_at": "2019-08-24T14:15:22Z",
+  "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+  "kind": "chat_turn",
+  "model": "string",
+  "provider": "string",
+  "started_at": "2019-08-24T14:15:22Z",
+  "status": "in_progress",
+  "summary": {
+    "property1": null,
+    "property2": null
+  },
+  "updated_at": "2019-08-24T14:15:22Z"
+}
+```
+
+### Properties
+
+| Name               | Type                                                   | Required | Restrictions | Description |
+|--------------------|--------------------------------------------------------|----------|--------------|-------------|
+| `chat_id`          | string                                                 | false    |              |             |
+| `finished_at`      | string                                                 | false    |              |             |
+| `id`               | string                                                 | false    |              |             |
+| `kind`             | [codersdk.ChatDebugRunKind](#codersdkchatdebugrunkind) | false    |              |             |
+| `model`            | string                                                 | false    |              |             |
+| `provider`         | string                                                 | false    |              |             |
+| `started_at`       | string                                                 | false    |              |             |
+| `status`           | [codersdk.ChatDebugStatus](#codersdkchatdebugstatus)   | false    |              |             |
+| `summary`          | object                                                 | false    |              |             |
+| » `[any property]` | any                                                    | false    |              |             |
+| `updated_at`       | string                                                 | false    |              |             |
+
+## codersdk.ChatDebugStatus
+
+```json
+"in_progress"
+```
+
+### Properties
+
+#### Enumerated Values
+
+| Value(s)                                           |
+|----------------------------------------------------|
+| `completed`, `error`, `in_progress`, `interrupted` |
+
+## codersdk.ChatDebugStep
+
+```json
+{
+  "assistant_message_id": 0,
+  "attempts": [
+    {
+      "property1": null,
+      "property2": null
+    }
+  ],
+  "chat_id": "efc9fe20-a1e5-4a8c-9c48-f1b30c1e4f86",
+  "error": {
+    "property1": null,
+    "property2": null
+  },
+  "finished_at": "2019-08-24T14:15:22Z",
+  "history_tip_message_id": 0,
+  "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+  "metadata": {
+    "property1": null,
+    "property2": null
+  },
+  "normalized_request": {
+    "property1": null,
+    "property2": null
+  },
+  "normalized_response": {
+    "property1": null,
+    "property2": null
+  },
+  "operation": "stream",
+  "run_id": "dded282c-8ebd-44cf-8ba5-9a234973d1ec",
+  "started_at": "2019-08-24T14:15:22Z",
+  "status": "in_progress",
+  "step_number": 0,
+  "updated_at": "2019-08-24T14:15:22Z",
+  "usage": {
+    "property1": null,
+    "property2": null
+  }
+}
+```
+
+### Properties
+
+| Name                     | Type                                                               | Required | Restrictions | Description |
+|--------------------------|--------------------------------------------------------------------|----------|--------------|-------------|
+| `assistant_message_id`   | integer                                                            | false    |              |             |
+| `attempts`               | array of object                                                    | false    |              |             |
+| » `[any property]`       | any                                                                | false    |              |             |
+| `chat_id`                | string                                                             | false    |              |             |
+| `error`                  | object                                                             | false    |              |             |
+| » `[any property]`       | any                                                                | false    |              |             |
+| `finished_at`            | string                                                             | false    |              |             |
+| `history_tip_message_id` | integer                                                            | false    |              |             |
+| `id`                     | string                                                             | false    |              |             |
+| `metadata`               | object                                                             | false    |              |             |
+| » `[any property]`       | any                                                                | false    |              |             |
+| `normalized_request`     | object                                                             | false    |              |             |
+| » `[any property]`       | any                                                                | false    |              |             |
+| `normalized_response`    | object                                                             | false    |              |             |
+| » `[any property]`       | any                                                                | false    |              |             |
+| `operation`              | [codersdk.ChatDebugStepOperation](#codersdkchatdebugstepoperation) | false    |              |             |
+| `run_id`                 | string                                                             | false    |              |             |
+| `started_at`             | string                                                             | false    |              |             |
+| `status`                 | [codersdk.ChatDebugStatus](#codersdkchatdebugstatus)               | false    |              |             |
+| `step_number`            | integer                                                            | false    |              |             |
+| `updated_at`             | string                                                             | false    |              |             |
+| `usage`                  | object                                                             | false    |              |             |
+| » `[any property]`       | any                                                                | false    |              |             |
+
+## codersdk.ChatDebugStepOperation
+
+```json
+"stream"
+```
+
+### Properties
+
+#### Enumerated Values
+
+| Value(s)             |
+|----------------------|
+| `generate`, `stream` |
+
+## codersdk.ChatDesktopEnabledResponse
+
+```json
+{
+  "enable_desktop": true
+}
+```
+
+### Properties
+
+| Name             | Type    | Required | Restrictions | Description |
+|------------------|---------|----------|--------------|-------------|
+| `enable_desktop` | boolean | false    |              |             |
 
 ## codersdk.ChatDiffContents
 
@@ -3032,6 +3362,689 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `model`        | string | false    |              |             |
 | `provider`     | string | false    |              |             |
 
+## codersdk.ChatModelAnthropicProviderOptions
+
+```json
+{
+  "allowed_domains": [
+    "string"
+  ],
+  "blocked_domains": [
+    "string"
+  ],
+  "disable_parallel_tool_use": true,
+  "effort": "string",
+  "send_reasoning": true,
+  "thinking": {
+    "budget_tokens": 0
+  },
+  "web_search_enabled": true
+}
+```
+
+### Properties
+
+| Name                        | Type                                                                                     | Required | Restrictions | Description |
+|-----------------------------|------------------------------------------------------------------------------------------|----------|--------------|-------------|
+| `allowed_domains`           | array of string                                                                          | false    |              |             |
+| `blocked_domains`           | array of string                                                                          | false    |              |             |
+| `disable_parallel_tool_use` | boolean                                                                                  | false    |              |             |
+| `effort`                    | string                                                                                   | false    |              |             |
+| `send_reasoning`            | boolean                                                                                  | false    |              |             |
+| `thinking`                  | [codersdk.ChatModelAnthropicThinkingOptions](#codersdkchatmodelanthropicthinkingoptions) | false    |              |             |
+| `web_search_enabled`        | boolean                                                                                  | false    |              |             |
+
+## codersdk.ChatModelAnthropicThinkingOptions
+
+```json
+{
+  "budget_tokens": 0
+}
+```
+
+### Properties
+
+| Name            | Type    | Required | Restrictions | Description |
+|-----------------|---------|----------|--------------|-------------|
+| `budget_tokens` | integer | false    |              |             |
+
+## codersdk.ChatModelCallConfig
+
+```json
+{
+  "cost": {
+    "cache_read_price_per_million_tokens": 0,
+    "cache_write_price_per_million_tokens": 0,
+    "input_price_per_million_tokens": 0,
+    "output_price_per_million_tokens": 0
+  },
+  "frequency_penalty": 0,
+  "max_output_tokens": 0,
+  "presence_penalty": 0,
+  "provider_options": {
+    "anthropic": {
+      "allowed_domains": [
+        "string"
+      ],
+      "blocked_domains": [
+        "string"
+      ],
+      "disable_parallel_tool_use": true,
+      "effort": "string",
+      "send_reasoning": true,
+      "thinking": {
+        "budget_tokens": 0
+      },
+      "web_search_enabled": true
+    },
+    "google": {
+      "cached_content": "string",
+      "safety_settings": [
+        {
+          "category": "string",
+          "threshold": "string"
+        }
+      ],
+      "thinking_config": {
+        "include_thoughts": true,
+        "thinking_budget": 0
+      },
+      "threshold": "string",
+      "web_search_enabled": true
+    },
+    "openai": {
+      "allowed_domains": [
+        "string"
+      ],
+      "include": [
+        "string"
+      ],
+      "instructions": "string",
+      "log_probs": true,
+      "logit_bias": {
+        "property1": 0,
+        "property2": 0
+      },
+      "max_completion_tokens": 0,
+      "max_tool_calls": 0,
+      "metadata": {
+        "property1": null,
+        "property2": null
+      },
+      "parallel_tool_calls": true,
+      "prediction": {
+        "property1": null,
+        "property2": null
+      },
+      "prompt_cache_key": "string",
+      "reasoning_effort": "string",
+      "reasoning_summary": "string",
+      "safety_identifier": "string",
+      "search_context_size": "string",
+      "service_tier": "string",
+      "store": true,
+      "strict_json_schema": true,
+      "structured_outputs": true,
+      "text_verbosity": "string",
+      "top_log_probs": 0,
+      "user": "string",
+      "web_search_enabled": true
+    },
+    "openaicompat": {
+      "reasoning_effort": "string",
+      "user": "string"
+    },
+    "openrouter": {
+      "extra_body": {
+        "property1": null,
+        "property2": null
+      },
+      "include_usage": true,
+      "log_probs": true,
+      "logit_bias": {
+        "property1": 0,
+        "property2": 0
+      },
+      "parallel_tool_calls": true,
+      "provider": {
+        "allow_fallbacks": true,
+        "data_collection": "string",
+        "ignore": [
+          "string"
+        ],
+        "only": [
+          "string"
+        ],
+        "order": [
+          "string"
+        ],
+        "quantizations": [
+          "string"
+        ],
+        "require_parameters": true,
+        "sort": "string"
+      },
+      "reasoning": {
+        "effort": "string",
+        "enabled": true,
+        "exclude": true,
+        "max_tokens": 0
+      },
+      "user": "string"
+    },
+    "vercel": {
+      "extra_body": {
+        "property1": null,
+        "property2": null
+      },
+      "logit_bias": {
+        "property1": 0,
+        "property2": 0
+      },
+      "logprobs": true,
+      "parallel_tool_calls": true,
+      "providerOptions": {
+        "models": [
+          "string"
+        ],
+        "order": [
+          "string"
+        ]
+      },
+      "reasoning": {
+        "effort": "string",
+        "enabled": true,
+        "exclude": true,
+        "max_tokens": 0
+      },
+      "top_logprobs": 0,
+      "user": "string"
+    }
+  },
+  "temperature": 0,
+  "top_k": 0,
+  "top_p": 0
+}
+```
+
+### Properties
+
+| Name                | Type                                                                   | Required | Restrictions | Description |
+|---------------------|------------------------------------------------------------------------|----------|--------------|-------------|
+| `cost`              | [codersdk.ModelCostConfig](#codersdkmodelcostconfig)                   | false    |              |             |
+| `frequency_penalty` | number                                                                 | false    |              |             |
+| `max_output_tokens` | integer                                                                | false    |              |             |
+| `presence_penalty`  | number                                                                 | false    |              |             |
+| `provider_options`  | [codersdk.ChatModelProviderOptions](#codersdkchatmodelprovideroptions) | false    |              |             |
+| `temperature`       | number                                                                 | false    |              |             |
+| `top_k`             | integer                                                                | false    |              |             |
+| `top_p`             | number                                                                 | false    |              |             |
+
+## codersdk.ChatModelConfig
+
+```json
+{
+  "compression_threshold": 0,
+  "context_limit": 0,
+  "created_at": "2019-08-24T14:15:22Z",
+  "display_name": "string",
+  "enabled": true,
+  "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+  "is_default": true,
+  "model": "string",
+  "model_config": {
+    "cost": {
+      "cache_read_price_per_million_tokens": 0,
+      "cache_write_price_per_million_tokens": 0,
+      "input_price_per_million_tokens": 0,
+      "output_price_per_million_tokens": 0
+    },
+    "frequency_penalty": 0,
+    "max_output_tokens": 0,
+    "presence_penalty": 0,
+    "provider_options": {
+      "anthropic": {
+        "allowed_domains": [
+          "string"
+        ],
+        "blocked_domains": [
+          "string"
+        ],
+        "disable_parallel_tool_use": true,
+        "effort": "string",
+        "send_reasoning": true,
+        "thinking": {
+          "budget_tokens": 0
+        },
+        "web_search_enabled": true
+      },
+      "google": {
+        "cached_content": "string",
+        "safety_settings": [
+          {
+            "category": "string",
+            "threshold": "string"
+          }
+        ],
+        "thinking_config": {
+          "include_thoughts": true,
+          "thinking_budget": 0
+        },
+        "threshold": "string",
+        "web_search_enabled": true
+      },
+      "openai": {
+        "allowed_domains": [
+          "string"
+        ],
+        "include": [
+          "string"
+        ],
+        "instructions": "string",
+        "log_probs": true,
+        "logit_bias": {
+          "property1": 0,
+          "property2": 0
+        },
+        "max_completion_tokens": 0,
+        "max_tool_calls": 0,
+        "metadata": {
+          "property1": null,
+          "property2": null
+        },
+        "parallel_tool_calls": true,
+        "prediction": {
+          "property1": null,
+          "property2": null
+        },
+        "prompt_cache_key": "string",
+        "reasoning_effort": "string",
+        "reasoning_summary": "string",
+        "safety_identifier": "string",
+        "search_context_size": "string",
+        "service_tier": "string",
+        "store": true,
+        "strict_json_schema": true,
+        "structured_outputs": true,
+        "text_verbosity": "string",
+        "top_log_probs": 0,
+        "user": "string",
+        "web_search_enabled": true
+      },
+      "openaicompat": {
+        "reasoning_effort": "string",
+        "user": "string"
+      },
+      "openrouter": {
+        "extra_body": {
+          "property1": null,
+          "property2": null
+        },
+        "include_usage": true,
+        "log_probs": true,
+        "logit_bias": {
+          "property1": 0,
+          "property2": 0
+        },
+        "parallel_tool_calls": true,
+        "provider": {
+          "allow_fallbacks": true,
+          "data_collection": "string",
+          "ignore": [
+            "string"
+          ],
+          "only": [
+            "string"
+          ],
+          "order": [
+            "string"
+          ],
+          "quantizations": [
+            "string"
+          ],
+          "require_parameters": true,
+          "sort": "string"
+        },
+        "reasoning": {
+          "effort": "string",
+          "enabled": true,
+          "exclude": true,
+          "max_tokens": 0
+        },
+        "user": "string"
+      },
+      "vercel": {
+        "extra_body": {
+          "property1": null,
+          "property2": null
+        },
+        "logit_bias": {
+          "property1": 0,
+          "property2": 0
+        },
+        "logprobs": true,
+        "parallel_tool_calls": true,
+        "providerOptions": {
+          "models": [
+            "string"
+          ],
+          "order": [
+            "string"
+          ]
+        },
+        "reasoning": {
+          "effort": "string",
+          "enabled": true,
+          "exclude": true,
+          "max_tokens": 0
+        },
+        "top_logprobs": 0,
+        "user": "string"
+      }
+    },
+    "temperature": 0,
+    "top_k": 0,
+    "top_p": 0
+  },
+  "provider": "string",
+  "updated_at": "2019-08-24T14:15:22Z"
+}
+```
+
+### Properties
+
+| Name                    | Type                                                         | Required | Restrictions | Description |
+|-------------------------|--------------------------------------------------------------|----------|--------------|-------------|
+| `compression_threshold` | integer                                                      | false    |              |             |
+| `context_limit`         | integer                                                      | false    |              |             |
+| `created_at`            | string                                                       | false    |              |             |
+| `display_name`          | string                                                       | false    |              |             |
+| `enabled`               | boolean                                                      | false    |              |             |
+| `id`                    | string                                                       | false    |              |             |
+| `is_default`            | boolean                                                      | false    |              |             |
+| `model`                 | string                                                       | false    |              |             |
+| `model_config`          | [codersdk.ChatModelCallConfig](#codersdkchatmodelcallconfig) | false    |              |             |
+| `provider`              | string                                                       | false    |              |             |
+| `updated_at`            | string                                                       | false    |              |             |
+
+## codersdk.ChatModelGoogleProviderOptions
+
+```json
+{
+  "cached_content": "string",
+  "safety_settings": [
+    {
+      "category": "string",
+      "threshold": "string"
+    }
+  ],
+  "thinking_config": {
+    "include_thoughts": true,
+    "thinking_budget": 0
+  },
+  "threshold": "string",
+  "web_search_enabled": true
+}
+```
+
+### Properties
+
+| Name                 | Type                                                                                    | Required | Restrictions | Description |
+|----------------------|-----------------------------------------------------------------------------------------|----------|--------------|-------------|
+| `cached_content`     | string                                                                                  | false    |              |             |
+| `safety_settings`    | array of [codersdk.ChatModelGoogleSafetySetting](#codersdkchatmodelgooglesafetysetting) | false    |              |             |
+| `thinking_config`    | [codersdk.ChatModelGoogleThinkingConfig](#codersdkchatmodelgooglethinkingconfig)        | false    |              |             |
+| `threshold`          | string                                                                                  | false    |              |             |
+| `web_search_enabled` | boolean                                                                                 | false    |              |             |
+
+## codersdk.ChatModelGoogleSafetySetting
+
+```json
+{
+  "category": "string",
+  "threshold": "string"
+}
+```
+
+### Properties
+
+| Name        | Type   | Required | Restrictions | Description |
+|-------------|--------|----------|--------------|-------------|
+| `category`  | string | false    |              |             |
+| `threshold` | string | false    |              |             |
+
+## codersdk.ChatModelGoogleThinkingConfig
+
+```json
+{
+  "include_thoughts": true,
+  "thinking_budget": 0
+}
+```
+
+### Properties
+
+| Name               | Type    | Required | Restrictions | Description |
+|--------------------|---------|----------|--------------|-------------|
+| `include_thoughts` | boolean | false    |              |             |
+| `thinking_budget`  | integer | false    |              |             |
+
+## codersdk.ChatModelOpenAICompatProviderOptions
+
+```json
+{
+  "reasoning_effort": "string",
+  "user": "string"
+}
+```
+
+### Properties
+
+| Name               | Type   | Required | Restrictions | Description |
+|--------------------|--------|----------|--------------|-------------|
+| `reasoning_effort` | string | false    |              |             |
+| `user`             | string | false    |              |             |
+
+## codersdk.ChatModelOpenAIProviderOptions
+
+```json
+{
+  "allowed_domains": [
+    "string"
+  ],
+  "include": [
+    "string"
+  ],
+  "instructions": "string",
+  "log_probs": true,
+  "logit_bias": {
+    "property1": 0,
+    "property2": 0
+  },
+  "max_completion_tokens": 0,
+  "max_tool_calls": 0,
+  "metadata": {
+    "property1": null,
+    "property2": null
+  },
+  "parallel_tool_calls": true,
+  "prediction": {
+    "property1": null,
+    "property2": null
+  },
+  "prompt_cache_key": "string",
+  "reasoning_effort": "string",
+  "reasoning_summary": "string",
+  "safety_identifier": "string",
+  "search_context_size": "string",
+  "service_tier": "string",
+  "store": true,
+  "strict_json_schema": true,
+  "structured_outputs": true,
+  "text_verbosity": "string",
+  "top_log_probs": 0,
+  "user": "string",
+  "web_search_enabled": true
+}
+```
+
+### Properties
+
+| Name                    | Type            | Required | Restrictions | Description |
+|-------------------------|-----------------|----------|--------------|-------------|
+| `allowed_domains`       | array of string | false    |              |             |
+| `include`               | array of string | false    |              |             |
+| `instructions`          | string          | false    |              |             |
+| `log_probs`             | boolean         | false    |              |             |
+| `logit_bias`            | object          | false    |              |             |
+| » `[any property]`      | integer         | false    |              |             |
+| `max_completion_tokens` | integer         | false    |              |             |
+| `max_tool_calls`        | integer         | false    |              |             |
+| `metadata`              | object          | false    |              |             |
+| » `[any property]`      | any             | false    |              |             |
+| `parallel_tool_calls`   | boolean         | false    |              |             |
+| `prediction`            | object          | false    |              |             |
+| » `[any property]`      | any             | false    |              |             |
+| `prompt_cache_key`      | string          | false    |              |             |
+| `reasoning_effort`      | string          | false    |              |             |
+| `reasoning_summary`     | string          | false    |              |             |
+| `safety_identifier`     | string          | false    |              |             |
+| `search_context_size`   | string          | false    |              |             |
+| `service_tier`          | string          | false    |              |             |
+| `store`                 | boolean         | false    |              |             |
+| `strict_json_schema`    | boolean         | false    |              |             |
+| `structured_outputs`    | boolean         | false    |              |             |
+| `text_verbosity`        | string          | false    |              |             |
+| `top_log_probs`         | integer         | false    |              |             |
+| `user`                  | string          | false    |              |             |
+| `web_search_enabled`    | boolean         | false    |              |             |
+
+## codersdk.ChatModelOpenRouterProvider
+
+```json
+{
+  "allow_fallbacks": true,
+  "data_collection": "string",
+  "ignore": [
+    "string"
+  ],
+  "only": [
+    "string"
+  ],
+  "order": [
+    "string"
+  ],
+  "quantizations": [
+    "string"
+  ],
+  "require_parameters": true,
+  "sort": "string"
+}
+```
+
+### Properties
+
+| Name                 | Type            | Required | Restrictions | Description |
+|----------------------|-----------------|----------|--------------|-------------|
+| `allow_fallbacks`    | boolean         | false    |              |             |
+| `data_collection`    | string          | false    |              |             |
+| `ignore`             | array of string | false    |              |             |
+| `only`               | array of string | false    |              |             |
+| `order`              | array of string | false    |              |             |
+| `quantizations`      | array of string | false    |              |             |
+| `require_parameters` | boolean         | false    |              |             |
+| `sort`               | string          | false    |              |             |
+
+## codersdk.ChatModelOpenRouterProviderOptions
+
+```json
+{
+  "extra_body": {
+    "property1": null,
+    "property2": null
+  },
+  "include_usage": true,
+  "log_probs": true,
+  "logit_bias": {
+    "property1": 0,
+    "property2": 0
+  },
+  "parallel_tool_calls": true,
+  "provider": {
+    "allow_fallbacks": true,
+    "data_collection": "string",
+    "ignore": [
+      "string"
+    ],
+    "only": [
+      "string"
+    ],
+    "order": [
+      "string"
+    ],
+    "quantizations": [
+      "string"
+    ],
+    "require_parameters": true,
+    "sort": "string"
+  },
+  "reasoning": {
+    "effort": "string",
+    "enabled": true,
+    "exclude": true,
+    "max_tokens": 0
+  },
+  "user": "string"
+}
+```
+
+### Properties
+
+| Name                  | Type                                                                         | Required | Restrictions | Description |
+|-----------------------|------------------------------------------------------------------------------|----------|--------------|-------------|
+| `extra_body`          | object                                                                       | false    |              |             |
+| » `[any property]`    | any                                                                          | false    |              |             |
+| `include_usage`       | boolean                                                                      | false    |              |             |
+| `log_probs`           | boolean                                                                      | false    |              |             |
+| `logit_bias`          | object                                                                       | false    |              |             |
+| » `[any property]`    | integer                                                                      | false    |              |             |
+| `parallel_tool_calls` | boolean                                                                      | false    |              |             |
+| `provider`            | [codersdk.ChatModelOpenRouterProvider](#codersdkchatmodelopenrouterprovider) | false    |              |             |
+| `reasoning`           | [codersdk.ChatModelReasoningOptions](#codersdkchatmodelreasoningoptions)     | false    |              |             |
+| `user`                | string                                                                       | false    |              |             |
+
+## codersdk.ChatModelOverrideContext
+
+```json
+"general"
+```
+
+### Properties
+
+#### Enumerated Values
+
+| Value(s)                                 |
+|------------------------------------------|
+| `explore`, `general`, `title_generation` |
+
+## codersdk.ChatModelOverrideResponse
+
+```json
+{
+  "context": "general",
+  "is_malformed": true,
+  "model_config_id": "string"
+}
+```
+
+### Properties
+
+| Name              | Type                                                                   | Required | Restrictions | Description |
+|-------------------|------------------------------------------------------------------------|----------|--------------|-------------|
+| `context`         | [codersdk.ChatModelOverrideContext](#codersdkchatmodeloverridecontext) | false    |              |             |
+| `is_malformed`    | boolean                                                                | false    |              |             |
+| `model_config_id` | string                                                                 | false    |              |             |
+
 ## codersdk.ChatModelProvider
 
 ```json
@@ -3059,6 +4072,162 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `provider`           | string                                                                                     | false    |              |             |
 | `unavailable_reason` | [codersdk.ChatModelProviderUnavailableReason](#codersdkchatmodelproviderunavailablereason) | false    |              |             |
 
+## codersdk.ChatModelProviderOptions
+
+```json
+{
+  "anthropic": {
+    "allowed_domains": [
+      "string"
+    ],
+    "blocked_domains": [
+      "string"
+    ],
+    "disable_parallel_tool_use": true,
+    "effort": "string",
+    "send_reasoning": true,
+    "thinking": {
+      "budget_tokens": 0
+    },
+    "web_search_enabled": true
+  },
+  "google": {
+    "cached_content": "string",
+    "safety_settings": [
+      {
+        "category": "string",
+        "threshold": "string"
+      }
+    ],
+    "thinking_config": {
+      "include_thoughts": true,
+      "thinking_budget": 0
+    },
+    "threshold": "string",
+    "web_search_enabled": true
+  },
+  "openai": {
+    "allowed_domains": [
+      "string"
+    ],
+    "include": [
+      "string"
+    ],
+    "instructions": "string",
+    "log_probs": true,
+    "logit_bias": {
+      "property1": 0,
+      "property2": 0
+    },
+    "max_completion_tokens": 0,
+    "max_tool_calls": 0,
+    "metadata": {
+      "property1": null,
+      "property2": null
+    },
+    "parallel_tool_calls": true,
+    "prediction": {
+      "property1": null,
+      "property2": null
+    },
+    "prompt_cache_key": "string",
+    "reasoning_effort": "string",
+    "reasoning_summary": "string",
+    "safety_identifier": "string",
+    "search_context_size": "string",
+    "service_tier": "string",
+    "store": true,
+    "strict_json_schema": true,
+    "structured_outputs": true,
+    "text_verbosity": "string",
+    "top_log_probs": 0,
+    "user": "string",
+    "web_search_enabled": true
+  },
+  "openaicompat": {
+    "reasoning_effort": "string",
+    "user": "string"
+  },
+  "openrouter": {
+    "extra_body": {
+      "property1": null,
+      "property2": null
+    },
+    "include_usage": true,
+    "log_probs": true,
+    "logit_bias": {
+      "property1": 0,
+      "property2": 0
+    },
+    "parallel_tool_calls": true,
+    "provider": {
+      "allow_fallbacks": true,
+      "data_collection": "string",
+      "ignore": [
+        "string"
+      ],
+      "only": [
+        "string"
+      ],
+      "order": [
+        "string"
+      ],
+      "quantizations": [
+        "string"
+      ],
+      "require_parameters": true,
+      "sort": "string"
+    },
+    "reasoning": {
+      "effort": "string",
+      "enabled": true,
+      "exclude": true,
+      "max_tokens": 0
+    },
+    "user": "string"
+  },
+  "vercel": {
+    "extra_body": {
+      "property1": null,
+      "property2": null
+    },
+    "logit_bias": {
+      "property1": 0,
+      "property2": 0
+    },
+    "logprobs": true,
+    "parallel_tool_calls": true,
+    "providerOptions": {
+      "models": [
+        "string"
+      ],
+      "order": [
+        "string"
+      ]
+    },
+    "reasoning": {
+      "effort": "string",
+      "enabled": true,
+      "exclude": true,
+      "max_tokens": 0
+    },
+    "top_logprobs": 0,
+    "user": "string"
+  }
+}
+```
+
+### Properties
+
+| Name           | Type                                                                                           | Required | Restrictions | Description |
+|----------------|------------------------------------------------------------------------------------------------|----------|--------------|-------------|
+| `anthropic`    | [codersdk.ChatModelAnthropicProviderOptions](#codersdkchatmodelanthropicprovideroptions)       | false    |              |             |
+| `google`       | [codersdk.ChatModelGoogleProviderOptions](#codersdkchatmodelgoogleprovideroptions)             | false    |              |             |
+| `openai`       | [codersdk.ChatModelOpenAIProviderOptions](#codersdkchatmodelopenaiprovideroptions)             | false    |              |             |
+| `openaicompat` | [codersdk.ChatModelOpenAICompatProviderOptions](#codersdkchatmodelopenaicompatprovideroptions) | false    |              |             |
+| `openrouter`   | [codersdk.ChatModelOpenRouterProviderOptions](#codersdkchatmodelopenrouterprovideroptions)     | false    |              |             |
+| `vercel`       | [codersdk.ChatModelVercelProviderOptions](#codersdkchatmodelvercelprovideroptions)             | false    |              |             |
+
 ## codersdk.ChatModelProviderUnavailableReason
 
 ```json
@@ -3072,6 +4241,94 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | Value(s)                                                   |
 |------------------------------------------------------------|
 | `fetch_failed`, `missing_api_key`, `user_api_key_required` |
+
+## codersdk.ChatModelReasoningOptions
+
+```json
+{
+  "effort": "string",
+  "enabled": true,
+  "exclude": true,
+  "max_tokens": 0
+}
+```
+
+### Properties
+
+| Name         | Type    | Required | Restrictions | Description |
+|--------------|---------|----------|--------------|-------------|
+| `effort`     | string  | false    |              |             |
+| `enabled`    | boolean | false    |              |             |
+| `exclude`    | boolean | false    |              |             |
+| `max_tokens` | integer | false    |              |             |
+
+## codersdk.ChatModelVercelGatewayProviderOptions
+
+```json
+{
+  "models": [
+    "string"
+  ],
+  "order": [
+    "string"
+  ]
+}
+```
+
+### Properties
+
+| Name     | Type            | Required | Restrictions | Description |
+|----------|-----------------|----------|--------------|-------------|
+| `models` | array of string | false    |              |             |
+| `order`  | array of string | false    |              |             |
+
+## codersdk.ChatModelVercelProviderOptions
+
+```json
+{
+  "extra_body": {
+    "property1": null,
+    "property2": null
+  },
+  "logit_bias": {
+    "property1": 0,
+    "property2": 0
+  },
+  "logprobs": true,
+  "parallel_tool_calls": true,
+  "providerOptions": {
+    "models": [
+      "string"
+    ],
+    "order": [
+      "string"
+    ]
+  },
+  "reasoning": {
+    "effort": "string",
+    "enabled": true,
+    "exclude": true,
+    "max_tokens": 0
+  },
+  "top_logprobs": 0,
+  "user": "string"
+}
+```
+
+### Properties
+
+| Name                  | Type                                                                                             | Required | Restrictions | Description |
+|-----------------------|--------------------------------------------------------------------------------------------------|----------|--------------|-------------|
+| `extra_body`          | object                                                                                           | false    |              |             |
+| » `[any property]`    | any                                                                                              | false    |              |             |
+| `logit_bias`          | object                                                                                           | false    |              |             |
+| » `[any property]`    | integer                                                                                          | false    |              |             |
+| `logprobs`            | boolean                                                                                          | false    |              |             |
+| `parallel_tool_calls` | boolean                                                                                          | false    |              |             |
+| `providerOptions`     | [codersdk.ChatModelVercelGatewayProviderOptions](#codersdkchatmodelvercelgatewayprovideroptions) | false    |              |             |
+| `reasoning`           | [codersdk.ChatModelReasoningOptions](#codersdkchatmodelreasoningoptions)                         | false    |              |             |
+| `top_logprobs`        | integer                                                                                          | false    |              |             |
+| `user`                | string                                                                                           | false    |              |             |
 
 ## codersdk.ChatModelsResponse
 
@@ -3101,6 +4358,94 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 |-------------|-------------------------------------------------------------------|----------|--------------|-------------|
 | `providers` | array of [codersdk.ChatModelProvider](#codersdkchatmodelprovider) | false    |              |             |
 
+## codersdk.ChatPersonalModelOverride
+
+```json
+{
+  "context": "root",
+  "is_malformed": true,
+  "is_set": true,
+  "mode": "deployment_default",
+  "model_config_id": "string"
+}
+```
+
+### Properties
+
+| Name              | Type                                                                                   | Required | Restrictions | Description |
+|-------------------|----------------------------------------------------------------------------------------|----------|--------------|-------------|
+| `context`         | [codersdk.ChatPersonalModelOverrideContext](#codersdkchatpersonalmodeloverridecontext) | false    |              |             |
+| `is_malformed`    | boolean                                                                                | false    |              |             |
+| `is_set`          | boolean                                                                                | false    |              |             |
+| `mode`            | [codersdk.ChatPersonalModelOverrideMode](#codersdkchatpersonalmodeloverridemode)       | false    |              |             |
+| `model_config_id` | string                                                                                 | false    |              |             |
+
+## codersdk.ChatPersonalModelOverrideContext
+
+```json
+"root"
+```
+
+### Properties
+
+#### Enumerated Values
+
+| Value(s)                     |
+|------------------------------|
+| `explore`, `general`, `root` |
+
+## codersdk.ChatPersonalModelOverrideDeploymentDefaults
+
+```json
+{
+  "explore": {
+    "context": "general",
+    "is_malformed": true,
+    "model_config_id": "string"
+  },
+  "general": {
+    "context": "general",
+    "is_malformed": true,
+    "model_config_id": "string"
+  }
+}
+```
+
+### Properties
+
+| Name      | Type                                                                     | Required | Restrictions | Description |
+|-----------|--------------------------------------------------------------------------|----------|--------------|-------------|
+| `explore` | [codersdk.ChatModelOverrideResponse](#codersdkchatmodeloverrideresponse) | false    |              |             |
+| `general` | [codersdk.ChatModelOverrideResponse](#codersdkchatmodeloverrideresponse) | false    |              |             |
+
+## codersdk.ChatPersonalModelOverrideMode
+
+```json
+"deployment_default"
+```
+
+### Properties
+
+#### Enumerated Values
+
+| Value(s)                                      |
+|-----------------------------------------------|
+| `chat_default`, `deployment_default`, `model` |
+
+## codersdk.ChatPersonalModelOverridesAdminSettings
+
+```json
+{
+  "allow_users": true
+}
+```
+
+### Properties
+
+| Name          | Type    | Required | Restrictions | Description |
+|---------------|---------|----------|--------------|-------------|
+| `allow_users` | boolean | false    |              |             |
+
 ## codersdk.ChatPlanMode
 
 ```json
@@ -3114,6 +4459,70 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | Value(s) |
 |----------|
 | `plan`   |
+
+## codersdk.ChatPlanModeInstructionsResponse
+
+```json
+{
+  "plan_mode_instructions": "string"
+}
+```
+
+### Properties
+
+| Name                     | Type   | Required | Restrictions | Description |
+|--------------------------|--------|----------|--------------|-------------|
+| `plan_mode_instructions` | string | false    |              |             |
+
+## codersdk.ChatProviderConfig
+
+```json
+{
+  "allow_central_api_key_fallback": true,
+  "allow_user_api_key": true,
+  "base_url": "string",
+  "central_api_key_enabled": true,
+  "created_at": "2019-08-24T14:15:22Z",
+  "display_name": "string",
+  "enabled": true,
+  "has_api_key": true,
+  "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+  "provider": "string",
+  "source": "database",
+  "updated_at": "2019-08-24T14:15:22Z"
+}
+```
+
+### Properties
+
+| Name                             | Type                                                                   | Required | Restrictions | Description |
+|----------------------------------|------------------------------------------------------------------------|----------|--------------|-------------|
+| `allow_central_api_key_fallback` | boolean                                                                | false    |              |             |
+| `allow_user_api_key`             | boolean                                                                | false    |              |             |
+| `base_url`                       | string                                                                 | false    |              |             |
+| `central_api_key_enabled`        | boolean                                                                | false    |              |             |
+| `created_at`                     | string                                                                 | false    |              |             |
+| `display_name`                   | string                                                                 | false    |              |             |
+| `enabled`                        | boolean                                                                | false    |              |             |
+| `has_api_key`                    | boolean                                                                | false    |              |             |
+| `id`                             | string                                                                 | false    |              |             |
+| `provider`                       | string                                                                 | false    |              |             |
+| `source`                         | [codersdk.ChatProviderConfigSource](#codersdkchatproviderconfigsource) | false    |              |             |
+| `updated_at`                     | string                                                                 | false    |              |             |
+
+## codersdk.ChatProviderConfigSource
+
+```json
+"database"
+```
+
+### Properties
+
+#### Enumerated Values
+
+| Value(s)                              |
+|---------------------------------------|
+| `database`, `env_preset`, `supported` |
 
 ## codersdk.ChatQueuedMessage
 
@@ -3632,6 +5041,40 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `tool_call_id` | string | false    |              |             |
 | `tool_name`    | string | false    |              |             |
 
+## codersdk.ChatSystemPromptResponse
+
+```json
+{
+  "default_system_prompt": "string",
+  "include_default_system_prompt": true,
+  "system_prompt": "string"
+}
+```
+
+### Properties
+
+| Name                            | Type    | Required | Restrictions | Description |
+|---------------------------------|---------|----------|--------------|-------------|
+| `default_system_prompt`         | string  | false    |              |             |
+| `include_default_system_prompt` | boolean | false    |              |             |
+| `system_prompt`                 | string  | false    |              |             |
+
+## codersdk.ChatTemplateAllowlist
+
+```json
+{
+  "template_ids": [
+    "string"
+  ]
+}
+```
+
+### Properties
+
+| Name           | Type            | Required | Restrictions | Description |
+|----------------|-----------------|----------|--------------|-------------|
+| `template_ids` | array of string | false    |              |             |
+
 ## codersdk.ChatWatchEvent
 
 ```json
@@ -3798,6 +5241,20 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | Value(s)                                                                                                         |
 |------------------------------------------------------------------------------------------------------------------|
 | `action_required`, `created`, `deleted`, `diff_status_change`, `status_change`, `summary_change`, `title_change` |
+
+## codersdk.ChatWorkspaceTTLResponse
+
+```json
+{
+  "workspace_ttl_ms": 0
+}
+```
+
+### Properties
+
+| Name               | Type    | Required | Restrictions | Description                                                                                                                 |
+|--------------------|---------|----------|--------------|-----------------------------------------------------------------------------------------------------------------------------|
+| `workspace_ttl_ms` | integer | false    |              | Workspace ttl ms is the workspace TTL in milliseconds. Zero means disabled, so the template's own autostop setting applies. |
 
 ## codersdk.ConnectionLatency
 
@@ -4253,6 +5710,215 @@ AuthorizationObject can represent a "set" of objects, such as: all workspaces in
 | `queued_message` | [codersdk.ChatQueuedMessage](#codersdkchatqueuedmessage) | false    |              |             |
 | `warnings`       | array of string                                          | false    |              |             |
 
+## codersdk.CreateChatModelConfigRequest
+
+```json
+{
+  "compression_threshold": 0,
+  "context_limit": 0,
+  "display_name": "string",
+  "enabled": true,
+  "is_default": true,
+  "model": "string",
+  "model_config": {
+    "cost": {
+      "cache_read_price_per_million_tokens": 0,
+      "cache_write_price_per_million_tokens": 0,
+      "input_price_per_million_tokens": 0,
+      "output_price_per_million_tokens": 0
+    },
+    "frequency_penalty": 0,
+    "max_output_tokens": 0,
+    "presence_penalty": 0,
+    "provider_options": {
+      "anthropic": {
+        "allowed_domains": [
+          "string"
+        ],
+        "blocked_domains": [
+          "string"
+        ],
+        "disable_parallel_tool_use": true,
+        "effort": "string",
+        "send_reasoning": true,
+        "thinking": {
+          "budget_tokens": 0
+        },
+        "web_search_enabled": true
+      },
+      "google": {
+        "cached_content": "string",
+        "safety_settings": [
+          {
+            "category": "string",
+            "threshold": "string"
+          }
+        ],
+        "thinking_config": {
+          "include_thoughts": true,
+          "thinking_budget": 0
+        },
+        "threshold": "string",
+        "web_search_enabled": true
+      },
+      "openai": {
+        "allowed_domains": [
+          "string"
+        ],
+        "include": [
+          "string"
+        ],
+        "instructions": "string",
+        "log_probs": true,
+        "logit_bias": {
+          "property1": 0,
+          "property2": 0
+        },
+        "max_completion_tokens": 0,
+        "max_tool_calls": 0,
+        "metadata": {
+          "property1": null,
+          "property2": null
+        },
+        "parallel_tool_calls": true,
+        "prediction": {
+          "property1": null,
+          "property2": null
+        },
+        "prompt_cache_key": "string",
+        "reasoning_effort": "string",
+        "reasoning_summary": "string",
+        "safety_identifier": "string",
+        "search_context_size": "string",
+        "service_tier": "string",
+        "store": true,
+        "strict_json_schema": true,
+        "structured_outputs": true,
+        "text_verbosity": "string",
+        "top_log_probs": 0,
+        "user": "string",
+        "web_search_enabled": true
+      },
+      "openaicompat": {
+        "reasoning_effort": "string",
+        "user": "string"
+      },
+      "openrouter": {
+        "extra_body": {
+          "property1": null,
+          "property2": null
+        },
+        "include_usage": true,
+        "log_probs": true,
+        "logit_bias": {
+          "property1": 0,
+          "property2": 0
+        },
+        "parallel_tool_calls": true,
+        "provider": {
+          "allow_fallbacks": true,
+          "data_collection": "string",
+          "ignore": [
+            "string"
+          ],
+          "only": [
+            "string"
+          ],
+          "order": [
+            "string"
+          ],
+          "quantizations": [
+            "string"
+          ],
+          "require_parameters": true,
+          "sort": "string"
+        },
+        "reasoning": {
+          "effort": "string",
+          "enabled": true,
+          "exclude": true,
+          "max_tokens": 0
+        },
+        "user": "string"
+      },
+      "vercel": {
+        "extra_body": {
+          "property1": null,
+          "property2": null
+        },
+        "logit_bias": {
+          "property1": 0,
+          "property2": 0
+        },
+        "logprobs": true,
+        "parallel_tool_calls": true,
+        "providerOptions": {
+          "models": [
+            "string"
+          ],
+          "order": [
+            "string"
+          ]
+        },
+        "reasoning": {
+          "effort": "string",
+          "enabled": true,
+          "exclude": true,
+          "max_tokens": 0
+        },
+        "top_logprobs": 0,
+        "user": "string"
+      }
+    },
+    "temperature": 0,
+    "top_k": 0,
+    "top_p": 0
+  },
+  "provider": "string"
+}
+```
+
+### Properties
+
+| Name                    | Type                                                         | Required | Restrictions | Description |
+|-------------------------|--------------------------------------------------------------|----------|--------------|-------------|
+| `compression_threshold` | integer                                                      | false    |              |             |
+| `context_limit`         | integer                                                      | false    |              |             |
+| `display_name`          | string                                                       | false    |              |             |
+| `enabled`               | boolean                                                      | false    |              |             |
+| `is_default`            | boolean                                                      | false    |              |             |
+| `model`                 | string                                                       | false    |              |             |
+| `model_config`          | [codersdk.ChatModelCallConfig](#codersdkchatmodelcallconfig) | false    |              |             |
+| `provider`              | string                                                       | false    |              |             |
+
+## codersdk.CreateChatProviderConfigRequest
+
+```json
+{
+  "allow_central_api_key_fallback": true,
+  "allow_user_api_key": true,
+  "api_key": "string",
+  "base_url": "string",
+  "central_api_key_enabled": true,
+  "display_name": "string",
+  "enabled": true,
+  "provider": "string"
+}
+```
+
+### Properties
+
+| Name                             | Type    | Required | Restrictions | Description |
+|----------------------------------|---------|----------|--------------|-------------|
+| `allow_central_api_key_fallback` | boolean | false    |              |             |
+| `allow_user_api_key`             | boolean | false    |              |             |
+| `api_key`                        | string  | false    |              |             |
+| `base_url`                       | string  | false    |              |             |
+| `central_api_key_enabled`        | boolean | false    |              |             |
+| `display_name`                   | string  | false    |              |             |
+| `enabled`                        | boolean | false    |              |             |
+| `provider`                       | string  | false    |              |             |
+
 ## codersdk.CreateChatRequest
 
 ```json
@@ -4682,6 +6348,20 @@ This is required on creation to enable a user-flow of validating a template work
 | `scope`      | [codersdk.APIKeyScope](#codersdkapikeyscope)                        | false    |              | Deprecated: use Scopes instead. |
 | `scopes`     | array of [codersdk.APIKeyScope](#codersdkapikeyscope)               | false    |              |                                 |
 | `token_name` | string                                                              | false    |              |                                 |
+
+## codersdk.CreateUserChatProviderKeyRequest
+
+```json
+{
+  "api_key": "string"
+}
+```
+
+### Properties
+
+| Name      | Type   | Required | Restrictions | Description |
+|-----------|--------|----------|--------------|-------------|
+| `api_key` | string | false    |              |             |
 
 ## codersdk.CreateUserRequestWithOrgs
 
@@ -7739,6 +9419,26 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 | `name`       | string | false    |              |             |
 | `username`   | string | true     |              |             |
 
+## codersdk.ModelCostConfig
+
+```json
+{
+  "cache_read_price_per_million_tokens": 0,
+  "cache_write_price_per_million_tokens": 0,
+  "input_price_per_million_tokens": 0,
+  "output_price_per_million_tokens": 0
+}
+```
+
+### Properties
+
+| Name                                   | Type   | Required | Restrictions | Description |
+|----------------------------------------|--------|----------|--------------|-------------|
+| `cache_read_price_per_million_tokens`  | number | false    |              |             |
+| `cache_write_price_per_million_tokens` | number | false    |              |             |
+| `input_price_per_million_tokens`       | number | false    |              |             |
+| `output_price_per_million_tokens`      | number | false    |              |             |
+
 ## codersdk.NotificationMethodsResponse
 
 ```json
@@ -9812,6 +11512,20 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 | `collect_db_metrics`       | boolean                              | false    |              |             |
 | `enable`                   | boolean                              | false    |              |             |
 
+## codersdk.ProposeChatTitleResponse
+
+```json
+{
+  "title": "string"
+}
+```
+
+### Properties
+
+| Name    | Type   | Required | Restrictions | Description |
+|---------|--------|----------|--------------|-------------|
+| `title` | string | false    |              |             |
+
 ## codersdk.ProvisionerConfig
 
 ```json
@@ -11158,6 +12872,28 @@ Only certain features set these fields: - FeatureManagedAgentLimit|
 |---------------|--------------------------------------------------------|----------|--------------|-------------|
 | `usage_stats` | [codersdk.UsageStatsConfig](#codersdkusagestatsconfig) | false    |              |             |
 
+## codersdk.SubmitToolResultsRequest
+
+```json
+{
+  "results": [
+    {
+      "is_error": true,
+      "output": [
+        0
+      ],
+      "tool_call_id": "string"
+    }
+  ]
+}
+```
+
+### Properties
+
+| Name      | Type                                                | Required | Restrictions | Description |
+|-----------|-----------------------------------------------------|----------|--------------|-------------|
+| `results` | array of [codersdk.ToolResult](#codersdktoolresult) | false    |              |             |
+
 ## codersdk.SupportConfig
 
 ```json
@@ -12486,6 +14222,26 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 |----------------------|---------|----------|--------------|-------------|
 | `max_token_lifetime` | integer | false    |              |             |
 
+## codersdk.ToolResult
+
+```json
+{
+  "is_error": true,
+  "output": [
+    0
+  ],
+  "tool_call_id": "string"
+}
+```
+
+### Properties
+
+| Name           | Type             | Required | Restrictions | Description |
+|----------------|------------------|----------|--------------|-------------|
+| `is_error`     | boolean          | false    |              |             |
+| `output`       | array of integer | false    |              |             |
+| `tool_call_id` | string           | false    |              |             |
+
 ## codersdk.TraceConfig
 
 ```json
@@ -12536,6 +14292,26 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 |------|--------|----------|--------------|-------------|
 | `id` | string | true     |              |             |
 
+## codersdk.UpdateAdvisorConfigRequest
+
+```json
+{
+  "enabled": true,
+  "max_output_tokens": 0,
+  "max_uses_per_run": 0,
+  "model_config_id": "f5fb4d91-62ca-4377-9ee6-5d43ba00d205"
+}
+```
+
+### Properties
+
+| Name                | Type    | Required | Restrictions | Description                                                                                                                                                                                                                                                                                                                  |
+|---------------------|---------|----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `enabled`           | boolean | false    |              | Enabled toggles the advisor runtime. When false, advisor is not attached to new chats.                                                                                                                                                                                                                                       |
+| `max_output_tokens` | integer | false    |              | Max output tokens caps the advisor model response tokens. 0 means use the runtime default.                                                                                                                                                                                                                                   |
+| `max_uses_per_run`  | integer | false    |              | Max uses per run caps how many times the advisor can be invoked per chat run. 0 means unlimited.                                                                                                                                                                                                                             |
+| `model_config_id`   | string  | false    |              | Model config ID selects a specific chat model config to power the advisor. uuid.Nil means reuse the outer chat model. The runtime must fall back to the outer chat model when this ID cannot be resolved (e.g. the referenced model config was soft-deleted or its provider was disabled after the admin saved this config). |
+
 ## codersdk.UpdateAppearanceConfig
 
 ```json
@@ -12565,6 +14341,325 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 | `application_name`     | string                                                  | false    |              |                                                                     |
 | `logo_url`             | string                                                  | false    |              |                                                                     |
 | `service_banner`       | [codersdk.BannerConfig](#codersdkbannerconfig)          | false    |              | Deprecated: ServiceBanner has been replaced by AnnouncementBanners. |
+
+## codersdk.UpdateChatAutoArchiveDaysRequest
+
+```json
+{
+  "auto_archive_days": 0
+}
+```
+
+### Properties
+
+| Name                | Type    | Required | Restrictions | Description |
+|---------------------|---------|----------|--------------|-------------|
+| `auto_archive_days` | integer | false    |              |             |
+
+## codersdk.UpdateChatComputerUseProviderRequest
+
+```json
+{
+  "provider": "string"
+}
+```
+
+### Properties
+
+| Name       | Type   | Required | Restrictions | Description |
+|------------|--------|----------|--------------|-------------|
+| `provider` | string | false    |              |             |
+
+## codersdk.UpdateChatDebugLoggingAllowUsersRequest
+
+```json
+{
+  "allow_users": true
+}
+```
+
+### Properties
+
+| Name          | Type    | Required | Restrictions | Description |
+|---------------|---------|----------|--------------|-------------|
+| `allow_users` | boolean | false    |              |             |
+
+## codersdk.UpdateChatDebugRetentionDaysRequest
+
+```json
+{
+  "debug_retention_days": 0
+}
+```
+
+### Properties
+
+| Name                   | Type    | Required | Restrictions | Description |
+|------------------------|---------|----------|--------------|-------------|
+| `debug_retention_days` | integer | false    |              |             |
+
+## codersdk.UpdateChatDesktopEnabledRequest
+
+```json
+{
+  "enable_desktop": true
+}
+```
+
+### Properties
+
+| Name             | Type    | Required | Restrictions | Description |
+|------------------|---------|----------|--------------|-------------|
+| `enable_desktop` | boolean | false    |              |             |
+
+## codersdk.UpdateChatModelConfigRequest
+
+```json
+{
+  "compression_threshold": 0,
+  "context_limit": 0,
+  "display_name": "string",
+  "enabled": true,
+  "is_default": true,
+  "model": "string",
+  "model_config": {
+    "cost": {
+      "cache_read_price_per_million_tokens": 0,
+      "cache_write_price_per_million_tokens": 0,
+      "input_price_per_million_tokens": 0,
+      "output_price_per_million_tokens": 0
+    },
+    "frequency_penalty": 0,
+    "max_output_tokens": 0,
+    "presence_penalty": 0,
+    "provider_options": {
+      "anthropic": {
+        "allowed_domains": [
+          "string"
+        ],
+        "blocked_domains": [
+          "string"
+        ],
+        "disable_parallel_tool_use": true,
+        "effort": "string",
+        "send_reasoning": true,
+        "thinking": {
+          "budget_tokens": 0
+        },
+        "web_search_enabled": true
+      },
+      "google": {
+        "cached_content": "string",
+        "safety_settings": [
+          {
+            "category": "string",
+            "threshold": "string"
+          }
+        ],
+        "thinking_config": {
+          "include_thoughts": true,
+          "thinking_budget": 0
+        },
+        "threshold": "string",
+        "web_search_enabled": true
+      },
+      "openai": {
+        "allowed_domains": [
+          "string"
+        ],
+        "include": [
+          "string"
+        ],
+        "instructions": "string",
+        "log_probs": true,
+        "logit_bias": {
+          "property1": 0,
+          "property2": 0
+        },
+        "max_completion_tokens": 0,
+        "max_tool_calls": 0,
+        "metadata": {
+          "property1": null,
+          "property2": null
+        },
+        "parallel_tool_calls": true,
+        "prediction": {
+          "property1": null,
+          "property2": null
+        },
+        "prompt_cache_key": "string",
+        "reasoning_effort": "string",
+        "reasoning_summary": "string",
+        "safety_identifier": "string",
+        "search_context_size": "string",
+        "service_tier": "string",
+        "store": true,
+        "strict_json_schema": true,
+        "structured_outputs": true,
+        "text_verbosity": "string",
+        "top_log_probs": 0,
+        "user": "string",
+        "web_search_enabled": true
+      },
+      "openaicompat": {
+        "reasoning_effort": "string",
+        "user": "string"
+      },
+      "openrouter": {
+        "extra_body": {
+          "property1": null,
+          "property2": null
+        },
+        "include_usage": true,
+        "log_probs": true,
+        "logit_bias": {
+          "property1": 0,
+          "property2": 0
+        },
+        "parallel_tool_calls": true,
+        "provider": {
+          "allow_fallbacks": true,
+          "data_collection": "string",
+          "ignore": [
+            "string"
+          ],
+          "only": [
+            "string"
+          ],
+          "order": [
+            "string"
+          ],
+          "quantizations": [
+            "string"
+          ],
+          "require_parameters": true,
+          "sort": "string"
+        },
+        "reasoning": {
+          "effort": "string",
+          "enabled": true,
+          "exclude": true,
+          "max_tokens": 0
+        },
+        "user": "string"
+      },
+      "vercel": {
+        "extra_body": {
+          "property1": null,
+          "property2": null
+        },
+        "logit_bias": {
+          "property1": 0,
+          "property2": 0
+        },
+        "logprobs": true,
+        "parallel_tool_calls": true,
+        "providerOptions": {
+          "models": [
+            "string"
+          ],
+          "order": [
+            "string"
+          ]
+        },
+        "reasoning": {
+          "effort": "string",
+          "enabled": true,
+          "exclude": true,
+          "max_tokens": 0
+        },
+        "top_logprobs": 0,
+        "user": "string"
+      }
+    },
+    "temperature": 0,
+    "top_k": 0,
+    "top_p": 0
+  },
+  "provider": "string"
+}
+```
+
+### Properties
+
+| Name                    | Type                                                         | Required | Restrictions | Description |
+|-------------------------|--------------------------------------------------------------|----------|--------------|-------------|
+| `compression_threshold` | integer                                                      | false    |              |             |
+| `context_limit`         | integer                                                      | false    |              |             |
+| `display_name`          | string                                                       | false    |              |             |
+| `enabled`               | boolean                                                      | false    |              |             |
+| `is_default`            | boolean                                                      | false    |              |             |
+| `model`                 | string                                                       | false    |              |             |
+| `model_config`          | [codersdk.ChatModelCallConfig](#codersdkchatmodelcallconfig) | false    |              |             |
+| `provider`              | string                                                       | false    |              |             |
+
+## codersdk.UpdateChatModelOverrideRequest
+
+```json
+{
+  "model_config_id": "string"
+}
+```
+
+### Properties
+
+| Name              | Type   | Required | Restrictions | Description |
+|-------------------|--------|----------|--------------|-------------|
+| `model_config_id` | string | false    |              |             |
+
+## codersdk.UpdateChatPersonalModelOverridesAdminSettingsRequest
+
+```json
+{
+  "allow_users": true
+}
+```
+
+### Properties
+
+| Name          | Type    | Required | Restrictions | Description |
+|---------------|---------|----------|--------------|-------------|
+| `allow_users` | boolean | false    |              |             |
+
+## codersdk.UpdateChatPlanModeInstructionsRequest
+
+```json
+{
+  "plan_mode_instructions": "string"
+}
+```
+
+### Properties
+
+| Name                     | Type   | Required | Restrictions | Description |
+|--------------------------|--------|----------|--------------|-------------|
+| `plan_mode_instructions` | string | false    |              |             |
+
+## codersdk.UpdateChatProviderConfigRequest
+
+```json
+{
+  "allow_central_api_key_fallback": true,
+  "allow_user_api_key": true,
+  "api_key": "string",
+  "base_url": "string",
+  "central_api_key_enabled": true,
+  "display_name": "string",
+  "enabled": true
+}
+```
+
+### Properties
+
+| Name                             | Type    | Required | Restrictions | Description |
+|----------------------------------|---------|----------|--------------|-------------|
+| `allow_central_api_key_fallback` | boolean | false    |              |             |
+| `allow_user_api_key`             | boolean | false    |              |             |
+| `api_key`                        | string  | false    |              |             |
+| `base_url`                       | string  | false    |              |             |
+| `central_api_key_enabled`        | boolean | false    |              |             |
+| `display_name`                   | string  | false    |              |             |
+| `enabled`                        | boolean | false    |              |             |
 
 ## codersdk.UpdateChatRequest
 
@@ -12607,6 +14702,36 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 | Name             | Type    | Required | Restrictions | Description |
 |------------------|---------|----------|--------------|-------------|
 | `retention_days` | integer | false    |              |             |
+
+## codersdk.UpdateChatSystemPromptRequest
+
+```json
+{
+  "include_default_system_prompt": true,
+  "system_prompt": "string"
+}
+```
+
+### Properties
+
+| Name                            | Type    | Required | Restrictions | Description |
+|---------------------------------|---------|----------|--------------|-------------|
+| `include_default_system_prompt` | boolean | false    |              |             |
+| `system_prompt`                 | string  | false    |              |             |
+
+## codersdk.UpdateChatWorkspaceTTLRequest
+
+```json
+{
+  "workspace_ttl_ms": 0
+}
+```
+
+### Properties
+
+| Name               | Type    | Required | Restrictions | Description                                                                                                                 |
+|--------------------|---------|----------|--------------|-----------------------------------------------------------------------------------------------------------------------------|
+| `workspace_ttl_ms` | integer | false    |              | Workspace ttl ms is the workspace TTL in milliseconds. Zero means disabled, so the template's own autostop setting applies. |
 
 ## codersdk.UpdateCheckResponse
 
@@ -12782,6 +14907,36 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 |--------------------|--------------------------------------------------------|----------|--------------|-------------|
 | `terminal_font`    | [codersdk.TerminalFontName](#codersdkterminalfontname) | true     |              |             |
 | `theme_preference` | string                                                 | true     |              |             |
+
+## codersdk.UpdateUserChatDebugLoggingRequest
+
+```json
+{
+  "debug_logging_enabled": true
+}
+```
+
+### Properties
+
+| Name                    | Type    | Required | Restrictions | Description |
+|-------------------------|---------|----------|--------------|-------------|
+| `debug_logging_enabled` | boolean | false    |              |             |
+
+## codersdk.UpdateUserChatPersonalModelOverrideRequest
+
+```json
+{
+  "mode": "deployment_default",
+  "model_config_id": "string"
+}
+```
+
+### Properties
+
+| Name              | Type                                                                             | Required | Restrictions | Description |
+|-------------------|----------------------------------------------------------------------------------|----------|--------------|-------------|
+| `mode`            | [codersdk.ChatPersonalModelOverrideMode](#codersdkchatpersonalmodeloverridemode) | false    |              |             |
+| `model_config_id` | string                                                                           | false    |              |             |
 
 ## codersdk.UpdateUserNotificationPreferences
 
@@ -13278,6 +15433,111 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 |--------------------|--------------------------------------------------------|----------|--------------|-------------|
 | `terminal_font`    | [codersdk.TerminalFontName](#codersdkterminalfontname) | false    |              |             |
 | `theme_preference` | string                                                 | false    |              |             |
+
+## codersdk.UserChatCustomPrompt
+
+```json
+{
+  "custom_prompt": "string"
+}
+```
+
+### Properties
+
+| Name            | Type   | Required | Restrictions | Description |
+|-----------------|--------|----------|--------------|-------------|
+| `custom_prompt` | string | false    |              |             |
+
+## codersdk.UserChatDebugLoggingSettings
+
+```json
+{
+  "debug_logging_enabled": true,
+  "forced_by_deployment": true,
+  "user_toggle_allowed": true
+}
+```
+
+### Properties
+
+| Name                    | Type    | Required | Restrictions | Description |
+|-------------------------|---------|----------|--------------|-------------|
+| `debug_logging_enabled` | boolean | false    |              |             |
+| `forced_by_deployment`  | boolean | false    |              |             |
+| `user_toggle_allowed`   | boolean | false    |              |             |
+
+## codersdk.UserChatPersonalModelOverridesResponse
+
+```json
+{
+  "deployment_defaults": {
+    "explore": {
+      "context": "general",
+      "is_malformed": true,
+      "model_config_id": "string"
+    },
+    "general": {
+      "context": "general",
+      "is_malformed": true,
+      "model_config_id": "string"
+    }
+  },
+  "enabled": true,
+  "explore": {
+    "context": "root",
+    "is_malformed": true,
+    "is_set": true,
+    "mode": "deployment_default",
+    "model_config_id": "string"
+  },
+  "general": {
+    "context": "root",
+    "is_malformed": true,
+    "is_set": true,
+    "mode": "deployment_default",
+    "model_config_id": "string"
+  },
+  "root": {
+    "context": "root",
+    "is_malformed": true,
+    "is_set": true,
+    "mode": "deployment_default",
+    "model_config_id": "string"
+  }
+}
+```
+
+### Properties
+
+| Name                  | Type                                                                                                         | Required | Restrictions | Description |
+|-----------------------|--------------------------------------------------------------------------------------------------------------|----------|--------------|-------------|
+| `deployment_defaults` | [codersdk.ChatPersonalModelOverrideDeploymentDefaults](#codersdkchatpersonalmodeloverridedeploymentdefaults) | false    |              |             |
+| `enabled`             | boolean                                                                                                      | false    |              |             |
+| `explore`             | [codersdk.ChatPersonalModelOverride](#codersdkchatpersonalmodeloverride)                                     | false    |              |             |
+| `general`             | [codersdk.ChatPersonalModelOverride](#codersdkchatpersonalmodeloverride)                                     | false    |              |             |
+| `root`                | [codersdk.ChatPersonalModelOverride](#codersdkchatpersonalmodeloverride)                                     | false    |              |             |
+
+## codersdk.UserChatProviderConfig
+
+```json
+{
+  "display_name": "string",
+  "has_central_api_key_fallback": true,
+  "has_user_api_key": true,
+  "provider": "string",
+  "provider_id": "fe3d49af-4061-436b-ae60-f7044f252a44"
+}
+```
+
+### Properties
+
+| Name                           | Type    | Required | Restrictions | Description |
+|--------------------------------|---------|----------|--------------|-------------|
+| `display_name`                 | string  | false    |              |             |
+| `has_central_api_key_fallback` | boolean | false    |              |             |
+| `has_user_api_key`             | boolean | false    |              |             |
+| `provider`                     | string  | false    |              |             |
+| `provider_id`                  | string  | false    |              |             |
 
 ## codersdk.UserLatency
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2764,7 +2764,7 @@ export const ChatWatchEventKinds: ChatWatchEventKind[] = [
 export interface ChatWorkspaceTTLResponse {
 	/**
 	 * WorkspaceTTLMillis is the workspace TTL in milliseconds.
-	 * Zero means disabled — the template's own autostop setting applies.
+	 * Zero means disabled, so the template's own autostop setting applies.
 	 */
 	readonly workspace_ttl_ms: number;
 }
@@ -3625,7 +3625,7 @@ export const DefaultChatDebugRetentionDays = 30;
 // From codersdk/chats.go
 /**
  * DefaultChatWorkspaceTTL is the default TTL for chat workspaces.
- * Zero means disabled — the template's own autostop setting applies.
+ * Zero means disabled, so the template's own autostop setting applies.
  */
 export const DefaultChatWorkspaceTTL = 0;
 
@@ -8122,7 +8122,7 @@ export interface UpdateChatUsageLimitOverrideRequest {
 export interface UpdateChatWorkspaceTTLRequest {
 	/**
 	 * WorkspaceTTLMillis is the workspace TTL in milliseconds.
-	 * Zero means disabled — the template's own autostop setting applies.
+	 * Zero means disabled, so the template's own autostop setting applies.
 	 */
 	readonly workspace_ttl_ms: number;
 }


### PR DESCRIPTION
## What

Document every `/api/experimental/chats` handler that was previously
missing from `docs/reference/api/chats.md`. The user reported that
routes like `model-configs` were not in the API docs even though
related routes like `chats` were.

After inspecting `coderd/exp_chats.go`, ~47 handlers had no
`@Router` swag annotation at all, so swag silently skipped them.
This PR adds annotations to all of them and regenerates apidoc.

New documented routes include:

- `model-configs` (list/create/patch/delete)
- `providers` (list/create/patch/delete)
- `user-provider-configs` (list/upsert/delete)
- `config/system-prompt`, `config/plan-mode-instructions`,
  `config/model-override/{context}`, `config/personal-model-overrides`,
  `config/user-personal-model-overrides`, `config/desktop-enabled`,
  `config/computer-use-provider`, `config/debug-logging`,
  `config/user-debug-logging`, `config/advisor`,
  `config/user-prompt`, `config/workspace-ttl`,
  `config/debug-retention-days`, `config/auto-archive-days`,
  `config/template-allowlist`
- `{chat}/queue/{queuedMessage}` (delete/promote)
- `{chat}/title/propose`, `{chat}/tool-results`,
  `{chat}/debug/runs`, `{chat}/debug/runs/{debugRun}`

## Out of scope

Handlers already marked with `@x-apidocgen {"skip": true}` are left
untouched: `chatsByWorkspace`, the usage-limits family,
`retention-days`, `user-compaction-thresholds`, `prInsights`, and the
chat cost summary/users endpoints. Those skips look intentional, so
whether to surface them is a separate discussion.

## Side effect

Regenerating `coderd/apidoc/swagger.json` and
`docs/reference/api/schemas.md` propagated emdash characters from
three comments on `ChatWorkspaceTTL`-related types in
`codersdk/chats.go` into the generated artifacts, which the
`make lint/emdash` rule rejects. I rephrased those three comments
to remove the emdash. No semantic change.

## Validation

- `make gen` runs cleanly with no swag warnings.
- Pre-commit hook passes (`fmt`, `lint/go`, `lint/ts`, `lint/emdash`,
  `lint/markdown`, etc.).
- `docs/reference/api/chats.md` now has 64 sections (was 17).
- Swagger paths under `/api/experimental/chats` went from ~17 to 44.
- exp_chats.go diff is comment-only.

<details>
<summary>Implementation plan</summary>

For each handler in `coderd/exp_chats.go` that lacked an `@Router`
annotation:

1. Look up the canonical URL and request/response types in
   `codersdk/chats.go` (the SDK is the source of truth).
2. Add a comment block matching the existing `listChats` /
   `postChats` style, using `Tags: Chats` so they all land in
   `chats.md`.
3. Preserve any existing `// EXPERIMENTAL:` lines, `//nolint:`
   directives, or "Keep in sync with..." comments.
4. Run `make gen` to regenerate apidoc, swagger.json, chats.md,
   schemas.md (and downstream `site/src/api/typesGenerated.ts`).
5. Resolve the emdash lint failure by rephrasing the three
   offending source comments in `codersdk/chats.go`.

Notes:

- Path params use the chi names from `coderd/coderd.go` so
  `{providerConfig}`, `{modelConfig}`, `{queuedMessage}`,
  `{debugRun}`, `{context}` match the actual routes.
- Override `{context}` is a string enum (general/explore/
  title_generation for `model-override`, root/general for
  `user-personal-model-overrides`).
- `{queuedMessage}` is an integer ID, not a UUID.

</details>

---

Generated with Coder Agents.