### PR TITLE
fix(.github/workflows/deploy-docs.yaml): drop self-trigger from paths

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -31,8 +31,10 @@ on:
       - main
       - "release/*"
     paths:
+      # Intentionally only docs/**. Edits to this workflow file must not
+      # auto-trigger a production reindex; use workflow_dispatch instead.
+      # See DOCS-121 (incident) and DOCS-124 (fix).
       - "docs/**"
-      - ".github/workflows/deploy-docs.yaml"
   workflow_dispatch:
     inputs:
       action:


### PR DESCRIPTION
Edits to `.github/workflows/deploy-docs.yaml` previously self-triggered the workflow on push to `main` and `release/*` because the file was listed in its own `paths:`. On 2026-05-12, this caused merge of #25049 to fire a production reindex with no `docs/**` changes, which entered the empty-`paths_json` whole-branch path in the Algolia handler and wiped the `docs` index (see DOCS-121).

This change removes `.github/workflows/deploy-docs.yaml` from `paths:` so the workflow only runs against real docs content. Reindexes from a workflow edit alone now require `workflow_dispatch`, which already accepts a `ref` input and an `action` choice of `index` or `delete`. The other safety net (a workflow-level `paths_json=[]` guard in `algolia-and-isr`) is tracked separately in DOCS-122.

Refs DOCS-121, DOCS-122, DOCS-124.

---
_Coder Agents on behalf of @nickvigilante._
