### PR TITLE
feat: report synthetic metadata from fake agents

### DIFF
--- a/enterprise/cli/exp_scaletest_agentfake.go
+++ b/enterprise/cli/exp_scaletest_agentfake.go
@@ -68,7 +68,7 @@ func (r *RootCmd) scaletestAgentFake() *serpent.Command {
 			}
 
 			logger := inv.Logger
-			mgr := agentfake.NewManager(client, logger, agentfake.ManagerOptions{
+			mgr := agentfake.NewManager(client.URL, client, logger, agentfake.ManagerOptions{
 				Template: template,
 				Owner:    owner,
 			})

--- a/enterprise/scaletest/agentfake/agent.go
+++ b/enterprise/scaletest/agentfake/agent.go
@@ -13,6 +13,7 @@ import (
 	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/agent/proto"
 	"github.com/coder/coder/v2/codersdk/agentsdk"
+	"github.com/coder/quartz"
 )
 
 const (
@@ -40,16 +41,35 @@ type Agent struct {
 	coderURL *url.URL
 	token    string
 	logger   slog.Logger
+	clock    quartz.Clock
 
 	cancel context.CancelFunc
 }
 
-func NewAgent(coderURL *url.URL, token string, logger slog.Logger) *Agent {
-	return &Agent{
+// Option configures an Agent.
+type Option func(*Agent)
+
+// WithClock injects a clock for time-based operations. Defaults to
+// quartz.NewReal(). Tests pass a *quartz.Mock to drive the metadata
+// loop deterministically. The clock is per-agent so a future caller
+// can give different agents slightly different cadences.
+func WithClock(c quartz.Clock) Option {
+	return func(a *Agent) {
+		a.clock = c
+	}
+}
+
+func NewAgent(coderURL *url.URL, token string, logger slog.Logger, opts ...Option) *Agent {
+	a := &Agent{
 		coderURL: coderURL,
 		token:    token,
 		logger:   logger,
+		clock:    quartz.NewReal(),
 	}
+	for _, opt := range opts {
+		opt(a)
+	}
+	return a
 }
 
 // Run opens a dRPC websocket to coderd as the "agent" role and keeps it open until ctx is canceled or Close is called.
@@ -72,10 +92,12 @@ func (a *Agent) Run(ctx context.Context) error {
 			a.logger.Warn(runCtx, "fake agent dRPC stream ended; reconnecting",
 				slog.Error(err))
 		}
+		timer := a.clock.NewTimer(reconnectBackoff, "agentfake", "reconnect")
 		select {
 		case <-runCtx.Done():
+			timer.Stop()
 			return nil
-		case <-time.After(reconnectBackoff):
+		case <-timer.C:
 		}
 	}
 }
@@ -146,7 +168,7 @@ func (a *Agent) runMetadata(ctx context.Context, rpc proto.DRPCAgentClient28, de
 	// the first tick fires every description.
 	intervals := make([]time.Duration, len(descs))
 	nextDue := make([]time.Time, len(descs))
-	now := time.Now()
+	now := a.clock.Now()
 	for i, d := range descs {
 		// The Interval field on the proto is a durationpb.Duration but
 		// carries the raw int64 seconds value cast through time.Duration
@@ -164,10 +186,10 @@ func (a *Agent) runMetadata(ctx context.Context, rpc proto.DRPCAgentClient28, de
 
 	// Per-agent RNG so we don't contend on the global math/rand mutex
 	// when many fake agents run in the same process.
-	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	rng := rand.New(rand.NewSource(a.clock.Now().UnixNano()))
 	buf := make([]byte, metadataValueBytes)
 
-	ticker := time.NewTicker(metadataTickInterval)
+	ticker := a.clock.NewTicker(metadataTickInterval, "agentfake", "runMetadata")
 	defer ticker.Stop()
 
 	for {

--- a/enterprise/scaletest/agentfake/agent.go
+++ b/enterprise/scaletest/agentfake/agent.go
@@ -14,8 +14,19 @@ import (
 	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/agent/proto"
 	"github.com/coder/coder/v2/codersdk/agentsdk"
+	tailnetproto "github.com/coder/coder/v2/tailnet/proto"
 	"github.com/coder/quartz"
 )
+
+// rpcDialer is the subset of agentsdk.Client agentfake uses. Defined
+// locally so tests can plug in *agent/agenttest.Client (or any other
+// test double) without depending on the rest of the agentsdk.Client
+// surface.
+type rpcDialer interface {
+	ConnectRPC29WithRole(ctx context.Context, role string) (
+		proto.DRPCAgentClient29, tailnetproto.DRPCTailnetClient28, error,
+	)
+}
 
 const (
 	reconnectBackoff = 1 * time.Second
@@ -43,6 +54,7 @@ type Agent struct {
 	token    string
 	logger   slog.Logger
 	clock    quartz.Clock
+	dialer   rpcDialer // nil → built from coderURL+token in Run
 
 	cancel context.CancelFunc
 }
@@ -57,6 +69,16 @@ type Option func(*Agent)
 func WithClock(c quartz.Clock) Option {
 	return func(a *Agent) {
 		a.clock = c
+	}
+}
+
+// WithDialer injects a custom RPC dialer. Defaults to a real
+// agentsdk.Client built from coderURL + token. Tests use this to
+// substitute *agent/agenttest.Client and avoid standing up a real
+// coderd.
+func WithDialer(d rpcDialer) Option {
+	return func(a *Agent) {
+		a.dialer = d
 	}
 }
 
@@ -83,7 +105,10 @@ func (a *Agent) Run(ctx context.Context) error {
 	a.cancel = cancel
 	defer a.cancel()
 
-	client := agentsdk.New(a.coderURL, agentsdk.WithFixedToken(a.token))
+	client := a.dialer
+	if client == nil {
+		client = agentsdk.New(a.coderURL, agentsdk.WithFixedToken(a.token))
+	}
 	for {
 		if err := runCtx.Err(); err != nil {
 			return nil
@@ -105,8 +130,8 @@ func (a *Agent) Run(ctx context.Context) error {
 
 // connectAndServe opens one dRPC websocket, announces lifecycle = READY, then blocks until ctx is canceled or the
 // connection is closed by either side. Returns the underlying error, if any.
-func (a *Agent) connectAndServe(ctx context.Context, client *agentsdk.Client) error {
-	rpc, _, err := client.ConnectRPC28WithRole(ctx, "agent")
+func (a *Agent) connectAndServe(ctx context.Context, client rpcDialer) error {
+	rpc, _, err := client.ConnectRPC29WithRole(ctx, "agent")
 	if err != nil {
 		return xerrors.Errorf("connect dRPC: %w", err)
 	}
@@ -179,7 +204,7 @@ func (a *Agent) connectAndServe(ctx context.Context, client *agentsdk.Client) er
 // Errors from BatchUpdateMetadata are logged and ignored. Tearing the
 // connection down over a metadata RPC blip would be wasteful; real agents
 // behave the same way (see agent.reportMetadata).
-func (a *Agent) runMetadata(ctx context.Context, rpc proto.DRPCAgentClient28, workspaceID uuid.UUID, descs []*proto.WorkspaceAgentMetadata_Description) {
+func (a *Agent) runMetadata(ctx context.Context, rpc proto.DRPCAgentClient29, workspaceID uuid.UUID, descs []*proto.WorkspaceAgentMetadata_Description) {
 	// Resolve declared intervals once, applying a floor so a malformed
 	// manifest can't spin us. Initialize all keys as immediately due so
 	// the first tick fires every description.

--- a/enterprise/scaletest/agentfake/agent.go
+++ b/enterprise/scaletest/agentfake/agent.go
@@ -2,6 +2,8 @@ package agentfake
 
 import (
 	"context"
+	"encoding/base64"
+	"math/rand"
 	"net/url"
 	"time"
 
@@ -13,7 +15,25 @@ import (
 	"github.com/coder/coder/v2/codersdk/agentsdk"
 )
 
-const reconnectBackoff = 1 * time.Second
+const (
+	reconnectBackoff = 1 * time.Second
+
+	// metadataTickInterval is the scheduler pulse for the per-agent metadata
+	// goroutine. Per-description cadence is enforced by tracking next-due
+	// timestamps; the ticker just wakes us up often enough to honor the
+	// shortest interval we expect (1s).
+	metadataTickInterval = 1 * time.Second
+
+	// metadataValueBytes matches the payload size produced by the real
+	// scaletest template's metadata script (`dd if=/dev/urandom bs=3072
+	// count=1 | base64`), so the synthetic load shape on the wire mirrors
+	// what a real agent emits.
+	metadataValueBytes = 3072
+
+	// metadataMinInterval is a floor applied to manifest-declared intervals
+	// to guard against a malformed manifest pinning the goroutine.
+	metadataMinInterval = 1 * time.Second
+)
 
 // Agent is a single fake agent. It owns one workspace-agent auth token and one dRPC connection to coderd.
 type Agent struct {
@@ -87,11 +107,102 @@ func (a *Agent) connectAndServe(ctx context.Context, client *agentsdk.Client) er
 			slog.Error(err))
 	}
 
+	// Fetch the agent manifest so we know which metadata descriptions the
+	// template declared. We synthesize values for each declared key at the
+	// declared interval. Failure here is non-fatal: a manifest fetch
+	// hiccup shouldn't tear the connection down, we just skip metadata
+	// for this session and let the next reconnect retry.
+	manifest, err := rpc.GetManifest(ctx, &proto.GetManifestRequest{})
+	if err != nil {
+		if ctx.Err() == nil {
+			a.logger.Warn(ctx, "get manifest for metadata", slog.Error(err))
+		}
+	} else if descs := manifest.GetMetadata(); len(descs) > 0 {
+		go a.runMetadata(ctx, rpc, descs)
+	}
+
 	select {
 	case <-ctx.Done():
 		return nil
 	case <-conn.Closed():
 		return xerrors.New("dRPC connection closed by remote")
+	}
+}
+
+// runMetadata sends synthetic values for every metadata description in the
+// agent manifest, batching per-tick into a single BatchUpdateMetadata call.
+//
+// One goroutine per agent (not per description): a 1s ticker pulses and we
+// track per-description next-due timestamps so each key reports at its own
+// declared interval. The goroutine is scoped to the connection's ctx; on
+// disconnect or shutdown it exits cleanly.
+//
+// Errors from BatchUpdateMetadata are logged and ignored. Tearing the
+// connection down over a metadata RPC blip would be wasteful; real agents
+// behave the same way (see agent.reportMetadata).
+func (a *Agent) runMetadata(ctx context.Context, rpc proto.DRPCAgentClient28, descs []*proto.WorkspaceAgentMetadata_Description) {
+	// Resolve declared intervals once, applying a floor so a malformed
+	// manifest can't spin us. Initialize all keys as immediately due so
+	// the first tick fires every description.
+	intervals := make([]time.Duration, len(descs))
+	nextDue := make([]time.Time, len(descs))
+	now := time.Now()
+	for i, d := range descs {
+		// The Interval field on the proto is a durationpb.Duration but
+		// carries the raw int64 seconds value cast through time.Duration
+		// (see coderd/agentapi/manifest.go and agent/agent.go). Mirror the
+		// same recovery the real agent does so manifest-declared intervals
+		// of e.g. 10s are honored as 10s, not 10ns.
+		intervalSeconds := int64(d.GetInterval().AsDuration())
+		interval := time.Duration(intervalSeconds) * time.Second
+		if interval < metadataMinInterval {
+			interval = metadataMinInterval
+		}
+		intervals[i] = interval
+		nextDue[i] = now
+	}
+
+	// Per-agent RNG so we don't contend on the global math/rand mutex
+	// when many fake agents run in the same process.
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	buf := make([]byte, metadataValueBytes)
+
+	ticker := time.NewTicker(metadataTickInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-ticker.C:
+			var batch []*proto.Metadata
+			for i, d := range descs {
+				if now.Before(nextDue[i]) {
+					continue
+				}
+				// Regenerate per entry so each value varies on the wire;
+				// matches what the real `dd | base64` script produces.
+				_, _ = rng.Read(buf)
+				value := base64.StdEncoding.EncodeToString(buf)
+				batch = append(batch, &proto.Metadata{
+					Key: d.GetKey(),
+					Result: &proto.WorkspaceAgentMetadata_Result{
+						CollectedAt: timestamppb.New(now),
+						Value:       value,
+					},
+				})
+				nextDue[i] = now.Add(intervals[i])
+			}
+			if len(batch) == 0 {
+				continue
+			}
+			if _, err := rpc.BatchUpdateMetadata(ctx, &proto.BatchUpdateMetadataRequest{
+				Metadata: batch,
+			}); err != nil && ctx.Err() == nil {
+				a.logger.Debug(ctx, "batch update metadata failed",
+					slog.Error(err))
+			}
+		}
 	}
 }
 

--- a/enterprise/scaletest/agentfake/agent.go
+++ b/enterprise/scaletest/agentfake/agent.go
@@ -3,10 +3,11 @@ package agentfake
 import (
 	"context"
 	"encoding/base64"
-	"math/rand"
 	"net/url"
+	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"golang.org/x/xerrors"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -140,7 +141,17 @@ func (a *Agent) connectAndServe(ctx context.Context, client *agentsdk.Client) er
 			a.logger.Warn(ctx, "get manifest for metadata", slog.Error(err))
 		}
 	} else if descs := manifest.GetMetadata(); len(descs) > 0 {
-		go a.runMetadata(ctx, rpc, descs)
+		// Parse the workspace ID out of the manifest so we can embed it
+		// in the synthetic metadata payload below. If the manifest bytes
+		// are malformed (shouldn't happen in practice), fall back to
+		// uuid.Nil; the payload is still valid, just less identifiable.
+		workspaceID, idErr := uuid.FromBytes(manifest.GetWorkspaceId())
+		if idErr != nil && ctx.Err() == nil {
+			a.logger.Warn(ctx, "parse workspace id from manifest; metadata payload will use uuid.Nil",
+				slog.Error(idErr))
+			workspaceID = uuid.Nil
+		}
+		go a.runMetadata(ctx, rpc, workspaceID, descs)
 	}
 
 	select {
@@ -159,10 +170,16 @@ func (a *Agent) connectAndServe(ctx context.Context, client *agentsdk.Client) er
 // declared interval. The goroutine is scoped to the connection's ctx; on
 // disconnect or shutdown it exits cleanly.
 //
+// The payload is a single fixed value, computed once: the workspace ID
+// prepended to a constant padding so each metadata row in scaletest logs
+// and the database is traceable back to the agent that emitted it. We
+// intentionally do not vary the value per key or per tick; if a future
+// scenario requires per-key/per-tick variation we can extend this then.
+//
 // Errors from BatchUpdateMetadata are logged and ignored. Tearing the
 // connection down over a metadata RPC blip would be wasteful; real agents
 // behave the same way (see agent.reportMetadata).
-func (a *Agent) runMetadata(ctx context.Context, rpc proto.DRPCAgentClient28, descs []*proto.WorkspaceAgentMetadata_Description) {
+func (a *Agent) runMetadata(ctx context.Context, rpc proto.DRPCAgentClient28, workspaceID uuid.UUID, descs []*proto.WorkspaceAgentMetadata_Description) {
 	// Resolve declared intervals once, applying a floor so a malformed
 	// manifest can't spin us. Initialize all keys as immediately due so
 	// the first tick fires every description.
@@ -184,13 +201,22 @@ func (a *Agent) runMetadata(ctx context.Context, rpc proto.DRPCAgentClient28, de
 		nextDue[i] = now
 	}
 
-	// Per-agent RNG so we don't contend on the global math/rand mutex
-	// when many fake agents run in the same process. Weak randomness is
-	// fine here since we are generating synthetic scaletest metadata, not
-	// security-sensitive values.
-	//nolint:gosec
-	rng := rand.New(rand.NewSource(a.clock.Now().UnixNano()))
-	buf := make([]byte, metadataValueBytes)
+	// Build the metadata payload once: prepend the workspace ID so
+	// scaletest log lines and DB rows are traceable back to the
+	// emitting agent, then pad out to metadataValueBytes so the wire
+	// shape (base64-encoded ~4096 chars) mirrors the real scaletest
+	// template's `dd if=/dev/urandom bs=3072 count=1 | base64` output.
+	// coderd truncates the stored value to 2048 chars (see
+	// coderd/agentapi/metadata.go maxValueLen), and the workspace ID
+	// lives in the first ~50 chars of the base64 output, so it
+	// survives truncation.
+	const tag = "fake-agent-metadata workspace="
+	prefix := tag + workspaceID.String() + " "
+	padLen := metadataValueBytes - len(prefix)
+	if padLen < 0 {
+		padLen = 0
+	}
+	value := base64.StdEncoding.EncodeToString([]byte(prefix + strings.Repeat("a", padLen)))
 
 	ticker := a.clock.NewTicker(metadataTickInterval, "agentfake", "runMetadata")
 	defer ticker.Stop()
@@ -205,10 +231,6 @@ func (a *Agent) runMetadata(ctx context.Context, rpc proto.DRPCAgentClient28, de
 				if now.Before(nextDue[i]) {
 					continue
 				}
-				// Regenerate per entry so each value varies on the wire;
-				// matches what the real `dd | base64` script produces.
-				_, _ = rng.Read(buf)
-				value := base64.StdEncoding.EncodeToString(buf)
 				batch = append(batch, &proto.Metadata{
 					Key: d.GetKey(),
 					Result: &proto.WorkspaceAgentMetadata_Result{

--- a/enterprise/scaletest/agentfake/agent.go
+++ b/enterprise/scaletest/agentfake/agent.go
@@ -218,39 +218,41 @@ func (a *Agent) runMetadata(ctx context.Context, rpc proto.DRPCAgentClient28, wo
 	}
 	value := base64.StdEncoding.EncodeToString([]byte(prefix + strings.Repeat("a", padLen)))
 
-	ticker := a.clock.NewTicker(metadataTickInterval, "agentfake", "runMetadata")
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case now := <-ticker.C:
-			var batch []*proto.Metadata
-			for i, d := range descs {
-				if now.Before(nextDue[i]) {
-					continue
-				}
-				batch = append(batch, &proto.Metadata{
-					Key: d.GetKey(),
-					Result: &proto.WorkspaceAgentMetadata_Result{
-						CollectedAt: timestamppb.New(now),
-						Value:       value,
-					},
-				})
-				nextDue[i] = now.Add(intervals[i])
-			}
-			if len(batch) == 0 {
+	// TickerFunc spawns its own goroutine that ticks until ctx is
+	// done and then stops the underlying ticker. We Wait on the
+	// returned Waiter so that runMetadata (itself running in the
+	// goroutine spawned by connectAndServe) stays alive for the
+	// connection's lifetime, matching the pre-refactor for/select
+	// shape. The Wait error is discarded: ticker exits are expected
+	// (ctx cancellation), and our tick func never returns a non-nil
+	// error of its own.
+	_ = a.clock.TickerFunc(ctx, metadataTickInterval, func() error {
+		now := a.clock.Now()
+		var batch []*proto.Metadata
+		for i, d := range descs {
+			if now.Before(nextDue[i]) {
 				continue
 			}
-			if _, err := rpc.BatchUpdateMetadata(ctx, &proto.BatchUpdateMetadataRequest{
-				Metadata: batch,
-			}); err != nil && ctx.Err() == nil {
-				a.logger.Debug(ctx, "batch update metadata failed",
-					slog.Error(err))
-			}
+			batch = append(batch, &proto.Metadata{
+				Key: d.GetKey(),
+				Result: &proto.WorkspaceAgentMetadata_Result{
+					CollectedAt: timestamppb.New(now),
+					Value:       value,
+				},
+			})
+			nextDue[i] = now.Add(intervals[i])
 		}
-	}
+		if len(batch) == 0 {
+			return nil
+		}
+		if _, err := rpc.BatchUpdateMetadata(ctx, &proto.BatchUpdateMetadataRequest{
+			Metadata: batch,
+		}); err != nil && ctx.Err() == nil {
+			a.logger.Debug(ctx, "batch update metadata failed",
+				slog.Error(err))
+		}
+		return nil
+	}, "agentfake", "runMetadata").Wait()
 }
 
 // Close stops the agent. Safe to call multiple times.

--- a/enterprise/scaletest/agentfake/agent.go
+++ b/enterprise/scaletest/agentfake/agent.go
@@ -185,7 +185,10 @@ func (a *Agent) runMetadata(ctx context.Context, rpc proto.DRPCAgentClient28, de
 	}
 
 	// Per-agent RNG so we don't contend on the global math/rand mutex
-	// when many fake agents run in the same process.
+	// when many fake agents run in the same process. Weak randomness is
+	// fine here since we are generating synthetic scaletest metadata, not
+	// security-sensitive values.
+	//nolint:gosec
 	rng := rand.New(rand.NewSource(a.clock.Now().UnixNano()))
 	buf := make([]byte, metadataValueBytes)
 

--- a/enterprise/scaletest/agentfake/agent_test.go
+++ b/enterprise/scaletest/agentfake/agent_test.go
@@ -11,13 +11,15 @@ import (
 
 	"cdr.dev/slog/v3"
 	"cdr.dev/slog/v3/sloggers/slogtest"
-	"github.com/coder/coder/v2/coderd/agentapi/metadatabatcher"
+	"github.com/coder/coder/v2/agent/agenttest"
+	agentproto "github.com/coder/coder/v2/agent/proto"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbfake"
 	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/codersdk/agentsdk"
 	"github.com/coder/coder/v2/enterprise/scaletest/agentfake"
-	sdkproto "github.com/coder/coder/v2/provisionersdk/proto"
+	"github.com/coder/coder/v2/tailnet"
 	"github.com/coder/coder/v2/testutil"
 	"github.com/coder/quartz"
 )
@@ -83,143 +85,75 @@ func TestAgent_ConnectsAndReachesReady(t *testing.T) {
 
 // Assert that, when the workspace agent manifest declares metadata
 // descriptions, the fake agent sends synthetic values for each key via
-// BatchUpdateMetadata. We verify end-to-end by subscribing to the same SSE
-// watch-metadata endpoint coderd uses to surface metadata in the UI.
+// BatchUpdateMetadata. The test drives the agent against
+// agent/agenttest.Client (an in-process fake of the agent-side coderd
+// API) rather than a real coderd, so the only quartz mock involved is
+// the agentfake clock that drives the metadata ticker.
 func TestAgent_SendsMetadata(t *testing.T) {
 	t.Parallel()
-	ctx := testutil.Context(t, testutil.WaitLong)
+	ctx := testutil.Context(t, testutil.WaitShort)
 
-	// Drive both the fake agent's metadata ticker AND coderd's
-	// metadatabatcher off the same mock clock so we don't wait on
-	// wall-clock time for either. Without this the test takes ~5s
-	// (the batcher's default scheduled flush interval); with it the
-	// test bottoms out at the SSE handler's stdlib 1s ticker.
 	mClock := quartz.NewMock(t)
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
 
-	client, db := coderdtest.NewWithDatabase(t, &coderdtest.Options{
-		Clock: mClock,
-		MetadataBatcherOptions: []metadatabatcher.Option{
-			metadatabatcher.WithClock(mClock),
-			// Shorten the scheduled flush so we don't have to advance
-			// the mock by 5s every time; 100ms is small enough to feel
-			// instant but large enough that we're not racing the agent
-			// tick when we advance below.
-			metadatabatcher.WithInterval(100 * time.Millisecond),
+	agentID := uuid.New()
+	manifest := agentsdk.Manifest{
+		AgentID:     agentID,
+		WorkspaceID: uuid.New(),
+		Metadata: []codersdk.WorkspaceAgentMetadataDescription{
+			{Key: "01_meta", DisplayName: "Meta 01", Script: "noop", Interval: 1, Timeout: 10},
+			{Key: "02_meta", DisplayName: "Meta 02", Script: "noop", Interval: 1, Timeout: 10},
 		},
-	})
-	user := coderdtest.CreateFirstUser(t, client)
-
-	// Declare two metadata descriptions on the workspace agent. Both at
-	// interval=1 so the test budget stays small. The script value is
-	// irrelevant; agentfake never runs it, it synthesizes a value
-	// directly.
-	descs := []*sdkproto.Agent_Metadata{
-		{Key: "01_meta", DisplayName: "Meta 01", Script: "noop", Interval: 1, Timeout: 10},
-		{Key: "02_meta", DisplayName: "Meta 02", Script: "noop", Interval: 1, Timeout: 10},
 	}
 
-	r := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
-		OrganizationID: user.OrganizationID,
-		OwnerID:        user.UserID,
-	}).WithAgent(func(agents []*sdkproto.Agent) []*sdkproto.Agent {
-		agents[0].Metadata = descs
-		return agents
-	}).Do()
+	// statsCh and coord are required by agenttest.NewClient but
+	// unused by agentfake. The dialer is the standin for the real
+	// agentsdk.Client; it records every RPC the agent makes so we
+	// can assert against the metadata batch directly.
+	statsCh := make(chan *agentproto.Stats, 1)
+	coord := tailnet.NewCoordinator(logger)
+	t.Cleanup(func() { _ = coord.Close() })
+	dialer := agenttest.NewClient(t, logger, agentID, manifest, statsCh, coord)
+	t.Cleanup(dialer.Close)
 
-	// dbfake.WorkspaceBuild drives provisionerdserver.InsertWorkspaceResource
-	// under the hood, which inserts the metadata description rows for each
-	// metadata block on the agent. BatchUpdateMetadata's UPDATE will match
-	// the rows that path created. No manual seeding needed.
-	agentID := workspaceAgentID(ctx, t, client, r.Workspace.ID)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
-	a := agentfake.NewAgent(client.URL, r.AgentToken, logger, agentfake.WithClock(mClock))
-	t.Cleanup(func() { a.Close() })
+	a := agentfake.NewAgent(nil, "", logger,
+		agentfake.WithDialer(dialer),
+		agentfake.WithClock(mClock),
+	)
+	t.Cleanup(a.Close)
 
 	// Trap the agent's runMetadata TickerFunc registration so we know
 	// the goroutine is parked on the mock clock before we Advance.
-	// Otherwise Advance could race the goroutine startup and the first
-	// tick would be missed.
+	// Otherwise Advance could race the goroutine startup and the
+	// first tick would be missed.
 	tickerTrap := mClock.Trap().TickerFunc("agentfake", "runMetadata")
 	defer tickerTrap.Close()
 
 	runCtx, cancel := context.WithCancel(ctx)
 	t.Cleanup(cancel)
-
 	runErr := make(chan error, 1)
-	go func() {
-		runErr <- a.Run(runCtx)
-	}()
+	go func() { runErr <- a.Run(runCtx) }()
 
-	coderdtest.NewWorkspaceAgentWaiter(t, client, r.Workspace.ID).
-		WithContext(ctx).
-		Wait()
-
-	// Wait for the agent to register its metadata ticker on the mock,
-	// then release the trapped call so the TickerFunc proceeds.
 	tickerTrap.MustWait(ctx).Release(ctx)
 
-	// Watch metadata via SSE. This exercises the same path coderd uses to
-	// surface metadata in the UI: BatchUpdate -> pubsub flush -> watcher.
-	// We wait for both declared keys to receive a non-empty, validly-encoded
-	// base64 value.
-	watchCtx, watchCancel := context.WithCancel(ctx)
-	t.Cleanup(watchCancel)
-	mdChan, mdErrChan := client.WatchWorkspaceAgentMetadata(watchCtx, agentID)
+	// One tick fires runMetadata's tick func, which calls
+	// BatchUpdateMetadata against agenttest.Client. The fake records
+	// it synchronously in-process; no pubsub, batcher, or SSE involved.
+	mClock.Advance(time.Second).MustWait(ctx)
 
-	// Advance the mock clock past the agent's 1s metadata tick and
-	// the batcher's 100ms scheduled flush. coderd registers other
-	// tickers on this clock too (cache refresh, etc.), so we use
-	// AdvanceNext in a loop to fire the soonest pending event each
-	// iteration until we've covered our 2-second window. This is
-	// robust regardless of which internal timers are registered.
-	target := mClock.Now().Add(2 * time.Second)
-	for mClock.Now().Before(target) {
-		d, w := mClock.AdvanceNext()
-		w.MustWait(ctx)
-		if d == 0 {
-			break
-		}
-	}
-
-	wantKeys := map[string]bool{"01_meta": false, "02_meta": false}
-waitLoop:
-	for {
-		select {
-		case <-ctx.Done():
-			t.Fatalf("timeout waiting for metadata; remaining keys: %v (%v)", wantKeys, ctx.Err())
-		case err := <-mdErrChan:
-			require.NoError(t, err, "metadata watcher errored")
-		case md := <-mdChan:
-			for _, m := range md {
-				if _, want := wantKeys[m.Description.Key]; !want {
-					continue
-				}
-				// coderd truncates the agent-reported value to 2048 chars
-				// (see coderd/agentapi/metadata.go maxValueLen). Our
-				// synthetic payload is larger than that on purpose, so we
-				// only check that we received a non-empty value and that
-				// the surviving chars are valid base64.
-				if m.Result.Value == "" {
-					continue
-				}
-				if _, err := base64.StdEncoding.DecodeString(m.Result.Value); err != nil {
-					continue
-				}
-				wantKeys[m.Description.Key] = true
+	require.Eventually(t, func() bool {
+		md := dialer.GetMetadata()
+		for _, key := range []string{"01_meta", "02_meta"} {
+			m, ok := md[key]
+			if !ok || m.Value == "" {
+				return false
 			}
-			allSeen := true
-			for _, ok := range wantKeys {
-				if !ok {
-					allSeen = false
-					break
-				}
-			}
-			if allSeen {
-				break waitLoop
+			if _, err := base64.StdEncoding.DecodeString(m.Value); err != nil {
+				return false
 			}
 		}
-	}
-	watchCancel()
+		return true
+	}, testutil.WaitShort, testutil.IntervalFast)
 
 	cancel()
 	select {
@@ -228,17 +162,4 @@ waitLoop:
 	case <-ctx.Done():
 		t.Fatalf("timed out waiting for Agent.Run to return: %v", ctx.Err())
 	}
-}
-
-func workspaceAgentID(ctx context.Context, t *testing.T, client *codersdk.Client, workspaceID uuid.UUID) uuid.UUID {
-	t.Helper()
-	ws, err := client.Workspace(ctx, workspaceID)
-	require.NoError(t, err)
-	for _, res := range ws.LatestBuild.Resources {
-		for _, agent := range res.Agents {
-			return agent.ID
-		}
-	}
-	t.Fatalf("no agent on workspace %s", workspaceID)
-	return uuid.Nil
 }

--- a/enterprise/scaletest/agentfake/agent_test.go
+++ b/enterprise/scaletest/agentfake/agent_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/base64"
 	"testing"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -114,7 +113,7 @@ func TestAgent_SendsMetadata(t *testing.T) {
 	agentID := workspaceAgentID(t, ctx, client, r.Workspace.ID)
 	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
 	a := agentfake.NewAgent(client.URL, r.AgentToken, logger)
-	t.Cleanup(func() { _ = a.Close() })
+	t.Cleanup(func() { a.Close() })
 
 	runCtx, cancel := context.WithCancel(ctx)
 	t.Cleanup(cancel)
@@ -137,13 +136,11 @@ func TestAgent_SendsMetadata(t *testing.T) {
 	mdChan, mdErrChan := client.WatchWorkspaceAgentMetadata(watchCtx, agentID)
 
 	wantKeys := map[string]bool{"01_meta": false, "02_meta": false}
-	deadline := time.NewTimer(testutil.WaitLong)
-	defer deadline.Stop()
 waitLoop:
 	for {
 		select {
-		case <-deadline.C:
-			t.Fatalf("timeout waiting for metadata; remaining keys: %v", wantKeys)
+		case <-ctx.Done():
+			t.Fatalf("timeout waiting for metadata; remaining keys: %v (%v)", wantKeys, ctx.Err())
 		case err := <-mdErrChan:
 			require.NoError(t, err, "metadata watcher errored")
 		case md := <-mdChan:

--- a/enterprise/scaletest/agentfake/agent_test.go
+++ b/enterprise/scaletest/agentfake/agent_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"encoding/base64"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
 	"cdr.dev/slog/v3/sloggers/slogtest"
+	"github.com/coder/coder/v2/coderd/agentapi/metadatabatcher"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbfake"
@@ -17,6 +19,7 @@ import (
 	"github.com/coder/coder/v2/enterprise/scaletest/agentfake"
 	sdkproto "github.com/coder/coder/v2/provisionersdk/proto"
 	"github.com/coder/coder/v2/testutil"
+	"github.com/coder/quartz"
 )
 
 // Assert that our fake agent routine establishes the drpc connection and sets its lifecycle status to Ready.
@@ -86,7 +89,24 @@ func TestAgent_SendsMetadata(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.Context(t, testutil.WaitLong)
 
-	client, db := coderdtest.NewWithDatabase(t, nil)
+	// Drive both the fake agent's metadata ticker AND coderd's
+	// metadatabatcher off the same mock clock so we don't wait on
+	// wall-clock time for either. Without this the test takes ~5s
+	// (the batcher's default scheduled flush interval); with it the
+	// test bottoms out at the SSE handler's stdlib 1s ticker.
+	mClock := quartz.NewMock(t)
+
+	client, db := coderdtest.NewWithDatabase(t, &coderdtest.Options{
+		Clock: mClock,
+		MetadataBatcherOptions: []metadatabatcher.Option{
+			metadatabatcher.WithClock(mClock),
+			// Shorten the scheduled flush so we don't have to advance
+			// the mock by 5s every time; 100ms is small enough to feel
+			// instant but large enough that we're not racing the agent
+			// tick when we advance below.
+			metadatabatcher.WithInterval(100 * time.Millisecond),
+		},
+	})
 	user := coderdtest.CreateFirstUser(t, client)
 
 	// Declare two metadata descriptions on the workspace agent. Both at
@@ -112,8 +132,15 @@ func TestAgent_SendsMetadata(t *testing.T) {
 	// the rows that path created. No manual seeding needed.
 	agentID := workspaceAgentID(ctx, t, client, r.Workspace.ID)
 	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
-	a := agentfake.NewAgent(client.URL, r.AgentToken, logger)
+	a := agentfake.NewAgent(client.URL, r.AgentToken, logger, agentfake.WithClock(mClock))
 	t.Cleanup(func() { a.Close() })
+
+	// Trap the agent's runMetadata TickerFunc registration so we know
+	// the goroutine is parked on the mock clock before we Advance.
+	// Otherwise Advance could race the goroutine startup and the first
+	// tick would be missed.
+	tickerTrap := mClock.Trap().TickerFunc("agentfake", "runMetadata")
+	defer tickerTrap.Close()
 
 	runCtx, cancel := context.WithCancel(ctx)
 	t.Cleanup(cancel)
@@ -127,6 +154,10 @@ func TestAgent_SendsMetadata(t *testing.T) {
 		WithContext(ctx).
 		Wait()
 
+	// Wait for the agent to register its metadata ticker on the mock,
+	// then release the trapped call so the TickerFunc proceeds.
+	tickerTrap.MustWait(ctx).Release(ctx)
+
 	// Watch metadata via SSE. This exercises the same path coderd uses to
 	// surface metadata in the UI: BatchUpdate -> pubsub flush -> watcher.
 	// We wait for both declared keys to receive a non-empty, validly-encoded
@@ -134,6 +165,21 @@ func TestAgent_SendsMetadata(t *testing.T) {
 	watchCtx, watchCancel := context.WithCancel(ctx)
 	t.Cleanup(watchCancel)
 	mdChan, mdErrChan := client.WatchWorkspaceAgentMetadata(watchCtx, agentID)
+
+	// Advance the mock clock past the agent's 1s metadata tick and
+	// the batcher's 100ms scheduled flush. coderd registers other
+	// tickers on this clock too (cache refresh, etc.), so we use
+	// AdvanceNext in a loop to fire the soonest pending event each
+	// iteration until we've covered our 2-second window. This is
+	// robust regardless of which internal timers are registered.
+	target := mClock.Now().Add(2 * time.Second)
+	for mClock.Now().Before(target) {
+		d, w := mClock.AdvanceNext()
+		w.MustWait(ctx)
+		if d == 0 {
+			break
+		}
+	}
 
 	wantKeys := map[string]bool{"01_meta": false, "02_meta": false}
 waitLoop:

--- a/enterprise/scaletest/agentfake/agent_test.go
+++ b/enterprise/scaletest/agentfake/agent_test.go
@@ -2,8 +2,11 @@ package agentfake_test
 
 import (
 	"context"
+	"encoding/base64"
 	"testing"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
@@ -13,6 +16,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbfake"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/enterprise/scaletest/agentfake"
+	sdkproto "github.com/coder/coder/v2/provisionersdk/proto"
 	"github.com/coder/coder/v2/testutil"
 )
 
@@ -73,4 +77,125 @@ func TestAgent_ConnectsAndReachesReady(t *testing.T) {
 	// Close is idempotent and safe to call after Run returns.
 	a.Close()
 	a.Close()
+}
+
+// Assert that, when the workspace agent manifest declares metadata
+// descriptions, the fake agent sends synthetic values for each key via
+// BatchUpdateMetadata. We verify end-to-end by subscribing to the same SSE
+// watch-metadata endpoint coderd uses to surface metadata in the UI.
+func TestAgent_SendsMetadata(t *testing.T) {
+	t.Parallel()
+	ctx := testutil.Context(t, testutil.WaitLong)
+
+	client, db := coderdtest.NewWithDatabase(t, nil)
+	user := coderdtest.CreateFirstUser(t, client)
+
+	// Declare two metadata descriptions on the workspace agent. Both at
+	// interval=1 so the test budget stays small. The script value is
+	// irrelevant; agentfake never runs it, it synthesizes a value
+	// directly.
+	descs := []*sdkproto.Agent_Metadata{
+		{Key: "01_meta", DisplayName: "Meta 01", Script: "noop", Interval: 1, Timeout: 10},
+		{Key: "02_meta", DisplayName: "Meta 02", Script: "noop", Interval: 1, Timeout: 10},
+	}
+
+	r := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
+		OrganizationID: user.OrganizationID,
+		OwnerID:        user.UserID,
+	}).WithAgent(func(agents []*sdkproto.Agent) []*sdkproto.Agent {
+		agents[0].Metadata = descs
+		return agents
+	}).Do()
+
+	// dbfake.WorkspaceBuild drives provisionerdserver.InsertWorkspaceResource
+	// under the hood, which inserts the metadata description rows for each
+	// metadata block on the agent. BatchUpdateMetadata's UPDATE will match
+	// the rows that path created. No manual seeding needed.
+	agentID := workspaceAgentID(t, ctx, client, r.Workspace.ID)
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	a := agentfake.NewAgent(client.URL, r.AgentToken, logger)
+	t.Cleanup(func() { _ = a.Close() })
+
+	runCtx, cancel := context.WithCancel(ctx)
+	t.Cleanup(cancel)
+
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- a.Run(runCtx)
+	}()
+
+	coderdtest.NewWorkspaceAgentWaiter(t, client, r.Workspace.ID).
+		WithContext(ctx).
+		Wait()
+
+	// Watch metadata via SSE. This exercises the same path coderd uses to
+	// surface metadata in the UI: BatchUpdate -> pubsub flush -> watcher.
+	// We wait for both declared keys to receive a non-empty, validly-encoded
+	// base64 value.
+	watchCtx, watchCancel := context.WithCancel(ctx)
+	t.Cleanup(watchCancel)
+	mdChan, mdErrChan := client.WatchWorkspaceAgentMetadata(watchCtx, agentID)
+
+	wantKeys := map[string]bool{"01_meta": false, "02_meta": false}
+	deadline := time.NewTimer(testutil.WaitLong)
+	defer deadline.Stop()
+waitLoop:
+	for {
+		select {
+		case <-deadline.C:
+			t.Fatalf("timeout waiting for metadata; remaining keys: %v", wantKeys)
+		case err := <-mdErrChan:
+			require.NoError(t, err, "metadata watcher errored")
+		case md := <-mdChan:
+			for _, m := range md {
+				if _, want := wantKeys[m.Description.Key]; !want {
+					continue
+				}
+				// coderd truncates the agent-reported value to 2048 chars
+				// (see coderd/agentapi/metadata.go maxValueLen). Our
+				// synthetic payload is larger than that on purpose, so we
+				// only check that we received a non-empty value and that
+				// the surviving chars are valid base64.
+				if m.Result.Value == "" {
+					continue
+				}
+				if _, err := base64.StdEncoding.DecodeString(m.Result.Value); err != nil {
+					continue
+				}
+				wantKeys[m.Description.Key] = true
+			}
+			allSeen := true
+			for _, ok := range wantKeys {
+				if !ok {
+					allSeen = false
+					break
+				}
+			}
+			if allSeen {
+				break waitLoop
+			}
+		}
+	}
+	watchCancel()
+
+	cancel()
+	select {
+	case err := <-runErr:
+		require.NoError(t, err, "Agent.Run returned unexpected error")
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for Agent.Run to return: %v", ctx.Err())
+	}
+}
+
+func workspaceAgentID(t *testing.T, ctx context.Context, client *codersdk.Client, workspaceID uuid.UUID) uuid.UUID {
+	t.Helper()
+	ws, err := client.Workspace(ctx, workspaceID)
+	require.NoError(t, err)
+	for _, res := range ws.LatestBuild.Resources {
+		for _, agent := range res.Agents {
+			return agent.ID
+		}
+	}
+	t.Fatalf("no agent on workspace %s", workspaceID)
+	return uuid.Nil
 }

--- a/enterprise/scaletest/agentfake/agent_test.go
+++ b/enterprise/scaletest/agentfake/agent_test.go
@@ -13,9 +13,6 @@ import (
 	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/agent/agenttest"
 	agentproto "github.com/coder/coder/v2/agent/proto"
-	"github.com/coder/coder/v2/coderd/coderdtest"
-	"github.com/coder/coder/v2/coderd/database"
-	"github.com/coder/coder/v2/coderd/database/dbfake"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/agentsdk"
 	"github.com/coder/coder/v2/enterprise/scaletest/agentfake"
@@ -27,47 +24,40 @@ import (
 // Assert that our fake agent routine establishes the drpc connection and sets its lifecycle status to Ready.
 func TestAgent_ConnectsAndReachesReady(t *testing.T) {
 	t.Parallel()
-	ctx := testutil.Context(t, testutil.WaitLong)
-
-	client, db := coderdtest.NewWithDatabase(t, nil)
-	user := coderdtest.CreateFirstUser(t, client)
-
-	r := dbfake.WorkspaceBuild(t, db, database.WorkspaceTable{
-		OrganizationID: user.OrganizationID,
-		OwnerID:        user.UserID,
-	}).WithAgent().Do()
+	ctx := testutil.Context(t, testutil.WaitShort)
 
 	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
-	a := agentfake.NewAgent(client.URL, r.AgentToken, logger)
-	t.Cleanup(func() { a.Close() })
+	agentID := uuid.New()
+	manifest := agentsdk.Manifest{
+		AgentID:     agentID,
+		WorkspaceID: uuid.New(),
+	}
+	statsCh := make(chan *agentproto.Stats, 1)
+	coord := tailnet.NewCoordinator(logger)
+	t.Cleanup(func() { _ = coord.Close() })
+	dialer := agenttest.NewClient(t, logger, agentID, manifest, statsCh, coord)
+	t.Cleanup(dialer.Close)
+
+	a := agentfake.NewAgent(nil, "", logger, agentfake.WithDialer(dialer))
+	t.Cleanup(a.Close)
 
 	runCtx, cancel := context.WithCancel(ctx)
 	t.Cleanup(cancel)
 
 	runErr := make(chan error, 1)
-	go func() {
-		runErr <- a.Run(runCtx)
-	}()
+	go func() { runErr <- a.Run(runCtx) }()
 
-	coderdtest.NewWorkspaceAgentWaiter(t, client, r.Workspace.ID).
-		WithContext(ctx).
-		Wait()
-
+	// The fake agent sends UpdateLifecycle(READY) once per dRPC
+	// connect; agenttest records every lifecycle update.
 	require.Eventually(t, func() bool {
-		ws, err := client.Workspace(ctx, r.Workspace.ID)
-		if err != nil {
-			return false
-		}
-		for _, res := range ws.LatestBuild.Resources {
-			for _, agent := range res.Agents {
-				if agent.LifecycleState != codersdk.WorkspaceAgentLifecycleReady {
-					return false
-				}
+		for _, state := range dialer.GetLifecycleStates() {
+			if state == codersdk.WorkspaceAgentLifecycleReady {
+				return true
 			}
 		}
-		return true
-	}, testutil.WaitLong, testutil.IntervalFast,
-		"agent never reached Lifecycle=ready in workspace %s", r.Workspace.ID)
+		return false
+	}, testutil.WaitShort, testutil.IntervalFast,
+		"agent never reported Lifecycle=ready")
 
 	// Cancel Run and confirm a clean exit (nil error, not ctx error).
 	cancel()

--- a/enterprise/scaletest/agentfake/agent_test.go
+++ b/enterprise/scaletest/agentfake/agent_test.go
@@ -110,7 +110,7 @@ func TestAgent_SendsMetadata(t *testing.T) {
 	// under the hood, which inserts the metadata description rows for each
 	// metadata block on the agent. BatchUpdateMetadata's UPDATE will match
 	// the rows that path created. No manual seeding needed.
-	agentID := workspaceAgentID(t, ctx, client, r.Workspace.ID)
+	agentID := workspaceAgentID(ctx, t, client, r.Workspace.ID)
 	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
 	a := agentfake.NewAgent(client.URL, r.AgentToken, logger)
 	t.Cleanup(func() { a.Close() })
@@ -184,7 +184,7 @@ waitLoop:
 	}
 }
 
-func workspaceAgentID(t *testing.T, ctx context.Context, client *codersdk.Client, workspaceID uuid.UUID) uuid.UUID {
+func workspaceAgentID(ctx context.Context, t *testing.T, client *codersdk.Client, workspaceID uuid.UUID) uuid.UUID {
 	t.Helper()
 	ws, err := client.Workspace(ctx, workspaceID)
 	require.NoError(t, err)

--- a/enterprise/scaletest/agentfake/manager.go
+++ b/enterprise/scaletest/agentfake/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"net/url"
 	"strconv"
 	"sync"
 	"time"
@@ -16,6 +17,16 @@ import (
 	"cdr.dev/slog/v3"
 	"github.com/coder/coder/v2/codersdk"
 )
+
+// ExternalAgentClient is the subset of *codersdk.Client the Manager
+// uses to enumerate external-agent workspaces under a template and
+// fetch each agent's auth token. *codersdk.Client satisfies this
+// interface, so production callers pass their client directly; tests
+// substitute a fake without standing up a real coderd.
+type ExternalAgentClient interface {
+	Workspaces(ctx context.Context, filter codersdk.WorkspaceFilter) (codersdk.WorkspacesResponse, error)
+	WorkspaceExternalAgentCredentials(ctx context.Context, workspaceID uuid.UUID, agentName string) (codersdk.ExternalAgentCredentials, error)
+}
 
 const (
 	enumeratePageSize        = 100
@@ -48,9 +59,10 @@ type ManagerOptions struct {
 // (via coder_external_agent tokens on workspaces matching opts.Template), then opens a dRPC stream per agent and keeps
 // them connected until ctx is canceled.
 type Manager struct {
-	client *codersdk.Client
-	logger slog.Logger
-	opts   ManagerOptions
+	coderURL *url.URL
+	client   ExternalAgentClient
+	logger   slog.Logger
+	opts     ManagerOptions
 
 	mu     sync.Mutex
 	agents []*Agent
@@ -58,12 +70,14 @@ type Manager struct {
 
 // NewManager returns an Agent Manager. The provided client must already be authenticated with sufficient privilege
 // to list workspaces by template and to call the enterprise-only WorkspaceExternalAgentCredentials endpoint
-// (template-admin or higher; FeatureWorkspaceExternalAgent must be enabled).
-func NewManager(client *codersdk.Client, logger slog.Logger, opts ManagerOptions) *Manager {
+// (template-admin or higher; FeatureWorkspaceExternalAgent must be enabled). coderURL is the URL the spawned
+// fake agents will dial.
+func NewManager(coderURL *url.URL, client ExternalAgentClient, logger slog.Logger, opts ManagerOptions) *Manager {
 	return &Manager{
-		client: client,
-		logger: logger,
-		opts:   opts,
+		coderURL: coderURL,
+		client:   client,
+		logger:   logger,
+		opts:     opts,
 	}
 }
 
@@ -84,7 +98,7 @@ func (m *Manager) Run(ctx context.Context) error {
 
 	agents := make([]*Agent, 0, len(tokens))
 	for i, ti := range tokens {
-		agents = append(agents, NewAgent(m.client.URL, ti.Token,
+		agents = append(agents, NewAgent(m.coderURL, ti.Token,
 			m.logger.Named("agent-"+strconv.Itoa(i))))
 	}
 	m.mu.Lock()

--- a/enterprise/scaletest/agentfake/manager_test.go
+++ b/enterprise/scaletest/agentfake/manager_test.go
@@ -2,76 +2,131 @@ package agentfake_test
 
 import (
 	"context"
-	"database/sql"
+	"net/http"
+	"net/url"
 	"sort"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
 	"cdr.dev/slog/v3/sloggers/slogtest"
-	"github.com/coder/coder/v2/coderd/coderdtest"
-	"github.com/coder/coder/v2/coderd/database"
-	"github.com/coder/coder/v2/coderd/database/dbfake"
 	"github.com/coder/coder/v2/codersdk"
-	"github.com/coder/coder/v2/enterprise/coderd/coderdenttest"
-	"github.com/coder/coder/v2/enterprise/coderd/license"
 	"github.com/coder/coder/v2/enterprise/scaletest/agentfake"
-	sdkproto "github.com/coder/coder/v2/provisionersdk/proto"
 	"github.com/coder/coder/v2/testutil"
 )
 
-// Asserts the TokenInfo shape (workspace IDs, agent names, tokens) returned by the enumeration loop.
+// fakeExternalAgentClient is an in-package fake for the
+// ExternalAgentClient interface used by
+// Manager.EnumerateExternalAgents. Tests populate workspaces /
+// credentials / workspacesErr before calling the Manager.
+type fakeExternalAgentClient struct {
+	// workspaces, in the order Workspaces() should return them. Each
+	// call returns up to filter.Limit entries starting at filter.Offset
+	// to model pagination, matching real coderd behavior.
+	workspaces []codersdk.Workspace
+	// credentials, keyed by "{workspaceID}/{agentName}". A nil entry
+	// causes WorkspaceExternalAgentCredentials to error with notFoundErr.
+	credentials map[string]codersdk.ExternalAgentCredentials
+
+	// workspacesErr, if non-nil, is returned from every Workspaces call.
+	workspacesErr error
+}
+
+func (f *fakeExternalAgentClient) Workspaces(_ context.Context, filter codersdk.WorkspaceFilter) (codersdk.WorkspacesResponse, error) {
+	if f.workspacesErr != nil {
+		return codersdk.WorkspacesResponse{}, f.workspacesErr
+	}
+	start := filter.Offset
+	if start > len(f.workspaces) {
+		start = len(f.workspaces)
+	}
+	end := start + filter.Limit
+	if end > len(f.workspaces) {
+		end = len(f.workspaces)
+	}
+	page := f.workspaces[start:end]
+	return codersdk.WorkspacesResponse{
+		Workspaces: page,
+		Count:      len(f.workspaces),
+	}, nil
+}
+
+func (f *fakeExternalAgentClient) WorkspaceExternalAgentCredentials(_ context.Context, wsID uuid.UUID, agentName string) (codersdk.ExternalAgentCredentials, error) {
+	key := wsID.String() + "/" + agentName
+	creds, ok := f.credentials[key]
+	if !ok {
+		return codersdk.ExternalAgentCredentials{}, xerrors.Errorf("no credentials for %s", key)
+	}
+	return creds, nil
+}
+
+// externalAgentWorkspace returns a codersdk.Workspace whose latest
+// build has HasExternalAgent=true and one agent with the given name.
+func externalAgentWorkspace(t *testing.T, name, agentName string) (codersdk.Workspace, uuid.UUID) {
+	t.Helper()
+	wsID := uuid.New()
+	agentID := uuid.New()
+	hasExternal := true
+	return codersdk.Workspace{
+		ID:   wsID,
+		Name: name,
+		LatestBuild: codersdk.WorkspaceBuild{
+			HasExternalAgent: &hasExternal,
+			Resources: []codersdk.WorkspaceResource{{
+				Name: "external",
+				Type: "coder_external_agent",
+				Agents: []codersdk.WorkspaceAgent{{
+					ID:   agentID,
+					Name: agentName,
+				}},
+			}},
+		},
+	}, agentID
+}
+
+// Asserts the TokenInfo shape (workspace IDs, agent names, tokens)
+// returned by the enumeration loop given a fake client.
 func Test_Manager_EnumerateExternalAgents_returnsAllTokens(t *testing.T) {
 	t.Parallel()
-	ctx := testutil.Context(t, testutil.WaitLong)
-
-	client, db, user := coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
-		LicenseOptions: &coderdenttest.LicenseOptions{
-			Features: license.Features{
-				codersdk.FeatureWorkspaceExternalAgent: 1,
-			},
-		},
-	})
+	ctx := testutil.Context(t, testutil.WaitShort)
 
 	const numWorkspaces = 3
-	first := buildExternalAgentWorkspace(t, db, user, uuid.Nil)
-	templateID := first.Workspace.TemplateID
-	want := []agentfake.TokenInfo{{
-		WorkspaceID:   first.Workspace.ID,
-		WorkspaceName: first.Workspace.Name,
-		AgentID:       first.Agents[0].ID,
-		AgentName:     first.Agents[0].Name,
-		Token:         first.AgentToken,
-	}}
-	for i := 1; i < numWorkspaces; i++ {
-		r := buildExternalAgentWorkspace(t, db, user, templateID)
+	workspaces := make([]codersdk.Workspace, 0, numWorkspaces)
+	credentials := map[string]codersdk.ExternalAgentCredentials{}
+	want := make([]agentfake.TokenInfo, 0, numWorkspaces)
+	for i := 0; i < numWorkspaces; i++ {
+		agentName := "external"
+		ws, agentID := externalAgentWorkspace(t, "ws-"+uuid.NewString(), agentName)
+		workspaces = append(workspaces, ws)
+		token := uuid.NewString()
+		credentials[ws.ID.String()+"/"+agentName] = codersdk.ExternalAgentCredentials{
+			AgentToken: token,
+		}
 		want = append(want, agentfake.TokenInfo{
-			WorkspaceID:   r.Workspace.ID,
-			WorkspaceName: r.Workspace.Name,
-			AgentID:       r.Agents[0].ID,
-			AgentName:     r.Agents[0].Name,
-			Token:         r.AgentToken,
+			WorkspaceID:   ws.ID,
+			WorkspaceName: ws.Name,
+			AgentID:       agentID,
+			AgentName:     agentName,
+			Token:         token,
 		})
 	}
 
-	tmpl, err := client.Template(ctx, templateID)
-	require.NoError(t, err)
-
+	client := &fakeExternalAgentClient{workspaces: workspaces, credentials: credentials}
+	coderURL, _ := url.Parse("http://fake")
 	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
-	m := agentfake.NewManager(client, logger, agentfake.ManagerOptions{Template: tmpl.Name})
+	m := agentfake.NewManager(coderURL, client, logger, agentfake.ManagerOptions{Template: "tmpl"})
 
 	got, err := m.EnumerateExternalAgents(ctx)
 	require.NoError(t, err)
 
-	// Order returned by coderd isn't guaranteed; sort both sides by WorkspaceID before comparing.
 	sortTokenInfosByWorkspaceID(want)
 	sortTokenInfosByWorkspaceID(got)
 
-	require.Equal(t, len(want), len(got),
-		"expected one TokenInfo per external-agent workspace under the template")
+	require.Equal(t, len(want), len(got), "expected one TokenInfo per external-agent workspace")
 	for i := range want {
 		assert.Equal(t, want[i].WorkspaceID, got[i].WorkspaceID, "WorkspaceID for entry %d", i)
 		assert.Equal(t, want[i].AgentName, got[i].AgentName, "AgentName for entry %d", i)
@@ -80,143 +135,29 @@ func Test_Manager_EnumerateExternalAgents_returnsAllTokens(t *testing.T) {
 	}
 }
 
-// Heavier-weight integration test for the agentfake harness: builds 5 external agents, sets up the client/Manager,
-// and asserts that each of the agents the Manager sees via its enumeration function is properly connected and Ready.
-func TestManager_FiveAgentsHeartbeat(t *testing.T) {
-	t.Parallel()
-
-	ctx := testutil.Context(t, testutil.WaitLong)
-
-	client, db, user := coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
-		LicenseOptions: &coderdenttest.LicenseOptions{
-			Features: license.Features{
-				codersdk.FeatureWorkspaceExternalAgent: 1,
-			},
-		},
-	})
-
-	const numAgents = 5
-	first := buildExternalAgentWorkspace(t, db, user, uuid.Nil)
-	templateID := first.Workspace.TemplateID
-	workspaceIDs := []uuid.UUID{first.Workspace.ID}
-	for i := 1; i < numAgents; i++ {
-		r := buildExternalAgentWorkspace(t, db, user, templateID)
-		workspaceIDs = append(workspaceIDs, r.Workspace.ID)
-	}
-
-	tmpl, err := client.Template(ctx, templateID)
-	require.NoError(t, err)
-
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
-	manager := agentfake.NewManager(client, logger, agentfake.ManagerOptions{
-		Template: tmpl.Name,
-	})
-	t.Cleanup(func() { manager.Close() })
-
-	managerCtx, cancelManager := context.WithCancel(ctx)
-	t.Cleanup(cancelManager)
-
-	managerErr := make(chan error, 1)
-	go func() {
-		managerErr <- manager.Run(managerCtx)
-	}()
-
-	// Each workspace's agent must reach Connected. Share the outer test ctx (testutil.WaitLong) across all five waiters
-	// so the total wait is bounded.
-	for _, wsID := range workspaceIDs {
-		coderdtest.NewWorkspaceAgentWaiter(t, client, wsID).WithContext(ctx).Wait()
-	}
-
-	// Each workspace's agent must also reach Lifecycle=ready. The fake sends UpdateLifecycle(READY) once per dRPC
-	// connect; coderd persists that and exposes it on the agent.
-	for _, wsID := range workspaceIDs {
-		require.Eventually(t, func() bool {
-			ws, err := client.Workspace(ctx, wsID)
-			if err != nil {
-				return false
-			}
-			for _, res := range ws.LatestBuild.Resources {
-				for _, agent := range res.Agents {
-					if agent.LifecycleState != codersdk.WorkspaceAgentLifecycleReady {
-						return false
-					}
-				}
-			}
-			return true
-		}, testutil.WaitLong, testutil.IntervalFast,
-			"agent never reached Lifecycle=ready in workspace %s", wsID)
-	}
-
-	// Cleanly stop the Manager and confirm it exits without a non-context error.
-	cancelManager()
-	select {
-	case err := <-managerErr:
-		if err != nil {
-			t.Fatalf("Manager.Run returned unexpected error: %v", err)
-		}
-	case <-ctx.Done():
-		t.Fatalf("timed out waiting for Manager.Run to return: %v", ctx.Err())
-	}
-}
-
-// Asserts that an authentication failure during enumeration produces a fatal error, so the retry loop in
-// enumerateWithRetry surfaces it immediately rather than hammering endpoints with credentials that will never work.
+// Asserts that an authentication failure during enumeration produces a
+// fatal error, so the retry loop in enumerateWithRetry surfaces it
+// immediately rather than hammering endpoints with credentials that
+// will never work.
 func Test_Manager_EnumerateExternalAgents_invalidTokenIsFatal(t *testing.T) {
 	t.Parallel()
-	ctx := testutil.Context(t, testutil.WaitLong)
+	ctx := testutil.Context(t, testutil.WaitShort)
 
-	client, db := coderdtest.NewWithDatabase(t, nil)
-	user := coderdtest.CreateFirstUser(t, client)
-
-	r := buildExternalAgentWorkspace(t, db, user, uuid.Nil)
-	tmpl, err := client.Template(ctx, r.Workspace.TemplateID)
-	require.NoError(t, err)
-
-	// Replace the client's session token with garbage to provoke a 401 from coderd's workspace-list endpoint.
-	// The Manager should surface that as a fatal error.
-	client.SetSessionToken("not-a-valid-session-token")
-
+	client := &fakeExternalAgentClient{
+		workspacesErr: codersdk.NewError(http.StatusUnauthorized, codersdk.Response{Message: "unauthorized"}),
+	}
+	coderURL, _ := url.Parse("http://fake")
 	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
-	m := agentfake.NewManager(client, logger, agentfake.ManagerOptions{Template: tmpl.Name})
+	m := agentfake.NewManager(coderURL, client, logger, agentfake.ManagerOptions{Template: "tmpl"})
 
-	_, err = m.EnumerateExternalAgents(ctx)
+	_, err := m.EnumerateExternalAgents(ctx)
 	require.Error(t, err, "expected enumeration to fail with an invalid session token")
 	require.True(t, agentfake.IsFatalEnumerationError(err),
-		"expected error to be classified as fatal so the harness exits and Kubernetes can restart it; got: %v", err)
+		"expected error to be classified as fatal; got: %v", err)
 }
 
 func sortTokenInfosByWorkspaceID(s []agentfake.TokenInfo) {
 	sort.Slice(s, func(i, j int) bool {
 		return s[i].WorkspaceID.String() < s[j].WorkspaceID.String()
 	})
-}
-
-// buildExternalAgentWorkspace creates one workspace with a coder_external_agent resource, an agent, and
-// HasExternalAgent=true on the latest build. If templateID is uuid.Nil, dbfake mints a fresh template (and the caller
-// can pass the returned Workspace.TemplateID into subsequent calls to share the template).
-func buildExternalAgentWorkspace(
-	t *testing.T,
-	db database.Store,
-	user codersdk.CreateFirstUserResponse,
-	templateID uuid.UUID,
-) dbfake.WorkspaceResponse {
-	t.Helper()
-
-	ws := database.WorkspaceTable{
-		OrganizationID: user.OrganizationID,
-		OwnerID:        user.UserID,
-	}
-	if templateID != uuid.Nil {
-		ws.TemplateID = templateID
-	}
-	return dbfake.WorkspaceBuild(t, db, ws).
-		Seed(database.WorkspaceBuild{
-			HasExternalAgent: sql.NullBool{Bool: true, Valid: true},
-		}).
-		Resource(&sdkproto.Resource{
-			Name: "external",
-			Type: "coder_external_agent",
-		}).
-		WithAgent().
-		Do()
 }


### PR DESCRIPTION
Fake agents now fetch their manifest, spawn a single per-agent metadata goroutine, and emit batched BatchUpdateMetadata calls with 3072-byte base64 payloads so scaletest runs mirror the load shape of real agents. This matches what the current scaletest workspace template does for metadata. In the future we can extend the harness here to take in a config option for the metadata payload size.
