### PR TITLE
fix: upgrade Go toolchain from 1.25.9 to 1.25.10

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -4,7 +4,7 @@ description: |
 inputs:
   version:
     description: "The Go version to use."
-    default: "1.25.9"
+    default: "1.25.10"
   use-cache:
     description: "Whether to use the cache."
     default: "true"

--- a/dogfood/coder/Dockerfile
+++ b/dogfood/coder/Dockerfile
@@ -11,8 +11,8 @@ RUN cargo install jj-cli typos-cli watchexec-cli
 FROM ubuntu:jammy@sha256:eb29ed27b0821dca09c2e28b39135e185fc1302036427d5f4d70a41ce8fd7659 AS go
 
 # Install Go manually, so that we can control the version
-ARG GO_VERSION=1.25.9
-ARG GO_CHECKSUM="00859d7bd6defe8bf84d9db9e57b9a4467b2887c18cd93ae7460e713db774bc1"
+ARG GO_VERSION=1.25.10
+ARG GO_CHECKSUM="42d4f7a32316aa66591eca7e89867256057a4264451aca10570a715b3637ba70"
 
 # Boring Go is needed to build FIPS-compliant binaries.
 RUN apt-get update && \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coder/coder/v2
 
-go 1.25.9
+go 1.25.10
 
 // Required until a v3 of chroma is created to lazily initialize all XML files.
 // None of our dependencies seem to use the registries anyways, so this


### PR DESCRIPTION
Go 1.25.10 (released 2026-05-07) includes 11 security fixes for CVEs affecting the go command, pack tool, html/template, net, net/http, net/http/httputil, net/mail, and syscall packages.

Fixes IronBank v2.32.x Go stdlib CVE exposure by upgrading from Go 1.25.9 to 1.25.10.

Reference: https://groups.google.com/g/golang-dev/c/h6eZjndBMqQ

### Changed files
- `go.mod`: `go 1.25.9` to `go 1.25.10`
- `dogfood/coder/Dockerfile`: `GO_VERSION` and `GO_CHECKSUM`
- `.github/actions/setup-go/action.yaml`: default version

> Generated by Coder Agents