### PR TITLE
fix(site/src/pages/AgentsPage/components): unify live thinking spacing and sizing

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -480,6 +480,7 @@ const ChatMessageItem = memo<{
 	isAfterEditingMessage?: boolean;
 	hideActions?: boolean;
 	hasActiveStream?: boolean;
+	isAwaitingFirstStreamChunk?: boolean;
 
 	// When true, renders a gradient overlay inside the bubble
 	// that fades text out toward the bottom. Used by the sticky
@@ -505,6 +506,7 @@ const ChatMessageItem = memo<{
 		isAfterEditingMessage = false,
 		hideActions = false,
 		hasActiveStream = false,
+		isAwaitingFirstStreamChunk = false,
 		fadeFromBottom = false,
 		onImplementPlan,
 		onSendAskUserQuestionResponse,
@@ -528,6 +530,7 @@ const ChatMessageItem = memo<{
 			parsed,
 			hideActions,
 			hasActiveStream,
+			isAwaitingFirstStreamChunk,
 		});
 		if (displayState.shouldHide) {
 			return null;
@@ -965,6 +968,7 @@ function computeLastInChainFlags(
 			parsed: entry.parsed,
 			hideActions: false,
 			hasActiveStream: false,
+			isAwaitingFirstStreamChunk: false,
 		});
 		if (entry.message.role !== "user") {
 			flags[i] = nextVisibleIsUser;
@@ -993,6 +997,7 @@ interface ConversationTimelineProps {
 	mcpServers?: readonly TypesGen.MCPServerConfig[];
 	showDesktopPreviews?: boolean;
 	hasActiveStream?: boolean;
+	isAwaitingFirstStreamChunk?: boolean;
 }
 
 export const ConversationTimeline = memo<ConversationTimelineProps>(
@@ -1009,6 +1014,7 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 		mcpServers,
 		showDesktopPreviews,
 		hasActiveStream,
+		isAwaitingFirstStreamChunk,
 	}) => {
 		const lastInChainFlags = computeLastInChainFlags(parsedMessages);
 
@@ -1110,6 +1116,7 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 								isAfterEditingMessage={afterEditingMessageIds.has(message.id)}
 								hideActions={!isLastInChain}
 								hasActiveStream={Boolean(hasActiveStream)}
+								isAwaitingFirstStreamChunk={Boolean(isAwaitingFirstStreamChunk)}
 								mcpServers={mcpServers}
 								subagentTitles={subagentTitles}
 								subagentVariants={subagentVariants}

--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
@@ -29,8 +29,8 @@ const hasTextOrReasoningBlock = (blocks: readonly RenderBlock[]): boolean =>
 
 /**
  * Placeholder shown during streaming before text or reasoning
- * blocks arrive. Uses the same shimmer animation as the
- * collapsible thinking disclosure label.
+ * blocks arrive. Uses the same shimmer animation and typography
+ * as the ChatStatusCallout status placeholder.
  */
 const StreamingThinkingPlaceholder: FC = () => (
 	<div className="flex w-full items-center gap-2 py-0.5 text-content-secondary">

--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
@@ -34,7 +34,7 @@ const hasTextOrReasoningBlock = (blocks: readonly RenderBlock[]): boolean =>
  */
 const StreamingThinkingPlaceholder: FC = () => (
 	<div className="flex w-full items-center gap-2 py-0.5 text-content-secondary">
-		<Shimmer as="span" className="text-sm">
+		<Shimmer as="span" className="text-[13px] leading-relaxed">
 			Thinking
 		</Shimmer>
 	</div>

--- a/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.test.ts
@@ -14,12 +14,16 @@ const buildMessage = (
 	content,
 });
 
-const getDisplayState = (message: ChatMessage) =>
+const getDisplayState = (
+	message: ChatMessage,
+	overrides: Partial<Parameters<typeof deriveMessageDisplayState>[0]> = {},
+) =>
 	deriveMessageDisplayState({
 		message,
 		parsed: parseMessageContent(message.content),
 		hideActions: false,
 		hasActiveStream: false,
+		...overrides,
 	});
 
 describe("deriveMessageDisplayState", () => {
@@ -57,5 +61,54 @@ describe("deriveMessageDisplayState", () => {
 		);
 
 		expect(getDisplayState(message).hasCopyableContent).toBe(false);
+	});
+
+	it("suppresses the assistant spacer while awaiting the first stream chunk", () => {
+		const message = buildMessage(
+			[{ type: "reasoning", text: "I should think before answering." }],
+			"assistant",
+		);
+
+		expect(
+			getDisplayState(message, { isAwaitingFirstStreamChunk: true })
+				.needsAssistantBottomSpacer,
+		).toBe(false);
+	});
+
+	it("keeps the assistant spacer hidden when actions are hidden, even while awaiting", () => {
+		const message = buildMessage(
+			[{ type: "reasoning", text: "I should think before answering." }],
+			"assistant",
+		);
+
+		expect(
+			getDisplayState(message, {
+				hideActions: true,
+				isAwaitingFirstStreamChunk: true,
+			}).needsAssistantBottomSpacer,
+		).toBe(false);
+	});
+
+	it("keeps the assistant spacer hidden when a stream is active", () => {
+		const message = buildMessage(
+			[{ type: "reasoning", text: "I should think before answering." }],
+			"assistant",
+		);
+
+		expect(
+			getDisplayState(message, {
+				hasActiveStream: true,
+				isAwaitingFirstStreamChunk: true,
+			}).needsAssistantBottomSpacer,
+		).toBe(false);
+	});
+
+	it("never shows the assistant spacer on user messages", () => {
+		const message = buildMessage([{ type: "text", text: "Hello" }], "user");
+
+		expect(
+			getDisplayState(message, { isAwaitingFirstStreamChunk: true })
+				.needsAssistantBottomSpacer,
+		).toBe(false);
 	});
 });

--- a/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.test.ts
@@ -63,6 +63,15 @@ describe("deriveMessageDisplayState", () => {
 		expect(getDisplayState(message).hasCopyableContent).toBe(false);
 	});
 
+	it("shows the assistant spacer for reasoning messages when no suppressing flags apply", () => {
+		const message = buildMessage(
+			[{ type: "reasoning", text: "I should think before answering." }],
+			"assistant",
+		);
+
+		expect(getDisplayState(message).needsAssistantBottomSpacer).toBe(true);
+	});
+
 	it("suppresses the assistant spacer while awaiting the first stream chunk", () => {
 		const message = buildMessage(
 			[{ type: "reasoning", text: "I should think before answering." }],
@@ -75,17 +84,15 @@ describe("deriveMessageDisplayState", () => {
 		).toBe(false);
 	});
 
-	it("keeps the assistant spacer hidden when actions are hidden, even while awaiting", () => {
+	it("keeps the assistant spacer hidden when actions are hidden", () => {
 		const message = buildMessage(
 			[{ type: "reasoning", text: "I should think before answering." }],
 			"assistant",
 		);
 
 		expect(
-			getDisplayState(message, {
-				hideActions: true,
-				isAwaitingFirstStreamChunk: true,
-			}).needsAssistantBottomSpacer,
+			getDisplayState(message, { hideActions: true })
+				.needsAssistantBottomSpacer,
 		).toBe(false);
 	});
 
@@ -96,19 +103,14 @@ describe("deriveMessageDisplayState", () => {
 		);
 
 		expect(
-			getDisplayState(message, {
-				hasActiveStream: true,
-				isAwaitingFirstStreamChunk: true,
-			}).needsAssistantBottomSpacer,
+			getDisplayState(message, { hasActiveStream: true })
+				.needsAssistantBottomSpacer,
 		).toBe(false);
 	});
 
 	it("never shows the assistant spacer on user messages", () => {
 		const message = buildMessage([{ type: "text", text: "Hello" }], "user");
 
-		expect(
-			getDisplayState(message, { isAwaitingFirstStreamChunk: true })
-				.needsAssistantBottomSpacer,
-		).toBe(false);
+		expect(getDisplayState(message).needsAssistantBottomSpacer).toBe(false);
 	});
 });

--- a/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.ts
@@ -42,11 +42,13 @@ export const deriveMessageDisplayState = ({
 	parsed,
 	hideActions,
 	hasActiveStream,
+	isAwaitingFirstStreamChunk,
 }: {
 	message: TypesGen.ChatMessage;
 	parsed: ParsedMessageContent;
 	hideActions: boolean;
 	hasActiveStream: boolean;
+	isAwaitingFirstStreamChunk: boolean;
 }): MessageDisplayState => {
 	const isUser = message.role === "user";
 	const userInlineContent = isUser
@@ -66,6 +68,7 @@ export const deriveMessageDisplayState = ({
 	const needsAssistantBottomSpacer =
 		!hideActions &&
 		!hasActiveStream &&
+		!isAwaitingFirstStreamChunk &&
 		!isUser &&
 		!hasCopyableContent &&
 		(Boolean(parsed.reasoning) ||

--- a/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.ts
+++ b/site/src/pages/AgentsPage/components/ChatConversation/messageHelpers.ts
@@ -42,13 +42,13 @@ export const deriveMessageDisplayState = ({
 	parsed,
 	hideActions,
 	hasActiveStream,
-	isAwaitingFirstStreamChunk,
+	isAwaitingFirstStreamChunk = false,
 }: {
 	message: TypesGen.ChatMessage;
 	parsed: ParsedMessageContent;
 	hideActions: boolean;
 	hasActiveStream: boolean;
-	isAwaitingFirstStreamChunk: boolean;
+	isAwaitingFirstStreamChunk?: boolean;
 }): MessageDisplayState => {
 	const isUser = message.role === "user";
 	const userInlineContent = isUser

--- a/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
@@ -114,7 +114,7 @@ export const StartingPhaseToolCallGapRegression: Story = {
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		expect(canvas.getAllByText("Thinking...").length).toBeGreaterThan(0);
+		canvas.getAllByText("Thinking...");
 		expect(canvas.queryByTestId("assistant-bottom-spacer")).toBeNull();
 	},
 };

--- a/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.stories.tsx
@@ -99,6 +99,26 @@ export const StreamingToolCallGapRegression: Story = {
 	},
 };
 
+export const StartingPhaseToolCallGapRegression: Story = {
+	render: () => {
+		const store = buildRegressionStore();
+		store.setChatStatus("running");
+
+		return (
+			<ChatPageTimeline
+				chatID={CHAT_ID}
+				store={store}
+				persistedError={undefined}
+			/>
+		);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getAllByText("Thinking...").length).toBeGreaterThan(0);
+		expect(canvas.queryByTestId("assistant-bottom-spacer")).toBeNull();
+	},
+};
+
 export const SpacerVisibleWhenNotStreaming: Story = {
 	render: () => {
 		const store = buildRegressionStore();

--- a/site/src/pages/AgentsPage/components/ChatPageContent.tsx
+++ b/site/src/pages/AgentsPage/components/ChatPageContent.tsx
@@ -22,6 +22,7 @@ import { getLatestContextUsage } from "./ChatConversation/chatHelpers";
 import {
 	selectChatStatus,
 	selectHasStreamState,
+	selectIsAwaitingFirstStreamChunk,
 	selectMessagesByID,
 	selectOrderedMessageIDs,
 	selectQueuedMessages,
@@ -75,6 +76,10 @@ export const ChatPageTimeline: FC<ChatPageTimelineProps> = ({
 	const orderedMessageIDs = useChatSelector(store, selectOrderedMessageIDs);
 	const chatStatus = useChatSelector(store, selectChatStatus);
 	const hasStream = useChatSelector(store, selectHasStreamState);
+	const isAwaitingFirstStreamChunk = useChatSelector(
+		store,
+		selectIsAwaitingFirstStreamChunk,
+	);
 	const isChatCompleted = !hasStream && chatStatus !== "pending";
 
 	const messages = orderedMessageIDs
@@ -119,6 +124,7 @@ export const ChatPageTimeline: FC<ChatPageTimelineProps> = ({
 					onSendAskUserQuestionResponse={onSendAskUserQuestionResponse}
 					isChatCompleted={isChatCompleted}
 					hasActiveStream={hasStream}
+					isAwaitingFirstStreamChunk={isAwaitingFirstStreamChunk}
 					urlTransform={urlTransform}
 					mcpServers={mcpServers}
 					showDesktopPreviews={false}


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood

This suppresses the assistant bottom spacer during the stream startup window, before the first chunk arrives, and aligns the live `Thinking` indicator typography across startup and tool-call-only streaming states.

The spacer fix now treats `isAwaitingFirstStreamChunk` the same way as an active stream for message spacing, while the live streaming placeholder now matches the `ChatStatusCallout` `Thinking...` typography instead of rendering larger text during tool-call-only streaming. A Storybook regression story covers the exact pre-first-chunk gap case, and the live thinking placeholder remains covered by existing streaming stories.
