### PR TITLE
fix(mise.toml): scope CGO_ENABLED to sqlc install

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,13 +1,6 @@
 [settings]
 lockfile = true
 
-[env]
-# Required for sqlc (coder fork) to compile against its sqlite dependency.
-# Mise applies [env] during `mise install`, but also at runtime when a
-# tool from this manifest is invoked. CGO_ENABLED is harmless to leave
-# set system-wide on the dogfood image.
-CGO_ENABLED = "1"
-
 [tools]
 # Languages and runtimes.
 bun = "1.2.15"
@@ -16,7 +9,6 @@ node = "22.19.0"
 pnpm = "10.33.2"
 
 # Codegen and proto toolchain.
-"go:github.com/coder/sqlc/cmd/sqlc" = "337309bfb9524f38466a5090e310040fc7af0203"
 "go:go.uber.org/mock/mockgen" = "v0.6.0"
 "go:storj.io/drpc/cmd/protoc-gen-go-drpc" = "v0.0.34"
 protoc = "23.4"
@@ -70,3 +62,12 @@ lazygit = "0.61.1"
 [tools."http:helm"]
 version = "3.12.0"
 url = 'https://get.helm.sh/helm-v{{version}}-{{os(macos="darwin")}}-{{arch(x64="amd64")}}.tar.gz'
+
+# sqlc (coder fork) bundles sqlite via cgo, so the `go install` build
+# needs CGO_ENABLED=1. Scope it with `install_env` so it only applies
+# during install. A top-level `[env]` would re-export CGO_ENABLED=1
+# through every mise shim at runtime and break cross-compilation of
+# coderd (scripts/build_go.sh expects cgo=0 for slim builds).
+[tools."go:github.com/coder/sqlc/cmd/sqlc"]
+version = "337309bfb9524f38466a5090e310040fc7af0203"
+install_env = { CGO_ENABLED = "1" }


### PR DESCRIPTION
Follow-up to #25387. The top-level `[env] CGO_ENABLED = "1"` was re-exported through every mise shim at runtime, forcing cgo on for `go build` calls and breaking cross-compilation of coderd (slim builds, `./scripts/develop.sh`) on the dogfood image.

`scripts/build_go.sh` sets `CGO_ENABLED=0` explicitly for non-boringcrypto builds, but the mise shim overwrites it back to `1` before `go` runs. Scope the variable to sqlc's `install_env` so it only applies during the one `go install` that needs it.

Ref: https://mise.en.dev/configuration.html#tools-dev-tools