### PR TITLE
test: fix TestWatcher_SharedParentRefcount on macOS

### DIFF
--- a/agent/agentgit/agentgit_test.go
+++ b/agent/agentgit/agentgit_test.go
@@ -43,13 +43,9 @@ func gitCmd(t *testing.T, dir string, args ...string) {
 // and returns the repo root path.
 func initTestRepo(t *testing.T) string {
 	t.Helper()
-	dir := t.TempDir()
 	// Resolve symlinks and short (8.3) names on Windows so test
 	// expectations match the canonical paths returned by git.
-	resolved, err := filepath.EvalSymlinks(dir)
-	if err == nil {
-		dir = resolved
-	}
+	dir := testutil.TempDirResolved(t)
 
 	gitCmd(t, dir, "init")
 	gitCmd(t, dir, "config", "user.name", "Test")
@@ -557,12 +553,9 @@ func TestScanDeletedWorktreeGitdirEmitsRemoved(t *testing.T) {
 	mainRepoDir := initTestRepo(t)
 
 	// Create a linked worktree using git CLI.
-	wtBase := t.TempDir()
 	// Resolve symlinks and short (8.3) names on Windows so test
 	// expectations match the canonical paths returned by git.
-	if resolved, err := filepath.EvalSymlinks(wtBase); err == nil {
-		wtBase = resolved
-	}
+	wtBase := testutil.TempDirResolved(t)
 	worktreeDir := filepath.Join(wtBase, "wt")
 	gitCmd(t, mainRepoDir, "branch", "worktree-branch")
 	gitCmd(t, mainRepoDir, "worktree", "add", worktreeDir, "worktree-branch")

--- a/agent/x/agentmcp/configwatcher_internal_test.go
+++ b/agent/x/agentmcp/configwatcher_internal_test.go
@@ -379,7 +379,11 @@ func TestWatcher_SharedParentRefcount(t *testing.T) {
 
 	ctx := testutil.Context(t, testutil.WaitLong)
 	logger := slogtest.Make(t, nil).Leveled(slog.LevelDebug)
-	dir := t.TempDir()
+	// On macOS, t.TempDir() lives under /var which is a symlink
+	// to /private/var. The watcher canonicalizes paths before
+	// storing parent-dir keys in w.dirs, so the test must look up
+	// the resolved form to match.
+	dir := testutil.TempDirResolved(t)
 	pathA := filepath.Join(dir, "a.mcp.json")
 	pathB := filepath.Join(dir, "b.mcp.json")
 

--- a/testutil/temp.go
+++ b/testutil/temp.go
@@ -2,6 +2,7 @@ package testutil
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -50,4 +51,23 @@ func CreateTemp(t *testing.T, dir, pattern string) *os.File {
 		}
 	})
 	return f
+}
+
+// TempDirResolved returns t.TempDir() with symlinks resolved via
+// filepath.EvalSymlinks. Tests that compare paths against values
+// processed by EvalSymlinks (directly or indirectly) should use
+// this helper so the comparison works on macOS, where the default
+// temp dir lives under /var which is a symlink to /private/var.
+//
+// If EvalSymlinks errors (for example on Windows where the temp
+// path may not resolve cleanly), the raw t.TempDir() result is
+// returned. This matches the lenient behavior already used in
+// existing tests.
+func TempDirResolved(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+		return resolved
+	}
+	return dir
 }


### PR DESCRIPTION
`TestWatcher_SharedParentRefcount` was deterministically broken on macOS: `t.TempDir()` lives under `/var` which is a symlink to `/private/var`, but the watcher canonicalizes paths via `filepath.EvalSymlinks` before storing them, so the test's `w.dirs[dir]` lookup missed and returned `0` instead of `2`.

Adds `testutil.TempDirResolved`, a shared helper that returns `t.TempDir()` with symlinks resolved and falls back to the raw temp dir on error (Windows-friendly). Migrates the matching inline `EvalSymlinks(t.TempDir())` callsites in `agent/agentgit/agentgit_test.go` to use it.

Closes https://github.com/coder/internal/issues/1531
