### PR TITLE
fix(site): stabilize agent chat scrolling

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -97,7 +97,6 @@
 		"react-confetti": "6.4.0",
 		"react-day-picker": "9.14.0",
 		"react-dom": "19.2.5",
-		"react-infinite-scroll-component": "7.1.0",
 		"react-markdown": "9.1.0",
 		"react-query": "npm:@tanstack/react-query@5.77.0",
 		"react-resizable-panels": "3.0.6",

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -206,9 +206,6 @@ importers:
       react-dom:
         specifier: 19.2.5
         version: 19.2.5(react@19.2.5)
-      react-infinite-scroll-component:
-        specifier: 7.1.0
-        version: 7.1.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react-markdown:
         specifier: 9.1.0
         version: 9.1.0(@types/react@19.2.14)(react@19.2.5)
@@ -5192,13 +5189,6 @@ packages:
 
   react-fast-compare@2.0.4:
     resolution: {integrity: sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==, tarball: https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz}
-
-  react-infinite-scroll-component@7.1.0:
-    resolution: {integrity: sha512-EPUMyOnpmJDqI1aoUi9uR/TSUfJCUN77ZkpzYSshGwrC2NTaH6p+rxaP/2DZJWygOZmZcAieZk4VciF8q9H/tw==, tarball: https://registry.npmjs.org/react-infinite-scroll-component/-/react-infinite-scroll-component-7.1.0.tgz}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      react: '>=17.0.0'
-      react-dom: '>=17.0.0'
 
   react-inspector@6.0.2:
     resolution: {integrity: sha512-x+b7LxhmHXjHoU/VrFAzw5iutsILRoYyDq97EDYdFpPLcvqtEzk4ZSZSQjnFPbr5T57tLXnHcqFYoN1pI6u8uQ==, tarball: https://registry.npmjs.org/react-inspector/-/react-inspector-6.0.2.tgz}
@@ -11618,11 +11608,6 @@ snapshots:
       react: 19.2.5
 
   react-fast-compare@2.0.4: {}
-
-  react-infinite-scroll-component@7.1.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
-    dependencies:
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
 
   react-inspector@6.0.2(react@19.2.5):
     dependencies:

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -27,6 +27,7 @@ import {
 	useChatSelector,
 } from "./components/ChatConversation/chatStore";
 import type { ModelSelectorOption } from "./components/ChatElements";
+import { getBottomGap } from "./components/chatViewportUtils";
 import { lastActiveSidebarTabStorageKeyPrefix } from "./utils/sidebarTabStorage";
 import type { ChatDetailError } from "./utils/usageLimitMessage";
 
@@ -434,7 +435,7 @@ export const SidebarCollapsed: Story = {
 	render: () => <StoryAgentChatPageView isSidebarCollapsed />,
 };
 
-/** No model options available — shows a disabled status message. */
+/** No model options available. Shows a disabled status message. */
 export const NoModelOptions: Story = {
 	render: () => (
 		<StoryAgentChatPageView
@@ -622,7 +623,7 @@ export const Loading: Story = {
 	render: () => (
 		<AgentChatPageLoadingView
 			sendShortcut="enter"
-			titleElement={<title>Loading — Agents</title>}
+			titleElement={<title>Loading | Agents</title>}
 			isInputDisabled
 			effectiveSelectedModel={defaultModelConfigID}
 			setSelectedModel={fn()}
@@ -641,7 +642,7 @@ export const LoadingWithModelOptions: Story = {
 	render: () => (
 		<AgentChatPageLoadingView
 			sendShortcut="enter"
-			titleElement={<title>Loading — Agents</title>}
+			titleElement={<title>Loading | Agents</title>}
 			isInputDisabled={false}
 			effectiveSelectedModel={defaultModelConfigID}
 			setSelectedModel={fn()}
@@ -659,7 +660,7 @@ export const LoadingWithRightPanel: Story = {
 	render: () => (
 		<AgentChatPageLoadingView
 			sendShortcut="enter"
-			titleElement={<title>Loading — Agents</title>}
+			titleElement={<title>Loading | Agents</title>}
 			isInputDisabled
 			effectiveSelectedModel={defaultModelConfigID}
 			setSelectedModel={fn()}
@@ -678,7 +679,7 @@ export const LoadingSidebarCollapsed: Story = {
 	render: () => (
 		<AgentChatPageLoadingView
 			sendShortcut="enter"
-			titleElement={<title>Loading — Agents</title>}
+			titleElement={<title>Loading | Agents</title>}
 			isInputDisabled
 			effectiveSelectedModel={defaultModelConfigID}
 			setSelectedModel={fn()}
@@ -734,7 +735,7 @@ const editingMessages = [
 	buildMessage(5, "user", "That was terrible, try again"),
 ];
 
-/** Editing a message in the middle of the conversation — shows the warning
+/** Editing a message in the middle of the conversation. Shows the warning
  *  border on the edited message, faded subsequent messages, and the editing
  *  banner + outline on the chat input. */
 export const EditingMessage: Story = {
@@ -757,7 +758,7 @@ export const EditingMessage: Story = {
 export const NotFound: Story = {
 	render: () => (
 		<AgentChatPageNotFoundView
-			titleElement={<title>Not Found — Agents</title>}
+			titleElement={<title>Not Found | Agents</title>}
 			isSidebarCollapsed={false}
 			onToggleSidebarCollapsed={fn()}
 		/>
@@ -768,7 +769,7 @@ export const NotFound: Story = {
 export const NotFoundSidebarCollapsed: Story = {
 	render: () => (
 		<AgentChatPageNotFoundView
-			titleElement={<title>Not Found — Agents</title>}
+			titleElement={<title>Not Found | Agents</title>}
 			isSidebarCollapsed
 			onToggleSidebarCollapsed={fn()}
 		/>
@@ -818,14 +819,49 @@ const waitForScrollOverflow = async (scrollContainer: HTMLElement) => {
 };
 
 const scrollToHistoryTop = (scrollContainer: HTMLElement) => {
-	// In the library's documented column-reverse layout, older history is
-	// reached by driving the scroll offset toward the negative extreme.
-	scrollContainer.scrollTop = -scrollContainer.scrollHeight;
+	scrollContainer.dispatchEvent(new WheelEvent("wheel", { deltaY: -1 }));
+	scrollContainer.scrollTop = 0;
 	scrollContainer.dispatchEvent(new Event("scroll"));
 };
 
 const scrollToLatestMessages = (scrollContainer: HTMLElement) => {
-	scrollContainer.scrollTop = 0;
+	scrollContainer.scrollTop = scrollContainer.scrollHeight;
+	scrollContainer.dispatchEvent(new Event("scroll"));
+};
+
+const getBottomGapForStory = (scrollContainer: HTMLElement) =>
+	getBottomGap(scrollContainer);
+
+const getChatAnchor = (
+	scrollContainer: HTMLElement,
+	anchorId: string,
+): HTMLElement => {
+	const anchor = scrollContainer.querySelector<HTMLElement>(
+		`[data-chat-anchor-id="${anchorId}"]`,
+	);
+	if (!anchor) {
+		throw new Error(`Expected chat anchor ${anchorId} to exist.`);
+	}
+	return anchor;
+};
+
+const getAnchorOffset = (
+	scrollContainer: HTMLElement,
+	anchor: HTMLElement,
+): number =>
+	anchor.getBoundingClientRect().top -
+	scrollContainer.getBoundingClientRect().top;
+
+const scrollAnchorNearTop = (
+	scrollContainer: HTMLElement,
+	anchor: HTMLElement,
+) => {
+	scrollContainer.dispatchEvent(new WheelEvent("wheel", { deltaY: -1 }));
+	const offset = getAnchorOffset(scrollContainer, anchor);
+	scrollContainer.scrollTop = Math.max(
+		0,
+		scrollContainer.scrollTop + offset - 80,
+	);
 	scrollContainer.dispatchEvent(new Event("scroll"));
 };
 
@@ -884,6 +920,18 @@ const getStoreMessages = (
 	return messages;
 };
 
+const appendNewestMessage = (
+	store: ReturnType<typeof createChatStore>,
+	text: string,
+) => {
+	const existing = getStoreMessages(store);
+	const newestID = existing.at(-1)?.id ?? 0;
+	store.replaceMessages([
+		...existing,
+		buildMessage(newestID + 1, "assistant", text),
+	]);
+};
+
 const prependOlderMessages = (
 	store: ReturnType<typeof createChatStore>,
 	count: number,
@@ -905,45 +953,40 @@ const prependOlderMessages = (
 
 const resetScrollStoryStore = (
 	store: ReturnType<typeof createChatStore>,
-	// Default to a transcript long enough to overflow the 600px decorator so the
-	// inverse-scroll stories exercise the fetch threshold immediately.
 	count = 80,
 ) => {
 	store.replaceMessages(buildLongConversation(count));
 	store.setChatStatus("completed");
 };
 
-const inverseScrollStore = buildStoreWithMessages(buildLongConversation(80));
-const inverseScrollFetchSpy = fn(() => {
-	prependOlderMessages(inverseScrollStore, 10);
+const historyLoadStore = buildStoreWithMessages(buildLongConversation(80));
+const historyLoadFetchSpy = fn(() => {
+	prependOlderMessages(historyLoadStore, 10);
 });
 
-/**
- * Scrolling upward in the library's inverse mode loads older messages into the
- * top of the transcript.
- */
-export const InverseScrollLoadsOlderMessages: Story = {
+export const ScrollLoadsOlderMessages: Story = {
 	parameters: { chromatic: { disableSnapshot: true } },
 	decorators: scrollStoryDecorators,
 	render: () => (
 		<StoryAgentChatPageView
-			store={inverseScrollStore}
+			store={historyLoadStore}
 			hasMoreMessages
-			onFetchMoreMessages={inverseScrollFetchSpy}
+			onFetchMoreMessages={historyLoadFetchSpy}
 		/>
 	),
 	play: async ({ canvasElement }) => {
-		resetScrollStoryStore(inverseScrollStore);
-		inverseScrollFetchSpy.mockClear();
+		resetScrollStoryStore(historyLoadStore);
+		historyLoadFetchSpy.mockClear();
 		const canvas = within(canvasElement);
 		const scrollContainer = canvas.getByTestId("scroll-container");
 
 		await waitForScrollOverflow(scrollContainer);
-		expect(inverseScrollFetchSpy).not.toHaveBeenCalled();
+		expect(historyLoadFetchSpy).not.toHaveBeenCalled();
 
 		scrollToHistoryTop(scrollContainer);
+		await waitForIntersectionObserverTick();
 
-		await waitForFetchCount(inverseScrollFetchSpy, 1);
+		await waitForFetchCount(historyLoadFetchSpy, 1);
 		await waitForVisibleText(canvas, "Older question 9.");
 	},
 };
@@ -953,11 +996,7 @@ const multiPageFetchSpy = fn(() => {
 	prependOlderMessages(multiPageScrollStore, 10);
 });
 
-/**
- * The library resets its one-shot load guard when dataLength changes, so a
- * second upward reveal can load another page.
- */
-export const InverseScrollCanLoadMultiplePages: Story = {
+export const ScrollCanLoadMultiplePages: Story = {
 	parameters: { chromatic: { disableSnapshot: true } },
 	decorators: scrollStoryDecorators,
 	render: () => (
@@ -976,18 +1015,58 @@ export const InverseScrollCanLoadMultiplePages: Story = {
 		await waitForScrollOverflow(scrollContainer);
 
 		scrollToHistoryTop(scrollContainer);
+		await waitForIntersectionObserverTick();
 		await waitForFetchCount(multiPageFetchSpy, 1);
 		await waitForVisibleText(canvas, "Older question 9.");
 
 		scrollToLatestMessages(scrollContainer);
 		await waitFor(() => {
-			expect(scrollContainer.scrollTop).toBe(0);
+			expect(getBottomGapForStory(scrollContainer)).toBeLessThanOrEqual(2);
 		});
 		await waitForIntersectionObserverTick();
 		scrollToHistoryTop(scrollContainer);
+		await waitForIntersectionObserverTick();
 
 		await waitForFetchCount(multiPageFetchSpy, 2);
 		await waitForVisibleText(canvas, "Older answer 10.");
+	},
+};
+
+const historyPrependStore = buildStoreWithMessages(buildLongConversation(80));
+const historyPrependFetchSpy = fn(() => {
+	prependOlderMessages(historyPrependStore, 10);
+});
+
+export const HistoryPrependPreservesViewport: Story = {
+	parameters: { chromatic: { disableSnapshot: true } },
+	decorators: scrollStoryDecorators,
+	render: () => (
+		<StoryAgentChatPageView
+			store={historyPrependStore}
+			hasMoreMessages
+			onFetchMoreMessages={historyPrependFetchSpy}
+		/>
+	),
+	play: async ({ canvasElement }) => {
+		resetScrollStoryStore(historyPrependStore);
+		historyPrependFetchSpy.mockClear();
+		const canvas = within(canvasElement);
+		const scrollContainer = canvas.getByTestId("scroll-container");
+
+		await waitForScrollOverflow(scrollContainer);
+		scrollToHistoryTop(scrollContainer);
+		await waitForIntersectionObserverTick();
+
+		const anchor = getChatAnchor(scrollContainer, "message-2");
+		const beforeOffset = getAnchorOffset(scrollContainer, anchor);
+
+		await waitForFetchCount(historyPrependFetchSpy, 1);
+		await waitForVisibleText(canvas, "Older question 9.");
+		await waitFor(() => {
+			expect(
+				Math.abs(getAnchorOffset(scrollContainer, anchor) - beforeOffset),
+			).toBeLessThanOrEqual(2);
+		});
 	},
 };
 
@@ -995,11 +1074,7 @@ const scrollToBottomButtonStoryStore = buildStoreWithMessages(
 	buildLongConversation(80),
 );
 
-/**
- * The replacement container should keep the floating affordance that returns a
- * user from older history to the newest messages.
- */
-export const ScrollToBottomButtonWorksWithInverseScroll: Story = {
+export const ScrollToBottomButtonUsesNormalFlow: Story = {
 	parameters: { chromatic: { disableSnapshot: true } },
 	decorators: scrollStoryDecorators,
 	render: () => (
@@ -1011,9 +1086,12 @@ export const ScrollToBottomButtonWorksWithInverseScroll: Story = {
 		const scrollContainer = canvas.getByTestId("scroll-container");
 
 		await waitForScrollOverflow(scrollContainer);
-		expect(
-			canvas.queryByRole("button", { name: /scroll to bottom/i }),
-		).toBeNull();
+		await waitFor(() => {
+			expect(getBottomGapForStory(scrollContainer)).toBeLessThanOrEqual(2);
+			expect(
+				canvas.queryByRole("button", { name: /scroll to bottom/i }),
+			).toBeNull();
+		});
 
 		scrollToHistoryTop(scrollContainer);
 
@@ -1028,7 +1106,71 @@ export const ScrollToBottomButtonWorksWithInverseScroll: Story = {
 		);
 
 		await waitFor(() => {
-			expect(scrollContainer.scrollTop).toBe(0);
+			expect(getBottomGapForStory(scrollContainer)).toBeLessThanOrEqual(2);
+			expect(
+				canvas.queryByRole("button", { name: /scroll to bottom/i }),
+			).toBeNull();
+		});
+	},
+};
+
+const detachedNewContentStore = buildStoreWithMessages(
+	buildLongConversation(80),
+);
+
+export const ScrollPositionPreservedOnNewContent: Story = {
+	parameters: { chromatic: { disableSnapshot: true } },
+	decorators: scrollStoryDecorators,
+	render: () => <StoryAgentChatPageView store={detachedNewContentStore} />,
+	play: async ({ canvasElement }) => {
+		resetScrollStoryStore(detachedNewContentStore);
+		const canvas = within(canvasElement);
+		const scrollContainer = canvas.getByTestId("scroll-container");
+
+		await waitForScrollOverflow(scrollContainer);
+		const anchor = getChatAnchor(scrollContainer, "message-40");
+		scrollAnchorNearTop(scrollContainer, anchor);
+		await waitFor(() => {
+			expect(getBottomGapForStory(scrollContainer)).toBeGreaterThan(100);
+		});
+		const beforeOffset = getAnchorOffset(scrollContainer, anchor);
+
+		appendNewestMessage(
+			detachedNewContentStore,
+			"Newest appended while detached.",
+		);
+		await waitForVisibleText(canvas, "Newest appended while detached.");
+
+		await waitFor(() => {
+			expect(
+				Math.abs(getAnchorOffset(scrollContainer, anchor) - beforeOffset),
+			).toBeLessThanOrEqual(2);
+		});
+	},
+};
+
+const pinnedNewContentStore = buildStoreWithMessages(buildLongConversation(80));
+
+export const ScrollPinnedToBottomOnNewContent: Story = {
+	parameters: { chromatic: { disableSnapshot: true } },
+	decorators: scrollStoryDecorators,
+	render: () => <StoryAgentChatPageView store={pinnedNewContentStore} />,
+	play: async ({ canvasElement }) => {
+		resetScrollStoryStore(pinnedNewContentStore);
+		const canvas = within(canvasElement);
+		const scrollContainer = canvas.getByTestId("scroll-container");
+
+		await waitForScrollOverflow(scrollContainer);
+		scrollToLatestMessages(scrollContainer);
+		await waitFor(() => {
+			expect(getBottomGapForStory(scrollContainer)).toBeLessThanOrEqual(2);
+		});
+
+		appendNewestMessage(pinnedNewContentStore, "Newest appended while pinned.");
+		await waitForVisibleText(canvas, "Newest appended while pinned.");
+
+		await waitFor(() => {
+			expect(getBottomGapForStory(scrollContainer)).toBeLessThanOrEqual(2);
 			expect(
 				canvas.queryByRole("button", { name: /scroll to bottom/i }),
 			).toBeNull();
@@ -1045,10 +1187,6 @@ const scrollToBottomStoryRef: { current: (() => void) | null } = {
 	current: null,
 };
 
-/**
- * Page-level send and edit flows still rely on an imperative scroll-to-bottom
- * hook, so the replacement container must keep that contract working.
- */
 export const ScrollToBottomRefStillWorks: Story = {
 	parameters: { chromatic: { disableSnapshot: true } },
 	decorators: scrollStoryDecorators,
@@ -1067,7 +1205,7 @@ export const ScrollToBottomRefStillWorks: Story = {
 		scrollToHistoryTop(scrollContainer);
 
 		await waitFor(() => {
-			expect(scrollContainer.scrollTop).toBeLessThan(0);
+			expect(scrollContainer.scrollTop).toBeLessThanOrEqual(2);
 			expect(typeof scrollToBottomStoryRef.current).toBe("function");
 		});
 
@@ -1078,7 +1216,7 @@ export const ScrollToBottomRefStillWorks: Story = {
 		scrollToBottom();
 
 		await waitFor(() => {
-			expect(scrollContainer.scrollTop).toBe(0);
+			expect(getBottomGapForStory(scrollContainer)).toBeLessThanOrEqual(2);
 		});
 	},
 };
@@ -1090,9 +1228,6 @@ const messageOrderStore = buildStoreWithMessages([
 	buildMessage(4, "assistant", "Newest reply"),
 ]);
 
-/**
- * The reversed container layout must not invert the transcript's visible order.
- */
 export const MessageOrderIsStillCorrect: Story = {
 	parameters: { chromatic: { disableSnapshot: true } },
 	decorators: scrollStoryDecorators,
@@ -1112,20 +1247,6 @@ export const MessageOrderIsStillCorrect: Story = {
 
 const stickyPinningStore = buildStoreWithMessages(buildLongConversation(40));
 
-/**
- * Regression guard for the StickyUserMessage push-up logic.
- *
- * `react-infinite-scroll-component` renders two wrapper divs between the
- * scroll container and the message tree. The library applies `overflow:
- * auto` to its inner wrapper, which used to make `position: sticky` on a
- * user message resolve against that wrapper instead of the actual scroller.
- * The fix forces both wrappers to `display: contents` so the sticky
- * container's nearest scrolling ancestor is once again the
- * `.overflow-y-auto` element.
- *
- * This story scrolls past the most recent user message and asserts the
- * message is pinned within a few pixels of the scroll container's top.
- */
 export const StickyUserMessagePinsOnScroll: Story = {
 	parameters: { chromatic: { disableSnapshot: true } },
 	decorators: scrollStoryDecorators,
@@ -1136,11 +1257,11 @@ export const StickyUserMessagePinsOnScroll: Story = {
 		const scrollContainer = canvas.getByTestId("scroll-container");
 
 		await waitForScrollOverflow(scrollContainer);
+		scrollToLatestMessages(scrollContainer);
+		await waitFor(() => {
+			expect(getBottomGapForStory(scrollContainer)).toBeLessThanOrEqual(2);
+		});
 
-		// Each sticky user message is the element immediately following its
-		// `data-user-sentinel` marker. The push-up logic depends on the
-		// sticky container resolving against the real scroll container,
-		// which is the regression this story guards against.
 		const sentinels = scrollContainer.querySelectorAll("[data-user-sentinel]");
 		expect(sentinels.length).toBeGreaterThan(0);
 		for (const sentinel of sentinels) {
@@ -1154,18 +1275,7 @@ export const StickyUserMessagePinsOnScroll: Story = {
 			);
 		}
 
-		// At the default `scrollTop = 0`, the inverse layout shows the
-		// newest messages at the bottom of the viewport. Older user
-		// messages whose sentinels have already scrolled above the
-		// scroller's top edge should be pinned by `position: sticky`. Pick
-		// a sentinel that is comfortably above the top edge so a tiny
-		// scroll offset cannot flip it on or off the boundary.
 		const scrollerRect = scrollContainer.getBoundingClientRect();
-		// Walk the sentinels in reverse DOM order so we land on the
-		// most recent user message whose sentinel has scrolled above
-		// the scroll container's top edge. That is the message the
-		// push-up logic actively pins at the top; earlier pinned
-		// messages will have been pushed out of view by it.
 		const pinnedSentinel = Array.from(sentinels)
 			.reverse()
 			.find(
@@ -1177,13 +1287,6 @@ export const StickyUserMessagePinsOnScroll: Story = {
 			return;
 		}
 		const pinnedContainer = pinnedSentinel.nextElementSibling as HTMLElement;
-
-		// `position: sticky` should pin the user message container near
-		// the scroll container's top edge while the assistant response
-		// below it is on screen. Before the fix, the sticky container
-		// resolved against the InfiniteScroll wrapper rather than the
-		// real scroll container, so it scrolled out with its sentinel
-		// and ended up far above the viewport.
 		const pinnedRect = pinnedContainer.getBoundingClientRect();
 		expect(window.getComputedStyle(pinnedContainer).position).toBe("sticky");
 		expect(pinnedRect.top - scrollerRect.top).toBeGreaterThanOrEqual(-1);

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -1070,6 +1070,118 @@ export const HistoryPrependPreservesViewport: Story = {
 	},
 };
 
+const asyncHistoryPrependStore = buildStoreWithMessages(
+	buildLongConversation(80),
+);
+const asyncHistoryPrependController: { resolve: (() => void) | null } = {
+	resolve: null,
+};
+const asyncHistoryPrependFetchSpy = fn(() => {
+	asyncHistoryPrependController.resolve = () => {
+		prependOlderMessages(asyncHistoryPrependStore, 10);
+		asyncHistoryPrependController.resolve = null;
+	};
+});
+
+export const AsyncHistoryPrependPreservesViewport: Story = {
+	parameters: { chromatic: { disableSnapshot: true } },
+	decorators: scrollStoryDecorators,
+	render: () => (
+		<StoryAgentChatPageView
+			store={asyncHistoryPrependStore}
+			hasMoreMessages
+			onFetchMoreMessages={asyncHistoryPrependFetchSpy}
+		/>
+	),
+	play: async ({ canvasElement }) => {
+		resetScrollStoryStore(asyncHistoryPrependStore);
+		asyncHistoryPrependFetchSpy.mockClear();
+		asyncHistoryPrependController.resolve = null;
+		const canvas = within(canvasElement);
+		const scrollContainer = canvas.getByTestId("scroll-container");
+
+		await waitForScrollOverflow(scrollContainer);
+		scrollToHistoryTop(scrollContainer);
+		await waitForIntersectionObserverTick();
+		await waitForFetchCount(asyncHistoryPrependFetchSpy, 1);
+
+		const anchor = getChatAnchor(scrollContainer, "message-2");
+		const beforeOffset = getAnchorOffset(scrollContainer, anchor);
+		const resolvePrepend = asyncHistoryPrependController.resolve as
+			| (() => void)
+			| null;
+		if (!resolvePrepend) {
+			throw new Error("Expected async history prepend to be pending.");
+		}
+		resolvePrepend();
+		await waitForVisibleText(canvas, "Older question 9.");
+
+		await waitFor(() => {
+			expect(
+				Math.abs(getAnchorOffset(scrollContainer, anchor) - beforeOffset),
+			).toBeLessThanOrEqual(2);
+		});
+	},
+};
+
+const asyncHistoryUserScrollStore = buildStoreWithMessages(
+	buildLongConversation(80),
+);
+const asyncHistoryUserScrollController: { resolve: (() => void) | null } = {
+	resolve: null,
+};
+const asyncHistoryUserScrollFetchSpy = fn(() => {
+	asyncHistoryUserScrollController.resolve = () => {
+		prependOlderMessages(asyncHistoryUserScrollStore, 10);
+		asyncHistoryUserScrollController.resolve = null;
+	};
+});
+
+export const AsyncHistoryPrependPreservesUserScroll: Story = {
+	parameters: { chromatic: { disableSnapshot: true } },
+	decorators: scrollStoryDecorators,
+	render: () => (
+		<StoryAgentChatPageView
+			store={asyncHistoryUserScrollStore}
+			hasMoreMessages
+			onFetchMoreMessages={asyncHistoryUserScrollFetchSpy}
+		/>
+	),
+	play: async ({ canvasElement }) => {
+		resetScrollStoryStore(asyncHistoryUserScrollStore);
+		asyncHistoryUserScrollFetchSpy.mockClear();
+		asyncHistoryUserScrollController.resolve = null;
+		const canvas = within(canvasElement);
+		const scrollContainer = canvas.getByTestId("scroll-container");
+
+		await waitForScrollOverflow(scrollContainer);
+		scrollToHistoryTop(scrollContainer);
+		await waitForIntersectionObserverTick();
+		await waitForFetchCount(asyncHistoryUserScrollFetchSpy, 1);
+
+		const anchor = getChatAnchor(scrollContainer, "message-20");
+		scrollAnchorNearTop(scrollContainer, anchor);
+		await waitFor(() => {
+			expect(getBottomGapForStory(scrollContainer)).toBeGreaterThan(100);
+		});
+		const beforeOffset = getAnchorOffset(scrollContainer, anchor);
+		const resolvePrepend = asyncHistoryUserScrollController.resolve as
+			| (() => void)
+			| null;
+		if (!resolvePrepend) {
+			throw new Error("Expected async history prepend to be pending.");
+		}
+		resolvePrepend();
+		await waitForVisibleText(canvas, "Older question 9.");
+
+		await waitFor(() => {
+			expect(
+				Math.abs(getAnchorOffset(scrollContainer, anchor) - beforeOffset),
+			).toBeLessThanOrEqual(2);
+		});
+	},
+};
+
 const scrollToBottomButtonStoryStore = buildStoreWithMessages(
 	buildLongConversation(80),
 );

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -208,7 +208,7 @@ const ReasoningDisclosure = memo<{
 );
 
 // Wrapper that runs the smooth-streaming jitter buffer on a single
-// response block. Only used during live streaming — historical
+// response block. Only used during live streaming. Historical
 // messages render through <Response> directly.
 const SmoothedResponse = memo<{
 	text: string;
@@ -719,9 +719,8 @@ const StickyUserMessage = memo<{
 			const sentinel = sentinelRef.current;
 			const container = containerRef.current;
 			if (!sentinel || !container) return;
-			const scroller = sentinel.closest(
-				".overflow-y-auto",
-			) as HTMLElement | null;
+			const scroller = (sentinel.closest('[data-testid="scroll-container"]') ??
+				sentinel.closest(".overflow-y-auto")) as HTMLElement | null;
 			if (!scroller) return;
 
 			const MIN_HEIGHT = 72;
@@ -733,9 +732,8 @@ const StickyUserMessage = memo<{
 			const update = () => {
 				const fullHeight = container.offsetHeight;
 
-				// Skip sticky behavior for messages that take up
-				// most of the visible area — accounting for the
-				// chat input and some breathing room.
+				// Avoid pinning messages that would cover most of the viewport.
+				// They need to remain scrollable for reading and editing.
 				const tooTall = fullHeight > scrollerHeight * 0.75;
 				setIsTooTall(tooTall);
 				if (tooTall) {
@@ -768,10 +766,8 @@ const StickyUserMessage = memo<{
 					Math.min((MIN_HEIGHT + FADE_RANGE - visible) / FADE_RANGE, 1),
 				);
 				container.style.setProperty("--fade-opacity", String(fade));
-				// Push-up effect: when the next user message's sentinel
-				// approaches the bottom of this sticky container, shift
-				// this container upward so it slides out of view — the
-				// same visual as the old section-boundary behavior.
+				// Adjacent sticky user messages should not overlap while one
+				// hands off to the next.
 				let nextSentinel: Element | null = sentinel.nextElementSibling;
 				while (nextSentinel) {
 					if (nextSentinel.hasAttribute("data-user-sentinel")) {
@@ -805,11 +801,8 @@ const StickyUserMessage = memo<{
 				});
 			};
 
-			// Re-run the visual update when the scrollable content height
-			// changes (e.g. streaming responses growing the transcript).
-			// In flex-col-reverse, scrollTop stays at 0 when pinned to
-			// bottom so no scroll event fires — but the content wrapper
-			// resizes and this observer catches that.
+			// Streaming can resize content without a matching scroll event,
+			// so recompute sticky geometry when the content wrapper changes.
 			const contentEl = scroller.firstElementChild as HTMLElement | null;
 			let contentRafId: number | null = null;
 			const contentObserver = contentEl
@@ -826,9 +819,7 @@ const StickyUserMessage = memo<{
 			scroller.addEventListener("scroll", onScroll, { passive: true });
 			window.addEventListener("resize", onResize);
 			update();
-			// Set immediately — both --clip-h and --overlay-ready are
-			// applied before the browser paints since we're in a
-			// useLayoutEffect.
+			// Set immediately so the first sticky paint uses measured geometry.
 			container.style.setProperty("--overlay-ready", "1");
 			return () => {
 				scroller.removeEventListener("scroll", onScroll);
@@ -860,21 +851,27 @@ const StickyUserMessage = memo<{
 					requestAnimationFrame(() => {
 						const sentinel = sentinelRef.current;
 						if (!sentinel) return;
-						const scroller = sentinel.closest(
-							".overflow-y-auto",
-						) as HTMLElement | null;
+						const scroller = (sentinel.closest(
+							'[data-testid="scroll-container"]',
+						) ?? sentinel.closest(".overflow-y-auto")) as HTMLElement | null;
 						if (!scroller) return;
 						const offset =
 							sentinel.getBoundingClientRect().top -
 							scroller.getBoundingClientRect().top;
-						scroller.scrollBy({ top: offset, behavior: "smooth" });
+						scroller.scrollTop = Math.max(0, scroller.scrollTop + offset);
 					});
 				}
 			: undefined;
 
 		return (
 			<>
-				<div ref={sentinelRef} className="h-0" data-user-sentinel />
+				<div
+					ref={sentinelRef}
+					className="h-0"
+					data-user-sentinel
+					data-chat-anchor="true"
+					data-chat-anchor-id={`message-${message.id}`}
+				/>
 				<div
 					ref={containerRef}
 					className={cn(
@@ -912,6 +909,7 @@ const StickyUserMessage = memo<{
 				    scroll handler sets on the container. */}
 					{isStuck && !isTooTall && (
 						<div
+							data-chat-anchor-ignore="true"
 							className="absolute inset-0"
 							style={{
 								opacity: "var(--overlay-ready, 0)",
@@ -1098,30 +1096,37 @@ export const ConversationTimeline = memo<ConversationTimelineProps>(
 						// precomputed in a single reverse pass above.
 						const isLastInChain = lastInChainFlags[msgIdx];
 						return (
-							<ChatMessageItem
+							<div
 								key={message.id}
-								message={message}
-								parsed={parsed}
-								onImplementPlan={onImplementPlan}
-								onSendAskUserQuestionResponse={onSendAskUserQuestionResponse}
-								isChatCompleted={isChatCompleted}
-								latestAskUserQuestionToolId={latestAskUserQuestionToolId}
-								askUserQuestionResponseTextByToolId={
-									historicalAskUserQuestionResponseTextByToolId
-								}
-								hasUserResponseAfterAskQuestion={
-									hasUserResponseAfterAskQuestion
-								}
-								urlTransform={urlTransform}
-								isAfterEditingMessage={afterEditingMessageIds.has(message.id)}
-								hideActions={!isLastInChain}
-								hasActiveStream={Boolean(hasActiveStream)}
-								isAwaitingFirstStreamChunk={Boolean(isAwaitingFirstStreamChunk)}
-								mcpServers={mcpServers}
-								subagentTitles={subagentTitles}
-								subagentVariants={subagentVariants}
-								showDesktopPreviews={showDesktopPreviews}
-							/>
+								data-chat-anchor="true"
+								data-chat-anchor-id={`message-${message.id}`}
+							>
+								<ChatMessageItem
+									message={message}
+									parsed={parsed}
+									onImplementPlan={onImplementPlan}
+									onSendAskUserQuestionResponse={onSendAskUserQuestionResponse}
+									isChatCompleted={isChatCompleted}
+									latestAskUserQuestionToolId={latestAskUserQuestionToolId}
+									askUserQuestionResponseTextByToolId={
+										historicalAskUserQuestionResponseTextByToolId
+									}
+									hasUserResponseAfterAskQuestion={
+										hasUserResponseAfterAskQuestion
+									}
+									urlTransform={urlTransform}
+									isAfterEditingMessage={afterEditingMessageIds.has(message.id)}
+									hideActions={!isLastInChain}
+									hasActiveStream={Boolean(hasActiveStream)}
+									isAwaitingFirstStreamChunk={Boolean(
+										isAwaitingFirstStreamChunk,
+									)}
+									mcpServers={mcpServers}
+									subagentTitles={subagentTitles}
+									subagentVariants={subagentVariants}
+									showDesktopPreviews={showDesktopPreviews}
+								/>
+							</div>
 						);
 					})}
 				</div>

--- a/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.tsx
@@ -5,6 +5,7 @@ import { Alert, AlertDescription } from "#/components/Alert/Alert";
 import { Button } from "#/components/Button/Button";
 import type { ChatDetailError } from "../../utils/usageLimitMessage";
 import type { SubagentVariant } from "../ChatElements/tools/subagentDescriptor";
+import { LIVE_STREAM_TAIL_ANCHOR_ID } from "../chatViewportUtils";
 import { ChatStatusCallout } from "./ChatStatusCallout";
 import {
 	selectIsAwaitingFirstStreamChunk,
@@ -71,7 +72,11 @@ export const LiveStreamTailContent = ({
 	}
 
 	return (
-		<div className="flex flex-col gap-2">
+		<div
+			data-chat-anchor="true"
+			data-chat-anchor-id={LIVE_STREAM_TAIL_ANCHOR_ID}
+			className="flex flex-col gap-2"
+		>
 			{shouldRenderEmptyState && (
 				<div className="py-12 text-center text-content-secondary">
 					<p className="text-sm">Start a conversation with your agent.</p>

--- a/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
+++ b/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
@@ -20,6 +20,7 @@ import {
 	getScrollMode,
 	resolveAnchorTarget,
 	restoreAnchorScrollTop,
+	restorePrependScrollTop,
 	type ScrollDirection,
 	type ScrollMode,
 } from "./chatViewportUtils";
@@ -98,6 +99,12 @@ const findAnchorSnapshot = (
 const getDirectionFromWheel = (deltaY: number): ScrollDirection =>
 	deltaY < 0 ? "up" : "down";
 
+interface HistoryScrollSnapshot {
+	anchor: AnchorSnapshot | null;
+	scrollHeight: number;
+	scrollTop: number;
+}
+
 const ChatScrollContainer: FC<{
 	scrollContainerRef: RefObject<HTMLDivElement | null>;
 	scrollToBottomRef: RefObject<(() => void) | null>;
@@ -121,9 +128,11 @@ const ChatScrollContainer: FC<{
 	const [mode, setMode] = useState<ScrollMode>("following-latest");
 	const modeRef = useRef<ScrollMode>("following-latest");
 	const anchorRef = useRef<AnchorSnapshot | null>(null);
+	const pendingHistoryScrollRef = useRef<HistoryScrollSnapshot | null>(null);
 	const previousMessageCountRef = useRef(messageCount);
 	const isFetchingHistoryRef = useRef(isFetchingMoreMessages);
 	const isProgrammaticScrollRef = useRef(false);
+	const hasUserScrollIntentRef = useRef(false);
 	const isPointerDownRef = useRef(false);
 	const activeTouchCountRef = useRef(0);
 	const scrollFrameRef = useRef<number | null>(null);
@@ -172,13 +181,15 @@ const ChatScrollContainer: FC<{
 		},
 	);
 
-	const captureAnchor = useEffectEvent(() => {
+	const captureAnchor = useEffectEvent((): AnchorSnapshot | null => {
 		const scrollElement = scrollElementRef.current;
 		const contentElement = contentElementRef.current;
 		if (!scrollElement || !contentElement) {
-			return;
+			return null;
 		}
-		anchorRef.current = findAnchorSnapshot(scrollElement, contentElement);
+		const snapshot = findAnchorSnapshot(scrollElement, contentElement);
+		anchorRef.current = snapshot;
+		return snapshot;
 	});
 
 	const restoreAnchor = useEffectEvent(() => {
@@ -204,6 +215,34 @@ const ChatScrollContainer: FC<{
 		scrollElement.scrollTop = nextScrollTop;
 	});
 
+	const restorePendingHistoryScroll = useEffectEvent((): boolean => {
+		const scrollElement = scrollElementRef.current;
+		const snapshot = pendingHistoryScrollRef.current;
+		if (!scrollElement || !snapshot) {
+			return false;
+		}
+		pendingHistoryScrollRef.current = null;
+
+		const nextScrollTop = restorePrependScrollTop(
+			scrollElement,
+			snapshot.scrollHeight,
+			snapshot.scrollTop,
+		);
+		if (Math.abs(nextScrollTop - scrollElement.scrollTop) > 1) {
+			isProgrammaticScrollRef.current = true;
+			scrollElement.scrollTop = nextScrollTop;
+		}
+
+		anchorRef.current = snapshot.anchor;
+		if (snapshot.anchor) {
+			restoreAnchor();
+		} else {
+			captureAnchor();
+		}
+
+		return true;
+	});
+
 	const requestHistoryFetch = useEffectEvent(() => {
 		const scrollElement = scrollElementRef.current;
 		if (
@@ -223,10 +262,17 @@ const ChatScrollContainer: FC<{
 			return;
 		}
 		if (isDetached) {
+			clearDeferredPin();
 			if (modeRef.current !== "detached") {
 				syncMode("detached");
 			}
-			captureAnchor();
+			pendingHistoryScrollRef.current = {
+				anchor: captureAnchor(),
+				scrollHeight: scrollElement.scrollHeight,
+				scrollTop: scrollElement.scrollTop,
+			};
+		} else {
+			pendingHistoryScrollRef.current = null;
 		}
 		isFetchingHistoryRef.current = true;
 		onFetchMoreMessages();
@@ -303,6 +349,7 @@ const ChatScrollContainer: FC<{
 			return;
 		}
 		anchorRef.current = null;
+		pendingHistoryScrollRef.current = null;
 		isProgrammaticScrollRef.current = true;
 		syncMode("following-latest");
 		pinToLatest();
@@ -348,6 +395,15 @@ const ChatScrollContainer: FC<{
 		}
 
 		const handleScroll = () => {
+			const isUserScroll =
+				!isProgrammaticScrollRef.current || hasUserScrollIntentRef.current;
+			if (isUserScroll) {
+				pendingHistoryScrollRef.current = null;
+				if (modeRef.current === "detached") {
+					captureAnchor();
+				}
+			}
+			hasUserScrollIntentRef.current = false;
 			if (getBottomGap(scrollElement) > FOLLOW_THRESHOLD_PX) {
 				clearDeferredPin();
 				if (modeRef.current === "following-latest") {
@@ -358,6 +414,8 @@ const ChatScrollContainer: FC<{
 			scheduleScrollModeUpdate();
 		};
 		const handleWheel = (event: WheelEvent) => {
+			hasUserScrollIntentRef.current = true;
+			pendingHistoryScrollRef.current = null;
 			const direction = getDirectionFromWheel(event.deltaY);
 			if (direction === "up") {
 				clearDeferredPin();
@@ -366,6 +424,8 @@ const ChatScrollContainer: FC<{
 		const handlePointerDown = (event: PointerEvent) => {
 			isPointerDownRef.current = event.target === scrollElement;
 			if (isPointerDownRef.current) {
+				hasUserScrollIntentRef.current = true;
+				pendingHistoryScrollRef.current = null;
 				clearDeferredPin();
 			}
 		};
@@ -374,6 +434,8 @@ const ChatScrollContainer: FC<{
 		};
 		const handleTouchStart = (event: TouchEvent) => {
 			activeTouchCountRef.current += Math.max(1, event.changedTouches.length);
+			hasUserScrollIntentRef.current = true;
+			pendingHistoryScrollRef.current = null;
 			clearDeferredPin();
 		};
 		const handleTouchEnd = (event: TouchEvent) => {
@@ -418,6 +480,18 @@ const ChatScrollContainer: FC<{
 	}, []);
 
 	useLayoutEffect(() => {
+		const previousMessageCount = previousMessageCountRef.current;
+		if (previousMessageCount !== messageCount) {
+			previousMessageCountRef.current = messageCount;
+			isFetchingHistoryRef.current = isFetchingMoreMessages;
+			if (
+				messageCount > previousMessageCount &&
+				modeRef.current === "detached" &&
+				restorePendingHistoryScroll()
+			) {
+				return;
+			}
+		}
 		syncViewportToMode();
 	});
 
@@ -467,19 +541,6 @@ const ChatScrollContainer: FC<{
 		observer.observe(topSentinelElement);
 		return () => observer.disconnect();
 	}, [hasMoreMessages]);
-
-	useEffect(() => {
-		if (previousMessageCountRef.current === messageCount) {
-			return;
-		}
-		previousMessageCountRef.current = messageCount;
-		isFetchingHistoryRef.current = isFetchingMoreMessages;
-		if (modeRef.current === "following-latest") {
-			scheduleDeferredPin();
-			return;
-		}
-		scheduleViewportSync();
-	});
 
 	return (
 		<div className="relative flex min-h-0 flex-1 flex-col">

--- a/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
+++ b/site/src/pages/AgentsPage/components/ChatScrollContainer.tsx
@@ -4,98 +4,99 @@ import {
 	type ReactNode,
 	type RefObject,
 	useEffect,
+	useEffectEvent,
+	useLayoutEffect,
+	useRef,
 	useState,
 } from "react";
-import InfiniteScroll from "react-infinite-scroll-component";
 import { Button } from "#/components/Button/Button";
 import { cn } from "#/utils/cn";
+import {
+	type AnchorSnapshot,
+	CHAT_ANCHOR_SELECTOR,
+	CHAT_NON_ANCHOR_SELECTOR,
+	FOLLOW_THRESHOLD_PX,
+	getBottomGap,
+	getScrollMode,
+	resolveAnchorTarget,
+	restoreAnchorScrollTop,
+	type ScrollDirection,
+	type ScrollMode,
+} from "./chatViewportUtils";
 
-const SCROLL_THRESHOLD = "600px";
-const SCROLL_TO_BOTTOM_BUTTON_OFFSET_PX = 70;
+const HISTORY_ROOT_MARGIN = "600px 0px 0px 0px";
+const HISTORY_FETCH_SCROLL_THRESHOLD_PX = 600;
+const DEFERRED_PIN_FRAME_COUNT = 8;
 
 const ScrollToBottomButton: FC<{
-	scrollContainerElement: HTMLDivElement | null;
-	messageCount: number;
+	show: boolean;
 	onScrollToBottom: () => void;
-}> = ({ scrollContainerElement, messageCount, onScrollToBottom }) => {
-	const [showScrollToBottomButton, setShowScrollToBottomButton] =
-		useState(false);
-
-	useEffect(() => {
-		if (!scrollContainerElement) {
-			setShowScrollToBottomButton(false);
-			return;
-		}
-
-		let frameId: number | null = null;
-		const updateVisibility = () => {
-			setShowScrollToBottomButton(
-				Math.abs(scrollContainerElement.scrollTop) >
-					SCROLL_TO_BOTTOM_BUTTON_OFFSET_PX,
-			);
-		};
-		const handleScroll = () => {
-			if (frameId !== null) {
-				return;
-			}
-			frameId = requestAnimationFrame(() => {
-				frameId = null;
-				updateVisibility();
-			});
-		};
-
-		updateVisibility();
-		scrollContainerElement.addEventListener("scroll", handleScroll, {
-			passive: true,
-		});
-
-		return () => {
-			scrollContainerElement.removeEventListener("scroll", handleScroll);
-			if (frameId !== null) {
-				cancelAnimationFrame(frameId);
-			}
-		};
-	}, [scrollContainerElement]);
-
-	useEffect(() => {
-		if (!scrollContainerElement) {
-			return;
-		}
-		setShowScrollToBottomButton(
-			messageCount > 0 &&
-				Math.abs(scrollContainerElement.scrollTop) >
-					SCROLL_TO_BOTTOM_BUTTON_OFFSET_PX,
-		);
-	}, [messageCount, scrollContainerElement]);
-
-	const handleScrollToBottom = () => {
-		onScrollToBottom();
-		setShowScrollToBottomButton(false);
-	};
-
+}> = ({ show, onScrollToBottom }) => {
 	return (
-		// Floating overlay above the scroll container. The button has its own
-		// fixed-size box so the wrapper does not need overflow handling.
-		<div className="pointer-events-none absolute inset-x-0 bottom-2 z-10 flex justify-center py-2">
+		<div
+			data-chat-anchor-ignore="true"
+			className="pointer-events-none absolute inset-x-0 bottom-2 z-10 flex justify-center py-2"
+		>
 			<Button
 				variant="outline"
 				size="icon"
 				className={cn(
 					"rounded-full bg-surface-primary shadow-md transition-all duration-200",
-					showScrollToBottomButton
+					show
 						? "pointer-events-auto translate-y-0 opacity-100"
 						: "translate-y-2 opacity-0",
 				)}
-				onClick={handleScrollToBottom}
+				onClick={onScrollToBottom}
 				aria-label="Scroll to bottom"
-				aria-hidden={!showScrollToBottomButton || undefined}
-				tabIndex={showScrollToBottomButton ? undefined : -1}
+				aria-hidden={!show || undefined}
+				tabIndex={show ? undefined : -1}
 			>
 				<ArrowDownIcon />
 			</Button>
 		</div>
 	);
 };
+
+const isAnchorCandidate = (element: Element): element is HTMLElement => {
+	if (!(element instanceof HTMLElement)) {
+		return false;
+	}
+	if (element.closest(CHAT_NON_ANCHOR_SELECTOR)) {
+		return false;
+	}
+	return element.dataset.chatAnchor === "true";
+};
+
+const findAnchorSnapshot = (
+	container: HTMLElement,
+	content: HTMLElement,
+): AnchorSnapshot | null => {
+	const containerRect = container.getBoundingClientRect();
+	const anchors = content.querySelectorAll(CHAT_ANCHOR_SELECTOR);
+	for (const anchor of anchors) {
+		if (!isAnchorCandidate(anchor)) {
+			continue;
+		}
+		const rect = anchor.getBoundingClientRect();
+		if (
+			rect.bottom > containerRect.top + 1 &&
+			rect.top < containerRect.bottom - 1
+		) {
+			const anchorId = anchor.dataset.chatAnchorId;
+			if (!anchorId) {
+				continue;
+			}
+			return {
+				anchorId,
+				offsetTop: rect.top - containerRect.top,
+			};
+		}
+	}
+	return null;
+};
+
+const getDirectionFromWheel = (deltaY: number): ScrollDirection =>
+	deltaY < 0 ? "up" : "down";
 
 const ChatScrollContainer: FC<{
 	scrollContainerRef: RefObject<HTMLDivElement | null>;
@@ -114,26 +115,371 @@ const ChatScrollContainer: FC<{
 	messageCount,
 	children,
 }) => {
-	const [scrollContainerElement, setScrollContainerElement] =
-		useState<HTMLDivElement | null>(null);
+	const scrollElementRef = useRef<HTMLDivElement | null>(null);
+	const contentElementRef = useRef<HTMLDivElement | null>(null);
+	const topSentinelElementRef = useRef<HTMLDivElement | null>(null);
+	const [mode, setMode] = useState<ScrollMode>("following-latest");
+	const modeRef = useRef<ScrollMode>("following-latest");
+	const anchorRef = useRef<AnchorSnapshot | null>(null);
+	const previousMessageCountRef = useRef(messageCount);
+	const isFetchingHistoryRef = useRef(isFetchingMoreMessages);
+	const isProgrammaticScrollRef = useRef(false);
+	const isPointerDownRef = useRef(false);
+	const activeTouchCountRef = useRef(0);
+	const scrollFrameRef = useRef<number | null>(null);
+	const restoreFrameRef = useRef<number | null>(null);
+	const deferredPinFrameRef = useRef<number | null>(null);
 
-	const scrollToBottom = () => {
-		// Read the live ref so remounts cannot leave callers targeting a detached
-		// scroll node.
-		const scrollContainer = scrollContainerRef.current;
-		if (!scrollContainer) {
+	const syncMode = useEffectEvent((nextMode: ScrollMode) => {
+		modeRef.current = nextMode;
+		setMode(nextMode);
+	});
+
+	const clearDeferredPin = useEffectEvent(() => {
+		if (deferredPinFrameRef.current !== null) {
+			cancelAnimationFrame(deferredPinFrameRef.current);
+			deferredPinFrameRef.current = null;
+		}
+	});
+
+	const pinToLatest = useEffectEvent(() => {
+		const scrollElement = scrollElementRef.current;
+		if (!scrollElement) {
 			return;
 		}
-		// In the library's reversed layout, the newest messages sit at the visual
-		// bottom, which maps to a zero scroll offset.
-		scrollContainer.scrollTop = 0;
-	};
+		scrollElement.scrollTop = scrollElement.scrollHeight;
+	});
+
+	const scheduleDeferredPin = useEffectEvent(
+		(frames = DEFERRED_PIN_FRAME_COUNT) => {
+			clearDeferredPin();
+			const step = (remainingFrames: number) => {
+				const scrollElement = scrollElementRef.current;
+				if (!scrollElement || modeRef.current !== "following-latest") {
+					deferredPinFrameRef.current = null;
+					return;
+				}
+				pinToLatest();
+				if (remainingFrames <= 0) {
+					deferredPinFrameRef.current = null;
+					return;
+				}
+				deferredPinFrameRef.current = requestAnimationFrame(() => {
+					step(remainingFrames - 1);
+				});
+			};
+			step(frames);
+		},
+	);
+
+	const captureAnchor = useEffectEvent(() => {
+		const scrollElement = scrollElementRef.current;
+		const contentElement = contentElementRef.current;
+		if (!scrollElement || !contentElement) {
+			return;
+		}
+		anchorRef.current = findAnchorSnapshot(scrollElement, contentElement);
+	});
+
+	const restoreAnchor = useEffectEvent(() => {
+		const scrollElement = scrollElementRef.current;
+		const contentElement = contentElementRef.current;
+		const snapshot = anchorRef.current;
+		if (!scrollElement || !contentElement || !snapshot) {
+			return;
+		}
+		const target = resolveAnchorTarget(contentElement, snapshot);
+		if (!target) {
+			return;
+		}
+		const nextScrollTop = restoreAnchorScrollTop(
+			scrollElement,
+			target,
+			snapshot,
+		);
+		if (Math.abs(nextScrollTop - scrollElement.scrollTop) <= 1) {
+			return;
+		}
+		isProgrammaticScrollRef.current = true;
+		scrollElement.scrollTop = nextScrollTop;
+	});
+
+	const requestHistoryFetch = useEffectEvent(() => {
+		const scrollElement = scrollElementRef.current;
+		if (
+			!scrollElement ||
+			!hasMoreMessages ||
+			isFetchingHistoryRef.current ||
+			scrollElement.scrollTop > HISTORY_FETCH_SCROLL_THRESHOLD_PX
+		) {
+			return;
+		}
+		const canFetchWhileFollowing =
+			scrollElement.scrollHeight <= scrollElement.clientHeight + 1;
+		const geometryMode = getScrollMode(getBottomGap(scrollElement));
+		const isDetached =
+			modeRef.current === "detached" || geometryMode === "detached";
+		if (!isDetached && !canFetchWhileFollowing) {
+			return;
+		}
+		if (isDetached) {
+			if (modeRef.current !== "detached") {
+				syncMode("detached");
+			}
+			captureAnchor();
+		}
+		isFetchingHistoryRef.current = true;
+		onFetchMoreMessages();
+	});
+
+	const syncViewportToMode = useEffectEvent(() => {
+		if (modeRef.current === "following-latest") {
+			if (isPointerDownRef.current || activeTouchCountRef.current > 0) {
+				return;
+			}
+			anchorRef.current = null;
+			scheduleDeferredPin();
+			return;
+		}
+		if (!anchorRef.current) {
+			captureAnchor();
+		}
+		restoreAnchor();
+	});
+
+	const scheduleViewportSync = useEffectEvent(() => {
+		if (restoreFrameRef.current !== null) {
+			return;
+		}
+		restoreFrameRef.current = requestAnimationFrame(() => {
+			restoreFrameRef.current = null;
+			syncViewportToMode();
+		});
+	});
+
+	const updateModeFromGeometry = useEffectEvent(() => {
+		const scrollElement = scrollElementRef.current;
+		const contentElement = contentElementRef.current;
+		if (!scrollElement || !contentElement) {
+			return;
+		}
+		const bottomGap = getBottomGap(scrollElement);
+		if (isProgrammaticScrollRef.current) {
+			isProgrammaticScrollRef.current = false;
+			if (bottomGap <= FOLLOW_THRESHOLD_PX) {
+				if (modeRef.current !== "following-latest") {
+					syncMode("following-latest");
+				}
+				anchorRef.current = null;
+				return;
+			}
+		}
+
+		const nextMode = getScrollMode(bottomGap);
+		if (nextMode !== modeRef.current) {
+			syncMode(nextMode);
+		}
+		if (nextMode === "detached") {
+			anchorRef.current = findAnchorSnapshot(scrollElement, contentElement);
+		} else {
+			anchorRef.current = null;
+		}
+		requestHistoryFetch();
+	});
+
+	const scheduleScrollModeUpdate = useEffectEvent(() => {
+		if (scrollFrameRef.current !== null) {
+			return;
+		}
+		scrollFrameRef.current = requestAnimationFrame(() => {
+			scrollFrameRef.current = null;
+			updateModeFromGeometry();
+		});
+	});
+
+	const scrollToBottom = useEffectEvent(() => {
+		const scrollElement = scrollElementRef.current;
+		if (!scrollElement) {
+			return;
+		}
+		anchorRef.current = null;
+		isProgrammaticScrollRef.current = true;
+		syncMode("following-latest");
+		pinToLatest();
+	});
 
 	const setScrollContainer = (element: HTMLDivElement | null) => {
+		scrollElementRef.current = element;
 		scrollContainerRef.current = element;
-		setScrollContainerElement(element);
 		scrollToBottomRef.current = element ? scrollToBottom : null;
 	};
+
+	const setContentElement = (element: HTMLDivElement | null) => {
+		contentElementRef.current = element;
+	};
+
+	const setTopSentinel = (element: HTMLDivElement | null) => {
+		topSentinelElementRef.current = element;
+	};
+
+	useEffect(() => {
+		isFetchingHistoryRef.current = isFetchingMoreMessages;
+	}, [isFetchingMoreMessages]);
+
+	useEffect(() => {
+		return () => {
+			if (scrollFrameRef.current !== null) {
+				cancelAnimationFrame(scrollFrameRef.current);
+			}
+			if (restoreFrameRef.current !== null) {
+				cancelAnimationFrame(restoreFrameRef.current);
+			}
+			if (deferredPinFrameRef.current !== null) {
+				cancelAnimationFrame(deferredPinFrameRef.current);
+			}
+			scrollToBottomRef.current = null;
+		};
+	}, [scrollToBottomRef]);
+
+	useEffect(() => {
+		const scrollElement = scrollElementRef.current;
+		if (!scrollElement) {
+			return;
+		}
+
+		const handleScroll = () => {
+			if (getBottomGap(scrollElement) > FOLLOW_THRESHOLD_PX) {
+				clearDeferredPin();
+				if (modeRef.current === "following-latest") {
+					syncMode("detached");
+					captureAnchor();
+				}
+			}
+			scheduleScrollModeUpdate();
+		};
+		const handleWheel = (event: WheelEvent) => {
+			const direction = getDirectionFromWheel(event.deltaY);
+			if (direction === "up") {
+				clearDeferredPin();
+			}
+		};
+		const handlePointerDown = (event: PointerEvent) => {
+			isPointerDownRef.current = event.target === scrollElement;
+			if (isPointerDownRef.current) {
+				clearDeferredPin();
+			}
+		};
+		const handlePointerUp = () => {
+			isPointerDownRef.current = false;
+		};
+		const handleTouchStart = (event: TouchEvent) => {
+			activeTouchCountRef.current += Math.max(1, event.changedTouches.length);
+			clearDeferredPin();
+		};
+		const handleTouchEnd = (event: TouchEvent) => {
+			activeTouchCountRef.current = Math.max(
+				0,
+				activeTouchCountRef.current - Math.max(1, event.changedTouches.length),
+			);
+		};
+		const handleVisibilityChange = () => {
+			if (document.hidden) {
+				activeTouchCountRef.current = 0;
+				isPointerDownRef.current = false;
+			}
+		};
+
+		scrollElement.addEventListener("scroll", handleScroll, { passive: true });
+		scrollElement.addEventListener("wheel", handleWheel, { passive: true });
+		scrollElement.addEventListener("pointerdown", handlePointerDown);
+		scrollElement.addEventListener("touchstart", handleTouchStart, {
+			passive: true,
+		});
+		scrollElement.addEventListener("touchend", handleTouchEnd, {
+			passive: true,
+		});
+		scrollElement.addEventListener("touchcancel", handleTouchEnd, {
+			passive: true,
+		});
+		window.addEventListener("pointerup", handlePointerUp);
+		document.addEventListener("visibilitychange", handleVisibilityChange);
+		updateModeFromGeometry();
+
+		return () => {
+			scrollElement.removeEventListener("scroll", handleScroll);
+			scrollElement.removeEventListener("wheel", handleWheel);
+			scrollElement.removeEventListener("pointerdown", handlePointerDown);
+			scrollElement.removeEventListener("touchstart", handleTouchStart);
+			scrollElement.removeEventListener("touchend", handleTouchEnd);
+			scrollElement.removeEventListener("touchcancel", handleTouchEnd);
+			window.removeEventListener("pointerup", handlePointerUp);
+			document.removeEventListener("visibilitychange", handleVisibilityChange);
+		};
+	}, []);
+
+	useLayoutEffect(() => {
+		syncViewportToMode();
+	});
+
+	useEffect(() => {
+		const scrollElement = scrollElementRef.current;
+		const contentElement = contentElementRef.current;
+		if (!scrollElement || !contentElement) {
+			return;
+		}
+
+		const mutationObserver = new MutationObserver(scheduleViewportSync);
+		mutationObserver.observe(contentElement, {
+			childList: true,
+			subtree: true,
+			characterData: true,
+		});
+
+		const resizeObserver = new ResizeObserver(scheduleViewportSync);
+		resizeObserver.observe(contentElement);
+		resizeObserver.observe(scrollElement);
+
+		return () => {
+			mutationObserver.disconnect();
+			resizeObserver.disconnect();
+		};
+	}, []);
+
+	useEffect(() => {
+		const scrollElement = scrollElementRef.current;
+		const topSentinelElement = topSentinelElementRef.current;
+		if (!scrollElement || !topSentinelElement || !hasMoreMessages) {
+			return;
+		}
+		const observer = new IntersectionObserver(
+			([entry]) => {
+				if (!entry?.isIntersecting) {
+					return;
+				}
+				requestHistoryFetch();
+			},
+			{
+				root: scrollElement,
+				rootMargin: HISTORY_ROOT_MARGIN,
+				threshold: 0.01,
+			},
+		);
+		observer.observe(topSentinelElement);
+		return () => observer.disconnect();
+	}, [hasMoreMessages]);
+
+	useEffect(() => {
+		if (previousMessageCountRef.current === messageCount) {
+			return;
+		}
+		previousMessageCountRef.current = messageCount;
+		isFetchingHistoryRef.current = isFetchingMoreMessages;
+		if (modeRef.current === "following-latest") {
+			scheduleDeferredPin();
+			return;
+		}
+		scheduleViewportSync();
+	});
 
 	return (
 		<div className="relative flex min-h-0 flex-1 flex-col">
@@ -141,40 +487,18 @@ const ChatScrollContainer: FC<{
 				ref={setScrollContainer}
 				data-testid="scroll-container"
 				aria-busy={isFetchingMoreMessages || undefined}
-				// `react-infinite-scroll-component` renders two wrapper divs
-				// between this scroller and the rendered messages. Force both
-				// out of the layout tree with `display: contents` so that
-				// (a) `position: sticky` on a user message resolves against
-				// this scroller rather than the inner wrapper (which has
-				// `overflow: auto` baked in by the library), and (b) the
-				// column-reverse inverse layout places the library's
-				// load-more sentinel at the visual top of the content stack.
-				className="flex min-h-0 flex-1 flex-col-reverse overflow-y-auto [&>[class$=outerdiv]]:contents [scrollbar-gutter:stable] [scrollbar-width:thin] [scrollbar-color:hsl(var(--surface-quaternary))_transparent]"
+				className="flex min-h-0 flex-1 flex-col overflow-y-auto [overflow-anchor:none] [overscroll-behavior:contain] [scrollbar-gutter:stable] [scrollbar-width:thin] [scrollbar-color:hsl(var(--surface-quaternary))_transparent]"
 			>
-				<div aria-hidden className="flex-1 basis-0" />
-				<InfiniteScroll
-					dataLength={messageCount}
-					next={onFetchMoreMessages}
-					hasMore={hasMoreMessages}
-					inverse
-					scrollableTarget={scrollContainerElement ?? undefined}
-					scrollThreshold={SCROLL_THRESHOLD}
-					hasChildren={messageCount > 0}
-					loader={isFetchingMoreMessages ? <div aria-hidden /> : null}
-					endMessage={null}
-					// `display: contents` removes this wrapper's box from the
-					// layout tree. Combined with the `outerdiv:contents`
-					// selector on the scroller above, the children render as
-					// direct flex items of the scroller so sticky messages
-					// can pin to its top edge.
-					style={{ display: "contents" }}
-				>
+				<div ref={setContentElement} className="flex min-h-full flex-col">
+					{hasMoreMessages ? (
+						<div ref={setTopSentinel} className="h-px shrink-0" />
+					) : null}
 					{children}
-				</InfiniteScroll>
+					<div className="h-px shrink-0" />
+				</div>
 			</div>
 			<ScrollToBottomButton
-				scrollContainerElement={scrollContainerElement}
-				messageCount={messageCount}
+				show={messageCount > 0 && mode === "detached"}
 				onScrollToBottom={scrollToBottom}
 			/>
 		</div>

--- a/site/src/pages/AgentsPage/components/chatViewportUtils.test.ts
+++ b/site/src/pages/AgentsPage/components/chatViewportUtils.test.ts
@@ -1,0 +1,241 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	type AnchorSnapshot,
+	canElementScrollInDirection,
+	FOLLOW_THRESHOLD_PX,
+	findNearestScrollableAncestor,
+	getBottomGap,
+	getPinnedPreviewMetrics,
+	getScrollMode,
+	LIVE_STREAM_TAIL_ANCHOR_ID,
+	PINNED_PREVIEW_MIN_HEIGHT_PX,
+	resolveAnchorTarget,
+	restoreAnchorScrollTop,
+} from "./chatViewportUtils";
+
+const setScrollMetrics = (
+	element: HTMLElement,
+	metrics: {
+		scrollHeight: number;
+		clientHeight: number;
+		scrollTop: number;
+	},
+): void => {
+	Object.defineProperty(element, "scrollHeight", {
+		configurable: true,
+		value: metrics.scrollHeight,
+	});
+	Object.defineProperty(element, "clientHeight", {
+		configurable: true,
+		value: metrics.clientHeight,
+	});
+	Object.defineProperty(element, "scrollTop", {
+		configurable: true,
+		writable: true,
+		value: metrics.scrollTop,
+	});
+};
+
+const setRect = (element: Element, top: number, height = 0): void => {
+	Object.defineProperty(element, "getBoundingClientRect", {
+		configurable: true,
+		value: () => new DOMRect(0, top, 0, height),
+	});
+};
+
+const appendAnchor = (
+	container: HTMLElement,
+	anchorId: string,
+): HTMLDivElement => {
+	const anchor = document.createElement("div");
+	anchor.dataset.chatAnchor = "true";
+	anchor.dataset.chatAnchorId = anchorId;
+	container.append(anchor);
+	return anchor;
+};
+
+describe("chatViewportUtils", () => {
+	beforeEach(() => {
+		document.body.innerHTML = "";
+	});
+
+	it("enters following mode when bottom gap is within threshold", () => {
+		const scrollContainer = document.createElement("div");
+		setScrollMetrics(scrollContainer, {
+			scrollHeight: 600,
+			clientHeight: 400,
+			scrollTop: 600 - 400 - FOLLOW_THRESHOLD_PX,
+		});
+
+		expect(getBottomGap(scrollContainer)).toBe(FOLLOW_THRESHOLD_PX);
+		expect(getScrollMode(getBottomGap(scrollContainer))).toBe(
+			"following-latest",
+		);
+	});
+
+	it("exits following mode when bottom gap exceeds threshold", () => {
+		const scrollContainer = document.createElement("div");
+		setScrollMetrics(scrollContainer, {
+			scrollHeight: 600,
+			clientHeight: 400,
+			scrollTop: 600 - 400 - FOLLOW_THRESHOLD_PX - 1,
+		});
+
+		expect(getBottomGap(scrollContainer)).toBe(FOLLOW_THRESHOLD_PX + 1);
+		expect(getScrollMode(getBottomGap(scrollContainer))).toBe("detached");
+	});
+
+	it("restores anchor position after layout growth", () => {
+		const scrollContainer = document.createElement("div");
+		setScrollMetrics(scrollContainer, {
+			scrollHeight: 1200,
+			clientHeight: 400,
+			scrollTop: 200,
+		});
+		setRect(scrollContainer, 50, 400);
+		const anchor = document.createElement("div");
+		setRect(anchor, 170, 24);
+		const snapshot: AnchorSnapshot = {
+			anchorId: "message-1",
+			offsetTop: 80,
+		};
+
+		expect(restoreAnchorScrollTop(scrollContainer, anchor, snapshot)).toBe(240);
+	});
+
+	it("restores anchor position after layout shrink", () => {
+		const scrollContainer = document.createElement("div");
+		setScrollMetrics(scrollContainer, {
+			scrollHeight: 1200,
+			clientHeight: 400,
+			scrollTop: 240,
+		});
+		setRect(scrollContainer, 50, 400);
+		const anchor = document.createElement("div");
+		setRect(anchor, 100, 24);
+		const snapshot: AnchorSnapshot = {
+			anchorId: "message-1",
+			offsetTop: 80,
+		};
+
+		expect(restoreAnchorScrollTop(scrollContainer, anchor, snapshot)).toBe(210);
+	});
+
+	it("resolves exact anchor matches", () => {
+		const scrollContainer = document.createElement("div");
+		const firstAnchor = appendAnchor(scrollContainer, "message-1");
+		const secondAnchor = appendAnchor(scrollContainer, "message-2");
+
+		expect(
+			resolveAnchorTarget(scrollContainer, {
+				anchorId: "message-2",
+				offsetTop: 0,
+			}),
+		).toBe(secondAnchor);
+		expect(firstAnchor.dataset.chatAnchorId).toBe("message-1");
+	});
+
+	it("falls back from live stream tail to latest durable anchor", () => {
+		const scrollContainer = document.createElement("div");
+		appendAnchor(scrollContainer, "message-1");
+		const latestDurableAnchor = appendAnchor(scrollContainer, "message-2");
+
+		expect(
+			resolveAnchorTarget(scrollContainer, {
+				anchorId: LIVE_STREAM_TAIL_ANCHOR_ID,
+				offsetTop: 0,
+			}),
+		).toBe(latestDurableAnchor);
+	});
+
+	it("ignores non-anchor elements when resolving live stream fallback", () => {
+		const scrollContainer = document.createElement("div");
+		appendAnchor(scrollContainer, "message-1");
+		const latestDurableAnchor = appendAnchor(scrollContainer, "message-2");
+		const ignoredWrapper = document.createElement("div");
+		ignoredWrapper.dataset.chatAnchorIgnore = "true";
+		scrollContainer.append(ignoredWrapper);
+		appendAnchor(ignoredWrapper, "ignored-anchor");
+
+		expect(
+			resolveAnchorTarget(scrollContainer, {
+				anchorId: LIVE_STREAM_TAIL_ANCHOR_ID,
+				offsetTop: 0,
+			}),
+		).toBe(latestDurableAnchor);
+	});
+
+	it("reports nested scroller boundary availability", () => {
+		const nestedScroller = document.createElement("div");
+		nestedScroller.style.overflowY = "auto";
+		setScrollMetrics(nestedScroller, {
+			scrollHeight: 400,
+			clientHeight: 100,
+			scrollTop: 0,
+		});
+
+		expect(canElementScrollInDirection(nestedScroller, "down")).toBe(true);
+		expect(canElementScrollInDirection(nestedScroller, "up")).toBe(false);
+
+		nestedScroller.scrollTop = 300;
+
+		expect(canElementScrollInDirection(nestedScroller, "down")).toBe(false);
+		expect(canElementScrollInDirection(nestedScroller, "up")).toBe(true);
+	});
+
+	it("finds nearest scrollable ancestor before the chat viewport", () => {
+		const scrollViewport = document.createElement("div");
+		scrollViewport.style.overflowY = "auto";
+		setScrollMetrics(scrollViewport, {
+			scrollHeight: 800,
+			clientHeight: 300,
+			scrollTop: 120,
+		});
+		const wrapper = document.createElement("div");
+		const nestedScroller = document.createElement("div");
+		nestedScroller.style.overflowY = "auto";
+		setScrollMetrics(nestedScroller, {
+			scrollHeight: 500,
+			clientHeight: 150,
+			scrollTop: 20,
+		});
+		const leaf = document.createElement("div");
+		document.body.append(scrollViewport);
+		scrollViewport.append(wrapper);
+		wrapper.append(nestedScroller);
+		nestedScroller.append(leaf);
+
+		expect(findNearestScrollableAncestor(leaf, scrollViewport, "down")).toBe(
+			nestedScroller,
+		);
+	});
+
+	it("calculates pinned preview metrics when inactive and clamped", () => {
+		const inactiveMetrics = getPinnedPreviewMetrics({
+			fullHeight: 310,
+			scrollerHeight: 400,
+			scrolledPastTop: 80,
+		});
+
+		expect(inactiveMetrics.isActive).toBe(false);
+		expect(inactiveMetrics.isTooTall).toBe(true);
+		expect(inactiveMetrics.isClamped).toBe(false);
+		expect(inactiveMetrics.clipHeight).toBe(310);
+		expect(inactiveMetrics.fadeOpacity).toBe(0);
+		expect(inactiveMetrics.stickyTop).toBe(8);
+
+		const clampedMetrics = getPinnedPreviewMetrics({
+			fullHeight: 140,
+			scrollerHeight: 400,
+			scrolledPastTop: 200,
+			nextAnchorTop: 60,
+		});
+
+		expect(clampedMetrics.isActive).toBe(true);
+		expect(clampedMetrics.isTooTall).toBe(false);
+		expect(clampedMetrics.isClamped).toBe(true);
+		expect(clampedMetrics.clipHeight).toBe(PINNED_PREVIEW_MIN_HEIGHT_PX);
+		expect(clampedMetrics.fadeOpacity).toBe(1);
+		expect(clampedMetrics.stickyTop).toBe(-4);
+	});
+});

--- a/site/src/pages/AgentsPage/components/chatViewportUtils.test.ts
+++ b/site/src/pages/AgentsPage/components/chatViewportUtils.test.ts
@@ -11,6 +11,7 @@ import {
 	PINNED_PREVIEW_MIN_HEIGHT_PX,
 	resolveAnchorTarget,
 	restoreAnchorScrollTop,
+	restorePrependScrollTop,
 } from "./chatViewportUtils";
 
 const setScrollMetrics = (
@@ -119,6 +120,39 @@ describe("chatViewportUtils", () => {
 		};
 
 		expect(restoreAnchorScrollTop(scrollContainer, anchor, snapshot)).toBe(210);
+	});
+
+	it("preserves viewport across history prepends with scroll height delta", () => {
+		const scrollContainer = document.createElement("div");
+		setScrollMetrics(scrollContainer, {
+			scrollHeight: 1400,
+			clientHeight: 400,
+			scrollTop: 120,
+		});
+
+		expect(restorePrependScrollTop(scrollContainer, 1000, 120)).toBe(520);
+	});
+
+	it("clamps history prepend restoration to the available scroll range", () => {
+		const scrollContainer = document.createElement("div");
+		setScrollMetrics(scrollContainer, {
+			scrollHeight: 900,
+			clientHeight: 400,
+			scrollTop: 480,
+		});
+
+		expect(restorePrependScrollTop(scrollContainer, 600, 480)).toBe(500);
+	});
+
+	it("ignores negative scroll height deltas for history prepend restoration", () => {
+		const scrollContainer = document.createElement("div");
+		setScrollMetrics(scrollContainer, {
+			scrollHeight: 900,
+			clientHeight: 400,
+			scrollTop: 120,
+		});
+
+		expect(restorePrependScrollTop(scrollContainer, 1000, 120)).toBe(120);
 	});
 
 	it("resolves exact anchor matches", () => {

--- a/site/src/pages/AgentsPage/components/chatViewportUtils.ts
+++ b/site/src/pages/AgentsPage/components/chatViewportUtils.ts
@@ -1,0 +1,195 @@
+export const FOLLOW_THRESHOLD_PX = 100;
+export const PINNED_PREVIEW_MIN_HEIGHT_PX = 72;
+export const CHAT_ANCHOR_SELECTOR = "[data-chat-anchor='true']";
+export const CHAT_NON_ANCHOR_SELECTOR = "[data-chat-anchor-ignore='true']";
+export const LIVE_STREAM_TAIL_ANCHOR_ID = "live-stream-tail";
+
+const STICKY_TOP_PX = 8;
+const PINNED_PREVIEW_FADE_RANGE_PX = 40;
+const PINNED_PREVIEW_MAX_HEIGHT_RATIO = 0.75;
+const EPSILON_PX = 1;
+
+export type ScrollDirection = "up" | "down";
+
+export type ScrollMode = "following-latest" | "detached";
+
+export interface AnchorSnapshot {
+	anchorId: string;
+	offsetTop: number;
+}
+
+interface PinnedPreviewMetricsOptions {
+	fullHeight: number;
+	scrollerHeight: number;
+	scrolledPastTop: number;
+	nextAnchorTop?: number;
+}
+
+interface PinnedPreviewMetrics {
+	clipHeight: number;
+	fadeOpacity: number;
+	stickyTop: number;
+	isActive: boolean;
+	isClamped: boolean;
+	isTooTall: boolean;
+}
+
+const clamp = (value: number, min: number, max: number): number =>
+	Math.min(Math.max(value, min), max);
+
+const getMaxScrollTop = (element: HTMLElement): number =>
+	Math.max(element.scrollHeight - element.clientHeight, 0);
+
+const getAnchorElements = (scrollContainer: HTMLElement): HTMLElement[] =>
+	Array.from(
+		scrollContainer.querySelectorAll<HTMLElement>(CHAT_ANCHOR_SELECTOR),
+	).filter((element) => !element.closest(CHAT_NON_ANCHOR_SELECTOR));
+
+const isOverflowScrollable = (value: string): boolean =>
+	value === "auto" || value === "scroll" || value === "overlay";
+
+export const getBottomGap = (scrollContainer: HTMLElement): number =>
+	Math.max(
+		scrollContainer.scrollHeight -
+			scrollContainer.clientHeight -
+			scrollContainer.scrollTop,
+		0,
+	);
+
+export const getScrollMode = (
+	bottomGap: number,
+	thresholdPx = FOLLOW_THRESHOLD_PX,
+): ScrollMode => (bottomGap <= thresholdPx ? "following-latest" : "detached");
+
+export const restoreAnchorScrollTop = (
+	scrollContainer: HTMLElement,
+	anchorElement: HTMLElement,
+	snapshot: AnchorSnapshot,
+): number => {
+	const scrollContainerTop = scrollContainer.getBoundingClientRect().top;
+	const anchorTop = anchorElement.getBoundingClientRect().top;
+	const currentOffsetTop = anchorTop - scrollContainerTop;
+	const nextScrollTop =
+		scrollContainer.scrollTop + currentOffsetTop - snapshot.offsetTop;
+
+	return clamp(nextScrollTop, 0, getMaxScrollTop(scrollContainer));
+};
+
+export const resolveAnchorTarget = (
+	scrollContainer: HTMLElement,
+	snapshot: AnchorSnapshot,
+): HTMLElement | null => {
+	const anchors = getAnchorElements(scrollContainer);
+	const exactMatch = anchors.find(
+		(anchor) => anchor.dataset.chatAnchorId === snapshot.anchorId,
+	);
+	if (exactMatch) {
+		return exactMatch;
+	}
+	if (snapshot.anchorId !== LIVE_STREAM_TAIL_ANCHOR_ID) {
+		return null;
+	}
+
+	for (let index = anchors.length - 1; index >= 0; index -= 1) {
+		const anchor = anchors[index];
+		if (anchor.dataset.chatAnchorId !== LIVE_STREAM_TAIL_ANCHOR_ID) {
+			return anchor;
+		}
+	}
+
+	return null;
+};
+
+export const canElementScrollInDirection = (
+	element: HTMLElement,
+	direction: ScrollDirection,
+): boolean => {
+	const style = getComputedStyle(element);
+	const overflowY = style.overflowY || style.overflow;
+	if (!isOverflowScrollable(overflowY)) {
+		return false;
+	}
+
+	const maxScrollTop = getMaxScrollTop(element);
+	if (maxScrollTop <= EPSILON_PX) {
+		return false;
+	}
+
+	if (direction === "up") {
+		return element.scrollTop > EPSILON_PX;
+	}
+
+	return element.scrollTop < maxScrollTop - EPSILON_PX;
+};
+
+export const findNearestScrollableAncestor = (
+	element: HTMLElement,
+	boundary: HTMLElement | null,
+	direction: ScrollDirection,
+): HTMLElement | null => {
+	let current = element.parentElement;
+	while (current && current !== boundary) {
+		if (canElementScrollInDirection(current, direction)) {
+			return current;
+		}
+		current = current.parentElement;
+	}
+
+	return null;
+};
+
+export const getPinnedPreviewMetrics = ({
+	fullHeight,
+	scrollerHeight,
+	scrolledPastTop,
+	nextAnchorTop,
+}: PinnedPreviewMetricsOptions): PinnedPreviewMetrics => {
+	const isTooTall =
+		fullHeight > scrollerHeight * PINNED_PREVIEW_MAX_HEIGHT_RATIO;
+	if (isTooTall) {
+		return {
+			clipHeight: fullHeight,
+			fadeOpacity: 0,
+			stickyTop: STICKY_TOP_PX,
+			isActive: false,
+			isClamped: false,
+			isTooTall,
+		};
+	}
+
+	if (scrolledPastTop <= 0) {
+		return {
+			clipHeight: fullHeight,
+			fadeOpacity: 0,
+			stickyTop: STICKY_TOP_PX,
+			isActive: false,
+			isClamped: false,
+			isTooTall,
+		};
+	}
+
+	const clipHeight = Math.max(
+		fullHeight - scrolledPastTop,
+		PINNED_PREVIEW_MIN_HEIGHT_PX,
+	);
+	const isClamped = clipHeight === PINNED_PREVIEW_MIN_HEIGHT_PX;
+	const fadeOpacity = clamp(
+		(PINNED_PREVIEW_MIN_HEIGHT_PX + PINNED_PREVIEW_FADE_RANGE_PX - clipHeight) /
+			PINNED_PREVIEW_FADE_RANGE_PX,
+		0,
+		1,
+	);
+	const stickyTop =
+		nextAnchorTop === undefined
+			? STICKY_TOP_PX
+			: Math.min(STICKY_TOP_PX, nextAnchorTop - clipHeight + STICKY_TOP_PX);
+
+	return {
+		clipHeight,
+		fadeOpacity,
+		stickyTop,
+		isActive: true,
+		isClamped,
+		isTooTall,
+	};
+};

--- a/site/src/pages/AgentsPage/components/chatViewportUtils.ts
+++ b/site/src/pages/AgentsPage/components/chatViewportUtils.ts
@@ -75,6 +75,22 @@ export const restoreAnchorScrollTop = (
 	return clamp(nextScrollTop, 0, getMaxScrollTop(scrollContainer));
 };
 
+export const restorePrependScrollTop = (
+	scrollContainer: HTMLElement,
+	previousScrollHeight: number,
+	previousScrollTop: number,
+): number => {
+	const scrollHeightDelta = Math.max(
+		scrollContainer.scrollHeight - previousScrollHeight,
+		0,
+	);
+	return clamp(
+		previousScrollTop + scrollHeightDelta,
+		0,
+		getMaxScrollTop(scrollContainer),
+	);
+};
+
 export const resolveAnchorTarget = (
 	scrollContainer: HTMLElement,
 	snapshot: AnchorSnapshot,


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood

## Summary

- Replaces the Agents chat inverse scroll wrapper with a normal-flow viewport so oldest messages render at the top and newest at the bottom.
- Adds explicit follow/detached scroll modes with anchor restoration for detached streaming, prepends, and resizes.
- Preserves lazy history loading, sticky previous-user message behavior, and instant bottom pinning while removing the unused `react-infinite-scroll-component` dependency.

## Verification

- `cd site && pnpm check`
- `cd site && pnpm run lint:types`
- `cd site && pnpm test -- src/pages/AgentsPage/components/chatViewportUtils.test.ts`
- `cd site && pnpm test:storybook src/pages/AgentsPage/AgentChatPageView.stories.tsx src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx`
- `cd site && pnpm format`
- `git commit` pre-commit hook passed

<details><summary>Implementation plan</summary>

# Agents Chat Scroll Redesign Implementation Plan

> For agentic workers: use `subagent-driven-development` for independent
> tasks, or `executing-plans` for inline execution. Track steps with checkbox
> syntax.

**Goal:** Replace the Agents chat reverse-scroll implementation with a normal-flow, Safari-safe viewport that preserves detached reading position while still pinning to latest content when the user is near the bottom.

**Architecture:** Use DOM order oldest to newest with a plain scroll viewport, explicit `following-latest` and `detached` modes, a top history sentinel, and stable anchor snapshots for detached restoration. Keep sticky previous user chat behavior as a visual layer and mark overlay/control elements as ignored by anchor selection.

**Tech Stack:** React, TypeScript, Tailwind, Storybook play tests, Vitest unit tests, `pnpm` commands under `site/`.

---

## File map

- Create `site/src/pages/AgentsPage/components/chatViewportUtils.ts` for pure scroll-mode, anchor, nested-scroll, and pinned-preview helpers.
- Create `site/src/pages/AgentsPage/components/chatViewportUtils.test.ts` for pure utility coverage.
- Modify `site/src/pages/AgentsPage/components/ChatScrollContainer.tsx` to remove `react-infinite-scroll-component`, use normal flow, own top and bottom sentinels, preserve anchors while detached, and pin while following.
- Modify `site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx` to add stable chat anchors and keep sticky user message behavior compatible with normal flow.
- Modify `site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.tsx` to expose an anchorable live-stream tail boundary.
- Modify `site/src/pages/AgentsPage/components/ChatPageContent.tsx` only if the content wrapper needs anchor participation or layout classes adjusted.
- Modify `site/src/pages/AgentsPage/AgentChatPageView.stories.tsx` to replace inverse-scroll assumptions with normal-flow behavior and add regression stories for detached streaming, bottom following, lazy prepend restoration, and sticky user message behavior.
- Modify package imports only if removing `react-infinite-scroll-component` leaves a direct unused dependency in this feature. Do not remove the package from the workspace unless it is unused repository-wide.

## Requirements coverage

- Oldest at top and newest at bottom: normal `flex-col` viewport and normal scroll math.
- Detached viewport preservation: capture first visible durable anchor and restore it after content mutations, streaming growth, history prepends, and resize.
- Bottom follow: if bottom gap is within threshold, pin to bottom after layout commits and during streaming.
- Lazy history loading: top sentinel triggers `onFetchMoreMessages`, with anchor captured before fetch and restored after render.
- Sticky previous user chat: keep user message sticky/clipped/faded behavior, update scroller discovery and anchor exclusion for normal flow.
- Safari/WebKit: avoid reverse scroll coordinates, disable native scroll anchoring on the viewport, batch reads/writes with `requestAnimationFrame`, and avoid smooth scrolling in restore/test paths.

## Task 1: Add pure viewport utilities

**Files:**
- Create: `site/src/pages/AgentsPage/components/chatViewportUtils.ts`
- Test: `site/src/pages/AgentsPage/components/chatViewportUtils.test.ts`

- [x] **Step 1: Write failing utility tests.**

Add tests for these names:

- `enters following mode when bottom gap is within threshold`
- `exits following mode when bottom gap exceeds threshold`
- `restores anchor position after layout growth`
- `restores anchor position after layout shrink`
- `resolves exact anchor matches`
- `falls back from live stream tail to latest durable anchor`
- `ignores non-anchor elements when resolving live stream fallback`
- `reports nested scroller boundary availability`
- `finds nearest scrollable ancestor before the chat viewport`
- `calculates pinned preview metrics when inactive and clamped`

Use pure DOM nodes and property overrides. Do not render React.

- [x] **Step 2: Run the tests and verify they fail because the file does not exist.**

```sh
cd site && pnpm test -- src/pages/AgentsPage/components/chatViewportUtils.test.ts
```

- [x] **Step 3: Implement the utilities.**

Export:

```ts
export const FOLLOW_THRESHOLD_PX = 100;
export const PINNED_PREVIEW_MIN_HEIGHT_PX = 72;
export const CHAT_ANCHOR_SELECTOR = "[data-chat-anchor='true']";
export const CHAT_NON_ANCHOR_SELECTOR = "[data-chat-anchor-ignore='true']";
export const LIVE_STREAM_TAIL_ANCHOR_ID = "live-stream-tail";

export type ScrollMode = "following-latest" | "detached";
export interface AnchorSnapshot {
  anchorId: string;
  offsetTop: number;
}
```

Implement `getBottomGap`, `getScrollMode`, `restoreAnchorScrollTop`, `resolveAnchorTarget`, `canElementScrollInDirection`, `findNearestScrollableAncestor`, and `getPinnedPreviewMetrics`.

- [x] **Step 4: Run utility tests and confirm they pass.**

```sh
cd site && pnpm test -- src/pages/AgentsPage/components/chatViewportUtils.test.ts
```

## Task 2: Replace the scroll container with normal-flow viewport ownership

**Files:**
- Modify: `site/src/pages/AgentsPage/components/ChatScrollContainer.tsx`
- Modify: `site/src/pages/AgentsPage/components/ChatConversation/LiveStreamTail.tsx`
- Modify: `site/src/pages/AgentsPage/components/ChatPageContent.tsx` if needed
- Test: `site/src/pages/AgentsPage/AgentChatPageView.stories.tsx`

- [x] **Step 1: Add failing Storybook coverage for core viewport behavior.**

Update or add stories with play functions:

- `ScrollPositionPreservedOnNewContent`: scroll to a middle message, append or stream new content, assert the same visible message remains at the same viewport offset within 2px.
- `ScrollPinnedToBottomOnNewContent`: start at bottom, append or stream new content, assert bottom gap remains within 2px and the scroll-to-bottom button is hidden.
- `HistoryPrependPreservesViewport`: scroll to the top sentinel, wait for older messages to load, assert the previously visible message remains at the same viewport offset within 2px.
- `ScrollToBottomButtonUsesNormalFlow`: scroll away from bottom, click the button, assert normal-flow bottom gap is within 2px.

Remove assumptions that history top uses negative `scrollTop`.

- [x] **Step 2: Run the targeted Storybook file and verify the new stories fail.**

```sh
cd site && pnpm test:storybook src/pages/AgentsPage/AgentChatPageView.stories.tsx
```

If Playwright browsers are missing, run:

```sh
cd site && pnpm exec playwright install chromium
```

Then rerun the Storybook command.

- [x] **Step 3: Implement the normal-flow `ChatScrollContainer`.**

Remove `react-infinite-scroll-component` usage. Keep the external props and refs. The component should:

- render `<div data-testid="scroll-container">` as `flex min-h-0 flex-1 flex-col overflow-y-auto [overflow-anchor:none] [overscroll-behavior:contain]`;
- render a content wrapper, optional top sentinel, `children`, and bottom sentinel in normal DOM order;
- set `scrollToBottomRef.current` to an instant bottom pin function that sets `scrollTop = scrollHeight` and switches mode to `following-latest`;
- compute mode from `getBottomGap` using a 100px threshold;
- capture the first visible `data-chat-anchor="true"` element when entering detached mode;
- restore the captured anchor on content resize or mutation while detached;
- pin after content resize or mutation while following;
- trigger `onFetchMoreMessages` through an IntersectionObserver on the top sentinel with `rootMargin: "600px 0px 0px 0px"`;
- guard duplicate fetches while `isFetchingMoreMessages` is true;
- RAF-throttle scroll and resize reactions.

- [x] **Step 4: Anchor live-stream tail.**

Add `data-chat-anchor="true"` and `data-chat-anchor-id={LIVE_STREAM_TAIL_ANCHOR_ID}` to the live-stream tail top-level boundary when it renders visible streaming content. Mark internal controls that should not anchor with `data-chat-anchor-ignore="true"` if needed.

- [x] **Step 5: Run targeted Storybook stories and utility tests.**

```sh
cd site && pnpm test -- src/pages/AgentsPage/components/chatViewportUtils.test.ts
cd site && pnpm test:storybook src/pages/AgentsPage/AgentChatPageView.stories.tsx
```

## Task 3: Preserve sticky previous user chat behavior in normal flow

**Files:**
- Modify: `site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx`
- Test: `site/src/pages/AgentsPage/AgentChatPageView.stories.tsx`
- Test: `site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx` if existing structure coverage needs updating

- [x] **Step 1: Update sticky regression stories.**

Keep `StickyUserMessagePinsOnScroll`, but change its setup to normal-flow scrolling. It should assert that a previous user message pins near the viewport top while assistant content scrolls under it. It must not assert class names.

- [x] **Step 2: Add stable anchors around messages.**

For assistant messages, wrap the top-level rendered message with:

```tsx
data-chat-anchor="true"
data-chat-anchor-id={`message-${message.id}`}
```

For user messages, add a zero-height or one-pixel marker before the sticky container with the same anchor attributes. Mark overlay clones or preview layers with `data-chat-anchor-ignore="true"`.

- [x] **Step 3: Adjust sticky scroller discovery and edit scrolling.**

Keep the current sticky/clipping behavior, but ensure it finds the actual `data-testid="scroll-container"` or nearest `.overflow-y-auto` in the normal-flow viewport. Replace smooth edit scrolling with instant or direct `scrollTop` math so tests and Safari do not depend on smooth scroll timing.

- [x] **Step 4: Run sticky stories.**

```sh
cd site && pnpm test:storybook src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx src/pages/AgentsPage/AgentChatPageView.stories.tsx
```

## Task 4: Clean up inverse-scroll assumptions and verify integration

**Files:**
- Modify: `site/src/pages/AgentsPage/AgentChatPageView.stories.tsx`
- Modify: any touched imports in Agents chat files

- [x] **Step 1: Replace helper functions that encode reverse scroll math.**

Update helpers so:

- `scrollToHistoryTop` sets `scrollTop = 0`;
- `scrollToLatestMessages` sets `scrollTop = scrollHeight`;
- button visibility uses normal bottom gap rather than `Math.abs(scrollTop)`;
- story names no longer refer to inverse scroll.

- [x] **Step 2: Remove dead imports and dependency usage.**

Confirm `react-infinite-scroll-component` is no longer imported from Agents chat files. Do not edit `package.json` unless repository-wide search proves the dependency is unused outside this feature.

- [x] **Step 3: Run focused checks.**

```sh
cd site && pnpm test -- src/pages/AgentsPage/components/chatViewportUtils.test.ts
cd site && pnpm test:storybook src/pages/AgentsPage/AgentChatPageView.stories.tsx src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
cd site && pnpm check
cd site && pnpm format
```

## Task 5: Prepare the single draft PR

**Files:**
- Modify only as required by formatting.

- [x] **Step 1: Inspect the final diff.**

```sh
git status --short
git diff --stat
git diff --check
```

- [x] **Step 2: Run final verification before claiming completion.**

Use the `verification-before-completion` skill. Minimum commands:

```sh
cd site && pnpm test -- src/pages/AgentsPage/components/chatViewportUtils.test.ts
cd site && pnpm test:storybook src/pages/AgentsPage/AgentChatPageView.stories.tsx src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.stories.tsx
cd site && pnpm check
cd site && pnpm format
```

If Storybook cannot run because browser binaries are missing and install fails, document the exact failure and still run all non-Playwright checks.

- [x] **Step 3: Commit with hooks enabled.**

Use the configured hooks through normal `git commit`, not `--no-verify`:

```sh
git commit -m "fix(site/src/pages/AgentsPage): stabilize chat scrolling"
```

- [x] **Step 4: Push and open a draft PR.**

```sh
git push -u origin danielle/agent-chat-scroll-redesign-single-pr
```

Create a draft PR with title:

```text
fix(site/src/pages/AgentsPage): stabilize chat scrolling
```

The PR body must include the Coder Agent disclosure and a collapsible implementation plan section using this plan file.


</details>
