### PR TITLE
docs(site/coder-kit): add design system index

### DIFF
--- a/site/coder-kit/checkbox.md
+++ b/site/coder-kit/checkbox.md
@@ -1,0 +1,222 @@
+# Checkbox
+
+A toggle control for binary or indeterminate selections. Built on
+[Radix UI Checkbox](https://www.radix-ui.com/primitives/docs/components/checkbox)
+with [Lucide](https://lucide.dev/) icons.
+
+Source: `site/src/components/Checkbox/Checkbox.tsx`
+
+---
+
+## Anatomy
+
+```
+┌──────────────────────────────────────┐
+│ ┌──────┐                             │
+│ │ 18×18│  Label text                  │
+│ │  box │  Description (optional)      │
+│ └──────┘                             │
+│  4 px margin (m-1) on all sides      │
+└──────────────────────────────────────┘
+```
+
+- **Box size**: 18×18 px (`size-[18px]`)
+- **Margin**: 4 px on all sides (`m-1`)
+- **Border radius**: 2 px (`rounded-xs`, computed from `calc(var(--radius) - 6px)`)
+- **Gap** between checkbox and label: 10 px (`gap-2.5`) in the canonical
+  `WithLabel` story. Usage patterns vary (see [Usage in context](#usage-in-context)).
+- **Checkbox vertical alignment**: `pt-0.5` (2 px) in the `WithLabel` story;
+  `mt-1` (4 px) in `RoleSelector`
+
+---
+
+## Styles
+
+### Box (unchecked)
+
+```
+size-[18px]
+rounded-xs
+border border-border border-solid
+bg-surface-primary
+```
+
+The border token `border-border` resolves to `hsl(var(--border-default))`
+through the Tailwind color config.
+
+### Box (checked)
+
+```
+bg-surface-invert-primary
+border-surface-invert-primary
+text-content-invert
+```
+
+### Box (indeterminate)
+
+Same tokens as checked.
+
+### Icons
+
+Both icons come from `lucide-react` and render inside a centered
+indicator (`absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2`).
+
+| State         | Icon        | Size   | Stroke width |
+|---------------|-------------|--------|--------------|
+| Checked       | `CheckIcon` | 16×16 (`size-4`) | 2.5 |
+| Indeterminate | `MinusIcon` | 16×16 (`size-4`) | 2.5 |
+
+Icon color is inherited from the parent's `text-content-invert` class.
+
+### Label (from `WithLabel` story)
+
+```
+text-sm font-medium
+→ 14px / 24px, weight 500
+color: content-primary (via inheritance)
+```
+
+When the checkbox is disabled, the label uses the `peer-disabled:` modifier:
+
+```
+peer-disabled:cursor-not-allowed
+peer-disabled:text-content-disabled
+```
+
+### Description (from `WithLabel` story)
+
+```
+text-sm text-content-secondary mt-1
+→ 14px / 24px, weight 500, color: content-secondary
+```
+
+---
+
+## States
+
+| State              | Box background             | Box border                 | Icon | Notes |
+|--------------------|----------------------------|----------------------------|------|-------|
+| Unchecked          | `surface-primary`          | `border-default`           | none | |
+| Unchecked, hover   | `surface-primary`          | `border-secondary`         | none | `hover:enabled:` |
+| Checked            | `surface-invert-primary`   | `surface-invert-primary`   | ✓    | |
+| Checked, hover     | `surface-invert-secondary` | `surface-invert-secondary` | ✓    | |
+| Indeterminate      | `surface-invert-primary`   | `surface-invert-primary`   | —    | |
+| Indeterminate, hover | `surface-invert-secondary` | `surface-invert-secondary` | —  | |
+| Disabled, unchecked | `surface-primary`         | `border-default`           | none | `cursor-not-allowed` |
+| Disabled, checked  | `surface-tertiary`         | `surface-tertiary`         | ✓    | `cursor-not-allowed` |
+
+> **Note:** There is no explicit disabled+indeterminate style. The
+> `disabled:bg-surface-primary` class applies but may conflict with the
+> `data-[state=indeterminate]:bg-surface-invert-primary` class depending
+> on CSS specificity. This could be a gap worth addressing.
+
+No opacity values are used on the Checkbox component itself. Disabled
+states are communicated through background and border color changes.
+Consumers may add opacity externally (e.g., `RoleSelector` uses
+`opacity-50` on the wrapper for non-assignable roles).
+
+### Focus ring
+
+```
+ring-2
+ring-content-link
+ring-offset-[3px]
+ring-offset-surface-primary
+```
+
+This uses Tailwind's ring utilities (box-shadow based), not CSS `outline`.
+
+### Transition
+
+No transition is defined on the component.
+
+---
+
+## Usage in context
+
+The Checkbox component is used with varying layouts depending on context.
+Gap, alignment, and disabled patterns are not standardized across usages.
+
+### WithLabel story (canonical)
+
+The simplest label pattern from the Storybook story.
+
+```
+Container:  flex gap-2.5           (10px gap)
+Checkbox:   wrapped in div.pt-0.5  (2px top padding for alignment)
+Label:      text-sm font-medium    (14px/24px, weight 500)
+Desc:       text-sm text-content-secondary mt-1
+```
+
+### Table rows (WorkspacesTable, TasksTable)
+
+Checkboxes in data table rows alongside `AvatarData`.
+
+```
+Layout:     flex items-center gap-5    (20px gap)
+Row height: 72px
+Avatar:     size="lg" (40px, rounded-[6px])
+Name:       text-sm font-semibold text-content-primary    (14px, weight 600)
+Subtitle:   text-content-secondary text-xs font-medium    (12px/16px, weight 500)
+Checked bg: bg-surface-secondary
+```
+
+### MultiUserSelect (member picker)
+
+Checkbox rows in a popover picker with avatars.
+
+```
+Layout:     flex items-center gap-3    (12px gap)
+Row:        flex min-h-[64px] items-center px-4 py-3
+Hover:      ring-1 ring-inset ring-border-secondary
+Checked bg: bg-surface-secondary
+Avatar:     size="lg" (40px, rounded-[6px])
+Name:       text-sm font-semibold text-content-primary    (14px, weight 600)
+Subtitle:   text-content-secondary text-xs font-medium    (12px/16px, weight 500)
+```
+
+### RoleSelector (permissions)
+
+Checkbox rows for role assignment in a scrollable container.
+
+```
+Layout:      flex items-start gap-2    (8px gap)
+Checkbox:    mt-1 shrink-0             (4px top margin for alignment)
+Container:   border border-border rounded-md p-3 flex flex-col gap-2
+             overflow-y-auto max-h-72
+Label:       text-sm font-medium       (14px/24px, weight 500)
+Description: text-sm text-content-secondary
+Non-assignable: cursor-not-allowed opacity-50
+```
+
+### Form checkboxes (settings, setup)
+
+Simple inline checkbox + label pairs.
+
+```
+Layout:     flex items-center gap-2    (8px gap)
+            or flex items-start gap-2
+Checkbox:   mt-0.5 (2px) for multi-line alignment
+Label:      text-sm font-medium
+```
+
+---
+
+## Behavior
+
+- **Click** toggles between unchecked and checked.
+- **Indeterminate** is a programmatic third state (e.g., parent group with
+  mixed children). Clicking an indeterminate checkbox resolves it per app
+  logic.
+- **Disabled** checkboxes use `cursor-not-allowed` and color changes rather
+  than opacity.
+- The checkbox must be **controlled** (pass `checked` prop) to support the
+  indeterminate state.
+
+---
+
+## Theme support
+
+All colors reference semantic tokens. The component renders correctly in
+both dark and light themes via CSS custom properties. No theme-specific
+logic exists in the component.

--- a/site/coder-kit/color.md
+++ b/site/coder-kit/color.md
@@ -1,0 +1,230 @@
+# Colors
+
+All color tokens are stored as HSL triplets (shadcn convention) so they compose with alpha:
+
+```css
+color: hsl(var(--content-primary));
+background: hsl(var(--surface-sky) / 0.5);   /* with alpha */
+```
+
+Dark is the default theme. Switch with `data-theme="light"` or class `light` on any ancestor.
+
+Source of truth: `site/src/index.css`
+
+---
+
+## Primitive Scales
+
+Raw color ramps imported from `site/src/theme/tailwindColors.ts`.
+Semantic tokens reference these indirectly. Avoid using primitives directly
+in UI code.
+
+### Zinc (neutral)
+
+The primary neutral scale. Includes a non-standard step 650.
+
+| Step | Hex       |
+|------|-----------|
+| 50   | `#fafafa` |
+| 100  | `#f4f4f5` |
+| 200  | `#e4e4e7` |
+| 300  | `#d4d4d8` |
+| 400  | `#a1a1aa` |
+| 500  | `#71717a` |
+| 600  | `#52525b` |
+| 650  | `#4b4b52` |
+| 700  | `#3f3f46` |
+| 800  | `#27272a` |
+| 900  | `#18181b` |
+| 950  | `#09090b` |
+
+### Blue (primary accent)
+
+Matches the standard Tailwind blue scale.
+
+| Step | Hex       |
+|------|-----------|
+| 50   | `#eff6ff` |
+| 100  | `#dbeafe` |
+| 200  | `#bfdbfe` |
+| 300  | `#93c5fd` |
+| 400  | `#60a5fa` |
+| 500  | `#3b82f6` |
+| 600  | `#2563eb` |
+| 700  | `#1d4ed8` |
+| 800  | `#1e40af` |
+| 900  | `#1e3a8a` |
+| 950  | `#172554` |
+
+All standard Tailwind color scales (slate, gray, neutral, stone, red,
+orange, amber, yellow, lime, green, emerald, teal, cyan, sky, indigo,
+violet, purple, fuchsia, pink, rose) are also available via
+`tailwindColors.ts`. The semantic tokens below for magenta and purple were
+defined directly as HSL values; no named primitive ramp exists for them.
+
+---
+
+## Content
+
+Text and icon foreground colors.
+
+| Token                   | Dark HSL         | Dark Hex  | Light HSL        | Light Hex | Usage                     |
+|-------------------------|------------------|-----------|------------------|-----------|---------------------------|
+| `--content-primary`     | `0 0% 100%`     | `#ffffff` | `240 10% 4%`    | `#09090b` | Default text              |
+| `--content-secondary`   | `240 5% 65%`    | `#a1a1aa` | `240 5% 34%`    | `#52525b` | Meta, labels, captions    |
+| `--content-link`        | `213 94% 68%`   | `#61a6fa` | `221 83% 53%`   | `#2463eb` | Links, focus rings        |
+| `--content-invert`      | `240 10% 4%`    | `#09090b` | `0 0% 98%`      | `#fafafa` | Text on inverted surfaces |
+| `--content-disabled`    | `240 5% 26%`    | `#3f3f46` | `240 5% 65%`    | `#a1a1aa` | Disabled text             |
+| `--content-success`     | `142 76% 36%`   | `#16a249` | `142 72% 29%`   | `#157f3c` | Running, success states   |
+| `--content-warning`     | `31 97% 72%`    | `#fdba72` | `27 96% 61%`    | `#fb923c` | Warnings                  |
+| `--content-destructive` | `0 91% 71%`     | `#f87272` | `0 84% 60%`     | `#ef4343` | Errors, failed states     |
+
+---
+
+## Surface
+
+Background fills for containers, cards, and tinted regions.
+
+| Token                        | Dark HSL          | Dark Hex  | Light HSL         | Light Hex | Usage                     |
+|------------------------------|-------------------|-----------|-------------------|-----------|---------------------------|
+| `--surface-primary`          | `240 10% 4%`     | `#09090b` | `0 0% 100%`      | `#ffffff` | Page background           |
+| `--surface-secondary`        | `240 6% 10%`     | `#18181b` | `240 5% 96%`     | `#f4f4f5` | Cards, sidebar            |
+| `--surface-tertiary`         | `240 4% 16%`     | `#27272a` | `240 6% 90%`     | `#e4e4e7` | Hover, active tab         |
+| `--surface-quaternary`       | `240 5% 26%`     | `#3f3f46` | `240 5% 84%`     | `#d4d4d8` | Selected, pressed         |
+| `--surface-invert-primary`   | `240 6% 90%`     | `#e4e4e7` | `240 4% 16%`     | `#27272a` | Inverted background       |
+| `--surface-invert-secondary` | `240 5% 65%`     | `#a1a1aa` | `240 5% 26%`     | `#3f3f46` | Inverted secondary        |
+| `--surface-destructive`      | `0 75% 15%`      | `#430a0a` | `0 93% 94%`      | `#fee1e1` | Error background          |
+| `--surface-green`            | `145 80% 10%`    | `#052e16` | `141 79% 85%`    | `#bbf7d0` | Success background        |
+| `--surface-grey`             | `240 6% 10%`     | `#18181b` | `240 5% 96%`     | `#f4f4f5` | Neutral tint              |
+| `--surface-orange`           | `13 81% 15%`     | `#451507` | `34 100% 92%`    | `#ffedd6` | Warning background        |
+| `--surface-sky`              | `196 67% 12%`    | `#0a2833` | `191 67% 89%`    | `#d0eff6` | Pending / info background |
+| `--surface-red`              | `0 75% 15%`      | `#430a0a` | `0 93% 94%`      | `#fee1e1` | Red tint (alias)          |
+| `--surface-purple`           | `268 68% 17%`    | `#290e49` | `259 100% 95%`   | `#eee5ff` | Purple tint               |
+| `--surface-magenta`          | `291 74% 15%`    | `#3a0a43` | `289 100% 98%`   | `#fdf5ff` | Magenta tint              |
+| `--surface-git-added`        | `145 80% 10%`    | `#052e16` | `141 84% 93%`    | `#defce9` | Diff addition background  |
+| `--surface-git-deleted`      | `0 75% 15%`      | `#430a0a` | `0 93% 94%`      | `#fee1e1` | Diff deletion background  |
+| `--surface-git-merged`       | `274 87% 21%`    | `#3c0764` | `269 100% 95%`   | `#f2e6ff` | Diff merge background     |
+
+---
+
+## Border
+
+Stroke colors for dividers, inputs, and status badges.
+
+| Token                  | Dark HSL               | Dark Hex  | Light HSL              | Light Hex | Usage                   |
+|------------------------|------------------------|-----------|------------------------|-----------|-------------------------|
+| `--border-default`     | `240 4% 16%`          | `#27272a` | `240 6% 90%`          | `#e4e4e7` | Default border          |
+| `--border-secondary`   | `240 5% 26%`          | `#3f3f46` | `240 5% 65%`          | `#a1a1aa` | Stronger / hover border |
+| `--border-success`     | `142 76% 36%`         | `#16a249` | `142 76% 36%`         | `#16a249` | Success badge outline   |
+| `--border-destructive` | `0 91% 71%`           | `#f87272` | `0 84% 60%`           | `#ef4343` | Error badge outline     |
+| `--border-warning`     | `30.66 97.16% 72.35%` | `#fdba74` | `30.66 97.16% 72.35%` | `#fdba74` | Warning badge outline   |
+| `--border-sky`         | `194 90% 62%`         | `#47cdf5` | `203 90% 40%`         | `#0a7bc2` | Pending / starting      |
+| `--border-green`       | `143 77% 87%`         | `#c4f7d8` | `138 82% 82%`         | `#abf7c2` | Green badge outline     |
+| `--border-purple`      | `255 92% 76%`         | `#a689fa` | `255 92% 76%`         | `#a689fa` | Purple badge outline    |
+| `--border-magenta`     | `292 100% 78%`        | `#f08fff` | `295 68% 46%`         | `#b826c5` | Magenta badge outline   |
+
+> **Note:** `--border-warning` currently uses the same value in both light
+> and dark themes. This is inconsistent with other border tokens that
+> differentiate by theme and may be a bug.
+
+---
+
+## Highlight
+
+High-contrast foreground colors used inside tinted badges and chips.
+Pair with the matching `--surface-*` token for accessible contrast.
+
+| Token                  | Dark HSL          | Dark Hex  | Light HSL         | Light Hex | Usage               |
+|------------------------|-------------------|-----------|-------------------|-----------|---------------------|
+| `--highlight-purple`   | `269 100% 74%`   | `#ba7aff` | `271 61% 35%`    | `#5b2390` | Purple badge text   |
+| `--highlight-green`    | `141 79% 85%`    | `#bbf7d0` | `143 64% 24%`    | `#166434` | Green badge text    |
+| `--highlight-orange`   | `31 100% 70%`    | `#ffb566` | `30 100% 32%`    | `#a35200` | Orange badge text   |
+| `--highlight-sky`      | `188 75% 80%`    | `#a6e8f2` | `195 61% 22%`    | `#16495a` | Sky / info badge text |
+| `--highlight-red`      | `0 91% 71%`      | `#f87272` | `0 74% 42%`      | `#ba1c1c` | Red badge text      |
+| `--highlight-magenta`  | `292 100% 78%`   | `#f08fff` | `295 68% 40%`    | `#a021ab` | Magenta badge text  |
+
+> **Known issue:** The Tailwind config references `highlight-grey` via
+> `hsl(var(--highlight-grey))`, but `--highlight-grey` is never defined
+> in `index.css`. Using `highlight-grey` utility classes produces invalid
+> CSS.
+
+### Badge pairing recipe
+
+Badges combine a `--highlight-*` foreground with a `--surface-*` background and a `--border-*` outline:
+
+| Badge   | Foreground           | Background         | Border                 | Usage                    |
+|---------|----------------------|--------------------|------------------------|--------------------------|
+| Sky     | `--highlight-sky`    | `--surface-sky`    | `--border-sky`         | Beta, pending, starting  |
+| Purple  | `--highlight-purple` | `--surface-purple` | `--border-purple`      | Enterprise, graphs       |
+| Red     | `--highlight-red`    | `--surface-red`    | `--border-destructive` | Errors, failed           |
+| Orange  | `--highlight-orange` | `--surface-orange` | `--border-warning`     | Warnings, build timeline |
+| Green   | `--highlight-green`  | `--surface-green`  | `--border-green`       | Success, running         |
+| Magenta | `--highlight-magenta`| `--surface-magenta`| `--border-magenta`     | Build timeline           |
+
+---
+
+## Overlay
+
+| Token               | Dark                | Light                | Usage          |
+|----------------------|---------------------|----------------------|----------------|
+| `--overlay-default`  | `240 10% 4% / 80%` | `240 5% 84% / 80%`  | Modal backdrop |
+
+Use with `hsla()`: `background: hsla(var(--overlay-default));`
+
+---
+
+## Syntax Highlighting
+
+Tokens for code blocks and inline code. Values differ between light and
+dark themes.
+
+| Token              | Dark HSL         | Dark Hex  | Light HSL        | Light Hex | Usage           |
+|--------------------|------------------|-----------|------------------|-----------|-----------------|
+| `--syntax-key`     | `201 98% 80%`   | `#9adbfe` | `211 95% 33%`   | `#0451a4` | Keywords        |
+| `--syntax-string`  | `18 47% 64%`    | `#ce9278` | `0 77% 36%`     | `#a21515` | String literals |
+| `--syntax-number`  | `100 28% 73%`   | `#b4cda7` | `158 88% 28%`   | `#098658` | Numbers         |
+| `--syntax-boolean` | `207 61% 59%`   | `#579dd6` | `240 100% 50%`  | `#0000ff` | Booleans        |
+
+---
+
+## Git Diff
+
+Foreground colors for diff indicators. Values differ between light and
+dark themes.
+
+| Token                  | Dark HSL         | Dark Hex  | Light HSL        | Light Hex | Usage           |
+|------------------------|------------------|-----------|------------------|-----------|-----------------|
+| `--git-added`          | `142 77% 73%`   | `#85efac` | `142 72% 29%`   | `#157f3c` | Additions       |
+| `--git-deleted`        | `0 94% 82%`     | `#fca6a6` | `0 74% 42%`     | `#ba1c1c` | Deletions       |
+| `--git-modified`       | `31 97% 72%`    | `#fdba72` | `17 88% 40%`    | `#c04a0c` | Modifications   |
+| `--git-merged`         | `271 91% 65%`   | `#a855f7` | `271 91% 65%`   | `#a855f7` | Merges          |
+| `--git-added-bright`   | `142 71% 45%`   | `#21c45d` | `142 72% 29%`   | `#157f3c` | Bright addition |
+| `--git-deleted-bright`  | `0 91% 71%`     | `#f87272` | `0 74% 42%`     | `#ba1c1c` | Bright deletion |
+| `--git-merged-bright`  | `270 95% 75%`   | `#bf7afc` | `272 72% 47%`   | `#7e22ce` | Bright merge    |
+
+> **Note:** `--git-merged` is the only git token with the same value in
+> both themes. All others differ.
+
+---
+
+## shadcn Aliases
+
+For compatibility with shadcn/ui components. These are defined using
+`var()` references so they resolve automatically per theme.
+
+| Alias                  | Maps to               |
+|------------------------|-----------------------|
+| `--background`         | `var(--surface-primary)` |
+| `--foreground`         | `var(--content-primary)` |
+| `--muted`              | `var(--surface-secondary)` |
+| `--muted-foreground`   | `var(--content-secondary)` |
+| `--primary`            | `var(--content-link)` |
+| `--primary-foreground` | `var(--surface-primary)` |
+
+These standalone shadcn tokens use raw HSL values (not references):
+
+| Token     | Dark HSL           | Light HSL         |
+|-----------|--------------------|-------------------|
+| `--border`| `240 3.7% 15.9%`  | `240 5.9% 90%`   |
+| `--input` | `240 3.7% 15.9%`  | `240 5.9% 90%`   |
+| `--ring`  | `240 4.9% 83.9%`  | `240 10% 3.9%`   |

--- a/site/coder-kit/index.md
+++ b/site/coder-kit/index.md
@@ -1,0 +1,118 @@
+# Coder Kit
+
+Coder Kit is Coder's design system. It documents the foundations, tokens,
+and components that make up the Coder UI.
+
+## Foundations
+
+| Topic | Description |
+|---|---|
+| [Color](./color.md) | Semantic color tokens for content, surfaces, borders, and highlights |
+| [Typography](./typography.md) | Font families, sizes, and weights |
+| [Spacing & Layout](./spacing.md) | Border radius, icon sizes, and layout primitives |
+| [Theming](./theming.md) | Light, dark, and colorblind-accessible theme variants |
+| [Icons](./icons.md) | Icon library and usage guidelines |
+
+## Tech Stack
+
+- **Component library:** [shadcn/ui](https://ui.shadcn.com/) (New York style)
+- **Styling:** [Tailwind CSS](https://tailwindcss.com/) with CSS custom properties
+- **Fonts:** Geist Variable (sans), Geist Mono Variable (mono)
+- **Icons:** [Lucide](https://lucide.dev/)
+- **Legacy layer:** MUI (being migrated to shadcn/ui + Tailwind)
+
+## Color System
+
+All colors are defined as HSL values in CSS custom properties and consumed
+through Tailwind utility classes. This allows opacity modifiers to work
+natively (e.g., `bg-surface-primary/50`).
+
+### Semantic Scales
+
+| Scale | Purpose | Examples |
+|---|---|---|
+| `content-*` | Text and icon foreground | `content-primary`, `content-link`, `content-destructive` |
+| `surface-*` | Backgrounds | `surface-primary`, `surface-secondary`, `surface-green` |
+| `border-*` | Borders and dividers | `border-default`, `border-success`, `border-destructive` |
+| `highlight-*` | Emphasis and accents | `highlight-purple`, `highlight-green`, `highlight-sky` |
+| `syntax-*` | Code syntax highlighting | `syntax-key`, `syntax-string`, `syntax-number` |
+| `git-*` | Version control status | `git-added`, `git-deleted`, `git-merged` |
+
+## Typography
+
+| Token | Size | Line Height | Weight |
+|---|---|---|---|
+| `text-2xs` | 0.625rem | 0.875rem | - |
+| `text-xs` | 0.75rem | 1rem | 500 |
+| `text-sm` | 0.875rem | 1.5rem | 500 |
+| `text-base` | 1rem | 1.5rem | 400 |
+| `text-3xl` | 2rem | 2.5rem | - |
+
+## Components
+
+Components live in `site/src/components/`. Each component has its own
+directory. Storybook stories serve as the primary documentation and test
+surface for all components.
+
+### Primitives
+
+Abbr, Alert, Avatar, Badge, Breadcrumb, Button, Calendar, Checkbox,
+Collapsible, Combobox, Command, ContextMenu, Dialog, DropdownMenu, Input,
+Kbd, Label, Link, Popover, RadioGroup, ScrollArea, Select, Separator,
+Skeleton, Slider, Spinner, Switch, Tabs, Textarea, Tooltip
+
+### Data Display
+
+Chart, CodeExample, CopyableValue, Logs, Markdown, Stats,
+StatusIndicator, StatusPill, SyntaxHighlighter, Table, Timeline
+
+### Forms & Input
+
+Autocomplete, DateRangePicker, DurationField, FileUpload, Filter, Form,
+FormField, IconField, InputGroup, MultiSelectCombobox, MultiUserSelect,
+PasswordField, RichParameterInput, Search, SearchField, SelectMenu,
+TagInput, UserAutocomplete, OrganizationAutocomplete
+
+### Layout
+
+EmptyState, Expander, FullPageForm, FullPageLayout, LinearProgress,
+Loader, Margins, Menu, OverflowY, PageHeader, PaginationWidget, Paywall,
+SettingsHeader, Sidebar, SignInLayout, Welcome
+
+### Feedback
+
+Dialogs, HelpPopover, InfoTooltip, Pill, Toaster
+
+## Theme Variants
+
+Coder ships six theme variants defined in `site/src/theme/`:
+
+| Variant | Directory |
+|---|---|
+| Light | `theme/light` |
+| Dark | `theme/dark` |
+| Dark Protanopia/Deuteranopia | `theme/darkProtanDeuter` |
+| Dark Tritanopia | `theme/darkTritan` |
+| Light Protanopia/Deuteranopia | `theme/lightProtanDeuter` |
+| Light Tritanopia | `theme/lightTritan` |
+
+## Directory Structure
+
+```
+site/coder-kit/
+  index.md          # This file
+  color.md          # Color tokens reference
+  typography.md     # Type scale and font usage
+  spacing.md        # Spacing, radius, and sizing tokens
+  theming.md        # Theme architecture and customization
+  icons.md          # Icon usage and guidelines
+```
+
+## Contributing
+
+When adding or changing design tokens:
+
+1. Update the CSS custom properties in `site/src/index.css`.
+2. Update the Tailwind config in `site/tailwind.config.js`.
+3. Update the relevant doc in this directory.
+4. Verify all six theme variants have consistent token coverage.


### PR DESCRIPTION
Adds the `site/coder-kit/` directory with an `index.md` to serve as the entry point for Coder Kit design system documentation.

The index covers:
- Semantic color scales (content, surface, border, highlight, syntax, git)
- Typography tokens
- Component inventory grouped by category (primitives, data display, forms, layout, feedback)
- Theme variants (light/dark + colorblind-accessible)
- Tech stack overview (shadcn/ui, Tailwind, Geist, Lucide)
- Planned directory structure for future pages

> Generated by Coder Agents on behalf of @tracyjohnsonux