### PR TITLE
fix(site): make agents sidebar resize handle highlight 1px thinner

### DIFF
--- a/site/src/pages/AgentsPage/components/RightPanel/RightPanel.tsx
+++ b/site/src/pages/AgentsPage/components/RightPanel/RightPanel.tsx
@@ -247,7 +247,7 @@ export const RightPanel = ({
 				onPointerMove={handlePointerMove}
 				onPointerUp={handlePointerUp}
 				className={cn(
-					"absolute top-0 left-0 z-20 hidden h-full w-1 cursor-col-resize select-none transition-colors hover:bg-content-link lg:block",
+					"absolute top-0 left-0 z-20 hidden h-full w-[2px] cursor-col-resize select-none transition-colors hover:bg-content-link lg:block",
 					visualExpanded && "-left-1",
 				)}
 			/>

--- a/site/src/pages/AgentsPage/components/Sidebar/ResizableAgentsSidebarFrame.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/ResizableAgentsSidebarFrame.tsx
@@ -133,7 +133,7 @@ export const ResizableAgentsSidebarFrame = ({
 				onPointerUp={handlePointerEnd}
 				onPointerCancel={handlePointerEnd}
 				onKeyDown={handleKeyDown}
-				className="absolute top-0 right-0 z-20 hidden h-full w-1 touch-none cursor-col-resize select-none transition-colors hover:bg-content-link focus-visible:bg-content-link focus-visible:outline-none sm:block"
+				className="absolute top-0 right-0 z-20 hidden h-full w-[3px] touch-none cursor-col-resize select-none transition-colors hover:bg-content-link focus-visible:bg-content-link focus-visible:outline-none sm:block"
 			/>
 		</div>
 	);

--- a/site/src/pages/AgentsPage/components/Sidebar/ResizableAgentsSidebarFrame.tsx
+++ b/site/src/pages/AgentsPage/components/Sidebar/ResizableAgentsSidebarFrame.tsx
@@ -133,7 +133,7 @@ export const ResizableAgentsSidebarFrame = ({
 				onPointerUp={handlePointerEnd}
 				onPointerCancel={handlePointerEnd}
 				onKeyDown={handleKeyDown}
-				className="absolute top-0 right-0 z-20 hidden h-full w-[3px] touch-none cursor-col-resize select-none transition-colors hover:bg-content-link focus-visible:bg-content-link focus-visible:outline-none sm:block"
+				className="absolute top-0 right-0 z-20 hidden h-full w-[2px] touch-none cursor-col-resize select-none transition-colors hover:bg-content-link focus-visible:bg-content-link focus-visible:outline-none sm:block"
 			/>
 		</div>
 	);


### PR DESCRIPTION
Reduces the agents sidebar resize handle highlight width from `w-1` (4px) to `w-[3px]` (3px).

> Generated by Coder Agents on behalf of @tracyjohnsonux