### PR TITLE
fix(go.mod): bump gomarkdown/markdown to fix GHSA-77fj-vx54-gvh7 (v2.29)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -130,7 +130,7 @@ require (
 	github.com/gohugoio/hugo v0.152.2
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/golang-migrate/migrate/v4 v4.19.0
-	github.com/gomarkdown/markdown v0.0.0-20240930133441-72d49d9543d8
+	github.com/gomarkdown/markdown v0.0.0-20260417124207-7d523f7318df
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-github/v43 v43.0.1-0.20220414155304-00e42332e405
 	github.com/google/go-github/v61 v61.0.0

--- a/go.sum
+++ b/go.sum
@@ -603,8 +603,8 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
-github.com/gomarkdown/markdown v0.0.0-20240930133441-72d49d9543d8 h1:4txT5G2kqVAKMjzidIabL/8KqjIK71yj30YOeuxLn10=
-github.com/gomarkdown/markdown v0.0.0-20240930133441-72d49d9543d8/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
+github.com/gomarkdown/markdown v0.0.0-20260417124207-7d523f7318df h1:Mwihr/o+v4L5h56rwHLOE20+hh7Okhwno5BHz3zDuao=
+github.com/gomarkdown/markdown v0.0.0-20260417124207-7d523f7318df/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
 github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
 github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/google/flatbuffers v25.2.10+incompatible h1:F3vclr7C3HpB1k9mxCGRMXq6FdUalZ6H/pNX4FP1v0Q=


### PR DESCRIPTION
## Summary

Bumps `github.com/gomarkdown/markdown` from `v0.0.0-20240930133441-72d49d9543d8` to `v0.0.0-20260417124207-7d523f7318df` on the `release/2.29` branch.

This fixes [GHSA-77fj-vx54-gvh7](https://github.com/advisories/GHSA-77fj-vx54-gvh7) (Out-of-bounds Read in SmartypantsRenderer, High severity).

Equivalent of [#24567](https://github.com/coder/coder/pull/24567) on `main`.

Resolves ENT-47.

<details><summary>Context</summary>

- **Vulnerability:** Processing a malformed input containing a `<` character not followed by `>` with a SmartypantsRenderer leads to OOB read or panic.
- **Mitigating factor:** Coder's user-facing markdown is rendered via react-markdown, not gomarkdown. The SmartypantsRenderer is likely not invoked at runtime.
- **Changes:** Only `go.mod` and `go.sum` are modified. Build verified with `go build ./...`.

</details>

> Generated by Coder Agents