### PR TITLE
feat: surface missing coder_secret requirements with a dialog on workspace update

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -12344,6 +12344,18 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/codersdk.WorkspaceBuild"
                         }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.WorkspaceBuildErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/codersdk.WorkspaceBuildErrorResponse"
+                        }
                     }
                 },
                 "security": [
@@ -25233,6 +25245,23 @@ const docTemplate = `{
                 }
             }
         },
+        "codersdk.WorkspaceBuildErrorResponse": {
+            "type": "object",
+            "properties": {
+                "detail": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "validations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/codersdk.WorkspaceBuildValidationError"
+                    }
+                }
+            }
+        },
         "codersdk.WorkspaceBuildParameter": {
             "type": "object",
             "properties": {
@@ -25267,6 +25296,35 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "codersdk.WorkspaceBuildValidationError": {
+            "type": "object",
+            "required": [
+                "detail",
+                "field"
+            ],
+            "properties": {
+                "detail": {
+                    "type": "string"
+                },
+                "field": {
+                    "type": "string"
+                },
+                "kind": {
+                    "$ref": "#/definitions/codersdk.WorkspaceBuildValidationErrorKind"
+                }
+            }
+        },
+        "codersdk.WorkspaceBuildValidationErrorKind": {
+            "type": "string",
+            "enum": [
+                "missing_secret_env",
+                "missing_secret_file"
+            ],
+            "x-enum-varnames": [
+                "WorkspaceBuildValidationErrorKindMissingSecretEnv",
+                "WorkspaceBuildValidationErrorKindMissingSecretFile"
+            ]
         },
         "codersdk.WorkspaceConnectionLatencyMS": {
             "type": "object",

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -10954,6 +10954,18 @@
 						"schema": {
 							"$ref": "#/definitions/codersdk.WorkspaceBuild"
 						}
+					},
+					"400": {
+						"description": "Bad Request",
+						"schema": {
+							"$ref": "#/definitions/codersdk.WorkspaceBuildErrorResponse"
+						}
+					},
+					"409": {
+						"description": "Conflict",
+						"schema": {
+							"$ref": "#/definitions/codersdk.WorkspaceBuildErrorResponse"
+						}
 					}
 				},
 				"security": [
@@ -23263,6 +23275,23 @@
 				}
 			}
 		},
+		"codersdk.WorkspaceBuildErrorResponse": {
+			"type": "object",
+			"properties": {
+				"detail": {
+					"type": "string"
+				},
+				"message": {
+					"type": "string"
+				},
+				"validations": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/codersdk.WorkspaceBuildValidationError"
+					}
+				}
+			}
+		},
 		"codersdk.WorkspaceBuildParameter": {
 			"type": "object",
 			"properties": {
@@ -23297,6 +23326,29 @@
 					}
 				}
 			}
+		},
+		"codersdk.WorkspaceBuildValidationError": {
+			"type": "object",
+			"required": ["detail", "field"],
+			"properties": {
+				"detail": {
+					"type": "string"
+				},
+				"field": {
+					"type": "string"
+				},
+				"kind": {
+					"$ref": "#/definitions/codersdk.WorkspaceBuildValidationErrorKind"
+				}
+			}
+		},
+		"codersdk.WorkspaceBuildValidationErrorKind": {
+			"type": "string",
+			"enum": ["missing_secret_env", "missing_secret_file"],
+			"x-enum-varnames": [
+				"WorkspaceBuildValidationErrorKindMissingSecretEnv",
+				"WorkspaceBuildValidationErrorKindMissingSecretFile"
+			]
 		},
 		"codersdk.WorkspaceConnectionLatencyMS": {
 			"type": "object",

--- a/coderd/dynamicparameters/error.go
+++ b/coderd/dynamicparameters/error.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 
 	"github.com/coder/coder/v2/codersdk"
+	previewtypes "github.com/coder/preview/types"
 )
 
 func parameterValidationError(diags hcl.Diagnostics) *DiagnosticError {
@@ -40,8 +41,11 @@ type DiagnosticError struct {
 	// Diagnostics are top level diagnostics that will be returned as "Detail" in the response.
 	Diagnostics hcl.Diagnostics
 	// KeyedDiagnostics translate to Validation errors in the response. A key could
-	// be a parameter name, or a tag name. This allows diagnostics to be more closely
-	// associated with a specific index/parameter/tag.
+	// be a parameter name, a tag name, or the env / file name of a missing
+	// coder_secret requirement. The diagnostic's Extra carries a
+	// previewtypes.DiagnosticExtra whose Code is propagated to the
+	// resulting WorkspaceBuildValidationError.Kind when known by
+	// BuildResponse.
 	KeyedDiagnostics map[string]hcl.Diagnostics
 }
 
@@ -83,20 +87,18 @@ func (e *DiagnosticError) Extend(key string, diag hcl.Diagnostics) {
 	e.KeyedDiagnostics[key] = e.KeyedDiagnostics[key].Extend(diag)
 }
 
+// Response is the generic SDK response that consumers outside the
+// workspace build endpoints rely on (tag validation, preset validation,
+// chatd diagnostic introspection, etc.). It does not carry per-entry
+// kind information; callers that need to distinguish between parameter
+// failures and missing coder_secret requirements use BuildResponse.
 func (e *DiagnosticError) Response() (int, codersdk.Response) {
 	resp := codersdk.Response{
 		Message:     e.Message,
 		Validations: nil,
 	}
 
-	// Sort the parameter names so that the order is consistent.
-	sortedNames := make([]string, 0, len(e.KeyedDiagnostics))
-	for name := range e.KeyedDiagnostics {
-		sortedNames = append(sortedNames, name)
-	}
-	slices.Sort(sortedNames)
-
-	for _, name := range sortedNames {
+	for _, name := range e.sortedKeyedDiagnosticNames() {
 		diag := e.KeyedDiagnostics[name]
 		resp.Validations = append(resp.Validations, codersdk.ValidationError{
 			Field:  name,
@@ -109,6 +111,76 @@ func (e *DiagnosticError) Response() (int, codersdk.Response) {
 	}
 
 	return http.StatusBadRequest, resp
+}
+
+// BuildResponse emits the kinded envelope used by workspace build
+// endpoints. Each keyed diagnostic group is translated to a
+// WorkspaceBuildValidationError whose Kind is derived from the first
+// error-severity diagnostic's previewtypes.DiagnosticExtra code, when
+// known. Top-level diagnostics flow into the response Detail.
+func (e *DiagnosticError) BuildResponse() (int, codersdk.WorkspaceBuildErrorResponse) {
+	resp := codersdk.WorkspaceBuildErrorResponse{
+		Message: e.Message,
+	}
+
+	for _, name := range e.sortedKeyedDiagnosticNames() {
+		diag := e.KeyedDiagnostics[name]
+		resp.Validations = append(resp.Validations, codersdk.WorkspaceBuildValidationError{
+			Field:  name,
+			Detail: DiagnosticsErrorString(diag),
+			Kind:   keyedDiagnosticsKind(diag),
+		})
+	}
+
+	if e.Diagnostics.HasErrors() {
+		resp.Detail = DiagnosticsErrorString(e.Diagnostics)
+	}
+
+	return http.StatusBadRequest, resp
+}
+
+// sortedKeyedDiagnosticNames returns the keys of KeyedDiagnostics in a
+// stable order so that Response and BuildResponse emit entries
+// deterministically.
+func (e *DiagnosticError) sortedKeyedDiagnosticNames() []string {
+	sorted := make([]string, 0, len(e.KeyedDiagnostics))
+	for name := range e.KeyedDiagnostics {
+		sorted = append(sorted, name)
+	}
+	slices.Sort(sorted)
+	return sorted
+}
+
+// keyedDiagnosticsKind iterates the given diagnostics in slice order
+// and returns the WorkspaceBuildValidationErrorKind for the first
+// error-severity diagnostic whose previewtypes.DiagnosticExtra code
+// matches a known missing-secret code. Diagnostics whose severity is
+// not hcl.DiagError, and error-severity diagnostics whose Extra code
+// is unknown, are skipped. The empty kind is returned when no
+// diagnostic in the group carries a known code, which is the default
+// for parameter validation entries.
+//
+// Callers must not insert diagnostics with mixed codes under a single
+// key. Today every keyed group comes from exactly one producer
+// (appendMissingSecretDiagnostic for missing-secret groups,
+// parameter-validation paths for everything else), so the
+// "first known code wins" rule is unambiguous; a future producer
+// that mixes sources under one key would need to revisit this
+// contract.
+func keyedDiagnosticsKind(diags hcl.Diagnostics) codersdk.WorkspaceBuildValidationErrorKind {
+	for _, d := range diags {
+		if d.Severity != hcl.DiagError {
+			continue
+		}
+		extra := previewtypes.ExtractDiagnosticExtra(d)
+		switch extra.Code {
+		case DiagCodeMissingSecretEnv:
+			return codersdk.WorkspaceBuildValidationErrorKindMissingSecretEnv
+		case DiagCodeMissingSecretFile:
+			return codersdk.WorkspaceBuildValidationErrorKindMissingSecretFile
+		}
+	}
+	return ""
 }
 
 func DiagnosticErrorString(d *hcl.Diagnostic) string {

--- a/coderd/dynamicparameters/error_internal_test.go
+++ b/coderd/dynamicparameters/error_internal_test.go
@@ -1,0 +1,133 @@
+package dynamicparameters
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/coder/v2/codersdk"
+	previewtypes "github.com/coder/preview/types"
+)
+
+func TestDiagnosticErrorResponse(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ParameterValidationOnly", func(t *testing.T) {
+		t.Parallel()
+
+		de := parameterValidationError(nil)
+		de.Append("region", &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "region is required",
+		})
+
+		status, resp := de.Response()
+		require.Equal(t, http.StatusBadRequest, status)
+		require.Len(t, resp.Validations, 1)
+		require.Equal(t, "region", resp.Validations[0].Field)
+	})
+
+	t.Run("HasErrorWithOnlyMissingSecrets", func(t *testing.T) {
+		t.Parallel()
+
+		// A call site that adds only missing-secret diagnostics must
+		// still be recognized as a real error so the caller does not
+		// proceed past the validation gate.
+		de := parameterValidationError(nil)
+		de.Append("GITHUB_TOKEN", &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Missing required secret",
+			Extra:    previewtypes.DiagnosticExtra{Code: DiagCodeMissingSecretEnv},
+		})
+		require.True(t, de.HasError())
+	})
+}
+
+// TestDiagnosticErrorBuildResponse covers the kinded envelope used by
+// workspace build endpoints. Generic consumers route through Response;
+// only WriteWorkspaceBuildError calls BuildResponse, which propagates
+// the per-validation Kind so the frontend can branch.
+func TestDiagnosticErrorBuildResponse(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ParameterValidationLeavesKindEmpty", func(t *testing.T) {
+		t.Parallel()
+
+		de := parameterValidationError(nil)
+		de.Append("region", &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "region is required",
+		})
+
+		status, resp := de.BuildResponse()
+		require.Equal(t, http.StatusBadRequest, status)
+		require.Len(t, resp.Validations, 1)
+		require.Equal(t, "region", resp.Validations[0].Field)
+		require.Empty(t, resp.Validations[0].Kind,
+			"parameter validation must leave Kind empty for backward compatibility")
+	})
+
+	t.Run("MissingSecretsTranslatedToValidationEntries", func(t *testing.T) {
+		t.Parallel()
+
+		de := parameterValidationError(nil)
+		de.Append("GITHUB_TOKEN", &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Missing required secret",
+			Detail:   "env GITHUB_TOKEN: Create a PAT with env=GITHUB_TOKEN",
+			Extra:    previewtypes.DiagnosticExtra{Code: DiagCodeMissingSecretEnv},
+		})
+		de.Append("/run/secrets/aws", &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Missing required secret",
+			Detail:   "file /run/secrets/aws: Mount AWS credentials",
+			Extra:    previewtypes.DiagnosticExtra{Code: DiagCodeMissingSecretFile},
+		})
+
+		_, resp := de.BuildResponse()
+		require.Len(t, resp.Validations, 2)
+
+		// KeyedDiagnostics are sorted by field name. "/run/secrets/aws"
+		// sorts before "GITHUB_TOKEN" because '/' < 'G' in ASCII.
+		fileEntry := resp.Validations[0]
+		require.Equal(t, "/run/secrets/aws", fileEntry.Field)
+		require.Equal(t, codersdk.WorkspaceBuildValidationErrorKindMissingSecretFile, fileEntry.Kind)
+		require.Contains(t, fileEntry.Detail, "Mount AWS credentials")
+
+		envEntry := resp.Validations[1]
+		require.Equal(t, "GITHUB_TOKEN", envEntry.Field)
+		require.Equal(t, codersdk.WorkspaceBuildValidationErrorKindMissingSecretEnv, envEntry.Kind)
+		require.Contains(t, envEntry.Detail, "Create a PAT with env=GITHUB_TOKEN")
+	})
+
+	t.Run("ParametersAndSecretsCoexist", func(t *testing.T) {
+		t.Parallel()
+
+		// A response that mixes parameter validations and missing
+		// secrets must carry the correct Kind per entry so consumers
+		// can route each one to the appropriate UX.
+		de := parameterValidationError(nil)
+		de.Append("region", &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "region is required",
+		})
+		de.Append("GITHUB_TOKEN", &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Missing required secret",
+			Detail:   "env GITHUB_TOKEN: Create a PAT",
+			Extra:    previewtypes.DiagnosticExtra{Code: DiagCodeMissingSecretEnv},
+		})
+
+		_, resp := de.BuildResponse()
+		require.Len(t, resp.Validations, 2)
+
+		// Entries are sorted by field name. "GITHUB_TOKEN" < "region".
+		require.Equal(t, "GITHUB_TOKEN", resp.Validations[0].Field)
+		require.Equal(t, codersdk.WorkspaceBuildValidationErrorKindMissingSecretEnv,
+			resp.Validations[0].Kind)
+		require.Equal(t, "region", resp.Validations[1].Field)
+		require.Empty(t, resp.Validations[1].Kind)
+	})
+}

--- a/coderd/dynamicparameters/render.go
+++ b/coderd/dynamicparameters/render.go
@@ -62,11 +62,24 @@ func IncludeSecretRequirements() RenderOption {
 }
 
 // Diagnostic extra codes for secret-requirement validation.
+// The missing-secret codes are bound to the codersdk wire enum so the
+// values cannot drift; the apidoc/swagger pipeline and the frontend
+// router both read the wire form, and the resolver's diagnostic
+// Extra.Code field is consumed by keyedDiagnosticsKind in error.go to
+// translate back into the same enum.
 const (
-	DiagCodeMissingSecret             = "missing_secret"
+	DiagCodeMissingSecretEnv          = string(codersdk.WorkspaceBuildValidationErrorKindMissingSecretEnv)
+	DiagCodeMissingSecretFile         = string(codersdk.WorkspaceBuildValidationErrorKindMissingSecretFile)
 	DiagCodeOwnerSecretsFetchFailed   = "owner_secrets_fetch_failed"
 	DiagCodeSecretValidationForbidden = "secret_validation_forbidden"
 )
+
+// isMissingSecretDiagCode returns true when the given diagnostic code
+// identifies one of the per-secret missing-requirement diagnostics that
+// the resolver synthesizes for each unsatisfied coder_secret.
+func isMissingSecretDiagCode(code string) bool {
+	return code == DiagCodeMissingSecretEnv || code == DiagCodeMissingSecretFile
+}
 
 // loader is used to load the necessary coder objects for rendering a template
 // version's parameters. The output is a Renderer, which is the object that uses

--- a/coderd/dynamicparameters/render_internal_test.go
+++ b/coderd/dynamicparameters/render_internal_test.go
@@ -387,7 +387,8 @@ func TestDynamicRender_NonOwnerCannotLeakSecretRequirements(t *testing.T) {
 func requireNoMissingSecret(t *testing.T, diags hcl.Diagnostics) {
 	t.Helper()
 	for _, d := range diags {
-		if extra, ok := d.Extra.(previewtypes.DiagnosticExtra); ok && extra.Code == DiagCodeMissingSecret {
+		extra := previewtypes.ExtractDiagnosticExtra(d)
+		if isMissingSecretDiagCode(extra.Code) {
 			t.Fatalf("unexpected missing_secret diagnostic: %s", d.Detail)
 		}
 	}

--- a/coderd/dynamicparameters/resolver.go
+++ b/coderd/dynamicparameters/resolver.go
@@ -133,26 +133,42 @@ func ResolveParameters(
 		renderOpts = append(renderOpts, IncludeSecretRequirements())
 	}
 	result, diags = renderer.Render(ctx, ownerID, values.ValuesMap(), renderOpts...)
-	if !o.skipSecretRequirements && !diags.HasErrors() {
-		var missing []codersdk.SecretRequirementStatus
-		for _, req := range result.SecretRequirements {
-			if !req.Satisfied {
-				missing = append(missing, req)
-			}
-		}
-		if len(missing) > 0 {
-			diags = append(diags, &hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Missing required secrets",
-				Detail:   formatMissingSecrets(missing),
-				Extra: previewtypes.DiagnosticExtra{
-					Code: DiagCodeMissingSecret,
-				},
-			})
-		}
-	}
 	if diags.HasErrors() {
 		return nil, parameterValidationError(diags)
+	}
+	if !o.skipSecretRequirements {
+		secretsErr := &DiagnosticError{
+			Message:          "Missing required secrets",
+			KeyedDiagnostics: make(map[string]hcl.Diagnostics),
+		}
+		var envCount, fileCount int
+		for _, req := range result.SecretRequirements {
+			if req.Satisfied {
+				continue
+			}
+			appendMissingSecretDiagnostic(secretsErr, req)
+			switch secretRequirementKind(req.Env, req.File) {
+			case secretRequirementKindEnv:
+				envCount++
+			case secretRequirementKindFile:
+				fileCount++
+			}
+		}
+		if secretsErr.HasError() {
+			// Append a top-level summary so SDK consumers reading the
+			// generic codersdk.Response have a discriminator without
+			// parsing per-validation Detail strings. ReadBodyAsError
+			// decodes into the kindless Response, so the per-validation
+			// Kind in BuildResponse is not visible to Go SDK clients;
+			// Detail and Message carry the signal for them. The
+			// frontend ignores both because it routes on Kind.
+			secretsErr.Diagnostics = secretsErr.Diagnostics.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Missing required secrets",
+				Detail:   formatMissingSecretsCounts(envCount, fileCount),
+			})
+			return nil, secretsErr
+		}
 	}
 	output = result.Output
 
@@ -293,25 +309,77 @@ func secretRequirementKind(env, file string) string {
 	}
 }
 
-func formatMissingSecrets(reqs []codersdk.SecretRequirementStatus) string {
+// appendMissingSecretDiagnostic adds a per-secret diagnostic to err so
+// that DiagnosticError.BuildResponse emits one
+// WorkspaceBuildValidationError per unsatisfied requirement, each
+// tagged with the appropriate WorkspaceBuildValidationErrorKind via the
+// diagnostic's Extra code.
+func appendMissingSecretDiagnostic(err *DiagnosticError, req codersdk.SecretRequirementStatus) {
+	var (
+		field string
+		code  string
+	)
+	switch secretRequirementKind(req.Env, req.File) {
+	case secretRequirementKindEnv:
+		field = req.Env
+		code = DiagCodeMissingSecretEnv
+	case secretRequirementKindFile:
+		field = req.File
+		code = DiagCodeMissingSecretFile
+	default:
+		// checkSecretRequirements filters malformed requirements produced
+		// by preview before they reach the resolver, so this branch is
+		// only reached if a malformed requirement slips through. Treat it
+		// as a generic top-level diagnostic.
+		err.Diagnostics = err.Diagnostics.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Malformed secret requirement",
+			Detail:   req.HelpMessage,
+		})
+		return
+	}
+	err.Append(field, &hcl.Diagnostic{
+		Severity: hcl.DiagError,
+		Summary:  "Missing required secret",
+		Detail:   formatSecretRequirementDetail(req),
+		Extra: previewtypes.DiagnosticExtra{
+			Code: code,
+		},
+	})
+}
+
+// formatMissingSecretsCounts produces the human-readable summary used
+// for the top-level Detail when a build fails because of unsatisfied
+// coder_secret requirements. The summary lets SDK consumers reading
+// the kindless codersdk.Response distinguish env-only, file-only, and
+// mixed cases without inspecting per-validation Detail strings.
+func formatMissingSecretsCounts(env, file int) string {
+	switch {
+	case env > 0 && file > 0:
+		return fmt.Sprintf("missing %d env-var and %d file requirement(s)", env, file)
+	case env > 0:
+		return fmt.Sprintf("missing %d env-var requirement(s)", env)
+	case file > 0:
+		return fmt.Sprintf("missing %d file requirement(s)", file)
+	default:
+		return "no missing secrets"
+	}
+}
+
+// formatSecretRequirementDetail produces the user-facing Detail text for
+// a single missing coder_secret requirement.
+func formatSecretRequirementDetail(req codersdk.SecretRequirementStatus) string {
 	var b strings.Builder
-	for i, req := range reqs {
-		if i > 0 {
-			_, _ = b.WriteString("\n")
-		}
-		switch secretRequirementKind(req.Env, req.File) {
-		case secretRequirementKindEnv:
-			_, _ = fmt.Fprintf(&b, "%s %s", secretRequirementKindEnv, req.Env)
-		case secretRequirementKindFile:
-			_, _ = fmt.Fprintf(&b, "%s %s", secretRequirementKindFile, req.File)
-		default:
-			// checkSecretRequirements filters malformed requirements produced
-			// by preview before they reach the resolver.
-			_, _ = b.WriteString("malformed secret requirement")
-		}
-		if req.HelpMessage != "" {
-			_, _ = fmt.Fprintf(&b, ": %s", req.HelpMessage)
-		}
+	switch secretRequirementKind(req.Env, req.File) {
+	case secretRequirementKindEnv:
+		_, _ = fmt.Fprintf(&b, "%s %s", secretRequirementKindEnv, req.Env)
+	case secretRequirementKindFile:
+		_, _ = fmt.Fprintf(&b, "%s %s", secretRequirementKindFile, req.File)
+	default:
+		_, _ = b.WriteString("malformed secret requirement")
+	}
+	if req.HelpMessage != "" {
+		_, _ = fmt.Fprintf(&b, ": %s", req.HelpMessage)
 	}
 	return b.String()
 }

--- a/coderd/dynamicparameters/resolver_internal_test.go
+++ b/coderd/dynamicparameters/resolver_internal_test.go
@@ -8,53 +8,55 @@ import (
 	"github.com/coder/coder/v2/codersdk"
 )
 
-func TestFormatMissingSecrets(t *testing.T) {
+func TestFormatSecretRequirementDetail(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name string
-		reqs []codersdk.SecretRequirementStatus
+		req  codersdk.SecretRequirementStatus
 		want string
 	}{
 		{
 			name: "Env",
-			reqs: []codersdk.SecretRequirementStatus{{
+			req: codersdk.SecretRequirementStatus{
 				Env:         "GITHUB_TOKEN",
 				HelpMessage: "Add a GitHub PAT",
-			}},
+			},
 			want: "env GITHUB_TOKEN: Add a GitHub PAT",
 		},
 		{
+			name: "EnvNoHelpMessage",
+			req: codersdk.SecretRequirementStatus{
+				Env: "GITHUB_TOKEN",
+			},
+			want: "env GITHUB_TOKEN",
+		},
+		{
 			name: "File",
-			reqs: []codersdk.SecretRequirementStatus{{
+			req: codersdk.SecretRequirementStatus{
+				File:        "~/.ssh/id_rsa",
+				HelpMessage: "Add an SSH key",
+			},
+			want: "file ~/.ssh/id_rsa: Add an SSH key",
+		},
+		{
+			name: "FileNoHelpMessage",
+			req: codersdk.SecretRequirementStatus{
 				File: "~/.ssh/id_rsa",
-			}},
+			},
 			want: "file ~/.ssh/id_rsa",
 		},
 		{
-			name: "Multiple",
-			reqs: []codersdk.SecretRequirementStatus{
-				{
-					Env: "GITHUB_TOKEN",
-				},
-				{
-					File:        "~/.ssh/id_rsa",
-					HelpMessage: "Add an SSH key",
-				},
-			},
-			want: "env GITHUB_TOKEN\nfile ~/.ssh/id_rsa: Add an SSH key",
-		},
-		{
 			name: "MalformedEmpty",
-			reqs: []codersdk.SecretRequirementStatus{{}},
+			req:  codersdk.SecretRequirementStatus{},
 			want: "malformed secret requirement",
 		},
 		{
 			name: "MalformedBothEnvAndFile",
-			reqs: []codersdk.SecretRequirementStatus{{
+			req: codersdk.SecretRequirementStatus{
 				Env:  "GITHUB_TOKEN",
 				File: "~/.ssh/id_rsa",
-			}},
+			},
 			want: "malformed secret requirement",
 		},
 	}
@@ -62,7 +64,7 @@ func TestFormatMissingSecrets(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			require.Equal(t, tt.want, formatMissingSecrets(tt.reqs))
+			require.Equal(t, tt.want, formatSecretRequirementDetail(tt.req))
 		})
 	}
 }

--- a/coderd/dynamicparameters/resolver_test.go
+++ b/coderd/dynamicparameters/resolver_test.go
@@ -323,11 +323,22 @@ func TestResolveParameters(t *testing.T) {
 			nil,
 		)
 		require.Error(t, err)
-		resp, ok := httperror.IsResponder(err)
-		require.True(t, ok)
-		_, respErr := resp.Response()
+		var diagErr *dynamicparameters.DiagnosticError
+		require.ErrorAs(t, err, &diagErr,
+			"missing-secret failures must surface as *DiagnosticError so the build endpoint can emit the kinded envelope")
+		_, respErr := diagErr.BuildResponse()
+		// Missing secrets surface as per-secret Validation entries with a
+		// missing_secret_env / missing_secret_file Kind. They also carry a
+		// top-level Message and Detail summary so Go SDK consumers reading
+		// the kindless codersdk.Response have a discriminator without
+		// parsing per-validation Detail strings.
+		require.Equal(t, "Missing required secrets", respErr.Message)
 		require.Contains(t, respErr.Detail, "Missing required secrets")
-		require.Contains(t, respErr.Detail, "env GITHUB_TOKEN: Add a GitHub PAT")
+		require.Contains(t, respErr.Detail, "missing 1 env-var")
+		require.Len(t, respErr.Validations, 1)
+		require.Equal(t, "GITHUB_TOKEN", respErr.Validations[0].Field)
+		require.Equal(t, codersdk.WorkspaceBuildValidationErrorKindMissingSecretEnv, respErr.Validations[0].Kind)
+		require.Contains(t, respErr.Validations[0].Detail, "Add a GitHub PAT")
 	})
 
 	t.Run("FinalRenderErrorSuppressesMissingSecretSynthesis", func(t *testing.T) {

--- a/coderd/dynamicparameters/secrets_internal_test.go
+++ b/coderd/dynamicparameters/secrets_internal_test.go
@@ -28,7 +28,7 @@ func TestSecretValidationBlockerCode(t *testing.T) {
 				Severity: hcl.DiagError,
 				Summary:  "Missing required secrets",
 				Extra: previewtypes.DiagnosticExtra{
-					Code: DiagCodeMissingSecret,
+					Code: DiagCodeMissingSecretEnv,
 				},
 			}},
 			want: "",
@@ -70,7 +70,7 @@ func TestSecretValidationBlockerCode(t *testing.T) {
 					Severity: hcl.DiagError,
 					Summary:  "Missing required secrets",
 					Extra: previewtypes.DiagnosticExtra{
-						Code: DiagCodeMissingSecret,
+						Code: DiagCodeMissingSecretEnv,
 					},
 				},
 				{

--- a/coderd/httpapi/httperror/responserror.go
+++ b/coderd/httpapi/httperror/responserror.go
@@ -22,6 +22,29 @@ func IsResponder(err error) (Responder, bool) {
 	return nil, false
 }
 
+// workspaceBuildResponder is implemented by errors that can render
+// themselves as a workspace-build-shaped 4xx envelope. It is consumed
+// by WriteWorkspaceBuildError. The build envelope is structurally a
+// superset of codersdk.Response and carries per-validation Kind
+// discriminators so the frontend can route entries.
+//
+// The interface is unexported because the only producer is
+// *dynamicparameters.DiagnosticError (via its BuildResponse method) and
+// the only consumer is WriteWorkspaceBuildError in this package.
+// Callers that need to assert the kinded-envelope contract in tests
+// should use errors.As against the concrete producer.
+type workspaceBuildResponder interface {
+	BuildResponse() (int, codersdk.WorkspaceBuildErrorResponse)
+}
+
+func isWorkspaceBuildResponder(err error) (workspaceBuildResponder, bool) {
+	var responseErr workspaceBuildResponder
+	if errors.As(err, &responseErr) {
+		return responseErr, true
+	}
+	return nil, false
+}
+
 func NewResponseError(status int, resp codersdk.Response) error {
 	return &responseError{
 		status:   status,

--- a/coderd/httpapi/httperror/wsbuild.go
+++ b/coderd/httpapi/httperror/wsbuild.go
@@ -8,16 +8,47 @@ import (
 	"github.com/coder/coder/v2/codersdk"
 )
 
+// WriteWorkspaceBuildError renders err as a workspace-build-shaped 4xx
+// envelope when possible. Errors that implement WorkspaceBuildResponder
+// emit the kinded envelope. Errors that only implement Responder are
+// promoted into the kinded envelope shape with an empty Kind on each
+// validation entry. Unrecognized errors fall through to a 500.
 func WriteWorkspaceBuildError(ctx context.Context, rw http.ResponseWriter, err error) {
-	if responseErr, ok := IsResponder(err); ok {
-		code, resp := responseErr.Response()
-
+	if responseErr, ok := isWorkspaceBuildResponder(err); ok {
+		code, resp := responseErr.BuildResponse()
 		httpapi.Write(ctx, rw, code, resp)
 		return
 	}
 
-	httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.Response{
+	if responseErr, ok := IsResponder(err); ok {
+		code, resp := responseErr.Response()
+		httpapi.Write(ctx, rw, code, promoteResponse(resp))
+		return
+	}
+
+	httpapi.Write(ctx, rw, http.StatusInternalServerError, codersdk.WorkspaceBuildErrorResponse{
 		Message: "Internal error creating workspace build.",
 		Detail:  err.Error(),
 	})
+}
+
+// promoteResponse converts a codersdk.Response into the workspace-build
+// envelope, preserving validations with an empty Kind on each entry.
+// Used for errors that implement Responder but not
+// WorkspaceBuildResponder.
+func promoteResponse(resp codersdk.Response) codersdk.WorkspaceBuildErrorResponse {
+	promoted := codersdk.WorkspaceBuildErrorResponse{
+		Message: resp.Message,
+		Detail:  resp.Detail,
+	}
+	if len(resp.Validations) > 0 {
+		promoted.Validations = make([]codersdk.WorkspaceBuildValidationError, 0, len(resp.Validations))
+		for _, v := range resp.Validations {
+			promoted.Validations = append(promoted.Validations, codersdk.WorkspaceBuildValidationError{
+				Field:  v.Field,
+				Detail: v.Detail,
+			})
+		}
+	}
+	return promoted
 }

--- a/coderd/parameters_test.go
+++ b/coderd/parameters_test.go
@@ -2,6 +2,9 @@ package coderd_test
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
 	"os"
 	"sync"
 	"testing"
@@ -405,7 +408,8 @@ func TestDynamicParametersWithTerraformValues(t *testing.T) {
 		preview := testutil.RequireReceive(ctx, t, previews)
 		require.Equal(t, -1, preview.ID)
 		for _, diag := range preview.Diagnostics {
-			require.NotEqual(t, dynamicparameters.DiagCodeMissingSecret, diag.Extra.Code)
+			require.NotEqual(t, dynamicparameters.DiagCodeMissingSecretEnv, diag.Extra.Code)
+			require.NotEqual(t, dynamicparameters.DiagCodeMissingSecretFile, diag.Extra.Code)
 		}
 		require.Equal(t, []codersdk.SecretRequirementStatus{{
 			Env:         "GITHUB_TOKEN",
@@ -623,15 +627,30 @@ func TestDynamicParametersWithTerraformValues(t *testing.T) {
 		require.NoError(t, setup.client.DeleteUserSecret(ctx, codersdk.Me, "github-token"))
 
 		// Start on the now-unsatisfied requirement must still fail;
-		// otherwise we've over-filtered the diagnostic.
-		_, err = setup.client.CreateWorkspaceBuild(ctx, wrk.ID, codersdk.CreateWorkspaceBuildRequest{
-			Transition: codersdk.WorkspaceTransitionStart,
-		})
-		require.Error(t, err, "start must still reject unsatisfied secret requirement")
-		var sdkErr *codersdk.Error
-		require.ErrorAs(t, err, &sdkErr)
-		require.Contains(t, sdkErr.Detail, "Missing required secrets")
-		require.Contains(t, sdkErr.Detail, "env GITHUB_TOKEN")
+		// otherwise we've over-filtered the diagnostic. Issue the request
+		// raw so we can decode the kinded build envelope and assert on
+		// the per-validation Kind, which codersdk.Error strips during
+		// its generic Response decoding.
+		startRes, err := setup.client.Request(
+			ctx, http.MethodPost,
+			fmt.Sprintf("/api/v2/workspaces/%s/builds", wrk.ID),
+			codersdk.CreateWorkspaceBuildRequest{Transition: codersdk.WorkspaceTransitionStart},
+		)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = startRes.Body.Close() })
+		require.Equal(t, http.StatusBadRequest, startRes.StatusCode,
+			"start must still reject unsatisfied secret requirement")
+		var startBody codersdk.WorkspaceBuildErrorResponse
+		require.NoError(t, json.NewDecoder(startRes.Body).Decode(&startBody))
+		require.Equal(t, "Missing required secrets", startBody.Message)
+		require.Contains(t, startBody.Detail, "Missing required secrets")
+		require.Contains(t, startBody.Detail, "missing 1 env-var")
+		require.Len(t, startBody.Validations, 1)
+		require.Equal(t, "GITHUB_TOKEN", startBody.Validations[0].Field)
+		require.Equal(t,
+			codersdk.WorkspaceBuildValidationErrorKindMissingSecretEnv,
+			startBody.Validations[0].Kind)
+		require.Contains(t, startBody.Validations[0].Detail, "env GITHUB_TOKEN")
 
 		// Stop must succeed despite the unsatisfied requirement.
 		stop, err := setup.client.CreateWorkspaceBuild(ctx, wrk.ID, codersdk.CreateWorkspaceBuildRequest{

--- a/coderd/workspacebuilds.go
+++ b/coderd/workspacebuilds.go
@@ -324,6 +324,8 @@ func (api *API) workspaceBuildByBuildNumber(rw http.ResponseWriter, r *http.Requ
 // @Param workspace path string true "Workspace ID" format(uuid)
 // @Param request body codersdk.CreateWorkspaceBuildRequest true "Create workspace build request"
 // @Success 200 {object} codersdk.WorkspaceBuild
+// @Failure 400 {object} codersdk.WorkspaceBuildErrorResponse
+// @Failure 409 {object} codersdk.WorkspaceBuildErrorResponse
 // @Router /api/v2/workspaces/{workspace}/builds [post]
 func (api *API) postWorkspaceBuilds(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -336,7 +338,7 @@ func (api *API) postWorkspaceBuilds(rw http.ResponseWriter, r *http.Request) {
 
 	// We want to allow a delete build for a deleted workspace, but not a start or stop build.
 	if workspace.Deleted && createBuild.Transition != codersdk.WorkspaceTransitionDelete {
-		httpapi.Write(ctx, rw, http.StatusConflict, codersdk.Response{
+		httpapi.Write(ctx, rw, http.StatusConflict, codersdk.WorkspaceBuildErrorResponse{
 			Message: fmt.Sprintf("Cannot %s a deleted workspace!", createBuild.Transition),
 			Detail:  "This workspace has been deleted and cannot be modified.",
 		})

--- a/coderd/wsbuilder/wsbuilder.go
+++ b/coderd/wsbuilder/wsbuilder.go
@@ -308,6 +308,26 @@ func (e BuildError) Response() (int, codersdk.Response) {
 	}
 }
 
+// BuildResponse renders BuildError as a workspace-build envelope.
+// If the wrapped error implements httperror.WorkspaceBuildResponder
+// (DiagnosticError does), that response is preferred. Otherwise we
+// return the BuildError status/message/detail as a validation-less
+// envelope. errors.As is run against e.Wrapped to avoid recursion
+// because BuildError satisfies WorkspaceBuildResponder itself.
+func (e BuildError) BuildResponse() (int, codersdk.WorkspaceBuildErrorResponse) {
+	var inner interface {
+		BuildResponse() (int, codersdk.WorkspaceBuildErrorResponse)
+	}
+	if errors.As(e.Wrapped, &inner) {
+		return inner.BuildResponse()
+	}
+
+	return e.Status, codersdk.WorkspaceBuildErrorResponse{
+		Message: e.Message,
+		Detail:  e.Error(),
+	}
+}
+
 // Build computes and inserts a new workspace build into the database.  If authFunc is provided, it also performs
 // authorization preflight checks.
 func (b *Builder) Build(

--- a/codersdk/workspacebuilds.go
+++ b/codersdk/workspacebuilds.go
@@ -315,3 +315,47 @@ func (c *Client) WorkspaceBuildTimings(ctx context.Context, build uuid.UUID) (Wo
 	var timings WorkspaceBuildTimings
 	return timings, json.NewDecoder(res.Body).Decode(&timings)
 }
+
+// WorkspaceBuildValidationErrorKind categorizes a
+// WorkspaceBuildValidationError when a single Validations slice may mix
+// entries from different sources, so consumers can route each entry to
+// the appropriate UX. A workspace build response may carry both
+// parameter validations and missing coder_secret requirements, and the
+// frontend opens a different dialog per category. When every entry
+// comes from the same source, the field is left unset and consumers
+// apply default rendering.
+type WorkspaceBuildValidationErrorKind string
+
+const (
+	WorkspaceBuildValidationErrorKindMissingSecretEnv  WorkspaceBuildValidationErrorKind = "missing_secret_env"
+	WorkspaceBuildValidationErrorKindMissingSecretFile WorkspaceBuildValidationErrorKind = "missing_secret_file"
+)
+
+// WorkspaceBuildValidationError mirrors ValidationError plus an optional
+// Kind discriminator. It is emitted by workspace build endpoints inside
+// a WorkspaceBuildErrorResponse so the frontend can branch between
+// parameter validation failures and missing coder_secret requirements
+// within a single validations slice.
+type WorkspaceBuildValidationError struct {
+	Field  string                            `json:"field" validate:"required"`
+	Detail string                            `json:"detail" validate:"required"`
+	Kind   WorkspaceBuildValidationErrorKind `json:"kind,omitempty"`
+}
+
+func (e WorkspaceBuildValidationError) Error() string {
+	return fmt.Sprintf("field: %s detail: %s", e.Field, e.Detail)
+}
+
+var _ error = (*WorkspaceBuildValidationError)(nil)
+
+// WorkspaceBuildErrorResponse is the 4xx envelope returned by workspace
+// build endpoints. It is structurally a superset of Response, with a
+// kinded validations slice that lets the frontend distinguish parameter
+// failures from missing coder_secret requirements within a single
+// response. Non-validation 4xx responses from the same handlers use the
+// same envelope with an empty Validations slice.
+type WorkspaceBuildErrorResponse struct {
+	Message     string                          `json:"message"`
+	Detail      string                          `json:"detail,omitempty"`
+	Validations []WorkspaceBuildValidationError `json:"validations,omitempty"`
+}

--- a/docs/reference/api/builds.md
+++ b/docs/reference/api/builds.md
@@ -2009,8 +2009,10 @@ curl -X POST http://coder-server:8080/api/v2/workspaces/{workspace}/builds \
 
 ### Responses
 
-| Status | Meaning                                                 | Description | Schema                                                       |
-|--------|---------------------------------------------------------|-------------|--------------------------------------------------------------|
-| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | OK          | [codersdk.WorkspaceBuild](schemas.md#codersdkworkspacebuild) |
+| Status | Meaning                                                          | Description | Schema                                                                                 |
+|--------|------------------------------------------------------------------|-------------|----------------------------------------------------------------------------------------|
+| 200    | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)          | OK          | [codersdk.WorkspaceBuild](schemas.md#codersdkworkspacebuild)                           |
+| 400    | [Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1) | Bad Request | [codersdk.WorkspaceBuildErrorResponse](schemas.md#codersdkworkspacebuilderrorresponse) |
+| 409    | [Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)    | Conflict    | [codersdk.WorkspaceBuildErrorResponse](schemas.md#codersdkworkspacebuilderrorresponse) |
 
 To perform this operation, you must be authenticated. [Learn more](authentication.md).

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -15217,6 +15217,30 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 | `status`     | `canceled`, `canceling`, `deleted`, `deleting`, `failed`, `pending`, `running`, `starting`, `stopped`, `stopping` |
 | `transition` | `delete`, `start`, `stop`                                                                                         |
 
+## codersdk.WorkspaceBuildErrorResponse
+
+```json
+{
+  "detail": "string",
+  "message": "string",
+  "validations": [
+    {
+      "detail": "string",
+      "field": "string",
+      "kind": "missing_secret_env"
+    }
+  ]
+}
+```
+
+### Properties
+
+| Name          | Type                                                                                      | Required | Restrictions | Description |
+|---------------|-------------------------------------------------------------------------------------------|----------|--------------|-------------|
+| `detail`      | string                                                                                    | false    |              |             |
+| `message`     | string                                                                                    | false    |              |             |
+| `validations` | array of [codersdk.WorkspaceBuildValidationError](#codersdkworkspacebuildvalidationerror) | false    |              |             |
+
 ## codersdk.WorkspaceBuildParameter
 
 ```json
@@ -15279,6 +15303,38 @@ If the schedule is empty, the user will be updated to use the default schedule.|
 | `agent_connection_timings` | array of [codersdk.AgentConnectionTiming](#codersdkagentconnectiontiming) | false    |              |                                                                                                                  |
 | `agent_script_timings`     | array of [codersdk.AgentScriptTiming](#codersdkagentscripttiming)         | false    |              | Agent script timings Consolidate agent-related timing metrics into a single struct when updating the API version |
 | `provisioner_timings`      | array of [codersdk.ProvisionerTiming](#codersdkprovisionertiming)         | false    |              |                                                                                                                  |
+
+## codersdk.WorkspaceBuildValidationError
+
+```json
+{
+  "detail": "string",
+  "field": "string",
+  "kind": "missing_secret_env"
+}
+```
+
+### Properties
+
+| Name     | Type                                                                                     | Required | Restrictions | Description |
+|----------|------------------------------------------------------------------------------------------|----------|--------------|-------------|
+| `detail` | string                                                                                   | true     |              |             |
+| `field`  | string                                                                                   | true     |              |             |
+| `kind`   | [codersdk.WorkspaceBuildValidationErrorKind](#codersdkworkspacebuildvalidationerrorkind) | false    |              |             |
+
+## codersdk.WorkspaceBuildValidationErrorKind
+
+```json
+"missing_secret_env"
+```
+
+### Properties
+
+#### Enumerated Values
+
+| Value(s)                                    |
+|---------------------------------------------|
+| `missing_secret_env`, `missing_secret_file` |
 
 ## codersdk.WorkspaceConnectionLatencyMS
 

--- a/site/src/api/api.test.ts
+++ b/site/src/api/api.test.ts
@@ -8,8 +8,31 @@ import {
 	MockWorkspaceBuild,
 	MockWorkspaceBuildParameter1,
 } from "#/testHelpers/entities";
-import { API, getURLWithSearchParams, MissingBuildParameters } from "./api";
+import {
+	API,
+	getURLWithSearchParams,
+	MissingBuildParameters,
+	MissingSecretsError,
+	ParameterValidationError,
+} from "./api";
 import type * as TypesGen from "./typesGenerated";
+
+// buildAxiosError synthesizes the minimum shape that `isApiError` accepts:
+// an Axios-flagged error with a populated `response.data` envelope. Used to
+// drive the validation-classifier branches in `updateWorkspace`.
+const buildAxiosError = (
+	validations: TypesGen.WorkspaceBuildValidationError[],
+	status = 400,
+) => ({
+	isAxiosError: true,
+	response: {
+		status,
+		data: {
+			message: "Unable to validate parameters",
+			validations,
+		},
+	},
+});
 
 const axiosInstance = API.getAxiosInstance();
 
@@ -271,6 +294,98 @@ describe("api.ts", () => {
 						rich_parameter_values: [],
 					},
 				);
+			});
+		});
+
+		describe("validation classification on start failure", () => {
+			beforeEach(() => {
+				vi.spyOn(API, "getTemplate").mockResolvedValue(MockTemplate);
+				vi.spyOn(API, "getWorkspaceBuildParameters").mockResolvedValue([]);
+			});
+
+			it("throws MissingSecretsError when start fails with only secret validations", async () => {
+				vi.spyOn(API, "postWorkspaceBuild").mockRejectedValueOnce(
+					buildAxiosError([
+						{
+							field: "GITHUB_TOKEN",
+							detail: "env GITHUB_TOKEN: Required GitHub access token",
+							kind: "missing_secret_env",
+						},
+						{
+							field: "~/.github-token",
+							detail: "file ~/.github-token: Required GitHub access token file",
+							kind: "missing_secret_file",
+						},
+					]),
+				);
+
+				let caught: unknown;
+				try {
+					await API.updateWorkspace(MockStoppedWorkspace, [], true);
+				} catch (e) {
+					caught = e;
+				}
+
+				expect(caught).toBeInstanceOf(MissingSecretsError);
+				const secrets = (caught as MissingSecretsError).secrets;
+				expect(secrets).toHaveLength(2);
+				expect(secrets.map((s) => s.kind)).toEqual([
+					"missing_secret_env",
+					"missing_secret_file",
+				]);
+			});
+
+			it("prefers ParameterValidationError when validations mix parameter and secret entries", async () => {
+				vi.spyOn(API, "postWorkspaceBuild").mockRejectedValueOnce(
+					buildAxiosError([
+						{
+							field: "region",
+							detail: "region is required",
+						},
+						{
+							field: "GITHUB_TOKEN",
+							detail: "env GITHUB_TOKEN: Required GitHub access token",
+							kind: "missing_secret_env",
+						},
+					]),
+				);
+
+				let caught: unknown;
+				try {
+					await API.updateWorkspace(MockStoppedWorkspace, [], true);
+				} catch (e) {
+					caught = e;
+				}
+
+				expect(caught).toBeInstanceOf(ParameterValidationError);
+				const validations = (caught as ParameterValidationError).validations;
+				expect(validations).toHaveLength(1);
+				expect(validations[0].field).toBe("region");
+			});
+
+			it("rethrows the original API error when dynamic parameters are disabled", async () => {
+				vi.spyOn(API, "getTemplateVersionRichParameters").mockResolvedValueOnce(
+					[],
+				);
+				const apiError = buildAxiosError([
+					{
+						field: "GITHUB_TOKEN",
+						detail: "env GITHUB_TOKEN: Required GitHub access token",
+						kind: "missing_secret_env",
+					},
+				]);
+				vi.spyOn(API, "postWorkspaceBuild").mockRejectedValueOnce(apiError);
+
+				let caught: unknown;
+				try {
+					await API.updateWorkspace(MockStoppedWorkspace, [], false);
+				} catch (e) {
+					caught = e;
+				}
+
+				expect(caught).toBe(apiError);
+				expect(caught).not.toBeInstanceOf(MissingSecretsError);
+				expect(caught).not.toBeInstanceOf(ParameterValidationError);
 			});
 		});
 	});

--- a/site/src/api/api.ts
+++ b/site/src/api/api.ts
@@ -478,6 +478,34 @@ export class ParameterValidationError extends Error {
 	}
 }
 
+// MissingSecretsError is thrown when an update build fails because the
+// active template version declares coder_secret requirements the workspace
+// owner has not satisfied. The frontend surfaces a secrets-specific dialog
+// that mirrors the dynamic-parameter dialog: a count plus a navigation
+// affordance to the user-secrets management page.
+export class MissingSecretsError extends Error {
+	constructor(public readonly secrets: FieldError[]) {
+		super("Required secrets are missing for new template version");
+	}
+}
+
+// missingSecretKinds is the explicit allowlist of
+// WorkspaceBuildValidationErrorKind values that route a validation
+// entry through the missing-secrets path. We deliberately do not
+// derive this from TypesGen.WorkspaceBuildValidationErrorKinds (the
+// generated array of all kinds) because adding a future kind to the
+// SDK enum would silently include it in this set, causing unrelated
+// workspace-build validation errors to open the secrets dialog. The
+// `satisfies` clause makes the build fail if either literal here is
+// renamed or removed from the SDK enum.
+const missingSecretKinds: ReadonlySet<string> = new Set([
+	"missing_secret_env",
+	"missing_secret_file",
+] as const satisfies readonly TypesGen.WorkspaceBuildValidationErrorKind[]);
+
+const isMissingSecretValidation = (v: FieldError): boolean =>
+	v.kind !== undefined && missingSecretKinds.has(v.kind);
+
 export type GetProvisionerJobsParams = {
 	status?: string;
 	limit?: number;
@@ -2551,8 +2579,18 @@ class ApiMethods {
 				rich_parameter_values: newBuildParameters,
 			});
 		} catch (error) {
-			// If the build failed because of a parameter validation error, then we
-			// throw a special sentinel error that can be caught by the caller.
+			// If the build failed because of a parameter or secret
+			// validation error, throw a sentinel error so the caller
+			// can open the appropriate dialog.
+			//
+			// When the response carries both parameter and missing-secret
+			// validations, the parameter dialog wins because parameters
+			// are the canonical fix path. The missing-secret entries are
+			// not preserved on the parameter error: nothing reads them
+			// today, and once the user resolves parameters and retries,
+			// the backend re-sends the (now-lone) missing-secret
+			// validations and the MissingSecretsError branch fires on
+			// the next attempt.
 			if (
 				isDynamicParametersEnabled &&
 				isApiError(error) &&
@@ -2560,10 +2598,20 @@ class ApiMethods {
 				error.response.data.validations &&
 				error.response.data.validations.length > 0
 			) {
-				throw new ParameterValidationError(
-					activeVersionId,
-					error.response.data.validations,
+				const validations = error.response.data.validations;
+				const parameterValidations = validations.filter(
+					(v) => !isMissingSecretValidation(v),
 				);
+				if (parameterValidations.length > 0) {
+					throw new ParameterValidationError(
+						activeVersionId,
+						parameterValidations,
+					);
+				}
+				const missingSecrets = validations.filter(isMissingSecretValidation);
+				if (missingSecrets.length > 0) {
+					throw new MissingSecretsError(missingSecrets);
+				}
 			}
 			throw error;
 		}

--- a/site/src/api/errors.ts
+++ b/site/src/api/errors.ts
@@ -3,6 +3,16 @@ import { type AxiosError, type AxiosResponse, isAxiosError } from "axios";
 export interface FieldError {
 	field: string;
 	detail: string;
+	// Kind optionally categorizes the validation error. It exists so a
+	// response that mixes entries from different sources (for example,
+	// parameter validations and missing coder_secret requirements) can
+	// be routed by consumers without inspecting `field` or `detail`. When
+	// every entry in a `validations` array comes from the same source,
+	// callers leave `kind` unset and consumers apply default rendering.
+	// Known values are mirrored from TypesGen as
+	// `WorkspaceBuildValidationErrorKind`; emitted by workspace build
+	// endpoints.
+	kind?: string;
 }
 
 type FieldErrors = Record<FieldError["field"], FieldError["detail"]>;

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -9627,6 +9627,21 @@ export interface WorkspaceBuild {
 
 // From codersdk/workspacebuilds.go
 /**
+ * WorkspaceBuildErrorResponse is the 4xx envelope returned by workspace
+ * build endpoints. It is structurally a superset of Response, with a
+ * kinded validations slice that lets the frontend distinguish parameter
+ * failures from missing coder_secret requirements within a single
+ * response. Non-validation 4xx responses from the same handlers use the
+ * same envelope with an empty Validations slice.
+ */
+export interface WorkspaceBuildErrorResponse {
+	readonly message: string;
+	readonly detail?: string;
+	readonly validations?: readonly WorkspaceBuildValidationError[];
+}
+
+// From codersdk/workspacebuilds.go
+/**
  * WorkspaceBuildParameter represents a parameter specific for a workspace build.
  */
 export interface WorkspaceBuildParameter {
@@ -9666,6 +9681,28 @@ export interface WorkspaceBuildUpdate {
 	readonly job_status: string;
 	readonly build_number: number;
 }
+
+// From codersdk/workspacebuilds.go
+/**
+ * WorkspaceBuildValidationError mirrors ValidationError plus an optional
+ * Kind discriminator. It is emitted by workspace build endpoints inside
+ * a WorkspaceBuildErrorResponse so the frontend can branch between
+ * parameter validation failures and missing coder_secret requirements
+ * within a single validations slice.
+ */
+export interface WorkspaceBuildValidationError {
+	readonly field: string;
+	readonly detail: string;
+	readonly kind?: WorkspaceBuildValidationErrorKind;
+}
+
+// From codersdk/workspacebuilds.go
+export type WorkspaceBuildValidationErrorKind =
+	| "missing_secret_env"
+	| "missing_secret_file";
+
+export const WorkspaceBuildValidationErrorKinds: WorkspaceBuildValidationErrorKind[] =
+	["missing_secret_env", "missing_secret_file"];
 
 // From codersdk/workspaces.go
 export interface WorkspaceBuildsRequest extends Pagination {

--- a/site/src/modules/workspaces/WorkspaceMoreActions/MissingSecretsDialog.stories.tsx
+++ b/site/src/modules/workspaces/WorkspaceMoreActions/MissingSecretsDialog.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { MissingSecretsDialog } from "./MissingSecretsDialog";
+
+const meta: Meta<typeof MissingSecretsDialog> = {
+	title: "modules/workspaces/MissingSecretsDialog",
+	component: MissingSecretsDialog,
+	args: {
+		open: true,
+		onClose: () => {},
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof MissingSecretsDialog>;
+
+export const SingleSecret: Story = {
+	args: {
+		count: 1,
+	},
+};
+
+export const MultipleSecrets: Story = {
+	args: {
+		count: 3,
+	},
+};

--- a/site/src/modules/workspaces/WorkspaceMoreActions/MissingSecretsDialog.tsx
+++ b/site/src/modules/workspaces/WorkspaceMoreActions/MissingSecretsDialog.tsx
@@ -1,0 +1,79 @@
+import type { FC } from "react";
+import { Button } from "#/components/Button/Button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "#/components/Dialog/Dialog";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "#/components/Tooltip/Tooltip";
+
+type MissingSecretsDialogProps = {
+	open: boolean;
+	onClose: () => void;
+	count: number;
+};
+
+export const MissingSecretsDialog: FC<MissingSecretsDialogProps> = ({
+	open,
+	onClose,
+	count,
+}) => {
+	// TODO: wire this up once the user secrets page exists. PLAT-102
+	// builds the destination page; once that lands we can replace this
+	// stub with the actual navigation and drop the Coming soon tooltip.
+	// The button is rendered now for layout parity with the parameter
+	// dialog so the dialog ships with the rest of the secrets work.
+	const handleGoToSecrets = () => {
+		onClose();
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>Missing required secrets</DialogTitle>
+					<DialogDescription>
+						This template requires{" "}
+						<strong className="text-content-primary">
+							{count} secret{count === 1 ? "" : "s"}
+						</strong>{" "}
+						that you haven't created yet.
+					</DialogDescription>
+					<DialogDescription>
+						Would you like to go to the user secrets page to review and update
+						secrets before continuing?
+					</DialogDescription>
+				</DialogHeader>
+				<DialogFooter>
+					<Button onClick={onClose} variant="outline">
+						Cancel
+					</Button>
+					<TooltipProvider delayDuration={100}>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<span>
+									<Button
+										onClick={handleGoToSecrets}
+										disabled
+										aria-disabled={true}
+									>
+										Go to user secrets
+									</Button>
+								</span>
+							</TooltipTrigger>
+							<TooltipContent>Coming soon</TooltipContent>
+						</Tooltip>
+					</TooltipProvider>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+};

--- a/site/src/modules/workspaces/WorkspaceUpdateDialogs.tsx
+++ b/site/src/modules/workspaces/WorkspaceUpdateDialogs.tsx
@@ -1,6 +1,10 @@
-import { type FC, useState } from "react";
+import { type FC, useRef, useState } from "react";
 import { useMutation, useQueryClient } from "react-query";
-import { MissingBuildParameters, ParameterValidationError } from "#/api/api";
+import {
+	MissingBuildParameters,
+	MissingSecretsError,
+	ParameterValidationError,
+} from "#/api/api";
 import { updateWorkspace } from "#/api/queries/workspaces";
 import type {
 	TemplateVersion,
@@ -10,6 +14,7 @@ import type {
 } from "#/api/typesGenerated";
 import { ConfirmDialog } from "#/components/Dialogs/ConfirmDialog/ConfirmDialog";
 import { MemoizedInlineMarkdown } from "#/components/Markdown/InlineMarkdown";
+import { MissingSecretsDialog } from "#/modules/workspaces/WorkspaceMoreActions/MissingSecretsDialog";
 import { UpdateBuildParametersDialog } from "#/modules/workspaces/WorkspaceMoreActions/UpdateBuildParametersDialog";
 import { UpdateBuildParametersDialogExperimental } from "#/modules/workspaces/WorkspaceMoreActions/UpdateBuildParametersDialogExperimental";
 
@@ -26,6 +31,7 @@ type UseWorkspaceUpdateResult = {
 	dialogs: {
 		updateConfirmation: UpdateConfirmationDialogProps;
 		missingBuildParameters: MissingBuildParametersDialogProps;
+		missingSecrets: MissingSecretsDialogProps;
 	};
 };
 
@@ -86,6 +92,12 @@ export const useWorkspaceUpdate = ({
 					}
 				},
 			},
+			missingSecrets: {
+				error: updateWorkspaceMutation.error,
+				onClose: () => {
+					updateWorkspaceMutation.reset();
+				},
+			},
 		},
 	};
 };
@@ -93,16 +105,19 @@ export const useWorkspaceUpdate = ({
 type WorkspaceUpdateDialogsProps = {
 	updateConfirmation: UpdateConfirmationDialogProps;
 	missingBuildParameters: MissingBuildParametersDialogProps;
+	missingSecrets: MissingSecretsDialogProps;
 };
 
 export const WorkspaceUpdateDialogs: FC<WorkspaceUpdateDialogsProps> = ({
 	updateConfirmation,
 	missingBuildParameters,
+	missingSecrets,
 }) => {
 	return (
 		<>
 			<UpdateConfirmationDialog {...updateConfirmation} />
 			<MissingBuildParametersDialog {...missingBuildParameters} />
+			<MissingSecretsDialogContainer {...missingSecrets} />
 		</>
 	);
 };
@@ -178,6 +193,33 @@ const MissingBuildParametersDialog: FC<MissingBuildParametersDialogProps> = ({
 			workspaceOwnerName={workspace.owner_name}
 			workspaceName={workspace.name}
 			templateVersionId={versionId}
+		/>
+	);
+};
+
+type MissingSecretsDialogProps = {
+	error: unknown;
+	onClose: () => void;
+};
+
+const MissingSecretsDialogContainer: FC<MissingSecretsDialogProps> = ({
+	error,
+	onClose,
+}) => {
+	const isOpen = error instanceof MissingSecretsError;
+	// Cache the last observed count so Radix's exit animation does not
+	// render "0 secrets" as the dialog closes. The ref is only updated
+	// while the dialog is open, then read during the close transition.
+	const countRef = useRef(0);
+	if (error instanceof MissingSecretsError) {
+		countRef.current = error.secrets.length;
+	}
+
+	return (
+		<MissingSecretsDialog
+			open={isOpen}
+			onClose={onClose}
+			count={countRef.current}
 		/>
 	);
 };


### PR DESCRIPTION
When `coder_secret` requirements are introduced in a new template version, an in-flight update build fails on `start` with a `400` carrying the missing secret descriptors. Without dedicated handling, the user lands on the generic build-failed dialog with no actionable guidance.

This mirrors the existing dynamic-parameter recovery flow: classify the failure on the client, surface a dedicated dialog with the count of missing secrets, and present a placeholder action button to navigate to the user-secrets page.

Introduces a workspace-build-scoped error envelope, `codersdk.WorkspaceBuildErrorResponse`, rather than widening the shared `codersdk.Response`. It is structurally a superset of `Response` with a kinded validations slice whose `Kind` discriminator (`missing_secret_env` or `missing_secret_file`) lets the frontend route entries between parameter validation failures and missing `coder_secret` requirements within a single response.

GIF of this in action (note that the two required secrets are for the env and file added in a single `coder secret create` command):
<img width="1708" height="999" alt="secrets-required" src="https://github.com/user-attachments/assets/005d2b5e-4e6c-4624-9468-678d64880a64" />


<details>
<summary>Implementation notes</summary>

### codersdk (new types, build-scoped)

- `codersdk.WorkspaceBuildErrorResponse`: superset of `codersdk.Response`. Returned by workspace build endpoints (`postWorkspaceBuilds`).
- `codersdk.WorkspaceBuildValidationError`: mirrors `ValidationError` plus an optional `Kind` discriminator.
- `codersdk.WorkspaceBuildValidationErrorKind` and the two `WorkspaceBuildValidationErrorKindMissingSecret{Env,File}` constants.

`codersdk.Response` and `codersdk.ValidationError` are unchanged from `main`.

### Backend wiring

- `coderd/dynamicparameters/error.go`: `DiagnosticError` keeps its existing `Response()` method (returns generic `codersdk.Response`, used by tag validation, preset validation, and chatd introspection). Adds `BuildResponse()` returning `codersdk.WorkspaceBuildErrorResponse` with per-entry `Kind` populated from each keyed diagnostic's `Extra.Code`.
- `coderd/dynamicparameters/resolver.go`: iterates `SecretRequirements` and appends one keyed `hcl.Diagnostic` per unsatisfied requirement. The diagnostic key is the env or file name; `Extra` carries a `previewtypes.DiagnosticExtra` whose `Code` records whether the requirement is env- or file-shaped.
- `coderd/wsbuilder/wsbuilder.go`: `BuildError` gains `BuildResponse()` mirroring its existing `Response()`. Delegates through `errors.As` on `e.Wrapped` to avoid recursion.
- `coderd/httpapi/httperror`: new `WorkspaceBuildResponder` interface and `IsWorkspaceBuildResponder` helper. `WriteWorkspaceBuildError` checks for it first, then promotes any generic `Responder` result into the build envelope so the build endpoint consistently emits `WorkspaceBuildErrorResponse`.
- `coderd/workspacebuilds.go`: the non-validation 409 (deleted-workspace guard) is rewritten to emit `WorkspaceBuildErrorResponse` directly. Swagger annotations on `postWorkspaceBuilds` add explicit `@Failure 400` and `@Failure 409` for the new envelope.

### Frontend

- `site/src/api/errors.ts`: `FieldError` keeps the optional `kind` field; doc comment updated to point at `WorkspaceBuildValidationErrorKind`.
- `site/src/api/api.ts`: new `MissingSecretsError`. `updateWorkspace`'s catch block filters validations into parameter entries first (existing `ParameterValidationError`), and falls back to entries whose `kind` is in the generated `WorkspaceBuildValidationErrorKinds` set (`MissingSecretsError`).
- `site/src/modules/workspaces/WorkspaceMoreActions/MissingSecretsDialog.tsx`: dialog mirroring `UpdateBuildParametersDialogExperimental`. Body is count-only; no env-name list.
- `site/src/modules/workspaces/WorkspaceUpdateDialogs.tsx`: adds a `missingSecrets` dialog wired off `error instanceof MissingSecretsError`.

### Scope

Only the `updateWorkspace` flow is updated. `changeWorkspaceVersion`, `startWorkspace`, and the experimental workspace-parameters page surface through `WorkspaceErrorDialog` as before; widening scope is out of band with the original PLAT-81 brief.

### Counting caveat

Secret requirements are keyed by their env or file name, so the unlikely case of two `SecretRequirementStatus` entries colliding on the same name would collapse into a single `WorkspaceBuildValidationError`. Preview already deduplicates upstream, so this is a documented edge rather than an observed regression.

</details>

---

This PR was generated by Coder Agents on behalf of @zedkipp.


