### PR TITLE
test(coderd/x/chatd): skip stale notification flakes

### DIFF
--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -2623,7 +2623,12 @@ func TestPromoteQueuedMessageReloadsChatWhenModelConfigChangesDuringPending(t *t
 
 func TestAutoPromoteQueuedMessagesPreservesPerTurnModelOrder(t *testing.T) {
 	t.Parallel()
-	skipUntilChatdNotificationFlowRefactor(t)
+	// TODO(CODAGT-353): Re-enable this test after the chatd notification flow
+	// refactor gives workers enough causal information to distinguish stale
+	// control NOTIFY messages from real interrupts. The current design reuses
+	// the same status notification shape for wake-only and interrupt intents,
+	// so a stale NOTIFY can cancel a new processChat run.
+	t.Skip("skipped until chatd notification flow refactor handles stale control notifications")
 
 	db, ps := dbtestutil.NewDB(t)
 	ctx := testutil.Context(t, testutil.WaitSuperLong)

--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -2623,6 +2623,7 @@ func TestPromoteQueuedMessageReloadsChatWhenModelConfigChangesDuringPending(t *t
 
 func TestAutoPromoteQueuedMessagesPreservesPerTurnModelOrder(t *testing.T) {
 	t.Parallel()
+	skipUntilChatdNotificationFlowRefactor(t)
 
 	db, ps := dbtestutil.NewDB(t)
 	ctx := testutil.Context(t, testutil.WaitSuperLong)

--- a/coderd/x/chatd/integration_responses_test.go
+++ b/coderd/x/chatd/integration_responses_test.go
@@ -23,19 +23,14 @@ import (
 	"github.com/coder/coder/v2/testutil"
 )
 
-func skipUntilChatdNotificationFlowRefactor(t *testing.T) {
-	t.Helper()
-	// TODO(CODAGT-353): Re-enable these tests after the chatd notification flow
+func TestOpenAIResponsesNoStaleWebSearchReplay(t *testing.T) {
+	t.Parallel()
+	// TODO(CODAGT-353): Re-enable this test after the chatd notification flow
 	// refactor gives workers enough causal information to distinguish stale
 	// control NOTIFY messages from real interrupts. The current design reuses
 	// the same status notification shape for wake-only and interrupt intents,
 	// so a stale NOTIFY can cancel a new processChat run.
 	t.Skip("skipped until chatd notification flow refactor handles stale control notifications")
-}
-
-func TestOpenAIResponsesNoStaleWebSearchReplay(t *testing.T) {
-	t.Parallel()
-	skipUntilChatdNotificationFlowRefactor(t)
 
 	db, ps := dbtestutil.NewDB(t)
 	ctx := testutil.Context(t, testutil.WaitLong)
@@ -119,7 +114,12 @@ func TestOpenAIResponsesNoStaleWebSearchReplay(t *testing.T) {
 
 func TestOpenAIResponsesFullReplayPairsReasoningAndWebSearch(t *testing.T) {
 	t.Parallel()
-	skipUntilChatdNotificationFlowRefactor(t)
+	// TODO(CODAGT-353): Re-enable this test after the chatd notification flow
+	// refactor gives workers enough causal information to distinguish stale
+	// control NOTIFY messages from real interrupts. The current design reuses
+	// the same status notification shape for wake-only and interrupt intents,
+	// so a stale NOTIFY can cancel a new processChat run.
+	t.Skip("skipped until chatd notification flow refactor handles stale control notifications")
 
 	db, ps := dbtestutil.NewDB(t)
 	ctx := testutil.Context(t, testutil.WaitLong)
@@ -202,7 +202,12 @@ func TestOpenAIResponsesFullReplayPairsReasoningAndWebSearch(t *testing.T) {
 
 func TestOpenAIResponsesChainModeSkipsWhenLocalCallPending(t *testing.T) {
 	t.Parallel()
-	skipUntilChatdNotificationFlowRefactor(t)
+	// TODO(CODAGT-353): Re-enable this test after the chatd notification flow
+	// refactor gives workers enough causal information to distinguish stale
+	// control NOTIFY messages from real interrupts. The current design reuses
+	// the same status notification shape for wake-only and interrupt intents,
+	// so a stale NOTIFY can cancel a new processChat run.
+	t.Skip("skipped until chatd notification flow refactor handles stale control notifications")
 
 	db, ps := dbtestutil.NewDB(t)
 	ctx := testutil.Context(t, testutil.WaitLong)
@@ -270,7 +275,12 @@ func TestOpenAIResponsesChainModeSkipsWhenLocalCallPending(t *testing.T) {
 
 func TestOpenAIResponsesChainModeStillFiresForProviderExecutedOnly(t *testing.T) {
 	t.Parallel()
-	skipUntilChatdNotificationFlowRefactor(t)
+	// TODO(CODAGT-353): Re-enable this test after the chatd notification flow
+	// refactor gives workers enough causal information to distinguish stale
+	// control NOTIFY messages from real interrupts. The current design reuses
+	// the same status notification shape for wake-only and interrupt intents,
+	// so a stale NOTIFY can cancel a new processChat run.
+	t.Skip("skipped until chatd notification flow refactor handles stale control notifications")
 
 	db, ps := dbtestutil.NewDB(t)
 	ctx := testutil.Context(t, testutil.WaitLong)

--- a/coderd/x/chatd/integration_responses_test.go
+++ b/coderd/x/chatd/integration_responses_test.go
@@ -23,8 +23,19 @@ import (
 	"github.com/coder/coder/v2/testutil"
 )
 
+func skipUntilChatdNotificationFlowRefactor(t *testing.T) {
+	t.Helper()
+	// TODO(CODAGT-353): Re-enable these tests after the chatd notification flow
+	// refactor gives workers enough causal information to distinguish stale
+	// control NOTIFY messages from real interrupts. The current design reuses
+	// the same status notification shape for wake-only and interrupt intents,
+	// so a stale NOTIFY can cancel a new processChat run.
+	t.Skip("skipped until chatd notification flow refactor handles stale control notifications")
+}
+
 func TestOpenAIResponsesNoStaleWebSearchReplay(t *testing.T) {
 	t.Parallel()
+	skipUntilChatdNotificationFlowRefactor(t)
 
 	db, ps := dbtestutil.NewDB(t)
 	ctx := testutil.Context(t, testutil.WaitLong)
@@ -108,6 +119,7 @@ func TestOpenAIResponsesNoStaleWebSearchReplay(t *testing.T) {
 
 func TestOpenAIResponsesFullReplayPairsReasoningAndWebSearch(t *testing.T) {
 	t.Parallel()
+	skipUntilChatdNotificationFlowRefactor(t)
 
 	db, ps := dbtestutil.NewDB(t)
 	ctx := testutil.Context(t, testutil.WaitLong)
@@ -190,6 +202,7 @@ func TestOpenAIResponsesFullReplayPairsReasoningAndWebSearch(t *testing.T) {
 
 func TestOpenAIResponsesChainModeSkipsWhenLocalCallPending(t *testing.T) {
 	t.Parallel()
+	skipUntilChatdNotificationFlowRefactor(t)
 
 	db, ps := dbtestutil.NewDB(t)
 	ctx := testutil.Context(t, testutil.WaitLong)
@@ -257,6 +270,7 @@ func TestOpenAIResponsesChainModeSkipsWhenLocalCallPending(t *testing.T) {
 
 func TestOpenAIResponsesChainModeStillFiresForProviderExecutedOnly(t *testing.T) {
 	t.Parallel()
+	skipUntilChatdNotificationFlowRefactor(t)
 
 	db, ps := dbtestutil.NewDB(t)
 	ctx := testutil.Context(t, testutil.WaitLong)


### PR DESCRIPTION
Skip the chatd tests that currently flake because the control notification flow cannot distinguish stale wake/status NOTIFY payloads from real interrupt requests. Each skipped test includes a TODO to re-enable it after the chatd notification flow refactor handles stale notifications correctly.

Supersedes #25133, #25134, #25135, and #25139.

Refs [CODAGT-353](https://linear.app/coder/issue/CODAGT-353), [CODAGT-356](https://linear.app/coder/issue/CODAGT-356), [CODAGT-360](https://linear.app/coder/issue/CODAGT-360), and [CODAGT-361](https://linear.app/coder/issue/CODAGT-361).

> Mux working on behalf of Mike.
