### PR TITLE
fix(site): align streaming thinking spacing

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.stories.tsx
@@ -268,13 +268,24 @@ export const ThinkingDuringStreamingWithToolCalls: Story = {
 				tool_call_id: "tc-1",
 				args: { command: "ls -la" },
 			},
+			{
+				type: "tool-call",
+				tool_name: "read_file",
+				tool_call_id: "tc-2",
+				args: { path: "README.md" },
+			},
 		]),
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		// "Thinking" should still be visible during streaming
-		// when only tool-call blocks have arrived.
+		// Tool-only stream chunks can otherwise clear the activity indicator before text arrives.
 		const matches = canvas.getAllByText("Thinking");
 		expect(matches.length).toBeGreaterThanOrEqual(1);
+
+		const thinkingBlock = matches[0].parentElement;
+		expect(thinkingBlock).toBeInstanceOf(HTMLElement);
+		expect(getComputedStyle(thinkingBlock as HTMLElement).marginTop).toBe(
+			"8px",
+		);
 	},
 };

--- a/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/StreamingOutput.tsx
@@ -92,7 +92,7 @@ export const StreamingOutput: FC<{
 		<ConversationItem {...conversationItemProps}>
 			<Message className="w-full">
 				<MessageContent className="whitespace-normal">
-					<div className="space-y-3">
+					<div className="space-y-2">
 						{shouldShowBlocks && (
 							<BlockList
 								blocks={blocks}


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood

The streaming-only Thinking placeholder used the same 12px block spacing as completed assistant message blocks, leaving a larger gap above the indicator than the 8px spacing used between adjacent streaming tool calls.

Tighten the streaming output stack to 8px and extend the Storybook interaction story to catch the margin regression for tool-only stream chunks.
