### PR TITLE
test: use typed atomics in test files

### DIFF
--- a/.claude/docs/GO.md
+++ b/.claude/docs/GO.md
@@ -68,7 +68,7 @@ directive version required in `go.mod`.
 | `fmt.Sprintf` + append to `[]byte` | `fmt.Appendf(buf, …)` (also `Append`, `Appendln`) | 1.18 |
 | `reflect.TypeOf((*T)(nil)).Elem()` | `reflect.TypeFor[T]()` | 1.22 |
 | `*(*[4]byte)(slice)` unsafe cast | `[4]byte(slice)` direct conversion | 1.20 |
-| `atomic.LoadInt64` / `StoreInt64` | `atomic.Int64` (also `Bool`, `Uint64`, `Pointer[T]`) | 1.19 |
+| `atomic.LoadInt64` / `AddInt64` / `StoreInt64` etc. | `atomic.Int64` (also `Int32`, `Uint32`, `Uint64`, `Bool`, `Pointer[T]`) | 1.19 |
 | `crypto/rand.Read(buf)` + hex/base64 encode | `crypto/rand.Text()` (one call) | 1.24 |
 | Checking `crypto/rand.Read` error | don't: return is always nil | 1.24 |
 | `time.Sleep` in tests | `testing/synctest` (deterministic fake clock) | 1.24/1.25 |

--- a/cli/agent_test.go
+++ b/cli/agent_test.go
@@ -122,8 +122,8 @@ func TestWorkspaceAgent(t *testing.T) {
 		var (
 			admin              = coderdtest.CreateFirstUser(t, client)
 			member, memberUser = coderdtest.CreateAnotherUser(t, client, admin.OrganizationID)
-			called             int64
-			derpCalled         int64
+			called             atomic.Int64
+			derpCalled         atomic.Int64
 		)
 
 		setHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -133,9 +133,9 @@ func TestWorkspaceAgent(t *testing.T) {
 				assert.Equal(t, "very-wow-"+client.URL.String(), r.Header.Get("X-Process-Testing"))
 				assert.Equal(t, "more-wow", r.Header.Get("X-Process-Testing2"))
 				if strings.HasPrefix(r.URL.Path, "/derp") {
-					atomic.AddInt64(&derpCalled, 1)
+					derpCalled.Add(1)
 				} else {
-					atomic.AddInt64(&called, 1)
+					called.Add(1)
 				}
 			}
 			coderAPI.RootHandler.ServeHTTP(w, r)
@@ -178,8 +178,8 @@ func TestWorkspaceAgent(t *testing.T) {
 		err := clientInv.WithContext(ctx).Run()
 		require.NoError(t, err)
 
-		require.Greater(t, atomic.LoadInt64(&called), int64(0), "expected coderd to be reached with custom headers")
-		require.Greater(t, atomic.LoadInt64(&derpCalled), int64(0), "expected /derp to be called with custom headers")
+		require.Greater(t, called.Load(), int64(0), "expected coderd to be reached with custom headers")
+		require.Greater(t, derpCalled.Load(), int64(0), "expected /derp to be called with custom headers")
 	})
 
 	t.Run("DisabledServers", func(t *testing.T) {

--- a/cli/cliui/agent_test.go
+++ b/cli/cliui/agent_test.go
@@ -536,7 +536,7 @@ func TestAgent(t *testing.T) {
 
 	t.Run("NotInfinite", func(t *testing.T) {
 		t.Parallel()
-		var fetchCalled uint64
+		var fetchCalled atomic.Uint64
 
 		cmd := &serpent.Command{
 			Handler: func(inv *serpent.Invocation) error {
@@ -544,7 +544,7 @@ func TestAgent(t *testing.T) {
 				err := cliui.Agent(inv.Context(), &buf, uuid.Nil, cliui.AgentOptions{
 					FetchInterval: 10 * time.Millisecond,
 					Fetch: func(ctx context.Context, agentID uuid.UUID) (codersdk.WorkspaceAgent, error) {
-						atomic.AddUint64(&fetchCalled, 1)
+						fetchCalled.Add(1)
 
 						return codersdk.WorkspaceAgent{
 							Status:         codersdk.WorkspaceAgentConnected,
@@ -557,7 +557,7 @@ func TestAgent(t *testing.T) {
 				}
 
 				require.Never(t, func() bool {
-					called := atomic.LoadUint64(&fetchCalled)
+					called := fetchCalled.Load()
 					return called > 5 || called == 0
 				}, time.Second, 100*time.Millisecond)
 

--- a/cli/cliui/output_test.go
+++ b/cli/cliui/output_test.go
@@ -80,7 +80,7 @@ func Test_OutputFormatter(t *testing.T) {
 	t.Run("OK", func(t *testing.T) {
 		t.Parallel()
 
-		var called int64
+		var called atomic.Int64
 		f := cliui.NewOutputFormatter(
 			cliui.JSONFormat(),
 			&format{
@@ -95,7 +95,7 @@ func Test_OutputFormatter(t *testing.T) {
 					})
 				},
 				formatFn: func(_ context.Context, _ any) (string, error) {
-					atomic.AddInt64(&called, 1)
+					called.Add(1)
 					return "foo", nil
 				},
 			},
@@ -121,18 +121,18 @@ func Test_OutputFormatter(t *testing.T) {
 		var got []string
 		require.NoError(t, json.Unmarshal([]byte(out), &got))
 		require.Equal(t, data, got)
-		require.EqualValues(t, 0, atomic.LoadInt64(&called))
+		require.EqualValues(t, 0, called.Load())
 
 		require.NoError(t, fs.Set("output", "foo"))
 		out, err = f.Format(ctx, data)
 		require.NoError(t, err)
 		require.Equal(t, "foo", out)
-		require.EqualValues(t, 1, atomic.LoadInt64(&called))
+		require.EqualValues(t, 1, called.Load())
 
 		require.Error(t, fs.Set("output", "bar"))
 		out, err = f.Format(ctx, data)
 		require.NoError(t, err)
 		require.Equal(t, "foo", out)
-		require.EqualValues(t, 2, atomic.LoadInt64(&called))
+		require.EqualValues(t, 2, called.Load())
 	})
 }

--- a/cli/gitssh_test.go
+++ b/cli/gitssh_test.go
@@ -118,10 +118,10 @@ func TestGitSSH(t *testing.T) {
 
 		setupCtx := testutil.Context(t, testutil.WaitLong)
 		client, token, pubkey := prepareTestGitSSH(setupCtx, t)
-		var inc int64
+		var inc atomic.Int64
 		errC := make(chan error, 1)
 		addr := serveSSHForGitSSH(t, func(s ssh.Session) {
-			atomic.AddInt64(&inc, 1)
+			inc.Add(1)
 			t.Log("got authenticated session")
 			select {
 			case errC <- s.Exit(0):
@@ -146,7 +146,7 @@ func TestGitSSH(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitSuperLong)
 		err := inv.WithContext(ctx).Run()
 		require.NoError(t, err)
-		require.EqualValues(t, 1, inc)
+		require.EqualValues(t, 1, inc.Load())
 
 		err = <-errC
 		require.NoError(t, err, "error in agent execute")

--- a/cli/root_test.go
+++ b/cli/root_test.go
@@ -164,9 +164,9 @@ func TestRoot(t *testing.T) {
 		t.Parallel()
 
 		var url string
-		var called int64
+		var called atomic.Int64
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			atomic.AddInt64(&called, 1)
+			called.Add(1)
 			assert.Equal(t, "wow", r.Header.Get("X-Testing"))
 			assert.Equal(t, "Dean was Here!", r.Header.Get("Cool-Header"))
 			assert.Equal(t, "very-wow-"+url, r.Header.Get("X-Process-Testing"))
@@ -193,7 +193,7 @@ func TestRoot(t *testing.T) {
 		err := inv.Run()
 		require.Error(t, err)
 		require.ErrorContains(t, err, "unexpected status code 410")
-		require.EqualValues(t, 1, atomic.LoadInt64(&called), "called exactly once")
+		require.EqualValues(t, 1, called.Load(), "called exactly once")
 	})
 }
 
@@ -238,7 +238,7 @@ func TestDERPHeaders(t *testing.T) {
 			"Cool-Header":       "Dean was Here!",
 			"X-Process-Testing": "very-wow",
 		}
-		derpCalled int64
+		derpCalled atomic.Int64
 	)
 	setHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(r.URL.Path, "/derp") {
@@ -252,7 +252,7 @@ func TestDERPHeaders(t *testing.T) {
 			if ok {
 				// Only increment if all the headers are set, because the agent
 				// calls derp also.
-				atomic.AddInt64(&derpCalled, 1)
+				derpCalled.Add(1)
 			}
 		}
 
@@ -289,7 +289,7 @@ func TestDERPHeaders(t *testing.T) {
 	pty.ExpectMatch("pong from " + workspace.Name)
 	<-cmdDone
 
-	require.Greater(t, atomic.LoadInt64(&derpCalled), int64(0), "expected /derp to be called at least once")
+	require.Greater(t, derpCalled.Load(), int64(0), "expected /derp to be called at least once")
 }
 
 func TestHandlersOK(t *testing.T) {

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -745,13 +745,13 @@ func TestServer(t *testing.T) {
 
 		var (
 			expectAddr string
-			dials      int64
+			dials      atomic.Int64
 		)
 		client := codersdk.New(accessURL)
 		client.HTTPClient = &http.Client{
 			Transport: &http.Transport{
 				DialTLSContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-					atomic.AddInt64(&dials, 1)
+					dials.Add(1)
 					assert.Equal(t, expectAddr, addr)
 
 					host, _, err := net.SplitHostPort(addr)
@@ -786,14 +786,14 @@ func TestServer(t *testing.T) {
 		expectAddr = "alpaca.com:443"
 		_, err := client.HasFirstUser(ctx)
 		require.NoError(t, err)
-		require.EqualValues(t, 1, atomic.LoadInt64(&dials))
+		require.EqualValues(t, 1, dials.Load())
 
 		// Use the second certificate (wildcard) and hostname.
 		client.URL.Host = "hi.llama.com:443"
 		expectAddr = "hi.llama.com:443"
 		_, err = client.HasFirstUser(ctx)
 		require.NoError(t, err)
-		require.EqualValues(t, 2, atomic.LoadInt64(&dials))
+		require.EqualValues(t, 2, dials.Load())
 	})
 
 	t.Run("TLSAndHTTP", func(t *testing.T) {

--- a/cli/templateedit_test.go
+++ b/cli/templateedit_test.go
@@ -464,7 +464,7 @@ func TestTemplateEdit(t *testing.T) {
 
 			// Make a proxy server that will return a valid entitlements
 			// response, including a valid advanced scheduling entitlement.
-			var updateTemplateCalled int64
+			var updateTemplateCalled atomic.Int64
 			proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.URL.Path == "/api/v2/entitlements" {
 					res := codersdk.Entitlements{
@@ -499,7 +499,7 @@ func TestTemplateEdit(t *testing.T) {
 					assert.EqualValues(t, req.AutostopRequirement.Weeks, 3)
 
 					r.Body = io.NopCloser(bytes.NewReader(body))
-					atomic.AddInt64(&updateTemplateCalled, 1)
+					updateTemplateCalled.Add(1)
 					// We still want to call the real route.
 				}
 
@@ -534,7 +534,7 @@ func TestTemplateEdit(t *testing.T) {
 			err = inv.WithContext(ctx).Run()
 			require.NoError(t, err)
 
-			require.EqualValues(t, 1, atomic.LoadInt64(&updateTemplateCalled))
+			require.EqualValues(t, 1, updateTemplateCalled.Load())
 
 			// Assert that the template metadata did not change. We verify the
 			// correct request gets sent to the server already.
@@ -720,7 +720,7 @@ func TestTemplateEdit(t *testing.T) {
 
 			// Make a proxy server that will return a valid entitlements
 			// response, including a valid advanced scheduling entitlement.
-			var updateTemplateCalled int64
+			var updateTemplateCalled atomic.Int64
 			proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.URL.Path == "/api/v2/entitlements" {
 					res := codersdk.Entitlements{
@@ -755,7 +755,7 @@ func TestTemplateEdit(t *testing.T) {
 					assert.False(t, req.AllowUserAutostop)
 
 					r.Body = io.NopCloser(bytes.NewReader(body))
-					atomic.AddInt64(&updateTemplateCalled, 1)
+					updateTemplateCalled.Add(1)
 					// We still want to call the real route.
 				}
 
@@ -790,7 +790,7 @@ func TestTemplateEdit(t *testing.T) {
 			err = inv.WithContext(ctx).Run()
 			require.NoError(t, err)
 
-			require.EqualValues(t, 1, atomic.LoadInt64(&updateTemplateCalled))
+			require.EqualValues(t, 1, updateTemplateCalled.Load())
 
 			// Assert that the template metadata did not change. We verify the
 			// correct request gets sent to the server already.

--- a/coderd/agentapi/lifecycle_test.go
+++ b/coderd/agentapi/lifecycle_test.go
@@ -311,7 +311,7 @@ func TestUpdateLifecycle(t *testing.T) {
 
 		dbM := dbmock.NewMockStore(gomock.NewController(t))
 
-		var publishCalled int64
+		var publishCalled atomic.Int64
 		reg := prometheus.NewRegistry()
 		metrics := agentapi.NewLifecycleMetrics(reg)
 
@@ -324,7 +324,7 @@ func TestUpdateLifecycle(t *testing.T) {
 			Log:         testutil.Logger(t),
 			Metrics:     metrics,
 			PublishWorkspaceUpdateFn: func(ctx context.Context, _ uuid.UUID, kind wspubsub.WorkspaceEventKind) error {
-				atomic.AddInt64(&publishCalled, 1)
+				publishCalled.Add(1)
 				return nil
 			},
 		}
@@ -384,7 +384,7 @@ func TestUpdateLifecycle(t *testing.T) {
 			})
 			require.NoError(t, err)
 			require.Equal(t, lifecycle, resp)
-			require.Equal(t, int64(i+1), atomic.LoadInt64(&publishCalled))
+			require.Equal(t, int64(i+1), publishCalled.Load())
 
 			// For future iterations:
 			agent.StartedAt = expectedStartedAt

--- a/coderd/coderd_test.go
+++ b/coderd/coderd_test.go
@@ -164,14 +164,14 @@ func TestDERPForceWebSockets(t *testing.T) {
 
 	// Set the HTTP handler to a custom one that ensures all /derp calls are
 	// WebSockets and not `Upgrade: derp`.
-	var upgradeCount int64
+	var upgradeCount atomic.Int64
 	setHandler(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(r.URL.Path, "/derp") {
 			up := r.Header.Get("Upgrade")
 			if up != "" && up != "websocket" {
 				t.Errorf("expected Upgrade: websocket, got %q", up)
 			} else {
-				atomic.AddInt64(&upgradeCount, 1)
+				upgradeCount.Add(1)
 			}
 		}
 
@@ -224,7 +224,7 @@ func TestDERPForceWebSockets(t *testing.T) {
 	}()
 	conn.AwaitReachable(ctx)
 
-	require.GreaterOrEqual(t, atomic.LoadInt64(&upgradeCount), int64(1), "expected at least one /derp call")
+	require.GreaterOrEqual(t, upgradeCount.Load(), int64(1), "expected at least one /derp call")
 }
 
 func TestDERPLatencyCheck(t *testing.T) {

--- a/coderd/httpmw/actor_test.go
+++ b/coderd/httpmw/actor_test.go
@@ -50,13 +50,13 @@ func TestRequireAPIKeyOrWorkspaceProxyAuth(t *testing.T) {
 		)
 		r.Header.Set(codersdk.SessionTokenHeader, token)
 
-		var called int64
+		var called atomic.Int64
 		httpmw.ExtractAPIKeyMW(httpmw.ExtractAPIKeyConfig{
 			DB:              db,
 			RedirectToLogin: false,
 		})(
 			httpmw.RequireAPIKeyOrWorkspaceProxyAuth()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				atomic.AddInt64(&called, 1)
+				called.Add(1)
 				rw.WriteHeader(http.StatusOK)
 			}))).
 			ServeHTTP(rw, r)
@@ -68,7 +68,7 @@ func TestRequireAPIKeyOrWorkspaceProxyAuth(t *testing.T) {
 		t.Log(string(dump))
 
 		require.Equal(t, http.StatusOK, rw.Code)
-		require.Equal(t, int64(1), atomic.LoadInt64(&called))
+		require.Equal(t, int64(1), called.Load())
 	})
 
 	t.Run("WorkspaceProxy", func(t *testing.T) {
@@ -122,12 +122,12 @@ func TestRequireAPIKeyOrWorkspaceProxyAuth(t *testing.T) {
 		)
 		r.Header.Set(httpmw.WorkspaceProxyAuthTokenHeader, fmt.Sprintf("%s:%s", proxy.ID, token))
 
-		var called int64
+		var called atomic.Int64
 		httpmw.ExtractWorkspaceProxy(httpmw.ExtractWorkspaceProxyConfig{
 			DB: db,
 		})(
 			httpmw.RequireAPIKeyOrWorkspaceProxyAuth()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				atomic.AddInt64(&called, 1)
+				called.Add(1)
 				rw.WriteHeader(http.StatusOK)
 			}))).
 			ServeHTTP(rw, r)
@@ -139,6 +139,6 @@ func TestRequireAPIKeyOrWorkspaceProxyAuth(t *testing.T) {
 		t.Log(string(dump))
 
 		require.Equal(t, http.StatusOK, rw.Code)
-		require.Equal(t, int64(1), atomic.LoadInt64(&called))
+		require.Equal(t, int64(1), called.Load())
 	})
 }

--- a/coderd/httpmw/apikey_test.go
+++ b/coderd/httpmw/apikey_test.go
@@ -802,9 +802,9 @@ func TestAPIKey(t *testing.T) {
 			r     = httptest.NewRequest("GET", "/", nil)
 			rw    = httptest.NewRecorder()
 
-			count   int64
+			count   atomic.Int64
 			handler = http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-				atomic.AddInt64(&count, 1)
+				count.Add(1)
 
 				apiKey, ok := httpmw.APIKeyOptional(r)
 				assert.False(t, ok)
@@ -823,7 +823,7 @@ func TestAPIKey(t *testing.T) {
 		res := rw.Result()
 		defer res.Body.Close()
 		require.Equal(t, http.StatusOK, res.StatusCode)
-		require.EqualValues(t, 1, atomic.LoadInt64(&count))
+		require.EqualValues(t, 1, count.Load())
 	})
 
 	t.Run("Tokens", func(t *testing.T) {

--- a/coderd/tailnet_test.go
+++ b/coderd/tailnet_test.go
@@ -407,7 +407,7 @@ func (failingHealthcheck) Ping(context.Context) (time.Duration, error) {
 
 type wrappedListener struct {
 	net.Listener
-	dials int32
+	dials atomic.Int32
 }
 
 func (w *wrappedListener) Accept() (net.Conn, error) {
@@ -416,12 +416,12 @@ func (w *wrappedListener) Accept() (net.Conn, error) {
 		return nil, err
 	}
 
-	atomic.AddInt32(&w.dials, 1)
+	w.dials.Add(1)
 	return conn, nil
 }
 
 func (w *wrappedListener) getDials() int {
-	return int(atomic.LoadInt32(&w.dials))
+	return int(w.dials.Load())
 }
 
 type agentWithID struct {

--- a/coderd/templates_test.go
+++ b/coderd/templates_test.go
@@ -198,11 +198,11 @@ func TestPostTemplateByOrganization(t *testing.T) {
 		t.Run("OK", func(t *testing.T) {
 			t.Parallel()
 
-			var setCalled int64
+			var setCalled atomic.Int64
 			client := coderdtest.New(t, &coderdtest.Options{
 				TemplateScheduleStore: schedule.MockTemplateScheduleStore{
 					SetFn: func(ctx context.Context, db database.Store, template database.Template, options schedule.TemplateScheduleOptions) (database.Template, error) {
-						atomic.AddInt64(&setCalled, 1)
+						setCalled.Add(1)
 						require.False(t, options.UserAutostartEnabled)
 						require.False(t, options.UserAutostopEnabled)
 						template.AllowUserAutostart = options.UserAutostartEnabled
@@ -225,7 +225,7 @@ func TestPostTemplateByOrganization(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.EqualValues(t, 1, atomic.LoadInt64(&setCalled))
+			require.EqualValues(t, 1, setCalled.Load())
 			require.False(t, got.AllowUserAutostart)
 			require.False(t, got.AllowUserAutostop)
 		})
@@ -275,11 +275,11 @@ func TestPostTemplateByOrganization(t *testing.T) {
 		t.Run("None", func(t *testing.T) {
 			t.Parallel()
 
-			var setCalled int64
+			var setCalled atomic.Int64
 			client := coderdtest.New(t, &coderdtest.Options{
 				TemplateScheduleStore: schedule.MockTemplateScheduleStore{
 					SetFn: func(ctx context.Context, db database.Store, template database.Template, options schedule.TemplateScheduleOptions) (database.Template, error) {
-						atomic.AddInt64(&setCalled, 1)
+						setCalled.Add(1)
 						assert.Zero(t, options.AutostopRequirement.DaysOfWeek)
 						assert.Zero(t, options.AutostopRequirement.Weeks)
 
@@ -317,7 +317,7 @@ func TestPostTemplateByOrganization(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.EqualValues(t, 1, atomic.LoadInt64(&setCalled))
+			require.EqualValues(t, 1, setCalled.Load())
 			require.Empty(t, got.AutostopRequirement.DaysOfWeek)
 			require.EqualValues(t, 1, got.AutostopRequirement.Weeks)
 		})
@@ -325,11 +325,11 @@ func TestPostTemplateByOrganization(t *testing.T) {
 		t.Run("OK", func(t *testing.T) {
 			t.Parallel()
 
-			var setCalled int64
+			var setCalled atomic.Int64
 			client := coderdtest.New(t, &coderdtest.Options{
 				TemplateScheduleStore: schedule.MockTemplateScheduleStore{
 					SetFn: func(ctx context.Context, db database.Store, template database.Template, options schedule.TemplateScheduleOptions) (database.Template, error) {
-						atomic.AddInt64(&setCalled, 1)
+						setCalled.Add(1)
 						assert.EqualValues(t, 0b00110000, options.AutostopRequirement.DaysOfWeek)
 						assert.EqualValues(t, 2, options.AutostopRequirement.Weeks)
 
@@ -371,7 +371,7 @@ func TestPostTemplateByOrganization(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.EqualValues(t, 1, atomic.LoadInt64(&setCalled))
+			require.EqualValues(t, 1, setCalled.Load())
 			require.Equal(t, []string{"friday", "saturday"}, got.AutostopRequirement.DaysOfWeek)
 			require.EqualValues(t, 2, got.AutostopRequirement.Weeks)
 
@@ -1135,11 +1135,11 @@ func TestPatchTemplateMeta(t *testing.T) {
 		t.Run("OK", func(t *testing.T) {
 			t.Parallel()
 
-			var setCalled int64
+			var setCalled atomic.Int64
 			client := coderdtest.New(t, &coderdtest.Options{
 				TemplateScheduleStore: schedule.MockTemplateScheduleStore{
 					SetFn: func(ctx context.Context, db database.Store, template database.Template, options schedule.TemplateScheduleOptions) (database.Template, error) {
-						if atomic.AddInt64(&setCalled, 1) == 2 {
+						if setCalled.Add(1) == 2 {
 							require.Equal(t, failureTTL, options.FailureTTL)
 							require.Equal(t, inactivityTTL, options.TimeTilDormant)
 							require.Equal(t, timeTilDormantAutoDelete, options.TimeTilDormantAutoDelete)
@@ -1176,7 +1176,7 @@ func TestPatchTemplateMeta(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.EqualValues(t, 2, atomic.LoadInt64(&setCalled))
+			require.EqualValues(t, 2, setCalled.Load())
 			require.Equal(t, failureTTL.Milliseconds(), got.FailureTTLMillis)
 			require.Equal(t, inactivityTTL.Milliseconds(), got.TimeTilDormantMillis)
 			require.Equal(t, timeTilDormantAutoDelete.Milliseconds(), got.TimeTilDormantAutoDeleteMillis)
@@ -1225,7 +1225,7 @@ func TestPatchTemplateMeta(t *testing.T) {
 			t.Parallel()
 
 			var (
-				setCalled      int64
+				setCalled      atomic.Int64
 				allowAutostart atomic.Bool
 				allowAutostop  atomic.Bool
 			)
@@ -1234,7 +1234,7 @@ func TestPatchTemplateMeta(t *testing.T) {
 			client := coderdtest.New(t, &coderdtest.Options{
 				TemplateScheduleStore: schedule.MockTemplateScheduleStore{
 					SetFn: func(ctx context.Context, db database.Store, template database.Template, options schedule.TemplateScheduleOptions) (database.Template, error) {
-						atomic.AddInt64(&setCalled, 1)
+						setCalled.Add(1)
 						assert.Equal(t, allowAutostart.Load(), options.UserAutostartEnabled)
 						assert.Equal(t, allowAutostop.Load(), options.UserAutostopEnabled)
 
@@ -1271,7 +1271,7 @@ func TestPatchTemplateMeta(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.EqualValues(t, 2, atomic.LoadInt64(&setCalled))
+			require.EqualValues(t, 2, setCalled.Load())
 			require.Equal(t, allowAutostart.Load(), got.AllowUserAutostart)
 			require.Equal(t, allowAutostop.Load(), got.AllowUserAutostop)
 		})
@@ -1400,11 +1400,11 @@ func TestPatchTemplateMeta(t *testing.T) {
 		t.Run("OK", func(t *testing.T) {
 			t.Parallel()
 
-			var setCalled int64
+			var setCalled atomic.Int64
 			client := coderdtest.New(t, &coderdtest.Options{
 				TemplateScheduleStore: schedule.MockTemplateScheduleStore{
 					SetFn: func(ctx context.Context, db database.Store, template database.Template, options schedule.TemplateScheduleOptions) (database.Template, error) {
-						if atomic.AddInt64(&setCalled, 1) == 2 {
+						if setCalled.Add(1) == 2 {
 							assert.EqualValues(t, 0b0110000, options.AutostopRequirement.DaysOfWeek)
 							assert.EqualValues(t, 2, options.AutostopRequirement.Weeks)
 						}
@@ -1434,7 +1434,7 @@ func TestPatchTemplateMeta(t *testing.T) {
 
 			version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
 			template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
-			require.EqualValues(t, 1, atomic.LoadInt64(&setCalled))
+			require.EqualValues(t, 1, setCalled.Load())
 			require.Empty(t, template.AutostopRequirement.DaysOfWeek)
 			require.EqualValues(t, 1, template.AutostopRequirement.Weeks)
 			req := codersdk.UpdateTemplateMeta{
@@ -1456,7 +1456,7 @@ func TestPatchTemplateMeta(t *testing.T) {
 
 			updated, err := client.UpdateTemplateMeta(ctx, template.ID, req)
 			require.NoError(t, err)
-			require.EqualValues(t, 2, atomic.LoadInt64(&setCalled))
+			require.EqualValues(t, 2, setCalled.Load())
 			require.Equal(t, []string{"friday", "saturday"}, updated.AutostopRequirement.DaysOfWeek)
 			require.EqualValues(t, 2, updated.AutostopRequirement.Weeks)
 
@@ -1471,11 +1471,11 @@ func TestPatchTemplateMeta(t *testing.T) {
 		t.Run("Unset", func(t *testing.T) {
 			t.Parallel()
 
-			var setCalled int64
+			var setCalled atomic.Int64
 			client := coderdtest.New(t, &coderdtest.Options{
 				TemplateScheduleStore: schedule.MockTemplateScheduleStore{
 					SetFn: func(ctx context.Context, db database.Store, template database.Template, options schedule.TemplateScheduleOptions) (database.Template, error) {
-						if atomic.AddInt64(&setCalled, 1) == 2 {
+						if setCalled.Add(1) == 2 {
 							assert.EqualValues(t, 0, options.AutostopRequirement.DaysOfWeek)
 							assert.EqualValues(t, 1, options.AutostopRequirement.Weeks)
 						}
@@ -1511,7 +1511,7 @@ func TestPatchTemplateMeta(t *testing.T) {
 					Weeks:      2,
 				}
 			})
-			require.EqualValues(t, 1, atomic.LoadInt64(&setCalled))
+			require.EqualValues(t, 1, setCalled.Load())
 			require.Equal(t, []string{"monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"}, template.AutostopRequirement.DaysOfWeek)
 			require.EqualValues(t, 2, template.AutostopRequirement.Weeks)
 			req := codersdk.UpdateTemplateMeta{
@@ -1532,7 +1532,7 @@ func TestPatchTemplateMeta(t *testing.T) {
 
 			updated, err := client.UpdateTemplateMeta(ctx, template.ID, req)
 			require.NoError(t, err)
-			require.EqualValues(t, 2, atomic.LoadInt64(&setCalled))
+			require.EqualValues(t, 2, setCalled.Load())
 			require.Empty(t, updated.AutostopRequirement.DaysOfWeek)
 			require.EqualValues(t, 1, updated.AutostopRequirement.Weeks)
 

--- a/coderd/tracing/httpmw_test.go
+++ b/coderd/tracing/httpmw_test.go
@@ -24,7 +24,7 @@ type noopTracer = noop.Tracer
 type fakeTracer struct {
 	noop.TracerProvider
 	noopTracer
-	startCalled int64
+	startCalled atomic.Int64
 }
 
 var (
@@ -39,7 +39,7 @@ func (f *fakeTracer) Tracer(_ string, _ ...trace.TracerOption) trace.Tracer {
 
 // Start implements trace.Tracer.
 func (f *fakeTracer) Start(ctx context.Context, _ string, _ ...trace.SpanStartOption) (context.Context, trace.Span) {
-	atomic.AddInt64(&f.startCalled, 1)
+	f.startCalled.Add(1)
 	return ctx, tracing.NoopSpan
 }
 
@@ -94,7 +94,7 @@ func Test_Middleware(t *testing.T) {
 					rw.WriteHeader(http.StatusNoContent)
 				})).ServeHTTP(rw, r)
 
-				didRun := atomic.LoadInt64(&fake.startCalled) == 1
+				didRun := fake.startCalled.Load() == 1
 				require.Equal(t, c.runs, didRun, "expected middleware to run/not run")
 			})
 		}

--- a/coderd/wsbuilder/wsbuilder_test.go
+++ b/coderd/wsbuilder/wsbuilder_test.go
@@ -1059,10 +1059,10 @@ func TestWorkspaceBuildUsageChecker(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		var calls int64
+		var calls atomic.Int64
 		fakeUsageChecker := &fakeUsageChecker{
 			checkBuildUsageFunc: func(_ context.Context, _ database.Store, _ *database.TemplateVersion, _ *database.Task, _ database.WorkspaceTransition) (wsbuilder.UsageCheckResponse, error) {
-				atomic.AddInt64(&calls, 1)
+				calls.Add(1)
 				return wsbuilder.UsageCheckResponse{Permitted: true}, nil
 			},
 		}
@@ -1095,7 +1095,7 @@ func TestWorkspaceBuildUsageChecker(t *testing.T) {
 		// nolint: dogsled
 		_, _, _, err := uut.Build(ctx, mDB, fc, nil, audit.WorkspaceBuildBaggage{})
 		require.NoError(t, err)
-		require.EqualValues(t, 1, calls)
+		require.EqualValues(t, 1, calls.Load())
 	})
 
 	// The failure cases are mostly identical from a test perspective.
@@ -1137,10 +1137,10 @@ func TestWorkspaceBuildUsageChecker(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			var calls int64
+			var calls atomic.Int64
 			fakeUsageChecker := &fakeUsageChecker{
 				checkBuildUsageFunc: func(_ context.Context, _ database.Store, _ *database.TemplateVersion, _ *database.Task, _ database.WorkspaceTransition) (wsbuilder.UsageCheckResponse, error) {
-					atomic.AddInt64(&calls, 1)
+					calls.Add(1)
 					return c.response, c.responseErr
 				},
 			}
@@ -1158,7 +1158,7 @@ func TestWorkspaceBuildUsageChecker(t *testing.T) {
 			// nolint: dogsled
 			_, _, _, err := uut.Build(ctx, mDB, fc, nil, audit.WorkspaceBuildBaggage{})
 			c.assertions(t, err)
-			require.EqualValues(t, 1, calls)
+			require.EqualValues(t, 1, calls.Load())
 		})
 	}
 }

--- a/enterprise/cli/proxyserver_test.go
+++ b/enterprise/cli/proxyserver_test.go
@@ -32,9 +32,9 @@ func Test_ProxyServer_Headers(t *testing.T) {
 	// We're not going to actually start a proxy, we're going to point it
 	// towards a fake server that returns an unexpected status code. This'll
 	// cause the proxy to exit with an error that we can check for.
-	var called int64
+	var called atomic.Int64
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt64(&called, 1)
+		called.Add(1)
 		assert.Equal(t, headerVal1, r.Header.Get(headerName1))
 		assert.Equal(t, headerVal2, r.Header.Get(headerName2))
 
@@ -57,7 +57,7 @@ func Test_ProxyServer_Headers(t *testing.T) {
 	require.ErrorContains(t, err, "unexpected status code 418")
 	require.NoError(t, pty.Close())
 
-	assert.EqualValues(t, 1, atomic.LoadInt64(&called))
+	assert.EqualValues(t, 1, called.Load())
 }
 
 //nolint:paralleltest,tparallel // Test uses a static port.

--- a/enterprise/wsproxy/wsproxysdk/wsproxysdk_test.go
+++ b/enterprise/wsproxy/wsproxysdk/wsproxysdk_test.go
@@ -39,9 +39,9 @@ func Test_IssueSignedAppTokenHTML(t *testing.T) {
 			expectedSessionToken   = "user-session-token"
 			expectedSignedTokenStr = "signed-app-token"
 		)
-		var called int64
+		var called atomic.Int64
 		srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-			atomic.AddInt64(&called, 1)
+			called.Add(1)
 
 			assert.Equal(t, r.Method, http.MethodPost)
 			assert.Equal(t, r.URL.Path, "/api/v2/workspaceproxies/me/issue-signed-app-token")
@@ -87,7 +87,7 @@ func Test_IssueSignedAppTokenHTML(t *testing.T) {
 		require.Equal(t, expectedSignedTokenStr, tokenRes.SignedTokenStr)
 		require.False(t, rw.WasWritten())
 
-		require.EqualValues(t, called, 1)
+		require.EqualValues(t, called.Load(), 1)
 	})
 
 	t.Run("Error", func(t *testing.T) {
@@ -98,9 +98,9 @@ func Test_IssueSignedAppTokenHTML(t *testing.T) {
 			expectedResponseStatus = http.StatusBadRequest
 			expectedResponseBody   = "bad request"
 		)
-		var called int64
+		var called atomic.Int64
 		srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-			atomic.AddInt64(&called, 1)
+			called.Add(1)
 
 			assert.Equal(t, r.Method, http.MethodPost)
 			assert.Equal(t, r.URL.Path, "/api/v2/workspaceproxies/me/issue-signed-app-token")
@@ -132,7 +132,7 @@ func Test_IssueSignedAppTokenHTML(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, expectedResponseBody, string(body))
 
-		require.EqualValues(t, called, 1)
+		require.EqualValues(t, called.Load(), 1)
 	})
 }
 

--- a/scaletest/agentconn/run_test.go
+++ b/scaletest/agentconn/run_test.go
@@ -264,14 +264,12 @@ func setupRunnerTest(t *testing.T) (client *codersdk.Client, agentID uuid.UUID) 
 func testServer(t *testing.T) (string, func() int64) {
 	t.Helper()
 
-	var count int64
+	var count atomic.Int64
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt64(&count, 1)
+		count.Add(1)
 		w.WriteHeader(http.StatusOK)
 	}))
 	t.Cleanup(srv.Close)
 
-	return srv.URL, func() int64 {
-		return atomic.LoadInt64(&count)
-	}
+	return srv.URL, count.Load
 }

--- a/scaletest/harness/run_test.go
+++ b/scaletest/harness/run_test.go
@@ -58,21 +58,21 @@ func Test_TestRun(t *testing.T) {
 
 		var (
 			name, id          = "test", "1"
-			runCalled         int64
-			cleanupCalled     int64
-			collectableCalled int64
+			runCalled         atomic.Int64
+			cleanupCalled     atomic.Int64
+			collectableCalled atomic.Int64
 
 			testFns = testFns{
 				RunFn: func(ctx context.Context, id string, logs io.Writer) error {
-					atomic.AddInt64(&runCalled, 1)
+					runCalled.Add(1)
 					return nil
 				},
 				CleanupFn: func(ctx context.Context, id string, logs io.Writer) error {
-					atomic.AddInt64(&cleanupCalled, 1)
+					cleanupCalled.Add(1)
 					return nil
 				},
 				GetMetricsFn: func() map[string]any {
-					atomic.AddInt64(&collectableCalled, 1)
+					collectableCalled.Add(1)
 					return nil
 				},
 			}
@@ -83,12 +83,12 @@ func Test_TestRun(t *testing.T) {
 
 		err := run.Run(context.Background())
 		require.NoError(t, err)
-		require.EqualValues(t, 1, atomic.LoadInt64(&runCalled))
-		require.EqualValues(t, 1, atomic.LoadInt64(&collectableCalled))
+		require.EqualValues(t, 1, runCalled.Load())
+		require.EqualValues(t, 1, collectableCalled.Load())
 
 		err = run.Cleanup(context.Background())
 		require.NoError(t, err)
-		require.EqualValues(t, 1, atomic.LoadInt64(&cleanupCalled))
+		require.EqualValues(t, 1, cleanupCalled.Load())
 	})
 
 	t.Run("Cleanup", func(t *testing.T) {
@@ -111,20 +111,20 @@ func Test_TestRun(t *testing.T) {
 		t.Run("NotDone", func(t *testing.T) {
 			t.Parallel()
 
-			var cleanupCalled int64
+			var cleanupCalled atomic.Int64
 			run := harness.NewTestRun("test", "1", testFns{
 				RunFn: func(ctx context.Context, id string, logs io.Writer) error {
 					return nil
 				},
 				CleanupFn: func(ctx context.Context, id string, logs io.Writer) error {
-					atomic.AddInt64(&cleanupCalled, 1)
+					cleanupCalled.Add(1)
 					return nil
 				},
 			})
 
 			err := run.Cleanup(context.Background())
 			require.NoError(t, err)
-			require.EqualValues(t, 0, atomic.LoadInt64(&cleanupCalled))
+			require.EqualValues(t, 0, cleanupCalled.Load())
 		})
 	})
 

--- a/scaletest/harness/strategies_test.go
+++ b/scaletest/harness/strategies_test.go
@@ -19,12 +19,13 @@ import (
 //nolint:paralleltest // this tests uses timings to determine if it's working
 func Test_LinearExecutionStrategy(t *testing.T) {
 	var (
-		lastSeenI int64 = -1
-		count     int64
+		lastSeenI atomic.Int64
+		count     atomic.Int64
 	)
+	lastSeenI.Store(-1)
 	runs, fns := strategyTestData(100, func(_ context.Context, i int, _ io.Writer) error {
-		atomic.AddInt64(&count, 1)
-		swapped := atomic.CompareAndSwapInt64(&lastSeenI, int64(i-1), int64(i))
+		count.Add(1)
+		swapped := lastSeenI.CompareAndSwap(int64(i-1), int64(i))
 		assert.True(t, swapped)
 		time.Sleep(2 * time.Millisecond)
 
@@ -38,7 +39,7 @@ func Test_LinearExecutionStrategy(t *testing.T) {
 	runErrs, err := strategy.Run(context.Background(), fns)
 	require.NoError(t, err)
 	require.Len(t, runErrs, 50)
-	require.EqualValues(t, 100, atomic.LoadInt64(&count))
+	require.EqualValues(t, 100, count.Load())
 
 	lastStartTime := time.Time{}
 	for _, run := range runs {


### PR DESCRIPTION
Use typed atomics (atomic.Int64, atomic.Int32, etc.) to prevent mixing atomic and non-atomic access on the same value, guarantee 64-bit alignment on 32-bit platforms, and provide a cleaner API.