### PR TITLE
feat: add AI provider chat routes

### DIFF
--- a/coderd/coderd.go
+++ b/coderd/coderd.go
@@ -1267,6 +1267,20 @@ func New(options *Options) *API {
 					r.Delete("/", api.deleteChatProvider)
 				})
 			})
+			r.Route("/ai-providers", func(r chi.Router) {
+				r.Get("/", api.listAIProviders)
+				r.Post("/", api.createAIProvider)
+				r.Route("/{aiProvider}", func(r chi.Router) {
+					r.Get("/", api.readAIProvider)
+					r.Patch("/", api.updateAIProvider)
+					r.Delete("/", api.deleteAIProvider)
+					r.Route("/keys", func(r chi.Router) {
+						r.Get("/", api.listAIProviderKeys)
+						r.Post("/", api.createAIProviderKey)
+						r.Delete("/{aiProviderKey}", api.deleteAIProviderKey)
+					})
+				})
+			})
 			// TODO(cian): place under /api/experimental/chats/config
 			r.Route("/model-configs", func(r chi.Router) {
 				r.Get("/", api.listChatModelConfigs)
@@ -1294,6 +1308,13 @@ func New(options *Options) *API {
 				r.Route("/{providerConfig}", func(r chi.Router) {
 					r.Put("/", api.upsertUserChatProviderKey)
 					r.Delete("/", api.deleteUserChatProviderKey)
+				})
+			})
+			r.Route("/user-ai-provider-keys", func(r chi.Router) {
+				r.Get("/", api.listUserAIProviderKeyConfigs)
+				r.Route("/{aiProvider}", func(r chi.Router) {
+					r.Put("/", api.upsertUserAIProviderKey)
+					r.Delete("/", api.deleteUserAIProviderKey)
 				})
 			})
 			r.Route("/{chat}", func(r chi.Router) {

--- a/coderd/database/dbauthz/dbauthz.go
+++ b/coderd/database/dbauthz/dbauthz.go
@@ -1943,6 +1943,13 @@ func (q *querier) DeleteChatModelConfigByID(ctx context.Context, id uuid.UUID) e
 	return q.db.DeleteChatModelConfigByID(ctx, id)
 }
 
+func (q *querier) DeleteChatModelConfigsByAIProviderID(ctx context.Context, aiProviderID uuid.UUID) error {
+	if err := q.authorizeContext(ctx, policy.ActionDelete, rbac.ResourceAIProvider); err != nil {
+		return err
+	}
+	return q.db.DeleteChatModelConfigsByAIProviderID(ctx, aiProviderID)
+}
+
 func (q *querier) DeleteChatModelConfigsByProvider(ctx context.Context, provider string) error {
 	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceDeploymentConfig); err != nil {
 		return err
@@ -2545,6 +2552,20 @@ func (q *querier) GetAIProviderByID(ctx context.Context, id uuid.UUID) (database
 		return database.AIProvider{}, err
 	}
 	return q.db.GetAIProviderByID(ctx, id)
+}
+
+func (q *querier) GetAIProviderByIDForReferenceLock(ctx context.Context, id uuid.UUID) (database.AIProvider, error) {
+	if err := q.authorizeContext(ctx, policy.ActionRead, rbac.ResourceAIProvider); err != nil {
+		return database.AIProvider{}, err
+	}
+	return q.db.GetAIProviderByIDForReferenceLock(ctx, id)
+}
+
+func (q *querier) GetAIProviderByIDForUpdate(ctx context.Context, id uuid.UUID) (database.AIProvider, error) {
+	if err := q.authorizeContext(ctx, policy.ActionUpdate, rbac.ResourceAIProvider); err != nil {
+		return database.AIProvider{}, err
+	}
+	return q.db.GetAIProviderByIDForUpdate(ctx, id)
 }
 
 func (q *querier) GetAIProviderByName(ctx context.Context, name string) (database.AIProvider, error) {

--- a/coderd/database/dbauthz/dbauthz_test.go
+++ b/coderd/database/dbauthz/dbauthz_test.go
@@ -557,6 +557,11 @@ func (s *MethodTestSuite) TestChats() {
 		dbm.EXPECT().DeleteChatModelConfigsByProvider(gomock.Any(), providerName).Return(nil).AnyTimes()
 		check.Args(providerName).Asserts(rbac.ResourceDeploymentConfig, policy.ActionUpdate)
 	}))
+	s.Run("DeleteChatModelConfigsByAIProviderID", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
+		providerID := uuid.New()
+		dbm.EXPECT().DeleteChatModelConfigsByAIProviderID(gomock.Any(), providerID).Return(nil).AnyTimes()
+		check.Args(providerID).Asserts(rbac.ResourceAIProvider, policy.ActionDelete)
+	}))
 	s.Run("DeleteChatProviderByID", s.Mocked(func(dbm *dbmock.MockStore, _ *gofakeit.Faker, check *expects) {
 		id := uuid.New()
 		dbm.EXPECT().DeleteChatProviderByID(gomock.Any(), id).Return(nil).AnyTimes()
@@ -6497,6 +6502,16 @@ func (s *MethodTestSuite) TestAIBridge() {
 		dbm.EXPECT().GetAIProviderByID(gomock.Any(), provider.ID).Return(provider, nil).AnyTimes()
 		check.Args(provider.ID).Asserts(rbac.ResourceAIProvider, policy.ActionRead).Returns(provider)
 	}))
+	s.Run("GetAIProviderByIDForReferenceLock", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
+		provider := testutil.Fake(s.T(), faker, database.AIProvider{})
+		dbm.EXPECT().GetAIProviderByIDForReferenceLock(gomock.Any(), provider.ID).Return(provider, nil).AnyTimes()
+		check.Args(provider.ID).Asserts(rbac.ResourceAIProvider, policy.ActionRead).Returns(provider)
+	}))
+	s.Run("GetAIProviderByIDForUpdate", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
+		provider := testutil.Fake(s.T(), faker, database.AIProvider{})
+		dbm.EXPECT().GetAIProviderByIDForUpdate(gomock.Any(), provider.ID).Return(provider, nil).AnyTimes()
+		check.Args(provider.ID).Asserts(rbac.ResourceAIProvider, policy.ActionUpdate).Returns(provider)
+	}))
 	s.Run("GetAIProviderByName", s.Mocked(func(dbm *dbmock.MockStore, faker *gofakeit.Faker, check *expects) {
 		provider := testutil.Fake(s.T(), faker, database.AIProvider{})
 		dbm.EXPECT().GetAIProviderByName(gomock.Any(), provider.Name).Return(provider, nil).AnyTimes()
@@ -6525,6 +6540,7 @@ func (s *MethodTestSuite) TestAIBridge() {
 		provider := testutil.Fake(s.T(), faker, database.AIProvider{})
 		arg := database.UpdateAIProviderParams{
 			ID:      provider.ID,
+			Name:    provider.Name,
 			Enabled: true,
 			BaseUrl: "https://api.example.com/",
 		}

--- a/coderd/database/dbmetrics/querymetrics.go
+++ b/coderd/database/dbmetrics/querymetrics.go
@@ -465,6 +465,14 @@ func (m queryMetricsStore) DeleteChatModelConfigByID(ctx context.Context, id uui
 	return r0
 }
 
+func (m queryMetricsStore) DeleteChatModelConfigsByAIProviderID(ctx context.Context, aiProviderID uuid.UUID) error {
+	start := time.Now()
+	r0 := m.s.DeleteChatModelConfigsByAIProviderID(ctx, aiProviderID)
+	m.queryLatencies.WithLabelValues("DeleteChatModelConfigsByAIProviderID").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "DeleteChatModelConfigsByAIProviderID").Inc()
+	return r0
+}
+
 func (m queryMetricsStore) DeleteChatModelConfigsByProvider(ctx context.Context, provider string) error {
 	start := time.Now()
 	r0 := m.s.DeleteChatModelConfigsByProvider(ctx, provider)
@@ -1038,6 +1046,22 @@ func (m queryMetricsStore) GetAIProviderByID(ctx context.Context, id uuid.UUID) 
 	r0, r1 := m.s.GetAIProviderByID(ctx, id)
 	m.queryLatencies.WithLabelValues("GetAIProviderByID").Observe(time.Since(start).Seconds())
 	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetAIProviderByID").Inc()
+	return r0, r1
+}
+
+func (m queryMetricsStore) GetAIProviderByIDForReferenceLock(ctx context.Context, id uuid.UUID) (database.AIProvider, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetAIProviderByIDForReferenceLock(ctx, id)
+	m.queryLatencies.WithLabelValues("GetAIProviderByIDForReferenceLock").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetAIProviderByIDForReferenceLock").Inc()
+	return r0, r1
+}
+
+func (m queryMetricsStore) GetAIProviderByIDForUpdate(ctx context.Context, id uuid.UUID) (database.AIProvider, error) {
+	start := time.Now()
+	r0, r1 := m.s.GetAIProviderByIDForUpdate(ctx, id)
+	m.queryLatencies.WithLabelValues("GetAIProviderByIDForUpdate").Observe(time.Since(start).Seconds())
+	m.queryCounts.WithLabelValues(httpmw.ExtractHTTPRoute(ctx), httpmw.ExtractHTTPMethod(ctx), "GetAIProviderByIDForUpdate").Inc()
 	return r0, r1
 }
 

--- a/coderd/database/dbmock/dbmock.go
+++ b/coderd/database/dbmock/dbmock.go
@@ -760,6 +760,20 @@ func (mr *MockStoreMockRecorder) DeleteChatModelConfigByID(ctx, id any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteChatModelConfigByID", reflect.TypeOf((*MockStore)(nil).DeleteChatModelConfigByID), ctx, id)
 }
 
+// DeleteChatModelConfigsByAIProviderID mocks base method.
+func (m *MockStore) DeleteChatModelConfigsByAIProviderID(ctx context.Context, aiProviderID uuid.UUID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteChatModelConfigsByAIProviderID", ctx, aiProviderID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteChatModelConfigsByAIProviderID indicates an expected call of DeleteChatModelConfigsByAIProviderID.
+func (mr *MockStoreMockRecorder) DeleteChatModelConfigsByAIProviderID(ctx, aiProviderID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteChatModelConfigsByAIProviderID", reflect.TypeOf((*MockStore)(nil).DeleteChatModelConfigsByAIProviderID), ctx, aiProviderID)
+}
+
 // DeleteChatModelConfigsByProvider mocks base method.
 func (m *MockStore) DeleteChatModelConfigsByProvider(ctx context.Context, provider string) error {
 	m.ctrl.T.Helper()
@@ -1797,6 +1811,36 @@ func (m *MockStore) GetAIProviderByID(ctx context.Context, id uuid.UUID) (databa
 func (mr *MockStoreMockRecorder) GetAIProviderByID(ctx, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAIProviderByID", reflect.TypeOf((*MockStore)(nil).GetAIProviderByID), ctx, id)
+}
+
+// GetAIProviderByIDForReferenceLock mocks base method.
+func (m *MockStore) GetAIProviderByIDForReferenceLock(ctx context.Context, id uuid.UUID) (database.AIProvider, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAIProviderByIDForReferenceLock", ctx, id)
+	ret0, _ := ret[0].(database.AIProvider)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAIProviderByIDForReferenceLock indicates an expected call of GetAIProviderByIDForReferenceLock.
+func (mr *MockStoreMockRecorder) GetAIProviderByIDForReferenceLock(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAIProviderByIDForReferenceLock", reflect.TypeOf((*MockStore)(nil).GetAIProviderByIDForReferenceLock), ctx, id)
+}
+
+// GetAIProviderByIDForUpdate mocks base method.
+func (m *MockStore) GetAIProviderByIDForUpdate(ctx context.Context, id uuid.UUID) (database.AIProvider, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAIProviderByIDForUpdate", ctx, id)
+	ret0, _ := ret[0].(database.AIProvider)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAIProviderByIDForUpdate indicates an expected call of GetAIProviderByIDForUpdate.
+func (mr *MockStoreMockRecorder) GetAIProviderByIDForUpdate(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAIProviderByIDForUpdate", reflect.TypeOf((*MockStore)(nil).GetAIProviderByIDForUpdate), ctx, id)
 }
 
 // GetAIProviderByName mocks base method.

--- a/coderd/database/querier.go
+++ b/coderd/database/querier.go
@@ -122,6 +122,7 @@ type sqlcQuerier interface {
 	// archive-cleanup retry).
 	DeleteChatDebugDataByChatID(ctx context.Context, arg DeleteChatDebugDataByChatIDParams) (int64, error)
 	DeleteChatModelConfigByID(ctx context.Context, id uuid.UUID) error
+	DeleteChatModelConfigsByAIProviderID(ctx context.Context, aiProviderID uuid.UUID) error
 	DeleteChatModelConfigsByProvider(ctx context.Context, provider string) error
 	DeleteChatProviderByID(ctx context.Context, id uuid.UUID) error
 	DeleteChatQueuedMessage(ctx context.Context, arg DeleteChatQueuedMessageParams) error
@@ -253,6 +254,8 @@ type sqlcQuerier interface {
 	GetAIBridgeUserPromptsByInterceptionID(ctx context.Context, interceptionID uuid.UUID) ([]AIBridgeUserPrompt, error)
 	GetAIModelPriceByProviderModel(ctx context.Context, arg GetAIModelPriceByProviderModelParams) (AiModelPrice, error)
 	GetAIProviderByID(ctx context.Context, id uuid.UUID) (AIProvider, error)
+	GetAIProviderByIDForReferenceLock(ctx context.Context, id uuid.UUID) (AIProvider, error)
+	GetAIProviderByIDForUpdate(ctx context.Context, id uuid.UUID) (AIProvider, error)
 	GetAIProviderByName(ctx context.Context, name string) (AIProvider, error)
 	GetAIProviderKeyByID(ctx context.Context, id uuid.UUID) (AIProviderKey, error)
 	// Returns every AI provider key row, including those belonging to a

--- a/coderd/database/queries.sql.go
+++ b/coderd/database/queries.sql.go
@@ -366,6 +366,64 @@ func (q *sqlQuerier) GetAIProviderByID(ctx context.Context, id uuid.UUID) (AIPro
 	return i, err
 }
 
+const getAIProviderByIDForReferenceLock = `-- name: GetAIProviderByIDForReferenceLock :one
+SELECT
+    id, type, name, display_name, enabled, deleted, base_url, settings, settings_key_id, created_at, updated_at
+FROM
+    ai_providers
+WHERE
+    id = $1::uuid AND deleted = FALSE
+FOR SHARE
+`
+
+func (q *sqlQuerier) GetAIProviderByIDForReferenceLock(ctx context.Context, id uuid.UUID) (AIProvider, error) {
+	row := q.db.QueryRowContext(ctx, getAIProviderByIDForReferenceLock, id)
+	var i AIProvider
+	err := row.Scan(
+		&i.ID,
+		&i.Type,
+		&i.Name,
+		&i.DisplayName,
+		&i.Enabled,
+		&i.Deleted,
+		&i.BaseUrl,
+		&i.Settings,
+		&i.SettingsKeyID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const getAIProviderByIDForUpdate = `-- name: GetAIProviderByIDForUpdate :one
+SELECT
+    id, type, name, display_name, enabled, deleted, base_url, settings, settings_key_id, created_at, updated_at
+FROM
+    ai_providers
+WHERE
+    id = $1::uuid AND deleted = FALSE
+FOR UPDATE
+`
+
+func (q *sqlQuerier) GetAIProviderByIDForUpdate(ctx context.Context, id uuid.UUID) (AIProvider, error) {
+	row := q.db.QueryRowContext(ctx, getAIProviderByIDForUpdate, id)
+	var i AIProvider
+	err := row.Scan(
+		&i.ID,
+		&i.Type,
+		&i.Name,
+		&i.DisplayName,
+		&i.Enabled,
+		&i.Deleted,
+		&i.BaseUrl,
+		&i.Settings,
+		&i.SettingsKeyID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const getAIProviderByName = `-- name: GetAIProviderByName :one
 SELECT
     id, type, name, display_name, enabled, deleted, base_url, settings, settings_key_id, created_at, updated_at
@@ -515,19 +573,21 @@ const updateAIProvider = `-- name: UpdateAIProvider :one
 UPDATE
     ai_providers
 SET
-    display_name = $1::text,
-    enabled = $2::boolean,
-    base_url = $3::text,
-    settings = $4::text,
-    settings_key_id = $5::text,
+    name = $1::text,
+    display_name = $2::text,
+    enabled = $3::boolean,
+    base_url = $4::text,
+    settings = $5::text,
+    settings_key_id = $6::text,
     updated_at = NOW()
 WHERE
-    id = $6::uuid AND deleted = FALSE
+    id = $7::uuid AND deleted = FALSE
 RETURNING
     id, type, name, display_name, enabled, deleted, base_url, settings, settings_key_id, created_at, updated_at
 `
 
 type UpdateAIProviderParams struct {
+	Name          string         `db:"name" json:"name"`
 	DisplayName   sql.NullString `db:"display_name" json:"display_name"`
 	Enabled       bool           `db:"enabled" json:"enabled"`
 	BaseUrl       string         `db:"base_url" json:"base_url"`
@@ -538,6 +598,7 @@ type UpdateAIProviderParams struct {
 
 func (q *sqlQuerier) UpdateAIProvider(ctx context.Context, arg UpdateAIProviderParams) (AIProvider, error) {
 	row := q.db.QueryRowContext(ctx, updateAIProvider,
+		arg.Name,
 		arg.DisplayName,
 		arg.Enabled,
 		arg.BaseUrl,
@@ -4948,6 +5009,23 @@ func (q *sqlQuerier) DeleteChatModelConfigByID(ctx context.Context, id uuid.UUID
 	return err
 }
 
+const deleteChatModelConfigsByAIProviderID = `-- name: DeleteChatModelConfigsByAIProviderID :exec
+UPDATE
+    chat_model_configs
+SET
+    deleted = TRUE,
+    deleted_at = NOW(),
+    updated_at = NOW()
+WHERE
+    ai_provider_id = $1::uuid
+    AND deleted = FALSE
+`
+
+func (q *sqlQuerier) DeleteChatModelConfigsByAIProviderID(ctx context.Context, aiProviderID uuid.UUID) error {
+	_, err := q.db.ExecContext(ctx, deleteChatModelConfigsByAIProviderID, aiProviderID)
+	return err
+}
+
 const deleteChatModelConfigsByProvider = `-- name: DeleteChatModelConfigsByProvider :exec
 UPDATE
     chat_model_configs
@@ -5092,13 +5170,18 @@ SELECT
     cmc.id, cmc.provider, cmc.model, cmc.display_name, cmc.created_by, cmc.updated_by, cmc.enabled, cmc.is_default, cmc.deleted, cmc.deleted_at, cmc.created_at, cmc.updated_at, cmc.context_limit, cmc.compression_threshold, cmc.options, cmc.ai_provider_id
 FROM
     chat_model_configs cmc
-JOIN
+LEFT JOIN
+    ai_providers ap ON ap.id = cmc.ai_provider_id AND ap.deleted = FALSE
+LEFT JOIN
     chat_providers cp ON cp.provider = cmc.provider
 WHERE
     cmc.id = $1::uuid
     AND cmc.deleted = FALSE
     AND cmc.enabled = TRUE
-    AND cp.enabled = TRUE
+    AND (
+        (cmc.ai_provider_id IS NOT NULL AND ap.enabled = TRUE)
+        OR (cmc.ai_provider_id IS NULL AND cp.enabled = TRUE)
+    )
 `
 
 // Providers can be disabled independently of their model configs.
@@ -5132,12 +5215,17 @@ SELECT
     cmc.id, cmc.provider, cmc.model, cmc.display_name, cmc.created_by, cmc.updated_by, cmc.enabled, cmc.is_default, cmc.deleted, cmc.deleted_at, cmc.created_at, cmc.updated_at, cmc.context_limit, cmc.compression_threshold, cmc.options, cmc.ai_provider_id
 FROM
     chat_model_configs cmc
-JOIN
+LEFT JOIN
+    ai_providers ap ON ap.id = cmc.ai_provider_id AND ap.deleted = FALSE
+LEFT JOIN
     chat_providers cp ON cp.provider = cmc.provider
 WHERE
     cmc.enabled = TRUE
     AND cmc.deleted = FALSE
-    AND cp.enabled = TRUE
+    AND (
+        (cmc.ai_provider_id IS NOT NULL AND ap.enabled = TRUE)
+        OR (cmc.ai_provider_id IS NULL AND cp.enabled = TRUE)
+    )
 ORDER BY
     cmc.provider ASC,
     cmc.model ASC,

--- a/coderd/database/queries/ai_providers.sql
+++ b/coderd/database/queries/ai_providers.sql
@@ -6,6 +6,24 @@ FROM
 WHERE
     id = @id::uuid AND deleted = FALSE;
 
+-- name: GetAIProviderByIDForUpdate :one
+SELECT
+    *
+FROM
+    ai_providers
+WHERE
+    id = @id::uuid AND deleted = FALSE
+FOR UPDATE;
+
+-- name: GetAIProviderByIDForReferenceLock :one
+SELECT
+    *
+FROM
+    ai_providers
+WHERE
+    id = @id::uuid AND deleted = FALSE
+FOR SHARE;
+
 -- name: GetAIProviderByName :one
 SELECT
     *
@@ -54,6 +72,7 @@ RETURNING
 UPDATE
     ai_providers
 SET
+    name = @name::text,
     display_name = sqlc.narg('display_name')::text,
     enabled = @enabled::boolean,
     base_url = @base_url::text,

--- a/coderd/database/queries/chatmodelconfigs.sql
+++ b/coderd/database/queries/chatmodelconfigs.sql
@@ -34,12 +34,17 @@ SELECT
     cmc.*
 FROM
     chat_model_configs cmc
-JOIN
+LEFT JOIN
+    ai_providers ap ON ap.id = cmc.ai_provider_id AND ap.deleted = FALSE
+LEFT JOIN
     chat_providers cp ON cp.provider = cmc.provider
 WHERE
     cmc.enabled = TRUE
     AND cmc.deleted = FALSE
-    AND cp.enabled = TRUE
+    AND (
+        (cmc.ai_provider_id IS NOT NULL AND ap.enabled = TRUE)
+        OR (cmc.ai_provider_id IS NULL AND cp.enabled = TRUE)
+    )
 ORDER BY
     cmc.provider ASC,
     cmc.model ASC,
@@ -53,13 +58,18 @@ FROM
     chat_model_configs cmc
 -- Providers can be disabled independently of their model configs.
 -- Check both to ensure the selected config is actually usable.
-JOIN
+LEFT JOIN
+    ai_providers ap ON ap.id = cmc.ai_provider_id AND ap.deleted = FALSE
+LEFT JOIN
     chat_providers cp ON cp.provider = cmc.provider
 WHERE
     cmc.id = @id::uuid
     AND cmc.deleted = FALSE
     AND cmc.enabled = TRUE
-    AND cp.enabled = TRUE;
+    AND (
+        (cmc.ai_provider_id IS NOT NULL AND ap.enabled = TRUE)
+        OR (cmc.ai_provider_id IS NULL AND cp.enabled = TRUE)
+    );
 
 -- name: InsertChatModelConfig :one
 INSERT INTO chat_model_configs (
@@ -137,4 +147,15 @@ SET
     updated_at = NOW()
 WHERE
     provider = @provider::text
+    AND deleted = FALSE;
+
+-- name: DeleteChatModelConfigsByAIProviderID :exec
+UPDATE
+    chat_model_configs
+SET
+    deleted = TRUE,
+    deleted_at = NOW(),
+    updated_at = NOW()
+WHERE
+    ai_provider_id = @ai_provider_id::uuid
     AND deleted = FALSE;

--- a/coderd/exp_chats.go
+++ b/coderd/exp_chats.go
@@ -6393,6 +6393,564 @@ func convertChatMessages(messages []database.ChatMessage) []codersdk.ChatMessage
 	return result
 }
 
+func parseAIProviderID(r *http.Request) (uuid.UUID, error) {
+	return uuid.Parse(chi.URLParam(r, "aiProvider"))
+}
+
+func parseAIProviderKeyID(r *http.Request) (uuid.UUID, error) {
+	return uuid.Parse(chi.URLParam(r, "aiProviderKey"))
+}
+
+func aiProviderDisplayName(displayName sql.NullString, name string) string {
+	if displayName.Valid {
+		return displayName.String
+	}
+	return name
+}
+
+func convertAIProvider(provider database.AIProvider) codersdk.AIProvider {
+	return codersdk.AIProvider{
+		ID:          provider.ID,
+		Type:        codersdk.AIProviderType(provider.Type),
+		Name:        provider.Name,
+		DisplayName: aiProviderDisplayName(provider.DisplayName, provider.Name),
+		Enabled:     provider.Enabled,
+		Deleted:     provider.Deleted,
+		BaseURL:     provider.BaseUrl,
+		CreatedAt:   provider.CreatedAt,
+		UpdatedAt:   provider.UpdatedAt,
+	}
+}
+
+func convertAIProviderSummary(provider database.AIProvider) codersdk.AIProviderSummary {
+	return codersdk.AIProviderSummary{
+		ID:          provider.ID,
+		Type:        codersdk.AIProviderType(provider.Type),
+		Name:        provider.Name,
+		DisplayName: aiProviderDisplayName(provider.DisplayName, provider.Name),
+		Enabled:     provider.Enabled,
+		Deleted:     provider.Deleted,
+	}
+}
+
+func convertAIProviderKey(key database.AIProviderKey) codersdk.AIProviderKey {
+	return codersdk.AIProviderKey{
+		ID:         key.ID,
+		ProviderID: key.ProviderID,
+		CreatedAt:  key.CreatedAt,
+		UpdatedAt:  key.UpdatedAt,
+	}
+}
+
+func validAIProviderName(name string) bool {
+	if name == "" || strings.HasPrefix(name, "agents-") {
+		return false
+	}
+	lastHyphen := true
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z':
+			lastHyphen = false
+		case r >= '0' && r <= '9':
+			lastHyphen = false
+		case r == '-':
+			if lastHyphen {
+				return false
+			}
+			lastHyphen = true
+		default:
+			return false
+		}
+	}
+	return !lastHyphen
+}
+
+func invalidAIProviderNameResponse() codersdk.Response {
+	return codersdk.Response{
+		Message: "Invalid AI provider name.",
+		Detail:  "Names must use lowercase letters, numbers, and single hyphens, and cannot use the reserved agents- prefix.",
+	}
+}
+
+func writeInvalidAIProviderName(ctx context.Context, rw http.ResponseWriter) {
+	httpapi.Write(ctx, rw, http.StatusBadRequest, invalidAIProviderNameResponse())
+}
+
+func (api *API) writeAIProviderInternalServerError(ctx context.Context, rw http.ResponseWriter, logMessage string, response codersdk.Response, err error, fields ...slog.Field) {
+	fields = append(fields, slog.Error(err))
+	api.Logger.Error(ctx, logMessage, fields...)
+	httpapi.Write(ctx, rw, http.StatusInternalServerError, response)
+}
+
+func (api *API) writeAIProviderResponseError(ctx context.Context, rw http.ResponseWriter, err error, fields ...slog.Field) {
+	if responseErr, ok := httperror.IsResponder(err); ok {
+		status, resp := responseErr.Response()
+		if status >= http.StatusInternalServerError {
+			api.Logger.Error(ctx, resp.Message, append(fields, slog.Error(err))...)
+		}
+		httpapi.Write(ctx, rw, status, resp)
+		return
+	}
+	api.writeAIProviderInternalServerError(ctx, rw, "AI provider handler failed", codersdk.Response{Message: "Internal server error", Detail: err.Error()}, err, fields...)
+}
+
+func (api *API) listAIProviders(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if !api.Authorize(r, policy.ActionRead, rbac.ResourceAIProvider) {
+		httpapi.Forbidden(rw)
+		return
+	}
+	providers, err := api.Database.GetAIProviders(ctx, database.GetAIProvidersParams{IncludeDisabled: true})
+	if err != nil {
+		api.writeAIProviderInternalServerError(ctx, rw, "failed to list AI providers", codersdk.Response{Message: "Failed to list AI providers."}, err)
+		return
+	}
+	resp := make([]codersdk.AIProvider, 0, len(providers))
+	for _, provider := range providers {
+		resp = append(resp, convertAIProvider(provider))
+	}
+	httpapi.Write(ctx, rw, http.StatusOK, resp)
+}
+
+func (api *API) createAIProvider(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if !api.Authorize(r, policy.ActionCreate, rbac.ResourceAIProvider) {
+		httpapi.Forbidden(rw)
+		return
+	}
+	var req codersdk.CreateAIProviderRequest
+	if !httpapi.Read(ctx, rw, r, &req) {
+		return
+	}
+	req.Name = strings.TrimSpace(req.Name)
+	req.DisplayName = strings.TrimSpace(req.DisplayName)
+	if !validAIProviderName(req.Name) {
+		writeInvalidAIProviderName(ctx, rw)
+		return
+	}
+	typ := database.AIProviderType(req.Type)
+	if !typ.Valid() {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{Message: "Invalid AI provider type."})
+		return
+	}
+	enabled := true
+	if req.Enabled != nil {
+		enabled = *req.Enabled
+	}
+	baseURL, err := normalizeChatProviderBaseURL(req.BaseURL)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "Invalid provider base URL.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+	provider, err := api.Database.InsertAIProvider(ctx, database.InsertAIProviderParams{
+		ID:            uuid.New(),
+		Type:          typ,
+		Name:          req.Name,
+		DisplayName:   sql.NullString{String: req.DisplayName, Valid: req.DisplayName != ""},
+		Enabled:       enabled,
+		BaseUrl:       baseURL,
+		Settings:      sql.NullString{},
+		SettingsKeyID: sql.NullString{},
+	})
+	if err != nil {
+		switch {
+		case database.IsUniqueViolation(err):
+			httpapi.Write(ctx, rw, http.StatusConflict, codersdk.Response{Message: "AI provider already exists."})
+		case database.IsCheckViolation(err):
+			httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{Message: "Invalid AI provider."})
+		default:
+			api.writeAIProviderInternalServerError(ctx, rw, "failed to create AI provider", codersdk.Response{Message: "Failed to create AI provider."}, err)
+		}
+		return
+	}
+	publishChatConfigEvent(api.Logger, api.Pubsub, pubsub.ChatConfigEventProviders, uuid.Nil)
+	httpapi.Write(ctx, rw, http.StatusCreated, convertAIProvider(provider))
+}
+
+func (api *API) readAIProvider(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if !api.Authorize(r, policy.ActionRead, rbac.ResourceAIProvider) {
+		httpapi.Forbidden(rw)
+		return
+	}
+	providerID, err := parseAIProviderID(r)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{Message: "Invalid AI provider ID."})
+		return
+	}
+	provider, err := api.Database.GetAIProviderByID(ctx, providerID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			httpapi.Write(ctx, rw, http.StatusNotFound, codersdk.Response{Message: "AI provider not found."})
+			return
+		}
+		api.writeAIProviderInternalServerError(ctx, rw, "failed to get AI provider", codersdk.Response{Message: "Failed to get AI provider."}, err, slog.F("ai_provider_id", providerID))
+		return
+	}
+	httpapi.Write(ctx, rw, http.StatusOK, convertAIProvider(provider))
+}
+
+func (api *API) updateAIProvider(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if !api.Authorize(r, policy.ActionUpdate, rbac.ResourceAIProvider) {
+		httpapi.Forbidden(rw)
+		return
+	}
+	providerID, err := parseAIProviderID(r)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{Message: "Invalid AI provider ID."})
+		return
+	}
+	var req codersdk.UpdateAIProviderRequest
+	if !httpapi.Read(ctx, rw, r, &req) {
+		return
+	}
+	var provider database.AIProvider
+	if err := api.Database.InTx(func(tx database.Store) error {
+		current, err := tx.GetAIProviderByIDForUpdate(ctx, providerID)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return httperror.NewResponseError(http.StatusNotFound, codersdk.Response{Message: "AI provider not found."})
+			}
+			return httperror.NewResponseError(http.StatusInternalServerError, codersdk.Response{Message: "Failed to get AI provider."})
+		}
+		name := current.Name
+		if req.Name != nil {
+			name = strings.TrimSpace(*req.Name)
+			if !validAIProviderName(name) {
+				return httperror.NewResponseError(http.StatusBadRequest, invalidAIProviderNameResponse())
+			}
+		}
+		displayName := current.DisplayName
+		if req.DisplayName != nil {
+			trimmed := strings.TrimSpace(*req.DisplayName)
+			displayName = sql.NullString{String: trimmed, Valid: trimmed != ""}
+		}
+		baseURL := current.BaseUrl
+		if req.BaseURL != nil {
+			baseURL, err = normalizeChatProviderBaseURL(*req.BaseURL)
+			if err != nil {
+				return httperror.NewResponseError(http.StatusBadRequest, codersdk.Response{
+					Message: "Invalid provider base URL.",
+					Detail:  err.Error(),
+				})
+			}
+		}
+		enabled := current.Enabled
+		if req.Enabled != nil {
+			enabled = *req.Enabled
+		}
+		provider, err = tx.UpdateAIProvider(ctx, database.UpdateAIProviderParams{
+			ID:            providerID,
+			Name:          name,
+			DisplayName:   displayName,
+			Enabled:       enabled,
+			BaseUrl:       baseURL,
+			Settings:      current.Settings,
+			SettingsKeyID: current.SettingsKeyID,
+		})
+		if err != nil {
+			switch {
+			case database.IsUniqueViolation(err):
+				return httperror.NewResponseError(http.StatusConflict, codersdk.Response{Message: "AI provider already exists."})
+			case database.IsCheckViolation(err):
+				return httperror.NewResponseError(http.StatusBadRequest, codersdk.Response{Message: "Invalid AI provider."})
+			default:
+				return httperror.NewResponseError(http.StatusInternalServerError, codersdk.Response{Message: "Failed to update AI provider."})
+			}
+		}
+		return nil
+	}, nil); err != nil {
+		api.writeAIProviderResponseError(ctx, rw, err, slog.F("ai_provider_id", providerID))
+		return
+	}
+	publishChatConfigEvent(api.Logger, api.Pubsub, pubsub.ChatConfigEventProviders, uuid.Nil)
+	httpapi.Write(ctx, rw, http.StatusOK, convertAIProvider(provider))
+}
+
+func (api *API) deleteAIProvider(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if !api.Authorize(r, policy.ActionDelete, rbac.ResourceAIProvider) {
+		httpapi.Forbidden(rw)
+		return
+	}
+	providerID, err := parseAIProviderID(r)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{Message: "Invalid AI provider ID."})
+		return
+	}
+	if err := api.Database.InTx(func(tx database.Store) error {
+		_, err := tx.GetAIProviderByIDForUpdate(ctx, providerID)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return httperror.NewResponseError(http.StatusNotFound, codersdk.Response{Message: "AI provider not found."})
+			}
+			return httperror.NewResponseError(http.StatusInternalServerError, codersdk.Response{Message: "Failed to get AI provider."})
+		}
+		if err := tx.DeleteChatModelConfigsByAIProviderID(ctx, providerID); err != nil {
+			return httperror.NewResponseError(http.StatusInternalServerError, codersdk.Response{Message: "Failed to delete chat model configs."})
+		}
+		if err := ensureDefaultChatModelConfig(ctx, tx); err != nil {
+			return err
+		}
+		//nolint:gocritic // The route already authorized AI provider deletion.
+		keys, err := tx.GetAIProviderKeysByProviderID(dbauthz.AsSystemRestricted(ctx), providerID)
+		if err != nil {
+			return httperror.NewResponseError(http.StatusInternalServerError, codersdk.Response{Message: "Failed to list AI provider keys."})
+		}
+		for _, key := range keys {
+			if err := tx.DeleteAIProviderKey(ctx, key.ID); err != nil {
+				return httperror.NewResponseError(http.StatusInternalServerError, codersdk.Response{Message: "Failed to delete AI provider key."})
+			}
+		}
+		if err := tx.DeleteUserAIProviderKeysByProviderID(ctx, providerID); err != nil {
+			return httperror.NewResponseError(http.StatusInternalServerError, codersdk.Response{Message: "Failed to delete user AI provider keys."})
+		}
+		if err := tx.DeleteAIProviderByID(ctx, providerID); err != nil {
+			return httperror.NewResponseError(http.StatusInternalServerError, codersdk.Response{Message: "Failed to delete AI provider."})
+		}
+		return nil
+	}, nil); err != nil {
+		api.writeAIProviderResponseError(ctx, rw, err, slog.F("ai_provider_id", providerID))
+		return
+	}
+	publishChatConfigEvent(api.Logger, api.Pubsub, pubsub.ChatConfigEventProviders, uuid.Nil)
+	httpapi.Write(ctx, rw, http.StatusNoContent, nil)
+}
+
+func (api *API) listAIProviderKeys(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if !api.Authorize(r, policy.ActionRead, rbac.ResourceAIProvider) {
+		httpapi.Forbidden(rw)
+		return
+	}
+	providerID, err := parseAIProviderID(r)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{Message: "Invalid AI provider ID."})
+		return
+	}
+	keys, err := api.Database.GetAIProviderKeysByProviderID(ctx, providerID)
+	if err != nil {
+		api.writeAIProviderInternalServerError(ctx, rw, "failed to list AI provider keys", codersdk.Response{Message: "Failed to list AI provider keys."}, err, slog.F("ai_provider_id", providerID))
+		return
+	}
+	resp := make([]codersdk.AIProviderKey, 0, len(keys))
+	for _, key := range keys {
+		resp = append(resp, convertAIProviderKey(key))
+	}
+	httpapi.Write(ctx, rw, http.StatusOK, resp)
+}
+
+func (api *API) createAIProviderKey(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if !api.Authorize(r, policy.ActionCreate, rbac.ResourceAIProvider) {
+		httpapi.Forbidden(rw)
+		return
+	}
+	providerID, err := parseAIProviderID(r)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{Message: "Invalid AI provider ID."})
+		return
+	}
+	var req codersdk.CreateAIProviderKeyRequest
+	if !httpapi.Read(ctx, rw, r, &req) {
+		return
+	}
+	trimmedAPIKey := strings.TrimSpace(req.APIKey)
+	if err := validateChatProviderAPIKeySize(trimmedAPIKey); err != nil {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "API key too large.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+	if trimmedAPIKey == "" {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{Message: "API key is required."})
+		return
+	}
+	var key database.AIProviderKey
+	if err := api.Database.InTx(func(tx database.Store) error {
+		//nolint:gocritic // The route already authorized provider key creation.
+		_, err := tx.GetAIProviderByID(dbauthz.AsSystemRestricted(ctx), providerID)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return httperror.NewResponseError(http.StatusNotFound, codersdk.Response{Message: "AI provider not found."})
+			}
+			return httperror.NewResponseError(http.StatusInternalServerError, codersdk.Response{Message: "Failed to get AI provider."})
+		}
+		now := api.Clock.Now()
+		key, err = tx.InsertAIProviderKey(ctx, database.InsertAIProviderKeyParams{
+			ID:          uuid.New(),
+			ProviderID:  providerID,
+			APIKey:      trimmedAPIKey,
+			ApiKeyKeyID: sql.NullString{},
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		})
+		if err != nil {
+			return httperror.NewResponseError(http.StatusInternalServerError, codersdk.Response{Message: "Failed to create AI provider key."})
+		}
+		return nil
+	}, nil); err != nil {
+		api.writeAIProviderResponseError(ctx, rw, err, slog.F("ai_provider_id", providerID))
+		return
+	}
+	publishChatConfigEvent(api.Logger, api.Pubsub, pubsub.ChatConfigEventProviders, uuid.Nil)
+	httpapi.Write(ctx, rw, http.StatusCreated, convertAIProviderKey(key))
+}
+
+func (api *API) deleteAIProviderKey(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if !api.Authorize(r, policy.ActionDelete, rbac.ResourceAIProvider) {
+		httpapi.Forbidden(rw)
+		return
+	}
+	providerID, err := parseAIProviderID(r)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{Message: "Invalid AI provider ID."})
+		return
+	}
+	keyID, err := parseAIProviderKeyID(r)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{Message: "Invalid AI provider key ID."})
+		return
+	}
+	key, err := api.Database.GetAIProviderKeyByID(ctx, keyID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			httpapi.Write(ctx, rw, http.StatusNotFound, codersdk.Response{Message: "AI provider key not found."})
+			return
+		}
+		api.writeAIProviderInternalServerError(ctx, rw, "failed to get AI provider key", codersdk.Response{Message: "Failed to get AI provider key."}, err, slog.F("ai_provider_id", providerID), slog.F("ai_provider_key_id", keyID))
+		return
+	}
+	if key.ProviderID != providerID {
+		httpapi.Write(ctx, rw, http.StatusNotFound, codersdk.Response{Message: "AI provider key not found."})
+		return
+	}
+	if err := api.Database.DeleteAIProviderKey(ctx, keyID); err != nil {
+		api.writeAIProviderInternalServerError(ctx, rw, "failed to delete AI provider key", codersdk.Response{Message: "Failed to delete AI provider key."}, err, slog.F("ai_provider_id", providerID), slog.F("ai_provider_key_id", keyID))
+		return
+	}
+	publishChatConfigEvent(api.Logger, api.Pubsub, pubsub.ChatConfigEventProviders, uuid.Nil)
+	httpapi.Write(ctx, rw, http.StatusNoContent, nil)
+}
+
+func (api *API) listUserAIProviderKeyConfigs(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	apiKey := httpmw.APIKey(r)
+	//nolint:gocritic // Users can list limited enabled provider metadata without AI provider admin permissions.
+	providers, err := api.Database.GetAIProviders(dbauthz.AsSystemRestricted(ctx), database.GetAIProvidersParams{IncludeDisabled: true})
+	if err != nil {
+		api.writeAIProviderInternalServerError(ctx, rw, "failed to list user AI provider configs", codersdk.Response{Message: "Failed to list AI providers."}, err, slog.F("user_id", apiKey.UserID))
+		return
+	}
+	keys, err := api.Database.GetUserAIProviderKeysByUserID(ctx, apiKey.UserID)
+	if err != nil {
+		api.writeAIProviderInternalServerError(ctx, rw, "failed to list user AI provider keys", codersdk.Response{Message: "Failed to list user AI provider keys."}, err, slog.F("user_id", apiKey.UserID))
+		return
+	}
+	keysByProviderID := make(map[uuid.UUID]struct{}, len(keys))
+	for _, key := range keys {
+		keysByProviderID[key.AIProviderID] = struct{}{}
+	}
+	byokEnabled := api.DeploymentValues.AI.BridgeConfig.AllowBYOK.Value()
+	configs := make([]codersdk.UserAIProviderKeyConfig, 0, len(providers))
+	for _, provider := range providers {
+		_, hasKey := keysByProviderID[provider.ID]
+		if provider.Deleted || (!provider.Enabled && !hasKey) {
+			continue
+		}
+		configs = append(configs, codersdk.UserAIProviderKeyConfig{
+			Provider:      convertAIProviderSummary(provider),
+			HasUserAPIKey: hasKey,
+			BYOKEnabled:   byokEnabled,
+		})
+	}
+	httpapi.Write(ctx, rw, http.StatusOK, configs)
+}
+
+func (api *API) upsertUserAIProviderKey(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if !api.DeploymentValues.AI.BridgeConfig.AllowBYOK.Value() {
+		httpapi.Write(ctx, rw, http.StatusForbidden, codersdk.Response{Message: "BYOK is disabled."})
+		return
+	}
+	apiKey := httpmw.APIKey(r)
+	providerID, err := parseAIProviderID(r)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{Message: "Invalid AI provider ID."})
+		return
+	}
+	//nolint:gocritic // Users can attach their own key to an enabled provider without AI provider admin permissions.
+	provider, err := api.Database.GetAIProviderByID(dbauthz.AsSystemRestricted(ctx), providerID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			httpapi.Write(ctx, rw, http.StatusNotFound, codersdk.Response{Message: "AI provider not found."})
+			return
+		}
+		api.writeAIProviderInternalServerError(ctx, rw, "failed to get AI provider", codersdk.Response{Message: "Failed to get AI provider."}, err, slog.F("ai_provider_id", providerID))
+		return
+	}
+	if !provider.Enabled {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{Message: "AI provider is disabled."})
+		return
+	}
+	var req codersdk.CreateUserAIProviderKeyRequest
+	if !httpapi.Read(ctx, rw, r, &req) {
+		return
+	}
+	trimmedAPIKey := strings.TrimSpace(req.APIKey)
+	if err := validateChatProviderAPIKeySize(trimmedAPIKey); err != nil {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{
+			Message: "API key too large.",
+			Detail:  err.Error(),
+		})
+		return
+	}
+	if trimmedAPIKey == "" {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{Message: "API key is required."})
+		return
+	}
+	now := api.Clock.Now()
+	_, err = api.Database.UpsertUserAIProviderKey(ctx, database.UpsertUserAIProviderKeyParams{
+		ID:           uuid.New(),
+		UserID:       apiKey.UserID,
+		AIProviderID: providerID,
+		APIKey:       trimmedAPIKey,
+		ApiKeyKeyID:  sql.NullString{},
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	})
+	if err != nil {
+		api.writeAIProviderInternalServerError(ctx, rw, "failed to update user AI provider key", codersdk.Response{Message: "Failed to update user AI provider key."}, err, slog.F("user_id", apiKey.UserID), slog.F("ai_provider_id", providerID))
+		return
+	}
+	httpapi.Write(ctx, rw, http.StatusOK, codersdk.UserAIProviderKeyConfig{
+		Provider:      convertAIProviderSummary(provider),
+		HasUserAPIKey: true,
+		BYOKEnabled:   true,
+	})
+}
+
+func (api *API) deleteUserAIProviderKey(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	apiKey := httpmw.APIKey(r)
+	providerID, err := parseAIProviderID(r)
+	if err != nil {
+		httpapi.Write(ctx, rw, http.StatusBadRequest, codersdk.Response{Message: "Invalid AI provider ID."})
+		return
+	}
+	if err := api.Database.DeleteUserAIProviderKey(ctx, database.DeleteUserAIProviderKeyParams{UserID: apiKey.UserID, AIProviderID: providerID}); err != nil {
+		api.writeAIProviderInternalServerError(ctx, rw, "failed to delete user AI provider key", codersdk.Response{Message: "Failed to delete user AI provider key."}, err, slog.F("user_id", apiKey.UserID), slog.F("ai_provider_id", providerID))
+		return
+	}
+	httpapi.Write(ctx, rw, http.StatusNoContent, nil)
+}
+
 func (api *API) listChatProviders(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	//nolint:gocritic // System context required to read enabled chat providers.

--- a/coderd/exp_chats_test.go
+++ b/coderd/exp_chats_test.go
@@ -2076,6 +2076,520 @@ func TestWatchChats(t *testing.T) {
 	})
 }
 
+func TestAIProviderCRUD(t *testing.T) {
+	t.Parallel()
+
+	t.Run("AdminLifecycle", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newChatClient(t)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
+		name := "test-openai-" + uuid.NewString()
+
+		provider, err := client.CreateAIProvider(ctx, codersdk.CreateAIProviderRequest{
+			Type:        codersdk.AIProviderTypeOpenAI,
+			Name:        name,
+			DisplayName: "OpenAI Test",
+			BaseURL:     "https://api.openai.example.com/v1",
+		})
+		require.NoError(t, err)
+		require.NotEqual(t, uuid.Nil, provider.ID)
+		require.Equal(t, codersdk.AIProviderTypeOpenAI, provider.Type)
+		require.Equal(t, name, provider.Name)
+		require.Equal(t, "OpenAI Test", provider.DisplayName)
+		require.True(t, provider.Enabled)
+
+		got, err := client.GetAIProvider(ctx, provider.ID)
+		require.NoError(t, err)
+		require.Equal(t, provider.ID, got.ID)
+
+		providers, err := client.ListAIProviders(ctx)
+		require.NoError(t, err)
+		require.Contains(t, providers, provider)
+
+		updatedName := "test-anthropic-" + uuid.NewString()
+		disabled := false
+		updated, err := client.UpdateAIProvider(ctx, provider.ID, codersdk.UpdateAIProviderRequest{
+			Name:        &updatedName,
+			DisplayName: ptr.Ref("Anthropic Test"),
+			BaseURL:     ptr.Ref("https://api.anthropic.example.com/v1"),
+			Enabled:     &disabled,
+		})
+		require.NoError(t, err)
+		require.Equal(t, updatedName, updated.Name)
+		require.Equal(t, "Anthropic Test", updated.DisplayName)
+		require.Equal(t, "https://api.anthropic.example.com/v1", updated.BaseURL)
+		require.False(t, updated.Enabled)
+
+		key, err := client.CreateAIProviderKey(ctx, provider.ID, codersdk.CreateAIProviderKeyRequest{APIKey: "test-api-key"})
+		require.NoError(t, err)
+		require.Equal(t, provider.ID, key.ProviderID)
+
+		keys, err := client.ListAIProviderKeys(ctx, provider.ID)
+		require.NoError(t, err)
+		require.Len(t, keys, 1)
+		require.Equal(t, key.ID, keys[0].ID)
+
+		require.NoError(t, client.DeleteAIProviderKey(ctx, provider.ID, key.ID))
+		keys, err = client.ListAIProviderKeys(ctx, provider.ID)
+		require.NoError(t, err)
+		require.Empty(t, keys)
+
+		require.NoError(t, client.DeleteAIProvider(ctx, provider.ID))
+		_, err = client.GetAIProvider(ctx, provider.ID)
+		requireSDKError(t, err, http.StatusNotFound)
+	})
+
+	t.Run("CreateValidation", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newChatClient(t)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
+		name := "test-openai-" + uuid.NewString()
+
+		_, err := client.CreateAIProvider(ctx, codersdk.CreateAIProviderRequest{
+			Type: codersdk.AIProviderTypeOpenAI,
+			Name: name,
+		})
+		require.NoError(t, err)
+
+		_, err = client.CreateAIProvider(ctx, codersdk.CreateAIProviderRequest{
+			Type: codersdk.AIProviderTypeOpenAI,
+			Name: name,
+		})
+		sdkErr := requireSDKError(t, err, http.StatusConflict)
+		require.Equal(t, "AI provider already exists.", sdkErr.Message)
+
+		_, err = client.CreateAIProvider(ctx, codersdk.CreateAIProviderRequest{
+			Type: codersdk.AIProviderTypeOpenAI,
+			Name: "InvalidName",
+		})
+		sdkErr = requireSDKError(t, err, http.StatusBadRequest)
+		require.Equal(t, "Invalid AI provider name.", sdkErr.Message)
+
+		_, err = client.CreateAIProvider(ctx, codersdk.CreateAIProviderRequest{
+			Type: codersdk.AIProviderType("not-a-provider"),
+			Name: "test-invalid-" + uuid.NewString(),
+		})
+		sdkErr = requireSDKError(t, err, http.StatusBadRequest)
+		require.Equal(t, "Invalid AI provider type.", sdkErr.Message)
+
+		for _, validName := range []string{"a", "1", "a-1", "agents"} {
+			_, err = client.CreateAIProvider(ctx, codersdk.CreateAIProviderRequest{
+				Type: codersdk.AIProviderTypeOpenAI,
+				Name: validName,
+			})
+			require.NoError(t, err, "valid name %q", validName)
+		}
+
+		for _, invalidName := range []string{"-agents", "agents-openai", "a--1", "a-", "not a valid provider name"} {
+			_, err = client.CreateAIProvider(ctx, codersdk.CreateAIProviderRequest{
+				Type: codersdk.AIProviderTypeOpenAI,
+				Name: invalidName,
+			})
+			sdkErr = requireSDKError(t, err, http.StatusBadRequest)
+			require.Equal(t, "Invalid AI provider name.", sdkErr.Message, "invalid name %q", invalidName)
+		}
+	})
+
+	t.Run("CreateNormalizesInput", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newChatClient(t)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
+		name := "test-normalized-" + uuid.NewString()
+
+		provider, err := client.CreateAIProvider(ctx, codersdk.CreateAIProviderRequest{
+			Type:        codersdk.AIProviderTypeOpenAI,
+			Name:        "  " + name + "  ",
+			DisplayName: "  Normalized Provider  ",
+			BaseURL:     "  https://api.openai.example.com/v1  ",
+		})
+		require.NoError(t, err)
+		require.Equal(t, name, provider.Name)
+		require.Equal(t, "Normalized Provider", provider.DisplayName)
+		require.Equal(t, "https://api.openai.example.com/v1", provider.BaseURL)
+	})
+
+	t.Run("CreateRejectsInvalidBaseURL", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newChatClient(t)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
+
+		_, err := client.CreateAIProvider(ctx, codersdk.CreateAIProviderRequest{
+			Type:    codersdk.AIProviderTypeOpenAI,
+			Name:    "test-invalid-base-url-" + uuid.NewString(),
+			BaseURL: "file:///tmp/model",
+		})
+		sdkErr := requireSDKError(t, err, http.StatusBadRequest)
+		require.Equal(t, "Invalid provider base URL.", sdkErr.Message)
+	})
+
+	t.Run("UpdateRejectsInvalidName", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newChatClient(t)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
+		provider, err := client.CreateAIProvider(ctx, codersdk.CreateAIProviderRequest{
+			Type: codersdk.AIProviderTypeOpenAI,
+			Name: "test-update-invalid-name-" + uuid.NewString(),
+		})
+		require.NoError(t, err)
+
+		_, err = client.UpdateAIProvider(ctx, provider.ID, codersdk.UpdateAIProviderRequest{
+			Name: ptr.Ref("not a valid provider name"),
+		})
+		sdkErr := requireSDKError(t, err, http.StatusBadRequest)
+		require.Equal(t, "Invalid AI provider name.", sdkErr.Message)
+		require.NotEmpty(t, sdkErr.Detail)
+	})
+
+	t.Run("UpdateRejectsDuplicateName", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newChatClient(t)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
+		provider, err := client.CreateAIProvider(ctx, codersdk.CreateAIProviderRequest{
+			Type: codersdk.AIProviderTypeOpenAI,
+			Name: "test-update-duplicate-name-" + uuid.NewString(),
+		})
+		require.NoError(t, err)
+		other, err := client.CreateAIProvider(ctx, codersdk.CreateAIProviderRequest{
+			Type: codersdk.AIProviderTypeOpenAI,
+			Name: "test-update-duplicate-other-" + uuid.NewString(),
+		})
+		require.NoError(t, err)
+
+		_, err = client.UpdateAIProvider(ctx, provider.ID, codersdk.UpdateAIProviderRequest{
+			Name: ptr.Ref(other.Name),
+		})
+		sdkErr := requireSDKError(t, err, http.StatusConflict)
+		require.Equal(t, "AI provider already exists.", sdkErr.Message)
+	})
+
+	t.Run("UpdateRejectsInvalidBaseURL", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newChatClient(t)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
+		provider, err := client.CreateAIProvider(ctx, codersdk.CreateAIProviderRequest{
+			Type: codersdk.AIProviderTypeOpenAI,
+			Name: "test-update-base-url-" + uuid.NewString(),
+		})
+		require.NoError(t, err)
+
+		_, err = client.UpdateAIProvider(ctx, provider.ID, codersdk.UpdateAIProviderRequest{
+			BaseURL: ptr.Ref("localhost:11434"),
+		})
+		sdkErr := requireSDKError(t, err, http.StatusBadRequest)
+		require.Equal(t, "Invalid provider base URL.", sdkErr.Message)
+	})
+
+	t.Run("DeleteMissingProvider", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newChatClient(t)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
+
+		err := client.DeleteAIProvider(ctx, uuid.New())
+		sdkErr := requireSDKError(t, err, http.StatusNotFound)
+		require.Equal(t, "AI provider not found.", sdkErr.Message)
+	})
+
+	t.Run("CreateKeyRejectsLargeAPIKey", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newChatClient(t)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
+		provider, err := client.CreateAIProvider(ctx, codersdk.CreateAIProviderRequest{
+			Type: codersdk.AIProviderTypeOpenAI,
+			Name: "test-large-key-" + uuid.NewString(),
+		})
+		require.NoError(t, err)
+
+		_, err = client.CreateAIProviderKey(ctx, provider.ID, codersdk.CreateAIProviderKeyRequest{APIKey: strings.Repeat("x", 10241)})
+		sdkErr := requireSDKError(t, err, http.StatusBadRequest)
+		require.Equal(t, "API key too large.", sdkErr.Message)
+	})
+
+	t.Run("CreateKeyRejectsEmptyAPIKey", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newChatClient(t)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
+		provider, err := client.CreateAIProvider(ctx, codersdk.CreateAIProviderRequest{
+			Type: codersdk.AIProviderTypeOpenAI,
+			Name: "test-empty-key-" + uuid.NewString(),
+		})
+		require.NoError(t, err)
+
+		_, err = client.CreateAIProviderKey(ctx, provider.ID, codersdk.CreateAIProviderKeyRequest{APIKey: "  "})
+		sdkErr := requireSDKError(t, err, http.StatusBadRequest)
+		require.Equal(t, "API key is required.", sdkErr.Message)
+	})
+
+	t.Run("CreateKeyForMissingProvider", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newChatClient(t)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
+
+		_, err := client.CreateAIProviderKey(ctx, uuid.New(), codersdk.CreateAIProviderKeyRequest{APIKey: "test-api-key"})
+		sdkErr := requireSDKError(t, err, http.StatusNotFound)
+		require.Equal(t, "AI provider not found.", sdkErr.Message)
+	})
+
+	t.Run("DeleteProviderDeletesProviderKeys", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		client := newChatClient(t)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
+		provider, err := client.CreateAIProvider(ctx, codersdk.CreateAIProviderRequest{
+			Type: codersdk.AIProviderTypeOpenAI,
+			Name: "test-delete-keys-" + uuid.NewString(),
+		})
+		require.NoError(t, err)
+		_, err = client.CreateAIProviderKey(ctx, provider.ID, codersdk.CreateAIProviderKeyRequest{APIKey: "test-api-key"})
+		require.NoError(t, err)
+
+		require.NoError(t, client.DeleteAIProvider(ctx, provider.ID))
+		keys, err := client.ListAIProviderKeys(ctx, provider.ID)
+		require.NoError(t, err)
+		require.Empty(t, keys)
+	})
+
+	t.Run("DeleteProviderDeletesUserKeys", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		adminClient, db := newChatClientWithDatabase(t)
+		firstUser := coderdtest.CreateFirstUser(t, adminClient.Client)
+		memberClientRaw, member := coderdtest.CreateAnotherUser(t, adminClient.Client, firstUser.OrganizationID)
+		memberClient := codersdk.NewExperimentalClient(memberClientRaw)
+		provider, err := adminClient.CreateAIProvider(ctx, codersdk.CreateAIProviderRequest{
+			Type: codersdk.AIProviderTypeOpenAI,
+			Name: "test-delete-user-keys-" + uuid.NewString(),
+		})
+		require.NoError(t, err)
+		_, err = memberClient.UpsertUserAIProviderKey(ctx, provider.ID, codersdk.CreateUserAIProviderKeyRequest{APIKey: "test-user-api-key"})
+		require.NoError(t, err)
+
+		_, err = db.GetUserAIProviderKeyByProviderID(dbauthz.AsSystemRestricted(ctx), database.GetUserAIProviderKeyByProviderIDParams{
+			UserID:       member.ID,
+			AIProviderID: provider.ID,
+		})
+		require.NoError(t, err)
+		require.NoError(t, adminClient.DeleteAIProvider(ctx, provider.ID))
+		_, err = db.GetUserAIProviderKeyByProviderID(dbauthz.AsSystemRestricted(ctx), database.GetUserAIProviderKeyByProviderIDParams{
+			UserID:       member.ID,
+			AIProviderID: provider.ID,
+		})
+		require.ErrorIs(t, err, sql.ErrNoRows)
+	})
+
+	t.Run("ForbiddenForOrganizationMember", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		adminClient := newChatClient(t)
+		firstUser := coderdtest.CreateFirstUser(t, adminClient.Client)
+		memberClientRaw, _ := coderdtest.CreateAnotherUser(t, adminClient.Client, firstUser.OrganizationID)
+		memberClient := codersdk.NewExperimentalClient(memberClientRaw)
+
+		_, err := memberClient.ListAIProviders(ctx)
+		requireSDKError(t, err, http.StatusForbidden)
+		_, err = memberClient.CreateAIProvider(ctx, codersdk.CreateAIProviderRequest{
+			Type: codersdk.AIProviderTypeOpenAI,
+			Name: "test-member-" + uuid.NewString(),
+		})
+		requireSDKError(t, err, http.StatusForbidden)
+	})
+}
+
+func TestUserAIProviderKeys(t *testing.T) {
+	t.Parallel()
+
+	t.Run("SelfServiceLifecycle", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		adminClient := newChatClient(t)
+		firstUser := coderdtest.CreateFirstUser(t, adminClient.Client)
+		memberClientRaw, _ := coderdtest.CreateAnotherUser(t, adminClient.Client, firstUser.OrganizationID)
+		memberClient := codersdk.NewExperimentalClient(memberClientRaw)
+
+		provider, err := adminClient.CreateAIProvider(ctx, codersdk.CreateAIProviderRequest{
+			Type: codersdk.AIProviderTypeOpenAI,
+			Name: "test-user-key-" + uuid.NewString(),
+		})
+		require.NoError(t, err)
+
+		configs, err := memberClient.ListUserAIProviderKeyConfigs(ctx)
+		require.NoError(t, err)
+		var cfg *codersdk.UserAIProviderKeyConfig
+		for i := range configs {
+			if configs[i].Provider.ID == provider.ID {
+				cfg = &configs[i]
+				break
+			}
+		}
+		require.NotNil(t, cfg)
+		require.False(t, cfg.HasUserAPIKey)
+		require.True(t, cfg.BYOKEnabled)
+
+		cfgValue, err := memberClient.UpsertUserAIProviderKey(ctx, provider.ID, codersdk.CreateUserAIProviderKeyRequest{APIKey: "test-user-api-key"})
+		require.NoError(t, err)
+		require.Equal(t, provider.ID, cfgValue.Provider.ID)
+		require.True(t, cfgValue.HasUserAPIKey)
+		require.True(t, cfgValue.BYOKEnabled)
+
+		configs, err = memberClient.ListUserAIProviderKeyConfigs(ctx)
+		require.NoError(t, err)
+		cfg = nil
+		for i := range configs {
+			if configs[i].Provider.ID == provider.ID {
+				cfg = &configs[i]
+				break
+			}
+		}
+		require.NotNil(t, cfg)
+		require.True(t, cfg.HasUserAPIKey)
+
+		cfgValue, err = memberClient.UpsertUserAIProviderKey(ctx, provider.ID, codersdk.CreateUserAIProviderKeyRequest{APIKey: "replacement-user-api-key"})
+		require.NoError(t, err)
+		require.Equal(t, provider.ID, cfgValue.Provider.ID)
+		require.True(t, cfgValue.HasUserAPIKey)
+
+		configs, err = memberClient.ListUserAIProviderKeyConfigs(ctx)
+		require.NoError(t, err)
+		cfg = nil
+		for i := range configs {
+			if configs[i].Provider.ID == provider.ID {
+				cfg = &configs[i]
+				break
+			}
+		}
+		require.NotNil(t, cfg)
+		require.True(t, cfg.HasUserAPIKey)
+
+		require.NoError(t, memberClient.DeleteUserAIProviderKey(ctx, provider.ID))
+		configs, err = memberClient.ListUserAIProviderKeyConfigs(ctx)
+		require.NoError(t, err)
+		for _, listed := range configs {
+			if listed.Provider.ID == provider.ID {
+				require.False(t, listed.HasUserAPIKey)
+				return
+			}
+		}
+		t.Fatal("provider config not found")
+	})
+
+	t.Run("RejectsDisabledProvider", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		adminClient := newChatClient(t)
+		firstUser := coderdtest.CreateFirstUser(t, adminClient.Client)
+		memberClientRaw, _ := coderdtest.CreateAnotherUser(t, adminClient.Client, firstUser.OrganizationID)
+		memberClient := codersdk.NewExperimentalClient(memberClientRaw)
+
+		disabled := false
+		provider, err := adminClient.CreateAIProvider(ctx, codersdk.CreateAIProviderRequest{
+			Type:    codersdk.AIProviderTypeOpenAI,
+			Name:    "test-disabled-user-key-" + uuid.NewString(),
+			Enabled: &disabled,
+		})
+		require.NoError(t, err)
+
+		_, err = memberClient.UpsertUserAIProviderKey(ctx, provider.ID, codersdk.CreateUserAIProviderKeyRequest{APIKey: "test-user-api-key"})
+		sdkErr := requireSDKError(t, err, http.StatusBadRequest)
+		require.Equal(t, "AI provider is disabled.", sdkErr.Message)
+	})
+
+	t.Run("RejectsLargeAPIKey", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		adminClient := newChatClient(t)
+		firstUser := coderdtest.CreateFirstUser(t, adminClient.Client)
+		memberClientRaw, _ := coderdtest.CreateAnotherUser(t, adminClient.Client, firstUser.OrganizationID)
+		memberClient := codersdk.NewExperimentalClient(memberClientRaw)
+
+		provider, err := adminClient.CreateAIProvider(ctx, codersdk.CreateAIProviderRequest{
+			Type: codersdk.AIProviderTypeOpenAI,
+			Name: "test-large-user-key-" + uuid.NewString(),
+		})
+		require.NoError(t, err)
+
+		_, err = memberClient.UpsertUserAIProviderKey(ctx, provider.ID, codersdk.CreateUserAIProviderKeyRequest{APIKey: strings.Repeat("x", 10241)})
+		sdkErr := requireSDKError(t, err, http.StatusBadRequest)
+		require.Equal(t, "API key too large.", sdkErr.Message)
+	})
+
+	t.Run("RejectsEmptyAPIKey", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		adminClient := newChatClient(t)
+		firstUser := coderdtest.CreateFirstUser(t, adminClient.Client)
+		memberClientRaw, _ := coderdtest.CreateAnotherUser(t, adminClient.Client, firstUser.OrganizationID)
+		memberClient := codersdk.NewExperimentalClient(memberClientRaw)
+
+		provider, err := adminClient.CreateAIProvider(ctx, codersdk.CreateAIProviderRequest{
+			Type: codersdk.AIProviderTypeOpenAI,
+			Name: "test-empty-user-key-" + uuid.NewString(),
+		})
+		require.NoError(t, err)
+
+		_, err = memberClient.UpsertUserAIProviderKey(ctx, provider.ID, codersdk.CreateUserAIProviderKeyRequest{APIKey: "  "})
+		sdkErr := requireSDKError(t, err, http.StatusBadRequest)
+		require.Equal(t, "API key is required.", sdkErr.Message)
+	})
+
+	t.Run("BYOKDisabledRejectsUpsertAndAllowsDelete", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t, testutil.WaitLong)
+		values := chatDeploymentValues(t)
+		values.AI.BridgeConfig.AllowBYOK = serpent.Bool(false)
+		client := newChatClientWithDeploymentValues(t, values)
+		_ = coderdtest.CreateFirstUser(t, client.Client)
+
+		provider, err := client.CreateAIProvider(ctx, codersdk.CreateAIProviderRequest{
+			Type: codersdk.AIProviderTypeOpenAI,
+			Name: "test-byok-disabled-" + uuid.NewString(),
+		})
+		require.NoError(t, err)
+
+		_, err = client.UpsertUserAIProviderKey(ctx, provider.ID, codersdk.CreateUserAIProviderKeyRequest{APIKey: "test-user-api-key"})
+		sdkErr := requireSDKError(t, err, http.StatusForbidden)
+		require.Equal(t, "BYOK is disabled.", sdkErr.Message)
+
+		configs, err := client.ListUserAIProviderKeyConfigs(ctx)
+		require.NoError(t, err)
+		for _, cfg := range configs {
+			if cfg.Provider.ID == provider.ID {
+				require.False(t, cfg.BYOKEnabled)
+				break
+			}
+		}
+		require.NoError(t, client.DeleteUserAIProviderKey(ctx, provider.ID))
+	})
+}
+
 func TestListChatProviders(t *testing.T) {
 	t.Parallel()
 

--- a/codersdk/aiproviders.go
+++ b/codersdk/aiproviders.go
@@ -151,15 +151,18 @@ func marshalSettings(s settingsTyped) ([]byte, error) {
 // table and managed via the keys sub-endpoints; secret fields on
 // Settings are never included in responses.
 type AIProvider struct {
-	ID          uuid.UUID          `json:"id" format:"uuid"`
-	Type        AIProviderType     `json:"type"`
-	Name        string             `json:"name"`
-	DisplayName string             `json:"display_name"`
-	Enabled     bool               `json:"enabled"`
-	BaseURL     string             `json:"base_url"`
-	Settings    AIProviderSettings `json:"settings"`
-	CreatedAt   time.Time          `json:"created_at" format:"date-time"`
-	UpdatedAt   time.Time          `json:"updated_at" format:"date-time"`
+	ID                uuid.UUID          `json:"id" format:"uuid"`
+	Type              AIProviderType     `json:"type"`
+	Name              string             `json:"name"`
+	DisplayName       string             `json:"display_name"`
+	Enabled           bool               `json:"enabled"`
+	Deleted           bool               `json:"deleted"`
+	HasProviderAPIKey bool               `json:"has_provider_api_key"`
+	BYOKEnabled       bool               `json:"byok_enabled"`
+	BaseURL           string             `json:"base_url"`
+	Settings          AIProviderSettings `json:"settings"`
+	CreatedAt         time.Time          `json:"created_at" format:"date-time"`
+	UpdatedAt         time.Time          `json:"updated_at" format:"date-time"`
 }
 
 // CreateAIProviderRequest is the payload for creating a new AI
@@ -171,9 +174,10 @@ type CreateAIProviderRequest struct {
 	Type        AIProviderType     `json:"type"`
 	Name        string             `json:"name"`
 	DisplayName string             `json:"display_name,omitempty"`
-	Enabled     bool               `json:"enabled"`
-	BaseURL     string             `json:"base_url"`
+	Enabled     *bool              `json:"enabled,omitempty"`
+	BaseURL     string             `json:"base_url,omitempty"`
 	Settings    AIProviderSettings `json:"settings,omitzero"`
+	APIKey      *string            `json:"api_key,omitempty"`
 }
 
 // UpdateAIProviderRequest is the payload for partially updating an
@@ -181,10 +185,12 @@ type CreateAIProviderRequest struct {
 // distinguish "not sent" (nil) from "set to empty/zero" (a pointer
 // to the zero value).
 type UpdateAIProviderRequest struct {
+	Name        *string             `json:"name,omitempty"`
 	DisplayName *string             `json:"display_name,omitempty"`
 	Enabled     *bool               `json:"enabled,omitempty"`
 	BaseURL     *string             `json:"base_url,omitempty"`
 	Settings    *AIProviderSettings `json:"settings,omitempty"`
+	APIKey      *string             `json:"api_key,omitempty"`
 }
 
 // AIProviderKey represents a single API key registered against an

--- a/codersdk/chats.go
+++ b/codersdk/chats.go
@@ -1112,6 +1112,30 @@ type UpdateChatProviderConfigRequest struct {
 	AllowCentralAPIKeyFallback *bool   `json:"allow_central_api_key_fallback,omitempty"`
 }
 
+// AIProviderSummary is provider metadata embedded in other API responses.
+type AIProviderSummary struct {
+	ID          uuid.UUID      `json:"id" format:"uuid"`
+	Type        AIProviderType `json:"type"`
+	Name        string         `json:"name"`
+	DisplayName string         `json:"display_name"`
+	Enabled     bool           `json:"enabled"`
+	Deleted     bool           `json:"deleted"`
+}
+
+// UserAIProviderKeyConfig is a provider summary from the current user's
+// perspective. It reports key presence but never returns key material.
+type UserAIProviderKeyConfig struct {
+	Provider      AIProviderSummary `json:"provider"`
+	HasUserAPIKey bool              `json:"has_user_api_key"`
+	BYOKEnabled   bool              `json:"byok_enabled"`
+}
+
+// CreateUserAIProviderKeyRequest creates or replaces a user's API key
+// for an AI provider.
+type CreateUserAIProviderKeyRequest struct {
+	APIKey string `json:"api_key"`
+}
+
 // UserChatProviderConfig is a summary of a provider that allows
 // user-supplied keys, as seen from the current user's perspective.
 type UserChatProviderConfig struct {
@@ -2073,6 +2097,163 @@ func (c *ExperimentalClient) DeleteChatProvider(ctx context.Context, providerID 
 	res, err := c.Request(ctx, http.MethodDelete, fmt.Sprintf("/api/experimental/chats/providers/%s", providerID), nil)
 	if err != nil {
 		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusNoContent {
+		return ReadBodyAsError(res)
+	}
+	return nil
+}
+
+// ListAIProviders returns admin-managed AI providers.
+func (c *ExperimentalClient) ListAIProviders(ctx context.Context) ([]AIProvider, error) {
+	res, err := c.Request(ctx, http.MethodGet, "/api/experimental/chats/ai-providers", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return nil, ReadBodyAsError(res)
+	}
+
+	var providers []AIProvider
+	return providers, json.NewDecoder(res.Body).Decode(&providers)
+}
+
+// CreateAIProvider creates an admin-managed AI provider.
+func (c *ExperimentalClient) CreateAIProvider(ctx context.Context, req CreateAIProviderRequest) (AIProvider, error) {
+	res, err := c.Request(ctx, http.MethodPost, "/api/experimental/chats/ai-providers", req)
+	if err != nil {
+		return AIProvider{}, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusCreated {
+		return AIProvider{}, ReadBodyAsError(res)
+	}
+
+	var provider AIProvider
+	return provider, json.NewDecoder(res.Body).Decode(&provider)
+}
+
+// GetAIProvider returns an admin-managed AI provider.
+func (c *ExperimentalClient) GetAIProvider(ctx context.Context, providerID uuid.UUID) (AIProvider, error) {
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/experimental/chats/ai-providers/%s", providerID), nil)
+	if err != nil {
+		return AIProvider{}, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return AIProvider{}, ReadBodyAsError(res)
+	}
+
+	var provider AIProvider
+	return provider, json.NewDecoder(res.Body).Decode(&provider)
+}
+
+// UpdateAIProvider updates an admin-managed AI provider.
+func (c *ExperimentalClient) UpdateAIProvider(ctx context.Context, providerID uuid.UUID, req UpdateAIProviderRequest) (AIProvider, error) {
+	res, err := c.Request(ctx, http.MethodPatch, fmt.Sprintf("/api/experimental/chats/ai-providers/%s", providerID), req)
+	if err != nil {
+		return AIProvider{}, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return AIProvider{}, ReadBodyAsError(res)
+	}
+
+	var provider AIProvider
+	return provider, json.NewDecoder(res.Body).Decode(&provider)
+}
+
+// DeleteAIProvider deletes an admin-managed AI provider.
+func (c *ExperimentalClient) DeleteAIProvider(ctx context.Context, providerID uuid.UUID) error {
+	res, err := c.Request(ctx, http.MethodDelete, fmt.Sprintf("/api/experimental/chats/ai-providers/%s", providerID), nil)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusNoContent {
+		return ReadBodyAsError(res)
+	}
+	return nil
+}
+
+// ListAIProviderKeys returns provider-scoped AI provider key summaries.
+func (c *ExperimentalClient) ListAIProviderKeys(ctx context.Context, providerID uuid.UUID) ([]AIProviderKey, error) {
+	res, err := c.Request(ctx, http.MethodGet, fmt.Sprintf("/api/experimental/chats/ai-providers/%s/keys", providerID), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return nil, ReadBodyAsError(res)
+	}
+
+	var keys []AIProviderKey
+	return keys, json.NewDecoder(res.Body).Decode(&keys)
+}
+
+// CreateAIProviderKey creates a provider-scoped AI provider key.
+func (c *ExperimentalClient) CreateAIProviderKey(ctx context.Context, providerID uuid.UUID, req CreateAIProviderKeyRequest) (AIProviderKey, error) {
+	res, err := c.Request(ctx, http.MethodPost, fmt.Sprintf("/api/experimental/chats/ai-providers/%s/keys", providerID), req)
+	if err != nil {
+		return AIProviderKey{}, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusCreated {
+		return AIProviderKey{}, ReadBodyAsError(res)
+	}
+
+	var key AIProviderKey
+	return key, json.NewDecoder(res.Body).Decode(&key)
+}
+
+// DeleteAIProviderKey deletes a provider-scoped AI provider key.
+func (c *ExperimentalClient) DeleteAIProviderKey(ctx context.Context, providerID uuid.UUID, keyID uuid.UUID) error {
+	res, err := c.Request(ctx, http.MethodDelete, fmt.Sprintf("/api/experimental/chats/ai-providers/%s/keys/%s", providerID, keyID), nil)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusNoContent {
+		return ReadBodyAsError(res)
+	}
+	return nil
+}
+
+// ListUserAIProviderKeyConfigs returns user-scoped AI provider key configs.
+func (c *ExperimentalClient) ListUserAIProviderKeyConfigs(ctx context.Context) ([]UserAIProviderKeyConfig, error) {
+	res, err := c.Request(ctx, http.MethodGet, "/api/experimental/chats/user-ai-provider-keys", nil)
+	if err != nil {
+		return nil, xerrors.Errorf("list user AI provider key configs: %w", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return nil, ReadBodyAsError(res)
+	}
+	var configs []UserAIProviderKeyConfig
+	return configs, json.NewDecoder(res.Body).Decode(&configs)
+}
+
+// UpsertUserAIProviderKey creates or replaces a user API key for an AI provider.
+func (c *ExperimentalClient) UpsertUserAIProviderKey(ctx context.Context, providerID uuid.UUID, req CreateUserAIProviderKeyRequest) (UserAIProviderKeyConfig, error) {
+	res, err := c.Request(ctx, http.MethodPut, fmt.Sprintf("/api/experimental/chats/user-ai-provider-keys/%s", providerID), req)
+	if err != nil {
+		return UserAIProviderKeyConfig{}, xerrors.Errorf("upsert user AI provider key: %w", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return UserAIProviderKeyConfig{}, ReadBodyAsError(res)
+	}
+	var config UserAIProviderKeyConfig
+	return config, json.NewDecoder(res.Body).Decode(&config)
+}
+
+// DeleteUserAIProviderKey deletes a user API key for an AI provider.
+func (c *ExperimentalClient) DeleteUserAIProviderKey(ctx context.Context, providerID uuid.UUID) error {
+	res, err := c.Request(ctx, http.MethodDelete, fmt.Sprintf("/api/experimental/chats/user-ai-provider-keys/%s", providerID), nil)
+	if err != nil {
+		return xerrors.Errorf("delete user AI provider key: %w", err)
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusNoContent {

--- a/enterprise/dbcrypt/dbcrypt.go
+++ b/enterprise/dbcrypt/dbcrypt.go
@@ -386,6 +386,9 @@ func (db *dbCrypt) GetCryptoKeysByFeature(ctx context.Context, feature database.
 }
 
 // decryptAIProvider decrypts the secret fields of an AI provider row.
+// API response converters omit these fields, but update paths preserve existing
+// settings by reading and writing them through dbcrypt. Returning plaintext here
+// avoids double-encrypting settings when callers update non-secret metadata.
 func (db *dbCrypt) decryptAIProvider(p *database.AIProvider) error {
 	if !p.Settings.Valid {
 		return nil
@@ -412,6 +415,17 @@ func (db *dbCrypt) encryptAIProviderSettings(settings *sql.NullString, keyID *sq
 
 func (db *dbCrypt) GetAIProviderByID(ctx context.Context, id uuid.UUID) (database.AIProvider, error) {
 	provider, err := db.Store.GetAIProviderByID(ctx, id)
+	if err != nil {
+		return database.AIProvider{}, err
+	}
+	if err := db.decryptAIProvider(&provider); err != nil {
+		return database.AIProvider{}, err
+	}
+	return provider, nil
+}
+
+func (db *dbCrypt) GetAIProviderByIDForUpdate(ctx context.Context, id uuid.UUID) (database.AIProvider, error) {
+	provider, err := db.Store.GetAIProviderByIDForUpdate(ctx, id)
 	if err != nil {
 		return database.AIProvider{}, err
 	}

--- a/enterprise/dbcrypt/dbcrypt_internal_test.go
+++ b/enterprise/dbcrypt/dbcrypt_internal_test.go
@@ -1195,6 +1195,7 @@ func TestAIProviders(t *testing.T) {
 		const newSettings = `{"_type":"bedrock","_version":1,"region":"us-east-1","model":"anthropic.claude-sonnet-4-5-20250929-v1:0","access_key":"AKIA-test","access_key_secret":"test-secret"}`
 		updated, err := crypt.UpdateAIProvider(ctx, database.UpdateAIProviderParams{
 			ID:          provider.ID,
+			Name:        provider.Name,
 			DisplayName: provider.DisplayName,
 			Enabled:     provider.Enabled,
 			BaseUrl:     provider.BaseUrl,
@@ -1211,6 +1212,7 @@ func TestAIProviders(t *testing.T) {
 		provider := insertProvider(t, crypt, ciphers)
 		updated, err := crypt.UpdateAIProvider(ctx, database.UpdateAIProviderParams{
 			ID:          provider.ID,
+			Name:        provider.Name,
 			DisplayName: provider.DisplayName,
 			Enabled:     provider.Enabled,
 			BaseUrl:     provider.BaseUrl,

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -311,6 +311,9 @@ export interface AIProvider {
 	readonly name: string;
 	readonly display_name: string;
 	readonly enabled: boolean;
+	readonly deleted: boolean;
+	readonly has_provider_api_key: boolean;
+	readonly byok_enabled: boolean;
 	readonly base_url: string;
 	readonly settings: AIProviderSettings;
 	readonly created_at: string;
@@ -422,6 +425,19 @@ export interface AIProviderSettings {}
  * AIProviderBedrockSettings.
  */
 export const AIProviderSettingsTypeBedrock = "bedrock";
+
+// From codersdk/chats.go
+/**
+ * AIProviderSummary is provider metadata embedded in other API responses.
+ */
+export interface AIProviderSummary {
+	readonly id: string;
+	readonly type: AIProviderType;
+	readonly name: string;
+	readonly display_name: string;
+	readonly enabled: boolean;
+	readonly deleted: boolean;
+}
 
 // From codersdk/aiproviders.go
 export type AIProviderType =
@@ -3172,9 +3188,10 @@ export interface CreateAIProviderRequest {
 	readonly type: AIProviderType;
 	readonly name: string;
 	readonly display_name?: string;
-	readonly enabled: boolean;
-	readonly base_url: string;
+	readonly enabled?: boolean;
+	readonly base_url?: string;
 	readonly settings?: AIProviderSettings;
+	readonly api_key?: string;
 }
 
 // From codersdk/chats.go
@@ -3538,6 +3555,15 @@ export interface CreateTokenRequest {
 	readonly scopes?: readonly APIKeyScope[];
 	readonly token_name: string;
 	readonly allow_list?: readonly APIAllowListTarget[];
+}
+
+// From codersdk/chats.go
+/**
+ * CreateUserAIProviderKeyRequest creates or replaces a user's API key
+ * for an AI provider.
+ */
+export interface CreateUserAIProviderKeyRequest {
+	readonly api_key: string;
 }
 
 // From codersdk/chats.go
@@ -8309,10 +8335,12 @@ export interface TransitionStats {
  * to the zero value).
  */
 export interface UpdateAIProviderRequest {
+	readonly name?: string;
 	readonly display_name?: string;
 	readonly enabled?: boolean;
 	readonly base_url?: string;
 	readonly settings?: AIProviderSettings;
+	readonly api_key?: string;
 }
 
 // From codersdk/templates.go
@@ -9032,6 +9060,17 @@ export interface User extends ReducedUser {
 	 * field, even when false.
 	 */
 	readonly has_ai_seat: boolean;
+}
+
+// From codersdk/chats.go
+/**
+ * UserAIProviderKeyConfig is a provider summary from the current user's
+ * perspective. It reports key presence but never returns key material.
+ */
+export interface UserAIProviderKeyConfig {
+	readonly provider: AIProviderSummary;
+	readonly has_user_api_key: boolean;
+	readonly byok_enabled: boolean;
 }
 
 // From codersdk/insights.go


### PR DESCRIPTION
> Mux updated this PR on behalf of Mike.

## Stack Context

This PR builds on #25412 in the AI providers stack.

Stack order:
1. #25411 AI provider glossary
2. #25412 schema expansion
3. #25413 API surface
4. #25414 backend cutover
5. #25415 frontend cutover
6. #25416 legacy cleanup

## What?

Adds the AI provider chat API surface, SDK types and methods, authorization coverage, and API tests.

## Validation

- `go test ./coderd -run '^(TestAIProviderCRUD|TestUserAIProviderKeys|TestListChatModelConfigs|TestCreateChatModelConfig|TestUpdateChatModelConfig|TestDeleteChatModelConfig)$' -count=1`
- pre-commit hook
