### PR TITLE
fix: bump goldmark to v1.7.17 to fix XSS (CVE-2026-5160)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -424,7 +424,7 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	github.com/yashtewari/glob-intersection v0.2.0 // indirect
-	github.com/yuin/goldmark v1.7.16 // indirect
+	github.com/yuin/goldmark v1.7.17 // indirect
 	github.com/yuin/goldmark-emoji v1.0.6 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	github.com/zclconf/go-cty v1.17.0

--- a/go.sum
+++ b/go.sum
@@ -1186,8 +1186,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-github.com/yuin/goldmark v1.7.16 h1:n+CJdUxaFMiDUNnWC3dMWCIQJSkxH4uz3ZwQBkAlVNE=
-github.com/yuin/goldmark v1.7.16/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
+github.com/yuin/goldmark v1.7.17 h1:p36OVWwRb246iHxA/U4p8OPEpOTESm4n+g+8t0EE5uA=
+github.com/yuin/goldmark v1.7.17/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 github.com/yuin/goldmark-emoji v1.0.6 h1:QWfF2FYaXwL74tfGOW5izeiZepUDroDJfWubQI9HTHs=
 github.com/yuin/goldmark-emoji v1.0.6/go.mod h1:ukxJDKFpdFb5x0a5HqbdlcKtebh086iJpI31LTKmWuA=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=


### PR DESCRIPTION
Bump `github.com/yuin/goldmark` from v1.7.16 to v1.7.17 to fix [CVE-2026-5160](https://nvd.nist.gov/vuln/detail/CVE-2026-5160).

goldmark v1.7.16 is vulnerable to XSS due to improper ordering of URL validation and normalization. The renderer validates link destinations using a prefix-based check (`IsDangerousURL`) before resolving HTML entities, allowing an attacker to bypass validation with entity-encoded `javascript:` URIs.

This is the minimal fix for the IronBank finding on the `coder/coder-enterprise/coder-service-2:2.31.11` image. The fix is already on `main` (v1.8.2 via Hugo bump in #23957); this targets the v2.31.x release branch with only the goldmark dependency change.

Closes [ENT-8](https://linear.app/codercom/issue/ENT-8)

> Generated by Coder Agents