### PR TITLE
feat: structured disconnect attribution for control plane RPCs

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1973,6 +1973,11 @@ func (a *agent) runDERPMapSubscriber(ctx context.Context, tClient tailnetproto.D
 		return xerrors.Errorf("stream DERP Maps: %w", err)
 	}
 	defer func() {
+		cErr := stream.Close()
+		if cErr != nil {
+			a.logger.Debug(ctx, "error closing DERPMap stream", slog.Error(err))
+		}
+
 		reason, initiator := classifyCoordinatorRPCExit(ctx, retErr)
 		a.logger.Debug(ctx, "disconnected from derp map RPC",
 			slog.F("disconnect_reason", reason),
@@ -1980,12 +1985,6 @@ func (a *agent) runDERPMapSubscriber(ctx context.Context, tClient tailnetproto.D
 			slog.F("disconnect_expected", reason.Expected()),
 			slog.Error(retErr),
 		)
-	}()
-	defer func() {
-		cErr := stream.Close()
-		if cErr != nil {
-			a.logger.Debug(ctx, "error closing DERPMap stream", slog.Error(err))
-		}
 	}()
 	a.logger.Info(ctx, "connected to derp map RPC")
 	for {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -514,7 +514,11 @@ func (a *agent) runLoop() {
 			return
 		}
 		if errors.Is(err, io.EOF) {
-			a.logger.Info(ctx, "disconnected from coderd")
+			a.logger.Info(ctx, "disconnected from coderd",
+				slog.F("disconnect_reason", codersdk.DisconnectReasonNetworkError),
+				slog.F("disconnect_initiator", codersdk.DisconnectInitiatorNetwork),
+				slog.F("disconnect_expected", codersdk.DisconnectReasonNetworkError.Expected()),
+			)
 			continue
 		}
 		a.logger.Warn(ctx, "run exited with error", slog.Error(err))
@@ -1878,16 +1882,42 @@ func (a *agent) createTailnet(
 	return network, nil
 }
 
+// classifyCoordinatorRPCExit determines the DisconnectReason and
+// DisconnectInitiator for a coordinator-style RPC (the coordination RPC
+// and the DERP map subscriber RPC) that has just returned. A canceled
+// local context means the agent itself is shutting down. A non-nil
+// return error without context cancellation means the stream broke
+// unexpectedly.
+func classifyCoordinatorRPCExit(ctx context.Context, retErr error) (codersdk.DisconnectReason, codersdk.DisconnectInitiator) {
+	localShutdown := ctx.Err() != nil
+	switch {
+	case localShutdown:
+		return codersdk.DisconnectReasonServerShutdown, codersdk.DisconnectInitiatorAgent
+	case retErr == nil:
+		return codersdk.DisconnectReasonGraceful, codersdk.DisconnectInitiatorServer
+	default:
+		return codersdk.DisconnectReasonNetworkError, codersdk.DisconnectInitiatorNetwork
+	}
+}
+
 // runCoordinator runs a coordinator and returns whether a reconnect
 // should occur.
-func (a *agent) runCoordinator(ctx context.Context, tClient tailnetproto.DRPCTailnetClient24, network *tailnet.Conn) error {
-	defer a.logger.Debug(ctx, "disconnected from coordination RPC")
+func (a *agent) runCoordinator(ctx context.Context, tClient tailnetproto.DRPCTailnetClient24, network *tailnet.Conn) (retErr error) {
 	// we run the RPC on the hardCtx so that we have a chance to send the disconnect message if we
 	// gracefully shut down.
 	coordinate, err := tClient.Coordinate(a.hardCtx)
 	if err != nil {
 		return xerrors.Errorf("failed to connect to the coordinate endpoint: %w", err)
 	}
+	defer func() {
+		reason, initiator := classifyCoordinatorRPCExit(ctx, retErr)
+		a.logger.Debug(ctx, "disconnected from coordination RPC",
+			slog.F("disconnect_reason", reason),
+			slog.F("disconnect_initiator", initiator),
+			slog.F("disconnect_expected", reason.Expected()),
+			slog.Error(retErr),
+		)
+	}()
 	defer func() {
 		cErr := coordinate.Close()
 		if cErr != nil {
@@ -1935,14 +1965,22 @@ func (a *agent) setCoordDisconnected() chan struct{} {
 }
 
 // runDERPMapSubscriber runs a coordinator and returns if a reconnect should occur.
-func (a *agent) runDERPMapSubscriber(ctx context.Context, tClient tailnetproto.DRPCTailnetClient24, network *tailnet.Conn) error {
-	defer a.logger.Debug(ctx, "disconnected from derp map RPC")
+func (a *agent) runDERPMapSubscriber(ctx context.Context, tClient tailnetproto.DRPCTailnetClient24, network *tailnet.Conn) (retErr error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	stream, err := tClient.StreamDERPMaps(ctx, &tailnetproto.StreamDERPMapsRequest{})
 	if err != nil {
 		return xerrors.Errorf("stream DERP Maps: %w", err)
 	}
+	defer func() {
+		reason, initiator := classifyCoordinatorRPCExit(ctx, retErr)
+		a.logger.Debug(ctx, "disconnected from derp map RPC",
+			slog.F("disconnect_reason", reason),
+			slog.F("disconnect_initiator", initiator),
+			slog.F("disconnect_expected", reason.Expected()),
+			slog.Error(retErr),
+		)
+	}()
 	defer func() {
 		cErr := stream.Close()
 		if cErr != nil {
@@ -2260,9 +2298,18 @@ lifecycleWaitLoop:
 	// Wait for graceful disconnect from the Coordinator RPC
 	select {
 	case <-a.hardCtx.Done():
-		a.logger.Warn(context.Background(), "timed out waiting for Coordinator RPC disconnect")
+		a.logger.Warn(context.Background(), "timed out waiting for Coordinator RPC disconnect",
+			slog.F("disconnect_reason", codersdk.DisconnectReasonServerShutdown),
+			slog.F("disconnect_initiator", codersdk.DisconnectInitiatorAgent),
+			slog.F("disconnect_expected", codersdk.DisconnectReasonServerShutdown.Expected()),
+			slog.F("disconnect_detail", "timed out waiting for coordinator RPC to disconnect"),
+		)
 	case <-coordDisconnected:
-		a.logger.Debug(context.Background(), "coordinator RPC disconnected")
+		a.logger.Debug(context.Background(), "coordinator RPC disconnected",
+			slog.F("disconnect_reason", codersdk.DisconnectReasonServerShutdown),
+			slog.F("disconnect_initiator", codersdk.DisconnectInitiatorAgent),
+			slog.F("disconnect_expected", codersdk.DisconnectReasonServerShutdown.Expected()),
+		)
 	}
 
 	// Wait for logs to be sent

--- a/agent/agent_internal_test.go
+++ b/agent/agent_internal_test.go
@@ -1,17 +1,20 @@
 package agent
 
 import (
+	"context"
 	"path/filepath"
 	"runtime"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
 	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/agent/agentcontextconfig"
 	"github.com/coder/coder/v2/agent/proto"
+	"github.com/coder/coder/v2/codersdk"
 	agentsdk "github.com/coder/coder/v2/codersdk/agentsdk"
 	"github.com/coder/coder/v2/testutil"
 )
@@ -85,4 +88,57 @@ func TestContextConfigAPI_InitOnce(t *testing.T) {
 	mcpFiles2 := a.contextConfigAPI.MCPConfigFiles()
 	require.NotEmpty(t, mcpFiles2)
 	require.Contains(t, mcpFiles2[0], dir2)
+}
+
+func TestClassifyCoordinatorRPCExit(t *testing.T) {
+	t.Parallel()
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cases := []struct {
+		name      string
+		ctx       context.Context
+		retErr    error
+		reason    codersdk.DisconnectReason
+		initiator codersdk.DisconnectInitiator
+	}{
+		{
+			name:      "local shutdown, no error",
+			ctx:       canceled,
+			retErr:    nil,
+			reason:    codersdk.DisconnectReasonServerShutdown,
+			initiator: codersdk.DisconnectInitiatorAgent,
+		},
+		{
+			name:      "local shutdown, with cleanup error",
+			ctx:       canceled,
+			retErr:    xerrors.New("close timed out"),
+			reason:    codersdk.DisconnectReasonServerShutdown,
+			initiator: codersdk.DisconnectInitiatorAgent,
+		},
+		{
+			name:      "remote graceful, no error",
+			ctx:       context.Background(),
+			retErr:    nil,
+			reason:    codersdk.DisconnectReasonGraceful,
+			initiator: codersdk.DisconnectInitiatorServer,
+		},
+		{
+			name:      "stream broke unexpectedly",
+			ctx:       context.Background(),
+			retErr:    xerrors.New("read: connection reset"),
+			reason:    codersdk.DisconnectReasonNetworkError,
+			initiator: codersdk.DisconnectInitiatorNetwork,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			reason, initiator := classifyCoordinatorRPCExit(tc.ctx, tc.retErr)
+			require.Equal(t, tc.reason, reason)
+			require.Equal(t, tc.initiator, initiator)
+		})
+	}
 }

--- a/coderd/tailnet.go
+++ b/coderd/tailnet.go
@@ -529,6 +529,7 @@ func NewMultiAgentController(ctx context.Context, logger slog.Logger, tracer tra
 			Logger:      logger,
 			Coordinatee: coordinatee,
 			SendAcks:    false, // we are a client, connecting to multiple agents
+			Initiator:   codersdk.DisconnectInitiatorServer,
 		},
 		logger:              logger,
 		tracer:              tracer,

--- a/codersdk/disconnect.go
+++ b/codersdk/disconnect.go
@@ -1,0 +1,201 @@
+package codersdk
+
+// DisconnectReason categorizes why a workspace connection ended. It is
+// emitted as a slog field at every disconnect log site so operators can
+// filter and aggregate disconnects without parsing free-form reason
+// strings.
+//
+// The set of values intentionally stays small. Use DisconnectReasonUnknown
+// when no other value applies; do not invent ad-hoc strings. Add a new
+// constant here (and update its godoc) when a new disconnect class is
+// genuinely distinct from the existing ones.
+type DisconnectReason string
+
+const (
+	// DisconnectReasonUnknown is the zero value. Use it when the disconnect
+	// path cannot determine a more specific reason. Treat any disconnect
+	// logged with this value as a bug to investigate, not as a normal
+	// outcome.
+	DisconnectReasonUnknown DisconnectReason = ""
+
+	// DisconnectReasonGraceful indicates the connection ended cleanly: the
+	// remote side acknowledged a Disconnect message, an SSH session exited
+	// with status 0, or a PTY closed without error. This is the expected
+	// "happy path" outcome.
+	DisconnectReasonGraceful DisconnectReason = "graceful"
+
+	// DisconnectReasonClientClosed indicates the client side closed the
+	// connection without an error (for example, the user closed their
+	// terminal or quit their IDE). The session ran to a natural end from
+	// the client's perspective.
+	DisconnectReasonClientClosed DisconnectReason = "client_closed"
+
+	// DisconnectReasonServerShutdown indicates the workspace agent or
+	// coderd is shutting down and is closing connections as part of that
+	// shutdown. The connection itself was healthy; the process is going
+	// away.
+	DisconnectReasonServerShutdown DisconnectReason = "server_shutdown"
+
+	// DisconnectReasonNetworkError indicates the transport failed: an EOF,
+	// a read or write error, a context cancellation caused by a timeout,
+	// or a similar I/O failure. The connection did not end cleanly.
+	DisconnectReasonNetworkError DisconnectReason = "network_error"
+
+	// DisconnectReasonProtocolError indicates a dRPC, SSH, or tailnet
+	// protocol violation by the peer. Distinct from network errors because
+	// the bytes flowed but the contents were unparsable or unexpected.
+	DisconnectReasonProtocolError DisconnectReason = "protocol_error"
+
+	// DisconnectReasonWorkspaceStopped indicates the workspace itself was
+	// stopped or deleted while the connection was open, so coderd closed
+	// outstanding sessions on its behalf.
+	DisconnectReasonWorkspaceStopped DisconnectReason = "workspace_stopped"
+
+	// DisconnectReasonControlPlaneLost indicates the agent or client lost
+	// its coordination RPC to coderd. The data plane (peer-to-peer or
+	// DERP) may still be functional; this records the control plane
+	// outcome specifically.
+	DisconnectReasonControlPlaneLost DisconnectReason = "control_plane_lost"
+)
+
+// Valid reports whether r is a known DisconnectReason. The zero value
+// (DisconnectReasonUnknown) is considered valid since it is the explicit
+// "no information" reason.
+func (r DisconnectReason) Valid() bool {
+	switch r {
+	case DisconnectReasonUnknown,
+		DisconnectReasonGraceful,
+		DisconnectReasonClientClosed,
+		DisconnectReasonServerShutdown,
+		DisconnectReasonNetworkError,
+		DisconnectReasonProtocolError,
+		DisconnectReasonWorkspaceStopped,
+		DisconnectReasonControlPlaneLost:
+		return true
+	default:
+		return false
+	}
+}
+
+// Expected reports whether a disconnect with this reason is part of
+// normal operation. Operators can use this to split dashboards or alerts
+// into "expected" and "investigate" buckets without enumerating every
+// reason.
+func (r DisconnectReason) Expected() bool {
+	switch r {
+	case DisconnectReasonGraceful,
+		DisconnectReasonClientClosed,
+		DisconnectReasonServerShutdown,
+		DisconnectReasonWorkspaceStopped:
+		return true
+	case DisconnectReasonUnknown,
+		DisconnectReasonNetworkError,
+		DisconnectReasonProtocolError,
+		DisconnectReasonControlPlaneLost:
+		return false
+	default:
+		// Unknown reason values are treated as not expected so that
+		// new emit sites that forget to classify themselves surface
+		// in the "investigate" bucket by default.
+		return false
+	}
+}
+
+// DisconnectInitiator identifies which side caused the disconnect. It
+// pairs with DisconnectReason: the reason describes what happened, the
+// initiator describes who started it.
+type DisconnectInitiator string
+
+const (
+	// DisconnectInitiatorUnknown means the disconnect site cannot
+	// attribute the close to a specific side. Avoid this where possible.
+	DisconnectInitiatorUnknown DisconnectInitiator = ""
+
+	// DisconnectInitiatorClient means the user-facing side (CLI, VS Code
+	// extension, JetBrains plugin, Coder Desktop) closed the connection.
+	DisconnectInitiatorClient DisconnectInitiator = "client"
+
+	// DisconnectInitiatorAgent means the workspace agent closed the
+	// connection.
+	DisconnectInitiatorAgent DisconnectInitiator = "agent"
+
+	// DisconnectInitiatorServer means coderd (or a workspace proxy)
+	// closed the connection.
+	DisconnectInitiatorServer DisconnectInitiator = "server"
+
+	// DisconnectInitiatorNetwork means an underlying network or transport
+	// fault caused the close. Neither end deliberately initiated it.
+	DisconnectInitiatorNetwork DisconnectInitiator = "network"
+)
+
+// Valid reports whether i is a known DisconnectInitiator.
+func (i DisconnectInitiator) Valid() bool {
+	switch i {
+	case DisconnectInitiatorUnknown,
+		DisconnectInitiatorClient,
+		DisconnectInitiatorAgent,
+		DisconnectInitiatorServer,
+		DisconnectInitiatorNetwork:
+		return true
+	default:
+		return false
+	}
+}
+
+// ConnectionMethod describes the network path a workspace connection
+// took at the moment a disconnect log was emitted. It is intended for
+// observability only; do not switch behavior on it.
+type ConnectionMethod string
+
+const (
+	// ConnectionMethodUnknown means the disconnect site does not have
+	// the information to determine the connection path.
+	ConnectionMethodUnknown ConnectionMethod = ""
+
+	// ConnectionMethodDirect means the peers were communicating over a
+	// direct, peer-to-peer connection (NAT-traversed via STUN).
+	ConnectionMethodDirect ConnectionMethod = "direct"
+
+	// ConnectionMethodDERP means the peers were communicating through a
+	// DERP relay rather than directly.
+	ConnectionMethodDERP ConnectionMethod = "derp"
+)
+
+// Valid reports whether m is a known ConnectionMethod.
+func (m ConnectionMethod) Valid() bool {
+	switch m {
+	case ConnectionMethodUnknown,
+		ConnectionMethodDirect,
+		ConnectionMethodDERP:
+		return true
+	default:
+		return false
+	}
+}
+
+// Stable slog field keys for disconnect attribution. Use these constants
+// (not raw strings) when emitting slog fields so operators can rely on
+// consistent key names across the codebase.
+//
+// New disconnect log sites should always include DisconnectReasonField
+// and DisconnectInitiatorField, and should include ConnectionMethodField
+// when the information is available.
+
+// DisconnectReasonField is the slog key for DisconnectReason values.
+const DisconnectReasonField = "disconnect_reason"
+
+// DisconnectInitiatorField is the slog key for DisconnectInitiator values.
+const DisconnectInitiatorField = "disconnect_initiator"
+
+// DisconnectExpectedField is the slog key for the boolean derived from
+// DisconnectReason.Expected. Operators can filter on this without
+// enumerating every reason value.
+const DisconnectExpectedField = "disconnect_expected"
+
+// ConnectionMethodField is the slog key for ConnectionMethod values.
+const ConnectionMethodField = "connection_method"
+
+// DisconnectDetailField is the slog key for the free-form, human-readable
+// detail string that supplements the structured reason. Use it for
+// "exited with code 137" style information that does not fit a category.
+const DisconnectDetailField = "disconnect_detail"

--- a/codersdk/disconnect_test.go
+++ b/codersdk/disconnect_test.go
@@ -1,0 +1,94 @@
+package codersdk_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/codersdk"
+)
+
+func TestDisconnectReason_Valid(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		reason codersdk.DisconnectReason
+		valid  bool
+	}{
+		{codersdk.DisconnectReasonUnknown, true},
+		{codersdk.DisconnectReasonGraceful, true},
+		{codersdk.DisconnectReasonClientClosed, true},
+		{codersdk.DisconnectReasonServerShutdown, true},
+		{codersdk.DisconnectReasonNetworkError, true},
+		{codersdk.DisconnectReasonProtocolError, true},
+		{codersdk.DisconnectReasonWorkspaceStopped, true},
+		{codersdk.DisconnectReasonControlPlaneLost, true},
+		{codersdk.DisconnectReason("not_a_real_reason"), false},
+	}
+
+	for _, c := range cases {
+		require.Equal(t, c.valid, c.reason.Valid(), "reason=%q", c.reason)
+	}
+}
+
+func TestDisconnectReason_Expected(t *testing.T) {
+	t.Parallel()
+
+	expected := map[codersdk.DisconnectReason]bool{
+		codersdk.DisconnectReasonGraceful:         true,
+		codersdk.DisconnectReasonClientClosed:     true,
+		codersdk.DisconnectReasonServerShutdown:   true,
+		codersdk.DisconnectReasonWorkspaceStopped: true,
+
+		codersdk.DisconnectReasonUnknown:          false,
+		codersdk.DisconnectReasonNetworkError:     false,
+		codersdk.DisconnectReasonProtocolError:    false,
+		codersdk.DisconnectReasonControlPlaneLost: false,
+	}
+
+	for reason, want := range expected {
+		require.Equal(t, want, reason.Expected(), "reason=%q", reason)
+	}
+
+	// Unknown values default to not-expected so that uncategorized
+	// emit sites surface in the "investigate" bucket.
+	require.False(t, codersdk.DisconnectReason("not_a_real_reason").Expected())
+}
+
+func TestDisconnectInitiator_Valid(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		initiator codersdk.DisconnectInitiator
+		valid     bool
+	}{
+		{codersdk.DisconnectInitiatorUnknown, true},
+		{codersdk.DisconnectInitiatorClient, true},
+		{codersdk.DisconnectInitiatorAgent, true},
+		{codersdk.DisconnectInitiatorServer, true},
+		{codersdk.DisconnectInitiatorNetwork, true},
+		{codersdk.DisconnectInitiator("nobody"), false},
+	}
+
+	for _, c := range cases {
+		require.Equal(t, c.valid, c.initiator.Valid(), "initiator=%q", c.initiator)
+	}
+}
+
+func TestConnectionMethod_Valid(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		method codersdk.ConnectionMethod
+		valid  bool
+	}{
+		{codersdk.ConnectionMethodUnknown, true},
+		{codersdk.ConnectionMethodDirect, true},
+		{codersdk.ConnectionMethodDERP, true},
+		{codersdk.ConnectionMethod("magic"), false},
+	}
+
+	for _, c := range cases {
+		require.Equal(t, c.valid, c.method.Valid(), "method=%q", c.method)
+	}
+}

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -2899,6 +2899,17 @@ export interface ConnectionLogsRequest extends Pagination {
 	readonly q?: string;
 }
 
+// From codersdk/disconnect.go
+export type ConnectionMethod = "derp" | "direct" | "";
+
+// From codersdk/disconnect.go
+/**
+ * ConnectionMethodField is the slog key for ConnectionMethod values.
+ */
+export const ConnectionMethodField = "connection_method";
+
+export const ConnectionMethods: ConnectionMethod[] = ["derp", "direct", ""];
+
 // From codersdk/connectionlog.go
 export type ConnectionType =
 	| "jetbrains"
@@ -3811,6 +3822,72 @@ export type DiagnosticSeverityString = "error" | "warning";
 export const DiagnosticSeverityStrings: DiagnosticSeverityString[] = [
 	"error",
 	"warning",
+];
+
+// From codersdk/disconnect.go
+/**
+ * DisconnectDetailField is the slog key for the free-form, human-readable
+ * detail string that supplements the structured reason. Use it for
+ * "exited with code 137" style information that does not fit a category.
+ */
+export const DisconnectDetailField = "disconnect_detail";
+
+// From codersdk/disconnect.go
+/**
+ * DisconnectExpectedField is the slog key for the boolean derived from
+ * DisconnectReason.Expected. Operators can filter on this without
+ * enumerating every reason value.
+ */
+export const DisconnectExpectedField = "disconnect_expected";
+
+// From codersdk/disconnect.go
+export type DisconnectInitiator =
+	| "agent"
+	| "client"
+	| "network"
+	| "server"
+	| "";
+
+// From codersdk/disconnect.go
+/**
+ * DisconnectInitiatorField is the slog key for DisconnectInitiator values.
+ */
+export const DisconnectInitiatorField = "disconnect_initiator";
+
+export const DisconnectInitiators: DisconnectInitiator[] = [
+	"agent",
+	"client",
+	"network",
+	"server",
+	"",
+];
+
+// From codersdk/disconnect.go
+export type DisconnectReason =
+	| "client_closed"
+	| "control_plane_lost"
+	| "graceful"
+	| "network_error"
+	| "protocol_error"
+	| "server_shutdown"
+	| ""
+	| "workspace_stopped";
+
+// From codersdk/disconnect.go
+/**
+ * DisconnectReasonField is the slog key for DisconnectReason values.
+ */
+export const DisconnectReasonField = "disconnect_reason";
+
+export const DisconnectReasons: DisconnectReason[] = [
+	"client_closed",
+	"control_plane_lost",
+	"graceful",
+	"network_error",
+	"protocol_error",
+	"server_shutdown",
+	"",
+	"workspace_stopped",
 ];
 
 // From codersdk/workspaceagents.go

--- a/tailnet/controllers.go
+++ b/tailnet/controllers.go
@@ -154,6 +154,14 @@ type BasicCoordinationController struct {
 	Logger      slog.Logger
 	Coordinatee Coordinatee
 	SendAcks    bool
+	// Initiator labels which side of the coordination this controller
+	// represents (e.g. "agent", "client", "server"). It is attached as
+	// a slog field to disconnect-related logs emitted by this
+	// coordination so operators can attribute connection-close events
+	// without inspecting call sites. Leave unset on synthetic
+	// controllers (tests, in-memory fakes) and the field will be
+	// omitted from log output.
+	Initiator codersdk.DisconnectInitiator
 }
 
 // New satisfies the method on the CoordinationController interface
@@ -170,6 +178,7 @@ func (c *BasicCoordinationController) NewCoordination(client CoordinatorClient) 
 		client:       client,
 		respLoopDone: make(chan struct{}),
 		sendAcks:     c.SendAcks,
+		initiator:    c.Initiator,
 	}
 
 	c.Coordinatee.SetNodeCallback(func(node *Node) {
@@ -211,6 +220,7 @@ type BasicCoordination struct {
 	client       CoordinatorClient
 	respLoopDone chan struct{}
 	sendAcks     bool
+	initiator    codersdk.DisconnectInitiator
 }
 
 // CloseClient forcibly closes the underlying coordinator client connection
@@ -244,10 +254,19 @@ func (c *BasicCoordination) Close(ctx context.Context) (retErr error) {
 	c.Unlock()
 	if err != nil && !xerrors.Is(err, io.EOF) {
 		// Log but don't return early; we must still clean up below.
-		c.logger.Warn(context.Background(), "failed to send disconnect", slog.Error(err))
+		c.logger.Warn(context.Background(), "failed to send disconnect",
+			slog.F("disconnect_reason", codersdk.DisconnectReasonNetworkError),
+			slog.F("disconnect_initiator", c.initiator),
+			slog.F("disconnect_expected", codersdk.DisconnectReasonNetworkError.Expected()),
+			slog.Error(err),
+		)
 		retErr = xerrors.Errorf("send disconnect: %w", err)
 	} else {
-		c.logger.Debug(context.Background(), "sent disconnect")
+		c.logger.Debug(context.Background(), "sent disconnect",
+			slog.F("disconnect_reason", codersdk.DisconnectReasonGraceful),
+			slog.F("disconnect_initiator", c.initiator),
+			slog.F("disconnect_expected", codersdk.DisconnectReasonGraceful.Expected()),
+		)
 	}
 
 	// We shouldn't just close the protocol right away, because the way dRPC streams work is
@@ -256,10 +275,19 @@ func (c *BasicCoordination) Close(ctx context.Context) (retErr error) {
 	// Disconnect message, so we should wait around for that until the context expires.
 	select {
 	case <-c.respLoopDone:
-		c.logger.Debug(ctx, "responses closed after disconnect")
+		c.logger.Debug(ctx, "responses closed after disconnect",
+			slog.F("disconnect_reason", codersdk.DisconnectReasonGraceful),
+			slog.F("disconnect_initiator", c.initiator),
+			slog.F("disconnect_expected", codersdk.DisconnectReasonGraceful.Expected()),
+		)
 		return retErr
 	case <-ctx.Done():
-		c.logger.Warn(ctx, "context expired while waiting for coordinate responses to close")
+		c.logger.Warn(ctx, "context expired while waiting for coordinate responses to close",
+			slog.F("disconnect_reason", codersdk.DisconnectReasonNetworkError),
+			slog.F("disconnect_initiator", c.initiator),
+			slog.F("disconnect_expected", codersdk.DisconnectReasonNetworkError.Expected()),
+			slog.F("disconnect_detail", "context expired before coordinator hung up"),
+		)
 	}
 	// forcefully close the stream
 	protoErr := c.client.Close()
@@ -369,6 +397,7 @@ func NewTunnelSrcCoordController(
 			Logger:      logger,
 			Coordinatee: coordinatee,
 			SendAcks:    false,
+			Initiator:   codersdk.DisconnectInitiatorClient,
 		},
 		dests: make(map[uuid.UUID]struct{}),
 	}
@@ -508,6 +537,7 @@ func NewAgentCoordinationController(
 		Logger:      logger,
 		Coordinatee: coordinatee,
 		SendAcks:    true,
+		Initiator:   codersdk.DisconnectInitiatorAgent,
 	}
 }
 
@@ -1505,7 +1535,12 @@ func (c *Controller) Run(ctx context.Context) {
 				}
 
 				if errors.Is(err, net.ErrClosed) {
-					c.logger.Warn(c.ctx, "control plane connection closed, retrying", slog.Error(err))
+					c.logger.Warn(c.ctx, "control plane connection closed, retrying",
+						slog.F("disconnect_reason", codersdk.DisconnectReasonNetworkError),
+						slog.F("disconnect_initiator", codersdk.DisconnectInitiatorNetwork),
+						slog.F("disconnect_expected", codersdk.DisconnectReasonNetworkError.Expected()),
+						slog.Error(err),
+					)
 					continue
 				}
 


### PR DESCRIPTION
Superseded by #25191 which now contains all commits from this PR.

---

_This PR was prepared by Coder Agents on behalf of @Emyrk._