### PR TITLE
refactor(site): inline single-use class string constant in AgentSetupNotice

### DIFF
--- a/site/src/pages/AgentsPage/components/AgentSetupNotice.tsx
+++ b/site/src/pages/AgentsPage/components/AgentSetupNotice.tsx
@@ -92,7 +92,10 @@ const AgentSetupStep: FC<AgentSetupStepProps> = ({
 				)}
 			</span>
 			<span className="text-content-secondary">{label}</span>
-			<Link to={linkTo} className="text-content-link transition-colors hover:text-content-link/80">
+			<Link
+				to={linkTo}
+				className="text-content-link transition-colors hover:text-content-link/80"
+			>
 				{linkText}
 			</Link>
 		</div>

--- a/site/src/pages/AgentsPage/components/AgentSetupNotice.tsx
+++ b/site/src/pages/AgentsPage/components/AgentSetupNotice.tsx
@@ -9,9 +9,6 @@ import {
 	DialogTitle,
 } from "#/components/Dialog/Dialog";
 
-const agentSetupLinkClassName =
-	"text-content-link transition-colors hover:text-content-link/80";
-
 interface AgentSetupNoticeProps {
 	providerCount: number;
 	modelCount: number;
@@ -95,7 +92,7 @@ const AgentSetupStep: FC<AgentSetupStepProps> = ({
 				)}
 			</span>
 			<span className="text-content-secondary">{label}</span>
-			<Link to={linkTo} className={agentSetupLinkClassName}>
+			<Link to={linkTo} className="text-content-link transition-colors hover:text-content-link/80">
 				{linkText}
 			</Link>
 		</div>


### PR DESCRIPTION
Inlines a single-use `agentSetupLinkClassName` string constant directly into the JSX `className` attribute. The constant was only used once in the component, so extracting it added indirection without benefit.