### PR TITLE
fix(coderd/x/chatd): ignore stale control notifications via DB re-read

### DIFF
--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -65,8 +65,12 @@ const (
 
 	homeInstructionLookupTimeout = 5 * time.Second
 	planPathLookupTimeout        = 5 * time.Second
-	instructionCacheTTL          = 5 * time.Minute
-	workspaceDialValidationDelay = 5 * time.Second
+	// chatControlNotifyDBReadTimeout caps the chat re-read performed
+	// inside subscribeChatControl's pubsub listener. It must be short
+	// because the read runs on the pubsub dispatch goroutine.
+	chatControlNotifyDBReadTimeout = 5 * time.Second
+	instructionCacheTTL            = 5 * time.Minute
+	workspaceDialValidationDelay   = 5 * time.Second
 	// Must exceed agent/x/agentmcp.connectTimeout (30s) so a
 	// cold-start agent's first MCP reload can settle before
 	// chatd gives up.
@@ -5329,7 +5333,10 @@ func (p *Server) subscribeChatControl(
 		// database does not block the pubsub dispatch goroutine, and
 		// so listener context cancellation from server shutdown does
 		// not skip the final cancel.
-		dbCtx, dbCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		dbCtx, dbCancel := context.WithTimeout(
+			context.Background(),
+			chatControlNotifyDBReadTimeout,
+		)
 		defer dbCancel()
 		//nolint:gocritic // AsChatd authorizes the daemon's own
 		// internal lookup against a chat it is actively processing.

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -5311,9 +5311,47 @@ func (p *Server) subscribeChatControl(
 			return
 		}
 
-		if shouldCancelChatFromControlNotification(notify, p.workerID) {
-			cancel(chatloop.ErrInterrupted)
+		if !shouldCancelChatFromControlNotification(notify, p.workerID) {
+			return
 		}
+
+		// Re-read the chat from the database before honoring the
+		// cancel signal. PostgreSQL NOTIFY delivery is asynchronous,
+		// so a stale "pending" notification published by this
+		// worker's own previous cleanup (finishActiveChat publishes
+		// status=pending before signalWake fires) can be delivered to
+		// the new subscriber registered by the next processChat for
+		// the same chat ID. Without this check, the stale
+		// notification would cancel the freshly armed run before it
+		// makes any upstream request.
+		//
+		// Use a detached context with a short timeout so a slow
+		// database does not block the pubsub dispatch goroutine, and
+		// so listener context cancellation from server shutdown does
+		// not skip the final cancel.
+		dbCtx, dbCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer dbCancel()
+		//nolint:gocritic // AsChatd authorizes the daemon's own
+		// internal lookup against a chat it is actively processing.
+		latest, latestErr := p.db.GetChatByID(dbauthz.AsChatd(dbCtx), chatID)
+		if latestErr == nil &&
+			latest.Status == database.ChatStatusRunning &&
+			latest.WorkerID.Valid &&
+			latest.WorkerID.UUID == p.workerID {
+			logger.Debug(ctx, "ignoring stale chat control notification",
+				slog.F("notify_status", notify.Status),
+				slog.F("notify_worker_id", notify.WorkerID),
+			)
+			return
+		}
+		if latestErr != nil {
+			logger.Warn(ctx, "failed to re-read chat for control notification; honoring cancel",
+				slog.F("notify_status", notify.Status),
+				slog.Error(latestErr),
+			)
+		}
+
+		cancel(chatloop.ErrInterrupted)
 	}
 
 	controlCancel, err := p.pubsub.SubscribeWithErr(

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -3488,9 +3488,9 @@ func TestProcessChat_IgnoresStaleControlNotification(t *testing.T) {
 
 	db.EXPECT().UpdateChatLastTurnSummary(gomock.Any(), gomock.Any()).Return(int64(1), nil)
 
-	// resolveChatModel fails immediately. We only
-	// need processChat to get past initialization without being
-	// interrupted by the stale notification.
+	// resolveChatModel fails immediately so we only need processChat to get
+	// past initialization without being interrupted by the stale
+	// notification.
 	db.EXPECT().GetChatModelConfigByID(gomock.Any(), gomock.Any()).Return(
 		database.ChatModelConfig{}, xerrors.New("no model configured"),
 	).AnyTimes()
@@ -3523,230 +3523,140 @@ func TestProcessChat_IgnoresStaleControlNotification(t *testing.T) {
 		"processChat should have reached runChat (error), not been interrupted (waiting)")
 }
 
-// TestSubscribeChatControl_IgnoresStaleNotificationWhenDBSaysRunning verifies
-// that the listener registered by subscribeChatControl re-reads the chat
-// from the database when a cancel-worthy notification arrives, and ignores
-// the notification when the database confirms the chat is still running
-// on this worker. This is the safeguard for the race documented in the
+// TestSubscribeChatControl_RereadsChatBeforeHonoringCancel verifies that
+// the listener registered by subscribeChatControl re-reads the chat from
+// the database when a cancel-worthy notification arrives. The fix
+// suppresses the cancel iff the database confirms the chat is still
+// running on this worker, guarding against the race documented in the
 // finishActiveChat cleanup path: the chat's own cleanup publishes
 // status=pending immediately before signalWake, and PostgreSQL NOTIFY
 // delivery is asynchronous so the stale "pending" can be delivered to
 // the next processChat's freshly registered subscriber.
-func TestSubscribeChatControl_IgnoresStaleNotificationWhenDBSaysRunning(t *testing.T) {
+func TestSubscribeChatControl_RereadsChatBeforeHonoringCancel(t *testing.T) {
 	t.Parallel()
 
-	ctx := testutil.Context(t, testutil.WaitShort)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
-	ctrl := gomock.NewController(t)
-	db := dbmock.NewMockStore(ctrl)
-	ps := dbpubsub.NewInMemory()
-
-	chatID := uuid.New()
-	workerID := uuid.New()
-
-	server := &Server{
-		db:       db,
-		logger:   logger,
-		pubsub:   ps,
-		workerID: workerID,
-	}
-
-	// The DB still says the chat is running on us, so the stale
-	// notification must be ignored.
-	db.EXPECT().GetChatByID(gomock.Any(), chatID).Return(database.Chat{
-		ID:       chatID,
-		Status:   database.ChatStatusRunning,
-		WorkerID: uuid.NullUUID{UUID: workerID, Valid: true},
-	}, nil).AnyTimes()
-
-	cancelCalled := make(chan error, 1)
-	cancel := func(cause error) {
-		select {
-		case cancelCalled <- cause:
-		default:
-		}
-	}
-
-	unsubscribe := server.subscribeChatControl(ctx, chatID, cancel, logger)
-	require.NotNil(t, unsubscribe)
-	defer unsubscribe()
-
-	notify, err := json.Marshal(coderdpubsub.ChatStreamNotifyMessage{
-		Status: string(database.ChatStatusPending),
-	})
-	require.NoError(t, err)
-	require.NoError(t, ps.Publish(coderdpubsub.ChatStreamNotifyChannel(chatID), notify))
-
-	select {
-	case cause := <-cancelCalled:
-		t.Fatalf("cancel was called for stale notification; cause=%v", cause)
-	case <-time.After(testutil.IntervalFast):
-	}
-}
-
-// TestSubscribeChatControl_CancelsWhenDBSaysWaiting verifies that the
-// listener honors a cancel-worthy notification when the database confirms
-// the chat is no longer running on this worker (i.e. an external
-// InterruptChat moved it to waiting and cleared the worker ID).
-func TestSubscribeChatControl_CancelsWhenDBSaysWaiting(t *testing.T) {
-	t.Parallel()
-
-	ctx := testutil.Context(t, testutil.WaitShort)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
-	ctrl := gomock.NewController(t)
-	db := dbmock.NewMockStore(ctrl)
-	ps := dbpubsub.NewInMemory()
-
-	chatID := uuid.New()
-	workerID := uuid.New()
-
-	server := &Server{
-		db:       db,
-		logger:   logger,
-		pubsub:   ps,
-		workerID: workerID,
-	}
-
-	db.EXPECT().GetChatByID(gomock.Any(), chatID).Return(database.Chat{
-		ID:       chatID,
-		Status:   database.ChatStatusWaiting,
-		WorkerID: uuid.NullUUID{},
-	}, nil).AnyTimes()
-
-	cancelCalled := make(chan error, 1)
-	cancel := func(cause error) {
-		select {
-		case cancelCalled <- cause:
-		default:
-		}
-	}
-
-	unsubscribe := server.subscribeChatControl(ctx, chatID, cancel, logger)
-	require.NotNil(t, unsubscribe)
-	defer unsubscribe()
-
-	notify, err := json.Marshal(coderdpubsub.ChatStreamNotifyMessage{
-		Status: string(database.ChatStatusWaiting),
-	})
-	require.NoError(t, err)
-	require.NoError(t, ps.Publish(coderdpubsub.ChatStreamNotifyChannel(chatID), notify))
-
-	select {
-	case cause := <-cancelCalled:
-		require.ErrorIs(t, cause, chatloop.ErrInterrupted)
-	case <-ctx.Done():
-		t.Fatal("timed out waiting for cancel")
-	}
-}
-
-// TestSubscribeChatControl_CancelsWhenDBSaysRunningOnDifferentWorker
-// verifies that the listener honors a cancel when the database shows the
-// chat has been claimed by another worker (cross-replica steal recovery).
-func TestSubscribeChatControl_CancelsWhenDBSaysRunningOnDifferentWorker(t *testing.T) {
-	t.Parallel()
-
-	ctx := testutil.Context(t, testutil.WaitShort)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
-	ctrl := gomock.NewController(t)
-	db := dbmock.NewMockStore(ctrl)
-	ps := dbpubsub.NewInMemory()
-
-	chatID := uuid.New()
 	workerID := uuid.New()
 	otherWorkerID := uuid.New()
 
-	server := &Server{
-		db:       db,
-		logger:   logger,
-		pubsub:   ps,
-		workerID: workerID,
+	cases := []struct {
+		name string
+		// dbChat is the row that GetChatByID returns. Ignored when
+		// dbErr is non-nil.
+		dbChat database.Chat
+		dbErr  error
+		// notify is the payload delivered on the control channel.
+		// shouldCancelChatFromControlNotification must return true
+		// for it, otherwise the re-read branch is not exercised.
+		notify       coderdpubsub.ChatStreamNotifyMessage
+		expectCancel bool
+	}{
+		{
+			name: "IgnoresStaleNotificationWhenDBSaysRunningOnSelf",
+			dbChat: database.Chat{
+				Status:   database.ChatStatusRunning,
+				WorkerID: uuid.NullUUID{UUID: workerID, Valid: true},
+			},
+			notify: coderdpubsub.ChatStreamNotifyMessage{
+				Status: string(database.ChatStatusPending),
+			},
+			expectCancel: false,
+		},
+		{
+			// External InterruptChat moved the chat to waiting and
+			// cleared worker_id.
+			name: "CancelsWhenDBSaysWaiting",
+			dbChat: database.Chat{
+				Status:   database.ChatStatusWaiting,
+				WorkerID: uuid.NullUUID{},
+			},
+			notify: coderdpubsub.ChatStreamNotifyMessage{
+				Status: string(database.ChatStatusWaiting),
+			},
+			expectCancel: true,
+		},
+		{
+			// Cross-replica steal: another worker now owns the chat.
+			name: "CancelsWhenDBSaysRunningOnDifferentWorker",
+			dbChat: database.Chat{
+				Status:   database.ChatStatusRunning,
+				WorkerID: uuid.NullUUID{UUID: otherWorkerID, Valid: true},
+			},
+			notify: coderdpubsub.ChatStreamNotifyMessage{
+				Status:   string(database.ChatStatusRunning),
+				WorkerID: otherWorkerID.String(),
+			},
+			expectCancel: true,
+		},
+		{
+			// Fail-open: the re-read errors, the listener still
+			// honors the cancel.
+			name:  "CancelsWhenDBReadFails",
+			dbErr: xerrors.New("boom"),
+			notify: coderdpubsub.ChatStreamNotifyMessage{
+				Status: string(database.ChatStatusWaiting),
+			},
+			expectCancel: true,
+		},
 	}
 
-	db.EXPECT().GetChatByID(gomock.Any(), chatID).Return(database.Chat{
-		ID:       chatID,
-		Status:   database.ChatStatusRunning,
-		WorkerID: uuid.NullUUID{UUID: otherWorkerID, Valid: true},
-	}, nil).AnyTimes()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	cancelCalled := make(chan error, 1)
-	cancel := func(cause error) {
-		select {
-		case cancelCalled <- cause:
-		default:
-		}
-	}
+			ctx := testutil.Context(t, testutil.WaitShort)
+			logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+			ctrl := gomock.NewController(t)
+			db := dbmock.NewMockStore(ctrl)
+			ps := dbpubsub.NewInMemory()
 
-	unsubscribe := server.subscribeChatControl(ctx, chatID, cancel, logger)
-	require.NotNil(t, unsubscribe)
-	defer unsubscribe()
+			chatID := uuid.New()
+			dbChat := tc.dbChat
+			dbChat.ID = chatID
 
-	// Publish a notification reporting that another worker now owns
-	// the chat. shouldCancelChatFromControlNotification returns true
-	// because the running worker no longer matches us.
-	notify, err := json.Marshal(coderdpubsub.ChatStreamNotifyMessage{
-		Status:   string(database.ChatStatusRunning),
-		WorkerID: otherWorkerID.String(),
-	})
-	require.NoError(t, err)
-	require.NoError(t, ps.Publish(coderdpubsub.ChatStreamNotifyChannel(chatID), notify))
+			server := &Server{
+				db:       db,
+				logger:   logger,
+				pubsub:   ps,
+				workerID: workerID,
+			}
 
-	select {
-	case cause := <-cancelCalled:
-		require.ErrorIs(t, cause, chatloop.ErrInterrupted)
-	case <-ctx.Done():
-		t.Fatal("timed out waiting for cancel")
-	}
-}
+			db.EXPECT().
+				GetChatByID(gomock.Any(), chatID).
+				Return(dbChat, tc.dbErr).
+				AnyTimes()
 
-// TestSubscribeChatControl_CancelsWhenDBReadFails verifies the fail-open
-// behavior: if the re-read query errors, the listener honors the cancel
-// signal rather than swallowing it.
-func TestSubscribeChatControl_CancelsWhenDBReadFails(t *testing.T) {
-	t.Parallel()
+			cancelCalled := make(chan error, 1)
+			cancel := func(cause error) {
+				select {
+				case cancelCalled <- cause:
+				default:
+				}
+			}
 
-	ctx := testutil.Context(t, testutil.WaitShort)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
-	ctrl := gomock.NewController(t)
-	db := dbmock.NewMockStore(ctrl)
-	ps := dbpubsub.NewInMemory()
+			unsubscribe := server.subscribeChatControl(ctx, chatID, cancel, logger)
+			require.NotNil(t, unsubscribe)
+			defer unsubscribe()
 
-	chatID := uuid.New()
-	workerID := uuid.New()
+			payload, err := json.Marshal(tc.notify)
+			require.NoError(t, err)
+			require.NoError(t, ps.Publish(coderdpubsub.ChatStreamNotifyChannel(chatID), payload))
 
-	server := &Server{
-		db:       db,
-		logger:   logger,
-		pubsub:   ps,
-		workerID: workerID,
-	}
+			if tc.expectCancel {
+				select {
+				case cause := <-cancelCalled:
+					require.ErrorIs(t, cause, chatloop.ErrInterrupted)
+				case <-ctx.Done():
+					t.Fatal("timed out waiting for cancel")
+				}
+				return
+			}
 
-	db.EXPECT().GetChatByID(gomock.Any(), chatID).Return(
-		database.Chat{}, xerrors.New("boom"),
-	).AnyTimes()
-
-	cancelCalled := make(chan error, 1)
-	cancel := func(cause error) {
-		select {
-		case cancelCalled <- cause:
-		default:
-		}
-	}
-
-	unsubscribe := server.subscribeChatControl(ctx, chatID, cancel, logger)
-	require.NotNil(t, unsubscribe)
-	defer unsubscribe()
-
-	notify, err := json.Marshal(coderdpubsub.ChatStreamNotifyMessage{
-		Status: string(database.ChatStatusWaiting),
-	})
-	require.NoError(t, err)
-	require.NoError(t, ps.Publish(coderdpubsub.ChatStreamNotifyChannel(chatID), notify))
-
-	select {
-	case cause := <-cancelCalled:
-		require.ErrorIs(t, cause, chatloop.ErrInterrupted)
-	case <-ctx.Done():
-		t.Fatal("timed out waiting for cancel")
+			select {
+			case cause := <-cancelCalled:
+				t.Fatalf("cancel was called for stale notification; cause=%v", cause)
+			case <-time.After(testutil.IntervalFast):
+			}
+		})
 	}
 }
 

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -3484,11 +3484,11 @@ func TestProcessChat_IgnoresStaleControlNotification(t *testing.T) {
 	db.EXPECT().GetChatByID(gomock.Any(), chatID).Return(
 		database.Chat{ID: chatID, Status: database.ChatStatusError},
 		nil,
-	)
+	).AnyTimes()
 
 	db.EXPECT().UpdateChatLastTurnSummary(gomock.Any(), gomock.Any()).Return(int64(1), nil)
 
-	// resolveChatModel fails immediately — that's fine, we only
+	// resolveChatModel fails immediately. We only
 	// need processChat to get past initialization without being
 	// interrupted by the stale notification.
 	db.EXPECT().GetChatModelConfigByID(gomock.Any(), gomock.Any()).Return(
@@ -3521,6 +3521,233 @@ func TestProcessChat_IgnoresStaleControlNotification(t *testing.T) {
 	// resolution → status is "error".
 	require.Equal(t, database.ChatStatusError, finalStatus,
 		"processChat should have reached runChat (error), not been interrupted (waiting)")
+}
+
+// TestSubscribeChatControl_IgnoresStaleNotificationWhenDBSaysRunning verifies
+// that the listener registered by subscribeChatControl re-reads the chat
+// from the database when a cancel-worthy notification arrives, and ignores
+// the notification when the database confirms the chat is still running
+// on this worker. This is the safeguard for the race documented in the
+// finishActiveChat cleanup path: the chat's own cleanup publishes
+// status=pending immediately before signalWake, and PostgreSQL NOTIFY
+// delivery is asynchronous so the stale "pending" can be delivered to
+// the next processChat's freshly registered subscriber.
+func TestSubscribeChatControl_IgnoresStaleNotificationWhenDBSaysRunning(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+	ps := dbpubsub.NewInMemory()
+
+	chatID := uuid.New()
+	workerID := uuid.New()
+
+	server := &Server{
+		db:       db,
+		logger:   logger,
+		pubsub:   ps,
+		workerID: workerID,
+	}
+
+	// The DB still says the chat is running on us, so the stale
+	// notification must be ignored.
+	db.EXPECT().GetChatByID(gomock.Any(), chatID).Return(database.Chat{
+		ID:       chatID,
+		Status:   database.ChatStatusRunning,
+		WorkerID: uuid.NullUUID{UUID: workerID, Valid: true},
+	}, nil).AnyTimes()
+
+	cancelCalled := make(chan error, 1)
+	cancel := func(cause error) {
+		select {
+		case cancelCalled <- cause:
+		default:
+		}
+	}
+
+	unsubscribe := server.subscribeChatControl(ctx, chatID, cancel, logger)
+	require.NotNil(t, unsubscribe)
+	defer unsubscribe()
+
+	notify, err := json.Marshal(coderdpubsub.ChatStreamNotifyMessage{
+		Status: string(database.ChatStatusPending),
+	})
+	require.NoError(t, err)
+	require.NoError(t, ps.Publish(coderdpubsub.ChatStreamNotifyChannel(chatID), notify))
+
+	select {
+	case cause := <-cancelCalled:
+		t.Fatalf("cancel was called for stale notification; cause=%v", cause)
+	case <-time.After(testutil.IntervalFast):
+	}
+}
+
+// TestSubscribeChatControl_CancelsWhenDBSaysWaiting verifies that the
+// listener honors a cancel-worthy notification when the database confirms
+// the chat is no longer running on this worker (i.e. an external
+// InterruptChat moved it to waiting and cleared the worker ID).
+func TestSubscribeChatControl_CancelsWhenDBSaysWaiting(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+	ps := dbpubsub.NewInMemory()
+
+	chatID := uuid.New()
+	workerID := uuid.New()
+
+	server := &Server{
+		db:       db,
+		logger:   logger,
+		pubsub:   ps,
+		workerID: workerID,
+	}
+
+	db.EXPECT().GetChatByID(gomock.Any(), chatID).Return(database.Chat{
+		ID:       chatID,
+		Status:   database.ChatStatusWaiting,
+		WorkerID: uuid.NullUUID{},
+	}, nil).AnyTimes()
+
+	cancelCalled := make(chan error, 1)
+	cancel := func(cause error) {
+		select {
+		case cancelCalled <- cause:
+		default:
+		}
+	}
+
+	unsubscribe := server.subscribeChatControl(ctx, chatID, cancel, logger)
+	require.NotNil(t, unsubscribe)
+	defer unsubscribe()
+
+	notify, err := json.Marshal(coderdpubsub.ChatStreamNotifyMessage{
+		Status: string(database.ChatStatusWaiting),
+	})
+	require.NoError(t, err)
+	require.NoError(t, ps.Publish(coderdpubsub.ChatStreamNotifyChannel(chatID), notify))
+
+	select {
+	case cause := <-cancelCalled:
+		require.ErrorIs(t, cause, chatloop.ErrInterrupted)
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for cancel")
+	}
+}
+
+// TestSubscribeChatControl_CancelsWhenDBSaysRunningOnDifferentWorker
+// verifies that the listener honors a cancel when the database shows the
+// chat has been claimed by another worker (cross-replica steal recovery).
+func TestSubscribeChatControl_CancelsWhenDBSaysRunningOnDifferentWorker(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+	ps := dbpubsub.NewInMemory()
+
+	chatID := uuid.New()
+	workerID := uuid.New()
+	otherWorkerID := uuid.New()
+
+	server := &Server{
+		db:       db,
+		logger:   logger,
+		pubsub:   ps,
+		workerID: workerID,
+	}
+
+	db.EXPECT().GetChatByID(gomock.Any(), chatID).Return(database.Chat{
+		ID:       chatID,
+		Status:   database.ChatStatusRunning,
+		WorkerID: uuid.NullUUID{UUID: otherWorkerID, Valid: true},
+	}, nil).AnyTimes()
+
+	cancelCalled := make(chan error, 1)
+	cancel := func(cause error) {
+		select {
+		case cancelCalled <- cause:
+		default:
+		}
+	}
+
+	unsubscribe := server.subscribeChatControl(ctx, chatID, cancel, logger)
+	require.NotNil(t, unsubscribe)
+	defer unsubscribe()
+
+	// Publish a notification reporting that another worker now owns
+	// the chat. shouldCancelChatFromControlNotification returns true
+	// because the running worker no longer matches us.
+	notify, err := json.Marshal(coderdpubsub.ChatStreamNotifyMessage{
+		Status:   string(database.ChatStatusRunning),
+		WorkerID: otherWorkerID.String(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, ps.Publish(coderdpubsub.ChatStreamNotifyChannel(chatID), notify))
+
+	select {
+	case cause := <-cancelCalled:
+		require.ErrorIs(t, cause, chatloop.ErrInterrupted)
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for cancel")
+	}
+}
+
+// TestSubscribeChatControl_CancelsWhenDBReadFails verifies the fail-open
+// behavior: if the re-read query errors, the listener honors the cancel
+// signal rather than swallowing it.
+func TestSubscribeChatControl_CancelsWhenDBReadFails(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+	ps := dbpubsub.NewInMemory()
+
+	chatID := uuid.New()
+	workerID := uuid.New()
+
+	server := &Server{
+		db:       db,
+		logger:   logger,
+		pubsub:   ps,
+		workerID: workerID,
+	}
+
+	db.EXPECT().GetChatByID(gomock.Any(), chatID).Return(
+		database.Chat{}, xerrors.New("boom"),
+	).AnyTimes()
+
+	cancelCalled := make(chan error, 1)
+	cancel := func(cause error) {
+		select {
+		case cancelCalled <- cause:
+		default:
+		}
+	}
+
+	unsubscribe := server.subscribeChatControl(ctx, chatID, cancel, logger)
+	require.NotNil(t, unsubscribe)
+	defer unsubscribe()
+
+	notify, err := json.Marshal(coderdpubsub.ChatStreamNotifyMessage{
+		Status: string(database.ChatStatusWaiting),
+	})
+	require.NoError(t, err)
+	require.NoError(t, ps.Publish(coderdpubsub.ChatStreamNotifyChannel(chatID), notify))
+
+	select {
+	case cause := <-cancelCalled:
+		require.ErrorIs(t, cause, chatloop.ErrInterrupted)
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for cancel")
+	}
 }
 
 func TestShouldPublishFinishedChatState(t *testing.T) {
@@ -5245,6 +5472,15 @@ func TestAutoPromote_InsertFailureSkipsStatusUpdate(t *testing.T) {
 		database.ChatUsageLimitConfig{}, sql.ErrNoRows,
 	).AnyTimes()
 	db.EXPECT().GetChatMessagesForPromptByChatID(gomock.Any(), chatID).Return(nil, nil).AnyTimes()
+	// subscribeChatControl re-reads the chat from the database when it
+	// receives a cancel-worthy control notification so it can ignore
+	// stale notifications from prior runs. The interrupt notification
+	// in this test is the legitimate cancel, so honoring it is the
+	// correct behavior whether or not the DB returns a row.
+	db.EXPECT().GetChatByID(gomock.Any(), chatID).Return(
+		database.Chat{ID: chatID, Status: database.ChatStatusWaiting},
+		nil,
+	).AnyTimes()
 
 	// The deferred cleanup transaction: InsertChatMessages fails,
 	// so UpdateChatStatus must NOT be called.


### PR DESCRIPTION
Fixes a flaky test caused by a pubsub race in `coderd/x/chatd`. When auto-promotion chains a queued message through a new `processChat` invocation, the cleanup defer of the previous run publishes `status=pending` and `signalWake()`. PostgreSQL `NOTIFY` delivery is asynchronous, so the new run's control subscriber can receive that stale `pending` notification after `close(controlArmed)` and cancel the run with `ErrInterrupted` before the upstream request is issued. `TestAutoPromoteQueuedMessagesPreservesPerTurnModelOrder` then times out waiting for the third streaming request.

The listener now re-reads the chat from the database before honoring a cancel-worthy notification. If the chat is still running on this worker the notification is treated as stale and ignored; external interrupts, cross-replica steals, and DB read failures still cancel the run. The re-read uses a detached context with a short timeout so a slow DB cannot stall the pubsub dispatch goroutine and listener context cancellation from shutdown does not silently skip the cancel.

Refs CODAGT-353

<sub>This PR was generated by Coder Agents on behalf of @ibetitsmike.</sub>

<details>
<summary>Root-cause analysis</summary>

The chained `processChat` lifecycle for auto-promotion looks roughly like:

1. `processChat` for the in-flight turn finishes and its `defer` cleanup publishes the chat as `status=pending` and calls `signalWake()` so the acquire loop wakes up.
2. The acquire loop transitions the chat back to `status=running` on this same worker and starts a new `processChat`.
3. The new `processChat` registers a fresh control subscriber via `subscribeChatControl` and then calls `close(controlArmed)` to start handling notifications.

Because `NOTIFY` delivery is asynchronous, the `pending` payload published in step 1 can still be in flight after step 3. `shouldCancelChatFromControlNotification` returns `true` for any non-running status regardless of `WorkerID`, so the listener cancels the run with `ErrInterrupted` before the upstream HTTP request is dispatched. The test then blocks on `testutil.TryReceive(ctx, t, thirdRunStarted)` until the suite timeout fires.

The fix re-reads the chat row via `p.db.GetChatByID(dbauthz.AsChatd(dbCtx), chatID)` from inside the listener and only honors the cancel when the database confirms it. If the chat is still `Running` on `p.workerID` the notification is stale and ignored. Any other state, including DB read errors, falls through to the existing cancel path so genuine interrupts and cross-replica steals continue to work. A detached `context.WithTimeout(context.Background(), chatControlNotifyDBReadTimeout)` is used so a slow DB cannot block the pubsub dispatch goroutine and a listener context cancellation triggered by shutdown does not skip the cancel.

`TestSubscribeChatControl_RereadsChatBeforeHonoringCancel` is a table-driven unit test that covers each branch of the listener's re-read decision:

- the DB still says the chat is running on this worker (stale notification, suppress cancel),
- the DB says the chat is waiting (genuine interrupt, honor cancel),
- the DB says the chat is running on a different worker (cross-replica steal, honor cancel),
- the DB read fails (fail open, honor cancel).

The previously flaky `TestAutoPromoteQueuedMessagesPreservesPerTurnModelOrder` was rerun with `-count=100 -race` and passed (0 failures), and the full `coderd/x/chatd` package passed with `-race -count=10` in ~160s.

</details>

