### PR TITLE
fix(site/src/pages/AgentsPage/components): allow horizontal diff scrolling

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
@@ -6,16 +6,17 @@ import { DesktopPanelContext } from "./DesktopPanelContext";
 import { Tool } from "./Tool";
 
 const executeCommand = "git fetch origin";
+// This must overflow the story's diff viewport so scroll behavior is observable.
 const longUnbrokenSegment = "0123456789abcdef".repeat(24);
 
-const getRenderedCode = (root: HTMLElement) => {
-	const container = root.querySelector("diffs-container");
+const getCodeElement = (diffElement: HTMLElement) => {
+	const container = diffElement.querySelector("diffs-container");
 	if (!(container instanceof HTMLElement)) {
-		throw new Error("Diff container was not rendered");
+		throw new Error("Expected <diffs-container> element inside diff root");
 	}
 	const code = container.shadowRoot?.querySelector("[data-code]");
 	if (!(code instanceof HTMLElement)) {
-		throw new Error("Diff code was not rendered");
+		throw new Error("Expected [data-code] element inside <diffs-container>");
 	}
 	return code;
 };
@@ -1117,13 +1118,15 @@ export const EditFilesLongLineHorizontalScroll: Story = {
 		const diff = canvas.getByTestId("edit-file-diff");
 
 		await waitFor(() => {
-			const code = getRenderedCode(diff);
+			const code = getCodeElement(diff);
 			expect(code.scrollWidth).toBeGreaterThan(code.clientWidth);
-
-			const originalScrollLeft = code.scrollLeft;
-			code.scrollLeft = 32;
-			expect(code.scrollLeft).toBeGreaterThan(originalScrollLeft);
 		});
+
+		const code = getCodeElement(diff);
+		const originalScrollLeft = code.scrollLeft;
+		const positiveScrollOffset = 32;
+		code.scrollLeft = positiveScrollOffset;
+		expect(code.scrollLeft).toBeGreaterThan(originalScrollLeft);
 	},
 };
 

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/Tool.stories.tsx
@@ -6,6 +6,20 @@ import { DesktopPanelContext } from "./DesktopPanelContext";
 import { Tool } from "./Tool";
 
 const executeCommand = "git fetch origin";
+const longUnbrokenSegment = "0123456789abcdef".repeat(24);
+
+const getRenderedCode = (root: HTMLElement) => {
+	const container = root.querySelector("diffs-container");
+	if (!(container instanceof HTMLElement)) {
+		throw new Error("Diff container was not rendered");
+	}
+	const code = container.shadowRoot?.querySelector("[data-code]");
+	if (!(code instanceof HTMLElement)) {
+		throw new Error("Diff code was not rendered");
+	}
+	return code;
+};
+
 const meta: Meta<typeof Tool> = {
 	title: "pages/AgentsPage/ChatElements/tools/Tool",
 	component: Tool,
@@ -1079,6 +1093,40 @@ export const EditFilesSingleSuccess: Story = {
 	},
 };
 
+export const EditFilesLongLineHorizontalScroll: Story = {
+	args: {
+		name: "edit_files",
+		status: "completed",
+		codeDiffDisplayMode: "auto",
+		args: {
+			files: [
+				{
+					path: "src/config.ts",
+					edits: [
+						{
+							search: `export const token = "${longUnbrokenSegment}";`,
+							replace: `export const token = "${longUnbrokenSegment}changed";`,
+						},
+					],
+				},
+			],
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const diff = canvas.getByTestId("edit-file-diff");
+
+		await waitFor(() => {
+			const code = getRenderedCode(diff);
+			expect(code.scrollWidth).toBeGreaterThan(code.clientWidth);
+
+			const originalScrollLeft = code.scrollLeft;
+			code.scrollLeft = 32;
+			expect(code.scrollLeft).toBeGreaterThan(originalScrollLeft);
+		});
+	},
+};
+
 export const EditFilesAlwaysCollapsed: Story = {
 	args: {
 		name: "edit_files",
@@ -1772,7 +1820,7 @@ export const WaitAgentComputerUseRunning: Story = {
 		expect(canvasElement.querySelector(".lucide-monitor")).not.toBeNull();
 		// The VNC preview container should mount (the connection will
 		// stay in "connecting" state without a real WebSocket, which
-		// is expected — we only verify the container renders).
+		// is expected, so we only verify the container renders).
 		await waitFor(() => {
 			expect(
 				canvas.getByRole("button", { name: "Open desktop tab" }),

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/utils.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/utils.test.ts
@@ -281,8 +281,10 @@ describe("getDiffViewerOptions", () => {
 		expect(opts.theme).toBe("github-dark-high-contrast");
 		expect(opts.diffStyle).toBe("unified");
 		expect(opts.diffIndicators).toBe("bars");
-		expect(opts.overflow).toBe("wrap");
+		expect(opts.overflow).toBe("scroll");
 		expect(opts.unsafeCSS).toBe(diffViewerCSS);
+		expect(opts.unsafeCSS).not.toContain("scrollbar-width: none");
+		expect(opts.unsafeCSS).not.toContain("::-webkit-scrollbar { height: 0");
 	});
 
 	it("returns light theme options", () => {

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/utils.test.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/utils.test.ts
@@ -291,6 +291,9 @@ describe("getDiffViewerOptions", () => {
 		const opts = getDiffViewerOptions(false);
 		expect(opts.themeType).toBe("light");
 		expect(opts.theme).toBe("github-light");
+		expect(opts.overflow).toBe("scroll");
+		expect(opts.unsafeCSS).not.toContain("scrollbar-width: none");
+		expect(opts.unsafeCSS).not.toContain("::-webkit-scrollbar { height: 0");
 	});
 });
 

--- a/site/src/pages/AgentsPage/components/ChatElements/tools/utils.ts
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/utils.ts
@@ -339,11 +339,6 @@ export const diffViewerCSS = [
 	// tint and word-level emphasis highlights remain visible.
 	"pre, [data-line]:not([data-selected-line]):not([data-line-type='change-addition']):not([data-line-type='change-deletion']), [data-diffs-header] { background-color: transparent !important; }",
 	"[data-diffs-header] { border-left: 1px solid var(--border); }",
-	// The library reserves a 6 px horizontal scrollbar track on
-	// [data-code] via overflow: scroll clip. In wrap mode lines
-	// never overflow, so hide the track to remove the phantom gap.
-	"[data-code] { scrollbar-width: none !important; }",
-	"[data-code]::-webkit-scrollbar { height: 0 !important; }",
 	DIFF_HEADER_CSS,
 	SELECTION_OVERRIDE_CSS,
 	SEPARATOR_CSS,
@@ -354,7 +349,7 @@ export function getDiffViewerOptions(isDark: boolean) {
 	return {
 		diffStyle: "unified" as const,
 		diffIndicators: "bars" as const,
-		overflow: "wrap" as const,
+		overflow: "scroll" as const,
 		themeType: (isDark ? "dark" : "light") as "dark" | "light",
 		theme: isDark ? "github-dark-high-contrast" : "github-light",
 		unsafeCSS: diffViewerCSS,

--- a/site/src/pages/AgentsPage/components/DiffViewer/DiffViewer.tsx
+++ b/site/src/pages/AgentsPage/components/DiffViewer/DiffViewer.tsx
@@ -120,6 +120,9 @@ const STICKY_HEADER_CSS = [
 	"}",
 ].join(" ");
 
+// The library reserves a 6px horizontal scrollbar track via
+// overflow: scroll clip. In wrap mode, lines never overflow, so
+// hide the track to remove the phantom gap.
 const WRAP_MODE_SCROLLBAR_HIDING_CSS = [
 	"[data-code] {",
 	"  scrollbar-width: none !important;",
@@ -544,8 +547,8 @@ export const DiffViewer: FC<DiffViewerProps> = ({
 	const diffOptions = {
 		...base,
 		diffStyle,
-		// Extend the base CSS to make file headers sticky so they
-		// remain visible while scrolling through long diffs.
+		// Extend the base CSS to keep file headers visible and
+		// remove the phantom scrollbar gap in wrap mode.
 		unsafeCSS: `${base.unsafeCSS ?? ""} ${STICKY_HEADER_CSS} ${WRAP_MODE_SCROLLBAR_HIDING_CSS}`,
 	};
 

--- a/site/src/pages/AgentsPage/components/DiffViewer/DiffViewer.tsx
+++ b/site/src/pages/AgentsPage/components/DiffViewer/DiffViewer.tsx
@@ -120,6 +120,15 @@ const STICKY_HEADER_CSS = [
 	"}",
 ].join(" ");
 
+const WRAP_MODE_SCROLLBAR_HIDING_CSS = [
+	"[data-code] {",
+	"  scrollbar-width: none !important;",
+	"}",
+	"[data-code]::-webkit-scrollbar {",
+	"  height: 0 !important;",
+	"}",
+].join(" ");
+
 export type DiffStyle = "unified" | "split";
 const DIFF_STYLE_KEY = "agents.diff-view-style";
 
@@ -537,7 +546,7 @@ export const DiffViewer: FC<DiffViewerProps> = ({
 		diffStyle,
 		// Extend the base CSS to make file headers sticky so they
 		// remain visible while scrolling through long diffs.
-		unsafeCSS: `${base.unsafeCSS ?? ""} ${STICKY_HEADER_CSS}`,
+		unsafeCSS: `${base.unsafeCSS ?? ""} ${STICKY_HEADER_CSS} ${WRAP_MODE_SCROLLBAR_HIDING_CSS}`,
 	};
 
 	const fileOptions = {

--- a/site/src/pages/AgentsPage/components/DiffViewer/DiffViewer.tsx
+++ b/site/src/pages/AgentsPage/components/DiffViewer/DiffViewer.tsx
@@ -542,7 +542,7 @@ export const DiffViewer: FC<DiffViewerProps> = ({
 
 	const fileOptions = {
 		...diffOptions,
-		overflow: "wrap" as const,
+		overflow: "scroll" as const,
 		enableLineSelection: true,
 		enableHoverUtility: true,
 		onLineSelected() {
@@ -558,7 +558,7 @@ export const DiffViewer: FC<DiffViewerProps> = ({
 
 	const getOptionsForFile = (fileName: string) => ({
 		...diffOptions,
-		overflow: "wrap" as const,
+		overflow: "scroll" as const,
 		enableLineSelection: true,
 		enableHoverUtility: true,
 		...(onLineNumberClick && {

--- a/site/src/pages/AgentsPage/components/DiffViewer/DiffViewer.tsx
+++ b/site/src/pages/AgentsPage/components/DiffViewer/DiffViewer.tsx
@@ -542,7 +542,7 @@ export const DiffViewer: FC<DiffViewerProps> = ({
 
 	const fileOptions = {
 		...diffOptions,
-		overflow: "scroll" as const,
+		overflow: "wrap" as const,
 		enableLineSelection: true,
 		enableHoverUtility: true,
 		onLineSelected() {
@@ -558,7 +558,7 @@ export const DiffViewer: FC<DiffViewerProps> = ({
 
 	const getOptionsForFile = (fileName: string) => ({
 		...diffOptions,
-		overflow: "scroll" as const,
+		overflow: "wrap" as const,
 		enableLineSelection: true,
 		enableHoverUtility: true,
 		...(onLineNumberClick && {


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood

Coder Agents conversation-flow inline diff renderers now preserve long lines and allow horizontal scrolling instead of wrapping. The diff viewer CSS no longer hides the @pierre/diffs horizontal scrollbar, and Storybook coverage exercises a long unbroken edit diff that can be scrolled horizontally.
