### PR TITLE
fix(scripts/ironbank): update base image to UBI9 and remove urllib3 (CVE-2026-44431)

### DIFF
--- a/scripts/ironbank/Dockerfile
+++ b/scripts/ironbank/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_REGISTRY=registry1.dso.mil
-ARG BASE_IMAGE=ironbank/redhat/ubi/ubi8-minimal
-ARG BASE_TAG=8.7
+ARG BASE_IMAGE=ironbank/redhat/ubi/ubi9-minimal
+ARG BASE_TAG=9.6
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG}
 
@@ -16,6 +16,9 @@ RUN microdnf update --assumeyes && \
       shadow-utils \
       tar \
       unzip && \
+    # Remove python3-urllib3 if present to address CVE-2026-44431.
+    # Coder is a Go binary and does not use Python at runtime.
+    microdnf remove --assumeyes python3-urllib3 2>/dev/null || true && \
     microdnf clean all
 
 # Configure the cryptography policy manually. These policies likely

--- a/scripts/ironbank/build_ironbank.sh
+++ b/scripts/ironbank/build_ironbank.sh
@@ -96,8 +96,8 @@ fi
 pushd "$tmpdir"
 docker build \
 	--build-arg BASE_REGISTRY=registry.access.redhat.com \
-	--build-arg BASE_IMAGE=ubi8/ubi-minimal \
-	--build-arg BASE_TAG=8.7 \
+	--build-arg BASE_IMAGE=ubi9/ubi-minimal \
+	--build-arg BASE_TAG=9.6 \
 	--build-arg TERRAFORM_CODER_PROVIDER_VERSION="$terraform_coder_provider_version" \
 	-t "$image_tag" \
 	. >&2


### PR DESCRIPTION
The IronBank Dockerfile used UBI8-minimal:8.7 as its base image. IronBank has migrated images to UBI9 base, and the bundled urllib3 1.26.5 in the image triggers CVE-2026-44431 (sensitive headers leaked on cross-origin redirects via the low-level API).

This updates the base image from UBI8-minimal to UBI9-minimal and explicitly removes python3-urllib3 after package installation. Coder is a Go binary and does not invoke Python at runtime, so urllib3 is unused.

Refs [ENT-4](https://linear.app/codercom/issue/ENT-4/ironbank-v23111-update-urllib3-from-1265-to-fix-cve-2026-44431), [ENT-51](https://linear.app/codercom/issue/ENT-51/ironbank-main-update-base-image-urllib3-cve-2026-44431), [CVE-2026-44431](https://nvd.nist.gov/vuln/detail/CVE-2026-44431)

> Generated by Coder Agents

<details><summary>Decision log</summary>

- **Base image**: Moved from `ubi8-minimal:8.7` to `ubi9-minimal:9.6` to align with IronBank's UBI9 migration and reduce overall vulnerability surface.
- **urllib3 removal**: Added explicit `microdnf remove python3-urllib3` with error suppression (`|| true`) so the build succeeds whether or not the package is present in the base image. This handles both the minimal and full UBI9 base image variants that IronBank may use.
- **Crypto policies**: RHEL 9 uses the same `/etc/crypto-policies/back-ends/*.config` paths as RHEL 8; no changes needed.
- **Build script**: Updated the `registry.access.redhat.com` override from `ubi8/ubi-minimal:8.7` to `ubi9/ubi-minimal:9.6` for local builds.

</details>