### PR TITLE
docs: mention making the GitHub App public and APP_INSTALL_URL

### DIFF
--- a/docs/admin/external-auth/index.md
+++ b/docs/admin/external-auth/index.md
@@ -334,6 +334,19 @@ CODER_EXTERNAL_AUTH_0_SCOPES="repo:read repo:write write:gpg_key"
 
    ![Install GitHub App](../../images/admin/github-app-install.png)
 
+1. If users other than yourself will link this provider, make the app
+   public. In the app's **Advanced** tab, click **Make this GitHub App
+   public**. Without this, users hitting the OAuth URL receive a GitHub
+   "Page not found" 404. Each user must then install the app on their
+   own account before linking; you can streamline that by also setting:
+
+   ```env
+   CODER_EXTERNAL_AUTH_0_APP_INSTALL_URL=https://github.com/apps/<your-app-slug>/installations/new
+   ```
+
+   With `APP_INSTALL_URL` set, Coder surfaces an "Install GitHub App"
+   link to users who need it.
+
 ## Multiple External Providers (Premium)
 
 Below is an example configuration with multiple providers:

--- a/docs/admin/external-auth/index.md
+++ b/docs/admin/external-auth/index.md
@@ -337,10 +337,11 @@ CODER_EXTERNAL_AUTH_0_SCOPES="repo:read repo:write write:gpg_key"
 1. Make the app installable by other users. In the app's **Advanced**
    tab, click **Make this GitHub App public**.
 
-   Without this, every user other than the app owner sees a GitHub 404
-   when they click **Link GitHub** in Coder. Each user must also install
-   the app on their own account before linking. To surface an
-   **Install GitHub App** link in the Coder UI, set:
+   Without this, anyone outside the app's owning account or owning
+   organization sees a GitHub 404 when they click **Link GitHub** in
+   Coder. Each user must also install the app on their own account
+   before linking. To surface an **Install GitHub App** link in the
+   Coder UI, set:
 
    ```env
    CODER_EXTERNAL_AUTH_0_APP_INSTALL_URL=https://github.com/apps/<your-app-slug>/installations/new

--- a/docs/admin/external-auth/index.md
+++ b/docs/admin/external-auth/index.md
@@ -335,13 +335,13 @@ CODER_EXTERNAL_AUTH_0_SCOPES="repo:read repo:write write:gpg_key"
    ![Install GitHub App](../../images/admin/github-app-install.png)
 
 1. Make the app installable by other users. In the app's **Advanced**
-   tab, click **Make this GitHub App public**.
+   tab, select **Make this GitHub App public**.
 
    Without this, anyone outside the app's owning account or owning
-   organization sees a GitHub 404 when they click **Link GitHub** in
+   organization gets a GitHub 404 when they select **Link GitHub** in
    Coder. Each user must also install the app on their own account
    before linking. To surface an **Install GitHub App** link in the
-   Coder UI, set:
+   Coder UI, set the following environment variable:
 
    ```env
    CODER_EXTERNAL_AUTH_0_APP_INSTALL_URL=https://github.com/apps/<your-app-slug>/installations/new

--- a/docs/admin/external-auth/index.md
+++ b/docs/admin/external-auth/index.md
@@ -334,18 +334,17 @@ CODER_EXTERNAL_AUTH_0_SCOPES="repo:read repo:write write:gpg_key"
 
    ![Install GitHub App](../../images/admin/github-app-install.png)
 
-1. If users other than yourself will link this provider, make the app
-   public. In the app's **Advanced** tab, click **Make this GitHub App
-   public**. Without this, users hitting the OAuth URL receive a GitHub
-   "Page not found" 404. Each user must then install the app on their
-   own account before linking; you can streamline that by also setting:
+1. Make the app installable by other users. In the app's **Advanced**
+   tab, click **Make this GitHub App public**.
+
+   Without this, every user other than the app owner sees a GitHub 404
+   when they click **Link GitHub** in Coder. Each user must also install
+   the app on their own account before linking. To surface an
+   **Install GitHub App** link in the Coder UI, set:
 
    ```env
    CODER_EXTERNAL_AUTH_0_APP_INSTALL_URL=https://github.com/apps/<your-app-slug>/installations/new
    ```
-
-   With `APP_INSTALL_URL` set, Coder surfaces an "Install GitHub App"
-   link to users who need it.
 
 ## Multiple External Providers (Premium)
 


### PR DESCRIPTION
## Summary

The GitHub App walkthrough in `docs/admin/external-auth/index.md` stops after \"install the app for your organization,\" which is enough for the admin who created the app but not for anyone else. Every other Coder user hitting **Link GitHub** lands on a GitHub 404 (`This is not the web page you are looking for`) because:

1. New GitHub Apps default to **\"Only on this account\"** / not public. GitHub returns 404 from the OAuth-authorize URL for any user other than the owner.
2. `CODER_EXTERNAL_AUTH_0_APP_INSTALL_URL` — the env var that makes Coder render an \"Install GitHub App\" link in the UI — is undocumented today.

This PR adds one extra step at the end of the GitHub App configuration walkthrough covering both.

## Test plan

- [x] \`make fmt/markdown\` clean
- [x] Doc reviewer eyes