### PR TITLE
chore: disable noEmptyInterface biome rule

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -146,5 +146,19 @@
 			"tailwindDirectives": true
 		}
 	},
+	"overrides": [
+		{
+			// Generated Go types can produce empty interfaces; the
+			// safe fix conflicts with noBannedTypes.
+			"includes": ["**/typesGenerated.ts"],
+			"linter": {
+				"rules": {
+					"suspicious": {
+						"noEmptyInterface": "off"
+					}
+				}
+			}
+		}
+	],
 	"$schema": "./node_modules/@biomejs/biome/configuration_schema.json"
 }


### PR DESCRIPTION
*Disclaimer: implemented by a Coder Agent using Claude Opus 4.6*

The `noEmptyInterface` rule is enabled by default as a recommended Biome rule. Its safe fix converts empty interfaces to type aliases (e.g. `export interface X {}` becomes `export type X = {}`), which then conflicts with `noBannedTypes` on the empty `{}` type. Since empty interfaces are legitimately produced by Go-to-TypeScript code generation, this disables the rule entirely.

<details><summary>Context</summary>

Discussion in Slack concluded that disabling the rule is preferable to adding per-type exceptions in `scripts/apitypings/main.go`, since the safe fix itself creates a worse lint violation.

</details>