### PR TITLE
ci: migrate doc-check workflow to coder/agents-chat-action

### DIFF
--- a/.github/workflows/doc-check.yaml
+++ b/.github/workflows/doc-check.yaml
@@ -2,9 +2,6 @@
 # It creates a Coder Agent chat session that uses AI to analyze the PR
 # changes, search existing docs, and comment with recommendations.
 #
-# Uses the coder/create-agent-chat-action wrapper around the Coder Chat
-# API (/api/experimental/chats); no workspace provisioning required.
-#
 # Triggers:
 #   - New PR opened: Initial documentation review
 #   - PR updated (synchronize): Re-review after changes
@@ -213,18 +210,9 @@ jobs:
             echo "EOFOUTPUT"
           } >> "${GITHUB_OUTPUT}"
 
-      # ------------------------------------------------------------------
-      # Create and run the chat via the coder/create-agent-chat-action.
-      # The action wraps the Coder Chat API: it creates the chat, polls
-      # until terminal status (waiting, completed, error) or timeout, and
-      # posts a lifecycle comment on the linked PR. coder-username pins
-      # the run to the doc-check bot identity, bypassing the action's
-      # auto-resolve trust gate so every event (including fork PRs)
-      # runs as the bot, matching today's behavior.
-      # ------------------------------------------------------------------
       - name: Run doc-check via Coder Agent Chat
         if: steps.check-secrets.outputs.skip != 'true'
-        # pin to v0 tag once tagged.
+        # Pin to v0 tag once tagged.
         uses: coder/agents-chat-action@7fc11ff850800d5f60fd47306099d75996a674dd
         with:
           coder-url: ${{ secrets.DOC_CHECK_CODER_URL }}
@@ -235,7 +223,6 @@ jobs:
           github-token: ${{ github.token }}
           wait: complete
           wait-timeout-seconds: "600"
-          # The doc-check agent posts its own sticky review comment when
-          # there are findings; failures surface in the workflow run log.
-          # The action's own lifecycle comment is not needed.
+          # The doc-check agent posts its own sticky comment when there
+          # are findings; failures surface in the workflow run log.
           comment-on-issue: "false"

--- a/.github/workflows/doc-check.yaml
+++ b/.github/workflows/doc-check.yaml
@@ -46,7 +46,8 @@ jobs:
         github.event.action == 'ready_for_review' ||
         github.event_name == 'workflow_dispatch'
       ) &&
-      (github.event.pull_request.draft == false || github.event_name == 'workflow_dispatch')
+      (github.event.pull_request.draft == false || github.event_name == 'workflow_dispatch') &&
+      (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository)
     timeout-minutes: 30
     permissions:
       contents: read
@@ -213,11 +214,10 @@ jobs:
       - name: Run doc-check via Coder Agent Chat
         if: steps.check-secrets.outputs.skip != 'true'
         # Pin to v0 tag once tagged.
-        uses: coder/agents-chat-action@7fc11ff850800d5f60fd47306099d75996a674dd
+        uses: coder/agents-chat-action@4a306258d449f8a34df7be77be2c6fc63397ad57
         with:
           coder-url: ${{ secrets.DOC_CHECK_CODER_URL }}
           coder-token: ${{ secrets.DOC_CHECK_CODER_SESSION_TOKEN }}
-          coder-username: doc-check-bot
           chat-prompt: ${{ steps.extract-context.outputs.chat_prompt }}
           github-url: ${{ steps.determine-context.outputs.pr_url }}
           github-token: ${{ github.token }}

--- a/.github/workflows/doc-check.yaml
+++ b/.github/workflows/doc-check.yaml
@@ -170,7 +170,7 @@ jobs:
 
           ${CONTEXT}
 
-          If this chat has no workspace attached yet, use \`list_templates\` and \`create_workspace\` to provision one from the \`coder-workflow-bot\` template. Its startup script bootstraps the GitHub App credentials \`gh\` needs to read and post on coder/coder. Reuse an existing workspace from that same template if one is already attached.
+          When creating a new workspace, use the \"coder-workflow-bot\" template.
 
           Use \`gh\` to get PR details, diff, and all comments. Look for an existing doc-check comment containing \`<!-- doc-check-sticky -->\` - if one exists, you'll update it instead of creating a new one.
 
@@ -235,3 +235,7 @@ jobs:
           github-token: ${{ github.token }}
           wait: complete
           wait-timeout-seconds: "600"
+          # The chat agent posts the doc-check sticky review comment
+          # itself; skip the action's own lifecycle comment to avoid
+          # dual-posting on every run.
+          comment-on-issue: "false"

--- a/.github/workflows/doc-check.yaml
+++ b/.github/workflows/doc-check.yaml
@@ -2,9 +2,8 @@
 # It creates a Coder Agent chat session that uses AI to analyze the PR
 # changes, search existing docs, and comment with recommendations.
 #
-# Uses the Coder Chat API (/api/experimental/chats) instead of the Tasks
-# API — all API calls use curl + jq directly, no dedicated GitHub Action
-# or workspace provisioning required.
+# Uses the coder/create-agent-chat-action wrapper around the Coder Chat
+# API (/api/experimental/chats); no workspace provisioning required.
 #
 # Triggers:
 #   - New PR opened: Initial documentation review
@@ -52,9 +51,6 @@ jobs:
       ) &&
       (github.event.pull_request.draft == false || github.event_name == 'workflow_dispatch')
     timeout-minutes: 30
-    env:
-      CODER_URL: ${{ secrets.DOC_CHECK_CODER_URL }}
-      CODER_SESSION_TOKEN: ${{ secrets.DOC_CHECK_CODER_SESSION_TOKEN }}
     permissions:
       contents: read
       pull-requests: write
@@ -216,162 +212,24 @@ jobs:
           } >> "${GITHUB_OUTPUT}"
 
       # ------------------------------------------------------------------
-      # Create a chat via the Coder Chat API.
-      # The Chat API creates a lightweight chat session — no workspace
-      # provisioning or dedicated GitHub Action checkout required.
+      # Create and run the chat via the coder/create-agent-chat-action.
+      # The action wraps the Coder Chat API: it creates the chat, polls
+      # until terminal status (waiting, completed, error) or timeout, and
+      # posts a lifecycle comment on the linked PR. coder-username pins
+      # the run to the doc-check bot identity, bypassing the action's
+      # auto-resolve trust gate so every event (including fork PRs)
+      # runs as the bot, matching today's behavior.
       # ------------------------------------------------------------------
-      - name: Create chat via Coder Chat API
+      - name: Run doc-check via Coder Agent Chat
         if: steps.check-secrets.outputs.skip != 'true'
-        id: create-chat
-        continue-on-error: true
-        env:
-          CHAT_PROMPT: ${{ steps.extract-context.outputs.chat_prompt }}
-        run: |
-          set -euo pipefail
-
-          echo "Creating chat session..."
-
-          RESPONSE=$(curl --silent --fail-with-body \
-            -X POST \
-            -H "Coder-Session-Token: ${CODER_SESSION_TOKEN}" \
-            -H "Content-Type: application/json" \
-            -d "$(jq -n --arg prompt "${CHAT_PROMPT}" \
-              '{content: [{type: "text", text: $prompt}]}')" \
-            "${CODER_URL}/api/experimental/chats")
-
-          CHAT_ID=$(echo "${RESPONSE}" | jq -r '.id')
-          CHAT_STATUS=$(echo "${RESPONSE}" | jq -r '.status')
-
-          if [[ -z "${CHAT_ID}" || "${CHAT_ID}" == "null" ]]; then
-            echo "::error::Failed to create chat — no ID returned"
-            echo "Response: ${RESPONSE}"
-            exit 1
-          fi
-
-          # Validate that CHAT_ID is a UUID before using it in URL paths.
-          if [[ ! "${CHAT_ID}" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
-            echo "::error::CHAT_ID is not a valid UUID: ${CHAT_ID}"
-            exit 1
-          fi
-
-          CHAT_URL="${CODER_URL}/agents?chat=${CHAT_ID}"
-
-          echo "Chat created: ${CHAT_ID} (status: ${CHAT_STATUS})"
-          echo "Chat URL: ${CHAT_URL}"
-
-          echo "chat_id=${CHAT_ID}" >> "${GITHUB_OUTPUT}"
-          echo "chat_url=${CHAT_URL}" >> "${GITHUB_OUTPUT}"
-
-      - name: Handle Chat Creation Failure
-        if: steps.check-secrets.outputs.skip != 'true' && steps.create-chat.outcome != 'success'
-        run: |
-          {
-            echo "## Documentation Check"
-            echo ""
-            echo "⚠️ The Coder Chat API was unavailable, so this"
-            echo "advisory documentation check did not run."
-            echo ""
-            echo "Maintainers can rerun the workflow or trigger it manually"
-            echo "after the service recovers."
-          } >> "${GITHUB_STEP_SUMMARY}"
-
-      - name: Write Chat Info
-        if: steps.check-secrets.outputs.skip != 'true' && steps.create-chat.outcome == 'success'
-        env:
-          CHAT_ID: ${{ steps.create-chat.outputs.chat_id }}
-          CHAT_URL: ${{ steps.create-chat.outputs.chat_url }}
-          PR_URL: ${{ steps.determine-context.outputs.pr_url }}
-        run: |
-          {
-            echo "## Documentation Check"
-            echo ""
-            echo "**PR:** ${PR_URL}"
-            echo "**Chat ID:** \`${CHAT_ID}\`"
-            echo "**Chat URL:** ${CHAT_URL}"
-            echo ""
-          } >> "${GITHUB_STEP_SUMMARY}"
-
-      # ------------------------------------------------------------------
-      # Poll the chat status until the agent finishes.
-      # The Chat API is asynchronous — after creation the agent begins
-      # working in the background. We poll GET /api/experimental/chats/<id>
-      # every 5 seconds until the status is "waiting" (agent needs input),
-      # "completed" (agent finished), or "error". Timeout after 10 minutes.
-      # ------------------------------------------------------------------
-      - name: Poll chat status
-        if: steps.check-secrets.outputs.skip != 'true' && steps.create-chat.outcome == 'success'
-        id: poll-status
-        env:
-          CHAT_ID: ${{ steps.create-chat.outputs.chat_id }}
-        run: |
-          set -euo pipefail
-
-          POLL_INTERVAL=5
-          TIMEOUT=600
-          ELAPSED=0
-
-          echo "Polling chat ${CHAT_ID} every ${POLL_INTERVAL}s (timeout: ${TIMEOUT}s)..."
-
-          while true; do
-            RESPONSE=$(curl --silent --fail-with-body \
-              -H "Coder-Session-Token: ${CODER_SESSION_TOKEN}" \
-              "${CODER_URL}/api/experimental/chats/${CHAT_ID}")
-
-            STATUS=$(echo "${RESPONSE}" | jq -r '.status')
-
-            echo "[${ELAPSED}s] Chat status: ${STATUS}"
-
-            case "${STATUS}" in
-              waiting|completed)
-                echo "Chat reached terminal status: ${STATUS}"
-                echo "final_status=${STATUS}" >> "${GITHUB_OUTPUT}"
-                exit 0
-                ;;
-              error)
-                echo "::error::Chat entered error state"
-                echo "${RESPONSE}" | jq .
-                echo "final_status=error" >> "${GITHUB_OUTPUT}"
-                exit 1
-                ;;
-              pending|running)
-                # Still working — keep polling.
-                ;;
-              *)
-                echo "::warning::Unknown chat status: ${STATUS}"
-                ;;
-            esac
-
-            if [[ ${ELAPSED} -ge ${TIMEOUT} ]]; then
-              echo "::error::Timed out after ${TIMEOUT}s waiting for chat to finish"
-              echo "final_status=timeout" >> "${GITHUB_OUTPUT}"
-              exit 1
-            fi
-
-            sleep "${POLL_INTERVAL}"
-            ELAPSED=$((ELAPSED + POLL_INTERVAL))
-          done
-
-      - name: Write Final Summary
-        if: always() && steps.check-secrets.outputs.skip != 'true'
-        env:
-          CREATE_CHAT_OUTCOME: ${{ steps.create-chat.outcome }}
-          CHAT_ID: ${{ steps.create-chat.outputs.chat_id }}
-          CHAT_URL: ${{ steps.create-chat.outputs.chat_url }}
-          FINAL_STATUS: ${{ steps.poll-status.outputs.final_status }}
-          PR_NUMBER: ${{ steps.determine-context.outputs.pr_number }}
-        run: |
-          {
-            echo ""
-            echo "---"
-            echo "### Result"
-            echo ""
-            if [[ "${CREATE_CHAT_OUTCOME}" == "success" ]]; then
-              echo "**Status:** ${FINAL_STATUS:-Chat completed}"
-              echo "**Chat URL:** ${CHAT_URL}"
-              echo ""
-              echo "Chat \`${CHAT_ID}\` has finished."
-            else
-              echo "**Status:** Skipped because the Coder Chat API"
-              echo "was unavailable."
-            fi
-          } >> "${GITHUB_STEP_SUMMARY}"
+        # pin to v0 tag once tagged.
+        uses: coder/create-agent-chat-action@6b790b141c672a38ce856f35c936ad1b939b1d53
+        with:
+          coder-url: ${{ secrets.DOC_CHECK_CODER_URL }}
+          coder-token: ${{ secrets.DOC_CHECK_CODER_SESSION_TOKEN }}
+          coder-username: doc-check-bot
+          chat-prompt: ${{ steps.extract-context.outputs.chat_prompt }}
+          github-url: ${{ steps.determine-context.outputs.pr_url }}
+          github-token: ${{ github.token }}
+          wait: complete
+          wait-timeout-seconds: "600"

--- a/.github/workflows/doc-check.yaml
+++ b/.github/workflows/doc-check.yaml
@@ -225,7 +225,7 @@ jobs:
       - name: Run doc-check via Coder Agent Chat
         if: steps.check-secrets.outputs.skip != 'true'
         # pin to v0 tag once tagged.
-        uses: coder/create-agent-chat-action@6b790b141c672a38ce856f35c936ad1b939b1d53
+        uses: coder/agents-chat-action@7fc11ff850800d5f60fd47306099d75996a674dd
         with:
           coder-url: ${{ secrets.DOC_CHECK_CODER_URL }}
           coder-token: ${{ secrets.DOC_CHECK_CODER_SESSION_TOKEN }}

--- a/.github/workflows/doc-check.yaml
+++ b/.github/workflows/doc-check.yaml
@@ -214,7 +214,7 @@ jobs:
       - name: Run doc-check via Coder Agent Chat
         if: steps.check-secrets.outputs.skip != 'true'
         # Pin to v0 tag once tagged.
-        uses: coder/agents-chat-action@4a306258d449f8a34df7be77be2c6fc63397ad57
+        uses: coder/agents-chat-action@f0b975f503d3ff3e4478517baae290d4d01a2c7e
         with:
           coder-url: ${{ secrets.DOC_CHECK_CODER_URL }}
           coder-token: ${{ secrets.DOC_CHECK_CODER_SESSION_TOKEN }}

--- a/.github/workflows/doc-check.yaml
+++ b/.github/workflows/doc-check.yaml
@@ -170,6 +170,8 @@ jobs:
 
           ${CONTEXT}
 
+          If this chat has no workspace attached yet, use \`list_templates\` and \`create_workspace\` to provision one from the \`coder-workflow-bot\` template. Its startup script bootstraps the GitHub App credentials \`gh\` needs to read and post on coder/coder. Reuse an existing workspace from that same template if one is already attached.
+
           Use \`gh\` to get PR details, diff, and all comments. Look for an existing doc-check comment containing \`<!-- doc-check-sticky -->\` - if one exists, you'll update it instead of creating a new one.
 
           **Do not comment if no documentation changes are needed.**

--- a/.github/workflows/doc-check.yaml
+++ b/.github/workflows/doc-check.yaml
@@ -235,7 +235,3 @@ jobs:
           github-token: ${{ github.token }}
           wait: complete
           wait-timeout-seconds: "600"
-          # The chat agent posts the doc-check sticky review comment
-          # itself; skip the action's own lifecycle comment to avoid
-          # dual-posting on every run.
-          comment-on-issue: "false"

--- a/.github/workflows/doc-check.yaml
+++ b/.github/workflows/doc-check.yaml
@@ -213,8 +213,7 @@ jobs:
 
       - name: Run doc-check via Coder Agent Chat
         if: steps.check-secrets.outputs.skip != 'true'
-        # Pin to v0 tag once tagged.
-        uses: coder/agents-chat-action@f0b975f503d3ff3e4478517baae290d4d01a2c7e
+        uses: coder/agents-chat-action@f0b975f503d3ff3e4478517baae290d4d01a2c7e # v0
         with:
           coder-url: ${{ secrets.DOC_CHECK_CODER_URL }}
           coder-token: ${{ secrets.DOC_CHECK_CODER_SESSION_TOKEN }}

--- a/.github/workflows/doc-check.yaml
+++ b/.github/workflows/doc-check.yaml
@@ -235,3 +235,7 @@ jobs:
           github-token: ${{ github.token }}
           wait: complete
           wait-timeout-seconds: "600"
+          # The doc-check agent posts its own sticky review comment when
+          # there are findings; failures surface in the workflow run log.
+          # The action's own lifecycle comment is not needed.
+          comment-on-issue: "false"


### PR DESCRIPTION
Replace the inline `curl` + `jq` block in `.github/workflows/doc-check.yaml` with a single `uses: coder/agents-chat-action` step.

Linear: [CODAGT-375](https://linear.app/codercom/issue/CODAGT-375/migrate-codercoder-doc-checkyaml-to-codercreate-agent-chat-actionv0)
Action repo: [coder/agents-chat-action](https://github.com/coder/agents-chat-action)

## Diff vs `main`

- `Create chat via Coder Chat API`, `Handle Chat Creation Failure`, `Write Chat Info`, `Poll chat status`, and `Write Final Summary` collapse into one `uses:` step.
- `Build chat prompt` gains one line: `When creating a new workspace, use the "coder-workflow-bot" template.` That template's startup script mints the GitHub App installation token the chat agent needs for `gh`. Without it the agent has no GitHub auth and silently no-ops; verified by scanning the last 100 PRs on `main` (zero `<!-- doc-check-sticky -->` comments dated after Apr 16).
- Job `env: CODER_URL / CODER_SESSION_TOKEN` is removed; both are now passed via `with:` inputs on the step.
- The job `if:` adds an explicit fork-PR gate (`pull_request.head.repo.full_name == github.repository`, with `workflow_dispatch` exempted). On `pull_request` GitHub already withholds `secrets.*` from fork PRs, so this is intent-not-mechanism.
- `comment-on-issue: false` keeps the action quiet; the chat agent posts its own `<!-- doc-check-sticky -->` review when there are findings, and failures show up in the workflow run log.

Triggers, draft guard, secret-availability guard, `Determine PR Context`, and the chat-prompt body are otherwise unchanged.

## Pinning

Pinned to [`f0b975f503d3ff3e4478517baae290d4d01a2c7e`](https://github.com/coder/agents-chat-action/commit/f0b975f503d3ff3e4478517baae290d4d01a2c7e), the commit tagged [`v0`](https://github.com/coder/agents-chat-action/tree/v0). SHA pin with version comment matches the convention used elsewhere in `.github/workflows/` for external actions.

## How to verify

```sh
gh workflow run doc-check.yaml \
  --ref mathias/migrate-doc-check-to-action \
  --field pr_url=<https://github.com/coder/coder/pull/SOMETHING>
```

Pick a Coder org member's recent PR with `docs/**` changes. Cold-start runs against a fresh PR provision a `doc-check-pr-<n>` workspace on the `coder-workflow-bot` template (a few minutes); subsequent runs reuse the warm workspace.

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻


