### PR TITLE
fix(site): hide sticky metadata user messages

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
@@ -1139,6 +1139,45 @@ export const UserMessageWithMultipleInlineFileRefs: Story = {
 	},
 };
 
+export const MetadataOnlyUserMessageDoesNotLeaveStickyGap: Story = {
+	args: {
+		...defaultArgs,
+		parsedMessages: buildMessages([
+			{
+				...baseMessage,
+				id: 1,
+				role: "assistant",
+				content: [{ type: "text", text: "Before hidden metadata." }],
+			},
+			{
+				...baseMessage,
+				id: 2,
+				role: "user",
+				content: [
+					{
+						type: "context-file",
+						context_file_path: "/home/coder/coder/AGENTS.md",
+					},
+				],
+			},
+			{
+				...baseMessage,
+				id: 3,
+				role: "assistant",
+				content: [{ type: "text", text: "After hidden metadata." }],
+			},
+		]),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		expect(canvas.getByText("Before hidden metadata.")).toBeVisible();
+		expect(canvas.getByText("After hidden metadata.")).toBeVisible();
+		expect(canvasElement.querySelectorAll("[data-user-sentinel]")).toHaveLength(
+			0,
+		);
+	},
+};
+
 /**
  * Verifies the structural requirements for sticky user messages
  * in the flat (section-less) message list:

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -1082,6 +1082,16 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 				>
 					{parsedMessages.map(({ message, parsed }, msgIdx) => {
 						if (message.role === "user") {
+							const { shouldHide } = deriveMessageDisplayState({
+								message,
+								parsed,
+								hideActions: false,
+								hasActiveStream: false,
+								isAwaitingFirstStreamChunk: false,
+							});
+							if (shouldHide) {
+								return null;
+							}
 							return (
 								<StickyUserMessage
 									key={message.id}


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood

Metadata-only user messages in agent conversations were hidden by `ChatMessageItem`, but the timeline still wrapped them in `StickyUserMessage`, leaving behind an empty sticky sentinel/container that could affect persisted conversation spacing.

Apply the existing message display-state check before rendering sticky user messages, and add a Storybook regression that verifies metadata-only user messages do not leave sticky sentinels in the DOM.
