### PR TITLE
feat: add chat compaction model override

### DIFF
--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -2723,6 +2723,13 @@ func (q *querier) GetChatByIDForUpdate(ctx context.Context, id uuid.UUID) (datab
 	return fetch(q.log, q.auth, q.db.GetChatByIDForUpdate)(ctx, id)
 }
 
+func (q *querier) GetChatCompactionModelOverride(ctx context.Context) (string, error) {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceDeploymentConfig); err != nil {
+		return "", err
+	}
+	return q.db.GetChatCompactionModelOverride(ctx)
+}
+
 func (q *querier) GetChatComputerUseProvider(ctx context.Context) (string, error) {
 	// The computer-use provider is a deployment-wide runtime chat setting
 	// read by authenticated chat users and chatd. Feature and experiment
@@ -7883,6 +7890,13 @@ func (q *querier) UpsertChatAutoArchiveDays(ctx context.Context, autoArchiveDays
 		return err
 	}
 	return q.db.UpsertChatAutoArchiveDays(ctx, autoArchiveDays)
+}
+
+func (q *querier) UpsertChatCompactionModelOverride(ctx context.Context, value string) error {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceDeploymentConfig); err != nil {
+		return err
+	}
+	return q.db.UpsertChatCompactionModelOverride(ctx, value)
 }
 
 func (q *querier) UpsertChatComputerUseProvider(ctx context.Context, provider string) error {

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -1085,6 +1085,10 @@ func (s *MethodTestSuite) TestChats() {
 		dbm.EXPECT().GetChatExploreModelOverride(gomock.Any()).Return("", nil).AnyTimes()
 		check.Args().Asserts(rbac.ResourceDeploymentConfig, policy.ActionRead)
 	}))
+	s.Run("GetChatCompactionModelOverride", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
+		dbm.EXPECT().GetChatCompactionModelOverride(gomock.Any()).Return("", nil).AnyTimes()
+		check.Args().Asserts(rbac.ResourceDeploymentConfig, policy.ActionRead)
+	}))
 	s.Run("GetChatTitleGenerationModelOverride", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
 		dbm.EXPECT().GetChatTitleGenerationModelOverride(gomock.Any()).Return("", nil).AnyTimes()
 		check.Args().Asserts(rbac.ResourceDeploymentConfig, policy.ActionRead)
@@ -1430,6 +1434,10 @@ func (s *MethodTestSuite) TestChats() {
 	}))
 	s.Run("UpsertChatExploreModelOverride", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
 		dbm.EXPECT().UpsertChatExploreModelOverride(gomock.Any(), "").Return(nil).AnyTimes()
+		check.Args("").Asserts(rbac.ResourceDeploymentConfig, policy.ActionUpdate)
+	}))
+	s.Run("UpsertChatCompactionModelOverride", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
+		dbm.EXPECT().UpsertChatCompactionModelOverride(gomock.Any(), "").Return(nil).AnyTimes()
 		check.Args("").Asserts(rbac.ResourceDeploymentConfig, policy.ActionUpdate)
 	}))
 	s.Run("UpsertChatTitleGenerationModelOverride", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -1249,6 +1249,14 @@ func (m queryMetricsStore) GetChatByIDForUpdate(ctx context.Context, id uuid.UUI
 	return r0, r1
 }
 
+func (m queryMetricsStore) GetChatCompactionModelOverride(ctx context.Context) (string, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetChatCompactionModelOverride(ctx)
+	m.queryLatencies.WithLabelValues("GetChatCompactionModelOverride").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetChatCompactionModelOverride").Inc()
+	return r0, r1
+}
+
 func (m queryMetricsStore) GetChatComputerUseProvider(ctx context.Context) (string, error) {
 	start := time.Now()
 	r0, r1 := m.s.GetChatComputerUseProvider(ctx)
@@ -5654,6 +5662,14 @@ func (m queryMetricsStore) UpsertChatAutoArchiveDays(ctx context.Context, autoAr
 	r0 := m.s.UpsertChatAutoArchiveDays(ctx, autoArchiveDays)
 	m.queryLatencies.WithLabelValues("UpsertChatAutoArchiveDays").Observe(time.Since(start).Seconds())
 	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "UpsertChatAutoArchiveDays").Inc()
+	return r0
+}
+
+func (m queryMetricsStore) UpsertChatCompactionModelOverride(ctx context.Context, value string) error {
+	start := time.Now()
+	r0 := m.s.UpsertChatCompactionModelOverride(ctx, value)
+	m.queryLatencies.WithLabelValues("UpsertChatCompactionModelOverride").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "UpsertChatCompactionModelOverride").Inc()
 	return r0
 }
 

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -2311,6 +2311,21 @@ func (mr *MockStoreMockRecorder) GetChatByIDForUpdate(ctx, id any) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChatByIDForUpdate", reflect.TypeOf((*MockStore)(nil).GetChatByIDForUpdate), ctx, id)
 }
 
+// GetChatCompactionModelOverride mocks base method.
+func (m *MockStore) GetChatCompactionModelOverride(ctx context.Context) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetChatCompactionModelOverride", ctx)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetChatCompactionModelOverride indicates an expected call of GetChatCompactionModelOverride.
+func (mr *MockStoreMockRecorder) GetChatCompactionModelOverride(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChatCompactionModelOverride", reflect.TypeOf((*MockStore)(nil).GetChatCompactionModelOverride), ctx)
+}
+
 // GetChatComputerUseProvider mocks base method.
 func (m *MockStore) GetChatComputerUseProvider(ctx context.Context) (string, error) {
 	m.ctrl.T.Helper()
@@ -10634,6 +10649,20 @@ func (m *MockStore) UpsertChatAutoArchiveDays(ctx context.Context, autoArchiveDa
 func (mr *MockStoreMockRecorder) UpsertChatAutoArchiveDays(ctx, autoArchiveDays any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertChatAutoArchiveDays", reflect.TypeOf((*MockStore)(nil).UpsertChatAutoArchiveDays), ctx, autoArchiveDays)
+}
+
+// UpsertChatCompactionModelOverride mocks base method.
+func (m *MockStore) UpsertChatCompactionModelOverride(ctx context.Context, value string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpsertChatCompactionModelOverride", ctx, value)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpsertChatCompactionModelOverride indicates an expected call of UpsertChatCompactionModelOverride.
+func (mr *MockStoreMockRecorder) UpsertChatCompactionModelOverride(ctx, value any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertChatCompactionModelOverride", reflect.TypeOf((*MockStore)(nil).UpsertChatCompactionModelOverride), ctx, value)
 }
 
 // UpsertChatComputerUseProvider mocks base method.

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -308,6 +308,7 @@ type sqlcQuerier interface {
 	GetChatAutoArchiveDays(ctx context.Context, defaultAutoArchiveDays int32) (int32, error)
 	GetChatByID(ctx context.Context, id uuid.UUID) (Chat, error)
 	GetChatByIDForUpdate(ctx context.Context, id uuid.UUID) (Chat, error)
+	GetChatCompactionModelOverride(ctx context.Context) (string, error)
 	GetChatComputerUseProvider(ctx context.Context) (string, error)
 	// Per-root-chat cost breakdown for a single user within a date range.
 	// Groups by root_chat_id so forked chats roll up under their root.
@@ -1324,6 +1325,7 @@ type sqlcQuerier interface {
 	// to JSON before invoking this query.
 	UpsertChatAdvisorConfig(ctx context.Context, value string) error
 	UpsertChatAutoArchiveDays(ctx context.Context, autoArchiveDays int32) error
+	UpsertChatCompactionModelOverride(ctx context.Context, value string) error
 	UpsertChatComputerUseProvider(ctx context.Context, provider string) error
 	// UpsertChatDebugLoggingAllowUsers updates the runtime admin setting that
 	// allows users to opt into chat debug logging.

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -22295,6 +22295,18 @@ func (q *sqlQuerier) GetChatAutoArchiveDays(ctx context.Context, defaultAutoArch
 	return auto_archive_days, err
 }
 
+const getChatCompactionModelOverride = `-- name: GetChatCompactionModelOverride :one
+SELECT
+	COALESCE((SELECT value FROM site_configs WHERE key = 'agents_chat_compaction_model_override'), '') :: text AS model_config_id
+`
+
+func (q *sqlQuerier) GetChatCompactionModelOverride(ctx context.Context) (string, error) {
+	row := q.db.QueryRowContext(ctx, getChatCompactionModelOverride)
+	var model_config_id string
+	err := row.Scan(&model_config_id)
+	return model_config_id, err
+}
+
 const getChatComputerUseProvider = `-- name: GetChatComputerUseProvider :one
 SELECT
 	COALESCE((SELECT value FROM site_configs WHERE key = 'agents_computer_use_provider'), '') :: text AS provider
@@ -22733,6 +22745,16 @@ WHERE site_configs.key = 'agents_chat_auto_archive_days'
 
 func (q *sqlQuerier) UpsertChatAutoArchiveDays(ctx context.Context, autoArchiveDays int32) error {
 	_, err := q.db.ExecContext(ctx, upsertChatAutoArchiveDays, autoArchiveDays)
+	return err
+}
+
+const upsertChatCompactionModelOverride = `-- name: UpsertChatCompactionModelOverride :exec
+INSERT INTO site_configs (key, value) VALUES ('agents_chat_compaction_model_override', $1)
+ON CONFLICT (key) DO UPDATE SET value = $1 WHERE site_configs.key = 'agents_chat_compaction_model_override'
+`
+
+func (q *sqlQuerier) UpsertChatCompactionModelOverride(ctx context.Context, value string) error {
+	_, err := q.db.ExecContext(ctx, upsertChatCompactionModelOverride, value)
 	return err
 }
 

--- a/coderd/database/queries/siteconfig.sql
+++ b/coderd/database/queries/siteconfig.sql
@@ -183,6 +183,14 @@ SELECT
 INSERT INTO site_configs (key, value) VALUES ('agents_chat_general_model_override', $1)
 ON CONFLICT (key) DO UPDATE SET value = $1 WHERE site_configs.key = 'agents_chat_general_model_override';
 
+-- name: GetChatCompactionModelOverride :one
+SELECT
+	COALESCE((SELECT value FROM site_configs WHERE key = 'agents_chat_compaction_model_override'), '') :: text AS model_config_id;
+
+-- name: UpsertChatCompactionModelOverride :exec
+INSERT INTO site_configs (key, value) VALUES ('agents_chat_compaction_model_override', $1)
+ON CONFLICT (key) DO UPDATE SET value = $1 WHERE site_configs.key = 'agents_chat_compaction_model_override';
+
 -- name: GetChatTitleGenerationModelOverride :one
 SELECT
 	COALESCE((SELECT value FROM site_configs WHERE key = 'agents_chat_title_generation_model_override'), '') :: text AS model_config_id;

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -592,6 +592,12 @@ func (api *API) chatModelOverrideSiteConfig(
 			getter: api.Database.GetChatTitleGenerationModelOverride,
 			upsert: api.Database.UpsertChatTitleGenerationModelOverride,
 		}, nil
+	case codersdk.ChatModelOverrideContextCompaction:
+		return chatModelOverrideSiteConfig{
+			label:  "compaction",
+			getter: api.Database.GetChatCompactionModelOverride,
+			upsert: api.Database.UpsertChatCompactionModelOverride,
+		}, nil
 	default:
 		return chatModelOverrideSiteConfig{}, xerrors.Errorf(
 			"unknown chat model override context %q",

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -10982,6 +10982,16 @@ func TestChatModelOverrides(t *testing.T) {
 			},
 		},
 		{
+			name:    "Compaction",
+			context: codersdk.ChatModelOverrideContextCompaction,
+			dbGet: func(ctx context.Context, db database.Store) (string, error) {
+				return db.GetChatCompactionModelOverride(dbauthz.AsSystemRestricted(ctx))
+			},
+			dbUpsert: func(ctx context.Context, db database.Store, value string) error {
+				return db.UpsertChatCompactionModelOverride(dbauthz.AsSystemRestricted(ctx), value)
+			},
+		},
+		{
 			name:    "TitleGeneration",
 			context: codersdk.ChatModelOverrideContextTitleGeneration,
 			dbGet: func(ctx context.Context, db database.Store) (string, error) {
@@ -11136,7 +11146,7 @@ func TestChatModelOverrides(t *testing.T) {
 		require.Equal(t, "Invalid chat model override context.", sdkErr.Message)
 		require.Equal(
 			t,
-			`Expected one of general, explore, title_generation. Got "not-a-context".`,
+			`Expected one of general, explore, title_generation, compaction. Got "not-a-context".`,
 			sdkErr.Detail,
 		)
 
@@ -11145,7 +11155,7 @@ func TestChatModelOverrides(t *testing.T) {
 		require.Equal(t, "Invalid chat model override context.", sdkErr.Message)
 		require.Equal(
 			t,
-			`Expected one of general, explore, title_generation. Got "not-a-context".`,
+			`Expected one of general, explore, title_generation, compaction. Got "not-a-context".`,
 			sdkErr.Detail,
 		)
 	})

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -7449,10 +7449,6 @@ func (p *Server) runChat(
 			persistCtx context.Context,
 			result chatloop.CompactionResult,
 		) error {
-			// Attribute the durable summary message to the active chat model
-			// config because the summary becomes part of that model's future
-			// conversation. Debug runs separately record the model that
-			// generated the summary.
 			if err := p.persistChatContextSummary(
 				persistCtx,
 				chat.ID,
@@ -7524,9 +7520,9 @@ func (p *Server) runChat(
 		providerKeys,
 		logger,
 	)
-	compactionOptions.ModelConfigID = compactionResolution.modelConfigID
-	compactionOptions.Provider = compactionResolution.provider
-	compactionOptions.Model = compactionResolution.modelName
+	compactionOptions.DebugModelConfigID = compactionResolution.modelConfigID
+	compactionOptions.DebugProvider = compactionResolution.provider
+	compactionOptions.DebugModelName = compactionResolution.modelName
 
 	allowAskUserQuestion := isPlanModeTurn && isRootChat
 	storeChatAttachment := p.newStoreChatAttachmentFunc(&workspaceCtx)
@@ -8049,10 +8045,11 @@ func buildProviderTools(options *codersdk.ChatModelProviderOptions) []chatloop.P
 
 // persistChatContextSummary persists a chat context summary to the database.
 // This is invoked via the chat loop's compaction callback.
+// activeModelConfigID is recorded on the synthetic summary messages.
 func (p *Server) persistChatContextSummary(
 	ctx context.Context,
 	chatID uuid.UUID,
-	modelConfigID uuid.UUID,
+	activeModelConfigID uuid.UUID,
 	toolCallID string,
 	result chatloop.CompactionResult,
 ) error {
@@ -8113,7 +8110,7 @@ func (p *Server) persistChatContextSummary(
 			database.ChatMessageRoleUser,
 			systemContent,
 			database.ChatMessageVisibilityModel,
-			modelConfigID,
+			activeModelConfigID,
 			chatprompt.CurrentContentVersion,
 		).withCompressed())
 
@@ -8122,7 +8119,7 @@ func (p *Server) persistChatContextSummary(
 			database.ChatMessageRoleAssistant,
 			assistantContent,
 			database.ChatMessageVisibilityUser,
-			modelConfigID,
+			activeModelConfigID,
 			chatprompt.CurrentContentVersion,
 		).withCompressed())
 
@@ -8131,7 +8128,7 @@ func (p *Server) persistChatContextSummary(
 			database.ChatMessageRoleTool,
 			toolResult,
 			database.ChatMessageVisibilityBoth,
-			modelConfigID,
+			activeModelConfigID,
 			chatprompt.CurrentContentVersion,
 		).withCompressed())
 

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -7449,6 +7449,10 @@ func (p *Server) runChat(
 			persistCtx context.Context,
 			result chatloop.CompactionResult,
 		) error {
+			// Attribute the durable summary message to the active chat model
+			// config because the summary becomes part of that model's future
+			// conversation. Debug runs separately record the model that
+			// generated the summary.
 			if err := p.persistChatContextSummary(
 				persistCtx,
 				chat.ID,

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -8176,13 +8176,19 @@ func (p *Server) resolveCompactionModelOverride(
 		provider:      fallbackModel.Provider(),
 		modelName:     fallbackModel.Model(),
 	}
-	logFallback := func(reason string, configuredModelConfigID string, err error) compactionModelResolution {
+	logFallback := func(
+		reason string,
+		configuredModelConfigID string,
+		err error,
+		extraFields ...slog.Field,
+	) compactionModelResolution {
 		fields := []slog.Field{
 			slog.F("active_model_config_id", fallbackConfig.ID),
 			slog.F("configured_compaction_model_config_id", configuredModelConfigID),
 			slog.F("resolved_compaction_model_config_id", fallback.modelConfigID),
 			slog.F("fallback_reason", reason),
 		}
+		fields = append(fields, extraFields...)
 		if err != nil {
 			fields = append(fields, slog.Error(err))
 		}
@@ -8219,9 +8225,10 @@ func (p *Server) resolveCompactionModelOverride(
 
 	if overrideConfig.ContextLimit > 0 && fallbackConfig.ContextLimit > 0 &&
 		overrideConfig.ContextLimit < fallbackConfig.ContextLimit {
-		logger.Warn(ctx, "compaction model context limit is smaller than chat model context limit",
-			slog.F("active_model_config_id", fallbackConfig.ID),
-			slog.F("configured_compaction_model_config_id", overrideID),
+		return logFallback(
+			"context_limit_too_small",
+			overrideID.String(),
+			nil,
 			slog.F("active_context_limit", fallbackConfig.ContextLimit),
 			slog.F("compaction_context_limit", overrideConfig.ContextLimit),
 		)

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -7512,6 +7512,18 @@ func (p *Server) runChat(
 		slog.F("model", model.Model()),
 	)
 
+	compactionResolution := p.resolveCompactionModelOverride(
+		ctx,
+		chat,
+		model,
+		modelConfig,
+		providerKeys,
+		logger,
+	)
+	compactionOptions.ModelConfigID = compactionResolution.modelConfigID
+	compactionOptions.Provider = compactionResolution.provider
+	compactionOptions.Model = compactionResolution.modelName
+
 	allowAskUserQuestion := isPlanModeTurn && isRootChat
 	storeChatAttachment := p.newStoreChatAttachmentFunc(&workspaceCtx)
 	tools := []fantasy.AgentTool{
@@ -7786,6 +7798,7 @@ func (p *Server) runChat(
 
 	loopErr = chatloop.Run(ctx, chatloop.RunOptions{
 		Model:              model,
+		CompactionModel:    compactionResolution.model,
 		Messages:           prompt,
 		Tools:              tools,
 		ActiveTools:        activeToolNames,
@@ -8139,6 +8152,106 @@ func (p *Server) persistChatContextSummary(
 		p.publishMessage(chatID, msg)
 	}
 	return nil
+}
+
+type compactionModelResolution struct {
+	model         fantasy.LanguageModel
+	modelConfigID uuid.UUID
+	provider      string
+	modelName     string
+}
+
+func (p *Server) resolveCompactionModelOverride(
+	ctx context.Context,
+	chat database.Chat,
+	fallbackModel fantasy.LanguageModel,
+	fallbackConfig database.ChatModelConfig,
+	providerKeys chatprovider.ProviderAPIKeys,
+	logger slog.Logger,
+) compactionModelResolution {
+	fallback := compactionModelResolution{
+		model:         fallbackModel,
+		modelConfigID: fallbackConfig.ID,
+		provider:      fallbackModel.Provider(),
+		modelName:     fallbackModel.Model(),
+	}
+	logFallback := func(reason string, configuredModelConfigID string, err error) compactionModelResolution {
+		fields := []slog.Field{
+			slog.F("active_model_config_id", fallbackConfig.ID),
+			slog.F("configured_compaction_model_config_id", configuredModelConfigID),
+			slog.F("resolved_compaction_model_config_id", fallback.modelConfigID),
+			slog.F("fallback_reason", reason),
+		}
+		if err != nil {
+			fields = append(fields, slog.Error(err))
+		}
+		logger.Warn(ctx, "compaction model override unavailable, continuing with chat model", fields...)
+		return fallback
+	}
+
+	//nolint:gocritic // Chat workers read deployment-wide model overrides.
+	rawOverride, err := p.db.GetChatCompactionModelOverride(dbauthz.AsChatd(ctx))
+	if err != nil {
+		return logFallback("lookup_failed", "", err)
+	}
+	trimmedOverride := strings.TrimSpace(rawOverride)
+	if trimmedOverride == "" {
+		return fallback
+	}
+
+	overrideID, err := uuid.Parse(trimmedOverride)
+	if err != nil {
+		return logFallback("malformed", trimmedOverride, err)
+	}
+	if overrideID == uuid.Nil {
+		return logFallback("nil_model_config_id", trimmedOverride, nil)
+	}
+
+	//nolint:gocritic // Chat workers validate deployment-wide model overrides.
+	overrideConfig, err := p.db.GetEnabledChatModelConfigByID(dbauthz.AsChatd(ctx), overrideID)
+	if err != nil {
+		if xerrors.Is(err, sql.ErrNoRows) {
+			return logFallback("disabled_or_unavailable", overrideID.String(), err)
+		}
+		return logFallback("config_lookup_failed", overrideID.String(), err)
+	}
+
+	if overrideConfig.ContextLimit > 0 && fallbackConfig.ContextLimit > 0 &&
+		overrideConfig.ContextLimit < fallbackConfig.ContextLimit {
+		logger.Warn(ctx, "compaction model context limit is smaller than chat model context limit",
+			slog.F("active_model_config_id", fallbackConfig.ID),
+			slog.F("configured_compaction_model_config_id", overrideID),
+			slog.F("active_context_limit", fallbackConfig.ContextLimit),
+			slog.F("compaction_context_limit", overrideConfig.ContextLimit),
+		)
+	}
+
+	overrideModel, _, err := p.newDebugAwareModelFromConfig(
+		ctx,
+		chat,
+		overrideConfig.Provider,
+		overrideConfig.Model,
+		providerKeys,
+		chatprovider.UserAgent(),
+		chatprovider.CoderHeaders(chat),
+	)
+	if err != nil {
+		return logFallback("model_creation_failed", overrideID.String(), err)
+	}
+
+	logger.Debug(ctx, "using compaction model override",
+		slog.F("active_model_config_id", fallbackConfig.ID),
+		slog.F("configured_compaction_model_config_id", overrideID),
+		slog.F("resolved_compaction_model_config_id", overrideConfig.ID),
+		slog.F("compaction_provider", overrideModel.Provider()),
+		slog.F("compaction_model", overrideModel.Model()),
+	)
+	return compactionModelResolution{
+		model:         overrideModel,
+		modelConfigID: overrideConfig.ID,
+		provider:      overrideModel.Provider(),
+		modelName:     overrideModel.Model(),
+	}
 }
 
 func (p *Server) resolveChatModel(

--- a/coderd/x/chatd/chatloop/chatloop.go
+++ b/coderd/x/chatd/chatloop/chatloop.go
@@ -1791,16 +1791,20 @@ func tryCompactOnExit(
 	if err != nil {
 		return
 	}
+	compactionModel := opts.CompactionModel
+	if compactionModel == nil {
+		compactionModel = opts.Model
+	}
 	did, compactErr := tryCompact(
 		ctx,
-		opts.Model,
+		compactionModel,
 		opts.Compaction,
 		opts.ContextLimitFallback,
 		usage,
 		metadata,
 		reloaded,
 	)
-	opts.Metrics.RecordCompaction(opts.Model.Provider(), opts.Model.Model(), did, compactErr)
+	opts.Metrics.RecordCompaction(compactionModel.Provider(), compactionModel.Model(), did, compactErr)
 	if compactErr != nil && opts.Compaction.OnError != nil {
 		opts.Compaction.OnError(compactErr)
 	}

--- a/coderd/x/chatd/chatloop/chatloop.go
+++ b/coderd/x/chatd/chatloop/chatloop.go
@@ -110,10 +110,12 @@ type PersistedStep struct {
 
 // RunOptions configures a single streaming chat loop run.
 type RunOptions struct {
-	Model    fantasy.LanguageModel
-	Messages []fantasy.Message
-	Tools    []fantasy.AgentTool
-	MaxSteps int
+	Model fantasy.LanguageModel
+	// CompactionModel generates context summaries. Nil uses Model.
+	CompactionModel fantasy.LanguageModel
+	Messages        []fantasy.Message
+	Tools           []fantasy.AgentTool
+	MaxSteps        int
 	// StartupTimeout bounds how long each model attempt may
 	// spend opening the provider stream and waiting for its
 	// first stream part before the attempt is canceled and
@@ -373,6 +375,13 @@ func Run(ctx context.Context, opts RunOptions) error {
 	if opts.Metrics == nil {
 		opts.Metrics = NopMetrics()
 	}
+
+	compactionModel := opts.CompactionModel
+	if compactionModel == nil {
+		compactionModel = opts.Model
+	}
+	compactionProvider := compactionModel.Provider()
+	compactionModelName := compactionModel.Model()
 
 	publishMessagePart := func(role codersdk.ChatMessageRole, part codersdk.ChatMessagePart) {
 		if opts.PublishMessagePart == nil {
@@ -649,14 +658,14 @@ func Run(ctx context.Context, opts RunOptions) error {
 			if !needsFullHistoryReload && opts.Compaction != nil && opts.ReloadMessages != nil {
 				did, compactErr := tryCompact(
 					ctx,
-					opts.Model,
+					compactionModel,
 					opts.Compaction,
 					opts.ContextLimitFallback,
 					result.usage,
 					result.providerMetadata,
 					messages,
 				)
-				opts.Metrics.RecordCompaction(provider, modelName, did, compactErr)
+				opts.Metrics.RecordCompaction(compactionProvider, compactionModelName, did, compactErr)
 				if compactErr != nil && opts.Compaction.OnError != nil {
 					opts.Compaction.OnError(compactErr)
 				}
@@ -691,14 +700,14 @@ func Run(ctx context.Context, opts RunOptions) error {
 		if !needsFullHistoryReload && !alreadyCompacted && opts.Compaction != nil && opts.ReloadMessages != nil {
 			did, err := tryCompact(
 				ctx,
-				opts.Model,
+				compactionModel,
 				opts.Compaction,
 				opts.ContextLimitFallback,
 				lastUsage,
 				lastProviderMetadata,
 				messages,
 			)
-			opts.Metrics.RecordCompaction(opts.Model.Provider(), opts.Model.Model(), did, err)
+			opts.Metrics.RecordCompaction(compactionProvider, compactionModelName, did, err)
 			if err != nil {
 				if opts.Compaction.OnError != nil {
 					opts.Compaction.OnError(err)

--- a/coderd/x/chatd/chatloop/compaction.go
+++ b/coderd/x/chatd/chatloop/compaction.go
@@ -58,12 +58,13 @@ type CompactionOptions struct {
 	Persist             func(context.Context, CompactionResult) error
 	DebugSvc            *chatdebug.Service
 	ChatID              uuid.UUID
-	// ModelConfigID, Provider, and Model identify the compaction
-	// model for debug run instrumentation. When set, they override
-	// the parent run's model identity in debug records.
-	ModelConfigID       uuid.UUID
-	Provider            string
-	Model               string
+	// DebugModelConfigID, DebugProvider, and DebugModelName populate
+	// the KindCompaction debug run. They identify the model used to
+	// generate the summary. When unset, the run inherits the parent
+	// chat turn identity, which matches the default compaction path.
+	DebugModelConfigID  uuid.UUID
+	DebugProvider       string
+	DebugModelName      string
 	HistoryTipMessageID int64
 
 	// ToolCallID and ToolName identify the synthetic tool call
@@ -306,15 +307,15 @@ func startCompactionDebugRun(
 		historyTipMessageID = parentRun.HistoryTipMessageID
 	}
 
-	modelConfigID := options.ModelConfigID
+	modelConfigID := options.DebugModelConfigID
 	if modelConfigID == uuid.Nil {
 		modelConfigID = parentRun.ModelConfigID
 	}
-	provider := strings.TrimSpace(options.Provider)
+	provider := strings.TrimSpace(options.DebugProvider)
 	if provider == "" {
 		provider = parentRun.Provider
 	}
-	model := strings.TrimSpace(options.Model)
+	model := strings.TrimSpace(options.DebugModelName)
 	if model == "" {
 		model = parentRun.Model
 	}

--- a/coderd/x/chatd/chatloop/compaction.go
+++ b/coderd/x/chatd/chatloop/compaction.go
@@ -58,6 +58,9 @@ type CompactionOptions struct {
 	Persist             func(context.Context, CompactionResult) error
 	DebugSvc            *chatdebug.Service
 	ChatID              uuid.UUID
+	// ModelConfigID, Provider, and Model identify the compaction
+	// model for debug run instrumentation. When set, they override
+	// the parent run's model identity in debug records.
 	ModelConfigID       uuid.UUID
 	Provider            string
 	Model               string

--- a/coderd/x/chatd/chatloop/compaction.go
+++ b/coderd/x/chatd/chatloop/compaction.go
@@ -58,6 +58,9 @@ type CompactionOptions struct {
 	Persist             func(context.Context, CompactionResult) error
 	DebugSvc            *chatdebug.Service
 	ChatID              uuid.UUID
+	ModelConfigID       uuid.UUID
+	Provider            string
+	Model               string
 	HistoryTipMessageID int64
 
 	// ToolCallID and ToolName identify the synthetic tool call
@@ -300,6 +303,19 @@ func startCompactionDebugRun(
 		historyTipMessageID = parentRun.HistoryTipMessageID
 	}
 
+	modelConfigID := options.ModelConfigID
+	if modelConfigID == uuid.Nil {
+		modelConfigID = parentRun.ModelConfigID
+	}
+	provider := strings.TrimSpace(options.Provider)
+	if provider == "" {
+		provider = parentRun.Provider
+	}
+	model := strings.TrimSpace(options.Model)
+	if model == "" {
+		model = parentRun.Model
+	}
+
 	// Use a separate short-lived context for the debug insert so a
 	// slow or locked DB cannot consume the compaction timeout budget
 	// and turn debug slowness into a compaction failure via
@@ -314,13 +330,13 @@ func startCompactionDebugRun(
 		ChatID:              options.ChatID,
 		RootChatID:          parentRun.RootChatID,
 		ParentChatID:        parentRun.ParentChatID,
-		ModelConfigID:       parentRun.ModelConfigID,
+		ModelConfigID:       modelConfigID,
 		TriggerMessageID:    parentRun.TriggerMessageID,
 		HistoryTipMessageID: historyTipMessageID,
 		Kind:                chatdebug.KindCompaction,
 		Status:              chatdebug.StatusInProgress,
-		Provider:            parentRun.Provider,
-		Model:               parentRun.Model,
+		Provider:            provider,
+		Model:               model,
 	})
 	createRunCancel()
 	if err != nil {
@@ -333,12 +349,12 @@ func startCompactionDebugRun(
 		ChatID:              options.ChatID,
 		RootChatID:          parentRun.RootChatID,
 		ParentChatID:        parentRun.ParentChatID,
-		ModelConfigID:       parentRun.ModelConfigID,
+		ModelConfigID:       modelConfigID,
 		TriggerMessageID:    parentRun.TriggerMessageID,
 		HistoryTipMessageID: historyTipMessageID,
 		Kind:                chatdebug.KindCompaction,
-		Provider:            parentRun.Provider,
-		Model:               parentRun.Model,
+		Provider:            provider,
+		Model:               model,
 	})
 
 	return compactionCtx, func(runErr error) {

--- a/coderd/x/chatd/chatloop/compaction_test.go
+++ b/coderd/x/chatd/chatloop/compaction_test.go
@@ -71,7 +71,7 @@ func TestStartCompactionDebugRun_DoesNotReportDebugErrors(t *testing.T) {
 		}
 	})
 
-	t.Run("UsesCompactionModelIdentity", func(t *testing.T) {
+	t.Run("UsesDebugModelIdentityForCompactionRun", func(t *testing.T) {
 		t.Parallel()
 
 		ctrl := gomock.NewController(t)
@@ -97,11 +97,11 @@ func TestStartCompactionDebugRun_DoesNotReportDebugErrors(t *testing.T) {
 
 		ctx := newParentContext(chatID)
 		compactionCtx, _ := startCompactionDebugRun(ctx, CompactionOptions{
-			DebugSvc:      svc,
-			ChatID:        chatID,
-			ModelConfigID: compactionModelID,
-			Provider:      "compaction-provider",
-			Model:         "compaction-model",
+			DebugSvc:           svc,
+			ChatID:             chatID,
+			DebugModelConfigID: compactionModelID,
+			DebugProvider:      "compaction-provider",
+			DebugModelName:     "compaction-model",
 		})
 		require.NotSame(t, ctx, compactionCtx)
 

--- a/coderd/x/chatd/chatloop/compaction_test.go
+++ b/coderd/x/chatd/chatloop/compaction_test.go
@@ -71,6 +71,47 @@ func TestStartCompactionDebugRun_DoesNotReportDebugErrors(t *testing.T) {
 		}
 	})
 
+	t.Run("UsesCompactionModelIdentity", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		db := dbmock.NewMockStore(ctrl)
+		svc := chatdebug.NewService(db, testutil.Logger(t), nil)
+		chatID := uuid.New()
+		runID := uuid.New()
+		compactionModelID := uuid.New()
+
+		db.EXPECT().InsertChatDebugRun(
+			gomock.Any(),
+			gomock.AssignableToTypeOf(database.InsertChatDebugRunParams{}),
+		).DoAndReturn(func(_ context.Context, params database.InsertChatDebugRunParams) (database.ChatDebugRun, error) {
+			require.Equal(t, chatID, params.ChatID)
+			require.True(t, params.ModelConfigID.Valid)
+			require.Equal(t, compactionModelID, params.ModelConfigID.UUID)
+			require.True(t, params.Provider.Valid)
+			require.Equal(t, "compaction-provider", params.Provider.String)
+			require.True(t, params.Model.Valid)
+			require.Equal(t, "compaction-model", params.Model.String)
+			return database.ChatDebugRun{ID: runID, ChatID: chatID}, nil
+		})
+
+		ctx := newParentContext(chatID)
+		compactionCtx, _ := startCompactionDebugRun(ctx, CompactionOptions{
+			DebugSvc:      svc,
+			ChatID:        chatID,
+			ModelConfigID: compactionModelID,
+			Provider:      "compaction-provider",
+			Model:         "compaction-model",
+		})
+		require.NotSame(t, ctx, compactionCtx)
+
+		run, ok := chatdebug.RunFromContext(compactionCtx)
+		require.True(t, ok)
+		require.Equal(t, compactionModelID, run.ModelConfigID)
+		require.Equal(t, "compaction-provider", run.Provider)
+		require.Equal(t, "compaction-model", run.Model)
+	})
+
 	t.Run("FinalizeRunAggregatesSummary", func(t *testing.T) {
 		t.Parallel()
 
@@ -1010,13 +1051,15 @@ func TestRun_Compaction(t *testing.T) {
 		t.Parallel()
 
 		var persistCompactionCalls int
+		var compactionGenerateCalls int
 		const summaryText = "compaction summary for dynamic tool exit"
 
 		// The LLM calls a dynamic tool. Usage is above the
 		// compaction threshold so compaction should fire even
 		// though the chatloop exits via ErrDynamicToolCall.
 		model := &chattest.FakeModel{
-			ProviderName: "fake",
+			ProviderName: "active-provider",
+			ModelName:    "active-model",
 			StreamFn: func(_ context.Context, _ fantasy.Call) (fantasy.StreamResponse, error) {
 				return streamFromParts([]fantasy.StreamPart{
 					{Type: fantasy.StreamPartTypeToolInputStart, ID: "tc-1", ToolCallName: "my_dynamic_tool"},
@@ -1038,7 +1081,16 @@ func TestRun_Compaction(t *testing.T) {
 					},
 				}), nil
 			},
+			GenerateFn: func(context.Context, fantasy.Call) (*fantasy.Response, error) {
+				t.Fatal("active model should not generate dynamic exit compaction summaries")
+				return nil, xerrors.New("active model generated dynamic exit compaction summary")
+			},
+		}
+		compactionModel := &chattest.FakeModel{
+			ProviderName: "compaction-provider",
+			ModelName:    "compaction-model",
 			GenerateFn: func(_ context.Context, _ fantasy.Call) (*fantasy.Response, error) {
+				compactionGenerateCalls++
 				return &fantasy.Response{
 					Content: []fantasy.Content{
 						fantasy.TextContent{Text: summaryText},
@@ -1048,7 +1100,8 @@ func TestRun_Compaction(t *testing.T) {
 		}
 
 		err := Run(context.Background(), RunOptions{
-			Model: model,
+			Model:           model,
+			CompactionModel: compactionModel,
 			Messages: []fantasy.Message{
 				textMessage(fantasy.MessageRoleUser, "hello"),
 			},
@@ -1076,5 +1129,6 @@ func TestRun_Compaction(t *testing.T) {
 		require.ErrorIs(t, err, ErrDynamicToolCall)
 		require.Equal(t, 1, persistCompactionCalls,
 			"compaction must fire before dynamic tool exit")
+		require.Equal(t, 1, compactionGenerateCalls)
 	})
 }

--- a/coderd/x/chatd/chatloop/compaction_test.go
+++ b/coderd/x/chatd/chatloop/compaction_test.go
@@ -427,6 +427,10 @@ func TestRun_Compaction(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
+		// Compaction fires twice: once inline when the threshold is
+		// reached on step 0 (the only step, since MaxSteps=1), and
+		// once from the post-run safety net during the re-entry
+		// iteration where totalSteps already equals MaxSteps.
 		require.Equal(t, 2, compactionGenerateCalls)
 	})
 

--- a/coderd/x/chatd/chatloop/compaction_test.go
+++ b/coderd/x/chatd/chatloop/compaction_test.go
@@ -321,6 +321,74 @@ func TestRun_Compaction(t *testing.T) {
 		require.InDelta(t, 80.0, persistedCompaction.UsagePercent, 0.0001)
 	})
 
+	t.Run("UsesCompactionModelForSummary", func(t *testing.T) {
+		t.Parallel()
+
+		compactionGenerateCalls := 0
+		activeModel := &chattest.FakeModel{
+			ProviderName: "active-provider",
+			ModelName:    "active-model",
+			StreamFn: func(_ context.Context, _ fantasy.Call) (fantasy.StreamResponse, error) {
+				return streamFromParts([]fantasy.StreamPart{
+					{Type: fantasy.StreamPartTypeTextStart, ID: "text-1"},
+					{Type: fantasy.StreamPartTypeTextDelta, ID: "text-1", Delta: "done"},
+					{Type: fantasy.StreamPartTypeTextEnd, ID: "text-1"},
+					{
+						Type:         fantasy.StreamPartTypeFinish,
+						FinishReason: fantasy.FinishReasonStop,
+						Usage: fantasy.Usage{
+							InputTokens: 80,
+							TotalTokens: 85,
+						},
+					},
+				}), nil
+			},
+			GenerateFn: func(context.Context, fantasy.Call) (*fantasy.Response, error) {
+				t.Fatal("active model should not generate compaction summaries")
+				return nil, xerrors.New("active model generated compaction summary")
+			},
+		}
+		compactionModel := &chattest.FakeModel{
+			ProviderName: "compaction-provider",
+			ModelName:    "compaction-model",
+			GenerateFn: func(_ context.Context, _ fantasy.Call) (*fantasy.Response, error) {
+				compactionGenerateCalls++
+				return &fantasy.Response{
+					Content: []fantasy.Content{
+						fantasy.TextContent{Text: "summary from compaction model"},
+					},
+				}, nil
+			},
+		}
+
+		err := Run(context.Background(), RunOptions{
+			Model:           activeModel,
+			CompactionModel: compactionModel,
+			Messages: []fantasy.Message{
+				textMessage(fantasy.MessageRoleUser, "hello"),
+			},
+			MaxSteps: 1,
+			PersistStep: func(context.Context, PersistedStep) error {
+				return nil
+			},
+			ContextLimitFallback: 100,
+			Compaction: &CompactionOptions{
+				ThresholdPercent: 70,
+				SummaryPrompt:    "summarize now",
+				Persist: func(context.Context, CompactionResult) error {
+					return nil
+				},
+			},
+			ReloadMessages: func(context.Context) ([]fantasy.Message, error) {
+				return []fantasy.Message{
+					textMessage(fantasy.MessageRoleUser, "hello"),
+				}, nil
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, 2, compactionGenerateCalls)
+	})
+
 	t.Run("PublishesPartsBeforeAndAfterPersist", func(t *testing.T) {
 		t.Parallel()
 

--- a/coderd/x/chatd/compaction_model_internal_test.go
+++ b/coderd/x/chatd/compaction_model_internal_test.go
@@ -106,6 +106,34 @@ func TestResolveCompactionModelOverride(t *testing.T) {
 		require.Equal(t, fallbackConfigID, got.modelConfigID)
 	})
 
+	t.Run("NilUUIDReturnsFallback", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitShort)
+		store := &compactionOverrideStubStore{
+			getChatCompactionModelOverride: func(context.Context) (string, error) {
+				return uuid.Nil.String(), nil
+			},
+			getEnabledChatModelConfigByID: func(context.Context, uuid.UUID) (database.ChatModelConfig, error) {
+				require.FailNow(t, "nil UUID should not query a model config")
+				return database.ChatModelConfig{}, nil
+			},
+		}
+		p := newAdvisorTestServer(ctx, t, store)
+
+		got := p.resolveCompactionModelOverride(
+			ctx,
+			database.Chat{},
+			fallbackModel,
+			fallbackConfig,
+			chatprovider.ProviderAPIKeys{},
+			logger,
+		)
+		require.Equal(t, fantasy.LanguageModel(fallbackModel), got.model)
+		require.Equal(t, fallbackConfigID, got.modelConfigID)
+		require.Equal(t, "stub", got.provider)
+		require.Equal(t, "stub", got.modelName)
+	})
+
 	t.Run("DisabledModelReturnsFallback", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitShort)

--- a/coderd/x/chatd/compaction_model_internal_test.go
+++ b/coderd/x/chatd/compaction_model_internal_test.go
@@ -1,0 +1,206 @@
+package chatd //nolint:testpackage // Accesses unexported compaction helpers.
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"charm.land/fantasy"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
+
+	"cdr.dev/slog/v3"
+	"github.com/coder/coder/v2/coderd/database"
+	"github.com/coder/coder/v2/coderd/x/chatd/chatprovider"
+	"github.com/coder/coder/v2/coderd/x/chatd/chattest"
+	"github.com/coder/coder/v2/testutil"
+)
+
+type compactionOverrideStubStore struct {
+	database.Store
+
+	getChatCompactionModelOverride func(context.Context) (string, error)
+	getEnabledChatModelConfigByID  func(context.Context, uuid.UUID) (database.ChatModelConfig, error)
+}
+
+func (s *compactionOverrideStubStore) GetChatCompactionModelOverride(ctx context.Context) (string, error) {
+	if s.getChatCompactionModelOverride == nil {
+		return "", xerrors.New("unexpected GetChatCompactionModelOverride call")
+	}
+	return s.getChatCompactionModelOverride(ctx)
+}
+
+func (s *compactionOverrideStubStore) GetEnabledChatModelConfigByID(
+	ctx context.Context,
+	id uuid.UUID,
+) (database.ChatModelConfig, error) {
+	if s.getEnabledChatModelConfigByID == nil {
+		return database.ChatModelConfig{}, xerrors.New("unexpected GetEnabledChatModelConfigByID call")
+	}
+	return s.getEnabledChatModelConfigByID(ctx, id)
+}
+
+func TestResolveCompactionModelOverride(t *testing.T) {
+	t.Parallel()
+
+	fallbackConfigID := uuid.New()
+	fallbackModel := &chattest.FakeModel{ProviderName: "stub", ModelName: "stub"}
+	fallbackConfig := database.ChatModelConfig{
+		ID:                   fallbackConfigID,
+		Provider:             "openai",
+		Model:                "gpt-4.1",
+		Enabled:              true,
+		CreatedAt:            time.Unix(0, 0).UTC(),
+		UpdatedAt:            time.Unix(0, 0).UTC(),
+		DisplayName:          "gpt-4.1",
+		ContextLimit:         1_000_000,
+		CompressionThreshold: 70,
+	}
+	logger := slog.Make()
+
+	t.Run("UnsetReturnsFallback", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitShort)
+		store := &compactionOverrideStubStore{
+			getChatCompactionModelOverride: func(context.Context) (string, error) {
+				return "", nil
+			},
+		}
+		p := newAdvisorTestServer(ctx, t, store)
+
+		got := p.resolveCompactionModelOverride(
+			ctx,
+			database.Chat{},
+			fallbackModel,
+			fallbackConfig,
+			chatprovider.ProviderAPIKeys{},
+			logger,
+		)
+		require.Equal(t, fantasy.LanguageModel(fallbackModel), got.model)
+		require.Equal(t, fallbackConfigID, got.modelConfigID)
+		require.Equal(t, "stub", got.provider)
+		require.Equal(t, "stub", got.modelName)
+	})
+
+	t.Run("MalformedReturnsFallback", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitShort)
+		store := &compactionOverrideStubStore{
+			getChatCompactionModelOverride: func(context.Context) (string, error) {
+				return "not-a-uuid", nil
+			},
+		}
+		p := newAdvisorTestServer(ctx, t, store)
+
+		got := p.resolveCompactionModelOverride(
+			ctx,
+			database.Chat{},
+			fallbackModel,
+			fallbackConfig,
+			chatprovider.ProviderAPIKeys{},
+			logger,
+		)
+		require.Equal(t, fantasy.LanguageModel(fallbackModel), got.model)
+		require.Equal(t, fallbackConfigID, got.modelConfigID)
+	})
+
+	t.Run("DisabledModelReturnsFallback", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitShort)
+		overrideID := uuid.New()
+		store := &compactionOverrideStubStore{
+			getChatCompactionModelOverride: func(context.Context) (string, error) {
+				return overrideID.String(), nil
+			},
+			getEnabledChatModelConfigByID: func(context.Context, uuid.UUID) (database.ChatModelConfig, error) {
+				return database.ChatModelConfig{}, sql.ErrNoRows
+			},
+		}
+		p := newAdvisorTestServer(ctx, t, store)
+
+		got := p.resolveCompactionModelOverride(
+			ctx,
+			database.Chat{},
+			fallbackModel,
+			fallbackConfig,
+			chatprovider.ProviderAPIKeys{OpenAI: "sk-test"},
+			logger,
+		)
+		require.Equal(t, fantasy.LanguageModel(fallbackModel), got.model)
+		require.Equal(t, fallbackConfigID, got.modelConfigID)
+	})
+
+	t.Run("MissingProviderKeyReturnsFallback", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitShort)
+		overrideID := uuid.New()
+		store := &compactionOverrideStubStore{
+			getChatCompactionModelOverride: func(context.Context) (string, error) {
+				return overrideID.String(), nil
+			},
+			getEnabledChatModelConfigByID: func(context.Context, uuid.UUID) (database.ChatModelConfig, error) {
+				return database.ChatModelConfig{
+					ID:          overrideID,
+					Provider:    "openai",
+					Model:       "gpt-5.2",
+					Enabled:     true,
+					CreatedAt:   time.Unix(0, 0).UTC(),
+					UpdatedAt:   time.Unix(0, 0).UTC(),
+					DisplayName: "gpt-5.2",
+				}, nil
+			},
+		}
+		p := newAdvisorTestServer(ctx, t, store)
+
+		got := p.resolveCompactionModelOverride(
+			ctx,
+			database.Chat{},
+			fallbackModel,
+			fallbackConfig,
+			chatprovider.ProviderAPIKeys{},
+			logger,
+		)
+		require.Equal(t, fantasy.LanguageModel(fallbackModel), got.model)
+		require.Equal(t, fallbackConfigID, got.modelConfigID)
+	})
+
+	t.Run("SuccessReturnsOverrideModelAndMetadata", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitShort)
+		overrideID := uuid.New()
+		store := &compactionOverrideStubStore{
+			getChatCompactionModelOverride: func(context.Context) (string, error) {
+				return overrideID.String(), nil
+			},
+			getEnabledChatModelConfigByID: func(context.Context, uuid.UUID) (database.ChatModelConfig, error) {
+				return database.ChatModelConfig{
+					ID:           overrideID,
+					Provider:     "openai",
+					Model:        "gpt-5.2",
+					Enabled:      true,
+					CreatedAt:    time.Unix(0, 0).UTC(),
+					UpdatedAt:    time.Unix(0, 0).UTC(),
+					DisplayName:  "gpt-5.2",
+					ContextLimit: 128_000,
+				}, nil
+			},
+		}
+		p := newAdvisorTestServer(ctx, t, store)
+
+		got := p.resolveCompactionModelOverride(
+			ctx,
+			database.Chat{},
+			fallbackModel,
+			fallbackConfig,
+			chatprovider.ProviderAPIKeys{OpenAI: "sk-test"},
+			logger,
+		)
+		require.NotEqual(t, fantasy.LanguageModel(fallbackModel), got.model)
+		require.NotNil(t, got.model)
+		require.Equal(t, overrideID, got.modelConfigID)
+		require.Equal(t, "openai", got.provider)
+		require.Equal(t, "gpt-5.2", got.modelName)
+	})
+}

--- a/coderd/x/chatd/compaction_model_internal_test.go
+++ b/coderd/x/chatd/compaction_model_internal_test.go
@@ -160,6 +160,43 @@ func TestResolveCompactionModelOverride(t *testing.T) {
 		require.Equal(t, fallbackConfigID, got.modelConfigID)
 	})
 
+	t.Run("SmallerContextLimitReturnsFallback", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitShort)
+		overrideID := uuid.New()
+		store := &compactionOverrideStubStore{
+			getChatCompactionModelOverride: func(context.Context) (string, error) {
+				return overrideID.String(), nil
+			},
+			getEnabledChatModelConfigByID: func(context.Context, uuid.UUID) (database.ChatModelConfig, error) {
+				return database.ChatModelConfig{
+					ID:           overrideID,
+					Provider:     "openai",
+					Model:        "gpt-5.2",
+					Enabled:      true,
+					CreatedAt:    time.Unix(0, 0).UTC(),
+					UpdatedAt:    time.Unix(0, 0).UTC(),
+					DisplayName:  "gpt-5.2",
+					ContextLimit: fallbackConfig.ContextLimit - 1,
+				}, nil
+			},
+		}
+		p := newAdvisorTestServer(ctx, t, store)
+
+		got := p.resolveCompactionModelOverride(
+			ctx,
+			database.Chat{},
+			fallbackModel,
+			fallbackConfig,
+			chatprovider.ProviderAPIKeys{OpenAI: "sk-test"},
+			logger,
+		)
+		require.Equal(t, fantasy.LanguageModel(fallbackModel), got.model)
+		require.Equal(t, fallbackConfigID, got.modelConfigID)
+		require.Equal(t, "stub", got.provider)
+		require.Equal(t, "stub", got.modelName)
+	})
+
 	t.Run("MissingProviderKeyReturnsFallback", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitShort)
@@ -211,7 +248,7 @@ func TestResolveCompactionModelOverride(t *testing.T) {
 					CreatedAt:    time.Unix(0, 0).UTC(),
 					UpdatedAt:    time.Unix(0, 0).UTC(),
 					DisplayName:  "gpt-5.2",
-					ContextLimit: 128_000,
+					ContextLimit: fallbackConfig.ContextLimit,
 				}, nil
 			},
 		}

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -648,6 +648,7 @@ const (
 	ChatModelOverrideContextGeneral         ChatModelOverrideContext = "general"
 	ChatModelOverrideContextExplore         ChatModelOverrideContext = "explore"
 	ChatModelOverrideContextTitleGeneration ChatModelOverrideContext = "title_generation"
+	ChatModelOverrideContextCompaction      ChatModelOverrideContext = "compaction"
 )
 
 // Valid reports whether the override context is one of the supported values.
@@ -655,7 +656,8 @@ func (c ChatModelOverrideContext) Valid() bool {
 	switch c {
 	case ChatModelOverrideContextGeneral,
 		ChatModelOverrideContextExplore,
-		ChatModelOverrideContextTitleGeneration:
+		ChatModelOverrideContextTitleGeneration,
+		ChatModelOverrideContextCompaction:
 		return true
 	default:
 		return false
@@ -668,6 +670,7 @@ func AllChatModelOverrideContexts() []ChatModelOverrideContext {
 		ChatModelOverrideContextGeneral,
 		ChatModelOverrideContextExplore,
 		ChatModelOverrideContextTitleGeneration,
+		ChatModelOverrideContextCompaction,
 	}
 }
 

--- a/codersdk/chats_test.go
+++ b/codersdk/chats_test.go
@@ -178,7 +178,6 @@ func TestChatModelOverrideContext(t *testing.T) {
 	for _, overrideContext := range contexts {
 		require.True(t, overrideContext.Valid(), "%q should be valid", overrideContext)
 	}
-	require.True(t, codersdk.ChatModelOverrideContextCompaction.Valid())
 	require.False(t, codersdk.ChatModelOverrideContext("unknown").Valid())
 }
 

--- a/codersdk/chats_test.go
+++ b/codersdk/chats_test.go
@@ -166,6 +166,22 @@ func TestChatErrorKind_JSONRoundTrip(t *testing.T) {
 	require.Equal(t, codersdk.ChatErrorKindUsageLimit, decodedRetry.Kind)
 }
 
+func TestChatModelOverrideContext(t *testing.T) {
+	t.Parallel()
+
+	contexts := codersdk.AllChatModelOverrideContexts()
+	require.Contains(t, contexts, codersdk.ChatModelOverrideContextGeneral)
+	require.Contains(t, contexts, codersdk.ChatModelOverrideContextExplore)
+	require.Contains(t, contexts, codersdk.ChatModelOverrideContextTitleGeneration)
+	require.Contains(t, contexts, codersdk.ChatModelOverrideContextCompaction)
+
+	for _, overrideContext := range contexts {
+		require.True(t, overrideContext.Valid(), "%q should be valid", overrideContext)
+	}
+	require.True(t, codersdk.ChatModelOverrideContextCompaction.Valid())
+	require.False(t, codersdk.ChatModelOverrideContext("unknown").Valid())
+}
+
 func TestChatMessagePart_StripInternal(t *testing.T) {
 	t.Parallel()
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2348,11 +2348,13 @@ export interface ChatModelOpenRouterProviderOptions {
 
 // From codersdk/chats.go
 export type ChatModelOverrideContext =
+	| "compaction"
 	| "explore"
 	| "general"
 	| "title_generation";
 
 export const ChatModelOverrideContexts: ChatModelOverrideContext[] = [
+	"compaction",
 	"explore",
 	"general",
 	"title_generation",

--- a/site/src/pages/AgentsPage/AgentSettingsAgentsPage.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsAgentsPage.tsx
@@ -18,6 +18,8 @@ import { AgentSettingsAgentsPageView } from "./AgentSettingsAgentsPageView";
 
 const generalOverrideContext: TypesGen.ChatModelOverrideContext = "general";
 const exploreOverrideContext: TypesGen.ChatModelOverrideContext = "explore";
+const compactionOverrideContext: TypesGen.ChatModelOverrideContext =
+	"compaction";
 const titleGenerationOverrideContext: TypesGen.ChatModelOverrideContext =
 	"title_generation";
 
@@ -62,6 +64,10 @@ const AgentSettingsAgentsPage: FC = () => {
 		...chatModelOverrideQuery(exploreOverrideContext),
 		enabled: canEditDeploymentConfig,
 	});
+	const compactionModelOverrideQuery = useQuery({
+		...chatModelOverrideQuery(compactionOverrideContext),
+		enabled: canEditDeploymentConfig,
+	});
 	const titleGenerationModelQuery = useQuery({
 		...chatModelOverrideQuery(titleGenerationOverrideContext),
 		enabled: canEditDeploymentConfig,
@@ -72,6 +78,9 @@ const AgentSettingsAgentsPage: FC = () => {
 	);
 	const saveGeneralModelOverrideMutation = useMutation(
 		updateChatModelOverrideMutation(queryClient, generalOverrideContext),
+	);
+	const saveCompactionModelOverrideMutation = useMutation(
+		updateChatModelOverrideMutation(queryClient, compactionOverrideContext),
 	);
 	const saveTitleGenerationModelMutation = useMutation(
 		updateChatModelOverrideMutation(
@@ -104,6 +113,7 @@ const AgentSettingsAgentsPage: FC = () => {
 					savePersonalModelOverridesAdminSettingsMutation.isError
 				}
 				generalModelOverrideData={generalModelOverrideQuery.data}
+				compactionModelOverrideData={compactionModelOverrideQuery.data}
 				titleGenerationModelOverrideData={titleGenerationModelQuery.data}
 				exploreModelOverrideData={exploreModelOverrideQuery.data}
 				modelConfigsData={modelConfigsQuery.data}
@@ -115,6 +125,15 @@ const AgentSettingsAgentsPage: FC = () => {
 				}
 				isSaveGeneralModelOverrideError={
 					saveGeneralModelOverrideMutation.isError
+				}
+				onSaveCompactionModelOverride={
+					saveCompactionModelOverrideMutation.mutate
+				}
+				isSavingCompactionModelOverride={
+					saveCompactionModelOverrideMutation.isPending
+				}
+				isSaveCompactionModelOverrideError={
+					saveCompactionModelOverrideMutation.isError
 				}
 				onSaveTitleGenerationModel={saveTitleGenerationModelMutation.mutate}
 				isSavingTitleGenerationModel={

--- a/site/src/pages/AgentsPage/AgentSettingsAgentsPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsAgentsPageView.stories.tsx
@@ -64,6 +64,13 @@ const titleModelConfig = buildModelConfig({
 	context_limit: 128_000,
 });
 
+const compactionModelConfig = buildModelConfig({
+	id: "model-compaction-gpt-4o-mini",
+	model: "gpt-4o-mini",
+	display_name: "GPT 4o Mini Compaction",
+	context_limit: 128_000,
+});
+
 const exploreFallbackModelConfig = buildModelConfig({
 	id: "model-explore-blank-display",
 	provider: "anthropic",
@@ -87,6 +94,14 @@ const titleDisabledModelConfig = buildModelConfig({
 	context_limit: 128_000,
 });
 
+const compactionDisabledModelConfig = buildModelConfig({
+	id: "model-compaction-disabled",
+	model: "gpt-4o-mini-legacy",
+	display_name: "GPT 4o Mini Compaction Legacy",
+	enabled: false,
+	context_limit: 128_000,
+});
+
 const exploreDisabledModelConfig = buildModelConfig({
 	id: "model-explore-disabled",
 	provider: "anthropic",
@@ -100,9 +115,11 @@ const allModelConfigs: TypesGen.ChatModelConfig[] = [
 	generalModelConfig,
 	claudeSonnetModelConfig,
 	titleModelConfig,
+	compactionModelConfig,
 	exploreFallbackModelConfig,
 	generalDisabledModelConfig,
 	titleDisabledModelConfig,
+	compactionDisabledModelConfig,
 	exploreDisabledModelConfig,
 ];
 
@@ -117,6 +134,7 @@ const makeArgs = (
 	isSavingAdminOverrides: false,
 	isSaveAdminOverridesError: false,
 	generalModelOverrideData: buildOverrideData("general"),
+	compactionModelOverrideData: buildOverrideData("compaction"),
 	titleGenerationModelOverrideData: buildTitleGenerationModelOverrideData(),
 	exploreModelOverrideData: buildOverrideData("explore"),
 	modelConfigsData: allModelConfigs,
@@ -125,6 +143,9 @@ const makeArgs = (
 	onSaveGeneralModelOverride: fn(),
 	isSavingGeneralModelOverride: false,
 	isSaveGeneralModelOverrideError: false,
+	onSaveCompactionModelOverride: fn(),
+	isSavingCompactionModelOverride: false,
+	isSaveCompactionModelOverrideError: false,
 	onSaveTitleGenerationModel: fn(),
 	isSavingTitleGenerationModel: false,
 	isSaveTitleGenerationModelError: false,
@@ -182,6 +203,7 @@ export const AllOverridesUnset: Story = {
 		expect(headings.map((heading) => heading.textContent?.trim())).toEqual([
 			"Enable users to define their personal overrides",
 			"General model",
+			"Compaction model",
 			"Title generation model",
 			"Explore subagent model",
 		]);
@@ -191,6 +213,10 @@ export const AllOverridesUnset: Story = {
 
 		const unsetSections = [
 			{ headingName: "General model", placeholder: "Use chat default" },
+			{
+				headingName: "Compaction model",
+				placeholder: "Use active chat model",
+			},
 			{
 				headingName: "Title generation model",
 				placeholder: "Use title default",
@@ -262,6 +288,9 @@ export const EachOverrideSetToEnabledModel: Story = {
 		generalModelOverrideData: buildOverrideData("general", {
 			model_config_id: generalModelConfig.id,
 		}),
+		compactionModelOverrideData: buildOverrideData("compaction", {
+			model_config_id: compactionModelConfig.id,
+		}),
 		titleGenerationModelOverrideData: buildTitleGenerationModelOverrideData({
 			model_config_id: titleModelConfig.id,
 		}),
@@ -271,6 +300,10 @@ export const EachOverrideSetToEnabledModel: Story = {
 	}),
 	play: async ({ canvasElement, args }) => {
 		const generalSection = await getSection(canvasElement, "General model");
+		const compactionSection = await getSection(
+			canvasElement,
+			"Compaction model",
+		);
 		const titleSection = await getSection(
 			canvasElement,
 			"Title generation model",
@@ -308,6 +341,33 @@ export const EachOverrideSetToEnabledModel: Story = {
 		await waitFor(() => {
 			expect(args.onSaveGeneralModelOverride).toHaveBeenCalledWith(
 				{ model_config_id: claudeSonnetModelConfig.id },
+				expect.anything(),
+			);
+		});
+
+		expect(
+			within(compactionSection).getByRole("combobox", {
+				name: /gpt 4o mini compaction/i,
+			}),
+		).toHaveTextContent("GPT 4o Mini Compaction");
+
+		const compactionClearButton = within(compactionSection).getByRole(
+			"button",
+			{
+				name: "Clear",
+			},
+		);
+		await userEvent.click(compactionClearButton);
+		const compactionSaveButton = within(compactionSection).getByRole("button", {
+			name: "Save",
+		});
+		await waitFor(() => {
+			expect(compactionSaveButton).toBeEnabled();
+		});
+		await userEvent.click(compactionSaveButton);
+		await waitFor(() => {
+			expect(args.onSaveCompactionModelOverride).toHaveBeenCalledWith(
+				{ model_config_id: "" },
 				expect.anything(),
 			);
 		});
@@ -357,6 +417,9 @@ export const MalformedOverridesRemainClearableAndSaveable: Story = {
 		generalModelOverrideData: buildOverrideData("general", {
 			is_malformed: true,
 		}),
+		compactionModelOverrideData: buildOverrideData("compaction", {
+			is_malformed: true,
+		}),
 		titleGenerationModelOverrideData: buildTitleGenerationModelOverrideData({
 			is_malformed: true,
 		}),
@@ -366,6 +429,10 @@ export const MalformedOverridesRemainClearableAndSaveable: Story = {
 	}),
 	play: async ({ canvasElement, args }) => {
 		const generalSection = await getSection(canvasElement, "General model");
+		const compactionSection = await getSection(
+			canvasElement,
+			"Compaction model",
+		);
 		const titleSection = await getSection(
 			canvasElement,
 			"Title generation model",
@@ -375,7 +442,12 @@ export const MalformedOverridesRemainClearableAndSaveable: Story = {
 			"Explore subagent model",
 		);
 
-		for (const section of [generalSection, titleSection, exploreSection]) {
+		for (const section of [
+			generalSection,
+			compactionSection,
+			titleSection,
+			exploreSection,
+		]) {
 			await within(section).findByText(OVERRIDE_MALFORMED_WARNING);
 		}
 
@@ -388,6 +460,20 @@ export const MalformedOverridesRemainClearableAndSaveable: Story = {
 		await userEvent.click(generalSaveButton);
 		await waitFor(() => {
 			expect(args.onSaveGeneralModelOverride).toHaveBeenCalledWith(
+				{ model_config_id: "" },
+				expect.anything(),
+			);
+		});
+
+		const compactionSaveButton = within(compactionSection).getByRole("button", {
+			name: "Save",
+		});
+		await waitFor(() => {
+			expect(compactionSaveButton).toBeEnabled();
+		});
+		await userEvent.click(compactionSaveButton);
+		await waitFor(() => {
+			expect(args.onSaveCompactionModelOverride).toHaveBeenCalledWith(
 				{ model_config_id: "" },
 				expect.anything(),
 			);
@@ -428,6 +514,9 @@ export const UnavailableSavedModels: Story = {
 		generalModelOverrideData: buildOverrideData("general", {
 			model_config_id: generalDisabledModelConfig.id,
 		}),
+		compactionModelOverrideData: buildOverrideData("compaction", {
+			model_config_id: compactionDisabledModelConfig.id,
+		}),
 		titleGenerationModelOverrideData: buildTitleGenerationModelOverrideData({
 			model_config_id: titleDisabledModelConfig.id,
 		}),
@@ -437,6 +526,10 @@ export const UnavailableSavedModels: Story = {
 	}),
 	play: async ({ canvasElement }) => {
 		const generalSection = await getSection(canvasElement, "General model");
+		const compactionSection = await getSection(
+			canvasElement,
+			"Compaction model",
+		);
 		const titleSection = await getSection(
 			canvasElement,
 			"Title generation model",
@@ -446,7 +539,7 @@ export const UnavailableSavedModels: Story = {
 			"Explore subagent model",
 		);
 
-		for (const section of [generalSection, exploreSection]) {
+		for (const section of [generalSection, compactionSection, exploreSection]) {
 			await within(section).findByText(UNAVAILABLE_SAVED_MODEL_WARNING);
 			expect(
 				within(section).getByRole("combobox", { name: "Unavailable model" }),

--- a/site/src/pages/AgentsPage/AgentSettingsAgentsPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsAgentsPageView.stories.tsx
@@ -10,6 +10,8 @@ const OVERRIDE_MALFORMED_WARNING =
 	"The saved override is malformed and is being treated as unset. Click Save to clear it.";
 const UNAVAILABLE_SAVED_MODEL_WARNING =
 	"The saved model is no longer enabled and will be ignored until you choose a new override.";
+const COMPACTION_UNAVAILABLE_SAVED_MODEL_WARNING =
+	"The saved model is no longer enabled. Compaction will use the active chat model until you choose a new override.";
 const TITLE_UNAVAILABLE_SAVED_MODEL_WARNING =
 	"The selected model is currently unavailable. Title generation will be skipped until you choose another model or clear this setting.";
 
@@ -539,12 +541,20 @@ export const UnavailableSavedModels: Story = {
 			"Explore subagent model",
 		);
 
-		for (const section of [generalSection, compactionSection, exploreSection]) {
+		for (const section of [generalSection, exploreSection]) {
 			await within(section).findByText(UNAVAILABLE_SAVED_MODEL_WARNING);
 			expect(
 				within(section).getByRole("combobox", { name: "Unavailable model" }),
 			).toBeInTheDocument();
 		}
+		await within(compactionSection).findByText(
+			COMPACTION_UNAVAILABLE_SAVED_MODEL_WARNING,
+		);
+		expect(
+			within(compactionSection).getByRole("combobox", {
+				name: "Unavailable model",
+			}),
+		).toBeInTheDocument();
 		await within(titleSection).findByText(
 			TITLE_UNAVAILABLE_SAVED_MODEL_WARNING,
 		);

--- a/site/src/pages/AgentsPage/AgentSettingsAgentsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsAgentsPageView.tsx
@@ -24,6 +24,7 @@ export interface AgentSettingsAgentsPageViewProps {
 	isSavingAdminOverrides: boolean;
 	isSaveAdminOverridesError: boolean;
 	generalModelOverrideData?: TypesGen.ChatModelOverrideResponse;
+	compactionModelOverrideData?: TypesGen.ChatModelOverrideResponse;
 	titleGenerationModelOverrideData?: TypesGen.ChatModelOverrideResponse;
 	exploreModelOverrideData?: TypesGen.ChatModelOverrideResponse;
 	modelConfigsData: TypesGen.ChatModelConfig[] | undefined;
@@ -32,6 +33,9 @@ export interface AgentSettingsAgentsPageViewProps {
 	onSaveGeneralModelOverride?: SaveModelOverride;
 	isSavingGeneralModelOverride?: boolean;
 	isSaveGeneralModelOverrideError?: boolean;
+	onSaveCompactionModelOverride: SaveModelOverride;
+	isSavingCompactionModelOverride: boolean;
+	isSaveCompactionModelOverrideError: boolean;
 	onSaveTitleGenerationModel: SaveModelOverride;
 	isSavingTitleGenerationModel: boolean;
 	isSaveTitleGenerationModelError: boolean;
@@ -51,6 +55,7 @@ export const AgentSettingsAgentsPageView: FC<
 	isSavingAdminOverrides,
 	isSaveAdminOverridesError,
 	generalModelOverrideData,
+	compactionModelOverrideData,
 	titleGenerationModelOverrideData,
 	exploreModelOverrideData,
 	modelConfigsData,
@@ -59,6 +64,9 @@ export const AgentSettingsAgentsPageView: FC<
 	onSaveGeneralModelOverride,
 	isSavingGeneralModelOverride = false,
 	isSaveGeneralModelOverrideError = false,
+	onSaveCompactionModelOverride,
+	isSavingCompactionModelOverride,
+	isSaveCompactionModelOverrideError,
 	onSaveTitleGenerationModel,
 	isSavingTitleGenerationModel,
 	isSaveTitleGenerationModelError,
@@ -112,6 +120,27 @@ export const AgentSettingsAgentsPageView: FC<
 					/>
 				</section>
 			)}
+			<section aria-label="Compaction model" className="flex flex-col gap-3">
+				<SectionHeader
+					label="Compaction model"
+					description="Deployment-wide model override for chat context compaction. Leave unset to compact with the chat model being summarized."
+					level="section"
+				/>
+				<SubagentModelOverrideSettings
+					title="Compaction model"
+					description="Choose a model for chat context compaction."
+					modelOverrideData={compactionModelOverrideData}
+					enabledModelConfigs={enabledModelConfigs}
+					modelConfigsError={modelConfigsError}
+					isLoading={isLoadingModelConfigs}
+					onSaveModelOverride={onSaveCompactionModelOverride}
+					isSaving={isSavingCompactionModelOverride}
+					isSaveError={isSaveCompactionModelOverrideError}
+					saveErrorMessage="Failed to save compaction model override."
+					unsetPlaceholder="Use active chat model"
+					showHeader={false}
+				/>
+			</section>
 			<section
 				aria-label="Title generation model"
 				className="flex flex-col gap-3"

--- a/site/src/pages/AgentsPage/AgentSettingsAgentsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsAgentsPageView.tsx
@@ -123,7 +123,7 @@ export const AgentSettingsAgentsPageView: FC<
 			<section aria-label="Compaction model" className="flex flex-col gap-3">
 				<SectionHeader
 					label="Compaction model"
-					description="Deployment-wide model override for chat context compaction. Leave unset to compact with the chat model being summarized."
+					description="Deployment-wide model override for chat context compaction. Leave unset to use the active chat model."
 					level="section"
 				/>
 				<SubagentModelOverrideSettings

--- a/site/src/pages/AgentsPage/AgentSettingsAgentsPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentSettingsAgentsPageView.tsx
@@ -138,6 +138,7 @@ export const AgentSettingsAgentsPageView: FC<
 					isSaveError={isSaveCompactionModelOverrideError}
 					saveErrorMessage="Failed to save compaction model override."
 					unsetPlaceholder="Use active chat model"
+					unavailableModelWarning="The saved model is no longer enabled. Compaction will use the active chat model until you choose a new override."
 					showHeader={false}
 				/>
 			</section>

--- a/site/src/pages/AgentsPage/AgentsPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentsPageView.stories.tsx
@@ -175,6 +175,11 @@ const AgentsRouteElement = () => (
 			model_config_id: "",
 			is_malformed: false,
 		}}
+		compactionModelOverrideData={{
+			context: "compaction",
+			model_config_id: "",
+			is_malformed: false,
+		}}
 		titleGenerationModelOverrideData={{
 			context: "title_generation",
 			model_config_id: "",
@@ -183,6 +188,9 @@ const AgentsRouteElement = () => (
 		modelConfigsData={[]}
 		modelConfigsError={undefined}
 		isLoadingModelConfigs={false}
+		onSaveCompactionModelOverride={fn()}
+		isSavingCompactionModelOverride={false}
+		isSaveCompactionModelOverrideError={false}
 		onSaveTitleGenerationModel={fn()}
 		isSavingTitleGenerationModel={false}
 		isSaveTitleGenerationModelError={false}


### PR DESCRIPTION
Adds a deployment-wide chat compaction model override so admins can choose a separate model for summary generation. The override uses the existing chat model override API and site config storage, with fallback to the active chat model when unset or unavailable.

The Agents settings page now exposes a Compaction model selector alongside the existing model override controls, and compaction debug runs record the actual compaction provider and model.

> Mux is working on behalf of Mike.
