### PR TITLE
feat: filter startup-failed workspaces

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -11281,7 +11281,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Search query in the format ` + "`" + `key:value` + "`" + `. Available keys are: owner, template, name, status, has-agent, dormant, last_used_after, last_used_before, has-ai-task, has_external_agent, healthy.",
+                        "description": "Search query in the format ` + "`" + `key:value` + "`" + `. Available keys are: owner, template, name, status, has-agent, dormant, last_used_after, last_used_before, has-ai-task, has_external_agent, healthy, startup_failed.",
                         "name": "q",
                         "in": "query"
                     },

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -10001,7 +10001,7 @@
 				"parameters": [
 					{
 						"type": "string",
-						"description": "Search query in the format `key:value`. Available keys are: owner, template, name, status, has-agent, dormant, last_used_after, last_used_before, has-ai-task, has_external_agent, healthy.",
+						"description": "Search query in the format `key:value`. Available keys are: owner, template, name, status, has-agent, dormant, last_used_after, last_used_before, has-ai-task, has_external_agent, healthy, startup_failed.",
 						"name": "q",
 						"in": "query"
 					},

--- a/coderd/database/modelqueries.go
+++ b/coderd/database/modelqueries.go
@@ -271,6 +271,7 @@ func (q *sqlQuerier) GetAuthorizedWorkspaces(ctx context.Context, arg GetWorkspa
 		arg.Name,
 		pq.Array(arg.HasAgentStatuses),
 		arg.AgentInactiveDisconnectTimeoutSeconds,
+		arg.StartupFailed,
 		arg.Dormant,
 		arg.LastUsedBefore,
 		arg.LastUsedAfter,

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -32709,32 +32709,52 @@ WHERE
 			) > 0
 		ELSE true
 	END
+	-- Filter by startup script failures on the latest start build.
+	AND CASE
+		WHEN $15 :: boolean IS NOT NULL THEN
+			$15 :: boolean = EXISTS (
+				SELECT
+					1
+				FROM
+					workspace_resources
+				JOIN
+					workspace_agents
+				ON
+					workspace_agents.resource_id = workspace_resources.id
+				WHERE
+					workspace_resources.job_id = latest_build.provisioner_job_id AND
+					latest_build.transition = 'start'::workspace_transition AND
+					workspace_agents.deleted = FALSE AND
+					workspace_agents.lifecycle_state = 'start_error'::workspace_agent_lifecycle_state
+			)
+		ELSE true
+	END
 	-- Filter by dormant workspaces.
 	AND CASE
-		WHEN $15 :: boolean != 'false' THEN
+		WHEN $16 :: boolean != 'false' THEN
 			dormant_at IS NOT NULL
 		ELSE true
 	END
 	-- Filter by last_used
 	AND CASE
-		  WHEN $16 :: timestamp with time zone > '0001-01-01 00:00:00Z' THEN
-				  workspaces.last_used_at <= $16
+		  WHEN $17 :: timestamp with time zone > '0001-01-01 00:00:00Z' THEN
+				  workspaces.last_used_at <= $17
 		  ELSE true
 	END
 	AND CASE
-		  WHEN $17 :: timestamp with time zone > '0001-01-01 00:00:00Z' THEN
-				  workspaces.last_used_at >= $17
+		  WHEN $18 :: timestamp with time zone > '0001-01-01 00:00:00Z' THEN
+				  workspaces.last_used_at >= $18
 		  ELSE true
 	END
   	AND CASE
-		  WHEN $18 :: boolean IS NOT NULL THEN
-			  (latest_build.template_version_id = template.active_version_id) = $18 :: boolean
+		  WHEN $19 :: boolean IS NOT NULL THEN
+			  (latest_build.template_version_id = template.active_version_id) = $19 :: boolean
 		  ELSE true
 	END
 	-- Filter by has_ai_task, checks if this is a task workspace.
 	AND CASE
-		WHEN $19::boolean IS NOT NULL
-		THEN $19::boolean = EXISTS (
+		WHEN $20::boolean IS NOT NULL
+		THEN $20::boolean = EXISTS (
 			SELECT
 				1
 			FROM
@@ -32748,26 +32768,26 @@ WHERE
 	END
 	-- Filter by has_external_agent in latest build
 	AND CASE
-		WHEN $20 :: boolean IS NOT NULL THEN
-			latest_build.has_external_agent = $20 :: boolean
+		WHEN $21 :: boolean IS NOT NULL THEN
+			latest_build.has_external_agent = $21 :: boolean
 		ELSE true
 	END
 	-- Filter by shared status
 	AND CASE
-		WHEN $21 :: boolean IS NOT NULL THEN
-			(workspaces.user_acl != '{}'::jsonb OR workspaces.group_acl != '{}'::jsonb) = $21 :: boolean
+		WHEN $22 :: boolean IS NOT NULL THEN
+			(workspaces.user_acl != '{}'::jsonb OR workspaces.group_acl != '{}'::jsonb) = $22 :: boolean
 		ELSE true
 	END
 	-- Filter by shared_with_user_id
 	AND CASE
-		WHEN $22 :: uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN
-			workspaces.user_acl ? ($22 :: uuid) :: text
+		WHEN $23 :: uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN
+			workspaces.user_acl ? ($23 :: uuid) :: text
 		ELSE true
 	END
 	-- Filter by shared_with_group_id
 	AND CASE
-		WHEN $23 :: uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN
-			workspaces.group_acl ? ($23 :: uuid) :: text
+		WHEN $24 :: uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN
+			workspaces.group_acl ? ($24 :: uuid) :: text
 		ELSE true
 	END
 
@@ -32780,7 +32800,7 @@ WHERE
 		filtered_workspaces fw
 	ORDER BY
 		-- To ensure that 'favorite' workspaces show up first in the list only for their owner.
-		CASE WHEN favorite AND owner_username = (SELECT users.username FROM users WHERE users.id = $24) THEN 0 ELSE 1 END ASC,
+		CASE WHEN favorite AND owner_username = (SELECT users.username FROM users WHERE users.id = $25) THEN 0 ELSE 1 END ASC,
 		(latest_build_completed_at IS NOT NULL AND
 			latest_build_canceled_at IS NULL AND
 			latest_build_error IS NULL AND
@@ -32789,11 +32809,11 @@ WHERE
 		LOWER(name) ASC
 	LIMIT
 		CASE
-			WHEN $26 :: integer > 0 THEN
-				$26
+			WHEN $27 :: integer > 0 THEN
+				$27
 		END
 	OFFSET
-		$25
+		$26
 ), filtered_workspaces_order_with_summary AS (
 	SELECT
 		fwo.id, fwo.created_at, fwo.updated_at, fwo.owner_id, fwo.organization_id, fwo.template_id, fwo.deleted, fwo.name, fwo.autostart_schedule, fwo.ttl, fwo.last_used_at, fwo.dormant_at, fwo.deleting_at, fwo.automatic_updates, fwo.favorite, fwo.next_start_at, fwo.group_acl, fwo.user_acl, fwo.owner_avatar_url, fwo.owner_username, fwo.owner_name, fwo.organization_name, fwo.organization_display_name, fwo.organization_icon, fwo.organization_description, fwo.template_name, fwo.template_display_name, fwo.template_icon, fwo.template_description, fwo.task_id, fwo.group_acl_display_info, fwo.user_acl_display_info, fwo.template_version_id, fwo.template_version_name, fwo.latest_build_completed_at, fwo.latest_build_canceled_at, fwo.latest_build_error, fwo.latest_build_transition, fwo.latest_build_status, fwo.latest_build_has_external_agent
@@ -32845,7 +32865,7 @@ WHERE
 		'unknown'::provisioner_job_status, -- latest_build_status
 		false -- latest_build_has_external_agent
 	WHERE
-		$27 :: boolean = true
+		$28 :: boolean = true
 ), total_count AS (
 	SELECT
 		count(*) AS count
@@ -32876,6 +32896,7 @@ type GetWorkspacesParams struct {
 	Name                                  string       `db:"name" json:"name"`
 	HasAgentStatuses                      []string     `db:"has_agent_statuses" json:"has_agent_statuses"`
 	AgentInactiveDisconnectTimeoutSeconds int64        `db:"agent_inactive_disconnect_timeout_seconds" json:"agent_inactive_disconnect_timeout_seconds"`
+	StartupFailed                         sql.NullBool `db:"startup_failed" json:"startup_failed"`
 	Dormant                               bool         `db:"dormant" json:"dormant"`
 	LastUsedBefore                        time.Time    `db:"last_used_before" json:"last_used_before"`
 	LastUsedAfter                         time.Time    `db:"last_used_after" json:"last_used_after"`
@@ -32954,6 +32975,7 @@ func (q *sqlQuerier) GetWorkspaces(ctx context.Context, arg GetWorkspacesParams)
 		arg.Name,
 		pq.Array(arg.HasAgentStatuses),
 		arg.AgentInactiveDisconnectTimeoutSeconds,
+		arg.StartupFailed,
 		arg.Dormant,
 		arg.LastUsedBefore,
 		arg.LastUsedAfter,

--- a/coderd/database/queries/workspaces.sql
+++ b/coderd/database/queries/workspaces.sql
@@ -328,6 +328,26 @@ WHERE
 			) > 0
 		ELSE true
 	END
+	-- Filter by startup script failures on the latest start build.
+	AND CASE
+		WHEN sqlc.narg('startup_failed') :: boolean IS NOT NULL THEN
+			sqlc.narg('startup_failed') :: boolean = EXISTS (
+				SELECT
+					1
+				FROM
+					workspace_resources
+				JOIN
+					workspace_agents
+				ON
+					workspace_agents.resource_id = workspace_resources.id
+				WHERE
+					workspace_resources.job_id = latest_build.provisioner_job_id AND
+					latest_build.transition = 'start'::workspace_transition AND
+					workspace_agents.deleted = FALSE AND
+					workspace_agents.lifecycle_state = 'start_error'::workspace_agent_lifecycle_state
+			)
+		ELSE true
+	END
 	-- Filter by dormant workspaces.
 	AND CASE
 		WHEN @dormant :: boolean != 'false' THEN

--- a/coderd/searchquery/search.go
+++ b/coderd/searchquery/search.go
@@ -270,6 +270,7 @@ func Workspaces(ctx context.Context, db database.Store, query string, page coder
 	}
 	filter.HasAITask = parser.NullableBoolean(values, sql.NullBool{}, "has-ai-task")
 	filter.HasExternalAgent = parser.NullableBoolean(values, sql.NullBool{}, "has_external_agent")
+	filter.StartupFailed = parser.NullableBoolean(values, sql.NullBool{}, "startup_failed")
 	filter.OrganizationID = parseOrganization(ctx, db, parser, values, "organization")
 	filter.Shared = parser.NullableBoolean(values, sql.NullBool{}, "shared")
 	// TODO: support "me" by passing in the actorID

--- a/coderd/searchquery/search_test.go
+++ b/coderd/searchquery/search_test.go
@@ -283,6 +283,36 @@ func TestSearchWorkspace(t *testing.T) {
 			},
 		},
 		{
+			Name:  "StartupFailedTrue",
+			Query: "startup_failed:true",
+			Expected: database.GetWorkspacesParams{
+				StartupFailed: sql.NullBool{
+					Bool:  true,
+					Valid: true,
+				},
+			},
+		},
+		{
+			Name:  "StartupFailedFalse",
+			Query: "startup_failed:false",
+			Expected: database.GetWorkspacesParams{
+				StartupFailed: sql.NullBool{
+					Bool:  false,
+					Valid: true,
+				},
+			},
+		},
+		{
+			Name:  "StartupFailedMissing",
+			Query: "",
+			Expected: database.GetWorkspacesParams{
+				StartupFailed: sql.NullBool{
+					Bool:  false,
+					Valid: false,
+				},
+			},
+		},
+		{
 			Name:  "SharedTrue",
 			Query: "shared:true",
 			Expected: database.GetWorkspacesParams{

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -142,7 +142,7 @@ func (api *API) workspace(rw http.ResponseWriter, r *http.Request) {
 // @Security CoderSessionToken
 // @Produce json
 // @Tags Workspaces
-// @Param q query string false "Search query in the format `key:value`. Available keys are: owner, template, name, status, has-agent, dormant, last_used_after, last_used_before, has-ai-task, has_external_agent, healthy."
+// @Param q query string false "Search query in the format `key:value`. Available keys are: owner, template, name, status, has-agent, dormant, last_used_after, last_used_before, has-ai-task, has_external_agent, healthy, startup_failed."
 // @Param limit query int false "Page limit"
 // @Param offset query int false "Page offset"
 // @Success 200 {object} codersdk.WorkspacesResponse

--- a/coderd/workspaces_test.go
+++ b/coderd/workspaces_test.go
@@ -2723,6 +2723,69 @@ func TestWorkspaceFilterManual(t *testing.T) {
 			require.Contains(t, workspaceIDs, timedOutBuild.Workspace.ID)
 		})
 	})
+
+	t.Run("StartupFailedFilter", func(t *testing.T) {
+		t.Parallel()
+
+		client, db := coderdtest.NewWithDatabase(t, nil)
+		user := coderdtest.CreateFirstUser(t, client)
+		now := time.Now()
+
+		//nolint:gocritic // This is a test, we need system context to update agent lifecycle state.
+		ctx := dbauthz.AsSystemRestricted(context.Background())
+
+		startErrorBuild := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
+			OrganizationID: user.OrganizationID,
+			OwnerID:        user.UserID,
+			Name:           "startup-failed-workspace",
+		}).WithAgent().Do()
+		require.Len(t, startErrorBuild.Agents, 1)
+		err := db.UpdateWorkspaceAgentLifecycleStateByID(ctx, database.UpdateWorkspaceAgentLifecycleStateByIDParams{
+			ID:             startErrorBuild.Agents[0].ID,
+			LifecycleState: database.WorkspaceAgentLifecycleStateStartError,
+			StartedAt:      sql.NullTime{Time: now, Valid: true},
+			ReadyAt:        sql.NullTime{Time: now, Valid: true},
+		})
+		require.NoError(t, err)
+
+		readyBuild := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
+			OrganizationID: user.OrganizationID,
+			OwnerID:        user.UserID,
+			Name:           "ready-workspace",
+		}).WithAgent().Do()
+		require.Len(t, readyBuild.Agents, 1)
+		err = db.UpdateWorkspaceAgentLifecycleStateByID(ctx, database.UpdateWorkspaceAgentLifecycleStateByIDParams{
+			ID:             readyBuild.Agents[0].ID,
+			LifecycleState: database.WorkspaceAgentLifecycleStateReady,
+			StartedAt:      sql.NullTime{Time: now, Valid: true},
+			ReadyAt:        sql.NullTime{Time: now, Valid: true},
+		})
+		require.NoError(t, err)
+
+		startTimeoutBuild := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
+			OrganizationID: user.OrganizationID,
+			OwnerID:        user.UserID,
+			Name:           "startup-timeout-workspace",
+		}).WithAgent().Do()
+		require.Len(t, startTimeoutBuild.Agents, 1)
+		err = db.UpdateWorkspaceAgentLifecycleStateByID(ctx, database.UpdateWorkspaceAgentLifecycleStateByIDParams{
+			ID:             startTimeoutBuild.Agents[0].ID,
+			LifecycleState: database.WorkspaceAgentLifecycleStateStartTimeout,
+			StartedAt:      sql.NullTime{Time: now, Valid: true},
+		})
+		require.NoError(t, err)
+
+		testCtx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+
+		res, err := client.Workspaces(testCtx, codersdk.WorkspaceFilter{
+			FilterQuery: "status:running startup_failed:true",
+		})
+		require.NoError(t, err)
+		require.Len(t, res.Workspaces, 1)
+		require.Equal(t, startErrorBuild.Workspace.ID, res.Workspaces[0].ID)
+	})
+
 	t.Run("Params", func(t *testing.T) {
 		t.Parallel()
 

--- a/codersdk/toolsdk/chatgpt.go
+++ b/codersdk/toolsdk/chatgpt.go
@@ -157,6 +157,7 @@ To pick what you want to search for, use the following query formats:
 	- "organization:<organization>" - Filter by organization ID or name. Example: "organization:engineering"
 	- "status:<status>" - Filter by workspace/build status. Values: starting, stopping, deleting, deleted, stopped, started, running, pending, canceling, canceled, failed. Example: "status:running"
 	- "has-agent:<agent-status>" - Filter by agent connectivity status. Values: connecting, connected, disconnected, timeout. Example: "has-agent:connected"
+	- "startup_failed:<true|false>" - Filter workspaces by whether a startup script failed on the latest start build. Example: "startup_failed:true"
 	- "dormant:<true|false>" - Filter dormant workspaces. Example: "dormant:true"
 	- "outdated:<true|false>" - Filter workspaces using outdated template versions. Example: "outdated:true"
 	- "last_used_after:<timestamp>" - Filter workspaces last used after a specific date. Example: "last_used_after:2023-12-01T00:00:00Z"

--- a/codersdk/workspaces.go
+++ b/codersdk/workspaces.go
@@ -520,6 +520,9 @@ type WorkspaceFilter struct {
 	Name string `json:"name,omitempty" typescript:"-"`
 	// Status is a workspace status, which is really the status of the latest build
 	Status string `json:"status,omitempty" typescript:"-"`
+	// StartupFailed filters workspaces by whether a startup script failed on the
+	// latest start build.
+	StartupFailed *bool `json:"startup_failed,omitempty" typescript:"-"`
 	// Offset is the number of workspaces to skip before returning results.
 	Offset int `json:"offset,omitempty" typescript:"-"`
 	// Limit is a limit on the number of workspaces returned.
@@ -552,6 +555,9 @@ func (f WorkspaceFilter) asRequestOption() RequestOption {
 		}
 		if f.Status != "" {
 			params = append(params, fmt.Sprintf("status:%q", f.Status))
+		}
+		if f.StartupFailed != nil {
+			params = append(params, fmt.Sprintf("startup_failed:%v", *f.StartupFailed))
 		}
 		if f.Shared != nil {
 			params = append(params, fmt.Sprintf("shared:%v", *f.Shared))

--- a/docs/reference/api/workspaces.md
+++ b/docs/reference/api/workspaces.md
@@ -1048,11 +1048,11 @@ curl -X GET http://coder-server:8080/api/v2/workspaces \
 
 ### Parameters
 
-| Name     | In    | Type    | Required | Description                                                                                                                                                                                 |
-|----------|-------|---------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `q`      | query | string  | false    | Search query in the format `key:value`. Available keys are: owner, template, name, status, has-agent, dormant, last_used_after, last_used_before, has-ai-task, has_external_agent, healthy. |
-| `limit`  | query | integer | false    | Page limit                                                                                                                                                                                  |
-| `offset` | query | integer | false    | Page offset                                                                                                                                                                                 |
+| Name     | In    | Type    | Required | Description                                                                                                                                                                                                 |
+|----------|-------|---------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `q`      | query | string  | false    | Search query in the format `key:value`. Available keys are: owner, template, name, status, has-agent, dormant, last_used_after, last_used_before, has-ai-task, has_external_agent, healthy, startup_failed. |
+| `limit`  | query | integer | false    | Page limit                                                                                                                                                                                                  |
+| `offset` | query | integer | false    | Page offset                                                                                                                                                                                                 |
 
 ### Example responses
 

--- a/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.tsx
@@ -293,9 +293,26 @@ const useWorkspacesFilter = ({
 	});
 
 	const statusMenu = useStatusFilterMenu({
-		value: filter.values.status,
-		onChange: (option) =>
-			filter.update({ ...filter.values, status: option?.value }),
+		value:
+			filter.values.status === "running" &&
+			filter.values.startup_failed === "true"
+				? "startup_failed"
+				: filter.values.status,
+		onChange: (option) => {
+			if (option?.value === "startup_failed") {
+				filter.update({
+					...filter.values,
+					status: "running",
+					startup_failed: "true",
+				});
+				return;
+			}
+			filter.update({
+				...filter.values,
+				status: option?.value,
+				startup_failed: undefined,
+			});
+		},
 	});
 
 	const { showOrganizations } = useDashboard();

--- a/site/src/pages/WorkspacesPage/filter/WorkspacesFilter.stories.tsx
+++ b/site/src/pages/WorkspacesPage/filter/WorkspacesFilter.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, within } from "storybook/test";
 import {
 	getDefaultFilterProps,
 	MockMenu,
@@ -77,5 +78,37 @@ export const WithError: Story = {
 export const WithDormantPreset: Story = {
 	parameters: {
 		features: ["advanced_template_scheduling"],
+	},
+};
+
+export const WithStartupFailedStatus: Story = {
+	args: {
+		filter: {
+			...defaultFilterProps.filter,
+			query: "owner:me status:running startup_failed:true",
+			values: {
+				owner: "me",
+				template: undefined,
+				status: "running",
+				startup_failed: "true",
+			},
+		},
+		statusMenu: {
+			...MockMenu,
+			selectedOption: {
+				label: "Startup failed",
+				value: "startup_failed",
+			},
+			searchOptions: [
+				{
+					label: "Startup failed",
+					value: "startup_failed",
+				},
+			],
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByText("Startup failed")).toBeVisible();
 	},
 };

--- a/site/src/pages/WorkspacesPage/filter/menus.tsx
+++ b/site/src/pages/WorkspacesPage/filter/menus.tsx
@@ -97,6 +97,8 @@ export const TemplateMenu: FC<TemplateMenuProps> = ({ width, menu }) => {
 
 /** Status Filter Menu */
 
+const startupFailedStatusValue = "startup_failed";
+
 export const useStatusFilterMenu = ({
 	value,
 	onChange,
@@ -107,7 +109,7 @@ export const useStatusFilterMenu = ({
 		"failed",
 		"pending",
 	];
-	const statusOptions = statusesToFilter.map((status) => {
+	const statusOptions: SelectFilterOption[] = statusesToFilter.map((status) => {
 		const display = getDisplayWorkspaceStatus(status);
 		return {
 			label: display.text,
@@ -116,6 +118,11 @@ export const useStatusFilterMenu = ({
 				<StatusIndicatorDot variant={getStatusIndicatorVariant(status)} />
 			),
 		};
+	});
+	statusOptions.push({
+		label: "Startup failed",
+		value: startupFailedStatusValue,
+		startIcon: <StatusIndicatorDot variant="warning" />,
 	});
 	return useFilterMenu({
 		onChange,
@@ -148,9 +155,11 @@ export const StatusMenu: FC<StatusMenuProps> = ({ width, menu }) => {
 };
 
 const getStatusIndicatorVariant = (
-	status: WorkspaceStatus,
+	status: WorkspaceStatus | typeof startupFailedStatusValue,
 ): StatusIndicatorDotProps["variant"] => {
 	switch (status) {
+		case "startup_failed":
+			return "warning";
 		case "running":
 			return "success";
 		case "starting":


### PR DESCRIPTION
Problem:

<img width="1363" height="69" alt="image" src="https://github.com/user-attachments/assets/9a4085f9-ba9a-48d8-9420-f6ca9289ae41" />

There is currently no way to filter for running Workspaces that startup failures

Solution:

Adds a backend-supported `startup_failed:<true|false>` workspace search filter and wires the Workspaces status dropdown to expose `Startup failed` as a synthetic running-state filter.

Selecting the new status preserves existing owner, template, and organization filters while applying `status:running startup_failed:true`. The search query, SDK filter serialization, API docs, tool help, generated database code, and Storybook/backend coverage are updated together.
