### PR TITLE
docs(docs/ai-coder/ai-gateway/clients): fix `enable_aibridge` -> `enable_ai_gateway`

### DIFF
--- a/docs/ai-coder/ai-gateway/clients/claude-code.md
+++ b/docs/ai-coder/ai-gateway/clients/claude-code.md
@@ -55,11 +55,11 @@ Template admins can pre-configure Claude Code for a seamless experience. Admins 
 
 ```hcl
 module "claude-code" {
-  source          = "registry.coder.com/coder/claude-code/coder"
-  version         = "4.7.3"
-  agent_id        = coder_agent.main.id
-  workdir         = "/path/to/project"  # Set to your project directory
-  enable_aibridge = true
+  source            = "registry.coder.com/coder/claude-code/coder"
+  version           = "4.7.3"
+  agent_id          = coder_agent.main.id
+  workdir           = "/path/to/project"  # Set to your project directory
+  enable_ai_gateway = true
 }
 ```
 
@@ -76,14 +76,14 @@ resource "coder_ai_task" "task" {
 data "coder_task" "me" {}
 
 module "claude-code" {
-  source         = "registry.coder.com/coder/claude-code/coder"
-  version        = "4.7.3"
-  agent_id       = coder_agent.main.id
-  workdir        = "/path/to/project"  # Set to your project directory
-  ai_prompt      = data.coder_task.me.prompt
+  source            = "registry.coder.com/coder/claude-code/coder"
+  version           = "4.7.3"
+  agent_id          = coder_agent.main.id
+  workdir           = "/path/to/project"  # Set to your project directory
+  ai_prompt         = data.coder_task.me.prompt
 
   # Route through AI Gateway (AI Governance Add-On)
-  enable_aibridge = true
+  enable_ai_gateway = true
 }
 ```
 

--- a/docs/ai-coder/ai-gateway/clients/codex.md
+++ b/docs/ai-coder/ai-gateway/clients/codex.md
@@ -91,11 +91,11 @@ If configuring within a Coder workspace, you can use the
 
 ```tf
 module "codex" {
-  source          = "registry.coder.com/coder-labs/codex/coder"
-  version         = "~> 4.1"
-  agent_id        = coder_agent.main.id
-  workdir         = "/path/to/project"  # Set to your project directory
-  enable_aibridge = true
+  source            = "registry.coder.com/coder-labs/codex/coder"
+  version           = "~> 4.1"
+  agent_id          = coder_agent.main.id
+  workdir           = "/path/to/project"  # Set to your project directory
+  enable_ai_gateway = true
 }
 ```
 


### PR DESCRIPTION
The Claude Code and Codex CLI registry modules expose the variable as `enable_ai_gateway`, not `enable_aibridge`. Templates using the docs as written fail Terraform init with `An argument named "enable_aibridge" is not expected here.`

Verified in [`registry/coder/modules/claude-code/main.tf`](https://github.com/coder/registry/blob/main/registry/coder/modules/claude-code/main.tf) and [`registry/coder-labs/modules/codex/main.tf`](https://github.com/coder/registry/blob/main/registry/coder-labs/modules/codex/main.tf), where the variable is declared as `enable_ai_gateway` and gates the `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN` injection.

_Generated with the help of Coder Agents._