### PR TITLE
fix: use system context for template metadata in workspace list

### DIFF
--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -2630,7 +2630,11 @@ func (api *API) workspaceData(ctx context.Context, workspaces []database.Workspa
 		eg          errgroup.Group
 	)
 	eg.Go(func() (err error) {
-		templates, err = api.Database.GetTemplatesWithFilter(ctx, database.GetTemplatesWithFilterParams{
+		// nolint:gocritic // System context to fetch template metadata for workspaces
+		// the caller is already authorized to read. Consistent with builds and
+		// app statuses below, and required for shared workspaces where the user
+		// may not have direct template read permission.
+		templates, err = api.Database.GetTemplatesWithFilter(dbauthz.AsSystemRestricted(ctx), database.GetTemplatesWithFilterParams{
 			IDs: templateIDs,
 		})
 		if err != nil && !errors.Is(err, sql.ErrNoRows) {


### PR DESCRIPTION
## Problem

When listing workspaces shared with a user, the user may not have direct read permission on the template. This causes the workspace list API to return `count: N` but an empty `workspaces: []` array, because template metadata fetch fails authorization.

## Fix

In `coderd/workspaces.go::workspaceData()`, change `GetTemplatesWithFilter` to use `dbauthz.AsSystemRestricted(ctx)` instead of the user's context.

## Why this is correct

1. **Consistency with existing code** — the same function already uses `AsSystemRestricted` for `GetLatestWorkspaceBuildsByWorkspaceIDs` and `GetLatestWorkspaceAppStatusesByWorkspaceIDs`:
   ```go
   // This query must be run as system restricted to be efficient.
   builds, err = api.Database.GetLatestWorkspaceBuildsByWorkspaceIDs(
       dbauthz.AsSystemRestricted(ctx), workspaceIDs)
   ```
   Templates were the odd one out.

2. **Consistency with PR #21049** — when Coder added "show users/groups a workspace is shared with" to the list endpoint, system permissions were used to fetch user/group display data, reasoning that if you can see the workspace, you can see its metadata. The same logic applies to templates.

3. **Authorization already happened** — the caller was already authorized to read the workspace itself, so fetching template metadata for display is safe.

## Testing

Verified fix resolves the issue where shared workspaces were not visible to the shared-with user.