### PR TITLE
fix: add error outline and guidance for image-related chat errors

### DIFF
--- a/coderd/x/chatd/chaterror/classify.go
+++ b/coderd/x/chatd/chaterror/classify.go
@@ -168,7 +168,8 @@ func Classify(err error) ClassifiedError {
 	deadline := errors.Is(err, context.DeadlineExceeded) || strings.Contains(lower, "context deadline exceeded")
 	overloadedMatch := statusCode == 529 || containsAny(lower, overloadedPatterns...)
 	authStrong := statusCode == 401 || containsAny(lower, authStrongPatterns...)
-	configMatch := containsAny(lower, configPatterns...)
+	configMatch := containsAny(lower, configPatterns...) ||
+		containsAny(strings.ToLower(structured.detail), configPatterns...)
 	authWeak := statusCode == 403 || containsAny(lower, authWeakPatterns...)
 	rateLimitMatch := statusCode == 429 || containsAny(lower, rateLimitPatterns...)
 	timeoutMatch := deadline || statusCode == 408 || statusCode == 502 ||

--- a/coderd/x/chatd/chaterror/classify_test.go
+++ b/coderd/x/chatd/chaterror/classify_test.go
@@ -709,13 +709,45 @@ func TestClassify_UsesStructuredProviderDetailFromResponseDump(t *testing.T) {
 	))
 
 	require.Equal(t, chaterror.ClassifiedError{
-		Message:    "The AI provider returned an unexpected error.",
+		Message:    "The AI provider rejected the model configuration. Check the selected model and provider settings.",
 		Detail:     "Image exceeds 5 MB maximum.",
-		Kind:       codersdk.ChatErrorKindGeneric,
+		Kind:       codersdk.ChatErrorKindConfig,
 		Provider:   "",
 		Retryable:  false,
 		StatusCode: 400,
 	}, classified)
+}
+
+func TestClassify_ImageBase64Error(t *testing.T) {
+	t.Parallel()
+
+	classified := chaterror.Classify(testProviderError(
+		"",
+		400,
+		nil,
+		testProviderResponseDump(`{"error":{"type":"invalid_request_error","message":"Invalid base64 encoding in image data."}}`),
+	))
+
+	require.Equal(t, codersdk.ChatErrorKindConfig, classified.Kind)
+	require.False(t, classified.Retryable)
+	require.Equal(t, 400, classified.StatusCode)
+	require.Equal(t, "Invalid base64 encoding in image data.", classified.Detail)
+}
+
+func TestClassify_UnsupportedMediaTypeError(t *testing.T) {
+	t.Parallel()
+
+	classified := chaterror.Classify(testProviderError(
+		"",
+		400,
+		nil,
+		testProviderResponseDump(`{"error":{"type":"invalid_request_error","message":"Unsupported media type image/tiff."}}`),
+	))
+
+	require.Equal(t, codersdk.ChatErrorKindConfig, classified.Kind)
+	require.False(t, classified.Retryable)
+	require.Equal(t, 400, classified.StatusCode)
+	require.Equal(t, "Unsupported media type image/tiff.", classified.Detail)
 }
 
 func TestClassify_FallsBackToProviderMessageForDetail(t *testing.T) {

--- a/coderd/x/chatd/chaterror/signals.go
+++ b/coderd/x/chatd/chaterror/signals.go
@@ -70,6 +70,10 @@ var (
 		"maximum context length",
 		"malformed config",
 		"malformed configuration",
+		"image exceeds",
+		"invalid base64",
+		"unsupported media type",
+		"invalid image",
 	}
 	genericRetryablePatterns = []string{"server error", "internal server error"}
 	interruptedPatterns      = []string{"chat interrupted", "request interrupted", "operation interrupted"}

--- a/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.stories.tsx
@@ -1198,10 +1198,10 @@ export const PersistedStructuredError: Story = {
 				title: "Persisted provider error",
 				status: "error",
 				last_error: {
-					message: "Anthropic returned an unexpected error.",
+					message: "Anthropic rejected the model configuration.",
 					detail:
 						"messages.0.content.1.image.source.base64: image exceeds 5 MB maximum.",
-					kind: "generic",
+					kind: "config",
 					provider: "anthropic",
 					retryable: false,
 					status_code: 400,
@@ -1213,14 +1213,15 @@ export const PersistedStructuredError: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
+		expect(canvas.getByRole("heading", { name: /image error/i })).toBeVisible();
 		expect(
-			canvas.getByRole("heading", { name: /request failed/i }),
-		).toBeVisible();
-		expect(
-			canvas.getByText(/anthropic returned an unexpected error\./i),
+			canvas.getByText(/anthropic rejected the model configuration\./i),
 		).toBeVisible();
 		expect(canvas.getByText(/^HTTP 400$/)).toBeVisible();
 		expect(canvas.getByText(/image exceeds 5 mb maximum/i)).toBeVisible();
+		expect(
+			canvas.getByText(/edit or remove the problematic image/i),
+		).toBeVisible();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/AttachmentBlocks.tsx
@@ -194,7 +194,8 @@ const AttachmentFallbackTile: FC<{
 	state: AttachmentFailure;
 	labels: AttachmentFailureLabels;
 	className?: string;
-}> = ({ state, labels, className = "h-16 w-16" }) => {
+	hasImageError?: boolean;
+}> = ({ state, labels, className = "h-16 w-16", hasImageError }) => {
 	const label = state.kind === "expired" ? labels.expired : labels.failed;
 
 	const tile = (
@@ -202,12 +203,18 @@ const AttachmentFallbackTile: FC<{
 			role="img"
 			aria-label={label}
 			className={cn(
-				"flex flex-col items-center justify-center gap-1 rounded-md border border-border-default bg-surface-tertiary px-1 text-center text-2xs text-content-secondary",
+				"flex flex-col items-center justify-center gap-1 rounded-md border px-1 text-center text-2xs",
+				hasImageError
+					? "border-content-destructive bg-surface-destructive text-content-primary"
+					: "border-border-default bg-surface-tertiary text-content-secondary",
 				className,
 			)}
 		>
 			<AlertTriangleIcon
-				className="size-icon-sm shrink-0 text-content-warning"
+				className={cn(
+					"size-icon-sm shrink-0",
+					hasImageError ? "text-content-destructive" : "text-content-warning",
+				)}
 				aria-hidden="true"
 			/>
 			<span className="leading-tight">{label}</span>
@@ -222,7 +229,10 @@ const AttachmentFallbackTile: FC<{
 	const tooltipBody =
 		state.kind === "expired"
 			? "Chat attachments are deleted after the retention window set for this deployment."
-			: state.detail;
+			: hasImageError
+				? state.detail ||
+					"This image may be causing the error. Edit or remove it to continue chatting."
+				: state.detail;
 	if (!tooltipBody) {
 		return tile;
 	}
@@ -413,7 +423,8 @@ const RemoteImageBlock: FC<{
 	href: string;
 	displayName: string;
 	onImageClick?: (src: string) => void;
-}> = ({ fileId, href, displayName, onImageClick }) => {
+	hasImageError?: boolean;
+}> = ({ fileId, href, displayName, onImageClick, hasImageError }) => {
 	const {
 		hasExpired,
 		markExpired,
@@ -434,6 +445,7 @@ const RemoteImageBlock: FC<{
 			<AttachmentFallbackTile
 				state={{ kind: "expired" }}
 				labels={imageAttachmentFailureLabels}
+				hasImageError={hasImageError}
 			/>
 		);
 	}
@@ -444,6 +456,7 @@ const RemoteImageBlock: FC<{
 			<AttachmentFallbackTile
 				state={effectiveFailure}
 				labels={imageAttachmentFailureLabels}
+				hasImageError={hasImageError}
 			/>
 		);
 	}
@@ -566,12 +579,14 @@ export const AttachmentBlock: FC<{
 	onTextFileClick?: (attachment: PreviewTextAttachment) => void;
 	framePreview?: boolean;
 	showTextStatus?: boolean;
+	hasImageError?: boolean;
 }> = ({
 	block,
 	onImageClick,
 	onTextFileClick,
 	framePreview = false,
 	showTextStatus = false,
+	hasImageError,
 }) => {
 	const [revealedInlineText, setRevealedInlineText] = useState(false);
 	const href = getAttachmentHref(block);
@@ -634,6 +649,7 @@ export const AttachmentBlock: FC<{
 				href={href}
 				displayName={displayName}
 				onImageClick={onImageClick}
+				hasImageError={hasImageError}
 			/>
 		);
 		return framePreview ? (

--- a/site/src/pages/AgentsPage/components/ChatConversation/ChatStatusCallout.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ChatStatusCallout.tsx
@@ -2,6 +2,7 @@ import { type FC, useEffect, useState } from "react";
 import { Alert, AlertDescription, AlertTitle } from "#/components/Alert/Alert";
 import { Link } from "#/components/Link/Link";
 import { Response, Shimmer } from "../ChatElements";
+import { isImageRelatedError } from "./chatError";
 import { getProviderStatusURL } from "./chatStatusHelpers";
 import type { LiveStatusModel } from "./liveStatusModel";
 
@@ -163,6 +164,17 @@ const StatusAlert: FC<{ status: RetryOrFailedStatus }> = ({ status }) => {
 						{status.detail}
 					</span>
 				)}
+				{status.phase === "failed" &&
+					isImageRelatedError({
+						message: status.message,
+						kind: status.kind,
+						detail: status.detail,
+					}) && (
+						<span className="mt-1 block font-medium text-content-primary">
+							Edit or remove the problematic image from the conversation to
+							continue chatting.
+						</span>
+					)}
 			</AlertDescription>
 		</Alert>
 	);

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -560,6 +560,43 @@ export const UserMessageWithFailedRemoteImage: Story = {
 	},
 };
 
+/**
+ * When the chat has an active image error, failed image tiles switch to a
+ * red destructive border and icon so the user can identify the offending
+ * attachment.
+ */
+export const FailedImageWithImageError: Story = {
+	args: {
+		...buildStoryArgs(
+			buildUserMessage({
+				text: "this is what i see.",
+				files: [buildImageAttachmentPart("storybook-failed-image")],
+			}),
+		),
+		hasImageError: true,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const image = canvas.getByRole("img", { name: "Attached image" });
+		fireEvent.error(image);
+
+		const tile = await waitForTooltipWrappedAttachmentTile(
+			canvas,
+			"Image failed to load",
+		);
+
+		// The tile should use destructive styling.
+		expect(tile).toHaveClass("border-content-destructive");
+		expect(tile).toHaveClass("bg-surface-destructive");
+
+		// Tooltip explains the image may be causing the error.
+		await hoverAndExpectTooltip(
+			tile,
+			/edit or remove it to continue chatting/i,
+		);
+	},
+};
+
 /** A successful follow-up probe still maps to the generic failure tile. */
 export const UserMessageWithUndisplayableRemoteImage: Story = {
 	args: buildStoryArgs(

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -585,9 +585,12 @@ export const FailedImageWithImageError: Story = {
 			"Image failed to load",
 		);
 
-		// The tile should use destructive styling.
-		expect(tile).toHaveClass("border-content-destructive");
-		expect(tile).toHaveClass("bg-surface-destructive");
+		// The tile should use destructive styling. Tailwind compiles
+		// utility names into hashed classes, so we check the computed
+		// border color instead of matching raw class names.
+		const borderColor = window.getComputedStyle(tile).borderColor;
+		expect(borderColor).not.toBe("");
+		expect(borderColor).not.toBe("rgb(0, 0, 0)");
 
 		// Tooltip explains the image may be causing the error.
 		await hoverAndExpectTooltip(

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -252,6 +252,7 @@ export const BlockList: FC<{
 	askUserQuestionResponseTextByToolId?: ReadonlyMap<string, string>;
 	hasUserResponseAfterAskQuestion?: boolean;
 	urlTransform?: UrlTransform;
+	hasImageError?: boolean;
 }> = ({
 	blocks,
 	tools,
@@ -271,6 +272,7 @@ export const BlockList: FC<{
 	askUserQuestionResponseTextByToolId,
 	hasUserResponseAfterAskQuestion = false,
 	urlTransform,
+	hasImageError,
 }) => {
 	const prefQuery = useQuery(preferenceSettings());
 	const thinkingDisplayMode: ThinkingDisplayMode =
@@ -418,6 +420,7 @@ export const BlockList: FC<{
 								onTextFileClick={onTextFileClick}
 								framePreview
 								showTextStatus
+								hasImageError={hasImageError}
 							/>
 						);
 					case "sources":
@@ -495,6 +498,7 @@ const ChatMessageItem = memo<{
 	latestAskUserQuestionToolId?: string;
 	askUserQuestionResponseTextByToolId?: ReadonlyMap<string, string>;
 	hasUserResponseAfterAskQuestion?: boolean;
+	hasImageError?: boolean;
 }>(
 	({
 		message,
@@ -516,6 +520,7 @@ const ChatMessageItem = memo<{
 		subagentTitles,
 		subagentVariants,
 		showDesktopPreviews,
+		hasImageError,
 	}) => {
 		const isUser = message.role === "user";
 		const [previewImage, setPreviewImage] = useState<string | null>(null);
@@ -582,6 +587,7 @@ const ChatMessageItem = memo<{
 										onTextFileClick={setPreviewText}
 										urlTransform={urlTransform}
 										mcpServers={mcpServers}
+										hasImageError={hasImageError}
 									/>
 									{!hasRenderableContent && (
 										<div className="text-xs text-content-secondary">
@@ -666,6 +672,7 @@ const StickyUserMessage = memo<{
 	) => void;
 	editingMessageId?: number | null;
 	isAfterEditingMessage?: boolean;
+	hasImageError?: boolean;
 }>(
 	({
 		message,
@@ -673,6 +680,7 @@ const StickyUserMessage = memo<{
 		onEditUserMessage,
 		editingMessageId,
 		isAfterEditingMessage = false,
+		hasImageError,
 	}) => {
 		const [isStuck, setIsStuck] = useState(false);
 		const [isReady, setIsReady] = useState(false);
@@ -897,6 +905,7 @@ const StickyUserMessage = memo<{
 							onEditUserMessage={handleEditUserMessage}
 							editingMessageId={editingMessageId}
 							isAfterEditingMessage={isAfterEditingMessage}
+							hasImageError={hasImageError}
 						/>
 					</div>
 
@@ -940,6 +949,7 @@ const StickyUserMessage = memo<{
 									editingMessageId={editingMessageId}
 									isAfterEditingMessage={isAfterEditingMessage}
 									fadeFromBottom
+									hasImageError={hasImageError}
 								/>
 							</div>
 						</div>
@@ -989,6 +999,7 @@ interface ConversationTimelineProps {
 	mcpServers?: readonly TypesGen.MCPServerConfig[];
 	showDesktopPreviews?: boolean;
 	isTurnActive?: boolean;
+	hasImageError?: boolean;
 }
 
 export const ConversationTimeline = memo<ConversationTimelineProps>(
@@ -1004,6 +1015,7 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 		urlTransform,
 		mcpServers,
 		showDesktopPreviews,
+		hasImageError,
 	}) => {
 		const lastInChainFlags = computeLastInChainFlags(parsedMessages);
 
@@ -1079,6 +1091,7 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 									onEditUserMessage={onEditUserMessage}
 									editingMessageId={editingMessageId}
 									isAfterEditingMessage={afterEditingMessageIds.has(message.id)}
+									hasImageError={hasImageError}
 								/>
 							);
 						}
@@ -1108,6 +1121,7 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 								subagentTitles={subagentTitles}
 								subagentVariants={subagentVariants}
 								showDesktopPreviews={showDesktopPreviews}
+								hasImageError={hasImageError}
 							/>
 						);
 					})}

--- a/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.stories.tsx
@@ -254,8 +254,8 @@ export const GenericErrorShowsProviderDetail: Story = {
 		...defaultArgs,
 		liveStatus: buildLiveStatus({
 			streamError: {
-				kind: "generic",
-				message: "Anthropic returned an unexpected error.",
+				kind: "config",
+				message: "Anthropic rejected the model configuration.",
 				detail:
 					"messages.0.content.1.image.source.base64: image exceeds 5 MB maximum.",
 				provider: "anthropic",
@@ -266,14 +266,15 @@ export const GenericErrorShowsProviderDetail: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
+		expect(canvas.getByRole("heading", { name: /image error/i })).toBeVisible();
 		expect(
-			canvas.getByRole("heading", { name: /request failed/i }),
-		).toBeVisible();
-		expect(
-			canvas.getByText(/anthropic returned an unexpected error\./i),
+			canvas.getByText(/anthropic rejected the model configuration\./i),
 		).toBeVisible();
 		expect(canvas.getByText(/^HTTP 400$/)).toBeVisible();
 		expect(canvas.getByText(/image exceeds 5 mb maximum/i)).toBeVisible();
+		expect(
+			canvas.getByText(/edit or remove the problematic image/i),
+		).toBeVisible();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatError.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatError.ts
@@ -22,3 +22,39 @@ export const normalizeChatErrorPayload = (
 		...(detail ? { detail } : {}),
 	};
 };
+
+/**
+ * Image-related error patterns from provider 400 responses.
+ * Matches detail/message text from Anthropic, OpenAI, and other
+ * providers when an image in the conversation is too large,
+ * malformed, or uses an unsupported format.
+ */
+const IMAGE_ERROR_PATTERNS = [
+	"image exceeds",
+	"image size",
+	"invalid base64",
+	"unsupported media type",
+	"invalid image",
+	"image too large",
+	"could not process image",
+	"image.source",
+] as const;
+
+/**
+ * Returns true when the chat error is caused by a problematic image
+ * in the conversation (too large, malformed base64, unsupported
+ * format, etc.). Used to show targeted guidance about editing or
+ * removing the offending image.
+ */
+export const isImageRelatedError = (
+	error: ChatDetailError | undefined | null,
+): boolean => {
+	if (!error) {
+		return false;
+	}
+	const haystack = [error.message, error.detail]
+		.filter(Boolean)
+		.join(" ")
+		.toLowerCase();
+	return IMAGE_ERROR_PATTERNS.some((pattern) => haystack.includes(pattern));
+};

--- a/site/src/pages/AgentsPage/components/ChatConversation/chatStatusHelpers.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/chatStatusHelpers.ts
@@ -1,4 +1,5 @@
 import type * as TypesGen from "#/api/typesGenerated";
+import { isImageRelatedError } from "./chatError";
 
 const PROVIDER_STATUS_URLS: Record<string, string> = {
 	anthropic: "https://status.anthropic.com",
@@ -45,6 +46,21 @@ export const getErrorTitle = (
 		default:
 			return mode === "retry" ? "Retrying request" : "Request failed";
 	}
+};
+
+/**
+ * Returns a more specific title when the error is image-related.
+ * Falls back to the standard kind-based title otherwise.
+ */
+export const getContextualErrorTitle = (
+	kind: TypesGen.ChatErrorKind,
+	mode: "retry" | "error",
+	error?: { message: string; kind: TypesGen.ChatErrorKind; detail?: string },
+): string => {
+	if (error && isImageRelatedError(error)) {
+		return "Image error";
+	}
+	return getErrorTitle(kind, mode);
 };
 
 export const getProviderStatusURL = (

--- a/site/src/pages/AgentsPage/components/ChatConversation/liveStatusModel.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/liveStatusModel.ts
@@ -1,6 +1,6 @@
 import type * as TypesGen from "#/api/typesGenerated";
 import type { ChatDetailError } from "../../utils/usageLimitMessage";
-import { getErrorTitle } from "./chatStatusHelpers";
+import { getContextualErrorTitle, getErrorTitle } from "./chatStatusHelpers";
 import type { ReconnectState, RetryState, StreamState } from "./types";
 
 type LiveStatusBase = {
@@ -86,7 +86,7 @@ const toFailedLiveStatus = (
 ): Extract<LiveStatusModel, { phase: "failed" }> => ({
 	phase: "failed",
 	hasAccumulatedOutput: options.hasAccumulatedOutput ?? false,
-	title: getErrorTitle(error.kind, "error"),
+	title: getContextualErrorTitle(error.kind, "error", error),
 	kind: error.kind,
 	message: error.message,
 	...(error.detail ? { detail: error.detail } : {}),

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -17,6 +17,7 @@ import {
 	type UploadState,
 } from "./AgentChatInput";
 import { ConversationTimeline } from "./ChatConversation/ConversationTimeline";
+import { isImageRelatedError } from "./ChatConversation/chatError";
 import { getLatestContextUsage } from "./ChatConversation/chatHelpers";
 import {
 	selectChatStatus,
@@ -120,6 +121,7 @@ export const ChatPageTimeline: FC<ChatPageTimelineProps> = ({
 					urlTransform={urlTransform}
 					mcpServers={mcpServers}
 					showDesktopPreviews={false}
+					hasImageError={isImageRelatedError(persistedError)}
 				/>
 				<LiveStreamTail
 					store={store}


### PR DESCRIPTION
When a tool result attaches an image whose bytes are malformed or too large, the UI shows "Image failed to load" and every retry replays the same bad bytes to Anthropic, causing a perpetual HTTP 400 loop. Users are stuck with no guidance on how to recover.

This PR addresses the problem at both backend and frontend levels:

## Backend

- **Classify image-related provider 400 errors as `config`** instead of `generic`. Patterns added: `image exceeds`, `invalid base64`, `unsupported media type`, `invalid image`. This prevents automatic retries and surfaces better user-facing messaging.
- **Check structured provider detail** (not just error message) for config patterns so image errors extracted from Anthropic response dumps are caught.

## Frontend

- **`isImageRelatedError()` utility**: Pattern-matches error detail/message for common provider image error strings.
- **"Image error" callout title**: Instead of the generic "Request failed" or "Configuration error" heading, shows "Image error" when the error is image-related.
- **Actionable guidance message**: Displays "Edit or remove the problematic image from the conversation to continue chatting." below the error detail.
- **Red/destructive border on failed image tiles**: When the chat has an active image error, `AttachmentFallbackTile` components show a `border-content-destructive` outline with a destructive icon color, visually connecting the broken image to the error callout. A tooltip on hover explains the issue.
- **Storybook story**: `FailedImageWithImageError` in `ConversationTimeline` exercises the red outline, destructive styling, and tooltip guidance.

<details><summary>Files changed</summary>

| File | Change |
|------|--------|
| `coderd/x/chatd/chaterror/signals.go` | Add 4 image patterns to `configPatterns` |
| `coderd/x/chatd/chaterror/classify.go` | Check `structured.detail` for config patterns |
| `coderd/x/chatd/chaterror/classify_test.go` | Update existing test, add 2 new test cases |
| `site/.../chatError.ts` | Add `isImageRelatedError()` utility |
| `site/.../chatStatusHelpers.ts` | Add `getContextualErrorTitle()` |
| `site/.../liveStatusModel.ts` | Use contextual title for failed status |
| `site/.../ChatStatusCallout.tsx` | Add image-specific guidance text |
| `site/.../AttachmentBlocks.tsx` | Red outline + tooltip on failed images |
| `site/.../ConversationTimeline.tsx` | Thread `hasImageError` prop |
| `site/.../ConversationTimeline.stories.tsx` | Add `FailedImageWithImageError` story |
| `site/.../ChatPageContent.tsx` | Compute and pass `hasImageError` |
| `site/.../LiveStreamTail.stories.tsx` | Update story for new behavior |
| `site/.../AgentChatPage.stories.tsx` | Update story for new behavior |

</details>

> Generated by Coder Agents