### PR TITLE
chore: add slogtest noise filter to testutil.Logger 

### DIFF
--- a/testutil/logger.go
+++ b/testutil/logger.go
@@ -34,7 +34,10 @@ func Logger(t testing.TB, opts ...LoggerOption) slog.Logger {
 		o(&cfg)
 	}
 
-	inner := newTestSink(t)
+	inner := newTestSink(t, sinkOptions{
+		ignoreAllErrors:  cfg.ignoreAllErrors,
+		extraIgnoredErrs: cfg.extraIgnoredErrs,
+	})
 	drop := buildDropFn(cfg)
 	return slog.Make(&filteringSink{inner: inner, drop: drop}).Leveled(slog.LevelDebug)
 }
@@ -43,8 +46,10 @@ func Logger(t testing.TB, opts ...LoggerOption) slog.Logger {
 type LoggerOption func(*loggerConfig)
 
 type loggerConfig struct {
-	applyDefaults bool
-	extra         []func(slog.SinkEntry) bool
+	applyDefaults    bool
+	extra            []func(slog.SinkEntry) bool
+	ignoreAllErrors  bool
+	extraIgnoredErrs []error
 }
 
 // WithNoFilter disables the default deny-list. The returned logger will emit
@@ -72,6 +77,32 @@ func WithFilter(fn func(slog.SinkEntry) bool) LoggerOption {
 		if fn != nil {
 			cfg.extra = append(cfg.extra, fn)
 		}
+	}
+}
+
+// WithIgnoreErrors causes the logger to never fail the test on error or
+// critical log entries. Such entries are still emitted via t.Log; they are
+// just downgraded so that they do not call t.Errorf.
+//
+// This mirrors slogtest.Options.IgnoreErrors and exists to ease migration of
+// call sites that previously used slogtest.Make directly.
+func WithIgnoreErrors() LoggerOption {
+	return func(cfg *loggerConfig) {
+		cfg.ignoreAllErrors = true
+	}
+}
+
+// WithIgnoredErrorIs adds errors that should not fail the test when they
+// appear in a log entry's "error" field. Matching uses xerrors.Is.
+//
+// This is additive to the built-in ignore list (yamux session shutdown,
+// context.Canceled / context.DeadlineExceeded, query-canceled errors) and to
+// any previous WithIgnoredErrorIs options.
+//
+// This mirrors slogtest.Options.IgnoredErrorIs.
+func WithIgnoredErrorIs(errs ...error) LoggerOption {
+	return func(cfg *loggerConfig) {
+		cfg.extraIgnoredErrs = append(cfg.extraIgnoredErrs, errs...)
 	}
 }
 
@@ -185,7 +216,8 @@ func (f *filteringSink) Sync() { f.inner.Sync() }
 // We own this sink so that we can wrap it in filteringSink. Going through
 // slogtest.Make directly would not give us access to the underlying sink.
 type testSink struct {
-	tb testing.TB
+	tb   testing.TB
+	opts sinkOptions
 
 	mu       sync.RWMutex
 	testDone bool
@@ -197,10 +229,16 @@ type testSink struct {
 	fmtSink slog.Sink
 }
 
-func newTestSink(tb testing.TB) *testSink {
+type sinkOptions struct {
+	ignoreAllErrors  bool
+	extraIgnoredErrs []error
+}
+
+func newTestSink(tb testing.TB, opts sinkOptions) *testSink {
 	buf := &lineBuffer{}
 	s := &testSink{
 		tb:      tb,
+		opts:    opts,
 		fmtBuf:  buf,
 		fmtSink: sloghuman.Sink(buf),
 	}
@@ -244,7 +282,7 @@ func (s *testSink) LogEntry(ctx context.Context, ent slog.SinkEntry) {
 	case slog.LevelDebug, slog.LevelInfo, slog.LevelWarn:
 		s.tb.Log(formatted)
 	case slog.LevelError, slog.LevelCritical:
-		if IgnoreLoggedError(ent) {
+		if s.shouldIgnoreError(ent) {
 			s.tb.Log(formatted)
 		} else {
 			s.tb.Errorf("%s\n *** slogtest: log detected at level %s; TEST FAILURE ***",
@@ -253,6 +291,28 @@ func (s *testSink) LogEntry(ctx context.Context, ent slog.SinkEntry) {
 	case slog.LevelFatal:
 		s.tb.Fatal(fmt.Sprintf("%s\n *** slogtest: FATAL log detected; TEST FAILURE ***", formatted))
 	}
+}
+
+func (s *testSink) shouldIgnoreError(ent slog.SinkEntry) bool {
+	if s.opts.ignoreAllErrors {
+		return true
+	}
+	if IgnoreLoggedError(ent) {
+		return true
+	}
+	if len(s.opts.extraIgnoredErrs) == 0 {
+		return false
+	}
+	err, ok := findFirstError(ent)
+	if !ok {
+		return false
+	}
+	for _, ig := range s.opts.extraIgnoredErrs {
+		if xerrors.Is(err, ig) {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *testSink) format(ctx context.Context, ent slog.SinkEntry) string {

--- a/testutil/logger.go
+++ b/testutil/logger.go
@@ -35,8 +35,9 @@ func Logger(t testing.TB, opts ...LoggerOption) slog.Logger {
 	}
 
 	inner := newTestSink(t, sinkOptions{
-		ignoreAllErrors:  cfg.ignoreAllErrors,
-		extraIgnoredErrs: cfg.extraIgnoredErrs,
+		ignoreAllErrors:     cfg.ignoreAllErrors,
+		extraIgnoredErrs:    cfg.extraIgnoredErrs,
+		extraIgnoreErrorFns: cfg.extraIgnoreErrorFns,
 	})
 	drop := buildDropFn(cfg)
 	return slog.Make(&filteringSink{inner: inner, drop: drop}).Leveled(slog.LevelDebug)
@@ -46,10 +47,11 @@ func Logger(t testing.TB, opts ...LoggerOption) slog.Logger {
 type LoggerOption func(*loggerConfig)
 
 type loggerConfig struct {
-	applyDefaults    bool
-	extra            []func(slog.SinkEntry) bool
-	ignoreAllErrors  bool
-	extraIgnoredErrs []error
+	applyDefaults       bool
+	extra               []func(slog.SinkEntry) bool
+	ignoreAllErrors     bool
+	extraIgnoredErrs    []error
+	extraIgnoreErrorFns []func(slog.SinkEntry) bool
 }
 
 // WithNoFilter disables the default deny-list. The returned logger will emit
@@ -103,6 +105,22 @@ func WithIgnoreErrors() LoggerOption {
 func WithIgnoredErrorIs(errs ...error) LoggerOption {
 	return func(cfg *loggerConfig) {
 		cfg.extraIgnoredErrs = append(cfg.extraIgnoredErrs, errs...)
+	}
+}
+
+// WithIgnoreErrorFn registers an additional predicate consulted when deciding
+// whether an error or critical entry should fail the test. If the predicate
+// returns true, the entry is downgraded to t.Log instead of t.Errorf.
+//
+// This composes additively with the built-in ignore list, WithIgnoreErrors,
+// WithIgnoredErrorIs, and any previous WithIgnoreErrorFn options.
+//
+// This mirrors slogtest.Options.IgnoreErrorFn.
+func WithIgnoreErrorFn(fn func(slog.SinkEntry) bool) LoggerOption {
+	return func(cfg *loggerConfig) {
+		if fn != nil {
+			cfg.extraIgnoreErrorFns = append(cfg.extraIgnoreErrorFns, fn)
+		}
 	}
 }
 
@@ -230,8 +248,9 @@ type testSink struct {
 }
 
 type sinkOptions struct {
-	ignoreAllErrors  bool
-	extraIgnoredErrs []error
+	ignoreAllErrors     bool
+	extraIgnoredErrs    []error
+	extraIgnoreErrorFns []func(slog.SinkEntry) bool
 }
 
 func newTestSink(tb testing.TB, opts sinkOptions) *testSink {
@@ -300,15 +319,15 @@ func (s *testSink) shouldIgnoreError(ent slog.SinkEntry) bool {
 	if IgnoreLoggedError(ent) {
 		return true
 	}
-	if len(s.opts.extraIgnoredErrs) == 0 {
-		return false
+	if err, ok := findFirstError(ent); ok {
+		for _, ig := range s.opts.extraIgnoredErrs {
+			if xerrors.Is(err, ig) {
+				return true
+			}
+		}
 	}
-	err, ok := findFirstError(ent)
-	if !ok {
-		return false
-	}
-	for _, ig := range s.opts.extraIgnoredErrs {
-		if xerrors.Is(err, ig) {
+	for _, fn := range s.opts.extraIgnoreErrorFns {
+		if fn(ent) {
 			return true
 		}
 	}

--- a/testutil/logger.go
+++ b/testutil/logger.go
@@ -1,7 +1,9 @@
 package testutil
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"strings"
 	"sync"
@@ -11,19 +13,263 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
+	"cdr.dev/slog/v3/sloggers/sloghuman"
 )
 
 // Logger returns a "standard" testing logger, with debug level and common flaky
 // errors ignored.
-func Logger(t testing.TB) slog.Logger {
-	return slogtest.Make(
-		t, &slogtest.Options{IgnoreErrorFn: IgnoreLoggedError},
-	).Leveled(slog.LevelDebug)
+//
+// By default, Logger applies a deny-list that drops known-noisy debug entries
+// (tailnet, wireguard, pubsub publish chatter, provisioner echo per-file
+// extraction, key cache and key rotator boot chatter, periodic background
+// loops). Info, warn, error, critical, and fatal entries are never filtered.
+//
+// To opt out of the default deny-list, pass WithNoFilter(). To add a custom
+// filter on top of (or instead of) the defaults, pass WithFilter(fn).
+func Logger(t testing.TB, opts ...LoggerOption) slog.Logger {
+	cfg := loggerConfig{
+		applyDefaults: true,
+	}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	inner := newTestSink(t)
+	drop := buildDropFn(cfg)
+	return slog.Make(&filteringSink{inner: inner, drop: drop}).Leveled(slog.LevelDebug)
 }
 
-func IgnoreLoggedError(entry slog.SinkEntry) bool {
-	err, ok := slogtest.FindFirstError(entry)
+// LoggerOption configures the Logger returned by Logger.
+type LoggerOption func(*loggerConfig)
+
+type loggerConfig struct {
+	applyDefaults bool
+	extra         []func(slog.SinkEntry) bool
+}
+
+// WithNoFilter disables the default deny-list. The returned logger will emit
+// every debug entry that the underlying test sink would have emitted. Useful
+// when investigating test failures where you want the full firehose.
+//
+// WithNoFilter can be combined with WithFilter; in that case the defaults are
+// off but caller-supplied predicates still apply.
+func WithNoFilter() LoggerOption {
+	return func(cfg *loggerConfig) {
+		cfg.applyDefaults = false
+	}
+}
+
+// WithFilter adds a caller-supplied predicate to the filter chain. If fn
+// returns true for a debug-level entry, that entry is dropped. WithFilter
+// composes with the default deny-list via logical OR: an entry is dropped if
+// the defaults match it or any WithFilter predicate matches it. Multiple
+// WithFilter options compose the same way.
+//
+// WithFilter only affects debug-level entries; info, warn, and error entries
+// are always emitted.
+func WithFilter(fn func(slog.SinkEntry) bool) LoggerOption {
+	return func(cfg *loggerConfig) {
+		if fn != nil {
+			cfg.extra = append(cfg.extra, fn)
+		}
+	}
+}
+
+func buildDropFn(cfg loggerConfig) func(slog.SinkEntry) bool {
+	preds := make([]func(slog.SinkEntry) bool, 0, 1+len(cfg.extra))
+	if cfg.applyDefaults {
+		preds = append(preds, defaultDropDebug)
+	}
+	preds = append(preds, cfg.extra...)
+	switch len(preds) {
+	case 0:
+		return nil
+	case 1:
+		return preds[0]
+	default:
+		return func(ent slog.SinkEntry) bool {
+			for _, p := range preds {
+				if p(ent) {
+					return true
+				}
+			}
+			return false
+		}
+	}
+}
+
+// defaultDropDebug is the built-in deny-list. It matches debug-level entries
+// that contribute the bulk of test-log noise without providing useful signal
+// during post-mortem.
+//
+// Guidelines for adding a pattern:
+//   - debug level only; never silence info/warn/error,
+//   - the logger or message fires >=100 times in a single test run,
+//   - the entry does not provide useful flake-debugging context.
+//
+// HTTP access logs (coderd: GET/POST/PATCH/...) are intentionally NOT in the
+// deny-list because they provide essential post-mortem context.
+func defaultDropDebug(ent slog.SinkEntry) bool {
+	logger := strings.Join(ent.LoggerNames, ".")
+
+	// Tailnet, wireguard, netstack, and coordinator chatter.
+	if strings.Contains(logger, ".net.wgengine") ||
+		strings.Contains(logger, ".net.netstack") ||
+		strings.HasPrefix(logger, "coderd.servertailnet") ||
+		strings.HasPrefix(logger, "agent.net.tailnet") ||
+		strings.HasPrefix(logger, "cli.net.tailnet") ||
+		strings.HasPrefix(logger, "cli.net.wgengine") ||
+		strings.HasPrefix(logger, "coderd.coord") {
+		return true
+	}
+
+	// Key cache and key rotator boot chatter.
+	if strings.HasPrefix(logger, "coderd.keyrotator") ||
+		strings.Contains(logger, "_keycache") {
+		return true
+	}
+
+	// Periodic background loops.
+	switch logger {
+	case "coderd.dbrollup",
+		"coderd.metrics_cache",
+		"coderd.metadata_batcher",
+		"coderd.workspace_usage_tracker",
+		"coderd.workspaceapps.stats_collector",
+		"coderd.cli-telemetry":
+		return true
+	}
+
+	// Pubsub lifecycle and per-publish chatter.
+	if logger == "pubsub" {
+		switch ent.Message {
+		case "publish",
+			"started listening to event channel",
+			"stopped listening to event channel",
+			"removing queueSet":
+			return true
+		}
+	}
+
+	// Provisioner echo per-archive-entry chatter.
+	if logger == "coderd.echo" {
+		switch ent.Message {
+		case "read archive entry", "extracted file":
+			return true
+		}
+	}
+
+	return false
+}
+
+// filteringSink wraps an inner slog.Sink and drops debug-level entries that
+// match drop. Non-debug entries always pass through.
+type filteringSink struct {
+	inner slog.Sink
+	drop  func(slog.SinkEntry) bool
+}
+
+func (f *filteringSink) LogEntry(ctx context.Context, ent slog.SinkEntry) {
+	if ent.Level == slog.LevelDebug && f.drop != nil && f.drop(ent) {
+		return
+	}
+	f.inner.LogEntry(ctx, ent)
+}
+
+func (f *filteringSink) Sync() { f.inner.Sync() }
+
+// testSink mirrors cdr.dev/slog/v3/sloggers/slogtest's testSink, formatting
+// entries with sloghuman and dispatching to the appropriate testing.TB method
+// based on level.
+//
+// We own this sink so that we can wrap it in filteringSink. Going through
+// slogtest.Make directly would not give us access to the underlying sink.
+type testSink struct {
+	tb testing.TB
+
+	mu       sync.RWMutex
+	testDone bool
+
+	// fmtSink is a sloghuman sink writing to a per-entry buffer. We reuse it
+	// across entries; it is safe for concurrent use behind the mutex below.
+	fmtMu   sync.Mutex
+	fmtBuf  *lineBuffer
+	fmtSink slog.Sink
+}
+
+func newTestSink(tb testing.TB) *testSink {
+	buf := &lineBuffer{}
+	s := &testSink{
+		tb:      tb,
+		fmtBuf:  buf,
+		fmtSink: sloghuman.Sink(buf),
+	}
+	tb.Cleanup(func() {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		s.testDone = true
+	})
+	return s
+}
+
+// lineBuffer is an io.Writer that accumulates bytes for one formatted entry at
+// a time. The sloghuman sink internally calls Write once per entry with a
+// fully-formatted byte slice (terminated with '\n').
+type lineBuffer struct {
+	buf bytes.Buffer
+}
+
+func (b *lineBuffer) Write(p []byte) (int, error) {
+	return b.buf.Write(p)
+}
+
+// take returns the accumulated formatted entry with a single trailing newline
+// trimmed (matching slogtest's tb.Log behaviour, which adds its own newline).
+func (b *lineBuffer) take() string {
+	s := b.buf.String()
+	b.buf.Reset()
+	return strings.TrimRight(s, "\n")
+}
+
+func (s *testSink) LogEntry(ctx context.Context, ent slog.SinkEntry) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.testDone {
+		return
+	}
+
+	formatted := s.format(ctx, ent)
+
+	switch ent.Level {
+	case slog.LevelDebug, slog.LevelInfo, slog.LevelWarn:
+		s.tb.Log(formatted)
+	case slog.LevelError, slog.LevelCritical:
+		if IgnoreLoggedError(ent) {
+			s.tb.Log(formatted)
+		} else {
+			s.tb.Errorf("%s\n *** slogtest: log detected at level %s; TEST FAILURE ***",
+				formatted, ent.Level)
+		}
+	case slog.LevelFatal:
+		s.tb.Fatal(fmt.Sprintf("%s\n *** slogtest: FATAL log detected; TEST FAILURE ***", formatted))
+	}
+}
+
+func (s *testSink) format(ctx context.Context, ent slog.SinkEntry) string {
+	s.fmtMu.Lock()
+	defer s.fmtMu.Unlock()
+	s.fmtSink.LogEntry(ctx, ent)
+	return s.fmtBuf.take()
+}
+
+func (s *testSink) Sync() {}
+
+// IgnoreLoggedError returns true if the entry's first error field should not
+// fail the test. This preserves the previous behaviour of testutil.Logger:
+// yamux session shutdown and query-canceled errors are common during test
+// teardown and not actionable.
+func IgnoreLoggedError(ent slog.SinkEntry) bool {
+	err, ok := findFirstError(ent)
 	if !ok {
 		return false
 	}
@@ -33,17 +279,30 @@ func IgnoreLoggedError(entry slog.SinkEntry) bool {
 		return true
 	}
 	// Canceled queries usually happen when we're shutting down tests, and so
-	// ignoring them should reduce flakiness.  This also includes
-	// context.Canceled and context.DeadlineExceeded errors, even if they are
-	// not part of a query.
+	// ignoring them should reduce flakiness. This also includes context.Canceled
+	// and context.DeadlineExceeded errors, even if they are not part of a query.
 	return isQueryCanceledError(err)
 }
 
-// isQueryCanceledError checks if the error is due to a query being canceled. This reproduces
-// database.IsQueryCanceledError, but is reimplemented here to avoid importing the database package,
-// which would result in import loops. We also use string matching on the error PostgreSQL returns
-// to us, rather than the pq error type, because we don't want testutil, which is imported in lots
-// of places to import lib/pq, which we have our own fork of.
+// findFirstError finds the first slog.Field named "error" that contains an
+// error value.
+func findFirstError(ent slog.SinkEntry) (error, bool) {
+	for _, f := range ent.Fields {
+		if f.Name == "error" {
+			if err, ok := f.Value.(error); ok {
+				return err, true
+			}
+		}
+	}
+	return nil, false
+}
+
+// isQueryCanceledError checks if the error is due to a query being canceled.
+// This reproduces database.IsQueryCanceledError, but is reimplemented here to
+// avoid importing the database package, which would result in import loops. We
+// also use string matching on the error PostgreSQL returns to us, rather than
+// the pq error type, because we don't want testutil, which is imported in lots
+// of places, to import lib/pq, which we have our own fork of.
 func isQueryCanceledError(err error) bool {
 	if xerrors.Is(err, context.Canceled) || xerrors.Is(err, context.DeadlineExceeded) {
 		return true

--- a/testutil/logger_bench_internal_test.go
+++ b/testutil/logger_bench_internal_test.go
@@ -1,0 +1,32 @@
+package testutil
+
+import (
+	"testing"
+
+	"cdr.dev/slog/v3"
+)
+
+// BenchmarkDefaultDropDebug exercises the default deny-list with a mix of
+// matching and non-matching entries. Used to guard against regressions that
+// would make the predicate noticeably slow in the hot test-log path.
+func BenchmarkDefaultDropDebug(b *testing.B) {
+	entries := []slog.SinkEntry{
+		{LoggerNames: []string{"coderd", "servertailnet", "net", "wgengine"}, Message: "magicsock: warning"},
+		{LoggerNames: []string{"pubsub"}, Message: "publish"},
+		{LoggerNames: []string{"pubsub"}, Message: "subscribe"},
+		{LoggerNames: []string{"coderd"}, Message: "GET"},
+		{LoggerNames: []string{"coderd", "echo"}, Message: "read archive entry"},
+		{LoggerNames: []string{"coderd", "echo"}, Message: "unpacking source archive"},
+		{LoggerNames: []string{"coderd", "keyrotator"}, Message: "inserted new key for feature"},
+		{LoggerNames: []string{"coderd", "dbrollup"}, Message: "rolling up data"},
+		{LoggerNames: []string{"coderd", "acquirer"}, Message: "acquiring job"},
+		{LoggerNames: []string{"my", "pkg"}, Message: "something"},
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	var drop bool
+	for i := 0; i < b.N; i++ {
+		drop = defaultDropDebug(entries[i%len(entries)])
+	}
+	_ = drop
+}

--- a/testutil/logger_test.go
+++ b/testutil/logger_test.go
@@ -1,0 +1,489 @@
+package testutil_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/hashicorp/yamux"
+	"golang.org/x/xerrors"
+
+	"cdr.dev/slog/v3"
+
+	"github.com/coder/coder/v2/testutil"
+)
+
+// recorderTB is a minimal testing.TB implementation used to capture calls made
+// by the testutil.Logger sink. It is intentionally not goroutine-safe except
+// where the sink itself synchronises, which matches how testing.TB is used in
+// practice.
+type recorderTB struct {
+	testing.TB
+
+	mu       sync.Mutex
+	logs     []string
+	errors   []string
+	fatals   []string
+	failed   bool
+	cleanups []func()
+	name     string
+}
+
+func newRecorderTB(name string) *recorderTB {
+	return &recorderTB{name: name}
+}
+
+func (r *recorderTB) Cleanup(f func()) {
+	r.mu.Lock()
+	r.cleanups = append(r.cleanups, f)
+	r.mu.Unlock()
+}
+
+func (r *recorderTB) runCleanups() {
+	r.mu.Lock()
+	cs := r.cleanups
+	r.cleanups = nil
+	r.mu.Unlock()
+	// LIFO, matching testing.T.
+	for i := len(cs) - 1; i >= 0; i-- {
+		cs[i]()
+	}
+}
+
+func (r *recorderTB) Error(args ...any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.errors = append(r.errors, fmt.Sprint(args...))
+	r.failed = true
+}
+
+func (r *recorderTB) Errorf(format string, args ...any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.errors = append(r.errors, fmt.Sprintf(format, args...))
+	r.failed = true
+}
+
+func (r *recorderTB) Fatal(args ...any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.fatals = append(r.fatals, fmt.Sprint(args...))
+	r.failed = true
+}
+
+func (r *recorderTB) Fatalf(format string, args ...any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.fatals = append(r.fatals, fmt.Sprintf(format, args...))
+	r.failed = true
+}
+
+func (r *recorderTB) Log(args ...any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.logs = append(r.logs, fmt.Sprint(args...))
+}
+
+func (r *recorderTB) Logf(format string, args ...any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.logs = append(r.logs, fmt.Sprintf(format, args...))
+}
+
+func (r *recorderTB) Helper()      {}
+func (r *recorderTB) Name() string { return r.name }
+
+func (r *recorderTB) Failed() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.failed
+}
+
+func (r *recorderTB) logCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.logs)
+}
+
+func (r *recorderTB) errorCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.errors)
+}
+
+// logsContain returns true if any captured log entry contains substr.
+func (r *recorderTB) logsContain(substr string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, l := range r.logs {
+		if strings.Contains(l, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// emitDebug logs a single debug entry under the given dotted logger name with
+// the given message and returns the recorder.
+func emitDebug(t *testing.T, loggerName, msg string, opts ...testutil.LoggerOption) *recorderTB {
+	t.Helper()
+	rec := newRecorderTB(t.Name())
+	log := testutil.Logger(rec, opts...)
+	log = withNamed(log, loggerName)
+	log.Debug(context.Background(), msg)
+	rec.runCleanups()
+	return rec
+}
+
+func emitAt(t *testing.T, level slog.Level, loggerName, msg string, opts ...testutil.LoggerOption) *recorderTB {
+	t.Helper()
+	rec := newRecorderTB(t.Name())
+	log := testutil.Logger(rec, opts...)
+	log = withNamed(log, loggerName)
+	switch level {
+	case slog.LevelDebug:
+		log.Debug(context.Background(), msg)
+	case slog.LevelInfo:
+		log.Info(context.Background(), msg)
+	case slog.LevelWarn:
+		log.Warn(context.Background(), msg)
+	case slog.LevelError:
+		log.Error(context.Background(), msg)
+	default:
+		t.Fatalf("unsupported level %v", level)
+	}
+	rec.runCleanups()
+	return rec
+}
+
+// withNamed applies a dotted logger name as a series of .Named() calls.
+func withNamed(log slog.Logger, dotted string) slog.Logger {
+	if dotted == "" {
+		return log
+	}
+	for _, part := range strings.Split(dotted, ".") {
+		log = log.Named(part)
+	}
+	return log
+}
+
+// --- Red phase tests ---
+
+func TestLogger_DropsTailnetDebug(t *testing.T) {
+	t.Parallel()
+	rec := emitDebug(t, "coderd.servertailnet.net.wgengine", "wgengine: Reconfig: configuring router")
+	if got := rec.logCount(); got != 0 {
+		t.Fatalf("expected 0 log lines, got %d: %v", got, rec.logs)
+	}
+}
+
+func TestLogger_DropsPubsubPublishDebug(t *testing.T) {
+	t.Parallel()
+	rec := emitDebug(t, "pubsub", "publish")
+	if got := rec.logCount(); got != 0 {
+		t.Fatalf("expected pubsub publish debug to be dropped, got %d log lines", got)
+	}
+}
+
+func TestLogger_KeepsPubsubInfo(t *testing.T) {
+	t.Parallel()
+	rec := emitAt(t, slog.LevelInfo, "pubsub", "publish")
+	if got := rec.logCount(); got != 1 {
+		t.Fatalf("expected pubsub publish info to be kept, got %d log lines", got)
+	}
+}
+
+func TestLogger_KeepsHTTPAccessLogsDebug(t *testing.T) {
+	t.Parallel()
+	for _, method := range []string{"GET", "POST", "PATCH", "DELETE", "PUT", "HEAD"} {
+		rec := emitDebug(t, "coderd", method)
+		if got := rec.logCount(); got != 1 {
+			t.Fatalf("expected coderd %s debug to be kept, got %d log lines", method, got)
+		}
+	}
+}
+
+func TestLogger_KeepsAcquirerDebug(t *testing.T) {
+	t.Parallel()
+	rec := emitDebug(t, "coderd.acquirer", "acquiring job")
+	if got := rec.logCount(); got != 1 {
+		t.Fatalf("expected coderd.acquirer debug to be kept, got %d log lines", got)
+	}
+}
+
+func TestLogger_DropsEchoArchiveEntries(t *testing.T) {
+	t.Parallel()
+	for _, msg := range []string{"read archive entry", "extracted file"} {
+		rec := emitDebug(t, "coderd.echo", msg)
+		if got := rec.logCount(); got != 0 {
+			t.Fatalf("expected coderd.echo %q to be dropped, got %d log lines", msg, got)
+		}
+	}
+	// Other echo debug messages should pass.
+	rec := emitDebug(t, "coderd.echo", "unpacking source archive")
+	if got := rec.logCount(); got != 1 {
+		t.Fatalf("expected coderd.echo other-message to be kept, got %d log lines", got)
+	}
+}
+
+func TestLogger_DropsPeriodicLoopDebug(t *testing.T) {
+	t.Parallel()
+	periodicLoggers := []string{
+		"coderd.dbrollup",
+		"coderd.metrics_cache",
+		"coderd.metadata_batcher",
+		"coderd.workspace_usage_tracker",
+		"coderd.workspaceapps.stats_collector",
+		"coderd.cli-telemetry",
+	}
+	for _, lg := range periodicLoggers {
+		rec := emitDebug(t, lg, "some periodic message")
+		if got := rec.logCount(); got != 0 {
+			t.Fatalf("expected periodic logger %q debug to be dropped, got %d log lines", lg, got)
+		}
+	}
+}
+
+func TestLogger_DropsKeyRotatorDebug(t *testing.T) {
+	t.Parallel()
+	rec := emitDebug(t, "coderd.keyrotator", "inserted new key for feature")
+	if got := rec.logCount(); got != 0 {
+		t.Fatalf("expected keyrotator debug to be dropped, got %d log lines", got)
+	}
+}
+
+func TestLogger_DropsKeyCacheDebug(t *testing.T) {
+	t.Parallel()
+	caches := []string{
+		"coderd.app_signing_keycache.workspace_apps_token_signing_keycache",
+		"coderd.workspace_apps_api_key_encryption_keycache",
+		"coderd.oidc_convert_keycache.oidc_convert_signing_keycache",
+	}
+	for _, lg := range caches {
+		rec := emitDebug(t, lg, "fetching crypto keys")
+		if got := rec.logCount(); got != 0 {
+			t.Fatalf("expected keycache logger %q debug to be dropped, got %d log lines", lg, got)
+		}
+	}
+}
+
+func TestLogger_KeepsAllWarn(t *testing.T) {
+	t.Parallel()
+	deniedLoggers := []string{
+		"coderd.servertailnet.net.wgengine",
+		"pubsub",
+		"coderd.echo",
+		"coderd.dbrollup",
+		"coderd.keyrotator",
+		"coderd.coord",
+	}
+	for _, lg := range deniedLoggers {
+		rec := emitAt(t, slog.LevelWarn, lg, "something looks wrong")
+		if got := rec.logCount(); got != 1 {
+			t.Fatalf("expected warn on %q to be kept, got %d log lines", lg, got)
+		}
+	}
+}
+
+func TestLogger_KeepsAllInfo(t *testing.T) {
+	t.Parallel()
+	deniedLoggers := []string{
+		"coderd.servertailnet.net.wgengine",
+		"pubsub",
+		"coderd.echo",
+		"coderd.dbrollup",
+		"coderd.keyrotator",
+		"coderd.coord",
+	}
+	for _, lg := range deniedLoggers {
+		rec := emitAt(t, slog.LevelInfo, lg, "an informative message")
+		if got := rec.logCount(); got != 1 {
+			t.Fatalf("expected info on %q to be kept, got %d log lines", lg, got)
+		}
+	}
+}
+
+func TestLogger_KeepsErrorAndFailsTest(t *testing.T) {
+	t.Parallel()
+	// An error on a deny-listed logger must still call tb.Errorf and mark the
+	// test as failed. This is the critical regression test: filtering must not
+	// swallow real test signals.
+	rec := newRecorderTB(t.Name())
+	log := testutil.Logger(rec)
+	log = withNamed(log, "coderd.servertailnet.net.wgengine")
+	log.Error(context.Background(), "something is very wrong")
+	rec.runCleanups()
+	if rec.errorCount() == 0 {
+		t.Fatalf("expected tb.Errorf to be called, got 0 errors")
+	}
+	if !rec.Failed() {
+		t.Fatalf("expected recorder.Failed() to be true")
+	}
+}
+
+func TestLogger_WithNoFilter_KeepsEverything(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		logger string
+		msg    string
+	}{
+		{"coderd.servertailnet.net.wgengine", "wgengine: Reconfig: configuring router"},
+		{"pubsub", "publish"},
+		{"coderd.echo", "read archive entry"},
+		{"coderd.dbrollup", "rolling up data"},
+		{"coderd.keyrotator", "inserted new key for feature"},
+		{"coderd.coord", "peerReadLoop got request"},
+	}
+	for _, c := range cases {
+		rec := emitDebug(t, c.logger, c.msg, testutil.WithNoFilter())
+		if got := rec.logCount(); got != 1 {
+			t.Fatalf("with WithNoFilter, expected %q/%q debug to be kept, got %d log lines",
+				c.logger, c.msg, got)
+		}
+	}
+}
+
+func TestLogger_RespectsIgnoreErrorFn(t *testing.T) {
+	t.Parallel()
+	// Errors matching testutil.IgnoreLoggedError should be downgraded to tb.Log
+	// instead of failing the test. Reuses the existing semantics.
+	cases := []error{
+		context.Canceled,
+		context.DeadlineExceeded,
+		yamux.ErrSessionShutdown,
+		xerrors.New("canceling statement due to user request"),
+	}
+	for _, ignored := range cases {
+		rec := newRecorderTB(t.Name())
+		log := testutil.Logger(rec).Named("coderd")
+		log.Error(context.Background(), "transient error, retrying", slog.Error(ignored))
+		rec.runCleanups()
+		if rec.errorCount() != 0 {
+			t.Fatalf("expected error %v to be downgraded to log, got %d errors", ignored, rec.errorCount())
+		}
+		if rec.logCount() != 1 {
+			t.Fatalf("expected error %v to appear in tb.Log, got %d log lines", ignored, rec.logCount())
+		}
+		if rec.Failed() {
+			t.Fatalf("expected recorder.Failed() to be false for ignored error %v", ignored)
+		}
+	}
+}
+
+func TestLogger_NoOptions_BehavesLikeBefore(t *testing.T) {
+	t.Parallel()
+	// Smoke test: Logger(t) returns a working logger with the default deny-list applied.
+	rec := newRecorderTB(t.Name())
+	log := testutil.Logger(rec)
+	log.Named("pubsub").Debug(context.Background(), "publish")
+	log.Named("coderd").Info(context.Background(), "starting up")
+	rec.runCleanups()
+	// pubsub.publish dropped, coderd.starting up kept.
+	if rec.logCount() != 1 {
+		t.Fatalf("expected exactly 1 log line, got %d: %v", rec.logCount(), rec.logs)
+	}
+	if !rec.logsContain("starting up") {
+		t.Fatalf("expected 'starting up' in logs, got %v", rec.logs)
+	}
+}
+
+func TestLogger_WithFilter_DropsCustomPattern(t *testing.T) {
+	t.Parallel()
+	custom := func(ent slog.SinkEntry) bool {
+		return strings.Join(ent.LoggerNames, ".") == "my.pkg"
+	}
+	// Matching debug entry is dropped.
+	rec := emitDebug(t, "my.pkg", "noisy detail", testutil.WithFilter(custom))
+	if got := rec.logCount(); got != 0 {
+		t.Fatalf("expected custom filter to drop my.pkg debug, got %d log lines", got)
+	}
+	// Non-matching, non-deny-listed debug entry passes.
+	rec = emitDebug(t, "my.otherpkg", "interesting detail", testutil.WithFilter(custom))
+	if got := rec.logCount(); got != 1 {
+		t.Fatalf("expected custom filter to keep non-matching debug, got %d log lines", got)
+	}
+	// Deny-listed debug entry remains dropped even when custom filter doesn't match.
+	rec = emitDebug(t, "pubsub", "publish", testutil.WithFilter(custom))
+	if got := rec.logCount(); got != 0 {
+		t.Fatalf("expected default deny-list still active, got %d log lines", got)
+	}
+}
+
+func TestLogger_WithFilter_DoesNotAffectNonDebug(t *testing.T) {
+	t.Parallel()
+	// A custom filter that returns true for everything must still allow non-debug entries through.
+	always := func(slog.SinkEntry) bool { return true }
+	for _, lvl := range []slog.Level{slog.LevelInfo, slog.LevelWarn} {
+		rec := emitAt(t, lvl, "my.pkg", "important", testutil.WithFilter(always))
+		if got := rec.logCount(); got != 1 {
+			t.Fatalf("expected %v level to bypass custom filter, got %d log lines", lvl, got)
+		}
+	}
+}
+
+func TestLogger_WithFilter_ComposesWithDefaults(t *testing.T) {
+	t.Parallel()
+	custom := func(ent slog.SinkEntry) bool {
+		return strings.Join(ent.LoggerNames, ".") == "my.pkg"
+	}
+	// Matched by defaults only.
+	rec := emitDebug(t, "pubsub", "publish", testutil.WithFilter(custom))
+	if rec.logCount() != 0 {
+		t.Fatalf("expected default match to drop, got %d log lines", rec.logCount())
+	}
+	// Matched by custom only.
+	rec = emitDebug(t, "my.pkg", "anything", testutil.WithFilter(custom))
+	if rec.logCount() != 0 {
+		t.Fatalf("expected custom match to drop, got %d log lines", rec.logCount())
+	}
+	// Matched by neither.
+	rec = emitDebug(t, "other.pkg", "anything", testutil.WithFilter(custom))
+	if rec.logCount() != 1 {
+		t.Fatalf("expected unmatched debug to pass, got %d log lines", rec.logCount())
+	}
+}
+
+func TestLogger_WithFilter_MultipleCompose(t *testing.T) {
+	t.Parallel()
+	f1 := func(ent slog.SinkEntry) bool {
+		return strings.Join(ent.LoggerNames, ".") == "alpha"
+	}
+	f2 := func(ent slog.SinkEntry) bool {
+		return strings.Join(ent.LoggerNames, ".") == "beta"
+	}
+	// f1 matches.
+	rec := emitDebug(t, "alpha", "msg", testutil.WithFilter(f1), testutil.WithFilter(f2))
+	if rec.logCount() != 0 {
+		t.Fatalf("expected f1 to drop alpha, got %d log lines", rec.logCount())
+	}
+	// f2 matches.
+	rec = emitDebug(t, "beta", "msg", testutil.WithFilter(f1), testutil.WithFilter(f2))
+	if rec.logCount() != 0 {
+		t.Fatalf("expected f2 to drop beta, got %d log lines", rec.logCount())
+	}
+	// Neither matches.
+	rec = emitDebug(t, "gamma", "msg", testutil.WithFilter(f1), testutil.WithFilter(f2))
+	if rec.logCount() != 1 {
+		t.Fatalf("expected gamma to pass, got %d log lines", rec.logCount())
+	}
+}
+
+func TestLogger_WithNoFilter_WithFilter_KeepsCustomOnly(t *testing.T) {
+	t.Parallel()
+	custom := func(ent slog.SinkEntry) bool {
+		return strings.Join(ent.LoggerNames, ".") == "my.pkg"
+	}
+	// Defaults are off, custom is on.
+	// Deny-listed pubsub.publish should now pass.
+	rec := emitDebug(t, "pubsub", "publish", testutil.WithNoFilter(), testutil.WithFilter(custom))
+	if rec.logCount() != 1 {
+		t.Fatalf("expected pubsub.publish to pass with WithNoFilter, got %d log lines", rec.logCount())
+	}
+	// Custom-matched entry should still drop.
+	rec = emitDebug(t, "my.pkg", "anything", testutil.WithNoFilter(), testutil.WithFilter(custom))
+	if rec.logCount() != 0 {
+		t.Fatalf("expected my.pkg debug to drop via custom filter, got %d log lines", rec.logCount())
+	}
+}

--- a/testutil/logger_test.go
+++ b/testutil/logger_test.go
@@ -486,3 +486,83 @@ func TestLogger_WithNoFilter_WithFilter_KeepsCustomOnly(t *testing.T) {
 		t.Fatalf("expected my.pkg debug to drop via custom filter, got %d log lines", rec.logCount())
 	}
 }
+
+func TestLogger_WithIgnoreErrors_DowngradesErrorToLog(t *testing.T) {
+	t.Parallel()
+	rec := newRecorderTB(t.Name())
+	log := testutil.Logger(rec, testutil.WithIgnoreErrors())
+	log.Named("coderd").Error(context.Background(), "boom", slog.Error(xerrors.New("kaboom")))
+	rec.runCleanups()
+	if rec.errorCount() != 0 {
+		t.Fatalf("expected WithIgnoreErrors to suppress tb.Errorf, got %d errors", rec.errorCount())
+	}
+	if rec.logCount() != 1 {
+		t.Fatalf("expected error to still appear via tb.Log, got %d log lines", rec.logCount())
+	}
+	if rec.Failed() {
+		t.Fatalf("expected recorder.Failed() to be false")
+	}
+}
+
+func TestLogger_WithIgnoredErrorIs_MatchedErrorDowngraded(t *testing.T) {
+	t.Parallel()
+	target := xerrors.New("expected during test teardown")
+	rec := newRecorderTB(t.Name())
+	log := testutil.Logger(rec, testutil.WithIgnoredErrorIs(target))
+	// Wrap so xerrors.Is finds it.
+	log.Named("coderd").Error(context.Background(), "shutting down",
+		slog.Error(xerrors.Errorf("wrapped: %w", target)))
+	rec.runCleanups()
+	if rec.errorCount() != 0 {
+		t.Fatalf("expected wrapped target error to be downgraded, got %d tb.Errorf calls", rec.errorCount())
+	}
+	if rec.logCount() != 1 {
+		t.Fatalf("expected error to still appear via tb.Log, got %d log lines", rec.logCount())
+	}
+}
+
+func TestLogger_WithIgnoredErrorIs_UnmatchedErrorFailsTest(t *testing.T) {
+	t.Parallel()
+	target := xerrors.New("expected")
+	other := xerrors.New("something else")
+	rec := newRecorderTB(t.Name())
+	log := testutil.Logger(rec, testutil.WithIgnoredErrorIs(target))
+	log.Named("coderd").Error(context.Background(), "real failure", slog.Error(other))
+	rec.runCleanups()
+	if rec.errorCount() != 1 {
+		t.Fatalf("expected non-matching error to fail test, got %d tb.Errorf calls", rec.errorCount())
+	}
+	if !rec.Failed() {
+		t.Fatalf("expected recorder.Failed() to be true")
+	}
+}
+
+func TestLogger_WithIgnoredErrorIs_AdditiveAcrossCalls(t *testing.T) {
+	t.Parallel()
+	a := xerrors.New("a")
+	b := xerrors.New("b")
+	for _, target := range []error{a, b} {
+		rec := newRecorderTB(t.Name())
+		log := testutil.Logger(rec, testutil.WithIgnoredErrorIs(a), testutil.WithIgnoredErrorIs(b))
+		log.Named("coderd").Error(context.Background(), "msg", slog.Error(target))
+		rec.runCleanups()
+		if rec.errorCount() != 0 {
+			t.Fatalf("expected %v to be downgraded, got %d tb.Errorf calls", target, rec.errorCount())
+		}
+	}
+}
+
+func TestLogger_WithIgnoredErrorIs_PreservesDefaultIgnoreList(t *testing.T) {
+	t.Parallel()
+	// Even when WithIgnoredErrorIs adds custom targets, the default ignore
+	// list (context.Canceled etc.) must still apply.
+	target := xerrors.New("custom")
+	rec := newRecorderTB(t.Name())
+	log := testutil.Logger(rec, testutil.WithIgnoredErrorIs(target))
+	log.Named("coderd").Error(context.Background(), "canceled",
+		slog.Error(context.Canceled))
+	rec.runCleanups()
+	if rec.errorCount() != 0 {
+		t.Fatalf("expected context.Canceled to remain ignored, got %d tb.Errorf calls", rec.errorCount())
+	}
+}

--- a/testutil/logger_test.go
+++ b/testutil/logger_test.go
@@ -11,7 +11,6 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
-
 	"github.com/coder/coder/v2/testutil"
 )
 

--- a/testutil/logger_test.go
+++ b/testutil/logger_test.go
@@ -566,3 +566,36 @@ func TestLogger_WithIgnoredErrorIs_PreservesDefaultIgnoreList(t *testing.T) {
 		t.Fatalf("expected context.Canceled to remain ignored, got %d tb.Errorf calls", rec.errorCount())
 	}
 }
+
+func TestLogger_WithIgnoreErrorFn_DowngradesMatchingErrors(t *testing.T) {
+	t.Parallel()
+	rec := newRecorderTB(t.Name())
+	predicate := func(ent slog.SinkEntry) bool {
+		return ent.Message == "noisy benign error"
+	}
+	log := testutil.Logger(rec, testutil.WithIgnoreErrorFn(predicate))
+	log.Named("coderd").Error(context.Background(), "noisy benign error",
+		slog.Error(xerrors.New("any")))
+	rec.runCleanups()
+	if rec.errorCount() != 0 {
+		t.Fatalf("expected predicate match to downgrade, got %d tb.Errorf calls", rec.errorCount())
+	}
+	if rec.logCount() != 1 {
+		t.Fatalf("expected error to appear via tb.Log, got %d log lines", rec.logCount())
+	}
+}
+
+func TestLogger_WithIgnoreErrorFn_UnmatchedFailsTest(t *testing.T) {
+	t.Parallel()
+	rec := newRecorderTB(t.Name())
+	predicate := func(ent slog.SinkEntry) bool {
+		return ent.Message == "specific msg"
+	}
+	log := testutil.Logger(rec, testutil.WithIgnoreErrorFn(predicate))
+	log.Named("coderd").Error(context.Background(), "other msg",
+		slog.Error(xerrors.New("any")))
+	rec.runCleanups()
+	if rec.errorCount() != 1 {
+		t.Fatalf("expected non-matching error to fail test, got %d tb.Errorf calls", rec.errorCount())
+	}
+}


### PR DESCRIPTION
Adds a default deny-list that drops known-noisy debug entries (tailnet,
wireguard, pubsub publish, provisioner echo per-file extraction, key
cache/rotator, periodic loops). Info/warn/error/fatal pass unchanged.

Opt out with testutil.Logger(t, testutil.WithNoFilter()). Add custom
patterns with testutil.WithFilter(fn). Both options compose.

HTTP access logs (coderd: GET/POST/...) are intentionally kept.

> 🤖 Created by Coder Agents