### PR TITLE
chore(dogfood): use default rustup profile

### DIFF
--- a/dogfood/coder/ubuntu-22.04/Dockerfile
+++ b/dogfood/coder/ubuntu-22.04/Dockerfile
@@ -205,7 +205,7 @@ RUN chmod a+x /usr/local/bin/configure-chrome-flags.sh && \
 ENV RUSTUP_HOME=/usr/local/rustup \
 	CARGO_HOME=/usr/local/cargo
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
-	sh -s -- -y --default-toolchain stable --profile minimal
+	sh -s -- -y --default-toolchain stable --profile default
 ENV PATH=$CARGO_HOME/bin:$PATH
 
 # NOTE: In scripts/Dockerfile.base we specifically install Terraform version 1.15.2.

--- a/dogfood/coder/ubuntu-26.04/Dockerfile
+++ b/dogfood/coder/ubuntu-26.04/Dockerfile
@@ -212,7 +212,7 @@ RUN chmod a+x /opt/configure-chrome-flags.sh && \
 ENV RUSTUP_HOME=/usr/local/rustup \
 	CARGO_HOME=/usr/local/cargo
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
-	sh -s -- -y --default-toolchain stable --profile minimal
+	sh -s -- -y --default-toolchain stable --profile default
 ENV PATH=$CARGO_HOME/bin:$PATH
 
 # NOTE: In scripts/Dockerfile.base we specifically install Terraform version 1.15.2.


### PR DESCRIPTION
Switches the dogfood Dockerfiles from `--profile minimal` to `--profile default` when installing Rust via rustup. This pulls in the standard component set (notably `rustfmt` and `clippy`) so cargo workflows just work out of the box.

> Made with :cherry_blossom: by Coder Agents.