### PR TITLE
test: cache providers for external-agent and ai-task-app-id

### DIFF
--- a/provisioner/terraform/provision_test.go
+++ b/provisioner/terraform/provision_test.go
@@ -1013,7 +1013,6 @@ func TestProvision(t *testing.T) {
 				}},
 				HasExternalAgents: true,
 			},
-			SkipCacheProviders: true,
 		},
 		{
 			Name: "ai-task-app-id",
@@ -1046,7 +1045,6 @@ func TestProvision(t *testing.T) {
 				},
 				HasAiTasks: true,
 			},
-			SkipCacheProviders: true,
 		},
 		{
 			Name: "malicious-tar",


### PR DESCRIPTION
Removes `SkipCacheProviders: true` from the `external-agent` and `ai-task-app-id` subtests of `TestProvision` so they go through `testutil.CacheTFProviders` like every other coder/coder-using test. Today both bypass the local provider mirror and hit `registry.terraform.io` on every CI run, which flakes on transient 5xx responses. The flag was originally added in #19286 as a workaround for an unreleased provider build; that workaround has been stale since `coder/coder v2.10.0` shipped.

This won't fix the flake outright. The first run after merge and any future test-name/file-content change are still cache misses that go to the registry. But in steady state on `main` the Actions cache will be hit and `terraform init` runs fully offline, which should drop registry exposure from ~every run to the small handful of cache-miss cases.

Relates to https://github.com/coder/internal/issues/1353
Relates to https://github.com/coder/internal/issues/1193
