### PR TITLE
docs(.claude/docs/OBSERVABILITY.md): tighten --trace-datadog bullet

### DIFF
--- a/.claude/docs/OBSERVABILITY.md
+++ b/.claude/docs/OBSERVABILITY.md
@@ -54,7 +54,9 @@ variables, not by the develop orchestrator itself:
 - `--trace-honeycomb-api-key` or `CODER_TRACE_HONEYCOMB_API_KEY` enables the
   Honeycomb exporter.
 - `--trace-datadog` or `CODER_TRACE_DATADOG` enables sending Go runtime
-  traces to the local DataDog agent.
+  traces plus CPU, heap, and goroutine profiles to the local DataDog
+  agent. The flag is hidden in `coder server --help` and is used
+  primarily for internal dogfood leak detection.
 
 To pass server flags through the develop script, put them after `--`. For
 example, use `./scripts/develop.sh -- --trace` when you already have an OTLP


### PR DESCRIPTION
This follow-up to PR #24791 tightens the Datadog tracing flag documentation so it matches the implementation details.

## Why

- Mention CPU, heap, and goroutine profiles as well as runtime traces, matching `coderd/tracing/exporter.go`.
- Note the flag is hidden (`Hidden: true` in `codersdk/deployment.go`), so agents and operators won't see it via `--help`.

## Validation

- `make lint/agents`, passed.
- `make lint/emdash`, passed.
- `make lint/markdown`, passed.
- `git diff --check origin/main..HEAD`, clean.
- `git log --oneline origin/main..HEAD`, exactly 1 commit.

> This PR was prepared by Mux working on Mike's behalf.
