### PR TITLE
fix: allow 'me' as user param on quiet-hours swagger

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -9478,8 +9478,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "format": "uuid",
-                        "description": "User ID",
+                        "description": "User ID, name, or me",
                         "name": "user",
                         "in": "path",
                         "required": true
@@ -9517,8 +9516,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "format": "uuid",
-                        "description": "User ID",
+                        "description": "User ID, name, or me",
                         "name": "user",
                         "in": "path",
                         "required": true

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -8403,8 +8403,7 @@
 				"parameters": [
 					{
 						"type": "string",
-						"format": "uuid",
-						"description": "User ID",
+						"description": "User ID, name, or me",
 						"name": "user",
 						"in": "path",
 						"required": true
@@ -8436,8 +8435,7 @@
 				"parameters": [
 					{
 						"type": "string",
-						"format": "uuid",
-						"description": "User ID",
+						"description": "User ID, name, or me",
 						"name": "user",
 						"in": "path",
 						"required": true

--- a/coderd/coderd_test.go
+++ b/coderd/coderd_test.go
@@ -319,6 +319,53 @@ func TestSwagger(t *testing.T) {
 		require.Contains(t, doc.Paths, "/.well-known/oauth-authorization-server")
 		require.Contains(t, doc.Paths, "/oauth2/tokens")
 		require.Contains(t, doc.Paths, "/scim/v2/Users")
+
+		// Regression for https://github.com/coder/coder/issues/24473.
+		// The {user} path parameter on /api/v2/users/{user}/quiet-hours
+		// used to be annotated with format(uuid), which made Swagger UI
+		// reject the "me" shortcut at submit time even though the
+		// handler (httpmw.UserParam) accepts it. We must not advertise a
+		// uuid format on these endpoints because users, names, and "me"
+		// are all valid inputs.
+		quietHoursPath, ok := doc.Paths["/api/v2/users/{user}/quiet-hours"]
+		require.True(t, ok,
+			"swagger doc should still expose /users/{user}/quiet-hours")
+		for method, raw := range quietHoursPath {
+			var op struct {
+				Parameters []struct {
+					Name        string `json:"name"`
+					In          string `json:"in"`
+					Type        string `json:"type"`
+					Format      string `json:"format"`
+					Description string `json:"description"`
+				} `json:"parameters"`
+			}
+			require.NoError(t, json.Unmarshal(raw, &op),
+				"unmarshal %s /quiet-hours operation", method)
+			var userParam *struct {
+				Name        string `json:"name"`
+				In          string `json:"in"`
+				Type        string `json:"type"`
+				Format      string `json:"format"`
+				Description string `json:"description"`
+			}
+			for i := range op.Parameters {
+				if op.Parameters[i].Name == "user" && op.Parameters[i].In == "path" {
+					userParam = &op.Parameters[i]
+					break
+				}
+			}
+			require.NotNil(t, userParam,
+				"%s /quiet-hours must declare a user path parameter", method)
+			require.Empty(t, userParam.Format,
+				"%s /quiet-hours user parameter must not advertise format=uuid; that blocks the 'me' shortcut in Swagger UI",
+				method)
+			// Use "or me" rather than just "me" so the assertion is not
+			// accidentally satisfied by the substring inside "name".
+			require.Contains(t, userParam.Description, "or me",
+				"%s /quiet-hours user parameter description must mention the 'me' shortcut so users know it is accepted",
+				method)
+		}
 	})
 	t.Run("endpoint disabled by default", func(t *testing.T) {
 		t.Parallel()

--- a/docs/reference/api/enterprise.md
+++ b/docs/reference/api/enterprise.md
@@ -3317,9 +3317,9 @@ curl -X GET http://coder-server:8080/api/v2/users/{user}/quiet-hours \
 
 ### Parameters
 
-| Name   | In   | Type         | Required | Description |
-|--------|------|--------------|----------|-------------|
-| `user` | path | string(uuid) | true     | User ID     |
+| Name   | In   | Type   | Required | Description          |
+|--------|------|--------|----------|----------------------|
+| `user` | path | string | true     | User ID, name, or me |
 
 ### Example responses
 
@@ -3386,7 +3386,7 @@ curl -X PUT http://coder-server:8080/api/v2/users/{user}/quiet-hours \
 
 | Name   | In   | Type                                                                                                   | Required | Description             |
 |--------|------|--------------------------------------------------------------------------------------------------------|----------|-------------------------|
-| `user` | path | string(uuid)                                                                                           | true     | User ID                 |
+| `user` | path | string                                                                                                 | true     | User ID, name, or me    |
 | `body` | body | [codersdk.UpdateUserQuietHoursScheduleRequest](schemas.md#codersdkupdateuserquiethoursschedulerequest) | true     | Update schedule request |
 
 ### Example responses

--- a/enterprise/coderd/users.go
+++ b/enterprise/coderd/users.go
@@ -41,7 +41,7 @@ func (api *API) autostopRequirementEnabledMW(next http.Handler) http.Handler {
 // @Security CoderSessionToken
 // @Produce json
 // @Tags Enterprise
-// @Param user path string true "User ID" format(uuid)
+// @Param user path string true "User ID, name, or me"
 // @Success 200 {array} codersdk.UserQuietHoursScheduleResponse
 // @Router /api/v2/users/{user}/quiet-hours [get]
 func (api *API) userQuietHoursSchedule(rw http.ResponseWriter, r *http.Request) {
@@ -76,7 +76,7 @@ func (api *API) userQuietHoursSchedule(rw http.ResponseWriter, r *http.Request) 
 // @Accept json
 // @Produce json
 // @Tags Enterprise
-// @Param user path string true "User ID" format(uuid)
+// @Param user path string true "User ID, name, or me"
 // @Param request body codersdk.UpdateUserQuietHoursScheduleRequest true "Update schedule request"
 // @Success 200 {array} codersdk.UserQuietHoursScheduleResponse
 // @Router /api/v2/users/{user}/quiet-hours [put]


### PR DESCRIPTION
## Summary

The two `/api/v2/users/{user}/quiet-hours` swagger annotations in
enterprise/coderd/users.go used `format(uuid)`, which made Swagger
UI reject "me" at submit time with `Value must be a Guid`. The
underlying handler (`httpmw.UserParam`) already accepts UUID,
username, and the "me" shortcut, so the validation was a docs-only
regression. Every other user-path-parameter annotation in the
codebase uses the description "User ID, name, or me" without a
format field; bring the quiet-hours annotations in line.

Changes:

- enterprise/coderd/users.go: drop `format(uuid)`, update
  description for GET and PUT `/quiet-hours`.
- coderd/apidoc/docs.go and coderd/apidoc/swagger.json: surgical
  edits matching what `swag init` would emit (verified by running
  the generator locally; restricted to these two endpoints to keep
  the diff reviewable).
- docs/reference/api/enterprise.md: matching tweak to the rendered
  API reference table cells.
- coderd/coderd_test.go: extend `TestSwagger/doc.json_exposed` with
  a regression block that walks every operation under
  `/users/{user}/quiet-hours` and asserts the user parameter does
  not advertise a format and does mention "or me" in its
  description.

Fixes #24473.

## Test plan

- [x] `go test ./coderd/... -run 'TestSwagger/doc.json_exposed'` passes; demonstrated to fail with the old annotations and pass with the fix
- [x] Verified `swag init` regen would produce a no-op diff on these blocks (field order matches sibling user-path params)