### PR TITLE
fix(agent): gate first context-config request on startup settled

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1414,6 +1414,7 @@ func (a *agent) handleManifest(manifestOK *checkpoint) func(ctx context.Context,
 				// This runs inside the tracked goroutine so it
 				// is properly awaited on shutdown.
 				a.mcpManager.MarkStartupSettled()
+				a.contextConfigAPI.MarkStartupSettled()
 				if mcpErr := a.mcpManager.Reload(a.gracefulCtx, a.contextConfigAPI.MCPConfigFiles()); mcpErr != nil {
 					a.logger.Warn(ctx, "failed to reload workspace MCP servers", slog.Error(mcpErr))
 				}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -424,7 +424,7 @@ func (a *agent) init() {
 	)
 	a.desktopAPI = agentdesktop.NewAPI(a.logger.Named("desktop"), desktop, a.clock)
 	a.mcpManager = agentmcp.NewManager(a.gracefulCtx, a.logger.Named("mcp"), a.execer, a.updateCommandEnv)
-	a.contextConfigAPI = agentcontextconfig.NewAPI(func() string {
+	a.contextConfigAPI = agentcontextconfig.NewAPI(a.logger.Named("context-config"), func() string {
 		if m := a.manifest.Load(); m != nil {
 			return m.Directory
 		}

--- a/agent/agent_internal_test.go
+++ b/agent/agent_internal_test.go
@@ -68,7 +68,7 @@ func TestContextConfigAPI_InitOnce(t *testing.T) {
 
 	a := &agent{}
 	a.manifest.Store(&agentsdk.Manifest{Directory: dir1})
-	a.contextConfigAPI = agentcontextconfig.NewAPI(func() string {
+	a.contextConfigAPI = agentcontextconfig.NewAPI(testutil.Logger(t), func() string {
 		if m := a.manifest.Load(); m != nil {
 			return m.Directory
 		}

--- a/agent/agentcontextconfig/api.go
+++ b/agent/agentcontextconfig/api.go
@@ -2,18 +2,25 @@ package agentcontextconfig
 
 import (
 	"cmp"
+	"context"
+	"errors"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/go-chi/chi/v5"
+	"golang.org/x/xerrors"
 
+	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
+	"github.com/coder/quartz"
 )
 
 // Env var names for context configuration. Prefixed with EXP_
@@ -123,32 +130,89 @@ func ClearEnvVars() {
 type API struct {
 	workingDir func() string
 	cfg        Config
+	logger     slog.Logger
+
+	// clock is injectable so tests can drive the startup-gate
+	// timer without sleeping.
+	clock quartz.Clock
+
+	// startupSettled is closed once startup scripts reach a
+	// terminal state. Before that, handleGet may return a result
+	// based on a still-empty filesystem because startup scripts
+	// have not yet written AGENTS.md or .agents/skills/.
+	//
+	// The shape mirrors agent/x/agentmcp.Manager. If a third
+	// caller appears, factor the gate into a shared helper.
+	startupSettled chan struct{}
+	startupOnce    sync.Once
+
+	// startupTimeout caps how long handleGet waits before
+	// falling back to reading whatever is on disk. Better a real
+	// answer than an indefinite hang.
+	startupTimeout time.Duration
+}
+
+// Option configures a new API.
+type Option func(*API)
+
+// WithClock overrides the API's clock. Tests pass a mock to
+// drive startupTimeout deterministically.
+func WithClock(c quartz.Clock) Option {
+	return func(a *API) { a.clock = c }
 }
 
 // NewAPI creates a context configuration API. The working
 // directory closure is evaluated lazily per request.
-//
-// The logger parameter and variadic Option are reserved for the
-// startup-gate work in CODAGT-377; this red-phase signature only
-// makes the new symbols compile.
-func NewAPI(_ any, workingDir func() string, cfg Config, _ ...Option) *API {
+func NewAPI(logger slog.Logger, workingDir func() string, cfg Config, opts ...Option) *API {
 	if workingDir == nil {
 		workingDir = func() string { return "" }
 	}
-	return &API{workingDir: workingDir, cfg: cfg.applyDefaults()}
+	a := &API{
+		workingDir:     workingDir,
+		cfg:            cfg.applyDefaults(),
+		logger:         logger,
+		clock:          quartz.NewReal(),
+		startupSettled: make(chan struct{}),
+		startupTimeout: 35 * time.Second,
+	}
+	for _, opt := range opts {
+		opt(a)
+	}
+	return a
 }
 
-// Option is reserved for future configuration of API. Real
-// implementation lands in the green phase of CODAGT-377.
-type Option func(*API)
+// MarkStartupSettled marks startup scripts as terminal for
+// context-config purposes. The first GET after this point
+// proceeds without waiting. Concurrent and repeat calls are
+// safe.
+func (api *API) MarkStartupSettled() {
+	api.startupOnce.Do(func() { close(api.startupSettled) })
+}
 
-// WithClock is a stub. Real implementation lands in the green
-// phase of CODAGT-377.
-func WithClock(_ any) Option { return func(*API) {} }
+// errStartupTimeout signals that the startup gate timed out
+// before settle. handleGet treats this as a fallback path, not
+// an error to the caller.
+var errStartupTimeout = xerrors.New("startup gate timed out")
 
-// MarkStartupSettled is a stub. Real implementation lands in the
-// green phase of CODAGT-377.
-func (*API) MarkStartupSettled() {}
+// waitForStartupSettled blocks until startup is marked settled,
+// the request context is canceled, or startupTimeout elapses.
+func (api *API) waitForStartupSettled(ctx context.Context) error {
+	select {
+	case <-api.startupSettled:
+		return nil
+	default:
+	}
+	timer := api.clock.NewTimer(api.startupTimeout, "agentcontextconfig", "startup_gate")
+	defer timer.Stop()
+	select {
+	case <-api.startupSettled:
+		return nil
+	case <-timer.C:
+		return errStartupTimeout
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
 
 // Resolve reads instruction files, discovers skills, and
 // resolves MCP config file paths for the given config and
@@ -231,6 +295,21 @@ func (api *API) Routes() http.Handler {
 }
 
 func (api *API) handleGet(rw http.ResponseWriter, r *http.Request) {
+	if err := api.waitForStartupSettled(r.Context()); err != nil {
+		if !errors.Is(err, errStartupTimeout) {
+			httpapi.Write(r.Context(), rw, http.StatusServiceUnavailable, codersdk.Response{
+				Message: "Agent startup has not settled.",
+				Detail:  err.Error(),
+			})
+			return
+		}
+		// On timeout we fall back to whatever is on disk so a slow
+		// or stuck startup script does not freeze chatd.
+		api.logger.Warn(r.Context(),
+			"context-config startup gate timed out, returning disk state",
+			slog.F("timeout", api.startupTimeout),
+		)
+	}
 	response, _ := Resolve(api.workingDir(), api.cfg)
 	httpapi.Write(r.Context(), rw, http.StatusOK, response)
 }

--- a/agent/agentcontextconfig/api.go
+++ b/agent/agentcontextconfig/api.go
@@ -127,12 +127,28 @@ type API struct {
 
 // NewAPI creates a context configuration API. The working
 // directory closure is evaluated lazily per request.
-func NewAPI(workingDir func() string, cfg Config) *API {
+//
+// The logger parameter and variadic Option are reserved for the
+// startup-gate work in CODAGT-377; this red-phase signature only
+// makes the new symbols compile.
+func NewAPI(_ any, workingDir func() string, cfg Config, _ ...Option) *API {
 	if workingDir == nil {
 		workingDir = func() string { return "" }
 	}
 	return &API{workingDir: workingDir, cfg: cfg.applyDefaults()}
 }
+
+// Option is reserved for future configuration of API. Real
+// implementation lands in the green phase of CODAGT-377.
+type Option func(*API)
+
+// WithClock is a stub. Real implementation lands in the green
+// phase of CODAGT-377.
+func WithClock(_ any) Option { return func(*API) {} }
+
+// MarkStartupSettled is a stub. Real implementation lands in the
+// green phase of CODAGT-377.
+func (*API) MarkStartupSettled() {}
 
 // Resolve reads instruction files, discovers skills, and
 // resolves MCP config file paths for the given config and

--- a/agent/agentcontextconfig/api_test.go
+++ b/agent/agentcontextconfig/api_test.go
@@ -1,16 +1,37 @@
 package agentcontextconfig_test
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"cdr.dev/slog/v3"
+	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/agent/agentcontextconfig"
 	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/codersdk/workspacesdk"
+	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/quartz"
 )
+
+// newAPISettled returns a new API with startup already marked
+// settled, for tests that do not exercise the gate.
+func newAPISettled(t *testing.T, logger slog.Logger, workingDir func() string, cfg agentcontextconfig.Config, opts ...agentcontextconfig.Option) *agentcontextconfig.API {
+	t.Helper()
+	api := agentcontextconfig.NewAPI(logger, workingDir, cfg, opts...)
+	api.MarkStartupSettled()
+	return api
+}
 
 // filterParts returns only the parts matching the given type.
 func filterParts(parts []codersdk.ChatMessagePart, t codersdk.ChatMessagePartType) []codersdk.ChatMessagePart {
@@ -471,7 +492,8 @@ func TestNewAPI_LazyDirectory(t *testing.T) {
 	t.Setenv(agentcontextconfig.EnvMCPConfigFiles, "")
 
 	dir := ""
-	api := agentcontextconfig.NewAPI(func() string { return dir }, agentcontextconfig.ReadEnvConfig())
+	logger := slogtest.Make(t, nil)
+	api := newAPISettled(t, logger, func() string { return dir }, agentcontextconfig.ReadEnvConfig())
 
 	// Before directory is set, MCP paths resolve to nothing.
 	mcpFiles := api.MCPConfigFiles()
@@ -541,4 +563,232 @@ func TestResolve_ConfigOverridesEnv(t *testing.T) {
 	ctxFiles := filterParts(result.Parts, codersdk.ChatMessagePartTypeContextFile)
 	require.Len(t, ctxFiles, 1)
 	require.Equal(t, "from config", ctxFiles[0].ContextFileContent)
+}
+
+// TestHandleGet_BlocksUntilSettled verifies that handleGet waits
+// for MarkStartupSettled before responding, and that the response
+// is the resolved context once settled.
+func TestHandleGet_BlocksUntilSettled(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	clock := quartz.NewMock(t)
+	timerTrap := clock.Trap().NewTimer("agentcontextconfig", "startup_gate")
+	defer timerTrap.Close()
+
+	workDir := t.TempDir()
+	instructionPath := filepath.Join(workDir, "AGENTS.md")
+	require.NoError(t, os.WriteFile(instructionPath, []byte("project instructions"), 0o600))
+
+	api := agentcontextconfig.NewAPI(
+		logger,
+		func() string { return workDir },
+		agentcontextconfig.Config{},
+		agentcontextconfig.WithClock(clock),
+	)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		api.Routes().ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	// Wait until the gate's timer is scheduled. This confirms the
+	// goroutine is actually blocked on the gate, not racing past it.
+	call := timerTrap.MustWait(ctx)
+	require.Equal(t, 35*time.Second, call.Duration)
+	call.MustRelease(ctx)
+
+	// Body must still be empty: no response written before settle.
+	assert.Equal(t, 0, rec.Body.Len(), "body should be empty before settle")
+
+	api.MarkStartupSettled()
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		t.Fatal("handleGet did not return after MarkStartupSettled")
+	}
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp workspacesdk.ContextConfigResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	ctxFiles := filterParts(resp.Parts, codersdk.ChatMessagePartTypeContextFile)
+	require.Len(t, ctxFiles, 1)
+	require.Equal(t, "project instructions", ctxFiles[0].ContextFileContent)
+}
+
+// TestHandleGet_ProceedsAfterSettled verifies that handleGet does
+// not wait or schedule a timer when startup is already settled.
+func TestHandleGet_ProceedsAfterSettled(t *testing.T) {
+	t.Parallel()
+
+	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	clock := quartz.NewMock(t)
+	// Trap NewTimer so we can assert it is never called.
+	timerTrap := clock.Trap().NewTimer("agentcontextconfig", "startup_gate")
+	defer timerTrap.Close()
+
+	workDir := t.TempDir()
+	instructionPath := filepath.Join(workDir, "AGENTS.md")
+	require.NoError(t, os.WriteFile(instructionPath, []byte("project instructions"), 0o600))
+
+	api := agentcontextconfig.NewAPI(
+		logger,
+		func() string { return workDir },
+		agentcontextconfig.Config{},
+		agentcontextconfig.WithClock(clock),
+	)
+	api.MarkStartupSettled()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	api.Routes().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp workspacesdk.ContextConfigResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	ctxFiles := filterParts(resp.Parts, codersdk.ChatMessagePartTypeContextFile)
+	require.Len(t, ctxFiles, 1)
+	require.Equal(t, "project instructions", ctxFiles[0].ContextFileContent)
+}
+
+// TestHandleGet_ContextCancel verifies that handleGet returns a
+// 503 structured error when the request context cancels before
+// startup settles, and writes no partial JSON before the error.
+func TestHandleGet_ContextCancel(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	clock := quartz.NewMock(t)
+	timerTrap := clock.Trap().NewTimer("agentcontextconfig", "startup_gate")
+	defer timerTrap.Close()
+
+	api := agentcontextconfig.NewAPI(
+		logger,
+		func() string { return t.TempDir() },
+		agentcontextconfig.Config{},
+		agentcontextconfig.WithClock(clock),
+	)
+
+	reqCtx, cancel := context.WithCancel(ctx)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(reqCtx)
+
+	done := make(chan struct{})
+	go func() {
+		api.Routes().ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	// Confirm the gate timer is scheduled, then cancel.
+	call := timerTrap.MustWait(ctx)
+	call.MustRelease(ctx)
+	cancel()
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		t.Fatal("handleGet did not return after context cancel")
+	}
+
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	var resp codersdk.Response
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.NotEmpty(t, resp.Message, "503 response must have a Message")
+}
+
+// TestHandleGet_TimeoutFallback verifies that after 35s without
+// settle, handleGet falls back to reading disk state and returns
+// 200, and logs a warning that the gate timed out.
+func TestHandleGet_TimeoutFallback(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.Context(t, testutil.WaitLong)
+	// Allow Warn-level "startup never settled" logs.
+	logger := slogtest.Make(t, &slogtest.Options{
+		IgnoreErrors: true,
+	}).Leveled(slog.LevelDebug)
+	clock := quartz.NewMock(t)
+	timerTrap := clock.Trap().NewTimer("agentcontextconfig", "startup_gate")
+	defer timerTrap.Close()
+
+	workDir := t.TempDir()
+	instructionPath := filepath.Join(workDir, "AGENTS.md")
+	require.NoError(t, os.WriteFile(instructionPath, []byte("disk fallback"), 0o600))
+
+	api := agentcontextconfig.NewAPI(
+		logger,
+		func() string { return workDir },
+		agentcontextconfig.Config{},
+		agentcontextconfig.WithClock(clock),
+	)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		api.Routes().ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	call := timerTrap.MustWait(ctx)
+	require.Equal(t, 35*time.Second, call.Duration)
+	call.MustRelease(ctx)
+
+	// Advance past the timeout. The gate fires and falls back.
+	clock.Advance(35 * time.Second).MustWait(ctx)
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		t.Fatal("handleGet did not return after timeout fallback")
+	}
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp workspacesdk.ContextConfigResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	ctxFiles := filterParts(resp.Parts, codersdk.ChatMessagePartTypeContextFile)
+	require.Len(t, ctxFiles, 1)
+	require.Equal(t, "disk fallback", ctxFiles[0].ContextFileContent)
+}
+
+// TestMarkStartupSettled_Idempotent verifies that concurrent and
+// sequential calls to MarkStartupSettled are safe.
+func TestMarkStartupSettled_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	api := agentcontextconfig.NewAPI(
+		logger,
+		func() string { return t.TempDir() },
+		agentcontextconfig.Config{},
+	)
+
+	var wg sync.WaitGroup
+	for range 16 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			api.MarkStartupSettled()
+		}()
+	}
+	wg.Wait()
+
+	// Sequential calls afterwards are also safe.
+	api.MarkStartupSettled()
+	api.MarkStartupSettled()
+
+	// A request after settle proceeds without blocking.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	api.Routes().ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
 }


### PR DESCRIPTION
The first `GET /api/v0/context-config` after agent start now blocks until startup scripts settle, or for at most 35s before falling back to whatever is on disk. This prevents chatd from caching an empty result when a chat starts before `~/.coder/AGENTS.md` or `.agents/skills/` exist on disk.

The agent calls `contextConfigAPI.MarkStartupSettled()` from the same tracked goroutine that already calls `mcpManager.MarkStartupSettled()`. If the request context cancels before settle, `handleGet` returns HTTP 503 with a `codersdk.Response` envelope so chatd's existing `workspaceConnOK = false` path takes over instead of persisting an empty result.

Fixes [CODAGT-377](https://linear.app/codercom/issue/CODAGT-377).

Prior art: [#25034](https://github.com/coder/coder/pull/25034) ported the equivalent gate to the MCP manager; this PR mirrors that shape (`startupSettled` chan + `startupOnce` + `MarkStartupSettled` + a wait helper). The two gates are intentionally duplicated for now, with a comment in `api.go` noting they should be factored out if a third caller appears.

<details>
<summary>Implementation plan</summary>

# Agent context startup gate

## Context

`handleGet` in `agent/agentcontextconfig/api.go:217-220` reads AGENTS.md
and discovers skills synchronously on every request. If chatd calls the
endpoint before startup scripts have populated `~/.coder/AGENTS.md` or
`.agents/skills/`, the agent returns an empty result. chatd persists
that empty result and the chat is frozen with no AGENTS.md or skills
until workspace rebuild or new chat.

PR #25034 fixed the same race for MCP via
`agent/x/agentmcp/manager.go` `MarkStartupSettled()`. This plan ports
that fix to the context-config endpoint.

The race is masked when chats arrive via `start_workspace` /
`create_workspace`, which block on `waitForAgentReady` (lifecycle
`Ready`). Externally started workspaces, or chats opened immediately
after agent start from another source, can still hit it.

Linear issue: CODAGT-377.

## Requirements

1. The first `GET /api/v0/context-config` after agent start blocks until
   startup scripts finish.
2. `MarkStartupSettled` is idempotent. Subsequent calls and concurrent
   calls are safe.
3. `MarkStartupSettled` is called from the same goroutine that calls
   `mcpManager.MarkStartupSettled()` at `agent/agent.go:1416`.
4. If startup never settles, `handleGet` falls back to reading disk
   after 35s. Better a real answer than an indefinite hang.
5. If the request context cancels before settle, return HTTP 503
   without partial response. chatd's existing `workspaceConnOK = false`
   path handles this.
6. Clock is injectable. Tests use `quartz` to advance time
   deterministically. No `time.Sleep` in tests.

## Decisions locked

| Q  | Decision                                                                 |
| -- | ------------------------------------------------------------------------ |
| 1  | Unified behavior across AGENTS.md and skills.                            |
| 2  | Per-turn-fresh deferred. Long-term direction is agent-pushed diffs.      |
| 6  | Agent-side startup gate. chatd-side lifecycle check rejected.            |
| 14 | Per-turn fetch dropped. Workspace context frozen per chat as today.      |

## Out of scope

- chatd changes.
- Per-turn freshness, snapshot-on-change, push-from-agent.
- Metrics on `handleGet` duration.
- Doc updates.

## Red phase: failing tests first

Add to `agent/agentcontextconfig/api_test.go`:

### Test 1: `TestHandleGet_BlocksUntilSettled`

- Setup: `NewAPI` with a `quartz.Mock` clock, do not call
  `MarkStartupSettled`.
- Action: spawn a goroutine to `httptest.NewRecorder()` and `handleGet`
  with a normal request context.
- Assert: after `quartz.Mock` advances 30s, the goroutine has not
  written a response (use `quartz.Trap` to confirm the timer is
  waiting; assert `rec.Body.Len() == 0`).
- Action: call `MarkStartupSettled()`.
- Assert: goroutine completes within 100ms wall time. Response has
  status 200 and decoded body matches the expected `Resolve` output.

### Test 2: `TestHandleGet_ProceedsAfterSettled`

- Setup: `NewAPI` with `quartz.Mock`. Call `MarkStartupSettled` before
  the request.
- Action: synchronously call `handleGet`.
- Assert: returns immediately with status 200 and the expected body.
  No timer is scheduled (`quartz.Mock` traps confirm no pending events).

### Test 3: `TestHandleGet_ContextCancel`

- Setup: `NewAPI` with `quartz.Mock`, do not settle.
- Action: spawn a goroutine that calls `handleGet` with a cancelable
  context. Cancel after the goroutine begins waiting.
- Assert: response status 503. Body is a structured error with a
  recognizable code that chatd can map to `workspaceConnOK = false`
  (e.g. `codersdk.Response{Message: ..., Detail: ...}` matching the
  agent's existing error shape).
- Assert: no partial JSON written before the 503.

### Test 4: `TestHandleGet_TimeoutFallback`

- Setup: `NewAPI` with `quartz.Mock`. Do not settle. Working directory
  contains a real AGENTS.md.
- Action: spawn `handleGet`. Advance `quartz.Mock` by 35s.
- Assert: response status 200, body contains the AGENTS.md content.
- Assert: log records a warning that startup never settled.

### Test 5: `TestMarkStartupSettled_Idempotent`

- Setup: `NewAPI`.
- Action: call `MarkStartupSettled` concurrently from 16 goroutines and
  again sequentially after.
- Assert: no panic, no deadlock. `handleGet` immediately after returns
  200.

### Test 6: existing `TestHandleGet_*` tests

- Add a helper `newAPISettled(t, ...)` that wraps `NewAPI` and calls
  `MarkStartupSettled` immediately. Convert existing tests that don't
  care about the gate to use it.

**Definition of done for red phase:** all six tests fail with the
current code (or fail to compile because `MarkStartupSettled`,
`WithClock`, etc. do not exist yet).

## Green phase: minimum implementation

### Step 1: extend `API` struct in `agent/agentcontextconfig/api.go`

Add fields:

```go
type API struct {
    workingDir       func() string
    cfg              Config
    clock            quartz.Clock
    startupSettled   chan struct{}
    startupOnce      sync.Once
    startupTimeout   time.Duration
}
```

### Step 2: option type for clock injection

```go
type Option func(*API)

func WithClock(c quartz.Clock) Option {
    return func(a *API) { a.clock = c }
}
```

### Step 3: update `NewAPI` to accept options

```go
func NewAPI(workingDir func() string, cfg Config, opts ...Option) *API {
    if workingDir == nil {
        workingDir = func() string { return "" }
    }
    a := &API{
        workingDir:     workingDir,
        cfg:            cfg.applyDefaults(),
        clock:          quartz.NewReal(),
        startupSettled: make(chan struct{}),
        startupTimeout: 35 * time.Second,
    }
    for _, opt := range opts {
        opt(a)
    }
    return a
}
```

### Step 4: add `MarkStartupSettled`

```go
func (api *API) MarkStartupSettled() {
    api.startupOnce.Do(func() { close(api.startupSettled) })
}
```

### Step 5: add `waitForStartupSettled`

```go
func (api *API) waitForStartupSettled(ctx context.Context) error {
    select {
    case <-api.startupSettled:
        return nil
    default:
    }
    timer := api.clock.NewTimer(api.startupTimeout)
    defer timer.Stop()
    select {
    case <-api.startupSettled:
        return nil
    case <-timer.C:
        return errStartupTimeout // sentinel for fallback path
    case <-ctx.Done():
        return ctx.Err()
    }
}
```

Define `errStartupTimeout` as a private sentinel. Callers distinguish
ctx cancel from timeout.

### Step 6: update `handleGet`

```go
func (api *API) handleGet(rw http.ResponseWriter, r *http.Request) {
    if err := api.waitForStartupSettled(r.Context()); err != nil {
        if errors.Is(err, errStartupTimeout) {
            // Log warning, proceed with whatever is on disk.
            api.logger.Warn(r.Context(), "context-config startup gate timed out, returning disk state")
            // Fall through.
        } else {
            // Context cancel: return 503 structured error.
            httpapi.Write(r.Context(), rw, http.StatusServiceUnavailable,
                codersdk.Response{Message: "agent startup not settled"})
            return
        }
    }
    response, _ := Resolve(api.workingDir(), api.cfg)
    httpapi.Write(r.Context(), rw, http.StatusOK, response)
}
```

Note: `API` does not currently hold a logger. Add `logger slog.Logger`
to the struct and a setter or `WithLogger` option. If the agent already
passes a logger to other APIs (it does for `agentmcp`, `agentdesktop`),
match that pattern.

### Step 7: wire `MarkStartupSettled` from `agent/agent.go`

In the goroutine at `agent/agent.go:1416`, add one line after the
existing MCP call:

```go
a.mcpManager.MarkStartupSettled()
a.contextConfigAPI.MarkStartupSettled()
if mcpErr := a.mcpManager.Reload(...); mcpErr != nil {
    ...
}
```

### Step 8: update tests in step 6 of red phase

Tests that don't care about the gate get the `newAPISettled` helper.

**Definition of done for green phase:** all six new tests pass. All
pre-existing tests in `agent/agentcontextconfig/`, `agent/`, and
`coderd/x/chatd/` that touch this code pass without modification or
with the `newAPISettled` helper.

## Refactor phase

After green, look for:

1. **Shared startup-gate pattern with MCP.** Both `agentcontextconfig`
   and `agentmcp` now have `startupSettled chan` + `startupOnce` +
   `MarkStartupSettled` + a wait helper. If the shapes are close enough,
   consider a tiny shared type `internal/startupgate.Gate` with
   `MarkSettled()` and `Wait(ctx, timeout) error`. Apply rule of three:
   if only two callers exist and the shapes diverge slightly,
   duplication is fine. **Decision: leave duplicated unless a third
   caller is imminent.** Note in a code comment that the two should
   stay in sync.

2. **Logger field placement.** If adding `logger` to `API` introduces
   awkward construction, refactor `NewAPI` to take `slog.Logger` as a
   required parameter rather than an option. Match `agentmcp.NewAPI`
   signature for consistency.

3. **Error shape.** Confirm the 503 response uses the same
   `codersdk.Response` envelope as other agent errors. If not, align.

4. **Test helper extraction.** If `newAPISettled` is also useful in
   tests outside `agentcontextconfig_test`, move it to a test-only
   package or export it.

No new features in this phase. All tests must still pass.

## Verification

- `make test RUN=TestHandleGet` from repo root passes.
- `make test RUN=TestMarkStartupSettled` passes.
- `make lint` clean.
- `make gen` clean (no generated changes expected; this is not a DB
  change).
- Manual: build the agent, start a workspace with a slow startup script
  (e.g. `sleep 10 && touch ~/.coder/AGENTS.md`), open a chat
  immediately. Confirm the chat sees AGENTS.md content rather than an
  empty response.

## Risks

1. Tests that don't call `MarkStartupSettled` hang for 35s before
   timing out. Mitigated by `newAPISettled` helper in step 8.
2. 35s timeout is conservative. Real startup scripts that take this
   long mean the workspace is broken. Fallback to disk read matches
   today's behavior for that edge case.
3. `errors.Is(err, context.Canceled)` and `errors.Is(err,
   context.DeadlineExceeded)` from the caller's context must be
   distinguishable from `errStartupTimeout`. Use a private sentinel
   value, not a context-related error, to avoid confusion.

## Coordination with PR #25044

Independent. This plan touches `agent/agentcontextconfig/` and one line
in `agent/agent.go`. PR #25044 touches `coderd/x/chatd/`. Zero file
overlap. Either order works.

</details>

---
This PR was generated by Coder Agents on behalf of @mafredri.

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻
