### PR TITLE
feat(coderd): include shared workspaces in workspace updates

### DIFF
--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -5216,12 +5216,12 @@ func (q *querier) GetWorkspaces(ctx context.Context, arg database.GetWorkspacesP
 	return q.db.GetAuthorizedWorkspaces(ctx, arg, prep)
 }
 
-func (q *querier) GetWorkspacesAndAgentsByOwnerID(ctx context.Context, ownerID uuid.UUID) ([]database.GetWorkspacesAndAgentsByOwnerIDRow, error) {
+func (q *querier) GetWorkspacesAndAgentsByOwnerID(ctx context.Context) ([]database.GetWorkspacesAndAgentsByOwnerIDRow, error) {
 	prep, err := prepareSQLFilter(ctx, q.auth, policy.ActionRead, rbac.ResourceWorkspace.Type)
 	if err != nil {
 		return nil, xerrors.Errorf("(dev error) prepare sql filter: %w", err)
 	}
-	return q.db.GetAuthorizedWorkspacesAndAgentsByOwnerID(ctx, ownerID, prep)
+	return q.db.GetAuthorizedWorkspacesAndAgentsByOwnerID(ctx, prep)
 }
 
 func (q *querier) GetWorkspacesByTemplateID(ctx context.Context, templateID uuid.UUID) ([]database.WorkspaceTable, error) {
@@ -8237,8 +8237,8 @@ func (q *querier) GetAuthorizedWorkspaces(ctx context.Context, arg database.GetW
 	return q.GetWorkspaces(ctx, arg)
 }
 
-func (q *querier) GetAuthorizedWorkspacesAndAgentsByOwnerID(ctx context.Context, ownerID uuid.UUID, _ rbac.PreparedAuthorized) ([]database.GetWorkspacesAndAgentsByOwnerIDRow, error) {
-	return q.GetWorkspacesAndAgentsByOwnerID(ctx, ownerID)
+func (q *querier) GetAuthorizedWorkspacesAndAgentsByOwnerID(ctx context.Context, _ rbac.PreparedAuthorized) ([]database.GetWorkspacesAndAgentsByOwnerIDRow, error) {
+	return q.GetWorkspacesAndAgentsByOwnerID(ctx)
 }
 
 // GetAuthorizedUsers is not required for dbauthz since GetUsers is already

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -3188,17 +3188,15 @@ func (s *MethodTestSuite) TestWorkspace() {
 		// No asserts here because SQLFilter.
 		check.Args(arg, emptyPreparedAuthorized{}).Asserts()
 	}))
-	s.Run("GetWorkspacesAndAgentsByOwnerID", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
-		ws := testutil.Fake(s.T(), faker, database.Workspace{})
-		dbm.EXPECT().GetAuthorizedWorkspacesAndAgentsByOwnerID(gomock.Any(), ws.OwnerID, gomock.Any()).Return([]database.GetWorkspacesAndAgentsByOwnerIDRow{}, nil).AnyTimes()
+	s.Run("GetWorkspacesAndAgentsByOwnerID", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
+		dbm.EXPECT().GetAuthorizedWorkspacesAndAgentsByOwnerID(gomock.Any(), gomock.Any()).Return([]database.GetWorkspacesAndAgentsByOwnerIDRow{}, nil).AnyTimes()
 		// No asserts here because SQLFilter.
-		check.Args(ws.OwnerID).Asserts()
+		check.Args().Asserts()
 	}))
-	s.Run("GetAuthorizedWorkspacesAndAgentsByOwnerID", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
-		ws := testutil.Fake(s.T(), faker, database.Workspace{})
-		dbm.EXPECT().GetAuthorizedWorkspacesAndAgentsByOwnerID(gomock.Any(), ws.OwnerID, gomock.Any()).Return([]database.GetWorkspacesAndAgentsByOwnerIDRow{}, nil).AnyTimes()
+	s.Run("GetAuthorizedWorkspacesAndAgentsByOwnerID", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
+		dbm.EXPECT().GetAuthorizedWorkspacesAndAgentsByOwnerID(gomock.Any(), gomock.Any()).Return([]database.GetWorkspacesAndAgentsByOwnerIDRow{}, nil).AnyTimes()
 		// No asserts here because SQLFilter.
-		check.Args(ws.OwnerID, emptyPreparedAuthorized{}).Asserts()
+		check.Args(emptyPreparedAuthorized{}).Asserts()
 	}))
 	s.Run("GetWorkspaceACLByID", s.Mocked(func(dbM *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		ws := testutil.Fake(s.T(), faker, database.Workspace{})

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -3569,9 +3569,9 @@ func (m queryMetricsStore) GetWorkspaces(ctx context.Context, arg database.GetWo
 	return r0, r1
 }
 
-func (m queryMetricsStore) GetWorkspacesAndAgentsByOwnerID(ctx context.Context, ownerID uuid.UUID) ([]database.GetWorkspacesAndAgentsByOwnerIDRow, error) {
+func (m queryMetricsStore) GetWorkspacesAndAgentsByOwnerID(ctx context.Context) ([]database.GetWorkspacesAndAgentsByOwnerIDRow, error) {
 	start := time.Now()
-	r0, r1 := m.s.GetWorkspacesAndAgentsByOwnerID(ctx, ownerID)
+	r0, r1 := m.s.GetWorkspacesAndAgentsByOwnerID(ctx)
 	m.queryLatencies.WithLabelValues("GetWorkspacesAndAgentsByOwnerID").Observe(time.Since(start).Seconds())
 	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetWorkspacesAndAgentsByOwnerID").Inc()
 	return r0, r1
@@ -6033,9 +6033,9 @@ func (m queryMetricsStore) GetAuthorizedWorkspaces(ctx context.Context, arg data
 	return r0, r1
 }
 
-func (m queryMetricsStore) GetAuthorizedWorkspacesAndAgentsByOwnerID(ctx context.Context, ownerID uuid.UUID, prepared rbac.PreparedAuthorized) ([]database.GetWorkspacesAndAgentsByOwnerIDRow, error) {
+func (m queryMetricsStore) GetAuthorizedWorkspacesAndAgentsByOwnerID(ctx context.Context, prepared rbac.PreparedAuthorized) ([]database.GetWorkspacesAndAgentsByOwnerIDRow, error) {
 	start := time.Now()
-	r0, r1 := m.s.GetAuthorizedWorkspacesAndAgentsByOwnerID(ctx, ownerID, prepared)
+	r0, r1 := m.s.GetAuthorizedWorkspacesAndAgentsByOwnerID(ctx, prepared)
 	m.queryLatencies.WithLabelValues("GetAuthorizedWorkspacesAndAgentsByOwnerID").Observe(time.Since(start).Seconds())
 	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetAuthorizedWorkspacesAndAgentsByOwnerID").Inc()
 	return r0, r1

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -2207,18 +2207,18 @@ func (mr *MockStoreMockRecorder) GetAuthorizedWorkspaces(ctx, arg, prepared any)
 }
 
 // GetAuthorizedWorkspacesAndAgentsByOwnerID mocks base method.
-func (m *MockStore) GetAuthorizedWorkspacesAndAgentsByOwnerID(ctx context.Context, ownerID uuid.UUID, prepared rbac.PreparedAuthorized) ([]database.GetWorkspacesAndAgentsByOwnerIDRow, error) {
+func (m *MockStore) GetAuthorizedWorkspacesAndAgentsByOwnerID(ctx context.Context, prepared rbac.PreparedAuthorized) ([]database.GetWorkspacesAndAgentsByOwnerIDRow, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAuthorizedWorkspacesAndAgentsByOwnerID", ctx, ownerID, prepared)
+	ret := m.ctrl.Call(m, "GetAuthorizedWorkspacesAndAgentsByOwnerID", ctx, prepared)
 	ret0, _ := ret[0].([]database.GetWorkspacesAndAgentsByOwnerIDRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAuthorizedWorkspacesAndAgentsByOwnerID indicates an expected call of GetAuthorizedWorkspacesAndAgentsByOwnerID.
-func (mr *MockStoreMockRecorder) GetAuthorizedWorkspacesAndAgentsByOwnerID(ctx, ownerID, prepared any) *gomock.Call {
+func (mr *MockStoreMockRecorder) GetAuthorizedWorkspacesAndAgentsByOwnerID(ctx, prepared any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAuthorizedWorkspacesAndAgentsByOwnerID", reflect.TypeOf((*MockStore)(nil).GetAuthorizedWorkspacesAndAgentsByOwnerID), ctx, ownerID, prepared)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAuthorizedWorkspacesAndAgentsByOwnerID", reflect.TypeOf((*MockStore)(nil).GetAuthorizedWorkspacesAndAgentsByOwnerID), ctx, prepared)
 }
 
 // GetChatAdvisorConfig mocks base method.
@@ -6677,18 +6677,18 @@ func (mr *MockStoreMockRecorder) GetWorkspaces(ctx, arg any) *gomock.Call {
 }
 
 // GetWorkspacesAndAgentsByOwnerID mocks base method.
-func (m *MockStore) GetWorkspacesAndAgentsByOwnerID(ctx context.Context, ownerID uuid.UUID) ([]database.GetWorkspacesAndAgentsByOwnerIDRow, error) {
+func (m *MockStore) GetWorkspacesAndAgentsByOwnerID(ctx context.Context) ([]database.GetWorkspacesAndAgentsByOwnerIDRow, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetWorkspacesAndAgentsByOwnerID", ctx, ownerID)
+	ret := m.ctrl.Call(m, "GetWorkspacesAndAgentsByOwnerID", ctx)
 	ret0, _ := ret[0].([]database.GetWorkspacesAndAgentsByOwnerIDRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetWorkspacesAndAgentsByOwnerID indicates an expected call of GetWorkspacesAndAgentsByOwnerID.
-func (mr *MockStoreMockRecorder) GetWorkspacesAndAgentsByOwnerID(ctx, ownerID any) *gomock.Call {
+func (mr *MockStoreMockRecorder) GetWorkspacesAndAgentsByOwnerID(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspacesAndAgentsByOwnerID", reflect.TypeOf((*MockStore)(nil).GetWorkspacesAndAgentsByOwnerID), ctx, ownerID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkspacesAndAgentsByOwnerID", reflect.TypeOf((*MockStore)(nil).GetWorkspacesAndAgentsByOwnerID), ctx)
 }
 
 // GetWorkspacesByTemplateID mocks base method.

--- a/coderd/database/modelqueries.go
+++ b/coderd/database/modelqueries.go
@@ -235,7 +235,7 @@ func (q *sqlQuerier) GetTemplateGroupRoles(ctx context.Context, id uuid.UUID) ([
 
 type workspaceQuerier interface {
 	GetAuthorizedWorkspaces(ctx context.Context, arg GetWorkspacesParams, prepared rbac.PreparedAuthorized) ([]GetWorkspacesRow, error)
-	GetAuthorizedWorkspacesAndAgentsByOwnerID(ctx context.Context, ownerID uuid.UUID, prepared rbac.PreparedAuthorized) ([]GetWorkspacesAndAgentsByOwnerIDRow, error)
+	GetAuthorizedWorkspacesAndAgentsByOwnerID(ctx context.Context, prepared rbac.PreparedAuthorized) ([]GetWorkspacesAndAgentsByOwnerIDRow, error)
 }
 
 // GetAuthorizedWorkspaces returns all workspaces that the user is authorized to access.
@@ -348,7 +348,7 @@ func (q *sqlQuerier) GetAuthorizedWorkspaces(ctx context.Context, arg GetWorkspa
 	return items, nil
 }
 
-func (q *sqlQuerier) GetAuthorizedWorkspacesAndAgentsByOwnerID(ctx context.Context, ownerID uuid.UUID, prepared rbac.PreparedAuthorized) ([]GetWorkspacesAndAgentsByOwnerIDRow, error) {
+func (q *sqlQuerier) GetAuthorizedWorkspacesAndAgentsByOwnerID(ctx context.Context, prepared rbac.PreparedAuthorized) ([]GetWorkspacesAndAgentsByOwnerIDRow, error) {
 	authorizedFilter, err := prepared.CompileToSQL(ctx, rbac.ConfigWorkspaces())
 	if err != nil {
 		return nil, xerrors.Errorf("compile authorized filter: %w", err)
@@ -363,7 +363,7 @@ func (q *sqlQuerier) GetAuthorizedWorkspacesAndAgentsByOwnerID(ctx context.Conte
 
 	// The name comment is for metric tracking
 	query := fmt.Sprintf("-- name: GetAuthorizedWorkspacesAndAgentsByOwnerID :many\n%s", filtered)
-	rows, err := q.db.QueryContext(ctx, query, ownerID)
+	rows, err := q.db.QueryContext(ctx, query)
 	if err != nil {
 		return nil, err
 	}

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -876,7 +876,12 @@ type sqlcQuerier interface {
 	// It has to be a CTE because the set returning function 'unnest' cannot
 	// be used in a WHERE clause.
 	GetWorkspaces(ctx context.Context, arg GetWorkspacesParams) ([]GetWorkspacesRow, error)
-	GetWorkspacesAndAgentsByOwnerID(ctx context.Context, ownerID uuid.UUID) ([]GetWorkspacesAndAgentsByOwnerIDRow, error)
+	//
+	// Returns workspaces the calling actor is authorized to read, both ones they
+	// own and ones shared with them via user_acl/group_acl. The query relies on
+	// the @authorize_filter (ActionRead against rbac.ResourceWorkspace) for
+	// visibility; the name is preserved to avoid churn in callers and metrics.
+	GetWorkspacesAndAgentsByOwnerID(ctx context.Context) ([]GetWorkspacesAndAgentsByOwnerIDRow, error)
 	GetWorkspacesByTemplateID(ctx context.Context, templateID uuid.UUID) ([]WorkspaceTable, error)
 	GetWorkspacesEligibleForTransition(ctx context.Context, now time.Time) ([]GetWorkspacesEligibleForTransitionRow, error)
 	GetWorkspacesForWorkspaceMetrics(ctx context.Context) ([]GetWorkspacesForWorkspaceMetricsRow, error)

--- a/coderd/database/querier_test.go
+++ b/coderd/database/querier_test.go
@@ -1127,6 +1127,9 @@ func TestGetAuthorizedWorkspacesAndAgentsByOwnerID(t *testing.T) {
 		RBACRoles: []string{rbac.RoleOwner().String()},
 	})
 	user := dbgen.User(t, db, database.User{})
+	// sharedUser is granted ActionRead on succeededID via user_acl, so they
+	// should see exactly that one workspace through the authorized query.
+	sharedUser := dbgen.User(t, db, database.User{})
 	tpl := dbgen.Template(t, db, database.Template{
 		OrganizationID: org.ID,
 		CreatedBy:      owner.ID,
@@ -1165,6 +1168,18 @@ func TestGetAuthorizedWorkspacesAndAgentsByOwnerID(t *testing.T) {
 		CreateAgent:         false,
 	})
 
+	// Grant sharedUser ActionRead on succeededID via user_acl.
+	setupCtx := testutil.Context(t, testutil.WaitMedium)
+	require.NoError(t, db.UpdateWorkspaceACLByID(setupCtx, database.UpdateWorkspaceACLByIDParams{
+		ID: succeededID,
+		UserACL: database.WorkspaceACL{
+			sharedUser.ID.String(): {
+				Permissions: []policy.Action{policy.ActionRead},
+			},
+		},
+		GroupACL: database.WorkspaceACL{},
+	}))
+
 	ownerCheckFn := func(ownerRows []database.GetWorkspacesAndAgentsByOwnerIDRow) {
 		require.Len(t, ownerRows, 4)
 		for _, row := range ownerRows {
@@ -1188,6 +1203,13 @@ func TestGetAuthorizedWorkspacesAndAgentsByOwnerID(t *testing.T) {
 			}
 		}
 	}
+	sharedCheckFn := func(sharedRows []database.GetWorkspacesAndAgentsByOwnerIDRow) {
+		require.Len(t, sharedRows, 1)
+		require.Equal(t, succeededID, sharedRows[0].ID)
+		require.Len(t, sharedRows[0].Agents, 2)
+		require.Equal(t, database.ProvisionerJobStatusSucceeded, sharedRows[0].JobStatus)
+		require.Equal(t, database.WorkspaceTransitionStart, sharedRows[0].Transition)
+	}
 	t.Run("sqlQuerier", func(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.Context(t, testutil.WaitMedium)
@@ -1197,7 +1219,7 @@ func TestGetAuthorizedWorkspacesAndAgentsByOwnerID(t *testing.T) {
 		preparedUser, err := authorizer.Prepare(ctx, userSubject, policy.ActionRead, rbac.ResourceWorkspace.Type)
 		require.NoError(t, err)
 		userCtx := dbauthz.As(ctx, userSubject)
-		userRows, err := db.GetAuthorizedWorkspacesAndAgentsByOwnerID(userCtx, owner.ID, preparedUser)
+		userRows, err := db.GetAuthorizedWorkspacesAndAgentsByOwnerID(userCtx, preparedUser)
 		require.NoError(t, err)
 		require.Len(t, userRows, 0)
 
@@ -1206,9 +1228,18 @@ func TestGetAuthorizedWorkspacesAndAgentsByOwnerID(t *testing.T) {
 		preparedOwner, err := authorizer.Prepare(ctx, ownerSubject, policy.ActionRead, rbac.ResourceWorkspace.Type)
 		require.NoError(t, err)
 		ownerCtx := dbauthz.As(ctx, ownerSubject)
-		ownerRows, err := db.GetAuthorizedWorkspacesAndAgentsByOwnerID(ownerCtx, owner.ID, preparedOwner)
+		ownerRows, err := db.GetAuthorizedWorkspacesAndAgentsByOwnerID(ownerCtx, preparedOwner)
 		require.NoError(t, err)
 		ownerCheckFn(ownerRows)
+
+		sharedSubject, _, err := httpmw.UserRBACSubject(ctx, db, sharedUser.ID, rbac.ExpandableScope(rbac.ScopeAll))
+		require.NoError(t, err)
+		preparedShared, err := authorizer.Prepare(ctx, sharedSubject, policy.ActionRead, rbac.ResourceWorkspace.Type)
+		require.NoError(t, err)
+		sharedCtx := dbauthz.As(ctx, sharedSubject)
+		sharedRows, err := db.GetAuthorizedWorkspacesAndAgentsByOwnerID(sharedCtx, preparedShared)
+		require.NoError(t, err)
+		sharedCheckFn(sharedRows)
 	})
 
 	t.Run("dbauthz", func(t *testing.T) {
@@ -1225,13 +1256,21 @@ func TestGetAuthorizedWorkspacesAndAgentsByOwnerID(t *testing.T) {
 		require.NoError(t, err)
 		ownerCtx := dbauthz.As(ctx, ownerSubject)
 
-		userRows, err := authzdb.GetWorkspacesAndAgentsByOwnerID(userCtx, owner.ID)
+		sharedSubject, _, err := httpmw.UserRBACSubject(ctx, authzdb, sharedUser.ID, rbac.ExpandableScope(rbac.ScopeAll))
+		require.NoError(t, err)
+		sharedCtx := dbauthz.As(ctx, sharedSubject)
+
+		userRows, err := authzdb.GetWorkspacesAndAgentsByOwnerID(userCtx)
 		require.NoError(t, err)
 		require.Len(t, userRows, 0)
 
-		ownerRows, err := authzdb.GetWorkspacesAndAgentsByOwnerID(ownerCtx, owner.ID)
+		ownerRows, err := authzdb.GetWorkspacesAndAgentsByOwnerID(ownerCtx)
 		require.NoError(t, err)
 		ownerCheckFn(ownerRows)
+
+		sharedRows, err := authzdb.GetWorkspacesAndAgentsByOwnerID(sharedCtx)
+		require.NoError(t, err)
+		sharedCheckFn(sharedRows)
 	})
 }
 

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -34786,9 +34786,7 @@ LEFT JOIN LATERAL (
 	WHERE job_id = latest_build.job_id
 ) resources ON true
 WHERE
-	-- Filter by owner_id
-	workspaces.owner_id = $1 :: uuid
-	AND workspaces.deleted = false
+	workspaces.deleted = false
 	-- Authorize Filter clause will be injected below in GetAuthorizedWorkspacesAndAgentsByOwnerID
 	-- @authorize_filter
 GROUP BY workspaces.id, workspaces.name, latest_build.job_status, latest_build.job_id, latest_build.transition
@@ -34802,8 +34800,12 @@ type GetWorkspacesAndAgentsByOwnerIDRow struct {
 	Agents     []AgentIDNamePair    `db:"agents" json:"agents"`
 }
 
-func (q *sqlQuerier) GetWorkspacesAndAgentsByOwnerID(ctx context.Context, ownerID uuid.UUID) ([]GetWorkspacesAndAgentsByOwnerIDRow, error) {
-	rows, err := q.db.QueryContext(ctx, getWorkspacesAndAgentsByOwnerID, ownerID)
+// Returns workspaces the calling actor is authorized to read, both ones they
+// own and ones shared with them via user_acl/group_acl. The query relies on
+// the @authorize_filter (ActionRead against rbac.ResourceWorkspace) for
+// visibility; the name is preserved to avoid churn in callers and metrics.
+func (q *sqlQuerier) GetWorkspacesAndAgentsByOwnerID(ctx context.Context) ([]GetWorkspacesAndAgentsByOwnerIDRow, error) {
+	rows, err := q.db.QueryContext(ctx, getWorkspacesAndAgentsByOwnerID)
 	if err != nil {
 		return nil, err
 	}

--- a/coderd/database/queries/workspaces.sql
+++ b/coderd/database/queries/workspaces.sql
@@ -878,6 +878,11 @@ UPDATE workspaces SET favorite = true WHERE id = @id;
 UPDATE workspaces SET favorite = false WHERE id = @id;
 
 -- name: GetWorkspacesAndAgentsByOwnerID :many
+--
+-- Returns workspaces the calling actor is authorized to read, both ones they
+-- own and ones shared with them via user_acl/group_acl. The query relies on
+-- the @authorize_filter (ActionRead against rbac.ResourceWorkspace) for
+-- visibility; the name is preserved to avoid churn in callers and metrics.
 SELECT
 	workspaces.id as id,
 	workspaces.name as name,
@@ -911,9 +916,7 @@ LEFT JOIN LATERAL (
 	WHERE job_id = latest_build.job_id
 ) resources ON true
 WHERE
-	-- Filter by owner_id
-	workspaces.owner_id = @owner_id :: uuid
-	AND workspaces.deleted = false
+	workspaces.deleted = false
 	-- Authorize Filter clause will be injected below in GetAuthorizedWorkspacesAndAgentsByOwnerID
 	-- @authorize_filter
 GROUP BY workspaces.id, workspaces.name, latest_build.job_status, latest_build.job_id, latest_build.transition;

--- a/coderd/workspaceupdates.go
+++ b/coderd/workspaceupdates.go
@@ -21,8 +21,10 @@ import (
 )
 
 type UpdatesQuerier interface {
-	// GetAuthorizedWorkspacesAndAgentsByOwnerID requires a context with an actor set
-	GetWorkspacesAndAgentsByOwnerID(ctx context.Context, ownerID uuid.UUID) ([]database.GetWorkspacesAndAgentsByOwnerIDRow, error)
+	// GetWorkspacesAndAgentsByOwnerID requires a context with an actor set.
+	// Despite the legacy name, it returns every workspace the actor is
+	// authorized to read (owned plus user_acl / group_acl shared).
+	GetWorkspacesAndAgentsByOwnerID(ctx context.Context) ([]database.GetWorkspacesAndAgentsByOwnerIDRow, error)
 	GetWorkspaceByAgentID(ctx context.Context, agentID uuid.UUID) (database.Workspace, error)
 }
 
@@ -54,7 +56,7 @@ type sub struct {
 	ps     pubsub.Pubsub
 	logger slog.Logger
 
-	psCancelFn func()
+	psCancelFns []func()
 }
 
 func (s *sub) handleEvent(ctx context.Context, event wspubsub.WorkspaceEvent, err error) {
@@ -74,8 +76,29 @@ func (s *sub) handleEvent(ctx context.Context, event wspubsub.WorkspaceEvent, er
 		s.logger.Warn(ctx, "failed to handle workspace event", slog.Error(err))
 	}
 
+	s.requery(ctx)
+}
+
+// handleBuildUpdate is the all-workspaces channel handler used to pick up
+// state changes for workspaces shared with this user. The payload schema on
+// AllWorkspaceEventChannel is WorkspaceBuildUpdate; we ignore the payload and
+// just trigger a re-query, which produceUpdate will diff against s.prev.
+func (s *sub) handleBuildUpdate(ctx context.Context, _ codersdk.WorkspaceBuildUpdate, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err != nil {
+		s.logger.Warn(ctx, "failed to handle workspace build update", slog.Error(err))
+	}
+
+	s.requery(ctx)
+}
+
+// requery refreshes the subscriber's view of authorized workspaces and emits
+// any delta to the update channel. Callers must hold s.mu.
+func (s *sub) requery(ctx context.Context) {
 	// Use context containing actor
-	rows, err := s.db.GetWorkspacesAndAgentsByOwnerID(s.ctx, s.userID)
+	rows, err := s.db.GetWorkspacesAndAgentsByOwnerID(s.ctx)
 	if err != nil {
 		s.logger.Warn(ctx, "failed to get workspaces and agents by owner ID", slog.Error(err))
 		return
@@ -96,7 +119,7 @@ func (s *sub) handleEvent(ctx context.Context, event wspubsub.WorkspaceEvent, er
 }
 
 func (s *sub) start(ctx context.Context) (err error) {
-	rows, err := s.db.GetWorkspacesAndAgentsByOwnerID(ctx, s.userID)
+	rows, err := s.db.GetWorkspacesAndAgentsByOwnerID(ctx)
 	if err != nil {
 		return xerrors.Errorf("get workspaces and agents by owner ID: %w", err)
 	}
@@ -106,20 +129,37 @@ func (s *sub) start(ctx context.Context) (err error) {
 	s.ch <- initUpdate
 	s.prev = latest
 
-	cancel, err := s.ps.SubscribeWithErr(wspubsub.WorkspaceEventChannel(s.userID), wspubsub.HandleWorkspaceEvent(s.handleEvent))
+	// Subscribe to events for workspaces owned by this user.
+	ownerCancel, err := s.ps.SubscribeWithErr(
+		wspubsub.WorkspaceEventChannel(s.userID),
+		wspubsub.HandleWorkspaceEvent(s.handleEvent),
+	)
 	if err != nil {
 		return xerrors.Errorf("subscribe to workspace event channel: %w", err)
 	}
+	s.psCancelFns = append(s.psCancelFns, ownerCancel)
 
-	s.psCancelFn = cancel
+	// Also subscribe to the all-workspaces channel so we pick up build events
+	// for workspaces shared with this user via user_acl / group_acl. The
+	// handler re-queries and produceUpdate diffs against s.prev, so extra
+	// wake-ups from unrelated workspaces are cheap.
+	allCancel, err := s.ps.SubscribeWithErr(
+		wspubsub.AllWorkspaceEventChannel,
+		wspubsub.HandleWorkspaceBuildUpdate(s.handleBuildUpdate),
+	)
+	if err != nil {
+		return xerrors.Errorf("subscribe to all workspace event channel: %w", err)
+	}
+	s.psCancelFns = append(s.psCancelFns, allCancel)
+
 	return nil
 }
 
 func (s *sub) Close() error {
 	s.cancelFn()
 
-	if s.psCancelFn != nil {
-		s.psCancelFn()
+	for _, cancel := range s.psCancelFns {
+		cancel()
 	}
 
 	close(s.ch)

--- a/coderd/workspaceupdates_test.go
+++ b/coderd/workspaceupdates_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/coder/coder/v2/coderd/rbac"
 	"github.com/coder/coder/v2/coderd/rbac/policy"
 	"github.com/coder/coder/v2/coderd/wspubsub"
+	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/tailnet"
 	"github.com/coder/coder/v2/tailnet/proto"
 	"github.com/coder/coder/v2/testutil"
@@ -302,6 +303,92 @@ func TestWorkspaceUpdates(t *testing.T) {
 		})
 		require.Equal(t, expected, update)
 	})
+
+	// SharedWorkspaceAppears asserts that a build event on the all-workspaces
+	// channel triggers a re-query and surfaces a workspace shared with the
+	// subscriber via user_acl/group_acl. The workspace is owned by some other
+	// user, so no event ever lands on WorkspaceEventChannel(subscriberID).
+	t.Run("SharedWorkspaceAppears", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitShort)
+
+		// On the initial subscribe the subscriber sees only ws1 (their own).
+		db := &mockWorkspaceStore{
+			orderedRows: []database.GetWorkspacesAndAgentsByOwnerIDRow{
+				{
+					ID:         ws1ID,
+					Name:       "ws1",
+					JobStatus:  database.ProvisionerJobStatusRunning,
+					Transition: database.WorkspaceTransitionStart,
+					Agents: []database.AgentIDNamePair{
+						{ID: agent1ID, Name: "agent1"},
+					},
+				},
+			},
+		}
+
+		ps := &mockPubsub{
+			cbs: map[string]pubsub.ListenerWithErr{},
+		}
+
+		updateProvider := coderd.NewUpdatesProvider(testutil.Logger(t), ps, db, &mockAuthorizer{})
+		t.Cleanup(func() {
+			_ = updateProvider.Close()
+		})
+
+		sub, err := updateProvider.Subscribe(dbauthz.As(ctx, ownerSubject), ownerID)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_ = sub.Close()
+		})
+
+		// Drain the initial snapshot.
+		initial := testutil.TryReceive(ctx, t, sub.Updates())
+		require.Len(t, initial.UpsertedWorkspaces, 1)
+
+		// Simulate a shared workspace becoming visible to the subscriber. The
+		// build happens on a workspace owned by someone else (ws2 / agent2),
+		// so the event is published only on the all-workspaces channel.
+		db.orderedRows = append(db.orderedRows, database.GetWorkspacesAndAgentsByOwnerIDRow{
+			ID:         ws2ID,
+			Name:       "ws2",
+			JobStatus:  database.ProvisionerJobStatusRunning,
+			Transition: database.WorkspaceTransitionStart,
+			Agents: []database.AgentIDNamePair{
+				{ID: agent2ID, Name: "agent2"},
+			},
+		})
+
+		publishWorkspaceBuildUpdate(t, ps, codersdk.WorkspaceBuildUpdate{
+			WorkspaceID:   ws2ID,
+			WorkspaceName: "ws2",
+			BuildID:       uuid.New(),
+			Transition:    "start",
+			JobStatus:     string(codersdk.ProvisionerJobRunning),
+			BuildNumber:   1,
+		})
+
+		update := testutil.TryReceive(ctx, t, sub.Updates())
+		require.Equal(t, &proto.WorkspaceUpdate{
+			UpsertedWorkspaces: []*proto.Workspace{
+				{
+					Id:     ws2IDSlice,
+					Name:   "ws2",
+					Status: proto.Workspace_STARTING,
+				},
+			},
+			UpsertedAgents: []*proto.Agent{
+				{
+					Id:          agent2IDSlice,
+					Name:        "agent2",
+					WorkspaceId: ws2IDSlice,
+				},
+			},
+			DeletedWorkspaces: []*proto.Workspace{},
+			DeletedAgents:     []*proto.Agent{},
+		}, update)
+	})
 }
 
 func publishWorkspaceEvent(t *testing.T, ps pubsub.Pubsub, ownerID uuid.UUID, event *wspubsub.WorkspaceEvent) {
@@ -310,12 +397,18 @@ func publishWorkspaceEvent(t *testing.T, ps pubsub.Pubsub, ownerID uuid.UUID, ev
 	ps.Publish(wspubsub.WorkspaceEventChannel(ownerID), msg)
 }
 
+func publishWorkspaceBuildUpdate(t *testing.T, ps pubsub.Pubsub, update codersdk.WorkspaceBuildUpdate) {
+	msg, err := json.Marshal(update)
+	require.NoError(t, err)
+	ps.Publish(wspubsub.AllWorkspaceEventChannel, msg)
+}
+
 type mockWorkspaceStore struct {
 	orderedRows []database.GetWorkspacesAndAgentsByOwnerIDRow
 }
 
-// GetAuthorizedWorkspacesAndAgentsByOwnerID implements coderd.UpdatesQuerier.
-func (m *mockWorkspaceStore) GetWorkspacesAndAgentsByOwnerID(context.Context, uuid.UUID) ([]database.GetWorkspacesAndAgentsByOwnerIDRow, error) {
+// GetWorkspacesAndAgentsByOwnerID implements coderd.UpdatesQuerier.
+func (m *mockWorkspaceStore) GetWorkspacesAndAgentsByOwnerID(context.Context) ([]database.GetWorkspacesAndAgentsByOwnerIDRow, error) {
 	return m.orderedRows, nil
 }
 


### PR DESCRIPTION
Widen the workspace-updates stream so it covers workspaces shared with the user via `user_acl` / `group_acl`, not only ones they own. Unblocks shared-workspaces support in Coder Desktop with no proto changes.

- `GetWorkspacesAndAgentsByOwnerID` drops the hard `owner_id` filter; the existing `@authorize_filter` (ActionRead on `rbac.ResourceWorkspace`) already covers owned + ACL-shared workspaces.
- `sub` now also subscribes to `wspubsub.AllWorkspaceEventChannel` so build events on shared workspaces wake up its diff/requery flow.
- Tests cover the SQL path (sharedUser sees the one shared workspace, owner still sees all, unrelated user still sees none) and the pubsub path (build update on the all-channel produces the expected delta).

<details>
<summary>Notes for reviewers</summary>

- `ownerID` is removed end-to-end from `GetWorkspacesAndAgentsByOwnerID` / `GetAuthorizedWorkspacesAndAgentsByOwnerID`. The name is kept to avoid further churn; a rename can land separately.
- The all-channel currently carries `WorkspaceBuildUpdate` payloads (not `WorkspaceEvent`), so the new subscription uses `HandleWorkspaceBuildUpdate` and just triggers a re-query. Agent-only events for shared workspaces will not wake the subscriber, but `produceUpdate` will still pick up any state diff on the next build or owner-side event.
- No proto, audit table, or CLI changes.

</details>

> Generated with Coder Agents on behalf of @aslilac.