### PR TITLE
fix(scripts/ironbank): update base image to UBI9 and remove urllib3 (CVE-2026-44431)

### DIFF
--- a/scripts/ironbank/Dockerfile
+++ b/scripts/ironbank/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_REGISTRY=registry1.dso.mil
-ARG BASE_IMAGE=ironbank/redhat/ubi/ubi8-minimal
-ARG BASE_TAG=8.7
+ARG BASE_IMAGE=ironbank/redhat/ubi/ubi9-minimal
+ARG BASE_TAG=9.6
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG}
 
@@ -16,6 +16,9 @@ RUN microdnf update --assumeyes && \
       shadow-utils \
       tar \
       unzip && \
+    # Remove python3-urllib3 if present to address CVE-2026-44431.
+    # Coder is a Go binary and does not use Python at runtime.
+    microdnf remove --assumeyes python3-urllib3 2>/dev/null || true && \
     microdnf clean all
 
 # Configure the cryptography policy manually. These policies likely

--- a/scripts/ironbank/build_ironbank.sh
+++ b/scripts/ironbank/build_ironbank.sh
@@ -96,8 +96,8 @@ fi
 pushd "$tmpdir"
 docker build \
 	--build-arg BASE_REGISTRY=registry.access.redhat.com \
-	--build-arg BASE_IMAGE=ubi8/ubi-minimal \
-	--build-arg BASE_TAG=8.7 \
+	--build-arg BASE_IMAGE=ubi9/ubi-minimal \
+	--build-arg BASE_TAG=9.6 \
 	--build-arg TERRAFORM_CODER_PROVIDER_VERSION="$terraform_coder_provider_version" \
 	-t "$image_tag" \
 	. >&2


### PR DESCRIPTION
## Summary

Update the IronBank Dockerfile and build script for the v2.30.x release branch to use UBI9-minimal instead of UBI8-minimal, and explicitly remove `python3-urllib3` after package installation to address CVE-2026-44431.

Coder is a Go binary and does not use Python at runtime — the vulnerable library is unused.

### Changes

- **Dockerfile**: Update base image from `ubi8-minimal:8.7` → `ubi9-minimal:9.6`; add `microdnf remove python3-urllib3` step
- **build_ironbank.sh**: Update build args from `ubi8/ubi-minimal:8.7` → `ubi9/ubi-minimal:9.6`

<details>
<summary>Context</summary>

Linear: [ENT-35](https://linear.app/codercom/issue/ENT-35/ironbank-v230x-update-base-image-urllib3-cve-2026-44431)

Mirrors the fix applied on the v2.31.x branch (commit 15350a411).
</details>

> 🤖 Generated by [Coder Agents](https://coder.com)