### PR TITLE
fix(agent/agentssh): re-derive login env so chsh in startup wins

### DIFF
--- a/agent/agentssh/agentssh.go
+++ b/agent/agentssh/agentssh.go
@@ -931,7 +931,16 @@ func (s *Server) CommandEnv(ei usershell.EnvInfoer, addEnv []string) (shell, dir
 		}
 		dir = homedir
 	}
-	env = append(ei.Environ(), addEnv...)
+	// USER, LOGNAME, and SHELL captured at agent process startup go
+	// stale when the workspace startup script edits /etc/passwd
+	// (e.g. `chsh -s /usr/bin/zsh`). Drop them here so the fresh
+	// values appended below win during the agent's first-wins
+	// dedup in updateCommandEnv. See coder/coder#24414. Values
+	// passed in via addEnv (template env vars, `coder ssh --env ...`)
+	// still take precedence because addEnv comes before the fresh
+	// values in the list and therefore wins the dedup.
+	env = filterLoginEnv(ei.Environ())
+	env = append(env, addEnv...)
 	// Set login variables (see `man login`).
 	env = append(env, fmt.Sprintf("USER=%s", username))
 	env = append(env, fmt.Sprintf("LOGNAME=%s", username))
@@ -943,6 +952,28 @@ func (s *Server) CommandEnv(ei usershell.EnvInfoer, addEnv []string) (shell, dir
 	}
 
 	return shell, dir, env, nil
+}
+
+// filterLoginEnv returns env with any USER, LOGNAME, or SHELL entries
+// removed. CommandEnv re-derives these from /etc/passwd on every
+// session so the inherited values from the agent process (captured at
+// agent startup) cannot leak into sessions after the startup script
+// runs `chsh` / `usermod`.
+func filterLoginEnv(env []string) []string {
+	filtered := make([]string, 0, len(env))
+	for _, kv := range env {
+		key, _, ok := strings.Cut(kv, "=")
+		if !ok {
+			filtered = append(filtered, kv)
+			continue
+		}
+		switch key {
+		case "USER", "LOGNAME", "SHELL":
+			continue
+		}
+		filtered = append(filtered, kv)
+	}
+	return filtered
 }
 
 // CreateCommand processes raw command input with OpenSSH-like behavior.

--- a/agent/agentssh/agentssh_internal_test.go
+++ b/agent/agentssh/agentssh_internal_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"io"
 	"net"
+	"os/user"
 	"testing"
 
 	gliderssh "github.com/gliderlabs/ssh"
@@ -204,4 +205,189 @@ func (testSSHContext) SetValue(_, _ interface{}) {
 
 func (testSSHContext) KeepAlive() *gliderssh.SessionKeepAlive {
 	panic("not implemented")
+}
+
+func TestFilterLoginEnv(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "DropsLoginVars",
+			in:   []string{"USER=root", "LOGNAME=root", "SHELL=/bin/bash", "PATH=/usr/bin"},
+			want: []string{"PATH=/usr/bin"},
+		},
+		{
+			name: "KeepsEntriesWithoutEquals",
+			in:   []string{"NOEQUALS", "SHELL=/bin/bash", "OK=1"},
+			want: []string{"NOEQUALS", "OK=1"},
+		},
+		{
+			name: "CaseSensitive",
+			in:   []string{"shell=foo", "Shell=bar", "SHELL=baz"},
+			// USER/LOGNAME/SHELL are upper-case in POSIX, and
+			// usershell.SystemEnvInfo.Shell only emits the upper-case
+			// SHELL= key (see agent/usershell/usershell.go). The agent
+			// therefore only needs to strip the upper-case forms; a
+			// lower-case "shell" set by a user must pass through.
+			want: []string{"shell=foo", "Shell=bar"},
+		},
+		{
+			name: "EmptyInput",
+			in:   []string{},
+			want: []string{},
+		},
+		{
+			name: "EmptyValueStillFiltered",
+			in:   []string{"SHELL=", "PATH=/x"},
+			want: []string{"PATH=/x"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := filterLoginEnv(tt.in)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// Regression test for https://github.com/coder/coder/issues/24414.
+// The agent process snapshots SHELL=/bin/bash from os.Environ() at
+// startup, then the workspace startup script runs `chsh -s /usr/bin/zsh`.
+// Sessions created afterwards must see SHELL=/usr/bin/zsh (the fresh
+// /etc/passwd value), not the stale snapshot.
+func TestCommandEnv_FreshShellWinsOverStaleEnv(t *testing.T) {
+	t.Parallel()
+
+	stale := []string{
+		// What os.Environ() returns inside the agent process after
+		// the agent booted but before chsh ran.
+		"SHELL=/bin/bash",
+		"USER=staleuser",
+		"LOGNAME=staleuser",
+		"PATH=/usr/bin",
+	}
+	ei := &fakeEnvInfoer{
+		userFn:    func() (*user.User, error) { return &user.User{Username: "coder", HomeDir: "/home/coder"}, nil },
+		shellFn:   func(string) (string, error) { return "/usr/bin/zsh", nil },
+		environFn: func() []string { return stale },
+		homeDirFn: func() (string, error) { return "/home/coder", nil },
+	}
+
+	s := &Server{config: &Config{
+		WorkingDirectory: func() string { return "/home/coder" },
+		UpdateEnv: func(current []string) ([]string, error) {
+			// Mirror agent.updateCommandEnv's first-wins dedup. With
+			// the legacy ordering (SHELL=/bin/bash from os.Environ
+			// first), this loop would lock in the stale shell.
+			seen := map[string]string{}
+			for _, kv := range current {
+				key, val, ok := splitEnv(kv)
+				if !ok {
+					continue
+				}
+				if _, dup := seen[key]; !dup {
+					seen[key] = val
+				}
+			}
+			out := make([]string, 0, len(seen))
+			for k, v := range seen {
+				out = append(out, k+"="+v)
+			}
+			return out, nil
+		},
+	}}
+
+	shell, _, env, err := s.CommandEnv(ei, nil)
+	require.NoError(t, err)
+	require.Equal(t, "/usr/bin/zsh", shell, "Shell return value must come from the passwd read")
+
+	got := envMap(env)
+	require.Equal(t, "/usr/bin/zsh", got["SHELL"], "fresh SHELL must win over the stale agent-startup snapshot")
+	require.Equal(t, "coder", got["USER"], "fresh USER must win over the stale snapshot")
+	require.Equal(t, "coder", got["LOGNAME"], "fresh LOGNAME must win over the stale snapshot")
+	require.Equal(t, "/usr/bin", got["PATH"], "non-login env vars from the agent process must still be inherited")
+}
+
+// addEnv (passed by users via e.g. `coder ssh --env SHELL=...`) wins
+// over both the stale snapshot and the fresh passwd value. This locks
+// in the precedence order the CommandEnv docstring promises and
+// guards against an over-aggressive fix to #24414 that would also
+// drop user-specified overrides.
+func TestCommandEnv_AddEnvShellWins(t *testing.T) {
+	t.Parallel()
+
+	ei := &fakeEnvInfoer{
+		userFn:    func() (*user.User, error) { return &user.User{Username: "coder", HomeDir: "/home/coder"}, nil },
+		shellFn:   func(string) (string, error) { return "/usr/bin/zsh", nil },
+		environFn: func() []string { return []string{"SHELL=/bin/bash"} },
+		homeDirFn: func() (string, error) { return "/home/coder", nil },
+	}
+
+	s := &Server{config: &Config{
+		WorkingDirectory: func() string { return "/home/coder" },
+		UpdateEnv: func(current []string) ([]string, error) {
+			seen := map[string]string{}
+			for _, kv := range current {
+				key, val, ok := splitEnv(kv)
+				if !ok {
+					continue
+				}
+				if _, dup := seen[key]; !dup {
+					seen[key] = val
+				}
+			}
+			out := make([]string, 0, len(seen))
+			for k, v := range seen {
+				out = append(out, k+"="+v)
+			}
+			return out, nil
+		},
+	}}
+
+	_, _, env, err := s.CommandEnv(ei, []string{"SHELL=/opt/fish/bin/fish"})
+	require.NoError(t, err)
+	require.Equal(t, "/opt/fish/bin/fish", envMap(env)["SHELL"],
+		"explicit addEnv SHELL must override both the stale snapshot and the passwd value")
+}
+
+type fakeEnvInfoer struct {
+	userFn    func() (*user.User, error)
+	shellFn   func(string) (string, error)
+	environFn func() []string
+	homeDirFn func() (string, error)
+}
+
+func (f *fakeEnvInfoer) User() (*user.User, error)      { return f.userFn() }
+func (f *fakeEnvInfoer) Shell(u string) (string, error) { return f.shellFn(u) }
+func (f *fakeEnvInfoer) Environ() []string              { return f.environFn() }
+func (f *fakeEnvInfoer) HomeDir() (string, error)       { return f.homeDirFn() }
+func (*fakeEnvInfoer) ModifyCommand(c string, a ...string) (string, []string) {
+	return c, a
+}
+
+func splitEnv(kv string) (string, string, bool) {
+	for i := 0; i < len(kv); i++ {
+		if kv[i] == '=' {
+			return kv[:i], kv[i+1:], true
+		}
+	}
+	return "", "", false
+}
+
+func envMap(env []string) map[string]string {
+	m := map[string]string{}
+	for _, kv := range env {
+		k, v, ok := splitEnv(kv)
+		if !ok {
+			continue
+		}
+		m[k] = v
+	}
+	return m
 }


### PR DESCRIPTION
## Summary

`CommandEnv` captured `os.Environ()` into the per-session env list
and then appended fresh `USER`, `LOGNAME`, and `SHELL` values derived
from a live `/etc/passwd` read. `updateCommandEnv` in agent/agent.go
does first-wins dedup over that list, so the snapshot taken at agent
process startup permanently shadowed the fresh values.

Concretely: on first workspace boot the agent comes up with
`SHELL=/bin/bash` inherited from the host. The startup script then
runs `chsh -s /usr/bin/zsh`, which correctly updates `/etc/passwd`.
But `ei.Shell(username)` returning `/usr/bin/zsh` was appended after
`SHELL=/bin/bash`, so the dedup pinned the stale shell for every
subsequent SSH, web terminal, and reconnecting PTY session for the
lifetime of the agent process. The same goes for `USER` and
`LOGNAME` if the startup script ever runs `usermod`.

Filter `USER`, `LOGNAME`, and `SHELL` out of `ei.Environ()` before
appending `addEnv` and the freshly derived values. User-supplied
overrides (passed via `addEnv`, e.g. `coder ssh --env SHELL=...`)
still come first in the list and therefore continue to win the
dedup, so the documented precedence (user override > passwd >
stale snapshot) now matches what the code does.

Fixes #24414.

## Test plan

- [x] `TestFilterLoginEnv`: drops the three login vars, leaves malformed entries alone, treats the name match case-sensitively, handles empty values, handles empty input (5 subtests)
- [x] `TestCommandEnv_FreshShellWinsOverStaleEnv`: stubbed `UpdateEnv` mirrors `updateCommandEnv`'s first-wins dedup; asserts `SHELL`, `USER`, `LOGNAME` all reflect the fresh values while non-login vars (PATH) survive
- [x] `TestCommandEnv_AddEnvShellWins`: an explicit `addEnv SHELL` still overrides both the stale snapshot and the passwd value
- All tests under `//go:build !windows` since `CommandEnv` reads passwd