### PR TITLE
fix(coderd): use stable log event names instead of dynamic runtime values

### DIFF
--- a/agent/agentscripts/agentscripts.go
+++ b/agent/agentscripts/agentscripts.go
@@ -290,7 +290,7 @@ func (r *Runner) run(ctx context.Context, script codersdk.WorkspaceAgentScript, 
 	defer func() {
 		err := fileWriter.Close()
 		if err != nil {
-			logger.Warn(ctx, fmt.Sprintf("close %s script log file", logPath), slog.Error(err))
+			logger.Warn(ctx, "close script log file failed", slog.Error(err))
 		}
 	}()
 
@@ -346,9 +346,9 @@ func (r *Runner) run(ctx context.Context, script codersdk.WorkspaceAgentScript, 
 			if xerrors.As(err, &exitError) {
 				exitCode = exitError.ExitCode()
 			}
-			logger.Warn(ctx, fmt.Sprintf("%s script failed", logPath), slog.F("execution_time", execTime), slog.F("exit_code", exitCode), slog.Error(err))
+			logger.Warn(ctx, "agent script failed", slog.F("execution_time", execTime), slog.F("exit_code", exitCode), slog.Error(err))
 		} else {
-			logger.Info(ctx, fmt.Sprintf("%s script completed", logPath), slog.F("execution_time", execTime), slog.F("exit_code", exitCode))
+			logger.Info(ctx, "agent script completed", slog.F("execution_time", execTime), slog.F("exit_code", exitCode))
 		}
 
 		if r.scriptCompleted == nil {

--- a/coderd/csp.go
+++ b/coderd/csp.go
@@ -38,11 +38,7 @@ func (api *API) logReportCSPViolations(rw http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	fields := make([]slog.Field, 0, len(v.Report))
-	for k, v := range v.Report {
-		fields = append(fields, slog.F(k, v))
-	}
-	api.Logger.Debug(ctx, "CSP violation reported", fields...)
+	api.Logger.Debug(ctx, "CSP violation reported", slog.F("report", v.Report))
 
 	httpapi.Write(ctx, rw, http.StatusOK, "ok")
 }

--- a/coderd/mcp/mcp.go
+++ b/coderd/mcp/mcp.go
@@ -167,9 +167,9 @@ type mcpLoggerAdapter struct {
 }
 
 func (l *mcpLoggerAdapter) Infof(format string, v ...any) {
-	l.logger.Info(context.Background(), fmt.Sprintf(format, v...))
+	l.logger.Info(context.Background(), "mcp server info", slog.F("message", fmt.Sprintf(format, v...)))
 }
 
 func (l *mcpLoggerAdapter) Errorf(format string, v ...any) {
-	l.logger.Error(context.Background(), fmt.Sprintf(format, v...))
+	l.logger.Error(context.Background(), "mcp server error", slog.F("message", fmt.Sprintf(format, v...)))
 }

--- a/coderd/workspaceapps/errors.go
+++ b/coderd/workspaceapps/errors.go
@@ -19,7 +19,8 @@ func WriteWorkspaceApp404(log slog.Logger, accessURL *url.URL, rw http.ResponseW
 	if appReq != nil {
 		slog.Helper()
 		log.Debug(r.Context(),
-			"workspace app 404: "+details,
+			"workspace app 404",
+			slog.F("details", details),
 			slog.F("username_or_id", appReq.UsernameOrID),
 			slog.F("workspace_and_agent", appReq.WorkspaceAndAgent),
 			slog.F("workspace_name_or_id", appReq.WorkspaceNameOrID),
@@ -60,7 +61,8 @@ func WriteWorkspaceApp500(log slog.Logger, accessURL *url.URL, rw http.ResponseW
 		)
 	}
 	log.Warn(ctx,
-		"workspace app auth server error: "+msg,
+		"workspace app auth server error",
+		slog.F("details", msg),
 		slog.Error(err),
 	)
 
@@ -83,7 +85,8 @@ func WriteWorkspaceAppOffline(log slog.Logger, accessURL *url.URL, rw http.Respo
 	if appReq != nil {
 		slog.Helper()
 		log.Debug(r.Context(),
-			"workspace app unavailable: "+msg,
+			"workspace app unavailable",
+			slog.F("details", msg),
 			slog.F("username_or_id", appReq.UsernameOrID),
 			slog.F("workspace_and_agent", appReq.WorkspaceAndAgent),
 			slog.F("workspace_name_or_id", appReq.WorkspaceNameOrID),


### PR DESCRIPTION
Fixes #25103

## Summary

Six logging call sites used dynamic runtime values (script paths, error messages, CSP report keys, formatted strings) as structured log event names or field keys. This causes unnecessary cardinality growth in observability backends, makes queries harder to write, and increases storage/indexing cost.

## Changes

| File | Issue | Fix |
|------|-------|-----|
| `coderd/csp.go` | CSP report map keys used as slog field names | Log entire report as a single `report` field |
| `agent/agentscripts/agentscripts.go` | `logPath` interpolated into message string | Static messages; `log_path` already in logger context |
| `coderd/mcp/mcp.go` | `fmt.Sprintf` result used as event name | Stable names `mcp server info`/`mcp server error` with `message` field |
| `coderd/workspaceapps/errors.go` | String concatenation in event names | Moved dynamic `details`/`msg` to a `details` structured field |

All event names are now static string literals. Dynamic data is emitted only as structured field values.

<details><summary>Decision log</summary>

- **CSP report**: Chose a single `report` field (map value) over enumerating known CSP fields, since the report schema is defined by the browser and may vary.
- **Agent scripts**: The `logger` already carries `log_path`, `log_source_id`, and `script_data_dir` in context fields (set at line 279-283), so embedding `logPath` in the message was redundant.
- **MCP adapter**: The adapter bridges `mcp-go`'s printf-style `util.Logger` to slog. Since we cannot control the caller's format strings, we preserve the formatted output in a `message` field.
- **Workspace app errors**: Also fixed `WriteWorkspaceApp500` and `WriteWorkspaceAppOffline` which had the same pattern, even though only `WriteWorkspaceApp404` was listed in the issue.

</details>

> 🤖 Generated by Coder Agents