### PR TITLE
test(agent): bound session.Wait in TestAgent_Session_TTY_QuietLogin/Hushlogin

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -977,8 +977,17 @@ func TestAgent_Session_TTY_QuietLogin(t *testing.T) {
 		require.NoError(t, err)
 
 		ptty.WriteLine("exit 0")
-		err = session.Wait()
-		require.NoError(t, err)
+
+		waitErr := make(chan error, 1)
+		go func() {
+			waitErr <- session.Wait()
+		}()
+		select {
+		case err = <-waitErr:
+			require.NoError(t, err)
+		case <-time.After(testutil.WaitLong):
+			require.Fail(t, "timed out waiting for session to exit")
+		}
 
 		require.NotContains(t, stdout.String(), wantNotMOTD, "should not show motd")
 		require.Contains(t, stdout.String(), wantMaybeServiceBanner, "should show service banner")


### PR DESCRIPTION
Under -race, the SSH session occasionally hangs on Wait(). Without a bound, the 20m go-test alarm fires and every parallel test in ./agent is reported as FAIL (unknown), hiding the real culprit.

This change was generated by Coder Agents on behalf of @zedkipp.

Note that this doesn't fix the root cause, but makes this test fail faster and the logs clearer about what actually happened.