### PR TITLE
feat(site/src/pages/AgentsPage/components): show workspace quota in usage indicator

### DIFF
--- a/site/src/pages/AgentsPage/components/UsageIndicator.stories.tsx
+++ b/site/src/pages/AgentsPage/components/UsageIndicator.stories.tsx
@@ -75,7 +75,10 @@ const openUsageMenu = async (canvasElement: HTMLElement) => {
 
 const periodStart = new Date().toISOString();
 const periodEnd = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
-const userWorkspacesRequest = { q: "owner:me", limit: 0 };
+const userWorkspacesRequest = {
+	q: `owner:me organization:${MockDefaultOrganization.name}`,
+	limit: 0,
+};
 const noWorkspaceQuota = {
 	credits_consumed: 0,
 	budget: 0,

--- a/site/src/pages/AgentsPage/components/UsageIndicator.stories.tsx
+++ b/site/src/pages/AgentsPage/components/UsageIndicator.stories.tsx
@@ -1,7 +1,20 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { FC } from "react";
 import { useQueryClient } from "react-query";
+import { expect, userEvent, within } from "storybook/test";
 import { chatUsageLimitStatusKey } from "#/api/queries/chats";
+import { getWorkspaceQuotaQueryKey } from "#/api/queries/workspaceQuota";
+import { workspacesKey } from "#/api/queries/workspaces";
+import type { WorkspaceQuota, WorkspacesResponse } from "#/api/typesGenerated";
+import {
+	MockDefaultOrganization,
+	MockPermissions,
+	MockUserOwner,
+} from "#/testHelpers/entities";
+import {
+	withAuthProvider,
+	withDashboardProvider,
+} from "#/testHelpers/storybook";
 import { UsageIndicator } from "./UsageIndicator";
 
 const withUsageLimitStatus =
@@ -19,12 +32,71 @@ const withUsageLimitStatus =
 		return <Story />;
 	};
 
+const withWorkspaceQuota = (quota: WorkspaceQuota) => (Story: FC) => {
+	const queryClient = useQueryClient();
+	queryClient.setQueryData(
+		getWorkspaceQuotaQueryKey(
+			MockDefaultOrganization.name,
+			MockUserOwner.username,
+		),
+		quota,
+	);
+	return <Story />;
+};
+
+const withWorkspaceCount = (count: number) => (Story: FC) => {
+	const queryClient = useQueryClient();
+	queryClient.setQueryData(workspacesKey(userWorkspacesRequest), {
+		workspaces: [],
+		count,
+	} satisfies WorkspacesResponse);
+	return <Story />;
+};
+
+const withUnavailableWorkspaceCount = (Story: FC) => {
+	const queryClient = useQueryClient();
+	queryClient.setQueryData(workspacesKey(userWorkspacesRequest), {
+		workspaces: [],
+		count: -1,
+	} satisfies WorkspacesResponse);
+	return <Story />;
+};
+
+const withUsageIndicatorFrame = (Story: FC) => (
+	<div className="flex h-12 w-[260px] items-stretch justify-end rounded-md bg-surface-secondary">
+		<Story />
+	</div>
+);
+
+const openUsageMenu = async (canvasElement: HTMLElement) => {
+	const canvas = within(canvasElement);
+	await userEvent.click(canvas.getByRole("button"));
+};
+
 const periodStart = new Date().toISOString();
 const periodEnd = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+const userWorkspacesRequest = { q: "owner:me", limit: 0 };
+const noWorkspaceQuota = {
+	credits_consumed: 0,
+	budget: 0,
+} satisfies WorkspaceQuota;
+const defaultWorkspaceQuota = {
+	credits_consumed: 30,
+	budget: 100,
+} satisfies WorkspaceQuota;
 
 const meta: Meta<typeof UsageIndicator> = {
 	title: "pages/AgentsPage/UsageIndicator",
 	component: UsageIndicator,
+	decorators: [
+		withAuthProvider,
+		withDashboardProvider,
+		withUsageIndicatorFrame,
+	],
+	parameters: {
+		user: MockUserOwner,
+		permissions: MockPermissions,
+	},
 };
 
 export default meta;
@@ -40,6 +112,7 @@ export const LowUsage: Story = {
 			period_start: periodStart,
 			period_end: periodEnd,
 		}),
+		withWorkspaceQuota(noWorkspaceQuota),
 	],
 };
 
@@ -53,6 +126,7 @@ export const MediumUsage: Story = {
 			period_start: periodStart,
 			period_end: periodEnd,
 		}),
+		withWorkspaceQuota(noWorkspaceQuota),
 	],
 };
 
@@ -66,6 +140,7 @@ export const HighUsage: Story = {
 			period_start: periodStart,
 			period_end: periodEnd,
 		}),
+		withWorkspaceQuota(noWorkspaceQuota),
 	],
 };
 
@@ -79,7 +154,79 @@ export const LimitExceeded: Story = {
 			period_start: periodStart,
 			period_end: periodEnd,
 		}),
+		withWorkspaceQuota(noWorkspaceQuota),
 	],
+};
+
+export const WorkspaceQuotaOnly: Story = {
+	decorators: [
+		withUsageLimitStatus({
+			is_limited: false,
+			current_spend: 0,
+		}),
+		withWorkspaceQuota(defaultWorkspaceQuota),
+		withWorkspaceCount(3),
+	],
+	play: async ({ canvasElement }) => {
+		await openUsageMenu(canvasElement);
+	},
+};
+
+export const UsageAndWorkspaceQuota: Story = {
+	decorators: [
+		withUsageLimitStatus({
+			is_limited: true,
+			period: "month",
+			spend_limit_micros: 50_000_000,
+			current_spend: 12_500_000,
+			period_start: periodStart,
+			period_end: periodEnd,
+		}),
+		withWorkspaceQuota(defaultWorkspaceQuota),
+		withWorkspaceCount(3),
+	],
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const progressBars = canvas.getAllByRole("progressbar");
+
+		expect(canvas.getByText("Usage")).toBeInTheDocument();
+		expect(progressBars.map((bar) => bar.getAttribute("aria-label"))).toEqual([
+			"Monthly spend usage",
+			"Workspace quota usage",
+		]);
+		await userEvent.click(canvas.getByRole("button"));
+	},
+};
+
+export const WorkspaceQuotaExceeded: Story = {
+	decorators: [
+		withUsageLimitStatus({
+			is_limited: false,
+			current_spend: 0,
+		}),
+		withWorkspaceQuota({
+			credits_consumed: 125,
+			budget: 100,
+		}),
+		withWorkspaceCount(7),
+	],
+	play: async ({ canvasElement }) => {
+		await openUsageMenu(canvasElement);
+	},
+};
+
+export const WorkspaceQuotaWithoutWorkspaceCount: Story = {
+	decorators: [
+		withUsageLimitStatus({
+			is_limited: false,
+			current_spend: 0,
+		}),
+		withWorkspaceQuota(defaultWorkspaceQuota),
+		withUnavailableWorkspaceCount,
+	],
+	play: async ({ canvasElement }) => {
+		await openUsageMenu(canvasElement);
+	},
 };
 
 export const NotLimited: Story = {
@@ -88,5 +235,6 @@ export const NotLimited: Story = {
 			is_limited: false,
 			current_spend: 0,
 		}),
+		withWorkspaceQuota(noWorkspaceQuota),
 	],
 };

--- a/site/src/pages/AgentsPage/components/UsageIndicator.stories.tsx
+++ b/site/src/pages/AgentsPage/components/UsageIndicator.stories.tsx
@@ -83,6 +83,10 @@ const noWorkspaceQuota = {
 	credits_consumed: 0,
 	budget: 0,
 } satisfies WorkspaceQuota;
+const unusedWorkspaceQuota = {
+	credits_consumed: 0,
+	budget: 100,
+} satisfies WorkspaceQuota;
 const defaultWorkspaceQuota = {
 	credits_consumed: 30,
 	budget: 100,
@@ -198,6 +202,21 @@ export const UsageAndWorkspaceQuota: Story = {
 			"Workspace quota usage",
 		]);
 		await userEvent.click(canvas.getByRole("button"));
+	},
+};
+
+export const WorkspaceQuotaUnused: Story = {
+	decorators: [
+		withUsageLimitStatus({
+			is_limited: false,
+			current_spend: 0,
+		}),
+		withWorkspaceQuota(unusedWorkspaceQuota),
+	],
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		expect(canvas.queryByRole("button")).not.toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/UsageIndicator.stories.tsx
+++ b/site/src/pages/AgentsPage/components/UsageIndicator.stories.tsx
@@ -5,7 +5,11 @@ import { expect, userEvent, within } from "storybook/test";
 import { chatUsageLimitStatusKey } from "#/api/queries/chats";
 import { getWorkspaceQuotaQueryKey } from "#/api/queries/workspaceQuota";
 import { workspacesKey } from "#/api/queries/workspaces";
-import type { WorkspaceQuota, WorkspacesResponse } from "#/api/typesGenerated";
+import type {
+	ChatUsageLimitStatus,
+	WorkspaceQuota,
+	WorkspacesResponse,
+} from "#/api/typesGenerated";
 import {
 	MockDefaultOrganization,
 	MockPermissions,
@@ -17,20 +21,11 @@ import {
 } from "#/testHelpers/storybook";
 import { UsageIndicator } from "./UsageIndicator";
 
-const withUsageLimitStatus =
-	(status: {
-		is_limited: boolean;
-		period?: "day" | "week" | "month";
-		spend_limit_micros?: number;
-		current_spend: number;
-		period_start?: string;
-		period_end?: string;
-	}) =>
-	(Story: FC) => {
-		const queryClient = useQueryClient();
-		queryClient.setQueryData(chatUsageLimitStatusKey, status);
-		return <Story />;
-	};
+const withUsageLimitStatus = (status: ChatUsageLimitStatus) => (Story: FC) => {
+	const queryClient = useQueryClient();
+	queryClient.setQueryData(chatUsageLimitStatusKey, status);
+	return <Story />;
+};
 
 const withWorkspaceQuota = (quota: WorkspaceQuota) => (Story: FC) => {
 	const queryClient = useQueryClient();
@@ -73,8 +68,23 @@ const openUsageMenu = async (canvasElement: HTMLElement) => {
 	await userEvent.click(canvas.getByRole("button"));
 };
 
-const periodStart = new Date().toISOString();
-const periodEnd = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+const limitedUsageStatus = (
+	overrides: Partial<ChatUsageLimitStatus> = {},
+): ChatUsageLimitStatus => ({
+	is_limited: true,
+	period: "month",
+	spend_limit_micros: 50_000_000,
+	current_spend: 12_500_000,
+	period_start: "2026-02-10T00:00:00Z",
+	period_end: "2026-03-12T00:00:00Z",
+	...overrides,
+});
+
+const unlimitedUsageStatus = {
+	is_limited: false,
+	current_spend: 0,
+} satisfies ChatUsageLimitStatus;
+
 const userWorkspacesRequest = {
 	q: `owner:me organization:${MockDefaultOrganization.name}`,
 	limit: 0,
@@ -107,66 +117,52 @@ type Story = StoryObj<typeof UsageIndicator>;
 
 export const LowUsage: Story = {
 	decorators: [
-		withUsageLimitStatus({
-			is_limited: true,
-			period: "month",
-			spend_limit_micros: 50_000_000,
-			current_spend: 12_500_000,
-			period_start: periodStart,
-			period_end: periodEnd,
-		}),
+		withUsageLimitStatus(limitedUsageStatus()),
 		withWorkspaceQuota(noWorkspaceQuota),
 	],
 };
 
 export const MediumUsage: Story = {
 	decorators: [
-		withUsageLimitStatus({
-			is_limited: true,
-			period: "week",
-			spend_limit_micros: 20_000_000,
-			current_spend: 16_000_000,
-			period_start: periodStart,
-			period_end: periodEnd,
-		}),
+		withUsageLimitStatus(
+			limitedUsageStatus({
+				period: "week",
+				spend_limit_micros: 20_000_000,
+				current_spend: 16_000_000,
+			}),
+		),
 		withWorkspaceQuota(noWorkspaceQuota),
 	],
 };
 
 export const HighUsage: Story = {
 	decorators: [
-		withUsageLimitStatus({
-			is_limited: true,
-			period: "day",
-			spend_limit_micros: 10_000_000,
-			current_spend: 9_500_000,
-			period_start: periodStart,
-			period_end: periodEnd,
-		}),
+		withUsageLimitStatus(
+			limitedUsageStatus({
+				period: "day",
+				spend_limit_micros: 10_000_000,
+				current_spend: 9_500_000,
+			}),
+		),
 		withWorkspaceQuota(noWorkspaceQuota),
 	],
 };
 
 export const LimitExceeded: Story = {
 	decorators: [
-		withUsageLimitStatus({
-			is_limited: true,
-			period: "month",
-			spend_limit_micros: 30_000_000,
-			current_spend: 32_000_000,
-			period_start: periodStart,
-			period_end: periodEnd,
-		}),
+		withUsageLimitStatus(
+			limitedUsageStatus({
+				spend_limit_micros: 30_000_000,
+				current_spend: 32_000_000,
+			}),
+		),
 		withWorkspaceQuota(noWorkspaceQuota),
 	],
 };
 
 export const WorkspaceQuotaOnly: Story = {
 	decorators: [
-		withUsageLimitStatus({
-			is_limited: false,
-			current_spend: 0,
-		}),
+		withUsageLimitStatus(unlimitedUsageStatus),
 		withWorkspaceQuota(defaultWorkspaceQuota),
 		withWorkspaceCount(3),
 	],
@@ -177,14 +173,7 @@ export const WorkspaceQuotaOnly: Story = {
 
 export const UsageAndWorkspaceQuota: Story = {
 	decorators: [
-		withUsageLimitStatus({
-			is_limited: true,
-			period: "month",
-			spend_limit_micros: 50_000_000,
-			current_spend: 12_500_000,
-			period_start: periodStart,
-			period_end: periodEnd,
-		}),
+		withUsageLimitStatus(limitedUsageStatus()),
 		withWorkspaceQuota(defaultWorkspaceQuota),
 		withWorkspaceCount(3),
 	],
@@ -203,10 +192,7 @@ export const UsageAndWorkspaceQuota: Story = {
 
 export const WorkspaceQuotaUnused: Story = {
 	decorators: [
-		withUsageLimitStatus({
-			is_limited: false,
-			current_spend: 0,
-		}),
+		withUsageLimitStatus(unlimitedUsageStatus),
 		withWorkspaceQuota({
 			credits_consumed: 0,
 			budget: 100,
@@ -221,10 +207,7 @@ export const WorkspaceQuotaUnused: Story = {
 
 export const WorkspaceQuotaWithoutBudget: Story = {
 	decorators: [
-		withUsageLimitStatus({
-			is_limited: false,
-			current_spend: 0,
-		}),
+		withUsageLimitStatus(unlimitedUsageStatus),
 		withWorkspaceQuota({
 			credits_consumed: 20,
 			budget: 0,
@@ -250,10 +233,7 @@ export const WorkspaceQuotaWithoutBudget: Story = {
 
 export const WorkspaceQuotaExceeded: Story = {
 	decorators: [
-		withUsageLimitStatus({
-			is_limited: false,
-			current_spend: 0,
-		}),
+		withUsageLimitStatus(unlimitedUsageStatus),
 		withWorkspaceQuota({
 			credits_consumed: 125,
 			budget: 100,
@@ -267,10 +247,7 @@ export const WorkspaceQuotaExceeded: Story = {
 
 export const WorkspaceQuotaWithoutWorkspaceCount: Story = {
 	decorators: [
-		withUsageLimitStatus({
-			is_limited: false,
-			current_spend: 0,
-		}),
+		withUsageLimitStatus(unlimitedUsageStatus),
 		withWorkspaceQuota(defaultWorkspaceQuota),
 		withUnavailableWorkspaceCount,
 	],
@@ -281,10 +258,7 @@ export const WorkspaceQuotaWithoutWorkspaceCount: Story = {
 
 export const NotLimited: Story = {
 	decorators: [
-		withUsageLimitStatus({
-			is_limited: false,
-			current_spend: 0,
-		}),
+		withUsageLimitStatus(unlimitedUsageStatus),
 		withWorkspaceQuota(noWorkspaceQuota),
 	],
 };

--- a/site/src/pages/AgentsPage/components/UsageIndicator.stories.tsx
+++ b/site/src/pages/AgentsPage/components/UsageIndicator.stories.tsx
@@ -87,6 +87,10 @@ const unusedWorkspaceQuota = {
 	credits_consumed: 0,
 	budget: 100,
 } satisfies WorkspaceQuota;
+const consumedWorkspaceQuotaWithoutBudget = {
+	credits_consumed: 20,
+	budget: 0,
+} satisfies WorkspaceQuota;
 const defaultWorkspaceQuota = {
 	credits_consumed: 30,
 	budget: 100,
@@ -217,6 +221,32 @@ export const WorkspaceQuotaUnused: Story = {
 		const canvas = within(canvasElement);
 
 		expect(canvas.queryByRole("button")).not.toBeInTheDocument();
+	},
+};
+
+export const WorkspaceQuotaWithoutBudget: Story = {
+	decorators: [
+		withUsageLimitStatus({
+			is_limited: false,
+			current_spend: 0,
+		}),
+		withWorkspaceQuota(consumedWorkspaceQuotaWithoutBudget),
+		withWorkspaceCount(1),
+	],
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const progressbar = canvas.getByRole("progressbar", {
+			name: "Workspace quota usage",
+		});
+
+		expect(canvas.getByText("Workspace quota")).toBeInTheDocument();
+		expect(progressbar).toHaveAttribute("aria-valuenow", "100");
+
+		await openUsageMenu(canvasElement);
+		expect(within(document.body).getByText("100%")).toBeInTheDocument();
+		expect(
+			within(document.body).getByText("1 workspace using 20 of 0 credits"),
+		).toBeInTheDocument();
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/UsageIndicator.stories.tsx
+++ b/site/src/pages/AgentsPage/components/UsageIndicator.stories.tsx
@@ -83,14 +83,6 @@ const noWorkspaceQuota = {
 	credits_consumed: 0,
 	budget: 0,
 } satisfies WorkspaceQuota;
-const unusedWorkspaceQuota = {
-	credits_consumed: 0,
-	budget: 100,
-} satisfies WorkspaceQuota;
-const consumedWorkspaceQuotaWithoutBudget = {
-	credits_consumed: 20,
-	budget: 0,
-} satisfies WorkspaceQuota;
 const defaultWorkspaceQuota = {
 	credits_consumed: 30,
 	budget: 100,
@@ -215,7 +207,10 @@ export const WorkspaceQuotaUnused: Story = {
 			is_limited: false,
 			current_spend: 0,
 		}),
-		withWorkspaceQuota(unusedWorkspaceQuota),
+		withWorkspaceQuota({
+			credits_consumed: 0,
+			budget: 100,
+		}),
 	],
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
@@ -230,7 +225,10 @@ export const WorkspaceQuotaWithoutBudget: Story = {
 			is_limited: false,
 			current_spend: 0,
 		}),
-		withWorkspaceQuota(consumedWorkspaceQuotaWithoutBudget),
+		withWorkspaceQuota({
+			credits_consumed: 20,
+			budget: 0,
+		}),
 		withWorkspaceCount(1),
 	],
 	play: async ({ canvasElement }) => {

--- a/site/src/pages/AgentsPage/components/UsageIndicator.tsx
+++ b/site/src/pages/AgentsPage/components/UsageIndicator.tsx
@@ -106,7 +106,7 @@ const useWorkspaceQuotaUsage = (): UsageSectionData | undefined => {
 	});
 	const quota = quotaQuery.data;
 	const shouldFetchWorkspaceCount =
-		quota !== undefined && quota.budget > 0 && quota.credits_consumed > 0;
+		quota !== undefined && quota.budget >= 0 && quota.credits_consumed > 0;
 	const userWorkspacesRequest = {
 		q: `owner:me organization:${organizationName}`,
 		limit: 0,
@@ -120,7 +120,7 @@ const useWorkspaceQuotaUsage = (): UsageSectionData | undefined => {
 		quotaQuery.isLoading ||
 		quotaQuery.isError ||
 		!quota ||
-		quota.budget <= 0 ||
+		quota.budget < 0 ||
 		quota.credits_consumed <= 0
 	) {
 		return undefined;
@@ -316,8 +316,11 @@ const UsageProgress: FC<{
 };
 
 function getPercent(used: number, budget: number): number {
-	if (!Number.isFinite(used) || !Number.isFinite(budget) || budget <= 0) {
+	if (!Number.isFinite(used) || !Number.isFinite(budget) || budget < 0) {
 		return 0;
+	}
+	if (budget === 0) {
+		return used > 0 ? 100 : 0;
 	}
 	return clampPercent((used / budget) * 100);
 }
@@ -330,8 +333,11 @@ function clampPercent(percent: number): number {
 }
 
 function getSeverity(used: number, budget: number): UsageSeverity {
-	if (!Number.isFinite(used) || !Number.isFinite(budget) || budget <= 0) {
+	if (!Number.isFinite(used) || !Number.isFinite(budget) || budget < 0) {
 		return "normal";
+	}
+	if (budget === 0) {
+		return used > 0 ? "exceeded" : "normal";
 	}
 	if (used >= budget) {
 		return "exceeded";

--- a/site/src/pages/AgentsPage/components/UsageIndicator.tsx
+++ b/site/src/pages/AgentsPage/components/UsageIndicator.tsx
@@ -41,11 +41,79 @@ type UsageSectionData = {
 const numberFormatter = new Intl.NumberFormat("en-US");
 
 export const UsageIndicator: FC = () => {
-	const aiSection = useAIUsage();
-	const quotaSection = useWorkspaceQuotaUsage();
-	const sections = [aiSection, quotaSection].filter(
-		(section): section is UsageSectionData => section !== undefined,
+	const { data: chatUsage, isError: isChatUsageError } = useQuery(
+		chatUsageLimitStatus(),
 	);
+	const { user } = useAuthenticated();
+	const { organizations } = useDashboard();
+	const organizationName =
+		organizations.find((org) => org.is_default)?.name ?? "";
+	const username = user.username;
+	const { data: quota, isError: isQuotaError } = useQuery({
+		...workspaceQuota(organizationName, username),
+		enabled: organizationName !== "" && username !== "",
+	});
+	const hasWorkspaceQuotaUsage =
+		quota !== undefined && quota.budget >= 0 && quota.credits_consumed > 0;
+	const workspacesQuery = useQuery({
+		...workspaces({
+			q: `owner:me organization:${organizationName}`,
+			limit: 0,
+		}),
+		enabled: hasWorkspaceQuotaUsage && organizationName !== "",
+	});
+	const sections: UsageSectionData[] = [];
+
+	if (!isChatUsageError && chatUsage?.is_limited) {
+		const spendLimit = chatUsage.spend_limit_micros ?? 0;
+		const currentSpend = chatUsage.current_spend;
+		const periodLabel = getUsageLimitPeriodLabel(chatUsage.period);
+		const exceeded = spendLimit > 0 && currentSpend >= spendLimit;
+
+		sections.push({
+			id: "ai-usage",
+			title: `${periodLabel} Usage`,
+			progressLabel: `${periodLabel} spend usage`,
+			percent: getPercent(currentSpend, spendLimit),
+			severity: getSeverity(currentSpend, spendLimit),
+			detail: (
+				<>
+					{formatCostMicros(currentSpend)} of {formatCostMicros(spendLimit)}{" "}
+					used
+					{exceeded && (
+						<span className="ml-1 text-content-destructive">
+							(limit exceeded)
+						</span>
+					)}
+				</>
+			),
+			secondaryDetail: chatUsage.period_end
+				? `Resets ${dayjs(chatUsage.period_end).format("MMM D, YYYY")}`
+				: undefined,
+		});
+	}
+
+	if (!isQuotaError && hasWorkspaceQuotaUsage) {
+		const creditsConsumed = quota.credits_consumed;
+		const workspaceCount = workspacesQuery.isError
+			? undefined
+			: getWorkspaceCount(workspacesQuery.data?.count);
+		const quotaDetail =
+			workspaceCount === undefined
+				? `${formatNumber(creditsConsumed)} of ${formatNumber(quota.budget)} credits used`
+				: `${formatNumber(workspaceCount)} ${workspaceCount === 1 ? "workspace" : "workspaces"} using ${formatNumber(creditsConsumed)} of ${formatNumber(quota.budget)} credits`;
+
+		sections.push({
+			id: "workspace-quota",
+			title: "Workspace quota",
+			progressLabel: "Workspace quota usage",
+			percent: getPercent(creditsConsumed, quota.budget),
+			severity: getSeverity(creditsConsumed, quota.budget),
+			detail: quotaDetail,
+			tooltip:
+				"Workspaces, stopped or running, may consume credits. Stop or delete unused ones to free quota.",
+		});
+	}
 
 	if (sections.length === 0) {
 		return null;
@@ -54,92 +122,11 @@ export const UsageIndicator: FC = () => {
 	return <UsageMenu sections={sections} />;
 };
 
-const useAIUsage = (): UsageSectionData | undefined => {
-	const { data, isLoading, isError } = useQuery(chatUsageLimitStatus());
-
-	if (isLoading || isError || !data?.is_limited) {
-		return undefined;
-	}
-
-	const spendLimit = data.spend_limit_micros ?? 0;
-	const currentSpend = data.current_spend;
-	const percent = getPercent(currentSpend, spendLimit);
-	const periodLabel = getUsageLimitPeriodLabel(data.period);
-	const exceeded = spendLimit > 0 && currentSpend >= spendLimit;
-
-	return {
-		id: "ai-usage",
-		title: `${periodLabel} Usage`,
-		progressLabel: `${periodLabel} spend usage`,
-		percent,
-		severity: getSeverity(currentSpend, spendLimit),
-		detail: (
-			<>
-				{formatCostMicros(currentSpend)} of {formatCostMicros(spendLimit)} used
-				{exceeded && (
-					<span className="ml-1 text-content-destructive">
-						(limit exceeded)
-					</span>
-				)}
-			</>
-		),
-		secondaryDetail: data.period_end
-			? `Resets ${dayjs(data.period_end).format("MMM D, YYYY")}`
-			: undefined,
-	};
-};
-
-const useWorkspaceQuotaUsage = (): UsageSectionData | undefined => {
-	const { user } = useAuthenticated();
-	const { organizations } = useDashboard();
-	const defaultOrg = organizations.find((org) => org.is_default);
-	const organizationName = defaultOrg?.name ?? "";
-	const username = user.username;
-	const quotaQuery = useQuery({
-		...workspaceQuota(organizationName, username),
-		enabled: organizationName !== "" && username !== "",
-	});
-	const quota = quotaQuery.data;
-	const shouldShowWorkspaceQuota =
-		quota !== undefined && quota.budget >= 0 && quota.credits_consumed > 0;
-	const workspacesQuery = useQuery({
-		...workspaces({
-			q: `owner:me organization:${organizationName}`,
-			limit: 0,
-		}),
-		enabled: shouldShowWorkspaceQuota && organizationName !== "",
-	});
-
-	if (quotaQuery.isLoading || quotaQuery.isError || !shouldShowWorkspaceQuota) {
-		return undefined;
-	}
-
-	const creditsConsumed = quota.credits_consumed;
-	const percent = getPercent(creditsConsumed, quota.budget);
-	const workspaceCount = workspacesQuery.isError
-		? undefined
-		: getWorkspaceCount(workspacesQuery.data?.count);
-	const quotaDetail =
-		workspaceCount === undefined
-			? `${formatNumber(creditsConsumed)} of ${formatNumber(quota.budget)} credits used`
-			: `${formatNumber(workspaceCount)} ${workspaceCount === 1 ? "workspace" : "workspaces"} using ${formatNumber(creditsConsumed)} of ${formatNumber(quota.budget)} credits`;
-
-	return {
-		id: "workspace-quota",
-		title: "Workspace quota",
-		progressLabel: "Workspace quota usage",
-		percent,
-		severity: getSeverity(creditsConsumed, quota.budget),
-		detail: quotaDetail,
-		tooltip:
-			"Workspaces, stopped or running, may consume credits. Stop or delete unused ones to free quota.",
-	};
-};
-
 const UsageMenu: FC<{ sections: readonly UsageSectionData[] }> = ({
 	sections,
 }) => {
-	const triggerLabel = getTriggerLabel(sections);
+	const triggerLabel =
+		sections.length > 1 ? "Usage" : (sections[0]?.title ?? "Usage");
 
 	return (
 		<DropdownMenu>
@@ -349,13 +336,6 @@ function getTextClassName(severity: UsageSeverity = "normal"): string {
 		case "normal":
 			return "text-content-secondary";
 	}
-}
-
-function getTriggerLabel(sections: readonly UsageSectionData[]): string {
-	if (sections.length > 1) {
-		return "Usage";
-	}
-	return sections[0]?.title ?? "Usage";
 }
 
 function getWorkspaceCount(count: number | undefined): number | undefined {

--- a/site/src/pages/AgentsPage/components/UsageIndicator.tsx
+++ b/site/src/pages/AgentsPage/components/UsageIndicator.tsx
@@ -1,8 +1,11 @@
 import dayjs from "dayjs";
-import type { FC } from "react";
+import { InfoIcon } from "lucide-react";
+import { type FC, Fragment, type ReactNode } from "react";
 import { useQuery } from "react-query";
 import { Link } from "react-router";
 import { chatUsageLimitStatus } from "#/api/queries/chats";
+import { workspaceQuota } from "#/api/queries/workspaceQuota";
+import { workspaces } from "#/api/queries/workspaces";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -10,23 +13,138 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "#/components/DropdownMenu/DropdownMenu";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "#/components/Tooltip/Tooltip";
+import { useAuthenticated } from "#/hooks/useAuthenticated";
+import { useDashboard } from "#/modules/dashboard/useDashboard";
+import { cn } from "#/utils/cn";
 import { formatCostMicros } from "#/utils/currency";
 import { getUsageLimitPeriodLabel } from "./ChatCostSummaryView";
 
+type UsageSeverity = "normal" | "warning" | "exceeded";
+
+type UsageSectionData = {
+	id: string;
+	title: string;
+	progressLabel: string;
+	percent: number;
+	detail: ReactNode;
+	secondaryDetail?: ReactNode;
+	tooltip?: ReactNode;
+	severity?: UsageSeverity;
+};
+
+const USER_WORKSPACES_REQUEST = { q: "owner:me", limit: 0 };
+
+const workspaceQuotaTooltip =
+	"Workspaces, stopped or running, may consume credits. Stop or delete unused ones to free quota.";
+
+const numberFormatter = new Intl.NumberFormat("en-US");
+
 export const UsageIndicator: FC = () => {
+	const aiSection = useAIUsage();
+	const quotaSection = useWorkspaceQuotaUsage();
+	const sections = [aiSection, quotaSection].filter(
+		(section): section is UsageSectionData => section !== undefined,
+	);
+
+	if (sections.length === 0) {
+		return null;
+	}
+
+	return <UsageMenu sections={sections} />;
+};
+
+const useAIUsage = (): UsageSectionData | undefined => {
 	const { data, isLoading, isError } = useQuery(chatUsageLimitStatus());
 
 	if (isLoading || isError || !data?.is_limited) {
-		return null;
+		return undefined;
 	}
 
 	const spendLimit = data.spend_limit_micros ?? 0;
 	const currentSpend = data.current_spend;
-	const percent =
-		spendLimit > 0 ? Math.min((currentSpend / spendLimit) * 100, 100) : 0;
-	const roundedPercent = Math.round(percent);
-	const exceeded = spendLimit > 0 && currentSpend >= spendLimit;
+	const percent = getPercent(currentSpend, spendLimit);
 	const periodLabel = getUsageLimitPeriodLabel(data.period);
+	const exceeded = spendLimit > 0 && currentSpend >= spendLimit;
+
+	return {
+		id: "ai-usage",
+		title: `${periodLabel} Usage`,
+		progressLabel: `${periodLabel} spend usage`,
+		percent,
+		severity: getSeverity(currentSpend, spendLimit),
+		detail: (
+			<>
+				{formatCostMicros(currentSpend)} of {formatCostMicros(spendLimit)} used
+				{exceeded && (
+					<span className="ml-1 text-content-destructive">
+						(limit exceeded)
+					</span>
+				)}
+			</>
+		),
+		secondaryDetail: data.period_end
+			? `Resets ${dayjs(data.period_end).format("MMM D, YYYY")}`
+			: undefined,
+	};
+};
+
+const useWorkspaceQuotaUsage = (): UsageSectionData | undefined => {
+	const { user } = useAuthenticated();
+	const { organizations } = useDashboard();
+	const defaultOrg = organizations.find((org) => org.is_default);
+	const organizationName = defaultOrg?.name ?? "";
+	const username = user.username;
+	const quotaQuery = useQuery({
+		...workspaceQuota(organizationName, username),
+		enabled: organizationName !== "" && username !== "",
+	});
+	const quota = quotaQuery.data;
+	const shouldFetchWorkspaceCount = quota !== undefined && quota.budget > 0;
+	const workspacesQuery = useQuery({
+		...workspaces(USER_WORKSPACES_REQUEST),
+		enabled: shouldFetchWorkspaceCount,
+	});
+
+	if (
+		quotaQuery.isLoading ||
+		quotaQuery.isError ||
+		!quota ||
+		quota.budget <= 0
+	) {
+		return undefined;
+	}
+
+	const creditsConsumed = quota.credits_consumed;
+	const percent = getPercent(creditsConsumed, quota.budget);
+	const workspaceCount = workspacesQuery.isError
+		? undefined
+		: getWorkspaceCount(workspacesQuery.data?.count);
+	const quotaDetail =
+		workspaceCount === undefined
+			? `${formatNumber(creditsConsumed)} of ${formatNumber(quota.budget)} credits used`
+			: `${formatNumber(workspaceCount)} ${pluralize("workspace", workspaceCount)} using ${formatNumber(creditsConsumed)} of ${formatNumber(quota.budget)} credits`;
+
+	return {
+		id: "workspace-quota",
+		title: "Workspace quota",
+		progressLabel: "Workspace quota usage",
+		percent,
+		severity: getSeverity(creditsConsumed, quota.budget),
+		detail: quotaDetail,
+		tooltip: workspaceQuotaTooltip,
+	};
+};
+
+const UsageMenu: FC<{ sections: readonly UsageSectionData[] }> = ({
+	sections,
+}) => {
+	const triggerLabel = getTriggerLabel(sections);
 
 	return (
 		<DropdownMenu>
@@ -35,69 +153,18 @@ export const UsageIndicator: FC = () => {
 					type="button"
 					className="ml-auto flex self-stretch flex-col justify-center items-start gap-1 border-none bg-transparent px-3 cursor-pointer select-none transition-colors text-content-secondary hover:bg-surface-tertiary/50 outline-none text-[13px]"
 				>
-					<span className="shrink-0 whitespace-nowrap">
-						{periodLabel} Usage
-					</span>
-					<div
-						role="progressbar"
-						aria-label={`${periodLabel} spend usage`}
-						aria-valuemin={0}
-						aria-valuemax={100}
-						aria-valuenow={roundedPercent}
-						className="h-1.5 w-full overflow-hidden rounded-full bg-surface-tertiary shrink-0"
-					>
-						<div
-							className="h-full rounded-full bg-content-secondary transition-all duration-300 ease-out"
-							style={{ width: `${percent}%` }}
-						/>
-					</div>
+					<span className="shrink-0 whitespace-nowrap">{triggerLabel}</span>
+					<UsageTriggerProgress sections={sections} />
 				</button>
 			</DropdownMenuTrigger>
 
 			<DropdownMenuContent align="end" className="min-w-auto w-[240px]">
-				{/* Header */}
-				<div className="flex items-center justify-between px-2 py-1.5">
-					<span className="text-sm font-medium text-content-primary">
-						{periodLabel} Usage
-					</span>
-					<span className="text-xs text-content-secondary">
-						{roundedPercent}%
-					</span>
-				</div>
-
-				{/* Progress bar */}
-				<div className="px-2 pb-2">
-					<div
-						role="progressbar"
-						aria-label={`${periodLabel} spend usage`}
-						aria-valuemin={0}
-						aria-valuemax={100}
-						aria-valuenow={roundedPercent}
-						className="h-1.5 overflow-hidden rounded-full bg-surface-tertiary"
-					>
-						<div
-							className="h-full rounded-full bg-content-secondary transition-all duration-300 ease-out"
-							style={{ width: `${percent}%` }}
-						/>
-					</div>
-				</div>
-
-				{/* Spend detail */}
-				<div className="px-2 pb-1.5 text-xs text-content-secondary">
-					{formatCostMicros(currentSpend)} of {formatCostMicros(spendLimit)}{" "}
-					used
-					{exceeded && (
-						<span className="ml-1 text-content-destructive">
-							— limit exceeded
-						</span>
-					)}
-				</div>
-
-				{data.period_end && (
-					<div className="px-2 pb-2 text-xs text-content-secondary">
-						Resets {dayjs(data.period_end).format("MMM D, YYYY")}
-					</div>
-				)}
+				{sections.map((section, index) => (
+					<Fragment key={section.id}>
+						{index > 0 && <DropdownMenuSeparator />}
+						<UsageSection section={section} />
+					</Fragment>
+				))}
 
 				<DropdownMenuSeparator />
 
@@ -108,3 +175,210 @@ export const UsageIndicator: FC = () => {
 		</DropdownMenu>
 	);
 };
+
+const UsageTriggerProgress: FC<{ sections: readonly UsageSectionData[] }> = ({
+	sections,
+}) => {
+	if (sections.length === 1) {
+		const section = sections[0];
+		if (section === undefined) {
+			return null;
+		}
+
+		return (
+			<UsageProgress
+				ariaLabel={section.progressLabel}
+				percent={section.percent}
+				severity={section.severity}
+				className="w-full shrink-0"
+			/>
+		);
+	}
+
+	return (
+		<div className="flex w-16 shrink-0 flex-col gap-0.5">
+			{sections.map((section) => (
+				<UsageProgress
+					key={section.id}
+					ariaLabel={section.progressLabel}
+					percent={section.percent}
+					severity={section.severity}
+					size="compact"
+				/>
+			))}
+		</div>
+	);
+};
+
+const UsageSection: FC<{ section: UsageSectionData }> = ({ section }) => {
+	const roundedPercent = Math.round(section.percent);
+
+	return (
+		<>
+			<div className="flex items-center justify-between gap-2 px-2 py-1.5">
+				<span className="truncate text-sm font-medium text-content-primary">
+					{section.title}
+				</span>
+				<span
+					className={cn("shrink-0 text-xs", getTextClassName(section.severity))}
+				>
+					{roundedPercent}%
+				</span>
+			</div>
+
+			<div className="px-2 pb-2">
+				<UsageProgress
+					ariaLabel={section.progressLabel}
+					percent={section.percent}
+					severity={section.severity}
+				/>
+			</div>
+
+			<div
+				className={cn(
+					"px-2 text-xs leading-5 text-content-secondary",
+					section.secondaryDetail ? "pb-1.5" : "pb-2",
+				)}
+			>
+				<div className="flex items-start gap-1.5">
+					<span className="min-w-0 flex-1">{section.detail}</span>
+					{section.tooltip && (
+						<TooltipProvider delayDuration={300}>
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<button
+										type="button"
+										className="mt-0.5 inline-flex size-3.5 shrink-0 cursor-help items-center justify-center rounded-sm border-none bg-transparent p-0 text-content-secondary/70 outline-none transition-colors hover:text-content-primary focus-visible:ring-2 focus-visible:ring-content-link"
+										aria-label={`${section.title} help`}
+									>
+										<InfoIcon className="size-3.5" />
+									</button>
+								</TooltipTrigger>
+								<TooltipContent
+									side="right"
+									sideOffset={4}
+									className="max-w-48 text-xs"
+								>
+									{section.tooltip}
+								</TooltipContent>
+							</Tooltip>
+						</TooltipProvider>
+					)}
+				</div>
+			</div>
+
+			{section.secondaryDetail && (
+				<div className="px-2 pb-2 text-xs text-content-secondary">
+					{section.secondaryDetail}
+				</div>
+			)}
+		</>
+	);
+};
+
+const UsageProgress: FC<{
+	ariaLabel: string;
+	percent: number;
+	severity?: UsageSeverity;
+	size?: "default" | "compact";
+	className?: string;
+}> = ({
+	ariaLabel,
+	percent,
+	severity = "normal",
+	size = "default",
+	className,
+}) => {
+	const clampedPercent = clampPercent(percent);
+
+	return (
+		<div
+			role="progressbar"
+			aria-label={ariaLabel}
+			aria-valuemin={0}
+			aria-valuemax={100}
+			aria-valuenow={Math.round(clampedPercent)}
+			className={cn(
+				size === "compact" ? "h-1" : "h-1.5",
+				"overflow-hidden rounded-full bg-surface-tertiary",
+				className,
+			)}
+		>
+			<div
+				className={cn(
+					"h-full rounded-full transition-all duration-300 ease-out",
+					getProgressClassName(severity),
+				)}
+				style={{ width: `${clampedPercent}%` }}
+			/>
+		</div>
+	);
+};
+
+function getPercent(used: number, budget: number): number {
+	if (!Number.isFinite(used) || !Number.isFinite(budget) || budget <= 0) {
+		return 0;
+	}
+	return clampPercent((used / budget) * 100);
+}
+
+function clampPercent(percent: number): number {
+	if (!Number.isFinite(percent)) {
+		return 0;
+	}
+	return Math.min(Math.max(percent, 0), 100);
+}
+
+function getSeverity(used: number, budget: number): UsageSeverity {
+	if (!Number.isFinite(used) || !Number.isFinite(budget) || budget <= 0) {
+		return "normal";
+	}
+	if (used >= budget) {
+		return "exceeded";
+	}
+	return used / budget >= 0.85 ? "warning" : "normal";
+}
+
+function getProgressClassName(severity: UsageSeverity): string {
+	switch (severity) {
+		case "exceeded":
+			return "bg-content-destructive";
+		case "warning":
+			return "bg-content-warning";
+		case "normal":
+			return "bg-content-secondary";
+	}
+}
+
+function getTextClassName(severity: UsageSeverity = "normal"): string {
+	switch (severity) {
+		case "exceeded":
+			return "text-content-destructive";
+		case "warning":
+			return "text-content-warning";
+		case "normal":
+			return "text-content-secondary";
+	}
+}
+
+function getTriggerLabel(sections: readonly UsageSectionData[]): string {
+	if (sections.length > 1) {
+		return "Usage";
+	}
+	return sections[0]?.title ?? "Usage";
+}
+
+function getWorkspaceCount(count: number | undefined): number | undefined {
+	if (count === undefined || !Number.isFinite(count) || count < 0) {
+		return undefined;
+	}
+	return count;
+}
+
+function pluralize(noun: string, count: number): string {
+	return count === 1 ? noun : `${noun}s`;
+}
+
+function formatNumber(value: number): string {
+	return numberFormatter.format(value);
+}

--- a/site/src/pages/AgentsPage/components/UsageIndicator.tsx
+++ b/site/src/pages/AgentsPage/components/UsageIndicator.tsx
@@ -38,11 +38,6 @@ type UsageSectionData = {
 	severity?: UsageSeverity;
 };
 
-const usageTriggerMeterWidthClassName = "w-24";
-
-const workspaceQuotaTooltip =
-	"Workspaces, stopped or running, may consume credits. Stop or delete unused ones to free quota.";
-
 const numberFormatter = new Intl.NumberFormat("en-US");
 
 export const UsageIndicator: FC = () => {
@@ -105,24 +100,17 @@ const useWorkspaceQuotaUsage = (): UsageSectionData | undefined => {
 		enabled: organizationName !== "" && username !== "",
 	});
 	const quota = quotaQuery.data;
-	const shouldFetchWorkspaceCount =
+	const shouldShowWorkspaceQuota =
 		quota !== undefined && quota.budget >= 0 && quota.credits_consumed > 0;
-	const userWorkspacesRequest = {
-		q: `owner:me organization:${organizationName}`,
-		limit: 0,
-	};
 	const workspacesQuery = useQuery({
-		...workspaces(userWorkspacesRequest),
-		enabled: shouldFetchWorkspaceCount && organizationName !== "",
+		...workspaces({
+			q: `owner:me organization:${organizationName}`,
+			limit: 0,
+		}),
+		enabled: shouldShowWorkspaceQuota && organizationName !== "",
 	});
 
-	if (
-		quotaQuery.isLoading ||
-		quotaQuery.isError ||
-		!quota ||
-		quota.budget < 0 ||
-		quota.credits_consumed <= 0
-	) {
+	if (quotaQuery.isLoading || quotaQuery.isError || !shouldShowWorkspaceQuota) {
 		return undefined;
 	}
 
@@ -134,7 +122,7 @@ const useWorkspaceQuotaUsage = (): UsageSectionData | undefined => {
 	const quotaDetail =
 		workspaceCount === undefined
 			? `${formatNumber(creditsConsumed)} of ${formatNumber(quota.budget)} credits used`
-			: `${formatNumber(workspaceCount)} ${pluralize("workspace", workspaceCount)} using ${formatNumber(creditsConsumed)} of ${formatNumber(quota.budget)} credits`;
+			: `${formatNumber(workspaceCount)} ${workspaceCount === 1 ? "workspace" : "workspaces"} using ${formatNumber(creditsConsumed)} of ${formatNumber(quota.budget)} credits`;
 
 	return {
 		id: "workspace-quota",
@@ -143,7 +131,8 @@ const useWorkspaceQuotaUsage = (): UsageSectionData | undefined => {
 		percent,
 		severity: getSeverity(creditsConsumed, quota.budget),
 		detail: quotaDetail,
-		tooltip: workspaceQuotaTooltip,
+		tooltip:
+			"Workspaces, stopped or running, may consume credits. Stop or delete unused ones to free quota.",
 	};
 };
 
@@ -190,12 +179,7 @@ const UsageTriggerProgress: FC<{ sections: readonly UsageSectionData[] }> = ({
 	const size = sections.length > 1 ? "compact" : "default";
 
 	return (
-		<div
-			className={cn(
-				"flex shrink-0 flex-col gap-0.5",
-				usageTriggerMeterWidthClassName,
-			)}
-		>
+		<div className="flex w-24 shrink-0 flex-col gap-0.5">
 			{sections.map((section) => (
 				<UsageProgress
 					key={section.id}
@@ -379,10 +363,6 @@ function getWorkspaceCount(count: number | undefined): number | undefined {
 		return undefined;
 	}
 	return count;
-}
-
-function pluralize(noun: string, count: number): string {
-	return count === 1 ? noun : `${noun}s`;
 }
 
 function formatNumber(value: number): string {

--- a/site/src/pages/AgentsPage/components/UsageIndicator.tsx
+++ b/site/src/pages/AgentsPage/components/UsageIndicator.tsx
@@ -105,7 +105,8 @@ const useWorkspaceQuotaUsage = (): UsageSectionData | undefined => {
 		enabled: organizationName !== "" && username !== "",
 	});
 	const quota = quotaQuery.data;
-	const shouldFetchWorkspaceCount = quota !== undefined && quota.budget > 0;
+	const shouldFetchWorkspaceCount =
+		quota !== undefined && quota.budget > 0 && quota.credits_consumed > 0;
 	const userWorkspacesRequest = {
 		q: `owner:me organization:${organizationName}`,
 		limit: 0,
@@ -119,7 +120,8 @@ const useWorkspaceQuotaUsage = (): UsageSectionData | undefined => {
 		quotaQuery.isLoading ||
 		quotaQuery.isError ||
 		!quota ||
-		quota.budget <= 0
+		quota.budget <= 0 ||
+		quota.credits_consumed <= 0
 	) {
 		return undefined;
 	}

--- a/site/src/pages/AgentsPage/components/UsageIndicator.tsx
+++ b/site/src/pages/AgentsPage/components/UsageIndicator.tsx
@@ -38,7 +38,7 @@ type UsageSectionData = {
 	severity?: UsageSeverity;
 };
 
-const USER_WORKSPACES_REQUEST = { q: "owner:me", limit: 0 };
+const usageTriggerMeterWidthClassName = "w-16";
 
 const workspaceQuotaTooltip =
 	"Workspaces, stopped or running, may consume credits. Stop or delete unused ones to free quota.";
@@ -106,9 +106,13 @@ const useWorkspaceQuotaUsage = (): UsageSectionData | undefined => {
 	});
 	const quota = quotaQuery.data;
 	const shouldFetchWorkspaceCount = quota !== undefined && quota.budget > 0;
+	const userWorkspacesRequest = {
+		q: `owner:me organization:${organizationName}`,
+		limit: 0,
+	};
 	const workspacesQuery = useQuery({
-		...workspaces(USER_WORKSPACES_REQUEST),
-		enabled: shouldFetchWorkspaceCount,
+		...workspaces(userWorkspacesRequest),
+		enabled: shouldFetchWorkspaceCount && organizationName !== "",
 	});
 
 	if (
@@ -151,9 +155,11 @@ const UsageMenu: FC<{ sections: readonly UsageSectionData[] }> = ({
 			<DropdownMenuTrigger asChild>
 				<button
 					type="button"
-					className="ml-auto flex self-stretch flex-col justify-center items-start gap-1 border-none bg-transparent px-3 cursor-pointer select-none transition-colors text-content-secondary hover:bg-surface-tertiary/50 outline-none text-[13px]"
+					className="ml-auto flex self-stretch flex-col items-center justify-center gap-1 border-none bg-transparent px-3 cursor-pointer select-none transition-colors text-content-secondary hover:bg-surface-tertiary/50 outline-none text-[13px]"
 				>
-					<span className="shrink-0 whitespace-nowrap">{triggerLabel}</span>
+					<span className="shrink-0 whitespace-nowrap text-center">
+						{triggerLabel}
+					</span>
 					<UsageTriggerProgress sections={sections} />
 				</button>
 			</DropdownMenuTrigger>
@@ -179,31 +185,23 @@ const UsageMenu: FC<{ sections: readonly UsageSectionData[] }> = ({
 const UsageTriggerProgress: FC<{ sections: readonly UsageSectionData[] }> = ({
 	sections,
 }) => {
-	if (sections.length === 1) {
-		const section = sections[0];
-		if (section === undefined) {
-			return null;
-		}
-
-		return (
-			<UsageProgress
-				ariaLabel={section.progressLabel}
-				percent={section.percent}
-				severity={section.severity}
-				className="w-full shrink-0"
-			/>
-		);
-	}
+	const size = sections.length > 1 ? "compact" : "default";
 
 	return (
-		<div className="flex w-16 shrink-0 flex-col gap-0.5">
+		<div
+			className={cn(
+				"flex shrink-0 flex-col gap-0.5",
+				usageTriggerMeterWidthClassName,
+			)}
+		>
 			{sections.map((section) => (
 				<UsageProgress
 					key={section.id}
 					ariaLabel={section.progressLabel}
 					percent={section.percent}
 					severity={section.severity}
-					size="compact"
+					size={size}
+					className="w-full"
 				/>
 			))}
 		</div>

--- a/site/src/pages/AgentsPage/components/UsageIndicator.tsx
+++ b/site/src/pages/AgentsPage/components/UsageIndicator.tsx
@@ -38,7 +38,7 @@ type UsageSectionData = {
 	severity?: UsageSeverity;
 };
 
-const usageTriggerMeterWidthClassName = "w-16";
+const usageTriggerMeterWidthClassName = "w-24";
 
 const workspaceQuotaTooltip =
 	"Workspaces, stopped or running, may consume credits. Stop or delete unused ones to free quota.";


### PR DESCRIPTION
This updates the Agents sidebar usage indicator to surface workspace quota alongside AI spend limits. When both signals are active, the compact trigger renders stacked bars in the same order as the dropdown instead of collapsing them into a single percent.

The dropdown still shows the full labels, percentages, and details for each usage section, and Storybook coverage now exercises the combined sidebar state.


<img width="315" height="261" alt="image" src="https://github.com/user-attachments/assets/e5cfc276-2cc0-4dc9-9400-6d1b829e75e2" />

<img width="320" height="243" alt="image" src="https://github.com/user-attachments/assets/506ae8ad-3d93-4857-9cdb-b3cf4142772d" />

<img width="314" height="353" alt="image" src="https://github.com/user-attachments/assets/5af3644f-f155-43a4-bae9-91b33a0a4333" />

<img width="322" height="349" alt="image" src="https://github.com/user-attachments/assets/9ae4ae55-55aa-4a2f-856e-f462793f389e" />




Relates to CODAGT-197
