### PR TITLE
chore(scripts/ironbank): update hardening_manifest.yaml to current versions

### DIFF
--- a/scripts/ironbank/hardening_manifest.yaml
+++ b/scripts/ironbank/hardening_manifest.yaml
@@ -7,13 +7,13 @@ name: "coder/coder-enterprise/coder-service-2"
 # The most specific version should be the first tag and will be shown
 # on ironbank.dso.mil
 tags:
-  - "0.15.3"
+  - "2.33.2"
   - "latest"
 
 # Build args passed to Dockerfile ARGs
 args:
   # Needs to be kept in sync with the resource below.
-  TERRAFORM_CODER_PROVIDER_VERSION: "0.6.10"
+  TERRAFORM_CODER_PROVIDER_VERSION: "2.16.0"
 
 # Docker image labels
 labels:
@@ -26,34 +26,34 @@ labels:
   org.opencontainers.image.url: "https://coder.com/docs"
   # Name of the distributing entity, organization or individual
   org.opencontainers.image.vendor: "Coder Technologies"
-  org.opencontainers.image.version: "0.15.3"
+  org.opencontainers.image.version: "2.33.2"
   # Keywords to help with search (ex. "cicd,gitops,golang")
   mil.dso.ironbank.image.keywords: "remote, workspaces"
 
 # List of resources to make available to the offline build context
 resources:
   # Coder binary
-  - url: "https://github.com/coder/coder/releases/download/v0.15.3/coder_0.15.3_linux_amd64.tar.gz"
+  - url: "https://github.com/coder/coder/releases/download/v2.33.2/coder_2.33.2_linux_amd64.tar.gz"
     filename: "coder.tar.gz"
     validation:
       type: sha256
-      value: 2c88555777f1d9cc77a8f049093f4002472dc43d52b026e6784ef477bdced4a2
+      value: 4d707233894f3525e6c1dba8d2329cc473aab23e59d35242be23109e900b7438
   # Terraform binary, bundled inside of Coder to support air-gapped installs.
-  - url: https://releases.hashicorp.com/terraform/1.3.7/terraform_1.3.7_linux_amd64.zip
+  - url: https://releases.hashicorp.com/terraform/1.15.2/terraform_1.15.2_linux_amd64.zip
     filename: "terraform.zip"
     validation:
       type: sha256
-      value: b8cf184dee15dfa89713fe56085313ab23db22e17284a9a27c0999c67ce3021e
+      value: c56ff2bc7e6ce9b3879a50392b03c2ea074b47688bf503ff966c87fb01b2aab8
   # Coder Terraform provider, bundled inside of Coder to support air-gapped
   # installs.
   #
   # The version of this provider needs to be kept in sync with the
   # TERRAFORM_CODER_PROVIDER_VERSION build arg.
-  - url: https://github.com/coder/terraform-provider-coder/releases/download/v0.6.10/terraform-provider-coder_0.6.10_linux_amd64.zip
+  - url: https://github.com/coder/terraform-provider-coder/releases/download/v2.16.0/terraform-provider-coder_2.16.0_linux_amd64.zip
     filename: "terraform-provider-coder.zip"
     validation:
       type: sha256
-      value: 4c2a16010621e146251f6fb5e27105dde9213d85ca8f3c8866c3f5a4159b81b0
+      value: 8eeb2c74e804087c3959d37c5cf773ec00beba431d3a312518aea5934bc8c73b
 
 # List of project maintainers
 maintainers:


### PR DESCRIPTION
Updates all pinned versions in the IronBank hardening manifest from v0.15.3-era (2022/2023) to current releases:

- **Coder**: v0.15.3 -> v2.33.2
- **Terraform**: v1.3.7 -> v1.15.2
- **Terraform provider coder**: v0.6.10 -> v2.16.0
- All SHA256 checksums updated to match new versions
- Image version label updated to 2.33.2

The Dockerfile was already updated to UBI9 in a prior change. This PR addresses the remaining stale references in the manifest.

**Note on maintainer contacts**: The manifest still lists Eric Paulsen and Dean Sheather. These should be verified as current IronBank maintainers; updating if needed is left for a follow-up.

Refs https://linear.app/codercom/issue/ENT-84

<details>
<summary>Coder Agents generated</summary>

Generated by Coder Agents on behalf of @Shelnutt2. Versions sourced from:
- Coder: latest stable git tag (v2.33.2)
- Terraform: `install.sh` (`TERRAFORM_VERSION=1.15.2`)
- Provider: `go.mod` (`github.com/coder/terraform-provider-coder/v2 v2.16.0`)
- SHA256 checksums fetched from official release checksum files
</details>