### PR TITLE
fix(site/src/modules/apps): handle invalid external app URLs gracefully

### DIFF
--- a/site/src/modules/apps/apps.test.ts
+++ b/site/src/modules/apps/apps.test.ts
@@ -180,6 +180,58 @@ describe("getAppHref", () => {
 			`/path-base/@${MockWorkspace.owner_name}/Test-Workspace.a-workspace-agent/apps/${app.slug}/`,
 		);
 	});
+
+	// Regression tests for https://github.com/coder/coder/issues/24417.
+	// A misconfigured `coder_app` with `external = true` and a non-URL
+	// value used to crash the whole UI because `new URL(app.url)` threw.
+	it.each([
+		["a bare string with no scheme", "my-app"],
+		["a protocol-relative URL", "//example.com"],
+		["an empty string", ""],
+		["whitespace", "   "],
+	])("returns the raw url without throwing when external app url is %s", (_label, badUrl) => {
+		const externalApp = {
+			...MockWorkspaceApp,
+			external: true,
+			url: badUrl,
+		};
+		expect(() =>
+			getAppHref(externalApp, {
+				host: "*.apps-host.tld",
+				path: "/path-base",
+				agent: MockWorkspaceAgent,
+				workspace: MockWorkspace,
+				token: "user-session-token",
+			}),
+		).not.toThrow();
+		const href = getAppHref(externalApp, {
+			host: "*.apps-host.tld",
+			path: "/path-base",
+			agent: MockWorkspaceAgent,
+			workspace: MockWorkspace,
+			token: "user-session-token",
+		});
+		expect(href).toBe(badUrl);
+	});
+
+	it("does not substitute the session token when external app url is invalid", () => {
+		const externalApp = {
+			...MockWorkspaceApp,
+			external: true,
+			url: `not-a-url-${SESSION_TOKEN_PLACEHOLDER}`,
+		};
+		const href = getAppHref(externalApp, {
+			host: "*.apps-host.tld",
+			path: "/path-base",
+			agent: MockWorkspaceAgent,
+			workspace: MockWorkspace,
+			token: "user-session-token",
+		});
+		// Invalid URLs are returned verbatim. The placeholder must not be
+		// replaced because we cannot verify the protocol is on the allow-list.
+		expect(href).toBe(externalApp.url);
+		expect(href).toContain(SESSION_TOKEN_PLACEHOLDER);
+	});
 });
 
 describe("openAppInNewWindow", () => {

--- a/site/src/modules/apps/apps.ts
+++ b/site/src/modules/apps/apps.ts
@@ -117,7 +117,19 @@ export const getAppHref = (
 	{ path, token, workspace, agent, host }: GetAppHrefParams,
 ): string => {
 	if (isExternalApp(app)) {
-		const appProtocol = new URL(app.url).protocol;
+		// A misconfigured `coder_app` can carry a value that is not a valid
+		// URL (e.g. a bare string with no scheme). Returning the raw value
+		// keeps the UI rendering and surfaces the configuration problem to
+		// the template author instead of crashing the page. We intentionally
+		// do not console.warn here because getAppHref runs once per render
+		// for every app on a workspace, so a single misconfigured value
+		// would flood the console on every state update.
+		let appProtocol: string;
+		try {
+			appProtocol = new URL(app.url).protocol;
+		} catch {
+			return app.url;
+		}
 		const isAllowedProtocol =
 			ALLOWED_EXTERNAL_APP_PROTOCOLS.includes(appProtocol);
 


### PR DESCRIPTION
## Summary

A `coder_app` resource with `external = true` and a value that is not
a parseable URL (e.g. a bare string like `my-app`, a protocol-relative
`//example.com`, or an empty string) used to throw `TypeError: Invalid
URL` from `new URL(app.url)` in `getAppHref`. Because `useAppLink`
calls this during render, a single misconfigured app crashed the
workspace list and detail pages.

Wrap the `new URL` call in try/catch and return the raw value when
parsing fails. The invalid value is rendered verbatim so the
configuration problem is visible to the template author instead of
the page going blank. The `\$SESSION_TOKEN` placeholder is
intentionally not substituted on the invalid-URL branch because the
allow-list protocol check cannot run.

Fixes #24417.
Partially addresses #22349 (frontend half; provider-side validation
tracked separately in coder/terraform-provider-coder#483).

## Test plan

- [x] `pnpm vitest run src/modules/apps/apps.test.ts` passes (17/17, including the 5 new regression cases for bare strings, protocol-relative URLs, empty strings, whitespace, and the no-token-substitution invariant for invalid URLs)
- [x] `pnpm biome check --error-on-warnings src/modules/apps/apps.ts src/modules/apps/apps.test.ts` clean
- [ ] Manual: render a workspace with a misconfigured `coder_app` and confirm the page renders instead of crashing