### PR TITLE
fix(cli): bound coderd HTTP requests with a ResponseHeaderTimeout

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -97,6 +97,37 @@ const (
 	envURL            = "CODER_URL"
 )
 
+// defaultCLIResponseHeaderTimeout bounds how long a single CLI HTTP
+// request will wait for the server to start sending response headers.
+// http.Transport has no header-wait timer by default, which lets a TCP
+// connection that stays healthy while no HTTP response arrives hang
+// indefinitely. The timer only governs the time-to-headers; long
+// streaming responses (logs, SSE, WebSocket upgrades) are unaffected
+// because the server flushes headers immediately. See
+// coder/coder#24519.
+const defaultCLIResponseHeaderTimeout = 60 * time.Second
+
+// envCLIResponseHeaderTimeout lets users override the default header
+// timeout with a Go duration string (e.g. "30s", "2m"). The override is
+// also used by tests to shrink the timeout to milliseconds without
+// having to inspect or rewire the transport chain.
+const envCLIResponseHeaderTimeout = "CODER_CLI_RESPONSE_HEADER_TIMEOUT"
+
+// cliResponseHeaderTimeout returns the configured response-header
+// timeout, falling back to defaultCLIResponseHeaderTimeout when the env
+// var is unset or unparseable.
+func cliResponseHeaderTimeout() time.Duration {
+	raw := os.Getenv(envCLIResponseHeaderTimeout)
+	if raw == "" {
+		return defaultCLIResponseHeaderTimeout
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		return defaultCLIResponseHeaderTimeout
+	}
+	return d
+}
+
 func (r *RootCmd) CoreSubcommands() []*serpent.Command {
 	// Please re-sort this list alphabetically if you change it!
 	return []*serpent.Command{
@@ -807,19 +838,26 @@ func (r *RootCmd) HeaderTransport(ctx context.Context, serverURL *url.URL) (*cod
 }
 
 func (r *RootCmd) createHTTPClient(ctx context.Context, serverURL *url.URL, inv *serpent.Invocation) (*http.Client, error) {
-	transport := http.DefaultTransport
+	// Always clone the default transport so we can apply a
+	// ResponseHeaderTimeout. http.DefaultTransport has no header-wait
+	// timer, so any coderd request that completes DNS/TCP/TLS but never
+	// receives response headers blocks until the TCP connection dies.
+	// Long-running invocations (`coder ssh --stdio` runs for the lifetime
+	// of an SSH session) cannot rely on a parent process to kill the
+	// hang, so we bound the header wait here. See coder/coder#24519.
+	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return nil, xerrors.New("http.DefaultTransport is not *http.Transport")
+	}
+	baseTransport := defaultTransport.Clone()
+	baseTransport.ResponseHeaderTimeout = cliResponseHeaderTimeout()
 
 	// Apply custom TLS config if specified
 	if r.tlsConfig != nil {
-		// Clone the default transport and apply TLS config
-		defaultTransport, ok := http.DefaultTransport.(*http.Transport)
-		if !ok {
-			return nil, xerrors.New("cannot apply TLS config: http.DefaultTransport is not *http.Transport")
-		}
-		customTransport := defaultTransport.Clone()
-		customTransport.TLSClientConfig = r.tlsConfig
-		transport = customTransport
+		baseTransport.TLSClientConfig = r.tlsConfig
 	}
+
+	var transport http.RoundTripper = baseTransport
 
 	transport = wrapTransportWithTelemetryHeader(transport, inv)
 	transport = wrapTransportWithUserAgentHeader(transport, inv)

--- a/cli/root_internal_test.go
+++ b/cli/root_internal_test.go
@@ -10,9 +10,11 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
@@ -472,4 +474,78 @@ func Test_ensureTLSConfig(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to parse CA certificate")
 	})
+}
+
+// Regression tests for https://github.com/coder/coder/issues/24519.
+// The CLI HTTP client used http.DefaultTransport with no
+// ResponseHeaderTimeout, so a server that completed DNS/TCP/TLS but
+// never sent response headers could hang the client indefinitely. The
+// fix sets ResponseHeaderTimeout on the cloned transport.
+func TestCLIResponseHeaderTimeout_FallbackToDefault(t *testing.T) {
+	t.Parallel()
+	require.Greater(t, defaultCLIResponseHeaderTimeout, 0*time.Second,
+		"the default must be positive or the original hang bug returns")
+}
+
+func TestCLIResponseHeaderTimeout_EnvOverride(t *testing.T) {
+	// Cannot t.Parallel: t.Setenv is used.
+	t.Run("ValidDuration", func(t *testing.T) {
+		t.Setenv(envCLIResponseHeaderTimeout, "15s")
+		require.Equal(t, 15*time.Second, cliResponseHeaderTimeout())
+	})
+
+	t.Run("InvalidIgnored", func(t *testing.T) {
+		t.Setenv(envCLIResponseHeaderTimeout, "not-a-duration")
+		require.Equal(t, defaultCLIResponseHeaderTimeout, cliResponseHeaderTimeout())
+	})
+
+	t.Run("ZeroIgnored", func(t *testing.T) {
+		// Allowing zero would silently restore the pre-#24519 bug. The
+		// override must clamp to the default.
+		t.Setenv(envCLIResponseHeaderTimeout, "0s")
+		require.Equal(t, defaultCLIResponseHeaderTimeout, cliResponseHeaderTimeout())
+	})
+
+	t.Run("NegativeIgnored", func(t *testing.T) {
+		t.Setenv(envCLIResponseHeaderTimeout, "-5s")
+		require.Equal(t, defaultCLIResponseHeaderTimeout, cliResponseHeaderTimeout())
+	})
+}
+
+// End-to-end check: a server that never sends response headers must not
+// hang the client. The env override shrinks the timeout to milliseconds
+// so the assertion completes in well under a second instead of 60.
+func TestCreateHTTPClient_HangingServer(t *testing.T) {
+	// Cannot t.Parallel: t.Setenv is used.
+	t.Setenv(envCLIResponseHeaderTimeout, "200ms")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		// Hold the connection open without writing headers. When the
+		// client times out via ResponseHeaderTimeout it tears the TCP
+		// connection down, which surfaces as request context
+		// cancellation here so the handler returns and srv.Close can
+		// complete without leaking this goroutine.
+		<-r.Context().Done()
+	}))
+	t.Cleanup(srv.Close)
+
+	serverURL, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	r := &RootCmd{noVersionCheck: true, noFeatureWarning: true}
+	cmd, err := r.Command(nil)
+	require.NoError(t, err)
+	inv := cmd.Invoke()
+	client, err := r.createHTTPClient(context.Background(), serverURL, inv)
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	start := time.Now()
+	resp, err := client.Do(req)
+	elapsed := time.Since(start)
+	require.Error(t, err, "request should fail when server never sends headers")
+	require.Nil(t, resp)
+	// Comfortable upper bound. The original bug would block here forever.
+	require.Less(t, elapsed, 5*time.Second,
+		"client must time out via ResponseHeaderTimeout instead of hanging")
 }

--- a/cli/ssh.go
+++ b/cli/ssh.go
@@ -67,7 +67,9 @@ var (
 )
 
 // isRetryableError checks for transient connection errors worth
-// retrying: DNS failures, connection refused, and server 5xx.
+// retrying: DNS failures, connection refused, transport-level timeouts
+// (e.g. ResponseHeaderTimeout from a server that completed DNS/TCP/TLS
+// but never sent headers, see coder/coder#24519), and server 5xx.
 func isRetryableError(err error) bool {
 	if err == nil || xerrors.Is(err, context.Canceled) {
 		return false
@@ -75,6 +77,30 @@ func isRetryableError(err error) bool {
 	// Check connection errors before context.DeadlineExceeded because
 	// net.Dialer.Timeout produces *net.OpError that matches both.
 	if codersdk.IsConnectionError(err) {
+		return true
+	}
+	// Transport-level timeouts surface from net/http as *url.Error.
+	// Most notably, the ResponseHeaderTimeout introduced in
+	// cli/root.go fires here when a server completes DNS/TCP/TLS but
+	// never sends response headers. The same shape covers
+	// IdleConnTimeout and any other transport-level timer.
+	//
+	// Without this branch, ResponseHeaderTimeout would short-circuit
+	// the next check (context.DeadlineExceeded is wrapped in the
+	// transport timeout chain) and turn a known retryable condition
+	// into a permanent failure for every CLI path that uses
+	// retryWithInterval. A bare context.DeadlineExceeded (from the
+	// caller's own ctx) is NOT a *url.Error, so it is not matched
+	// here; it falls through to the next check and short-circuits
+	// retry as intended.
+	//
+	// Note: when the caller's ctx expires DURING a request, client.Do
+	// wraps that into a *url.Error too. Returning true here is still
+	// correct because retryWithInterval's outer `r.Wait(ctx)` exits
+	// the loop the next iteration regardless of what isRetryableError
+	// says, so a canceled caller never triggers an extra retry.
+	var urlErr *url.Error
+	if xerrors.As(err, &urlErr) && urlErr.Timeout() {
 		return true
 	}
 	if xerrors.Is(err, context.DeadlineExceeded) {

--- a/cli/ssh_internal_test.go
+++ b/cli/ssh_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"sync"
@@ -532,6 +533,57 @@ func TestIsRetryableError(t *testing.T) {
 		assert.True(t, isRetryableError(err))
 		// Also when wrapped, as runCoderConnectStdio does.
 		assert.True(t, isRetryableError(xerrors.Errorf("dial coder connect: %w", err)))
+	})
+
+	// Regression for https://github.com/coder/coder/issues/24519.
+	// ResponseHeaderTimeout (introduced in cli/root.go) surfaces as
+	// *url.Error whose underlying error reports Timeout() == true.
+	// Without explicit handling in isRetryableError, the classifier
+	// would treat this as a non-retryable failure and the retry-wrapped
+	// CLI paths would bail on the first transient header timeout,
+	// converting "hang forever" into "permanent failure on first
+	// occurrence".
+	t.Run("ResponseHeaderTimeout", func(t *testing.T) {
+		t.Parallel()
+
+		hangCtx, cancelHang := context.WithCancel(context.Background())
+		defer cancelHang()
+		srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			// Hold the connection until the test signals shutdown
+			// through hangCtx or the client disconnects.
+			select {
+			case <-r.Context().Done():
+			case <-hangCtx.Done():
+			}
+		}))
+		t.Cleanup(srv.Close)
+
+		// Build a transport with a very short ResponseHeaderTimeout to
+		// reproduce the production behavior without waiting 60 seconds.
+		transport := &http.Transport{
+			ResponseHeaderTimeout: 100 * time.Millisecond,
+		}
+		client := &http.Client{Transport: transport}
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+		require.NoError(t, err)
+		_, err = client.Do(req)
+		require.Error(t, err, "client.Do must return an error when the server never sends headers")
+
+		// Sanity-check the exact error shape so a future net/http
+		// change can be debugged without re-reading the bug history.
+		// Note: net/http does wrap context.DeadlineExceeded into the
+		// chain for ResponseHeaderTimeout; the *url.Error.Timeout()
+		// check in isRetryableError must therefore run BEFORE the
+		// context.DeadlineExceeded short-circuit.
+		var urlErr *url.Error
+		require.ErrorAs(t, err, &urlErr)
+		require.True(t, urlErr.Timeout(), "*url.Error.Timeout() must report true")
+
+		assert.True(t, isRetryableError(err),
+			"transport-level ResponseHeaderTimeout must be retryable (issue #24519)")
+		// Also when wrapped, as CLI callers typically do via xerrors.Errorf.
+		assert.True(t, isRetryableError(xerrors.Errorf("fetch buildinfo: %w", err)),
+			"retryability must survive xerrors.Errorf wrapping")
 	})
 }
 


### PR DESCRIPTION
## Summary

`createHTTPClient` previously handed `http.DefaultTransport` (or a
clone with TLS settings applied) to the codersdk client without
setting `ResponseHeaderTimeout`. `http.Transport` has no header-wait
timer by default, so any coderd request that completes DNS/TCP/TLS
but never receives response headers blocks indefinitely. There is no
recovery unless the TCP connection itself dies or the context is
canceled, neither of which fires when TCP stays healthy while no
HTTP response arrives.

On 2026-04-15 this manifested as `coder ssh --stdio` producing no
stderr output for 17m55s after spawn, never logging the version
banner that `wrapTransportWithVersionCheck` emits on the first
successful coderd response. VS Code's local server eventually killed
the bootstrap as unrecoverable.

Two coordinated fixes (the issue body warned that doing only the
first turns "hang forever" into "permanent failure on first
occurrence"):

1. Always clone the default transport (so a TLS config is no longer
   the only path that gets a non-shared transport) and apply a
   60-second `ResponseHeaderTimeout` to the clone. The timeout only
   governs the time from request-sent to first header byte;
   streaming bodies, SSE, log follow, and WebSocket upgrades remain
   unaffected because all of those flush headers immediately and
   stream after. Add `CODER_CLI_RESPONSE_HEADER_TIMEOUT` as an
   escape hatch (accepts any positive Go duration; ignored when
   unset, zero, or negative).

2. Teach `isRetryableError` in cli/ssh.go about transport-level
   timeouts. `ResponseHeaderTimeout` surfaces as `*url.Error` whose
   underlying error reports `Timeout() == true` and also contains
   `context.DeadlineExceeded` in the chain. The existing classifier
   short-circuited on `context.DeadlineExceeded`, treating
   `ResponseHeaderTimeout` as non-retryable. The new check uses
   `*url.Error.Timeout()` and runs before the
   `context.DeadlineExceeded` short-circuit. A bare
   `context.DeadlineExceeded` from the caller's own context is not
   a `*url.Error` and still short-circuits retry as before.
   `retryWithInterval`'s outer `r.Wait(ctx)` exits the loop the
   next iteration when the caller's ctx is done, so a parent-context
   deadline never triggers an extra retry.

Fixes #24519.

## Test plan

- [x] `TestCLIResponseHeaderTimeout_FallbackToDefault`: the constant stays positive
- [x] `TestCLIResponseHeaderTimeout_EnvOverride`: valid durations win, invalid / zero / negative fall back
- [x] `TestCreateHTTPClient_HangingServer`: hanging server returns an error in well under a second when the env override shrinks the timeout to 200ms
- [x] `TestIsRetryableError/ResponseHeaderTimeout`: hanging httptest server, 100ms transport timeout, result is retryable
- [x] `TestIsRetryableError/ContextDeadlineExceeded`: still returns false (the two error shapes must remain distinguishable)
- [x] `TestIsRetryableError/DialTimeout`: still returns true