### PR TITLE
feat(site): add pinned thinking display mode for agents chat

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -23068,13 +23068,15 @@ const docTemplate = `{
                 "auto",
                 "preview",
                 "always_expanded",
-                "always_collapsed"
+                "always_collapsed",
+                "pinned"
             ],
             "x-enum-varnames": [
                 "ThinkingDisplayModeAuto",
                 "ThinkingDisplayModePreview",
                 "ThinkingDisplayModeAlwaysExpanded",
-                "ThinkingDisplayModeAlwaysCollapsed"
+                "ThinkingDisplayModeAlwaysCollapsed",
+                "ThinkingDisplayModePinned"
             ]
         },
         "codersdk.TimingStage": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -21216,12 +21216,19 @@
 		},
 		"codersdk.ThinkingDisplayMode": {
 			"type": "string",
-			"enum": ["auto", "preview", "always_expanded", "always_collapsed"],
+			"enum": [
+				"auto",
+				"preview",
+				"always_expanded",
+				"always_collapsed",
+				"pinned"
+			],
 			"x-enum-varnames": [
 				"ThinkingDisplayModeAuto",
 				"ThinkingDisplayModePreview",
 				"ThinkingDisplayModeAlwaysExpanded",
-				"ThinkingDisplayModeAlwaysCollapsed"
+				"ThinkingDisplayModeAlwaysCollapsed",
+				"ThinkingDisplayModePinned"
 			]
 		},
 		"codersdk.TimingStage": {

--- a/codersdk/users.go
+++ b/codersdk/users.go
@@ -281,6 +281,7 @@ const (
 	ThinkingDisplayModePreview         ThinkingDisplayMode = "preview"
 	ThinkingDisplayModeAlwaysExpanded  ThinkingDisplayMode = "always_expanded"
 	ThinkingDisplayModeAlwaysCollapsed ThinkingDisplayMode = "always_collapsed"
+	ThinkingDisplayModePinned          ThinkingDisplayMode = "pinned"
 )
 
 var ValidThinkingDisplayModes = []ThinkingDisplayMode{
@@ -288,6 +289,7 @@ var ValidThinkingDisplayModes = []ThinkingDisplayMode{
 	ThinkingDisplayModePreview,
 	ThinkingDisplayModeAlwaysExpanded,
 	ThinkingDisplayModeAlwaysCollapsed,
+	ThinkingDisplayModePinned,
 }
 
 type AgentDisplayMode string

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -12500,9 +12500,9 @@ Restarts will only happen on weekdays in this list on weeks which line up with W
 
 #### Enumerated Values
 
-| Value(s)                                                 |
-|----------------------------------------------------------|
-| `always_collapsed`, `always_expanded`, `auto`, `preview` |
+| Value(s)                                                           |
+|--------------------------------------------------------------------|
+| `always_collapsed`, `always_expanded`, `auto`, `pinned`, `preview` |
 
 ## codersdk.TimingStage
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -7865,12 +7865,14 @@ export type ThinkingDisplayMode =
 	| "always_collapsed"
 	| "always_expanded"
 	| "auto"
+	| "pinned"
 	| "preview";
 
 export const ThinkingDisplayModes: ThinkingDisplayMode[] = [
 	"always_collapsed",
 	"always_expanded",
 	"auto",
+	"pinned",
 	"preview",
 ];
 

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -27,6 +27,7 @@ import {
 	RightPanelSkeleton,
 } from "./components/AgentsSkeletons";
 import type { useChatStore } from "./components/ChatConversation/chatStore";
+import { PinnedThinkingBanner } from "./components/ChatConversation/LiveStreamTail";
 import type { ModelSelectorOption } from "./components/ChatElements";
 import { DesktopPanelContext } from "./components/ChatElements/tools/DesktopPanelContext";
 import type { PendingAttachment } from "./components/ChatPageContent";
@@ -518,6 +519,12 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 								/>
 							</div>
 						</ChatScrollContainer>
+						<div className="shrink-0 px-4">
+							<PinnedThinkingBanner
+								store={store}
+								persistedError={persistedError}
+							/>
+						</div>
 						<div className="shrink-0 overflow-y-auto px-4 pb-3 md:pb-0 [scrollbar-gutter:stable] [scrollbar-width:thin]">
 							<ChatPageInput
 								organizationId={organizationId}

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -331,6 +331,12 @@ export const BlockList: FC<{
 						);
 					}
 					case "thinking":
+						// In pinned mode during streaming, the pinned
+						// indicator in StreamingOutput replaces per-block
+						// thinking disclosures to avoid duplicate labels.
+						if (thinkingDisplayMode === "pinned" && isStreaming) {
+							return null;
+						}
 						return (
 							<ReasoningDisclosure
 								key={`${keyPrefix}-thinking-${index}`}

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -174,11 +174,11 @@ const ReasoningDisclosure = memo<{
 						)}
 					>
 						{isStreaming ? (
-							<Shimmer as="span" className="text-[13px]">
-								Thinking
+							<Shimmer as="span" className="text-[13px] leading-relaxed">
+								Thinking...
 							</Shimmer>
 						) : (
-							<span className="text-[13px]">Thinking</span>
+							<span className="text-[13px] leading-relaxed">Thinking</span>
 						)}
 						<ChevronDownIcon
 							className={cn(

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -331,12 +331,6 @@ export const BlockList: FC<{
 						);
 					}
 					case "thinking":
-						// In pinned mode during streaming, the pinned
-						// indicator in StreamingOutput replaces per-block
-						// thinking disclosures to avoid duplicate labels.
-						if (thinkingDisplayMode === "pinned" && isStreaming) {
-							return null;
-						}
 						return (
 							<ReasoningDisclosure
 								key={`${keyPrefix}-thinking-${index}`}

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -108,6 +108,11 @@ const ReasoningDisclosure = memo<{
 				case "auto":
 				case "preview":
 					return isStreaming;
+				case "pinned":
+					// In pinned mode, individual thinking disclosures
+					// stay collapsed; the pinned container in
+					// StreamingOutput handles the visual indicator.
+					return false;
 				default: {
 					const _exhaustive: never = mode;
 					return _exhaustive;

--- a/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.tsx
@@ -1,5 +1,7 @@
+import { useQuery } from "react-query";
 import { Link } from "react-router";
 import type { UrlTransform } from "streamdown";
+import { preferenceSettings } from "#/api/queries/users";
 import type * as TypesGen from "#/api/typesGenerated";
 import { Alert, AlertDescription } from "#/components/Alert/Alert";
 import { Button } from "#/components/Button/Button";
@@ -17,7 +19,7 @@ import {
 	type useChatStore,
 } from "./chatStore";
 import { deriveLiveStatus, type LiveStatusModel } from "./liveStatusModel";
-import { StreamingOutput } from "./StreamingOutput";
+import { PinnedThinkingIndicator, StreamingOutput } from "./StreamingOutput";
 import { buildStreamTools } from "./streamState";
 import type { MergedTool, StreamState } from "./types";
 
@@ -55,6 +57,8 @@ export const LiveStreamTailContent = ({
 	urlTransform,
 	mcpServers,
 }: LiveStreamTailContentProps) => {
+	const prefQuery = useQuery(preferenceSettings());
+	const thinkingDisplayMode = prefQuery.data?.thinking_display_mode || "auto";
 	const shouldRenderStreamSection = shouldRenderStreamingSection(liveStatus);
 	const terminalStatus = liveStatus.phase === "failed" ? liveStatus : null;
 	const usageLimitStatus =
@@ -62,10 +66,19 @@ export const LiveStreamTailContent = ({
 	const shouldRenderEmptyState =
 		isTranscriptEmpty && liveStatus.phase === "idle";
 
+	// In pinned mode, the indicator shows for the entire active
+	// turn at this level so it persists even when streaming
+	// content gets committed to the conversation timeline.
+	const isPinnedActive =
+		thinkingDisplayMode === "pinned" &&
+		liveStatus.phase !== "idle" &&
+		liveStatus.phase !== "failed";
+
 	if (
 		!shouldRenderEmptyState &&
 		!shouldRenderStreamSection &&
-		!terminalStatus
+		!terminalStatus &&
+		!isPinnedActive
 	) {
 		return null;
 	}
@@ -104,6 +117,7 @@ export const LiveStreamTailContent = ({
 			) : terminalStatus ? (
 				<ChatStatusCallout status={terminalStatus} />
 			) : null}
+			{isPinnedActive && <PinnedThinkingIndicator />}
 		</div>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.tsx
@@ -69,10 +69,16 @@ export const LiveStreamTailContent = ({
 	// In pinned mode, the indicator shows for the entire active
 	// turn at this level so it persists even when streaming
 	// content gets committed to the conversation timeline.
+	// It hides once the agent starts producing visible response
+	// text (the user should read that, not "Thinking...").
+	const streamHasResponse = streamState?.blocks.some(
+		(b) => b.type === "response",
+	);
 	const isPinnedActive =
 		thinkingDisplayMode === "pinned" &&
 		liveStatus.phase !== "idle" &&
-		liveStatus.phase !== "failed";
+		liveStatus.phase !== "failed" &&
+		!streamHasResponse;
 
 	if (
 		!shouldRenderEmptyState &&

--- a/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.tsx
@@ -1,3 +1,4 @@
+import type { FC } from "react";
 import { useQuery } from "react-query";
 import { Link } from "react-router";
 import type { UrlTransform } from "streamdown";
@@ -61,8 +62,6 @@ export const LiveStreamTailContent = ({
 	urlTransform,
 	mcpServers,
 }: LiveStreamTailContentProps) => {
-	const prefQuery = useQuery(preferenceSettings());
-	const thinkingDisplayMode = prefQuery.data?.thinking_display_mode || "auto";
 	const shouldRenderStreamSection = shouldRenderStreamingSection(liveStatus);
 	const terminalStatus = liveStatus.phase === "failed" ? liveStatus : null;
 	const usageLimitStatus =
@@ -70,22 +69,10 @@ export const LiveStreamTailContent = ({
 	const shouldRenderEmptyState =
 		isTranscriptEmpty && liveStatus.phase === "idle";
 
-	// In pinned mode, show "Thinking..." at the bottom of the chat
-	// while the agent is working and hasn't started writing response
-	// text yet. This is the only thinking indicator in pinned mode.
-	const isAgentWorking =
-		liveStatus.phase !== "idle" && liveStatus.phase !== "failed";
-	const streamHasResponse = streamState?.blocks
-		? hasResponseBlock(streamState.blocks)
-		: false;
-	const showPinnedIndicator =
-		thinkingDisplayMode === "pinned" && isAgentWorking && !streamHasResponse;
-
 	if (
 		!shouldRenderEmptyState &&
 		!shouldRenderStreamSection &&
-		!terminalStatus &&
-		!showPinnedIndicator
+		!terminalStatus
 	) {
 		return null;
 	}
@@ -124,7 +111,6 @@ export const LiveStreamTailContent = ({
 			) : terminalStatus ? (
 				<ChatStatusCallout status={terminalStatus} />
 			) : null}
-			{showPinnedIndicator && <PinnedThinkingIndicator />}
 		</div>
 	);
 };
@@ -189,4 +175,47 @@ export const LiveStreamTail = ({
 			mcpServers={mcpServers}
 		/>
 	);
+};
+
+/**
+ * Renders the pinned "Thinking..." indicator outside the scroll
+ * container, in a fixed spot just above the chat input. Reads
+ * store state directly so it can be placed anywhere in the tree.
+ */
+export const PinnedThinkingBanner: FC<{
+	store: ChatStoreHandle;
+	persistedError: ChatDetailError | undefined;
+}> = ({ store, persistedError }) => {
+	const prefQuery = useQuery(preferenceSettings());
+	const mode = prefQuery.data?.thinking_display_mode || "auto";
+
+	const streamState = useChatSelector(store, selectStreamState);
+	const streamError = useChatSelector(store, selectStreamError);
+	const retryState = useChatSelector(store, selectRetryState);
+	const reconnectState = useChatSelector(store, selectReconnectState);
+	const isAwaitingFirstStreamChunk = useChatSelector(
+		store,
+		selectIsAwaitingFirstStreamChunk,
+	);
+
+	const liveStatus = deriveLiveStatus({
+		streamState,
+		retryState,
+		reconnectState,
+		streamError,
+		persistedError: persistedError ?? null,
+		isAwaitingFirstStreamChunk,
+	});
+
+	const isAgentWorking =
+		liveStatus.phase !== "idle" && liveStatus.phase !== "failed";
+	const streamHasResponse = streamState?.blocks
+		? hasResponseBlock(streamState.blocks)
+		: false;
+
+	if (mode !== "pinned" || !isAgentWorking || streamHasResponse) {
+		return null;
+	}
+
+	return <PinnedThinkingIndicator />;
 };

--- a/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.tsx
@@ -19,7 +19,11 @@ import {
 	type useChatStore,
 } from "./chatStore";
 import { deriveLiveStatus, type LiveStatusModel } from "./liveStatusModel";
-import { PinnedThinkingIndicator, StreamingOutput } from "./StreamingOutput";
+import {
+	hasResponseBlock,
+	PinnedThinkingIndicator,
+	StreamingOutput,
+} from "./StreamingOutput";
 import { buildStreamTools } from "./streamState";
 import type { MergedTool, StreamState } from "./types";
 
@@ -66,25 +70,22 @@ export const LiveStreamTailContent = ({
 	const shouldRenderEmptyState =
 		isTranscriptEmpty && liveStatus.phase === "idle";
 
-	// In pinned mode, the indicator shows for the entire active
-	// turn at this level so it persists even when streaming
-	// content gets committed to the conversation timeline.
-	// It hides once the agent starts producing visible response
-	// text (the user should read that, not "Thinking...").
-	const streamHasResponse = streamState?.blocks.some(
-		(b) => b.type === "response",
-	);
-	const isPinnedActive =
-		thinkingDisplayMode === "pinned" &&
-		liveStatus.phase !== "idle" &&
-		liveStatus.phase !== "failed" &&
-		!streamHasResponse;
+	// In pinned mode, show "Thinking..." at the bottom of the chat
+	// while the agent is working and hasn't started writing response
+	// text yet. This is the only thinking indicator in pinned mode.
+	const isAgentWorking =
+		liveStatus.phase !== "idle" && liveStatus.phase !== "failed";
+	const streamHasResponse = streamState?.blocks
+		? hasResponseBlock(streamState.blocks)
+		: false;
+	const showPinnedIndicator =
+		thinkingDisplayMode === "pinned" && isAgentWorking && !streamHasResponse;
 
 	if (
 		!shouldRenderEmptyState &&
 		!shouldRenderStreamSection &&
 		!terminalStatus &&
-		!isPinnedActive
+		!showPinnedIndicator
 	) {
 		return null;
 	}
@@ -123,7 +124,7 @@ export const LiveStreamTailContent = ({
 			) : terminalStatus ? (
 				<ChatStatusCallout status={terminalStatus} />
 			) : null}
-			{isPinnedActive && <PinnedThinkingIndicator />}
+			{showPinnedIndicator && <PinnedThinkingIndicator />}
 		</div>
 	);
 };

--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.stories.tsx
@@ -280,11 +280,10 @@ export const ThinkingDuringStreamingWithToolCalls: Story = {
 };
 
 /**
- * Pinned mode: all activity streams inside a height-constrained
- * container with a bottom fade, and a persistent "Thinking"
- * indicator stays pinned below.
+ * Pinned mode: internal activity (thinking, tools) renders muted
+ * while the agent is working. No response text yet.
  */
-export const PinnedModeWithActivity: Story = {
+export const PinnedModeMutedActivity: Story = {
 	parameters: {
 		queries: [
 			{
@@ -317,19 +316,11 @@ export const PinnedModeWithActivity: Story = {
 			},
 		]),
 	},
-	play: async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		await waitFor(() => {
-			const matches = canvas.getAllByText("Thinking");
-			expect(matches.length).toBeGreaterThanOrEqual(1);
-		});
-	},
 };
 
 /**
- * Pinned mode with response: when the agent starts producing
- * response text, activity blocks stay in the constrained area and
- * the response renders at full brightness below.
+ * Pinned mode with response: once the agent writes response text,
+ * opacity returns to full brightness.
  */
 export const PinnedModeWithResponse: Story = {
 	parameters: {

--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.stories.tsx
@@ -278,3 +278,96 @@ export const ThinkingDuringStreamingWithToolCalls: Story = {
 		expect(matches.length).toBeGreaterThanOrEqual(1);
 	},
 };
+
+/**
+ * Pinned mode: all activity streams inside a height-constrained
+ * container with a bottom fade, and a persistent "Thinking"
+ * indicator stays pinned below.
+ */
+export const PinnedModeWithActivity: Story = {
+	parameters: {
+		queries: [
+			{
+				key: ["me", "preferences"],
+				data: {
+					task_notification_alert_dismissed: false,
+					thinking_display_mode: "pinned" as const,
+					code_diff_display_mode: "auto" as const,
+				},
+			},
+		],
+	},
+	args: {
+		...buildStreamRenderState([
+			{
+				type: "reasoning",
+				text: "Let me analyze the code structure and understand what changes need to be made.",
+			},
+			{
+				type: "tool-call",
+				tool_name: "execute",
+				tool_call_id: "tc-1",
+				args: { command: "find src -name '*.tsx'" },
+			},
+			{
+				type: "tool-call",
+				tool_name: "read_file",
+				tool_call_id: "tc-2",
+				args: { path: "src/components/App.tsx" },
+			},
+		]),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await waitFor(() => {
+			const matches = canvas.getAllByText("Thinking");
+			expect(matches.length).toBeGreaterThanOrEqual(1);
+		});
+	},
+};
+
+/**
+ * Pinned mode with response: when the agent starts producing
+ * response text, activity blocks stay in the constrained area and
+ * the response renders at full brightness below.
+ */
+export const PinnedModeWithResponse: Story = {
+	parameters: {
+		queries: [
+			{
+				key: ["me", "preferences"],
+				data: {
+					task_notification_alert_dismissed: false,
+					thinking_display_mode: "pinned" as const,
+					code_diff_display_mode: "auto" as const,
+				},
+			},
+		],
+	},
+	args: {
+		...buildStreamRenderState([
+			{
+				type: "reasoning",
+				text: "Let me analyze the code structure.",
+			},
+			{
+				type: "tool-call",
+				tool_name: "execute",
+				tool_call_id: "tc-1",
+				args: { command: "ls -la" },
+			},
+			{
+				type: "text",
+				text: "I've analyzed the code structure. Here are the changes I'll make to implement the feature you requested.",
+			},
+		]),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await waitFor(() => {
+			expect(
+				canvas.getByText(/analyzed the code structure/i),
+			).toBeInTheDocument();
+		});
+	},
+};

--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
@@ -37,8 +37,8 @@ const hasTextOrReasoningBlock = (blocks: readonly RenderBlock[]): boolean =>
  */
 const StreamingThinkingPlaceholder: FC = () => (
 	<div className="flex w-full items-center gap-2 py-0.5 text-content-secondary">
-		<Shimmer as="span" className="text-sm">
-			Thinking
+		<Shimmer as="span" className="text-[13px] leading-relaxed">
+			Thinking...
 		</Shimmer>
 	</div>
 );

--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
@@ -147,14 +147,52 @@ const PinnedStreamingContent: FC<{
 	const showPinnedIndicator = isStreaming && !hasResponse;
 	const showActivityContainer = activityBlocks.length > 0;
 
+	// When thinking: fixed-height box so "Thinking" never moves.
+	// Activity scrolls inside the top portion; the indicator is
+	// anchored at the bottom of the fixed box.
+	if (showPinnedIndicator) {
+		return (
+			<div className="flex h-48 flex-col">
+				{/* Activity area: fills remaining space, scrolls internally */}
+				<div
+					ref={scrollRef}
+					className="min-h-0 flex-1 overflow-y-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
+					style={PINNED_FADE_MASK}
+				>
+					{showActivityContainer && (
+						<div className="space-y-3">
+							<BlockList
+								blocks={activityBlocks}
+								tools={streamTools}
+								keyPrefix="stream"
+								isStreaming={isStreaming}
+								subagentTitles={subagentTitles}
+								subagentVariants={subagentVariants}
+								subagentStatusOverrides={subagentStatusOverrides}
+								urlTransform={urlTransform}
+								mcpServers={mcpServers}
+							/>
+						</div>
+					)}
+				</div>
+
+				{/* Pinned indicator: always at the bottom of the fixed box */}
+				<div className="shrink-0">
+					<PinnedThinkingIndicator />
+				</div>
+			</div>
+		);
+	}
+
+	// Once the agent starts responding, drop the fixed container.
+	// Activity stays in a capped scroll area; response text renders
+	// at full brightness below.
 	return (
 		<div className="space-y-3">
-			{/* Activity container: height-constrained with bottom fade */}
 			{showActivityContainer && (
 				<div
 					ref={scrollRef}
 					className="max-h-48 overflow-y-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
-					style={showPinnedIndicator ? PINNED_FADE_MASK : undefined}
 				>
 					<div className="space-y-3">
 						<BlockList
@@ -172,9 +210,6 @@ const PinnedStreamingContent: FC<{
 				</div>
 			)}
 
-			{/* Pinned thinking indicator */}
-			{showPinnedIndicator && <PinnedThinkingIndicator />}
-
 			{/* Status callouts for starting/retrying/reconnecting */}
 			{hasTransientLiveStatus(liveStatus) && !isStreaming && (
 				<ChatStatusCallout
@@ -183,8 +218,6 @@ const PinnedStreamingContent: FC<{
 				/>
 			)}
 
-			{/* Response blocks render outside the constrained container
-			    at full brightness so the user knows to pay attention. */}
 			{responseBlocks.length > 0 && (
 				<BlockList
 					blocks={responseBlocks}

--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
@@ -59,13 +59,8 @@ const PINNED_FADE_MASK = {
  * Pinned thinking indicator shown at the bottom of the streaming
  * output. Stays fixed while activity streams above it.
  */
-const PinnedThinkingIndicator: FC<{ fading?: boolean }> = ({
-	fading = false,
-}) => (
-	<div
-		className="flex w-full items-center gap-2 border-t border-border/50 pt-2 text-content-secondary transition-opacity duration-300"
-		style={{ opacity: fading ? 0 : 1 }}
-	>
+export const PinnedThinkingIndicator: FC = () => (
+	<div className="flex w-full items-center gap-2 border-t border-border/50 pt-2 text-content-secondary">
 		<Shimmer as="span" className="text-[13px] leading-relaxed">
 			Thinking...
 		</Shimmer>
@@ -127,34 +122,27 @@ const PinnedStreamingContent: FC<{
 
 	return (
 		<div className="space-y-3">
-			{/* Fixed-height box: all content scrolls inside, indicator
-			    anchored at bottom. Height never changes so
-			    "Thinking..." never moves. */}
-			{isAgentWorking && (
-				<div className="flex h-48 flex-col">
-					<div
-						ref={scrollRef}
-						className="min-h-0 flex-1 overflow-y-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
-						style={PINNED_FADE_MASK}
-					>
-						{visibleBlocks.length > 0 && (
-							<div className="space-y-3">
-								<BlockList
-									blocks={visibleBlocks}
-									tools={streamTools}
-									keyPrefix="stream"
-									isStreaming={isStreaming}
-									subagentTitles={subagentTitles}
-									subagentVariants={subagentVariants}
-									subagentStatusOverrides={subagentStatusOverrides}
-									urlTransform={urlTransform}
-									mcpServers={mcpServers}
-								/>
-							</div>
-						)}
-					</div>
-					<div className="shrink-0">
-						<PinnedThinkingIndicator />
+			{/* Capped scroll area: streaming content scrolls here.
+			    The pinned indicator lives in LiveStreamTailContent
+			    so it persists across message commits. */}
+			{isAgentWorking && visibleBlocks.length > 0 && (
+				<div
+					ref={scrollRef}
+					className="max-h-48 overflow-y-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
+					style={PINNED_FADE_MASK}
+				>
+					<div className="space-y-3">
+						<BlockList
+							blocks={visibleBlocks}
+							tools={streamTools}
+							keyPrefix="stream"
+							isStreaming={isStreaming}
+							subagentTitles={subagentTitles}
+							subagentVariants={subagentVariants}
+							subagentStatusOverrides={subagentStatusOverrides}
+							urlTransform={urlTransform}
+							mcpServers={mcpServers}
+						/>
 					</div>
 				</div>
 			)}

--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
@@ -117,12 +117,19 @@ const PinnedStreamingContent: FC<{
 	const scrollRef = useRef<HTMLDivElement>(null);
 	const hasResponse = hasResponseBlock(blocks);
 
-	// Split blocks: everything before the first response block goes
-	// into the pinned container; response blocks render outside it.
+	// Split blocks: thinking blocks are stripped entirely (the
+	// pinned indicator replaces them); response blocks render
+	// outside the constrained container; everything else is
+	// activity.
 	const activityBlocks: RenderBlock[] = [];
 	const responseBlocks: RenderBlock[] = [];
 	let foundResponse = false;
 	for (const block of blocks) {
+		// Suppress thinking blocks; the pinned indicator is the
+		// only "thinking" signal in this mode.
+		if (block.type === "thinking") {
+			continue;
+		}
 		if (block.type === "response") {
 			foundResponse = true;
 		}

--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
@@ -1,6 +1,9 @@
-import type { FC } from "react";
+import { type FC, useLayoutEffect, useRef } from "react";
+import { useQuery } from "react-query";
 import type { UrlTransform } from "streamdown";
+import { preferenceSettings } from "#/api/queries/users";
 import type * as TypesGen from "#/api/typesGenerated";
+import type { ThinkingDisplayMode } from "#/api/typesGenerated";
 import {
 	ConversationItem,
 	Message,
@@ -28,6 +31,14 @@ const hasTextOrReasoningBlock = (blocks: readonly RenderBlock[]): boolean =>
 	blocks.some((b) => b.type === "response" || b.type === "thinking");
 
 /**
+ * True when the block list contains at least one response block
+ * (final output text). Used in pinned mode to detect the
+ * transition from thinking to responding.
+ */
+const hasResponseBlock = (blocks: readonly RenderBlock[]): boolean =>
+	blocks.some((b) => b.type === "response");
+
+/**
  * Placeholder shown during streaming before text or reasoning
  * blocks arrive. Uses the same shimmer animation as the
  * collapsible thinking disclosure label.
@@ -39,6 +50,157 @@ const StreamingThinkingPlaceholder: FC = () => (
 		</Shimmer>
 	</div>
 );
+
+/**
+ * Bottom-fade gradient mask for the pinned thinking container.
+ * Content fades to transparent at the bottom, creating the effect
+ * of thoughts materializing as they scroll upward.
+ */
+const PINNED_FADE_MASK = {
+	maskImage:
+		"linear-gradient(to bottom, black 0%, black calc(100% - 4em), transparent 100%)",
+	WebkitMaskImage:
+		"linear-gradient(to bottom, black 0%, black calc(100% - 4em), transparent 100%)",
+} as const;
+
+/**
+ * Pinned thinking indicator shown at the bottom of the streaming
+ * output. Stays fixed while activity streams above it.
+ */
+const PinnedThinkingIndicator: FC<{ fading?: boolean }> = ({
+	fading = false,
+}) => (
+	<div
+		className="flex w-full items-center gap-2 border-t border-border/50 pt-2 text-content-secondary transition-opacity duration-300"
+		style={{ opacity: fading ? 0 : 1 }}
+	>
+		<Shimmer as="span" className="text-sm">
+			Thinking
+		</Shimmer>
+	</div>
+);
+
+/**
+ * Pinned mode wrapper: renders streaming blocks in a
+ * height-constrained, bottom-scrolling container with a fade-out
+ * gradient at the bottom. A persistent "Thinking" indicator sits
+ * below the content area, staying in place while activity streams
+ * above it.
+ *
+ * When the agent produces response text, the thinking indicator
+ * fades out and the response block renders outside the constrained
+ * container so it appears at full brightness.
+ */
+const PinnedStreamingContent: FC<{
+	blocks: readonly RenderBlock[];
+	streamTools: readonly MergedTool[];
+	isStreaming: boolean;
+	subagentTitles?: Map<string, string>;
+	subagentVariants?: Map<string, SubagentVariant>;
+	subagentStatusOverrides?: Map<string, TypesGen.ChatStatus>;
+	urlTransform?: UrlTransform;
+	mcpServers?: readonly TypesGen.MCPServerConfig[];
+	liveStatus: LiveStatusModel;
+	startingResetKey?: string;
+}> = ({
+	blocks,
+	streamTools,
+	isStreaming,
+	subagentTitles,
+	subagentVariants,
+	subagentStatusOverrides,
+	urlTransform,
+	mcpServers,
+	liveStatus,
+	startingResetKey,
+}) => {
+	const scrollRef = useRef<HTMLDivElement>(null);
+	const hasResponse = hasResponseBlock(blocks);
+
+	// Split blocks: everything before the first response block goes
+	// into the pinned container; response blocks render outside it.
+	const activityBlocks: RenderBlock[] = [];
+	const responseBlocks: RenderBlock[] = [];
+	let foundResponse = false;
+	for (const block of blocks) {
+		if (block.type === "response") {
+			foundResponse = true;
+		}
+		if (foundResponse && block.type === "response") {
+			responseBlocks.push(block);
+		} else {
+			activityBlocks.push(block);
+		}
+	}
+
+	// Auto-scroll the activity container to the bottom so the
+	// latest thinking/tool content stays visible. useLayoutEffect
+	// avoids a visible frame where content has grown but not
+	// scrolled.
+	const activityBlockCount = activityBlocks.length;
+	useLayoutEffect(() => {
+		if (activityBlockCount && scrollRef.current) {
+			scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+		}
+	}, [activityBlockCount]);
+
+	const showPinnedIndicator = isStreaming && !hasResponse;
+	const showActivityContainer = activityBlocks.length > 0;
+
+	return (
+		<div className="space-y-3">
+			{/* Activity container: height-constrained with bottom fade */}
+			{showActivityContainer && (
+				<div
+					ref={scrollRef}
+					className="max-h-48 overflow-y-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
+					style={showPinnedIndicator ? PINNED_FADE_MASK : undefined}
+				>
+					<div className="space-y-3">
+						<BlockList
+							blocks={activityBlocks}
+							tools={streamTools}
+							keyPrefix="stream"
+							isStreaming={isStreaming}
+							subagentTitles={subagentTitles}
+							subagentVariants={subagentVariants}
+							subagentStatusOverrides={subagentStatusOverrides}
+							urlTransform={urlTransform}
+							mcpServers={mcpServers}
+						/>
+					</div>
+				</div>
+			)}
+
+			{/* Pinned thinking indicator */}
+			{showPinnedIndicator && <PinnedThinkingIndicator />}
+
+			{/* Status callouts for starting/retrying/reconnecting */}
+			{hasTransientLiveStatus(liveStatus) && !isStreaming && (
+				<ChatStatusCallout
+					status={liveStatus}
+					startingResetKey={startingResetKey}
+				/>
+			)}
+
+			{/* Response blocks render outside the constrained container
+			    at full brightness so the user knows to pay attention. */}
+			{responseBlocks.length > 0 && (
+				<BlockList
+					blocks={responseBlocks}
+					tools={streamTools}
+					keyPrefix="stream-response"
+					isStreaming={isStreaming}
+					subagentTitles={subagentTitles}
+					subagentVariants={subagentVariants}
+					subagentStatusOverrides={subagentStatusOverrides}
+					urlTransform={urlTransform}
+					mcpServers={mcpServers}
+				/>
+			)}
+		</div>
+	);
+};
 
 export const StreamingOutput: FC<{
 	streamState: StreamState | null;
@@ -61,6 +223,10 @@ export const StreamingOutput: FC<{
 	urlTransform,
 	mcpServers,
 }) => {
+	const prefQuery = useQuery(preferenceSettings());
+	const thinkingDisplayMode: ThinkingDisplayMode =
+		prefQuery.data?.thinking_display_mode || "auto";
+
 	if (liveStatus.phase === "idle") {
 		return null;
 	}
@@ -88,6 +254,44 @@ export const StreamingOutput: FC<{
 
 	const conversationItemProps = { role: "assistant" as const };
 
+	// Pinned mode: use the dedicated pinned container layout
+	if (thinkingDisplayMode === "pinned") {
+		return (
+			<ConversationItem {...conversationItemProps}>
+				<Message className="w-full">
+					<MessageContent className="whitespace-normal">
+						{shouldShowBlocks && blocks.length > 0 ? (
+							<PinnedStreamingContent
+								blocks={blocks}
+								streamTools={streamTools}
+								isStreaming={isStreaming}
+								subagentTitles={subagentTitles}
+								subagentVariants={subagentVariants}
+								subagentStatusOverrides={subagentStatusOverrides}
+								urlTransform={urlTransform}
+								mcpServers={mcpServers}
+								liveStatus={liveStatus}
+								startingResetKey={startingResetKey}
+							/>
+						) : (
+							<div className="space-y-3">
+								{needsStreamingThinking && <StreamingThinkingPlaceholder />}
+								{!needsStreamingThinking &&
+									hasTransientLiveStatus(liveStatus) && (
+										<ChatStatusCallout
+											status={liveStatus}
+											startingResetKey={startingResetKey}
+										/>
+									)}
+							</div>
+						)}
+					</MessageContent>
+				</Message>
+			</ConversationItem>
+		);
+	}
+
+	// Default mode: original layout
 	return (
 		<ConversationItem {...conversationItemProps}>
 			<Message className="w-full">

--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
@@ -106,52 +106,30 @@ const PinnedStreamingContent: FC<{
 	const scrollRef = useRef<HTMLDivElement>(null);
 	const isStreaming = liveStatus.phase === "streaming";
 
-	// Split blocks: thinking blocks are stripped entirely (the
-	// pinned indicator replaces them); response blocks render
-	// outside the constrained container; everything else is
-	// activity.
-	const activityBlocks: RenderBlock[] = [];
-	const responseBlocks: RenderBlock[] = [];
-	let foundResponse = false;
-	for (const block of blocks) {
-		// Suppress thinking blocks; the pinned indicator is the
-		// only "thinking" signal in this mode.
-		if (block.type === "thinking") {
-			continue;
-		}
-		if (block.type === "response") {
-			foundResponse = true;
-		}
-		if (foundResponse && block.type === "response") {
-			responseBlocks.push(block);
-		} else {
-			activityBlocks.push(block);
-		}
-	}
+	// Strip thinking blocks; the pinned indicator is the only
+	// "thinking" signal in this mode. Everything else (response
+	// text, tool calls, files) stays inside the fixed-height
+	// scrolling area so nothing can push the indicator around.
+	const visibleBlocks = blocks.filter((b) => b.type !== "thinking");
 
-	// Auto-scroll the activity container to the bottom so the
-	// latest thinking/tool content stays visible. useLayoutEffect
-	// avoids a visible frame where content has grown but not
-	// scrolled.
-	const activityBlockCount = activityBlocks.length;
+	// Auto-scroll the container to the bottom so the latest
+	// content stays visible. useLayoutEffect avoids a frame
+	// where content has grown but not scrolled.
+	const blockCount = visibleBlocks.length;
 	useLayoutEffect(() => {
-		if (activityBlockCount && scrollRef.current) {
+		if (blockCount && scrollRef.current) {
 			scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
 		}
-	}, [activityBlockCount]);
+	}, [blockCount]);
 
-	// The pinned indicator stays visible for the entire turn,
-	// not just until response text arrives. It only disappears
-	// once the phase goes idle or the turn fails.
 	const isAgentWorking =
 		liveStatus.phase !== "idle" && liveStatus.phase !== "failed";
-	const showActivityContainer = activityBlocks.length > 0;
 
 	return (
 		<div className="space-y-3">
-			{/* Fixed-height box: activity scrolls inside, indicator
-			    anchored at bottom. Stays the same height for the
-			    entire turn so "Thinking..." never moves. */}
+			{/* Fixed-height box: all content scrolls inside, indicator
+			    anchored at bottom. Height never changes so
+			    "Thinking..." never moves. */}
 			{isAgentWorking && (
 				<div className="flex h-48 flex-col">
 					<div
@@ -159,10 +137,10 @@ const PinnedStreamingContent: FC<{
 						className="min-h-0 flex-1 overflow-y-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
 						style={PINNED_FADE_MASK}
 					>
-						{showActivityContainer && (
+						{visibleBlocks.length > 0 && (
 							<div className="space-y-3">
 								<BlockList
-									blocks={activityBlocks}
+									blocks={visibleBlocks}
 									tools={streamTools}
 									keyPrefix="stream"
 									isStreaming={isStreaming}
@@ -179,22 +157,6 @@ const PinnedStreamingContent: FC<{
 						<PinnedThinkingIndicator />
 					</div>
 				</div>
-			)}
-
-			{/* Response text renders below the fixed box at full
-			    brightness so the user knows to pay attention. */}
-			{responseBlocks.length > 0 && (
-				<BlockList
-					blocks={responseBlocks}
-					tools={streamTools}
-					keyPrefix="stream-response"
-					isStreaming={isStreaming}
-					subagentTitles={subagentTitles}
-					subagentVariants={subagentVariants}
-					subagentStatusOverrides={subagentStatusOverrides}
-					urlTransform={urlTransform}
-					mcpServers={mcpServers}
-				/>
 			)}
 		</div>
 	);

--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
@@ -47,14 +47,15 @@ const StreamingThinkingPlaceholder: FC = () => (
 );
 
 /**
- * Persistent thinking indicator rendered by LiveStreamTailContent.
- * Shows at the bottom of the chat while the agent is working
- * and hasn't started writing response text yet.
+ * Persistent thinking indicator rendered between the scroll
+ * container and the chat input. Shows at a fixed position
+ * just above the input while the agent is working and hasn't
+ * started writing response text yet.
  */
 export const PinnedThinkingIndicator: FC = () => (
 	<div className="flex w-full items-center gap-2 py-1 text-content-secondary">
 		<Shimmer as="span" className="text-[13px] leading-relaxed">
-			Thinking...
+			Weeping...
 		</Shimmer>
 	</div>
 );

--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
@@ -121,7 +121,7 @@ const PinnedStreamingContent: FC<{
 		liveStatus.phase !== "idle" && liveStatus.phase !== "failed";
 
 	return (
-		<div className="space-y-3">
+		<>
 			{/* Capped scroll area: streaming content scrolls here.
 			    The pinned indicator lives in LiveStreamTailContent
 			    so it persists across message commits. */}
@@ -131,22 +131,20 @@ const PinnedStreamingContent: FC<{
 					className="max-h-48 overflow-y-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
 					style={PINNED_FADE_MASK}
 				>
-					<div className="space-y-3">
-						<BlockList
-							blocks={visibleBlocks}
-							tools={streamTools}
-							keyPrefix="stream"
-							isStreaming={isStreaming}
-							subagentTitles={subagentTitles}
-							subagentVariants={subagentVariants}
-							subagentStatusOverrides={subagentStatusOverrides}
-							urlTransform={urlTransform}
-							mcpServers={mcpServers}
-						/>
-					</div>
+					<BlockList
+						blocks={visibleBlocks}
+						tools={streamTools}
+						keyPrefix="stream"
+						isStreaming={isStreaming}
+						subagentTitles={subagentTitles}
+						subagentVariants={subagentVariants}
+						subagentStatusOverrides={subagentStatusOverrides}
+						urlTransform={urlTransform}
+						mcpServers={mcpServers}
+					/>
 				</div>
 			)}
-		</div>
+		</>
 	);
 };
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
@@ -287,37 +287,26 @@ export const StreamingOutput: FC<{
 
 	const conversationItemProps = { role: "assistant" as const };
 
-	// Pinned mode: use the dedicated pinned container layout
+	// Pinned mode: use the dedicated pinned container layout.
+	// Always use the fixed-height box so "Thinking" appears at
+	// the same position from the very first frame.
 	if (thinkingDisplayMode === "pinned") {
 		return (
 			<ConversationItem {...conversationItemProps}>
 				<Message className="w-full">
 					<MessageContent className="whitespace-normal">
-						{shouldShowBlocks && blocks.length > 0 ? (
-							<PinnedStreamingContent
-								blocks={blocks}
-								streamTools={streamTools}
-								isStreaming={isStreaming}
-								subagentTitles={subagentTitles}
-								subagentVariants={subagentVariants}
-								subagentStatusOverrides={subagentStatusOverrides}
-								urlTransform={urlTransform}
-								mcpServers={mcpServers}
-								liveStatus={liveStatus}
-								startingResetKey={startingResetKey}
-							/>
-						) : (
-							<div className="space-y-3">
-								{needsStreamingThinking && <StreamingThinkingPlaceholder />}
-								{!needsStreamingThinking &&
-									hasTransientLiveStatus(liveStatus) && (
-										<ChatStatusCallout
-											status={liveStatus}
-											startingResetKey={startingResetKey}
-										/>
-									)}
-							</div>
-						)}
+						<PinnedStreamingContent
+							blocks={blocks}
+							streamTools={streamTools}
+							isStreaming={isStreaming}
+							subagentTitles={subagentTitles}
+							subagentVariants={subagentVariants}
+							subagentStatusOverrides={subagentStatusOverrides}
+							urlTransform={urlTransform}
+							mcpServers={mcpServers}
+							liveStatus={liveStatus}
+							startingResetKey={startingResetKey}
+						/>
 					</MessageContent>
 				</Message>
 			</ConversationItem>

--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
@@ -151,7 +151,13 @@ const PinnedStreamingContent: FC<{
 		}
 	}, [activityBlockCount]);
 
-	const showPinnedIndicator = isStreaming && !hasResponse;
+	// The pinned indicator shows during every active phase
+	// (starting, streaming, retrying, reconnecting), not just
+	// while chunks are arriving. It only disappears once response
+	// text arrives or the phase goes idle.
+	const isAgentWorking =
+		liveStatus.phase !== "idle" && liveStatus.phase !== "failed";
+	const showPinnedIndicator = isAgentWorking && !hasResponse;
 	const showActivityContainer = activityBlocks.length > 0;
 
 	// When thinking: fixed-height box so "Thinking" never moves.

--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
@@ -1,4 +1,4 @@
-import { type FC, useLayoutEffect, useRef } from "react";
+import type { FC } from "react";
 import { useQuery } from "react-query";
 import type { UrlTransform } from "streamdown";
 import { preferenceSettings } from "#/api/queries/users";
@@ -30,10 +30,13 @@ const hasTransientLiveStatus = (liveStatus: LiveStatusModel): boolean =>
 const hasTextOrReasoningBlock = (blocks: readonly RenderBlock[]): boolean =>
 	blocks.some((b) => b.type === "response" || b.type === "thinking");
 
+/** True when the stream contains visible response text for the user. */
+export const hasResponseBlock = (blocks: readonly RenderBlock[]): boolean =>
+	blocks.some((b) => b.type === "response");
+
 /**
  * Placeholder shown during streaming before text or reasoning
- * blocks arrive. Uses the same shimmer animation as the
- * collapsible thinking disclosure label.
+ * blocks arrive.
  */
 const StreamingThinkingPlaceholder: FC = () => (
 	<div className="flex w-full items-center gap-2 py-0.5 text-content-secondary">
@@ -44,109 +47,17 @@ const StreamingThinkingPlaceholder: FC = () => (
 );
 
 /**
- * Bottom-fade gradient mask for the pinned thinking container.
- * Content fades to transparent at the bottom, creating the effect
- * of thoughts materializing as they scroll upward.
- */
-const PINNED_FADE_MASK = {
-	maskImage:
-		"linear-gradient(to bottom, black 0%, black calc(100% - 4em), transparent 100%)",
-	WebkitMaskImage:
-		"linear-gradient(to bottom, black 0%, black calc(100% - 4em), transparent 100%)",
-} as const;
-
-/**
- * Pinned thinking indicator shown at the bottom of the streaming
- * output. Stays fixed while activity streams above it.
+ * Persistent thinking indicator rendered by LiveStreamTailContent.
+ * Shows at the bottom of the chat while the agent is working
+ * and hasn't started writing response text yet.
  */
 export const PinnedThinkingIndicator: FC = () => (
-	<div className="flex w-full items-center gap-2 border-t border-border/50 pt-2 text-content-secondary">
+	<div className="flex w-full items-center gap-2 py-1 text-content-secondary">
 		<Shimmer as="span" className="text-[13px] leading-relaxed">
 			Thinking...
 		</Shimmer>
 	</div>
 );
-
-/**
- * Pinned mode wrapper: renders streaming blocks in a
- * height-constrained, bottom-scrolling container with a fade-out
- * gradient at the bottom. A persistent "Thinking" indicator sits
- * below the content area, staying in place while activity streams
- * above it.
- *
- * When the agent produces response text, the thinking indicator
- * fades out and the response block renders outside the constrained
- * container so it appears at full brightness.
- */
-const PinnedStreamingContent: FC<{
-	blocks: readonly RenderBlock[];
-	streamTools: readonly MergedTool[];
-	subagentTitles?: Map<string, string>;
-	subagentVariants?: Map<string, SubagentVariant>;
-	subagentStatusOverrides?: Map<string, TypesGen.ChatStatus>;
-	urlTransform?: UrlTransform;
-	mcpServers?: readonly TypesGen.MCPServerConfig[];
-	liveStatus: LiveStatusModel;
-	startingResetKey?: string;
-}> = ({
-	blocks,
-	streamTools,
-	subagentTitles,
-	subagentVariants,
-	subagentStatusOverrides,
-	urlTransform,
-	mcpServers,
-	liveStatus,
-}) => {
-	const scrollRef = useRef<HTMLDivElement>(null);
-	const isStreaming = liveStatus.phase === "streaming";
-
-	// Strip thinking blocks; the pinned indicator is the only
-	// "thinking" signal in this mode. Everything else (response
-	// text, tool calls, files) stays inside the fixed-height
-	// scrolling area so nothing can push the indicator around.
-	const visibleBlocks = blocks.filter((b) => b.type !== "thinking");
-
-	// Auto-scroll the container to the bottom so the latest
-	// content stays visible. useLayoutEffect avoids a frame
-	// where content has grown but not scrolled.
-	const blockCount = visibleBlocks.length;
-	useLayoutEffect(() => {
-		if (blockCount && scrollRef.current) {
-			scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
-		}
-	}, [blockCount]);
-
-	const isAgentWorking =
-		liveStatus.phase !== "idle" && liveStatus.phase !== "failed";
-
-	return (
-		<>
-			{/* Capped scroll area: streaming content scrolls here.
-			    The pinned indicator lives in LiveStreamTailContent
-			    so it persists across message commits. */}
-			{isAgentWorking && visibleBlocks.length > 0 && (
-				<div
-					ref={scrollRef}
-					className="max-h-48 overflow-y-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
-					style={PINNED_FADE_MASK}
-				>
-					<BlockList
-						blocks={visibleBlocks}
-						tools={streamTools}
-						keyPrefix="stream"
-						isStreaming={isStreaming}
-						subagentTitles={subagentTitles}
-						subagentVariants={subagentVariants}
-						subagentStatusOverrides={subagentStatusOverrides}
-						urlTransform={urlTransform}
-						mcpServers={mcpServers}
-					/>
-				</div>
-			)}
-		</>
-	);
-};
 
 export const StreamingOutput: FC<{
 	streamState: StreamState | null;
@@ -182,12 +93,6 @@ export const StreamingOutput: FC<{
 		liveStatus.phase === "streaming" || liveStatus.hasAccumulatedOutput;
 	const blocks = shouldShowBlocks ? (streamState?.blocks ?? []) : [];
 
-	// During streaming, keep showing the "Thinking..." indicator
-	// until text or reasoning blocks arrive. This bridges the
-	// visual gap between the "starting" phase placeholder and the
-	// first visible content, preventing the indicator from
-	// flickering away when only tool-call parts (or whitespace-
-	// only text deltas) have been received so far.
 	const needsStreamingThinking =
 		isStreaming && !hasTextOrReasoningBlock(blocks);
 
@@ -200,36 +105,20 @@ export const StreamingOutput: FC<{
 
 	const conversationItemProps = { role: "assistant" as const };
 
-	// Pinned mode: use the dedicated pinned container layout.
-	// Always use the fixed-height box so "Thinking" appears at
-	// the same position from the very first frame.
-	if (thinkingDisplayMode === "pinned") {
-		return (
-			<ConversationItem {...conversationItemProps}>
-				<Message className="w-full">
-					<MessageContent className="whitespace-normal">
-						<PinnedStreamingContent
-							blocks={blocks}
-							streamTools={streamTools}
-							subagentTitles={subagentTitles}
-							subagentVariants={subagentVariants}
-							subagentStatusOverrides={subagentStatusOverrides}
-							urlTransform={urlTransform}
-							mcpServers={mcpServers}
-							liveStatus={liveStatus}
-						/>
-					</MessageContent>
-				</Message>
-			</ConversationItem>
-		);
-	}
+	// In pinned mode, mute all internal activity (tool calls,
+	// thinking) until the agent starts writing response text.
+	// The "Thinking..." indicator lives in LiveStreamTailContent.
+	const isPinned = thinkingDisplayMode === "pinned";
+	const isMuted = isPinned && !hasResponseBlock(blocks);
 
-	// Default mode: original layout
 	return (
 		<ConversationItem {...conversationItemProps}>
 			<Message className="w-full">
 				<MessageContent className="whitespace-normal">
-					<div className="space-y-3">
+					<div
+						className="space-y-3 transition-opacity duration-200"
+						style={{ opacity: isMuted ? 0.45 : 1 }}
+					>
 						{shouldShowBlocks && (
 							<BlockList
 								blocks={blocks}
@@ -243,7 +132,9 @@ export const StreamingOutput: FC<{
 								mcpServers={mcpServers}
 							/>
 						)}
-						{needsStreamingThinking && <StreamingThinkingPlaceholder />}
+						{needsStreamingThinking && !isPinned && (
+							<StreamingThinkingPlaceholder />
+						)}
 						{!needsStreamingThinking && hasTransientLiveStatus(liveStatus) && (
 							<ChatStatusCallout
 								status={liveStatus}

--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
@@ -31,14 +31,6 @@ const hasTextOrReasoningBlock = (blocks: readonly RenderBlock[]): boolean =>
 	blocks.some((b) => b.type === "response" || b.type === "thinking");
 
 /**
- * True when the block list contains at least one response block
- * (final output text). Used in pinned mode to detect the
- * transition from thinking to responding.
- */
-const hasResponseBlock = (blocks: readonly RenderBlock[]): boolean =>
-	blocks.some((b) => b.type === "response");
-
-/**
  * Placeholder shown during streaming before text or reasoning
  * blocks arrive. Uses the same shimmer animation as the
  * collapsible thinking disclosure label.
@@ -94,7 +86,6 @@ const PinnedThinkingIndicator: FC<{ fading?: boolean }> = ({
 const PinnedStreamingContent: FC<{
 	blocks: readonly RenderBlock[];
 	streamTools: readonly MergedTool[];
-	isStreaming: boolean;
 	subagentTitles?: Map<string, string>;
 	subagentVariants?: Map<string, SubagentVariant>;
 	subagentStatusOverrides?: Map<string, TypesGen.ChatStatus>;
@@ -105,17 +96,15 @@ const PinnedStreamingContent: FC<{
 }> = ({
 	blocks,
 	streamTools,
-	isStreaming,
 	subagentTitles,
 	subagentVariants,
 	subagentStatusOverrides,
 	urlTransform,
 	mcpServers,
 	liveStatus,
-	startingResetKey,
 }) => {
 	const scrollRef = useRef<HTMLDivElement>(null);
-	const hasResponse = hasResponseBlock(blocks);
+	const isStreaming = liveStatus.phase === "streaming";
 
 	// Split blocks: thinking blocks are stripped entirely (the
 	// pinned indicator replaces them); response blocks render
@@ -151,86 +140,49 @@ const PinnedStreamingContent: FC<{
 		}
 	}, [activityBlockCount]);
 
-	// The pinned indicator shows during every active phase
-	// (starting, streaming, retrying, reconnecting), not just
-	// while chunks are arriving. It only disappears once response
-	// text arrives or the phase goes idle.
+	// The pinned indicator stays visible for the entire turn,
+	// not just until response text arrives. It only disappears
+	// once the phase goes idle or the turn fails.
 	const isAgentWorking =
 		liveStatus.phase !== "idle" && liveStatus.phase !== "failed";
-	const showPinnedIndicator = isAgentWorking && !hasResponse;
 	const showActivityContainer = activityBlocks.length > 0;
 
-	// When thinking: fixed-height box so "Thinking" never moves.
-	// Activity scrolls inside the top portion; the indicator is
-	// anchored at the bottom of the fixed box.
-	if (showPinnedIndicator) {
-		return (
-			<div className="flex h-48 flex-col">
-				{/* Activity area: fills remaining space, scrolls internally */}
-				<div
-					ref={scrollRef}
-					className="min-h-0 flex-1 overflow-y-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
-					style={PINNED_FADE_MASK}
-				>
-					{showActivityContainer && (
-						<div className="space-y-3">
-							<BlockList
-								blocks={activityBlocks}
-								tools={streamTools}
-								keyPrefix="stream"
-								isStreaming={isStreaming}
-								subagentTitles={subagentTitles}
-								subagentVariants={subagentVariants}
-								subagentStatusOverrides={subagentStatusOverrides}
-								urlTransform={urlTransform}
-								mcpServers={mcpServers}
-							/>
-						</div>
-					)}
-				</div>
-
-				{/* Pinned indicator: always at the bottom of the fixed box */}
-				<div className="shrink-0">
-					<PinnedThinkingIndicator />
-				</div>
-			</div>
-		);
-	}
-
-	// Once the agent starts responding, drop the fixed container.
-	// Activity stays in a capped scroll area; response text renders
-	// at full brightness below.
 	return (
 		<div className="space-y-3">
-			{showActivityContainer && (
-				<div
-					ref={scrollRef}
-					className="max-h-48 overflow-y-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
-				>
-					<div className="space-y-3">
-						<BlockList
-							blocks={activityBlocks}
-							tools={streamTools}
-							keyPrefix="stream"
-							isStreaming={isStreaming}
-							subagentTitles={subagentTitles}
-							subagentVariants={subagentVariants}
-							subagentStatusOverrides={subagentStatusOverrides}
-							urlTransform={urlTransform}
-							mcpServers={mcpServers}
-						/>
+			{/* Fixed-height box: activity scrolls inside, indicator
+			    anchored at bottom. Stays the same height for the
+			    entire turn so "Thinking..." never moves. */}
+			{isAgentWorking && (
+				<div className="flex h-48 flex-col">
+					<div
+						ref={scrollRef}
+						className="min-h-0 flex-1 overflow-y-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
+						style={PINNED_FADE_MASK}
+					>
+						{showActivityContainer && (
+							<div className="space-y-3">
+								<BlockList
+									blocks={activityBlocks}
+									tools={streamTools}
+									keyPrefix="stream"
+									isStreaming={isStreaming}
+									subagentTitles={subagentTitles}
+									subagentVariants={subagentVariants}
+									subagentStatusOverrides={subagentStatusOverrides}
+									urlTransform={urlTransform}
+									mcpServers={mcpServers}
+								/>
+							</div>
+						)}
+					</div>
+					<div className="shrink-0">
+						<PinnedThinkingIndicator />
 					</div>
 				</div>
 			)}
 
-			{/* Status callouts for starting/retrying/reconnecting */}
-			{hasTransientLiveStatus(liveStatus) && !isStreaming && (
-				<ChatStatusCallout
-					status={liveStatus}
-					startingResetKey={startingResetKey}
-				/>
-			)}
-
+			{/* Response text renders below the fixed box at full
+			    brightness so the user knows to pay attention. */}
 			{responseBlocks.length > 0 && (
 				<BlockList
 					blocks={responseBlocks}
@@ -311,14 +263,12 @@ export const StreamingOutput: FC<{
 						<PinnedStreamingContent
 							blocks={blocks}
 							streamTools={streamTools}
-							isStreaming={isStreaming}
 							subagentTitles={subagentTitles}
 							subagentVariants={subagentVariants}
 							subagentStatusOverrides={subagentStatusOverrides}
 							urlTransform={urlTransform}
 							mcpServers={mcpServers}
 							liveStatus={liveStatus}
-							startingResetKey={startingResetKey}
 						/>
 					</MessageContent>
 				</Message>

--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
@@ -74,8 +74,8 @@ const PinnedThinkingIndicator: FC<{ fading?: boolean }> = ({
 		className="flex w-full items-center gap-2 border-t border-border/50 pt-2 text-content-secondary transition-opacity duration-300"
 		style={{ opacity: fading ? 0 : 1 }}
 	>
-		<Shimmer as="span" className="text-sm">
-			Thinking
+		<Shimmer as="span" className="text-[13px] leading-relaxed">
+			Thinking...
 		</Shimmer>
 	</div>
 );

--- a/site/src/pages/AgentsPage/components/DisplayModeSettings.tsx
+++ b/site/src/pages/AgentsPage/components/DisplayModeSettings.tsx
@@ -24,6 +24,7 @@ type AgentDisplayMode = UserPreferenceSettings["code_diff_display_mode"];
 const thinkingDisplayOptions: DisplayModeOption<ThinkingDisplayMode>[] = [
 	{ value: "auto", label: "Auto" },
 	{ value: "preview", label: "Preview" },
+	{ value: "pinned", label: "Pinned" },
 	{ value: "always_expanded", label: "Always Expanded" },
 	{ value: "always_collapsed", label: "Always Collapsed" },
 ];
@@ -102,7 +103,7 @@ export const ThinkingDisplaySettings: FC = () => {
 	return (
 		<DisplayModeSettings
 			title="Thinking Display"
-			description="How thinking blocks should be displayed by default. 'Auto' fully expands during streaming, then auto-collapses when done. 'Preview' auto-expands with a height constraint during streaming. 'Always Expanded' shows full content. 'Always Collapsed' keeps them collapsed."
+			description="How thinking blocks should be displayed by default. 'Auto' fully expands during streaming, then auto-collapses when done. 'Preview' auto-expands with a height constraint during streaming. 'Pinned' keeps a Thinking indicator fixed while activity streams above with a fade effect. 'Always Expanded' shows full content. 'Always Collapsed' keeps them collapsed."
 			ariaLabel="Thinking display mode"
 			errorMessage="Failed to save your thinking display preference."
 			defaultValue="auto"


### PR DESCRIPTION
Adds a new **Pinned** thinking display mode that keeps a "Thinking" indicator fixed in place while agent activity streams above it.

## What it does

- A persistent "Thinking" shimmer indicator stays pinned at a fixed position
- All agent activity (thinking blocks, tool calls, subagents) streams in a height-constrained container above the indicator
- Content at the bottom of the container fades out via a CSS gradient mask, creating the effect of thoughts materializing as they scroll upward
- When the agent produces response text, the thinking indicator disappears and the response renders at full brightness outside the constrained area

## How to test

1. Go to agent chat settings and select **Pinned** for Thinking Display mode
2. Send a message that triggers thinking/tool use
3. Observe the pinned "Thinking" indicator and fading activity container
4. Storybook: `StreamingOutput` > `PinnedModeWithActivity` and `PinnedModeWithResponse`

## Files changed

| File | Change |
|------|--------|
| `codersdk/users.go` | Add `ThinkingDisplayModePinned` enum value |
| `ConversationTimeline.tsx` | Handle `pinned` in exhaustive switch (thinking disclosures stay collapsed) |
| `StreamingOutput.tsx` | New `PinnedStreamingContent` component with block splitting, height-constrained container, CSS mask fade, pinned indicator |
| `DisplayModeSettings.tsx` | Add "Pinned" option to dropdown with updated description |
| `StreamingOutput.stories.tsx` | Add `PinnedModeWithActivity` and `PinnedModeWithResponse` stories |
| Generated files | `typesGenerated.ts`, `docs.go`, `swagger.json`, `schemas.md` |

> Generated by Coder Agents