### PR TITLE
fix(coderd/x/chatd/chaterror): deflake TestClassify_ParsesRetryAfterHTTPDate

### DIFF
--- a/coderd/x/chatd/chaterror/classify_test.go
+++ b/coderd/x/chatd/chaterror/classify_test.go
@@ -653,7 +653,16 @@ func TestClassify_PrefersRetryAfterMsOverRetryAfter(t *testing.T) {
 func TestClassify_ParsesRetryAfterHTTPDate(t *testing.T) {
 	t.Parallel()
 
-	retryAt := time.Now().Add(3 * time.Second).UTC().Format(http.TimeFormat)
+	// http.TimeFormat has second precision, so formatting truncates the
+	// sub-second component (up to ~1s of loss). Round the target up to the
+	// next whole second before formatting so the parsed deadline is never
+	// earlier than now+offset, regardless of where now's fractional second
+	// lands. Without this, a now with frac near 1s plus any scheduling
+	// jitter can drive the computed RetryAfter just under offset-1s and
+	// flake the lower bound.
+	offset := 3 * time.Second
+	target := time.Now().Add(offset).Truncate(time.Second).Add(time.Second)
+	retryAt := target.UTC().Format(http.TimeFormat)
 	classified := chaterror.Classify(testProviderError(
 		"upstream failed",
 		429,
@@ -661,8 +670,8 @@ func TestClassify_ParsesRetryAfterHTTPDate(t *testing.T) {
 	))
 
 	require.Equal(t, 429, classified.StatusCode)
-	require.GreaterOrEqual(t, classified.RetryAfter, 2*time.Second)
-	require.LessOrEqual(t, classified.RetryAfter, 4*time.Second)
+	require.GreaterOrEqual(t, classified.RetryAfter, offset-time.Second)
+	require.LessOrEqual(t, classified.RetryAfter, offset+time.Second)
 }
 
 func TestClassify_IgnoresInvalidRetryAfter(t *testing.T) {


### PR DESCRIPTION
The test built a `Retry-After` HTTP-date with `time.Now().Add(3*time.Second).UTC().Format(http.TimeFormat)`, then asserted that the parsed `RetryAfter` was `>= 2s`. `http.TimeFormat` has second precision, so `Format()` truncates up to ~1s. Combined with the small elapsed time between formatting in the test and `time.Until()` in production, the value could land just under `offset-1s` (1.997s observed in CI), failing the lower bound.

Round the formatted target up to the next whole second so the parsed deadline is never earlier than `now+offset`, and assert against a symmetric `[offset-1s, offset+1s]` window.

Closes [CODAGT-365](https://linear.app/codercom/issue/CODAGT-365/flake-testclassify-parsesretryafterhttpdate)
Refs https://github.com/coder/internal/issues/1512

<sub>Created by [Coder Agents](https://coder.com/docs/agent).</sub>
