### PR TITLE
test: use default provider in TestPatchChatMessage/ChangesModel

### DIFF
--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -7290,7 +7290,7 @@ func TestPatchChatMessage(t *testing.T) {
 		overrideModel := createAdditionalChatModelConfig(
 			t,
 			client,
-			"openai",
+			defaultModel.Provider,
 			"gpt-4o-mini-edit-override",
 		)
 

--- a/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.test.ts
@@ -19,6 +19,7 @@ const getDisplayState = (message: ChatMessage) =>
 		message,
 		parsed: parseMessageContent(message.content),
 		hideActions: false,
+		hasActiveStream: false,
 	});
 
 describe("deriveMessageDisplayState", () => {


### PR DESCRIPTION
`TestPatchChatMessage/ChangesModel` hardcoded `"openai"` as the provider for the override model config. After #25171, the shared chat test harness registers a single `"openai-compat"` provider by default, so calling `createAdditionalChatModelConfig(..., "openai", ...)` fails with HTTP 400 `Chat provider is not configured` before the test can exercise the model-change path. The subtest was added in #25084 after #25171 was reviewed, so the harness change and the new hardcoded provider only met on `main`.

Use `defaultModel.Provider` so the override always matches whatever provider the harness registered. This mirrors every other call site of `createAdditionalChatModelConfig` in the file.

Closes https://github.com/coder/internal/issues/1530
