### PR TITLE
fix: bump Go toolchain to 1.25.9 (backport to 2.29)

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -4,7 +4,7 @@ description: |
 inputs:
   version:
     description: "The Go version to use."
-    default: "1.25.8"
+    default: "1.25.9"
   use-preinstalled-go:
     description: "Whether to use preinstalled Go."
     default: "false"

--- a/dogfood/coder/Dockerfile
+++ b/dogfood/coder/Dockerfile
@@ -11,8 +11,8 @@ RUN cargo install jj-cli typos-cli watchexec-cli@2.3.2
 FROM ubuntu:jammy@sha256:104ae83764a5119017b8e8d6218fa0832b09df65aae7d5a6de29a85d813da2fb AS go
 
 # Install Go manually, so that we can control the version
-ARG GO_VERSION=1.25.8
-ARG GO_CHECKSUM="ceb5e041bbc3893846bd1614d76cb4681c91dadee579426cf21a63f2d7e03be6"
+ARG GO_VERSION=1.25.9
+ARG GO_CHECKSUM="00859d7bd6defe8bf84d9db9e57b9a4467b2887c18cd93ae7460e713db774bc1"
 
 # Boring Go is needed to build FIPS-compliant binaries.
 RUN apt-get update && \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coder/coder/v2
 
-go 1.25.8
+go 1.25.9
 
 // Required until a v3 of chroma is created to lazily initialize all XML files.
 // None of our dependencies seem to use the registries anyways, so this


### PR DESCRIPTION
## Summary

Backports the Go 1.25.9 toolchain bump to the `release/2.29` branch, addressing 9 CVEs (1 Critical, 5 High, 3 Medium) present in Go 1.25.8.

Cherry-picked from the main branch change in #24293.

## Changes

| File | Change |
|------|--------|
| `go.mod` | `go 1.25.8` -> `go 1.25.9` |
| `.github/actions/setup-go/action.yaml` | Default Go version `1.25.8` -> `1.25.9` |
| `dogfood/coder/Dockerfile` | `GO_VERSION` and `GO_CHECKSUM` updated to 1.25.9 |

Fixes: https://linear.app/codercom/issue/ENT-48

> Generated by Coder Agents

<details>
<summary>Context</summary>

- Parent issue: ENT-18 (IronBank: Upgrade bundled Terraform Go toolchain from 1.25.8 to 1.25.9+)
- v2.29.12 currently ships Go 1.25.8 (set by PR #24905)
- Go 1.25.9 was bumped on main in PR #24293 (commit 03d662a)
- The same pattern was backported to release/2.31 via PR #24329
</details>