### PR TITLE
fix(site): stop running workspace before changing template version

### DIFF
--- a/site/src/api/api.test.ts
+++ b/site/src/api/api.test.ts
@@ -275,6 +275,102 @@ describe("api.ts", () => {
 		});
 	});
 
+	// Regression tests for https://github.com/coder/coder/issues/24333.
+	// changeWorkspaceVersion used to skip the stop-before-start step, so
+	// long-lived infrastructure (EC2, bare VMs) kept the previous agent
+	// process attached to an invalidated token across the version change.
+	describe("changeWorkspaceVersion", () => {
+		describe("given a running workspace", () => {
+			it("stops with current version before starting with the chosen version", async () => {
+				vi.spyOn(API, "getWorkspaceBuildParameters").mockResolvedValue([]);
+				vi.spyOn(API, "getTemplateVersionRichParameters").mockResolvedValue([]);
+				const stopBuild = {
+					...MockWorkspaceBuild,
+					transition: "stop" as const,
+					status: "stopped" as const,
+				};
+				vi.spyOn(API, "postWorkspaceBuild").mockResolvedValueOnce(stopBuild);
+				vi.spyOn(API, "waitForBuild").mockResolvedValueOnce(stopBuild);
+				vi.spyOn(API, "postWorkspaceBuild").mockResolvedValueOnce({
+					...MockWorkspaceBuild,
+					template_version_id: MockTemplateVersion2.id,
+					transition: "start",
+				});
+
+				await API.changeWorkspaceVersion(
+					MockWorkspace,
+					MockTemplateVersion2.id,
+				);
+
+				expect(API.postWorkspaceBuild).toHaveBeenCalledTimes(2);
+				expect(API.postWorkspaceBuild).toHaveBeenNthCalledWith(
+					1,
+					MockWorkspace.id,
+					{
+						transition: "stop",
+						log_level: undefined,
+					},
+				);
+				expect(API.postWorkspaceBuild).toHaveBeenNthCalledWith(
+					2,
+					MockWorkspace.id,
+					{
+						transition: "start",
+						template_version_id: MockTemplateVersion2.id,
+						rich_parameter_values: [],
+					},
+				);
+			});
+
+			it("rejects when the intermediate stop build is canceled", async () => {
+				vi.spyOn(API, "getWorkspaceBuildParameters").mockResolvedValue([]);
+				vi.spyOn(API, "getTemplateVersionRichParameters").mockResolvedValue([]);
+				const stopBuild = {
+					...MockWorkspaceBuild,
+					transition: "stop" as const,
+				};
+				vi.spyOn(API, "postWorkspaceBuild").mockResolvedValueOnce(stopBuild);
+				vi.spyOn(API, "waitForBuild").mockResolvedValueOnce({
+					...stopBuild,
+					status: "canceled",
+				});
+
+				await expect(
+					API.changeWorkspaceVersion(MockWorkspace, MockTemplateVersion2.id),
+				).rejects.toThrow(/canceled/i);
+				// The start build must not be issued after a canceled stop.
+				expect(API.postWorkspaceBuild).toHaveBeenCalledTimes(1);
+			});
+		});
+
+		describe("given a stopped workspace", () => {
+			it("skips the stop step and starts directly", async () => {
+				vi.spyOn(API, "getWorkspaceBuildParameters").mockResolvedValue([]);
+				vi.spyOn(API, "getTemplateVersionRichParameters").mockResolvedValue([]);
+				vi.spyOn(API, "postWorkspaceBuild").mockResolvedValueOnce({
+					...MockWorkspaceBuild,
+					template_version_id: MockTemplateVersion2.id,
+					transition: "start",
+				});
+
+				await API.changeWorkspaceVersion(
+					MockStoppedWorkspace,
+					MockTemplateVersion2.id,
+				);
+
+				expect(API.postWorkspaceBuild).toHaveBeenCalledTimes(1);
+				expect(API.postWorkspaceBuild).toHaveBeenCalledWith(
+					MockStoppedWorkspace.id,
+					{
+						transition: "start",
+						template_version_id: MockTemplateVersion2.id,
+						rich_parameter_values: [],
+					},
+				);
+			});
+		});
+	});
+
 	describe("chat configuration endpoints", () => {
 		it.each<[string, () => Promise<unknown>, unknown]>([
 			[

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -2451,6 +2451,15 @@ class ApiMethods {
 	 * - Update the build parameters and check if there are missed parameters for
 	 *   the new version
 	 *   - If there are missing parameters raise an error
+	 * - Stop the workspace with the current template version if it is already
+	 *   running, mirroring updateWorkspace, so resources with `ignore_changes`
+	 *   (prebuilds in particular) are recreated, agent tokens are refreshed
+	 *   in the new build, and startup scripts re-execute. See coder/coder#24333
+	 *   and the original stop-before-start rationale in #17840 / #20333.
+	 *   Note: this also applies when `templateVersionId` matches the current
+	 *   build's version (e.g. the user re-selects the same version to apply
+	 *   parameter changes). The workspace will be restarted in that case,
+	 *   matching `updateWorkspace`'s behavior.
 	 * - Create a build with the version and updated build parameters
 	 */
 	changeWorkspaceVersion = async (
@@ -2483,6 +2492,24 @@ class ApiMethods {
 
 		if (missingParameters.length > 0) {
 			throw new MissingBuildParameters(missingParameters, templateVersionId);
+		}
+
+		// Stop the workspace if it is already running. Without this, long-lived
+		// infrastructure (EC2 instances, bare VMs) keeps the existing agent
+		// process attached to invalidated tokens because the Terraform apply
+		// updates resources in-place rather than tearing them down.
+		if (workspace.latest_build.status === "running") {
+			const stopBuild = await this.stopWorkspace(workspace.id);
+			const awaitedStopBuild = await this.waitForBuild(stopBuild);
+			// If the stop is canceled halfway through we bail, matching
+			// updateWorkspace's behavior.
+			if (awaitedStopBuild?.status === "canceled") {
+				return Promise.reject(
+					new Error(
+						"Workspace stop was canceled, not proceeding with version change.",
+					),
+				);
+			}
 		}
 
 		return this.postWorkspaceBuild(workspace.id, {

--- a/site/src/modules/workspaces/WorkspaceMoreActions/WorkspaceMoreActions.tsx
+++ b/site/src/modules/workspaces/WorkspaceMoreActions/WorkspaceMoreActions.tsx
@@ -70,13 +70,30 @@ export const WorkspaceMoreActions: FC<WorkspaceMoreActionsProps> = ({
 
 	// Change version
 	const [changeVersionDialogOpen, setChangeVersionDialogOpen] = useState(false);
-	const changeVersionMutation = useMutation(
-		changeVersion(
-			workspace,
-			queryClient,
-			!workspace.template_use_classic_parameter_flow,
-		),
+	const changeVersionOptions = changeVersion(
+		workspace,
+		queryClient,
+		!workspace.template_use_classic_parameter_flow,
 	);
+	const changeVersionMutation = useMutation({
+		...changeVersionOptions,
+		// MissingBuildParameters and ParameterValidationError are surfaced
+		// through the dedicated dialogs below via `changeVersionMutation.error`,
+		// so let those pass through to the dialog renderer. Every other
+		// failure (most importantly the canceled stop build introduced
+		// by coder/coder#24333, but also generic 5xx / network errors)
+		// would otherwise be silent because react-query does not surface
+		// mutation errors itself.
+		onError: (error: unknown) => {
+			if (
+				error instanceof MissingBuildParameters ||
+				error instanceof ParameterValidationError
+			) {
+				return;
+			}
+			handleError(error);
+		},
+	});
 
 	const handleError = (error: unknown) => {
 		if (isApiError(error) && error.code === "ERR_BAD_REQUEST") {


### PR DESCRIPTION
## Summary

Changing the template version of a running workspace via "More
actions → Change version..." (or the equivalent API call) skipped
the stop-before-start logic that `updateWorkspace` performs. For
workspaces backed by long-lived infrastructure (EC2 instances, bare
VMs), the agent process kept running after the Terraform apply with
an invalidated token, never re-executed startup scripts, and
resources marked `ignore_changes` (notably prebuilds) were never
recreated. Container-based workspaces survived only because the
container teardown happened to kill the old agent process.

This is the same class of bug as #17840 and #20333. PR #18425 added
stop-before-start to `updateWorkspace` but the parallel path through
`changeWorkspaceVersion` was missed.

Add the same stop-before-start guard, including the canceled-stop
short circuit. The reject message names "version change" so the user
toast distinguishes this from a canceled regular update.

Also wire `onError: handleError` on the `changeVersionMutation`
caller in `WorkspaceMoreActions.tsx`. Pre-fix the rejection branch
was unreachable (no stop was ever issued), so the missing handler
was benign; post-fix the canceled-stop path is reachable and would
otherwise be silent. `MissingBuildParameters` and
`ParameterValidationError` are passed through to the existing dialog
renderers via `changeVersionMutation.error`.

Fixes #24333.

## Test plan

- [x] `pnpm vitest run src/api/api.test.ts` passes (26/26, including 3 new `changeWorkspaceVersion` cases: stop-then-start on running, canceled-stop short circuit, no-stop on stopped)
- [x] All three new tests follow the structure of the existing `updateWorkspace` tests so behavioral parity is visible at review time
- [ ] Manual: trigger a "Change version" on a long-lived running workspace (EC2-backed) and verify the agent reconnects with fresh tokens