### PR TITLE
feat(coderd): add shared-with workspace search filter

### DIFF
--- a/coderd/database/modelqueries.go
+++ b/coderd/database/modelqueries.go
@@ -280,6 +280,8 @@ func (q *sqlQuerier) GetAuthorizedWorkspaces(ctx context.Context, arg GetWorkspa
 		arg.Shared,
 		arg.SharedWithUserID,
 		arg.SharedWithGroupID,
+		arg.SharedWithPrincipalUserID,
+		arg.SharedWithPrincipalGroupID,
 		arg.RequesterID,
 		arg.Offset,
 		arg.Limit,

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -34491,6 +34491,23 @@ WHERE
 			workspaces.group_acl ? ($23 :: uuid) :: text
 		ELSE true
 	END
+	-- Filter by shared-with principal. The principal is resolved at parse
+	-- time to either a user (shared_with_principal_user_id) or a group
+	-- (shared_with_principal_group_id); at most one is non-nil. A workspace
+	-- matches if the principal has access via user_acl, group_acl, or
+	-- (for users) via membership in any group present in group_acl.
+	AND CASE
+		WHEN $24 :: uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN
+			workspaces.user_acl ? ($24 :: uuid) :: text
+			OR EXISTS (
+				SELECT 1 FROM group_members_expanded gme
+				WHERE gme.user_id = $24 :: uuid
+					AND workspaces.group_acl ? gme.group_id :: text
+			)
+		WHEN $25 :: uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN
+			workspaces.group_acl ? ($25 :: uuid) :: text
+		ELSE true
+	END
 
 	-- Authorize Filter clause will be injected below in GetAuthorizedWorkspaces
 	-- @authorize_filter
@@ -34501,7 +34518,7 @@ WHERE
 		filtered_workspaces fw
 	ORDER BY
 		-- To ensure that 'favorite' workspaces show up first in the list only for their owner.
-		CASE WHEN favorite AND owner_username = (SELECT users.username FROM users WHERE users.id = $24) THEN 0 ELSE 1 END ASC,
+		CASE WHEN favorite AND owner_username = (SELECT users.username FROM users WHERE users.id = $26) THEN 0 ELSE 1 END ASC,
 		(latest_build_completed_at IS NOT NULL AND
 			latest_build_canceled_at IS NULL AND
 			latest_build_error IS NULL AND
@@ -34510,11 +34527,11 @@ WHERE
 		LOWER(name) ASC
 	LIMIT
 		CASE
-			WHEN $26 :: integer > 0 THEN
-				$26
+			WHEN $28 :: integer > 0 THEN
+				$28
 		END
 	OFFSET
-		$25
+		$27
 ), filtered_workspaces_order_with_summary AS (
 	SELECT
 		fwo.id, fwo.created_at, fwo.updated_at, fwo.owner_id, fwo.organization_id, fwo.template_id, fwo.deleted, fwo.name, fwo.autostart_schedule, fwo.ttl, fwo.last_used_at, fwo.dormant_at, fwo.deleting_at, fwo.automatic_updates, fwo.favorite, fwo.next_start_at, fwo.group_acl, fwo.user_acl, fwo.owner_avatar_url, fwo.owner_username, fwo.owner_name, fwo.organization_name, fwo.organization_display_name, fwo.organization_icon, fwo.organization_description, fwo.template_name, fwo.template_display_name, fwo.template_icon, fwo.template_description, fwo.task_id, fwo.group_acl_display_info, fwo.user_acl_display_info, fwo.template_version_id, fwo.template_version_name, fwo.latest_build_completed_at, fwo.latest_build_canceled_at, fwo.latest_build_error, fwo.latest_build_transition, fwo.latest_build_status, fwo.latest_build_has_external_agent
@@ -34566,7 +34583,7 @@ WHERE
 		'unknown'::provisioner_job_status, -- latest_build_status
 		false -- latest_build_has_external_agent
 	WHERE
-		$27 :: boolean = true
+		$29 :: boolean = true
 ), total_count AS (
 	SELECT
 		count(*) AS count
@@ -34606,6 +34623,8 @@ type GetWorkspacesParams struct {
 	Shared                                sql.NullBool `db:"shared" json:"shared"`
 	SharedWithUserID                      uuid.UUID    `db:"shared_with_user_id" json:"shared_with_user_id"`
 	SharedWithGroupID                     uuid.UUID    `db:"shared_with_group_id" json:"shared_with_group_id"`
+	SharedWithPrincipalUserID             uuid.UUID    `db:"shared_with_principal_user_id" json:"shared_with_principal_user_id"`
+	SharedWithPrincipalGroupID            uuid.UUID    `db:"shared_with_principal_group_id" json:"shared_with_principal_group_id"`
 	RequesterID                           uuid.UUID    `db:"requester_id" json:"requester_id"`
 	Offset                                int32        `db:"offset_" json:"offset_"`
 	Limit                                 int32        `db:"limit_" json:"limit_"`
@@ -34684,6 +34703,8 @@ func (q *sqlQuerier) GetWorkspaces(ctx context.Context, arg GetWorkspacesParams)
 		arg.Shared,
 		arg.SharedWithUserID,
 		arg.SharedWithGroupID,
+		arg.SharedWithPrincipalUserID,
+		arg.SharedWithPrincipalGroupID,
 		arg.RequesterID,
 		arg.Offset,
 		arg.Limit,

--- a/coderd/database/queries/workspaces.sql
+++ b/coderd/database/queries/workspaces.sql
@@ -389,6 +389,23 @@ WHERE
 			workspaces.group_acl ? (@shared_with_group_id :: uuid) :: text
 		ELSE true
 	END
+	-- Filter by shared-with principal. The principal is resolved at parse
+	-- time to either a user (shared_with_principal_user_id) or a group
+	-- (shared_with_principal_group_id); at most one is non-nil. A workspace
+	-- matches if the principal has access via user_acl, group_acl, or
+	-- (for users) via membership in any group present in group_acl.
+	AND CASE
+		WHEN @shared_with_principal_user_id :: uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN
+			workspaces.user_acl ? (@shared_with_principal_user_id :: uuid) :: text
+			OR EXISTS (
+				SELECT 1 FROM group_members_expanded gme
+				WHERE gme.user_id = @shared_with_principal_user_id :: uuid
+					AND workspaces.group_acl ? gme.group_id :: text
+			)
+		WHEN @shared_with_principal_group_id :: uuid != '00000000-0000-0000-0000-000000000000'::uuid THEN
+			workspaces.group_acl ? (@shared_with_principal_group_id :: uuid) :: text
+		ELSE true
+	END
 
 	-- Authorize Filter clause will be injected below in GetAuthorizedWorkspaces
 	-- @authorize_filter

--- a/coderd/searchquery/search.go
+++ b/coderd/searchquery/search.go
@@ -216,7 +216,7 @@ func Members(query string, organizationID uuid.UUID) (database.OrganizationMembe
 	return params, parser.Errors
 }
 
-func Workspaces(ctx context.Context, db database.Store, query string, page codersdk.Pagination, agentInactiveDisconnectTimeout time.Duration) (database.GetWorkspacesParams, []codersdk.ValidationError) {
+func Workspaces(ctx context.Context, db database.Store, query string, page codersdk.Pagination, agentInactiveDisconnectTimeout time.Duration, actorID uuid.UUID) (database.GetWorkspacesParams, []codersdk.ValidationError) {
 	filter := database.GetWorkspacesParams{
 		AgentInactiveDisconnectTimeoutSeconds: int64(agentInactiveDisconnectTimeout.Seconds()),
 
@@ -272,9 +272,9 @@ func Workspaces(ctx context.Context, db database.Store, query string, page coder
 	filter.HasExternalAgent = parser.NullableBoolean(values, sql.NullBool{}, "has_external_agent")
 	filter.OrganizationID = parseOrganization(ctx, db, parser, values, "organization")
 	filter.Shared = parser.NullableBoolean(values, sql.NullBool{}, "shared")
-	// TODO: support "me" by passing in the actorID
-	filter.SharedWithUserID = parseUser(ctx, db, parser, values, "shared_with_user", uuid.Nil)
+	filter.SharedWithUserID = parseUser(ctx, db, parser, values, "shared_with_user", actorID)
 	filter.SharedWithGroupID = parseGroup(ctx, db, parser, values, "shared_with_group")
+	filter.SharedWithPrincipalUserID, filter.SharedWithPrincipalGroupID = parseSharedWith(ctx, db, parser, values, "shared-with", actorID)
 	// Translate healthy filter to has-agent statuses
 	// healthy:true = connected, healthy:false = disconnected or timeout
 	if healthy := parser.NullableBoolean(values, sql.NullBool{}, "healthy"); healthy.Valid {
@@ -695,54 +695,103 @@ func parseGroup(ctx context.Context, db database.Store, parser *httpapi.QueryPar
 		if v == "" {
 			return uuid.Nil, nil
 		}
-		groupID, err := uuid.Parse(v)
-		if err == nil {
-			return groupID, nil
+		return resolveGroup(ctx, db, v)
+	})
+}
+
+// parseSharedWith resolves a `shared-with:<principal>` value into either a user
+// UUID or a group UUID. The principal can be:
+//   - the literal "me" (resolves to actorID),
+//   - a user UUID, username, or email,
+//   - a group UUID, group name, or <org>/<group>.
+//
+// It tries to resolve as a user first; on miss it falls back to a group. If
+// both fail, it surfaces a validation error. At most one of the returned
+// UUIDs is non-nil.
+func parseSharedWith(ctx context.Context, db database.Store, parser *httpapi.QueryParamParser, vals url.Values, queryParam string, actorID uuid.UUID) (userID, groupID uuid.UUID) {
+	userID = httpapi.ParseCustom(parser, vals, uuid.Nil, queryParam, func(v string) (uuid.UUID, error) {
+		if v == "" {
+			return uuid.Nil, nil
 		}
-
-		var groupName string
-		var org database.Organization
-		parts := strings.Split(v, "/")
-		switch len(parts) {
-		case 1:
-			dbOrg, err := db.GetDefaultOrganization(ctx)
-			if err != nil {
-				return uuid.Nil, xerrors.New("fetching default organization")
-			}
-			org = dbOrg
-			groupName = parts[0]
-		case 2:
-			orgName := parts[0]
-			if err := codersdk.NameValid(orgName); err != nil {
-				return uuid.Nil, xerrors.Errorf("invalid organization name %w", err)
-			}
-			dbOrg, err := db.GetOrganizationByName(ctx, database.GetOrganizationByNameParams{
-				Name: orgName,
-			})
-			if err != nil {
-				return uuid.Nil, xerrors.Errorf("organization %q either does not exist, or you are unauthorized to view it", orgName)
-			}
-			org = dbOrg
-
-			groupName = parts[1]
-
-		default:
-			return uuid.Nil, xerrors.New("invalid organization or group name, the filter must be in the pattern of <organization name>/<group name>")
+		if v == codersdk.Me && actorID != uuid.Nil {
+			return actorID, nil
 		}
-
-		if err := codersdk.GroupNameValid(groupName); err != nil {
-			return uuid.Nil, xerrors.Errorf("invalid group name %w", err)
+		if id, err := uuid.Parse(v); err == nil {
+			// Could be a user or group UUID. Try user first, then group.
+			if _, err := db.GetUserByID(ctx, id); err == nil {
+				return id, nil
+			}
+			if _, err := db.GetGroupByID(ctx, id); err == nil {
+				groupID = id
+				return uuid.Nil, nil
+			}
+			return uuid.Nil, xerrors.Errorf("user or group with id %q either does not exist, or you are unauthorized to view them", v)
 		}
+		// Not a UUID. Try username/email first; if that fails, try group lookup.
+		if user, err := db.GetUserByEmailOrUsername(ctx, database.GetUserByEmailOrUsernameParams{
+			Username: v,
+			Email:    v,
+		}); err == nil {
+			return user.ID, nil
+		}
+		id, err := resolveGroup(ctx, db, v)
+		if err != nil {
+			return uuid.Nil, xerrors.Errorf("principal %q either does not match a user or group, or you are unauthorized to view it", v)
+		}
+		groupID = id
+		return uuid.Nil, nil
+	})
+	return userID, groupID
+}
 
-		group, err := db.GetGroupByOrgAndName(ctx, database.GetGroupByOrgAndNameParams{
-			OrganizationID: org.ID,
-			Name:           groupName,
+// resolveGroup resolves a group identifier string (group name, <org>/<group>,
+// or UUID) to a group UUID. It mirrors parseGroup, but returns an error
+// instead of recording one on a parser.
+func resolveGroup(ctx context.Context, db database.Store, v string) (uuid.UUID, error) {
+	if id, err := uuid.Parse(v); err == nil {
+		return id, nil
+	}
+
+	var groupName string
+	var org database.Organization
+	parts := strings.Split(v, "/")
+	switch len(parts) {
+	case 1:
+		dbOrg, err := db.GetDefaultOrganization(ctx)
+		if err != nil {
+			return uuid.Nil, xerrors.New("fetching default organization")
+		}
+		org = dbOrg
+		groupName = parts[0]
+	case 2:
+		orgName := parts[0]
+		if err := codersdk.NameValid(orgName); err != nil {
+			return uuid.Nil, xerrors.Errorf("invalid organization name %w", err)
+		}
+		dbOrg, err := db.GetOrganizationByName(ctx, database.GetOrganizationByNameParams{
+			Name: orgName,
 		})
 		if err != nil {
-			return uuid.Nil, xerrors.Errorf("group %q either does not exist, does not belong to the organization %q, or you are unauthorized to view it", groupName, org.Name)
+			return uuid.Nil, xerrors.Errorf("organization %q either does not exist, or you are unauthorized to view it", orgName)
 		}
-		return group.ID, nil
+		org = dbOrg
+		groupName = parts[1]
+	default:
+		return uuid.Nil, xerrors.New("invalid organization or group name, the filter must be in the pattern of <organization name>/<group name>")
+	}
+
+	if err := codersdk.GroupNameValid(groupName); err != nil {
+		return uuid.Nil, xerrors.Errorf("invalid group name %w", err)
+	}
+
+	group, err := db.GetGroupByOrgAndName(ctx, database.GetGroupByOrgAndNameParams{
+		OrganizationID: org.ID,
+		Name:           groupName,
 	})
+	if err != nil {
+		return uuid.Nil, xerrors.Errorf("group %q either does not exist, does not belong to the organization %q, or you are unauthorized to view it", groupName, org.Name)
+	}
+	return group.ID, nil
 }
 
 // splitQueryParameterByDelimiter takes a query string and splits it into the individual elements

--- a/coderd/searchquery/search_test.go
+++ b/coderd/searchquery/search_test.go
@@ -27,6 +27,7 @@ func TestSearchWorkspace(t *testing.T) {
 		Expected              database.GetWorkspacesParams
 		ExpectedErrorContains string
 		Setup                 func(t *testing.T, db database.Store)
+		ActorID               uuid.UUID
 	}{
 		{
 			Name:     "Empty",
@@ -418,6 +419,89 @@ func TestSearchWorkspace(t *testing.T) {
 				SharedWithGroupID: uuid.MustParse("a7d1ba00-53c7-4aa6-92ea-83157dd57480"),
 			},
 		},
+		{
+			Name:    "SharedWithUserMe",
+			Query:   `shared_with_user:me`,
+			ActorID: uuid.MustParse("a3a2b6d4-9ec8-4d6f-8f47-30b7bb4d8b1e"),
+			Expected: database.GetWorkspacesParams{
+				SharedWithUserID: uuid.MustParse("a3a2b6d4-9ec8-4d6f-8f47-30b7bb4d8b1e"),
+			},
+		},
+		{
+			Name:    "SharedWithMe",
+			Query:   `shared-with:me`,
+			ActorID: uuid.MustParse("a3a2b6d4-9ec8-4d6f-8f47-30b7bb4d8b1e"),
+			Expected: database.GetWorkspacesParams{
+				SharedWithPrincipalUserID: uuid.MustParse("a3a2b6d4-9ec8-4d6f-8f47-30b7bb4d8b1e"),
+			},
+		},
+		{
+			Name:  "SharedWithPrincipalUserByName",
+			Query: `shared-with:wibble`,
+			Setup: func(t *testing.T, db database.Store) {
+				dbgen.User(t, db, database.User{
+					ID:       uuid.MustParse("3dd8b1b8-dff5-4b22-8ae9-c243ca136ecf"),
+					Username: "wibble",
+				})
+			},
+			Expected: database.GetWorkspacesParams{
+				SharedWithPrincipalUserID: uuid.MustParse("3dd8b1b8-dff5-4b22-8ae9-c243ca136ecf"),
+			},
+		},
+		{
+			Name:  "SharedWithPrincipalUserByUUID",
+			Query: `shared-with:3dd8b1b8-dff5-4b22-8ae9-c243ca136ecf`,
+			Setup: func(t *testing.T, db database.Store) {
+				dbgen.User(t, db, database.User{
+					ID: uuid.MustParse("3dd8b1b8-dff5-4b22-8ae9-c243ca136ecf"),
+				})
+			},
+			Expected: database.GetWorkspacesParams{
+				SharedWithPrincipalUserID: uuid.MustParse("3dd8b1b8-dff5-4b22-8ae9-c243ca136ecf"),
+			},
+		},
+		{
+			Name:  "SharedWithPrincipalGroupByName",
+			Query: `shared-with:wibblegroup`,
+			Setup: func(t *testing.T, db database.Store) {
+				org, err := db.GetOrganizationByName(t.Context(), database.GetOrganizationByNameParams{
+					Name: "coder",
+				})
+				require.NoError(t, err)
+
+				dbgen.Group(t, db, database.Group{
+					ID:             uuid.MustParse("590f1006-15e6-4b21-a6e1-92e33af8a5c3"),
+					Name:           "wibblegroup",
+					OrganizationID: org.ID,
+				})
+			},
+			Expected: database.GetWorkspacesParams{
+				SharedWithPrincipalGroupID: uuid.MustParse("590f1006-15e6-4b21-a6e1-92e33af8a5c3"),
+			},
+		},
+		{
+			Name:  "SharedWithPrincipalGroupInOrg",
+			Query: `shared-with:wibbleorg/wobble`,
+			Setup: func(t *testing.T, db database.Store) {
+				org := dbgen.Organization(t, db, database.Organization{
+					ID:   uuid.MustParse("dbeb1bd5-dce6-459c-ab7b-b7f8b9b10467"),
+					Name: "wibbleorg",
+				})
+				dbgen.Group(t, db, database.Group{
+					ID:             uuid.MustParse("3c831688-0a5a-45a2-a796-f7648874df34"),
+					Name:           "wobble",
+					OrganizationID: org.ID,
+				})
+			},
+			Expected: database.GetWorkspacesParams{
+				SharedWithPrincipalGroupID: uuid.MustParse("3c831688-0a5a-45a2-a796-f7648874df34"),
+			},
+		},
+		{
+			Name:                  "SharedWithUnknownPrincipal",
+			Query:                 `shared-with:no-such-thing`,
+			ExpectedErrorContains: "either does not match a user or group",
+		},
 
 		// Failures
 		{
@@ -485,7 +569,7 @@ func TestSearchWorkspace(t *testing.T) {
 			if c.Setup != nil {
 				c.Setup(t, db)
 			}
-			values, errs := searchquery.Workspaces(context.Background(), db, c.Query, codersdk.Pagination{}, 0)
+			values, errs := searchquery.Workspaces(context.Background(), db, c.Query, codersdk.Pagination{}, 0, c.ActorID)
 			if c.ExpectedErrorContains != "" {
 				assert.True(t, len(errs) > 0, "expect some errors")
 				var s strings.Builder
@@ -517,7 +601,7 @@ func TestSearchWorkspace(t *testing.T) {
 		query := ``
 		timeout := 1337 * time.Second
 		db, _ := dbtestutil.NewDB(t)
-		values, errs := searchquery.Workspaces(context.Background(), db, query, codersdk.Pagination{}, timeout)
+		values, errs := searchquery.Workspaces(context.Background(), db, query, codersdk.Pagination{}, timeout, uuid.Nil)
 		require.Empty(t, errs)
 		require.Equal(t, int64(timeout.Seconds()), values.AgentInactiveDisconnectTimeoutSeconds)
 	})

--- a/coderd/workspaces.go
+++ b/coderd/workspaces.go
@@ -158,7 +158,7 @@ func (api *API) workspaces(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	queryStr := r.URL.Query().Get("q")
-	filter, errs := searchquery.Workspaces(ctx, api.Database, queryStr, page, api.AgentInactiveDisconnectTimeout)
+	filter, errs := searchquery.Workspaces(ctx, api.Database, queryStr, page, api.AgentInactiveDisconnectTimeout, apiKey.UserID)
 	if len(errs) > 0 {
 		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
 			Message:     "Invalid workspace search query.",

--- a/docs/user-guides/shared-workspaces.md
+++ b/docs/user-guides/shared-workspaces.md
@@ -52,6 +52,7 @@ To list shared workspaces:
 - `coder list --search shared:true`
 - `coder list --search shared_with_user:<user>`
 - `coder list --search shared_with_group:<group>`
+- `coder list --search shared-with:<user-or-group>` (use `me` for your own user; matches access via the user, any of their groups, or a named group)
 
 ### UI
 


### PR DESCRIPTION
Adds a new `shared-with:<principal>` search filter for workspaces that
matches a user (directly, or transitively via group membership) or a
group. Principal accepts `me`, a username/email/UUID, a group name,
`<org>/<group>`, or a group UUID.

Also fixes the existing TODO so `shared_with_user:me` resolves to the
current actor (like `owner:me`).

<details>
<summary>Notes</summary>

- Two new SQL params (`shared_with_principal_user_id`,
  `shared_with_principal_group_id`) gate a single combined clause in
  `coderd/database/queries/workspaces.sql`; the user branch ORs
  `user_acl` and a `group_members_expanded` lookup against `group_acl`
  so the transitive case works (including Everyone-via-org-membership).
- Existing `shared_with_user:` / `shared_with_group:` filters are
  unchanged.
- Skipped end-to-end SQL coverage in `querier_test.go` because the
  existing shared filters also have no SQL-level test and adding one
  needs fixture wiring beyond current helpers. Follow-up if desired.

</details>

> Generated with Coder Agents on behalf of @aslilac.