### PR TITLE
feat: widen `ai_provider_type` enum for chatd providers

### DIFF
--- a/coderd/database/dump.sql
+++ b/coderd/database/dump.sql
@@ -12,7 +12,13 @@ CREATE TYPE agent_key_scope_enum AS ENUM (
 
 CREATE TYPE ai_provider_type AS ENUM (
     'openai',
-    'anthropic'
+    'anthropic',
+    'azure',
+    'bedrock',
+    'google',
+    'openai-compat',
+    'openrouter',
+    'vercel'
 );
 
 CREATE TYPE ai_seat_usage_reason AS ENUM (

--- a/coderd/database/migrations/000499_ai_provider_type_chatd_values.down.sql
+++ b/coderd/database/migrations/000499_ai_provider_type_chatd_values.down.sql
@@ -1,0 +1,3 @@
+-- No-op: Postgres does not allow removing enum values safely.
+-- Matches the precedent in 000495_ai_providers.down.sql for ALTER
+-- TYPE resource_type / api_key_scope ADD VALUE.

--- a/coderd/database/migrations/000499_ai_provider_type_chatd_values.up.sql
+++ b/coderd/database/migrations/000499_ai_provider_type_chatd_values.up.sql
@@ -1,0 +1,15 @@
+-- Widen ai_provider_type to carry the full chatd provider set so the
+-- chatd-side migration can preserve type fidelity when it lands. The
+-- aibridge runtime currently has native support only for OpenAI and
+-- Anthropic (with a Bedrock variant on the Anthropic client); the new
+-- non-Bedrock types route through the OpenAI fantasy client today
+-- because chatd already configures these providers against their
+-- OpenAI-compatible endpoints. Native gateway-side support for these
+-- providers comes later, at which point this enum already carries the
+-- right discriminator and no further migration is needed.
+ALTER TYPE ai_provider_type ADD VALUE IF NOT EXISTS 'azure';
+ALTER TYPE ai_provider_type ADD VALUE IF NOT EXISTS 'bedrock';
+ALTER TYPE ai_provider_type ADD VALUE IF NOT EXISTS 'google';
+ALTER TYPE ai_provider_type ADD VALUE IF NOT EXISTS 'openai-compat';
+ALTER TYPE ai_provider_type ADD VALUE IF NOT EXISTS 'openrouter';
+ALTER TYPE ai_provider_type ADD VALUE IF NOT EXISTS 'vercel';

--- a/coderd/database/models.go
+++ b/coderd/database/models.go
@@ -19,8 +19,14 @@ import (
 type AIProviderType string
 
 const (
-	AiProviderTypeOpenai    AIProviderType = "openai"
-	AiProviderTypeAnthropic AIProviderType = "anthropic"
+	AiProviderTypeOpenai       AIProviderType = "openai"
+	AiProviderTypeAnthropic    AIProviderType = "anthropic"
+	AiProviderTypeAzure        AIProviderType = "azure"
+	AiProviderTypeBedrock      AIProviderType = "bedrock"
+	AiProviderTypeGoogle       AIProviderType = "google"
+	AiProviderTypeOpenaiCompat AIProviderType = "openai-compat"
+	AiProviderTypeOpenrouter   AIProviderType = "openrouter"
+	AiProviderTypeVercel       AIProviderType = "vercel"
 )
 
 func (e *AIProviderType) Scan(src interface{}) error {
@@ -61,7 +67,13 @@ func (ns NullAIProviderType) Value() (driver.Value, error) {
 func (e AIProviderType) Valid() bool {
 	switch e {
 	case AiProviderTypeOpenai,
-		AiProviderTypeAnthropic:
+		AiProviderTypeAnthropic,
+		AiProviderTypeAzure,
+		AiProviderTypeBedrock,
+		AiProviderTypeGoogle,
+		AiProviderTypeOpenaiCompat,
+		AiProviderTypeOpenrouter,
+		AiProviderTypeVercel:
 		return true
 	}
 	return false
@@ -71,6 +83,12 @@ func AllAIProviderTypeValues() []AIProviderType {
 	return []AIProviderType{
 		AiProviderTypeOpenai,
 		AiProviderTypeAnthropic,
+		AiProviderTypeAzure,
+		AiProviderTypeBedrock,
+		AiProviderTypeGoogle,
+		AiProviderTypeOpenaiCompat,
+		AiProviderTypeOpenrouter,
+		AiProviderTypeVercel,
 	}
 }
 

--- a/codersdk/aiproviders.go
+++ b/codersdk/aiproviders.go
@@ -19,6 +19,20 @@ type AIProviderType string
 const (
 	AIProviderTypeOpenAI    AIProviderType = "openai"
 	AIProviderTypeAnthropic AIProviderType = "anthropic"
+	// AIProviderTypeAzure, AIProviderTypeGoogle, AIProviderTypeOpenAICompat,
+	// AIProviderTypeOpenrouter, and AIProviderTypeVercel route through
+	// aibridge's OpenAI client today because chatd configures these
+	// providers against their OpenAI-compatible endpoints. Native
+	// gateway-side support arrives later without an enum change.
+	AIProviderTypeAzure        AIProviderType = "azure"
+	AIProviderTypeGoogle       AIProviderType = "google"
+	AIProviderTypeOpenAICompat AIProviderType = "openai-compat"
+	AIProviderTypeOpenrouter   AIProviderType = "openrouter"
+	AIProviderTypeVercel       AIProviderType = "vercel"
+	// AIProviderTypeBedrock routes through aibridge's Anthropic client
+	// using the Bedrock discriminator in Settings; native support is
+	// future work.
+	AIProviderTypeBedrock AIProviderType = "bedrock"
 )
 
 // AIProviderSettings is the discriminated container for type-specific

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -424,9 +424,26 @@ export interface AIProviderSettings {}
 export const AIProviderSettingsTypeBedrock = "bedrock";
 
 // From codersdk/aiproviders.go
-export type AIProviderType = "anthropic" | "openai";
+export type AIProviderType =
+	| "anthropic"
+	| "azure"
+	| "bedrock"
+	| "google"
+	| "openai"
+	| "openai-compat"
+	| "openrouter"
+	| "vercel";
 
-export const AIProviderTypes: AIProviderType[] = ["anthropic", "openai"];
+export const AIProviderTypes: AIProviderType[] = [
+	"anthropic",
+	"azure",
+	"bedrock",
+	"google",
+	"openai",
+	"openai-compat",
+	"openrouter",
+	"vercel",
+];
 
 // From codersdk/allowlist.go
 /**


### PR DESCRIPTION
*Disclaimer: implemented by a Coder Agent using Claude Opus 4.7*

Splits the `ai_provider_type` enum widening out of the original chatd PR so it can land as a focused database change ahead of the runtime and CLI plumbing it unlocks.

Adds six values to the Postgres enum: `azure`, `bedrock`, `google`, `openai-compat`, `openrouter`, `vercel`. Mirrors the new values in `codersdk.AIProviderType` and regenerates the SQL dump, Go models, and `typesGenerated.ts`. No runtime behaviour change: validation widening, env/seed mapping, and dbsource routing for the new types live in #25435.

`bedrock` here is the enum value used to tag native Bedrock providers when aibridge grows direct Bedrock support; current Bedrock providers still ride on `type='anthropic'` plus the bedrock discriminator in `ai_providers.settings`.

The down migration is a no-op because Postgres does not allow removing enum values safely, matching the precedent in `000495_ai_providers.down.sql`.

Part of the implementation of [RFC: Migrate chatd providers to ai_providers and route Coder-agent traffic via aibridge](https://www.notion.so/coderhq/RFC-Migrate-chatd-providers-to-ai_providers-and-route-Coder-agent-traffic-via-aibridge-358d579be5928187a868eb8cb4db09b8).