### PR TITLE
fix(agent): retry devcontainer sub-agent rejection test

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -2829,15 +2829,15 @@ func TestAgent_DevcontainersDisabledForSubAgent(t *testing.T) {
 		o.Devcontainers = true
 	})
 
-	// Query the containers API endpoint. This should fail because
-	// devcontainers have been disabled for the sub agent.
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitMedium)
 	defer cancel()
 
-	_, err := conn.ListContainers(ctx)
+	var err error
+	testutil.Eventually(ctx, t, func(ctx context.Context) bool {
+		_, err = conn.ListContainers(ctx)
+		return err != nil && strings.Contains(err.Error(), "Dev Container feature not supported.")
+	}, testutil.IntervalFast, "containers endpoint should reject devcontainers inside sub agents")
 	require.Error(t, err)
-
-	// Verify the error message contains the expected text.
 	require.Contains(t, err.Error(), "Dev Container feature not supported.")
 	require.Contains(t, err.Error(), "Dev Container integration inside other Dev Containers is explicitly not supported.")
 }

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -2833,8 +2833,13 @@ func TestAgent_DevcontainersDisabledForSubAgent(t *testing.T) {
 	defer cancel()
 
 	var err error
+	// setupAgent only waits for tailnet reachability, not for the HTTP API
+	// listener to serve the expected sub-agent rejection response.
 	testutil.Eventually(ctx, t, func(ctx context.Context) bool {
 		_, err = conn.ListContainers(ctx)
+		if err != nil {
+			t.Logf("Error listing containers: %v", err)
+		}
 		return err != nil && strings.Contains(err.Error(), "Dev Container feature not supported.")
 	}, testutil.IntervalFast, "containers endpoint should reject devcontainers inside sub agents")
 	require.Error(t, err)


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood

`TestAgent_DevcontainersDisabledForSubAgent` only waits for tailnet reachability before calling the agent containers API. The API listener starts separately, so under race detector load the single request can hit the endpoint before the stable sub-agent 403 response is available.

Retry the `ListContainers` call until the expected devcontainer-disabled response is observed, then assert the full error text.

Fixes CODAGT-107.

<details><summary>Investigation</summary>

- Historical failing commit `3a4a0b7270436e58ad6aa9a03a242c73f73bd388` reproduced with `go test -race ./agent -run TestAgent_DevcontainersDisabledForSubAgent -count=50`.
- `setupAgent()` returns after `agentConn.AwaitReachable(ctx)`, which verifies tailnet reachability, not HTTP API readiness.
- The HTTP API listener starts asynchronously in `agent.createTailnet()`.
- The stable expected result for a sub-agent is a `403` with `Dev Container feature not supported.` and `Dev Container integration inside other Dev Containers is explicitly not supported.`
- Current `main` did not reproduce locally in 100 race runs, but the code still had the single-shot request pattern.

</details>

## Verification

- `go test ./agent -run TestAgent_DevcontainersDisabledForSubAgent -count=50`
- `go test -race ./agent -run TestAgent_DevcontainersDisabledForSubAgent -count=50`
- `make fmt && make lint`
- pre-commit hook ran during commit and passed
