### PR TITLE
chore(coderd/x/chatd): instrument PromoteQueued + stream subscriber for ENG-2645

### DIFF
--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -2289,6 +2289,13 @@ func (p *Server) PromoteQueued(
 	p.publishMessage(opts.ChatID, promoted)
 	p.publishStatus(opts.ChatID, updatedChat.Status, updatedChat.WorkerID)
 	p.publishChatPubsubEvent(updatedChat, codersdk.ChatWatchEventKindStatusChange, nil)
+	// Marker for ENG-2645: confirms post-TX publishes ran.
+	p.logger.Debug(ctx, "promote queued completed",
+		slog.F("chat_id", opts.ChatID),
+		slog.F("promoted_id", promoted.ID),
+		slog.F("synthetic_count", len(syntheticResults)),
+		slog.F("status", updatedChat.Status),
+	)
 	p.signalWake()
 
 	return result, nil
@@ -4714,12 +4721,25 @@ func (p *Server) SubscribeAuthorized(
 				}
 				return
 			case notify := <-notifications:
+				// Marker for ENG-2645: subscriber received pubsub notify.
+				p.logger.Debug(mergedCtx, "stream subscriber received notify",
+					slog.F("chat_id", chatID),
+					slog.F("after_message_id", notify.AfterMessageID),
+					slog.F("status", notify.Status),
+					slog.F("queue_update", notify.QueueUpdate),
+					slog.F("last_message_id", lastMessageID),
+				)
 				if notify.AfterMessageID > 0 || notify.FullRefresh {
 					if notify.FullRefresh {
 						lastMessageID = 0
 					}
+					var (
+						deliveredCount int
+						source         string
+					)
 					cached := p.getCachedDurableMessages(chatID, lastMessageID)
 					if !notify.FullRefresh && len(cached) > 0 {
+						source = "cache"
 						for _, event := range cached {
 							select {
 							case <-mergedCtx.Done():
@@ -4728,6 +4748,7 @@ func (p *Server) SubscribeAuthorized(
 							}
 							lastMessageID = event.Message.ID
 						}
+						deliveredCount = len(cached)
 					} else if newMessages, msgErr := p.db.GetChatMessagesByChatID(mergedCtx, database.GetChatMessagesByChatIDParams{
 						ChatID:  chatID,
 						AfterID: lastMessageID,
@@ -4737,6 +4758,7 @@ func (p *Server) SubscribeAuthorized(
 							slog.Error(msgErr),
 						)
 					} else {
+						source = "db"
 						for _, msg := range newMessages {
 							if msg.ID <= lastMessageID {
 								continue
@@ -4752,8 +4774,17 @@ func (p *Server) SubscribeAuthorized(
 							}:
 							}
 							lastMessageID = msg.ID
+							deliveredCount++
 						}
 					}
+					// Marker for ENG-2645: subscriber delivered durable messages.
+					p.logger.Debug(mergedCtx, "stream subscriber delivered messages",
+						slog.F("chat_id", chatID),
+						slog.F("after_message_id", notify.AfterMessageID),
+						slog.F("source", source),
+						slog.F("delivered_count", deliveredCount),
+						slog.F("last_message_id", lastMessageID),
+					)
 				}
 				if notify.Status != "" {
 					status := database.ChatStatus(notify.Status)

--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -9122,8 +9122,10 @@ func TestPromoteQueuedWhileRequiresActionMixedTools(t *testing.T) {
 		select {
 		case ev := <-events:
 			if ev.Type != codersdk.ChatStreamEventTypeMessage || ev.Message == nil {
+				t.Logf("subscriber consumed non-message event type=%s", ev.Type)
 				return false
 			}
+			t.Logf("subscriber consumed message id=%d role=%s match_promoted=%t", ev.Message.ID, ev.Message.Role, ev.Message.ID == promoteResult.PromotedMessage.ID)
 			switch ev.Message.Role {
 			case codersdk.ChatMessageRoleTool:
 				syntheticPublishCount++


### PR DESCRIPTION
Adds three Debug-level log markers in `chatd.go` plus two `t.Logf` markers in the test reader so the next occurrence of ENG-2645 leaves a smoking gun in CI logs:
- End of `PromoteQueued`'s post-TX block: confirms the four pubsub publishes were issued.
- Merge-loop notify case entry: confirms the subscriber received the NOTIFY.
- Merge-loop message delivery: confirms cached or DB-fetched messages reached `mergedEvents`.
- Test `Eventually` reader: confirms what events the test consumed from its channel.

Three occurrences across Windows + Ubuntu CI runners since 2026-05-06. Local repro on the dev workspace has not surfaced it; the markers will produce the smoking gun on the next CI hit. The May 8 Ubuntu log shows all four `PromoteQueued` post-TX publishes reaching `pg_notify`, yet the test still timed out 25s later, so the failure is downstream between the subscriber's pubsub listener and the test's `events` channel reader. The new markers cover that gap.

Debug-level logs cost nothing in production; the test markers run only under `go test`.

Disclosure: Coder Agents generated this change.

Closes https://github.com/coder/internal/issues/1523
