### PR TITLE
fix(coderd/x/chatd): verify chat state before honoring control NOTIFY cancel

### DIFF
--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -5289,6 +5289,49 @@ func shouldCancelChatFromControlNotification(
 	}
 }
 
+// controlNotifyIsStaleForThisWorker reports whether a cancel-shaped
+// control notification is stale and should be ignored. It re-reads the
+// chat row and returns true only when the chat is still running on this
+// worker. The PostgreSQL LISTEN/NOTIFY race described at
+// https://www.postgresql.org/docs/current/sql-listen.html can deliver a
+// pending/waiting notification published by SendMessage just before
+// AcquireChats marked the chat running on this worker. Those stale
+// notifications must not interrupt active processing. Legitimate
+// cross-replica interrupts (InterruptChat, EditMessage, etc.) write the
+// new chat state before publishing, so the DB read here observes the
+// chat in a non-(running+ours) state and correctly cancels.
+//
+// On any DB read error the function fails open (returns false) so that
+// the cancel proceeds, preserving prior behavior.
+func (p *Server) controlNotifyIsStaleForThisWorker(
+	ctx context.Context,
+	chatID uuid.UUID,
+	logger slog.Logger,
+) bool {
+	if ctx.Err() != nil {
+		return false
+	}
+	lookupCtx, cancelLookup := context.WithTimeout(ctx, chatStreamControlFetchTimeout)
+	defer cancelLookup()
+	//nolint:gocritic // Control-path DB read for stale-notify filtering
+	// runs with daemon scope, identical to the heartbeat loop.
+	chat, err := p.db.GetChatByID(dbauthz.AsChatd(lookupCtx), chatID)
+	if err != nil {
+		logger.Debug(ctx, "failed to verify chat state for control notify; allowing cancel",
+			slog.F("chat_id", chatID),
+			slog.Error(err),
+		)
+		return false
+	}
+	if chat.Status != database.ChatStatusRunning {
+		return false
+	}
+	if !chat.WorkerID.Valid || chat.WorkerID.UUID != p.workerID {
+		return false
+	}
+	return true
+}
+
 func (p *Server) subscribeChatControl(
 	ctx context.Context,
 	chatID uuid.UUID,
@@ -5311,9 +5354,23 @@ func (p *Server) subscribeChatControl(
 			return
 		}
 
-		if shouldCancelChatFromControlNotification(notify, p.workerID) {
-			cancel(chatloop.ErrInterrupted)
+		if !shouldCancelChatFromControlNotification(notify, p.workerID) {
+			return
 		}
+		// Re-read the chat row so a stale pending/waiting notification
+		// published before AcquireChats stamped this worker as owner
+		// cannot interrupt the in-progress run. See
+		// controlNotifyIsStaleForThisWorker for the PostgreSQL
+		// LISTEN/NOTIFY race details.
+		if p.controlNotifyIsStaleForThisWorker(ctx, chatID, logger) {
+			logger.Debug(ctx, "ignoring stale chat control notification",
+				slog.F("chat_id", chatID),
+				slog.F("notify_status", notify.Status),
+				slog.F("notify_worker_id", notify.WorkerID),
+			)
+			return
+		}
+		cancel(chatloop.ErrInterrupted)
 	}
 
 	controlCancel, err := p.pubsub.SubscribeWithErr(

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -5705,11 +5705,20 @@ func (p *Server) processChat(ctx context.Context, chat database.Chat) {
 	}
 
 	controlCancel := p.subscribeChatControl(chatCtx, chat.ID, gatedCancel, logger)
-	defer func() {
-		if controlCancel != nil {
-			controlCancel()
+	// stopControlListener unsubscribes the control listener once, so that
+	// the cleanup-cycle publishStatus(waiting) self-notification does not
+	// trigger an extra GetChatByID through controlNotifyIsStaleForThisWorker.
+	// The closure is invoked both at the top of the main cleanup defer and
+	// by the LIFO defer below; the second call is a no-op because
+	// controlCancel is cleared.
+	stopControlListener := func() {
+		if controlCancel == nil {
+			return
 		}
-	}()
+		controlCancel()
+		controlCancel = nil
+	}
+	defer stopControlListener()
 
 	// Register with the centralized heartbeat loop instead of
 	// running a per-chat goroutine. The loop issues a single batch
@@ -5778,6 +5787,14 @@ func (p *Server) processChat(ctx context.Context, chat database.Chat) {
 		// reliably update the chat status in the database during
 		// graceful shutdown.
 		cleanupCtx := context.WithoutCancel(ctx)
+
+		// Stop the control listener before the cleanup-cycle status
+		// publish so its self-notification cannot drive a wasted
+		// GetChatByID through controlNotifyIsStaleForThisWorker. The
+		// cleanup defer is the last-registered defer in this function,
+		// so LIFO order would otherwise run cleanup while the listener
+		// is still subscribed.
+		stopControlListener()
 
 		// Handle panics gracefully.
 		if r := recover(); r != nil {

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -3481,15 +3481,15 @@ func TestProcessChat_IgnoresStaleControlNotification(t *testing.T) {
 			}, nil
 		},
 	)
-	// Cleanup re-reads the chat row via shouldPublishFinishedChatState
-	// and the cleanup-cycle publishStatus(waiting) drives the new
-	// controlNotifyIsStaleForThisWorker helper through the same mock.
-	// Returning a non-(running+ours) status keeps both reads on the
-	// "not stale" path so the test still exercises the pre-arm gate.
+	// Cleanup re-reads the chat row via shouldPublishFinishedChatState.
+	// The control listener is unsubscribed at the top of the cleanup defer
+	// (see processChat's stopControlListener) so the cleanup-cycle
+	// publishStatus(waiting) does not invoke the new
+	// controlNotifyIsStaleForThisWorker helper.
 	db.EXPECT().GetChatByID(gomock.Any(), chatID).Return(
 		database.Chat{ID: chatID, Status: database.ChatStatusError},
 		nil,
-	).AnyTimes()
+	)
 
 	db.EXPECT().UpdateChatLastTurnSummary(gomock.Any(), gomock.Any()).Return(int64(1), nil)
 
@@ -3659,7 +3659,7 @@ func TestSubscribeChatControl_StalePendingDoesNotInterrupt(t *testing.T) {
 		ID:       chatID,
 		Status:   database.ChatStatusRunning,
 		WorkerID: uuid.NullUUID{UUID: workerID, Valid: true},
-	}, nil).AnyTimes()
+	}, nil).MinTimes(1)
 
 	chatCtx, cancel := context.WithCancelCause(ctx)
 	defer cancel(nil)
@@ -3669,7 +3669,11 @@ func TestSubscribeChatControl_StalePendingDoesNotInterrupt(t *testing.T) {
 	defer unsub()
 
 	// Publish the stale notification SendMessage would emit before
-	// AcquireChats stamped this worker as owner.
+	// AcquireChats stamped this worker as owner. MemoryPubsub.Publish
+	// only returns after every listener callback has run, so the
+	// GetChatByID mock above (.MinTimes(1)) proves the verification
+	// helper executed; a future regression that drops the message
+	// before reaching it would fail mock verification.
 	notify, err := json.Marshal(coderdpubsub.ChatStreamNotifyMessage{
 		Status: string(database.ChatStatusPending),
 	})

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -3481,16 +3481,21 @@ func TestProcessChat_IgnoresStaleControlNotification(t *testing.T) {
 			}, nil
 		},
 	)
+	// Cleanup re-reads the chat row via shouldPublishFinishedChatState
+	// and the cleanup-cycle publishStatus(waiting) drives the new
+	// controlNotifyIsStaleForThisWorker helper through the same mock.
+	// Returning a non-(running+ours) status keeps both reads on the
+	// "not stale" path so the test still exercises the pre-arm gate.
 	db.EXPECT().GetChatByID(gomock.Any(), chatID).Return(
 		database.Chat{ID: chatID, Status: database.ChatStatusError},
 		nil,
-	)
+	).AnyTimes()
 
 	db.EXPECT().UpdateChatLastTurnSummary(gomock.Any(), gomock.Any()).Return(int64(1), nil)
 
-	// resolveChatModel fails immediately — that's fine, we only
-	// need processChat to get past initialization without being
-	// interrupted by the stale notification.
+	// resolveChatModel fails immediately. That is fine; we only need
+	// processChat to get past initialization without being interrupted by
+	// the stale notification.
 	db.EXPECT().GetChatModelConfigByID(gomock.Any(), gomock.Any()).Return(
 		database.ChatModelConfig{}, xerrors.New("no model configured"),
 	).AnyTimes()
@@ -3521,6 +3526,214 @@ func TestProcessChat_IgnoresStaleControlNotification(t *testing.T) {
 	// resolution → status is "error".
 	require.Equal(t, database.ChatStatusError, finalStatus,
 		"processChat should have reached runChat (error), not been interrupted (waiting)")
+}
+
+// TestControlNotifyIsStaleForThisWorker pins the cancel-shaped
+// control-notification filter that prevents a pending/waiting NOTIFY
+// published before AcquireChats stamped this worker as owner from
+// interrupting an in-progress run. The PostgreSQL LISTEN/NOTIFY commit
+// step can deliver such a stale notification after subscribeChatControl
+// arms the listener, so the filter re-reads the chat row and reports
+// the notification as stale only when the chat is still running on
+// this worker. Legitimate cross-replica interrupts (InterruptChat,
+// EditMessage, etc.) write the new chat state before publishing, so
+// the DB read observes a non-(running+ours) state and the cancel
+// proceeds.
+func TestControlNotifyIsStaleForThisWorker(t *testing.T) {
+	t.Parallel()
+
+	workerID := uuid.New()
+	chatID := uuid.New()
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+
+	newServer := func(db database.Store) *Server {
+		return &Server{
+			db:       db,
+			logger:   logger,
+			workerID: workerID,
+		}
+	}
+
+	t.Run("RunningOnThisWorkerIsStale", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitShort)
+		ctrl := gomock.NewController(t)
+		db := dbmock.NewMockStore(ctrl)
+		db.EXPECT().GetChatByID(gomock.Any(), chatID).Return(database.Chat{
+			ID:       chatID,
+			Status:   database.ChatStatusRunning,
+			WorkerID: uuid.NullUUID{UUID: workerID, Valid: true},
+		}, nil)
+		require.True(t, newServer(db).controlNotifyIsStaleForThisWorker(ctx, chatID, logger))
+	})
+
+	t.Run("RunningOnOtherWorkerIsLegitimate", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitShort)
+		ctrl := gomock.NewController(t)
+		db := dbmock.NewMockStore(ctrl)
+		db.EXPECT().GetChatByID(gomock.Any(), chatID).Return(database.Chat{
+			ID:       chatID,
+			Status:   database.ChatStatusRunning,
+			WorkerID: uuid.NullUUID{UUID: uuid.New(), Valid: true},
+		}, nil)
+		require.False(t, newServer(db).controlNotifyIsStaleForThisWorker(ctx, chatID, logger))
+	})
+
+	t.Run("NonRunningStatusIsLegitimate", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitShort)
+		ctrl := gomock.NewController(t)
+		db := dbmock.NewMockStore(ctrl)
+		db.EXPECT().GetChatByID(gomock.Any(), chatID).Return(database.Chat{
+			ID:       chatID,
+			Status:   database.ChatStatusWaiting,
+			WorkerID: uuid.NullUUID{UUID: workerID, Valid: true},
+		}, nil)
+		require.False(t, newServer(db).controlNotifyIsStaleForThisWorker(ctx, chatID, logger))
+	})
+
+	t.Run("NullWorkerIDIsLegitimate", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitShort)
+		ctrl := gomock.NewController(t)
+		db := dbmock.NewMockStore(ctrl)
+		db.EXPECT().GetChatByID(gomock.Any(), chatID).Return(database.Chat{
+			ID:       chatID,
+			Status:   database.ChatStatusRunning,
+			WorkerID: uuid.NullUUID{},
+		}, nil)
+		require.False(t, newServer(db).controlNotifyIsStaleForThisWorker(ctx, chatID, logger))
+	})
+
+	t.Run("DBErrorFailsOpen", func(t *testing.T) {
+		t.Parallel()
+		ctx := testutil.Context(t, testutil.WaitShort)
+		ctrl := gomock.NewController(t)
+		db := dbmock.NewMockStore(ctrl)
+		db.EXPECT().GetChatByID(gomock.Any(), chatID).Return(
+			database.Chat{}, xerrors.New("boom"),
+		)
+		require.False(t, newServer(db).controlNotifyIsStaleForThisWorker(ctx, chatID, logger),
+			"fail-open: a re-read error must not silently drop a legitimate interrupt")
+	})
+
+	t.Run("CanceledContextSkipsDBRead", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		ctrl := gomock.NewController(t)
+		db := dbmock.NewMockStore(ctrl)
+		// No DB call expected: a canceled context means the run already
+		// finished and there is nothing left to cancel.
+		require.False(t, newServer(db).controlNotifyIsStaleForThisWorker(ctx, chatID, logger))
+	})
+}
+
+// TestSubscribeChatControl_StalePendingDoesNotInterrupt drives the
+// listener registered by subscribeChatControl through the same wire
+// path that processChat uses. It asserts that a stale pending
+// notification (the SendMessage / CreateChat shape) delivered after
+// the listener is armed does NOT cancel the chat context when the
+// DB still reports the chat running on this worker.
+func TestSubscribeChatControl_StalePendingDoesNotInterrupt(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+	ps := dbpubsub.NewInMemory()
+
+	chatID := uuid.New()
+	workerID := uuid.New()
+
+	server := &Server{
+		db:       db,
+		logger:   logger,
+		pubsub:   ps,
+		workerID: workerID,
+	}
+
+	db.EXPECT().GetChatByID(gomock.Any(), chatID).Return(database.Chat{
+		ID:       chatID,
+		Status:   database.ChatStatusRunning,
+		WorkerID: uuid.NullUUID{UUID: workerID, Valid: true},
+	}, nil).AnyTimes()
+
+	chatCtx, cancel := context.WithCancelCause(ctx)
+	defer cancel(nil)
+
+	unsub := server.subscribeChatControl(chatCtx, chatID, cancel, logger)
+	require.NotNil(t, unsub)
+	defer unsub()
+
+	// Publish the stale notification SendMessage would emit before
+	// AcquireChats stamped this worker as owner.
+	notify, err := json.Marshal(coderdpubsub.ChatStreamNotifyMessage{
+		Status: string(database.ChatStatusPending),
+	})
+	require.NoError(t, err)
+	require.NoError(t, ps.Publish(coderdpubsub.ChatStreamNotifyChannel(chatID), notify))
+
+	require.NoError(t, chatCtx.Err(),
+		"stale pending notification must not interrupt a chat still running on this worker")
+	require.NoError(t, context.Cause(chatCtx))
+}
+
+// TestSubscribeChatControl_LegitimateWaitingInterrupts is the
+// counterpart to the stale-notification test: when the DB confirms
+// that the chat is no longer running on this worker (an
+// InterruptChat-style transition), the listener must cancel the chat
+// context with ErrInterrupted so runChat returns promptly.
+func TestSubscribeChatControl_LegitimateWaitingInterrupts(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitShort)
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	ctrl := gomock.NewController(t)
+	db := dbmock.NewMockStore(ctrl)
+	ps := dbpubsub.NewInMemory()
+
+	chatID := uuid.New()
+	workerID := uuid.New()
+
+	server := &Server{
+		db:       db,
+		logger:   logger,
+		pubsub:   ps,
+		workerID: workerID,
+	}
+
+	// InterruptChat writes the chat back to Waiting (clearing WorkerID)
+	// before publishing, so the DB read here observes the new state.
+	db.EXPECT().GetChatByID(gomock.Any(), chatID).Return(database.Chat{
+		ID:       chatID,
+		Status:   database.ChatStatusWaiting,
+		WorkerID: uuid.NullUUID{},
+	}, nil).AnyTimes()
+
+	chatCtx, cancel := context.WithCancelCause(ctx)
+	defer cancel(nil)
+
+	unsub := server.subscribeChatControl(chatCtx, chatID, cancel, logger)
+	require.NotNil(t, unsub)
+	defer unsub()
+
+	notify, err := json.Marshal(coderdpubsub.ChatStreamNotifyMessage{
+		Status: string(database.ChatStatusWaiting),
+	})
+	require.NoError(t, err)
+	require.NoError(t, ps.Publish(coderdpubsub.ChatStreamNotifyChannel(chatID), notify))
+
+	// The MemoryPubsub delivers synchronously in a worker goroutine; we
+	// observe the cancel by waiting on chatCtx.Done().
+	select {
+	case <-chatCtx.Done():
+	case <-ctx.Done():
+		t.Fatal("legitimate interrupt did not cancel the chat context")
+	}
+	require.ErrorIs(t, context.Cause(chatCtx), chatloop.ErrInterrupted)
 }
 
 func TestShouldPublishFinishedChatState(t *testing.T) {
@@ -5245,6 +5458,15 @@ func TestAutoPromote_InsertFailureSkipsStatusUpdate(t *testing.T) {
 		database.ChatUsageLimitConfig{}, sql.ErrNoRows,
 	).AnyTimes()
 	db.EXPECT().GetChatMessagesForPromptByChatID(gomock.Any(), chatID).Return(nil, nil).AnyTimes()
+
+	// The chat control listener re-reads the chat row when a cancel-shaped
+	// notification arrives (see controlNotifyIsStaleForThisWorker). Return a
+	// non-(Running+ours) state so the verification confirms the interrupt is
+	// legitimate and the cancel proceeds.
+	db.EXPECT().GetChatByID(gomock.Any(), chatID).Return(
+		database.Chat{ID: chatID, Status: database.ChatStatusWaiting},
+		nil,
+	).AnyTimes()
 
 	// The deferred cleanup transaction: InsertChatMessages fails,
 	// so UpdateChatStatus must NOT be called.

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -3711,11 +3711,14 @@ func TestSubscribeChatControl_LegitimateWaitingInterrupts(t *testing.T) {
 
 	// InterruptChat writes the chat back to Waiting (clearing WorkerID)
 	// before publishing, so the DB read here observes the new state.
+	// MinTimes(1) proves the listener walked through
+	// controlNotifyIsStaleForThisWorker rather than bypassing the
+	// verification helper entirely.
 	db.EXPECT().GetChatByID(gomock.Any(), chatID).Return(database.Chat{
 		ID:       chatID,
 		Status:   database.ChatStatusWaiting,
 		WorkerID: uuid.NullUUID{},
-	}, nil).AnyTimes()
+	}, nil).MinTimes(1)
 
 	chatCtx, cancel := context.WithCancelCause(ctx)
 	defer cancel(nil)

--- a/coderd/x/chatd/integration_responses_test.go
+++ b/coderd/x/chatd/integration_responses_test.go
@@ -390,14 +390,7 @@ func newOpenAIResponsesTestServer(
 	ps dbpubsub.Pubsub,
 ) *chatd.Server {
 	t.Helper()
-	return newActiveTestServer(t, db, ps, func(cfg *chatd.Config) {
-		// Let CreateChat and SendMessage publish their pending status
-		// before wake-driven processing starts. The responses tests are
-		// not exercising periodic polling, and PostgreSQL can otherwise
-		// deliver that stale pending notification after processChat
-		// subscribes to control events.
-		cfg.PendingChatAcquireInterval = testutil.WaitLong
-	})
+	return newActiveTestServer(t, db, ps)
 }
 
 func insertOpenAIResponsesModelConfig(


### PR DESCRIPTION
## Summary

Treat a cancel-shaped chat control NOTIFY as authoritative only after re-reading the chat row. This eliminates a PostgreSQL LISTEN/NOTIFY race that was canceling in-flight chat runs with `ErrInterrupted`, producing the recurring `recorder.all()` shortfalls in the OpenAI responses integration tests.

## Problem

`SendMessage` (and other entry points) update the chat to `pending` and emit a NOTIFY on `chat:stream:<chatID>` before `signalWake` triggers `AcquireChats` to claim the chat for this worker. `processChat` then calls `subscribeChatControl`, which registers a PG `LISTEN` on the same channel.

PostgreSQL's `LISTEN/NOTIFY` has a documented commit-step race: a notification committed just before a listener registers can still be delivered to that listener. In chatd, this means the `pending` NOTIFY from step 1 can land at the control listener after step 2 has already stamped this worker as the chat owner. `shouldCancelChatFromControlNotification` returned true for `pending` regardless of `worker_id`, so the listener canceled `chatCtx` with `ErrInterrupted`. The first OpenAI streaming request was abandoned mid-flight and the test recorder saw one fewer call than expected.

A workerID-only filter is insufficient: legitimate cross-replica interrupts (`InterruptChat`, `EditMessage`, `ArchiveChat`, `SubmitToolResults`, `PromoteQueued`) all publish `pending`/`waiting` with an empty `WorkerID` and share the wire shape of the stale notification.

## Fix

Add `controlNotifyIsStaleForThisWorker`. When a cancel-shaped notification arrives, the listener re-reads the chat row via `GetChatByID`. The notification is treated as stale (ignored) only when the row says `status=Running` and `worker_id=ours`. Every legitimate cross-replica interrupt updates the chat row before publishing, so the re-read observes the new state and the cancel proceeds.

- DB errors fail open (helper returns `false`) so legitimate interrupts are never silently dropped.
- The DB lookup runs on the listener's per-subscription pubsub goroutine, so it does not block other subscribers.
- The cleanup-cycle `publishStatus(waiting)` self-NOTIFY still arrives at the listener, but by then `processChat` is already past `runChat` and the additional `GetChatByID` is observed as a non-(running+ours) row, so no spurious cancel fires.

The now-redundant `PendingChatAcquireInterval: testutil.WaitLong` workaround in `newOpenAIResponsesTestServer` is removed so the responses tests exercise the real fix.

### Validation

- Targeted suites: `TestControlNotifyIsStaleForThisWorker`, `TestSubscribeChatControl_StalePendingDoesNotInterrupt`, `TestSubscribeChatControl_LegitimateWaitingInterrupts` exercise the helper and listener wiring directly.
- `TestOpenAIResponses*` race suite (the four originally-flaky tests) green at `-count=200` locally with PostgreSQL.
- Full `coderd/x/chatd` race suite green.
- `make pre-commit` (lint + build) passes.

Resolves CODAGT-361.

<details>
<summary>Implementation plan</summary>

```markdown
# Plan — CODAGT-361 Fix `chatd` Control NOTIFY Stale-Cancel Flake

## Failing tests
- `TestOpenAIResponsesNoStaleWebSearchReplay`
- `TestOpenAIResponsesFullReplayPairsReasoningAndWebSearch`
- `TestOpenAIResponsesChainModeSkipsWhenLocalCallPending`
- `TestOpenAIResponsesChainModeStillFiresForProviderExecutedOnly`

Failure mode (from CI logs): `recorder.all()` short by one request; `processor: chat interrupted` and `chatdebug: ... error="context canceled"` lines present.

## Root cause

PostgreSQL LISTEN/NOTIFY has a documented commit-step race: a `LISTEN` may receive a notification that was published before the `LISTEN` SQL ran, if the publishing transaction is still in its commit step when `LISTEN` registers.

In `chatd`:

1. `SendMessage` (and `CreateChat`-followups, `EditMessage`, etc.) update the chat to `pending` and call `publishStatus(chat.ID, pending, empty)` which fans out a NOTIFY on `chat:stream:<chatID>`.
2. The same call ends with `signalWake()`, which wakes `acquireLoop`.
3. `AcquireChats` transitions `pending → running` with this worker's ID.
4. `processChat` spawns and calls `subscribeChatControl` → `pubsub.SubscribeWithErr` → `pgListener.Listen("chat:stream:<chatID>")`.
5. `processChat` then calls `publishStatus(running, ourWorkerID)` and `close(controlArmed)`.
6. Due to the PG race, the stale `pending` NOTIFY from step 1 can be dispatched to our listener AFTER step 5's `close(controlArmed)`.
7. `shouldCancelChatFromControlNotification` returns `true` for `pending` regardless of workerID → `gatedCancel(ErrInterrupted)` cancels our `chatCtx`, `runChat` returns `ErrInterrupted`, the OpenAI request is not recorded.

The existing `controlArmed` gate only guards against arrivals BEFORE arming; the PG race delivers AFTER arming.

## Why a workerID filter alone won't work

Legitimate cross-replica interrupts (`InterruptChat`, `EditMessage`, `SubmitToolResults`, `PromoteQueued` deferred path) all publish `pending`/`waiting` with an EMPTY workerID. They share the wire shape with the stale `SendMessage` notification.

## Fix

In the chat control listener, when a notification would cancel processing, verify the DB row first. If the chat is still `running` with this worker's ID, the notification is stale; ignore it.

This works because:
- Stale `pending` NOTIFY from `SendMessage`: by the time it arrives, `AcquireChats` has already set `status=running, worker_id=us`. DB read says `running/us` → ignore.
- Legitimate cross-replica interrupt (`EditMessage` etc.): the DB is updated BEFORE the NOTIFY, so the listener's DB read sees `pending/empty` (or some other non-`running/us` state) → cancel honored.

The `running` branch is unaffected; it already only cancels for a different `workerID`.

## Audit of cancel-shaped `publishStatus` call sites

| Caller                                | Status   | WorkerID  | Outcome under new filter                                |
|---------------------------------------|----------|-----------|---------------------------------------------------------|
| `SendMessage` post-tx (stale)         | pending  | empty     | DB shows `running/us` → ignore (the root-cause path)    |
| `EditMessage` post-tx                 | pending  | empty     | DB shows new state → cancel                             |
| `ArchiveChat` interrupted loop        | waiting  | empty     | DB shows new state → cancel                             |
| `PromoteQueued` deferred              | waiting  | empty     | DB shows new state → cancel                             |
| `setChatWaiting` (used by `Interrupt`)| waiting  | empty     | DB shows new state → cancel                             |
| `processChat` running self-publish    | running  | us        | Filtered earlier by `shouldCancelChatFromControlNotification` running branch |
| `processChat` cleanup self-publish    | terminal | empty     | Listener still re-reads chat; row no longer `running/us` → cancel is a no-op against an already-finished `chatCtx` |
```

</details>

---

This PR was opened by a Coder Agent on behalf of the user. The implementation plan is captured above so reviewers can cross-check the change.
