### PR TITLE
fix(site/pages/AgentsPage): prevent multiple sticky prompts from overlapping

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -742,6 +742,7 @@ const StickyUserMessage = memo<{
 					container.style.setProperty("--clip-h", `${fullHeight}px`);
 					container.style.setProperty("--fade-opacity", "0");
 					container.style.top = `${STICKY_TOP}px`;
+					container.style.visibility = "";
 
 					return;
 				}
@@ -754,6 +755,7 @@ const StickyUserMessage = memo<{
 					container.style.setProperty("--clip-h", `${fullHeight}px`);
 					container.style.setProperty("--fade-opacity", "0");
 					container.style.top = `${STICKY_TOP}px`;
+					container.style.visibility = "";
 
 					return;
 				}
@@ -781,9 +783,15 @@ const StickyUserMessage = memo<{
 				}
 				if (nextSentinel) {
 					const nextY = nextSentinel.getBoundingClientRect().top - scrollerTop;
-					container.style.top = `${Math.min(STICKY_TOP, nextY - visible + STICKY_TOP)}px`;
+					const pushTop = Math.min(STICKY_TOP, nextY - visible + STICKY_TOP);
+					container.style.top = `${pushTop}px`;
+					// Once this container is pushed fully above the
+					// viewport by the next sticky prompt, hide it
+					// entirely to prevent multiple prompts stacking.
+					container.style.visibility = pushTop + visible <= 0 ? "hidden" : "";
 				} else {
 					container.style.top = `${STICKY_TOP}px`;
+					container.style.visibility = "";
 				}
 			};
 			updateFnRef.current = update;

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -889,13 +889,8 @@ const StickyUserMessage = memo<{
 						"relative px-3 -mx-3 -mt-2",
 						!isTooTall && "sticky z-10",
 						!isReady && "invisible",
-						isStuck && !isTooTall && "pointer-events-none overflow-hidden",
+						isStuck && !isTooTall && "pointer-events-none",
 					)}
-					style={
-						isStuck && !isTooTall
-							? { maxHeight: "var(--clip-h, none)" }
-							: undefined
-					}
 				>
 					{/* Flow element: always in the DOM to preserve
 				    scroll layout. Hidden when stuck so the

--- a/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
+++ b/site/src/pages/AgentsPage/components/ChatConversation/ConversationTimeline.tsx
@@ -889,8 +889,13 @@ const StickyUserMessage = memo<{
 						"relative px-3 -mx-3 -mt-2",
 						!isTooTall && "sticky z-10",
 						!isReady && "invisible",
-						isStuck && !isTooTall && "pointer-events-none",
+						isStuck && !isTooTall && "pointer-events-none overflow-hidden",
 					)}
+					style={
+						isStuck && !isTooTall
+							? { maxHeight: "var(--clip-h, none)" }
+							: undefined
+					}
 				>
 					{/* Flow element: always in the DOM to preserve
 				    scroll layout. Hidden when stuck so the


### PR DESCRIPTION
When multiple user messages are close together in the chat, their sticky containers all share `z-10` and can visually stack 2-3 deep on top of each other.

The push-up effect shifts `container.style.top` upward when the next user message approaches, but never hides the container once it fully exits the viewport. Since `position: sticky` keeps the element rendered even with a negative `top` value, the old prompt remains visible underneath the current one.

Fix by setting `visibility: hidden` on the container once the push-up `top` plus the visible height goes to zero or below. This ensures only one sticky prompt is ever visible at a time. Visibility is cleared in all other code paths (not-stuck, too-tall, no-next-sentinel) so the container reappears correctly when scrolling back.

> Generated by Coder Agents on behalf of @tracyjohnsonux