### PR TITLE
fix(site): remove flaky pagination test from WorkspacesPage (cherry-pick #24165)

### DIFF
--- a/site/src/pages/WorkspacesPage/WorkspacesPage.test.tsx
+++ b/site/src/pages/WorkspacesPage/WorkspacesPage.test.tsx
@@ -296,67 +296,6 @@ describe("WorkspacesPage", () => {
 			MockStoppedWorkspace.latest_build.template_version_id,
 		);
 	});
-
-	it("correctly handles pagination by including pagination parameters in query key", async () => {
-		const totalWorkspaces = 50;
-		const workspacesPage1 = Array.from({ length: 25 }, (_, i) => ({
-			...MockWorkspace,
-			id: `page1-workspace-${i}`,
-			name: `page1-workspace-${i}`,
-		}));
-		const workspacesPage2 = Array.from({ length: 25 }, (_, i) => ({
-			...MockWorkspace,
-			id: `page2-workspace-${i}`,
-			name: `page2-workspace-${i}`,
-		}));
-
-		const getWorkspacesSpy = vi.spyOn(API, "getWorkspaces");
-
-		getWorkspacesSpy.mockImplementation(({ offset }) => {
-			switch (offset) {
-				case 0:
-					return Promise.resolve({
-						workspaces: workspacesPage1,
-						count: totalWorkspaces,
-					});
-				case 25:
-					return Promise.resolve({
-						workspaces: workspacesPage2,
-						count: totalWorkspaces,
-					});
-				default:
-					return Promise.reject(new Error("Unexpected offset"));
-			}
-		});
-
-		const user = userEvent.setup();
-		renderWithAuth(<WorkspacesPage />);
-
-		await waitFor(() => {
-			expect(screen.getByText("page1-workspace-0")).toBeInTheDocument();
-		});
-
-		expect(getWorkspacesSpy).toHaveBeenLastCalledWith({
-			q: "owner:me",
-			offset: 0,
-			limit: 25,
-		});
-
-		const nextPageButton = screen.getByRole("button", { name: /next page/i });
-		await user.click(nextPageButton);
-
-		await waitFor(() => {
-			expect(screen.getByText("page2-workspace-0")).toBeInTheDocument();
-		});
-
-		expect(getWorkspacesSpy).toHaveBeenLastCalledWith({
-			q: "owner:me",
-			offset: 25,
-			limit: 25,
-		});
-
-		expect(screen.queryByText("page1-workspace-0")).not.toBeInTheDocument();
-	});
 });
 
 const getWorkspaceCheckbox = (workspace: Workspace) => {


### PR DESCRIPTION
Cherry-pick of #24165 to `release/2.31`.

Removes the flaky pagination query key test that timed out in CI (6204ms vs 5000ms limit) because `renderWithAuth` boots 12+ MSW round-trips before the page mounts.

On this branch `WorkspacesPage.stories.tsx` does not exist, so the test is removed rather than moved to a story.

> 🤖 Generated by Coder Agent