### PR TITLE
fix: bump go-jose/go-jose/v4 to v4.1.4 (CVE-2026-34986)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -123,7 +123,7 @@ require (
 	github.com/go-chi/chi/v5 v5.2.4
 	github.com/go-chi/cors v1.2.1
 	github.com/go-chi/httprate v0.15.0
-	github.com/go-jose/go-jose/v4 v4.1.3
+	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-logr/logr v1.4.3
 	github.com/go-playground/validator/v10 v10.28.0
 	github.com/gofrs/flock v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -489,8 +489,8 @@ github.com/go-git/go-git/v5 v5.18.0 h1:O831KI+0PR51hM2kep6T8k+w0/LIAD490gvqMCvL5
 github.com/go-git/go-git/v5 v5.18.0/go.mod h1:pW/VmeqkanRFqR6AljLcs7EA7FbZaN5MQqO7oZADXpo=
 github.com/go-ini/ini v1.67.0 h1:z6ZrTEZqSWOTyH2FlglNbNgARyHG8oLW9gMELqKr06A=
 github.com/go-ini/ini v1.67.0/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
-github.com/go-jose/go-jose/v4 v4.1.3 h1:CVLmWDhDVRa6Mi/IgCgaopNosCaHz7zrMeF9MlZRkrs=
-github.com/go-jose/go-jose/v4 v4.1.3/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
+github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
+github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-json-experiment/json v0.0.0-20250725192818-e39067aee2d2 h1:iizUGZ9pEquQS5jTGkh4AqeeHCMbfbjeb0zMt0aEFzs=
 github.com/go-json-experiment/json v0.0.0-20250725192818-e39067aee2d2/go.mod h1:TiCD2a1pcmjd7YnhGH0f/zKNcCD06B029pHhzV23c2M=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=


### PR DESCRIPTION
## Summary

Bumps `github.com/go-jose/go-jose/v4` from v4.1.3 to v4.1.4 on the `release/2.29` branch to fix a JWE decryption panic.

| CVE | Severity | Advisory |
|-----|----------|----------|
| CVE-2026-34986 | High | [NVD](https://nvd.nist.gov/vuln/detail/CVE-2026-34986) |
| GHSA-78h2-9frx-2jm8 | High | [GitHub](https://github.com/advisories/GHSA-78h2-9frx-2jm8) |

## Changes

- `go.mod`: `go-jose/go-jose/v4` v4.1.3 -> v4.1.4
- `go.sum`: updated checksums

No code changes; dependency-only bump.

Ref: [ENT-55](https://linear.app/codercom/issue/ENT-55), [ENT-65](https://linear.app/codercom/issue/ENT-65)

> Generated by Coder Agents ([session](https://linear.app/codercom/issue/ENT-55/ironbank-upgrade-go-jose-to-fix-jwe-decryption-panic-cve-2026-34986#agent-session-f2144e2c))