### PR TITLE
fix(site): auto-select all log sources instead of startup script

### DIFF
--- a/site/src/modules/resources/AgentRow.tsx
+++ b/site/src/modules/resources/AgentRow.tsx
@@ -235,14 +235,7 @@ export const AgentRow: FC<AgentRowProps> = ({
 		agent,
 		Boolean(hasDevcontainerErrors || shouldShowWildcardWarning),
 	);
-	const failedStartupScriptSource = hasAgentIssues
-		? agent.log_sources.find(
-				(s) => s.display_name === STARTUP_SCRIPT_DISPLAY_NAME,
-			)
-		: undefined;
-	const [selectedLogTab, setSelectedLogTab] = useState(
-		failedStartupScriptSource?.id ?? "all",
-	);
+	const [selectedLogTab, setSelectedLogTab] = useState("all");
 	const sortedSourceLogTabs = agent.log_sources
 		.filter((logSource) => {
 			// Remove the logSources that have no entries.


### PR DESCRIPTION
If the AgentRow detects there is an agent issue, we pop open the log drawer and select the Startup Script tab. This changes the behavior to auto-select All Logs instead. 