### PR TITLE
feat(site/src/pages/AgentsPage/components): collapse sequential read file events

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
 import {
 	expect,
 	fireEvent,
@@ -235,6 +236,67 @@ const buildStoryArgs = (...messages: TypesGen.ChatMessage[]) => ({
 	...defaultArgs,
 	parsedMessages: buildMessages(messages),
 });
+
+const buildParsedReadFileEntry = ({
+	messageId,
+	toolId,
+	path,
+	status,
+	content = "",
+	errorMessage,
+	isError = status === "error",
+}: {
+	messageId: number;
+	toolId: string;
+	path: string;
+	status: "completed" | "error" | "running";
+	content?: string;
+	errorMessage?: string;
+	isError?: boolean;
+}): ParsedMessageEntry => {
+	const args = { path };
+	const result =
+		content || errorMessage
+			? {
+					...(content ? { content } : {}),
+					...(errorMessage ? { error: errorMessage } : {}),
+				}
+			: undefined;
+
+	return {
+		message: {
+			...baseMessage,
+			id: messageId,
+			role: "assistant",
+			content: [
+				{
+					type: "tool-call",
+					tool_call_id: toolId,
+					tool_name: "read_file",
+					args,
+				},
+			],
+		},
+		parsed: {
+			markdown: "",
+			reasoning: "",
+			toolCalls: [{ id: toolId, name: "read_file", args }],
+			toolResults: [],
+			tools: [
+				{
+					id: toolId,
+					name: "read_file",
+					args,
+					result,
+					isError,
+					status,
+				},
+			],
+			blocks: [{ type: "tool", id: toolId }],
+			sources: [],
+		},
+	};
+};
 
 const LONG_USER_MESSAGE = [
 	"This is a deliberately long user message that should stay pinned to the",
@@ -2309,6 +2371,169 @@ export const SequentialReadFilesCollapsed: Story = {
 			expect(canvas.getByText("site/src/a.ts")).toBeVisible();
 			expect(canvas.getByText("site/src/b.ts")).toBeVisible();
 			expect(canvas.getByText("site/src/c.ts")).toBeVisible();
+		});
+	},
+};
+
+export const SequentialReadFilesErrorStates: Story = {
+	args: {
+		...defaultArgs,
+		parsedMessages: [
+			buildParsedReadFileEntry({
+				messageId: 1,
+				toolId: "read-error-1",
+				path: "site/src/missing-a.ts",
+				status: "error",
+				errorMessage: "ENOENT: no such file or directory",
+			}),
+			buildParsedReadFileEntry({
+				messageId: 2,
+				toolId: "read-error-2",
+				path: "site/src/missing-b.ts",
+				status: "error",
+				errorMessage: "permission denied",
+			}),
+			...buildMessages([
+				{
+					...baseMessage,
+					id: 3,
+					role: "assistant",
+					content: [{ type: "text", text: "Trying a different file set." }],
+				},
+			]),
+			buildParsedReadFileEntry({
+				messageId: 4,
+				toolId: "read-mixed-1",
+				path: "site/src/ok.ts",
+				status: "completed",
+				content: "export const ok = true;",
+			}),
+			buildParsedReadFileEntry({
+				messageId: 5,
+				toolId: "read-mixed-2",
+				path: "site/src/missing-c.ts",
+				status: "error",
+				errorMessage: "not found",
+			}),
+		] satisfies ParsedMessageEntry[],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const buttons = canvas.getAllByRole("button", { name: /read 2 files/i });
+		expect(buttons).toHaveLength(2);
+
+		await userEvent.click(buttons[0]);
+		await waitFor(() => {
+			expect(canvas.getByText("site/src/missing-a.ts")).toBeVisible();
+			expect(
+				canvas.getByText("ENOENT: no such file or directory"),
+			).toBeVisible();
+			expect(canvas.getByText("site/src/missing-b.ts")).toBeVisible();
+			expect(canvas.getByText("permission denied")).toBeVisible();
+		});
+
+		await userEvent.click(buttons[1]);
+		await waitFor(() => {
+			expect(canvas.getByText("site/src/ok.ts")).toBeVisible();
+			expect(canvas.getByText("site/src/missing-c.ts")).toBeVisible();
+			expect(canvas.getByText("not found")).toBeVisible();
+		});
+	},
+};
+
+export const SequentialReadFilesRunningState: Story = {
+	args: {
+		...defaultArgs,
+		parsedMessages: [
+			buildParsedReadFileEntry({
+				messageId: 1,
+				toolId: "read-running-1",
+				path: "site/src/one.ts",
+				status: "running",
+			}),
+			buildParsedReadFileEntry({
+				messageId: 2,
+				toolId: "read-running-2",
+				path: "site/src/two.ts",
+				status: "running",
+			}),
+			buildParsedReadFileEntry({
+				messageId: 3,
+				toolId: "read-running-3",
+				path: "site/src/three.ts",
+				status: "running",
+			}),
+		] satisfies ParsedMessageEntry[],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByText(/reading 3 files/i)).toBeInTheDocument();
+	},
+};
+
+export const SequentialReadFilesExpansionPersistsAcrossGrouping: Story = {
+	render: function Render(args) {
+		const [parsedMessages, setParsedMessages] = useState<ParsedMessageEntry[]>([
+			buildParsedReadFileEntry({
+				messageId: 1,
+				toolId: "read-stream-1",
+				path: "site/src/a.ts",
+				status: "completed",
+				content: "export const a = 1;",
+			}),
+		]);
+
+		return (
+			<div className="space-y-4">
+				<button
+					type="button"
+					onClick={() =>
+						setParsedMessages([
+							buildParsedReadFileEntry({
+								messageId: 1,
+								toolId: "read-stream-1",
+								path: "site/src/a.ts",
+								status: "completed",
+								content: "export const a = 1;",
+							}),
+							buildParsedReadFileEntry({
+								messageId: 2,
+								toolId: "read-stream-2",
+								path: "site/src/b.ts",
+								status: "completed",
+								content: "export const b = 2;",
+							}),
+						])
+					}
+					className="rounded border border-border-default px-2 py-1 text-xs"
+				>
+					Add second read_file
+				</button>
+				<ConversationTimeline {...args} parsedMessages={parsedMessages} />
+			</div>
+		);
+	},
+	args: {
+		...defaultArgs,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const singleReadButton = canvas.getByRole("button", {
+			name: /read a\.ts/i,
+		});
+		await userEvent.click(singleReadButton);
+		expect(singleReadButton).toHaveAttribute("aria-expanded", "true");
+
+		await userEvent.click(
+			canvas.getByRole("button", { name: /add second read_file/i }),
+		);
+
+		await waitFor(() => {
+			expect(
+				canvas.getByRole("button", { name: /read 2 files/i }),
+			).toHaveAttribute("aria-expanded", "true");
+			expect(canvas.getByText("site/src/a.ts")).toBeVisible();
+			expect(canvas.getByText("site/src/b.ts")).toBeVisible();
 		});
 	},
 };

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -2375,6 +2375,38 @@ export const SequentialReadFilesCollapsed: Story = {
 	},
 };
 
+export const SequentialReadFilesEmptyFilesExpandable: Story = {
+	args: {
+		...defaultArgs,
+		parsedMessages: [
+			buildParsedReadFileEntry({
+				messageId: 1,
+				toolId: "read-empty-1",
+				path: "site/src/empty-a.ts",
+				status: "completed",
+			}),
+			buildParsedReadFileEntry({
+				messageId: 2,
+				toolId: "read-empty-2",
+				path: "site/src/empty-b.ts",
+				status: "completed",
+			}),
+		] satisfies ParsedMessageEntry[],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const groupButton = canvas.getByRole("button", { name: /read 2 files/i });
+		expect(groupButton).toBeInTheDocument();
+		expect(canvas.queryByText("site/src/empty-a.ts")).not.toBeInTheDocument();
+		expect(canvas.queryByText("site/src/empty-b.ts")).not.toBeInTheDocument();
+		await userEvent.click(groupButton);
+		await waitFor(() => {
+			expect(canvas.getByText("site/src/empty-a.ts")).toBeVisible();
+			expect(canvas.getByText("site/src/empty-b.ts")).toBeVisible();
+		});
+	},
+};
+
 export const SequentialReadFilesErrorStates: Story = {
 	args: {
 		...defaultArgs,

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -2344,9 +2344,16 @@ export const SequentialReadFilesCollapsed: Story = {
 		).not.toBeInTheDocument();
 		await userEvent.click(groupButton);
 		await waitFor(() => {
-			expect(canvas.getByText("site/src/a.ts")).toBeVisible();
-			expect(canvas.getByText("site/src/b.ts")).toBeVisible();
-			expect(canvas.getByText("site/src/c.ts")).toBeVisible();
+			expect(canvas.getByRole("button", { name: /read a\.ts/i })).toBeVisible();
+			expect(canvas.getByRole("button", { name: /read b\.ts/i })).toBeVisible();
+			expect(canvas.getByRole("button", { name: /read c\.ts/i })).toBeVisible();
+		});
+		const firstFileButton = canvas.getByRole("button", { name: /read a\.ts/i });
+		expect(firstFileButton).toHaveAttribute("aria-expanded", "false");
+
+		await userEvent.click(firstFileButton);
+		await waitFor(() => {
+			expect(firstFileButton).toHaveAttribute("aria-expanded", "true");
 		});
 	},
 };
@@ -2398,18 +2405,27 @@ export const SequentialReadFilesEmptyAndErrorStates: Story = {
 
 		await userEvent.click(buttons[0]);
 		await waitFor(() => {
-			expect(canvas.getByText("site/src/empty-a.ts")).toBeVisible();
-			expect(canvas.getByText("site/src/empty-b.ts")).toBeVisible();
+			expect(canvas.getByText("Read empty-a.ts")).toBeVisible();
+			expect(canvas.getByText("Read empty-b.ts")).toBeVisible();
 		});
 
 		await userEvent.click(buttons[1]);
 		await waitFor(() => {
-			expect(canvas.getByText("site/src/missing-a.ts")).toBeVisible();
+			expect(
+				canvas.getByRole("button", { name: /read missing-a\.ts/i }),
+			).toBeVisible();
+			expect(
+				canvas.getByRole("button", { name: /read missing-b\.ts/i }),
+			).toBeVisible();
+		});
+
+		await userEvent.click(
+			canvas.getByRole("button", { name: /read missing-a\.ts/i }),
+		);
+		await waitFor(() => {
 			expect(
 				canvas.getByText("ENOENT: no such file or directory"),
 			).toBeVisible();
-			expect(canvas.getByText("site/src/missing-b.ts")).toBeVisible();
-			expect(canvas.getByText("permission denied")).toBeVisible();
 		});
 	},
 };

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -2507,14 +2507,16 @@ export const ThinkingBlockWithToolCall: Story = {
 		const toolButton = canvas.getByRole("button", {
 			name: /read package\.json/i,
 		});
-		const thinkingContainer = thinkingButton.closest("[data-transcript-row]");
-		const toolContainer = toolButton.closest("[data-transcript-row]");
-		expect(thinkingContainer).toBeInstanceOf(HTMLElement);
-		expect(toolContainer).toBeInstanceOf(HTMLElement);
-		expect(toolContainer?.firstElementChild).not.toHaveAttribute("data-state");
-		expect(thinkingContainer?.firstElementChild).not.toHaveAttribute(
-			"data-state",
-		);
+		const thinkingContainer =
+			thinkingButton.closest("[data-transcript-row]") ?? thinkingButton;
+		const toolContainer =
+			toolButton.closest("[data-transcript-row]") ?? toolButton;
+		expect(
+			toolContainer.firstElementChild ?? toolContainer,
+		).not.toHaveAttribute("data-state");
+		expect(
+			thinkingContainer.firstElementChild ?? thinkingContainer,
+		).not.toHaveAttribute("data-state");
 		expect(
 			canvas.queryByTestId("assistant-bottom-spacer"),
 		).not.toBeInTheDocument();
@@ -2601,30 +2603,20 @@ export const ThinkingBlockWithShellTools: Story = {
 			name: /expand process output/i,
 		});
 
-		const thinkingRow = thinkingButton.closest(
-			"[data-transcript-row]",
-		)?.firstElementChild;
-		const executeRow = executeButton.closest(
-			"[data-transcript-row]",
-		)?.firstElementChild;
-		const processOutputRow = processOutputButton.closest(
-			"[data-transcript-row]",
-		)?.firstElementChild;
+		const wrappers = [
+			thinkingButton.closest("[data-transcript-row]") ?? thinkingButton,
+			executeButton.closest("[data-transcript-row]") ?? executeButton,
+			processOutputButton.closest("[data-transcript-row]") ??
+				processOutputButton,
+		];
 
-		expect(thinkingRow).toBeInstanceOf(HTMLElement);
-		expect(executeRow).toBeInstanceOf(HTMLElement);
-		expect(processOutputRow).toBeInstanceOf(HTMLElement);
-
-		const rowHeights = [thinkingRow, executeRow, processOutputRow].map((row) =>
-			Math.round((row as HTMLElement).getBoundingClientRect().height),
+		const rows = wrappers.map(
+			(wrapper) => wrapper.firstElementChild ?? wrapper,
+		);
+		const rowHeights = rows.map((row) =>
+			Math.round(row.getBoundingClientRect().height),
 		);
 		expect(new Set(rowHeights)).toHaveLength(1);
-
-		const wrappers = [
-			thinkingButton.closest("[data-transcript-row]"),
-			executeButton.closest("[data-transcript-row]"),
-			processOutputButton.closest("[data-transcript-row]"),
-		].map((row) => row as HTMLElement);
 		const gaps = [
 			Math.round(
 				wrappers[1].getBoundingClientRect().top -

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -298,6 +298,43 @@ const buildParsedReadFileEntry = ({
 	};
 };
 
+const buildReadFileExchange = (
+	callMessageId: number,
+	toolId: string,
+	path: string,
+	content: string,
+): TypesGen.ChatMessage[] => {
+	const args = { path };
+	return [
+		{
+			...baseMessage,
+			id: callMessageId,
+			role: "assistant",
+			content: [
+				{
+					type: "tool-call",
+					tool_call_id: toolId,
+					tool_name: "read_file",
+					args,
+				},
+			],
+		},
+		{
+			...baseMessage,
+			id: callMessageId + 1,
+			role: "tool",
+			content: [
+				{
+					type: "tool-result",
+					tool_call_id: toolId,
+					tool_name: "read_file",
+					result: { content },
+				},
+			],
+		},
+	];
+};
+
 const LONG_USER_MESSAGE = [
 	"This is a deliberately long user message that should stay pinned to the",
 	"right edge while the bubble stops short of filling the entire timeline",
@@ -2279,84 +2316,24 @@ export const SequentialReadFilesCollapsed: Story = {
 				role: "assistant",
 				content: [{ type: "text", text: "I'll inspect the relevant files." }],
 			},
-			{
-				...baseMessage,
-				id: 2,
-				role: "assistant",
-				content: [
-					{
-						type: "tool-call",
-						tool_call_id: "read-1",
-						tool_name: "read_file",
-						args: { path: "site/src/a.ts" },
-					},
-				],
-			},
-			{
-				...baseMessage,
-				id: 3,
-				role: "tool",
-				content: [
-					{
-						type: "tool-result",
-						tool_call_id: "read-1",
-						tool_name: "read_file",
-						result: { content: "export const a = 1;" },
-					},
-				],
-			},
-			{
-				...baseMessage,
-				id: 4,
-				role: "assistant",
-				content: [
-					{
-						type: "tool-call",
-						tool_call_id: "read-2",
-						tool_name: "read_file",
-						args: { path: "site/src/b.ts" },
-					},
-				],
-			},
-			{
-				...baseMessage,
-				id: 5,
-				role: "tool",
-				content: [
-					{
-						type: "tool-result",
-						tool_call_id: "read-2",
-						tool_name: "read_file",
-						result: { content: "export const b = 2;" },
-					},
-				],
-			},
-			{
-				...baseMessage,
-				id: 6,
-				role: "assistant",
-				content: [
-					{
-						type: "tool-call",
-						tool_call_id: "read-3",
-						tool_name: "read_file",
-						args: { path: "site/src/c.ts" },
-					},
-				],
-			},
-			{
-				...baseMessage,
-				id: 7,
-				role: "tool",
-				content: [
-					{
-						type: "tool-result",
-						tool_call_id: "read-3",
-						tool_name: "read_file",
-						result: { content: "export const c = 3;" },
-					},
-				],
-			},
+			...buildReadFileExchange(
+				2,
+				"read-1",
+				"site/src/a.ts",
+				"export const a = 1;",
+			),
+			...buildReadFileExchange(
+				4,
+				"read-2",
+				"site/src/b.ts",
+				"export const b = 2;",
+			),
+			...buildReadFileExchange(
+				6,
+				"read-3",
+				"site/src/c.ts",
+				"export const c = 3;",
+			),
 		]),
 	},
 	play: async ({ canvasElement }) => {
@@ -2375,7 +2352,7 @@ export const SequentialReadFilesCollapsed: Story = {
 	},
 };
 
-export const SequentialReadFilesEmptyFilesExpandable: Story = {
+export const SequentialReadFilesEmptyAndErrorStates: Story = {
 	args: {
 		...defaultArgs,
 		parsedMessages: [
@@ -2391,40 +2368,6 @@ export const SequentialReadFilesEmptyFilesExpandable: Story = {
 				path: "site/src/empty-b.ts",
 				status: "completed",
 			}),
-		] satisfies ParsedMessageEntry[],
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const groupButton = canvas.getByRole("button", { name: /read 2 files/i });
-		expect(groupButton).toBeInTheDocument();
-		expect(canvas.queryByText("site/src/empty-a.ts")).not.toBeInTheDocument();
-		expect(canvas.queryByText("site/src/empty-b.ts")).not.toBeInTheDocument();
-		await userEvent.click(groupButton);
-		await waitFor(() => {
-			expect(canvas.getByText("site/src/empty-a.ts")).toBeVisible();
-			expect(canvas.getByText("site/src/empty-b.ts")).toBeVisible();
-		});
-	},
-};
-
-export const SequentialReadFilesErrorStates: Story = {
-	args: {
-		...defaultArgs,
-		parsedMessages: [
-			buildParsedReadFileEntry({
-				messageId: 1,
-				toolId: "read-error-1",
-				path: "site/src/missing-a.ts",
-				status: "error",
-				errorMessage: "ENOENT: no such file or directory",
-			}),
-			buildParsedReadFileEntry({
-				messageId: 2,
-				toolId: "read-error-2",
-				path: "site/src/missing-b.ts",
-				status: "error",
-				errorMessage: "permission denied",
-			}),
 			...buildMessages([
 				{
 					...baseMessage,
@@ -2435,17 +2378,17 @@ export const SequentialReadFilesErrorStates: Story = {
 			]),
 			buildParsedReadFileEntry({
 				messageId: 4,
-				toolId: "read-mixed-1",
-				path: "site/src/ok.ts",
-				status: "completed",
-				content: "export const ok = true;",
+				toolId: "read-error-1",
+				path: "site/src/missing-a.ts",
+				status: "error",
+				errorMessage: "ENOENT: no such file or directory",
 			}),
 			buildParsedReadFileEntry({
 				messageId: 5,
-				toolId: "read-mixed-2",
-				path: "site/src/missing-c.ts",
+				toolId: "read-error-2",
+				path: "site/src/missing-b.ts",
 				status: "error",
-				errorMessage: "not found",
+				errorMessage: "permission denied",
 			}),
 		] satisfies ParsedMessageEntry[],
 	},
@@ -2456,6 +2399,12 @@ export const SequentialReadFilesErrorStates: Story = {
 
 		await userEvent.click(buttons[0]);
 		await waitFor(() => {
+			expect(canvas.getByText("site/src/empty-a.ts")).toBeVisible();
+			expect(canvas.getByText("site/src/empty-b.ts")).toBeVisible();
+		});
+
+		await userEvent.click(buttons[1]);
+		await waitFor(() => {
 			expect(canvas.getByText("site/src/missing-a.ts")).toBeVisible();
 			expect(
 				canvas.getByText("ENOENT: no such file or directory"),
@@ -2463,43 +2412,6 @@ export const SequentialReadFilesErrorStates: Story = {
 			expect(canvas.getByText("site/src/missing-b.ts")).toBeVisible();
 			expect(canvas.getByText("permission denied")).toBeVisible();
 		});
-
-		await userEvent.click(buttons[1]);
-		await waitFor(() => {
-			expect(canvas.getByText("site/src/ok.ts")).toBeVisible();
-			expect(canvas.getByText("site/src/missing-c.ts")).toBeVisible();
-			expect(canvas.getByText("not found")).toBeVisible();
-		});
-	},
-};
-
-export const SequentialReadFilesRunningState: Story = {
-	args: {
-		...defaultArgs,
-		parsedMessages: [
-			buildParsedReadFileEntry({
-				messageId: 1,
-				toolId: "read-running-1",
-				path: "site/src/one.ts",
-				status: "running",
-			}),
-			buildParsedReadFileEntry({
-				messageId: 2,
-				toolId: "read-running-2",
-				path: "site/src/two.ts",
-				status: "running",
-			}),
-			buildParsedReadFileEntry({
-				messageId: 3,
-				toolId: "read-running-3",
-				path: "site/src/three.ts",
-				status: "running",
-			}),
-		] satisfies ParsedMessageEntry[],
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		expect(canvas.getByText(/reading 3 files/i)).toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -2415,6 +2415,38 @@ export const SequentialReadFilesEmptyAndErrorStates: Story = {
 	},
 };
 
+export const SequentialReadFilesRunningState: Story = {
+	args: {
+		...defaultArgs,
+		parsedMessages: [
+			buildParsedReadFileEntry({
+				messageId: 1,
+				toolId: "read-running-1",
+				path: "site/src/one.ts",
+				status: "running",
+			}),
+			buildParsedReadFileEntry({
+				messageId: 2,
+				toolId: "read-running-2",
+				path: "site/src/two.ts",
+				status: "running",
+			}),
+			buildParsedReadFileEntry({
+				messageId: 3,
+				toolId: "read-running-3",
+				path: "site/src/three.ts",
+				status: "running",
+			}),
+		] satisfies ParsedMessageEntry[],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(
+			canvas.getByRole("button", { name: /reading 3 files/i }),
+		).toBeInTheDocument();
+	},
+};
+
 export const SequentialReadFilesExpansionPersistsAcrossGrouping: Story = {
 	render: function Render(args) {
 		const [parsedMessages, setParsedMessages] = useState<ParsedMessageEntry[]>([

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { useState } from "react";
 import {
 	expect,
 	fireEvent,
@@ -2444,73 +2443,6 @@ export const SequentialReadFilesRunningState: Story = {
 		expect(
 			canvas.getByRole("button", { name: /reading 3 files/i }),
 		).toBeInTheDocument();
-	},
-};
-
-export const SequentialReadFilesExpansionPersistsAcrossGrouping: Story = {
-	render: function Render(args) {
-		const [parsedMessages, setParsedMessages] = useState<ParsedMessageEntry[]>([
-			buildParsedReadFileEntry({
-				messageId: 1,
-				toolId: "read-stream-1",
-				path: "site/src/a.ts",
-				status: "completed",
-				content: "export const a = 1;",
-			}),
-		]);
-
-		return (
-			<div className="space-y-4">
-				<button
-					type="button"
-					onClick={() =>
-						setParsedMessages([
-							buildParsedReadFileEntry({
-								messageId: 1,
-								toolId: "read-stream-1",
-								path: "site/src/a.ts",
-								status: "completed",
-								content: "export const a = 1;",
-							}),
-							buildParsedReadFileEntry({
-								messageId: 2,
-								toolId: "read-stream-2",
-								path: "site/src/b.ts",
-								status: "completed",
-								content: "export const b = 2;",
-							}),
-						])
-					}
-					className="rounded border border-border-default px-2 py-1 text-xs"
-				>
-					Add second read_file
-				</button>
-				<ConversationTimeline {...args} parsedMessages={parsedMessages} />
-			</div>
-		);
-	},
-	args: {
-		...defaultArgs,
-	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const singleReadButton = canvas.getByRole("button", {
-			name: /read a\.ts/i,
-		});
-		await userEvent.click(singleReadButton);
-		expect(singleReadButton).toHaveAttribute("aria-expanded", "true");
-
-		await userEvent.click(
-			canvas.getByRole("button", { name: /add second read_file/i }),
-		);
-
-		await waitFor(() => {
-			expect(
-				canvas.getByRole("button", { name: /read 2 files/i }),
-			).toHaveAttribute("aria-expanded", "true");
-			expect(canvas.getByText("site/src/a.ts")).toBeVisible();
-			expect(canvas.getByText("site/src/b.ts")).toBeVisible();
-		});
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -2207,6 +2207,112 @@ export const ThinkingBlockAlwaysCollapsed: Story = {
 	},
 };
 
+export const SequentialReadFilesCollapsed: Story = {
+	args: {
+		...defaultArgs,
+		parsedMessages: buildMessages([
+			{
+				...baseMessage,
+				id: 1,
+				role: "assistant",
+				content: [{ type: "text", text: "I'll inspect the relevant files." }],
+			},
+			{
+				...baseMessage,
+				id: 2,
+				role: "assistant",
+				content: [
+					{
+						type: "tool-call",
+						tool_call_id: "read-1",
+						tool_name: "read_file",
+						args: { path: "site/src/a.ts" },
+					},
+				],
+			},
+			{
+				...baseMessage,
+				id: 3,
+				role: "tool",
+				content: [
+					{
+						type: "tool-result",
+						tool_call_id: "read-1",
+						tool_name: "read_file",
+						result: { content: "export const a = 1;" },
+					},
+				],
+			},
+			{
+				...baseMessage,
+				id: 4,
+				role: "assistant",
+				content: [
+					{
+						type: "tool-call",
+						tool_call_id: "read-2",
+						tool_name: "read_file",
+						args: { path: "site/src/b.ts" },
+					},
+				],
+			},
+			{
+				...baseMessage,
+				id: 5,
+				role: "tool",
+				content: [
+					{
+						type: "tool-result",
+						tool_call_id: "read-2",
+						tool_name: "read_file",
+						result: { content: "export const b = 2;" },
+					},
+				],
+			},
+			{
+				...baseMessage,
+				id: 6,
+				role: "assistant",
+				content: [
+					{
+						type: "tool-call",
+						tool_call_id: "read-3",
+						tool_name: "read_file",
+						args: { path: "site/src/c.ts" },
+					},
+				],
+			},
+			{
+				...baseMessage,
+				id: 7,
+				role: "tool",
+				content: [
+					{
+						type: "tool-result",
+						tool_call_id: "read-3",
+						tool_name: "read_file",
+						result: { content: "export const c = 3;" },
+					},
+				],
+			},
+		]),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const groupButton = canvas.getByRole("button", { name: /read 3 files/i });
+		expect(groupButton).toBeInTheDocument();
+		expect(
+			canvas.queryByRole("button", { name: /read a\.ts/i }),
+		).not.toBeInTheDocument();
+		await userEvent.click(groupButton);
+		await waitFor(() => {
+			expect(canvas.getByText("site/src/a.ts")).toBeVisible();
+			expect(canvas.getByText("site/src/b.ts")).toBeVisible();
+			expect(canvas.getByText("site/src/c.ts")).toBeVisible();
+		});
+	},
+};
+
 /** Collapsed thinking should visually align with adjacent tool calls. */
 export const ThinkingBlockWithToolCall: Story = {
 	parameters: {

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -225,10 +225,7 @@ const ReadFileTimelineBlock = memo<{
 	if (tools.length === 1) {
 		const readFile = getReadFileToolData(firstTool);
 		return (
-			<div
-				data-tool-call=""
-				className="py-0.5 [&:has(+[data-tool-call])]:pb-0 [[data-tool-call]+&]:pt-0"
-			>
+			<div data-tool-call="">
 				<ReadFileTool
 					{...readFile}
 					status={firstTool.status}

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -31,13 +31,14 @@ import {
 	Shimmer,
 	Tool,
 } from "../ChatElements";
-import { asRecord, asString } from "../ChatElements/runtimeTypeUtils";
 import { WebSearchSources } from "../ChatElements/tools";
 import { ReadFilesTool } from "../ChatElements/tools/ReadFilesTool";
-import { ReadFileTool } from "../ChatElements/tools/ReadFileTool";
+import {
+	getReadFileToolData,
+	ReadFileTool,
+} from "../ChatElements/tools/ReadFileTool";
 import type { SubagentVariant } from "../ChatElements/tools/subagentDescriptor";
 import { ToolCollapsible } from "../ChatElements/tools/ToolCollapsible";
-import { parseArgs } from "../ChatElements/tools/utils";
 import { ImageLightbox } from "../ImageLightbox";
 import { TextPreviewDialog } from "../TextPreviewDialog";
 import {
@@ -225,23 +226,15 @@ const ReadFileTimelineBlock = memo<{
 	}
 
 	if (tools.length === 1) {
-		const parsedArgs = parseArgs(firstTool.args);
-		const path = parsedArgs ? asString(parsedArgs.path).trim() : "";
-		const result = asRecord(firstTool.result);
-		const content = result ? asString(result.content).trim() : "";
+		const readFile = getReadFileToolData(firstTool);
 		return (
 			<div
 				data-tool-call=""
 				className="py-0.5 [&:has(+[data-tool-call])]:pb-0 [[data-tool-call]+&]:pt-0"
 			>
 				<ReadFileTool
-					path={path || "file"}
-					content={content}
+					{...readFile}
 					status={firstTool.status}
-					isError={firstTool.isError}
-					errorMessage={
-						result ? asString(result.error || result.message) : undefined
-					}
 					expanded={expanded}
 					onExpandedChange={setExpanded}
 				/>

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -32,6 +32,7 @@ import {
 	Tool,
 } from "../ChatElements";
 import { WebSearchSources } from "../ChatElements/tools";
+import { ReadFilesTool } from "../ChatElements/tools/ReadFilesTool";
 import type { SubagentVariant } from "../ChatElements/tools/subagentDescriptor";
 import { ToolCollapsible } from "../ChatElements/tools/ToolCollapsible";
 import { ImageLightbox } from "../ImageLightbox";
@@ -40,8 +41,15 @@ import {
 	AttachmentBlock,
 	type PreviewTextAttachment,
 } from "./AttachmentBlocks";
+import {
+	getToolIDsForBlock,
+	groupSequentialReadFileBlocks,
+} from "./blockUtils";
 import { FileProbeProvider } from "./FileProbeContext";
-import { deriveMessageDisplayState } from "./messageHelpers";
+import {
+	deriveMessageDisplayState,
+	groupSequentialReadFileMessages,
+} from "./messageHelpers";
 import { getEditableUserMessagePayload } from "./messageParsing";
 import { useSmoothStreamingText } from "./SmoothText";
 import { getThinkingDisclosureDisplay } from "./thinkingTitle";
@@ -257,16 +265,17 @@ export const BlockList: FC<{
 		prefQuery.data?.code_diff_display_mode || "auto";
 
 	const toolByID = new Map(tools.map((tool) => [tool.id, tool]));
+	const displayBlocks = groupSequentialReadFileBlocks(blocks, tools);
 
 	// Pre-compute which tool IDs have a corresponding block so
 	// we can render "remaining" (block-less) tools afterwards.
 	const blockToolIDs = new Set(
-		blocks
-			.filter(
-				(b): b is Extract<RenderBlock, { type: "tool" }> =>
-					b.type === "tool" && (toolByID.has(b.id) || isStreaming),
-			)
-			.map((b) => b.id),
+		displayBlocks.flatMap((block) => {
+			if (block.type === "tool" && !(toolByID.has(block.id) || isStreaming)) {
+				return [];
+			}
+			return [...getToolIDsForBlock(block)];
+		}),
 	);
 
 	const remainingTools = tools.filter((tool) => !blockToolIDs.has(tool.id));
@@ -274,12 +283,13 @@ export const BlockList: FC<{
 	// A thinking block is actively streaming only when it is the
 	// very last block in the list. Once newer content arrives
 	// (response, tool call, etc.) the thinking phase is over.
-	const lastBlockIsThinking =
-		blocks.length > 0 && blocks[blocks.length - 1].type === "thinking";
+	const lastDisplayBlockIsThinking =
+		displayBlocks.length > 0 &&
+		displayBlocks[displayBlocks.length - 1].type === "thinking";
 
 	return (
 		<>
-			{blocks.map((block, index) => {
+			{displayBlocks.map((block, index) => {
 				switch (block.type) {
 					case "response": {
 						const responseEl = isStreaming ? (
@@ -311,8 +321,8 @@ export const BlockList: FC<{
 								text={block.text}
 								isStreaming={
 									isStreaming &&
-									lastBlockIsThinking &&
-									index === blocks.length - 1
+									lastDisplayBlockIsThinking &&
+									index === displayBlocks.length - 1
 								}
 								urlTransform={urlTransform}
 								thinkingDisplayMode={thinkingDisplayMode}
@@ -332,6 +342,20 @@ export const BlockList: FC<{
 								</span>
 							</div>
 						);
+					case "tool-group": {
+						const groupTools = block.ids
+							.map((id) => toolByID.get(id))
+							.filter((tool): tool is MergedTool => Boolean(tool));
+						if (groupTools.length === 0) {
+							return null;
+						}
+						return (
+							<ReadFilesTool
+								key={`${keyPrefix}-tool-group-${index}`}
+								tools={groupTools}
+							/>
+						);
+					}
 					case "tool": {
 						const tool = toolByID.get(block.id);
 						if (!tool) {
@@ -1012,25 +1036,16 @@ const StickyUserMessage = memo<{
 );
 
 function computeLastInChainFlags(
-	parsedMessages: readonly ParsedMessageEntry[],
+	displayMessages: readonly ParsedMessageEntry[],
 ): boolean[] {
-	const flags = new Array<boolean>(parsedMessages.length).fill(false);
-	let nextVisibleIsUser = true; // no next visible => treat as chain end
-	for (let i = parsedMessages.length - 1; i >= 0; i--) {
-		const entry = parsedMessages[i];
-		const { shouldHide } = deriveMessageDisplayState({
-			message: entry.message,
-			parsed: entry.parsed,
-			hideActions: false,
-			hasActiveStream: false,
-			isAwaitingFirstStreamChunk: false,
-		});
+	const flags = new Array<boolean>(displayMessages.length).fill(false);
+	let nextVisibleIsUser = true;
+	for (let i = displayMessages.length - 1; i >= 0; i--) {
+		const entry = displayMessages[i];
 		if (entry.message.role !== "user") {
 			flags[i] = nextVisibleIsUser;
 		}
-		if (!shouldHide) {
-			nextVisibleIsUser = entry.message.role === "user";
-		}
+		nextVisibleIsUser = entry.message.role === "user";
 	}
 	return flags;
 }
@@ -1086,7 +1101,8 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 			});
 		};
 
-		const lastInChainFlags = computeLastInChainFlags(parsedMessages);
+		const displayMessages = groupSequentialReadFileMessages(parsedMessages);
+		const lastInChainFlags = computeLastInChainFlags(displayMessages);
 
 		if (parsedMessages.length === 0) {
 			return null;
@@ -1178,7 +1194,7 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 					data-testid="conversation-timeline"
 					className="flex flex-col gap-2"
 				>
-					{parsedMessages.map(({ message, parsed }, msgIdx) => {
+					{displayMessages.map(({ message, parsed }, msgIdx) => {
 						if (message.role === "user") {
 							const { shouldHide } = deriveMessageDisplayState({
 								message,

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -45,10 +45,7 @@ import {
 	AttachmentBlock,
 	type PreviewTextAttachment,
 } from "./AttachmentBlocks";
-import {
-	getToolIDsForBlock,
-	groupSequentialReadFileBlocks,
-} from "./blockUtils";
+import { groupSequentialReadFileBlocks } from "./blockUtils";
 import { FileProbeProvider } from "./FileProbeContext";
 import {
 	deriveMessageDisplayState,
@@ -310,10 +307,13 @@ export const BlockList: FC<{
 	// we can render "remaining" (block-less) tools afterwards.
 	const blockToolIDs = new Set(
 		displayBlocks.flatMap((block) => {
-			if (block.type === "tool" && !(toolByID.has(block.id) || isStreaming)) {
-				return [];
+			if (block.type === "tool") {
+				return toolByID.has(block.id) || isStreaming ? [block.id] : [];
 			}
-			return [...getToolIDsForBlock(block)];
+			if (block.type === "tool-group") {
+				return block.ids;
+			}
+			return [];
 		}),
 	);
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -31,10 +31,13 @@ import {
 	Shimmer,
 	Tool,
 } from "../ChatElements";
+import { asRecord, asString } from "../ChatElements/runtimeTypeUtils";
 import { WebSearchSources } from "../ChatElements/tools";
 import { ReadFilesTool } from "../ChatElements/tools/ReadFilesTool";
+import { ReadFileTool } from "../ChatElements/tools/ReadFileTool";
 import type { SubagentVariant } from "../ChatElements/tools/subagentDescriptor";
 import { ToolCollapsible } from "../ChatElements/tools/ToolCollapsible";
+import { parseArgs } from "../ChatElements/tools/utils";
 import { ImageLightbox } from "../ImageLightbox";
 import { TextPreviewDialog } from "../TextPreviewDialog";
 import {
@@ -212,6 +215,49 @@ const SmoothedResponse = memo<{
 	);
 });
 
+const READ_FILE_TIMELINE_BLOCK_CLASS_NAME =
+	"py-0.5 [&:has(+[data-tool-call])]:pb-0 [[data-tool-call]+&]:pt-0";
+
+const ReadFileTimelineBlock = memo<{
+	tools: readonly MergedTool[];
+}>(({ tools }) => {
+	const [expanded, setExpanded] = useState(false);
+	const [firstTool] = tools;
+	if (!firstTool) {
+		return null;
+	}
+
+	if (tools.length === 1) {
+		const parsedArgs = parseArgs(firstTool.args);
+		const path = parsedArgs ? asString(parsedArgs.path).trim() : "";
+		const result = asRecord(firstTool.result);
+		const content = result ? asString(result.content).trim() : "";
+		return (
+			<div data-tool-call="" className={READ_FILE_TIMELINE_BLOCK_CLASS_NAME}>
+				<ReadFileTool
+					path={path || "file"}
+					content={content}
+					status={firstTool.status}
+					isError={firstTool.isError}
+					errorMessage={
+						result ? asString(result.error || result.message) : undefined
+					}
+					expanded={expanded}
+					onExpandedChange={setExpanded}
+				/>
+			</div>
+		);
+	}
+
+	return (
+		<ReadFilesTool
+			tools={tools}
+			expanded={expanded}
+			onExpandedChange={setExpanded}
+		/>
+	);
+});
+
 // Shared block renderer used by both ChatMessageItem (historical
 // messages) and StreamingOutput (live stream). Encapsulates the
 // response / thinking / tool / file / sources switch so both
@@ -345,13 +391,14 @@ export const BlockList: FC<{
 					case "tool-group": {
 						const groupTools = block.ids
 							.map((id) => toolByID.get(id))
-							.filter((tool): tool is MergedTool => Boolean(tool));
-						if (groupTools.length === 0) {
+							.filter((tool) => tool !== undefined);
+						const [firstGroupTool] = groupTools;
+						if (!firstGroupTool) {
 							return null;
 						}
 						return (
-							<ReadFilesTool
-								key={`${keyPrefix}-tool-group-${index}`}
+							<ReadFileTimelineBlock
+								key={firstGroupTool.id}
 								tools={groupTools}
 							/>
 						);
@@ -377,6 +424,9 @@ export const BlockList: FC<{
 									mcpServers={mcpServers}
 								/>
 							);
+						}
+						if (tool.name === "read_file") {
+							return <ReadFileTimelineBlock key={tool.id} tools={[tool]} />;
 						}
 						return (
 							<Tool

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -215,9 +215,6 @@ const SmoothedResponse = memo<{
 	);
 });
 
-const READ_FILE_TIMELINE_BLOCK_CLASS_NAME =
-	"py-0.5 [&:has(+[data-tool-call])]:pb-0 [[data-tool-call]+&]:pt-0";
-
 const ReadFileTimelineBlock = memo<{
 	tools: readonly MergedTool[];
 }>(({ tools }) => {
@@ -233,7 +230,10 @@ const ReadFileTimelineBlock = memo<{
 		const result = asRecord(firstTool.result);
 		const content = result ? asString(result.content).trim() : "";
 		return (
-			<div data-tool-call="" className={READ_FILE_TIMELINE_BLOCK_CLASS_NAME}>
+			<div
+				data-tool-call=""
+				className="py-0.5 [&:has(+[data-tool-call])]:pb-0 [[data-tool-call]+&]:pt-0"
+			>
 				<ReadFileTool
 					path={path || "file"}
 					content={content}

--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.stories.tsx
@@ -281,32 +281,28 @@ export const ThinkingDuringStreamingWithToolCalls: Story = {
 		// Tool-only stream chunks can otherwise clear the activity indicator before text arrives.
 		expect(canvas.getAllByText("Thinking").length).toBeGreaterThanOrEqual(1);
 
-		const toolCallWrappers = Array.from(
-			canvasElement.querySelectorAll("[data-transcript-row]"),
-		);
-		expect(toolCallWrappers).toHaveLength(3);
+		const executeButton = canvas.getByRole("button", {
+			name: /collapse command/i,
+		});
+		const readFileLabel = canvas.getByText(/reading README\.md/i);
+		const thinkingText = canvas.getAllByText("Thinking").at(-1);
+		expect(thinkingText).toBeInstanceOf(HTMLElement);
 
-		const thinkingWrapper = toolCallWrappers.at(-1);
-		const previousToolWrapper = toolCallWrappers.at(-2);
-		expect(thinkingWrapper).toBeInstanceOf(HTMLElement);
-		expect(previousToolWrapper).toBeInstanceOf(HTMLElement);
-		expect(thinkingWrapper).toHaveTextContent("Thinking");
+		const wrappers = [
+			executeButton.closest("[data-transcript-row]") ?? executeButton,
+			readFileLabel.closest("[data-tool-call]") ?? readFileLabel,
+			(thinkingText as HTMLElement).closest("[data-transcript-row]") ??
+				(thinkingText as HTMLElement),
+		];
+		expect(wrappers.at(-1)).toHaveTextContent("Thinking");
 
 		const gap = Math.round(
-			(thinkingWrapper as HTMLElement).getBoundingClientRect().top -
-				(previousToolWrapper as HTMLElement).getBoundingClientRect().bottom,
+			wrappers[2].getBoundingClientRect().top -
+				wrappers[1].getBoundingClientRect().bottom,
 		);
 		expect(gap).toBe(8);
 
-		// The placeholder inner row must match the committed collapsed
-		// Thinking row height so the transition from streaming to settled
-		// does not jump. ToolCollapsible enforces min-h-6 (24px).
-		const placeholderRow = (thinkingWrapper as HTMLElement).firstElementChild;
-		expect(placeholderRow).toBeInstanceOf(HTMLElement);
-		expect(
-			Math.round(
-				(placeholderRow as HTMLElement).getBoundingClientRect().height,
-			),
-		).toBe(24);
+		const placeholderRow = wrappers[2].firstElementChild ?? wrappers[2];
+		expect(Math.round(placeholderRow.getBoundingClientRect().height)).toBe(24);
 	},
 };

--- a/site/src/pages/AgentsPage/components/ChatConversation/blockUtils.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/blockUtils.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import {
 	appendTextBlock,
 	asNonEmptyString,
-	getToolIDsForBlock,
 	groupSequentialReadFileBlocks,
 } from "./blockUtils";
 import type { MergedTool, RenderBlock } from "./types";
@@ -102,55 +101,14 @@ describe("appendTextBlock", () => {
 	});
 });
 
-describe("getToolIDsForBlock", () => {
-	it("returns the tool ID for tool blocks", () => {
-		expect(getToolIDsForBlock({ type: "tool", id: "read-1" })).toEqual([
-			"read-1",
-		]);
-	});
-
-	it("returns all tool IDs for tool-group blocks", () => {
-		expect(
-			getToolIDsForBlock({
-				type: "tool-group",
-				toolName: "read_file",
-				ids: ["read-1", "read-2"],
-			}),
-		).toEqual(["read-1", "read-2"]);
-	});
-
-	it("returns an empty list for non-tool blocks", () => {
-		expect(getToolIDsForBlock({ type: "response", text: "hello" })).toEqual([]);
-	});
-});
-
 describe("groupSequentialReadFileBlocks", () => {
-	const tools: MergedTool[] = [
-		{
-			id: "read-1",
-			name: "read_file",
-			args: { path: "a.ts" },
-			result: { content: "a" },
-			isError: false,
-			status: "completed",
-		},
-		{
-			id: "read-2",
-			name: "read_file",
-			args: { path: "b.ts" },
-			result: { content: "b" },
-			isError: false,
-			status: "completed",
-		},
-		{
-			id: "execute-1",
-			name: "execute",
-			args: { command: "pwd" },
-			result: { output: "/home/coder" },
-			isError: false,
-			status: "completed",
-		},
-	];
+	const tool = (id: string, name = "read_file"): MergedTool => ({
+		id,
+		name,
+		isError: false,
+		status: "completed",
+	});
+	const tools = [tool("read-1"), tool("read-2"), tool("execute-1", "execute")];
 
 	it("collapses consecutive read_file tool blocks", () => {
 		const result = groupSequentialReadFileBlocks(
@@ -164,7 +122,6 @@ describe("groupSequentialReadFileBlocks", () => {
 		expect(result).toEqual([
 			{
 				type: "tool-group",
-				toolName: "read_file",
 				ids: ["read-1", "read-2"],
 			},
 		]);
@@ -179,54 +136,34 @@ describe("groupSequentialReadFileBlocks", () => {
 		expect(result).toEqual([{ type: "tool", id: "read-1" }]);
 	});
 
-	it("does not collapse read_file blocks across other content", () => {
-		const result = groupSequentialReadFileBlocks(
+	it.each([
+		[
+			"response content",
 			[
 				{ type: "tool", id: "read-1" },
 				{ type: "response", text: "middle" },
 				{ type: "tool", id: "read-2" },
 			],
-			tools,
-		);
-
-		expect(result).toEqual([
-			{ type: "tool", id: "read-1" },
-			{ type: "response", text: "middle" },
-			{ type: "tool", id: "read-2" },
-		]);
-	});
-
-	it("does not collapse read_file blocks across another tool", () => {
-		const result = groupSequentialReadFileBlocks(
+		],
+		[
+			"another tool",
 			[
 				{ type: "tool", id: "read-1" },
 				{ type: "tool", id: "execute-1" },
 				{ type: "tool", id: "read-2" },
 			],
-			tools,
-		);
-
-		expect(result).toEqual([
-			{ type: "tool", id: "read-1" },
-			{ type: "tool", id: "execute-1" },
-			{ type: "tool", id: "read-2" },
-		]);
-	});
-
-	it("keeps unresolved tool blocks ungrouped", () => {
-		const result = groupSequentialReadFileBlocks(
+		],
+		[
+			"an unresolved tool",
 			[
 				{ type: "tool", id: "read-1" },
 				{ type: "tool", id: "missing" },
 				{ type: "tool", id: "read-2" },
 			],
-			tools,
-		);
-
-		expect(result).toEqual([
-			{ type: "tool", id: "read-1" },
-			{ type: "tool", id: "missing" },
-			{ type: "tool", id: "read-2" },
-		]);
+		],
+	] satisfies Array<
+		[string, RenderBlock[]]
+	>)("does not collapse read_file blocks across %s", (_, blocks) => {
+		expect(groupSequentialReadFileBlocks(blocks, tools)).toEqual(blocks);
 	});
 });

--- a/site/src/pages/AgentsPage/components/ChatConversation/blockUtils.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/blockUtils.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { appendTextBlock, asNonEmptyString } from "./blockUtils";
-import type { RenderBlock } from "./types";
+import {
+	appendTextBlock,
+	asNonEmptyString,
+	groupSequentialReadFileBlocks,
+} from "./blockUtils";
+import type { MergedTool, RenderBlock } from "./types";
 
 // ---------------------------------------------------------------------------
 // asNonEmptyString
@@ -94,5 +98,112 @@ describe("appendTextBlock", () => {
 		expect(blocks).toHaveLength(1);
 		expect((blocks[0] as { text: string }).text).toBe("original");
 		expect(result).not.toBe(blocks);
+	});
+});
+
+describe("groupSequentialReadFileBlocks", () => {
+	const tools: MergedTool[] = [
+		{
+			id: "read-1",
+			name: "read_file",
+			args: { path: "a.ts" },
+			result: { content: "a" },
+			isError: false,
+			status: "completed",
+		},
+		{
+			id: "read-2",
+			name: "read_file",
+			args: { path: "b.ts" },
+			result: { content: "b" },
+			isError: false,
+			status: "completed",
+		},
+		{
+			id: "execute-1",
+			name: "execute",
+			args: { command: "pwd" },
+			result: { output: "/home/coder" },
+			isError: false,
+			status: "completed",
+		},
+	];
+
+	it("collapses consecutive read_file tool blocks", () => {
+		const result = groupSequentialReadFileBlocks(
+			[
+				{ type: "tool", id: "read-1" },
+				{ type: "tool", id: "read-2" },
+			],
+			tools,
+		);
+
+		expect(result).toEqual([
+			{
+				type: "tool-group",
+				toolName: "read_file",
+				ids: ["read-1", "read-2"],
+			},
+		]);
+	});
+
+	it("leaves a single read_file tool block ungrouped", () => {
+		const result = groupSequentialReadFileBlocks(
+			[{ type: "tool", id: "read-1" }],
+			tools,
+		);
+
+		expect(result).toEqual([{ type: "tool", id: "read-1" }]);
+	});
+
+	it("does not collapse read_file blocks across other content", () => {
+		const result = groupSequentialReadFileBlocks(
+			[
+				{ type: "tool", id: "read-1" },
+				{ type: "response", text: "middle" },
+				{ type: "tool", id: "read-2" },
+			],
+			tools,
+		);
+
+		expect(result).toEqual([
+			{ type: "tool", id: "read-1" },
+			{ type: "response", text: "middle" },
+			{ type: "tool", id: "read-2" },
+		]);
+	});
+
+	it("does not collapse read_file blocks across another tool", () => {
+		const result = groupSequentialReadFileBlocks(
+			[
+				{ type: "tool", id: "read-1" },
+				{ type: "tool", id: "execute-1" },
+				{ type: "tool", id: "read-2" },
+			],
+			tools,
+		);
+
+		expect(result).toEqual([
+			{ type: "tool", id: "read-1" },
+			{ type: "tool", id: "execute-1" },
+			{ type: "tool", id: "read-2" },
+		]);
+	});
+
+	it("keeps unresolved tool blocks ungrouped", () => {
+		const result = groupSequentialReadFileBlocks(
+			[
+				{ type: "tool", id: "read-1" },
+				{ type: "tool", id: "missing" },
+				{ type: "tool", id: "read-2" },
+			],
+			tools,
+		);
+
+		expect(result).toEqual([
+			{ type: "tool", id: "read-1" },
+			{ type: "tool", id: "missing" },
+			{ type: "tool", id: "read-2" },
+		]);
 	});
 });

--- a/site/src/pages/AgentsPage/components/ChatConversation/blockUtils.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/blockUtils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
 	appendTextBlock,
 	asNonEmptyString,
+	getToolIDsForBlock,
 	groupSequentialReadFileBlocks,
 } from "./blockUtils";
 import type { MergedTool, RenderBlock } from "./types";
@@ -98,6 +99,28 @@ describe("appendTextBlock", () => {
 		expect(blocks).toHaveLength(1);
 		expect((blocks[0] as { text: string }).text).toBe("original");
 		expect(result).not.toBe(blocks);
+	});
+});
+
+describe("getToolIDsForBlock", () => {
+	it("returns the tool ID for tool blocks", () => {
+		expect(getToolIDsForBlock({ type: "tool", id: "read-1" })).toEqual([
+			"read-1",
+		]);
+	});
+
+	it("returns all tool IDs for tool-group blocks", () => {
+		expect(
+			getToolIDsForBlock({
+				type: "tool-group",
+				toolName: "read_file",
+				ids: ["read-1", "read-2"],
+			}),
+		).toEqual(["read-1", "read-2"]);
+	});
+
+	it("returns an empty list for non-tool blocks", () => {
+		expect(getToolIDsForBlock({ type: "response", text: "hello" })).toEqual([]);
 	});
 });
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/blockUtils.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/blockUtils.ts
@@ -67,7 +67,7 @@ export const groupSequentialReadFileBlocks = (
 		if (block.type === "tool") {
 			const tool = toolByID.get(block.id);
 			if (tool?.name === "read_file") {
-				currentReadFileIDs = [...currentReadFileIDs, block.id];
+				currentReadFileIDs.push(block.id);
 				continue;
 			}
 		}

--- a/site/src/pages/AgentsPage/components/ChatConversation/blockUtils.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/blockUtils.ts
@@ -33,7 +33,6 @@ export const appendTextBlock = (
 
 type ToolGroupRenderBlock = {
 	type: "tool-group";
-	toolName: "read_file";
 	ids: string[];
 };
 
@@ -56,7 +55,6 @@ export const groupSequentialReadFileBlocks = (
 		} else {
 			grouped.push({
 				type: "tool-group",
-				toolName: "read_file",
 				ids: currentReadFileIDs,
 			});
 		}
@@ -78,16 +76,4 @@ export const groupSequentialReadFileBlocks = (
 
 	flushReadFileIDs();
 	return grouped;
-};
-
-export const getToolIDsForBlock = (
-	block: TimelineRenderBlock,
-): readonly string[] => {
-	if (block.type === "tool") {
-		return [block.id];
-	}
-	if (block.type === "tool-group") {
-		return block.ids;
-	}
-	return [];
 };

--- a/site/src/pages/AgentsPage/components/ChatConversation/blockUtils.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/blockUtils.ts
@@ -1,5 +1,5 @@
 import { asString } from "../ChatElements/runtimeTypeUtils";
-import type { RenderBlock } from "./types";
+import type { MergedTool, RenderBlock } from "./types";
 
 export const asNonEmptyString = (value: unknown): string | undefined => {
 	const next = asString(value).trim();
@@ -29,4 +29,65 @@ export const appendTextBlock = (
 	}
 	nextBlocks.push({ type, text });
 	return nextBlocks;
+};
+
+type ToolGroupRenderBlock = {
+	type: "tool-group";
+	toolName: "read_file";
+	ids: string[];
+};
+
+type TimelineRenderBlock = RenderBlock | ToolGroupRenderBlock;
+
+export const groupSequentialReadFileBlocks = (
+	blocks: readonly RenderBlock[],
+	tools: readonly MergedTool[],
+): TimelineRenderBlock[] => {
+	const toolByID = new Map(tools.map((tool) => [tool.id, tool]));
+	const grouped: TimelineRenderBlock[] = [];
+	let currentReadFileIDs: string[] = [];
+
+	const flushReadFileIDs = () => {
+		if (currentReadFileIDs.length === 0) {
+			return;
+		}
+		if (currentReadFileIDs.length === 1) {
+			grouped.push({ type: "tool", id: currentReadFileIDs[0] });
+		} else {
+			grouped.push({
+				type: "tool-group",
+				toolName: "read_file",
+				ids: currentReadFileIDs,
+			});
+		}
+		currentReadFileIDs = [];
+	};
+
+	for (const block of blocks) {
+		if (block.type === "tool") {
+			const tool = toolByID.get(block.id);
+			if (tool?.name === "read_file") {
+				currentReadFileIDs = [...currentReadFileIDs, block.id];
+				continue;
+			}
+		}
+
+		flushReadFileIDs();
+		grouped.push(block);
+	}
+
+	flushReadFileIDs();
+	return grouped;
+};
+
+export const getToolIDsForBlock = (
+	block: TimelineRenderBlock,
+): readonly string[] => {
+	if (block.type === "tool") {
+		return [block.id];
+	}
+	if (block.type === "tool-group") {
+		return block.ids;
+	}
+	return [];
 };

--- a/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.test.ts
@@ -133,16 +133,18 @@ const textMessage = (
 	});
 
 const executeMessage = (messageID: number): ParsedMessageEntry => {
+	const args = { command: "pnpm test" };
 	const tool: MergedTool = {
 		id: "execute-1",
 		name: "execute",
+		args,
 		isError: false,
 		status: "completed",
 	};
 	return entry({
 		messageID,
 		parsedOverrides: {
-			toolCalls: [{ id: tool.id, name: tool.name }],
+			toolCalls: [{ id: tool.id, name: tool.name, args }],
 			tools: [tool],
 			blocks: [{ type: "tool", id: tool.id }],
 		},
@@ -272,7 +274,22 @@ describe("deriveMessageDisplayState", () => {
 			"assistant",
 		);
 
-		expect(getDisplayState(message).shouldHide).toBe(false);
+		expect(
+			getDisplayState(message, {
+				parsed: parsed({
+					tools: [
+						{
+							id: "tool-1",
+							name: "execute",
+							args: { command: "pnpm test" },
+							isError: false,
+							status: "completed",
+						},
+					],
+					blocks: [{ type: "tool", id: "tool-1" }],
+				}),
+			}).shouldHide,
+		).toBe(false);
 	});
 
 	it("hides running wait_agent messages until the chat id is available", () => {

--- a/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.test.ts
@@ -1,13 +1,20 @@
 import { describe, expect, it } from "vitest";
-import type { ChatMessage, ChatMessagePart } from "#/api/typesGenerated";
-import { deriveMessageDisplayState } from "./messageHelpers";
-import { parseMessagesWithMergedTools } from "./messageParsing";
-import type { ParsedMessageContent } from "./types";
+import type * as TypesGen from "#/api/typesGenerated";
+import {
+	deriveMessageDisplayState,
+	groupSequentialReadFileMessages,
+} from "./messageHelpers";
+import { parseMessageContent } from "./messageParsing";
+import type {
+	MergedTool,
+	ParsedMessageContent,
+	ParsedMessageEntry,
+} from "./types";
 
 const buildMessage = (
-	content: ChatMessagePart[],
+	content: TypesGen.ChatMessagePart[],
 	role: "user" | "assistant" = "user",
-): ChatMessage => ({
+): TypesGen.ChatMessage => ({
 	id: 1,
 	chat_id: "chat-1",
 	created_at: "2026-05-11T00:00:00.000Z",
@@ -15,20 +22,132 @@ const buildMessage = (
 	content,
 });
 
-const getParsedMessage = (message: ChatMessage) =>
-	parseMessagesWithMergedTools([message])[0].parsed;
-
 const getDisplayState = (
-	message: ChatMessage,
+	message: TypesGen.ChatMessage,
 	overrides: Partial<Parameters<typeof deriveMessageDisplayState>[0]> = {},
 ) =>
 	deriveMessageDisplayState({
 		message,
-		parsed: getParsedMessage(message),
+		parsed: parseMessageContent(message.content),
 		hideActions: false,
 		hasActiveStream: false,
 		...overrides,
 	});
+
+const baseMessage = {
+	chat_id: "chat",
+	created_at: "2026-03-10T00:00:00.000Z",
+} as const;
+
+const parsed = (
+	overrides: Partial<ParsedMessageContent> = {},
+): ParsedMessageContent => ({
+	markdown: "",
+	reasoning: "",
+	toolCalls: [],
+	toolResults: [],
+	tools: [],
+	blocks: [],
+	sources: [],
+	...overrides,
+});
+
+const entry = ({
+	messageID,
+	role = "assistant",
+	content = [],
+	parsedOverrides,
+}: {
+	messageID: number;
+	role?: TypesGen.ChatMessageRole;
+	content?: TypesGen.ChatMessagePart[];
+	parsedOverrides: Partial<ParsedMessageContent>;
+}): ParsedMessageEntry => ({
+	message: { ...baseMessage, id: messageID, role, content },
+	parsed: parsed(parsedOverrides),
+});
+
+const readFileArgs = (id: string) => ({ path: `${id}.ts` });
+
+const readFileTool = (id: string): MergedTool => ({
+	id,
+	name: "read_file",
+	args: readFileArgs(id),
+	result: { content: id },
+	isError: false,
+	status: "completed",
+});
+
+const readFileToolResult = (id: string) => ({
+	id,
+	name: "read_file" as const,
+	result: { content: id },
+	isError: false,
+});
+
+const readFileMessage = (
+	messageID: number,
+	toolID: string,
+	parsedOverrides: Partial<ParsedMessageContent> = {},
+): ParsedMessageEntry => {
+	const args = readFileArgs(toolID);
+	return entry({
+		messageID,
+		parsedOverrides: {
+			toolCalls: [{ id: toolID, name: "read_file", args }],
+			toolResults: [readFileToolResult(toolID)],
+			tools: [readFileTool(toolID)],
+			blocks: [{ type: "tool", id: toolID }],
+			...parsedOverrides,
+		},
+	});
+};
+
+const hiddenToolResultMessage = (
+	messageID: number,
+	toolID: string,
+): ParsedMessageEntry =>
+	entry({
+		messageID,
+		role: "tool",
+		parsedOverrides: {
+			toolResults: [readFileToolResult(toolID)],
+			tools: [readFileTool(toolID)],
+			blocks: [{ type: "tool", id: toolID }],
+		},
+	});
+
+const textMessage = (
+	messageID: number,
+	text: string,
+	role: TypesGen.ChatMessageRole = "assistant",
+): ParsedMessageEntry =>
+	entry({
+		messageID,
+		role,
+		content: [{ type: "text", text }],
+		parsedOverrides: {
+			markdown: text,
+			blocks: [{ type: "response", text }],
+		},
+	});
+
+const executeMessage = (messageID: number): ParsedMessageEntry => {
+	const tool: MergedTool = {
+		id: "execute-1",
+		name: "execute",
+		isError: false,
+		status: "completed",
+	};
+	return entry({
+		messageID,
+		parsedOverrides: {
+			toolCalls: [{ id: tool.id, name: tool.name }],
+			tools: [tool],
+			blocks: [{ type: "tool", id: tool.id }],
+		},
+	});
+};
 
 describe("deriveMessageDisplayState", () => {
 	it("marks text-only user messages as copyable", () => {
@@ -67,43 +186,9 @@ describe("deriveMessageDisplayState", () => {
 		expect(getDisplayState(message).hasCopyableContent).toBe(false);
 	});
 
-	it("shows the assistant spacer for thinking-only messages when no suppressing flags apply", () => {
+	it("shows the assistant spacer for reasoning messages when no suppressing flags apply", () => {
 		const message = buildMessage(
 			[{ type: "reasoning", text: "I should think before answering." }],
-			"assistant",
-		);
-
-		expect(getDisplayState(message).needsAssistantBottomSpacer).toBe(true);
-	});
-
-	it("hides the assistant spacer when thinking is followed by a tool call", () => {
-		const message = buildMessage(
-			[
-				{ type: "reasoning", text: "I should think before acting." },
-				{
-					type: "tool-call",
-					tool_call_id: "tool-1",
-					tool_name: "execute",
-					args: { command: "pnpm storybook --no-open" },
-				},
-			],
-			"assistant",
-		);
-
-		expect(getDisplayState(message).needsAssistantBottomSpacer).toBe(false);
-	});
-
-	it("shows the assistant spacer when thinking is followed by a hidden execute tool", () => {
-		const message = buildMessage(
-			[
-				{ type: "reasoning", text: "I should think before acting." },
-				{
-					type: "tool-call",
-					tool_call_id: "tool-1",
-					tool_name: "execute",
-					args: {},
-				},
-			],
 			"assistant",
 		);
 
@@ -192,8 +277,8 @@ describe("deriveMessageDisplayState", () => {
 
 	it("hides running wait_agent messages until the chat id is available", () => {
 		const message = buildMessage([], "assistant");
-		const parsed: ParsedMessageContent = {
-			...getParsedMessage(message),
+		const parsedContent: ParsedMessageContent = {
+			...parseMessageContent(message.content),
 			blocks: [{ type: "tool", id: "wait-1" }],
 			tools: [
 				{
@@ -209,10 +294,99 @@ describe("deriveMessageDisplayState", () => {
 		expect(
 			deriveMessageDisplayState({
 				message,
-				parsed,
+				parsed: parsedContent,
 				hideActions: false,
 				hasActiveStream: false,
 			}).shouldHide,
 		).toBe(true);
+	});
+});
+
+describe("groupSequentialReadFileMessages", () => {
+	it("returns a single read_file-only message unchanged", () => {
+		const readFile = readFileMessage(1, "read-1");
+
+		const result = groupSequentialReadFileMessages([readFile]);
+
+		expect(result).toHaveLength(1);
+		expect(result[0]).toBe(readFile);
+	});
+
+	it("collapses read_file-only assistant messages across hidden tool results", () => {
+		const result = groupSequentialReadFileMessages([
+			readFileMessage(1, "read-1"),
+			hiddenToolResultMessage(2, "read-1"),
+			readFileMessage(3, "read-2"),
+			hiddenToolResultMessage(4, "read-2"),
+		]);
+
+		expect(result).toHaveLength(1);
+		expect(result[0].message.id).toBe(1);
+		expect(result[0].parsed.toolCalls).toEqual([
+			{ id: "read-1", name: "read_file", args: { path: "read-1.ts" } },
+			{ id: "read-2", name: "read_file", args: { path: "read-2.ts" } },
+		]);
+		expect(result[0].parsed.toolResults).toEqual([
+			readFileToolResult("read-1"),
+			readFileToolResult("read-2"),
+		]);
+		expect(result[0].parsed.blocks).toEqual([
+			{ type: "tool", id: "read-1" },
+			{ type: "tool", id: "read-2" },
+		]);
+		expect(result[0].parsed.tools.map((tool) => tool.id)).toEqual([
+			"read-1",
+			"read-2",
+		]);
+	});
+
+	it.each([
+		["assistant", textMessage(2, "middle")],
+		["user", textMessage(2, "middle", "user")],
+	] satisfies Array<
+		[string, ParsedMessageEntry]
+	>)("does not collapse read_file messages across visible %s content", (_, message) => {
+		const result = groupSequentialReadFileMessages([
+			readFileMessage(1, "read-1"),
+			message,
+			readFileMessage(3, "read-2"),
+		]);
+
+		expect(result.map((entry) => entry.message.id)).toEqual([1, 2, 3]);
+		expect(result[0].parsed.blocks).toEqual([{ type: "tool", id: "read-1" }]);
+		expect(result[2].parsed.blocks).toEqual([{ type: "tool", id: "read-2" }]);
+	});
+
+	it.each([
+		["markdown", { markdown: "Visible markdown" }],
+		["reasoning", { reasoning: "Visible reasoning" }],
+		[
+			"sources",
+			{
+				sources: [
+					{ url: "https://example.com/read-2", title: "Read 2 source" },
+				],
+			},
+		],
+	] satisfies Array<
+		[string, Partial<ParsedMessageContent>]
+	>)("does not collapse read_file messages with visible %s", (_, overrides) => {
+		const result = groupSequentialReadFileMessages([
+			readFileMessage(1, "read-1"),
+			readFileMessage(2, "read-2", overrides),
+			readFileMessage(3, "read-3"),
+		]);
+
+		expect(result.map((entry) => entry.message.id)).toEqual([1, 2, 3]);
+	});
+
+	it("does not collapse read_file messages across another visible tool", () => {
+		const result = groupSequentialReadFileMessages([
+			readFileMessage(1, "read-1"),
+			executeMessage(2),
+			readFileMessage(3, "read-2"),
+		]);
+
+		expect(result.map((entry) => entry.message.id)).toEqual([1, 2, 3]);
 	});
 });

--- a/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.ts
@@ -166,6 +166,12 @@ const mergeReadFileMessageGroup = (
 	};
 };
 
+// Real transcripts place hidden tool-result-only messages between
+// sequential read_file assistant messages. Those hidden entries stay
+// transparent so the visible timeline reflects one file-reading run instead
+// of one row per persisted message. Synthetic grouped entries deliberately
+// render from merged parsed fields because their raw message payload still
+// belongs to the first persisted message.
 export const groupSequentialReadFileMessages = (
 	entries: readonly ParsedMessageEntry[],
 ): ParsedMessageEntry[] => {
@@ -191,7 +197,7 @@ export const groupSequentialReadFileMessages = (
 			continue;
 		}
 		if (isReadFileOnlyMessage(entry)) {
-			currentReadFileEntries = [...currentReadFileEntries, entry];
+			currentReadFileEntries.push(entry);
 			continue;
 		}
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.ts
@@ -1,6 +1,10 @@
 import type * as TypesGen from "#/api/typesGenerated";
 import { shouldRenderTool } from "../ChatElements/tools/toolVisibility";
-import type { ParsedMessageContent, RenderBlock } from "./types";
+import type {
+	ParsedMessageContent,
+	ParsedMessageEntry,
+	RenderBlock,
+} from "./types";
 
 export type UserInlineRenderBlock =
 	| Extract<RenderBlock, { type: "response" }>
@@ -118,4 +122,83 @@ export const deriveMessageDisplayState = ({
 		hasCopyableContent,
 		needsAssistantBottomSpacer,
 	};
+};
+
+const isReadFileOnlyMessage = (entry: ParsedMessageEntry): boolean => {
+	if (entry.message.role !== "assistant") {
+		return false;
+	}
+	if (
+		entry.parsed.blocks.length === 0 ||
+		entry.parsed.markdown.trim() ||
+		entry.parsed.reasoning.trim() ||
+		entry.parsed.sources.length > 0
+	) {
+		return false;
+	}
+
+	const toolByID = new Map(entry.parsed.tools.map((tool) => [tool.id, tool]));
+	return entry.parsed.blocks.every(
+		(block) =>
+			block.type === "tool" && toolByID.get(block.id)?.name === "read_file",
+	);
+};
+
+const mergeReadFileMessageGroup = (
+	group: readonly ParsedMessageEntry[],
+): ParsedMessageEntry => {
+	if (group.length === 1) {
+		return group[0];
+	}
+
+	const [first] = group;
+	return {
+		message: first.message,
+		parsed: {
+			markdown: "",
+			reasoning: "",
+			toolCalls: group.flatMap((entry) => entry.parsed.toolCalls),
+			toolResults: group.flatMap((entry) => entry.parsed.toolResults),
+			tools: group.flatMap((entry) => entry.parsed.tools),
+			blocks: group.flatMap((entry) => entry.parsed.blocks),
+			sources: [],
+		},
+	};
+};
+
+export const groupSequentialReadFileMessages = (
+	entries: readonly ParsedMessageEntry[],
+): ParsedMessageEntry[] => {
+	const grouped: ParsedMessageEntry[] = [];
+	let currentReadFileEntries: ParsedMessageEntry[] = [];
+
+	const flushReadFileEntries = () => {
+		if (currentReadFileEntries.length === 0) {
+			return;
+		}
+		grouped.push(mergeReadFileMessageGroup(currentReadFileEntries));
+		currentReadFileEntries = [];
+	};
+
+	for (const entry of entries) {
+		const displayState = deriveMessageDisplayState({
+			message: entry.message,
+			parsed: entry.parsed,
+			hideActions: false,
+			hasActiveStream: false,
+		});
+		if (displayState.shouldHide) {
+			continue;
+		}
+		if (isReadFileOnlyMessage(entry)) {
+			currentReadFileEntries = [...currentReadFileEntries, entry];
+			continue;
+		}
+
+		flushReadFileEntries();
+		grouped.push(entry);
+	}
+
+	flushReadFileEntries();
+	return grouped;
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ReadFileTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ReadFileTool.tsx
@@ -17,7 +17,7 @@ import {
 	type ToolStatus,
 } from "./utils";
 
-export const ReadFileContent: React.FC<{
+const ReadFileContent: React.FC<{
 	path: string;
 	content: string;
 }> = ({ path, content }) => {
@@ -83,7 +83,7 @@ export const ReadFileTool: React.FC<{
 	expanded,
 	onExpandedChange,
 }) => {
-	const hasContent = content.length > 0;
+	const hasContent = content.length > 0 || isError;
 	const isRunning = status === "running";
 	const filename = path.split("/").pop() || path;
 	const label = isRunning ? `Reading ${filename}…` : `Read ${filename}`;
@@ -113,7 +113,12 @@ export const ReadFileTool: React.FC<{
 				</>
 			}
 		>
-			<ReadFileContent path={path} content={content} />
+			{isError && (
+				<div className="mt-1 text-xs text-content-destructive">
+					{errorMessage || "Failed to read file"}
+				</div>
+			)}
+			{content.length > 0 && <ReadFileContent path={path} content={content} />}
 		</ToolCollapsible>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ReadFileTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ReadFileTool.tsx
@@ -50,7 +50,17 @@ export const ReadFileTool: React.FC<{
 	status: ToolStatus;
 	isError: boolean;
 	errorMessage?: string;
-}> = ({ path, content, status, isError, errorMessage }) => {
+	expanded?: boolean;
+	onExpandedChange?: (expanded: boolean) => void;
+}> = ({
+	path,
+	content,
+	status,
+	isError,
+	errorMessage,
+	expanded,
+	onExpandedChange,
+}) => {
 	const hasContent = content.length > 0;
 	const isRunning = status === "running";
 	const filename = path.split("/").pop() || path;
@@ -60,6 +70,8 @@ export const ReadFileTool: React.FC<{
 		<ToolCollapsible
 			className="w-full"
 			hasContent={hasContent}
+			expanded={expanded}
+			onExpandedChange={onExpandedChange}
 			header={
 				<>
 					<span className="text-[13px]">{label}</span>

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ReadFileTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ReadFileTool.tsx
@@ -8,10 +8,12 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
+import { asRecord, asString } from "../runtimeTypeUtils";
 import { ToolCollapsible } from "./ToolCollapsible";
 import {
 	DIFFS_FONT_STYLE,
 	getFileViewerOptionsMinimal,
+	parseArgs,
 	type ToolStatus,
 } from "./utils";
 
@@ -38,6 +40,26 @@ export const ReadFileContent: React.FC<{
 			/>
 		</ScrollArea>
 	);
+};
+
+export const getReadFileToolData = ({
+	args,
+	result,
+	isError,
+}: {
+	args?: unknown;
+	result?: unknown;
+	isError: boolean;
+}) => {
+	const parsedArgs = parseArgs(args);
+	const path = parsedArgs ? asString(parsedArgs.path).trim() : "";
+	const rec = asRecord(result);
+	return {
+		path: path || "file",
+		content: rec ? asString(rec.content).trim() : "",
+		isError,
+		errorMessage: rec ? asString(rec.error || rec.message) : undefined,
+	};
 };
 
 /**

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ReadFileTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ReadFileTool.tsx
@@ -15,6 +15,31 @@ import {
 	type ToolStatus,
 } from "./utils";
 
+export const ReadFileContent: React.FC<{
+	path: string;
+	content: string;
+}> = ({ path, content }) => {
+	const theme = useTheme();
+	const isDark = theme.palette.mode === "dark";
+
+	return (
+		<ScrollArea
+			className="mt-1.5 rounded-md border border-solid border-border-default text-2xs"
+			viewportClassName="max-h-64"
+			scrollBarClassName="w-1.5"
+		>
+			<FileViewer
+				file={{
+					name: path,
+					contents: content,
+				}}
+				options={getFileViewerOptionsMinimal(isDark)}
+				style={DIFFS_FONT_STYLE}
+			/>
+		</ScrollArea>
+	);
+};
+
 /**
  * Collapsed-by-default rendering for `read_file` tool calls. Shows
  * "Read <filename>" with a chevron; expanding reveals the file viewer.
@@ -26,8 +51,6 @@ export const ReadFileTool: React.FC<{
 	isError: boolean;
 	errorMessage?: string;
 }> = ({ path, content, status, isError, errorMessage }) => {
-	const theme = useTheme();
-	const isDark = theme.palette.mode === "dark";
 	const hasContent = content.length > 0;
 	const isRunning = status === "running";
 	const filename = path.split("/").pop() || path;
@@ -56,20 +79,7 @@ export const ReadFileTool: React.FC<{
 				</>
 			}
 		>
-			<ScrollArea
-				className="mt-1.5 rounded-md border border-solid border-border-default text-2xs"
-				viewportClassName="max-h-64"
-				scrollBarClassName="w-1.5"
-			>
-				<FileViewer
-					file={{
-						name: path,
-						contents: content,
-					}}
-					options={getFileViewerOptionsMinimal(isDark)}
-					style={DIFFS_FONT_STYLE}
-				/>
-			</ScrollArea>
+			<ReadFileContent path={path} content={content} />
 		</ToolCollapsible>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ReadFilesTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ReadFilesTool.tsx
@@ -42,10 +42,7 @@ export const ReadFilesTool: FC<{
 	const errorMessage = items.find((item) => item.errorMessage)?.errorMessage;
 
 	return (
-		<div
-			data-tool-call=""
-			className="py-0.5 [&:has(+[data-tool-call])]:pb-0 [[data-tool-call]+&]:pt-0"
-		>
+		<div data-tool-call="">
 			<ToolCollapsible
 				className="w-full"
 				hasContent={hasContent}
@@ -70,9 +67,9 @@ export const ReadFilesTool: FC<{
 					</>
 				}
 			>
-				<div className="space-y-1 pl-3">
+				<div className="space-y-1 py-0.5 pl-3">
 					{items.map((item) => (
-						<div key={item.id} className="min-h-6">
+						<div key={item.id}>
 							<ReadFileTool
 								path={item.path}
 								content={item.content}

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ReadFilesTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ReadFilesTool.tsx
@@ -70,28 +70,29 @@ export const ReadFilesTool: FC<{
 					</>
 				}
 			>
-				<div className="mt-2 space-y-1 pl-3">
+				<div className="space-y-1 pl-3">
 					{items.map((item) => (
-						<ReadFileTool
-							key={item.id}
-							path={item.path}
-							content={item.content}
-							status={item.status}
-							isError={item.isError}
-							errorMessage={item.errorMessage}
-							expanded={expandedFileIDs.has(item.id)}
-							onExpandedChange={(nextExpanded) => {
-								setExpandedFileIDs((previous) => {
-									const next = new Set(previous);
-									if (nextExpanded) {
-										next.add(item.id);
-									} else {
-										next.delete(item.id);
-									}
-									return next;
-								});
-							}}
-						/>
+						<div key={item.id} className="min-h-6">
+							<ReadFileTool
+								path={item.path}
+								content={item.content}
+								status={item.status}
+								isError={item.isError}
+								errorMessage={item.errorMessage}
+								expanded={expandedFileIDs.has(item.id)}
+								onExpandedChange={(nextExpanded) => {
+									setExpandedFileIDs((previous) => {
+										const next = new Set(previous);
+										if (nextExpanded) {
+											next.add(item.id);
+										} else {
+											next.delete(item.id);
+										}
+										return next;
+									});
+								}}
+							/>
+						</div>
 					))}
 				</div>
 			</ToolCollapsible>

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ReadFilesTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ReadFilesTool.tsx
@@ -1,0 +1,94 @@
+import { LoaderIcon, TriangleAlertIcon } from "lucide-react";
+import type React from "react";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "#/components/Tooltip/Tooltip";
+import type { MergedTool } from "../../ChatConversation/types";
+import { asRecord, asString } from "../runtimeTypeUtils";
+import { ReadFileContent } from "./ReadFileTool";
+import { ToolCollapsible } from "./ToolCollapsible";
+import { parseArgs } from "./utils";
+
+type ReadFileItem = {
+	id: string;
+	path: string;
+	content: string;
+	isError: boolean;
+	errorMessage?: string;
+};
+
+const getReadFileItem = (tool: MergedTool): ReadFileItem => {
+	const parsedArgs = parseArgs(tool.args);
+	const path = parsedArgs ? asString(parsedArgs.path).trim() : "";
+	const rec = asRecord(tool.result);
+	return {
+		id: tool.id,
+		path: path || "file",
+		content: rec ? asString(rec.content).trim() : "",
+		isError: tool.isError,
+		errorMessage: rec ? asString(rec.error || rec.message) : undefined,
+	};
+};
+
+export const ReadFilesTool: React.FC<{
+	tools: readonly MergedTool[];
+}> = ({ tools }) => {
+	const items = tools.map(getReadFileItem);
+	const isRunning = tools.some((tool) => tool.status === "running");
+	const isError = tools.some((tool) => tool.isError);
+	const hasContent = items.some((item) => item.content.length > 0);
+	const label = isRunning
+		? `Reading ${tools.length} files…`
+		: `Read ${tools.length} files`;
+	const errorMessage = items.find((item) => item.errorMessage)?.errorMessage;
+
+	return (
+		<div
+			data-tool-call=""
+			className="py-0.5 [&:has(+[data-tool-call])]:pb-0 [[data-tool-call]+&]:pt-0"
+		>
+			<ToolCollapsible
+				className="w-full"
+				hasContent={hasContent}
+				header={
+					<>
+						<span className="text-[13px]">{label}</span>
+						{isError && (
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<TriangleAlertIcon className="h-3.5 w-3.5 shrink-0 text-current" />
+								</TooltipTrigger>
+								<TooltipContent>
+									{errorMessage || "Failed to read one or more files"}
+								</TooltipContent>
+							</Tooltip>
+						)}
+						{isRunning && (
+							<LoaderIcon className="h-3.5 w-3.5 shrink-0 animate-spin motion-reduce:animate-none text-current" />
+						)}
+					</>
+				}
+			>
+				<div className="space-y-3">
+					{items.map((item) => (
+						<section key={item.id} className="min-w-0">
+							<div className="mt-2 truncate text-xs text-content-secondary">
+								{item.path}
+							</div>
+							{item.isError && (
+								<div className="mt-1 text-xs text-content-destructive">
+									{item.errorMessage || "Failed to read file"}
+								</div>
+							)}
+							{item.content.length > 0 && (
+								<ReadFileContent path={item.path} content={item.content} />
+							)}
+						</section>
+					))}
+				</div>
+			</ToolCollapsible>
+		</div>
+	);
+};

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ReadFilesTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ReadFilesTool.tsx
@@ -1,32 +1,37 @@
 import { LoaderIcon, TriangleAlertIcon } from "lucide-react";
-import type React from "react";
+import { type FC, useState } from "react";
 import {
 	Tooltip,
 	TooltipContent,
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
 import type { MergedTool } from "../../ChatConversation/types";
-import { getReadFileToolData, ReadFileContent } from "./ReadFileTool";
+import { getReadFileToolData, ReadFileTool } from "./ReadFileTool";
 import { ToolCollapsible } from "./ToolCollapsible";
 
 type ReadFileItem = {
 	id: string;
 	path: string;
 	content: string;
+	status: MergedTool["status"];
 	isError: boolean;
 	errorMessage?: string;
 };
 
 const getReadFileItem = (tool: MergedTool): ReadFileItem => ({
 	id: tool.id,
+	status: tool.status,
 	...getReadFileToolData(tool),
 });
 
-export const ReadFilesTool: React.FC<{
+export const ReadFilesTool: FC<{
 	tools: readonly MergedTool[];
 	expanded?: boolean;
 	onExpandedChange?: (expanded: boolean) => void;
 }> = ({ tools, expanded, onExpandedChange }) => {
+	const [expandedFileIDs, setExpandedFileIDs] = useState<ReadonlySet<string>>(
+		new Set(),
+	);
 	const items = tools.map(getReadFileItem);
 	const isRunning = tools.some((tool) => tool.status === "running");
 	const isError = tools.some((tool) => tool.isError);
@@ -65,21 +70,28 @@ export const ReadFilesTool: React.FC<{
 					</>
 				}
 			>
-				<div className="space-y-3">
+				<div className="mt-2 space-y-1 pl-3">
 					{items.map((item) => (
-						<section key={item.id} className="min-w-0">
-							<div className="mt-2 truncate text-xs text-content-secondary">
-								{item.path}
-							</div>
-							{item.isError && (
-								<div className="mt-1 text-xs text-content-destructive">
-									{item.errorMessage || "Failed to read file"}
-								</div>
-							)}
-							{item.content.length > 0 && (
-								<ReadFileContent path={item.path} content={item.content} />
-							)}
-						</section>
+						<ReadFileTool
+							key={item.id}
+							path={item.path}
+							content={item.content}
+							status={item.status}
+							isError={item.isError}
+							errorMessage={item.errorMessage}
+							expanded={expandedFileIDs.has(item.id)}
+							onExpandedChange={(nextExpanded) => {
+								setExpandedFileIDs((previous) => {
+									const next = new Set(previous);
+									if (nextExpanded) {
+										next.add(item.id);
+									} else {
+										next.delete(item.id);
+									}
+									return next;
+								});
+							}}
+						/>
 					))}
 				</div>
 			</ToolCollapsible>

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ReadFilesTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ReadFilesTool.tsx
@@ -34,11 +34,15 @@ const getReadFileItem = (tool: MergedTool): ReadFileItem => {
 
 export const ReadFilesTool: React.FC<{
 	tools: readonly MergedTool[];
-}> = ({ tools }) => {
+	expanded?: boolean;
+	onExpandedChange?: (expanded: boolean) => void;
+}> = ({ tools, expanded, onExpandedChange }) => {
 	const items = tools.map(getReadFileItem);
 	const isRunning = tools.some((tool) => tool.status === "running");
 	const isError = tools.some((tool) => tool.isError);
-	const hasContent = items.some((item) => item.content.length > 0);
+	const hasContent = items.some(
+		(item) => item.content.length > 0 || item.isError,
+	);
 	const label = isRunning
 		? `Reading ${tools.length} files…`
 		: `Read ${tools.length} files`;
@@ -52,6 +56,8 @@ export const ReadFilesTool: React.FC<{
 			<ToolCollapsible
 				className="w-full"
 				hasContent={hasContent}
+				expanded={expanded}
+				onExpandedChange={onExpandedChange}
 				header={
 					<>
 						<span className="text-[13px]">{label}</span>

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ReadFilesTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ReadFilesTool.tsx
@@ -6,10 +6,8 @@ import {
 	TooltipTrigger,
 } from "#/components/Tooltip/Tooltip";
 import type { MergedTool } from "../../ChatConversation/types";
-import { asRecord, asString } from "../runtimeTypeUtils";
-import { ReadFileContent } from "./ReadFileTool";
+import { getReadFileToolData, ReadFileContent } from "./ReadFileTool";
 import { ToolCollapsible } from "./ToolCollapsible";
-import { parseArgs } from "./utils";
 
 type ReadFileItem = {
 	id: string;
@@ -19,18 +17,10 @@ type ReadFileItem = {
 	errorMessage?: string;
 };
 
-const getReadFileItem = (tool: MergedTool): ReadFileItem => {
-	const parsedArgs = parseArgs(tool.args);
-	const path = parsedArgs ? asString(parsedArgs.path).trim() : "";
-	const rec = asRecord(tool.result);
-	return {
-		id: tool.id,
-		path: path || "file",
-		content: rec ? asString(rec.content).trim() : "",
-		isError: tool.isError,
-		errorMessage: rec ? asString(rec.error || rec.message) : undefined,
-	};
-};
+const getReadFileItem = (tool: MergedTool): ReadFileItem => ({
+	id: tool.id,
+	...getReadFileToolData(tool),
+});
 
 export const ReadFilesTool: React.FC<{
 	tools: readonly MergedTool[];
@@ -40,9 +30,7 @@ export const ReadFilesTool: React.FC<{
 	const items = tools.map(getReadFileItem);
 	const isRunning = tools.some((tool) => tool.status === "running");
 	const isError = tools.some((tool) => tool.isError);
-	const hasContent = items.some(
-		(item) => item.content.length > 0 || item.isError,
-	);
+	const hasContent = items.length > 0;
 	const label = isRunning
 		? `Reading ${tools.length} files…`
 		: `Read ${tools.length} files`;

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.tsx
@@ -27,7 +27,7 @@ import {
 import { ListTemplatesTool } from "./ListTemplatesTool";
 import { ProcessOutputTool } from "./ProcessOutputTool";
 import { ProposePlanTool } from "./ProposePlanTool";
-import { ReadFileTool } from "./ReadFileTool";
+import { getReadFileToolData, ReadFileTool } from "./ReadFileTool";
 import { ReadSkillTool } from "./ReadSkillTool";
 import { ReadTemplateTool } from "./ReadTemplateTool";
 import { StartWorkspaceTool } from "./StartWorkspaceTool";
@@ -314,22 +314,12 @@ const ReadFileRenderer: FC<ToolRendererProps> = ({
 	args,
 	result,
 	isError,
-}) => {
-	const parsedArgs = parseArgs(args);
-	const path = parsedArgs ? asString(parsedArgs.path).trim() : "";
-	const rec = asRecord(result);
-	const content = rec ? asString(rec.content).trim() : "";
-
-	return (
-		<ReadFileTool
-			path={path || "file"}
-			content={content}
-			status={status}
-			isError={isError}
-			errorMessage={rec ? asString(rec.error || rec.message) : undefined}
-		/>
-	);
-};
+}) => (
+	<ReadFileTool
+		{...getReadFileToolData({ args, result, isError })}
+		status={status}
+	/>
+);
 
 const ReadSkillRenderer: FC<ToolRendererProps> = ({
 	status,


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood

Collapses sequential `read_file` tool activity in the Agents chat timeline into a single UI event while leaving the tool API and persisted transcript shape unchanged.

The grouping handles both multiple tool blocks within one assistant message and the real persisted shape where `read_file` calls are split across adjacent assistant and tool-result messages. Refs CODAGT-337.

<details><summary>Implementation plan</summary>

# Collapse Sequential Read File Events Implementation Plan

> For agentic workers: use `subagent-driven-development` for independent
> tasks, or `executing-plans` for inline execution. Track steps with checkbox
> syntax.

**Goal:** Collapse consecutive `read_file` tool calls into a single conversation timeline UI entry such as `Read 3 files` while keeping each tool call singular.

**Architecture:** This is a render-time frontend grouping change. `BlockList` will derive a grouped view from existing `RenderBlock[]` and `MergedTool[]`, leaving message parsing, streaming state, persisted transcript shape, and the `read_file` tool protocol unchanged. A new grouped read-file component will reuse the same file viewer behavior as `ReadFileTool` so expanded groups still expose every file read.

**Tech Stack:** React, TypeScript, Vite, Vitest, Storybook interaction tests, Biome formatting, pnpm commands from `site/`.

---

## Requirements

- Consecutive rendered tool blocks whose resolved tool name is `read_file` collapse into one UI event.
- Single `read_file` blocks continue to render as the existing single-file `ReadFileTool`.
- Non-consecutive `read_file` blocks do not collapse across text, reasoning, source, file, or other tool blocks.
- The `read_file` tool API stays singular. Do not change tool schemas or backend code.
- Grouped UI shows a summary such as `Read N files` and can expand to show each file's content.
- If any grouped read is running, the group uses a running label and spinner. If any grouped read errors, the group shows an error indicator.

## File Map

- Modify: `site/src/pages/AgentsPage/components/ChatConversation/blockUtils.ts`
  - Add pure render-block grouping helpers.
- Modify: `site/src/pages/AgentsPage/components/ChatConversation/blockUtils.test.ts`
  - Add unit tests for grouping behavior.
- Modify: `site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx`
  - Use grouped blocks in `BlockList`, account for grouped IDs in remaining-tool filtering, and render grouped read files.
- Create: `site/src/pages/AgentsPage/components/ChatElements/tools/ReadFilesTool.tsx`
  - Render grouped `read_file` calls using `ToolCollapsible` and file viewers.
- Modify: `site/src/pages/AgentsPage/components/ChatElements/tools/ReadFileTool.tsx`
  - Export a reusable file viewer body if needed by `ReadFilesTool`.
- Modify: `site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx`
  - Add a story and play assertions for collapsed sequential reads.

No database, generated API, backend, or docs changes are expected.

## Implementation Details

### Grouping model

Do not add a persisted `RenderBlock` union member. Keep grouping as a local render derivation so other code that consumes parsed blocks does not need to understand grouped reads.

Add these types and helpers to `blockUtils.ts`:

```ts
export type ToolGroupRenderBlock = {
	type: "tool-group";
	toolName: "read_file";
	ids: string[];
};

export type TimelineRenderBlock = RenderBlock | ToolGroupRenderBlock;

export const groupSequentialReadFileBlocks = (
	blocks: readonly RenderBlock[],
	tools: readonly MergedTool[],
): TimelineRenderBlock[] => {
	const toolByID = new Map(tools.map((tool) => [tool.id, tool]));
	const grouped: TimelineRenderBlock[] = [];
	let currentReadFileIDs: string[] = [];

	const flushReadFileIDs = () => {
		if (currentReadFileIDs.length === 0) {
			return;
		}
		if (currentReadFileIDs.length === 1) {
			grouped.push({ type: "tool", id: currentReadFileIDs[0] });
		} else {
			grouped.push({
				type: "tool-group",
				toolName: "read_file",
				ids: currentReadFileIDs,
			});
		}
		currentReadFileIDs = [];
	};

	for (const block of blocks) {
		if (block.type === "tool") {
			const tool = toolByID.get(block.id);
			if (tool?.name === "read_file") {
				currentReadFileIDs = [...currentReadFileIDs, block.id];
				continue;
			}
		}

		flushReadFileIDs();
		grouped.push(block);
	}

	flushReadFileIDs();
	return grouped;
};

export const getToolIDsForBlock = (
	block: TimelineRenderBlock,
): readonly string[] => {
	if (block.type === "tool") {
		return [block.id];
	}
	if (block.type === "tool-group") {
		return block.ids;
	}
	return [];
};
```

`groupSequentialReadFileBlocks` should:

- Build `toolByID = new Map(tools.map((tool) => [tool.id, tool]))`.
- Iterate through `blocks` in order.
- For each `block.type === "tool"`, resolve the tool from `toolByID`.
- Accumulate consecutive tool blocks only when the resolved tool exists and `tool.name === "read_file"`.
- When a non-read block or unresolved tool block appears, flush the current run.
- Flush a run as:
  - one original tool block when the run length is 1,
  - one `{ type: "tool-group", toolName: "read_file", ids }` block when the run length is greater than 1.
- Preserve original block order and object identity for non-grouped blocks where practical.

### Grouped component behavior

Create `ReadFilesTool.tsx` with props:

```ts
import type { MergedTool } from "../../ChatConversation/types";

export const ReadFilesTool: React.FC<{
	tools: readonly MergedTool[];
}> = ({ tools }) => {
	// Implementation described in Task 3.
};
```

Inside `ReadFilesTool`:

- Derive each file item from its tool with `parseArgs`, `asRecord`, and `asString`, matching `ReadFileRenderer` in `Tool.tsx`.
- Use `path || "file"` as the display path fallback.
- Use `asString(rec.content).trim()` for content to match existing single-file behavior.
- Compute status:
  - running if any tool has `status === "running"`,
  - error if no running tools and any tool has `isError`,
  - completed otherwise.
- Header label:
  - `Reading ${tools.length} files…` when running,
  - `Read ${tools.length} files` otherwise.
- `hasContent` is true if any grouped item has non-empty content.
- Use `ToolCollapsible` with `className="w-full"`.
- In expanded content, render a vertical list of file sections. Each section shows the path and a scrollable file viewer body.
- Preserve per-file errors in the expanded list by showing the error message near that file if present.

To avoid duplicating file viewer setup, extract a small exported component from `ReadFileTool.tsx`:

```ts
export const ReadFileContent: React.FC<{
	path: string;
	content: string;
}> = ({ path, content }) => {
	// Existing ScrollArea plus FileViewer body.
};
```

Then `ReadFileTool` renders `<ReadFileContent path={path} content={content} />`, and `ReadFilesTool` reuses it for each file.

### `BlockList` integration

In `ConversationTimeline.tsx`:

- Import `getToolIDsForBlock`, `groupSequentialReadFileBlocks`, and `ReadFilesTool`.
- Keep `toolByID` creation.
- Compute `const displayBlocks = groupSequentialReadFileBlocks(blocks, tools);` after `toolByID`.
- Build `blockToolIDs` from `displayBlocks.flatMap(getToolIDsForBlock)` and retain the existing streaming check behavior for unresolved single tool placeholders.
- Render `displayBlocks.map` instead of `blocks.map`.
- Add `case "tool-group"` before `case "tool"`:

```tsx
case "tool-group": {
	const groupTools = block.ids
		.map((id) => toolByID.get(id))
		.filter((tool): tool is MergedTool => Boolean(tool));
	if (groupTools.length === 0) {
		return null;
	}
	return <ReadFilesTool key={`${keyPrefix}-tool-group-${index}`} tools={groupTools} />;
}
```

- Keep the existing single-tool render path unchanged.
- For `lastBlockIsThinking`, continue using the original `blocks` input because grouping only affects tool blocks.

## Tasks

### Task 1: Add pure grouping helper tests

**Files:**
- Test: `site/src/pages/AgentsPage/components/ChatConversation/blockUtils.test.ts`
- Modify later: `site/src/pages/AgentsPage/components/ChatConversation/blockUtils.ts`

- [x] **Step 1: Add failing tests for grouped read blocks.**

Add `MergedTool` to the type imports and add a new suite after `appendTextBlock`:

```ts
describe("groupSequentialReadFileBlocks", () => {
	const tools: MergedTool[] = [
		{
			id: "read-1",
			name: "read_file",
			args: { path: "a.ts" },
			result: { content: "a" },
			isError: false,
			status: "completed",
		},
		{
			id: "read-2",
			name: "read_file",
			args: { path: "b.ts" },
			result: { content: "b" },
			isError: false,
			status: "completed",
		},
		{
			id: "execute-1",
			name: "execute",
			args: { command: "pwd" },
			result: { output: "/home/coder" },
			isError: false,
			status: "completed",
		},
	];

	it("collapses consecutive read_file tool blocks", () => {
		const result = groupSequentialReadFileBlocks(
			[
				{ type: "tool", id: "read-1" },
				{ type: "tool", id: "read-2" },
			],
			tools,
		);

		expect(result).toEqual([
			{ type: "tool-group", toolName: "read_file", ids: ["read-1", "read-2"] },
		]);
	});

	it("leaves a single read_file tool block ungrouped", () => {
		const result = groupSequentialReadFileBlocks(
			[{ type: "tool", id: "read-1" }],
			tools,
		);

		expect(result).toEqual([{ type: "tool", id: "read-1" }]);
	});

	it("does not collapse read_file blocks across other content", () => {
		const result = groupSequentialReadFileBlocks(
			[
				{ type: "tool", id: "read-1" },
				{ type: "response", text: "middle" },
				{ type: "tool", id: "read-2" },
			],
			tools,
		);

		expect(result).toEqual([
			{ type: "tool", id: "read-1" },
			{ type: "response", text: "middle" },
			{ type: "tool", id: "read-2" },
		]);
	});

	it("does not collapse read_file blocks across another tool", () => {
		const result = groupSequentialReadFileBlocks(
			[
				{ type: "tool", id: "read-1" },
				{ type: "tool", id: "execute-1" },
				{ type: "tool", id: "read-2" },
			],
			tools,
		);

		expect(result).toEqual([
			{ type: "tool", id: "read-1" },
			{ type: "tool", id: "execute-1" },
			{ type: "tool", id: "read-2" },
		]);
	});

	it("keeps unresolved tool blocks ungrouped", () => {
		const result = groupSequentialReadFileBlocks(
			[
				{ type: "tool", id: "read-1" },
				{ type: "tool", id: "missing" },
				{ type: "tool", id: "read-2" },
			],
			tools,
		);

		expect(result).toEqual([
			{ type: "tool", id: "read-1" },
			{ type: "tool", id: "missing" },
			{ type: "tool", id: "read-2" },
		]);
	});
});
```

- [x] **Step 2: Run the focused test and verify it fails because the helper is missing.**

```sh
cd site && pnpm test -- src/pages/AgentsPage/components/ChatConversation/blockUtils.test.ts -t groupSequentialReadFileBlocks
```

Expected: Vitest fails because `groupSequentialReadFileBlocks` is not exported from `blockUtils.ts`.

### Task 2: Implement grouping helpers

**Files:**
- Modify: `site/src/pages/AgentsPage/components/ChatConversation/blockUtils.ts`
- Test: `site/src/pages/AgentsPage/components/ChatConversation/blockUtils.test.ts`

- [x] **Step 1: Add the helper types and implementation.**

Update imports:

```ts
import type { MergedTool, RenderBlock } from "./types";
```

Add the types and helpers after `appendTextBlock`:

```ts
export type ToolGroupRenderBlock = {
	type: "tool-group";
	toolName: "read_file";
	ids: string[];
};

export type TimelineRenderBlock = RenderBlock | ToolGroupRenderBlock;

export const groupSequentialReadFileBlocks = (
	blocks: readonly RenderBlock[],
	tools: readonly MergedTool[],
): TimelineRenderBlock[] => {
	const toolByID = new Map(tools.map((tool) => [tool.id, tool]));
	const grouped: TimelineRenderBlock[] = [];
	let currentReadFileIDs: string[] = [];

	const flushReadFileIDs = () => {
		if (currentReadFileIDs.length === 0) {
			return;
		}
		if (currentReadFileIDs.length === 1) {
			grouped.push({ type: "tool", id: currentReadFileIDs[0] });
		} else {
			grouped.push({
				type: "tool-group",
				toolName: "read_file",
				ids: currentReadFileIDs,
			});
		}
		currentReadFileIDs = [];
	};

	for (const block of blocks) {
		if (block.type === "tool") {
			const tool = toolByID.get(block.id);
			if (tool?.name === "read_file") {
				currentReadFileIDs = [...currentReadFileIDs, block.id];
				continue;
			}
		}

		flushReadFileIDs();
		grouped.push(block);
	}

	flushReadFileIDs();
	return grouped;
};

export const getToolIDsForBlock = (
	block: TimelineRenderBlock,
): readonly string[] => {
	if (block.type === "tool") {
		return [block.id];
	}
	if (block.type === "tool-group") {
		return block.ids;
	}
	return [];
};
```

- [x] **Step 2: Import the helper in the test file.**

Update the `blockUtils.test.ts` import to include `groupSequentialReadFileBlocks` and import `MergedTool`:

```ts
import {
	appendTextBlock,
	asNonEmptyString,
	groupSequentialReadFileBlocks,
} from "./blockUtils";
import type { MergedTool, RenderBlock } from "./types";
```

- [x] **Step 3: Run the focused helper tests and verify they pass.**

```sh
cd site && pnpm test -- src/pages/AgentsPage/components/ChatConversation/blockUtils.test.ts -t groupSequentialReadFileBlocks
```

Expected: the new grouping tests pass.

- [x] **Step 4: Run all block utility tests.**

```sh
cd site && pnpm test -- src/pages/AgentsPage/components/ChatConversation/blockUtils.test.ts
```

Expected: all `blockUtils.test.ts` tests pass.

### Task 3: Add grouped read-file component with reusable file viewer body

**Files:**
- Modify: `site/src/pages/AgentsPage/components/ChatElements/tools/ReadFileTool.tsx`
- Create: `site/src/pages/AgentsPage/components/ChatElements/tools/ReadFilesTool.tsx`

- [x] **Step 1: Extract `ReadFileContent` from `ReadFileTool.tsx`.**

Add this exported component before `ReadFileTool`:

```tsx
export const ReadFileContent: React.FC<{
	path: string;
	content: string;
}> = ({ path, content }) => {
	const theme = useTheme();
	const isDark = theme.palette.mode === "dark";

	return (
		<ScrollArea
			className="mt-1.5 rounded-md border border-solid border-border-default text-2xs"
			viewportClassName="max-h-64"
			scrollBarClassName="w-1.5"
		>
			<FileViewer
				file={{
					name: path,
					contents: content,
				}}
				options={getFileViewerOptionsMinimal(isDark)}
				style={DIFFS_FONT_STYLE}
			/>
		</ScrollArea>
	);
};
```

Then replace the existing inline `ScrollArea` in `ReadFileTool` with:

```tsx
<ReadFileContent path={path} content={content} />
```

- [x] **Step 2: Create `ReadFilesTool.tsx`.**

Use this shape:

```tsx
import { LoaderIcon, TriangleAlertIcon } from "lucide-react";
import type React from "react";
import {
	Tooltip,
	TooltipContent,
	TooltipTrigger,
} from "#/components/Tooltip/Tooltip";
import type { MergedTool } from "../../ChatConversation/types";
import { asRecord, asString } from "../runtimeTypeUtils";
import { ReadFileContent } from "./ReadFileTool";
import { ToolCollapsible } from "./ToolCollapsible";
import { parseArgs } from "./utils";

type ReadFileItem = {
	id: string;
	path: string;
	content: string;
	isError: boolean;
	errorMessage?: string;
};

const getReadFileItem = (tool: MergedTool): ReadFileItem => {
	const parsedArgs = parseArgs(tool.args);
	const path = parsedArgs ? asString(parsedArgs.path).trim() : "";
	const rec = asRecord(tool.result);
	return {
		id: tool.id,
		path: path || "file",
		content: rec ? asString(rec.content).trim() : "",
		isError: tool.isError,
		errorMessage: rec ? asString(rec.error || rec.message) : undefined,
	};
};

export const ReadFilesTool: React.FC<{
	tools: readonly MergedTool[];
}> = ({ tools }) => {
	const items = tools.map(getReadFileItem);
	const isRunning = tools.some((tool) => tool.status === "running");
	const isError = tools.some((tool) => tool.isError);
	const hasContent = items.some((item) => item.content.length > 0);
	const label = isRunning
		? `Reading ${tools.length} files…`
		: `Read ${tools.length} files`;
	const errorMessage = items.find((item) => item.errorMessage)?.errorMessage;

	return (
		<ToolCollapsible
			className="w-full"
			hasContent={hasContent}
			header={
				<>
					<span className="text-[13px]">{label}</span>
					{isError && (
						<Tooltip>
							<TooltipTrigger asChild>
								<TriangleAlertIcon className="h-3.5 w-3.5 shrink-0 text-current" />
							</TooltipTrigger>
							<TooltipContent>
								{errorMessage || "Failed to read one or more files"}
							</TooltipContent>
						</Tooltip>
					)}
					{isRunning && (
						<LoaderIcon className="h-3.5 w-3.5 shrink-0 animate-spin motion-reduce:animate-none text-current" />
					)}
				</>
			}
		>
			<div className="space-y-3">
				{items.map((item) => (
					<section key={item.id} className="min-w-0">
						<div className="mt-2 truncate text-xs text-content-secondary">
							{item.path}
						</div>
						{item.isError && (
							<div className="mt-1 text-xs text-content-destructive">
								{item.errorMessage || "Failed to read file"}
							</div>
						)}
						{item.content.length > 0 && (
							<ReadFileContent path={item.path} content={item.content} />
						)}
					</section>
				))}
			</div>
		</ToolCollapsible>
	);
};
```

- [x] **Step 3: Run TypeScript check for immediate errors.**

```sh
cd site && pnpm check
```

Expected: no TypeScript errors from the new component and extracted viewer body.

### Task 4: Integrate grouped blocks into `BlockList`

**Files:**
- Modify: `site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx`

- [x] **Step 1: Import the helper and grouped component.**

Add `ReadFilesTool` near the existing tool imports:

```ts
import { ReadFilesTool } from "../ChatElements/tools/ReadFilesTool";
```

Update the block utility import:

```ts
import {
	getToolIDsForBlock,
	groupSequentialReadFileBlocks,
} from "./blockUtils";
```

If `ConversationTimeline.tsx` already imports from `blockUtils`, merge these names into that import instead of adding a duplicate.

- [x] **Step 2: Derive `displayBlocks` and update remaining-tool filtering.**

In `BlockList`, after `toolByID`:

```ts
const displayBlocks = groupSequentialReadFileBlocks(blocks, tools);
```

Replace the existing `blockToolIDs` computation with:

```ts
const blockToolIDs = new Set(
	displayBlocks.flatMap((block) => {
		if (
			block.type === "tool" &&
			!(toolByID.has(block.id) || isStreaming)
		) {
			return [];
		}
		return [...getToolIDsForBlock(block)];
	}),
);
```

This keeps unresolved streaming placeholders eligible for single-tool rendering while also excluding grouped tool IDs from `remainingTools`.

- [x] **Step 3: Render `displayBlocks` and add the grouped case.**

Change:

```tsx
{blocks.map((block, index) => {
```

to:

```tsx
{displayBlocks.map((block, index) => {
```

Add this switch case before `case "tool"`:

```tsx
case "tool-group": {
	const groupTools = block.ids
		.map((id) => toolByID.get(id))
		.filter((tool): tool is MergedTool => Boolean(tool));
	if (groupTools.length === 0) {
		return null;
	}
	return (
		<ReadFilesTool
			key={`${keyPrefix}-tool-group-${index}`}
			tools={groupTools}
		/>
	);
}
```

- [x] **Step 4: Run focused tests and typecheck.**

```sh
cd site && pnpm test -- src/pages/AgentsPage/components/ChatConversation/blockUtils.test.ts
cd site && pnpm check
```

Expected: tests pass and TypeScript accepts the new `TimelineRenderBlock` switch case.

### Task 5: Add Storybook coverage for sequential reads

**Files:**
- Modify: `site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx`

- [x] **Step 1: Add a story with play assertions.**

Add a story near the other tool/rendering regression stories:

```tsx
export const SequentialReadFilesCollapsed: Story = {
	args: {
		...defaultArgs,
		parsedMessages: buildMessages([
			{
				...baseMessage,
				id: 1,
				role: "assistant",
				content: [
					{ type: "text", text: "I'll inspect the relevant files." },
					{
						type: "tool-call",
						tool_call_id: "read-1",
						tool_name: "read_file",
						args: { path: "site/src/a.ts" },
					},
					{
						type: "tool-result",
						tool_call_id: "read-1",
						tool_name: "read_file",
						result: { content: "export const a = 1;" },
					},
					{
						type: "tool-call",
						tool_call_id: "read-2",
						tool_name: "read_file",
						args: { path: "site/src/b.ts" },
					},
					{
						type: "tool-result",
						tool_call_id: "read-2",
						tool_name: "read_file",
						result: { content: "export const b = 2;" },
					},
					{
						type: "tool-call",
						tool_call_id: "read-3",
						tool_name: "read_file",
						args: { path: "site/src/c.ts" },
					},
					{
						type: "tool-result",
						tool_call_id: "read-3",
						tool_name: "read_file",
						result: { content: "export const c = 3;" },
					},
				],
			},
		]),
	},
	play: async ({ canvasElement }) => {
		const canvas = within(canvasElement);
		const groupButton = canvas.getByRole("button", { name: /read 3 files/i });
		expect(groupButton).toBeInTheDocument();
		expect(
			canvas.queryByRole("button", { name: /read a\.ts/i }),
		).not.toBeInTheDocument();
		await userEvent.click(groupButton);
		await waitFor(() => {
			expect(canvas.getByText("site/src/a.ts")).toBeVisible();
			expect(canvas.getByText("site/src/b.ts")).toBeVisible();
			expect(canvas.getByText("site/src/c.ts")).toBeVisible();
		});
	},
};
```

The exact text queries for code contents may need adjustment because `@pierre/diffs/react` may split code into decorated spans. Prefer asserting visible file paths and the group button.

- [x] **Step 2: Not applicable because Task 4 was already completed before the story test run.**

If Task 4 is complete, this should pass. If running this before Task 4, expected failure is that `Read 3 files` is not found.

```sh
cd site && pnpm test:storybook src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx -- --grep SequentialReadFilesCollapsed
```

- [x] **Step 3: Run the story test after integration.**

```sh
cd site && pnpm test:storybook src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx -- --grep SequentialReadFilesCollapsed
```

Expected: the story passes and confirms one grouped UI event.

### Task 6: Format and verify the frontend change

**Files:**
- All modified frontend files from previous tasks.

- [x] **Step 1: Format frontend files.**

```sh
cd site && pnpm format
```

Expected: Biome formats changed files.

- [x] **Step 2: Run focused unit tests.**

```sh
cd site && pnpm test -- src/pages/AgentsPage/components/ChatConversation/blockUtils.test.ts
```

Expected: all block utility tests pass.

- [x] **Step 3: Run the focused Storybook interaction test.**

```sh
cd site && pnpm test:storybook src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx -- --grep SequentialReadFilesCollapsed
```

Expected: the sequential read-file story passes.

- [x] **Step 4: Run TypeScript check.**

```sh
cd site && pnpm check
```

Expected: no TypeScript errors.

- [x] **Step 5: Inspect the diff for unrelated changes.**

```sh
git diff -- site/src/pages/AgentsPage/components/ChatConversation/blockUtils.ts site/src/pages/AgentsPage/components/ChatConversation/blockUtils.test.ts site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx site/src/pages/AgentsPage/components/ChatElements/tools/ReadFileTool.tsx site/src/pages/AgentsPage/components/ChatElements/tools/ReadFilesTool.tsx site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
```

Expected: the diff only contains grouping helpers, grouped UI, integration, and tests for CODAGT-337.

## Follow-up: Real transcript shape fix

After manual testing showed the initial implementation did not collapse reads in
real chats, the reproduced transcript shape was updated to match persisted chat
messages: each `read_file` tool call can appear in its own assistant message,
with a hidden `tool` role result message between calls. The original
block-level grouping only handled multiple tool blocks inside one assistant
message, so those real sequential reads stayed separate.

Additional changes:

- Added `groupSequentialReadFileMessages` in `messageHelpers.ts` to collapse
  adjacent read-file-only assistant messages before rendering the timeline.
- Hidden tool-result-only messages are transparent for grouping and remain
  omitted from the rendered timeline.
- Visible assistant text, reasoning, files, sources, user messages, and other
  visible tools still break a read-file group.
- Updated `SequentialReadFilesCollapsed` to use the real multi-message shape.
- Added `messageHelpers.test.ts` coverage for cross-message grouping.


</details>
