### PR TITLE
feat(coderd/x/chatd): allow attach_file in root plan-mode chats

### DIFF
--- a/coderd/x/chatd/chatd.go
+++ b/coderd/x/chatd/chatd.go
@@ -6250,7 +6250,7 @@ func builtinPlanToolAllowed(name string, isRootChat bool) bool {
 		return true
 	case "write_file", "edit_files", "list_templates", "read_template",
 		"create_workspace", "start_workspace", "stop_workspace", "propose_plan", "spawn_agent",
-		"spawn_explore_agent", "wait_agent", "ask_user_question":
+		"spawn_explore_agent", "wait_agent", "ask_user_question", "attach_file":
 		return isRootChat
 	case "process_list", "process_signal", "message_agent", "close_agent",
 		"spawn_computer_use_agent":


### PR DESCRIPTION
`attach_file` was registered for plan-mode turns but never added to `builtinPlanToolAllowed`, so the per-turn `ActiveTools` allowlist filtered it out and calls failed with `Tool not active in this turn: attach_file`. This was an omission rather than a deliberate block — the tool (#24280) landed shortly after plan mode (#24236) and no subsequent edit to the allowlist picked it up.

Add `attach_file` under the `isRootChat` case, matching how other artifact-producing tools (`propose_plan`, `write_file`, `edit_files`) are gated. The tool only reads from the workspace and writes to chat-attachment storage, so it preserves plan mode's invariant of not making implementation changes to the workspace. Subagents in plan mode remain restricted to the minimal read-only surface.
