### PR TITLE
ci(.github/actions/setup-node): verify active Node version

### DIFF
--- a/.github/actions/setup-node/action.yaml
+++ b/.github/actions/setup-node/action.yaml
@@ -11,15 +11,28 @@ runs:
   using: "composite"
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
+      uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
 
     - name: Setup Node
-      uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: 22.19.0
         # See https://github.com/actions/setup-node#caching-global-packages-data
         cache: "pnpm"
         cache-dependency-path: ${{ inputs.directory }}/pnpm-lock.yaml
+
+    - name: Verify Node
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        expected="v22.19.0"
+        actual="$(node --version)"
+        if [[ "$actual" != "$expected" ]]; then
+          echo "::error::Expected Node.js $expected, but got $actual from $(command -v node)."
+          exit 1
+        fi
+        echo "Node.js $actual is active at $(command -v node)."
 
     - name: Install root node_modules
       shell: bash


### PR DESCRIPTION
Updates the shared setup-node composite action to current Node 24 based releases of `pnpm/action-setup` and `actions/setup-node`. This avoids the deprecated Node 20 action runtime seen in CODAGT-178 while keeping the third-party actions pinned by SHA.

Adds an explicit post-setup check that fails inside Setup Node when `node --version` is not `v22.19.0`, so self-hosted runner/toolcache mismatches are surfaced before `pnpm install` reports a dependency engine error.

Closes https://github.com/coder/internal/issues/1457

Generated by Coder Agents.
