### PR TITLE
refactor(site): update UsageIndicator trigger to show inline rows with icons

### DIFF
--- a/site/src/pages/AgentsPage/components/UsageIndicator.stories.tsx
+++ b/site/src/pages/AgentsPage/components/UsageIndicator.stories.tsx
@@ -58,13 +58,13 @@ const withUnavailableWorkspaceCount = (Story: FC) => {
 };
 
 const withNarrowFrame = (Story: FC) => (
-	<div className="flex h-14 w-[260px] items-stretch justify-end rounded-md bg-surface-secondary">
+	<div className="flex h-14 w-[200px] items-stretch justify-end rounded-md bg-surface-secondary">
 		<Story />
 	</div>
 );
 
 const withWideFrame = (Story: FC) => (
-	<div className="flex h-12 w-[540px] items-stretch justify-end rounded-md bg-surface-secondary">
+	<div className="flex h-12 w-[400px] items-stretch justify-end rounded-md bg-surface-secondary">
 		<Story />
 	</div>
 );

--- a/site/src/pages/AgentsPage/components/UsageIndicator.stories.tsx
+++ b/site/src/pages/AgentsPage/components/UsageIndicator.stories.tsx
@@ -57,8 +57,14 @@ const withUnavailableWorkspaceCount = (Story: FC) => {
 	return <Story />;
 };
 
-const withUsageIndicatorFrame = (Story: FC) => (
-	<div className="flex h-14 w-[340px] items-stretch justify-end rounded-md bg-surface-secondary">
+const withNarrowFrame = (Story: FC) => (
+	<div className="flex h-14 w-[260px] items-stretch justify-end rounded-md bg-surface-secondary">
+		<Story />
+	</div>
+);
+
+const withWideFrame = (Story: FC) => (
+	<div className="flex h-12 w-[540px] items-stretch justify-end rounded-md bg-surface-secondary">
 		<Story />
 	</div>
 );
@@ -104,7 +110,7 @@ const meta: Meta<typeof UsageIndicator> = {
 	decorators: [
 		withAuthProvider,
 		withDashboardProvider,
-		withUsageIndicatorFrame,
+		withNarrowFrame,
 	],
 	parameters: {
 		user: MockUserOwner,
@@ -187,6 +193,15 @@ export const UsageAndWorkspaceQuota: Story = {
 		]);
 		await userEvent.click(canvas.getByRole("button"));
 	},
+};
+
+export const UsageAndWorkspaceQuotaWide: Story = {
+	decorators: [
+		withUsageLimitStatus(limitedUsageStatus()),
+		withWorkspaceQuota(defaultWorkspaceQuota),
+		withWorkspaceCount(3),
+		withWideFrame,
+	],
 };
 
 export const WorkspaceQuotaUnused: Story = {

--- a/site/src/pages/AgentsPage/components/UsageIndicator.stories.tsx
+++ b/site/src/pages/AgentsPage/components/UsageIndicator.stories.tsx
@@ -221,7 +221,9 @@ export const WorkspaceQuotaWithoutBudget: Story = {
 
 		await openUsageMenu(canvasElement);
 		expect(
-			within(document.body).getByText("1 workspace using 20 of 0 credits"),
+			within(document.body).getByText(
+				"1 workspace using 20 of unlimited credits",
+			),
 		).toBeInTheDocument();
 	},
 };

--- a/site/src/pages/AgentsPage/components/UsageIndicator.stories.tsx
+++ b/site/src/pages/AgentsPage/components/UsageIndicator.stories.tsx
@@ -254,6 +254,22 @@ export const WorkspaceQuotaWithoutWorkspaceCount: Story = {
 	},
 };
 
+export const UsageAndUnlimitedWorkspaceQuota: Story = {
+	decorators: [
+		withUsageLimitStatus(
+			limitedUsageStatus({
+				spend_limit_micros: 50_000_000,
+				current_spend: 498_100_000,
+			}),
+		),
+		withWorkspaceQuota({
+			credits_consumed: 24,
+			budget: 0,
+		}),
+		withWorkspaceCount(2),
+	],
+};
+
 export const NotLimited: Story = {
 	decorators: [
 		withUsageLimitStatus(unlimitedUsageStatus),

--- a/site/src/pages/AgentsPage/components/UsageIndicator.stories.tsx
+++ b/site/src/pages/AgentsPage/components/UsageIndicator.stories.tsx
@@ -58,7 +58,7 @@ const withUnavailableWorkspaceCount = (Story: FC) => {
 };
 
 const withUsageIndicatorFrame = (Story: FC) => (
-	<div className="flex h-12 w-[260px] items-stretch justify-end rounded-md bg-surface-secondary">
+	<div className="flex h-14 w-[340px] items-stretch justify-end rounded-md bg-surface-secondary">
 		<Story />
 	</div>
 );
@@ -181,7 +181,6 @@ export const UsageAndWorkspaceQuota: Story = {
 		const canvas = within(canvasElement);
 		const progressBars = canvas.getAllByRole("progressbar");
 
-		expect(canvas.getByText("Usage")).toBeInTheDocument();
 		expect(progressBars.map((bar) => bar.getAttribute("aria-label"))).toEqual([
 			"Monthly spend usage",
 			"Workspace quota usage",
@@ -220,7 +219,6 @@ export const WorkspaceQuotaWithoutBudget: Story = {
 			name: "Workspace quota usage",
 		});
 
-		expect(canvas.getByText("Workspace quota")).toBeInTheDocument();
 		expect(progressbar).toHaveAttribute("aria-valuenow", "100");
 
 		await openUsageMenu(canvasElement);

--- a/site/src/pages/AgentsPage/components/UsageIndicator.stories.tsx
+++ b/site/src/pages/AgentsPage/components/UsageIndicator.stories.tsx
@@ -215,14 +215,11 @@ export const WorkspaceQuotaWithoutBudget: Story = {
 	],
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		const progressbar = canvas.getByRole("progressbar", {
-			name: "Workspace quota usage",
-		});
 
-		expect(progressbar).toHaveAttribute("aria-valuenow", "100");
+		expect(canvas.queryByRole("progressbar")).not.toBeInTheDocument();
+		expect(canvas.getByText("20 of unlimited")).toBeInTheDocument();
 
 		await openUsageMenu(canvasElement);
-		expect(within(document.body).getByText("100%")).toBeInTheDocument();
 		expect(
 			within(document.body).getByText("1 workspace using 20 of 0 credits"),
 		).toBeInTheDocument();

--- a/site/src/pages/AgentsPage/components/UsageIndicator.stories.tsx
+++ b/site/src/pages/AgentsPage/components/UsageIndicator.stories.tsx
@@ -222,7 +222,7 @@ export const WorkspaceQuotaWithoutBudget: Story = {
 		await openUsageMenu(canvasElement);
 		expect(
 			within(document.body).getByText(
-				"1 workspace using 20 of unlimited credits",
+				"using 20 of unlimited credits",
 			),
 		).toBeInTheDocument();
 	},

--- a/site/src/pages/AgentsPage/components/UsageIndicator.tsx
+++ b/site/src/pages/AgentsPage/components/UsageIndicator.tsx
@@ -35,6 +35,7 @@ type UsageSectionData = {
 	detail: ReactNode;
 	icon: ReactNode;
 	summaryValue: string;
+	showProgress?: boolean;
 	secondaryDetail?: ReactNode;
 	tooltip?: ReactNode;
 	severity?: UsageSeverity;
@@ -107,14 +108,19 @@ export const UsageIndicator: FC = () => {
 				? `${formatNumber(creditsConsumed)} of ${formatNumber(quota.budget)} credits used`
 				: `${formatNumber(workspaceCount)} ${workspaceCount === 1 ? "workspace" : "workspaces"} using ${formatNumber(creditsConsumed)} of ${formatNumber(quota.budget)} credits`;
 
+		const hasQuotaBudget = quota.budget > 0;
+
 		sections.push({
 			id: "workspace-quota",
 			title: "Workspace quota",
 			progressLabel: "Workspace quota usage",
 			percent: getPercent(creditsConsumed, quota.budget),
-			severity: getSeverity(creditsConsumed, quota.budget),
+			severity: hasQuotaBudget
+				? getSeverity(creditsConsumed, quota.budget)
+				: "normal",
 			icon: <ServerIcon className="size-3.5" />,
-			summaryValue: quota.budget > 0
+			showProgress: hasQuotaBudget,
+			summaryValue: hasQuotaBudget
 				? `${formatNumber(creditsConsumed)} of ${formatNumber(quota.budget)}`
 				: `${formatNumber(creditsConsumed)} of unlimited`,
 			detail: quotaDetail,
@@ -177,13 +183,15 @@ const UsageTriggerProgress: FC<{ sections: readonly UsageSectionData[] }> = ({
 					>
 						{section.icon}
 					</span>
-					<UsageProgress
-						ariaLabel={section.progressLabel}
-						percent={section.percent}
-						severity={section.severity}
-						size="compact"
-						className="w-20"
-					/>
+					{section.showProgress !== false && (
+						<UsageProgress
+							ariaLabel={section.progressLabel}
+							percent={section.percent}
+							severity={section.severity}
+							size="compact"
+							className="w-20"
+						/>
+					)}
 					<span
 						className={cn(
 							"shrink-0 whitespace-nowrap text-xs tabular-nums",

--- a/site/src/pages/AgentsPage/components/UsageIndicator.tsx
+++ b/site/src/pages/AgentsPage/components/UsageIndicator.tsx
@@ -1,5 +1,5 @@
 import dayjs from "dayjs";
-import { InfoIcon } from "lucide-react";
+import { CoinsIcon, InfoIcon, ServerIcon } from "lucide-react";
 import { type FC, Fragment, type ReactNode } from "react";
 import { useQuery } from "react-query";
 import { Link } from "react-router";
@@ -33,6 +33,8 @@ type UsageSectionData = {
 	progressLabel: string;
 	percent: number;
 	detail: ReactNode;
+	icon: ReactNode;
+	summaryValue: string;
 	secondaryDetail?: ReactNode;
 	tooltip?: ReactNode;
 	severity?: UsageSeverity;
@@ -76,6 +78,8 @@ export const UsageIndicator: FC = () => {
 			progressLabel: `${periodLabel} spend usage`,
 			percent: getPercent(currentSpend, spendLimit),
 			severity: getSeverity(currentSpend, spendLimit),
+			icon: <CoinsIcon className="size-3.5" />,
+			summaryValue: formatCostMicros(currentSpend),
 			detail: (
 				<>
 					{formatCostMicros(currentSpend)} of {formatCostMicros(spendLimit)}{" "}
@@ -109,6 +113,8 @@ export const UsageIndicator: FC = () => {
 			progressLabel: "Workspace quota usage",
 			percent: getPercent(creditsConsumed, quota.budget),
 			severity: getSeverity(creditsConsumed, quota.budget),
+			icon: <ServerIcon className="size-3.5" />,
+			summaryValue: `${formatNumber(creditsConsumed)} of ${formatNumber(quota.budget)}`,
 			detail: quotaDetail,
 			tooltip:
 				"Workspaces, stopped or running, may consume credits. Stop or delete unused ones to free quota.",
@@ -125,19 +131,13 @@ export const UsageIndicator: FC = () => {
 const UsageMenu: FC<{ sections: readonly UsageSectionData[] }> = ({
 	sections,
 }) => {
-	const triggerLabel =
-		sections.length > 1 ? "Usage" : (sections[0]?.title ?? "Usage");
-
 	return (
 		<DropdownMenu>
 			<DropdownMenuTrigger asChild>
 				<button
 					type="button"
-					className="ml-auto flex self-stretch flex-col items-center justify-center gap-1 border-none bg-transparent px-3 cursor-pointer select-none transition-colors text-content-secondary hover:bg-surface-tertiary/50 outline-none text-[13px]"
+					className="ml-auto flex self-stretch items-center justify-center border-none bg-transparent px-3 cursor-pointer select-none transition-colors hover:bg-surface-tertiary/50 outline-none"
 				>
-					<span className="shrink-0 whitespace-nowrap text-center">
-						{triggerLabel}
-					</span>
 					<UsageTriggerProgress sections={sections} />
 				</button>
 			</DropdownMenuTrigger>
@@ -163,19 +163,34 @@ const UsageMenu: FC<{ sections: readonly UsageSectionData[] }> = ({
 const UsageTriggerProgress: FC<{ sections: readonly UsageSectionData[] }> = ({
 	sections,
 }) => {
-	const size = sections.length > 1 ? "compact" : "default";
-
 	return (
-		<div className="flex w-24 shrink-0 flex-col gap-0.5">
+		<div className="flex shrink-0 flex-col gap-1">
 			{sections.map((section) => (
-				<UsageProgress
-					key={section.id}
-					ariaLabel={section.progressLabel}
-					percent={section.percent}
-					severity={section.severity}
-					size={size}
-					className="w-full"
-				/>
+				<div key={section.id} className="flex items-center gap-2">
+					<span
+						className={cn(
+							"flex shrink-0 items-center",
+							getTextClassName(section.severity),
+						)}
+					>
+						{section.icon}
+					</span>
+					<UsageProgress
+						ariaLabel={section.progressLabel}
+						percent={section.percent}
+						severity={section.severity}
+						size="compact"
+						className="w-20"
+					/>
+					<span
+						className={cn(
+							"shrink-0 whitespace-nowrap text-xs tabular-nums",
+							getTextClassName(section.severity),
+						)}
+					>
+						{section.summaryValue}
+					</span>
+				</div>
 			))}
 		</div>
 	);

--- a/site/src/pages/AgentsPage/components/UsageIndicator.tsx
+++ b/site/src/pages/AgentsPage/components/UsageIndicator.tsx
@@ -100,15 +100,17 @@ export const UsageIndicator: FC = () => {
 
 	if (!isQuotaError && hasWorkspaceQuotaUsage) {
 		const creditsConsumed = quota.credits_consumed;
+		const hasQuotaBudget = quota.budget > 0;
 		const workspaceCount = workspacesQuery.isError
 			? undefined
 			: getWorkspaceCount(workspacesQuery.data?.count);
+		const budgetLabel = hasQuotaBudget
+			? formatNumber(quota.budget)
+			: "unlimited";
 		const quotaDetail =
 			workspaceCount === undefined
-				? `${formatNumber(creditsConsumed)} of ${formatNumber(quota.budget)} credits used`
-				: `${formatNumber(workspaceCount)} ${workspaceCount === 1 ? "workspace" : "workspaces"} using ${formatNumber(creditsConsumed)} of ${formatNumber(quota.budget)} credits`;
-
-		const hasQuotaBudget = quota.budget > 0;
+				? `${formatNumber(creditsConsumed)} of ${budgetLabel} credits used`
+				: `${formatNumber(workspaceCount)} ${workspaceCount === 1 ? "workspace" : "workspaces"} using ${formatNumber(creditsConsumed)} of ${budgetLabel} credits`;
 
 		sections.push({
 			id: "workspace-quota",
@@ -215,20 +217,27 @@ const UsageSection: FC<{ section: UsageSectionData }> = ({ section }) => {
 				<span className="truncate text-sm font-medium text-content-primary">
 					{section.title}
 				</span>
-				<span
-					className={cn("shrink-0 text-xs", getTextClassName(section.severity))}
-				>
-					{roundedPercent}%
-				</span>
+				{section.showProgress !== false && (
+					<span
+						className={cn(
+							"shrink-0 text-xs",
+							getTextClassName(section.severity),
+						)}
+					>
+						{roundedPercent}%
+					</span>
+				)}
 			</div>
 
-			<div className="px-2 pb-2">
-				<UsageProgress
-					ariaLabel={section.progressLabel}
-					percent={section.percent}
-					severity={section.severity}
-				/>
-			</div>
+			{section.showProgress !== false && (
+				<div className="px-2 pb-2">
+					<UsageProgress
+						ariaLabel={section.progressLabel}
+						percent={section.percent}
+						severity={section.severity}
+					/>
+				</div>
+			)}
 
 			<div
 				className={cn(

--- a/site/src/pages/AgentsPage/components/UsageIndicator.tsx
+++ b/site/src/pages/AgentsPage/components/UsageIndicator.tsx
@@ -114,7 +114,9 @@ export const UsageIndicator: FC = () => {
 			percent: getPercent(creditsConsumed, quota.budget),
 			severity: getSeverity(creditsConsumed, quota.budget),
 			icon: <ServerIcon className="size-3.5" />,
-			summaryValue: `${formatNumber(creditsConsumed)} of ${formatNumber(quota.budget)}`,
+			summaryValue: quota.budget > 0
+				? `${formatNumber(creditsConsumed)} of ${formatNumber(quota.budget)}`
+				: `${formatNumber(creditsConsumed)} of unlimited`,
 			detail: quotaDetail,
 			tooltip:
 				"Workspaces, stopped or running, may consume credits. Stop or delete unused ones to free quota.",

--- a/site/src/pages/AgentsPage/components/UsageIndicator.tsx
+++ b/site/src/pages/AgentsPage/components/UsageIndicator.tsx
@@ -206,7 +206,7 @@ const UsageTriggerProgress: FC<{ sections: readonly UsageSectionData[] }> = ({
 					)}
 					<span
 						className={cn(
-							"hidden shrink-0 whitespace-nowrap text-xs tabular-nums @[120px]:block",
+							"shrink-0 whitespace-nowrap text-xs tabular-nums @max-[80px]:hidden",
 							getTextClassName(section.severity),
 						)}
 					>

--- a/site/src/pages/AgentsPage/components/UsageIndicator.tsx
+++ b/site/src/pages/AgentsPage/components/UsageIndicator.tsx
@@ -184,7 +184,7 @@ const UsageTriggerProgress: FC<{ sections: readonly UsageSectionData[] }> = ({
 	sections,
 }) => {
 	return (
-		<div className="flex shrink-0 flex-col gap-1">
+		<div className="flex shrink-0 flex-col gap-1 md:flex-row md:gap-4">
 			{sections.map((section) => (
 				<div key={section.id} className="flex items-center gap-2">
 					<span
@@ -201,7 +201,7 @@ const UsageTriggerProgress: FC<{ sections: readonly UsageSectionData[] }> = ({
 							percent={section.percent}
 							severity={section.severity}
 							size="compact"
-							className="w-20"
+							className="hidden w-20 md:block"
 						/>
 					)}
 					<span

--- a/site/src/pages/AgentsPage/components/UsageIndicator.tsx
+++ b/site/src/pages/AgentsPage/components/UsageIndicator.tsx
@@ -156,7 +156,7 @@ const UsageMenu: FC<{ sections: readonly UsageSectionData[] }> = ({
 			<DropdownMenuTrigger asChild>
 				<button
 					type="button"
-					className="ml-auto flex min-w-0 shrink self-stretch items-center justify-center border-none bg-transparent px-3 cursor-pointer select-none transition-colors hover:bg-surface-tertiary/50 outline-none"
+					className="@container ml-auto flex min-w-0 shrink self-stretch items-center justify-center border-none bg-transparent px-3 cursor-pointer select-none transition-colors hover:bg-surface-tertiary/50 outline-none"
 				>
 					<UsageTriggerProgress sections={sections} />
 				</button>
@@ -206,7 +206,7 @@ const UsageTriggerProgress: FC<{ sections: readonly UsageSectionData[] }> = ({
 					)}
 					<span
 						className={cn(
-							"shrink-0 whitespace-nowrap text-xs tabular-nums",
+							"hidden shrink-0 whitespace-nowrap text-xs tabular-nums @[120px]:block",
 							getTextClassName(section.severity),
 						)}
 					>

--- a/site/src/pages/AgentsPage/components/UsageIndicator.tsx
+++ b/site/src/pages/AgentsPage/components/UsageIndicator.tsx
@@ -156,7 +156,7 @@ const UsageMenu: FC<{ sections: readonly UsageSectionData[] }> = ({
 			<DropdownMenuTrigger asChild>
 				<button
 					type="button"
-					className="ml-auto flex self-stretch items-center justify-center border-none bg-transparent px-3 cursor-pointer select-none transition-colors hover:bg-surface-tertiary/50 outline-none"
+					className="ml-auto flex min-w-0 shrink self-stretch items-center justify-center border-none bg-transparent px-3 cursor-pointer select-none transition-colors hover:bg-surface-tertiary/50 outline-none"
 				>
 					<UsageTriggerProgress sections={sections} />
 				</button>
@@ -184,9 +184,9 @@ const UsageTriggerProgress: FC<{ sections: readonly UsageSectionData[] }> = ({
 	sections,
 }) => {
 	return (
-		<div className="flex shrink-0 flex-col gap-1 md:flex-row md:gap-4">
+		<div className="flex min-w-0 shrink flex-col gap-1">
 			{sections.map((section) => (
-				<div key={section.id} className="flex items-center gap-2">
+				<div key={section.id} className="flex min-w-0 items-center gap-2">
 					<span
 						className={cn(
 							"flex shrink-0 items-center",
@@ -201,7 +201,7 @@ const UsageTriggerProgress: FC<{ sections: readonly UsageSectionData[] }> = ({
 							percent={section.percent}
 							severity={section.severity}
 							size="compact"
-							className="hidden w-20 md:block"
+							className="min-w-8 flex-1"
 						/>
 					)}
 					<span

--- a/site/src/pages/AgentsPage/components/UsageIndicator.tsx
+++ b/site/src/pages/AgentsPage/components/UsageIndicator.tsx
@@ -108,9 +108,19 @@ export const UsageIndicator: FC = () => {
 			? formatNumber(quota.budget)
 			: "unlimited";
 		const quotaDetail =
-			workspaceCount === undefined
-				? `${formatNumber(creditsConsumed)} of ${budgetLabel} credits used`
-				: `${formatNumber(workspaceCount)} ${workspaceCount === 1 ? "workspace" : "workspaces"} using ${formatNumber(creditsConsumed)} of ${budgetLabel} credits`;
+			workspaceCount === undefined ? (
+				`using ${formatNumber(creditsConsumed)} of ${budgetLabel} credits`
+			) : (
+				<>
+					<div>
+						{formatNumber(workspaceCount)}{" "}
+						{workspaceCount === 1 ? "workspace" : "workspaces"}
+					</div>
+					<div>
+						using {formatNumber(creditsConsumed)} of {budgetLabel} credits
+					</div>
+				</>
+			);
 
 		sections.push({
 			id: "workspace-quota",


### PR DESCRIPTION
Replaces the "Usage" label + stacked progress bars trigger with individual rows per section. Each row displays a severity-colored icon, progress bar, and summary value.

> Generated by Coder Agents on behalf of @tracyjohnsonux