### PR TITLE
fix(deps): upgrade gomarkdown/markdown to fix GHSA-77fj-vx54-gvh7 (v2.30.x)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -130,7 +130,7 @@ require (
 	github.com/gohugoio/hugo v0.154.2
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/golang-migrate/migrate/v4 v4.19.0
-	github.com/gomarkdown/markdown v0.0.0-20240930133441-72d49d9543d8
+	github.com/gomarkdown/markdown v0.0.0-20260417124207-7d523f7318df
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-github/v43 v43.0.1-0.20220414155304-00e42332e405
 	github.com/google/go-github/v61 v61.0.0

--- a/go.sum
+++ b/go.sum
@@ -1290,8 +1290,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/gomarkdown/markdown v0.0.0-20240930133441-72d49d9543d8 h1:4txT5G2kqVAKMjzidIabL/8KqjIK71yj30YOeuxLn10=
-github.com/gomarkdown/markdown v0.0.0-20240930133441-72d49d9543d8/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
+github.com/gomarkdown/markdown v0.0.0-20260417124207-7d523f7318df h1:Mwihr/o+v4L5h56rwHLOE20+hh7Okhwno5BHz3zDuao=
+github.com/gomarkdown/markdown v0.0.0-20260417124207-7d523f7318df/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=


### PR DESCRIPTION
## Summary

Upgrades `github.com/gomarkdown/markdown` on the `release/2.30` branch to fix [GHSA-77fj-vx54-gvh7](https://github.com/advisories/GHSA-77fj-vx54-gvh7) (High severity OOB Read in SmartypantsRenderer).

| | Version |
|---|---|
| **Before** | `v0.0.0-20240930133441-72d49d9543d8` |
| **After** | `v0.0.0-20260417124207-7d523f7318df` |

## Context

- Parent issue: [ENT-14](https://linear.app/codercom/issue/ENT-14)
- This issue: [ENT-34](https://linear.app/codercom/issue/ENT-34/ironbank-v230x-upgrade-gomarkdownmarkdown-ghsa-77fj-vx54-gvh7)
- Already fixed on `main` via [#24567](https://github.com/coder/coder/pull/24567). A direct cherry-pick does not apply cleanly to `release/2.30`, so this is a manual `go get` bump.
- Coder's user-facing markdown is rendered via react-markdown, not gomarkdown. The SmartypantsRenderer is likely not invoked at runtime, but bumping removes the vulnerability from dependency scans (IronBank).

## Changes

- `go.mod` / `go.sum`: bumped `github.com/gomarkdown/markdown` to latest

## Testing

- `go build ./...` passes
- `go test ./coderd/render/...` passes (the only package importing gomarkdown)

> Generated by Coder Agents. [ENT-34](https://linear.app/codercom/issue/ENT-34)