### PR TITLE
fix(coderd): exclude stale prior-build agents from instance-identity auth

### DIFF
--- a/coderd/workspaceresourceauth.go
+++ b/coderd/workspaceresourceauth.go
@@ -149,17 +149,32 @@ func (api *API) handleAuthInstanceID(rw http.ResponseWriter, r *http.Request, in
 	// agents. Keep only workspace build agents before resolving ambiguity so
 	// template version agents do not force CODER_AGENT_NAME.
 	//
-	// We attach the provisioner job to each candidate during the filter
-	// loop so the post-selection code below can read it directly from the
-	// chosen candidate instead of re-querying. The previous code re-fetched
-	// the resource and job for the surviving agent, firing the
-	// resource->job->build->workspace dbauthz cascade twice and saturating
-	// the pgx pool under load.
+	// Every rebuild of a workspace inserts new workspace_agents rows that
+	// keep the original auth_instance_id, so historical agents accumulate
+	// on long-lived instances. Restrict candidates to agents whose build
+	// is still the latest for their workspace; stale agents from prior
+	// builds must not authenticate (and would otherwise spuriously trip
+	// the multi-agent ambiguity branch below). Pre-v2.33 the SQL query
+	// masked this with ORDER BY created_at DESC LIMIT 1; the move to
+	// :many to support multi-agent templates (#24325) removed that mask.
+	//
+	// This also subsumes the "instance ID recycled across workspaces"
+	// guard the post-selection code used to perform: a recycled instance
+	// only survives the filter if it points at the current build of its
+	// current workspace.
+	//
+	// We attach the provisioner job and workspace build to each candidate
+	// during the filter loop so the post-selection code below can read
+	// them directly instead of re-querying.
 	type instanceCandidate struct {
-		agent database.WorkspaceAgent
-		job   database.ProvisionerJob
+		agent          database.WorkspaceAgent
+		job            database.ProvisionerJob
+		workspaceBuild database.WorkspaceBuild
 	}
 	buildCandidates := make([]instanceCandidate, 0, len(agents))
+	// Cache the latest build per workspace so an instance ID shared across
+	// many stale agents on the same workspace only triggers one lookup.
+	latestBuildByWorkspace := make(map[uuid.UUID]uuid.UUID)
 	for _, candidate := range agents {
 		resource, err := api.Database.GetWorkspaceResourceByID(systemCtx, candidate.ResourceID)
 		if err != nil {
@@ -177,12 +192,46 @@ func (api *API) handleAuthInstanceID(rw http.ResponseWriter, r *http.Request, in
 			})
 			return
 		}
-		if job.Type == database.ProvisionerJobTypeWorkspaceBuild {
-			buildCandidates = append(buildCandidates, instanceCandidate{
-				agent: candidate,
-				job:   job,
-			})
+		if job.Type != database.ProvisionerJobTypeWorkspaceBuild {
+			continue
 		}
+		var jobData provisionerdserver.WorkspaceProvisionJob
+		if err := json.Unmarshal(job.Input, &jobData); err != nil {
+			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+				Message: "Internal error extracting job data.",
+				Detail:  err.Error(),
+			})
+			return
+		}
+		workspaceBuild, err := api.Database.GetWorkspaceBuildByID(systemCtx, jobData.WorkspaceBuildID)
+		if err != nil {
+			httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+				Message: "Internal error fetching workspace build.",
+				Detail:  err.Error(),
+			})
+			return
+		}
+		latestBuildID, ok := latestBuildByWorkspace[workspaceBuild.WorkspaceID]
+		if !ok {
+			latest, err := api.Database.GetLatestWorkspaceBuildByWorkspaceID(systemCtx, workspaceBuild.WorkspaceID)
+			if err != nil {
+				httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+					Message: "Internal error fetching the latest workspace build.",
+					Detail:  err.Error(),
+				})
+				return
+			}
+			latestBuildID = latest.ID
+			latestBuildByWorkspace[workspaceBuild.WorkspaceID] = latestBuildID
+		}
+		if latestBuildID != workspaceBuild.ID {
+			continue
+		}
+		buildCandidates = append(buildCandidates, instanceCandidate{
+			agent:          candidate,
+			job:            job,
+			workspaceBuild: workspaceBuild,
+		})
 	}
 	if len(buildCandidates) == 0 {
 		httpapi.Write(ctx, rw, http.StatusNotFound, codersdk.Response{
@@ -227,44 +276,10 @@ func (api *API) handleAuthInstanceID(rw http.ResponseWriter, r *http.Request, in
 		}
 		selected = buildCandidates[0]
 	}
-	agent := selected.agent
-	job := selected.job
-	var jobData provisionerdserver.WorkspaceProvisionJob
-	err = json.Unmarshal(job.Input, &jobData)
-	if err != nil {
-		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-			Message: "Internal error extracting job data.",
-			Detail:  err.Error(),
-		})
-		return
-	}
-	resourceHistory, err := api.Database.GetWorkspaceBuildByID(systemCtx, jobData.WorkspaceBuildID)
-	if err != nil {
-		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-			Message: "Internal error fetching workspace build.",
-			Detail:  err.Error(),
-		})
-		return
-	}
-	// This token should only be exchanged if the instance ID is valid
-	// for the latest history. If an instance ID is recycled by a cloud,
-	// we'd hate to leak access to a user's workspace.
-	latestHistory, err := api.Database.GetLatestWorkspaceBuildByWorkspaceID(systemCtx, resourceHistory.WorkspaceID)
-	if err != nil {
-		httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
-			Message: "Internal error fetching the latest workspace build.",
-			Detail:  err.Error(),
-		})
-		return
-	}
-	if latestHistory.ID != resourceHistory.ID {
-		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
-			Message: fmt.Sprintf("Resource found for id %q, but isn't registered on the latest history.", instanceID),
-		})
-		return
-	}
-
+	// Recycled-instance protection and stale-build rejection were applied
+	// during candidate filtering: selected.workspaceBuild is the latest
+	// build of its workspace, so we can issue the session token directly.
 	httpapi.Write(ctx, rw, http.StatusOK, agentsdk.AuthenticateResponse{
-		SessionToken: agent.AuthToken.String(),
+		SessionToken: selected.agent.AuthToken.String(),
 	})
 }

--- a/coderd/workspaceresourceauth_test.go
+++ b/coderd/workspaceresourceauth_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/coder/coder/v2/coderd/coderdtest"
@@ -283,6 +284,70 @@ func TestPostWorkspaceAuthAWSInstanceIdentity(t *testing.T) {
 		err := agentClient.RefreshToken(ctx)
 		require.NoError(t, err)
 		require.Equal(t, rootAgent.AuthToken.String(), agentClient.SDK.SessionToken())
+	})
+
+	// Rebuilding a workspace inserts a new workspace_agents row that
+	// keeps the original auth_instance_id, so historical agents
+	// accumulate on long-lived instances. The latest build's agent
+	// should authenticate; agents bound to prior builds must be
+	// excluded from the candidate set so a single live agent is not
+	// misreported as multi-agent ambiguity.
+	t.Run("Ambiguous/PriorBuildAgentsExcluded", func(t *testing.T) {
+		t.Parallel()
+
+		instanceID := newTestInstanceID(t)
+		certificates, metadataClient := coderdtest.NewAWSInstanceIdentity(t, instanceID)
+		client, store := setupInstanceIDWorkspace(t, &coderdtest.Options{
+			AWSCertificates: certificates,
+		}, workspaceAgentsForInstanceID(instanceID, "dev"))
+
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+		defer cancel()
+		sysCtx := dbauthz.AsSystemRestricted(ctx)
+
+		// Walk from the first agent back to its workspace.
+		staleAgent := requireWorkspaceAgentByInstanceIDAndName(t, store, instanceID, "dev")
+		staleResource, err := store.GetWorkspaceResourceByID(sysCtx, staleAgent.ResourceID)
+		require.NoError(t, err)
+		firstBuild, err := store.GetWorkspaceBuildByJobID(sysCtx, staleResource.JobID)
+		require.NoError(t, err)
+		workspace, err := client.Workspace(ctx, firstBuild.WorkspaceID)
+		require.NoError(t, err)
+
+		// Stop then restart so the workspace ends on a fresh Start build
+		// with a brand-new agent reusing the same instance ID.
+		stopBuild := coderdtest.CreateWorkspaceBuild(t, client, workspace, database.WorkspaceTransitionStop)
+		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, stopBuild.ID)
+		startBuild := coderdtest.CreateWorkspaceBuild(t, client, workspace, database.WorkspaceTransitionStart)
+		coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, startBuild.ID)
+
+		// More than one agent now shares the instance ID: every workspace
+		// build of this template echoes the same agent definition, so the
+		// original Start build's agent plus every subsequent build's agent
+		// all carry the same auth_instance_id. Without the latest-build
+		// filter the handler would treat this as multi-agent ambiguity and
+		// 409.
+		allAgents, err := store.GetWorkspaceAgentsByInstanceID(sysCtx, instanceID)
+		require.NoError(t, err)
+		require.Greater(t, len(allAgents), 1, "expected stale and fresh agents to share the instance ID")
+
+		latestBuild, err := store.GetLatestWorkspaceBuildByWorkspaceID(sysCtx, workspace.ID)
+		require.NoError(t, err)
+		latestResources, err := store.GetWorkspaceResourcesByJobID(sysCtx, latestBuild.JobID)
+		require.NoError(t, err)
+		require.NotEmpty(t, latestResources)
+		latestAgents, err := store.GetWorkspaceAgentsByResourceIDs(sysCtx, []uuid.UUID{latestResources[0].ID})
+		require.NoError(t, err)
+		require.Len(t, latestAgents, 1)
+		freshAgent := latestAgents[0]
+		require.NotEqual(t, staleAgent.ID, freshAgent.ID)
+
+		agentClient := agentsdk.New(client.URL, agentsdk.WithAWSInstanceIdentity())
+		agentClient.SDK.HTTPClient = metadataClient
+
+		err = agentClient.RefreshToken(ctx)
+		require.NoError(t, err)
+		require.Equal(t, freshAgent.AuthToken.String(), agentClient.SDK.SessionToken())
 	})
 }
 


### PR DESCRIPTION
Closes #25157

## Summary

Restrict instance-identity agent auth candidates to agents whose workspace build is the latest build of their workspace. Stale `workspace_agents` rows bound to prior builds no longer trip the multi-agent ambiguity check, so workspaces with a single live agent authenticate without `CODER_AGENT_NAME`.

## Problem

#24325 changed `GetWorkspaceAgentByInstanceID` (`:one` with `ORDER BY created_at DESC`) to `GetWorkspaceAgentsByInstanceID` (`:many`) to support multi-agent templates. Every rebuild inserts a new `workspace_agents` row that keeps the original `auth_instance_id`, so on long-lived instances every historical agent comes back. `handleAuthInstanceID` then sees N>1 candidates and 409s with `Multiple agents found with instance ID...`. The agent retries on the 409 and each retry fans out N candidate lookups, putting sustained pressure on the pgx pool. #24973 (backported as #24982) cut the dbauthz cascade for system callers but did not fix the underlying stale-candidate set.

## Fix

`coderd/workspaceresourceauth.go` candidate loop now resolves each candidate's `workspace_build` and rejects any whose build is not the latest for its workspace. The latest build per workspace is memoized inside the loop, so a single auth call only fans out once per workspace regardless of how many stale rows share the instance ID.

Multi-agent shared-instance templates still work because their agents all belong to the same (current) build and survive the filter together. The post-selection `GetWorkspaceBuildByID` + `GetLatestWorkspaceBuildByWorkspaceID` block that guarded against instance-ID recycling is removed — the filter establishes the same invariant up front, and the build is now carried on `instanceCandidate` so the chosen agent's data is already in hand.

## Test coverage

Adds `TestPostWorkspaceAuthAWSInstanceIdentity/Ambiguous/PriorBuildAgentsExcluded`:

1. Create a workspace with a single agent named `dev`.
2. Stop and restart the workspace to produce a fresh build with a new `workspace_agents` row carrying the same `auth_instance_id`.
3. Confirm `GetWorkspaceAgentsByInstanceID` returns more than one row (the stale-candidate scenario).
4. Hit instance-identity auth with no `CODER_AGENT_NAME` and assert the returned session token belongs to the fresh agent.

Verified failure on `main` and pass with this change. Existing `Ambiguous/*` subtests still pass, including `Ambiguous/MultipleAgentsNoSelector` (legitimate same-build multi-agent still 409s appropriately) and `Ambiguous/MultipleAgentsWithSelector` (`CODER_AGENT_NAME` still selects).