### PR TITLE
refactor: migrate slogtest.Make to testutil.Logger

### DIFF
--- a/agent/agent_internal_test.go
+++ b/agent/agent_internal_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/agent/agentcontextconfig"
 	"github.com/coder/coder/v2/agent/proto"
 	agentsdk "github.com/coder/coder/v2/codersdk/agentsdk"
@@ -31,7 +30,7 @@ func platformAbsPath(parts ...string) string {
 func TestReportConnectionEmpty(t *testing.T) {
 	t.Parallel()
 	connID := uuid.UUID{1}
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	ctx := testutil.Context(t, testutil.WaitShort)
 
 	uut := &agent{

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -43,7 +43,6 @@ import (
 	"tailscale.com/tailcfg"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/agent"
 	"github.com/coder/coder/v2/agent/agentcontainers"
 	"github.com/coder/coder/v2/agent/agentssh"
@@ -80,11 +79,9 @@ func TestAgent_ImmediateClose(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 	defer cancel()
 
-	logger := slogtest.Make(t, &slogtest.Options{
-		// Agent can drop errors when shutting down, and some, like the
-		// fasthttplistener connection closed error, are unexported.
-		IgnoreErrors: true,
-	}).Leveled(slog.LevelDebug)
+	// Agent can drop errors when shutting down, and some, like the
+	// fasthttplistener connection closed error, are unexported.
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	manifest := agentsdk.Manifest{
 		AgentID:       uuid.New(),
 		AgentName:     "test-agent",
@@ -3293,7 +3290,7 @@ func TestAgent_UpdatedDERP(t *testing.T) {
 func TestAgent_Speedtest(t *testing.T) {
 	t.Parallel()
 	t.Skip("This test is relatively flakey because of Tailscale's speedtest code...")
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 	defer cancel()
 	derpMap, _ := tailnettest.RunDERPAndSTUN(t)
@@ -3750,11 +3747,9 @@ func setupAgentWithSecrets(t testing.TB, metadata agentsdk.Manifest, secrets []a
 	afero.Fs,
 	agent.Agent,
 ) {
-	logger := slogtest.Make(t, &slogtest.Options{
-		// Agent can drop errors when shutting down, and some, like the
-		// fasthttplistener connection closed error, are unexported.
-		IgnoreErrors: true,
-	}).Leveled(slog.LevelDebug)
+	// Agent can drop errors when shutting down, and some, like the
+	// fasthttplistener connection closed error, are unexported.
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	if metadata.DERPMap == nil {
 		metadata.DERPMap, _ = tailnettest.RunDERPAndSTUN(t)
 	}

--- a/agent/agentcontainers/api_test.go
+++ b/agent/agentcontainers/api_test.go
@@ -29,7 +29,6 @@ import (
 
 	"cdr.dev/slog/v3"
 	"cdr.dev/slog/v3/sloggers/sloghuman"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/agent/agentcontainers"
 	"github.com/coder/coder/v2/agent/agentcontainers/acmock"
 	"github.com/coder/coder/v2/agent/agentcontainers/watcher"
@@ -522,7 +521,7 @@ func TestAPI(t *testing.T) {
 		var (
 			ctx        = testutil.Context(t, testutil.WaitShort)
 			logbuf     strings.Builder
-			logger     = slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug).AppendSinks(sloghuman.Sink(&logbuf))
+			logger     = testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug).AppendSinks(sloghuman.Sink(&logbuf))
 			mClock     = quartz.NewMock(t)
 			tickerTrap = mClock.Trap().TickerFunc("updaterLoop")
 			firstErr   = xerrors.New("first error")
@@ -715,7 +714,7 @@ func TestAPI(t *testing.T) {
 			updaterTickerTrap = mClock.Trap().TickerFunc("updaterLoop")
 			mCtrl             = gomock.NewController(t)
 			mLister           = acmock.NewMockContainerCLI(mCtrl)
-			logger            = slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+			logger            = testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		)
 
 		// Set up initial state for immediate send on connection
@@ -872,7 +871,7 @@ func TestAPI(t *testing.T) {
 					tickerTrap = mClock.Trap().TickerFunc("updaterLoop")
 					mCtrl      = gomock.NewController(t)
 					mLister    = acmock.NewMockContainerCLI(mCtrl)
-					logger     = slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+					logger     = testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 					r          = chi.NewRouter()
 				)
 
@@ -1081,7 +1080,7 @@ func TestAPI(t *testing.T) {
 
 				ctx := testutil.Context(t, testutil.WaitShort)
 
-				logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+				logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 				mClock := quartz.NewMock(t)
 				mClock.Set(time.Now()).MustWait(ctx)
 				tickerTrap := mClock.Trap().TickerFunc("updaterLoop")
@@ -1434,7 +1433,7 @@ func TestAPI(t *testing.T) {
 
 				var (
 					ctx          = testutil.Context(t, testutil.WaitShort)
-					logger       = slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+					logger       = testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 					mClock       = quartz.NewMock(t)
 					withSubAgent = tt.wantSubAgentDeleted
 				)
@@ -1847,7 +1846,7 @@ func TestAPI(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
 
-				logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+				logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 
 				mClock := quartz.NewMock(t)
 				mClock.Set(time.Now()).MustWait(testutil.Context(t, testutil.WaitShort))
@@ -1964,7 +1963,7 @@ func TestAPI(t *testing.T) {
 
 		ctx := testutil.Context(t, testutil.WaitShort)
 
-		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 		fLister := &fakeContainerCLI{
 			containers: codersdk.WorkspaceAgentListContainersResponse{
 				Containers: []codersdk.WorkspaceAgentContainer{container},
@@ -2072,7 +2071,7 @@ func TestAPI(t *testing.T) {
 		}
 		fDCCLI := &fakeDevcontainerCLI{}
 
-		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 		api := agentcontainers.NewAPI(
 			logger,
 			agentcontainers.WithDevcontainerCLI(fDCCLI),
@@ -2194,7 +2193,7 @@ func TestAPI(t *testing.T) {
 		tickerTrap := mClock.Trap().TickerFunc("updaterLoop")
 
 		api := agentcontainers.NewAPI(
-			slogtest.Make(t, nil).Leveled(slog.LevelDebug),
+			testutil.Logger(t).Leveled(slog.LevelDebug),
 			agentcontainers.WithContainerCLI(fLister),
 			agentcontainers.WithWatcher(fWatcher),
 			agentcontainers.WithClock(mClock),
@@ -2247,7 +2246,7 @@ func TestAPI(t *testing.T) {
 		var (
 			ctx                     = testutil.Context(t, testutil.WaitMedium)
 			errTestTermination      = xerrors.New("test termination")
-			logger                  = slogtest.Make(t, &slogtest.Options{IgnoredErrorIs: []error{errTestTermination}}).Leveled(slog.LevelDebug)
+			logger                  = testutil.Logger(t, testutil.WithIgnoredErrorIs(errTestTermination)).Leveled(slog.LevelDebug)
 			mClock                  = quartz.NewMock(t)
 			mCCLI                   = acmock.NewMockContainerCLI(gomock.NewController(t))
 			fakeSAC, cleanupSAC     = newFakeSubAgentClient(t, logger.Named("fakeSubAgentClient"))
@@ -2611,7 +2610,7 @@ func TestAPI(t *testing.T) {
 		}
 
 		var (
-			logger = slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+			logger = testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 			mCtrl  = gomock.NewController(t)
 
 			// Given: A terraform-defined devcontainer with a pre-assigned subagent ID.
@@ -2726,7 +2725,7 @@ func TestAPI(t *testing.T) {
 
 		var (
 			ctx    = testutil.Context(t, testutil.WaitMedium)
-			logger = slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+			logger = testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 			mCtrl  = gomock.NewController(t)
 
 			terraformAgentID = uuid.New()
@@ -2879,7 +2878,7 @@ func TestAPI(t *testing.T) {
 
 		var (
 			ctx    = testutil.Context(t, testutil.WaitMedium)
-			logger = slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+			logger = testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 			mCtrl  = gomock.NewController(t)
 
 			terraformAgentID = uuid.New()
@@ -2994,7 +2993,7 @@ func TestAPI(t *testing.T) {
 
 			var (
 				ctx    = testutil.Context(t, testutil.WaitMedium)
-				logger = slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+				logger = testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 				mClock = quartz.NewMock(t)
 				fCCLI  = &fakeContainerCLI{arch: "<none>"}
 				fDCCLI = &fakeDevcontainerCLI{
@@ -3119,7 +3118,7 @@ func TestAPI(t *testing.T) {
 
 			var (
 				ctx    = testutil.Context(t, testutil.WaitMedium)
-				logger = slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+				logger = testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 				mClock = quartz.NewMock(t)
 
 				testContainer = codersdk.WorkspaceAgentContainer{
@@ -3230,7 +3229,7 @@ func TestAPI(t *testing.T) {
 
 			var (
 				ctx    = testutil.Context(t, testutil.WaitMedium)
-				logger = slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+				logger = testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 				mClock = quartz.NewMock(t)
 				mCCLI  = acmock.NewMockContainerCLI(gomock.NewController(t))
 				fDCCLI = &fakeDevcontainerCLI{}
@@ -3892,7 +3891,7 @@ func TestAPI(t *testing.T) {
 		t.Parallel()
 
 		ctx := testutil.Context(t, testutil.WaitShort)
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 
 		// Create fake execer to track execution details.
 		fakeExec := &fakeExecer{}
@@ -3984,14 +3983,14 @@ func TestAPI(t *testing.T) {
 			},
 		}
 
-		fakeSAC, cleanupSAC := newFakeSubAgentClient(t, slogtest.Make(t, nil).Named("fakeSubAgentClient"))
+		fakeSAC, cleanupSAC := newFakeSubAgentClient(t, testutil.Logger(t).Named("fakeSubAgentClient"))
 		defer cleanupSAC()
 
 		mClock := quartz.NewMock(t)
 		mClock.Set(startTime)
 		fWatcher := newFakeWatcher(t)
 
-		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 		api := agentcontainers.NewAPI(
 			logger,
 			agentcontainers.WithDevcontainerCLI(fDCCLI),

--- a/agent/agentcontainers/devcontainercli_test.go
+++ b/agent/agentcontainers/devcontainercli_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/agent/agentcontainers"
 	"github.com/coder/coder/v2/agent/agentexec"
 	"github.com/coder/coder/v2/codersdk"
@@ -36,7 +35,7 @@ func TestDevcontainerCLI_ArgsAndParsing(t *testing.T) {
 	testExePath, err := os.Executable()
 	require.NoError(t, err, "get test executable path")
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 
 	t.Run("Up", func(t *testing.T) {
 		t.Parallel()
@@ -383,7 +382,7 @@ func TestDevcontainerCLI_WithOutput(t *testing.T) {
 			wantError:   false,
 			logFile:     filepath.Join("testdata", "devcontainercli", "parse", "up.log"),
 		}
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		dccli := agentcontainers.NewDevcontainerCLI(logger, testExecer)
 
 		// Call Up with WithUpOutput to capture CLI logs.
@@ -424,7 +423,7 @@ func TestDevcontainerCLI_WithOutput(t *testing.T) {
 			wantError:   false,
 			logFile:     logFile,
 		}
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		dccli := agentcontainers.NewDevcontainerCLI(logger, testExecer)
 
 		// Call Exec with WithExecOutput and WithContainerID to capture any command output.
@@ -561,7 +560,7 @@ func TestDockerDevcontainerCLI(t *testing.T) {
 
 		// Use a long timeout because container operations are slow.
 		ctx := testutil.Context(t, testutil.WaitLong)
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 
 		// Create the devcontainer CLI under test.
 		dccli := agentcontainers.NewDevcontainerCLI(logger, agentexec.DefaultExecer)

--- a/agent/agentfiles/files_test.go
+++ b/agent/agentfiles/files_test.go
@@ -23,7 +23,6 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/agent/agentchat"
 	"github.com/coder/coder/v2/agent/agentfiles"
 	"github.com/coder/coder/v2/agent/agentgit"
@@ -115,7 +114,7 @@ func TestReadFile(t *testing.T) {
 	tmpdir := os.TempDir()
 	noPermsFilePath := filepath.Join(tmpdir, "no-perms")
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	fs := newTestFs(afero.NewMemMapFs(), func(call, file string) error {
 		if file == noPermsFilePath {
 			return os.ErrPermission
@@ -295,7 +294,7 @@ func TestWriteFile(t *testing.T) {
 	tmpdir := os.TempDir()
 	noPermsFilePath := filepath.Join(tmpdir, "no-perms-file")
 	noPermsDirPath := filepath.Join(tmpdir, "no-perms-dir")
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	fs := newTestFs(afero.NewMemMapFs(), func(call, file string) error {
 		if file == noPermsFilePath || file == noPermsDirPath {
 			return os.ErrPermission
@@ -404,7 +403,7 @@ func TestWriteFile(t *testing.T) {
 func TestWriteFile_ReportsIOError(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	fs := afero.NewMemMapFs()
 	api := agentfiles.NewAPI(logger, fs, nil)
 
@@ -445,7 +444,7 @@ func TestWriteFile_PreservesPermissions(t *testing.T) {
 	}
 
 	dir := t.TempDir()
-	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 	osFs := afero.NewOsFs()
 	api := agentfiles.NewAPI(logger, osFs, nil)
 
@@ -484,7 +483,7 @@ func TestEditFiles(t *testing.T) {
 	tmpdir := os.TempDir()
 	noPermsFilePath := filepath.Join(tmpdir, "no-perms-file")
 	failRenameFilePath := filepath.Join(tmpdir, "fail-rename")
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	fs := newTestFs(afero.NewMemMapFs(), func(call, file string) error {
 		if file == noPermsFilePath {
 			return &os.PathError{
@@ -1083,7 +1082,7 @@ func TestEditFiles_PreservesPermissions(t *testing.T) {
 	}
 
 	dir := t.TempDir()
-	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 	osFs := afero.NewOsFs()
 	api := agentfiles.NewAPI(logger, osFs, nil)
 
@@ -1140,7 +1139,7 @@ func TestHandleWriteFile_ChatHeaders_UpdatesPathStore(t *testing.T) {
 	t.Parallel()
 
 	pathStore := agentgit.NewPathStore()
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	fs := afero.NewMemMapFs()
 	api := agentfiles.NewAPI(logger, fs, pathStore)
 
@@ -1174,7 +1173,7 @@ func TestHandleWriteFile_NoChatHeaders_NoPathStoreUpdate(t *testing.T) {
 	t.Parallel()
 
 	pathStore := agentgit.NewPathStore()
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	fs := afero.NewMemMapFs()
 	api := agentfiles.NewAPI(logger, fs, pathStore)
 
@@ -1198,7 +1197,7 @@ func TestHandleWriteFile_Failure_NoPathStoreUpdate(t *testing.T) {
 	t.Parallel()
 
 	pathStore := agentgit.NewPathStore()
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	fs := afero.NewMemMapFs()
 	api := agentfiles.NewAPI(logger, fs, pathStore)
 
@@ -1225,7 +1224,7 @@ func TestHandleEditFiles_ChatHeaders_UpdatesPathStore(t *testing.T) {
 	t.Parallel()
 
 	pathStore := agentgit.NewPathStore()
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	fs := afero.NewMemMapFs()
 	api := agentfiles.NewAPI(logger, fs, pathStore)
 
@@ -1265,7 +1264,7 @@ func TestHandleEditFiles_Failure_NoPathStoreUpdate(t *testing.T) {
 	t.Parallel()
 
 	pathStore := agentgit.NewPathStore()
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	fs := afero.NewMemMapFs()
 	api := agentfiles.NewAPI(logger, fs, pathStore)
 
@@ -1305,7 +1304,7 @@ func TestReadFileLines(t *testing.T) {
 	tmpdir := os.TempDir()
 	noPermsFilePath := filepath.Join(tmpdir, "no-perms-lines")
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	fs := newTestFs(afero.NewMemMapFs(), func(call, file string) error {
 		if file == noPermsFilePath {
 			return os.ErrPermission
@@ -1492,7 +1491,7 @@ func TestWriteFile_FollowsSymlinks(t *testing.T) {
 	}
 
 	dir := t.TempDir()
-	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 	osFs := afero.NewOsFs()
 	api := agentfiles.NewAPI(logger, osFs, nil)
 
@@ -1535,7 +1534,7 @@ func TestEditFiles_FollowsSymlinks(t *testing.T) {
 	}
 
 	dir := t.TempDir()
-	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 	osFs := afero.NewOsFs()
 	api := agentfiles.NewAPI(logger, osFs, nil)
 
@@ -1590,7 +1589,7 @@ func TestEditFiles_FileResults(t *testing.T) {
 	t.Parallel()
 
 	tmpdir := os.TempDir()
-	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 
 	t.Run("DiffRequestedSingleFile", func(t *testing.T) {
 		t.Parallel()
@@ -1816,7 +1815,7 @@ func TestFuzzyReplace_EndingAndWhitespace(t *testing.T) {
 	t.Parallel()
 
 	tmpdir := os.TempDir()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 
 	type edit struct {
 		search, replace string
@@ -2085,7 +2084,7 @@ func TestFuzzyReplace_EndingNormalization(t *testing.T) {
 	t.Parallel()
 
 	tmpdir := os.TempDir()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 
 	type edit struct {
 		search, replace string
@@ -2230,7 +2229,7 @@ func TestFuzzyReplace_FuzzyCollapse_PreservesNextLine(t *testing.T) {
 	t.Parallel()
 
 	tmpdir := os.TempDir()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 
 	type edit struct {
 		search, replace string
@@ -2333,7 +2332,7 @@ func TestEditFiles_WhitespaceAndLineEndings(t *testing.T) {
 	t.Parallel()
 
 	tmpdir := os.TempDir()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 
 	cases := []struct {
 		name            string
@@ -2504,7 +2503,7 @@ func TestFuzzyReplace_Rejects(t *testing.T) {
 	t.Parallel()
 
 	tmpdir := os.TempDir()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 
 	type edit struct {
 		search, replace string
@@ -2630,7 +2629,7 @@ func TestEditFiles_DuplicatePath_Rejects(t *testing.T) {
 	t.Parallel()
 
 	tmpdir := os.TempDir()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	fs := afero.NewMemMapFs()
 	api := agentfiles.NewAPI(logger, fs, nil)
 	path := filepath.Join(tmpdir, "dup-path")
@@ -2676,7 +2675,7 @@ func TestEditFiles_DuplicatePath_SymlinkAliasRejects(t *testing.T) {
 		t.Skip("symlinks are not reliably supported on Windows")
 	}
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	dir := t.TempDir()
 	osFs := afero.NewOsFs()
 	api := agentfiles.NewAPI(logger, osFs, nil)
@@ -2733,7 +2732,7 @@ func TestEditFiles_ReplaceAll_FuzzyIndentGap(t *testing.T) {
 	t.Parallel()
 
 	tmpdir := os.TempDir()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	fs := afero.NewMemMapFs()
 	api := agentfiles.NewAPI(logger, fs, nil)
 	path := filepath.Join(tmpdir, "replaceall-fuzzyindent-gap")
@@ -2801,7 +2800,7 @@ func TestEditFiles_FuzzyIndent_InsertionLevelAware(t *testing.T) {
 	t.Parallel()
 
 	tmpdir := os.TempDir()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 
 	type edit struct {
 		search, replace string
@@ -3126,7 +3125,7 @@ func TestFuzzyReplace_Expansion_PreservesFileIndent(t *testing.T) {
 	t.Parallel()
 
 	tmpdir := os.TempDir()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	fs := afero.NewMemMapFs()
 	api := agentfiles.NewAPI(logger, fs, nil)
 	path := filepath.Join(tmpdir, "fuzzy-expansion-gap")
@@ -3200,7 +3199,7 @@ func TestFuzzyReplace_Hints(t *testing.T) {
 	t.Parallel()
 
 	tmpdir := os.TempDir()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 
 	type edit struct {
 		search, replace string

--- a/agent/agentfiles/resolvepath_test.go
+++ b/agent/agentfiles/resolvepath_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/agent/agentfiles"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
 	"github.com/coder/coder/v2/testutil"
@@ -29,7 +28,7 @@ func TestResolvePath_FollowsFileSymlink(t *testing.T) {
 	}
 
 	dir := t.TempDir()
-	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 	osFs := afero.NewOsFs()
 	api := agentfiles.NewAPI(logger, osFs, nil)
 
@@ -62,7 +61,7 @@ func TestResolvePath_FollowsSymlinkedParentForMissingFile(t *testing.T) {
 	}
 
 	dir := t.TempDir()
-	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 	osFs := afero.NewOsFs()
 	api := agentfiles.NewAPI(logger, osFs, nil)
 
@@ -98,7 +97,7 @@ func TestResolvePath_FollowsSymlinkedParentForExistingFile(t *testing.T) {
 	}
 
 	dir := t.TempDir()
-	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 	osFs := afero.NewOsFs()
 	api := agentfiles.NewAPI(logger, osFs, nil)
 

--- a/agent/agentgit/agentgit_test.go
+++ b/agent/agentgit/agentgit_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/agent/agentgit"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/wsjson"
@@ -69,7 +68,7 @@ func TestSubscribeBulkPathsAndDedupes(t *testing.T) {
 	t.Parallel()
 
 	repoDir := initTestRepo(t)
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 
 	h := agentgit.NewHandler(logger)
 
@@ -88,7 +87,7 @@ func TestSubscribeBulkPathsAndDedupes(t *testing.T) {
 func TestSubscribeNonGitPathsIgnored(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	h := agentgit.NewHandler(logger)
 
 	nonGitDir := t.TempDir()
@@ -99,7 +98,7 @@ func TestSubscribeNonGitPathsIgnored(t *testing.T) {
 func TestSubscribeRelativePathsIgnored(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	h := agentgit.NewHandler(logger)
 
 	added := h.Subscribe([]string{"relative/path.go"})
@@ -109,7 +108,7 @@ func TestSubscribeRelativePathsIgnored(t *testing.T) {
 func TestSubscribeEmptyPaths(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	h := agentgit.NewHandler(logger)
 
 	added := h.Subscribe([]string{})
@@ -127,7 +126,7 @@ func TestScanReturnsRepoChanges(t *testing.T) {
 	t.Parallel()
 
 	repoDir := initTestRepo(t)
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 
 	h := agentgit.NewHandler(logger)
 
@@ -155,7 +154,7 @@ func TestScanRespectsGitignore(t *testing.T) {
 	t.Parallel()
 
 	repoDir := initTestRepo(t)
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 
 	// Add a .gitignore that ignores *.log files and the build/ directory.
 	require.NoError(t, os.WriteFile(filepath.Join(repoDir, ".gitignore"), []byte("*.log\nbuild/\n"), 0o600))
@@ -193,7 +192,7 @@ func TestScanRespectsGitignoreNestedNegation(t *testing.T) {
 	t.Parallel()
 
 	repoDir := initTestRepo(t)
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 
 	// Add a .gitignore that ignores node_modules/.
 	require.NoError(t, os.WriteFile(filepath.Join(repoDir, ".gitignore"), []byte("node_modules/\n"), 0o600))
@@ -237,7 +236,7 @@ func TestScanDeltaEmission(t *testing.T) {
 	t.Parallel()
 
 	repoDir := initTestRepo(t)
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 
 	h := agentgit.NewHandler(logger)
 
@@ -282,7 +281,7 @@ func TestScanHeartbeatOnCleanRepo(t *testing.T) {
 	t.Parallel()
 
 	repoDir := initTestRepo(t)
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 
 	h := agentgit.NewHandler(logger)
 	require.True(t, h.Subscribe([]string{repoDir}))
@@ -319,7 +318,7 @@ func TestScanHeartbeatOnCleanRepo(t *testing.T) {
 func TestScanNoHeartbeatWithoutSubscribedRoots(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	h := agentgit.NewHandler(logger)
 
 	msg := h.Scan(context.Background())
@@ -330,7 +329,7 @@ func TestScanDeltaDetectsContentChanges(t *testing.T) {
 	t.Parallel()
 
 	repoDir := initTestRepo(t)
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 
 	h := agentgit.NewHandler(logger)
 
@@ -394,7 +393,7 @@ func TestScanRateLimiting(t *testing.T) {
 	t.Parallel()
 
 	repoDir := initTestRepo(t)
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 
 	h := agentgit.NewHandler(logger)
 
@@ -418,7 +417,7 @@ func TestSubscribeDeeplyNestedFile(t *testing.T) {
 	t.Parallel()
 
 	repoDir := initTestRepo(t)
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 
 	// Create a deeply nested directory structure inside the repo.
 	nestedDir := filepath.Join(repoDir, "a", "b", "c")
@@ -464,7 +463,7 @@ func TestSubscribeNestedGitRepos(t *testing.T) {
 	dirtyFile := filepath.Join(innerDir, "dirty.go")
 	require.NoError(t, os.WriteFile(dirtyFile, []byte("package inner\n"), 0o600))
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	h := agentgit.NewHandler(logger)
 
 	// Subscribe with the path inside the inner repo.
@@ -484,7 +483,7 @@ func TestScanDeletedRepoEmitsRemoved(t *testing.T) {
 	t.Parallel()
 
 	repoDir := initTestRepo(t)
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 
 	h := agentgit.NewHandler(logger)
 
@@ -527,7 +526,7 @@ func TestScanDeletedGitDirEmitsRemoved(t *testing.T) {
 	t.Parallel()
 
 	repoDir := initTestRepo(t)
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 
 	h := agentgit.NewHandler(logger)
 
@@ -567,7 +566,7 @@ func TestScanDeletedWorktreeGitdirEmitsRemoved(t *testing.T) {
 	gitCmd(t, mainRepoDir, "branch", "worktree-branch")
 	gitCmd(t, mainRepoDir, "worktree", "add", worktreeDir, "worktree-branch")
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	h := agentgit.NewHandler(logger)
 
 	// Create a dirty file so the initial scan has something to report.
@@ -610,7 +609,7 @@ func TestScanTransientErrorDoesNotRemoveRepo(t *testing.T) {
 	t.Parallel()
 
 	repoDir := initTestRepo(t)
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 
 	h := agentgit.NewHandler(logger)
 
@@ -670,7 +669,7 @@ func dialGitWatch(t *testing.T, opts ...agentgit.Option) *wsjson.Stream[
 	codersdk.WorkspaceAgentGitClientMessage,
 ] {
 	t.Helper()
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	api := agentgit.NewAPI(logger, nil, opts...)
 	srv := httptest.NewServer(api.Routes())
 	t.Cleanup(srv.Close)
@@ -700,7 +699,7 @@ func dialGitWatchWithPathStore(
 	codersdk.WorkspaceAgentGitClientMessage,
 ] {
 	t.Helper()
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	api := agentgit.NewAPI(logger, ps, opts...)
 	srv := httptest.NewServer(api.Routes())
 	t.Cleanup(srv.Close)
@@ -884,7 +883,7 @@ func TestGetRepoChangesStagedModifiedDeleted(t *testing.T) {
 	t.Parallel()
 
 	repoDir := initTestRepo(t)
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 
 	h := agentgit.NewHandler(logger)
 
@@ -966,7 +965,7 @@ func TestMultipleConcurrentConnections(t *testing.T) {
 	chatID := uuid.New()
 	ps.AddPaths([]uuid.UUID{chatID}, []string{filepath.Join(repoDir, "c.go")})
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	api := agentgit.NewAPI(logger, ps)
 	srv := httptest.NewServer(api.Routes())
 	t.Cleanup(srv.Close)
@@ -1008,7 +1007,7 @@ func TestScanLargeFileTooLargeToDiff(t *testing.T) {
 	t.Parallel()
 
 	repoDir := initTestRepo(t)
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 
 	h := agentgit.NewHandler(logger)
 
@@ -1042,7 +1041,7 @@ func TestScanLargeFileDeltaTracking(t *testing.T) {
 	t.Parallel()
 
 	repoDir := initTestRepo(t)
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 
 	h := agentgit.NewHandler(logger)
 
@@ -1079,7 +1078,7 @@ func TestScanTotalDiffTooLargeForWire(t *testing.T) {
 	t.Parallel()
 
 	repoDir := initTestRepo(t)
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 
 	h := agentgit.NewHandler(logger)
 
@@ -1123,7 +1122,7 @@ func TestScanBinaryFileDiff(t *testing.T) {
 	t.Parallel()
 
 	repoDir := initTestRepo(t)
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 
 	h := agentgit.NewHandler(logger)
 
@@ -1170,7 +1169,7 @@ func TestScanBinaryFileModifiedDiff(t *testing.T) {
 	// Modify the binary file in the worktree.
 	require.NoError(t, os.WriteFile(binPath, []byte("v2\x00\x03\x04\x05"), 0o600))
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	h := agentgit.NewHandler(logger)
 	h.Subscribe([]string{binPath})
 
@@ -1194,7 +1193,7 @@ func TestScanFileDiffTooLargeForWire(t *testing.T) {
 	t.Parallel()
 
 	repoDir := initTestRepo(t)
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 
 	h := agentgit.NewHandler(logger)
 
@@ -1491,7 +1490,7 @@ func TestE2E_RepoDeletionEmitsRemoved(t *testing.T) {
 func TestRunLoopExitsPromptlyOnCancel_DuringPoll(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	mClock := quartz.NewMock(t)
 	h := agentgit.NewHandler(logger, agentgit.WithClock(mClock))
 
@@ -1534,7 +1533,7 @@ func TestRunLoopExitsPromptlyOnCancel_DuringCooldown(t *testing.T) {
 	t.Parallel()
 
 	repoDir := initTestRepo(t)
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	mClock := quartz.NewMock(t)
 	h := agentgit.NewHandler(logger, agentgit.WithClock(mClock))
 

--- a/agent/agentproc/api_test.go
+++ b/agent/agentproc/api_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/agent/agentchat"
 	"github.com/coder/coder/v2/agent/agentexec"
 	"github.com/coder/coder/v2/agent/agentgit"
@@ -133,9 +132,7 @@ func newTestAPIWithUpdateEnv(t *testing.T, updateEnv func([]string) ([]string, e
 func newTestAPIWithOptions(t *testing.T, updateEnv func([]string) ([]string, error), workingDir func() string) http.Handler {
 	t.Helper()
 
-	logger := slogtest.Make(t, &slogtest.Options{
-		IgnoreErrors: true,
-	}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	api := agentproc.NewAPI(logger, agentexec.DefaultExecer, updateEnv, nil, workingDir)
 	t.Cleanup(func() {
 		_ = api.Close()
@@ -1083,7 +1080,7 @@ func TestHandleStartProcess_ChatHeaders_EmptyWorkDir_StillNotifies(t *testing.T)
 	ch, unsub := pathStore.Subscribe(chatID)
 	defer unsub()
 
-	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 	api := agentproc.NewAPI(logger, agentexec.DefaultExecer, func(current []string) ([]string, error) {
 		return current, nil
 	}, pathStore, nil)

--- a/agent/agentssh/agentssh_test.go
+++ b/agent/agentssh/agentssh_test.go
@@ -25,7 +25,6 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/agent/agentexec"
 	"github.com/coder/coder/v2/agent/agentssh"
 	"github.com/coder/coder/v2/pty/ptytest"
@@ -152,7 +151,7 @@ func TestNewServer_CloseActiveConnections(t *testing.T) {
 
 	prepare := func(ctx context.Context, t *testing.T) (*agentssh.Server, func()) {
 		t.Helper()
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		s, err := agentssh.NewServer(ctx, logger, prometheus.NewRegistry(), afero.NewMemMapFs(), agentexec.DefaultExecer, nil)
 		require.NoError(t, err)
 		t.Cleanup(func() {

--- a/agent/checkpoint_internal_test.go
+++ b/agent/checkpoint_internal_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/testutil"
 )
 
@@ -23,7 +22,7 @@ func TestCheckpoint_CompleteWait(t *testing.T) {
 
 func TestCheckpoint_CompleteTwice(t *testing.T) {
 	t.Parallel()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	ctx := testutil.Context(t, testutil.WaitShort)
 	uut := newCheckpoint(logger)
 	err := xerrors.New("test")

--- a/agent/filefinder/bench_test.go
+++ b/agent/filefinder/bench_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/agent/filefinder"
+	"github.com/coder/coder/v2/testutil"
 )
 
 var (
@@ -166,7 +166,7 @@ func BenchmarkSearch_ConcurrentReads(b *testing.B) {
 	dir := b.TempDir()
 	generateFileTree(b, dir, 10_000, 42)
 
-	logger := slogtest.Make(b, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelError)
+	logger := testutil.Logger(b, testutil.WithIgnoreErrors()).Leveled(slog.LevelError)
 	ctx := context.Background()
 	eng := filefinder.NewEngine(logger)
 	require.NoError(b, eng.AddRoot(ctx, dir))

--- a/agent/filefinder/engine_test.go
+++ b/agent/filefinder/engine_test.go
@@ -10,14 +10,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/agent/filefinder"
 	"github.com/coder/coder/v2/testutil"
 )
 
 func newTestEngine(t *testing.T) (*filefinder.Engine, context.Context) {
 	t.Helper()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	eng := filefinder.NewEngine(logger)
 	t.Cleanup(func() { _ = eng.Close() })
 	return eng, context.Background()
@@ -157,7 +156,7 @@ func TestEngine_CloseIsClean(t *testing.T) {
 	dir := t.TempDir()
 	createFile(t, dir, "file.txt", "data")
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	ctx := context.Background()
 	eng := filefinder.NewEngine(logger)
 	require.NoError(t, eng.AddRoot(ctx, dir))

--- a/agent/write_secret_files_test.go
+++ b/agent/write_secret_files_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/codersdk/agentsdk"
 	"github.com/coder/coder/v2/testutil"
 )
@@ -18,7 +17,7 @@ func TestWriteSecretFiles(t *testing.T) {
 		t.Parallel()
 		fs := afero.NewMemMapFs()
 		ctx := testutil.Context(t, testutil.WaitShort)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		writeSecretFiles(ctx, logger, fs, "/home/coder", []agentsdk.WorkspaceSecret{
 			{FilePath: "/etc/myapp/config.json", Value: []byte(`{"key":"val"}`)},
@@ -41,7 +40,7 @@ func TestWriteSecretFiles(t *testing.T) {
 		t.Parallel()
 		fs := afero.NewMemMapFs()
 		ctx := testutil.Context(t, testutil.WaitShort)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		writeSecretFiles(ctx, logger, fs, "/home/coder", []agentsdk.WorkspaceSecret{
 			{FilePath: "~/.ssh/id_rsa", Value: []byte("private-key")},
@@ -64,7 +63,7 @@ func TestWriteSecretFiles(t *testing.T) {
 		t.Parallel()
 		fs := afero.NewMemMapFs()
 		ctx := testutil.Context(t, testutil.WaitShort)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		writeSecretFiles(ctx, logger, fs, "", []agentsdk.WorkspaceSecret{
 			{FilePath: "~/.config/token", Value: []byte("token")},
@@ -79,7 +78,7 @@ func TestWriteSecretFiles(t *testing.T) {
 		t.Parallel()
 		fs := afero.NewMemMapFs()
 		ctx := testutil.Context(t, testutil.WaitShort)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		writeSecretFiles(ctx, logger, fs, "/home/coder", []agentsdk.WorkspaceSecret{
 			{EnvName: "MY_TOKEN", Value: []byte("token")},
@@ -95,7 +94,7 @@ func TestWriteSecretFiles(t *testing.T) {
 		t.Parallel()
 		fs := afero.NewMemMapFs()
 		ctx := testutil.Context(t, testutil.WaitShort)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		writeSecretFiles(ctx, logger, fs, "/home/coder", []agentsdk.WorkspaceSecret{
 			{FilePath: "/etc/secret-a", Value: []byte("aaa")},
@@ -116,7 +115,7 @@ func TestWriteSecretFiles(t *testing.T) {
 		t.Parallel()
 		fs := afero.NewMemMapFs()
 		ctx := testutil.Context(t, testutil.WaitShort)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		require.NoError(t, afero.WriteFile(fs, "/secret", []byte("old"), 0o644))
 
@@ -140,7 +139,7 @@ func TestWriteSecretFiles(t *testing.T) {
 		t.Parallel()
 		fs := afero.NewMemMapFs()
 		ctx := testutil.Context(t, testutil.WaitShort)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		// "~/collide" and "/home/coder/collide" resolve to the same
 		// absolute path. The later secret should win.
@@ -158,7 +157,7 @@ func TestWriteSecretFiles(t *testing.T) {
 		t.Parallel()
 		fs := afero.NewMemMapFs()
 		ctx := testutil.Context(t, testutil.WaitShort)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		writeSecretFiles(ctx, logger, fs, "/home/coder", nil)
 
@@ -171,7 +170,7 @@ func TestWriteSecretFiles(t *testing.T) {
 		t.Parallel()
 		fs := afero.NewMemMapFs()
 		ctx := testutil.Context(t, testutil.WaitShort)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		binaryData := []byte{0x00, 0x01, 0x02, 0xFF, 0xFE, 0xFD}
 		writeSecretFiles(ctx, logger, fs, "", []agentsdk.WorkspaceSecret{

--- a/agent/x/agentdesktop/api_test.go
+++ b/agent/x/agentdesktop/api_test.go
@@ -24,10 +24,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/agent/x/agentdesktop"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
+	"github.com/coder/coder/v2/testutil"
 	"github.com/coder/quartz"
 )
 
@@ -279,7 +279,7 @@ func (f *oversizedFakeDesktop) StopRecording(ctx context.Context, recordingID st
 func TestHandleDesktopVNC_StartError(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	fake := &fakeDesktop{startErr: xerrors.New("no desktop")}
 	api := agentdesktop.NewAPI(logger, fake, nil)
 	defer api.Close()
@@ -301,7 +301,7 @@ func TestHandleDesktopVNC_StartError(t *testing.T) {
 func TestHandleAction_CallsRecordActivity(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	fake := &fakeDesktop{
 		startCfg: agentdesktop.DisplayConfig{Width: 1920, Height: 1080},
 	}
@@ -332,7 +332,7 @@ func TestHandleAction_CallsRecordActivity(t *testing.T) {
 func TestHandleAction_Screenshot(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	geometry := workspacesdk.DefaultDesktopGeometry()
 	fake := &fakeDesktop{
 		startCfg: agentdesktop.DisplayConfig{
@@ -373,7 +373,7 @@ func TestHandleAction_Screenshot(t *testing.T) {
 func TestHandleAction_ScreenshotUsesDeclaredDimensionsFromRequest(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	fake := &fakeDesktop{
 		startCfg:      agentdesktop.DisplayConfig{Width: 1920, Height: 1080},
 		screenshotRes: agentdesktop.ScreenshotResult{Data: "base64data"},
@@ -411,7 +411,7 @@ func TestHandleAction_ScreenshotUsesDeclaredDimensionsFromRequest(t *testing.T) 
 func TestHandleAction_LeftClick(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	fake := &fakeDesktop{
 		startCfg: agentdesktop.DisplayConfig{Width: 1920, Height: 1080},
 	}
@@ -444,7 +444,7 @@ func TestHandleAction_LeftClick(t *testing.T) {
 func TestHandleAction_UnknownAction(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	fake := &fakeDesktop{
 		startCfg: agentdesktop.DisplayConfig{Width: 1920, Height: 1080},
 	}
@@ -468,7 +468,7 @@ func TestHandleAction_UnknownAction(t *testing.T) {
 func TestHandleAction_KeyAction(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	fake := &fakeDesktop{
 		startCfg: agentdesktop.DisplayConfig{Width: 1920, Height: 1080},
 	}
@@ -497,7 +497,7 @@ func TestHandleAction_KeyAction(t *testing.T) {
 func TestHandleAction_TypeAction(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	fake := &fakeDesktop{
 		startCfg: agentdesktop.DisplayConfig{Width: 1920, Height: 1080},
 	}
@@ -539,7 +539,7 @@ func TestHandleAction_KeyDownAndUp(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			logger := slogtest.Make(t, nil)
+			logger := testutil.Logger(t)
 			fake := &fakeDesktop{
 				startCfg: agentdesktop.DisplayConfig{Width: 1920, Height: 1080},
 			}
@@ -579,7 +579,7 @@ func TestHandleAction_KeyDownAndUp(t *testing.T) {
 func TestHandleAction_HoldKey(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	fake := &fakeDesktop{
 		startCfg: agentdesktop.DisplayConfig{Width: 1920, Height: 1080},
 	}
@@ -629,7 +629,7 @@ func TestHandleAction_HoldKey(t *testing.T) {
 func TestHandleAction_HoldKeyMissingText(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	fake := &fakeDesktop{
 		startCfg: agentdesktop.DisplayConfig{Width: 1920, Height: 1080},
 	}
@@ -658,7 +658,7 @@ func TestHandleAction_HoldKeyMissingText(t *testing.T) {
 func TestHandleAction_ScrollDown(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	fake := &fakeDesktop{
 		startCfg: agentdesktop.DisplayConfig{Width: 1920, Height: 1080},
 	}
@@ -690,7 +690,7 @@ func TestHandleAction_ScrollDown(t *testing.T) {
 func TestHandleAction_CoordinateScaling(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	fake := &fakeDesktop{
 		startCfg: agentdesktop.DisplayConfig{Width: 1920, Height: 1080},
 	}
@@ -723,7 +723,7 @@ func TestHandleAction_CoordinateScaling(t *testing.T) {
 func TestHandleAction_CoordinateScalingClampsToLastPixel(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	fake := &fakeDesktop{
 		startCfg: agentdesktop.DisplayConfig{Width: 1920, Height: 1080},
 	}
@@ -756,7 +756,7 @@ func TestHandleAction_CoordinateScalingClampsToLastPixel(t *testing.T) {
 func TestClose_DelegatesToDesktop(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	fake := &fakeDesktop{}
 	api := agentdesktop.NewAPI(logger, fake, nil)
 
@@ -768,7 +768,7 @@ func TestClose_DelegatesToDesktop(t *testing.T) {
 func TestClose_PreventsNewSessions(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	fake := &fakeDesktop{}
 	api := agentdesktop.NewAPI(logger, fake, nil)
 
@@ -789,7 +789,7 @@ func TestClose_PreventsNewSessions(t *testing.T) {
 func TestHandleAction_CursorPositionReturnsDeclaredCoordinates(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	fake := &fakeDesktop{
 		startCfg:  agentdesktop.DisplayConfig{Width: 1920, Height: 1080},
 		cursorPos: [2]int{960, 540},
@@ -826,7 +826,7 @@ func TestHandleAction_CursorPositionReturnsDeclaredCoordinates(t *testing.T) {
 func TestRecordingStartStop(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	fake := &fakeDesktop{
 		startCfg: agentdesktop.DisplayConfig{Width: 1920, Height: 1080},
 	}
@@ -857,7 +857,7 @@ func TestRecordingStartStop(t *testing.T) {
 func TestRecordingStartFails(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	fake := &failStartRecordingDesktop{
 		fakeDesktop: fakeDesktop{
 			startCfg: agentdesktop.DisplayConfig{Width: 1920, Height: 1080},
@@ -886,7 +886,7 @@ func TestRecordingStartFails(t *testing.T) {
 func TestRecordingStartIdempotent(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	fake := &fakeDesktop{
 		startCfg: agentdesktop.DisplayConfig{Width: 1920, Height: 1080},
 	}
@@ -919,7 +919,7 @@ func TestRecordingStartIdempotent(t *testing.T) {
 func TestRecordingStopIdempotent(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	fake := &fakeDesktop{
 		startCfg: agentdesktop.DisplayConfig{Width: 1920, Height: 1080},
 	}
@@ -954,7 +954,7 @@ func TestRecordingStopIdempotent(t *testing.T) {
 func TestRecordingStopInvalidIDFormat(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	fake := &fakeDesktop{
 		startCfg: agentdesktop.DisplayConfig{Width: 1920, Height: 1080},
 	}
@@ -974,7 +974,7 @@ func TestRecordingStopInvalidIDFormat(t *testing.T) {
 func TestRecordingStopUnknownRecording(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	fake := &fakeDesktop{
 		startCfg: agentdesktop.DisplayConfig{Width: 1920, Height: 1080},
 	}
@@ -1001,7 +1001,7 @@ func TestRecordingStopUnknownRecording(t *testing.T) {
 func TestRecordingStopOversizedFile(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	fake := &oversizedFakeDesktop{
 		fakeDesktop: fakeDesktop{
 			startCfg: agentdesktop.DisplayConfig{Width: 1920, Height: 1080},
@@ -1038,7 +1038,7 @@ func TestRecordingStopOversizedFile(t *testing.T) {
 func TestRecordingMultipleSimultaneous(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	fake := &fakeDesktop{
 		startCfg: agentdesktop.DisplayConfig{Width: 1920, Height: 1080},
 	}
@@ -1077,7 +1077,7 @@ func TestRecordingMultipleSimultaneous(t *testing.T) {
 func TestRecordingStartMalformedBody(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	fake := &fakeDesktop{
 		startCfg: agentdesktop.DisplayConfig{Width: 1920, Height: 1080},
 	}
@@ -1095,7 +1095,7 @@ func TestRecordingStartMalformedBody(t *testing.T) {
 func TestRecordingStartEmptyID(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	fake := &fakeDesktop{
 		startCfg: agentdesktop.DisplayConfig{Width: 1920, Height: 1080},
 	}
@@ -1115,7 +1115,7 @@ func TestRecordingStartEmptyID(t *testing.T) {
 func TestRecordingStopEmptyID(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	fake := &fakeDesktop{
 		startCfg: agentdesktop.DisplayConfig{Width: 1920, Height: 1080},
 	}
@@ -1135,7 +1135,7 @@ func TestRecordingStopEmptyID(t *testing.T) {
 func TestRecordingStopMalformedBody(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	fake := &fakeDesktop{
 		startCfg: agentdesktop.DisplayConfig{Width: 1920, Height: 1080},
 	}
@@ -1153,7 +1153,7 @@ func TestRecordingStopMalformedBody(t *testing.T) {
 func TestRecordingStartAfterCompleted(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	fake := &fakeDesktop{
 		startCfg: agentdesktop.DisplayConfig{Width: 1920, Height: 1080},
 	}
@@ -1206,7 +1206,7 @@ func TestRecordingStartAfterCompleted(t *testing.T) {
 func TestRecordingStartAfterClose(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	fake := &fakeDesktop{
 		startCfg: agentdesktop.DisplayConfig{Width: 1920, Height: 1080},
 	}
@@ -1234,7 +1234,7 @@ func TestRecordingStartAfterClose(t *testing.T) {
 func TestRecordingStartDesktopClosed(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	// StartRecording returns ErrDesktopClosed to simulate a race
 	// where the desktop is closed between the API-level check and
 	// the desktop-level StartRecording call.
@@ -1266,7 +1266,7 @@ func TestRecordingStartDesktopClosed(t *testing.T) {
 func TestRecordingStopCorrupted(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	fake := &corruptedStopDesktop{
 		fakeDesktop: fakeDesktop{
 			startCfg: agentdesktop.DisplayConfig{Width: 1920, Height: 1080},
@@ -1328,7 +1328,7 @@ func parseMultipartParts(t *testing.T, contentType string, body []byte) map[stri
 func TestHandleRecordingStop_WithThumbnail(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	// Create a fake JPEG header: 0xFF 0xD8 0xFF followed by 509 zero bytes.
 	thumbnail := make([]byte, 512)
 	thumbnail[0] = 0xff
@@ -1378,7 +1378,7 @@ func TestHandleRecordingStop_WithThumbnail(t *testing.T) {
 func TestHandleRecordingStop_NoThumbnail(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	fake := &fakeDesktop{
 		startCfg: agentdesktop.DisplayConfig{Width: 1920, Height: 1080},
 	}
@@ -1419,7 +1419,7 @@ func TestHandleRecordingStop_NoThumbnail(t *testing.T) {
 func TestHandleRecordingStop_OversizedThumbnail(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	// Create thumbnail data that exceeds MaxThumbnailSize.
 	oversizedThumb := make([]byte, workspacesdk.MaxThumbnailSize+1)
 	oversizedThumb[0] = 0xff

--- a/agent/x/agentdesktop/portabledesktop_internal_test.go
+++ b/agent/x/agentdesktop/portabledesktop_internal_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/agent/agentexec"
 	"github.com/coder/coder/v2/pty"
 	"github.com/coder/coder/v2/testutil"
@@ -76,7 +75,7 @@ func (r *recordedExecer) PTYCommandContext(ctx context.Context, cmd string, args
 func TestPortableDesktop_Start_ParsesOutput(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 
 	// The "up" script prints the JSON line then sleeps until
 	// the context is canceled (simulating a long-running process).
@@ -110,7 +109,7 @@ func TestPortableDesktop_Start_ParsesOutput(t *testing.T) {
 func TestPortableDesktop_Start_Idempotent(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 
 	rec := &recordedExecer{
 		scripts: map[string]string{
@@ -153,7 +152,7 @@ func TestPortableDesktop_Start_Idempotent(t *testing.T) {
 func TestPortableDesktop_Screenshot(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 
 	rec := &recordedExecer{
 		scripts: map[string]string{
@@ -179,7 +178,7 @@ func TestPortableDesktop_Screenshot(t *testing.T) {
 func TestPortableDesktop_Screenshot_WithTargetDimensions(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 
 	rec := &recordedExecer{
 		scripts: map[string]string{
@@ -279,7 +278,7 @@ func TestPortableDesktop_MouseMethods(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			logger := slogtest.Make(t, nil)
+			logger := testutil.Logger(t)
 			rec := &recordedExecer{
 				scripts: map[string]string{
 					"mouse": `echo ok`,
@@ -364,7 +363,7 @@ func TestPortableDesktop_KeyboardMethods(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			logger := slogtest.Make(t, nil)
+			logger := testutil.Logger(t)
 			rec := &recordedExecer{
 				scripts: map[string]string{
 					"keyboard": `echo ok`,
@@ -397,7 +396,7 @@ func TestPortableDesktop_KeyboardMethods(t *testing.T) {
 func TestPortableDesktop_CursorPosition(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	rec := &recordedExecer{
 		scripts: map[string]string{
 			"cursor": `echo '{"x":100,"y":200}'`,
@@ -420,7 +419,7 @@ func TestPortableDesktop_CursorPosition(t *testing.T) {
 func TestPortableDesktop_Close(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 
 	rec := &recordedExecer{
 		scripts: map[string]string{
@@ -466,7 +465,7 @@ func TestEnsureBinary_UsesCachedBinPath(t *testing.T) {
 
 	// When binPath is already set, ensureBinary should return
 	// immediately without doing any work.
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	pd := &portableDesktop{
 		logger:       logger,
 		execer:       agentexec.DefaultExecer,
@@ -488,7 +487,7 @@ func TestEnsureBinary_UsesScriptBinDir(t *testing.T) {
 	require.NoError(t, os.WriteFile(binPath, []byte("#!/bin/sh\n"), 0o600))
 	require.NoError(t, os.Chmod(binPath, 0o755))
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	pd := &portableDesktop{
 		logger:       logger,
 		execer:       agentexec.DefaultExecer,
@@ -516,7 +515,7 @@ func TestEnsureBinary_ScriptBinDirNotExecutable(t *testing.T) {
 	require.NoError(t, os.WriteFile(binPath, []byte("#!/bin/sh\n"), 0o600))
 	_ = binPath
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	pd := &portableDesktop{
 		logger:       logger,
 		execer:       agentexec.DefaultExecer,
@@ -535,7 +534,7 @@ func TestEnsureBinary_NotFound(t *testing.T) {
 	// Cannot use t.Parallel because t.Setenv modifies the process
 	// environment.
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	pd := &portableDesktop{
 		logger:       logger,
 		execer:       agentexec.DefaultExecer,
@@ -553,7 +552,7 @@ func TestEnsureBinary_NotFound(t *testing.T) {
 func TestPortableDesktop_StartRecording(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	rec := &recordedExecer{
 		scripts: map[string]string{
 			"record": `trap 'exit 0' INT; sleep 120 & wait`,
@@ -597,7 +596,7 @@ func TestPortableDesktop_StartRecording(t *testing.T) {
 func TestPortableDesktop_StartRecording_ConcurrentLimit(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	rec := &recordedExecer{
 		scripts: map[string]string{
 			"record": `trap 'exit 0' INT; sleep 120 & wait`,
@@ -633,7 +632,7 @@ func TestPortableDesktop_StartRecording_ConcurrentLimit(t *testing.T) {
 func TestPortableDesktop_StopRecording_ReturnsArtifact(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	rec := &recordedExecer{
 		scripts: map[string]string{
 			// Use exec so SIGINT is delivered directly to sleep
@@ -679,7 +678,7 @@ func TestPortableDesktop_StopRecording_ReturnsArtifact(t *testing.T) {
 func TestPortableDesktop_StopRecording_WithThumbnail(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	rec := &recordedExecer{
 		scripts: map[string]string{
 			// See TestPortableDesktop_StopRecording_ReturnsArtifact
@@ -738,7 +737,7 @@ func TestPortableDesktop_StopRecording_WithThumbnail(t *testing.T) {
 func TestPortableDesktop_StopRecording_UnknownID(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	rec := &recordedExecer{
 		scripts: map[string]string{
 			"record": `trap 'exit 0' INT; sleep 120 & wait`,
@@ -771,7 +770,7 @@ var _ Desktop = (*portableDesktop)(nil)
 func TestPortableDesktop_IdleTimeout_StopsRecordings(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	rec := &recordedExecer{
 		scripts: map[string]string{
 			"record": `trap 'exit 0' INT; sleep 120 & wait`,
@@ -842,7 +841,7 @@ func TestPortableDesktop_IdleTimeout_StopsRecordings(t *testing.T) {
 func TestPortableDesktop_IdleTimeout_ActivityResetsTimer(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	rec := &recordedExecer{
 		scripts: map[string]string{
 			"record": `trap 'exit 0' INT; sleep 120 & wait`,
@@ -906,7 +905,7 @@ func TestPortableDesktop_IdleTimeout_ActivityResetsTimer(t *testing.T) {
 func TestPortableDesktop_IdleTimeout_MultipleRecordings(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	rec := &recordedExecer{
 		scripts: map[string]string{
 			"record": `trap 'exit 0' INT; sleep 120 & wait`,
@@ -977,7 +976,7 @@ func TestPortableDesktop_IdleTimeout_MultipleRecordings(t *testing.T) {
 func TestPortableDesktop_StartRecording_ReturnsErrDesktopClosed(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	rec := &recordedExecer{
 		scripts: map[string]string{
 			"up": `printf '{"vncPort":5901,"geometry":"1920x1080"}\n' && sleep 120`,
@@ -1009,7 +1008,7 @@ func TestPortableDesktop_StartRecording_ReturnsErrDesktopClosed(t *testing.T) {
 func TestPortableDesktop_Start_ReturnsErrDesktopClosed(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	rec := &recordedExecer{
 		scripts: map[string]string{
 			"up": `printf '{"vncPort":5901,"geometry":"1920x1080"}\n' && sleep 120`,

--- a/agent/x/agentmcp/api_internal_test.go
+++ b/agent/x/agentmcp/api_internal_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/agent/agentexec"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
 	"github.com/coder/coder/v2/testutil"
@@ -65,7 +64,7 @@ func TestHandleListTools_ReloadOnChange(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := testutil.Context(t, testutil.WaitLong)
-			logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+			logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 			dir := t.TempDir()
 
 			configPath := writeMCPConfig(t, dir, tc.entries(t))
@@ -106,7 +105,7 @@ func TestHandleListTools_ReloadOnChange(t *testing.T) {
 	t.Run("ConfigChangeTriggersReload", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
-		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 		dir := t.TempDir()
 
 		_, entry1 := fakeMCPServerConfig(t, "srv1")
@@ -163,7 +162,7 @@ func TestHandleListTools_ReloadsAfterStartupSettled(t *testing.T) {
 	}
 
 	ctx := testutil.Context(t, testutil.WaitLong)
-	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 	dir := t.TempDir()
 
 	_, entry := fakeMCPServerConfig(t, "srv")
@@ -200,7 +199,7 @@ func TestHandleListTools_WaitsForStartupSettled(t *testing.T) {
 	}
 
 	ctx := testutil.Context(t, testutil.WaitLong)
-	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, ".mcp.json")
 

--- a/agent/x/agentmcp/configwatcher_internal_test.go
+++ b/agent/x/agentmcp/configwatcher_internal_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/agent/agentexec"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
 	"github.com/coder/coder/v2/testutil"
@@ -63,7 +62,7 @@ func TestWatcher_LateFileTriggersReload(t *testing.T) {
 	}
 
 	ctx := testutil.Context(t, testutil.WaitLong)
-	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, ".mcp.json")
 
@@ -102,7 +101,7 @@ func TestWatcher_RewriteTriggersReload(t *testing.T) {
 	}
 
 	ctx := testutil.Context(t, testutil.WaitLong)
-	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 	dir := t.TempDir()
 
 	_, entry := fakeMCPServerConfig(t, "srv")
@@ -141,7 +140,7 @@ func TestWatcher_RemovalTransitionsToEmpty(t *testing.T) {
 	}
 
 	ctx := testutil.Context(t, testutil.WaitLong)
-	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 	dir := t.TempDir()
 
 	_, entry := fakeMCPServerConfig(t, "srv")
@@ -172,7 +171,7 @@ func TestWatcher_RemovalTransitionsToEmpty(t *testing.T) {
 func TestWatcher_DebouncesBurst(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 	mClock := quartz.NewMock(t)
 
 	var fires atomic.Int64
@@ -242,7 +241,7 @@ func TestWatcher_CloseStopsGoroutine(t *testing.T) {
 	t.Parallel()
 
 	ctx := testutil.Context(t, testutil.WaitLong)
-	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, ".mcp.json")
 
@@ -277,7 +276,7 @@ func TestWatcher_DualAgentHTTPNoStall(t *testing.T) {
 	}
 
 	ctx := testutil.Context(t, testutil.WaitLong)
-	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, ".mcp.json")
 
@@ -334,7 +333,7 @@ func TestWatcher_LateParentDirTriggersReload(t *testing.T) {
 	}
 
 	ctx := testutil.Context(t, testutil.WaitLong)
-	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 	root := t.TempDir()
 	// Parent directory does not exist yet: armAncestorLocked
 	// will watch root instead.
@@ -378,7 +377,7 @@ func TestWatcher_SharedParentRefcount(t *testing.T) {
 	}
 
 	ctx := testutil.Context(t, testutil.WaitLong)
-	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 	dir := t.TempDir()
 	pathA := filepath.Join(dir, "a.mcp.json")
 	pathB := filepath.Join(dir, "b.mcp.json")
@@ -454,7 +453,7 @@ func TestWatcher_CloseDoesNotStallOnInFlightReload(t *testing.T) {
 	}
 
 	ctx := testutil.Context(t, testutil.WaitLong)
-	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, ".mcp.json")
 

--- a/agent/x/agentmcp/manager_internal_test.go
+++ b/agent/x/agentmcp/manager_internal_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/agent/agentexec"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
 	"github.com/coder/coder/v2/testutil"
@@ -254,7 +253,7 @@ func TestManager_WaitReloadTimeout(t *testing.T) {
 	t.Parallel()
 
 	ctx := testutil.Context(t, testutil.WaitLong)
-	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 	clock := quartz.NewMock(t)
 	timerTrap := clock.Trap().NewTimer("agentmcp", "tools_reload")
 	defer timerTrap.Close()
@@ -290,7 +289,7 @@ func TestManager_ToolsStartupGate(t *testing.T) {
 	t.Run("MissingBeforeStartupCanAppearBeforeSettlement", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
-		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 		dir := t.TempDir()
 		configPath := filepath.Join(dir, ".mcp.json")
 
@@ -324,7 +323,7 @@ func TestManager_ToolsStartupGate(t *testing.T) {
 	t.Run("MissingAfterStartupReturnsEmptyAndMarksFirstSync", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
-		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 		dir := t.TempDir()
 		configPath := filepath.Join(dir, ".mcp.json")
 
@@ -345,7 +344,7 @@ func TestManager_ToolsStartupGate(t *testing.T) {
 	t.Run("ConfigAppearsAfterEmptySyncReloads", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
-		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 		dir := t.TempDir()
 		configPath := filepath.Join(dir, ".mcp.json")
 
@@ -369,7 +368,7 @@ func TestManager_ToolsStartupGate(t *testing.T) {
 	t.Run("ConcurrentFirstListToolsCallsAllSucceed", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
-		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 		dir := t.TempDir()
 		_, entry := fakeMCPServerConfig(t, "srv")
 		configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
@@ -400,7 +399,7 @@ func TestManager_ToolsStartupGate(t *testing.T) {
 	t.Run("CloseUnblocksStartupWait", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
-		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 		dir := t.TempDir()
 		configPath := filepath.Join(dir, ".mcp.json")
 
@@ -425,7 +424,7 @@ func TestManager_ToolsStartupGate(t *testing.T) {
 	t.Run("CallerCanceledBeforeStartupReturnsNoTools", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
-		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 		dir := t.TempDir()
 		configPath := filepath.Join(dir, ".mcp.json")
 
@@ -443,7 +442,7 @@ func TestManager_ToolsStartupGate(t *testing.T) {
 	t.Run("ManagerCanceledBeforeStartupReturnsNoTools", func(t *testing.T) {
 		t.Parallel()
 		ctx, cancel := context.WithCancel(testutil.Context(t, testutil.WaitLong))
-		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 		dir := t.TempDir()
 		configPath := filepath.Join(dir, ".mcp.json")
 
@@ -460,7 +459,7 @@ func TestManager_ToolsStartupGate(t *testing.T) {
 	t.Run("ClosedBeforeFirstSyncReturnsNoTools", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
-		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 		dir := t.TempDir()
 		configPath := filepath.Join(dir, ".mcp.json")
 
@@ -477,7 +476,7 @@ func TestManager_ToolsStartupGate(t *testing.T) {
 	t.Run("CanceledBeforeFirstSyncStillStartsReload", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
-		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 		dir := t.TempDir()
 		configPath := filepath.Join(dir, ".mcp.json")
 		paths := []string{configPath}
@@ -508,7 +507,7 @@ func TestManager_ToolsStartupGate(t *testing.T) {
 	t.Run("CanceledAfterFirstSyncNoopReturnsCachedTools", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
-		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 		dir := t.TempDir()
 		_, entry := fakeMCPServerConfig(t, "srv")
 		configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})
@@ -532,7 +531,7 @@ func TestManager_ToolsStartupGate(t *testing.T) {
 	t.Run("ManagerCanceledAfterFirstSyncReturnsCachedTools", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
-		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 		dir := t.TempDir()
 		_, entry := fakeMCPServerConfig(t, "srv")
 		configPath := writeMCPConfig(t, dir, map[string]mcpServerEntry{"srv": entry})

--- a/agent/x/agentmcp/reload_internal_test.go
+++ b/agent/x/agentmcp/reload_internal_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/agent/agentexec"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
 	"github.com/coder/coder/v2/testutil"
@@ -151,7 +150,7 @@ func TestSnapshotChanged(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := testutil.Context(t, testutil.WaitLong)
-			logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+			logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 			dir := t.TempDir()
 
 			paths := tc.setup(t, dir)
@@ -186,7 +185,7 @@ func TestSnapshotChanged_MultipleConfigFiles(t *testing.T) {
 	}
 
 	ctx := testutil.Context(t, testutil.WaitLong)
-	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 
 	dir1 := t.TempDir()
 	dir2 := t.TempDir()
@@ -234,7 +233,7 @@ func TestReload(t *testing.T) {
 	t.Run("SingleReloadUpdatesSnapshot", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
-		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 		dir := t.TempDir()
 
 		_, entry := fakeMCPServerConfig(t, "srv")
@@ -257,7 +256,7 @@ func TestReload(t *testing.T) {
 	t.Run("ReloadAfterClose", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
-		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 
 		m := NewManager(ctx, logger, agentexec.DefaultExecer, nil)
 		require.NoError(t, m.Close())
@@ -269,7 +268,7 @@ func TestReload(t *testing.T) {
 	t.Run("ConcurrentReloadsCoalesce", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
-		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 		dir := t.TempDir()
 
 		_, entry := fakeMCPServerConfig(t, "srv")
@@ -300,7 +299,7 @@ func TestReload(t *testing.T) {
 	t.Run("CallerContextCanceled", func(t *testing.T) {
 		t.Parallel()
 		mgrCtx := testutil.Context(t, testutil.WaitLong)
-		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 		dir := t.TempDir()
 		paths := []string{filepath.Join(dir, ".mcp.json")}
 
@@ -328,7 +327,7 @@ func TestReload(t *testing.T) {
 	t.Run("SequentialReloadsDiffDetect", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
-		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 		dir := t.TempDir()
 
 		_, entry1 := fakeMCPServerConfig(t, "srv1")
@@ -360,7 +359,7 @@ func TestReload(t *testing.T) {
 	t.Run("PerServerConnectFailureUpdatesSnapshot", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
-		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 		dir := t.TempDir()
 
 		// Config with a nonexistent binary: connect will fail.
@@ -382,7 +381,7 @@ func TestReload(t *testing.T) {
 	t.Run("EmptyConfigClosesServers", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
-		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 		dir := t.TempDir()
 
 		_, entry := fakeMCPServerConfig(t, "srv")
@@ -417,7 +416,7 @@ func TestDifferentialReload(t *testing.T) {
 	t.Run("UnchangedServerReusesClient", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
-		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 		dir := t.TempDir()
 
 		_, entry := fakeMCPServerConfig(t, "srv")
@@ -458,7 +457,7 @@ func TestDifferentialReload(t *testing.T) {
 	t.Run("ChangedServerGetsNewClient", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
-		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 		dir := t.TempDir()
 
 		_, entry := fakeMCPServerConfig(t, "srv")
@@ -491,7 +490,7 @@ func TestDifferentialReload(t *testing.T) {
 	t.Run("RemovedServerIsClosed", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
-		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 		dir := t.TempDir()
 
 		_, entryA := fakeMCPServerConfig(t, "srvA")
@@ -534,7 +533,7 @@ func TestDifferentialReload(t *testing.T) {
 	t.Run("ConnectFailureRetainsOldClient", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
-		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 		dir := t.TempDir()
 
 		_, entry := fakeMCPServerConfig(t, "srv")
@@ -575,7 +574,7 @@ func TestDifferentialReload(t *testing.T) {
 	t.Run("PostReloadToolCallReachesKeptServer", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitLong)
-		logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 		dir := t.TempDir()
 
 		_, entry := fakeMCPServerConfig(t, "srv")
@@ -624,7 +623,7 @@ func TestReload_FirstBootPath(t *testing.T) {
 	}
 
 	ctx := testutil.Context(t, testutil.WaitLong)
-	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 	dir := t.TempDir()
 
 	_, entry := fakeMCPServerConfig(t, "srv")
@@ -653,7 +652,7 @@ func TestReload_NoopWhenUnchanged(t *testing.T) {
 	}
 
 	ctx := testutil.Context(t, testutil.WaitLong)
-	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 	dir := t.TempDir()
 
 	_, entry := fakeMCPServerConfig(t, "srv")
@@ -698,7 +697,7 @@ func TestClose_SuppressesSubprocessExitError(t *testing.T) {
 	}
 
 	ctx := testutil.Context(t, testutil.WaitLong)
-	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 	dir := t.TempDir()
 
 	_, entry := fakeMCPServerConfig(t, "srv")

--- a/aibridge/bridge_test.go
+++ b/aibridge/bridge_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/aibridge"
 	"github.com/coder/coder/v2/aibridge/config"
 	"github.com/coder/coder/v2/aibridge/internal/testutil"
 	"github.com/coder/coder/v2/aibridge/provider"
+	codertestutil "github.com/coder/coder/v2/testutil"
 )
 
 var bridgeTestTracer = otel.Tracer("bridge_test")
@@ -21,7 +21,7 @@ var bridgeTestTracer = otel.Tracer("bridge_test")
 func TestValidateProviders(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := codertestutil.Logger(t)
 
 	tests := []struct {
 		name      string
@@ -182,7 +182,7 @@ func TestPassthroughRoutesForProviders(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			logger := slogtest.Make(t, nil)
+			logger := codertestutil.Logger(t)
 
 			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, tc.expectPath, r.URL.Path)

--- a/aibridge/intercept/apidump/apidump_test.go
+++ b/aibridge/intercept/apidump/apidump_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
+	"github.com/coder/coder/v2/testutil"
 	"github.com/coder/quartz"
 )
 
@@ -32,7 +32,7 @@ func TestBridgedMiddleware_RedactsSensitiveRequestHeaders(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: false}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 	clk := quartz.NewMock(t)
 	interceptionID := uuid.New()
 
@@ -90,7 +90,7 @@ func TestBridgedMiddleware_RedactsSensitiveResponseHeaders(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: false}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 	clk := quartz.NewMock(t)
 	interceptionID := uuid.New()
 
@@ -151,7 +151,7 @@ func TestBridgedMiddleware_WritesErrorFile_WhenNextFails(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: false}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 	clk := quartz.NewMock(t)
 	interceptionID := uuid.New()
 
@@ -178,7 +178,7 @@ func TestBridgedMiddleware_WritesErrorFile_WhenNextFails(t *testing.T) {
 func TestBridgedMiddleware_EmptyBaseDir_ReturnsNil(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: false}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 	middleware := NewBridgeMiddleware("", "openai", "gpt-4", uuid.New(), logger, quartz.NewMock(t))
 	require.Nil(t, middleware)
 }
@@ -187,7 +187,7 @@ func TestBridgedMiddleware_PreservesRequestBody(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: false}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 	clk := quartz.NewMock(t)
 	interceptionID := uuid.New()
 
@@ -221,7 +221,7 @@ func TestBridgedMiddleware_ModelWithSlash(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: false}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 	clk := quartz.NewMock(t)
 	interceptionID := uuid.New()
 
@@ -302,7 +302,7 @@ func TestBridgedMiddleware_AllSensitiveRequestHeaders(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: false}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 	clk := quartz.NewMock(t)
 	interceptionID := uuid.New()
 
@@ -365,7 +365,7 @@ func TestPassthroughMiddleware(t *testing.T) {
 
 	t.Run("empty_base_dir_returns_original_transport", func(t *testing.T) {
 		t.Parallel()
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: false}).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 		inner := http.DefaultTransport
 		rt := NewPassthroughMiddleware(inner, "", "openai", logger, quartz.NewMock(t))
 		require.Equal(t, inner, rt)
@@ -375,7 +375,7 @@ func TestPassthroughMiddleware(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: false}).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 		clk := quartz.NewMock(t)
 
 		innerErr := io.ErrUnexpectedEOF
@@ -405,7 +405,7 @@ func TestPassthroughMiddleware(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: false}).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 		clk := quartz.NewMock(t)
 
 		req1Body := `first request`

--- a/aibridge/intercept/apidump/streaming_test.go
+++ b/aibridge/intercept/apidump/streaming_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
+	"github.com/coder/coder/v2/testutil"
 	"github.com/coder/quartz"
 )
 
@@ -21,7 +21,7 @@ func TestMiddleware_StreamingResponse(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: false}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 	clk := quartz.NewMock(t)
 	interceptionID := uuid.New()
 
@@ -99,7 +99,7 @@ func TestMiddleware_PreservesResponseBody(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: false}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 	clk := quartz.NewMock(t)
 	interceptionID := uuid.New()
 

--- a/aibridge/intercept/chatcompletions/streaming_test.go
+++ b/aibridge/intercept/chatcompletions/streaming_test.go
@@ -16,13 +16,13 @@ import (
 	"go.opentelemetry.io/otel"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/aibridge/config"
 	"github.com/coder/coder/v2/aibridge/intercept"
 	"github.com/coder/coder/v2/aibridge/internal/testutil"
 	"github.com/coder/coder/v2/aibridge/keypool"
 	"github.com/coder/coder/v2/aibridge/mcp"
 	"github.com/coder/coder/v2/aibridge/utils"
+	codertestutil "github.com/coder/coder/v2/testutil"
 	"github.com/coder/quartz"
 )
 
@@ -97,7 +97,7 @@ func TestStreamingInterception_RelaysUpstreamErrorToClient(t *testing.T) {
 			tracer := otel.Tracer("test")
 			interceptor := NewStreamingInterceptor(uuid.New(), req, config.ProviderOpenAI, cfg, httpReq.Header, "Authorization", tracer, intercept.CredentialInfo{})
 
-			logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: false}).Leveled(slog.LevelDebug)
+			logger := codertestutil.Logger(t).Leveled(slog.LevelDebug)
 			interceptor.Setup(logger, &testutil.MockRecorder{}, nil)
 
 			// Process the request

--- a/aibridge/intercept/eventstream/eventstream_test.go
+++ b/aibridge/intercept/eventstream/eventstream_test.go
@@ -14,8 +14,8 @@ import (
 
 	"cdr.dev/slog/v3"
 	"cdr.dev/slog/v3/sloggers/sloghuman"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/aibridge/intercept/eventstream"
+	"github.com/coder/coder/v2/testutil"
 	"github.com/coder/quartz"
 )
 
@@ -41,7 +41,7 @@ func TestEventStream_LogsWarning_WhenFlushIsSlow(t *testing.T) {
 	t.Parallel()
 
 	var buf strings.Builder
-	logger := slogtest.Make(t, nil).AppendSinks(sloghuman.Sink(&buf)).Leveled(slog.LevelWarn)
+	logger := testutil.Logger(t).AppendSinks(sloghuman.Sink(&buf)).Leveled(slog.LevelWarn)
 	ctx := context.Background()
 	clk := quartz.NewMock(t)
 
@@ -79,7 +79,7 @@ func TestEventStream_NoWarning_WhenFlushIsFast(t *testing.T) {
 	t.Parallel()
 
 	var buf strings.Builder
-	logger := slogtest.Make(t, nil).AppendSinks(sloghuman.Sink(&buf)).Leveled(slog.LevelWarn)
+	logger := testutil.Logger(t).AppendSinks(sloghuman.Sink(&buf)).Leveled(slog.LevelWarn)
 	ctx := context.Background()
 	clk := quartz.NewMock(t)
 

--- a/aibridge/internal/integrationtest/helpers.go
+++ b/aibridge/internal/integrationtest/helpers.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/aibridge/config"
 	"github.com/coder/coder/v2/aibridge/recorder"
+	"github.com/coder/coder/v2/testutil"
 )
 
 // anthropicCfg creates a minimal Anthropic config for testing.
@@ -52,7 +52,7 @@ func openaiCfgWithAPIDump(url string, key string, dumpDir string) config.OpenAI 
 // newLogger creates a test logger at Debug level.
 func newLogger(t *testing.T) slog.Logger {
 	t.Helper()
-	return slogtest.Make(t, &slogtest.Options{}).Leveled(slog.LevelDebug)
+	return testutil.Logger(t).Leveled(slog.LevelDebug)
 }
 
 func newModelThought(content, source string) recorder.ModelThoughtRecord {

--- a/aibridge/internal/integrationtest/mockmcp.go
+++ b/aibridge/internal/integrationtest/mockmcp.go
@@ -17,9 +17,9 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/aibridge/internal/testutil"
 	"github.com/coder/coder/v2/aibridge/mcp"
+	codertestutil "github.com/coder/coder/v2/testutil"
 )
 
 // mockToolName is the primary mock tool name used in MCP tests.
@@ -55,7 +55,7 @@ func setupMCPForTestWithName(t *testing.T, name string, tracer trace.Tracer) *mo
 	mcpSrv := httptest.NewServer(srv)
 	t.Cleanup(mcpSrv.Close) // FIRST registered → runs LAST (LIFO)
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: false}).Leveled(slog.LevelDebug)
+	logger := codertestutil.Logger(t).Leveled(slog.LevelDebug)
 	// Use a dedicated HTTP client so MCP mocks don't use http.DefaultTransport,
 	// which can break when httptest.Server calls CloseIdleConnections in parallel
 	// resulting in error `init MCP client: failed to send initialized notification: failed to send request: failed to send request: Post "http://127.0.0.1:43843": net/http: HTTP/1.x transport connection broken: http: CloseIdleConnections called`

--- a/aibridge/keypool/keymark_test.go
+++ b/aibridge/keypool/keymark_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/aibridge/keypool"
+	"github.com/coder/coder/v2/testutil"
 	"github.com/coder/quartz"
 )
 
@@ -108,7 +108,7 @@ func TestMarkKeyOnStatus(t *testing.T) {
 				resp,
 				// 401 and 403 cases legitimately log at error
 				// level when marking a key permanent.
-				slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+				testutil.Logger(t, testutil.WithIgnoreErrors()),
 				"test",
 			)
 

--- a/aibridge/mcp/mcp_test.go
+++ b/aibridge/mcp/mcp_test.go
@@ -17,9 +17,9 @@ import (
 	"go.uber.org/goleak"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/aibridge/internal/testutil"
 	"github.com/coder/coder/v2/aibridge/mcp"
+	codertestutil "github.com/coder/coder/v2/testutil"
 )
 
 func TestMain(m *testing.M) {
@@ -298,7 +298,7 @@ func TestToolInjectionOrder(t *testing.T) {
 	t.Parallel()
 
 	// Setup.
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: false}).Leveled(slog.LevelDebug)
+	logger := codertestutil.Logger(t).Leveled(slog.LevelDebug)
 	ctx, cancel := context.WithTimeout(t.Context(), testutil.WaitLong)
 	t.Cleanup(cancel)
 

--- a/aibridge/passthrough_test.go
+++ b/aibridge/passthrough_test.go
@@ -17,11 +17,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/aibridge/config"
 	"github.com/coder/coder/v2/aibridge/internal/testutil"
 	"github.com/coder/coder/v2/aibridge/keypool"
 	"github.com/coder/coder/v2/aibridge/provider"
+	codertestutil "github.com/coder/coder/v2/testutil"
 	"github.com/coder/quartz"
 )
 
@@ -106,7 +106,7 @@ func TestPassthroughRoutes(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			logger := slogtest.Make(t, nil)
+			logger := codertestutil.Logger(t)
 
 			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, tc.expectRequestPath, r.URL.Path)
@@ -273,7 +273,7 @@ func TestPassthroughRouterReusesProxyInstance(t *testing.T) {
 	upstream.Start()
 	t.Cleanup(upstream.Close)
 
-	logger := slogtest.Make(t, nil)
+	logger := codertestutil.Logger(t)
 	prov := &testutil.MockProvider{URL: upstream.URL}
 	handler := newPassthroughRouter(prov, logger, nil, testTracer)
 
@@ -551,7 +551,7 @@ func TestPassthrough_KeyFailover(t *testing.T) {
 				// IgnoreErrors: MarkKey logs at ERROR level when a
 				// key is marked permanent (401/403); slogtest would
 				// otherwise fail those scenarios.
-				logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+				logger := codertestutil.Logger(t, codertestutil.WithIgnoreErrors())
 				handler := newPassthroughRouter(p, logger, nil, testTracer)
 
 				req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)

--- a/cli/clitest/clitest.go
+++ b/cli/clitest/clitest.go
@@ -18,7 +18,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/cli"
 	"github.com/coder/coder/v2/cli/config"
 	"github.com/coder/coder/v2/codersdk"
@@ -85,7 +84,7 @@ func setupInvocation(t testing.TB, cmd *serpent.Command, args ...string,
 ) *serpent.Invocation {
 	// I really would like to fail test on error logs, but realistically, turning on by default
 	// in all our CLI tests is going to create a lot of flaky noise.
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).
 		Leveled(slog.LevelDebug).
 		Named("cli")
 	i := &serpent.Invocation{

--- a/cli/exp_scaletest_test.go
+++ b/cli/exp_scaletest_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/cli/clitest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/pty/ptytest"
@@ -26,7 +25,7 @@ func TestScaleTestCreateWorkspaces(t *testing.T) {
 	ctx, cancelFunc := context.WithTimeout(context.Background(), testutil.WaitLong)
 	defer cancelFunc()
 
-	log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	log := testutil.Logger(t, testutil.WithIgnoreErrors())
 	client := coderdtest.New(t, &coderdtest.Options{
 		// We are not including any provisioner daemons because we do not actually
 		// build any workspaces here.
@@ -76,7 +75,7 @@ func TestScaleTestWorkspaceTraffic(t *testing.T) {
 	ctx, cancelFunc := context.WithTimeout(context.Background(), testutil.WaitMedium)
 	defer cancelFunc()
 
-	log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	log := testutil.Logger(t, testutil.WithIgnoreErrors())
 	client := coderdtest.New(t, &coderdtest.Options{
 		Logger: &log,
 	})
@@ -110,7 +109,7 @@ func TestScaleTestWorkspaceTraffic_Template(t *testing.T) {
 	ctx, cancelFunc := context.WithTimeout(context.Background(), testutil.WaitMedium)
 	defer cancelFunc()
 
-	log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	log := testutil.Logger(t, testutil.WithIgnoreErrors())
 	client := coderdtest.New(t, &coderdtest.Options{
 		Logger: &log,
 	})
@@ -139,7 +138,7 @@ func TestScaleTestWorkspaceTraffic_TargetWorkspaces(t *testing.T) {
 	ctx, cancelFunc := context.WithTimeout(context.Background(), testutil.WaitMedium)
 	defer cancelFunc()
 
-	log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	log := testutil.Logger(t, testutil.WithIgnoreErrors())
 	client := coderdtest.New(t, &coderdtest.Options{
 		Logger: &log,
 	})
@@ -168,7 +167,7 @@ func TestScaleTestCleanup_Template(t *testing.T) {
 	ctx, cancelFunc := context.WithTimeout(context.Background(), testutil.WaitMedium)
 	defer cancelFunc()
 
-	log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	log := testutil.Logger(t, testutil.WithIgnoreErrors())
 	client := coderdtest.New(t, &coderdtest.Options{
 		Logger: &log,
 	})
@@ -198,7 +197,7 @@ func TestScaleTestDashboard(t *testing.T) {
 		ctx, cancelFunc := context.WithTimeout(context.Background(), testutil.WaitShort)
 		defer cancelFunc()
 
-		log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		log := testutil.Logger(t, testutil.WithIgnoreErrors())
 		client := coderdtest.New(t, &coderdtest.Options{
 			Logger: &log,
 		})
@@ -221,7 +220,7 @@ func TestScaleTestDashboard(t *testing.T) {
 		ctx, cancelFunc := context.WithTimeout(context.Background(), testutil.WaitShort)
 		defer cancelFunc()
 
-		log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		log := testutil.Logger(t, testutil.WithIgnoreErrors())
 		client := coderdtest.New(t, &coderdtest.Options{
 			Logger: &log,
 		})
@@ -245,7 +244,7 @@ func TestScaleTestDashboard(t *testing.T) {
 		ctx, cancelFunc := context.WithTimeout(context.Background(), testutil.WaitMedium)
 		defer cancelFunc()
 
-		log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		log := testutil.Logger(t, testutil.WithIgnoreErrors())
 		client := coderdtest.New(t, &coderdtest.Options{
 			Logger: &log,
 		})
@@ -273,7 +272,7 @@ func TestScaleTestDashboard(t *testing.T) {
 		ctx, cancelFunc := context.WithTimeout(context.Background(), testutil.WaitMedium)
 		defer cancelFunc()
 
-		log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		log := testutil.Logger(t, testutil.WithIgnoreErrors())
 		client := coderdtest.New(t, &coderdtest.Options{
 			Logger: &log,
 		})

--- a/cli/exptest/exptest_scaletest_test.go
+++ b/cli/exptest/exptest_scaletest_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/cli/clitest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/codersdk"
@@ -20,7 +19,7 @@ import (
 // can influence other tests in the same package.
 // nolint:paralleltest
 func TestScaleTestWorkspaceTraffic_UseHostLogin(t *testing.T) {
-	log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	log := testutil.Logger(t, testutil.WithIgnoreErrors())
 	client := coderdtest.New(t, &coderdtest.Options{
 		Logger:                   &log,
 		IncludeProvisionerDaemon: true,

--- a/cli/server_aibridge_internal_test.go
+++ b/cli/server_aibridge_internal_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/aibridge"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/testutil"
@@ -324,7 +323,7 @@ func TestReadAIBridgeProvidersFromEnv(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			providers, err := ReadAIBridgeProvidersFromEnv(slogtest.Make(t, nil), tt.env)
+			providers, err := ReadAIBridgeProvidersFromEnv(testutil.Logger(t), tt.env)
 			if tt.errContains != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errContains)
@@ -355,7 +354,7 @@ func TestReadAIBridgeProvidersFromEnv(t *testing.T) {
 				Keys: []string{fmt.Sprintf("sk-%d", i)},
 			})
 		}
-		providers, err := ReadAIBridgeProvidersFromEnv(slogtest.Make(t, nil), env)
+		providers, err := ReadAIBridgeProvidersFromEnv(testutil.Logger(t), env)
 		require.NoError(t, err)
 		require.Equal(t, expected, providers)
 	})

--- a/cli/server_test.go
+++ b/cli/server_test.go
@@ -41,7 +41,6 @@ import (
 	"tailscale.com/derp/derphttp"
 	"tailscale.com/types/key"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/buildinfo"
 	"github.com/coder/coder/v2/cli"
 	"github.com/coder/coder/v2/cli/clitest"
@@ -2349,7 +2348,7 @@ func TestConnectToPostgres(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
 		t.Cleanup(cancel)
 
-		log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		log := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 		dbURL, err := dbtestutil.Open(t)
 		require.NoError(t, err)

--- a/cli/ssh_internal_test.go
+++ b/cli/ssh_internal_test.go
@@ -20,7 +20,6 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/testutil"
 	"github.com/coder/quartz"
@@ -133,7 +132,7 @@ func TestCloserStack_Context(t *testing.T) {
 func TestCloserStack_PushAfterClose(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.Context(t, testutil.WaitShort)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	uut := newCloserStack(ctx, logger, quartz.NewMock(t))
 	closes := new([]*fakeCloser)
 	fc0 := &fakeCloser{closes: closes}
@@ -156,7 +155,7 @@ func TestCloserStack_CloseAfterContext(t *testing.T) {
 	testCtx := testutil.Context(t, testutil.WaitShort)
 	ctx, cancel := context.WithCancel(testCtx)
 	defer cancel()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	uut := newCloserStack(ctx, logger, quartz.NewMock(t))
 	ac := newAsyncCloser(testCtx, t)
 	defer ac.unblock()
@@ -187,7 +186,7 @@ func TestCloserStack_CloseAfterContext(t *testing.T) {
 func TestCloserStack_Timeout(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.Context(t, testutil.WaitShort)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	mClock := quartz.NewMock(t)
 	trap := mClock.Trap().TickerFunc("closerStack")
 	defer trap.Close()
@@ -231,7 +230,7 @@ func TestCloserStack_Timeout(t *testing.T) {
 func TestCloserStack_PushAfterClose_ConnClosed(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.Context(t, testutil.WaitShort)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	uut := newCloserStack(ctx, logger, quartz.NewMock(t))
 
 	uut.close(xerrors.New("canceled"))
@@ -267,7 +266,7 @@ func TestCoderConnectStdio(t *testing.T) {
 	t.Parallel()
 
 	ctx := testutil.Context(t, testutil.WaitShort)
-	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 	stack := newCloserStack(ctx, logger, quartz.NewMock(t))
 
 	clientOutput, clientInput := io.Pipe()
@@ -542,7 +541,7 @@ func TestRetryWithInterval(t *testing.T) {
 	const maxAttempts = 3
 
 	dnsErr := &net.DNSError{Err: "no such host", Name: "example.com", IsNotFound: true}
-	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 
 	t.Run("Succeeds_FirstTry", func(t *testing.T) {
 		t.Parallel()

--- a/coderd/agentapi/metadatabatcher/metadata_batcher_internal_test.go
+++ b/coderd/agentapi/metadatabatcher/metadata_batcher_internal_test.go
@@ -16,7 +16,6 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbmock"
 	"github.com/coder/coder/v2/coderd/database/pubsub/psmock"
@@ -180,7 +179,7 @@ func TestMetadataBatcher(t *testing.T) {
 
 	// Given: a fresh batcher with no data
 	ctx := testutil.Context(t, testutil.WaitShort)
-	log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	log := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	ctrl := gomock.NewController(t)
 	store := dbmock.NewMockStore(ctrl)
 	ps := psmock.NewMockPubsub(ctrl)
@@ -410,7 +409,7 @@ func TestMetadataBatcher_DropsWhenFull(t *testing.T) {
 	t.Parallel()
 
 	ctx := testutil.Context(t, testutil.WaitShort)
-	log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	log := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 
 	ctrl := gomock.NewController(t)
 	store := dbmock.NewMockStore(ctrl)
@@ -550,7 +549,7 @@ func TestMetadataBatcher_Deduplication(t *testing.T) {
 			t.Parallel()
 
 			ctx := testutil.Context(t, testutil.WaitShort)
-			log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+			log := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 			ctrl := gomock.NewController(t)
 			store := dbmock.NewMockStore(ctrl)
 			ps := psmock.NewMockPubsub(ctrl)
@@ -673,7 +672,7 @@ func TestMetadataBatcher_TimestampOrdering(t *testing.T) {
 	t.Parallel()
 
 	ctx := testutil.Context(t, testutil.WaitShort)
-	log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	log := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	ctrl := gomock.NewController(t)
 	store := dbmock.NewMockStore(ctrl)
 	ps := psmock.NewMockPubsub(ctrl)
@@ -760,7 +759,7 @@ func TestMetadataBatcher_PubsubChunking(t *testing.T) {
 	t.Parallel()
 
 	ctx := testutil.Context(t, testutil.WaitShort)
-	log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	log := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	ctrl := gomock.NewController(t)
 	store := dbmock.NewMockStore(ctrl)
 	ps := psmock.NewMockPubsub(ctrl)
@@ -909,7 +908,7 @@ func TestMetadataBatcher_ConcurrentAddsToSameAgent(t *testing.T) {
 	t.Parallel()
 
 	ctx := testutil.Context(t, testutil.WaitShort)
-	log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	log := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	ctrl := gomock.NewController(t)
 	store := dbmock.NewMockStore(ctrl)
 	ps := psmock.NewMockPubsub(ctrl)

--- a/coderd/aibridge/prices/prices_test.go
+++ b/coderd/aibridge/prices/prices_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/aibridge/prices"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
@@ -162,7 +161,7 @@ func TestSeedFromBytes(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitShort)
 		rawDB, _ := dbtestutil.NewDB(t)
-		authzDB := dbauthz.New(rawDB, rbac.NewStrictAuthorizer(prometheus.NewRegistry()), slogtest.Make(t, nil), coderdtest.AccessControlStorePointer())
+		authzDB := dbauthz.New(rawDB, rbac.NewStrictAuthorizer(prometheus.NewRegistry()), testutil.Logger(t), coderdtest.AccessControlStorePointer())
 
 		require.NoError(t, prices.SeedFromBytes(dbauthz.AsAIBridged(ctx), authzDB, []byte(testSeedJSON)))
 

--- a/coderd/audit_internal_test.go
+++ b/coderd/audit_internal_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbmock"
+	"github.com/coder/coder/v2/testutil"
 )
 
 func TestAuditLogIsResourceDeleted(t *testing.T) {
@@ -38,7 +38,7 @@ func TestAuditLogIsResourceDeleted(t *testing.T) {
 			db.EXPECT().GetChatByID(gomock.Any(), chatID).Return(database.Chat{}, tc.err)
 
 			api := &API{
-				Options: &Options{Database: db, Logger: slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})},
+				Options: &Options{Database: db, Logger: testutil.Logger(t, testutil.WithIgnoreErrors())},
 			}
 
 			deleted := api.auditLogIsResourceDeleted(context.Background(), database.GetAuditLogsOffsetRow{

--- a/coderd/audit_test.go
+++ b/coderd/audit_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/audit"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
@@ -20,6 +19,7 @@ import (
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/provisioner/echo"
 	"github.com/coder/coder/v2/provisionersdk/proto"
+	"github.com/coder/coder/v2/testutil"
 )
 
 func TestAuditLogs(t *testing.T) {
@@ -146,9 +146,7 @@ func TestAuditLogs(t *testing.T) {
 	t.Run("Organization", func(t *testing.T) {
 		t.Parallel()
 
-		logger := slogtest.Make(t, &slogtest.Options{
-			IgnoreErrors: true,
-		})
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 		ctx := context.Background()
 		client := coderdtest.New(t, &coderdtest.Options{
 			Logger: &logger,
@@ -206,9 +204,7 @@ func TestAuditLogs(t *testing.T) {
 	t.Run("Organization404", func(t *testing.T) {
 		t.Parallel()
 
-		logger := slogtest.Make(t, &slogtest.Options{
-			IgnoreErrors: true,
-		})
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 		ctx := context.Background()
 		client := coderdtest.New(t, &coderdtest.Options{
 			Logger: &logger,

--- a/coderd/autobuild/lifecycle_executor_test.go
+++ b/coderd/autobuild/lifecycle_executor_test.go
@@ -13,7 +13,6 @@ import (
 	"go.uber.org/goleak"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/autobuild"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
@@ -197,13 +196,17 @@ func TestExecutorAutostartTemplateUpdated(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+			var loggerOpts []testutil.LoggerOption
+			if !tc.expectStart {
+				loggerOpts = append(loggerOpts, testutil.WithIgnoreErrors())
+			}
 			var (
 				sched      = mustSchedule(t, "CRON_TZ=UTC 0 * * * *")
 				ctx        = context.Background()
 				err        error
 				tickCh     = make(chan time.Time)
 				statsCh    = make(chan autobuild.Stats)
-				logger     = slogtest.Make(t, &slogtest.Options{IgnoreErrors: !tc.expectStart}).Leveled(slog.LevelDebug)
+				logger     = testutil.Logger(t, loggerOpts...).Leveled(slog.LevelDebug)
 				enqueuer   = notificationstest.FakeEnqueuer{}
 				client, db = coderdtest.NewWithDatabase(t, &coderdtest.Options{
 					AutobuildTicker:          tickCh,
@@ -1177,11 +1180,8 @@ func TestExecutorFailedWorkspace(t *testing.T) {
 		var (
 			ticker = make(chan time.Time)
 			statCh = make(chan autobuild.Stats)
-			logger = slogtest.Make(t, &slogtest.Options{
-				// We ignore errors here since we expect to fail
-				// builds.
-				IgnoreErrors: true,
-			})
+			// We ignore errors here since we expect to fail builds.
+			logger     = testutil.Logger(t, testutil.WithIgnoreErrors())
 			failureTTL = time.Millisecond
 
 			client = coderdtest.New(t, &coderdtest.Options{
@@ -1229,11 +1229,8 @@ func TestExecutorInactiveWorkspace(t *testing.T) {
 		var (
 			ticker = make(chan time.Time)
 			statCh = make(chan autobuild.Stats)
-			logger = slogtest.Make(t, &slogtest.Options{
-				// We ignore errors here since we expect to fail
-				// builds.
-				IgnoreErrors: true,
-			})
+			// We ignore errors here since we expect to fail builds.
+			logger      = testutil.Logger(t, testutil.WithIgnoreErrors())
 			inactiveTTL = time.Millisecond
 
 			client = coderdtest.New(t, &coderdtest.Options{

--- a/coderd/coderdtest/coderdtest.go
+++ b/coderd/coderdtest/coderdtest.go
@@ -52,7 +52,6 @@ import (
 
 	"cdr.dev/slog/v3"
 	"cdr.dev/slog/v3/sloggers/sloghuman"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/archive"
 	"github.com/coder/coder/v2/coderd"
 	"github.com/coder/coder/v2/coderd/agentapi/metadatabatcher"
@@ -245,7 +244,7 @@ func NewOptions(t testing.TB, options *Options) (func(http.Handler), context.Can
 		options = &Options{}
 	}
 	if options.Logger == nil {
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug).Named("coderd")
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug).Named("coderd")
 		options.Logger = &logger
 	}
 	if options.GoogleTokenValidator == nil {

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -20,7 +20,6 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
@@ -5893,7 +5892,7 @@ func TestInsertAPIKey_AsPrebuildsUser(t *testing.T) {
 	}
 	ctx := dbauthz.As(testutil.Context(t, testutil.WaitShort), prebuildsSubj)
 	mDB := dbmock.NewMockStore(gomock.NewController(t))
-	log := slogtest.Make(t, nil)
+	log := testutil.Logger(t)
 	mDB.EXPECT().Wrappers().Times(1).Return([]string{})
 	dbz := dbauthz.New(mDB, nil, log, nil)
 	faker := gofakeit.New(0)
@@ -6235,7 +6234,7 @@ func TestGetLatestWorkspaceBuildByWorkspaceID_FastPath(t *testing.T) {
 		dbm.EXPECT().GetLatestWorkspaceBuildByWorkspaceID(gomock.Any(), workspace.ID).Return(build, nil).AnyTimes()
 		dbm.EXPECT().Wrappers().Return([]string{})
 
-		q := dbauthz.New(dbm, authorizer, slogtest.Make(t, nil), coderdtest.AccessControlStorePointer())
+		q := dbauthz.New(dbm, authorizer, testutil.Logger(t), coderdtest.AccessControlStorePointer())
 
 		result, err := q.GetLatestWorkspaceBuildByWorkspaceID(ctx, workspace.ID)
 		require.NoError(t, err)
@@ -6252,7 +6251,7 @@ func TestGetLatestWorkspaceBuildByWorkspaceID_FastPath(t *testing.T) {
 		dbm.EXPECT().GetLatestWorkspaceBuildByWorkspaceID(gomock.Any(), workspace.ID).Return(build, nil).AnyTimes()
 		dbm.EXPECT().Wrappers().Return([]string{})
 
-		q := dbauthz.New(dbm, authorizer, slogtest.Make(t, nil), coderdtest.AccessControlStorePointer())
+		q := dbauthz.New(dbm, authorizer, testutil.Logger(t), coderdtest.AccessControlStorePointer())
 
 		result, err := q.GetLatestWorkspaceBuildByWorkspaceID(ctx, workspace.ID)
 		require.NoError(t, err)
@@ -6311,7 +6310,7 @@ func TestGetWorkspaceAgentByID_FastPath(t *testing.T) {
 		// GetWorkspaceByAgentID should NOT be called
 		mockDB.EXPECT().GetWorkspaceAgentByID(gomock.Any(), agentID).Return(agent, nil)
 
-		q := dbauthz.New(mockDB, authorizer, slogtest.Make(t, nil), coderdtest.AccessControlStorePointer())
+		q := dbauthz.New(mockDB, authorizer, testutil.Logger(t), coderdtest.AccessControlStorePointer())
 
 		result, err := q.GetWorkspaceAgentByID(ctx, agentID)
 		require.NoError(t, err)
@@ -6330,7 +6329,7 @@ func TestGetWorkspaceAgentByID_FastPath(t *testing.T) {
 		mockDB.EXPECT().GetWorkspaceByAgentID(gomock.Any(), agentID).Return(workspace, nil)
 		mockDB.EXPECT().GetWorkspaceAgentByID(gomock.Any(), agentID).Return(agent, nil)
 
-		q := dbauthz.New(mockDB, authorizer, slogtest.Make(t, nil), coderdtest.AccessControlStorePointer())
+		q := dbauthz.New(mockDB, authorizer, testutil.Logger(t), coderdtest.AccessControlStorePointer())
 
 		result, err := q.GetWorkspaceAgentByID(ctx, agentID)
 		require.NoError(t, err)
@@ -6367,7 +6366,7 @@ func TestAuthorizeProvisionerJob_SystemFastPath(t *testing.T) {
 		// the test if either is invoked.
 		mockDB.EXPECT().GetProvisionerJobByID(gomock.Any(), jobID).Return(job, nil)
 
-		q := dbauthz.New(mockDB, authorizer, slogtest.Make(t, nil), coderdtest.AccessControlStorePointer())
+		q := dbauthz.New(mockDB, authorizer, testutil.Logger(t), coderdtest.AccessControlStorePointer())
 		ctx := dbauthz.AsSystemRestricted(context.Background())
 
 		got, err := q.GetProvisionerJobByID(ctx, jobID)
@@ -6393,7 +6392,7 @@ func TestAuthorizeProvisionerJob_SystemFastPath(t *testing.T) {
 		mockDB.EXPECT().Wrappers().Return([]string{})
 		mockDB.EXPECT().GetProvisionerJobByID(gomock.Any(), tvJobID).Return(tvJob, nil)
 
-		q := dbauthz.New(mockDB, authorizer, slogtest.Make(t, nil), coderdtest.AccessControlStorePointer())
+		q := dbauthz.New(mockDB, authorizer, testutil.Logger(t), coderdtest.AccessControlStorePointer())
 		ctx := dbauthz.AsSystemRestricted(context.Background())
 
 		got, err := q.GetProvisionerJobByID(ctx, tvJobID)
@@ -6436,7 +6435,7 @@ func TestAuthorizeProvisionerJob_SystemFastPath(t *testing.T) {
 		mockDB.EXPECT().GetWorkspaceBuildByJobID(gomock.Any(), jobID).Return(build, nil)
 		mockDB.EXPECT().GetWorkspaceByID(gomock.Any(), wsID).Return(workspace, nil)
 
-		q := dbauthz.New(mockDB, authorizer, slogtest.Make(t, nil), coderdtest.AccessControlStorePointer())
+		q := dbauthz.New(mockDB, authorizer, testutil.Logger(t), coderdtest.AccessControlStorePointer())
 		ctx := dbauthz.As(context.Background(), auditor)
 
 		_, err := q.GetProvisionerJobByID(ctx, jobID)

--- a/coderd/database/dbauthz/groupsauth_test.go
+++ b/coderd/database/dbauthz/groupsauth_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
@@ -16,6 +15,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/coderd/rbac/rolestore"
+	"github.com/coder/coder/v2/testutil"
 )
 
 // nolint:tparallel
@@ -24,9 +24,7 @@ func TestGroupsAuth(t *testing.T) {
 
 	authz := rbac.NewAuthorizer(prometheus.NewRegistry())
 	store, _ := dbtestutil.NewDB(t)
-	db := dbauthz.New(store, authz, slogtest.Make(t, &slogtest.Options{
-		IgnoreErrors: true,
-	}), coderdtest.AccessControlStorePointer())
+	db := dbauthz.New(store, authz, testutil.Logger(t, testutil.WithIgnoreErrors()), coderdtest.AccessControlStorePointer())
 
 	ownerCtx := dbauthz.As(context.Background(), rbac.Subject{
 		ID:     "owner",

--- a/coderd/database/dbfake/dbfake.go
+++ b/coderd/database/dbfake/dbfake.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
@@ -25,6 +24,7 @@ import (
 	"github.com/coder/coder/v2/coderd/wspubsub"
 	"github.com/coder/coder/v2/provisionersdk"
 	sdkproto "github.com/coder/coder/v2/provisionersdk/proto"
+	"github.com/coder/coder/v2/testutil"
 )
 
 var ownerCtx = dbauthz.As(context.Background(), rbac.Subject{
@@ -124,7 +124,7 @@ func WithJobErrorCode(code string) BuilderOption {
 func WorkspaceBuild(t testing.TB, db database.Store, ws database.WorkspaceTable) WorkspaceBuildBuilder {
 	return WorkspaceBuildBuilder{
 		t: t, db: db, ws: ws,
-		logger: slogtest.Make(t, &slogtest.Options{}).Named("dbfake").Leveled(slog.LevelDebug),
+		logger: testutil.Logger(t).Named("dbfake").Leveled(slog.LevelDebug),
 	}
 }
 
@@ -596,7 +596,7 @@ func ProvisionerJobResources(
 ) ProvisionerJobResourcesBuilder {
 	return ProvisionerJobResourcesBuilder{
 		t:          t,
-		logger:     slogtest.Make(t, &slogtest.Options{}).Named("dbfake").Leveled(slog.LevelDebug).With(slog.F("job_id", jobID)),
+		logger:     testutil.Logger(t).Named("dbfake").Leveled(slog.LevelDebug).With(slog.F("job_id", jobID)),
 		db:         db,
 		jobID:      jobID,
 		transition: transition,
@@ -647,7 +647,7 @@ type TemplateVersionBuilder struct {
 func TemplateVersion(t testing.TB, db database.Store) TemplateVersionBuilder {
 	return TemplateVersionBuilder{
 		t:                  t,
-		logger:             slogtest.Make(t, &slogtest.Options{}).Named("dbfake").Leveled(slog.LevelDebug),
+		logger:             testutil.Logger(t).Named("dbfake").Leveled(slog.LevelDebug),
 		db:                 db,
 		promote:            true,
 		autoCreateTemplate: true,

--- a/coderd/database/dbpurge/dbpurge_test.go
+++ b/coderd/database/dbpurge/dbpurge_test.go
@@ -22,7 +22,6 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/audit"
 	"github.com/coder/coder/v2/coderd/coderdtest/promhelp"
 	"github.com/coder/coder/v2/coderd/database"
@@ -80,7 +79,7 @@ func TestMetrics(t *testing.T) {
 		clk.Set(now).MustWait(ctx)
 
 		db, _ := dbtestutil.NewDB(t)
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 		user := dbgen.User(t, db, database.User{})
 
 		oldExpiredKey, _ := dbgen.APIKey(t, db, database.APIKey{
@@ -173,7 +172,7 @@ func TestMetrics(t *testing.T) {
 				return f(mDB)
 			}).MinTimes(1)
 
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 		done := awaitDoTick(ctx, t, clk)
 		closer := dbpurge.New(ctx, logger, mDB, &codersdk.DeploymentValues{}, reg, nopAuditorPtr(t), dbpurge.WithClock(clk))
@@ -210,7 +209,7 @@ func TestMetrics(t *testing.T) {
 			Return(xerrors.New("simulated database error")).
 			MinTimes(1)
 
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 		done := awaitDoTick(ctx, t, clk)
 		closer := dbpurge.New(ctx, logger, mDB, &codersdk.DeploymentValues{}, reg, nopAuditorPtr(t), dbpurge.WithClock(clk))
@@ -265,7 +264,7 @@ func TestMetrics(t *testing.T) {
 				return f(mDB)
 			}).MinTimes(1)
 
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 		done := awaitDoTick(ctx, t, clk)
 		closer := dbpurge.New(ctx, logger, mDB, &codersdk.DeploymentValues{}, reg, nopAuditorPtr(t), dbpurge.WithClock(clk))
@@ -309,7 +308,7 @@ func TestMetrics(t *testing.T) {
 		mDB.EXPECT().InTx(gomock.Any(), database.DefaultTXOptions().WithID("db_purge")).
 			Return(nil).MinTimes(1)
 
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 		done := awaitDoTick(ctx, t, clk)
 		closer := dbpurge.New(ctx, logger, mDB, &codersdk.DeploymentValues{}, reg, nopAuditorPtr(t), dbpurge.WithClock(clk))
@@ -362,7 +361,7 @@ func TestMetrics(t *testing.T) {
 				return f(mDB)
 			}).MinTimes(1)
 
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 		done := awaitDoTick(ctx, t, clk)
 		closer := dbpurge.New(ctx, logger, mDB, &codersdk.DeploymentValues{}, reg, nopAuditorPtr(t), dbpurge.WithClock(clk))
@@ -393,7 +392,7 @@ func TestDeleteOldWorkspaceAgentStats(t *testing.T) {
 	//       before using quarts.NewMock()
 	clk := quartz.NewReal()
 	db, _ := dbtestutil.NewDB(t)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 
 	defer func() {
 		if t.Failed() {
@@ -520,7 +519,7 @@ func TestDeleteOldWorkspaceAgentLogs(t *testing.T) {
 	tv := dbgen.TemplateVersion(t, db, database.TemplateVersion{OrganizationID: org.ID, CreatedBy: user.ID})
 	tmpl := dbgen.Template(t, db, database.Template{OrganizationID: org.ID, ActiveVersionID: tv.ID, CreatedBy: user.ID})
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	// Given the following:
 
@@ -829,7 +828,7 @@ func TestDeleteOldWorkspaceAgentLogsRetention(t *testing.T) {
 			oldTime := now.Add(-tc.logsAge)
 
 			db, _ := dbtestutil.NewDB(t, dbtestutil.WithDumpOnFailure())
-			logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+			logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 			org := dbgen.Organization(t, db, database.Organization{})
 			user := dbgen.User(t, db, database.User{})
 			_ = dbgen.OrganizationMember(t, db, database.OrganizationMember{UserID: user.ID, OrganizationID: org.ID})
@@ -871,7 +870,7 @@ func TestDeleteOldProvisionerDaemons(t *testing.T) {
 	clk := quartz.NewReal()
 	db, _ := dbtestutil.NewDB(t, dbtestutil.WithDumpOnFailure())
 	defaultOrg := dbgen.Organization(t, db, database.Organization{})
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitShort)
 	defer cancel()
@@ -981,7 +980,7 @@ func TestDeleteOldAuditLogConnectionEvents(t *testing.T) {
 	clk.Set(now).MustWait(ctx)
 
 	db, _ := dbtestutil.NewDB(t, dbtestutil.WithDumpOnFailure())
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	user := dbgen.User(t, db, database.User{})
 	org := dbgen.Organization(t, db, database.Organization{})
 
@@ -1184,7 +1183,7 @@ func TestDeleteOldTelemetryHeartbeats(t *testing.T) {
 	ctx := testutil.Context(t, testutil.WaitLong)
 
 	db, _, sqlDB := dbtestutil.NewDBWithSQLDB(t, dbtestutil.WithDumpOnFailure())
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	clk := quartz.NewMock(t)
 	now := clk.Now().UTC()
 
@@ -1278,7 +1277,7 @@ func TestDeleteOldConnectionLogs(t *testing.T) {
 			clk.Set(now).MustWait(ctx)
 
 			db, _ := dbtestutil.NewDB(t, dbtestutil.WithDumpOnFailure())
-			logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+			logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 			// Setup test fixtures.
 			user := dbgen.User(t, db, database.User{})
@@ -1467,7 +1466,7 @@ func TestDeleteOldAIBridgeRecords(t *testing.T) {
 			clk.Set(now).MustWait(ctx)
 
 			db, _ := dbtestutil.NewDB(t, dbtestutil.WithDumpOnFailure())
-			logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+			logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 			user := dbgen.User(t, db, database.User{})
 
 			// Create old AI Bridge interception (should be deleted when retention enabled).
@@ -1637,7 +1636,7 @@ func TestDeleteOldAuditLogs(t *testing.T) {
 			clk.Set(now).MustWait(ctx)
 
 			db, _ := dbtestutil.NewDB(t, dbtestutil.WithDumpOnFailure())
-			logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+			logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 			// Setup test fixtures.
 			user := dbgen.User(t, db, database.User{})
@@ -1706,7 +1705,7 @@ func TestDeleteOldAuditLogs(t *testing.T) {
 		clk.Set(now).MustWait(ctx)
 
 		db, _ := dbtestutil.NewDB(t, dbtestutil.WithDumpOnFailure())
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 		user := dbgen.User(t, db, database.User{})
 		org := dbgen.Organization(t, db, database.Organization{})
 
@@ -1844,7 +1843,7 @@ func TestDeleteExpiredAPIKeys(t *testing.T) {
 			clk.Set(now).MustWait(ctx)
 
 			db, _ := dbtestutil.NewDB(t, dbtestutil.WithDumpOnFailure())
-			logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+			logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 			user := dbgen.User(t, db, database.User{})
 
 			// Create API key that expired long ago.
@@ -2030,7 +2029,7 @@ func TestPurgeChatDebugRuns(t *testing.T) {
 				clk.Set(now).MustWait(ctx)
 
 				db, _, rawDB := dbtestutil.NewDBWithSQLDB(t, dbtestutil.WithDumpOnFailure())
-				logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+				logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 				reg := prometheus.NewRegistry()
 				deps := setupChatDebugDeps(t, db)
 				require.NoError(t, db.UpsertChatDebugRetentionDays(ctx, int32(7)))
@@ -2071,7 +2070,7 @@ func TestPurgeChatDebugRuns(t *testing.T) {
 				clk.Set(now).MustWait(ctx)
 
 				db, _, rawDB := dbtestutil.NewDBWithSQLDB(t, dbtestutil.WithDumpOnFailure())
-				logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+				logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 				deps := setupChatDebugDeps(t, db)
 				require.NoError(t, db.UpsertChatDebugRetentionDays(ctx, int32(0)))
 
@@ -2096,7 +2095,7 @@ func TestPurgeChatDebugRuns(t *testing.T) {
 				clk.Set(now).MustWait(ctx)
 
 				db, _, rawDB := dbtestutil.NewDBWithSQLDB(t, dbtestutil.WithDumpOnFailure())
-				logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+				logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 				deps := setupChatDebugDeps(t, db)
 				require.NoError(t, db.UpsertChatRetentionDays(ctx, int32(30)))
 				require.NoError(t, db.UpsertChatDebugRetentionDays(ctx, int32(0)))
@@ -2199,7 +2198,7 @@ func TestDeleteOldChatFiles(t *testing.T) {
 				clk.Set(now).MustWait(ctx)
 
 				db, _, rawDB := dbtestutil.NewDBWithSQLDB(t, dbtestutil.WithDumpOnFailure())
-				logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+				logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 				deps := setupChatDeps(t, db)
 
 				// Disable retention.
@@ -2230,7 +2229,7 @@ func TestDeleteOldChatFiles(t *testing.T) {
 				clk.Set(now).MustWait(ctx)
 
 				db, _, rawDB := dbtestutil.NewDBWithSQLDB(t, dbtestutil.WithDumpOnFailure())
-				logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+				logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 				deps := setupChatDeps(t, db)
 
 				err := db.UpsertChatRetentionDays(ctx, int32(30))
@@ -2284,7 +2283,7 @@ func TestDeleteOldChatFiles(t *testing.T) {
 				clk.Set(now).MustWait(ctx)
 
 				db, _, rawDB := dbtestutil.NewDBWithSQLDB(t, dbtestutil.WithDumpOnFailure())
-				logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+				logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 				deps := setupChatDeps(t, db)
 
 				err := db.UpsertChatRetentionDays(ctx, int32(30))
@@ -2335,7 +2334,7 @@ func TestDeleteOldChatFiles(t *testing.T) {
 				clk.Set(now).MustWait(ctx)
 
 				db, _, rawDB := dbtestutil.NewDBWithSQLDB(t, dbtestutil.WithDumpOnFailure())
-				logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+				logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 				deps := setupChatDeps(t, db)
 
 				err := db.UpsertChatRetentionDays(ctx, int32(30))
@@ -2630,7 +2629,7 @@ func newArchiveHarness(t *testing.T, now time.Time) *archiveHarness {
 	clk := quartz.NewMock(t)
 	clk.Set(now).MustWait(ctx)
 	db, _, rawDB := dbtestutil.NewDBWithSQLDB(t, dbtestutil.WithDumpOnFailure())
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	return &archiveHarness{
 		ctx:    ctx,
 		clk:    clk,

--- a/coderd/database/dbrollup/dbrollup_test.go
+++ b/coderd/database/dbrollup/dbrollup_test.go
@@ -11,7 +11,6 @@ import (
 	"go.uber.org/goleak"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbrollup"
@@ -136,7 +135,7 @@ func TestRollupTemplateUsageStats(t *testing.T) {
 	t.Parallel()
 
 	db, ps := dbtestutil.NewDB(t, dbtestutil.WithDumpOnFailure())
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 
 	anHourAgo := dbtime.Now().Add(-time.Hour).Truncate(time.Hour).UTC()
 	anHourAndSixMonthsAgo := anHourAgo.AddDate(0, -6, 0).UTC()

--- a/coderd/database/pubsub/pubsub_linux_test.go
+++ b/coderd/database/pubsub/pubsub_linux_test.go
@@ -17,7 +17,6 @@ import (
 
 	"cdr.dev/slog/v3"
 	"cdr.dev/slog/v3/sloggers/sloghuman"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/pubsub"
 	"github.com/coder/coder/v2/coderd/database/pubsub/psmock"
@@ -170,7 +169,7 @@ func TestPubsub_Disconnect(t *testing.T) {
 
 	ctx, cancelFunc := context.WithTimeout(context.Background(), testutil.WaitSuperLong)
 	defer cancelFunc()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	ps, err := pubsub.New(ctx, logger, db, connectionURL)
 	require.NoError(t, err)
 	defer ps.Close()
@@ -355,7 +354,7 @@ func TestMeasureLatency(t *testing.T) {
 		t.Parallel()
 
 		var buf bytes.Buffer
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		logger = logger.AppendSinks(sloghuman.Sink(&buf))
 
 		lm := pubsub.NewLatencyMeasurer(logger)

--- a/coderd/database/pubsub/pubsub_test.go
+++ b/coderd/database/pubsub/pubsub_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/database/pubsub"
 	"github.com/coder/coder/v2/testutil"
@@ -121,9 +120,7 @@ func TestPGPubsubDriver(t *testing.T) {
 	t.Parallel()
 
 	ctx := testutil.Context(t, testutil.WaitLong)
-	logger := slogtest.Make(t, &slogtest.Options{
-		IgnoreErrors: true,
-	}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 
 	connectionURL, err := dbtestutil.Open(t)
 	require.NoError(t, err)

--- a/coderd/database/pubsub/watchdog_test.go
+++ b/coderd/database/pubsub/watchdog_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database/pubsub"
 	"github.com/coder/coder/v2/testutil"
 	"github.com/coder/quartz"
@@ -17,7 +16,7 @@ func TestWatchdog_NoTimeout(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.Context(t, testutil.WaitShort)
 	mClock := quartz.NewMock(t)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	fPS := newFakePubsub()
 
 	// trap the ticker and timer.Stop() calls
@@ -75,7 +74,7 @@ func TestWatchdog_Timeout(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.Context(t, testutil.WaitShort)
 	mClock := quartz.NewMock(t)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	fPS := newFakePubsub()
 
 	// trap the ticker calls

--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
@@ -120,7 +119,7 @@ func TestGetDeploymentWorkspaceAgentUsageStats(t *testing.T) {
 
 		db, _ := dbtestutil.NewDB(t)
 		authz := rbac.NewAuthorizer(prometheus.NewRegistry())
-		db = dbauthz.New(db, authz, slogtest.Make(t, &slogtest.Options{}), coderdtest.AccessControlStorePointer())
+		db = dbauthz.New(db, authz, testutil.Logger(t), coderdtest.AccessControlStorePointer())
 		ctx := context.Background()
 		agentID := uuid.New()
 		// Since the queries exclude the current minute
@@ -192,7 +191,7 @@ func TestGetDeploymentWorkspaceAgentUsageStats(t *testing.T) {
 
 		db, _ := dbtestutil.NewDB(t)
 		authz := rbac.NewAuthorizer(prometheus.NewRegistry())
-		db = dbauthz.New(db, authz, slogtest.Make(t, &slogtest.Options{}), coderdtest.AccessControlStorePointer())
+		db = dbauthz.New(db, authz, testutil.Logger(t), coderdtest.AccessControlStorePointer())
 		ctx := context.Background()
 		agentID := uuid.New()
 		// Since the queries exclude the current minute
@@ -715,7 +714,7 @@ func TestGetWorkspaceAgentUsageStats(t *testing.T) {
 
 		db, _ := dbtestutil.NewDB(t)
 		authz := rbac.NewAuthorizer(prometheus.NewRegistry())
-		db = dbauthz.New(db, authz, slogtest.Make(t, &slogtest.Options{}), coderdtest.AccessControlStorePointer())
+		db = dbauthz.New(db, authz, testutil.Logger(t), coderdtest.AccessControlStorePointer())
 		ctx := context.Background()
 		// Since the queries exclude the current minute
 		insertTime := dbtime.Now().Add(-time.Minute)
@@ -857,7 +856,7 @@ func TestGetWorkspaceAgentUsageStats(t *testing.T) {
 
 		db, _ := dbtestutil.NewDB(t)
 		authz := rbac.NewAuthorizer(prometheus.NewRegistry())
-		db = dbauthz.New(db, authz, slogtest.Make(t, &slogtest.Options{}), coderdtest.AccessControlStorePointer())
+		db = dbauthz.New(db, authz, testutil.Logger(t), coderdtest.AccessControlStorePointer())
 		ctx := context.Background()
 		// Since the queries exclude the current minute
 		insertTime := dbtime.Now().Add(-time.Minute)
@@ -1215,7 +1214,7 @@ func TestGetAuthorizedWorkspacesAndAgentsByOwnerID(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitMedium)
 
-		authzdb := dbauthz.New(db, authorizer, slogtest.Make(t, &slogtest.Options{}), coderdtest.AccessControlStorePointer())
+		authzdb := dbauthz.New(db, authorizer, testutil.Logger(t), coderdtest.AccessControlStorePointer())
 
 		userSubject, _, err := httpmw.UserRBACSubject(ctx, authzdb, user.ID, rbac.ExpandableScope(rbac.ScopeAll))
 		require.NoError(t, err)
@@ -1381,7 +1380,7 @@ func TestGetAuthorizedChats(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitMedium)
 
-		authzdb := dbauthz.New(db, authorizer, slogtest.Make(t, &slogtest.Options{}), coderdtest.AccessControlStorePointer())
+		authzdb := dbauthz.New(db, authorizer, testutil.Logger(t), coderdtest.AccessControlStorePointer())
 
 		// As member: should see only own 2 chats.
 		memberSubject, _, err := httpmw.UserRBACSubject(ctx, authzdb, member.ID, rbac.ExpandableScope(rbac.ScopeAll))
@@ -2869,7 +2868,7 @@ func TestAuthorizedAuditLogs(t *testing.T) {
 	var allLogs []database.AuditLog
 	db, _ := dbtestutil.NewDB(t)
 	authz := rbac.NewAuthorizer(prometheus.NewRegistry())
-	db = dbauthz.New(db, authz, slogtest.Make(t, &slogtest.Options{}), coderdtest.AccessControlStorePointer())
+	db = dbauthz.New(db, authz, testutil.Logger(t), coderdtest.AccessControlStorePointer())
 
 	siteWideIDs := []uuid.UUID{uuid.New(), uuid.New()}
 	for _, id := range siteWideIDs {
@@ -3059,7 +3058,7 @@ func TestGetAuthorizedConnectionLogsOffset(t *testing.T) {
 	var allLogs []database.ConnectionLog
 	db, _ := dbtestutil.NewDB(t)
 	authz := rbac.NewAuthorizer(prometheus.NewRegistry())
-	authDb := dbauthz.New(db, authz, slogtest.Make(t, &slogtest.Options{}), coderdtest.AccessControlStorePointer())
+	authDb := dbauthz.New(db, authz, testutil.Logger(t), coderdtest.AccessControlStorePointer())
 
 	orgA := dbfake.Organization(t, db).Do()
 	orgB := dbfake.Organization(t, db).Do()
@@ -7988,7 +7987,7 @@ func TestUserSecretsAuthorization(t *testing.T) {
 	// Use raw database and wrap with dbauthz for authorization testing
 	db, _ := dbtestutil.NewDB(t)
 	authorizer := rbac.NewStrictCachingAuthorizer(prometheus.NewRegistry())
-	authDB := dbauthz.New(db, authorizer, slogtest.Make(t, &slogtest.Options{}), coderdtest.AccessControlStorePointer())
+	authDB := dbauthz.New(db, authorizer, testutil.Logger(t), coderdtest.AccessControlStorePointer())
 
 	// Create test users
 	user1 := dbgen.User(t, db, database.User{})

--- a/coderd/debug_test.go
+++ b/coderd/debug_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/healthcheck"
@@ -99,7 +98,7 @@ func TestDebugHealth(t *testing.T) {
 
 		var (
 			// Need to ignore errors due to ctx timeout
-			logger      = slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+			logger      = testutil.Logger(t, testutil.WithIgnoreErrors())
 			ctx, cancel = context.WithTimeout(context.Background(), testutil.WaitShort)
 			done        = make(chan struct{})
 			client      = coderdtest.New(t, &coderdtest.Options{

--- a/coderd/files/cache_test.go
+++ b/coderd/files/cache_test.go
@@ -14,7 +14,6 @@ import (
 	"go.uber.org/mock/gomock"
 	"golang.org/x/sync/errgroup"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/coderdtest/promhelp"
 	"github.com/coder/coder/v2/coderd/database"
@@ -340,7 +339,7 @@ func TestRelease(t *testing.T) {
 func cacheAuthzSetup(t *testing.T) (database.Store, *files.Cache, *coderdtest.RecordingAuthorizer) {
 	t.Helper()
 
-	logger := slogtest.Make(t, &slogtest.Options{})
+	logger := testutil.Logger(t)
 	reg := prometheus.NewRegistry()
 
 	db, _ := dbtestutil.NewDB(t)

--- a/coderd/httpapi/httpapi_test.go
+++ b/coderd/httpapi/httpapi_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/testutil"
@@ -263,7 +262,7 @@ func TestOneWayWebSocketEventSender(t *testing.T) {
 			req.Proto = p.proto
 
 			writer := newOneWayWriter(t)
-			_, _, err := httpapi.OneWayWebSocketEventSender(slogtest.Make(t, nil))(writer, req)
+			_, _, err := httpapi.OneWayWebSocketEventSender(testutil.Logger(t))(writer, req)
 			require.ErrorContains(t, err, p.proto)
 		}
 	})
@@ -274,7 +273,7 @@ func TestOneWayWebSocketEventSender(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitShort)
 		req := newBaseRequest(ctx)
 		writer := newOneWayWriter(t)
-		send, _, err := httpapi.OneWayWebSocketEventSender(slogtest.Make(t, nil))(writer, req)
+		send, _, err := httpapi.OneWayWebSocketEventSender(testutil.Logger(t))(writer, req)
 		require.NoError(t, err)
 
 		serverPayload := codersdk.ServerSentEvent{
@@ -300,7 +299,7 @@ func TestOneWayWebSocketEventSender(t *testing.T) {
 		ctx, cancel := context.WithCancel(testutil.Context(t, testutil.WaitShort))
 		req := newBaseRequest(ctx)
 		writer := newOneWayWriter(t)
-		_, done, err := httpapi.OneWayWebSocketEventSender(slogtest.Make(t, nil))(writer, req)
+		_, done, err := httpapi.OneWayWebSocketEventSender(testutil.Logger(t))(writer, req)
 		require.NoError(t, err)
 
 		successC := make(chan bool)
@@ -324,7 +323,7 @@ func TestOneWayWebSocketEventSender(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitShort)
 		req := newBaseRequest(ctx)
 		writer := newOneWayWriter(t)
-		_, done, err := httpapi.OneWayWebSocketEventSender(slogtest.Make(t, nil))(writer, req)
+		_, done, err := httpapi.OneWayWebSocketEventSender(testutil.Logger(t))(writer, req)
 		require.NoError(t, err)
 
 		successC := make(chan bool)
@@ -354,7 +353,7 @@ func TestOneWayWebSocketEventSender(t *testing.T) {
 		ctx, cancel := context.WithCancel(testutil.Context(t, testutil.WaitShort))
 		req := newBaseRequest(ctx)
 		writer := newOneWayWriter(t)
-		send, done, err := httpapi.OneWayWebSocketEventSender(slogtest.Make(t, nil))(writer, req)
+		send, done, err := httpapi.OneWayWebSocketEventSender(testutil.Logger(t))(writer, req)
 		require.NoError(t, err)
 
 		successC := make(chan bool)
@@ -395,7 +394,7 @@ func TestOneWayWebSocketEventSender(t *testing.T) {
 		ctx := testutil.Context(t, timeout)
 		req := newBaseRequest(ctx)
 		writer := newOneWayWriter(t)
-		_, _, err := httpapi.OneWayWebSocketEventSender(slogtest.Make(t, nil))(writer, req)
+		_, _, err := httpapi.OneWayWebSocketEventSender(testutil.Logger(t))(writer, req)
 		require.NoError(t, err)
 
 		type Result struct {

--- a/coderd/idpsync/group_test.go
+++ b/coderd/idpsync/group_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
@@ -31,7 +30,7 @@ func TestParseGroupClaims(t *testing.T) {
 	t.Run("EmptyConfig", func(t *testing.T) {
 		t.Parallel()
 
-		s := idpsync.NewAGPLSync(slogtest.Make(t, &slogtest.Options{}),
+		s := idpsync.NewAGPLSync(testutil.Logger(t),
 			runtimeconfig.NewManager(),
 			idpsync.DeploymentSyncSettings{})
 
@@ -46,7 +45,7 @@ func TestParseGroupClaims(t *testing.T) {
 	t.Run("NotInAllowList", func(t *testing.T) {
 		t.Parallel()
 
-		s := idpsync.NewAGPLSync(slogtest.Make(t, &slogtest.Options{}),
+		s := idpsync.NewAGPLSync(testutil.Logger(t),
 			runtimeconfig.NewManager(),
 			idpsync.DeploymentSyncSettings{
 				GroupField: "groups",
@@ -73,7 +72,7 @@ func TestParseGroupClaims(t *testing.T) {
 	t.Run("InAllowList", func(t *testing.T) {
 		t.Parallel()
 
-		s := idpsync.NewAGPLSync(slogtest.Make(t, &slogtest.Options{}),
+		s := idpsync.NewAGPLSync(testutil.Logger(t),
 			runtimeconfig.NewManager(),
 			idpsync.DeploymentSyncSettings{
 				GroupField: "groups",
@@ -278,7 +277,7 @@ func TestGroupSyncTable(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			db, _ := dbtestutil.NewDB(t)
 			manager := runtimeconfig.NewManager()
-			s := idpsync.NewAGPLSync(slogtest.Make(t, &slogtest.Options{}),
+			s := idpsync.NewAGPLSync(testutil.Logger(t),
 				manager,
 				idpsync.DeploymentSyncSettings{
 					GroupField: "groups",
@@ -318,7 +317,7 @@ func TestGroupSyncTable(t *testing.T) {
 	t.Run("AllTogether", func(t *testing.T) {
 		db, _ := dbtestutil.NewDB(t)
 		manager := runtimeconfig.NewManager()
-		s := idpsync.NewAGPLSync(slogtest.Make(t, &slogtest.Options{}),
+		s := idpsync.NewAGPLSync(testutil.Logger(t),
 			manager,
 			// Also sync the default org!
 			idpsync.DeploymentSyncSettings{
@@ -400,7 +399,7 @@ func TestSyncDisabled(t *testing.T) {
 
 	db, _ := dbtestutil.NewDB(t)
 	manager := runtimeconfig.NewManager()
-	s := idpsync.NewAGPLSync(slogtest.Make(t, &slogtest.Options{}),
+	s := idpsync.NewAGPLSync(testutil.Logger(t),
 		manager,
 		idpsync.DeploymentSyncSettings{},
 	)
@@ -578,7 +577,7 @@ func TestApplyGroupDifference(t *testing.T) {
 				}
 			}
 
-			s := idpsync.NewAGPLSync(slogtest.Make(t, &slogtest.Options{}), mgr, idpsync.FromDeploymentValues(coderdtest.DeploymentValues(t)))
+			s := idpsync.NewAGPLSync(testutil.Logger(t), mgr, idpsync.FromDeploymentValues(coderdtest.DeploymentValues(t)))
 			err = s.ApplyGroupDifference(context.Background(), db, user, tc.Add, tc.Remove)
 			require.NoError(t, err)
 

--- a/coderd/idpsync/organizations_test.go
+++ b/coderd/idpsync/organizations_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbfake"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
@@ -94,7 +93,7 @@ func TestParseOrganizationClaims(t *testing.T) {
 		t.Parallel()
 
 		// AGPL has limited behavior
-		s := idpsync.NewAGPLSync(slogtest.Make(t, &slogtest.Options{}),
+		s := idpsync.NewAGPLSync(testutil.Logger(t),
 			runtimeconfig.NewManager(),
 			idpsync.DeploymentSyncSettings{
 				OrganizationField: "orgs",
@@ -143,7 +142,7 @@ func TestSyncOrganizations(t *testing.T) {
 
 		// Now sync the user to the deleted organization
 		s := idpsync.NewAGPLSync(
-			slogtest.Make(t, &slogtest.Options{}),
+			testutil.Logger(t),
 			runtimeconfig.NewManager(),
 			idpsync.DeploymentSyncSettings{
 				OrganizationField: "orgs",
@@ -190,7 +189,7 @@ func TestSyncOrganizations(t *testing.T) {
 
 		// Now sync the user to the deleted organization
 		s := idpsync.NewAGPLSync(
-			slogtest.Make(t, &slogtest.Options{}),
+			testutil.Logger(t),
 			runtimeconfig.NewManager(),
 			idpsync.DeploymentSyncSettings{
 				OrganizationField: "orgs",

--- a/coderd/idpsync/role_test.go
+++ b/coderd/idpsync/role_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbmock"
@@ -192,9 +191,7 @@ func TestRoleSyncTable(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			db, _ := dbtestutil.NewDB(t)
 			manager := runtimeconfig.NewManager()
-			s := idpsync.NewAGPLSync(slogtest.Make(t, &slogtest.Options{
-				IgnoreErrors: true,
-			}),
+			s := idpsync.NewAGPLSync(testutil.Logger(t, testutil.WithIgnoreErrors()),
 				manager,
 				idpsync.DeploymentSyncSettings{
 					SiteRoleField: "roles",
@@ -226,9 +223,7 @@ func TestRoleSyncTable(t *testing.T) {
 	t.Run("AllTogether", func(t *testing.T) {
 		db, _ := dbtestutil.NewDB(t)
 		manager := runtimeconfig.NewManager()
-		s := idpsync.NewAGPLSync(slogtest.Make(t, &slogtest.Options{
-			IgnoreErrors: true,
-		}),
+		s := idpsync.NewAGPLSync(testutil.Logger(t, testutil.WithIgnoreErrors()),
 			manager,
 			// Also sync some site wide roles
 			idpsync.DeploymentSyncSettings{
@@ -300,7 +295,7 @@ func TestNoopNoDiff(t *testing.T) {
 	mDB := dbmock.NewMockStore(ctrl)
 
 	mgr := runtimeconfig.NewManager()
-	s := idpsync.NewAGPLSync(slogtest.Make(t, &slogtest.Options{}), mgr, idpsync.DeploymentSyncSettings{
+	s := idpsync.NewAGPLSync(testutil.Logger(t), mgr, idpsync.DeploymentSyncSettings{
 		SiteRoleField:    "",
 		SiteRoleMapping:  nil,
 		SiteDefaultRoles: nil,

--- a/coderd/insights_test.go
+++ b/coderd/insights_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/agent/agenttest"
 	agentproto "github.com/coder/coder/v2/agent/proto"
 	"github.com/coder/coder/v2/coderd/coderdtest"
@@ -244,7 +243,7 @@ func TestUserLatencyInsights(t *testing.T) {
 	t.Parallel()
 
 	db, ps := dbtestutil.NewDB(t)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	client := coderdtest.New(t, &coderdtest.Options{
 		Database:                  db,
 		Pubsub:                    ps,

--- a/coderd/notifications/dispatch/inbox_test.go
+++ b/coderd/notifications/dispatch/inbox_test.go
@@ -8,19 +8,19 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/notifications"
 	"github.com/coder/coder/v2/coderd/notifications/dispatch"
 	"github.com/coder/coder/v2/coderd/notifications/types"
+	"github.com/coder/coder/v2/testutil"
 )
 
 func TestInbox(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	tests := []struct {
 		name          string
 		msgID         uuid.UUID

--- a/coderd/notifications/dispatch/smtp_test.go
+++ b/coderd/notifications/dispatch/smtp_test.go
@@ -15,7 +15,6 @@ import (
 	"go.uber.org/goleak"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/notifications/dispatch"
 	"github.com/coder/coder/v2/coderd/notifications/dispatch/smtptest"
 	"github.com/coder/coder/v2/coderd/notifications/types"
@@ -49,7 +48,7 @@ func TestSMTP(t *testing.T) {
 		keyFile  = "smtptest/fixtures/server.key"
 	)
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true, IgnoredErrorIs: []error{}}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	tests := []struct {
 		name             string
 		cfg              codersdk.NotificationsEmailConfig
@@ -566,7 +565,7 @@ func TestSMTPEnvelopeAndHeaders(t *testing.T) {
 			t.Parallel()
 
 			ctx := testutil.Context(t, testutil.WaitShort)
-			logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+			logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 
 			cfg := codersdk.NotificationsEmailConfig{
 				Hello: serpent.String(hello),

--- a/coderd/notifications/dispatch/webhook_test.go
+++ b/coderd/notifications/dispatch/webhook_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/notifications/dispatch"
 	"github.com/coder/coder/v2/coderd/notifications/types"
 	"github.com/coder/coder/v2/codersdk"
@@ -98,7 +97,7 @@ func TestWebhook(t *testing.T) {
 		},
 	}
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 
 	// nolint:paralleltest // Irrelevant as of Go v1.22
 	for _, tc := range tests {

--- a/coderd/notifications/reports/generator_internal_test.go
+++ b/coderd/notifications/reports/generator_internal_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
@@ -23,6 +22,7 @@ import (
 	"github.com/coder/coder/v2/coderd/notifications"
 	"github.com/coder/coder/v2/coderd/notifications/notificationstest"
 	"github.com/coder/coder/v2/coderd/rbac"
+	"github.com/coder/coder/v2/testutil"
 	"github.com/coder/quartz"
 )
 
@@ -554,7 +554,7 @@ func setup(t *testing.T) (context.Context, slog.Logger, database.Store, pubsub.P
 	t.Helper()
 
 	ctx := dbauthz.AsSystemRestricted(context.Background())
-	logger := slogtest.Make(t, &slogtest.Options{})
+	logger := testutil.Logger(t)
 	db, ps := dbtestutil.NewDB(t)
 	notifyEnq := &notificationstest.FakeEnqueuer{}
 	clk := quartz.NewMock(t)

--- a/coderd/parameters_internal_test.go
+++ b/coderd/parameters_internal_test.go
@@ -9,7 +9,6 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/coderd/rbac/policy"
@@ -107,12 +106,9 @@ func TestCanSubscribeUserSecretEventsRequiresSecretRead(t *testing.T) {
 		t.Parallel()
 
 		auth := &recordingAuthorizer{}
-		logger := slogtest.Make(t, &slogtest.Options{
-			IgnoredErrorIs: []error{},
-			IgnoreErrorFn: func(entry slog.SinkEntry) bool {
-				return entry.Message == "no authorization actor for user secret event subscription"
-			},
-		})
+		logger := testutil.Logger(t, testutil.WithIgnoreErrorFn(func(entry slog.SinkEntry) bool {
+			return entry.Message == "no authorization actor for user secret event subscription"
+		}))
 		api := &API{
 			Options: &Options{
 				Logger: logger,

--- a/coderd/prebuilds/claim_test.go
+++ b/coderd/prebuilds/claim_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database/pubsub"
 	"github.com/coder/coder/v2/coderd/prebuilds"
 	"github.com/coder/coder/v2/codersdk/agentsdk"
@@ -69,7 +68,7 @@ func TestPubsubWorkspaceClaimListener(t *testing.T) {
 		t.Parallel()
 
 		ps := pubsub.NewInMemory()
-		listener := prebuilds.NewPubsubWorkspaceClaimListener(ps, slogtest.Make(t, nil))
+		listener := prebuilds.NewPubsubWorkspaceClaimListener(ps, testutil.Logger(t))
 
 		workspaceID := uuid.New()
 		events, cancelFunc, err := listener.ListenForWorkspaceClaims(context.Background(), workspaceID)
@@ -94,7 +93,7 @@ func TestPubsubWorkspaceClaimListener(t *testing.T) {
 		t.Parallel()
 
 		ps := pubsub.NewInMemory()
-		listener := prebuilds.NewPubsubWorkspaceClaimListener(ps, slogtest.Make(t, nil))
+		listener := prebuilds.NewPubsubWorkspaceClaimListener(ps, testutil.Logger(t))
 
 		workspaceID := uuid.New()
 		otherWorkspaceID := uuid.New()
@@ -120,7 +119,7 @@ func TestPubsubWorkspaceClaimListener(t *testing.T) {
 		t.Parallel()
 
 		ps := &brokenPubsub{}
-		listener := prebuilds.NewPubsubWorkspaceClaimListener(ps, slogtest.Make(t, nil))
+		listener := prebuilds.NewPubsubWorkspaceClaimListener(ps, testutil.Logger(t))
 
 		_, _, err := listener.ListenForWorkspaceClaims(context.Background(), uuid.New())
 		require.ErrorContains(t, err, "failed to subscribe to prebuild claimed channel")

--- a/coderd/prometheusmetrics/aggregator_internal_test.go
+++ b/coderd/prometheusmetrics/aggregator_internal_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	agentproto "github.com/coder/coder/v2/agent/proto"
 	"github.com/coder/coder/v2/coderd/agentmetrics"
 	"github.com/coder/coder/v2/testutil"
@@ -33,7 +32,7 @@ func TestDescCache_DescExpire(t *testing.T) {
 
 	// given
 	registry := prometheus.NewRegistry()
-	ma, err := NewMetricsAggregator(slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}), registry, time.Millisecond, agentmetrics.LabelAll)
+	ma, err := NewMetricsAggregator(testutil.Logger(t, testutil.WithIgnoreErrors()), registry, time.Millisecond, agentmetrics.LabelAll)
 	require.NoError(t, err)
 
 	given := []*agentproto.Stats_Metric{
@@ -65,7 +64,7 @@ func TestDescCacheTimestampUpdate(t *testing.T) {
 
 	mClock := quartz.NewMock(t)
 	registry := prometheus.NewRegistry()
-	ma, err := NewMetricsAggregator(slogtest.Make(t, nil), registry, time.Hour, nil, WithClock(mClock))
+	ma, err := NewMetricsAggregator(testutil.Logger(t), registry, time.Hour, nil, WithClock(mClock))
 	require.NoError(t, err)
 
 	baseLabelNames := []string{"label1", "label2"}

--- a/coderd/prometheusmetrics/aggregator_test.go
+++ b/coderd/prometheusmetrics/aggregator_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	agentproto "github.com/coder/coder/v2/agent/proto"
 	"github.com/coder/coder/v2/coderd/agentmetrics"
 	"github.com/coder/coder/v2/coderd/prometheusmetrics"
@@ -41,7 +40,7 @@ func TestUpdateMetrics_MetricsDoNotExpire(t *testing.T) {
 
 	// given
 	registry := prometheus.NewRegistry()
-	metricsAggregator, err := prometheusmetrics.NewMetricsAggregator(slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}), registry, time.Hour, nil) // time.Hour, so metrics won't expire
+	metricsAggregator, err := prometheusmetrics.NewMetricsAggregator(testutil.Logger(t, testutil.WithIgnoreErrors()), registry, time.Hour, nil) // time.Hour, so metrics won't expire
 	require.NoError(t, err)
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
@@ -269,7 +268,7 @@ func TestUpdateMetrics_MetricsExpire(t *testing.T) {
 
 	// given
 	registry := prometheus.NewRegistry()
-	metricsAggregator, err := prometheusmetrics.NewMetricsAggregator(slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}), registry, time.Millisecond, agentmetrics.LabelAll)
+	metricsAggregator, err := prometheusmetrics.NewMetricsAggregator(testutil.Logger(t, testutil.WithIgnoreErrors()), registry, time.Millisecond, agentmetrics.LabelAll)
 	require.NoError(t, err)
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
@@ -595,7 +594,7 @@ func TestLabelsAggregation(t *testing.T) {
 
 			// given
 			registry := prometheus.NewRegistry()
-			metricsAggregator, err := prometheusmetrics.NewMetricsAggregator(slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}), registry, time.Hour, tc.aggregateOn) // time.Hour, so metrics won't expire
+			metricsAggregator, err := prometheusmetrics.NewMetricsAggregator(testutil.Logger(t, testutil.WithIgnoreErrors()), registry, time.Hour, tc.aggregateOn) // time.Hour, so metrics won't expire
 			require.NoError(t, err)
 
 			ctx, cancelFunc := context.WithCancel(context.Background())
@@ -652,7 +651,7 @@ func benchmarkRunner(b *testing.B, aggregateByLabels []string) {
 
 	// given
 	registry := prometheus.NewRegistry()
-	metricsAggregator := must(prometheusmetrics.NewMetricsAggregator(slogtest.Make(b, &slogtest.Options{IgnoreErrors: true}), registry, time.Hour, aggregateByLabels))
+	metricsAggregator := must(prometheusmetrics.NewMetricsAggregator(testutil.Logger(b, testutil.WithIgnoreErrors()), registry, time.Hour, aggregateByLabels))
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	b.Cleanup(cancelFunc)

--- a/coderd/prometheusmetrics/insights/metricscollector_test.go
+++ b/coderd/prometheusmetrics/insights/metricscollector_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	agentproto "github.com/coder/coder/v2/agent/proto"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
@@ -33,7 +32,7 @@ import (
 func TestCollectInsights(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	db, ps := dbtestutil.NewDB(t, dbtestutil.WithDumpOnFailure())
 
 	options := &coderdtest.Options{

--- a/coderd/prometheusmetrics/prometheusmetrics_test.go
+++ b/coderd/prometheusmetrics/prometheusmetrics_test.go
@@ -19,7 +19,6 @@ import (
 	"tailscale.com/tailcfg"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	agentproto "github.com/coder/coder/v2/agent/proto"
 	"github.com/coder/coder/v2/coderd/agentmetrics"
 	"github.com/coder/coder/v2/coderd/coderdtest"
@@ -583,9 +582,7 @@ func TestAgents(t *testing.T) {
 	defer cancelFunc()
 
 	// when
-	closeFunc, err := prometheusmetrics.Agents(ctx, slogtest.Make(t, &slogtest.Options{
-		IgnoreErrors: true,
-	}), registry, db, &coordinatorPtr, derpMapFn, agentInactiveDisconnectTimeout, 50*time.Millisecond)
+	closeFunc, err := prometheusmetrics.Agents(ctx, testutil.Logger(t, testutil.WithIgnoreErrors()), registry, db, &coordinatorPtr, derpMapFn, agentInactiveDisconnectTimeout, 50*time.Millisecond)
 	require.NoError(t, err)
 	t.Cleanup(closeFunc)
 
@@ -723,9 +720,7 @@ func TestAgentStats(t *testing.T) {
 	//
 	// Set initialCreateAfter to some time in the past, so that AgentStats would include all above PostStats,
 	// and it doesn't depend on the real time.
-	closeFunc, err := prometheusmetrics.AgentStats(ctx, slogtest.Make(t, &slogtest.Options{
-		IgnoreErrors: true,
-	}), registry, db, time.Now().Add(-time.Minute), time.Millisecond, agentmetrics.LabelAll, false)
+	closeFunc, err := prometheusmetrics.AgentStats(ctx, testutil.Logger(t, testutil.WithIgnoreErrors()), registry, db, time.Now().Add(-time.Minute), time.Millisecond, agentmetrics.LabelAll, false)
 	require.NoError(t, err)
 	t.Cleanup(closeFunc)
 

--- a/coderd/provisionerdserver/provisionerdserver_test.go
+++ b/coderd/provisionerdserver/provisionerdserver_test.go
@@ -26,7 +26,6 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"storj.io/drpc"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/buildinfo"
 	"github.com/coder/coder/v2/coderd"
 	"github.com/coder/coder/v2/coderd/audit"
@@ -5264,13 +5263,17 @@ func setup(t *testing.T, ignoreLogErrors bool, ov *overrides) (proto.DRPCProvisi
 		db = ov.wrapDB(db)
 	}
 	serverDB := dbauthz.New(db, authorizer, logger, coderdtest.AccessControlStorePointer())
+	var serverLoggerOpts []testutil.LoggerOption
+	if ignoreLogErrors {
+		serverLoggerOpts = append(serverLoggerOpts, testutil.WithIgnoreErrors())
+	}
 	srv, err := provisionerdserver.NewServer(
 		ov.ctx,
 		proto.CurrentVersion.String(),
 		&url.URL{},
 		daemon.ID,
 		defOrg.ID,
-		slogtest.Make(t, &slogtest.Options{IgnoreErrors: ignoreLogErrors}),
+		testutil.Logger(t, serverLoggerOpts...),
 		[]database.ProvisionerType{database.ProvisionerTypeEcho},
 		provisionerdserver.Tags(daemon.Tags),
 		serverDB,

--- a/coderd/updatecheck/updatecheck_test.go
+++ b/coderd/updatecheck/updatecheck_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/coderd/updatecheck"
 	"github.com/coder/coder/v2/testutil"
@@ -49,7 +48,7 @@ func TestChecker_Notify(t *testing.T) {
 	defer srv.Close()
 
 	db, _ := dbtestutil.NewDB(t)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Named(t.Name())
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Named(t.Name())
 	notify := make(chan updatecheck.Result, len(wantVersion))
 	c := updatecheck.New(db, logger, updatecheck.Options{
 		Interval: 1 * time.Nanosecond, // Zero means unset.
@@ -130,7 +129,7 @@ func TestChecker_Latest(t *testing.T) {
 			defer srv.Close()
 
 			db, _ := dbtestutil.NewDB(t)
-			logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Named(t.Name())
+			logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Named(t.Name())
 			c := updatecheck.New(db, logger, updatecheck.Options{
 				URL: srv.URL,
 			})

--- a/coderd/userauth_test.go
+++ b/coderd/userauth_test.go
@@ -28,7 +28,6 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd"
 	"github.com/coder/coder/v2/coderd/audit"
 	"github.com/coder/coder/v2/coderd/coderdtest"
@@ -1543,7 +1542,7 @@ func TestUserOIDC(t *testing.T) {
 			})
 
 			auditor := audit.NewMock()
-			logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+			logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 			owner := coderdtest.New(t, &coderdtest.Options{
 				Auditor:    auditor,
 				OIDCConfig: cfg,
@@ -1595,7 +1594,7 @@ func TestUserOIDC(t *testing.T) {
 			cfg.AllowSignups = true
 		})
 
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		owner, db := coderdtest.NewWithDatabase(t, &coderdtest.Options{
 			Auditor:    auditor,
 			OIDCConfig: cfg,

--- a/coderd/webpush/webpush_test.go
+++ b/coderd/webpush/webpush_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
@@ -531,7 +530,7 @@ func setupPushTest(ctx context.Context, t *testing.T, handlerFunc func(w http.Re
 
 func setupPushTestWithOptions(ctx context.Context, t *testing.T, db database.Store, handlerFunc func(w http.ResponseWriter, r *http.Request), opts ...webpush.Option) (webpush.Dispatcher, database.Store, string) {
 	t.Helper()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 
 	server := httptest.NewServer(http.HandlerFunc(handlerFunc))
 	t.Cleanup(server.Close)
@@ -584,7 +583,7 @@ func TestSSRFPrevention(t *testing.T) {
 	// Create a dispatcher via New() WITHOUT WithHTTPClient so it
 	// uses the default SSRF-safe client that blocks loopback.
 	db, _ := dbtestutil.NewDB(t)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	manager, err := webpush.New(ctx, &logger, db, "http://example.com")
 	require.NoError(t, err)
 

--- a/coderd/workspaceagents_chat_context_internal_test.go
+++ b/coderd/workspaceagents_chat_context_internal_test.go
@@ -11,11 +11,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbmock"
 	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/testutil"
 )
 
 func TestUpdateAgentChatLastInjectedContextFromMessagesUsesMessageIDTieBreaker(t *testing.T) {
@@ -80,7 +80,7 @@ func TestUpdateAgentChatLastInjectedContextFromMessagesUsesMessageIDTieBreaker(t
 
 	err = updateAgentChatLastInjectedContextFromMessages(
 		context.Background(),
-		slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+		testutil.Logger(t, testutil.WithIgnoreErrors()),
 		db,
 		chatID,
 	)

--- a/coderd/workspaceagents_internal_test.go
+++ b/coderd/workspaceagents_internal_test.go
@@ -21,7 +21,6 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbmock"
@@ -110,7 +109,7 @@ func runWatchChatGitWorkspaceLookupTest(t *testing.T, workspaceErr error, wantSt
 
 	var (
 		ctx    = testutil.Context(t, testutil.WaitShort)
-		logger = slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug).Named("coderd")
+		logger = testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug).Named("coderd")
 
 		mCtrl = gomock.NewController(t)
 		mDB   = dbmock.NewMockStore(mCtrl)
@@ -171,7 +170,7 @@ func TestWatchChatGit(t *testing.T) {
 
 		var (
 			ctx    = testutil.Context(t, testutil.WaitShort)
-			logger = slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug).Named("coderd")
+			logger = testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug).Named("coderd")
 
 			mCtrl = gomock.NewController(t)
 			mDB   = dbmock.NewMockStore(mCtrl)
@@ -245,7 +244,7 @@ func TestWatchChatGit(t *testing.T) {
 
 		var (
 			ctx    = testutil.Context(t, testutil.WaitShort)
-			logger = slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug).Named("coderd")
+			logger = testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug).Named("coderd")
 
 			mCtrl = gomock.NewController(t)
 			mDB   = dbmock.NewMockStore(mCtrl)
@@ -301,7 +300,7 @@ func TestWatchChatGit(t *testing.T) {
 
 		var (
 			ctx    = testutil.Context(t, testutil.WaitShort)
-			logger = slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug).Named("coderd")
+			logger = testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug).Named("coderd")
 
 			mCtrl        = gomock.NewController(t)
 			mDB          = dbmock.NewMockStore(mCtrl)
@@ -389,7 +388,7 @@ func TestWatchChatGit(t *testing.T) {
 
 		var (
 			ctx    = testutil.Context(t, testutil.WaitLong)
-			logger = slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug).Named("coderd")
+			logger = testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug).Named("coderd")
 
 			mCtrl        = gomock.NewController(t)
 			mDB          = dbmock.NewMockStore(mCtrl)
@@ -567,7 +566,7 @@ func TestWatchChatGit(t *testing.T) {
 
 		var (
 			ctx    = testutil.Context(t, testutil.WaitLong)
-			logger = slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug).Named("coderd")
+			logger = testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug).Named("coderd")
 
 			mCtrl        = gomock.NewController(t)
 			mDB          = dbmock.NewMockStore(mCtrl)
@@ -739,7 +738,7 @@ func TestWatchAgentContainers(t *testing.T) {
 
 		var (
 			ctx    = testutil.Context(t, testutil.WaitLong)
-			logger = slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug).Named("coderd")
+			logger = testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug).Named("coderd")
 
 			mCtrl        = gomock.NewController(t)
 			mDB          = dbmock.NewMockStore(mCtrl)
@@ -856,7 +855,7 @@ func TestWatchAgentContainers(t *testing.T) {
 
 		var (
 			ctx    = testutil.Context(t, testutil.WaitShort)
-			logger = slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug).Named("coderd")
+			logger = testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug).Named("coderd")
 
 			mCtrl        = gomock.NewController(t)
 			mDB          = dbmock.NewMockStore(mCtrl)

--- a/coderd/workspaceagents_test.go
+++ b/coderd/workspaceagents_test.go
@@ -30,7 +30,6 @@ import (
 	"tailscale.com/tailcfg"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/agent"
 	"github.com/coder/coder/v2/agent/agentcontainers"
 	"github.com/coder/coder/v2/agent/agentcontainers/acmock"
@@ -117,7 +116,7 @@ func TestWorkspaceAgent(t *testing.T) {
 	t.Run("Timeout", func(t *testing.T) {
 		t.Parallel()
 		// timeouts can cause error logs to be dropped on shutdown
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		client, db := coderdtest.NewWithDatabase(t, &coderdtest.Options{
 			Logger: &logger,
 		})
@@ -1511,7 +1510,7 @@ func TestWorkspaceAgentContainers(t *testing.T) {
 				ctrl := gomock.NewController(t)
 				mcl := acmock.NewMockContainerCLI(ctrl)
 				expected, expectedErr := tc.setupMock(mcl)
-				logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+				logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 				client, db := coderdtest.NewWithDatabase(t, &coderdtest.Options{
 					Logger: &logger,
 				})
@@ -1561,7 +1560,7 @@ func TestWatchWorkspaceAgentDevcontainers(t *testing.T) {
 
 		var (
 			ctx               = testutil.Context(t, testutil.WaitLong)
-			logger            = slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+			logger            = testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 			mClock            = quartz.NewMock(t)
 			updaterTickerTrap = mClock.Trap().TickerFunc("updaterLoop")
 			mCtrl             = gomock.NewController(t)
@@ -1809,7 +1808,7 @@ func TestWorkspaceAgentRecreateDevcontainer(t *testing.T) {
 					mCtrl      = gomock.NewController(t)
 					mCCLI      = acmock.NewMockContainerCLI(mCtrl)
 					mDCCLI     = acmock.NewMockDevcontainerCLI(mCtrl)
-					logger     = slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+					logger     = testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 					client, db = coderdtest.NewWithDatabase(t, &coderdtest.Options{
 						Logger: &logger,
 					})
@@ -1968,7 +1967,7 @@ func TestWorkspaceAgentDeleteDevcontainer(t *testing.T) {
 			t.Parallel()
 
 			ctx := testutil.Context(t, testutil.WaitLong)
-			logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+			logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 			client, db := coderdtest.NewWithDatabase(t, &coderdtest.Options{
 				Logger: &logger,
 			})
@@ -2511,7 +2510,7 @@ func TestWorkspaceAgent_Metadata_CatchMemoryLeak(t *testing.T) {
 
 	store, psub := dbtestutil.NewDB(t)
 	db := &testWAMErrorStore{Store: store}
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Named("coderd").Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Named("coderd").Leveled(slog.LevelDebug)
 	client := coderdtest.New(t, &coderdtest.Options{
 		Database:                 db,
 		Pubsub:                   psub,

--- a/coderd/workspacebuilds_test.go
+++ b/coderd/workspacebuilds_test.go
@@ -21,7 +21,6 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/audit"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/coderdtest/oidctest"
@@ -604,7 +603,7 @@ func TestPatchCancelWorkspaceBuild(t *testing.T) {
 
 		// need to include our own logger because the provisioner (rightly) drops error logs when we shut down the
 		// test with a build in progress.
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		client := coderdtest.New(t, &coderdtest.Options{IncludeProvisionerDaemon: true, Logger: &logger})
 		owner := coderdtest.CreateFirstUser(t, client)
 		version := coderdtest.CreateTemplateVersion(t, client, owner.OrganizationID, &echo.Responses{
@@ -1958,7 +1957,7 @@ func TestPostWorkspaceBuild(t *testing.T) {
 		// Given: a workspace that has already been deleted
 		var (
 			ctx             = testutil.Context(t, testutil.WaitShort)
-			logger          = slogtest.Make(t, &slogtest.Options{}).Leveled(slog.LevelError)
+			logger          = testutil.Logger(t).Leveled(slog.LevelError)
 			adminClient, db = coderdtest.NewWithDatabase(t, &coderdtest.Options{
 				Logger: &logger,
 			})

--- a/coderd/workspacestats/batcher_internal_test.go
+++ b/coderd/workspacestats/batcher_internal_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	agentproto "github.com/coder/coder/v2/agent/proto"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
@@ -17,6 +16,7 @@ import (
 	"github.com/coder/coder/v2/coderd/database/pubsub"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/cryptorand"
+	"github.com/coder/coder/v2/testutil"
 )
 
 func TestBatchStats(t *testing.T) {
@@ -25,7 +25,7 @@ func TestBatchStats(t *testing.T) {
 	// Given: a fresh batcher with no data
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	log := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	store, ps := dbtestutil.NewDB(t)
 
 	// Set up some test dependencies.

--- a/coderd/x/chatd/chatd_internal_test.go
+++ b/coderd/x/chatd/chatd_internal_test.go
@@ -16,7 +16,6 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbmock"
@@ -170,7 +169,7 @@ func TestAppendComputerUseProviderTool(t *testing.T) {
 		computerUseProviderToolOptions{
 			provider:      chattool.ComputerUseProviderOpenAI,
 			isComputerUse: true,
-			logger:        slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+			logger:        testutil.Logger(t, testutil.WithIgnoreErrors()),
 		},
 	)
 	require.NoError(t, err)
@@ -234,7 +233,7 @@ func TestAppendComputerUseProviderTool_AnthropicHasNoResultMetadata(t *testing.T
 		computerUseProviderToolOptions{
 			provider:      chattool.ComputerUseProviderAnthropic,
 			isComputerUse: true,
-			logger:        slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+			logger:        testutil.Logger(t, testutil.WithIgnoreErrors()),
 		},
 	)
 	require.NoError(t, err)
@@ -666,7 +665,7 @@ func TestRenameChatTitle(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitShort)
 		ctrl := gomock.NewController(t)
 		db := dbmock.NewMockStore(ctrl)
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 		chatID := uuid.New()
 		workerID := uuid.New()
@@ -700,7 +699,7 @@ func TestRenameChatTitle(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitShort)
 		ctrl := gomock.NewController(t)
 		db := dbmock.NewMockStore(ctrl)
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 		chatID := uuid.New()
 		workerID := uuid.New()
@@ -735,7 +734,7 @@ func TestRegenerateChatTitle_PersistsAndBroadcasts(t *testing.T) {
 	lockTx := dbmock.NewMockStore(ctrl)
 	usageTx := dbmock.NewMockStore(ctrl)
 	unlockTx := dbmock.NewMockStore(ctrl)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	pubsub := dbpubsub.NewInMemory()
 	clock := quartz.NewReal()
 
@@ -895,7 +894,7 @@ func TestRegenerateChatTitle_PersistsAndBroadcasts_IdleChatReleasesManualLock(t 
 	lockTx := dbmock.NewMockStore(ctrl)
 	usageTx := dbmock.NewMockStore(ctrl)
 	unlockTx := dbmock.NewMockStore(ctrl)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	pubsub := dbpubsub.NewInMemory()
 	clock := quartz.NewReal()
 
@@ -1299,7 +1298,7 @@ func TestPersistInstructionFilesIncludesAgentMetadata(t *testing.T) {
 			ContextFileContent: "# Project instructions",
 		}},
 	}, nil).AnyTimes()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	server := &Server{
 		db:                             db,
 		logger:                         logger,
@@ -1350,7 +1349,7 @@ func TestPersistInstructionFilesSkipsSentinelWhenWorkspaceUnavailable(t *testing
 	}
 	server := &Server{
 		db:     db,
-		logger: slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+		logger: testutil.Logger(t, testutil.WithIgnoreErrors()),
 	}
 
 	instruction, _, err := server.persistInstructionFiles(
@@ -1467,7 +1466,7 @@ func TestPersistInstructionFilesSentinelWithSkills(t *testing.T) {
 			SkillDir:         "/home/coder/project/.agents/skills/my-skill",
 		}},
 	}, nil).AnyTimes()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	server := &Server{
 		db:                             db,
 		logger:                         logger,
@@ -1555,7 +1554,7 @@ func TestPersistInstructionFilesSentinelNoSkillsClearsColumn(t *testing.T) {
 		// Agent returns pre-read content: no files, no skills.
 		Parts: []codersdk.ChatMessagePart{},
 	}, nil).AnyTimes()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	server := &Server{
 		db:                             db,
 		logger:                         logger,
@@ -2600,7 +2599,7 @@ func newSubscribeTestServer(t *testing.T, db database.Store) *Server {
 
 	return &Server{
 		db:     db,
-		logger: slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+		logger: testutil.Logger(t, testutil.WithIgnoreErrors()),
 		pubsub: dbpubsub.NewInMemory(),
 	}
 }
@@ -3430,7 +3429,7 @@ func TestProcessChat_IgnoresStaleControlNotification(t *testing.T) {
 	t.Parallel()
 
 	ctx := testutil.Context(t, testutil.WaitShort)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	ctrl := gomock.NewController(t)
 	db := dbmock.NewMockStore(ctrl)
 	ps := dbpubsub.NewInMemory()
@@ -3529,7 +3528,7 @@ func TestShouldPublishFinishedChatState(t *testing.T) {
 	t.Parallel()
 
 	ctx := testutil.Context(t, testutil.WaitShort)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	ctrl := gomock.NewController(t)
 	db := dbmock.NewMockStore(ctrl)
 	chatID := uuid.New()
@@ -3568,7 +3567,7 @@ func TestShouldPublishFinishedChatState_DBErrorPublishes(t *testing.T) {
 	t.Parallel()
 
 	ctx := testutil.Context(t, testutil.WaitShort)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	ctrl := gomock.NewController(t)
 	db := dbmock.NewMockStore(ctrl)
 	chatID := uuid.New()
@@ -3597,7 +3596,7 @@ func TestHeartbeatTick_StolenChatIsInterrupted(t *testing.T) {
 	t.Parallel()
 
 	ctx := testutil.Context(t, testutil.WaitShort)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	ctrl := gomock.NewController(t)
 	db := dbmock.NewMockStore(ctrl)
 	clock := quartz.NewMock(t)
@@ -3680,7 +3679,7 @@ func TestHeartbeatTick_DBErrorDoesNotInterruptChats(t *testing.T) {
 	t.Parallel()
 
 	ctx := testutil.Context(t, testutil.WaitShort)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	ctrl := gomock.NewController(t)
 	db := dbmock.NewMockStore(ctrl)
 	clock := quartz.NewMock(t)
@@ -3724,7 +3723,7 @@ func TestHeartbeatTick_DBErrorDoesNotInterruptChats(t *testing.T) {
 func TestSubscribeCancelDuringGrace_ReapedBySweep(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	mClock := quartz.NewMock(t)
 
 	server := &Server{
@@ -3781,7 +3780,7 @@ func TestSweepIdleStreams_ReapsStaleRetainedBuffer(t *testing.T) {
 
 	mClock := quartz.NewMock(t)
 	server := &Server{
-		logger: slogtest.Make(t, nil),
+		logger: testutil.Logger(t),
 		clock:  mClock,
 	}
 
@@ -3813,7 +3812,7 @@ func TestSweepIdleStreams_DoesNotReapActiveBuffering(t *testing.T) {
 
 	mClock := quartz.NewMock(t)
 	server := &Server{
-		logger: slogtest.Make(t, nil),
+		logger: testutil.Logger(t),
 		clock:  mClock,
 	}
 
@@ -3844,7 +3843,7 @@ func TestSweepIdleStreams_DoesNotReapWithSubscribers(t *testing.T) {
 
 	mClock := quartz.NewMock(t)
 	server := &Server{
-		logger: slogtest.Make(t, nil),
+		logger: testutil.Logger(t),
 		clock:  mClock,
 	}
 
@@ -3878,7 +3877,7 @@ func TestSweepIdleStreams_DefersDuringGracePeriod(t *testing.T) {
 
 	mClock := quartz.NewMock(t)
 	server := &Server{
-		logger: slogtest.Make(t, nil),
+		logger: testutil.Logger(t),
 		clock:  mClock,
 	}
 
@@ -3918,7 +3917,7 @@ func TestPublishToStream_DropZeroesBackingSlot(t *testing.T) {
 
 	mClock := quartz.NewMock(t)
 	server := &Server{
-		logger: slogtest.Make(t, nil),
+		logger: testutil.Logger(t),
 		clock:  mClock,
 	}
 
@@ -3988,7 +3987,7 @@ func TestCleanupStreamIfIdle_StalePointerDoesNotDeleteFreshEntry(t *testing.T) {
 
 	mClock := quartz.NewMock(t)
 	server := &Server{
-		logger: slogtest.Make(t, nil),
+		logger: testutil.Logger(t),
 		clock:  mClock,
 	}
 
@@ -4034,7 +4033,7 @@ func TestSafeSweepIdleStreams_RecoversFromPanic(t *testing.T) {
 	t.Parallel()
 
 	server := &Server{
-		logger: slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+		logger: testutil.Logger(t, testutil.WithIgnoreErrors()),
 		clock:  quartz.NewMock(t),
 	}
 
@@ -4134,7 +4133,7 @@ func TestGetWorkspaceConn_StaleAgentRecovery(t *testing.T) {
 
 	server := &Server{
 		db:                             db,
-		logger:                         slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+		logger:                         testutil.Logger(t, testutil.WithIgnoreErrors()),
 		clock:                          quartz.NewReal(),
 		agentInactiveDisconnectTimeout: 30 * time.Second,
 		dialTimeout:                    defaultDialTimeout,
@@ -4229,7 +4228,7 @@ func TestGetWorkspaceConn_SameBuildAgentCrash(t *testing.T) {
 	dialErr := xerrors.New("agent is not connected")
 	server := &Server{
 		db:                             db,
-		logger:                         slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+		logger:                         testutil.Logger(t, testutil.WithIgnoreErrors()),
 		clock:                          quartz.NewReal(),
 		agentInactiveDisconnectTimeout: 30 * time.Second,
 		dialTimeout:                    defaultDialTimeout,
@@ -4379,7 +4378,7 @@ func TestGetWorkspaceConn_StatusCheck(t *testing.T) {
 
 			server := &Server{
 				db:                             db,
-				logger:                         slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+				logger:                         testutil.Logger(t, testutil.WithIgnoreErrors()),
 				clock:                          clock,
 				agentInactiveDisconnectTimeout: 30 * time.Second,
 				dialTimeout:                    defaultDialTimeout,
@@ -4491,7 +4490,7 @@ func TestGetWorkspaceConn_DialTimeoutDisconnectedRecoveryThreshold(t *testing.T)
 
 			server := &Server{
 				db:                             db,
-				logger:                         slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+				logger:                         testutil.Logger(t, testutil.WithIgnoreErrors()),
 				clock:                          clock,
 				agentInactiveDisconnectTimeout: 30 * time.Second,
 				dialTimeout:                    10 * time.Millisecond,
@@ -4569,7 +4568,7 @@ func TestGetWorkspaceConn_DisconnectedStatusDialSuccessDoesNotEscalate(t *testin
 
 	server := &Server{
 		db:                             db,
-		logger:                         slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+		logger:                         testutil.Logger(t, testutil.WithIgnoreErrors()),
 		clock:                          quartz.NewReal(),
 		agentInactiveDisconnectTimeout: 30 * time.Second,
 		dialTimeout:                    10 * time.Millisecond,
@@ -4638,7 +4637,7 @@ func TestGetWorkspaceConn_CacheHitDisconnectedRetriesDialBeforeEscalating(t *tes
 
 	server := &Server{
 		db:                             db,
-		logger:                         slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+		logger:                         testutil.Logger(t, testutil.WithIgnoreErrors()),
 		clock:                          quartz.NewReal(),
 		agentInactiveDisconnectTimeout: 30 * time.Second,
 		dialTimeout:                    10 * time.Millisecond,
@@ -4942,7 +4941,7 @@ func TestGetWorkspaceConn_PreflightExternalAgentTimedOut(t *testing.T) {
 
 	server := &Server{
 		db:                             db,
-		logger:                         slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+		logger:                         testutil.Logger(t, testutil.WithIgnoreErrors()),
 		clock:                          quartz.NewReal(),
 		agentInactiveDisconnectTimeout: 30 * time.Second,
 		dialTimeout:                    defaultDialTimeout,
@@ -5011,7 +5010,7 @@ func TestGetWorkspaceConn_PreflightExternalAgentConnectingDials(t *testing.T) {
 	dialed := false
 	server := &Server{
 		db:                             db,
-		logger:                         slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+		logger:                         testutil.Logger(t, testutil.WithIgnoreErrors()),
 		clock:                          quartz.NewReal(),
 		agentInactiveDisconnectTimeout: 30 * time.Second,
 		dialTimeout:                    defaultDialTimeout,
@@ -5140,7 +5139,7 @@ func TestAutoPromote_InsertFailureRollsBackTransaction(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	db := dbmock.NewMockStore(ctrl)
 	tx := dbmock.NewMockStore(ctrl)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	ps := dbpubsub.NewInMemory()
 	clock := quartz.NewReal()
 
@@ -5220,7 +5219,7 @@ func TestAutoPromote_InsertFailureSkipsStatusUpdate(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	db := dbmock.NewMockStore(ctrl)
 	tx := dbmock.NewMockStore(ctrl)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	ps := dbpubsub.NewInMemory()
 	clock := quartz.NewReal()
 
@@ -5474,7 +5473,7 @@ func TestPublishToStream_AppendsAsInProgress(t *testing.T) {
 
 	mClock := quartz.NewMock(t)
 	server := &Server{
-		logger: slogtest.Make(t, nil),
+		logger: testutil.Logger(t),
 		clock:  mClock,
 	}
 
@@ -5516,7 +5515,7 @@ func TestClaimCommittedParts(t *testing.T) {
 		t.Parallel()
 
 		server := &Server{
-			logger: slogtest.Make(t, nil),
+			logger: testutil.Logger(t),
 			clock:  quartz.NewMock(t),
 		}
 		chatID := uuid.New()
@@ -5548,7 +5547,7 @@ func TestClaimCommittedParts(t *testing.T) {
 		t.Parallel()
 
 		server := &Server{
-			logger: slogtest.Make(t, nil),
+			logger: testutil.Logger(t),
 			clock:  quartz.NewMock(t),
 		}
 		chatID := uuid.New()
@@ -5577,7 +5576,7 @@ func TestClaimCommittedParts(t *testing.T) {
 		t.Parallel()
 
 		server := &Server{
-			logger: slogtest.Make(t, nil),
+			logger: testutil.Logger(t),
 			clock:  quartz.NewMock(t),
 		}
 		chatID := uuid.New()
@@ -5603,7 +5602,7 @@ func TestClaimCommittedParts(t *testing.T) {
 		t.Parallel()
 
 		server := &Server{
-			logger: slogtest.Make(t, nil),
+			logger: testutil.Logger(t),
 			clock:  quartz.NewMock(t),
 		}
 		chatID := uuid.New()
@@ -5633,7 +5632,7 @@ func TestSubscribeToStream_FiltersBufferedParts_Integration(t *testing.T) {
 
 	mClock := quartz.NewMock(t)
 	server := &Server{
-		logger: slogtest.Make(t, nil),
+		logger: testutil.Logger(t),
 		clock:  mClock,
 	}
 	chatID := uuid.New()

--- a/coderd/x/chatd/chatd_test.go
+++ b/coderd/x/chatd/chatd_test.go
@@ -28,7 +28,6 @@ import (
 	"go.uber.org/mock/gomock"
 	"golang.org/x/xerrors"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/agent/agentcontextconfig"
 	"github.com/coder/coder/v2/agent/agenttest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
@@ -3588,7 +3587,7 @@ func TestRecoverStaleChatsPeriodically(t *testing.T) {
 	// Start a new replica. Its startup recovery will reset the
 	// chat (since the heartbeat is old), but the key point is that
 	// the periodic loop also recovers newly-stale chats.
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	server := chatd.New(chatd.Config{
 		Logger:                     logger,
 		Database:                   db,
@@ -3677,7 +3676,7 @@ func TestRecoverStaleRequiresActionChat(t *testing.T) {
 		time.Now().Add(-time.Hour), chat.ID)
 	require.NoError(t, err)
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	server := chatd.New(chatd.Config{
 		Logger:                     logger,
 		Database:                   db,
@@ -3771,7 +3770,7 @@ func TestWaitingChatsAreNotRecoveredAsStale(t *testing.T) {
 	})
 
 	// Start a replica with a short stale threshold.
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	server := chatd.New(chatd.Config{
 		Logger:                     logger,
 		Database:                   db,
@@ -4082,7 +4081,7 @@ func TestRequiresActionChatPersistsWaitingStatusLabel(t *testing.T) {
 	})
 
 	mockPush := &mockWebpushDispatcher{}
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	server := chatd.New(chatd.Config{
 		Logger:                     logger,
 		Database:                   db,
@@ -5458,15 +5457,15 @@ func TestHeartbeatBumpsWorkspaceUsage(t *testing.T) {
 	flushDone := make(chan int, 1)
 	tracker := workspacestats.NewTracker(db,
 		workspacestats.TrackerWithTickFlush(flushTick, flushDone),
-		workspacestats.TrackerWithLogger(slogtest.Make(t, nil)),
+		workspacestats.TrackerWithLogger(testutil.Logger(t)),
 	)
 	t.Cleanup(func() { tracker.Close() })
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	// Wrap the database with dbauthz so the chatd server's
 	// AsChatd context is enforced on every query, matching
 	// production behavior.
-	authzDB := dbauthz.New(db, rbac.NewStrictCachingAuthorizer(prometheus.NewRegistry()), slogtest.Make(t, nil), coderdtest.AccessControlStorePointer())
+	authzDB := dbauthz.New(db, rbac.NewStrictCachingAuthorizer(prometheus.NewRegistry()), testutil.Logger(t), coderdtest.AccessControlStorePointer())
 	server := chatd.New(chatd.Config{
 		Logger:                     logger,
 		Database:                   authzDB,
@@ -5588,11 +5587,11 @@ func TestHeartbeatNoWorkspaceNoBump(t *testing.T) {
 	flushCh := make(chan int, 1)
 	tracker := workspacestats.NewTracker(db,
 		workspacestats.TrackerWithTickFlush(usageTickCh, flushCh),
-		workspacestats.TrackerWithLogger(slogtest.Make(t, nil)),
+		workspacestats.TrackerWithLogger(testutil.Logger(t)),
 	)
 	t.Cleanup(func() { tracker.Close() })
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	server := chatd.New(chatd.Config{
 		Logger:                     logger,
 		Database:                   db,
@@ -5680,7 +5679,7 @@ func newTestServer(
 ) *chatd.Server {
 	t.Helper()
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	server := chatd.New(chatd.Config{
 		Logger:                     logger,
 		Database:                   db,
@@ -5730,7 +5729,7 @@ func newStartedTestServer(
 ) *chatd.Server {
 	t.Helper()
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	server := chatd.New(chatd.Config{
 		Logger:                     logger,
 		Database:                   db,
@@ -5758,7 +5757,7 @@ func newDebugEnabledTestServer(
 ) *chatd.Server {
 	t.Helper()
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	server := chatd.New(chatd.Config{
 		Logger:                     logger,
 		Database:                   db,
@@ -5785,7 +5784,7 @@ func newActiveTestServer(
 ) *chatd.Server {
 	t.Helper()
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	cfg := chatd.Config{
 		Logger:                     logger,
 		Database:                   db,
@@ -5869,7 +5868,7 @@ func TestProposeChatTitle_DebugRun(t *testing.T) {
 				openAIURL,
 			)
 			server := chatd.New(chatd.Config{
-				Logger:                     slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+				Logger:                     testutil.Logger(t, testutil.WithIgnoreErrors()),
 				Database:                   db,
 				ReplicaID:                  uuid.New(),
 				Pubsub:                     ps,
@@ -6233,7 +6232,7 @@ func TestInterruptChatDoesNotSendWebPushNotification(t *testing.T) {
 	// Mock webpush dispatcher that records calls.
 	mockPush := &mockWebpushDispatcher{}
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	server := chatd.New(chatd.Config{
 		Logger:                     logger,
 		Database:                   db,
@@ -6354,7 +6353,7 @@ func TestSuccessfulChatSendsWebPushWithNavigationData(t *testing.T) {
 	// Mock webpush dispatcher that captures the dispatched message.
 	mockPush := &mockWebpushDispatcher{}
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	server := chatd.New(chatd.Config{
 		Logger:                     logger,
 		Database:                   db,
@@ -6441,7 +6440,7 @@ func TestCloseDuringShutdownContextCanceledShouldRetryOnNewReplica(t *testing.T)
 		return chattest.OpenAIStreamingResponse(chattest.OpenAITextChunks("retry", " complete")...)
 	})
 
-	loggerA := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	loggerA := testutil.Logger(t, testutil.WithIgnoreErrors())
 	serverA := chatd.New(chatd.Config{
 		Logger:                     loggerA,
 		Database:                   db,
@@ -6496,7 +6495,7 @@ func TestCloseDuringShutdownContextCanceledShouldRetryOnNewReplica(t *testing.T)
 			!fromDB.LastError.Valid
 	}, testutil.WaitMedium, testutil.IntervalFast)
 
-	loggerB := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	loggerB := testutil.Logger(t, testutil.WithIgnoreErrors())
 	serverB := chatd.New(chatd.Config{
 		Logger:                     loggerB,
 		Database:                   db,
@@ -6550,7 +6549,7 @@ func TestSuccessfulChatSendsWebPushWithSummary(t *testing.T) {
 
 	mockPush := &mockWebpushDispatcher{}
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	server := chatd.New(chatd.Config{
 		Logger:                     logger,
 		Database:                   db,
@@ -6668,7 +6667,7 @@ func TestSuccessfulChatSendsWebPushFallbackWithoutSummaryForEmptyAssistantText(t
 
 	mockPush := &mockWebpushDispatcher{}
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	server := chatd.New(chatd.Config{
 		Logger:                     logger,
 		Database:                   db,
@@ -6728,7 +6727,7 @@ func TestErroredChatClearsLastTurnSummaryAndSendsWebPush(t *testing.T) {
 
 	mockPush := &mockWebpushDispatcher{}
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	server := chatd.New(chatd.Config{
 		Logger:                     logger,
 		Database:                   db,
@@ -7121,7 +7120,7 @@ func TestInterruptChatPersistsPartialResponse(t *testing.T) {
 		return chattest.OpenAIResponse{StreamingChunks: chunks}
 	})
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	server := chatd.New(chatd.Config{
 		Logger:                     logger,
 		Database:                   db,
@@ -10775,7 +10774,7 @@ func TestPromoteQueuedFallsThroughOnStaleHeartbeat(t *testing.T) {
 	ctx := testutil.Context(t, testutil.WaitLong)
 
 	staleAfter := 100 * time.Millisecond
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	server := chatd.New(chatd.Config{
 		Logger:                     logger,
 		Database:                   db,
@@ -10849,7 +10848,7 @@ func TestRecoverStaleChatsRecoversWaitingWithQueue(t *testing.T) {
 	ctx := testutil.Context(t, testutil.WaitLong)
 
 	staleAfter := 100 * time.Millisecond
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	server := chatd.New(chatd.Config{
 		Logger:                     logger,
 		Database:                   db,
@@ -10934,7 +10933,7 @@ func TestRecoverStaleChatsWaitingWithUnresolvedToolCallInsertsSyntheticResults(t
 	ctx := testutil.Context(t, testutil.WaitLong)
 
 	staleAfter := 100 * time.Millisecond
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	server := chatd.New(chatd.Config{
 		Logger:                     logger,
 		Database:                   db,
@@ -11286,7 +11285,7 @@ func TestRecoverStaleChatsWaitingPropagatesSynthError(t *testing.T) {
 	ctx := testutil.Context(t, testutil.WaitLong)
 
 	staleAfter := 100 * time.Millisecond
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	server := chatd.New(chatd.Config{
 		Logger:                     logger,
 		Database:                   db,

--- a/coderd/x/chatd/chatloop/chatloop_test.go
+++ b/coderd/x/chatd/chatloop/chatloop_test.go
@@ -21,7 +21,6 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/x/chatd/chaterror"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatretry"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatsanitize"
@@ -3634,7 +3633,7 @@ func TestRun_AnthropicProviderToolPreRequestGuard(t *testing.T) {
 
 		guarded := chatsanitize.ApplyAnthropicProviderToolGuard(
 			context.Background(),
-			slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+			testutil.Logger(t, testutil.WithIgnoreErrors()),
 			fantasyanthropic.Name,
 			"claude-test",
 			[]fantasy.Message{
@@ -3672,7 +3671,7 @@ func TestRun_AnthropicProviderToolPreRequestGuard(t *testing.T) {
 		content = append(content, providerPair("ws-two")...)
 		guarded := chatsanitize.ApplyAnthropicProviderToolGuard(
 			context.Background(),
-			slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+			testutil.Logger(t, testutil.WithIgnoreErrors()),
 			fantasyanthropic.Name,
 			"claude-test",
 			[]fantasy.Message{{Role: fantasy.MessageRoleAssistant, Content: content}},
@@ -3698,7 +3697,7 @@ func TestRun_AnthropicProviderToolPreRequestGuard(t *testing.T) {
 		}
 		guarded := chatsanitize.ApplyAnthropicProviderToolGuard(
 			context.Background(),
-			slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+			testutil.Logger(t, testutil.WithIgnoreErrors()),
 			"fake",
 			"fake-model",
 			prompt,

--- a/coderd/x/chatd/chatprompt/chatprompt_test.go
+++ b/coderd/x/chatd/chatprompt/chatprompt_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/db2sdk"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
@@ -54,7 +53,7 @@ func convertMessagesWithoutFiles(t *testing.T, messages []database.ChatMessage) 
 		context.Background(),
 		messages,
 		nil,
-		slogtest.Make(t, nil),
+		testutil.Logger(t),
 	)
 	require.NoError(t, err)
 	return prompt
@@ -193,7 +192,7 @@ func TestConvertMessagesWithFiles_ResolvesFileData(t *testing.T) {
 			},
 		},
 		resolver,
-		slogtest.Make(t, nil),
+		testutil.Logger(t),
 	)
 	require.NoError(t, err)
 	require.Len(t, prompt, 1)
@@ -251,7 +250,7 @@ func TestConvertMessagesWithFiles_MissingFileBackedAttachmentBecomesTextPart(t *
 					Content:    pqtype.NullRawMessage{RawMessage: rawContent, Valid: true},
 				}},
 				resolver,
-				slogtest.Make(t, nil),
+				testutil.Logger(t),
 			)
 			require.NoError(t, err)
 			require.Len(t, prompt, 1)
@@ -298,7 +297,7 @@ func TestConvertMessagesWithFiles_ResolvedZeroByteFileIsDropped(t *testing.T) {
 			Content:    pqtype.NullRawMessage{RawMessage: rawContent, Valid: true},
 		}},
 		resolver,
-		slogtest.Make(t, nil),
+		testutil.Logger(t),
 	)
 	require.NoError(t, err)
 	require.Empty(t, prompt)
@@ -350,7 +349,7 @@ func TestConvertMessagesWithFiles_MixedResolvedAndMissingFilePartsInSingleMessag
 			Content:    pqtype.NullRawMessage{RawMessage: rawContent, Valid: true},
 		}},
 		resolver,
-		slogtest.Make(t, nil),
+		testutil.Logger(t),
 	)
 	require.NoError(t, err)
 	require.Len(t, prompt, 1)
@@ -415,7 +414,7 @@ func TestConvertMessagesWithFiles_BackwardCompat(t *testing.T) {
 			},
 		},
 		resolver,
-		slogtest.Make(t, nil),
+		testutil.Logger(t),
 	)
 	require.NoError(t, err)
 	require.Len(t, prompt, 1)
@@ -1340,7 +1339,7 @@ func TestProviderMetadataRoundTrip(t *testing.T) {
 			Content:    legacyContent,
 		}},
 		nil,
-		slogtest.Make(t, nil),
+		testutil.Logger(t),
 	)
 	require.NoError(t, err)
 	require.Len(t, prompt, 1)
@@ -1388,7 +1387,7 @@ func TestFileReferencePreservation(t *testing.T) {
 			Content:    raw,
 		}},
 		nil,
-		slogtest.Make(t, nil),
+		testutil.Logger(t),
 	)
 	require.NoError(t, err)
 	require.Len(t, prompt, 1)
@@ -1443,7 +1442,7 @@ func TestAssistantWriteRoundTrip(t *testing.T) {
 			Content:    raw,
 		}},
 		nil,
-		slogtest.Make(t, nil),
+		testutil.Logger(t),
 	)
 	require.NoError(t, err)
 	require.Len(t, prompt, 1)
@@ -1587,7 +1586,7 @@ func TestMixedFormatConversation(t *testing.T) {
 	}
 
 	prompt, err := chatprompt.ConvertMessagesWithFiles(
-		context.Background(), messages, resolver, slogtest.Make(t, nil),
+		context.Background(), messages, resolver, testutil.Logger(t),
 	)
 	require.NoError(t, err)
 	require.Len(t, prompt, 6, "all 6 messages should produce prompt entries")
@@ -1707,7 +1706,7 @@ func TestQueuedMessageRoundTrip(t *testing.T) {
 			Content:    pqtype.NullRawMessage{RawMessage: raw.RawMessage, Valid: true},
 		}},
 		nil,
-		slogtest.Make(t, nil),
+		testutil.Logger(t),
 	)
 	require.NoError(t, err)
 	require.Len(t, prompt, 1)
@@ -2022,7 +2021,7 @@ func TestConvertMessagesWithFiles_FiltersEmptyTextAndReasoningParts(t *testing.T
 			context.Background(),
 			[]database.ChatMessage{makeMsg(t, database.ChatMessageRoleUser, parts)},
 			nil,
-			slogtest.Make(t, nil),
+			testutil.Logger(t),
 		)
 		require.NoError(t, err)
 		require.Len(t, prompt, 1)
@@ -2068,7 +2067,7 @@ func TestConvertMessagesWithFiles_FiltersEmptyTextAndReasoningParts(t *testing.T
 			context.Background(),
 			[]database.ChatMessage{makeMsg(t, database.ChatMessageRoleAssistant, parts)},
 			nil,
-			slogtest.Make(t, nil),
+			testutil.Logger(t),
 		)
 		require.NoError(t, err)
 		// 2 messages: assistant + synthetic tool result injected
@@ -2102,7 +2101,7 @@ func TestConvertMessagesWithFiles_FiltersEmptyTextAndReasoningParts(t *testing.T
 			context.Background(),
 			[]database.ChatMessage{makeMsg(t, database.ChatMessageRoleAssistant, parts)},
 			nil,
-			slogtest.Make(t, nil),
+			testutil.Logger(t),
 		)
 		require.NoError(t, err)
 		require.Empty(t, prompt, "all-empty message should be dropped entirely")
@@ -2280,7 +2279,7 @@ func TestConvertMessagesWithFiles_AssistantAttachmentIsNotReplayed(t *testing.T)
 			},
 		},
 		resolver,
-		slogtest.Make(t, nil),
+		testutil.Logger(t),
 	)
 	require.NoError(t, err)
 	require.Len(t, resolverCalls, 1)
@@ -2333,7 +2332,7 @@ func convertSingleResolvedFileMessage(t *testing.T, fileID uuid.UUID, fileData c
 			Content:    pqtype.NullRawMessage{RawMessage: rawContent, Valid: true},
 		}},
 		resolver,
-		slogtest.Make(t, nil),
+		testutil.Logger(t),
 	)
 	require.NoError(t, err)
 	return prompt
@@ -2422,7 +2421,7 @@ func TestMediaToolResultRoundTrip(t *testing.T) {
 		dbMsgs, loadErr := db.GetChatMessagesForPromptByChatID(ctx, chat.ID)
 		require.NoError(t, loadErr)
 		prompt, convErr := chatprompt.ConvertMessagesWithFiles(
-			ctx, dbMsgs, nil, slogtest.Make(t, nil),
+			ctx, dbMsgs, nil, testutil.Logger(t),
 		)
 		require.NoError(t, convErr)
 		return prompt
@@ -2869,7 +2868,7 @@ func TestPartFromContent_CreatedAtNotStamped(t *testing.T) {
 
 func TestToolResultAntivenom(t *testing.T) {
 	t.Parallel()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	t.Run("PoisonedTextResultSanitized", func(t *testing.T) {
 		t.Parallel()
@@ -3034,7 +3033,7 @@ func TestToolResultAntivenom(t *testing.T) {
 
 func TestToolResultContentToPart_UTF8Sanitization(t *testing.T) {
 	t.Parallel()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	t.Run("TextWithInvalidUTF8", func(t *testing.T) {
 		t.Parallel()

--- a/coderd/x/chatd/chattool/computeruse_test.go
+++ b/coderd/x/chatd/chattool/computeruse_test.go
@@ -15,7 +15,6 @@ import (
 	"go.uber.org/mock/gomock"
 	"golang.org/x/xerrors"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	openaicomputeruse "github.com/coder/coder/v2/coderd/x/chatd/chatopenai/computeruse"
 	"github.com/coder/coder/v2/coderd/x/chatd/chattool"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
@@ -174,7 +173,7 @@ func TestComputerUseTool_Run_Screenshot(t *testing.T) {
 
 	tool := chattool.NewComputerUseTool(chattool.ComputerUseProviderAnthropic, geometry.DeclaredWidth, geometry.DeclaredHeight, func(_ context.Context) (workspacesdk.AgentConn, error) {
 		return mockConn, nil
-	}, nil, quartz.NewReal(), slogtest.Make(t, nil))
+	}, nil, quartz.NewReal(), testutil.Logger(t))
 
 	call := fantasy.ToolCall{
 		ID:    "test-1",
@@ -228,7 +227,7 @@ func TestComputerUseTool_Run_Screenshot_PersistsAttachment(t *testing.T) {
 			MediaType: storedType,
 			Name:      name,
 		}, nil
-	}, quartz.NewReal(), slogtest.Make(t, nil))
+	}, quartz.NewReal(), testutil.Logger(t))
 
 	resp, err := tool.Run(context.Background(), fantasy.ToolCall{
 		ID: "test-screenshot-persist", Name: "computer", Input: `{"action":"screenshot"}`,
@@ -274,7 +273,7 @@ func TestComputerUseTool_Run_Screenshot_StoreErrorFallsBackToImage(t *testing.T)
 		return mockConn, nil
 	}, func(_ context.Context, _ string, _ string, _ []byte) (chattool.AttachmentMetadata, error) {
 		return chattool.AttachmentMetadata{}, xerrors.New("chat already has the maximum of 20 linked files")
-	}, quartz.NewReal(), slogtest.Make(t, nil))
+	}, quartz.NewReal(), testutil.Logger(t))
 
 	resp, err := tool.Run(context.Background(), fantasy.ToolCall{
 		ID: "test-screenshot-store-error", Name: "computer", Input: `{"action":"screenshot"}`,
@@ -311,7 +310,7 @@ func TestComputerUseTool_Run_Screenshot_OversizedAttachmentFallsBackToImage(t *t
 	}, func(_ context.Context, _ string, _ string, _ []byte) (chattool.AttachmentMetadata, error) {
 		t.Fatal("storeFile should not be called for oversized screenshots")
 		return chattool.AttachmentMetadata{}, nil
-	}, quartz.NewReal(), slogtest.Make(t, nil))
+	}, quartz.NewReal(), testutil.Logger(t))
 
 	resp, err := tool.Run(context.Background(), fantasy.ToolCall{
 		ID: "test-screenshot-oversized", Name: "computer", Input: `{"action":"screenshot"}`,
@@ -371,7 +370,7 @@ func TestComputerUseTool_Run_LeftClick(t *testing.T) {
 	}, func(_ context.Context, _ string, _ string, _ []byte) (chattool.AttachmentMetadata, error) {
 		t.Fatal("storeFile should not be called for left_click follow-up screenshots")
 		return chattool.AttachmentMetadata{}, nil
-	}, quartz.NewReal(), slogtest.Make(t, nil))
+	}, quartz.NewReal(), testutil.Logger(t))
 
 	call := fantasy.ToolCall{
 		ID:    "test-2",
@@ -419,7 +418,7 @@ func TestComputerUseTool_Run_Wait(t *testing.T) {
 	}, func(_ context.Context, _ string, _ string, _ []byte) (chattool.AttachmentMetadata, error) {
 		t.Fatal("storeFile should not be called for wait screenshots")
 		return chattool.AttachmentMetadata{}, nil
-	}, quartz.NewReal(), slogtest.Make(t, nil))
+	}, quartz.NewReal(), testutil.Logger(t))
 
 	call := fantasy.ToolCall{
 		ID:    "test-3",
@@ -469,7 +468,7 @@ func TestComputerUseTool_Run_ScreenshotDataIsDecodedBinary(t *testing.T) {
 		},
 		nil,
 		quartz.NewReal(),
-		slogtest.Make(t, nil),
+		testutil.Logger(t),
 	)
 
 	call := fantasy.ToolCall{
@@ -505,7 +504,7 @@ func TestComputerUseTool_Run_ConnError(t *testing.T) {
 	geometry := workspacesdk.DefaultDesktopGeometry()
 	tool := chattool.NewComputerUseTool(chattool.ComputerUseProviderAnthropic, geometry.DeclaredWidth, geometry.DeclaredHeight, func(_ context.Context) (workspacesdk.AgentConn, error) {
 		return nil, xerrors.New("workspace not available")
-	}, nil, quartz.NewReal(), slogtest.Make(t, nil))
+	}, nil, quartz.NewReal(), testutil.Logger(t))
 
 	call := fantasy.ToolCall{
 		ID:    "test-4",
@@ -525,7 +524,7 @@ func TestComputerUseTool_Run_InvalidInput(t *testing.T) {
 	geometry := workspacesdk.DefaultDesktopGeometry()
 	tool := chattool.NewComputerUseTool(chattool.ComputerUseProviderAnthropic, geometry.DeclaredWidth, geometry.DeclaredHeight, func(_ context.Context) (workspacesdk.AgentConn, error) {
 		return nil, xerrors.New("should not be called")
-	}, nil, quartz.NewReal(), slogtest.Make(t, nil))
+	}, nil, quartz.NewReal(), testutil.Logger(t))
 
 	call := fantasy.ToolCall{
 		ID:    "test-5",
@@ -1007,7 +1006,7 @@ func newOpenAIComputerUseTool(
 		},
 		storeFile,
 		clock,
-		slogtest.Make(t, nil),
+		testutil.Logger(t),
 	)
 }
 

--- a/coderd/x/chatd/chattool/createworkspace_test.go
+++ b/coderd/x/chatd/chattool/createworkspace_test.go
@@ -15,7 +15,6 @@ import (
 	"go.uber.org/mock/gomock"
 	"golang.org/x/xerrors"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbmock"
@@ -23,6 +22,7 @@ import (
 	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/codersdk/workspacesdk"
+	"github.com/coder/coder/v2/testutil"
 )
 
 func newCreateWorkspaceMockStore(ctrl *gomock.Controller) *dbmock.MockStore {
@@ -300,7 +300,7 @@ func TestCreateWorkspace_PrefersChatSuffixAgent(t *testing.T) {
 		CreateFn:    createFn,
 		AgentConnFn: agentConnFn,
 		WorkspaceMu: &sync.Mutex{},
-		Logger:      slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+		Logger:      testutil.Logger(t, testutil.WithIgnoreErrors()),
 	})
 
 	input := fmt.Sprintf(`{"template_id":%q,"name":"test-chat-agent"}`, templateID.String())
@@ -402,7 +402,7 @@ func TestCreateWorkspace_ReturnsSelectionErrorImmediately(t *testing.T) {
 			return nil, nil, xerrors.New("unexpected agent dial")
 		},
 		WorkspaceMu: &sync.Mutex{},
-		Logger:      slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+		Logger:      testutil.Logger(t, testutil.WithIgnoreErrors()),
 	})
 
 	input := fmt.Sprintf(`{"template_id":%q,"name":"test-selection-error"}`, templateID.String())
@@ -498,7 +498,7 @@ func TestCreateWorkspace_PostCreationBuildFailure(t *testing.T) {
 
 		CreateFn:    createFn,
 		WorkspaceMu: &sync.Mutex{},
-		Logger:      slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+		Logger:      testutil.Logger(t, testutil.WithIgnoreErrors()),
 	})
 
 	input := fmt.Sprintf(`{"template_id":%q,"name":"test-build-fail"}`, templateID.String())
@@ -611,7 +611,7 @@ func TestCreateWorkspace_PostCreationQuotaFailure(t *testing.T) {
 		OwnerID:     ownerID,
 		CreateFn:    createFn,
 		WorkspaceMu: &sync.Mutex{},
-		Logger:      slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+		Logger:      testutil.Logger(t, testutil.WithIgnoreErrors()),
 	})
 
 	input := fmt.Sprintf(`{"template_id":%q,"name":"test-quota-fail"}`, templateID.String())
@@ -742,7 +742,7 @@ func TestCreateWorkspace_ExistingBuildQuotaFailure(t *testing.T) {
 			return codersdk.Workspace{}, nil
 		},
 		WorkspaceMu: &sync.Mutex{},
-		Logger:      slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+		Logger:      testutil.Logger(t, testutil.WithIgnoreErrors()),
 	})
 
 	input := fmt.Sprintf(`{"template_id":%q,"name":"test-existing-quota-fail"}`, templateID.String())
@@ -816,7 +816,7 @@ func TestCreateWorkspace_ResponderErrorPreservesStructuredFields(t *testing.T) {
 			})
 		},
 		WorkspaceMu: &sync.Mutex{},
-		Logger:      slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+		Logger:      testutil.Logger(t, testutil.WithIgnoreErrors()),
 	})
 
 	input := fmt.Sprintf(`{"template_id":%q,"name":"test-structured-error"}`, templateID.String())
@@ -952,7 +952,7 @@ func TestCreateWorkspace_GlobalTTL(t *testing.T) {
 
 				CreateFn:    createFn,
 				WorkspaceMu: &sync.Mutex{},
-				Logger:      slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+				Logger:      testutil.Logger(t, testutil.WithIgnoreErrors()),
 			})
 
 			input := fmt.Sprintf(`{"template_id":%q,"name":"test-ws-%s"}`, templateID.String(), tc.name)
@@ -1025,7 +1025,7 @@ func TestCreateWorkspace_RejectsCrossOrgTemplate(t *testing.T) {
 			return codersdk.Workspace{}, nil
 		},
 		WorkspaceMu: &sync.Mutex{},
-		Logger:      slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+		Logger:      testutil.Logger(t, testutil.WithIgnoreErrors()),
 	})
 
 	input := fmt.Sprintf(`{"template_id":%q}`, templateID.String())
@@ -1087,7 +1087,7 @@ func TestCreateWorkspace_BlocksExternalTemplate(t *testing.T) {
 			return codersdk.Workspace{}, nil
 		},
 		WorkspaceMu: &sync.Mutex{},
-		Logger:      slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+		Logger:      testutil.Logger(t, testutil.WithIgnoreErrors()),
 	})
 
 	input := fmt.Sprintf(`{"template_id":%q}`, templateID.String())
@@ -1514,7 +1514,7 @@ func TestWaitForBuild_CanceledJob(t *testing.T) {
 
 		CreateFn:    createFn,
 		WorkspaceMu: &sync.Mutex{},
-		Logger:      slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+		Logger:      testutil.Logger(t, testutil.WithIgnoreErrors()),
 	})
 
 	input := fmt.Sprintf(`{"template_id":%q,"name":"test-build-cancel"}`, templateID.String())
@@ -1755,7 +1755,7 @@ func TestCreateWorkspace_OnChatUpdatedFiresAfterBuild(t *testing.T) {
 
 		CreateFn:    createFn,
 		WorkspaceMu: &sync.Mutex{},
-		Logger:      slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+		Logger:      testutil.Logger(t, testutil.WithIgnoreErrors()),
 		OnChatUpdated: func(chat database.Chat) {
 			mu.Lock()
 			callbackChats = append(callbackChats, chat)
@@ -1914,7 +1914,7 @@ func TestCreateWorkspace_WithPresetID(t *testing.T) {
 		CreateFn:    createFn,
 		AgentConnFn: agentConnFn,
 		WorkspaceMu: &sync.Mutex{},
-		Logger:      slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+		Logger:      testutil.Logger(t, testutil.WithIgnoreErrors()),
 	})
 
 	input := fmt.Sprintf(
@@ -1947,7 +1947,7 @@ func TestCreateWorkspace_InvalidPresetID(t *testing.T) {
 			return codersdk.Workspace{}, nil
 		},
 		WorkspaceMu: &sync.Mutex{},
-		Logger:      slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+		Logger:      testutil.Logger(t, testutil.WithIgnoreErrors()),
 	})
 
 	input := fmt.Sprintf(
@@ -1995,7 +1995,7 @@ func TestCreateWorkspace_WithPresetAndParams(t *testing.T) {
 		CreateFn:    createFn,
 		AgentConnFn: agentConnFn,
 		WorkspaceMu: &sync.Mutex{},
-		Logger:      slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+		Logger:      testutil.Logger(t, testutil.WithIgnoreErrors()),
 	})
 
 	input := fmt.Sprintf(

--- a/coderd/x/chatd/chattool/startworkspace_test.go
+++ b/coderd/x/chatd/chattool/startworkspace_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbfake"
@@ -668,7 +667,7 @@ func TestStartWorkspace(t *testing.T) {
 				return codersdk.WorkspaceBuild{}, nil
 			},
 			WorkspaceMu:   &sync.Mutex{},
-			Logger:        slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+			Logger:        testutil.Logger(t, testutil.WithIgnoreErrors()),
 			OnChatUpdated: func(_ database.Chat) { onChatUpdatedCalled.Store(true) },
 		})
 
@@ -743,7 +742,7 @@ func TestStartWorkspace(t *testing.T) {
 		authzDB := dbauthz.New(
 			db,
 			rbac.NewStrictCachingAuthorizer(prometheus.NewRegistry()),
-			slogtest.Make(t, nil),
+			testutil.Logger(t),
 			testAccessControlStorePointer(),
 		)
 		jobRead := make(chan struct{}, 1)
@@ -759,7 +758,7 @@ func TestStartWorkspace(t *testing.T) {
 				return codersdk.WorkspaceBuild{}, nil
 			},
 			WorkspaceMu: &sync.Mutex{},
-			Logger:      slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+			Logger:      testutil.Logger(t, testutil.WithIgnoreErrors()),
 		})
 
 		type toolResult struct {
@@ -862,7 +861,7 @@ func TestStartWorkspace(t *testing.T) {
 				return nil, func() {}, nil
 			},
 			WorkspaceMu: &sync.Mutex{},
-			Logger:      slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+			Logger:      testutil.Logger(t, testutil.WithIgnoreErrors()),
 		})
 
 		type toolResult struct {

--- a/coderd/x/chatd/chattool/stopworkspace_test.go
+++ b/coderd/x/chatd/chattool/stopworkspace_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbfake"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
@@ -270,7 +269,7 @@ func TestStopWorkspace(t *testing.T) {
 				return codersdk.WorkspaceBuild{ID: buildResp.Build.ID}, nil
 			},
 			WorkspaceMu:   &sync.Mutex{},
-			Logger:        slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+			Logger:        testutil.Logger(t, testutil.WithIgnoreErrors()),
 			OnChatUpdated: func(_ database.Chat) { onChatUpdatedCalled.Store(true) },
 		})
 
@@ -412,7 +411,7 @@ func TestStopWorkspace(t *testing.T) {
 			OwnerID:     user.ID,
 			StopFn:      stopFn,
 			WorkspaceMu: &sync.Mutex{},
-			Logger:      slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+			Logger:      testutil.Logger(t, testutil.WithIgnoreErrors()),
 		})
 
 		type toolResult struct {

--- a/coderd/x/chatd/dynamictool_internal_test.go
+++ b/coderd/x/chatd/dynamictool_internal_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/codersdk"
+	"github.com/coder/coder/v2/testutil"
 )
 
 func TestDynamicToolsFromSDK(t *testing.T) {
@@ -15,14 +15,14 @@ func TestDynamicToolsFromSDK(t *testing.T) {
 
 	t.Run("EmptySlice", func(t *testing.T) {
 		t.Parallel()
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 		result := dynamicToolsFromSDK(logger, nil)
 		require.Nil(t, result)
 	})
 
 	t.Run("ValidToolWithSchema", func(t *testing.T) {
 		t.Parallel()
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 		tools := []codersdk.DynamicTool{
 			{
 				Name:        "my_tool",
@@ -43,7 +43,7 @@ func TestDynamicToolsFromSDK(t *testing.T) {
 
 	t.Run("ToolWithoutSchema", func(t *testing.T) {
 		t.Parallel()
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 		tools := []codersdk.DynamicTool{
 			{
 				Name:        "no_schema",
@@ -61,7 +61,7 @@ func TestDynamicToolsFromSDK(t *testing.T) {
 
 	t.Run("MalformedSchema", func(t *testing.T) {
 		t.Parallel()
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 		tools := []codersdk.DynamicTool{
 			{
 				Name:        "bad_schema",
@@ -80,7 +80,7 @@ func TestDynamicToolsFromSDK(t *testing.T) {
 
 	t.Run("MultipleTools", func(t *testing.T) {
 		t.Parallel()
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 		tools := []codersdk.DynamicTool{
 			{Name: "first", Description: "First tool"},
 			{Name: "second", Description: "Second tool"},
@@ -95,7 +95,7 @@ func TestDynamicToolsFromSDK(t *testing.T) {
 
 	t.Run("SchemaWithoutProperties", func(t *testing.T) {
 		t.Parallel()
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 		tools := []codersdk.DynamicTool{
 			{
 				Name:        "bare_schema",

--- a/coderd/x/chatd/mcpclient/coder_headers_test.go
+++ b/coderd/x/chatd/mcpclient/coder_headers_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatprovider"
 	"github.com/coder/coder/v2/coderd/x/chatd/mcpclient"
+	"github.com/coder/coder/v2/testutil"
 )
 
 // newHeaderRecordingServer creates a streamable HTTP MCP server with a
@@ -51,7 +51,7 @@ func newHeaderRecordingServer(t *testing.T) (*httptest.Server, *sync.Mutex, *[]h
 func TestConnectAll_ForwardCoderHeaders_DefaultOff(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	ts, mu, recorded := newHeaderRecordingServer(t)
 
@@ -93,7 +93,7 @@ func TestConnectAll_ForwardCoderHeaders_DefaultOff(t *testing.T) {
 func TestConnectAll_ForwardCoderHeaders_Enabled(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	ts, mu, recorded := newHeaderRecordingServer(t)
 
@@ -142,7 +142,7 @@ func TestConnectAll_ForwardCoderHeaders_Enabled(t *testing.T) {
 func TestConnectAll_ForwardCoderHeaders_RootChat(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	ts, mu, recorded := newHeaderRecordingServer(t)
 
@@ -185,7 +185,7 @@ func TestConnectAll_ForwardCoderHeaders_RootChat(t *testing.T) {
 func TestConnectAll_ForwardCoderHeaders_WithAPIKeyAuth(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	ts, mu, recorded := newHeaderRecordingServer(t)
 
@@ -230,7 +230,7 @@ func TestConnectAll_ForwardCoderHeaders_WithAPIKeyAuth(t *testing.T) {
 func TestConnectAll_ForwardCoderHeaders_WithOAuth2(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	ts, mu, recorded := newHeaderRecordingServer(t)
 
@@ -285,7 +285,7 @@ func TestConnectAll_ForwardCoderHeaders_WithOAuth2(t *testing.T) {
 func TestConnectAll_ForwardCoderHeaders_WithCustomHeaders(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	ts, mu, recorded := newHeaderRecordingServer(t)
 

--- a/coderd/x/chatd/mcpclient/mcpclient_test.go
+++ b/coderd/x/chatd/mcpclient/mcpclient_test.go
@@ -18,9 +18,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/x/chatd/mcpclient"
+	"github.com/coder/coder/v2/testutil"
 )
 
 // newTestMCPServer creates a streamable HTTP MCP server with the
@@ -91,7 +91,7 @@ func makeConfig(slug, url string) database.MCPServerConfig {
 func TestConnectAll_DiscoverTools(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	ts := newTestMCPServer(t, echoTool(), greetTool())
 
@@ -116,7 +116,7 @@ func TestConnectAll_DiscoverTools(t *testing.T) {
 func TestConnectAll_CallTool(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	ts := newTestMCPServer(t, echoTool())
 
@@ -139,7 +139,7 @@ func TestConnectAll_CallTool(t *testing.T) {
 func TestConnectAll_ToolAllowList(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	ts := newTestMCPServer(t, echoTool(), greetTool())
 
@@ -157,7 +157,7 @@ func TestConnectAll_ToolAllowList(t *testing.T) {
 func TestConnectAll_ToolDenyList(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	ts := newTestMCPServer(t, echoTool(), greetTool())
 
@@ -175,7 +175,7 @@ func TestConnectAll_ToolDenyList(t *testing.T) {
 func TestConnectAll_ConnectionFailure(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	cfg := makeConfig("bad", "http://127.0.0.1:0/does-not-exist")
 
@@ -188,7 +188,7 @@ func TestConnectAll_ConnectionFailure(t *testing.T) {
 func TestConnectAll_MultipleServers(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	ts1 := newTestMCPServer(t, echoTool())
 	ts2 := newTestMCPServer(t, greetTool())
@@ -215,7 +215,7 @@ func TestConnectAll_MultipleServers(t *testing.T) {
 func TestConnectAll_NoToolsAfterFiltering(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	ts := newTestMCPServer(t, echoTool())
 
@@ -241,7 +241,7 @@ func TestConnectAll_DeterministicOrder(t *testing.T) {
 	t.Run("AcrossServers", func(t *testing.T) {
 		t.Parallel()
 		ctx := context.Background()
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 		ts1 := newTestMCPServer(t, makeTool("zebra"))
 		ts2 := newTestMCPServer(t, makeTool("alpha"))
@@ -273,7 +273,7 @@ func TestConnectAll_DeterministicOrder(t *testing.T) {
 	t.Run("WithMultiToolServer", func(t *testing.T) {
 		t.Parallel()
 		ctx := context.Background()
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 		multi := newTestMCPServer(t, makeTool("zeta"), makeTool("beta"))
 		other := newTestMCPServer(t, makeTool("gamma"))
@@ -301,7 +301,7 @@ func TestConnectAll_DeterministicOrder(t *testing.T) {
 	t.Run("TiebreakByConfigID", func(t *testing.T) {
 		t.Parallel()
 		ctx := context.Background()
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 		ts1 := newTestMCPServer(t, makeTool("b__z"))
 		ts2 := newTestMCPServer(t, makeTool("z"))
@@ -338,7 +338,7 @@ func TestConnectAll_DeterministicOrder(t *testing.T) {
 func TestConnectAll_AuthHeaders(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	// Create a server whose tool handler records the Authorization
 	// header it receives on each request.
@@ -434,7 +434,7 @@ func findTool(tools []fantasy.AgentTool, name string) fantasy.AgentTool {
 func TestConnectAll_DisabledServer(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	ts := newTestMCPServer(t, echoTool())
 
@@ -451,7 +451,7 @@ func TestConnectAll_DisabledServer(t *testing.T) {
 func TestConnectAll_CallToolInvalidInput(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	ts := newTestMCPServer(t, echoTool())
 
@@ -476,7 +476,7 @@ func TestConnectAll_CallToolInvalidInput(t *testing.T) {
 func TestConnectAll_ToolInfoParameters(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	ts := newTestMCPServer(t, echoTool())
 
@@ -508,7 +508,7 @@ func TestConnectAll_ToolInfoParameters(t *testing.T) {
 func TestConnectAll_NilRequiredBecomesEmptySlice(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	// noRequiredTool defines a tool with no required parameters.
 	noRequiredTool := mcpserver.ServerTool{
@@ -543,7 +543,7 @@ func TestConnectAll_NilRequiredBecomesEmptySlice(t *testing.T) {
 func TestConnectAll_APIKeyAuth(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	var (
 		mu          sync.Mutex
@@ -602,7 +602,7 @@ func TestConnectAll_APIKeyAuth(t *testing.T) {
 func TestConnectAll_CustomHeadersAuth(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	var (
 		mu          sync.Mutex
@@ -661,7 +661,7 @@ func TestConnectAll_CustomHeadersAuth(t *testing.T) {
 func TestConnectAll_CustomHeadersInvalidJSON(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	ts := newTestMCPServer(t, echoTool())
 
@@ -699,7 +699,7 @@ func (s staticOIDCSource) OIDCAccessToken(_ context.Context, _ uuid.UUID) (strin
 func TestConnectAll_UserOIDCAuth(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	var (
 		mu          sync.Mutex
@@ -759,7 +759,7 @@ func TestConnectAll_UserOIDCAuth(t *testing.T) {
 func TestConnectAll_UserOIDCAuth_NoLink(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	var (
 		mu          sync.Mutex
@@ -817,7 +817,7 @@ func TestConnectAll_UserOIDCAuth_NoLink(t *testing.T) {
 func TestConnectAll_UserOIDCAuth_NilSource(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	ts := newTestMCPServer(t, echoTool())
 
@@ -840,7 +840,7 @@ func TestConnectAll_UserOIDCAuth_NilSource(t *testing.T) {
 func TestConnectAll_ParallelConnections(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	ts1 := newTestMCPServer(t, echoTool())
 	ts2 := newTestMCPServer(t, greetTool())
@@ -894,7 +894,7 @@ func TestRedactURL(t *testing.T) {
 func TestConnectAll_ExpiredToken(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	ts := newTestMCPServer(t, echoTool())
 
@@ -928,7 +928,7 @@ func TestConnectAll_ExpiredToken(t *testing.T) {
 func TestConnectAll_EmptyAccessToken(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	ts := newTestMCPServer(t, echoTool())
 
@@ -964,7 +964,7 @@ func TestConnectAll_EmptyAccessToken(t *testing.T) {
 func TestConnectAll_MCPToolIdentifier(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	ts := newTestMCPServer(t, echoTool())
 
@@ -995,7 +995,7 @@ func TestConnectAll_MCPToolIdentifier(t *testing.T) {
 func TestConnectAll_MCPToolIdentifier_MultipleServers(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	ts1 := newTestMCPServer(t, echoTool())
 	ts2 := newTestMCPServer(t, greetTool())
@@ -1051,7 +1051,7 @@ func TestConnectAll_MCPToolIdentifier_MultipleServers(t *testing.T) {
 func TestConnectAll_EmbeddedResourceText(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	srv := mcpserver.NewMCPServer("embedded-text-server", "1.0.0")
 	srv.AddTools(mcpserver.ServerTool{
@@ -1119,7 +1119,7 @@ func TestConnectAll_EmbeddedResourceBlob(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()
-			logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+			logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 			blobData := base64.StdEncoding.EncodeToString([]byte("binary-content"))
 			mime := tt.mimeType
@@ -1210,7 +1210,7 @@ func TestConnectAll_ResourceLink(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()
-			logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+			logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 			link := tt.link
 			srv := mcpserver.NewMCPServer("resource-link-server", "1.0.0")
@@ -1254,7 +1254,7 @@ func TestConnectAll_ResourceLink(t *testing.T) {
 func TestConnectAll_CallToolError(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	// Server with a tool that always returns an error result.
 	srv := mcpserver.NewMCPServer("error-server", "1.0.0")
@@ -1291,7 +1291,7 @@ func TestConnectAll_CallToolError(t *testing.T) {
 func TestModelIntent_Info_WrapsSchema(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	ts := newTestMCPServer(t, echoTool())
 
@@ -1327,7 +1327,7 @@ func TestModelIntent_Info_WrapsSchema(t *testing.T) {
 func TestModelIntent_Info_NoWrapWhenDisabled(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	ts := newTestMCPServer(t, echoTool())
 
@@ -1350,7 +1350,7 @@ func TestModelIntent_Info_NoWrapWhenDisabled(t *testing.T) {
 func TestModelIntent_Run_UnwrapsProperties(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	ts := newTestMCPServer(t, echoTool())
 
@@ -1375,7 +1375,7 @@ func TestModelIntent_Run_UnwrapsProperties(t *testing.T) {
 func TestModelIntent_Run_UnwrapsFlat(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	ts := newTestMCPServer(t, echoTool())
 
@@ -1400,7 +1400,7 @@ func TestModelIntent_Run_UnwrapsFlat(t *testing.T) {
 func TestModelIntent_Run_PassthroughWhenDisabled(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	ts := newTestMCPServer(t, echoTool())
 
@@ -1425,7 +1425,7 @@ func TestModelIntent_Run_PassthroughWhenDisabled(t *testing.T) {
 func TestModelIntent_Run_FallbackOnBadJSON(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	ts := newTestMCPServer(t, echoTool())
 

--- a/coderd/x/chatd/quickgen_test.go
+++ b/coderd/x/chatd/quickgen_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/sqlc-dev/pqtype"
 	"github.com/stretchr/testify/require"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
@@ -418,7 +417,7 @@ func TestMaybeGenerateChatTitlePreservesUpdatedAt(t *testing.T) {
 	)
 	message.ID = 1
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	generated := &generatedChatTitle{}
 	server := &Server{db: db}
 	server.maybeGenerateChatTitle(

--- a/coderd/x/chatd/subagent_internal_test.go
+++ b/coderd/x/chatd/subagent_internal_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
@@ -78,7 +77,7 @@ func newInternalTestServer(
 		db,
 		ps,
 		keys,
-		slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+		testutil.Logger(t, testutil.WithIgnoreErrors()),
 		nil,
 	)
 }
@@ -95,7 +94,7 @@ func newInternalTestServerWithClock(
 		db,
 		ps,
 		keys,
-		slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+		testutil.Logger(t, testutil.WithIgnoreErrors()),
 		clk,
 	)
 }
@@ -910,7 +909,7 @@ func TestSpawnAgent_GeneralOverrideLogsAndFallsBackWhenCredentialsUnavailable(t 
 
 	db, ps := dbtestutil.NewDB(t)
 	logSink := &subagentTestLogSink{}
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).AppendSinks(logSink)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).AppendSinks(logSink)
 	server := newInternalTestServerWithLogger(t, db, ps, chatprovider.ProviderAPIKeys{}, logger)
 
 	ctx := chatdTestContext(t)
@@ -968,7 +967,7 @@ func TestSpawnAgent_GeneralOverrideLogsAndFallsBackWhenProviderDisabled(t *testi
 
 	db, ps := dbtestutil.NewDB(t)
 	logSink := &subagentTestLogSink{}
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).AppendSinks(logSink)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).AppendSinks(logSink)
 	server := newInternalTestServerWithLogger(
 		t,
 		db,
@@ -1038,7 +1037,7 @@ func TestResolveConfiguredModelOverride_AcceptsAmbientCredentialsProvider(
 	t.Parallel()
 
 	logSink := &subagentTestLogSink{}
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).AppendSinks(logSink)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).AppendSinks(logSink)
 	server := &Server{logger: logger}
 	ctx := chatdTestContext(t)
 	ownerID := uuid.New()
@@ -1995,7 +1994,7 @@ func TestSpawnAgent_ComputerUseRejectsInvalidConfiguredProviderWithStableReason(
 	require.NoError(t, db.UpsertChatDesktopEnabled(ctx, true))
 	require.NoError(t, db.UpsertChatComputerUseProvider(ctx, "bogus"))
 	logSink := &subagentTestLogSink{}
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).AppendSinks(logSink)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).AppendSinks(logSink)
 	server := newInternalTestServerWithLogger(t, db, ps, chatprovider.ProviderAPIKeys{}, logger)
 
 	user, org, model := seedInternalChatDeps(t, db)

--- a/coderd/x/chatd/title_override_test.go
+++ b/coderd/x/chatd/title_override_test.go
@@ -13,7 +13,6 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbmock"
 	"github.com/coder/coder/v2/coderd/x/chatd/chatprovider"
@@ -32,7 +31,7 @@ func TestMaybeGenerateChatTitle_TitleGenerationOverrideUnset(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitShort)
 		ctrl := gomock.NewController(t)
 		db := dbmock.NewMockStore(ctrl)
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 		chat, messages := titleOverrideTestChatAndMessages(t)
 		wantTitle := "Preferred title"
 
@@ -83,7 +82,7 @@ func TestMaybeGenerateChatTitle_TitleGenerationOverrideUnset(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitShort)
 		ctrl := gomock.NewController(t)
 		db := dbmock.NewMockStore(ctrl)
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 		chat, messages := titleOverrideTestChatAndMessages(t)
 		wantTitle := "Fallback title"
 
@@ -131,7 +130,7 @@ func TestMaybeGenerateChatTitle_TitleGenerationOverrideReadDBError(t *testing.T)
 	ctx := testutil.Context(t, testutil.WaitShort)
 	ctrl := gomock.NewController(t)
 	db := dbmock.NewMockStore(ctrl)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	chat, messages := titleOverrideTestChatAndMessages(t)
 	wantTitle := "Fallback title"
 
@@ -178,7 +177,7 @@ func TestMaybeGenerateChatTitle_TitleGenerationOverrideMalformedFallsThrough(t *
 	ctx := testutil.Context(t, testutil.WaitShort)
 	ctrl := gomock.NewController(t)
 	db := dbmock.NewMockStore(ctrl)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	chat, messages := titleOverrideTestChatAndMessages(t)
 	wantTitle := "Fallback title"
 
@@ -225,7 +224,7 @@ func TestMaybeGenerateChatTitle_TitleGenerationOverrideSetUsable(t *testing.T) {
 	ctx := testutil.Context(t, testutil.WaitShort)
 	ctrl := gomock.NewController(t)
 	db := dbmock.NewMockStore(ctrl)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	chat, messages := titleOverrideTestChatAndMessages(t)
 	overrideConfig := titleOverrideModelConfig("gpt-4.1", true)
 	wantTitle := "Override title"
@@ -279,7 +278,7 @@ func TestMaybeGenerateChatTitle_TitleGenerationOverrideSetUnusableSkips(t *testi
 	ctx := testutil.Context(t, testutil.WaitShort)
 	ctrl := gomock.NewController(t)
 	db := dbmock.NewMockStore(ctrl)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	chat, messages := titleOverrideTestChatAndMessages(t)
 	overrideConfig := titleOverrideModelConfig("gpt-4.1", false)
 	fallbackModel := &chattest.FakeModel{
@@ -317,7 +316,7 @@ func TestMaybeGenerateChatTitle_TitleGenerationOverrideCallFailureSkipsFallback(
 	ctx := testutil.Context(t, testutil.WaitShort)
 	ctrl := gomock.NewController(t)
 	db := dbmock.NewMockStore(ctrl)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	chat, messages := titleOverrideTestChatAndMessages(t)
 	overrideConfig := titleOverrideModelConfig("gpt-4.1", true)
 
@@ -365,7 +364,7 @@ func TestResolveManualTitleModel_TitleGenerationOverrideUnset(t *testing.T) {
 	ctx := testutil.Context(t, testutil.WaitShort)
 	ctrl := gomock.NewController(t)
 	db := dbmock.NewMockStore(ctrl)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	chat, _ := titleOverrideTestChatAndMessages(t)
 	preferredConfig := database.ChatModelConfig{
 		ID:       uuid.New(),
@@ -398,7 +397,7 @@ func TestResolveManualTitleModel_TitleGenerationOverrideReadDBError(t *testing.T
 	ctx := testutil.Context(t, testutil.WaitShort)
 	ctrl := gomock.NewController(t)
 	db := dbmock.NewMockStore(ctrl)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	chat, _ := titleOverrideTestChatAndMessages(t)
 	preferredConfig := database.ChatModelConfig{
 		ID:       uuid.New(),
@@ -431,7 +430,7 @@ func TestResolveManualTitleModel_TitleGenerationOverrideSetUsable(t *testing.T) 
 	ctx := testutil.Context(t, testutil.WaitShort)
 	ctrl := gomock.NewController(t)
 	db := dbmock.NewMockStore(ctrl)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	chat, _ := titleOverrideTestChatAndMessages(t)
 	overrideConfig := titleOverrideModelConfig("gpt-4.1", true)
 
@@ -457,7 +456,7 @@ func TestResolveManualTitleModel_TitleGenerationOverrideMissingCredentials(t *te
 	ctx := testutil.Context(t, testutil.WaitShort)
 	ctrl := gomock.NewController(t)
 	db := dbmock.NewMockStore(ctrl)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	chat, _ := titleOverrideTestChatAndMessages(t)
 	overrideConfig := titleOverrideModelConfig("gpt-4.1", true)
 
@@ -485,7 +484,7 @@ func TestResolveManualTitleModel_TitleGenerationOverrideSetUnusable(t *testing.T
 	ctx := testutil.Context(t, testutil.WaitShort)
 	ctrl := gomock.NewController(t)
 	db := dbmock.NewMockStore(ctrl)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	chat, _ := titleOverrideTestChatAndMessages(t)
 	overrideConfig := titleOverrideModelConfig("gpt-4.1", false)
 

--- a/coderd/x/chatd/turn_summary_internal_test.go
+++ b/coderd/x/chatd/turn_summary_internal_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
@@ -66,7 +65,7 @@ func TestUpdateLastTurnSummaryRejectsStaleWrites(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	server := &Server{db: db}
 	server.updateLastTurnSummary(ctx, chat, chat.UpdatedAt, "fresh summary", logger)
 
@@ -151,7 +150,7 @@ func TestPendingChatPersistsSummaryButSkipsWebPush(t *testing.T) {
 	}
 
 	dispatcher := &recordingWebpushDispatcher{}
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	server := &Server{db: db, webpushDispatcher: dispatcher}
 	server.maybeFinalizeTurnStatusLabelAndPush(
 		context.WithoutCancel(ctx),

--- a/coderd/x/gitsync/gitsync_test.go
+++ b/coderd/x/gitsync/gitsync_test.go
@@ -15,11 +15,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/externalauth/gitprovider"
 	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/coderd/x/gitsync"
+	"github.com/coder/coder/v2/testutil"
 	"github.com/coder/quartz"
 )
 
@@ -133,7 +133,7 @@ func TestRefresher_WithPRURL(t *testing.T) {
 		return ptr.Ref("test-token"), nil
 	}
 
-	r := gitsync.NewRefresher(providers, tokens, slogtest.Make(t, nil), quartz.NewReal())
+	r := gitsync.NewRefresher(providers, tokens, testutil.Logger(t), quartz.NewReal())
 
 	chatID := uuid.New()
 	row := database.ChatDiffStatus{
@@ -189,7 +189,7 @@ func TestRefresher_BranchResolvesToPR(t *testing.T) {
 		return ptr.Ref("test-token"), nil
 	}
 
-	r := gitsync.NewRefresher(providers, tokens, slogtest.Make(t, nil), quartz.NewReal())
+	r := gitsync.NewRefresher(providers, tokens, testutil.Logger(t), quartz.NewReal())
 
 	row := database.ChatDiffStatus{
 		ChatID:          uuid.New(),
@@ -231,7 +231,7 @@ func TestRefresher_BranchNoPRYet(t *testing.T) {
 		return ptr.Ref("test-token"), nil
 	}
 
-	r := gitsync.NewRefresher(providers, tokens, slogtest.Make(t, nil), quartz.NewReal())
+	r := gitsync.NewRefresher(providers, tokens, testutil.Logger(t), quartz.NewReal())
 
 	row := database.ChatDiffStatus{
 		ChatID:          uuid.New(),
@@ -260,7 +260,7 @@ func TestRefresher_NoProviderForOrigin(t *testing.T) {
 		return ptr.Ref("test-token"), nil
 	}
 
-	r := gitsync.NewRefresher(providers, tokens, slogtest.Make(t, nil), quartz.NewReal())
+	r := gitsync.NewRefresher(providers, tokens, testutil.Logger(t), quartz.NewReal())
 
 	row := database.ChatDiffStatus{
 		ChatID:          uuid.New(),
@@ -301,7 +301,7 @@ func TestRefresher_TokenResolutionFails(t *testing.T) {
 		return nil, errors.New("token lookup failed")
 	}
 
-	r := gitsync.NewRefresher(providers, tokens, slogtest.Make(t, nil), quartz.NewReal())
+	r := gitsync.NewRefresher(providers, tokens, testutil.Logger(t), quartz.NewReal())
 
 	row := database.ChatDiffStatus{
 		ChatID:          uuid.New(),
@@ -333,7 +333,7 @@ func TestRefresher_EmptyToken(t *testing.T) {
 		return ptr.Ref(""), nil
 	}
 
-	r := gitsync.NewRefresher(providers, tokens, slogtest.Make(t, nil), quartz.NewReal())
+	r := gitsync.NewRefresher(providers, tokens, testutil.Logger(t), quartz.NewReal())
 
 	row := database.ChatDiffStatus{
 		ChatID:          uuid.New(),
@@ -371,7 +371,7 @@ func TestRefresher_ProviderFetchFails(t *testing.T) {
 		return ptr.Ref("test-token"), nil
 	}
 
-	r := gitsync.NewRefresher(providers, tokens, slogtest.Make(t, nil), quartz.NewReal())
+	r := gitsync.NewRefresher(providers, tokens, testutil.Logger(t), quartz.NewReal())
 
 	row := database.ChatDiffStatus{
 		ChatID:          uuid.New(),
@@ -407,7 +407,7 @@ func TestRefresher_PRURLParseFailure(t *testing.T) {
 		return ptr.Ref("test-token"), nil
 	}
 
-	r := gitsync.NewRefresher(providers, tokens, slogtest.Make(t, nil), quartz.NewReal())
+	r := gitsync.NewRefresher(providers, tokens, testutil.Logger(t), quartz.NewReal())
 
 	row := database.ChatDiffStatus{
 		ChatID:          uuid.New(),
@@ -448,7 +448,7 @@ func TestRefresher_BatchGroupsByOwnerAndOrigin(t *testing.T) {
 		return ptr.Ref("test-token"), nil
 	}
 
-	r := gitsync.NewRefresher(providers, tokens, slogtest.Make(t, nil), quartz.NewReal())
+	r := gitsync.NewRefresher(providers, tokens, testutil.Logger(t), quartz.NewReal())
 
 	ownerID := uuid.New()
 	originA := "https://github.com/org/repo"
@@ -527,7 +527,7 @@ func TestRefresher_UsesInjectedClock(t *testing.T) {
 		return ptr.Ref("test-token"), nil
 	}
 
-	r := gitsync.NewRefresher(providers, tokens, slogtest.Make(t, nil), mClock)
+	r := gitsync.NewRefresher(providers, tokens, testutil.Logger(t), mClock)
 
 	chatID := uuid.New()
 	row := database.ChatDiffStatus{
@@ -581,7 +581,7 @@ func TestRefresher_RateLimitSkipsRemainingInGroup(t *testing.T) {
 
 	// Concurrency=1 ensures sequential semaphore acquisition so
 	// the rate-limit flag is always visible to later goroutines.
-	r := gitsync.NewRefresher(providers, tokens, slogtest.Make(t, nil), quartz.NewReal(), gitsync.WithConcurrency(1))
+	r := gitsync.NewRefresher(providers, tokens, testutil.Logger(t), quartz.NewReal(), gitsync.WithConcurrency(1))
 
 	ownerID := uuid.New()
 	origin := "https://github.com/org/repo"
@@ -697,7 +697,7 @@ func TestRefresher_CorrectTokenPerOrigin(t *testing.T) {
 
 	providers := func(_ string) gitprovider.Provider { return mp }
 
-	r := gitsync.NewRefresher(providers, tokens, slogtest.Make(t, nil), quartz.NewReal())
+	r := gitsync.NewRefresher(providers, tokens, testutil.Logger(t), quartz.NewReal())
 
 	ownerID := uuid.New()
 
@@ -787,7 +787,7 @@ func TestRefresher_ConcurrentProcessing(t *testing.T) {
 
 	// Concurrency must be >= numRows so all goroutines can enter
 	// simultaneously.
-	r := gitsync.NewRefresher(providers, tokens, slogtest.Make(t, nil), quartz.NewReal(), gitsync.WithConcurrency(numRows))
+	r := gitsync.NewRefresher(providers, tokens, testutil.Logger(t), quartz.NewReal(), gitsync.WithConcurrency(numRows))
 
 	ownerID := uuid.New()
 	origin := "https://github.com/org/repo"

--- a/coderd/x/gitsync/worker_test.go
+++ b/coderd/x/gitsync/worker_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbmock"
@@ -87,7 +86,7 @@ func newTestRefresher(t *testing.T, clk quartz.Clock, opts ...testRefresherOpt) 
 		return ptr.Ref("tok"), nil
 	}
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	return gitsync.NewRefresher(providers, tokens, logger, clk, cfg.refresherOpts...)
 }
 
@@ -165,7 +164,7 @@ func TestWorker_SkipsFreshRows(t *testing.T) {
 		})
 
 	mClock := quartz.NewMock(t)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	refresher := newTestRefresher(t, mClock)
 	worker := gitsync.NewWorker(store, refresher, nil, mClock, logger)
 
@@ -209,7 +208,7 @@ func TestWorker_LimitsToNRows(t *testing.T) {
 	}
 
 	mClock := quartz.NewMock(t)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	refresher := newTestRefresher(t, mClock)
 	worker := gitsync.NewWorker(store, refresher, pub, mClock, logger)
 
@@ -253,7 +252,7 @@ func TestWorker_NoPR_RecentMarkStale_BacksOffShort(t *testing.T) {
 			return nil
 		})
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	// ResolveBranchPullRequest returns nil → Refresher returns
 	// (nil, nil).
@@ -293,7 +292,7 @@ func TestWorker_NoPR_OldRow_Skips(t *testing.T) {
 		Return([]database.AcquireStaleChatDiffStatusesRow{row}, nil)
 	// BackoffChatDiffStatus should NOT be called.
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	refresher := newTestRefresher(t, mClock, withResolveBranchPR(
 		func(context.Context, string, gitprovider.BranchRef) (*gitprovider.PRRef, error) {
@@ -332,7 +331,7 @@ func TestWorker_NoPR_BoundaryExactWindow_Skips(t *testing.T) {
 		Return([]database.AcquireStaleChatDiffStatusesRow{row}, nil)
 	// BackoffChatDiffStatus should NOT be called.
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	refresher := newTestRefresher(t, mClock, withResolveBranchPR(
 		func(context.Context, string, gitprovider.BranchRef) (*gitprovider.PRRef, error) {
@@ -386,7 +385,7 @@ func TestWorker_NoPR_BackoffError_ContinuesNextRow(t *testing.T) {
 			return nil
 		}).Times(2)
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	refresher := newTestRefresher(t, mClock, withResolveBranchPR(
 		func(context.Context, string, gitprovider.BranchRef) (*gitprovider.PRRef, error) {
@@ -459,7 +458,7 @@ func TestWorker_RefresherError_BacksOffRow(t *testing.T) {
 		return nil
 	}
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	// Fail ResolveBranchPullRequest based on the branch name
 	// so the behavior is deterministic regardless of execution
@@ -549,7 +548,7 @@ func TestWorker_UpsertError_ContinuesNextRow(t *testing.T) {
 	}
 
 	mClock := quartz.NewMock(t)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	refresher := newTestRefresher(t, mClock)
 	worker := gitsync.NewWorker(store, refresher, pub, mClock, logger)
 
@@ -573,7 +572,7 @@ func TestWorker_RespectsShutdown(t *testing.T) {
 		Return(nil, nil).AnyTimes()
 
 	mClock := quartz.NewMock(t)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	refresher := newTestRefresher(t, mClock)
 	worker := gitsync.NewWorker(store, refresher, nil, mClock, logger)
 
@@ -637,7 +636,7 @@ func TestWorker_MarkStale_UpsertAndPublish(t *testing.T) {
 
 	mClock := quartz.NewMock(t)
 	now := mClock.Now()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	refresher := newTestRefresher(t, mClock)
 	worker := gitsync.NewWorker(store, refresher, pub, mClock, logger)
 
@@ -676,7 +675,7 @@ func TestWorker_MarkStale_NoMatchingChats(t *testing.T) {
 		Return(nil, nil)
 
 	mClock := quartz.NewMock(t)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	refresher := newTestRefresher(t, mClock)
 	worker := gitsync.NewWorker(store, refresher, nil, mClock, logger)
 
@@ -720,7 +719,7 @@ func TestWorker_MarkStale_UpsertFails_ContinuesNext(t *testing.T) {
 	}
 
 	mClock := quartz.NewMock(t)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	refresher := newTestRefresher(t, mClock)
 	worker := gitsync.NewWorker(store, refresher, pub, mClock, logger)
 
@@ -744,7 +743,7 @@ func TestWorker_MarkStale_GetChatsByWorkspaceIDsFails(t *testing.T) {
 		Return(nil, fmt.Errorf("db error"))
 
 	mClock := quartz.NewMock(t)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	refresher := newTestRefresher(t, mClock)
 	worker := gitsync.NewWorker(store, refresher, nil, mClock, logger)
 
@@ -771,7 +770,7 @@ func TestWorker_TickStoreError(t *testing.T) {
 		})
 
 	mClock := quartz.NewMock(t)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	refresher := newTestRefresher(t, mClock)
 	worker := gitsync.NewWorker(store, refresher, nil, mClock, logger)
 
@@ -800,7 +799,7 @@ func TestWorker_MarkStale_EmptyBranchOrOrigin(t *testing.T) {
 			store := dbmock.NewMockStore(ctrl)
 
 			mClock := quartz.NewMock(t)
-			logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+			logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 			refresher := newTestRefresher(t, mClock)
 			worker := gitsync.NewWorker(store, refresher, nil, mClock, logger)
 
@@ -844,7 +843,7 @@ func TestWorker_MarkStale_WithChatID(t *testing.T) {
 
 	mClock := quartz.NewMock(t)
 	now := mClock.Now()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	refresher := newTestRefresher(t, mClock)
 	worker := gitsync.NewWorker(store, refresher, pub, mClock, logger)
 
@@ -908,7 +907,7 @@ func TestWorker_MarkStale_NilChatID_Broadcasts(t *testing.T) {
 	}
 
 	mClock := quartz.NewMock(t)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	refresher := newTestRefresher(t, mClock)
 	worker := gitsync.NewWorker(store, refresher, pub, mClock, logger)
 
@@ -985,7 +984,7 @@ func TestWorker(t *testing.T) {
 	}
 
 	// 7. Create and run the worker for one tick.
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	worker := gitsync.NewWorker(db, refresher, pub, mClock, logger)
 
 	tickOnce(ctx, t, mClock, worker, tickDone)
@@ -1049,7 +1048,7 @@ func TestRefreshChat_Success(t *testing.T) {
 	}
 
 	mClock := quartz.NewMock(t)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	refresher := newTestRefresher(t, mClock)
 	worker := gitsync.NewWorker(store, refresher, pub, mClock, logger)
 
@@ -1085,7 +1084,7 @@ func TestRefreshChat_NoPR(t *testing.T) {
 	}
 
 	mClock := quartz.NewMock(t)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	// ResolveBranchPullRequest returns nil → no PR exists yet.
 	refresher := newTestRefresher(t, mClock, withResolveBranchPR(
@@ -1126,7 +1125,7 @@ func TestRefreshChat_RefreshError(t *testing.T) {
 	}
 
 	mClock := quartz.NewMock(t)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	refresher := gitsync.NewRefresher(providers, tokens, logger, mClock)
 	worker := gitsync.NewWorker(store, refresher, nil, mClock, logger)
 
@@ -1162,7 +1161,7 @@ func TestRefreshChat_UpsertError(t *testing.T) {
 	}
 
 	mClock := quartz.NewMock(t)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	refresher := newTestRefresher(t, mClock)
 	worker := gitsync.NewWorker(store, refresher, pub, mClock, logger)
 
@@ -1210,7 +1209,7 @@ func TestWorker_NoTokenBackoff(t *testing.T) {
 		return ptr.Ref(""), nil
 	}
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	refresher := gitsync.NewRefresher(providers, tokens, logger, mClock)
 	worker := gitsync.NewWorker(store, refresher, nil, mClock, logger)
 

--- a/codersdk/agentsdk/agentsdk_test.go
+++ b/codersdk/agentsdk/agentsdk_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"tailscale.com/tailcfg"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/codersdk/agentsdk"
 	"github.com/coder/coder/v2/testutil"
 )
@@ -35,7 +34,7 @@ func TestStreamAgentReinitEvents(t *testing.T) {
 		transmitCtx := testutil.Context(t, testutil.WaitShort)
 		transmitErrCh := make(chan error, 1)
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			transmitter := agentsdk.NewSSEAgentReinitTransmitter(slogtest.Make(t, nil), w, r)
+			transmitter := agentsdk.NewSSEAgentReinitTransmitter(testutil.Logger(t), w, r)
 			transmitErrCh <- transmitter.Transmit(transmitCtx, events)
 		}))
 		defer srv.Close()
@@ -70,7 +69,7 @@ func TestStreamAgentReinitEvents(t *testing.T) {
 		cancelTransmit()
 		transmitErrCh := make(chan error, 1)
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			transmitter := agentsdk.NewSSEAgentReinitTransmitter(slogtest.Make(t, nil), w, r)
+			transmitter := agentsdk.NewSSEAgentReinitTransmitter(testutil.Logger(t), w, r)
 			transmitErrCh <- transmitter.Transmit(transmitCtx, events)
 		}))
 
@@ -105,7 +104,7 @@ func TestStreamAgentReinitEvents(t *testing.T) {
 		transmitCtx := testutil.Context(t, testutil.WaitShort)
 		transmitErrCh := make(chan error, 1)
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			transmitter := agentsdk.NewSSEAgentReinitTransmitter(slogtest.Make(t, nil), w, r)
+			transmitter := agentsdk.NewSSEAgentReinitTransmitter(testutil.Logger(t), w, r)
 			transmitErrCh <- transmitter.Transmit(transmitCtx, events)
 		}))
 		defer srv.Close()

--- a/codersdk/workspacesdk/dialer_test.go
+++ b/codersdk/workspacesdk/dialer_test.go
@@ -16,7 +16,6 @@ import (
 	"tailscale.com/tailcfg"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/apiversion"
 	"github.com/coder/coder/v2/coderd/httpapi"
 	"github.com/coder/coder/v2/codersdk"
@@ -31,9 +30,7 @@ import (
 func TestWebsocketDialer_TokenController(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.Context(t, testutil.WaitMedium)
-	logger := slogtest.Make(t, &slogtest.Options{
-		IgnoreErrors: true,
-	}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 
 	fTokenProv := newFakeTokenController(ctx, t)
 	fCoord := tailnettest.NewFakeCoordinator()
@@ -114,9 +111,7 @@ func TestWebsocketDialer_TokenController(t *testing.T) {
 func TestWebsocketDialer_NoTokenController(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.Context(t, testutil.WaitShort)
-	logger := slogtest.Make(t, &slogtest.Options{
-		IgnoreErrors: true,
-	}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 
 	fCoord := tailnettest.NewFakeCoordinator()
 	var coord tailnet.Coordinator = fCoord
@@ -175,9 +170,7 @@ func TestWebsocketDialer_NoTokenController(t *testing.T) {
 func TestWebsocketDialer_ResumeTokenFailure(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.Context(t, testutil.WaitShort)
-	logger := slogtest.Make(t, &slogtest.Options{
-		IgnoreErrors: true,
-	}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 
 	fTokenProv := newFakeTokenController(ctx, t)
 	fCoord := tailnettest.NewFakeCoordinator()
@@ -273,9 +266,7 @@ func TestWebsocketDialer_ResumeTokenFailure(t *testing.T) {
 func TestWebsocketDialer_UnauthenticatedFailFast(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.Context(t, testutil.WaitShort)
-	logger := slogtest.Make(t, &slogtest.Options{
-		IgnoreErrors: true,
-	}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		httpapi.Write(ctx, w, http.StatusUnauthorized, codersdk.Response{})
@@ -293,9 +284,7 @@ func TestWebsocketDialer_UnauthenticatedFailFast(t *testing.T) {
 func TestWebsocketDialer_UnauthorizedFailFast(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.Context(t, testutil.WaitShort)
-	logger := slogtest.Make(t, &slogtest.Options{
-		IgnoreErrors: true,
-	}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		httpapi.Write(ctx, w, http.StatusUnauthorized, codersdk.Response{})
@@ -313,7 +302,7 @@ func TestWebsocketDialer_UnauthorizedFailFast(t *testing.T) {
 func TestWebsocketDialer_UplevelVersion(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.Context(t, testutil.WaitShort)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		sVer := apiversion.New(2, 2)
@@ -356,9 +345,7 @@ func TestWebsocketDialer_UplevelVersion(t *testing.T) {
 func TestWebsocketDialer_WorkspaceUpdates(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.Context(t, testutil.WaitShort)
-	logger := slogtest.Make(t, &slogtest.Options{
-		IgnoreErrors: true,
-	}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 
 	fCoord := tailnettest.NewFakeCoordinator()
 	var coord tailnet.Coordinator = fCoord

--- a/enterprise/aibridged/aibridged_test.go
+++ b/enterprise/aibridged/aibridged_test.go
@@ -15,7 +15,6 @@ import (
 	"golang.org/x/xerrors"
 	"storj.io/drpc"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/aibridge"
 	"github.com/coder/coder/v2/aibridge/intercept"
 	agplaibridge "github.com/coder/coder/v2/coderd/aibridge"
@@ -29,7 +28,7 @@ import (
 func newTestServer(t *testing.T) (*aibridged.Server, *mock.MockDRPCClient, *mock.MockPooler) {
 	t.Helper()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	ctrl := gomock.NewController(t)
 	client := mock.NewMockDRPCClient(ctrl)
 	pool := mock.NewMockPooler(ctrl)
@@ -408,7 +407,7 @@ func TestServeHTTP_ActorHeaders(t *testing.T) {
 			t.Cleanup(upstreamSrv.Close)
 
 			// Setup with SendActorHeaders enabled.
-			logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+			logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 			ctrl := gomock.NewController(t)
 			client := mock.NewMockDRPCClient(ctrl)
 
@@ -518,7 +517,7 @@ func TestRouting(t *testing.T) {
 			t.Cleanup(antSrv.Close)
 
 			// Setup.
-			logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+			logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 			ctrl := gomock.NewController(t)
 			client := mock.NewMockDRPCClient(ctrl)
 

--- a/enterprise/aibridged/pool_test.go
+++ b/enterprise/aibridged/pool_test.go
@@ -11,11 +11,11 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/mock/gomock"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/aibridge/mcp"
 	"github.com/coder/coder/v2/aibridge/mcpmock"
 	"github.com/coder/coder/v2/enterprise/aibridged"
 	mock "github.com/coder/coder/v2/enterprise/aibridged/aibridgedmock"
+	"github.com/coder/coder/v2/testutil"
 )
 
 // TestPool validates the published behavior of [aibridged.CachedBridgePool].
@@ -24,7 +24,7 @@ import (
 func TestPool(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 
 	ctrl := gomock.NewController(t)
 	client := mock.NewMockDRPCClient(ctrl)
@@ -111,7 +111,7 @@ func TestPool_Expiry(t *testing.T) {
 	t.Parallel()
 
 	synctest.Test(t, func(t *testing.T) {
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 		ctrl := gomock.NewController(t)
 		client := mock.NewMockDRPCClient(ctrl)
 		mcpProxy := mcpmock.NewMockServerProxier(ctrl)

--- a/enterprise/aibridgeproxyd/aibridgeproxyd_test.go
+++ b/enterprise/aibridgeproxyd/aibridgeproxyd_test.go
@@ -31,7 +31,6 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/aibridge"
 	agplaibridge "github.com/coder/coder/v2/coderd/aibridge"
 	"github.com/coder/coder/v2/enterprise/aibridgeproxyd"
@@ -272,7 +271,7 @@ func newTestProxy(t *testing.T, opts ...testProxyOption) *aibridgeproxyd.Server 
 	}
 
 	mitmCertFile, mitmKeyFile := getSharedTestMITMCert(t)
-	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 
 	aibridgeOpts := aibridgeproxyd.Options{
 		ListenAddr:               cfg.listenAddr,
@@ -433,7 +432,7 @@ func TestNew(t *testing.T) {
 		t.Parallel()
 
 		mitmCertFile, mitmKeyFile := getSharedTestMITMCert(t)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		_, err := aibridgeproxyd.New(t.Context(), logger, aibridgeproxyd.Options{
 			CoderAccessURL:  "http://localhost:3000",
@@ -449,7 +448,7 @@ func TestNew(t *testing.T) {
 		t.Parallel()
 
 		mitmCertFile, mitmKeyFile := getSharedTestMITMCert(t)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		_, err := aibridgeproxyd.New(t.Context(), logger, aibridgeproxyd.Options{
 			ListenAddr:      "",
@@ -466,7 +465,7 @@ func TestNew(t *testing.T) {
 		t.Parallel()
 
 		mitmCertFile, mitmKeyFile := getSharedTestMITMCert(t)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		_, err := aibridgeproxyd.New(t.Context(), logger, aibridgeproxyd.Options{
 			ListenAddr:      "127.0.0.1:0",
@@ -484,7 +483,7 @@ func TestNew(t *testing.T) {
 		t.Parallel()
 
 		mitmCertFile, mitmKeyFile := getSharedTestMITMCert(t)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		_, err := aibridgeproxyd.New(t.Context(), logger, aibridgeproxyd.Options{
 			ListenAddr:      "127.0.0.1:0",
@@ -502,7 +501,7 @@ func TestNew(t *testing.T) {
 		t.Parallel()
 
 		mitmCertFile, mitmKeyFile := getSharedTestMITMCert(t)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		_, err := aibridgeproxyd.New(t.Context(), logger, aibridgeproxyd.Options{
 			ListenAddr:               "127.0.0.1:0",
@@ -522,7 +521,7 @@ func TestNew(t *testing.T) {
 		t.Parallel()
 
 		mitmCertFile, mitmKeyFile := getSharedTestMITMCert(t)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		_, err := aibridgeproxyd.New(t.Context(), logger, aibridgeproxyd.Options{
 			ListenAddr:      "127.0.0.1:0",
@@ -538,7 +537,7 @@ func TestNew(t *testing.T) {
 		t.Parallel()
 
 		mitmCertFile, mitmKeyFile := getSharedTestMITMCert(t)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		_, err := aibridgeproxyd.New(t.Context(), logger, aibridgeproxyd.Options{
 			ListenAddr:      "127.0.0.1:0",
@@ -555,7 +554,7 @@ func TestNew(t *testing.T) {
 		t.Parallel()
 
 		mitmCertFile, mitmKeyFile := getSharedTestMITMCert(t)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		_, err := aibridgeproxyd.New(t.Context(), logger, aibridgeproxyd.Options{
 			ListenAddr:      "127.0.0.1:0",
@@ -572,7 +571,7 @@ func TestNew(t *testing.T) {
 		t.Parallel()
 
 		mitmCertFile, mitmKeyFile := getSharedTestMITMCert(t)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		srv, err := aibridgeproxyd.New(t.Context(), logger, aibridgeproxyd.Options{
 			ListenAddr:               "127.0.0.1:0",
@@ -591,7 +590,7 @@ func TestNew(t *testing.T) {
 		t.Parallel()
 
 		mitmCertFile, mitmKeyFile := getSharedTestMITMCert(t)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		srv, err := aibridgeproxyd.New(t.Context(), logger, aibridgeproxyd.Options{
 			ListenAddr:               "127.0.0.1:0",
@@ -610,7 +609,7 @@ func TestNew(t *testing.T) {
 		t.Parallel()
 
 		mitmCertFile, mitmKeyFile := getSharedTestMITMCert(t)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		srv, err := aibridgeproxyd.New(t.Context(), logger, aibridgeproxyd.Options{
 			ListenAddr:               "127.0.0.1:0",
@@ -628,7 +627,7 @@ func TestNew(t *testing.T) {
 	t.Run("MissingCertFile", func(t *testing.T) {
 		t.Parallel()
 
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		_, err := aibridgeproxyd.New(t.Context(), logger, aibridgeproxyd.Options{
 			ListenAddr:      ":0",
@@ -643,7 +642,7 @@ func TestNew(t *testing.T) {
 	t.Run("MissingKeyFile", func(t *testing.T) {
 		t.Parallel()
 
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		_, err := aibridgeproxyd.New(t.Context(), logger, aibridgeproxyd.Options{
 			ListenAddr:      ":0",
@@ -658,7 +657,7 @@ func TestNew(t *testing.T) {
 	t.Run("InvalidCertFile", func(t *testing.T) {
 		t.Parallel()
 
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		_, err := aibridgeproxyd.New(t.Context(), logger, aibridgeproxyd.Options{
 			ListenAddr:               ":0",
@@ -676,7 +675,7 @@ func TestNew(t *testing.T) {
 		t.Parallel()
 
 		mitmCertFile, mitmKeyFile := getSharedTestMITMCert(t)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		_, err := aibridgeproxyd.New(t.Context(), logger, aibridgeproxyd.Options{
 			ListenAddr:     ":0",
@@ -692,7 +691,7 @@ func TestNew(t *testing.T) {
 		t.Parallel()
 
 		mitmCertFile, mitmKeyFile := getSharedTestMITMCert(t)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		_, err := aibridgeproxyd.New(t.Context(), logger, aibridgeproxyd.Options{
 			ListenAddr:      ":0",
@@ -709,7 +708,7 @@ func TestNew(t *testing.T) {
 		t.Parallel()
 
 		mitmCertFile, mitmKeyFile := getSharedTestMITMCert(t)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		_, err := aibridgeproxyd.New(t.Context(), logger, aibridgeproxyd.Options{
 			ListenAddr:      "127.0.0.1:0",
@@ -726,7 +725,7 @@ func TestNew(t *testing.T) {
 		t.Parallel()
 
 		mitmCertFile, mitmKeyFile := getSharedTestMITMCert(t)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		_, err := aibridgeproxyd.New(t.Context(), logger, aibridgeproxyd.Options{
 			ListenAddr:      "127.0.0.1:0",
@@ -743,7 +742,7 @@ func TestNew(t *testing.T) {
 		t.Parallel()
 
 		mitmCertFile, mitmKeyFile := getSharedTestMITMCert(t)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		_, err := aibridgeproxyd.New(t.Context(), logger, aibridgeproxyd.Options{
 			ListenAddr:               "127.0.0.1:0",
@@ -761,7 +760,7 @@ func TestNew(t *testing.T) {
 		t.Parallel()
 
 		mitmCertFile, mitmKeyFile := getSharedTestMITMCert(t)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		_, err := aibridgeproxyd.New(t.Context(), logger, aibridgeproxyd.Options{
 			ListenAddr:               "127.0.0.1:0",
@@ -780,7 +779,7 @@ func TestNew(t *testing.T) {
 		t.Parallel()
 
 		mitmCertFile, mitmKeyFile := getSharedTestMITMCert(t)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		_, err := aibridgeproxyd.New(t.Context(), logger, aibridgeproxyd.Options{
 			ListenAddr:               "127.0.0.1:0",
@@ -800,7 +799,7 @@ func TestNew(t *testing.T) {
 		t.Parallel()
 
 		mitmCertFile, mitmKeyFile := getSharedTestMITMCert(t)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		_, err := aibridgeproxyd.New(t.Context(), logger, aibridgeproxyd.Options{
 			ListenAddr:               "127.0.0.1:0",
@@ -819,7 +818,7 @@ func TestNew(t *testing.T) {
 		t.Parallel()
 
 		mitmCertFile, mitmKeyFile := getSharedTestMITMCert(t)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		_, err := aibridgeproxyd.New(t.Context(), logger, aibridgeproxyd.Options{
 			ListenAddr:               "127.0.0.1:0",
@@ -838,7 +837,7 @@ func TestNew(t *testing.T) {
 		t.Parallel()
 
 		mitmCertFile, mitmKeyFile := getSharedTestMITMCert(t)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		srv, err := aibridgeproxyd.New(t.Context(), logger, aibridgeproxyd.Options{
 			ListenAddr:               "127.0.0.1:0",
@@ -857,7 +856,7 @@ func TestNew(t *testing.T) {
 
 		mitmCertFile, mitmKeyFile := getSharedTestMITMCert(t)
 		listenerCertFile, listenerKeyFile := generateListenerCert(t)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		srv, err := aibridgeproxyd.New(t.Context(), logger, aibridgeproxyd.Options{
 			ListenAddr:               "127.0.0.1:0",
@@ -877,7 +876,7 @@ func TestNew(t *testing.T) {
 		t.Parallel()
 
 		mitmCertFile, mitmKeyFile := getSharedTestMITMCert(t)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		srv, err := aibridgeproxyd.New(t.Context(), logger, aibridgeproxyd.Options{
 			ListenAddr:               "127.0.0.1:0",
@@ -896,7 +895,7 @@ func TestNew(t *testing.T) {
 		t.Parallel()
 
 		mitmCertFile, mitmKeyFile := getSharedTestMITMCert(t)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		// Use the shared MITM certificate as the upstream proxy CA (it's a valid PEM cert)
 		srv, err := aibridgeproxyd.New(t.Context(), logger, aibridgeproxyd.Options{
@@ -917,7 +916,7 @@ func TestNew(t *testing.T) {
 		t.Parallel()
 
 		mitmCertFile, mitmKeyFile := getSharedTestMITMCert(t)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		srv, err := aibridgeproxyd.New(t.Context(), logger, aibridgeproxyd.Options{
 			ListenAddr:               "127.0.0.1:0",
@@ -936,7 +935,7 @@ func TestNew(t *testing.T) {
 		t.Parallel()
 
 		mitmCertFile, mitmKeyFile := getSharedTestMITMCert(t)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		srv, err := aibridgeproxyd.New(t.Context(), logger, aibridgeproxyd.Options{
 			ListenAddr:               "127.0.0.1:0",
@@ -955,7 +954,7 @@ func TestNew(t *testing.T) {
 		t.Parallel()
 
 		mitmCertFile, mitmKeyFile := getSharedTestMITMCert(t)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		// Username only (no colon) should also succeed (password is optional)
 		srv, err := aibridgeproxyd.New(t.Context(), logger, aibridgeproxyd.Options{
@@ -975,7 +974,7 @@ func TestNew(t *testing.T) {
 		t.Parallel()
 
 		mitmCertFile, mitmKeyFile := getSharedTestMITMCert(t)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		srv, err := aibridgeproxyd.New(t.Context(), logger, aibridgeproxyd.Options{
 			ListenAddr:               "127.0.0.1:0",
@@ -994,7 +993,7 @@ func TestNew(t *testing.T) {
 		t.Parallel()
 
 		mitmCertFile, mitmKeyFile := getSharedTestMITMCert(t)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		// Create metrics instance to verify it can be passed and stored.
 		reg := prometheus.NewRegistry()
@@ -1017,7 +1016,7 @@ func TestNew(t *testing.T) {
 		t.Parallel()
 
 		mitmCertFile, mitmKeyFile := getSharedTestMITMCert(t)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		srv, err := aibridgeproxyd.New(t.Context(), logger, aibridgeproxyd.Options{
 			ListenAddr:               "127.0.0.1:0",
@@ -1040,7 +1039,7 @@ func TestClose(t *testing.T) {
 		t.Parallel()
 
 		mitmCertFile, mitmKeyFile := getSharedTestMITMCert(t)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		srv, err := aibridgeproxyd.New(t.Context(), logger, aibridgeproxyd.Options{
 			ListenAddr:               "127.0.0.1:0",
@@ -1064,7 +1063,7 @@ func TestClose(t *testing.T) {
 		t.Parallel()
 
 		mitmCertFile, mitmKeyFile := getSharedTestMITMCert(t)
-		logger := slogtest.Make(t, nil)
+		logger := testutil.Logger(t)
 
 		// Create metrics instance to verify Close() properly unregisters them.
 		reg := prometheus.NewRegistry()
@@ -1778,7 +1777,7 @@ func TestServeCACert_CompoundPEM(t *testing.T) {
 	err = os.WriteFile(compoundCertFile, compoundPEM, 0o600)
 	require.NoError(t, err)
 
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 
 	srv, err := aibridgeproxyd.New(t.Context(), logger, aibridgeproxyd.Options{
 		ListenAddr:      "127.0.0.1:0",

--- a/enterprise/aiseats/tracker_test.go
+++ b/enterprise/aiseats/tracker_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	agplaiseats "github.com/coder/coder/v2/coderd/aiseats"
 	"github.com/coder/coder/v2/coderd/audit"
 	"github.com/coder/coder/v2/coderd/coderdtest"
@@ -29,7 +28,7 @@ func authzSetup(t *testing.T) (rawDB database.Store, authzDB database.Store) {
 	t.Helper()
 	rawDB, _ = dbtestutil.NewDB(t)
 	authz := rbac.NewStrictAuthorizer(prometheus.NewRegistry())
-	authzDB = dbauthz.New(rawDB, authz, slogtest.Make(t, nil), coderdtest.AccessControlStorePointer())
+	authzDB = dbauthz.New(rawDB, authz, testutil.Logger(t), coderdtest.AccessControlStorePointer())
 	return rawDB, authzDB
 }
 
@@ -62,7 +61,7 @@ func TestSeatTrackerDB(t *testing.T) {
 
 		rawDB, _ := dbtestutil.NewDB(t)
 		authz := rbac.NewStrictAuthorizer(prometheus.NewRegistry())
-		authzDB := dbauthz.New(rawDB, authz, slogtest.Make(t, nil), coderdtest.AccessControlStorePointer())
+		authzDB := dbauthz.New(rawDB, authz, testutil.Logger(t), coderdtest.AccessControlStorePointer())
 
 		ctx := testutil.Context(t, testutil.WaitShort)
 		clock := quartz.NewMock(t)

--- a/enterprise/coderd/coderd_test.go
+++ b/enterprise/coderd/coderd_test.go
@@ -24,7 +24,6 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/agent"
 	"github.com/coder/coder/v2/agent/agenttest"
 	agplcoderd "github.com/coder/coder/v2/coderd"
@@ -1105,7 +1104,7 @@ func TestConn_CoordinatorRollingRestart(t *testing.T) {
 			dv := coderdtest.DeploymentValues(t, func(dv *codersdk.DeploymentValues) {
 				dv.DERP.Config.BlockDirect = serpent.Bool(!direct)
 			})
-			logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+			logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 
 			// Create two restartable test servers with the same database.
 			client1, user, s1 := newRestartableTestServer(t, &coderdenttest.Options{

--- a/enterprise/coderd/connectionlog/connectionlog_internal_test.go
+++ b/enterprise/coderd/connectionlog/connectionlog_internal_test.go
@@ -13,7 +13,6 @@ import (
 	"golang.org/x/xerrors"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbmock"
 	"github.com/coder/coder/v2/testutil"
@@ -235,7 +234,7 @@ func Test_batcherFlush(t *testing.T) {
 		t.Parallel()
 
 		ctx := testutil.Context(t, testutil.WaitShort)
-		log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		log := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		ctrl := gomock.NewController(t)
 		store := dbmock.NewMockStore(ctrl)
 		clock := quartz.NewMock(t)
@@ -266,7 +265,7 @@ func Test_batcherFlush(t *testing.T) {
 		t.Parallel()
 
 		ctx := testutil.Context(t, testutil.WaitShort)
-		log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		log := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		ctrl := gomock.NewController(t)
 		store := dbmock.NewMockStore(ctrl)
 		clock := quartz.NewMock(t)
@@ -295,7 +294,7 @@ func Test_batcherFlush(t *testing.T) {
 		t.Parallel()
 
 		ctx := testutil.Context(t, testutil.WaitShort)
-		log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		log := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		ctrl := gomock.NewController(t)
 		store := dbmock.NewMockStore(ctrl)
 		clock := quartz.NewMock(t)
@@ -323,7 +322,7 @@ func Test_batcherFlush(t *testing.T) {
 		t.Parallel()
 
 		ctx := testutil.Context(t, testutil.WaitShort)
-		log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		log := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		ctrl := gomock.NewController(t)
 		store := dbmock.NewMockStore(ctrl)
 		clock := quartz.NewMock(t)
@@ -350,7 +349,7 @@ func Test_batcherFlush(t *testing.T) {
 		t.Parallel()
 
 		ctx := testutil.Context(t, testutil.WaitShort)
-		log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		log := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		ctrl := gomock.NewController(t)
 		store := dbmock.NewMockStore(ctrl)
 		clock := quartz.NewMock(t)
@@ -401,7 +400,7 @@ func Test_batcherFlush(t *testing.T) {
 		t.Parallel()
 
 		ctx := testutil.Context(t, testutil.WaitShort)
-		log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		log := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		ctrl := gomock.NewController(t)
 		store := dbmock.NewMockStore(ctrl)
 		clock := quartz.NewMock(t)

--- a/enterprise/coderd/connectionlog/connectionlog_test.go
+++ b/enterprise/coderd/connectionlog/connectionlog_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
@@ -57,7 +56,7 @@ func TestDBBackendIntegration(t *testing.T) {
 
 		db, _ := dbtestutil.NewDB(t)
 		ctx := testutil.Context(t, testutil.WaitShort)
-		log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		log := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		clock := quartz.NewMock(t)
 
 		ws := createWorkspace(t, db)
@@ -103,7 +102,7 @@ func TestDBBackendIntegration(t *testing.T) {
 
 		db, _ := dbtestutil.NewDB(t)
 		ctx := testutil.Context(t, testutil.WaitShort)
-		log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		log := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		clock := quartz.NewMock(t)
 
 		ws := createWorkspace(t, db)
@@ -174,7 +173,7 @@ func TestDBBackendIntegration(t *testing.T) {
 
 		db, _ := dbtestutil.NewDB(t)
 		ctx := testutil.Context(t, testutil.WaitShort)
-		log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		log := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		clock := quartz.NewMock(t)
 
 		ws := createWorkspace(t, db)
@@ -241,7 +240,7 @@ func TestDBBackendIntegration(t *testing.T) {
 
 		db, _ := dbtestutil.NewDB(t)
 		ctx := testutil.Context(t, testutil.WaitShort)
-		log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		log := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		clock := quartz.NewMock(t)
 
 		ws := createWorkspace(t, db)
@@ -286,7 +285,7 @@ func TestDBBackendIntegration(t *testing.T) {
 
 		db, _ := dbtestutil.NewDB(t)
 		ctx := testutil.Context(t, testutil.WaitShort)
-		log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		log := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		clock := quartz.NewMock(t)
 
 		ws := createWorkspace(t, db)
@@ -331,7 +330,7 @@ func TestDBBackendIntegration(t *testing.T) {
 
 		db, _ := dbtestutil.NewDB(t)
 		ctx := testutil.Context(t, testutil.WaitShort)
-		log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		log := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		clock := quartz.NewMock(t)
 
 		ws := createWorkspace(t, db)

--- a/enterprise/coderd/dormancy/dormantusersjob_test.go
+++ b/enterprise/coderd/dormancy/dormantusersjob_test.go
@@ -8,11 +8,11 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/audit"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/enterprise/coderd/dormancy"
+	"github.com/coder/coder/v2/testutil"
 	"github.com/coder/quartz"
 )
 
@@ -24,7 +24,7 @@ func TestCheckInactiveUsers(t *testing.T) {
 	dormancyPeriod := 90 * 24 * time.Hour
 
 	// Add some dormant accounts
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	db, _ := dbtestutil.NewDB(t)
 
 	ctx, cancelFunc := context.WithCancel(context.Background())

--- a/enterprise/coderd/enidpsync/groups_test.go
+++ b/enterprise/coderd/enidpsync/groups_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/stretchr/testify/require"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/entitlements"
 	"github.com/coder/coder/v2/coderd/idpsync"
 	"github.com/coder/coder/v2/coderd/runtimeconfig"
@@ -29,7 +28,7 @@ func TestEnterpriseParseGroupClaims(t *testing.T) {
 	t.Run("NoEntitlements", func(t *testing.T) {
 		t.Parallel()
 
-		s := enidpsync.NewSync(slogtest.Make(t, &slogtest.Options{}),
+		s := enidpsync.NewSync(testutil.Logger(t),
 			runtimeconfig.NewManager(),
 			entitlements.New(),
 			idpsync.DeploymentSyncSettings{})
@@ -45,7 +44,7 @@ func TestEnterpriseParseGroupClaims(t *testing.T) {
 	t.Run("NotInAllowList", func(t *testing.T) {
 		t.Parallel()
 
-		s := enidpsync.NewSync(slogtest.Make(t, &slogtest.Options{}),
+		s := enidpsync.NewSync(testutil.Logger(t),
 			runtimeconfig.NewManager(),
 			entitled,
 			idpsync.DeploymentSyncSettings{
@@ -73,7 +72,7 @@ func TestEnterpriseParseGroupClaims(t *testing.T) {
 	t.Run("InAllowList", func(t *testing.T) {
 		t.Parallel()
 
-		s := enidpsync.NewSync(slogtest.Make(t, &slogtest.Options{}),
+		s := enidpsync.NewSync(testutil.Logger(t),
 			runtimeconfig.NewManager(),
 			entitled,
 			idpsync.DeploymentSyncSettings{

--- a/enterprise/coderd/enidpsync/organizations_test.go
+++ b/enterprise/coderd/enidpsync/organizations_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
@@ -294,7 +293,7 @@ func TestOrganizationSync(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			ctx := testutil.Context(t, testutil.WaitMedium)
-			logger := slogtest.Make(t, &slogtest.Options{})
+			logger := testutil.Logger(t)
 
 			rdb, _ := dbtestutil.NewDB(t)
 			db := dbauthz.New(rdb, rbac.NewAuthorizer(prometheus.NewRegistry()), logger, coderdtest.AccessControlStorePointer())

--- a/enterprise/coderd/prebuilds/membership_test.go
+++ b/enterprise/coderd/prebuilds/membership_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
@@ -140,7 +139,7 @@ func TestReconcileAll(t *testing.T) {
 						require.ElementsMatch(t, expectedMembershipsBefore, extractOrgIDs(preReconcileMemberships))
 
 						// Reconcile
-						reconciler := prebuilds.NewStoreMembershipReconciler(db, clock, slogtest.Make(t, nil))
+						reconciler := prebuilds.NewStoreMembershipReconciler(db, clock, testutil.Logger(t))
 						require.NoError(t, reconciler.ReconcileAll(ctx, database.PrebuildsSystemUserID, prebuilds.PrebuiltWorkspacesGroupName))
 
 						// Verify memberships after reconciliation.

--- a/enterprise/coderd/prebuilds/metricscollector_test.go
+++ b/enterprise/coderd/prebuilds/metricscollector_test.go
@@ -12,7 +12,6 @@ import (
 	"go.opentelemetry.io/otel/trace/noop"
 	"tailscale.com/types/ptr"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
@@ -182,7 +181,7 @@ func TestMetricsCollector(t *testing.T) {
 								t.Run(fmt.Sprintf("%v/transition:%s/jobStatus:%s", test.name, transition, jobStatus), func(t *testing.T) {
 									t.Parallel()
 
-									logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+									logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 									t.Cleanup(func() {
 										if t.Failed() {
 											t.Logf("failed to run test: %s", test.name)
@@ -333,7 +332,7 @@ func TestMetricsCollector_DuplicateTemplateNames(t *testing.T) {
 		eligible: true,
 	}
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	clock := quartz.NewMock(t)
 	db, pubsub := dbtestutil.NewDB(t)
 	cache := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
@@ -492,7 +491,7 @@ func TestMetricsCollector_ReconciliationPausedMetric(t *testing.T) {
 	t.Run("reconciliation_not_paused", func(t *testing.T) {
 		t.Parallel()
 
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 		db, pubsub := dbtestutil.NewDB(t)
 		cache := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
 		registry := prometheus.NewPedanticRegistry()
@@ -530,7 +529,7 @@ func TestMetricsCollector_ReconciliationPausedMetric(t *testing.T) {
 		t.Parallel()
 
 		// Create isolated collector and registry for this test
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 		db, pubsub := dbtestutil.NewDB(t)
 		cache := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
 		registry := prometheus.NewPedanticRegistry()
@@ -568,7 +567,7 @@ func TestMetricsCollector_ReconciliationPausedMetric(t *testing.T) {
 		t.Parallel()
 
 		// Create isolated collector and registry for this test
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 		db, pubsub := dbtestutil.NewDB(t)
 		cache := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
 		registry := prometheus.NewPedanticRegistry()

--- a/enterprise/coderd/prebuilds/reconcile_test.go
+++ b/enterprise/coderd/prebuilds/reconcile_test.go
@@ -19,7 +19,6 @@ import (
 	"tailscale.com/types/ptr"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbfake"
@@ -392,9 +391,7 @@ func (tc testCase) run(t *testing.T) {
 		clock := quartz.NewMock(t)
 		ctx := testutil.Context(t, testutil.WaitShort)
 		cfg := codersdk.PrebuildsConfig{}
-		logger := slogtest.Make(
-			t, &slogtest.Options{IgnoreErrors: true},
-		).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		db, pubSub := dbtestutil.NewDB(t)
 
 		ownerID := uuid.New()
@@ -548,9 +545,7 @@ func TestMultiplePresetsPerTemplateVersion(t *testing.T) {
 	clock := quartz.NewMock(t)
 	ctx := testutil.Context(t, testutil.WaitShort)
 	cfg := codersdk.PrebuildsConfig{}
-	logger := slogtest.Make(
-		t, &slogtest.Options{IgnoreErrors: true},
-	).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	db, pubSub := dbtestutil.NewDB(t)
 	cache := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
 	controller := prebuilds.NewStoreReconciler(
@@ -680,9 +675,7 @@ func TestPrebuildScheduling(t *testing.T) {
 			clock.Set(tc.now)
 			ctx := testutil.Context(t, testutil.WaitShort)
 			cfg := codersdk.PrebuildsConfig{}
-			logger := slogtest.Make(
-				t, &slogtest.Options{IgnoreErrors: true},
-			).Leveled(slog.LevelDebug)
+			logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 			db, pubSub := dbtestutil.NewDB(t)
 			cache := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
 			controller := prebuilds.NewStoreReconciler(
@@ -790,9 +783,7 @@ func TestInvalidPreset(t *testing.T) {
 	clock := quartz.NewMock(t)
 	ctx := testutil.Context(t, testutil.WaitShort)
 	cfg := codersdk.PrebuildsConfig{}
-	logger := slogtest.Make(
-		t, &slogtest.Options{IgnoreErrors: true},
-	).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	db, pubSub := dbtestutil.NewDB(t)
 	cache := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
 	controller := prebuilds.NewStoreReconciler(
@@ -861,9 +852,7 @@ func TestDeletionOfPrebuiltWorkspaceWithInvalidPreset(t *testing.T) {
 	clock := quartz.NewMock(t)
 	ctx := testutil.Context(t, testutil.WaitShort)
 	cfg := codersdk.PrebuildsConfig{}
-	logger := slogtest.Make(
-		t, &slogtest.Options{IgnoreErrors: true},
-	).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	db, pubSub := dbtestutil.NewDB(t)
 	cache := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
 	controller := prebuilds.NewStoreReconciler(
@@ -962,9 +951,7 @@ func TestSkippingHardLimitedPresets(t *testing.T) {
 				FailureHardLimit:              serpent.Int64(tc.hardLimit),
 				ReconciliationBackoffInterval: 0,
 			}
-			logger := slogtest.Make(
-				t, &slogtest.Options{IgnoreErrors: true},
-			).Leveled(slog.LevelDebug)
+			logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 			db, pubSub := dbtestutil.NewDB(t)
 			fakeEnqueuer := newFakeEnqueuer()
 			registry := prometheus.NewRegistry()
@@ -1093,9 +1080,7 @@ func TestValidationFailedPresets(t *testing.T) {
 	clock := quartz.NewMock(t)
 	ctx := testutil.Context(t, testutil.WaitMedium)
 	cfg := codersdk.PrebuildsConfig{}
-	logger := slogtest.Make(
-		t, &slogtest.Options{IgnoreErrors: true},
-	).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	db, pubSub := dbtestutil.NewDB(t)
 	cache := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
 	registry := prometheus.NewRegistry()
@@ -1281,9 +1266,7 @@ func TestValidationFailedPresetResets(t *testing.T) {
 	clock := quartz.NewMock(t)
 	ctx := testutil.Context(t, testutil.WaitMedium)
 	cfg := codersdk.PrebuildsConfig{}
-	logger := slogtest.Make(
-		t, &slogtest.Options{IgnoreErrors: true},
-	).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	db, pubSub := dbtestutil.NewDB(t)
 	cache := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
 	registry := prometheus.NewRegistry()
@@ -1464,9 +1447,7 @@ func TestHardLimitedPresetShouldNotBlockDeletion(t *testing.T) {
 				FailureHardLimit:              serpent.Int64(tc.hardLimit),
 				ReconciliationBackoffInterval: 0,
 			}
-			logger := slogtest.Make(
-				t, &slogtest.Options{IgnoreErrors: true},
-			).Leveled(slog.LevelDebug)
+			logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 			db, pubSub := dbtestutil.NewDB(t)
 			fakeEnqueuer := newFakeEnqueuer()
 			registry := prometheus.NewRegistry()
@@ -1670,7 +1651,7 @@ func TestRunLoop(t *testing.T) {
 		ReconciliationInterval:        serpent.Duration(time.Second),
 	}
 	// Do not ignore errors as we want a graceful stop
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: false}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 	db, pubSub := dbtestutil.NewDB(t)
 	cache := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
 	reconciler := prebuilds.NewStoreReconciler(
@@ -1851,9 +1832,7 @@ func TestFailedBuildBackoff(t *testing.T) {
 		ReconciliationBackoffInterval: serpent.Duration(backoffInterval),
 		ReconciliationInterval:        serpent.Duration(time.Second),
 	}
-	logger := slogtest.Make(
-		t, &slogtest.Options{IgnoreErrors: true},
-	).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	db, ps := dbtestutil.NewDB(t)
 	cache := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
 	reconciler := prebuilds.NewStoreReconciler(
@@ -1968,7 +1947,7 @@ func TestReconciliationLock(t *testing.T) {
 	t.Parallel()
 
 	ctx := testutil.Context(t, testutil.WaitSuperLong)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	db, ps := dbtestutil.NewDB(t)
 
 	wg := sync.WaitGroup{}
@@ -1983,7 +1962,7 @@ func TestReconciliationLock(t *testing.T) {
 				ps,
 				cache,
 				codersdk.PrebuildsConfig{},
-				slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug),
+				testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug),
 				quartz.NewMock(t),
 				prometheus.NewRegistry(),
 				newNoopEnqueuer(),
@@ -2014,7 +1993,7 @@ func TestTrackResourceReplacement(t *testing.T) {
 
 	// Setup.
 	clock := quartz.NewMock(t)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: false}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 	db, ps := dbtestutil.NewDB(t)
 
 	fakeEnqueuer := newFakeEnqueuer()
@@ -2174,9 +2153,7 @@ func TestExpiredPrebuildsMultipleActions(t *testing.T) {
 			clock := quartz.NewMock(t)
 			ctx := testutil.Context(t, testutil.WaitLong)
 			cfg := codersdk.PrebuildsConfig{}
-			logger := slogtest.Make(
-				t, &slogtest.Options{IgnoreErrors: true},
-			).Leveled(slog.LevelDebug)
+			logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 			db, pubSub := dbtestutil.NewDB(t)
 			fakeEnqueuer := newFakeEnqueuer()
 			registry := prometheus.NewRegistry()
@@ -2646,7 +2623,7 @@ func TestCancelPendingPrebuilds(t *testing.T) {
 				fakeEnqueuer := newFakeEnqueuer()
 				registry := prometheus.NewRegistry()
 				cache := files.New(registry, &coderdtest.FakeAuthorizer{})
-				logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: false}).Leveled(slog.LevelDebug)
+				logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 				reconciler := prebuilds.NewStoreReconciler(
 					db, ps, cache, codersdk.PrebuildsConfig{}, logger,
 					clock,
@@ -2892,7 +2869,7 @@ func TestCancelPendingPrebuilds(t *testing.T) {
 		fakeEnqueuer := newFakeEnqueuer()
 		registry := prometheus.NewRegistry()
 		cache := files.New(registry, &coderdtest.FakeAuthorizer{})
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: false}).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 		reconciler := prebuilds.NewStoreReconciler(
 			db, ps, cache, codersdk.PrebuildsConfig{}, logger,
 			clock,
@@ -2966,7 +2943,7 @@ func TestReconciliationStats(t *testing.T) {
 	fakeEnqueuer := newFakeEnqueuer()
 	registry := prometheus.NewRegistry()
 	cache := files.New(registry, &coderdtest.FakeAuthorizer{})
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: false}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t).Leveled(slog.LevelDebug)
 	reconciler := prebuilds.NewStoreReconciler(
 		db, ps, cache, codersdk.PrebuildsConfig{}, logger,
 		clock,
@@ -3563,7 +3540,7 @@ func BenchmarkReconcileAll_NoOps(b *testing.B) {
 			cfg := codersdk.PrebuildsConfig{
 				ReconciliationInterval: serpent.Duration(testutil.WaitLong),
 			}
-			prebuildsLogger := slogtest.Make(b, &slogtest.Options{IgnoreErrors: false}).Leveled(slog.LevelError)
+			prebuildsLogger := testutil.Logger(b).Leveled(slog.LevelError)
 			cache := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
 			controller := prebuilds.NewStoreReconciler(
 				db, ps, cache, cfg, prebuildsLogger,
@@ -3675,7 +3652,7 @@ func BenchmarkReconcileAll_ConnectionContention(b *testing.B) {
 				cfg := codersdk.PrebuildsConfig{
 					ReconciliationInterval: serpent.Duration(testutil.WaitLong),
 				}
-				prebuildsLogger := slogtest.Make(b, &slogtest.Options{IgnoreErrors: false}).Leveled(slog.LevelError)
+				prebuildsLogger := testutil.Logger(b).Leveled(slog.LevelError)
 				cache := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
 				controller := prebuilds.NewStoreReconciler(
 					db, ps, cache, cfg, prebuildsLogger,
@@ -3795,7 +3772,7 @@ func BenchmarkReconcileAll_Mix(b *testing.B) {
 				cfg := codersdk.PrebuildsConfig{
 					ReconciliationInterval: serpent.Duration(testutil.WaitLong),
 				}
-				prebuildsLogger := slogtest.Make(b, &slogtest.Options{IgnoreErrors: false}).Leveled(slog.LevelError)
+				prebuildsLogger := testutil.Logger(b).Leveled(slog.LevelError)
 				cache := files.New(prometheus.NewRegistry(), &coderdtest.FakeAuthorizer{})
 				controller := prebuilds.NewStoreReconciler(
 					db, ps, cache, cfg, prebuildsLogger,

--- a/enterprise/coderd/provisionerdaemons_test.go
+++ b/enterprise/coderd/provisionerdaemons_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/apiversion"
 	"github.com/coder/coder/v2/buildinfo"
 	"github.com/coder/coder/v2/coderd/coderdtest"
@@ -76,7 +75,7 @@ func TestProvisionerDaemonServe(t *testing.T) {
 		// WebSocket protocol violation. This just means the pre-flight checks have passed though.
 
 		// Sending a HTTP request triggers an error log, which would otherwise fail the test.
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 		client, user := coderdenttest.New(t, &coderdenttest.Options{
 			LicenseOptions: &coderdenttest.LicenseOptions{
 				Features: license.Features{
@@ -129,7 +128,7 @@ func TestProvisionerDaemonServe(t *testing.T) {
 		// version header that should cause provisionerd to refuse to serve us, so no websocket for you!
 
 		// Sending a HTTP request triggers an error log, which would otherwise fail the test.
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 		client, user := coderdenttest.New(t, &coderdenttest.Options{
 			LicenseOptions: &coderdenttest.LicenseOptions{
 				Features: license.Features{

--- a/enterprise/coderd/schedule/template_test.go
+++ b/enterprise/coderd/schedule/template_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
 	"github.com/coder/coder/v2/coderd/database/dbfake"
@@ -273,7 +272,7 @@ func TestTemplateUpdateBuildDeadlines(t *testing.T) {
 			wsBuild, err := db.GetWorkspaceBuildByID(ctx, buildResp.Build.ID)
 			require.NoError(t, err)
 
-			logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+			logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 
 			userQuietHoursStore, err := schedule.NewEnterpriseUserQuietHoursScheduleStore(userQuietHoursSchedule, true)
 			require.NoError(t, err)
@@ -567,7 +566,7 @@ func TestTemplateUpdateBuildDeadlinesSkip(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 
 	userQuietHoursStore, err := schedule.NewEnterpriseUserQuietHoursScheduleStore(userQuietHoursSchedule, true)
 	require.NoError(t, err)
@@ -682,7 +681,7 @@ func TestNotifications(t *testing.T) {
 
 		// Setup dependencies
 		notifyEnq := notificationstest.FakeEnqueuer{}
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		const userQuietHoursSchedule = "CRON_TZ=UTC 0 0 * * *" // midnight UTC
 		userQuietHoursStore, err := schedule.NewEnterpriseUserQuietHoursScheduleStore(userQuietHoursSchedule, true)
 		require.NoError(t, err)
@@ -780,7 +779,7 @@ func TestNotifications(t *testing.T) {
 
 		// Setup dependencies
 		notifyEnq := notificationstest.NewFakeEnqueuer()
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		const userQuietHoursSchedule = "CRON_TZ=UTC 0 0 * * *" // midnight UTC
 		userQuietHoursStore, err := schedule.NewEnterpriseUserQuietHoursScheduleStore(userQuietHoursSchedule, true)
 		require.NoError(t, err)
@@ -871,7 +870,7 @@ func TestNotifications(t *testing.T) {
 
 		// Setup dependencies
 		notifyEnq := notificationstest.NewFakeEnqueuer()
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		const userQuietHoursSchedule = "CRON_TZ=UTC 0 0 * * *" // midnight UTC
 		userQuietHoursStore, err := schedule.NewEnterpriseUserQuietHoursScheduleStore(userQuietHoursSchedule, true)
 		require.NoError(t, err)
@@ -970,7 +969,7 @@ func TestTemplateTTL(t *testing.T) {
 			t.Parallel()
 
 			var (
-				logger = slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+				logger = testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 				db, _  = dbtestutil.NewDB(t)
 				ctx    = testutil.Context(t, testutil.WaitLong)
 				user   = dbgen.User(t, db, database.User{})
@@ -1076,7 +1075,7 @@ func TestTemplateTTL(t *testing.T) {
 		t.Parallel()
 
 		var (
-			logger = slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+			logger = testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 			db, _  = dbtestutil.NewDB(t)
 			ctx    = testutil.Context(t, testutil.WaitLong)
 			user   = dbgen.User(t, db, database.User{})
@@ -1291,7 +1290,7 @@ func TestTemplateUpdatePrebuilds(t *testing.T) {
 
 			// Setup
 			var (
-				logger = slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+				logger = testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 				db, _  = dbtestutil.NewDB(t, dbtestutil.WithDumpOnFailure())
 				ctx    = testutil.Context(t, testutil.WaitLong)
 				user   = dbgen.User(t, db, database.User{})

--- a/enterprise/coderd/templates_test.go
+++ b/enterprise/coderd/templates_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/audit"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
@@ -35,7 +34,7 @@ import (
 func TestTemplates(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 
 	t.Run("Deprecated", func(t *testing.T) {
 		t.Parallel()

--- a/enterprise/coderd/usage/cron_test.go
+++ b/enterprise/coderd/usage/cron_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
@@ -46,7 +45,7 @@ func TestCron(t *testing.T) {
 			}).AnyTimes()
 
 		inserter := usage.NewDBInserter(usage.InserterWithClock(clock))
-		cron := usage.NewCron(clock, slogtest.Make(t, nil), db, inserter)
+		cron := usage.NewCron(clock, testutil.Logger(t), db, inserter)
 		require.NoError(t, cron.Register(usage.CronJob{
 			Name:      "test-job",
 			Interval:  5 * time.Minute,
@@ -94,7 +93,7 @@ func TestAISeatsHeartbeat(t *testing.T) {
 	db.EXPECT().GetActiveAISeatCount(gomock.Any()).Return(int64(42), nil)
 
 	authz := rbac.NewStrictAuthorizer(prometheus.NewRegistry())
-	authzDB := dbauthz.New(db, authz, slogtest.Make(t, nil), coderdtest.AccessControlStorePointer())
+	authzDB := dbauthz.New(db, authz, testutil.Logger(t), coderdtest.AccessControlStorePointer())
 
 	// AISeatsHeartbeat internally uses AsUsagePublisher, which must
 	// have ResourceAiSeat.ActionRead to pass the dbauthz check.

--- a/enterprise/coderd/usage/publisher_test.go
+++ b/enterprise/coderd/usage/publisher_test.go
@@ -16,7 +16,6 @@ import (
 	"go.uber.org/goleak"
 	"go.uber.org/mock/gomock"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbauthz"
@@ -42,7 +41,7 @@ func TestIntegration(t *testing.T) {
 	const eventCount = 3
 
 	ctx := testutil.Context(t, testutil.WaitLong)
-	log := slogtest.Make(t, nil)
+	log := testutil.Logger(t)
 	db, _ := dbtestutil.NewDB(t)
 
 	clock := quartz.NewMock(t)
@@ -200,7 +199,7 @@ func TestIntegration(t *testing.T) {
 func TestPublisherNoEligibleLicenses(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.Context(t, testutil.WaitLong)
-	log := slogtest.Make(t, nil)
+	log := testutil.Logger(t)
 	ctrl := gomock.NewController(t)
 	db := dbmock.NewMockStore(ctrl)
 	clock := quartz.NewMock(t)
@@ -276,7 +275,7 @@ func TestPublisherNoEligibleLicenses(t *testing.T) {
 func TestPublisherClaimExpiry(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.Context(t, testutil.WaitLong)
-	log := slogtest.Make(t, nil)
+	log := testutil.Logger(t)
 	db, _ := dbtestutil.NewDB(t)
 	clock := quartz.NewMock(t)
 	deploymentID, licenseJWT := configureDeployment(ctx, t, db)
@@ -354,7 +353,7 @@ func TestPublisherClaimExpiry(t *testing.T) {
 func TestPublisherMissingEvents(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.Context(t, testutil.WaitLong)
-	log := slogtest.Make(t, nil)
+	log := testutil.Logger(t)
 	ctrl := gomock.NewController(t)
 	db := dbmock.NewMockStore(ctrl)
 	deploymentID, licenseJWT := configureMockDeployment(t, db)
@@ -428,7 +427,7 @@ func TestPublisherMissingEvents(t *testing.T) {
 func TestPublisherLicenseSelection(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.Context(t, testutil.WaitLong)
-	log := slogtest.Make(t, nil)
+	log := testutil.Logger(t)
 	ctrl := gomock.NewController(t)
 	db := dbmock.NewMockStore(ctrl)
 	clock := quartz.NewMock(t)
@@ -563,7 +562,7 @@ func TestPublisherLicenseSelection(t *testing.T) {
 func TestPublisherTallymanError(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.Context(t, testutil.WaitLong)
-	log := slogtest.Make(t, nil)
+	log := testutil.Logger(t)
 	ctrl := gomock.NewController(t)
 	db := dbmock.NewMockStore(ctrl)
 	clock := quartz.NewMock(t)

--- a/enterprise/coderd/workspaceproxy_test.go
+++ b/enterprise/coderd/workspaceproxy_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/agent/agenttest"
 	"github.com/coder/coder/v2/buildinfo"
 	"github.com/coder/coder/v2/coderd/coderdtest"
@@ -1104,9 +1103,7 @@ func TestGetCryptoKeys(t *testing.T) {
 		ctx := testutil.Context(t, testutil.WaitMedium)
 		db, pubsub := dbtestutil.NewDB(t)
 		// IgnoreErrors is set here to avoid a test failure due to "used of closed network connection".
-		logger := slogtest.Make(t, &slogtest.Options{
-			IgnoreErrors: true,
-		})
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 		cclient, _, api, _ := coderdenttest.NewWithAPI(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				Database:                 db,

--- a/enterprise/coderd/workspaces_test.go
+++ b/enterprise/coderd/workspaces_test.go
@@ -21,7 +21,6 @@ import (
 	"go.opentelemetry.io/otel/trace/noop"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/audit"
 	"github.com/coder/coder/v2/coderd/autobuild"
 	"github.com/coder/coder/v2/coderd/coderdtest"
@@ -605,11 +604,8 @@ func TestWorkspaceAutobuild(t *testing.T) {
 		var (
 			ticker = make(chan time.Time)
 			statCh = make(chan autobuild.Stats)
-			logger = slogtest.Make(t, &slogtest.Options{
-				// We ignore errors here since we expect to fail
-				// builds.
-				IgnoreErrors: true,
-			})
+			// We ignore errors here since we expect to fail builds.
+			logger     = testutil.Logger(t, testutil.WithIgnoreErrors())
 			failureTTL = time.Minute
 		)
 
@@ -659,11 +655,8 @@ func TestWorkspaceAutobuild(t *testing.T) {
 		var (
 			ticker = make(chan time.Time)
 			statCh = make(chan autobuild.Stats)
-			logger = slogtest.Make(t, &slogtest.Options{
-				// We ignore errors here since we expect to fail
-				// builds.
-				IgnoreErrors: true,
-			})
+			// We ignore errors here since we expect to fail builds.
+			logger     = testutil.Logger(t, testutil.WithIgnoreErrors())
 			failureTTL = time.Minute
 		)
 
@@ -713,11 +706,8 @@ func TestWorkspaceAutobuild(t *testing.T) {
 		var (
 			ticker = make(chan time.Time)
 			statCh = make(chan autobuild.Stats)
-			logger = slogtest.Make(t, &slogtest.Options{
-				// We ignore errors here since we expect to fail
-				// builds.
-				IgnoreErrors: true,
-			})
+			// We ignore errors here since we expect to fail builds.
+			logger = testutil.Logger(t, testutil.WithIgnoreErrors())
 		)
 
 		client, user := coderdenttest.New(t, &coderdenttest.Options{
@@ -763,7 +753,7 @@ func TestWorkspaceAutobuild(t *testing.T) {
 			auditRecorder = audit.NewMock()
 		)
 
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 
 		client, db, user := coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
@@ -845,7 +835,7 @@ func TestWorkspaceAutobuild(t *testing.T) {
 			ticker      = make(chan time.Time)
 			statCh      = make(chan autobuild.Stats)
 			inactiveTTL = time.Minute
-			logger      = slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+			logger      = testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		)
 
 		client, db, user := coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
@@ -929,7 +919,7 @@ func TestWorkspaceAutobuild(t *testing.T) {
 		// another connection from within a transaction.
 		sdb.SetMaxOpenConns(maxConns)
 		auditor := entaudit.NewAuditor(db, entaudit.DefaultFilter, backends.NewPostgres(db, true))
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 
 		client, user := coderdenttest.New(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
@@ -992,7 +982,7 @@ func TestWorkspaceAutobuild(t *testing.T) {
 			inactiveTTL = time.Minute
 		)
 
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		client, user := coderdenttest.New(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				AutobuildTicker:          ticker,
@@ -1035,7 +1025,7 @@ func TestWorkspaceAutobuild(t *testing.T) {
 			autoDeleteTTL = time.Minute
 		)
 
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		client, user := coderdenttest.New(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				AutobuildTicker:          ticker,
@@ -1078,7 +1068,7 @@ func TestWorkspaceAutobuild(t *testing.T) {
 			inactiveTTL = time.Minute
 		)
 
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		client, db, user := coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				AutobuildTicker:          ticker,
@@ -1136,7 +1126,7 @@ func TestWorkspaceAutobuild(t *testing.T) {
 			transitionTTL = time.Minute
 		)
 
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		client, db, user := coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				AutobuildTicker:          ticker,
@@ -1214,7 +1204,7 @@ func TestWorkspaceAutobuild(t *testing.T) {
 			dormantTTL = time.Minute
 		)
 
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		client, db, user := coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				AutobuildTicker:          ticker,
@@ -1283,7 +1273,7 @@ func TestWorkspaceAutobuild(t *testing.T) {
 			inactiveTTL = time.Minute
 		)
 
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		client, db, user := coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				AutobuildTicker:          tickCh,
@@ -1370,7 +1360,7 @@ func TestWorkspaceAutobuild(t *testing.T) {
 			transitionTTL = time.Minute
 		)
 
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		client, db, user := coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				AutobuildTicker:          ticker,
@@ -1469,7 +1459,7 @@ func TestWorkspaceAutobuild(t *testing.T) {
 			statsCh = make(chan autobuild.Stats)
 		)
 
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		client, db, user := coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				AutobuildTicker:          tickCh,
@@ -1575,7 +1565,7 @@ func TestWorkspaceAutobuild(t *testing.T) {
 
 		clock.Set(dbtime.Now())
 
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		client, db, user := coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				AutobuildTicker:          tickCh,
@@ -1666,7 +1656,7 @@ func TestWorkspaceAutobuild(t *testing.T) {
 		// this test deterministic.
 		clock.Set(time.Date(2024, 1, 1, 8, 0, 0, 0, time.UTC))
 
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		templateScheduleStore := schedule.NewEnterpriseTemplateScheduleStore(agplUserQuietHoursScheduleStore(), notifications.NewNoopEnqueuer(), logger, nil)
 		templateScheduleStore.Clock = clock
 		client, user := coderdenttest.New(t, &coderdenttest.Options{
@@ -1728,7 +1718,7 @@ func TestWorkspaceAutobuild(t *testing.T) {
 			statsCh = make(chan autobuild.Stats)
 		)
 
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		client, db, user := coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				AutobuildTicker:          tickCh,
@@ -1805,7 +1795,7 @@ func TestTemplateDoesNotAllowUserAutostop(t *testing.T) {
 
 	t.Run("TTLSetByTemplate", func(t *testing.T) {
 		t.Parallel()
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		client := coderdtest.New(t, &coderdtest.Options{
 			IncludeProvisionerDaemon: true,
 			TemplateScheduleStore:    schedule.NewEnterpriseTemplateScheduleStore(agplUserQuietHoursScheduleStore(), notifications.NewNoopEnqueuer(), logger, nil),
@@ -3146,7 +3136,7 @@ func TestWorkspaceTemplateParamsChange(t *testing.T) {
 	tfCliConfigPath := downloadProviders(t, mainTfTemplate)
 	t.Setenv("TF_CLI_CONFIG_FILE", tfCliConfigPath)
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: false})
+	logger := testutil.Logger(t)
 	dv := coderdtest.DeploymentValues(t)
 
 	client, owner := coderdenttest.New(t, &coderdenttest.Options{
@@ -3562,7 +3552,7 @@ func TestExecutorAutostartBlocked(t *testing.T) {
 		tickCh  = make(chan time.Time)
 		statsCh = make(chan autobuild.Stats)
 
-		logger        = slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		logger        = testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		client, owner = coderdenttest.New(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				AutobuildTicker:          tickCh,
@@ -3608,7 +3598,7 @@ func TestWorkspacesFiltering(t *testing.T) {
 	t.Run("Dormant", func(t *testing.T) {
 		t.Parallel()
 
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		client, db, owner := coderdenttest.NewWithDatabase(t, &coderdenttest.Options{
 			Options: &coderdtest.Options{
 				TemplateScheduleStore: schedule.NewEnterpriseTemplateScheduleStore(agplUserQuietHoursScheduleStore(), notifications.NewNoopEnqueuer(), logger, nil),

--- a/enterprise/coderd/x/chatd/chatd_retry_test.go
+++ b/enterprise/coderd/x/chatd/chatd_retry_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	dbpubsub "github.com/coder/coder/v2/coderd/database/pubsub"
@@ -754,7 +753,7 @@ func TestDialRelayReal401(t *testing.T) {
 		StatusNotifications: statusCh,
 		RequestHeader:       http.Header{codersdk.SessionTokenHeader: {"test-token"}},
 		DB:                  db,
-		Logger:              slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}),
+		Logger:              testutil.Logger(t, testutil.WithIgnoreErrors()),
 	})
 
 	statusCh <- osschatd.StatusNotification{

--- a/enterprise/coderd/x/chatd/chatd_test.go
+++ b/enterprise/coderd/x/chatd/chatd_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbgen"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
@@ -62,7 +61,7 @@ func newTestServer(
 	clock quartz.Clock,
 ) *osschatd.Server {
 	t.Helper()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	server := osschatd.New(osschatd.Config{
 		Logger:                     logger,
 		Database:                   db,
@@ -85,7 +84,7 @@ func newActiveWorkerServer(
 	replicaID uuid.UUID,
 ) *osschatd.Server {
 	t.Helper()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	server := osschatd.New(osschatd.Config{
 		Logger:                     logger,
 		Database:                   db,
@@ -1299,7 +1298,7 @@ func TestSubscribeRelayDialCanceledOnFastCompletion(t *testing.T) {
 
 	// Worker server with a 1-hour acquire interval so it only processes
 	// when explicitly woken by SendMessage's signalWake.
-	workerLogger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	workerLogger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	worker := osschatd.New(osschatd.Config{
 		Logger:                     workerLogger,
 		Database:                   db,
@@ -1459,7 +1458,7 @@ func TestSubscribeRelayEstablishedMidStream(t *testing.T) {
 	// trigger is signalWake() from SendMessage, but under heavy
 	// CI load the wake goroutine may be delayed. A short poll
 	// ensures the worker always picks up the pending chat.
-	workerLogger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	workerLogger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	worker := osschatd.New(osschatd.Config{
 		Logger:                     workerLogger,
 		Database:                   db,

--- a/enterprise/tailnet/multiagent_test.go
+++ b/enterprise/tailnet/multiagent_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
 	"github.com/coder/coder/v2/enterprise/tailnet"
 	agpl "github.com/coder/coder/v2/tailnet"
@@ -24,7 +23,7 @@ import (
 func TestPGCoordinator_MultiAgent(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	store, ps := dbtestutil.NewDB(t)
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 	defer cancel()
@@ -58,7 +57,7 @@ func TestPGCoordinator_MultiAgent(t *testing.T) {
 func TestPGCoordinator_MultiAgent_CoordClose(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	store, ps := dbtestutil.NewDB(t)
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 	defer cancel()
@@ -85,7 +84,7 @@ func TestPGCoordinator_MultiAgent_CoordClose(t *testing.T) {
 func TestPGCoordinator_MultiAgent_UnsubscribeRace(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	store, ps := dbtestutil.NewDB(t)
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitMedium)
 	defer cancel()
@@ -127,7 +126,7 @@ func TestPGCoordinator_MultiAgent_UnsubscribeRace(t *testing.T) {
 func TestPGCoordinator_MultiAgent_Unsubscribe(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	store, ps := dbtestutil.NewDB(t)
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 	defer cancel()
@@ -186,7 +185,7 @@ func TestPGCoordinator_MultiAgent_Unsubscribe(t *testing.T) {
 func TestPGCoordinator_MultiAgent_MultiCoordinator(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	store, ps := dbtestutil.NewDB(t)
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitMedium)
 	defer cancel()
@@ -233,7 +232,7 @@ func TestPGCoordinator_MultiAgent_MultiCoordinator(t *testing.T) {
 func TestPGCoordinator_MultiAgent_MultiCoordinator_UpdateBeforeSubscribe(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	store, ps := dbtestutil.NewDB(t)
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitMedium)
 	defer cancel()
@@ -282,7 +281,7 @@ func TestPGCoordinator_MultiAgent_MultiCoordinator_UpdateBeforeSubscribe(t *test
 func TestPGCoordinator_MultiAgent_TwoAgents(t *testing.T) {
 	t.Parallel()
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	store, ps := dbtestutil.NewDB(t)
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitMedium)
 	defer cancel()

--- a/enterprise/tailnet/pgcoord_internal_test.go
+++ b/enterprise/tailnet/pgcoord_internal_test.go
@@ -18,7 +18,6 @@ import (
 	gProto "google.golang.org/protobuf/proto"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbmock"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
@@ -378,7 +377,7 @@ func TestGetDebug(t *testing.T) {
 func TestPGCoordinatorUnhealthy(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.Context(t, testutil.WaitShort)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 
 	ctrl := gomock.NewController(t)
 	mStore := dbmock.NewMockStore(ctrl)

--- a/enterprise/tailnet/pgcoord_test.go
+++ b/enterprise/tailnet/pgcoord_test.go
@@ -17,7 +17,6 @@ import (
 	gProto "google.golang.org/protobuf/proto"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/database"
 	"github.com/coder/coder/v2/coderd/database/dbmock"
 	"github.com/coder/coder/v2/coderd/database/dbtestutil"
@@ -570,7 +569,7 @@ func TestPGCoordinator_Unhealthy(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mStore := dbmock.NewMockStore(ctrl)
 	ps := pubsub.NewInMemory()
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 
 	calls := make(chan struct{})
 	// first call succeeds, so that our Agent will successfully connect.
@@ -779,7 +778,7 @@ func TestPGCoordinatorDual_FailedHeartbeat(t *testing.T) {
 
 	// We do this to avoid failing due errors related to the
 	// database connection being close.
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 
 	// Create two coordinators, 1 for each peer.
 	c1, err := tailnet.NewPGCoord(ctx, logger, ps1, store1)

--- a/enterprise/wsproxy/wsproxy_test.go
+++ b/enterprise/wsproxy/wsproxy_test.go
@@ -23,7 +23,6 @@ import (
 	"tailscale.com/types/key"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/agent/agenttest"
 	"github.com/coder/coder/v2/buildinfo"
 	"github.com/coder/coder/v2/coderd/coderdtest"
@@ -436,9 +435,7 @@ resourceLoop:
 	// Connect to the workspace agent.
 	conn, err := workspacesdk.New(client).
 		DialAgent(ctx, agentID, &workspacesdk.DialAgentOptions{
-			Logger: slogtest.Make(t, &slogtest.Options{
-				IgnoreErrors: true,
-			}).Named("client").Leveled(slog.LevelDebug),
+			Logger: testutil.Logger(t, testutil.WithIgnoreErrors()).Named("client").Leveled(slog.LevelDebug),
 			// Force DERP.
 			BlockEndpoints: true,
 		})

--- a/provisioner/terraform/convertstate_test.go
+++ b/provisioner/terraform/convertstate_test.go
@@ -14,7 +14,6 @@ import (
 	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/stretchr/testify/require"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/provisioner/terraform"
 	"github.com/coder/coder/v2/testutil"
 )
@@ -62,7 +61,7 @@ func TestConvertStateGolden(t *testing.T) {
 				dotFile := filepath.Join(testDirectoryPath, testFiles[dotIdx].Name())
 
 				ctx := testutil.Context(t, testutil.WaitMedium)
-				logger := slogtest.Make(t, nil)
+				logger := testutil.Logger(t)
 
 				// Gather plan
 				tfStepRaw, err := os.ReadFile(planFile)
@@ -167,7 +166,7 @@ func TestConvertStateDeterministic(t *testing.T) {
 				dotFile := filepath.Join(testDirectoryPath, testFiles[dotIdx].Name())
 
 				ctx := testutil.Context(t, testutil.WaitMedium)
-				logger := slogtest.Make(t, nil)
+				logger := testutil.Logger(t)
 
 				tfStepRaw, err := os.ReadFile(planFile)
 				require.NoError(t, err)

--- a/provisioner/terraform/provision_test.go
+++ b/provisioner/terraform/provision_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/codersdk/drpcsdk"
 	"github.com/coder/coder/v2/provisioner/terraform"
 	"github.com/coder/coder/v2/provisionersdk"
@@ -194,7 +193,7 @@ func TestProvision_Cancel(t *testing.T) {
 			require.NoError(t, err)
 			t.Logf("wrote fake terraform script to %s", binPath)
 
-			logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).
+			logger := testutil.Logger(t, testutil.WithIgnoreErrors()).
 				With(slog.F("source", "provisioner")).
 				Leveled(slog.LevelDebug)
 
@@ -360,7 +359,7 @@ func TestProvision_TextFileBusy(t *testing.T) {
 		srvErr <- srv.Serve(l)
 	}()
 
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 	ctx, api := setupProvisioner(t, &provisionerServeOptions{
 		binaryPath:  binPath,
 		exitTimeout: time.Second,

--- a/provisioner/terraform/resources_test.go
+++ b/provisioner/terraform/resources_test.go
@@ -19,7 +19,6 @@ import (
 	protobuf "google.golang.org/protobuf/proto"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/cryptorand"
 	"github.com/coder/coder/v2/provisioner/terraform"
@@ -1234,7 +1233,7 @@ func TestConvertResources(t *testing.T) {
 
 func TestInvalidTerraformAddress(t *testing.T) {
 	t.Parallel()
-	ctx, logger := context.Background(), slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	ctx, logger := context.Background(), testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	state, err := terraform.ConvertState(ctx, []*tfjson.StateModule{{
 		Resources: []*tfjson.StateResource{{
 			Address:         "invalid",

--- a/provisionerd/provisionerd_test.go
+++ b/provisionerd/provisionerd_test.go
@@ -21,7 +21,6 @@ import (
 	"storj.io/drpc/drpcserver"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/codersdk/drpcsdk"
 	"github.com/coder/coder/v2/provisionerd"
 	"github.com/coder/coder/v2/provisionerd/proto"
@@ -1081,7 +1080,7 @@ func TestProvisionerd(t *testing.T) {
 		t.Cleanup(func() {
 			close(done)
 		})
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 		m := sync.Mutex{}
 		var ops []string
 		completeChan := make(chan struct{})
@@ -1182,7 +1181,7 @@ func TestProvisionerd(t *testing.T) {
 // Creates a provisionerd implementation with the provided dialer and provisioners.
 func createProvisionerd(t *testing.T, dialer provisionerd.Dialer, connector provisionerd.LocalProvisioners) *provisionerd.Server {
 	server := provisionerd.New(dialer, &provisionerd.Options{
-		Logger:         slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Named("provisionerd").Leveled(slog.LevelDebug),
+		Logger:         testutil.Logger(t, testutil.WithIgnoreErrors()).Named("provisionerd").Leveled(slog.LevelDebug),
 		UpdateInterval: 50 * time.Millisecond,
 		Connector:      connector,
 	})
@@ -1404,7 +1403,7 @@ func (a *acquireOne) acquireWithCancel(stream proto.DRPCProvisionerDaemon_Acquir
 }
 
 func extractInit(t *testing.T) func(s *provisionersdk.Session, r *provisionersdk.InitRequest, canceledOrComplete <-chan struct{}) *sdkproto.InitComplete {
-	logger := slogtest.Make(t, nil)
+	logger := testutil.Logger(t)
 	return func(s *provisionersdk.Session, r *provisionersdk.InitRequest, canceledOrComplete <-chan struct{}) *sdkproto.InitComplete {
 		err := s.Files.ExtractArchive(s.Context(), logger, afero.NewOsFs(), r.TemplateSourceArchive, nil)
 		if err != nil {

--- a/provisionersdk/archive_test.go
+++ b/provisionersdk/archive_test.go
@@ -10,14 +10,14 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/provisionersdk"
+	"github.com/coder/coder/v2/testutil"
 )
 
 func TestTar(t *testing.T) {
 	t.Parallel()
 
-	log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+	log := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 	t.Run("NoFollowSymlink", func(t *testing.T) {
 		t.Parallel()
@@ -187,7 +187,7 @@ func TestUntar(t *testing.T) {
 	t.Run("Basic", func(t *testing.T) {
 		t.Parallel()
 
-		log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		log := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 		dir := t.TempDir()
 		file, err := os.CreateTemp(dir, "*.tf")
@@ -209,7 +209,7 @@ func TestUntar(t *testing.T) {
 	t.Run("Overwrite", func(t *testing.T) {
 		t.Parallel()
 
-		log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		log := testutil.Logger(t, testutil.WithIgnoreErrors())
 
 		dir1 := t.TempDir()
 		dir2 := t.TempDir()

--- a/provisionersdk/tfpath/tfpath_test.go
+++ b/provisionersdk/tfpath/tfpath_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/provisionersdk/tfpath"
 	"github.com/coder/coder/v2/testutil"
 )
@@ -38,9 +37,7 @@ func TestCleanStaleSessions(t *testing.T) {
 
 		future := time.Now().Add(time.Hour * 24 * 120)
 		l := tfpath.Session(parentDir, "sess1")
-		err = l.CleanStaleSessions(ctx, slogtest.Make(t, &slogtest.Options{
-			IgnoreErrors: true,
-		}), failingFs, future)
+		err = l.CleanStaleSessions(ctx, testutil.Logger(t, testutil.WithIgnoreErrors()), failingFs, future)
 		require.NoError(t, err)
 		require.True(t, called)
 	})
@@ -68,9 +65,7 @@ func TestCleanStaleSessions(t *testing.T) {
 		}
 
 		future := time.Now().Add(time.Hour * 24 * 120)
-		err = staleSession.CleanStaleSessions(ctx, slogtest.Make(t, &slogtest.Options{
-			IgnoreErrors: true,
-		}), failingFs, future)
+		err = staleSession.CleanStaleSessions(ctx, testutil.Logger(t, testutil.WithIgnoreErrors()), failingFs, future)
 		require.ErrorContains(t, err, "constant failure")
 		require.True(t, called)
 	})

--- a/scaletest/createworkspaces/run_test.go
+++ b/scaletest/createworkspaces/run_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/agent"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/coderd/httpapi"
@@ -198,7 +197,7 @@ func Test_Runner(t *testing.T) {
 
 		// need to include our own logger because the provisioner (rightly) drops error logs when we shut down the
 		// test with a build in progress.
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		client := coderdtest.New(t, &coderdtest.Options{
 			IncludeProvisionerDaemon: true,
 			Logger:                   &logger,
@@ -472,7 +471,7 @@ func Test_Runner(t *testing.T) {
 	t.Run("FailedBuild", func(t *testing.T) {
 		t.Parallel()
 
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 		client := coderdtest.New(t, &coderdtest.Options{
 			IncludeProvisionerDaemon: true,
 			Logger:                   &logger,
@@ -559,7 +558,7 @@ func goEventuallyStartFakeAgent(ctx context.Context, t *testing.T, client *coder
 		agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(agentToken))
 		agentCloser := agent.New(agent.Options{
 			Client: agentClient,
-			Logger: slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).
+			Logger: testutil.Logger(t, testutil.WithIgnoreErrors()).
 				Named("agent").Leveled(slog.LevelWarn),
 		})
 		resources := coderdtest.AwaitWorkspaceAgents(t, client, workspace.ID)

--- a/scaletest/dashboard/run_test.go
+++ b/scaletest/dashboard/run_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/scaletest/dashboard"
 	"github.com/coder/coder/v2/testutil"
@@ -45,9 +44,7 @@ func Test_Run(t *testing.T) {
 	client := coderdtest.New(t, nil)
 	_ = coderdtest.CreateFirstUser(t, client)
 
-	log := slogtest.Make(t, &slogtest.Options{
-		IgnoreErrors: true,
-	})
+	log := testutil.Logger(t, testutil.WithIgnoreErrors())
 	m := &testMetrics{}
 	var (
 		waitLoadedCalled atomic.Bool

--- a/scaletest/smtpmock/server_test.go
+++ b/scaletest/smtpmock/server_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/scaletest/smtpmock"
 	"github.com/coder/coder/v2/testutil"
 )
@@ -27,7 +26,7 @@ func TestServer_StartStop(t *testing.T) {
 		HostAddress: "127.0.0.1",
 		SMTPPort:    0,
 		APIPort:     0,
-		Logger:      slogtest.Make(t, nil),
+		Logger:      testutil.Logger(t),
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, srv.SMTPAddress())
@@ -46,7 +45,7 @@ func TestServer_SendAndReceiveEmail(t *testing.T) {
 		HostAddress: "127.0.0.1",
 		SMTPPort:    0,
 		APIPort:     0,
-		Logger:      slogtest.Make(t, nil),
+		Logger:      testutil.Logger(t),
 	})
 	require.NoError(t, err)
 	defer srv.Stop()
@@ -84,7 +83,7 @@ func TestServer_FilterByEmail(t *testing.T) {
 		HostAddress: "127.0.0.1",
 		SMTPPort:    0,
 		APIPort:     0,
-		Logger:      slogtest.Make(t, nil),
+		Logger:      testutil.Logger(t),
 	})
 	require.NoError(t, err)
 	defer srv.Stop()
@@ -123,7 +122,7 @@ func TestServer_NotificationTemplateID(t *testing.T) {
 		HostAddress: "127.0.0.1",
 		SMTPPort:    0,
 		APIPort:     0,
-		Logger:      slogtest.Make(t, nil),
+		Logger:      testutil.Logger(t),
 	})
 	require.NoError(t, err)
 	defer srv.Stop()
@@ -162,7 +161,7 @@ func TestServer_Purge(t *testing.T) {
 		HostAddress: "127.0.0.1",
 		SMTPPort:    0,
 		APIPort:     0,
-		Logger:      slogtest.Make(t, nil),
+		Logger:      testutil.Logger(t),
 	})
 	require.NoError(t, err)
 	defer srv.Stop()

--- a/scaletest/workspacebuild/run_test.go
+++ b/scaletest/workspacebuild/run_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/agent"
 	"github.com/coder/coder/v2/coderd/coderdtest"
 	"github.com/coder/coder/v2/codersdk"
@@ -141,7 +140,7 @@ func Test_Runner(t *testing.T) {
 				agentClient := agentsdk.New(client.URL, agentsdk.WithFixedToken(authToken))
 				agentCloser := agent.New(agent.Options{
 					Client: agentClient,
-					Logger: slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).
+					Logger: testutil.Logger(t, testutil.WithIgnoreErrors()).
 						Named(fmt.Sprintf("agent%d", i)).
 						Leveled(slog.LevelWarn),
 				})
@@ -195,7 +194,7 @@ func Test_Runner(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 		client := coderdtest.New(t, &coderdtest.Options{
 			IncludeProvisionerDaemon: true,
 			Logger:                   &logger,
@@ -241,7 +240,7 @@ func Test_Runner(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutil.WaitLong)
 		defer cancel()
 
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors())
 		client := coderdtest.New(t, &coderdtest.Options{
 			IncludeProvisionerDaemon: true,
 			Logger:                   &logger,

--- a/support/support_test.go
+++ b/support/support_test.go
@@ -17,7 +17,6 @@ import (
 
 	"cdr.dev/slog/v3"
 	"cdr.dev/slog/v3/sloggers/sloghuman"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/agent"
 	"github.com/coder/coder/v2/agent/agenttest"
 	"github.com/coder/coder/v2/coderd/coderdtest"
@@ -124,7 +123,7 @@ func TestRun(t *testing.T) {
 		_ = coderdtest.CreateFirstUser(t, client)
 		bun, err := support.Run(ctx, &support.Deps{
 			Client: client,
-			Log:    slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Named("bundle").Leveled(slog.LevelDebug),
+			Log:    testutil.Logger(t, testutil.WithIgnoreErrors()).Named("bundle").Leveled(slog.LevelDebug),
 		})
 		require.NoError(t, err)
 		assertNotNilNotEmpty(t, bun, "bundle should be present")
@@ -159,7 +158,7 @@ func TestRun(t *testing.T) {
 		})
 		bun, err := support.Run(ctx, &support.Deps{
 			Client: client,
-			Log:    slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Named("bundle").Leveled(slog.LevelDebug),
+			Log:    testutil.Logger(t, testutil.WithIgnoreErrors()).Named("bundle").Leveled(slog.LevelDebug),
 		})
 		var sdkErr *codersdk.Error
 		require.Nil(t, bun)
@@ -177,7 +176,7 @@ func TestRun(t *testing.T) {
 		memberClient, _ := coderdtest.CreateAnotherUser(t, client, admin.OrganizationID)
 		bun, err := support.Run(ctx, &support.Deps{
 			Client: memberClient,
-			Log:    slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Named("bundle").Leveled(slog.LevelDebug),
+			Log:    testutil.Logger(t, testutil.WithIgnoreErrors()).Named("bundle").Leveled(slog.LevelDebug),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, bun)

--- a/tailnet/controllers_test.go
+++ b/tailnet/controllers_test.go
@@ -28,7 +28,6 @@ import (
 	"tailscale.com/util/dnsname"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/tailnet"
 	"github.com/coder/coder/v2/tailnet/proto"
 	"github.com/coder/coder/v2/tailnet/tailnettest"
@@ -998,12 +997,8 @@ func TestController_Disconnects(t *testing.T) {
 	t.Parallel()
 	testCtx := testutil.Context(t, testutil.WaitShort)
 	ctx, cancel := context.WithCancel(testCtx)
-	logger := slogtest.Make(t, &slogtest.Options{
-		IgnoredErrorIs: append(slogtest.DefaultIgnoredErrorIs,
-			io.EOF,                   // we get EOF when we simulate a DERPMap error
-			yamux.ErrSessionShutdown, // coordination can throw these when DERP error tears down session
-		),
-	}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoredErrorIs(io.EOF,
+		yamux.ErrSessionShutdown)).Leveled(slog.LevelDebug)
 	agentID := uuid.UUID{0x55}
 	clientID := uuid.UUID{0x66}
 	fCoord := tailnettest.NewFakeCoordinator()
@@ -1220,9 +1215,7 @@ func TestController_WorkspaceUpdates(t *testing.T) {
 	theError := xerrors.New("a bad thing happened")
 	testCtx := testutil.Context(t, testutil.WaitShort)
 	ctx, cancel := context.WithCancel(testCtx)
-	logger := slogtest.Make(t, &slogtest.Options{
-		IgnoredErrorIs: append(slogtest.DefaultIgnoredErrorIs, theError),
-	}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoredErrorIs(theError)).Leveled(slog.LevelDebug)
 
 	fClient := newFakeWorkspaceUpdateClient(testCtx, t)
 	dialer := &fakeWorkspaceUpdatesDialer{
@@ -1863,8 +1856,7 @@ func TestTunnelAllWorkspaceUpdatesController_DNSError(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.Context(t, testutil.WaitShort)
 	dnsError := xerrors.New("a bad thing happened")
-	logger := slogtest.Make(t,
-		&slogtest.Options{IgnoredErrorIs: []error{dnsError}}).
+	logger := testutil.Logger(t, testutil.WithIgnoredErrorIs(dnsError)).
 		Leveled(slog.LevelDebug)
 
 	fDNS := newFakeDNSSetter(ctx, t)
@@ -2004,7 +1996,7 @@ func TestTunnelAllWorkspaceUpdatesController_HandleErrors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := testutil.Context(t, testutil.WaitShort)
-			logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+			logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 
 			fConn := &fakeCoordinatee{}
 			tsc := tailnet.NewTunnelSrcCoordController(logger, fConn)
@@ -2236,7 +2228,7 @@ func TestTunnelAllWorkspaceUpdatesController_SnapshotClearsInheritedState(t *tes
 func TestBasicDERPController_RewriteDERPMap(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.Context(t, testutil.WaitShort)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 
 	testDERPMap := &tailcfg.DERPMap{
 		Regions: map[int]*tailcfg.DERPRegion{

--- a/tailnet/coordinator_test.go
+++ b/tailnet/coordinator_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/tailnet"
 	"github.com/coder/coder/v2/tailnet/proto"
 	"github.com/coder/coder/v2/tailnet/test"
@@ -41,7 +40,7 @@ func TestCoordinator(t *testing.T) {
 
 	t.Run("ClientWithoutAgent_InvalidIPBits", func(t *testing.T) {
 		t.Parallel()
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		ctx := testutil.Context(t, testutil.WaitShort)
 		coordinator := tailnet.NewCoordinator(logger)
 		defer func() {
@@ -87,7 +86,7 @@ func TestCoordinator(t *testing.T) {
 
 	t.Run("AgentWithoutClients_InvalidIP", func(t *testing.T) {
 		t.Parallel()
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		ctx := testutil.Context(t, testutil.WaitShort)
 		coordinator := tailnet.NewCoordinator(logger)
 		defer func() {
@@ -107,7 +106,7 @@ func TestCoordinator(t *testing.T) {
 
 	t.Run("AgentWithoutClients_InvalidBits", func(t *testing.T) {
 		t.Parallel()
-		logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+		logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 		ctx := testutil.Context(t, testutil.WaitShort)
 		coordinator := tailnet.NewCoordinator(logger)
 		defer func() {

--- a/vpn/speaker_internal_test.go
+++ b/vpn/speaker_internal_test.go
@@ -14,7 +14,6 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/coder/v2/testutil"
 )
 
@@ -95,7 +94,7 @@ func TestSpeaker_HandshakeRWFailure(t *testing.T) {
 	// immediately close the pipe, so we'll get read & write failures on handshake
 	_ = mp.Close()
 	ctx := testutil.Context(t, testutil.WaitShort)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 
 	var tun *speaker[*TunnelMessage, *ManagerMessage, ManagerMessage]
 	errCh := make(chan error, 1)
@@ -118,7 +117,7 @@ func TestSpeaker_HandshakeCtxDone(t *testing.T) {
 	defer tp.Close()
 	testCtx := testutil.Context(t, testutil.WaitShort)
 	ctx, cancel := context.WithCancel(testCtx)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 
 	var tun *speaker[*TunnelMessage, *ManagerMessage, ManagerMessage]
 	errCh := make(chan error, 1)
@@ -147,7 +146,7 @@ func TestSpeaker_OversizeHandshake(t *testing.T) {
 	require.NoError(t, err)
 	err = mp.SetWriteDeadline(time.Now().Add(testutil.WaitShort))
 	require.NoError(t, err)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	var tun *speaker[*TunnelMessage, *ManagerMessage, ManagerMessage]
 	errCh := make(chan error, 1)
 	go func() {
@@ -195,7 +194,7 @@ func TestSpeaker_HandshakeInvalid(t *testing.T) {
 			require.NoError(t, err)
 			err = mp.SetWriteDeadline(time.Now().Add(testutil.WaitShort))
 			require.NoError(t, err)
-			logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+			logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 			var tun *speaker[*TunnelMessage, *ManagerMessage, ManagerMessage]
 			errCh := make(chan error, 1)
 			go func() {
@@ -235,7 +234,7 @@ func TestSpeaker_CorruptMessage(t *testing.T) {
 	require.NoError(t, err)
 	err = mp.SetWriteDeadline(time.Now().Add(testutil.WaitShort))
 	require.NoError(t, err)
-	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
+	logger := testutil.Logger(t, testutil.WithIgnoreErrors()).Leveled(slog.LevelDebug)
 	var tun *speaker[*TunnelMessage, *ManagerMessage, ManagerMessage]
 	errCh := make(chan error, 1)
 	go func() {


### PR DESCRIPTION
Mechanical sweep. All slogtest.Make call sites except coderd/coderdtest/oidctest/idp.go (which has *slogtest.Options in its public WithLogging signature) now route through testutil.Logger so they pick up the default deny-list filter.

Five files in aibridge/ import a local aibridge/internal/testutil package as 'testutil', so the new coder/coder/testutil import is aliased as 'codertestutil' there.

Two conditional-IgnoreErrors call sites
(coderd/autobuild/lifecycle_executor_test.go,
coderd/provisionerdserver/provisionerdserver_test.go) were rewritten by hand to build a []testutil.LoggerOption based on the predicate.

> 🤖 Created by Coder Agents
