### PR TITLE
chore: unhide flag to force unix filepaths in config-ssh

### DIFF
--- a/cli/configssh.go
+++ b/cli/configssh.go
@@ -566,11 +566,6 @@ func (r *RootCmd) configSSH() *serpent.Command {
 				"This might be an issue in Windows machine that use a unix-like shell. " +
 				"This flag forces the use of unix file paths (the forward slash '/').",
 			Value: serpent.BoolOf(&sshConfigOpts.forceUnixSeparators),
-			// On non-windows showing this command is useless because it is a noop.
-			// Hide vs disable it though so if a command is copied from a Windows
-			// machine to a unix machine it will still work and not throw an
-			// "unknown flag" error.
-			Hidden: hideForceUnixSlashes,
 		},
 		cliui.SkipPromptOption(),
 	}

--- a/cli/configssh_internal_test.go
+++ b/cli/configssh_internal_test.go
@@ -12,11 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func init() {
-	// For golden files, always show the flag.
-	hideForceUnixSlashes = false
-}
-
 func Test_sshConfigSplitOnCoderSection(t *testing.T) {
 	t.Parallel()
 

--- a/cli/configssh_other.go
+++ b/cli/configssh_other.go
@@ -8,8 +8,6 @@ import (
 	"golang.org/x/xerrors"
 )
 
-var hideForceUnixSlashes = true
-
 // sshConfigMatchExecEscape prepares the path for use in `Match exec` statement.
 //
 // OpenSSH parses the Match line with a very simple tokenizer that accepts "-enclosed strings for the exec command, and

--- a/cli/configssh_windows.go
+++ b/cli/configssh_windows.go
@@ -9,9 +9,6 @@ import (
 	"golang.org/x/xerrors"
 )
 
-// Must be a var for unit tests to conform behavior
-var hideForceUnixSlashes = false
-
 // sshConfigMatchExecEscape prepares the path for use in `Match exec` statement.
 //
 // OpenSSH parses the Match line with a very simple tokenizer that accepts "-enclosed strings for the exec command, and

--- a/docs/reference/cli/config-ssh.md
+++ b/docs/reference/cli/config-ssh.md
@@ -108,6 +108,15 @@ Specifies whether or not to wait for the startup script to finish executing. Aut
 
 Disable starting the workspace automatically when connecting via SSH.
 
+### --force-unix-filepaths
+
+|             |                                              |
+|-------------|----------------------------------------------|
+| Type        | <code>bool</code>                            |
+| Environment | <code>$CODER_CONFIGSSH_UNIX_FILEPATHS</code> |
+
+By default, 'config-ssh' uses the os path separator when writing the ssh config. This might be an issue in Windows machine that use a unix-like shell. This flag forces the use of unix file paths (the forward slash '/').
+
 ### -y, --yes
 
 |      |                   |


### PR DESCRIPTION
Docs now include this flag. This flag is now also viewable in linux/mac despite it effectively being a `no-op`.

Closes https://github.com/coder/coder/issues/24205