### PR TITLE
fix(site): show running script count instead of log source count in agent log badge

### DIFF
--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -150,6 +150,9 @@ export const AgentRow: FC<AgentRowProps> = ({
 	const showVSCode = hasVSCodeApp && !browser_only;
 
 	const hasStartupFeatures = Boolean(agent.logs_length);
+	const runningScriptsCount = agent.scripts.filter(
+		(s) => s.run_on_start && !s.status,
+	).length;
 	const healthIssues = getAgentHealthIssues(agent);
 	const hasAgentIssues = healthIssues.length > 0;
 	const hasWarningIssues = healthIssues.some((i) => i.severity === "warning");
@@ -510,7 +513,7 @@ export const AgentRow: FC<AgentRowProps> = ({
 						<ChevronDownIcon open={showLogs} />
 						<span>Logs</span>
 						{agent.lifecycle_state === "starting" &&
-							agent.log_sources.length > 0 &&
+							runningScriptsCount > 0 &&
 							healthIssues.length === 0 && (
 								<Badge
 									variant="default"
@@ -523,7 +526,7 @@ export const AgentRow: FC<AgentRowProps> = ({
 										loading={true}
 										className="text-content-secondary -ml-1"
 									/>
-									<span>{agent.log_sources.length}</span>
+									<span>{runningScriptsCount}</span>
 								</Badge>
 							)}
 						{healthIssues.length > 0 && (


### PR DESCRIPTION
The badge next to the loading spinner in the agent logs section was showing `agent.log_sources.length` (total log sources registered on the agent). This is a static count unrelated to what's actively running.

Now it shows the count of startup scripts still in progress: scripts where `run_on_start` is true and `status` is not yet set. Scripts without a `status` haven't completed; completed scripts receive `"ok"`, `"exit_failure"`, `"timed_out"`, or `"pipes_left_open"`. The badge also hides when zero scripts are running.

> [!NOTE]
> Generated by Coder Agents