### PR TITLE
refactor(coderd/x/chatd/chattool): consolidate plan-path validation

### DIFF
--- a/coderd/x/chatd/chattool/editfiles.go
+++ b/coderd/x/chatd/chattool/editfiles.go
@@ -11,7 +11,7 @@ import (
 
 type EditFilesOptions struct {
 	GetWorkspaceConn func(context.Context) (workspacesdk.AgentConn, error)
-	ResolvePlanPath  func(context.Context) (chatPath string, home string, err error)
+	ResolvePlanPath  ResolveChatPlanPath
 	IsPlanTurn       bool
 }
 
@@ -64,36 +64,18 @@ func executeEditFilesTool(
 	ctx context.Context,
 	conn workspacesdk.AgentConn,
 	args EditFilesArgs,
-	resolvePlanPath func(context.Context) (chatPath string, home string, err error),
+	resolvePlanPath ResolveChatPlanPath,
 ) (fantasy.ToolResponse, error) {
 	if len(args.Files) == 0 {
 		return fantasy.NewTextErrorResponse("files is required"), nil
 	}
 
-	var (
-		chatPath       string
-		home           string
-		planPathErr    error
-		planPathLoaded bool
-	)
+	// Memoize so the workspace home is resolved at most once per batch
+	// even though validatePlanPath gets called per file.
+	resolver := memoizedPlanPathResolver(resolvePlanPath)
 	for i := range args.Files {
 		args.Files[i].Path = strings.TrimSpace(args.Files[i].Path)
-		file := args.Files[i]
-
-		hasPlanFileName := looksLikePlanFileName(file.Path)
-		if hasPlanFileName && !isAbsolutePath(file.Path) {
-			return fantasy.NewTextErrorResponse(
-				"plan files must use absolute paths; use the chat-specific absolute plan path; no files in this batch were applied",
-			), nil
-		}
-		if resolvePlanPath == nil || !hasPlanFileName {
-			continue
-		}
-		if !planPathLoaded {
-			chatPath, home, planPathErr = resolvePlanPath(ctx)
-			planPathLoaded = true
-		}
-		if resp, rejected := rejectSharedPlanPath(file.Path, home, chatPath, planPathErr); rejected {
+		if resp, rejected := validatePlanPath(ctx, args.Files[i].Path, resolver); rejected {
 			return fantasy.NewTextErrorResponse(
 				resp.Content + "; no files in this batch were applied",
 			), nil

--- a/coderd/x/chatd/chattool/planpath.go
+++ b/coderd/x/chatd/chattool/planpath.go
@@ -5,6 +5,7 @@ import (
 	"path"
 	"strings"
 
+	"charm.land/fantasy"
 	"github.com/google/uuid"
 	"golang.org/x/xerrors"
 
@@ -55,7 +56,7 @@ func PlanPathForChat(home string, chatID uuid.UUID) string {
 
 func resolvePlanTurnPath(
 	ctx context.Context,
-	resolvePlanPath func(context.Context) (chatPath string, home string, err error),
+	resolvePlanPath ResolveChatPlanPath,
 ) (string, error) {
 	if resolvePlanPath == nil {
 		return "", xerrors.New("chat-specific plan path resolver is not configured")
@@ -107,4 +108,74 @@ func LooksLikeHomePlanFile(requestedPath, home string) bool {
 func looksLikeLegacySharedPlanPath(requestedPath string) bool {
 	normalized := path.Clean(requestedPath)
 	return strings.EqualFold(normalized, LegacySharedPlanPath)
+}
+
+// ResolveChatPlanPath is the resolver signature used by every chattool
+// handler that needs to validate plan-file paths. It returns the
+// chat-specific plan path, the workspace home directory, and any
+// resolution error.
+type ResolveChatPlanPath func(ctx context.Context) (chatPath string, home string, err error)
+
+// validatePlanPath enforces plan-file path rules for a single requested
+// path. It returns (response, true) when the caller must short-circuit
+// with the returned error response, and (zero, false) when the path is
+// acceptable and the caller can proceed.
+//
+// The rules are:
+//
+//  1. A path whose basename matches plan.md (case-insensitive) must be
+//     absolute. Relative plan paths are rejected because the agent has
+//     no consistent working directory between turns.
+//  2. When a resolver is configured, a path that targets the legacy
+//     shared plan file or the same plan.md sitting directly in the
+//     workspace home is rejected and the user is pointed at the
+//     chat-specific plan path.
+//
+// Suitable for single-path tools (write_file, propose_plan). Multi-path
+// tools (edit_files) should call this per file and may wrap the error
+// content to add batch context. Wrap the resolver in
+// memoizedPlanPathResolver to avoid resolving the workspace home once
+// per file when iterating a batch.
+func validatePlanPath(
+	ctx context.Context,
+	requestedPath string,
+	resolvePlanPath ResolveChatPlanPath,
+) (fantasy.ToolResponse, bool) {
+	hasPlanFileName := looksLikePlanFileName(requestedPath)
+	if hasPlanFileName && !isAbsolutePath(requestedPath) {
+		return fantasy.NewTextErrorResponse(
+			"plan files must use absolute paths; use the chat-specific absolute plan path",
+		), true
+	}
+
+	if resolvePlanPath == nil || !hasPlanFileName {
+		return fantasy.ToolResponse{}, false
+	}
+
+	chatPath, home, err := resolvePlanPath(ctx)
+	return rejectSharedPlanPath(requestedPath, home, chatPath, err)
+}
+
+// memoizedPlanPathResolver wraps resolver so the underlying call runs at
+// most once. Subsequent invocations return the cached chat path, home,
+// and error. Returns nil when resolver is nil. The returned resolver is
+// not safe for concurrent use; chattool handlers iterate file batches
+// sequentially.
+func memoizedPlanPathResolver(resolver ResolveChatPlanPath) ResolveChatPlanPath {
+	if resolver == nil {
+		return nil
+	}
+	var (
+		loaded   bool
+		chatPath string
+		home     string
+		err      error
+	)
+	return func(ctx context.Context) (string, string, error) {
+		if !loaded {
+			chatPath, home, err = resolver(ctx)
+			loaded = true
+		}
+		return chatPath, home, err
+	}
 }

--- a/coderd/x/chatd/chattool/planpath_internal_test.go
+++ b/coderd/x/chatd/chattool/planpath_internal_test.go
@@ -1,9 +1,11 @@
 package chattool
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
 )
 
 func TestIsAbsolutePath(t *testing.T) {
@@ -129,4 +131,151 @@ func TestSharedPlanPathMessage(t *testing.T) {
 		"the plan path /home/coder/plan.md could not be verified because the workspace is currently unavailable to resolve the chat-specific plan path, try again shortly",
 		planPathVerificationMessage("/home/coder/plan.md"),
 	)
+}
+
+func TestValidatePlanPath(t *testing.T) {
+	t.Parallel()
+
+	const (
+		home     = "/home/coder"
+		chatPath = "/home/coder/.coder/plans/PLAN-chat.md"
+	)
+
+	okResolver := func(context.Context) (string, string, error) {
+		return chatPath, home, nil
+	}
+	errResolver := func(context.Context) (string, string, error) {
+		return "", "", xerrors.New("workspace unavailable")
+	}
+
+	tests := []struct {
+		name           string
+		requestedPath  string
+		resolver       ResolveChatPlanPath
+		wantRejected   bool
+		wantContentSub string
+	}{
+		{
+			name:          "NonPlanFileNoOp",
+			requestedPath: "/workspace/src/main.go",
+			resolver:      okResolver,
+			wantRejected:  false,
+		},
+		{
+			name:           "PlanFileRelativePathRejected",
+			requestedPath:  "plan.md",
+			resolver:       okResolver,
+			wantRejected:   true,
+			wantContentSub: "plan files must use absolute paths",
+		},
+		{
+			name:           "PlanFileDotRelativeRejected",
+			requestedPath:  "./PLAN.md",
+			resolver:       okResolver,
+			wantRejected:   true,
+			wantContentSub: "plan files must use absolute paths",
+		},
+		{
+			name:           "PlanFileInHomeRejected",
+			requestedPath:  "/home/coder/plan.md",
+			resolver:       okResolver,
+			wantRejected:   true,
+			wantContentSub: "use the chat-specific plan path",
+		},
+		{
+			name:          "ChatSpecificPathAccepted",
+			requestedPath: chatPath,
+			resolver:      okResolver,
+			wantRejected:  false,
+		},
+		{
+			name:          "NoResolverNonPlanAccepted",
+			requestedPath: "/workspace/src/main.go",
+			resolver:      nil,
+			wantRejected:  false,
+		},
+		{
+			name:           "NoResolverPlanFileRelativeRejected",
+			requestedPath:  "plan.md",
+			resolver:       nil,
+			wantRejected:   true,
+			wantContentSub: "plan files must use absolute paths",
+		},
+		{
+			name:          "NoResolverAbsolutePlanFileAccepted",
+			requestedPath: "/home/coder/plan.md",
+			resolver:      nil,
+			wantRejected:  false,
+		},
+		{
+			name:           "ResolverErrorWithLegacyPathRejected",
+			requestedPath:  LegacySharedPlanPath,
+			resolver:       errResolver,
+			wantRejected:   true,
+			wantContentSub: "could not be verified",
+		},
+		{
+			name:          "ResolverErrorWithNonLegacyPathAccepted",
+			requestedPath: "/some/other/plan.md",
+			resolver:      errResolver,
+			wantRejected:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			resp, rejected := validatePlanPath(t.Context(), tt.requestedPath, tt.resolver)
+			require.Equal(t, tt.wantRejected, rejected)
+			if tt.wantRejected {
+				require.True(t, resp.IsError)
+				require.Contains(t, resp.Content, tt.wantContentSub)
+			}
+		})
+	}
+}
+
+func TestMemoizedPlanPathResolver(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NilReturnsNil", func(t *testing.T) {
+		t.Parallel()
+		require.Nil(t, memoizedPlanPathResolver(nil))
+	})
+
+	t.Run("CachesResult", func(t *testing.T) {
+		t.Parallel()
+		var calls int
+		base := func(context.Context) (string, string, error) {
+			calls++
+			return "/chat/plan.md", "/home/coder", nil
+		}
+		memo := memoizedPlanPathResolver(base)
+		require.NotNil(t, memo)
+
+		for range 5 {
+			chatPath, home, err := memo(t.Context())
+			require.NoError(t, err)
+			require.Equal(t, "/chat/plan.md", chatPath)
+			require.Equal(t, "/home/coder", home)
+		}
+		require.Equal(t, 1, calls, "underlying resolver should only run once")
+	})
+
+	t.Run("CachesError", func(t *testing.T) {
+		t.Parallel()
+		var calls int
+		sentinel := xerrors.New("boom")
+		base := func(context.Context) (string, string, error) {
+			calls++
+			return "", "", sentinel
+		}
+		memo := memoizedPlanPathResolver(base)
+
+		_, _, err1 := memo(t.Context())
+		_, _, err2 := memo(t.Context())
+		require.ErrorIs(t, err1, sentinel)
+		require.ErrorIs(t, err2, sentinel)
+		require.Equal(t, 1, calls)
+	})
 }

--- a/coderd/x/chatd/chattool/proposeplan.go
+++ b/coderd/x/chatd/chattool/proposeplan.go
@@ -16,7 +16,7 @@ const maxProposePlanSize = 32 * 1024 // 32 KiB
 // ProposePlanOptions configures the propose_plan tool.
 type ProposePlanOptions struct {
 	GetWorkspaceConn func(context.Context) (workspacesdk.AgentConn, error)
-	ResolvePlanPath  func(context.Context) (chatPath string, home string, err error)
+	ResolvePlanPath  ResolveChatPlanPath
 	StoreFile        StoreFileFunc
 	IsPlanTurn       bool
 }
@@ -70,7 +70,7 @@ func executeProposePlanTool(
 	ctx context.Context,
 	conn workspacesdk.AgentConn,
 	args ProposePlanArgs,
-	resolvePlanPath func(context.Context) (chatPath string, home string, err error),
+	resolvePlanPath ResolveChatPlanPath,
 	storeFile StoreFileFunc,
 ) (fantasy.ToolResponse, error) {
 	requestedPath := strings.TrimSpace(args.Path)
@@ -81,18 +81,8 @@ func executeProposePlanTool(
 		return fantasy.NewTextErrorResponse("path must end with .md"), nil
 	}
 
-	hasPlanFileName := looksLikePlanFileName(requestedPath)
-	if hasPlanFileName && !isAbsolutePath(requestedPath) {
-		return fantasy.NewTextErrorResponse(
-			"plan files must use absolute paths; use the chat-specific absolute plan path",
-		), nil
-	}
-
-	if resolvePlanPath != nil && hasPlanFileName {
-		chatPath, home, err := resolvePlanPath(ctx)
-		if resp, rejected := rejectSharedPlanPath(requestedPath, home, chatPath, err); rejected {
-			return resp, nil
-		}
+	if resp, rejected := validatePlanPath(ctx, requestedPath, resolvePlanPath); rejected {
+		return resp, nil
 	}
 
 	rc, _, err := conn.ReadFile(ctx, requestedPath, 0, maxProposePlanSize+1)

--- a/coderd/x/chatd/chattool/writefile.go
+++ b/coderd/x/chatd/chattool/writefile.go
@@ -11,7 +11,7 @@ import (
 
 type WriteFileOptions struct {
 	GetWorkspaceConn func(context.Context) (workspacesdk.AgentConn, error)
-	ResolvePlanPath  func(context.Context) (chatPath string, home string, err error)
+	ResolvePlanPath  ResolveChatPlanPath
 	IsPlanTurn       bool
 }
 
@@ -58,25 +58,15 @@ func executeWriteFileTool(
 	ctx context.Context,
 	conn workspacesdk.AgentConn,
 	args WriteFileArgs,
-	resolvePlanPath func(context.Context) (chatPath string, home string, err error),
+	resolvePlanPath ResolveChatPlanPath,
 ) (fantasy.ToolResponse, error) {
 	requestedPath := strings.TrimSpace(args.Path)
 	if requestedPath == "" {
 		return fantasy.NewTextErrorResponse("path is required"), nil
 	}
 
-	hasPlanFileName := looksLikePlanFileName(requestedPath)
-	if hasPlanFileName && !isAbsolutePath(requestedPath) {
-		return fantasy.NewTextErrorResponse(
-			"plan files must use absolute paths; use the chat-specific absolute plan path",
-		), nil
-	}
-
-	if resolvePlanPath != nil && hasPlanFileName {
-		chatPath, home, err := resolvePlanPath(ctx)
-		if resp, rejected := rejectSharedPlanPath(requestedPath, home, chatPath, err); rejected {
-			return resp, nil
-		}
+	if resp, rejected := validatePlanPath(ctx, requestedPath, resolvePlanPath); rejected {
+		return resp, nil
 	}
 
 	if err := conn.WriteFile(ctx, requestedPath, strings.NewReader(args.Content)); err != nil {


### PR DESCRIPTION
## Summary

PR #24268 added the same ~12-line plan-file path validation block to
three tool handlers (write_file, edit_files, propose_plan). Each
block rejected relative `plan.md` paths and pointed callers at the
chat-specific plan path when they targeted the legacy shared path or
the home-root plan file. The duplication was flagged in review by
@mafredri (PR #24268 review thread r2341399622).

Extract the single-path case into a `validatePlanPath` helper and a
`ResolveChatPlanPath` type alias in planpath.go:

- write_file and propose_plan call validatePlanPath directly.
- edit_files wraps the resolver in `memoizedPlanPathResolver` so the
  workspace home is still resolved at most once per batch even
  though validatePlanPath is invoked per file. The batch error
  suffix (`; no files in this batch were applied`) is appended at
  the call site, preserving the existing message.

Add table-driven unit tests for validatePlanPath covering plan-name
detection, absolute-path enforcement, resolver-success rejection,
resolver-error legacy fallback, and the no-resolver branch. Add
tests for memoizedPlanPathResolver covering nil pass-through,
single-call caching, and error caching.

No behavioral change: existing write_file, edit_files, and
propose_plan tests continue to pass without modification under
`-race`.

Fixes #24290.

## Test plan

- [x] `go test -race -run 'TestValidatePlanPath|TestMemoizedPlanPathResolver|TestWriteFile|TestEditFiles|TestProposePlan|TestPlanPath' ./coderd/x/chatd/chattool/...` passes
- [x] All existing handler tests still pass without modification
- [ ] CI on full chattool suite