### PR TITLE
fix(security): bump gomarkdown/markdown to fix OOB read (GHSA-77fj-vx54-gvh7)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -131,7 +131,7 @@ require (
 	github.com/gohugoio/hugo v0.156.0
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/golang-migrate/migrate/v4 v4.19.0
-	github.com/gomarkdown/markdown v0.0.0-20240930133441-72d49d9543d8
+	github.com/gomarkdown/markdown v0.0.0-20260411013819-759bbc3e3207
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-github/v43 v43.0.1-0.20220414155304-00e42332e405
 	github.com/google/go-github/v61 v61.0.0

--- a/go.sum
+++ b/go.sum
@@ -601,8 +601,8 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
-github.com/gomarkdown/markdown v0.0.0-20240930133441-72d49d9543d8 h1:4txT5G2kqVAKMjzidIabL/8KqjIK71yj30YOeuxLn10=
-github.com/gomarkdown/markdown v0.0.0-20240930133441-72d49d9543d8/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
+github.com/gomarkdown/markdown v0.0.0-20260411013819-759bbc3e3207 h1:p7t34F7K4OCRQblcDhNJnP46Uaarz3z2cLcvOZYxWn8=
+github.com/gomarkdown/markdown v0.0.0-20260411013819-759bbc3e3207/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
 github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
 github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/google/flatbuffers v25.2.10+incompatible h1:F3vclr7C3HpB1k9mxCGRMXq6FdUalZ6H/pNX4FP1v0Q=


### PR DESCRIPTION
Cherry-picks the gomarkdown/markdown bump from main (#24567) to `release/2.31`.

Updates `github.com/gomarkdown/markdown` from `v0.0.0-20240930133441-72d49d9543d8` to `v0.0.0-20260411013819-759bbc3e3207`, fixing GHSA-77fj-vx54-gvh7 (OOB Read in SmartypantsRenderer).

Note: `coderd/render/markdown.go` uses `html.CommonFlags` which enables Smartypants by default, so this code path is reachable. The bump resolves the IronBank finding for image `coder/coder-enterprise/coder-service-2:2.31.11`.

<details><summary>Codebase verification</summary>

Only `coderd/render/markdown.go` imports `gomarkdown`. It calls `html.NewRenderer` with `html.CommonFlags`, which includes the Smartypants flag. No explicit SmartypantsRenderer configuration exists, but the default flags enable smartypants processing. The patched revision fixes the OOB read in that code path.

</details>

Closes https://linear.app/codercom/issue/ENT-6

> 🤖 Generated with [Coder Agents](https://coder.com)