### PR TITLE
docs: update GitHub OAuth User Authorization Callback URL

### DIFF
--- a/docs/admin/users/github-auth.md
+++ b/docs/admin/users/github-auth.md
@@ -69,7 +69,7 @@ CODER_OAUTH2_GITHUB_DEFAULT_PROVIDER_ENABLE=false
    - **Homepage URL**: Set to your Coder deployment's
      [`CODER_ACCESS_URL`](../../reference/cli/server.md#--access-url) (e.g.
      `https://coder.domain.com`)
-   - **User Authorization Callback URL**: Set to `https://coder.domain.com`
+   - **User Authorization Callback URL**: Set to `https://coder.domain.com/api/v2/users/oauth2/github/callback`
 
      If you want to allow multiple Coder deployments hosted on subdomains, such as
      `coder1.domain.com`, `coder2.domain.com`, to authenticate with the


### PR DESCRIPTION
This pull request updates the documentation for configuring GitHub OAuth2 authentication with Coder. The main change clarifies the correct value for the "User Authorization Callback URL" required during the GitHub OAuth app setup. Based on my real usage as well as this line of code https://github.com/coder/coder/blame/4124d1137de1c88b957e15490f7a42adf8538bc9/cli/server.go#L2068, I believe the callback url should be different from what is stated in the document 