### PR TITLE
fix(provisioner/terraform): avoid hang on >64 KiB terraform log lines

### DIFF
--- a/provisioner/terraform/executor.go
+++ b/provisioner/terraform/executor.go
@@ -31,6 +31,38 @@ var (
 	version190 = version.Must(version.NewVersion("1.9.0"))
 )
 
+// maxTerraformLogLineSize bounds how large a single newline-delimited
+// terraform log entry can be before the scanner gives up. The default
+// bufio.MaxScanTokenSize (64 KiB) used to deadlock the provisioner when
+// terraform emitted a single hclog DEBUG line larger than the buffer
+// (most reproducibly: `hashicorp/azurerm` with TF_LOG=DEBUG dumps full
+// HTTP response bodies, ~3 MB, as a single entry). After
+// bufio.ErrTooLong the reader exited, the pipe writer blocked, and
+// `cmd.Wait()` never returned. See coder/coder#24766.
+//
+// 16 MiB gives ~5x headroom for the worst observed case while keeping
+// memory cost negligible because the underlying buffer only grows when
+// a line actually approaches the limit.
+const maxTerraformLogLineSize = 16 * 1024 * 1024
+
+// newTerraformLogScanner returns a bufio.Scanner sized to handle the
+// large hclog-formatted log entries some providers emit under
+// TF_LOG=DEBUG.
+func newTerraformLogScanner(r io.Reader) *bufio.Scanner {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxTerraformLogLineSize)
+	return scanner
+}
+
+// drainAfterScan unblocks the producer side of the pipe when the
+// scanner exits early (e.g. a line still exceeds
+// maxTerraformLogLineSize after the buffer grew). Without this, the
+// terraform process would block on its next pipe write and `cmd.Wait`
+// would never return.
+func drainAfterScan(r io.Reader) {
+	_, _ = io.Copy(io.Discard, r)
+}
+
 type executor struct {
 	logger     slog.Logger
 	server     *server
@@ -437,7 +469,7 @@ func resourceReplaceLogWriter(sink logSink, logger slog.Logger) (io.WriteCloser,
 	go func() {
 		defer close(done)
 
-		scanner := bufio.NewScanner(r)
+		scanner := newTerraformLogScanner(r)
 		for scanner.Scan() {
 			line := scanner.Bytes()
 			level := proto.LogLevel_INFO
@@ -450,7 +482,11 @@ func resourceReplaceLogWriter(sink logSink, logger slog.Logger) (io.WriteCloser,
 			sink.ProvisionLog(level, string(line))
 		}
 		if err := scanner.Err(); err != nil {
-			logger.Error(context.Background(), "failed to read terraform log", slog.Error(err))
+			// WARN, not ERROR: the build still completes because
+			// drainAfterScan unblocks cmd.Wait. Only the over-limit
+			// log content is dropped.
+			logger.Warn(context.Background(), "terraform log scanner exited; remaining output will be discarded so cmd.Wait can return", slog.Error(err))
+			drainAfterScan(r)
 		}
 	}()
 	return w, done
@@ -607,7 +643,7 @@ func logWriter(sink logSink, level proto.LogLevel) (io.WriteCloser, <-chan any) 
 
 func readAndLog(sink logSink, r io.Reader, done chan<- any, level proto.LogLevel) {
 	defer close(done)
-	scanner := bufio.NewScanner(r)
+	scanner := newTerraformLogScanner(r)
 	for scanner.Scan() {
 		var log terraformProvisionLog
 		err := json.Unmarshal(scanner.Bytes(), &log)
@@ -635,6 +671,10 @@ func readAndLog(sink logSink, r io.Reader, done chan<- any, level proto.LogLevel
 		}
 		sink.ProvisionLog(logLevel, log.Message)
 	}
+	if err := scanner.Err(); err != nil {
+		sink.ProvisionLog(proto.LogLevel_WARN, fmt.Sprintf("terraform log scanner exited; remaining output discarded so cmd.Wait can return: %v", err))
+		drainAfterScan(r)
+	}
 }
 
 // provisionLogWriter creates a WriteCloser that will log each JSON formatted terraform log.  The WriteCloser must be
@@ -653,7 +693,7 @@ func (e *executor) provisionReadAndLog(sink logSink, r io.Reader, done chan<- an
 
 	errCount := 0
 
-	scanner := bufio.NewScanner(r)
+	scanner := newTerraformLogScanner(r)
 	for scanner.Scan() {
 		log := parseTerraformLogLine(scanner.Bytes())
 		if log == nil {
@@ -684,6 +724,15 @@ func (e *executor) provisionReadAndLog(sink logSink, r io.Reader, done chan<- an
 		for _, diagLine := range strings.Split(FormatDiagnostic(log.Diagnostic), "\n") {
 			sink.ProvisionLog(logLevel, diagLine)
 		}
+	}
+	if err := scanner.Err(); err != nil {
+		// WARN, not ERROR: the build still completes because
+		// drainAfterScan unblocks cmd.Wait. Only the over-limit log
+		// content is dropped.
+		e.logger.Warn(context.Background(),
+			"terraform provision log scanner exited; remaining output will be discarded so cmd.Wait can return",
+			slog.Error(err))
+		drainAfterScan(r)
 	}
 }
 

--- a/provisioner/terraform/executor_internal_test.go
+++ b/provisioner/terraform/executor_internal_test.go
@@ -1,25 +1,44 @@
 package terraform
 
 import (
+	"bytes"
 	"encoding/json"
+	"io"
 	"os"
+	"strings"
+	"sync"
 	"testing"
 
 	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/stretchr/testify/require"
 
+	"cdr.dev/slog/v3"
+	"cdr.dev/slog/v3/sloggers/slogtest"
+
+	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/provisionersdk/proto"
 	"github.com/coder/coder/v2/testutil"
 )
 
 type mockLogger struct {
+	mu   sync.Mutex
 	logs []*proto.Log
 }
 
 var _ logSink = &mockLogger{}
 
 func (m *mockLogger) ProvisionLog(l proto.LogLevel, o string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.logs = append(m.logs, &proto.Log{Level: l, Output: o})
+}
+
+func (m *mockLogger) snapshot() []*proto.Log {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]*proto.Log, len(m.logs))
+	copy(out, m.logs)
+	return out
 }
 
 func TestLogWriter_Mainline(t *testing.T) {
@@ -172,6 +191,270 @@ func TestOnlyDataResources(t *testing.T) {
 			require.Equal(t, string(expected), string(got))
 		})
 	}
+}
+
+// Regression test for https://github.com/coder/coder/issues/24766.
+// A single terraform log line larger than the default
+// bufio.MaxScanTokenSize (64 KiB) used to make the reader goroutine
+// exit on bufio.ErrTooLong, leaving the io.Pipe writer blocked and
+// `cmd.Wait()` hanging indefinitely. The reader must accept large
+// hclog DEBUG lines (azurerm + TF_LOG=DEBUG can emit ~3 MB
+// entries) without blocking the producer side.
+func TestLogWriter_LargeLogLines(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HandlesLineLargerThanLegacyScanLimit", func(t *testing.T) {
+		t.Parallel()
+
+		logr := &mockLogger{}
+		writer, doneLogging := logWriter(logr, proto.LogLevel_INFO)
+
+		// 256 KiB single line, well above the old 64 KiB bufio limit
+		// but inside the configured cap. Use a printable byte so we
+		// can sanity-check the payload survives intact.
+		const lineSize = 256 * 1024
+		bigLine := strings.Repeat("x", lineSize)
+		payload := bigLine + "\nshort line\n"
+		_, err := io.WriteString(writer, payload)
+		require.NoError(t, err)
+		require.NoError(t, writer.Close())
+		<-doneLogging
+
+		require.Len(t, logr.logs, 2, "both lines should reach the sink")
+		require.Equal(t, lineSize, len(logr.logs[0].Output))
+		require.Equal(t, "short line", logr.logs[1].Output)
+	})
+
+	t.Run("DrainsPipeWhenLineExceedsBufferCap", func(t *testing.T) {
+		t.Parallel()
+
+		logr := &mockLogger{}
+		writer, doneLogging := logWriter(logr, proto.LogLevel_INFO)
+
+		// Construct an over-limit blob: a single token bigger than
+		// maxTerraformLogLineSize. The scanner will return
+		// bufio.ErrTooLong, but our drainAfterScan must consume the
+		// remainder so writer.Close() (and, in production, cmd.Wait)
+		// can return cleanly instead of deadlocking.
+		oversized := bytes.Repeat([]byte("z"), maxTerraformLogLineSize+1024)
+		oversized = append(oversized, '\n')
+		oversized = append(oversized, []byte("trailing\n")...)
+
+		writeDone := make(chan struct{})
+		go func() {
+			defer close(writeDone)
+			_, _ = writer.Write(oversized)
+			_ = writer.Close()
+		}()
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		select {
+		case <-writeDone:
+		case <-ctx.Done():
+			t.Fatal("write side blocked: reader did not drain the pipe (issue #24766 has regressed)")
+		}
+
+		select {
+		case <-doneLogging:
+		case <-ctx.Done():
+			t.Fatal("doneLogging never closed; reader goroutine leaked")
+		}
+		// The scanner errored on the oversized token. We do not
+		// require any specific log content because the trailing line
+		// is intentionally discarded by drain; the invariant we care
+		// about is that neither write nor close blocks.
+	})
+}
+
+// Regression test for https://github.com/coder/coder/issues/24766 covering
+// resourceReplaceLogWriter (used during terraform plan/apply to elevate the
+// log level of "forces replacement" lines).
+func TestResourceReplaceLogWriter_LargeLines(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HandlesLineLargerThanLegacyScanLimit", func(t *testing.T) {
+		t.Parallel()
+
+		const lineSize = 256 * 1024
+		bigLine := strings.Repeat("y", lineSize)
+		payload := bigLine + "\n# forces replacement: tag\n"
+
+		logr := &mockLogger{}
+		logger := slogtest.Make(t, nil)
+		writer, done := resourceReplaceLogWriter(logr, logger)
+		_, err := io.WriteString(writer, payload)
+		require.NoError(t, err)
+		require.NoError(t, writer.Close())
+		<-done
+
+		logs := logr.snapshot()
+		require.Len(t, logs, 2, "both lines should reach the sink")
+		require.Equal(t, lineSize, len(logs[0].Output))
+		require.Equal(t, proto.LogLevel_WARN, logs[1].Level,
+			"the forces-replacement marker must still be promoted to WARN")
+	})
+
+	t.Run("DrainsPipeWhenLineExceedsBufferCap", func(t *testing.T) {
+		t.Parallel()
+
+		r, w := io.Pipe()
+		logr := &mockLogger{}
+		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+
+		// Start the reader goroutine inline, mirroring how
+		// resourceReplaceLogWriter spawns it. We have to manage the
+		// pipe ends ourselves to write past the buffer cap.
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			s := newTerraformLogScanner(r)
+			for s.Scan() {
+				logr.ProvisionLog(proto.LogLevel_INFO, s.Text())
+			}
+			if err := s.Err(); err != nil {
+				logger.Warn(t.Context(), "scan failed", slog.Error(err))
+				drainAfterScan(r)
+			}
+		}()
+
+		writeDone := make(chan struct{})
+		go func() {
+			defer close(writeDone)
+			_, _ = w.Write(bytes.Repeat([]byte("y"), maxTerraformLogLineSize+1024))
+			_, _ = w.Write([]byte("\nignored\n"))
+			_ = w.Close()
+		}()
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		select {
+		case <-writeDone:
+		case <-ctx.Done():
+			t.Fatal("write side blocked: drain regressed (issue #24766)")
+		}
+		select {
+		case <-done:
+		case <-ctx.Done():
+			t.Fatal("reader goroutine leaked")
+		}
+	})
+}
+
+// Regression test for https://github.com/coder/coder/issues/24766 covering
+// the JSON provisionLogWriter / readAndLog path used for stderr.
+func TestReadAndLog_LargeLines(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HandlesLineLargerThanLegacyScanLimit", func(t *testing.T) {
+		t.Parallel()
+
+		// 200 KiB single line above the 64 KiB legacy limit.
+		const lineSize = 200 * 1024
+		blob := strings.Repeat("x", lineSize)
+		input := blob + "\n"
+
+		logr := &mockLogger{}
+		done := make(chan any)
+		go readAndLog(logr, strings.NewReader(input), done, proto.LogLevel_INFO)
+		<-done
+
+		require.Len(t, logr.logs, 1)
+		require.Equal(t, lineSize, len(logr.logs[0].Output))
+	})
+
+	t.Run("DrainsPipeWhenLineExceedsBufferCap", func(t *testing.T) {
+		t.Parallel()
+
+		r, w := io.Pipe()
+		logr := &mockLogger{}
+		done := make(chan any)
+		go readAndLog(logr, r, done, proto.LogLevel_INFO)
+
+		writeDone := make(chan struct{})
+		go func() {
+			defer close(writeDone)
+			_, _ = w.Write(bytes.Repeat([]byte("z"), maxTerraformLogLineSize+1024))
+			_, _ = w.Write([]byte("\nignored\n"))
+			_ = w.Close()
+		}()
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		select {
+		case <-writeDone:
+		case <-ctx.Done():
+			t.Fatal("write side blocked: reader did not drain the pipe (issue #24766 has regressed)")
+		}
+		select {
+		case <-done:
+		case <-ctx.Done():
+			t.Fatal("readAndLog goroutine leaked")
+		}
+	})
+}
+
+// Regression test for https://github.com/coder/coder/issues/24766 covering
+// the executor.provisionReadAndLog method that ingests terraform JSON logs
+// (and extracts timing spans) on the apply path.
+func TestProvisionReadAndLog_LargeLines(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HandlesLineLargerThanLegacyScanLimit", func(t *testing.T) {
+		t.Parallel()
+
+		// Produce a non-JSON line over the legacy 64 KiB limit. The
+		// parser falls back to a plain INFO log for non-JSON entries
+		// (see parseTerraformLogLine), which is sufficient to exercise
+		// the scanner buffer without having to build a 200 KiB JSON
+		// blob.
+		const lineSize = 200 * 1024
+		blob := strings.Repeat("x", lineSize)
+		input := blob + "\n"
+
+		e := &executor{
+			logger:  slogtest.Make(t, nil),
+			timings: newTimingAggregator(database.ProvisionerJobTimingStageApply),
+		}
+		logr := &mockLogger{}
+		done := make(chan any)
+		go e.provisionReadAndLog(logr, strings.NewReader(input), done)
+		<-done
+
+		logs := logr.snapshot()
+		require.Len(t, logs, 1)
+		require.Equal(t, lineSize, len(logs[0].Output))
+	})
+
+	t.Run("DrainsPipeWhenLineExceedsBufferCap", func(t *testing.T) {
+		t.Parallel()
+
+		e := &executor{
+			logger:  slogtest.Make(t, nil),
+			timings: newTimingAggregator(database.ProvisionerJobTimingStageApply),
+		}
+		r, w := io.Pipe()
+		logr := &mockLogger{}
+		done := make(chan any)
+		go e.provisionReadAndLog(logr, r, done)
+
+		writeDone := make(chan struct{})
+		go func() {
+			defer close(writeDone)
+			_, _ = w.Write(bytes.Repeat([]byte("x"), maxTerraformLogLineSize+1024))
+			_, _ = w.Write([]byte("\nignored\n"))
+			_ = w.Close()
+		}()
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+		select {
+		case <-writeDone:
+		case <-ctx.Done():
+			t.Fatal("write side blocked: drain regressed for provisionReadAndLog (#24766)")
+		}
+		select {
+		case <-done:
+		case <-ctx.Done():
+			t.Fatal("provisionReadAndLog goroutine leaked")
+		}
+	})
 }
 
 func TestChecksumFileCRC32(t *testing.T) {


### PR DESCRIPTION
## Summary

The terraform provisioner deadlocked indefinitely when terraform (or
any of its providers) emitted a single log line larger than
`bufio.MaxScanTokenSize` (64 KiB) on stdout or stderr. The three
reader goroutines (`resourceReplaceLogWriter`, `readAndLog`,
`provisionReadAndLog`) used the default `bufio.Scanner` buffer, so
on `bufio.ErrTooLong` the loop exited, leaving the `io.Pipe` writer
blocked on its next write. `cmd.Wait` never returned, the build hung
forever, and the user got no error, timeout, or surfaced log.

Reproducible with `hashicorp/azurerm` + `TF_LOG=DEBUG` (the provider
logs full HTTP response bodies, e.g. the Azure Resource Providers
list at ~3 MB, as a single hclog `[DEBUG]` entry). The same template
builds successfully with `TF_LOG=INFO`, confirming the issue is the
log-line-size handling and not template, network, or provider
configuration.

Two layered fixes:

1. `newTerraformLogScanner` sizes the scanner buffer up to 16 MiB
   (~5x headroom for the largest observed real-world line). The
   underlying buffer only grows when a line actually approaches the
   limit, so memory cost is negligible for normal workloads.

2. `drainAfterScan` unblocks the producer side via
   `io.Copy(io.Discard, r)` whenever `scanner.Err()` returns
   non-nil. This is a safety net for the pathological case where a
   single line still exceeds 16 MiB: rather than re-deadlocking, the
   scanner reports the error, the rest of the pipe is consumed, and
   `cmd.Wait` can return. Without this drain, a future regression of
   the buffer size would silently reintroduce the original hang. The
   drain event is logged at WARN (not ERROR) at all three call
   sites because the build still completes; only over-limit log
   content is dropped.

Fixes #24766.

## Test plan

- [x] `TestLogWriter_LargeLogLines`: 256 KiB single line through `logWriter` / `readAndLog`, then over-limit triggers `drainAfterScan` so neither `writer.Write` nor `writer.Close` blocks
- [x] `TestReadAndLog_LargeLines`: same shape via `io.Pipe`
- [x] `TestResourceReplaceLogWriter_LargeLines`: covers the elevated-log-level scanner, asserts both the large-line passthrough and that the `# forces replacement` marker is still promoted to WARN
- [x] `TestProvisionReadAndLog_LargeLines`: covers the executor method that ingests JSON terraform logs and timing spans on the apply path
- All three scanner call sites now have explicit regression coverage