### PR TITLE
fix(dogfood): install rust-src component

### DIFF
--- a/dogfood/coder/ubuntu-22.04/Dockerfile
+++ b/dogfood/coder/ubuntu-22.04/Dockerfile
@@ -205,7 +205,7 @@ RUN chmod a+x /usr/local/bin/configure-chrome-flags.sh && \
 ENV RUSTUP_HOME=/usr/local/rustup \
 	CARGO_HOME=/usr/local/cargo
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
-	sh -s -- -y --default-toolchain stable --profile default
+	sh -s -- -y --default-toolchain stable --profile default -c rust-src
 ENV PATH=$CARGO_HOME/bin:$PATH
 
 # NOTE: In scripts/Dockerfile.base we specifically install Terraform version 1.15.2.

--- a/dogfood/coder/ubuntu-26.04/Dockerfile
+++ b/dogfood/coder/ubuntu-26.04/Dockerfile
@@ -212,7 +212,7 @@ RUN chmod a+x /opt/configure-chrome-flags.sh && \
 ENV RUSTUP_HOME=/usr/local/rustup \
 	CARGO_HOME=/usr/local/cargo
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
-	sh -s -- -y --default-toolchain stable --profile default
+	sh -s -- -y --default-toolchain stable --profile default -c rust-src
 ENV PATH=$CARGO_HOME/bin:$PATH
 
 # NOTE: In scripts/Dockerfile.base we specifically install Terraform version 1.15.2.


### PR DESCRIPTION
rust-analyzer fails on Rust workspaces with:

```
can't load standard library from sysroot
/usr/local/rustup/toolchains/stable-x86_64-unknown-linux-gnu
(discovered via `rustc --print sysroot`)
try installing `rust-src` the same way you installed `rustc`
```

The dogfood images install rustup with `--profile default`, which omits `rust-src`. Add `-c rust-src` to pull it in alongside the toolchain.

Disclosure: written by a Coder Agent on behalf of @aslilac.