### PR TITLE
feat: record observed user secrets in build logs

### DIFF
--- a/coderd/workspacebuilds_test.go
+++ b/coderd/workspacebuilds_test.go
@@ -1094,6 +1094,154 @@ func TestWorkspaceBuildLogs(t *testing.T) {
 	require.Fail(t, "example message never happened")
 }
 
+// TestWorkspaceBuildLogs_UserSecrets asserts that the runner emits a
+// "User secrets" stage with one INFO line per user secret describing the
+// environment variable and/or file path the user configured. The stage
+// serves as the canonical record of which user secrets the build
+// observed at plan time. The secret value must never appear in any log
+// line.
+func TestWorkspaceBuildLogs_UserSecrets(t *testing.T) {
+	t.Parallel()
+
+	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+	user := coderdtest.CreateFirstUser(t, client)
+
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+	defer cancel()
+
+	// Create three secrets covering each binding combination, plus one
+	// secret with neither binding that must be filtered.
+	const (
+		envOnlyValue  = "env-only-value-must-not-leak"
+		fileOnlyValue = "file-only-value-must-not-leak"
+		bothValue     = "both-value-must-not-leak"
+		noBindValue   = "no-bind-value-must-not-leak"
+	)
+	_, err := client.CreateUserSecret(ctx, codersdk.Me, codersdk.CreateUserSecretRequest{
+		Name: "github-token", Value: envOnlyValue, EnvName: "GITHUB_TOKEN",
+	})
+	require.NoError(t, err)
+	_, err = client.CreateUserSecret(ctx, codersdk.Me, codersdk.CreateUserSecretRequest{
+		Name: "ssh-key", Value: fileOnlyValue, FilePath: "/home/coder/.ssh/id_rsa",
+	})
+	require.NoError(t, err)
+	_, err = client.CreateUserSecret(ctx, codersdk.Me, codersdk.CreateUserSecretRequest{
+		Name: "both-binding", Value: bothValue, EnvName: "BOTH", FilePath: "/etc/both",
+	})
+	require.NoError(t, err)
+	_, err = client.CreateUserSecret(ctx, codersdk.Me, codersdk.CreateUserSecretRequest{
+		Name: "no-binding", Value: noBindValue,
+	})
+	require.NoError(t, err)
+
+	version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
+	coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+	template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
+	workspace := coderdtest.CreateWorkspace(t, client, template.ID)
+
+	logs, closer, err := client.WorkspaceBuildLogsAfter(ctx, workspace.LatestBuild.ID, 0)
+	require.NoError(t, err)
+	defer closer.Close()
+
+	var secretLogs []codersdk.ProvisionerJobLog
+	for log := range logs {
+		if log.Stage == "User secrets" {
+			secretLogs = append(secretLogs, log)
+		}
+		// Defensive: assert no secret value leaked into any log line, not
+		// just the User secrets stage.
+		require.NotContains(t, log.Output, envOnlyValue, "env-only secret value leaked")
+		require.NotContains(t, log.Output, fileOnlyValue, "file-only secret value leaked")
+		require.NotContains(t, log.Output, bothValue, "both-binding secret value leaked")
+		require.NotContains(t, log.Output, noBindValue, "no-binding secret value leaked")
+	}
+
+	outputs := make([]string, 0, len(secretLogs))
+	for _, l := range secretLogs {
+		outputs = append(outputs, l.Output)
+		require.Equal(t, codersdk.LogLevelInfo, l.Level)
+		require.Equal(t, codersdk.LogSourceProvisionerDaemon, l.Source)
+	}
+	require.ElementsMatch(t, []string{
+		"Observed secret with environment variable BOTH and file path /etc/both",
+		"Observed secret with environment variable GITHUB_TOKEN",
+		"Observed secret with file path /home/coder/.ssh/id_rsa",
+	}, outputs, "expected exactly three User secrets lines, one per bound secret")
+}
+
+// TestWorkspaceBuildLogs_UserSecrets_NoBindings asserts that the "User
+// secrets" stage is always present on a Start build, even when the user
+// has no secrets configured. This makes the section a definitive record
+// of which user secrets the build observed.
+func TestWorkspaceBuildLogs_UserSecrets_NoBindings(t *testing.T) {
+	t.Parallel()
+
+	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+	user := coderdtest.CreateFirstUser(t, client)
+
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+	defer cancel()
+
+	version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
+	coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+	template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
+	workspace := coderdtest.CreateWorkspace(t, client, template.ID)
+
+	logs, closer, err := client.WorkspaceBuildLogsAfter(ctx, workspace.LatestBuild.ID, 0)
+	require.NoError(t, err)
+	defer closer.Close()
+
+	var secretLogs []codersdk.ProvisionerJobLog
+	for log := range logs {
+		if log.Stage == "User secrets" {
+			secretLogs = append(secretLogs, log)
+		}
+	}
+	require.Len(t, secretLogs, 1, "expected exactly one User secrets line when no bindings are configured")
+	require.Equal(t, "No user secrets observed.", secretLogs[0].Output)
+	require.Equal(t, codersdk.LogLevelInfo, secretLogs[0].Level)
+	require.Equal(t, codersdk.LogSourceProvisionerDaemon, secretLogs[0].Source)
+}
+
+// TestWorkspaceBuildLogs_UserSecrets_StopTransition asserts that the
+// "User secrets" stage is suppressed on Stop transitions: user secrets
+// are not in scope for teardown builds, and emitting a section on every
+// shutdown would add noise without informational value. Destroy is
+// gated by the same condition.
+func TestWorkspaceBuildLogs_UserSecrets_StopTransition(t *testing.T) {
+	t.Parallel()
+
+	client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true})
+	user := coderdtest.CreateFirstUser(t, client)
+
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
+	defer cancel()
+
+	// Configure a secret so a regression that removed the transition gate
+	// would surface as a User secrets stage on stop.
+	_, err := client.CreateUserSecret(ctx, codersdk.Me, codersdk.CreateUserSecretRequest{
+		Name: "github-token", Value: "value-must-not-leak", EnvName: "GITHUB_TOKEN",
+	})
+	require.NoError(t, err)
+
+	version := coderdtest.CreateTemplateVersion(t, client, user.OrganizationID, nil)
+	coderdtest.AwaitTemplateVersionJobCompleted(t, client, version.ID)
+	template := coderdtest.CreateTemplate(t, client, user.OrganizationID, version.ID)
+	workspace := coderdtest.CreateWorkspace(t, client, template.ID)
+	coderdtest.AwaitWorkspaceBuildJobCompleted(t, client, workspace.LatestBuild.ID)
+	stopped := coderdtest.MustTransitionWorkspace(t, client, workspace.ID,
+		codersdk.WorkspaceTransitionStart, codersdk.WorkspaceTransitionStop)
+
+	logs, closer, err := client.WorkspaceBuildLogsAfter(ctx, stopped.LatestBuild.ID, 0)
+	require.NoError(t, err)
+	defer closer.Close()
+
+	for log := range logs {
+		require.NotEqual(t, "User secrets", log.Stage,
+			"Stop transitions must not emit a User secrets stage")
+	}
+}
+
 func TestWorkspaceBuildLogsFormat(t *testing.T) {
 	t.Parallel()
 

--- a/provisionerd/runner/runner.go
+++ b/provisionerd/runner/runner.go
@@ -956,6 +956,9 @@ func (r *Runner) runWorkspaceBuild(ctx context.Context) (*proto.CompletedJob, *p
 		}
 	}
 
+	// Log the user secrets that will be available to terraform plan.
+	r.logUserSecrets(ctx, r.job.GetWorkspaceBuild().GetUserSecrets())
+
 	// Run `terraform plan`
 	planComplete, failed := r.plan(ctx, "Planning Infrastructure", &sdkproto.PlanRequest{
 		Metadata:                r.job.GetWorkspaceBuild().Metadata,
@@ -1095,6 +1098,68 @@ func (r *Runner) runWorkspaceBuild(ctx context.Context) (*proto.CompletedJob, *p
 			},
 		},
 	}, nil
+}
+
+// logUserSecrets emits one INFO log line per user secret describing the
+// bindings (environment variable name, file path, or both) under a
+// dedicated "User secrets" stage. This stage is the canonical record of
+// the user secrets that were observed during this build's plan; readers
+// can rely on its presence (on a Start transition) to confirm what the
+// build received. The secret value is intentionally never included.
+func (r *Runner) logUserSecrets(ctx context.Context, secrets []*sdkproto.UserSecretValue) {
+	// Only emit on Start transitions. Stop and Destroy builds carry no
+	// user secrets (acquireProtoJob filters them out for non-Start
+	// transitions), and emitting an empty section on every teardown
+	// would add noise without informational value.
+	if r.job.GetWorkspaceBuild().GetMetadata().GetWorkspaceTransition() != sdkproto.WorkspaceTransition_START {
+		return
+	}
+
+	const stage = "User secrets"
+	now := time.Now().UnixMilli()
+	emit := func(output string) {
+		r.queueLog(ctx, &proto.Log{
+			Source:    proto.LogSource_PROVISIONER_DAEMON,
+			Level:     sdkproto.LogLevel_INFO,
+			CreatedAt: now,
+			Stage:     stage,
+			Output:    output,
+		})
+	}
+
+	var emitted int
+	for _, secret := range secrets {
+		line := formatUserSecretLog(secret)
+		if line == "" {
+			continue
+		}
+		emit(line)
+		emitted++
+	}
+	if emitted == 0 {
+		// Always emit at least one line so the section is a definitive
+		// record even for users with no secrets configured.
+		emit("No user secrets observed.")
+	}
+}
+
+// formatUserSecretLog returns a single log line describing the bindings of
+// a user secret. Returns the empty string for a secret with neither an
+// environment variable name nor a file path, indicating no line should be
+// emitted. The secret value is intentionally never included.
+func formatUserSecretLog(secret *sdkproto.UserSecretValue) string {
+	env := secret.GetEnvName()
+	file := secret.GetFilePath()
+	switch {
+	case env != "" && file != "":
+		return fmt.Sprintf("Observed secret with environment variable %s and file path %s", env, file)
+	case env != "":
+		return fmt.Sprintf("Observed secret with environment variable %s", env)
+	case file != "":
+		return fmt.Sprintf("Observed secret with file path %s", file)
+	default:
+		return ""
+	}
 }
 
 func resourceNames(rs []*sdkproto.Resource) []string {


### PR DESCRIPTION
Emit a "User secrets" stage in the build log after Terraform init and before Terraform plan, listing the user secrets the build received via the plan request. The stage is a definitive record on every Start build: one INFO line per secret describing its environment variable and/or file path binding, or a single "No user secrets observed." line when the user has no secrets configured. Secret values are never included. Stop and Destroy builds suppress the stage.

The goal of this change is to provide visibility into what user secrets were observed when the workspace was created. The user's secrets may change after the build, but this helps with visibility and debugging.

This is what it looks like when viewing build output:

<img width="1718" height="384" alt="Screenshot 2026-05-12 at 4 54 36 PM" src="https://github.com/user-attachments/assets/d168f757-f9fb-4c0d-be91-331875b5b943" />
