### PR TITLE
style(site): use terminal icon for shell tool

### DIFF
--- a/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
+++ b/site/src/pages/AgentsPage/components/ChatElements/tools/ExecuteTool.tsx
@@ -6,6 +6,7 @@ import {
 	LayersIcon,
 	LoaderIcon,
 	OctagonXIcon,
+	TerminalIcon,
 	TriangleAlertIcon,
 } from "lucide-react";
 import type React from "react";
@@ -187,10 +188,8 @@ const ShellCommandLine: React.FC<{
 }> = ({ command, durationLabel, expanded }) => {
 	return (
 		<>
-			<span className="shrink-0 text-[13px] font-normal text-content-success">
-				$
-			</span>
-			<span className="block min-w-0 truncate text-[13px] font-normal text-content-primary">
+			<TerminalIcon aria-hidden className="size-3.5 shrink-0 text-current" />
+			<span className="block min-w-0 truncate text-[13px] font-normal text-current">
 				{command}
 			</span>
 			{durationLabel && (


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was written by Coder Agent on behalf of Danielle Maywood

The execute shell tool no longer uses the green `$` prompt. It now uses the Lucide terminal icon and inherits the muted row color used by the rest of the shell tool text.
