### PR TITLE
feat(site): add template access warnings to workspace sharing

### DIFF
--- a/site/src/modules/workspaces/WorkspaceSharingForm/WorkspaceSharingForm.stories.tsx
+++ b/site/src/modules/workspaces/WorkspaceSharingForm/WorkspaceSharingForm.stories.tsx
@@ -1,0 +1,112 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { TemplateACL, WorkspaceACL } from "#/api/typesGenerated";
+import {
+	MockGroup,
+	MockGroup2,
+	MockOrganization,
+	MockTemplateACL,
+	MockUserMember,
+	MockUserOwner,
+} from "#/testHelpers/entities";
+import { WorkspaceSharingForm } from "./WorkspaceSharingForm";
+
+const mockWorkspaceACL: WorkspaceACL = {
+	users: [
+		{ ...MockUserOwner, role: "admin" },
+		{ ...MockUserMember, role: "use" },
+	],
+	group: [{ ...MockGroup, role: "use" }],
+};
+
+const meta: Meta<typeof WorkspaceSharingForm> = {
+	title: "modules/workspaces/WorkspaceSharingForm",
+	component: WorkspaceSharingForm,
+	args: {
+		organizationId: MockOrganization.id,
+		canUpdatePermissions: true,
+		error: undefined,
+		updatingUserId: undefined,
+		updatingGroupId: undefined,
+		onUpdateUser: () => {},
+		onRemoveUser: () => {},
+		onUpdateGroup: () => {},
+		onRemoveGroup: () => {},
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof WorkspaceSharingForm>;
+
+export const Empty: Story = {
+	args: {
+		workspaceACL: { users: [], group: [] },
+		templateACL: MockTemplateACL,
+	},
+};
+
+export const WithMembers: Story = {
+	args: {
+		workspaceACL: mockWorkspaceACL,
+		templateACL: MockTemplateACL,
+	},
+};
+
+// The template's ACL includes the "everyone" group (org ID), so all members
+// have access and no warnings are shown.
+export const AllMembersHaveTemplateAccess: Story = {
+	args: {
+		workspaceACL: mockWorkspaceACL,
+		templateACL: MockTemplateACL,
+	},
+};
+
+// The template is restricted: only specific users/groups in its ACL can
+// access it. Members not in the template ACL see a warning icon and a
+// summary alert appears above the table.
+export const SomeMembersLackTemplateAccess: Story = {
+	args: {
+		workspaceACL: {
+			users: [
+				{ ...MockUserOwner, role: "admin" },
+				{ ...MockUserMember, role: "use" },
+			],
+			group: [
+				{ ...MockGroup, role: "use" },
+				{ ...MockGroup2, role: "use" },
+			],
+		},
+		// Restricted template: no "everyone" group, only MockUserOwner and
+		// MockGroup have access. MockUserMember and MockGroup2 lack access.
+		templateACL: {
+			users: [{ ...MockUserOwner, role: "use" }],
+			group: [{ ...MockGroup, role: "use" }],
+		} satisfies TemplateACL,
+	},
+};
+
+// When template ACL is undefined (still loading or the caller lacks
+// permission to read it), no warnings are shown.
+export const TemplateACLUnavailable: Story = {
+	args: {
+		workspaceACL: mockWorkspaceACL,
+		templateACL: undefined,
+	},
+};
+
+// Compact variant used in the share popover.
+export const CompactWithWarnings: Story = {
+	args: {
+		isCompact: true,
+		workspaceACL: {
+			users: [
+				{ ...MockUserOwner, role: "admin" },
+				{ ...MockUserMember, role: "use" },
+			],
+			group: [{ ...MockGroup, role: "use" }],
+		},
+		templateACL: {
+			users: [{ ...MockUserOwner, role: "use" }],
+			group: [],
+		} satisfies TemplateACL,
+	},
+};

--- a/site/src/modules/workspaces/WorkspaceSharingForm/WorkspaceSharingForm.tsx
+++ b/site/src/modules/workspaces/WorkspaceSharingForm/WorkspaceSharingForm.tsx
@@ -1,9 +1,14 @@
-import { EllipsisVerticalIcon, UserPlusIcon } from "lucide-react";
+import {
+	EllipsisVerticalIcon,
+	TriangleAlertIcon,
+	UserPlusIcon,
+} from "lucide-react";
 import type { FC, ReactNode } from "react";
 import { useQuery } from "react-query";
 import { workspaceSharingSettings } from "#/api/queries/organizations";
 import type {
 	Group,
+	TemplateACL,
 	WorkspaceACL,
 	WorkspaceGroup,
 	WorkspaceRole,
@@ -38,7 +43,62 @@ import {
 	TableRow,
 } from "#/components/Table/Table";
 import { TableLoader } from "#/components/TableLoader/TableLoader";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "#/components/Tooltip/Tooltip";
 import { getGroupSubtitle } from "#/modules/groups";
+
+/**
+ * Checks whether a user or group has access to a template based on its ACL.
+ * Returns true (assumes access) when template ACL data is unavailable.
+ */
+function hasTemplateAccess(
+	entityId: string,
+	entityType: "user" | "group",
+	tplACL: TemplateACL | undefined,
+	organizationId: string,
+): boolean {
+	// No template ACL data available (still loading, or the caller lacks
+	// permission to read it). Assume access so we do not show false warnings.
+	if (!tplACL) {
+		return true;
+	}
+
+	// The "everyone" group has the same ID as the organization. When it
+	// appears in the template's group ACL, every org member has access.
+	const everyoneHasAccess = tplACL.group.some((g) => g.id === organizationId);
+	if (everyoneHasAccess) {
+		return true;
+	}
+
+	if (entityType === "group") {
+		return tplACL.group.some((g) => g.id === entityId);
+	}
+
+	// For users, check direct user ACL. This does not cover indirect access
+	// through group membership; the warning text accounts for that.
+	return tplACL.users.some((u) => u.id === entityId);
+}
+
+const NoTemplateAccessIcon: FC = () => {
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<TriangleAlertIcon
+					className="size-4 text-content-warning shrink-0"
+					aria-label="No template access"
+				/>
+			</TooltipTrigger>
+			<TooltipContent className="max-w-xs">
+				This member may not have access to this workspace's template. They will
+				not be able to view or use this workspace until a template admin grants
+				them access.
+			</TooltipContent>
+		</Tooltip>
+	);
+};
 
 interface RoleSelectProps {
 	value: WorkspaceRole;
@@ -143,6 +203,7 @@ export const RoleSelectField: FC<RoleSelectFieldProps> = ({
 interface WorkspaceSharingFormProps {
 	organizationId: string;
 	workspaceACL: WorkspaceACL | undefined;
+	templateACL?: TemplateACL;
 	canUpdatePermissions: boolean;
 	error: unknown;
 	onUpdateUser: (user: WorkspaceUser, role: WorkspaceRole) => void;
@@ -159,6 +220,7 @@ interface WorkspaceSharingFormProps {
 export const WorkspaceSharingForm: FC<WorkspaceSharingFormProps> = ({
 	organizationId,
 	workspaceACL,
+	templateACL,
 	canUpdatePermissions,
 	error,
 	updatingUserId,
@@ -217,6 +279,23 @@ export const WorkspaceSharingForm: FC<WorkspaceSharingFormProps> = ({
 			workspaceACL.group.length === 0,
 	);
 
+	// Determine which members lack template access so we can show warnings.
+	const usersWithoutAccess = workspaceACL
+		? workspaceACL.users.filter(
+				(u) => !hasTemplateAccess(u.id, "user", templateACL, organizationId),
+			)
+		: [];
+	const groupsWithoutAccess = workspaceACL
+		? workspaceACL.group.filter(
+				(g) => !hasTemplateAccess(g.id, "group", templateACL, organizationId),
+			)
+		: [];
+	const hasAccessWarnings =
+		usersWithoutAccess.length > 0 || groupsWithoutAccess.length > 0;
+
+	const userLacksAccess = new Set(usersWithoutAccess.map((u) => u.id));
+	const groupLacksAccess = new Set(groupsWithoutAccess.map((g) => g.id));
+
 	const tableHeader = (
 		<TableHeader>
 			<TableRow>
@@ -246,17 +325,20 @@ export const WorkspaceSharingForm: FC<WorkspaceSharingFormProps> = ({
 					{workspaceACL.group.map((group) => (
 						<TableRow key={group.id}>
 							<TableCell className="py-2 w-[50%]">
-								<AvatarData
-									avatar={
-										<Avatar
-											size="lg"
-											fallback={group.display_name || group.name}
-											src={group.avatar_url}
-										/>
-									}
-									title={group.display_name || group.name}
-									subtitle={getGroupSubtitle(group)}
-								/>
+								<div className="flex items-center gap-2">
+									<AvatarData
+										avatar={
+											<Avatar
+												size="lg"
+												fallback={group.display_name || group.name}
+												src={group.avatar_url}
+											/>
+										}
+										title={group.display_name || group.name}
+										subtitle={getGroupSubtitle(group)}
+									/>
+									{groupLacksAccess.has(group.id) && <NoTemplateAccessIcon />}
+								</div>
 							</TableCell>
 							<TableCell className="py-2 w-[40%]">
 								{canUpdatePermissions ? (
@@ -300,11 +382,14 @@ export const WorkspaceSharingForm: FC<WorkspaceSharingFormProps> = ({
 					{workspaceACL.users.map((user) => (
 						<TableRow key={user.id}>
 							<TableCell className="py-2 w-[50%]">
-								<AvatarData
-									title={user.username}
-									subtitle={user.name}
-									src={user.avatar_url}
-								/>
+								<div className="flex items-center gap-2">
+									<AvatarData
+										title={user.username}
+										subtitle={user.name}
+										src={user.avatar_url}
+									/>
+									{userLacksAccess.has(user.id) && <NoTemplateAccessIcon />}
+								</div>
 							</TableCell>
 							<TableCell className="py-2 w-[40%]">
 								{canUpdatePermissions ? (
@@ -349,6 +434,18 @@ export const WorkspaceSharingForm: FC<WorkspaceSharingFormProps> = ({
 		</TableBody>
 	);
 
+	const warnings = (
+		<>
+			{hasAccessWarnings && (
+				<Alert severity="warning">
+					Some shared members may not have access to this workspace's template
+					and will not be able to view or use this workspace until a template
+					admin grants them access.
+				</Alert>
+			)}
+		</>
+	);
+
 	if (isCompact) {
 		return (
 			<div className="flex flex-col gap-4">
@@ -359,6 +456,7 @@ export const WorkspaceSharingForm: FC<WorkspaceSharingFormProps> = ({
 						Workspace restart required for the removal to take effect.
 					</Alert>
 				)}
+				{warnings}
 				<div>
 					<Table>{tableHeader}</Table>
 					<div className="max-h-60 overflow-y-auto">
@@ -378,6 +476,7 @@ export const WorkspaceSharingForm: FC<WorkspaceSharingFormProps> = ({
 					Workspace restart required for the removal to take effect.
 				</Alert>
 			)}
+			{warnings}
 			<Table>
 				{tableHeader}
 				{tableBody}

--- a/site/src/modules/workspaces/WorkspaceSharingForm/useWorkspaceSharing.ts
+++ b/site/src/modules/workspaces/WorkspaceSharingForm/useWorkspaceSharing.ts
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
 import { toast } from "sonner";
+import { templateACL as templateACLQuery } from "#/api/queries/templates";
 import {
 	setWorkspaceGroupRole,
 	setWorkspaceUserRole,
@@ -24,6 +25,14 @@ export function useWorkspaceSharing(workspace: Workspace) {
 	const [hasRemovedMember, setHasRemovedMember] = useState(false);
 
 	const workspaceACLQuery = useQuery(workspaceACL(workspace.id));
+
+	// Fetch template ACL to determine if shared users/groups can actually
+	// access the workspace's template. If this query fails (e.g. the caller
+	// lacks permission to read template ACLs), warnings are silently skipped.
+	const templateACLResult = useQuery({
+		...templateACLQuery(workspace.template_id),
+		retry: false,
+	});
 
 	const addUserMutation = useMutation(setWorkspaceUserRole(queryClient));
 	const updateUserMutation = useMutation(setWorkspaceUserRole(queryClient));
@@ -113,6 +122,7 @@ export function useWorkspaceSharing(workspace: Workspace) {
 
 	return {
 		workspaceACL: workspaceACLQuery.data,
+		templateACL: templateACLResult.data,
 		isLoading: workspaceACLQuery.isLoading,
 		error: workspaceACLQuery.error,
 		mutationError,

--- a/site/src/pages/WorkspacePage/WorkspaceActions/ShareButton.tsx
+++ b/site/src/pages/WorkspacePage/WorkspaceActions/ShareButton.tsx
@@ -40,6 +40,7 @@ export const ShareButton: FC<ShareButtonProps> = ({
 				<WorkspaceSharingForm
 					organizationId={workspace.organization_id}
 					workspaceACL={sharing.workspaceACL}
+					templateACL={sharing.templateACL}
 					canUpdatePermissions={canUpdatePermissions}
 					error={sharing.error ?? sharing.mutationError}
 					updatingUserId={sharing.updatingUserId}

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSharingPage/WorkspaceSharingPage.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSharingPage/WorkspaceSharingPage.tsx
@@ -42,6 +42,7 @@ const WorkspaceSharingPage: FC = () => {
 			<WorkspaceSharingPageView
 				workspace={workspace}
 				workspaceACL={sharing.workspaceACL}
+				templateACL={sharing.templateACL}
 				canUpdatePermissions={canUpdatePermissions}
 				error={error}
 				onAddUser={sharing.addUser}

--- a/site/src/pages/WorkspaceSettingsPage/WorkspaceSharingPage/WorkspaceSharingPageView.tsx
+++ b/site/src/pages/WorkspaceSettingsPage/WorkspaceSharingPage/WorkspaceSharingPageView.tsx
@@ -1,6 +1,7 @@
 import type { FC } from "react";
 import type {
 	Group,
+	TemplateACL,
 	Workspace,
 	WorkspaceACL,
 	WorkspaceGroup,
@@ -14,6 +15,7 @@ import { WorkspaceSharingForm } from "#/modules/workspaces/WorkspaceSharingForm/
 interface WorkspaceSharingPageViewProps {
 	workspace: Workspace;
 	workspaceACL: WorkspaceACL | undefined;
+	templateACL?: TemplateACL;
 	canUpdatePermissions: boolean;
 	error: unknown;
 	onAddUser: (
@@ -36,6 +38,7 @@ interface WorkspaceSharingPageViewProps {
 export const WorkspaceSharingPageView: FC<WorkspaceSharingPageViewProps> = ({
 	workspace,
 	workspaceACL,
+	templateACL,
 	canUpdatePermissions,
 	error,
 	onAddUser,
@@ -54,6 +57,7 @@ export const WorkspaceSharingPageView: FC<WorkspaceSharingPageViewProps> = ({
 		<WorkspaceSharingForm
 			organizationId={workspace.organization_id}
 			workspaceACL={workspaceACL}
+			templateACL={templateACL}
 			canUpdatePermissions={canUpdatePermissions}
 			error={error}
 			updatingUserId={updatingUserId}


### PR DESCRIPTION
When adding users or groups to workspace sharing, the UI now warns if members may not have access to the workspace's template. This prevents the confusing situation where a user is shared on a workspace but cannot see it because they lack template access.

The frontend fetches the template ACL via `templateACL(workspace.template_id)` and cross-references it with the workspace ACL members. A warning icon with tooltip appears next to each member who may lack template access, and a summary alert is shown above the member list when any warnings exist.

If the template ACL query fails (e.g. insufficient permissions), no warnings are shown to avoid false positives.

Relates to #25338

<details>
<summary>Implementation details</summary>

### Changes

- **`useWorkspaceSharing.ts`**: Added `templateACL` query with `retry: false` to gracefully handle permission errors
- **`WorkspaceSharingForm.tsx`**: Added `templateACL` prop, `hasTemplateAccess()` helper, `NoTemplateAccessIcon` component with tooltip, summary `Alert`, and per-row warning icons
- **`ShareButton.tsx`**, **`WorkspaceSharingPage.tsx`**, **`WorkspaceSharingPageView.tsx`**: Pass `templateACL` through to `WorkspaceSharingForm`
- **`WorkspaceSharingForm.stories.tsx`**: New Storybook stories for all warning states

### Access check logic

1. If the "everyone" group (org ID == group ID) is in the template's group ACL, all org members have access; no warnings shown
2. If the template is restricted, each workspace ACL member is checked against the template's user/group ACL
3. User-level check does not cover indirect access through group membership; the warning text uses "may not have access" language to account for this

</details>

> 🤖 Generated with [Coder Agents](https://coder.com/agents)