### PR TITLE
feat: add OpenAI-compatible provider options

### DIFF
--- a/.github/workflows/flake-go.yaml
+++ b/.github/workflows/flake-go.yaml
@@ -48,7 +48,7 @@ jobs:
         uses: ./.github/actions/go-cache
 
       - name: Install Go mise tools
-        run: ./.github/scripts/retry.sh -- mise install --locked go:github.com/coder/whichtests
+        run: ./.github/scripts/retry.sh -- mise install --locked go:github.com/coder/whichtests go:gotest.tools/gotestsum
 
       - name: Select changed tests
         id: selector

--- a/cli/agent_test.go
+++ b/cli/agent_test.go
@@ -149,6 +149,7 @@ func TestWorkspaceAgent(t *testing.T) {
 		if runtime.GOOS == "windows" {
 			coderURLEnv = "%CODER_URL%"
 		}
+		headerCommand := "echo X-Process-Testing=very-wow-" + coderURLEnv + " && echo X-Process-Testing2=more-wow"
 
 		logDir := t.TempDir()
 		agentInv, _ := clitest.New(t,
@@ -159,7 +160,7 @@ func TestWorkspaceAgent(t *testing.T) {
 			"--log-dir", logDir,
 			"--agent-header", "X-Testing=agent",
 			"--agent-header", "Cool-Header=Ethan was Here!",
-			"--agent-header-command", "printf X-Process-Testing=very-wow-"+coderURLEnv+"'\\r\\n'X-Process-Testing2=more-wow",
+			"--agent-header-command", headerCommand,
 			"--socket-path", testutil.AgentSocketPath(t),
 		)
 		clitest.Start(t, agentInv)

--- a/cli/configssh_internal_test.go
+++ b/cli/configssh_internal_test.go
@@ -227,10 +227,22 @@ func Test_sshConfigMatchExecEscape(t *testing.T) {
 			err = os.WriteFile(bin, contents, 0o755) //nolint:gosec
 			require.NoError(t, err)
 
-			// OpenSSH processes %% escape sequences into %
-			escaped = strings.ReplaceAll(escaped, "%%", "%")
-			b, err := exec.Command(cmd, arg, escaped).CombinedOutput() //nolint:gosec
-			require.NoError(t, err)
+			var b []byte
+			if runtime.GOOS == "windows" {
+				// OpenSSH does not invoke Match exec through Go's Windows
+				// command-line quoting. Run the command from a batch file so the
+				// generated %% escape sequences are interpreted like they are in
+				// the SSH config path.
+				script := filepath.Join(t.TempDir(), "match-exec.cmd")
+				err = os.WriteFile(script, []byte("@echo off\r\n"+escaped+"\r\n"), 0o755) //nolint:gosec
+				require.NoError(t, err)
+				b, err = exec.Command(cmd, arg, script).CombinedOutput() //nolint:gosec
+			} else {
+				// OpenSSH processes %% escape sequences into %.
+				escaped = strings.ReplaceAll(escaped, "%%", "%")
+				b, err = exec.Command(cmd, arg, escaped).CombinedOutput() //nolint:gosec
+			}
+			require.NoErrorf(t, err, "output: %s", b)
 			got := strings.TrimSpace(string(b))
 			require.Equal(t, "yay", got)
 		})

--- a/cli/configssh_internal_test.go
+++ b/cli/configssh_internal_test.go
@@ -229,10 +229,8 @@ func Test_sshConfigMatchExecEscape(t *testing.T) {
 
 			var b []byte
 			if runtime.GOOS == "windows" {
-				// OpenSSH does not invoke Match exec through Go's Windows
-				// command-line quoting. Run the command from a batch file so the
-				// generated %% escape sequences are interpreted like they are in
-				// the SSH config path.
+				// OpenSSH passes Match exec to cmd.exe, not through Go's quoting.
+				// %% escapes must be expanded the same way as in the SSH config.
 				script := filepath.Join(t.TempDir(), "match-exec.cmd")
 				err = os.WriteFile(script, []byte("@echo off\r\n"+escaped+"\r\n"), 0o755) //nolint:gosec
 				require.NoError(t, err)

--- a/cli/configssh_windows.go
+++ b/cli/configssh_windows.go
@@ -3,6 +3,7 @@
 package cli
 
 import (
+	"cmp"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -21,7 +22,9 @@ import (
 //
 // So, we can't actually include " directly, but here is a horrible workaround:
 //
-// "for /f %%a in ('powershell.exe -Command [char]34') do @cmd.exe /c %%aC:\Program Files\Coder\bin\coder.exe%%a connect exists %h"
+// Simplified, the actual command resolves PowerShell and cmd.exe to absolute paths:
+//
+// "for /f %%a in ('C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile -Command [char]34') do @C:\Windows\System32\cmd.exe /c %%aC:\Program Files\Coder\bin\coder.exe%%a connect exists %h"
 //
 // The key insight here is to store the character " in a variable (%a in this case, but the % itself needs to be
 // escaped, so it becomes %%a), and then use that variable to construct the double-quoted path:
@@ -38,6 +41,7 @@ import (
 //     it the double-quote gets interpreted as part of the path, and you get: '"C:\Program' is not recognized.
 //     Constructing the string and then passing it to another instance of cmd.exe does this trick here. We resolve
 //     cmd.exe to an absolute path for the same minimal PATH reason as PowerShell.
+//   - -NoProfile prevents profile script stdout from corrupting the `for /f` capture.
 //   - OpenSSH passes the `Match exec` command to cmd.exe regardless of whether the user has a unix-like shell like
 //     git bash, so we don't have a `forceUnixPath` option like for the ProxyCommand which does respect the user's
 //     configured shell on Windows.
@@ -54,15 +58,25 @@ func sshConfigMatchExecEscape(path string) (string, error) {
 
 	if strings.ContainsAny(path, " ") {
 		// c.f. function comment for how this works.
-		cmd := "cmd.exe"
-		if comspec := os.Getenv("ComSpec"); comspec != "" {
-			cmd = comspec
+		cmd := cmp.Or(os.Getenv("ComSpec"), "cmd.exe")
+		if err := validateMatchExecHelperPath("cmd.exe", cmd); err != nil {
+			return "", err
 		}
 		powershell := "powershell.exe"
 		if systemRoot := os.Getenv("SystemRoot"); systemRoot != "" {
 			powershell = filepath.Join(systemRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
 		}
+		if err := validateMatchExecHelperPath("powershell.exe", powershell); err != nil {
+			return "", err
+		}
 		path = fmt.Sprintf("for /f %%%%a in ('%s -NoProfile -Command [char]34') do @%s /c %%%%a%s%%%%a", powershell, cmd, path) //nolint:gocritic // We don't want %q here.
 	}
 	return path, nil
+}
+
+func validateMatchExecHelperPath(name, path string) error {
+	if strings.ContainsAny(path, " \"\t\r\n") {
+		return xerrors.Errorf("resolved %s path must not contain spaces, quotes, tabs, or newlines: %q", name, path)
+	}
+	return nil
 }

--- a/cli/configssh_windows.go
+++ b/cli/configssh_windows.go
@@ -4,6 +4,8 @@ package cli
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"golang.org/x/xerrors"
@@ -27,13 +29,15 @@ import (
 // %%aC:\Program Files\Coder\bin\coder.exe%%a.
 //
 // How do we generate a single " character without actually using that character? I couldn't find any command in cmd.exe
-// to do it, but powershell.exe can convert ASCII to characters like this: `[char]34` (where 34 is the code point for ").
+// to do it, but PowerShell can convert ASCII to characters like this: `[char]34` (where 34 is the code point for ").
+// We resolve PowerShell to an absolute path because minimal CI PATHs do not always include it.
 //
 // Other notes:
 //   - @ in `@cmd.exe` suppresses echoing it, so you don't get this command printed
 //   - we need another invocation of cmd.exe (e.g. `do @cmd.exe /c %%aC:\Program Files\Coder\bin\coder.exe%%a`). Without
 //     it the double-quote gets interpreted as part of the path, and you get: '"C:\Program' is not recognized.
-//     Constructing the string and then passing it to another instance of cmd.exe does this trick here.
+//     Constructing the string and then passing it to another instance of cmd.exe does this trick here. We resolve
+//     cmd.exe to an absolute path for the same minimal PATH reason as PowerShell.
 //   - OpenSSH passes the `Match exec` command to cmd.exe regardless of whether the user has a unix-like shell like
 //     git bash, so we don't have a `forceUnixPath` option like for the ProxyCommand which does respect the user's
 //     configured shell on Windows.
@@ -50,7 +54,15 @@ func sshConfigMatchExecEscape(path string) (string, error) {
 
 	if strings.ContainsAny(path, " ") {
 		// c.f. function comment for how this works.
-		path = fmt.Sprintf("for /f %%%%a in ('powershell.exe -Command [char]34') do @cmd.exe /c %%%%a%s%%%%a", path) //nolint:gocritic // We don't want %q here.
+		cmd := "cmd.exe"
+		if comspec := os.Getenv("ComSpec"); comspec != "" {
+			cmd = comspec
+		}
+		powershell := "powershell.exe"
+		if systemRoot := os.Getenv("SystemRoot"); systemRoot != "" {
+			powershell = filepath.Join(systemRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
+		}
+		path = fmt.Sprintf("for /f %%%%a in ('%s -NoProfile -Command [char]34') do @%s /c %%%%a%s%%%%a", powershell, cmd, path) //nolint:gocritic // We don't want %q here.
 	}
 	return path, nil
 }

--- a/cli/root_test.go
+++ b/cli/root_test.go
@@ -180,12 +180,13 @@ func TestRoot(t *testing.T) {
 		if runtime.GOOS == "windows" {
 			coderURLEnv = "%CODER_URL%"
 		}
+		headerCommand := "echo X-Process-Testing=very-wow-" + coderURLEnv + " && echo X-Process-Testing2=more-wow"
 		inv, _ := clitest.New(t,
 			"--no-feature-warning",
 			"--no-version-warning",
 			"--header", "X-Testing=wow",
 			"--header", "Cool-Header=Dean was Here!",
-			"--header-command", "printf X-Process-Testing=very-wow-"+coderURLEnv+"'\\r\\n'X-Process-Testing2=more-wow",
+			"--header-command", headerCommand,
 			"login", srv.URL,
 		)
 		inv.Stdout = buf
@@ -266,7 +267,7 @@ func TestDERPHeaders(t *testing.T) {
 		"--no-version-warning",
 		"ping", workspace.Name,
 		"-n", "1",
-		"--header-command", "printf X-Process-Testing=very-wow",
+		"--header-command", "echo X-Process-Testing=very-wow",
 	}
 	for k, v := range expectedHeaders {
 		if k != "X-Process-Testing" {

--- a/coderd/x/chatd/chatopenai/options.go
+++ b/coderd/x/chatd/chatopenai/options.go
@@ -147,6 +147,7 @@ func ReasoningEffortFromChat(value *string) *fantasyopenai.ReasoningEffort {
 
 	effort := chatutil.NormalizedEnumValue(
 		normalized,
+		string(fantasyopenai.ReasoningEffortNone),
 		string(fantasyopenai.ReasoningEffortMinimal),
 		string(fantasyopenai.ReasoningEffortLow),
 		string(fantasyopenai.ReasoningEffortMedium),

--- a/coderd/x/chatd/chatopenai/options_test.go
+++ b/coderd/x/chatd/chatopenai/options_test.go
@@ -296,7 +296,7 @@ func TestReasoningEffortFromChat(t *testing.T) {
 		{name: "Medium", value: ptr("medium"), want: ptr(fantasyopenai.ReasoningEffortMedium)},
 		{name: "High", value: ptr("high"), want: ptr(fantasyopenai.ReasoningEffortHigh)},
 		{name: "XHigh", value: ptr("xhigh"), want: ptr(fantasyopenai.ReasoningEffortXHigh)},
-		{name: "NoneUnsupported", value: ptr("none")},
+		{name: "None", value: ptr("none"), want: ptr(fantasyopenai.ReasoningEffortNone)},
 		{name: "Invalid", value: ptr("max")},
 	}
 

--- a/coderd/x/chatd/chatprovider/chatprovider.go
+++ b/coderd/x/chatd/chatprovider/chatprovider.go
@@ -2,6 +2,7 @@ package chatprovider
 
 import (
 	"context"
+	"maps"
 	"net/http"
 	"sort"
 	"strings"
@@ -727,9 +728,12 @@ func ReasoningEffortFromChat(provider string, value *string) *string {
 	case fantasyopenrouter.Name:
 		return chatutil.NormalizedEnumValue(
 			normalized,
+			string(fantasyopenrouter.ReasoningEffortNone),
+			string(fantasyopenrouter.ReasoningEffortMinimal),
 			string(fantasyopenrouter.ReasoningEffortLow),
 			string(fantasyopenrouter.ReasoningEffortMedium),
 			string(fantasyopenrouter.ReasoningEffortHigh),
+			string(fantasyopenrouter.ReasoningEffortXHigh),
 		)
 	case fantasyvercel.Name:
 		return chatutil.NormalizedEnumValue(
@@ -935,6 +939,7 @@ func MergeMissingProviderOptions(
 			}
 			if current.OpenAICompat == nil {
 				copied := *defaults.OpenAICompat
+				copied.ExtraBody = maps.Clone(defaults.OpenAICompat.ExtraBody)
 				current.OpenAICompat = &copied
 				continue
 			}
@@ -956,7 +961,7 @@ func MergeMissingProviderOptions(
 				dstCompat.PromptCacheKey = defaultCompat.PromptCacheKey
 			}
 			if dstCompat.ExtraBody == nil {
-				dstCompat.ExtraBody = defaultCompat.ExtraBody
+				dstCompat.ExtraBody = maps.Clone(defaultCompat.ExtraBody)
 			}
 
 		case fantasyopenrouter.Name:
@@ -965,6 +970,7 @@ func MergeMissingProviderOptions(
 			}
 			if current.OpenRouter == nil {
 				copied := *defaults.OpenRouter
+				copied.ExtraBody = maps.Clone(defaults.OpenRouter.ExtraBody)
 				current.OpenRouter = &copied
 				continue
 			}
@@ -987,7 +993,7 @@ func MergeMissingProviderOptions(
 				}
 			}
 			if dstRouter.ExtraBody == nil {
-				dstRouter.ExtraBody = defaultRouter.ExtraBody
+				dstRouter.ExtraBody = maps.Clone(defaultRouter.ExtraBody)
 			}
 			if dstRouter.IncludeUsage == nil {
 				dstRouter.IncludeUsage = defaultRouter.IncludeUsage
@@ -1039,6 +1045,7 @@ func MergeMissingProviderOptions(
 			}
 			if current.Vercel == nil {
 				copied := *defaults.Vercel
+				copied.ExtraBody = maps.Clone(defaults.Vercel.ExtraBody)
 				current.Vercel = &copied
 				continue
 			}
@@ -1086,7 +1093,7 @@ func MergeMissingProviderOptions(
 				dstVercel.ParallelToolCalls = defaultVercel.ParallelToolCalls
 			}
 			if dstVercel.ExtraBody == nil {
-				dstVercel.ExtraBody = defaultVercel.ExtraBody
+				dstVercel.ExtraBody = maps.Clone(defaultVercel.ExtraBody)
 			}
 		}
 	}
@@ -1442,7 +1449,7 @@ func openAICompatProviderOptionsFromChatConfig(
 		ParallelToolCalls:   options.ParallelToolCalls,
 		ReasoningEffort:     chatopenai.ReasoningEffortFromChat(options.ReasoningEffort),
 		MaxCompletionTokens: options.MaxCompletionTokens,
-		PromptCacheKey:      options.PromptCacheKey,
+		PromptCacheKey:      chatutil.NormalizedStringPointer(options.PromptCacheKey),
 		ExtraBody:           options.ExtraBody,
 	}
 }

--- a/coderd/x/chatd/chatprovider/chatprovider.go
+++ b/coderd/x/chatd/chatprovider/chatprovider.go
@@ -943,8 +943,20 @@ func MergeMissingProviderOptions(
 			if dstCompat.User == nil {
 				dstCompat.User = defaultCompat.User
 			}
+			if dstCompat.ParallelToolCalls == nil {
+				dstCompat.ParallelToolCalls = defaultCompat.ParallelToolCalls
+			}
 			if dstCompat.ReasoningEffort == nil {
 				dstCompat.ReasoningEffort = defaultCompat.ReasoningEffort
+			}
+			if dstCompat.MaxCompletionTokens == nil {
+				dstCompat.MaxCompletionTokens = defaultCompat.MaxCompletionTokens
+			}
+			if dstCompat.PromptCacheKey == nil {
+				dstCompat.PromptCacheKey = defaultCompat.PromptCacheKey
+			}
+			if dstCompat.ExtraBody == nil {
+				dstCompat.ExtraBody = defaultCompat.ExtraBody
 			}
 
 		case fantasyopenrouter.Name:
@@ -1426,8 +1438,12 @@ func openAICompatProviderOptionsFromChatConfig(
 	options *codersdk.ChatModelOpenAICompatProviderOptions,
 ) *fantasyopenaicompat.ProviderOptions {
 	return &fantasyopenaicompat.ProviderOptions{
-		User:            chatutil.NormalizedStringPointer(options.User),
-		ReasoningEffort: chatopenai.ReasoningEffortFromChat(options.ReasoningEffort),
+		User:                chatutil.NormalizedStringPointer(options.User),
+		ParallelToolCalls:   options.ParallelToolCalls,
+		ReasoningEffort:     chatopenai.ReasoningEffortFromChat(options.ReasoningEffort),
+		MaxCompletionTokens: options.MaxCompletionTokens,
+		PromptCacheKey:      options.PromptCacheKey,
+		ExtraBody:           options.ExtraBody,
 	}
 }
 

--- a/coderd/x/chatd/chatprovider/chatprovider_test.go
+++ b/coderd/x/chatd/chatprovider/chatprovider_test.go
@@ -1564,6 +1564,8 @@ func TestMergeMissingProviderOptions_OpenAICompat(t *testing.T) {
 		require.Equal(t, map[string]any{
 			"default_field": "default-value",
 		}, options.OpenAICompat.ExtraBody)
+		options.OpenAICompat.ExtraBody["default_field"] = "changed"
+		require.Equal(t, "default-value", defaults.OpenAICompat.ExtraBody["default_field"])
 		require.Equal(t, "default-cache-key", *options.OpenAICompat.PromptCacheKey)
 	})
 

--- a/coderd/x/chatd/chatprovider/chatprovider_test.go
+++ b/coderd/x/chatd/chatprovider/chatprovider_test.go
@@ -1510,3 +1510,98 @@ func TestResolveModelWithProviderHint(t *testing.T) {
 		})
 	}
 }
+
+func TestMergeMissingProviderOptions_OpenAICompat(t *testing.T) {
+	t.Parallel()
+
+	options := &codersdk.ChatModelProviderOptions{
+		OpenAICompat: &codersdk.ChatModelOpenAICompatProviderOptions{
+			ReasoningEffort: ptr.Ref("low"),
+		},
+	}
+	defaults := &codersdk.ChatModelProviderOptions{
+		OpenAICompat: &codersdk.ChatModelOpenAICompatProviderOptions{
+			User:                ptr.Ref("default-user"),
+			ParallelToolCalls:   ptr.Ref(true),
+			ReasoningEffort:     ptr.Ref("high"),
+			MaxCompletionTokens: ptr.Ref[int64](4096),
+			PromptCacheKey:      ptr.Ref("default-cache-key"),
+			ExtraBody: map[string]any{
+				"default_field": "default-value",
+			},
+		},
+	}
+
+	chatprovider.MergeMissingProviderOptions(&options, defaults)
+
+	require.NotNil(t, options)
+	require.NotNil(t, options.OpenAICompat)
+	require.Equal(t, "default-user", *options.OpenAICompat.User)
+	require.True(t, *options.OpenAICompat.ParallelToolCalls)
+	require.Equal(t, "low", *options.OpenAICompat.ReasoningEffort)
+	require.EqualValues(t, 4096, *options.OpenAICompat.MaxCompletionTokens)
+	require.Equal(t, map[string]any{
+		"default_field": "default-value",
+	}, options.OpenAICompat.ExtraBody)
+	require.Equal(t, "default-cache-key", *options.OpenAICompat.PromptCacheKey)
+}
+
+func TestProviderOptionsFromChatModelConfig_OpenAICompat(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ForwardsOpenAICompatProviderOptions", func(t *testing.T) {
+		t.Parallel()
+
+		providerOptions := chatprovider.ProviderOptionsFromChatModelConfig(
+			nil,
+			&codersdk.ChatModelProviderOptions{
+				OpenAICompat: &codersdk.ChatModelOpenAICompatProviderOptions{
+					User:                ptr.Ref("compat-user"),
+					ParallelToolCalls:   ptr.Ref(true),
+					ReasoningEffort:     ptr.Ref("medium"),
+					MaxCompletionTokens: ptr.Ref[int64](2048),
+					PromptCacheKey:      ptr.Ref("cache-key"),
+					ExtraBody: map[string]any{
+						"custom_field": "custom-value",
+					},
+				},
+			},
+		)
+
+		raw := providerOptions[fantasyopenaicompat.Name]
+		require.NotNil(t, raw)
+		options, ok := raw.(*fantasyopenaicompat.ProviderOptions)
+		require.True(t, ok)
+		require.Equal(t, "compat-user", *options.User)
+		require.True(t, *options.ParallelToolCalls)
+		require.NotNil(t, options.ReasoningEffort)
+		require.Equal(t, fantasyopenai.ReasoningEffortMedium, *options.ReasoningEffort)
+		require.EqualValues(t, 2048, *options.MaxCompletionTokens)
+		require.Equal(t, map[string]any{
+			"custom_field": "custom-value",
+		}, options.ExtraBody)
+		require.Equal(t, "cache-key", *options.PromptCacheKey)
+	})
+
+	t.Run("LeavesUnsetOpenAICompatProviderOptionsNil", func(t *testing.T) {
+		t.Parallel()
+
+		providerOptions := chatprovider.ProviderOptionsFromChatModelConfig(
+			nil,
+			&codersdk.ChatModelProviderOptions{
+				OpenAICompat: &codersdk.ChatModelOpenAICompatProviderOptions{},
+			},
+		)
+
+		raw := providerOptions[fantasyopenaicompat.Name]
+		require.NotNil(t, raw)
+		options, ok := raw.(*fantasyopenaicompat.ProviderOptions)
+		require.True(t, ok)
+		require.Nil(t, options.User)
+		require.Nil(t, options.ParallelToolCalls)
+		require.Nil(t, options.ReasoningEffort)
+		require.Nil(t, options.MaxCompletionTokens)
+		require.Nil(t, options.ExtraBody)
+		require.Nil(t, options.PromptCacheKey)
+	})
+}

--- a/coderd/x/chatd/chatprovider/chatprovider_test.go
+++ b/coderd/x/chatd/chatprovider/chatprovider_test.go
@@ -313,6 +313,24 @@ func TestReasoningEffortFromChat(t *testing.T) {
 			want:     ptr.Ref(string(fantasyopenrouter.ReasoningEffortMedium)),
 		},
 		{
+			name:     "OpenRouterNoneEffort",
+			provider: "openrouter",
+			input:    ptr.Ref("none"),
+			want:     ptr.Ref(string(fantasyopenrouter.ReasoningEffortNone)),
+		},
+		{
+			name:     "OpenRouterMinimalEffort",
+			provider: "openrouter",
+			input:    ptr.Ref("minimal"),
+			want:     ptr.Ref(string(fantasyopenrouter.ReasoningEffortMinimal)),
+		},
+		{
+			name:     "OpenRouterXHighEffort",
+			provider: "openrouter",
+			input:    ptr.Ref("xhigh"),
+			want:     ptr.Ref(string(fantasyopenrouter.ReasoningEffortXHigh)),
+		},
+		{
 			name:     "VercelEffort",
 			provider: "vercel",
 			input:    ptr.Ref("xhigh"),
@@ -1514,36 +1532,79 @@ func TestResolveModelWithProviderHint(t *testing.T) {
 func TestMergeMissingProviderOptions_OpenAICompat(t *testing.T) {
 	t.Parallel()
 
-	options := &codersdk.ChatModelProviderOptions{
-		OpenAICompat: &codersdk.ChatModelOpenAICompatProviderOptions{
-			ReasoningEffort: ptr.Ref("low"),
-		},
-	}
-	defaults := &codersdk.ChatModelProviderOptions{
-		OpenAICompat: &codersdk.ChatModelOpenAICompatProviderOptions{
-			User:                ptr.Ref("default-user"),
-			ParallelToolCalls:   ptr.Ref(true),
-			ReasoningEffort:     ptr.Ref("high"),
-			MaxCompletionTokens: ptr.Ref[int64](4096),
-			PromptCacheKey:      ptr.Ref("default-cache-key"),
-			ExtraBody: map[string]any{
-				"default_field": "default-value",
+	t.Run("FillsUnsetFields", func(t *testing.T) {
+		t.Parallel()
+
+		options := &codersdk.ChatModelProviderOptions{
+			OpenAICompat: &codersdk.ChatModelOpenAICompatProviderOptions{
+				ReasoningEffort: ptr.Ref("low"),
 			},
-		},
-	}
+		}
+		defaults := &codersdk.ChatModelProviderOptions{
+			OpenAICompat: &codersdk.ChatModelOpenAICompatProviderOptions{
+				User:                ptr.Ref("default-user"),
+				ParallelToolCalls:   ptr.Ref(true),
+				ReasoningEffort:     ptr.Ref("high"),
+				MaxCompletionTokens: ptr.Ref[int64](4096),
+				PromptCacheKey:      ptr.Ref("default-cache-key"),
+				ExtraBody: map[string]any{
+					"default_field": "default-value",
+				},
+			},
+		}
 
-	chatprovider.MergeMissingProviderOptions(&options, defaults)
+		chatprovider.MergeMissingProviderOptions(&options, defaults)
 
-	require.NotNil(t, options)
-	require.NotNil(t, options.OpenAICompat)
-	require.Equal(t, "default-user", *options.OpenAICompat.User)
-	require.True(t, *options.OpenAICompat.ParallelToolCalls)
-	require.Equal(t, "low", *options.OpenAICompat.ReasoningEffort)
-	require.EqualValues(t, 4096, *options.OpenAICompat.MaxCompletionTokens)
-	require.Equal(t, map[string]any{
-		"default_field": "default-value",
-	}, options.OpenAICompat.ExtraBody)
-	require.Equal(t, "default-cache-key", *options.OpenAICompat.PromptCacheKey)
+		require.NotNil(t, options)
+		require.NotNil(t, options.OpenAICompat)
+		require.Equal(t, "default-user", *options.OpenAICompat.User)
+		require.True(t, *options.OpenAICompat.ParallelToolCalls)
+		require.Equal(t, "low", *options.OpenAICompat.ReasoningEffort)
+		require.EqualValues(t, 4096, *options.OpenAICompat.MaxCompletionTokens)
+		require.Equal(t, map[string]any{
+			"default_field": "default-value",
+		}, options.OpenAICompat.ExtraBody)
+		require.Equal(t, "default-cache-key", *options.OpenAICompat.PromptCacheKey)
+	})
+
+	t.Run("PreservesExplicitFalseParallelToolCalls", func(t *testing.T) {
+		t.Parallel()
+
+		options := &codersdk.ChatModelProviderOptions{
+			OpenAICompat: &codersdk.ChatModelOpenAICompatProviderOptions{
+				ParallelToolCalls: ptr.Ref(false),
+			},
+		}
+		defaults := &codersdk.ChatModelProviderOptions{
+			OpenAICompat: &codersdk.ChatModelOpenAICompatProviderOptions{
+				ParallelToolCalls: ptr.Ref(true),
+			},
+		}
+
+		chatprovider.MergeMissingProviderOptions(&options, defaults)
+
+		require.NotNil(t, options.OpenAICompat.ParallelToolCalls)
+		require.False(t, *options.OpenAICompat.ParallelToolCalls)
+	})
+
+	t.Run("ClonesDefaultExtraBody", func(t *testing.T) {
+		t.Parallel()
+
+		options := &codersdk.ChatModelProviderOptions{}
+		defaults := &codersdk.ChatModelProviderOptions{
+			OpenAICompat: &codersdk.ChatModelOpenAICompatProviderOptions{
+				ExtraBody: map[string]any{
+					"default_field": "default-value",
+				},
+			},
+		}
+
+		chatprovider.MergeMissingProviderOptions(&options, defaults)
+
+		require.NotNil(t, options.OpenAICompat)
+		options.OpenAICompat.ExtraBody["default_field"] = "changed"
+		require.Equal(t, "default-value", defaults.OpenAICompat.ExtraBody["default_field"])
+	})
 }
 
 func TestProviderOptionsFromChatModelConfig_OpenAICompat(t *testing.T) {
@@ -1557,10 +1618,10 @@ func TestProviderOptionsFromChatModelConfig_OpenAICompat(t *testing.T) {
 			&codersdk.ChatModelProviderOptions{
 				OpenAICompat: &codersdk.ChatModelOpenAICompatProviderOptions{
 					User:                ptr.Ref("compat-user"),
-					ParallelToolCalls:   ptr.Ref(true),
+					ParallelToolCalls:   ptr.Ref(false),
 					ReasoningEffort:     ptr.Ref("medium"),
 					MaxCompletionTokens: ptr.Ref[int64](2048),
-					PromptCacheKey:      ptr.Ref("cache-key"),
+					PromptCacheKey:      ptr.Ref(" cache-key "),
 					ExtraBody: map[string]any{
 						"custom_field": "custom-value",
 					},
@@ -1573,7 +1634,7 @@ func TestProviderOptionsFromChatModelConfig_OpenAICompat(t *testing.T) {
 		options, ok := raw.(*fantasyopenaicompat.ProviderOptions)
 		require.True(t, ok)
 		require.Equal(t, "compat-user", *options.User)
-		require.True(t, *options.ParallelToolCalls)
+		require.False(t, *options.ParallelToolCalls)
 		require.NotNil(t, options.ReasoningEffort)
 		require.Equal(t, fantasyopenai.ReasoningEffortMedium, *options.ReasoningEffort)
 		require.EqualValues(t, 2048, *options.MaxCompletionTokens)

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -1258,11 +1258,8 @@ type ChatModelGoogleProviderOptions struct {
 
 // ChatModelOpenAICompatProviderOptions configures OpenAI-compatible behavior.
 //
-// Every field on this struct must be a nilable type (pointer, slice, or map)
-// so JSON omitempty can distinguish an unset field from an explicit zero
-// value. Adding a bare bool, int, or string field would silently lose user
-// intent because false, 0, and "" would be indistinguishable from unset at the
-// SDK boundary and on the wire.
+// Every field must be nilable so omitempty distinguishes unset from zero.
+// A bare bool, int, or string silently equates false, 0, or "" with unset.
 type ChatModelOpenAICompatProviderOptions struct {
 	User                *string        `json:"user,omitempty" description:"Unique identifier for the end user for abuse monitoring" hidden:"true"`
 	ParallelToolCalls   *bool          `json:"parallel_tool_calls,omitempty" description:"Whether the model may make multiple tool calls in parallel"`

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -1257,9 +1257,19 @@ type ChatModelGoogleProviderOptions struct {
 }
 
 // ChatModelOpenAICompatProviderOptions configures OpenAI-compatible behavior.
+//
+// Every field on this struct must be a nilable type (pointer, slice, or map)
+// so JSON omitempty can distinguish an unset field from an explicit zero
+// value. Adding a bare bool, int, or string field would silently lose user
+// intent because false, 0, and "" would be indistinguishable from unset at the
+// SDK boundary and on the wire.
 type ChatModelOpenAICompatProviderOptions struct {
-	User            *string `json:"user,omitempty" description:"Unique identifier for the end user for abuse monitoring" hidden:"true"`
-	ReasoningEffort *string `json:"reasoning_effort,omitempty" description:"Controls the level of reasoning effort" enum:"none,minimal,low,medium,high,xhigh"`
+	User                *string        `json:"user,omitempty" description:"Unique identifier for the end user for abuse monitoring" hidden:"true"`
+	ParallelToolCalls   *bool          `json:"parallel_tool_calls,omitempty" description:"Whether the model may make multiple tool calls in parallel"`
+	ReasoningEffort     *string        `json:"reasoning_effort,omitempty" description:"Controls the level of reasoning effort" enum:"none,minimal,low,medium,high,xhigh"`
+	MaxCompletionTokens *int64         `json:"max_completion_tokens,omitempty" description:"Upper bound on tokens the model may generate"`
+	PromptCacheKey      *string        `json:"prompt_cache_key,omitempty" description:"Key for enabling cross-request prompt caching"`
+	ExtraBody           map[string]any `json:"extra_body,omitempty" description:"Additional fields to include in the request body" hidden:"true"`
 }
 
 // ChatModelReasoningOptions configures reasoning behavior for model

--- a/enterprise/cli/proxyserver_test.go
+++ b/enterprise/cli/proxyserver_test.go
@@ -48,7 +48,7 @@ func Test_ProxyServer_Headers(t *testing.T) {
 		"--access-url", "http://localhost:8080",
 		"--http-address", ":0",
 		"--header", fmt.Sprintf("%s=%s", headerName1, headerVal1),
-		"--header-command", fmt.Sprintf("printf %s=%s", headerName2, headerVal2),
+		"--header-command", fmt.Sprintf("echo %s=%s", headerName2, headerVal2),
 	)
 	pty := ptytest.New(t)
 	inv.Stdout = pty.Output()

--- a/go.mod
+++ b/go.mod
@@ -79,7 +79,7 @@ replace github.com/spf13/afero => github.com/aslilac/afero v0.0.0-20250403163713
 // Forked from coder/fantasy (coder_2_33) which adds:
 // 1) Anthropic computer use + thinking effort
 // 2) Go 1.25 downgrade for Windows CI compat
-// 3) ibetitsmike/fantasy#4 — skip ephemeral replay items when store=false
+// 3) ibetitsmike/fantasy#4, skip ephemeral replay items when store=false
 // 4) (anthropic-sdk-go) dannykopping's appendCompact performance fixes
 // 5) (anthropic-sdk-go) DirectEncoder to eliminate nested MarshalJSON allocation chain
 // 6) Anthropic EffortXHigh constant for Claude Opus 4.7
@@ -90,8 +90,10 @@ replace github.com/spf13/afero => github.com/aslilac/afero v0.0.0-20250403163713
 //    streams close before their terminal events.
 // 9) coder/fantasy#35, preserve Anthropic replay fidelity for signed
 //    reasoning and provider-executed web_search error results.
-// See: https://github.com/coder/fantasy/commits/cfca5fd82c5dd
-replace charm.land/fantasy => github.com/coder/fantasy v0.0.0-20260514123132-cfca5fd82c5d
+// 10) coder/fantasy#34, typed OpenAI-compatible parallel_tool_calls,
+//    max_completion_tokens, prompt_cache_key, and extra_body options.
+// See: https://github.com/coder/fantasy/commits/640407e67c72
+replace charm.land/fantasy => github.com/coder/fantasy v0.0.0-20260601144839-640407e67c72
 
 // coder/coder uses a fork of charmbracelet's fork of the Anthropic Go SDK
 // with performance improvements and Bedrock header cleanup.

--- a/go.sum
+++ b/go.sum
@@ -324,8 +324,8 @@ github.com/coder/bubbletea v1.2.2-0.20241212190825-007a1cdb2c41 h1:SBN/DA63+ZHwu
 github.com/coder/bubbletea v1.2.2-0.20241212190825-007a1cdb2c41/go.mod h1:I9ULxr64UaOSUv7hcb3nX4kowodJCVS7vt7VVJk/kW4=
 github.com/coder/clistat v1.2.1 h1:P9/10njXMyj5cWzIU5wkRsSy5LVQH49+tcGMsAgWX0w=
 github.com/coder/clistat v1.2.1/go.mod h1:m7SC0uj88eEERgvF8Kn6+w6XF21BeSr+15f7GoLAw0A=
-github.com/coder/fantasy v0.0.0-20260514123132-cfca5fd82c5d h1:CS3b2CZUDdHMwwtDoAtZF2/dzZd57yJtSJi3t86pmxE=
-github.com/coder/fantasy v0.0.0-20260514123132-cfca5fd82c5d/go.mod h1:wZ0e3lEPqrM0XiIdAUQLvMKCLYhc3gi96MRX2wjbX44=
+github.com/coder/fantasy v0.0.0-20260601144839-640407e67c72 h1:B/yZ3/j25b9kh0UMZywfPY2Ysxa62rFQTZzVBB6mCnI=
+github.com/coder/fantasy v0.0.0-20260601144839-640407e67c72/go.mod h1:d3BHfn1TWaxcpH1ukH/Hs/u7DSpRyNoTbNXyU4Xig0M=
 github.com/coder/flog v1.1.0 h1:kbAes1ai8fIS5OeV+QAnKBQE22ty1jRF/mcAwHpLBa4=
 github.com/coder/flog v1.1.0/go.mod h1:UQlQvrkJBvnRGo69Le8E24Tcl5SJleAAR7gYEHzAmdQ=
 github.com/coder/go-httpstat v0.0.0-20230801153223-321c88088322 h1:m0lPZjlQ7vdVpRBPKfYIFlmgevoTkBxB10wv6l2gOaU=

--- a/site/src/api/chatModelOptionsGenerated.json
+++ b/site/src/api/chatModelOptionsGenerated.json
@@ -419,6 +419,14 @@
 					"hidden": true
 				},
 				{
+					"json_name": "parallel_tool_calls",
+					"go_name": "ParallelToolCalls",
+					"type": "boolean",
+					"description": "Whether the model may make multiple tool calls in parallel",
+					"required": false,
+					"input_type": "select"
+				},
+				{
 					"json_name": "reasoning_effort",
 					"go_name": "ReasoningEffort",
 					"type": "string",
@@ -426,6 +434,31 @@
 					"required": false,
 					"enum": ["none", "minimal", "low", "medium", "high", "xhigh"],
 					"input_type": "select"
+				},
+				{
+					"json_name": "max_completion_tokens",
+					"go_name": "MaxCompletionTokens",
+					"type": "integer",
+					"description": "Upper bound on tokens the model may generate",
+					"required": false,
+					"input_type": "input"
+				},
+				{
+					"json_name": "prompt_cache_key",
+					"go_name": "PromptCacheKey",
+					"type": "string",
+					"description": "Key for enabling cross-request prompt caching",
+					"required": false,
+					"input_type": "input"
+				},
+				{
+					"json_name": "extra_body",
+					"go_name": "ExtraBody",
+					"type": "object",
+					"description": "Additional fields to include in the request body",
+					"required": false,
+					"input_type": "json",
+					"hidden": true
 				}
 			]
 		},

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2355,10 +2355,21 @@ export interface ChatModelGoogleThinkingConfig {
 // From codersdk/chats.go
 /**
  * ChatModelOpenAICompatProviderOptions configures OpenAI-compatible behavior.
+ *
+ * Every field on this struct must be a nilable type (pointer, slice, or map)
+ * so JSON omitempty can distinguish an unset field from an explicit zero
+ * value. Adding a bare bool, int, or string field would silently lose user
+ * intent because false, 0, and "" would be indistinguishable from unset at the
+ * SDK boundary and on the wire.
  */
 export interface ChatModelOpenAICompatProviderOptions {
 	readonly user?: string;
+	readonly parallel_tool_calls?: boolean;
 	readonly reasoning_effort?: string;
+	readonly max_completion_tokens?: number;
+	readonly prompt_cache_key?: string;
+	// empty interface{} type, falling back to unknown
+	readonly extra_body?: Record<string, unknown>;
 }
 
 // From codersdk/chats.go

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2356,11 +2356,8 @@ export interface ChatModelGoogleThinkingConfig {
 /**
  * ChatModelOpenAICompatProviderOptions configures OpenAI-compatible behavior.
  *
- * Every field on this struct must be a nilable type (pointer, slice, or map)
- * so JSON omitempty can distinguish an unset field from an explicit zero
- * value. Adding a bare bool, int, or string field would silently lose user
- * intent because false, 0, and "" would be indistinguishable from unset at the
- * SDK boundary and on the wire.
+ * Every field must be nilable so omitempty distinguishes unset from zero.
+ * A bare bool, int, or string silently equates false, 0, or "" with unset.
  */
 export interface ChatModelOpenAICompatProviderOptions {
 	readonly user?: string;

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ChatModelAdminPanel.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/ChatModelAdminPanel.stories.tsx
@@ -2030,6 +2030,15 @@ export const ModelFormOpenAICompat: Story = {
 		await expect(
 			await body.findByLabelText(/Reasoning Effort/i),
 		).toBeInTheDocument();
+		await expect(
+			await body.findByLabelText(/Parallel Tool Calls/i),
+		).toBeInTheDocument();
+		await expect(
+			await body.findByLabelText(/Max Completion Tokens/i),
+		).toBeInTheDocument();
+		await expect(
+			await body.findByLabelText(/Prompt Cache Key/i),
+		).toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/modelConfigFormLogic.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/modelConfigFormLogic.test.ts
@@ -357,6 +357,10 @@ describe("extractModelConfigFormState", () => {
 				provider_options: {
 					openaicompat: {
 						reasoning_effort: "low",
+						parallel_tool_calls: true,
+						max_completion_tokens: 1024,
+						prompt_cache_key: "compat-cache-key",
+						extra_body: { custom_field: "custom-value" },
 						user: "compat-user",
 					},
 				},
@@ -365,6 +369,12 @@ describe("extractModelConfigFormState", () => {
 		const result = extractModelConfigFormState(model);
 		const openaicompat = result.openaicompat as Record<string, unknown>;
 		expect(openaicompat.reasoningEffort).toBe("low");
+		expect(openaicompat.parallelToolCalls).toBe("true");
+		expect(openaicompat.maxCompletionTokens).toBe("1024");
+		expect(openaicompat.promptCacheKey).toBe("compat-cache-key");
+		expect(openaicompat.extraBody).toBe(
+			JSON.stringify({ custom_field: "custom-value" }, null, 2),
+		);
 		expect(openaicompat.user).toBe("compat-user");
 	});
 
@@ -902,6 +912,10 @@ describe("buildModelConfigFromForm", () => {
 				formWith({
 					openaicompat: {
 						reasoningEffort: "low",
+						parallelToolCalls: "true",
+						maxCompletionTokens: "2048",
+						promptCacheKey: "compat-cache-key",
+						extraBody: JSON.stringify({ custom_field: "custom-value" }),
 						user: "compat-user",
 					},
 				}),
@@ -909,6 +923,10 @@ describe("buildModelConfigFromForm", () => {
 			expect(result.fieldErrors).toEqual({});
 			expect(result.modelConfig?.provider_options?.openaicompat).toEqual({
 				reasoning_effort: "low",
+				parallel_tool_calls: true,
+				max_completion_tokens: 2048,
+				prompt_cache_key: "compat-cache-key",
+				extra_body: { custom_field: "custom-value" },
 				user: "compat-user",
 			});
 		});
@@ -921,6 +939,23 @@ describe("buildModelConfigFromForm", () => {
 			expect(result.fieldErrors["openaicompat.reasoningEffort"]).toContain(
 				"invalid value",
 			);
+		});
+
+		it("omits blank optional openaicompat fields", () => {
+			const result = buildModelConfigFromForm(
+				"openaicompat",
+				formWith({
+					temperature: "0.5",
+					openaicompat: {
+						parallelToolCalls: "",
+						maxCompletionTokens: " ",
+						promptCacheKey: "   ",
+						extraBody: "   ",
+					},
+				}),
+			);
+			expect(result.fieldErrors).toEqual({});
+			expect(result.modelConfig?.provider_options).toBeUndefined();
 		});
 
 		it("does not set provider_options when all fields empty", () => {

--- a/site/src/pages/AgentsPage/components/ChatModelAdminPanel/modelConfigFormLogic.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatModelAdminPanel/modelConfigFormLogic.test.ts
@@ -931,6 +931,26 @@ describe("buildModelConfigFromForm", () => {
 			});
 		});
 
+		it("reports error when extra body is invalid JSON", () => {
+			const result = buildModelConfigFromForm(
+				"openaicompat",
+				formWith({ openaicompat: { extraBody: "not-json" } }),
+			);
+			expect(result.fieldErrors["openaicompat.extraBody"]).toContain(
+				"must be valid JSON",
+			);
+		});
+
+		it("reports error when extra body JSON is not an object", () => {
+			const result = buildModelConfigFromForm(
+				"openaicompat",
+				formWith({ openaicompat: { extraBody: "[1,2]" } }),
+			);
+			expect(result.fieldErrors["openaicompat.extraBody"]).toContain(
+				"must be a JSON object",
+			);
+		});
+
 		it("reports error for invalid reasoning effort", () => {
 			const result = buildModelConfigFromForm(
 				"openaicompat",

--- a/site/src/pages/AgentsPage/utils/modelOptions.test.ts
+++ b/site/src/pages/AgentsPage/utils/modelOptions.test.ts
@@ -225,6 +225,7 @@ describe("formatProviderLabel", () => {
 	it("formats OpenAI compatible providers", () => {
 		expect(formatProviderLabel("openai-compat")).toBe("OpenAI-compatible");
 		expect(formatProviderLabel("openai-compatible")).toBe("OpenAI-compatible");
+		expect(formatProviderLabel("openaicompat")).toBe("OpenAI-compatible");
 	});
 });
 

--- a/site/src/utils/aiProviders.ts
+++ b/site/src/utils/aiProviders.ts
@@ -14,6 +14,7 @@ export const formatProviderLabel = (provider: string): string => {
 		case "openai-compat":
 		case "openai-compatible":
 		case "openai_compatible":
+		case "openaicompat":
 			return "OpenAI-compatible";
 		case "openrouter":
 			return "OpenRouter";


### PR DESCRIPTION
Adds typed OpenAI-compatible provider options to Coder Agents model settings so admins can configure portable Chat Completions params in the same schema-driven UI used by other providers.

> Mux is working on this on behalf of Mike.

## What changes

New visible OpenAI-compatible provider options:

- `parallel_tool_calls`
- `max_completion_tokens`
- `prompt_cache_key`

New hidden OpenAI-compatible provider option:

- `extra_body`, for additional provider-specific Chat Completions request body fields

Existing OpenAI-compatible options remain available:

- `reasoning_effort`
- hidden `user`

Backend:

- Extend `codersdk.ChatModelOpenAICompatProviderOptions` and forward the new fields through `openAICompatProviderOptionsFromChatConfig` in `coderd/x/chatd/chatprovider`.
- Extend default merging in `MergeMissingProviderOptions`.
- Pass through `reasoning_effort: "none"` in the shared OpenAI reasoning normalizer so the enum, UI, and runtime agree.
- Align OpenRouter reasoning effort normalization with its SDK enum values.
- Normalize `prompt_cache_key` before Fantasy forwarding, clone `extra_body` defaults when merging, and keep explicit `false` `parallel_tool_calls` overrides distinct from unset.
- Document that OpenAI-compatible provider option fields must stay nilable so unset and explicit zero values remain distinct.
- Bump `github.com/coder/fantasy` to the current commit on `coder/fantasy#34`.

CI:

- Install `gotestsum` in `flake-go` before running targeted Go flake checks under the new mise setup.
- Make header command tests use shell-portable `echo` commands so Windows CI no longer depends on Git Bash `printf` being on PATH.
- Run the Windows `Match exec` escape harness from a batch file so it avoids Go command-line quoting differences and keeps testing the SSH config path.
- Resolve PowerShell and cmd.exe by absolute path when generating Windows SSH config `Match exec` commands, avoiding minimal CI PATH issues.
- Document `-NoProfile` and reject helper executable paths that cannot be represented safely in Windows `Match exec` commands.

Frontend:

- Regenerated `site/src/api/chatModelOptionsGenerated.json` from the new struct tags.
- Existing `ModelConfigFields` renders the new visible fields with no provider-specific UI changes.
- Updated the `ModelFormOpenAICompat` Storybook play function to assert each new visible field renders.
- Fixed `formatProviderLabel("openaicompat")` so the canonical schema key resolves to `OpenAI-compatible`.

Tests:

- New OpenAI-compatible merge and provider option forwarding coverage, including explicit `false` and cloned `extra_body` defaults.
- Updated reasoning effort normalization coverage for `none` and OpenRouter enum values.
- Extended `modelConfigFormLogic.test.ts` for serialization, initial values, blank-field omission, and `extra_body` JSON handling, including invalid JSON cases.
- Extended `modelOptions.test.ts` for the label fix.

## Out of scope

Intentionally not included to keep this PR a safe Chat Completions parity slice for OpenAI-compatible. These should be revisited only with explicit need:

- `store`, `service_tier`, `reasoning_summary`, `text_verbosity`.
- OpenAI built-in web search fields (`web_search_enabled`, `search_context_size`, `allowed_domains`).
- Responses-only fields like `include`, `instructions`, `prediction`, `safety_identifier`, `structured_outputs`, `strict_json_schema`.
- Low-level Chat Completions fields like `logit_bias`, `logprobs`, `top_logprobs`, `metadata`.

## Blocked on

- coder/fantasy#34, which adds the typed `parallel_tool_calls`, `max_completion_tokens`, `prompt_cache_key`, and `extra_body` fields on `providers/openaicompat.ProviderOptions` and serializes them in OpenAI-compatible Chat Completions requests. Coder's `go.mod` references the current head commit (`640407e67c72`) of that PR's branch, which is rebased on the current Fantasy `coder_2_33` branch and includes the toolchain and `golang.org/x/net` updates needed for Fantasy govulncheck. Once the PR merges into `coder_2_33`, this PR's `go.mod` should be re-bumped to the post-merge commit.

## Validation

- `make gen`
- `make lint`
- `go test ./coderd/x/chatd/chatopenai/... ./coderd/x/chatd/chatprovider/... -run 'TestReasoningEffortFromChat|TestProviderOptionsFromChatModelConfig_OpenAICompat|TestMergeMissingProviderOptions_OpenAICompat' -count=1`
- `go test ./coderd/x/chatd/chatopenai -run TestReasoningEffortFromChat`
- `go test ./coderd/x/chatd/chatprovider -run 'Test(MergeMissingProviderOptions_OpenAICompat|ProviderOptionsFromChatModelConfig_OpenAICompat)'`
- `pnpm -C site exec vitest run --project=unit src/pages/AgentsPage/components/ChatModelAdminPanel/modelConfigFormLogic.test.ts src/pages/AgentsPage/utils/modelOptions.test.ts`
- `GOOS=windows GOARCH=amd64 go test -c ./cli -o /tmp/cli.test.exe`
- `git diff --check`
- `git commit`, with the configured pre-commit hook enabled and passing







