### PR TITLE
test(coderd/x/chatd): guard passive server against signalWake races

### DIFF
--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -5666,6 +5666,17 @@ func waitForChatProcessed(
 
 // newTestServer creates a passive server that never calls
 // processOnce on its own.
+//
+// Historical note: prior to dd49a818f ("fix: export chatd.Start to
+// separate server lifecycle") chatd.New() unconditionally started
+// the acquire/wake loop. That caused signalWake from CreateChat,
+// SendMessage, EditMessage and PromoteQueued to race with test
+// assertions about chat status. Tests that need the chat to stay in
+// pending or waiting (e.g. TestPromoteQueuedMessage* and the cases
+// tracked in coder/internal#1428) rely on the post-fix invariant
+// that a server without Start() called never acquires chats. See
+// TestPassiveServerDoesNotProcessAfterPromoteQueued and friends for
+// the regression guard.
 func newTestServer(
 	t *testing.T,
 	db database.Store,
@@ -5711,6 +5722,106 @@ func TestPassiveServerDoesNotProcess(t *testing.T) {
 	stored, err := db.GetChatByID(ctx, chat.ID)
 	require.NoError(t, err)
 	require.Equal(t, database.ChatStatusPending, stored.Status)
+}
+
+// TestPassiveServerDoesNotProcessAfterPromoteQueued guards against the
+// flakes tracked in coder/internal#1428 (Linear CODAGT-81): a passive
+// chatd server must not transition a pending chat to running after
+// PromoteQueued, even though PromoteQueued calls signalWake. Without
+// the New/Start split landed in dd49a818f the wake channel had a
+// reader (the auto-started acquireLoop) and the chat would race to
+// running before tests like
+// TestPromoteQueuedMessageReloadsChatWhenModelConfigChangesDuringPending
+// could assert pending.
+func TestPassiveServerDoesNotProcessAfterPromoteQueued(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	db, ps := dbtestutil.NewDB(t, dbtestutil.WithDumpOnFailure())
+	user, org, model := seedChatDependencies(t, db)
+
+	server := newTestServer(t, db, ps, uuid.New())
+
+	chat := dbgen.Chat(t, db, database.Chat{
+		OrganizationID:    org.ID,
+		Status:            database.ChatStatusPending,
+		OwnerID:           user.ID,
+		LastModelConfigID: model.ID,
+		Title:             "should-stay-pending-after-promote",
+	})
+
+	queuedContent, err := json.Marshal([]codersdk.ChatMessagePart{
+		codersdk.ChatMessageText("queued message"),
+	})
+	require.NoError(t, err)
+	queuedMessage, err := db.InsertChatQueuedMessage(ctx, database.InsertChatQueuedMessageParams{
+		ChatID:  chat.ID,
+		Content: queuedContent,
+		ModelConfigID: uuid.NullUUID{
+			UUID:  model.ID,
+			Valid: true,
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = server.PromoteQueued(ctx, chatd.PromoteQueuedOptions{
+		ChatID:          chat.ID,
+		QueuedMessageID: queuedMessage.ID,
+		CreatedBy:       user.ID,
+	})
+	require.NoError(t, err)
+
+	chatd.WaitUntilIdleForTest(server)
+
+	stored, err := db.GetChatByID(ctx, chat.ID)
+	require.NoError(t, err)
+	require.Equal(t, database.ChatStatusPending, stored.Status,
+		"passive server must not acquire a chat after PromoteQueued signalWake; see coder/internal#1428")
+}
+
+// TestPassiveServerDoesNotProcessAfterSendMessage guards the same
+// New/Start invariant for SendMessage's signalWake path. See
+// TestPassiveServerDoesNotProcessAfterPromoteQueued for the
+// historical context.
+func TestPassiveServerDoesNotProcessAfterSendMessage(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	db, ps := dbtestutil.NewDB(t, dbtestutil.WithDumpOnFailure())
+	user, org, model := seedChatDependencies(t, db)
+
+	server := newTestServer(t, db, ps, uuid.New())
+
+	chat, err := server.CreateChat(ctx, chatd.CreateOptions{
+		OrganizationID:     org.ID,
+		OwnerID:            user.ID,
+		Title:              "should-stay-pending-after-send",
+		InitialUserContent: []codersdk.ChatMessagePart{codersdk.ChatMessageText("hello")},
+		ModelConfigID:      model.ID,
+	})
+	require.NoError(t, err)
+
+	// Move out of pending so SendMessage goes through the normal
+	// insert+set-pending path rather than the queued path. This
+	// exercises a second signalWake call from SendMessage.
+	_, err = db.UpdateChatStatus(ctx, database.UpdateChatStatusParams{
+		ID:     chat.ID,
+		Status: database.ChatStatusWaiting,
+	})
+	require.NoError(t, err)
+
+	_, err = server.SendMessage(ctx, chatd.SendMessageOptions{
+		ChatID:  chat.ID,
+		Content: []codersdk.ChatMessagePart{codersdk.ChatMessageText("follow up")},
+	})
+	require.NoError(t, err)
+
+	chatd.WaitUntilIdleForTest(server)
+
+	stored, err := db.GetChatByID(ctx, chat.ID)
+	require.NoError(t, err)
+	require.Equal(t, database.ChatStatusPending, stored.Status,
+		"passive server must not acquire a chat after SendMessage signalWake; see coder/internal#1428")
 }
 
 // newStartedTestServer creates a server with Start() called.


### PR DESCRIPTION
Closes [CODAGT-81](https://linear.app/codercom/issue/CODAGT-81) / coder/internal#1428.

## Why

The issue tracks recurring flakes in `coderd/x/chatd` where tests asserting `status="pending"` would intermittently observe `status="running"`:

- `TestSubscribeNoPubsubNoDuplicateMessageParts`
- `TestPromoteQueuedAllowsAlreadyQueuedMessageWhenUsageLimitReached`
- `TestSendMessageInterruptBehaviorQueuesAndInterruptsWhenBusy`
- `TestPromoteQueuedMessageUsesQueuedModelConfigID`
- `TestPromoteQueuedMessageReloadsChatWhenModelConfigChangesDuringPending`

### Root cause and prior fixes

The original three flakes were stabilized in #23816 by introducing `waitForChatProcessed`, which lets tests synchronize on chat termination before mutating status manually.

The last two variants kept flaking on `newTestServer` (a “passive” server) because `chatd.New()` used to auto-start the acquire/wake loop. `SendMessage` / `PromoteQueued` would `signalWake`, the loop would pick the chat up, and the test’s `require.Equal(pending, ...)` would fire after the acquire-loop set the chat to `running`. #24761 fixed this by separating `Start()` from `New()`. After that PR, a passive server has no reader on `wakeCh`, so `signalWake` is a no-op for tests that don’t call `Start()`.

### What this PR adds

The original Linear/flake issue stays open even though the regressions are fixed, and the invariant the model-config tests rely on is implicit. Without an explicit guard a future refactor that re-couples `Start` into `New` (or adds another `acquireLoop` reader) would silently reintroduce the same race.

This PR adds two regression tests next to the existing `TestPassiveServerDoesNotProcess`:

- `TestPassiveServerDoesNotProcessAfterPromoteQueued` covers the exact flake mode from CODAGT-81: a pending chat plus a queued message, `PromoteQueued` calls `signalWake`, the chat must stay pending.
- `TestPassiveServerDoesNotProcessAfterSendMessage` covers the same invariant for `SendMessage`’s wake path.

It also pins the historical context with a comment on `newTestServer` so the next person digging through these tests doesn’t have to re-derive why “passive means no Start” matters.

## Verification

- New tests pass 500x with `-race` alongside the original flake set.
- Full `coderd/x/chatd` package: 3x `-race -parallel 16`, clean.
- Local repro of the historical flake mode failed (as expected on current main).

<details>
<summary>Stress run</summary>

```
$ go test ./coderd/x/chatd \
    -run 'TestPassiveServer|TestSubscribeNoPubsubNoDuplicateMessageParts$|TestPromoteQueuedAllowsAlreadyQueuedMessageWhenUsageLimitReached$|TestSendMessageInterruptBehaviorQueuesAndInterruptsWhenBusy$|TestPromoteQueuedMessageReloadsChatWhenModelConfigChangesDuringPending$|TestPromoteQueuedMessageUsesQueuedModelConfigID$' \
    -count=500 -race -timeout=1800s -parallel 16
ok  	github.com/coder/coder/v2/coderd/x/chatd	210.337s
```

</details>

---

Authored by [Coder Agents](https://coder.com).

---

**Update:** Closing this PR — the underlying flake is already resolved by #23816 and #24761. The regression guards here are nice-to-have but not necessary; commenting on the Linear issue with the fix history instead.