### PR TITLE
feat(agent/agentfiles): add post-fail diagnostic hints for edit_files

### DIFF
--- a/agent/agentfiles/files.go
+++ b/agent/agentfiles/files.go
@@ -1226,8 +1226,7 @@ func inversionHint(
 	replaceLines []string,
 	trimRight, trimAll func(a, b string) bool,
 ) string {
-	const minInversionBytes = 20
-	if len(replace) < minInversionBytes || len(replaceLines) == 0 {
+	if len(replaceLines) == 0 {
 		return ""
 	}
 

--- a/agent/agentfiles/files.go
+++ b/agent/agentfiles/files.go
@@ -1196,9 +1196,234 @@ func fuzzyReplace(content string, edit workspacesdk.FileEdit) (string, error) {
 		return result, err
 	}
 
-	return "", xerrors.New("search string not found in file. Verify the search " +
+	// All passes missed. Run cheap diagnostic scans on the failure
+	// path only: a single failed call eats their cost. The base
+	// error stays the leading sentence so existing log scrapers keep
+	// matching it.
+	msg := "search string not found in file. Verify the search " +
 		"string matches the file content exactly, including whitespace " +
-		"and indentation")
+		"and indentation"
+	if hint := inversionHint(contentLines, replace, replaceLines, trimRight, trimAll); hint != "" {
+		msg += ". " + hint
+	}
+	if hint := miscountHint(contentLines, searchLines); hint != "" {
+		msg += ". " + hint
+	}
+	return "", xerrors.New(msg)
+}
+
+// inversionHint detects the case where the caller swapped `search`
+// and `replace`: `search` did not match anywhere in the file, but
+// `replace` does. The hint suggests the swap so the agent can retry
+// without fabricating a tool quirk to explain the failure.
+//
+// Suppression rules:
+//   - replace shorter than minInversionBytes is too generic to
+//     be informative; common short strings like "return nil" would
+//     match incidentally. The threshold is small and meant to be
+//     easy to tune at code-review time.
+//   - replace matching at more than maxInversionAnchors locations
+//     is also too generic to point at "the" anchor.
+//
+// The cascade reuses the matcher's pass 1/2/3 equivalents to avoid
+// inventing a separate similarity heuristic. The first pass that
+// finds matches wins; we report at most maxInversionAnchors hits.
+func inversionHint(
+	contentLines []string,
+	replace string,
+	replaceLines []string,
+	trimRight, trimAll func(a, b string) bool,
+) string {
+	const (
+		minInversionBytes   = 20
+		maxInversionAnchors = 5
+	)
+	if len(replace) < minInversionBytes {
+		return ""
+	}
+	if len(replaceLines) == 0 {
+		return ""
+	}
+
+	// Pass 1: exact substring. Resolve to a 1-based line number by
+	// counting newlines before the byte offset.
+	joined := stringsJoin(contentLines)
+	if idx := strings.Index(joined, replace); idx >= 0 {
+		count := strings.Count(joined, replace)
+		if count > maxInversionAnchors {
+			return ""
+		}
+		if count == 1 {
+			line := 1 + strings.Count(joined[:idx], "\n")
+			return fmt.Sprintf(
+				"your %q string was not found, but the %q string appears at line %d. Did you swap %q and %q?",
+				"search", "replace", line, "search", "replace",
+			)
+		}
+		// More than one but within the cap: don't pick an arbitrary
+		// anchor. Fall through to line-based scans, which often
+		// disambiguate via blank-line context.
+	}
+
+	// Passes 2 and 3: line-equivalent matching, mirroring the
+	// matcher's own cascade.
+	for _, eq := range []func(a, b string) bool{trimRight, trimAll} {
+		var starts []int
+		if len(replaceLines) > len(contentLines) {
+			continue
+		}
+	outer:
+		for i := 0; i <= len(contentLines)-len(replaceLines); i++ {
+			for j, rLine := range replaceLines {
+				if !eq(contentLines[i+j], rLine) {
+					continue outer
+				}
+			}
+			starts = append(starts, i)
+			if len(starts) > maxInversionAnchors {
+				// Too generic; bail.
+				return ""
+			}
+		}
+		if len(starts) == 1 {
+			return fmt.Sprintf(
+				"your %q string was not found, but the %q string appears at line %d. Did you swap %q and %q?",
+				"search", "replace", starts[0]+1, "search", "replace",
+			)
+		}
+	}
+	return ""
+}
+
+// stringsJoin concatenates lines back into the original buffer.
+// strings.SplitAfter preserves each line's terminator, so a plain
+// Join with "" reconstructs content verbatim.
+func stringsJoin(lines []string) string {
+	var b strings.Builder
+	for _, l := range lines {
+		_, _ = b.WriteString(l)
+	}
+	return b.String()
+}
+
+// miscountHint detects the case where a search line and a content
+// line agree on every rune except for the count of one repeated
+// character. The shape comes from agents reconstructing decorative
+// runs (box-drawing dashes, ASCII separators) by eye and miscounting
+// the run length. Naming the codepoint and both counts lets the
+// agent fix the run instead of misattributing the failure to a
+// general "Unicode breaks edit_files" rule.
+//
+// Suppression rules:
+//   - At least one of the runs must be of length >= 2; a single
+//     extra character is more often a typo than a miscount.
+//   - Exactly one content line must qualify for a given search
+//     line; multiple candidates make the hint speculative.
+//
+// The diffCount==1 condition (every other rune class has identical
+// counts in both lines) already enforces the ticket's "shares >=80%
+// of search-line bytes (modulo the repeated character)" guidance
+// at 100%. A separate 80% overlap threshold would only matter if
+// we relaxed diffCount, which the observed failure data does not
+// require.
+//
+// Returns the hint for the first qualifying search line. Returns
+// "" when no search line produces a unique miscount candidate.
+func miscountHint(contentLines, searchLines []string) string {
+	for _, sLine := range searchLines {
+		sContent, _ := splitEnding(sLine)
+		if strings.TrimSpace(sContent) == "" {
+			continue
+		}
+		type hit struct {
+			line   int
+			rune   rune
+			sCount int
+			cCount int
+		}
+		var hits []hit
+		for i, cLine := range contentLines {
+			cContent, _ := splitEnding(cLine)
+			r, sc, cc, ok := singleRuneCountMismatch(sContent, cContent)
+			if !ok {
+				continue
+			}
+			hits = append(hits, hit{line: i + 1, rune: r, sCount: sc, cCount: cc})
+			if len(hits) > 1 {
+				break
+			}
+		}
+		if len(hits) != 1 {
+			continue
+		}
+		h := hits[0]
+		return fmt.Sprintf(
+			"your search has %d %q (U+%04X); the closest match at line %d has %d. Adjust the run length",
+			h.sCount, string(h.rune), h.rune, h.line, h.cCount,
+		)
+	}
+	return ""
+}
+
+// singleRuneCountMismatch reports whether two strings agree on every
+// rune except for the count of exactly one rune. Returns the
+// disagreeing rune, its counts in s and c, and whether the line
+// shape qualifies. Qualification requires:
+//
+//   - exactly one rune class has a nonzero count delta;
+//   - at least one of the two counts is >= 2 (a true repeat).
+//
+// The frequency-vector approach is sufficient for the observed
+// failure shapes: the search and the file line have the same
+// non-r rune multiset, with the disagreeing rune appearing at
+// different counts. A positional Levenshtein check could be added
+// if false positives prove a problem in practice.
+func singleRuneCountMismatch(s, c string) (r rune, sCount, cCount int, ok bool) {
+	if s == "" || c == "" {
+		return 0, 0, 0, false
+	}
+	sFreq := runeFrequency(s)
+	cFreq := runeFrequency(c)
+	var (
+		diffRune  rune
+		diffCount int
+		sc        int
+		cc        int
+	)
+	for r, scv := range sFreq {
+		ccv := cFreq[r]
+		if scv != ccv {
+			diffCount++
+			diffRune = r
+			sc = scv
+			cc = ccv
+		}
+	}
+	for r, ccv := range cFreq {
+		if _, ok := sFreq[r]; ok {
+			continue
+		}
+		diffCount++
+		diffRune = r
+		sc = 0
+		cc = ccv
+	}
+	if diffCount != 1 {
+		return 0, 0, 0, false
+	}
+	if sc < 2 && cc < 2 {
+		return 0, 0, 0, false
+	}
+	return diffRune, sc, cc, true
+}
+
+// runeFrequency returns a map from rune to occurrence count in s.
+func runeFrequency(s string) map[rune]int {
+	freq := make(map[rune]int)
+	for _, r := range s {
+		freq[r]++
+	}
+	return freq
 }
 
 // seekLines scans contentLines looking for a contiguous subsequence that matches

--- a/agent/agentfiles/files.go
+++ b/agent/agentfiles/files.go
@@ -1248,8 +1248,9 @@ func inversionHint(
 }
 
 // substringMatchLines returns the 1-based line numbers where needle
-// occurs in content as a byte-for-byte substring. Repeat occurrences
-// on the same line collapse to a single line number.
+// occurs in content as a byte-for-byte substring, including
+// overlapping starts. Repeat occurrences on the same line collapse
+// to a single line number.
 func substringMatchLines(content, needle string) []int {
 	if needle == "" {
 		return nil
@@ -1267,7 +1268,10 @@ func substringMatchLines(content, needle string) []int {
 			seen[line] = struct{}{}
 			lines = append(lines, line)
 		}
-		offset = idx + len(needle)
+		// Advance by one byte so self-overlapping needles (e.g.
+		// "A\nB\nA\n" inside "A\nB\nA\nB\nA\n") still report
+		// every distinct starting line.
+		offset = idx + 1
 		if offset > len(content) {
 			break
 		}
@@ -1312,8 +1316,9 @@ func formatLineList(lines []int) string {
 }
 
 // miscountHint detects search lines that match a file line except for
-// the count of one repeated rune. Emits one hint per such search line,
-// capped at maxMiscountHints total with " and N more" suffix.
+// the count of one repeated rune. Emits one hint per
+// (search-line, disagreeing-rune) group, capped at maxMiscountHints
+// total with " and N more" suffix.
 func miscountHint(contentLines, searchLines []string) string {
 	const maxMiscountHints = 3
 	var hints []string

--- a/agent/agentfiles/files.go
+++ b/agent/agentfiles/files.go
@@ -1199,14 +1199,23 @@ func fuzzyReplace(content string, edit workspacesdk.FileEdit) (string, error) {
 	msg := "search string not found in file. Verify the search " +
 		"string matches the file content exactly, including whitespace " +
 		"and indentation"
-	if hint := inversionHint(content, contentLines, replace, replaceLines, trimRight, trimAll); hint != "" {
-		msg += ". " + hint
-	}
+	// miscount takes precedence: a near-match means the search is the
+	// model's typo'd new text, not a swapped field. Emitting both can
+	// trick an agent into following the inversion hint and corrupting
+	// an unrelated line where the replace string coincidentally
+	// occurs.
 	if hint := miscountHint(contentLines, searchLines); hint != "" {
+		msg += ". " + hint
+	} else if hint := inversionHint(content, contentLines, replace, replaceLines, trimRight, trimAll); hint != "" {
 		msg += ". " + hint
 	}
 	return "", xerrors.New(msg)
 }
+
+// maxHintLines caps the number of line numbers (inversion) or
+// candidate file lines (per miscount) listed in a single hint before
+// truncation with " and N more".
+const maxHintLines = 5
 
 // inversionHint detects the case where the caller swapped `search`
 // and `replace`: search did not match but replace appears in the file.
@@ -1239,16 +1248,25 @@ func inversionHint(
 }
 
 // substringMatchLines returns the 1-based line numbers where needle
-// occurs in content as a byte-for-byte substring.
+// occurs in content as a byte-for-byte substring. Repeat occurrences
+// on the same line collapse to a single line number.
 func substringMatchLines(content, needle string) []int {
+	if needle == "" {
+		return nil
+	}
 	var lines []int
+	seen := make(map[int]struct{})
 	for offset := 0; ; {
 		rel := strings.Index(content[offset:], needle)
 		if rel < 0 {
 			break
 		}
 		idx := offset + rel
-		lines = append(lines, 1+strings.Count(content[:idx], "\n"))
+		line := 1 + strings.Count(content[:idx], "\n")
+		if _, dup := seen[line]; !dup {
+			seen[line] = struct{}{}
+			lines = append(lines, line)
+		}
 		offset = idx + len(needle)
 		if offset > len(content) {
 			break
@@ -1279,12 +1297,8 @@ outer:
 // formatLineList renders a sorted line list as "12, 47, 89", truncated
 // to maxHintLines entries with " and N more" when more exist.
 func formatLineList(lines []int) string {
-	const maxHintLines = 5
 	var b strings.Builder
-	shown := len(lines)
-	if shown > maxHintLines {
-		shown = maxHintLines
-	}
+	shown := min(len(lines), maxHintLines)
 	for i := 0; i < shown; i++ {
 		if i > 0 {
 			_, _ = b.WriteString(", ")
@@ -1298,9 +1312,12 @@ func formatLineList(lines []int) string {
 }
 
 // miscountHint detects search lines that match a file line except for
-// the count of one repeated rune. Emits one hint per such search line.
+// the count of one repeated rune. Emits one hint per such search line,
+// capped at maxMiscountHints total with " and N more" suffix.
 func miscountHint(contentLines, searchLines []string) string {
+	const maxMiscountHints = 3
 	var hints []string
+	extra := 0
 	for _, sLine := range searchLines {
 		sContent, _ := splitEnding(sLine)
 		if strings.TrimSpace(sContent) == "" {
@@ -1325,21 +1342,24 @@ func miscountHint(contentLines, searchLines []string) string {
 			groups[r] = append(groups[r], candidate{line: i + 1, cCount: cc})
 		}
 		for _, r := range order {
+			if len(hints) >= maxMiscountHints {
+				extra++
+				continue
+			}
 			hints = append(hints, formatMiscount(counts[r], r, groups[r]))
 		}
+	}
+	if extra > 0 {
+		hints = append(hints, fmt.Sprintf("and %d more", extra))
 	}
 	return strings.Join(hints, ". ")
 }
 
 // formatMiscount renders one miscount candidate group.
 func formatMiscount(sCount int, r rune, cands []candidate) string {
-	const maxHintLines = 5
 	var b strings.Builder
 	_, _ = fmt.Fprintf(&b, "Your search has %d %q (U+%04X); the file has ", sCount, string(r), r)
-	shown := len(cands)
-	if shown > maxHintLines {
-		shown = maxHintLines
-	}
+	shown := min(len(cands), maxHintLines)
 	for i := 0; i < shown; i++ {
 		if i > 0 {
 			_, _ = b.WriteString(", ")
@@ -1352,7 +1372,8 @@ func formatMiscount(sCount int, r rune, cands []candidate) string {
 	return b.String()
 }
 
-// candidate is the file-line count of the disagreeing rune.
+// candidate records a file line where one rune's count disagrees with
+// the search.
 type candidate struct {
 	line   int
 	cCount int
@@ -1400,6 +1421,7 @@ func singleRuneCountMismatch(s, c string) (r rune, sCount, cCount int, ok bool) 
 	return diffRune, sc, cc, true
 }
 
+// runeFrequency returns the count of each rune in s.
 func runeFrequency(s string) map[rune]int {
 	freq := make(map[rune]int)
 	for _, r := range s {

--- a/agent/agentfiles/files.go
+++ b/agent/agentfiles/files.go
@@ -1196,14 +1196,10 @@ func fuzzyReplace(content string, edit workspacesdk.FileEdit) (string, error) {
 		return result, err
 	}
 
-	// All passes missed. Run cheap diagnostic scans on the failure
-	// path only: a single failed call eats their cost. The base
-	// error stays the leading sentence so existing log scrapers keep
-	// matching it.
 	msg := "search string not found in file. Verify the search " +
 		"string matches the file content exactly, including whitespace " +
 		"and indentation"
-	if hint := inversionHint(contentLines, replace, replaceLines, trimRight, trimAll); hint != "" {
+	if hint := inversionHint(content, contentLines, replace, replaceLines, trimRight, trimAll); hint != "" {
 		msg += ". " + hint
 	}
 	if hint := miscountHint(contentLines, searchLines); hint != "" {
@@ -1213,171 +1209,158 @@ func fuzzyReplace(content string, edit workspacesdk.FileEdit) (string, error) {
 }
 
 // inversionHint detects the case where the caller swapped `search`
-// and `replace`: `search` did not match anywhere in the file, but
-// `replace` does. The hint suggests the swap so the agent can retry
-// without fabricating a tool quirk to explain the failure.
-//
-// Suppression rules:
-//   - replace shorter than minInversionBytes is too generic to
-//     be informative; common short strings like "return nil" would
-//     match incidentally. The threshold is small and meant to be
-//     easy to tune at code-review time.
-//   - replace matching at more than maxInversionAnchors locations
-//     is also too generic to point at "the" anchor.
-//
-// The cascade reuses the matcher's pass 1/2/3 equivalents to avoid
-// inventing a separate similarity heuristic. The first pass that
-// finds matches wins; we report at most maxInversionAnchors hits.
+// and `replace`: search did not match but replace appears in the file.
 func inversionHint(
+	content string,
 	contentLines []string,
 	replace string,
 	replaceLines []string,
 	trimRight, trimAll func(a, b string) bool,
 ) string {
-	const (
-		minInversionBytes   = 20
-		maxInversionAnchors = 5
+	const minInversionBytes = 20
+	if len(replace) < minInversionBytes || len(replaceLines) == 0 {
+		return ""
+	}
+
+	lines := substringMatchLines(content, replace)
+	if len(lines) == 0 {
+		lines = lineEquivalentMatchLines(contentLines, replaceLines, trimRight)
+	}
+	if len(lines) == 0 {
+		lines = lineEquivalentMatchLines(contentLines, replaceLines, trimAll)
+	}
+	if len(lines) == 0 {
+		return ""
+	}
+	return fmt.Sprintf(
+		"Did you swap %q and %q? Your replace string appears at line %s",
+		"search", "replace", formatLineList(lines),
 	)
-	if len(replace) < minInversionBytes {
-		return ""
-	}
-	if len(replaceLines) == 0 {
-		return ""
-	}
-
-	// Pass 1: exact substring. Resolve to a 1-based line number by
-	// counting newlines before the byte offset.
-	joined := stringsJoin(contentLines)
-	if idx := strings.Index(joined, replace); idx >= 0 {
-		count := strings.Count(joined, replace)
-		if count > maxInversionAnchors {
-			return ""
-		}
-		if count == 1 {
-			line := 1 + strings.Count(joined[:idx], "\n")
-			return fmt.Sprintf(
-				"your %q string was not found, but the %q string appears at line %d. Did you swap %q and %q?",
-				"search", "replace", line, "search", "replace",
-			)
-		}
-		// More than one but within the cap: don't pick an arbitrary
-		// anchor. Fall through to line-based scans, which often
-		// disambiguate via blank-line context.
-	}
-
-	// Passes 2 and 3: line-equivalent matching, mirroring the
-	// matcher's own cascade.
-	for _, eq := range []func(a, b string) bool{trimRight, trimAll} {
-		var starts []int
-		if len(replaceLines) > len(contentLines) {
-			continue
-		}
-	outer:
-		for i := 0; i <= len(contentLines)-len(replaceLines); i++ {
-			for j, rLine := range replaceLines {
-				if !eq(contentLines[i+j], rLine) {
-					continue outer
-				}
-			}
-			starts = append(starts, i)
-			if len(starts) > maxInversionAnchors {
-				// Too generic; bail.
-				return ""
-			}
-		}
-		if len(starts) == 1 {
-			return fmt.Sprintf(
-				"your %q string was not found, but the %q string appears at line %d. Did you swap %q and %q?",
-				"search", "replace", starts[0]+1, "search", "replace",
-			)
-		}
-	}
-	return ""
 }
 
-// stringsJoin concatenates lines back into the original buffer.
-// strings.SplitAfter preserves each line's terminator, so a plain
-// Join with "" reconstructs content verbatim.
-func stringsJoin(lines []string) string {
+// substringMatchLines returns the 1-based line numbers where needle
+// occurs in content as a byte-for-byte substring.
+func substringMatchLines(content, needle string) []int {
+	var lines []int
+	for offset := 0; ; {
+		rel := strings.Index(content[offset:], needle)
+		if rel < 0 {
+			break
+		}
+		idx := offset + rel
+		lines = append(lines, 1+strings.Count(content[:idx], "\n"))
+		offset = idx + len(needle)
+		if offset > len(content) {
+			break
+		}
+	}
+	return lines
+}
+
+// lineEquivalentMatchLines returns the 1-based start line of every
+// contiguous block of contentLines that matches needleLines under eq.
+func lineEquivalentMatchLines(contentLines, needleLines []string, eq func(a, b string) bool) []int {
+	if len(needleLines) == 0 || len(needleLines) > len(contentLines) {
+		return nil
+	}
+	var starts []int
+outer:
+	for i := 0; i <= len(contentLines)-len(needleLines); i++ {
+		for j, n := range needleLines {
+			if !eq(contentLines[i+j], n) {
+				continue outer
+			}
+		}
+		starts = append(starts, i+1)
+	}
+	return starts
+}
+
+// formatLineList renders a sorted line list as "12, 47, 89", truncated
+// to maxHintLines entries with " and N more" when more exist.
+func formatLineList(lines []int) string {
+	const maxHintLines = 5
 	var b strings.Builder
-	for _, l := range lines {
-		_, _ = b.WriteString(l)
+	shown := len(lines)
+	if shown > maxHintLines {
+		shown = maxHintLines
+	}
+	for i := 0; i < shown; i++ {
+		if i > 0 {
+			_, _ = b.WriteString(", ")
+		}
+		_, _ = fmt.Fprintf(&b, "%d", lines[i])
+	}
+	if rest := len(lines) - shown; rest > 0 {
+		_, _ = fmt.Fprintf(&b, " and %d more", rest)
 	}
 	return b.String()
 }
 
-// miscountHint detects the case where a search line and a content
-// line agree on every rune except for the count of one repeated
-// character. The shape comes from agents reconstructing decorative
-// runs (box-drawing dashes, ASCII separators) by eye and miscounting
-// the run length. Naming the codepoint and both counts lets the
-// agent fix the run instead of misattributing the failure to a
-// general "Unicode breaks edit_files" rule.
-//
-// Suppression rules:
-//   - At least one of the runs must be of length >= 2; a single
-//     extra character is more often a typo than a miscount.
-//   - Exactly one content line must qualify for a given search
-//     line; multiple candidates make the hint speculative.
-//
-// The diffCount==1 condition (every other rune class has identical
-// counts in both lines) already enforces the ticket's "shares >=80%
-// of search-line bytes (modulo the repeated character)" guidance
-// at 100%. A separate 80% overlap threshold would only matter if
-// we relaxed diffCount, which the observed failure data does not
-// require.
-//
-// Returns the hint for the first qualifying search line. Returns
-// "" when no search line produces a unique miscount candidate.
+// miscountHint detects search lines that match a file line except for
+// the count of one repeated rune. Emits one hint per such search line.
 func miscountHint(contentLines, searchLines []string) string {
+	var hints []string
 	for _, sLine := range searchLines {
 		sContent, _ := splitEnding(sLine)
 		if strings.TrimSpace(sContent) == "" {
 			continue
 		}
-		type hit struct {
-			line   int
-			rune   rune
-			sCount int
-			cCount int
-		}
-		var hits []hit
+		// One search line can disagree on different runes against
+		// different file lines; group by rune so each hint names a
+		// single codepoint.
+		groups := make(map[rune][]candidate)
+		counts := make(map[rune]int)
+		order := []rune{}
 		for i, cLine := range contentLines {
 			cContent, _ := splitEnding(cLine)
 			r, sc, cc, ok := singleRuneCountMismatch(sContent, cContent)
 			if !ok {
 				continue
 			}
-			hits = append(hits, hit{line: i + 1, rune: r, sCount: sc, cCount: cc})
-			if len(hits) > 1 {
-				break
+			if _, seen := groups[r]; !seen {
+				order = append(order, r)
+				counts[r] = sc
 			}
+			groups[r] = append(groups[r], candidate{line: i + 1, cCount: cc})
 		}
-		if len(hits) != 1 {
-			continue
+		for _, r := range order {
+			hints = append(hints, formatMiscount(counts[r], r, groups[r]))
 		}
-		h := hits[0]
-		return fmt.Sprintf(
-			"your search has %d %q (U+%04X); the closest match at line %d has %d. Adjust the run length",
-			h.sCount, string(h.rune), h.rune, h.line, h.cCount,
-		)
 	}
-	return ""
+	return strings.Join(hints, ". ")
 }
 
-// singleRuneCountMismatch reports whether two strings agree on every
-// rune except for the count of exactly one rune. Returns the
-// disagreeing rune, its counts in s and c, and whether the line
-// shape qualifies. Qualification requires:
-//
-//   - exactly one rune class has a nonzero count delta;
-//   - at least one of the two counts is >= 2 (a true repeat).
-//
-// The frequency-vector approach is sufficient for the observed
-// failure shapes: the search and the file line have the same
-// non-r rune multiset, with the disagreeing rune appearing at
-// different counts. A positional Levenshtein check could be added
-// if false positives prove a problem in practice.
+// formatMiscount renders one miscount candidate group.
+func formatMiscount(sCount int, r rune, cands []candidate) string {
+	const maxHintLines = 5
+	var b strings.Builder
+	_, _ = fmt.Fprintf(&b, "Your search has %d %q (U+%04X); the file has ", sCount, string(r), r)
+	shown := len(cands)
+	if shown > maxHintLines {
+		shown = maxHintLines
+	}
+	for i := 0; i < shown; i++ {
+		if i > 0 {
+			_, _ = b.WriteString(", ")
+		}
+		_, _ = fmt.Fprintf(&b, "%d at line %d", cands[i].cCount, cands[i].line)
+	}
+	if rest := len(cands) - shown; rest > 0 {
+		_, _ = fmt.Fprintf(&b, " and %d more", rest)
+	}
+	return b.String()
+}
+
+// candidate is the file-line count of the disagreeing rune.
+type candidate struct {
+	line   int
+	cCount int
+}
+
+// singleRuneCountMismatch reports whether s and c agree on every rune
+// class except one, where the disagreeing rune appears at least twice
+// on one side.
 func singleRuneCountMismatch(s, c string) (r rune, sCount, cCount int, ok bool) {
 	if s == "" || c == "" {
 		return 0, 0, 0, false
@@ -1390,21 +1373,21 @@ func singleRuneCountMismatch(s, c string) (r rune, sCount, cCount int, ok bool) 
 		sc        int
 		cc        int
 	)
-	for r, scv := range sFreq {
-		ccv := cFreq[r]
+	for rr, scv := range sFreq {
+		ccv := cFreq[rr]
 		if scv != ccv {
 			diffCount++
-			diffRune = r
+			diffRune = rr
 			sc = scv
 			cc = ccv
 		}
 	}
-	for r, ccv := range cFreq {
-		if _, ok := sFreq[r]; ok {
+	for rr, ccv := range cFreq {
+		if _, present := sFreq[rr]; present {
 			continue
 		}
 		diffCount++
-		diffRune = r
+		diffRune = rr
 		sc = 0
 		cc = ccv
 	}
@@ -1417,7 +1400,6 @@ func singleRuneCountMismatch(s, c string) (r rune, sCount, cCount int, ok bool) 
 	return diffRune, sc, cc, true
 }
 
-// runeFrequency returns a map from rune to occurrence count in s.
 func runeFrequency(s string) map[rune]int {
 	freq := make(map[rune]int)
 	for _, r := range s {

--- a/agent/agentfiles/files_test.go
+++ b/agent/agentfiles/files_test.go
@@ -3192,20 +3192,10 @@ const baseFuzzyNotFoundMessage = "search string not found in file. " +
 	"Verify the search string matches the file content exactly, " +
 	"including whitespace and indentation"
 
-// TestFuzzyReplace_Hints pins the post-fail diagnostic hints that
-// fire after pass 3 misses. Two detectors run in order:
-//
-//  1. Inversion. The search did not match anywhere, but the
-//     replace string occurs at a single anchor; the agent likely
-//     swapped the two fields.
-//  2. Repeated-character miscount. A search line agrees with one
-//     content line on every rune except for the count of one
-//     repeated rune; the agent miscounted a decorative run.
-//
-// Both detectors only run on the failing path, after pass 3 has
-// already missed. Both can fire in the same response. The base
-// error string must remain the leading sentence so existing log
-// scrapers continue to match it.
+// TestFuzzyReplace_Hints exercises the post-fail diagnostic hints:
+// inversion (search and replace swapped) and miscount (one repeated
+// rune at the wrong count). Each detector lists every match it finds
+// and truncates the output to five entries with " and N more".
 func TestFuzzyReplace_Hints(t *testing.T) {
 	t.Parallel()
 
@@ -3216,22 +3206,12 @@ func TestFuzzyReplace_Hints(t *testing.T) {
 		search, replace string
 	}
 	tests := []struct {
-		name string
-		// content is the on-disk file content.
-		content string
-		edit    edit
-		// wantSubs are substrings the error must contain. The
-		// base error is always present unless overridden by the
-		// test's intent; tests assert on the hint text plus any
-		// rune/count details they care about.
-		wantSubs []string
-		// notWantSubs are substrings the error must NOT contain.
-		// Used to pin the suppression cases.
+		name        string
+		content     string
+		edit        edit
+		wantSubs    []string
 		notWantSubs []string
 	}{
-		// Inversion: the search clearly is not in the file but the
-		// replace is the file's actual content. Replace is well
-		// over the 20-byte threshold and matches at one anchor.
 		{
 			name: "Inversion_HintIncludesSwapAndLine",
 			content: "package main\n" +
@@ -3240,20 +3220,51 @@ func TestFuzzyReplace_Hints(t *testing.T) {
 				"\n" +
 				"// trailing comment\n",
 			edit: edit{
-				// Search is what the agent intends the new state
-				// to be (does not exist in the file).
-				search: "func adder(a, b int) int {\n\treturn a + b\n}\n",
-				// Replace is the actual file content (inversion).
+				search:  "func adder(a, b int) int {\n\treturn a + b\n}\n",
 				replace: "func adder(a int, b int) int { return a + b }\n",
 			},
 			wantSubs: []string{
 				baseFuzzyNotFoundMessage,
-				`Did you swap "search" and "replace"?`,
-				"line 3",
+				`Did you swap "search" and "replace"? Your replace string appears at line 3`,
 			},
 		},
-		// Inversion suppressed: replace is too short to be a
-		// confident anchor.
+		{
+			name: "Inversion_ThreeAnchors_AllListed",
+			content: "a\n" +
+				"matching block body of substantial length\n" +
+				"b\n" +
+				"matching block body of substantial length\n" +
+				"c\n" +
+				"matching block body of substantial length\n" +
+				"d\n",
+			edit: edit{
+				search:  "this search text is absent from the file\n",
+				replace: "matching block body of substantial length\n",
+			},
+			wantSubs: []string{
+				baseFuzzyNotFoundMessage,
+				`Did you swap "search" and "replace"? Your replace string appears at line 2, 4, 6`,
+			},
+			notWantSubs: []string{"more"},
+		},
+		{
+			name: "Inversion_SevenAnchors_TruncatedWithAndMore",
+			content: "matching block body of substantial length\n" +
+				"matching block body of substantial length\n" +
+				"matching block body of substantial length\n" +
+				"matching block body of substantial length\n" +
+				"matching block body of substantial length\n" +
+				"matching block body of substantial length\n" +
+				"matching block body of substantial length\n",
+			edit: edit{
+				search:  "this search text is absent from the file\n",
+				replace: "matching block body of substantial length\n",
+			},
+			wantSubs: []string{
+				baseFuzzyNotFoundMessage,
+				`Did you swap "search" and "replace"? Your replace string appears at line 1, 2, 3, 4, 5 and 2 more`,
+			},
+		},
 		{
 			name:    "Inversion_ReplaceTooShort_NoHint",
 			content: "alpha\nbeta\ngamma\n",
@@ -3264,28 +3275,6 @@ func TestFuzzyReplace_Hints(t *testing.T) {
 			wantSubs:    []string{baseFuzzyNotFoundMessage},
 			notWantSubs: []string{"swap", "appears at line"},
 		},
-		// Inversion suppressed: replace appears at >5 distinct
-		// anchors. The line-equivalent passes are too generic to
-		// pick "the" anchor.
-		{
-			name: "Inversion_TooManyAnchors_NoHint",
-			content: "\trepeated line of fixed text\n" +
-				"\trepeated line of fixed text\n" +
-				"\trepeated line of fixed text\n" +
-				"\trepeated line of fixed text\n" +
-				"\trepeated line of fixed text\n" +
-				"\trepeated line of fixed text\n" +
-				"\trepeated line of fixed text\n",
-			edit: edit{
-				search:  "unrelated text the agent invented out of thin air\n",
-				replace: "repeated line of fixed text\n",
-			},
-			wantSubs:    []string{baseFuzzyNotFoundMessage},
-			notWantSubs: []string{"swap", "appears at line"},
-		},
-		// Miscount: search reconstructs a JSX-style decorative
-		// comment line with the wrong number of box-drawing
-		// dashes. Names U+2500 and both counts.
 		{
 			name: "Miscount_BoxDrawingDashes_HintNamesCodepoint",
 			content: "<header>\n" +
@@ -3297,14 +3286,9 @@ func TestFuzzyReplace_Hints(t *testing.T) {
 			},
 			wantSubs: []string{
 				baseFuzzyNotFoundMessage,
-				"your search has 32 \"\u2500\" (U+2500)",
-				"line 2",
-				"has 37",
-				"Adjust the run length",
+				"Your search has 32 \"\u2500\" (U+2500); the file has 37 at line 2",
 			},
 		},
-		// Miscount: ASCII case. Search line has 5 `=` runs,
-		// content has 7. Hint format works for ASCII codepoints.
 		{
 			name: "Miscount_ASCIIEquals_HintWorks",
 			content: "title\n" +
@@ -3316,33 +3300,52 @@ func TestFuzzyReplace_Hints(t *testing.T) {
 			},
 			wantSubs: []string{
 				baseFuzzyNotFoundMessage,
-				`your search has 5 "=" (U+003D)`,
-				"line 2",
-				"has 7",
-				"Adjust the run length",
+				`Your search has 5 "=" (U+003D); the file has 7 at line 2`,
 			},
 		},
-		// Miscount suppressed: search and content differ in two
-		// distinct rune classes. Not a clean repeated-char
-		// miscount.
+		{
+			name: "Miscount_TwoCandidates_BothListed",
+			content: "section =======\n" +
+				"section ===\n",
+			edit: edit{
+				search:  "section =====\n",
+				replace: "section *****\n",
+			},
+			wantSubs: []string{
+				baseFuzzyNotFoundMessage,
+				`Your search has 5 "=" (U+003D); the file has 7 at line 1, 3 at line 2`,
+			},
+			notWantSubs: []string{"more"},
+		},
+		{
+			name: "Miscount_SixCandidates_TruncatedWithAndMore",
+			content: "section ==\n" +
+				"section ===\n" +
+				"section ======\n" +
+				"section =======\n" +
+				"section ========\n" +
+				"section =========\n",
+			edit: edit{
+				search:  "section =====\n",
+				replace: "section *****\n",
+			},
+			wantSubs: []string{
+				baseFuzzyNotFoundMessage,
+				`Your search has 5 "=" (U+003D); the file has 2 at line 1, 3 at line 2, 6 at line 3, 7 at line 4, 8 at line 5 and 1 more`,
+			},
+		},
 		{
 			name: "Miscount_TwoDistinctChanges_NoHint",
 			content: "first\n" +
 				"a===b\n" +
 				"last\n",
 			edit: edit{
-				// Search differs from content in BOTH the count
-				// of '=' (5 vs 3) and the presence of '!' (the
-				// content line has none).
 				search:  "a=====b!\n",
 				replace: "unused\n",
 			},
 			wantSubs:    []string{baseFuzzyNotFoundMessage},
-			notWantSubs: []string{"Adjust the run length", "closest match"},
+			notWantSubs: []string{"Your search has", "the file has"},
 		},
-		// Miscount suppressed: search and content are unrelated.
-		// No content line shares a non-r multiset with the search
-		// line, so no candidate emerges.
 		{
 			name:    "Miscount_Unrelated_NoHint",
 			content: "package foo\n\nfunc bar() {}\n",
@@ -3351,11 +3354,8 @@ func TestFuzzyReplace_Hints(t *testing.T) {
 				replace: "unused\n",
 			},
 			wantSubs:    []string{baseFuzzyNotFoundMessage},
-			notWantSubs: []string{"Adjust the run length", "closest match"},
+			notWantSubs: []string{"Your search has", "the file has"},
 		},
-		// Search legitimately not in file: short replace, no
-		// near-miscount candidate. Base error returned with no
-		// hints appended.
 		{
 			name: "NoHints_BaseErrorOnly",
 			content: "package foo\n" +
@@ -3366,7 +3366,7 @@ func TestFuzzyReplace_Hints(t *testing.T) {
 				replace: "new\n",
 			},
 			wantSubs:    []string{baseFuzzyNotFoundMessage},
-			notWantSubs: []string{"swap", "Adjust the run length", "appears at line", "closest match"},
+			notWantSubs: []string{"swap", "Your search has", "appears at line"},
 		},
 	}
 
@@ -3409,8 +3409,6 @@ func TestFuzzyReplace_Hints(t *testing.T) {
 				require.NotContains(t, msg, sub, "unwanted substring present")
 			}
 
-			// File on disk is untouched: hints fire only on the
-			// failing path, no partial writes.
 			data, err := afero.ReadFile(fs, path)
 			require.NoError(t, err)
 			require.Equal(t, tt.content, string(data))

--- a/agent/agentfiles/files_test.go
+++ b/agent/agentfiles/files_test.go
@@ -3357,6 +3357,117 @@ func TestFuzzyReplace_Hints(t *testing.T) {
 			notWantSubs: []string{"Your search has", "the file has"},
 		},
 		{
+			name: "Miscount_SuppressesInversion_WhenBothCouldFire",
+			content: "<header>\n" +
+				"{/* SECTION HEADING " + strings.Repeat("\u2500", 8) + " */}\n" +
+				"<body>\n" +
+				"doSomethingWithLongName(ctx)\n" +
+				"</body>\n",
+			edit: edit{
+				// Search has 6 dashes (miscount target on line 2).
+				search: "{/* SECTION HEADING " + strings.Repeat("\u2500", 6) + " */}\n",
+				// Replace is unrelated text that happens to appear at
+				// line 4. Without miscount-takes-precedence, the
+				// inversion hint would direct an agent to swap and
+				// corrupt line 4.
+				replace: "doSomethingWithLongName(ctx)\n",
+			},
+			wantSubs: []string{
+				baseFuzzyNotFoundMessage,
+				"Your search has 6 \"\u2500\" (U+2500); the file has 8 at line 2",
+			},
+			notWantSubs: []string{"swap", "appears at line"},
+		},
+		{
+			name: "Inversion_DedupRepeatsOnOneLine",
+			content: "prefix\n" +
+				"AAAAAAAAAAAAAAAAAAAA AAAAAAAAAAAAAAAAAAAA AAAAAAAAAAAAAAAAAAAA\n" +
+				"suffix\n",
+			edit: edit{
+				search:  "absent search line not in file at all\n",
+				replace: "AAAAAAAAAAAAAAAAAAAA\n",
+			},
+			wantSubs: []string{
+				baseFuzzyNotFoundMessage,
+				`Did you swap "search" and "replace"? Your replace string appears at line 2`,
+			},
+			// Line 2 must appear once, not 2, 2, 2.
+			notWantSubs: []string{"line 2, 2", "more"},
+		},
+		{
+			name: "Inversion_TrimRightFallback_TrailingSpaces",
+			// Content line has trailing spaces; replace omits them.
+			// Byte-substring misses; trimRight line-equivalent
+			// matches.
+			content: "preamble\n" +
+				"matching block body of substantial length   \n" +
+				"trailer\n",
+			edit: edit{
+				search:  "absent search line not in file at all\n",
+				replace: "matching block body of substantial length\n",
+			},
+			wantSubs: []string{
+				baseFuzzyNotFoundMessage,
+				`Did you swap "search" and "replace"? Your replace string appears at line 2`,
+			},
+		},
+		{
+			name: "Inversion_TrimAllFallback_LeadingIndent",
+			// Content line has leading indentation that replace
+			// omits. Byte-substring misses; trim-right also misses
+			// (the leading whitespace is on a different side);
+			// trim-all matches.
+			content: "preamble\n" +
+				"\t\tmatching block body of substantial length\n" +
+				"trailer\n",
+			edit: edit{
+				search:  "absent search line not in file at all\n",
+				replace: "matching block body of substantial length\n",
+			},
+			wantSubs: []string{
+				baseFuzzyNotFoundMessage,
+				`Did you swap "search" and "replace"? Your replace string appears at line 2`,
+			},
+		},
+		{
+			name: "Miscount_SingleRuneDiff_Suppressed",
+			// Rune `b` differs (sc=1, cc=0). Both counts < 2, the
+			// suppression guard fires, no hint.
+			content: "first\nxa\nlast\n",
+			edit: edit{
+				search:  "xab\n",
+				replace: "unused\n",
+			},
+			wantSubs:    []string{baseFuzzyNotFoundMessage},
+			notWantSubs: []string{"Your search has", "the file has"},
+		},
+		{
+			name: "Miscount_TotalHintsCapped",
+			// Four search lines, each matching a distinct file line
+			// via a distinct miscount rune. With maxMiscountHints=3,
+			// only 3 hint sentences appear plus " and 1 more".
+			content: "section ==\n" +
+				"divider ++\n" +
+				"line ##\n" +
+				"header @@\n",
+			edit: edit{
+				search: "section ====\n" +
+					"divider ++++\n" +
+					"line ####\n" +
+					"header @@@@\n",
+				replace: "unused\n",
+			},
+			wantSubs: []string{
+				baseFuzzyNotFoundMessage,
+				`Your search has 4 "=" (U+003D)`,
+				`Your search has 4 "+" (U+002B)`,
+				`Your search has 4 "#" (U+0023)`,
+				"and 1 more",
+			},
+			// The fourth hint (`@`) is suppressed by the cap.
+			notWantSubs: []string{`"@"`},
+		},
+		{
 			name: "NoHints_BaseErrorOnly",
 			content: "package foo\n" +
 				"\n" +
@@ -3401,7 +3512,7 @@ func TestFuzzyReplace_Hints(t *testing.T) {
 			require.Equal(t, http.StatusBadRequest, w.Code, "body: %s", w.Body.String())
 			got := &codersdk.Error{}
 			require.NoError(t, json.NewDecoder(w.Body).Decode(got))
-			msg := got.Error()
+			msg := got.Message
 			for _, sub := range tt.wantSubs {
 				require.Contains(t, msg, sub, "want substring missing")
 			}

--- a/agent/agentfiles/files_test.go
+++ b/agent/agentfiles/files_test.go
@@ -3183,3 +3183,237 @@ func TestFuzzyReplace_Expansion_PreservesFileIndent(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expected, string(data))
 }
+
+// baseFuzzyNotFoundMessage is the leading sentence the matcher
+// returns when all three passes miss. It must remain the leading
+// sentence even when diagnostic hints are appended, so existing log
+// scrapers continue to match.
+const baseFuzzyNotFoundMessage = "search string not found in file. " +
+	"Verify the search string matches the file content exactly, " +
+	"including whitespace and indentation"
+
+// TestFuzzyReplace_Hints pins the post-fail diagnostic hints that
+// fire after pass 3 misses. Two detectors run in order:
+//
+//  1. Inversion. The search did not match anywhere, but the
+//     replace string occurs at a single anchor; the agent likely
+//     swapped the two fields.
+//  2. Repeated-character miscount. A search line agrees with one
+//     content line on every rune except for the count of one
+//     repeated rune; the agent miscounted a decorative run.
+//
+// Both detectors only run on the failing path, after pass 3 has
+// already missed. Both can fire in the same response. The base
+// error string must remain the leading sentence so existing log
+// scrapers continue to match it.
+func TestFuzzyReplace_Hints(t *testing.T) {
+	t.Parallel()
+
+	tmpdir := os.TempDir()
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+
+	type edit struct {
+		search, replace string
+	}
+	tests := []struct {
+		name string
+		// content is the on-disk file content.
+		content string
+		edit    edit
+		// wantSubs are substrings the error must contain. The
+		// base error is always present unless overridden by the
+		// test's intent; tests assert on the hint text plus any
+		// rune/count details they care about.
+		wantSubs []string
+		// notWantSubs are substrings the error must NOT contain.
+		// Used to pin the suppression cases.
+		notWantSubs []string
+	}{
+		// Inversion: the search clearly is not in the file but the
+		// replace is the file's actual content. Replace is well
+		// over the 20-byte threshold and matches at one anchor.
+		{
+			name: "Inversion_HintIncludesSwapAndLine",
+			content: "package main\n" +
+				"\n" +
+				"func adder(a int, b int) int { return a + b }\n" +
+				"\n" +
+				"// trailing comment\n",
+			edit: edit{
+				// Search is what the agent intends the new state
+				// to be (does not exist in the file).
+				search: "func adder(a, b int) int {\n\treturn a + b\n}\n",
+				// Replace is the actual file content (inversion).
+				replace: "func adder(a int, b int) int { return a + b }\n",
+			},
+			wantSubs: []string{
+				baseFuzzyNotFoundMessage,
+				`Did you swap "search" and "replace"?`,
+				"line 3",
+			},
+		},
+		// Inversion suppressed: replace is too short to be a
+		// confident anchor.
+		{
+			name:    "Inversion_ReplaceTooShort_NoHint",
+			content: "alpha\nbeta\ngamma\n",
+			edit: edit{
+				search:  "missing line that does not occur anywhere\n",
+				replace: "beta\n",
+			},
+			wantSubs:    []string{baseFuzzyNotFoundMessage},
+			notWantSubs: []string{"swap", "appears at line"},
+		},
+		// Inversion suppressed: replace appears at >5 distinct
+		// anchors. The line-equivalent passes are too generic to
+		// pick "the" anchor.
+		{
+			name: "Inversion_TooManyAnchors_NoHint",
+			content: "\trepeated line of fixed text\n" +
+				"\trepeated line of fixed text\n" +
+				"\trepeated line of fixed text\n" +
+				"\trepeated line of fixed text\n" +
+				"\trepeated line of fixed text\n" +
+				"\trepeated line of fixed text\n" +
+				"\trepeated line of fixed text\n",
+			edit: edit{
+				search:  "unrelated text the agent invented out of thin air\n",
+				replace: "repeated line of fixed text\n",
+			},
+			wantSubs:    []string{baseFuzzyNotFoundMessage},
+			notWantSubs: []string{"swap", "appears at line"},
+		},
+		// Miscount: search reconstructs a JSX-style decorative
+		// comment line with the wrong number of box-drawing
+		// dashes. Names U+2500 and both counts.
+		{
+			name: "Miscount_BoxDrawingDashes_HintNamesCodepoint",
+			content: "<header>\n" +
+				"{/* SECTION HEADING " + strings.Repeat("\u2500", 37) + " */}\n" +
+				"<body/>\n",
+			edit: edit{
+				search:  "{/* SECTION HEADING " + strings.Repeat("\u2500", 32) + " */}\n",
+				replace: "{/* REPLACED */}\n",
+			},
+			wantSubs: []string{
+				baseFuzzyNotFoundMessage,
+				"your search has 32 \"\u2500\" (U+2500)",
+				"line 2",
+				"has 37",
+				"Adjust the run length",
+			},
+		},
+		// Miscount: ASCII case. Search line has 5 `=` runs,
+		// content has 7. Hint format works for ASCII codepoints.
+		{
+			name: "Miscount_ASCIIEquals_HintWorks",
+			content: "title\n" +
+				"section =======\n" +
+				"body\n",
+			edit: edit{
+				search:  "section =====\n",
+				replace: "section *****\n",
+			},
+			wantSubs: []string{
+				baseFuzzyNotFoundMessage,
+				`your search has 5 "=" (U+003D)`,
+				"line 2",
+				"has 7",
+				"Adjust the run length",
+			},
+		},
+		// Miscount suppressed: search and content differ in two
+		// distinct rune classes. Not a clean repeated-char
+		// miscount.
+		{
+			name: "Miscount_TwoDistinctChanges_NoHint",
+			content: "first\n" +
+				"a===b\n" +
+				"last\n",
+			edit: edit{
+				// Search differs from content in BOTH the count
+				// of '=' (5 vs 3) and the presence of '!' (the
+				// content line has none).
+				search:  "a=====b!\n",
+				replace: "unused\n",
+			},
+			wantSubs:    []string{baseFuzzyNotFoundMessage},
+			notWantSubs: []string{"Adjust the run length", "closest match"},
+		},
+		// Miscount suppressed: search and content are unrelated.
+		// No content line shares a non-r multiset with the search
+		// line, so no candidate emerges.
+		{
+			name:    "Miscount_Unrelated_NoHint",
+			content: "package foo\n\nfunc bar() {}\n",
+			edit: edit{
+				search:  "this content is wholly different from the file\n",
+				replace: "unused\n",
+			},
+			wantSubs:    []string{baseFuzzyNotFoundMessage},
+			notWantSubs: []string{"Adjust the run length", "closest match"},
+		},
+		// Search legitimately not in file: short replace, no
+		// near-miscount candidate. Base error returned with no
+		// hints appended.
+		{
+			name: "NoHints_BaseErrorOnly",
+			content: "package foo\n" +
+				"\n" +
+				"func bar() {}\n",
+			edit: edit{
+				search:  "func zzzz() {}\n",
+				replace: "new\n",
+			},
+			wantSubs:    []string{baseFuzzyNotFoundMessage},
+			notWantSubs: []string{"swap", "Adjust the run length", "appears at line", "closest match"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fs := afero.NewMemMapFs()
+			api := agentfiles.NewAPI(logger, fs, nil)
+			path := filepath.Join(tmpdir, "hint-"+tt.name)
+			require.NoError(t, afero.WriteFile(fs, path, []byte(tt.content), 0o644))
+
+			req := workspacesdk.FileEditRequest{
+				Files: []workspacesdk.FileEdits{{
+					Path: path,
+					Edits: []workspacesdk.FileEdit{{
+						Search:  tt.edit.search,
+						Replace: tt.edit.replace,
+					}},
+				}},
+			}
+
+			ctx := testutil.Context(t, testutil.WaitShort)
+			buf := bytes.NewBuffer(nil)
+			enc := json.NewEncoder(buf)
+			enc.SetEscapeHTML(false)
+			require.NoError(t, enc.Encode(req))
+			w := httptest.NewRecorder()
+			r := httptest.NewRequestWithContext(ctx, http.MethodPost, "/edit-files", buf)
+			api.Routes().ServeHTTP(w, r)
+
+			require.Equal(t, http.StatusBadRequest, w.Code, "body: %s", w.Body.String())
+			got := &codersdk.Error{}
+			require.NoError(t, json.NewDecoder(w.Body).Decode(got))
+			msg := got.Error()
+			for _, sub := range tt.wantSubs {
+				require.Contains(t, msg, sub, "want substring missing")
+			}
+			for _, sub := range tt.notWantSubs {
+				require.NotContains(t, msg, sub, "unwanted substring present")
+			}
+
+			// File on disk is untouched: hints fire only on the
+			// failing path, no partial writes.
+			data, err := afero.ReadFile(fs, path)
+			require.NoError(t, err)
+			require.Equal(t, tt.content, string(data))
+		})
+	}
+}

--- a/agent/agentfiles/files_test.go
+++ b/agent/agentfiles/files_test.go
@@ -3468,6 +3468,43 @@ func TestFuzzyReplace_Hints(t *testing.T) {
 			notWantSubs: []string{`"@"`},
 		},
 		{
+			name: "Inversion_OverlappingMultilineMatch",
+			// Self-overlapping multi-line replace: "A\nB\nA\n"
+			// starts at line 1 and line 3 of the file. The old
+			// non-overlapping advancement missed line 3.
+			content: "AAAAAAAAAAAAAAAAAAAA\n" +
+				"BBBBBBBBBBBBBBBBBBBB\n" +
+				"AAAAAAAAAAAAAAAAAAAA\n" +
+				"BBBBBBBBBBBBBBBBBBBB\n" +
+				"AAAAAAAAAAAAAAAAAAAA\n",
+			edit: edit{
+				search: "absent search line not in file at all\n",
+				replace: "AAAAAAAAAAAAAAAAAAAA\n" +
+					"BBBBBBBBBBBBBBBBBBBB\n" +
+					"AAAAAAAAAAAAAAAAAAAA\n",
+			},
+			wantSubs: []string{
+				baseFuzzyNotFoundMessage,
+				`Did you swap "search" and "replace"? Your replace string appears at line 1, 3`,
+			},
+			notWantSubs: []string{"more"},
+		},
+		{
+			name: "Miscount_RuneOnlyInFile",
+			// Disagreeing rune `b` appears only in the file line.
+			// Exercises the second loop of singleRuneCountMismatch
+			// (runes in c but absent from s).
+			content: "section ==bb\n",
+			edit: edit{
+				search:  "section ==\n",
+				replace: "section --\n",
+			},
+			wantSubs: []string{
+				baseFuzzyNotFoundMessage,
+				`Your search has 0 "b" (U+0062); the file has 2 at line 1`,
+			},
+		},
+		{
 			name: "NoHints_BaseErrorOnly",
 			content: "package foo\n" +
 				"\n" +

--- a/agent/agentfiles/files_test.go
+++ b/agent/agentfiles/files_test.go
@@ -3266,14 +3266,20 @@ func TestFuzzyReplace_Hints(t *testing.T) {
 			},
 		},
 		{
-			name:    "Inversion_ReplaceTooShort_NoHint",
-			content: "alpha\nbeta\ngamma\n",
+			name: "Inversion_ShortReplace_TruncatedWithAndMore",
+			// Short replace strings used to be silently suppressed by
+			// a length floor. Now the line-list cap signals "your
+			// replace is too generic" by showing five matches plus
+			// " and N more", which is more informative than no hint.
+			content: "alpha\nbeta\nbeta\nbeta\nbeta\nbeta\nbeta\nbeta\ngamma\n",
 			edit: edit{
 				search:  "missing line that does not occur anywhere\n",
 				replace: "beta\n",
 			},
-			wantSubs:    []string{baseFuzzyNotFoundMessage},
-			notWantSubs: []string{"swap", "appears at line"},
+			wantSubs: []string{
+				baseFuzzyNotFoundMessage,
+				`Did you swap "search" and "replace"? Your replace string appears at line 2, 3, 4, 5, 6 and 2 more`,
+			},
 		},
 		{
 			name: "Miscount_BoxDrawingDashes_HintNamesCodepoint",


### PR DESCRIPTION
When `fuzzyReplace` fails after pass 3, append diagnostic hints to the base error. The base sentence stays leading so existing log scrapers keep matching.

## Two detectors

**Inversion**: if `search` didn't match but `replace` does, list the lines where `replace` appears:

> `Did you swap "search" and "replace"? Your replace string appears at line 12, 47, 89.`

Lines are listed in document order, truncated to 5 with `and N more` when more exist. A short, generic `replace` that matches many lines surfaces as `line 2, 3, 4, 5, 6 and 7 more`, which is itself the signal that the replace string is too generic to point at one location.

**Repeated-character miscount**: if a search line agrees with one or more file lines on every rune except the count of one repeated rune, name the codepoint and list every candidate:

> `Your search has 32 "─" (U+2500); the file has 37 at line 2.`

Multiple candidates:

> `Your search has 32 "─" (U+2500); the file has 37 at line 2, 5 at line 89.`

Suppressed when the disagreeing rune appears fewer than 2 times on both sides. One hint per (search-line, disagreeing-rune) group. Total hint sentences capped at 3 with `and N more` suffix when exceeded.

Miscount takes precedence over inversion. When the search has a near-match against a file line, it is the model's typo'd new text rather than a swapped field, so emitting both hints would mislead an agent into corrupting an unrelated line where the replace string coincidentally appears.

## Why

Both shapes were observed as the trigger for the [CODAGT-312](https://linear.app/codercom/issue/CODAGT-312) doctrine pattern:

- Inversion (chats `06bbaf0f`, `7732515b`): the model put new text in `search` and old text in `replace`, repeatedly. `7732515b`'s model wrote verbatim "Once again I have it inverted."
- Miscount (`bb8dc3b9`, the chat that prompted CODAGT-312): the model's search had 32 box-drawing dashes; the file had 37. All other characters matched. The model attributed the failure to "multi-byte Unicode characters" in general and pivoted to Python; that misdiagnosis became the persistent doctrine.

The existing error gives the agent no signal about *what* went wrong, which is the trigger for the misdiagnosis-and-fabricate chain.

## Tests

`TestFuzzyReplace_Hints` in `agent/agentfiles/files_test.go` covers single-match and multi-match cases for both detectors, the truncation-with-and-more case, and the suppression cases (replace too short, two distinct character differences, unrelated lines).

## Out of scope

- Within-batch duplicate-search handling. Originally CODAGT-328 / PR #25091; closed after review since the existing matcher error is already actionable.
- Schema reorder (`replace` before `search`). Deferred to a separate change. The fields are JSON-deserialized in the tool path (input strings, order-independent), so the reorder is safe; it is held out of this PR to keep the diagnostic-hint scope focused and to allow a dedicated review of any frontend or serialization callers.
- Unicode normalization. Em-dash failures in the field were verified to never be em-dash-caused (`~/codagt-312/work/em-dash-verification.md`).

<details>
<summary>CODAGT-312 context</summary>

Follow-up from the [CODAGT-312](https://linear.app/codercom/issue/CODAGT-312) investigation. Tracked under [CODAGT-330](https://linear.app/codercom/issue/CODAGT-330) (parent: [CODAGT-327](https://linear.app/codercom/issue/CODAGT-327)).

After this lands, the Grafana dashboard at https://grafana.dev.coder.com/d/codagt-312-edit-files (panels "edit_files failures by class" and "chats with prescriptive doctrine") should show the `search_not_found` rate and the prescriptive-doctrine count both decreasing over a 60-day window.
</details>

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻
