### PR TITLE
feat: bake mise tools into a shared dir on dogfood image

### DIFF
--- a/dogfood/coder/ubuntu-22.04/Dockerfile
+++ b/dogfood/coder/ubuntu-22.04/Dockerfile
@@ -205,18 +205,20 @@ RUN install --directory --mode=0755 /etc/mise
 COPY --chmod=0644 mise.toml /etc/mise/config.toml
 COPY --chmod=0644 mise.lock /etc/mise/mise.lock
 
-# Pre-install image tools as coder so they land on the home volume
-# layer. Sudo drops env vars, so MISE_* are re-exported via `env`.
-# github_token (optional build secret) authenticates aqua's API
-# calls; without it builds may hit GitHub's 60/hr unauth limit.
+# Pre-install tools into /opt/mise/data so they survive the home
+# volume's copy-on-first-mount. MISE_SHARED_INSTALL_DIRS (set below)
+# exposes them at runtime; MISE_DATA_DIR stays on the home volume.
+# github_token authenticates aqua's API calls (optional secret).
+RUN install --directory --owner=coder --group=coder --mode=0755 /opt/mise /opt/mise/data
 RUN --mount=type=secret,id=github_token,required=false \
 	gh_token="$(cat /run/secrets/github_token 2>/dev/null || true)" && \
 	sudo --user=coder env \
-		"MISE_DATA_DIR=$MISE_DATA_DIR" \
+		"MISE_DATA_DIR=/opt/mise/data" \
 		"MISE_TRUSTED_CONFIG_PATHS=$MISE_TRUSTED_CONFIG_PATHS" \
 		"GITHUB_TOKEN=$gh_token" \
 		/usr/local/bin/mise install --yes && \
-	PATH="$MISE_DATA_DIR/shims:$PATH" pnpm dlx playwright@1.47.0 install --with-deps chromium && \
+	PATH="/opt/mise/data/shims:$PATH" MISE_DATA_DIR=/opt/mise/data pnpm dlx playwright@1.47.0 install --with-deps chromium && \
+	rm -rf /opt/mise/data/cache /opt/mise/data/downloads && \
 	apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install Homebrew as the coder user so the supported Linux prefix remains
@@ -240,7 +242,10 @@ ENV HOMEBREW_PREFIX="/home/linuxbrew/.linuxbrew" \
 # Pin npm globals to a stable home dir, otherwise they land in
 # mise's version-specific node bin dir which isn't on PATH.
 ENV NPM_CONFIG_PREFIX="/home/coder/.npm-global"
-ENV PATH="/home/coder/.npm-global/bin:${MISE_DATA_DIR}/shims:${HOMEBREW_PREFIX}/bin:${HOMEBREW_PREFIX}/sbin:/home/coder/go/bin:${PATH}"
+# Baked shims trail user shims on PATH so user installs win when
+# both exist.
+ENV MISE_SHARED_INSTALL_DIRS="/opt/mise/data/installs"
+ENV PATH="/home/coder/.npm-global/bin:${MISE_DATA_DIR}/shims:/opt/mise/data/shims:${HOMEBREW_PREFIX}/bin:${HOMEBREW_PREFIX}/sbin:/home/coder/go/bin:${PATH}"
 
 # Override CARGO_HOME so cargo registry/cache writes go to the coder
 # user's home directory instead of the root-owned /usr/local/cargo.

--- a/dogfood/coder/ubuntu-22.04/Dockerfile
+++ b/dogfood/coder/ubuntu-22.04/Dockerfile
@@ -237,7 +237,10 @@ USER coder
 ENV HOMEBREW_PREFIX="/home/linuxbrew/.linuxbrew" \
 	HOMEBREW_CELLAR="/home/linuxbrew/.linuxbrew/Cellar" \
 	HOMEBREW_REPOSITORY="/home/linuxbrew/.linuxbrew/Homebrew"
-ENV PATH="${MISE_DATA_DIR}/shims:${HOMEBREW_PREFIX}/bin:${HOMEBREW_PREFIX}/sbin:/home/coder/go/bin:${PATH}"
+# Pin npm globals to a stable home dir, otherwise they land in
+# mise's version-specific node bin dir which isn't on PATH.
+ENV NPM_CONFIG_PREFIX="/home/coder/.npm-global"
+ENV PATH="/home/coder/.npm-global/bin:${MISE_DATA_DIR}/shims:${HOMEBREW_PREFIX}/bin:${HOMEBREW_PREFIX}/sbin:/home/coder/go/bin:${PATH}"
 
 # Override CARGO_HOME so cargo registry/cache writes go to the coder
 # user's home directory instead of the root-owned /usr/local/cargo.

--- a/dogfood/coder/ubuntu-26.04/Dockerfile
+++ b/dogfood/coder/ubuntu-26.04/Dockerfile
@@ -247,7 +247,10 @@ USER coder
 ENV HOMEBREW_PREFIX="/home/linuxbrew/.linuxbrew" \
 	HOMEBREW_CELLAR="/home/linuxbrew/.linuxbrew/Cellar" \
 	HOMEBREW_REPOSITORY="/home/linuxbrew/.linuxbrew/Homebrew"
-ENV PATH="${MISE_DATA_DIR}/shims:${HOMEBREW_PREFIX}/bin:${HOMEBREW_PREFIX}/sbin:/home/coder/go/bin:${PATH}"
+# Pin npm globals to a stable home dir, otherwise they land in
+# mise's version-specific node bin dir which isn't on PATH.
+ENV NPM_CONFIG_PREFIX="/home/coder/.npm-global"
+ENV PATH="/home/coder/.npm-global/bin:${MISE_DATA_DIR}/shims:${HOMEBREW_PREFIX}/bin:${HOMEBREW_PREFIX}/sbin:/home/coder/go/bin:${PATH}"
 
 # Override CARGO_HOME so cargo registry/cache writes go to the coder
 # user's home directory instead of the root-owned /usr/local/cargo.

--- a/dogfood/coder/ubuntu-26.04/Dockerfile
+++ b/dogfood/coder/ubuntu-26.04/Dockerfile
@@ -215,18 +215,20 @@ RUN install --directory --mode=0755 /etc/mise
 COPY --chmod=0644 mise.toml /etc/mise/config.toml
 COPY --chmod=0644 mise.lock /etc/mise/mise.lock
 
-# Pre-install image tools as coder so they land on the home volume
-# layer. Sudo drops env vars, so MISE_* are re-exported via `env`.
-# github_token (optional build secret) authenticates aqua's API
-# calls; without it builds may hit GitHub's 60/hr unauth limit.
+# Pre-install tools into /opt/mise/data so they survive the home
+# volume's copy-on-first-mount. MISE_SHARED_INSTALL_DIRS (set below)
+# exposes them at runtime; MISE_DATA_DIR stays on the home volume.
+# github_token authenticates aqua's API calls (optional secret).
+RUN install --directory --owner=coder --group=coder --mode=0755 /opt/mise /opt/mise/data
 RUN --mount=type=secret,id=github_token,required=false \
 	gh_token="$(cat /run/secrets/github_token 2>/dev/null || true)" && \
 	sudo --user=coder env \
-		"MISE_DATA_DIR=$MISE_DATA_DIR" \
+		"MISE_DATA_DIR=/opt/mise/data" \
 		"MISE_TRUSTED_CONFIG_PATHS=$MISE_TRUSTED_CONFIG_PATHS" \
 		"GITHUB_TOKEN=$gh_token" \
 		/usr/local/bin/mise install --yes && \
-	PATH="$MISE_DATA_DIR/shims:$PATH" pnpm dlx playwright@1.47.0 install --with-deps chromium && \
+	PATH="/opt/mise/data/shims:$PATH" MISE_DATA_DIR=/opt/mise/data pnpm dlx playwright@1.47.0 install --with-deps chromium && \
+	rm -rf /opt/mise/data/cache /opt/mise/data/downloads && \
 	apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install Homebrew as the coder user so the supported Linux prefix remains
@@ -250,7 +252,10 @@ ENV HOMEBREW_PREFIX="/home/linuxbrew/.linuxbrew" \
 # Pin npm globals to a stable home dir, otherwise they land in
 # mise's version-specific node bin dir which isn't on PATH.
 ENV NPM_CONFIG_PREFIX="/home/coder/.npm-global"
-ENV PATH="/home/coder/.npm-global/bin:${MISE_DATA_DIR}/shims:${HOMEBREW_PREFIX}/bin:${HOMEBREW_PREFIX}/sbin:/home/coder/go/bin:${PATH}"
+# Baked shims trail user shims on PATH so user installs win when
+# both exist.
+ENV MISE_SHARED_INSTALL_DIRS="/opt/mise/data/installs"
+ENV PATH="/home/coder/.npm-global/bin:${MISE_DATA_DIR}/shims:/opt/mise/data/shims:${HOMEBREW_PREFIX}/bin:${HOMEBREW_PREFIX}/sbin:/home/coder/go/bin:${PATH}"
 
 # Override CARGO_HOME so cargo registry/cache writes go to the coder
 # user's home directory instead of the root-owned /usr/local/cargo.

--- a/mise.lock
+++ b/mise.lock
@@ -16,7 +16,15 @@ url = "https://github.com/ahmetb/kubectx/releases/download/v0.9.4/kubens_v0.9.4_
 checksum = "sha256:8b3672961fb15f8b87d5793af8bd3c1cca52c016596fbf57c46ab4ef39265fcd"
 url = "https://github.com/ahmetb/kubectx/releases/download/v0.9.4/kubens_v0.9.4_linux_x86_64.tar.gz"
 
+[tools."aqua:ahmetb/kubectx/kubens"."platforms.linux-x64-baseline"]
+checksum = "sha256:8b3672961fb15f8b87d5793af8bd3c1cca52c016596fbf57c46ab4ef39265fcd"
+url = "https://github.com/ahmetb/kubectx/releases/download/v0.9.4/kubens_v0.9.4_linux_x86_64.tar.gz"
+
 [tools."aqua:ahmetb/kubectx/kubens"."platforms.linux-x64-musl"]
+checksum = "sha256:8b3672961fb15f8b87d5793af8bd3c1cca52c016596fbf57c46ab4ef39265fcd"
+url = "https://github.com/ahmetb/kubectx/releases/download/v0.9.4/kubens_v0.9.4_linux_x86_64.tar.gz"
+
+[tools."aqua:ahmetb/kubectx/kubens"."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:8b3672961fb15f8b87d5793af8bd3c1cca52c016596fbf57c46ab4ef39265fcd"
 url = "https://github.com/ahmetb/kubectx/releases/download/v0.9.4/kubens_v0.9.4_linux_x86_64.tar.gz"
 
@@ -28,7 +36,15 @@ url = "https://github.com/ahmetb/kubectx/releases/download/v0.9.4/kubens_v0.9.4_
 checksum = "sha256:ef43ab1217e09ac1b929d4b9dd2c22cbb10540ef277a3a9b484c020820c988b1"
 url = "https://github.com/ahmetb/kubectx/releases/download/v0.9.4/kubens_v0.9.4_darwin_x86_64.tar.gz"
 
+[tools."aqua:ahmetb/kubectx/kubens"."platforms.macos-x64-baseline"]
+checksum = "sha256:ef43ab1217e09ac1b929d4b9dd2c22cbb10540ef277a3a9b484c020820c988b1"
+url = "https://github.com/ahmetb/kubectx/releases/download/v0.9.4/kubens_v0.9.4_darwin_x86_64.tar.gz"
+
 [tools."aqua:ahmetb/kubectx/kubens"."platforms.windows-x64"]
+checksum = "sha256:eab9ace6e25303b522e7006a1c9e44747b9e9c005e15b1fcf8a9678569ca1c95"
+url = "https://github.com/ahmetb/kubectx/releases/download/v0.9.4/kubens_v0.9.4_windows_x86_64.zip"
+
+[tools."aqua:ahmetb/kubectx/kubens"."platforms.windows-x64-baseline"]
 checksum = "sha256:eab9ace6e25303b522e7006a1c9e44747b9e9c005e15b1fcf8a9678569ca1c95"
 url = "https://github.com/ahmetb/kubectx/releases/download/v0.9.4/kubens_v0.9.4_windows_x86_64.zip"
 
@@ -48,7 +64,15 @@ url = "https://github.com/crate-ci/typos/releases/download/v1.46.1/typos-v1.46.1
 checksum = "sha256:c574fa505596922ba2e7b1027a0a5b2df528f399b86b6915d85748186a65ca44"
 url = "https://github.com/crate-ci/typos/releases/download/v1.46.1/typos-v1.46.1-x86_64-unknown-linux-musl.tar.gz"
 
+[tools."aqua:crate-ci/typos"."platforms.linux-x64-baseline"]
+checksum = "sha256:c574fa505596922ba2e7b1027a0a5b2df528f399b86b6915d85748186a65ca44"
+url = "https://github.com/crate-ci/typos/releases/download/v1.46.1/typos-v1.46.1-x86_64-unknown-linux-musl.tar.gz"
+
 [tools."aqua:crate-ci/typos"."platforms.linux-x64-musl"]
+checksum = "sha256:c574fa505596922ba2e7b1027a0a5b2df528f399b86b6915d85748186a65ca44"
+url = "https://github.com/crate-ci/typos/releases/download/v1.46.1/typos-v1.46.1-x86_64-unknown-linux-musl.tar.gz"
+
+[tools."aqua:crate-ci/typos"."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:c574fa505596922ba2e7b1027a0a5b2df528f399b86b6915d85748186a65ca44"
 url = "https://github.com/crate-ci/typos/releases/download/v1.46.1/typos-v1.46.1-x86_64-unknown-linux-musl.tar.gz"
 
@@ -60,7 +84,15 @@ url = "https://github.com/crate-ci/typos/releases/download/v1.46.1/typos-v1.46.1
 checksum = "sha256:bc585c22f2c4f5963ad782df1d4764a91476d3079477a08833ff87dfa416bb72"
 url = "https://github.com/crate-ci/typos/releases/download/v1.46.1/typos-v1.46.1-x86_64-apple-darwin.tar.gz"
 
+[tools."aqua:crate-ci/typos"."platforms.macos-x64-baseline"]
+checksum = "sha256:bc585c22f2c4f5963ad782df1d4764a91476d3079477a08833ff87dfa416bb72"
+url = "https://github.com/crate-ci/typos/releases/download/v1.46.1/typos-v1.46.1-x86_64-apple-darwin.tar.gz"
+
 [tools."aqua:crate-ci/typos"."platforms.windows-x64"]
+checksum = "sha256:a7b042fc79bf7b73b00ece054ec3109858e001136c2642f28004544b571d37a2"
+url = "https://github.com/crate-ci/typos/releases/download/v1.46.1/typos-v1.46.1-x86_64-pc-windows-msvc.zip"
+
+[tools."aqua:crate-ci/typos"."platforms.windows-x64-baseline"]
 checksum = "sha256:a7b042fc79bf7b73b00ece054ec3109858e001136c2642f28004544b571d37a2"
 url = "https://github.com/crate-ci/typos/releases/download/v1.46.1/typos-v1.46.1-x86_64-pc-windows-msvc.zip"
 
@@ -80,7 +112,15 @@ url = "https://github.com/jj-vcs/jj/releases/download/v0.41.0/jj-v0.41.0-aarch64
 checksum = "sha256:42181a80d316ac157874c817c9945e104275114fb461d99e06e2312502f08f99"
 url = "https://github.com/jj-vcs/jj/releases/download/v0.41.0/jj-v0.41.0-x86_64-unknown-linux-musl.tar.gz"
 
+[tools."aqua:jj-vcs/jj"."platforms.linux-x64-baseline"]
+checksum = "sha256:42181a80d316ac157874c817c9945e104275114fb461d99e06e2312502f08f99"
+url = "https://github.com/jj-vcs/jj/releases/download/v0.41.0/jj-v0.41.0-x86_64-unknown-linux-musl.tar.gz"
+
 [tools."aqua:jj-vcs/jj"."platforms.linux-x64-musl"]
+checksum = "sha256:42181a80d316ac157874c817c9945e104275114fb461d99e06e2312502f08f99"
+url = "https://github.com/jj-vcs/jj/releases/download/v0.41.0/jj-v0.41.0-x86_64-unknown-linux-musl.tar.gz"
+
+[tools."aqua:jj-vcs/jj"."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:42181a80d316ac157874c817c9945e104275114fb461d99e06e2312502f08f99"
 url = "https://github.com/jj-vcs/jj/releases/download/v0.41.0/jj-v0.41.0-x86_64-unknown-linux-musl.tar.gz"
 
@@ -92,7 +132,15 @@ url = "https://github.com/jj-vcs/jj/releases/download/v0.41.0/jj-v0.41.0-aarch64
 checksum = "sha256:b40d238bf9de4379be9bfd629cff92cd3ec14e2d072a8f7f7bbb929dac9d22f6"
 url = "https://github.com/jj-vcs/jj/releases/download/v0.41.0/jj-v0.41.0-x86_64-apple-darwin.tar.gz"
 
+[tools."aqua:jj-vcs/jj"."platforms.macos-x64-baseline"]
+checksum = "sha256:b40d238bf9de4379be9bfd629cff92cd3ec14e2d072a8f7f7bbb929dac9d22f6"
+url = "https://github.com/jj-vcs/jj/releases/download/v0.41.0/jj-v0.41.0-x86_64-apple-darwin.tar.gz"
+
 [tools."aqua:jj-vcs/jj"."platforms.windows-x64"]
+checksum = "sha256:1c5ac3015caf0b15ae81cbafa1d94024dbd17b5dff933204d489787dfb95f835"
+url = "https://github.com/jj-vcs/jj/releases/download/v0.41.0/jj-v0.41.0-x86_64-pc-windows-msvc.zip"
+
+[tools."aqua:jj-vcs/jj"."platforms.windows-x64-baseline"]
 checksum = "sha256:1c5ac3015caf0b15ae81cbafa1d94024dbd17b5dff933204d489787dfb95f835"
 url = "https://github.com/jj-vcs/jj/releases/download/v0.41.0/jj-v0.41.0-x86_64-pc-windows-msvc.zip"
 
@@ -112,7 +160,15 @@ url = "https://github.com/watchexec/watchexec/releases/download/v2.5.1/watchexec
 checksum = "sha256:9efabd08de720c1ee7e57b487fe11904f0966828e76146e2b5ea5deee90626be"
 url = "https://github.com/watchexec/watchexec/releases/download/v2.5.1/watchexec-2.5.1-x86_64-unknown-linux-musl.tar.xz"
 
+[tools."aqua:watchexec/watchexec"."platforms.linux-x64-baseline"]
+checksum = "sha256:9efabd08de720c1ee7e57b487fe11904f0966828e76146e2b5ea5deee90626be"
+url = "https://github.com/watchexec/watchexec/releases/download/v2.5.1/watchexec-2.5.1-x86_64-unknown-linux-musl.tar.xz"
+
 [tools."aqua:watchexec/watchexec"."platforms.linux-x64-musl"]
+checksum = "sha256:9efabd08de720c1ee7e57b487fe11904f0966828e76146e2b5ea5deee90626be"
+url = "https://github.com/watchexec/watchexec/releases/download/v2.5.1/watchexec-2.5.1-x86_64-unknown-linux-musl.tar.xz"
+
+[tools."aqua:watchexec/watchexec"."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:9efabd08de720c1ee7e57b487fe11904f0966828e76146e2b5ea5deee90626be"
 url = "https://github.com/watchexec/watchexec/releases/download/v2.5.1/watchexec-2.5.1-x86_64-unknown-linux-musl.tar.xz"
 
@@ -124,7 +180,15 @@ url = "https://github.com/watchexec/watchexec/releases/download/v2.5.1/watchexec
 checksum = "sha256:bb74bf33286ff7f31dd8e763e017fbc0418360d88baefd35bc57d662d28394e2"
 url = "https://github.com/watchexec/watchexec/releases/download/v2.5.1/watchexec-2.5.1-x86_64-apple-darwin.tar.xz"
 
+[tools."aqua:watchexec/watchexec"."platforms.macos-x64-baseline"]
+checksum = "sha256:bb74bf33286ff7f31dd8e763e017fbc0418360d88baefd35bc57d662d28394e2"
+url = "https://github.com/watchexec/watchexec/releases/download/v2.5.1/watchexec-2.5.1-x86_64-apple-darwin.tar.xz"
+
 [tools."aqua:watchexec/watchexec"."platforms.windows-x64"]
+checksum = "sha256:aa448c2704ca1a37ce0f1fc75381d9a411946dd293cf6236293f549426a577f7"
+url = "https://github.com/watchexec/watchexec/releases/download/v2.5.1/watchexec-2.5.1-x86_64-pc-windows-msvc.zip"
+
+[tools."aqua:watchexec/watchexec"."platforms.windows-x64-baseline"]
 checksum = "sha256:aa448c2704ca1a37ce0f1fc75381d9a411946dd293cf6236293f549426a577f7"
 url = "https://github.com/watchexec/watchexec/releases/download/v2.5.1/watchexec-2.5.1-x86_64-pc-windows-msvc.zip"
 
@@ -192,7 +256,15 @@ url = "https://github.com/sigstore/cosign/releases/download/v2.4.3/cosign-linux-
 checksum = "sha256:caaad125acef1cb81d58dcdc454a1e429d09a750d1e9e2b3ed1aed8964454708"
 url = "https://github.com/sigstore/cosign/releases/download/v2.4.3/cosign-linux-amd64"
 
+[tools.cosign."platforms.linux-x64-baseline"]
+checksum = "sha256:caaad125acef1cb81d58dcdc454a1e429d09a750d1e9e2b3ed1aed8964454708"
+url = "https://github.com/sigstore/cosign/releases/download/v2.4.3/cosign-linux-amd64"
+
 [tools.cosign."platforms.linux-x64-musl"]
+checksum = "sha256:caaad125acef1cb81d58dcdc454a1e429d09a750d1e9e2b3ed1aed8964454708"
+url = "https://github.com/sigstore/cosign/releases/download/v2.4.3/cosign-linux-amd64"
+
+[tools.cosign."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:caaad125acef1cb81d58dcdc454a1e429d09a750d1e9e2b3ed1aed8964454708"
 url = "https://github.com/sigstore/cosign/releases/download/v2.4.3/cosign-linux-amd64"
 
@@ -204,7 +276,15 @@ url = "https://github.com/sigstore/cosign/releases/download/v2.4.3/cosign-darwin
 checksum = "sha256:98a3bfd691f42c6a5b721880116f89210d8fdff61cc0224cd3ef2f8e55a466fb"
 url = "https://github.com/sigstore/cosign/releases/download/v2.4.3/cosign-darwin-amd64"
 
+[tools.cosign."platforms.macos-x64-baseline"]
+checksum = "sha256:98a3bfd691f42c6a5b721880116f89210d8fdff61cc0224cd3ef2f8e55a466fb"
+url = "https://github.com/sigstore/cosign/releases/download/v2.4.3/cosign-darwin-amd64"
+
 [tools.cosign."platforms.windows-x64"]
+checksum = "sha256:a2ac24e197111c9430cb2a98f10a641164381afb83df036504868e4ea5720800"
+url = "https://github.com/sigstore/cosign/releases/download/v2.4.3/cosign-windows-amd64.exe"
+
+[tools.cosign."platforms.windows-x64-baseline"]
 checksum = "sha256:a2ac24e197111c9430cb2a98f10a641164381afb83df036504868e4ea5720800"
 url = "https://github.com/sigstore/cosign/releases/download/v2.4.3/cosign-windows-amd64.exe"
 
@@ -224,7 +304,15 @@ url = "https://github.com/digitalocean/doctl/releases/download/v1.158.0/doctl-1.
 checksum = "sha256:ef633ccbef39b8060413f1abcda2e33e0f13268570a271d9ba22d974dca74fe2"
 url = "https://github.com/digitalocean/doctl/releases/download/v1.158.0/doctl-1.158.0-linux-amd64.tar.gz"
 
+[tools.doctl."platforms.linux-x64-baseline"]
+checksum = "sha256:ef633ccbef39b8060413f1abcda2e33e0f13268570a271d9ba22d974dca74fe2"
+url = "https://github.com/digitalocean/doctl/releases/download/v1.158.0/doctl-1.158.0-linux-amd64.tar.gz"
+
 [tools.doctl."platforms.linux-x64-musl"]
+checksum = "sha256:ef633ccbef39b8060413f1abcda2e33e0f13268570a271d9ba22d974dca74fe2"
+url = "https://github.com/digitalocean/doctl/releases/download/v1.158.0/doctl-1.158.0-linux-amd64.tar.gz"
+
+[tools.doctl."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:ef633ccbef39b8060413f1abcda2e33e0f13268570a271d9ba22d974dca74fe2"
 url = "https://github.com/digitalocean/doctl/releases/download/v1.158.0/doctl-1.158.0-linux-amd64.tar.gz"
 
@@ -236,7 +324,15 @@ url = "https://github.com/digitalocean/doctl/releases/download/v1.158.0/doctl-1.
 checksum = "sha256:3cac266c6b36c69d0836840f6ac549a05b8dbfdd1b2e02ae85949ba0450177e3"
 url = "https://github.com/digitalocean/doctl/releases/download/v1.158.0/doctl-1.158.0-darwin-amd64.tar.gz"
 
+[tools.doctl."platforms.macos-x64-baseline"]
+checksum = "sha256:3cac266c6b36c69d0836840f6ac549a05b8dbfdd1b2e02ae85949ba0450177e3"
+url = "https://github.com/digitalocean/doctl/releases/download/v1.158.0/doctl-1.158.0-darwin-amd64.tar.gz"
+
 [tools.doctl."platforms.windows-x64"]
+checksum = "sha256:e1245a0a760a45b236e7a25bf118c1defc8447734bdeb4260ea3ec15d1797f05"
+url = "https://github.com/digitalocean/doctl/releases/download/v1.158.0/doctl-1.158.0-windows-amd64.zip"
+
+[tools.doctl."platforms.windows-x64-baseline"]
 checksum = "sha256:e1245a0a760a45b236e7a25bf118c1defc8447734bdeb4260ea3ec15d1797f05"
 url = "https://github.com/digitalocean/doctl/releases/download/v1.158.0/doctl-1.158.0-windows-amd64.zip"
 
@@ -256,7 +352,15 @@ url = "https://dl.google.com/go/go1.26.2.linux-arm64.tar.gz"
 checksum = "sha256:990e6b4bbba816dc3ee129eaeaf4b42f17c2800b88a2166c265ac1a200262282"
 url = "https://dl.google.com/go/go1.26.2.linux-amd64.tar.gz"
 
+[tools.go."platforms.linux-x64-baseline"]
+checksum = "sha256:990e6b4bbba816dc3ee129eaeaf4b42f17c2800b88a2166c265ac1a200262282"
+url = "https://dl.google.com/go/go1.26.2.linux-amd64.tar.gz"
+
 [tools.go."platforms.linux-x64-musl"]
+checksum = "sha256:990e6b4bbba816dc3ee129eaeaf4b42f17c2800b88a2166c265ac1a200262282"
+url = "https://dl.google.com/go/go1.26.2.linux-amd64.tar.gz"
+
+[tools.go."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:990e6b4bbba816dc3ee129eaeaf4b42f17c2800b88a2166c265ac1a200262282"
 url = "https://dl.google.com/go/go1.26.2.linux-amd64.tar.gz"
 
@@ -268,7 +372,15 @@ url = "https://dl.google.com/go/go1.26.2.darwin-arm64.tar.gz"
 checksum = "sha256:bc3f1500d9968c36d705442d90ba91addf9271665033748b82532682e90a7966"
 url = "https://dl.google.com/go/go1.26.2.darwin-amd64.tar.gz"
 
+[tools.go."platforms.macos-x64-baseline"]
+checksum = "sha256:bc3f1500d9968c36d705442d90ba91addf9271665033748b82532682e90a7966"
+url = "https://dl.google.com/go/go1.26.2.darwin-amd64.tar.gz"
+
 [tools.go."platforms.windows-x64"]
+checksum = "sha256:98eb3570bade15cb826b0909338df6cc6d2cf590bc39c471142002db3832b708"
+url = "https://dl.google.com/go/go1.26.2.windows-amd64.zip"
+
+[tools.go."platforms.windows-x64-baseline"]
 checksum = "sha256:98eb3570bade15cb826b0909338df6cc6d2cf590bc39c471142002db3832b708"
 url = "https://dl.google.com/go/go1.26.2.windows-amd64.zip"
 
@@ -336,7 +448,15 @@ url = "https://github.com/golangci/golangci-lint/releases/download/v1.64.8/golan
 checksum = "sha256:b6270687afb143d019f387c791cd2a6f1cb383be9b3124d241ca11bd3ce2e54e"
 url = "https://github.com/golangci/golangci-lint/releases/download/v1.64.8/golangci-lint-1.64.8-linux-amd64.tar.gz"
 
+[tools.golangci-lint."platforms.linux-x64-baseline"]
+checksum = "sha256:b6270687afb143d019f387c791cd2a6f1cb383be9b3124d241ca11bd3ce2e54e"
+url = "https://github.com/golangci/golangci-lint/releases/download/v1.64.8/golangci-lint-1.64.8-linux-amd64.tar.gz"
+
 [tools.golangci-lint."platforms.linux-x64-musl"]
+checksum = "sha256:b6270687afb143d019f387c791cd2a6f1cb383be9b3124d241ca11bd3ce2e54e"
+url = "https://github.com/golangci/golangci-lint/releases/download/v1.64.8/golangci-lint-1.64.8-linux-amd64.tar.gz"
+
+[tools.golangci-lint."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:b6270687afb143d019f387c791cd2a6f1cb383be9b3124d241ca11bd3ce2e54e"
 url = "https://github.com/golangci/golangci-lint/releases/download/v1.64.8/golangci-lint-1.64.8-linux-amd64.tar.gz"
 
@@ -348,7 +468,15 @@ url = "https://github.com/golangci/golangci-lint/releases/download/v1.64.8/golan
 checksum = "sha256:b52aebb8cb51e00bfd5976099083fbe2c43ef556cef9c87e58a8ae656e740444"
 url = "https://github.com/golangci/golangci-lint/releases/download/v1.64.8/golangci-lint-1.64.8-darwin-amd64.tar.gz"
 
+[tools.golangci-lint."platforms.macos-x64-baseline"]
+checksum = "sha256:b52aebb8cb51e00bfd5976099083fbe2c43ef556cef9c87e58a8ae656e740444"
+url = "https://github.com/golangci/golangci-lint/releases/download/v1.64.8/golangci-lint-1.64.8-darwin-amd64.tar.gz"
+
 [tools.golangci-lint."platforms.windows-x64"]
+checksum = "sha256:54c2ed3a6b4f2f5da1056fb6e83d6b73b592e06684b65a5999174fabbb251a8f"
+url = "https://github.com/golangci/golangci-lint/releases/download/v1.64.8/golangci-lint-1.64.8-windows-amd64.zip"
+
+[tools.golangci-lint."platforms.windows-x64-baseline"]
 checksum = "sha256:54c2ed3a6b4f2f5da1056fb6e83d6b73b592e06684b65a5999174fabbb251a8f"
 url = "https://github.com/golangci/golangci-lint/releases/download/v1.64.8/golangci-lint-1.64.8-windows-amd64.zip"
 
@@ -372,7 +500,15 @@ url = "https://github.com/ahmetb/kubectx/releases/download/v0.9.4/kubectx_v0.9.4
 checksum = "sha256:db5a48e85ff4d8c6fa947e3021e11ba4376f9588dd5fa779a80ed5c18287db22"
 url = "https://github.com/ahmetb/kubectx/releases/download/v0.9.4/kubectx_v0.9.4_linux_x86_64.tar.gz"
 
+[tools.kubectx."platforms.linux-x64-baseline"]
+checksum = "sha256:db5a48e85ff4d8c6fa947e3021e11ba4376f9588dd5fa779a80ed5c18287db22"
+url = "https://github.com/ahmetb/kubectx/releases/download/v0.9.4/kubectx_v0.9.4_linux_x86_64.tar.gz"
+
 [tools.kubectx."platforms.linux-x64-musl"]
+checksum = "sha256:db5a48e85ff4d8c6fa947e3021e11ba4376f9588dd5fa779a80ed5c18287db22"
+url = "https://github.com/ahmetb/kubectx/releases/download/v0.9.4/kubectx_v0.9.4_linux_x86_64.tar.gz"
+
+[tools.kubectx."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:db5a48e85ff4d8c6fa947e3021e11ba4376f9588dd5fa779a80ed5c18287db22"
 url = "https://github.com/ahmetb/kubectx/releases/download/v0.9.4/kubectx_v0.9.4_linux_x86_64.tar.gz"
 
@@ -384,7 +520,15 @@ url = "https://github.com/ahmetb/kubectx/releases/download/v0.9.4/kubectx_v0.9.4
 checksum = "sha256:99392d5cc3d174a18b68d9cce6872dc6c7216d58b6913e4f6a51274cffa95583"
 url = "https://github.com/ahmetb/kubectx/releases/download/v0.9.4/kubectx_v0.9.4_darwin_x86_64.tar.gz"
 
+[tools.kubectx."platforms.macos-x64-baseline"]
+checksum = "sha256:99392d5cc3d174a18b68d9cce6872dc6c7216d58b6913e4f6a51274cffa95583"
+url = "https://github.com/ahmetb/kubectx/releases/download/v0.9.4/kubectx_v0.9.4_darwin_x86_64.tar.gz"
+
 [tools.kubectx."platforms.windows-x64"]
+checksum = "sha256:31a30912ace13fe0a458a253bc76bd106c48f3b0967ac2676cfd8b7fae71e314"
+url = "https://github.com/ahmetb/kubectx/releases/download/v0.9.4/kubectx_v0.9.4_windows_x86_64.zip"
+
+[tools.kubectx."platforms.windows-x64-baseline"]
 checksum = "sha256:31a30912ace13fe0a458a253bc76bd106c48f3b0967ac2676cfd8b7fae71e314"
 url = "https://github.com/ahmetb/kubectx/releases/download/v0.9.4/kubectx_v0.9.4_windows_x86_64.zip"
 
@@ -404,7 +548,15 @@ url = "https://github.com/jesseduffield/lazygit/releases/download/v0.61.1/lazygi
 checksum = "sha256:1b91e660700f2332696726b635202576b543e2bc49b639830dccd26bc5160d5d"
 url = "https://github.com/jesseduffield/lazygit/releases/download/v0.61.1/lazygit_0.61.1_linux_x86_64.tar.gz"
 
+[tools.lazygit."platforms.linux-x64-baseline"]
+checksum = "sha256:1b91e660700f2332696726b635202576b543e2bc49b639830dccd26bc5160d5d"
+url = "https://github.com/jesseduffield/lazygit/releases/download/v0.61.1/lazygit_0.61.1_linux_x86_64.tar.gz"
+
 [tools.lazygit."platforms.linux-x64-musl"]
+checksum = "sha256:1b91e660700f2332696726b635202576b543e2bc49b639830dccd26bc5160d5d"
+url = "https://github.com/jesseduffield/lazygit/releases/download/v0.61.1/lazygit_0.61.1_linux_x86_64.tar.gz"
+
+[tools.lazygit."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:1b91e660700f2332696726b635202576b543e2bc49b639830dccd26bc5160d5d"
 url = "https://github.com/jesseduffield/lazygit/releases/download/v0.61.1/lazygit_0.61.1_linux_x86_64.tar.gz"
 
@@ -416,7 +568,15 @@ url = "https://github.com/jesseduffield/lazygit/releases/download/v0.61.1/lazygi
 checksum = "sha256:6efdb97b8ec24b5729156555d6bc05b340776f00084ddd78ab8bdc7f3dd9b727"
 url = "https://github.com/jesseduffield/lazygit/releases/download/v0.61.1/lazygit_0.61.1_darwin_x86_64.tar.gz"
 
+[tools.lazygit."platforms.macos-x64-baseline"]
+checksum = "sha256:6efdb97b8ec24b5729156555d6bc05b340776f00084ddd78ab8bdc7f3dd9b727"
+url = "https://github.com/jesseduffield/lazygit/releases/download/v0.61.1/lazygit_0.61.1_darwin_x86_64.tar.gz"
+
 [tools.lazygit."platforms.windows-x64"]
+checksum = "sha256:6024f3094904caaf9b9672b801cba31a65ad36729a0d2c5a03c432f739c0678b"
+url = "https://github.com/jesseduffield/lazygit/releases/download/v0.61.1/lazygit_0.61.1_windows_x86_64.zip"
+
+[tools.lazygit."platforms.windows-x64-baseline"]
 checksum = "sha256:6024f3094904caaf9b9672b801cba31a65ad36729a0d2c5a03c432f739c0678b"
 url = "https://github.com/jesseduffield/lazygit/releases/download/v0.61.1/lazygit_0.61.1_windows_x86_64.zip"
 
@@ -435,7 +595,15 @@ url = "https://unofficial-builds.nodejs.org/download/release/v22.19.0/node-v22.1
 checksum = "sha256:d36e56998220085782c0ca965f9d51b7726335aed2f5fc7321c6c0ad233aa96d"
 url = "https://nodejs.org/dist/v22.19.0/node-v22.19.0-linux-x64.tar.gz"
 
+[tools.node."platforms.linux-x64-baseline"]
+checksum = "sha256:d36e56998220085782c0ca965f9d51b7726335aed2f5fc7321c6c0ad233aa96d"
+url = "https://nodejs.org/dist/v22.19.0/node-v22.19.0-linux-x64.tar.gz"
+
 [tools.node."platforms.linux-x64-musl"]
+checksum = "sha256:97e0454f54244661a3f0ad743e1537d96adcb7904ff88cf993ddd3957bab7092"
+url = "https://unofficial-builds.nodejs.org/download/release/v22.19.0/node-v22.19.0-linux-x64-musl.tar.gz"
+
+[tools.node."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:97e0454f54244661a3f0ad743e1537d96adcb7904ff88cf993ddd3957bab7092"
 url = "https://unofficial-builds.nodejs.org/download/release/v22.19.0/node-v22.19.0-linux-x64-musl.tar.gz"
 
@@ -447,9 +615,21 @@ url = "https://nodejs.org/dist/v22.19.0/node-v22.19.0-darwin-arm64.tar.gz"
 checksum = "sha256:3cfed4795cd97277559763c5f56e711852d2cc2420bda1cea30c8aa9ac77ce0c"
 url = "https://nodejs.org/dist/v22.19.0/node-v22.19.0-darwin-x64.tar.gz"
 
+[tools.node."platforms.macos-x64-baseline"]
+checksum = "sha256:3cfed4795cd97277559763c5f56e711852d2cc2420bda1cea30c8aa9ac77ce0c"
+url = "https://nodejs.org/dist/v22.19.0/node-v22.19.0-darwin-x64.tar.gz"
+
 [tools.node."platforms.windows-x64"]
 checksum = "sha256:ea3fad0e67a991d8477d8c01344b56e69c676ccb733f065b22436994b1253f86"
 url = "https://nodejs.org/dist/v22.19.0/node-v22.19.0-win-x64.zip"
+
+[tools.node."platforms.windows-x64-baseline"]
+checksum = "sha256:ea3fad0e67a991d8477d8c01344b56e69c676ccb733f065b22436994b1253f86"
+url = "https://nodejs.org/dist/v22.19.0/node-v22.19.0-win-x64.zip"
+
+[[tools."npm:@devcontainers/cli"]]
+version = "0.87.0"
+backend = "npm:@devcontainers/cli"
 
 [[tools.pnpm]]
 version = "10.33.2"
@@ -467,7 +647,15 @@ url = "https://github.com/pnpm/pnpm/releases/download/v10.33.2/pnpm-linux-arm64"
 checksum = "sha256:39d7b6600239712bc9581ea219b17ffef46ba60998779cb717be2e068be029ef"
 url = "https://github.com/pnpm/pnpm/releases/download/v10.33.2/pnpm-linux-x64"
 
+[tools.pnpm."platforms.linux-x64-baseline"]
+checksum = "sha256:39d7b6600239712bc9581ea219b17ffef46ba60998779cb717be2e068be029ef"
+url = "https://github.com/pnpm/pnpm/releases/download/v10.33.2/pnpm-linux-x64"
+
 [tools.pnpm."platforms.linux-x64-musl"]
+checksum = "sha256:39d7b6600239712bc9581ea219b17ffef46ba60998779cb717be2e068be029ef"
+url = "https://github.com/pnpm/pnpm/releases/download/v10.33.2/pnpm-linux-x64"
+
+[tools.pnpm."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:39d7b6600239712bc9581ea219b17ffef46ba60998779cb717be2e068be029ef"
 url = "https://github.com/pnpm/pnpm/releases/download/v10.33.2/pnpm-linux-x64"
 
@@ -479,7 +667,15 @@ url = "https://github.com/pnpm/pnpm/releases/download/v10.33.2/pnpm-macos-arm64"
 checksum = "sha256:3b66abb865f4e7a82393861f0f3784d67a704a31a4021739874d4b7910793dca"
 url = "https://github.com/pnpm/pnpm/releases/download/v10.33.2/pnpm-macos-x64"
 
+[tools.pnpm."platforms.macos-x64-baseline"]
+checksum = "sha256:3b66abb865f4e7a82393861f0f3784d67a704a31a4021739874d4b7910793dca"
+url = "https://github.com/pnpm/pnpm/releases/download/v10.33.2/pnpm-macos-x64"
+
 [tools.pnpm."platforms.windows-x64"]
+checksum = "sha256:3d1af71e9da7081efd58f95942e1f7e2107bf8fcdae03eb2331c0b6cea59510b"
+url = "https://github.com/pnpm/pnpm/releases/download/v10.33.2/pnpm-win-x64.exe"
+
+[tools.pnpm."platforms.windows-x64-baseline"]
 checksum = "sha256:3d1af71e9da7081efd58f95942e1f7e2107bf8fcdae03eb2331c0b6cea59510b"
 url = "https://github.com/pnpm/pnpm/releases/download/v10.33.2/pnpm-win-x64.exe"
 
@@ -496,7 +692,13 @@ url = "https://github.com/protocolbuffers/protobuf/releases/download/v23.4/proto
 [tools.protoc."platforms.linux-x64"]
 url = "https://github.com/protocolbuffers/protobuf/releases/download/v23.4/protoc-23.4-linux-x86_64.zip"
 
+[tools.protoc."platforms.linux-x64-baseline"]
+url = "https://github.com/protocolbuffers/protobuf/releases/download/v23.4/protoc-23.4-linux-x86_64.zip"
+
 [tools.protoc."platforms.linux-x64-musl"]
+url = "https://github.com/protocolbuffers/protobuf/releases/download/v23.4/protoc-23.4-linux-x86_64.zip"
+
+[tools.protoc."platforms.linux-x64-musl-baseline"]
 url = "https://github.com/protocolbuffers/protobuf/releases/download/v23.4/protoc-23.4-linux-x86_64.zip"
 
 [tools.protoc."platforms.macos-arm64"]
@@ -505,7 +707,13 @@ url = "https://github.com/protocolbuffers/protobuf/releases/download/v23.4/proto
 [tools.protoc."platforms.macos-x64"]
 url = "https://github.com/protocolbuffers/protobuf/releases/download/v23.4/protoc-23.4-osx-x86_64.zip"
 
+[tools.protoc."platforms.macos-x64-baseline"]
+url = "https://github.com/protocolbuffers/protobuf/releases/download/v23.4/protoc-23.4-osx-x86_64.zip"
+
 [tools.protoc."platforms.windows-x64"]
+url = "https://github.com/protocolbuffers/protobuf/releases/download/v23.4/protoc-23.4-win64.zip"
+
+[tools.protoc."platforms.windows-x64-baseline"]
 url = "https://github.com/protocolbuffers/protobuf/releases/download/v23.4/protoc-23.4-win64.zip"
 
 [[tools.protoc-gen-go]]
@@ -521,7 +729,13 @@ url = "https://github.com/protocolbuffers/protobuf-go/releases/download/v1.30.0/
 [tools.protoc-gen-go."platforms.linux-x64"]
 url = "https://github.com/protocolbuffers/protobuf-go/releases/download/v1.30.0/protoc-gen-go.v1.30.0.linux.amd64.tar.gz"
 
+[tools.protoc-gen-go."platforms.linux-x64-baseline"]
+url = "https://github.com/protocolbuffers/protobuf-go/releases/download/v1.30.0/protoc-gen-go.v1.30.0.linux.amd64.tar.gz"
+
 [tools.protoc-gen-go."platforms.linux-x64-musl"]
+url = "https://github.com/protocolbuffers/protobuf-go/releases/download/v1.30.0/protoc-gen-go.v1.30.0.linux.amd64.tar.gz"
+
+[tools.protoc-gen-go."platforms.linux-x64-musl-baseline"]
 url = "https://github.com/protocolbuffers/protobuf-go/releases/download/v1.30.0/protoc-gen-go.v1.30.0.linux.amd64.tar.gz"
 
 [tools.protoc-gen-go."platforms.macos-arm64"]
@@ -530,7 +744,13 @@ url = "https://github.com/protocolbuffers/protobuf-go/releases/download/v1.30.0/
 [tools.protoc-gen-go."platforms.macos-x64"]
 url = "https://github.com/protocolbuffers/protobuf-go/releases/download/v1.30.0/protoc-gen-go.v1.30.0.darwin.amd64.tar.gz"
 
+[tools.protoc-gen-go."platforms.macos-x64-baseline"]
+url = "https://github.com/protocolbuffers/protobuf-go/releases/download/v1.30.0/protoc-gen-go.v1.30.0.darwin.amd64.tar.gz"
+
 [tools.protoc-gen-go."platforms.windows-x64"]
+url = "https://github.com/protocolbuffers/protobuf-go/releases/download/v1.30.0/protoc-gen-go.v1.30.0.windows.amd64.zip"
+
+[tools.protoc-gen-go."platforms.windows-x64-baseline"]
 url = "https://github.com/protocolbuffers/protobuf-go/releases/download/v1.30.0/protoc-gen-go.v1.30.0.windows.amd64.zip"
 
 [[tools.syft]]
@@ -549,7 +769,15 @@ url = "https://github.com/anchore/syft/releases/download/v1.20.0/syft_1.20.0_lin
 checksum = "sha256:689e12c5cbf67521ce61b9c126068f9eaabe1223e77971b2fede50033ff6b5cc"
 url = "https://github.com/anchore/syft/releases/download/v1.20.0/syft_1.20.0_linux_amd64.tar.gz"
 
+[tools.syft."platforms.linux-x64-baseline"]
+checksum = "sha256:689e12c5cbf67521ce61b9c126068f9eaabe1223e77971b2fede50033ff6b5cc"
+url = "https://github.com/anchore/syft/releases/download/v1.20.0/syft_1.20.0_linux_amd64.tar.gz"
+
 [tools.syft."platforms.linux-x64-musl"]
+checksum = "sha256:689e12c5cbf67521ce61b9c126068f9eaabe1223e77971b2fede50033ff6b5cc"
+url = "https://github.com/anchore/syft/releases/download/v1.20.0/syft_1.20.0_linux_amd64.tar.gz"
+
+[tools.syft."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:689e12c5cbf67521ce61b9c126068f9eaabe1223e77971b2fede50033ff6b5cc"
 url = "https://github.com/anchore/syft/releases/download/v1.20.0/syft_1.20.0_linux_amd64.tar.gz"
 
@@ -561,7 +789,15 @@ url = "https://github.com/anchore/syft/releases/download/v1.20.0/syft_1.20.0_dar
 checksum = "sha256:5fdf7afd0f1bfdbb2a1a575eacef8e10edfcb4783631baaa7572a9f4a4d86441"
 url = "https://github.com/anchore/syft/releases/download/v1.20.0/syft_1.20.0_darwin_amd64.tar.gz"
 
+[tools.syft."platforms.macos-x64-baseline"]
+checksum = "sha256:5fdf7afd0f1bfdbb2a1a575eacef8e10edfcb4783631baaa7572a9f4a4d86441"
+url = "https://github.com/anchore/syft/releases/download/v1.20.0/syft_1.20.0_darwin_amd64.tar.gz"
+
 [tools.syft."platforms.windows-x64"]
+checksum = "sha256:b8bfdedb261de2a69768097422a73bc72273ee92136ff676a20c3161e658881f"
+url = "https://github.com/anchore/syft/releases/download/v1.20.0/syft_1.20.0_windows_amd64.zip"
+
+[tools.syft."platforms.windows-x64-baseline"]
 checksum = "sha256:b8bfdedb261de2a69768097422a73bc72273ee92136ff676a20c3161e658881f"
 url = "https://github.com/anchore/syft/releases/download/v1.20.0/syft_1.20.0_windows_amd64.zip"
 
@@ -581,7 +817,15 @@ url = "https://releases.hashicorp.com/terraform/1.15.2/terraform_1.15.2_linux_ar
 checksum = "sha256:c56ff2bc7e6ce9b3879a50392b03c2ea074b47688bf503ff966c87fb01b2aab8"
 url = "https://releases.hashicorp.com/terraform/1.15.2/terraform_1.15.2_linux_amd64.zip"
 
+[tools.terraform."platforms.linux-x64-baseline"]
+checksum = "sha256:c56ff2bc7e6ce9b3879a50392b03c2ea074b47688bf503ff966c87fb01b2aab8"
+url = "https://releases.hashicorp.com/terraform/1.15.2/terraform_1.15.2_linux_amd64.zip"
+
 [tools.terraform."platforms.linux-x64-musl"]
+checksum = "sha256:c56ff2bc7e6ce9b3879a50392b03c2ea074b47688bf503ff966c87fb01b2aab8"
+url = "https://releases.hashicorp.com/terraform/1.15.2/terraform_1.15.2_linux_amd64.zip"
+
+[tools.terraform."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:c56ff2bc7e6ce9b3879a50392b03c2ea074b47688bf503ff966c87fb01b2aab8"
 url = "https://releases.hashicorp.com/terraform/1.15.2/terraform_1.15.2_linux_amd64.zip"
 
@@ -593,6 +837,14 @@ url = "https://releases.hashicorp.com/terraform/1.15.2/terraform_1.15.2_darwin_a
 checksum = "sha256:2bb701bc2db93ed39613df4f4e033ec4c2de9eba1c036d9a2f62cffc988af066"
 url = "https://releases.hashicorp.com/terraform/1.15.2/terraform_1.15.2_darwin_amd64.zip"
 
+[tools.terraform."platforms.macos-x64-baseline"]
+checksum = "sha256:2bb701bc2db93ed39613df4f4e033ec4c2de9eba1c036d9a2f62cffc988af066"
+url = "https://releases.hashicorp.com/terraform/1.15.2/terraform_1.15.2_darwin_amd64.zip"
+
 [tools.terraform."platforms.windows-x64"]
+checksum = "sha256:a7e25570dd85f363581e96cac0b468257c45945ca8875d951413b6606c9b86d4"
+url = "https://releases.hashicorp.com/terraform/1.15.2/terraform_1.15.2_windows_amd64.zip"
+
+[tools.terraform."platforms.windows-x64-baseline"]
 checksum = "sha256:a7e25570dd85f363581e96cac0b468257c45945ca8875d951413b6606c9b86d4"
 url = "https://releases.hashicorp.com/terraform/1.15.2/terraform_1.15.2_windows_amd64.zip"

--- a/mise.toml
+++ b/mise.toml
@@ -56,6 +56,10 @@ terraform = "1.15.2"
 doctl = "1.158.0"
 lazygit = "0.61.1"
 
+# Pre-installs the binary so the upstream devcontainers-cli coder
+# module's `command -v devcontainer` short-circuit fires
+"npm:@devcontainers/cli" = "0.87.0"
+
 # helm publishes binaries at get.helm.sh, not on GitHub. Mise's aqua
 # plugin templates the URL without the `v` prefix (404), and the
 # github backend can't find the binary (helm only publishes signatures


### PR DESCRIPTION
Three changes to make mise-managed tooling reach every dogfood workspace cleanly, with the upstream `devcontainers-cli` module fix as the original trigger.

## Why the module breaks

The upstream [`devcontainers-cli` coder module](https://github.com/coder/registry/blob/main/registry/coder/modules/devcontainers-cli/run.sh) does `npm install -g @devcontainers/cli` and then verifies the binary is on `PATH`. With mise-managed Node (introduced in #25282), `npm install -g` lands the binary at `$MISE_DATA_DIR/installs/node/<ver>/bin/`, which is *not* on `PATH` and which `mise reshim` does not surface as a shim. The post-install check fails:

```
Installing @devcontainers/cli using npm...
changed 1 package in 661ms
Reshimming mise 26...
Installation completed but 'devcontainer' command not found in PATH
```

Even though nothing the user does is actually broken.

## What this PR does

1. **`mise.toml`** — pre-install `@devcontainers/cli` via mise's `npm:` backend (`npm:@devcontainers/cli = "0.87.0"`). The mise shim lands at `$MISE_DATA_DIR/shims/devcontainer`, on `PATH`. The upstream module's `run.sh` short-circuits on its `command -v devcontainer` check and exits 0 without ever running the broken npm-install path. Strictly redundant after fix the second point makes `npm i -g` work natively, but kept for build-time pre-install and pinned-version reasons matching the other mise-pinned CLIs.

2. **`dogfood/coder/ubuntu-*.04/Dockerfile`** — set `NPM_CONFIG_PREFIX=/home/coder/.npm-global` and prepend `/home/coder/.npm-global/bin` to `PATH`. With this, generic `npm install -g <pkg>` (prettier, biome, anything frontend folks reach for) lands in a stable home-volume dir that is already on `PATH`, survives node version bumps, and needs no `mise reshim`. The mise `npm:` backend keeps using its own `--prefix` internally so the `npm:@devcontainers/cli` pin still installs under `$MISE_DATA_DIR` as before.

3. **`dogfood/coder/ubuntu-*.04/Dockerfile`** — install image tools into `/opt/mise/data` at build time (owned by `coder`) and expose them at runtime via `MISE_SHARED_INSTALL_DIRS=/opt/mise/data/installs`, keeping `MISE_DATA_DIR=/home/coder/.local/share/mise` for the user's own installs. This decouples baked tool versions from the home volume's copy-on-first-mount: fresh and existing workspaces both immediately see the image's tool set without a `mise install` step, and the user's own `mise install <tool>` / `mise use --global` still lands on the home volume. The `/opt/mise/data/shims` dir trails the user shim dir on `PATH` so a user-installed version wins when both exist.

Pinned to `0.87.0` (current latest) so Renovate/Dependabot can bump deliberately, matching the policy applied to the other floating tools during the mise migration (`lazygit`, `doctl`, `jj`, `typos`, `watchexec`).
