### PR TITLE
feat(agent/agentfiles): reject within-batch duplicate search strings

### DIFF
--- a/agent/agentfiles/files.go
+++ b/agent/agentfiles/files.go
@@ -509,6 +509,17 @@ func (api *API) prepareFileEdit(path string, edits []workspacesdk.FileEdit) (int
 		return http.StatusBadRequest, nil, xerrors.New("must specify at least one edit")
 	}
 
+	// Reject duplicate search strings within a single file's edits
+	// before any I/O or matching runs. This isolates the
+	// "matches N occurrences" signal to actual file-level ambiguity
+	// and removes a known foot-gun where the model emits the same
+	// search snippet across multiple edits in one batch without
+	// setting replace_all.
+	edits, err := dedupeBatchedEdits(edits)
+	if err != nil {
+		return http.StatusBadRequest, nil, xerrors.Errorf("edit %s: %w", path, err)
+	}
+
 	resolved, err := api.resolvePath(path)
 	if err != nil {
 		return http.StatusInternalServerError, nil, xerrors.Errorf("resolve symlink %q: %w", path, err)
@@ -1074,6 +1085,113 @@ func buildReplacementLines(matched, searchLines []string, replace, forcedEnding 
 		_, _ = b.WriteString(ending)
 	}
 	return b.String()
+}
+
+// dedupeBatchedEdits checks for two or more edits in the same
+// batch that carry byte-identical search strings. The duplicates
+// are foot-guns: each edit consumes one match, so the second and
+// later edits either trigger the matcher's "matches N occurrences"
+// (when replace_all is unset, the common case observed in
+// CODAGT-312) or a "search string not found" once the earlier
+// edit has already consumed every match.
+//
+// Behavior:
+//
+//   - When every edit in a duplicate group has replace_all=true and
+//     identical replace text, the group is collapsed to one edit:
+//     the duplicates are redundant and harmless.
+//   - Otherwise the request is rejected with an error that names
+//     the offending indices and a short head of the search string
+//     so the caller can locate the duplicate group quickly.
+func dedupeBatchedEdits(edits []workspacesdk.FileEdit) ([]workspacesdk.FileEdit, error) {
+	if len(edits) < 2 {
+		return edits, nil
+	}
+
+	// Group edit indices by search string while preserving input
+	// order. We only care about searches that occur more than once;
+	// keep the index list per group to populate the error message.
+	type group struct {
+		indices []int
+	}
+	groups := make(map[string]*group, len(edits))
+	order := make([]string, 0, len(edits))
+	for i, e := range edits {
+		g, ok := groups[e.Search]
+		if !ok {
+			g = &group{}
+			groups[e.Search] = g
+			order = append(order, e.Search)
+		}
+		g.indices = append(g.indices, i)
+	}
+
+	// Walk groups in first-seen order so the rejection error is
+	// stable across runs.
+	drop := make(map[int]bool)
+	for _, search := range order {
+		g := groups[search]
+		if len(g.indices) < 2 {
+			continue
+		}
+		first := edits[g.indices[0]]
+		collapsible := first.ReplaceAll
+		if collapsible {
+			for _, idx := range g.indices[1:] {
+				e := edits[idx]
+				if !e.ReplaceAll || e.Replace != first.Replace {
+					collapsible = false
+					break
+				}
+			}
+		}
+		if collapsible {
+			for _, idx := range g.indices[1:] {
+				drop[idx] = true
+			}
+			continue
+		}
+		return nil, xerrors.Errorf("edits %s share an identical search string %s; "+
+			"combine them into one edit with replace_all=true, or include "+
+			"surrounding context to make each search unique",
+			formatEditIndices(g.indices), formatSearchHead(search))
+	}
+
+	if len(drop) == 0 {
+		return edits, nil
+	}
+	out := make([]workspacesdk.FileEdit, 0, len(edits)-len(drop))
+	for i, e := range edits {
+		if drop[i] {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out, nil
+}
+
+// formatEditIndices renders a list of edit indices for the duplicate
+// search error, e.g. "0, 2, 4".
+func formatEditIndices(indices []int) string {
+	parts := make([]string, len(indices))
+	for i, idx := range indices {
+		parts[i] = strconv.Itoa(idx)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// formatSearchHead returns a Go-quoted prefix of the search string,
+// truncated so the error message stays readable for large multi-line
+// snippets. The truncation is byte-based since search strings are
+// matched byte-for-byte; truncating at a UTF-8 continuation byte is
+// fine because the result is fed through %q which escapes the
+// trailing partial rune.
+func formatSearchHead(search string) string {
+	const maxHead = 40
+	if len(search) <= maxHead {
+		return fmt.Sprintf("%q", search)
+	}
+	return fmt.Sprintf("%q...", search[:maxHead])
 }
 
 // fuzzyReplace attempts to find `search` inside `content` and replace it

--- a/agent/agentfiles/files_test.go
+++ b/agent/agentfiles/files_test.go
@@ -2716,6 +2716,251 @@ func TestEditFiles_DuplicatePath_SymlinkAliasRejects(t *testing.T) {
 	require.Equal(t, original, string(data))
 }
 
+// TestEditFiles_BatchDuplicateSearch_Rejects pins that two edits in
+// the same file with byte-identical search strings are rejected by
+// the per-file pre-flight check, before the matcher runs. The error
+// names both edit indices so the caller can locate the duplicate
+// group quickly.
+//
+// This is the cause of two doctrine-forming chats observed in
+// CODAGT-312 (df422652, f5a6afa5): the model emitted the same search
+// snippet across multiple edits in one batch without setting
+// replace_all, and the original "matches N occurrences" message did
+// not signal that the duplicate was within the batch itself.
+func TestEditFiles_BatchDuplicateSearch_Rejects(t *testing.T) {
+	t.Parallel()
+
+	tmpdir := os.TempDir()
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	fs := afero.NewMemMapFs()
+	api := agentfiles.NewAPI(logger, fs, nil)
+	path := filepath.Join(tmpdir, "batch-dup-search")
+	original := "alpha\nbeta\ngamma\n"
+	require.NoError(t, afero.WriteFile(fs, path, []byte(original), 0o644))
+
+	req := workspacesdk.FileEditRequest{
+		Files: []workspacesdk.FileEdits{
+			{Path: path, Edits: []workspacesdk.FileEdit{
+				{Search: "alpha", Replace: "ALPHA"},
+				{Search: "alpha", Replace: "AAA"},
+			}},
+		},
+	}
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	buf := bytes.NewBuffer(nil)
+	enc := json.NewEncoder(buf)
+	enc.SetEscapeHTML(false)
+	require.NoError(t, enc.Encode(req))
+	w := httptest.NewRecorder()
+	r := httptest.NewRequestWithContext(ctx, http.MethodPost, "/edit-files", buf)
+	api.Routes().ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusBadRequest, w.Code, "body: %s", w.Body.String())
+	got := &codersdk.Error{}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(got))
+	// The error must name both offending edit indices and quote the
+	// shared search string so the caller can find the duplicate.
+	require.ErrorContains(t, got, "edits 0, 1")
+	require.ErrorContains(t, got, "share an identical search string")
+	require.ErrorContains(t, got, `"alpha"`)
+	require.ErrorContains(t, got, "replace_all=true")
+
+	// File on disk must be untouched: pre-flight runs before any
+	// write, and the duplicate group prevents any edit from
+	// applying.
+	data, err := afero.ReadFile(fs, path)
+	require.NoError(t, err)
+	require.Equal(t, original, string(data))
+}
+
+// TestEditFiles_BatchDuplicateSearch_NamesAllIndices pins that the
+// pre-flight error lists every edit index in the duplicate group, in
+// input order, even when the duplicates are not contiguous.
+func TestEditFiles_BatchDuplicateSearch_NamesAllIndices(t *testing.T) {
+	t.Parallel()
+
+	tmpdir := os.TempDir()
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	fs := afero.NewMemMapFs()
+	api := agentfiles.NewAPI(logger, fs, nil)
+	path := filepath.Join(tmpdir, "batch-dup-three")
+	original := "alpha\nbeta\ngamma\ndelta\n"
+	require.NoError(t, afero.WriteFile(fs, path, []byte(original), 0o644))
+
+	// Edits 0, 2, 4 share "alpha"; edits 1, 3 are interleaved with
+	// distinct searches so the index list must explicitly name 0, 2,
+	// 4 and skip 1, 3.
+	req := workspacesdk.FileEditRequest{
+		Files: []workspacesdk.FileEdits{
+			{Path: path, Edits: []workspacesdk.FileEdit{
+				{Search: "alpha", Replace: "A0"},
+				{Search: "beta", Replace: "B"},
+				{Search: "alpha", Replace: "A2"},
+				{Search: "gamma", Replace: "G"},
+				{Search: "alpha", Replace: "A4"},
+			}},
+		},
+	}
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	buf := bytes.NewBuffer(nil)
+	enc := json.NewEncoder(buf)
+	enc.SetEscapeHTML(false)
+	require.NoError(t, enc.Encode(req))
+	w := httptest.NewRecorder()
+	r := httptest.NewRequestWithContext(ctx, http.MethodPost, "/edit-files", buf)
+	api.Routes().ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusBadRequest, w.Code, "body: %s", w.Body.String())
+	got := &codersdk.Error{}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(got))
+	require.ErrorContains(t, got, "edits 0, 2, 4")
+}
+
+// TestEditFiles_FileLevelDuplicateMatch_PreservesMatcherMessage pins
+// that a single edit whose search appears multiple times in the file
+// (not duplicated within the batch) still falls through to the
+// existing matcher message. The pre-flight check must not eclipse
+// the file-level ambiguity error: the call site is what tells the
+// caller whether to disambiguate via context or collapse duplicate
+// edits.
+func TestEditFiles_FileLevelDuplicateMatch_PreservesMatcherMessage(t *testing.T) {
+	t.Parallel()
+
+	tmpdir := os.TempDir()
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	fs := afero.NewMemMapFs()
+	api := agentfiles.NewAPI(logger, fs, nil)
+	path := filepath.Join(tmpdir, "file-level-dup")
+	original := "foo bar foo baz foo"
+	require.NoError(t, afero.WriteFile(fs, path, []byte(original), 0o644))
+
+	req := workspacesdk.FileEditRequest{
+		Files: []workspacesdk.FileEdits{
+			{Path: path, Edits: []workspacesdk.FileEdit{
+				{Search: "foo", Replace: "qux"},
+			}},
+		},
+	}
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	buf := bytes.NewBuffer(nil)
+	enc := json.NewEncoder(buf)
+	enc.SetEscapeHTML(false)
+	require.NoError(t, enc.Encode(req))
+	w := httptest.NewRecorder()
+	r := httptest.NewRequestWithContext(ctx, http.MethodPost, "/edit-files", buf)
+	api.Routes().ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusBadRequest, w.Code, "body: %s", w.Body.String())
+	got := &codersdk.Error{}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(got))
+	// The existing matcher message must be returned unchanged so the
+	// caller still gets the same disambiguation hint for file-level
+	// duplicates.
+	require.ErrorContains(t, got, "matches 3 occurrences")
+	require.ErrorContains(t, got, "set replace_all to true")
+	// And the new pre-flight wording must NOT leak into this case.
+	require.NotContains(t, got.Message, "share an identical search string")
+
+	data, err := afero.ReadFile(fs, path)
+	require.NoError(t, err)
+	require.Equal(t, original, string(data))
+}
+
+// TestEditFiles_BatchDuplicateSearch_ReplaceAllIdenticalAccepted pins
+// the "redundant but harmless" exception: two edits in the same
+// batch with byte-identical search and replace AND replace_all=true
+// are accepted. The duplicates collapse to a single logical edit at
+// pre-flight, so the matcher sees one replace_all=true edit and
+// rewrites every occurrence of the search.
+//
+// This sub-decision (collapse the redundant copies in pre-flight
+// rather than letting both run through the matcher, which today
+// would reject the second with "search string not found" once the
+// first has consumed every match) is documented in the
+// dedupeBatchedEdits helper.
+func TestEditFiles_BatchDuplicateSearch_ReplaceAllIdenticalAccepted(t *testing.T) {
+	t.Parallel()
+
+	tmpdir := os.TempDir()
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	fs := afero.NewMemMapFs()
+	api := agentfiles.NewAPI(logger, fs, nil)
+	path := filepath.Join(tmpdir, "batch-dup-ra")
+	original := "hello hello world\n"
+	require.NoError(t, afero.WriteFile(fs, path, []byte(original), 0o644))
+
+	req := workspacesdk.FileEditRequest{
+		Files: []workspacesdk.FileEdits{
+			{Path: path, Edits: []workspacesdk.FileEdit{
+				{Search: "hello", Replace: "hi", ReplaceAll: true},
+				{Search: "hello", Replace: "hi", ReplaceAll: true},
+			}},
+		},
+	}
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	buf := bytes.NewBuffer(nil)
+	enc := json.NewEncoder(buf)
+	enc.SetEscapeHTML(false)
+	require.NoError(t, enc.Encode(req))
+	w := httptest.NewRecorder()
+	r := httptest.NewRequestWithContext(ctx, http.MethodPost, "/edit-files", buf)
+	api.Routes().ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	data, err := afero.ReadFile(fs, path)
+	require.NoError(t, err)
+	require.Equal(t, "hi hi world\n", string(data))
+}
+
+// TestEditFiles_BatchDuplicateSearch_ReplaceAllDifferentReplaceRejects
+// pins that two edits with the same search and replace_all=true but
+// DIFFERENT replace text are rejected. Collapsing them would silently
+// pick one replace and discard the other, so this case must surface
+// the conflict to the caller.
+func TestEditFiles_BatchDuplicateSearch_ReplaceAllDifferentReplaceRejects(t *testing.T) {
+	t.Parallel()
+
+	tmpdir := os.TempDir()
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	fs := afero.NewMemMapFs()
+	api := agentfiles.NewAPI(logger, fs, nil)
+	path := filepath.Join(tmpdir, "batch-dup-ra-conflict")
+	original := "hello hello world\n"
+	require.NoError(t, afero.WriteFile(fs, path, []byte(original), 0o644))
+
+	req := workspacesdk.FileEditRequest{
+		Files: []workspacesdk.FileEdits{
+			{Path: path, Edits: []workspacesdk.FileEdit{
+				{Search: "hello", Replace: "hi", ReplaceAll: true},
+				{Search: "hello", Replace: "howdy", ReplaceAll: true},
+			}},
+		},
+	}
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	buf := bytes.NewBuffer(nil)
+	enc := json.NewEncoder(buf)
+	enc.SetEscapeHTML(false)
+	require.NoError(t, enc.Encode(req))
+	w := httptest.NewRecorder()
+	r := httptest.NewRequestWithContext(ctx, http.MethodPost, "/edit-files", buf)
+	api.Routes().ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusBadRequest, w.Code, "body: %s", w.Body.String())
+	got := &codersdk.Error{}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(got))
+	require.ErrorContains(t, got, "edits 0, 1")
+	require.ErrorContains(t, got, "share an identical search string")
+
+	data, err := afero.ReadFile(fs, path)
+	require.NoError(t, err)
+	require.Equal(t, original, string(data))
+}
+
 // TestEditFiles_ReplaceAll_FuzzyIndentGap locks the CURRENT output
 // of a known foot-gun, it doesn't bless it.
 //


### PR DESCRIPTION
Reject `edit_files` calls where multiple edits in one file share a byte-identical `search` string without all of them setting `replace_all=true` with the same `replace`. Errors return the offending edit indices and a short head of the search string.

When every edit in a duplicate group has `replace_all=true` and an identical `replace`, the duplicates collapse to a single edit instead of failing.

## Why

This is a real foot-gun observed in the [CODAGT-312](https://linear.app/codercom/issue/CODAGT-312) investigation. Two chats over the 60-day baseline produced the prescriptive `python > edit_files` doctrine because of within-batch search-string duplication:

- `df422652` (Implement backend computer-use gating): 18 edits across 8 files; three edits in one file shared a 96-byte test-setup snippet. The matcher returned `matches 3 occurrences (expected exactly 1)`. The model interpreted that as a tool quirk and pivoted to Python.
- `f5a6afa5` (rename chat feature): one 140-byte search snippet appeared verbatim in 3 different `args` objects in a Storybook stories file.

The existing `matches N occurrences` error is correct, but it doesn't tell the agent that the duplication is in the batch, not in the file. This pre-flight check surfaces that earlier with a more actionable message.

## How

Adds a per-file pre-flight pass in `prepareFileEdit` that groups edits by search string and either rejects the batch or collapses fully-redundant `replace_all=true` duplicates. Pre-flight runs before any I/O.

## Tests

Five new test cases in `agent/agentfiles/files_test.go` covering rejection, index naming for non-contiguous duplicates, regression for the existing matcher message, the accept-via-collapse path, and the conflict path (`replace_all=true` with different replaces).

## Out of scope

- The two post-fail diagnostic hints (inversion + miscount) are CODAGT-330 and live in a separate PR.
- Renaming `search`/`replace` was discussed and rejected in [CODAGT-327](https://linear.app/codercom/issue/CODAGT-327).

<details>
<summary>CODAGT-312 context</summary>

This is one of three diagnostic-feedback fixes in the [CODAGT-327](https://linear.app/codercom/issue/CODAGT-327) epic, which followed up on the [CODAGT-312](https://linear.app/codercom/issue/CODAGT-312) investigation. The investigation found a recurring chain in which one `edit_files` failure leads the agent to misdiagnose the cause, pivot to Python, and let compaction crystallize the pivot into a forward-looking rule that propagates across model swaps.

The data and falsifier metric for this fix live on the Grafana dashboard at https://grafana.dev.coder.com/d/codagt-312-edit-files (panel "edit_files failures by class"). After this lands, `non_unique_match` count over a 60-day window should fall.
</details>

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻
