### PR TITLE
fix(cli): default config-ssh to forward-slash paths on Windows

### DIFF
--- a/cli/configssh.go
+++ b/cli/configssh.go
@@ -107,7 +107,8 @@ func (o sshConfigOptions) equal(other sshConfigOptions) bool {
 		o.userHostPrefix == other.userHostPrefix &&
 		o.disableAutostart == other.disableAutostart &&
 		o.headerCommand == other.headerCommand &&
-		o.hostnameSuffix == other.hostnameSuffix
+		o.hostnameSuffix == other.hostnameSuffix &&
+		o.forceUnixSeparators == other.forceUnixSeparators
 }
 
 func (o sshConfigOptions) writeToBuffer(buf *bytes.Buffer) error {
@@ -214,6 +215,16 @@ func (o sshConfigOptions) asList() (list []string) {
 	if o.disableAutostart {
 		list = append(list, fmt.Sprintf("disable-autostart: %v", o.disableAutostart))
 	}
+	// Serialize forceUnixSeparators whenever it diverges from the
+	// platform default, so `--use-previous-options` (or the
+	// "use previous" branch of the divergent-options prompt) preserves
+	// the user's explicit choice. Without this, every second run on
+	// Windows that used --use-previous-options would silently revert
+	// to backslash paths, undoing the default introduced in
+	// coder/coder#24205.
+	if o.forceUnixSeparators != defaultForceUnixSeparators {
+		list = append(list, fmt.Sprintf("force-unix-filepaths: %v", o.forceUnixSeparators))
+	}
 	for _, opt := range o.sshOptions {
 		list = append(list, fmt.Sprintf("ssh-option: %s", opt))
 	}
@@ -229,8 +240,13 @@ func (o sshConfigOptions) asList() (list []string) {
 
 func (r *RootCmd) configSSH() *serpent.Command {
 	var (
-		sshConfigFile   string
-		sshConfigOpts   sshConfigOptions
+		sshConfigFile string
+		// On Windows the flag defaults to true so ProxyCommand paths use
+		// forward slashes, which work in both cmd.exe / PowerShell and in
+		// Git Bash's /bin/sh. See defaultForceUnixSeparators.
+		sshConfigOpts = sshConfigOptions{
+			forceUnixSeparators: defaultForceUnixSeparators,
+		}
 		usePreviousOpts bool
 		dryRun          bool
 		coderCliPath    string
@@ -562,9 +578,13 @@ func (r *RootCmd) configSSH() *serpent.Command {
 		{
 			Flag: "force-unix-filepaths",
 			Env:  "CODER_CONFIGSSH_UNIX_FILEPATHS",
-			Description: "By default, 'config-ssh' uses the os path separator when writing the ssh config. " +
-				"This might be an issue in Windows machine that use a unix-like shell. " +
-				"This flag forces the use of unix file paths (the forward slash '/').",
+			Description: "Force the use of unix file paths (forward slash '/') for paths " +
+				"emitted in ProxyCommand. Defaults to true on Windows so the " +
+				"generated config works with both Windows OpenSSH (cmd.exe / " +
+				"PowerShell) and Git Bash's OpenSSH (which runs ProxyCommand " +
+				"through /bin/sh, where backslashes get interpreted as escape " +
+				"characters). Set to false to keep native Windows backslash " +
+				"paths. Noop on non-Windows platforms.",
 			Value: serpent.BoolOf(&sshConfigOpts.forceUnixSeparators),
 			// On non-windows showing this command is useless because it is a noop.
 			// Hide vs disable it though so if a command is copied from a Windows
@@ -682,6 +702,12 @@ func sshConfigWriteSectionEnd(w io.Writer) {
 func sshConfigParseLastOptions(r io.Reader) (o sshConfigOptions) {
 	// Default values.
 	o.waitEnum = "auto"
+	// Default to the platform-specific value so a previous config that
+	// predates the force-unix-filepaths serialization keeps the right
+	// behavior (true on Windows, false elsewhere). Without this,
+	// --use-previous-options on Windows would clobber the new default
+	// with a zero-value false. See coder/coder#24205.
+	o.forceUnixSeparators = defaultForceUnixSeparators
 
 	s := bufio.NewScanner(r)
 	for s.Scan() {
@@ -700,6 +726,8 @@ func sshConfigParseLastOptions(r io.Reader) (o sshConfigOptions) {
 				o.sshOptions = append(o.sshOptions, parts[1])
 			case "disable-autostart":
 				o.disableAutostart, _ = strconv.ParseBool(parts[1])
+			case "force-unix-filepaths":
+				o.forceUnixSeparators, _ = strconv.ParseBool(parts[1])
 			case "header":
 				o.header = append(o.header, parts[1])
 			case "header-command":

--- a/cli/configssh_internal_test.go
+++ b/cli/configssh_internal_test.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -305,6 +307,139 @@ func Test_sshConfigExecEscapeSeparatorForce(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Regression test for https://github.com/coder/coder/issues/24205.
+// Verifies that writeToBuffer threads the forceUnixSeparators flag into the
+// ProxyCommand and --global-config paths. The actual backslash-to-slash
+// conversion lives in sshConfigProxyCommandEscape (already covered by
+// Test_sshConfigExecEscapeSeparatorForce) and is OS-specific via
+// filepath.ToSlash, so the rendered substitution itself only happens on
+// Windows. The Linux assertion confirms the flag plumbing without
+// asserting the OS-specific conversion.
+func Test_sshConfigOptions_writeToBuffer_PathSeparators(t *testing.T) {
+	t.Parallel()
+
+	const (
+		winCoderBinary = `C:\Users\me\AppData\Local\Coder\coder.exe`
+		winGlobalCfg   = `C:\Users\me\AppData\Roaming\coderv2`
+	)
+
+	render := func(t *testing.T, forceUnix bool) string {
+		t.Helper()
+		opts := sshConfigOptions{
+			waitEnum:            "auto",
+			hostnameSuffix:      "coder",
+			userHostPrefix:      "coder.",
+			coderBinaryPath:     winCoderBinary,
+			globalConfigPath:    winGlobalCfg,
+			forceUnixSeparators: forceUnix,
+		}
+		buf := &bytes.Buffer{}
+		require.NoError(t, opts.writeToBuffer(buf))
+		return buf.String()
+	}
+
+	t.Run("ForceUnixForwardSlashesOnWindows", func(t *testing.T) {
+		t.Parallel()
+		if runtime.GOOS != "windows" {
+			t.Skip("backslash to forward-slash conversion only fires on Windows because filepath.ToSlash is OS-specific")
+		}
+		out := render(t, true)
+		require.Contains(t, out,
+			`C:/Users/me/AppData/Local/Coder/coder.exe`,
+			"ProxyCommand should use forward-slash coder.exe path when force-unix is enabled")
+		require.Contains(t, out,
+			`C:/Users/me/AppData/Roaming/coderv2`,
+			"global-config arg should use forward slashes when force-unix is enabled")
+		require.NotContains(t, out,
+			`C:\Users\me\AppData\Local\Coder\coder.exe`,
+			"no backslash binary path should leak through when force-unix is enabled")
+	})
+
+	t.Run("WithoutForceUnixBackslashesLeak", func(t *testing.T) {
+		t.Parallel()
+		// Cross-platform: the helper is a noop on the host OS path
+		// separator, so on every platform the raw Windows path is
+		// embedded verbatim when forceUnix is false. This is the failing
+		// pre-#24205 behavior on Git Bash.
+		out := render(t, false)
+		require.Contains(t, out, winCoderBinary)
+		require.Contains(t, out, winGlobalCfg)
+	})
+}
+
+// Regression test for https://github.com/coder/coder/issues/24205. The flag
+// must default to true on Windows so users who run `coder config-ssh` with
+// no extra arguments get a Git Bash-compatible config.
+func Test_defaultForceUnixSeparators(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		require.True(t, defaultForceUnixSeparators,
+			"on Windows the default must be true so ProxyCommand paths use forward slashes")
+	} else {
+		require.False(t, defaultForceUnixSeparators,
+			"on non-Windows the flag is a noop and must default to false")
+	}
+}
+
+// Regression test for https://github.com/coder/coder/issues/24205.
+// `--use-previous-options` copies the parsed config wholesale over the
+// current run's options. If forceUnixSeparators is not serialized in
+// asList() and not parsed back, a Windows user who relies on the new
+// default would silently regress to backslash paths on the second run.
+func Test_sshConfigOptions_ForceUnixSeparators_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	t.Run("DefaultValueNotSerialized", func(t *testing.T) {
+		t.Parallel()
+		o := sshConfigOptions{
+			forceUnixSeparators: defaultForceUnixSeparators,
+		}
+		list := o.asList()
+		for _, entry := range list {
+			require.NotContains(t, entry, "force-unix-filepaths",
+				"default value must not appear in the persisted section")
+		}
+	})
+
+	t.Run("NonDefaultValueSerialized", func(t *testing.T) {
+		t.Parallel()
+		o := sshConfigOptions{
+			forceUnixSeparators: !defaultForceUnixSeparators,
+		}
+		list := o.asList()
+		want := fmt.Sprintf("force-unix-filepaths: %v", !defaultForceUnixSeparators)
+		require.Contains(t, list, want,
+			"non-default value must be persisted so --use-previous-options keeps it")
+	})
+
+	t.Run("ParserDefaultsToPlatformValue", func(t *testing.T) {
+		t.Parallel()
+		// Empty section (e.g., one written before force-unix-filepaths
+		// was serialized). The parser must fall back to the platform
+		// default, not the zero value, so --use-previous-options on
+		// Windows preserves the new default.
+		section := "# :wait=auto\n"
+		parsed := sshConfigParseLastOptions(strings.NewReader(section))
+		require.Equal(t, defaultForceUnixSeparators, parsed.forceUnixSeparators)
+	})
+
+	t.Run("ParserRoundTripsExplicitValue", func(t *testing.T) {
+		t.Parallel()
+		section := fmt.Sprintf("# :force-unix-filepaths=%v\n", !defaultForceUnixSeparators)
+		parsed := sshConfigParseLastOptions(strings.NewReader(section))
+		require.Equal(t, !defaultForceUnixSeparators, parsed.forceUnixSeparators)
+	})
+
+	t.Run("EqualIncludesForceUnix", func(t *testing.T) {
+		t.Parallel()
+		a := sshConfigOptions{waitEnum: "auto", forceUnixSeparators: true}
+		b := sshConfigOptions{waitEnum: "auto", forceUnixSeparators: false}
+		require.False(t, a.equal(b),
+			"equal must compare forceUnixSeparators or the divergent-options prompt skips this difference")
+	})
 }
 
 func Test_sshConfigOptions_addOption(t *testing.T) {

--- a/cli/configssh_other.go
+++ b/cli/configssh_other.go
@@ -10,6 +10,13 @@ import (
 
 var hideForceUnixSlashes = true
 
+// defaultForceUnixSeparators is the default value of the
+// `--force-unix-filepaths` flag on non-Windows platforms. The flag is a
+// noop here (paths are already POSIX), but keeping a platform-specific
+// constant mirrors the Windows file and avoids OS conditionals inside
+// the shared command setup.
+var defaultForceUnixSeparators = false
+
 // sshConfigMatchExecEscape prepares the path for use in `Match exec` statement.
 //
 // OpenSSH parses the Match line with a very simple tokenizer that accepts "-enclosed strings for the exec command, and

--- a/cli/configssh_windows.go
+++ b/cli/configssh_windows.go
@@ -12,6 +12,19 @@ import (
 // Must be a var for unit tests to conform behavior
 var hideForceUnixSlashes = false
 
+// defaultForceUnixSeparators is the default value of the
+// `--force-unix-filepaths` flag on Windows.
+//
+// Defaulting to true generates ProxyCommand paths with forward slashes,
+// which work in both cmd.exe / PowerShell (Windows accepts either
+// separator for filesystem paths in CreateProcess) and in Git Bash's
+// `/bin/sh`. With the previous default of false, a user whose PATH puts
+// Git Bash's OpenSSH before Windows OpenSSH would see `/bin/sh` strip
+// backslashes as escape characters from the ProxyCommand and fail with
+// "command not found", breaking `coder ssh` and Coder Desktop File Sync.
+// See coder/coder#24205.
+var defaultForceUnixSeparators = true
+
 // sshConfigMatchExecEscape prepares the path for use in `Match exec` statement.
 //
 // OpenSSH parses the Match line with a very simple tokenizer that accepts "-enclosed strings for the exec command, and

--- a/cli/testdata/coder_config-ssh_--help.golden
+++ b/cli/testdata/coder_config-ssh_--help.golden
@@ -28,10 +28,12 @@ OPTIONS:
           Perform a trial run with no changes made, showing a diff at the end.
 
       --force-unix-filepaths bool, $CODER_CONFIGSSH_UNIX_FILEPATHS
-          By default, 'config-ssh' uses the os path separator when writing the
-          ssh config. This might be an issue in Windows machine that use a
-          unix-like shell. This flag forces the use of unix file paths (the
-          forward slash '/').
+          Force the use of unix file paths (forward slash '/') for paths emitted
+          in ProxyCommand. Defaults to true on Windows so the generated config
+          works with both Windows OpenSSH (cmd.exe / PowerShell) and Git Bash's
+          OpenSSH (which runs ProxyCommand through /bin/sh, where backslashes
+          get interpreted as escape characters). Set to false to keep native
+          Windows backslash paths. Noop on non-Windows platforms.
 
       --hostname-suffix string, $CODER_CONFIGSSH_HOSTNAME_SUFFIX
           Override the default hostname suffix.


### PR DESCRIPTION
## Summary

`coder config-ssh` writes ProxyCommand and `--global-config` paths
into ~/.ssh/config using the OS path separator. On Windows that is
`\`, which works with the native Windows OpenSSH (cmd.exe /
PowerShell) but breaks when Git Bash's OpenSSH (`C:\Program
Files\Git\usr\bin\ssh.exe`) is first in PATH. Git Bash's ssh
executes ProxyCommand via `/bin/sh -c "..."`, and `/bin/sh`
interprets `\` as an escape character, collapsing the path:

```
/bin/sh: line 1: C:UsersMeAppData...coder.exe: command not found
```

This breaks `coder ssh` and Coder Desktop File Sync (mutagen SCP)
for every Windows developer who has Git Bash in PATH, even though
the `--force-unix-filepaths` flag has existed since #8164 to fix
exactly this case. The flag was opt-in, so first-time users hit the
broken default with no obvious diagnostic.

Make `forceUnixSeparators` default to true on Windows and false on
other platforms. The flag stays available so users with cmd.exe /
PowerShell shells that prefer native backslash paths can opt out
with `--force-unix-filepaths=false`. Windows kernel CreateProcess
and the shells we care about (cmd.exe, PowerShell, Git Bash, MSYS2)
all accept forward slashes in filesystem paths, so flipping the
default does not regress the cmd.exe / PowerShell path.

Persist the flag value through the config section serialization
(`asList` / `sshConfigParseLastOptions`) so that:

- `--use-previous-options` (and the "use previous" branch of the
  divergent-options prompt) preserves the user's explicit choice
  instead of silently reverting to the parsed zero value.
- A previous section written before this commit lands still picks
  up the new default on read, because the parser initializes
  `forceUnixSeparators` to `defaultForceUnixSeparators` before
  scanning. Without this, a Windows user with a pre-existing config
  section would lose the new default on their next run.

Only persist the value when it diverges from the platform default,
to keep generated config sections minimal. Extend `equal()` to
compare `forceUnixSeparators` so the divergent-options prompt fires
when a user toggles the flag.

Fixes #24205.

## Test plan

- [x] `go test -race ./cli/...` for `Test_sshConfigOptions_ForceUnixSeparators_RoundTrip`, `Test_defaultForceUnixSeparators`, `Test_sshConfigOptions_writeToBuffer_PathSeparators`, `Test_sshConfigExecEscapeSeparatorForce`
- [x] `TestCommandHelp/coder_config-ssh_--help` golden file updated and passing
- [ ] CI on Windows runner to verify the writeToBuffer ProxyCommand actually uses forward slashes end-to-end