### PR TITLE
fix(site/src/modules/resources): show More Actions for failed devcontainers

### DIFF
--- a/site/src/modules/resources/AgentDevcontainerCard.stories.tsx
+++ b/site/src/modules/resources/AgentDevcontainerCard.stories.tsx
@@ -59,6 +59,35 @@ export const HasError: Story = {
 	},
 };
 
+// Regression test for https://github.com/coder/coder/issues/23754.
+// The three-dot "More actions" menu (which contains Delete) must remain
+// reachable for a devcontainer whose container failed to start, otherwise
+// users have no UI path to clean up failed devcontainers.
+export const FailedHasMoreActionsMenu: Story = {
+	args: {
+		devcontainer: {
+			...MockWorkspaceAgentDevcontainer,
+			error: "exit status 1: devcontainer up failed",
+			status: "stopped",
+			container: undefined,
+			agent: undefined,
+		},
+		subAgents: [],
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		// The button is rendered with an sr-only label of
+		// "Dev Container actions" (see AgentDevcontainerMoreActions).
+		const moreActions = canvas.getByRole("button", {
+			name: "Dev Container actions",
+		});
+		await userEvent.click(moreActions);
+		// Delete must be reachable from the dropdown for a failed
+		// devcontainer; this is the user-visible regression of #23754.
+		await screen.findByText("Delete…");
+	},
+};
+
 export const NoPorts: Story = {};
 
 export const WithPorts: Story = {

--- a/site/src/modules/resources/AgentDevcontainerCard.tsx
+++ b/site/src/modules/resources/AgentDevcontainerCard.tsx
@@ -151,7 +151,9 @@ export const AgentDevcontainerCard: FC<AgentDevcontainerCardProps> = ({
 		},
 	});
 
-	const showDevcontainerControls = subAgent && devcontainer.container;
+	// Apps that talk to the running container (SSH, port forwarding) only
+	// make sense when the container and its sub-agent are present.
+	const showRunningControls = subAgent && devcontainer.container;
 	const isTransitioning =
 		devcontainer.status === "starting" ||
 		devcontainer.status === "stopping" ||
@@ -256,14 +258,14 @@ export const AgentDevcontainerCard: FC<AgentDevcontainerCardProps> = ({
 						{rebuildButtonLabel(devcontainer)}
 					</Button>
 
-					{showDevcontainerControls && displayApps.includes("ssh_helper") && (
+					{showRunningControls && displayApps.includes("ssh_helper") && (
 						<AgentSSHButton
 							workspaceName={workspace.name}
 							agentName={subAgent.name}
 							workspaceOwnerUsername={workspace.owner_name}
 						/>
 					)}
-					{showDevcontainerControls &&
+					{showRunningControls &&
 						displayApps.includes("port_forwarding_helper") &&
 						proxy.preferredWildcardHostname !== "" && (
 							<PortForwardButton
@@ -274,11 +276,17 @@ export const AgentDevcontainerCard: FC<AgentDevcontainerCardProps> = ({
 							/>
 						)}
 
-					{showDevcontainerControls && (
-						<AgentDevcontainerMoreActions
-							deleteDevContainer={deleteDevcontainerMutation.mutate}
-						/>
-					)}
+					{/*
+					 * The More Actions menu currently only exposes Delete,
+					 * which targets the devcontainer record (not the
+					 * container) and must remain reachable when the
+					 * container failed to start. If a future action does
+					 * need a running container, reintroduce a gate here.
+					 * See coder/coder#23754.
+					 */}
+					<AgentDevcontainerMoreActions
+						deleteDevContainer={deleteDevcontainerMutation.mutate}
+					/>
 
 					<DevcontainerDeleteErrorDialog
 						open={deleteDevcontainerMutation.isError}


### PR DESCRIPTION
## Summary

`AgentDevcontainerCard` gated the three-dot More Actions menu on
`subAgent && devcontainer.container`, which is false for any
devcontainer whose container failed to start. The menu currently
contains only the Delete action, and the delete mutation targets
the devcontainer record (not the running container), so failed
devcontainers had no UI path to clean up: only the Start button was
rendered. Users had to drop to the API or `docker rm` to remove
them.

Decouple the More Actions menu from the running-container check.
SSH and port-forwarding buttons still gate on `showRunningControls`
(subAgent + container) because they need a live container. The
More Actions menu is always rendered with an inline comment
explaining why; if a future action does need a running container,
reintroduce a gate at that call site.

Add a new `FailedHasMoreActionsMenu` Storybook play story that
renders the failed-state devcontainer (no container, no agent, error
string set), opens the menu, and asserts the Delete option is
reachable. This is the user-visible regression of #23754.

Fixes #23754.

## Test plan

- [x] `pnpm vitest run --project=storybook src/modules/resources/AgentDevcontainerCard.stories.tsx` passes (17/17)
- [x] `pnpm biome check --error-on-warnings` clean
- [ ] Manual: trigger a devcontainer failure (e.g. exit status 1 in `devcontainer up`) and confirm the three-dot menu now appears with Delete