### PR TITLE
fix(enterprise/coderd/prebuilds): downgrade reconciliation stats log to debug

### DIFF
--- a/enterprise/coderd/prebuilds/reconcile.go
+++ b/enterprise/coderd/prebuilds/reconcile.go
@@ -254,7 +254,7 @@ func (c *StoreReconciler) Run(ctx context.Context) {
 			if c.reconciliationDuration != nil {
 				c.reconciliationDuration.Observe(stats.Elapsed.Seconds())
 			}
-			c.logger.Info(ctx, "reconciliation stats",
+			c.logger.Debug(ctx, "reconciliation stats",
 				slog.F("elapsed", stats.Elapsed),
 				slog.F("presets_total", stats.PresetsTotal),
 				slog.F("presets_reconciled", stats.PresetsReconciled),


### PR DESCRIPTION
*Disclaimer: implemented by a Coder Agent using Claude Opus 4.6*

The `reconciliation stats` log line runs on every reconciliation tick (every 5 minutes by default), even when there are no presets to reconcile. In a steady-state installation without prebuilds activity, this is the only log line that persistently shows up at info level. Demote it to `debug` so the steady-state log output stays quiet.

Before:

```
2026-05-14 15:01:25.085 [info]  coderd.prebuilds: reconciliation stats  elapsed=1.649153ms  presets_total=0  presets_reconciled=0
```

After: same line is emitted at `debug` level and is suppressed at the default info log level.