### PR TITLE
feat: add agent-summary-tab experiment with summary panel

### DIFF
--- a/coderd/apidoc/docs.go
+++ b/coderd/apidoc/docs.go
@@ -18251,9 +18251,11 @@ const docTemplate = `{
                 "workspace-usage",
                 "oauth2",
                 "mcp-server-http",
-                "workspace-build-updates"
+                "workspace-build-updates",
+                "agent-summary-tab"
             ],
             "x-enum-comments": {
+                "ExperimentAgentSummaryTab": "Enables the summary tab in the agent sidebar.",
                 "ExperimentAutoFillParameters": "This should not be taken out of experiments until we have redesigned the feature.",
                 "ExperimentExample": "This isn't used for anything.",
                 "ExperimentMCPServerHTTP": "Enables the MCP HTTP server functionality.",
@@ -18269,7 +18271,8 @@ const docTemplate = `{
                 "Enables the new workspace usage tracking.",
                 "Enables OAuth2 provider functionality.",
                 "Enables the MCP HTTP server functionality.",
-                "Enables publishing workspace build updates to the all builds pubsub channel."
+                "Enables publishing workspace build updates to the all builds pubsub channel.",
+                "Enables the summary tab in the agent sidebar."
             ],
             "x-enum-varnames": [
                 "ExperimentExample",
@@ -18278,7 +18281,8 @@ const docTemplate = `{
                 "ExperimentWorkspaceUsage",
                 "ExperimentOAuth2",
                 "ExperimentMCPServerHTTP",
-                "ExperimentWorkspaceBuildUpdates"
+                "ExperimentWorkspaceBuildUpdates",
+                "ExperimentAgentSummaryTab"
             ]
         },
         "codersdk.ExternalAPIKeyScopes": {

--- a/coderd/apidoc/swagger.json
+++ b/coderd/apidoc/swagger.json
@@ -16584,9 +16584,11 @@
 				"workspace-usage",
 				"oauth2",
 				"mcp-server-http",
-				"workspace-build-updates"
+				"workspace-build-updates",
+				"agent-summary-tab"
 			],
 			"x-enum-comments": {
+				"ExperimentAgentSummaryTab": "Enables the summary tab in the agent sidebar.",
 				"ExperimentAutoFillParameters": "This should not be taken out of experiments until we have redesigned the feature.",
 				"ExperimentExample": "This isn't used for anything.",
 				"ExperimentMCPServerHTTP": "Enables the MCP HTTP server functionality.",
@@ -16602,7 +16604,8 @@
 				"Enables the new workspace usage tracking.",
 				"Enables OAuth2 provider functionality.",
 				"Enables the MCP HTTP server functionality.",
-				"Enables publishing workspace build updates to the all builds pubsub channel."
+				"Enables publishing workspace build updates to the all builds pubsub channel.",
+				"Enables the summary tab in the agent sidebar."
 			],
 			"x-enum-varnames": [
 				"ExperimentExample",
@@ -16611,7 +16614,8 @@
 				"ExperimentWorkspaceUsage",
 				"ExperimentOAuth2",
 				"ExperimentMCPServerHTTP",
-				"ExperimentWorkspaceBuildUpdates"
+				"ExperimentWorkspaceBuildUpdates",
+				"ExperimentAgentSummaryTab"
 			]
 		},
 		"codersdk.ExternalAPIKeyScopes": {

--- a/codersdk/deployment.go
+++ b/codersdk/deployment.go
@@ -4497,6 +4497,7 @@ const (
 	ExperimentOAuth2                Experiment = "oauth2"                  // Enables OAuth2 provider functionality.
 	ExperimentMCPServerHTTP         Experiment = "mcp-server-http"         // Enables the MCP HTTP server functionality.
 	ExperimentWorkspaceBuildUpdates Experiment = "workspace-build-updates" // Enables publishing workspace build updates to the all builds pubsub channel.
+	ExperimentAgentSummaryTab       Experiment = "agent-summary-tab"       // Enables the summary tab in the agent sidebar.
 )
 
 func (e Experiment) DisplayName() string {
@@ -4515,6 +4516,8 @@ func (e Experiment) DisplayName() string {
 		return "MCP HTTP Server Functionality"
 	case ExperimentWorkspaceBuildUpdates:
 		return "Workspace Build Updates Channel"
+	case ExperimentAgentSummaryTab:
+		return "Agent Summary Tab"
 	default:
 		// Split on hyphen and convert to title case
 		// e.g. "mcp-server-http" -> "Mcp Server Http"
@@ -4532,6 +4535,7 @@ var ExperimentsKnown = Experiments{
 	ExperimentOAuth2,
 	ExperimentMCPServerHTTP,
 	ExperimentWorkspaceBuildUpdates,
+	ExperimentAgentSummaryTab,
 }
 
 // ExperimentsSafe should include all experiments that are safe for

--- a/docs/reference/api/schemas.md
+++ b/docs/reference/api/schemas.md
@@ -6825,9 +6825,9 @@ CreateWorkspaceRequest provides options for creating a new workspace. Only one o
 
 #### Enumerated Values
 
-| Value(s)                                                                                                                      |
-|-------------------------------------------------------------------------------------------------------------------------------|
-| `auto-fill-parameters`, `example`, `mcp-server-http`, `notifications`, `oauth2`, `workspace-build-updates`, `workspace-usage` |
+| Value(s)                                                                                                                                           |
+|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `agent-summary-tab`, `auto-fill-parameters`, `example`, `mcp-server-http`, `notifications`, `oauth2`, `workspace-build-updates`, `workspace-usage` |
 
 ## codersdk.ExternalAPIKeyScopes
 

--- a/site/src/api/typesGenerated.ts
+++ b/site/src/api/typesGenerated.ts
@@ -4010,6 +4010,7 @@ export const EntitlementsWarningHeader = "X-Coder-Entitlements-Warning";
 
 // From codersdk/deployment.go
 export type Experiment =
+	| "agent-summary-tab"
 	| "auto-fill-parameters"
 	| "example"
 	| "mcp-server-http"
@@ -4019,6 +4020,7 @@ export type Experiment =
 	| "workspace-usage";
 
 export const Experiments: Experiment[] = [
+	"agent-summary-tab",
 	"auto-fill-parameters",
 	"example",
 	"mcp-server-http",

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -1566,6 +1566,7 @@ const AgentChatPage: FC = () => {
 			diffStatusData={chatQuery.data?.diff_status}
 			debugLoggingEnabled={debugLoggingEnabled}
 			summaryTabEnabled={summaryTabEnabled}
+			summaryData={undefined}
 			gitWatcher={gitWatcher}
 			sshCommand={sshCommand}
 			handleCommit={handleCommit}

--- a/site/src/pages/AgentsPage/AgentChatPage.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPage.tsx
@@ -47,6 +47,7 @@ import type * as TypesGen from "#/api/typesGenerated";
 import type { ChatMessagePart } from "#/api/typesGenerated";
 import { useProxy } from "#/contexts/ProxyContext";
 import { useAuthenticated } from "#/hooks/useAuthenticated";
+import { useDashboard } from "#/modules/dashboard/useDashboard";
 import { isMobileViewport } from "#/utils/mobile";
 import { pageTitle } from "#/utils/page";
 import { rewriteLocalhostURL } from "#/utils/portForward";
@@ -667,6 +668,7 @@ const AgentChatPage: FC = () => {
 	} = useOutletContext<AgentsOutletContext>();
 	const queryClient = useQueryClient();
 	const { permissions, user: currentUser } = useAuthenticated();
+	const { experiments } = useDashboard();
 	const [selectedModel, setSelectedModel] = useState("");
 	const scrollToBottomRef = useRef<(() => void) | null>(null);
 	const chatInputRef = useRef<ChatMessageInputRef | null>(null);
@@ -733,6 +735,7 @@ const AgentChatPage: FC = () => {
 	const desktopEnabled = desktopEnabledQuery.data?.enable_desktop ?? false;
 	const debugLoggingEnabled =
 		userDebugLoggingQuery.data?.debug_logging_enabled ?? false;
+	const summaryTabEnabled = experiments.includes("agent-summary-tab");
 
 	// MCP server selection state.
 	const mcpServers = mcpServersQuery.data ?? [];
@@ -1562,6 +1565,7 @@ const AgentChatPage: FC = () => {
 			prNumber={prNumber}
 			diffStatusData={chatQuery.data?.diff_status}
 			debugLoggingEnabled={debugLoggingEnabled}
+			summaryTabEnabled={summaryTabEnabled}
 			gitWatcher={gitWatcher}
 			sshCommand={sshCommand}
 			handleCommit={handleCommit}

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -160,6 +160,7 @@ const StoryAgentChatPageView: FC<StoryProps> = ({ editing, ...overrides }) => {
 		>["diffStatusData"],
 		debugLoggingEnabled: false,
 		summaryTabEnabled: false,
+		summaryData: undefined,
 		gitWatcher: buildGitWatcher(),
 		sshCommand: undefined as string | undefined,
 		handleCommit: fn(),

--- a/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.stories.tsx
@@ -159,6 +159,7 @@ const StoryAgentChatPageView: FC<StoryProps> = ({ editing, ...overrides }) => {
 			typeof AgentChatPageView
 		>["diffStatusData"],
 		debugLoggingEnabled: false,
+		summaryTabEnabled: false,
 		gitWatcher: buildGitWatcher(),
 		sshCommand: undefined as string | undefined,
 		handleCommit: fn(),

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -39,6 +39,7 @@ import { RightPanel } from "./components/RightPanel/RightPanel";
 import { getEffectiveTabId } from "./components/Sidebar/getEffectiveTabId";
 import { SidebarTabView } from "./components/Sidebar/SidebarTabView";
 import { getWorkspaceStatus, StatusIcon } from "./components/StatusIcon";
+import { SummaryPanel } from "./components/SummaryPanel/SummaryPanel";
 import { TerminalPanel } from "./components/TerminalPanel";
 import { ChatWorkspaceContext } from "./context/ChatWorkspaceContext";
 import { chatWidthClass, useChatFullWidth } from "./hooks/useChatFullWidth";
@@ -136,6 +137,7 @@ interface AgentChatPageViewProps {
 	prNumber: number | undefined;
 	diffStatusData: ChatDiffStatus | undefined;
 	debugLoggingEnabled: boolean;
+	summaryTabEnabled: boolean;
 	gitWatcher: {
 		repositories: ReadonlyMap<string, TypesGen.WorkspaceAgentRepoChanges>;
 		everDirty: ReadonlySet<string>;
@@ -227,6 +229,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	prNumber,
 	diffStatusData,
 	debugLoggingEnabled,
+	summaryTabEnabled,
 	gitWatcher,
 	sshCommand,
 	handleCommit,
@@ -348,6 +351,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	// new tab can never be added to one without the other going out of
 	// sync.
 	const sidebarTabConfigs = [
+		...(summaryTabEnabled ? [{ id: "summary", label: "Summary" }] : []),
 		{ id: "git", label: "Git" },
 		...(workspace && workspaceAgent
 			? [{ id: "terminal", label: "Terminal" }]
@@ -362,6 +366,8 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	);
 	const renderTabContent = (tabId: string): ReactNode => {
 		switch (tabId) {
+			case "summary":
+				return <SummaryPanel chatTitle={chatTitle} />;
 			case "git":
 				return (
 					<GitPanel

--- a/site/src/pages/AgentsPage/AgentChatPageView.tsx
+++ b/site/src/pages/AgentsPage/AgentChatPageView.tsx
@@ -39,7 +39,10 @@ import { RightPanel } from "./components/RightPanel/RightPanel";
 import { getEffectiveTabId } from "./components/Sidebar/getEffectiveTabId";
 import { SidebarTabView } from "./components/Sidebar/SidebarTabView";
 import { getWorkspaceStatus, StatusIcon } from "./components/StatusIcon";
-import { SummaryPanel } from "./components/SummaryPanel/SummaryPanel";
+import {
+	SummaryPanel,
+	type SummaryPanelProps,
+} from "./components/SummaryPanel/SummaryPanel";
 import { TerminalPanel } from "./components/TerminalPanel";
 import { ChatWorkspaceContext } from "./context/ChatWorkspaceContext";
 import { chatWidthClass, useChatFullWidth } from "./hooks/useChatFullWidth";
@@ -138,6 +141,7 @@ interface AgentChatPageViewProps {
 	diffStatusData: ChatDiffStatus | undefined;
 	debugLoggingEnabled: boolean;
 	summaryTabEnabled: boolean;
+	summaryData: SummaryPanelProps | undefined;
 	gitWatcher: {
 		repositories: ReadonlyMap<string, TypesGen.WorkspaceAgentRepoChanges>;
 		everDirty: ReadonlySet<string>;
@@ -230,6 +234,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	diffStatusData,
 	debugLoggingEnabled,
 	summaryTabEnabled,
+	summaryData,
 	gitWatcher,
 	sshCommand,
 	handleCommit,
@@ -367,7 +372,7 @@ export const AgentChatPageView: FC<AgentChatPageViewProps> = ({
 	const renderTabContent = (tabId: string): ReactNode => {
 		switch (tabId) {
 			case "summary":
-				return <SummaryPanel chatTitle={chatTitle} />;
+				return summaryData ? <SummaryPanel {...summaryData} /> : null;
 			case "git":
 				return (
 					<GitPanel

--- a/site/src/pages/AgentsPage/components/SummaryPanel/SummaryPanel.stories.tsx
+++ b/site/src/pages/AgentsPage/components/SummaryPanel/SummaryPanel.stories.tsx
@@ -270,3 +270,15 @@ export const MinimalActivity: Story = {
 		relatedChats: [],
 	},
 };
+
+/** Tests the minimum panel width (360px) to verify nothing overflows. */
+export const NarrowWidth: Story = {
+	args: sampleData,
+	decorators: [
+		(Story) => (
+			<div className="h-[900px] w-[360px] border border-border-default bg-surface-primary">
+				<Story />
+			</div>
+		),
+	],
+};

--- a/site/src/pages/AgentsPage/components/SummaryPanel/SummaryPanel.stories.tsx
+++ b/site/src/pages/AgentsPage/components/SummaryPanel/SummaryPanel.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { SummaryPanel } from "./SummaryPanel";
+
+const meta: Meta<typeof SummaryPanel> = {
+	title: "pages/AgentsPage/SummaryPanel",
+	component: SummaryPanel,
+	decorators: [
+		(Story) => (
+			<div className="h-96 w-80 border border-border-default">
+				<Story />
+			</div>
+		),
+	],
+};
+
+export default meta;
+type Story = StoryObj<typeof SummaryPanel>;
+
+export const Default: Story = {
+	args: {
+		chatTitle: undefined,
+	},
+};
+
+export const WithTitle: Story = {
+	args: {
+		chatTitle: "Fix login bug",
+	},
+};

--- a/site/src/pages/AgentsPage/components/SummaryPanel/SummaryPanel.stories.tsx
+++ b/site/src/pages/AgentsPage/components/SummaryPanel/SummaryPanel.stories.tsx
@@ -1,12 +1,103 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { SummaryPanelProps } from "./SummaryPanel";
 import { SummaryPanel } from "./SummaryPanel";
+
+const sampleData: SummaryPanelProps = {
+	metadata: {
+		createdAt: "Dec 12, 2025: 03:01:09 PM",
+		lastUpdatedAt: "May 4, 2026: 09:32:05 PM",
+		costDisplay: "$87.45",
+		tokens: {
+			input: 123_132,
+			cached: 2_134_563,
+			output: 233,
+		},
+		model: "claude-opus-4-5-20251101",
+		tags: ["backend", "api", "performance", "project name"],
+	},
+	repo: "repo name goes here",
+	prDetails: [
+		{
+			number: 4847,
+			title: "Add per-user rate limit",
+			additions: 25,
+			deletions: 65,
+		},
+	],
+	prompts: [
+		{
+			index: 37,
+			text: "Verify token bucket decay math with edge cases",
+		},
+		{
+			index: 36,
+			text: "Add route-level override config to router",
+		},
+		{
+			index: 35,
+			text: "Fix retry-after header injection on 429 response",
+		},
+	],
+	totalPrompts: 37,
+	activities: [
+		{ text: "Set up Redis TTL key schema for user buckets" },
+		{ text: "Added route-level override support in router" },
+		{ text: "Wrote retry-after header injection on 429" },
+	],
+	totalActivities: 15,
+	files: [
+		{
+			path: "ratelimit/bucket.go",
+			status: "New",
+			additions: 54,
+			deletions: 0,
+		},
+		{
+			path: "api/routes.go",
+			status: "Edited",
+			additions: 115,
+			deletions: 0,
+		},
+		{
+			path: "docs/api/rate-limiting.md",
+			status: "New",
+			additions: 25,
+			deletions: 0,
+		},
+		{
+			path: "config/defaults.yaml",
+			status: "Edited",
+			additions: 30,
+			deletions: 1,
+		},
+		{
+			path: "config/defaults.yaml",
+			status: "Edited",
+			additions: 64,
+			deletions: 70,
+		},
+	],
+	totalFiles: 34,
+	relatedChats: [
+		{
+			title: "Investigate API latency spikes",
+			reason: "references same files",
+		},
+		{
+			title: "Refactor api/middleware chain",
+			reason: "references same files",
+		},
+		{ title: "Add caching to /v1/users", reason: "shared tags" },
+		{ title: "Token bucket research notes", reason: "shared tags" },
+	],
+};
 
 const meta: Meta<typeof SummaryPanel> = {
 	title: "pages/AgentsPage/SummaryPanel",
 	component: SummaryPanel,
 	decorators: [
 		(Story) => (
-			<div className="h-96 w-80 border border-border-default">
+			<div className="h-[900px] w-[420px] border border-border-default bg-surface-primary">
 				<Story />
 			</div>
 		),
@@ -17,13 +108,61 @@ export default meta;
 type Story = StoryObj<typeof SummaryPanel>;
 
 export const Default: Story = {
+	args: sampleData,
+};
+
+export const WithEditableTags: Story = {
 	args: {
-		chatTitle: undefined,
+		...sampleData,
+		onRemoveTag: () => {},
+		onEditTags: () => {},
 	},
 };
 
-export const WithTitle: Story = {
+export const MultiplePRs: Story = {
 	args: {
-		chatTitle: "Fix login bug",
+		...sampleData,
+		prDetails: [
+			{
+				number: 4847,
+				title: "Add per-user rate limit",
+				additions: 25,
+				deletions: 65,
+			},
+			{
+				number: 4848,
+				title: "Fix rate limit headers",
+				additions: 10,
+				deletions: 3,
+			},
+		],
+	},
+};
+
+export const NoPRs: Story = {
+	args: {
+		...sampleData,
+		prDetails: [],
+		repo: undefined,
+	},
+};
+
+export const MinimalActivity: Story = {
+	args: {
+		...sampleData,
+		prompts: [{ index: 1, text: "Initial prompt" }],
+		totalPrompts: 1,
+		activities: [{ text: "Started working" }],
+		totalActivities: 1,
+		files: [
+			{
+				path: "main.go",
+				status: "New",
+				additions: 10,
+				deletions: 0,
+			},
+		],
+		totalFiles: 1,
+		relatedChats: [],
 	},
 };

--- a/site/src/pages/AgentsPage/components/SummaryPanel/SummaryPanel.stories.tsx
+++ b/site/src/pages/AgentsPage/components/SummaryPanel/SummaryPanel.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
 import type { SummaryPanelProps } from "./SummaryPanel";
 import { SummaryPanel } from "./SummaryPanel";
 
@@ -15,11 +16,12 @@ const sampleData: SummaryPanelProps = {
 		model: "claude-opus-4-5-20251101",
 		tags: ["backend", "api", "performance", "project name"],
 	},
-	repo: "repo name goes here",
+	repo: "coder/coder",
 	prDetails: [
 		{
 			number: 4847,
 			title: "Add per-user rate limit",
+			url: "https://github.com/coder/coder/pull/4847",
 			additions: 25,
 			deletions: 65,
 		},
@@ -28,14 +30,17 @@ const sampleData: SummaryPanelProps = {
 		{
 			index: 37,
 			text: "Verify token bucket decay math with edge cases",
+			messageId: 100,
 		},
 		{
 			index: 36,
 			text: "Add route-level override config to router",
+			messageId: 98,
 		},
 		{
 			index: 35,
 			text: "Fix retry-after header injection on 429 response",
+			messageId: 96,
 		},
 	],
 	totalPrompts: 37,
@@ -71,7 +76,7 @@ const sampleData: SummaryPanelProps = {
 			deletions: 1,
 		},
 		{
-			path: "config/defaults.yaml",
+			path: "config/overrides.yaml",
 			status: "Edited",
 			additions: 64,
 			deletions: 70,
@@ -82,14 +87,26 @@ const sampleData: SummaryPanelProps = {
 		{
 			title: "Investigate API latency spikes",
 			reason: "references same files",
+			chatId: "chat-1",
 		},
 		{
 			title: "Refactor api/middleware chain",
 			reason: "references same files",
+			chatId: "chat-2",
 		},
-		{ title: "Add caching to /v1/users", reason: "shared tags" },
-		{ title: "Token bucket research notes", reason: "shared tags" },
+		{
+			title: "Add caching to /v1/users",
+			reason: "shared tags",
+			chatId: "chat-3",
+		},
+		{
+			title: "Token bucket research notes",
+			reason: "shared tags",
+			chatId: "chat-4",
+		},
 	],
+	onPromptClick: fn(),
+	onRelatedChatClick: fn(),
 };
 
 const meta: Meta<typeof SummaryPanel> = {
@@ -114,8 +131,8 @@ export const Default: Story = {
 export const WithEditableTags: Story = {
 	args: {
 		...sampleData,
-		onRemoveTag: () => {},
-		onEditTags: () => {},
+		onRemoveTag: fn(),
+		onEditTags: fn(),
 	},
 };
 
@@ -124,18 +141,105 @@ export const MultiplePRs: Story = {
 		...sampleData,
 		prDetails: [
 			{
-				number: 4847,
-				title: "Add per-user rate limit",
+				number: 25426,
+				title: "Replace filter dropdown with rich popover",
+				url: "https://github.com/coder/coder/pull/25426",
 				additions: 25,
 				deletions: 65,
 			},
 			{
-				number: 4848,
-				title: "Fix rate limit headers",
+				number: 25425,
+				title: "Add search to sidebar chat list",
+				url: "https://github.com/coder/coder/pull/25425",
 				additions: 10,
 				deletions: 3,
 			},
 		],
+	},
+};
+
+export const FewPrompts: Story = {
+	args: {
+		...sampleData,
+		metadata: {
+			...sampleData.metadata,
+			createdAt: "2026-05-18T06:00:29.345Z",
+			lastUpdatedAt: "2026-05-18T07:00:29.345Z",
+			costDisplay: "$4.82",
+			tokens: { input: 48_200, cached: 12_800, output: 9_100 },
+			model: "claude-sonnet-4-20250514",
+			tags: ["frontend", "sidebar", "ux-review"],
+		},
+		prDetails: [
+			{
+				number: 25426,
+				title: "Replace filter dropdown with rich popover",
+				url: "https://github.com/coder/coder/pull/25426",
+				additions: 25,
+				deletions: 65,
+			},
+			{
+				number: 25425,
+				title: "Add search to sidebar chat list",
+				url: "https://github.com/coder/coder/pull/25425",
+				additions: 10,
+				deletions: 3,
+			},
+		],
+		prompts: [
+			{
+				index: 1,
+				text: "Add a search function to the agents sidebar",
+				messageId: 10,
+			},
+			{
+				index: 2,
+				text: "Replace the filter dropdown with a rich popover",
+				messageId: 20,
+			},
+			{
+				index: 3,
+				text: "Make the sidebar resize handle thinner",
+				messageId: 30,
+			},
+		],
+		totalPrompts: 3,
+		activities: [
+			{ text: "Created SearchButton component in FilterDropdown.tsx" },
+			{
+				text: "Added client-side chat filtering with multi-field match",
+			},
+			{ text: "Replaced FilterIcon with ListFilterIcon" },
+		],
+		totalActivities: 5,
+		files: [
+			{
+				path: "site/src/components/FilterDropdown.tsx",
+				status: "Edited",
+				additions: 45,
+				deletions: 12,
+			},
+			{
+				path: "site/src/pages/AgentsPage/AgentsSidebar.tsx",
+				status: "Edited",
+				additions: 80,
+				deletions: 5,
+			},
+			{
+				path: "site/src/components/SearchButton.tsx",
+				status: "New",
+				additions: 35,
+				deletions: 0,
+			},
+			{
+				path: "site/src/components/ResizeHandle.tsx",
+				status: "Edited",
+				additions: 3,
+				deletions: 3,
+			},
+		],
+		totalFiles: 4,
+		relatedChats: [],
 	},
 };
 
@@ -150,7 +254,7 @@ export const NoPRs: Story = {
 export const MinimalActivity: Story = {
 	args: {
 		...sampleData,
-		prompts: [{ index: 1, text: "Initial prompt" }],
+		prompts: [{ index: 1, text: "Initial prompt", messageId: 1 }],
 		totalPrompts: 1,
 		activities: [{ text: "Started working" }],
 		totalActivities: 1,

--- a/site/src/pages/AgentsPage/components/SummaryPanel/SummaryPanel.tsx
+++ b/site/src/pages/AgentsPage/components/SummaryPanel/SummaryPanel.tsx
@@ -1,23 +1,369 @@
-import { FileTextIcon } from "lucide-react";
+import {
+	ArrowDownIcon,
+	ArrowUpIcon,
+	CheckIcon,
+	FileIcon,
+	GitPullRequestIcon,
+	LayersIcon,
+	PenLineIcon,
+	XIcon,
+} from "lucide-react";
 import type { FC } from "react";
+import { useState } from "react";
+import { Badge } from "#/components/Badge/Badge";
 import { ScrollArea } from "#/components/ScrollArea/ScrollArea";
+import { cn } from "#/utils/cn";
+import { DiffStatBadge } from "../DiffViewer/DiffStats";
 
-interface SummaryPanelProps {
-	chatTitle: string | undefined;
+// ---------------------------------------------------------------------------
+// Data types
+// ---------------------------------------------------------------------------
+
+interface SummaryMetadata {
+	createdAt: string;
+	lastUpdatedAt: string;
+	costDisplay: string;
+	tokens: {
+		input: number;
+		cached: number;
+		output: number;
+	};
+	model: string;
+	tags: readonly string[];
 }
 
-export const SummaryPanel: FC<SummaryPanelProps> = ({ chatTitle }) => {
+interface SummaryPRDetail {
+	number: number;
+	title: string;
+	additions: number;
+	deletions: number;
+}
+
+interface SummaryPrompt {
+	index: number;
+	text: string;
+}
+
+interface SummaryActivity {
+	text: string;
+}
+
+interface SummaryFileChange {
+	path: string;
+	status: "New" | "Edited" | "Deleted";
+	additions: number;
+	deletions: number;
+}
+
+interface SummaryRelatedChat {
+	title: string;
+	reason: string;
+}
+
+export interface SummaryPanelProps {
+	metadata: SummaryMetadata;
+	repo: string | undefined;
+	prDetails: readonly SummaryPRDetail[];
+	prompts: readonly SummaryPrompt[];
+	totalPrompts: number;
+	activities: readonly SummaryActivity[];
+	totalActivities: number;
+	files: readonly SummaryFileChange[];
+	totalFiles: number;
+	relatedChats: readonly SummaryRelatedChat[];
+	onRemoveTag?: (tag: string) => void;
+	onEditTags?: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatCompactNumber(n: number): string {
+	if (n >= 1_000_000) {
+		const m = n / 1_000_000;
+		return `${m % 1 === 0 ? m.toFixed(0) : m.toFixed(1)}M`;
+	}
+	return n.toLocaleString("en-US");
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+const SectionDivider: FC = () => (
+	<div className="border-0 border-t border-solid border-border-default" />
+);
+
+const MetadataRow: FC<{
+	label: string;
+	children: React.ReactNode;
+	className?: string;
+}> = ({ label, children, className }) => (
+	<div className={cn("flex items-start gap-3 text-sm", className)}>
+		<span className="w-28 shrink-0 text-content-secondary">{label}</span>
+		<span className="min-w-0 flex-1 text-content-primary">{children}</span>
+	</div>
+);
+
+const TokenBadge: FC<{
+	icon: React.ReactNode;
+	value: number;
+}> = ({ icon, value }) => (
+	<Badge variant="default" size="sm">
+		{icon}
+		{formatCompactNumber(value)}
+	</Badge>
+);
+
+const TagBadge: FC<{
+	label: string;
+	onRemove?: () => void;
+}> = ({ label, onRemove }) => (
+	<Badge variant="default" size="sm" className="gap-1">
+		{label}
+		{onRemove && (
+			<button
+				type="button"
+				onClick={onRemove}
+				className="ml-0.5 flex items-center text-content-secondary hover:text-content-primary"
+			>
+				<XIcon className="size-3" />
+			</button>
+		)}
+	</Badge>
+);
+
+const PRRow: FC<{ pr: SummaryPRDetail }> = ({ pr }) => (
+	<div className="flex items-center gap-2 text-sm">
+		<span className="min-w-0 flex-1 truncate text-content-primary">
+			PR #{pr.number} &quot;{pr.title}&quot;
+		</span>
+		<GitPullRequestIcon className="size-4 shrink-0 text-content-secondary" />
+		<DiffStatBadge additions={pr.additions} deletions={pr.deletions} />
+	</div>
+);
+
+const FileRow: FC<{ file: SummaryFileChange }> = ({ file }) => (
+	<div className="flex items-center gap-2 py-1.5 text-sm">
+		<FileIcon className="size-4 shrink-0 text-content-secondary" />
+		<span className="min-w-0 flex-1 truncate font-mono text-[13px] text-content-primary">
+			{file.path}
+		</span>
+		<span className="shrink-0 text-xs text-content-secondary">
+			{file.status}
+		</span>
+		<span className="shrink-0 font-mono text-[13px]">
+			{file.additions > 0 && (
+				<span className="text-git-added-bright">+{file.additions}</span>
+			)}
+			{file.additions > 0 && file.deletions > 0 && " "}
+			{file.deletions > 0 && (
+				<span className="text-git-deleted-bright">-{file.deletions}</span>
+			)}
+		</span>
+	</div>
+);
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export const SummaryPanel: FC<SummaryPanelProps> = ({
+	metadata,
+	repo,
+	prDetails,
+	prompts,
+	totalPrompts,
+	activities,
+	totalActivities,
+	files,
+	totalFiles,
+	relatedChats,
+	onRemoveTag,
+	onEditTags,
+}) => {
+	const [showAllPrompts, setShowAllPrompts] = useState(false);
+	const [showAllActivities, setShowAllActivities] = useState(false);
+
+	const hiddenPrompts = totalPrompts - prompts.length;
+	const hiddenActivities = totalActivities - activities.length;
+
 	return (
-		<ScrollArea className="flex h-full flex-col">
-			<div className="flex flex-col items-center justify-center gap-3 p-6 text-center text-content-secondary">
-				<FileTextIcon className="size-8 text-content-tertiary" />
-				<h3 className="text-sm font-medium text-content-primary">
-					{chatTitle ?? "Chat Summary"}
-				</h3>
-				<p className="max-w-xs text-xs">
-					A summary of this chat session will appear here as the conversation
-					progresses.
-				</p>
+		<ScrollArea className="h-full" scrollBarClassName="w-1.5">
+			<div className="flex flex-col gap-0">
+				{/* Metadata section */}
+				<div className="flex flex-col gap-2.5 px-4 py-4">
+					<MetadataRow label="Created:">{metadata.createdAt}</MetadataRow>
+					<MetadataRow label="Last updated:">
+						{metadata.lastUpdatedAt}
+					</MetadataRow>
+					<MetadataRow label="Cost:">{metadata.costDisplay}</MetadataRow>
+					<MetadataRow label="Tokens:">
+						<div className="flex flex-wrap gap-1.5">
+							<TokenBadge
+								icon={<ArrowDownIcon className="size-3" />}
+								value={metadata.tokens.input}
+							/>
+							<TokenBadge
+								icon={<LayersIcon className="size-3" />}
+								value={metadata.tokens.cached}
+							/>
+							<TokenBadge
+								icon={<ArrowUpIcon className="size-3" />}
+								value={metadata.tokens.output}
+							/>
+						</div>
+					</MetadataRow>
+					<MetadataRow label="Model:">
+						<Badge variant="default" size="sm">
+							{metadata.model}
+						</Badge>
+					</MetadataRow>
+					<MetadataRow label="Tags:">
+						<div className="flex flex-wrap items-center gap-1.5">
+							{metadata.tags.map((tag) => (
+								<TagBadge
+									key={tag}
+									label={tag}
+									onRemove={onRemoveTag ? () => onRemoveTag(tag) : undefined}
+								/>
+							))}
+							{onEditTags && (
+								<button
+									type="button"
+									onClick={onEditTags}
+									className="flex items-center text-content-secondary hover:text-content-primary"
+								>
+									<PenLineIcon className="size-4" />
+								</button>
+							)}
+						</div>
+					</MetadataRow>
+				</div>
+
+				<SectionDivider />
+
+				{/* PR details */}
+				{(prDetails.length > 0 || repo) && (
+					<>
+						<div className="flex flex-col gap-2 px-4 py-4">
+							{prDetails.length > 0 && (
+								<MetadataRow label="PR details:">
+									<div className="flex flex-col gap-1.5">
+										{prDetails.map((pr) => (
+											<PRRow key={pr.number} pr={pr} />
+										))}
+									</div>
+								</MetadataRow>
+							)}
+							{repo && <MetadataRow label="Repo:">{repo}</MetadataRow>}
+						</div>
+						<SectionDivider />
+					</>
+				)}
+
+				{/* Prompt history */}
+				<div className="flex flex-col gap-2 px-4 py-4">
+					<h3 className="text-sm font-medium text-content-primary">
+						Prompt history ({totalPrompts})
+					</h3>
+					<div className="flex flex-col gap-1.5">
+						{(showAllPrompts ? prompts : prompts.slice(0, 3)).map((prompt) => (
+							<div
+								key={prompt.index}
+								className="flex items-start gap-3 text-sm"
+							>
+								<span className="w-6 shrink-0 text-right tabular-nums text-content-secondary">
+									{prompt.index}
+								</span>
+								<span className="text-content-primary">{prompt.text}</span>
+							</div>
+						))}
+					</div>
+					{!showAllPrompts && hiddenPrompts > 0 && (
+						<button
+							type="button"
+							onClick={() => setShowAllPrompts(true)}
+							className="self-start text-sm text-content-link hover:underline"
+						>
+							+{hiddenPrompts} earlier
+						</button>
+					)}
+				</div>
+
+				<SectionDivider />
+
+				{/* Activity */}
+				<div className="flex flex-col gap-2 px-4 py-4">
+					<h3 className="text-sm font-medium text-content-primary">
+						Activity ({totalActivities})
+					</h3>
+					<div className="flex flex-col gap-2">
+						{(showAllActivities ? activities : activities.slice(0, 3)).map(
+							(activity) => (
+								<div
+									key={activity.text}
+									className="flex items-start gap-2.5 text-sm"
+								>
+									<CheckIcon className="mt-0.5 size-4 shrink-0 text-content-secondary" />
+									<span className="text-content-primary">{activity.text}</span>
+								</div>
+							),
+						)}
+					</div>
+					{!showAllActivities && hiddenActivities > 0 && (
+						<button
+							type="button"
+							onClick={() => setShowAllActivities(true)}
+							className="self-start text-sm text-content-link hover:underline"
+						>
+							+{hiddenActivities} more
+						</button>
+					)}
+				</div>
+
+				<SectionDivider />
+
+				{/* Files */}
+				<div className="flex flex-col gap-2 px-4 py-4">
+					<h3 className="text-sm font-medium text-content-primary">
+						Files ({totalFiles})
+					</h3>
+					<div className="rounded-lg border border-solid border-border-default">
+						<div className="flex flex-col divide-y divide-border-default px-3">
+							{files.map((file) => (
+								<FileRow key={file.path} file={file} />
+							))}
+						</div>
+					</div>
+				</div>
+
+				<SectionDivider />
+
+				{/* Related chats */}
+				{relatedChats.length > 0 && (
+					<div className="flex flex-col gap-2 px-4 py-4">
+						<h3 className="text-sm font-medium text-content-primary">
+							Related chats
+						</h3>
+						<div className="flex flex-col gap-1.5">
+							{relatedChats.map((chat) => (
+								<div
+									key={chat.title}
+									className="flex items-baseline gap-2 text-sm"
+								>
+									<span className="font-medium text-content-primary">
+										{chat.title}
+									</span>
+									<span className="text-content-secondary">
+										({chat.reason})
+									</span>
+								</div>
+							))}
+						</div>
+					</div>
+				)}
 			</div>
 		</ScrollArea>
 	);

--- a/site/src/pages/AgentsPage/components/SummaryPanel/SummaryPanel.tsx
+++ b/site/src/pages/AgentsPage/components/SummaryPanel/SummaryPanel.tsx
@@ -111,7 +111,7 @@ const Section: FC<{
 }> = ({ children, className }) => (
 	<div
 		className={cn(
-			"min-w-0 overflow-hidden border-0 border-l-2 border-t border-solid border-border-default px-5 py-5",
+			"min-w-0 overflow-hidden border-0 border-l-2 border-t border-solid border-border-default px-3 py-4",
 			className,
 		)}
 	>
@@ -121,14 +121,17 @@ const Section: FC<{
 
 /**
  * Key-value row used in the metadata and PR details sections.
- * The value column is overflow-hidden so children can truncate.
+ * The label uses its natural width so the layout adapts to any
+ * panel size without wasting space.
  */
 const MetadataRow: FC<{
 	label: string;
 	children: React.ReactNode;
 }> = ({ label, children }) => (
-	<div className="flex min-w-0 items-start gap-4 text-sm leading-6">
-		<span className="w-[7.5rem] shrink-0 text-content-secondary">{label}</span>
+	<div className="flex min-w-0 items-start gap-3 text-sm leading-6">
+		<span className="shrink-0 whitespace-nowrap text-content-secondary">
+			{label}
+		</span>
 		<div className="min-w-0 flex-1 overflow-hidden text-content-primary">
 			{children}
 		</div>
@@ -244,7 +247,7 @@ export const SummaryPanel: FC<SummaryPanelProps> = ({
 			<div className="flex flex-col">
 				{/* ---- Metadata ---- */}
 				<Section className="border-l-0 border-t-0">
-					<div className="flex flex-col gap-3">
+					<div className="flex flex-col gap-2.5">
 						<MetadataRow label="Created:">
 							<MetadataValue>{metadata.createdAt}</MetadataValue>
 						</MetadataRow>
@@ -305,7 +308,7 @@ export const SummaryPanel: FC<SummaryPanelProps> = ({
 				{/* ---- PR details ---- */}
 				{(prDetails.length > 0 || repo) && (
 					<Section>
-						<div className="flex min-w-0 flex-col gap-3">
+						<div className="flex min-w-0 flex-col gap-2.5">
 							{prDetails.length > 0 && (
 								<MetadataRow label="PR details:">
 									<div className="flex min-w-0 flex-col gap-1.5">
@@ -326,27 +329,27 @@ export const SummaryPanel: FC<SummaryPanelProps> = ({
 
 				{/* ---- Prompt history ---- */}
 				<Section>
-					<div className="flex min-w-0 flex-col gap-3">
+					<div className="flex min-w-0 flex-col gap-2.5">
 						<h3 className="text-sm font-medium text-content-secondary">
 							Prompt history ({totalPrompts})
 						</h3>
-						<div className="flex flex-col gap-2.5">
+						<div className="flex flex-col gap-2">
 							{(showAllPrompts ? prompts : prompts.slice(0, 3)).map(
 								(prompt) => (
 									<div
 										key={prompt.index}
-										className="flex min-w-0 items-start gap-4 text-sm"
+										className="flex min-w-0 items-start gap-3 text-sm"
 									>
 										{prompt.messageId && onPromptClick ? (
 											<button
 												type="button"
 												onClick={() => onPromptClick(prompt.messageId!)}
-												className="w-7 shrink-0 text-right tabular-nums text-content-link hover:underline"
+												className="w-6 shrink-0 text-right tabular-nums text-content-link hover:underline"
 											>
 												{prompt.index}
 											</button>
 										) : (
-											<span className="w-7 shrink-0 text-right tabular-nums text-content-secondary">
+											<span className="w-6 shrink-0 text-right tabular-nums text-content-secondary">
 												{prompt.index}
 											</span>
 										)}
@@ -371,16 +374,16 @@ export const SummaryPanel: FC<SummaryPanelProps> = ({
 
 				{/* ---- Activity ---- */}
 				<Section>
-					<div className="flex min-w-0 flex-col gap-3">
+					<div className="flex min-w-0 flex-col gap-2.5">
 						<h3 className="text-sm font-medium text-content-secondary">
 							Activity ({totalActivities})
 						</h3>
-						<div className="flex flex-col gap-2.5">
+						<div className="flex flex-col gap-2">
 							{(showAllActivities ? activities : activities.slice(0, 3)).map(
 								(activity) => (
 									<div
 										key={activity.text}
-										className="flex min-w-0 items-start gap-3 text-sm"
+										className="flex min-w-0 items-start gap-2.5 text-sm"
 									>
 										<CheckIcon className="mt-0.5 size-4 shrink-0 text-content-secondary" />
 										<span className="min-w-0 flex-1 truncate text-content-primary">
@@ -404,7 +407,7 @@ export const SummaryPanel: FC<SummaryPanelProps> = ({
 
 				{/* ---- Files ---- */}
 				<Section>
-					<div className="flex min-w-0 flex-col gap-3">
+					<div className="flex min-w-0 flex-col gap-2.5">
 						<h3 className="text-sm font-medium text-content-secondary">
 							Files ({totalFiles})
 						</h3>
@@ -421,30 +424,27 @@ export const SummaryPanel: FC<SummaryPanelProps> = ({
 				{/* ---- Related chats ---- */}
 				{relatedChats.length > 0 && (
 					<Section>
-						<div className="flex min-w-0 flex-col gap-3">
+						<div className="flex min-w-0 flex-col gap-2.5">
 							<h3 className="text-sm font-medium text-content-secondary">
 								Related chats
 							</h3>
-							<div className="flex flex-col gap-2">
+							<div className="flex flex-col gap-1.5">
 								{relatedChats.map((chat) => (
-									<div
-										key={chat.title}
-										className="flex min-w-0 items-baseline gap-2 text-sm"
-									>
+									<div key={chat.title} className="min-w-0 text-sm">
 										{chat.chatId && onRelatedChatClick ? (
 											<button
 												type="button"
 												onClick={() => onRelatedChatClick(chat.chatId!)}
-												className="min-w-0 shrink truncate text-left font-medium text-content-primary hover:text-content-link hover:underline"
+												className="truncate text-left font-medium text-content-primary hover:text-content-link hover:underline"
 											>
 												{chat.title}
 											</button>
 										) : (
-											<span className="min-w-0 shrink truncate font-medium text-content-primary">
+											<span className="block truncate font-medium text-content-primary">
 												{chat.title}
 											</span>
 										)}
-										<span className="shrink-0 text-content-secondary">
+										<span className="text-xs text-content-secondary">
 											({chat.reason})
 										</span>
 									</div>

--- a/site/src/pages/AgentsPage/components/SummaryPanel/SummaryPanel.tsx
+++ b/site/src/pages/AgentsPage/components/SummaryPanel/SummaryPanel.tsx
@@ -102,8 +102,8 @@ function formatCompactNumber(n: number): string {
 // ---------------------------------------------------------------------------
 
 /**
- * A section wrapper that adds a left accent border and consistent padding.
- * Each logical group in the summary panel is wrapped in this.
+ * Section wrapper with left accent border, top divider, and overflow
+ * containment so descendant `truncate` classes actually take effect.
  */
 const Section: FC<{
 	children: React.ReactNode;
@@ -111,7 +111,7 @@ const Section: FC<{
 }> = ({ children, className }) => (
 	<div
 		className={cn(
-			"border-0 border-l-2 border-t border-solid border-border-default px-5 py-5",
+			"min-w-0 overflow-hidden border-0 border-l-2 border-t border-solid border-border-default px-5 py-5",
 			className,
 		)}
 	>
@@ -119,14 +119,25 @@ const Section: FC<{
 	</div>
 );
 
+/**
+ * Key-value row used in the metadata and PR details sections.
+ * The value column is overflow-hidden so children can truncate.
+ */
 const MetadataRow: FC<{
 	label: string;
 	children: React.ReactNode;
 }> = ({ label, children }) => (
-	<div className="flex items-start gap-4 text-sm leading-6">
+	<div className="flex min-w-0 items-start gap-4 text-sm leading-6">
 		<span className="w-[7.5rem] shrink-0 text-content-secondary">{label}</span>
-		<span className="min-w-0 flex-1 text-content-primary">{children}</span>
+		<div className="min-w-0 flex-1 overflow-hidden text-content-primary">
+			{children}
+		</div>
 	</div>
+);
+
+/** Plain text value that truncates with an ellipsis. */
+const MetadataValue: FC<{ children: React.ReactNode }> = ({ children }) => (
+	<span className="block truncate">{children}</span>
 );
 
 const TokenBadge: FC<{
@@ -160,7 +171,7 @@ const TagBadge: FC<{
 const PRRow: FC<{ pr: SummaryPRDetail }> = ({ pr }) => {
 	const label = `PR #${pr.number} "${pr.title}"`;
 	return (
-		<div className="flex items-center gap-2 text-sm leading-6">
+		<div className="flex min-w-0 items-center gap-2 text-sm leading-6">
 			{pr.url ? (
 				<a
 					href={pr.url}
@@ -182,7 +193,7 @@ const PRRow: FC<{ pr: SummaryPRDetail }> = ({ pr }) => {
 };
 
 const FileRow: FC<{ file: SummaryFileChange }> = ({ file }) => (
-	<div className="flex items-center gap-2 py-2 text-sm">
+	<div className="flex min-w-0 items-center gap-2 py-2 text-sm">
 		<FileIcon className="size-4 shrink-0 text-content-secondary" />
 		<span className="min-w-0 flex-1 truncate font-mono text-[13px] text-content-primary">
 			{file.path}
@@ -234,11 +245,15 @@ export const SummaryPanel: FC<SummaryPanelProps> = ({
 				{/* ---- Metadata ---- */}
 				<Section className="border-l-0 border-t-0">
 					<div className="flex flex-col gap-3">
-						<MetadataRow label="Created:">{metadata.createdAt}</MetadataRow>
-						<MetadataRow label="Last updated:">
-							{metadata.lastUpdatedAt}
+						<MetadataRow label="Created:">
+							<MetadataValue>{metadata.createdAt}</MetadataValue>
 						</MetadataRow>
-						<MetadataRow label="Cost:">{metadata.costDisplay}</MetadataRow>
+						<MetadataRow label="Last updated:">
+							<MetadataValue>{metadata.lastUpdatedAt}</MetadataValue>
+						</MetadataRow>
+						<MetadataRow label="Cost:">
+							<MetadataValue>{metadata.costDisplay}</MetadataValue>
+						</MetadataRow>
 						<MetadataRow label="Tokens:">
 							<div className="flex flex-wrap gap-1.5">
 								<TokenBadge
@@ -256,7 +271,11 @@ export const SummaryPanel: FC<SummaryPanelProps> = ({
 							</div>
 						</MetadataRow>
 						<MetadataRow label="Model:">
-							<Badge variant="default" size="sm">
+							<Badge
+								variant="default"
+								size="sm"
+								className="max-w-full truncate"
+							>
 								{metadata.model}
 							</Badge>
 						</MetadataRow>
@@ -286,24 +305,28 @@ export const SummaryPanel: FC<SummaryPanelProps> = ({
 				{/* ---- PR details ---- */}
 				{(prDetails.length > 0 || repo) && (
 					<Section>
-						<div className="flex flex-col gap-3">
+						<div className="flex min-w-0 flex-col gap-3">
 							{prDetails.length > 0 && (
 								<MetadataRow label="PR details:">
-									<div className="flex flex-col gap-1.5">
+									<div className="flex min-w-0 flex-col gap-1.5">
 										{prDetails.map((pr) => (
 											<PRRow key={pr.number} pr={pr} />
 										))}
 									</div>
 								</MetadataRow>
 							)}
-							{repo && <MetadataRow label="Repo:">{repo}</MetadataRow>}
+							{repo && (
+								<MetadataRow label="Repo:">
+									<MetadataValue>{repo}</MetadataValue>
+								</MetadataRow>
+							)}
 						</div>
 					</Section>
 				)}
 
 				{/* ---- Prompt history ---- */}
 				<Section>
-					<div className="flex flex-col gap-3">
+					<div className="flex min-w-0 flex-col gap-3">
 						<h3 className="text-sm font-medium text-content-primary">
 							Prompt history ({totalPrompts})
 						</h3>
@@ -312,7 +335,7 @@ export const SummaryPanel: FC<SummaryPanelProps> = ({
 								(prompt) => (
 									<div
 										key={prompt.index}
-										className="flex items-start gap-4 text-sm"
+										className="flex min-w-0 items-start gap-4 text-sm"
 									>
 										{prompt.messageId && onPromptClick ? (
 											<button
@@ -327,7 +350,9 @@ export const SummaryPanel: FC<SummaryPanelProps> = ({
 												{prompt.index}
 											</span>
 										)}
-										<span className="text-content-primary">{prompt.text}</span>
+										<span className="min-w-0 flex-1 truncate text-content-primary">
+											{prompt.text}
+										</span>
 									</div>
 								),
 							)}
@@ -346,7 +371,7 @@ export const SummaryPanel: FC<SummaryPanelProps> = ({
 
 				{/* ---- Activity ---- */}
 				<Section>
-					<div className="flex flex-col gap-3">
+					<div className="flex min-w-0 flex-col gap-3">
 						<h3 className="text-sm font-medium text-content-primary">
 							Activity ({totalActivities})
 						</h3>
@@ -355,10 +380,10 @@ export const SummaryPanel: FC<SummaryPanelProps> = ({
 								(activity) => (
 									<div
 										key={activity.text}
-										className="flex items-start gap-3 text-sm"
+										className="flex min-w-0 items-start gap-3 text-sm"
 									>
 										<CheckIcon className="mt-0.5 size-4 shrink-0 text-content-secondary" />
-										<span className="text-content-primary">
+										<span className="min-w-0 flex-1 truncate text-content-primary">
 											{activity.text}
 										</span>
 									</div>
@@ -379,11 +404,11 @@ export const SummaryPanel: FC<SummaryPanelProps> = ({
 
 				{/* ---- Files ---- */}
 				<Section>
-					<div className="flex flex-col gap-3">
+					<div className="flex min-w-0 flex-col gap-3">
 						<h3 className="text-sm font-medium text-content-primary">
 							Files ({totalFiles})
 						</h3>
-						<div className="rounded-lg border border-solid border-border-default">
+						<div className="min-w-0 overflow-hidden rounded-lg border border-solid border-border-default">
 							<div className="flex flex-col divide-y divide-border-default px-3">
 								{files.map((file) => (
 									<FileRow key={`${file.path}-${file.status}`} file={file} />
@@ -396,7 +421,7 @@ export const SummaryPanel: FC<SummaryPanelProps> = ({
 				{/* ---- Related chats ---- */}
 				{relatedChats.length > 0 && (
 					<Section>
-						<div className="flex flex-col gap-3">
+						<div className="flex min-w-0 flex-col gap-3">
 							<h3 className="text-sm font-medium text-content-primary">
 								Related chats
 							</h3>
@@ -404,22 +429,22 @@ export const SummaryPanel: FC<SummaryPanelProps> = ({
 								{relatedChats.map((chat) => (
 									<div
 										key={chat.title}
-										className="flex items-baseline gap-2 text-sm"
+										className="flex min-w-0 items-baseline gap-2 text-sm"
 									>
 										{chat.chatId && onRelatedChatClick ? (
 											<button
 												type="button"
 												onClick={() => onRelatedChatClick(chat.chatId!)}
-												className="font-medium text-content-primary hover:text-content-link hover:underline"
+												className="min-w-0 shrink truncate text-left font-medium text-content-primary hover:text-content-link hover:underline"
 											>
 												{chat.title}
 											</button>
 										) : (
-											<span className="font-medium text-content-primary">
+											<span className="min-w-0 shrink truncate font-medium text-content-primary">
 												{chat.title}
 											</span>
 										)}
-										<span className="text-content-secondary">
+										<span className="shrink-0 text-content-secondary">
 											({chat.reason})
 										</span>
 									</div>

--- a/site/src/pages/AgentsPage/components/SummaryPanel/SummaryPanel.tsx
+++ b/site/src/pages/AgentsPage/components/SummaryPanel/SummaryPanel.tsx
@@ -35,13 +35,17 @@ interface SummaryMetadata {
 interface SummaryPRDetail {
 	number: number;
 	title: string;
+	url?: string;
 	additions: number;
 	deletions: number;
 }
 
 interface SummaryPrompt {
+	/** 1-based prompt number shown in the UI. */
 	index: number;
 	text: string;
+	/** Chat message ID this prompt corresponds to. */
+	messageId?: number;
 }
 
 interface SummaryActivity {
@@ -58,6 +62,8 @@ interface SummaryFileChange {
 interface SummaryRelatedChat {
 	title: string;
 	reason: string;
+	/** Agent chat ID to link to. */
+	chatId?: string;
 }
 
 export interface SummaryPanelProps {
@@ -73,6 +79,10 @@ export interface SummaryPanelProps {
 	relatedChats: readonly SummaryRelatedChat[];
 	onRemoveTag?: (tag: string) => void;
 	onEditTags?: () => void;
+	/** Called when the user clicks a prompt to scroll to that message. */
+	onPromptClick?: (messageId: number) => void;
+	/** Called when the user clicks a related chat link. */
+	onRelatedChatClick?: (chatId: string) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -91,17 +101,30 @@ function formatCompactNumber(n: number): string {
 // Sub-components
 // ---------------------------------------------------------------------------
 
-const SectionDivider: FC = () => (
-	<div className="border-0 border-t border-solid border-border-default" />
+/**
+ * A section wrapper that adds a left accent border and consistent padding.
+ * Each logical group in the summary panel is wrapped in this.
+ */
+const Section: FC<{
+	children: React.ReactNode;
+	className?: string;
+}> = ({ children, className }) => (
+	<div
+		className={cn(
+			"border-0 border-l-2 border-t border-solid border-border-default px-5 py-5",
+			className,
+		)}
+	>
+		{children}
+	</div>
 );
 
 const MetadataRow: FC<{
 	label: string;
 	children: React.ReactNode;
-	className?: string;
-}> = ({ label, children, className }) => (
-	<div className={cn("flex items-start gap-3 text-sm", className)}>
-		<span className="w-28 shrink-0 text-content-secondary">{label}</span>
+}> = ({ label, children }) => (
+	<div className="flex items-start gap-4 text-sm leading-6">
+		<span className="w-[7.5rem] shrink-0 text-content-secondary">{label}</span>
 		<span className="min-w-0 flex-1 text-content-primary">{children}</span>
 	</div>
 );
@@ -134,18 +157,32 @@ const TagBadge: FC<{
 	</Badge>
 );
 
-const PRRow: FC<{ pr: SummaryPRDetail }> = ({ pr }) => (
-	<div className="flex items-center gap-2 text-sm">
-		<span className="min-w-0 flex-1 truncate text-content-primary">
-			PR #{pr.number} &quot;{pr.title}&quot;
-		</span>
-		<GitPullRequestIcon className="size-4 shrink-0 text-content-secondary" />
-		<DiffStatBadge additions={pr.additions} deletions={pr.deletions} />
-	</div>
-);
+const PRRow: FC<{ pr: SummaryPRDetail }> = ({ pr }) => {
+	const label = `PR #${pr.number} "${pr.title}"`;
+	return (
+		<div className="flex items-center gap-2 text-sm leading-6">
+			{pr.url ? (
+				<a
+					href={pr.url}
+					target="_blank"
+					rel="noopener noreferrer"
+					className="min-w-0 flex-1 truncate text-content-primary hover:text-content-link hover:underline"
+				>
+					{label}
+				</a>
+			) : (
+				<span className="min-w-0 flex-1 truncate text-content-primary">
+					{label}
+				</span>
+			)}
+			<GitPullRequestIcon className="size-4 shrink-0 text-content-secondary" />
+			<DiffStatBadge additions={pr.additions} deletions={pr.deletions} />
+		</div>
+	);
+};
 
 const FileRow: FC<{ file: SummaryFileChange }> = ({ file }) => (
-	<div className="flex items-center gap-2 py-1.5 text-sm">
+	<div className="flex items-center gap-2 py-2 text-sm">
 		<FileIcon className="size-4 shrink-0 text-content-secondary" />
 		<span className="min-w-0 flex-1 truncate font-mono text-[13px] text-content-primary">
 			{file.path}
@@ -182,6 +219,8 @@ export const SummaryPanel: FC<SummaryPanelProps> = ({
 	relatedChats,
 	onRemoveTag,
 	onEditTags,
+	onPromptClick,
+	onRelatedChatClick,
 }) => {
 	const [showAllPrompts, setShowAllPrompts] = useState(false);
 	const [showAllActivities, setShowAllActivities] = useState(false);
@@ -191,63 +230,63 @@ export const SummaryPanel: FC<SummaryPanelProps> = ({
 
 	return (
 		<ScrollArea className="h-full" scrollBarClassName="w-1.5">
-			<div className="flex flex-col gap-0">
-				{/* Metadata section */}
-				<div className="flex flex-col gap-2.5 px-4 py-4">
-					<MetadataRow label="Created:">{metadata.createdAt}</MetadataRow>
-					<MetadataRow label="Last updated:">
-						{metadata.lastUpdatedAt}
-					</MetadataRow>
-					<MetadataRow label="Cost:">{metadata.costDisplay}</MetadataRow>
-					<MetadataRow label="Tokens:">
-						<div className="flex flex-wrap gap-1.5">
-							<TokenBadge
-								icon={<ArrowDownIcon className="size-3" />}
-								value={metadata.tokens.input}
-							/>
-							<TokenBadge
-								icon={<LayersIcon className="size-3" />}
-								value={metadata.tokens.cached}
-							/>
-							<TokenBadge
-								icon={<ArrowUpIcon className="size-3" />}
-								value={metadata.tokens.output}
-							/>
-						</div>
-					</MetadataRow>
-					<MetadataRow label="Model:">
-						<Badge variant="default" size="sm">
-							{metadata.model}
-						</Badge>
-					</MetadataRow>
-					<MetadataRow label="Tags:">
-						<div className="flex flex-wrap items-center gap-1.5">
-							{metadata.tags.map((tag) => (
-								<TagBadge
-									key={tag}
-									label={tag}
-									onRemove={onRemoveTag ? () => onRemoveTag(tag) : undefined}
+			<div className="flex flex-col">
+				{/* ---- Metadata ---- */}
+				<Section className="border-l-0 border-t-0">
+					<div className="flex flex-col gap-3">
+						<MetadataRow label="Created:">{metadata.createdAt}</MetadataRow>
+						<MetadataRow label="Last updated:">
+							{metadata.lastUpdatedAt}
+						</MetadataRow>
+						<MetadataRow label="Cost:">{metadata.costDisplay}</MetadataRow>
+						<MetadataRow label="Tokens:">
+							<div className="flex flex-wrap gap-1.5">
+								<TokenBadge
+									icon={<ArrowDownIcon className="size-3" />}
+									value={metadata.tokens.input}
 								/>
-							))}
-							{onEditTags && (
-								<button
-									type="button"
-									onClick={onEditTags}
-									className="flex items-center text-content-secondary hover:text-content-primary"
-								>
-									<PenLineIcon className="size-4" />
-								</button>
-							)}
-						</div>
-					</MetadataRow>
-				</div>
+								<TokenBadge
+									icon={<LayersIcon className="size-3" />}
+									value={metadata.tokens.cached}
+								/>
+								<TokenBadge
+									icon={<ArrowUpIcon className="size-3" />}
+									value={metadata.tokens.output}
+								/>
+							</div>
+						</MetadataRow>
+						<MetadataRow label="Model:">
+							<Badge variant="default" size="sm">
+								{metadata.model}
+							</Badge>
+						</MetadataRow>
+						<MetadataRow label="Tags:">
+							<div className="flex flex-wrap items-center gap-1.5">
+								{metadata.tags.map((tag) => (
+									<TagBadge
+										key={tag}
+										label={tag}
+										onRemove={onRemoveTag ? () => onRemoveTag(tag) : undefined}
+									/>
+								))}
+								{onEditTags && (
+									<button
+										type="button"
+										onClick={onEditTags}
+										className="flex items-center text-content-secondary hover:text-content-primary"
+									>
+										<PenLineIcon className="size-4" />
+									</button>
+								)}
+							</div>
+						</MetadataRow>
+					</div>
+				</Section>
 
-				<SectionDivider />
-
-				{/* PR details */}
+				{/* ---- PR details ---- */}
 				{(prDetails.length > 0 || repo) && (
-					<>
-						<div className="flex flex-col gap-2 px-4 py-4">
+					<Section>
+						<div className="flex flex-col gap-3">
 							{prDetails.length > 0 && (
 								<MetadataRow label="PR details:">
 									<div className="flex flex-col gap-1.5">
@@ -259,110 +298,135 @@ export const SummaryPanel: FC<SummaryPanelProps> = ({
 							)}
 							{repo && <MetadataRow label="Repo:">{repo}</MetadataRow>}
 						</div>
-						<SectionDivider />
-					</>
+					</Section>
 				)}
 
-				{/* Prompt history */}
-				<div className="flex flex-col gap-2 px-4 py-4">
-					<h3 className="text-sm font-medium text-content-primary">
-						Prompt history ({totalPrompts})
-					</h3>
-					<div className="flex flex-col gap-1.5">
-						{(showAllPrompts ? prompts : prompts.slice(0, 3)).map((prompt) => (
-							<div
-								key={prompt.index}
-								className="flex items-start gap-3 text-sm"
+				{/* ---- Prompt history ---- */}
+				<Section>
+					<div className="flex flex-col gap-3">
+						<h3 className="text-sm font-medium text-content-primary">
+							Prompt history ({totalPrompts})
+						</h3>
+						<div className="flex flex-col gap-2.5">
+							{(showAllPrompts ? prompts : prompts.slice(0, 3)).map(
+								(prompt) => (
+									<div
+										key={prompt.index}
+										className="flex items-start gap-4 text-sm"
+									>
+										{prompt.messageId && onPromptClick ? (
+											<button
+												type="button"
+												onClick={() => onPromptClick(prompt.messageId!)}
+												className="w-7 shrink-0 text-right tabular-nums text-content-link hover:underline"
+											>
+												{prompt.index}
+											</button>
+										) : (
+											<span className="w-7 shrink-0 text-right tabular-nums text-content-secondary">
+												{prompt.index}
+											</span>
+										)}
+										<span className="text-content-primary">{prompt.text}</span>
+									</div>
+								),
+							)}
+						</div>
+						{!showAllPrompts && hiddenPrompts > 0 && (
+							<button
+								type="button"
+								onClick={() => setShowAllPrompts(true)}
+								className="self-start text-sm text-content-link hover:underline"
 							>
-								<span className="w-6 shrink-0 text-right tabular-nums text-content-secondary">
-									{prompt.index}
-								</span>
-								<span className="text-content-primary">{prompt.text}</span>
-							</div>
-						))}
-					</div>
-					{!showAllPrompts && hiddenPrompts > 0 && (
-						<button
-							type="button"
-							onClick={() => setShowAllPrompts(true)}
-							className="self-start text-sm text-content-link hover:underline"
-						>
-							+{hiddenPrompts} earlier
-						</button>
-					)}
-				</div>
-
-				<SectionDivider />
-
-				{/* Activity */}
-				<div className="flex flex-col gap-2 px-4 py-4">
-					<h3 className="text-sm font-medium text-content-primary">
-						Activity ({totalActivities})
-					</h3>
-					<div className="flex flex-col gap-2">
-						{(showAllActivities ? activities : activities.slice(0, 3)).map(
-							(activity) => (
-								<div
-									key={activity.text}
-									className="flex items-start gap-2.5 text-sm"
-								>
-									<CheckIcon className="mt-0.5 size-4 shrink-0 text-content-secondary" />
-									<span className="text-content-primary">{activity.text}</span>
-								</div>
-							),
+								+{hiddenPrompts} earlier
+							</button>
 						)}
 					</div>
-					{!showAllActivities && hiddenActivities > 0 && (
-						<button
-							type="button"
-							onClick={() => setShowAllActivities(true)}
-							className="self-start text-sm text-content-link hover:underline"
-						>
-							+{hiddenActivities} more
-						</button>
-					)}
-				</div>
+				</Section>
 
-				<SectionDivider />
-
-				{/* Files */}
-				<div className="flex flex-col gap-2 px-4 py-4">
-					<h3 className="text-sm font-medium text-content-primary">
-						Files ({totalFiles})
-					</h3>
-					<div className="rounded-lg border border-solid border-border-default">
-						<div className="flex flex-col divide-y divide-border-default px-3">
-							{files.map((file) => (
-								<FileRow key={file.path} file={file} />
-							))}
-						</div>
-					</div>
-				</div>
-
-				<SectionDivider />
-
-				{/* Related chats */}
-				{relatedChats.length > 0 && (
-					<div className="flex flex-col gap-2 px-4 py-4">
+				{/* ---- Activity ---- */}
+				<Section>
+					<div className="flex flex-col gap-3">
 						<h3 className="text-sm font-medium text-content-primary">
-							Related chats
+							Activity ({totalActivities})
 						</h3>
-						<div className="flex flex-col gap-1.5">
-							{relatedChats.map((chat) => (
-								<div
-									key={chat.title}
-									className="flex items-baseline gap-2 text-sm"
-								>
-									<span className="font-medium text-content-primary">
-										{chat.title}
-									</span>
-									<span className="text-content-secondary">
-										({chat.reason})
-									</span>
-								</div>
-							))}
+						<div className="flex flex-col gap-2.5">
+							{(showAllActivities ? activities : activities.slice(0, 3)).map(
+								(activity) => (
+									<div
+										key={activity.text}
+										className="flex items-start gap-3 text-sm"
+									>
+										<CheckIcon className="mt-0.5 size-4 shrink-0 text-content-secondary" />
+										<span className="text-content-primary">
+											{activity.text}
+										</span>
+									</div>
+								),
+							)}
+						</div>
+						{!showAllActivities && hiddenActivities > 0 && (
+							<button
+								type="button"
+								onClick={() => setShowAllActivities(true)}
+								className="self-start text-sm text-content-link hover:underline"
+							>
+								+{hiddenActivities} more
+							</button>
+						)}
+					</div>
+				</Section>
+
+				{/* ---- Files ---- */}
+				<Section>
+					<div className="flex flex-col gap-3">
+						<h3 className="text-sm font-medium text-content-primary">
+							Files ({totalFiles})
+						</h3>
+						<div className="rounded-lg border border-solid border-border-default">
+							<div className="flex flex-col divide-y divide-border-default px-3">
+								{files.map((file) => (
+									<FileRow key={`${file.path}-${file.status}`} file={file} />
+								))}
+							</div>
 						</div>
 					</div>
+				</Section>
+
+				{/* ---- Related chats ---- */}
+				{relatedChats.length > 0 && (
+					<Section>
+						<div className="flex flex-col gap-3">
+							<h3 className="text-sm font-medium text-content-primary">
+								Related chats
+							</h3>
+							<div className="flex flex-col gap-2">
+								{relatedChats.map((chat) => (
+									<div
+										key={chat.title}
+										className="flex items-baseline gap-2 text-sm"
+									>
+										{chat.chatId && onRelatedChatClick ? (
+											<button
+												type="button"
+												onClick={() => onRelatedChatClick(chat.chatId!)}
+												className="font-medium text-content-primary hover:text-content-link hover:underline"
+											>
+												{chat.title}
+											</button>
+										) : (
+											<span className="font-medium text-content-primary">
+												{chat.title}
+											</span>
+										)}
+										<span className="text-content-secondary">
+											({chat.reason})
+										</span>
+									</div>
+								))}
+							</div>
+						</div>
+					</Section>
 				)}
 			</div>
 		</ScrollArea>

--- a/site/src/pages/AgentsPage/components/SummaryPanel/SummaryPanel.tsx
+++ b/site/src/pages/AgentsPage/components/SummaryPanel/SummaryPanel.tsx
@@ -1,0 +1,24 @@
+import { FileTextIcon } from "lucide-react";
+import type { FC } from "react";
+import { ScrollArea } from "#/components/ScrollArea/ScrollArea";
+
+interface SummaryPanelProps {
+	chatTitle: string | undefined;
+}
+
+export const SummaryPanel: FC<SummaryPanelProps> = ({ chatTitle }) => {
+	return (
+		<ScrollArea className="flex h-full flex-col">
+			<div className="flex flex-col items-center justify-center gap-3 p-6 text-center text-content-secondary">
+				<FileTextIcon className="size-8 text-content-tertiary" />
+				<h3 className="text-sm font-medium text-content-primary">
+					{chatTitle ?? "Chat Summary"}
+				</h3>
+				<p className="max-w-xs text-xs">
+					A summary of this chat session will appear here as the conversation
+					progresses.
+				</p>
+			</div>
+		</ScrollArea>
+	);
+};

--- a/site/src/pages/AgentsPage/components/SummaryPanel/SummaryPanel.tsx
+++ b/site/src/pages/AgentsPage/components/SummaryPanel/SummaryPanel.tsx
@@ -327,7 +327,7 @@ export const SummaryPanel: FC<SummaryPanelProps> = ({
 				{/* ---- Prompt history ---- */}
 				<Section>
 					<div className="flex min-w-0 flex-col gap-3">
-						<h3 className="text-sm font-medium text-content-primary">
+						<h3 className="text-sm font-medium text-content-secondary">
 							Prompt history ({totalPrompts})
 						</h3>
 						<div className="flex flex-col gap-2.5">
@@ -372,7 +372,7 @@ export const SummaryPanel: FC<SummaryPanelProps> = ({
 				{/* ---- Activity ---- */}
 				<Section>
 					<div className="flex min-w-0 flex-col gap-3">
-						<h3 className="text-sm font-medium text-content-primary">
+						<h3 className="text-sm font-medium text-content-secondary">
 							Activity ({totalActivities})
 						</h3>
 						<div className="flex flex-col gap-2.5">
@@ -405,7 +405,7 @@ export const SummaryPanel: FC<SummaryPanelProps> = ({
 				{/* ---- Files ---- */}
 				<Section>
 					<div className="flex min-w-0 flex-col gap-3">
-						<h3 className="text-sm font-medium text-content-primary">
+						<h3 className="text-sm font-medium text-content-secondary">
 							Files ({totalFiles})
 						</h3>
 						<div className="min-w-0 overflow-hidden rounded-lg border border-solid border-border-default">
@@ -422,7 +422,7 @@ export const SummaryPanel: FC<SummaryPanelProps> = ({
 				{relatedChats.length > 0 && (
 					<Section>
 						<div className="flex min-w-0 flex-col gap-3">
-							<h3 className="text-sm font-medium text-content-primary">
+							<h3 className="text-sm font-medium text-content-secondary">
 								Related chats
 							</h3>
 							<div className="flex flex-col gap-2">


### PR DESCRIPTION
Adds a new `agent-summary-tab` experiment that, when enabled, shows a **Summary** tab in the agent right sidebar, positioned before the **Git** tab.

## Changes

**Backend (`codersdk/deployment.go`)**
- Added `ExperimentAgentSummaryTab` constant with value `"agent-summary-tab"`
- Added display name and registered in `ExperimentsKnown`

**Frontend**
- Created `SummaryPanel` component with the full UI from the design:
  - Metadata section (created, updated, cost, tokens, model, tags)
  - PR details with diff stat badges and repo name
  - Prompt history with numbered list and expand/collapse
  - Activity list with checkmarks and expand/collapse
  - Files changed with status labels and line-count diffs
  - Related chats with relationship reasons
- Added `summaryTabEnabled` and `summaryData` props to `AgentChatPageView`, gated on the experiment
- Wired experiment check in `AgentChatPage` container via `useDashboard().experiments`
- Added Storybook stories with sample data matching the design

The view currently passes `summaryData={undefined}` since the backend data endpoints are not yet available. The `SummaryPanelProps` interface is ready for wiring to real data sources.

## How to test

Enable the experiment:
```bash
coder server --experiments=agent-summary-tab
```
Then open any agent chat; the Summary tab appears as the first tab in the right sidebar.

To see the full UI, run Storybook and navigate to `pages/AgentsPage/SummaryPanel`.

> Generated by Coder Agents on behalf of @tracyjohnsonux