### PR TITLE
fix: tag chatd wake-only status notifications to stop stale interrupts

### DIFF
--- a/coderd/pubsub/chatstreamnotify.go
+++ b/coderd/pubsub/chatstreamnotify.go
@@ -53,4 +53,16 @@ type ChatStreamNotifyMessage struct {
 	// messages from the beginning (e.g. after an edit that
 	// truncates message history).
 	FullRefresh bool `json:"full_refresh,omitempty"`
+
+	// WakeOnly marks a status notification as a lifecycle wake
+	// (e.g. SendMessage transitioning a waiting chat to pending so
+	// the processor acquires it) rather than a request to interrupt
+	// any in-flight processing. Control subscribers must not cancel
+	// ongoing work when WakeOnly is true even if Status would
+	// otherwise be a cancel-trigger (pending, waiting, error).
+	//
+	// Defaulting to false preserves the historical interrupt-on-
+	// cancelable-status behavior for rolling deploys where older
+	// replicas publish without this field set.
+	WakeOnly bool `json:"wake_only,omitempty"`
 }

--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -1913,7 +1913,9 @@ func (p *Server) EditMessage(
 	p.publishChatStreamNotify(opts.ChatID, coderdpubsub.ChatStreamNotifyMessage{
 		QueueUpdate: true,
 	})
-	p.publishStatus(opts.ChatID, result.Chat.Status, result.Chat.WorkerID)
+	// EditMessage forces the chat to pending, which must interrupt any
+	// active worker so the edited turn replaces the in-flight run.
+	p.publishStatusInterrupt(opts.ChatID, result.Chat.Status, result.Chat.WorkerID)
 	p.publishChatPubsubEvent(result.Chat, codersdk.ChatWatchEventKindStatusChange, nil)
 
 	// Editing can race with an interrupted worker still flushing its
@@ -1993,7 +1995,9 @@ func (p *Server) ArchiveChat(ctx context.Context, chat database.Chat) error {
 	}
 
 	for _, interruptedChat := range interruptedChats {
-		p.publishStatus(interruptedChat.ID, interruptedChat.Status, interruptedChat.WorkerID)
+		// Archiving transitions in-flight chats to waiting so the
+		// active worker must abandon its run.
+		p.publishStatusInterrupt(interruptedChat.ID, interruptedChat.Status, interruptedChat.WorkerID)
 		p.publishChatPubsubEvent(interruptedChat, codersdk.ChatWatchEventKindStatusChange, nil)
 	}
 
@@ -2330,7 +2334,10 @@ func (p *Server) PromoteQueued(
 		p.publishChatStreamNotify(opts.ChatID, coderdpubsub.ChatStreamNotifyMessage{
 			QueueUpdate: true,
 		})
-		p.publishStatus(opts.ChatID, updatedChat.Status, updatedChat.WorkerID)
+		// Deferred promote relies on the active worker observing the
+		// waiting status and aborting its run so its persist+auto-
+		// promote cleanup picks up the reordered queued message.
+		p.publishStatusInterrupt(opts.ChatID, updatedChat.Status, updatedChat.WorkerID)
 		p.publishChatPubsubEvent(updatedChat, codersdk.ChatWatchEventKindStatusChange, nil)
 		return result, nil
 	}
@@ -3593,7 +3600,11 @@ func (p *Server) setChatWaiting(ctx context.Context, chatID uuid.UUID) (database
 	if err != nil {
 		return database.Chat{}, err
 	}
-	p.publishStatus(chatID, updatedChat.Status, updatedChat.WorkerID)
+	// setChatWaiting is called by interrupt-intent code paths
+	// (SendMessage busy/interrupt, InterruptChat, post-archive
+	// cleanup). Publish with interrupt semantics so a running
+	// worker observes the cancel.
+	p.publishStatusInterrupt(chatID, updatedChat.Status, updatedChat.WorkerID)
 	p.publishChatPubsubEvent(updatedChat, codersdk.ChatWatchEventKindStatusChange, nil)
 	return updatedChat, nil
 }
@@ -4998,13 +5009,33 @@ func (p *Server) publishEvent(chatID uuid.UUID, event codersdk.ChatStreamEvent) 
 	p.publishToStream(chatID, event)
 }
 
+// publishStatus publishes a status update intended only to wake
+// subscribers and the run loop. Use publishStatusInterrupt when the
+// publish must also cancel in-flight processing for the chat (e.g.
+// EditMessage, setChatWaiting, archive, deferred PromoteQueued).
 func (p *Server) publishStatus(chatID uuid.UUID, status database.ChatStatus, workerID uuid.NullUUID) {
+	p.publishStatusNotify(chatID, status, workerID, true)
+}
+
+// publishStatusInterrupt publishes a status update that any control
+// subscriber for this chat must treat as an interrupt request.
+func (p *Server) publishStatusInterrupt(chatID uuid.UUID, status database.ChatStatus, workerID uuid.NullUUID) {
+	p.publishStatusNotify(chatID, status, workerID, false)
+}
+
+func (p *Server) publishStatusNotify(
+	chatID uuid.UUID,
+	status database.ChatStatus,
+	workerID uuid.NullUUID,
+	wakeOnly bool,
+) {
 	p.publishEvent(chatID, codersdk.ChatStreamEvent{
 		Type:   codersdk.ChatStreamEventTypeStatus,
 		Status: &codersdk.ChatStreamStatus{Status: codersdk.ChatStatus(status)},
 	})
 	notify := coderdpubsub.ChatStreamNotifyMessage{
-		Status: string(status),
+		Status:   string(status),
+		WakeOnly: wakeOnly,
 	}
 	if workerID.Valid {
 		notify.WorkerID = workerID.UUID.String()
@@ -5266,6 +5297,23 @@ func (p *Server) publishMessagePart(chatID uuid.UUID, role codersdk.ChatMessageR
 	})
 }
 
+// shouldCancelChatFromControlNotification decides whether the control
+// subscriber for a chat should cancel its in-flight processing in
+// response to the given notification.
+//
+// Cancelable statuses (waiting, pending, error) reflect a transition
+// that the chat is no longer being run by the local worker. Historically
+// any such status canceled the local worker, but SendMessage and
+// PromoteQueued legitimately publish pending or waiting notifications
+// only to wake the run loop. Async PostgreSQL NOTIFY delivery can cause
+// those wake-intent notifications to arrive at the new control
+// subscriber after it has armed, spuriously interrupting the chat. We
+// avoid this by ignoring notifications explicitly tagged as WakeOnly.
+//
+// Notifications without WakeOnly continue to cancel so that genuine
+// interrupters (EditMessage, setChatWaiting, archive, deferred
+// PromoteQueued) and notifications from older replicas during a rolling
+// deploy retain the legacy interrupt behavior.
 func shouldCancelChatFromControlNotification(
 	notify coderdpubsub.ChatStreamNotifyMessage,
 	workerID uuid.UUID,
@@ -5273,7 +5321,7 @@ func shouldCancelChatFromControlNotification(
 	status := database.ChatStatus(strings.TrimSpace(notify.Status))
 	switch status {
 	case database.ChatStatusWaiting, database.ChatStatusPending, database.ChatStatusError:
-		return true
+		return !notify.WakeOnly
 	case database.ChatStatusRunning:
 		worker := strings.TrimSpace(notify.WorkerID)
 		if worker == "" {

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -3416,6 +3416,153 @@ func TestSelectSkillMetasForInstructionRefresh(t *testing.T) {
 	})
 }
 
+// TestShouldCancelChatFromControlNotification pins the cancel-vs-wake
+// decision for control-channel status notifications. The WakeOnly tag
+// suppresses interrupts for status changes that only exist to wake the
+// run loop (SendMessage/PromoteQueued sync path/processChat lifecycle)
+// while legacy notifications without the tag continue to cancel, which
+// preserves correctness during rolling deploys from older replicas.
+func TestShouldCancelChatFromControlNotification(t *testing.T) {
+	t.Parallel()
+
+	selfID := uuid.New()
+	otherID := uuid.New()
+	require.NotEqual(t, selfID, otherID)
+
+	testCases := []struct {
+		name   string
+		notify coderdpubsub.ChatStreamNotifyMessage
+		expect bool
+		reason string
+	}{
+		{
+			name:   "PendingWakeOnly",
+			notify: coderdpubsub.ChatStreamNotifyMessage{Status: string(database.ChatStatusPending), WakeOnly: true},
+			expect: false,
+			reason: "SendMessage and sync PromoteQueued publish pending only to wake the run loop",
+		},
+		{
+			name:   "PendingInterrupt",
+			notify: coderdpubsub.ChatStreamNotifyMessage{Status: string(database.ChatStatusPending), WakeOnly: false},
+			expect: true,
+			reason: "EditMessage transitions the chat to pending and must interrupt the active worker",
+		},
+		{
+			name:   "PendingLegacyNoWakeOnly",
+			notify: coderdpubsub.ChatStreamNotifyMessage{Status: string(database.ChatStatusPending)},
+			expect: true,
+			reason: "older replicas during a rolling deploy must retain the legacy interrupt behavior",
+		},
+		{
+			name:   "WaitingWakeOnly",
+			notify: coderdpubsub.ChatStreamNotifyMessage{Status: string(database.ChatStatusWaiting), WakeOnly: true},
+			expect: false,
+			reason: "processChat cleanup transitions to waiting only to wake watchers",
+		},
+		{
+			name:   "WaitingInterrupt",
+			notify: coderdpubsub.ChatStreamNotifyMessage{Status: string(database.ChatStatusWaiting), WakeOnly: false},
+			expect: true,
+			reason: "setChatWaiting publishes from interrupt-intent code paths (SendMessage busy, InterruptChat, archive cleanup)",
+		},
+		{
+			name:   "WaitingLegacyNoWakeOnly",
+			notify: coderdpubsub.ChatStreamNotifyMessage{Status: string(database.ChatStatusWaiting)},
+			expect: true,
+			reason: "legacy waiting publish from older replicas must cancel",
+		},
+		{
+			name:   "ErrorWakeOnly",
+			notify: coderdpubsub.ChatStreamNotifyMessage{Status: string(database.ChatStatusError), WakeOnly: true},
+			expect: false,
+			reason: "processChat publishes terminal error only to wake watchers",
+		},
+		{
+			name:   "ErrorLegacyNoWakeOnly",
+			notify: coderdpubsub.ChatStreamNotifyMessage{Status: string(database.ChatStatusError)},
+			expect: true,
+			reason: "legacy error publish from older replicas must cancel",
+		},
+		{
+			name:   "RunningSameWorker",
+			notify: coderdpubsub.ChatStreamNotifyMessage{Status: string(database.ChatStatusRunning), WorkerID: selfID.String()},
+			expect: false,
+			reason: "the local worker is the one running the chat; do not cancel ourselves",
+		},
+		{
+			name:   "RunningOtherWorker",
+			notify: coderdpubsub.ChatStreamNotifyMessage{Status: string(database.ChatStatusRunning), WorkerID: otherID.String()},
+			expect: true,
+			reason: "another replica claimed the chat; the local run must abort",
+		},
+		{
+			name:   "RunningEmptyWorker",
+			notify: coderdpubsub.ChatStreamNotifyMessage{Status: string(database.ChatStatusRunning)},
+			expect: false,
+			reason: "a running notification without a worker is ambiguous; prefer not to self-cancel",
+		},
+		{
+			name:   "RunningUnparseableWorker",
+			notify: coderdpubsub.ChatStreamNotifyMessage{Status: string(database.ChatStatusRunning), WorkerID: "not-a-uuid"},
+			expect: false,
+			reason: "malformed worker IDs must not be allowed to interrupt the local run",
+		},
+		{
+			name:   "RunningWakeOnlyIgnored",
+			notify: coderdpubsub.ChatStreamNotifyMessage{Status: string(database.ChatStatusRunning), WorkerID: otherID.String(), WakeOnly: true},
+			expect: true,
+			reason: "WakeOnly does not suppress cancellation for running status; foreign worker IDs always cancel",
+		},
+		{
+			name:   "UnknownStatus",
+			notify: coderdpubsub.ChatStreamNotifyMessage{Status: "queued"},
+			expect: false,
+			reason: "unknown statuses must never interrupt the run loop",
+		},
+		{
+			name:   "EmptyStatus",
+			notify: coderdpubsub.ChatStreamNotifyMessage{},
+			expect: false,
+			reason: "an empty status carries no signal; do not interrupt",
+		},
+		{
+			name:   "WhitespacePaddedPending",
+			notify: coderdpubsub.ChatStreamNotifyMessage{Status: "  pending  "},
+			expect: true,
+			reason: "whitespace-padded statuses are still recognized; legacy interrupt semantics apply",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := shouldCancelChatFromControlNotification(tc.notify, selfID)
+			require.Equal(t, tc.expect, got, tc.reason)
+		})
+	}
+}
+
+// TestShouldCancelChatFromControlNotification_LegacyJSONNoWakeOnly
+// exercises the wire-level rolling-deploy compatibility: an older
+// replica that does not know about the wake_only field publishes a JSON
+// document without it, and the decoded notify must still trigger a
+// cancel.
+func TestShouldCancelChatFromControlNotification_LegacyJSONNoWakeOnly(t *testing.T) {
+	t.Parallel()
+
+	selfID := uuid.New()
+
+	// Hand-crafted to mirror the on-the-wire payload produced by a
+	// pre-fix replica. The decoded WakeOnly field stays false, so the
+	// notification cancels just like before the fix.
+	payload := []byte(`{"status":"pending"}`)
+	var notify coderdpubsub.ChatStreamNotifyMessage
+	require.NoError(t, json.Unmarshal(payload, &notify))
+	require.False(t, notify.WakeOnly, "legacy payload must decode WakeOnly to false")
+
+	require.True(t, shouldCancelChatFromControlNotification(notify, selfID))
+}
+
 // TestProcessChat_IgnoresStaleControlNotification verifies that
 // processChat is not interrupted by a "pending" notification
 // published before processing begins. This is the race that caused

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -3448,6 +3448,13 @@ func TestShouldCancelChatFromControlNotification(t *testing.T) {
 			reason: "EditMessage transitions the chat to pending and must interrupt the active worker",
 		},
 		{
+			// Same code path as PendingInterrupt; the row exists
+			// to document that an explicit zero value
+			// (WakeOnly omitted) preserves legacy interrupt
+			// semantics, which is the contract relied on by
+			// older replicas during a rolling deploy.
+			// TestShouldCancelChatFromControlNotification_LegacyJSONNoWakeOnly
+			// exercises the wire-format side of that contract.
 			name:   "PendingLegacyNoWakeOnly",
 			notify: coderdpubsub.ChatStreamNotifyMessage{Status: string(database.ChatStatusPending)},
 			expect: true,
@@ -3466,6 +3473,8 @@ func TestShouldCancelChatFromControlNotification(t *testing.T) {
 			reason: "setChatWaiting publishes from interrupt-intent code paths (SendMessage busy, InterruptChat, archive cleanup)",
 		},
 		{
+			// Same code path as WaitingInterrupt; documents the
+			// rolling-deploy zero-value contract.
 			name:   "WaitingLegacyNoWakeOnly",
 			notify: coderdpubsub.ChatStreamNotifyMessage{Status: string(database.ChatStatusWaiting)},
 			expect: true,
@@ -3478,6 +3487,9 @@ func TestShouldCancelChatFromControlNotification(t *testing.T) {
 			reason: "processChat publishes terminal error only to wake watchers",
 		},
 		{
+			// Same code path as an Error-with-WakeOnly-false
+			// case; documents the rolling-deploy zero-value
+			// contract.
 			name:   "ErrorLegacyNoWakeOnly",
 			notify: coderdpubsub.ChatStreamNotifyMessage{Status: string(database.ChatStatusError)},
 			expect: true,
@@ -3563,6 +3575,124 @@ func TestShouldCancelChatFromControlNotification_LegacyJSONNoWakeOnly(t *testing
 	require.True(t, shouldCancelChatFromControlNotification(notify, selfID))
 }
 
+// TestSubscribeChatControl_WakeOnlySuppression deterministically
+// exercises the post-arm race: it subscribes via subscribeChatControl,
+// publishes a sequence of notifications on the control channel after
+// the subscriber registers, and verifies cancel is only invoked for
+// notifications whose decision the WakeOnly fix expects to cancel.
+//
+// This is the production race that produced CODAGT-356: in
+// processChat, close(controlArmed) opens the gate after publishing
+// running; PG NOTIFY can dispatch a SendMessage "pending"
+// notification after that point. The gate alone cannot suppress it
+// because the dispatch happens after the gate opens. The WakeOnly tag
+// is what suppresses the cancel.
+func TestSubscribeChatControl_WakeOnlySuppression(t *testing.T) {
+	t.Parallel()
+
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	ps := dbpubsub.NewInMemory()
+
+	selfID := uuid.New()
+	otherID := uuid.New()
+
+	server := &Server{
+		logger:   logger,
+		pubsub:   ps,
+		workerID: selfID,
+	}
+
+	type testCase struct {
+		name       string
+		notify     coderdpubsub.ChatStreamNotifyMessage
+		wantCancel bool
+	}
+	testCases := []testCase{
+		{
+			name:       "PendingWakeOnly",
+			notify:     coderdpubsub.ChatStreamNotifyMessage{Status: string(database.ChatStatusPending), WakeOnly: true},
+			wantCancel: false,
+		},
+		{
+			name:       "WaitingWakeOnly",
+			notify:     coderdpubsub.ChatStreamNotifyMessage{Status: string(database.ChatStatusWaiting), WakeOnly: true},
+			wantCancel: false,
+		},
+		{
+			name:       "ErrorWakeOnly",
+			notify:     coderdpubsub.ChatStreamNotifyMessage{Status: string(database.ChatStatusError), WakeOnly: true},
+			wantCancel: false,
+		},
+		{
+			name:       "RunningSelfWorker",
+			notify:     coderdpubsub.ChatStreamNotifyMessage{Status: string(database.ChatStatusRunning), WorkerID: selfID.String(), WakeOnly: true},
+			wantCancel: false,
+		},
+		{
+			name:       "PendingInterrupt",
+			notify:     coderdpubsub.ChatStreamNotifyMessage{Status: string(database.ChatStatusPending)},
+			wantCancel: true,
+		},
+		{
+			name:       "WaitingInterrupt",
+			notify:     coderdpubsub.ChatStreamNotifyMessage{Status: string(database.ChatStatusWaiting)},
+			wantCancel: true,
+		},
+		{
+			name:       "RunningForeignWorker",
+			notify:     coderdpubsub.ChatStreamNotifyMessage{Status: string(database.ChatStatusRunning), WorkerID: otherID.String()},
+			wantCancel: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Each subtest needs its own chatID so concurrent
+			// subscribers do not observe each other's
+			// notifications when running in parallel.
+			chatID := uuid.New()
+
+			cancelCalled := make(chan struct{}, 1)
+			cancel := func(error) {
+				select {
+				case cancelCalled <- struct{}{}:
+				default:
+				}
+			}
+
+			ctx := testutil.Context(t, testutil.WaitShort)
+			unsub := server.subscribeChatControl(ctx, chatID, cancel, logger)
+			require.NotNil(t, unsub, "subscribeChatControl returned nil; test cannot proceed")
+			defer unsub()
+
+			payload, err := json.Marshal(tc.notify)
+			require.NoError(t, err)
+
+			// MemoryPubsub.Publish dispatches to each listener
+			// from a goroutine and then waits for all of them to
+			// return, so the subscriber has observed the message
+			// by the time Publish returns.
+			require.NoError(t, ps.Publish(coderdpubsub.ChatStreamNotifyChannel(chatID), payload))
+
+			if tc.wantCancel {
+				select {
+				case <-cancelCalled:
+				case <-ctx.Done():
+					t.Fatalf("expected cancel to be called for %s", tc.name)
+				}
+				return
+			}
+			select {
+			case <-cancelCalled:
+				t.Fatalf("expected cancel NOT to be called for %s", tc.name)
+			default:
+			}
+		})
+	}
+}
+
 // TestProcessChat_IgnoresStaleControlNotification verifies that
 // processChat is not interrupted by a "pending" notification
 // published before processing begins. This is the race that caused
@@ -3571,6 +3701,12 @@ func TestShouldCancelChatFromControlNotification_LegacyJSONNoWakeOnly(t *testing
 // to async delivery the notification can arrive at the control
 // subscriber after it registers but before the processor publishes
 // "running".
+//
+// Caveat: MemoryPubsub.Publish drops messages with no current
+// subscribers, so the stale notification published below never reaches
+// processChat. The test therefore exercises the cleanup path under
+// no-interrupt conditions; the post-arm race itself is exercised
+// deterministically by TestSubscribeChatControl_WakeOnlySuppression.
 func TestProcessChat_IgnoresStaleControlNotification(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
`processChat` could be interrupted by its own `SendMessage` `pending` notification when PostgreSQL `NOTIFY` dispatched the message after the control subscriber armed. The earlier `controlArmed` gate (#23865) only protected against notifications dispatched before `close(controlArmed)`. Notifications enqueued before the close and delivered after still passed through and triggered `cancel(chatloop.ErrInterrupted)`, producing the `chat interrupted` flakes tracked in the linked issues.

Add a `WakeOnly bool` field to `ChatStreamNotifyMessage` and split `publishStatus` into a wake-only default plus a `publishStatusInterrupt` variant. Callers whose intent is to interrupt an in-flight worker (`EditMessage`, `ArchiveChat`, deferred `PromoteQueued`, `setChatWaiting`) use `publishStatusInterrupt`; everything else (`SendMessage`, sync `PromoteQueued`, `RefreshStatus`, and the `processChat` start and finish lifecycle publishes) wakes the run loop without canceling the active worker. `shouldCancelChatFromControlNotification` returns `!notify.WakeOnly` for cancelable statuses (`waiting`, `pending`, `error`). The field defaults to `false` so notifications from older replicas during a rolling deploy retain the legacy interrupt-on-pending behavior.

Fixes [CODAGT-356](https://linear.app/coder/issue/CODAGT-356).
Closes coder/internal#1501.
Closes coder/internal#1504.
Closes coder/internal#1508.

<details>
<summary>Implementation plan and decision log</summary>

## Root cause

Race in `coderd/x/chatd/chatd.go` between `SendMessage` and `processChat`:

1. `SendMessage` publishes `pending` on the chat's control channel via PG NOTIFY (`publishStatus` -> `publishChatStreamNotify`).
2. `signalWake` -> `processOnce` -> `processChat` runs.
3. `processChat` creates the `controlArmed` gate, subscribes to the control channel with `gatedCancel`, then publishes `running` and closes the gate.
4. The PG NOTIFY dispatcher (`coderd/database/pubsub/pubsub.go` `msgQueue.run()`) can deliver the stale `pending` notification AFTER `close(controlArmed)`, opening the gate; `shouldCancelChatFromControlNotification` returned `true` for `pending`, triggering `cancel(chatloop.ErrInterrupted)` and turning the in-flight run into a `chat interrupted` error.

#23865 added the `controlArmed` gate, but only protected against deliveries that happen before the close, not against notifications enqueued before the close and dispatched after.

## Fix design

Tag wake-only status notifications so subscribers know they should not be treated as interrupt requests.

```go
// coderd/pubsub/chatstreamnotify.go
type ChatStreamNotifyMessage struct {
    // ... existing fields
    WakeOnly bool `json:"wake_only,omitempty"`
}
```

`shouldCancelChatFromControlNotification` now returns `!notify.WakeOnly` for `waiting`, `pending`, and `error`. Default-false preserves the existing semantics for older replicas during a rolling deploy.

### Call-site classification

| Site | Function | Intent | Helper |
| --- | --- | --- | --- |
| `chatd.go:1682` | `SendMessage` (non-busy path) | wake | `publishStatus` (`WakeOnly=true`) |
| `chatd.go:1918` | `EditMessage` | interrupt | `publishStatusInterrupt` |
| `chatd.go:1995` | `ArchiveChat` (per interrupted chat) | interrupt | `publishStatusInterrupt` |
| `chatd.go:2340` | `PromoteQueued` deferred path | interrupt | `publishStatusInterrupt` |
| `chatd.go:2358` | `PromoteQueued` sync path | wake | `publishStatus` |
| `chatd.go:3570` | `RefreshStatus` | wake | `publishStatus` |
| `chatd.go:3604` | `setChatWaiting` | interrupt | `publishStatusInterrupt` |
| `chatd.go:5746` | `processChat` start (`running`) | wake | `publishStatus` |
| `chatd.go:5832` | `processChat` finish (terminal) | wake | `publishStatus` |

## Test plan

- `GOWORK=off go vet ./coderd/x/chatd/... ./coderd/pubsub/...`
- `GOWORK=off go build ./...`
- `GOWORK=off go test -count=1 -run 'TestShouldCancelChatFromControlNotification|TestProcessChat_IgnoresStaleControlNotification' ./coderd/x/chatd/`
- `GOWORK=off go test -count=10 -race -run 'TestOpenAIResponsesFullReplayPairsReasoningAndWebSearch|TestOpenAIResponsesNoStaleWebSearchReplay|TestOpenAIResponsesChainModeStillFiresForProviderExecutedOnly|TestProcessChat_IgnoresStaleControlNotification|TestShouldCancelChatFromControlNotification' ./coderd/x/chatd/`
- `GOWORK=off go test -count=1 ./coderd/x/chatd/`
- `make pre-commit` (gen, fmt, lint, build)

## Rolling-deploy compatibility

Older replicas serialize `ChatStreamNotifyMessage` without `wake_only`. After upgrade, newer replicas decode that payload with `WakeOnly == false`, which preserves the legacy interrupt-on-pending behavior. `TestShouldCancelChatFromControlNotification_LegacyJSONNoWakeOnly` pins this.

</details>

This pull request was generated by a Coder Agent.
