### PR TITLE
feat(site/src/pages/AIBridgePage): scaffold AI Bridge provider management pages

### DIFF
--- a/site/src/pages/AIBridgePage/AIBridgeProvidersLayout.tsx
+++ b/site/src/pages/AIBridgePage/AIBridgeProvidersLayout.tsx
@@ -1,0 +1,37 @@
+import type { FC, PropsWithChildren } from "react";
+import { Outlet } from "react-router";
+import { Link } from "#/components/Link/Link";
+import { Margins } from "#/components/Margins/Margins";
+import {
+	PageHeader,
+	PageHeaderSubtitle,
+	PageHeaderTitle,
+} from "#/components/PageHeader/PageHeader";
+import { docs } from "#/utils/docs";
+
+const AIBridgeProvidersLayout: FC<PropsWithChildren> = () => {
+	return (
+		<Margins className="pb-12">
+			<PageHeader>
+				<PageHeaderTitle>
+					<div className="flex items-center gap-2">
+						<span>AI Providers</span>
+					</div>
+				</PageHeaderTitle>
+				<PageHeaderSubtitle>
+					Configure the LLM providers that AI Bridge routes requests through.{" "}
+					<Link
+						href={docs("/ai-coder/ai-bridge")}
+						className="ml-auto"
+						target="_blank"
+					>
+						Learn how to manage AI providers
+					</Link>
+				</PageHeaderSubtitle>
+			</PageHeader>
+			<Outlet />
+		</Margins>
+	);
+};
+
+export default AIBridgeProvidersLayout;

--- a/site/src/pages/AIBridgePage/CreateProviderPage/CreateProviderPage.tsx
+++ b/site/src/pages/AIBridgePage/CreateProviderPage/CreateProviderPage.tsx
@@ -1,0 +1,16 @@
+import type { FC } from "react";
+import { pageTitle } from "#/utils/page";
+
+const CreateProviderPage: FC = () => {
+	// TODO(jakehwll): wire up the create provider form.
+	// See https://linear.app/codercom/project/coder-agents-ai-gov-unification
+	// for the AI Bridge provider CRUD work this page hangs off of.
+	return (
+		<>
+			<title>{pageTitle("Create Provider", "AI Bridge")}</title>
+			<p>TODO: create a new AI Bridge provider.</p>
+		</>
+	);
+};
+
+export default CreateProviderPage;

--- a/site/src/pages/AIBridgePage/EditProviderPage/EditProviderPage.tsx
+++ b/site/src/pages/AIBridgePage/EditProviderPage/EditProviderPage.tsx
@@ -1,0 +1,16 @@
+import type { FC } from "react";
+import { pageTitle } from "#/utils/page";
+
+const EditProviderPage: FC = () => {
+	// TODO(jakehwll): wire up the edit provider form.
+	// See https://linear.app/codercom/project/coder-agents-ai-gov-unification
+	// for the AI Bridge provider CRUD work this page hangs off of.
+	return (
+		<>
+			<title>{pageTitle("Edit Provider", "AI Bridge")}</title>
+			<p>TODO: edit an existing AI Bridge provider.</p>
+		</>
+	);
+};
+
+export default EditProviderPage;

--- a/site/src/pages/AIBridgePage/ListProvidersPage/ListProvidersPage.tsx
+++ b/site/src/pages/AIBridgePage/ListProvidersPage/ListProvidersPage.tsx
@@ -1,0 +1,16 @@
+import type { FC } from "react";
+import { pageTitle } from "#/utils/page";
+
+const ListProvidersPage: FC = () => {
+	// TODO(jakehwll): wire up the providers list view.
+	// See https://linear.app/codercom/project/coder-agents-ai-gov-unification
+	// for the AI Bridge provider CRUD work this page hangs off of.
+	return (
+		<>
+			<title>{pageTitle("Providers", "AI Bridge")}</title>
+			<p>TODO: list AI Bridge providers.</p>
+		</>
+	);
+};
+
+export default ListProvidersPage;

--- a/site/src/router.tsx
+++ b/site/src/router.tsx
@@ -426,6 +426,20 @@ const AIBridgeSessionThreadsPage = lazy(
 	() => import("./pages/AIBridgePage/SessionThreadsPage/SessionThreadsPage"),
 );
 
+const AIBridgeProvidersLayout = lazy(
+	() => import("./pages/AIBridgePage/AIBridgeProvidersLayout"),
+);
+
+const AIBridgeListProvidersPage = lazy(
+	() => import("./pages/AIBridgePage/ListProvidersPage/ListProvidersPage"),
+);
+const AIBridgeCreateProviderPage = lazy(
+	() => import("./pages/AIBridgePage/CreateProviderPage/CreateProviderPage"),
+);
+const AIBridgeEditProviderPage = lazy(
+	() => import("./pages/AIBridgePage/EditProviderPage/EditProviderPage"),
+);
+
 const GlobalLayout = () => {
 	return (
 		<Suspense fallback={<Loader fullscreen />}>
@@ -673,6 +687,15 @@ export const router = createBrowserRouter(
 					<Route path="/aibridge/sessions" element={<AIBridgeSessionsLayout />}>
 						<Route index element={<AIBridgeListSessionsPage />} />
 						<Route path=":sessionId" element={<AIBridgeSessionThreadsPage />} />
+					</Route>
+
+					<Route
+						path="/aibridge/providers"
+						element={<AIBridgeProvidersLayout />}
+					>
+						<Route index element={<AIBridgeListProvidersPage />} />
+						<Route path="new" element={<AIBridgeCreateProviderPage />} />
+						<Route path=":providerId" element={<AIBridgeEditProviderPage />} />
 					</Route>
 
 					<Route path="/health" element={<HealthLayout />}>


### PR DESCRIPTION
> 🤖 This PR was written by Coder Agents on behalf of Jake Howell.

Scaffolds a new set of pages for AI Bridge provider management, mirroring how the AI Sessions area is structured.

## What's here

- `AIBridgeProvidersLayout` — wrapping layout (analogous to `AIBridgeSessionsLayout`).
- `ListProvidersPage`, `CreateProviderPage`, `EditProviderPage` — TODO stubs for the CRUD surface.
- Router wiring for `/aibridge/providers`, `/aibridge/providers/new`, and `/aibridge/providers/:providerId`.

This is intentionally scaffold-only. Page contents are placeholder TODOs to be filled in alongside the AI Bridge provider CRUD API work in the Coder Agents <> AI Gov Unification project.

## Out of scope

- API queries / mutations
- Permission gating (`getAIBridgePermissions` already exists and will be reused)
- Forms, tables, navigation entries, paywall handling

## Notes

- `make pre-commit` passed locally (gen + fmt + lint + slim build, ~2 min).
- No DB or audit changes.