### PR TITLE
fix(site): track external auth polling per provider

### DIFF
--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.test.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.test.tsx
@@ -2,7 +2,10 @@ import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { act } from "react";
 import { API } from "#/api/api";
-import type { DynamicParametersResponse } from "#/api/typesGenerated";
+import type {
+	DynamicParametersResponse,
+	TemplateVersionExternalAuth,
+} from "#/api/typesGenerated";
 import {
 	MockDropdownParameter,
 	MockDynamicParametersResponse,
@@ -25,6 +28,15 @@ import { mockDynamicParameterWebSocket } from "#/testHelpers/websockets";
 import CreateWorkspacePage from "./CreateWorkspacePage";
 
 describe("CreateWorkspacePage", () => {
+	const MockTemplateVersionExternalAuthGitLab: TemplateVersionExternalAuth = {
+		id: "gitlab",
+		type: "gitlab",
+		authenticate_url: "https://example.com/external-auth/gitlab",
+		authenticated: false,
+		display_icon: "/icon/gitlab.svg",
+		display_name: "GitLab",
+	};
+
 	const renderCreateWorkspacePage = (
 		route = `/templates/${MockTemplate.name}/workspace`,
 	) => {
@@ -408,6 +420,79 @@ describe("CreateWorkspacePage", () => {
 				expect(screen.getByText("GitHub")).toBeInTheDocument();
 				expect(screen.getByText(/authenticated/i)).toBeInTheDocument();
 			});
+		});
+
+		it("only disables the external auth provider that started polling", async () => {
+			const open = vi.spyOn(window, "open").mockImplementation(() => null);
+			vi.spyOn(API, "getTemplateVersionExternalAuth").mockResolvedValue([
+				MockTemplateVersionExternalAuthGithub,
+				MockTemplateVersionExternalAuthGitLab,
+			]);
+
+			renderCreateWorkspacePage();
+			await waitForLoaderToBeRemoved();
+
+			const githubButton = await screen.findByRole("button", {
+				name: /login with github/i,
+			});
+			const gitlabButton = screen.getByRole("button", {
+				name: /login with gitlab/i,
+			});
+
+			await userEvent.click(githubButton);
+
+			await waitFor(() => {
+				expect(githubButton).toBeDisabled();
+			});
+			expect(gitlabButton).toBeEnabled();
+			expect(open).toHaveBeenCalledWith(
+				MockTemplateVersionExternalAuthGithub.authenticate_url,
+				"_blank",
+				"width=900,height=600",
+			);
+		});
+
+		it("only shows retry for the external auth provider whose polling timed out", async () => {
+			vi.spyOn(window, "open").mockImplementation(() => null);
+			vi.spyOn(API, "getTemplateVersionExternalAuth").mockResolvedValue([
+				MockTemplateVersionExternalAuthGithub,
+				MockTemplateVersionExternalAuthGitLab,
+			]);
+
+			renderCreateWorkspacePage();
+			await waitForLoaderToBeRemoved();
+
+			vi.useFakeTimers({ shouldAdvanceTime: true });
+			const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+			const githubButton = await screen.findByRole("button", {
+				name: /login with github/i,
+			});
+			await user.click(githubButton);
+
+			await act(async () => {
+				vi.advanceTimersByTime(60_000);
+			});
+
+			const githubRow = screen.getByText("GitHub").closest("div");
+			const gitlabRow = screen.getByText("GitLab").closest("div");
+			expect(githubRow).not.toBeNull();
+			expect(gitlabRow).not.toBeNull();
+
+			expect(
+				within(githubRow!).getByRole("button", {
+					name: /refresh external auth/i,
+				}),
+			).toBeInTheDocument();
+			expect(
+				within(gitlabRow!).queryByRole("button", {
+					name: /refresh external auth/i,
+				}),
+			).not.toBeInTheDocument();
+			expect(
+				within(gitlabRow!).getByRole("button", {
+					name: /login with gitlab/i,
+				}),
+			).toBeEnabled();
 		});
 
 		it("prevents auto-creation when required external auth is missing", async () => {

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePage.tsx
@@ -194,7 +194,7 @@ const CreateWorkspacePage: FC = () => {
 
 	const {
 		externalAuth,
-		externalAuthPollingState,
+		externalAuthPollingStates,
 		startPollingExternalAuth,
 		isLoadingExternalAuth,
 	} = useExternalAuth(realizedVersionId);
@@ -331,7 +331,7 @@ const CreateWorkspacePage: FC = () => {
 					versionId={realizedVersionId}
 					versionName={templateVersionQuery.data?.name}
 					externalAuth={externalAuth ?? []}
-					externalAuthPollingState={externalAuthPollingState}
+					externalAuthPollingStates={externalAuthPollingStates}
 					startPollingExternalAuth={startPollingExternalAuth}
 					hasAllRequiredExternalAuth={hasAllRequiredExternalAuth}
 					permissions={permissionsQuery.data as CreateWorkspacePermissions}
@@ -365,45 +365,108 @@ const CreateWorkspacePage: FC = () => {
 };
 
 const useExternalAuth = (versionId: string | undefined) => {
-	const [externalAuthPollingState, setExternalAuthPollingState] =
-		useState<ExternalAuthPollingState>("idle");
+	const abandonTimers = useRef<Record<string, ReturnType<typeof setTimeout>>>(
+		{},
+	);
+	const [externalAuthPollingStates, setExternalAuthPollingStates] = useState<
+		Record<string, ExternalAuthPollingState>
+	>({});
 
-	const startPollingExternalAuth = useCallback(() => {
-		setExternalAuthPollingState("polling");
+	const clearAbandonTimer = useCallback((authID: string) => {
+		const abandonTimer = abandonTimers.current[authID];
+		if (abandonTimer) {
+			clearTimeout(abandonTimer);
+			delete abandonTimers.current[authID];
+		}
 	}, []);
 
+	const startPollingExternalAuth = useCallback(
+		(authID: string) => {
+			clearAbandonTimer(authID);
+			setExternalAuthPollingStates((states) => ({
+				...states,
+				[authID]: "polling",
+			}));
+			abandonTimers.current[authID] = setTimeout(() => {
+				setExternalAuthPollingStates((states) => {
+					if (states[authID] !== "polling") {
+						return states;
+					}
+
+					return {
+						...states,
+						[authID]: "abandoned",
+					};
+				});
+				delete abandonTimers.current[authID];
+			}, 60_000);
+		},
+		[clearAbandonTimer],
+	);
+
+	useEffect(() => {
+		return () => {
+			for (const abandonTimer of Object.values(abandonTimers.current)) {
+				clearTimeout(abandonTimer);
+			}
+		};
+	}, []);
+
+	const isPollingExternalAuth = Object.values(externalAuthPollingStates).some(
+		(state) => state === "polling",
+	);
 	const { data: externalAuth, isLoading: isLoadingExternalAuth } = useQuery({
 		...templateVersionExternalAuth(versionId ?? ""),
 		enabled: Boolean(versionId),
-		refetchInterval: externalAuthPollingState === "polling" ? 1000 : false,
+		refetchInterval: isPollingExternalAuth ? 1000 : false,
 	});
 
-	const allSignedIn = externalAuth?.every((it) => it.authenticated);
-
 	useEffect(() => {
-		if (allSignedIn) {
-			setExternalAuthPollingState("idle");
+		if (!externalAuth) {
 			return;
 		}
 
-		if (externalAuthPollingState !== "polling") {
-			return;
-		}
-
-		// Poll for a maximum of one minute
-		const quitPolling = setTimeout(
-			() => setExternalAuthPollingState("abandoned"),
-			60_000,
+		const externalAuthIDs = new Set(externalAuth.map((auth) => auth.id));
+		const authenticatedExternalAuthIDs = new Set(
+			externalAuth.filter((auth) => auth.authenticated).map((auth) => auth.id),
 		);
-		return () => {
-			clearTimeout(quitPolling);
-		};
-	}, [externalAuthPollingState, allSignedIn]);
+		for (const authID of Object.keys(abandonTimers.current)) {
+			if (
+				authenticatedExternalAuthIDs.has(authID) ||
+				!externalAuthIDs.has(authID)
+			) {
+				clearAbandonTimer(authID);
+			}
+		}
+
+		setExternalAuthPollingStates((states) => {
+			let nextStates: typeof states | undefined;
+			for (const authID of authenticatedExternalAuthIDs) {
+				if (states[authID] === undefined) {
+					continue;
+				}
+
+				nextStates ??= { ...states };
+				delete nextStates[authID];
+			}
+
+			for (const authID of Object.keys(states)) {
+				if (externalAuthIDs.has(authID)) {
+					continue;
+				}
+
+				nextStates ??= { ...states };
+				delete nextStates[authID];
+			}
+
+			return nextStates ?? states;
+		});
+	}, [clearAbandonTimer, externalAuth]);
 
 	return {
 		startPollingExternalAuth,
 		externalAuth,
-		externalAuthPollingState,
+		externalAuthPollingStates,
 		isLoadingExternalAuth,
 	};
 };

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.stories.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.stories.tsx
@@ -16,7 +16,7 @@ const meta: Meta<typeof CreateWorkspacePageView> = {
 		defaultName: "",
 		defaultOwner: MockUserOwner,
 		externalAuth: [],
-		externalAuthPollingState: "idle",
+		externalAuthPollingStates: {},
 		hasAllRequiredExternalAuth: true,
 		mode: "form",
 		parameters: [],

--- a/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
+++ b/site/src/pages/CreateWorkspacePage/CreateWorkspacePageView.tsx
@@ -65,7 +65,7 @@ interface CreateWorkspacePageViewProps {
 	disabledParams?: string[];
 	error: unknown;
 	externalAuth: TypesGen.TemplateVersionExternalAuth[];
-	externalAuthPollingState: ExternalAuthPollingState;
+	externalAuthPollingStates: Record<string, ExternalAuthPollingState>;
 	hasAllRequiredExternalAuth: boolean;
 	mode: CreateWorkspaceMode;
 	parameters: PreviewParameter[];
@@ -81,7 +81,7 @@ interface CreateWorkspacePageViewProps {
 	) => void;
 	resetMutation: () => void;
 	sendMessage: (message: Record<string, string>, ownerId?: string) => void;
-	startPollingExternalAuth: () => void;
+	startPollingExternalAuth: (authID: string) => void;
 	owner: TypesGen.MinimalUser;
 	setOwner: (user: TypesGen.MinimalUser) => void;
 }
@@ -96,7 +96,7 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 	disabledParams,
 	error,
 	externalAuth,
-	externalAuthPollingState,
+	externalAuthPollingStates,
 	hasAllRequiredExternalAuth,
 	mode,
 	parameters,
@@ -553,16 +553,21 @@ export const CreateWorkspacePageView: FC<CreateWorkspacePageViewProps> = ({
 										all required external authentication providers listed below.
 									</Alert>
 								)}
-								{externalAuth.map((auth) => (
-									<ExternalAuthButton
-										key={auth.id}
-										error={error}
-										auth={auth}
-										isLoading={externalAuthPollingState === "polling"}
-										onStartPolling={startPollingExternalAuth}
-										displayRetry={externalAuthPollingState === "abandoned"}
-									/>
-								))}
+								{externalAuth.map((auth) => {
+									const pollingState =
+										externalAuthPollingStates[auth.id] ?? "idle";
+
+									return (
+										<ExternalAuthButton
+											key={auth.id}
+											error={error}
+											auth={auth}
+											isLoading={pollingState === "polling"}
+											onStartPolling={() => startPollingExternalAuth(auth.id)}
+											displayRetry={pollingState === "abandoned"}
+										/>
+									);
+								})}
 							</div>
 						</section>
 					)}


### PR DESCRIPTION
External auth polling on the workspace creation form was tracked as one shared state, so starting auth for one provider disabled every unauthenticated provider until all providers signed in.

Track polling and retry state per provider ID, and keep refetching while any provider is actively polling.

Fixes #22420.