### PR TITLE
docs(.agents/skills/pull-requests): warn against hard-wrapping PR bodies

### DIFF
--- a/.agents/skills/pull-requests/SKILL.md
+++ b/.agents/skills/pull-requests/SKILL.md
@@ -23,6 +23,18 @@ Use the canonical docs for shared conventions and validation guidance:
 - Local validation commands and git hooks: `AGENTS.md` (Essential Commands and
   Git Hooks sections)
 
+## Body Formatting
+
+GitHub renders the PR description as Markdown and soft-wraps paragraphs to the
+viewport. Do not hard-wrap prose at 72 or 80 columns. Insert manual line
+breaks only where Markdown needs them: between paragraphs, around headings,
+lists, tables, code blocks, and blockquotes.
+
+The commit message body is not the PR body. Commit messages are typically
+hard-wrapped; PR bodies are not. When deriving the PR body from a commit
+message, unwrap each paragraph into a single line before passing it to
+`gh pr create --body` or `--body-file`.
+
 ## Lifecycle Rules
 
 1. **Check for an existing PR** before creating a new one:


### PR DESCRIPTION
PR bodies copied from a commit message body keep their 72/80-column hard wraps, and GitHub renders those as ragged-right line breaks instead of soft-wrapped paragraphs (e.g. the original body of #25130, fixed in this branch).

The rule already exists in `.claude/docs/PR_STYLE_GUIDE.md`, but it is buried in a 200-line style guide and easy to miss when an agent is mechanically running `gh pr create`. This change adds a short "Body Formatting" section directly to `.agents/skills/pull-requests/SKILL.md`, which is the proximate context loaded at PR-write time, and explicitly tells callers to unwrap commit-message paragraphs before reusing them as a PR body.

> Generated by Coder Agents on behalf of the assignee.
