### PR TITLE
fix(testutil): ensure FakeSink does not swallow logs

### DIFF
--- a/testutil/fake_sink.go
+++ b/testutil/fake_sink.go
@@ -3,6 +3,7 @@ package testutil
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"cdr.dev/slog/v3"
@@ -15,11 +16,16 @@ type FakeSink struct {
 	t       testing.TB
 	mu      sync.RWMutex
 	entries []slog.SinkEntry
+	tDone   atomic.Bool
 }
 
 // NewFakeSink returns a FakeSink ready for use.
 func NewFakeSink(t testing.TB) *FakeSink {
-	return &FakeSink{t: t}
+	fs := &FakeSink{t: t}
+	t.Cleanup(func() {
+		fs.tDone.Store(true)
+	})
+	return fs
 }
 
 // LogEntry implements slog.Sink. It appends the entry to the
@@ -28,7 +34,7 @@ func (s *FakeSink) LogEntry(_ context.Context, e slog.SinkEntry) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.entries = append(s.entries, e)
-	if s.t.Context().Err() == nil { // avoid log after test finished
+	if !s.tDone.Load() {
 		s.t.Log(e.Message, e.Fields)
 	}
 }

--- a/testutil/fake_sink.go
+++ b/testutil/fake_sink.go
@@ -12,13 +12,14 @@ import (
 // tests can assert on what was logged. It requires a testing.TB
 // as it is only meant for use in tests.
 type FakeSink struct {
+	t       testing.TB
 	mu      sync.RWMutex
 	entries []slog.SinkEntry
 }
 
 // NewFakeSink returns a FakeSink ready for use.
-func NewFakeSink(_ testing.TB) *FakeSink {
-	return &FakeSink{}
+func NewFakeSink(t testing.TB) *FakeSink {
+	return &FakeSink{t: t}
 }
 
 // LogEntry implements slog.Sink. It appends the entry to the
@@ -27,6 +28,9 @@ func (s *FakeSink) LogEntry(_ context.Context, e slog.SinkEntry) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.entries = append(s.entries, e)
+	if s.t.Context().Err() == nil { // avoid log after test finished
+		s.t.Log(e.Message, e.Fields)
+	}
 }
 
 // Sync implements slog.Sink.

--- a/testutil/fake_sink.go
+++ b/testutil/fake_sink.go
@@ -3,7 +3,6 @@ package testutil
 import (
 	"context"
 	"sync"
-	"sync/atomic"
 	"testing"
 
 	"cdr.dev/slog/v3"
@@ -16,14 +15,16 @@ type FakeSink struct {
 	t       testing.TB
 	mu      sync.RWMutex
 	entries []slog.SinkEntry
-	tDone   atomic.Bool
+	tDone   bool
 }
 
 // NewFakeSink returns a FakeSink ready for use.
 func NewFakeSink(t testing.TB) *FakeSink {
 	fs := &FakeSink{t: t}
 	t.Cleanup(func() {
-		fs.tDone.Store(true)
+		fs.mu.Lock()
+		fs.tDone = true
+		fs.mu.Unlock()
 	})
 	return fs
 }
@@ -32,9 +33,10 @@ func NewFakeSink(t testing.TB) *FakeSink {
 // internal slice.
 func (s *FakeSink) LogEntry(_ context.Context, e slog.SinkEntry) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	s.entries = append(s.entries, e)
-	if !s.tDone.Load() {
+	shouldLog := !s.tDone
+	s.mu.Unlock()
+	if shouldLog {
 		s.t.Log(e.Message, e.Fields)
 	}
 }


### PR DESCRIPTION
`FakeSink` was silently capturing log entries without forwarding them to `testing.TB.Log`. This made debugging test failures harder because logs were invisible in `go test -v` output.

Store `testing.TB` in `FakeSink` and call `t.Log` on each entry, guarded by a context check to avoid logging after the test has finished.

Split out from #25012.

> 🤖 Generated with [Coder Agents](https://coder.com)